### PR TITLE
fix(discord): protect mention aliases in code fences

### DIFF
--- a/extensions/discord/src/mentions.test.ts
+++ b/extensions/discord/src/mentions.test.ts
@@ -116,6 +116,18 @@ describe("rewriteDiscordKnownMentions", () => {
     );
   });
 
+  it("rewrites mentions after same-line fenced code blocks", () => {
+    rememberDiscordDirectoryUser({
+      accountId: "default",
+      userId: "123456789",
+      handles: ["alice", "bob"],
+    });
+    const rewritten = rewriteDiscordKnownMentions("```@alice``` outside @bob", {
+      accountId: "default",
+    });
+    expect(rewritten).toBe("```@alice``` outside <@123456789>");
+  });
+
   it("keeps shorter backtick fence lines inside longer fenced code blocks", () => {
     rememberDiscordDirectoryUser({
       accountId: "default",

--- a/extensions/discord/src/mentions.test.ts
+++ b/extensions/discord/src/mentions.test.ts
@@ -103,6 +103,42 @@ describe("rewriteDiscordKnownMentions", () => {
     expect(rewritten).toBe("inline `@alice` fence ```\n@alice\n``` text <@123456789>");
   });
 
+  it("does not rewrite mentions after triple-backtick literals inside fenced code", () => {
+    rememberDiscordDirectoryUser({
+      accountId: "default",
+      userId: "123456789",
+      handles: ["alice"],
+    });
+    const text = '```js\nconst fence = "```";\n// do not ping @alice\n```\noutside @alice';
+    const rewritten = rewriteDiscordKnownMentions(text, { accountId: "default" });
+    expect(rewritten).toBe(
+      '```js\nconst fence = "```";\n// do not ping @alice\n```\noutside <@123456789>',
+    );
+  });
+
+  it("keeps shorter backtick fence lines inside longer fenced code blocks", () => {
+    rememberDiscordDirectoryUser({
+      accountId: "default",
+      userId: "123456789",
+      handles: ["alice"],
+    });
+    const text = "````md\n```\n@alice\n```\n````\noutside @alice";
+    const rewritten = rewriteDiscordKnownMentions(text, { accountId: "default" });
+    expect(rewritten).toBe("````md\n```\n@alice\n```\n````\noutside <@123456789>");
+  });
+
+  it("does not rewrite mentions inside multi-backtick inline code spans", () => {
+    rememberDiscordDirectoryUser({
+      accountId: "default",
+      userId: "123456789",
+      handles: ["alice"],
+    });
+    const rewritten = rewriteDiscordKnownMentions("inline ``do not ` ping @alice`` outside @alice", {
+      accountId: "default",
+    });
+    expect(rewritten).toBe("inline ``do not ` ping @alice`` outside <@123456789>");
+  });
+
   it("is account-scoped", () => {
     rememberDiscordDirectoryUser({
       accountId: "ops",

--- a/extensions/discord/src/mentions.ts
+++ b/extensions/discord/src/mentions.ts
@@ -191,6 +191,22 @@ function findFencedCodeSegment(text: string, index: number): MarkdownCodeSegment
   const lineStart = text.lastIndexOf("\n", index - 1) + 1;
   const openerIsIndentedLine =
     index - lineStart <= 3 && text.slice(lineStart, index).trim() === "";
+  const openerLineEnd = findLineEnd(text, index);
+  let sameLineCloserCursor = index + fenceLength;
+  while (sameLineCloserCursor < openerLineEnd) {
+    if (text[sameLineCloserCursor] !== fenceChar) {
+      sameLineCloserCursor += 1;
+      continue;
+    }
+    const closingLength = countRun(text, sameLineCloserCursor, fenceChar);
+    if (closingLength >= fenceLength) {
+      return {
+        start: openerIsIndentedLine ? lineStart : index,
+        end: sameLineCloserCursor + closingLength,
+      };
+    }
+    sameLineCloserCursor += closingLength;
+  }
   let nextLineStart = findLineEnd(text, index);
   if (nextLineStart < text.length) {
     nextLineStart += 1;

--- a/extensions/discord/src/mentions.ts
+++ b/extensions/discord/src/mentions.ts
@@ -8,12 +8,12 @@ import { resolveDiscordDirectoryUserId } from "./directory-cache.js";
 
 type DiscordMentionAliasesConfig = Record<string, string>;
 
-const MARKDOWN_CODE_SEGMENT_PATTERN = /```[\s\S]*?```|`[^`\n]*`/g;
 const MENTION_CANDIDATE_PATTERN = /(^|[\s([{"'.,;:!?])@([a-z0-9_.-]{2,32}(?:#[0-9]{4})?)/gi;
 const DISCORD_RESERVED_MENTIONS = new Set(["everyone", "here"]);
 const DISCORD_DISCRIMINATOR_SUFFIX = /#\d{4}$/;
 const DISCORD_TARGETED_MENTION_PATTERN = /<@!?\d+>|<@&\d+>/;
 const DISCORD_BROADCAST_MENTION_PATTERN = /@(everyone|here)\b/;
+type MarkdownCodeSegment = { start: number; end: number };
 
 function normalizeSnowflake(value: string | number | bigint): string | null {
   const text = normalizeOptionalStringifiedId(value) ?? "";
@@ -126,6 +126,145 @@ function rewritePlainTextMentions(
   });
 }
 
+function countRun(text: string, index: number, char: "`" | "~"): number {
+  let end = index;
+  while (end < text.length && text[end] === char) {
+    end += 1;
+  }
+  return end - index;
+}
+
+function findLineEnd(text: string, index: number): number {
+  const lineEnd = text.indexOf("\n", index);
+  return lineEnd === -1 ? text.length : lineEnd;
+}
+
+function isFenceLine(params: {
+  text: string;
+  lineStart: number;
+  fenceChar?: "`" | "~";
+  minLength: number;
+  requireClosingLine: boolean;
+}): { fenceChar: "`" | "~"; fenceLength: number; fenceStart: number; fenceEnd: number } | null {
+  const { text, lineStart, fenceChar, minLength, requireClosingLine } = params;
+  const lineEnd = findLineEnd(text, lineStart);
+  let index = lineStart;
+  let indent = 0;
+  while (index < lineEnd && text[index] === " " && indent < 4) {
+    index += 1;
+    indent += 1;
+  }
+  if (indent > 3 || index >= lineEnd) {
+    return null;
+  }
+  const currentFenceChar = text[index];
+  if (currentFenceChar !== "`" && currentFenceChar !== "~") {
+    return null;
+  }
+  if (fenceChar != null && currentFenceChar !== fenceChar) {
+    return null;
+  }
+  const fenceLength = countRun(text, index, currentFenceChar);
+  if (fenceLength < minLength) {
+    return null;
+  }
+  if (requireClosingLine && text.slice(index + fenceLength, lineEnd).trim() !== "") {
+    return null;
+  }
+  return {
+    fenceChar: currentFenceChar,
+    fenceLength,
+    fenceStart: index,
+    fenceEnd: index + fenceLength,
+  };
+}
+
+function findFencedCodeSegment(text: string, index: number): MarkdownCodeSegment | null {
+  const fenceChar = text[index];
+  if (fenceChar !== "`" && fenceChar !== "~") {
+    return null;
+  }
+  const fenceLength = countRun(text, index, fenceChar);
+  if (fenceLength < 3) {
+    return null;
+  }
+  const lineStart = text.lastIndexOf("\n", index - 1) + 1;
+  const openerIsIndentedLine =
+    index - lineStart <= 3 && text.slice(lineStart, index).trim() === "";
+  let nextLineStart = findLineEnd(text, index);
+  if (nextLineStart < text.length) {
+    nextLineStart += 1;
+  }
+  while (nextLineStart < text.length) {
+    const closer = isFenceLine({
+      text,
+      lineStart: nextLineStart,
+      fenceChar,
+      minLength: fenceLength,
+      requireClosingLine: false,
+    });
+    const lineEnd = findLineEnd(text, nextLineStart);
+    if (closer) {
+      return {
+        start: openerIsIndentedLine ? lineStart : index,
+        end: closer.fenceEnd,
+      };
+    }
+    nextLineStart = lineEnd < text.length ? lineEnd + 1 : text.length;
+  }
+  if (!openerIsIndentedLine) {
+    return null;
+  }
+  return {
+    start: lineStart,
+    end: text.length,
+  };
+}
+
+function findInlineCodeSegment(text: string, index: number): MarkdownCodeSegment | null {
+  if (text[index] !== "`") {
+    return null;
+  }
+  const fenceLength = countRun(text, index, "`");
+  let cursor = index + fenceLength;
+  while (cursor < text.length && text[cursor] !== "\n") {
+    if (text[cursor] !== "`") {
+      cursor += 1;
+      continue;
+    }
+    const closingLength = countRun(text, cursor, "`");
+    if (closingLength === fenceLength) {
+      return {
+        start: index,
+        end: cursor + closingLength,
+      };
+    }
+    cursor += closingLength;
+  }
+  return null;
+}
+
+function collectMarkdownCodeSegments(text: string): MarkdownCodeSegment[] {
+  const segments: MarkdownCodeSegment[] = [];
+  let index = 0;
+  while (index < text.length) {
+    const fenced = findFencedCodeSegment(text, index);
+    if (fenced) {
+      segments.push(fenced);
+      index = fenced.end;
+      continue;
+    }
+    const inline = findInlineCodeSegment(text, index);
+    if (inline) {
+      segments.push(inline);
+      index = inline.end;
+      continue;
+    }
+    index += 1;
+  }
+  return segments;
+}
+
 export function rewriteDiscordKnownMentions(
   text: string,
   params: {
@@ -138,12 +277,10 @@ export function rewriteDiscordKnownMentions(
   }
   let rewritten = "";
   let offset = 0;
-  MARKDOWN_CODE_SEGMENT_PATTERN.lastIndex = 0;
-  for (const match of text.matchAll(MARKDOWN_CODE_SEGMENT_PATTERN)) {
-    const matchIndex = match.index ?? 0;
-    rewritten += rewritePlainTextMentions(text.slice(offset, matchIndex), params);
-    rewritten += match[0];
-    offset = matchIndex + match[0].length;
+  for (const segment of collectMarkdownCodeSegments(text)) {
+    rewritten += rewritePlainTextMentions(text.slice(offset, segment.start), params);
+    rewritten += text.slice(segment.start, segment.end);
+    offset = segment.end;
   }
   rewritten += rewritePlainTextMentions(text.slice(offset), params);
   return rewritten;


### PR DESCRIPTION
## Summary
- replace the Discord mention code-region regex with a scanner that keeps fenced code blocks intact when the body contains shorter backtick runs
- preserve multi-backtick inline code spans while still rewriting plain text aliases outside code
- add regressions for triple-backtick literals, longer fenced blocks, and multi-backtick inline spans

Fixes #90643

## Tests
- node scripts/run-vitest.mjs extensions/discord/src/mentions.test.ts
- node scripts/run-vitest.mjs extensions/discord/src/send.sends-basic-channel-messages.test.ts extensions/discord/src/send.webhook-activity.test.ts
- git diff --check

## Note
- `node_modules/.bin/tsc -p extensions/discord/tsconfig.json --noEmit --pretty false` currently fails on pre-existing Discord/plugin-sdk type drift unrelated to this patch.