### PR TITLE
fix(nextcloud-talk): ignore signed non-message webhooks

### DIFF
--- a/extensions/nextcloud-talk/src/monitor.replay.test.ts
+++ b/extensions/nextcloud-talk/src/monitor.replay.test.ts
@@ -6,7 +6,10 @@ import {
   processNextcloudTalkReplayGuardedMessage,
   readNextcloudTalkWebhookBody,
 } from "./monitor.js";
-import { createSignedCreateMessageRequest } from "./monitor.test-fixtures.js";
+import {
+  createSignedCreateMessageRequest,
+  createSignedWebhookRequest,
+} from "./monitor.test-fixtures.js";
 import { startWebhookServer } from "./monitor.test-harness.js";
 import { createNextcloudTalkReplayGuard } from "./replay-guard.js";
 import { generateNextcloudTalkSignature } from "./signature.js";
@@ -218,6 +221,36 @@ describe("createNextcloudTalkWebhookServer payload validation", () => {
 
     expect(response.status).toBe(400);
     expect(await response.json()).toEqual({ error: "Invalid payload format" });
+  });
+
+  it("acknowledges signed non-message activity payloads without dispatching", async () => {
+    const onMessage = vi.fn();
+    const payload = {
+      type: "Create",
+      actor: { type: "Person", id: "alice", name: "Alice" },
+      object: {
+        type: "Document",
+        id: "file-1",
+        name: "report.pdf",
+        mediaType: "application/pdf",
+      },
+      target: { type: "Collection", id: "room-1", name: "Room 1" },
+    };
+    const { body, headers } = createSignedWebhookRequest(payload);
+    const harness = await startWebhookServer({
+      path: "/nextcloud-non-message-payload",
+      onMessage,
+    });
+
+    const response = await fetch(harness.webhookUrl, {
+      method: "POST",
+      headers,
+      body,
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("");
+    expect(onMessage).not.toHaveBeenCalled();
   });
 });
 

--- a/extensions/nextcloud-talk/src/monitor.test-fixtures.ts
+++ b/extensions/nextcloud-talk/src/monitor.test-fixtures.ts
@@ -1,19 +1,7 @@
 // Nextcloud Talk plugin module implements monitor fixtures behavior.
 import { generateNextcloudTalkSignature } from "./signature.js";
 
-export function createSignedCreateMessageRequest(params?: { backend?: string }) {
-  const payload = {
-    type: "Create",
-    actor: { type: "Person", id: "alice", name: "Alice" },
-    object: {
-      type: "Note",
-      id: "msg-1",
-      name: "hello",
-      content: "hello",
-      mediaType: "text/plain",
-    },
-    target: { type: "Collection", id: "room-1", name: "Room 1" },
-  };
+export function createSignedWebhookRequest(payload: unknown, params?: { backend?: string }) {
   const body = JSON.stringify(payload);
   const { random, signature } = generateNextcloudTalkSignature({
     body,
@@ -28,4 +16,20 @@ export function createSignedCreateMessageRequest(params?: { backend?: string }) 
       "x-nextcloud-talk-backend": params?.backend ?? "https://nextcloud.example",
     },
   };
+}
+
+export function createSignedCreateMessageRequest(params?: { backend?: string }) {
+  const payload = {
+    type: "Create",
+    actor: { type: "Person", id: "alice", name: "Alice" },
+    object: {
+      type: "Note",
+      id: "msg-1",
+      name: "hello",
+      content: "hello",
+      mediaType: "text/plain",
+    },
+    target: { type: "Collection", id: "room-1", name: "Room 1" },
+  };
+  return createSignedWebhookRequest(payload, params);
 }

--- a/extensions/nextcloud-talk/src/monitor.ts
+++ b/extensions/nextcloud-talk/src/monitor.ts
@@ -1,6 +1,5 @@
 // Nextcloud Talk plugin module implements monitor behavior.
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
-import { safeParseJsonWithSchema } from "openclaw/plugin-sdk/extension-shared";
 import {
   WEBHOOK_RATE_LIMIT_DEFAULTS,
   createAuthRateLimiter,
@@ -110,8 +109,39 @@ function formatError(err: unknown): string {
   return typeof err === "string" ? err : JSON.stringify(err);
 }
 
-function parseWebhookPayload(body: string): NextcloudTalkWebhookPayload | null {
-  return safeParseJsonWithSchema(NextcloudTalkWebhookPayloadSchema, body);
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseWebhookJson(body: string): { ok: true; value: unknown } | { ok: false } {
+  try {
+    return { ok: true, value: JSON.parse(body) as unknown };
+  } catch {
+    return { ok: false };
+  }
+}
+
+function parseWebhookPayload(value: unknown): NextcloudTalkWebhookPayload | null {
+  const parsed = NextcloudTalkWebhookPayloadSchema.safeParse(value);
+  return parsed.success ? parsed.data : null;
+}
+
+function isSupportedMessagePayloadCandidate(value: Record<string, unknown>): boolean {
+  const object = value.object;
+  return (
+    (value.type === "Create" || value.type === "Update" || value.type === "Delete") &&
+    isRecord(object) &&
+    object.type === "Note"
+  );
+}
+
+function isActivityPayloadCandidate(value: Record<string, unknown>): boolean {
+  return (
+    typeof value.type === "string" ||
+    isRecord(value.actor) ||
+    isRecord(value.object) ||
+    isRecord(value.target)
+  );
 }
 
 function writeJsonResponse(
@@ -184,8 +214,20 @@ function decodeWebhookCreateMessage(params: {
   | { kind: "message"; message: NextcloudTalkInboundMessage }
   | { kind: "ignore" }
   | { kind: "invalid" } {
-  const payload = parseWebhookPayload(params.body);
+  const decodedJson = parseWebhookJson(params.body);
+  if (!decodedJson.ok || !isRecord(decodedJson.value)) {
+    writeWebhookError(params.res, 400, WEBHOOK_ERRORS.invalidPayloadFormat);
+    return { kind: "invalid" };
+  }
+
+  const payload = parseWebhookPayload(decodedJson.value);
   if (!payload) {
+    if (
+      isActivityPayloadCandidate(decodedJson.value) &&
+      !isSupportedMessagePayloadCandidate(decodedJson.value)
+    ) {
+      return { kind: "ignore" };
+    }
     writeWebhookError(params.res, 400, WEBHOOK_ERRORS.invalidPayloadFormat);
     return { kind: "invalid" };
   }


### PR DESCRIPTION
## Summary
- distinguish malformed webhook JSON / malformed supported Note payloads from signed Activity Streams events that are not chat messages
- acknowledge signed non-message Talk events with 200 without dispatching them to the bot
- add a signed Document activity regression fixture while preserving the existing invalid-payload 400 test

Fixes #81566

## Tests
- node scripts/run-vitest.mjs extensions/nextcloud-talk/src/monitor.replay.test.ts
- git diff --check

## Real behavior proof
- Behavior addressed: signed Nextcloud Talk webhook events that are valid Activity Streams but not chat-message Notes are acknowledged without entering bot dispatch, while malformed supported message payloads still fail validation.
- Real environment tested: local OpenClaw checkout at PR head `b784fee2a4c74df475384ba877d9a0fa3e7aac15` on macOS 15.5 with Node v22.22.1 and pnpm 11.2.2; no live Nextcloud credentials were used.
- Exact steps or command run after this patch: `node scripts/run-vitest.mjs extensions/nextcloud-talk/src/monitor.replay.test.ts`; `git diff --check upstream/main...HEAD`.
- Evidence after fix: terminal output from the PR-head checkout:

```text
$ node scripts/run-vitest.mjs extensions/nextcloud-talk/src/monitor.replay.test.ts
✓  extension-messaging  extensions/nextcloud-talk/src/monitor.replay.test.ts (11 tests) 56ms
Test Files  1 passed (1)
Tests  11 passed (11)
[test] passed 1 Vitest shard in 6.91s

$ git diff --check upstream/main...HEAD
# no output; exit code 0
```

- Observed result after fix: the Nextcloud Talk replay shard passed at PR head, including signed non-message webhook acknowledgement and malformed Note rejection coverage; the PR diff has no whitespace errors.
- What was not tested: a live Nextcloud Talk webhook delivery against a real server; this proof uses the local monitor replay harness with signed fixture payloads.