### PR TITLE
fix(discord): allow authorized one-to-one DM reads

### DIFF
--- a/extensions/discord/src/actions/runtime.messaging.shared.ts
+++ b/extensions/discord/src/actions/runtime.messaging.shared.ts
@@ -1,6 +1,13 @@
 // Discord plugin module implements runtime.messaging.shared behavior.
+import { ChannelType } from "discord-api-types/v10";
+import { isDangerousNameMatchingEnabled } from "openclaw/plugin-sdk/dangerous-name-runtime";
 import { resolveOpenProviderRuntimeGroupPolicy } from "openclaw/plugin-sdk/runtime-group-policy";
-import { mergeDiscordAccountConfig, resolveDefaultDiscordAccountId } from "../accounts.js";
+import {
+  mergeDiscordAccountConfig,
+  resolveDefaultDiscordAccountId,
+  resolveDiscordAccountAllowFrom,
+  resolveDiscordAccountDmPolicy,
+} from "../accounts.js";
 import { createDiscordRuntimeAccountContext } from "../client.js";
 import {
   isDiscordGroupAllowedByPolicy,
@@ -8,10 +15,12 @@ import {
   resolveDiscordChannelConfigWithFallback,
   type DiscordGuildEntryResolved,
 } from "../monitor/allow-list.js";
+import { resolveDiscordDmCommandAccess } from "../monitor/dm-command-auth.js";
 import {
   type ActionGate,
   readStringParam,
   type DiscordActionConfig,
+  type DiscordAccountConfig,
   type OpenClawConfig,
   withNormalizedTimestamp,
 } from "../runtime-api.js";
@@ -100,6 +109,8 @@ function resolveDiscordActionGuildEntry(params: {
 
 type DiscordReadTargetContext = {
   channelId: string;
+  channelType?: number;
+  dmRecipientId?: string;
   guildId?: string;
   channelName?: string;
   channelSlug: string;
@@ -131,9 +142,24 @@ function readDiscordChannelType(value: unknown): number | undefined {
   return typeof type === "number" ? type : undefined;
 }
 
+function readDiscordSingleDmRecipientId(value: unknown): string | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  const recipients = (value as Record<string, unknown>).recipients;
+  if (!Array.isArray(recipients) || recipients.length !== 1) {
+    return undefined;
+  }
+  return readDiscordChannelStringField(recipients[0], "id");
+}
+
 function isDiscordThreadChannel(value: unknown): boolean {
   const type = readDiscordChannelType(value);
   return type === 10 || type === 11 || type === 12;
+}
+
+function isDiscordDmChannelType(channelType: number | undefined): boolean {
+  return channelType === ChannelType.DM || channelType === ChannelType.GroupDM;
 }
 
 function isDiscordReadTargetAllowedInGuild(params: {
@@ -179,6 +205,46 @@ function isDiscordReadTargetExplicitlyAllowedById(params: {
   });
 }
 
+async function isDiscordOneToOneDmReadTargetAllowed(params: {
+  accountId: string;
+  cfg: OpenClawConfig;
+  discordConfig: DiscordAccountConfig;
+  dmEnabled: boolean;
+  target: DiscordReadTargetContext;
+}): Promise<boolean> {
+  if (params.target.guildId || params.target.channelType !== ChannelType.DM) {
+    return false;
+  }
+  const recipientId = params.target.dmRecipientId;
+  if (!recipientId) {
+    return false;
+  }
+  const dmPolicy =
+    resolveDiscordAccountDmPolicy({
+      cfg: params.cfg,
+      accountId: params.accountId,
+    }) ?? "pairing";
+  if (!params.dmEnabled || dmPolicy === "disabled") {
+    return false;
+  }
+  const access = await resolveDiscordDmCommandAccess({
+    accountId: params.accountId,
+    dmPolicy,
+    configuredAllowFrom:
+      resolveDiscordAccountAllowFrom({
+        cfg: params.cfg,
+        accountId: params.accountId,
+      }) ?? [],
+    sender: {
+      id: recipientId,
+    },
+    allowNameMatching: isDangerousNameMatchingEnabled(params.discordConfig),
+    cfg: params.cfg,
+    eventKind: "message",
+  });
+  return access.senderAccess.decision === "allow";
+}
+
 export function createDiscordMessagingActionContext(params: {
   action: string;
   input: Record<string, unknown>;
@@ -201,6 +267,7 @@ export function createDiscordMessagingActionContext(params: {
   });
   const withOpts = (extra?: Record<string, unknown>) =>
     createDiscordActionOptions({ cfg: params.cfg, accountId, extra });
+  const resolvedActionAccountId = accountId ?? resolveDefaultDiscordAccountId(params.cfg);
   const resolvedReactionAccountId = accountId ?? resolveDefaultDiscordAccountId(params.cfg);
   const reactionRuntimeOptions = resolvedReactionAccountId
     ? createDiscordRuntimeAccountContext({
@@ -268,6 +335,14 @@ export function createDiscordMessagingActionContext(params: {
       channelId,
       channelSlug: channelName ? normalizeDiscordSlug(channelName) : fallback.channelSlug,
     };
+    const channelType = readDiscordChannelType(channelInfo);
+    if (channelType !== undefined) {
+      target.channelType = channelType;
+    }
+    const dmRecipientId = readDiscordSingleDmRecipientId(channelInfo);
+    if (dmRecipientId) {
+      target.dmRecipientId = dmRecipientId;
+    }
     const targetGuildId = readDiscordChannelStringField(channelInfo, "guild_id", "guildId");
     if (targetGuildId) {
       target.guildId = targetGuildId;
@@ -313,10 +388,24 @@ export function createDiscordMessagingActionContext(params: {
       ),
     assertReadTargetAllowed: async ({ guildId, channelId }) => {
       const targetChannelId = discordMessagingActionRuntime.resolveDiscordChannelId(channelId);
+      const target = await resolveReadTargetContext(targetChannelId);
+      if (isDiscordDmChannelType(target.channelType)) {
+        if (
+          await isDiscordOneToOneDmReadTargetAllowed({
+            accountId: resolvedActionAccountId,
+            cfg: params.cfg,
+            discordConfig: accountConfig,
+            dmEnabled: accountConfig.dm?.enabled ?? true,
+            target,
+          })
+        ) {
+          return;
+        }
+        throw new Error("Discord read target channel is not allowed.");
+      }
       if (!hasGuildEntries && groupPolicy !== "disabled" && groupPolicy !== "allowlist") {
         return;
       }
-      const target = await resolveReadTargetContext(targetChannelId);
       if (guildId) {
         if (target.guildId && target.guildId !== guildId) {
           throw new Error("Discord read target channel is not allowed.");

--- a/extensions/discord/src/actions/runtime.test.ts
+++ b/extensions/discord/src/actions/runtime.test.ts
@@ -22,10 +22,11 @@ const originalDiscordModerationActionRuntime = { ...discordModerationActionRunti
 
 type DiscordChannelInfoTest = {
   id: string;
-  type: number;
+  type?: number;
   guild_id?: string;
   name?: string;
   parent_id?: string;
+  recipients?: Array<{ id?: string }>;
 };
 
 const discordSendMocks = {
@@ -125,6 +126,25 @@ const DISCORD_TEST_CFG = {
     },
   },
 } as OpenClawConfig;
+
+function createDiscordDmReadAllowlistConfig(allowFrom: string[]): OpenClawConfig {
+  return {
+    channels: {
+      discord: {
+        token: "token",
+        groupPolicy: "allowlist",
+        allowFrom,
+        guilds: {
+          "111": {
+            channels: {
+              "222": { enabled: true },
+            },
+          },
+        },
+      },
+    },
+  } as OpenClawConfig;
+}
 
 type MockCallSource = { mock: { calls: Array<Array<unknown>> } };
 
@@ -557,6 +577,285 @@ describe("handleDiscordMessagingAction", () => {
     );
   });
 
+  it.each([
+    { name: "raw id", allowFrom: "123456789012345678" },
+    { name: "user prefix", allowFrom: "user:123456789012345678" },
+    { name: "mention", allowFrom: "<@123456789012345678>" },
+    { name: "nickname mention", allowFrom: "<@!123456789012345678>" },
+  ])("reads one-to-one DMs when the recipient is allowlisted by $name", async ({ allowFrom }) => {
+    fetchChannelInfoDiscord.mockResolvedValueOnce({
+      id: "333",
+      type: ChannelType.DM,
+      recipients: [{ id: "123456789012345678" }],
+    });
+    const cfg = createDiscordDmReadAllowlistConfig([allowFrom]);
+
+    await handleMessagingAction("readMessages", { channelId: "333" }, enableAllActions, cfg);
+
+    expect(readMessagesDiscord).toHaveBeenCalledWith(
+      "333",
+      { limit: undefined, before: undefined, after: undefined, around: undefined },
+      { cfg },
+    );
+  });
+
+  it("uses account-scoped allowFrom when authorizing one-to-one DM reads", async () => {
+    fetchChannelInfoDiscord.mockResolvedValueOnce({
+      id: "333",
+      type: ChannelType.DM,
+      recipients: [{ id: "123456789012345678" }],
+    });
+    const cfg = {
+      channels: {
+        discord: {
+          token: "token",
+          groupPolicy: "allowlist",
+          allowFrom: ["987654321098765432"],
+          guilds: {
+            "111": {
+              channels: {
+                "222": { enabled: true },
+              },
+            },
+          },
+          accounts: {
+            work: {
+              token: "token-work",
+              allowFrom: ["123456789012345678"],
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    await handleMessagingAction(
+      "readMessages",
+      { channelId: "333", accountId: "work" },
+      enableAllActions,
+      cfg,
+    );
+
+    expect(readMessagesDiscord).toHaveBeenCalledWith(
+      "333",
+      { limit: undefined, before: undefined, after: undefined, around: undefined },
+      { cfg, accountId: "work" },
+    );
+  });
+
+  it("reads one-to-one DMs when dmPolicy open uses a wildcard allowlist", async () => {
+    fetchChannelInfoDiscord.mockResolvedValueOnce({
+      id: "333",
+      type: ChannelType.DM,
+      recipients: [{ id: "123456789012345678" }],
+    });
+    const cfg = createDiscordDmReadAllowlistConfig(["*"]);
+    cfg.channels!.discord!.dmPolicy = "open";
+
+    await handleMessagingAction("readMessages", { channelId: "333" }, enableAllActions, cfg);
+
+    expect(readMessagesDiscord).toHaveBeenCalledWith(
+      "333",
+      { limit: undefined, before: undefined, after: undefined, around: undefined },
+      { cfg },
+    );
+  });
+
+  it("reads one-to-one DMs authorized by a message-sender access group", async () => {
+    fetchChannelInfoDiscord.mockResolvedValueOnce({
+      id: "333",
+      type: ChannelType.DM,
+      recipients: [{ id: "123456789012345678" }],
+    });
+    const cfg = createDiscordDmReadAllowlistConfig(["accessGroup:owners"]);
+    cfg.channels!.discord!.dmPolicy = "allowlist";
+    cfg.accessGroups = {
+      owners: {
+        type: "message.senders",
+        members: {
+          discord: ["discord:123456789012345678"],
+        },
+      },
+    };
+
+    await handleMessagingAction("readMessages", { channelId: "333" }, enableAllActions, cfg);
+
+    expect(readMessagesDiscord).toHaveBeenCalledWith(
+      "333",
+      { limit: undefined, before: undefined, after: undefined, around: undefined },
+      { cfg },
+    );
+  });
+
+  it("checks one-to-one DM policy before open group-policy read shortcuts", async () => {
+    fetchChannelInfoDiscord.mockResolvedValueOnce({
+      id: "333",
+      type: ChannelType.DM,
+      recipients: [{ id: "123456789012345678" }],
+    });
+    const cfg = {
+      channels: {
+        discord: {
+          token: "token",
+          groupPolicy: "open",
+          dmPolicy: "allowlist",
+          allowFrom: ["123456789012345678"],
+        },
+      },
+    } as OpenClawConfig;
+
+    await handleMessagingAction("readMessages", { channelId: "333" }, enableAllActions, cfg);
+
+    expect(readMessagesDiscord).toHaveBeenCalledWith(
+      "333",
+      { limit: undefined, before: undefined, after: undefined, around: undefined },
+      { cfg },
+    );
+  });
+
+  it("rejects DMs disabled by policy before open group-policy read shortcuts", async () => {
+    fetchChannelInfoDiscord.mockResolvedValueOnce({
+      id: "333",
+      type: ChannelType.DM,
+      recipients: [{ id: "123456789012345678" }],
+    });
+    const cfg = {
+      channels: {
+        discord: {
+          token: "token",
+          groupPolicy: "open",
+          dmPolicy: "disabled",
+          allowFrom: ["123456789012345678"],
+        },
+      },
+    } as OpenClawConfig;
+
+    await expect(
+      handleMessagingAction("readMessages", { channelId: "333" }, enableAllActions, cfg),
+    ).rejects.toThrow("Discord read target channel is not allowed.");
+    expect(readMessagesDiscord).not.toHaveBeenCalled();
+  });
+
+  it("rejects known DM channel ids even when they are configured under guild channels", async () => {
+    fetchChannelInfoDiscord.mockResolvedValueOnce({
+      id: "333",
+      type: ChannelType.DM,
+      recipients: [{ id: "987654321098765432" }],
+    });
+    const cfg = {
+      channels: {
+        discord: {
+          token: "token",
+          groupPolicy: "allowlist",
+          allowFrom: ["123456789012345678"],
+          guilds: {
+            "111": {
+              channels: {
+                "333": { enabled: true },
+              },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    await expect(
+      handleMessagingAction("readMessages", { channelId: "333" }, enableAllActions, cfg),
+    ).rejects.toThrow("Discord read target channel is not allowed.");
+    expect(readMessagesDiscord).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      name: "non-allowlisted DM recipient",
+      channelInfo: {
+        id: "333",
+        type: ChannelType.DM,
+        recipients: [{ id: "987654321098765432" }],
+      },
+      allowFrom: ["123456789012345678"],
+    },
+    {
+      name: "DM channel id allowlisting",
+      channelInfo: {
+        id: "333",
+        type: ChannelType.DM,
+        recipients: [{ id: "987654321098765432" }],
+      },
+      allowFrom: ["333"],
+    },
+    {
+      name: "group DM metadata",
+      channelInfo: {
+        id: "333",
+        type: ChannelType.GroupDM,
+        recipients: [{ id: "123456789012345678" }],
+      },
+      allowFrom: ["123456789012345678"],
+    },
+    {
+      name: "one-to-one DM metadata with multiple recipients",
+      channelInfo: {
+        id: "333",
+        type: ChannelType.DM,
+        recipients: [{ id: "123456789012345678" }, { id: "222222222222222222" }],
+      },
+      allowFrom: ["123456789012345678"],
+    },
+    {
+      name: "one-to-one DM metadata with missing recipients",
+      channelInfo: {
+        id: "333",
+        type: ChannelType.DM,
+      },
+      allowFrom: ["123456789012345678"],
+    },
+    {
+      name: "DM-like metadata with missing channel type",
+      channelInfo: {
+        id: "333",
+        recipients: [{ id: "123456789012345678" }],
+      },
+      allowFrom: ["123456789012345678"],
+    },
+    {
+      name: "DM target when dmPolicy is disabled",
+      channelInfo: {
+        id: "333",
+        type: ChannelType.DM,
+        recipients: [{ id: "123456789012345678" }],
+      },
+      allowFrom: ["123456789012345678"],
+      dmPolicy: "disabled",
+    },
+    {
+      name: "DM target when DMs are disabled",
+      channelInfo: {
+        id: "333",
+        type: ChannelType.DM,
+        recipients: [{ id: "123456789012345678" }],
+      },
+      allowFrom: ["123456789012345678"],
+      dmEnabled: false,
+    },
+  ])(
+    "rejects $name for Discord message reads",
+    async ({ channelInfo, allowFrom, dmPolicy, dmEnabled }) => {
+      fetchChannelInfoDiscord.mockResolvedValueOnce(channelInfo);
+      const cfg = createDiscordDmReadAllowlistConfig(allowFrom);
+      if (dmPolicy === "disabled") {
+        cfg.channels!.discord!.dmPolicy = dmPolicy;
+      }
+      if (dmEnabled === false) {
+        cfg.channels!.discord!.dm = { enabled: false };
+      }
+
+      await expect(
+        handleMessagingAction("readMessages", { channelId: "333" }, enableAllActions, cfg),
+      ).rejects.toThrow("Discord read target channel is not allowed.");
+      expect(readMessagesDiscord).not.toHaveBeenCalled();
+    },
+  );
+
   it("reads from Discord target channels allowlisted under a guild slug", async () => {
     fetchChannelInfoDiscord.mockResolvedValueOnce({
       id: "222",
@@ -668,6 +967,24 @@ describe("handleDiscordMessagingAction", () => {
       cfg,
     );
     expect(fetchMessageDiscord).toHaveBeenCalledWith("C1", "M1", { cfg });
+  });
+
+  it("fetches one-to-one DM messages when the recipient is allowlisted", async () => {
+    fetchChannelInfoDiscord.mockResolvedValueOnce({
+      id: "333",
+      type: ChannelType.DM,
+      recipients: [{ id: "123456789012345678" }],
+    });
+    const cfg = createDiscordDmReadAllowlistConfig(["123456789012345678"]);
+
+    await handleMessagingAction(
+      "fetchMessage",
+      { guildId: "111", channelId: "333", messageId: "444" },
+      enableAllActions,
+      cfg,
+    );
+
+    expect(fetchMessageDiscord).toHaveBeenCalledWith("333", "444", { cfg });
   });
 
   it("fetches Discord messages from channels allowlisted under a guild slug", async () => {


### PR DESCRIPTION
## Summary

- Allow Discord read-guarded actions, including `readMessages` and `fetchMessage`, to read a freshly fetched one-to-one DM only when its single recipient is authorized by the selected account's DM policy and allowlist.
- Keep Discord DM reads fail-closed for disabled DMs, `dmPolicy: "disabled"`, group DM metadata, malformed/missing recipient metadata, and DM channel ids configured as guild channels.
- Preserve existing guild/channel/thread allowlist behavior for non-DM read targets.

Fixes #90499.
Supersedes #90549, which was auto-closed by the active-PR queue policy and could not be reopened after the branch was force-pushed.

## Verification

- `node scripts/run-vitest.mjs extensions/discord/src/actions/runtime.test.ts`
  - 110 passed
- `node scripts/run-vitest.mjs extensions/discord/src/targets.test.ts extensions/discord/src/outbound-adapter.test.ts extensions/discord/src/monitor/dm-command-auth.test.ts`
  - 67 passed
- `node_modules\.bin\oxfmt.cmd --check extensions\discord\src\actions\runtime.messaging.shared.ts extensions\discord\src\actions\runtime.test.ts`
- `node scripts/run-oxlint.mjs extensions/discord/src/actions/runtime.messaging.shared.ts extensions/discord/src/actions/runtime.test.ts`
- `node scripts/run-tsgo.mjs -p extensions/discord/tsconfig.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/discord.tsbuildinfo`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo`
- `git diff --check origin/main...HEAD`
- `python .agents\skills\autoreview\scripts\autoreview --mode branch --base origin/main`
  - clean, no accepted/actionable findings

## Dependency contract checked

- `extensions/discord/package.json` pins `discord-api-types` to `0.38.48`.
- `node_modules/discord-api-types/payloads/v10/channel.d.ts` defines `APIDMChannelBase` with optional `recipients?: APIUser[]`, `APIDMChannel extends APIDMChannelBase<ChannelType.DM>`, `ChannelType.DM = 1`, and `ChannelType.GroupDM = 3`.

## Real behavior proof

Behavior addressed: Discord one-to-one DM read targets now authorize through freshly fetched channel metadata and the existing Discord DM ingress policy instead of being rejected by `fetchMessage`'s guild placeholder or falling through to guild channel-id allowlists.

Real environment tested: Windows checkout, Node test wrapper, final rebased head `1aa60fa560` on `fix/90499-discord-dm-read` against `origin/main` at `e0018382eb`.

Exact steps or command run after this patch: The commands listed in `Verification` were run after the final rebase and before opening this replacement PR.

Evidence after fix: The regression suite covers raw id, `user:<id>`, `<@id>`, `<@!id>`, account-scoped allowFrom, `dmPolicy: "open"` with wildcard, message-sender access groups, `fetchMessage` with an allowlisted one-to-one DM recipient, disabled DM policy, disabled DMs, non-allowlisted recipients, group DMs, malformed DM metadata, DM channel-id allowlisting, and DM channel ids configured under guild channels.

Observed result after fix: Authorized one-to-one DM reads proceed to `readMessagesDiscord` or `fetchMessageDiscord`; unauthorized or malformed DM targets throw `Discord read target channel is not allowed.` before any message read call.

What was not tested: No live Discord bot credentials were used; the proof is source-level with mocked Discord channel metadata and focused Discord plugin tests.