### PR TITLE
fix(telegram): avoid restarts for runtime reloads

### DIFF
--- a/extensions/telegram/src/shared.ts
+++ b/extensions/telegram/src/shared.ts
@@ -185,9 +185,8 @@ export function createTelegramPluginBase(params: {
     security: telegramSecurityAdapter,
     reload: {
       // Transport-affecting keys that require a full channel restart to take effect.
-      // Runtime-only keys (groups, dmPolicy, streaming, allowList, blockList, welcome,
-      // commandDescriptions, agentConfig, etc.) are caught by the broad noop prefix
-      // and do NOT restart the channel, preserving in-memory session state.
+      // Each path is individually listed - no catch-all prefix that could mask
+      // lifecycle, credential, webhook, network, or security-sensitive changes.
       configPrefixes: [
         "channels.telegram.botToken",
         "channels.telegram.tokenFile",
@@ -196,7 +195,44 @@ export function createTelegramPluginBase(params: {
         "channels.telegram.webhookSecret",
         "channels.telegram.accounts",
       ],
-      noopPrefixes: ["channels.telegram"],
+      // Runtime-only policy / read paths that can be hot-reloaded without
+      // restarting the channel.  Account-scoped sub-paths are matched via the
+      // `*` wildcard segment (e.g. accounts.<id>.dmPolicy matches the
+      // "channels.telegram.accounts.*.dmPolicy" prefix).
+      // When adding a new key here, verify it does not affect transport,
+      // lifecycle, or identity - otherwise add it to configPrefixes instead.
+      noopPrefixes: [
+        "channels.telegram.groups",
+        "channels.telegram.dmPolicy",
+        "channels.telegram.allowFrom",
+        "channels.telegram.defaultTo",
+        "channels.telegram.groupAllowFrom",
+        "channels.telegram.groupPolicy",
+        "channels.telegram.mentionPatterns",
+        "channels.telegram.contextVisibility",
+        "channels.telegram.historyLimit",
+        "channels.telegram.dmHistoryLimit",
+        "channels.telegram.streaming",
+        "channels.telegram.welcome",
+        "channels.telegram.commandDescriptions",
+        "channels.telegram.agentConfig",
+        "channels.telegram.blockStreaming",
+        "channels.telegram.accounts.*.groups",
+        "channels.telegram.accounts.*.dmPolicy",
+        "channels.telegram.accounts.*.allowFrom",
+        "channels.telegram.accounts.*.defaultTo",
+        "channels.telegram.accounts.*.groupAllowFrom",
+        "channels.telegram.accounts.*.groupPolicy",
+        "channels.telegram.accounts.*.mentionPatterns",
+        "channels.telegram.accounts.*.contextVisibility",
+        "channels.telegram.accounts.*.historyLimit",
+        "channels.telegram.accounts.*.dmHistoryLimit",
+        "channels.telegram.accounts.*.streaming",
+        "channels.telegram.accounts.*.welcome",
+        "channels.telegram.accounts.*.commandDescriptions",
+        "channels.telegram.accounts.*.agentConfig",
+        "channels.telegram.accounts.*.blockStreaming",
+      ],
     },
     configSchema: TelegramChannelConfigSchema,
     config: {

--- a/extensions/telegram/src/shared.ts
+++ b/extensions/telegram/src/shared.ts
@@ -183,7 +183,21 @@ export function createTelegramPluginBase(params: {
     },
     doctor: telegramDoctor,
     security: telegramSecurityAdapter,
-    reload: { configPrefixes: ["channels.telegram"] },
+    reload: {
+      // Transport-affecting keys that require a full channel restart to take effect.
+      // Runtime-only keys (groups, dmPolicy, streaming, allowList, blockList, welcome,
+      // commandDescriptions, agentConfig, etc.) are caught by the broad noop prefix
+      // and do NOT restart the channel, preserving in-memory session state.
+      configPrefixes: [
+        "channels.telegram.botToken",
+        "channels.telegram.tokenFile",
+        "channels.telegram.apiRoot",
+        "channels.telegram.network",
+        "channels.telegram.webhookSecret",
+        "channels.telegram.accounts",
+      ],
+      noopPrefixes: ["channels.telegram"],
+    },
     configSchema: TelegramChannelConfigSchema,
     config: {
       ...telegramConfigAdapter,

--- a/src/gateway/config-reload-plan.ts
+++ b/src/gateway/config-reload-plan.ts
@@ -234,10 +234,13 @@ function listReloadRules(): ReloadRule[] {
  * a specific prefix like `channels.telegram.botToken` takes priority over a
  * wildcard like `channels.telegram.*.botToken`.
  *
- * The wildcard matches exactly one dot-separated segment, so an account-scoped
- * pattern `channels.telegram.accounts.*.dmPolicy` matches
- * `channels.telegram.accounts.mybot.dmPolicy` but not
- * `channels.telegram.accounts.mybot.sub.dmPolicy`.
+ * The `*` matches exactly one dot-separated segment, but a wildcard rule still
+ * matches deeper subtree paths the same way a plain prefix does. So
+ * `channels.telegram.accounts.*.groups` covers both
+ * `channels.telegram.accounts.mybot.groups` and the nested
+ * `channels.telegram.accounts.mybot.groups.-100.dmPolicy`; without this a nested
+ * account-scoped policy edit would fall through to the broad
+ * `channels.telegram.accounts` restart rule and discard live session state.
  */
 function matchRule(path: string): ReloadRule | null {
   const pathSegments = path.split(".");
@@ -256,8 +259,10 @@ function matchRule(path: string): ReloadRule | null {
         }
       }
     } else {
-      // Wildcard: must have enough segments and match before and after the `*`.
-      if (pathSegments.length !== prefixSegments.length) {
+      // Wildcard: the path must have at least as many segments as the pattern so
+      // the wildcard binds one segment; extra trailing segments are a subtree
+      // match (e.g. accounts.<id>.groups also covers accounts.<id>.groups.<gid>.x).
+      if (pathSegments.length < prefixSegments.length) {
         continue;
       }
       let matches = true;

--- a/src/gateway/config-reload-plan.ts
+++ b/src/gateway/config-reload-plan.ts
@@ -227,13 +227,57 @@ function listReloadRules(): ReloadRule[] {
   return rules;
 }
 
+/**
+ * Match a config path against reload rules, supporting `*` as a single-segment
+ * wildcard.  When multiple rules match (e.g. a concrete prefix and a wildcard
+ * variant), the rule with the most matching segments wins.  This ensures that
+ * a specific prefix like `channels.telegram.botToken` takes priority over a
+ * wildcard like `channels.telegram.*.botToken`.
+ *
+ * The wildcard matches exactly one dot-separated segment, so an account-scoped
+ * pattern `channels.telegram.accounts.*.dmPolicy` matches
+ * `channels.telegram.accounts.mybot.dmPolicy` but not
+ * `channels.telegram.accounts.mybot.sub.dmPolicy`.
+ */
 function matchRule(path: string): ReloadRule | null {
+  const pathSegments = path.split(".");
+  let best: ReloadRule | null = null;
+  let bestSegmentCount = -1;
+
   for (const rule of listReloadRules()) {
-    if (path === rule.prefix || path.startsWith(`${rule.prefix}.`)) {
-      return rule;
+    const prefixSegments = rule.prefix.split(".");
+    const wildcardIndex = prefixSegments.indexOf("*");
+    if (wildcardIndex === -1) {
+      // No wildcard: exact match or prefix match.
+      if (path === rule.prefix || path.startsWith(`${rule.prefix}.`)) {
+        if (prefixSegments.length > bestSegmentCount) {
+          best = rule;
+          bestSegmentCount = prefixSegments.length;
+        }
+      }
+    } else {
+      // Wildcard: must have enough segments and match before and after the `*`.
+      if (pathSegments.length !== prefixSegments.length) {
+        continue;
+      }
+      let matches = true;
+      for (let i = 0; i < prefixSegments.length; i++) {
+        if (prefixSegments[i] === "*") {
+          continue;
+        }
+        if (pathSegments[i] !== prefixSegments[i]) {
+          matches = false;
+          break;
+        }
+      }
+      if (matches && prefixSegments.length > bestSegmentCount) {
+        best = rule;
+        bestSegmentCount = prefixSegments.length;
+      }
     }
   }
-  return null;
+
+  return best;
 }
 
 export function resolveConfigReloadMetadata(path: string): ConfigReloadMetadata {

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -153,7 +153,41 @@ describe("buildGatewayReloadPlan", () => {
         "channels.telegram.webhookSecret",
         "channels.telegram.accounts",
       ],
-      noopPrefixes: ["channels.telegram"],
+      // Runtime-only noop prefixes - each individually listed, no catch-all.
+      // The accounts.*.X patterns rely on the `*` single-segment wildcard in
+      // matchRule to match config paths like accounts.mybot.dmPolicy.
+      noopPrefixes: [
+        "channels.telegram.groups",
+        "channels.telegram.dmPolicy",
+        "channels.telegram.allowFrom",
+        "channels.telegram.defaultTo",
+        "channels.telegram.groupAllowFrom",
+        "channels.telegram.groupPolicy",
+        "channels.telegram.mentionPatterns",
+        "channels.telegram.contextVisibility",
+        "channels.telegram.historyLimit",
+        "channels.telegram.dmHistoryLimit",
+        "channels.telegram.streaming",
+        "channels.telegram.welcome",
+        "channels.telegram.commandDescriptions",
+        "channels.telegram.agentConfig",
+        "channels.telegram.blockStreaming",
+        "channels.telegram.accounts.*.groups",
+        "channels.telegram.accounts.*.dmPolicy",
+        "channels.telegram.accounts.*.allowFrom",
+        "channels.telegram.accounts.*.defaultTo",
+        "channels.telegram.accounts.*.groupAllowFrom",
+        "channels.telegram.accounts.*.groupPolicy",
+        "channels.telegram.accounts.*.mentionPatterns",
+        "channels.telegram.accounts.*.contextVisibility",
+        "channels.telegram.accounts.*.historyLimit",
+        "channels.telegram.accounts.*.dmHistoryLimit",
+        "channels.telegram.accounts.*.streaming",
+        "channels.telegram.accounts.*.welcome",
+        "channels.telegram.accounts.*.commandDescriptions",
+        "channels.telegram.accounts.*.agentConfig",
+        "channels.telegram.accounts.*.blockStreaming",
+      ],
     },
   };
   const whatsappPlugin: ChannelPlugin = {
@@ -258,6 +292,20 @@ describe("buildGatewayReloadPlan", () => {
     expect(plan.restartGateway).toBe(false);
     expect(plan.restartChannels).toEqual(new Set());
     expect(plan.noopPaths).toContain("channels.telegram.dmPolicy");
+  });
+
+  it("keeps account-scoped runtime-only channels.telegram.accounts.* changes as hot no-ops (wildcard match)", () => {
+    const plan = buildGatewayReloadPlan(["channels.telegram.accounts.mybot.dmPolicy"]);
+    expect(plan.restartGateway).toBe(false);
+    expect(plan.restartChannels).toEqual(new Set());
+    expect(plan.noopPaths).toContain("channels.telegram.accounts.mybot.dmPolicy");
+  });
+
+  it("restarts the telegram channel when an account-scoped transport-affecting path changes (wildcard noop does not match botToken)", () => {
+    const plan = buildGatewayReloadPlan(["channels.telegram.accounts.mybot.botToken"]);
+    expect(plan.restartGateway).toBe(false);
+    expect(plan.restartChannels).toContain("telegram");
+    expect(plan.noopPaths).toStrictEqual([]);
   });
 
   it("refreshes channel reload rules when only the tracked channel registry changes", () => {

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -308,6 +308,21 @@ describe("buildGatewayReloadPlan", () => {
     expect(plan.noopPaths).toStrictEqual([]);
   });
 
+  it("keeps nested account-scoped group/topic runtime-only changes as hot no-ops (subtree wildcard, no restart)", () => {
+    // Regression: a per-group/topic policy edit nested under an account must not
+    // fall through to the broad channels.telegram.accounts restart rule, which
+    // would discard live Telegram session state.
+    for (const path of [
+      "channels.telegram.accounts.mybot.groups.-1001234567.dmPolicy",
+      "channels.telegram.accounts.mybot.groups.-1001234567.topics.42.groupPolicy",
+    ]) {
+      const plan = buildGatewayReloadPlan([path]);
+      expect(plan.restartGateway, path).toBe(false);
+      expect(plan.restartChannels, path).toEqual(new Set());
+      expect(plan.noopPaths, path).toContain(path);
+    }
+  });
+
   it("refreshes channel reload rules when only the tracked channel registry changes", () => {
     const activeOnlyRegistry = createTestRegistry([]);
     const channelOnlyRegistry = createTestRegistry([

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -144,7 +144,17 @@ describe("buildGatewayReloadPlan", () => {
       listAccountIds: () => [],
       resolveAccount: () => ({}),
     },
-    reload: { configPrefixes: ["channels.telegram"] },
+    reload: {
+      configPrefixes: [
+        "channels.telegram.botToken",
+        "channels.telegram.tokenFile",
+        "channels.telegram.apiRoot",
+        "channels.telegram.network",
+        "channels.telegram.webhookSecret",
+        "channels.telegram.accounts",
+      ],
+      noopPrefixes: ["channels.telegram"],
+    },
   };
   const whatsappPlugin: ChannelPlugin = {
     id: "whatsapp",
@@ -241,6 +251,13 @@ describe("buildGatewayReloadPlan", () => {
     expect(plan.restartGateway).toBe(false);
     expect(plan.restartChannels).toEqual(new Set());
     expect(plan.noopPaths).toContain("channels.whatsapp.replyToMode");
+  });
+
+  it("keeps runtime-only channels.telegram.* changes as hot no-ops (does not restart the channel)", () => {
+    const plan = buildGatewayReloadPlan(["channels.telegram.dmPolicy"]);
+    expect(plan.restartGateway).toBe(false);
+    expect(plan.restartChannels).toEqual(new Set());
+    expect(plan.noopPaths).toContain("channels.telegram.dmPolicy");
   });
 
   it("refreshes channel reload rules when only the tracked channel registry changes", () => {


### PR DESCRIPTION
## What changed

- Narrow Telegram reload restart prefixes to transport-affecting settings only.
- Add a broad Telegram no-op prefix so runtime-only settings like `historyLimit` and `dmPolicy` do not restart the channel.
- Add focused gateway reload-plan coverage for runtime-only Telegram config changes.

Fixes #68232.

## Real behavior proof

**Behavior or issue addressed:**

Runtime-only `channels.telegram.*` config edits previously planned a Telegram channel restart, which destroys in-memory Telegram session state. This branch keeps runtime-only Telegram config changes on the hot no-op path while preserving restarts for transport-affecting Telegram settings.

**Real environment tested:**

- Repository: `openclaw/openclaw`
- Branch: `fastino-68232-telegram-reload-history-b`
- Platform tested: macOS arm64
- Runtime path: local OpenClaw Node/pnpm workspace using the production Telegram plugin reload rules and repository test scripts

**Exact steps or command run before this patch:**

1. Created a temporary base checkout at `origin/main`.
2. Loaded the production Telegram plugin into the gateway reload planner.
3. Planned reload behavior for `channels.telegram.historyLimit` and `channels.telegram.botToken`.

```text
$ git -C /Users/allahyar/Documents/fastino-tasks/openclaw-tui-68232b worktree add --detach /private/tmp/openclaw-base-68232-proof-20260605 origin/main
$ /Users/allahyar/Documents/fastino-tasks/openclaw-tui-68232b/node_modules/.bin/tsx --conditions=browser -e "import { telegramPlugin } from './extensions/telegram/src/channel.ts'; import { createTestRegistry } from './src/test-utils/channel-plugins.ts'; import { setActivePluginRegistry, resetPluginRuntimeStateForTest } from './src/plugins/runtime.ts'; import { buildGatewayReloadPlan } from './src/gateway/config-reload.ts'; setActivePluginRegistry(createTestRegistry([{ pluginId: 'telegram', plugin: telegramPlugin, source: 'test' }])); const runtimeOnly = buildGatewayReloadPlan(['channels.telegram.historyLimit']); const transport = buildGatewayReloadPlan(['channels.telegram.botToken']); console.log(JSON.stringify({ runtimeOnly: { restartGateway: runtimeOnly.restartGateway, restartChannels: [...runtimeOnly.restartChannels], noopPaths: runtimeOnly.noopPaths }, transport: { restartGateway: transport.restartGateway, restartChannels: [...transport.restartChannels], noopPaths: transport.noopPaths } }, null, 2)); resetPluginRuntimeStateForTest();"
{
  "runtimeOnly": {
    "restartGateway": false,
    "restartChannels": [
      "telegram"
    ],
    "noopPaths": []
  },
  "transport": {
    "restartGateway": false,
    "restartChannels": [
      "telegram"
    ],
    "noopPaths": []
  }
}
```

**Exact steps or command run after this patch:**

```text
$ pnpm exec tsx --conditions=browser -e "import { telegramPlugin } from './extensions/telegram/src/channel.ts'; import { createTestRegistry } from './src/test-utils/channel-plugins.ts'; import { setActivePluginRegistry, resetPluginRuntimeStateForTest } from './src/plugins/runtime.ts'; import { buildGatewayReloadPlan } from './src/gateway/config-reload.ts'; setActivePluginRegistry(createTestRegistry([{ pluginId: 'telegram', plugin: telegramPlugin, source: 'test' }])); const runtimeOnly = buildGatewayReloadPlan(['channels.telegram.historyLimit']); const transport = buildGatewayReloadPlan(['channels.telegram.botToken']); console.log(JSON.stringify({ runtimeOnly: { restartGateway: runtimeOnly.restartGateway, restartChannels: [...runtimeOnly.restartChannels], noopPaths: runtimeOnly.noopPaths }, transport: { restartGateway: transport.restartGateway, restartChannels: [...transport.restartChannels], noopPaths: transport.noopPaths } }, null, 2)); resetPluginRuntimeStateForTest();"
{
  "runtimeOnly": {
    "restartGateway": false,
    "restartChannels": [],
    "noopPaths": [
      "channels.telegram.historyLimit"
    ]
  },
  "transport": {
    "restartGateway": false,
    "restartChannels": [
      "telegram"
    ],
    "noopPaths": []
  }
}
```

Focused test shard:

```text
$ pnpm test src/gateway/config-reload.test.ts --reporter=verbose
✓ |gateway-core| ../../src/gateway/config-reload.test.ts > buildGatewayReloadPlan > keeps runtime-only channels.telegram.* changes as hot no-ops (does not restart the channel) 0ms
✓ |gateway-server| ../../src/gateway/config-reload.test.ts > buildGatewayReloadPlan > keeps runtime-only channels.telegram.* changes as hot no-ops (does not restart the channel) 1ms
✓ |gateway-client| ../../src/gateway/config-reload.test.ts > buildGatewayReloadPlan > keeps runtime-only channels.telegram.* changes as hot no-ops (does not restart the channel) 0ms
✓ |gateway-methods| ../../src/gateway/config-reload.test.ts > buildGatewayReloadPlan > keeps runtime-only channels.telegram.* changes as hot no-ops (does not restart the channel) 0ms

Test Files  4 passed (4)
Tests  324 passed (324)
[test] passed 1 Vitest shard in 17.40s
```

Additional checks:

```text
$ pnpm exec oxfmt --check extensions/telegram/src/shared.ts src/gateway/config-reload.test.ts
All matched files use the correct format.

$ pnpm exec oxlint extensions/telegram/src/shared.ts src/gateway/config-reload.test.ts --report-unused-disable-directives-severity error
# passed with no output
```

**Observed result after fix:**

`channels.telegram.historyLimit` no longer plans a Telegram channel restart and is recorded as a no-op reload path. `channels.telegram.botToken` still plans a Telegram channel restart, preserving the restart behavior for transport-affecting configuration.

**evidence:**

The before/after production reload-plan probe above is copied from the local OpenClaw workspace. It loads the real `telegramPlugin` from `extensions/telegram/src/channel.ts`, installs it into the gateway reload planner registry, and compares the planned restart/no-op behavior for `channels.telegram.historyLimit` and `channels.telegram.botToken`.

The focused repository test shard also passed with the new regression case in all four gateway test projects:

- `gateway-core`
- `gateway-server`
- `gateway-client`
- `gateway-methods`

**Not tested:**

No live Telegram bot token or native Telegram Desktop account was used. The exercised path is the gateway reload planner plus production Telegram plugin reload metadata, which is the source-level path responsible for deciding whether a config edit restarts the Telegram channel.


## Follow-up: nested account-scoped reloads (addresses review)

ClawSweeper flagged that a nested account-scoped policy edit (a per-group/topic override under `channels.telegram.accounts.<id>`) still fell through to the broad `channels.telegram.accounts` restart rule and discarded live session state, because the `*` wildcard required an exact segment count. Wildcard reload rules now match deeper subtree paths the same way a plain prefix does, and a nested-path regression test was added.

**Before this follow-up** (exact-length wildcard) the production planner restarted the channel for a nested edit:

```text
channels.telegram.accounts.mybot.groups.-1001234567.dmPolicy -> restartChannels: ["telegram"]   # discards live session state
```

**After** — production planner via `buildGatewayReloadPlan` (`pnpm exec tsx --conditions=browser` driving the real Telegram plugin reload rules):

```text
{"path":"channels.telegram.accounts.mybot.groups.-1001234567.dmPolicy","restartChannels":[],"noopPaths":["channels.telegram.accounts.mybot.groups.-1001234567.dmPolicy"]}
{"path":"channels.telegram.accounts.mybot.groups.-1001234567.topics.42.groupPolicy","restartChannels":[],"noopPaths":["channels.telegram.accounts.mybot.groups.-1001234567.topics.42.groupPolicy"]}
{"path":"channels.telegram.accounts.mybot.botToken","restartChannels":["telegram"],"noopPaths":[]}   # transport-affecting still restarts
```

Nested runtime-only edits are now hot no-ops while transport-affecting paths still restart. Focused suite: `node scripts/run-vitest.mjs src/gateway/config-reload.test.ts` → 336 passed (includes the new nested account-scoped regression test).
