### PR TITLE
fix(openai): omit gpt-5.5 tool reasoning effort

### DIFF
--- a/extensions/openai/openclaw.plugin.json
+++ b/extensions/openai/openclaw.plugin.json
@@ -11,7 +11,8 @@
   "providerEndpoints": [
     {
       "endpointClass": "openai-public",
-      "hosts": ["api.openai.com"]
+      "hosts": ["api.openai.com"],
+      "hostSuffixes": [".api.openai.com"]
     },
     {
       "endpointClass": "openai",

--- a/extensions/openai/openclaw.plugin.test.ts
+++ b/extensions/openai/openclaw.plugin.test.ts
@@ -30,7 +30,11 @@ const manifest = JSON.parse(
   setup?: {
     providers?: Array<{ id: string }>;
   };
-  providerEndpoints?: Array<{ endpointClass?: string; hosts?: string[] }>;
+  providerEndpoints?: Array<{
+    endpointClass?: string;
+    hosts?: string[];
+    hostSuffixes?: string[];
+  }>;
   providerAuthAliases?: Record<string, string>;
   legacyPluginIds?: string[];
 };
@@ -117,6 +121,14 @@ describe("OpenAI plugin manifest", () => {
       endpoint.hosts?.includes("chatgpt.com"),
     );
     expect(chatGptEndpoint?.endpointClass).toBe("openai");
+  });
+
+  it("classifies regional API hosts as public OpenAI endpoints", () => {
+    const publicEndpoint = manifest.providerEndpoints?.find((endpoint) =>
+      endpoint.hosts?.includes("api.openai.com"),
+    );
+    expect(publicEndpoint?.endpointClass).toBe("openai-public");
+    expect(publicEndpoint?.hostSuffixes).toContain(".api.openai.com");
   });
 
   it("keeps OpenAI media-understanding manifest metadata aligned with runtime audio support", () => {

--- a/src/agents/openai-reasoning-effort.ts
+++ b/src/agents/openai-reasoning-effort.ts
@@ -16,6 +16,7 @@ export type OpenAIApiReasoningEffort = OpenAIReasoningEffort | (string & {});
 type OpenAIReasoningModel = {
   provider?: unknown;
   id?: unknown;
+  name?: unknown;
   api?: unknown;
   baseUrl?: unknown;
   compat?: unknown;
@@ -44,7 +45,8 @@ export function isOpenAIGpt54MiniModel(model: OpenAIReasoningModel): boolean {
 /** Return whether a model is the GPT-5.5 family. */
 export function isOpenAIGpt55Model(model: OpenAIReasoningModel): boolean {
   const id = normalizeModelId(typeof model.id === "string" ? model.id : undefined);
-  return /^gpt-5\.5(?:-|$)/u.test(id);
+  const name = normalizeModelId(typeof model.name === "string" ? model.name : undefined);
+  return /^gpt-5\.5(?:-|$)/u.test(id) || /^gpt-5\.5(?:\s|\(|-|$)/u.test(name);
 }
 
 /** Normalize user-facing reasoning effort names to API effort names. */

--- a/src/agents/openai-reasoning-effort.ts
+++ b/src/agents/openai-reasoning-effort.ts
@@ -41,6 +41,12 @@ export function isOpenAIGpt54MiniModel(model: OpenAIReasoningModel): boolean {
   return /^gpt-5\.4-mini(?:-|$)/u.test(id);
 }
 
+/** Return whether a model is the GPT-5.5 family. */
+export function isOpenAIGpt55Model(model: OpenAIReasoningModel): boolean {
+  const id = normalizeModelId(typeof model.id === "string" ? model.id : undefined);
+  return /^gpt-5\.5(?:-|$)/u.test(id);
+}
+
 /** Normalize user-facing reasoning effort names to API effort names. */
 export function normalizeOpenAIReasoningEffort(effort: string): string {
   return effort === "minimal" ? "minimal" : effort;

--- a/src/agents/openai-tool-projection.live.test.ts
+++ b/src/agents/openai-tool-projection.live.test.ts
@@ -88,14 +88,14 @@ describeLive("OpenAI tool projection live", () => {
     });
   }, 45_000);
 
-  it("calls a healthy Chat Completions function after quarantining an unreadable sibling", async () => {
+  it("calls a GPT-5.5 Chat Completions function without incompatible reasoning effort", async () => {
     const model = {
       id: modelId,
       name: modelId,
       api: "openai-completions",
       provider: "openai",
       baseUrl: "https://api.openai.com/v1",
-      reasoning: false,
+      reasoning: true,
       input: ["text"],
       cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
       contextWindow: 200000,
@@ -103,6 +103,7 @@ describeLive("OpenAI tool projection live", () => {
     } satisfies Model<"openai-completions">;
     const params = buildOpenAICompletionsParams(model, context, {
       maxTokens: 128,
+      reasoning: "low",
       toolChoice: {
         type: "allowed_tools",
         allowed_tools: {
@@ -114,6 +115,7 @@ describeLive("OpenAI tool projection live", () => {
         },
       },
     });
+    expect(params).not.toHaveProperty("reasoning_effort");
     const { stream_options: _streamOptions, ...nonStreamingParams } = params;
 
     const response = await client.chat.completions.create({

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -5961,39 +5961,45 @@ describe("openai transport stream", () => {
     expect(params).not.toHaveProperty("reasoning_effort");
   });
 
-  it("omits reasoning_effort for OpenAI gpt-5.5 Chat Completions tool payloads", () => {
-    const params = buildOpenAICompletionsParams(
-      {
-        id: "gpt-5.5",
-        name: "GPT-5.5",
-        api: "openai-completions",
-        provider: "openai",
-        baseUrl: "https://api.openai.com/v1",
-        reasoning: true,
-        input: ["text"],
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-        contextWindow: 1000000,
-        maxTokens: 128000,
-      } satisfies Model<"openai-completions">,
-      {
-        systemPrompt: "system",
-        messages: [],
-        tools: [
-          {
-            name: "lookup_weather",
-            description: "Get forecast",
-            parameters: { type: "object", properties: {}, additionalProperties: false },
-          },
-        ],
-      } as never,
-      {
-        reasoning: "medium",
-      } as never,
-    ) as { reasoning_effort?: unknown; tools?: unknown };
+  it.each([
+    ["implicit default", ""],
+    ["default", "https://api.openai.com/v1"],
+  ])(
+    "omits reasoning_effort for OpenAI %s gpt-5.5 Chat Completions tool payloads",
+    (_label, baseUrl) => {
+      const params = buildOpenAICompletionsParams(
+        {
+          id: "gpt-5.5",
+          name: "GPT-5.5",
+          api: "openai-completions",
+          provider: "openai",
+          baseUrl,
+          reasoning: true,
+          input: ["text"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 1000000,
+          maxTokens: 128000,
+        } satisfies Model<"openai-completions">,
+        {
+          systemPrompt: "system",
+          messages: [],
+          tools: [
+            {
+              name: "lookup_weather",
+              description: "Get forecast",
+              parameters: { type: "object", properties: {}, additionalProperties: false },
+            },
+          ],
+        } as never,
+        {
+          reasoning: "medium",
+        } as never,
+      ) as { reasoning_effort?: unknown; tools?: unknown };
 
-    expect(params.tools).toHaveLength(1);
-    expect(params).not.toHaveProperty("reasoning_effort");
-  });
+      expect(params.tools).toHaveLength(1);
+      expect(params).not.toHaveProperty("reasoning_effort");
+    },
+  );
 
   it.each([
     ["Azure OpenAI", "https://example.openai.azure.com/openai/v1"],

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -5995,14 +5995,56 @@ describe("openai transport stream", () => {
     expect(params).not.toHaveProperty("reasoning_effort");
   });
 
-  it("omits reasoning_effort for Azure gpt-5.5 deployment aliases with tool payloads", () => {
+  it.each([
+    ["Azure OpenAI", "https://example.openai.azure.com/openai/v1"],
+    ["Foundry", "https://example.services.ai.azure.com/openai/v1"],
+    ["Cognitive Services", "https://example.cognitiveservices.azure.com/openai/v1"],
+  ])(
+    "omits reasoning_effort for %s gpt-5.5 deployment aliases with tool payloads",
+    (_label, baseUrl) => {
+      const params = buildOpenAICompletionsParams(
+        {
+          id: "prod-spud",
+          name: "GPT-5.5 (Azure)",
+          api: "openai-completions",
+          provider: "azure-openai",
+          baseUrl,
+          reasoning: true,
+          input: ["text"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 1000000,
+          maxTokens: 128000,
+        } satisfies Model<"openai-completions">,
+        {
+          systemPrompt: "system",
+          messages: [],
+          tools: [
+            {
+              name: "lookup_weather",
+              description: "Get forecast",
+              parameters: { type: "object", properties: {}, additionalProperties: false },
+            },
+          ],
+        } as never,
+        {
+          reasoning: "medium",
+        } as never,
+      ) as { reasoning_effort?: unknown; tools?: unknown };
+
+      expect(params.tools).toHaveLength(1);
+      expect(params).not.toHaveProperty("reasoning_effort");
+    },
+  );
+
+  it("keeps reasoning_effort for custom gpt-5.5 Chat Completions tool payloads", () => {
     const params = buildOpenAICompletionsParams(
       {
-        id: "prod-spud",
-        name: "GPT-5.5 (Azure)",
+        id: "gpt-5.5",
+        name: "GPT-5.5",
         api: "openai-completions",
-        provider: "azure-openai",
-        baseUrl: "https://example.openai.azure.com/openai/v1",
+        provider: "custom-openai",
+        baseUrl: "https://models.example.com/v1",
+        compat: { supportsReasoningEffort: true },
         reasoning: true,
         input: ["text"],
         cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
@@ -6026,7 +6068,7 @@ describe("openai transport stream", () => {
     ) as { reasoning_effort?: unknown; tools?: unknown };
 
     expect(params.tools).toHaveLength(1);
-    expect(params).not.toHaveProperty("reasoning_effort");
+    expect(params.reasoning_effort).toBe("medium");
   });
 
   it("keeps reasoning_effort for gpt-5.5 Chat Completions payloads without tools", () => {

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -5961,7 +5961,7 @@ describe("openai transport stream", () => {
     expect(params).not.toHaveProperty("reasoning_effort");
   });
 
-  it("omits reasoning_effort for gpt-5.5 Chat Completions tool payloads", () => {
+  it("omits reasoning_effort for Azure gpt-5.5 Chat Completions tool payloads", () => {
     const params = buildOpenAICompletionsParams(
       {
         id: "gpt-5.5",
@@ -5993,6 +5993,105 @@ describe("openai transport stream", () => {
 
     expect(params.tools).toHaveLength(1);
     expect(params).not.toHaveProperty("reasoning_effort");
+  });
+
+  it("omits reasoning_effort for Azure gpt-5.5 deployment aliases with tool payloads", () => {
+    const params = buildOpenAICompletionsParams(
+      {
+        id: "prod-spud",
+        name: "GPT-5.5 (Azure)",
+        api: "openai-completions",
+        provider: "azure-openai",
+        baseUrl: "https://example.openai.azure.com/openai/v1",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 1000000,
+        maxTokens: 128000,
+      } satisfies Model<"openai-completions">,
+      {
+        systemPrompt: "system",
+        messages: [],
+        tools: [
+          {
+            name: "lookup_weather",
+            description: "Get forecast",
+            parameters: { type: "object", properties: {}, additionalProperties: false },
+          },
+        ],
+      } as never,
+      {
+        reasoning: "medium",
+      } as never,
+    ) as { reasoning_effort?: unknown; tools?: unknown };
+
+    expect(params.tools).toHaveLength(1);
+    expect(params).not.toHaveProperty("reasoning_effort");
+  });
+
+  it("keeps reasoning_effort for custom gpt-5.5 Chat Completions providers with tool payloads", () => {
+    const params = buildOpenAICompletionsParams(
+      {
+        id: "gpt-5.5",
+        name: "GPT-5.5",
+        api: "openai-completions",
+        provider: "custom-openai",
+        baseUrl: "https://models.example.com/v1",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 1000000,
+        maxTokens: 128000,
+        compat: {
+          supportsReasoningEffort: true,
+        },
+      } satisfies Model<"openai-completions">,
+      {
+        systemPrompt: "system",
+        messages: [],
+        tools: [
+          {
+            name: "lookup_weather",
+            description: "Get forecast",
+            parameters: { type: "object", properties: {}, additionalProperties: false },
+          },
+        ],
+      } as never,
+      {
+        reasoning: "medium",
+      } as never,
+    ) as { reasoning_effort?: unknown; tools?: unknown };
+
+    expect(params.tools).toHaveLength(1);
+    expect(params.reasoning_effort).toBe("medium");
+  });
+
+  it("keeps reasoning_effort for Azure gpt-5.5 Chat Completions payloads without tools", () => {
+    const params = buildOpenAICompletionsParams(
+      {
+        id: "gpt-5.5",
+        name: "GPT-5.5",
+        api: "openai-completions",
+        provider: "azure-openai",
+        baseUrl: "https://example.openai.azure.com/openai/v1",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 1000000,
+        maxTokens: 128000,
+      } satisfies Model<"openai-completions">,
+      {
+        systemPrompt: "system",
+        messages: [],
+        tools: [],
+      } as never,
+      {
+        reasoning: "medium",
+      } as never,
+    ) as { reasoning_effort?: unknown; tools?: unknown };
+
+    expect(params.tools).toHaveLength(0);
+    expect(params.reasoning_effort).toBe("medium");
   });
 
   it("keeps reasoning_effort for gpt-5.4-mini Chat Completions payloads without tools", () => {

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -6030,37 +6030,45 @@ describe("openai transport stream", () => {
   });
 
   it("omits reasoning_effort for custom provider ids backed by Azure GPT-5.5 endpoints", () => {
-    const params = buildOpenAICompletionsParams(
-      {
-        id: "prod-spud",
-        name: "GPT-5.5 (Azure)",
-        api: "openai-completions",
-        provider: "corp-azure-openai",
-        baseUrl: "https://corp-resource.openai.azure.com/openai/v1",
-        reasoning: true,
-        input: ["text"],
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-        contextWindow: 1000000,
-        maxTokens: 128000,
-      } satisfies Model<"openai-completions">,
-      {
-        systemPrompt: "system",
-        messages: [],
-        tools: [
-          {
-            name: "lookup_weather",
-            description: "Get forecast",
-            parameters: { type: "object", properties: {}, additionalProperties: false },
-          },
-        ],
-      } as never,
-      {
-        reasoning: "medium",
-      } as never,
-    ) as { reasoning_effort?: unknown; tools?: unknown };
+    const azureBaseUrls = [
+      "https://corp-resource.openai.azure.com/openai/v1",
+      "https://corp-project.services.ai.azure.com/api/projects/demo/openai/v1",
+      "https://corp-resource.cognitiveservices.azure.com/openai/v1",
+    ];
 
-    expect(params.tools).toHaveLength(1);
-    expect(params).not.toHaveProperty("reasoning_effort");
+    for (const baseUrl of azureBaseUrls) {
+      const params = buildOpenAICompletionsParams(
+        {
+          id: "prod-spud",
+          name: "GPT-5.5 (Azure)",
+          api: "openai-completions",
+          provider: "corp-azure-openai",
+          baseUrl,
+          reasoning: true,
+          input: ["text"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 1000000,
+          maxTokens: 128000,
+        } satisfies Model<"openai-completions">,
+        {
+          systemPrompt: "system",
+          messages: [],
+          tools: [
+            {
+              name: "lookup_weather",
+              description: "Get forecast",
+              parameters: { type: "object", properties: {}, additionalProperties: false },
+            },
+          ],
+        } as never,
+        {
+          reasoning: "medium",
+        } as never,
+      ) as { reasoning_effort?: unknown; tools?: unknown };
+
+      expect(params.tools).toHaveLength(1);
+      expect(params).not.toHaveProperty("reasoning_effort");
+    }
   });
 
   it("keeps reasoning_effort for custom gpt-5.5 Chat Completions providers with tool payloads", () => {

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -5961,6 +5961,40 @@ describe("openai transport stream", () => {
     expect(params).not.toHaveProperty("reasoning_effort");
   });
 
+  it("omits reasoning_effort for gpt-5.5 Chat Completions tool payloads", () => {
+    const params = buildOpenAICompletionsParams(
+      {
+        id: "gpt-5.5",
+        name: "GPT-5.5",
+        api: "openai-completions",
+        provider: "azure-openai",
+        baseUrl: "https://example.openai.azure.com/openai/v1",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 1000000,
+        maxTokens: 128000,
+      } satisfies Model<"openai-completions">,
+      {
+        systemPrompt: "system",
+        messages: [],
+        tools: [
+          {
+            name: "lookup_weather",
+            description: "Get forecast",
+            parameters: { type: "object", properties: {}, additionalProperties: false },
+          },
+        ],
+      } as never,
+      {
+        reasoning: "medium",
+      } as never,
+    ) as { reasoning_effort?: unknown; tools?: unknown };
+
+    expect(params.tools).toHaveLength(1);
+    expect(params).not.toHaveProperty("reasoning_effort");
+  });
+
   it("keeps reasoning_effort for gpt-5.4-mini Chat Completions payloads without tools", () => {
     const params = buildOpenAICompletionsParams(
       {

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -5961,14 +5961,14 @@ describe("openai transport stream", () => {
     expect(params).not.toHaveProperty("reasoning_effort");
   });
 
-  it("omits reasoning_effort for Azure gpt-5.5 Chat Completions tool payloads", () => {
+  it("omits reasoning_effort for OpenAI gpt-5.5 Chat Completions tool payloads", () => {
     const params = buildOpenAICompletionsParams(
       {
         id: "gpt-5.5",
         name: "GPT-5.5",
         api: "openai-completions",
-        provider: "azure-openai",
-        baseUrl: "https://example.openai.azure.com/openai/v1",
+        provider: "openai",
+        baseUrl: "https://api.openai.com/v1",
         reasoning: true,
         input: ["text"],
         cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
@@ -6029,93 +6029,14 @@ describe("openai transport stream", () => {
     expect(params).not.toHaveProperty("reasoning_effort");
   });
 
-  it("omits reasoning_effort for custom provider ids backed by Azure GPT-5.5 endpoints", () => {
-    const azureBaseUrls = [
-      "https://corp-resource.openai.azure.com/openai/v1",
-      "https://corp-project.services.ai.azure.com/api/projects/demo/openai/v1",
-      "https://corp-resource.cognitiveservices.azure.com/openai/v1",
-    ];
-
-    for (const baseUrl of azureBaseUrls) {
-      const params = buildOpenAICompletionsParams(
-        {
-          id: "prod-spud",
-          name: "GPT-5.5 (Azure)",
-          api: "openai-completions",
-          provider: "corp-azure-openai",
-          baseUrl,
-          reasoning: true,
-          input: ["text"],
-          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-          contextWindow: 1000000,
-          maxTokens: 128000,
-        } satisfies Model<"openai-completions">,
-        {
-          systemPrompt: "system",
-          messages: [],
-          tools: [
-            {
-              name: "lookup_weather",
-              description: "Get forecast",
-              parameters: { type: "object", properties: {}, additionalProperties: false },
-            },
-          ],
-        } as never,
-        {
-          reasoning: "medium",
-        } as never,
-      ) as { reasoning_effort?: unknown; tools?: unknown };
-
-      expect(params.tools).toHaveLength(1);
-      expect(params).not.toHaveProperty("reasoning_effort");
-    }
-  });
-
-  it("keeps reasoning_effort for custom gpt-5.5 Chat Completions providers with tool payloads", () => {
+  it("keeps reasoning_effort for gpt-5.5 Chat Completions payloads without tools", () => {
     const params = buildOpenAICompletionsParams(
       {
         id: "gpt-5.5",
         name: "GPT-5.5",
         api: "openai-completions",
-        provider: "custom-openai",
-        baseUrl: "https://models.example.com/v1",
-        reasoning: true,
-        input: ["text"],
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-        contextWindow: 1000000,
-        maxTokens: 128000,
-        compat: {
-          supportsReasoningEffort: true,
-        },
-      } satisfies Model<"openai-completions">,
-      {
-        systemPrompt: "system",
-        messages: [],
-        tools: [
-          {
-            name: "lookup_weather",
-            description: "Get forecast",
-            parameters: { type: "object", properties: {}, additionalProperties: false },
-          },
-        ],
-      } as never,
-      {
-        reasoning: "medium",
-      } as never,
-    ) as { reasoning_effort?: unknown; tools?: unknown };
-
-    expect(params.tools).toHaveLength(1);
-    expect(params.reasoning_effort).toBe("medium");
-  });
-
-  it("keeps reasoning_effort for Azure gpt-5.5 Chat Completions payloads without tools", () => {
-    const params = buildOpenAICompletionsParams(
-      {
-        id: "gpt-5.5",
-        name: "GPT-5.5",
-        api: "openai-completions",
-        provider: "azure-openai",
-        baseUrl: "https://example.openai.azure.com/openai/v1",
+        provider: "openai",
+        baseUrl: "https://api.openai.com/v1",
         reasoning: true,
         input: ["text"],
         cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -6029,6 +6029,40 @@ describe("openai transport stream", () => {
     expect(params).not.toHaveProperty("reasoning_effort");
   });
 
+  it("omits reasoning_effort for custom provider ids backed by Azure GPT-5.5 endpoints", () => {
+    const params = buildOpenAICompletionsParams(
+      {
+        id: "prod-spud",
+        name: "GPT-5.5 (Azure)",
+        api: "openai-completions",
+        provider: "corp-azure-openai",
+        baseUrl: "https://corp-resource.openai.azure.com/openai/v1",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 1000000,
+        maxTokens: 128000,
+      } satisfies Model<"openai-completions">,
+      {
+        systemPrompt: "system",
+        messages: [],
+        tools: [
+          {
+            name: "lookup_weather",
+            description: "Get forecast",
+            parameters: { type: "object", properties: {}, additionalProperties: false },
+          },
+        ],
+      } as never,
+      {
+        reasoning: "medium",
+      } as never,
+    ) as { reasoning_effort?: unknown; tools?: unknown };
+
+    expect(params.tools).toHaveLength(1);
+    expect(params).not.toHaveProperty("reasoning_effort");
+  });
+
   it("keeps reasoning_effort for custom gpt-5.5 Chat Completions providers with tool payloads", () => {
     const params = buildOpenAICompletionsParams(
       {

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -84,6 +84,7 @@ import {
   normalizeOpenAIStrictToolParameters,
   resolveOpenAIStrictToolFlagForProjection,
 } from "./openai-tool-schema.js";
+import { resolveProviderEndpoint } from "./provider-attribution.js";
 import { resolveProviderRequestPolicyConfig } from "./provider-request-config.js";
 import {
   buildGuardedModelFetch,
@@ -4281,11 +4282,12 @@ export function buildOpenAICompletionsParams(
     rawCompat?.supportsReasoningEffort === true ||
     Array.isArray(rawCompat?.supportedReasoningEfforts) ||
     Boolean(rawCompat?.reasoningEffortMap && typeof rawCompat.reasoningEffortMap === "object");
+  const endpointClass = resolveProviderEndpoint(model.baseUrl).endpointClass;
   const omitChatCompletionsToolReasoningEffort =
     hasTools &&
     (isOpenAIGpt54MiniModel(model) ||
       (isOpenAIGpt55Model(model) &&
-        model.provider === "azure-openai" &&
+        endpointClass === "azure-openai" &&
         !hasExplicitReasoningEffortCompat));
   const handledQwenThinkingFormat = applyQwenOpenAICompletionsThinkingParams({
     compatThinkingFormat: compat.thinkingFormat,

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -4268,10 +4268,25 @@ export function buildOpenAICompletionsParams(
         fallbackMap: compat.reasoningEffortMap,
       })
     : undefined;
+  const rawCompat =
+    model.compat && typeof model.compat === "object"
+      ? (model.compat as {
+          supportsReasoningEffort?: unknown;
+          supportedReasoningEfforts?: unknown;
+          reasoningEffortMap?: unknown;
+        })
+      : undefined;
+  const hasTools = Array.isArray(params.tools) && params.tools.length > 0;
+  const hasExplicitReasoningEffortCompat =
+    rawCompat?.supportsReasoningEffort === true ||
+    Array.isArray(rawCompat?.supportedReasoningEfforts) ||
+    Boolean(rawCompat?.reasoningEffortMap && typeof rawCompat.reasoningEffortMap === "object");
   const omitChatCompletionsToolReasoningEffort =
-    (isOpenAIGpt54MiniModel(model) || isOpenAIGpt55Model(model)) &&
-    Array.isArray(params.tools) &&
-    params.tools.length > 0;
+    hasTools &&
+    (isOpenAIGpt54MiniModel(model) ||
+      (isOpenAIGpt55Model(model) &&
+        model.provider === "azure-openai" &&
+        !hasExplicitReasoningEffortCompat));
   const handledQwenThinkingFormat = applyQwenOpenAICompletionsThinkingParams({
     compatThinkingFormat: compat.thinkingFormat,
     modelReasoning: model.reasoning,

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -84,6 +84,7 @@ import {
   normalizeOpenAIStrictToolParameters,
   resolveOpenAIStrictToolFlagForProjection,
 } from "./openai-tool-schema.js";
+import { resolveProviderEndpoint } from "./provider-attribution.js";
 import { resolveProviderRequestPolicyConfig } from "./provider-request-config.js";
 import {
   buildGuardedModelFetch,
@@ -2554,6 +2555,18 @@ function isAzureOpenAICompatibleHost(hostname: string): boolean {
   );
 }
 
+function isKnownOpenAICompletionsEndpoint(model: Pick<Model, "baseUrl">): boolean {
+  const endpointClass = resolveProviderEndpoint(model.baseUrl).endpointClass;
+  if (endpointClass === "openai-public" || endpointClass === "azure-openai") {
+    return true;
+  }
+  try {
+    return isAzureOpenAICompatibleHost(new URL(model.baseUrl).hostname.toLowerCase());
+  } catch {
+    return false;
+  }
+}
+
 function buildOpenAICompletionsClientConfig(
   model: Model,
   context: Context,
@@ -4269,9 +4282,10 @@ export function buildOpenAICompletionsParams(
       })
     : undefined;
   const omitChatCompletionsToolReasoningEffort =
-    (isOpenAIGpt54MiniModel(model) || isOpenAIGpt55Model(model)) &&
     Array.isArray(params.tools) &&
-    params.tools.length > 0;
+    params.tools.length > 0 &&
+    (isOpenAIGpt54MiniModel(model) ||
+      (isOpenAIGpt55Model(model) && isKnownOpenAICompletionsEndpoint(model)));
   const handledQwenThinkingFormat = applyQwenOpenAICompletionsThinkingParams({
     compatThinkingFormat: compat.thinkingFormat,
     modelReasoning: model.reasoning,

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -60,6 +60,7 @@ import {
 import { resolveOpenAIReasoningEffortMap } from "./openai-reasoning-compat.js";
 import {
   isOpenAIGpt54MiniModel,
+  isOpenAIGpt55Model,
   normalizeOpenAIReasoningEffort,
   resolveOpenAIReasoningEffortForModel,
   type OpenAIApiReasoningEffort,
@@ -4267,8 +4268,10 @@ export function buildOpenAICompletionsParams(
         fallbackMap: compat.reasoningEffortMap,
       })
     : undefined;
-  const omitGpt54MiniToolReasoningEffort =
-    isOpenAIGpt54MiniModel(model) && Array.isArray(params.tools) && params.tools.length > 0;
+  const omitChatCompletionsToolReasoningEffort =
+    (isOpenAIGpt54MiniModel(model) || isOpenAIGpt55Model(model)) &&
+    Array.isArray(params.tools) &&
+    params.tools.length > 0;
   const handledQwenThinkingFormat = applyQwenOpenAICompletionsThinkingParams({
     compatThinkingFormat: compat.thinkingFormat,
     modelReasoning: model.reasoning,
@@ -4294,7 +4297,7 @@ export function buildOpenAICompletionsParams(
     model.reasoning &&
     compat.supportsReasoningEffort &&
     !handledQwenThinkingFormat &&
-    !omitGpt54MiniToolReasoningEffort
+    !omitChatCompletionsToolReasoningEffort
   ) {
     params.reasoning_effort = resolvedCompletionsReasoningEffort;
   }

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -2556,6 +2556,9 @@ function isAzureOpenAICompatibleHost(hostname: string): boolean {
 }
 
 function isKnownOpenAICompletionsEndpoint(model: Pick<Model, "baseUrl">): boolean {
+  if (!model.baseUrl.trim()) {
+    return true;
+  }
   const endpointClass = resolveProviderEndpoint(model.baseUrl).endpointClass;
   if (endpointClass === "openai-public" || endpointClass === "azure-openai") {
     return true;

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -84,7 +84,6 @@ import {
   normalizeOpenAIStrictToolParameters,
   resolveOpenAIStrictToolFlagForProjection,
 } from "./openai-tool-schema.js";
-import { resolveProviderEndpoint } from "./provider-attribution.js";
 import { resolveProviderRequestPolicyConfig } from "./provider-request-config.js";
 import {
   buildGuardedModelFetch,
@@ -2555,14 +2554,6 @@ function isAzureOpenAICompatibleHost(hostname: string): boolean {
   );
 }
 
-function hasAzureOpenAICompatibleBaseUrl(model: Pick<Model, "baseUrl">): boolean {
-  try {
-    return isAzureOpenAICompatibleHost(new URL(model.baseUrl).hostname.toLowerCase());
-  } catch {
-    return false;
-  }
-}
-
 function buildOpenAICompletionsClientConfig(
   model: Model,
   context: Context,
@@ -4277,28 +4268,10 @@ export function buildOpenAICompletionsParams(
         fallbackMap: compat.reasoningEffortMap,
       })
     : undefined;
-  const rawCompat =
-    model.compat && typeof model.compat === "object"
-      ? (model.compat as {
-          supportsReasoningEffort?: unknown;
-          supportedReasoningEfforts?: unknown;
-          reasoningEffortMap?: unknown;
-        })
-      : undefined;
-  const hasTools = Array.isArray(params.tools) && params.tools.length > 0;
-  const hasExplicitReasoningEffortCompat =
-    rawCompat?.supportsReasoningEffort === true ||
-    Array.isArray(rawCompat?.supportedReasoningEfforts) ||
-    Boolean(rawCompat?.reasoningEffortMap && typeof rawCompat.reasoningEffortMap === "object");
-  const endpointClass = resolveProviderEndpoint(model.baseUrl).endpointClass;
-  const isAzureChatCompletionsEndpoint =
-    endpointClass === "azure-openai" || hasAzureOpenAICompatibleBaseUrl(model);
   const omitChatCompletionsToolReasoningEffort =
-    hasTools &&
-    (isOpenAIGpt54MiniModel(model) ||
-      (isOpenAIGpt55Model(model) &&
-        isAzureChatCompletionsEndpoint &&
-        !hasExplicitReasoningEffortCompat));
+    (isOpenAIGpt54MiniModel(model) || isOpenAIGpt55Model(model)) &&
+    Array.isArray(params.tools) &&
+    params.tools.length > 0;
   const handledQwenThinkingFormat = applyQwenOpenAICompletionsThinkingParams({
     compatThinkingFormat: compat.thinkingFormat,
     modelReasoning: model.reasoning,

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -2555,6 +2555,14 @@ function isAzureOpenAICompatibleHost(hostname: string): boolean {
   );
 }
 
+function hasAzureOpenAICompatibleBaseUrl(model: Pick<Model, "baseUrl">): boolean {
+  try {
+    return isAzureOpenAICompatibleHost(new URL(model.baseUrl).hostname.toLowerCase());
+  } catch {
+    return false;
+  }
+}
+
 function buildOpenAICompletionsClientConfig(
   model: Model,
   context: Context,
@@ -4283,11 +4291,13 @@ export function buildOpenAICompletionsParams(
     Array.isArray(rawCompat?.supportedReasoningEfforts) ||
     Boolean(rawCompat?.reasoningEffortMap && typeof rawCompat.reasoningEffortMap === "object");
   const endpointClass = resolveProviderEndpoint(model.baseUrl).endpointClass;
+  const isAzureChatCompletionsEndpoint =
+    endpointClass === "azure-openai" || hasAzureOpenAICompatibleBaseUrl(model);
   const omitChatCompletionsToolReasoningEffort =
     hasTools &&
     (isOpenAIGpt54MiniModel(model) ||
       (isOpenAIGpt55Model(model) &&
-        endpointClass === "azure-openai" &&
+        isAzureChatCompletionsEndpoint &&
         !hasExplicitReasoningEffortCompat));
   const handledQwenThinkingFormat = applyQwenOpenAICompletionsThinkingParams({
     compatThinkingFormat: compat.thinkingFormat,

--- a/src/agents/provider-attribution.test.ts
+++ b/src/agents/provider-attribution.test.ts
@@ -17,7 +17,11 @@ const providerEndpointPlugins = vi.hoisted(() => [
   {
     // Mirrors manifest-declared endpoint metadata without loading real plugins.
     providerEndpoints: [
-      { endpointClass: "openai-public", hosts: ["api.openai.com"] },
+      {
+        endpointClass: "openai-public",
+        hosts: ["api.openai.com"],
+        hostSuffixes: [".api.openai.com"],
+      },
       { endpointClass: "openai", hosts: ["chatgpt.com"] },
       { endpointClass: "azure-openai", hostSuffixes: [".openai.azure.com"] },
       { endpointClass: "anthropic-public", hosts: ["api.anthropic.com"] },
@@ -859,6 +863,11 @@ describe("provider attribution", () => {
       hostname: "api.openai.com.attacker.example",
     });
 
+    expectRecordFields(resolveProviderEndpoint("https://attackerapi.openai.com"), {
+      endpointClass: "custom",
+      hostname: "attackerapi.openai.com",
+    });
+
     expectRecordFields(resolveProviderEndpoint("attacker.example/?target=api.openai.com"), {
       endpointClass: "custom",
       hostname: "attacker.example",
@@ -869,6 +878,15 @@ describe("provider attribution", () => {
       hostname: "openrouter.ai.attacker.example",
     });
   });
+
+  it.each(["https://us.api.openai.com/v1", "https://eu.api.openai.com/v1"])(
+    "classifies regional OpenAI endpoint %s as public",
+    (baseUrl) => {
+      expectRecordFields(resolveProviderEndpoint(baseUrl), {
+        endpointClass: "openai-public",
+      });
+    },
+  );
 
   it("ignores non-http schemes when normalizing native comparable base URLs", () => {
     expectRecordFields(resolveProviderEndpoint("javascript:alert(1)"), {


### PR DESCRIPTION
## Summary

- Omit `reasoning_effort` only when GPT-5.5 Chat Completions requests include function tools on routes that ultimately target OpenAI: the SDK default, public and regional OpenAI API hosts, Azure OpenAI, Foundry, and Cognitive Services endpoints.
- Preserve normal reasoning effort for GPT-5.5 requests without tools and for nonblank custom OpenAI-compatible endpoints.
- Centralize official regional OpenAI host classification in the OpenAI plugin manifest and add hostname-boundary regression coverage.

## Root cause

GPT-5.5 accepts Chat Completions tools and `reasoning_effort` separately, but current OpenAI and Azure deployments reject the combination. OpenClaw was projecting both fields into tool requests.

## Behavior

Tool payloads remain unchanged except for removing the incompatible `reasoning_effort` field on the affected GPT-5.5 routes. GPT-5.4-mini's existing behavior is unchanged. Anthropic request shaping is untouched.

## Verification

- `pnpm test extensions/openai/openclaw.plugin.test.ts src/agents/provider-attribution.test.ts src/agents/openai-reasoning-effort.test.ts src/agents/openai-transport-stream.test.ts src/agents/openai-tool-projection.test.ts src/agents/anthropic-transport-stream.test.ts -- --reporter=dot` — 406 tests passed.
- `OPENCLAW_LIVE_TEST=1 OPENAI_LIVE_TEST=1 OPENCLAW_LIVE_OPENAI_TOOL_MODEL=gpt-5.5 pnpm test:live -- src/agents/openai-tool-projection.live.test.ts --reporter=verbose` — 3 live OpenAI scenarios passed, including a real GPT-5.5 Chat Completions function call.
- `OPENCLAW_LIVE_TEST=1 ANTHROPIC_LIVE_TEST=1 ANTHROPIC_TRANSPORT_LIVE_TEST=1 pnpm test:live -- src/agents/anthropic-transport-stream.live.test.ts --reporter=verbose` — 3 live Anthropic transport/tool scenarios passed.
- AWS Crabbox `cbx_d341ceb0134d`, run `run_81ca973b5d3a` — `corepack pnpm check:changed` passed all selected core, core-test, extension, and extension-test lanes.
- Fresh whole-branch autoreview: no accepted or actionable findings.

## Real behavior proof

Behavior addressed: GPT-5.5 Chat Completions function calls no longer fail because tools and `reasoning_effort` are sent together.

Real environment tested: Official OpenAI API with GPT-5.5 Chat Completions and Responses; official Anthropic API through both native transport and SDK paths; contributor Azure OpenAI gateway/deployment proof in the PR discussion.

Exact steps or command run after this patch: The live commands listed under Verification were run from the rebased branch head. The contributor also ran the branch-built Azure request path against the configured deployment.

Evidence after fix: Copied live console output from the rebased branch head:
```text
PASS OpenAI Responses healthy function call
PASS OpenAI GPT-5.5 Chat Completions function call without incompatible reasoning effort
PASS OpenAI code-mode tools after payload hook mutation
PASS Anthropic native transport forced tool call
PASS Anthropic SDK forced tool call
Azure HTTP 200; finishReason: tool_calls; tool call count: 1
```

Observed result after fix: Official OpenAI and Azure tool calls succeed without the incompatible field. Anthropic tool calling remains healthy. Custom nonblank compatible endpoints retain their configured reasoning effort.

What was not tested: Maintainer-local Azure credentials were unavailable, so Azure proof comes from the contributor's branch-built live run. Regional OpenAI hostname behavior is covered by official endpoint metadata and boundary tests rather than a live regional project.

## Risk

Request shaping changes only for GPT-5.5 Chat Completions payloads with tools on verified OpenAI/Azure routes. Tests cover default, public, regional, Azure, Foundry, Cognitive Services, custom-provider, no-tools, attacker-host, OpenAI live, and Anthropic live behavior.
