### PR TITLE
fix(whatsapp): preserve unsent streamed finals

### DIFF
--- a/src/auto-reply/reply/agent-runner-payloads.test.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.test.ts
@@ -492,7 +492,7 @@ describe("buildReplyPayloads media filter integration", () => {
     expect(replyPayloads).toHaveLength(0);
   });
 
-  it("drops all final payloads when block pipeline streamed successfully", async () => {
+  it("preserves unsent text-only final payloads after block pipeline streamed partial content", async () => {
     const pipeline: Parameters<typeof buildReplyPayloads>[0]["blockReplyPipeline"] = {
       didStream: () => true,
       isAborted: () => false,
@@ -503,8 +503,35 @@ describe("buildReplyPayloads media filter integration", () => {
       hasBuffered: () => false,
       getSentMediaUrls: () => [],
     };
-    // shouldDropFinalPayloads short-circuits to [] when the pipeline streamed
-    // without aborting, so hasSentPayload is never reached.
+    // The pipeline streamed some partial content, but the final text payload was
+    // never sent (hasSentPayload returns false). The old bug dropped all text-only
+    // finals unconditionally; the fix preserves unsent finals.
+    const { replyPayloads } = await buildReplyPayloads({
+      ...baseParams,
+      blockStreamingEnabled: true,
+      blockReplyPipeline: pipeline,
+      replyToMode: "all",
+      payloads: [{ text: "response", replyToId: "post-123" }],
+    });
+
+    expect(replyPayloads).toHaveLength(1);
+    expect(replyPayloads[0]?.text).toBe("response");
+  });
+
+  it("drops already-sent text-only final payloads after block pipeline streamed the exact same text", async () => {
+    const pipeline: Parameters<typeof buildReplyPayloads>[0]["blockReplyPipeline"] = {
+      didStream: () => true,
+      isAborted: () => false,
+      hasSentPayload: (payload) =>
+        payload.text === "response" && !payload.mediaUrl && !payload.mediaUrls,
+      enqueue: () => {},
+      flush: async () => {},
+      stop: () => {},
+      hasBuffered: () => false,
+      getSentMediaUrls: () => [],
+    };
+    // The final text-only payload matches what the pipeline already sent,
+    // so it should be dropped.
     const { replyPayloads } = await buildReplyPayloads({
       ...baseParams,
       blockStreamingEnabled: true,

--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -338,7 +338,13 @@ export async function buildReplyPayloads(params: {
     }
     const reply = resolveSendableOutboundReplyParts(payload);
     if (!reply.hasMedia) {
-      return null;
+      // Drop text-only payloads only when the exact payload was already sent.
+      // A partial streamed block does not prove the final complete text was delivered,
+      // so keep the payload unless the pipeline confirms it sent this exact content.
+      if (params.blockReplyPipeline?.hasSentPayload(payload)) {
+        return null;
+      }
+      return payload;
     }
     if (!reply.trimmedText) {
       return payload;


### PR DESCRIPTION
## What changed

- Preserve final text-only replies after block streaming when the block pipeline did not send that exact final payload.
- Keep deduplication for text-only payloads that the block pipeline confirms were already sent.
- Update the focused payload-builder coverage for both the preserved and already-sent cases.

Fixes #81078.

## Real behavior proof

- **Behavior or issue addressed:**

When block streaming has delivered partial content but has not sent the final complete text payload, OpenClaw now keeps the final payload instead of suppressing it. If the pipeline confirms that the exact final text payload was already sent, the duplicate is still dropped.

- **Real environment tested:**

- Repository: `openclaw/openclaw`
- Branch: `fastino-81078-whatsapp-block-stream-final`
- Platform tested: macOS arm64
- Runtime path: local OpenClaw Node/pnpm workspace using repository test scripts

- **Exact steps or command run after this patch:**

1. Created a temporary base checkout at `origin/main`.
2. Applied only the updated regression tests to the base checkout.
3. Ran `node scripts/test-projects.mjs src/auto-reply/reply/agent-runner-payloads.test.ts --reporter=verbose` and confirmed the old source dropped an unsent final text payload.
4. Ran the same focused test command on this branch.
5. Ran focused formatting and lint checks for the changed files.

- **Evidence after fix:**

Before behavior on base with only the regression test applied:

```text
$ git -C /Users/allahyar/Documents/fastino-tasks/openclaw-tui-81078 worktree add --detach /private/tmp/openclaw-base-81078-proof origin/main
$ git -C /private/tmp/openclaw-base-81078-proof apply /private/tmp/81078-test-only.patch
$ node scripts/test-projects.mjs src/auto-reply/reply/agent-runner-payloads.test.ts --reporter=verbose

× |auto-reply| src/auto-reply/reply/agent-runner-payloads.test.ts > buildReplyPayloads media filter integration > preserves unsent text-only final payloads after block pipeline streamed partial content 6ms
  → expected [] to have a length of 1 but got +0

Test Files  1 failed (1)
Tests  1 failed | 39 passed (40)
```

After behavior on this branch:

```text
$ node scripts/test-projects.mjs src/auto-reply/reply/agent-runner-payloads.test.ts --reporter=verbose

✓ |auto-reply| src/auto-reply/reply/agent-runner-payloads.test.ts > buildReplyPayloads media filter integration > preserves unsent text-only final payloads after block pipeline streamed partial content 0ms
✓ |auto-reply| src/auto-reply/reply/agent-runner-payloads.test.ts > buildReplyPayloads media filter integration > drops already-sent text-only final payloads after block pipeline streamed the exact same text 0ms

Test Files  1 passed (1)
Tests  40 passed (40)
[test] passed 1 Vitest shard in 15.20s
```

Additional checks:

```text
$ pnpm exec oxfmt --check src/auto-reply/reply/agent-runner-payloads.ts src/auto-reply/reply/agent-runner-payloads.test.ts
All matched files use the correct format.

$ pnpm exec oxlint src/auto-reply/reply/agent-runner-payloads.ts src/auto-reply/reply/agent-runner-payloads.test.ts --report-unused-disable-directives-severity error
# passed with no output
```

- **Observed result after fix:**

The base checkout returns no final reply payload for the unsent text-only final after partial block streaming. This branch returns the final text payload in that case while still dropping an exact payload that `hasSentPayload` reports as already sent; the focused shard passes 40/40.

- **What was not tested:**

No external WhatsApp account was used. The fix is in the generic final payload filter used by the WhatsApp block-streaming path, and the proof exercises that filter directly through the existing auto-reply test shard.
