### PR TITLE
fix(compaction): preserve assistant boundary replies

### DIFF
--- a/src/agents/embedded-agent-runner/compaction-successor-transcript.test.ts
+++ b/src/agents/embedded-agent-runner/compaction-successor-transcript.test.ts
@@ -250,7 +250,12 @@ describe("rotateTranscriptAfterCompaction", () => {
     );
     expect(successorCompaction.firstKeptEntryId).toBe(firstKeptId);
     const contextMessages = successor.buildSessionContext().messages;
-    expect(JSON.stringify(contextMessages)).not.toContain("old assistant");
+    expect(
+      contextMessages.some(
+        (message) =>
+          message.role === "assistant" && JSON.stringify(message.content).includes("old assistant"),
+      ),
+    ).toBe(false);
     expect(JSON.stringify(contextMessages)).toContain("kept user");
   });
 

--- a/src/agents/embedded-agent-runner/compaction-successor-transcript.test.ts
+++ b/src/agents/embedded-agent-runner/compaction-successor-transcript.test.ts
@@ -222,6 +222,38 @@ describe("rotateTranscriptAfterCompaction", () => {
     ).toBe(false);
   });
 
+  it("does not preserve a summarized assistant when custom entries separate the kept user", async () => {
+    const dir = await createTmpDir();
+    const manager = SessionManager.create(dir, dir);
+    manager.appendMessage({ role: "user", content: "old user", timestamp: 1 });
+    const oldAssistantId = manager.appendMessage(makeAssistant("old assistant", 2));
+    manager.appendCustomEntry("branch_summary", { summary: "intervening summary" });
+    const firstKeptId = manager.appendMessage({ role: "user", content: "kept user", timestamp: 3 });
+    manager.appendCompaction("Summary of old user and old assistant.", firstKeptId, 5000);
+    const sessionFile = requireString(manager.getSessionFile(), "compacted session file");
+
+    const result = await rotateTranscriptAfterCompaction({
+      sessionManager: manager,
+      sessionFile,
+      now: () => new Date("2026-04-27T12:03:00.000Z"),
+    });
+
+    expect(result.rotated).toBe(true);
+    const successor = SessionManager.open(
+      requireString(result.sessionFile, "successor session file"),
+    );
+    expect(successor.getEntries().find((entry) => entry.id === oldAssistantId)).toBeUndefined();
+    const successorCompaction = requireEntryByType(
+      successor.getEntries(),
+      "compaction",
+      "successor compaction",
+    );
+    expect(successorCompaction.firstKeptEntryId).toBe(firstKeptId);
+    const contextMessages = successor.buildSessionContext().messages;
+    expect(JSON.stringify(contextMessages)).not.toContain("old assistant");
+    expect(JSON.stringify(contextMessages)).toContain("kept user");
+  });
+
   it("creates a compacted successor transcript and leaves the archive untouched", async () => {
     const dir = await createTmpDir();
     const { manager, sessionFile, firstKeptId, oldUserId } = createCompactedSession(dir);

--- a/src/agents/embedded-agent-runner/compaction-successor-transcript.test.ts
+++ b/src/agents/embedded-agent-runner/compaction-successor-transcript.test.ts
@@ -92,6 +92,7 @@ function createCompactedSession(sessionDir: string): {
   sessionFile: string;
   firstKeptId: string;
   oldUserId: string;
+  oldAssistantId: string;
 } {
   // Fixture includes pre-compaction history, preserved branch metadata, and
   // post-compaction turns so rotation can prove exactly which entries survive.
@@ -101,7 +102,7 @@ function createCompactedSession(sessionDir: string): {
   manager.appendCustomEntry("test-extension", { cursor: "before-compaction" });
   const oldUserId = manager.appendMessage({ role: "user", content: "old user", timestamp: 1 });
   manager.appendLabelChange(oldUserId, "old bookmark");
-  manager.appendMessage(makeAssistant("old assistant", 2));
+  const oldAssistantId = manager.appendMessage(makeAssistant("old assistant", 2));
   const firstKeptId = manager.appendMessage({ role: "user", content: "kept user", timestamp: 3 });
   manager.appendLabelChange(firstKeptId, "kept bookmark");
   manager.appendMessage(makeAssistant("kept assistant", 4));
@@ -113,6 +114,7 @@ function createCompactedSession(sessionDir: string): {
     sessionFile: requireString(manager.getSessionFile(), "compacted session file"),
     firstKeptId,
     oldUserId,
+    oldAssistantId,
   };
 }
 
@@ -164,6 +166,11 @@ describe("rotateTranscriptAfterCompaction", () => {
         summary: "Summary of old user and old assistant.",
         tokensBefore: 5000,
       },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "old assistant" }],
+        timestamp: 2,
+      },
       { role: "user", content: "kept user", timestamp: 3 },
       {
         role: "assistant",
@@ -177,6 +184,42 @@ describe("rotateTranscriptAfterCompaction", () => {
         timestamp: 6,
       },
     ]);
+  });
+
+  it("preserves the summarized assistant reply before a surviving user message", async () => {
+    const dir = await createTmpDir();
+    const { manager, sessionFile, oldUserId, oldAssistantId } = createCompactedSession(dir);
+
+    const result = await rotateTranscriptAfterCompaction({
+      sessionManager: manager,
+      sessionFile,
+      now: () => new Date("2026-04-27T12:02:00.000Z"),
+    });
+
+    expect(result.rotated).toBe(true);
+    const successor = SessionManager.open(
+      requireString(result.sessionFile, "successor session file"),
+    );
+    expect(successor.getEntries().find((entry) => entry.id === oldUserId)).toBeUndefined();
+    const oldAssistant = requireEntryByIdAndType(
+      successor.getEntries(),
+      oldAssistantId,
+      "message",
+      "preserved summarized assistant",
+    );
+    expect(oldAssistant.message.role).toBe("assistant");
+    expect(JSON.stringify(oldAssistant.message)).toContain("old assistant");
+    const successorCompaction = requireEntryByType(
+      successor.getEntries(),
+      "compaction",
+      "successor compaction",
+    );
+    expect(successorCompaction.firstKeptEntryId).toBe(oldAssistantId);
+    const contextMessages = successor.buildSessionContext().messages;
+    expect(JSON.stringify(contextMessages)).toContain("old assistant");
+    expect(
+      contextMessages.some((message) => message.role === "user" && message.content === "old user"),
+    ).toBe(false);
   });
 
   it("creates a compacted successor transcript and leaves the archive untouched", async () => {
@@ -215,6 +258,7 @@ describe("rotateTranscriptAfterCompaction", () => {
     const context = successor.buildSessionContext();
     const contextText = JSON.stringify(context.messages);
     expect(contextText).toContain("Summary of old user and old assistant.");
+    expect(contextText).toContain("old assistant");
     expect(contextText).toContain("kept user");
     expect(contextText).toContain("post assistant");
     expect(
@@ -571,16 +615,19 @@ describe("rotateTranscriptAfterCompaction — thinking signature stripping", () 
       return undefined;
     }
 
+    // Preserved summarized assistant (timestamp 2): signature stripped
+    expect(getThinkingSignatureForTimestamp(2)).toBeUndefined();
     // Pre-compaction kept message (timestamp 4): signature stripped
     expect(getThinkingSignatureForTimestamp(4)).toBeUndefined();
     // Post-compaction message (timestamp 6): signature preserved intact
     expect(getThinkingSignatureForTimestamp(6)).toBe("fresh_sig");
 
-    // Old summarized messages should not appear
+    // Old summarized user should not appear
     expect(entries.find((e) => e.id === oldUserId)).toBeUndefined();
 
     // Context should remain coherent: compaction summary + kept + post-compaction
     const contextText = JSON.stringify(successor.buildSessionContext().messages);
+    expect(contextText).toContain("old answer");
     expect(contextText).toContain("kept question");
     expect(contextText).toContain("kept answer");
     expect(contextText).toContain("post answer");

--- a/src/agents/embedded-agent-runner/compaction-successor-transcript.ts
+++ b/src/agents/embedded-agent-runner/compaction-successor-transcript.ts
@@ -259,7 +259,7 @@ function collectAssistantBoundaryMessageIds(params: {
     for (let candidateIndex = index - 1; candidateIndex >= 0; candidateIndex -= 1) {
       const candidate = branch[candidateIndex];
       if (candidate?.type !== "message") {
-        continue;
+        break;
       }
       if (candidate.message.role === "assistant" && summarizedBranchIds.has(candidate.id)) {
         ids.add(candidate.id);

--- a/src/agents/embedded-agent-runner/compaction-successor-transcript.ts
+++ b/src/agents/embedded-agent-runner/compaction-successor-transcript.ts
@@ -144,9 +144,17 @@ function buildSuccessorEntries(params: {
 
   const removedIds = new Set<string>();
   const duplicateUserMessageIds = collectDuplicateUserMessageEntryIdsForCompaction(branch);
+  const assistantBoundaryMessageIds = collectAssistantBoundaryMessageIds({
+    branch,
+    latestCompactionIndex,
+    preCompactionKeptBranchIds,
+    summarizedBranchIds,
+  });
   for (const entry of allEntries) {
     if (
-      (summarizedBranchIds.has(entry.id) && entry.type === "message") ||
+      (summarizedBranchIds.has(entry.id) &&
+        entry.type === "message" &&
+        !assistantBoundaryMessageIds.has(entry.id)) ||
       staleStateEntryIds.has(entry.id) ||
       duplicateUserMessageIds.has(entry.id)
     ) {
@@ -183,14 +191,27 @@ function buildSuccessorEntries(params: {
 
     const reparented =
       parentId === entry.parentId ? entry : ({ ...entry, parentId } as SessionEntry);
+    const reanchored =
+      reparented.type === "compaction"
+        ? ({
+            ...reparented,
+            firstKeptEntryId: resolveSuccessorCompactionFirstKeptEntryId({
+              compaction: reparented,
+              assistantBoundaryMessageIds,
+              originalIndexById,
+            }),
+          } as SessionEntry)
+        : reparented;
     // Strip thinking signatures only from pre-compaction kept entries. Pre-compaction
     // signatures are bound to the original context prefix; the successor file has a different
     // prefix so those signatures would cause Anthropic "Invalid signature in thinking block".
     // Post-compaction entries were generated in the new context and have valid signatures.
     const transformed =
-      reparented.type === "message" && preCompactionKeptBranchIds.has(reparented.id)
-        ? { ...reparented, message: stripThinkingSignaturesFromMessage(reparented.message) }
-        : reparented;
+      reanchored.type === "message" &&
+      (preCompactionKeptBranchIds.has(reanchored.id) ||
+        assistantBoundaryMessageIds.has(reanchored.id))
+        ? { ...reanchored, message: stripThinkingSignaturesFromMessage(reanchored.message) }
+        : reanchored;
     keptEntries.push(transformed);
   }
 
@@ -199,6 +220,54 @@ function buildSuccessorEntries(params: {
     activeBranchIds,
     originalIndexById,
   });
+}
+
+function resolveSuccessorCompactionFirstKeptEntryId(params: {
+  compaction: CompactionEntry;
+  assistantBoundaryMessageIds: Set<string>;
+  originalIndexById: Map<string, number>;
+}): string {
+  let firstKeptEntryId = params.compaction.firstKeptEntryId;
+  let firstKeptIndex = params.originalIndexById.get(firstKeptEntryId) ?? Number.MAX_SAFE_INTEGER;
+  for (const id of params.assistantBoundaryMessageIds) {
+    const index = params.originalIndexById.get(id) ?? Number.MAX_SAFE_INTEGER;
+    if (index < firstKeptIndex) {
+      firstKeptEntryId = id;
+      firstKeptIndex = index;
+    }
+  }
+  return firstKeptEntryId;
+}
+
+function collectAssistantBoundaryMessageIds(params: {
+  branch: SessionEntry[];
+  latestCompactionIndex: number;
+  preCompactionKeptBranchIds: Set<string>;
+  summarizedBranchIds: Set<string>;
+}): Set<string> {
+  const ids = new Set<string>();
+  const { branch, latestCompactionIndex, preCompactionKeptBranchIds, summarizedBranchIds } = params;
+  for (let index = 0; index < latestCompactionIndex; index += 1) {
+    const entry = branch[index];
+    if (
+      entry?.type !== "message" ||
+      entry.message.role !== "user" ||
+      !preCompactionKeptBranchIds.has(entry.id)
+    ) {
+      continue;
+    }
+    for (let candidateIndex = index - 1; candidateIndex >= 0; candidateIndex -= 1) {
+      const candidate = branch[candidateIndex];
+      if (candidate?.type !== "message") {
+        continue;
+      }
+      if (candidate.message.role === "assistant" && summarizedBranchIds.has(candidate.id)) {
+        ids.add(candidate.id);
+      }
+      break;
+    }
+  }
+  return ids;
 }
 
 function collectLatestStateEntryIds(entries: SessionEntry[]): Set<string> {


### PR DESCRIPTION
## Summary
- preserve the summarized assistant reply immediately before a surviving pre-compaction user message when writing successor transcripts
- move the successor compaction replay boundary to that preserved assistant so agent context stays `summary -> assistant -> user` instead of hiding the reply
- strip stale thinking signatures from preserved boundary assistants along with other pre-compaction kept messages

Fixes #76729

## Tests
- node scripts/run-vitest.mjs src/agents/embedded-agent-runner/compaction-successor-transcript.test.ts
- git diff --check

## Real behavior proof
- Behavior addressed: successor transcripts now keep the assistant reply immediately before the first surviving pre-compaction user message so replay preserves the visible `summary -> assistant -> user` boundary.
- Real environment tested: local OpenClaw checkout at PR head `ba959f19332c40305f241e15ef483c4a8923cc7` on macOS 15.5 with Node v22.22.1 and pnpm 11.2.2.
- Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/compaction-successor-transcript.test.ts`; `git diff --check upstream/main...HEAD`.
- Evidence after fix: terminal output from the PR-head checkout:

```text
$ node scripts/run-vitest.mjs src/agents/embedded-agent-runner/compaction-successor-transcript.test.ts
✓  agents  src/agents/embedded-agent-runner/compaction-successor-transcript.test.ts (12 tests) 132ms
Test Files  1 passed (1)
Tests  12 passed (12)
[test] passed 1 Vitest shard in 6.82s

$ git diff --check upstream/main...HEAD
# no output; exit code 0
```

- Observed result after fix: the compaction successor transcript shard passed at PR head, including the preserved assistant-boundary replay coverage; the PR diff has no whitespace errors.
- What was not tested: a live model session performing an end-to-end compaction run; this proof uses the local embedded-agent successor-transcript runtime harness.