### PR TITLE
fix(gateway): preserve node offloaded media transcripts

### DIFF
--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -92,6 +92,24 @@ function makeCliResult(text: string): EmbeddedAgentRunResult {
   };
 }
 
+function makeUserTurnTranscriptRecorder() {
+  return {
+    message: undefined,
+    resolveMessage: vi.fn(),
+    markRuntimePersistencePending: vi.fn(),
+    markRuntimePersisted: vi.fn(),
+    markBlocked: vi.fn(),
+    hasPersisted: vi.fn(() => false),
+    isBlocked: vi.fn(() => false),
+    hasRuntimePersistencePending: vi.fn(() => false),
+    waitForRuntimePersistence: vi.fn(async () => {}),
+    persistApproved: vi.fn(async () => undefined),
+    persistFallback: vi.fn(async () => undefined),
+  } satisfies NonNullable<
+    Parameters<typeof runAgentAttempt>[0]["opts"]["userTurnTranscriptRecorder"]
+  >;
+}
+
 async function readSessionMessages(sessionFile: string) {
   return (await readSessionFileJsonLines<{ type?: string; message?: unknown }>(sessionFile))
     .filter((entry) => entry.type === "message")
@@ -1319,6 +1337,102 @@ describe("CLI attempt execution", () => {
       provider: "openai",
       model: "gpt-5.4",
     });
+  });
+
+  it("forwards prepared user-turn transcript recorders to embedded runs", async () => {
+    const sessionKey = "agent:main:direct:prepared-user-turn";
+    const sessionEntry: SessionEntry = {
+      sessionId: "openclaw-session-prepared-user-turn",
+      updatedAt: Date.now(),
+    };
+    const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
+    const userTurnTranscriptRecorder = makeUserTurnTranscriptRecorder();
+    runEmbeddedAgentMock.mockResolvedValueOnce({
+      meta: { durationMs: 1, executionTrace: { runner: "embedded" } },
+    } satisfies EmbeddedAgentRunResult);
+
+    await runAgentAttempt({
+      providerOverride: "openai",
+      originalProvider: "openai",
+      modelOverride: "gpt-5.4",
+      cfg: {} as OpenClawConfig,
+      sessionEntry,
+      sessionId: sessionEntry.sessionId,
+      sessionKey,
+      sessionAgentId: "main",
+      sessionFile: path.join(tmpDir, "session.jsonl"),
+      workspaceDir: tmpDir,
+      body: "use prepared transcript media",
+      isFallbackRetry: false,
+      resolvedThinkLevel: "medium",
+      timeoutMs: 1_000,
+      runId: "run-prepared-user-turn",
+      opts: {
+        message: "use prepared transcript media",
+        userTurnTranscriptRecorder,
+      } as Parameters<typeof runAgentAttempt>[0]["opts"],
+      runContext: {} as Parameters<typeof runAgentAttempt>[0]["runContext"],
+      spawnedBy: undefined,
+      messageChannel: "node",
+      skillsSnapshot: undefined,
+      resolvedVerboseLevel: undefined,
+      agentDir: tmpDir,
+      onAgentEvent: vi.fn(),
+      authProfileProvider: "openai",
+      sessionStore,
+      storePath,
+      sessionHasHistory: false,
+    });
+
+    expect(runCliAgentMock).not.toHaveBeenCalled();
+    expect(firstEmbeddedAgentArg().userTurnTranscriptRecorder).toBe(userTurnTranscriptRecorder);
+  });
+
+  it("forwards prepared user-turn transcript recorders to CLI runs", async () => {
+    const sessionKey = "agent:main:direct:prepared-user-turn-cli";
+    const sessionEntry: SessionEntry = {
+      sessionId: "openclaw-session-prepared-user-turn-cli",
+      updatedAt: Date.now(),
+    };
+    const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
+    const userTurnTranscriptRecorder = makeUserTurnTranscriptRecorder();
+    runCliAgentMock.mockResolvedValueOnce(makeCliResult("prepared cli response"));
+
+    await runAgentAttempt({
+      providerOverride: "claude-cli",
+      originalProvider: "claude-cli",
+      modelOverride: "opus",
+      cfg: {} as OpenClawConfig,
+      sessionEntry,
+      sessionId: sessionEntry.sessionId,
+      sessionKey,
+      sessionAgentId: "main",
+      sessionFile: path.join(tmpDir, "session.jsonl"),
+      workspaceDir: tmpDir,
+      body: "use prepared transcript media",
+      isFallbackRetry: false,
+      resolvedThinkLevel: "medium",
+      timeoutMs: 1_000,
+      runId: "run-prepared-user-turn-cli",
+      opts: {
+        message: "use prepared transcript media",
+        userTurnTranscriptRecorder,
+      } as Parameters<typeof runAgentAttempt>[0]["opts"],
+      runContext: {} as Parameters<typeof runAgentAttempt>[0]["runContext"],
+      spawnedBy: undefined,
+      messageChannel: "node",
+      skillsSnapshot: undefined,
+      resolvedVerboseLevel: undefined,
+      agentDir: tmpDir,
+      onAgentEvent: vi.fn(),
+      authProfileProvider: "claude-cli",
+      sessionStore,
+      storePath,
+      sessionHasHistory: false,
+    });
+
+    expect(runEmbeddedAgentMock).not.toHaveBeenCalled();
+    expect(firstRunCliAgentArg().userTurnTranscriptRecorder).toBe(userTurnTranscriptRecorder);
   });
 
   it("forwards user-pinned OpenAI API-key backup profiles to Codex harness runs", async () => {

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -579,6 +579,7 @@ export function runAgentAttempt(params: {
         runId: params.runId,
         extraSystemPrompt: params.opts.extraSystemPrompt,
         inputProvenance: params.opts.inputProvenance,
+        userTurnTranscriptRecorder: params.opts.userTurnTranscriptRecorder,
         cliSessionId: nextCliSessionId,
         cliSessionBinding:
           nextCliSessionId === activeCliSessionBinding?.sessionId
@@ -697,6 +698,7 @@ export function runAgentAttempt(params: {
     toolsAllow: params.opts.toolsAllow,
     internalEvents: params.opts.internalEvents,
     inputProvenance: params.opts.inputProvenance,
+    userTurnTranscriptRecorder: params.opts.userTurnTranscriptRecorder,
     sourceReplyDeliveryMode: params.opts.sourceReplyDeliveryMode,
     disableMessageTool: params.opts.disableMessageTool,
     streamParams: params.opts.streamParams,

--- a/src/agents/command/types.ts
+++ b/src/agents/command/types.ts
@@ -8,6 +8,7 @@ import type { SourceReplyDeliveryMode } from "../../auto-reply/get-reply-options
 import type { ChannelOutboundTargetMode } from "../../channels/plugins/types.public.js";
 import type { PromptImageOrderEntry } from "../../media/prompt-image-order.js";
 import type { InputProvenance } from "../../sessions/input-provenance.js";
+import type { UserTurnTranscriptRecorder } from "../../sessions/user-turn-transcript.js";
 import type { ExecElevatedDefaults } from "../bash-tools.exec-types.js";
 import type { AgentStreamParams, ClientToolDefinition } from "./shared-types.js";
 
@@ -114,6 +115,8 @@ export type AgentCommandOpts = {
   bootstrapContextRunKind?: "default" | "heartbeat" | "cron";
   internalEvents?: AgentInternalEvent[];
   inputProvenance?: InputProvenance;
+  /** Prepared user-turn transcript persistence for caller-owned text/media metadata. */
+  userTurnTranscriptRecorder?: UserTurnTranscriptRecorder;
   /** Internal runs can execute against a session without updating visible status/model/usage. */
   sessionEffects?: "visible" | "internal";
   /** Internal handoffs can write transcript turns without changing user-facing model/usage state. */

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -1094,7 +1094,7 @@ function normalizeOptionalChatSystemReceipt(
   return { ok: true, receipt: receipt || undefined };
 }
 
-function isAcpBridgeClient(client: GatewayRequestHandlerOptions["client"]): boolean {
+function isAcpBridgeClient(client: GatewayRequestHandlerOptions["client"] | undefined): boolean {
   const info = client?.connect?.client;
   return (
     info?.id === GATEWAY_CLIENT_NAMES.CLI &&
@@ -1109,12 +1109,12 @@ function canInjectSystemProvenance(client: GatewayRequestHandlerOptions["client"
   return scopes.includes(ADMIN_SCOPE);
 }
 
-async function persistChatSendImages(params: {
+export async function persistChatSendImages(params: {
   images: ChatImageContent[];
   imageOrder: PromptImageOrderEntry[];
   offloadedRefs: OffloadedRef[];
-  client: GatewayRequestHandlerOptions["client"];
-  logGateway: GatewayRequestContext["logGateway"];
+  client: GatewayRequestHandlerOptions["client"] | undefined;
+  logGateway: Pick<GatewayRequestContext["logGateway"], "warn">;
 }): Promise<SavedMedia[]> {
   if (
     (params.images.length === 0 && params.offloadedRefs.length === 0) ||
@@ -1355,7 +1355,9 @@ function applyChatSendManagedMediaFields(ctx: MsgContext, fields: ChatSendManage
   }
 }
 
-function buildChatSendUserTurnMedia(savedMedia: SavedMedia[]): NonNullable<UserTurnInput["media"]> {
+export function buildChatSendUserTurnMedia(
+  savedMedia: SavedMedia[],
+): NonNullable<UserTurnInput["media"]> {
   return savedMedia.map((entry) => ({
     path: entry.path,
     contentType: entry.contentType,

--- a/src/gateway/server-node-events.runtime.ts
+++ b/src/gateway/server-node-events.runtime.ts
@@ -9,6 +9,7 @@ export { createOutboundSendDeps } from "../cli/outbound-send-deps.js";
 export { agentCommandFromIngress } from "../commands/agent.js";
 export { getRuntimeConfig } from "../config/io.js";
 export { updateSessionStore } from "../config/sessions.js";
+export { runAgentHarnessBeforeMessageWriteHook } from "../agents/harness/hook-helpers.js";
 export { loadOrCreateDeviceIdentity } from "../infra/device-identity.js";
 export { requestHeartbeat } from "../infra/heartbeat-wake.js";
 export { buildOutboundSessionContext } from "../infra/outbound/session-context.js";
@@ -18,8 +19,10 @@ export { enqueueSystemEvent } from "../infra/system-events.js";
 export { deleteMediaBuffer } from "../media/store.js";
 export { normalizeMainKey, scopedHeartbeatWakeOptions } from "../routing/session-key.js";
 export { defaultRuntime } from "../runtime.js";
+export { createUserTurnTranscriptRecorder } from "../sessions/user-turn-transcript.js";
 export { parseMessageWithAttachments, resolveChatAttachmentMaxBytes } from "./chat-attachments.js";
 export { normalizeRpcAttachmentsToChatAttachments } from "./server-methods/attachment-normalize.js";
+export { buildChatSendUserTurnMedia, persistChatSendImages } from "./server-methods/chat.js";
 export {
   loadSessionEntry,
   migrateAndPruneGatewaySessionStoreKey,

--- a/src/gateway/server-node-events.test.ts
+++ b/src/gateway/server-node-events.test.ts
@@ -68,13 +68,49 @@ const sanitizeInboundSystemTagsMock = vi.hoisted(() =>
 );
 const updatePairedDeviceMetadataMock = vi.hoisted(() => vi.fn().mockResolvedValue(true));
 const updatePairedNodeMetadataMock = vi.hoisted(() => vi.fn().mockResolvedValue(true));
+const persistChatSendImagesMock = vi.hoisted(() =>
+  vi.fn(async () => [
+    {
+      id: "saved-offload-1",
+      path: "/tmp/openclaw/media/offloaded-image.png",
+      contentType: "image/png",
+      size: 0,
+    },
+  ]),
+);
+const buildChatSendUserTurnMediaMock = vi.hoisted(() =>
+  vi.fn((savedMedia: Array<{ path: string; contentType?: string }>) =>
+    savedMedia.map((entry) => ({
+      path: entry.path,
+      contentType: entry.contentType,
+    })),
+  ),
+);
+const nodeUserTurnTranscriptRecorder = vi.hoisted(() => ({
+  message: undefined,
+  resolveMessage: vi.fn(),
+  markRuntimePersistencePending: vi.fn(),
+  markRuntimePersisted: vi.fn(),
+  markBlocked: vi.fn(),
+  hasPersisted: vi.fn(() => false),
+  isBlocked: vi.fn(() => false),
+  hasRuntimePersistencePending: vi.fn(() => false),
+  waitForRuntimePersistence: vi.fn(async () => {}),
+  persistApproved: vi.fn(async () => undefined),
+  persistFallback: vi.fn(async () => undefined),
+}));
+const createUserTurnTranscriptRecorderMock = vi.hoisted(() =>
+  vi.fn(() => nodeUserTurnTranscriptRecorder),
+);
 
 const runtimeMocks = vi.hoisted(() => ({
   agentCommandFromIngress: ingressAgentCommandMock,
+  buildChatSendUserTurnMedia: buildChatSendUserTurnMediaMock,
   buildOutboundSessionContext: vi.fn(({ sessionKey }: { sessionKey: string }) => ({
     key: sessionKey,
     agentId: "main",
   })),
+  createUserTurnTranscriptRecorder: createUserTurnTranscriptRecorderMock,
   createOutboundSendDeps: vi.fn((deps: unknown) => deps),
   defaultRuntime: {},
   deleteMediaBuffer: vi.fn(async () => {}),
@@ -95,6 +131,7 @@ const runtimeMocks = vi.hoisted(() => ({
   normalizeMainKey: vi.fn((key?: string | null) => key?.trim() || "agent:main:main"),
   normalizeRpcAttachmentsToChatAttachments: vi.fn((attachments?: unknown[]) => attachments ?? []),
   parseMessageWithAttachments: parseMessageWithAttachmentsMock,
+  persistChatSendImages: persistChatSendImagesMock,
   registerApnsRegistration: registerApnsRegistrationMock,
   requestHeartbeat: vi.fn(),
   resolveChatAttachmentMaxBytes: vi.fn(() => 20 * 1024 * 1024),
@@ -128,6 +165,7 @@ const runtimeMocks = vi.hoisted(() => ({
       model: entry?.model ?? "default-model",
     }),
   ),
+  runAgentHarnessBeforeMessageWriteHook: vi.fn(({ message }: { message: unknown }) => message),
   sanitizeInboundSystemTags: sanitizeInboundSystemTagsMock,
   scopedHeartbeatWakeOptions: vi.fn((sessionKey?: string, opts?: { reason: string }) => {
     const wakeOptions = { reason: opts?.reason };
@@ -1105,6 +1143,12 @@ describe("notifications changed events", () => {
 describe("agent request events", () => {
   beforeEach(() => {
     agentCommandMock.mockClear();
+    buildChatSendUserTurnMediaMock.mockClear();
+    createUserTurnTranscriptRecorderMock.mockClear();
+    persistChatSendImagesMock.mockClear();
+    nodeUserTurnTranscriptRecorder.markRuntimePersistencePending.mockClear();
+    nodeUserTurnTranscriptRecorder.markBlocked.mockClear();
+    nodeUserTurnTranscriptRecorder.persistFallback.mockClear();
     parseMessageWithAttachmentsMock.mockReset();
     updateSessionStoreMock.mockClear();
     loadSessionEntryMock.mockClear();
@@ -1222,6 +1266,198 @@ describe("agent request events", () => {
     expect(parseCall?.[0]).toBe("describe");
     expect(Array.isArray(parseCall?.[1])).toBe(true);
     expectFields(parseCall?.[2], { supportsInlineImages: false });
+  });
+
+  it("preserves parsed offloaded refs for node request user-turn transcripts", async () => {
+    const ctx = buildCtx();
+    loadSessionEntryMock.mockReturnValue({
+      ...buildSessionLookup("agent:main:main", {
+        sessionId: "sid-node-share",
+      }),
+      canonicalKey: "agent:main:main",
+    });
+    const offloadedRef = {
+      id: "offload-node-image",
+      mediaRef: "media://inbound/offload-node-image",
+      path: "/tmp/openclaw/media/offloaded-image.png",
+      mimeType: "image/png",
+    };
+    parseMessageWithAttachmentsMock.mockResolvedValueOnce({
+      message: "parsed message\n[media attached: media://inbound/offload-node-image]",
+      images: [],
+      imageOrder: ["offloaded"],
+      offloadedRefs: [offloadedRef],
+    });
+
+    await handleNodeEvent(ctx, "node-share", {
+      event: "agent.request",
+      payloadJSON: JSON.stringify({
+        message: "describe this",
+        sessionKey: "agent:main:main",
+        attachments: [
+          {
+            type: "image",
+            mimeType: "image/png",
+            fileName: "share.png",
+            content: "AAAA",
+          },
+        ],
+      }),
+    });
+
+    expect(persistChatSendImagesMock).toHaveBeenCalledWith({
+      images: [],
+      imageOrder: ["offloaded"],
+      offloadedRefs: [offloadedRef],
+      client: undefined,
+      logGateway: ctx.logGateway,
+    });
+    expect(buildChatSendUserTurnMediaMock).toHaveBeenCalledWith([
+      {
+        id: "saved-offload-1",
+        path: "/tmp/openclaw/media/offloaded-image.png",
+        contentType: "image/png",
+        size: 0,
+      },
+    ]);
+    expect(createUserTurnTranscriptRecorderMock).toHaveBeenCalledTimes(1);
+    const recorderArg = mockCallArg(createUserTurnTranscriptRecorderMock, 0) as {
+      input?: unknown;
+      target?: () => unknown;
+    };
+    expect(recorderArg.input).toEqual({
+      text: "describe this",
+      timestamp: expect.any(Number),
+      idempotencyKey: expect.stringMatching(/^[0-9a-f-]{36}:user$/),
+      media: [
+        {
+          path: "/tmp/openclaw/media/offloaded-image.png",
+          contentType: "image/png",
+        },
+      ],
+      mediaOnlyText: "[User sent media without caption]",
+    });
+    expect(recorderArg.target?.()).toMatchObject({
+      sessionId: "sid-node-share",
+      sessionKey: "agent:main:main",
+      agentId: "main",
+      storePath: "/tmp/sessions.json",
+    });
+    expect(agentCommandMock).toHaveBeenCalledTimes(1);
+    const agentCommandOpts = mockCallArg(agentCommandMock) as {
+      message?: unknown;
+      userTurnTranscriptRecorder?: unknown;
+    };
+    expect(agentCommandOpts.message).toBe(
+      "parsed message\n[media attached: media://inbound/offload-node-image]",
+    );
+    expect(agentCommandOpts.userTurnTranscriptRecorder).toBe(nodeUserTurnTranscriptRecorder);
+    await vi.waitFor(() =>
+      expect(nodeUserTurnTranscriptRecorder.persistFallback).toHaveBeenCalledTimes(1),
+    );
+    expect(nodeUserTurnTranscriptRecorder.markRuntimePersistencePending).toHaveBeenCalledTimes(1);
+    expect(nodeUserTurnTranscriptRecorder.markRuntimePersistencePending).toHaveBeenCalledWith(
+      expect.any(Promise),
+    );
+    expect(nodeUserTurnTranscriptRecorder.markBlocked).not.toHaveBeenCalled();
+
+    parseMessageWithAttachmentsMock.mockResolvedValueOnce({
+      message: "parsed followup\n[media attached: media://inbound/offload-node-image-2]",
+      images: [],
+      imageOrder: ["offloaded"],
+      offloadedRefs: [
+        {
+          ...offloadedRef,
+          id: "offload-node-image-2",
+          mediaRef: "media://inbound/offload-node-image-2",
+        },
+      ],
+    });
+
+    await handleNodeEvent(ctx, "node-share", {
+      event: "agent.request",
+      payloadJSON: JSON.stringify({
+        message: "describe another",
+        sessionKey: "agent:main:main",
+        attachments: [
+          {
+            type: "image",
+            mimeType: "image/png",
+            fileName: "share-2.png",
+            content: "BBBB",
+          },
+        ],
+      }),
+    });
+
+    expect(createUserTurnTranscriptRecorderMock).toHaveBeenCalledTimes(2);
+    const secondRecorderArg = mockCallArg(createUserTurnTranscriptRecorderMock, 1) as {
+      input?: { idempotencyKey?: string; text?: string };
+    };
+    const firstInput = recorderArg.input as { idempotencyKey?: string };
+    expect(secondRecorderArg.input?.text).toBe("describe another");
+    expect(secondRecorderArg.input?.idempotencyKey).toEqual(
+      expect.stringMatching(/^[0-9a-f-]{36}:user$/),
+    );
+    expect(secondRecorderArg.input?.idempotencyKey).not.toBe(firstInput.idempotencyKey);
+    await vi.waitFor(() =>
+      expect(nodeUserTurnTranscriptRecorder.persistFallback).toHaveBeenCalledTimes(2),
+    );
+    expect(nodeUserTurnTranscriptRecorder.markRuntimePersistencePending).toHaveBeenCalledTimes(2);
+    expect(nodeUserTurnTranscriptRecorder.markBlocked).not.toHaveBeenCalled();
+  });
+
+  it("marks before_agent_run block results before node request transcript fallback", async () => {
+    const ctx = buildCtx();
+    loadSessionEntryMock.mockReturnValue({
+      ...buildSessionLookup("agent:main:main", {
+        sessionId: "sid-node-blocked",
+      }),
+      canonicalKey: "agent:main:main",
+    });
+    const offloadedRef = {
+      id: "offload-blocked-image",
+      mediaRef: "media://inbound/offload-blocked-image",
+      path: "/tmp/openclaw/media/offloaded-blocked-image.png",
+      mimeType: "image/png",
+    };
+    parseMessageWithAttachmentsMock.mockResolvedValueOnce({
+      message: "parsed blocked\n[media attached: media://inbound/offload-blocked-image]",
+      images: [],
+      imageOrder: ["offloaded"],
+      offloadedRefs: [offloadedRef],
+    });
+    agentCommandMock.mockResolvedValueOnce({
+      payloads: [],
+      meta: {
+        durationMs: 1,
+        error: { kind: "hook_block", message: "blocked" },
+      },
+    } as never);
+
+    await handleNodeEvent(ctx, "node-blocked", {
+      event: "agent.request",
+      payloadJSON: JSON.stringify({
+        message: "describe blocked media",
+        sessionKey: "agent:main:main",
+        attachments: [
+          {
+            type: "image",
+            mimeType: "image/png",
+            fileName: "blocked.png",
+            content: "AAAA",
+          },
+        ],
+      }),
+    });
+
+    await vi.waitFor(() =>
+      expect(nodeUserTurnTranscriptRecorder.persistFallback).toHaveBeenCalledTimes(1),
+    );
+    expect(nodeUserTurnTranscriptRecorder.markBlocked).toHaveBeenCalledTimes(1);
+    expect(nodeUserTurnTranscriptRecorder.markBlocked.mock.invocationCallOrder[0]).toBeLessThan(
+      nodeUserTurnTranscriptRecorder.persistFallback.mock.invocationCallOrder[0],
+    );
   });
 
   it("declines non-image attachments cleanly when parse throws UnsupportedAttachmentError", async () => {

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -19,10 +19,13 @@ import {
   NODE_PRESENCE_ALIVE_EVENT,
   normalizeNodePresenceAliveReason,
 } from "../shared/node-presence.js";
+import type { OffloadedRef } from "./chat-attachments.js";
 import type { NodeEvent, NodeEventContext } from "./server-node-events-types.js";
 import {
   agentCommandFromIngress,
+  buildChatSendUserTurnMedia,
   buildOutboundSessionContext,
+  createUserTurnTranscriptRecorder,
   createOutboundSendDeps,
   defaultRuntime,
   deleteMediaBuffer,
@@ -36,6 +39,7 @@ import {
   normalizeMainKey,
   normalizeRpcAttachmentsToChatAttachments,
   parseMessageWithAttachments,
+  persistChatSendImages,
   registerApnsRegistration,
   requestHeartbeat,
   resolveChatAttachmentMaxBytes,
@@ -43,6 +47,7 @@ import {
   resolveOutboundTarget,
   resolveSessionAgentId,
   resolveSessionModelRef,
+  runAgentHarnessBeforeMessageWriteHook,
   sanitizeInboundSystemTags,
   sendDurableMessageBatch,
   updateSessionStore,
@@ -69,6 +74,7 @@ export type NodeEventHandleResult = {
 };
 
 type NodeAgentCommandInput = Parameters<typeof agentCommandFromIngress>[0];
+type NodeAgentCommandResult = Awaited<ReturnType<typeof agentCommandFromIngress>>;
 
 function normalizeFiniteInteger(value: unknown): number | null {
   return typeof value === "number" && Number.isFinite(value) ? Math.trunc(value) : null;
@@ -78,10 +84,15 @@ function dispatchNodeAgentCommand(
   ctx: NodeEventContext,
   nodeId: string,
   input: NodeAgentCommandInput,
-): void {
-  void agentCommandFromIngress(input, defaultRuntime, ctx.deps).catch((err: unknown) => {
+): Promise<NodeAgentCommandResult | undefined> {
+  return agentCommandFromIngress(input, defaultRuntime, ctx.deps).catch((err: unknown) => {
     ctx.logGateway.warn(`agent failed node=${nodeId}: ${formatForLog(err)}`);
+    return undefined;
   });
+}
+
+function isBeforeAgentRunBlockedCommandResult(result: NodeAgentCommandResult | undefined): boolean {
+  return result?.meta?.error?.kind === "hook_block";
 }
 
 function resolveVoiceTranscriptFingerprint(obj: Record<string, unknown>, text: string): string {
@@ -429,7 +440,7 @@ export const handleNodeEvent = async (
         clientRunId: `voice-${randomUUID()}`,
       });
 
-      dispatchNodeAgentCommand(ctx, nodeId, {
+      void dispatchNodeAgentCommand(ctx, nodeId, {
         runId,
         message: text,
         sessionId,
@@ -480,13 +491,16 @@ export const handleNodeEvent = async (
       const sessionKey = sessionKeyRaw.length > 0 ? sessionKeyRaw : `node-${nodeId}`;
       const cfg = getRuntimeConfig();
       const { storePath, entry, canonicalKey } = loadSessionEntry(sessionKey);
+      const sessionAgentId = resolveSessionAgentId({ sessionKey: canonicalKey, config: cfg });
 
-      let message = (link?.message ?? "").trim();
+      const rawMessage = (link?.message ?? "").trim();
+      let message = rawMessage;
       const normalizedAttachments = normalizeRpcAttachmentsToChatAttachments(
         link?.attachments ?? undefined,
       );
       let images: Array<{ type: "image"; data: string; mimeType: string }> = [];
       let imageOrder: PromptImageOrderEntry[] = [];
+      let offloadedRefs: OffloadedRef[] = [];
       if (!message && normalizedAttachments.length === 0) {
         return undefined;
       }
@@ -494,7 +508,6 @@ export const handleNodeEvent = async (
         return undefined;
       }
       if (normalizedAttachments.length > 0) {
-        const sessionAgentId = resolveSessionAgentId({ sessionKey, config: cfg });
         const modelRef = resolveSessionModelRef(cfg, entry, sessionAgentId);
         const supportsInlineImages = await resolveGatewayModelSupportsImages({
           loadGatewayModelCatalog: ctx.loadGatewayModelCatalog,
@@ -514,6 +527,7 @@ export const handleNodeEvent = async (
           message = parsed.message.trim();
           images = parsed.images;
           imageOrder = parsed.imageOrder;
+          offloadedRefs = parsed.offloadedRefs;
           if (message.length > 20_000) {
             ctx.logGateway.warn(
               `agent.request message exceeds limit after attachment parsing (length=${message.length})`,
@@ -552,7 +566,50 @@ export const handleNodeEvent = async (
 
       const now = Date.now();
       const sessionId = entry?.sessionId ?? randomUUID();
+      const userTurnTranscriptId = randomUUID();
       await touchSessionStore({ cfg, sessionKey, storePath, canonicalKey, entry, sessionId, now });
+      let userTurnTranscriptRecorder: NodeAgentCommandInput["userTurnTranscriptRecorder"];
+      if (normalizedAttachments.length > 0) {
+        const persistedMedia = await persistChatSendImages({
+          images,
+          imageOrder,
+          offloadedRefs,
+          client: undefined,
+          logGateway: ctx.logGateway,
+        });
+        const userTurnMedia = buildChatSendUserTurnMedia(persistedMedia);
+        if (userTurnMedia.length > 0) {
+          userTurnTranscriptRecorder = createUserTurnTranscriptRecorder({
+            input: {
+              text: rawMessage,
+              timestamp: now,
+              idempotencyKey: `${userTurnTranscriptId}:user`,
+              media: userTurnMedia,
+              mediaOnlyText: "[User sent media without caption]",
+            },
+            target: () => {
+              const latest = loadSessionEntry(canonicalKey);
+              const latestEntry = latest.entry ?? entry;
+              return {
+                sessionId: latestEntry?.sessionId ?? sessionId,
+                sessionKey: latest.canonicalKey,
+                sessionEntry: latestEntry,
+                sessionStore: latest.store,
+                storePath: latest.storePath,
+                agentId: sessionAgentId,
+                config: cfg,
+              };
+            },
+            errorContext: "node request user turn transcript",
+            beforeMessageWrite: runAgentHarnessBeforeMessageWriteHook,
+            onPersistenceError: (err) => {
+              ctx.logGateway.warn(
+                `agent.request user turn transcript persistence failed node=${nodeId}: ${formatForLog(err)}`,
+              );
+            },
+          });
+        }
+      }
 
       if (deliverRequested && (!channel || !to)) {
         const entryChannel =
@@ -593,7 +650,7 @@ export const handleNodeEvent = async (
         );
       }
 
-      dispatchNodeAgentCommand(ctx, nodeId, {
+      const dispatchPromise = dispatchNodeAgentCommand(ctx, nodeId, {
         runId: sessionId,
         message,
         images,
@@ -607,8 +664,25 @@ export const handleNodeEvent = async (
         timeout:
           typeof link?.timeoutSeconds === "number" ? link.timeoutSeconds.toString() : undefined,
         messageChannel: "node",
+        ...(userTurnTranscriptRecorder ? { userTurnTranscriptRecorder } : {}),
         allowModelOverride: false,
       });
+      if (userTurnTranscriptRecorder) {
+        userTurnTranscriptRecorder.markRuntimePersistencePending(dispatchPromise.then(() => {}));
+        void dispatchPromise
+          .then((result) => {
+            if (isBeforeAgentRunBlockedCommandResult(result)) {
+              userTurnTranscriptRecorder.markBlocked();
+            }
+          })
+          .finally(() => {
+            void userTurnTranscriptRecorder.persistFallback().catch((err: unknown) => {
+              ctx.logGateway.warn(
+                `agent.request user turn transcript fallback failed node=${nodeId}: ${formatForLog(err)}`,
+              );
+            });
+          });
+      }
       return undefined;
     }
     case "notifications.changed": {


### PR DESCRIPTION
## Summary

- Persist node `agent.request` offloaded image refs through the existing `chat.send` media helpers so session transcripts keep `MediaPath` / `MediaPaths` for iOS share and node gateway attachments.
- Thread the prepared user-turn transcript recorder through command ingress to both embedded and CLI runners, then add a block-aware fallback for early runtime failures.
- Keep `before_agent_run` hook blocks safe by marking the recorder blocked from the command result before fallback persistence runs.

Fixes #60339.

## Verification

- `node scripts/run-vitest.mjs src/gateway/server-node-events.test.ts`
  - 82 passed
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/agents/command/attempt-execution.cli.test.ts -t "forwards prepared user-turn transcript recorders"`
  - 4 passed, 70 skipped
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/gateway/server-methods/chat.directive-tags.test.ts -t "preserves offloaded attachment media paths in transcript order"`
  - 2 passed, 204 skipped
- `node_modules\.bin\oxfmt.cmd --check src/agents/command/attempt-execution.cli.test.ts src/agents/command/attempt-execution.ts src/agents/command/types.ts src/gateway/server-methods/chat.ts src/gateway/server-node-events.runtime.ts src/gateway/server-node-events.test.ts src/gateway/server-node-events.ts`
- `git diff --check`
- `node scripts/run-oxlint.mjs src/agents/command/attempt-execution.cli.test.ts src/agents/command/attempt-execution.ts src/agents/command/types.ts src/gateway/server-methods/chat.ts src/gateway/server-node-events.runtime.ts src/gateway/server-node-events.test.ts src/gateway/server-node-events.ts`
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-60339-core.tsbuildinfo`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-60339-core-test.tsbuildinfo`
- `python .agents\skills\autoreview\scripts\autoreview --mode branch --base origin/main --engine claude`
  - clean, no accepted/actionable findings

## Source / contract proof

- `src/gateway/server-methods/chat.ts` already owns the `persistChatSendImages` -> `buildChatSendUserTurnMedia` -> `createUserTurnTranscriptRecorder` flow for web/chat upload transcripts; this patch reuses that path instead of adding a node-only media persistence implementation.
- `src/agents/embedded-agent-runner/run.ts` propagates `meta.error.kind: "hook_block"` for `before_agent_run` blocks, and `src/agents/command/delivery.ts` preserves run `meta` in the command delivery result. The node fallback uses that established hook-block signal before calling `persistFallback()`.
- `src/sessions/user-turn-transcript.ts` already skips fallback persistence when the recorder has been marked blocked, and short-circuits fallback after runtime persistence succeeds.

## Real behavior proof

Behavior addressed: node/iOS share `agent.request` attachments that parse into `offloadedRefs` now persist transcript media metadata instead of leaving the media orphaned after the parser returns.

Real environment tested: Windows OpenClaw checkout, focused Vitest wrappers and static checks at head `f026bae77d` on `fix/60339-node-offloaded-refs` against `origin/main` `1a3ce7c2a8`.

Exact steps or command run after this patch: commands listed in `Verification` were run after the final block-aware fallback change and before opening this PR.

Evidence after fix: `server-node-events.test.ts` covers parsed node offloaded refs being passed into `persistChatSendImages`, converted into recorder media, forwarded into `agentCommandFromIngress`, retried with a fresh per-request user idempotency key, and protected by fallback persistence. It also covers `meta.error.kind: "hook_block"` marking the recorder blocked before fallback runs. `attempt-execution.cli.test.ts` covers recorder forwarding to both embedded and CLI runners.

Observed result after fix: The prepared user-turn transcript recorder receives the raw user text plus persisted media paths, the agent still receives the parsed marker-bearing message, and fallback persistence cannot re-persist raw input for blocked runs.

What was not tested: No live iOS share extension or real node client attachment run was executed; this is source-level behavior proof with focused gateway and command-runner tests.