### PR TITLE
fix(memory-wiki): accept wiki_apply CLI op aliases

### DIFF
--- a/docs/plugins/memory-wiki.md
+++ b/docs/plugins/memory-wiki.md
@@ -346,6 +346,9 @@ What they do:
 - `wiki_apply`: narrow synthesis/metadata mutations without freeform page surgery
 - `wiki_lint`: structural checks, provenance gaps, contradictions, open questions
 
+`wiki_apply` accepts the CLI-style `op` values `synthesis` and `metadata`, plus
+the canonical internal values `create_synthesis` and `update_metadata`.
+
 The plugin also registers a non-exclusive memory corpus supplement, so shared
 `memory_search` and `memory_get` can reach the wiki when the active memory
 plugin supports corpus selection.

--- a/extensions/memory-wiki/src/apply.test.ts
+++ b/extensions/memory-wiki/src/apply.test.ts
@@ -29,6 +29,25 @@ describe("applyMemoryWikiMutation", () => {
     ).toMatchObject({ confidence: 0.4 });
   });
 
+  it("normalizes CLI-style wiki apply operation aliases", () => {
+    expect(
+      normalizeMemoryWikiMutationInput({
+        op: "synthesis",
+        title: "Alpha Synthesis",
+        body: "Alpha summary body.",
+        sourceIds: ["source.alpha"],
+      }),
+    ).toMatchObject({ op: "create_synthesis" });
+
+    expect(
+      normalizeMemoryWikiMutationInput({
+        op: "metadata",
+        lookup: "entity.alpha",
+        status: "review",
+      }),
+    ).toMatchObject({ op: "update_metadata" });
+  });
+
   it("rejects out-of-range string confidence in wiki mutations", () => {
     expect(() =>
       normalizeMemoryWikiMutationInput({

--- a/extensions/memory-wiki/src/apply.ts
+++ b/extensions/memory-wiki/src/apply.ts
@@ -56,6 +56,8 @@ export type ApplyMemoryWikiMutation =
   | CreateSynthesisMemoryWikiMutation
   | UpdateMetadataMemoryWikiMutation;
 
+type ApplyMemoryWikiMutationInputOp = ApplyMemoryWikiMutation["op"] | "synthesis" | "metadata";
+
 type ApplyMemoryWikiMutationResult = {
   changed: boolean;
   operation: ApplyMemoryWikiMutation["op"];
@@ -85,9 +87,21 @@ function normalizeMutationConfidence(
   });
 }
 
+function normalizeMemoryWikiMutationOp(
+  op: ApplyMemoryWikiMutationInputOp,
+): ApplyMemoryWikiMutation["op"] {
+  if (op === "synthesis") {
+    return "create_synthesis";
+  }
+  if (op === "metadata") {
+    return "update_metadata";
+  }
+  return op;
+}
+
 export function normalizeMemoryWikiMutationInput(rawParams: unknown): ApplyMemoryWikiMutation {
   const params = rawParams as {
-    op: ApplyMemoryWikiMutation["op"];
+    op: ApplyMemoryWikiMutationInputOp;
     title?: string;
     body?: string;
     lookup?: string;
@@ -98,7 +112,8 @@ export function normalizeMemoryWikiMutationInput(rawParams: unknown): ApplyMemor
     confidence?: number | null;
     status?: string;
   };
-  if (params.op === "create_synthesis") {
+  const op = normalizeMemoryWikiMutationOp(params.op);
+  if (op === "create_synthesis") {
     if (!params.title?.trim()) {
       throw new Error("wiki mutation requires title for create_synthesis.");
     }

--- a/extensions/memory-wiki/src/tool.test.ts
+++ b/extensions/memory-wiki/src/tool.test.ts
@@ -41,6 +41,22 @@ describe("memory-wiki tools", () => {
     expect(evidenceProperties.confidence).toEqual({ type: "number", minimum: 0, maximum: 1 });
   });
 
+  it("accepts CLI-style wiki_apply operation aliases", () => {
+    const tool = createWikiApplyTool({} as ResolvedMemoryWikiConfig);
+    const applyProperties = asSchemaObject(asSchemaObject(tool.parameters).properties);
+    const opSchema = asSchemaObject(applyProperties.op);
+    const variants = (opSchema.anyOf as Array<Record<string, unknown>>).map((variant) =>
+      variant.const,
+    );
+
+    expect(variants).toEqual([
+      "create_synthesis",
+      "update_metadata",
+      "synthesis",
+      "metadata",
+    ]);
+  });
+
   it("returns tool-safe relative report paths from wiki_lint", async () => {
     const { rootDir, config } = await harness.createVault({ initialize: true });
     await fs.mkdir(path.join(rootDir, "syntheses"), { recursive: true });

--- a/extensions/memory-wiki/src/tool.ts
+++ b/extensions/memory-wiki/src/tool.ts
@@ -80,9 +80,15 @@ const WikiClaimSchema = Type.Object(
   },
   { additionalProperties: false },
 );
+const WikiApplyOperationSchema = Type.Union([
+  Type.Literal("create_synthesis"),
+  Type.Literal("update_metadata"),
+  Type.Literal("synthesis"),
+  Type.Literal("metadata"),
+]);
 const WikiApplySchema = Type.Object(
   {
-    op: Type.Union([Type.Literal("create_synthesis"), Type.Literal("update_metadata")]),
+    op: WikiApplyOperationSchema,
     title: Type.Optional(Type.String({ minLength: 1 })),
     body: Type.Optional(Type.String({ minLength: 1 })),
     lookup: Type.Optional(Type.String({ minLength: 1 })),


### PR DESCRIPTION
## Summary
- accept `wiki_apply` op aliases `synthesis` and `metadata` in the tool schema
- normalize those aliases to the canonical `create_synthesis` and `update_metadata` mutations before execution
- document the accepted op values in the memory-wiki plugin docs

Fixes #90303

## Tests
- node scripts/run-vitest.mjs extensions/memory-wiki/src/tool.test.ts extensions/memory-wiki/src/apply.test.ts
- git diff --check upstream/main...HEAD

## Real behavior proof
- Behavior addressed: `wiki_apply` now accepts the CLI-style `synthesis` and `metadata` op values shown to users/agents and normalizes them to canonical mutation operations.
- Real environment tested: local OpenClaw checkout at PR head `de46db2e4cbe51315c2801bc5c14ee6fac40ea6a` on macOS 15.5 with Node v22.22.1 and pnpm 11.2.2.
- Exact steps or command run after this patch: `node --import tsx --input-type=module` with `normalizeMemoryWikiMutationInput(...)` for both aliases; `node scripts/run-vitest.mjs extensions/memory-wiki/src/tool.test.ts extensions/memory-wiki/src/apply.test.ts`; `git diff --check upstream/main...HEAD`.
- Evidence after fix: terminal output from the PR-head checkout:

```text
$ node --import tsx --input-type=module
synthesis -> create_synthesis
metadata -> update_metadata

$ node scripts/run-vitest.mjs extensions/memory-wiki/src/tool.test.ts extensions/memory-wiki/src/apply.test.ts
✓  extension-memory  extensions/memory-wiki/src/apply.test.ts (5 tests) 115ms
✓  extension-memory  extensions/memory-wiki/src/tool.test.ts (3 tests) 97ms
Test Files  2 passed (2)
Tests  8 passed (8)
[test] passed 1 Vitest shard in 9.19s

$ git diff --check upstream/main...HEAD
# no output; exit code 0
```

- Observed result after fix: the local OpenClaw memory-wiki normalizer converted both aliases to canonical operations, the schema/apply focused shard passed at PR head, and the PR diff has no whitespace errors.
- What was not tested: live agent tool invocation through a running Gateway; this proof uses the local memory-wiki plugin implementation directly.