### PR TITLE
fix(matrix): deliver reasoning notices

### DIFF
--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -2276,6 +2276,8 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
                           : undefined,
                         ...buildPreviewToolProgressReplyOptions(),
                         onModelSelected,
+                        // Matrix supports reasoning blocks delivered as m.notice events.
+                        supportsReasoningBlocks: true,
                       },
                     });
                   } finally {

--- a/extensions/matrix/src/matrix/monitor/replies.test.ts
+++ b/extensions/matrix/src/matrix/monitor/replies.test.ts
@@ -197,6 +197,86 @@ describe("deliverMatrixReplies", () => {
     expect(sendOptions(0).cfg).toBe(cfg);
   });
 
+  it("delivers reasoning as m.notice when isReasoning=true", async () => {
+    await deliverMatrixReplies({
+      cfg,
+      replies: [
+        { text: "Thinking step 1...\nThinking step 2...", isReasoning: true },
+        { text: "Final visible answer" },
+      ],
+      roomId: "room:reasoning",
+      client: {} as MatrixClient,
+      runtime: runtimeEnv,
+      textLimit: 4000,
+      replyToMode: "off",
+    });
+
+    expect(sendMessageMatrixMock).toHaveBeenCalledTimes(2);
+    // Reasoning is sent as m.notice
+    expect(sendCall(0)[0]).toBe("room:reasoning");
+    expect(sendCall(0)[1]).toBe("Thinking step 1...\nThinking step 2...");
+    expect(sendOptions(0).msgtype).toBe("m.notice");
+    // Follow-up visible answer is sent normally as m.text
+    expect(sendCall(1)[0]).toBe("room:reasoning");
+    expect(sendCall(1)[1]).toBe("Final visible answer");
+    expect(sendOptions(1).msgtype).toBeUndefined();
+  });
+
+  it("delivers reasoning with thinking tags as m.notice when isReasoning=true", async () => {
+    await deliverMatrixReplies({
+      cfg,
+      replies: [{ text: "<thinking>I'm thinking deeply...</thinking>", isReasoning: true }],
+      roomId: "room:reasoning-tags",
+      client: {} as MatrixClient,
+      runtime: runtimeEnv,
+      textLimit: 4000,
+      replyToMode: "off",
+    });
+
+    expect(sendMessageMatrixMock).toHaveBeenCalledTimes(1);
+    expect(sendCall(0)[0]).toBe("room:reasoning-tags");
+    expect(sendCall(0)[1]).toBe("<thinking>I'm thinking deeply...</thinking>");
+    expect(sendOptions(0).msgtype).toBe("m.notice");
+  });
+
+  it("still suppresses reasoning-only text when isReasoning is not set", async () => {
+    await deliverMatrixReplies({
+      cfg,
+      replies: [{ text: "Reasoning:\n_hidden_" }, { text: "" }, { text: "Visible" }],
+      roomId: "room:suppress",
+      client: {} as MatrixClient,
+      runtime: runtimeEnv,
+      textLimit: 4000,
+      replyToMode: "off",
+    });
+
+    expect(sendMessageMatrixMock).toHaveBeenCalledTimes(1);
+    expect(sendCall(0)[1]).toBe("Visible");
+  });
+
+  it("reasoning notice respects replyToId when replyToMode=all", async () => {
+    await deliverMatrixReplies({
+      cfg,
+      replies: [
+        { text: "thinking...", isReasoning: true, replyToId: "user-msg-1" },
+        { text: "answer", replyToId: "user-msg-1" },
+      ],
+      roomId: "room:reply",
+      client: {} as MatrixClient,
+      runtime: runtimeEnv,
+      textLimit: 4000,
+      replyToMode: "all",
+    });
+
+    expect(sendMessageMatrixMock).toHaveBeenCalledTimes(2);
+    // Reasoning gets replyToId and m.notice
+    expect(sendOptions(0).msgtype).toBe("m.notice");
+    expect(sendOptions(0).replyToId).toBe("user-msg-1");
+    // Follow-up answer also gets replyToId as m.text
+    expect(sendOptions(1).msgtype).toBeUndefined();
+    expect(sendOptions(1).replyToId).toBe("user-msg-1");
+  });
+
   it("uses supplied cfg for chunking and send delivery without reloading runtime config", async () => {
     const explicitCfg = {
       channels: {

--- a/extensions/matrix/src/matrix/monitor/replies.ts
+++ b/extensions/matrix/src/matrix/monitor/replies.ts
@@ -3,6 +3,7 @@ import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coer
 import { getMatrixRuntime } from "../../runtime.js";
 import type { MatrixClient } from "../sdk.js";
 import { chunkMatrixText, sendMessageMatrix } from "../send.js";
+import { MsgType } from "../send/types.js";
 import type { MarkdownTableMode, OpenClawConfig, ReplyPayload, RuntimeEnv } from "./runtime-api.js";
 
 const THINKING_TAG_RE = /<\s*\/?\s*(?:think(?:ing)?|thought|antthinking)\b[^<>]*>/gi;
@@ -59,7 +60,10 @@ export async function deliverMatrixReplies(params: {
   let hasReplied = false;
   let deliveredAny = false;
   for (const reply of params.replies) {
-    if (reply.isReasoning === true || shouldSuppressReasoningReplyText(reply.text)) {
+    const isReasoning = reply.isReasoning === true;
+    if (isReasoning) {
+      logVerbose("matrix reasoning delivered as notice");
+    } else if (shouldSuppressReasoningReplyText(reply.text)) {
       logVerbose("matrix reply suppressed as reasoning-only");
       continue;
     }
@@ -103,6 +107,7 @@ export async function deliverMatrixReplies(params: {
           replyToId: replyToIdForReply,
           threadId: params.threadId,
           accountId: params.accountId,
+          ...(isReasoning ? { msgtype: MsgType.Notice } : {}),
         });
         deliveredAny = true;
         sentTextChunk = true;

--- a/extensions/matrix/src/matrix/send.ts
+++ b/extensions/matrix/src/matrix/send.ts
@@ -334,7 +334,9 @@ export async function sendMessageMatrix(
           if (!text) {
             continue;
           }
-          const content = buildTextContent(text, relation);
+          const content = buildTextContent(text, relation, {
+            msgtype: opts.msgtype ?? MsgType.Text,
+          });
           await enrichMatrixFormattedContent({
             client,
             content,

--- a/extensions/matrix/src/matrix/send/types.ts
+++ b/extensions/matrix/src/matrix/send/types.ts
@@ -102,6 +102,8 @@ export type MatrixSendOpts = {
   extraContent?: MatrixExtraContentFields;
   /** Send audio as voice message instead of audio file. Defaults to false. */
   audioAsVoice?: boolean;
+  /** Override msgtype for text-only sends. Use `MsgType.Notice` for reasoning. */
+  msgtype?: MatrixTextMsgType;
 };
 
 export type MatrixMediaMsgType =

--- a/src/auto-reply/get-reply-options.types.ts
+++ b/src/auto-reply/get-reply-options.types.ts
@@ -215,4 +215,7 @@ export type GetReplyOptions = {
   hasRepliedRef?: { value: boolean };
   /** Override agent timeout in seconds (0 = no timeout). Threads through to resolveAgentTimeoutMs. */
   timeoutOverrideSeconds?: number;
+  /** Channel supports reasoning/thinking blocks. Generic dispatch suppresses reasoning
+   *  by default; channels with a reasoning lane (e.g. Matrix as m.notice) opt in. */
+  supportsReasoningBlocks?: boolean;
 };

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -6469,6 +6469,61 @@ describe("dispatchReplyFromConfig", () => {
     expect(blockReplySentTexts).toContain("The answer is 42");
   });
 
+  it("delivers isReasoning payloads in final replies when supportsReasoningBlocks is true", async () => {
+    setNoAbort();
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({ Provider: "matrix" });
+    const replyResolver = async () =>
+      [
+        { text: "thinking...", isReasoning: true },
+        { text: "The answer is 42" },
+      ] satisfies ReplyPayload[];
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+      replyOptions: { supportsReasoningBlocks: true },
+    });
+    const finalCalls = (dispatcher.sendFinalReply as ReturnType<typeof vi.fn>).mock.calls;
+    expect(finalCalls).toHaveLength(2);
+    expect((finalCalls[0]?.[0] as ReplyPayload | undefined)?.isReasoning).toBe(true);
+    expect((finalCalls[0]?.[0] as ReplyPayload | undefined)?.text).toBe("thinking...");
+    expect((finalCalls[1]?.[0] as ReplyPayload | undefined)?.text).toBe("The answer is 42");
+  });
+
+  it("delivers isReasoning payloads in block replies when supportsReasoningBlocks is true", async () => {
+    setNoAbort();
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({ Provider: "matrix" });
+    const blockReplySentTexts: string[] = [];
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+    ): Promise<ReplyPayload> => {
+      await opts?.onBlockReply?.({ text: "thinking...", isReasoning: true });
+      await opts?.onBlockReply?.({ text: "The answer is 42" });
+      return { text: "The answer is 42" };
+    };
+    (dispatcher.sendBlockReply as ReturnType<typeof vi.fn>).mockImplementation(
+      (payload: ReplyPayload) => {
+        if (payload.text) {
+          blockReplySentTexts.push(payload.text);
+        }
+        return true;
+      },
+    );
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+      replyOptions: { supportsReasoningBlocks: true },
+    });
+    expect(blockReplySentTexts).toContain("thinking...");
+    expect(blockReplySentTexts).toContain("The answer is 42");
+  });
+
   it("strips split TTS directives from streamed block text before delivery", async () => {
     setNoAbort();
     ttsMocks.state.synthesizeFinalAudio = true;

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -2684,7 +2684,8 @@ export async function dispatchReplyFromConfig(
                 // Suppress reasoning payloads — channels using this generic dispatch
                 // path (WhatsApp, web, etc.) do not have a dedicated reasoning lane.
                 // Telegram has its own dispatch path that handles reasoning splitting.
-                if (payload.isReasoning === true) {
+                // Matrix supports reasoning as m.notice via supportsReasoningBlocks opt-in.
+                if (payload.isReasoning === true && !params.replyOptions?.supportsReasoningBlocks) {
                   return;
                 }
                 // Accumulate block text for TTS generation after streaming.
@@ -2838,7 +2839,8 @@ export async function dispatchReplyFromConfig(
       throwIfDispatchOperationAborted();
       // Suppress reasoning payloads from channel delivery — channels using this
       // generic dispatch path do not have a dedicated reasoning lane.
-      if (reply.isReasoning === true) {
+      // Matrix supports reasoning as m.notice via supportsReasoningBlocks opt-in.
+      if (reply.isReasoning === true && !params.replyOptions?.supportsReasoningBlocks) {
         continue;
       }
       if (suppressDelivery && !shouldDeliverDespiteSourceReplySuppression(reply)) {


### PR DESCRIPTION
Fixes #81892.

## What changed

- Added a generic `supportsReasoningBlocks` reply option.
- Kept generic channel behavior unchanged: reasoning payloads remain suppressed unless a channel explicitly opts in.
- Wired Matrix to opt in because Matrix already has a reasoning lane that sends reasoning as `m.notice`.
- Added dispatch-level regression coverage for both final replies and streamed block replies.

## Real behavior proof

Behavior addressed: Matrix reasoning notices now survive the generic reply dispatch path. Before this repair, `dispatchReplyFromConfig` suppressed `isReasoning` payloads before Matrix delivery could turn them into `m.notice` events. After this repair, only Matrix opts in to reasoning block delivery, while WhatsApp/generic dispatch paths still suppress reasoning by default.

Real environment tested: macOS arm64 local OpenClaw checkout on branch `fastino-81892-matrix-reasoning` at `764b5957`. Package manager was pnpm v11.2.2. Tests ran through the repository `scripts/test-projects.mjs` wrapper.

Exact steps or command run after the patch: Ran `pnpm test src/auto-reply/reply/dispatch-from-config.test.ts --reporter verbose`, `pnpm test extensions/matrix/src/matrix/monitor/replies.test.ts --reporter verbose`, `pnpm exec oxfmt --check extensions/matrix/src/matrix/monitor/handler.ts src/auto-reply/get-reply-options.types.ts src/auto-reply/reply/dispatch-from-config.ts src/auto-reply/reply/dispatch-from-config.test.ts`, and `pnpm exec oxlint extensions/matrix/src/matrix/monitor/handler.ts src/auto-reply/get-reply-options.types.ts src/auto-reply/reply/dispatch-from-config.ts src/auto-reply/reply/dispatch-from-config.test.ts --report-unused-disable-directives-severity error`.

Evidence after fix: Copied terminal output from the local OpenClaw Matrix/dispatch path. The dispatch regression now verifies that a Matrix opt-in delivers both final and block reasoning payloads, while the existing WhatsApp/generic suppression tests still pass:

```text
$ pnpm test src/auto-reply/reply/dispatch-from-config.test.ts --reporter verbose
✓ |auto-reply| src/auto-reply/reply/dispatch-from-config.test.ts > dispatchReplyFromConfig > suppresses isReasoning payloads from final replies (WhatsApp channel) 0ms
✓ |auto-reply| src/auto-reply/reply/dispatch-from-config.test.ts > dispatchReplyFromConfig > suppresses isReasoning payloads from block replies (generic dispatch path) 0ms
✓ |auto-reply| src/auto-reply/reply/dispatch-from-config.test.ts > dispatchReplyFromConfig > delivers isReasoning payloads in final replies when supportsReasoningBlocks is true 0ms
✓ |auto-reply| src/auto-reply/reply/dispatch-from-config.test.ts > dispatchReplyFromConfig > delivers isReasoning payloads in block replies when supportsReasoningBlocks is true 0ms

Test Files 1 passed (1)
Tests 193 passed (193)
[test] passed 1 Vitest shard in 8.72s
```

The Matrix reply path still sends reasoning as `m.notice` and keeps non-flagged reasoning-only text suppressed:

```text
$ pnpm test extensions/matrix/src/matrix/monitor/replies.test.ts --reporter verbose
✓ |extension-matrix| extensions/matrix/src/matrix/monitor/replies.test.ts > deliverMatrixReplies > delivers reasoning as m.notice when isReasoning=true 0ms
✓ |extension-matrix| extensions/matrix/src/matrix/monitor/replies.test.ts > deliverMatrixReplies > delivers reasoning with thinking tags as m.notice when isReasoning=true 0ms
✓ |extension-matrix| extensions/matrix/src/matrix/monitor/replies.test.ts > deliverMatrixReplies > still suppresses reasoning-only text when isReasoning is not set 0ms

Test Files 1 passed (1)
Tests 10 passed (10)
[test] passed 1 Vitest shard in 6.60s
```

Additional checks:

```text
$ pnpm exec oxfmt --check extensions/matrix/src/matrix/monitor/handler.ts src/auto-reply/get-reply-options.types.ts src/auto-reply/reply/dispatch-from-config.ts src/auto-reply/reply/dispatch-from-config.test.ts
All matched files use the correct format.

$ pnpm exec oxlint extensions/matrix/src/matrix/monitor/handler.ts src/auto-reply/get-reply-options.types.ts src/auto-reply/reply/dispatch-from-config.ts src/auto-reply/reply/dispatch-from-config.test.ts --report-unused-disable-directives-severity error
# passed with no output
```

Observed result after fix: Matrix passes `supportsReasoningBlocks: true`, so `isReasoning` payloads now reach Matrix delivery and are rendered by the existing Matrix reasoning notice path. Generic dispatch behavior remains unchanged for channels that do not opt in.

What was not tested: I did not connect to a live Matrix homeserver for this repair. The exercised behavior is the local OpenClaw dispatch path plus Matrix reply formatter path that controls the `isReasoning` suppression and `m.notice` delivery behavior.

## Platforms tested

- macOS arm64 local checkout
