### PR TITLE
fix: preserve LM Studio Responses tool arguments

### DIFF
--- a/src/llm/providers/openai-responses-shared.test.ts
+++ b/src/llm/providers/openai-responses-shared.test.ts
@@ -1,8 +1,9 @@
 // OpenAI Responses shared tests cover tool conversion and response item mapping.
 import type { Tool as OpenAIResponsesTool } from "openai/resources/responses/responses.js";
 import { describe, expect, it } from "vitest";
-import type { Context, Model, Tool } from "../types.js";
-import { convertResponsesMessages } from "./openai-responses-shared.js";
+import type { AssistantMessage, Context, Model, Tool } from "../types.js";
+import { AssistantMessageEventStream } from "../utils/event-stream.js";
+import { convertResponsesMessages, processResponsesStream } from "./openai-responses-shared.js";
 import { convertResponsesTools } from "./openai-responses-tools.js";
 
 type ResponsesFunctionTool = Extract<OpenAIResponsesTool, { type: "function" }>;
@@ -31,6 +32,32 @@ const proxyOpenAIModel = {
   name: "Custom Model",
   baseUrl: "https://proxy.example.com/v1",
 } satisfies Model<"openai-responses">;
+
+function createAssistantOutput(): AssistantMessage {
+  return {
+    role: "assistant",
+    api: nativeOpenAIModel.api,
+    provider: nativeOpenAIModel.provider,
+    model: nativeOpenAIModel.id,
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: "stop",
+    timestamp: 0,
+    content: [],
+  };
+}
+
+async function* responseEvents(events: Array<Record<string, unknown>>) {
+  for (const event of events) {
+    yield event as never;
+  }
+}
 
 describe("convertResponsesTools", () => {
   it("enables native strict OpenAI Responses tools and normalizes schemas", () => {
@@ -326,5 +353,84 @@ describe("convertResponsesMessages", () => {
       call_id: "call_abc",
     });
     expect(functionCall).not.toHaveProperty("id");
+  });
+});
+
+describe("processResponsesStream", () => {
+  it.each([
+    ["omits arguments", undefined],
+    ["sends empty arguments", ""],
+  ])("preserves streamed tool-call arguments when done %s", async (_label, doneArguments) => {
+    const output = createAssistantOutput();
+    const stream = new AssistantMessageEventStream();
+    const events: Array<Record<string, unknown>> = [];
+    const collect = (async () => {
+      for await (const event of stream) {
+        events.push(event as unknown as Record<string, unknown>);
+      }
+    })();
+
+    await processResponsesStream(
+      responseEvents([
+        {
+          type: "response.output_item.added",
+          item: {
+            type: "function_call",
+            id: "fc_read",
+            call_id: "call_read",
+            name: "read",
+            arguments: "",
+          },
+        },
+        {
+          type: "response.function_call_arguments.delta",
+          delta: '{"path":"docs/gateway/local-models.md"}',
+        },
+        {
+          type: "response.function_call_arguments.done",
+          ...(doneArguments === undefined ? {} : { arguments: doneArguments }),
+          item_id: "fc_read",
+          name: "read",
+          output_index: 0,
+          sequence_number: 3,
+        },
+        {
+          type: "response.output_item.done",
+          item: {
+            type: "function_call",
+            id: "fc_read",
+            call_id: "call_read",
+            name: "read",
+          },
+        },
+        {
+          type: "response.completed",
+          response: {
+            id: "resp_1",
+            status: "completed",
+          },
+        },
+      ]),
+      output,
+      stream,
+      nativeOpenAIModel,
+    );
+    stream.end();
+    await collect;
+
+    expect(output.stopReason).toBe("toolUse");
+    expect(output.content).toEqual([
+      {
+        type: "toolCall",
+        id: "call_read|fc_read",
+        name: "read",
+        arguments: { path: "docs/gateway/local-models.md" },
+      },
+    ]);
+    expect(events.map((event) => event.type)).toEqual([
+      "toolcall_start",
+      "toolcall_delta",
+      "toolcall_end",
+    ]);
   });
 });

--- a/src/llm/providers/openai-responses-shared.ts
+++ b/src/llm/providers/openai-responses-shared.ts
@@ -667,11 +667,18 @@ export async function processResponsesStream<TApi extends Api>(
     } else if (event.type === "response.function_call_arguments.done") {
       if (currentItem?.type === "function_call" && currentBlock?.type === "toolCall") {
         const previousPartialJson = currentBlock.partialJson;
-        currentBlock.partialJson = event.arguments;
-        currentBlock.arguments = parseStreamingJson(currentBlock.partialJson);
+        const doneArguments = typeof event.arguments === "string" ? event.arguments : undefined;
 
-        if (event.arguments.startsWith(previousPartialJson)) {
-          const delta = event.arguments.slice(previousPartialJson.length);
+        if (
+          doneArguments !== undefined &&
+          (doneArguments.length > 0 || previousPartialJson === "")
+        ) {
+          currentBlock.partialJson = doneArguments;
+          currentBlock.arguments = parseStreamingJson(currentBlock.partialJson);
+        }
+
+        if (doneArguments?.startsWith(previousPartialJson)) {
+          const delta = doneArguments.slice(previousPartialJson.length);
           if (delta.length > 0) {
             stream.push({
               type: "toolcall_delta",


### PR DESCRIPTION
## Summary

- Preserve streamed OpenAI Responses tool-call arguments when the final `response.function_call_arguments.done` event omits `arguments` or sends an empty string.
- Add shared parser regression coverage for both LM Studio-style done event shapes.

Fixes #90585.

## Verification

- `node scripts/run-vitest.mjs src/llm/providers/openai-responses-shared.test.ts`
- `node scripts/run-vitest.mjs extensions/lmstudio/src/stream.test.ts`
- `./node_modules/.bin/oxfmt --check --threads=1 src/llm/providers/openai-responses-shared.ts src/llm/providers/openai-responses-shared.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local` -> clean, no accepted/actionable findings

## Real behavior proof

Behavior addressed: LM Studio/OpenAI-compatible Responses streams can emit function-call argument deltas, then a `response.function_call_arguments.done` event whose `arguments` field is missing or empty. The parser now keeps the accumulated delta JSON instead of replacing it with an empty/missing final payload.

Real environment tested: Local OpenAI-compatible HTTP/SSE fixture exercised through `streamSimpleOpenAIResponses`, using a real POST to `/responses` and streamed SSE events matching the LM Studio failure shape. Local LM Studio itself was checked at `http://127.0.0.1:1234/v1/models`, but no LM Studio server was running on this machine.

Exact steps or command run after this patch: Ran a one-shot `node --import tsx --input-type=module` script that started an HTTP server, returned Responses SSE events with `response.function_call_arguments.delta` followed by `response.function_call_arguments.done` without `arguments`, and consumed it through `streamSimpleOpenAIResponses`.

Evidence after fix: Copied terminal output from the local HTTP/SSE fixture run:

```json
{
  "ok": true,
  "eventTypes": [
    "start",
    "toolcall_start",
    "toolcall_delta",
    "toolcall_end",
    "done"
  ],
  "stopReason": "toolUse",
  "toolCall": {
    "type": "toolCall",
    "id": "call_read|fc_read",
    "name": "read",
    "arguments": {
      "path": "docs/gateway/local-models.md"
    }
  },
  "requestPath": "/responses",
  "requestStream": true
}
```

Observed result after fix: The streamed `read` tool call retained its `path` argument and the provider stream ended with `stopReason: "toolUse"`.

What was not tested: A live LM Studio model run was not possible because `127.0.0.1:1234` was not reachable in this environment.
