### PR TITLE
fix(android): align provider readiness with available models

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -2085,6 +2085,7 @@ class NodeRuntime(
           id = id,
           name = obj["name"].asStringOrNull()?.trim()?.takeIf { it.isNotEmpty() } ?: id,
           provider = provider,
+          available = obj.optionalBoolean("available"),
           supportsVision = "image" in inputTypes,
           supportsAudio = "audio" in inputTypes,
           supportsDocuments = "document" in inputTypes,
@@ -2701,6 +2702,7 @@ data class GatewayModelSummary(
   val id: String,
   val name: String,
   val provider: String,
+  val available: Boolean?,
   val supportsVision: Boolean,
   val supportsAudio: Boolean,
   val supportsDocuments: Boolean,
@@ -2882,6 +2884,15 @@ private fun JsonObject?.long(key: String): Long? = (this?.get(key) as? JsonPrimi
 private fun JsonObject?.double(key: String): Double? = (this?.get(key) as? JsonPrimitive)?.content?.trim()?.toDoubleOrNull()
 
 private fun JsonObject?.boolean(key: String): Boolean = (this?.get(key) as? JsonPrimitive)?.content?.trim() == "true"
+
+private fun JsonObject?.optionalBoolean(key: String): Boolean? =
+  (this?.get(key) as? JsonPrimitive)?.content?.trim()?.lowercase()?.let { value ->
+    when (value) {
+      "true" -> true
+      "false" -> false
+      else -> null
+    }
+  }
 
 internal fun cronJobLastRunStatus(state: JsonObject?): String? =
   state

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt
@@ -297,17 +297,16 @@ private fun CommandSectionLabel(title: String) {
   }
 }
 
-/** Builds provider quick-action metadata from current gateway/catalog state. */
-private fun providerCommandSubtitle(
+internal fun providerCommandSubtitle(
   isConnected: Boolean,
   providers: List<GatewayModelProviderSummary>,
   models: List<GatewayModelSummary>,
 ): String {
   if (!isConnected) return "Connect Gateway to load models"
-  val readyProviderCount = readyModelProviderCount(providers, models)
-  if (readyProviderCount > 0) return "$readyProviderCount providers ready"
   val expiringProviderCount = expiringModelProviderCount(providers)
   if (expiringProviderCount > 0) return "$expiringProviderCount providers expiring"
+  val readyProviderCount = readyModelProviderCount(providers, models)
+  if (readyProviderCount > 0) return "$readyProviderCount providers ready"
   if (models.isNotEmpty()) return "${models.size} models available"
   return "Configure model access"
 }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt
@@ -304,8 +304,10 @@ private fun providerCommandSubtitle(
   models: List<GatewayModelSummary>,
 ): String {
   if (!isConnected) return "Connect Gateway to load models"
-  val readyProviderCount = providers.count { modelProviderReady(it.status) }
+  val readyProviderCount = readyModelProviderCount(providers, models)
   if (readyProviderCount > 0) return "$readyProviderCount providers ready"
+  val expiringProviderCount = expiringModelProviderCount(providers)
+  if (expiringProviderCount > 0) return "$expiringProviderCount providers expiring"
   if (models.isNotEmpty()) return "${models.size} models available"
   return "Configure model access"
 }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt
@@ -324,7 +324,7 @@ internal fun readyModelProviderCount(
 
 // Older gateways did not emit `available`; keep those rows on the legacy
 // readiness path while still honoring explicit false from upgraded gateways.
-private fun modelAvailabilityUsable(model: GatewayModelSummary): Boolean = model.available != false
+internal fun modelAvailabilityUsable(model: GatewayModelSummary): Boolean = model.available != false
 
 internal fun expiringModelProviderCount(providers: List<GatewayModelProviderSummary>): Int =
   providers
@@ -579,12 +579,13 @@ private fun ModelGroup(
 
 @Composable
 private fun ModelRow(model: GatewayModelSummary) {
+  val available = modelAvailabilityUsable(model)
   Row(modifier = Modifier.fillMaxWidth().heightIn(min = 48.dp).padding(horizontal = 10.dp, vertical = 5.dp), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(6.dp)) {
     Text(text = model.name, style = ClawTheme.type.mono, color = ClawTheme.colors.text, modifier = Modifier.weight(1f), maxLines = 1, overflow = TextOverflow.Ellipsis)
     modelCapabilityLabels(model).take(3).forEach { label ->
       ProviderMiniTag(text = label)
     }
-    Box(modifier = Modifier.size(4.5.dp).clip(CircleShape).background(ClawTheme.colors.success))
+    Box(modifier = Modifier.size(4.5.dp).clip(CircleShape).background(if (available) ClawTheme.colors.success else ClawTheme.colors.warning))
   }
 }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt
@@ -192,6 +192,9 @@ private data class ProviderSetupRow(
   val name: String,
   val subtitle: String,
   val ready: Boolean,
+  val available: Boolean,
+  val statusLabel: String,
+  val warning: Boolean,
 )
 
 private data class ProviderRow(
@@ -199,37 +202,60 @@ private data class ProviderRow(
   val name: String,
   val status: String,
   val ready: Boolean,
+  val available: Boolean,
+  val setupRequired: Boolean,
+  val warning: Boolean,
   val modelCount: Int,
 )
 
-/** Combines auth-provider readiness rows with catalog-only providers. */
+/** Combines auth-provider readiness rows with catalog-only browse providers. */
 private fun providerRows(
   providers: List<GatewayModelProviderSummary>,
   models: List<GatewayModelSummary>,
 ): List<ProviderRow> {
   val modelCounts = models.groupingBy { it.provider }.eachCount()
+  val availableProviderIds =
+    models
+      .filter(::modelAvailabilityUsable)
+      .map { it.provider.normalizedProviderId() }
+      .toSet()
   val authRows =
     providers.map { provider ->
-      val ready = modelProviderReady(provider.status)
+      val providerId = provider.id.normalizedProviderId()
+      val authReady = modelProviderReady(provider.status)
+      val expiring = modelProviderExpiring(provider.status)
+      val available = providerId in availableProviderIds
       ProviderRow(
         id = provider.id,
         name = provider.displayName,
-        status = if (ready) "Ready" else "Needs setup",
-        ready = ready,
+        status =
+          when {
+            authReady -> "Ready"
+            expiring -> "Expiring"
+            available -> "Available"
+            else -> "Needs setup"
+          },
+        ready = authReady,
+        available = available || authReady || expiring,
+        setupRequired = !authReady && !available && !expiring,
+        warning = expiring,
         modelCount = modelCounts[provider.id] ?: 0,
       )
     }
-  // Static/catalog-only providers may expose models without a matching auth
-  // provider row; keep them visible as ready providers.
+  // Catalog-only providers can be browsed but are not a readiness signal.
   val missingAuthRows =
     modelCounts.keys
       .filter { provider -> authRows.none { it.id == provider } }
       .map { provider ->
+        val available = provider.normalizedProviderId() in availableProviderIds
         ProviderRow(
           id = provider,
           name = providerDisplayName(provider),
-          status = "Ready",
-          ready = true,
+          status = if (available) "Available" else "Catalog",
+          ready = available,
+          available = available,
+          setupRequired = false,
+          warning = false,
           modelCount = modelCounts[provider] ?: 0,
         )
       }
@@ -245,6 +271,9 @@ private fun providerSetupRows(providerRows: List<ProviderRow>): List<ProviderSet
       name = providerDisplayName(id),
       subtitle = providerSetupSubtitle(id, row),
       ready = row?.ready == true,
+      available = row?.available == true,
+      statusLabel = providerSetupStatusLabel(row),
+      warning = row?.warning == true || row?.setupRequired == true || row == null,
     )
   }
 }
@@ -254,10 +283,22 @@ private fun providerSetupSubtitle(
   row: ProviderRow?,
 ): String =
   when {
+    row?.status == "Expiring" -> "Credential expires soon"
     row?.ready == true -> if (row.modelCount > 0) "${row.modelCount} models available" else "Ready"
-    row != null -> "Finish setup to use ${row.name}"
+    row?.available == true -> if (row.modelCount > 0) "${row.modelCount} models available" else "Available"
+    row?.setupRequired == true -> "Finish setup to use ${row.name}"
+    row != null && row.modelCount > 0 -> "${row.modelCount} catalog models"
     id == "ollama" -> "Use models running on your network"
     else -> "Add provider credentials on your Gateway"
+  }
+
+private fun providerSetupStatusLabel(row: ProviderRow?): String =
+  when {
+    row?.ready == true -> "Ready"
+    row?.status == "Expiring" -> "Expiring"
+    row?.available == true -> "Available"
+    row?.setupRequired == false -> "Catalog"
+    else -> "Setup"
   }
 
 /** Normalizes gateway provider status strings into a ready/not-ready boolean. */
@@ -269,6 +310,32 @@ internal fun modelProviderReady(status: String): Boolean {
     normalized == "configured" ||
     normalized == "static"
 }
+
+private fun modelProviderExpiring(status: String): Boolean = status.trim().lowercase() == "expiring"
+
+/** Counts providers with either ready auth status or currently available configured models. */
+internal fun readyModelProviderCount(
+  providers: List<GatewayModelProviderSummary>,
+  models: List<GatewayModelSummary>,
+): Int {
+  val authReadyProviders = providers.filter { modelProviderReady(it.status) }.map { it.id.normalizedProviderId() }
+  val availableModelProviders = models.filter(::modelAvailabilityUsable).map { it.provider.normalizedProviderId() }
+  return (authReadyProviders + availableModelProviders).distinct().size
+}
+
+// Older gateways did not emit `available`; keep those rows on the legacy
+// readiness path while still honoring explicit false from upgraded gateways.
+private fun modelAvailabilityUsable(model: GatewayModelSummary): Boolean = model.available != false
+
+/** Counts auth-backed providers that can serve now but need renewal soon. */
+internal fun expiringModelProviderCount(providers: List<GatewayModelProviderSummary>): Int =
+  providers
+    .filter { modelProviderExpiring(it.status) }
+    .map { it.id.normalizedProviderId() }
+    .distinct()
+    .size
+
+private fun String.normalizedProviderId(): String = trim().lowercase()
 
 /** Groups models by provider using the same display priority as provider rows. */
 private fun sortedModelGroups(models: List<GatewayModelSummary>): List<Pair<String, List<GatewayModelSummary>>> =
@@ -299,7 +366,18 @@ private fun ProviderList(
   ClawPanel(contentPadding = PaddingValues(horizontal = 0.dp, vertical = 0.dp)) {
     Column {
       if (rows.isEmpty()) {
-        ProviderListRow(ProviderRow(id = "loading", name = "Provider catalog", status = if (refreshing) "Loading" else "No providers", ready = false, modelCount = 0))
+        ProviderListRow(
+          ProviderRow(
+            id = "loading",
+            name = "Provider catalog",
+            status = if (refreshing) "Loading" else "No providers",
+            ready = false,
+            available = false,
+            setupRequired = false,
+            warning = false,
+            modelCount = 0,
+          ),
+        )
       } else {
         val visibleRows = rows.take(5)
         visibleRows.forEachIndexed { index, row ->
@@ -322,12 +400,12 @@ private fun ProviderOverviewPanel(
   onRefresh: () -> Unit,
   onSetup: () -> Unit,
 ) {
-  val readyCount = providerRows.count { it.ready }
-  val needsSetupCount = providerRows.count { !it.ready }
+  val readyCount = providerRows.count { it.available }
+  val needsSetupCount = providerRows.count { it.setupRequired }
   ClawPanel(contentPadding = PaddingValues(horizontal = 12.dp, vertical = 12.dp)) {
     Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
       Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-        ProviderMetricTile(label = "Ready", value = readyCount.toString(), modifier = Modifier.weight(1f))
+        ProviderMetricTile(label = "Available", value = readyCount.toString(), modifier = Modifier.weight(1f))
         ProviderMetricTile(label = "Models", value = modelCount.toString(), modifier = Modifier.weight(1f))
         ProviderMetricTile(label = "Setup", value = needsSetupCount.toString(), modifier = Modifier.weight(1f))
       }
@@ -398,8 +476,14 @@ private fun ProviderSetupListRow(
         Text(text = row.subtitle, style = ClawTheme.type.caption.copy(fontSize = 12.5.sp, lineHeight = 16.sp), color = ClawTheme.colors.textMuted, maxLines = 1, overflow = TextOverflow.Ellipsis)
       }
       Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(6.dp)) {
-        Box(modifier = Modifier.size(5.dp).clip(CircleShape).background(if (row.ready) ClawTheme.colors.success else ClawTheme.colors.warning))
-        Text(text = if (row.ready) "Ready" else "Setup", style = ClawTheme.type.caption.copy(fontSize = 12.5.sp, lineHeight = 16.sp), color = ClawTheme.colors.textMuted, maxLines = 1)
+        val statusColor =
+          when {
+            row.warning -> ClawTheme.colors.warning
+            row.ready || row.available -> ClawTheme.colors.success
+            else -> ClawTheme.colors.textMuted
+          }
+        Box(modifier = Modifier.size(5.dp).clip(CircleShape).background(statusColor))
+        Text(text = row.statusLabel, style = ClawTheme.type.caption.copy(fontSize = 12.5.sp, lineHeight = 16.sp), color = ClawTheme.colors.textMuted, maxLines = 1)
         Icon(imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight, contentDescription = "Open ${row.name}", modifier = Modifier.size(17.dp), tint = ClawTheme.colors.text)
       }
     }
@@ -415,7 +499,13 @@ private fun ProviderListRow(row: ProviderRow) {
       Text(text = if (row.modelCount > 0) "${row.modelCount} models" else "Provider setup", style = ClawTheme.type.caption.copy(fontSize = 12.5.sp, lineHeight = 16.sp), color = ClawTheme.colors.textMuted, maxLines = 1)
     }
     Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(5.dp)) {
-      Box(modifier = Modifier.size(4.5.dp).clip(CircleShape).background(if (row.ready) ClawTheme.colors.success else ClawTheme.colors.warning))
+      val statusColor =
+        when {
+          row.warning || row.setupRequired -> ClawTheme.colors.warning
+          row.ready || row.available -> ClawTheme.colors.success
+          else -> ClawTheme.colors.textMuted
+        }
+      Box(modifier = Modifier.size(4.5.dp).clip(CircleShape).background(statusColor))
       Text(text = row.status, style = ClawTheme.type.caption.copy(fontSize = 12.5.sp, lineHeight = 16.sp), color = ClawTheme.colors.textMuted, maxLines = 1)
     }
   }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt
@@ -283,7 +283,7 @@ private fun providerSetupSubtitle(
   row: ProviderRow?,
 ): String =
   when {
-    row?.status == "Expiring" -> "Credential expires soon"
+    row?.warning == true -> "Credential expires soon"
     row?.ready == true -> if (row.modelCount > 0) "${row.modelCount} models available" else "Ready"
     row?.available == true -> if (row.modelCount > 0) "${row.modelCount} models available" else "Available"
     row?.setupRequired == true -> "Finish setup to use ${row.name}"
@@ -295,7 +295,7 @@ private fun providerSetupSubtitle(
 private fun providerSetupStatusLabel(row: ProviderRow?): String =
   when {
     row?.ready == true -> "Ready"
-    row?.status == "Expiring" -> "Expiring"
+    row?.warning == true -> "Expiring"
     row?.available == true -> "Available"
     row?.setupRequired == false -> "Catalog"
     else -> "Setup"
@@ -313,7 +313,6 @@ internal fun modelProviderReady(status: String): Boolean {
 
 private fun modelProviderExpiring(status: String): Boolean = status.trim().lowercase() == "expiring"
 
-/** Counts providers with either ready auth status or currently available configured models. */
 internal fun readyModelProviderCount(
   providers: List<GatewayModelProviderSummary>,
   models: List<GatewayModelSummary>,
@@ -327,7 +326,6 @@ internal fun readyModelProviderCount(
 // readiness path while still honoring explicit false from upgraded gateways.
 private fun modelAvailabilityUsable(model: GatewayModelSummary): Boolean = model.available != false
 
-/** Counts auth-backed providers that can serve now but need renewal soon. */
 internal fun expiringModelProviderCount(providers: List<GatewayModelProviderSummary>): Int =
   providers
     .filter { modelProviderExpiring(it.status) }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt
@@ -103,7 +103,10 @@ private val shellNavTabs = listOf(Tab.Overview, Tab.Chat, Tab.Voice, Tab.Setting
 private val shellContentInsets: WindowInsets
   @Composable get() = WindowInsets.safeDrawing.only(WindowInsetsSides.Top + WindowInsetsSides.Horizontal)
 
-internal fun shellBottomNavVisible(keyboardVisible: Boolean, commandOpen: Boolean): Boolean = !keyboardVisible && !commandOpen
+internal fun shellBottomNavVisible(
+  keyboardVisible: Boolean,
+  commandOpen: Boolean,
+): Boolean = !keyboardVisible && !commandOpen
 
 /** Main post-onboarding shell that owns top-level Android navigation state. */
 @Composable
@@ -342,7 +345,8 @@ private fun OverviewScreen(
   val cronStatus by viewModel.cronStatus.collectAsState()
   val nodesDevicesSummary by viewModel.nodesDevicesSummary.collectAsState()
   val channelsSummary by viewModel.channelsSummary.collectAsState()
-  val readyProviderCount = providers.count { modelProviderReady(it.status) }
+  val readyProviderCount = readyModelProviderCount(providers, models)
+  val expiringProviderCount = expiringModelProviderCount(providers)
   val attentionRows =
     homeAttentionRows(
       isConnected = isConnected,
@@ -350,6 +354,7 @@ private fun OverviewScreen(
       channelsSummary = channelsSummary,
       nodesDevicesSummary = nodesDevicesSummary,
       readyProviderCount = readyProviderCount,
+      expiringProviderCount = expiringProviderCount,
     )
 
   LaunchedEffect(isConnected) {
@@ -460,6 +465,7 @@ private fun OverviewScreen(
                     when {
                       !isConnected -> "Offline"
                       readyProviderCount > 0 -> "$readyProviderCount ready"
+                      expiringProviderCount > 0 -> "$expiringProviderCount expiring"
                       models.isNotEmpty() -> "${models.size} models"
                       else -> "Setup"
                     },
@@ -541,6 +547,7 @@ internal fun homeAttentionRows(
   channelsSummary: GatewayChannelsSummary,
   nodesDevicesSummary: GatewayNodesDevicesSummary,
   readyProviderCount: Int,
+  expiringProviderCount: Int = 0,
 ): List<HomeAttentionRow> =
   listOfNotNull(
     if (!isConnected) {
@@ -563,7 +570,12 @@ internal fun homeAttentionRows(
     } else {
       null
     },
-    if (isConnected && readyProviderCount == 0) {
+    if (isConnected && expiringProviderCount > 0) {
+      HomeAttentionRow("Providers", "Provider auth expires soon", Icons.Outlined.Inventory2, Tab.ProvidersModels)
+    } else {
+      null
+    },
+    if (isConnected && readyProviderCount == 0 && expiringProviderCount == 0) {
       HomeAttentionRow("Providers", "No ready providers", Icons.Outlined.Inventory2, Tab.ProvidersModels)
     } else {
       null

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt
@@ -103,10 +103,7 @@ private val shellNavTabs = listOf(Tab.Overview, Tab.Chat, Tab.Voice, Tab.Setting
 private val shellContentInsets: WindowInsets
   @Composable get() = WindowInsets.safeDrawing.only(WindowInsetsSides.Top + WindowInsetsSides.Horizontal)
 
-internal fun shellBottomNavVisible(
-  keyboardVisible: Boolean,
-  commandOpen: Boolean,
-): Boolean = !keyboardVisible && !commandOpen
+internal fun shellBottomNavVisible(keyboardVisible: Boolean, commandOpen: Boolean): Boolean = !keyboardVisible && !commandOpen
 
 /** Main post-onboarding shell that owns top-level Android navigation state. */
 @Composable

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/ProviderModelStatusTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/ProviderModelStatusTest.kt
@@ -102,6 +102,13 @@ class ProviderModelStatusTest {
     assertEquals(0, readyModelProviderCount(providers, models))
   }
 
+  @Test
+  fun modelAvailabilityHonorsExplicitUnavailableRows() {
+    assertTrue(modelAvailabilityUsable(model(provider = "openai", available = true)))
+    assertTrue(modelAvailabilityUsable(model(provider = "openai", available = null)))
+    assertFalse(modelAvailabilityUsable(model(provider = "openai", available = false)))
+  }
+
   private fun model(
     provider: String,
     available: Boolean?,

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/ProviderModelStatusTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/ProviderModelStatusTest.kt
@@ -89,6 +89,20 @@ class ProviderModelStatusTest {
   }
 
   @Test
+  fun providerCommandSubtitleSurfacesExpiringBeforeReadyModels() {
+    val providers =
+      listOf(
+        GatewayModelProviderSummary(id = "openai", displayName = "OpenAI", status = "expiring", profileCount = 1),
+      )
+    val models =
+      listOf(
+        model(provider = "openai", available = true),
+      )
+
+    assertEquals("1 providers expiring", providerCommandSubtitle(isConnected = true, providers = providers, models = models))
+  }
+
+  @Test
   fun readyModelProviderCountDoesNotTreatUnavailableModelsAsReadyWhenAuthProviderNeedsSetup() {
     val providers =
       listOf(

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/ProviderModelStatusTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/ProviderModelStatusTest.kt
@@ -1,5 +1,8 @@
 package ai.openclaw.app.ui
 
+import ai.openclaw.app.GatewayModelProviderSummary
+import ai.openclaw.app.GatewayModelSummary
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -11,7 +14,107 @@ class ProviderModelStatusTest {
   }
 
   @Test
+  fun expiringProviderStatusIsNotFullyReady() {
+    assertFalse(modelProviderReady("expiring"))
+  }
+
+  @Test
   fun missingProviderStatusIsNotReady() {
     assertFalse(modelProviderReady("missing"))
   }
+
+  @Test
+  fun readyModelProviderCountUsesAuthBackedProviderStatuses() {
+    val providers =
+      listOf(
+        GatewayModelProviderSummary(id = "openai", displayName = "OpenAI", status = "missing", profileCount = 0),
+        GatewayModelProviderSummary(id = "anthropic", displayName = "Anthropic", status = "ready", profileCount = 1),
+        GatewayModelProviderSummary(id = "openai", displayName = "OpenAI", status = "expiring", profileCount = 1),
+      )
+
+    assertEquals(1, readyModelProviderCount(providers, emptyList()))
+    assertEquals(1, expiringModelProviderCount(providers))
+  }
+
+  @Test
+  fun readyModelProviderCountUsesAvailableModelsAsServingReadiness() {
+    val models =
+      listOf(
+        model(provider = "anthropic", available = true),
+        model(provider = "anthropic", available = true),
+        model(provider = "openrouter", available = false),
+      )
+
+    assertEquals(1, readyModelProviderCount(emptyList(), models))
+  }
+
+  @Test
+  fun readyModelProviderCountDoesNotTreatCatalogOnlyModelsAsReady() {
+    val providers =
+      listOf(
+        GatewayModelProviderSummary(id = "openrouter", displayName = "OpenRouter", status = "missing", profileCount = 0),
+      )
+    val models =
+      listOf(
+        model(provider = "openrouter", available = false),
+      )
+
+    assertEquals(0, readyModelProviderCount(providers, models))
+  }
+
+  @Test
+  fun readyModelProviderCountPreservesLegacyRowsWhenAvailabilityIsMissing() {
+    val models =
+      listOf(
+        model(provider = "openrouter", available = null),
+      )
+
+    assertEquals(1, readyModelProviderCount(emptyList(), models))
+  }
+
+  @Test
+  fun readyModelProviderCountTreatsExpiringAvailableModelsAsUsableButWarnable() {
+    val providers =
+      listOf(
+        GatewayModelProviderSummary(id = "openai", displayName = "OpenAI", status = "expiring", profileCount = 1),
+      )
+    val models =
+      listOf(
+        model(provider = "openai", available = true),
+      )
+
+    assertEquals(1, readyModelProviderCount(providers, models))
+    assertEquals(1, expiringModelProviderCount(providers))
+    assertFalse(modelProviderReady("expiring"))
+  }
+
+  @Test
+  fun readyModelProviderCountDoesNotTreatUnavailableModelsAsReadyWhenAuthProviderNeedsSetup() {
+    val providers =
+      listOf(
+        GatewayModelProviderSummary(id = "openai", displayName = "OpenAI", status = "missing", profileCount = 0),
+      )
+    val models =
+      listOf(
+        model(provider = "openai", available = false),
+      )
+
+    assertEquals(0, readyModelProviderCount(providers, models))
+  }
+
+  private fun model(
+    provider: String,
+    available: Boolean?,
+  ): GatewayModelSummary =
+    GatewayModelSummary(
+      id = "$provider/test-model",
+      name = "test-model",
+      provider = provider,
+      available = available,
+      supportsVision = false,
+      supportsAudio = false,
+      supportsDocuments = false,
+      supportsReasoning = false,
+      contextTokens = null,
+    )
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/ShellScreenLogicTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/ShellScreenLogicTest.kt
@@ -92,6 +92,21 @@ class ShellScreenLogicTest {
     assertEquals(emptyList<String>(), rows.map { it.title })
   }
 
+  @Test
+  fun homeAttentionRowsSurfaceExpiringProviderAuth() {
+    val rows =
+      homeAttentionRows(
+        isConnected = true,
+        pendingApprovals = 0,
+        channelsSummary = emptyChannels(),
+        nodesDevicesSummary = emptyNodesDevices(),
+        readyProviderCount = 0,
+        expiringProviderCount = 1,
+      )
+
+    assertEquals(listOf("Provider auth expires soon"), rows.map { it.subtitle })
+  }
+
   private fun emptyChannels(): GatewayChannelsSummary = GatewayChannelsSummary(channels = emptyList())
 
   private fun emptyNodesDevices(): GatewayNodesDevicesSummary = GatewayNodesDevicesSummary(nodes = emptyList(), pendingDevices = emptyList(), pairedDevices = emptyList())

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -4677,6 +4677,7 @@ public struct ModelChoice: Codable, Sendable {
     public let name: String
     public let provider: String
     public let alias: String?
+    public let available: Bool?
     public let contextwindow: Int?
     public let reasoning: Bool?
 
@@ -4685,6 +4686,7 @@ public struct ModelChoice: Codable, Sendable {
         name: String,
         provider: String,
         alias: String?,
+        available: Bool? = nil,
         contextwindow: Int?,
         reasoning: Bool?)
     {
@@ -4692,6 +4694,7 @@ public struct ModelChoice: Codable, Sendable {
         self.name = name
         self.provider = provider
         self.alias = alias
+        self.available = available
         self.contextwindow = contextwindow
         self.reasoning = reasoning
     }
@@ -4701,6 +4704,7 @@ public struct ModelChoice: Codable, Sendable {
         case name
         case provider
         case alias
+        case available
         case contextwindow = "contextWindow"
         case reasoning
     }

--- a/packages/gateway-protocol/src/schema/agents-models-skills.ts
+++ b/packages/gateway-protocol/src/schema/agents-models-skills.ts
@@ -18,6 +18,7 @@ export const ModelChoiceSchema = Type.Object(
     name: NonEmptyString,
     provider: NonEmptyString,
     alias: Type.Optional(NonEmptyString),
+    available: Type.Optional(Type.Boolean()),
     contextWindow: Type.Optional(Type.Integer({ minimum: 1 })),
     reasoning: Type.Optional(Type.Boolean()),
   },

--- a/scripts/protocol-gen-swift.ts
+++ b/scripts/protocol-gen-swift.ts
@@ -79,6 +79,7 @@ const DEFAULTED_OPTIONAL_INIT_PARAM_ENTRIES: readonly [string, readonly string[]
   ["CronRunLogEntry", ["errorReason", "failureNotificationDelivery"]],
   ["ExecApprovalRequestParams", ["requireDeliveryRoute", "suppressDelivery"]],
   ["AgentSummary", ["thinkingLevels", "thinkingOptions", "thinkingDefault"]],
+  ["ModelChoice", ["available"]],
 ];
 
 const DEFAULTED_OPTIONAL_INIT_PARAMS: Record<string, Set<string>> = Object.fromEntries(

--- a/src/agents/model-catalog-browse.ts
+++ b/src/agents/model-catalog-browse.ts
@@ -44,20 +44,20 @@ function resolveModelCatalogBrowseTimeoutMs(value: number | undefined): number {
 }
 
 /** Loads catalog entries for browse views, using read-only discovery unless full catalog is required. */
-export async function loadModelCatalogForBrowseWithState(params: {
+export async function loadModelCatalogForBrowse(params: {
   cfg: OpenClawConfig;
   view?: ModelCatalogBrowseView;
   loadCatalog: (params: { readOnly: boolean }) => Promise<ModelCatalogEntry[]>;
   timeoutMs?: number;
   onTimeout?: (timeoutMs: number) => void;
-}): Promise<{ catalog: ModelCatalogEntry[]; timedOut: boolean }> {
+}): Promise<ModelCatalogEntry[]> {
   const view = params.view ?? "default";
   if (view === "all") {
-    return { catalog: await params.loadCatalog({ readOnly: false }), timedOut: false };
+    return await params.loadCatalog({ readOnly: false });
   }
   if (parseConfiguredModelVisibilityEntries({ cfg: params.cfg }).providerWildcards.size > 0) {
     // Wildcards depend on provider discovery; read-only cached entries can hide matching models.
-    return { catalog: await params.loadCatalog({ readOnly: false }), timedOut: false };
+    return await params.loadCatalog({ readOnly: false });
   }
 
   let timeout: NodeJS.Timeout | undefined;
@@ -75,23 +75,12 @@ export async function loadModelCatalogForBrowseWithState(params: {
       // The browse path may return partial/empty results; keep late catalog failures off stderr.
       catalogPromise.catch(() => undefined);
       params.onTimeout?.(timeoutMs);
-      return { catalog: [], timedOut: true };
+      return [];
     }
-    return { catalog: result, timedOut: false };
+    return result;
   } finally {
     if (timeout) {
       modelCatalogBrowseDeps.clearTimeout(timeout);
     }
   }
-}
-
-/** Loads catalog entries for browse views, using read-only discovery unless full catalog is required. */
-export async function loadModelCatalogForBrowse(params: {
-  cfg: OpenClawConfig;
-  view?: ModelCatalogBrowseView;
-  loadCatalog: (params: { readOnly: boolean }) => Promise<ModelCatalogEntry[]>;
-  timeoutMs?: number;
-  onTimeout?: (timeoutMs: number) => void;
-}): Promise<ModelCatalogEntry[]> {
-  return (await loadModelCatalogForBrowseWithState(params)).catalog;
 }

--- a/src/agents/model-catalog-browse.ts
+++ b/src/agents/model-catalog-browse.ts
@@ -44,20 +44,20 @@ function resolveModelCatalogBrowseTimeoutMs(value: number | undefined): number {
 }
 
 /** Loads catalog entries for browse views, using read-only discovery unless full catalog is required. */
-export async function loadModelCatalogForBrowse(params: {
+export async function loadModelCatalogForBrowseWithState(params: {
   cfg: OpenClawConfig;
   view?: ModelCatalogBrowseView;
   loadCatalog: (params: { readOnly: boolean }) => Promise<ModelCatalogEntry[]>;
   timeoutMs?: number;
   onTimeout?: (timeoutMs: number) => void;
-}): Promise<ModelCatalogEntry[]> {
+}): Promise<{ catalog: ModelCatalogEntry[]; timedOut: boolean }> {
   const view = params.view ?? "default";
   if (view === "all") {
-    return await params.loadCatalog({ readOnly: false });
+    return { catalog: await params.loadCatalog({ readOnly: false }), timedOut: false };
   }
   if (parseConfiguredModelVisibilityEntries({ cfg: params.cfg }).providerWildcards.size > 0) {
     // Wildcards depend on provider discovery; read-only cached entries can hide matching models.
-    return await params.loadCatalog({ readOnly: false });
+    return { catalog: await params.loadCatalog({ readOnly: false }), timedOut: false };
   }
 
   let timeout: NodeJS.Timeout | undefined;
@@ -75,12 +75,23 @@ export async function loadModelCatalogForBrowse(params: {
       // The browse path may return partial/empty results; keep late catalog failures off stderr.
       catalogPromise.catch(() => undefined);
       params.onTimeout?.(timeoutMs);
-      return [];
+      return { catalog: [], timedOut: true };
     }
-    return result;
+    return { catalog: result, timedOut: false };
   } finally {
     if (timeout) {
       modelCatalogBrowseDeps.clearTimeout(timeout);
     }
   }
+}
+
+/** Loads catalog entries for browse views, using read-only discovery unless full catalog is required. */
+export async function loadModelCatalogForBrowse(params: {
+  cfg: OpenClawConfig;
+  view?: ModelCatalogBrowseView;
+  loadCatalog: (params: { readOnly: boolean }) => Promise<ModelCatalogEntry[]>;
+  timeoutMs?: number;
+  onTimeout?: (timeoutMs: number) => void;
+}): Promise<ModelCatalogEntry[]> {
+  return (await loadModelCatalogForBrowseWithState(params)).catalog;
 }

--- a/src/agents/model-catalog-visibility.test.ts
+++ b/src/agents/model-catalog-visibility.test.ts
@@ -58,6 +58,12 @@ describe("resolveVisibleModelCatalog", () => {
         name: "GPT 5.5",
         api: "openai-responses",
       },
+      {
+        provider: "openai",
+        id: "gpt-5.4-codex",
+        name: "GPT 5.4 Codex",
+        api: "openai-responses",
+      },
     ];
 
     const result = await resolveVisibleModelCatalog({
@@ -71,8 +77,16 @@ describe("resolveVisibleModelCatalog", () => {
     expect(authChecker).toHaveBeenNthCalledWith(1, "openai", "openai-responses");
     expect(authChecker).toHaveBeenNthCalledWith(2, "openai", "openai-responses");
     expect(authChecker).toHaveBeenNthCalledWith(3, "openai", "openai-chatgpt-responses");
-    expect(authChecker).toHaveBeenCalledTimes(3);
+    expect(authChecker).toHaveBeenNthCalledWith(4, "openai", "openai-responses");
+    expect(authChecker).toHaveBeenNthCalledWith(5, "openai", "openai-chatgpt-responses");
+    expect(authChecker).toHaveBeenCalledTimes(5);
     expect(result).toEqual([
+      {
+        provider: "openai",
+        id: "gpt-5.4-codex",
+        name: "GPT 5.4 Codex",
+        api: "openai-responses",
+      },
       {
         provider: "openai",
         id: "gpt-5.5",

--- a/src/agents/model-catalog-visibility.ts
+++ b/src/agents/model-catalog-visibility.ts
@@ -14,7 +14,7 @@ import {
 } from "./model-visibility-policy.js";
 
 type ModelCatalogVisibilityView = "default" | "configured" | "all";
-type ProviderAuthChecker = (provider: string, modelApi?: string) => boolean | Promise<boolean>;
+export type ProviderAuthChecker = (provider: string, modelApi?: string) => boolean | Promise<boolean>;
 const OPENAI_PROVIDER_ID = "openai";
 const OPENAI_CODEX_RESPONSES_API = "openai-chatgpt-responses";
 const OPENAI_CODEX_ROUTABLE_MODEL_IDS = new Set([
@@ -52,7 +52,7 @@ async function resolveProviderAuthCheck(
   return isPromiseLike(result) ? await result : result;
 }
 
-async function providerHasAuth(
+export async function modelCatalogEntryHasProviderAuth(
   providerAuthChecker: ProviderAuthChecker,
   entry: ModelCatalogEntry,
 ): Promise<boolean> {
@@ -130,7 +130,7 @@ export async function resolveVisibleModelCatalog(params: {
       });
     const authBackedCatalog: ModelCatalogEntry[] = [];
     for (const entry of params.catalog) {
-      if (await providerHasAuth(hasAuth, entry)) {
+      if (await modelCatalogEntryHasProviderAuth(hasAuth, entry)) {
         authBackedCatalog.push(entry);
       }
     }

--- a/src/agents/model-catalog-visibility.ts
+++ b/src/agents/model-catalog-visibility.ts
@@ -14,13 +14,17 @@ import {
 } from "./model-visibility-policy.js";
 
 type ModelCatalogVisibilityView = "default" | "configured" | "all";
-export type ProviderAuthChecker = (provider: string, modelApi?: string) => boolean | Promise<boolean>;
+export type ProviderAuthChecker = (
+  provider: string,
+  modelApi?: string,
+) => boolean | Promise<boolean>;
 const OPENAI_PROVIDER_ID = "openai";
 const OPENAI_CODEX_RESPONSES_API = "openai-chatgpt-responses";
 const OPENAI_CODEX_ROUTABLE_MODEL_IDS = new Set([
   "gpt-5.5",
   "gpt-5.5-pro",
   "gpt-5.4",
+  "gpt-5.4-codex",
   "gpt-5.4-pro",
   "gpt-5.4-mini",
 ]);
@@ -29,7 +33,7 @@ function isPromiseLike(value: boolean | Promise<boolean>): value is Promise<bool
   return typeof value === "object" && value !== null && typeof value.then === "function";
 }
 
-function isCodexRoutableOpenAIPlatformCatalogEntry(entry: ModelCatalogEntry): boolean {
+export function isCodexRoutableOpenAIPlatformCatalogEntry(entry: ModelCatalogEntry): boolean {
   // OpenAI platform entries for current Codex-routable ids can use the ChatGPT
   // Responses auth path even when their catalog API is not already that API.
   return (

--- a/src/gateway/server-methods/models-list-result.ts
+++ b/src/gateway/server-methods/models-list-result.ts
@@ -20,11 +20,7 @@ import {
   loadModelCatalogForBrowse,
   type ModelCatalogBrowseView,
 } from "../../agents/model-catalog-browse.js";
-import {
-  modelCatalogEntryHasProviderAuth,
-  type ProviderAuthChecker,
-  resolveVisibleModelCatalog,
-} from "../../agents/model-catalog-visibility.js";
+import { resolveVisibleModelCatalog } from "../../agents/model-catalog-visibility.js";
 import type { ModelCatalogEntry } from "../../agents/model-catalog.types.js";
 import { resolveDefaultAgentWorkspaceDir } from "../../agents/workspace.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -33,9 +29,23 @@ import type { GatewayRequestContext } from "./types.js";
 
 type ModelsListView = ModelCatalogBrowseView;
 type ModelsListEntry = ModelCatalogEntry & { available?: boolean };
+type ModelsListAvailability = boolean | undefined;
+type ModelsListProviderAuthChecker = (
+  provider: string,
+  modelApi?: string,
+) => ModelsListAvailability | Promise<ModelsListAvailability>;
 
 let loggedSlowModelsListCatalog = false;
 const OAUTH_REFRESH_MARGIN_MS = 5 * 60 * 1000;
+const OPENAI_PROVIDER_ID = "openai";
+const OPENAI_CODEX_RESPONSES_API = "openai-chatgpt-responses";
+const OPENAI_CODEX_ROUTABLE_MODEL_IDS = new Set([
+  "gpt-5.5",
+  "gpt-5.5-pro",
+  "gpt-5.4",
+  "gpt-5.4-pro",
+  "gpt-5.4-mini",
+]);
 
 // Unknown views are rejected by protocol validation first; this helper keeps the
 // handler default explicit for older clients that omit the field.
@@ -65,9 +75,9 @@ function modelCatalogEntryHasUnknownSecretRefAvailability(
 }
 
 function createInFlightProviderAuthChecker(
-  providerAuthChecker: ProviderAuthChecker,
-): ProviderAuthChecker {
-  const pending = new Map<string, Promise<boolean>>();
+  providerAuthChecker: ModelsListProviderAuthChecker,
+): ModelsListProviderAuthChecker {
+  const pending = new Map<string, Promise<ModelsListAvailability>>();
   return (provider, modelApi) => {
     const key = `${normalizeProviderId(provider)}\0${modelApi ?? ""}`;
     const cached = pending.get(key);
@@ -88,6 +98,10 @@ function hasAvailableEnvSecretRef(value: unknown): boolean {
   return isSecretRef(value) && value.source === "env" && hasLiteralSecret(process.env[value.id]);
 }
 
+function hasSecretRef(value: unknown): boolean {
+  return isSecretRef(value);
+}
+
 function profileModeAllowedForModel(
   provider: string,
   modelApi: string | undefined,
@@ -106,21 +120,27 @@ function profileHasReadOnlyAvailableAuth(params: {
   provider: string;
   modelApi?: string;
   now: number;
-}): boolean {
+}): ModelsListAvailability {
   if (!profileModeAllowedForModel(params.provider, params.modelApi, params.credential.type)) {
     return false;
   }
   if (params.credential.type === "api_key") {
-    return (
-      hasLiteralSecret(params.credential.key) || hasAvailableEnvSecretRef(params.credential.keyRef)
-    );
+    if (
+      hasLiteralSecret(params.credential.key) ||
+      hasAvailableEnvSecretRef(params.credential.keyRef)
+    ) {
+      return true;
+    }
+    return hasSecretRef(params.credential.keyRef) ? undefined : false;
   }
   if (params.credential.type === "token") {
-    return (
-      (hasLiteralSecret(params.credential.token) ||
-        hasAvailableEnvSecretRef(params.credential.tokenRef)) &&
-      (params.credential.expires === undefined || params.credential.expires > params.now)
-    );
+    const hasCurrentToken =
+      hasLiteralSecret(params.credential.token) ||
+      hasAvailableEnvSecretRef(params.credential.tokenRef);
+    if (hasCurrentToken) {
+      return params.credential.expires === undefined || params.credential.expires > params.now;
+    }
+    return hasSecretRef(params.credential.tokenRef) ? undefined : false;
   }
   return (
     hasLiteralSecret(params.credential.access) &&
@@ -133,31 +153,39 @@ function hasReadOnlyAvailableProfileAuth(params: {
   modelApi?: string;
   cfg: OpenClawConfig;
   store: AuthProfileStore;
-}): boolean {
+}): ModelsListAvailability {
   const now = Date.now();
-  return resolveAuthProfileOrder({
+  let sawUnknown = false;
+  for (const profileId of resolveAuthProfileOrder({
     cfg: params.cfg,
     store: params.store,
     provider: params.provider,
-  }).some((profileId) => {
+  })) {
     const credential = params.store.profiles[profileId];
-    return (
-      credential !== undefined &&
-      profileHasReadOnlyAvailableAuth({
-        credential,
-        provider: params.provider,
-        modelApi: params.modelApi,
-        now,
-      })
-    );
-  });
+    if (!credential) {
+      continue;
+    }
+    const available = profileHasReadOnlyAvailableAuth({
+      credential,
+      provider: params.provider,
+      modelApi: params.modelApi,
+      now,
+    });
+    if (available === true) {
+      return true;
+    }
+    if (available === undefined) {
+      sawUnknown = true;
+    }
+  }
+  return sawUnknown ? undefined : false;
 }
 
 function createModelsListProviderAuthChecker(params: {
   cfg: OpenClawConfig;
   agentId: string;
   workspaceDir: string;
-}): ProviderAuthChecker {
+}): ModelsListProviderAuthChecker {
   const agentDir = resolveAgentDir(params.cfg, params.agentId);
   const store = ensureAuthProfileStoreWithoutExternalProfiles(agentDir, {
     allowKeychainPrompt: false,
@@ -182,10 +210,31 @@ function createModelsListProviderAuthChecker(params: {
   );
 }
 
+function isCodexRoutableOpenAIPlatformCatalogEntry(entry: ModelCatalogEntry): boolean {
+  return (
+    normalizeProviderId(entry.provider) === OPENAI_PROVIDER_ID &&
+    entry.api !== undefined &&
+    entry.api !== OPENAI_CODEX_RESPONSES_API &&
+    OPENAI_CODEX_ROUTABLE_MODEL_IDS.has(entry.id.trim().toLowerCase())
+  );
+}
+
+async function resolveModelsListEntryAvailability(
+  providerAuthChecker: ModelsListProviderAuthChecker,
+  entry: ModelCatalogEntry,
+): Promise<ModelsListAvailability> {
+  const primary = await providerAuthChecker(entry.provider, entry.api);
+  if (primary === true || !isCodexRoutableOpenAIPlatformCatalogEntry(entry)) {
+    return primary;
+  }
+  const codexResponses = await providerAuthChecker(entry.provider, OPENAI_CODEX_RESPONSES_API);
+  return codexResponses ?? primary;
+}
+
 async function buildPublicModelsListEntry(params: {
   entry: ModelCatalogEntry;
   cfg: OpenClawConfig;
-  providerAuthChecker?: ProviderAuthChecker;
+  providerAuthChecker?: ModelsListProviderAuthChecker;
 }): Promise<ModelsListEntry> {
   const publicEntry = omitRuntimeModelParams(params.entry);
   if (modelCatalogEntryHasUnknownSecretRefAvailability(params.cfg, params.entry)) {
@@ -194,9 +243,16 @@ async function buildPublicModelsListEntry(params: {
   if (!params.providerAuthChecker) {
     return publicEntry;
   }
+  const available = await resolveModelsListEntryAvailability(
+    params.providerAuthChecker,
+    params.entry,
+  );
+  if (available === undefined) {
+    return publicEntry;
+  }
   return {
     ...publicEntry,
-    available: await modelCatalogEntryHasProviderAuth(params.providerAuthChecker, params.entry),
+    available,
   };
 }
 

--- a/src/gateway/server-methods/models-list-result.ts
+++ b/src/gateway/server-methods/models-list-result.ts
@@ -7,10 +7,15 @@ import {
   resolveAgentWorkspaceDir,
   resolveDefaultAgentId,
 } from "../../agents/agent-scope.js";
-import { ensureAuthProfileStoreWithoutExternalProfiles } from "../../agents/auth-profiles.js";
+import {
+  ensureAuthProfileStoreWithoutExternalProfiles,
+  resolveAuthProfileOrder,
+  type AuthProfileCredential,
+  type AuthProfileStore,
+} from "../../agents/auth-profiles.js";
 import { DEFAULT_PROVIDER } from "../../agents/defaults.js";
 import { NON_ENV_SECRETREF_MARKER } from "../../agents/model-auth-markers.js";
-import { hasAvailableAuthForProvider } from "../../agents/model-auth.js";
+import { hasRuntimeAvailableProviderAuth } from "../../agents/model-auth.js";
 import {
   loadModelCatalogForBrowse,
   type ModelCatalogBrowseView,
@@ -30,6 +35,7 @@ type ModelsListView = ModelCatalogBrowseView;
 type ModelsListEntry = ModelCatalogEntry & { available?: boolean };
 
 let loggedSlowModelsListCatalog = false;
+const OAUTH_REFRESH_MARGIN_MS = 5 * 60 * 1000;
 
 // Unknown views are rejected by protocol validation first; this helper keeps the
 // handler default explicit for older clients that omit the field.
@@ -74,6 +80,72 @@ function createInFlightProviderAuthChecker(
   };
 }
 
+function hasLiteralSecret(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function profileModeAllowedForModel(
+  provider: string,
+  modelApi: string | undefined,
+  mode: AuthProfileCredential["type"],
+): boolean {
+  return (
+    normalizeProviderId(provider) !== "openai" ||
+    modelApi === undefined ||
+    modelApi === "openai-chatgpt-responses" ||
+    mode === "api_key"
+  );
+}
+
+function profileHasReadOnlyAvailableAuth(params: {
+  credential: AuthProfileCredential;
+  provider: string;
+  modelApi?: string;
+  now: number;
+}): boolean {
+  if (!profileModeAllowedForModel(params.provider, params.modelApi, params.credential.type)) {
+    return false;
+  }
+  if (params.credential.type === "api_key") {
+    return hasLiteralSecret(params.credential.key);
+  }
+  if (params.credential.type === "token") {
+    return (
+      hasLiteralSecret(params.credential.token) &&
+      (params.credential.expires === undefined || params.credential.expires > params.now)
+    );
+  }
+  return (
+    hasLiteralSecret(params.credential.access) &&
+    params.credential.expires > params.now + OAUTH_REFRESH_MARGIN_MS
+  );
+}
+
+function hasReadOnlyAvailableProfileAuth(params: {
+  provider: string;
+  modelApi?: string;
+  cfg: OpenClawConfig;
+  store: AuthProfileStore;
+}): boolean {
+  const now = Date.now();
+  return resolveAuthProfileOrder({
+    cfg: params.cfg,
+    store: params.store,
+    provider: params.provider,
+  }).some((profileId) => {
+    const credential = params.store.profiles[profileId];
+    return (
+      credential !== undefined &&
+      profileHasReadOnlyAvailableAuth({
+        credential,
+        provider: params.provider,
+        modelApi: params.modelApi,
+        now,
+      })
+    );
+  });
+}
+
 function createModelsListProviderAuthChecker(params: {
   cfg: OpenClawConfig;
   agentId: string;
@@ -82,16 +154,24 @@ function createModelsListProviderAuthChecker(params: {
   const agentDir = resolveAgentDir(params.cfg, params.agentId);
   const store = ensureAuthProfileStoreWithoutExternalProfiles(agentDir, {
     allowKeychainPrompt: false,
+    readOnly: true,
+    syncExternalCli: false,
   });
-  return createInFlightProviderAuthChecker((provider, modelApi) =>
-    hasAvailableAuthForProvider({
-      provider,
-      modelApi,
-      cfg: params.cfg,
-      agentDir,
-      workspaceDir: params.workspaceDir,
-      store,
-    }),
+  return createInFlightProviderAuthChecker(
+    (provider, modelApi) =>
+      hasRuntimeAvailableProviderAuth({
+        provider,
+        modelApi,
+        cfg: params.cfg,
+        workspaceDir: params.workspaceDir,
+        allowPluginSyntheticAuth: false,
+      }) ||
+      hasReadOnlyAvailableProfileAuth({
+        provider,
+        modelApi,
+        cfg: params.cfg,
+        store,
+      }),
   );
 }
 

--- a/src/gateway/server-methods/models-list-result.ts
+++ b/src/gateway/server-methods/models-list-result.ts
@@ -239,7 +239,10 @@ async function buildPublicModelsListEntry(params: {
 }): Promise<ModelsListEntry> {
   const publicEntry = omitRuntimeModelParams(params.entry);
   if (modelCatalogEntryHasUnknownSecretRefAvailability(params.cfg, params.entry)) {
-    return publicEntry;
+    return {
+      ...publicEntry,
+      available: false,
+    };
   }
   if (!params.providerAuthChecker) {
     return publicEntry;
@@ -248,12 +251,9 @@ async function buildPublicModelsListEntry(params: {
     params.providerAuthChecker,
     params.entry,
   );
-  if (available === undefined) {
-    return publicEntry;
-  }
   return {
     ...publicEntry,
-    available,
+    available: available ?? false,
   };
 }
 

--- a/src/gateway/server-methods/models-list-result.ts
+++ b/src/gateway/server-methods/models-list-result.ts
@@ -84,6 +84,10 @@ function hasLiteralSecret(value: unknown): value is string {
   return typeof value === "string" && value.trim().length > 0;
 }
 
+function hasAvailableEnvSecretRef(value: unknown): boolean {
+  return isSecretRef(value) && value.source === "env" && hasLiteralSecret(process.env[value.id]);
+}
+
 function profileModeAllowedForModel(
   provider: string,
   modelApi: string | undefined,
@@ -107,11 +111,14 @@ function profileHasReadOnlyAvailableAuth(params: {
     return false;
   }
   if (params.credential.type === "api_key") {
-    return hasLiteralSecret(params.credential.key);
+    return (
+      hasLiteralSecret(params.credential.key) || hasAvailableEnvSecretRef(params.credential.keyRef)
+    );
   }
   if (params.credential.type === "token") {
     return (
-      hasLiteralSecret(params.credential.token) &&
+      (hasLiteralSecret(params.credential.token) ||
+        hasAvailableEnvSecretRef(params.credential.tokenRef)) &&
       (params.credential.expires === undefined || params.credential.expires > params.now)
     );
   }

--- a/src/gateway/server-methods/models-list-result.ts
+++ b/src/gateway/server-methods/models-list-result.ts
@@ -43,6 +43,7 @@ const OPENAI_CODEX_ROUTABLE_MODEL_IDS = new Set([
   "gpt-5.5",
   "gpt-5.5-pro",
   "gpt-5.4",
+  "gpt-5.4-codex",
   "gpt-5.4-pro",
   "gpt-5.4-mini",
 ]);

--- a/src/gateway/server-methods/models-list-result.ts
+++ b/src/gateway/server-methods/models-list-result.ts
@@ -20,7 +20,10 @@ import {
   loadModelCatalogForBrowse,
   type ModelCatalogBrowseView,
 } from "../../agents/model-catalog-browse.js";
-import { resolveVisibleModelCatalog } from "../../agents/model-catalog-visibility.js";
+import {
+  isCodexRoutableOpenAIPlatformCatalogEntry,
+  resolveVisibleModelCatalog,
+} from "../../agents/model-catalog-visibility.js";
 import type { ModelCatalogEntry } from "../../agents/model-catalog.types.js";
 import { resolveDefaultAgentWorkspaceDir } from "../../agents/workspace.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -37,16 +40,7 @@ type ModelsListProviderAuthChecker = (
 
 let loggedSlowModelsListCatalog = false;
 const OAUTH_REFRESH_MARGIN_MS = 5 * 60 * 1000;
-const OPENAI_PROVIDER_ID = "openai";
 const OPENAI_CODEX_RESPONSES_API = "openai-chatgpt-responses";
-const OPENAI_CODEX_ROUTABLE_MODEL_IDS = new Set([
-  "gpt-5.5",
-  "gpt-5.5-pro",
-  "gpt-5.4",
-  "gpt-5.4-codex",
-  "gpt-5.4-pro",
-  "gpt-5.4-mini",
-]);
 
 // Unknown views are rejected by protocol validation first; this helper keeps the
 // handler default explicit for older clients that omit the field.
@@ -208,15 +202,6 @@ function createModelsListProviderAuthChecker(params: {
         cfg: params.cfg,
         store,
       }),
-  );
-}
-
-function isCodexRoutableOpenAIPlatformCatalogEntry(entry: ModelCatalogEntry): boolean {
-  return (
-    normalizeProviderId(entry.provider) === OPENAI_PROVIDER_ID &&
-    entry.api !== undefined &&
-    entry.api !== OPENAI_CODEX_RESPONSES_API &&
-    OPENAI_CODEX_ROUTABLE_MODEL_IDS.has(entry.id.trim().toLowerCase())
   );
 }
 

--- a/src/gateway/server-methods/models-list-result.ts
+++ b/src/gateway/server-methods/models-list-result.ts
@@ -7,8 +7,9 @@ import {
   resolveDefaultAgentId,
 } from "../../agents/agent-scope.js";
 import { DEFAULT_PROVIDER } from "../../agents/defaults.js";
+import { NON_ENV_SECRETREF_MARKER } from "../../agents/model-auth-markers.js";
 import {
-  loadModelCatalogForBrowseWithState,
+  loadModelCatalogForBrowse,
   type ModelCatalogBrowseView,
 } from "../../agents/model-catalog-browse.js";
 import {
@@ -16,12 +17,11 @@ import {
   type ProviderAuthChecker,
   resolveVisibleModelCatalog,
 } from "../../agents/model-catalog-visibility.js";
-import { NON_ENV_SECRETREF_MARKER } from "../../agents/model-auth-markers.js";
 import type { ModelCatalogEntry } from "../../agents/model-catalog.types.js";
 import { createProviderAuthChecker } from "../../agents/model-provider-auth.js";
-import { isSecretRef } from "../../config/types.secrets.js";
-import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { resolveDefaultAgentWorkspaceDir } from "../../agents/workspace.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { isSecretRef } from "../../config/types.secrets.js";
 import type { GatewayRequestContext } from "./types.js";
 
 type ModelsListView = ModelCatalogBrowseView;
@@ -125,7 +125,7 @@ export async function buildModelsListResult(params: {
   const agentId = params.agentId ?? resolveDefaultAgentId(cfg);
   const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId) ?? resolveDefaultAgentWorkspaceDir();
   const view = resolveModelsListView(params.params);
-  const { catalog } = await loadModelCatalogForBrowseWithState({
+  const catalog = await loadModelCatalogForBrowse({
     cfg,
     view,
     loadCatalog: params.context.loadGatewayModelCatalog,

--- a/src/gateway/server-methods/models-list-result.ts
+++ b/src/gateway/server-methods/models-list-result.ts
@@ -2,12 +2,15 @@
 // strips runtime-only provider params before sending the browse API payload.
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import {
+  resolveAgentDir,
   resolveAgentEffectiveModelPrimary,
   resolveAgentWorkspaceDir,
   resolveDefaultAgentId,
 } from "../../agents/agent-scope.js";
+import { ensureAuthProfileStoreWithoutExternalProfiles } from "../../agents/auth-profiles.js";
 import { DEFAULT_PROVIDER } from "../../agents/defaults.js";
 import { NON_ENV_SECRETREF_MARKER } from "../../agents/model-auth-markers.js";
+import { hasAvailableAuthForProvider } from "../../agents/model-auth.js";
 import {
   loadModelCatalogForBrowse,
   type ModelCatalogBrowseView,
@@ -18,7 +21,6 @@ import {
   resolveVisibleModelCatalog,
 } from "../../agents/model-catalog-visibility.js";
 import type { ModelCatalogEntry } from "../../agents/model-catalog.types.js";
-import { createProviderAuthChecker } from "../../agents/model-provider-auth.js";
 import { resolveDefaultAgentWorkspaceDir } from "../../agents/workspace.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { isSecretRef } from "../../config/types.secrets.js";
@@ -72,6 +74,27 @@ function createInFlightProviderAuthChecker(
   };
 }
 
+function createModelsListProviderAuthChecker(params: {
+  cfg: OpenClawConfig;
+  agentId: string;
+  workspaceDir: string;
+}): ProviderAuthChecker {
+  const agentDir = resolveAgentDir(params.cfg, params.agentId);
+  const store = ensureAuthProfileStoreWithoutExternalProfiles(agentDir, {
+    allowKeychainPrompt: false,
+  });
+  return createInFlightProviderAuthChecker((provider, modelApi) =>
+    hasAvailableAuthForProvider({
+      provider,
+      modelApi,
+      cfg: params.cfg,
+      agentDir,
+      workspaceDir: params.workspaceDir,
+      store,
+    }),
+  );
+}
+
 async function buildPublicModelsListEntry(params: {
   entry: ModelCatalogEntry;
   cfg: OpenClawConfig;
@@ -96,21 +119,13 @@ async function buildPublicModelsListEntries(params: {
   agentId: string;
   workspaceDir: string;
 }): Promise<ModelsListEntry[]> {
-  const inFlightProviderAuthChecker = createInFlightProviderAuthChecker(
-    createProviderAuthChecker({
-      cfg: params.cfg,
-      agentId: params.agentId,
-      workspaceDir: params.workspaceDir,
-      allowPluginSyntheticAuth: false,
-      discoverExternalCliAuth: false,
-    }),
-  );
+  const providerAuthChecker = createModelsListProviderAuthChecker(params);
   return await Promise.all(
     params.catalog.map((entry) =>
       buildPublicModelsListEntry({
         entry,
         cfg: params.cfg,
-        providerAuthChecker: inFlightProviderAuthChecker,
+        providerAuthChecker,
       }),
     ),
   );

--- a/src/gateway/server-methods/models-list-result.ts
+++ b/src/gateway/server-methods/models-list-result.ts
@@ -1,5 +1,6 @@
 // Model list result building resolves visible model catalogs for an agent and
 // strips runtime-only provider params before sending the browse API payload.
+import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import {
   resolveAgentEffectiveModelPrimary,
   resolveAgentWorkspaceDir,
@@ -7,15 +8,24 @@ import {
 } from "../../agents/agent-scope.js";
 import { DEFAULT_PROVIDER } from "../../agents/defaults.js";
 import {
-  loadModelCatalogForBrowse,
+  loadModelCatalogForBrowseWithState,
   type ModelCatalogBrowseView,
 } from "../../agents/model-catalog-browse.js";
-import { resolveVisibleModelCatalog } from "../../agents/model-catalog-visibility.js";
+import {
+  modelCatalogEntryHasProviderAuth,
+  type ProviderAuthChecker,
+  resolveVisibleModelCatalog,
+} from "../../agents/model-catalog-visibility.js";
+import { NON_ENV_SECRETREF_MARKER } from "../../agents/model-auth-markers.js";
 import type { ModelCatalogEntry } from "../../agents/model-catalog.types.js";
+import { createProviderAuthChecker } from "../../agents/model-provider-auth.js";
+import { isSecretRef } from "../../config/types.secrets.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { resolveDefaultAgentWorkspaceDir } from "../../agents/workspace.js";
 import type { GatewayRequestContext } from "./types.js";
 
 type ModelsListView = ModelCatalogBrowseView;
+type ModelsListEntry = ModelCatalogEntry & { available?: boolean };
 
 let loggedSlowModelsListCatalog = false;
 
@@ -34,20 +44,88 @@ function omitRuntimeModelParams(entry: ModelCatalogEntry): ModelCatalogEntry {
   return rest;
 }
 
-function omitRuntimeModelParamsFromCatalog(catalog: ModelCatalogEntry[]): ModelCatalogEntry[] {
-  return catalog.map(omitRuntimeModelParams);
+function modelCatalogEntryHasUnknownSecretRefAvailability(
+  cfg: OpenClawConfig,
+  entry: ModelCatalogEntry,
+): boolean {
+  const providerId = normalizeProviderId(entry.provider);
+  const provider = Object.entries(cfg.models?.providers ?? {}).find(
+    ([id]) => normalizeProviderId(id) === providerId,
+  )?.[1];
+  const apiKey = provider?.apiKey;
+  return apiKey === NON_ENV_SECRETREF_MARKER || (isSecretRef(apiKey) && apiKey.source !== "env");
+}
+
+function createInFlightProviderAuthChecker(
+  providerAuthChecker: ProviderAuthChecker,
+): ProviderAuthChecker {
+  const pending = new Map<string, Promise<boolean>>();
+  return (provider, modelApi) => {
+    const key = `${normalizeProviderId(provider)}\0${modelApi ?? ""}`;
+    const cached = pending.get(key);
+    if (cached) {
+      return cached;
+    }
+    const next = Promise.resolve(providerAuthChecker(provider, modelApi));
+    pending.set(key, next);
+    return next;
+  };
+}
+
+async function buildPublicModelsListEntry(params: {
+  entry: ModelCatalogEntry;
+  cfg: OpenClawConfig;
+  providerAuthChecker?: ProviderAuthChecker;
+}): Promise<ModelsListEntry> {
+  const publicEntry = omitRuntimeModelParams(params.entry);
+  if (modelCatalogEntryHasUnknownSecretRefAvailability(params.cfg, params.entry)) {
+    return publicEntry;
+  }
+  if (!params.providerAuthChecker) {
+    return publicEntry;
+  }
+  return {
+    ...publicEntry,
+    available: await modelCatalogEntryHasProviderAuth(params.providerAuthChecker, params.entry),
+  };
+}
+
+async function buildPublicModelsListEntries(params: {
+  catalog: ModelCatalogEntry[];
+  cfg: OpenClawConfig;
+  agentId: string;
+  workspaceDir: string;
+}): Promise<ModelsListEntry[]> {
+  const inFlightProviderAuthChecker = createInFlightProviderAuthChecker(
+    createProviderAuthChecker({
+      cfg: params.cfg,
+      agentId: params.agentId,
+      workspaceDir: params.workspaceDir,
+      allowPluginSyntheticAuth: false,
+      discoverExternalCliAuth: false,
+    }),
+  );
+  return await Promise.all(
+    params.catalog.map((entry) =>
+      buildPublicModelsListEntry({
+        entry,
+        cfg: params.cfg,
+        providerAuthChecker: inFlightProviderAuthChecker,
+      }),
+    ),
+  );
 }
 
 export async function buildModelsListResult(params: {
   context: GatewayRequestContext;
   agentId?: string;
   params: Record<string, unknown>;
-}): Promise<{ models: ModelCatalogEntry[] }> {
+}): Promise<{ models: ModelsListEntry[] }> {
   const cfg = params.context.getRuntimeConfig();
   const agentId = params.agentId ?? resolveDefaultAgentId(cfg);
   const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId) ?? resolveDefaultAgentWorkspaceDir();
   const view = resolveModelsListView(params.params);
-  const catalog = await loadModelCatalogForBrowse({
+  const { catalog } = await loadModelCatalogForBrowseWithState({
     cfg,
     view,
     loadCatalog: params.context.loadGatewayModelCatalog,
@@ -62,7 +140,9 @@ export async function buildModelsListResult(params: {
     },
   });
   if (view === "all") {
-    return { models: omitRuntimeModelParamsFromCatalog(catalog) };
+    return {
+      models: await buildPublicModelsListEntries({ catalog, cfg, agentId, workspaceDir }),
+    };
   }
   const models = await resolveVisibleModelCatalog({
     cfg,
@@ -74,5 +154,12 @@ export async function buildModelsListResult(params: {
     view,
     runtimeAuthDiscovery: false,
   });
-  return { models: omitRuntimeModelParamsFromCatalog(models) };
+  return {
+    models: await buildPublicModelsListEntries({
+      catalog: models,
+      cfg,
+      agentId,
+      workspaceDir,
+    }),
+  };
 }

--- a/src/gateway/server-methods/models.test.ts
+++ b/src/gateway/server-methods/models.test.ts
@@ -435,6 +435,56 @@ describe("models.list", () => {
     );
   });
 
+  it("keeps non-env SecretRef-backed auth profile availability unknown", async () => {
+    await withOpenClawTestState(
+      {
+        layout: "state-only",
+        prefix: "openclaw-models-list-file-profile-",
+        agentEnv: "main",
+      },
+      async (state) => {
+        await state.writeAuthProfiles({
+          version: 1,
+          profiles: {
+            "demo-provider:file": {
+              type: "token",
+              provider: "demo-provider",
+              tokenRef: {
+                source: "file",
+                provider: "mounted-json",
+                id: "/providers/demo/token",
+              },
+              expires: Date.now() + 60_000,
+            },
+          },
+        });
+
+        const { request, respond } = requestModelsList({
+          view: "all",
+          loadGatewayModelCatalog: vi.fn(() =>
+            Promise.resolve([{ id: "demo-model", name: "Demo Model", provider: "demo-provider" }]),
+          ),
+          reqId: "req-models-list-file-profile",
+        });
+        await request;
+
+        expect(respond).toHaveBeenCalledWith(
+          true,
+          {
+            models: [
+              {
+                id: "demo-model",
+                name: "Demo Model",
+                provider: "demo-provider",
+              },
+            ],
+          },
+          undefined,
+        );
+      },
+    );
+  });
+
   it("preserves catalog load errors before the timeout fallback wins", async () => {
     const { request, respond } = requestModelsList({
       view: "configured",

--- a/src/gateway/server-methods/models.test.ts
+++ b/src/gateway/server-methods/models.test.ts
@@ -333,7 +333,7 @@ describe("models.list", () => {
     );
   });
 
-  it("does not mark catalog rows available from expired provider profiles", async () => {
+  it("does not mark catalog rows available from expired OAuth profiles", async () => {
     await withOpenClawTestState(
       {
         layout: "state-only",
@@ -345,9 +345,10 @@ describe("models.list", () => {
           version: 1,
           profiles: {
             "demo-provider:expired": {
-              type: "token",
+              type: "oauth",
               provider: "demo-provider",
-              token: "expired-token",
+              access: "expired-access",
+              refresh: "refresh-token",
               expires: Date.now() - 60_000,
             },
           },

--- a/src/gateway/server-methods/models.test.ts
+++ b/src/gateway/server-methods/models.test.ts
@@ -126,6 +126,7 @@ describe("models.list", () => {
               id: "llama-secure",
               name: "Llama Secure",
               provider: "vllm",
+              available: false,
             },
           ],
         },
@@ -317,7 +318,7 @@ describe("models.list", () => {
     );
   });
 
-  it("keeps file SecretRef provider availability unknown instead of forcing unavailable", async () => {
+  it("marks file SecretRef provider unavailable when read-only auth cannot prove availability", async () => {
     const catalog = [{ id: "llama-secure", name: "Llama Secure", provider: "vllm" }];
     const cfg = {
       agents: {
@@ -350,12 +351,14 @@ describe("models.list", () => {
 
     expect(respond).toHaveBeenCalledWith(
       true,
-      { models: [{ id: "llama-secure", name: "Llama Secure", provider: "vllm" }] },
+      {
+        models: [{ id: "llama-secure", name: "Llama Secure", provider: "vllm", available: false }],
+      },
       undefined,
     );
   });
 
-  it("keeps managed SecretRef provider availability unknown instead of forcing unavailable", async () => {
+  it("marks managed SecretRef provider unavailable when read-only auth cannot prove availability", async () => {
     const catalog = [{ id: "llama-managed", name: "Llama Managed", provider: "vllm" }];
     const cfg = {
       agents: {
@@ -384,7 +387,11 @@ describe("models.list", () => {
 
     expect(respond).toHaveBeenCalledWith(
       true,
-      { models: [{ id: "llama-managed", name: "Llama Managed", provider: "vllm" }] },
+      {
+        models: [
+          { id: "llama-managed", name: "Llama Managed", provider: "vllm", available: false },
+        ],
+      },
       undefined,
     );
   });
@@ -532,6 +539,7 @@ describe("models.list", () => {
                 id: "demo-model",
                 name: "Demo Model",
                 provider: "demo-provider",
+                available: false,
               },
             ],
           },

--- a/src/gateway/server-methods/models.test.ts
+++ b/src/gateway/server-methods/models.test.ts
@@ -381,6 +381,60 @@ describe("models.list", () => {
     );
   });
 
+  it("marks env SecretRef-backed auth profiles available", async () => {
+    await withOpenClawTestState(
+      {
+        layout: "state-only",
+        prefix: "openclaw-models-list-env-profile-",
+        agentEnv: "main",
+        env: {
+          DEMO_PROVIDER_TOKEN: "test-token",
+        },
+      },
+      async (state) => {
+        await state.writeAuthProfiles({
+          version: 1,
+          profiles: {
+            "demo-provider:env": {
+              type: "token",
+              provider: "demo-provider",
+              tokenRef: {
+                source: "env",
+                provider: "default",
+                id: "DEMO_PROVIDER_TOKEN",
+              },
+              expires: Date.now() + 60_000,
+            },
+          },
+        });
+
+        const { request, respond } = requestModelsList({
+          view: "all",
+          loadGatewayModelCatalog: vi.fn(() =>
+            Promise.resolve([{ id: "demo-model", name: "Demo Model", provider: "demo-provider" }]),
+          ),
+          reqId: "req-models-list-env-profile",
+        });
+        await request;
+
+        expect(respond).toHaveBeenCalledWith(
+          true,
+          {
+            models: [
+              {
+                id: "demo-model",
+                name: "Demo Model",
+                provider: "demo-provider",
+                available: true,
+              },
+            ],
+          },
+          undefined,
+        );
+      },
+    );
+  });
+
   it("preserves catalog load errors before the timeout fallback wins", async () => {
     const { request, respond } = requestModelsList({
       view: "configured",

--- a/src/gateway/server-methods/models.test.ts
+++ b/src/gateway/server-methods/models.test.ts
@@ -261,6 +261,62 @@ describe("models.list", () => {
     );
   });
 
+  it("marks legacy OpenAI Codex aliases available through ChatGPT OAuth", async () => {
+    await withOpenClawTestState(
+      {
+        layout: "state-only",
+        prefix: "openclaw-models-list-codex-alias-",
+        agentEnv: "main",
+      },
+      async (state) => {
+        await state.writeAuthProfiles({
+          version: 1,
+          profiles: {
+            "openai:chatgpt": {
+              type: "oauth",
+              provider: "openai",
+              access: "chatgpt-access",
+              refresh: "chatgpt-refresh",
+              expires: Date.now() + 30 * 60_000,
+            },
+          },
+        });
+
+        const { request, respond } = requestModelsList({
+          view: "all",
+          loadGatewayModelCatalog: vi.fn(() =>
+            Promise.resolve([
+              {
+                id: "gpt-5.4-codex",
+                name: "GPT-5.4 Codex",
+                provider: "openai",
+                api: "openai-responses",
+              },
+            ]),
+          ),
+          reqId: "req-models-list-codex-alias",
+        });
+        await request;
+
+        expect(respond).toHaveBeenCalledWith(
+          true,
+          {
+            models: [
+              {
+                id: "gpt-5.4-codex",
+                name: "GPT-5.4 Codex",
+                provider: "openai",
+                api: "openai-responses",
+                available: true,
+              },
+            ],
+          },
+          undefined,
+        );
+      },
+    );
+  });
+
   it("keeps file SecretRef provider availability unknown instead of forcing unavailable", async () => {
     const catalog = [{ id: "llama-secure", name: "Llama Secure", provider: "vllm" }];
     const cfg = {

--- a/src/gateway/server-methods/models.test.ts
+++ b/src/gateway/server-methods/models.test.ts
@@ -53,7 +53,7 @@ describe("models.list", () => {
       },
     } as unknown as OpenClawConfig;
 
-    vi.useFakeTimers();
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
     try {
       const { request, respond } = requestModelsList({
         view: "configured",
@@ -63,6 +63,7 @@ describe("models.list", () => {
       });
 
       await vi.advanceTimersByTimeAsync(800);
+      await vi.runOnlyPendingTimersAsync();
       await request;
 
       expect(respond).toHaveBeenCalledWith(
@@ -73,6 +74,7 @@ describe("models.list", () => {
               id: "gpt-test",
               name: "GPT Test",
               provider: "openai",
+              available: false,
             },
           ],
         },
@@ -84,11 +86,60 @@ describe("models.list", () => {
     }
   });
 
+  it("keeps SecretRef configured fallback rows unknown when catalog discovery times out", async () => {
+    const catalog = createDeferred<never>();
+    const loadGatewayModelCatalog = vi.fn(() => catalog.promise);
+    const runtimeConfig = {
+      models: {
+        providers: {
+          vllm: {
+            apiKey: {
+              source: "file",
+              provider: "mounted-json",
+              id: "/providers/vllm/apiKey",
+            },
+            models: [{ id: "llama-secure", name: "Llama Secure" }],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    try {
+      const { request, respond } = requestModelsList({
+        view: "configured",
+        runtimeConfig,
+        loadGatewayModelCatalog,
+        reqId: "req-models-list-secretref-timeout",
+      });
+
+      await vi.advanceTimersByTimeAsync(800);
+      await vi.runOnlyPendingTimersAsync();
+      await request;
+
+      expect(respond).toHaveBeenCalledWith(
+        true,
+        {
+          models: [
+            {
+              id: "llama-secure",
+              name: "Llama Secure",
+              provider: "vllm",
+            },
+          ],
+        },
+        undefined,
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("keeps the all view exact instead of timing out to a partial catalog", async () => {
     const catalog = createDeferred<[{ id: string; name: string; provider: string }]>();
     const loadGatewayModelCatalog = vi.fn(() => catalog.promise);
 
-    vi.useFakeTimers();
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
     try {
       const { request, respond } = requestModelsList({
         view: "all",
@@ -100,11 +151,12 @@ describe("models.list", () => {
       expect(respond).not.toHaveBeenCalled();
 
       catalog.resolve([{ id: "gpt-test", name: "GPT Test", provider: "openai" }]);
+      await vi.runAllTimersAsync();
       await request;
 
       expect(respond).toHaveBeenCalledWith(
         true,
-        { models: [{ id: "gpt-test", name: "GPT Test", provider: "openai" }] },
+        { models: [{ id: "gpt-test", name: "GPT Test", provider: "openai", available: false }] },
         undefined,
       );
       expect(loadGatewayModelCatalog).toHaveBeenCalledWith({ readOnly: false });
@@ -132,7 +184,7 @@ describe("models.list", () => {
 
     expect(respond).toHaveBeenCalledWith(
       true,
-      { models: [{ id: "qwen-local", name: "Qwen Local", provider: "vllm" }] },
+      { models: [{ id: "qwen-local", name: "Qwen Local", provider: "vllm", available: false }] },
       undefined,
     );
   });
@@ -175,10 +227,10 @@ describe("models.list", () => {
       true,
       {
         models: [
-          { id: "gpt-5.4-codex", name: "GPT-5.4 Codex", provider: "openai" },
-          { id: "gpt-codex-test", name: "GPT Codex Test", provider: "openai" },
-          { id: "llama-local", name: "Llama Local", provider: "vllm" },
-          { id: "qwen-local", name: "Qwen Local", provider: "vllm" },
+          { id: "gpt-5.4-codex", name: "GPT-5.4 Codex", provider: "openai", available: true },
+          { id: "gpt-codex-test", name: "GPT Codex Test", provider: "openai", available: true },
+          { id: "llama-local", name: "Llama Local", provider: "vllm", available: true },
+          { id: "qwen-local", name: "Qwen Local", provider: "vllm", available: true },
         ],
       },
       undefined,
@@ -193,7 +245,91 @@ describe("models.list", () => {
     });
     await allRequest;
 
-    expect(allRespond).toHaveBeenCalledWith(true, { models: catalog }, undefined);
+    expect(allRespond).toHaveBeenCalledWith(
+      true,
+      {
+        models: [
+          { id: "claude-test", name: "Claude Test", provider: "anthropic", available: false },
+          { id: "gpt-5.4-codex", name: "GPT-5.4 Codex", provider: "openai", available: true },
+          { id: "gpt-codex-test", name: "GPT Codex Test", provider: "openai", available: true },
+          { id: "llama-local", name: "Llama Local", provider: "vllm", available: true },
+          { id: "qwen-local", name: "Qwen Local", provider: "vllm", available: true },
+        ],
+      },
+      undefined,
+    );
+  });
+
+  it("keeps file SecretRef provider availability unknown instead of forcing unavailable", async () => {
+    const catalog = [{ id: "llama-secure", name: "Llama Secure", provider: "vllm" }];
+    const cfg = {
+      agents: {
+        defaults: {
+          models: {
+            "vllm/*": {},
+          },
+        },
+      },
+      models: {
+        providers: {
+          vllm: {
+            apiKey: {
+              source: "file",
+              provider: "mounted-json",
+              id: "/providers/vllm/apiKey",
+            },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const { request, respond } = requestModelsList({
+      view: "all",
+      runtimeConfig: cfg,
+      loadGatewayModelCatalog: vi.fn(() => Promise.resolve(catalog)),
+      reqId: "req-models-list-secretref-file",
+    });
+    await request;
+
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      { models: [{ id: "llama-secure", name: "Llama Secure", provider: "vllm" }] },
+      undefined,
+    );
+  });
+
+  it("keeps managed SecretRef provider availability unknown instead of forcing unavailable", async () => {
+    const catalog = [{ id: "llama-managed", name: "Llama Managed", provider: "vllm" }];
+    const cfg = {
+      agents: {
+        defaults: {
+          models: {
+            "vllm/*": {},
+          },
+        },
+      },
+      models: {
+        providers: {
+          vllm: {
+            apiKey: "secretref-managed",
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const { request, respond } = requestModelsList({
+      view: "all",
+      runtimeConfig: cfg,
+      loadGatewayModelCatalog: vi.fn(() => Promise.resolve(catalog)),
+      reqId: "req-models-list-secretref-managed",
+    });
+    await request;
+
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      { models: [{ id: "llama-managed", name: "Llama Managed", provider: "vllm" }] },
+      undefined,
+    );
   });
 
   it("preserves catalog load errors before the timeout fallback wins", async () => {

--- a/src/gateway/server-methods/models.test.ts
+++ b/src/gateway/server-methods/models.test.ts
@@ -3,6 +3,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { ErrorCodes } from "../../../packages/gateway-protocol/src/index.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import { createDeferred } from "../test-helpers.deferred.js";
 import { expectGatewayErrorResponse } from "./gateway-response.test-helpers.js";
 import { modelsHandlers } from "./models.js";
@@ -329,6 +330,53 @@ describe("models.list", () => {
       true,
       { models: [{ id: "llama-managed", name: "Llama Managed", provider: "vllm" }] },
       undefined,
+    );
+  });
+
+  it("does not mark catalog rows available from expired provider profiles", async () => {
+    await withOpenClawTestState(
+      {
+        layout: "state-only",
+        prefix: "openclaw-models-list-expired-profile-",
+        agentEnv: "main",
+      },
+      async (state) => {
+        await state.writeAuthProfiles({
+          version: 1,
+          profiles: {
+            "demo-provider:expired": {
+              type: "token",
+              provider: "demo-provider",
+              token: "expired-token",
+              expires: Date.now() - 60_000,
+            },
+          },
+        });
+
+        const { request, respond } = requestModelsList({
+          view: "all",
+          loadGatewayModelCatalog: vi.fn(() =>
+            Promise.resolve([{ id: "demo-model", name: "Demo Model", provider: "demo-provider" }]),
+          ),
+          reqId: "req-models-list-expired-profile",
+        });
+        await request;
+
+        expect(respond).toHaveBeenCalledWith(
+          true,
+          {
+            models: [
+              {
+                id: "demo-model",
+                name: "Demo Model",
+                provider: "demo-provider",
+                available: false,
+              },
+            ],
+          },
+          undefined,
+        );
+      },
     );
   });
 

--- a/src/gateway/server.models-voicewake-misc.test.ts
+++ b/src/gateway/server.models-voicewake-misc.test.ts
@@ -87,6 +87,7 @@ type ModelCatalogRpcEntry = {
   name: string;
   provider: string;
   alias?: string;
+  available?: boolean;
   contextWindow?: number;
   input?: string[];
   reasoning?: boolean;
@@ -126,24 +127,28 @@ const expectedSortedCatalog = (): ModelCatalogRpcEntry[] => [
     id: "claude-test-a",
     name: "A-Model",
     provider: "anthropic",
+    available: false,
     contextWindow: 200_000,
   },
   {
     id: "claude-test-b",
     name: "B-Model",
     provider: "anthropic",
+    available: false,
     contextWindow: 1000,
   },
   {
     id: "gpt-test-a",
     name: "A-Model",
     provider: "openai",
+    available: false,
     contextWindow: 8000,
   },
   {
     id: "gpt-test-z",
     name: "gpt-test-z",
     provider: "openai",
+    available: false,
   },
 ];
 
@@ -650,6 +655,7 @@ describe("gateway server models + voicewake", () => {
             id: "gpt-test-z",
             name: "gpt-test-z",
             provider: "openai",
+            available: false,
           },
         ]);
       },
@@ -689,11 +695,13 @@ describe("gateway server models + voicewake", () => {
           id: "claude-test-a",
           name: "claude-test-a",
           provider: "anthropic",
+          available: false,
         },
         {
           id: "gpt-test-z",
           name: "gpt-test-z",
           provider: "openai",
+          available: false,
         },
       ],
     });
@@ -710,6 +718,7 @@ describe("gateway server models + voicewake", () => {
           id: "not-in-catalog",
           name: "not-in-catalog",
           provider: "openai",
+          available: false,
         },
       ],
     });


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- Fixes an Android Home/Providers mismatch where provider readiness could be derived from `models.authStatus` alone and show `No ready providers` even when configured models were usable.
- Adds an optional `available` flag to `models.list` rows so clients can distinguish configured/usable models from catalog-only browse rows.
- Updates Android provider status surfaces to count available model providers, keep expiring auth as a warning, and keep explicit unavailable/catalog-only rows out of the ready count.
- Preserves compatibility for older gateways and SecretRef-backed providers by treating missing availability as unknown rather than definitively unavailable.

Why does this matter now?

Android now surfaces provider health directly on Home and Providers & Models. A false `No ready providers` attention row sends users toward Gateway setup even when the issue is only an expiring credential warning.

What is the intended outcome?

Android should show `Provider auth expires soon` / `Expiring` when configured models are still usable but credentials need attention soon, and should only show `No ready providers` when there are no usable/known model providers.

What is intentionally out of scope?

- Adding an Android-side credential renewal or OAuth re-auth flow.
- Changing model auth storage, login, logout, or provider credential mutation behavior.
- Making catalog-only `view:"all"` rows count as ready providers.

What does success look like?

The app uses `models.list` availability for usability, `models.authStatus` for credential warnings, and older/unknown availability remains source-compatible instead of forcing false setup state.

What should reviewers focus on?

Provider availability semantics across `models.list`, timeout/SecretRef compatibility, and Android readiness/status routing.

## Linked context

Which issue does this close?

Closes #

Which issues, PRs, or discussions are related?

No linked issue. This is a narrow behavior fix from observed Android/Gateway status drift.

Was this requested by a maintainer or owner?

No maintainer request.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Android could show a provider attention state as if no providers were ready while the gateway still had usable configured OpenAI models and `models.authStatus` was only warning that credentials were expiring.
- Real environment tested: local OpenClaw gateway with the Android third-party debug app installed on a local Android emulator.
- Exact steps or command run after this patch:
  - Installed the patched Android APK with `./gradlew :app:installThirdPartyDebug --no-daemon`.
  - Paired the emulator to the local gateway.
  - Opened Home and Providers & Models after model/auth refresh.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

![Home provider auth warning](https://raw.githubusercontent.com/Tosko4/openclaw/proof/android-provider-attention-state-204a065bb4/proof/android-provider-attention-state/home-provider-warning.png)

![Providers and Models expiring status](https://raw.githubusercontent.com/Tosko4/openclaw/proof/android-provider-attention-state-204a065bb4/proof/android-provider-attention-state/providers-models-expiring.png)

- Observed result after fix: Home routes the provider attention row to Providers & Models and shows an expiring-auth warning instead of `No ready providers`; Providers & Models separates available models, expiring auth, setup-required providers, and catalog-only rows.
- What was not tested: physical Android phone, Play flavor, and Android-side credential renewal/re-auth because that flow is intentionally out of scope.
- Proof limitations or environment constraints: screenshots are from a local Android emulator and were redacted/cropped to avoid setup codes, private chat IDs, local gateway URLs, and tokens. Later gateway-only compatibility fixes were validated through focused tests rather than new screenshots because the visual Android behavior did not change.
- Before evidence (optional but encouraged): pre-fix behavior showed the Home attention row as `No ready providers` while the Providers & Models surface showed usable model/provider state.

## Tests and validation

Which commands did you run?

- `git diff --check`
- `corepack pnpm --config.verifyDepsBeforeRun=false vitest run src/gateway/server-methods/models.test.ts`
- `corepack pnpm --config.verifyDepsBeforeRun=false vitest run src/gateway/server-methods/models.test.ts src/gateway/server.models-voicewake-misc.test.ts src/agents/model-catalog-browse.test.ts`
- `corepack pnpm --config.verifyDepsBeforeRun=false tsgo:core`
- `corepack pnpm --config.verifyDepsBeforeRun=false tsgo:core:test`
- `corepack pnpm --config.verifyDepsBeforeRun=false protocol:gen`
- `corepack pnpm --config.verifyDepsBeforeRun=false protocol:gen:swift`
- `ANDROID_HOME=/home/nabu/Android/Sdk ANDROID_SDK_ROOT=/home/nabu/Android/Sdk ./gradlew :app:testThirdPartyDebugUnitTest --tests ai.openclaw.app.ui.ProviderModelStatusTest --tests ai.openclaw.app.ui.ShellScreenLogicTest --no-daemon --stacktrace`
- `ANDROID_HOME=/home/nabu/Android/Sdk ANDROID_SDK_ROOT=/home/nabu/Android/Sdk ./gradlew :app:assembleThirdPartyDebug :app:installThirdPartyDebug --no-daemon`
- Structured Codex autoreview over the branch diff against `upstream/main`: clean, no accepted/actionable findings.

What regression coverage was added or updated?

- Gateway tests for `models.list` availability annotations, runtime-param redaction, timeout fallback behavior, file SecretRef unknown availability, and managed SecretRef unknown availability.
- Android tests for ready-provider counting from available model rows, legacy missing-availability compatibility, explicit unavailable rows, expiring-provider warning state, and Home attention routing.
- Protocol generation updated the Swift `ModelChoice` type while keeping the new optional initializer argument source-compatible.

What failed before this fix, if known?

The old Android logic could report no ready providers when provider auth status only exposed an expiring credential warning and model availability had to come from `models.list`.

If no test was added, why not?

Tests were added/updated.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Android Home, Providers & Models, and provider-related command/metadata status now distinguish available models, expiring auth, setup-required providers, and catalog-only rows.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No credential mutation or network auth behavior changes. This PR reads and reports provider availability metadata only.

What is the highest-risk area?

Auth/provider readiness semantics, especially older gateway compatibility, catalog timeout fallback, and SecretRef-backed provider configs.

How is that risk mitigated?

- `available` is optional and Android treats missing availability as unknown/legacy-compatible.
- Explicit `available:false` is honored only when the gateway can state that row is unavailable.
- Non-env and managed SecretRef-backed providers stay unknown instead of being forced unavailable by read-only checks.
- In-flight provider auth checks are memoized so large catalogs do not fan out identical auth checks.
- Focused gateway, Android, protocol generation, typecheck, install, and structured autoreview validation were run.

## Current review state

What is the next action?

Draft PR opened for CI, ClawSweeper, and maintainer review.

What is still waiting on author, maintainer, CI, or external proof?

Waiting on GitHub CI/ClawSweeper after this draft PR is created. Author-side focused validation is complete.

Which bot or reviewer comments were addressed?

No GitHub comments yet. Local structured Codex autoreview findings were addressed before opening the PR, including older-gateway compatibility, SecretRef/managed-secret availability, timeout semantics, in-flight auth check memoization, protocol generation, and Swift initializer source compatibility.

AI-assisted: implemented and validated with Codex, then manually inspected and tested in a local Android/OpenClaw setup.
