### PR TITLE
fix: persist sender metadata in group chat JSONL records

### DIFF
--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -1202,6 +1202,14 @@ export async function runPreparedReply(
                 mediaOnlyText: "[User sent media without caption]",
               }
             : {}),
+          // Propagate sender identity for group chat JSONL records.
+          ...(sessionCtx.SenderId
+            ? {
+                senderId: sessionCtx.SenderId,
+                senderName: sessionCtx.SenderName ?? null,
+                senderUsername: sessionCtx.SenderUsername ?? null,
+              }
+            : {}),
         }
       : undefined;
   const userTurnTranscriptRecorder =

--- a/src/sessions/user-turn-transcript.test.ts
+++ b/src/sessions/user-turn-transcript.test.ts
@@ -733,4 +733,114 @@ describe("user turn transcript persistence", () => {
       ]);
     });
   });
+
+  describe("sender metadata in group chat sessions", () => {
+    it("persists __openclaw sender metadata when senderId is provided", async () => {
+      const dir = createTempDir("openclaw-user-turn-sender-metadata-");
+      const transcriptPath = path.join(dir, "session.jsonl");
+
+      const appended = await appendUserTurnTranscriptMessage({
+        transcriptPath,
+        sessionId: "session-1",
+        sessionKey: "main",
+        cwd: dir,
+        input: {
+          text: "hello from Ram",
+          timestamp: 123,
+          senderId: "8489979671",
+          senderName: "Ram Shenoy",
+          senderUsername: "ramshenoy",
+        },
+        updateMode: "none",
+      });
+
+      expect(appended?.message).toMatchObject({
+        role: "user",
+        content: "hello from Ram",
+      });
+      // Check the __openclaw block in the returned message.
+      expect(appended?.message).toHaveProperty("__openclaw");
+      expect((appended?.message as Record<string, unknown>).__openclaw).toMatchObject({
+        from: {
+          id: "8489979671",
+          first_name: "Ram Shenoy",
+          username: "ramshenoy",
+        },
+        senderId: "8489979671",
+      });
+
+      // Check the JSONL record also contains the __openclaw block.
+      const messages = readTranscriptMessages(transcriptPath);
+      expect(messages).toHaveLength(1);
+      expect(messages[0]).toMatchObject({
+        role: "user",
+        content: "hello from Ram",
+        __openclaw: {
+          from: {
+            id: "8489979671",
+            first_name: "Ram Shenoy",
+            username: "ramshenoy",
+          },
+          senderId: "8489979671",
+        },
+      });
+    });
+
+    it("persists senderId without name/username when only senderId is provided", async () => {
+      const dir = createTempDir("openclaw-user-turn-sender-id-only-");
+      const transcriptPath = path.join(dir, "session.jsonl");
+
+      const appended = await appendUserTurnTranscriptMessage({
+        transcriptPath,
+        sessionId: "session-1",
+        sessionKey: "main",
+        cwd: dir,
+        input: {
+          text: "hello",
+          timestamp: 456,
+          senderId: "999888777",
+        },
+        updateMode: "none",
+      });
+
+      expect(appended?.message).toHaveProperty("__openclaw");
+      expect((appended?.message as Record<string, unknown>).__openclaw).toMatchObject({
+        from: {
+          id: "999888777",
+        },
+        senderId: "999888777",
+      });
+
+      const messages = readTranscriptMessages(transcriptPath);
+      expect(messages[0]).toMatchObject({
+        role: "user",
+        content: "hello",
+        __openclaw: {
+          from: { id: "999888777" },
+          senderId: "999888777",
+        },
+      });
+    });
+
+    it("does not add __openclaw when senderId is absent", async () => {
+      const dir = createTempDir("openclaw-user-turn-no-sender-");
+      const transcriptPath = path.join(dir, "session.jsonl");
+
+      const appended = await appendUserTurnTranscriptMessage({
+        transcriptPath,
+        sessionId: "session-1",
+        sessionKey: "main",
+        cwd: dir,
+        input: {
+          text: "direct message",
+          timestamp: 789,
+        },
+        updateMode: "none",
+      });
+
+      expect(appended?.message).not.toHaveProperty("__openclaw");
+      const messages = readTranscriptMessages(transcriptPath);
+      expect(messages[0]).not.toHaveProperty("__openclaw");
+    });
+  });
 });

--- a/src/sessions/user-turn-transcript.ts
+++ b/src/sessions/user-turn-transcript.ts
@@ -44,6 +44,10 @@ export type UserTurnInput = {
   idempotencyKey?: string;
   provenance?: InputProvenance;
   mediaOnlyText?: string;
+  /** Sender identity from the originating channel (e.g. Telegram group chat). */
+  senderId?: string | null;
+  senderName?: string | null;
+  senderUsername?: string | null;
 };
 
 type UserTurnTranscriptUpdateMode = "inline" | "none";
@@ -305,7 +309,29 @@ function buildPersistedUserTurnMessage(params: UserTurnInput): PersistedUserTurn
     ...(params.idempotencyKey ? { idempotencyKey: params.idempotencyKey } : {}),
     ...mediaFields,
   } as PersistedUserTurnMessage;
-  return applyInputProvenanceToUserMessage(message, params.provenance) as PersistedUserTurnMessage;
+  let withProvenance = applyInputProvenanceToUserMessage(
+    message,
+    params.provenance,
+  ) as PersistedUserTurnMessage;
+  // Add sender metadata __openclaw block for group chat sessions.
+  if (params.senderId) {
+    const openclawMeta: Record<string, unknown> = {
+      ...((withProvenance as { __openclaw?: unknown }).__openclaw as
+        | Record<string, unknown>
+        | undefined),
+      from: {
+        id: params.senderId,
+        ...(params.senderName ? { first_name: params.senderName } : {}),
+        ...(params.senderUsername ? { username: params.senderUsername } : {}),
+      },
+      senderId: params.senderId,
+    };
+    withProvenance = {
+      ...(withProvenance as unknown as Record<string, unknown>),
+      __openclaw: openclawMeta,
+    } as PersistedUserTurnMessage;
+  }
+  return withProvenance;
 }
 
 function resolvePersistedUserTurnMessage(


### PR DESCRIPTION
## Summary

Group chat user messages in session JSONL were missing the `__openclaw` metadata block (senderId, from.id, from.first_name, from.username) that is present in 1:1 direct session messages. This made it impossible for agents and transcript loggers to distinguish which human participant sent each message in a group chat.

## Fix

**Files changed:**
- `src/sessions/user-turn-transcript.ts` — Added `senderId`/`senderName`/`senderUsername` fields to `UserTurnInput` type and updated `buildPersistedUserTurnMessage` to add `__openclaw` block with sender identity
- `src/auto-reply/reply/get-reply-run.ts` — Thread `sessionCtx.SenderId`/`SenderName`/`SenderUsername` into `userTurnInput` when available
- `src/sessions/user-turn-transcript.test.ts` — Added 3 regression tests for sender metadata persistence

## Test results

\`\`\`
✓ 28 tests passed (user-turn-transcript.test.ts)
\`\`\`

Fixes #90531