### PR TITLE
fix(configure): mask gateway password input in CLI wizard prompt

### DIFF
--- a/src/commands/configure.gateway.test.ts
+++ b/src/commands/configure.gateway.test.ts
@@ -4,6 +4,7 @@ import type { RuntimeEnv } from "../runtime.js";
 
 const mocks = vi.hoisted(() => ({
   text: vi.fn(),
+  password: vi.fn(),
   select: vi.fn(),
   confirm: vi.fn(),
   resolveGatewayPort: vi.fn(),
@@ -23,6 +24,7 @@ vi.mock("../config/config.js", async (importActual) => {
 
 vi.mock("./configure.shared.js", () => ({
   text: mocks.text,
+  password: mocks.password,
   select: mocks.select,
   confirm: mocks.confirm,
 }));
@@ -76,6 +78,7 @@ async function runGatewayPrompt(params: {
     return input.initialValue ?? input.options[0]?.value;
   });
   mocks.text.mockImplementation(async () => params.textQueue.shift());
+  mocks.password.mockImplementation(async () => params.textQueue.shift());
   mocks.randomToken.mockReturnValue(params.randomToken ?? "generated-token");
   mocks.confirm.mockResolvedValue(params.confirmResult ?? true);
   mocks.buildGatewayAuthConfig.mockImplementation((input) =>

--- a/src/commands/configure.gateway.ts
+++ b/src/commands/configure.gateway.ts
@@ -21,7 +21,7 @@ import { findTailscaleBinary } from "../infra/tailscale.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { resolveDefaultSecretProviderAlias } from "../secrets/ref-contract.js";
 import { buildGatewayAuthConfig } from "./configure.gateway-auth.js";
-import { confirm, select, text } from "./configure.shared.js";
+import { confirm, password, select, text } from "./configure.shared.js";
 import {
   guardCancel,
   normalizeGatewayTokenInput,
@@ -245,14 +245,14 @@ export async function promptGatewayConfig(
   }
 
   if (authMode === "password") {
-    const password = guardCancel(
-      await text({
+    const passwordInput = guardCancel(
+      await password({
         message: "Gateway password",
         validate: validateGatewayPasswordInput,
       }),
       runtime,
     );
-    gatewayPassword = normalizeOptionalString(password) ?? "";
+    gatewayPassword = normalizeOptionalString(passwordInput) ?? "";
   }
 
   if (authMode === "trusted-proxy") {

--- a/src/commands/configure.shared.ts
+++ b/src/commands/configure.shared.ts
@@ -3,6 +3,7 @@ import {
   confirm as clackConfirm,
   intro as clackIntro,
   outro as clackOutro,
+  password as clackPassword,
   select as clackSelect,
   text as clackText,
 } from "@clack/prompts";
@@ -86,6 +87,12 @@ export const outro = (message: string) => clackOutro(stylePromptTitle(message) ?
 /** Styled text prompt wrapper. */
 export const text = (params: Parameters<typeof clackText>[0]) =>
   clackText({
+    ...params,
+    message: stylePromptMessage(params.message),
+  });
+/** Styled password prompt wrapper. Echoes bullets so secrets never appear in cleartext. */
+export const password = (params: Parameters<typeof clackPassword>[0]) =>
+  clackPassword({
     ...params,
     message: stylePromptMessage(params.message),
   });

--- a/src/commands/configure.wizard.test.ts
+++ b/src/commands/configure.wizard.test.ts
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => {
     clackSelect: vi.fn(),
     clackText: vi.fn(),
     clackConfirm: vi.fn(),
+    clackPassword: vi.fn(),
     resolveSearchProviderOptions: vi.fn(),
     resolvePluginContributionOwners: vi.fn(),
     setupSearch: vi.fn(),
@@ -45,6 +46,7 @@ vi.mock("@clack/prompts", () => ({
   select: mocks.clackSelect,
   text: mocks.clackText,
   confirm: mocks.clackConfirm,
+  password: mocks.clackPassword,
 }));
 
 vi.mock("../config/config.js", () => ({


### PR DESCRIPTION
## Summary

What problem does this PR solve?
The `openclaw configure --section gateway` wizard echoes the typed Gateway password in cleartext on the terminal. This is reproducible on the latest published CLI with no special setup — anyone using documented onboarding steps over a shared screen, screen recording, pair-programming session, or office display can leak their gateway password.

Why does this matter now?
This is the same class of UX/security defect already fixed for onboarding-wizard token/credential inputs in #76693 — the gateway configure surface was missed by that PR. Closing the gap keeps interactive credential entry consistent across all OpenClaw configure flows.

What is the intended outcome?
The `Gateway password` prompt renders bullets (`••••`) instead of the typed characters. Persisted config shape, validation, and downstream auth behavior are unchanged.

What is intentionally out of scope?
- The sibling `Gateway token (blank to generate)` prompt — addressed in sibling PR #91059.
- The `openclaw models auth paste-token --provider <p>` prompt (`masked: false`) — separate PR #90893.

What does success look like?
Running the published-CLI repro after this patch shows bullets where the screenshot below shows the cleartext password. No regression in the `authMode === "password"` config persistence path (existing unit test `does not set password to literal 'undefined' when prompt returns undefined` still passes).

What should reviewers focus on?
- That the new `password` helper in `configure.shared.ts` matches the styling of the existing `text/confirm/select` wrappers.
- That the local-variable rename (`password` → `passwordInput`) in `configure.gateway.ts` does not shadow the new imported helper.
- That `configure.gateway.test.ts`'s existing `textQueue` fixtures still feed the password branch via the new `password` mock.

## Linked context

Which issue does this close?

None — this PR was authored from an audit of unmasked credential prompts, not in response to an open issue.

Which issues, PRs, or discussions are related?

- Predecessor that established this discipline: #76693
- Sibling gateway-token mask (also in-flight): #91059
- Repro C (paste-token mask): #90893
- macOS verification tracked: #90634
- Linux verification tracked: #90635

Was this requested by a maintainer or owner?

No — found while auditing remaining unmasked credential prompts after #76693 merged.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: `openclaw configure --section gateway` echoes the Gateway password in cleartext.
- Real environment tested: Windows 10 Home Single Language (build 19045.7291), PowerShell, OpenClaw `2026.6.1 (2e08f0f)` for before-evidence (installed via the documented global installer `npm install -g openclaw@latest`); OpenClaw `2026.6.2 (861bf54)` from this branch via `pnpm openclaw configure --section gateway` for after-evidence.
- Exact steps or command run after this patch:
  1. `git checkout fix/mask-gateway-token`
  2. `pnpm install && pnpm build`
  3. `pnpm openclaw configure --section gateway`
  4. Answer prompts: bind=Loopback, access protection=Password, Tailscale=Off
  5. At `Gateway password`, type `USING_DUMMY_PASSWORD`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): <img width="720" alt="fix_mask-gateway_token" src="https://github.com/user-attachments/assets/db383f34-32c9-40d7-934d-53c8e39a9349"/>

- Observed result after fix: characters render as bullets; persisted `gateway.auth.password` value is the typed string (validated end-to-end by `openclaw configure` printing `Updated config: ~/.openclaw/openclaw.json`).
- What was not tested: macOS, Linux. The change touches cross-platform `@clack/prompts` code with no `process.platform` branching, so the fix applies on all three platforms. Verification on each is tracked as a separate atomic task — macOS: #90634; Linux: #90635.
- Proof limitations or environment constraints: My machine is Windows-only. The fix path is platform-agnostic, but I cannot personally screenshot macOS/Linux output.
- Before evidence (optional but encouraged): <img width="720" alt="gateway_token_issue" src="https://github.com/user-attachments/assets/7c422ecb-4f0c-4e42-ab43-c183715e0942"/>


## Tests and validation

Which commands did you run?

```
pnpm build ; pnpm check ; pnpm test
```

`pnpm install` run first (fresh checkout). `pnpm check` — typecheck green; one pre-existing lint failure in `extensions/slack/` (this PR's commits touch zero slack/plugin-sdk surface, per `CONTRIBUTING.md:128-129`). `pnpm test` — pre-existing Windows-only failures (POSIX-path, SQLite EBUSY, PTY tests) — none in this PR's files; `configure.gateway.test.ts` shard passes. Targeted regression: `npx vitest run src/commands/configure.gateway.test.ts` — `Test Files 1 passed (1) / Tests 11 passed (11)`. After commit `fa3f5e8aa4`: `pnpm tsgo:core` and `pnpm test:changed` — green (one pre-existing POSIX-path failure in `src/crestodian/operations.test.ts`, unrelated). Manual repro per the steps above.

What regression coverage was added or updated?

Updated mock setup in `src/commands/configure.gateway.test.ts` to register the new `password` helper. Existing assertions covering the password branch (`'does not set password to literal "undefined"'`, Tailscale-funnel-requires-password) continue to pass unchanged, demonstrating that the masked prompt feeds the same persistence path. Added `clackPassword: vi.fn()` and `password: mocks.clackPassword` to the `@clack/prompts` mock in `src/commands/configure.wizard.test.ts` so the shared module import chain resolves correctly (commit `fa3f5e8aa4`).

What failed before this fix, if known?

No automated test failure — this is a UX/security defect not previously asserted. The proof is the live terminal capture.

If no test was added, why not?

A test was not added because automated tests cannot meaningfully assert "the TTY echoes bullets, not characters" — that requires a real terminal. The structural fix is the new `password` import; verifying it is correctly wired is exactly what the manual repro screenshots prove.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes — the `Gateway password` prompt now renders bullets instead of typed characters. No other visible UI changes.

Did config, environment, or migration behavior change? (`Yes/No`)

No — `gateway.auth.password` in `openclaw.json` is persisted unchanged. Backup file path unchanged. No migration.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

Yes — masking the on-screen rendering of secret input. This is the intended security fix; no other auth/network behavior altered.

What is the highest-risk area?

Local-variable shadowing: I renamed `const password` (the local variable holding the answer) to `passwordInput` so it doesn't shadow the new imported `password` helper. If a reviewer prefers an alternative name (e.g., `passwordAnswer`), it's a one-token change.

How is that risk mitigated?

The new helper is named identically across the wizard surface (`text`, `confirm`, `select`, now `password`) so future credential prompts in `configure.gateway.ts` and siblings have an obvious masked counterpart and won't accidentally regress to `text(...)`. The variable rename is mechanical and locally scoped.

## Current review state

What is the next action?

Maintainer review.

What is still waiting on author, maintainer, CI, or external proof?

- Maintainer review.
- Optional macOS spot-check tracked in #90634.
- Optional Linux spot-check tracked in #90635.

Which bot or reviewer comments were addressed?

ClawSweeper Codex review (2026-06-07, commit `3b067a65ab`): P1 finding addressed in commit `fa3f5e8aa4` — added `clackPassword: vi.fn()` to the `vi.hoisted()` mocks and `password: mocks.clackPassword` to the `vi.mock("@clack/prompts", ...)` block in `src/commands/configure.wizard.test.ts`. All targeted tests pass after the fix.

---

**AI-assisted PR:**
- [x] Mark as AI-assisted in the PR title or description
- [x] Include human-run real behavior proof from your own setup. AI-generated tests, mocks, lint, typechecks, and CI output are supplemental only; they do not prove the fix works for users.
- [ ] Include prompts or session logs if possible (super helpful!)
- [x] Confirm you understand what the code does
- [ ] If you have access to Codex, run `codex review --base origin/main` locally and address the findings before asking for review
- [x] Resolve or reply to bot review conversations after you address them