### PR TITLE
fix(sessions): include sender metadata in group chat session JSONL (#90531)

### DIFF
--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -1202,6 +1202,12 @@ export async function runPreparedReply(
                 mediaOnlyText: "[User sent media without caption]",
               }
             : {}),
+          ...(sessionCtx.SenderId || sessionCtx.SenderName
+            ? {
+                senderId: normalizeOptionalString(sessionCtx.SenderId),
+                senderName: normalizeOptionalString(sessionCtx.SenderName),
+              }
+            : {}),
         }
       : undefined;
   const userTurnTranscriptRecorder =

--- a/src/sessions/user-turn-transcript.test.ts
+++ b/src/sessions/user-turn-transcript.test.ts
@@ -286,6 +286,93 @@ describe("user turn transcript persistence", () => {
       ]);
     });
 
+    it("attaches sender metadata to group chat user turns", async () => {
+      const dir = createTempDir("openclaw-user-turn-sender-meta-");
+      const transcriptPath = path.join(dir, "session.jsonl");
+
+      const appended = await appendUserTurnTranscriptMessage({
+        transcriptPath,
+        sessionId: "session-1",
+        sessionKey: "main",
+        cwd: dir,
+        input: {
+          text: "hello group",
+          timestamp: 123,
+          senderId: "user-42",
+          senderName: "Alice",
+        },
+        updateMode: "none",
+      });
+
+      expect(appended?.message).toMatchObject({
+        role: "user",
+        content: "hello group",
+        __openclaw: { senderId: "user-42", senderName: "Alice" },
+      });
+      expect(readTranscriptMessages(transcriptPath)).toEqual([
+        expect.objectContaining({
+          role: "user",
+          content: "hello group",
+          __openclaw: { senderId: "user-42", senderName: "Alice" },
+        }),
+      ]);
+    });
+
+    it("attaches sender metadata when only senderId is present", async () => {
+      const dir = createTempDir("openclaw-user-turn-sender-id-only-");
+      const transcriptPath = path.join(dir, "session.jsonl");
+
+      const appended = await appendUserTurnTranscriptMessage({
+        transcriptPath,
+        sessionId: "session-1",
+        sessionKey: "main",
+        cwd: dir,
+        input: {
+          text: "hello from anon",
+          senderId: "user-99",
+        },
+        updateMode: "none",
+      });
+
+      expect(appended?.message).toMatchObject({
+        role: "user",
+        content: "hello from anon",
+        __openclaw: { senderId: "user-99" },
+      });
+      expect(readTranscriptMessages(transcriptPath)).toEqual([
+        expect.objectContaining({
+          role: "user",
+          content: "hello from anon",
+          __openclaw: { senderId: "user-99" },
+        }),
+      ]);
+    });
+
+    it("does not attach __openclaw when no sender metadata is present", async () => {
+      const dir = createTempDir("openclaw-user-turn-no-sender-");
+      const transcriptPath = path.join(dir, "session.jsonl");
+
+      const appended = await appendUserTurnTranscriptMessage({
+        transcriptPath,
+        sessionId: "session-1",
+        sessionKey: "main",
+        cwd: dir,
+        input: {
+          text: "direct message",
+        },
+        updateMode: "none",
+      });
+
+      expect(appended?.message).toMatchObject({
+        role: "user",
+        content: "direct message",
+      });
+      expect(appended?.message).not.toHaveProperty("__openclaw");
+      const transcriptMessages = readTranscriptMessages(transcriptPath);
+      expect(transcriptMessages).toHaveLength(1);
+      expect(transcriptMessages[0]).not.toHaveProperty("__openclaw");
+    });
+
     it("returns the existing user turn when the idempotency key was already persisted", async () => {
       const dir = createTempDir("openclaw-user-turn-append-idempotent-");
       const transcriptPath = path.join(dir, "session.jsonl");

--- a/src/sessions/user-turn-transcript.ts
+++ b/src/sessions/user-turn-transcript.ts
@@ -44,6 +44,8 @@ export type UserTurnInput = {
   idempotencyKey?: string;
   provenance?: InputProvenance;
   mediaOnlyText?: string;
+  senderId?: string;
+  senderName?: string;
 };
 
 type UserTurnTranscriptUpdateMode = "inline" | "none";
@@ -298,12 +300,20 @@ function buildPersistedUserTurnMessage(params: UserTurnInput): PersistedUserTurn
   const hasMedia = Boolean(mediaFields.MediaPath);
   const text = normalizeTranscriptText(params.text);
   const content = text || (hasMedia ? (params.mediaOnlyText ?? "") : "");
+  const senderMeta: Record<string, unknown> | undefined =
+    params.senderId || params.senderName
+      ? {
+          ...(params.senderId ? { senderId: params.senderId } : {}),
+          ...(params.senderName ? { senderName: params.senderName } : {}),
+        }
+      : undefined;
   const message = {
     role: "user",
     content,
     timestamp: params.timestamp ?? Date.now(),
     ...(params.idempotencyKey ? { idempotencyKey: params.idempotencyKey } : {}),
     ...mediaFields,
+    ...(senderMeta ? { __openclaw: senderMeta } : {}),
   } as PersistedUserTurnMessage;
   return applyInputProvenanceToUserMessage(message, params.provenance) as PersistedUserTurnMessage;
 }


### PR DESCRIPTION
## Summary

Fixes #90531.

Group chat user messages were missing the \`__openclaw\` metadata block in session JSONL transcripts. Direct (1:1) sessions already included this block with sender identity, but group chat sessions only wrote \`{ role: \"user\", content: \"...\", timestamp: ... }\`.

The root cause: \`sessionCtx.SenderId\` and \`sessionCtx.SenderName\` were available in the reply run path, but were not being passed through to the user turn transcript recorder. \`buildPersistedUserTurnMessage\` therefore had no sender metadata to attach.

### Changes

- \`src/sessions/user-turn-transcript.ts\`: Extended \`UserTurnInput\` with optional \`senderId\` and \`senderName\` fields. \`buildPersistedUserTurnMessage\` now attaches \`__openclaw: { senderId?, senderName? }\` when present.
- \`src/auto-reply/reply/get-reply-run.ts\`: Extracts \`SenderId\`/\`SenderName\` from \`sessionCtx\` and forwards them into \`userTurnInput\`.
- \`src/sessions/user-turn-transcript.test.ts\`: Added tests for group chat sender metadata, senderId-only, and no-sender cases.

### Backward compatibility

No breaking changes. When sender metadata is absent (e.g. direct chat or CLI), no \`__openclaw\` block is added, preserving existing behavior.

## Verification

\`\`\`bash
# Core unit tests
node scripts/run-vitest.mjs src/sessions/user-turn-transcript.test.ts --run
# 28 passed

# Related reply-run tests
node scripts/run-vitest.mjs src/auto-reply/reply/get-reply-run.exec-hint.test.ts src/auto-reply/reply/reply-flow.test.ts src/auto-reply/reply/session-transcript-replay.test.ts src/auto-reply/reply/groups.test.ts --run
# 32 passed

# Lint
node scripts/run-oxlint.mjs src/sessions/user-turn-transcript.ts src/sessions/user-turn-transcript.test.ts src/auto-reply/reply/get-reply-run.ts
# exit 0
\`\`\`

## Real behavior proof

**Behavior addressed:** Group chat session JSONL should include \`__openclaw\` sender metadata (\`senderId\`, \`senderName\`), matching the existing direct-chat behavior.

**Real environment tested:** Local OpenClaw source checkout on branch \`fix/group-chat-session-sender-metadata-90531\`, Node.js 22.22.0, temporary isolated directory.

**Exact steps or command run after this patch:**

\`\`\`bash
node --import tsx -e '
import fs from \"node:fs\";
import path from \"node:path\";
import os from \"node:os\";
import assert from \"node:assert/strict\";
import { appendUserTurnTranscriptMessage } from \"./src/sessions/user-turn-transcript.ts\";

const dir = fs.mkdtempSync(path.join(os.tmpdir(), \"openclaw-real-proof-\"));
const transcriptPath = path.join(dir, \"session.jsonl\");

// Group chat turn with sender metadata (the reported case)
await appendUserTurnTranscriptMessage({
  transcriptPath,
  sessionId: \"group-session-1\",
  sessionKey: \"telegram-group-klubk\",
  cwd: dir,
  input: {
    text: \"Hey everyone, what do you think?\",
    timestamp: 1780628953073,
    senderId: \"8489979671\",
    senderName: \"Ram Shenoy\",
  },
  updateMode: \"none\",
});

// Direct chat turn without sender metadata (existing behavior must not change)
await appendUserTurnTranscriptMessage({
  transcriptPath,
  sessionId: \"group-session-1\",
  sessionKey: \"telegram-group-klubk\",
  cwd: dir,
  input: {
    text: \"Direct message example\",
    timestamp: 1780628954000,
  },
  updateMode: \"none\",
});

const lines = fs.readFileSync(transcriptPath, \"utf8\")
  .trim().split(\"\\n\").filter(l => l.trim());
const messages = lines
  .filter(l => JSON.parse(l).type === \"message\")
  .map(l => JSON.parse(l).message);

assert.equal(messages[0].role, \"user\");
assert.equal(messages[0].content, \"Hey everyone, what do you think?\");
assert.deepEqual(messages[0].__openclaw, { senderId: \"8489979671\", senderName: \"Ram Shenoy\" });

assert.equal(messages[1].role, \"user\");
assert.equal(messages[1].content, \"Direct message example\");
assert.equal(messages[1].__openclaw, undefined);

console.log(\"All assertions passed.\");
console.log(\"Group chat message __openclaw:\", JSON.stringify(messages[0].__openclaw));
console.log(\"Direct chat message __openclaw:\", messages[1].__openclaw);

fs.rmSync(dir, { recursive: true, force: true });
'
\`\`\`

**Evidence after fix:** Terminal output from the real source run after the patch:

\`\`\`text
All assertions passed.
Group chat message __openclaw: {\"senderId\":\"8489979671\",\"senderName\":\"Ram Shenoy\"}
Direct chat message __openclaw: undefined
\`\`\`

**Observed result after fix:**
- Group chat user messages now carry \`__openclaw: { senderId, senderName }\` in the persisted session JSONL.
- Direct chat user messages without sender metadata remain unchanged (no \`__openclaw\` block).

**What was not tested:** I did not test against a live Telegram gateway group chat; the proof exercises the real \`appendUserTurnTranscriptMessage\` source entrypoint that owns this persistence decision.