### PR TITLE
fix(voice-call): preserve live Twilio streams in stale reaper

### DIFF
--- a/extensions/voice-call/src/webhook.test.ts
+++ b/extensions/voice-call/src/webhook.test.ts
@@ -616,6 +616,21 @@ describe("VoiceCallWebhookServer stale call reaper", () => {
     });
     expect(endCall).not.toHaveBeenCalled();
   });
+
+  it("does not reap live calls in speaking state without answeredAt (inbound Twilio)", async () => {
+    const { endCall } = await runStaleCallReaperCase({
+      callAgeMs: 120_000,
+      staleCallReaperSeconds: 60,
+      advanceMs: 30_000,
+      callOverrides: {
+        state: "speaking",
+        // answeredAt intentionally absent — inbound Twilio calls never fire
+        // call.answered, so answeredAt stays undefined even while live.
+        answeredAt: undefined,
+      },
+    });
+    expect(endCall).not.toHaveBeenCalled();
+  });
 });
 
 describe("VoiceCallWebhookServer path matching", () => {

--- a/extensions/voice-call/src/webhook/stale-call-reaper.ts
+++ b/extensions/voice-call/src/webhook/stale-call-reaper.ts
@@ -1,10 +1,17 @@
 // Voice Call plugin module implements stale call reaper behavior.
 import type { CallManager } from "../manager.js";
+import type { CallState } from "../types.js";
 import { TerminalStates } from "../types.js";
 
 // Background cleanup loop for calls that never reached answered/terminal state.
 
 const CHECK_INTERVAL_MS = 30_000;
+
+/** States that indicate a live conversation with speech/transcription.
+ * Inbound Twilio calls may never fire a call.answered event, so answeredAt
+ * can be absent even while the call is actively transcribing. These states
+ * prove the call is live and should not be reaped. */
+const LiveConversationStates: ReadonlySet<CallState> = new Set(["speaking", "listening"]);
 
 /** Start a stale-call reaper and return its cleanup callback. */
 export function startStaleCallReaper(params: {
@@ -20,7 +27,16 @@ export function startStaleCallReaper(params: {
   const interval = setInterval(() => {
     const now = Date.now();
     for (const call of params.manager.getActiveCalls()) {
-      if (call.answeredAt || TerminalStates.has(call.state)) {
+      // Skip calls that have been answered (answeredAt set) or are in a live
+      // conversation state. Inbound Twilio calls may never fire a call.answered
+      // event so answeredAt may be absent even when the call is actively
+      // transcribing/responding. Without this state guard live calls in
+      // speaking/listening state get reaped as stale.
+      if (
+        call.answeredAt ||
+        TerminalStates.has(call.state) ||
+        LiveConversationStates.has(call.state)
+      ) {
         continue;
       }
 


### PR DESCRIPTION
Fixes #79121.

## What changed

- Keep the voice-call stale reaper from ending calls that are actively in live conversation states (`speaking` / `listening`) even when `answeredAt` is absent.
- Add a regression test for the inbound Twilio shape where a live `speaking` call has no `answeredAt` and should not be reaped.

## Real behavior proof

Behavior addressed: The stale-call reaper no longer ends a live Twilio-style voice call that is in `speaking` state with no `answeredAt`. This matches inbound Twilio media-stream conversations where speech/transcription activity can advance the call state even when no separate `call.answered` event populated `answeredAt`.

Real environment tested: macOS local OpenClaw checkout. Base proof used clean `origin/main` at `1a3ce7c2` in `/private/tmp/openclaw-79121-base`. Fix proof used branch `fastino-79121-twilio-stale-reaper` at `e1cd850a` in `/Users/allahyar/Documents/fastino-tasks/openclaw-tui-79121`. Package manager was pnpm v11.2.2.

Exact steps or command run after the patch: Ran a runtime probe that imports the real `startStaleCallReaper`, intercepts the interval callback, sets `Date.now()` to `2026-02-16T00:00:00Z`, and gives the manager one active call: `{ callId: "twilio-live-speaking", startedAt: now - 120000, state: "speaking" }` with no `answeredAt`. I ran the same probe on clean `origin/main` and this branch. I also ran focused stale-reaper tests, the full voice-call extension suite, formatting, lint, and whitespace checks.

Evidence after fix: Before the fix, clean `origin/main` reaped the live `speaking` call:

```text
$ node --import tsx --input-type=module -e 'const callbacks=[]; const originalSetInterval=globalThis.setInterval; const originalClearInterval=globalThis.clearInterval; const originalNow=Date.now; globalThis.setInterval=(fn)=>{callbacks.push(fn); return 1}; globalThis.clearInterval=()=>{}; Date.now=()=>Date.parse("2026-02-16T00:00:00Z"); const { startStaleCallReaper } = await import("./extensions/voice-call/src/webhook/stale-call-reaper.ts"); const ended=[]; const manager={ getActiveCalls:()=>[{ callId:"twilio-live-speaking", startedAt: Date.now() - 120000, state:"speaking" }], endCall: async (id)=>{ ended.push(id); } }; const stop=startStaleCallReaper({ manager, staleCallReaperSeconds:60 }); callbacks[0](); await Promise.resolve(); console.log(JSON.stringify({ worktree:"origin/main", callbacks:callbacks.length, stopType:typeof stop, ended })); globalThis.setInterval=originalSetInterval; globalThis.clearInterval=originalClearInterval; Date.now=originalNow;'
[voice-call] Reaping stale call twilio-live-speaking (age: 120s, state: speaking)
{"worktree":"origin/main","callbacks":1,"stopType":"function","ended":["twilio-live-speaking"]}
```

After the fix, the same runtime probe on this branch leaves the live `speaking` call alone:

```text
$ node --import tsx --input-type=module -e 'const callbacks=[]; const originalSetInterval=globalThis.setInterval; const originalClearInterval=globalThis.clearInterval; const originalNow=Date.now; globalThis.setInterval=(fn)=>{callbacks.push(fn); return 1}; globalThis.clearInterval=()=>{}; Date.now=()=>Date.parse("2026-02-16T00:00:00Z"); const { startStaleCallReaper } = await import("./extensions/voice-call/src/webhook/stale-call-reaper.ts"); const ended=[]; const manager={ getActiveCalls:()=>[{ callId:"twilio-live-speaking", startedAt: Date.now() - 120000, state:"speaking" }], endCall: async (id)=>{ ended.push(id); } }; const stop=startStaleCallReaper({ manager, staleCallReaperSeconds:60 }); callbacks[0](); await Promise.resolve(); console.log(JSON.stringify({ worktree:"fastino-79121-twilio-stale-reaper", callbacks:callbacks.length, stopType:typeof stop, ended })); globalThis.setInterval=originalSetInterval; globalThis.clearInterval=originalClearInterval; Date.now=originalNow;'
{"worktree":"fastino-79121-twilio-stale-reaper","callbacks":1,"stopType":"function","ended":[]}
```

Additional verification:

```text
$ pnpm test:extension voice-call -t 'stale call reaper'
Test Files  2 passed | 48 skipped (50)
Tests  6 passed | 443 skipped (449)

$ pnpm test:extension voice-call
Test Files  50 passed (50)
Tests  449 passed (449)

$ pnpm exec oxfmt --check extensions/voice-call/src/webhook/stale-call-reaper.ts extensions/voice-call/src/webhook.test.ts
All matched files use the correct format.

$ pnpm exec oxlint extensions/voice-call/src/webhook/stale-call-reaper.ts extensions/voice-call/src/webhook.test.ts --report-unused-disable-directives-severity error
# passed with no output

$ git diff --check
# passed with no output
```

Observed result after fix: Before the fix, a 120-second `speaking` call with no `answeredAt` was logged and ended as stale. After the fix, the same call is recognized as live conversation activity and is not ended. Existing stale cleanup behavior for non-live stale calls remains covered by the full voice-call extension suite.

What was not tested: I did not place a live Twilio phone call. The exercised behavior is the local production stale-reaper code path that caused #79121, using a runtime manager probe and the voice-call extension tests.

## Platforms tested

- macOS local checkout