### PR TITLE
test(whatsapp): cover media metadata hook payloads

### DIFF
--- a/extensions/whatsapp/src/auto-reply/monitor/process-message.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/process-message.test.ts
@@ -444,6 +444,85 @@ describe("processMessage group system prompt wiring", () => {
     });
   });
 
+  it("fires message_received hooks with media metadata fields", async () => {
+    const internalReceived = vi.fn();
+    registerInternalHook("message:received", internalReceived);
+    resolvePolicyMock.mockReturnValue(makePolicy(makeAccount()));
+    buildContextMock.mockImplementationOnce(() => ({
+      Body: "check out this image",
+      BodyForCommands: "check out this image",
+      RawBody: "check out this image",
+      CommandBody: "check out this image",
+      From: GROUP_JID,
+      To: "+15550001111",
+      SessionKey: baseRoute.sessionKey,
+      AccountId: "default",
+      MessageSid: "msg-media-1",
+      SenderId: "+15550002222",
+      SenderName: "Alice",
+      SenderE164: "+15550002222",
+      Timestamp: 1710000001,
+      Provider: "whatsapp",
+      Surface: "whatsapp",
+      OriginatingChannel: "whatsapp",
+      OriginatingTo: GROUP_JID,
+      GroupSubject: "Test Group",
+      MediaPath: "/tmp/wa-media/abc123.jpg",
+      MediaType: "image/jpeg",
+      MediaUrl: "https://example.com/media/abc123.jpg",
+      MediaPaths: ["/tmp/wa-media/abc123.jpg"],
+      MediaTypes: ["image/jpeg"],
+      MediaUrls: ["https://example.com/media/abc123.jpg"],
+    }));
+
+    await callProcessMessage({
+      cfg: {
+        channels: {
+          whatsapp: {
+            pluginHooks: {
+              messageReceived: true,
+            },
+          },
+        },
+      },
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(runMessageReceivedMock).toHaveBeenCalledTimes(1);
+
+    // First arg is the PluginHookMessageReceivedEvent — check metadata media fields
+    const pluginEvent = mockCallArg(runMessageReceivedMock, "runMessageReceived", 0, 0) as Record<
+      string,
+      unknown
+    >;
+    expect(pluginEvent.metadata).toMatchObject({
+      mediaPath: "/tmp/wa-media/abc123.jpg",
+      mediaType: "image/jpeg",
+      mediaUrl: "https://example.com/media/abc123.jpg",
+      mediaPaths: ["/tmp/wa-media/abc123.jpg"],
+      mediaTypes: ["image/jpeg"],
+      mediaUrls: ["https://example.com/media/abc123.jpg"],
+    });
+
+    // Second arg is the internal message:received event — check media fields on context
+    expect(internalReceived).toHaveBeenCalledTimes(1);
+    const internalEvent = mockCallArg(internalReceived, "internal message received") as Record<
+      string,
+      unknown
+    >;
+    const context = internalEvent.context as Record<string, unknown>;
+    const metadata = context.metadata as Record<string, unknown>;
+    expect(metadata).toMatchObject({
+      mediaPath: "/tmp/wa-media/abc123.jpg",
+      mediaType: "image/jpeg",
+      mediaUrl: "https://example.com/media/abc123.jpg",
+      mediaPaths: ["/tmp/wa-media/abc123.jpg"],
+      mediaTypes: ["image/jpeg"],
+      mediaUrls: ["https://example.com/media/abc123.jpg"],
+    });
+  });
+
   it("does not fire WhatsApp message_received hooks without explicit opt-in", async () => {
     const internalReceived = vi.fn();
     registerInternalHook("message:received", internalReceived);


### PR DESCRIPTION
## What changed

- Added focused regression coverage for WhatsApp `message_received` hook payloads when an inbound message context includes media fields.
- The test asserts that `MediaPath`, `MediaType`, `MediaUrl`, `MediaPaths`, `MediaTypes`, and `MediaUrls` are exposed through both the plugin hook event metadata and the internal `message:received` event context metadata.

## Real Behavior Proof

### Behavior

WhatsApp inbound processing should preserve media metadata on `message_received` hook payloads. The regression exercises an inbound context containing `MediaPath`, `MediaType`, `MediaUrl`, `MediaPaths`, `MediaTypes`, and `MediaUrls`, then observes both hook surfaces that OpenClaw exposes to plugins.

### Environment

```sh
cd /Users/allahyar/Documents/fastino-tasks/openclaw-tui-87229b
```

macOS arm64 local OpenClaw checkout, branch `fastino-87229-whatsapp-media-metadata-b`.

### Steps

```sh
pnpm test extensions/whatsapp/src/auto-reply/monitor/process-message.test.ts
```

```sh
pnpm exec oxlint extensions/whatsapp/src/auto-reply/monitor/process-message.test.ts --type-aware --tsconfig config/tsconfig/oxlint.json --report-unused-disable-directives-severity error
```

### Evidence

```text
Test Files  1 passed (1)
Tests  7 passed (7)
[test] passed 1 Vitest shard in 20.85s
```

```text
targeted oxlint exit code 0
```

### Observed Result

The added regression passes while asserting that all six WhatsApp media metadata fields are present in the plugin `messageReceived` event metadata and in the internal `message:received` event context metadata.

### Not Tested

No live WhatsApp account or external WhatsApp network delivery was exercised for this PR; the changed behavior is the local inbound hook payload path.

## Related issue

Related to #87229
