### PR TITLE
fix(sessions): persist sender metadata in user turn transcript JSONL

### DIFF
--- a/src/agents/embedded-agent-runner.guard.test.ts
+++ b/src/agents/embedded-agent-runner.guard.test.ts
@@ -1,5 +1,8 @@
 // Covers session-manager guard behavior for tool-result pairing and transcript
 // redaction.
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { AgentMessage } from "openclaw/plugin-sdk/agent-core";
 import { SessionManager } from "openclaw/plugin-sdk/agent-sessions";
 import {
@@ -9,6 +12,10 @@ import {
 import { createMockPluginRegistry } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { afterEach, describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  attachRuntimeUserTurnTranscriptContext,
+  createUserTurnTranscriptRecorder,
+} from "../sessions/user-turn-transcript.js";
 import { guardSessionManager } from "./session-tool-result-guard-wrapper.js";
 import { sanitizeToolUseResultPairing } from "./session-transcript-repair.js";
 
@@ -20,7 +27,14 @@ function assistantToolCall(id: string): AgentMessage {
 }
 
 describe("guardSessionManager integration", () => {
-  afterEach(() => resetGlobalHookRunner());
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    resetGlobalHookRunner();
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
 
   it("persists synthetic toolResult before subsequent assistant message", () => {
     // Providers require every assistant tool call to be followed by a result
@@ -162,12 +176,19 @@ describe("guardSessionManager integration", () => {
         },
       ]),
     );
+    const config = {
+      logging: {
+        redactSensitive: "tools",
+        redactPatterns: [String.raw`secret-[a-z]+`],
+      },
+    } satisfies OpenClawConfig;
     const sm = guardSessionManager(SessionManager.inMemory(), {
+      config,
       preparedUserTurnMessage: {
         role: "user",
         content: "private group prompt",
         timestamp: 123,
-        __openclaw: { senderId: "user-42", senderName: "Ada" },
+        __openclaw: { senderId: "secret-user", senderName: "secret-name" },
       } as Extract<AgentMessage, { role: "user" }>,
     });
 
@@ -181,10 +202,63 @@ describe("guardSessionManager integration", () => {
       content: "[redacted by hook]",
       __openclaw: {
         hookOwned: true,
-        senderId: "user-42",
-        senderName: "Ada",
+        senderId: expect.any(String),
+        senderName: expect.any(String),
       },
     });
+    expect(JSON.stringify(message?.message)).not.toContain("secret-user");
+    expect(JSON.stringify(message?.message)).not.toContain("secret-name");
+  });
+
+  it("commits queued group sender metadata to JSONL and completes its recorder", () => {
+    const dir = mkdtempSync(join(tmpdir(), "openclaw-queued-group-turn-"));
+    tempDirs.push(dir);
+    const sessionManager = SessionManager.create(dir, dir);
+    const sessionFile = sessionManager.getSessionFile();
+    if (!sessionFile) {
+      throw new Error("expected file-backed session manager");
+    }
+    const recorder = createUserTurnTranscriptRecorder({
+      input: {
+        text: "visible group prompt",
+        sender: { id: "user-42", name: "Ada", username: "ada42" },
+      },
+      target: { transcriptPath: sessionFile },
+    });
+    const preparedMessage = recorder.message;
+    if (!preparedMessage) {
+      throw new Error("expected prepared group turn");
+    }
+    const sm = guardSessionManager(sessionManager);
+    const runtimeMessage = attachRuntimeUserTurnTranscriptContext(
+      {
+        role: "user",
+        content: [{ type: "text", text: "runtime group prompt" }],
+        timestamp: 456,
+      },
+      { message: preparedMessage, recorder },
+    );
+
+    sm.appendMessage(runtimeMessage);
+    sm.appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "acknowledged" }],
+    } as AgentMessage);
+
+    const entries = readFileSync(sessionFile, "utf8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as { type: string; message?: AgentMessage });
+    expect(entries.find((entry) => entry.message?.role === "user")?.message).toMatchObject({
+      role: "user",
+      content: "visible group prompt",
+      __openclaw: {
+        senderId: "user-42",
+        senderName: "Ada",
+        senderUsername: "ada42",
+      },
+    });
+    expect(recorder.hasPersisted()).toBe(true);
   });
 
   it("does not consume prepared user persistence for before-agent-run blocked messages", () => {

--- a/src/agents/embedded-agent-runner.guard.test.ts
+++ b/src/agents/embedded-agent-runner.guard.test.ts
@@ -2,7 +2,12 @@
 // redaction.
 import type { AgentMessage } from "openclaw/plugin-sdk/agent-core";
 import { SessionManager } from "openclaw/plugin-sdk/agent-sessions";
-import { describe, expect, it } from "vitest";
+import {
+  initializeGlobalHookRunner,
+  resetGlobalHookRunner,
+} from "openclaw/plugin-sdk/hook-runtime";
+import { createMockPluginRegistry } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { afterEach, describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { guardSessionManager } from "./session-tool-result-guard-wrapper.js";
 import { sanitizeToolUseResultPairing } from "./session-transcript-repair.js";
@@ -15,6 +20,8 @@ function assistantToolCall(id: string): AgentMessage {
 }
 
 describe("guardSessionManager integration", () => {
+  afterEach(() => resetGlobalHookRunner());
+
   it("persists synthetic toolResult before subsequent assistant message", () => {
     // Providers require every assistant tool call to be followed by a result
     // before the next assistant turn.
@@ -138,6 +145,46 @@ describe("guardSessionManager integration", () => {
       MediaTypes: ["image/png"],
     });
     expect(messages[1]).toEqual({ role: "user", content: "follow-up" });
+  });
+
+  it("preserves prepared sender metadata after a write hook replaces the user message", () => {
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([
+        {
+          hookName: "before_message_write",
+          handler: () => ({
+            message: {
+              role: "user",
+              content: "[redacted by hook]",
+              __openclaw: { hookOwned: true },
+            } as AgentMessage,
+          }),
+        },
+      ]),
+    );
+    const sm = guardSessionManager(SessionManager.inMemory(), {
+      preparedUserTurnMessage: {
+        role: "user",
+        content: "private group prompt",
+        timestamp: 123,
+        __openclaw: { senderId: "user-42", senderName: "Ada" },
+      } as Extract<AgentMessage, { role: "user" }>,
+    });
+
+    sm.appendMessage({ role: "user", content: "runtime prompt" } as AgentMessage);
+
+    const message = sm.getEntries().find((entry) => entry.type === "message") as
+      | { message?: AgentMessage }
+      | undefined;
+    expect(message?.message).toMatchObject({
+      role: "user",
+      content: "[redacted by hook]",
+      __openclaw: {
+        hookOwned: true,
+        senderId: "user-42",
+        senderName: "Ada",
+      },
+    });
   });
 
   it("does not consume prepared user persistence for before-agent-run blocked messages", () => {

--- a/src/agents/embedded-agent-runner.guard.test.ts
+++ b/src/agents/embedded-agent-runner.guard.test.ts
@@ -18,6 +18,7 @@ import {
 } from "../sessions/user-turn-transcript.js";
 import { guardSessionManager } from "./session-tool-result-guard-wrapper.js";
 import { sanitizeToolUseResultPairing } from "./session-transcript-repair.js";
+import { makeAgentAssistantMessage } from "./test-helpers/agent-message-fixtures.js";
 
 function assistantToolCall(id: string): AgentMessage {
   return {
@@ -170,6 +171,7 @@ describe("guardSessionManager integration", () => {
             message: {
               role: "user",
               content: "[redacted by hook]",
+              timestamp: 124,
               __openclaw: { hookOwned: true },
             } as AgentMessage,
           }),
@@ -192,7 +194,7 @@ describe("guardSessionManager integration", () => {
       } as Extract<AgentMessage, { role: "user" }>,
     });
 
-    sm.appendMessage({ role: "user", content: "runtime prompt" } as AgentMessage);
+    sm.appendMessage({ role: "user", content: "runtime prompt", timestamp: 125 });
 
     const message = sm.getEntries().find((entry) => entry.type === "message") as
       | { message?: AgentMessage }
@@ -240,10 +242,11 @@ describe("guardSessionManager integration", () => {
     );
 
     sm.appendMessage(runtimeMessage);
-    sm.appendMessage({
-      role: "assistant",
-      content: [{ type: "text", text: "acknowledged" }],
-    } as AgentMessage);
+    sm.appendMessage(
+      makeAgentAssistantMessage({
+        content: [{ type: "text", text: "acknowledged" }],
+      }),
+    );
 
     const entries = readFileSync(sessionFile, "utf8")
       .trim()

--- a/src/agents/embedded-agent-runner.guard.test.ts
+++ b/src/agents/embedded-agent-runner.guard.test.ts
@@ -1,8 +1,6 @@
 // Covers session-manager guard behavior for tool-result pairing and transcript
 // redaction.
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { readFileSync } from "node:fs";
 import type { AgentMessage } from "openclaw/plugin-sdk/agent-core";
 import { SessionManager } from "openclaw/plugin-sdk/agent-sessions";
 import {
@@ -11,6 +9,7 @@ import {
 } from "openclaw/plugin-sdk/hook-runtime";
 import { createMockPluginRegistry } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { afterEach, describe, expect, it } from "vitest";
+import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   attachRuntimeUserTurnTranscriptContext,
@@ -32,9 +31,7 @@ describe("guardSessionManager integration", () => {
 
   afterEach(() => {
     resetGlobalHookRunner();
-    for (const dir of tempDirs.splice(0)) {
-      rmSync(dir, { force: true, recursive: true });
-    }
+    cleanupTempDirs(tempDirs);
   });
 
   it("persists synthetic toolResult before subsequent assistant message", () => {
@@ -213,8 +210,7 @@ describe("guardSessionManager integration", () => {
   });
 
   it("commits queued group sender metadata to JSONL and completes its recorder", () => {
-    const dir = mkdtempSync(join(tmpdir(), "openclaw-queued-group-turn-"));
-    tempDirs.push(dir);
+    const dir = makeTempDir(tempDirs, "openclaw-queued-group-turn-");
     const sessionManager = SessionManager.create(dir, dir);
     const sessionFile = sessionManager.getSessionFile();
     if (!sessionFile) {

--- a/src/agents/embedded-agent-runner.guard.test.ts
+++ b/src/agents/embedded-agent-runner.guard.test.ts
@@ -9,7 +9,7 @@ import {
 } from "openclaw/plugin-sdk/hook-runtime";
 import { createMockPluginRegistry } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { afterEach, describe, expect, it } from "vitest";
-import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   attachRuntimeUserTurnTranscriptContext,
@@ -27,11 +27,10 @@ function assistantToolCall(id: string): AgentMessage {
 }
 
 describe("guardSessionManager integration", () => {
-  const tempDirs: string[] = [];
+  const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
   afterEach(() => {
     resetGlobalHookRunner();
-    cleanupTempDirs(tempDirs);
   });
 
   it("persists synthetic toolResult before subsequent assistant message", () => {
@@ -206,7 +205,7 @@ describe("guardSessionManager integration", () => {
   });
 
   it("commits queued group sender metadata to JSONL and completes its recorder", () => {
-    const dir = makeTempDir(tempDirs, "openclaw-queued-group-turn-");
+    const dir = tempDirs.make("openclaw-queued-group-turn-");
     const sessionManager = SessionManager.create(dir, dir);
     const sessionFile = sessionManager.getSessionFile();
     if (!sessionFile) {

--- a/src/agents/embedded-agent-runner.guard.test.ts
+++ b/src/agents/embedded-agent-runner.guard.test.ts
@@ -159,7 +159,7 @@ describe("guardSessionManager integration", () => {
     expect(messages[1]).toEqual({ role: "user", content: "follow-up" });
   });
 
-  it("preserves prepared sender metadata after a write hook replaces the user message", () => {
+  it("lets a write hook remove sender identity while preserving auth state", () => {
     initializeGlobalHookRunner(
       createMockPluginRegistry([
         {
@@ -175,19 +175,16 @@ describe("guardSessionManager integration", () => {
         },
       ]),
     );
-    const config = {
-      logging: {
-        redactSensitive: "tools",
-        redactPatterns: [String.raw`secret-[a-z]+`],
-      },
-    } satisfies OpenClawConfig;
     const sm = guardSessionManager(SessionManager.inMemory(), {
-      config,
       preparedUserTurnMessage: {
         role: "user",
         content: "private group prompt",
         timestamp: 123,
-        __openclaw: { senderId: "secret-user", senderName: "secret-name" },
+        __openclaw: {
+          senderIsOwner: true,
+          senderId: "secret-user",
+          senderName: "secret-name",
+        },
       } as Extract<AgentMessage, { role: "user" }>,
     });
 
@@ -201,8 +198,7 @@ describe("guardSessionManager integration", () => {
       content: "[redacted by hook]",
       __openclaw: {
         hookOwned: true,
-        senderId: expect.any(String),
-        senderName: expect.any(String),
+        senderIsOwner: true,
       },
     });
     expect(JSON.stringify(message?.message)).not.toContain("secret-user");

--- a/src/agents/embedded-agent-runner.guard.test.ts
+++ b/src/agents/embedded-agent-runner.guard.test.ts
@@ -222,7 +222,9 @@ describe("guardSessionManager integration", () => {
     if (!preparedMessage) {
       throw new Error("expected prepared group turn");
     }
-    const sm = guardSessionManager(sessionManager);
+    const sm = guardSessionManager(sessionManager, {
+      inputProvenance: { kind: "inter_session", sourceTool: "sessions_send" },
+    });
     const runtimeMessage = attachRuntimeUserTurnTranscriptContext(
       {
         role: "user",
@@ -251,6 +253,7 @@ describe("guardSessionManager integration", () => {
         senderName: "Ada",
         senderUsername: "ada42",
       },
+      provenance: { kind: "inter_session", sourceTool: "sessions_send" },
     });
     expect(recorder.hasPersisted()).toBe(true);
   });

--- a/src/agents/embedded-agent-runner/run-state.ts
+++ b/src/agents/embedded-agent-runner/run-state.ts
@@ -7,6 +7,7 @@ import {
   listActiveReplyRunSessionKeys,
   listActiveReplyRunSessionIds,
   resolveActiveReplyRunSessionId,
+  type ReplyBackendQueueMessageOptions,
 } from "../../auto-reply/reply/reply-run-registry.js";
 import { resolveGlobalSingleton } from "../../shared/global-singleton.js";
 
@@ -30,13 +31,7 @@ export type EmbeddedAgentQueueHandle = {
   sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
 };
 
-export type EmbeddedAgentQueueMessageOptions = {
-  steeringMode?: "all";
-  debounceMs?: number;
-  deliveryTimeoutMs?: number;
-  waitForTranscriptCommit?: boolean;
-  sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
-};
+export type EmbeddedAgentQueueMessageOptions = ReplyBackendQueueMessageOptions;
 
 export type ActiveEmbeddedRunSnapshot = {
   transcriptLeafId: string | null;

--- a/src/agents/embedded-agent-runner/run/attempt.queue-message.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.queue-message.test.ts
@@ -1,12 +1,32 @@
 // Coverage for queued steering message commit and cancellation behavior.
 import { describe, expect, it, vi } from "vitest";
+import { createUserTurnTranscriptRecorder } from "../../../sessions/user-turn-transcript.js";
 import {
   cancelQueuedSteeringMessage,
+  steerActiveSessionWithOptionalDeliveryWait,
   steerAndWaitForTranscriptCommit,
   type EmbeddedAgentActiveSessionSteerTarget,
 } from "./attempt.queue-message.js";
 
 describe("embedded OpenClaw queued steering cancellation", () => {
+  it("forwards prepared transcript context with a queued steering message", async () => {
+    const steer = vi.fn(async () => undefined);
+    const recorder = createUserTurnTranscriptRecorder({
+      input: { text: "visible prompt", sender: { id: "user-42" } },
+      target: { transcriptPath: "/tmp/unused-session.jsonl" },
+    });
+    const activeSession: EmbeddedAgentActiveSessionSteerTarget = {
+      steer,
+      subscribe: () => () => {},
+    };
+
+    await steerActiveSessionWithOptionalDeliveryWait(activeSession, "runtime prompt", {
+      userTurnTranscriptRecorder: recorder,
+    });
+
+    expect(steer).toHaveBeenCalledWith("runtime prompt", undefined, recorder);
+  });
+
   it("waits for the queued user message_end transcript boundary", async () => {
     // A queued steer is only durable once the user message_end event lands in
     // the active transcript.

--- a/src/agents/embedded-agent-runner/run/attempt.queue-message.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.queue-message.ts
@@ -2,6 +2,7 @@
  * Steers active embedded sessions and waits for transcript commits when needed.
  */
 import { toErrorObject } from "../../../infra/errors.js";
+import type { UserTurnTranscriptRecorder } from "../../../sessions/user-turn-transcript.types.js";
 import { log } from "../logger.js";
 
 /**
@@ -11,7 +12,11 @@ import { log } from "../logger.js";
 export type EmbeddedAgentActiveSessionSteerTarget = {
   agent?: unknown;
   getSteeringMessages?(): readonly string[];
-  steer(text: string): Promise<void>;
+  steer(
+    text: string,
+    images?: undefined,
+    userTurnTranscriptRecorder?: UserTurnTranscriptRecorder,
+  ): Promise<void>;
   subscribe(listener: (event: unknown) => void): () => void;
 };
 
@@ -126,6 +131,7 @@ export async function steerAndWaitForTranscriptCommit(
   activeSession: EmbeddedAgentActiveSessionSteerTarget,
   text: string,
   timeoutMs: number,
+  userTurnTranscriptRecorder?: UserTurnTranscriptRecorder,
 ): Promise<void> {
   await new Promise<void>((resolve, reject) => {
     let settled = false;
@@ -206,7 +212,10 @@ export async function steerAndWaitForTranscriptCommit(
         scheduleTerminalCancellation();
       }
     });
-    activeSession.steer(text).catch((err: unknown) => {
+    const steer = userTurnTranscriptRecorder
+      ? activeSession.steer(text, undefined, userTurnTranscriptRecorder)
+      : activeSession.steer(text);
+    steer.catch((err: unknown) => {
       finish(err);
     });
   });
@@ -219,15 +228,26 @@ export async function steerAndWaitForTranscriptCommit(
 export async function steerActiveSessionWithOptionalDeliveryWait(
   activeSession: EmbeddedAgentActiveSessionSteerTarget,
   text: string,
-  options: { deliveryTimeoutMs?: number; waitForTranscriptCommit?: boolean } | undefined,
+  options:
+    | {
+        deliveryTimeoutMs?: number;
+        waitForTranscriptCommit?: boolean;
+        userTurnTranscriptRecorder?: UserTurnTranscriptRecorder;
+      }
+    | undefined,
 ): Promise<void> {
   if (options?.waitForTranscriptCommit !== true) {
-    await activeSession.steer(text);
+    if (options?.userTurnTranscriptRecorder) {
+      await activeSession.steer(text, undefined, options.userTurnTranscriptRecorder);
+    } else {
+      await activeSession.steer(text);
+    }
     return;
   }
   await steerAndWaitForTranscriptCommit(
     activeSession,
     text,
     options.deliveryTimeoutMs ?? DEFAULT_QUEUE_TRANSCRIPT_COMMIT_TIMEOUT_MS,
+    options.userTurnTranscriptRecorder,
   );
 }

--- a/src/agents/embedded-agent-runner/runs.test.ts
+++ b/src/agents/embedded-agent-runner/runs.test.ts
@@ -16,6 +16,7 @@ import {
   resetDiagnosticSessionStateForTest,
 } from "../../logging/diagnostic-session-state.js";
 import { diagnosticLogger } from "../../logging/diagnostic.js";
+import { createUserTurnTranscriptRecorder } from "../../sessions/user-turn-transcript.js";
 import { MAX_TIMER_TIMEOUT_MS } from "../../shared/number-coercion.js";
 import {
   testing,
@@ -594,11 +595,15 @@ describe("embedded-agent runner run registry", () => {
       queueMessage,
     });
     operation.setPhase("running");
+    const recorder = createUserTurnTranscriptRecorder({
+      input: { text: "visible group prompt", sender: { id: "user-42" } },
+      target: { transcriptPath: "/tmp/unused-session.jsonl" },
+    });
 
     const outcome = await queueEmbeddedAgentMessageWithOutcomeAsync(
       "session-reply-run",
       "completion from child",
-      { waitForTranscriptCommit: true },
+      { waitForTranscriptCommit: true, userTurnTranscriptRecorder: recorder },
     );
 
     expect(outcome.queued).toBe(true);
@@ -613,7 +618,10 @@ describe("embedded-agent runner run registry", () => {
     });
     expect(outcome.enqueuedAtMs).toEqual(expect.any(Number));
     expect(outcome.deliveredAtMs).toBeUndefined();
-    expect(queueMessage).toHaveBeenCalledWith("completion from child");
+    expect(queueMessage).toHaveBeenCalledWith("completion from child", {
+      waitForTranscriptCommit: true,
+      userTurnTranscriptRecorder: recorder,
+    });
   });
 
   it("force-clears an aborted run that does not drain", async () => {

--- a/src/agents/embedded-agent-runner/runs.ts
+++ b/src/agents/embedded-agent-runner/runs.ts
@@ -441,7 +441,7 @@ function prepareEmbeddedAgentQueueMessage(
 ): PreparedEmbeddedAgentQueueMessage {
   const handle = ACTIVE_EMBEDDED_RUNS.get(sessionId);
   if (!handle) {
-    const queuedReplyRunMessage = queueReplyRunMessage(sessionId, text);
+    const queuedReplyRunMessage = queueReplyRunMessage(sessionId, text, options);
     if (queuedReplyRunMessage) {
       logMessageQueued({ sessionId, source: "embedded-agent-runner" });
       return {

--- a/src/agents/session-tool-result-guard-wrapper.ts
+++ b/src/agents/session-tool-result-guard-wrapper.ts
@@ -10,9 +10,13 @@ import {
   type InputProvenance,
 } from "../sessions/input-provenance.js";
 import {
+  attachRuntimeUserTurnTranscriptRecorder,
   mergePreparedUserTurnOpenClawMetaForRuntime,
   mergePreparedUserTurnMessageForRuntime,
+  takeRuntimeUserTurnTranscriptContext,
+  takeRuntimeUserTurnTranscriptRecorder,
   type PersistedUserTurnMessage,
+  type UserTurnTranscriptRecorder,
 } from "../sessions/user-turn-transcript.js";
 import { resolveLiveToolResultMaxChars } from "./embedded-agent-runner/tool-result-truncation.js";
 import type { AgentMessage } from "./runtime/index.js";
@@ -66,7 +70,7 @@ export function guardSessionManager(
 
   const hookRunner = getGlobalHookRunner();
   let pendingPreparedUserTurnMessage = opts?.preparedUserTurnMessage;
-  let preparedUserTurnMessageForWriteHook: PersistedUserTurnMessage | undefined;
+  let queuedUserTurnTranscriptRecorder: UserTurnTranscriptRecorder | undefined;
   const beforeMessageWrite = (event: { message: AgentMessage }) => {
     let message = event.message;
     let changed = false;
@@ -76,11 +80,17 @@ export function guardSessionManager(
         sessionKey: opts?.sessionKey,
       });
       if (result?.block) {
-        preparedUserTurnMessageForWriteHook = undefined;
+        queuedUserTurnTranscriptRecorder?.markBlocked();
+        queuedUserTurnTranscriptRecorder = undefined;
         return result;
       }
       if (result?.message) {
-        message = result.message;
+        message = mergePreparedUserTurnOpenClawMetaForRuntime({
+          runtimeMessage: result.message,
+          ...(event.message.role === "user"
+            ? { preparedMessage: event.message as PersistedUserTurnMessage }
+            : {}),
+        });
         changed = true;
       }
     }
@@ -89,16 +99,13 @@ export function guardSessionManager(
       message = redacted;
       changed = true;
     }
-    const withPreparedMeta = mergePreparedUserTurnOpenClawMetaForRuntime({
-      runtimeMessage: message,
-      ...(preparedUserTurnMessageForWriteHook
-        ? { preparedMessage: preparedUserTurnMessageForWriteHook }
-        : {}),
-    });
-    preparedUserTurnMessageForWriteHook = undefined;
-    if (withPreparedMeta !== message) {
-      message = withPreparedMeta;
-      changed = true;
+    if (message.role !== "user" && queuedUserTurnTranscriptRecorder) {
+      queuedUserTurnTranscriptRecorder.markBlocked();
+      queuedUserTurnTranscriptRecorder = undefined;
+    }
+    if (message.role === "user" && queuedUserTurnTranscriptRecorder) {
+      message = attachRuntimeUserTurnTranscriptRecorder(message, queuedUserTurnTranscriptRecorder);
+      queuedUserTurnTranscriptRecorder = undefined;
     }
     return changed ? { message } : undefined;
   };
@@ -130,15 +137,20 @@ export function guardSessionManager(
     sessionKey: opts?.sessionKey,
     agentId: opts?.agentId,
     transformMessageForPersistence: (message) => {
+      queuedUserTurnTranscriptRecorder = undefined;
       const withProvenance = applyInputProvenanceToUserMessage(message, opts?.inputProvenance);
-      const prepared = pendingPreparedUserTurnMessage;
+      const runtimeContext = takeRuntimeUserTurnTranscriptContext(message);
+      const prepared = runtimeContext?.message ?? pendingPreparedUserTurnMessage;
       const merged = mergePreparedUserTurnMessageForRuntime({
         runtimeMessage: withProvenance,
         ...(prepared ? { preparedMessage: prepared } : {}),
       });
       if (merged !== withProvenance) {
-        pendingPreparedUserTurnMessage = undefined;
-        preparedUserTurnMessageForWriteHook = prepared;
+        if (runtimeContext) {
+          queuedUserTurnTranscriptRecorder = runtimeContext.recorder;
+        } else {
+          pendingPreparedUserTurnMessage = undefined;
+        }
       }
       return merged;
     },
@@ -161,7 +173,11 @@ export function guardSessionManager(
     suppressAssistantErrorPersistence: opts?.suppressAssistantErrorPersistence,
     onMessagePersisted: opts?.onMessagePersisted,
     withCompactionPersistence: opts?.withCompactionPersistence,
-    onUserMessagePersisted: opts?.onUserMessagePersisted,
+    onUserMessagePersisted: async (message) => {
+      const recorder = takeRuntimeUserTurnTranscriptRecorder(message);
+      recorder?.markRuntimePersisted(message);
+      await opts?.onUserMessagePersisted?.(message);
+    },
     onUserMessageBlocked: opts?.onUserMessageBlocked,
     onAssistantErrorMessagePersisted: opts?.onAssistantErrorMessagePersisted,
   });

--- a/src/agents/session-tool-result-guard-wrapper.ts
+++ b/src/agents/session-tool-result-guard-wrapper.ts
@@ -11,10 +11,12 @@ import {
 } from "../sessions/input-provenance.js";
 import {
   attachRuntimeUserTurnTranscriptRecorder,
-  mergePreparedUserTurnMessageForRuntime,
-  restorePreparedUserTurnOperationalMetaForRuntime,
   takeRuntimeUserTurnTranscriptContext,
   takeRuntimeUserTurnTranscriptRecorder,
+} from "../sessions/user-turn-transcript-runtime-context.js";
+import {
+  mergePreparedUserTurnMessageForRuntime,
+  restorePreparedUserTurnOperationalMetaForRuntime,
   type PersistedUserTurnMessage,
   type UserTurnTranscriptRecorder,
 } from "../sessions/user-turn-transcript.js";

--- a/src/agents/session-tool-result-guard-wrapper.ts
+++ b/src/agents/session-tool-result-guard-wrapper.ts
@@ -11,8 +11,8 @@ import {
 } from "../sessions/input-provenance.js";
 import {
   attachRuntimeUserTurnTranscriptRecorder,
-  mergePreparedUserTurnOpenClawMetaForRuntime,
   mergePreparedUserTurnMessageForRuntime,
+  restorePreparedUserTurnOperationalMetaForRuntime,
   takeRuntimeUserTurnTranscriptContext,
   takeRuntimeUserTurnTranscriptRecorder,
   type PersistedUserTurnMessage,
@@ -85,7 +85,7 @@ export function guardSessionManager(
         return result;
       }
       if (result?.message) {
-        message = mergePreparedUserTurnOpenClawMetaForRuntime({
+        message = restorePreparedUserTurnOperationalMetaForRuntime({
           runtimeMessage: result.message,
           ...(event.message.role === "user" ? { preparedMessage: event.message } : {}),
         });

--- a/src/agents/session-tool-result-guard-wrapper.ts
+++ b/src/agents/session-tool-result-guard-wrapper.ts
@@ -87,9 +87,7 @@ export function guardSessionManager(
       if (result?.message) {
         message = mergePreparedUserTurnOpenClawMetaForRuntime({
           runtimeMessage: result.message,
-          ...(event.message.role === "user"
-            ? { preparedMessage: event.message as PersistedUserTurnMessage }
-            : {}),
+          ...(event.message.role === "user" ? { preparedMessage: event.message } : {}),
         });
         changed = true;
       }

--- a/src/agents/session-tool-result-guard-wrapper.ts
+++ b/src/agents/session-tool-result-guard-wrapper.ts
@@ -10,6 +10,7 @@ import {
   type InputProvenance,
 } from "../sessions/input-provenance.js";
 import {
+  mergePreparedUserTurnOpenClawMetaForRuntime,
   mergePreparedUserTurnMessageForRuntime,
   type PersistedUserTurnMessage,
 } from "../sessions/user-turn-transcript.js";
@@ -65,6 +66,7 @@ export function guardSessionManager(
 
   const hookRunner = getGlobalHookRunner();
   let pendingPreparedUserTurnMessage = opts?.preparedUserTurnMessage;
+  let preparedUserTurnMessageForWriteHook: PersistedUserTurnMessage | undefined;
   const beforeMessageWrite = (event: { message: AgentMessage }) => {
     let message = event.message;
     let changed = false;
@@ -74,6 +76,7 @@ export function guardSessionManager(
         sessionKey: opts?.sessionKey,
       });
       if (result?.block) {
+        preparedUserTurnMessageForWriteHook = undefined;
         return result;
       }
       if (result?.message) {
@@ -84,6 +87,17 @@ export function guardSessionManager(
     const redacted = redactTranscriptMessage(message, opts?.config);
     if (redacted !== message) {
       message = redacted;
+      changed = true;
+    }
+    const withPreparedMeta = mergePreparedUserTurnOpenClawMetaForRuntime({
+      runtimeMessage: message,
+      ...(preparedUserTurnMessageForWriteHook
+        ? { preparedMessage: preparedUserTurnMessageForWriteHook }
+        : {}),
+    });
+    preparedUserTurnMessageForWriteHook = undefined;
+    if (withPreparedMeta !== message) {
+      message = withPreparedMeta;
       changed = true;
     }
     return changed ? { message } : undefined;
@@ -124,6 +138,7 @@ export function guardSessionManager(
       });
       if (merged !== withProvenance) {
         pendingPreparedUserTurnMessage = undefined;
+        preparedUserTurnMessageForWriteHook = prepared;
       }
       return merged;
     },

--- a/src/agents/sessions/agent-session.ts
+++ b/src/agents/sessions/agent-session.ts
@@ -34,11 +34,11 @@ import type {
   TextContent,
 } from "../../llm/types.js";
 import { isRetryableAssistantError } from "../../llm/utils/retry.js";
-import {
-  attachRuntimeUserTurnTranscriptContext,
-  type PersistedUserTurnMessage,
-  type UserTurnTranscriptRecorder,
-} from "../../sessions/user-turn-transcript.js";
+import { attachRuntimeUserTurnTranscriptContext } from "../../sessions/user-turn-transcript-runtime-context.js";
+import type {
+  PersistedUserTurnMessage,
+  UserTurnTranscriptRecorder,
+} from "../../sessions/user-turn-transcript.types.js";
 import type {
   Agent,
   AgentEvent,

--- a/src/agents/sessions/agent-session.ts
+++ b/src/agents/sessions/agent-session.ts
@@ -34,6 +34,11 @@ import type {
   TextContent,
 } from "../../llm/types.js";
 import { isRetryableAssistantError } from "../../llm/utils/retry.js";
+import {
+  attachRuntimeUserTurnTranscriptContext,
+  type PersistedUserTurnMessage,
+  type UserTurnTranscriptRecorder,
+} from "../../sessions/user-turn-transcript.js";
 import type {
   Agent,
   AgentEvent,
@@ -1361,9 +1366,14 @@ export class AgentSession {
    * before the next LLM call.
    * Expands skill commands and prompt templates. Errors on extension commands.
    * @param images Optional image attachments to include with the message
+   * @param userTurnTranscriptRecorder Prepared channel fields for transcript-only persistence
    * @throws Error if text is an extension command
    */
-  async steer(text: string, images?: ImageContent[]): Promise<void> {
+  async steer(
+    text: string,
+    images?: ImageContent[],
+    userTurnTranscriptRecorder?: UserTurnTranscriptRecorder,
+  ): Promise<void> {
     // Check for extension commands (cannot be queued)
     if (text.startsWith("/")) {
       this.throwIfExtensionCommand(text);
@@ -1373,7 +1383,14 @@ export class AgentSession {
     let expandedText = this.expandSkillCommand(text);
     expandedText = expandPromptTemplate(expandedText, [...this.promptTemplates]);
 
-    await this.queueSteer(expandedText, images);
+    const preparedMessage = await userTurnTranscriptRecorder?.resolveMessage();
+    await this.queueSteer(
+      expandedText,
+      images,
+      preparedMessage && userTurnTranscriptRecorder
+        ? { message: preparedMessage, recorder: userTurnTranscriptRecorder }
+        : undefined,
+    );
   }
 
   /**
@@ -1399,18 +1416,30 @@ export class AgentSession {
   /**
    * Internal: Queue a steering message (already expanded, no extension command check).
    */
-  private async queueSteer(text: string, images?: ImageContent[]): Promise<void> {
+  private async queueSteer(
+    text: string,
+    images?: ImageContent[],
+    transcriptContext?: {
+      message: PersistedUserTurnMessage;
+      recorder: UserTurnTranscriptRecorder;
+    },
+  ): Promise<void> {
     this.steeringMessages.push(text);
     this.emitQueueUpdate();
     const content: (TextContent | ImageContent)[] = [{ type: "text", text }];
     if (images) {
       content.push(...images);
     }
-    this.agent.steer({
+    const runtimeMessage = {
       role: "user",
       content,
       timestamp: Date.now(),
-    });
+    } satisfies PersistedUserTurnMessage;
+    this.agent.steer(
+      transcriptContext
+        ? attachRuntimeUserTurnTranscriptContext(runtimeMessage, transcriptContext)
+        : runtimeMessage,
+    );
   }
 
   /**

--- a/src/agents/sessions/sdk.test.ts
+++ b/src/agents/sessions/sdk.test.ts
@@ -3,6 +3,10 @@
 import { Type } from "typebox";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Context, Model, SimpleStreamOptions } from "../../llm/types.js";
+import {
+  createUserTurnTranscriptRecorder,
+  takeRuntimeUserTurnTranscriptContext,
+} from "../../sessions/user-turn-transcript.js";
 
 const thinkingMocks = vi.hoisted(() => ({
   resolveThinkingDefaultForModel: vi.fn(() => "medium"),
@@ -185,6 +189,39 @@ describe("AgentSession getLastAssistantText", () => {
     const session = await createSessionFromManager(sessionManager);
 
     expect(session.getLastAssistantText()).toBe("previous answer");
+  });
+});
+
+describe("AgentSession queued user turns", () => {
+  it("carries prepared transcript context on the exact steered message", async () => {
+    const session = await createSessionFromManager(SessionManager.inMemory());
+    const recorder = createUserTurnTranscriptRecorder({
+      input: {
+        text: "visible group prompt",
+        sender: { id: "user-42", name: "Ada" },
+      },
+      target: { transcriptPath: "/tmp/unused-session.jsonl" },
+    });
+    const steer = vi.spyOn(session.agent, "steer").mockImplementation(() => undefined);
+
+    await session.steer("runtime group prompt", undefined, recorder);
+
+    const runtimeMessage = steer.mock.calls[0]?.[0];
+    expect(runtimeMessage).toMatchObject({
+      role: "user",
+      content: [{ type: "text", text: "runtime group prompt" }],
+    });
+    if (!runtimeMessage) {
+      throw new Error("expected queued runtime message");
+    }
+    expect(takeRuntimeUserTurnTranscriptContext(runtimeMessage)).toMatchObject({
+      message: {
+        role: "user",
+        content: "visible group prompt",
+        __openclaw: { senderId: "user-42", senderName: "Ada" },
+      },
+      recorder,
+    });
   });
 });
 

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -10,6 +10,7 @@ import {
   HEARTBEAT_RUN_SCOPE,
   type ReplyOptionsWithHeartbeatRunScope,
 } from "../../infra/heartbeat-run-scope.js";
+import { createUserTurnTranscriptRecorder } from "../../sessions/user-turn-transcript.js";
 import type { TemplateContext } from "../templating.js";
 import type { GetReplyOptions } from "../types.js";
 import {
@@ -135,8 +136,27 @@ vi.mock("../../agents/embedded-agent.js", () => ({
 }));
 
 vi.mock("../../agents/embedded-agent-runner/runs.js", () => ({
-  queueEmbeddedAgentMessage: (sessionId: string, prompt: string, options: unknown) =>
-    state.queueEmbeddedAgentMessageMock(sessionId, prompt, options),
+  formatEmbeddedAgentQueueFailureSummary: () => "test queue rejection",
+  queueEmbeddedAgentMessageWithOutcomeAsync: async (
+    sessionId: string,
+    prompt: string,
+    options: unknown,
+  ) =>
+    state.queueEmbeddedAgentMessageMock(sessionId, prompt, options)
+      ? {
+          queued: true,
+          sessionId,
+          target: "embedded_run",
+          gatewayHealth: "live",
+          enqueuedAtMs: Date.now(),
+        }
+      : {
+          queued: false,
+          sessionId,
+          reason: "no_active_run",
+          target: "none",
+          gatewayHealth: "live",
+        },
 }));
 
 vi.mock("./queue.js", () => ({
@@ -234,6 +254,7 @@ function createMinimalRun(params?: {
   } as unknown as FollowupRun;
 
   return {
+    followupRun,
     typing,
     opts,
     run: async () => {
@@ -266,6 +287,37 @@ function createMinimalRun(params?: {
     },
   };
 }
+
+describe("runReplyAgent active steering", () => {
+  it("carries the prepared user-turn recorder into the embedded queue", async () => {
+    state.queueEmbeddedAgentMessageMock.mockReturnValueOnce(true);
+    const recorder = createUserTurnTranscriptRecorder({
+      input: {
+        text: "visible group prompt",
+        sender: { id: "user-42", name: "Ada" },
+      },
+      target: { transcriptPath: "/tmp/unused-session.jsonl" },
+    });
+    const { followupRun, run } = createMinimalRun({
+      isActive: true,
+      isStreaming: true,
+      shouldSteer: true,
+      resolvedQueueMode: "steer",
+    });
+    followupRun.userTurnTranscriptRecorder = recorder;
+
+    await expect(run()).resolves.toBeUndefined();
+
+    expect(state.queueEmbeddedAgentMessageMock).toHaveBeenCalledWith(
+      "session",
+      "hello",
+      expect.objectContaining({
+        steeringMode: "all",
+        userTurnTranscriptRecorder: recorder,
+      }),
+    );
+  });
+});
 
 describe("runReplyAgent heartbeat followup guard", () => {
   it("drops heartbeat runs when reply-lane admission finds an active owner", async () => {

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1269,6 +1269,9 @@ export async function runReplyAgent(params: {
       {
         steeringMode: "all",
         ...(resolvedQueue.debounceMs !== undefined ? { debounceMs: resolvedQueue.debounceMs } : {}),
+        ...(followupRun.userTurnTranscriptRecorder
+          ? { userTurnTranscriptRecorder: followupRun.userTurnTranscriptRecorder }
+          : {}),
       },
     );
     if (steerOutcome.queued) {

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -1170,6 +1170,55 @@ describe("runPreparedReply media-only handling", () => {
     expect(call.followupRun.userTurnTranscriptRecorder?.message).not.toHaveProperty("MediaPaths");
   });
 
+  it.each([
+    ["group", true],
+    ["channel", true],
+    ["direct", false],
+  ] as const)("persists sender attribution for %s turns only", async (chatType, shouldPersist) => {
+    await runPreparedReply(
+      baseParams({
+        ctx: {
+          Body: "hello",
+          RawBody: "hello",
+          CommandBody: "hello",
+          OriginatingChannel: "telegram",
+          OriginatingTo: "chat-1",
+          ChatType: chatType,
+        },
+        sessionCtx: {
+          Body: "hello",
+          BodyStripped: "hello",
+          Provider: "telegram",
+          OriginatingChannel: "telegram",
+          OriginatingTo: "chat-1",
+          ChatType: chatType,
+          SenderId: "user-42",
+          SenderName: "Ada",
+          SenderUsername: "ada",
+        },
+        sessionEntry: {
+          sessionId: "session-1",
+          updatedAt: 1,
+          chatType,
+          channel: "telegram",
+        } as SessionEntry,
+      }),
+    );
+
+    const message = requireRunReplyAgentCall().followupRun.userTurnTranscriptRecorder?.message;
+    if (shouldPersist) {
+      expect(message).toMatchObject({
+        __openclaw: {
+          senderId: "user-42",
+          senderName: "Ada",
+          senderUsername: "ada",
+        },
+      });
+    } else {
+      expect(message).not.toHaveProperty("__openclaw");
+    }
+  });
+
   it("normalizes second-based inbound timestamps before preparing user turns", async () => {
     await runPreparedReply(
       baseParams({

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -2263,7 +2263,7 @@ describe("runPreparedReply media-only handling", () => {
       role: "user",
       content: "#35676 Keśava: No wtf",
       timestamp: expect.any(Number),
-      __openclaw: { senderIsOwner: false },
+      __openclaw: { senderIsOwner: false, senderName: "Keśava" },
     });
     call?.followupRun.userTurnTranscriptRecorder?.markRuntimePersisted({
       role: "user",

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -1215,7 +1215,9 @@ describe("runPreparedReply media-only handling", () => {
         },
       });
     } else {
-      expect(message).not.toHaveProperty("__openclaw");
+      expect(message).not.toHaveProperty("__openclaw.senderId");
+      expect(message).not.toHaveProperty("__openclaw.senderName");
+      expect(message).not.toHaveProperty("__openclaw.senderUsername");
     }
   });
 

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -1305,6 +1305,19 @@ export async function runPreparedReply(
     opts?.queuedFollowupLifecycle || inboundEventKind === "room_event"
       ? (opts?.queuedFollowupAbortSignal ?? opts?.abortSignal)
       : undefined;
+  const replyRoute = resolveEffectiveReplyRoute({
+    ctx: {
+      Provider: ctx.Provider ?? sessionCtx.Provider,
+      Surface: ctx.Surface ?? sessionCtx.Surface,
+      OriginatingChannel: ctx.OriginatingChannel ?? sessionCtx.OriginatingChannel,
+      OriginatingTo: ctx.OriginatingTo ?? sessionCtx.OriginatingTo,
+      AccountId: ctx.AccountId ?? sessionCtx.AccountId,
+      InputProvenance: ctx.InputProvenance ?? sessionCtx.InputProvenance,
+      ChatType: ctx.ChatType ?? sessionCtx.ChatType,
+    },
+    entry: preparedSessionState.sessionEntry,
+  });
+  const persistGroupSender = replyRoute.chatType === "group" || replyRoute.chatType === "channel";
   const userTurnMediaForPersistence = buildPersistedUserTurnMediaInputsFromFields(ctx);
   const inputProvenance = ctx.InputProvenance ?? sessionCtx.InputProvenance;
   const userTurnTimestamp = normalizeMessageTimestampMs(ctx.Timestamp);
@@ -1329,9 +1342,17 @@ export async function runPreparedReply(
           // is identical whether this turn is sent as the current turn or
           // replayed as history. See: https://github.com/openclaw/openclaw/issues/3658
           ...(userTurnTimestamp ? { timestamp: userTurnTimestamp } : {}),
-          senderId: normalizeOptionalString(sessionCtx.SenderId),
-          senderName: normalizeOptionalString(sessionCtx.SenderName),
-          senderUsername: normalizeOptionalString(sessionCtx.SenderUsername),
+          // Group transcripts need participant attribution. Direct transcripts
+          // keep their existing shape and avoid a broader identity-storage change.
+          ...(persistGroupSender
+            ? {
+                sender: {
+                  id: normalizeOptionalString(sessionCtx.SenderId),
+                  name: normalizeOptionalString(sessionCtx.SenderName),
+                  username: normalizeOptionalString(sessionCtx.SenderUsername),
+                },
+              }
+            : {}),
         }
       : undefined;
   const userTurnTranscriptRecorder =
@@ -1362,18 +1383,6 @@ export async function runPreparedReply(
             : undefined,
         })
       : undefined);
-  const replyRoute = resolveEffectiveReplyRoute({
-    ctx: {
-      Provider: ctx.Provider ?? sessionCtx.Provider,
-      Surface: ctx.Surface ?? sessionCtx.Surface,
-      OriginatingChannel: ctx.OriginatingChannel ?? sessionCtx.OriginatingChannel,
-      OriginatingTo: ctx.OriginatingTo ?? sessionCtx.OriginatingTo,
-      AccountId: ctx.AccountId ?? sessionCtx.AccountId,
-      InputProvenance: ctx.InputProvenance ?? sessionCtx.InputProvenance,
-      ChatType: ctx.ChatType ?? sessionCtx.ChatType,
-    },
-    entry: preparedSessionState.sessionEntry,
-  });
   const messageProvider = resolveOriginMessageProvider({
     originatingChannel: replyRoute.channel,
     // Prefer Provider over Surface for fallback channel identity.

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -1342,17 +1342,14 @@ export async function runPreparedReply(
           // is identical whether this turn is sent as the current turn or
           // replayed as history. See: https://github.com/openclaw/openclaw/issues/3658
           ...(userTurnTimestamp ? { timestamp: userTurnTimestamp } : {}),
-          // Group transcripts need participant attribution. Direct transcripts
-          // keep their existing shape and avoid a broader identity-storage change.
-          ...(persistGroupSender
+          // Direct transcripts keep their existing identity-storage boundary.
+          sender: persistGroupSender
             ? {
-                sender: {
-                  id: normalizeOptionalString(sessionCtx.SenderId),
-                  name: normalizeOptionalString(sessionCtx.SenderName),
-                  username: normalizeOptionalString(sessionCtx.SenderUsername),
-                },
+                id: normalizeOptionalString(sessionCtx.SenderId),
+                name: normalizeOptionalString(sessionCtx.SenderName),
+                username: normalizeOptionalString(sessionCtx.SenderUsername),
               }
-            : {}),
+            : undefined,
         }
       : undefined;
   const userTurnTranscriptRecorder =

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -1332,7 +1332,6 @@ export async function runPreparedReply(
           senderId: normalizeOptionalString(sessionCtx.SenderId),
           senderName: normalizeOptionalString(sessionCtx.SenderName),
           senderUsername: normalizeOptionalString(sessionCtx.SenderUsername),
-          senderE164: normalizeOptionalString(sessionCtx.SenderE164),
         }
       : undefined;
   const userTurnTranscriptRecorder =

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -1329,6 +1329,10 @@ export async function runPreparedReply(
           // is identical whether this turn is sent as the current turn or
           // replayed as history. See: https://github.com/openclaw/openclaw/issues/3658
           ...(userTurnTimestamp ? { timestamp: userTurnTimestamp } : {}),
+          senderId: normalizeOptionalString(sessionCtx.SenderId),
+          senderName: normalizeOptionalString(sessionCtx.SenderName),
+          senderUsername: normalizeOptionalString(sessionCtx.SenderUsername),
+          senderE164: normalizeOptionalString(sessionCtx.SenderE164),
         }
       : undefined;
   const userTurnTranscriptRecorder =

--- a/src/auto-reply/reply/reply-run-registry.ts
+++ b/src/auto-reply/reply/reply-run-registry.ts
@@ -9,8 +9,10 @@ import {
   markDiagnosticEmbeddedRunEnded,
   markDiagnosticEmbeddedRunStarted,
 } from "../../logging/diagnostic-run-activity.js";
+import type { UserTurnTranscriptRecorder } from "../../sessions/user-turn-transcript.types.js";
 import { resolveGlobalSingleton } from "../../shared/global-singleton.js";
 import { resolveTimerTimeoutMs } from "../../shared/number-coercion.js";
+import type { SourceReplyDeliveryMode } from "../get-reply-options.types.js";
 import type { ReplyFollowupAdmissionBarrierTimeoutPolicy } from "./reply-dispatcher.types.js";
 
 export type ReplyRunKey = string;
@@ -19,13 +21,23 @@ export type ReplyBackendKind = "embedded" | "cli";
 
 export type ReplyBackendCancelReason = "user_abort" | "restart" | "superseded";
 
+export type ReplyBackendQueueMessageOptions = {
+  steeringMode?: "all";
+  debounceMs?: number;
+  deliveryTimeoutMs?: number;
+  waitForTranscriptCommit?: boolean;
+  sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
+  /** Prepared channel turn to merge only at transcript persistence. */
+  userTurnTranscriptRecorder?: UserTurnTranscriptRecorder;
+};
+
 export type ReplyBackendHandle = {
   readonly kind: ReplyBackendKind;
   cancel(reason?: ReplyBackendCancelReason): void;
   isStreaming(): boolean;
   isStopped?: () => boolean;
   isAbortable?: () => boolean;
-  queueMessage?: (text: string) => Promise<void>;
+  queueMessage?: (text: string, options?: ReplyBackendQueueMessageOptions) => Promise<void>;
   /**
    * Compatibility-only hook so legacy "abort compacting runs" paths can still
    * find embedded runs that are compacting during the main run phase.
@@ -811,7 +823,11 @@ export function isReplyRunStreamingForSessionId(sessionId: string): boolean {
   return getAttachedBackend(operation)?.isStreaming() ?? false;
 }
 
-export function queueReplyRunMessage(sessionId: string, text: string): boolean {
+export function queueReplyRunMessage(
+  sessionId: string,
+  text: string,
+  options?: ReplyBackendQueueMessageOptions,
+): boolean {
   const operation = resolveReplyRunForCurrentSessionId(sessionId);
   const backend = operation ? getAttachedBackend(operation) : undefined;
   if (!operation || operation.phase !== "running" || !backend?.queueMessage) {
@@ -820,7 +836,7 @@ export function queueReplyRunMessage(sessionId: string, text: string): boolean {
   if (!isReplyBackendMessageInjectable(backend)) {
     return false;
   }
-  void backend.queueMessage(text);
+  void (options ? backend.queueMessage(text, options) : backend.queueMessage(text));
   return true;
 }
 

--- a/src/infra/exec-policy.ts
+++ b/src/infra/exec-policy.ts
@@ -22,9 +22,8 @@ export function applyExecPolicyLayer<TBase extends ExecPolicyLayer>(
     };
   }
   if (layer.security !== undefined || layer.ask !== undefined) {
-    const { mode: _mode, ...baseWithoutMode } = base;
     return {
-      ...baseWithoutMode,
+      ...base,
       security: layer.security ?? base.security,
       ask: layer.ask ?? base.ask,
     };

--- a/src/infra/exec-policy.ts
+++ b/src/infra/exec-policy.ts
@@ -22,11 +22,12 @@ export function applyExecPolicyLayer<TBase extends ExecPolicyLayer>(
     };
   }
   if (layer.security !== undefined || layer.ask !== undefined) {
+    const { mode: _mode, ...baseWithoutMode } = base;
     return {
-      ...base,
+      ...baseWithoutMode,
       security: layer.security ?? base.security,
       ask: layer.ask ?? base.ask,
-    };
+    } as unknown as TBase & ExecPolicyLayer;
   }
   return base;
 }

--- a/src/infra/exec-policy.ts
+++ b/src/infra/exec-policy.ts
@@ -19,7 +19,7 @@ export function applyExecPolicyLayer<TBase extends ExecPolicyLayer>(
       ...base,
       mode: layer.mode,
       ...resolveExecPolicyForMode(layer.mode),
-    };
+    } as unknown as TBase & ExecPolicyLayer;
   }
   if (layer.security !== undefined || layer.ask !== undefined) {
     const { mode: _mode, ...baseWithoutMode } = base;

--- a/src/infra/exec-policy.ts
+++ b/src/infra/exec-policy.ts
@@ -19,7 +19,7 @@ export function applyExecPolicyLayer<TBase extends ExecPolicyLayer>(
       ...base,
       mode: layer.mode,
       ...resolveExecPolicyForMode(layer.mode),
-    } as unknown as TBase & ExecPolicyLayer;
+    };
   }
   if (layer.security !== undefined || layer.ask !== undefined) {
     const { mode: _mode, ...baseWithoutMode } = base;
@@ -27,7 +27,7 @@ export function applyExecPolicyLayer<TBase extends ExecPolicyLayer>(
       ...baseWithoutMode,
       security: layer.security ?? base.security,
       ask: layer.ask ?? base.ask,
-    } as unknown as TBase & ExecPolicyLayer;
+    };
   }
   return base;
 }

--- a/src/sessions/user-turn-transcript-runtime-context.ts
+++ b/src/sessions/user-turn-transcript-runtime-context.ts
@@ -1,0 +1,69 @@
+// Transient user-turn transcript context carried through runtime queues.
+import type { AgentMessage } from "../../packages/agent-core/src/types.js";
+import type {
+  PersistedUserTurnMessage,
+  UserTurnTranscriptRecorder,
+} from "./user-turn-transcript.types.js";
+
+const RUNTIME_USER_TURN_TRANSCRIPT_CONTEXT = Symbol.for(
+  "openclaw.runtimeUserTurnTranscriptContext",
+);
+const RUNTIME_USER_TURN_TRANSCRIPT_RECORDER = Symbol.for(
+  "openclaw.runtimeUserTurnTranscriptRecorder",
+);
+
+export type RuntimeUserTurnTranscriptContext = {
+  message: PersistedUserTurnMessage;
+  recorder: UserTurnTranscriptRecorder;
+};
+
+/** Carries transcript-only fields with a queued runtime message without exposing them to the model. */
+export function attachRuntimeUserTurnTranscriptContext(
+  runtimeMessage: PersistedUserTurnMessage,
+  context: RuntimeUserTurnTranscriptContext,
+): PersistedUserTurnMessage {
+  Object.defineProperty(runtimeMessage, RUNTIME_USER_TURN_TRANSCRIPT_CONTEXT, {
+    configurable: true,
+    value: context,
+  });
+  return runtimeMessage;
+}
+
+/** Consumes the transient queued-turn context before the message is serialized. */
+export function takeRuntimeUserTurnTranscriptContext(
+  runtimeMessage: AgentMessage,
+): RuntimeUserTurnTranscriptContext | undefined {
+  const record = runtimeMessage as unknown as Record<PropertyKey, unknown>;
+  const context = record[RUNTIME_USER_TURN_TRANSCRIPT_CONTEXT] as
+    | RuntimeUserTurnTranscriptContext
+    | undefined;
+  if (context) {
+    delete record[RUNTIME_USER_TURN_TRANSCRIPT_CONTEXT];
+  }
+  return context;
+}
+
+/** Keeps the queued recorder attached to the exact final message until persistence succeeds. */
+export function attachRuntimeUserTurnTranscriptRecorder(
+  runtimeMessage: AgentMessage,
+  recorder: UserTurnTranscriptRecorder,
+): AgentMessage {
+  Object.defineProperty(runtimeMessage, RUNTIME_USER_TURN_TRANSCRIPT_RECORDER, {
+    configurable: true,
+    value: recorder,
+  });
+  return runtimeMessage;
+}
+
+export function takeRuntimeUserTurnTranscriptRecorder(
+  runtimeMessage: AgentMessage,
+): UserTurnTranscriptRecorder | undefined {
+  const record = runtimeMessage as unknown as Record<PropertyKey, unknown>;
+  const recorder = record[RUNTIME_USER_TURN_TRANSCRIPT_RECORDER] as
+    | UserTurnTranscriptRecorder
+    | undefined;
+  if (recorder) {
+    delete record[RUNTIME_USER_TURN_TRANSCRIPT_RECORDER];
+  }
+  return recorder;
+}

--- a/src/sessions/user-turn-transcript.test.ts
+++ b/src/sessions/user-turn-transcript.test.ts
@@ -541,8 +541,6 @@ describe("user turn transcript persistence", () => {
           __openclaw: {
             hookOwned: true,
             senderIsOwner: true,
-            senderId: "user-42",
-            senderName: "Ada",
           },
         }),
       ]);

--- a/src/sessions/user-turn-transcript.test.ts
+++ b/src/sessions/user-turn-transcript.test.ts
@@ -320,6 +320,66 @@ describe("user turn transcript persistence", () => {
       ]);
     });
 
+    it("persists sender metadata as __openclaw envelope", async () => {
+      const dir = createTempDir("openclaw-user-turn-append-sender-");
+      const transcriptPath = path.join(dir, "session.jsonl");
+
+      const appended = await appendUserTurnTranscriptMessage({
+        transcriptPath,
+        sessionId: "session-1",
+        sessionKey: "main",
+        cwd: dir,
+        input: {
+          text: "hello from group",
+          senderId: "8489979671",
+          senderName: "Ram Shenoy",
+          senderUsername: "ram_s",
+        },
+        updateMode: "none",
+      });
+
+      expect(appended?.message).toMatchObject({
+        role: "user",
+        content: "hello from group",
+        __openclaw: {
+          senderId: "8489979671",
+          senderName: "Ram Shenoy",
+          senderUsername: "ram_s",
+        },
+      });
+      expect(readTranscriptMessages(transcriptPath)).toEqual([
+        expect.objectContaining({
+          role: "user",
+          content: "hello from group",
+          __openclaw: {
+            senderId: "8489979671",
+            senderName: "Ram Shenoy",
+            senderUsername: "ram_s",
+          },
+        }),
+      ]);
+    });
+
+    it("omits __openclaw when no sender metadata is provided", async () => {
+      const dir = createTempDir("openclaw-user-turn-append-nosender-");
+      const transcriptPath = path.join(dir, "session.jsonl");
+
+      const appended = await appendUserTurnTranscriptMessage({
+        transcriptPath,
+        sessionId: "session-1",
+        sessionKey: "main",
+        cwd: dir,
+        input: {
+          text: "hello without sender",
+          senderId: "",
+          senderName: null,
+        },
+        updateMode: "none",
+      });
+
+      expect(appended?.message).not.toHaveProperty("__openclaw");
+    });
+
     it("uses inline update mode by default", async () => {
       const dir = createTempDir("openclaw-user-turn-append-inline-");
       const transcriptPath = path.join(dir, "session.jsonl");

--- a/src/sessions/user-turn-transcript.test.ts
+++ b/src/sessions/user-turn-transcript.test.ts
@@ -537,9 +537,13 @@ describe("user turn transcript persistence", () => {
           role: "user",
           content: "[redacted by hook]",
           idempotencyKey: "chat-run-1:user",
-          __openclaw: { senderIsOwner: true },
           provenance,
-          __openclaw: { hookOwned: true, senderId: "user-42", senderName: "Ada" },
+          __openclaw: {
+            hookOwned: true,
+            senderIsOwner: true,
+            senderId: "user-42",
+            senderName: "Ada",
+          },
         }),
       ]);
       expect(hookCalls).toBe(1);

--- a/src/sessions/user-turn-transcript.test.ts
+++ b/src/sessions/user-turn-transcript.test.ts
@@ -201,6 +201,33 @@ describe("user turn transcript persistence", () => {
       });
     });
 
+    it("preserves runtime metadata when adding prepared sender attribution", () => {
+      const recorder = createUserTurnTranscriptRecorder({
+        input: {
+          text: "group prompt",
+          sender: { id: "user-42", name: "Ada" },
+        },
+        target: { transcriptPath: "/tmp/session.jsonl" },
+      });
+
+      expect(
+        mergePreparedUserTurnMessageForRuntime({
+          runtimeMessage: castAgentMessage({
+            role: "user",
+            content: "runtime prompt",
+            __openclaw: { mirrorIdentity: "run-1:prompt" },
+          }),
+          preparedMessage: recorder.message,
+        }),
+      ).toMatchObject({
+        __openclaw: {
+          mirrorIdentity: "run-1:prompt",
+          senderId: "user-42",
+          senderName: "Ada",
+        },
+      });
+    });
+
     it("does not replace blocked before_agent_run user markers", () => {
       const recorder = createUserTurnTranscriptRecorder({
         input: { text: "raw prompt" },
@@ -331,9 +358,11 @@ describe("user turn transcript persistence", () => {
         cwd: dir,
         input: {
           text: "hello from group",
-          senderId: "8489979671",
-          senderName: "Ram Shenoy",
-          senderUsername: "ram_s",
+          sender: {
+            id: "8489979671",
+            name: "Ram Shenoy",
+            username: "ram_s",
+          },
         },
         updateMode: "none",
       });
@@ -371,8 +400,7 @@ describe("user turn transcript persistence", () => {
         cwd: dir,
         input: {
           text: "hello without sender",
-          senderId: "",
-          senderName: null,
+          sender: { id: "", name: null },
         },
         updateMode: "none",
       });

--- a/src/sessions/user-turn-transcript.test.ts
+++ b/src/sessions/user-turn-transcript.test.ts
@@ -482,7 +482,7 @@ describe("user turn transcript persistence", () => {
       ]);
     });
 
-    it("preserves idempotency keys when before_message_write replaces a user turn", async () => {
+    it("preserves transcript metadata when before_message_write replaces a user turn", async () => {
       let hookCalls = 0;
       const provenance = {
         kind: "inter_session" as const,
@@ -499,6 +499,7 @@ describe("user turn transcript persistence", () => {
                 message: castAgentMessage({
                   role: "user",
                   content: "[redacted by hook]",
+                  __openclaw: { hookOwned: true },
                 }),
               };
             },
@@ -515,6 +516,7 @@ describe("user turn transcript persistence", () => {
           idempotencyKey: "chat-run-1:user",
           senderIsOwner: true,
           provenance,
+          sender: { id: "user-42", name: "Ada" },
         },
         beforeMessageWrite: runAgentHarnessBeforeMessageWriteHook,
       });
@@ -525,6 +527,7 @@ describe("user turn transcript persistence", () => {
           idempotencyKey: "chat-run-1:user",
           senderIsOwner: true,
           provenance,
+          sender: { id: "user-42", name: "Ada" },
         },
         beforeMessageWrite: runAgentHarnessBeforeMessageWriteHook,
       });
@@ -536,6 +539,7 @@ describe("user turn transcript persistence", () => {
           idempotencyKey: "chat-run-1:user",
           __openclaw: { senderIsOwner: true },
           provenance,
+          __openclaw: { hookOwned: true, senderId: "user-42", senderName: "Ada" },
         }),
       ]);
       expect(hookCalls).toBe(1);

--- a/src/sessions/user-turn-transcript.ts
+++ b/src/sessions/user-turn-transcript.ts
@@ -403,8 +403,8 @@ export function mergePreparedUserTurnMessageForRuntime(params: {
   } as unknown as AgentMessage;
 }
 
-/** Restores runtime-owned OpenClaw metadata after a write hook replaces the user message. */
-export function mergePreparedUserTurnOpenClawMetaForRuntime(params: {
+/** Restores only auth state that write hooks must not be able to forge or erase. */
+export function restorePreparedUserTurnOperationalMetaForRuntime(params: {
   runtimeMessage: AgentMessage;
   preparedMessage?: PersistedUserTurnMessage;
 }): AgentMessage {
@@ -412,12 +412,13 @@ export function mergePreparedUserTurnOpenClawMetaForRuntime(params: {
     return params.runtimeMessage;
   }
   const preparedMeta = readOpenClawMessageMeta(params.preparedMessage);
-  if (!preparedMeta) {
+  const senderIsOwner = preparedMeta?.senderIsOwner;
+  if (typeof senderIsOwner !== "boolean") {
     return params.runtimeMessage;
   }
   return {
     ...(params.runtimeMessage as unknown as Record<string, unknown>),
-    __openclaw: { ...readOpenClawMessageMeta(params.runtimeMessage), ...preparedMeta },
+    __openclaw: { ...readOpenClawMessageMeta(params.runtimeMessage), senderIsOwner },
   } as unknown as AgentMessage;
 }
 
@@ -438,7 +439,7 @@ export function preparePersistedUserTurnMessageForTranscriptWrite(
   const provenance = normalizeInputProvenance(
     (message as unknown as { provenance?: unknown }).provenance,
   );
-  const originalMeta = readOpenClawMessageMeta(message);
+  const senderIsOwner = readOpenClawMessageMeta(message)?.senderIsOwner;
   const nextMessage = params.beforeMessageWrite({
     message,
     ...(params.agentId ? { agentId: params.agentId } : {}),
@@ -450,19 +451,21 @@ export function preparePersistedUserTurnMessageForTranscriptWrite(
   const nextUserMessage = provenance
     ? (applyInputProvenanceToUserMessage(nextMessage, provenance) as PersistedUserTurnMessage)
     : nextMessage;
-  const nextMessageMeta = readOpenClawMessageMeta(nextUserMessage);
-  const nextUserMessageWithMetadata = originalMeta
-    ? ({
-        ...(nextUserMessage as unknown as Record<string, unknown>),
-        __openclaw: { ...nextMessageMeta, ...originalMeta },
-      } as unknown as PersistedUserTurnMessage)
-    : nextUserMessage;
-  return idempotencyKey
-    ? ({
-        ...(nextUserMessageWithMetadata as unknown as Record<string, unknown>),
-        idempotencyKey,
-      } as unknown as PersistedUserTurnMessage)
-    : nextUserMessageWithMetadata;
+  if (!idempotencyKey && typeof senderIsOwner !== "boolean") {
+    return nextUserMessage;
+  }
+  return {
+    ...(nextUserMessage as unknown as Record<string, unknown>),
+    ...(idempotencyKey ? { idempotencyKey } : {}),
+    ...(typeof senderIsOwner === "boolean"
+      ? {
+          __openclaw: {
+            ...readOpenClawMessageMeta(nextUserMessage),
+            senderIsOwner,
+          },
+        }
+      : {}),
+  } as unknown as PersistedUserTurnMessage;
 }
 
 export async function appendUserTurnTranscriptMessage(

--- a/src/sessions/user-turn-transcript.ts
+++ b/src/sessions/user-turn-transcript.ts
@@ -24,6 +24,13 @@ export type {
   UserTurnInput,
   UserTurnTranscriptRecorder,
 } from "./user-turn-transcript.types.js";
+export {
+  attachRuntimeUserTurnTranscriptContext,
+  attachRuntimeUserTurnTranscriptRecorder,
+  takeRuntimeUserTurnTranscriptContext,
+  takeRuntimeUserTurnTranscriptRecorder,
+  type RuntimeUserTurnTranscriptContext,
+} from "./user-turn-transcript-runtime-context.js";
 
 type PersistedUserTurnMediaFields = {
   MediaPath?: string;
@@ -249,69 +256,6 @@ function readOpenClawMessageMeta(message: AgentMessage): Record<string, unknown>
   return meta && typeof meta === "object" && !Array.isArray(meta)
     ? (meta as Record<string, unknown>)
     : undefined;
-}
-
-const RUNTIME_USER_TURN_TRANSCRIPT_CONTEXT = Symbol.for(
-  "openclaw.runtimeUserTurnTranscriptContext",
-);
-const RUNTIME_USER_TURN_TRANSCRIPT_RECORDER = Symbol.for(
-  "openclaw.runtimeUserTurnTranscriptRecorder",
-);
-
-type RuntimeUserTurnTranscriptContext = {
-  message: PersistedUserTurnMessage;
-  recorder: UserTurnTranscriptRecorder;
-};
-
-/** Carries transcript-only fields with a queued runtime message without exposing them to the model. */
-export function attachRuntimeUserTurnTranscriptContext(
-  runtimeMessage: PersistedUserTurnMessage,
-  context: RuntimeUserTurnTranscriptContext,
-): PersistedUserTurnMessage {
-  Object.defineProperty(runtimeMessage, RUNTIME_USER_TURN_TRANSCRIPT_CONTEXT, {
-    configurable: true,
-    value: context,
-  });
-  return runtimeMessage;
-}
-
-/** Consumes the transient queued-turn context before the message is serialized. */
-export function takeRuntimeUserTurnTranscriptContext(
-  runtimeMessage: AgentMessage,
-): RuntimeUserTurnTranscriptContext | undefined {
-  const record = runtimeMessage as unknown as Record<PropertyKey, unknown>;
-  const context = record[RUNTIME_USER_TURN_TRANSCRIPT_CONTEXT] as
-    | RuntimeUserTurnTranscriptContext
-    | undefined;
-  if (context) {
-    delete record[RUNTIME_USER_TURN_TRANSCRIPT_CONTEXT];
-  }
-  return context;
-}
-
-/** Keeps the queued recorder attached to the exact final message until persistence succeeds. */
-export function attachRuntimeUserTurnTranscriptRecorder(
-  runtimeMessage: AgentMessage,
-  recorder: UserTurnTranscriptRecorder,
-): AgentMessage {
-  Object.defineProperty(runtimeMessage, RUNTIME_USER_TURN_TRANSCRIPT_RECORDER, {
-    configurable: true,
-    value: recorder,
-  });
-  return runtimeMessage;
-}
-
-export function takeRuntimeUserTurnTranscriptRecorder(
-  runtimeMessage: AgentMessage,
-): UserTurnTranscriptRecorder | undefined {
-  const record = runtimeMessage as unknown as Record<PropertyKey, unknown>;
-  const recorder = record[RUNTIME_USER_TURN_TRANSCRIPT_RECORDER] as
-    | UserTurnTranscriptRecorder
-    | undefined;
-  if (recorder) {
-    delete record[RUNTIME_USER_TURN_TRANSCRIPT_RECORDER];
-  }
-  return recorder;
 }
 
 function buildPersistedUserTurnMessage(params: UserTurnInput): PersistedUserTurnMessage {

--- a/src/sessions/user-turn-transcript.ts
+++ b/src/sessions/user-turn-transcript.ts
@@ -228,6 +228,30 @@ function buildPersistedUserTurnMediaFields(
   };
 }
 
+function buildUserTurnSenderMeta(params: UserTurnInput): Record<string, unknown> | undefined {
+  const senderId = normalizeOptionalText(params.senderId);
+  const senderName = normalizeOptionalText(params.senderName);
+  const senderUsername = normalizeOptionalText(params.senderUsername);
+  const senderE164 = normalizeOptionalText(params.senderE164);
+  if (!senderId && !senderName && !senderUsername && !senderE164) {
+    return undefined;
+  }
+  const meta: Record<string, unknown> = {};
+  if (senderId) {
+    meta.senderId = senderId;
+  }
+  if (senderName) {
+    meta.senderName = senderName;
+  }
+  if (senderUsername) {
+    meta.senderUsername = senderUsername;
+  }
+  if (senderE164) {
+    meta.senderE164 = senderE164;
+  }
+  return meta;
+}
+
 function buildPersistedUserTurnMessage(params: UserTurnInput): PersistedUserTurnMessage {
   const mediaFields = buildPersistedUserTurnMediaFields(params.media);
   const hasMedia = Boolean(mediaFields.MediaPath);
@@ -239,7 +263,7 @@ function buildPersistedUserTurnMessage(params: UserTurnInput): PersistedUserTurn
   // here would NOT match the bare-current arrival (the gateway no longer stamps
   // the live turn) — see https://github.com/openclaw/openclaw/issues/3658.
   const content = text || (hasMedia ? (params.mediaOnlyText ?? "") : "");
-
+  const senderMeta = buildUserTurnSenderMeta(params);
   const message = {
     role: "user",
     content,
@@ -249,6 +273,7 @@ function buildPersistedUserTurnMessage(params: UserTurnInput): PersistedUserTurn
       ? {}
       : { __openclaw: { senderIsOwner: params.senderIsOwner } }),
     ...mediaFields,
+    ...(senderMeta ? { __openclaw: senderMeta } : {}),
   } as PersistedUserTurnMessage;
   return applyInputProvenanceToUserMessage(message, params.provenance) as PersistedUserTurnMessage;
 }

--- a/src/sessions/user-turn-transcript.ts
+++ b/src/sessions/user-turn-transcript.ts
@@ -340,6 +340,24 @@ export function mergePreparedUserTurnMessageForRuntime(params: {
   } as unknown as AgentMessage;
 }
 
+/** Restores runtime-owned OpenClaw metadata after a write hook replaces the user message. */
+export function mergePreparedUserTurnOpenClawMetaForRuntime(params: {
+  runtimeMessage: AgentMessage;
+  preparedMessage?: PersistedUserTurnMessage;
+}): AgentMessage {
+  if (!params.preparedMessage || !isUserMessage(params.runtimeMessage)) {
+    return params.runtimeMessage;
+  }
+  const preparedMeta = readOpenClawMessageMeta(params.preparedMessage);
+  if (!preparedMeta) {
+    return params.runtimeMessage;
+  }
+  return {
+    ...(params.runtimeMessage as unknown as Record<string, unknown>),
+    __openclaw: { ...readOpenClawMessageMeta(params.runtimeMessage), ...preparedMeta },
+  } as unknown as AgentMessage;
+}
+
 /** Applies before-message hooks while preserving user-turn transcript metadata. */
 export function preparePersistedUserTurnMessageForTranscriptWrite(
   message: PersistedUserTurnMessage,

--- a/src/sessions/user-turn-transcript.ts
+++ b/src/sessions/user-turn-transcript.ts
@@ -244,6 +244,13 @@ function buildUserTurnSenderMeta(
   };
 }
 
+function readOpenClawMessageMeta(message: AgentMessage): Record<string, unknown> | undefined {
+  const meta = (message as unknown as Record<string, unknown>)["__openclaw"];
+  return meta && typeof meta === "object" && !Array.isArray(meta)
+    ? (meta as Record<string, unknown>)
+    : undefined;
+}
+
 function buildPersistedUserTurnMessage(params: UserTurnInput): PersistedUserTurnMessage {
   const mediaFields = buildPersistedUserTurnMediaFields(params.media);
   const hasMedia = Boolean(mediaFields.MediaPath);
@@ -321,14 +328,8 @@ export function mergePreparedUserTurnMessageForRuntime(params: {
   }
   const runtimeMessage = params.runtimeMessage as unknown as Record<string, unknown>;
   const preparedMessage = params.preparedMessage as unknown as Record<string, unknown>;
-  const runtimeMeta =
-    runtimeMessage["__openclaw"] && typeof runtimeMessage["__openclaw"] === "object"
-      ? (runtimeMessage["__openclaw"] as Record<string, unknown>)
-      : undefined;
-  const preparedMeta =
-    preparedMessage["__openclaw"] && typeof preparedMessage["__openclaw"] === "object"
-      ? (preparedMessage["__openclaw"] as Record<string, unknown>)
-      : undefined;
+  const runtimeMeta = readOpenClawMessageMeta(params.runtimeMessage);
+  const preparedMeta = readOpenClawMessageMeta(params.preparedMessage);
   return {
     ...runtimeMessage,
     ...preparedMessage,
@@ -356,6 +357,7 @@ export function preparePersistedUserTurnMessageForTranscriptWrite(
   const provenance = normalizeInputProvenance(
     (message as unknown as { provenance?: unknown }).provenance,
   );
+  const originalMeta = readOpenClawMessageMeta(message);
   const nextMessage = params.beforeMessageWrite({
     message,
     ...(params.agentId ? { agentId: params.agentId } : {}),
@@ -367,26 +369,19 @@ export function preparePersistedUserTurnMessageForTranscriptWrite(
   const nextUserMessage = provenance
     ? (applyInputProvenanceToUserMessage(nextMessage, provenance) as PersistedUserTurnMessage)
     : nextMessage;
-  const originalOpenClaw = (message as unknown as { __openclaw?: unknown })["__openclaw"];
-  const senderIsOwner =
-    originalOpenClaw && typeof originalOpenClaw === "object"
-      ? (originalOpenClaw as { senderIsOwner?: unknown }).senderIsOwner
-      : undefined;
-  if (!idempotencyKey && typeof senderIsOwner !== "boolean") {
-    return nextUserMessage;
-  }
-  const nextRecord = nextUserMessage as unknown as Record<string, unknown>;
-  const nextOpenClaw =
-    nextRecord["__openclaw"] && typeof nextRecord["__openclaw"] === "object"
-      ? (nextRecord["__openclaw"] as Record<string, unknown>)
-      : {};
-  return {
-    ...nextRecord,
-    ...(idempotencyKey ? { idempotencyKey } : {}),
-    ...(typeof senderIsOwner === "boolean"
-      ? { __openclaw: { ...nextOpenClaw, senderIsOwner } }
-      : {}),
-  } as unknown as PersistedUserTurnMessage;
+  const nextMessageMeta = readOpenClawMessageMeta(nextUserMessage);
+  const nextUserMessageWithMetadata = originalMeta
+    ? ({
+        ...(nextUserMessage as unknown as Record<string, unknown>),
+        __openclaw: { ...nextMessageMeta, ...originalMeta },
+      } as unknown as PersistedUserTurnMessage)
+    : nextUserMessage;
+  return idempotencyKey
+    ? ({
+        ...(nextUserMessageWithMetadata as unknown as Record<string, unknown>),
+        idempotencyKey,
+      } as unknown as PersistedUserTurnMessage)
+    : nextUserMessageWithMetadata;
 }
 
 export async function appendUserTurnTranscriptMessage(

--- a/src/sessions/user-turn-transcript.ts
+++ b/src/sessions/user-turn-transcript.ts
@@ -232,8 +232,7 @@ function buildUserTurnSenderMeta(params: UserTurnInput): Record<string, unknown>
   const senderId = normalizeOptionalText(params.senderId);
   const senderName = normalizeOptionalText(params.senderName);
   const senderUsername = normalizeOptionalText(params.senderUsername);
-  const senderE164 = normalizeOptionalText(params.senderE164);
-  if (!senderId && !senderName && !senderUsername && !senderE164) {
+  if (!senderId && !senderName && !senderUsername) {
     return undefined;
   }
   const meta: Record<string, unknown> = {};
@@ -245,9 +244,6 @@ function buildUserTurnSenderMeta(params: UserTurnInput): Record<string, unknown>
   }
   if (senderUsername) {
     meta.senderUsername = senderUsername;
-  }
-  if (senderE164) {
-    meta.senderE164 = senderE164;
   }
   return meta;
 }

--- a/src/sessions/user-turn-transcript.ts
+++ b/src/sessions/user-turn-transcript.ts
@@ -251,6 +251,69 @@ function readOpenClawMessageMeta(message: AgentMessage): Record<string, unknown>
     : undefined;
 }
 
+const RUNTIME_USER_TURN_TRANSCRIPT_CONTEXT = Symbol.for(
+  "openclaw.runtimeUserTurnTranscriptContext",
+);
+const RUNTIME_USER_TURN_TRANSCRIPT_RECORDER = Symbol.for(
+  "openclaw.runtimeUserTurnTranscriptRecorder",
+);
+
+type RuntimeUserTurnTranscriptContext = {
+  message: PersistedUserTurnMessage;
+  recorder: UserTurnTranscriptRecorder;
+};
+
+/** Carries transcript-only fields with a queued runtime message without exposing them to the model. */
+export function attachRuntimeUserTurnTranscriptContext(
+  runtimeMessage: PersistedUserTurnMessage,
+  context: RuntimeUserTurnTranscriptContext,
+): PersistedUserTurnMessage {
+  Object.defineProperty(runtimeMessage, RUNTIME_USER_TURN_TRANSCRIPT_CONTEXT, {
+    configurable: true,
+    value: context,
+  });
+  return runtimeMessage;
+}
+
+/** Consumes the transient queued-turn context before the message is serialized. */
+export function takeRuntimeUserTurnTranscriptContext(
+  runtimeMessage: AgentMessage,
+): RuntimeUserTurnTranscriptContext | undefined {
+  const record = runtimeMessage as unknown as Record<PropertyKey, unknown>;
+  const context = record[RUNTIME_USER_TURN_TRANSCRIPT_CONTEXT] as
+    | RuntimeUserTurnTranscriptContext
+    | undefined;
+  if (context) {
+    delete record[RUNTIME_USER_TURN_TRANSCRIPT_CONTEXT];
+  }
+  return context;
+}
+
+/** Keeps the queued recorder attached to the exact final message until persistence succeeds. */
+export function attachRuntimeUserTurnTranscriptRecorder(
+  runtimeMessage: AgentMessage,
+  recorder: UserTurnTranscriptRecorder,
+): AgentMessage {
+  Object.defineProperty(runtimeMessage, RUNTIME_USER_TURN_TRANSCRIPT_RECORDER, {
+    configurable: true,
+    value: recorder,
+  });
+  return runtimeMessage;
+}
+
+export function takeRuntimeUserTurnTranscriptRecorder(
+  runtimeMessage: AgentMessage,
+): UserTurnTranscriptRecorder | undefined {
+  const record = runtimeMessage as unknown as Record<PropertyKey, unknown>;
+  const recorder = record[RUNTIME_USER_TURN_TRANSCRIPT_RECORDER] as
+    | UserTurnTranscriptRecorder
+    | undefined;
+  if (recorder) {
+    delete record[RUNTIME_USER_TURN_TRANSCRIPT_RECORDER];
+  }
+  return recorder;
+}
+
 function buildPersistedUserTurnMessage(params: UserTurnInput): PersistedUserTurnMessage {
   const mediaFields = buildPersistedUserTurnMediaFields(params.media);
   const hasMedia = Boolean(mediaFields.MediaPath);

--- a/src/sessions/user-turn-transcript.ts
+++ b/src/sessions/user-turn-transcript.ts
@@ -228,24 +228,20 @@ function buildPersistedUserTurnMediaFields(
   };
 }
 
-function buildUserTurnSenderMeta(params: UserTurnInput): Record<string, unknown> | undefined {
-  const senderId = normalizeOptionalText(params.senderId);
-  const senderName = normalizeOptionalText(params.senderName);
-  const senderUsername = normalizeOptionalText(params.senderUsername);
+function buildUserTurnSenderMeta(
+  sender: UserTurnInput["sender"],
+): Record<string, string> | undefined {
+  const senderId = normalizeOptionalText(sender?.id);
+  const senderName = normalizeOptionalText(sender?.name);
+  const senderUsername = normalizeOptionalText(sender?.username);
   if (!senderId && !senderName && !senderUsername) {
     return undefined;
   }
-  const meta: Record<string, unknown> = {};
-  if (senderId) {
-    meta.senderId = senderId;
-  }
-  if (senderName) {
-    meta.senderName = senderName;
-  }
-  if (senderUsername) {
-    meta.senderUsername = senderUsername;
-  }
-  return meta;
+  return {
+    ...(senderId ? { senderId } : {}),
+    ...(senderName ? { senderName } : {}),
+    ...(senderUsername ? { senderUsername } : {}),
+  };
 }
 
 function buildPersistedUserTurnMessage(params: UserTurnInput): PersistedUserTurnMessage {
@@ -259,17 +255,18 @@ function buildPersistedUserTurnMessage(params: UserTurnInput): PersistedUserTurn
   // here would NOT match the bare-current arrival (the gateway no longer stamps
   // the live turn) — see https://github.com/openclaw/openclaw/issues/3658.
   const content = text || (hasMedia ? (params.mediaOnlyText ?? "") : "");
-  const senderMeta = buildUserTurnSenderMeta(params);
+  const senderMeta = buildUserTurnSenderMeta(params.sender);
+  const openClawMeta = {
+    ...(params.senderIsOwner === undefined ? {} : { senderIsOwner: params.senderIsOwner }),
+    ...senderMeta,
+  };
   const message = {
     role: "user",
     content,
     timestamp: params.timestamp ?? Date.now(),
     ...(params.idempotencyKey ? { idempotencyKey: params.idempotencyKey } : {}),
-    ...(params.senderIsOwner === undefined
-      ? {}
-      : { __openclaw: { senderIsOwner: params.senderIsOwner } }),
     ...mediaFields,
-    ...(senderMeta ? { __openclaw: senderMeta } : {}),
+    ...(Object.keys(openClawMeta).length > 0 ? { __openclaw: openClawMeta } : {}),
   } as PersistedUserTurnMessage;
   return applyInputProvenanceToUserMessage(message, params.provenance) as PersistedUserTurnMessage;
 }
@@ -322,9 +319,20 @@ export function mergePreparedUserTurnMessageForRuntime(params: {
   ) {
     return params.runtimeMessage;
   }
+  const runtimeMessage = params.runtimeMessage as unknown as Record<string, unknown>;
+  const preparedMessage = params.preparedMessage as unknown as Record<string, unknown>;
+  const runtimeMeta =
+    runtimeMessage["__openclaw"] && typeof runtimeMessage["__openclaw"] === "object"
+      ? (runtimeMessage["__openclaw"] as Record<string, unknown>)
+      : undefined;
+  const preparedMeta =
+    preparedMessage["__openclaw"] && typeof preparedMessage["__openclaw"] === "object"
+      ? (preparedMessage["__openclaw"] as Record<string, unknown>)
+      : undefined;
   return {
-    ...(params.runtimeMessage as unknown as Record<string, unknown>),
-    ...(params.preparedMessage as unknown as Record<string, unknown>),
+    ...runtimeMessage,
+    ...preparedMessage,
+    ...(preparedMeta ? { __openclaw: { ...runtimeMeta, ...preparedMeta } } : {}),
     ...(userMessageHasImageContent(params.runtimeMessage)
       ? { content: params.runtimeMessage.content }
       : {}),

--- a/src/sessions/user-turn-transcript.types.ts
+++ b/src/sessions/user-turn-transcript.types.ts
@@ -18,6 +18,12 @@ export type PersistedUserTurnMediaInput = {
 
 export type PersistedUserTurnMessage = Extract<AgentMessage, { role: "user" }>;
 
+export type UserTurnSenderInput = {
+  id?: string | null;
+  name?: string | null;
+  username?: string | null;
+};
+
 export type UserTurnInput = {
   text?: string | null;
   media?: readonly PersistedUserTurnMediaInput[] | null;
@@ -26,9 +32,8 @@ export type UserTurnInput = {
   senderIsOwner?: boolean;
   provenance?: InputProvenance;
   mediaOnlyText?: string;
-  senderId?: string | null;
-  senderName?: string | null;
-  senderUsername?: string | null;
+  /** Durable participant attribution. Callers must opt in at the product boundary. */
+  sender?: UserTurnSenderInput | null;
 };
 
 export type UserTurnTranscriptUpdateMode = "inline" | "none";

--- a/src/sessions/user-turn-transcript.types.ts
+++ b/src/sessions/user-turn-transcript.types.ts
@@ -29,7 +29,6 @@ export type UserTurnInput = {
   senderId?: string | null;
   senderName?: string | null;
   senderUsername?: string | null;
-  senderE164?: string | null;
 };
 
 export type UserTurnTranscriptUpdateMode = "inline" | "none";

--- a/src/sessions/user-turn-transcript.types.ts
+++ b/src/sessions/user-turn-transcript.types.ts
@@ -26,6 +26,10 @@ export type UserTurnInput = {
   senderIsOwner?: boolean;
   provenance?: InputProvenance;
   mediaOnlyText?: string;
+  senderId?: string | null;
+  senderName?: string | null;
+  senderUsername?: string | null;
+  senderE164?: string | null;
 };
 
 export type UserTurnTranscriptUpdateMode = "inline" | "none";

--- a/src/sessions/user-turn-transcript.types.ts
+++ b/src/sessions/user-turn-transcript.types.ts
@@ -18,12 +18,6 @@ export type PersistedUserTurnMediaInput = {
 
 export type PersistedUserTurnMessage = Extract<AgentMessage, { role: "user" }>;
 
-export type UserTurnSenderInput = {
-  id?: string | null;
-  name?: string | null;
-  username?: string | null;
-};
-
 export type UserTurnInput = {
   text?: string | null;
   media?: readonly PersistedUserTurnMediaInput[] | null;
@@ -33,7 +27,7 @@ export type UserTurnInput = {
   provenance?: InputProvenance;
   mediaOnlyText?: string;
   /** Durable participant attribution. Callers must opt in at the product boundary. */
-  sender?: UserTurnSenderInput | null;
+  sender?: { id?: string | null; name?: string | null; username?: string | null } | null;
 };
 
 export type UserTurnTranscriptUpdateMode = "inline" | "none";


### PR DESCRIPTION
## What Problem This Solves

Telegram group and channel conversations can share one OpenClaw session, but their durable user-turn transcript rows did not retain which participant sent each message. That made later transcript reads lose participant attribution even though the inbound channel context had it.

Fixes #90531.

## Why This Change Was Made

- Resolve the effective reply route before preparing the durable user turn, then include sender identity only for group and channel routes.
- Persist `senderId`, `senderName`, and `senderUsername` in the existing `message.__openclaw` envelope; intentionally exclude phone-number identity.
- Carry the prepared transcript row through active-run steering queues and reply-run fallback paths without changing model-visible prompt content.
- Let write hooks redact sender identity while restoring only the trusted `senderIsOwner` authorization bit.
- Keep transcript redaction after metadata merging so configured sensitive-value redaction still applies.
- Leave direct-message transcript behavior unchanged.

## User Impact

Shared group/channel transcripts now retain participant attribution for every committed user turn, including turns queued behind an active run. Direct chats do not gain new persisted sender identity, and hook/redaction behavior remains intact.

## Evidence

- Immediate pre-rebase head `97cd10e0eef686cd09b2158cbe539e3d74c8ad13` passed a full build on isolated AWS Crabbox lease `cbx_4f878654a015`, run `run_0503a3f8d022`.
- The same run passed `pnpm check:changed` for `core` and `coreTests` with zero warnings and zero runtime import cycles.
- Focused Vitest proof: 4 shards, 292 tests passed across transcript writing, hooks, queued steering, reply fallback, session SDK, transcript rewriting, and E2E agent-runner coverage.
- Final exact head `4d8648ea9131dd6d86ead4e7d4da6eaf1e6ff94a` passed all 69 applicable hosted checks, including build, both whole-suite shards, and QA smoke ([run 28767468051](https://github.com/openclaw/openclaw/actions/runs/28767468051)).
- Before the final merge-policy-only rebase, 97 auto-reply tests and 14 guard/transcript-rewrite tests passed locally against the combined product tree at `ae72ccaee550a301baa8756f7763f9aad368802b`.
- The contributor's earlier live Telegram proof confirmed a group message round trip produced a JSONL row containing all three sender fields; the lease and credentials were released afterward.
- Fresh full-branch Codex autoreview returned no accepted/actionable findings.
