### PR TITLE
fix(google): preserve Vertex ADC catalog auth

### DIFF
--- a/extensions/google/index.test.ts
+++ b/extensions/google/index.test.ts
@@ -17,6 +17,7 @@ import type { RealtimeVoiceProviderPlugin } from "openclaw/plugin-sdk/realtime-v
 import { describe, expect, it, vi } from "vitest";
 import { registerGoogleGeminiCliProvider } from "./gemini-cli-provider.js";
 import googlePlugin from "./index.js";
+import googleProviderDiscovery from "./provider-discovery.js";
 import { registerGoogleProvider } from "./provider-registration.js";
 
 const googleProviderPlugin = {
@@ -203,6 +204,16 @@ describe("google provider plugin hooks", () => {
           GOOGLE_APPLICATION_CREDENTIALS: credentialsPath,
           GOOGLE_CLOUD_PROJECT: "",
           GCLOUD_PROJECT: "vertex-project",
+          GOOGLE_CLOUD_LOCATION: "global",
+        },
+      }),
+    ).toBe("gcp-vertex-credentials");
+    expect(
+      googleProviderDiscovery.resolveConfigApiKey?.({
+        provider: "google-vertex",
+        env: {
+          GOOGLE_APPLICATION_CREDENTIALS: credentialsPath,
+          GOOGLE_CLOUD_PROJECT: "vertex-project",
           GOOGLE_CLOUD_LOCATION: "global",
         },
       }),

--- a/extensions/google/index.test.ts
+++ b/extensions/google/index.test.ts
@@ -1,4 +1,7 @@
 // Google tests cover index plugin behavior.
+import { mkdtemp, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import type { Context, Model } from "openclaw/plugin-sdk/llm";
 import type {
   ProviderReplaySessionEntry,
@@ -161,6 +164,49 @@ describe("google provider plugin hooks", () => {
         modelId: "gemini-3.1-pro-preview",
       } as never),
     ).toBe("native");
+  });
+
+  it("resolves Google Vertex ADC auth evidence to the config marker", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-google-vertex-config-key-"));
+    const credentialsPath = path.join(tempDir, "application_default_credentials.json");
+    await writeFile(
+      credentialsPath,
+      JSON.stringify({
+        type: "authorized_user",
+        client_id: "client-id",
+        client_secret: "client-secret",
+        refresh_token: "refresh-token",
+      }),
+      "utf8",
+    );
+    const { providers } = await registerProviderPlugin({
+      plugin: googleProviderPlugin,
+      id: "google",
+      name: "Google Provider",
+    });
+    const provider = requireRegisteredProvider(providers, "google-vertex");
+
+    expect(
+      provider.resolveConfigApiKey?.({
+        provider: "google-vertex",
+        env: {
+          GOOGLE_APPLICATION_CREDENTIALS: credentialsPath,
+          GOOGLE_CLOUD_PROJECT: "vertex-project",
+          GOOGLE_CLOUD_LOCATION: "global",
+        },
+      }),
+    ).toBe("gcp-vertex-credentials");
+    expect(
+      provider.resolveConfigApiKey?.({
+        provider: "google-vertex",
+        env: {
+          GOOGLE_APPLICATION_CREDENTIALS: credentialsPath,
+          GOOGLE_CLOUD_PROJECT: "",
+          GCLOUD_PROJECT: "vertex-project",
+          GOOGLE_CLOUD_LOCATION: "global",
+        },
+      }),
+    ).toBe("gcp-vertex-credentials");
   });
 
   it("owns Gemini tool schema normalization for direct and CLI providers", async () => {

--- a/extensions/google/provider-discovery.ts
+++ b/extensions/google/provider-discovery.ts
@@ -4,12 +4,15 @@ import {
   buildGoogleStaticCatalogProvider,
   buildGoogleVertexStaticCatalogProvider,
 } from "./provider-catalog.js";
+import { resolveGoogleVertexConfigApiKey } from "./vertex-adc.js";
 
 const googleProviderDiscovery: ProviderPlugin = {
   id: "google",
   label: "Google AI Studio",
   docsPath: "/providers/models",
   auth: [],
+  resolveConfigApiKey: ({ provider, env }) =>
+    provider === "google-vertex" ? resolveGoogleVertexConfigApiKey(env) : undefined,
   staticCatalog: {
     order: "simple",
     run: async () => ({

--- a/extensions/google/provider-registration.ts
+++ b/extensions/google/provider-registration.ts
@@ -22,6 +22,7 @@ import {
   createGoogleGenerativeAiTransportStreamFn,
   createGoogleVertexTransportStreamFn,
 } from "./transport-stream.js";
+import { resolveGoogleVertexConfigApiKey } from "./vertex-adc.js";
 
 function resolveGoogleReasoningOutputMode(
   ctx: ProviderReasoningOutputModeContext,
@@ -68,6 +69,8 @@ export function buildGoogleProvider(): ProviderPlugin {
       resolveGoogleGenerativeAiTransport({ provider, api, baseUrl }),
     normalizeConfig: ({ provider, providerConfig }) =>
       normalizeGoogleProviderConfig(provider, providerConfig),
+    resolveConfigApiKey: ({ provider, env }) =>
+      provider === "google-vertex" ? resolveGoogleVertexConfigApiKey(env) : undefined,
     staticCatalog: {
       order: "simple",
       run: async () => ({

--- a/extensions/google/vertex-adc.ts
+++ b/extensions/google/vertex-adc.ts
@@ -93,6 +93,17 @@ export function isGoogleVertexCredentialsMarker(
   return apiKey === undefined || apiKey === GCP_VERTEX_CREDENTIALS_MARKER;
 }
 
+function hasGoogleVertexProjectEnv(env: NodeJS.ProcessEnv): boolean {
+  return Boolean(
+    normalizeOptionalString(env.GOOGLE_CLOUD_PROJECT) ||
+    normalizeOptionalString(env.GCLOUD_PROJECT),
+  );
+}
+
+function hasGoogleVertexLocationEnv(env: NodeJS.ProcessEnv): boolean {
+  return Boolean(normalizeOptionalString(env.GOOGLE_CLOUD_LOCATION));
+}
+
 function resolveGoogleApplicationCredentialsPath(
   env: NodeJS.ProcessEnv = process.env,
 ): string | undefined {
@@ -181,6 +192,16 @@ export function hasGoogleVertexAuthorizedUserAdcSync(
     }
   }
   return false;
+}
+
+export function resolveGoogleVertexConfigApiKey(
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  return hasGoogleVertexProjectEnv(env) &&
+    hasGoogleVertexLocationEnv(env) &&
+    hasGoogleVertexAuthorizedUserAdcSync(env)
+    ? GCP_VERTEX_CREDENTIALS_MARKER
+    : undefined;
 }
 
 async function refreshGoogleVertexAuthorizedUserAccessToken(params: {

--- a/src/agents/models-config.applies-config-env-vars.test.ts
+++ b/src/agents/models-config.applies-config-env-vars.test.ts
@@ -495,6 +495,60 @@ describe("models-config", () => {
     }
   });
 
+  it("keeps google-vertex static catalog rows when ADC auth evidence supplies the marker", async () => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-google-vertex-adc-models-"));
+    const credentialsPath = path.join(agentDir, "application_default_credentials.json");
+    await fs.writeFile(credentialsPath, JSON.stringify({ type: "authorized_user" }), "utf8");
+    try {
+      const plan = await planOpenClawModelsJsonWithDeps(
+        {
+          cfg: {
+            agents: {
+              defaults: {
+                models: {
+                  "google-vertex/gemini-2.5-pro": {},
+                },
+                model: { primary: "google-vertex/gemini-2.5-pro" },
+              },
+            },
+            models: { providers: {} },
+          },
+          agentDir,
+          env: {
+            GOOGLE_APPLICATION_CREDENTIALS: credentialsPath,
+            GOOGLE_CLOUD_PROJECT: "vertex-project",
+            GOOGLE_CLOUD_LOCATION: "global",
+          } as NodeJS.ProcessEnv,
+          existingRaw: "",
+          existingParsed: null,
+        },
+        {
+          resolveImplicitProviders: async () => ({
+            "google-vertex": createImplicitGoogleVertexProvider(),
+          }),
+        },
+      );
+
+      expect(plan.action).toBe("write");
+      if (plan.action !== "write") {
+        throw new Error("Expected models.json write plan");
+      }
+      const parsed = JSON.parse(plan.contents) as {
+        providers?: Record<
+          string,
+          { apiKey?: string; api?: string; models?: Array<{ id?: string }> }
+        >;
+      };
+      expect(parsed.providers?.["google-vertex"]?.api).toBe("google-vertex");
+      expect(parsed.providers?.["google-vertex"]?.apiKey).toBe("gcp-vertex-credentials");
+      expect(parsed.providers?.["google-vertex"]?.models?.map((model) => model.id)).toEqual([
+        "gemini-2.5-pro",
+      ]);
+    } finally {
+      await fs.rm(agentDir, { recursive: true, force: true });
+    }
+  });
+
   it("uses config env.vars entries for implicit provider discovery without mutating process.env", async () => {
     await withTempEnv(["OPENROUTER_API_KEY", TEST_ENV_VAR], async () => {
       unsetEnv(["OPENROUTER_API_KEY", TEST_ENV_VAR]);

--- a/src/agents/models-config.providers.implicit.discovery-scope.test.ts
+++ b/src/agents/models-config.providers.implicit.discovery-scope.test.ts
@@ -1,4 +1,7 @@
 // Exercises startup provider discovery scoping without loading real plugin manifests.
+import { mkdtemp, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { PluginMetadataSnapshotOwnerMaps } from "../plugins/plugin-metadata-snapshot.js";
 import type { ProviderPlugin } from "../plugins/types.js";
@@ -203,6 +206,38 @@ describe("resolveImplicitProviders startup discovery scope", () => {
 
     expect(mocks.runProviderStaticCatalog).toHaveBeenCalledTimes(1);
     expect(mocks.runProviderCatalog).not.toHaveBeenCalled();
+  });
+
+  it("fills missing static catalog apiKey from Google Vertex ADC auth evidence", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-google-vertex-adc-"));
+    const credentialsPath = path.join(tempDir, "application_default_credentials.json");
+    await writeFile(credentialsPath, JSON.stringify({ type: "authorized_user" }));
+    mocks.resolveRuntimePluginDiscoveryProviders.mockResolvedValue([
+      createStaticOnlyProvider("google"),
+    ]);
+    mocks.runProviderStaticCatalog.mockResolvedValue({
+      providers: {
+        "google-vertex": {
+          baseUrl: "https://aiplatform.googleapis.com",
+          api: "google-vertex" as const,
+          models: [createTextModel("gemini-3.1-pro-preview", "Gemini 3.1 Pro Preview")],
+        },
+      },
+    });
+
+    const providers = await resolveImplicitProviders({
+      agentDir: "/tmp/openclaw-agent",
+      config: {},
+      env: {
+        GOOGLE_APPLICATION_CREDENTIALS: credentialsPath,
+        GOOGLE_CLOUD_PROJECT: "vertex-project",
+        GOOGLE_CLOUD_LOCATION: "global",
+      } as NodeJS.ProcessEnv,
+      explicitProviders: {},
+      providerDiscoveryEntriesOnly: true,
+    });
+
+    expect(providers?.["google-vertex"]?.apiKey).toBe("gcp-vertex-credentials");
   });
 
   it("falls back to static provider catalogs when runtime discovery has no rows", async () => {

--- a/src/agents/models-config.providers.implicit.ts
+++ b/src/agents/models-config.providers.implicit.ts
@@ -38,6 +38,7 @@ import type {
 import {
   createProviderApiKeyResolver,
   createProviderAuthResolver,
+  resolveMissingProviderApiKey,
 } from "./models-config.providers.secrets.js";
 
 const log = createSubsystemLogger("agents/model-providers");
@@ -293,6 +294,19 @@ function mergeImplicitProviderConfig(params: {
   };
 }
 
+function resolveImplicitProviderAuthMarker(params: {
+  ctx: ImplicitProviderContext;
+  providerId: string;
+  provider: ProviderConfig;
+}): ProviderConfig {
+  return resolveMissingProviderApiKey({
+    providerKey: params.providerId,
+    provider: params.provider,
+    env: params.ctx.env,
+    profileApiKey: undefined,
+  });
+}
+
 function resolveConfiguredImplicitProvider(params: {
   configuredProviders?: Record<string, ProviderConfig> | null;
   providerIds: readonly string[];
@@ -430,7 +444,7 @@ async function resolvePluginImplicitProviders(
       result,
     });
     for (const [providerId, implicitProvider] of Object.entries(normalizedResult)) {
-      discovered[providerId] = mergeImplicitProviderConfig({
+      const mergedProvider = mergeImplicitProviderConfig({
         providerId,
         existing:
           discovered[providerId] ??
@@ -448,6 +462,11 @@ async function resolvePluginImplicitProviders(
           config: ctx.config,
           providerId,
         }),
+      });
+      discovered[providerId] = resolveImplicitProviderAuthMarker({
+        ctx,
+        providerId,
+        provider: mergedProvider,
       });
     }
   }

--- a/src/agents/models-config.providers.secret-helpers.ts
+++ b/src/agents/models-config.providers.secret-helpers.ts
@@ -98,6 +98,18 @@ export function resolveAwsSdkApiKeyVarName(
   return resolveAwsSdkEnvVarName(env);
 }
 
+function resolveEnvAuthEvidenceApiKeyMarker(
+  provider: string,
+  env: NodeJS.ProcessEnv,
+): string | undefined {
+  const resolved = resolveEnvApiKey(provider, env);
+  const apiKey = resolved?.apiKey?.trim();
+  if (!apiKey || !isNonSecretApiKeyMarker(apiKey, { includeEnvVarName: false })) {
+    return undefined;
+  }
+  return apiKey;
+}
+
 /** Rewrites secret-backed provider headers to stable marker values. */
 export function normalizeHeaderValues(params: {
   headers: ProviderConfig["headers"] | undefined;
@@ -334,11 +346,14 @@ export function resolveMissingProviderApiKey(params: {
   }
 
   const fromEnv = resolveEnvApiKeyVarName(params.providerKey, params.env);
-  const apiKey = fromEnv ?? params.profileApiKey?.apiKey;
+  const fromAuthEvidence = fromEnv
+    ? undefined
+    : resolveEnvAuthEvidenceApiKeyMarker(params.providerKey, params.env);
+  const apiKey = fromEnv ?? fromAuthEvidence ?? params.profileApiKey?.apiKey;
   if (!apiKey?.trim()) {
     return params.provider;
   }
-  if (params.profileApiKey && params.profileApiKey.source !== "plaintext") {
+  if (fromAuthEvidence || (params.profileApiKey && params.profileApiKey.source !== "plaintext")) {
     params.secretRefManagedProviders?.add(params.providerKey);
   }
   return {


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- Fixes generated `models.json` and plugin catalog generation dropping static `google-vertex` catalog providers when auth is available through ADC evidence instead of an API-key env var or auth profile.
- Reuses the existing non-secret `gcp-vertex-credentials` marker instead of writing credential material or adding new config.
- Registers the Google provider-owned config marker hook so the built/plugin discovery path sees the same ADC marker as the core planner path.

Why does this matter now?

- #90506 reports a regression from 2026.5.28/2026.6.1 where `google-vertex/*` models appear in model listing/startup but fail at runtime with `model_not_found` for ADC-backed users.

What is the intended outcome?

- ADC-backed Google Vertex catalog rows remain writable and embedded runtime model resolution can find `google-vertex/*` models while the Google transport continues resolving bearer auth from ADC at request time.

What is intentionally out of scope?

- No new provider config, env var, doctor migration, or Google transport request behavior change.
- No live Google Cloud credential changes.

What does success look like?

- With `GOOGLE_APPLICATION_CREDENTIALS`, either `GOOGLE_CLOUD_PROJECT` or `GCLOUD_PROJECT`, and `GOOGLE_CLOUD_LOCATION` present, generated catalog data keeps the `google-vertex` provider with `apiKey: "gcp-vertex-credentials"` and its static model rows.

What should reviewers focus on?

- Whether the core config writer accepts only known non-secret auth-evidence markers.
- Whether the Google plugin, not core, owns the Google Vertex ADC marker policy for provider discovery.

## Linked context

Which issue does this close?

Closes #90506

Which issues, PRs, or discussions are related?

Related #65715, #56253

Was this requested by a maintainer or owner?

- Requested through maintainer-side issue repair workflow.

## Real behavior proof (required for external PRs)

Behavior addressed: Google Vertex ADC-backed static catalog providers were filtered from generated model config, making `google-vertex/*` fail as `model_not_found` at runtime despite valid ADC evidence.

Real environment tested: Local OpenClaw source checkout on macOS with a temporary ADC `application_default_credentials.json` file, process env `GOOGLE_APPLICATION_CREDENTIALS`, `GOOGLE_CLOUD_PROJECT`, and `GOOGLE_CLOUD_LOCATION`, using the real `ensureOpenClawModelsJson` startup catalog-generation entry point.

Exact steps or command run after this patch: `node --import tsx` source-checkout probe that created a temporary ADC credentials file, set Google Vertex ADC process env, called `ensureOpenClawModelsJson({ models: { providers: {} } }, agentDir, { workspaceDir, providerDiscoveryProviderIds: ["google-vertex"], providerDiscoveryEntriesOnly: true, providerDiscoveryTimeoutMs: 60000 })`, and read the generated `plugins/google/catalog.json` sidecar.

Evidence after fix: Console output from the generated catalog probe:

```json
{
  "wrote": true,
  "pluginFiles": [
    "catalog.json"
  ],
  "rootProviderIds": [],
  "generatedBy": "openclaw-plugin-model-catalog-v1",
  "googleCatalogProviderIds": [
    "google-vertex"
  ],
  "googleVertexApiKey": "gcp-vertex-credentials",
  "googleVertexModelCount": 6,
  "sampleGoogleVertexModels": [
    "gemini-2.5-pro",
    "gemini-2.5-flash",
    "gemini-2.5-flash-lite"
  ]
}
```

Observed result after fix: The same startup entries-only generation path now writes the Google plugin catalog sidecar, keeps the `google-vertex` provider row, preserves the existing non-secret `gcp-vertex-credentials` marker, and keeps static model rows without persisting credential material.

What was not tested: A live Vertex AI network request with real Google Cloud ADC credentials. No real Google Cloud credentials were available, and the proof intentionally uses only local ADC evidence and generated config output.

Before evidence: The new models-config regression failed before the implementation because the `google-vertex` provider was filtered out of generated models config. A local CLI attempt with temp ADC env reproduced the reported `model_not_found` behavior before the plugin-owned config marker hook and implicit static-catalog auth fill were added.

## Tests and validation

Which commands did you run?

- `node scripts/run-vitest.mjs src/agents/models-config.applies-config-env-vars.test.ts` before implementation, expected failure observed in the new regression.
- `node scripts/run-vitest.mjs src/agents/models-config.applies-config-env-vars.test.ts src/agents/embedded-agent-runner/model.test.ts extensions/google/transport-stream.test.ts`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.src.json --incremental --tsBuildInfoFile /tmp/openclaw-google-vertex-adc-test-src.tsbuildinfo`
- `node scripts/run-vitest.mjs extensions/google/index.test.ts`
- `node scripts/run-vitest.mjs src/agents/models-config.applies-config-env-vars.test.ts src/agents/embedded-agent-runner/model.test.ts extensions/google/transport-stream.test.ts extensions/google/index.test.ts`
- `node --import tsx` source-checkout Google provider ADC marker probe
- `node --import tsx` source-checkout `ensureOpenClawModelsJson` generated catalog probe
- `node scripts/run-vitest.mjs src/agents/models-config.providers.implicit.discovery-scope.test.ts`
- `node scripts/run-vitest.mjs extensions/google/index.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

What regression coverage was added or updated?

- Added a models.json planning regression that creates a temp ADC credentials file, provides Google Cloud project/location env, omits auth profiles, and asserts the generated `google-vertex` provider retains static model rows with `gcp-vertex-credentials`.
- Added a Google provider plugin hook regression that asserts ADC evidence resolves to the same non-secret config marker for both `GOOGLE_CLOUD_PROJECT` and `GCLOUD_PROJECT` project env paths.
- Added an entries-only static catalog regression that asserts generated implicit `google-vertex` rows are filled from ADC auth evidence before writable filtering.

What failed before this fix, if known?

- The new models-config regression failed before the core implementation because the `google-vertex` provider was filtered out of generated models config.
- A local CLI attempt with temp ADC env reproduced `model_not_found` before the plugin-owned config marker hook was added.

If no test was added, why not?

- N/A; focused regression coverage was added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. ADC-backed Google Vertex users should stop seeing runtime `model_not_found` caused by generated catalog omission.

Did config, environment, or migration behavior change? (`Yes/No`)

Yes, narrowly. Existing ADC env/file evidence can now populate the existing non-secret auth marker in generated provider config; no new config or env surface was added.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

Yes, narrowly in auth config generation. The code only persists known non-secret markers and still avoids writing plaintext env values.

What is the highest-risk area?

- Accidentally treating plaintext env credentials as writable markers.

How is that risk mitigated?

- The implementation accepts `resolveEnvApiKey` results only when `isNonSecretApiKeyMarker(..., { includeEnvVarName: false })` recognizes the value, while env API keys continue to be represented by env var names via the existing `resolveEnvApiKeyVarName` path.
- The Google plugin hook only returns the existing `gcp-vertex-credentials` marker when ADC file, project, and location evidence are all present.

## Current review state

What is the next action?

- Maintainer review and CI.

What is still waiting on author, maintainer, CI, or external proof?

- CI and optional maintainer live Vertex ADC verification if credentials are available.

Which bot or reviewer comments were addressed?

- Addresses the ClawSweeper source-level review on #90506 that identified missing propagation of Google Vertex ADC auth evidence into generated provider config.


