### PR TITLE
refactor(tui): drop unused pending-user chat-log helpers

### DIFF
--- a/src/tui/components/chat-log.test.ts
+++ b/src/tui/components/chat-log.test.ts
@@ -174,17 +174,6 @@ describe("ChatLog", () => {
     expect(chatLog.render(120).join("\n")).toContain("queued hello");
   });
 
-  it("stops counting a pending user message once the run is committed", () => {
-    const chatLog = new ChatLog(40);
-
-    chatLog.addPendingUser("run-1", "hello");
-    expect(chatLog.countPendingUsers()).toBe(1);
-
-    expect(chatLog.commitPendingUser("run-1")).toBe(true);
-    expect(chatLog.countPendingUsers()).toBe(0);
-    expect(chatLog.render(120).join("\n")).toContain("hello");
-  });
-
   it("reconciles pending users against rebuilt history using timestamps", () => {
     const chatLog = new ChatLog(40);
 

--- a/src/tui/components/chat-log.ts
+++ b/src/tui/components/chat-log.ts
@@ -198,10 +198,6 @@ export class ChatLog extends Container {
     return component;
   }
 
-  commitPendingUser(runId: string) {
-    return this.pendingUsers.delete(runId);
-  }
-
   dropPendingUser(runId: string) {
     const existing = this.pendingUsers.get(runId);
     if (!existing) {
@@ -210,10 +206,6 @@ export class ChatLog extends Container {
     this.removeChild(existing.component);
     this.pendingUsers.delete(runId);
     return true;
-  }
-
-  hasPendingUser(runId: string) {
-    return this.pendingUsers.has(runId);
   }
 
   reconcilePendingUsers(


### PR DESCRIPTION
## Summary

Removes two `ChatLog` pending-user helpers that have no production caller anywhere in the tree:

- `commitPendingUser(runId)` — only ever referenced by a single unit test; no runtime call site on `main`.
- `hasPendingUser(runId)` — referenced nowhere at all (no prod, no test).

These shipped with the TUI import but were never wired into a call site. The other pending-user helpers (`addPendingUser`, `dropPendingUser`, `reconcilePendingUsers`, `restorePendingUsers`, `clearPendingUsers`) and the `countPendingUsers` test accessor are retained — they are the surface an in-flight TUI PR (#86205) activates, and `countPendingUsers` is the observability hook used by the kept tests.

Also drops the now-orphaned `commitPendingUser` unit test.

## Verification

- `git grep commitPendingUser hasPendingUser` → no references remain in `src/tui/`.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.tui.config.ts src/tui/components/chat-log.test.ts` → 18 passed.
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.ui.json` → exit 0.

Net: 19 deletions, no behavior change (dead code only).
