### PR TITLE
fix(telegram): trust open group policy for native commands

### DIFF
--- a/extensions/telegram/src/bot-native-commands.group-auth.test.ts
+++ b/extensions/telegram/src/bot-native-commands.group-auth.test.ts
@@ -74,6 +74,27 @@ describe("native command auth in groups", () => {
     expect(notAuthCalls).toHaveLength(0);
   });
 
+  it("authorizes native commands from a per-group open policy override", async () => {
+    const { handlers, sendMessage } = setup({
+      telegramCfg: {
+        groupPolicy: "allowlist",
+      } as TelegramAccountConfig,
+      groupConfig: {
+        groupPolicy: "open",
+      },
+      useAccessGroups: true,
+    });
+
+    const ctx = createTelegramGroupCommandContext({
+      username: "random",
+    });
+
+    await handlers.status?.(ctx);
+
+    const notAuthCalls = findNotAuthorizedCalls(sendMessage);
+    expect(notAuthCalls).toHaveLength(0);
+  });
+
   it("does not authorize group native commands from the DM allowlist store", async () => {
     const { handlers, sendMessage } = setup({
       storeAllowFrom: ["12345"],

--- a/extensions/telegram/src/bot-native-commands.group-auth.test.ts
+++ b/extensions/telegram/src/bot-native-commands.group-auth.test.ts
@@ -54,6 +54,26 @@ describe("native command auth in groups", () => {
     expect(notAuthCalls).toHaveLength(0);
   });
 
+  it("authorizes native commands in open groups without a sender allowlist", async () => {
+    const { handlers, sendMessage } = setup({
+      cfg: {
+        channels: {
+          telegram: {
+            groupPolicy: "open",
+          },
+        },
+      } as OpenClawConfig,
+      useAccessGroups: true,
+    });
+
+    const ctx = createTelegramGroupCommandContext();
+
+    await handlers.status?.(ctx);
+
+    const notAuthCalls = findNotAuthorizedCalls(sendMessage);
+    expect(notAuthCalls).toHaveLength(0);
+  });
+
   it("does not authorize group native commands from the DM allowlist store", async () => {
     const { handlers, sendMessage } = setup({
       storeAllowFrom: ["12345"],

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -633,7 +633,7 @@ async function resolveTelegramCommandAuth(params: {
     senderUsername,
     resolveGroupPolicy,
     enforcePolicy: useAccessGroups,
-    useTopicAndGroupOverrides: false,
+    useTopicAndGroupOverrides: true,
     enforceAllowlistAuthorization: requireAuth && !commandsAllowFromConfigured,
     allowEmptyAllowlistEntries: true,
     requireSenderForAllowlistAuthorization: true,

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -665,8 +665,11 @@ async function resolveTelegramCommandAuth(params: {
     storeAllowFrom: isGroup ? [] : storeAllowFrom,
     dmPolicy: effectiveDmPolicy,
   });
+  const groupCommandAuthorizedByPolicy = isGroup && policyAccess.groupPolicy === "open";
   const commandAuthorized = commandsAllowFromConfigured
     ? Boolean(commandsAllowFromAccess?.isAuthorizedSender)
+    : groupCommandAuthorizedByPolicy
+      ? true
     : (
         await resolveTelegramCommandIngressAuthorization({
           accountId,


### PR DESCRIPTION
## Summary
- allow Telegram native commands in groups when the resolved group policy is open and no commands.allowFrom override is configured
- keep commands.allowFrom.telegram as the sole command auth source when configured
- add regression coverage for /status in open groups without sender allowlists

Fixes #74698

## Tests
- node scripts/run-vitest.mjs extensions/telegram/src/bot-native-commands.group-auth.test.ts
- node scripts/run-vitest.mjs extensions/telegram/src/group-access.base-access.test.ts src/plugin-sdk/channel-ingress-runtime.test.ts
- git diff --check

## Real behavior proof
- Behavior addressed: Telegram native `/status` in a configured open group can proceed without a sender allowlist unless `channels.telegram.commands.allowFrom` is configured.
- Real environment tested: local OpenClaw checkout at PR head `749f7105d1f80e54b0b0484f445c75471139e3a8` on macOS 15.5 with Node v22.22.1 and pnpm 11.2.2; no live Telegram credentials were used.
- Exact steps or command run after this patch: `node scripts/run-vitest.mjs extensions/telegram/src/bot-native-commands.group-auth.test.ts`; `git diff --check upstream/main...HEAD`.
- Evidence after fix: terminal output from the PR-head checkout:

```text
$ node scripts/run-vitest.mjs extensions/telegram/src/bot-native-commands.group-auth.test.ts
✓  extension-telegram  extensions/telegram/src/bot-native-commands.group-auth.test.ts (10 tests) 36ms
Test Files  1 passed (1)
Tests  10 passed (10)
[test] passed 1 Vitest shard in 16.13s

$ git diff --check upstream/main...HEAD
# no output; exit code 0
```

- Observed result after fix: the Telegram native-command group-auth shard passed at PR head, covering open group command authorization and explicit `commands.allowFrom` override behavior; the PR diff has no whitespace errors.
- What was not tested: live Telegram bot delivery against a real group; this proof uses the local plugin native-command harness with synthetic chat/user ids.