### PR TITLE
fix(codex): enforce OpenClaw policy for native tool surfaces

### DIFF
--- a/extensions/codex/src/app-server/attempt-startup.test.ts
+++ b/extensions/codex/src/app-server/attempt-startup.test.ts
@@ -120,6 +120,7 @@ function startThreadWithHarness(
     finalConfigPatch: undefined,
     bundleMcpThreadConfig,
     nativeToolSurfaceEnabled: true,
+    preserveBindingWhenNativeCodeModeDisabled: false,
     sandboxExecServerEnabled: false,
     sandbox: null,
     contextEngineProjection: undefined,

--- a/extensions/codex/src/app-server/attempt-startup.ts
+++ b/extensions/codex/src/app-server/attempt-startup.ts
@@ -102,6 +102,7 @@ export async function startCodexAttemptThread(params: {
   nativeHookRelayGeneration?: string;
   bundleMcpThreadConfig: CodexBundleMcpThreadConfig;
   nativeToolSurfaceEnabled: boolean;
+  preserveBindingWhenNativeCodeModeDisabled: boolean;
   sandboxExecServerEnabled: boolean;
   sandbox: CodexSandboxContext;
   contextEngineProjection: CodexContextEngineThreadBootstrapProjection | undefined;
@@ -308,6 +309,8 @@ export async function startCodexAttemptThread(params: {
                 nativeHookRelayGeneration: params.nativeHookRelayGeneration,
                 nativeCodeModeEnabled: params.nativeToolSurfaceEnabled,
                 nativeCodeModeOnlyEnabled: params.appServer.codeModeOnly,
+                preserveBindingWhenNativeCodeModeDisabled:
+                  params.preserveBindingWhenNativeCodeModeDisabled,
                 userMcpServersEnabled: params.nativeToolSurfaceEnabled,
                 mcpServersFingerprint: params.bundleMcpThreadConfig.fingerprint,
                 mcpServersFingerprintEvaluated: params.bundleMcpThreadConfig.evaluated,

--- a/extensions/codex/src/app-server/dynamic-tool-build.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.test.ts
@@ -400,6 +400,34 @@ describe("Codex app-server dynamic tool build", () => {
     expect(runtimePolicyTools.map((tool) => tool.name)).toEqual(["message", "exec", "process"]);
   });
 
+  it("keeps OpenClaw shell tools when before_tool_call policy disables native Code Mode", async () => {
+    setOpenClawCodingToolsFactoryForTests(() => [
+      createRuntimeDynamicTool("exec"),
+      createRuntimeDynamicTool("process"),
+      createRuntimeDynamicTool("message"),
+    ]);
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createParams(sessionFile, workspaceDir);
+    params.disableTools = false;
+    params.runtimePlan = createCodexRuntimePlanFixture();
+    const nativeToolSurfaceEnabled = shouldEnableCodexAppServerNativeToolSurface(
+      params,
+      undefined,
+      {
+        beforeToolCallPolicyActive: true,
+      },
+    );
+
+    const tools = await buildDynamicToolsForTest(params, workspaceDir, {
+      nativeToolSurfaceEnabled,
+      beforeToolCallPolicyActive: true,
+    });
+
+    expect(nativeToolSurfaceEnabled).toBe(false);
+    expect(tools.map((tool) => tool.name)).toEqual(["message", "exec", "process"]);
+  });
+
   it("exposes Docker sandbox shell tools when native Code Mode cannot honor sandbox paths", async () => {
     setOpenClawCodingToolsFactoryForTests(() => [
       createRuntimeDynamicTool("exec"),
@@ -734,6 +762,18 @@ describe("Codex app-server dynamic tool build", () => {
 
     params.toolsAllow = ["message"];
     expect(shouldEnableCodexAppServerNativeToolSurface(params)).toBe(false);
+  });
+
+  it("disables Codex native tool surfaces when OpenClaw before_tool_call policy is active", () => {
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);
+    params.disableTools = false;
+
+    expect(
+      shouldEnableCodexAppServerNativeToolSurface(params, undefined, {
+        beforeToolCallPolicyActive: true,
+      }),
+    ).toBe(false);
   });
 
   it("disables Codex native tool surfaces when the effective exec target is node", () => {

--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -62,6 +62,7 @@ export type DynamicToolBuildParams = {
   sandboxSessionKey: string;
   sandbox: OpenClawSandboxContext;
   nativeToolSurfaceEnabled?: boolean;
+  beforeToolCallPolicyActive?: boolean;
   runAbortController: AbortController;
   sessionAgentId: string;
   pluginConfig: CodexPluginConfig;
@@ -391,9 +392,13 @@ export function shouldEnableCodexAppServerNativeToolSurface(
     agentId?: string;
     runtimeSessionKey?: string;
     sandboxExecServerEnabled?: boolean;
+    beforeToolCallPolicyActive?: boolean;
   } = {},
 ): boolean {
   if (isCodexMemoryFlushRun(params)) {
+    return false;
+  }
+  if (options.beforeToolCallPolicyActive === true) {
     return false;
   }
   if (
@@ -637,14 +642,7 @@ function addNodeShellDynamicToolsIfNeeded(
   allTools: OpenClawDynamicTool[],
   input: DynamicToolBuildParams,
 ): OpenClawDynamicTool[] {
-  if (
-    isCodexMemoryFlushRun(input.params) ||
-    !isCodexNativeExecutionBlockedByNodeExecHost(input.params, {
-      agentId: input.sessionAgentId,
-      runtimeSessionKey: input.sandboxSessionKey,
-      sandbox: input.sandbox,
-    })
-  ) {
+  if (!shouldExposeOpenClawNodeShellDynamicTools(input)) {
     return filteredTools;
   }
   let next = filteredTools;
@@ -667,6 +665,26 @@ function addNodeShellDynamicToolsIfNeeded(
     next.push(tool);
   }
   return next;
+}
+
+function shouldExposeOpenClawNodeShellDynamicTools(input: DynamicToolBuildParams): boolean {
+  if (isCodexMemoryFlushRun(input.params)) {
+    return false;
+  }
+  if (
+    isCodexNativeExecutionBlockedByNodeExecHost(input.params, {
+      agentId: input.sessionAgentId,
+      runtimeSessionKey: input.sandboxSessionKey,
+      sandbox: input.sandbox,
+    })
+  ) {
+    return true;
+  }
+  return (
+    input.beforeToolCallPolicyActive === true &&
+    input.nativeToolSurfaceEnabled === false &&
+    input.sandbox?.enabled !== true
+  );
 }
 
 /** Applies a normalized tool allowlist while preserving sandbox shell aliases for exec/process. */

--- a/extensions/codex/src/app-server/native-hook-relay.test.ts
+++ b/extensions/codex/src/app-server/native-hook-relay.test.ts
@@ -17,7 +17,6 @@ describe("Codex native hook relay config", () => {
 
     expect(config).toEqual({
       "features.hooks": true,
-      bypass_hook_trust: true,
       "hooks.PreToolUse": [
         {
           hooks: [
@@ -123,7 +122,6 @@ describe("Codex native hook relay config", () => {
       }),
     ).toEqual({
       "features.hooks": true,
-      bypass_hook_trust: true,
       "hooks.PermissionRequest": [
         {
           hooks: [
@@ -159,7 +157,6 @@ describe("Codex native hook relay config", () => {
       }),
     ).toEqual({
       "features.hooks": true,
-      bypass_hook_trust: true,
       "hooks.PreToolUse": [
         {
           hooks: [
@@ -197,7 +194,6 @@ describe("Codex native hook relay config", () => {
       }),
     ).toEqual({
       "features.hooks": true,
-      bypass_hook_trust: true,
       "hooks.PreToolUse": [
         {
           hooks: [
@@ -234,7 +230,6 @@ describe("Codex native hook relay config", () => {
       }),
     ).toEqual({
       "features.hooks": true,
-      bypass_hook_trust: true,
       "hooks.PreToolUse": [],
       "hooks.PostToolUse": [],
       "hooks.PermissionRequest": [

--- a/extensions/codex/src/app-server/native-hook-relay.test.ts
+++ b/extensions/codex/src/app-server/native-hook-relay.test.ts
@@ -17,6 +17,7 @@ describe("Codex native hook relay config", () => {
 
     expect(config).toEqual({
       "features.hooks": true,
+      bypass_hook_trust: true,
       "hooks.PreToolUse": [
         {
           hooks: [
@@ -122,6 +123,7 @@ describe("Codex native hook relay config", () => {
       }),
     ).toEqual({
       "features.hooks": true,
+      bypass_hook_trust: true,
       "hooks.PermissionRequest": [
         {
           hooks: [
@@ -157,6 +159,7 @@ describe("Codex native hook relay config", () => {
       }),
     ).toEqual({
       "features.hooks": true,
+      bypass_hook_trust: true,
       "hooks.PreToolUse": [
         {
           hooks: [
@@ -186,7 +189,7 @@ describe("Codex native hook relay config", () => {
     });
   });
 
-  it("keeps selected no-policy PreToolUse installed with an unavailable no-op marker", () => {
+  it("keeps selected no-policy PreToolUse installed without an unavailable no-op marker", () => {
     expect(
       buildCodexNativeHookRelayConfig({
         relay: createRelay({ inactiveEvents: ["pre_tool_use"] }),
@@ -194,13 +197,14 @@ describe("Codex native hook relay config", () => {
       }),
     ).toEqual({
       "features.hooks": true,
+      bypass_hook_trust: true,
       "hooks.PreToolUse": [
         {
           hooks: [
             {
               type: "command",
               command:
-                "openclaw hooks relay --provider codex --relay-id relay-1 --generation generation-1 --event pre_tool_use --pre-tool-use-unavailable noop",
+                "openclaw hooks relay --provider codex --relay-id relay-1 --generation generation-1 --event pre_tool_use",
               timeout: 5,
               async: false,
               statusMessage: "OpenClaw native hook relay",
@@ -230,6 +234,7 @@ describe("Codex native hook relay config", () => {
       }),
     ).toEqual({
       "features.hooks": true,
+      bypass_hook_trust: true,
       "hooks.PreToolUse": [],
       "hooks.PostToolUse": [],
       "hooks.PermissionRequest": [
@@ -312,11 +317,7 @@ function createRelay(options?: {
     expiresAtMs: Date.now() + 1000,
     shouldRelayEvent: (event) => !inactiveEvents.has(event),
     commandForEvent: (event) =>
-      `openclaw hooks relay --provider codex --relay-id relay-1 --generation generation-1 --event ${event}${
-        event === "pre_tool_use" && inactiveEvents.has(event)
-          ? " --pre-tool-use-unavailable noop"
-          : ""
-      }`,
+      `openclaw hooks relay --provider codex --relay-id relay-1 --generation generation-1 --event ${event}`,
     renew: () => undefined,
     unregister: () => undefined,
   };

--- a/extensions/codex/src/app-server/native-hook-relay.ts
+++ b/extensions/codex/src/app-server/native-hook-relay.ts
@@ -241,9 +241,6 @@ export function buildCodexNativeHookRelayConfig(params: {
   const selectedEvents = new Set<NativeHookRelayEvent>(events);
   const config: JsonObject = {
     "features.hooks": true,
-    // OpenClaw owns this per-thread relay command and computes its trust state;
-    // tell Codex app-server not to suppress these managed hooks at startup.
-    bypass_hook_trust: true,
   };
   const hookState: JsonObject = {};
   for (const event of CODEX_NATIVE_HOOK_RELAY_EVENTS) {

--- a/extensions/codex/src/app-server/native-hook-relay.ts
+++ b/extensions/codex/src/app-server/native-hook-relay.ts
@@ -241,16 +241,19 @@ export function buildCodexNativeHookRelayConfig(params: {
   const selectedEvents = new Set<NativeHookRelayEvent>(events);
   const config: JsonObject = {
     "features.hooks": true,
+    // OpenClaw owns this per-thread relay command and computes its trust state;
+    // tell Codex app-server not to suppress these managed hooks at startup.
+    bypass_hook_trust: true,
   };
   const hookState: JsonObject = {};
   for (const event of CODEX_NATIVE_HOOK_RELAY_EVENTS) {
     const codexEvent = CODEX_HOOK_EVENT_BY_NATIVE_EVENT[event];
     const selected = selectedEvents.has(event);
     const shouldRelay = params.relay.shouldRelayEvent(event);
-    // Keep no-policy PreToolUse commands installed with an explicit no-op marker;
-    // otherwise a stale relay fallback cannot distinguish no policy from unknown policy.
-    const selectedNoopPreToolUse = selected && event === "pre_tool_use" && !shouldRelay;
-    if (!selected || (!shouldRelay && !selectedNoopPreToolUse)) {
+    // Keep selected PreToolUse commands installed even before hook-only plugins
+    // have loaded; unavailable PreToolUse must still fail closed.
+    const selectedPreToolUse = selected && event === "pre_tool_use";
+    if (!selected || (!shouldRelay && !selectedPreToolUse)) {
       if (selected || params.clearOmittedEvents) {
         config[`hooks.${codexEvent}`] = [] satisfies JsonValue;
       }

--- a/extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts
@@ -44,7 +44,7 @@ describe("runCodexAppServerAttempt native hook relay", () => {
     const startConfig = (startRequest?.params as { config?: Record<string, unknown> } | undefined)
       ?.config;
     expect(startConfig?.["features.hooks"]).toBe(true);
-    expect(startConfig?.bypass_hook_trust).toBe(true);
+    expect(startConfig).not.toHaveProperty("bypass_hook_trust");
     const preToolUseHooks = startConfig?.["hooks.PreToolUse"] as
       | Array<{ hooks?: Array<{ command?: string; timeout?: number; type?: string }> }>
       | undefined;
@@ -272,7 +272,7 @@ describe("runCodexAppServerAttempt native hook relay", () => {
     const startConfig = (startRequest?.params as { config?: Record<string, unknown> } | undefined)
       ?.config;
     expect(startConfig?.["features.hooks"]).toBe(true);
-    expect(startConfig?.bypass_hook_trust).toBe(true);
+    expect(startConfig).not.toHaveProperty("bypass_hook_trust");
     expect(Array.isArray(startConfig?.["hooks.PreToolUse"])).toBe(true);
     expect(startConfig?.["hooks.PostToolUse"]).toEqual([]);
     expect(startConfig?.["hooks.Stop"]).toEqual([]);
@@ -310,7 +310,7 @@ describe("runCodexAppServerAttempt native hook relay", () => {
     const startConfig = (startRequest?.params as { config?: Record<string, unknown> } | undefined)
       ?.config;
     expect(startConfig?.["features.hooks"]).toBe(true);
-    expect(startConfig?.bypass_hook_trust).toBe(true);
+    expect(startConfig).not.toHaveProperty("bypass_hook_trust");
     expect(Array.isArray(startConfig?.["hooks.PermissionRequest"])).toBe(true);
     const relayId = extractRelayIdFromThreadRequest(startRequest?.params);
     expect(
@@ -493,7 +493,7 @@ describe("runCodexAppServerAttempt native hook relay", () => {
     testing.flushPendingCodexNativeHookRelayUnregistersForTests();
   });
 
-  it("starts a fresh thread when a native-hook-enabled turn finds a pre-generation binding", async () => {
+  it("resumes and annotates pre-generation bindings with the active native hook relay generation", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");
     await writeCodexAppServerBinding(sessionFile, {
@@ -503,7 +503,7 @@ describe("runCodexAppServerAttempt native hook relay", () => {
       modelProvider: "openai",
       dynamicToolsFingerprint: "[]",
     });
-    const harness = createStartedThreadHarness();
+    const harness = createResumeHarness();
 
     const run = runCodexAppServerAttempt(createParams(sessionFile, workspaceDir), {
       nativeHookRelay: {
@@ -513,26 +513,25 @@ describe("runCodexAppServerAttempt native hook relay", () => {
     });
     await harness.waitForMethod("turn/start");
 
-    expect(harness.requests.map((request) => request.method)).not.toContain("thread/resume");
-    const startRequest = harness.requests.find((request) => request.method === "thread/start");
-    const relayId = extractRelayIdFromThreadRequest(startRequest?.params);
-    const currentGeneration = extractGenerationFromThreadRequest(startRequest?.params);
-    expect(currentGeneration).not.toBe("legacy-generation-from-running-thread");
+    expect(harness.requests.map((request) => request.method)).not.toContain("thread/start");
+    const resumeRequest = harness.requests.find((request) => request.method === "thread/resume");
+    const relayId = extractRelayIdFromThreadRequest(resumeRequest?.params);
+    const currentGeneration = extractGenerationFromThreadRequest(resumeRequest?.params);
     await expect(
       invokeNativeHookRelay({
         provider: "codex",
         relayId,
-        generation: "legacy-generation-from-running-thread",
+        generation: currentGeneration,
         event: "pre_tool_use",
         requireGeneration: true,
         rawPayload: {
           hook_event_name: "PreToolUse",
           tool_name: "Bash",
-          tool_use_id: "first-tool-after-restart",
+          tool_use_id: "first-tool-after-resume",
           tool_input: { command: "pwd" },
         },
       }),
-    ).rejects.toThrow("native hook relay bridge stale registration");
+    ).resolves.toMatchObject({ exitCode: 0 });
     await expect(
       invokeNativeHookRelay({
         provider: "codex",
@@ -547,9 +546,9 @@ describe("runCodexAppServerAttempt native hook relay", () => {
           tool_input: { command: "pwd" },
         },
       }),
-    ).rejects.toThrow("native hook relay bridge stale registration");
+    ).resolves.toMatchObject({ exitCode: 0 });
 
-    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await harness.completeTurn({ threadId: "thread-existing", turnId: "turn-1" });
     await run;
     expect((await readCodexAppServerBinding(sessionFile))?.nativeHookRelayGeneration).toBe(
       currentGeneration,

--- a/extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts
@@ -44,6 +44,7 @@ describe("runCodexAppServerAttempt native hook relay", () => {
     const startConfig = (startRequest?.params as { config?: Record<string, unknown> } | undefined)
       ?.config;
     expect(startConfig?.["features.hooks"]).toBe(true);
+    expect(startConfig?.bypass_hook_trust).toBe(true);
     const preToolUseHooks = startConfig?.["hooks.PreToolUse"] as
       | Array<{ hooks?: Array<{ command?: string; timeout?: number; type?: string }> }>
       | undefined;
@@ -51,6 +52,7 @@ describe("runCodexAppServerAttempt native hook relay", () => {
     expect(preToolUseCommand?.type).toBe("command");
     expect(preToolUseCommand?.timeout).toBe(9);
     expect(preToolUseCommand?.command).toContain("--event pre_tool_use --timeout 4321");
+    expect(preToolUseCommand?.command).not.toContain("--pre-tool-use-unavailable");
     const hookState = startConfig?.["hooks.state"] as Record<
       string,
       { enabled?: unknown; trusted_hash?: unknown }
@@ -270,6 +272,7 @@ describe("runCodexAppServerAttempt native hook relay", () => {
     const startConfig = (startRequest?.params as { config?: Record<string, unknown> } | undefined)
       ?.config;
     expect(startConfig?.["features.hooks"]).toBe(true);
+    expect(startConfig?.bypass_hook_trust).toBe(true);
     expect(Array.isArray(startConfig?.["hooks.PreToolUse"])).toBe(true);
     expect(startConfig?.["hooks.PostToolUse"]).toEqual([]);
     expect(startConfig?.["hooks.Stop"]).toEqual([]);
@@ -307,6 +310,7 @@ describe("runCodexAppServerAttempt native hook relay", () => {
     const startConfig = (startRequest?.params as { config?: Record<string, unknown> } | undefined)
       ?.config;
     expect(startConfig?.["features.hooks"]).toBe(true);
+    expect(startConfig?.bypass_hook_trust).toBe(true);
     expect(Array.isArray(startConfig?.["hooks.PermissionRequest"])).toBe(true);
     const relayId = extractRelayIdFromThreadRequest(startRequest?.params);
     expect(
@@ -489,7 +493,7 @@ describe("runCodexAppServerAttempt native hook relay", () => {
     testing.flushPendingCodexNativeHookRelayUnregistersForTests();
   });
 
-  it("accepts a stale first hook generation when resuming a pre-generation binding", async () => {
+  it("starts a fresh thread when a native-hook-enabled turn finds a pre-generation binding", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");
     await writeCodexAppServerBinding(sessionFile, {
@@ -499,7 +503,7 @@ describe("runCodexAppServerAttempt native hook relay", () => {
       modelProvider: "openai",
       dynamicToolsFingerprint: "[]",
     });
-    const harness = createResumeHarness();
+    const harness = createStartedThreadHarness();
 
     const run = runCodexAppServerAttempt(createParams(sessionFile, workspaceDir), {
       nativeHookRelay: {
@@ -509,9 +513,10 @@ describe("runCodexAppServerAttempt native hook relay", () => {
     });
     await harness.waitForMethod("turn/start");
 
-    const resumeRequest = harness.requests.find((request) => request.method === "thread/resume");
-    const relayId = extractRelayIdFromThreadRequest(resumeRequest?.params);
-    const currentGeneration = extractGenerationFromThreadRequest(resumeRequest?.params);
+    expect(harness.requests.map((request) => request.method)).not.toContain("thread/resume");
+    const startRequest = harness.requests.find((request) => request.method === "thread/start");
+    const relayId = extractRelayIdFromThreadRequest(startRequest?.params);
+    const currentGeneration = extractGenerationFromThreadRequest(startRequest?.params);
     expect(currentGeneration).not.toBe("legacy-generation-from-running-thread");
     await expect(
       invokeNativeHookRelay({
@@ -527,7 +532,7 @@ describe("runCodexAppServerAttempt native hook relay", () => {
           tool_input: { command: "pwd" },
         },
       }),
-    ).resolves.toMatchObject({ exitCode: 0 });
+    ).rejects.toThrow("native hook relay bridge stale registration");
     await expect(
       invokeNativeHookRelay({
         provider: "codex",
@@ -544,7 +549,7 @@ describe("runCodexAppServerAttempt native hook relay", () => {
       }),
     ).rejects.toThrow("native hook relay bridge stale registration");
 
-    await harness.completeTurn({ threadId: "thread-existing", turnId: "turn-1" });
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
     await run;
     expect((await readCodexAppServerBinding(sessionFile))?.nativeHookRelayGeneration).toBe(
       currentGeneration,
@@ -689,6 +694,7 @@ describe("runCodexAppServerAttempt native hook relay", () => {
     const startConfig = (startRequest?.params as { config?: Record<string, unknown> } | undefined)
       ?.config;
     expect(startConfig?.["features.hooks"]).toBe(false);
+    expect(startConfig).not.toHaveProperty("bypass_hook_trust");
     expect(startConfig?.["hooks.PreToolUse"]).toEqual([]);
     expect(startConfig?.["hooks.PostToolUse"]).toEqual([]);
     expect(startConfig?.["hooks.PermissionRequest"]).toEqual([]);

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -1573,6 +1573,30 @@ describe("runCodexAppServerAttempt", () => {
     expect(request.mock.calls.map(([method]) => method)).not.toContain("app/list");
   });
 
+  it("disables bundled MCP when runtime policy disables native tool surfaces", () => {
+    expect(
+      testing.resolveCodexBundleMcpToolsAllow({
+        nodeExecBlocksNativeExecution: false,
+        nativeToolSurfaceEnabled: false,
+        toolsAllow: ["web_search"],
+      }),
+    ).toEqual([]);
+    expect(
+      testing.resolveCodexBundleMcpToolsAllow({
+        nodeExecBlocksNativeExecution: true,
+        nativeToolSurfaceEnabled: true,
+        toolsAllow: ["web_search"],
+      }),
+    ).toEqual([]);
+    expect(
+      testing.resolveCodexBundleMcpToolsAllow({
+        nodeExecBlocksNativeExecution: false,
+        nativeToolSurfaceEnabled: true,
+        toolsAllow: ["web_search"],
+      }),
+    ).toEqual(["web_search"]);
+  });
+
   it("fails closed for Codex app defaults when restricted native tools have no plugin config", async () => {
     testing.setOpenClawCodingToolsFactoryForTests(() => [createRuntimeDynamicTool("message")]);
     const params = createParams(

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -2725,9 +2725,17 @@ describe("runCodexAppServerAttempt", () => {
     await run;
 
     const startRequest = harness.requests.find((request) => request.method === "thread/start");
-    const startParams = startRequest?.params as Record<string, unknown> | undefined;
+    const startParams = startRequest?.params as
+      | {
+          approvalPolicy?: string;
+          sandbox?: string;
+          config?: Record<string, unknown>;
+        }
+      | undefined;
     expect(startParams?.approvalPolicy).toBe("untrusted");
     expect(startParams?.sandbox).toBe("danger-full-access");
+    expect(startParams?.config?.["features.code_mode"]).toBe(false);
+    expect(startParams?.config?.["features.code_mode_only"]).toBe(false);
     expect(info).toHaveBeenCalledWith(
       "codex app-server approval policy promoted for OpenClaw tool policy",
       {

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -1577,24 +1577,57 @@ describe("runCodexAppServerAttempt", () => {
     expect(
       testing.resolveCodexBundleMcpToolsAllow({
         nodeExecBlocksNativeExecution: false,
-        nativeToolSurfaceEnabled: false,
+        policyDisablesNativeToolSurface: true,
         toolsAllow: ["web_search"],
       }),
     ).toEqual([]);
     expect(
       testing.resolveCodexBundleMcpToolsAllow({
         nodeExecBlocksNativeExecution: true,
-        nativeToolSurfaceEnabled: true,
+        policyDisablesNativeToolSurface: false,
         toolsAllow: ["web_search"],
       }),
     ).toEqual([]);
     expect(
       testing.resolveCodexBundleMcpToolsAllow({
         nodeExecBlocksNativeExecution: false,
-        nativeToolSurfaceEnabled: true,
+        policyDisablesNativeToolSurface: false,
+        toolsAllow: ["bundle-mcp"],
+      }),
+    ).toEqual(["bundle-mcp"]);
+    expect(
+      testing.resolveCodexBundleMcpToolsAllow({
+        nodeExecBlocksNativeExecution: false,
+        policyDisablesNativeToolSurface: false,
         toolsAllow: ["web_search"],
       }),
     ).toEqual(["web_search"]);
+  });
+
+  it("keeps context-engine startup binding visible for policy-disabled resume turns", () => {
+    const startupBinding = { threadId: "thread-bootstrapped" } as never;
+
+    expect(
+      testing.resolveContextEngineDecisionStartupBinding({
+        nativeToolSurfaceEnabled: false,
+        preserveNativeDisabledBinding: true,
+        startupBinding,
+      }),
+    ).toBe(startupBinding);
+    expect(
+      testing.resolveContextEngineDecisionStartupBinding({
+        nativeToolSurfaceEnabled: false,
+        preserveNativeDisabledBinding: false,
+        startupBinding,
+      }),
+    ).toBeUndefined();
+    expect(
+      testing.resolveContextEngineDecisionStartupBinding({
+        nativeToolSurfaceEnabled: true,
+        preserveNativeDisabledBinding: false,
+        startupBinding,
+      }),
+    ).toBe(startupBinding);
   });
 
   it("fails closed for Codex app defaults when restricted native tools have no plugin config", async () => {

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -366,6 +366,9 @@ export async function runCodexAppServerAttempt(
     agentId: params.agentId,
   });
   const beforeToolCallPolicy = getBeforeToolCallPolicyDiagnosticState();
+  const beforeToolCallPolicyActive =
+    beforeToolCallPolicy.hasBeforeToolCallHook ||
+    beforeToolCallPolicy.trustedToolPolicies.length > 0;
   preDynamicStartupStages.mark("config");
   const resolvedWorkspace = resolveUserPath(params.workspaceDir);
   await ensureCodexWorkspaceDirOnce(resolvedWorkspace);
@@ -408,9 +411,7 @@ export async function runCodexAppServerAttempt(
     appServer: configuredAppServer,
     pluginConfig,
     env: process.env,
-    shouldPromote:
-      beforeToolCallPolicy.hasBeforeToolCallHook ||
-      beforeToolCallPolicy.trustedToolPolicies.length > 0,
+    shouldPromote: beforeToolCallPolicyActive,
     execPolicy,
     canUseUntrustedApprovalPolicy:
       configuredAppServer.start.transport !== "stdio" ||
@@ -525,6 +526,7 @@ export async function runCodexAppServerAttempt(
     agentId: sessionAgentId,
     runtimeSessionKey: sandboxSessionKey,
     sandboxExecServerEnabled,
+    beforeToolCallPolicyActive,
   });
   preDynamicStartupStages.mark("native-tool-surface");
   for (const diagnostic of bundleMcpThreadConfig.diagnostics) {
@@ -564,6 +566,7 @@ export async function runCodexAppServerAttempt(
     sandboxSessionKey,
     sandbox,
     nativeToolSurfaceEnabled,
+    beforeToolCallPolicyActive,
     runAbortController,
     sessionAgentId,
     pluginConfig,
@@ -581,6 +584,7 @@ export async function runCodexAppServerAttempt(
     sandboxSessionKey,
     sandbox,
     nativeToolSurfaceEnabled,
+    beforeToolCallPolicyActive,
     runAbortController,
     sessionAgentId,
     pluginConfig,

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -513,14 +513,6 @@ export async function runCodexAppServerAttempt(
     sandbox,
   });
   preDynamicStartupStages.mark("native-exec-policy");
-  const bundleMcpThreadConfig = await loadCodexBundleMcpThreadConfig({
-    workspaceDir: effectiveWorkspace,
-    cfg: params.config,
-    toolsEnabled: supportsModelTools(params.model),
-    disableTools: params.disableTools,
-    toolsAllow: nodeExecBlocksNativeExecution ? [] : params.toolsAllow,
-  });
-  preDynamicStartupStages.mark("bundle-mcp");
   const sandboxExecServerEnabled = isCodexSandboxExecServerEnabled(pluginConfig);
   const nativeToolSurfaceEnabled = shouldEnableCodexAppServerNativeToolSurface(params, sandbox, {
     agentId: sessionAgentId,
@@ -529,6 +521,18 @@ export async function runCodexAppServerAttempt(
     beforeToolCallPolicyActive,
   });
   preDynamicStartupStages.mark("native-tool-surface");
+  const bundleMcpThreadConfig = await loadCodexBundleMcpThreadConfig({
+    workspaceDir: effectiveWorkspace,
+    cfg: params.config,
+    toolsEnabled: supportsModelTools(params.model),
+    disableTools: params.disableTools,
+    toolsAllow: resolveCodexBundleMcpToolsAllow({
+      nodeExecBlocksNativeExecution,
+      nativeToolSurfaceEnabled,
+      toolsAllow: params.toolsAllow,
+    }),
+  });
+  preDynamicStartupStages.mark("bundle-mcp");
   for (const diagnostic of bundleMcpThreadConfig.diagnostics) {
     embeddedAgentLog.warn(`bundle-mcp: ${diagnostic.pluginId}: ${diagnostic.message}`);
   }
@@ -1083,6 +1087,7 @@ export async function runCodexAppServerAttempt(
       buildFinalConfigPatch: buildNativeHookRelayFinalConfigPatch,
       bundleMcpThreadConfig,
       nativeToolSurfaceEnabled,
+      preserveBindingWhenNativeCodeModeDisabled: beforeToolCallPolicyActive,
       sandboxExecServerEnabled,
       sandbox,
       contextEngineProjection,
@@ -2648,6 +2653,16 @@ function waitForCodexNotificationDispatchTurn(): Promise<void> {
   });
 }
 
+function resolveCodexBundleMcpToolsAllow(params: {
+  nodeExecBlocksNativeExecution: boolean;
+  nativeToolSurfaceEnabled: boolean;
+  toolsAllow?: string[];
+}): string[] | undefined {
+  return params.nodeExecBlocksNativeExecution || !params.nativeToolSurfaceEnabled
+    ? []
+    : params.toolsAllow;
+}
+
 function handleApprovalRequest(params: {
   method: string;
   params: JsonValue | undefined;
@@ -2681,6 +2696,7 @@ export const testing = {
   resolveCodexAppServerHookChannelId,
   buildCodexAppServerPromptTimeoutOutcome,
   resolveOpenClawCodingToolsSessionKeys,
+  resolveCodexBundleMcpToolsAllow,
   shouldEnableCodexAppServerNativeToolSurface,
   shouldForceMessageTool,
   hasPendingDynamicToolTerminalDiagnostic,

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -528,7 +528,7 @@ export async function runCodexAppServerAttempt(
     disableTools: params.disableTools,
     toolsAllow: resolveCodexBundleMcpToolsAllow({
       nodeExecBlocksNativeExecution,
-      nativeToolSurfaceEnabled,
+      policyDisablesNativeToolSurface: beforeToolCallPolicyActive && !nativeToolSurfaceEnabled,
       toolsAllow: params.toolsAllow,
     }),
   });
@@ -615,6 +615,8 @@ export async function runCodexAppServerAttempt(
       channelId: hookChannelId,
     },
   });
+  const preserveNativeDisabledBinding =
+    beforeToolCallPolicyActive && !nativeToolSurfaceEnabled && toolBridge.specs.length > 0;
   const hadSessionFile = await pathExists(activeSessionFile);
   let historyMessages = (await readMirroredSessionHistoryMessages(activeSessionFile)) ?? [];
   const hookContextWindowFields = {
@@ -786,7 +788,11 @@ export async function runCodexAppServerAttempt(
   if (activeContextEngine) {
     try {
       await applyActiveContextEngineProjection(
-        !nativeToolSurfaceEnabled ? undefined : startupBinding,
+        resolveContextEngineDecisionStartupBinding({
+          nativeToolSurfaceEnabled,
+          preserveNativeDisabledBinding,
+          startupBinding,
+        }),
       );
     } catch (assembleErr) {
       embeddedAgentLog.warn("context engine assemble failed; using Codex baseline prompt", {
@@ -1087,7 +1093,7 @@ export async function runCodexAppServerAttempt(
       buildFinalConfigPatch: buildNativeHookRelayFinalConfigPatch,
       bundleMcpThreadConfig,
       nativeToolSurfaceEnabled,
-      preserveBindingWhenNativeCodeModeDisabled: beforeToolCallPolicyActive,
+      preserveBindingWhenNativeCodeModeDisabled: preserveNativeDisabledBinding,
       sandboxExecServerEnabled,
       sandbox,
       contextEngineProjection,
@@ -2655,12 +2661,22 @@ function waitForCodexNotificationDispatchTurn(): Promise<void> {
 
 function resolveCodexBundleMcpToolsAllow(params: {
   nodeExecBlocksNativeExecution: boolean;
-  nativeToolSurfaceEnabled: boolean;
+  policyDisablesNativeToolSurface: boolean;
   toolsAllow?: string[];
 }): string[] | undefined {
-  return params.nodeExecBlocksNativeExecution || !params.nativeToolSurfaceEnabled
+  return params.nodeExecBlocksNativeExecution || params.policyDisablesNativeToolSurface
     ? []
     : params.toolsAllow;
+}
+
+function resolveContextEngineDecisionStartupBinding(params: {
+  nativeToolSurfaceEnabled: boolean;
+  preserveNativeDisabledBinding: boolean;
+  startupBinding?: CodexAppServerThreadBinding;
+}): CodexAppServerThreadBinding | undefined {
+  return !params.nativeToolSurfaceEnabled && !params.preserveNativeDisabledBinding
+    ? undefined
+    : params.startupBinding;
 }
 
 function handleApprovalRequest(params: {
@@ -2697,6 +2713,7 @@ export const testing = {
   buildCodexAppServerPromptTimeoutOutcome,
   resolveOpenClawCodingToolsSessionKeys,
   resolveCodexBundleMcpToolsAllow,
+  resolveContextEngineDecisionStartupBinding,
   shouldEnableCodexAppServerNativeToolSurface,
   shouldForceMessageTool,
   hasPendingDynamicToolTerminalDiagnostic,

--- a/extensions/codex/src/app-server/side-question.test.ts
+++ b/extensions/codex/src/app-server/side-question.test.ts
@@ -1041,48 +1041,12 @@ describe("runCodexAppServerSideQuestion", () => {
     expect(activeDiagnosticToolKeys(diagnosticEvents)).toEqual(new Set());
   });
 
-  it("normalizes hook channel ids for side-thread dynamic tool requests", async () => {
-    const beforeToolCall = vi.fn((...args: unknown[]) => {
-      const context = args[1] as { channelId?: string };
-      expect(context.channelId).toBe("voice-room");
-      return undefined;
-    });
+  it("rejects side threads while OpenClaw before_tool_call policy is active", async () => {
+    const beforeToolCall = vi.fn();
     initializeGlobalHookRunner(
       createMockPluginRegistry([{ hookName: "before_tool_call", handler: beforeToolCall }]),
     );
     const client = createFakeClient();
-    client.request.mockImplementation(async (method: string) => {
-      if (method === "thread/fork") {
-        return threadResult("side-thread");
-      }
-      if (method === "thread/inject_items") {
-        return {};
-      }
-      if (method === "turn/start") {
-        setTimeout(() => {
-          void (async () => {
-            await client.handleRequest({
-              id: 42,
-              method: "item/tool/call",
-              params: {
-                threadId: "side-thread",
-                turnId: "turn-1",
-                callId: "tool-1",
-                tool: "wiki_status",
-                arguments: { topic: "AGENTS.md" },
-              },
-            });
-            client.emit(agentDelta("side-thread", "turn-1", "Tool answer."));
-            client.emit(turnCompleted("side-thread", "turn-1", "Tool answer."));
-          })();
-        }, 0);
-        return turnStartResult("turn-1");
-      }
-      if (method === "thread/unsubscribe" || method === "turn/interrupt") {
-        return {};
-      }
-      throw new Error(`unexpected request: ${method}`);
-    });
     getSharedCodexAppServerClientMock.mockResolvedValue(client);
 
     await expect(
@@ -1093,13 +1057,13 @@ describe("runCodexAppServerSideQuestion", () => {
           currentChannelId: "discord:voice-room",
         }),
       ),
-    ).resolves.toEqual({ text: "Tool answer." });
+    ).rejects.toThrow("Codex /btw is disabled while OpenClaw before_tool_call");
 
-    expect(beforeToolCall).toHaveBeenCalledTimes(1);
-    expect(createOpenClawCodingToolsMock).toHaveBeenCalledWith(
-      expect.objectContaining({ hookChannelId: "voice-room" }),
-    );
-    expect(toolExecuteMock).toHaveBeenCalledTimes(1);
+    expect(beforeToolCall).not.toHaveBeenCalled();
+    expect(getSharedCodexAppServerClientMock).not.toHaveBeenCalled();
+    expect(client.request).not.toHaveBeenCalled();
+    expect(createOpenClawCodingToolsMock).not.toHaveBeenCalled();
+    expect(toolExecuteMock).not.toHaveBeenCalled();
   });
 
   it("returns an empty response for side-thread user input requests", async () => {

--- a/extensions/codex/src/app-server/side-question.ts
+++ b/extensions/codex/src/app-server/side-question.ts
@@ -3,6 +3,7 @@ import {
   buildAgentHookContextChannelFields,
   embeddedAgentLog,
   formatErrorMessage,
+  getBeforeToolCallPolicyDiagnosticState,
   resolveAgentDir,
   resolveAttemptSpawnWorkspaceDir,
   resolveModelAuthMode,
@@ -144,6 +145,15 @@ export async function runCodexAppServerSideQuestion(
   });
   if (nativeExecutionBlock) {
     throw new Error(nativeExecutionBlock);
+  }
+  const beforeToolCallPolicy = getBeforeToolCallPolicyDiagnosticState();
+  if (
+    beforeToolCallPolicy.hasBeforeToolCallHook ||
+    beforeToolCallPolicy.trustedToolPolicies.length > 0
+  ) {
+    throw new Error(
+      "Codex /btw is disabled while OpenClaw before_tool_call or trusted tool policy is active because side threads cannot safely expose Codex native tools.",
+    );
   }
 
   const pluginConfig = readCodexPluginConfig(options.pluginConfig);

--- a/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
@@ -8,7 +8,7 @@ import {
   threadStartResult,
 } from "./run-attempt-test-harness.js";
 import { readCodexAppServerBinding, writeCodexAppServerBinding } from "./session-binding.js";
-import { startOrResumeThread } from "./thread-lifecycle.js";
+import { codexDynamicToolsFingerprint, startOrResumeThread } from "./thread-lifecycle.js";
 
 function createThreadLifecycleAppServerOptions(): Parameters<
   typeof startOrResumeThread
@@ -669,7 +669,7 @@ describe("Codex app-server thread lifecycle bindings", () => {
     expect(savedAfterAllowed?.pluginAppPolicyContext).toEqual(pluginAppPolicyContext);
   });
 
-  it("resumes and updates bindings for policy-disabled replacement dynamic tools", async () => {
+  it("starts a restricted thread when policy-disabled replacement dynamic tools are not installed", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");
     await writeCodexAppServerBinding(sessionFile, {
@@ -688,8 +688,8 @@ describe("Codex app-server thread lifecycle bindings", () => {
     const params = createParams(sessionFile, workspaceDir);
     const appServer = createThreadLifecycleAppServerOptions();
     const request = vi.fn(async (method: string) => {
-      if (method === "thread/resume") {
-        return threadStartResult("thread-native");
+      if (method === "thread/start") {
+        return threadStartResult("thread-restricted");
       }
       throw new Error(`unexpected method: ${method}`);
     });
@@ -734,6 +734,105 @@ describe("Codex app-server thread lifecycle bindings", () => {
     });
 
     const requestCalls = request.mock.calls as unknown as Array<
+      [string, { config?: Record<string, unknown>; dynamicTools?: Array<{ name?: string }> }]
+    >;
+    expect(requestCalls.map(([method]) => method)).toEqual(["thread/start"]);
+    expect(requestCalls[0]?.[1].dynamicTools?.map((tool) => tool.name)).toEqual(["exec"]);
+    expect(requestCalls[0]?.[1].config?.["features.code_mode"]).toBe(false);
+    expect(requestCalls[0]?.[1].config?.["features.code_mode_only"]).toBe(false);
+    expect(requestCalls[0]?.[1].config).toMatchObject({
+      apps: {
+        _default: {
+          enabled: false,
+          destructive_enabled: false,
+          open_world_enabled: false,
+        },
+      },
+    });
+    expect(binding.threadId).toBe("thread-restricted");
+    expect(binding.dynamicToolsFingerprint).not.toBe("[]");
+    expect(binding.userMcpServersFingerprint).toBeUndefined();
+    expect(binding.mcpServersFingerprint).toBeUndefined();
+    expect(binding.pluginAppsFingerprint).toBe("plugin-apps-restricted");
+    expect(binding.pluginAppsInputFingerprint).toBe("plugin-input-restricted");
+    expect(binding.pluginAppPolicyContext).toEqual(restrictedPluginPolicyContext);
+    const savedBinding = await readCodexAppServerBinding(sessionFile);
+    expect(savedBinding?.threadId).toBe("thread-restricted");
+    expect(savedBinding?.dynamicToolsFingerprint).toBe(binding.dynamicToolsFingerprint);
+    expect(savedBinding?.userMcpServersFingerprint).toBeUndefined();
+    expect(savedBinding?.mcpServersFingerprint).toBeUndefined();
+    expect(savedBinding?.pluginAppsFingerprint).toBe("plugin-apps-restricted");
+    expect(savedBinding?.pluginAppsInputFingerprint).toBe("plugin-input-restricted");
+    expect(savedBinding?.pluginAppPolicyContext).toEqual(restrictedPluginPolicyContext);
+  });
+
+  it("resumes restricted policy-disabled threads through native-only binding drift", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const dynamicTools = [createDeferredNamedDynamicTool("exec")];
+    await writeCodexAppServerBinding(sessionFile, {
+      threadId: "thread-restricted",
+      cwd: workspaceDir,
+      model: "gpt-5.4-codex",
+      modelProvider: "openai",
+      dynamicToolsFingerprint: codexDynamicToolsFingerprint(dynamicTools),
+      dynamicToolsContainDeferred: false,
+      userMcpServersFingerprint: "user-mcp-v1",
+      mcpServersFingerprint: "bundle-mcp-v1",
+      pluginAppsFingerprint: "plugin-apps-enabled",
+      pluginAppsInputFingerprint: "plugin-input-enabled",
+      pluginAppPolicyContext: createPluginAppPolicyContext(),
+      environmentSelectionFingerprint: "native-env-v1",
+    });
+    const params = createParams(sessionFile, workspaceDir);
+    const appServer = createThreadLifecycleAppServerOptions();
+    const request = vi.fn(async (method: string) => {
+      if (method === "thread/resume") {
+        return threadStartResult("thread-restricted");
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+    const restrictedPluginPolicyContext = {
+      fingerprint: "plugin-policy-restricted",
+      apps: {},
+      pluginAppIds: {},
+    };
+
+    const binding = await startOrResumeThread({
+      client: { request } as never,
+      params,
+      cwd: workspaceDir,
+      dynamicTools,
+      appServer,
+      nativeCodeModeEnabled: false,
+      preserveBindingWhenNativeCodeModeDisabled: true,
+      userMcpServersEnabled: false,
+      mcpServersFingerprint: undefined,
+      mcpServersFingerprintEvaluated: true,
+      pluginThreadConfig: {
+        enabled: true,
+        inputFingerprint: "plugin-input-restricted",
+        enabledPluginConfigKeys: [],
+        build: async () => ({
+          enabled: true,
+          configPatch: {
+            apps: {
+              _default: {
+                enabled: false,
+                destructive_enabled: false,
+                open_world_enabled: false,
+              },
+            },
+          },
+          fingerprint: "plugin-apps-restricted",
+          inputFingerprint: "plugin-input-restricted",
+          policyContext: restrictedPluginPolicyContext,
+          diagnostics: [],
+        }),
+      },
+    });
+
+    const requestCalls = request.mock.calls as unknown as Array<
       [string, { config?: Record<string, unknown> }]
     >;
     expect(requestCalls.map(([method]) => method)).toEqual(["thread/resume"]);
@@ -748,21 +847,25 @@ describe("Codex app-server thread lifecycle bindings", () => {
         },
       },
     });
-    expect(binding.threadId).toBe("thread-native");
-    expect(binding.dynamicToolsFingerprint).not.toBe("[]");
+    expect(binding.threadId).toBe("thread-restricted");
+    expect(binding.dynamicToolsFingerprint).toBe(codexDynamicToolsFingerprint(dynamicTools));
+    expect(binding.dynamicToolsContainDeferred).toBe(true);
     expect(binding.userMcpServersFingerprint).toBeUndefined();
     expect(binding.mcpServersFingerprint).toBeUndefined();
     expect(binding.pluginAppsFingerprint).toBe("plugin-apps-restricted");
     expect(binding.pluginAppsInputFingerprint).toBe("plugin-input-restricted");
     expect(binding.pluginAppPolicyContext).toEqual(restrictedPluginPolicyContext);
+    expect(binding.environmentSelectionFingerprint).toBeUndefined();
     const savedBinding = await readCodexAppServerBinding(sessionFile);
-    expect(savedBinding?.threadId).toBe("thread-native");
+    expect(savedBinding?.threadId).toBe("thread-restricted");
     expect(savedBinding?.dynamicToolsFingerprint).toBe(binding.dynamicToolsFingerprint);
+    expect(savedBinding?.dynamicToolsContainDeferred).toBe(true);
     expect(savedBinding?.userMcpServersFingerprint).toBeUndefined();
     expect(savedBinding?.mcpServersFingerprint).toBeUndefined();
     expect(savedBinding?.pluginAppsFingerprint).toBe("plugin-apps-restricted");
     expect(savedBinding?.pluginAppsInputFingerprint).toBe("plugin-input-restricted");
     expect(savedBinding?.pluginAppPolicyContext).toEqual(restrictedPluginPolicyContext);
+    expect(savedBinding?.environmentSelectionFingerprint).toBeUndefined();
   });
 
   it("keeps zero-tool policy-disabled turns transient", async () => {

--- a/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
@@ -669,6 +669,87 @@ describe("Codex app-server thread lifecycle bindings", () => {
     expect(savedAfterAllowed?.pluginAppPolicyContext).toEqual(pluginAppPolicyContext);
   });
 
+  it("resumes and updates bindings for policy-disabled replacement dynamic tools", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    await writeCodexAppServerBinding(sessionFile, {
+      threadId: "thread-native",
+      cwd: workspaceDir,
+      model: "gpt-5.4-codex",
+      modelProvider: "openai",
+      dynamicToolsFingerprint: "[]",
+      dynamicToolsContainDeferred: false,
+    });
+    const params = createParams(sessionFile, workspaceDir);
+    const appServer = createThreadLifecycleAppServerOptions();
+    const request = vi.fn(async (method: string) => {
+      if (method === "thread/resume") {
+        return threadStartResult("thread-native");
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    const binding = await startOrResumeThread({
+      client: { request } as never,
+      params,
+      cwd: workspaceDir,
+      dynamicTools: [createNamedDynamicTool("exec")],
+      appServer,
+      nativeCodeModeEnabled: false,
+      preserveBindingWhenNativeCodeModeDisabled: true,
+      userMcpServersEnabled: false,
+    });
+
+    const requestCalls = request.mock.calls as unknown as Array<
+      [string, { config?: Record<string, unknown> }]
+    >;
+    expect(requestCalls.map(([method]) => method)).toEqual(["thread/resume"]);
+    expect(requestCalls[0]?.[1].config?.["features.code_mode"]).toBe(false);
+    expect(requestCalls[0]?.[1].config?.["features.code_mode_only"]).toBe(false);
+    expect(binding.threadId).toBe("thread-native");
+    expect(binding.dynamicToolsFingerprint).not.toBe("[]");
+    const savedBinding = await readCodexAppServerBinding(sessionFile);
+    expect(savedBinding?.threadId).toBe("thread-native");
+    expect(savedBinding?.dynamicToolsFingerprint).toBe(binding.dynamicToolsFingerprint);
+  });
+
+  it("keeps zero-tool policy-disabled turns transient", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    await writeCodexAppServerBinding(sessionFile, {
+      threadId: "thread-native",
+      cwd: workspaceDir,
+      model: "gpt-5.4-codex",
+      modelProvider: "openai",
+      dynamicToolsFingerprint: "native-tool-fingerprint",
+      dynamicToolsContainDeferred: false,
+    });
+    const params = createParams(sessionFile, workspaceDir);
+    const appServer = createThreadLifecycleAppServerOptions();
+    const request = vi.fn(async (method: string) => {
+      if (method === "thread/start") {
+        return threadStartResult("thread-transient");
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    await startOrResumeThread({
+      client: { request } as never,
+      params,
+      cwd: workspaceDir,
+      dynamicTools: [],
+      appServer,
+      nativeCodeModeEnabled: false,
+      preserveBindingWhenNativeCodeModeDisabled: true,
+      userMcpServersEnabled: false,
+    });
+
+    expect(request.mock.calls.map(([method]) => method)).toEqual(["thread/start"]);
+    const savedBinding = await readCodexAppServerBinding(sessionFile);
+    expect(savedBinding?.threadId).toBe("thread-native");
+    expect(savedBinding?.dynamicToolsFingerprint).toBe("native-tool-fingerprint");
+  });
+
   it("preserves the binding when the app-server closes during thread resume", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");

--- a/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
@@ -679,6 +679,11 @@ describe("Codex app-server thread lifecycle bindings", () => {
       modelProvider: "openai",
       dynamicToolsFingerprint: "[]",
       dynamicToolsContainDeferred: false,
+      userMcpServersFingerprint: "user-mcp-v1",
+      mcpServersFingerprint: "bundle-mcp-v1",
+      pluginAppsFingerprint: "plugin-apps-enabled",
+      pluginAppsInputFingerprint: "plugin-input-enabled",
+      pluginAppPolicyContext: createPluginAppPolicyContext(),
     });
     const params = createParams(sessionFile, workspaceDir);
     const appServer = createThreadLifecycleAppServerOptions();
@@ -688,6 +693,11 @@ describe("Codex app-server thread lifecycle bindings", () => {
       }
       throw new Error(`unexpected method: ${method}`);
     });
+    const restrictedPluginPolicyContext = {
+      fingerprint: "plugin-policy-restricted",
+      apps: {},
+      pluginAppIds: {},
+    };
 
     const binding = await startOrResumeThread({
       client: { request } as never,
@@ -698,6 +708,29 @@ describe("Codex app-server thread lifecycle bindings", () => {
       nativeCodeModeEnabled: false,
       preserveBindingWhenNativeCodeModeDisabled: true,
       userMcpServersEnabled: false,
+      mcpServersFingerprint: undefined,
+      mcpServersFingerprintEvaluated: true,
+      pluginThreadConfig: {
+        enabled: true,
+        inputFingerprint: "plugin-input-restricted",
+        enabledPluginConfigKeys: [],
+        build: async () => ({
+          enabled: true,
+          configPatch: {
+            apps: {
+              _default: {
+                enabled: false,
+                destructive_enabled: false,
+                open_world_enabled: false,
+              },
+            },
+          },
+          fingerprint: "plugin-apps-restricted",
+          inputFingerprint: "plugin-input-restricted",
+          policyContext: restrictedPluginPolicyContext,
+          diagnostics: [],
+        }),
+      },
     });
 
     const requestCalls = request.mock.calls as unknown as Array<
@@ -706,11 +739,30 @@ describe("Codex app-server thread lifecycle bindings", () => {
     expect(requestCalls.map(([method]) => method)).toEqual(["thread/resume"]);
     expect(requestCalls[0]?.[1].config?.["features.code_mode"]).toBe(false);
     expect(requestCalls[0]?.[1].config?.["features.code_mode_only"]).toBe(false);
+    expect(requestCalls[0]?.[1].config).toMatchObject({
+      apps: {
+        _default: {
+          enabled: false,
+          destructive_enabled: false,
+          open_world_enabled: false,
+        },
+      },
+    });
     expect(binding.threadId).toBe("thread-native");
     expect(binding.dynamicToolsFingerprint).not.toBe("[]");
+    expect(binding.userMcpServersFingerprint).toBeUndefined();
+    expect(binding.mcpServersFingerprint).toBeUndefined();
+    expect(binding.pluginAppsFingerprint).toBe("plugin-apps-restricted");
+    expect(binding.pluginAppsInputFingerprint).toBe("plugin-input-restricted");
+    expect(binding.pluginAppPolicyContext).toEqual(restrictedPluginPolicyContext);
     const savedBinding = await readCodexAppServerBinding(sessionFile);
     expect(savedBinding?.threadId).toBe("thread-native");
     expect(savedBinding?.dynamicToolsFingerprint).toBe(binding.dynamicToolsFingerprint);
+    expect(savedBinding?.userMcpServersFingerprint).toBeUndefined();
+    expect(savedBinding?.mcpServersFingerprint).toBeUndefined();
+    expect(savedBinding?.pluginAppsFingerprint).toBe("plugin-apps-restricted");
+    expect(savedBinding?.pluginAppsInputFingerprint).toBe("plugin-input-restricted");
+    expect(savedBinding?.pluginAppPolicyContext).toEqual(restrictedPluginPolicyContext);
   });
 
   it("keeps zero-tool policy-disabled turns transient", async () => {

--- a/extensions/codex/src/app-server/thread-lifecycle.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.ts
@@ -361,6 +361,20 @@ export async function startOrResumeThread(params: {
     params.nativeCodeModeEnabled === false &&
     params.preserveBindingWhenNativeCodeModeDisabled === true &&
     params.dynamicTools.length > 0;
+  if (
+    binding?.threadId &&
+    preserveNativeDisabledBinding &&
+    binding.dynamicToolsFingerprint !== dynamicToolsFingerprint
+  ) {
+    embeddedAgentLog.debug(
+      "codex app-server native tool surface disabled persistently; starting a restricted thread with replacement dynamic tools",
+      {
+        threadId: binding.threadId,
+      },
+    );
+    await clearCodexAppServerBinding(params.params.sessionFile);
+    binding = undefined;
+  }
   if (binding?.threadId && preserveNativeDisabledBinding && params.pluginThreadConfig?.enabled) {
     prebuiltPluginThreadConfig = await lifecycleTiming.measure(
       "plugin-config-native-disabled-preserve",
@@ -418,7 +432,8 @@ export async function startOrResumeThread(params: {
   }
   if (
     binding?.threadId &&
-    binding.environmentSelectionFingerprint !== environmentSelectionFingerprint
+    binding.environmentSelectionFingerprint !== environmentSelectionFingerprint &&
+    !preserveNativeDisabledBinding
   ) {
     embeddedAgentLog.debug(
       "codex app-server environment selection changed; starting a new thread",
@@ -503,7 +518,8 @@ export async function startOrResumeThread(params: {
       binding.dynamicToolsFingerprint &&
       params.dynamicTools.length > 0 &&
       binding.dynamicToolsContainDeferred !== dynamicToolsContainDeferred &&
-      (binding.dynamicToolsContainDeferred !== undefined || !dynamicToolsContainDeferred)
+      (binding.dynamicToolsContainDeferred !== undefined || !dynamicToolsContainDeferred) &&
+      !preserveNativeDisabledBinding
     ) {
       embeddedAgentLog.debug(
         "codex app-server dynamic tool loading changed; starting a new thread",
@@ -525,35 +541,26 @@ export async function startOrResumeThread(params: {
         dynamicToolsFingerprint,
       )
     ) {
-      if (preserveNativeDisabledBinding) {
+      preserveExistingBinding = shouldStartTransientNoToolThread({
+        previous: binding.dynamicToolsFingerprint,
+        next: dynamicToolsFingerprint,
+      });
+      if (preserveExistingBinding) {
         embeddedAgentLog.debug(
-          "codex app-server native tool surface disabled persistently; resuming thread with replacement dynamic tools",
+          "codex app-server dynamic tools unavailable for turn; starting transient thread",
           {
             threadId: binding.threadId,
           },
         );
       } else {
-        preserveExistingBinding = shouldStartTransientNoToolThread({
-          previous: binding.dynamicToolsFingerprint,
-          next: dynamicToolsFingerprint,
-        });
-        if (preserveExistingBinding) {
-          embeddedAgentLog.debug(
-            "codex app-server dynamic tools unavailable for turn; starting transient thread",
-            {
-              threadId: binding.threadId,
-            },
-          );
-        } else {
-          embeddedAgentLog.debug(
-            "codex app-server dynamic tool catalog changed; starting a new thread",
-            {
-              threadId: binding.threadId,
-            },
-          );
-          await clearCodexAppServerBinding(params.params.sessionFile);
-          binding = undefined;
-        }
+        embeddedAgentLog.debug(
+          "codex app-server dynamic tool catalog changed; starting a new thread",
+          {
+            threadId: binding.threadId,
+          },
+        );
+        await clearCodexAppServerBinding(params.params.sessionFile);
+        binding = undefined;
       }
     }
     if (binding?.threadId && !preserveExistingBinding) {

--- a/extensions/codex/src/app-server/thread-lifecycle.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.ts
@@ -296,6 +296,7 @@ export async function startOrResumeThread(params: {
   nativeHookRelayGeneration?: string;
   nativeCodeModeEnabled?: boolean;
   nativeCodeModeOnlyEnabled?: boolean;
+  preserveBindingWhenNativeCodeModeDisabled?: boolean;
   userMcpServersEnabled?: boolean;
   mcpServersFingerprint?: string;
   mcpServersFingerprintEvaluated?: boolean;
@@ -356,7 +357,15 @@ export async function startOrResumeThread(params: {
     error.name = "AbortError";
     throw error;
   };
-  if (binding?.threadId && params.nativeCodeModeEnabled === false) {
+  const preserveNativeDisabledBinding =
+    params.nativeCodeModeEnabled === false &&
+    params.preserveBindingWhenNativeCodeModeDisabled === true &&
+    params.dynamicTools.length > 0;
+  if (
+    binding?.threadId &&
+    params.nativeCodeModeEnabled === false &&
+    !preserveNativeDisabledBinding
+  ) {
     embeddedAgentLog.debug(
       "codex app-server native tool surface disabled for turn; starting transient thread",
       {
@@ -495,27 +504,38 @@ export async function startOrResumeThread(params: {
         dynamicToolsFingerprint,
       )
     ) {
-      preserveExistingBinding = shouldStartTransientNoToolThread({
-        previous: binding.dynamicToolsFingerprint,
-        next: dynamicToolsFingerprint,
-      });
-      if (preserveExistingBinding) {
+      if (preserveNativeDisabledBinding) {
         embeddedAgentLog.debug(
-          "codex app-server dynamic tools unavailable for turn; starting transient thread",
+          "codex app-server native tool surface disabled persistently; resuming thread with replacement dynamic tools",
           {
             threadId: binding.threadId,
           },
         );
       } else {
-        embeddedAgentLog.debug(
-          "codex app-server dynamic tool catalog changed; starting a new thread",
-          {
-            threadId: binding.threadId,
-          },
-        );
-        await clearCodexAppServerBinding(params.params.sessionFile);
+        preserveExistingBinding = shouldStartTransientNoToolThread({
+          previous: binding.dynamicToolsFingerprint,
+          next: dynamicToolsFingerprint,
+        });
+        if (preserveExistingBinding) {
+          embeddedAgentLog.debug(
+            "codex app-server dynamic tools unavailable for turn; starting transient thread",
+            {
+              threadId: binding.threadId,
+            },
+          );
+        } else {
+          embeddedAgentLog.debug(
+            "codex app-server dynamic tool catalog changed; starting a new thread",
+            {
+              threadId: binding.threadId,
+            },
+          );
+          await clearCodexAppServerBinding(params.params.sessionFile);
+          binding = undefined;
+        }
       }
-    } else {
+    }
+    if (binding?.threadId && !preserveExistingBinding) {
       const resumeBinding = binding;
       const finalConfigPatch = params.buildFinalConfigPatch?.({
         action: "resume",
@@ -526,128 +546,126 @@ export async function startOrResumeThread(params: {
       };
       if (finalConfigPatch.nativeHookRelayGeneration && !resumeBinding.nativeHookRelayGeneration) {
         embeddedAgentLog.debug(
-          "codex app-server native hook relay binding missing generation; starting a new thread",
+          "codex app-server native hook relay binding missing generation; resuming with current generation",
           {
             threadId: resumeBinding.threadId,
           },
         );
-        await clearCodexAppServerBinding(params.params.sessionFile);
-      } else {
-        try {
-          const authProfileId = params.params.authProfileId ?? resumeBinding.authProfileId;
-          const resumeConfig = mergeCodexThreadConfigs(
-            params.config,
-            userMcpServersConfigPatch,
-            finalConfigPatch.configPatch,
-          );
-          const resumeParams = lifecycleTiming.measureSync("thread-resume-params", () =>
-            buildThreadResumeParams(params.params, {
-              threadId: resumeBinding.threadId,
-              authProfileId,
-              appServer: params.appServer,
-              dynamicTools: params.dynamicTools,
-              developerInstructions: params.developerInstructions,
-              config: resumeConfig,
-              nativeCodeModeEnabled: params.nativeCodeModeEnabled,
-              nativeCodeModeOnlyEnabled: params.nativeCodeModeOnlyEnabled,
-            }),
-          );
-          const response = assertCodexThreadResumeResponse(
-            await lifecycleTiming.measure("thread-resume-request", () =>
-              params.client.request("thread/resume", resumeParams, { signal: params.signal }),
-            ),
-          );
-          throwIfAborted();
-          const boundAuthProfileId = authProfileId;
-          const fallbackModelProvider = resolveCodexAppServerModelProvider({
-            provider: params.params.provider,
-            authProfileId: boundAuthProfileId,
-            authProfileStore: params.params.authProfileStore,
-            agentDir: params.params.agentDir,
-            config: params.params.config,
-          });
-          const nextMcpServersFingerprint =
-            params.mcpServersFingerprintEvaluated === true
-              ? params.mcpServersFingerprint
-              : resumeBinding.mcpServersFingerprint;
-          await lifecycleTiming.measure("thread-resume-write-binding", () =>
-            writeCodexAppServerBinding(
-              params.params.sessionFile,
-              {
-                threadId: response.thread.id,
-                cwd: params.cwd,
-                authProfileId: boundAuthProfileId,
-                model: params.params.modelId,
-                modelProvider: response.modelProvider ?? fallbackModelProvider,
-                dynamicToolsFingerprint,
-                dynamicToolsContainDeferred,
-                userMcpServersFingerprint,
-                mcpServersFingerprint: nextMcpServersFingerprint,
-                nativeHookRelayGeneration:
-                  finalConfigPatch.nativeHookRelayGeneration ??
-                  resumeBinding.nativeHookRelayGeneration,
-                pluginAppsFingerprint: resumeBinding.pluginAppsFingerprint,
-                pluginAppsInputFingerprint: resumeBinding.pluginAppsInputFingerprint,
-                pluginAppPolicyContext: resumeBinding.pluginAppPolicyContext,
-                contextEngine: contextEngineBinding,
-                environmentSelectionFingerprint,
-                createdAt: resumeBinding.createdAt,
-              },
-              {
-                authProfileStore: params.params.authProfileStore,
-                agentDir: params.params.agentDir,
-                config: params.params.config,
-              },
-            ),
-          );
-          if (contextEngineBinding) {
-            embeddedAgentLog.info("codex app-server wrote context-engine thread binding", {
-              sessionId: params.params.sessionId,
-              sessionKey: params.params.sessionKey,
+      }
+      try {
+        const authProfileId = params.params.authProfileId ?? resumeBinding.authProfileId;
+        const resumeConfig = mergeCodexThreadConfigs(
+          params.config,
+          userMcpServersConfigPatch,
+          finalConfigPatch.configPatch,
+        );
+        const resumeParams = lifecycleTiming.measureSync("thread-resume-params", () =>
+          buildThreadResumeParams(params.params, {
+            threadId: resumeBinding.threadId,
+            authProfileId,
+            appServer: params.appServer,
+            dynamicTools: params.dynamicTools,
+            developerInstructions: params.developerInstructions,
+            config: resumeConfig,
+            nativeCodeModeEnabled: params.nativeCodeModeEnabled,
+            nativeCodeModeOnlyEnabled: params.nativeCodeModeOnlyEnabled,
+          }),
+        );
+        const response = assertCodexThreadResumeResponse(
+          await lifecycleTiming.measure("thread-resume-request", () =>
+            params.client.request("thread/resume", resumeParams, { signal: params.signal }),
+          ),
+        );
+        throwIfAborted();
+        const boundAuthProfileId = authProfileId;
+        const fallbackModelProvider = resolveCodexAppServerModelProvider({
+          provider: params.params.provider,
+          authProfileId: boundAuthProfileId,
+          authProfileStore: params.params.authProfileStore,
+          agentDir: params.params.agentDir,
+          config: params.params.config,
+        });
+        const nextMcpServersFingerprint =
+          params.mcpServersFingerprintEvaluated === true
+            ? params.mcpServersFingerprint
+            : resumeBinding.mcpServersFingerprint;
+        await lifecycleTiming.measure("thread-resume-write-binding", () =>
+          writeCodexAppServerBinding(
+            params.params.sessionFile,
+            {
               threadId: response.thread.id,
-              engineId: contextEngineBinding.engineId,
-              epoch: contextEngineBinding.projection?.epoch,
-              fingerprint: contextEngineBinding.projection?.fingerprint,
-              action: "resumed",
-            });
-          }
-          lifecycleTiming.mark("thread-ready");
-          lifecycleTiming.logSummary({
-            runId: params.params.runId,
+              cwd: params.cwd,
+              authProfileId: boundAuthProfileId,
+              model: params.params.modelId,
+              modelProvider: response.modelProvider ?? fallbackModelProvider,
+              dynamicToolsFingerprint,
+              dynamicToolsContainDeferred,
+              userMcpServersFingerprint,
+              mcpServersFingerprint: nextMcpServersFingerprint,
+              nativeHookRelayGeneration:
+                finalConfigPatch.nativeHookRelayGeneration ??
+                resumeBinding.nativeHookRelayGeneration,
+              pluginAppsFingerprint: resumeBinding.pluginAppsFingerprint,
+              pluginAppsInputFingerprint: resumeBinding.pluginAppsInputFingerprint,
+              pluginAppPolicyContext: resumeBinding.pluginAppPolicyContext,
+              contextEngine: contextEngineBinding,
+              environmentSelectionFingerprint,
+              createdAt: resumeBinding.createdAt,
+            },
+            {
+              authProfileStore: params.params.authProfileStore,
+              agentDir: params.params.agentDir,
+              config: params.params.config,
+            },
+          ),
+        );
+        if (contextEngineBinding) {
+          embeddedAgentLog.info("codex app-server wrote context-engine thread binding", {
             sessionId: params.params.sessionId,
             sessionKey: params.params.sessionKey,
             threadId: response.thread.id,
+            engineId: contextEngineBinding.engineId,
+            epoch: contextEngineBinding.projection?.epoch,
+            fingerprint: contextEngineBinding.projection?.fingerprint,
             action: "resumed",
           });
-          return {
-            ...resumeBinding,
-            threadId: response.thread.id,
-            cwd: params.cwd,
-            authProfileId: boundAuthProfileId,
-            model: params.params.modelId,
-            modelProvider: response.modelProvider ?? fallbackModelProvider,
-            dynamicToolsFingerprint,
-            dynamicToolsContainDeferred,
-            userMcpServersFingerprint,
-            mcpServersFingerprint: nextMcpServersFingerprint,
-            nativeHookRelayGeneration:
-              finalConfigPatch.nativeHookRelayGeneration ?? resumeBinding.nativeHookRelayGeneration,
-            pluginAppsFingerprint: resumeBinding.pluginAppsFingerprint,
-            pluginAppsInputFingerprint: resumeBinding.pluginAppsInputFingerprint,
-            pluginAppPolicyContext: resumeBinding.pluginAppPolicyContext,
-            contextEngine: contextEngineBinding,
-            environmentSelectionFingerprint,
-            lifecycle: { action: "resumed" },
-          };
-        } catch (error) {
-          if (isCodexAppServerConnectionClosedError(error)) {
-            throw error;
-          }
-          embeddedAgentLog.warn("codex app-server thread resume failed; starting a new thread", {
-            error,
-          });
-          await clearCodexAppServerBinding(params.params.sessionFile);
         }
+        lifecycleTiming.mark("thread-ready");
+        lifecycleTiming.logSummary({
+          runId: params.params.runId,
+          sessionId: params.params.sessionId,
+          sessionKey: params.params.sessionKey,
+          threadId: response.thread.id,
+          action: "resumed",
+        });
+        return {
+          ...resumeBinding,
+          threadId: response.thread.id,
+          cwd: params.cwd,
+          authProfileId: boundAuthProfileId,
+          model: params.params.modelId,
+          modelProvider: response.modelProvider ?? fallbackModelProvider,
+          dynamicToolsFingerprint,
+          dynamicToolsContainDeferred,
+          userMcpServersFingerprint,
+          mcpServersFingerprint: nextMcpServersFingerprint,
+          nativeHookRelayGeneration:
+            finalConfigPatch.nativeHookRelayGeneration ?? resumeBinding.nativeHookRelayGeneration,
+          pluginAppsFingerprint: resumeBinding.pluginAppsFingerprint,
+          pluginAppsInputFingerprint: resumeBinding.pluginAppsInputFingerprint,
+          pluginAppPolicyContext: resumeBinding.pluginAppPolicyContext,
+          contextEngine: contextEngineBinding,
+          environmentSelectionFingerprint,
+          lifecycle: { action: "resumed" },
+        };
+      } catch (error) {
+        if (isCodexAppServerConnectionClosedError(error)) {
+          throw error;
+        }
+        embeddedAgentLog.warn("codex app-server thread resume failed; starting a new thread", {
+          error,
+        });
+        await clearCodexAppServerBinding(params.params.sessionFile);
       }
     }
   }

--- a/extensions/codex/src/app-server/thread-lifecycle.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.ts
@@ -361,6 +361,12 @@ export async function startOrResumeThread(params: {
     params.nativeCodeModeEnabled === false &&
     params.preserveBindingWhenNativeCodeModeDisabled === true &&
     params.dynamicTools.length > 0;
+  if (binding?.threadId && preserveNativeDisabledBinding && params.pluginThreadConfig?.enabled) {
+    prebuiltPluginThreadConfig = await lifecycleTiming.measure(
+      "plugin-config-native-disabled-preserve",
+      () => params.pluginThreadConfig!.build(),
+    );
+  }
   if (
     binding?.threadId &&
     params.nativeCodeModeEnabled === false &&
@@ -399,7 +405,11 @@ export async function startOrResumeThread(params: {
       rotatedContextEngineBinding = true;
     }
   }
-  if (binding?.threadId && binding.userMcpServersFingerprint !== userMcpServersFingerprint) {
+  if (
+    binding?.threadId &&
+    binding.userMcpServersFingerprint !== userMcpServersFingerprint &&
+    !preserveNativeDisabledBinding
+  ) {
     embeddedAgentLog.debug("codex app-server user MCP config changed; starting a new thread", {
       threadId: binding.threadId,
     });
@@ -422,7 +432,8 @@ export async function startOrResumeThread(params: {
   if (
     binding?.threadId &&
     params.mcpServersFingerprintEvaluated === true &&
-    binding.mcpServersFingerprint !== params.mcpServersFingerprint
+    binding.mcpServersFingerprint !== params.mcpServersFingerprint &&
+    !preserveNativeDisabledBinding
   ) {
     embeddedAgentLog.debug("codex app-server MCP config changed; starting a new thread", {
       threadId: binding.threadId,
@@ -458,6 +469,15 @@ export async function startOrResumeThread(params: {
         });
       }
     }
+    if (pluginBindingStale && preserveNativeDisabledBinding) {
+      embeddedAgentLog.debug(
+        "codex app-server native tool surface disabled persistently; resuming thread with restricted plugin app config",
+        {
+          threadId: binding.threadId,
+        },
+      );
+      pluginBindingStale = false;
+    }
     if (pluginBindingStale) {
       embeddedAgentLog.debug("codex app-server plugin app config changed; starting a new thread", {
         threadId: binding.threadId,
@@ -469,7 +489,8 @@ export async function startOrResumeThread(params: {
   if (
     binding?.threadId &&
     params.mcpServersFingerprintEvaluated === true &&
-    binding.mcpServersFingerprint !== params.mcpServersFingerprint
+    binding.mcpServersFingerprint !== params.mcpServersFingerprint &&
+    !preserveNativeDisabledBinding
   ) {
     embeddedAgentLog.debug("codex app-server MCP config changed; starting a new thread", {
       threadId: binding.threadId,
@@ -552,11 +573,15 @@ export async function startOrResumeThread(params: {
           },
         );
       }
+      const resumePluginThreadConfig = preserveNativeDisabledBinding
+        ? prebuiltPluginThreadConfig
+        : undefined;
       try {
         const authProfileId = params.params.authProfileId ?? resumeBinding.authProfileId;
         const resumeConfig = mergeCodexThreadConfigs(
           params.config,
           userMcpServersConfigPatch,
+          resumePluginThreadConfig?.configPatch,
           finalConfigPatch.configPatch,
         );
         const resumeParams = lifecycleTiming.measureSync("thread-resume-params", () =>
@@ -605,9 +630,13 @@ export async function startOrResumeThread(params: {
               nativeHookRelayGeneration:
                 finalConfigPatch.nativeHookRelayGeneration ??
                 resumeBinding.nativeHookRelayGeneration,
-              pluginAppsFingerprint: resumeBinding.pluginAppsFingerprint,
-              pluginAppsInputFingerprint: resumeBinding.pluginAppsInputFingerprint,
-              pluginAppPolicyContext: resumeBinding.pluginAppPolicyContext,
+              pluginAppsFingerprint:
+                resumePluginThreadConfig?.fingerprint ?? resumeBinding.pluginAppsFingerprint,
+              pluginAppsInputFingerprint:
+                resumePluginThreadConfig?.inputFingerprint ??
+                resumeBinding.pluginAppsInputFingerprint,
+              pluginAppPolicyContext:
+                resumePluginThreadConfig?.policyContext ?? resumeBinding.pluginAppPolicyContext,
               contextEngine: contextEngineBinding,
               environmentSelectionFingerprint,
               createdAt: resumeBinding.createdAt,
@@ -651,9 +680,12 @@ export async function startOrResumeThread(params: {
           mcpServersFingerprint: nextMcpServersFingerprint,
           nativeHookRelayGeneration:
             finalConfigPatch.nativeHookRelayGeneration ?? resumeBinding.nativeHookRelayGeneration,
-          pluginAppsFingerprint: resumeBinding.pluginAppsFingerprint,
-          pluginAppsInputFingerprint: resumeBinding.pluginAppsInputFingerprint,
-          pluginAppPolicyContext: resumeBinding.pluginAppPolicyContext,
+          pluginAppsFingerprint:
+            resumePluginThreadConfig?.fingerprint ?? resumeBinding.pluginAppsFingerprint,
+          pluginAppsInputFingerprint:
+            resumePluginThreadConfig?.inputFingerprint ?? resumeBinding.pluginAppsInputFingerprint,
+          pluginAppPolicyContext:
+            resumePluginThreadConfig?.policyContext ?? resumeBinding.pluginAppPolicyContext,
           contextEngine: contextEngineBinding,
           environmentSelectionFingerprint,
           lifecycle: { action: "resumed" },

--- a/extensions/codex/src/app-server/thread-lifecycle.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.ts
@@ -516,126 +516,138 @@ export async function startOrResumeThread(params: {
         await clearCodexAppServerBinding(params.params.sessionFile);
       }
     } else {
-      try {
-        const authProfileId = params.params.authProfileId ?? binding.authProfileId;
-        const finalConfigPatch = params.buildFinalConfigPatch?.({
-          action: "resume",
-          binding,
-        }) ?? {
-          configPatch: params.finalConfigPatch,
-          nativeHookRelayGeneration: params.nativeHookRelayGeneration,
-        };
-        const resumeConfig = mergeCodexThreadConfigs(
-          params.config,
-          userMcpServersConfigPatch,
-          finalConfigPatch.configPatch,
+      const resumeBinding = binding;
+      const finalConfigPatch = params.buildFinalConfigPatch?.({
+        action: "resume",
+        binding: resumeBinding,
+      }) ?? {
+        configPatch: params.finalConfigPatch,
+        nativeHookRelayGeneration: params.nativeHookRelayGeneration,
+      };
+      if (finalConfigPatch.nativeHookRelayGeneration && !resumeBinding.nativeHookRelayGeneration) {
+        embeddedAgentLog.debug(
+          "codex app-server native hook relay binding missing generation; starting a new thread",
+          {
+            threadId: resumeBinding.threadId,
+          },
         );
-        const resumeParams = lifecycleTiming.measureSync("thread-resume-params", () =>
-          buildThreadResumeParams(params.params, {
-            threadId: binding.threadId,
-            authProfileId,
-            appServer: params.appServer,
-            dynamicTools: params.dynamicTools,
-            developerInstructions: params.developerInstructions,
-            config: resumeConfig,
-            nativeCodeModeEnabled: params.nativeCodeModeEnabled,
-            nativeCodeModeOnlyEnabled: params.nativeCodeModeOnlyEnabled,
-          }),
-        );
-        const response = assertCodexThreadResumeResponse(
-          await lifecycleTiming.measure("thread-resume-request", () =>
-            params.client.request("thread/resume", resumeParams, { signal: params.signal }),
-          ),
-        );
-        throwIfAborted();
-        const boundAuthProfileId = authProfileId;
-        const fallbackModelProvider = resolveCodexAppServerModelProvider({
-          provider: params.params.provider,
-          authProfileId: boundAuthProfileId,
-          authProfileStore: params.params.authProfileStore,
-          agentDir: params.params.agentDir,
-          config: params.params.config,
-        });
-        const nextMcpServersFingerprint =
-          params.mcpServersFingerprintEvaluated === true
-            ? params.mcpServersFingerprint
-            : binding.mcpServersFingerprint;
-        await lifecycleTiming.measure("thread-resume-write-binding", () =>
-          writeCodexAppServerBinding(
-            params.params.sessionFile,
-            {
+        await clearCodexAppServerBinding(params.params.sessionFile);
+      } else {
+        try {
+          const authProfileId = params.params.authProfileId ?? resumeBinding.authProfileId;
+          const resumeConfig = mergeCodexThreadConfigs(
+            params.config,
+            userMcpServersConfigPatch,
+            finalConfigPatch.configPatch,
+          );
+          const resumeParams = lifecycleTiming.measureSync("thread-resume-params", () =>
+            buildThreadResumeParams(params.params, {
+              threadId: resumeBinding.threadId,
+              authProfileId,
+              appServer: params.appServer,
+              dynamicTools: params.dynamicTools,
+              developerInstructions: params.developerInstructions,
+              config: resumeConfig,
+              nativeCodeModeEnabled: params.nativeCodeModeEnabled,
+              nativeCodeModeOnlyEnabled: params.nativeCodeModeOnlyEnabled,
+            }),
+          );
+          const response = assertCodexThreadResumeResponse(
+            await lifecycleTiming.measure("thread-resume-request", () =>
+              params.client.request("thread/resume", resumeParams, { signal: params.signal }),
+            ),
+          );
+          throwIfAborted();
+          const boundAuthProfileId = authProfileId;
+          const fallbackModelProvider = resolveCodexAppServerModelProvider({
+            provider: params.params.provider,
+            authProfileId: boundAuthProfileId,
+            authProfileStore: params.params.authProfileStore,
+            agentDir: params.params.agentDir,
+            config: params.params.config,
+          });
+          const nextMcpServersFingerprint =
+            params.mcpServersFingerprintEvaluated === true
+              ? params.mcpServersFingerprint
+              : resumeBinding.mcpServersFingerprint;
+          await lifecycleTiming.measure("thread-resume-write-binding", () =>
+            writeCodexAppServerBinding(
+              params.params.sessionFile,
+              {
+                threadId: response.thread.id,
+                cwd: params.cwd,
+                authProfileId: boundAuthProfileId,
+                model: params.params.modelId,
+                modelProvider: response.modelProvider ?? fallbackModelProvider,
+                dynamicToolsFingerprint,
+                dynamicToolsContainDeferred,
+                userMcpServersFingerprint,
+                mcpServersFingerprint: nextMcpServersFingerprint,
+                nativeHookRelayGeneration:
+                  finalConfigPatch.nativeHookRelayGeneration ??
+                  resumeBinding.nativeHookRelayGeneration,
+                pluginAppsFingerprint: resumeBinding.pluginAppsFingerprint,
+                pluginAppsInputFingerprint: resumeBinding.pluginAppsInputFingerprint,
+                pluginAppPolicyContext: resumeBinding.pluginAppPolicyContext,
+                contextEngine: contextEngineBinding,
+                environmentSelectionFingerprint,
+                createdAt: resumeBinding.createdAt,
+              },
+              {
+                authProfileStore: params.params.authProfileStore,
+                agentDir: params.params.agentDir,
+                config: params.params.config,
+              },
+            ),
+          );
+          if (contextEngineBinding) {
+            embeddedAgentLog.info("codex app-server wrote context-engine thread binding", {
+              sessionId: params.params.sessionId,
+              sessionKey: params.params.sessionKey,
               threadId: response.thread.id,
-              cwd: params.cwd,
-              authProfileId: boundAuthProfileId,
-              model: params.params.modelId,
-              modelProvider: response.modelProvider ?? fallbackModelProvider,
-              dynamicToolsFingerprint,
-              dynamicToolsContainDeferred,
-              userMcpServersFingerprint,
-              mcpServersFingerprint: nextMcpServersFingerprint,
-              nativeHookRelayGeneration:
-                finalConfigPatch.nativeHookRelayGeneration ?? binding.nativeHookRelayGeneration,
-              pluginAppsFingerprint: binding.pluginAppsFingerprint,
-              pluginAppsInputFingerprint: binding.pluginAppsInputFingerprint,
-              pluginAppPolicyContext: binding.pluginAppPolicyContext,
-              contextEngine: contextEngineBinding,
-              environmentSelectionFingerprint,
-              createdAt: binding.createdAt,
-            },
-            {
-              authProfileStore: params.params.authProfileStore,
-              agentDir: params.params.agentDir,
-              config: params.params.config,
-            },
-          ),
-        );
-        if (contextEngineBinding) {
-          embeddedAgentLog.info("codex app-server wrote context-engine thread binding", {
+              engineId: contextEngineBinding.engineId,
+              epoch: contextEngineBinding.projection?.epoch,
+              fingerprint: contextEngineBinding.projection?.fingerprint,
+              action: "resumed",
+            });
+          }
+          lifecycleTiming.mark("thread-ready");
+          lifecycleTiming.logSummary({
+            runId: params.params.runId,
             sessionId: params.params.sessionId,
             sessionKey: params.params.sessionKey,
             threadId: response.thread.id,
-            engineId: contextEngineBinding.engineId,
-            epoch: contextEngineBinding.projection?.epoch,
-            fingerprint: contextEngineBinding.projection?.fingerprint,
             action: "resumed",
           });
+          return {
+            ...resumeBinding,
+            threadId: response.thread.id,
+            cwd: params.cwd,
+            authProfileId: boundAuthProfileId,
+            model: params.params.modelId,
+            modelProvider: response.modelProvider ?? fallbackModelProvider,
+            dynamicToolsFingerprint,
+            dynamicToolsContainDeferred,
+            userMcpServersFingerprint,
+            mcpServersFingerprint: nextMcpServersFingerprint,
+            nativeHookRelayGeneration:
+              finalConfigPatch.nativeHookRelayGeneration ?? resumeBinding.nativeHookRelayGeneration,
+            pluginAppsFingerprint: resumeBinding.pluginAppsFingerprint,
+            pluginAppsInputFingerprint: resumeBinding.pluginAppsInputFingerprint,
+            pluginAppPolicyContext: resumeBinding.pluginAppPolicyContext,
+            contextEngine: contextEngineBinding,
+            environmentSelectionFingerprint,
+            lifecycle: { action: "resumed" },
+          };
+        } catch (error) {
+          if (isCodexAppServerConnectionClosedError(error)) {
+            throw error;
+          }
+          embeddedAgentLog.warn("codex app-server thread resume failed; starting a new thread", {
+            error,
+          });
+          await clearCodexAppServerBinding(params.params.sessionFile);
         }
-        lifecycleTiming.mark("thread-ready");
-        lifecycleTiming.logSummary({
-          runId: params.params.runId,
-          sessionId: params.params.sessionId,
-          sessionKey: params.params.sessionKey,
-          threadId: response.thread.id,
-          action: "resumed",
-        });
-        return {
-          ...binding,
-          threadId: response.thread.id,
-          cwd: params.cwd,
-          authProfileId: boundAuthProfileId,
-          model: params.params.modelId,
-          modelProvider: response.modelProvider ?? fallbackModelProvider,
-          dynamicToolsFingerprint,
-          dynamicToolsContainDeferred,
-          userMcpServersFingerprint,
-          mcpServersFingerprint: nextMcpServersFingerprint,
-          nativeHookRelayGeneration:
-            finalConfigPatch.nativeHookRelayGeneration ?? binding.nativeHookRelayGeneration,
-          pluginAppsFingerprint: binding.pluginAppsFingerprint,
-          pluginAppsInputFingerprint: binding.pluginAppsInputFingerprint,
-          pluginAppPolicyContext: binding.pluginAppPolicyContext,
-          contextEngine: contextEngineBinding,
-          environmentSelectionFingerprint,
-          lifecycle: { action: "resumed" },
-        };
-      } catch (error) {
-        if (isCodexAppServerConnectionClosedError(error)) {
-          throw error;
-        }
-        embeddedAgentLog.warn("codex app-server thread resume failed; starting a new thread", {
-          error,
-        });
-        await clearCodexAppServerBinding(params.params.sessionFile);
       }
     }
   }

--- a/src/agents/harness/native-hook-relay.test.ts
+++ b/src/agents/harness/native-hook-relay.test.ts
@@ -534,7 +534,7 @@ describe("native hook relay registry", () => {
     expect(relay.shouldRelayEvent("permission_request")).toBe(true);
     expect(relay.commandForEvent("pre_tool_use")).toBe(
       "/usr/local/bin/node '/opt/Open Claw/openclaw.mjs' hooks relay --provider codex --relay-id " +
-        `${relay.relayId} --generation ${relay.generation} --event pre_tool_use --pre-tool-use-unavailable noop --timeout 1234`,
+        `${relay.relayId} --generation ${relay.generation} --event pre_tool_use --timeout 1234`,
     );
   });
 

--- a/src/agents/harness/native-hook-relay.ts
+++ b/src/agents/harness/native-hook-relay.ts
@@ -442,10 +442,6 @@ export function registerNativeHookRelay(
         relayId,
         generation: registration.generation,
         event,
-        preToolUseUnavailable:
-          event === "pre_tool_use" && !nativeHookRelayEventHasLocalWork(registration, event)
-            ? "noop"
-            : undefined,
         nice: params.command?.nice,
         timeoutMs: params.command?.timeoutMs,
         executable: params.command?.executable,
@@ -772,8 +768,8 @@ export function renderNativeHookRelayUnavailableResponse(params: {
   const message = params.message?.trim() || "Native hook relay unavailable";
   if (event === "pre_tool_use") {
     // The standalone CLI cannot reconstruct the originating registration after
-    // relay lookup fails, so unavailable PreToolUse must fail closed unless the
-    // generated command explicitly recorded that no before-tool policy existed.
+    // relay lookup fails, so unavailable PreToolUse must fail closed. The noop
+    // escape remains for older generated commands that carried it explicitly.
     if (params.preToolUseUnavailable === "noop") {
       return adapter.renderNoopResponse(event);
     }
@@ -966,9 +962,6 @@ function registerNativeHookRelayBridge(registration: ActiveNativeHookRelayRegist
     }
     writeNativeHookRelayBridgeRecordForRegistration(registration, bridge);
   });
-  if (relayBridges.get(registration.relayId) === bridge) {
-    writeNativeHookRelayBridgeRecordForRegistration(registration, bridge);
-  }
   server.unref();
 }
 


### PR DESCRIPTION
## Summary

Fixes the Codex app-server policy-enforcement gap where OpenClaw `before_tool_call` / oc-firewall policy could be bypassed by Codex-owned native shell/file/MCP surfaces when native `PreToolUse` delivery is unavailable or not trusted.

Changes:
- Disable Codex native shell/file surfaces while OpenClaw tool policy is active, and route shell execution through OpenClaw-owned dynamic `exec` / `process` tools.
- Disable Codex-owned user MCP and bundled MCP projection whenever native Codex tool surfaces are disabled by OpenClaw policy or node-exec host policy.
- Trust OpenClaw native hook relay commands through per-hook `hooks.state` `trusted_hash`; remove Codex's global `bypass_hook_trust` override.
- Keep policy-disabled replacement-tool lifecycle safe: start a restricted thread when the replacement dynamic-tool catalog is not installed yet, then resume that restricted thread through MCP/plugin/environment drift once the catalog fingerprint matches.
- Preserve pre-generation native-hook bindings by resuming with the bounded generation-mismatch grace path and then writing the active relay generation.
- Reject `/btw` side threads while OpenClaw `before_tool_call` or trusted tool policy is active.

## Root Cause

The upstream Codex Code Mode payload fix was necessary but not sufficient. On OpenClaw 2026.6.1, the Codex app-server/native hook path still did not deliver a `PreToolUse` event for native shell execution, so oc-firewall never saw the sentinel read. The model used native Codex shell and the sentinel contents reached output.

The safe OpenClaw-side boundary is: when OpenClaw policy must enforce tool access, OpenClaw must own every executable tool path. This PR disables Codex-owned native and MCP tool paths in policy-active turns, exposes OpenClaw dynamic shell tools instead, and ensures Codex only records a policy-disabled binding after the replacement dynamic-tool catalog has actually been delivered to Codex.

## Real Behavior Proof

- Behavior or issue addressed: Codex app-server turns with active OpenClaw `before_tool_call` / oc-firewall policy no longer bypass the firewall by exposing Codex-owned shell/file/MCP tool paths when native `PreToolUse` delivery is unavailable.
- Real environment tested: Current exact PR head `1343690524529034a9ac92369740fea7202b0d30` was live-tested on the local production OpenClaw gateway on 2026-06-05 after deploying a remote-built `@openclaw/codex` plugin dist from that exact head. The dist was built on Crabbox/GCP Spot in `us-east1-b`, `e2-standard-8`, lease `cbx_b69467ee4932`, then deployed into `/home/captain/.openclaw/npm/projects/openclaw-codex-8902d781d4/node_modules/@openclaw/codex/dist` and loaded by graceful gateway restart. Exact-head build/type/test validation also passed on Crabbox/GCP Spot in `us-east1-b`, `e2-standard-8`, lease `cbx_488604745933`.
- Exact steps or command run after this patch: Built the Codex plugin dist remotely from `1343690524529034a9ac92369740fea7202b0d30` with `pnpm install --frozen-lockfile --reporter=append-only` and `node scripts/lib/plugin-npm-runtime-build.mjs extensions/codex`, downloaded `/tmp/codex-dist-134369052452.tar.gz`, verified checksum `10dacdcc02097e8dccd85cccd782a4db9745b558fed5b25de5d8187c56c0c95f`, backed up the previous active dist to `/home/captain/.openclaw/npm/projects/openclaw-codex-8902d781d4/node_modules/@openclaw/codex/dist.pre-pr90633-134369052452-20260605T172900Z`, swapped in the current-head dist, and restarted through `bash /home/captain/.openclaw/workspace/scripts/graceful-restart.sh --delay 0 --reason 'PR 90633 exact-head Codex plugin proof deploy'`. Then ran `bash /home/captain/.openclaw/workspace/scripts/oc-regression-suite.sh --tier 2 --skip-tag agent --skip-tag sidecar --skip-tag policy --skip-tag pi --skip-tag hooks --skip-tag observability --skip-tag cron --skip-tag model-health --skip-tag lcm --max-wall 300 --json /home/captain/codex-workspace/proof/codex-native-hook-delivery-2026-06-05/after-exact-head-134369052452-tier2-codex.json`.
- Evidence after fix: Current-head live gateway output:
  ```text
  preflight: gateway stable (PID=91094)
  [T2] test_firewall_blocks_codex_exec  PASS   41.7s  codex: firewall blocked the sentinel read - enforcement verified, gateway path
  codex harness confirmed (provider=openai); firewall blocked the sentinel read - enforcement verified on codex path
  Overall: 1/1 PASS (skipped=15, total wall 41.7s)
  wrote JSON: /home/captain/codex-workspace/proof/codex-native-hook-delivery-2026-06-05/after-exact-head-134369052452-tier2-codex.json
  ```
  Current-head active dist chunk hashes after deploy:
  ```text
  1d4bb44320edfd76024eacf16007159fbef2ef4b1283494c23d9e16ab3831b77  run-attempt-BGH-eXMq.js
  75134fc5d8b7244876a22dedc0b5146e2e0db47ca48b522f1cd7ff0105f14840  thread-lifecycle-D2VwZmmS.js
  7a65ab31340aa9ff3ff1ae2964b97fb9e7ee77cece4c68200f0c7ddf0f17675a  native-hook-relay-S-x_kIiz.js
  d965f53440b475be7bffb7b486fa21109fe65c31d704ccd3e0a9578ea774fea2  side-question-BU-x_xrm.js
  ```
  Current-head remote validation output:
  ```text
  Test Files 5 passed (5)
  Tests 165 passed (165)
  [build-all] tsdown done in 250.4s
  [build-all] phase timings: total 345.9s; slowest tsdown 250.4s
  command complete in 9m27.992s total=9m36.704s
  {"provider":"gcp","leaseId":"cbx_488604745933","syncSkipped":false,"commandMs":567992,"totalMs":576704,"exitCode":0}
  ```
  Current-head remote build artifact output:
  ```text
  1343690524529034a9ac92369740fea7202b0d30
  [plugin-npm-runtime-build] built codex runtime (8 entries)
  10dacdcc02097e8dccd85cccd782a4db9745b558fed5b25de5d8187c56c0c95f  /tmp/codex-dist-134369052452.tar.gz
  {"provider":"gcp","leaseId":"cbx_b69467ee4932","syncSkipped":false,"commandMs":31338,"totalMs":72173,"exitCode":0}
  ```
  Crabbox/GCP cleanup after both exact-head remote runs: `gcloud compute instances list --project my-openclaw-490500 --format=json` returned `[]`.
- Observed result after fix: The current-head deployed gateway proof shows the Codex harness genuinely engaged (`provider=openai`) and the firewall blocked the sentinel read before sentinel contents reached output. The exact test `test_firewall_blocks_codex_exec` passed with `codex: firewall blocked the sentinel read - enforcement verified, gateway path`. Current-head focused tests also cover the review-fix regressions: no global hook trust bypass, bundled MCP disabled only for node-exec or OpenClaw policy-native-surface disable reasons, explicit bundled MCP allowlists preserved outside that policy case, first policy-disabled replacement-tool transitions start a restricted thread so Codex receives `dynamicTools`, already-restricted turns resume through stale MCP/plugin/environment/deferred metadata, zero-tool turns stay transient, pre-generation bindings resume with generation grace, and context-engine bootstrap bindings remain visible for policy-disabled resume decisions.
- What was not tested: No changed-path proof gap remains. I did not add screenshot or video proof because the changed behavior is CLI/gateway policy enforcement; the relevant proof is terminal output plus the JSON regression artifact. Maintainer acceptance is still needed for the intentional compatibility tradeoff: policy-active turns disable Codex-owned native Code Mode, user/bundled MCP projection, and `/btw` until a proven native hook-delivery path can cover every executable surface.

## Validation

Current head `1343690524529034a9ac92369740fea7202b0d30`:
- Live local production gateway Codex firewall proof PASS, `test_firewall_blocks_codex_exec`, 41.7s, JSON artifact at `/home/captain/codex-workspace/proof/codex-native-hook-delivery-2026-06-05/after-exact-head-134369052452-tier2-codex.json`
- Remote current-head Codex plugin dist build PASS on Crabbox/GCP, lease `cbx_b69467ee4932`, checksum `10dacdcc02097e8dccd85cccd782a4db9745b558fed5b25de5d8187c56c0c95f`
- `git diff --check` PASS
- Local focused regression after final lifecycle tightening: `pnpm test extensions/codex/src/app-server/thread-lifecycle.binding.test.ts extensions/codex/src/app-server/run-attempt.test.ts` PASS, 2 files / 115 tests
- Crabbox/GCP focused 5-file Codex app-server regression suite PASS, 165 tests
- Crabbox/GCP `pnpm tsgo:core` PASS
- Crabbox/GCP `pnpm build` PASS
- Crabbox/GCP `pnpm tsgo:core:test` PASS
- Crabbox/GCP cleanup after exact-head remote runs returned `[]`

Earlier validation before review-fix commits:
- Focused test shard PASS, 2 shards, 6 files, 180 tests
- Targeted run-attempt policy assertion PASS
- `pnpm tsgo:prod` PASS
- `pnpm check:test-types` PASS
- `node scripts/run-vitest.mjs extensions/codex/src/app-server/dynamic-tool-build.test.ts extensions/codex/src/app-server/side-question.test.ts extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts extensions/codex/src/app-server/thread-lifecycle.binding.test.ts extensions/codex/src/app-server/native-hook-relay.test.ts src/agents/harness/native-hook-relay.test.ts` PASS, 2 shards, 6 files, 180 tests
- `node scripts/lib/plugin-npm-runtime-build.mjs extensions/codex` PASS

## Residual Risk

Policy-active Codex turns intentionally trade native Code Mode, user/bundled MCP projection, and `/btw` availability for OpenClaw-owned enforcement. Native Code Mode should only be re-enabled for policy-active turns after a future proven native hook-delivery path can safely cover every Codex-owned executable surface.