### PR TITLE
fix(ui): hide workspace files rail when empty and idle

### DIFF
--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -907,6 +907,51 @@ describe("chat composer workbench", () => {
     expect(onOpenFile).toHaveBeenCalledWith("AGENTS.md");
   });
 
+  it("hides the workspace files rail when there are no files, no error, and not loading", () => {
+    const container = renderChatView({
+      workspaceFiles: {
+        agentId: "main",
+        list: null,
+        loading: false,
+        error: null,
+        activeName: null,
+        onRefresh: vi.fn(),
+        onOpenFile: vi.fn(),
+      },
+    });
+    expect(container.querySelector(".chat-workspace-rail")).toBeNull();
+  });
+
+  it("shows the workspace files rail during loading even when no files yet", () => {
+    const container = renderChatView({
+      workspaceFiles: {
+        agentId: "main",
+        list: null,
+        loading: true,
+        error: null,
+        activeName: null,
+        onRefresh: vi.fn(),
+        onOpenFile: vi.fn(),
+      },
+    });
+    expect(container.querySelector(".chat-workspace-rail")).not.toBeNull();
+  });
+
+  it("shows the workspace files rail when there is an error with no files", () => {
+    const container = renderChatView({
+      workspaceFiles: {
+        agentId: "main",
+        list: null,
+        loading: false,
+        error: "Failed to load",
+        activeName: null,
+        onRefresh: vi.fn(),
+        onOpenFile: vi.fn(),
+      },
+    });
+    expect(container.querySelector(".chat-workspace-rail")).not.toBeNull();
+  });
+
   it("keeps the secondary New session and Export controls suppressed in the composer", () => {
     const container = renderChatView({
       messages: [{ role: "assistant", content: "ready" }],

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -1013,6 +1013,9 @@ function renderWorkspaceFileRail(
     return nothing;
   }
   const files = workspaceFiles.list?.files ?? [];
+  if (files.length === 0 && !workspaceFiles.loading && !workspaceFiles.error) {
+    return nothing;
+  }
   return html`
     <aside class="chat-workspace-rail" aria-label="Workspace files">
       <div class="chat-workspace-rail__header">


### PR DESCRIPTION
## Summary

Fixes #90359: The "Workspace Files" right sidebar was shown by default in the chat UI even when there were no files to display, nothing loading, and no error. This wasted chat space unnecessarily.

The fix adds an early return in `renderWorkspaceFileRail` to hide the rail when:
- No files are present (`files.length === 0`)
- Not loading (`!workspaceFiles.loading`)
- No error to display (`!workspaceFiles.error`)

The rail still appears during loading (to show progress) and when it has files or errors to display.

## Real behavior proof

**Behavior addressed:** Workspace Files panel takes up right-side chat space by default even when empty/not loaded.

**Real environment tested:** macOS 26.1, Node.js 24, `ui/src/ui/views/chat.test.ts` via Vitest.

**Exact steps or command run after this patch:**
```
npx vitest run ui/src/ui/views/chat.test.ts --no-color
```

**Evidence after fix:**
```
Test Files  1 passed (1)
     Tests  97 passed (97)
```

New regression tests added (3 tests in `describe("chat composer workbench")`):
1. `"hides the workspace files rail when there are no files, no error, and not loading"` — asserts `.chat-workspace-rail` is null when list is null, loading=false, error=null
2. `"shows the workspace files rail during loading even when no files yet"` — asserts `.chat-workspace-rail` is present when loading=true even with null list
3. `"shows the workspace files rail when there is an error with no files"` — asserts `.chat-workspace-rail` is present when error is set with null list

Existing test `"renders session controls in the composer and workspace files in the rail"` (with actual file content) continues to pass unchanged.

**Observed result after fix:**
- Before fix: empty workspace files rail visible with "No workspace files" text, wasting chat space
- After fix: workspace files rail hidden when there's nothing useful to display, only appears when loading/has files/has error

**What was not tested:** Full end-to-end browser rendering of the chat UI with live WebSocket workspace file loading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)