### PR TITLE
fix(agents): propagate ADC credential marker so google-vertex passes isWritableProviderConfig

### DIFF
--- a/src/agents/models-config.applies-config-env-vars.test.ts
+++ b/src/agents/models-config.applies-config-env-vars.test.ts
@@ -495,6 +495,62 @@ describe("models-config", () => {
     }
   });
 
+  it("keeps google-vertex rows and injects gcp-vertex-credentials marker when ADC is configured", async () => {
+    // Regression test for #90506: ADC auth evidence has source "gcloud adc", not "env: VAR".
+    // resolveEnvApiKeyVarName discards it, leaving apiKey undefined so isWritableProviderConfig
+    // filters the provider out of models.json. The fix: fall back to resolveEnvApiKey directly.
+    const adcDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gcp-adc-"));
+    const adcFile = path.join(adcDir, "application_default_credentials.json");
+    try {
+      await fs.writeFile(adcFile, "{}");
+      const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-google-vertex-adc-"));
+      try {
+        const plan = await planOpenClawModelsJsonWithDeps(
+          {
+            cfg: {
+              agents: {
+                defaults: {
+                  models: { "google-vertex/gemini-2.5-pro": {} },
+                  model: { primary: "google-vertex/gemini-2.5-pro" },
+                },
+              },
+              models: { providers: {} },
+            },
+            agentDir,
+            env: {
+              GOOGLE_APPLICATION_CREDENTIALS: adcFile,
+              GOOGLE_CLOUD_PROJECT: "my-test-project",
+              GOOGLE_CLOUD_LOCATION: "us-central1",
+            },
+            existingRaw: "",
+            existingParsed: null,
+          },
+          {
+            resolveImplicitProviders: async () => ({
+              "google-vertex": createImplicitGoogleVertexProvider(),
+            }),
+          },
+        );
+
+        expect(plan.action).toBe("write");
+        if (plan.action !== "write") {
+          throw new Error("Expected models.json write plan");
+        }
+        const parsed = JSON.parse(plan.contents) as {
+          providers?: Record<string, { apiKey?: string; models?: Array<{ id?: string }> }>;
+        };
+        expect(parsed.providers?.["google-vertex"]?.apiKey).toBe("gcp-vertex-credentials");
+        expect(parsed.providers?.["google-vertex"]?.models?.map((m) => m.id)).toEqual([
+          "gemini-2.5-pro",
+        ]);
+      } finally {
+        await fs.rm(agentDir, { recursive: true, force: true });
+      }
+    } finally {
+      await fs.rm(adcDir, { recursive: true, force: true });
+    }
+  });
+
   it("uses config env.vars entries for implicit provider discovery without mutating process.env", async () => {
     await withTempEnv(["OPENROUTER_API_KEY", TEST_ENV_VAR], async () => {
       unsetEnv(["OPENROUTER_API_KEY", TEST_ENV_VAR]);

--- a/src/agents/models-config.providers.secret-helpers.ts
+++ b/src/agents/models-config.providers.secret-helpers.ts
@@ -333,7 +333,10 @@ export function resolveMissingProviderApiKey(params: {
     };
   }
 
-  const fromEnv = resolveEnvApiKeyVarName(params.providerKey, params.env);
+  const fromEnvVarName = resolveEnvApiKeyVarName(params.providerKey, params.env);
+  // resolveEnvApiKeyVarName drops non-env-var markers (e.g. "gcp-vertex-credentials" whose source
+  // is "gcloud adc"). Fall back to the raw resolved value so ADC providers pass isWritableProviderConfig.
+  const fromEnv = fromEnvVarName ?? resolveEnvApiKey(params.providerKey, params.env)?.apiKey;
   const apiKey = fromEnv ?? params.profileApiKey?.apiKey;
   if (!apiKey?.trim()) {
     return params.provider;


### PR DESCRIPTION
### Summary

- **Problem**: Google Vertex ADC-backed models (`google-vertex/gemini-3-flash-preview`, `google-vertex/gemini-2.5-flash`) produce `model_not_found` for every agent turn since v2026.5.28; v2026.5.26 was the last-good release.
- **Root Cause**: `51b5f75b92` (refactor: move plugin model catalogs into plugin state, merged between v2026.5.26 and v2026.5.28) added `filterWritableProviders` to `planOpenClawModelsJson`, which calls `isWritableProviderConfig` and requires `baseUrl && apiKey` for any provider with model rows. Before that refactor, providers were written to models.json regardless of whether `apiKey` was set. The latent gap exposed by the new filter: `resolveMissingProviderApiKey` calls `resolveEnvApiKeyVarName` to fill a missing `apiKey`, but that helper discards any result whose `source` is not `"env: VAR"` or `"shell env: VAR"`. Google Vertex ADC auth evidence (`GOOGLE_APPLICATION_CREDENTIALS` + project/location env) resolves with `source: "gcloud adc"`, which fails the regex. `resolveEnvApiKeyVarName` returns `undefined`, `fromEnv` falls through to `undefined`, and `isWritableProviderConfig` filters the provider out of models.json entirely.
- **Fix**: In `resolveMissingProviderApiKey`, add `?? resolveEnvApiKey(params.providerKey, params.env)?.apiKey` after `resolveEnvApiKeyVarName`. When `resolveEnvApiKeyVarName` returns `undefined` because the source is a non-env-var marker (e.g. `"gcloud adc"`), the fallback call returns the credential marker (`gcp-vertex-credentials`) directly. The `??` short-circuits for normal env-var providers so there is no second call on the fast path. No secret leakage risk: the ADC path returns a non-secret credential marker, not a raw key value.
- **What changed**:
  - `src/agents/models-config.providers.secret-helpers.ts` — fall back to `resolveEnvApiKey` when `resolveEnvApiKeyVarName` returns `undefined`, preserving non-env-var auth evidence markers (e.g. `gcp-vertex-credentials`) in `fromEnv`.
  - `src/agents/models-config.applies-config-env-vars.test.ts` — regression test: ADC env (`GOOGLE_APPLICATION_CREDENTIALS` pointing to a real temp file, `GOOGLE_CLOUD_PROJECT`, `GOOGLE_CLOUD_LOCATION`) produces a `write` plan with `apiKey: "gcp-vertex-credentials"` and model rows intact.
- **What did NOT change (scope boundary)**:
  - `isWritableProviderConfig` and `filterWritableProviders` are unchanged; the fix satisfies the existing check rather than relaxing it.
  - `secretRefManagedProviders` tracking is unchanged; ADC providers correctly remain outside the set (no profile key, non-secret marker).
  - Config surface unchanged (no schema, defaults, doctor migrations, or `docs/reference/config`).
  - Plugin surface unchanged (no plugin SDK, manifest, `extensions/*` api/runtime-api, registry/loader).

### Reproduction

1. Configure `google-vertex` as the default provider using ADC: set `GOOGLE_APPLICATION_CREDENTIALS`, `GOOGLE_CLOUD_PROJECT`, and `GOOGLE_CLOUD_LOCATION`; no explicit `apiKey` under `models.providers.google-vertex` in `openclaw.json`.
2. Start the gateway and run any agent turn targeting a `google-vertex` model.
3. **Before this PR**: `resolveMissingProviderApiKey` drops the ADC credential marker; `isWritableProviderConfig` filters `google-vertex` from models.json; every turn fails with `model_not_found`.
4. **After this PR**: ADC marker propagated to `apiKey: "gcp-vertex-credentials"`; `isWritableProviderConfig` passes; provider and catalog models written to models.json; Vertex turns succeed.

### Real behavior proof

**Behavior addressed (#90506)**: Google Vertex ADC-backed models resolve as `model_not_found` since v2026.5.28 (regression from v2026.5.26). Source-level root cause confirmed: `filterWritableProviders` in `51b5f75b92` exposes a pre-existing gap where `resolveEnvApiKeyVarName` discards ADC credential markers.

**Real environment tested (Linux, Node 22 — Vitest against the full production normalization path including `hasLocalFileAuthEvidence` `fs.existsSync`, manifest-backed `authEvidenceMap`, and `planOpenClawModelsJsonWithDeps`)**: `GOOGLE_APPLICATION_CREDENTIALS` pointing to a real temp file, `GOOGLE_CLOUD_PROJECT`, and `GOOGLE_CLOUD_LOCATION` set; no explicit provider `apiKey` in config; `resolveImplicitProviders` injected with a static `google-vertex` catalog.

**Exact steps or command run after this patch**: `node scripts/run-vitest.mjs src/agents/models-config.applies-config-env-vars.test.ts` — 13/13 pass including the new regression case.

**Evidence after fix**:

```text
✓ keeps google-vertex rows and injects gcp-vertex-credentials marker when ADC is configured
Tests  13 passed (13)
```

`providers["google-vertex"].apiKey === "gcp-vertex-credentials"` and model rows present in the written plan; `plan.action === "write"`.

**Observed result after fix**: `resolveMissingProviderApiKey` returns the provider with `apiKey: "gcp-vertex-credentials"`; `isWritableProviderConfig` returns `true`; the provider and its catalog models are written to models.json; ADC-backed Vertex turns no longer produce `model_not_found`.

**What was not tested**: live ADC Vertex turn in a managed gateway. The `hasLocalFileAuthEvidence` `fs.existsSync` check and the full manifest-backed auth evidence resolution path are covered by the regression test; a full managed-gateway round-trip was not driven.

**Repro confirmation**: the new test fails on the unfixed tree (`plan.action === "skip"` or `apiKey` absent) and passes with the fix, confirming the test covers the production change.

### Risk / Mitigation

- **Risk**: a second `resolveEnvApiKey` call on the fallback path adds overhead. **Mitigation**: the `??` operator short-circuits when `resolveEnvApiKeyVarName` already returned a value, so the second call only fires when `fromEnvVarName` is `undefined`; for normal env-var providers the fast path is unchanged.
- **Risk**: non-env-var markers other than `gcp-vertex-credentials` could be injected unexpectedly. **Mitigation**: `resolveEnvApiKey` only returns values sourced from env candidates, manifest auth evidence entries, or `resolveConfigApiKey` plugin hooks — all of which are pre-declared, non-secret markers. No raw credential values are returned on this path.

### Change Type (select all)

- [x] Bug fix (non-breaking change which fixes an issue)

### Scope (select all touched areas)

- [x] Agent runtime / model routing

### Linked Issue/PR

Fixes #90506