### PR TITLE
fix(agents): warn on cron announce skip

### DIFF
--- a/src/agents/subagent-announce.test.ts
+++ b/src/agents/subagent-announce.test.ts
@@ -363,6 +363,30 @@ describe("subagent announce seam flow", () => {
     logSpy.mockRestore();
   });
 
+  it("does not warn when fallback reply is delivered for a cron ANNOUNCE_SKIP", async () => {
+    const logSpy = vi.spyOn(defaultRuntime, "log").mockImplementation(() => {});
+
+    const didAnnounce = await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:cron-worker",
+      childRunId: "run-cron-announce-skip-fallback",
+      requesterSessionKey: "agent:main:cron:daily-report",
+      requesterDisplayKey: "cron:daily-report",
+      task: "cron job",
+      timeoutMs: 10,
+      cleanup: "keep",
+      waitForCompletion: false,
+      startedAt: 10,
+      endedAt: 20,
+      outcome: { status: "ok" },
+      roundOneReply: "ANNOUNCE_SKIP",
+      fallbackReply: "an actual fallback result",
+    });
+
+    expect(didAnnounce).toBe(true);
+    expect(logSpy).not.toHaveBeenCalled();
+    logSpy.mockRestore();
+  });
+
   it("keeps lifecycle hooks enabled when deleting a completed session-mode child session", async () => {
     const didAnnounce = await runSubagentAnnounceFlow({
       childSessionKey: "agent:main:subagent:test",

--- a/src/agents/subagent-announce.test.ts
+++ b/src/agents/subagent-announce.test.ts
@@ -337,6 +337,32 @@ describe("subagent announce seam flow", () => {
     });
   });
 
+  it("warns when ANNOUNCE_SKIP suppresses a cron job completion", async () => {
+    const logSpy = vi.spyOn(defaultRuntime, "log").mockImplementation(() => {});
+
+    const didAnnounce = await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:cron-worker",
+      childRunId: "run-cron-announce-skip",
+      requesterSessionKey: "agent:main:cron:daily-report",
+      requesterDisplayKey: "cron:daily-report",
+      task: "cron job",
+      timeoutMs: 10,
+      cleanup: "keep",
+      waitForCompletion: false,
+      startedAt: 10,
+      endedAt: 20,
+      outcome: { status: "ok" },
+      roundOneReply: "ANNOUNCE_SKIP",
+    });
+
+    expect(didAnnounce).toBe(true);
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining("cron job completion for session=agent:main:cron:daily-report"),
+    );
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("suppressed by ANNOUNCE_SKIP"));
+    logSpy.mockRestore();
+  });
+
   it("keeps lifecycle hooks enabled when deleting a completed session-mode child session", async () => {
     const didAnnounce = await runSubagentAnnounceFlow({
       childSessionKey: "agent:main:subagent:test",

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -435,20 +435,27 @@ export async function runSubagentAnnounceFlow(params: {
       }
 
       if (isAnnounceSkip(reply) || isSilentReplyText(reply, SILENT_REPLY_TOKEN)) {
-        if (isAnnounceSkip(reply) && isCronSessionKey(targetRequesterSessionKey)) {
-          logWarn(
-            `cron job completion for session=${targetRequesterSessionKey} ` +
-              `run=${params.childRunId} suppressed by ANNOUNCE_SKIP; ` +
-              `the agent replied with the skip sentinel instead of delivering a result`,
-          );
-        }
         if (fallbackReply && !fallbackIsSilent) {
           const cleaned = stripAndClassifyReply(fallbackReply);
           if (cleaned === null) {
+            if (isAnnounceSkip(reply) && isCronSessionKey(targetRequesterSessionKey)) {
+              logWarn(
+                `cron job completion for session=${targetRequesterSessionKey} ` +
+                  `run=${params.childRunId} suppressed by ANNOUNCE_SKIP; ` +
+                  `the agent replied with the skip sentinel instead of delivering a result`,
+              );
+            }
             return true;
           }
           reply = cleaned;
         } else {
+          if (isAnnounceSkip(reply) && isCronSessionKey(targetRequesterSessionKey)) {
+            logWarn(
+              `cron job completion for session=${targetRequesterSessionKey} ` +
+                `run=${params.childRunId} suppressed by ANNOUNCE_SKIP; ` +
+                `the agent replied with the skip sentinel instead of delivering a result`,
+            );
+          }
           return true;
         }
       } else if (reply) {

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -11,6 +11,7 @@ import {
   stripLeadingSilentToken,
   stripSilentToken,
 } from "../auto-reply/tokens.js";
+import { logWarn } from "../logger.js";
 import { defaultRuntime } from "../runtime.js";
 import { isCronSessionKey } from "../sessions/session-key-utils.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
@@ -434,6 +435,13 @@ export async function runSubagentAnnounceFlow(params: {
       }
 
       if (isAnnounceSkip(reply) || isSilentReplyText(reply, SILENT_REPLY_TOKEN)) {
+        if (isAnnounceSkip(reply) && isCronSessionKey(targetRequesterSessionKey)) {
+          logWarn(
+            `cron job completion for session=${targetRequesterSessionKey} ` +
+              `run=${params.childRunId} suppressed by ANNOUNCE_SKIP; ` +
+              `the agent replied with the skip sentinel instead of delivering a result`,
+          );
+        }
         if (fallbackReply && !fallbackIsSilent) {
           const cleaned = stripAndClassifyReply(fallbackReply);
           if (cleaned === null) {


### PR DESCRIPTION
## What changed

- Log a warning when a cron requester receives `ANNOUNCE_SKIP` from a completed subagent announce flow.
- Add regression coverage that proves the cron path no longer suppresses the completion silently.

Fixes #68561.

## Real behavior proof

- **Behavior or issue addressed:**

When a cron requester receives an `ANNOUNCE_SKIP` completion from a subagent announce flow, OpenClaw now records a warning instead of silently returning a successful announce result with no delivered completion.

- **Real environment tested:**

- Repository: `openclaw/openclaw`
- Branch: `fastino-68561-cron-announce-skip`
- Platform tested: macOS arm64
- Runtime path: local OpenClaw Node/pnpm workspace using repository test scripts

- **Exact steps or command run after this patch:**

1. Created a temporary base checkout at `origin/main`.
2. Applied only the new regression test to the base checkout.
3. Ran `node scripts/test-projects.mjs src/agents/subagent-announce.test.ts --reporter=verbose` and confirmed the old source produced no warning log call.
4. Ran the same focused test command on this branch.
5. Ran focused formatting and lint checks for the changed files.

- **Evidence after fix:**

Before behavior on base with only the regression test applied:

```text
$ git -C /Users/allahyar/Documents/fastino-tasks/openclaw-tui-68561 worktree add --detach /private/tmp/openclaw-base-68561-proof origin/main
$ git -C /private/tmp/openclaw-base-68561-proof apply /private/tmp/68561-test-only.patch
$ node scripts/test-projects.mjs src/agents/subagent-announce.test.ts --reporter=verbose

× |agents| src/agents/subagent-announce.test.ts > subagent announce seam flow > warns when ANNOUNCE_SKIP suppresses a cron job completion 4ms
  → expected "log" to be called with arguments: [ StringContaining{...} ]

Number of calls: 0

Test Files  1 failed (1)
Tests  1 failed | 10 passed (11)
```

After behavior on this branch:

```text
$ node scripts/test-projects.mjs src/agents/subagent-announce.test.ts --reporter=verbose

✓ |agents| src/agents/subagent-announce.test.ts > subagent announce seam flow > warns when ANNOUNCE_SKIP suppresses a cron job completion 3ms

Test Files  1 passed (1)
Tests  11 passed (11)
[test] passed 1 Vitest shard in 5.20s
```

Additional checks:

```text
$ pnpm exec oxfmt --check src/agents/subagent-announce.ts src/agents/subagent-announce.test.ts
All matched files use the correct format.

$ pnpm exec oxlint src/agents/subagent-announce.ts src/agents/subagent-announce.test.ts --report-unused-disable-directives-severity error
# passed with no output
```

- **Observed result after fix:**

The base checkout keeps the announce flow successful but produces zero warning logs for the cron `ANNOUNCE_SKIP` path. This branch emits the warning and keeps the existing announce behavior intact; the focused shard passes 11/11.

- **What was not tested:**

No external channel service was needed for this path. The proof uses the existing subagent announce runtime test seam that exercises the cron requester session key and `ANNOUNCE_SKIP` branch directly.


## Additional real behavior proof - production announce flow

Setup:

- Repository: OpenClaw checkout.
- Before checkout: `/Users/allahyar/Documents/fastino-tasks/openclaw`.
- After checkout: `/Users/allahyar/Documents/fastino-tasks/openclaw-tui-68561`.
- Proof script: `/private/tmp/openclaw-90566-proof.ts`, which imports the real `src/agents/subagent-announce.ts` production path and lets the real logger emit output.

Before, on current main:

```text
node_modules/.bin/tsx /private/tmp/openclaw-90566-proof.ts /Users/allahyar/Documents/fastino-tasks/openclaw
repo=/Users/allahyar/Documents/fastino-tasks/openclaw
scenario=cron ANNOUNCE_SKIP without fallback
didAnnounce=true
scenario=cron ANNOUNCE_SKIP with delivered fallback
didAnnounce=false
```

After, on this branch:

```text
node_modules/.bin/tsx /private/tmp/openclaw-90566-proof.ts /Users/allahyar/Documents/fastino-tasks/openclaw-tui-68561
repo=/Users/allahyar/Documents/fastino-tasks/openclaw-tui-68561
scenario=cron ANNOUNCE_SKIP without fallback
cron job completion for session=agent:main:cron:daily-report run=run-cron-announce-skip-proof suppressed by ANNOUNCE_SKIP; the agent replied with the skip sentinel instead of delivering a result
didAnnounce=true
scenario=cron ANNOUNCE_SKIP with delivered fallback
didAnnounce=false
```

Verification rerun on this branch:

```text
node scripts/run-vitest.mjs src/agents/subagent-announce.test.ts --reporter=dot
Test Files  1 passed (1)
Tests  12 passed (12)
[test] passed 1 Vitest shard in 3.25s
```
