### PR TITLE
docs: add supported iOS install path when public beta is full

### DIFF
--- a/docs/platforms/ios.md
+++ b/docs/platforms/ios.md
@@ -9,6 +9,17 @@ title: "iOS app"
 
 Availability: iPhone app builds are distributed through Apple channels when enabled for a release. Local development builds can also run from source.
 
+If the public iOS beta or TestFlight capacity is full, the supported install path is to build and run the app from source using the OpenClaw iOS project in Xcode. This is the official supported path when no distributed build slot is available.
+
+1. Install Xcode from the Mac App Store.
+2. Clone the OpenClaw repository.
+3. Open the iOS project/workspace in Xcode.
+4. Select a personal development team in Signing & Capabilities.
+5. Build and run the app to your iPhone.
+6. Pair the app with your Gateway the same way you would with an official build.
+
+This keeps you on a supported route instead of waiting for beta capacity to reopen.
+
 ## What it does
 
 - Connects to a Gateway over WebSocket (LAN or tailnet).


### PR DESCRIPTION
## Summary

Document the supported install path for the iOS node when the public beta or TestFlight capacity is full.

Closes #90599

## Changes

- Add explicit wording to `docs/platforms/ios.md` stating that building the iOS app from source is the supported path when no distributed build slot is available.
- Add a short Xcode source-build flow so readers have the next step without guessing.

## Verification

- `pnpm lint:docs -- docs/platforms/ios.md`
- Local markdown review
