### PR TITLE
fix(gateway): watch config include files

### DIFF
--- a/src/config/includes-scan.ts
+++ b/src/config/includes-scan.ts
@@ -47,6 +47,13 @@ function resolveIncludePath(baseConfigPath: string, includePath: string): string
   );
 }
 
+export function collectDirectIncludePaths(params: {
+  configPath: string;
+  parsed: unknown;
+}): string[] {
+  return listDirectIncludes(params.parsed).map((raw) => resolveIncludePath(params.configPath, raw));
+}
+
 /** Collects recursively referenced config include files without requiring a valid full config. */
 export async function collectIncludePathsRecursive(params: {
   configPath: string;

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -1,5 +1,8 @@
 // Gateway config reload tests cover changed-path detection, reload planning,
 // plugin registry refresh, skill snapshot invalidation, and watcher behavior.
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import nodePath from "node:path";
 import chokidar from "chokidar";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { listChannelPlugins } from "../channels/plugins/index.js";
@@ -555,7 +558,7 @@ describe("resolveGatewayReloadSettings", () => {
   });
 });
 
-type WatcherHandler = () => void;
+type WatcherHandler = (eventPath?: string) => void;
 type WatcherEvent = "add" | "change" | "unlink" | "error";
 
 function createWatcherMock() {
@@ -567,11 +570,13 @@ function createWatcherMock() {
       handlers.set(event, existing);
       return this;
     },
-    emit(event: WatcherEvent) {
+    emit(event: WatcherEvent, eventPath?: string) {
       for (const handler of handlers.get(event) ?? []) {
-        handler();
+        handler(eventPath);
       }
     },
+    add: vi.fn<(paths: string | string[]) => void>(() => {}),
+    unwatch: vi.fn<(paths: string | string[]) => void>(() => {}),
     close: vi.fn(async () => {}),
   };
 }
@@ -641,9 +646,12 @@ function createReloaderHarness(
     promoteSnapshot?: (snapshot: ConfigFileSnapshot, reason: string) => Promise<boolean>;
     initialPluginInstallRecords?: Record<string, PluginInstallRecord>;
     readPluginInstallRecords?: () => Promise<Record<string, PluginInstallRecord>>;
+    initialSnapshot?: ConfigFileSnapshot;
+    configureWatcher?: (watcher: ReturnType<typeof createWatcherMock>) => void;
   } = {},
 ) {
   const watcher = createWatcherMock();
+  options.configureWatcher?.(watcher);
   vi.spyOn(chokidar, "watch").mockReturnValue(watcher as unknown as never);
   const onHotReload = vi.fn(async (_plan: GatewayReloadPlan, _nextConfig: OpenClawConfig) => {});
   const onRestart = vi.fn((_plan: GatewayReloadPlan, _nextConfig: OpenClawConfig) => {});
@@ -665,6 +673,7 @@ function createReloaderHarness(
     initialConfig: { gateway: { reload: { debounceMs: 0 } } },
     initialCompareConfig: options.initialCompareConfig,
     initialInternalWriteHash: options.initialInternalWriteHash,
+    initialSnapshot: options.initialSnapshot,
     readSnapshot,
     promoteSnapshot: options.promoteSnapshot,
     initialPluginInstallRecords: options.initialPluginInstallRecords ?? {},
@@ -718,7 +727,24 @@ function getOnlyPromoteSnapshotCall(promoteSnapshot: {
   return call;
 }
 
-describe("startGatewayConfigReloader", () => {
+function resolveIncludePathForTest(configPath: string, includePath: string): string {
+  return nodePath.normalize(nodePath.resolve(nodePath.dirname(configPath), includePath));
+}
+
+async function waitForCondition(condition: () => boolean): Promise<void> {
+  const deadline = Date.now() + 1_000;
+  while (Date.now() < deadline) {
+    if (condition()) {
+      return;
+    }
+    await new Promise((resolve) => {
+      setTimeout(resolve, 10);
+    });
+  }
+  expect(condition()).toBe(true);
+}
+
+describe.sequential("startGatewayConfigReloader", () => {
   beforeEach(() => {
     vi.useFakeTimers();
   });
@@ -726,6 +752,320 @@ describe("startGatewayConfigReloader", () => {
   afterEach(() => {
     vi.useRealTimers();
     vi.restoreAllMocks();
+  });
+
+  it("reloads include-only changes even when the root config hash matches a recent write", async () => {
+    const configPath = "/tmp/openclaw.json";
+    const includePath = resolveIncludePathForTest(configPath, "includes/runtime.json");
+    const startupSnapshot = makeSnapshot({
+      path: configPath,
+      parsed: { $include: "includes/runtime.json" },
+    });
+    const includeConfig = {
+      gateway: { reload: { debounceMs: 0 } },
+      hooks: { enabled: true },
+    } satisfies OpenClawConfig;
+    const includeChangedSnapshot = makeSnapshot({
+      path: configPath,
+      parsed: { $include: "includes/runtime.json" },
+      sourceConfig: includeConfig,
+      runtimeConfig: includeConfig,
+      config: includeConfig,
+      hash: "root-hash",
+    });
+    const readSnapshot = vi
+      .fn<() => Promise<ConfigFileSnapshot>>()
+      .mockResolvedValue(includeChangedSnapshot);
+    const harness = createReloaderHarness(readSnapshot, {
+      initialCompareConfig: {
+        gateway: { reload: { debounceMs: 0 } },
+        hooks: { enabled: false },
+      },
+      initialInternalWriteHash: "root-hash",
+      initialSnapshot: startupSnapshot,
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    harness.watcher.emit("change", includePath);
+    await vi.runAllTimersAsync();
+
+    expect(readSnapshot).toHaveBeenCalledTimes(1);
+    expect(harness.log.info.mock.calls).toEqual([
+      ["config change detected; evaluating reload (hooks.enabled)"],
+    ]);
+    expect(harness.log.error).not.toHaveBeenCalled();
+    expect(harness.log.warn).not.toHaveBeenCalled();
+    expect(harness.onRestart).not.toHaveBeenCalled();
+    const [plan] = getOnlyHotReloadCall(harness);
+    expect(plan.reloadHooks).toBe(true);
+    expect(plan.hotReasons).toContain("hooks.enabled");
+
+    await harness.reloader.stop();
+  });
+
+  it("does not drop include changes that arrive while include watches are syncing", async () => {
+    vi.useRealTimers();
+    const configPath = "/tmp/openclaw.json";
+    const includePath = resolveIncludePathForTest(configPath, "includes/runtime.json");
+    const startupSnapshot = makeSnapshot({
+      path: configPath,
+      parsed: { $include: "includes/runtime.json" },
+    });
+    const includeConfig = {
+      gateway: { reload: { debounceMs: 0 } },
+      hooks: { enabled: true },
+    } satisfies OpenClawConfig;
+    const includeChangedSnapshot = makeSnapshot({
+      path: configPath,
+      parsed: { $include: "includes/runtime.json" },
+      sourceConfig: includeConfig,
+      runtimeConfig: includeConfig,
+      config: includeConfig,
+      hash: "root-hash",
+    });
+    const readSnapshot = vi
+      .fn<() => Promise<ConfigFileSnapshot>>()
+      .mockResolvedValue(includeChangedSnapshot);
+    const harness = createReloaderHarness(readSnapshot, {
+      initialCompareConfig: {
+        gateway: { reload: { debounceMs: 0 } },
+        hooks: { enabled: false },
+      },
+      initialInternalWriteHash: "root-hash",
+      initialSnapshot: startupSnapshot,
+      configureWatcher: (watcher) => {
+        watcher.add.mockImplementationOnce((paths) => {
+          const watchPaths = Array.isArray(paths) ? paths : [paths];
+          if (watchPaths.includes(includePath)) {
+            watcher.emit("change", includePath);
+          }
+        });
+      },
+    });
+
+    try {
+      await waitForCondition(() => harness.log.info.mock.calls.length === 1);
+
+      expect(readSnapshot).toHaveBeenCalledTimes(1);
+      expect(harness.log.info.mock.calls).toEqual([
+        ["config change detected; evaluating reload (hooks.enabled)"],
+      ]);
+      expect(harness.log.error).not.toHaveBeenCalled();
+      expect(harness.log.warn).not.toHaveBeenCalled();
+      const [plan] = getOnlyHotReloadCall(harness);
+      expect(plan.reloadHooks).toBe(true);
+    } finally {
+      await harness.reloader.stop();
+    }
+  });
+
+  it("watches $include files from the startup snapshot", async () => {
+    const configPath = "/tmp/openclaw.json";
+    const includePath = resolveIncludePathForTest(configPath, "includes/models.json");
+    const startupSnapshot = makeSnapshot({
+      path: configPath,
+      parsed: { $include: "includes/models.json" },
+    });
+    const readSnapshot = vi.fn<() => Promise<ConfigFileSnapshot>>();
+    const { watcher, reloader } = createReloaderHarness(readSnapshot, {
+      initialSnapshot: startupSnapshot,
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(readSnapshot).not.toHaveBeenCalled();
+    expect(watcher.add).toHaveBeenCalledWith([includePath]);
+
+    await reloader.stop();
+  });
+
+  it("watches nested $include files from the startup snapshot", async () => {
+    vi.useRealTimers();
+    const tmpDir = await fs.mkdtemp(nodePath.join(os.tmpdir(), "openclaw-reload-test-"));
+    const includeDir = nodePath.join(tmpDir, "includes");
+    await fs.mkdir(includeDir, { recursive: true });
+    const configPath = nodePath.join(tmpDir, "openclaw.json");
+    const outerIncludePath = nodePath.join(includeDir, "outer.json");
+    const nestedIncludePath = nodePath.join(includeDir, "nested.json");
+    await fs.writeFile(outerIncludePath, JSON.stringify({ $include: "./nested.json" }));
+    await fs.writeFile(nestedIncludePath, JSON.stringify({ hooks: { enabled: true } }));
+    const startupSnapshot = makeSnapshot({
+      path: configPath,
+      parsed: { $include: "./includes/outer.json" },
+    });
+    const readSnapshot = vi.fn<() => Promise<ConfigFileSnapshot>>();
+    const { watcher, reloader } = createReloaderHarness(readSnapshot, {
+      initialSnapshot: startupSnapshot,
+    });
+
+    try {
+      await waitForCondition(() =>
+        watcher.add.mock.calls.some(
+          ([paths]) => Array.isArray(paths) && paths.includes(nestedIncludePath),
+        ),
+      );
+
+      expect(watcher.add).toHaveBeenCalledWith([outerIncludePath]);
+      expect(watcher.add).toHaveBeenCalledWith([nestedIncludePath]);
+      expect(readSnapshot).not.toHaveBeenCalled();
+    } finally {
+      await reloader.stop();
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps nested $include watches during direct-phase refresh", async () => {
+    vi.useRealTimers();
+    const tmpDir = await fs.mkdtemp(nodePath.join(os.tmpdir(), "openclaw-reload-test-"));
+    const includeDir = nodePath.join(tmpDir, "includes");
+    await fs.mkdir(includeDir, { recursive: true });
+    const configPath = nodePath.join(tmpDir, "openclaw.json");
+    const outerIncludePath = nodePath.join(includeDir, "outer.json");
+    const nestedIncludePath = nodePath.join(includeDir, "nested.json");
+    await fs.writeFile(outerIncludePath, JSON.stringify({ $include: "./nested.json" }));
+    await fs.writeFile(nestedIncludePath, JSON.stringify({ hooks: { enabled: true } }));
+    const startupSnapshot = makeSnapshot({
+      path: configPath,
+      parsed: { $include: "./includes/outer.json" },
+      config: { gateway: { reload: { debounceMs: 0 } } },
+    });
+    const readSnapshot = vi
+      .fn<() => Promise<ConfigFileSnapshot>>()
+      .mockResolvedValue(startupSnapshot);
+    const promoteSnapshot = vi.fn(async () => true);
+    const { watcher, reloader } = createReloaderHarness(readSnapshot, {
+      initialSnapshot: startupSnapshot,
+      promoteSnapshot,
+    });
+
+    try {
+      await waitForCondition(() =>
+        watcher.add.mock.calls.some(
+          ([paths]) => Array.isArray(paths) && paths.includes(nestedIncludePath),
+        ),
+      );
+      watcher.add.mockClear();
+      watcher.unwatch.mockClear();
+
+      watcher.emit("change", configPath);
+      await waitForCondition(() => promoteSnapshot.mock.calls.length === 1);
+
+      expect(watcher.add).not.toHaveBeenCalled();
+      expect(watcher.unwatch).not.toHaveBeenCalled();
+    } finally {
+      await reloader.stop();
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("suppresses synthetic add events from dynamically watched $include files", async () => {
+    const configPath = "/tmp/openclaw.json";
+    const includePath = resolveIncludePathForTest(configPath, "includes/models.json");
+    const startupSnapshot = makeSnapshot({
+      path: configPath,
+      parsed: { $include: "includes/models.json" },
+    });
+    const readSnapshot = vi.fn<() => Promise<ConfigFileSnapshot>>();
+    const { watcher, reloader } = createReloaderHarness(readSnapshot, {
+      initialSnapshot: startupSnapshot,
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    watcher.emit("add", includePath);
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(readSnapshot).not.toHaveBeenCalled();
+
+    await reloader.stop();
+  });
+
+  it("refreshes watched $include files after an accepted config snapshot", async () => {
+    vi.useRealTimers();
+    const configPath = "/tmp/openclaw.json";
+    const oldIncludePath = resolveIncludePathForTest(configPath, "includes/old.json");
+    const nextIncludePath = resolveIncludePathForTest(configPath, "includes/next.json");
+    const startupSnapshot = makeSnapshot({
+      path: configPath,
+      parsed: { $include: "includes/old.json" },
+    });
+    const nextSnapshot = makeSnapshot({
+      path: configPath,
+      parsed: { $include: "includes/next.json" },
+      config: {
+        gateway: { reload: { debounceMs: 0 } },
+        hooks: { enabled: true },
+      },
+      hash: "next-root-hash",
+    });
+    const readSnapshot = vi
+      .fn<() => Promise<ConfigFileSnapshot>>()
+      .mockResolvedValueOnce(nextSnapshot);
+    const { watcher, reloader } = createReloaderHarness(readSnapshot, {
+      initialSnapshot: startupSnapshot,
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    watcher.add.mockClear();
+    watcher.unwatch.mockClear();
+
+    watcher.emit("change", configPath);
+    await waitForCondition(() => watcher.unwatch.mock.calls.length === 1);
+
+    expect(watcher.add).toHaveBeenCalledWith([nextIncludePath]);
+    expect(watcher.unwatch).toHaveBeenCalledWith([oldIncludePath]);
+
+    await reloader.stop();
+  });
+
+  it("refreshes watched $include files after an accepted in-process write", async () => {
+    vi.useRealTimers();
+    const configPath = "/tmp/openclaw.json";
+    const oldIncludePath = resolveIncludePathForTest(configPath, "includes/old.json");
+    const nextIncludePath = resolveIncludePathForTest(configPath, "includes/next.json");
+    const startupSnapshot = makeSnapshot({
+      path: configPath,
+      parsed: { $include: "includes/old.json" },
+    });
+    const nextConfig = {
+      gateway: { reload: { debounceMs: 0 } },
+      hooks: { enabled: true },
+    } satisfies OpenClawConfig;
+    const acceptedSnapshot = makeSnapshot({
+      path: configPath,
+      parsed: { $include: "includes/next.json" },
+      sourceConfig: nextConfig,
+      runtimeConfig: nextConfig,
+      config: nextConfig,
+      hash: "internal-include-hash",
+    });
+    const readSnapshot = vi
+      .fn<() => Promise<ConfigFileSnapshot>>()
+      .mockResolvedValueOnce(acceptedSnapshot);
+    const harness = createReloaderHarness(readSnapshot, {
+      initialSnapshot: startupSnapshot,
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    const { watcher, reloader } = harness;
+    watcher.add.mockClear();
+    watcher.unwatch.mockClear();
+
+    harness.emitWrite({
+      ...makeZeroDebounceHookWrite("internal-include-hash"),
+      sourceConfig: nextConfig,
+      runtimeConfig: nextConfig,
+    });
+    await waitForCondition(() => watcher.unwatch.mock.calls.length === 1);
+
+    expect(readSnapshot).toHaveBeenCalledTimes(1);
+    expect(watcher.add).toHaveBeenCalledWith([nextIncludePath]);
+    expect(watcher.unwatch).toHaveBeenCalledWith([oldIncludePath]);
+
+    await reloader.stop();
   });
 
   it("retries missing snapshots and reloads once config file reappears", async () => {
@@ -754,6 +1094,55 @@ describe("startGatewayConfigReloader", () => {
     expect(log.warn).not.toHaveBeenCalledWith("config reload skipped (config file not found)");
 
     await reloader.stop();
+  });
+
+  it("preserves include-triggered reloads across missing snapshot retries", async () => {
+    vi.useRealTimers();
+    const configPath = "/tmp/openclaw.json";
+    const includePath = resolveIncludePathForTest(configPath, "includes/runtime.json");
+    const startupSnapshot = makeSnapshot({
+      path: configPath,
+      parsed: { $include: "includes/runtime.json" },
+    });
+    const includeConfig = {
+      gateway: { reload: { debounceMs: 0 } },
+      hooks: { enabled: true },
+    } satisfies OpenClawConfig;
+    const includeChangedSnapshot = makeSnapshot({
+      path: configPath,
+      parsed: { $include: "includes/runtime.json" },
+      sourceConfig: includeConfig,
+      runtimeConfig: includeConfig,
+      config: includeConfig,
+      hash: "root-hash",
+    });
+    const readSnapshot = vi
+      .fn<() => Promise<ConfigFileSnapshot>>()
+      .mockResolvedValueOnce(makeSnapshot({ exists: false, raw: null, hash: "missing-1" }))
+      .mockResolvedValueOnce(includeChangedSnapshot);
+    const harness = createReloaderHarness(readSnapshot, {
+      initialCompareConfig: {
+        gateway: { reload: { debounceMs: 0 } },
+        hooks: { enabled: false },
+      },
+      initialInternalWriteHash: "root-hash",
+      initialSnapshot: startupSnapshot,
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    harness.watcher.emit("change", includePath);
+    await waitForCondition(() => harness.onHotReload.mock.calls.length === 1);
+
+    expect(readSnapshot).toHaveBeenCalledTimes(2);
+    expect(harness.log.info).toHaveBeenCalledWith(
+      "config reload retry (1/2): config file not found",
+    );
+    const [plan] = getOnlyHotReloadCall(harness);
+    expect(plan.reloadHooks).toBe(true);
+    expect(plan.hotReasons).toContain("hooks.enabled");
+
+    await harness.reloader.stop();
   });
 
   it("caps missing-file retries and skips reload after retry budget is exhausted", async () => {

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -1,6 +1,11 @@
 // Gateway config hot-reload watcher.
 // Diffs config/plugin install snapshots and dispatches hot reload or restart plans.
+import nodePath from "node:path";
 import chokidar from "chokidar";
+import {
+  collectDirectIncludePaths,
+  collectIncludePathsRecursive,
+} from "../config/includes-scan.js";
 import type { ConfigWriteNotification } from "../config/io.js";
 import { formatConfigIssueLines } from "../config/issue-format.js";
 import { resolveConfigWriteFollowUp } from "../config/runtime-snapshot.js";
@@ -89,6 +94,7 @@ export function startGatewayConfigReloader(opts: {
   initialConfig: OpenClawConfig;
   initialCompareConfig?: OpenClawConfig;
   initialInternalWriteHash?: string | null;
+  initialSnapshot?: ConfigFileSnapshot;
   readSnapshot: () => Promise<ConfigFileSnapshot>;
   onHotReload: (plan: GatewayReloadPlan, nextConfig: OpenClawConfig) => Promise<void>;
   onRestart: (plan: GatewayReloadPlan, nextConfig: OpenClawConfig) => void | Promise<void>;
@@ -123,6 +129,138 @@ export function startGatewayConfigReloader(opts: {
     opts.initialPluginInstallRecords ?? loadInstalledPluginIndexInstallRecordsSync();
   const readPluginInstallRecords =
     opts.readPluginInstallRecords ?? loadInstalledPluginIndexInstallRecords;
+  const rootWatchPath = nodePath.normalize(opts.watchPath);
+  const watcher = chokidar.watch(opts.watchPath, {
+    ignoreInitial: true,
+    awaitWriteFinish: { stabilityThreshold: 200, pollInterval: 50 },
+    usePolling: Boolean(process.env.VITEST),
+  });
+  let watchedIncludePaths = new Set<string>();
+  let includeWatchGeneration = 0;
+  let pendingIncludeWatchEvent = false;
+  const suppressIncludeAddEvents = new Set<string>();
+  const suppressIncludeAddEventTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+  const normalizeIncludeWatchPaths = (includePaths: string[]): string[] =>
+    Array.from(
+      new Set(
+        includePaths
+          .map((includePath) => nodePath.normalize(includePath))
+          .filter((includePath) => includePath !== rootWatchPath),
+      ),
+    ).sort();
+
+  const collectDirectIncludeWatchPaths = (snapshot: ConfigFileSnapshot): string[] => {
+    if (!snapshot.exists || !snapshot.valid) {
+      return [];
+    }
+    return normalizeIncludeWatchPaths(
+      collectDirectIncludePaths({
+        configPath: snapshot.path,
+        parsed: snapshot.parsed,
+      }),
+    );
+  };
+
+  const collectIncludeWatchPaths = async (snapshot: ConfigFileSnapshot): Promise<string[]> => {
+    if (!snapshot.exists || !snapshot.valid) {
+      return [];
+    }
+    const includePaths = await collectIncludePathsRecursive({
+      configPath: snapshot.path,
+      parsed: snapshot.parsed,
+    });
+    return normalizeIncludeWatchPaths(includePaths);
+  };
+
+  const suppressNextIncludeAddEvent = (includePath: string) => {
+    suppressIncludeAddEvents.add(includePath);
+    const existingTimer = suppressIncludeAddEventTimers.get(includePath);
+    if (existingTimer) {
+      clearTimeout(existingTimer);
+    }
+    const timer = setTimeout(() => {
+      suppressIncludeAddEvents.delete(includePath);
+      suppressIncludeAddEventTimers.delete(includePath);
+    }, 1_000);
+    timer.unref?.();
+    suppressIncludeAddEventTimers.set(includePath, timer);
+  };
+
+  const clearSuppressedIncludeAddEvent = (includePath: string): boolean => {
+    const hadSuppressedEvent = suppressIncludeAddEvents.delete(includePath);
+    const timer = suppressIncludeAddEventTimers.get(includePath);
+    if (timer) {
+      clearTimeout(timer);
+      suppressIncludeAddEventTimers.delete(includePath);
+    }
+    return hadSuppressedEvent;
+  };
+
+  const applyIncludeWatchPaths = (
+    nextIncludePaths: string[],
+    reason: string,
+    mode: "additive" | "authoritative" = "authoritative",
+  ) => {
+    if (stopped) {
+      return;
+    }
+    const nextIncludePathSet = new Set(nextIncludePaths);
+    const toAdd = nextIncludePaths.filter((includePath) => !watchedIncludePaths.has(includePath));
+    const toRemove =
+      mode === "authoritative"
+        ? Array.from(watchedIncludePaths)
+            .filter((includePath) => !nextIncludePathSet.has(includePath))
+            .toSorted()
+        : [];
+    if (toAdd.length === 0 && toRemove.length === 0) {
+      return;
+    }
+    const nextWatchedIncludePaths =
+      mode === "authoritative"
+        ? nextIncludePathSet
+        : new Set([...watchedIncludePaths, ...nextIncludePaths]);
+    try {
+      if (toAdd.length > 0) {
+        for (const includePath of toAdd) {
+          suppressNextIncludeAddEvent(includePath);
+        }
+        watcher.add(toAdd);
+      }
+      if (toRemove.length > 0) {
+        for (const includePath of toRemove) {
+          clearSuppressedIncludeAddEvent(includePath);
+        }
+        watcher.unwatch(toRemove);
+      }
+      watchedIncludePaths = nextWatchedIncludePaths;
+    } catch (err) {
+      opts.log.warn(`config reload include watch sync failed (${reason}): ${String(err)}`);
+    }
+  };
+
+  const syncIncludeWatchPaths = async (snapshot: ConfigFileSnapshot, reason: string) => {
+    const generation = ++includeWatchGeneration;
+    try {
+      const directIncludePaths = collectDirectIncludeWatchPaths(snapshot);
+      if (stopped || generation !== includeWatchGeneration) {
+        return;
+      }
+      applyIncludeWatchPaths(directIncludePaths, `${reason}-direct`, "additive");
+    } catch (err) {
+      opts.log.warn(`config reload include watch sync failed (${reason}): ${String(err)}`);
+      return;
+    }
+    try {
+      const includePaths = await collectIncludeWatchPaths(snapshot);
+      if (stopped || generation !== includeWatchGeneration) {
+        return;
+      }
+      applyIncludeWatchPaths(includePaths, reason);
+    } catch (err) {
+      opts.log.warn(`config reload include watch sync failed (${reason}): ${String(err)}`);
+    }
+  };
 
   const scheduleAfter = (wait: number) => {
     if (stopped) {
@@ -303,18 +441,18 @@ export function startGatewayConfigReloader(opts: {
     }
   };
 
-  const promoteAcceptedInProcessWrite = async (persistedHash: string) => {
-    if (!opts.promoteSnapshot) {
-      return;
-    }
+  const handleAcceptedInProcessWriteSnapshot = async (persistedHash: string) => {
     try {
       const snapshot = await opts.readSnapshot();
       if (snapshot.hash !== persistedHash || !snapshot.valid) {
         return;
       }
-      await promoteAcceptedSnapshot(snapshot, "in-process-write");
+      await syncIncludeWatchPaths(snapshot, "in-process-write");
+      if (opts.promoteSnapshot) {
+        await promoteAcceptedSnapshot(snapshot, "in-process-write");
+      }
     } catch (err) {
-      opts.log.warn(`config reload in-process last-known-good promotion failed: ${String(err)}`);
+      opts.log.warn(`config reload in-process snapshot handling failed: ${String(err)}`);
     }
   };
 
@@ -327,6 +465,13 @@ export function startGatewayConfigReloader(opts: {
       return;
     }
     running = true;
+    const includeTriggeredReload = pendingIncludeWatchEvent;
+    pendingIncludeWatchEvent = false;
+    const preserveIncludeTriggeredReload = () => {
+      if (includeTriggeredReload) {
+        pendingIncludeWatchEvent = true;
+      }
+    };
     if (debounceTimer) {
       clearTimeout(debounceTimer);
       debounceTimer = null;
@@ -341,23 +486,30 @@ export function startGatewayConfigReloader(opts: {
           pendingWrite.compareConfig,
           pendingWrite.afterWrite,
         );
-        await promoteAcceptedInProcessWrite(pendingWrite.persistedHash);
+        await handleAcceptedInProcessWriteSnapshot(pendingWrite.persistedHash);
+        if (includeTriggeredReload) {
+          pendingIncludeWatchEvent = true;
+          pending = true;
+        }
         return;
       }
       const snapshot = await opts.readSnapshot();
       if (lastAppliedWriteHash && typeof snapshot.hash === "string") {
-        if (snapshot.hash === lastAppliedWriteHash) {
+        if (snapshot.hash === lastAppliedWriteHash && !includeTriggeredReload) {
           return;
         }
         lastAppliedWriteHash = null;
       }
       if (handleMissingSnapshot(snapshot)) {
+        preserveIncludeTriggeredReload();
         return;
       }
       if (!snapshot.valid) {
         handleInvalidSnapshot(snapshot);
+        preserveIncludeTriggeredReload();
         return;
       }
+      await syncIncludeWatchPaths(snapshot, "valid-config");
       await applySnapshot(snapshot.config, snapshot.sourceConfig);
       await promoteAcceptedSnapshot(snapshot, "valid-config");
     } catch (err) {
@@ -371,13 +523,19 @@ export function startGatewayConfigReloader(opts: {
     }
   };
 
-  const watcher = chokidar.watch(opts.watchPath, {
-    ignoreInitial: true,
-    awaitWriteFinish: { stabilityThreshold: 200, pollInterval: 50 },
-    usePolling: Boolean(process.env.VITEST),
-  });
-
-  const scheduleFromWatcher = () => {
+  const scheduleFromWatcher = (eventKind: "add" | "change" | "unlink") => (eventPath?: string) => {
+    const normalizedEventPath =
+      typeof eventPath === "string" ? nodePath.normalize(eventPath) : null;
+    if (
+      eventKind === "add" &&
+      normalizedEventPath &&
+      clearSuppressedIncludeAddEvent(normalizedEventPath)
+    ) {
+      return;
+    }
+    if (normalizedEventPath && normalizedEventPath !== rootWatchPath) {
+      pendingIncludeWatchEvent = true;
+    }
     schedule();
   };
 
@@ -396,9 +554,12 @@ export function startGatewayConfigReloader(opts: {
       scheduleAfter(0);
     }) ?? (() => {});
 
-  watcher.on("add", scheduleFromWatcher);
-  watcher.on("change", scheduleFromWatcher);
-  watcher.on("unlink", scheduleFromWatcher);
+  watcher.on("add", scheduleFromWatcher("add"));
+  watcher.on("change", scheduleFromWatcher("change"));
+  watcher.on("unlink", scheduleFromWatcher("unlink"));
+  if (opts.initialSnapshot) {
+    void syncIncludeWatchPaths(opts.initialSnapshot, "startup");
+  }
   let watcherClosed = false;
   watcher.on("error", (err) => {
     if (watcherClosed) {
@@ -415,6 +576,11 @@ export function startGatewayConfigReloader(opts: {
       if (debounceTimer) {
         clearTimeout(debounceTimer);
       }
+      for (const timer of suppressIncludeAddEventTimers.values()) {
+        clearTimeout(timer);
+      }
+      suppressIncludeAddEventTimers.clear();
+      suppressIncludeAddEvents.clear();
       debounceTimer = null;
       watcherClosed = true;
       unsubscribeFromWrites();

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -15,7 +15,7 @@ import { getTotalPendingReplies } from "../auto-reply/reply/dispatcher-registry.
 import type { CliDeps } from "../cli/deps.types.js";
 import { isRestartEnabled } from "../config/commands.flags.js";
 import { getRuntimeConfig } from "../config/config.js";
-import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { ConfigFileSnapshot, OpenClawConfig } from "../config/types.openclaw.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import type { HeartbeatRunner } from "../infra/heartbeat-runner.js";
@@ -175,6 +175,7 @@ type ManagedGatewayConfigReloaderParams = Omit<
   initialConfig: OpenClawConfig;
   initialCompareConfig?: OpenClawConfig;
   initialInternalWriteHash: string | null;
+  initialSnapshot?: ConfigFileSnapshot;
   watchPath: string;
   readSnapshot: typeof import("../config/config.js").readConfigFileSnapshot;
   promoteSnapshot: typeof import("../config/config.js").promoteConfigSnapshotToLastKnownGood;
@@ -658,6 +659,7 @@ export function startManagedGatewayConfigReloader(params: ManagedGatewayConfigRe
     initialConfig: params.initialConfig,
     initialCompareConfig: params.initialCompareConfig,
     initialInternalWriteHash: params.initialInternalWriteHash,
+    initialSnapshot: params.initialSnapshot,
     readSnapshot: params.readSnapshot,
     promoteSnapshot: async (snapshot, _reason) => await params.promoteSnapshot(snapshot),
     subscribeToWrites: params.subscribeToWrites,

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -1667,6 +1667,7 @@ export async function startGatewayServer(
       initialConfig: cfgAtStart,
       initialCompareConfig: startupLastGoodSnapshot.sourceConfig,
       initialInternalWriteHash: startupInternalWriteHash,
+      initialSnapshot: startupLastGoodSnapshot,
       watchPath: configSnapshot.path,
       readSnapshot: readConfigFileSnapshot,
       promoteSnapshot: promoteConfigSnapshotToLastKnownGood,


### PR DESCRIPTION
Fixes #59616
Relates #41587
Supersedes the closed/unmerged attempts in #59632 and #82698.
Replaces #90652, which was auto-closed by the active-PR queue gate.

## Summary
- Seed gateway config include watches from the startup `ConfigFileSnapshot` so `$include` dependencies are watched immediately.
- Keep dynamic Chokidar include watches in sync after valid snapshots and accepted in-process writes, with direct includes added first and recursive removals applied only from the authoritative include graph.
- Let include-triggered changes bypass the root-hash internal-write dedupe path while preserving that trigger across transient missing root snapshots.
- Suppress synthetic dynamic `add` events without dropping real include `change`/`unlink` events that arrive during watch-sync windows.
- Cover startup, nested includes, in-process writes, stale watch removal, synthetic add suppression, include-sync races, and retry edge cases.

## Verification
- `node scripts\run-vitest.mjs src\gateway\config-reload.test.ts` (356 tests passed after the CI race fix)
- `node scripts\run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts\tsgo-59616-core-ci-fix.tsbuildinfo`
- `node scripts\run-tsgo.mjs -p test\tsconfig\tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts\tsgo-59616-core-test-ci-fix.tsbuildinfo`
- `node_modules\.bin\oxfmt.cmd --check src\gateway\config-reload.ts src\gateway\config-reload.test.ts`
- `node scripts\run-oxlint.mjs src\gateway\config-reload.ts src\gateway\config-reload.test.ts`
- `git diff --check` and `git diff --check HEAD~1..HEAD`
- `PYTHONUTF8=1 python .agents\skills\autoreview\scripts\autoreview --mode local --engine claude --output .artifacts\autoreview-59616-ci-race-claude.txt --json-output .artifacts\autoreview-59616-ci-race-claude.json` (clean, no accepted/actionable findings)

## Real behavior proof
Behavior addressed: Config hot-reload now observes files referenced by `$include`; editing an included file no longer requires a manual gateway restart.

Real environment tested: Local Windows checkout using the real OpenClaw `startGatewayConfigReloader`, real Chokidar filesystem watcher, and temporary real config files under the OS temp directory. The watcher itself was not mocked.

Exact steps or command run after this patch: Ran `node_modules\.bin\tsx.cmd .artifacts\include-watch-smoke.ts` with a temporary proof script that created a root `openclaw.json` containing `{ "$include": "./includes/runtime.json", "gateway": { "reload": { "debounceMs": 0 } } }`, started `startGatewayConfigReloader` with the startup `ConfigFileSnapshot` and `initialInternalWriteHash` equal to the root hash, then changed only `includes/runtime.json` from `hooks.enabled: false` to `true`.

Evidence after fix:

```json
{
  "rootHashUnchanged": true,
  "events": [
    {
      "hotReasons": [
        "hooks.enabled"
      ],
      "reloadHooks": true,
      "hooks": {
        "enabled": true
      }
    }
  ],
  "warnings": [],
  "errors": []
}
```

Observed result after fix: The root config hash stayed unchanged, but the include-only file edit produced one hot reload for `hooks.enabled`, and the reloader reported no warnings or errors.

What was not tested: Broad `pnpm check:changed`/Testbox proof has not been run locally; focused source, type, lint, format, autoreview, real watcher proof, and the PR CI gateway-core race regression are covered.

Reported by @alkor2000. This replacement keeps the useful direction from prior closed attempts while avoiding nested-watch churn and real-event drops during include watch sync.