### PR TITLE
fix(discord): protect mention aliases in code fences

### DIFF
--- a/extensions/discord/src/mentions.test.ts
+++ b/extensions/discord/src/mentions.test.ts
@@ -103,6 +103,73 @@ describe("rewriteDiscordKnownMentions", () => {
     expect(rewritten).toBe("inline `@alice` fence ```\n@alice\n``` text <@123456789>");
   });
 
+  it("does not rewrite mentions after a triple-backtick literal inside a fenced block", () => {
+    rememberDiscordDirectoryUser({
+      accountId: "default",
+      userId: "123456789",
+      handles: ["alice"],
+    });
+    const text = '```js\nconst fence = "```";\n// do not ping @alice\n```\ntext @alice';
+
+    const rewritten = rewriteDiscordKnownMentions(text, { accountId: "default" });
+
+    expect(rewritten).toBe(
+      '```js\nconst fence = "```";\n// do not ping @alice\n```\ntext <@123456789>',
+    );
+  });
+
+  it("uses the opening fence length when skipping Discord mention rewrites", () => {
+    rememberDiscordDirectoryUser({
+      accountId: "default",
+      userId: "123456789",
+      handles: ["alice"],
+    });
+    const text = "````md\n```js\n// do not ping @alice\n```\n````\ntext @alice";
+
+    const rewritten = rewriteDiscordKnownMentions(text, { accountId: "default" });
+
+    expect(rewritten).toBe("````md\n```js\n// do not ping @alice\n```\n````\ntext <@123456789>");
+  });
+
+  it("does not treat tilde runs as Discord code fences", () => {
+    rememberDiscordDirectoryUser({
+      accountId: "default",
+      userId: "123456789",
+      handles: ["alice"],
+    });
+    const text = "~~~\n@alice\n~~~";
+
+    const rewritten = rewriteDiscordKnownMentions(text, { accountId: "default" });
+
+    expect(rewritten).toBe("~~~\n<@123456789>\n~~~");
+  });
+
+  it("does not let shorter backtick runs close inline code spans", () => {
+    rememberDiscordDirectoryUser({
+      accountId: "default",
+      userId: "123456789",
+      handles: ["alice"],
+    });
+    const text = "inline ``code ` @alice`` text @alice";
+
+    const rewritten = rewriteDiscordKnownMentions(text, { accountId: "default" });
+
+    expect(rewritten).toBe("inline ``code ` @alice`` text <@123456789>");
+  });
+
+  it("does not treat same-line inline triple-backtick spans as EOF fences", () => {
+    rememberDiscordDirectoryUser({
+      accountId: "default",
+      userId: "123456789",
+      handles: ["alice"],
+    });
+    const text = "inline ```@alice```\ntext @alice";
+
+    const rewritten = rewriteDiscordKnownMentions(text, { accountId: "default" });
+
+    expect(rewritten).toBe("inline ```@alice```\ntext <@123456789>");
+  });
+
   it("is account-scoped", () => {
     rememberDiscordDirectoryUser({
       accountId: "ops",

--- a/extensions/discord/src/mentions.ts
+++ b/extensions/discord/src/mentions.ts
@@ -8,12 +8,16 @@ import { resolveDiscordDirectoryUserId } from "./directory-cache.js";
 
 type DiscordMentionAliasesConfig = Record<string, string>;
 
-const MARKDOWN_CODE_SEGMENT_PATTERN = /```[\s\S]*?```|`[^`\n]*`/g;
 const MENTION_CANDIDATE_PATTERN = /(^|[\s([{"'.,;:!?])@([a-z0-9_.-]{2,32}(?:#[0-9]{4})?)/gi;
 const DISCORD_RESERVED_MENTIONS = new Set(["everyone", "here"]);
 const DISCORD_DISCRIMINATOR_SUFFIX = /#\d{4}$/;
 const DISCORD_TARGETED_MENTION_PATTERN = /<@!?\d+>|<@&\d+>/;
 const DISCORD_BROADCAST_MENTION_PATTERN = /@(everyone|here)\b/;
+
+type MarkdownCodeSegment = {
+  end: number;
+  start: number;
+};
 
 function normalizeSnowflake(value: string | number | bigint): string | null {
   const text = normalizeOptionalStringifiedId(value) ?? "";
@@ -126,6 +130,130 @@ function rewritePlainTextMentions(
   });
 }
 
+function findLineEnd(text: string, start: number): number {
+  const lineFeed = text.indexOf("\n", start);
+  return lineFeed === -1 ? text.length : lineFeed + 1;
+}
+
+function stripLineBreak(line: string): string {
+  return line.replace(/\r?\n$/, "");
+}
+
+function findClosingFenceEnd(params: {
+  markerLength: number;
+  start: number;
+  text: string;
+}): number {
+  let lineStart = params.start;
+  while (lineStart < params.text.length) {
+    const lineEnd = findLineEnd(params.text, lineStart);
+    const line = stripLineBreak(params.text.slice(lineStart, lineEnd));
+    const closing = /^( {0,3})(`{3,})/.exec(line);
+    if (closing?.[2] && closing[2].length >= params.markerLength) {
+      return lineStart + closing[1].length + closing[2].length;
+    }
+    lineStart = lineEnd;
+  }
+  return params.text.length;
+}
+
+function findFencedCodeSegments(text: string): MarkdownCodeSegment[] {
+  const segments: MarkdownCodeSegment[] = [];
+  let cursor = 0;
+  while (cursor < text.length) {
+    const opening = /`{3,}/.exec(text.slice(cursor));
+    if (!opening) {
+      break;
+    }
+    const start = cursor + opening.index;
+    const marker = opening[0];
+    const lineEnd = findLineEnd(text, start);
+    const lineTail = stripLineBreak(text.slice(start + marker.length, lineEnd));
+    if (lineEnd === text.length && text[lineEnd - 1] !== "\n") {
+      cursor = start + marker.length;
+      continue;
+    }
+    if (lineTail.includes("`")) {
+      cursor = lineEnd;
+      continue;
+    }
+    const end = findClosingFenceEnd({
+      markerLength: marker.length,
+      start: lineEnd,
+      text,
+    });
+    segments.push({ start, end });
+    cursor = end;
+  }
+  return segments;
+}
+
+function findContainingSegment(
+  segments: readonly MarkdownCodeSegment[],
+  index: number,
+): MarkdownCodeSegment | undefined {
+  return segments.find((segment) => index >= segment.start && index < segment.end);
+}
+
+function findInlineCodeSegments(
+  text: string,
+  fencedSegments: readonly MarkdownCodeSegment[],
+): MarkdownCodeSegment[] {
+  const segments: MarkdownCodeSegment[] = [];
+  let index = 0;
+  while (index < text.length) {
+    const fenced = findContainingSegment(fencedSegments, index);
+    if (fenced) {
+      index = fenced.end;
+      continue;
+    }
+    if (text[index] !== "`") {
+      index += 1;
+      continue;
+    }
+    const start = index;
+    let runLength = 0;
+    while (index < text.length && text[index] === "`") {
+      runLength += 1;
+      index += 1;
+    }
+    let cursor = index;
+    while (cursor < text.length) {
+      const nextFence = findContainingSegment(fencedSegments, cursor);
+      if (nextFence) {
+        cursor = nextFence.end;
+        continue;
+      }
+      if (text[cursor] !== "`") {
+        cursor += 1;
+        continue;
+      }
+      const closeStart = cursor;
+      let closeLength = 0;
+      while (cursor < text.length && text[cursor] === "`") {
+        closeLength += 1;
+        cursor += 1;
+      }
+      if (closeLength === runLength) {
+        segments.push({ start, end: cursor });
+        break;
+      }
+      cursor = closeStart + Math.max(1, closeLength);
+    }
+    index = segments.at(-1)?.start === start ? (segments.at(-1)?.end ?? index) : index;
+  }
+  return segments;
+}
+
+function findMarkdownCodeSegments(text: string): MarkdownCodeSegment[] {
+  // Discord mention aliases must ignore code without adding plugin dependencies;
+  // keep this scanner scoped to Discord-rendered backtick code segments.
+  const fencedSegments = findFencedCodeSegments(text);
+  return [...fencedSegments, ...findInlineCodeSegments(text, fencedSegments)].toSorted(
+    (a, b) => a.start - b.start || a.end - b.end,
+  );
+}
+
 export function rewriteDiscordKnownMentions(
   text: string,
   params: {
@@ -138,12 +266,10 @@ export function rewriteDiscordKnownMentions(
   }
   let rewritten = "";
   let offset = 0;
-  MARKDOWN_CODE_SEGMENT_PATTERN.lastIndex = 0;
-  for (const match of text.matchAll(MARKDOWN_CODE_SEGMENT_PATTERN)) {
-    const matchIndex = match.index ?? 0;
-    rewritten += rewritePlainTextMentions(text.slice(offset, matchIndex), params);
-    rewritten += match[0];
-    offset = matchIndex + match[0].length;
+  for (const segment of findMarkdownCodeSegments(text)) {
+    rewritten += rewritePlainTextMentions(text.slice(offset, segment.start), params);
+    rewritten += text.slice(segment.start, segment.end);
+    offset = segment.end;
   }
   rewritten += rewritePlainTextMentions(text.slice(offset), params);
   return rewritten;


### PR DESCRIPTION
## Summary

Fixes #90643.

Discord mention alias rewriting now skips Markdown code spans with a local scanner instead of a non-greedy regex, so a triple-backtick literal inside a fenced code block no longer makes later in-fence `@handle` text eligible for outbound mention rewriting.

This keeps the existing Discord behavior where text after a closing fence marker can still be rewritten, while preventing the code body itself from producing an unintended `<@USER_ID>` mention.

## Root Cause

`rewriteDiscordKnownMentions` previously used:

```ts
/```[\s\S]*?```|`[^`\n]*`/g
```

That regex closes the skipped code segment on the first downstream triple-backtick sequence anywhere. In a block like this, the string literal was treated as the closing fence:

````text
```js
const fence = "```";
// do not ping @alice
```
````

The remaining code-body line was then passed through mention alias rewriting and could become a real Discord targeted mention.

## Real behavior proof

- Behavior addressed: Discord mention aliases no longer rewrite an `@handle` that is inside a backtick fenced code block when the code body contains a triple-backtick literal. Handles after the closing fence still rewrite.
- Real environment tested: local OpenClaw checkout on this PR branch, exercising the same `rewriteDiscordKnownMentions` helper used by Discord normal sends, structured sends, webhooks, and final-preview create/edit gating.
- Exact steps or command run after this patch: `node --import tsx --input-type=module` with the script below, importing `rewriteDiscordKnownMentions` and the Discord directory-cache helpers from this checkout.
- Evidence after fix: terminal output copied from the command below: `{"actual":"```js\nconst fence = \"```\";\n// do not ping @alice\n```\ntext <@123456789>"}`.
- Observed result after fix: the in-fence `@alice` remains literal, while the `@alice` after the closing fence rewrites to `<@123456789>`.
- What was not tested: I did not run a live Discord send. The proof exercises the exact outbound rewriting helper used by the Discord send paths.

Command and terminal output:

```bash
node --import tsx --input-type=module - <<'NODE'
import assert from 'node:assert/strict';
import { rewriteDiscordKnownMentions } from './extensions/discord/src/mentions.ts';
import { resetDiscordDirectoryCacheForTest, rememberDiscordDirectoryUser } from './extensions/discord/src/directory-cache.ts';
resetDiscordDirectoryCacheForTest();
rememberDiscordDirectoryUser({ accountId: 'default', userId: '123456789', handles: ['alice'] });
const bug = '```js\nconst fence = "```";\n// do not ping @alice\n```\ntext @alice';
const actual = rewriteDiscordKnownMentions(bug, { accountId: 'default' });
assert.equal(actual, '```js\nconst fence = "```";\n// do not ping @alice\n```\ntext <@123456789>');
console.log(JSON.stringify({ actual }, null, 2));
NODE
```

Evidence after fix:

```json
{
  "actual": "```js\nconst fence = \"```\";\n// do not ping @alice\n```\ntext <@123456789>"
}
```

Follow-up proof for the same-line inline triple-backtick case:

```bash
node --import tsx --input-type=module - <<'NODE'
import assert from 'node:assert/strict';
import { rewriteDiscordKnownMentions } from './extensions/discord/src/mentions.ts';
import { resetDiscordDirectoryCacheForTest, rememberDiscordDirectoryUser } from './extensions/discord/src/directory-cache.ts';
resetDiscordDirectoryCacheForTest();
rememberDiscordDirectoryUser({ accountId: 'default', userId: '123456789', handles: ['alice'] });
const inline = 'inline ```@alice```\ntext @alice';
const actual = rewriteDiscordKnownMentions(inline, { accountId: 'default' });
assert.equal(actual, 'inline ```@alice```\ntext <@123456789>');
console.log(JSON.stringify({ actual }, null, 2));
NODE
```

Follow-up evidence after fix:

```json
{
  "actual": "inline ```@alice```\ntext <@123456789>"
}
```

## Tests And Checks

```bash
node scripts/run-vitest.mjs extensions/discord/src/mentions.test.ts extensions/discord/src/send.sends-basic-channel-messages.test.ts extensions/discord/src/send.webhook-activity.test.ts --reporter dot
node scripts/run-vitest.mjs extensions/discord/src/mentions.test.ts --reporter dot
pnpm exec oxfmt --check extensions/discord/src/mentions.ts extensions/discord/src/mentions.test.ts
node scripts/run-oxlint.mjs extensions/discord/src/mentions.ts extensions/discord/src/mentions.test.ts
pnpm tsgo:extensions
git diff --check
```

Results:

- focused Vitest passed: 3 files, 63 tests
- focused mention Vitest passed after the follow-up fix: 1 file, 20 tests
- oxfmt check passed
- oxlint passed
- `pnpm tsgo:extensions` passed
- `git diff --check` passed

## Compatibility And Risk

The change stays local to Discord mention rewriting and does not add plugin dependencies. It preserves existing simple inline-code/fence behavior and adds coverage for longer fence delimiters, inline spans with shorter backtick runs inside, and the fact that tilde runs are not Discord code fences.

Overlap: #90646 opened against the same issue while this local fix was being prepared.
