### PR TITLE
feat(skills): add /review skill for AI-powered code review

### DIFF
--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: review
+description: "AI-powered code review for staged changes, unstaged changes, specific files, or the current PR. Usage: /review [target] where target is: (no args) review staged changes, 'unstaged' for working tree diff, a file path for a single file, or 'pr' for the current PR's full diff against base. NOT for: reviewing remote PRs by URL (use the github skill), reviewing non-git files, or bulk multi-repo audits."
+user-invocable: true
+metadata: { "openclaw": { "emoji": "🔎", "requires": { "bins": ["git"] } } }
+---
+
+# Code Review
+
+You are a code reviewer. Follow the steps below based on the target the user specified.
+
+## Step 1 -- Determine the target
+
+Parse the argument after `/review`:
+
+| Input           | Target                             | How to get the diff    |
+| --------------- | ---------------------------------- | ---------------------- |
+| _(no argument)_ | Staged changes                     | `git diff --cached`    |
+| `unstaged`      | Unstaged working tree changes      | `git diff`             |
+| `pr`            | Current PR against its base branch | See **PR mode** below  |
+| anything else   | Treat as a file path               | Read the file directly |
+
+**PR mode** -- detect the base branch and diff against it:
+
+```bash
+# Get the current branch
+CURRENT=$(git rev-parse --abbrev-ref HEAD)
+
+# Try to find the PR's base from gh (if available)
+BASE=$(gh pr view --json baseRefName -q .baseRefName 2>/dev/null)
+
+# Fallback: use main or master
+if [ -z "$BASE" ]; then
+  BASE=$(git rev-parse --verify origin/main 2>/dev/null && echo main || echo master)
+fi
+
+git diff "origin/$BASE"...HEAD
+```
+
+## Step 2 -- Retrieve the diff
+
+Run the appropriate git command from Step 1 via the terminal tool.
+
+**If the diff is empty**, stop and tell the user:
+
+- Staged mode: "No staged changes. Stage files with `git add` first, or use `/review unstaged`."
+- Unstaged mode: "No unstaged changes."
+- PR mode: "No commits differ from the base branch."
+- File mode: if the file does not exist, say so.
+
+**If the diff exceeds ~3000 lines**, warn the user and suggest narrowing scope:
+
+> "The diff is large (~N lines). For a more focused review, try:
+>
+> - `/review <specific-file>` to review one file
+> - Stage a subset and run `/review`"
+
+Then proceed with the review anyway, focusing on the highest-risk changes.
+
+## Step 3 -- Review the diff
+
+Analyze the code for the categories below. Only report findings you are confident about. Do not pad the review with generic advice.
+
+**Categories (in priority order):**
+
+1. **Security** -- injection, auth bypass, secret exposure, path traversal, unsafe deserialization, SSRF
+2. **Correctness** -- logic errors, off-by-one, null/undefined access, race conditions, broken error propagation
+3. **Error handling** -- swallowed exceptions, missing validation at system boundaries, misleading error messages
+4. **Performance** -- unnecessary allocations in hot paths, O(n^2) where O(n) is straightforward, missing pagination, unbounded growth
+5. **Maintainability** -- naming that obscures intent, duplicated logic that should be extracted, dead code, overly complex conditionals
+
+**Skip these** -- the review is not for style policing:
+
+- Formatting and whitespace (that is the linter's job)
+- Import ordering
+- Comment style preferences
+- Subjective naming bikesheds where the existing name is clear enough
+
+## Step 4 -- Report findings
+
+Use this output format:
+
+### Review: `<target description>`
+
+**Verdict:** `APPROVE` | `CONCERNS` | `REQUEST_CHANGES`
+
+Use `APPROVE` when there are no blocking issues and the code is ready. Minor suggestions can accompany an APPROVE.
+Use `CONCERNS` when there are non-blocking issues worth discussing before merge.
+Use `REQUEST_CHANGES` when there are bugs, security issues, or correctness problems that must be fixed.
+
+#### Findings
+
+For each finding:
+
+> **[Category] Title** (`path/to/file:line`)
+>
+> _What is wrong and why it matters._
+>
+> Suggested fix (if non-obvious):
+>
+> ```diff
+> - old line
+> + new line
+> ```
+
+If there are no findings, say so directly: "No issues found. Code looks good."
+
+#### Summary
+
+One to three sentences covering the overall quality, the riskiest area, and any patterns worth watching across the changeset.
+
+## Rules
+
+- Be direct. State the problem, state the fix. Do not hedge with "you might want to consider possibly."
+- File paths must be repo-root-relative.
+- Do not repeat the diff back to the user. Reference lines by number.
+- If the diff touches tests, review the tests with the same rigor as production code.
+- If you spot a potential issue but are not sure, prefix with "Uncertain:" and explain what would confirm or rule it out.
+- Do not invent issues. A clean diff gets a clean review.


### PR DESCRIPTION
## Summary

- Adds a bundled `/review` skill for code review. Users type `/review` instead of writing a freeform prompt each time.
- Built as a skill, not a built-in tool. No token overhead in sessions that skip it, per the issue author's follow-up recommendation.
- Four targets: staged changes (default), unstaged changes, a specific file, or the current PR diff.

## What changed

`skills/review/SKILL.md` uses the standard bundled skill pattern: YAML frontmatter plus markdown instructions.

The skill:

1. Parses the user's argument to pick a target (defaults to staged changes)
2. Runs the matching git command to retrieve the diff
3. Reviews the diff across five categories: security, correctness, error handling, performance, maintainability
4. Reports a structured verdict (APPROVE / CONCERNS / REQUEST_CHANGES) with file-line references and suggested fixes

Empty diffs get a specific message pointing to the right next step. Diffs over ~3000 lines trigger a scope-narrowing suggestion before proceeding. Style policing (formatting, imports, naming bikesheds) stays with the linter.

Only requires `git`.

## Test plan

- [x] SKILL.md frontmatter parses correctly (name, description, metadata, requires.bins)
- [x] Skill-related tests pass: frontmatter parser (7/7), skill filter (4/4), skills-status (2/2), workspace prompt builder (3/3)
- [x] Format check passes (oxfmt --write)
- [x] Skill loads in the bundled skills directory alongside 55+ existing skills

Closes #4251