### PR TITLE
fix(synology-chat): remove local deliver timeout

### DIFF
--- a/extensions/synology-chat/src/webhook-handler.test.ts
+++ b/extensions/synology-chat/src/webhook-handler.test.ts
@@ -619,6 +619,37 @@ describe("createWebhookHandler", () => {
     expectBotReplySentTo("123");
   });
 
+  it("awaits deliver directly with no local hardcoded timeout wrapper", async () => {
+    // Previously this webhook handler wrapped deliver with a hardcoded 120s
+    // Promise.race that overrode the configurable agents.defaults.timeoutSeconds
+    // from core. That wrapper created a setTimeout(_, 120000) on every deliver
+    // call. We spy on setTimeout to prove no such call exists in the current code.
+    const setTimeoutSpy = vi.spyOn(global, "setTimeout");
+    try {
+      const deliver = vi.fn().mockResolvedValue("late reply");
+      const handler = createWebhookHandler({
+        account: makeAccount({ accountId: "no-hardcoded-timeout-" + Date.now() }),
+        deliver,
+        log,
+      });
+
+      const res = makeRes();
+      const req = makeReq("POST", validBody);
+      await handler(req, res);
+
+      expect(res.status).toBe(204);
+
+      // Collect all setTimeout delays used during this handler run
+      const delays = setTimeoutSpy.mock.calls.map((call) => call[1]);
+      // Every delay should be well under 120s — the old hardcoded wrapper would
+      // have produced exactly one call with delay === 120000.
+      const longDelays = delays.filter((d) => typeof d === "number" && d >= 120_000);
+      expect(longDelays).toEqual([]);
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
+  });
+
   it("sanitizes input before delivery", async () => {
     const deliver = vi.fn().mockResolvedValue(null);
     const handler = createWebhookHandler({

--- a/extensions/synology-chat/src/webhook-handler.ts
+++ b/extensions/synology-chat/src/webhook-handler.ts
@@ -554,7 +554,7 @@ async function processAuthorizedSynologyWebhook(params: {
       log: params.log,
     });
 
-    const deliverPromise = params.deliver({
+    const reply = await params.deliver({
       body: params.message.body,
       from: authorizedWebhookUserId,
       senderName: params.message.payload.username,
@@ -564,10 +564,6 @@ async function processAuthorizedSynologyWebhook(params: {
       commandAuthorized: params.message.commandAuthorized,
       chatUserId: deliveryUserId,
     });
-    const timeoutPromise = new Promise<null>((_, reject) => {
-      setTimeout(() => reject(new Error("Agent response timeout (120s)")), 120_000);
-    });
-    const reply = await Promise.race([deliverPromise, timeoutPromise]);
     if (!reply) {
       return;
     }


### PR DESCRIPTION
Fixes #59966.

## What changed

Removed the Synology Chat webhook handler's local `Promise.race` wrapper with the hardcoded 120s timeout. The handler now awaits `params.deliver(...)` directly, so the channel layer no longer overrides the core agent timeout configuration.

Added focused regression coverage proving a successful webhook delivery path no longer schedules a 120000ms timeout.

## Real behavior proof

**behavior:** Synology Chat webhook delivery should not install a local 120s timeout wrapper around `deliver`; timeout policy should remain with the core agent runtime.

**environment:** macOS arm64, Node v26.0.0, pnpm in `/Users/allahyar/Documents/fastino-tasks/openclaw-tui-59966`.

**steps:**

Before, from clean `origin/main` checkout:

```text
$ pnpm exec tsx --conditions=browser -e "<direct createWebhookHandler probe that records setTimeout delays during one authorized Synology webhook request>"
{
  "status": 204,
  "delays": [
    120000
  ],
  "hasHardcoded120sTimeout": true
}
```

After, from this branch:

```text
$ pnpm exec tsx --conditions=browser -e "<same direct createWebhookHandler probe>"
{
  "status": 204,
  "delays": [],
  "hasHardcoded120sTimeout": false
}
```

Focused regression test:

```text
$ pnpm test extensions/synology-chat/src/webhook-handler.test.ts --reporter=verbose
✓ |extension-messaging| extensions/synology-chat/src/webhook-handler.test.ts > createWebhookHandler > awaits deliver directly with no local hardcoded timeout wrapper 1ms

Test Files  1 passed (1)
Tests  23 passed (23)
[test] passed 1 Vitest shard in 7.02s
```

Format and lint:

```text
$ pnpm exec oxfmt --check extensions/synology-chat/src/webhook-handler.ts extensions/synology-chat/src/webhook-handler.test.ts
All matched files use the correct format.

$ pnpm exec oxlint extensions/synology-chat/src/webhook-handler.ts extensions/synology-chat/src/webhook-handler.test.ts --report-unused-disable-directives-severity error
# passed with no output
```

**evidence:** The before probe records the old `120000`ms timeout from the webhook handler. The after probe exercises the same handler path and records no hardcoded 120s timeout; the focused regression test covers the same behavior in the Synology Chat extension test suite.

**observedResult:** The authorized webhook path still returns 204 and calls through delivery, but the local channel timeout wrapper is gone.

**Not tested:** Live Synology Chat network delivery against a real NAS instance.
