### PR TITLE
fix(ui): preserve dashboard session parent lineage when session list is stale

### DIFF
--- a/ui/src/ui/app-render.helpers.node.test.ts
+++ b/ui/src/ui/app-render.helpers.node.test.ts
@@ -835,6 +835,42 @@ describe("createChatSession", () => {
     expect(loadChatHistoryMock).toHaveBeenCalledWith(state);
   });
 
+  it("keeps the selected session as parent when the session list is stale", async () => {
+    const state = createChatSessionState({
+      sessionsResult: {
+        ts: 0,
+        path: "",
+        count: 1,
+        defaults: { modelProvider: "openai", model: "gpt-5", contextTokens: null },
+        sessions: [row({ key: "agent:ops:dashboard:older" })],
+      },
+    });
+    createSessionAndRefreshMock.mockResolvedValue("agent:ops:dashboard:new-chat");
+    refreshChatAvatarMock.mockResolvedValue(undefined);
+    refreshSlashCommandsMock.mockResolvedValue(undefined);
+    loadChatHistoryMock.mockResolvedValue(undefined);
+    loadSessionsMock.mockResolvedValue(undefined);
+
+    await createChatSession(state, { source: "user" });
+
+    expect(createSessionAndRefreshMock).toHaveBeenCalledWith(
+      state,
+      {
+        agentId: "ops",
+        parentSessionKey: "agent:ops:main",
+        emitCommandHooks: true,
+      },
+      {
+        activeMinutes: 120,
+        limit: 50,
+        includeGlobal: true,
+        includeUnknown: true,
+        showArchived: false,
+        agentId: "ops",
+      },
+    );
+  });
+
   it("creates selected global sessions under the same agent used for refresh", async () => {
     const state = createChatSessionState({
       sessionKey: "global",
@@ -872,6 +908,43 @@ describe("createChatSession", () => {
       },
     );
     expect(state.sessionKey).toBe("agent:work:dashboard:new-chat");
+  });
+
+  it("does not use the synthetic unknown session as a parent", async () => {
+    const state = createChatSessionState({
+      sessionKey: "unknown",
+      sessionsResult: {
+        ts: 0,
+        path: "",
+        count: 1,
+        defaults: { modelProvider: "openai", model: "gpt-5", contextTokens: null },
+        sessions: [row({ key: "unknown", kind: "unknown" })],
+      },
+    });
+    createSessionAndRefreshMock.mockResolvedValue("agent:main:dashboard:new-chat");
+    refreshChatAvatarMock.mockResolvedValue(undefined);
+    refreshSlashCommandsMock.mockResolvedValue(undefined);
+    loadChatHistoryMock.mockResolvedValue(undefined);
+    loadSessionsMock.mockResolvedValue(undefined);
+
+    await createChatSession(state, { source: "user" });
+
+    expect(createSessionAndRefreshMock).toHaveBeenCalledWith(
+      state,
+      {
+        agentId: "main",
+        parentSessionKey: undefined,
+        emitCommandHooks: undefined,
+      },
+      {
+        activeMinutes: 120,
+        limit: 50,
+        includeGlobal: true,
+        includeUnknown: true,
+        showArchived: false,
+      },
+    );
+    expect(state.sessionKey).toBe("agent:main:dashboard:new-chat");
   });
 
   it("preserves draft and attachment edits made while session creation is in flight", async () => {

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -731,11 +731,11 @@ export async function createChatSession(
   state.lastError = null;
   state.chatError = null;
   const previousSessionKey = state.sessionKey;
-  const parentSessionKey = state.sessionsResult?.sessions.some(
-    (row) => row.key === previousSessionKey,
-  )
-    ? previousSessionKey
-    : undefined;
+  const normalizedPreviousSessionKey = normalizeOptionalString(previousSessionKey);
+  const parentSessionKey =
+    normalizeLowercaseStringOrEmpty(normalizedPreviousSessionKey) === "unknown"
+      ? undefined
+      : normalizedPreviousSessionKey;
   const nextSessionKey = await createSessionAndRefresh(
     state as unknown as Parameters<typeof createSessionAndRefresh>[0],
     {


### PR DESCRIPTION
## Summary

Dashboard-created agent sessions (`agent:<id>:dashboard:*`) could lose their parent lineage. In the Control UI, `createChatSession` only kept `parentSessionKey` when the previously selected session key already appeared in `state.sessionsResult`. When that session list was stale, filtered, or not yet loaded, the parent link was dropped, the dashboard session was created unparented, and default tree visibility then omitted it from `sessions_list` — so assistant replies were written to the transcript but never shown in the dashboard UI.

Fixes #90623.

## Affected surface

- `ui/src/ui/app-render.helpers.ts` — `createChatSession` now derives `parentSessionKey` from the normalized currently-selected `state.sessionKey` instead of requiring it to be present in the possibly stale/filtered `state.sessionsResult`. The gateway's existing parent validation remains the backstop for genuinely unknown parents.
- `ui/src/ui/app-render.helpers.node.test.ts` — RED/GREEN regression.

## Scope

- Only the Control UI session-creation lineage is changed. iOS/shared `ChatViewModel` already passes the parent unconditionally; this aligns the Control UI path with that existing contract.
- No change to unrelated session visibility logic, gateway validation, or other channels.

## Real behavior proof

**Behavior or issue addressed:** a dashboard child session created from the currently selected parent should keep `parentSessionKey` even when the Control UI session list is not loaded yet. After the gateway returns the dashboard child and `sessions.list` includes the parent-linked child row, the child should stay visible in the Control UI and assistant replies should render in that child session.

**Real environment tested:** local macOS development machine on `darwin`, branch `wolf/dashboard-session-parent-lineage`. The proof used real Playwright Chromium launched against the repository Control UI E2E Vite server and the repository `installMockGateway` WebSocket helper with redacted local-only data. No production endpoint, token, or model credential was used. Screenshot artifact captured locally under the contributor's temporary artifacts directory.

**Exact steps or command run after this patch:**

```sh
node scripts/ensure-playwright-chromium.mjs
node scripts/run-vitest.mjs ui/src/ui/app-render.helpers.node.test.ts
node --import tsx --input-type=module  # starts Control UI E2E server, opens Chromium, installs mock Gateway, captures screenshot/JSON proof
```

Browser proof scenario:

1. Opened real Control UI `/chat` with selected parent `agent:ops:main`.
2. Left the session list intentionally unloaded before creating the dashboard child; proof observed `preCreateSessionsListRequestCount: 0`.
3. Clicked the visible `New session` control in the UI.
4. Captured the real mock-gateway `sessions.create` request.
5. Mock gateway returned child key `agent:ops:dashboard:new-proof`, then `sessions.list` returned a visible child row labeled `Proof child visible` with `parentSessionKey: agent:ops:main`.
6. Sent a chat turn in the child session and emitted an assistant final event for that same child session.
7. Verified the child label, prompt, and assistant final reply were visible in the browser page; captured screenshot and JSON evidence.

**Evidence after fix:** focused RED/GREEN test proof and copied live Chromium Control UI proof output.

Focused RED/GREEN test proof:

- Before the fix, the stale/missing-list regression resolves `parentSessionKey` to `undefined` when `state.sessionsResult` does not contain the selected parent.
- After the fix, `createChatSession` passes `parentSessionKey: "agent:ops:main"` even when `sessionsResult` is stale.
- `node scripts/run-vitest.mjs ui/src/ui/app-render.helpers.node.test.ts` passed: 68/68 tests.

Real Chromium Control UI proof output:

```json
{
  "platform": "darwin",
  "head": "6286e0522b9c85d93faaabb0aa95f9b247b44bea",
  "proofKind": "real Chromium Control UI with repository mock Gateway helper",
  "url": "http://127.0.0.1:51110/chat?session=agent%3Aops%3Adashboard%3Anew-proof",
  "parentKey": "agent:ops:main",
  "childKey": "agent:ops:dashboard:new-proof",
  "preCreateSessionsListRequestCount": 0,
  "createParams": {
    "agentId": "ops",
    "parentSessionKey": "agent:ops:main",
    "emitCommandHooks": true
  },
  "sendParams": {
    "sessionKey": "agent:ops:dashboard:new-proof",
    "message": "show the proof reply in the dashboard child session",
    "deliver": false,
    "hasRunId": true
  },
  "sessionsListRequestCountAfterCreate": 2,
  "observed": {
    "childLabelVisible": true,
    "childUrlContainsSessionKey": true,
    "promptVisible": true,
    "assistantReplyVisible": true
  }
}
```

Screenshot proof was captured locally under the contributor's temporary artifacts directory.

The screenshot shows the real Control UI with:

- `Proof child visible` selected in the chat session control
- `Proof child visible` visible in the left recent sessions list
- the sent prompt visible in the child session transcript
- `Proof reply visible in dashboard child session.` visible as the assistant reply

**Observed result after fix:** the Control UI created the dashboard child from an unloaded session-list state while still sending `parentSessionKey: "agent:ops:main"`. The returned child session became the active dashboard chat, appeared in the UI session controls/recent list, and rendered the assistant final reply in the child transcript.

**What was not tested:**

- I did not use a production gateway, public endpoint, private token, or live model provider credential.
- I did not run a real remote assistant/model turn; the assistant final event was emitted through the repository mock Gateway helper after the UI sent a real `chat.send` request for the child session.
- I did not test iOS/shared `ChatViewModel`; that path already passes the parent unconditionally and is outside this Control UI-only patch.

## De-duplication

Five independent open-PR searches (`Fixes #90623`, `#90623`, `dashboard session reply`, `parentSessionKey dashboard`, `app-render createChatSession`) returned no competing open PR. Two nearby but unrelated open PRs exist (#90489 visibility error wording, #89461 current-session alias visibility); neither targets dashboard session lineage.

## Narrow-fix rationale

1. Existing contract: dashboard child sessions are meant to be parent-linked; the Control UI could silently drop that link.
2. Adjacent paths: iOS/shared `ChatViewModel` already passes the parent unconditionally — the Control UI was the odd path.
3. Canonical owner: Control UI creation path plus the existing gateway parent-validation backstop.
4. Supersession risk: low; no open PR targets this lineage gap.



## Maintainer update

Maintainer follow-up fixed the added regression test to use explicit user intent and added coverage that the synthetic `unknown` session key is not sent as `parentSessionKey`; the gateway remains the validation backstop for genuinely unknown parents.
