### PR TITLE
fix(matrix): prune finished fake-indexeddb transactions

### DIFF
--- a/extensions/matrix/src/matrix/sdk/crypto-runtime.ts
+++ b/extensions/matrix/src/matrix/sdk/crypto-runtime.ts
@@ -1,5 +1,8 @@
 // Matrix plugin module implements crypto runtime behavior.
 import "fake-indexeddb/auto";
+import { installFakeIndexedDbTransactionPruner } from "./fake-indexeddb-prune.js";
+
+installFakeIndexedDbTransactionPruner();
 
 export { MatrixCryptoBootstrapper } from "./crypto-bootstrap.js";
 export type { MatrixCryptoBootstrapResult } from "./crypto-bootstrap.js";

--- a/extensions/matrix/src/matrix/sdk/fake-indexeddb-prune.test.ts
+++ b/extensions/matrix/src/matrix/sdk/fake-indexeddb-prune.test.ts
@@ -1,0 +1,88 @@
+// Matrix tests cover fake-indexeddb transaction pruning for crypto stores.
+import "fake-indexeddb/auto";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  installFakeIndexedDbTransactionPruner,
+  pruneFinishedFakeIndexedDbTransactions,
+} from "./fake-indexeddb-prune.js";
+
+function openDatabase(name: string): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(name, 1);
+    request.onupgradeneeded = () => {
+      request.result.createObjectStore("sessions", { keyPath: "key" });
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+function deleteDatabase(name: string): Promise<void> {
+  return new Promise((resolve) => {
+    const request = indexedDB.deleteDatabase(name);
+    request.onsuccess = () => resolve();
+    request.onerror = () => resolve();
+    request.onblocked = () => resolve();
+  });
+}
+
+function putRecord(db: IDBDatabase, key: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const transaction = db.transaction("sessions", "readwrite");
+    transaction.objectStore("sessions").put({ key, value: "payload" });
+    transaction.oncomplete = () => resolve();
+    transaction.onerror = () => reject(transaction.error);
+    transaction.onabort = () => reject(transaction.error ?? new Error("transaction aborted"));
+  });
+}
+
+function rawTransactions(db: IDBDatabase): Array<{ _state?: string }> {
+  return ((db as unknown as { _rawDatabase?: { transactions?: Array<{ _state?: string }> } })._rawDatabase?.transactions ?? []);
+}
+
+describe("Matrix fake-indexeddb transaction pruning", () => {
+  const databaseNames = new Set<string>();
+
+  afterEach(async () => {
+    for (const name of databaseNames) {
+      await deleteDatabase(name);
+    }
+    databaseNames.clear();
+  });
+
+  it("prunes finished transactions for Matrix crypto databases", async () => {
+    installFakeIndexedDbTransactionPruner();
+    const databaseName = `openclaw-matrix-prune-test-${Date.now()}::matrix-sdk-crypto`;
+    databaseNames.add(databaseName);
+    const db = await openDatabase(databaseName);
+
+    for (let i = 0; i < 5; i += 1) {
+      await putRecord(db, `key-${i}`);
+    }
+
+    expect(rawTransactions(db)).toHaveLength(0);
+    db.close();
+  });
+
+  it("does not prune unrelated fake-indexeddb databases", async () => {
+    installFakeIndexedDbTransactionPruner();
+    const databaseName = `openclaw-matrix-unrelated-prune-test-${Date.now()}`;
+    databaseNames.add(databaseName);
+    const db = await openDatabase(databaseName);
+
+    await putRecord(db, "key-1");
+
+    expect(rawTransactions(db).filter((transaction) => transaction._state === "finished").length).toBeGreaterThan(0);
+    db.close();
+  });
+
+  it("keeps active transactions when pruning the raw transaction queue", () => {
+    const rawDatabase = {
+      name: "openclaw-matrix-direct-prune-test::matrix-sdk-crypto",
+      transactions: [{ _state: "finished" }, { _state: "active" }, { _state: "inactive" }],
+    };
+
+    expect(pruneFinishedFakeIndexedDbTransactions(rawDatabase)).toBe(1);
+    expect(rawDatabase.transactions).toEqual([{ _state: "active" }, { _state: "inactive" }]);
+  });
+});

--- a/extensions/matrix/src/matrix/sdk/fake-indexeddb-prune.test.ts
+++ b/extensions/matrix/src/matrix/sdk/fake-indexeddb-prune.test.ts
@@ -9,20 +9,26 @@ import {
 function openDatabase(name: string): Promise<IDBDatabase> {
   return new Promise((resolve, reject) => {
     const request = indexedDB.open(name, 1);
-    request.onupgradeneeded = () => {
+    request.addEventListener("upgradeneeded", () => {
       request.result.createObjectStore("sessions", { keyPath: "key" });
-    };
-    request.onsuccess = () => resolve(request.result);
-    request.onerror = () => reject(request.error);
+    });
+    request.addEventListener("success", () => resolve(request.result), { once: true });
+    request.addEventListener(
+      "error",
+      () => reject(request.error ?? new Error("database open failed")),
+      {
+        once: true,
+      },
+    );
   });
 }
 
 function deleteDatabase(name: string): Promise<void> {
   return new Promise((resolve) => {
     const request = indexedDB.deleteDatabase(name);
-    request.onsuccess = () => resolve();
-    request.onerror = () => resolve();
-    request.onblocked = () => resolve();
+    request.addEventListener("success", () => resolve(), { once: true });
+    request.addEventListener("error", () => resolve(), { once: true });
+    request.addEventListener("blocked", () => resolve(), { once: true });
   });
 }
 
@@ -30,14 +36,30 @@ function putRecord(db: IDBDatabase, key: string): Promise<void> {
   return new Promise((resolve, reject) => {
     const transaction = db.transaction("sessions", "readwrite");
     transaction.objectStore("sessions").put({ key, value: "payload" });
-    transaction.oncomplete = () => resolve();
-    transaction.onerror = () => reject(transaction.error);
-    transaction.onabort = () => reject(transaction.error ?? new Error("transaction aborted"));
+    transaction.addEventListener("complete", () => resolve(), { once: true });
+    transaction.addEventListener(
+      "error",
+      () => reject(transaction.error ?? new Error("transaction failed")),
+      {
+        once: true,
+      },
+    );
+    transaction.addEventListener(
+      "abort",
+      () => reject(transaction.error ?? new Error("transaction aborted")),
+      {
+        once: true,
+      },
+    );
   });
 }
 
 function rawTransactions(db: IDBDatabase): Array<{ _state?: string }> {
-  return ((db as unknown as { _rawDatabase?: { transactions?: Array<{ _state?: string }> } })._rawDatabase?.transactions ?? []);
+  return (
+    (db as unknown as { _rawDatabase?: { transactions?: Array<{ _state?: string }> } })[
+      "_rawDatabase"
+    ]?.transactions ?? []
+  );
 }
 
 describe("Matrix fake-indexeddb transaction pruning", () => {
@@ -64,6 +86,20 @@ describe("Matrix fake-indexeddb transaction pruning", () => {
     db.close();
   });
 
+  it("prunes finished transactions for Matrix crypto metadata databases", async () => {
+    installFakeIndexedDbTransactionPruner();
+    const databaseName = `openclaw-matrix-meta-prune-test-${Date.now()}::matrix-sdk-crypto-meta`;
+    databaseNames.add(databaseName);
+    const db = await openDatabase(databaseName);
+
+    for (let i = 0; i < 5; i += 1) {
+      await putRecord(db, `key-${i}`);
+    }
+
+    expect(rawTransactions(db)).toHaveLength(0);
+    db.close();
+  });
+
   it("does not prune unrelated fake-indexeddb databases", async () => {
     installFakeIndexedDbTransactionPruner();
     const databaseName = `openclaw-matrix-unrelated-prune-test-${Date.now()}`;
@@ -72,7 +108,9 @@ describe("Matrix fake-indexeddb transaction pruning", () => {
 
     await putRecord(db, "key-1");
 
-    expect(rawTransactions(db).filter((transaction) => transaction._state === "finished").length).toBeGreaterThan(0);
+    expect(
+      rawTransactions(db).filter((transaction) => transaction["_state"] === "finished").length,
+    ).toBeGreaterThan(0);
     db.close();
   });
 

--- a/extensions/matrix/src/matrix/sdk/fake-indexeddb-prune.ts
+++ b/extensions/matrix/src/matrix/sdk/fake-indexeddb-prune.ts
@@ -18,7 +18,7 @@ type FakeIndexedDbDatabaseConnection = {
 };
 
 type FakeIndexedDbDatabasePrototype = FakeIndexedDbDatabaseConnection & {
-  transaction?: (...args: unknown[]) => unknown;
+  transaction?: IDBDatabase["transaction"];
   [PRUNER_INSTALLED]?: true;
 };
 
@@ -50,11 +50,12 @@ function isMatrixCryptoDatabase(rawDatabase: FakeIndexedDbRawDatabase | undefine
 }
 
 export function pruneFinishedFakeIndexedDbTransactions(rawDatabase: unknown): number {
-  if (!isMatrixCryptoDatabase(rawDatabase as FakeIndexedDbRawDatabase | undefined)) {
+  const matrixRawDatabase = rawDatabase as FakeIndexedDbRawDatabase | undefined;
+  if (!isMatrixCryptoDatabase(matrixRawDatabase)) {
     return 0;
   }
 
-  const transactions = rawDatabase.transactions;
+  const transactions = matrixRawDatabase.transactions;
   const activeTransactions = transactions.filter((transaction) => transaction?._state !== "finished");
   const removed = transactions.length - activeTransactions.length;
   if (removed > 0) {
@@ -77,13 +78,13 @@ export function installFakeIndexedDbTransactionPruner(): void {
     value: true,
   });
 
-  databasePrototype.transaction = function patchedMatrixFakeIndexedDbTransaction(
-    this: FakeIndexedDbDatabaseConnection,
-    ...args: unknown[]
-  ): unknown {
+  const patchedTransaction = function patchedMatrixFakeIndexedDbTransaction(
+    this: IDBDatabase & FakeIndexedDbDatabaseConnection,
+    ...args: Parameters<IDBDatabase["transaction"]>
+  ): ReturnType<IDBDatabase["transaction"]> {
     pruneFinishedFakeIndexedDbTransactions(getRawDatabase(this));
 
-    const transaction = originalTransaction.apply(this, args) as FakeIndexedDbTransaction;
+    const transaction = originalTransaction.apply(this, args) as IDBTransaction & FakeIndexedDbTransaction;
     const rawDatabase = getRawDatabase(transaction?.db) ?? getRawDatabase(this);
     if (isMatrixCryptoDatabase(rawDatabase) && typeof transaction?.addEventListener === "function") {
       const prune = (): void => {
@@ -94,5 +95,7 @@ export function installFakeIndexedDbTransactionPruner(): void {
     }
 
     return transaction;
-  };
+  } as IDBDatabase["transaction"];
+
+  databasePrototype.transaction = patchedTransaction;
 }

--- a/extensions/matrix/src/matrix/sdk/fake-indexeddb-prune.ts
+++ b/extensions/matrix/src/matrix/sdk/fake-indexeddb-prune.ts
@@ -1,0 +1,98 @@
+// Matrix SDK helper mitigates fake-indexeddb finished-transaction retention.
+const MATRIX_CRYPTO_DATABASE_SUFFIX = "::matrix-sdk-crypto";
+const PRUNER_INSTALLED = Symbol.for("openclaw.matrix.fakeIndexedDbTransactionPruner");
+
+type FakeIndexedDbTransaction = {
+  _state?: string;
+  addEventListener?: (type: "complete" | "abort", listener: () => void) => void;
+  db?: FakeIndexedDbDatabaseConnection;
+};
+
+type FakeIndexedDbRawDatabase = {
+  name?: string;
+  transactions?: FakeIndexedDbTransaction[];
+};
+
+type FakeIndexedDbDatabaseConnection = {
+  _rawDatabase?: FakeIndexedDbRawDatabase;
+};
+
+type FakeIndexedDbDatabasePrototype = FakeIndexedDbDatabaseConnection & {
+  transaction?: (...args: unknown[]) => unknown;
+  [PRUNER_INSTALLED]?: true;
+};
+
+type GlobalWithFakeIndexedDb = typeof globalThis & {
+  IDBDatabase?: {
+    prototype?: FakeIndexedDbDatabasePrototype;
+  };
+};
+
+function getRawDatabase(value: unknown): FakeIndexedDbRawDatabase | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  const rawDatabase = (value as FakeIndexedDbDatabaseConnection)._rawDatabase;
+  if (!rawDatabase || typeof rawDatabase !== "object") {
+    return undefined;
+  }
+  return rawDatabase;
+}
+
+function isMatrixCryptoDatabase(rawDatabase: FakeIndexedDbRawDatabase | undefined): rawDatabase is FakeIndexedDbRawDatabase & {
+  transactions: FakeIndexedDbTransaction[];
+} {
+  return (
+    typeof rawDatabase?.name === "string" &&
+    rawDatabase.name.endsWith(MATRIX_CRYPTO_DATABASE_SUFFIX) &&
+    Array.isArray(rawDatabase.transactions)
+  );
+}
+
+export function pruneFinishedFakeIndexedDbTransactions(rawDatabase: unknown): number {
+  if (!isMatrixCryptoDatabase(rawDatabase as FakeIndexedDbRawDatabase | undefined)) {
+    return 0;
+  }
+
+  const transactions = rawDatabase.transactions;
+  const activeTransactions = transactions.filter((transaction) => transaction?._state !== "finished");
+  const removed = transactions.length - activeTransactions.length;
+  if (removed > 0) {
+    transactions.splice(0, transactions.length, ...activeTransactions);
+  }
+  return removed;
+}
+
+export function installFakeIndexedDbTransactionPruner(): void {
+  const globalObject = globalThis as GlobalWithFakeIndexedDb;
+  const databasePrototype = globalObject.IDBDatabase?.prototype;
+  const originalTransaction = databasePrototype?.transaction;
+  if (!databasePrototype || typeof originalTransaction !== "function" || databasePrototype[PRUNER_INSTALLED]) {
+    return;
+  }
+
+  Object.defineProperty(databasePrototype, PRUNER_INSTALLED, {
+    configurable: false,
+    enumerable: false,
+    value: true,
+  });
+
+  databasePrototype.transaction = function patchedMatrixFakeIndexedDbTransaction(
+    this: FakeIndexedDbDatabaseConnection,
+    ...args: unknown[]
+  ): unknown {
+    pruneFinishedFakeIndexedDbTransactions(getRawDatabase(this));
+
+    const transaction = originalTransaction.apply(this, args) as FakeIndexedDbTransaction;
+    const rawDatabase = getRawDatabase(transaction?.db) ?? getRawDatabase(this);
+    if (isMatrixCryptoDatabase(rawDatabase) && typeof transaction?.addEventListener === "function") {
+      const prune = (): void => {
+        pruneFinishedFakeIndexedDbTransactions(rawDatabase);
+      };
+      transaction.addEventListener("complete", prune);
+      transaction.addEventListener("abort", prune);
+    }
+
+    return transaction;
+  };
+}

--- a/extensions/matrix/src/matrix/sdk/fake-indexeddb-prune.ts
+++ b/extensions/matrix/src/matrix/sdk/fake-indexeddb-prune.ts
@@ -1,5 +1,8 @@
 // Matrix SDK helper mitigates fake-indexeddb finished-transaction retention.
-const MATRIX_CRYPTO_DATABASE_SUFFIX = "::matrix-sdk-crypto";
+const MATRIX_CRYPTO_DATABASE_SUFFIXES = [
+  "::matrix-sdk-crypto",
+  "::matrix-sdk-crypto-meta",
+] as const;
 const PRUNER_INSTALLED = Symbol.for("openclaw.matrix.fakeIndexedDbTransactionPruner");
 
 type FakeIndexedDbTransaction = {
@@ -32,20 +35,25 @@ function getRawDatabase(value: unknown): FakeIndexedDbRawDatabase | undefined {
   if (!value || typeof value !== "object") {
     return undefined;
   }
-  const rawDatabase = (value as FakeIndexedDbDatabaseConnection)._rawDatabase;
+  const rawDatabase = (value as FakeIndexedDbDatabaseConnection)["_rawDatabase"];
   if (!rawDatabase || typeof rawDatabase !== "object") {
     return undefined;
   }
   return rawDatabase;
 }
 
-function isMatrixCryptoDatabase(rawDatabase: FakeIndexedDbRawDatabase | undefined): rawDatabase is FakeIndexedDbRawDatabase & {
+function isMatrixCryptoDatabase(
+  rawDatabase: FakeIndexedDbRawDatabase | undefined,
+): rawDatabase is FakeIndexedDbRawDatabase & {
   transactions: FakeIndexedDbTransaction[];
 } {
+  if (!rawDatabase || !Array.isArray(rawDatabase.transactions)) {
+    return false;
+  }
+  const databaseName = rawDatabase.name;
   return (
-    typeof rawDatabase?.name === "string" &&
-    rawDatabase.name.endsWith(MATRIX_CRYPTO_DATABASE_SUFFIX) &&
-    Array.isArray(rawDatabase.transactions)
+    typeof databaseName === "string" &&
+    MATRIX_CRYPTO_DATABASE_SUFFIXES.some((suffix) => databaseName.endsWith(suffix))
   );
 }
 
@@ -56,7 +64,9 @@ export function pruneFinishedFakeIndexedDbTransactions(rawDatabase: unknown): nu
   }
 
   const transactions = matrixRawDatabase.transactions;
-  const activeTransactions = transactions.filter((transaction) => transaction?._state !== "finished");
+  const activeTransactions = transactions.filter(
+    (transaction) => transaction?.["_state"] !== "finished",
+  );
   const removed = transactions.length - activeTransactions.length;
   if (removed > 0) {
     transactions.splice(0, transactions.length, ...activeTransactions);
@@ -68,7 +78,11 @@ export function installFakeIndexedDbTransactionPruner(): void {
   const globalObject = globalThis as GlobalWithFakeIndexedDb;
   const databasePrototype = globalObject.IDBDatabase?.prototype;
   const originalTransaction = databasePrototype?.transaction;
-  if (!databasePrototype || typeof originalTransaction !== "function" || databasePrototype[PRUNER_INSTALLED]) {
+  if (
+    !databasePrototype ||
+    typeof originalTransaction !== "function" ||
+    databasePrototype[PRUNER_INSTALLED]
+  ) {
     return;
   }
 
@@ -84,9 +98,13 @@ export function installFakeIndexedDbTransactionPruner(): void {
   ): ReturnType<IDBDatabase["transaction"]> {
     pruneFinishedFakeIndexedDbTransactions(getRawDatabase(this));
 
-    const transaction = originalTransaction.apply(this, args) as IDBTransaction & FakeIndexedDbTransaction;
+    const transaction = originalTransaction.apply(this, args) as IDBTransaction &
+      FakeIndexedDbTransaction;
     const rawDatabase = getRawDatabase(transaction?.db) ?? getRawDatabase(this);
-    if (isMatrixCryptoDatabase(rawDatabase) && typeof transaction?.addEventListener === "function") {
+    if (
+      isMatrixCryptoDatabase(rawDatabase) &&
+      typeof transaction?.addEventListener === "function"
+    ) {
       const prune = (): void => {
         pruneFinishedFakeIndexedDbTransactions(rawDatabase);
       };


### PR DESCRIPTION
<!-- hermes-auto-maintainer -->

## Summary

- Adds a Matrix-owned fake-indexeddb transaction pruner that is installed immediately after `fake-indexeddb/auto` in the Matrix crypto runtime.
- Scopes pruning to Matrix rust-crypto IndexedDB stores whose names end with `::matrix-sdk-crypto`, so unrelated fake-indexeddb databases keep their current behavior.
- Adds a focused regression test covering Matrix crypto-store pruning, unrelated database non-pruning, and raw queue pruning that preserves active/inactive transactions.

## Test Plan

- RED proof: `node /tmp/openclaw-auto-90455/proof-red.mjs` against unpatched `fake-indexeddb@6.2.5` failed as expected with 6 retained finished transactions.
- GREEN proof: `./probe/node_modules/.bin/esbuild proof-green.ts --bundle --platform=node --format=esm --outfile=proof-green.mjs && node proof-green.mjs` passed against the patched helper/runtime source.
- Syntax/source checks: `esbuild` bundled `fake-indexeddb-prune.ts` and `fake-indexeddb-prune.test.ts` successfully in the API-only temp workspace.
- Whitespace check: `git diff --no-index --check main patched` reported no whitespace errors.



### CI repair follow-up (2026-06-12)

After the draft PR was rechecked, CI reported TypeScript-only failures in `extensions/matrix/src/matrix/sdk/fake-indexeddb-prune.ts`:

```text
extensions/matrix/src/matrix/sdk/fake-indexeddb-prune.ts(57,24): error TS18046: 'rawDatabase' is of type 'unknown'.
extensions/matrix/src/matrix/sdk/fake-indexeddb-prune.ts(58,51): error TS7006: Parameter 'transaction' implicitly has an 'any' type.
extensions/matrix/src/matrix/sdk/fake-indexeddb-prune.ts(80,3): error TS2322: patched transaction return type was `unknown`, not `IDBTransaction`.
```

API-only repair commit `264c6fbd2ba6c807fb79b35680aee466b50cd4f8` narrows the raw database before reading `transactions`, gives the patched prototype the DOM `IDBDatabase["transaction"]` signature, and returns `IDBTransaction & FakeIndexedDbTransaction`.

Verification run after the CI repair (temp source-level type probe, no clone):

```text
$ npx -y -p typescript@5.9.3 tsc -p /tmp/openclaw-pr-90628/tsconfig.fake-indexeddb-prune.json
# exit 0; no TypeScript diagnostics
```

## Real behavior proof

Behavior or issue addressed: Matrix E2EE uses fake-indexeddb for `openclaw-matrix-*::matrix-sdk-crypto` stores. Current fake-indexeddb 6.2.5 retains every finished transaction in the raw `transactions` array, which grows without bound during long-running Matrix crypto sync. This patch installs a Matrix-scoped runtime pruner so finished transactions are removed for Matrix crypto stores after completion/abort, without changing unrelated fake-indexeddb databases.

Real environment tested: API-only temp workspace `/tmp/openclaw-auto-90455` on macOS runner; Node.js v22.22.1; npm-installed `fake-indexeddb@6.2.5` and `esbuild@0.25.6`; source downloaded from `openclaw/openclaw` main via `gh api` (no clone).

Exact steps or command run after this patch:

```bash
cd /tmp/openclaw-auto-90455
./probe/node_modules/.bin/esbuild proof-green.ts --bundle --platform=node --format=esm --outfile=proof-green.mjs
node proof-green.mjs
./probe/node_modules/.bin/esbuild patched/extensions/matrix/src/matrix/sdk/fake-indexeddb-prune.ts --bundle --platform=node --format=esm --outfile=/tmp/openclaw-auto-90455/helper-check.mjs
./probe/node_modules/.bin/esbuild patched/extensions/matrix/src/matrix/sdk/fake-indexeddb-prune.test.ts --bundle --platform=node --format=esm --packages=external --outfile=/tmp/openclaw-auto-90455/test-check.mjs
git diff --no-index --check main patched
```

Evidence before fix (RED, expected failure):

```text
red_status=1
{"databaseName":"openclaw-matrix-proof-red-1780654376777::matrix-sdk-crypto","transactionsAfterFiveSequentialCommits":6,"finishedTransactions":6}
AssertionError [ERR_ASSERTION]: finished Matrix crypto transactions should be pruned
6 !== 0
Node.js v22.22.1
```

Evidence after fix:

```text
green_status=0
{
  "matrixResult": {
    "databaseName": "openclaw-matrix-proof-green-1780654737766::matrix-sdk-crypto",
    "transactionsAfterFiveSequentialCommits": 0,
    "finishedTransactions": 0
  },
  "unrelatedResult": {
    "databaseName": "openclaw-nonmatrix-proof-green-1780654737770",
    "transactionsAfterFiveSequentialCommits": 6,
    "finishedTransactions": 6
  },
  "sourceAssertions": "passed"
}
helper_esbuild=ok
test_esbuild=ok
git diff --check: no whitespace errors reported
```

Observed result after fix: Five sequential writes to a Matrix crypto-store database leave `raw.transactions.length === 0` and `finishedTransactions === 0`; the same probe against an unrelated fake-indexeddb database still retains 6 finished transactions, proving the mitigation is Matrix-scoped.

What was not tested: I did not run the full OpenClaw Vitest suite or a live Matrix gateway/E2EE sync because this cron run must stay API-only without cloning the OpenClaw repository or using a full checkout. The focused proof uses the real fake-indexeddb package and API-downloaded patched source.

## Risk/Notes

- This intentionally avoids the prior closed dependency-patch approach, so it does not change `pnpm-lock.yaml`, `pnpm-workspace.yaml`, shrinkwrap files, package versions, or dependency graph policy surfaces.
- The runtime patch is idempotent and only wraps `IDBDatabase.prototype.transaction` after fake-indexeddb installs the global `IDBDatabase` constructor.
- Pruning only removes transactions whose internal `_state` is `"finished"`; active/inactive/waiting transactions remain in the raw queue.

Fixes #90455

