### PR TITLE
fix(agents): dispatch subagent spawn in process

### DIFF
--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -621,10 +621,12 @@ tombstoned sessions.
 <Note>
 If a sub-agent spawn fails with Gateway `PAIRING_REQUIRED` /
 `scope-upgrade`, check the RPC caller before editing pairing state.
-Internal `sessions_spawn` coordination should connect as
-`client.id: "gateway-client"` with `client.mode: "backend"` over direct
-loopback shared-token/password auth; that path does not depend on the
-CLI's paired-device scope baseline. Remote callers, explicit
+Internal `sessions_spawn` coordination dispatches in process when the
+caller is already running inside the gateway request context, so it does
+not open a loopback WebSocket or depend on the CLI's paired-device scope
+baseline. Callers outside the gateway process still use the WebSocket
+fallback as `client.id: "gateway-client"` with `client.mode: "backend"`
+over direct loopback shared-token/password auth. Remote callers, explicit
 `deviceIdentity`, explicit device-token paths, and browser/node clients
 still need normal device approval for scope upgrades.
 </Note>

--- a/src/agents/subagent-spawn.runtime.ts
+++ b/src/agents/subagent-spawn.runtime.ts
@@ -17,6 +17,10 @@ export {
 export { ensureContextEnginesInitialized } from "../context-engine/init.js";
 export { resolveContextEngine } from "../context-engine/registry.js";
 export { callGateway } from "../gateway/call.js";
+export {
+  dispatchGatewayMethodInProcess,
+  hasInProcessGatewayContext,
+} from "../gateway/server-plugins.js";
 export { ADMIN_SCOPE, isAdminOnlyMethod } from "../gateway/method-scopes.js";
 export { getSessionBindingService } from "../infra/outbound/session-binding-service.js";
 export {

--- a/src/agents/subagent-spawn.test-helpers.ts
+++ b/src/agents/subagent-spawn.test-helpers.ts
@@ -128,6 +128,8 @@ export function expectPersistedRuntimeModel(params: {
 /** Load subagent-spawn with runtime dependencies replaced by test doubles. */
 export async function loadSubagentSpawnModuleForTest(params: {
   callGatewayMock: MockFn;
+  dispatchGatewayMethodInProcessMock?: MockFn;
+  hasInProcessGatewayContextMock?: MockFn;
   getRuntimeConfig?: () => Record<string, unknown>;
   loadSessionStoreMock?: MockFn;
   ensureContextEnginesInitializedMock?: MockFn;
@@ -209,6 +211,9 @@ export async function loadSubagentSpawnModuleForTest(params: {
 
   vi.doMock("./subagent-spawn.runtime.js", () => ({
     callGateway: (opts: unknown) => params.callGatewayMock(opts),
+    dispatchGatewayMethodInProcess: (...args: unknown[]) =>
+      params.dispatchGatewayMethodInProcessMock?.(...args),
+    hasInProcessGatewayContext: () => Boolean(params.hasInProcessGatewayContextMock?.()),
     buildSubagentSystemPrompt: () => "system-prompt",
     forkSessionFromParent:
       params.forkSessionFromParentMock ??

--- a/src/agents/subagent-spawn.test.ts
+++ b/src/agents/subagent-spawn.test.ts
@@ -17,6 +17,8 @@ const hoisted = vi.hoisted(() => ({
   pruneLegacyStoreKeysMock: vi.fn(),
   registerSubagentRunMock: vi.fn(),
   emitSessionLifecycleEventMock: vi.fn(),
+  dispatchGatewayMethodInProcessMock: vi.fn(),
+  hasInProcessGatewayContextMock: vi.fn(),
   resolveAgentConfigMock: vi.fn(),
   configOverride: {} as Record<string, unknown>,
 }));
@@ -67,6 +69,8 @@ describe("spawnSubagentDirect seam flow", () => {
   beforeAll(async () => {
     ({ resetSubagentRegistryForTests, spawnSubagentDirect } = await loadSubagentSpawnModuleForTest({
       callGatewayMock: hoisted.callGatewayMock,
+      dispatchGatewayMethodInProcessMock: hoisted.dispatchGatewayMethodInProcessMock,
+      hasInProcessGatewayContextMock: hoisted.hasInProcessGatewayContextMock,
       getRuntimeConfig: () => hoisted.configOverride,
       loadSessionStoreMock: hoisted.loadSessionStoreMock,
       updateSessionStoreMock: hoisted.updateSessionStoreMock,
@@ -88,6 +92,8 @@ describe("spawnSubagentDirect seam flow", () => {
     hoisted.pruneLegacyStoreKeysMock.mockReset();
     hoisted.registerSubagentRunMock.mockReset();
     hoisted.emitSessionLifecycleEventMock.mockReset();
+    hoisted.dispatchGatewayMethodInProcessMock.mockReset();
+    hoisted.hasInProcessGatewayContextMock.mockReset().mockReturnValue(false);
     hoisted.resolveAgentConfigMock.mockReset();
     hoisted.resolveAgentConfigMock.mockImplementation(
       (cfg: { agents?: { list?: Array<{ id?: string }> } }, agentId: string) =>
@@ -264,6 +270,76 @@ describe("spawnSubagentDirect seam flow", () => {
     const agentParams = requireRecord(agentRequest.params);
     expect(agentParams.sessionKey).toBe(childSessionKey);
     expect(agentParams.cleanupBundleMcpOnRunEnd).toBe(true);
+  });
+
+  it("dispatches spawned agent runs in process when a gateway context is available", async () => {
+    hoisted.hasInProcessGatewayContextMock.mockReturnValue(true);
+    hoisted.callGatewayMock.mockRejectedValue(new Error("unexpected websocket gateway call"));
+    hoisted.dispatchGatewayMethodInProcessMock.mockImplementation(async (method: string) => {
+      if (method === "agent") {
+        return { runId: "run-in-process" };
+      }
+      return { ok: true };
+    });
+
+    const result = await spawnSubagentDirect(
+      {
+        task: "spawn without websocket self-connection",
+      },
+      {
+        agentSessionKey: "agent:main:main",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    expect(result.runId).toBe("run-in-process");
+    expect(hoisted.callGatewayMock).not.toHaveBeenCalled();
+    expect(hoisted.dispatchGatewayMethodInProcessMock).toHaveBeenCalledWith(
+      "agent",
+      expect.objectContaining({
+        message: expect.stringContaining("spawn without websocket self-connection"),
+        sessionKey: result.childSessionKey,
+      }),
+      expect.objectContaining({
+        timeoutMs: expect.any(Number),
+      }),
+    );
+  });
+
+  it("keeps admin-scoped cleanup on in-process spawn failure", async () => {
+    hoisted.hasInProcessGatewayContextMock.mockReturnValue(true);
+    hoisted.callGatewayMock.mockRejectedValue(new Error("unexpected websocket gateway call"));
+    hoisted.dispatchGatewayMethodInProcessMock.mockImplementation(async (method: string) => {
+      if (method === "agent") {
+        throw new Error("spawn failed");
+      }
+      return { ok: true };
+    });
+
+    const result = await spawnSubagentDirect(
+      {
+        task: "spawn failure cleanup",
+      },
+      {
+        agentSessionKey: "agent:main:main",
+      },
+    );
+
+    expect(result.status).toBe("error");
+    expect(result.error).toContain("spawn failed");
+    expect(hoisted.callGatewayMock).not.toHaveBeenCalled();
+    expect(hoisted.dispatchGatewayMethodInProcessMock).toHaveBeenCalledWith(
+      "sessions.delete",
+      expect.objectContaining({
+        key: result.childSessionKey,
+        deleteTranscript: true,
+      }),
+      expect.objectContaining({
+        forceSyntheticClient: true,
+        syntheticScopes: ["operator.admin"],
+        timeoutMs: 60_000,
+      }),
+    );
   });
 
   it("inherits requester thinking level when no spawn or subagent default is configured", async () => {

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -87,11 +87,13 @@ import {
   DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH,
   buildSubagentSystemPrompt,
   callGateway,
+  dispatchGatewayMethodInProcess,
   emitSessionLifecycleEvent,
   forkSessionFromParent,
   getGlobalHookRunner,
   getSessionBindingService,
   getRuntimeConfig,
+  hasInProcessGatewayContext,
   loadSessionStore,
   mergeSessionEntry,
   mergeDeliveryContext,
@@ -133,9 +135,11 @@ function resolveConfiguredAgentIds(cfg: OpenClawConfig): string[] {
 
 type SubagentSpawnDeps = {
   callGateway: typeof callGateway;
+  dispatchGatewayMethodInProcess: typeof dispatchGatewayMethodInProcess;
   forkSessionFromParent: typeof forkSessionFromParent;
   getGlobalHookRunner: () => SubagentLifecycleHookRunner | null;
   getRuntimeConfig: typeof getRuntimeConfig;
+  hasInProcessGatewayContext: typeof hasInProcessGatewayContext;
   ensureContextEnginesInitialized: typeof ensureContextEnginesInitialized;
   resolveContextEngine: typeof resolveContextEngine;
   resolveParentForkDecision: typeof resolveParentForkDecision;
@@ -144,9 +148,11 @@ type SubagentSpawnDeps = {
 
 const defaultSubagentSpawnDeps: SubagentSpawnDeps = {
   callGateway,
+  dispatchGatewayMethodInProcess,
   forkSessionFromParent,
   getGlobalHookRunner,
   getRuntimeConfig,
+  hasInProcessGatewayContext,
   ensureContextEnginesInitialized,
   resolveContextEngine,
   resolveParentForkDecision,
@@ -245,10 +251,30 @@ async function callSubagentGateway(
   // Only admin-only methods are pinned to ADMIN_SCOPE; other methods (e.g.
   // "agent" -> write) keep their least-privilege scope.
   const scopes = params.scopes ?? (isAdminOnlyMethod(params.method) ? [ADMIN_SCOPE] : undefined);
-  return await subagentSpawnDeps.callGateway({
+  const request = {
     ...params,
     ...(scopes != null ? { scopes } : {}),
-  });
+  };
+  if (
+    subagentSpawnDeps.hasInProcessGatewayContext() &&
+    request.params != null &&
+    typeof request.params === "object" &&
+    !Array.isArray(request.params)
+  ) {
+    // Spawn is already running in the gateway process for channel/tool calls.
+    // Direct dispatch avoids self-connecting over WS while the same event loop is busy.
+    return await subagentSpawnDeps.dispatchGatewayMethodInProcess(
+      request.method,
+      request.params as Record<string, unknown>,
+      {
+        expectFinal: request.expectFinal,
+        ...(scopes != null ? { forceSyntheticClient: true } : {}),
+        timeoutMs: request.timeoutMs,
+        ...(scopes != null ? { syntheticScopes: scopes } : {}),
+      },
+    );
+  }
+  return await subagentSpawnDeps.callGateway(request);
 }
 
 function readGatewayRunId(response: Awaited<ReturnType<typeof callGateway>>): string | undefined {

--- a/src/gateway/server-plugins.test.ts
+++ b/src/gateway/server-plugins.test.ts
@@ -815,7 +815,9 @@ describe("loadGatewayPlugins", () => {
         setTimeout(() => {
           opts.respond(true, { status: "ok", runId: "run-deadline" });
         }, 13);
-        await new Promise((resolve) => setTimeout(resolve, 13));
+        await new Promise((resolve) => {
+          setTimeout(resolve, 13);
+        });
       });
 
       const result = expect(
@@ -840,7 +842,9 @@ describe("loadGatewayPlugins", () => {
       serverPluginsModule.setFallbackGatewayContext(createTestContext("accepted-then-error"));
       handleGatewayRequest.mockImplementationOnce(async (opts: HandleGatewayRequestOptions) => {
         opts.respond(true, { status: "accepted", runId: "run-error-after-accepted" });
-        await new Promise((resolve) => setTimeout(resolve, 5));
+        await new Promise((resolve) => {
+          setTimeout(resolve, 5);
+        });
         throw new Error("handler failed after accepted");
       });
 

--- a/src/gateway/server-plugins.test.ts
+++ b/src/gateway/server-plugins.test.ts
@@ -804,6 +804,62 @@ describe("loadGatewayPlugins", () => {
     ).resolves.toEqual({ status: "accepted", runId: "run-accepted" });
   });
 
+  test("uses one timeout budget across accepted and final in-process responses", async () => {
+    vi.useFakeTimers();
+    try {
+      serverPluginsModule.setFallbackGatewayContext(createTestContext("single-final-deadline"));
+      handleGatewayRequest.mockImplementationOnce(async (opts: HandleGatewayRequestOptions) => {
+        setTimeout(() => {
+          opts.respond(true, { status: "accepted", runId: "run-deadline" });
+        }, 7);
+        setTimeout(() => {
+          opts.respond(true, { status: "ok", runId: "run-deadline" });
+        }, 13);
+        await new Promise((resolve) => setTimeout(resolve, 13));
+      });
+
+      const result = expect(
+        serverPluginsModule.dispatchGatewayMethodInProcess(
+          "agent",
+          { sessionKey: "s-deadline" },
+          { expectFinal: true, timeoutMs: 10 },
+        ),
+      ).rejects.toThrow("gateway request timeout for agent");
+
+      await vi.advanceTimersByTimeAsync(10);
+      await result;
+      await vi.advanceTimersByTimeAsync(10);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("clears final-response timeout when handler rejects after accepted response", async () => {
+    vi.useFakeTimers();
+    try {
+      serverPluginsModule.setFallbackGatewayContext(createTestContext("accepted-then-error"));
+      handleGatewayRequest.mockImplementationOnce(async (opts: HandleGatewayRequestOptions) => {
+        opts.respond(true, { status: "accepted", runId: "run-error-after-accepted" });
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        throw new Error("handler failed after accepted");
+      });
+
+      const result = expect(
+        serverPluginsModule.dispatchGatewayMethodInProcess(
+          "agent",
+          { sessionKey: "s-error-after-accepted" },
+          { expectFinal: true, timeoutMs: 1_000 },
+        ),
+      ).rejects.toThrow("handler failed after accepted");
+
+      await vi.advanceTimersByTimeAsync(5);
+      await result;
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   test("filters connected plugin nodes locally without sending unsupported node.list params", async () => {
     loadOpenClawPlugins.mockReturnValue(createRegistry([]));
     loadGatewayStartupPluginsForTest();

--- a/src/gateway/server-plugins.test.ts
+++ b/src/gateway/server-plugins.test.ts
@@ -773,6 +773,37 @@ describe("loadGatewayPlugins", () => {
     });
   });
 
+  test("times out while waiting for the first in-process gateway response", async () => {
+    serverPluginsModule.setFallbackGatewayContext(createTestContext("initial-response-timeout"));
+    handleGatewayRequest.mockImplementationOnce(async () => {
+      await new Promise(() => {});
+    });
+
+    await expect(
+      serverPluginsModule.dispatchGatewayMethodInProcess(
+        "sessions.delete",
+        { key: "stuck-session" },
+        { timeoutMs: 5 },
+      ),
+    ).rejects.toThrow("gateway request timeout for sessions.delete");
+  });
+
+  test("returns an accepted in-process response without waiting for handler completion", async () => {
+    serverPluginsModule.setFallbackGatewayContext(createTestContext("accepted-before-complete"));
+    handleGatewayRequest.mockImplementationOnce(async (opts: HandleGatewayRequestOptions) => {
+      opts.respond(true, { status: "accepted", runId: "run-accepted" });
+      await new Promise(() => {});
+    });
+
+    await expect(
+      serverPluginsModule.dispatchGatewayMethodInProcess(
+        "agent",
+        { sessionKey: "s-accepted" },
+        { timeoutMs: 5 },
+      ),
+    ).resolves.toEqual({ status: "accepted", runId: "run-accepted" });
+  });
+
   test("filters connected plugin nodes locally without sending unsupported node.list params", async () => {
     loadOpenClawPlugins.mockReturnValue(createRegistry([]));
     loadGatewayStartupPluginsForTest();
@@ -1388,11 +1419,14 @@ describe("loadGatewayPlugins", () => {
     const runtime = await createSubagentRuntime(serverPlugins);
     let currentContext = createTestContext("before-resolver-update");
 
+    expect(serverPlugins.hasInProcessGatewayContext()).toBe(false);
     serverPlugins.setFallbackGatewayContextResolver(() => currentContext);
+    expect(serverPlugins.hasInProcessGatewayContext()).toBe(true);
     await runtime.run({ sessionKey: "s-4", message: "before resolver update" });
     expect(getLastDispatchedContext()).toBe(currentContext);
 
     currentContext = createTestContext("after-resolver-update");
+    expect(serverPlugins.hasInProcessGatewayContext()).toBe(true);
     await runtime.run({ sessionKey: "s-4", message: "after resolver update" });
     expect(getLastDispatchedContext()).toBe(currentContext);
   });
@@ -1434,6 +1468,7 @@ describe("loadGatewayPlugins", () => {
 
     serverPlugins.clearFallbackGatewayContext();
 
+    expect(serverPlugins.hasInProcessGatewayContext()).toBe(false);
     await expect(runtime.run({ sessionKey: "s-7", message: "after clear" })).rejects.toThrow(
       "No scope set and no fallback context available",
     );

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -340,13 +340,24 @@ function resolveInProcessDispatchTimeoutMs(timeoutMs?: number): number | undefin
     : undefined;
 }
 
+function resolveInProcessDispatchDeadlineMs(timeoutMs?: number): number | undefined {
+  const safeTimeoutMs = resolveInProcessDispatchTimeoutMs(timeoutMs);
+  return safeTimeoutMs === undefined ? undefined : Date.now() + safeTimeoutMs;
+}
+
+function resolveRemainingInProcessDispatchTimeoutMs(deadlineMs?: number): number | undefined {
+  return deadlineMs === undefined
+    ? undefined
+    : resolveSafeTimeoutDelayMs(deadlineMs - Date.now(), { minMs: 0 });
+}
+
 async function waitForInProcessDispatch<T>(
   method: string,
   promise: Promise<T>,
-  timeoutMs?: number,
+  deadlineMs?: number,
 ): Promise<T> {
-  const safeTimeoutMs = resolveInProcessDispatchTimeoutMs(timeoutMs);
-  if (safeTimeoutMs === undefined) {
+  const remainingTimeoutMs = resolveRemainingInProcessDispatchTimeoutMs(deadlineMs);
+  if (remainingTimeoutMs === undefined) {
     return await promise;
   }
   let timeout: NodeJS.Timeout | undefined;
@@ -356,7 +367,7 @@ async function waitForInProcessDispatch<T>(
       new Promise<never>((_resolve, reject) => {
         timeout = setTimeout(() => {
           reject(new Error(`gateway request timeout for ${method}`));
-        }, safeTimeoutMs);
+        }, remainingTimeoutMs);
       }),
     ]);
   } finally {
@@ -396,6 +407,7 @@ export async function dispatchGatewayMethodInProcessRaw(
     resolveFirstResponse = resolve;
     rejectFirstResponse = reject;
   });
+  const deadlineMs = resolveInProcessDispatchDeadlineMs(options?.timeoutMs);
   const { handleGatewayRequest } = await import("./server-methods.js");
   const pluginRuntimeOwnerId =
     typeof options?.pluginRuntimeOwnerId === "string" && options.pluginRuntimeOwnerId.trim()
@@ -462,7 +474,7 @@ export async function dispatchGatewayMethodInProcessRaw(
       rejectFinalResponse?.(error);
     });
 
-  firstResponse = await waitForInProcessDispatch(method, firstResponsePromise, options?.timeoutMs);
+  firstResponse = await waitForInProcessDispatch(method, firstResponsePromise, deadlineMs);
   const firstPayload = firstResponse.payload as { status?: unknown } | undefined;
   if (options?.expectFinal !== true || firstPayload?.status !== "accepted") {
     return firstResponse;
@@ -474,32 +486,33 @@ export async function dispatchGatewayMethodInProcessRaw(
     finalResponse ??
     (await new Promise<GatewayMethodDispatchResponse>((resolve, reject) => {
       resolveFinalResponse = resolve;
-      rejectFinalResponse = reject;
-      const timeoutMs = resolveInProcessDispatchTimeoutMs(options.timeoutMs);
+      const timeoutMs = resolveRemainingInProcessDispatchTimeoutMs(deadlineMs);
       const timeout =
         timeoutMs === undefined
           ? undefined
           : setTimeout(() => {
               reject(new Error(`gateway request timeout for ${method}`));
             }, timeoutMs);
-      if (postFirstResponseError) {
+      const clearFinalTimeout = () => {
         if (timeout) {
           clearTimeout(timeout);
         }
-        reject(postFirstResponseError);
+      };
+      rejectFinalResponse = (err) => {
+        clearFinalTimeout();
+        reject(err);
+      };
+      if (postFirstResponseError) {
+        rejectFinalResponse(postFirstResponseError);
         return;
       }
       if (finalResponse) {
-        if (timeout) {
-          clearTimeout(timeout);
-        }
+        clearFinalTimeout();
         resolve(finalResponse);
         return;
       }
       resolveFinalResponse = (response) => {
-        if (timeout) {
-          clearTimeout(timeout);
-        }
+        clearFinalTimeout();
         resolve(response);
       };
     }));

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -91,6 +91,10 @@ function getFallbackGatewayContext(): GatewayRequestContext | undefined {
   return resolved ?? fallbackGatewayContextState.context;
 }
 
+export function hasInProcessGatewayContext(): boolean {
+  return Boolean(getPluginRuntimeGatewayRequestScope()?.context ?? getFallbackGatewayContext());
+}
+
 type PluginSubagentOverridePolicy = {
   allowModelOverride: boolean;
   allowAnyModel: boolean;
@@ -330,6 +334,38 @@ function unwrapGatewayMethodDispatchResponse(
   return response.payload;
 }
 
+function resolveInProcessDispatchTimeoutMs(timeoutMs?: number): number | undefined {
+  return typeof timeoutMs === "number" && Number.isFinite(timeoutMs)
+    ? resolveSafeTimeoutDelayMs(timeoutMs)
+    : undefined;
+}
+
+async function waitForInProcessDispatch<T>(
+  method: string,
+  promise: Promise<T>,
+  timeoutMs?: number,
+): Promise<T> {
+  const safeTimeoutMs = resolveInProcessDispatchTimeoutMs(timeoutMs);
+  if (safeTimeoutMs === undefined) {
+    return await promise;
+  }
+  let timeout: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_resolve, reject) => {
+        timeout = setTimeout(() => {
+          reject(new Error(`gateway request timeout for ${method}`));
+        }, safeTimeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  }
+}
+
 export async function dispatchGatewayMethodInProcessRaw(
   method: string,
   params: unknown,
@@ -351,7 +387,15 @@ export async function dispatchGatewayMethodInProcessRaw(
 
   let firstResponse: GatewayMethodDispatchResponse | undefined;
   let finalResponse: GatewayMethodDispatchResponse | undefined;
+  let resolveFirstResponse: ((response: GatewayMethodDispatchResponse) => void) | undefined;
+  let rejectFirstResponse: ((err: Error) => void) | undefined;
   let resolveFinalResponse: ((response: GatewayMethodDispatchResponse) => void) | undefined;
+  let rejectFinalResponse: ((err: Error) => void) | undefined;
+  let postFirstResponseError: Error | undefined;
+  const firstResponsePromise = new Promise<GatewayMethodDispatchResponse>((resolve, reject) => {
+    resolveFirstResponse = resolve;
+    rejectFirstResponse = reject;
+  });
   const { handleGatewayRequest } = await import("./server-methods.js");
   const pluginRuntimeOwnerId =
     typeof options?.pluginRuntimeOwnerId === "string" && options.pluginRuntimeOwnerId.trim()
@@ -375,7 +419,7 @@ export async function dispatchGatewayMethodInProcessRaw(
   if (options?.disableSyntheticClient === true && !scopedClient) {
     throw new Error(`In-process gateway dispatch requires a scoped client (method: ${method}).`);
   }
-  await handleGatewayRequest({
+  void handleGatewayRequest({
     req: {
       type: "req",
       id: `plugin-subagent-${randomUUID()}`,
@@ -391,6 +435,7 @@ export async function dispatchGatewayMethodInProcessRaw(
       const response = { ok, payload, error, ...(meta ? { meta } : {}) };
       if (!firstResponse) {
         firstResponse = response;
+        resolveFirstResponse?.(response);
         return;
       }
       if (!finalResponse) {
@@ -399,29 +444,51 @@ export async function dispatchGatewayMethodInProcessRaw(
       }
     },
     context,
-  });
+  })
+    .then(() => {
+      if (!firstResponse) {
+        rejectFirstResponse?.(
+          new Error(`Gateway method "${method}" completed without a response.`),
+        );
+      }
+    })
+    .catch((err: unknown) => {
+      const error = err instanceof Error ? err : new Error(String(err));
+      if (!firstResponse) {
+        rejectFirstResponse?.(error);
+        return;
+      }
+      postFirstResponseError = error;
+      rejectFinalResponse?.(error);
+    });
 
-  if (!firstResponse) {
-    throw new Error(`Gateway method "${method}" completed without a response.`);
-  }
+  firstResponse = await waitForInProcessDispatch(method, firstResponsePromise, options?.timeoutMs);
   const firstPayload = firstResponse.payload as { status?: unknown } | undefined;
   if (options?.expectFinal !== true || firstPayload?.status !== "accepted") {
     return firstResponse;
+  }
+  if (postFirstResponseError) {
+    throw postFirstResponseError;
   }
   const final =
     finalResponse ??
     (await new Promise<GatewayMethodDispatchResponse>((resolve, reject) => {
       resolveFinalResponse = resolve;
-      const timeoutMs =
-        typeof options.timeoutMs === "number" && Number.isFinite(options.timeoutMs)
-          ? resolveSafeTimeoutDelayMs(options.timeoutMs)
-          : undefined;
+      rejectFinalResponse = reject;
+      const timeoutMs = resolveInProcessDispatchTimeoutMs(options.timeoutMs);
       const timeout =
         timeoutMs === undefined
           ? undefined
           : setTimeout(() => {
               reject(new Error(`gateway request timeout for ${method}`));
             }, timeoutMs);
+      if (postFirstResponseError) {
+        if (timeout) {
+          clearTimeout(timeout);
+        }
+        reject(postFirstResponseError);
+        return;
+      }
       if (finalResponse) {
         if (timeout) {
           clearTimeout(timeout);


### PR DESCRIPTION
## Summary

Route `sessions_spawn`'s internal gateway RPC through in-process dispatch when the caller is already running inside the gateway process.

## Background

A Feishu-delivered profiling request exposed a `sessions_spawn` timeout while several agent runs were active in the same gateway process. The observed failure was not a Feishu delivery problem: the message send path eventually returned a successful message id. The failing path was the subagent spawn control plane: `sessions_spawn` called back into the same gateway over `ws://127.0.0.1:<port>`, while the gateway event loop was saturated by active agent work. That self-connection pattern can delay the WebSocket handshake and the timeout timer itself, so a configured 60s timeout can surface much later.

Announce delivery already avoids this class of failure by dispatching the gateway method in process. This PR applies the same ownership boundary to subagent spawn's internal gateway calls.

## What changed

- Added `hasInProcessGatewayContext()` so callers can detect whether in-process gateway dispatch is available.
- Changed `callSubagentGateway()` to use `dispatchGatewayMethodInProcess()` when a gateway context exists, avoiding loopback WebSocket self-connections for in-process `sessions_spawn` work.
- Preserved fallback behavior: outside the gateway process, subagent spawn still uses the existing `callGateway()` WebSocket path.
- Preserved method scopes: admin-only lifecycle calls such as `sessions.delete` and `sessions.patch` force a synthetic admin client, while ordinary `agent` calls keep the normal write-scoped behavior.
- Tightened in-process dispatch timeout behavior so `timeoutMs` bounds the initial response wait, while accepted/final two-phase calls still return the initial accepted response immediately when `expectFinal` is not requested and wait for final only when it is requested.

## What this does not do

- It does not solve all event-loop starvation. Heavy context assembly, streaming processing, or other CPU-heavy work can still delay unrelated timers and I/O.
- It does not change model streaming, compaction, or worker-thread behavior.
- It does not change Feishu/message delivery behavior; the reported missing message was determined to be a timing misunderstanding rather than a delivery failure.
- It does not add a live high-concurrency reproduction harness. Coverage here is focused on the dispatch contract and timeout/scope regressions that caused the spawn path to be fragile.

## Verification

- `node scripts/run-vitest.mjs src/agents/subagent-spawn.test.ts src/gateway/server-plugins.test.ts`
- `pnpm run tsgo:core`
- `pnpm run tsgo:test:src`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode commit --commit HEAD --prompt "Review the final rebased sessions_spawn in-process dispatch commit. Focus on gateway scope preservation, timeout semantics, fallback behavior, and subagent cleanup."`

## Real behavior proof

Behavior addressed: `sessions_spawn` no longer self-connects to the local gateway WebSocket when it is already executing inside the gateway process.

Real environment tested: Local OpenClaw source checkout on macOS, rebased onto current `upstream/main`.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/subagent-spawn.test.ts src/gateway/server-plugins.test.ts`; `pnpm run tsgo:core`; `pnpm run tsgo:test:src`; `git diff --check`; final autoreview command listed above.

Evidence after fix: The targeted Vitest run passed 2 shards covering `src/gateway/server-plugins.test.ts` and `src/agents/subagent-spawn.test.ts`; `tsgo:core` and `tsgo:test:src` completed successfully; final autoreview reported no accepted/actionable findings.

Observed result after fix: In-process subagent spawn calls dispatch through `dispatchGatewayMethodInProcess`; admin cleanup calls retain synthetic admin scope; initial in-process responses time out if no response is sent, but accepted two-phase responses still return before handler completion unless final output is requested.

What was not tested: A live saturated-gateway repro with multiple concurrent real model streams and Feishu/Telegram delivery was not run in this PR.
