### PR TITLE
fix(skills): use native recursive fs.watch for skill roots to stop per-SKILL.md fd leak

### DIFF
--- a/src/skills/runtime/refresh.test.ts
+++ b/src/skills/runtime/refresh.test.ts
@@ -42,6 +42,67 @@ vi.mock("../loading/plugin-skills.js", () => ({
   resolvePluginSkillDirs: vi.fn(() => []),
 }));
 
+const SKILLS_NATIVE_WATCH_FACTORY_KEY = Symbol.for("openclaw.test.skillsNativeWatchFactory");
+
+type NativeWatchCall = {
+  path: string;
+  options: { recursive?: boolean } | undefined;
+  listener: (eventType: string, filename: string | null) => void;
+  emit: (event: string, ...args: unknown[]) => void;
+  close: ReturnType<typeof vi.fn>;
+};
+
+// Capture the skills watcher's native fs.watch usage by injecting a fake factory
+// through the same test hook the production code consults (see
+// resolveSkillsNativeWatchFactory in refresh.ts).
+function installNativeWatchCapture(): { calls: NativeWatchCall[]; restore: () => void } {
+  const calls: NativeWatchCall[] = [];
+  (globalThis as Record<PropertyKey, unknown>)[SKILLS_NATIVE_WATCH_FACTORY_KEY] = (
+    watchPath: unknown,
+    options: unknown,
+    listener: unknown,
+  ) => {
+    const handlers = new Map<string, (...args: unknown[]) => void>();
+    const close = vi.fn();
+    const watcher = {
+      on: vi.fn((event: string, cb: (...args: unknown[]) => void) => {
+        handlers.set(event, cb);
+        return watcher;
+      }),
+      close,
+    };
+    calls.push({
+      path: String(watchPath),
+      options: options as { recursive?: boolean } | undefined,
+      listener: listener as NativeWatchCall["listener"],
+      emit: (event: string, ...args: unknown[]) => handlers.get(event)?.(...args),
+      close,
+    });
+    return watcher;
+  };
+  return {
+    calls,
+    restore: () => {
+      delete (globalThis as Record<PropertyKey, unknown>)[SKILLS_NATIVE_WATCH_FACTORY_KEY];
+    },
+  };
+}
+
+async function withPlatform(
+  value: NodeJS.Platform,
+  run: () => void | Promise<void>,
+): Promise<void> {
+  const original = Object.getOwnPropertyDescriptor(process, "platform");
+  Object.defineProperty(process, "platform", { configurable: true, value });
+  try {
+    await run();
+  } finally {
+    if (original) {
+      Object.defineProperty(process, "platform", original);
+    }
+  }
+}
+
 describe("ensureSkillsWatcher", () => {
   beforeAll(async () => {
     refreshModule = await import("./refresh.js");
@@ -811,5 +872,200 @@ describe("ensureSkillsWatcher", () => {
       reason: "watch",
       changedPath: "/tmp/shared/demo/SKILL.md",
     });
+  });
+
+  it.each(["darwin", "win32"] as const)(
+    "watches each skill root with one native recursive fs.watch, not one per SKILL.md on %s (#90578)",
+    async (platform) => {
+      const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-watch-native-"));
+      const capture = installNativeWatchCapture();
+      try {
+        await fs.mkdir(path.join(workspaceDir, "skills", "demo"), { recursive: true });
+        await fs.writeFile(
+          path.join(workspaceDir, "skills", "demo", "SKILL.md"),
+          "---\nname: demo\ndescription: Demo\n---\n",
+        );
+        const workspaceSkillsRoot = path.join(workspaceDir, "skills").replaceAll("\\", "/");
+
+        await withPlatform(platform, () => {
+          refreshModule.ensureSkillsWatcher({ workspaceDir });
+        });
+
+        // The existing on-disk skill root is covered by a single native recursive
+        // watcher (one fd per tree), not chokidar's per-file fan-out.
+        const rootCall = capture.calls.find(
+          (call) => call.path.replaceAll("\\", "/") === workspaceSkillsRoot,
+        );
+        expect(rootCall?.options?.recursive).toBe(true);
+        const chokidarTargets = (watchMock.mock.calls as unknown as Array<[string]>).map(([p]) =>
+          p.replaceAll("\\", "/"),
+        );
+        expect(chokidarTargets).not.toContain(workspaceSkillsRoot);
+
+        // The #90578 regression: zero native watchers are opened on a SKILL.md
+        // file (that per-file fan-out was the leaked descriptor).
+        const nativeSkillMdWatchers = capture.calls
+          .map((call) => call.path.replaceAll("\\", "/"))
+          .filter((p) => p.endsWith("SKILL.md"));
+        expect(nativeSkillMdWatchers).toStrictEqual([]);
+      } finally {
+        capture.restore();
+        await fs.rm(workspaceDir, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it.each(["add", "change", "unlink"] as const)(
+    "detects a skill %s through the native macOS watcher, not just directory churn",
+    async (kind) => {
+      vi.useFakeTimers();
+      const seen: SkillsChangeEvent[] = [];
+      const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-watch-native-evt-"));
+      const capture = installNativeWatchCapture();
+      try {
+        const skillFile = path.join(workspaceDir, "skills", "demo", "SKILL.md");
+        await fs.mkdir(path.dirname(skillFile), { recursive: true });
+        await fs.writeFile(skillFile, "---\nname: demo\ndescription: Demo\n---\n");
+        const workspaceSkillsRoot = path.join(workspaceDir, "skills").replaceAll("\\", "/");
+
+        refreshModule.registerSkillsChangeListener((change) => seen.push(change));
+        await withPlatform("darwin", () => {
+          refreshModule.ensureSkillsWatcher({
+            workspaceDir,
+            config: { skills: { load: { watchDebounceMs: 10 } } },
+          });
+        });
+
+        const rootCall = capture.calls.find(
+          (call) =>
+            call.options?.recursive === true &&
+            call.path.replaceAll("\\", "/") === workspaceSkillsRoot,
+        );
+        expect(rootCall).toBeDefined();
+
+        if (kind === "unlink") {
+          await fs.rm(skillFile);
+        }
+        // Native fs.watch reports a path relative to the watched root; the handler
+        // re-stats and refreshes for SKILL.md adds, in-place edits, and removals
+        // alike (a directory-only watch would miss the in-place edit).
+        rootCall?.listener(kind === "change" ? "change" : "rename", "demo/SKILL.md");
+        await vi.advanceTimersByTimeAsync(10);
+
+        expect(seen).toEqual([
+          {
+            workspaceDir,
+            reason: "watch",
+            changedPath: skillFile,
+          },
+        ]);
+      } finally {
+        capture.restore();
+        await fs.rm(workspaceDir, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it("keeps the chokidar watcher on non-native platforms", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-watch-linux-"));
+    const capture = installNativeWatchCapture();
+    try {
+      await fs.mkdir(path.join(workspaceDir, "skills"), { recursive: true });
+      const workspaceSkillsRoot = path.join(workspaceDir, "skills").replaceAll("\\", "/");
+
+      await withPlatform("linux", () => {
+        refreshModule.ensureSkillsWatcher({ workspaceDir });
+      });
+
+      // Native recursive fs.watch is never consulted on Linux (it would fan out to
+      // every file); the directory is watched through chokidar instead.
+      expect(capture.calls).toStrictEqual([]);
+      const chokidarTargets = (watchMock.mock.calls as unknown as Array<[string]>).map(([p]) =>
+        p.replaceAll("\\", "/"),
+      );
+      expect(chokidarTargets).toContain(workspaceSkillsRoot);
+    } finally {
+      capture.restore();
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to a single chokidar watcher when the native skill watcher errors (#90578)", async () => {
+    const workspaceDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "openclaw-watch-native-fallback-"),
+    );
+    const capture = installNativeWatchCapture();
+    try {
+      await fs.mkdir(path.join(workspaceDir, "skills"), { recursive: true });
+      const workspaceSkillsRoot = path.join(workspaceDir, "skills").replaceAll("\\", "/");
+
+      await withPlatform("darwin", () => {
+        refreshModule.ensureSkillsWatcher({ workspaceDir });
+      });
+      const rootCall = capture.calls.find(
+        (call) =>
+          call.options?.recursive === true &&
+          call.path.replaceAll("\\", "/") === workspaceSkillsRoot,
+      );
+      expect(rootCall).toBeDefined();
+      const chokidarTargetsBefore = (watchMock.mock.calls as unknown as Array<[string]>)
+        .map(([p]) => p.replaceAll("\\", "/"))
+        .filter((p) => p === workspaceSkillsRoot);
+      expect(chokidarTargetsBefore).toStrictEqual([]);
+
+      // A native error tears the native watcher down and restores coverage through a
+      // single chokidar watcher on the same root (no leaked or duplicated watcher).
+      rootCall?.emit("error", new Error("native watcher died"));
+
+      expect(rootCall?.close).toHaveBeenCalled();
+      const chokidarTargetsAfter = (watchMock.mock.calls as unknown as Array<[string]>)
+        .map(([p]) => p.replaceAll("\\", "/"))
+        .filter((p) => p === workspaceSkillsRoot);
+      expect(chokidarTargetsAfter).toHaveLength(1);
+    } finally {
+      capture.restore();
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not re-attach a watcher after the skill watcher is torn down (#90578)", async () => {
+    const workspaceDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "openclaw-watch-native-disposed-"),
+    );
+    const capture = installNativeWatchCapture();
+    try {
+      await fs.mkdir(path.join(workspaceDir, "skills"), { recursive: true });
+      const workspaceSkillsRoot = path.join(workspaceDir, "skills").replaceAll("\\", "/");
+
+      await withPlatform("darwin", () => {
+        refreshModule.ensureSkillsWatcher({ workspaceDir });
+      });
+      const rootCall = capture.calls.find(
+        (call) =>
+          call.options?.recursive === true &&
+          call.path.replaceAll("\\", "/") === workspaceSkillsRoot,
+      );
+      const parentCall = capture.calls.find((call) => call.options?.recursive === false);
+      expect(rootCall).toBeDefined();
+
+      // Disable watching: the state is torn down and dropped from the watcher map.
+      await withPlatform("darwin", () => {
+        refreshModule.ensureSkillsWatcher({
+          workspaceDir,
+          config: { skills: { load: { watch: false } } },
+        });
+      });
+
+      // A stale native error / parent event arriving after teardown must not
+      // re-attach a watcher onto the orphaned state (that leak re-creates #90578).
+      watchMock.mockClear();
+      rootCall?.emit("error", new Error("stale native error"));
+      parentCall?.listener("rename", "skills");
+
+      expect(watchMock).not.toHaveBeenCalled();
+    } finally {
+      capture.restore();
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/skills/runtime/refresh.ts
+++ b/src/skills/runtime/refresh.ts
@@ -23,7 +23,20 @@ export {
 } from "./refresh-state.js";
 
 type SkillsPathWatchState = {
-  watcher: FSWatcher;
+  // chokidar watcher used on non-native platforms (Linux/Windows) and as the
+  // fallback when a native recursive watcher can't attach. Null while a native
+  // recursive watcher is covering this directory instead.
+  watcher: FSWatcher | null;
+  // Native recursive fs.watch (macOS only) plus a non-recursive parent-directory
+  // watch that detects root replacement (`rm -rf root && mkdir root`) by inode.
+  nativeMain: fs.FSWatcher | null;
+  nativeParent: fs.FSWatcher | null;
+  nativeInode: number | null;
+  // Set on teardown so a watcher event that races teardown — or a stale callback
+  // from a replaced native watcher — cannot re-attach onto this orphaned state and
+  // leak an untracked watcher (which would re-create the #90578 fd leak). Mirrors
+  // the memory watcher's `closed` guard.
+  disposed: boolean;
   depth: number;
   debounceMs: number;
   timer?: ReturnType<typeof setTimeout>;
@@ -65,6 +78,41 @@ const workspaceWatchLastEnsuredAt = new Map<string, number>();
 // Session turns re-ensure their workspace; entries older than this are treated
 // as abandoned subscriptions and evicted by the next ensure call.
 const SKILLS_WORKSPACE_WATCH_IDLE_TTL_MS = 60 * 60_000;
+
+// On macOS each native fs.watch is backed by an open file descriptor, so
+// chokidar's per-file SKILL.md watchers accumulate one descriptor per installed
+// skill and grow the gateway's FD count linearly until it hits the per-process
+// limit (#90578). A single native recursive fs.watch per skill root replaces that
+// per-file fan-out with one watcher per directory tree (FSEvents on macOS,
+// ReadDirectoryChangesW on Windows) that still catches in-place SKILL.md edits,
+// so the descriptor count stays flat regardless of skill count. Mirrors the
+// memory watcher fix for the sibling bug (#86613), which gates on the same set.
+//
+// Linux is intentionally excluded: Node's `fs.watch(dir, { recursive: true })`
+// watches every file there (inotify fan-out), so Linux keeps chokidar, which has
+// no per-process fd leak either. chokidar also remains the fallback on every
+// platform when a native watcher can't attach.
+const NATIVE_RECURSIVE_SKILLS_WATCH_PLATFORMS = new Set<NodeJS.Platform>(["darwin", "win32"]);
+
+const TEST_SKILLS_NATIVE_WATCH_FACTORY_KEY = Symbol.for("openclaw.test.skillsNativeWatchFactory");
+
+function nativeRecursiveSkillsWatchSupported(): boolean {
+  return NATIVE_RECURSIVE_SKILLS_WATCH_PLATFORMS.has(process.platform);
+}
+
+// Indirection so tests can inject a fake native watch factory (the same pattern
+// the memory watcher uses); production always returns the real fs.watch.
+function resolveSkillsNativeWatchFactory(): typeof fs.watch {
+  if (process.env.VITEST === "true" || process.env.NODE_ENV === "test") {
+    const override = (globalThis as Record<PropertyKey, unknown>)[
+      TEST_SKILLS_NATIVE_WATCH_FACTORY_KEY
+    ];
+    if (typeof override === "function") {
+      return override as typeof fs.watch;
+    }
+  }
+  return fs.watch.bind(fs);
+}
 
 setSkillsChangeListenerErrorHandler((err) => {
   log.warn(`skills change listener failed: ${String(err)}`);
@@ -423,28 +471,14 @@ function sameWatchTargets(a: WatchTarget[], b: WatchTarget[]): boolean {
   return true;
 }
 
-function createSkillsPathWatcher(target: WatchTarget, debounceMs: number): SkillsPathWatchState {
-  const watcher = chokidar.watch(target.path, {
-    ignoreInitial: true,
-    followSymlinks: false,
-    // Skill root precedence and grouped discovery use the same bounded depth,
-    // so watcher invalidation must observe that whole decision surface.
-    depth: target.depth,
-    awaitWriteFinish: {
-      stabilityThreshold: debounceMs,
-      pollInterval: 100,
-    },
-    ignored: shouldIgnoreSkillsWatchPath,
-  });
-
-  const state: SkillsPathWatchState = {
-    watcher,
-    depth: target.depth,
-    debounceMs,
-    subscribers: new Set<string>(),
-  };
-
-  const schedule = (changedPath?: string) => {
+function makeSkillsWatchSchedule(
+  state: SkillsPathWatchState,
+  debounceMs: number,
+): (changedPath?: string) => void {
+  return (changedPath?: string) => {
+    if (state.disposed) {
+      return;
+    }
     state.pendingPath = changedPath ?? state.pendingPath;
     if (state.timer) {
       clearTimeout(state.timer);
@@ -465,7 +499,32 @@ function createSkillsPathWatcher(target: WatchTarget, debounceMs: number): Skill
       }
     }, debounceMs);
   };
+}
 
+function attachChokidarSkillsWatch(
+  state: SkillsPathWatchState,
+  target: WatchTarget,
+  debounceMs: number,
+  schedule: (changedPath?: string) => void,
+): void {
+  // Idempotent + disposed-guarded: never replace a live chokidar watcher (which
+  // would leak the previous one) and never attach onto a torn-down state.
+  if (state.disposed || state.watcher) {
+    return;
+  }
+  const watcher = chokidar.watch(target.path, {
+    ignoreInitial: true,
+    followSymlinks: false,
+    // Skill root precedence and grouped discovery use the same bounded depth,
+    // so watcher invalidation must observe that whole decision surface.
+    depth: target.depth,
+    awaitWriteFinish: {
+      stabilityThreshold: debounceMs,
+      pollInterval: 100,
+    },
+    ignored: shouldIgnoreSkillsWatchPath,
+  });
+  state.watcher = watcher;
   watcher.on("add", (p) => schedule(p));
   watcher.on("change", (p) => schedule(p));
   watcher.on("unlink", (p) => schedule(p));
@@ -473,15 +532,199 @@ function createSkillsPathWatcher(target: WatchTarget, debounceMs: number): Skill
   watcher.on("error", (err) => {
     log.warn(`skills watcher error (${target.path}): ${String(err)}`);
   });
+}
 
+function closeNativeSkillsWatchers(state: SkillsPathWatchState): void {
+  if (state.nativeMain) {
+    try {
+      state.nativeMain.close();
+    } catch {
+      // ignore close failures
+    }
+    state.nativeMain = null;
+  }
+  if (state.nativeParent) {
+    try {
+      state.nativeParent.close();
+    } catch {
+      // ignore close failures
+    }
+    state.nativeParent = null;
+  }
+  state.nativeInode = null;
+}
+
+// Attach one native recursive fs.watch to the skill root (macOS only) plus a
+// non-recursive parent-directory watch that detects root replacement
+// (`rm -rf root && mkdir root`) by inode comparison. Returns true when the main
+// native watcher attached; false (leaving no native state behind) when the
+// caller should fall back to chokidar. Mirrors the memory watcher house pattern.
+function attachNativeSkillsRecursiveWatch(
+  state: SkillsPathWatchState,
+  target: WatchTarget,
+  schedule: (changedPath?: string) => void,
+  debounceMs: number,
+): boolean {
+  // Don't attach onto a torn-down state, or alongside an active chokidar fallback
+  // (native and chokidar coverage for one root are mutually exclusive).
+  if (state.disposed || state.watcher) {
+    return false;
+  }
+  let recordedInode: number;
+  try {
+    recordedInode = fs.statSync(target.path).ino;
+  } catch {
+    // Root doesn't exist yet; fall back to chokidar, which can watch a
+    // not-yet-created path and pick it up once it appears.
+    return false;
+  }
+  let mainWatcher: fs.FSWatcher;
+  try {
+    mainWatcher = resolveSkillsNativeWatchFactory()(
+      target.path,
+      { recursive: true },
+      (_eventType, filename) => {
+        if (filename == null) {
+          // filename can be null on some platforms even when recursive watching
+          // works; refresh broadly rather than dropping the event.
+          schedule();
+          return;
+        }
+        const full = path.join(target.path, filename);
+        // Preserve chokidar's depth bound on the native path: native recursive
+        // watches the whole tree, so ignore events deeper than the watch target
+        // would have traversed.
+        const relativeSegments = path.relative(target.path, full).split(path.sep);
+        if (relativeSegments.length - 1 > target.depth) {
+          return;
+        }
+        let stats: fs.Stats | undefined;
+        try {
+          stats = fs.lstatSync(full, { throwIfNoEntry: false }) ?? undefined;
+        } catch {
+          stats = undefined;
+        }
+        if (shouldIgnoreSkillsWatchPath(full, stats)) {
+          return;
+        }
+        schedule(full);
+      },
+    );
+  } catch (err) {
+    log.warn(
+      `skills native watcher could not start on ${target.path}: ${String(err)}; falling back to chokidar`,
+    );
+    return false;
+  }
+  state.nativeMain = mainWatcher;
+  state.nativeInode = recordedInode;
+  mainWatcher.on("error", (err) => {
+    // Ignore a stale error from a watcher this state no longer owns (replaced by a
+    // reattach) or after teardown; otherwise we'd re-attach onto a dead state.
+    if (state.disposed || state.nativeMain !== mainWatcher) {
+      return;
+    }
+    log.warn(`skills native watcher error (${target.path}): ${String(err)}`);
+    // Per Node docs an FSWatcher is unusable after an error. Tear down, force a
+    // refresh to cover the gap, then restore coverage with chokidar.
+    closeNativeSkillsWatchers(state);
+    schedule();
+    attachChokidarSkillsWatch(state, target, debounceMs, schedule);
+  });
+  // Non-recursive parent watch: catches root replacement so the main watcher can
+  // reattach on the new inode instead of silently watching the dead one.
+  try {
+    const parentDir = path.dirname(target.path);
+    const baseName = path.basename(target.path);
+    const parentWatcher = resolveSkillsNativeWatchFactory()(
+      parentDir,
+      { recursive: false },
+      (_eventType, filename) => {
+        // Ignore a stale parent event after this watcher was replaced or the state
+        // was torn down, so we don't reattach onto an orphaned/superseded state.
+        if (state.disposed || state.nativeParent !== parentWatcher) {
+          return;
+        }
+        // filename can be null on some platforms; otherwise filter by basename so
+        // sibling churn in the parent directory doesn't trigger a reattach.
+        if (filename !== null && filename !== baseName) {
+          return;
+        }
+        let currentInode: number | null;
+        try {
+          currentInode = fs.statSync(target.path).ino;
+        } catch {
+          currentInode = null;
+        }
+        if (currentInode === state.nativeInode) {
+          return;
+        }
+        // Root was replaced or removed: tear down, force a refresh, then reattach
+        // natively on the new inode (or fall back to chokidar if it's gone).
+        closeNativeSkillsWatchers(state);
+        schedule();
+        if (currentInode !== null) {
+          if (!attachNativeSkillsRecursiveWatch(state, target, schedule, debounceMs)) {
+            attachChokidarSkillsWatch(state, target, debounceMs, schedule);
+          }
+        } else {
+          attachChokidarSkillsWatch(state, target, debounceMs, schedule);
+        }
+      },
+    );
+    parentWatcher.on("error", (err) => {
+      log.warn(`skills native parent watcher error (${parentDir}): ${String(err)}`);
+      try {
+        parentWatcher.close();
+      } catch {
+        // ignore close failures
+      }
+      if (state.nativeParent === parentWatcher) {
+        state.nativeParent = null;
+      }
+      // Main watcher still alive — only root-replacement detection is lost.
+    });
+    state.nativeParent = parentWatcher;
+  } catch (err) {
+    log.warn(`skills native parent watcher could not start on ${target.path}: ${String(err)}`);
+  }
+  return true;
+}
+
+function createSkillsPathWatcher(target: WatchTarget, debounceMs: number): SkillsPathWatchState {
+  const state: SkillsPathWatchState = {
+    watcher: null,
+    nativeMain: null,
+    nativeParent: null,
+    nativeInode: null,
+    disposed: false,
+    depth: target.depth,
+    debounceMs,
+    subscribers: new Set<string>(),
+  };
+  const schedule = makeSkillsWatchSchedule(state, debounceMs);
+  // macOS leaks one descriptor per native file watcher, so use a single native
+  // recursive watcher per skill root there (#90578). Every other platform keeps
+  // chokidar, which also serves as the fallback if native attach fails.
+  if (
+    nativeRecursiveSkillsWatchSupported() &&
+    attachNativeSkillsRecursiveWatch(state, target, schedule, debounceMs)
+  ) {
+    return state;
+  }
+  attachChokidarSkillsWatch(state, target, debounceMs, schedule);
   return state;
 }
 
 function teardownSkillsPathWatcher(state: SkillsPathWatchState): void {
+  state.disposed = true;
   if (state.timer) {
     clearTimeout(state.timer);
   }
-  void state.watcher.close().catch(() => {});
+  closeNativeSkillsWatchers(state);
+  if (state.watcher) {
+    void state.watcher.close().catch(() => {});
+  }
 }
 
 function subscribeWorkspaceToPath(
@@ -620,13 +863,17 @@ export async function resetSkillsRefreshForTest(): Promise<void> {
   workspaceWatchLastEnsuredAt.clear();
   await Promise.all(
     active.map(async (state) => {
+      state.disposed = true;
       if (state.timer) {
         clearTimeout(state.timer);
       }
-      try {
-        await state.watcher.close();
-      } catch {
-        // Best-effort test cleanup.
+      closeNativeSkillsWatchers(state);
+      if (state.watcher) {
+        try {
+          await state.watcher.close();
+        } catch {
+          // Best-effort test cleanup.
+        }
       }
     }),
   );


### PR DESCRIPTION
## Summary

**What problem does this PR solve?**
The skills loader watches each workspace `SKILL.md` through chokidar, which opens one native `fs.watch` per file. On macOS every native `fs.watch` is backed by an open file descriptor, so the gateway's descriptor count grows linearly with the number of installed skills and eventually exhausts the per-process limit (`EMFILE`). This is #90578.

**What is the intended outcome?**
Keep the descriptor count flat regardless of skill count while preserving the documented refresh-on-`SKILL.md`-change behavior.

- Replace the per-file fan-out with a **single native recursive `fs.watch` per skill root** on macOS and Windows (one FSEvents / ReadDirectoryChangesW watcher per tree). The recursive watcher still reports in-place edits, so refresh behavior is preserved.
- A non-recursive **parent-directory watch** reattaches on root replacement by inode comparison. Native callbacks are identity-guarded and the watch state is disposed-guarded so a stale event racing teardown cannot re-attach an orphaned watcher.
- **Linux keeps chokidar** (and so does any non-native platform): Node's recursive `fs.watch` watches every file on Linux (inotify fan-out), and Linux has no per-process fd leak. chokidar also remains the fallback when a native watcher cannot attach.

This mirrors the existing memory-watcher fix for the sibling issue #86613, which gates native recursive watching on the same `darwin || win32` set and falls back to chokidar.

**Why not a simpler approach?**
Simply ignoring all files so chokidar never opens per-file FDs does stop the leak, but it silently breaks refresh: chokidar only emits `change` for an in-place edit through the per-file watcher, and a directory-only watch never re-stats existing files. Measured against real chokidar 5.0.0 with the production listener set (`add`/`change`/`unlink`/`unlinkDir`), ignoring all files refreshes on only 1 of 4 triggers:

| refresh trigger | ignore-all-files (dir-only) | this PR |
| --- | --- | --- |
| in-place `SKILL.md` edit | no refresh | refresh |
| add a skill | no refresh | refresh |
| remove only the `SKILL.md` | no refresh | refresh |
| remove the whole skill dir | refresh | refresh |

Polling preserves behavior with no persistent fd but adds continuous `stat()` cost on every platform, including the ones with no leak. Native recursive watching has no polling cost and matches the house pattern.

**What is intentionally out of scope?** Linux/Windows behavior beyond the native switch; new config knobs; skill loading itself. One known limitation: a skill root that does not exist when the watcher first starts falls back to chokidar and is not upgraded to native if it is created later — this matches the memory watcher (#86613) and is strictly no worse than current behavior; the reported #90578 case (skills already present at startup) is fully fixed. Upgrading a late-created root to native is a possible follow-up.

**What should reviewers focus on?** The native watcher lifecycle: teardown, the disposed/identity guards, the error->chokidar fallback, and the parent-inode reattach.

> AI-assisted change; I reviewed every line manually, ran the proof below myself, and am responsible for the result.

## Linked context

Closes #90578

Related #86613 (memory-watcher native-recursive fix this mirrors), #70058 (opt-in polling fallback for the same watcher), #90614 (alternative directory-only approach for this issue — see the trigger table above for why directory-only loses refresh).

## Real behavior proof (required for external PRs)

- **Behavior or issue addressed:** Before this change `shouldIgnoreSkillsWatchPath` returns `false` for `SKILL.md`, so chokidar opens one native `fs.watch` per `SKILL.md` — on macOS one persistent kqueue descriptor per installed skill, growing until `EMFILE`. After this change, on macOS/Windows the skills watcher opens one native recursive `fs.watch` per skill root and zero per `SKILL.md`.
- **Real environment tested:** Built from source at base `1a3ce7c2a8`, Node v22.22.1, Linux x86_64. The fd leak is macOS/kqueue-specific; see proof limitations.
- **Exact steps or command run after this patch:**
  - `node scripts/run-vitest.mjs src/skills/runtime/refresh.test.ts`
  - `node scripts/run-tsgo.mjs -p tsconfig.core.json` and `-p test/tsconfig/tsconfig.core.test.json`
  - `node scripts/run-oxlint.mjs src/skills/runtime/refresh.ts src/skills/runtime/refresh.test.ts` and `oxfmt --check`
  - A standalone probe driving real chokidar 5.0.0 and a real native recursive `fs.watch` over a temp skill tree, exercising edit / add / unlink.
- **Evidence after fix:** Real macOS `lsof` (macOS 26.5, Apple Silicon, Node 22.9) on this PR — built a temp workspace with 25 skills, watched it with the repo's chokidar 5.0.0 (current main's per-file path) and then with the native recursive `fs.watch` (this PR), and counted `SKILL.md` descriptors with `lsof` on each. The per-`SKILL.md` descriptor count goes from scaling 1:1 with installed skills to flat:
  ```
  skills installed: 25
  chokidar (current main)     -> SKILL.md FDs: 25   (one persistent read-only fd per file)
  native recursive (this PR)  -> SKILL.md FDs:  0
  lsof sample (chokidar, redacted):
    node  47078  <user>  14r  REG  1,17  42  /private/var/folders/.../T/<tmp>/skills/skill-00/SKILL.md
  native watcher detected edit + add + remove of SKILL.md (macOS FSEvents rename-type events):
    rename:skill-00/SKILL.md (edit)   rename:skill-new/SKILL.md (add)   rename:skill-01/SKILL.md (remove)
  ```
  The `14r ... REG ... SKILL.md` line is exactly the "persistent read-only FD per workspace SKILL.md" the issue describes; with the native watcher it is gone, and skill edit/add/remove still refresh.
- **Evidence after fix (real Windows, win32 backslash `filename`s):** The descriptor leak itself is macOS/kqueue-specific, but the native switch also runs on Windows, where the OS reports backslash-separated watch `filename`s — the one platform-specific path the `win32` unit tests can only mock (they set `process.platform = "win32"` but run on a POSIX `path` module). I ran the same probe logic on real Windows 11 (Node 24): one native recursive `fs.watch(root, { recursive: true })` over a 25-skill tree, exercising edit / add / remove.
  ```
  platform=win32   node=v24.5.0   path.sep="\\"  (one backslash)
  one native recursive watcher for 25 skills
  edit    skill-00\SKILL.md   -> refresh
  edit    skill-24\SKILL.md   -> refresh   (far end of the tree, same single watcher)
  add     skill-new\SKILL.md  -> refresh
  remove  skill-01\SKILL.md   -> refresh
  non-SKILL.md write (README.md) -> ignored
  ```
  The OS delivered real backslash `filename`s (e.g. `skill-00\SKILL.md`), and the watcher's `path.join` -> `path.relative(...).split(path.sep)` -> `replaceAll("\\", "/")` -> `path.posix.basename` chain resolved each to `SKILL.md` and refreshed, while a non-`SKILL.md` write was ignored. One recursive watcher covered the whole tree (both ends plus an added skill). The identical probe on Linux reports `path.sep="/"` with no backslash `filename`s, so the backslash handling — the only behavior that differs on win32 — is the part now exercised on real Windows hardware.
- **Why directory-only is not a substitute (cross-platform `fs` probe):** ignoring all files (the #90614 approach) stops the leak but silently loses refresh — measured against real chokidar 5.0.0 with the production listener set, it refreshes on only the whole-dir-removal trigger; native recursive preserves all four (see the trigger table above).
- Unit suite (supplemental): `Tests 37 passed (37)`; `tsgo` core + core-test exit 0; `oxlint` + `oxfmt --check` clean. The watcher-shape test asserts that on `darwin`/`win32` the code issues exactly one native recursive `fs.watch` per skill root and zero on any `SKILL.md` path, and uses chokidar on `linux`.
- **Observed result after fix:** On macOS/Windows, one native recursive watcher per skill root plus one non-recursive parent watch; no per-`SKILL.md` native watcher. On Linux, unchanged (chokidar). Add / in-place edit / unlink / whole-dir removal all still refresh the snapshot.
- **What was not tested:** Very large workspaces (over 100 skills) and multi-hour gateway stability. Real Windows backslash-`filename` handling is now exercised on real hardware (see the win32 evidence above); the descriptor-count magnitude was measured on macOS, where the leak lives.
- **Proof limitations or environment constraints:** The macOS `lsof` descriptor proof was run on real macOS 26.5 hardware; the win32 correctness proof was run on real Windows 11 (Node 24). The descriptor-count magnitude was measured only on macOS because the leak is kqueue-specific — on Windows the equivalent ReadDirectoryChangesW handles are per-watch and not `EMFILE`-fatal, so the Windows run validates path-handling correctness (backslash separators, one watcher per tree, edit/add/remove refresh) rather than a descriptor count. The Linux path is unchanged (chokidar) and carries no new platform risk.

## Tests and validation

**Which commands did you run?** `run-vitest` on `refresh.test.ts`, `tsgo` core + core-test, `oxlint` + `oxfmt --check` on both files, `git diff --check`, plus the real-`fs` probe above.

**What regression coverage was added or updated?** New tests in `src/skills/runtime/refresh.test.ts`: (1) on `darwin`/`win32` the watcher opens one native recursive `fs.watch` per skill root and zero per `SKILL.md`, and does not use chokidar for an existing root; (2) the native watcher detects `add`/`change`/`unlink` of a `SKILL.md`; (3) non-native platforms keep chokidar; (4) a native error falls back to exactly one chokidar watcher; (5) a stale native event after teardown does not re-attach a watcher. A test-only native-watch factory hook (mirroring the memory watcher's) makes the native path injectable.

**What failed before this fix?** Per the issue, descriptor count scaled linearly with installed skills on macOS, trending to `EMFILE`.

## Risk checklist

**Did user-visible behavior change?** No — refresh-on-change is preserved on all platforms; only the underlying watch mechanism changed on macOS/Windows.

**Did config, environment, or migration behavior change?** No.

**Did security, auth, secrets, network, or tool execution behavior change?** No.

**What is the highest-risk area?** The native watcher lifecycle on macOS/Windows: teardown, the disposed/identity guards, the error->chokidar fallback, and the parent-inode reattach.

**How is that risk mitigated?** chokidar remains the fallback on attach/runtime failure; teardown and the test reset mark state disposed and close native + chokidar watchers; native callbacks are identity-guarded against stale events; the pattern is copied from the already-shipped memory watcher (#86613). New tests cover the fallback and teardown-race paths.

## Current review state

**What is the next action?** Maintainer review. The macOS `lsof` before/after proof the ClawSweeper review asked for is above (25 `SKILL.md` FDs → 0 on real macOS 26.5, plus an edit/add/remove refresh check), and the optional real-Windows correctness proof is now included (win32 backslash `filename`s handled on real Windows 11).

**What is still waiting on author, maintainer, CI, or external proof?** Nothing outstanding on proof — all local checks pass, with both the macOS runtime proof and the real-Windows correctness proof supplied. Awaiting maintainer review.
