### PR TITLE
fix(sessions): reconcile stale terminal main transcripts

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.runtime.ts
+++ b/extensions/telegram/src/bot-message-dispatch.runtime.ts
@@ -4,6 +4,7 @@ export {
   readLatestAssistantTextFromSessionTranscript,
   resolveAndPersistSessionFile,
   resolveSessionStoreEntry,
+  updateSessionStoreEntry,
 } from "openclaw/plugin-sdk/session-store-runtime";
 export { resolveMarkdownTableMode } from "openclaw/plugin-sdk/markdown-table-runtime";
 export { getAgentScopedMediaLocalRoots } from "openclaw/plugin-sdk/media-runtime";

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -70,7 +70,11 @@ const createChannelMessageReplyPipeline = vi.hoisted(() =>
 );
 const wasSentByBot = vi.hoisted(() => vi.fn(() => false));
 const appendSessionTranscriptMessage = vi.hoisted(() =>
-  vi.fn(async (_params: { message?: unknown }) => ({ messageId: "m1" })),
+  vi.fn(async ({ message }: { message?: unknown }) => ({
+    messageId: "m1",
+    message,
+    appended: true,
+  })),
 );
 const emitSessionTranscriptUpdate = vi.hoisted(() => vi.fn());
 const loadSessionStore = vi.hoisted(() => vi.fn());
@@ -101,6 +105,7 @@ const resolveSessionStoreEntry = vi.hoisted(() =>
     existing: store[sessionKey],
   })),
 );
+const updateSessionStoreEntry = vi.hoisted(() => vi.fn(async () => null));
 
 vi.mock("./draft-stream.js", () => ({
   createTelegramDraftStream,
@@ -155,6 +160,7 @@ vi.mock("./bot-message-dispatch.runtime.js", () => ({
   resolveMarkdownTableMode,
   resolveSessionStoreEntry,
   resolveStorePath,
+  updateSessionStoreEntry,
 }));
 
 vi.mock("./bot-message-dispatch.agent.runtime.js", () => ({
@@ -268,11 +274,13 @@ describe("dispatchTelegramMessage draft streaming", () => {
     loadSessionStore.mockReset();
     resolveStorePath.mockReset();
     resolveAndPersistSessionFile.mockReset();
+    updateSessionStoreEntry.mockReset();
     generateTopicLabel.mockReset();
     getAgentScopedMediaLocalRoots.mockClear();
     resolveChunkMode.mockClear();
     resolveMarkdownTableMode.mockClear();
     resolveSessionStoreEntry.mockClear();
+    updateSessionStoreEntry.mockClear();
     describeStickerImage.mockReset();
     loadModelCatalog.mockReset();
     findModelInCatalog.mockReset();
@@ -1443,6 +1451,29 @@ describe("dispatchTelegramMessage draft streaming", () => {
       sessionKey: "agent:default:telegram:direct:123",
       messageId: "m1",
     });
+  });
+
+  it("advances the session marker after mirroring preview-finalized finals", async () => {
+    setupDraftStreams({ answerMessageId: 2001 });
+    const context = createContext();
+    context.ctxPayload.SessionKey = "agent:default:telegram:direct:123";
+    loadSessionStore.mockReturnValue({
+      "agent:default:telegram:direct:123": { sessionId: "s1" },
+    });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver({ text: "Final answer" }, { kind: "final" });
+      return { queuedFinal: true };
+    });
+
+    await dispatchWithContext({ context });
+
+    const markerUpdateCall = expectRecordFields(mockCallArg(updateSessionStoreEntry), {
+      storePath: "/tmp/sessions.json",
+      sessionKey: "agent:default:telegram:direct:123",
+    });
+    const update = markerUpdateCall.update as (entry: { sessionId?: string }) => unknown;
+    expect(update({ sessionId: "s1" })).toEqual({ updatedAt: expect.any(Number) });
+    expect(update({ sessionId: "new-session" })).toBeNull();
   });
 
   it("does not mirror non-final tool progress into the session transcript", async () => {

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -1576,6 +1576,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     });
     appendSessionTranscriptMessage.mockImplementationOnce(async ({ message }) => ({
       messageId: "m1",
+      appended: true,
       message: {
         ...(message as Record<string, unknown>),
         content: [{ type: "text", text: "Final sk-abc…0xyz" }],

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -79,6 +79,7 @@ import {
   resolveMarkdownTableMode,
   resolveAndPersistSessionFile,
   resolveSessionStoreEntry,
+  updateSessionStoreEntry,
 } from "./bot-message-dispatch.runtime.js";
 import type { TelegramBotOptions } from "./bot.types.js";
 import { deliverReplies, emitInternalMessageSentHook } from "./bot/delivery.js";
@@ -373,11 +374,26 @@ async function mirrorTelegramAssistantReplyToTranscript(params: {
     stopReason: "stop" as const,
     timestamp: Date.now(),
   };
-  const { messageId, message: appendedMessage } = await appendSessionTranscriptMessage({
+  const {
+    appended,
+    messageId,
+    message: appendedMessage,
+  } = await appendSessionTranscriptMessage({
     transcriptPath: sessionFile,
     message,
     config: params.cfg,
   });
+  if (appended) {
+    const transcriptMarkerUpdatedAt = Date.now();
+    await updateSessionStoreEntry({
+      storePath,
+      sessionKey: params.sessionKey,
+      update: (current) =>
+        current.sessionId === sessionEntry.sessionId
+          ? { updatedAt: transcriptMarkerUpdatedAt }
+          : null,
+    });
+  }
   emitSessionTranscriptUpdate({
     sessionFile,
     sessionKey: params.sessionKey,

--- a/src/agents/cli-session.ts
+++ b/src/agents/cli-session.ts
@@ -138,8 +138,13 @@ export function clearCliSession(entry: SessionEntry, provider: string): void {
   }
 }
 
+type MutableCliSessionFields = Pick<
+  SessionEntry,
+  "cliSessionBindings" | "cliSessionIds" | "claudeCliSessionId"
+>;
+
 /** Remove every CLI session binding from a session entry. */
-export function clearAllCliSessions(entry: SessionEntry): void {
+export function clearAllCliSessions(entry: Partial<MutableCliSessionFields>): void {
   entry.cliSessionBindings = undefined;
   entry.cliSessionIds = undefined;
   entry.claudeCliSessionId = undefined;

--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -693,30 +693,62 @@ describe("CLI attempt execution", () => {
 
   it("persists CLI replies into the session transcript", async () => {
     const sessionKey = "agent:main:subagent:cli-transcript";
+    const sessionFile = path.join(tmpDir, "session-cli-transcript.jsonl");
     const sessionEntry: SessionEntry = {
       sessionId: "session-cli-transcript",
-      updatedAt: Date.now(),
+      sessionFile,
+      updatedAt: 1,
+      status: "running",
+      startedAt: 2,
     };
     const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
-    await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2), "utf-8");
-
-    const updatedEntry = await persistCliTurnTranscript({
-      body: "persist this",
-      result: makeCliResult("hello from cli"),
-      sessionId: sessionEntry.sessionId,
-      sessionKey,
-      sessionEntry,
-      sessionStore,
+    await fs.writeFile(
       storePath,
-      sessionAgentId: "main",
-      sessionCwd: tmpDir,
-      config: {},
-    });
+      JSON.stringify(
+        {
+          [sessionKey]: {
+            ...sessionEntry,
+            updatedAt: 5,
+            status: "done",
+            endedAt: 4,
+          },
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
 
-    const sessionFile = updatedEntry?.sessionFile;
-    if (!sessionFile) {
+    const nowCalls: number[] = [];
+    let nextNow = 10_000;
+    const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => {
+      nextNow += 1_000;
+      nowCalls.push(nextNow);
+      return nextNow;
+    });
+    let updatedEntry: SessionEntry | undefined;
+    try {
+      updatedEntry = await persistCliTurnTranscript({
+        body: "persist this",
+        result: makeCliResult("hello from cli"),
+        sessionId: sessionEntry.sessionId,
+        sessionKey,
+        sessionEntry,
+        sessionStore,
+        storePath,
+        sessionAgentId: "main",
+        sessionCwd: tmpDir,
+        config: {},
+      });
+    } finally {
+      nowSpy.mockRestore();
+    }
+
+    const updatedSessionFile = updatedEntry?.sessionFile;
+    if (!updatedSessionFile) {
       throw new Error("expected CLI transcript persistence to create a session file");
     }
+    expect(updatedSessionFile).toBe(sessionFile);
     const entries = await readSessionFileEntries(sessionFile);
     expectRecordFields(requireRecord(entries[0], "session entry"), {
       type: "session",
@@ -744,6 +776,18 @@ describe("CLI attempt execution", () => {
       model: "opus",
       content: [{ type: "text", text: "hello from cli" }],
     });
+
+    const persisted = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
+      string,
+      SessionEntry
+    >;
+    expect(persisted[sessionKey]?.sessionFile).toBe(sessionFile);
+    expect(persisted[sessionKey]?.updatedAt).toBeGreaterThan(sessionEntry.updatedAt);
+    expect(persisted[sessionKey]?.updatedAt).toBeLessThan(nowCalls.at(-1) ?? 0);
+    expect(persisted[sessionKey]?.status).toBe("done");
+    expect(persisted[sessionKey]?.endedAt).toBe(4);
+    expect(persisted[sessionKey]?.startedAt).toBe(2);
+    expect(sessionStore[sessionKey]?.updatedAt).toBe(persisted[sessionKey]?.updatedAt);
   });
 
   it("embedded assistant gap-fill skips user mirror and dedupes identical assistant tails", async () => {

--- a/src/agents/command/attempt-execution.shared.ts
+++ b/src/agents/command/attempt-execution.shared.ts
@@ -21,10 +21,16 @@ export type PersistSessionEntryParams = {
   storePath: string;
   entry: SessionEntry;
   clearedFields?: string[];
+  preserveTranscriptMarkerUpdatedAt?: boolean;
   shouldPersist?: (entry: SessionEntry | undefined) => boolean;
 };
 
 /** Persists one session entry while keeping the caller's in-memory store aligned. */
+
+function normalizeTranscriptMarkerUpdatedAt(value: number | undefined): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined;
+}
+
 export async function persistSessionEntry(
   params: PersistSessionEntryParams,
 ): Promise<SessionEntry | undefined> {
@@ -36,6 +42,13 @@ export async function persistSessionEntry(
         return current;
       }
       const merged = mergeSessionEntry(store[params.sessionKey], params.entry);
+      if (params.preserveTranscriptMarkerUpdatedAt) {
+        const currentUpdatedAt = normalizeTranscriptMarkerUpdatedAt(current?.updatedAt);
+        const markerUpdatedAt = normalizeTranscriptMarkerUpdatedAt(params.entry.updatedAt);
+        if (markerUpdatedAt !== undefined) {
+          merged.updatedAt = Math.max(currentUpdatedAt ?? 0, markerUpdatedAt);
+        }
+      }
       for (const field of params.clearedFields ?? []) {
         // Cleared fields only apply when the replacement entry did not set the
         // field again; this preserves explicit false/null updates.

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -48,6 +48,7 @@ import {
   claudeCliSessionTranscriptHasContent,
   resolveFallbackRetryPrompt,
 } from "./attempt-execution.helpers.js";
+import { persistSessionEntry } from "./attempt-execution.shared.js";
 import { resolveAgentRunContext } from "./run-context.js";
 import { clearCliSessionInStore } from "./session-store.js";
 import type { AgentCommandOpts } from "./types.js";

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -244,7 +244,9 @@ async function persistTextTurnTranscript(
     ...resolveSessionWriteLockOptions(params.config),
     allowReentrant: true,
   });
+  let transcriptMarkerUpdatedAt: number | undefined;
   try {
+    let wroteTranscript = false;
     const userMessage = params.userMessage;
     if (userMessage || promptText) {
       await appendUserTurnTranscriptMessage({
@@ -264,6 +266,7 @@ async function persistTextTurnTranscript(
             }),
         updateMode: "none",
       });
+      wroteTranscript = true;
     }
 
     if (replyText) {
@@ -293,10 +296,36 @@ async function persistTextTurnTranscript(
             timestamp: Date.now(),
           },
         });
+        wroteTranscript = true;
       }
+    }
+    if (wroteTranscript) {
+      transcriptMarkerUpdatedAt = Date.now();
     }
   } finally {
     await lock.release();
+  }
+
+  let updatedSessionEntry = sessionEntry;
+  if (params.sessionStore && params.storePath && transcriptMarkerUpdatedAt !== undefined) {
+    const currentEntry = params.sessionStore[params.sessionKey] ?? sessionEntry;
+    if (currentEntry?.sessionId === params.sessionId) {
+      // Keep updatedAt as the registry marker for transcript writes we own.
+      // Session reuse checks compare transcript mtime against this marker, not endedAt.
+      updatedSessionEntry =
+        (await persistSessionEntry({
+          sessionStore: params.sessionStore,
+          sessionKey: params.sessionKey,
+          storePath: params.storePath,
+          entry: {
+            sessionId: params.sessionId,
+            sessionFile,
+            updatedAt: transcriptMarkerUpdatedAt,
+          },
+          preserveTranscriptMarkerUpdatedAt: true,
+          shouldPersist: (current) => current?.sessionId === params.sessionId,
+        })) ?? updatedSessionEntry;
+    }
   }
 
   emitSessionTranscriptUpdate({
@@ -304,7 +333,7 @@ async function persistTextTurnTranscript(
     sessionKey: params.sessionKey,
     agentId: params.sessionAgentId,
   });
-  return sessionEntry;
+  return updatedSessionEntry;
 }
 
 function resolveCliTranscriptReplyText(result: EmbeddedAgentRunResult): string {

--- a/src/agents/command/session.ts
+++ b/src/agents/command/session.ts
@@ -70,6 +70,8 @@ function clearRotatedTerminalMainSessionMetadata(
     endedAt: undefined,
     runtimeMs: undefined,
     abortedLastRun: undefined,
+    sessionStartedAt: undefined,
+    lastInteractionAt: undefined,
   };
 }
 
@@ -362,16 +364,18 @@ export function resolveSession(opts: {
     resetType,
     resetOverride: channelReset,
   });
-  const terminalMainTranscriptNewerThanRegistry = sessionEntry
-    ? hasTerminalMainSessionTranscriptNewerThanRegistrySync({
-        entry: sessionEntry,
-        sessionScope: sessionCfg?.scope,
-        sessionKey,
-        agentId: sessionAgentId,
-        mainKey: sessionCfg?.mainKey,
-        storePath,
-      })
-    : false;
+  const requestedSessionId = opts.sessionId?.trim() || undefined;
+  const terminalMainTranscriptNewerThanRegistry =
+    sessionEntry && !requestedSessionId
+      ? hasTerminalMainSessionTranscriptNewerThanRegistrySync({
+          entry: sessionEntry,
+          sessionScope: sessionCfg?.scope,
+          sessionKey,
+          agentId: sessionAgentId,
+          mainKey: sessionCfg?.mainKey,
+          storePath,
+        })
+      : false;
   const fresh = sessionEntry
     ? !terminalMainTranscriptNewerThanRegistry &&
       evaluateSessionFreshness({
@@ -386,8 +390,8 @@ export function resolveSession(opts: {
       }).fresh
     : false;
   const sessionId =
-    opts.sessionId?.trim() || (fresh ? sessionEntry?.sessionId : undefined) || crypto.randomUUID();
-  const isNewSession = !fresh && !opts.sessionId;
+    requestedSessionId || (fresh ? sessionEntry?.sessionId : undefined) || crypto.randomUUID();
+  const isNewSession = !fresh && !requestedSessionId;
   const resolvedSessionEntry = terminalMainTranscriptNewerThanRegistry
     ? clearRotatedTerminalMainSessionMetadata(sessionEntry)
     : sessionEntry;

--- a/src/agents/command/session.ts
+++ b/src/agents/command/session.ts
@@ -9,7 +9,10 @@ import {
   type ThinkLevel,
   type VerboseLevel,
 } from "../../auto-reply/thinking.js";
-import { resolveSessionLifecycleTimestamps } from "../../config/sessions/lifecycle.js";
+import {
+  hasTerminalMainSessionTranscriptNewerThanRegistrySync,
+  resolveSessionLifecycleTimestamps,
+} from "../../config/sessions/lifecycle.js";
 import {
   resolveAgentIdFromSessionKey,
   resolveExplicitAgentSessionKey,
@@ -52,6 +55,23 @@ type SessionKeyResolution = {
   sessionStore: Record<string, SessionEntry>;
   storePath: string;
 };
+
+function clearRotatedTerminalMainSessionMetadata(
+  entry: SessionEntry | undefined,
+): SessionEntry | undefined {
+  if (!entry) {
+    return undefined;
+  }
+  return {
+    ...entry,
+    sessionFile: undefined,
+    status: undefined,
+    startedAt: undefined,
+    endedAt: undefined,
+    runtimeMs: undefined,
+    abortedLastRun: undefined,
+  };
+}
 
 type SessionIdMatchSet = {
   matches: Array<[string, SessionEntry]>;
@@ -328,6 +348,9 @@ export function resolveSession(opts: {
   const now = Date.now();
 
   const sessionEntry = sessionKey ? sessionStore[sessionKey] : undefined;
+  const sessionAgentId = opts.agentId?.trim()
+    ? normalizeAgentId(opts.agentId)
+    : resolveAgentIdFromSessionKey(sessionKey);
 
   const resetType = resolveSessionResetType({ sessionKey });
   const channelReset = resolveChannelResetConfig({
@@ -339,12 +362,23 @@ export function resolveSession(opts: {
     resetType,
     resetOverride: channelReset,
   });
+  const terminalMainTranscriptNewerThanRegistry = sessionEntry
+    ? hasTerminalMainSessionTranscriptNewerThanRegistrySync({
+        entry: sessionEntry,
+        sessionScope: sessionCfg?.scope,
+        sessionKey,
+        agentId: sessionAgentId,
+        mainKey: sessionCfg?.mainKey,
+        storePath,
+      })
+    : false;
   const fresh = sessionEntry
-    ? evaluateSessionFreshness({
+    ? !terminalMainTranscriptNewerThanRegistry &&
+      evaluateSessionFreshness({
         updatedAt: sessionEntry.updatedAt,
         ...resolveSessionLifecycleTimestamps({
           entry: sessionEntry,
-          agentId: opts.agentId,
+          agentId: sessionAgentId,
           storePath,
         }),
         now,
@@ -354,6 +388,9 @@ export function resolveSession(opts: {
   const sessionId =
     opts.sessionId?.trim() || (fresh ? sessionEntry?.sessionId : undefined) || crypto.randomUUID();
   const isNewSession = !fresh && !opts.sessionId;
+  const resolvedSessionEntry = terminalMainTranscriptNewerThanRegistry
+    ? clearRotatedTerminalMainSessionMetadata(sessionEntry)
+    : sessionEntry;
 
   clearBootstrapSnapshotOnSessionRollover({
     sessionKey,
@@ -372,7 +409,7 @@ export function resolveSession(opts: {
   return {
     sessionId,
     sessionKey,
-    sessionEntry,
+    sessionEntry: resolvedSessionEntry,
     sessionStore,
     storePath,
     isNewSession,

--- a/src/agents/command/session.ts
+++ b/src/agents/command/session.ts
@@ -37,6 +37,7 @@ import {
 import { resolveSessionIdMatchSelection } from "../../sessions/session-id-resolution.js";
 import { listAgentIds, resolveDefaultAgentId } from "../agent-scope.js";
 import { clearBootstrapSnapshotOnSessionRollover } from "../bootstrap-cache.js";
+import { clearAllCliSessions } from "../cli-session.js";
 
 /** Resolved command session identity plus backing store metadata. */
 export type SessionResolution = {
@@ -62,7 +63,7 @@ function clearRotatedTerminalMainSessionMetadata(
   if (!entry) {
     return undefined;
   }
-  return {
+  const next = {
     ...entry,
     sessionFile: undefined,
     status: undefined,
@@ -73,6 +74,8 @@ function clearRotatedTerminalMainSessionMetadata(
     sessionStartedAt: undefined,
     lastInteractionAt: undefined,
   };
+  clearAllCliSessions(next);
+  return next;
 }
 
 type SessionIdMatchSet = {

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -186,6 +186,7 @@ async function writeTerminalTranscriptSessionStore(params: {
   sessionKey: string;
   sessionId: string;
   status?: SessionEntry["status"];
+  omitStatus?: boolean;
   updatedAt: number;
   endedAt: number;
   transcriptMtimeMs: number;
@@ -198,6 +199,7 @@ async function writeTerminalTranscriptSessionStore(params: {
     "utf-8",
   );
   await fs.utimes(transcriptPath, params.transcriptMtimeMs / 1000, params.transcriptMtimeMs / 1000);
+  const status = params.status ?? (params.omitStatus ? undefined : "done");
   await writeSessionStoreFast(params.storePath, {
     [params.sessionKey]: {
       sessionId: params.sessionId,
@@ -206,7 +208,7 @@ async function writeTerminalTranscriptSessionStore(params: {
       startedAt: params.endedAt - 10_000,
       endedAt: params.endedAt,
       runtimeMs: 9_000,
-      status: params.status ?? "done",
+      ...(status ? { status } : {}),
     },
   });
 }
@@ -1642,6 +1644,15 @@ describe("initSessionState reset policy", () => {
       expectNewSession: true,
     },
     {
+      name: "main endedAt-only rows rotate when transcript is newer than updatedAt",
+      sessionKey: "agent:main:main",
+      updatedAtOffsetMs: -10_000,
+      endedAtOffsetMs: -11_000,
+      transcriptMtimeOffsetMs: 0,
+      omitStatus: true,
+      expectNewSession: true,
+    },
+    {
       name: "failed main terminal rows reuse when the transcript exists",
       sessionKey: "agent:main:main",
       status: "failed" as const,
@@ -1687,6 +1698,7 @@ describe("initSessionState reset policy", () => {
       sessionKey: scenario.sessionKey,
       sessionId: existingSessionId,
       status: scenario.status,
+      omitStatus: scenario.omitStatus,
       updatedAt: terminalUpdatedAt,
       endedAt: terminalEndedAt,
       transcriptMtimeMs: now + scenario.transcriptMtimeOffsetMs,

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -181,6 +181,36 @@ async function writeSessionStoreFast(
   await fs.writeFile(storePath, JSON.stringify(store), "utf-8");
 }
 
+async function writeTerminalTranscriptSessionStore(params: {
+  storePath: string;
+  sessionKey: string;
+  sessionId: string;
+  status?: SessionEntry["status"];
+  updatedAt: number;
+  endedAt: number;
+  transcriptMtimeMs: number;
+}): Promise<void> {
+  const sessionFile = `${params.sessionId}.jsonl`;
+  const transcriptPath = path.join(path.dirname(params.storePath), sessionFile);
+  await fs.writeFile(
+    transcriptPath,
+    `${JSON.stringify({ type: "session", id: params.sessionId })}\n`,
+    "utf-8",
+  );
+  await fs.utimes(transcriptPath, params.transcriptMtimeMs / 1000, params.transcriptMtimeMs / 1000);
+  await writeSessionStoreFast(params.storePath, {
+    [params.sessionKey]: {
+      sessionId: params.sessionId,
+      sessionFile,
+      updatedAt: params.updatedAt,
+      startedAt: params.endedAt - 10_000,
+      endedAt: params.endedAt,
+      runtimeMs: 9_000,
+      status: params.status ?? "done",
+    },
+  });
+}
+
 function setMinimalCurrentConversationBindingRegistryForTests(): void {
   setActivePluginRegistry(
     createTestRegistry([
@@ -1592,6 +1622,101 @@ describe("initSessionState reset policy", () => {
     expect(persisted[sessionKey]?.startedAt).toBe(Date.now() - 10_000);
     expect(persisted[sessionKey]?.endedAt).toBe(Date.now() - 1_000);
     expect(persisted[sessionKey]?.runtimeMs).toBe(9_000);
+  });
+
+  it.each([
+    {
+      name: "non-main terminal rows ignore transcript mtime",
+      sessionKey: "agent:main:whatsapp:dm:terminal-entry",
+      updatedAtOffsetMs: -5_000,
+      endedAtOffsetMs: -6_000,
+      transcriptMtimeOffsetMs: -3_000,
+      expectNewSession: false,
+    },
+    {
+      name: "main terminal rows rotate when transcript is newer than updatedAt",
+      sessionKey: "agent:main:main",
+      updatedAtOffsetMs: -10_000,
+      endedAtOffsetMs: -11_000,
+      transcriptMtimeOffsetMs: 0,
+      expectNewSession: true,
+    },
+    {
+      name: "failed main terminal rows reuse when the transcript exists",
+      sessionKey: "agent:main:main",
+      status: "failed" as const,
+      updatedAtOffsetMs: -10_000,
+      endedAtOffsetMs: -11_000,
+      transcriptMtimeOffsetMs: 0,
+      expectNewSession: false,
+    },
+    {
+      name: "main terminal rows reuse when updatedAt already reflects the transcript",
+      sessionKey: "agent:main:main",
+      updatedAtOffsetMs: -1_000,
+      endedAtOffsetMs: -6_000,
+      transcriptMtimeOffsetMs: -4_000,
+      expectNewSession: false,
+    },
+    {
+      name: "main terminal rows reuse when transcript mtime differs only by sub-millisecond precision",
+      sessionKey: "agent:main:main",
+      updatedAtOffsetMs: -4_000,
+      endedAtOffsetMs: -6_000,
+      transcriptMtimeOffsetMs: -3_999.5,
+      expectNewSession: false,
+    },
+    {
+      name: "main terminal rows reuse when transcript is not newer than updatedAt",
+      sessionKey: "agent:main:main",
+      updatedAtOffsetMs: -10_000,
+      endedAtOffsetMs: -11_000,
+      transcriptMtimeOffsetMs: -15_000,
+      expectNewSession: false,
+    },
+  ])("$name", async (scenario) => {
+    vi.setSystemTime(new Date(2026, 0, 18, 5, 30, 0));
+    const root = await makeCaseDir("openclaw-reset-terminal-entry-");
+    const storePath = path.join(root, "sessions.json");
+    const existingSessionId = "terminal-entry-old";
+    const now = Date.now();
+    const terminalUpdatedAt = now + scenario.updatedAtOffsetMs;
+    const terminalEndedAt = now + scenario.endedAtOffsetMs;
+    await writeTerminalTranscriptSessionStore({
+      storePath,
+      sessionKey: scenario.sessionKey,
+      sessionId: existingSessionId,
+      status: scenario.status,
+      updatedAt: terminalUpdatedAt,
+      endedAt: terminalEndedAt,
+      transcriptMtimeMs: now + scenario.transcriptMtimeOffsetMs,
+    });
+
+    const cfg = { session: { store: storePath } } as OpenClawConfig;
+    const result = await initSessionState({
+      ctx: { Body: "hello", SessionKey: scenario.sessionKey },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.isNewSession).toBe(scenario.expectNewSession);
+    const persisted = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
+      string,
+      SessionEntry
+    >;
+    const entry = persisted[scenario.sessionKey];
+    if (scenario.expectNewSession) {
+      expect(result.sessionId).not.toBe(existingSessionId);
+      expect(entry?.sessionId).not.toBe(existingSessionId);
+      expect(entry?.status).toBeUndefined();
+      expect(entry?.startedAt).toBeUndefined();
+      expect(entry?.endedAt).toBeUndefined();
+      expect(entry?.runtimeMs).toBeUndefined();
+    } else {
+      expect(result.sessionId).toBe(existingSessionId);
+      expect(entry?.status).toBe(scenario.status ?? "done");
+      expect(entry?.endedAt).toBe(terminalEndedAt);
+    }
   });
 
   it("keeps the existing stale session for /reset soft", async () => {

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -14,7 +14,10 @@ import { resetRegisteredAgentHarnessSessions } from "../../agents/harness/regist
 import { cleanupBrowserSessionsForLifecycleEnd } from "../../browser-lifecycle-cleanup.js";
 import { normalizeChatType } from "../../channels/chat-type.js";
 import { resolveGroupSessionKey } from "../../config/sessions/group.js";
-import { resolveSessionLifecycleTimestamps } from "../../config/sessions/lifecycle.js";
+import {
+  hasTerminalMainSessionTranscriptNewerThanRegistry,
+  resolveSessionLifecycleTimestamps,
+} from "../../config/sessions/lifecycle.js";
 import { canonicalizeMainSessionAlias } from "../../config/sessions/main-session.js";
 import { deriveSessionMetaPatch } from "../../config/sessions/metadata.js";
 import { resolveSessionTranscriptPath, resolveStorePath } from "../../config/sessions/paths.js";
@@ -467,10 +470,20 @@ export async function initSessionState(params: {
         skipConfiguredFallbackWhenActiveSessionNonAcp: false,
       }) ?? "",
     );
+  const terminalMainTranscriptNewerThanRegistry =
+    !isSystemEvent &&
+    (await hasTerminalMainSessionTranscriptNewerThanRegistry({
+      entry,
+      sessionScope,
+      sessionKey,
+      agentId,
+      mainKey,
+      storePath,
+    }));
   const freshEntry =
     (isSystemEvent && canReuseExistingEntry) ||
-    (entryFreshness?.fresh ?? false) ||
-    (softResetAllowed && canReuseExistingEntry);
+    (((entryFreshness?.fresh ?? false) || (softResetAllowed && canReuseExistingEntry)) &&
+      !terminalMainTranscriptNewerThanRegistry);
   // Capture the current session entry before any reset so its transcript can be
   // archived afterward.  We need to do this for both explicit resets (/new, /reset)
   // and for scheduled/daily resets where the session has become stale (!freshEntry).

--- a/src/commands/agent.session.test.ts
+++ b/src/commands/agent.session.test.ts
@@ -4,8 +4,11 @@ import path from "node:path";
 import { withTempHome as withTempHomeBase } from "openclaw/plugin-sdk/test-env";
 import { beforeEach, describe, expect, it } from "vitest";
 import { resolveAgentDir, resolveSessionAgentId } from "../agents/agent-scope.js";
+import { updateSessionStoreAfterAgentRun } from "../agents/command/session-store.js";
 import { resolveSession } from "../agents/command/session.js";
+import { loadSessionStore } from "../config/sessions/store-load.js";
 import { clearSessionStoreCacheForTest } from "../config/sessions/store.js";
+import { resolveSessionTranscriptFile } from "../config/sessions/transcript.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { buildOutboundSessionContext } from "../infra/outbound/session-context.js";
 
@@ -144,6 +147,91 @@ describe("agent session resolution", () => {
       expect(resolution.sessionId).toBe("origin-provider-reset");
       expect(resolution.isNewSession).toBe(false);
     });
+  });
+
+  it("rotates stale terminal main sessions whose transcript is newer than the registry", async () => {
+    const scenarios = [
+      { label: "canonical main", mainKey: "main", sessionKey: "agent:main:main" },
+      { label: "raw main alias", mainKey: "main", sessionKey: "main" },
+      { label: "custom main alias", mainKey: "work", sessionKey: "agent:main:main" },
+    ];
+    for (const scenario of scenarios) {
+      await withTempHome(async (home) => {
+        const store = path.join(home, "sessions.json");
+        const sessionFile = path.join(home, `session-${scenario.label.replaceAll(" ", "-")}.jsonl`);
+        const sessionId = `stale-terminal-${scenario.label.replaceAll(" ", "-")}`;
+        const registryUpdatedAt = Date.now() - 10_000;
+        fs.mkdirSync(path.dirname(sessionFile), { recursive: true });
+        fs.writeFileSync(sessionFile, JSON.stringify({ type: "session", id: sessionId }) + "\n");
+        fs.utimesSync(
+          sessionFile,
+          (registryUpdatedAt + 5_000) / 1000,
+          (registryUpdatedAt + 5_000) / 1000,
+        );
+        writeSessionStoreSeed(store, {
+          [scenario.sessionKey]: {
+            sessionId,
+            sessionFile,
+            updatedAt: registryUpdatedAt,
+            status: "done",
+            startedAt: registryUpdatedAt - 1_000,
+            endedAt: registryUpdatedAt - 100,
+          },
+        });
+        const cfg = mockConfig(home, store);
+        cfg.session = { ...cfg.session, mainKey: scenario.mainKey };
+
+        const resolution = resolveSession({ cfg, sessionKey: scenario.sessionKey });
+
+        expect(resolution.isNewSession).toBe(true);
+        expect(resolution.sessionId).not.toBe(sessionId);
+        expect(resolution.sessionEntry?.sessionFile).toBeUndefined();
+        expect(resolution.sessionEntry?.status).toBeUndefined();
+        expect(resolution.sessionEntry?.startedAt).toBeUndefined();
+        expect(resolution.sessionEntry?.endedAt).toBeUndefined();
+        expect(resolution.sessionEntry?.runtimeMs).toBeUndefined();
+
+        const sessionStore = {
+          [scenario.sessionKey]: resolution.sessionEntry!,
+        };
+        await resolveSessionTranscriptFile({
+          sessionId: resolution.sessionId,
+          sessionKey: scenario.sessionKey,
+          sessionEntry: resolution.sessionEntry,
+          sessionStore,
+          storePath: resolution.storePath,
+          agentId: "main",
+        });
+        await updateSessionStoreAfterAgentRun({
+          cfg,
+          sessionId: resolution.sessionId,
+          sessionKey: scenario.sessionKey,
+          storePath: resolution.storePath,
+          sessionStore,
+          defaultProvider: "openai",
+          defaultModel: "gpt-5.5",
+          result: {
+            payloads: [],
+            meta: {
+              aborted: false,
+              agentMeta: {
+                provider: "openai",
+                model: "gpt-5.5",
+              },
+            },
+          } as never,
+        });
+        const persisted = loadSessionStore(resolution.storePath, { skipCache: true })[
+          scenario.sessionKey
+        ];
+        expect(persisted?.sessionId).toBe(resolution.sessionId);
+        expect(persisted?.sessionFile).not.toBe(sessionFile);
+        expect(persisted?.status).toBeUndefined();
+        expect(persisted?.startedAt).toBeUndefined();
+        expect(persisted?.endedAt).toBeUndefined();
+        expect(persisted?.runtimeMs).toBeUndefined();
+      });
+    }
   });
 
   it("forwards resolved outbound session context when resuming by sessionId", async () => {

--- a/src/commands/agent.session.test.ts
+++ b/src/commands/agent.session.test.ts
@@ -151,9 +151,20 @@ describe("agent session resolution", () => {
 
   it("rotates stale terminal main sessions whose transcript is newer than the registry", async () => {
     const scenarios = [
-      { label: "canonical main", mainKey: "main", sessionKey: "agent:main:main" },
-      { label: "raw main alias", mainKey: "main", sessionKey: "main" },
-      { label: "custom main alias", mainKey: "work", sessionKey: "agent:main:main" },
+      {
+        label: "canonical main",
+        mainKey: "main",
+        sessionKey: "agent:main:main",
+        status: "done" as const,
+      },
+      { label: "raw main alias", mainKey: "main", sessionKey: "main", status: "done" as const },
+      {
+        label: "custom main alias",
+        mainKey: "work",
+        sessionKey: "agent:main:main",
+        status: "done" as const,
+      },
+      { label: "endedAt-only main", mainKey: "main", sessionKey: "agent:main:main" },
     ];
     for (const scenario of scenarios) {
       await withTempHome(async (home) => {
@@ -173,7 +184,9 @@ describe("agent session resolution", () => {
             sessionId,
             sessionFile,
             updatedAt: registryUpdatedAt,
-            status: "done",
+            ...(scenario.status ? { status: scenario.status } : {}),
+            sessionStartedAt: registryUpdatedAt - 60_000,
+            lastInteractionAt: registryUpdatedAt - 30_000,
             startedAt: registryUpdatedAt - 1_000,
             endedAt: registryUpdatedAt - 100,
           },
@@ -190,6 +203,8 @@ describe("agent session resolution", () => {
         expect(resolution.sessionEntry?.startedAt).toBeUndefined();
         expect(resolution.sessionEntry?.endedAt).toBeUndefined();
         expect(resolution.sessionEntry?.runtimeMs).toBeUndefined();
+        expect(resolution.sessionEntry?.sessionStartedAt).toBeUndefined();
+        expect(resolution.sessionEntry?.lastInteractionAt).toBeUndefined();
 
         const sessionStore = {
           [scenario.sessionKey]: resolution.sessionEntry!,
@@ -230,8 +245,71 @@ describe("agent session resolution", () => {
         expect(persisted?.startedAt).toBeUndefined();
         expect(persisted?.endedAt).toBeUndefined();
         expect(persisted?.runtimeMs).toBeUndefined();
+        expect(persisted?.sessionStartedAt).toBeGreaterThan(registryUpdatedAt);
+        expect(persisted?.lastInteractionAt).toBeGreaterThan(registryUpdatedAt);
       });
     }
+  });
+
+  it("preserves explicit session-id resumes for stale terminal main rows", async () => {
+    await withTempHome(async (home) => {
+      const store = path.join(home, "sessions.json");
+      const sessionFile = path.join(home, "explicit-terminal-main.jsonl");
+      const sessionId = "explicit-terminal-main";
+      const registryUpdatedAt = Date.now() - 10_000;
+      fs.writeFileSync(sessionFile, JSON.stringify({ type: "session", id: sessionId }) + "\n");
+      fs.utimesSync(
+        sessionFile,
+        (registryUpdatedAt + 5_000) / 1000,
+        (registryUpdatedAt + 5_000) / 1000,
+      );
+      writeSessionStoreSeed(store, {
+        "agent:main:main": {
+          sessionId,
+          sessionFile,
+          updatedAt: registryUpdatedAt,
+          status: "done",
+          startedAt: registryUpdatedAt - 1_000,
+          endedAt: registryUpdatedAt - 100,
+          runtimeMs: 900,
+        },
+      });
+      const cfg = mockConfig(home, store);
+
+      const resolution = resolveSession({ cfg, sessionId });
+
+      expect(resolution.sessionKey).toBe("agent:main:main");
+      expect(resolution.sessionId).toBe(sessionId);
+      expect(resolution.isNewSession).toBe(false);
+      expect(resolution.sessionEntry?.sessionFile).toBe(sessionFile);
+      expect(resolution.sessionEntry?.status).toBe("done");
+      expect(resolution.sessionEntry?.startedAt).toBe(registryUpdatedAt - 1_000);
+      expect(resolution.sessionEntry?.endedAt).toBe(registryUpdatedAt - 100);
+      expect(resolution.sessionEntry?.runtimeMs).toBe(900);
+
+      if (!resolution.sessionKey || !resolution.sessionStore) {
+        throw new Error("expected resolved explicit session store");
+      }
+      const resolvedTranscript = await resolveSessionTranscriptFile({
+        sessionId: resolution.sessionId,
+        sessionKey: resolution.sessionKey,
+        sessionEntry: resolution.sessionEntry,
+        sessionStore: resolution.sessionStore,
+        storePath: resolution.storePath,
+        agentId: "main",
+      });
+      expect(resolvedTranscript.sessionFile).toBe(sessionFile);
+
+      const persisted = loadSessionStore(resolution.storePath, { skipCache: true })[
+        resolution.sessionKey
+      ];
+      expect(persisted?.sessionId).toBe(sessionId);
+      expect(persisted?.sessionFile).toBe(sessionFile);
+      expect(persisted?.status).toBe("done");
+      expect(persisted?.startedAt).toBe(registryUpdatedAt - 1_000);
+      expect(persisted?.endedAt).toBe(registryUpdatedAt - 100);
+      expect(persisted?.runtimeMs).toBe(900);
+    });
   });
 
   it("forwards resolved outbound session context when resuming by sessionId", async () => {

--- a/src/commands/agent.session.test.ts
+++ b/src/commands/agent.session.test.ts
@@ -189,6 +189,15 @@ describe("agent session resolution", () => {
             lastInteractionAt: registryUpdatedAt - 30_000,
             startedAt: registryUpdatedAt - 1_000,
             endedAt: registryUpdatedAt - 100,
+            cliSessionBindings: {
+              "claude-cli": { sessionId: "old-claude-cli-session" },
+              "codex-cli": { sessionId: "old-codex-cli-session" },
+            },
+            cliSessionIds: {
+              "claude-cli": "old-claude-cli-session",
+              "codex-cli": "old-codex-cli-session",
+            },
+            claudeCliSessionId: "old-claude-cli-session",
           },
         });
         const cfg = mockConfig(home, store);
@@ -205,6 +214,9 @@ describe("agent session resolution", () => {
         expect(resolution.sessionEntry?.runtimeMs).toBeUndefined();
         expect(resolution.sessionEntry?.sessionStartedAt).toBeUndefined();
         expect(resolution.sessionEntry?.lastInteractionAt).toBeUndefined();
+        expect(resolution.sessionEntry?.cliSessionBindings).toBeUndefined();
+        expect(resolution.sessionEntry?.cliSessionIds).toBeUndefined();
+        expect(resolution.sessionEntry?.claudeCliSessionId).toBeUndefined();
 
         const sessionStore = {
           [scenario.sessionKey]: resolution.sessionEntry!,
@@ -245,6 +257,9 @@ describe("agent session resolution", () => {
         expect(persisted?.startedAt).toBeUndefined();
         expect(persisted?.endedAt).toBeUndefined();
         expect(persisted?.runtimeMs).toBeUndefined();
+        expect(persisted?.cliSessionBindings).toBeUndefined();
+        expect(persisted?.cliSessionIds).toBeUndefined();
+        expect(persisted?.claudeCliSessionId).toBeUndefined();
         expect(persisted?.sessionStartedAt).toBeGreaterThan(registryUpdatedAt);
         expect(persisted?.lastInteractionAt).toBeGreaterThan(registryUpdatedAt);
       });

--- a/src/config/sessions/lifecycle.ts
+++ b/src/config/sessions/lifecycle.ts
@@ -1,12 +1,14 @@
 // Session lifecycle timestamps prefer store metadata and fall back to transcript headers.
 import fs from "node:fs";
+import fsp from "node:fs/promises";
 import { asDateTimestampMs } from "../../shared/number-coercion.js";
+import { canonicalizeMainSessionAlias } from "./main-session.js";
 import {
   resolveSessionFilePath,
   resolveSessionFilePathOptions,
   type SessionFilePathOptions,
 } from "./paths.js";
-import type { SessionEntry } from "./types.js";
+import { isTerminalSessionStatus, type SessionEntry, type SessionScope } from "./types.js";
 
 type SessionLifecycleEntry = Pick<
   SessionEntry,
@@ -14,9 +16,29 @@ type SessionLifecycleEntry = Pick<
 >;
 
 // Transcript headers are read lazily to recover startedAt without parsing full files.
+
+type TerminalMainSessionTranscriptRegistryParams = {
+  entry: SessionEntry | undefined;
+  sessionScope?: SessionScope;
+  sessionKey?: string;
+  agentId: string;
+  mainKey?: string;
+  storePath?: string;
+};
+
+type TerminalMainSessionTranscriptRegistryCheck = {
+  sessionId: string;
+  registryTimestampMs: number;
+};
+
 function resolveTimestamp(value: number | undefined): number | undefined {
   const timestampMs = asDateTimestampMs(value);
   return timestampMs !== undefined && timestampMs >= 0 ? timestampMs : undefined;
+}
+
+function resolvePositiveTimestamp(value: number | undefined): number | undefined {
+  const timestampMs = resolveTimestamp(value);
+  return timestampMs !== undefined && timestampMs > 0 ? timestampMs : undefined;
 }
 
 function parseTimestampMs(value: unknown): number | undefined {
@@ -116,4 +138,100 @@ export function resolveSessionLifecycleTimestamps(params: {
       }),
     lastInteractionAt: resolveTimestamp(entry.lastInteractionAt),
   };
+}
+
+export function resolveTerminalMainSessionTranscriptRegistryCheck(
+  params: TerminalMainSessionTranscriptRegistryParams,
+): TerminalMainSessionTranscriptRegistryCheck | undefined {
+  if (!params.entry || !params.sessionKey) {
+    return undefined;
+  }
+  const configuredMainSessionKey = canonicalizeMainSessionAlias({
+    cfg: { session: { scope: params.sessionScope, mainKey: params.mainKey } },
+    agentId: params.agentId,
+    sessionKey: params.mainKey ?? "main",
+  });
+  const candidateSessionKey = canonicalizeMainSessionAlias({
+    cfg: { session: { scope: params.sessionScope, mainKey: params.mainKey } },
+    agentId: params.agentId,
+    sessionKey: params.sessionKey,
+  });
+  if (candidateSessionKey !== configuredMainSessionKey) {
+    return undefined;
+  }
+  if (!isTerminalSessionStatus(params.entry.status)) {
+    return undefined;
+  }
+  if (params.entry.status === "failed") {
+    // Failed rows with a present transcript stay reusable for retry/recovery.
+    // Callers already rotate failed rows when the transcript is missing.
+    return undefined;
+  }
+  // updatedAt is touched after managed transcript appends; endedAt can predate
+  // healthy post-run transcript writes and would rotate valid sessions.
+  const registryTimestampMs = resolvePositiveTimestamp(params.entry.updatedAt);
+  if (registryTimestampMs === undefined) {
+    return undefined;
+  }
+  const sessionId = typeof params.entry.sessionId === "string" ? params.entry.sessionId.trim() : "";
+  if (!sessionId) {
+    return undefined;
+  }
+  return { sessionId, registryTimestampMs };
+}
+
+function isTranscriptMtimeNewerThanRegistry(params: {
+  transcriptMtimeMs: number;
+  registryTimestampMs: number;
+}): boolean {
+  const transcriptMtimeMs = Math.floor(params.transcriptMtimeMs);
+  const registryTimestampMs = Math.floor(params.registryTimestampMs);
+  return Number.isFinite(transcriptMtimeMs) && transcriptMtimeMs > registryTimestampMs;
+}
+
+export function hasTerminalMainSessionTranscriptNewerThanRegistrySync(
+  params: TerminalMainSessionTranscriptRegistryParams,
+): boolean {
+  const check = resolveTerminalMainSessionTranscriptRegistryCheck(params);
+  if (!check) {
+    return false;
+  }
+  const pathOptions = resolveSessionFilePathOptions({
+    agentId: params.agentId,
+    storePath: params.storePath,
+  });
+  try {
+    const sessionFile = resolveSessionFilePath(check.sessionId, params.entry, pathOptions);
+    const stats = fs.statSync(sessionFile);
+    return isTranscriptMtimeNewerThanRegistry({
+      transcriptMtimeMs: stats.mtimeMs,
+      registryTimestampMs: check.registryTimestampMs,
+    });
+  } catch {
+    return false;
+  }
+}
+
+export async function hasTerminalMainSessionTranscriptNewerThanRegistry(
+  params: TerminalMainSessionTranscriptRegistryParams,
+): Promise<boolean> {
+  const check = resolveTerminalMainSessionTranscriptRegistryCheck(params);
+  if (!check) {
+    return false;
+  }
+  const pathOptions = resolveSessionFilePathOptions({
+    agentId: params.agentId,
+    storePath: params.storePath,
+  });
+  try {
+    // Session admission owns this bounded stat as the terminal-main reconciliation gate.
+    const sessionFile = resolveSessionFilePath(check.sessionId, params.entry, pathOptions);
+    const stats = await fsp.stat(sessionFile);
+    return isTranscriptMtimeNewerThanRegistry({
+      transcriptMtimeMs: stats.mtimeMs,
+      registryTimestampMs: check.registryTimestampMs,
+    });
+  } catch {
+    return false;
+  }
 }

--- a/src/config/sessions/lifecycle.ts
+++ b/src/config/sessions/lifecycle.ts
@@ -159,7 +159,10 @@ export function resolveTerminalMainSessionTranscriptRegistryCheck(
   if (candidateSessionKey !== configuredMainSessionKey) {
     return undefined;
   }
-  if (!isTerminalSessionStatus(params.entry.status)) {
+  const hasTerminalLifecycle =
+    isTerminalSessionStatus(params.entry.status) ||
+    resolvePositiveTimestamp(params.entry.endedAt) !== undefined;
+  if (!hasTerminalLifecycle) {
     return undefined;
   }
   if (params.entry.status === "failed") {

--- a/src/config/sessions/transcript.test.ts
+++ b/src/config/sessions/transcript.test.ts
@@ -138,6 +138,91 @@ describe("appendAssistantMessageToSessionTranscript", () => {
     }
   });
 
+  it("advances the session registry marker after managed transcript appends", async () => {
+    const updatedAt = Date.parse("2026-05-18T09:00:00.000Z");
+    const appendedAt = Date.parse("2026-05-18T09:05:00.000Z");
+    const sessionFile = "managed-marker.jsonl";
+    fs.writeFileSync(
+      fixture.storePath(),
+      JSON.stringify({
+        [sessionKey]: {
+          sessionId,
+          sessionFile,
+          updatedAt,
+          status: "done",
+        },
+      }),
+      "utf-8",
+    );
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(appendedAt);
+    try {
+      const result = await appendAssistantMessageToSessionTranscript({
+        sessionKey,
+        text: "Hello with registry marker",
+        storePath: fixture.storePath(),
+      });
+
+      expect(result.ok).toBe(true);
+      const store = JSON.parse(fs.readFileSync(fixture.storePath(), "utf-8")) as Record<
+        string,
+        { updatedAt?: number; status?: string }
+      >;
+      expect(store[sessionKey]?.updatedAt).toBe(appendedAt);
+      expect(store[sessionKey]?.status).toBe("done");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not advance the registry marker for duplicate delivery mirror replays", async () => {
+    const updatedAt = Date.parse("2026-05-18T10:00:00.000Z");
+    const firstAppendAt = Date.parse("2026-05-18T10:05:00.000Z");
+    const duplicateReplayAt = Date.parse("2026-05-18T10:10:00.000Z");
+    const sessionFile = "duplicate-marker.jsonl";
+    fs.writeFileSync(
+      fixture.storePath(),
+      JSON.stringify({
+        [sessionKey]: {
+          sessionId,
+          sessionFile,
+          updatedAt,
+          status: "done",
+        },
+      }),
+      "utf-8",
+    );
+    vi.useFakeTimers({ toFake: ["Date"] });
+    try {
+      vi.setSystemTime(firstAppendAt);
+      const first = await appendAssistantMessageToSessionTranscript({
+        sessionKey,
+        text: "Replay-safe marker",
+        storePath: fixture.storePath(),
+      });
+      expect(first.ok).toBe(true);
+
+      vi.setSystemTime(duplicateReplayAt);
+      const duplicate = await appendAssistantMessageToSessionTranscript({
+        sessionKey,
+        text: "Replay-safe marker",
+        storePath: fixture.storePath(),
+      });
+      expect(duplicate.ok).toBe(true);
+
+      const store = JSON.parse(fs.readFileSync(fixture.storePath(), "utf-8")) as Record<
+        string,
+        { updatedAt?: number }
+      >;
+      expect(store[sessionKey]?.updatedAt).toBe(firstAppendAt);
+      if (first.ok && duplicate.ok) {
+        expect(duplicate.messageId).toBe(first.messageId);
+      }
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("uses spawned cwd when creating a missing transcript header", async () => {
     const taskCwd = path.join(fixture.sessionsDir(), "task-repo");
     fs.mkdirSync(taskCwd, { recursive: true });

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -15,7 +15,7 @@ import {
   resolveSessionTranscriptPath,
 } from "./paths.js";
 import { resolveAndPersistSessionFile } from "./session-file.js";
-import { loadSessionStore, resolveSessionStoreEntry } from "./store.js";
+import { loadSessionStore, resolveSessionStoreEntry, updateSessionStoreEntry } from "./store.js";
 import { parseSessionThreadInfo } from "./thread-info.js";
 import { appendSessionTranscriptMessage } from "./transcript-append.js";
 import { createSessionTranscriptHeader } from "./transcript-header.js";
@@ -299,7 +299,8 @@ export async function appendExactAssistantMessageToSessionTranscript(params: {
     };
   }
 
-  return await runWithOwnedSessionTranscriptWriteLock(
+  let transcriptMarkerUpdatedAt: number | undefined;
+  const result = await runWithOwnedSessionTranscriptWriteLock(
     { sessionFile, sessionKey: resolved.normalizedKey },
     async () => {
       const explicitIdempotencyKey =
@@ -340,6 +341,7 @@ export async function appendExactAssistantMessageToSessionTranscript(params: {
       if (!appended) {
         return { ok: true, sessionFile, messageId };
       }
+      transcriptMarkerUpdatedAt = Date.now();
 
       switch (params.updateMode ?? "inline") {
         case "inline":
@@ -364,6 +366,15 @@ export async function appendExactAssistantMessageToSessionTranscript(params: {
       return { ok: true, sessionFile, messageId };
     },
   );
+  if (result.ok && transcriptMarkerUpdatedAt !== undefined) {
+    await updateSessionStoreEntry({
+      storePath,
+      sessionKey: resolved.normalizedKey,
+      update: (current) =>
+        current.sessionId === entry.sessionId ? { updatedAt: transcriptMarkerUpdatedAt } : null,
+    });
+  }
+  return result;
 }
 
 function isRedundantDeliveryMirror(message: SessionTranscriptAssistantMessage): boolean {

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -302,7 +302,7 @@ export async function appendExactAssistantMessageToSessionTranscript(params: {
   let transcriptMarkerUpdatedAt: number | undefined;
   const result = await runWithOwnedSessionTranscriptWriteLock<SessionTranscriptAppendResult>(
     { sessionFile, sessionKey: resolved.normalizedKey },
-    async () => {
+    async (): Promise<SessionTranscriptAppendResult> => {
       const explicitIdempotencyKey =
         params.idempotencyKey ??
         ((params.message as { idempotencyKey?: unknown }).idempotencyKey as string | undefined);

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -300,7 +300,7 @@ export async function appendExactAssistantMessageToSessionTranscript(params: {
   }
 
   let transcriptMarkerUpdatedAt: number | undefined;
-  const result = await runWithOwnedSessionTranscriptWriteLock(
+  const result = await runWithOwnedSessionTranscriptWriteLock<SessionTranscriptAppendResult>(
     { sessionFile, sessionKey: resolved.normalizedKey },
     async () => {
       const explicitIdempotencyKey =

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -723,14 +723,72 @@ describe("gateway agent handler", () => {
     expect(capturedEntry?.sessionFile).toBeUndefined();
   });
 
-  it("rotates a terminal main session when its transcript is newer than the registry row", async () => {
-    const now = Date.parse("2026-05-18T09:47:00.000Z");
+  it.each([
+    { name: "status terminal row", status: "done" as const },
+    { name: "endedAt-only terminal row" },
+  ])(
+    "rotates a terminal main session from a $name when its transcript is newer",
+    async (scenario) => {
+      const now = Date.parse("2026-05-18T09:47:00.000Z");
+      vi.useFakeTimers({ toFake: ["Date"] });
+      dateOnlyFakeClockActive = true;
+      vi.setSystemTime(now);
+
+      await withTempDir(
+        { prefix: "openclaw-gateway-terminal-main-newer-transcript-" },
+        async (root) => {
+          const sessionsDir = `${root}/sessions`;
+          await fs.mkdir(sessionsDir, { recursive: true });
+          const sessionFile = "terminal-main-session.jsonl";
+          const transcriptPath = `${sessionsDir}/${sessionFile}`;
+          await fs.writeFile(
+            transcriptPath,
+            `${JSON.stringify({ type: "session", id: "terminal-main-session" })}\n`,
+            "utf8",
+          );
+          await fs.utimes(transcriptPath, new Date(now - 1_000), new Date(now - 1_000));
+          mocks.loadSessionEntry.mockReturnValue({
+            cfg: {},
+            storePath: `${sessionsDir}/sessions.json`,
+            entry: {
+              sessionId: "terminal-main-session",
+              sessionFile,
+              ...(scenario.status ? { status: scenario.status } : {}),
+              updatedAt: now - 10_000,
+              sessionStartedAt: now - 60_000,
+              lastInteractionAt: now - 10_000,
+              startedAt: now - 20_000,
+              endedAt: now - 15_000,
+              runtimeMs: 5_000,
+            },
+            canonicalKey: "agent:main:main",
+          });
+
+          const capturedEntry = await runMainAgentAndCaptureEntry(
+            "test-idem-terminal-main-newer-transcript",
+          );
+
+          const call = await waitForAgentCommandCall<{ sessionId?: string }>();
+          expect(call.sessionId).not.toBe("terminal-main-session");
+          expect(capturedEntry?.sessionId).not.toBe("terminal-main-session");
+          expect(capturedEntry?.status).toBeUndefined();
+          expect(capturedEntry?.startedAt).toBeUndefined();
+          expect(capturedEntry?.endedAt).toBeUndefined();
+          expect(capturedEntry?.runtimeMs).toBeUndefined();
+          expect(capturedEntry?.sessionFile).toBeUndefined();
+        },
+      );
+    },
+  );
+
+  it("honors explicit gateway session-id resumes for terminal main rows", async () => {
+    const now = Date.parse("2026-05-18T09:48:00.000Z");
     vi.useFakeTimers({ toFake: ["Date"] });
     dateOnlyFakeClockActive = true;
     vi.setSystemTime(now);
 
     await withTempDir(
-      { prefix: "openclaw-gateway-terminal-main-newer-transcript-" },
+      { prefix: "openclaw-gateway-terminal-main-explicit-resume-" },
       async (root) => {
         const sessionsDir = `${root}/sessions`;
         await fs.mkdir(sessionsDir, { recursive: true });
@@ -742,35 +800,53 @@ describe("gateway agent handler", () => {
           "utf8",
         );
         await fs.utimes(transcriptPath, new Date(now - 1_000), new Date(now - 1_000));
+        const existingEntry = {
+          sessionId: "terminal-main-session",
+          sessionFile,
+          status: "done",
+          updatedAt: now - 10_000,
+          sessionStartedAt: now - 60_000,
+          lastInteractionAt: now - 10_000,
+          startedAt: now - 20_000,
+          endedAt: now - 15_000,
+          runtimeMs: 5_000,
+        };
         mocks.loadSessionEntry.mockReturnValue({
           cfg: {},
           storePath: `${sessionsDir}/sessions.json`,
-          entry: {
-            sessionId: "terminal-main-session",
-            sessionFile,
-            status: "done",
-            updatedAt: now - 10_000,
-            sessionStartedAt: now - 60_000,
-            lastInteractionAt: now - 10_000,
-            startedAt: now - 20_000,
-            endedAt: now - 15_000,
-            runtimeMs: 5_000,
-          },
+          entry: existingEntry,
           canonicalKey: "agent:main:main",
         });
+        let capturedEntry: Record<string, unknown> | undefined;
+        mocks.updateSessionStore.mockImplementation(async (_path, updater) => {
+          const store: Record<string, unknown> = {
+            "agent:main:main": { ...existingEntry },
+          };
+          const result = await updater(store);
+          capturedEntry = result as Record<string, unknown>;
+          return result;
+        });
+        mocks.agentCommand.mockResolvedValue({
+          payloads: [{ text: "ok" }],
+          meta: { durationMs: 100 },
+        });
 
-        const capturedEntry = await runMainAgentAndCaptureEntry(
-          "test-idem-terminal-main-newer-transcript",
-        );
+        await invokeAgent({
+          message: "resume terminal main",
+          agentId: "main",
+          sessionKey: "agent:main:main",
+          sessionId: "terminal-main-session",
+          idempotencyKey: "test-idem-terminal-main-explicit-resume",
+        } as AgentParams);
 
         const call = await waitForAgentCommandCall<{ sessionId?: string }>();
-        expect(call.sessionId).not.toBe("terminal-main-session");
-        expect(capturedEntry?.sessionId).not.toBe("terminal-main-session");
-        expect(capturedEntry?.status).toBeUndefined();
-        expect(capturedEntry?.startedAt).toBeUndefined();
-        expect(capturedEntry?.endedAt).toBeUndefined();
-        expect(capturedEntry?.runtimeMs).toBeUndefined();
-        expect(capturedEntry?.sessionFile).toBeUndefined();
+        expect(call.sessionId).toBe("terminal-main-session");
+        expect(capturedEntry?.sessionId).toBe("terminal-main-session");
+        expect(capturedEntry?.sessionFile).toBe(sessionFile);
+        expect(capturedEntry?.status).toBe("done");
+        expect(capturedEntry?.startedAt).toBe(now - 20_000);
+        expect(capturedEntry?.endedAt).toBe(now - 15_000);
+        expect(capturedEntry?.runtimeMs).toBe(5_000);
       },
     );
   });

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -723,6 +723,128 @@ describe("gateway agent handler", () => {
     expect(capturedEntry?.sessionFile).toBeUndefined();
   });
 
+  it("rotates a terminal main session when its transcript is newer than the registry row", async () => {
+    const now = Date.parse("2026-05-18T09:47:00.000Z");
+    vi.useFakeTimers({ toFake: ["Date"] });
+    dateOnlyFakeClockActive = true;
+    vi.setSystemTime(now);
+
+    await withTempDir(
+      { prefix: "openclaw-gateway-terminal-main-newer-transcript-" },
+      async (root) => {
+        const sessionsDir = `${root}/sessions`;
+        await fs.mkdir(sessionsDir, { recursive: true });
+        const sessionFile = "terminal-main-session.jsonl";
+        const transcriptPath = `${sessionsDir}/${sessionFile}`;
+        await fs.writeFile(
+          transcriptPath,
+          `${JSON.stringify({ type: "session", id: "terminal-main-session" })}\n`,
+          "utf8",
+        );
+        await fs.utimes(transcriptPath, new Date(now - 1_000), new Date(now - 1_000));
+        mocks.loadSessionEntry.mockReturnValue({
+          cfg: {},
+          storePath: `${sessionsDir}/sessions.json`,
+          entry: {
+            sessionId: "terminal-main-session",
+            sessionFile,
+            status: "done",
+            updatedAt: now - 10_000,
+            sessionStartedAt: now - 60_000,
+            lastInteractionAt: now - 10_000,
+            startedAt: now - 20_000,
+            endedAt: now - 15_000,
+            runtimeMs: 5_000,
+          },
+          canonicalKey: "agent:main:main",
+        });
+
+        const capturedEntry = await runMainAgentAndCaptureEntry(
+          "test-idem-terminal-main-newer-transcript",
+        );
+
+        const call = await waitForAgentCommandCall<{ sessionId?: string }>();
+        expect(call.sessionId).not.toBe("terminal-main-session");
+        expect(capturedEntry?.sessionId).not.toBe("terminal-main-session");
+        expect(capturedEntry?.status).toBeUndefined();
+        expect(capturedEntry?.startedAt).toBeUndefined();
+        expect(capturedEntry?.endedAt).toBeUndefined();
+        expect(capturedEntry?.runtimeMs).toBeUndefined();
+        expect(capturedEntry?.sessionFile).toBeUndefined();
+      },
+    );
+  });
+
+  it.each(["heartbeat", "cron"] as const)(
+    "preserves terminal main session reuse for %s gateway runs",
+    async (runKind) => {
+      const now = Date.parse("2026-05-18T09:49:00.000Z");
+      vi.useFakeTimers({ toFake: ["Date"] });
+      dateOnlyFakeClockActive = true;
+      vi.setSystemTime(now);
+
+      await withTempDir(
+        { prefix: `openclaw-gateway-terminal-main-${runKind}-reuse-` },
+        async (root) => {
+          const sessionsDir = `${root}/sessions`;
+          await fs.mkdir(sessionsDir, { recursive: true });
+          const sessionFile = `terminal-main-${runKind}.jsonl`;
+          const transcriptPath = `${sessionsDir}/${sessionFile}`;
+          await fs.writeFile(
+            transcriptPath,
+            `${JSON.stringify({ type: "session", id: "terminal-main-session" })}\n`,
+            "utf8",
+          );
+          await fs.utimes(transcriptPath, new Date(now - 1_000), new Date(now - 1_000));
+          const existingEntry = {
+            sessionId: "terminal-main-session",
+            sessionFile,
+            status: "done",
+            updatedAt: now - 10_000,
+            sessionStartedAt: now - 60_000,
+            lastInteractionAt: now - 10_000,
+            startedAt: now - 20_000,
+            endedAt: now - 15_000,
+            runtimeMs: 5_000,
+          };
+          mocks.loadSessionEntry.mockReturnValue({
+            cfg: {},
+            storePath: `${sessionsDir}/sessions.json`,
+            entry: existingEntry,
+            canonicalKey: "agent:main:main",
+          });
+
+          let capturedEntry: Record<string, unknown> | undefined;
+          mocks.updateSessionStore.mockImplementation(async (_path, updater) => {
+            const store: Record<string, unknown> = {
+              "agent:main:main": { ...existingEntry },
+            };
+            const result = await updater(store);
+            capturedEntry = result as Record<string, unknown>;
+            return result;
+          });
+          mocks.agentCommand.mockResolvedValue({
+            payloads: [{ text: "ok" }],
+            meta: { durationMs: 100 },
+          });
+
+          await invokeAgent({
+            message: `${runKind} probe`,
+            agentId: "main",
+            sessionKey: "agent:main:main",
+            bootstrapContextRunKind: runKind,
+            idempotencyKey: `test-idem-terminal-main-${runKind}-reuse`,
+          } as AgentParams);
+
+          const call = await waitForAgentCommandCall<{ sessionId?: string }>();
+          expect(call.sessionId).toBe("terminal-main-session");
+          expect(capturedEntry?.sessionId).toBe("terminal-main-session");
+          expect(capturedEntry?.sessionFile).toBe(sessionFile);
+        },
+      );
+    },
+  );
+
   it("rotates a failed session when its default transcript is missing", async () => {
     const now = Date.parse("2026-05-18T09:48:00.000Z");
     vi.useFakeTimers({ toFake: ["Date"] });

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -760,6 +760,15 @@ describe("gateway agent handler", () => {
               startedAt: now - 20_000,
               endedAt: now - 15_000,
               runtimeMs: 5_000,
+              cliSessionBindings: {
+                "claude-cli": { sessionId: "old-claude-cli-session" },
+                "codex-cli": { sessionId: "old-codex-cli-session" },
+              },
+              cliSessionIds: {
+                "claude-cli": "old-claude-cli-session",
+                "codex-cli": "old-codex-cli-session",
+              },
+              claudeCliSessionId: "old-claude-cli-session",
             },
             canonicalKey: "agent:main:main",
           });
@@ -776,10 +785,79 @@ describe("gateway agent handler", () => {
           expect(capturedEntry?.endedAt).toBeUndefined();
           expect(capturedEntry?.runtimeMs).toBeUndefined();
           expect(capturedEntry?.sessionFile).toBeUndefined();
+          expect(capturedEntry?.cliSessionBindings).toBeUndefined();
+          expect(capturedEntry?.cliSessionIds).toBeUndefined();
+          expect(capturedEntry?.claudeCliSessionId).toBeUndefined();
         },
       );
     },
   );
+
+  it("reuses terminal main sessions when the fresh store row has the transcript marker", async () => {
+    const now = Date.parse("2026-05-18T09:47:30.000Z");
+    vi.useFakeTimers({ toFake: ["Date"] });
+    dateOnlyFakeClockActive = true;
+    vi.setSystemTime(now);
+
+    await withTempDir({ prefix: "openclaw-gateway-terminal-main-fresh-marker-" }, async (root) => {
+      const sessionsDir = `${root}/sessions`;
+      await fs.mkdir(sessionsDir, { recursive: true });
+      const sessionFile = "terminal-main-session.jsonl";
+      const transcriptPath = `${sessionsDir}/${sessionFile}`;
+      await fs.writeFile(
+        transcriptPath,
+        `${JSON.stringify({ type: "session", id: "terminal-main-session" })}\n`,
+        "utf8",
+      );
+      await fs.utimes(transcriptPath, new Date(now - 1_000), new Date(now - 1_000));
+      const staleEntry = {
+        sessionId: "terminal-main-session",
+        sessionFile,
+        status: "done",
+        updatedAt: now - 10_000,
+        cliSessionBindings: {
+          "claude-cli": { sessionId: "existing-claude-cli-session" },
+        },
+        cliSessionIds: {
+          "claude-cli": "existing-claude-cli-session",
+        },
+        claudeCliSessionId: "existing-claude-cli-session",
+      };
+      mocks.loadSessionEntry.mockReturnValue({
+        cfg: {},
+        storePath: `${sessionsDir}/sessions.json`,
+        entry: staleEntry,
+        canonicalKey: "agent:main:main",
+      });
+      let capturedEntry: Record<string, unknown> | undefined;
+      mocks.updateSessionStore.mockImplementation(async (_path, updater) => {
+        const store = {
+          "agent:main:main": {
+            ...staleEntry,
+            updatedAt: now,
+          },
+        };
+        const result = await updater(store);
+        capturedEntry = result as Record<string, unknown>;
+        return result;
+      });
+      mocks.agentCommand.mockResolvedValue({
+        payloads: [{ text: "ok" }],
+        meta: { durationMs: 100 },
+      });
+
+      await runMainAgent("hi", "test-idem-terminal-main-fresh-marker");
+
+      const call = await waitForAgentCommandCall<{ sessionId?: string }>();
+      expect(call.sessionId).toBe("terminal-main-session");
+      expect(capturedEntry?.sessionId).toBe("terminal-main-session");
+      expect(capturedEntry?.sessionFile).toBe(sessionFile);
+      expect(capturedEntry?.cliSessionIds).toEqual({
+        "claude-cli": "existing-claude-cli-session",
+      });
+      expect(capturedEntry?.claudeCliSessionId).toBe("existing-claude-cli-session");
+    });
+  });
 
   it("honors explicit gateway session-id resumes for terminal main rows", async () => {
     const now = Date.parse("2026-05-18T09:48:00.000Z");

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -1823,6 +1823,7 @@ describe("gateway agent handler", () => {
   });
   it("reactivates completed subagent sessions and broadcasts send updates", async () => {
     const childSessionKey = "agent:main:subagent:followup";
+    const updatedAt = Date.now() - 1_000;
     const completedRun = {
       runId: "run-old",
       childSessionKey,
@@ -1843,7 +1844,7 @@ describe("gateway agent handler", () => {
       storePath: "/tmp/sessions.json",
       entry: {
         sessionId: "sess-followup",
-        updatedAt: Date.now(),
+        updatedAt,
       },
       canonicalKey: childSessionKey,
     });
@@ -1851,7 +1852,7 @@ describe("gateway agent handler", () => {
       const store: Record<string, unknown> = {
         [childSessionKey]: {
           sessionId: "sess-followup",
-          updatedAt: Date.now(),
+          updatedAt,
         },
       };
       return await updater(store);

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -1907,9 +1907,10 @@ describe("gateway agent handler", () => {
   });
 
   it("includes live session setting metadata in agent send events", async () => {
+    const updatedAt = Date.now() - 1_000;
     mockMainSessionEntry({
       sessionId: "sess-main",
-      updatedAt: Date.now(),
+      updatedAt,
       fastMode: true,
       sendPolicy: "deny",
       lastChannel: "telegram",
@@ -1920,6 +1921,8 @@ describe("gateway agent handler", () => {
     mocks.updateSessionStore.mockImplementation(async (_path, updater) => {
       const store: Record<string, unknown> = {
         "agent:main:main": buildExistingMainStoreEntry({
+          sessionId: "sess-main",
+          updatedAt,
           fastMode: true,
           sendPolicy: "deny",
           lastChannel: "telegram",

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -51,7 +51,9 @@ import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { agentCommandFromIngress } from "../../commands/agent.js";
 import {
   evaluateSessionFreshness,
+  hasTerminalMainSessionTranscriptNewerThanRegistry,
   mergeSessionEntry,
+  resolveTerminalMainSessionTranscriptRegistryCheck,
   resolveChannelResetConfig,
   resolveAgentIdFromSessionKey,
   resolveExplicitAgentSessionKey,
@@ -1656,10 +1658,38 @@ export const agentHandlers: GatewayRequestHandlers = {
             failedSessionTranscriptMissing = true;
           }
         }
+        const mainSessionKeyForRequest = resolveAgentMainSessionKey({
+          cfg: cfgLocal,
+          agentId: canonicalSessionAgentId,
+        });
+        const isSystemGatewayRun =
+          request.bootstrapContextRunKind === "cron" ||
+          request.bootstrapContextRunKind === "heartbeat";
+        const terminalMainTranscriptCheck = isSystemGatewayRun
+              ? undefined
+              : resolveTerminalMainSessionTranscriptRegistryCheck({
+                  entry,
+                  sessionScope: cfgLocal.session?.scope,
+                  sessionKey: canonicalKey,
+                  agentId: canonicalSessionAgentId,
+                  mainKey: cfgLocal.session?.mainKey,
+                  storePath,
+                });
+        const terminalMainTranscriptNewerThanRegistry = terminalMainTranscriptCheck
+          ? await hasTerminalMainSessionTranscriptNewerThanRegistry({
+              entry,
+              sessionScope: cfgLocal.session?.scope,
+              sessionKey: canonicalKey,
+              agentId: canonicalSessionAgentId,
+              mainKey: cfgLocal.session?.mainKey,
+              storePath,
+            })
+          : false;
         const canReuseSession =
           Boolean(entry?.sessionId) &&
           (freshness?.fresh ?? false) &&
-          !failedSessionTranscriptMissing;
+          !failedSessionTranscriptMissing &&
+          !terminalMainTranscriptNewerThanRegistry;
         const usableRequestedSessionId =
           requestedSessionId && (!entry?.sessionId || canReuseSession)
             ? requestedSessionId
@@ -1672,10 +1702,7 @@ export const agentHandlers: GatewayRequestHandlers = {
           (!canReuseSession && !usableRequestedSessionId) ||
           Boolean(usableRequestedSessionId && entry?.sessionId !== usableRequestedSessionId);
         const rotatedSessionId = Boolean(entry?.sessionId && entry.sessionId !== sessionId);
-        const touchInteraction =
-          request.bootstrapContextRunKind !== "cron" &&
-          request.bootstrapContextRunKind !== "heartbeat" &&
-          !request.internalEvents?.length;
+        const touchInteraction = !isSystemGatewayRun && !request.internalEvents?.length;
         const sessionAgent = canonicalSessionAgentId;
         type AgentSessionPatchBuild = {
           patch: Partial<SessionEntry>;
@@ -1831,10 +1858,7 @@ export const agentHandlers: GatewayRequestHandlers = {
         resolvedSessionKey = canonicalSessionKey;
         const sessionAgentId = canonicalSessionAgentId;
         resolvedSessionAgentId = sessionAgentId;
-        const mainSessionKey = resolveAgentMainSessionKey({
-          cfg: cfgLocal,
-          agentId: sessionAgentId,
-        });
+        const mainSessionKey = mainSessionKeyForRequest;
         // Legacy stores may lack sessionStartedAt entirely. Pre-compute a
         // JSONL-transcript-derived candidate outside the store lock; the
         // updater below only writes it when the freshly-loaded store still

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -1665,16 +1665,20 @@ export const agentHandlers: GatewayRequestHandlers = {
         const isSystemGatewayRun =
           request.bootstrapContextRunKind === "cron" ||
           request.bootstrapContextRunKind === "heartbeat";
-        const terminalMainTranscriptCheck = isSystemGatewayRun
-              ? undefined
-              : resolveTerminalMainSessionTranscriptRegistryCheck({
-                  entry,
-                  sessionScope: cfgLocal.session?.scope,
-                  sessionKey: canonicalKey,
-                  agentId: canonicalSessionAgentId,
-                  mainKey: cfgLocal.session?.mainKey,
-                  storePath,
-                });
+        const requestedSessionMatchesEntry = Boolean(
+          requestedSessionId && entry?.sessionId?.trim() === requestedSessionId,
+        );
+        const terminalMainTranscriptCheck =
+          isSystemGatewayRun || requestedSessionMatchesEntry
+            ? undefined
+            : resolveTerminalMainSessionTranscriptRegistryCheck({
+                entry,
+                sessionScope: cfgLocal.session?.scope,
+                sessionKey: canonicalKey,
+                agentId: canonicalSessionAgentId,
+                mainKey: cfgLocal.session?.mainKey,
+                storePath,
+              });
         const terminalMainTranscriptNewerThanRegistry = terminalMainTranscriptCheck
           ? await hasTerminalMainSessionTranscriptNewerThanRegistry({
               entry,

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -30,6 +30,7 @@ import {
   consumeExecApprovalFollowupRuntimeHandoff,
   parseExecApprovalFollowupApprovalId,
 } from "../../agents/bash-tools.exec-approval-followup-state.js";
+import { clearAllCliSessions } from "../../agents/cli-session.js";
 import type { AgentCommandOpts } from "../../agents/command/types.js";
 import { isTimeoutError } from "../../agents/failover-error.js";
 import {
@@ -51,7 +52,7 @@ import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { agentCommandFromIngress } from "../../commands/agent.js";
 import {
   evaluateSessionFreshness,
-  hasTerminalMainSessionTranscriptNewerThanRegistry,
+  hasTerminalMainSessionTranscriptNewerThanRegistrySync,
   mergeSessionEntry,
   resolveTerminalMainSessionTranscriptRegistryCheck,
   resolveChannelResetConfig,
@@ -1636,7 +1637,7 @@ export const agentHandlers: GatewayRequestHandlers = {
               agentId: canonicalSessionAgentId,
             })
           : undefined;
-        const freshness = entry
+        let freshness = entry
           ? evaluateSessionFreshness({
               updatedAt: entry.updatedAt,
               ...lifecycleTimestamps,
@@ -1644,20 +1645,25 @@ export const agentHandlers: GatewayRequestHandlers = {
               policy: resetPolicy,
             })
           : undefined;
-        let failedSessionTranscriptMissing = false;
-        if (entry?.status === "failed" && entry.sessionId?.trim()) {
+        const resolveFailedSessionTranscriptMissingForEntry = (
+          candidateEntry: SessionEntry | undefined,
+        ) => {
+          if (candidateEntry?.status !== "failed" || !candidateEntry.sessionId?.trim()) {
+            return false;
+          }
           try {
             const sessionPathOpts = resolveSessionFilePathOptions({
               storePath,
               agentId: canonicalSessionAgentId,
             });
-            failedSessionTranscriptMissing = !existsSync(
-              resolveSessionFilePath(entry.sessionId, entry, sessionPathOpts),
+            return !existsSync(
+              resolveSessionFilePath(candidateEntry.sessionId, candidateEntry, sessionPathOpts),
             );
           } catch {
-            failedSessionTranscriptMissing = true;
+            return true;
           }
-        }
+        };
+        const failedSessionTranscriptMissing = resolveFailedSessionTranscriptMissingForEntry(entry);
         const mainSessionKeyForRequest = resolveAgentMainSessionKey({
           cfg: cfgLocal,
           agentId: canonicalSessionAgentId,
@@ -1680,7 +1686,7 @@ export const agentHandlers: GatewayRequestHandlers = {
                 storePath,
               });
         const terminalMainTranscriptNewerThanRegistry = terminalMainTranscriptCheck
-          ? await hasTerminalMainSessionTranscriptNewerThanRegistry({
+          ? hasTerminalMainSessionTranscriptNewerThanRegistrySync({
               entry,
               sessionScope: cfgLocal.session?.scope,
               sessionKey: canonicalKey,
@@ -1694,7 +1700,7 @@ export const agentHandlers: GatewayRequestHandlers = {
           (freshness?.fresh ?? false) &&
           !failedSessionTranscriptMissing &&
           !terminalMainTranscriptNewerThanRegistry;
-        const usableRequestedSessionId =
+        let usableRequestedSessionId =
           requestedSessionId && (!entry?.sessionId || canReuseSession)
             ? requestedSessionId
             : undefined;
@@ -1705,7 +1711,7 @@ export const agentHandlers: GatewayRequestHandlers = {
           !entry ||
           (!canReuseSession && !usableRequestedSessionId) ||
           Boolean(usableRequestedSessionId && entry?.sessionId !== usableRequestedSessionId);
-        const rotatedSessionId = Boolean(entry?.sessionId && entry.sessionId !== sessionId);
+        let rotatedSessionId = Boolean(entry?.sessionId && entry.sessionId !== sessionId);
         const touchInteraction = !isSystemGatewayRun && !request.internalEvents?.length;
         const sessionAgent = canonicalSessionAgentId;
         type AgentSessionPatchBuild = {
@@ -1715,6 +1721,10 @@ export const agentHandlers: GatewayRequestHandlers = {
           groupChannel: string | undefined;
           groupSpace: string | undefined;
           freshSessionRotatedSinceLoad: boolean;
+          isNewSession: boolean;
+          rotatedSessionId: boolean;
+          usableRequestedSessionId: string | undefined;
+          freshness: typeof freshness;
         };
         const requestDeliveryHint = normalizeDeliveryContext({
           channel: request.channel?.trim(),
@@ -1807,12 +1817,69 @@ export const agentHandlers: GatewayRequestHandlers = {
           const freshSessionRotatedSinceLoad = Boolean(
             entry?.sessionId && freshEntry?.sessionId && freshEntry.sessionId !== entry.sessionId,
           );
-          const patchSessionId = freshSessionRotatedSinceLoad ? freshEntry?.sessionId : sessionId;
-          const shouldClearRotatedState = rotatedSessionId && !freshSessionRotatedSinceLoad;
+          const freshLifecycleTimestamps = freshEntry
+            ? resolveSessionLifecycleTimestamps({
+                entry: freshEntry,
+                storePath,
+                agentId: sessionAgent,
+              })
+            : undefined;
+          const freshFreshness = freshEntry
+            ? evaluateSessionFreshness({
+                updatedAt: freshEntry.updatedAt,
+                ...freshLifecycleTimestamps,
+                now,
+                policy: resetPolicy,
+              })
+            : undefined;
+          const freshRequestedSessionMatchesEntry = Boolean(
+            requestedSessionId && freshEntry?.sessionId?.trim() === requestedSessionId,
+          );
+          const freshTerminalMainTranscriptNewerThanRegistry =
+            isSystemGatewayRun || freshRequestedSessionMatchesEntry
+              ? false
+              : hasTerminalMainSessionTranscriptNewerThanRegistrySync({
+                  entry: freshEntry,
+                  sessionScope: cfgLocal.session?.scope,
+                  sessionKey: canonicalKey,
+                  agentId: sessionAgent,
+                  mainKey: cfgLocal.session?.mainKey,
+                  storePath,
+                });
+          const freshFailedSessionTranscriptMissing =
+            resolveFailedSessionTranscriptMissingForEntry(freshEntry);
+          const freshCanReuseSession =
+            Boolean(freshEntry?.sessionId) &&
+            (freshFreshness?.fresh ?? false) &&
+            !freshFailedSessionTranscriptMissing &&
+            !freshTerminalMainTranscriptNewerThanRegistry;
+          const freshUsableRequestedSessionId =
+            requestedSessionId && (!freshEntry?.sessionId || freshCanReuseSession)
+              ? requestedSessionId
+              : undefined;
+          const freshSessionId = freshUsableRequestedSessionId
+            ? freshUsableRequestedSessionId
+            : ((freshCanReuseSession ? freshEntry?.sessionId : undefined) ?? sessionId);
+          const freshIsNewSession =
+            !freshEntry ||
+            (!freshCanReuseSession && !freshUsableRequestedSessionId) ||
+            Boolean(
+              freshUsableRequestedSessionId &&
+              freshEntry?.sessionId !== freshUsableRequestedSessionId,
+            );
+          const freshRotatedSessionId = Boolean(
+            freshEntry?.sessionId && freshEntry.sessionId !== freshSessionId,
+          );
+          const patchSessionId = freshSessionRotatedSinceLoad
+            ? freshEntry?.sessionId
+            : freshSessionId;
+          const shouldClearRotatedState = freshRotatedSessionId && !freshSessionRotatedSinceLoad;
           const patch: Partial<SessionEntry> = {
             sessionId: patchSessionId,
             updatedAt: now,
-            ...(isNewSession && !freshSessionRotatedSinceLoad ? { sessionStartedAt: now } : {}),
+            ...(freshIsNewSession && !freshSessionRotatedSinceLoad
+              ? { sessionStartedAt: now }
+              : {}),
             ...(touchInteraction ? { lastInteractionAt: now } : {}),
             ...(effectiveDeliveryFields.route ? { route: effectiveDeliveryFields.route } : {}),
             ...(effectiveDeliveryFields.deliveryContext
@@ -1846,6 +1913,9 @@ export const agentHandlers: GatewayRequestHandlers = {
                 }
               : {}),
           };
+          if (shouldClearRotatedState) {
+            clearAllCliSessions(patch);
+          }
           return {
             patch,
             spawnedBy: freshSpawnedBy,
@@ -1853,9 +1923,17 @@ export const agentHandlers: GatewayRequestHandlers = {
             groupChannel: nextGroup.groupChannel,
             groupSpace: nextGroup.groupSpace,
             freshSessionRotatedSinceLoad,
+            isNewSession: freshIsNewSession,
+            rotatedSessionId: freshRotatedSessionId,
+            usableRequestedSessionId: freshUsableRequestedSessionId,
+            freshness: freshFreshness,
           };
         };
         let patchBuild = buildSessionPatch(entry);
+        isNewSession = patchBuild.isNewSession;
+        rotatedSessionId = patchBuild.rotatedSessionId;
+        usableRequestedSessionId = patchBuild.usableRequestedSessionId;
+        freshness = patchBuild.freshness;
         sessionEntry = mergeSessionEntry(entry, patchBuild.patch);
         resolvedSessionId = sessionEntry?.sessionId ?? sessionId;
         const canonicalSessionKey = canonicalKey;
@@ -1961,6 +2039,10 @@ export const agentHandlers: GatewayRequestHandlers = {
             return;
           }
         }
+        isNewSession = patchBuild.isNewSession;
+        rotatedSessionId = patchBuild.rotatedSessionId;
+        usableRequestedSessionId = patchBuild.usableRequestedSessionId;
+        freshness = patchBuild.freshness;
         spawnedByValue = patchBuild.spawnedBy;
         resolvedGroupId = patchBuild.groupId;
         resolvedGroupChannel = patchBuild.groupChannel;

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -2328,6 +2328,54 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     expect(nodeSend?.[2].sessionKey).toBe("agent:main:canon");
   });
 
+  it("chat.inject advances the session registry marker after transcript append", async () => {
+    const fixtureDir = createTranscriptFixture("openclaw-chat-inject-registry-marker-");
+    const updatedAt = Date.parse("2026-05-18T11:00:00.000Z");
+    const appendedAt = Date.parse("2026-05-18T11:05:00.000Z");
+    const storePath = path.join(path.dirname(mockState.transcriptPath), "sessions.json");
+    fs.writeFileSync(
+      storePath,
+      JSON.stringify({
+        main: {
+          sessionId: mockState.sessionId,
+          sessionFile: mockState.transcriptPath,
+          updatedAt,
+          status: "done",
+        },
+      }),
+      "utf-8",
+    );
+    const respond = vi.fn();
+    const context = createChatContext();
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(appendedAt);
+    try {
+      await chatHandlers["chat.inject"]({
+        params: {
+          sessionKey: "main",
+          message: "hello with registry marker",
+        },
+        respond,
+        req: {} as never,
+        client: null as never,
+        isWebchatConnect: () => false,
+        context: context as GatewayRequestContext,
+      });
+
+      const response = lastRespondCall(respond);
+      expect(response?.[0]).toBe(true);
+      const store = JSON.parse(fs.readFileSync(storePath, "utf-8")) as Record<
+        string,
+        { updatedAt?: number; status?: string }
+      >;
+      expect(store.main?.updatedAt).toBe(appendedAt);
+      expect(store.main?.status).toBe("done");
+    } finally {
+      vi.useRealTimers();
+      fs.rmSync(fixtureDir, { recursive: true, force: true });
+    }
+  });
+
   it("chat.inject scopes selected-agent global sessions before appending", async () => {
     createTranscriptFixture("openclaw-chat-inject-selected-global-");
     mockState.config = {

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -1402,6 +1402,21 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         fs.writeFileSync(savedImagePath, Buffer.from(TINY_PNG_BASE64, "base64"));
         mockState.savedMediaResults = [{ path: savedImagePath, contentType: "image/png" }];
         const mirrorIdempotencyKey = "idem-agent-source-reply-media:internal-source-reply:0";
+        const updatedAt = Date.parse("2026-05-18T11:00:00.000Z");
+        const rewrittenAt = Date.parse("2026-05-18T11:05:00.000Z");
+        const storePath = path.join(path.dirname(mockState.transcriptPath), "sessions.json");
+        fs.writeFileSync(
+          storePath,
+          JSON.stringify({
+            main: {
+              sessionId: mockState.sessionId,
+              sessionFile: mockState.transcriptPath,
+              updatedAt,
+              status: "done",
+            },
+          }),
+          "utf-8",
+        );
         await appendSourceReplyMirrorEntry({
           idempotencyKey: mirrorIdempotencyKey,
           text: "Codex source reply with media",
@@ -1430,34 +1445,47 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         const respond = vi.fn();
         const context = createChatContext();
 
-        const broadcast = await runNonStreamingChatSend({
-          context,
-          respond,
-          idempotencyKey: "idem-agent-source-reply-media",
-          message: "hello from codex",
-        });
+        vi.useFakeTimers({ toFake: ["Date"] });
+        vi.setSystemTime(rewrittenAt);
+        try {
+          const broadcast = await runNonStreamingChatSend({
+            context,
+            respond,
+            idempotencyKey: "idem-agent-source-reply-media",
+            message: "hello from codex",
+          });
 
-        expect(broadcast).toMatchObject({
-          runId: "idem-agent-source-reply-media",
-          sessionKey: "main",
-          state: "final",
-        });
-        expect(extractFirstTextBlock(broadcast)).toBe("Codex source reply with media");
-        const broadcastContent = getMessageContent(broadcast);
-        expect(String(broadcastContent[1]?.url)).toContain("/api/chat/media/outgoing/");
-        expect(String(broadcastContent[1]?.openUrl)).toContain("/api/chat/media/outgoing/");
-        const assistantUpdates = mockState.emittedTranscriptUpdates.filter(
-          (update) =>
-            typeof update.message === "object" &&
-            update.message !== null &&
-            (update.message as { role?: unknown }).role === "assistant",
-        );
-        expect(assistantUpdates).toStrictEqual([]);
-        const assistantEntries = await readActiveAssistantTranscriptMessages();
-        expect(assistantEntries).toHaveLength(1);
-        expect(assistantEntries[0]?.idempotencyKey).toBe(mirrorIdempotencyKey);
-        expect(JSON.stringify(assistantEntries[0])).toContain("/api/chat/media/outgoing/");
-        expect(JSON.stringify(assistantEntries[0])).not.toContain(mediaUrl);
+          expect(broadcast).toMatchObject({
+            runId: "idem-agent-source-reply-media",
+            sessionKey: "main",
+            state: "final",
+          });
+          expect(extractFirstTextBlock(broadcast)).toBe("Codex source reply with media");
+          const broadcastContent = getMessageContent(broadcast);
+          expect(String(broadcastContent[1]?.url)).toContain("/api/chat/media/outgoing/");
+          expect(String(broadcastContent[1]?.openUrl)).toContain("/api/chat/media/outgoing/");
+          const assistantUpdates = mockState.emittedTranscriptUpdates.filter(
+            (update) =>
+              typeof update.message === "object" &&
+              update.message !== null &&
+              (update.message as { role?: unknown }).role === "assistant",
+          );
+          expect(assistantUpdates).toStrictEqual([]);
+          const assistantEntries = await readActiveAssistantTranscriptMessages();
+          expect(assistantEntries).toHaveLength(1);
+          expect(assistantEntries[0]?.idempotencyKey).toBe(mirrorIdempotencyKey);
+          expect(JSON.stringify(assistantEntries[0])).toContain("/api/chat/media/outgoing/");
+          expect(JSON.stringify(assistantEntries[0])).not.toContain(mediaUrl);
+          const store = JSON.parse(fs.readFileSync(storePath, "utf-8")) as Record<
+            string,
+            { updatedAt?: number; status?: string }
+          >;
+          expect(store.main?.updatedAt).toBeGreaterThanOrEqual(rewrittenAt);
+          expect(store.main?.updatedAt).toBeGreaterThan(updatedAt);
+          expect(store.main?.status).toBe("done");
+        } finally {
+          vi.useRealTimers();
+        }
       },
     );
   });

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -48,7 +48,7 @@ import { getReplyPayloadMetadata, type ReplyPayload } from "../../auto-reply/rep
 import { createReplyDispatcher } from "../../auto-reply/reply/reply-dispatcher.js";
 import { stageSandboxMedia } from "../../auto-reply/reply/stage-sandbox-media.js";
 import type { MsgContext, TemplateContext } from "../../auto-reply/templating.js";
-import { resolveSessionFilePath } from "../../config/sessions.js";
+import { resolveSessionFilePath, updateSessionStoreEntry } from "../../config/sessions.js";
 import { resolveMirroredTranscriptText } from "../../config/sessions/transcript-mirror.js";
 import { CURRENT_SESSION_VERSION } from "../../config/sessions/version.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -1631,7 +1631,7 @@ async function appendAssistantTranscriptMessage(params: {
     }
   }
 
-  return await appendInjectedAssistantMessageToTranscript({
+  const appended = await appendInjectedAssistantMessageToTranscript({
     transcriptPath,
     sessionKey: params.sessionKey,
     ...(params.agentId ? { agentId: params.agentId } : {}),
@@ -1643,6 +1643,16 @@ async function appendAssistantTranscriptMessage(params: {
     ttsSupplement: params.ttsSupplement,
     config: params.cfg,
   });
+  if (appended.ok && params.storePath) {
+    const transcriptMarkerUpdatedAt = Date.now();
+    await updateSessionStoreEntry({
+      storePath: params.storePath,
+      sessionKey: params.sessionKey,
+      update: (current) =>
+        current.sessionId === params.sessionId ? { updatedAt: transcriptMarkerUpdatedAt } : null,
+    });
+  }
+  return appended;
 }
 
 function collectSessionAbortPartials(params: {

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -1643,16 +1643,32 @@ async function appendAssistantTranscriptMessage(params: {
     ttsSupplement: params.ttsSupplement,
     config: params.cfg,
   });
-  if (appended.ok && params.storePath) {
-    const transcriptMarkerUpdatedAt = Date.now();
-    await updateSessionStoreEntry({
+  if (appended.ok) {
+    await advanceSessionTranscriptMarker({
       storePath: params.storePath,
       sessionKey: params.sessionKey,
-      update: (current) =>
-        current.sessionId === params.sessionId ? { updatedAt: transcriptMarkerUpdatedAt } : null,
+      sessionId: params.sessionId,
     });
   }
   return appended;
+}
+
+async function advanceSessionTranscriptMarker(params: {
+  storePath: string | undefined;
+  sessionKey: string;
+  sessionId: string;
+}): Promise<void> {
+  if (!params.storePath) {
+    return;
+  }
+
+  const transcriptMarkerUpdatedAt = Date.now();
+  await updateSessionStoreEntry({
+    storePath: params.storePath,
+    sessionKey: params.sessionKey,
+    update: (current) =>
+      current.sessionId === params.sessionId ? { updatedAt: transcriptMarkerUpdatedAt } : null,
+  });
 }
 
 function collectSessionAbortPartials(params: {
@@ -4114,6 +4130,11 @@ export const chatHandlers: GatewayRequestHandlers = {
                             },
                           });
                           if (result.changed) {
+                            await advanceSessionTranscriptMarker({
+                              storePath: latestStorePath,
+                              sessionKey,
+                              sessionId,
+                            });
                             for (const target of rewriteTargets) {
                               const rewritten =
                                 await findSourceReplyTranscriptMirrorByIdempotencyKey(


### PR DESCRIPTION
## Summary

Fixes #60542.

This PR reconciles stale terminal main-session rows against their transcript file before implicit session reuse. If the main-session row is terminal and its transcript mtime is newer than the registry marker, implicit CLI, Gateway, and auto-reply paths start a fresh session instead of reusing stale terminal state.

It also advances the session registry marker after managed transcript writes so normal OpenClaw appends do not create a false "transcript newer than registry" signal.

## AI assistance

This PR was implemented with Codex assistance. I reviewed the affected session/transcript path and understand how the change works.

## Real behavior proof

Behavior addressed: stale terminal main-session registry entries are reconciled against their transcript mtime before implicit reuse.

Real environment tested: local Node 24 TypeScript runtime modules with an isolated throwaway OpenClaw session store/transcript directory.

Exact steps or command run after this patch: `node --import tsx <inline proof script exercising resolveSession, appendAssistantMessageToSessionTranscript, and hasTerminalMainSessionTranscriptNewerThanRegistrySync>`.

Evidence after fix: copied terminal output from the isolated runtime proof:

```text
Behavior addressed: stale terminal main-session registry entries are reconciled against their transcript mtime before implicit reuse.
Real environment tested: local Node 24 TypeScript runtime modules with an isolated throwaway OpenClaw session store/transcript directory.
Exact steps or command run after this patch: node --import tsx <inline proof script exercising resolveSession, appendAssistantMessageToSessionTranscript, and hasTerminalMainSessionTranscriptNewerThanRegistrySync>.
Evidence after fix: {"staleDetected":true,"implicitRotated":true,"implicitClearedTerminalMetadata":true,"explicitSessionIdBypassedRotation":true,"managedAppendOk":true,"managedAppendMarkerAtOrAfterTranscriptMtime":true,"managedAppendNoFalseStale":true}
Observed result after fix: implicit main resolution rotated the stale terminal row, explicit session-id resume reused it, and a managed append advanced the registry marker so the appended transcript was not considered stale.
What was not tested: live provider/model execution, real Telegram delivery, and browser UI; this proof isolates the affected session/transcript runtime path.
```

Observed result after fix: implicit main resolution rotated the stale terminal row, explicit session-id resume reused it, and a managed append advanced the registry marker so the appended transcript was not considered stale.

What was not tested: live provider/model execution, real Telegram delivery, and browser UI; this proof isolates the affected session/transcript runtime path.

## Root Cause

OpenClaw had several implicit main-session entry points that trusted the session store row's freshness independently from the transcript file. When a main-session row was already terminal but older than its transcript file, later implicit turns could keep reusing or forking from stale terminal session state.

The missing piece was a shared check that treats "terminal main row plus newer transcript mtime" as stale for implicit reuse. The companion issue was that managed transcript append paths also needed to update the store marker after real writes, otherwise the new guard would rotate healthy sessions after OpenClaw wrote to their transcripts itself.

## Dependency Contract

No external dependency or API contract changed.

Internal contracts checked:

- Session lifecycle freshness is decided from store timestamps plus transcript metadata in `src/config/sessions/lifecycle.ts`.
- `appendSessionTranscriptMessage` reports whether a real transcript append happened, so marker updates can stay tied to actual writes.
- `updateSessionStoreEntry` merges `updatedAt` through the existing session store write path instead of adding a sidecar or fallback store.
- Gateway server-method transcript writes continue using the session transcript append helpers, matching `src/gateway/server-methods/AGENTS.md`.

## Regression Test Plan

Added focused coverage for the affected entry points and writers:

- CLI session resolution rotates stale terminal main rows, including endedAt-only rows, and clears stale lifecycle fields.
- Explicit `sessionId` resume is not rotated by the implicit main-session guard.
- Gateway `agent.run` rotates stale implicit main rows but bypasses explicit session-id, cron, and heartbeat runs.
- Auto-reply rotates user events but bypasses system events.
- Managed assistant transcript appends update the registry marker only after a real append.
- Telegram delivery mirror appends advance the active session marker.

## Security Impact

No credential handling, auth policy, secret storage, sandboxing, or network surface changes. The real behavior proof used a throwaway local session store and did not print real credentials.

## Human Verification

I reviewed the code path and proof output for the session/transcript reconciliation behavior. The proof is intentionally isolated from real provider credentials and live channel accounts.

## CODEOWNERS / Owner Review

`.github/CODEOWNERS` has no explicit required owner match for the touched paths. The affected areas are session lifecycle, CLI/Gateway/auto-reply session resolution, and Telegram delivery mirror behavior, so Agents/Gateway/Telegram maintainer review would still be useful.

## Changelog

No `CHANGELOG.md` edit. This is a contributor PR; maintainers can add release-note wording when landing if they want it called out.

## Review Conversations

No GitHub review conversations yet.

Local review before opening:

- `codex review --base origin/main` found the endedAt-only terminal-row gap; fixed and retested.
- `autoreview` found stale lifecycle timestamps carried through rotated CLI session entries; fixed and retested.
- Final `codex review --base origin/main` completed cleanly.

## Risks

The main risk is session rotation sensitivity: if a terminal main row has a transcript mtime newer than the registry marker for a reason unrelated to real transcript activity, implicit reuse now starts fresh. That is deliberate for the reported state divergence, and the check is limited to terminal main rows.

## Behavior Tradeoffs

The patch favors starting a fresh implicit main session over reusing terminal state when the transcript proves newer activity than the registry. Explicit `sessionId` resume, failed-row recovery, cron, heartbeat, non-main sessions, and system auto-reply events keep their existing behavior.

## Scope Boundaries

This is not a session storage rewrite. It does not migrate state, change transcript formats, add config, alter provider execution, or change live channel delivery policy. It adds one shared reconciliation check and updates the managed transcript writers that can create the marker drift.

Codex/Copilot transcript mirror paths were inspected as siblings but left unchanged because they are runtime-owned mirror flows outside the affected main-session reuse path.

## Validation

Focused tests:

```text
node scripts/run-vitest.mjs extensions/telegram/src/bot-message-dispatch.test.ts src/gateway/server-methods/chat.directive-tags.test.ts src/config/sessions/transcript.test.ts src/agents/command/attempt-execution.cli.test.ts src/commands/agent.session.test.ts src/auto-reply/reply/session.test.ts src/gateway/server-methods/agent.test.ts
```

Result:

```text
[test] passed 6 Vitest shards
gateway: 4 files / 506 tests
runtime-config: 1 file / 29 tests
commands: 1 file / 7 tests
auto-reply: 1 file / 103 tests
agents: 1 file / 35 tests
extension-telegram: 1 file / 104 tests
```

Lint/format checks:

```text
node scripts/run-oxlint.mjs extensions/telegram/src/bot-message-dispatch.runtime.ts extensions/telegram/src/bot-message-dispatch.test.ts extensions/telegram/src/bot-message-dispatch.ts src/agents/command/attempt-execution.cli.test.ts src/agents/command/attempt-execution.shared.ts src/agents/command/attempt-execution.ts src/agents/command/session.ts src/auto-reply/reply/session.test.ts src/auto-reply/reply/session.ts src/commands/agent.session.test.ts src/config/sessions/lifecycle.ts src/config/sessions/transcript.test.ts src/config/sessions/transcript.ts src/gateway/server-methods/agent.test.ts src/gateway/server-methods/agent.ts src/gateway/server-methods/chat.directive-tags.test.ts src/gateway/server-methods/chat.ts
git diff --check origin/main
```

Result: both passed.

Review gates:

```text
.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --output .artifacts/autoreview-60542-after-lifecycle.log --json-output .artifacts/autoreview-60542-after-lifecycle.json
codex review --base origin/main
```

Result: both clean after addressed findings.
