### PR TITLE
fix(voice-call): track Twilio streams after connect

### DIFF
--- a/extensions/voice-call/src/providers/twilio.test.ts
+++ b/extensions/voice-call/src/providers/twilio.test.ts
@@ -245,6 +245,8 @@ describe("TwilioProvider", () => {
     const secondInbound = createContext("CallStatus=ringing&Direction=inbound&CallSid=CA222");
 
     const firstResult = provider.parseWebhookEvent(firstInbound);
+    // Simulate the stream actually connecting (the bug: without this, no activeStreamCalls entry exists)
+    provider.registerCallStream("CA111", "MZ111");
     const secondResult = provider.parseWebhookEvent(secondInbound);
 
     expectStreamingTwiml(requireResponseBody(firstResult.providerResponseBody));
@@ -257,6 +259,7 @@ describe("TwilioProvider", () => {
     const secondInbound = createContext("CallStatus=ringing&Direction=inbound&CallSid=CA322");
 
     provider.parseWebhookEvent(firstInbound);
+    provider.registerCallStream("CA311", "MZ311");
     provider.unregisterCallStream("CA311");
     const secondResult = provider.parseWebhookEvent(secondInbound);
 
@@ -274,6 +277,7 @@ describe("TwilioProvider", () => {
     const nextInbound = createContext("CallStatus=ringing&Direction=inbound&CallSid=CA422");
 
     provider.parseWebhookEvent(firstInbound);
+    provider.registerCallStream("CA411", "MZ411");
     provider.parseWebhookEvent(completed);
     const nextResult = provider.parseWebhookEvent(nextInbound);
 
@@ -291,6 +295,7 @@ describe("TwilioProvider", () => {
     const nextInbound = createContext("CallStatus=ringing&Direction=inbound&CallSid=CA522");
 
     provider.parseWebhookEvent(firstInbound);
+    provider.registerCallStream("CA511", "MZ511");
     provider.parseWebhookEvent(canceled);
     const nextResult = provider.parseWebhookEvent(nextInbound);
 
@@ -305,11 +310,29 @@ describe("TwilioProvider", () => {
     const secondInbound = createContext("CallStatus=ringing&Direction=inbound&CallSid=CA622");
 
     provider.parseWebhookEvent(firstInbound);
+    provider.registerCallStream("CA611", "MZ611");
     const result = provider.parseWebhookEvent(secondInbound);
 
     expect(requireResponseBody(result.providerResponseBody)).toContain(
       'waitUrl="/voice/hold-music"',
     );
+  });
+
+  it("does not block subsequent call when first call never opens a media stream", () => {
+    const provider = createProvider();
+    const firstInbound = createContext("CallStatus=ringing&Direction=inbound&CallSid=CA711");
+    const secondInbound = createContext("CallStatus=ringing&Direction=inbound&CallSid=CA722");
+
+    // First call gets streaming TwiML but never connects a media stream
+    // (no registerCallStream ever fires for CA711)
+    provider.parseWebhookEvent(firstInbound);
+
+    // Second inbound call should NOT be queued — no active stream is registered
+    const secondResult = provider.parseWebhookEvent(secondInbound);
+
+    const secondBody = requireResponseBody(secondResult.providerResponseBody);
+    expectStreamingTwiml(secondBody);
+    expect(secondBody).not.toContain("hold-queue");
   });
 
   it("uses a stable fallback dedupeKey for identical request payloads", () => {

--- a/extensions/voice-call/src/providers/twilio.ts
+++ b/extensions/voice-call/src/providers/twilio.ts
@@ -170,6 +170,7 @@ export class TwilioProvider implements VoiceCallProvider {
 
   registerCallStream(callSid: string, streamSid: string): void {
     this.callStreamMap.set(callSid, streamSid);
+    this.activeStreamCalls.add(callSid);
   }
 
   hasRegisteredStream(callSid: string): boolean {
@@ -433,10 +434,6 @@ export class TwilioProvider implements VoiceCallProvider {
     if (decision.consumeStoredTwimlCallId) {
       this.deleteStoredTwiml(decision.consumeStoredTwimlCallId);
     }
-    if (decision.activateStreamCallSid) {
-      this.activeStreamCalls.add(decision.activateStreamCallSid);
-    }
-
     switch (decision.kind) {
       case "stored":
         return storedTwiml ?? TwilioProvider.EMPTY_TWIML;


### PR DESCRIPTION
Fixes #81122.

## What changed

- Track a Twilio call as active only when the media stream actually connects via `registerCallStream`.
- Stop marking a call active when TwiML is merely generated.
- Update existing queue/cleanup tests to explicitly register connected streams.
- Add regression coverage for the case where an inbound call receives stream TwiML but never opens a media stream.

## Real behavior proof

Behavior addressed: Twilio inbound queueing no longer treats generated stream TwiML as an active media stream. If the first inbound call receives streaming TwiML but never opens a WebSocket media stream, a later inbound call receives streaming TwiML instead of being sent to `hold-queue`.

Real environment tested: macOS arm64 local OpenClaw checkout. Base proof used clean `origin/main` at `1a3ce7c2` with only the new regression-test diff applied in `/private/tmp/openclaw-81122-before-9071`. Fix proof used branch `fastino-81122-twilio-hold-music` at `22575a9f`. Package manager was pnpm v11.2.2.

Exact steps or command run after the patch: Ran the Twilio provider command on the patched branch: `pnpm test extensions/voice-call/src/providers/twilio.test.ts --reporter verbose`. Also ran `git diff --check`, `pnpm exec oxfmt --check extensions/voice-call/src/providers/twilio.ts extensions/voice-call/src/providers/twilio.test.ts`, and `pnpm exec oxlint extensions/voice-call/src/providers/twilio.ts extensions/voice-call/src/providers/twilio.test.ts --report-unused-disable-directives-severity error`. For before evidence, I created a clean `origin/main` worktree and applied only the new regression-test diff, then ran the same Twilio provider command.

Evidence after fix: Copied terminal output and TwiML payload from the local OpenClaw provider path. Before fix, the second inbound call produced hold queue TwiML instead of a stream URL:

```text
$ pnpm test extensions/voice-call/src/providers/twilio.test.ts --reporter verbose
FAIL |extension-voice-call| extensions/voice-call/src/providers/twilio.test.ts > TwilioProvider > does not block subsequent call when first call never opens a media stream
AssertionError: expected ... to contain wss://example.ngrok.app/voice/stream

Received:
<Response>
  <Say voice="alice">Please hold while we connect you.</Say>
  <Enqueue waitUrl="/voice/hold-music">hold-queue</Enqueue>
</Response>

Test Files 1 failed (1)
Tests 1 failed | 24 passed (25)
```

After fix, the same provider path returned streaming TwiML for the second inbound call; the regression checks for `wss://example.ngrok.app/voice/stream`, `<Connect>`, and no `hold-queue` payload:

```text
$ pnpm test extensions/voice-call/src/providers/twilio.test.ts --reporter verbose
✓ |extension-voice-call| extensions/voice-call/src/providers/twilio.test.ts > TwilioProvider > does not block subsequent call when first call never opens a media stream 0ms
Test Files 1 passed (1)
Tests 25 passed (25)
[test] passed 1 Vitest shard in 7.98s

$ git diff --check
# passed with no output

$ pnpm exec oxfmt --check extensions/voice-call/src/providers/twilio.ts extensions/voice-call/src/providers/twilio.test.ts
All matched files use the correct format.

$ pnpm exec oxlint extensions/voice-call/src/providers/twilio.ts extensions/voice-call/src/providers/twilio.test.ts --report-unused-disable-directives-severity error
# passed with no output
```

Observed result after fix: Before the fix, the second inbound call was sent to `hold-queue` after the first call generated streaming TwiML but never registered a media stream. After the fix, the second inbound call receives streaming TwiML because no call is considered active until `registerCallStream` runs for a real media stream.

What was not tested: A live Twilio account was not exercised. The exercised behavior is the local Twilio provider TwiML decision path and stream-registration state transition that caused #81122.

## Platforms tested

- macOS arm64 local checkout
