### PR TITLE
feat(i18n): localize runtime user-facing copy

### DIFF
--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -3804,6 +3804,37 @@ describe("active-memory plugin", () => {
     expect(prompt).not.toContain("User prefers aisle seats and extra buffer on connections.");
   });
 
+  it("strips localized incomplete-turn boilerplate from retrieval queries", async () => {
+    api.pluginConfig = {
+      agents: ["main"],
+      queryMode: "recent",
+    };
+    plugin.register(api as unknown as OpenClawPluginApi);
+
+    await hooks.before_prompt_build(
+      {
+        prompt: [
+          "⚠️ Agent 未能生成回复。请重试。",
+          "⚠️ Agent 未能產生回覆。請重試。",
+          "what wings should i order?",
+        ].join("\n"),
+        messages: [],
+      },
+      {
+        agentId: "main",
+        trigger: "user",
+        sessionKey: "agent:main:main",
+        messageProvider: "webchat",
+      },
+    );
+
+    const prompt = lastEmbeddedPrompt();
+    const searchQuerySection = prompt.split("\n\nConversation context:")[0] ?? prompt;
+    expect(prompt).toContain("Bounded memory search query:\nwhat wings should i order?");
+    expect(searchQuerySection).not.toContain("未能生成回复");
+    expect(searchQuerySection).not.toContain("未能產生回覆");
+  });
+
   it("does not drop ordinary user text when the active-memory tag appears inline without a matching block", async () => {
     api.pluginConfig = {
       agents: ["main"],

--- a/extensions/active-memory/index.ts
+++ b/extensions/active-memory/index.ts
@@ -131,6 +131,8 @@ const RECALLED_CONTEXT_LINE_PATTERNS = [
   /^active memory debug:/i,
   /^active memory:/i,
 ];
+const INCOMPLETE_TURN_FAILURE_LINE_RE =
+  /^⚠️?\s*(?:Agent couldn't generate a response|Agent 未能生成回复|Agent 未能產生回覆)/i;
 
 type ActiveRecallPluginConfig = {
   enabled?: boolean;
@@ -2199,7 +2201,7 @@ function normalizeSearchQueryText(text: string): string {
       if (/^(source: external|---|untrusted discord message body)$/i.test(line)) {
         return false;
       }
-      if (/^⚠️?\s*Agent couldn't generate a response/i.test(line)) {
+      if (INCOMPLETE_TURN_FAILURE_LINE_RE.test(line)) {
         return false;
       }
       if (/^Please try again\.?$/i.test(line)) {

--- a/extensions/imessage/src/monitor/reflection-guard.test.ts
+++ b/extensions/imessage/src/monitor/reflection-guard.test.ts
@@ -121,4 +121,17 @@ describe("detectReflectedContent", () => {
     expect(result.isReflection).toBe(true);
     expect(result.matchedLabels).toContain("gateway-missing-api-key");
   });
+
+  it("detects reflected localized gateway auth failure replies", () => {
+    for (const text of [
+      "⚠️ Gateway 缺少 OpenAI API Key。请使用带 OpenAI OAuth profile 的 `openai/gpt-5.5`，或为直接 OpenAI API Key 运行设置 `OPENAI_API_KEY`。",
+      "⚠️ Gateway 缺少 OpenAI API Key。請使用帶 OpenAI OAuth profile 的 `openai/gpt-5.5`，或為直接 OpenAI API Key 執行設定 `OPENAI_API_KEY`。",
+      '⚠️ 缺少 provider "openai" 的 API Key。请运行 `openclaw doctor --fix` 修复过期的 OpenAI 模型/会话路由；如果 doctor 提示，请重启 gateway 后再试。',
+      '⚠️ 缺少 provider "openai" 的 API Key。請執行 `openclaw doctor --fix` 修復過期的 OpenAI 模型/工作階段路由；如果 doctor 提示，請重新啟動 gateway 後再試。',
+    ]) {
+      const result = detectReflectedContent(text);
+      expect(result.isReflection).toBe(true);
+      expect(result.matchedLabels).toContain("gateway-missing-api-key");
+    }
+  });
 });

--- a/extensions/imessage/src/monitor/reflection-guard.ts
+++ b/extensions/imessage/src/monitor/reflection-guard.ts
@@ -9,7 +9,8 @@ const RELEVANT_MEMORIES_TAG_RE = /<\s*\/?\s*relevant[-_]memories\b[^<>]*>/i;
 // Require closing `>` to avoid false-positives on phrases like "<final answer>".
 const FINAL_TAG_RE = /<\s*\/?\s*final\b[^<>]*>/i;
 const ACP_ERROR_RE = /\bACP error\s*\(\s*ACP_[A-Z0-9_]+\s*\):/i;
-const GATEWAY_MISSING_API_KEY_RE = /\bMissing API key for\b.+\bon the gateway\b/i;
+const GATEWAY_MISSING_API_KEY_RE =
+  /\bMissing API key for\b.+\bon the gateway\b|Gateway\s+缺少.+API Key|缺少\s+provider\s+"[^"]+"\s+的\s+API Key.+gateway/i;
 
 const REFLECTION_PATTERNS: Array<{ re: RegExp; label: string }> = [
   { re: INTERNAL_SEPARATOR_RE, label: "internal-separator" },

--- a/extensions/qa-lab/src/reply-failure.test.ts
+++ b/extensions/qa-lab/src/reply-failure.test.ts
@@ -9,12 +9,25 @@ describe("extractQaFailureReplyText", () => {
     ).toBe(undefined);
   });
 
+  it("does not classify ordinary localized warning replies as failures", () => {
+    expect(extractQaFailureReplyText("⚠️ 缺少足够信息判断这个问题。")).toBe(undefined);
+  });
+
   it("classifies the generic external fallback reply as a failure", () => {
     expect(
       extractQaFailureReplyText(
         "⚠️ Something went wrong while processing your request. Please try again, or use /new to start a fresh session.",
       ),
     ).toContain("Something went wrong while processing your request.");
+  });
+
+  it("classifies localized generic external fallback replies as failures", () => {
+    for (const text of [
+      "⚠️ 处理你的请求时出了问题。请重试，或使用 /new 开始一个新会话。",
+      "⚠️ 處理你的請求時發生問題。請重試，或使用 /new 開始新工作階段。",
+    ]) {
+      expect(extractQaFailureReplyText(text)).toBe(text);
+    }
   });
 
   it("classifies explicit provider auth guidance as a failure", () => {
@@ -31,6 +44,22 @@ describe("extractQaFailureReplyText", () => {
         "⚠️ Missing API key for OpenAI on the gateway. Use `openai/gpt-5.5` with the Codex OAuth profile, or set `OPENAI_API_KEY`, then try again.",
       ),
     ).toContain("Missing API key for OpenAI on the gateway.");
+  });
+
+  it("classifies localized runtime failure guidance as failures", () => {
+    for (const text of [
+      "⚠️ Agent 在回复前失败：模型切换未能完成。请求的模型可能暂时不可用。请稍后重试。",
+      "⚠️ Agent 在回覆前失敗：模型切換未能完成。請求的模型可能暫時不可用。請稍後重試。",
+      "⚠️ Gateway 上的模型登录已过期（openai）。请使用 `openclaw models auth login --provider openai` 重新认证后再试。",
+      "⚠️ Gateway 上的模型登入失敗（openai）。請重試。如果持續發生，請使用 `openclaw models auth login --provider openai` 重新認證。",
+      "⚠️ Gateway 缺少 OpenAI API Key。请使用带 OpenAI OAuth profile 的 `openai/gpt-5.5`，或为直接 OpenAI API Key 运行设置 `OPENAI_API_KEY`。",
+      '⚠️ 缺少 provider "openai" 的 API Key。請執行 `openclaw doctor --fix` 修復過期的 OpenAI 模型/工作階段路由。',
+      "⚠️ 上下文超出限制：这次请求对当前模型来说太长了。请缩短消息，或换用更大上下文的模型。",
+      "⚠️ 上下文过大，自动压缩未能恢复本轮。请重试，使用 /compact，或使用 /new 开始一个新会话。",
+      "⚠️ 上下文過大，自動壓縮未能恢復本輪。請重試，使用 /compact，或使用 /new 開始新工作階段。",
+    ]) {
+      expect(extractQaFailureReplyText(text)).toBe(text);
+    }
   });
 
   it("classifies leaked codex harness coordination chatter as a failure", () => {

--- a/extensions/qa-lab/src/reply-failure.ts
+++ b/extensions/qa-lab/src/reply-failure.ts
@@ -9,10 +9,23 @@ const FAILURE_REPLY_PREFIXES = [
   "⚠️ message ordering conflict.",
   "⚠️ model login expired on the gateway",
   "⚠️ model login failed on the gateway",
+  "⚠️ gateway 上的模型登录已过期",
+  "⚠️ gateway 上的模型登入已過期",
+  "⚠️ gateway 上的模型登录失败",
+  "⚠️ gateway 上的模型登入失敗",
   "⚠️ agent failed before reply:",
+  "⚠️ agent 在回复前失败：",
+  "⚠️ agent 在回覆前失敗：",
   "⚠️ ✉️ message failed",
   "⚠️ no api key found for provider ",
   "⚠️ missing api key for ",
+  "⚠️ gateway 缺少",
+  "⚠️ 缺少 provider ",
+  "⚠️ 处理你的请求时出了问题。",
+  "⚠️ 處理你的請求時發生問題。",
+  "⚠️ 上下文超出限制",
+  "⚠️ 上下文过大",
+  "⚠️ 上下文過大",
 ];
 
 const VISIBLE_REPLY_LEAK_PATTERNS = [

--- a/src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts
+++ b/src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts
@@ -24,6 +24,7 @@ import {
   stripToolCallXmlTags,
 } from "../../shared/text/assistant-visible-text.js";
 import { stripFinalTags } from "../../shared/text/final-tags.js";
+import { t as runtimeT } from "../../wizard/i18n/index.js";
 import { formatExecDeniedUserMessage } from "../exec-approval-result.js";
 import { stripInternalRuntimeContext } from "../internal-runtime-context.js";
 import { stableStringify } from "../stable-stringify.js";
@@ -41,18 +42,19 @@ export function formatBillingErrorMessage(provider?: string, model?: string): st
   const providerLabel =
     providerName && modelName ? `${providerName} (${modelName})` : providerName || undefined;
   if (providerLabel) {
-    return `⚠️ ${providerLabel} returned a billing error — your API key has run out of credits or has an insufficient balance. Check your ${providerName} billing dashboard and top up or switch to a different API key.`;
+    return runtimeT("runtime.channel.apiBillingErrorForProvider", {
+      providerLabel,
+      providerName,
+    });
   }
-  return "⚠️ API provider returned a billing error — your API key has run out of credits or has an insufficient balance. Check your provider's billing dashboard and top up or switch to a different API key.";
+  return runtimeT("runtime.channel.apiBillingError");
 }
 
 export const BILLING_ERROR_USER_MESSAGE = formatBillingErrorMessage();
 
-const RATE_LIMIT_ERROR_USER_MESSAGE = "⚠️ API rate limit reached. Please try again later.";
-const MODEL_CAPACITY_ERROR_USER_MESSAGE =
-  "⚠️ Selected model is at capacity. Try a different model, or wait and retry.";
-const OVERLOADED_ERROR_USER_MESSAGE =
-  "The AI service is temporarily overloaded. Please try again in a moment.";
+const RATE_LIMIT_ERROR_USER_MESSAGE = runtimeT("runtime.channel.apiRateLimitReached");
+const MODEL_CAPACITY_ERROR_USER_MESSAGE = runtimeT("runtime.channel.modelAtCapacity");
+const OVERLOADED_ERROR_USER_MESSAGE = runtimeT("runtime.channel.aiServiceOverloaded");
 const TOOL_CALLS_OMITTED_PLACEHOLDER_LINE_RE = /^[ \t]*\[tool calls omitted\][ \t]*$/i;
 const ERROR_PREFIX_RE =
   /^(?:error|(?:[a-z][\w-]*\s+)?api\s*error|openai\s*error|anthropic\s*error|gateway\s*error|codex\s*error|request failed|failed|exception)(?:\s+\d{3})?[:\s-]+/i;

--- a/src/agents/embedded-agent-runner/result-fallback-classifier.ts
+++ b/src/agents/embedded-agent-runner/result-fallback-classifier.ts
@@ -2,6 +2,7 @@
  * Classifies embedded-agent run results for model fallback decisions.
  */
 import { isSilentReplyPayloadText } from "../../auto-reply/tokens.js";
+import { t as runtimeT } from "../../wizard/i18n/index.js";
 import { classifyFailoverReason } from "../embedded-agent-helpers/errors.js";
 import type { FailoverReason } from "../embedded-agent-helpers/types.js";
 import { isGpt5ModelId } from "../gpt5-prompt-overlay.js";
@@ -17,6 +18,14 @@ import type { EmbeddedAgentRunResult } from "./types.js";
  */
 const EMPTY_TERMINAL_REPLY_RE = /Agent couldn't generate a response/i;
 const PLAN_ONLY_TERMINAL_REPLY_RE = /Agent stopped after repeated plan-only turns/i;
+
+function isEmptyTerminalReplyText(text: string): boolean {
+  return (
+    EMPTY_TERMINAL_REPLY_RE.test(text) ||
+    text.includes(runtimeT("runtime.channel.agentCouldntGenerateResponse")) ||
+    text.includes(runtimeT("runtime.channel.agentCouldntGenerateResponseWithSideEffects"))
+  );
+}
 
 function isEmbeddedAgentRunResult(value: unknown): value is EmbeddedAgentRunResult {
   return Boolean(
@@ -130,7 +139,7 @@ export function classifyEmbeddedAgentRunResultForModelFallback(params: {
     .filter((payload) => payload?.isError === true)
     .map((payload) => (typeof payload.text === "string" ? payload.text : ""))
     .join("\n");
-  if (EMPTY_TERMINAL_REPLY_RE.test(errorText)) {
+  if (isEmptyTerminalReplyText(errorText)) {
     return {
       message: `${params.provider}/${params.model} ended with an incomplete terminal response`,
       reason: "format",
@@ -176,7 +185,7 @@ export function classifyEmbeddedAgentRunResultForModelFallback(params: {
       code: "planning_only_result",
     };
   }
-  if (!EMPTY_TERMINAL_REPLY_RE.test(errorText)) {
+  if (!isEmptyTerminalReplyText(errorText)) {
     return null;
   }
 

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -26,6 +26,7 @@ import type { CommandQueueEnqueueOptions } from "../../process/command-queue.typ
 import { createAgentHarnessTaskRuntimeScope } from "../../tasks/agent-harness-task-runtime-scope.js";
 import { resolveUserPath } from "../../utils.js";
 import { isMarkdownCapableMessageChannel } from "../../utils/message-channel.js";
+import { t as runtimeT } from "../../wizard/i18n/index.js";
 import {
   retireSessionMcpRuntime,
   retireSessionMcpRuntimeForSessionKey,
@@ -1274,18 +1275,15 @@ export async function runEmbeddedAgent(
           `rate-limit profile rotation cap reached for ${sanitizeForLog(provider)}/${sanitizeForLog(modelId)} after ${rateLimitProfileRotations} rotations; escalating to model fallback`,
         );
         paramsLocal.logFallbackDecision("fallback_model", { status });
-        throw new FailoverError(
-          "The AI service is temporarily rate-limited. Please try again in a moment.",
-          {
-            reason: "rate_limit",
-            provider: paramsLocal.failoverProvider,
-            model: paramsLocal.failoverModel,
-            profileId: lastProfileId,
-            sessionId: activeSessionId,
-            lane: globalLane,
-            status,
-          },
-        );
+        throw new FailoverError(runtimeT("runtime.channel.aiServiceRateLimited"), {
+          reason: "rate_limit",
+          provider: paramsLocal.failoverProvider,
+          model: paramsLocal.failoverModel,
+          profileId: lastProfileId,
+          sessionId: activeSessionId,
+          lane: globalLane,
+          status,
+        });
       };
       const maybeMarkAuthProfileFailure = async (failure: {
         profileId?: string;
@@ -3326,15 +3324,16 @@ export async function runEmbeddedAgent(
             };
           }
           if (reasoningOnlyRetriesExhausted && !finalAssistantVisibleText) {
-            const replayInvalid = resolveReplayInvalidForAttempt(
-              "⚠️ Agent couldn't generate a response. Please try again.",
+            const agentCouldntGenerateResponse = runtimeT(
+              "runtime.channel.agentCouldntGenerateResponse",
             );
+            const replayInvalid = resolveReplayInvalidForAttempt(agentCouldntGenerateResponse);
             const livenessState = resolveRunLivenessState({
               payloadCount: 0,
               aborted,
               timedOut,
               attempt,
-              incompleteTurnText: "⚠️ Agent couldn't generate a response. Please try again.",
+              incompleteTurnText: agentCouldntGenerateResponse,
             });
             attempt.setTerminalLifecycleMeta?.({
               replayInvalid,
@@ -3350,7 +3349,7 @@ export async function runEmbeddedAgent(
             return {
               payloads: [
                 {
-                  text: "⚠️ Agent couldn't generate a response. Please try again.",
+                  text: agentCouldntGenerateResponse,
                   isError: true,
                 },
               ],

--- a/src/agents/embedded-agent-runner/run/assistant-failover.ts
+++ b/src/agents/embedded-agent-runner/run/assistant-failover.ts
@@ -4,6 +4,7 @@
 import { sanitizeForLog } from "../../../../packages/terminal-core/src/ansi.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import type { AssistantMessage } from "../../../llm/types.js";
+import { t as runtimeT } from "../../../wizard/i18n/index.js";
 import type { AuthProfileFailureReason } from "../../auth-profiles.js";
 import {
   formatAssistantErrorText,
@@ -138,17 +139,14 @@ export async function handleAssistantFailover(params: {
         return {
           action: "throw",
           overloadProfileRotations,
-          error: new FailoverError(
-            "The AI service is temporarily overloaded. Please try again in a moment.",
-            {
-              reason: "overloaded",
-              provider: params.activeErrorContext.provider,
-              model: params.activeErrorContext.model,
-              profileId: params.lastProfileId,
-              status,
-              rawError: params.lastAssistant?.errorMessage?.trim(),
-            },
-          ),
+          error: new FailoverError(runtimeT("runtime.channel.aiServiceOverloaded"), {
+            reason: "overloaded",
+            provider: params.activeErrorContext.provider,
+            model: params.activeErrorContext.model,
+            profileId: params.lastProfileId,
+            status,
+            rawError: params.lastAssistant?.errorMessage?.trim(),
+          }),
         };
       }
     }

--- a/src/agents/embedded-agent-runner/run/incomplete-turn.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn.ts
@@ -10,6 +10,7 @@ import {
   SILENT_REPLY_TOKEN,
 } from "../../../auto-reply/tokens.js";
 import type { EmbeddedAgentExecutionContract } from "../../../config/types.agent-defaults.js";
+import { t as runtimeT } from "../../../wizard/i18n/index.js";
 import { hasAcceptedSessionSpawn } from "../../accepted-session-spawn.js";
 import { collectTextContentBlocks } from "../../content-blocks.js";
 import {
@@ -338,8 +339,8 @@ export function resolveIncompleteTurnPayloadText(params: {
   }
 
   return resolveAttemptReplayMetadata(params.attempt).hadPotentialSideEffects
-    ? "⚠️ Agent couldn't generate a response. Note: some tool actions may have already been executed — please verify before retrying."
-    : "⚠️ Agent couldn't generate a response. Please try again.";
+    ? runtimeT("runtime.channel.agentCouldntGenerateResponseWithSideEffects")
+    : runtimeT("runtime.channel.agentCouldntGenerateResponse");
 }
 
 /**

--- a/src/agents/embedded-agent-runner/run/payloads.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.ts
@@ -26,6 +26,7 @@ import type { AssistantMessage } from "../../../llm/types.js";
 import { isCronSessionKey } from "../../../routing/session-key.js";
 import { extractAssistantTextForPhase } from "../../../shared/chat-message-content.js";
 import { parseInlineDirectives } from "../../../utils/directive-tags.js";
+import { t as runtimeT } from "../../../wizard/i18n/index.js";
 import {
   BILLING_ERROR_USER_MESSAGE,
   formatAssistantErrorText,
@@ -537,7 +538,10 @@ export function buildEmbeddedRunPayloads(params: {
         warningPolicy.includeDetails && params.lastToolError.error
           ? `: ${params.lastToolError.error}`
           : "";
-      const warningText = `⚠️ ${toolSummary} failed${errorSuffix}`;
+      const warningText = runtimeT("runtime.channel.toolFailed", {
+        toolSummary,
+        errorSuffix,
+      });
       const normalizedWarning = normalizeTextForComparison(warningText);
       const duplicateWarning = normalizedWarning
         ? replyItems.some((item) => {

--- a/src/auto-reply/reply-payload.ts
+++ b/src/auto-reply/reply-payload.ts
@@ -4,6 +4,7 @@ import type {
   MessagePresentation,
   ReplyPayloadDelivery,
 } from "../interactive/payload.js";
+import { t as runtimeT } from "../wizard/i18n/index.js";
 
 /** Channel-agnostic assistant reply payload. */
 export type ReplyPayload = {
@@ -67,7 +68,7 @@ export type ReplyPayloadTtsSupplement = {
   visibleTextAlreadyDelivered?: boolean;
 };
 
-export const REPLY_MEDIA_FAILURE_WARNING = "⚠️ Media failed.";
+export const REPLY_MEDIA_FAILURE_WARNING = runtimeT("runtime.channel.mediaFailed");
 
 /** Appends the standard media failure warning without duplicating it. */
 export function appendReplyMediaFailureWarning(text: string | undefined): string {

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -5161,7 +5161,7 @@ describe("runAgentTurnWithFallback", () => {
       const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
       const result = await runAgentTurnWithFallback(
         createMinimalRunAgentTurnParams({
-          sessionCtx: createNonDirectFailureSessionCtx(NON_DIRECT_FAILURE_SURFACE_CASES[0]!),
+          sessionCtx: createNonDirectFailureSessionCtx(NON_DIRECT_FAILURE_SURFACE_CASES[0]),
         }),
       );
 

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -5149,6 +5149,35 @@ describe("runAgentTurnWithFallback", () => {
     },
   );
 
+  it("keeps localized generated runner failure boilerplate out of non-direct chats", async () => {
+    const previousLocale = process.env.OPENCLAW_LOCALE;
+    process.env.OPENCLAW_LOCALE = "zh-CN";
+    state.isInternalMessageChannelMock.mockReturnValue(true);
+    state.runEmbeddedAgentMock.mockRejectedValueOnce(
+      new Error("INVALID_ARGUMENT: localized failure"),
+    );
+
+    try {
+      const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+      const result = await runAgentTurnWithFallback(
+        createMinimalRunAgentTurnParams({
+          sessionCtx: createNonDirectFailureSessionCtx(NON_DIRECT_FAILURE_SURFACE_CASES[0]!),
+        }),
+      );
+
+      expect(result.kind).toBe("final");
+      if (result.kind === "final") {
+        expect(result.payload.text).toBe(SILENT_REPLY_TOKEN);
+      }
+    } finally {
+      if (previousLocale === undefined) {
+        delete process.env.OPENCLAW_LOCALE;
+      } else {
+        process.env.OPENCLAW_LOCALE = previousLocale;
+      }
+    }
+  });
+
   it.each(["group", "channel"] as const)(
     "surfaces raw runner failure copy in Discord %s chats when silentReply.group is set to disallow",
     async (chatType) => {

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -77,6 +77,7 @@ import {
   resolveMessageChannel,
 } from "../../utils/message-channel.js";
 import { isInternalMessageChannel } from "../../utils/message-channel.js";
+import { t as runtimeT } from "../../wizard/i18n/index.js";
 import { stripHeartbeatToken } from "../heartbeat.js";
 import { markReplyPayloadForSourceSuppressionDelivery } from "../reply-payload.js";
 import type { TemplateContext } from "../templating.js";
@@ -545,19 +546,19 @@ function buildRateLimitCooldownMessage(err: unknown): string {
     return BILLING_ERROR_USER_MESSAGE;
   }
   if (!isFallbackSummaryError(err)) {
-    return "⚠️ All models are temporarily rate-limited. Please try again in a few minutes.";
+    return runtimeT("runtime.channel.rateLimitAllModels");
   }
   const expiry = err.soonestCooldownExpiry;
   const now = Date.now();
   if (typeof expiry === "number" && expiry > now) {
     const secsLeft = Math.max(1, Math.ceil((expiry - now) / 1000));
     if (secsLeft <= 60) {
-      return `⚠️ Rate-limited — ready in ~${secsLeft}s. Please wait a moment.`;
+      return runtimeT("runtime.channel.rateLimitReadySeconds", { seconds: secsLeft });
     }
     const minsLeft = Math.ceil(secsLeft / 60);
-    return `⚠️ Rate-limited — ready in ~${minsLeft} min. Please try again shortly.`;
+    return runtimeT("runtime.channel.rateLimitReadyMinutes", { minutes: minsLeft });
   }
-  return "⚠️ All models are temporarily rate-limited. Please try again in a few minutes.";
+  return runtimeT("runtime.channel.rateLimitAllModels");
 }
 
 function extractCodexUsageLimitErrorMessage(err: unknown): string | undefined {
@@ -633,7 +634,6 @@ function collapseRepeatedFailureDetail(message: string): string {
 
 const SAFE_MISSING_API_KEY_PROVIDERS = new Set(["anthropic", "google", "openai"]);
 const EXTERNAL_RUN_FAILURE_DETAIL_MAX_CHARS = 900;
-const AGENT_FAILED_BEFORE_REPLY_TEXT = "Agent failed before reply:";
 const PREFLIGHT_COMPACTION_FAILURE_PREFIX = "Preflight compaction required but failed:";
 
 type ExternalRunFailureReply = {
@@ -656,12 +656,15 @@ function resolveExternalRunFailureTextForConversation(params: {
   text: string;
   sessionCtx: TemplateContext;
   isGenericRunnerFailure: boolean;
+  applyRunnerFailureSilentPolicy?: boolean;
   cfg?: OpenClawConfig;
 }): string {
   if (!isNonDirectConversationContext(params.sessionCtx)) {
     return params.text;
   }
-  if (!params.isGenericRunnerFailure && !params.text.includes(AGENT_FAILED_BEFORE_REPLY_TEXT)) {
+  const shouldApplySilentPolicy =
+    params.isGenericRunnerFailure || params.applyRunnerFailureSilentPolicy === true;
+  if (!shouldApplySilentPolicy) {
     return params.text;
   }
   // Match normal reply routing: default group/channel failures stay silent,
@@ -691,10 +694,10 @@ const CODEX_APP_SERVER_TURN_COMPLETION_IDLE_TIMEOUT_RE =
 function buildCodexAppServerFailureText(message: string): string | null {
   const normalizedMessage = collapseRepeatedFailureDetail(message);
   if (CODEX_APP_SERVER_CLIENT_CLOSED_BEFORE_REPLY_RE.test(normalizedMessage)) {
-    return "⚠️ Codex app-server connection closed before this turn finished. OpenClaw retried once when the stdio turn was still replay-safe; please try again if this keeps happening.";
+    return runtimeT("runtime.channel.codexAppServerConnectionClosed");
   }
   if (CODEX_APP_SERVER_TURN_COMPLETION_IDLE_TIMEOUT_RE.test(normalizedMessage)) {
-    return "⚠️ Codex app-server stopped before confirming turn completion. OpenClaw did not replay the turn automatically because it may still be active; try again, or use /new if the session stays stuck.";
+    return runtimeT("runtime.channel.codexAppServerStopped");
   }
   return null;
 }
@@ -714,11 +717,11 @@ export function buildPreflightCompactionFailureText(
   )
     .trim()
     .replace(/\s+/gu, " ");
-  const reasonSuffix = options?.includeDetails && reason ? ` Reason: ${reason}.` : "";
-  return (
-    "⚠️ Context is too large and auto-compaction could not recover this turn." +
-    `${reasonSuffix} Try again, use /compact, or use /new to start a fresh session.`
-  );
+  const reasonSuffix =
+    options?.includeDetails && reason
+      ? runtimeT("runtime.channel.preflightCompactionReason", { reason })
+      : "";
+  return runtimeT("runtime.channel.preflightCompactionFailure", { reasonSuffix });
 }
 
 function buildCliBackendTimeoutFailureText(message: string): string | null {
@@ -733,10 +736,11 @@ function buildCliBackendTimeoutFailureText(message: string): string | null {
   const routedModelRef = normalizedMessage.match(CLI_BACKEND_ROUTING_REF_BEFORE_ERROR_RE)?.[1];
   const routingSuffix = routedModelRef ? ` (routing ${routedModelRef})` : "";
   const modeLabel = stall ? "no-output stall" : "overall CLI turn budget";
-  return (
-    `⚠️ CLI subprocess${routingSuffix}: timed out after ${seconds}s (${modeLabel}). The gateway may still be healthy. Try \`/new\`, a lighter model, or raise ` +
-    "`agents.defaults.timeoutSeconds` and the watchdog `noOutputTimeoutMs` entries under `cliBackends.<your-runtime>`."
-  );
+  return runtimeT("runtime.channel.cliBackendTimeout", {
+    routingSuffix,
+    seconds,
+    modeLabel,
+  });
 }
 
 function buildMissingApiKeyFailureText(input: { message: string; error?: unknown }): string | null {
@@ -751,15 +755,15 @@ function buildMissingApiKeyFailureText(input: { message: string; error?: unknown
     return null;
   }
   if (provider === "openai" && normalizedMessage.includes("OpenAI Codex OAuth")) {
-    return "⚠️ Missing API key for OpenAI on the gateway. Use `openai/gpt-5.5` with the OpenAI OAuth profile, or set `OPENAI_API_KEY` for direct OpenAI API-key runs.";
+    return runtimeT("runtime.channel.missingApiKeyOpenAiOAuth");
   }
   if (provider === "openai") {
-    return '⚠️ Missing API key for provider "openai". Run `openclaw doctor --fix` to repair stale OpenAI model/session routes, restart the gateway if doctor asks, then try again. If doctor has nothing to repair or the error persists, re-auth with `openclaw models auth login --provider openai` or run `openclaw configure`.';
+    return runtimeT("runtime.channel.missingApiKeyOpenAi");
   }
   if (SAFE_MISSING_API_KEY_PROVIDERS.has(provider)) {
-    return `⚠️ Missing API key for provider "${provider}". Configure the gateway auth for that provider, then try again.`;
+    return runtimeT("runtime.channel.missingApiKeyProvider", { provider });
   }
-  return "⚠️ Missing API key for the selected provider on the gateway. Configure provider auth, then try again.";
+  return runtimeT("runtime.channel.missingApiKeySelectedProvider");
 }
 
 function buildAuthProfileFailoverFailureText(error: unknown): string | null {
@@ -787,7 +791,7 @@ function formatForwardedExternalRunFailureText(message: string): string {
       ? `${sanitized.slice(0, EXTERNAL_RUN_FAILURE_DETAIL_MAX_CHARS - 1).trimEnd()}…`
       : sanitized;
   const suffix = /[.!?]$/u.test(detail) ? "" : ".";
-  return `⚠️ Agent failed before reply: ${detail}${suffix} Please try again, or use /new to start a fresh session.`;
+  return runtimeT("runtime.channel.agentFailedBeforeReply", { detail, suffix });
 }
 
 function buildExternalRunFailureReply(
@@ -819,14 +823,25 @@ function buildExternalRunFailureReply(
     classifyOAuthRefreshFailureError(error) ?? classifyOAuthRefreshFailure(normalizedMessage);
   if (oauthRefreshFailure) {
     const loginCommand = buildOAuthRefreshFailureLoginCommand(oauthRefreshFailure.provider);
+    const providerSuffix = oauthRefreshFailure.provider
+      ? runtimeT("runtime.channel.modelLoginProviderSuffix", {
+          provider: oauthRefreshFailure.provider,
+        })
+      : "";
     if (oauthRefreshFailure.reason) {
       return {
-        text: `⚠️ Model login expired on the gateway${oauthRefreshFailure.provider ? ` for ${oauthRefreshFailure.provider}` : ""}. Re-auth with \`${loginCommand}\`, then try again.`,
+        text: runtimeT("runtime.channel.modelLoginExpired", {
+          providerSuffix,
+          loginCommand,
+        }),
         isGenericRunnerFailure: false,
       };
     }
     return {
-      text: `⚠️ Model login failed on the gateway${oauthRefreshFailure.provider ? ` for ${oauthRefreshFailure.provider}` : ""}. Please try again. If this keeps happening, re-auth with \`${loginCommand}\`.`,
+      text: runtimeT("runtime.channel.modelLoginFailed", {
+        providerSuffix,
+        loginCommand,
+      }),
       isGenericRunnerFailure: false,
     };
   }
@@ -1219,10 +1234,10 @@ export function buildContextOverflowRecoveryText(params: {
   activeSessionEntry?: SessionEntry;
 }): string {
   const prefix = params.preserveSessionMapping
-    ? "⚠️ Auto-compaction could not recover this turn. I kept this conversation mapped to the current session. Please try again, use /compact, or use /new to start a fresh session."
+    ? runtimeT("runtime.channel.contextAutoCompactionCouldNotRecover")
     : params.duringCompaction
-      ? "⚠️ Context limit exceeded during compaction. I've reset our conversation to start fresh - please try again."
-      : "⚠️ Context limit exceeded. I've reset our conversation to start fresh - please try again.";
+      ? runtimeT("runtime.channel.contextLimitExceededDuringCompaction")
+      : runtimeT("runtime.channel.contextLimitExceededReset");
   const primaryContextWindow = resolveContextWindowForCompactionHint({
     cfg: params.cfg,
     primaryProvider: params.primaryProvider,
@@ -1250,7 +1265,7 @@ export function buildContextOverflowRecoveryText(params: {
 }
 
 function buildRestartLifecycleReplyText(): string {
-  return "⚠️ Gateway is restarting. Please wait a few seconds and try again.";
+  return runtimeT("runtime.channel.gatewayRestarting");
 }
 
 function resolveRestartLifecycleError(
@@ -1613,10 +1628,10 @@ export async function runAgentTurnWithFallback(params: {
     }
     const text =
       phase === "start"
-        ? "🧹 Compacting context..."
+        ? runtimeT("runtime.channel.compactingContext")
         : phase === "end"
-          ? "🧹 Compaction complete"
-          : "🧹 Compaction incomplete";
+          ? runtimeT("runtime.channel.compactionComplete")
+          : runtimeT("runtime.channel.compactionIncomplete");
     const noticePayload = params.applyReplyToMode({
       text,
       replyToId: currentMessageId,
@@ -2726,7 +2741,9 @@ export async function runAgentTurnWithFallback(params: {
           kind: "final",
           payload: markAgentRunFailureReplyPayload({
             text: shouldSurfaceToControlUi
-              ? `⚠️ Agent failed before reply: ${embeddedErrorText}.\nLogs: openclaw logs --follow`
+              ? runtimeT("runtime.channel.agentFailedBeforeReplyWithLogs", {
+                  detail: embeddedErrorText,
+                })
               : (providerRequestError?.userMessage ??
                 PROVIDER_CONVERSATION_STATE_ERROR_USER_MESSAGE),
           }),
@@ -2748,13 +2765,10 @@ export async function runAgentTurnWithFallback(params: {
               `(${sanitizeForLog(err.provider)}/${sanitizeForLog(err.model)}). The requested model may be unavailable.`,
           );
           const switchErrorText = shouldSurfaceToControlUi
-            ? "⚠️ Agent failed before reply: model switch could not be completed. " +
-              "The requested model may be temporarily unavailable.\n" +
-              "Logs: openclaw logs --follow"
+            ? runtimeT("runtime.channel.modelSwitchFailedBeforeReplyWithLogs")
             : isVerboseFailureDetailEnabled(params.resolvedVerboseLevel)
-              ? "⚠️ Agent failed before reply: model switch could not be completed. " +
-                "The requested model may be temporarily unavailable. Please try again shortly."
-              : "⚠️ Model switch could not be completed. The requested model may be temporarily unavailable. Please try again shortly.";
+              ? runtimeT("runtime.channel.modelSwitchFailedBeforeReply")
+              : runtimeT("runtime.channel.modelSwitchCouldNotComplete");
           params.replyOperation?.fail("run_failed", err);
           return {
             kind: "final",
@@ -2763,6 +2777,7 @@ export async function runAgentTurnWithFallback(params: {
                 text: switchErrorText,
                 sessionCtx: params.sessionCtx,
                 isGenericRunnerFailure: !shouldSurfaceToControlUi,
+                applyRunnerFailureSilentPolicy: true,
                 cfg: params.followupRun.run.config,
               }),
             }),
@@ -2925,14 +2940,23 @@ export async function runAgentTurnWithFallback(params: {
           : rateLimitOrOverloadedCopy
             ? rateLimitOrOverloadedCopy
             : isContextOverflow
-              ? "⚠️ Context overflow — prompt too large for this model. Try a shorter message or a larger-context model."
+              ? runtimeT("runtime.channel.contextOverflowPromptTooLarge")
               : shouldSurfaceToControlUi
-                ? `⚠️ Agent failed before reply: ${trimmedMessage}.\nLogs: openclaw logs --follow`
+                ? runtimeT("runtime.channel.agentFailedBeforeReplyWithLogs", {
+                    detail: trimmedMessage,
+                  })
                 : (externalRunFailureReply?.text ?? genericFallbackText);
+      const usesGeneratedAgentFailedBeforeReplyText =
+        !isBilling &&
+        !(isRateLimit && !isOverloadedErrorMessage(message)) &&
+        !rateLimitOrOverloadedCopy &&
+        !isContextOverflow &&
+        shouldSurfaceToControlUi;
       const userVisibleFallbackText = resolveExternalRunFailureTextForConversation({
         text: fallbackText,
         sessionCtx: params.sessionCtx,
         isGenericRunnerFailure: externalRunFailureReply?.isGenericRunnerFailure ?? false,
+        applyRunnerFailureSilentPolicy: usesGeneratedAgentFailedBeforeReplyText,
         cfg: params.followupRun.run.config,
       });
 
@@ -2960,7 +2984,7 @@ export async function runAgentTurnWithFallback(params: {
       return {
         kind: "final",
         payload: markAgentRunFailureReplyPayload({
-          text: "⚠️ Context overflow — this conversation is too large for the model. Use /new to start a fresh session.",
+          text: runtimeT("runtime.channel.contextOverflowConversationTooLarge"),
         }),
       };
     }

--- a/src/auto-reply/reply/agent-runner-failure-copy.ts
+++ b/src/auto-reply/reply/agent-runner-failure-copy.ts
@@ -1,9 +1,13 @@
 // Centralizes user-facing failure copy for external agent runner errors.
-export const GENERIC_EXTERNAL_RUN_FAILURE_TEXT =
-  "⚠️ Something went wrong while processing your request. Please try again, or use /new to start a fresh session.";
+import { t as runtimeT } from "../../wizard/i18n/index.js";
 
-export const HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT =
-  "⚠️ Heartbeat check failed before it could produce an update. The main chat session remains available.";
+export const GENERIC_EXTERNAL_RUN_FAILURE_TEXT = runtimeT(
+  "runtime.channel.genericExternalRunFailure",
+);
+
+export const HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT = runtimeT(
+  "runtime.channel.heartbeatExternalRunFailure",
+);
 
 /** True when text is exactly the generic external run failure copy. */
 export function isGenericExternalRunFailureText(text: string | undefined): boolean {

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -40,6 +40,7 @@ import { isAbortError } from "../../infra/unhandled-rejections.js";
 import { resolveMemoryFlushPlan } from "../../plugins/memory-state.js";
 import { CommandLane } from "../../process/lanes.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
+import { t as runtimeT } from "../../wizard/i18n/index.js";
 import type { TemplateContext } from "../templating.js";
 import type { VerboseLevel } from "../thinking.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
@@ -310,7 +311,9 @@ function buildMemoryFlushErrorPayload(err: unknown): ReplyPayload | undefined {
   if (!message) {
     return undefined;
   }
-  const visibleText = message.startsWith("⚠️") ? message : `⚠️ ${message}`;
+  const visibleText = message.startsWith("⚠️")
+    ? message
+    : runtimeT("runtime.channel.warningMessage", { message });
   return {
     text:
       visibleText.length > MAX_VISIBLE_MEMORY_FLUSH_ERROR_CHARS
@@ -1419,7 +1422,9 @@ export async function runMemoryFlushIfNeeded(params: {
           }
           params.onVisibleErrorPayloads?.([
             {
-              text: `⚠️ Memory flush failed after ${MAX_FLUSH_FAILURES} attempts; skipping for this cycle. It will retry after the next compaction.`,
+              text: runtimeT("runtime.channel.memoryFlushExhausted", {
+                attempts: MAX_FLUSH_FAILURES,
+              }),
               isError: true,
             },
           ]);

--- a/src/auto-reply/reply/agent-runner-utils.ts
+++ b/src/auto-reply/reply/agent-runner-utils.ts
@@ -22,6 +22,7 @@ import {
   type OpenClawConfig,
 } from "../../config/config.js";
 import { isReasoningTagProvider } from "../../utils/provider-utils.js";
+import { t as runtimeT } from "../../wizard/i18n/index.js";
 import type { TemplateContext } from "../templating.js";
 import {
   resolveProviderScopedAuthProfile,
@@ -183,9 +184,9 @@ export const isBunFetchSocketError = (message?: string) =>
 export const formatBunFetchSocketError = (message: string) => {
   const trimmed = message.trim();
   return [
-    "⚠️ LLM connection failed. This could be due to server issues, network problems, or context length exceeded (e.g., with local LLMs like LM Studio). Original error:",
+    runtimeT("runtime.channel.llmConnectionFailed"),
     "```",
-    trimmed || "Unknown error",
+    trimmed || runtimeT("runtime.channel.unknownError"),
     "```",
   ].join("\n");
 };

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -52,6 +52,7 @@ import {
   formatTokenCount,
   resolveModelCostConfig,
 } from "../../utils/usage-format.js";
+import { t as runtimeT } from "../../wizard/i18n/index.js";
 import {
   buildFallbackClearedNotice,
   buildFallbackNotice,
@@ -145,9 +146,10 @@ function buildSilentFallbackFailurePayload(params: {
     return undefined;
   }
   return markReplyPayloadForSourceSuppressionDelivery({
-    text:
-      `⚠️ I couldn't reach the configured model backend ${params.fallbackTransition.selectedModelRef}. ` +
-      `Fallback used ${params.fallbackTransition.activeModelRef}, but it produced no visible reply.`,
+    text: runtimeT("runtime.channel.fallbackBackendNoVisibleReply", {
+      selectedModelRef: params.fallbackTransition.selectedModelRef,
+      activeModelRef: params.fallbackTransition.activeModelRef,
+    }),
     isError: true,
   });
 }
@@ -2100,7 +2102,9 @@ export async function runReplyAgent(params: {
     const prefixNotices: ReplyPayload[] = [];
 
     if (verboseEnabled && activeIsNewSession) {
-      prefixNotices.push({ text: `🧭 New session: ${followupRun.run.sessionId}` });
+      prefixNotices.push({
+        text: runtimeT("runtime.channel.newSession", { sessionId: followupRun.run.sessionId }),
+      });
     }
 
     if (autoCompactionCount > 0) {
@@ -2148,7 +2152,9 @@ export async function runReplyAgent(params: {
 
       if (verboseEnabled) {
         const suffix = typeof count === "number" ? ` (count ${count})` : "";
-        prefixNotices.push({ text: `🧹 Auto-compaction complete${suffix}.` });
+        prefixNotices.push({
+          text: runtimeT("runtime.channel.autoCompactionComplete", { suffix }),
+        });
       }
     }
     const prefixPayloads = [...prefixNotices];
@@ -2388,7 +2394,7 @@ export async function runReplyAgent(params: {
     ) {
       return returnWithQueuedFollowupDrain(
         markReplyPayloadForSourceSuppressionDelivery({
-          text: "⚠️ Gateway is restarting. Please wait a few seconds and try again.",
+          text: runtimeT("runtime.channel.gatewayRestarting"),
         }),
       );
     }
@@ -2399,7 +2405,7 @@ export async function runReplyAgent(params: {
       replyOperation.fail("gateway_draining", error);
       return returnWithQueuedFollowupDrain(
         markReplyPayloadForSourceSuppressionDelivery({
-          text: "⚠️ Gateway is restarting. Please wait a few seconds and try again.",
+          text: runtimeT("runtime.channel.gatewayRestarting"),
         }),
       );
     }
@@ -2407,7 +2413,7 @@ export async function runReplyAgent(params: {
       replyOperation.fail("command_lane_cleared", error);
       return returnWithQueuedFollowupDrain(
         markReplyPayloadForSourceSuppressionDelivery({
-          text: "⚠️ Gateway is restarting. Please wait a few seconds and try again.",
+          text: runtimeT("runtime.channel.gatewayRestarting"),
         }),
       );
     }

--- a/src/auto-reply/reply/commands-reset.ts
+++ b/src/auto-reply/reply/commands-reset.ts
@@ -5,6 +5,7 @@ import { resetConfiguredBindingTargetInPlace } from "../../channels/plugins/bind
 import { updateSessionStoreEntry } from "../../config/sessions/store.js";
 import { logVerbose } from "../../globals.js";
 import { isAcpSessionKey } from "../../routing/session-key.js";
+import { t as runtimeT } from "../../wizard/i18n/index.js";
 import { resolveBoundAcpThreadSessionKey } from "./commands-acp/targets.js";
 import { emitResetCommandHooks, type ResetCommandAction } from "./commands-reset-hooks.js";
 import { parseSoftResetCommand } from "./commands-reset-mode.js";
@@ -149,12 +150,12 @@ export async function maybeHandleResetCommand(
       }
       return {
         shouldContinue: false,
-        reply: { text: "✅ ACP session reset in place." },
+        reply: { text: runtimeT("runtime.channel.sessionResetAcpInPlace") },
       };
     }
     return {
       shouldContinue: false,
-      reply: { text: "⚠️ ACP session reset failed. Check /acp status and try again." },
+      reply: { text: runtimeT("runtime.channel.sessionResetAcpFailed") },
     };
   }
 
@@ -177,7 +178,10 @@ export async function maybeHandleResetCommand(
         ? {}
         : {
             reply: {
-              text: commandAction === "reset" ? "✅ Session reset." : "✅ New session started.",
+              text:
+                commandAction === "reset"
+                  ? runtimeT("runtime.channel.sessionReset")
+                  : runtimeT("runtime.channel.sessionStarted"),
             },
           }),
     };

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -29,6 +29,7 @@ import { formatErrorMessage } from "../../infra/errors.js";
 import { defaultRuntime } from "../../runtime.js";
 import { shouldPreserveUserFacingSessionStateForInputProvenance } from "../../sessions/input-provenance.js";
 import { isInternalMessageChannel } from "../../utils/message-channel.js";
+import { t as runtimeT } from "../../wizard/i18n/index.js";
 import { markReplyPayloadForSourceSuppressionDelivery } from "../reply-payload.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import {
@@ -1142,7 +1143,7 @@ export function createFollowupRunner(params: {
           const suffix = typeof count === "number" ? ` (count ${count})` : "";
           deliveryPayloads = [
             {
-              text: `🧹 Auto-compaction complete${suffix}.`,
+              text: runtimeT("runtime.channel.autoCompactionComplete", { suffix }),
             },
             ...finalPayloads,
           ];

--- a/src/auto-reply/reply/get-reply-run-queue.ts
+++ b/src/auto-reply/reply/get-reply-run-queue.ts
@@ -1,5 +1,6 @@
 /** Active-run queue admission for prepared reply turns. */
 import { logVerbose } from "../../globals.js";
+import { t as runtimeT } from "../../wizard/i18n/index.js";
 import type { ReplyPayload } from "../types.js";
 import type { ActiveRunQueueAction } from "./queue-policy.js";
 import type { QueueSettings } from "./queue.js";
@@ -11,8 +12,9 @@ export type ReplyRunQueueBusyState = {
   isStreaming: boolean;
 };
 
-export const REPLY_RUN_STILL_SHUTTING_DOWN_TEXT =
-  "⚠️ Previous run is still shutting down. Please try again in a moment.";
+export const REPLY_RUN_STILL_SHUTTING_DOWN_TEXT = runtimeT(
+  "runtime.channel.previousRunStillShuttingDown",
+);
 
 /** Resolves whether a new reply may continue after active-run queue handling. */
 export async function resolvePreparedReplyQueueState(params: {

--- a/src/auto-reply/reply/provider-request-error-classifier.ts
+++ b/src/auto-reply/reply/provider-request-error-classifier.ts
@@ -1,6 +1,7 @@
 // Classifies provider request failures into retry and user-facing categories.
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { formatErrorMessage } from "../../infra/errors.js";
+import { t as runtimeT } from "../../wizard/i18n/index.js";
 
 /** Provider request error classes that get a specialized user-facing reply. */
 export type ProviderRequestErrorCode = "provider_conversation_state_error";
@@ -13,8 +14,9 @@ export type ProviderRequestErrorClassification = {
 };
 
 /** User-facing copy for provider-side broken conversation state. */
-export const PROVIDER_CONVERSATION_STATE_ERROR_USER_MESSAGE =
-  "⚠️ The model provider rejected the conversation state. Please try again, or use /new to start a fresh session.";
+export const PROVIDER_CONVERSATION_STATE_ERROR_USER_MESSAGE = runtimeT(
+  "runtime.channel.providerConversationStateError",
+);
 
 /** Classifies provider request failures that are actionable for users. */
 export function classifyProviderRequestError(

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -27,6 +27,7 @@ import { resolveMediaReferenceLocalPath } from "../media/media-reference.js";
 import { AVATAR_MAX_BYTES } from "../shared/avatar-policy.js";
 import { resolveUserPath } from "../utils.js";
 import { resolveRuntimeServiceVersion } from "../version.js";
+import { t as runtimeT } from "../wizard/i18n/index.js";
 import { DEFAULT_ASSISTANT_IDENTITY, resolveAssistantIdentity } from "./assistant-identity.js";
 import {
   AUTH_RATE_LIMIT_SCOPE_DEVICE_TOKEN,
@@ -474,18 +475,30 @@ function classifyAssistantMediaError(err: unknown): AssistantMediaAvailability {
   if (err instanceof FsSafeError) {
     switch (err.code) {
       case "not-found":
-        return { available: false, code: "file-not-found", reason: "File not found" };
+        return {
+          available: false,
+          code: "file-not-found",
+          reason: runtimeT("runtime.gateway.fileNotFound"),
+        };
       case "not-file":
-        return { available: false, code: "not-a-file", reason: "Not a file" };
+        return {
+          available: false,
+          code: "not-a-file",
+          reason: runtimeT("runtime.gateway.notAFile"),
+        };
       case "invalid-path":
       case "path-mismatch":
       case "symlink":
-        return { available: false, code: "invalid-file", reason: "Invalid file" };
+        return {
+          available: false,
+          code: "invalid-file",
+          reason: runtimeT("runtime.gateway.invalidFile"),
+        };
       default:
         return {
           available: false,
           code: "attachment-unavailable",
-          reason: "Attachment unavailable",
+          reason: runtimeT("runtime.gateway.attachmentUnavailable"),
         };
     }
   }
@@ -496,23 +509,39 @@ function classifyAssistantMediaError(err: unknown): AssistantMediaAvailability {
         return {
           available: false,
           code: "outside-allowed-folders",
-          reason: "Outside allowed folders",
+          reason: runtimeT("runtime.gateway.outsideAllowedFolders"),
         };
       case "invalid-file-url":
       case "invalid-path":
       case "unsafe-bypass":
       case "network-path-not-allowed":
       case "invalid-root":
-        return { available: false, code: "blocked-local-file", reason: "Blocked local file" };
+        return {
+          available: false,
+          code: "blocked-local-file",
+          reason: runtimeT("runtime.gateway.blockedLocalFile"),
+        };
       case "not-found":
-        return { available: false, code: "file-not-found", reason: "File not found" };
+        return {
+          available: false,
+          code: "file-not-found",
+          reason: runtimeT("runtime.gateway.fileNotFound"),
+        };
       case "not-file":
-        return { available: false, code: "not-a-file", reason: "Not a file" };
+        return {
+          available: false,
+          code: "not-a-file",
+          reason: runtimeT("runtime.gateway.notAFile"),
+        };
       default:
         break;
     }
   }
-  return { available: false, code: "attachment-unavailable", reason: "Attachment unavailable" };
+  return {
+    available: false,
+    code: "attachment-unavailable",
+    reason: runtimeT("runtime.gateway.attachmentUnavailable"),
+  };
 }
 
 async function resolveAssistantMediaAvailability(

--- a/src/gateway/http-common.ts
+++ b/src/gateway/http-common.ts
@@ -5,6 +5,7 @@ import {
   logRejectedLargePayload,
   parseContentLengthHeader,
 } from "../logging/diagnostic-payload.js";
+import { t as runtimeT } from "../wizard/i18n/index.js";
 import type { GatewayAuthResult } from "./auth.js";
 import { readJsonBody } from "./hooks.js";
 
@@ -56,7 +57,7 @@ export function sendRateLimited(res: ServerResponse, retryAfterMs?: number) {
   }
   sendJson(res, 429, {
     error: {
-      message: "Too many failed authentication attempts. Please try again later.",
+      message: runtimeT("runtime.gateway.tooManyFailedAuthAttempts"),
       type: "rate_limited",
     },
   });

--- a/src/gateway/server-cron-notifications.ts
+++ b/src/gateway/server-cron-notifications.ts
@@ -20,6 +20,7 @@ import { normalizeHttpWebhookUrl } from "../cron/webhook-url.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
 import { SsrFBlockedError } from "../infra/net/ssrf.js";
+import { t as runtimeT } from "../wizard/i18n/index.js";
 
 const CRON_WEBHOOK_TIMEOUT_MS = 10_000;
 
@@ -358,7 +359,7 @@ function dispatchCronFailureDestinationNotifications(params: {
           accountId: failureDest.accountId,
           sessionKey: deliverySessionKey,
         },
-        `⚠️ ${failureMessage}`,
+        runtimeT("runtime.channel.warningMessage", { message: failureMessage }),
       );
     }
     return;
@@ -381,6 +382,6 @@ function dispatchCronFailureDestinationNotifications(params: {
       accountId: primaryPlan.accountId,
       sessionKey: deliverySessionKey,
     },
-    `⚠️ ${failureMessage}`,
+    runtimeT("runtime.channel.warningMessage", { message: failureMessage }),
   );
 }

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -16,6 +16,7 @@ import {
   createDiagnosticTraceContext,
   runWithDiagnosticTraceContext,
 } from "../infra/diagnostic-trace-context.js";
+import { t as runtimeT } from "../wizard/i18n/index.js";
 import { resolveAssistantIdentity } from "./assistant-identity.js";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import {
@@ -340,7 +341,7 @@ function writeUpgradeAuthFailure(
         "",
         JSON.stringify({
           error: {
-            message: "Too many failed authentication attempts. Please try again later.",
+            message: runtimeT("runtime.gateway.tooManyFailedAuthAttempts"),
             type: "rate_limited",
           },
         }),

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -114,6 +114,7 @@ import {
   isInternalNonDeliveryChannel,
   normalizeMessageChannel,
 } from "../../utils/message-channel.js";
+import { t as runtimeT } from "../../wizard/i18n/index.js";
 import { resolveAssistantIdentity } from "../assistant-identity.js";
 import {
   type ChatAbortControllerEntry,
@@ -270,7 +271,9 @@ async function runSessionResetFromAgent(params: {
 }
 
 function sessionResetAckText(reason: "new" | "reset"): string {
-  return reason === "new" ? "✅ New session started." : "✅ Session reset.";
+  return reason === "new"
+    ? runtimeT("runtime.channel.sessionStarted")
+    : runtimeT("runtime.channel.sessionReset");
 }
 
 function buildBareSessionResetResult(params: { reason: "new" | "reset"; sessionId?: string }) {

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -97,6 +97,7 @@ import {
   isWebchatClient,
   normalizeMessageChannel,
 } from "../../utils/message-channel.js";
+import { t as runtimeT } from "../../wizard/i18n/index.js";
 import {
   abortChatRunById,
   boundInFlightRunSnapshotForChatHistory,
@@ -4130,7 +4131,12 @@ export const chatHandlers: GatewayRequestHandlers = {
                           );
                           return stripped?.length
                             ? stripped
-                            : [{ type: "text", text: "Media reply could not be displayed." }];
+                            : [
+                                {
+                                  type: "text",
+                                  text: runtimeT("runtime.gateway.mediaReplyCouldNotBeDisplayed"),
+                                },
+                              ];
                         }
                         return state.broadcastContent;
                       })

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -80,6 +80,7 @@ import {
   resolveAgentIdFromSessionKey,
   toAgentStoreSessionKey,
 } from "../../routing/session-key.js";
+import { t as runtimeT } from "../../wizard/i18n/index.js";
 import { ADMIN_SCOPE } from "../operator-scopes.js";
 import { resolveSessionKeyForRun } from "../server-session-key.js";
 import {
@@ -841,7 +842,7 @@ async function interruptSessionRunIfActive(params: {
         interrupted: true,
         error: errorShape(
           ErrorCodes.UNAVAILABLE,
-          `Session ${params.requestedKey} is still active; try again in a moment.`,
+          runtimeT("runtime.gateway.sessionStillActive", { sessionKey: params.requestedKey }),
         ),
       };
     }

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -53,6 +53,7 @@ import {
   normalizeAgentId,
   parseAgentSessionKey,
 } from "../routing/session-key.js";
+import { t as runtimeT } from "../wizard/i18n/index.js";
 import {
   forgetActiveSessionForShutdown,
   listActiveSessionsForShutdown,
@@ -422,7 +423,7 @@ async function ensureSessionRuntimeCleanup(params: {
   }
   return errorShape(
     ErrorCodes.UNAVAILABLE,
-    `Session ${params.key} is still active; try again in a moment.`,
+    runtimeT("runtime.gateway.sessionStillActive", { sessionKey: params.key }),
   );
 }
 
@@ -483,7 +484,7 @@ async function closeAcpRuntimeForSession(params: {
   if (cancelOutcome.status === "timeout") {
     return errorShape(
       ErrorCodes.UNAVAILABLE,
-      `Session ${params.sessionKey} is still active; try again in a moment.`,
+      runtimeT("runtime.gateway.sessionStillActive", { sessionKey: params.sessionKey }),
     );
   }
   if (cancelOutcome.status === "error") {
@@ -507,7 +508,7 @@ async function closeAcpRuntimeForSession(params: {
   if (closeOutcome.status === "timeout") {
     return errorShape(
       ErrorCodes.UNAVAILABLE,
-      `Session ${params.sessionKey} is still active; try again in a moment.`,
+      runtimeT("runtime.gateway.sessionStillActive", { sessionKey: params.sessionKey }),
     );
   }
   if (closeOutcome.status === "error") {

--- a/src/tui/tui-formatters.ts
+++ b/src/tui/tui-formatters.ts
@@ -5,6 +5,7 @@ import type { SessionGoal } from "../config/sessions/types.js";
 import { formatRawAssistantErrorForUi } from "../shared/assistant-error-format.js";
 import { extractAssistantVisibleText } from "../shared/chat-message-content.js";
 import { formatTokenCount } from "../utils/usage-format.js";
+import { t as runtimeT } from "../wizard/i18n/index.js";
 
 const REPLACEMENT_CHAR_RE = /\uFFFD/g;
 const MAX_TOKEN_CHARS = 32;
@@ -242,7 +243,7 @@ export function composeThinkingAndContent(params: {
   const parts: string[] = [];
 
   if (params.showThinking && thinkingText) {
-    parts.push(`[thinking]\n${thinkingText}`);
+    parts.push(`[${runtimeT("runtime.tui.thinking")}]\n${thinkingText}`);
   }
   if (contentText) {
     parts.push(contentText);

--- a/src/wizard/i18n/locales/en.ts
+++ b/src/wizard/i18n/locales/en.ts
@@ -18,6 +18,112 @@ export const en = {
     skipForNow: "Skip for now",
     tokenRecommended: "Token (recommended)",
   },
+  runtime: {
+    channel: {
+      aiServiceOverloaded:
+        "The AI service is temporarily overloaded. Please try again in a moment.",
+      aiServiceRateLimited:
+        "The AI service is temporarily rate-limited. Please try again in a moment.",
+      agentFailedBeforeReply:
+        "⚠️ Agent failed before reply: {detail}{suffix} Please try again, or use /new to start a fresh session.",
+      agentFailedBeforeReplyWithLogs:
+        "⚠️ Agent failed before reply: {detail}.\nLogs: openclaw logs --follow",
+      agentCouldntGenerateResponse: "⚠️ Agent couldn't generate a response. Please try again.",
+      agentCouldntGenerateResponseWithSideEffects:
+        "⚠️ Agent couldn't generate a response. Note: some tool actions may have already been executed — please verify before retrying.",
+      apiBillingError:
+        "⚠️ API provider returned a billing error — your API key has run out of credits or has an insufficient balance. Check your provider's billing dashboard and top up or switch to a different API key.",
+      apiBillingErrorForProvider:
+        "⚠️ {providerLabel} returned a billing error — your API key has run out of credits or has an insufficient balance. Check your {providerName} billing dashboard and top up or switch to a different API key.",
+      apiRateLimitReached: "⚠️ API rate limit reached. Please try again later.",
+      autoCompactionComplete: "🧹 Auto-compaction complete{suffix}.",
+      cliBackendTimeout:
+        "⚠️ CLI subprocess{routingSuffix}: timed out after {seconds}s ({modeLabel}). The gateway may still be healthy. Try `/new`, a lighter model, or raise `agents.defaults.timeoutSeconds` and the watchdog `noOutputTimeoutMs` entries under `cliBackends.<your-runtime>`.",
+      codexAppServerConnectionClosed:
+        "⚠️ Codex app-server connection closed before this turn finished. OpenClaw retried once when the stdio turn was still replay-safe; please try again if this keeps happening.",
+      codexAppServerStopped:
+        "⚠️ Codex app-server stopped before confirming turn completion. OpenClaw did not replay the turn automatically because it may still be active; try again, or use /new if the session stays stuck.",
+      compactionComplete: "🧹 Compaction complete",
+      compactionIncomplete: "🧹 Compaction incomplete",
+      compactingContext: "🧹 Compacting context...",
+      contextAutoCompactionCouldNotRecover:
+        "⚠️ Auto-compaction could not recover this turn. I kept this conversation mapped to the current session. Please try again, use /compact, or use /new to start a fresh session.",
+      contextLimitExceededDuringCompaction:
+        "⚠️ Context limit exceeded during compaction. I've reset our conversation to start fresh - please try again.",
+      contextLimitExceededReset:
+        "⚠️ Context limit exceeded. I've reset our conversation to start fresh - please try again.",
+      contextOverflowConversationTooLarge:
+        "⚠️ Context overflow — this conversation is too large for the model. Use /new to start a fresh session.",
+      contextOverflowPromptTooLarge:
+        "⚠️ Context overflow — prompt too large for this model. Try a shorter message or a larger-context model.",
+      fallbackBackendNoVisibleReply:
+        "⚠️ I couldn't reach the configured model backend {selectedModelRef}. Fallback used {activeModelRef}, but it produced no visible reply.",
+      gatewayRestarting: "⚠️ Gateway is restarting. Please wait a few seconds and try again.",
+      genericExternalRunFailure:
+        "⚠️ Something went wrong while processing your request. Please try again, or use /new to start a fresh session.",
+      heartbeatExternalRunFailure:
+        "⚠️ Heartbeat check failed before it could produce an update. The main chat session remains available.",
+      llmConnectionFailed:
+        "⚠️ LLM connection failed. This could be due to server issues, network problems, or context length exceeded (e.g., with local LLMs like LM Studio). Original error:",
+      mediaFailed: "⚠️ Media failed.",
+      memoryFlushExhausted:
+        "⚠️ Memory flush failed after {attempts} attempts; skipping for this cycle. It will retry after the next compaction.",
+      missingApiKeyOpenAi:
+        '⚠️ Missing API key for provider "openai". Run `openclaw doctor --fix` to repair stale OpenAI model/session routes, restart the gateway if doctor asks, then try again. If doctor has nothing to repair or the error persists, re-auth with `openclaw models auth login --provider openai` or run `openclaw configure`.',
+      missingApiKeyOpenAiOAuth:
+        "⚠️ Missing API key for OpenAI on the gateway. Use `openai/gpt-5.5` with the OpenAI OAuth profile, or set `OPENAI_API_KEY` for direct OpenAI API-key runs.",
+      missingApiKeyProvider:
+        '⚠️ Missing API key for provider "{provider}". Configure the gateway auth for that provider, then try again.',
+      missingApiKeySelectedProvider:
+        "⚠️ Missing API key for the selected provider on the gateway. Configure provider auth, then try again.",
+      modelAtCapacity:
+        "⚠️ Selected model is at capacity. Try a different model, or wait and retry.",
+      modelLoginExpired:
+        "⚠️ Model login expired on the gateway{providerSuffix}. Re-auth with `{loginCommand}`, then try again.",
+      modelLoginFailed:
+        "⚠️ Model login failed on the gateway{providerSuffix}. Please try again. If this keeps happening, re-auth with `{loginCommand}`.",
+      modelLoginProviderSuffix: " for {provider}",
+      modelSwitchCouldNotComplete:
+        "⚠️ Model switch could not be completed. The requested model may be temporarily unavailable. Please try again shortly.",
+      modelSwitchFailedBeforeReply:
+        "⚠️ Agent failed before reply: model switch could not be completed. The requested model may be temporarily unavailable. Please try again shortly.",
+      modelSwitchFailedBeforeReplyWithLogs:
+        "⚠️ Agent failed before reply: model switch could not be completed. The requested model may be temporarily unavailable.\nLogs: openclaw logs --follow",
+      newSession: "🧭 New session: {sessionId}",
+      preflightCompactionFailure:
+        "⚠️ Context is too large and auto-compaction could not recover this turn.{reasonSuffix} Try again, use /compact, or use /new to start a fresh session.",
+      preflightCompactionReason: " Reason: {reason}.",
+      previousRunStillShuttingDown:
+        "⚠️ Previous run is still shutting down. Please try again in a moment.",
+      providerConversationStateError:
+        "⚠️ The model provider rejected the conversation state. Please try again, or use /new to start a fresh session.",
+      sessionReset: "✅ Session reset.",
+      sessionResetAcpFailed: "⚠️ ACP session reset failed. Check /acp status and try again.",
+      sessionResetAcpInPlace: "✅ ACP session reset in place.",
+      sessionStarted: "✅ New session started.",
+      toolFailed: "⚠️ {toolSummary} failed{errorSuffix}",
+      unknownError: "Unknown error",
+      warningMessage: "⚠️ {message}",
+      rateLimitAllModels:
+        "⚠️ All models are temporarily rate-limited. Please try again in a few minutes.",
+      rateLimitReadyMinutes: "⚠️ Rate-limited — ready in ~{minutes} min. Please try again shortly.",
+      rateLimitReadySeconds: "⚠️ Rate-limited — ready in ~{seconds}s. Please wait a moment.",
+    },
+    gateway: {
+      attachmentUnavailable: "Attachment unavailable",
+      blockedLocalFile: "Blocked local file",
+      fileNotFound: "File not found",
+      invalidFile: "Invalid file",
+      mediaReplyCouldNotBeDisplayed: "Media reply could not be displayed.",
+      notAFile: "Not a file",
+      outsideAllowedFolders: "Outside allowed folders",
+      sessionStillActive: "Session {sessionKey} is still active; try again in a moment.",
+      tooManyFailedAuthAttempts: "Too many failed authentication attempts. Please try again later.",
+    },
+    tui: {
+      thinking: "thinking",
+    },
+  },
   wizard: {
     customProvider: {
       apiBaseUrl: "API Base URL",

--- a/src/wizard/i18n/locales/zh-CN.ts
+++ b/src/wizard/i18n/locales/zh-CN.ts
@@ -18,6 +18,102 @@ export const zh_CN = {
     skipForNow: "暂时跳过",
     tokenRecommended: "令牌（推荐）",
   },
+  runtime: {
+    channel: {
+      aiServiceOverloaded: "AI 服务暂时过载。请稍后再试。",
+      aiServiceRateLimited: "AI 服务暂时触发限流。请稍后再试。",
+      agentFailedBeforeReply:
+        "⚠️ Agent 在回复前失败：{detail}{suffix} 请重试，或使用 /new 开始一个新会话。",
+      agentFailedBeforeReplyWithLogs:
+        "⚠️ Agent 在回复前失败：{detail}。\n日志：openclaw logs --follow",
+      agentCouldntGenerateResponse: "⚠️ Agent 未能生成回复。请重试。",
+      agentCouldntGenerateResponseWithSideEffects:
+        "⚠️ Agent 未能生成回复。注意：部分工具操作可能已经执行，请先确认结果后再重试。",
+      apiBillingError:
+        "⚠️ API 提供商返回了计费错误：你的 API Key 额度已用尽或余额不足。请检查提供商的计费面板并充值，或切换到其他 API Key。",
+      apiBillingErrorForProvider:
+        "⚠️ {providerLabel} 返回了计费错误：你的 API Key 额度已用尽或余额不足。请检查 {providerName} 的计费面板并充值，或切换到其他 API Key。",
+      apiRateLimitReached: "⚠️ API 已触发限流。请稍后再试。",
+      autoCompactionComplete: "🧹 自动压缩已完成{suffix}。",
+      cliBackendTimeout:
+        "⚠️ CLI 子进程{routingSuffix}：{modeLabel} 超时，已运行 {seconds} 秒。Gateway 可能仍然正常。请尝试 `/new`、更轻量的模型，或提高 `agents.defaults.timeoutSeconds` 以及 `cliBackends.<your-runtime>` 下的 watchdog `noOutputTimeoutMs`。",
+      codexAppServerConnectionClosed:
+        "⚠️ Codex app-server 连接在本轮完成前关闭。OpenClaw 已在 stdio 回放仍安全时重试一次；如果持续发生，请再试一次。",
+      codexAppServerStopped:
+        "⚠️ Codex app-server 在确认本轮完成前停止。OpenClaw 未自动重放，因为该轮可能仍在运行；请重试，或在会话持续卡住时使用 /new。",
+      compactionComplete: "🧹 压缩已完成",
+      compactionIncomplete: "🧹 压缩未完成",
+      compactingContext: "🧹 正在压缩上下文...",
+      contextAutoCompactionCouldNotRecover:
+        "⚠️ 自动压缩未能恢复本轮。我已保留这段对话到当前会话的映射。请重试，使用 /compact，或使用 /new 开始一个新会话。",
+      contextLimitExceededDuringCompaction:
+        "⚠️ 压缩期间上下文超出限制。我已重置对话并重新开始，请再试一次。",
+      contextLimitExceededReset: "⚠️ 上下文超出限制。我已重置对话并重新开始，请再试一次。",
+      contextOverflowConversationTooLarge:
+        "⚠️ 上下文超出限制：这段对话对当前模型来说太长了。请使用 /new 开始一个新会话。",
+      contextOverflowPromptTooLarge:
+        "⚠️ 上下文超出限制：这次请求对当前模型来说太长了。请缩短消息，或换用更大上下文的模型。",
+      fallbackBackendNoVisibleReply:
+        "⚠️ 无法连接配置的模型后端 {selectedModelRef}。已使用备用模型 {activeModelRef}，但没有产生可见回复。",
+      gatewayRestarting: "⚠️ Gateway 正在重启。请稍等几秒后再试。",
+      genericExternalRunFailure: "⚠️ 处理你的请求时出了问题。请重试，或使用 /new 开始一个新会话。",
+      heartbeatExternalRunFailure: "⚠️ 心跳检查未能生成更新。主聊天会话仍可继续使用。",
+      llmConnectionFailed:
+        "⚠️ LLM 连接失败。可能是服务端问题、网络问题，或上下文长度超限（例如 LM Studio 等本地 LLM）。原始错误：",
+      mediaFailed: "⚠️ 媒体发送失败。",
+      memoryFlushExhausted: "⚠️ 记忆刷新连续 {attempts} 次失败；本轮将跳过。下次压缩后会再次尝试。",
+      missingApiKeyOpenAi:
+        '⚠️ 缺少 provider "openai" 的 API Key。请运行 `openclaw doctor --fix` 修复过期的 OpenAI 模型/会话路由；如果 doctor 提示，请重启 gateway 后再试。如果 doctor 没有可修复项或错误仍然存在，请使用 `openclaw models auth login --provider openai` 重新认证，或运行 `openclaw configure`。',
+      missingApiKeyOpenAiOAuth:
+        "⚠️ Gateway 缺少 OpenAI API Key。请使用带 OpenAI OAuth profile 的 `openai/gpt-5.5`，或为直接 OpenAI API Key 运行设置 `OPENAI_API_KEY`。",
+      missingApiKeyProvider:
+        '⚠️ 缺少 provider "{provider}" 的 API Key。请为 gateway 配置该 provider 的认证后再试。',
+      missingApiKeySelectedProvider:
+        "⚠️ Gateway 缺少当前所选 provider 的 API Key。请配置 provider 认证后再试。",
+      modelAtCapacity: "⚠️ 当前所选模型容量已满。请切换模型，或稍后重试。",
+      modelLoginExpired:
+        "⚠️ Gateway 上的模型登录已过期{providerSuffix}。请使用 `{loginCommand}` 重新认证后再试。",
+      modelLoginFailed:
+        "⚠️ Gateway 上的模型登录失败{providerSuffix}。请重试。如果持续发生，请使用 `{loginCommand}` 重新认证。",
+      modelLoginProviderSuffix: "（{provider}）",
+      modelSwitchCouldNotComplete: "⚠️ 模型切换未能完成。请求的模型可能暂时不可用。请稍后重试。",
+      modelSwitchFailedBeforeReply:
+        "⚠️ Agent 在回复前失败：模型切换未能完成。请求的模型可能暂时不可用。请稍后重试。",
+      modelSwitchFailedBeforeReplyWithLogs:
+        "⚠️ Agent 在回复前失败：模型切换未能完成。请求的模型可能暂时不可用。\n日志：openclaw logs --follow",
+      newSession: "🧭 新会话：{sessionId}",
+      preflightCompactionFailure:
+        "⚠️ 上下文过大，自动压缩未能恢复本轮。{reasonSuffix} 请重试，使用 /compact，或使用 /new 开始一个新会话。",
+      preflightCompactionReason: " 原因：{reason}。",
+      previousRunStillShuttingDown: "⚠️ 上一次运行仍在关闭中。请稍后再试。",
+      providerConversationStateError:
+        "⚠️ 模型提供商拒绝了当前对话状态。请重试，或使用 /new 开始一个新会话。",
+      sessionReset: "✅ 会话已重置。",
+      sessionResetAcpFailed: "⚠️ ACP 会话重置失败。请检查 /acp status 后再试。",
+      sessionResetAcpInPlace: "✅ ACP 会话已原地重置。",
+      sessionStarted: "✅ 新会话已开始。",
+      toolFailed: "⚠️ {toolSummary} 失败{errorSuffix}",
+      unknownError: "未知错误",
+      warningMessage: "⚠️ {message}",
+      rateLimitAllModels: "⚠️ 所有模型暂时触发限流。请几分钟后再试。",
+      rateLimitReadyMinutes: "⚠️ 已触发限流，约 {minutes} 分钟后可重试。请稍后再试。",
+      rateLimitReadySeconds: "⚠️ 已触发限流，约 {seconds} 秒后可重试。请稍等。",
+    },
+    gateway: {
+      attachmentUnavailable: "附件不可用",
+      blockedLocalFile: "本地文件被阻止",
+      fileNotFound: "文件未找到",
+      invalidFile: "文件无效",
+      mediaReplyCouldNotBeDisplayed: "媒体回复无法显示。",
+      notAFile: "不是文件",
+      outsideAllowedFolders: "不在允许访问的文件夹内",
+      sessionStillActive: "会话 {sessionKey} 仍在运行；请稍后再试。",
+      tooManyFailedAuthAttempts: "认证失败次数过多。请稍后再试。",
+    },
+    tui: {
+      thinking: "思考",
+    },
+  },
   wizard: {
     customProvider: {
       apiBaseUrl: "API 基础 URL",

--- a/src/wizard/i18n/locales/zh-TW.ts
+++ b/src/wizard/i18n/locales/zh-TW.ts
@@ -18,6 +18,102 @@ export const zh_TW = {
     skipForNow: "暫時略過",
     tokenRecommended: "權杖（建議）",
   },
+  runtime: {
+    channel: {
+      aiServiceOverloaded: "AI 服務暫時過載。請稍後再試。",
+      aiServiceRateLimited: "AI 服務暫時觸發限流。請稍後再試。",
+      agentFailedBeforeReply:
+        "⚠️ Agent 在回覆前失敗：{detail}{suffix} 請重試，或使用 /new 開始新工作階段。",
+      agentFailedBeforeReplyWithLogs:
+        "⚠️ Agent 在回覆前失敗：{detail}。\n記錄：openclaw logs --follow",
+      agentCouldntGenerateResponse: "⚠️ Agent 未能產生回覆。請重試。",
+      agentCouldntGenerateResponseWithSideEffects:
+        "⚠️ Agent 未能產生回覆。注意：部分工具操作可能已經執行，請先確認結果後再重試。",
+      apiBillingError:
+        "⚠️ API 提供者回傳計費錯誤：你的 API Key 額度已用盡或餘額不足。請檢查提供者的計費面板並儲值，或切換到其他 API Key。",
+      apiBillingErrorForProvider:
+        "⚠️ {providerLabel} 回傳計費錯誤：你的 API Key 額度已用盡或餘額不足。請檢查 {providerName} 的計費面板並儲值，或切換到其他 API Key。",
+      apiRateLimitReached: "⚠️ API 已觸發限流。請稍後再試。",
+      autoCompactionComplete: "🧹 自動壓縮已完成{suffix}。",
+      cliBackendTimeout:
+        "⚠️ CLI 子行程{routingSuffix}：{modeLabel} 逾時，已執行 {seconds} 秒。Gateway 可能仍然正常。請嘗試 `/new`、更輕量的模型，或提高 `agents.defaults.timeoutSeconds` 以及 `cliBackends.<your-runtime>` 下的 watchdog `noOutputTimeoutMs`。",
+      codexAppServerConnectionClosed:
+        "⚠️ Codex app-server 連線在本輪完成前關閉。OpenClaw 已在 stdio 回放仍安全時重試一次；如果持續發生，請再試一次。",
+      codexAppServerStopped:
+        "⚠️ Codex app-server 在確認本輪完成前停止。OpenClaw 未自動回放，因為該輪可能仍在執行；請重試，或在工作階段持續卡住時使用 /new。",
+      compactionComplete: "🧹 壓縮已完成",
+      compactionIncomplete: "🧹 壓縮未完成",
+      compactingContext: "🧹 正在壓縮上下文...",
+      contextAutoCompactionCouldNotRecover:
+        "⚠️ 自動壓縮未能恢復本輪。我已保留這段對話到目前工作階段的映射。請重試，使用 /compact，或使用 /new 開始新工作階段。",
+      contextLimitExceededDuringCompaction:
+        "⚠️ 壓縮期間上下文超出限制。我已重設對話並重新開始，請再試一次。",
+      contextLimitExceededReset: "⚠️ 上下文超出限制。我已重設對話並重新開始，請再試一次。",
+      contextOverflowConversationTooLarge:
+        "⚠️ 上下文超出限制：這段對話對目前模型來說太長了。請使用 /new 開始新工作階段。",
+      contextOverflowPromptTooLarge:
+        "⚠️ 上下文超出限制：這次請求對目前模型來說太長了。請縮短訊息，或改用更大上下文的模型。",
+      fallbackBackendNoVisibleReply:
+        "⚠️ 無法連接設定的模型後端 {selectedModelRef}。已使用備用模型 {activeModelRef}，但沒有產生可見回覆。",
+      gatewayRestarting: "⚠️ Gateway 正在重新啟動。請稍等幾秒後再試。",
+      genericExternalRunFailure: "⚠️ 處理你的請求時發生問題。請重試，或使用 /new 開始新工作階段。",
+      heartbeatExternalRunFailure: "⚠️ 心跳檢查未能產生更新。主聊天工作階段仍可繼續使用。",
+      llmConnectionFailed:
+        "⚠️ LLM 連線失敗。可能是伺服器問題、網路問題，或上下文長度超限（例如 LM Studio 等本機 LLM）。原始錯誤：",
+      mediaFailed: "⚠️ 媒體傳送失敗。",
+      memoryFlushExhausted: "⚠️ 記憶刷新連續 {attempts} 次失敗；本輪將略過。下次壓縮後會再次嘗試。",
+      missingApiKeyOpenAi:
+        '⚠️ 缺少 provider "openai" 的 API Key。請執行 `openclaw doctor --fix` 修復過期的 OpenAI 模型/工作階段路由；如果 doctor 提示，請重新啟動 gateway 後再試。如果 doctor 沒有可修復項或錯誤仍然存在，請使用 `openclaw models auth login --provider openai` 重新認證，或執行 `openclaw configure`。',
+      missingApiKeyOpenAiOAuth:
+        "⚠️ Gateway 缺少 OpenAI API Key。請使用帶 OpenAI OAuth profile 的 `openai/gpt-5.5`，或為直接 OpenAI API Key 執行設定 `OPENAI_API_KEY`。",
+      missingApiKeyProvider:
+        '⚠️ 缺少 provider "{provider}" 的 API Key。請為 gateway 設定該 provider 的認證後再試。',
+      missingApiKeySelectedProvider:
+        "⚠️ Gateway 缺少目前所選 provider 的 API Key。請設定 provider 認證後再試。",
+      modelAtCapacity: "⚠️ 目前所選模型容量已滿。請切換模型，或稍後重試。",
+      modelLoginExpired:
+        "⚠️ Gateway 上的模型登入已過期{providerSuffix}。請使用 `{loginCommand}` 重新認證後再試。",
+      modelLoginFailed:
+        "⚠️ Gateway 上的模型登入失敗{providerSuffix}。請重試。如果持續發生，請使用 `{loginCommand}` 重新認證。",
+      modelLoginProviderSuffix: "（{provider}）",
+      modelSwitchCouldNotComplete: "⚠️ 模型切換未能完成。請求的模型可能暫時不可用。請稍後重試。",
+      modelSwitchFailedBeforeReply:
+        "⚠️ Agent 在回覆前失敗：模型切換未能完成。請求的模型可能暫時不可用。請稍後重試。",
+      modelSwitchFailedBeforeReplyWithLogs:
+        "⚠️ Agent 在回覆前失敗：模型切換未能完成。請求的模型可能暫時不可用。\n記錄：openclaw logs --follow",
+      newSession: "🧭 新工作階段：{sessionId}",
+      preflightCompactionFailure:
+        "⚠️ 上下文過大，自動壓縮未能恢復本輪。{reasonSuffix} 請重試，使用 /compact，或使用 /new 開始新工作階段。",
+      preflightCompactionReason: " 原因：{reason}。",
+      previousRunStillShuttingDown: "⚠️ 上一次執行仍在關閉中。請稍後再試。",
+      providerConversationStateError:
+        "⚠️ 模型提供者拒絕了目前對話狀態。請重試，或使用 /new 開始新工作階段。",
+      sessionReset: "✅ 工作階段已重設。",
+      sessionResetAcpFailed: "⚠️ ACP 工作階段重設失敗。請檢查 /acp status 後再試。",
+      sessionResetAcpInPlace: "✅ ACP 工作階段已原地重設。",
+      sessionStarted: "✅ 新工作階段已開始。",
+      toolFailed: "⚠️ {toolSummary} 失敗{errorSuffix}",
+      unknownError: "未知錯誤",
+      warningMessage: "⚠️ {message}",
+      rateLimitAllModels: "⚠️ 所有模型暫時觸發限流。請幾分鐘後再試。",
+      rateLimitReadyMinutes: "⚠️ 已觸發限流，約 {minutes} 分鐘後可重試。請稍後再試。",
+      rateLimitReadySeconds: "⚠️ 已觸發限流，約 {seconds} 秒後可重試。請稍等。",
+    },
+    gateway: {
+      attachmentUnavailable: "附件不可用",
+      blockedLocalFile: "本機檔案被阻擋",
+      fileNotFound: "找不到檔案",
+      invalidFile: "檔案無效",
+      mediaReplyCouldNotBeDisplayed: "媒體回覆無法顯示。",
+      notAFile: "不是檔案",
+      outsideAllowedFolders: "不在允許存取的資料夾內",
+      sessionStillActive: "工作階段 {sessionKey} 仍在執行；請稍後再試。",
+      tooManyFailedAuthAttempts: "認證失敗次數過多。請稍後再試。",
+    },
+    tui: {
+      thinking: "思考",
+    },
+  },
   wizard: {
     customProvider: {
       apiBaseUrl: "API 基礎 URL",


### PR DESCRIPTION
## Summary

Localizes shared runtime/user-facing copy through the existing wizard i18n runtime translator and adds English, Simplified Chinese, and Traditional Chinese locale entries for the new runtime keys.

## What changed

- Added runtime copy keys under `runtime.channel`, `runtime.gateway`, and `runtime.tui` in the wizard i18n locale maps.
- Routed shared agent/runtime reply copy through `runtimeT(...)`, including rate limits, billing/capacity/overload errors, missing API keys, model login/switch failures, context overflow/compaction notices, fallback backend notices, gateway restart notices, memory flush failures, and LLM socket error formatting.
- Localized gateway-facing reason strings for attachment availability, auth rate limiting, active-session reset/delete conflicts, and webchat media fallback display text.
- Localized TUI thinking labels and session reset/new-session acknowledgements that are shared across runtime surfaces.
- Preserved stable non-display behavior where other code consumes these strings: non-direct silent-reply routing now uses an explicit runner-failure flag, and iMessage, active-memory, and QA-lab classifiers recognize the localized runtime failure text they intentionally inspect.
- Kept English defaults equivalent to the previous user-facing strings so existing behavior remains stable when `OPENCLAW_LOCALE` is unset or unsupported.

## Boundary note

This PR originally scoped the implementation to core `src/**` runtime copy. During review, we found downstream consumers outside `src` that rely on static English user-visible runtime failure text as classification signals rather than stable metadata. Specifically, iMessage reflection detection, active-memory query cleanup, and QA-lab failure detection matched English runtime failure strings.

That is why the current PR includes narrow `extensions/` classifier updates: they preserve existing behavior after core failure copy is localized. The PR does not migrate or rewrite plugin-owned product copy beyond those guards.

## What this intentionally does not do

- Does not migrate every command-specific response yet. `/config`, `/plugins`, `/session`, ACP, TTS, subagents, allowlist, export, diagnostics, and similar command help/status strings still have many command-owned literals.
- Does not change plugin-owned product copy outside the classifier updates needed for localized shared runtime failure strings.
- Does not introduce a new runtime i18n package or move the translator out of `src/wizard/i18n`; this follows the branch's existing runtime translator pattern.
- Does not change protocol codes, gateway error `type` values, or behavioral branching contracts; user-visible text is translated while routing/classification decisions stay on stable metadata or explicit localized classifier contracts.
- Does not include an agent transcript section in this PR body.

## Real behavior proof

Behavior addressed: Shared runtime and gateway user-visible strings now resolve through locale-aware i18n keys for English, Simplified Chinese, and Traditional Chinese, while localized failure text still preserves existing non-direct suppression and downstream failure classifiers.

Real environment tested: Local Codex worktree on macOS after rebasing this branch onto latest `upstream/main`.

Exact steps or command run after this patch:

```bash
node --import tsx - <<'NODE'
import { buildKnownAgentRunFailureReplyPayload, buildPreflightCompactionFailureText } from './src/auto-reply/reply/agent-runner-execution.ts';
import { t } from './src/wizard/i18n/index.ts';
for (const locale of ['en', 'zh-CN', 'zh-TW']) {
  process.env.OPENCLAW_LOCALE = locale;
  const missingApiKey = buildKnownAgentRunFailureReplyPayload({
    err: new Error('No API key found for provider "openai". You are authenticated with OpenAI Codex OAuth.'),
    sessionCtx: { Provider: 'whatsapp', MessageSid: 'proof' },
    resolvedVerboseLevel: 'off',
  });
  console.log(`locale=${locale}`);
  console.log(`generic=${t('runtime.channel.genericExternalRunFailure')}`);
  console.log(`missingApiKey=${missingApiKey?.text}`);
  console.log(`preflight=${buildPreflightCompactionFailureText('Preflight compaction required but failed: proof reason', { includeDetails: true })}`);
  console.log('---');
}
NODE

git diff --check
./node_modules/.bin/oxfmt --check extensions/qa-lab/src/reply-failure.ts extensions/qa-lab/src/reply-failure.test.ts extensions/active-memory/index.ts extensions/active-memory/index.test.ts src/auto-reply/reply/agent-runner-execution.ts src/auto-reply/reply/agent-runner-execution.test.ts extensions/imessage/src/monitor/reflection-guard.ts extensions/imessage/src/monitor/reflection-guard.test.ts
node scripts/run-vitest.mjs extensions/qa-lab/src/reply-failure.test.ts extensions/active-memory/index.test.ts src/auto-reply/reply/agent-runner-execution.test.ts extensions/imessage/src/monitor/reflection-guard.test.ts src/wizard/i18n/index.test.ts
.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main
```

Evidence after fix: The runtime proof command printed English, zh-CN, and zh-TW output from the actual runtime translation and failure-formatting paths. Example output was:

```text
locale=en
generic=⚠️ Something went wrong while processing your request. Please try again, or use /new to start a fresh session.
missingApiKey=⚠️ Missing API key for OpenAI on the gateway. Use `openai/gpt-5.5` with the OpenAI OAuth profile, or set `OPENAI_API_KEY` for direct OpenAI API-key runs.
preflight=⚠️ Context is too large and auto-compaction could not recover this turn. Reason: proof reason. Try again, use /compact, or use /new to start a fresh session.
---
locale=zh-CN
generic=⚠️ 处理你的请求时出了问题。请重试，或使用 /new 开始一个新会话。
missingApiKey=⚠️ Gateway 缺少 OpenAI API Key。请使用带 OpenAI OAuth profile 的 `openai/gpt-5.5`，或为直接 OpenAI API Key 运行设置 `OPENAI_API_KEY`。
preflight=⚠️ 上下文过大，自动压缩未能恢复本轮。 原因：proof reason。 请重试，使用 /compact，或使用 /new 开始一个新会话。
---
locale=zh-TW
generic=⚠️ 處理你的請求時發生問題。請重試，或使用 /new 開始新工作階段。
missingApiKey=⚠️ Gateway 缺少 OpenAI API Key。請使用帶 OpenAI OAuth profile 的 `openai/gpt-5.5`，或為直接 OpenAI API Key 執行設定 `OPENAI_API_KEY`。
preflight=⚠️ 上下文過大，自動壓縮未能恢復本輪。 原因：proof reason。 請重試，使用 /compact，或使用 /new 開始新工作階段。
---
```

Observed result after fix: Default English output remains equivalent to the previous strings, zh-CN/zh-TW runtime output is localized, and the focused regression tests confirm localized failure strings still participate in silent-reply suppression, iMessage reflection detection, active-memory query cleanup, and QA-lab failure detection.

What was not tested: Full `pnpm check`, broad CI, live provider turns, and every command-specific text command surface were not run as part of this focused copy migration.

## Verification

- `git diff --check`
- `./node_modules/.bin/oxfmt --check extensions/qa-lab/src/reply-failure.ts extensions/qa-lab/src/reply-failure.test.ts extensions/active-memory/index.ts extensions/active-memory/index.test.ts src/auto-reply/reply/agent-runner-execution.ts src/auto-reply/reply/agent-runner-execution.test.ts extensions/imessage/src/monitor/reflection-guard.ts extensions/imessage/src/monitor/reflection-guard.test.ts`
- `node scripts/run-vitest.mjs extensions/qa-lab/src/reply-failure.test.ts extensions/active-memory/index.test.ts src/auto-reply/reply/agent-runner-execution.test.ts extensions/imessage/src/monitor/reflection-guard.test.ts src/wizard/i18n/index.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main` -> clean, no accepted/actionable findings

