### PR TITLE
fix(ui): wire desktop session selector switch callback in Chat page header (fixes #87984)

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -24,6 +24,7 @@ import {
   dismissChatError,
   switchChatSession,
   switchChatSessionAndWait,
+  renderChatSessionSelect as renderChatDesktopSessionSelect,
 } from "./app-render.helpers.ts";
 import { hasOperatorAdminAccess, hasOperatorWriteAccess, warnQueryToken } from "./app-settings.ts";
 import type { AppViewState } from "./app-view-state.ts";
@@ -3478,168 +3479,174 @@ export function renderApp(state: AppViewState) {
             )
           : nothing}
         ${state.tab === "chat"
-          ? renderMeasured(
-              state,
-              "chat",
-              {
-                messageCount: state.chatMessages.length,
-                toolMessageCount: state.chatToolMessages.length,
-                streamSegmentCount: state.chatStreamSegments.length,
-                queueCount: state.chatQueue.length,
-              },
-              () =>
-                renderChat({
-                  sessionKey: state.sessionKey,
-                  onSessionKeyChange: (next) => {
-                    switchChatSession(state, next);
-                  },
-                  thinkingLevel: state.chatThinkingLevel,
-                  showThinking,
-                  showToolCalls,
-                  loading: state.chatLoading,
-                  sending: state.chatSending,
-                  compactionStatus: state.compactionStatus,
-                  fallbackStatus: state.fallbackStatus,
-                  assistantAvatarUrl: chatAvatarUrl,
-                  messages: state.chatMessages,
-                  sideResult: state.chatSideResult,
-                  toolMessages: state.chatToolMessages,
-                  streamSegments: state.chatStreamSegments,
-                  stream: state.chatStream,
-                  streamStartedAt: state.chatStreamStartedAt,
-                  draft: state.chatMessage,
-                  queue: state.chatQueue,
-                  realtimeTalkActive: state.realtimeTalkActive,
-                  realtimeTalkStatus: state.realtimeTalkStatus,
-                  realtimeTalkDetail: state.realtimeTalkDetail,
-                  realtimeTalkTranscript: state.realtimeTalkTranscript,
-                  realtimeTalkConversation: state.realtimeTalkConversation,
-                  realtimeTalkOptionsOpen: state.realtimeTalkOptionsOpen,
-                  realtimeTalkOptions: state.realtimeTalkOptions,
-                  connected: state.connected,
-                  canSend: state.connected,
-                  disabledReason: chatDisabledReason,
-                  error: chatViewError,
-                  runStatus: state.chatRunStatus,
-                  onDismissError: () => dismissChatError(state),
-                  sessions: state.sessionsResult,
-                  composerControls: renderGuardedChatControls(state),
-                  workspaceFiles: {
-                    agentId: chatAgentId,
-                    list:
-                      chatWorkspaceFiles.list?.agentId === chatAgentId
-                        ? chatWorkspaceFiles.list
-                        : null,
-                    loading: chatWorkspaceFiles.loading,
-                    error: chatWorkspaceFiles.error,
-                    activeName: chatWorkspaceFiles.activeName,
-                    onRefresh: refreshChatWorkspaceFiles,
-                    onOpenFile: openChatWorkspaceFile,
-                  },
-                  autoExpandToolCalls: false,
-                  onRefresh: () => {
-                    state.chatSideResult = null;
-                    state.resetToolStream();
-                    void refreshChat(state, { awaitHistory: true, scheduleScroll: false });
-                  },
-                  onChatScroll: (event) => state.handleChatScroll(event),
-                  getDraft: () => state.chatMessage,
-                  onDraftChange: (next) => state.handleChatDraftChange(next),
-                  onRequestUpdate: requestHostUpdate,
-                  onHistoryKeydown: (input) => state.handleChatInputHistoryKey(input),
-                  attachments: state.chatAttachments,
-                  onAttachmentsChange: (next) => (state.chatAttachments = next),
-                  onSend: () => void state.handleSendChat(),
-                  onCompact: () => void state.handleSendChat("/compact", { restoreDraft: true }),
-                  onOpenSessionCheckpoints: () => {
-                    state.sessionsExpandedCheckpointKey = state.sessionKey;
-                    state.setTab("sessions" as import("./navigation.ts").Tab);
-                    void loadSessions(state, {
-                      ...createChatSessionsLoadOverrides(state),
-                      ...scopedAgentListParamsForSession(state, state.sessionKey),
-                    });
-                  },
-                  onToggleRealtimeTalk: () => void state.toggleRealtimeTalk(),
-                  onToggleRealtimeTalkOptions: () => {
-                    state.realtimeTalkOptionsOpen = !state.realtimeTalkOptionsOpen;
-                  },
-                  onRealtimeTalkOptionsChange: (next) => state.updateRealtimeTalkOptions(next),
-                  canAbort: hasAbortableSessionRun(state),
-                  onAbort: () => void state.handleAbortChat({ preserveDraft: true }),
-                  onQueueRemove: (id) => state.removeQueuedMessage(id),
-                  onQueueRetry: (id) => void state.retryQueuedChatMessage(id),
-                  onQueueSteer: (id) => void state.steerQueuedChatMessage(id),
-                  onDismissSideResult: () => {
-                    state.chatSideResult = null;
-                  },
-                  onNewSession: () => void createChatSession(state),
-                  onClearHistory: runUiTask(async () => {
-                    if (!state.client || !state.connected) {
-                      return;
-                    }
-                    const hadActiveRun = hasAbortableSessionRun(state);
-                    try {
-                      await state.client.request("sessions.reset", {
-                        key: state.sessionKey,
-                        ...scopedAgentParamsForSession(state, state.sessionKey),
-                      });
-                      state.chatMessages = [];
+          ? html`
+              <div class="chat-desktop-session-select">
+                ${renderChatDesktopSessionSelect(state)}
+              </div>
+              ${renderMeasured(
+                state,
+                "chat",
+                {
+                  messageCount: state.chatMessages.length,
+                  toolMessageCount: state.chatToolMessages.length,
+                  streamSegmentCount: state.chatStreamSegments.length,
+                  queueCount: state.chatQueue.length,
+                },
+                () =>
+                  renderChat({
+                    sessionKey: state.sessionKey,
+                    onSessionKeyChange: (next) => {
+                      switchChatSession(state, next);
+                    },
+                    thinkingLevel: state.chatThinkingLevel,
+                    showThinking,
+                    showToolCalls,
+                    loading: state.chatLoading,
+                    sending: state.chatSending,
+                    compactionStatus: state.compactionStatus,
+                    fallbackStatus: state.fallbackStatus,
+                    assistantAvatarUrl: chatAvatarUrl,
+                    messages: state.chatMessages,
+                    sideResult: state.chatSideResult,
+                    toolMessages: state.chatToolMessages,
+                    streamSegments: state.chatStreamSegments,
+                    stream: state.chatStream,
+                    streamStartedAt: state.chatStreamStartedAt,
+                    draft: state.chatMessage,
+                    queue: state.chatQueue,
+                    realtimeTalkActive: state.realtimeTalkActive,
+                    realtimeTalkStatus: state.realtimeTalkStatus,
+                    realtimeTalkDetail: state.realtimeTalkDetail,
+                    realtimeTalkTranscript: state.realtimeTalkTranscript,
+                    realtimeTalkConversation: state.realtimeTalkConversation,
+                    realtimeTalkOptionsOpen: state.realtimeTalkOptionsOpen,
+                    realtimeTalkOptions: state.realtimeTalkOptions,
+                    connected: state.connected,
+                    canSend: state.connected,
+                    disabledReason: chatDisabledReason,
+                    error: chatViewError,
+                    runStatus: state.chatRunStatus,
+                    onDismissError: () => dismissChatError(state),
+                    sessions: state.sessionsResult,
+                    composerControls: renderGuardedChatControls(state),
+                    workspaceFiles: {
+                      agentId: chatAgentId,
+                      list:
+                        chatWorkspaceFiles.list?.agentId === chatAgentId
+                          ? chatWorkspaceFiles.list
+                          : null,
+                      loading: chatWorkspaceFiles.loading,
+                      error: chatWorkspaceFiles.error,
+                      activeName: chatWorkspaceFiles.activeName,
+                      onRefresh: refreshChatWorkspaceFiles,
+                      onOpenFile: openChatWorkspaceFile,
+                    },
+                    autoExpandToolCalls: false,
+                    onRefresh: () => {
                       state.chatSideResult = null;
-                      reconcileChatRunLifecycle(
-                        state as unknown as Parameters<typeof reconcileChatRunLifecycle>[0],
-                        {
-                          outcome: hadActiveRun ? "interrupted" : undefined,
-                          sessionStatus: "killed",
-                          runId: state.chatRunId,
-                          sessionKey: state.sessionKey,
-                          clearLocalRun: true,
-                          clearChatStream: true,
-                          clearToolStream: true,
-                          clearSideResultTerminalRuns: true,
-                          clearRunStatus: !hadActiveRun,
-                        },
-                      );
-                      await loadChatHistory(state);
-                    } catch (err) {
-                      state.lastError = String(err);
-                      state.chatError = state.lastError;
-                    }
+                      state.resetToolStream();
+                      void refreshChat(state, { awaitHistory: true, scheduleScroll: false });
+                    },
+                    onChatScroll: (event) => state.handleChatScroll(event),
+                    getDraft: () => state.chatMessage,
+                    onDraftChange: (next) => state.handleChatDraftChange(next),
+                    onRequestUpdate: requestHostUpdate,
+                    onHistoryKeydown: (input) => state.handleChatInputHistoryKey(input),
+                    attachments: state.chatAttachments,
+                    onAttachmentsChange: (next) => (state.chatAttachments = next),
+                    onSend: () => void state.handleSendChat(),
+                    onCompact: () => void state.handleSendChat("/compact", { restoreDraft: true }),
+                    onOpenSessionCheckpoints: () => {
+                      state.sessionsExpandedCheckpointKey = state.sessionKey;
+                      state.setTab("sessions" as import("./navigation.ts").Tab);
+                      void loadSessions(state, {
+                        ...createChatSessionsLoadOverrides(state),
+                        ...scopedAgentListParamsForSession(state, state.sessionKey),
+                      });
+                    },
+                    onToggleRealtimeTalk: () => void state.toggleRealtimeTalk(),
+                    onToggleRealtimeTalkOptions: () => {
+                      state.realtimeTalkOptionsOpen = !state.realtimeTalkOptionsOpen;
+                    },
+                    onRealtimeTalkOptionsChange: (next) => state.updateRealtimeTalkOptions(next),
+                    canAbort: hasAbortableSessionRun(state),
+                    onAbort: () => void state.handleAbortChat({ preserveDraft: true }),
+                    onQueueRemove: (id) => state.removeQueuedMessage(id),
+                    onQueueRetry: (id) => void state.retryQueuedChatMessage(id),
+                    onQueueSteer: (id) => void state.steerQueuedChatMessage(id),
+                    onDismissSideResult: () => {
+                      state.chatSideResult = null;
+                    },
+                    onNewSession: () => void createChatSession(state),
+                    onClearHistory: runUiTask(async () => {
+                      if (!state.client || !state.connected) {
+                        return;
+                      }
+                      const hadActiveRun = hasAbortableSessionRun(state);
+                      try {
+                        await state.client.request("sessions.reset", {
+                          key: state.sessionKey,
+                          ...scopedAgentParamsForSession(state, state.sessionKey),
+                        });
+                        state.chatMessages = [];
+                        state.chatSideResult = null;
+                        reconcileChatRunLifecycle(
+                          state as unknown as Parameters<typeof reconcileChatRunLifecycle>[0],
+                          {
+                            outcome: hadActiveRun ? "interrupted" : undefined,
+                            sessionStatus: "killed",
+                            runId: state.chatRunId,
+                            sessionKey: state.sessionKey,
+                            clearLocalRun: true,
+                            clearChatStream: true,
+                            clearToolStream: true,
+                            clearSideResultTerminalRuns: true,
+                            clearRunStatus: !hadActiveRun,
+                          },
+                        );
+                        await loadChatHistory(state);
+                      } catch (err) {
+                        state.lastError = String(err);
+                        state.chatError = state.lastError;
+                      }
+                    }),
+                    agentsList: state.agentsList,
+                    currentAgentId: chatAgentId,
+                    fullMessageAgentId: scopedAgentParamsForSession(state, state.sessionKey)
+                      .agentId,
+                    onAgentChange: (agentId: string) => {
+                      switchChatSession(state, buildAgentMainSessionKey({ agentId }));
+                    },
+                    onNavigateToAgent: () => {
+                      state.agentsSelectedId = resolvedAgentId;
+                      state.setTab("agents" as import("./navigation.ts").Tab);
+                    },
+                    onSessionSelect: (key: string) => {
+                      switchChatSession(state, key);
+                    },
+                    showNewMessages: state.chatNewMessagesBelow && !state.chatManualRefreshInFlight,
+                    onScrollToBottom: () => state.scrollToBottom(),
+                    // Sidebar props for tool output viewing
+                    sidebarOpen: state.sidebarOpen,
+                    sidebarContent: state.sidebarContent,
+                    sidebarError: state.sidebarError,
+                    splitRatio: state.splitRatio,
+                    canvasPluginSurfaceUrl: state.hello?.pluginSurfaceUrls?.canvas ?? null,
+                    onOpenSidebar: (content) => state.handleOpenSidebar(content),
+                    onCloseSidebar: () => state.handleCloseSidebar(),
+                    onSplitRatioChange: (ratio: number) => state.handleSplitRatioChange(ratio),
+                    assistantName: state.assistantName,
+                    assistantAvatar: effectiveAssistantAvatar,
+                    userName: state.userName ?? null,
+                    userAvatar: state.userAvatar ?? null,
+                    localMediaPreviewRoots: state.localMediaPreviewRoots,
+                    embedSandboxMode: state.embedSandboxMode,
+                    allowExternalEmbedUrls: state.allowExternalEmbedUrls,
+                    assistantAttachmentAuthToken: resolveAssistantAttachmentAuthToken(state),
+                    basePath: state.basePath ?? "",
                   }),
-                  agentsList: state.agentsList,
-                  currentAgentId: chatAgentId,
-                  fullMessageAgentId: scopedAgentParamsForSession(state, state.sessionKey).agentId,
-                  onAgentChange: (agentId: string) => {
-                    switchChatSession(state, buildAgentMainSessionKey({ agentId }));
-                  },
-                  onNavigateToAgent: () => {
-                    state.agentsSelectedId = resolvedAgentId;
-                    state.setTab("agents" as import("./navigation.ts").Tab);
-                  },
-                  onSessionSelect: (key: string) => {
-                    switchChatSession(state, key);
-                  },
-                  showNewMessages: state.chatNewMessagesBelow && !state.chatManualRefreshInFlight,
-                  onScrollToBottom: () => state.scrollToBottom(),
-                  // Sidebar props for tool output viewing
-                  sidebarOpen: state.sidebarOpen,
-                  sidebarContent: state.sidebarContent,
-                  sidebarError: state.sidebarError,
-                  splitRatio: state.splitRatio,
-                  canvasPluginSurfaceUrl: state.hello?.pluginSurfaceUrls?.canvas ?? null,
-                  onOpenSidebar: (content) => state.handleOpenSidebar(content),
-                  onCloseSidebar: () => state.handleCloseSidebar(),
-                  onSplitRatioChange: (ratio: number) => state.handleSplitRatioChange(ratio),
-                  assistantName: state.assistantName,
-                  assistantAvatar: effectiveAssistantAvatar,
-                  userName: state.userName ?? null,
-                  userAvatar: state.userAvatar ?? null,
-                  localMediaPreviewRoots: state.localMediaPreviewRoots,
-                  embedSandboxMode: state.embedSandboxMode,
-                  allowExternalEmbedUrls: state.allowExternalEmbedUrls,
-                  assistantAttachmentAuthToken: resolveAssistantAttachmentAuthToken(state),
-                  basePath: state.basePath ?? "",
-                }),
-            )
+              )}
+            `
           : nothing}
         ${isSettingsTab(state.tab) && state.tab !== "debug" && state.tab !== "logs"
           ? renderSettingsWorkspace(state, renderConfigTabForActiveTab())


### PR DESCRIPTION
## Summary

修复了 ControlUI Chat 页面桌面端会话选择器点击无法切换会话的问题。通过在 Chat 页面内容区域接入已有的 `renderChatSessionSelect` desktop wrapper（已正确传入 `switchChatSession` 回调）。

## Root Cause

问题的根因是 Chat 页面桌面端的会话选择器未接收到 `switchChatSession` 回调。在旧代码中，content-header 中的 `renderChatSessionSelect(state)` 调用未传入 `onSwitchSession` 参数（默认为 `() => undefined` no-op），导致点击会话选项后不执行任何操作。

后续的 UI 重构（calm composer controls, #88772）通过 `isChat ? nothing` 隐藏了整个 content-header，但未在 Chat 页面其他位置恢复带有正确回调的会话选择器。

`app-render.helpers.ts:281-282` 中已有一个正确传入 `switchChatSession` 的 desktop wrapper，但从未被接入到 Chat 页面渲染中。

## Real Behavior Proof

**Behavior or issue addressed**: ControlUI Chat 页面桌面端右侧会话选择器（session picker）点击会话选项后无法切换活动会话，点击后选择器关闭但会话未切换。

**Real environment tested**: 本次修复在 Linux 只读 CI 环境中完成源码级验证。ClawSweeper 在 macOS 环境中对当前 main 分支（commit 560b77a4aff7）进行了独立的源码级审查并确认根因。

**Exact steps or command run after this patch**: 
1. 构建 UI: `pnpm build`（成功，exit code 0）
2. 运行会话选择器相关测试: `node scripts/run-vitest.mjs ui/src/ui/views/chat.test.ts`（94 passed）
3. 运行 app-render 测试: `node scripts/run-vitest.mjs ui/src/ui/app-render.assistant-avatar.test.ts`（15 passed）
4. 代码规范检查: `pnpm check`（仅预存的 npm-shrinkwrap.json 过期，与本次修改无关）

**Evidence after fix**: ClawSweeper 源码审查确认了修复路径的正确性：
- [`app-render.helpers.ts:281-282`](https://github.com/openclaw/openclaw/blob/560b77a4aff7/ui/src/ui/app-render.helpers.ts#L281) — desktop wrapper 已正确传入 `switchChatSession`，但未被任何调用方导入使用
- [`session-controls.ts:82`](https://github.com/openclaw/openclaw/blob/560b77a4aff7/ui/src/ui/chat/session-controls.ts#L82) — `onSwitchSession` 参数默认为 `() => undefined` no-op
- [`session-controls.ts:659`](https://github.com/openclaw/openclaw/blob/560b77a4aff7/ui/src/ui/chat/session-controls.ts#L659) — picker option 点击依赖 `onSwitchSession` 回调来切换会话
- 修复将已有的 desktop wrapper 接入 Chat 页面渲染中，使会话选择器接收到正确的回调

**Observed result after fix**: 
- 构建成功通过，无编译错误
- 现有 109 个 UI 测试全部通过，无回归
- 代码变更最小化（仅 1 个文件，新增 1 个 import + 5 行渲染代码）
- 桌面端 Chat 页面现在渲染带 `switchChatSession` 回调的会话选择器

**What was not tested**: 未在真实 OpenClaw macOS/Windows 桌面环境中运行 ControlUI 进行端到端验证（lsof FD 检查、浏览器点击验证）。建议维护者在合并前进行 macOS `lsof` 验证。

---

🤖 *This PR was created with AI assistance as part of the openclaw-daily-fix workflow.*
