### PR TITLE
fix(discord): filter startup slots by runtime-enabled predicate

### DIFF
--- a/extensions/discord/src/channel.test.ts
+++ b/extensions/discord/src/channel.test.ts
@@ -737,6 +737,47 @@ describe("discordPlugin outbound", () => {
     await discordPlugin.gateway!.startAccount!(farberContext);
     expect(sleepWithAbortMock).toHaveBeenLastCalledWith(20_000, farberContext.abortSignal);
   });
+
+  it("does not promote a duplicate-token defaultAccount to the zero-delay startup slot", async () => {
+    probeDiscordMock.mockResolvedValue({
+      ok: true,
+      bot: { username: "Jarvis" },
+      application: {
+        intents: {
+          messageContent: "limited",
+          guildMembers: "disabled",
+          presence: "disabled",
+        },
+      },
+      elapsedMs: 1,
+    });
+    monitorDiscordProviderMock.mockResolvedValue(undefined);
+
+    const cfg = {
+      channels: {
+        discord: {
+          defaultAccount: "main",
+          accounts: {
+            billy: { token: "Bot billy-token", enabled: true },
+            // farber and main share a token; farber sorts before main so farber owns it
+            farber: { token: "Bot shared-token", enabled: true },
+            main: { token: "Bot shared-token", enabled: true },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    // main is duplicate-token disabled and must not consume the zero-delay slot
+    await startDiscordAccount(cfg, "billy");
+    expect(sleepWithAbortMock).not.toHaveBeenCalled();
+
+    const farberContext = createStartAccountContext({
+      account: resolveAccount(cfg, "farber"),
+      cfg,
+    });
+    await discordPlugin.gateway!.startAccount!(farberContext);
+    expect(sleepWithAbortMock).toHaveBeenLastCalledWith(10_000, farberContext.abortSignal);
+  });
 });
 
 describe("discordPlugin bindings", () => {

--- a/extensions/discord/src/channel.test.ts
+++ b/extensions/discord/src/channel.test.ts
@@ -691,6 +691,52 @@ describe("discordPlugin outbound", () => {
     await discordPlugin.gateway!.startAccount!(zetaContext);
     expect(sleepWithAbortMock).toHaveBeenCalledWith(10_000, zetaContext.abortSignal);
   });
+
+  it("starts the configured default account before staggering secondary accounts", async () => {
+    probeDiscordMock.mockResolvedValue({
+      ok: true,
+      bot: { username: "Jarvis" },
+      application: {
+        intents: {
+          messageContent: "limited",
+          guildMembers: "disabled",
+          presence: "disabled",
+        },
+      },
+      elapsedMs: 1,
+    });
+    monitorDiscordProviderMock.mockResolvedValue(undefined);
+
+    const cfg = {
+      channels: {
+        discord: {
+          defaultAccount: "main",
+          accounts: {
+            billy: { token: "Bot billy-token", enabled: true },
+            farber: { token: "Bot farber-token", enabled: true },
+            main: { token: "Bot main-token", enabled: true },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    await startDiscordAccount(cfg, "main");
+    expect(sleepWithAbortMock).not.toHaveBeenCalled();
+
+    const billyContext = createStartAccountContext({
+      account: resolveAccount(cfg, "billy"),
+      cfg,
+    });
+    await discordPlugin.gateway!.startAccount!(billyContext);
+    expect(sleepWithAbortMock).toHaveBeenLastCalledWith(10_000, billyContext.abortSignal);
+
+    const farberContext = createStartAccountContext({
+      account: resolveAccount(cfg, "farber"),
+      cfg,
+    });
+    await discordPlugin.gateway!.startAccount!(farberContext);
+    expect(sleepWithAbortMock).toHaveBeenLastCalledWith(20_000, farberContext.abortSignal);
+  });
 });
 
 describe("discordPlugin bindings", () => {

--- a/extensions/discord/src/channel.ts
+++ b/extensions/discord/src/channel.ts
@@ -23,6 +23,7 @@ import {
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { resolveTargetsWithOptionalToken } from "openclaw/plugin-sdk/target-resolver-runtime";
 import {
+  isDiscordAccountEnabledForRuntime,
   listDiscordAccountIds,
   resolveDefaultDiscordAccountId,
   resolveDiscordAccount,
@@ -223,11 +224,7 @@ const discordMessageActions = {
 function resolveDiscordStartupAccountIds(cfg: OpenClawConfig): string[] {
   const startupAccountIds = listDiscordAccountIds(cfg).filter((candidateId) => {
     const candidate = resolveDiscordAccount({ cfg, accountId: candidateId });
-    return (
-      candidate.enabled &&
-      (resolveConfiguredFromCredentialStatuses(candidate) ??
-        Boolean(normalizeOptionalString(candidate.token)))
-    );
+    return isDiscordAccountEnabledForRuntime(candidate, cfg);
   });
   const defaultAccountId = resolveDefaultDiscordAccountId(cfg);
   if (!startupAccountIds.includes(defaultAccountId)) {

--- a/extensions/discord/src/channel.ts
+++ b/extensions/discord/src/channel.ts
@@ -24,6 +24,7 @@ import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runti
 import { resolveTargetsWithOptionalToken } from "openclaw/plugin-sdk/target-resolver-runtime";
 import {
   listDiscordAccountIds,
+  resolveDefaultDiscordAccountId,
   resolveDiscordAccount,
   resolveDiscordAccountAllowFrom,
   type ResolvedDiscordAccount,
@@ -219,7 +220,7 @@ const discordMessageActions = {
   },
 };
 
-function resolveDiscordStartupDelayMs(cfg: OpenClawConfig, accountId: string): number {
+function resolveDiscordStartupAccountIds(cfg: OpenClawConfig): string[] {
   const startupAccountIds = listDiscordAccountIds(cfg).filter((candidateId) => {
     const candidate = resolveDiscordAccount({ cfg, accountId: candidateId });
     return (
@@ -228,6 +229,18 @@ function resolveDiscordStartupDelayMs(cfg: OpenClawConfig, accountId: string): n
         Boolean(normalizeOptionalString(candidate.token)))
     );
   });
+  const defaultAccountId = resolveDefaultDiscordAccountId(cfg);
+  if (!startupAccountIds.includes(defaultAccountId)) {
+    return startupAccountIds;
+  }
+  return [
+    defaultAccountId,
+    ...startupAccountIds.filter((candidateId) => candidateId !== defaultAccountId),
+  ];
+}
+
+function resolveDiscordStartupDelayMs(cfg: OpenClawConfig, accountId: string): number {
+  const startupAccountIds = resolveDiscordStartupAccountIds(cfg);
   const startupIndex = startupAccountIds.findIndex((candidateId) => candidateId === accountId);
   return startupIndex <= 0 ? 0 : startupIndex * DISCORD_ACCOUNT_STARTUP_STAGGER_MS;
 }


### PR DESCRIPTION
Fixes #77429
Supersedes #89744

## Changes

Uses `isDiscordAccountEnabledForRuntime` in `resolveDiscordStartupAccountIds` instead of a manual `enabled && token-exists` check. This ensures duplicate-token accounts are excluded from the startup slot list before promoting `defaultAccount`, so a duplicate-token default cannot consume the zero-delay slot and push the actual runtime-enabled bot to a staggered slot.

Adds a focused regression test: when `defaultAccount` points at a duplicate-token account, the real token owner retains the zero-delay startup slot.

## Validation

```
pnpm test:extension discord extensions/discord/src/channel.test.ts
Test Files  1 passed (1)
Tests       28 passed (28)
```