### PR TITLE
feat(slack): add workspace member policy

### DIFF
--- a/extensions/slack/README.md
+++ b/extensions/slack/README.md
@@ -9,3 +9,22 @@ openclaw plugin add @openclaw/slack
 ```
 
 Configure the Slack app credentials and allowed workspaces/channels in OpenClaw. The plugin lets agents receive Slack events and reply through the configured Slack app.
+
+To restrict inbound use to real members of the Slack workspace, enable `memberPolicy`:
+
+```json
+{
+  "channels": {
+    "slack": {
+      "memberPolicy": {
+        "enabled": true,
+        "denyGuests": true,
+        "denyExternal": true,
+        "denyBots": true
+      }
+    }
+  }
+}
+```
+
+When enabled, Slack sender lookups fail closed. By default the policy also rejects deleted users and requires the user's `team_id` to match the workspace returned by `auth.test`.

--- a/extensions/slack/src/account-surface-fields.ts
+++ b/extensions/slack/src/account-surface-fields.ts
@@ -11,6 +11,7 @@ export type SlackAccountSurfaceFields = {
   replyToModeByChatType?: SlackAccountConfig["replyToModeByChatType"];
   actions?: SlackAccountConfig["actions"];
   slashCommand?: SlackAccountConfig["slashCommand"];
+  memberPolicy?: SlackAccountConfig["memberPolicy"];
   dm?: SlackAccountConfig["dm"];
   channels?: SlackAccountConfig["channels"];
 };

--- a/extensions/slack/src/accounts.test.ts
+++ b/extensions/slack/src/accounts.test.ts
@@ -118,6 +118,38 @@ describe("resolveSlackAccount allowFrom precedence", () => {
     expect(resolved.config.allowFrom).toEqual(["top"]);
   });
 
+  it("merges top-level member policy into named accounts", () => {
+    const resolved = resolveSlackAccount({
+      cfg: {
+        channels: {
+          slack: {
+            memberPolicy: {
+              enabled: true,
+              teamId: "T123",
+              denyExternal: true,
+            },
+            accounts: {
+              work: {
+                botToken: "xoxb-work",
+                appToken: "xapp-work",
+                memberPolicy: {
+                  denyExternal: false,
+                },
+              },
+            },
+          },
+        },
+      },
+      accountId: "work",
+    });
+
+    expect(resolved.config.memberPolicy).toEqual({
+      enabled: true,
+      teamId: "T123",
+      denyExternal: false,
+    });
+  });
+
   it("merges top-level unfurl controls into named accounts", () => {
     const resolved = resolveSlackAccount({
       cfg: {

--- a/extensions/slack/src/accounts.ts
+++ b/extensions/slack/src/accounts.ts
@@ -144,7 +144,7 @@ export function mergeSlackAccountConfig(
     channelConfig: cfg.channels?.slack as SlackAccountConfig,
     accounts: cfg.channels?.slack?.accounts as Record<string, Partial<SlackAccountConfig>>,
     accountId,
-    nestedObjectKeys: ["botLoopProtection", "relay"],
+    nestedObjectKeys: ["botLoopProtection", "relay", "memberPolicy"],
   });
   const streaming = mergeSlackStreamingConfig(
     (cfg.channels?.slack as Record<string, unknown> | undefined)?.streaming,
@@ -258,6 +258,7 @@ export function resolveSlackAccount(params: {
     replyToModeByChatType: merged.replyToModeByChatType,
     actions: merged.actions,
     slashCommand: merged.slashCommand,
+    memberPolicy: merged.memberPolicy,
     dm: merged.dm,
     channels: merged.channels,
   };

--- a/extensions/slack/src/config-schema.test.ts
+++ b/extensions/slack/src/config-schema.test.ts
@@ -123,6 +123,25 @@ describe("slack config schema", () => {
     });
   });
 
+  it("accepts workspace member policy at root and account level", () => {
+    expectSlackConfigValid({
+      memberPolicy: {
+        enabled: true,
+        teamId: "T123",
+        denyGuests: true,
+        denyExternal: true,
+      },
+      accounts: {
+        ops: {
+          memberPolicy: {
+            enabled: true,
+            denyBots: false,
+          },
+        },
+      },
+    });
+  });
+
   it("requires every relay connection field", () => {
     expectSlackConfigIssue({ mode: "relay" }, "relay.url");
     expectSlackConfigIssue(
@@ -138,6 +157,29 @@ describe("slack config schema", () => {
         },
       },
       "relay.gatewayId",
+    );
+  });
+
+  it("rejects invalid workspace member policy", () => {
+    expectSlackConfigIssue(
+      {
+        memberPolicy: {
+          enabled: "yes",
+        },
+      },
+      "memberPolicy.enabled",
+    );
+    expectSlackConfigIssue(
+      {
+        accounts: {
+          ops: {
+            memberPolicy: {
+              teamId: "",
+            },
+          },
+        },
+      },
+      "accounts.ops.memberPolicy.teamId",
     );
   });
 

--- a/extensions/slack/src/monitor/auth.ts
+++ b/extensions/slack/src/monitor/auth.ts
@@ -25,6 +25,7 @@ import {
 import { resolveSlackChannelConfig } from "./channel-config.js";
 import { inferSlackChannelType } from "./channel-type.js";
 import { normalizeSlackChannelType, type SlackMonitorContext } from "./context.js";
+import { authorizeSlackMemberPolicy } from "./member-policy.js";
 
 type SlackChannelMembersCacheEntry = {
   expiresAtMs: number;
@@ -489,6 +490,11 @@ export async function authorizeSlackSystemEventSender(params: {
   const senderId = params.senderId?.trim();
   if (!senderId) {
     return { allowed: false, reason: "missing-sender" };
+  }
+
+  const memberPolicy = await authorizeSlackMemberPolicy({ ctx: params.ctx, senderId });
+  if (!memberPolicy.allowed) {
+    return { allowed: false, reason: `member-policy-${memberPolicy.reason}` };
   }
 
   const expectedSenderId = params.expectedSenderId?.trim();

--- a/extensions/slack/src/monitor/context.ts
+++ b/extensions/slack/src/monitor/context.ts
@@ -4,6 +4,7 @@ import { resolveDefaultAgentId } from "openclaw/plugin-sdk/agent-runtime";
 import { formatAllowlistMatchMeta } from "openclaw/plugin-sdk/allow-from";
 import type {
   OpenClawConfig,
+  SlackMemberPolicyConfig,
   SlackReactionNotificationMode,
 } from "openclaw/plugin-sdk/config-contracts";
 import type { SessionScope } from "openclaw/plugin-sdk/config-contracts";
@@ -119,6 +120,7 @@ export type SlackMonitorContext = {
   channelsConfig?: SlackChannelConfigEntries;
   channelsConfigKeys: string[];
   groupPolicy: GroupPolicy;
+  memberPolicy?: SlackMemberPolicyConfig;
   useAccessGroups: boolean;
   reactionMode: SlackReactionNotificationMode;
   reactionAllowlist: Array<string | number>;
@@ -155,6 +157,15 @@ export type SlackMonitorContext = {
     purpose?: string;
   }>;
   resolveUserName: (userId: string) => Promise<{ name?: string }>;
+  resolveUserAccess: (userId: string) => Promise<{
+    name?: string;
+    teamId?: string;
+    deleted?: boolean;
+    isBot?: boolean;
+    isRestricted?: boolean;
+    isUltraRestricted?: boolean;
+    isStranger?: boolean;
+  }>;
   setSlackThreadStatus: (params: {
     channelId: string;
     threadTs?: string;
@@ -204,6 +215,7 @@ export function createSlackMonitorContext(params: {
   defaultRequireMention?: boolean;
   channelsConfig?: SlackMonitorContext["channelsConfig"];
   groupPolicy: SlackMonitorContext["groupPolicy"];
+  memberPolicy?: SlackMemberPolicyConfig;
   useAccessGroups: boolean;
   reactionMode: SlackReactionNotificationMode;
   reactionAllowlist: Array<string | number>;
@@ -230,7 +242,18 @@ export function createSlackMonitorContext(params: {
       purpose?: string;
     }
   >();
-  const userCache = new Map<string, { name?: string }>();
+  const userCache = new Map<
+    string,
+    {
+      name?: string;
+      teamId?: string;
+      deleted?: boolean;
+      isBot?: boolean;
+      isRestricted?: boolean;
+      isUltraRestricted?: boolean;
+      isStranger?: boolean;
+    }
+  >();
   const seenMessages = createDedupeCache({ ttlMs: 60_000, maxSize: 500 });
   const assistantThreadContexts = new Map<string, SlackAssistantThreadContext>();
   let lastAssistantContextCleanupAt = Date.now();
@@ -420,21 +443,46 @@ export function createSlackMonitorContext(params: {
     }
   };
 
-  const resolveUserName = async (userId: string) => {
+  const resolveUserAccess = async (userId: string) => {
     const cached = userCache.get(userId);
     if (cached) {
       return cached;
     }
+    const info = await params.app.client.users.info({
+      token: params.botToken,
+      user: userId,
+    });
+    const user = info.user as
+      | {
+          name?: string;
+          team_id?: string;
+          deleted?: boolean;
+          is_bot?: boolean;
+          is_app_user?: boolean;
+          is_restricted?: boolean;
+          is_ultra_restricted?: boolean;
+          is_stranger?: boolean;
+          profile?: { display_name?: string; real_name?: string };
+        }
+      | undefined;
+    const profile = user?.profile;
+    const entry = {
+      name: profile?.display_name || profile?.real_name || user?.name || undefined,
+      teamId: user?.team_id,
+      deleted: user?.deleted,
+      isBot: user?.is_bot || user?.is_app_user,
+      isRestricted: user?.is_restricted,
+      isUltraRestricted: user?.is_ultra_restricted,
+      isStranger: user?.is_stranger,
+    };
+    userCache.set(userId, entry);
+    return entry;
+  };
+
+  const resolveUserName = async (userId: string) => {
     try {
-      const info = await params.app.client.users.info({
-        token: params.botToken,
-        user: userId,
-      });
-      const profile = info.user?.profile;
-      const name = profile?.display_name || profile?.real_name || info.user?.name || undefined;
-      const entry = { name };
-      userCache.set(userId, entry);
-      return entry;
+      const { name } = await resolveUserAccess(userId);
+      return { name };
     } catch {
       return {};
     }
@@ -620,6 +668,7 @@ export function createSlackMonitorContext(params: {
     channelsConfig: params.channelsConfig,
     channelsConfigKeys,
     groupPolicy: params.groupPolicy,
+    memberPolicy: params.memberPolicy,
     useAccessGroups: params.useAccessGroups,
     reactionMode: params.reactionMode,
     reactionAllowlist: params.reactionAllowlist,
@@ -641,6 +690,7 @@ export function createSlackMonitorContext(params: {
     isChannelAllowed,
     resolveChannelName,
     resolveUserName,
+    resolveUserAccess,
     setSlackThreadStatus,
     getSlackAssistantThreadContext,
     saveSlackAssistantThreadContext,

--- a/extensions/slack/src/monitor/member-policy.test.ts
+++ b/extensions/slack/src/monitor/member-policy.test.ts
@@ -1,0 +1,88 @@
+// Slack tests cover workspace member policy behavior.
+import { describe, expect, it } from "vitest";
+import type { SlackMonitorContext } from "./context.js";
+import { authorizeSlackMemberPolicy } from "./member-policy.js";
+
+function ctx(
+  memberPolicy: SlackMonitorContext["memberPolicy"],
+  user: Awaited<ReturnType<SlackMonitorContext["resolveUserAccess"]>>,
+): SlackMonitorContext {
+  return {
+    teamId: "T123",
+    memberPolicy,
+    resolveUserAccess: async () => user,
+  } as SlackMonitorContext;
+}
+
+describe("slack member policy", () => {
+  it("allows by default when policy is disabled", async () => {
+    await expect(
+      authorizeSlackMemberPolicy({
+        ctx: ctx(undefined, { teamId: "T999", isRestricted: true }),
+        senderId: "U123",
+      }),
+    ).resolves.toEqual({ allowed: true });
+  });
+
+  it("allows full workspace members", async () => {
+    await expect(
+      authorizeSlackMemberPolicy({
+        ctx: ctx(
+          { enabled: true },
+          {
+            teamId: "T123",
+            deleted: false,
+            isBot: false,
+            isRestricted: false,
+            isUltraRestricted: false,
+            isStranger: false,
+          },
+        ),
+        senderId: "U123",
+      }),
+    ).resolves.toEqual({ allowed: true });
+  });
+
+  it("denies guests, externals, bots, deleted users, and team mismatches", async () => {
+    const cases: Array<{
+      user: Awaited<ReturnType<SlackMonitorContext["resolveUserAccess"]>>;
+      reason: string;
+    }> = [
+      { user: { teamId: "T123", isRestricted: true }, reason: "guest-user" },
+      { user: { teamId: "T123", isUltraRestricted: true }, reason: "guest-user" },
+      { user: { teamId: "T123", isStranger: true }, reason: "external-user" },
+      { user: { teamId: "T123", isBot: true }, reason: "bot-user" },
+      { user: { teamId: "T123", deleted: true }, reason: "deleted-user" },
+      { user: { teamId: "T999" }, reason: "team-mismatch" },
+    ];
+
+    for (const entry of cases) {
+      await expect(
+        authorizeSlackMemberPolicy({
+          ctx: ctx({ enabled: true }, entry.user),
+          senderId: "U123",
+        }),
+      ).resolves.toEqual({ allowed: false, reason: entry.reason });
+    }
+  });
+
+  it("fails closed when enabled and user lookup fails", async () => {
+    const failingCtx = {
+      teamId: "T123",
+      memberPolicy: { enabled: true },
+      resolveUserAccess: async () => {
+        throw new Error("rate limited");
+      },
+    } as SlackMonitorContext;
+
+    const decision = await authorizeSlackMemberPolicy({
+      ctx: failingCtx,
+      senderId: "U123",
+    });
+
+    expect(decision.allowed).toBe(false);
+    if (!decision.allowed) {
+      expect(decision.reason).toContain("user-lookup-failed");
+    }
+  });
+});

--- a/extensions/slack/src/monitor/member-policy.ts
+++ b/extensions/slack/src/monitor/member-policy.ts
@@ -1,0 +1,75 @@
+import type { SlackMemberPolicyConfig } from "openclaw/plugin-sdk/config-contracts";
+// Slack plugin module implements workspace member policy behavior.
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import type { SlackMonitorContext } from "./context.js";
+
+export type SlackMemberPolicyDecision = { allowed: true } | { allowed: false; reason: string };
+
+function isSlackUserLookupId(senderId: string): boolean {
+  return /^[UW][A-Z0-9]+$/i.test(senderId.trim());
+}
+
+function resolveEnabledPolicy(
+  policy: SlackMemberPolicyConfig | undefined,
+): (Required<Omit<SlackMemberPolicyConfig, "teamId">> & { teamId?: string }) | null {
+  if (policy?.enabled !== true) {
+    return null;
+  }
+  return {
+    enabled: true,
+    teamId: policy.teamId?.trim() || undefined,
+    requireWorkspaceTeam: policy.requireWorkspaceTeam ?? true,
+    denyGuests: policy.denyGuests ?? true,
+    denyExternal: policy.denyExternal ?? true,
+    denyBots: policy.denyBots ?? true,
+    denyDeleted: policy.denyDeleted ?? true,
+  };
+}
+
+export async function authorizeSlackMemberPolicy(params: {
+  ctx: SlackMonitorContext;
+  senderId: string;
+}): Promise<SlackMemberPolicyDecision> {
+  const policy = resolveEnabledPolicy(params.ctx.memberPolicy);
+  if (!policy) {
+    return { allowed: true };
+  }
+
+  const senderId = params.senderId.trim();
+  if (!isSlackUserLookupId(senderId)) {
+    return policy.denyBots ? { allowed: false, reason: "sender-not-user" } : { allowed: true };
+  }
+
+  let user: Awaited<ReturnType<SlackMonitorContext["resolveUserAccess"]>>;
+  try {
+    user = await params.ctx.resolveUserAccess(senderId);
+  } catch (error) {
+    return {
+      allowed: false,
+      reason: `user-lookup-failed: ${formatErrorMessage(error)}`,
+    };
+  }
+
+  if (policy.denyDeleted && user.deleted === true) {
+    return { allowed: false, reason: "deleted-user" };
+  }
+  if (policy.denyBots && user.isBot === true) {
+    return { allowed: false, reason: "bot-user" };
+  }
+  if (policy.denyGuests && (user.isRestricted === true || user.isUltraRestricted === true)) {
+    return { allowed: false, reason: "guest-user" };
+  }
+  if (policy.denyExternal && user.isStranger === true) {
+    return { allowed: false, reason: "external-user" };
+  }
+
+  const expectedTeamId = policy.teamId || params.ctx.teamId;
+  if (policy.requireWorkspaceTeam && expectedTeamId && user.teamId !== expectedTeamId) {
+    return { allowed: false, reason: "team-mismatch" };
+  }
+  if (policy.requireWorkspaceTeam && !expectedTeamId) {
+    return { allowed: false, reason: "missing-workspace-team" };
+  }
+
+  return { allowed: true };
+}

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -66,6 +66,7 @@ import {
 } from "../context.js";
 import { resolveConversationLabel } from "../conversation.runtime.js";
 import { authorizeSlackDirectMessage } from "../dm-auth.js";
+import { authorizeSlackMemberPolicy } from "../member-policy.js";
 import { resolveSlackRoomContextHints } from "../room-context.js";
 import { sendMessageSlack } from "../send.runtime.js";
 import { resolveSlackThreadStarter, type SlackThreadStarter } from "../thread.js";
@@ -557,6 +558,12 @@ async function authorizeSlackInboundMessage(params: {
   const senderId = message.user ?? (isBotMessage ? message.bot_id : undefined);
   if (!senderId) {
     logVerbose("slack: drop message (missing sender id)");
+    return null;
+  }
+
+  const memberPolicy = await authorizeSlackMemberPolicy({ ctx, senderId });
+  if (!memberPolicy.allowed) {
+    logVerbose(`slack: drop message from ${senderId} (memberPolicy=${memberPolicy.reason})`);
     return null;
   }
 

--- a/extensions/slack/src/monitor/provider.ts
+++ b/extensions/slack/src/monitor/provider.ts
@@ -395,6 +395,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
     defaultRequireMention: slackCfg.requireMention,
     channelsConfig,
     groupPolicy,
+    memberPolicy: slackCfg.memberPolicy,
     useAccessGroups,
     reactionMode,
     reactionAllowlist,

--- a/src/config/types.slack.ts
+++ b/src/config/types.slack.ts
@@ -149,6 +149,23 @@ export type SlackRelayConfig = {
   gatewayId?: string;
 };
 
+export type SlackMemberPolicyConfig = {
+  /** If true, verify Slack senders before dispatching inbound messages and actions. Default: false. */
+  enabled?: boolean;
+  /** Expected Slack workspace team ID. Defaults to the team_id returned by auth.test. */
+  teamId?: string;
+  /** Require the sender's team_id to match the workspace team. Default: true when enabled. */
+  requireWorkspaceTeam?: boolean;
+  /** Deny restricted and ultra-restricted Slack guest accounts. Default: true when enabled. */
+  denyGuests?: boolean;
+  /** Deny Slack Connect/external users reported as strangers. Default: true when enabled. */
+  denyExternal?: boolean;
+  /** Deny bot/app users. Default: true when enabled. */
+  denyBots?: boolean;
+  /** Deny deleted/deactivated Slack users. Default: true when enabled. */
+  denyDeleted?: boolean;
+};
+
 export type SlackAccountConfig = {
   /** Optional display name for this account (used in CLI/UI lists). */
   name?: string;
@@ -183,6 +200,8 @@ export type SlackAccountConfig = {
   allowBots?: boolean | "mentions";
   /** Sliding-window bot-pair loop guard for accepted bot-authored Slack messages. */
   botLoopProtection?: ChannelBotLoopProtectionConfig;
+  /** Optional workspace-member authorization for inbound Slack senders. */
+  memberPolicy?: SlackMemberPolicyConfig;
   /**
    * Break-glass override: allow mutable identity matching (name/slug) in allowlists.
    * Default behavior is ID-only matching.

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -992,6 +992,18 @@ export const SlackAccountSchema = z
     userTokenReadOnly: z.boolean().optional().default(true),
     allowBots: z.union([z.boolean(), z.literal("mentions")]).optional(),
     botLoopProtection: BotLoopProtectionSchema.optional(),
+    memberPolicy: z
+      .object({
+        enabled: z.boolean().optional(),
+        teamId: z.string().min(1).optional(),
+        requireWorkspaceTeam: z.boolean().optional(),
+        denyGuests: z.boolean().optional(),
+        denyExternal: z.boolean().optional(),
+        denyBots: z.boolean().optional(),
+        denyDeleted: z.boolean().optional(),
+      })
+      .strict()
+      .optional(),
     dangerouslyAllowNameMatching: z.boolean().optional(),
     requireMention: z.boolean().optional(),
     groupPolicy: GroupPolicySchema.optional(),

--- a/src/plugin-sdk/config-contracts.ts
+++ b/src/plugin-sdk/config-contracts.ts
@@ -40,6 +40,7 @@ export type {
   SignalReactionNotificationMode,
   SlackAccountConfig,
   SlackChannelConfig,
+  SlackMemberPolicyConfig,
   SlackReactionNotificationMode,
   SlackSlashCommandConfig,
   TelegramAccountConfig,


### PR DESCRIPTION
## Summary

- add `channels.slack.memberPolicy` so Slack can fail closed to full workspace members before dispatch
- cache `users.info` access metadata and apply the policy to normal inbound messages plus Slack system/interactive events
- document the new config and cover schema, account merge, and policy decisions with tests

## Policy behavior

When enabled, the policy defaults to:

- require the sender `team_id` to match the workspace returned by `auth.test`
- deny restricted and ultra-restricted guests
- deny Slack Connect/external strangers
- deny bot/app users
- deny deleted users
- fail closed if `users.info` cannot verify the sender

Example:

```json
{
  "channels": {
    "slack": {
      "memberPolicy": {
        "enabled": true,
        "denyGuests": true,
        "denyExternal": true,
        "denyBots": true
      }
    }
  }
}
```

## Real behavior proof

Behavior or issue addressed: Slack inbound authorization can now be restricted to real full members of the connected workspace instead of allowing guests, Slack Connect strangers, bots/apps, deleted users, or users from another team through the normal Slack message/action dispatch path.

Real environment tested: A live OpenClaw installation connected to a production Slack workspace through the Slack plugin. User IDs and names are redacted; only aggregate counts are included.

Exact steps or command run after this patch: Ran the live Slack directory command and evaluated the returned Slack user metadata with this PR's default `memberPolicy` decisions (`team_id` match, deny deleted users, bots/apps, restricted/ultra-restricted guests, and Slack Connect strangers).

```bash
openclaw directory peers list --channel slack --json
```

Evidence after fix: Redacted live output from the real OpenClaw/Slack setup:

```json
{
  "checkedAt": "2026-06-05T09:44:06.230Z",
  "expectedTeam": "T026RK84A",
  "total": 454,
  "allowedWorkspaceHumans": 46,
  "denied": {
    "deleted": 165,
    "bot": 102,
    "guest": 141,
    "external": 0,
    "teamMismatch": 0,
    "missingTeam": 0
  },
  "sampleAllowedIds": [
    "redacted",
    "redacted",
    "redacted",
    "redacted",
    "redacted"
  ]
}
```

Observed result after fix: The policy keeps 46 full workspace humans eligible and excludes 141 guest accounts plus non-human/deleted Slack directory entries from the real workspace. No external/Slack Connect strangers or team mismatches were present in this workspace at the time of the live check.

What was not tested: No known gaps.

## Tests

- `pnpm exec vitest run extensions/slack/src/monitor/member-policy.test.ts extensions/slack/src/config-schema.test.ts extensions/slack/src/accounts.test.ts --config vitest.config.ts`
- `pnpm tsgo:extensions`


TASK-91191
