### PR TITLE
fix(feishu): drop self-authored receive echoes

### DIFF
--- a/extensions/feishu/src/monitor.message-handler.test.ts
+++ b/extensions/feishu/src/monitor.message-handler.test.ts
@@ -1,0 +1,112 @@
+// Feishu tests cover monitor.message handler plugin behavior.
+import { describe, expect, it, vi } from "vitest";
+import type { ClawdbotConfig, PluginRuntime } from "../runtime-api.js";
+import type { FeishuMessageEvent } from "./event-types.js";
+import { createFeishuMessageReceiveHandler } from "./monitor.message-handler.js";
+
+type MessageReceiveHandlerContext = Parameters<typeof createFeishuMessageReceiveHandler>[0];
+type HandleMessageParams = Parameters<MessageReceiveHandlerContext["handleMessage"]>[0];
+
+function createTextEvent(params: {
+  messageId: string;
+  senderOpenId: string;
+  senderType: "bot" | "user";
+}): FeishuMessageEvent {
+  return {
+    sender: {
+      sender_id: { open_id: params.senderOpenId },
+      sender_type: params.senderType,
+    },
+    message: {
+      message_id: params.messageId,
+      chat_id: "oc_chat_1",
+      chat_type: "p2p",
+      message_type: "text",
+      content: JSON.stringify({ text: "hello" }),
+    },
+  };
+}
+
+function createHandler() {
+  let onFlush: ((entries: FeishuMessageEvent[]) => Promise<void>) | undefined;
+  const enqueue = vi.fn(async (event: FeishuMessageEvent) => {
+    await onFlush?.([event]);
+  });
+  const channelRuntime = {
+    commands: {
+      isControlCommandMessage: () => false,
+    },
+    debounce: {
+      resolveInboundDebounceMs: () => 0,
+      createInboundDebouncer: vi.fn((params: { onFlush: typeof onFlush }) => {
+        onFlush = params.onFlush;
+        return { enqueue };
+      }),
+    },
+  } as unknown as PluginRuntime["channel"];
+  const handleMessage = vi.fn(async (_params: HandleMessageParams) => {});
+
+  const handler = createFeishuMessageReceiveHandler({
+    cfg: {} as ClawdbotConfig,
+    channelRuntime,
+    accountId: "default",
+    chatHistories: new Map(),
+    handleMessage,
+    resolveDebounceText: () => "hello",
+    hasProcessedMessage: vi.fn(async () => false),
+    recordProcessedMessage: vi.fn(async () => true),
+    getBotOpenId: () => "ou_bot",
+  });
+
+  return { handler, handleMessage, enqueue };
+}
+
+describe("createFeishuMessageReceiveHandler self-message filtering", () => {
+  it("drops the current bot before debounce and processing claims", async () => {
+    const { handler, handleMessage, enqueue } = createHandler();
+
+    await handler(
+      createTextEvent({
+        messageId: "om_reused",
+        senderOpenId: "ou_bot",
+        senderType: "bot",
+      }),
+    );
+    await handler(
+      createTextEvent({
+        messageId: "om_reused",
+        senderOpenId: "ou_user",
+        senderType: "user",
+      }),
+    );
+
+    expect(enqueue).toHaveBeenCalledTimes(1);
+    expect(handleMessage).toHaveBeenCalledTimes(1);
+    expect(handleMessage.mock.calls[0]?.[0]?.event.sender.sender_id.open_id).toBe("ou_user");
+  });
+
+  it("keeps peer bot and user messages flowing to dispatch", async () => {
+    const { handler, handleMessage, enqueue } = createHandler();
+
+    await handler(
+      createTextEvent({
+        messageId: "om_other_bot",
+        senderOpenId: "ou_other_bot",
+        senderType: "bot",
+      }),
+    );
+    await handler(
+      createTextEvent({
+        messageId: "om_user",
+        senderOpenId: "ou_user",
+        senderType: "user",
+      }),
+    );
+
+    expect(enqueue).toHaveBeenCalledTimes(2);
+    expect(handleMessage).toHaveBeenCalledTimes(2);
+    expect(
+      handleMessage.mock.calls.map(([params]) => params.event.sender.sender_id.open_id),
+    ).toEqual(["ou_other_bot", "ou_user"]);
+  });
+});

--- a/extensions/feishu/src/monitor.message-handler.ts
+++ b/extensions/feishu/src/monitor.message-handler.ts
@@ -321,6 +321,14 @@ export function createFeishuMessageReceiveHandler({
       return;
     }
     const messageId = event.message?.message_id?.trim();
+    const botOpenId = getBotOpenId(accountId)?.trim();
+    const senderOpenId = event.sender.sender_id.open_id?.trim();
+    if (botOpenId && senderOpenId === botOpenId) {
+      // Feishu bot receive events identify their sender by open_id. Drop this
+      // account's bot before it can consume a claim or debounce slot.
+      log(`feishu[${accountId}]: dropping self-authored message ${messageId ?? "unknown"}`);
+      return;
+    }
     const messageDedupeKey = resolveFeishuMessageDedupeKey(event);
     if (!tryBeginFeishuMessageProcessing(messageDedupeKey, accountId)) {
       log(`feishu[${accountId}]: dropping duplicate event for message ${messageId}`);


### PR DESCRIPTION
## Summary

- Drop Feishu receive events authored by the current bot open_id before the in-flight processing claim and inbound debounce queue.
- Add focused monitor-message-handler regressions for bot-open-id echoes, ordinary users, and other app-authored senders.

Refs #90559. This PR addresses the self-talk feedback-loop portion when Feishu/Lark receive events identify the current bot by open_id; slow-run queue abort, queue-depth backpressure, and session-lock policy remain follow-up work.

## Root cause

Feishu `im.message.receive_v1` events enter `createFeishuMessageReceiveHandler`, then immediately claim processing and enqueue into the inbound debouncer. Current `main`, `v2026.6.1`, and `v2026.6.4-alpha.1` have no early self-message filter on that path, so a Feishu/Lark receive echo whose sender `open_id` is the bot open_id can be treated as fresh inbound input and start another agent turn.

The repair is intentionally narrow: it only drops events whose sender `open_id` matches the stored bot open_id for the account. It does not drop all `sender_type: app` messages, so other app-authored messages can still flow through normal Feishu policy and dispatch. A previous app-id sender branch was removed because Lark `message.get` sender metadata does not prove an equivalent app-id sender identity exists on `im.message.receive_v1` events.

## Real behavior proof

Behavior addressed: The bot-open-id self-talk feedback-loop portion of #90559 is addressed: Feishu/Lark receive events can no longer consume processing/debounce capacity or dispatch another agent turn when `sender.sender_id.open_id` matches the configured bot open_id.

Real environment tested: Real Lark production app using persistent WebSocket mode, with a real user message in a group where the bot was installed, plus a real bot reply sent through Lark `im.message.reply`. Credentials, tenant, chat, user, message, app, and bot identifiers were redacted.

Exact steps or command run after this patch: Started a local Node/tsx proof harness against this checkout, using `@larksuiteoapi/node-sdk` persistent connection on the Lark domain; sent one real group message mentioning the bot; let the patched `createFeishuMessageReceiveHandler` process that live event; sent a real bot reply via Lark `im.message.reply`; fetched the reply with `im.message.get`; separately exercised the patched handler with a bot-open-id receive event to prove the drop happens before debounce/dispatch.

Evidence after fix:

```text
probe_ok domain=lark appId=cli_...9e17 botOpenId=ou_...c73d
websocket_receive_event senderType=user senderIdTypes=[open_id,union_id,user_id] senderOpenIdMatchesBot=false
handler_enqueue enqueueCount=1
handler_dispatch dispatchCount=1
bot_reply_api_result code=0 ok=true
live_bot_reply_sender sender.id=cli_...9e17 sender.id_type=app_id sender.sender_type=app
local_handler_self_open_id_event senderOpenIdMatchesBot=true
local_handler_log dropping self-authored message <message-id>
local_handler_summary selfOpenIdDropObserved=true enqueueAfterSelfEcho=0 dispatchAfterSelfEcho=0
```

Observed result after fix: The real user message from WebSocket reached enqueue and dispatch exactly once. The real bot reply was accepted by Lark. The patched handler drops a bot-open-id receive event before debounce/dispatch. The final code does not use the `message.get` app-id sender shape as a receive-event identity contract.

What was not tested: This Lark tenant did not naturally emit the bot reply back over `im.message.receive_v1` during the observation window, so the proof does not claim a natural Lark WebSocket self-echo was observed. No China Feishu-domain tenant was available for this credential set. App-authored receive echoes without bot open_id remain unproven and are not handled by this PR. Slow-LLM queue abort, queue-depth backpressure, and session-lock policy remain outside this narrow patch.

## Verification

- `./node_modules/.bin/oxfmt --check --threads=1 extensions/feishu/src/event-types.ts extensions/feishu/src/monitor.account.ts extensions/feishu/src/monitor.message-handler.ts extensions/feishu/src/monitor.message-handler.test.ts && git diff --check`
- `node scripts/run-vitest.mjs extensions/feishu/src/monitor.message-handler.test.ts extensions/feishu/src/monitor.reaction.test.ts extensions/feishu/src/sequential-queue.test.ts extensions/feishu/src/bot.test.ts extensions/feishu/src/monitor.webhook-e2e.test.ts` — 5 files, 115 tests passed
- `.agents/skills/autoreview/scripts/autoreview --mode local` — final result: clean, no accepted/actionable findings reported

## Evidence checked

- Feishu/Lark receive-message contract: official Lark docs and `@larksuiteoapi/node-sdk@1.66.0` types expose `im.message.receive_v1.sender.sender_id.open_id` and `sender_type`.
- Feishu/Lark message-get contract: official Lark docs and live API output show app/bot-sent messages use message-get sender metadata with `sender_type=app` and `id_type=app_id`; that shape is not treated as a receive-event sender identity contract in this patch.
- Current/shipped behavior: `origin/main`, `v2026.6.1`, and `v2026.6.4-alpha.1` route receive events into `tryBeginFeishuMessageProcessing` and `inboundDebouncer.enqueue` without an early bot-open-id self-filter.

