### PR TITLE
chore(codeowners): gate heartbeat template and repair changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -58,10 +58,11 @@
 /docs/reference/secretref-credential-surface.md @openclaw/openclaw-secops
 /docs/reference/secretref-user-supplied-credentials-matrix.json @openclaw/openclaw-secops
 
-# Heartbeat runtime templates and repair logic affect scheduled API call behavior.
-# Changes require maintainer review to prevent template/content mismatches that
-# cause silent heartbeat regressions or unintended API call triggers.
+# Heartbeat template, content emptiness check, and doctor repair are coupled.
+# Changes to any of these can cause silent heartbeat regressions or unintended
+# API call triggers. Changes require maintainer review for discussion.
 /src/agents/templates/ @hxy91819 @vincentkoc
+/src/auto-reply/heartbeat.ts @hxy91819 @vincentkoc
 /src/commands/doctor-heartbeat-template-repair.ts @hxy91819 @vincentkoc
 
 # Release workflow and its supporting release-path checks.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -58,10 +58,12 @@
 /docs/reference/secretref-credential-surface.md @openclaw/openclaw-secops
 /docs/reference/secretref-user-supplied-credentials-matrix.json @openclaw/openclaw-secops
 
-# Heartbeat template, content emptiness check, and doctor repair are coupled.
-# Changes to any of these can cause silent heartbeat regressions or unintended
-# API call triggers. Changes require maintainer review for discussion.
+# Heartbeat template, content emptiness check, template resolution, and doctor
+# repair are coupled. Changes to any of these can cause silent heartbeat
+# regressions or unintended API call triggers. Changes require maintainer
+# review for discussion.
 /src/agents/templates/ @hxy91819 @vincentkoc
+/src/agents/workspace-templates.ts @hxy91819 @vincentkoc
 /src/auto-reply/heartbeat.ts @hxy91819 @vincentkoc
 /src/commands/doctor-heartbeat-template-repair.ts @hxy91819 @vincentkoc
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -62,7 +62,7 @@
 # repair are coupled. Changes to any of these can cause silent heartbeat
 # regressions or unintended API call triggers. Changes require maintainer
 # review for discussion.
-/src/agents/templates/ @hxy91819 @vincentkoc
+/src/agents/templates/HEARTBEAT.md @hxy91819 @vincentkoc
 /src/agents/workspace-templates.ts @hxy91819 @vincentkoc
 /src/auto-reply/heartbeat.ts @hxy91819 @vincentkoc
 /src/commands/doctor-heartbeat-template-repair.ts @hxy91819 @vincentkoc

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -58,6 +58,12 @@
 /docs/reference/secretref-credential-surface.md @openclaw/openclaw-secops
 /docs/reference/secretref-user-supplied-credentials-matrix.json @openclaw/openclaw-secops
 
+# Heartbeat runtime templates and repair logic affect scheduled API call behavior.
+# Changes require maintainer review to prevent template/content mismatches that
+# cause silent heartbeat regressions or unintended API call triggers.
+/src/agents/templates/ @hxy91819 @vincentkoc
+/src/commands/doctor-heartbeat-template-repair.ts @hxy91819 @vincentkoc
+
 # Release workflow and its supporting release-path checks.
 /.github/workflows/openclaw-npm-release.yml @openclaw/openclaw-release-managers
 /docs/reference/RELEASING.md @openclaw/openclaw-release-managers


### PR DESCRIPTION
## Summary

Add CODEOWNERS review gates for heartbeat template, content emptiness check, template resolution, and doctor repair logic. Changes to any of these files now require review from @hxy91819 or @vincentkoc.

### Scope

| File | Role | Risk if changed incorrectly |
|---|---|---|
| `src/agents/templates/HEARTBEAT.md` | Runtime heartbeat template content | Non-comment lines in template cause heartbeat API calls to fire for all newly bootstrapped workspaces |
| `src/agents/workspace-templates.ts` | Template directory resolution and search paths | Changes to `FALLBACK_TEMPLATE_DIR` or candidate order could redirect heartbeat template loading back to docs directory, breaking the decoupling from #85416 |
| `src/auto-reply/heartbeat.ts` | `isHeartbeatContentEffectivelyEmpty()` and `parseHeartbeatTasks()` | Changes to emptiness check logic can cause false skips (heartbeat not firing) or false triggers (unnecessary API calls) |
| `src/commands/doctor-heartbeat-template-repair.ts` | Doctor repair matching and fix logic | Hardcoded constants are coupled to template content; mismatches cause missed detections or false `dirty-template-with-custom-content` verdicts |

### Background

Historically, the heartbeat runtime template (`HEARTBEAT.md`) was loaded from the docs template directory (`docs/reference/templates/`). Docs edits (frontmatter, fenced code blocks, prose descriptions, "Related" sections) leaked into user workspace files after `stripFrontMatter`, causing:

- Non-comment/non-header lines (prose, markdown links like `- [Heartbeat config](...)`) made `isHeartbeatContentEffectivelyEmpty()` return `false`, triggering heartbeat API calls for users who never configured any tasks.
- This happened multiple times across different docs template versions (2026-01, 2026-03, 2026-04), resulting in numerous user complaints about unexpected heartbeat activity and API token consumption.

PR #85416 decoupled the runtime template to `src/agents/templates/HEARTBEAT.md`, preventing docs edits from affecting runtime behavior. However, the risk remains: if any of the gated files are modified incorrectly, the same class of regression reoccurs.

### Purpose

The purpose of this CODEOWNERS gate is to ensure that any change to these files triggers a required review discussion. A seemingly harmless edit can cause all newly bootstrapped workspaces to fire heartbeat API calls unexpectedly, leading to significant unintended token consumption for users. The designated reviewers can evaluate whether the change is safe and whether the coupled code (doctor repair constants, emptiness check logic, template resolution paths) needs to be updated in tandem.

## Verification

- `git diff --check`
- CODEOWNERS syntax verified against GitHub documentation (last-match-wins semantics, user/team references)
