### PR TITLE
fix: allow trusted host-read html after outbound staging

### DIFF
--- a/src/media/outbound-attachment.test.ts
+++ b/src/media/outbound-attachment.test.ts
@@ -1,11 +1,16 @@
 // Outbound attachment tests cover media loading rules for outgoing messages.
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 const loadWebMedia = vi.hoisted(() => vi.fn());
+const markTrustedGeneratedHtmlPath = vi.hoisted(() => vi.fn());
 const saveMediaBuffer = vi.hoisted(() => vi.fn());
+const rm = vi.hoisted(() => vi.fn(async () => {}));
+
+vi.mock("node:fs/promises", () => ({ rm }));
 
 vi.mock("./web-media.js", () => ({
   loadWebMedia,
+  markTrustedGeneratedHtmlPath,
 }));
 
 vi.mock("./store.js", () => ({
@@ -14,6 +19,8 @@ vi.mock("./store.js", () => ({
 
 const { resolveOutboundAttachmentFromBuffer, resolveOutboundAttachmentFromUrl } =
   await import("./outbound-attachment.js");
+
+afterEach(() => vi.clearAllMocks());
 
 describe("resolveOutboundAttachmentFromUrl", () => {
   it("preserves the loaded file name when staging outbound media", async () => {
@@ -37,6 +44,45 @@ describe("resolveOutboundAttachmentFromUrl", () => {
       1024,
       "report.pdf",
     );
+    expect(markTrustedGeneratedHtmlPath).not.toHaveBeenCalled();
+  });
+
+  it("marks staged trusted HTML with its exact bytes", async () => {
+    const buffer = Buffer.from("<!doctype html><title>report</title>");
+    loadWebMedia.mockResolvedValueOnce({
+      buffer,
+      contentType: "text/html",
+      fileName: "report.html",
+      trustedGeneratedHtmlSource: true,
+    });
+    saveMediaBuffer.mockResolvedValueOnce({
+      path: "/tmp/media/outbound/report---uuid.html",
+      contentType: "text/html",
+    });
+
+    await resolveOutboundAttachmentFromUrl("/tmp/openclaw/report.html", 1024);
+
+    expect(markTrustedGeneratedHtmlPath).toHaveBeenCalledWith(
+      "/tmp/media/outbound/report---uuid.html",
+      buffer,
+    );
+  });
+
+  it("removes the staged file and propagates marker write failures", async () => {
+    const buffer = Buffer.from("<!doctype html><title>report</title>");
+    const stagedPath = "/tmp/media/outbound/report---uuid.html";
+    loadWebMedia.mockResolvedValueOnce({
+      buffer,
+      contentType: "text/html",
+      trustedGeneratedHtmlSource: true,
+    });
+    saveMediaBuffer.mockResolvedValueOnce({ path: stagedPath, contentType: "text/html" });
+    markTrustedGeneratedHtmlPath.mockRejectedValueOnce(new Error("marker write failed"));
+
+    await expect(
+      resolveOutboundAttachmentFromUrl("/tmp/openclaw/report.html", 1024),
+    ).rejects.toThrow("marker write failed");
+    expect(rm).toHaveBeenCalledWith(stagedPath, { force: true });
   });
 });
 

--- a/src/media/outbound-attachment.ts
+++ b/src/media/outbound-attachment.ts
@@ -1,7 +1,8 @@
 // Outbound attachment helpers prepare media attachments for channel delivery.
+import { rm } from "node:fs/promises";
 import { buildOutboundMediaLoadOptions, type OutboundMediaAccess } from "./load-options.js";
 import { saveMediaBuffer } from "./store.js";
-import { loadWebMedia } from "./web-media.js";
+import { loadWebMedia, markTrustedGeneratedHtmlPath } from "./web-media.js";
 
 /** Loads a remote/local media URL and stages it into the outbound media store. */
 export async function resolveOutboundAttachmentFromUrl(
@@ -30,6 +31,14 @@ export async function resolveOutboundAttachmentFromUrl(
     maxBytes,
     media.fileName,
   );
+  if (media.trustedGeneratedHtmlSource) {
+    try {
+      await markTrustedGeneratedHtmlPath(saved.path, media.buffer);
+    } catch (error) {
+      await rm(saved.path, { force: true }).catch(() => {});
+      throw error;
+    }
+  }
   return { path: saved.path, contentType: saved.contentType };
 }
 

--- a/src/media/store.ts
+++ b/src/media/store.ts
@@ -206,6 +206,9 @@ export async function cleanOldMedia(ttlMs = DEFAULT_TTL_MS, options: CleanOldMed
     recursive: options.recursive ?? true,
     pruneEmptyDirs: options.pruneEmptyDirs,
   });
+  // Trust metadata must not outlive the staged file that it authorizes.
+  const { pruneStaleTrustedGeneratedHtmlMarkers } = await import("./web-media.js");
+  await pruneStaleTrustedGeneratedHtmlMarkers();
 }
 
 function looksLikeUrl(src: string) {

--- a/src/media/web-media.test.ts
+++ b/src/media/web-media.test.ts
@@ -680,6 +680,245 @@ describe("loadWebMedia", () => {
     expect(result.contentType).toBe("text/html");
   });
 
+  it("allows exact marked outbound HTML bytes and rejects same-size replacements", async () => {
+    const stateRoot = await fs.mkdtemp(path.join(os.tmpdir(), "web-media-state-"));
+    try {
+      await withEnvAsync({ OPENCLAW_STATE_DIR: stateRoot }, async () => {
+        const { saveMediaBuffer } = await import("./store.js");
+        const { markTrustedGeneratedHtmlPath } = await import("./web-media.js");
+        const original = Buffer.from("<!doctype html><h1>A</h1>", "utf8");
+        const replacement = Buffer.from("<!doctype html><h1>B</h1>", "utf8");
+        expect(replacement.length).toBe(original.length);
+        const saved = await saveMediaBuffer(
+          original,
+          "text/html",
+          "outbound",
+          1024 * 1024,
+          "report.html",
+        );
+        await markTrustedGeneratedHtmlPath(saved.path, original);
+
+        const allowed = await loadWebMedia(saved.path, {
+          maxBytes: 1024 * 1024,
+          localRoots: "any",
+          readFile: async (filePath) => await fs.readFile(filePath),
+          hostReadCapability: true,
+        });
+        expect(allowed.buffer).toEqual(original);
+        expect(allowed.trustedGeneratedHtmlSource).toBe(true);
+
+        await fs.writeFile(saved.path, replacement);
+        await expectLoadWebMediaErrorCode(
+          loadWebMedia(saved.path, {
+            maxBytes: 1024 * 1024,
+            localRoots: "any",
+            readFile: async (filePath) => await fs.readFile(filePath),
+            hostReadCapability: true,
+          }),
+          "path-not-allowed",
+        );
+      });
+    } finally {
+      await fs.rm(stateRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects unmarked outbound HTML", async () => {
+    const stateRoot = await fs.mkdtemp(path.join(os.tmpdir(), "web-media-state-"));
+    try {
+      await withEnvAsync({ OPENCLAW_STATE_DIR: stateRoot }, async () => {
+        const { saveMediaBuffer } = await import("./store.js");
+        const saved = await saveMediaBuffer(
+          Buffer.from("<!doctype html><h1>untrusted</h1>", "utf8"),
+          "text/html",
+          "outbound",
+          1024 * 1024,
+          "report.html",
+        );
+        await expectLoadWebMediaErrorCode(
+          loadWebMedia(saved.path, {
+            maxBytes: 1024 * 1024,
+            localRoots: "any",
+            readFile: async (filePath) => await fs.readFile(filePath),
+            hostReadCapability: true,
+          }),
+          "path-not-allowed",
+        );
+      });
+    } finally {
+      await fs.rm(stateRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("requires a marker when outbound staging is nested under the trusted temp root", async () => {
+    const stateRoot = await fs.mkdtemp(
+      path.join(resolvePreferredOpenClawTmpDir(), "web-media-overlap-state-"),
+    );
+    try {
+      await withEnvAsync({ OPENCLAW_STATE_DIR: stateRoot }, async () => {
+        const { saveMediaBuffer } = await import("./store.js");
+        const saved = await saveMediaBuffer(
+          Buffer.from("<!doctype html><h1>unmarked overlap</h1>", "utf8"),
+          "text/html",
+          "outbound",
+          1024 * 1024,
+          "report.html",
+        );
+        expect(path.resolve(saved.path)).toContain(path.resolve(resolvePreferredOpenClawTmpDir()));
+        await expectLoadWebMediaErrorCode(
+          loadWebMedia(saved.path, {
+            maxBytes: 1024 * 1024,
+            localRoots: "any",
+            readFile: async (filePath) => await fs.readFile(filePath),
+            hostReadCapability: true,
+          }),
+          "path-not-allowed",
+        );
+      });
+    } finally {
+      await fs.rm(stateRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("prunes markers whose staged file was removed", async () => {
+    const stateRoot = await fs.mkdtemp(path.join(os.tmpdir(), "web-media-state-"));
+    try {
+      await withEnvAsync({ OPENCLAW_STATE_DIR: stateRoot }, async () => {
+        const { saveMediaBuffer } = await import("./store.js");
+        const { markTrustedGeneratedHtmlPath, pruneStaleTrustedGeneratedHtmlMarkers } =
+          await import("./web-media.js");
+        const html = Buffer.from("<!doctype html><h1>report</h1>", "utf8");
+        const saved = await saveMediaBuffer(
+          html,
+          "text/html",
+          "outbound",
+          1024 * 1024,
+          "report.html",
+        );
+        await markTrustedGeneratedHtmlPath(saved.path, html);
+        await fs.rm(saved.path);
+        await pruneStaleTrustedGeneratedHtmlMarkers();
+        await fs.writeFile(saved.path, html);
+
+        await expectLoadWebMediaErrorCode(
+          loadWebMedia(saved.path, {
+            maxBytes: 1024 * 1024,
+            localRoots: "any",
+            readFile: async (filePath) => await fs.readFile(filePath),
+            hostReadCapability: true,
+          }),
+          "path-not-allowed",
+        );
+      });
+    } finally {
+      await fs.rm(stateRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps markers when filesystem inspection fails transiently", async () => {
+    const stateRoot = await fs.mkdtemp(path.join(os.tmpdir(), "web-media-state-"));
+    try {
+      await withEnvAsync({ OPENCLAW_STATE_DIR: stateRoot }, async () => {
+        const { saveMediaBuffer } = await import("./store.js");
+        const { markTrustedGeneratedHtmlPath, pruneStaleTrustedGeneratedHtmlMarkers } =
+          await import("./web-media.js");
+        const html = Buffer.from("<!doctype html><h1>report</h1>", "utf8");
+        const saved = await saveMediaBuffer(
+          html,
+          "text/html",
+          "outbound",
+          1024 * 1024,
+          "report.html",
+        );
+        await markTrustedGeneratedHtmlPath(saved.path, html);
+        const lstatSpy = vi
+          .spyOn(fs, "lstat")
+          .mockRejectedValueOnce(Object.assign(new Error("busy"), { code: "EMFILE" }));
+        try {
+          await pruneStaleTrustedGeneratedHtmlMarkers();
+        } finally {
+          lstatSpy.mockRestore();
+        }
+
+        const result = await loadWebMedia(saved.path, {
+          maxBytes: 1024 * 1024,
+          localRoots: "any",
+          readFile: async (filePath) => await fs.readFile(filePath),
+          hostReadCapability: true,
+        });
+        expect(result.buffer).toEqual(html);
+      });
+    } finally {
+      await fs.rm(stateRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("prunes more stale markers than one SQLite parameter batch", async () => {
+    const stateRoot = await fs.mkdtemp(path.join(os.tmpdir(), "web-media-state-"));
+    try {
+      await withEnvAsync({ OPENCLAW_STATE_DIR: stateRoot }, async () => {
+        const { executeSqliteQuerySync, executeSqliteQueryTakeFirstSync, getNodeSqliteKysely } =
+          await import("../infra/kysely-sync.js");
+        const { openOpenClawStateDatabase, runOpenClawStateWriteTransaction } =
+          await import("../state/openclaw-state-db.js");
+        const { pruneStaleTrustedGeneratedHtmlMarkers } = await import("./web-media.js");
+        type ProvenanceDb = {
+          outbound_media_provenance: {
+            realpath: string;
+            kind: string;
+            version: number;
+            sha256: string;
+            size_bytes: number;
+            created_at_ms: number;
+          };
+        };
+        runOpenClawStateWriteTransaction(({ db }) => {
+          const kysely = getNodeSqliteKysely<ProvenanceDb>(db);
+          for (let index = 0; index < 1_001; index += 1) {
+            executeSqliteQuerySync(
+              db,
+              kysely.insertInto("outbound_media_provenance").values({
+                realpath: path.join(stateRoot, `missing-${index}.html`),
+                kind: "trusted-generated-html",
+                version: 1,
+                sha256: "0".repeat(64),
+                size_bytes: 1,
+                created_at_ms: 1,
+              }),
+            );
+          }
+        });
+
+        await pruneStaleTrustedGeneratedHtmlMarkers();
+
+        const { db } = openOpenClawStateDatabase();
+        const count = executeSqliteQueryTakeFirstSync(
+          db,
+          getNodeSqliteKysely<ProvenanceDb>(db)
+            .selectFrom("outbound_media_provenance")
+            .select(({ fn }) => fn.countAll<number>().as("count")),
+        );
+        expect(Number(count?.count)).toBe(0);
+      });
+    } finally {
+      await fs.rm(stateRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("refuses to mark paths outside outbound staging", async () => {
+    const outsideRoot = await fs.mkdtemp(path.join(os.tmpdir(), "web-media-marker-outside-"));
+    const outsideFile = path.join(outsideRoot, "report.html");
+    await fs.writeFile(outsideFile, "<!doctype html><h1>outside</h1>", "utf8");
+    try {
+      const { markTrustedGeneratedHtmlPath } = await import("./web-media.js");
+      await expect(
+        markTrustedGeneratedHtmlPath(outsideFile, await fs.readFile(outsideFile)),
+      ).rejects.toThrow(/outside outbound staging/i);
+    } finally {
+      await fs.rm(outsideRoot, { recursive: true, force: true });
+    }
+  });
+
   it("rejects host-read HTML files outside the trusted OpenClaw temp root", async () => {
     const outsideRoot = await fs.mkdtemp(path.join(os.tmpdir(), "web-media-host-html-"));
     const htmlFile = path.join(outsideRoot, "report.html");

--- a/src/media/web-media.ts
+++ b/src/media/web-media.ts
@@ -1,4 +1,5 @@
 // Web media helpers load local and remote media for web-facing surfaces.
+import { createHash } from "node:crypto";
 import { lstat, realpath } from "node:fs/promises";
 import path from "node:path";
 import { maxBytesForKind, type MediaKind } from "@openclaw/media-core/constants";
@@ -17,11 +18,23 @@ import { resolveCanvasHttpPathToLocalPath } from "../canvas/documents.js";
 import { logVerbose, shouldLogVerbose } from "../globals.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { FsSafeError, readLocalFileSafely } from "../infra/fs-safe.js";
+import {
+  executeSqliteQuerySync,
+  executeSqliteQueryTakeFirstSync,
+  getNodeSqliteKysely,
+} from "../infra/kysely-sync.js";
 import { assertNoWindowsNetworkPath, safeFileURLToPath } from "../infra/local-file-access.js";
 import type { PinnedDispatcherPolicy, SsrFPolicy } from "../infra/net/ssrf.js";
+import { isNotFoundPathError } from "../infra/path-guards.js";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 import { getActivePluginRegistry } from "../plugins/runtime.js";
+import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
+import {
+  openOpenClawStateDatabase,
+  runOpenClawStateWriteTransaction,
+} from "../state/openclaw-state-db.js";
 import { resolveUserPath } from "../utils.js";
+import { chunkItems } from "../utils/chunk-items.js";
 import { readRemoteMediaBuffer } from "./fetch.js";
 import {
   assertLocalMediaAllowed,
@@ -46,6 +59,8 @@ export type WebMediaResult = {
   contentType?: string;
   kind: MediaKind | undefined;
   fileName?: string;
+  /** Source bytes came from a generated-HTML trust boundary. */
+  trustedGeneratedHtmlSource?: boolean;
 };
 
 type WebMediaOptions = {
@@ -299,28 +314,160 @@ function hasHtmlDocumentShape(text: string): boolean {
   return /^(?:<!doctype\s+html\b|<html\b)/iu.test(sample) || /<\/(?:html|body)>/iu.test(sample);
 }
 
-async function isTrustedGeneratedHostReadHtmlPath(filePath: string | undefined): Promise<boolean> {
+type HostReadHtmlTrust =
+  | { source: "temp-root" }
+  | { source: "outbound"; expectedSha256: string; expectedSize: number };
+
+const TRUSTED_GENERATED_HTML_MARKER_VERSION = 1;
+const TRUSTED_GENERATED_HTML_MARKER_KIND = "trusted-generated-html";
+type OutboundProvenanceDatabase = Pick<OpenClawStateKyselyDatabase, "outbound_media_provenance">;
+
+async function getTrustedGeneratedHtmlMarker(
+  resolvedFilePath: string,
+): Promise<{ sha256: string; size: number } | undefined> {
+  try {
+    const { db } = openOpenClawStateDatabase();
+    const row = executeSqliteQueryTakeFirstSync(
+      db,
+      getNodeSqliteKysely<OutboundProvenanceDatabase>(db)
+        .selectFrom("outbound_media_provenance")
+        .select(["kind", "version", "sha256", "size_bytes"])
+        .where("realpath", "=", resolvedFilePath),
+    );
+    return row?.kind === TRUSTED_GENERATED_HTML_MARKER_KIND &&
+      row.version === TRUSTED_GENERATED_HTML_MARKER_VERSION
+      ? { sha256: row.sha256, size: row.size_bytes }
+      : undefined;
+  } catch (error) {
+    // State failures must narrow trust, never turn into a permissive fallback.
+    logVerbose(
+      `trusted-html marker lookup failed (${resolvedFilePath}): ${formatErrorMessage(error)}`,
+    );
+    return undefined;
+  }
+}
+
+async function resolveTrustedGeneratedHostReadHtml(
+  filePath: string | undefined,
+): Promise<HostReadHtmlTrust | undefined> {
   if (!filePath) {
-    return false;
+    return undefined;
   }
   const info = await lstat(filePath).catch(() => undefined);
   if (!info?.isFile() || info.isSymbolicLink() || info.nlink !== 1) {
-    return false;
+    return undefined;
   }
-  const [resolvedFilePath, resolvedTmpRoot] = await Promise.all([
+  const [resolvedFilePath, tmpRoot, outboundRoot] = await Promise.all([
     realpath(filePath).catch(() => undefined),
     realpath(resolvePreferredOpenClawTmpDir()).catch(() => undefined),
+    realpath(path.join(getMediaDir(), "outbound")).catch(() => undefined),
   ]);
-  return Boolean(
-    resolvedFilePath && resolvedTmpRoot && isPathInsideRoot(resolvedFilePath, resolvedTmpRoot),
-  );
+  if (!resolvedFilePath) {
+    return undefined;
+  }
+  // Outbound staging always requires provenance, even when a custom state dir
+  // places media/outbound underneath the otherwise trusted temp root.
+  if (outboundRoot && isPathInsideRoot(resolvedFilePath, outboundRoot)) {
+    const marker = await getTrustedGeneratedHtmlMarker(resolvedFilePath);
+    return marker
+      ? { source: "outbound", expectedSha256: marker.sha256, expectedSize: marker.size }
+      : undefined;
+  }
+  return tmpRoot && isPathInsideRoot(resolvedFilePath, tmpRoot)
+    ? { source: "temp-root" }
+    : undefined;
+}
+
+/** Records exact-byte provenance for a trusted generated HTML staged outbound. */
+export async function markTrustedGeneratedHtmlPath(
+  filePath: string,
+  contents: Buffer,
+): Promise<void> {
+  const resolvedFilePath = await realpath(filePath);
+  const outboundRoot = await realpath(path.join(getMediaDir(), "outbound")).catch(() => undefined);
+  if (!outboundRoot || !isPathInsideRoot(resolvedFilePath, outboundRoot)) {
+    throw new Error(
+      `markTrustedGeneratedHtmlPath: refusing path outside outbound staging: ${resolvedFilePath}`,
+    );
+  }
+  const sha256 = createHash("sha256").update(contents).digest("hex");
+  const sizeBytes = contents.length;
+  const createdAtMs = Date.now();
+  runOpenClawStateWriteTransaction(({ db }) => {
+    executeSqliteQuerySync(
+      db,
+      getNodeSqliteKysely<OutboundProvenanceDatabase>(db)
+        .insertInto("outbound_media_provenance")
+        .values({
+          realpath: resolvedFilePath,
+          kind: TRUSTED_GENERATED_HTML_MARKER_KIND,
+          version: TRUSTED_GENERATED_HTML_MARKER_VERSION,
+          sha256,
+          size_bytes: sizeBytes,
+          created_at_ms: createdAtMs,
+        })
+        .onConflict((conflict) =>
+          conflict.column("realpath").doUpdateSet({
+            kind: TRUSTED_GENERATED_HTML_MARKER_KIND,
+            version: TRUSTED_GENERATED_HTML_MARKER_VERSION,
+            sha256,
+            size_bytes: sizeBytes,
+            created_at_ms: createdAtMs,
+          }),
+        ),
+    );
+  });
+}
+
+/** Removes provenance whose staged regular file no longer exists. */
+export async function pruneStaleTrustedGeneratedHtmlMarkers(): Promise<void> {
+  const { db } = openOpenClawStateDatabase();
+  const rows = executeSqliteQuerySync(
+    db,
+    getNodeSqliteKysely<OutboundProvenanceDatabase>(db)
+      .selectFrom("outbound_media_provenance")
+      .select("realpath"),
+  ).rows;
+  const stale: string[] = [];
+  for (const row of rows) {
+    let info: Awaited<ReturnType<typeof lstat>>;
+    try {
+      info = await lstat(row.realpath);
+    } catch (error) {
+      if (isNotFoundPathError(error)) {
+        stale.push(row.realpath);
+      } else {
+        logVerbose(
+          `trusted-html prune kept uninspectable marker (${row.realpath}): ${formatErrorMessage(error)}`,
+        );
+      }
+      continue;
+    }
+    if (!info?.isFile() || info.isSymbolicLink() || info.nlink !== 1) {
+      stale.push(row.realpath);
+    }
+  }
+  if (stale.length === 0) {
+    return;
+  }
+  runOpenClawStateWriteTransaction(({ db: writeDb }) => {
+    for (const batch of chunkItems(stale, 500)) {
+      executeSqliteQuerySync(
+        writeDb,
+        getNodeSqliteKysely<OutboundProvenanceDatabase>(writeDb)
+          .deleteFrom("outbound_media_provenance")
+          .where("realpath", "in", batch),
+      );
+    }
+  });
+  logVerbose(`trusted-html prune removed ${stale.length} stale marker(s)`);
 }
 
 function isTrustedGeneratedHostReadHtml(params: {
   filePath?: string;
   sniffedContentType?: string;
   buffer?: Buffer;
-  trustedGeneratedHtmlPath?: boolean;
+  trustedGeneratedHtmlPath?: HostReadHtmlTrust;
 }): boolean {
   const sniffedMime = normalizeMimeType(params.sniffedContentType);
   if (sniffedMime && sniffedMime !== "text/html") {
@@ -330,7 +477,17 @@ function isTrustedGeneratedHostReadHtml(params: {
     return false;
   }
   const text = getValidatedHostReadText(params.buffer);
-  return text !== undefined && hasHtmlDocumentShape(text);
+  if (text === undefined || !hasHtmlDocumentShape(text)) {
+    return false;
+  }
+  if (params.trustedGeneratedHtmlPath.source === "temp-root") {
+    return true;
+  }
+  return (
+    params.buffer?.length === params.trustedGeneratedHtmlPath.expectedSize &&
+    createHash("sha256").update(params.buffer).digest("hex") ===
+      params.trustedGeneratedHtmlPath.expectedSha256
+  );
 }
 
 function isAllowedHostReadTextAlias(mime: string | undefined, filePath?: string): boolean {
@@ -373,7 +530,7 @@ function assertHostReadMediaAllowed(params: {
   filePath?: string;
   kind: MediaKind | undefined;
   buffer?: Buffer;
-  trustedGeneratedHtmlPath?: boolean;
+  trustedGeneratedHtmlPath?: HostReadHtmlTrust;
 }): void {
   const declaredMime = normalizeMimeType(mimeTypeFromFilePath(params.filePath));
   const normalizedMime = normalizeMimeType(params.contentType);
@@ -922,6 +1079,7 @@ async function loadWebMediaInternal(
     contentType?: string;
     kind: MediaKind | undefined;
     fileName?: string;
+    trustedGeneratedHtmlSource?: boolean;
   }): Promise<WebMediaResult> => {
     // If caller explicitly provides maxBytes, trust it (for channels that handle large files).
     // Otherwise fall back to per-kind defaults.
@@ -971,6 +1129,7 @@ async function loadWebMediaInternal(
       contentType: params.contentType ?? undefined,
       kind: params.kind,
       fileName: params.fileName,
+      ...(params.trustedGeneratedHtmlSource ? { trustedGeneratedHtmlSource: true } : {}),
     };
   };
 
@@ -1036,11 +1195,11 @@ async function loadWebMediaInternal(
   const hostReadDeclaredMime = hostReadCapability
     ? normalizeMimeType(mimeTypeFromFilePath(mediaUrl))
     : undefined;
-  const trustedGeneratedHtmlPath =
+  const htmlTrust =
     hostReadDeclaredMime === "text/html"
-      ? await isTrustedGeneratedHostReadHtmlPath(mediaUrl)
-      : false;
-  if (hostReadDeclaredMime === "text/html" && !trustedGeneratedHtmlPath) {
+      ? await resolveTrustedGeneratedHostReadHtml(mediaUrl)
+      : undefined;
+  if (hostReadDeclaredMime === "text/html" && !htmlTrust) {
     throw new LocalMediaAccessError("path-not-allowed", HOST_READ_DECLARED_TEXT_ERROR);
   }
 
@@ -1084,7 +1243,7 @@ async function loadWebMediaInternal(
       filePath: mediaUrl,
       kind,
       buffer: data,
-      trustedGeneratedHtmlPath,
+      trustedGeneratedHtmlPath: htmlTrust,
     });
   }
   let fileName = resolveLocalMediaFileName(mediaUrl);
@@ -1099,6 +1258,7 @@ async function loadWebMediaInternal(
     contentType: mime,
     kind,
     fileName,
+    trustedGeneratedHtmlSource: Boolean(htmlTrust && hostReadDeclaredMime === "text/html"),
   });
 }
 

--- a/src/state/openclaw-state-db.generated.d.ts
+++ b/src/state/openclaw-state-db.generated.d.ts
@@ -876,6 +876,15 @@ export interface OperatorApprovals {
   updated_at_ms: number;
 }
 
+export interface OutboundMediaProvenance {
+  created_at_ms: number;
+  kind: string;
+  realpath: string;
+  sha256: string;
+  size_bytes: number;
+  version: number;
+}
+
 export interface PluginBindingApprovals {
   account_id: string;
   approved_at: number;
@@ -1451,6 +1460,7 @@ export interface DB {
   official_external_plugin_catalog_snapshots: OfficialExternalPluginCatalogSnapshots;
   onboarding_recommendations: OnboardingRecommendations;
   operator_approvals: OperatorApprovals;
+  outbound_media_provenance: OutboundMediaProvenance;
   plugin_binding_approvals: PluginBindingApprovals;
   plugin_blob_entries: PluginBlobEntries;
   plugin_state_entries: PluginStateEntries;

--- a/src/state/openclaw-state-schema.generated.ts
+++ b/src/state/openclaw-state-schema.generated.ts
@@ -1990,4 +1990,13 @@ CREATE TABLE IF NOT EXISTS claw_package_refs (
   installed_at_ms INTEGER NOT NULL,
   updated_at_ms INTEGER NOT NULL,
   PRIMARY KEY (agent_id, package_kind, package_source, package_ref, package_version)
+) STRICT;
+
+CREATE TABLE IF NOT EXISTS outbound_media_provenance (
+  realpath TEXT NOT NULL PRIMARY KEY,
+  kind TEXT NOT NULL,
+  version INTEGER NOT NULL,
+  sha256 TEXT NOT NULL,
+  size_bytes INTEGER NOT NULL,
+  created_at_ms INTEGER NOT NULL
 ) STRICT;\n`;

--- a/src/state/openclaw-state-schema.sql
+++ b/src/state/openclaw-state-schema.sql
@@ -1986,3 +1986,12 @@ CREATE TABLE IF NOT EXISTS claw_package_refs (
   updated_at_ms INTEGER NOT NULL,
   PRIMARY KEY (agent_id, package_kind, package_source, package_ref, package_version)
 ) STRICT;
+
+CREATE TABLE IF NOT EXISTS outbound_media_provenance (
+  realpath TEXT NOT NULL PRIMARY KEY,
+  kind TEXT NOT NULL,
+  version INTEGER NOT NULL,
+  sha256 TEXT NOT NULL,
+  size_bytes INTEGER NOT NULL,
+  created_at_ms INTEGER NOT NULL
+) STRICT;


### PR DESCRIPTION
## What Problem This Solves

Fixes #90557. Trusted generated HTML reports pass the initial host-read check under the OpenClaw temp root, but normal reply delivery copies them into `media/outbound` and a channel adapter later reloads that staged path with host-read enabled. The staged path is outside the trusted temp root, so the second load rejects it and the outbound reply can be lost.

The trust decision must survive a process boundary. Normal reply delivery can persist a write-ahead queue intent before platform I/O, and gateway startup reloads pending delivery payloads for retry. An in-memory marker would therefore be insufficient for restart recovery.

## Why This Change Was Made

When `resolveOutboundAttachmentFromUrl` stages HTML that already passed the generated-HTML trust gate, it records the staged file's canonical realpath, SHA-256, byte size, provenance kind, version, and creation time in the shared SQLite state DB. `loadWebMedia` accepts outbound HTML only when containment, the provenance row, and the exact buffer already read all agree.

This does not trust the outbound directory by path. The existing regular-file, no-symlink, single-link, text-shape, and HTML-document checks remain in force. Outbound precedence also prevents an overlapping configured temp/state root from bypassing provenance. Marker-write failure removes the staged file and propagates; media cleanup prunes stale rows in bounded batches.

## User Impact

Generated `MEDIA:/tmp/openclaw/*.html` reports can be delivered after outbound staging instead of being rejected by the channel adapter's second host-read check. Arbitrary, unmarked, or byte-replaced HTML under `media/outbound` remains rejected.

## Evidence

Exact head: `28fe171dd9666352e19c59443e32cf8896734be3`, rebased on `d823cdc79496877883d8bba75691eac2e633fb99`.

```text
node scripts/run-vitest.mjs src/media/outbound-attachment.test.ts src/media/web-media.test.ts
# 2 files passed, 86 tests passed

node scripts/generate-kysely-types.mjs --verify
# exit 0

git diff --check
# exit 0

.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --stream-engine-output
# autoreview clean: no accepted/actionable findings reported
```

Regression coverage includes exact-byte acceptance, same-size replacement rejection, unmarked outbound rejection, overlapping-root precedence, marker-write cleanup, stale-row pruning, transient filesystem-error retention, and refusal to mark paths outside outbound staging.

The original report reproduces the first trusted load followed by the rejected staged reload. Independent Linux reproduction and a real Telegram Bot API send in the PR discussion confirm the same gate and end-to-end delivery behavior.

Contributor credit is preserved in the commit as `Co-authored-by: wanglu241 <wanglu241@jd.com>`.
