### PR TITLE
fix(doctor): normalize stale OpenAI Codex session refs

### DIFF
--- a/src/commands/doctor/shared/codex-route-warnings.test.ts
+++ b/src/commands/doctor/shared/codex-route-warnings.test.ts
@@ -3879,6 +3879,35 @@ describe("collectCodexRouteWarnings", () => {
     expect(store.main.agentRuntimeOverride).toBeUndefined();
   });
 
+  it("repairs legacy Codex model refs under canonical OpenAI session providers", () => {
+    const store: Record<string, SessionEntry> = {
+      main: {
+        sessionId: "s1",
+        updatedAt: 1,
+        modelProvider: "openai",
+        model: "openai-codex/gpt-5.5",
+        providerOverride: "openai",
+        modelOverride: "openai-codex/gpt-5.4",
+        agentHarnessId: "codex",
+        agentRuntimeOverride: "codex",
+      },
+    };
+
+    const result = repairCodexSessionStoreRoutes({
+      store,
+      now: 123,
+    });
+
+    expect(result).toEqual({ changed: true, sessionKeys: ["main"] });
+    expect(store.main.updatedAt).toBe(123);
+    expect(store.main.modelProvider).toBe("openai");
+    expect(store.main.model).toBe("gpt-5.5");
+    expect(store.main.providerOverride).toBe("openai");
+    expect(store.main.modelOverride).toBe("gpt-5.4");
+    expect(store.main.agentHarnessId).toBeUndefined();
+    expect(store.main.agentRuntimeOverride).toBeUndefined();
+  });
+
   it("repairs Telegram direct session routes while preserving canonical OpenAI auth pins", () => {
     const store: Record<string, SessionEntry> = {
       "agent:main:telegram:default:direct:5550100999": {

--- a/src/commands/doctor/shared/codex-route-warnings.ts
+++ b/src/commands/doctor/shared/codex-route-warnings.ts
@@ -2899,7 +2899,8 @@ function rewriteSessionModelPair(params: {
     return true;
   }
   if (model && isOpenAICodexModelRef(model)) {
-    const canonicalModel = toCanonicalOpenAIModelRef(model);
+    const canonicalModel =
+      provider === "openai" ? toOpenAIModelId(model) : toCanonicalOpenAIModelRef(model);
     if (canonicalModel) {
       params.entry[params.modelKey] = canonicalModel;
       changed = true;


### PR DESCRIPTION
## Summary

This PR tightens the doctor repair path for stale Codex session store state after the OpenAI/Codex provider unification.

- If a persisted session already has canonical `modelProvider: "openai"` / `providerOverride: "openai"` but still stores a legacy `openai-codex/...` model value, doctor now rewrites the model value to the unscoped OpenAI model id (`gpt-*`).
- Existing behavior for providerless legacy refs still canonicalizes to `openai/...` so the provider can be inferred later.
- Existing behavior for legacy `modelProvider: "openai-codex"` still rewrites the provider to `openai` and keeps the model unscoped.
- Stale Codex runtime pins continue to be cleared as part of session route repair.

This is intentionally doctor/update repair only. It does not reintroduce the closed runtime write-boundary shim from #90321.

## Linked context

Related #90319
Related #90321

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: a stale persisted session shape with canonical `modelProvider: "openai"` but legacy `model: "openai-codex/gpt-*"` was repaired to `model: "openai/gpt-*"`, leaving a provider-prefixed model under an already canonical provider. Session resolution treats `modelProvider` + `model` as a pair, so the durable repaired state should be `modelProvider: "openai"`, `model: "gpt-*"`.
- Real environment tested: macOS local OpenClaw source checkout on this PR branch (`agent/xiaozhua/codex-session-doctor-normalize`, commit `0f24e0f9570`) using the real `repairCodexSessionStoreRoutes` doctor session repair function.
- Exact steps or command run after this patch:

```bash
node --import tsx - <<'EOF'
import { repairCodexSessionStoreRoutes } from './src/commands/doctor/shared/codex-route-warnings.ts';
const store = {
  staleOpenAIProvider: {
    sessionId: 's1',
    updatedAt: 1,
    modelProvider: 'openai',
    model: 'openai-codex/gpt-5.5',
    providerOverride: 'openai',
    modelOverride: 'openai-codex/gpt-5.4',
    agentHarnessId: 'codex',
    agentRuntimeOverride: 'codex',
  },
};
const result = repairCodexSessionStoreRoutes({ store, now: 123 });
console.log(JSON.stringify({ result, store }, null, 2));
EOF
```

- Evidence after fix:

```json
{
  "result": {
    "changed": true,
    "sessionKeys": [
      "staleOpenAIProvider"
    ]
  },
  "store": {
    "staleOpenAIProvider": {
      "sessionId": "s1",
      "updatedAt": 123,
      "modelProvider": "openai",
      "model": "gpt-5.5",
      "providerOverride": "openai",
      "modelOverride": "gpt-5.4"
    }
  }
}
```

- Observed result after fix: doctor rewrites canonical OpenAI session-provider pairs to unscoped OpenAI model ids and clears stale Codex runtime pins.
- What was not tested: I did not run this against a production session store. The proof uses the real doctor repair function plus focused and full tests for the relevant doctor warning file.
- Before evidence: before this patch, the same `modelProvider: "openai"`, `model: "openai-codex/gpt-5.5"` shape repaired to `model: "openai/gpt-5.5"`, leaving a provider-prefixed model under canonical `modelProvider: "openai"`.

## Tests and validation

Commands run:

```bash
node scripts/run-vitest.mjs src/commands/doctor/shared/codex-route-warnings.test.ts --testNamePattern="repairs legacy Codex model refs under canonical OpenAI session providers|repairs persisted session route refs|repairs Telegram direct session routes"
node scripts/run-vitest.mjs src/commands/doctor/shared/codex-route-warnings.test.ts
pnpm exec oxlint src/commands/doctor/shared/codex-route-warnings.ts src/commands/doctor/shared/codex-route-warnings.test.ts
git diff --check
```

Results:

```text
[test] passed 1 Vitest shard in 26.02s
[test] passed 1 Vitest shard in 35.06s
Found 0 warnings and 0 errors.
```

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Running doctor/update on stale session stores produces cleaner canonical OpenAI session model state.

Did config, environment, or migration behavior change? (`Yes/No`)

Yes. Doctor session-store repair now normalizes this additional stale session shape.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

Accidentally changing providerless legacy model refs that need a provider prefix for later inference.

How is that risk mitigated?

The new unscoped rewrite applies only when the persisted session provider is already canonical `openai`; providerless legacy refs continue to use the existing `openai/...` canonical form. Existing full `codex-route-warnings` coverage still passes.

## Current review state

What is the next action?

Wait for CI and ClawSweeper review.

What is still waiting on author, maintainer, CI, or external proof?

CI/ClawSweeper are pending.

Which bot or reviewer comments were addressed?

None. This follows up on the remaining doctor-session repair gap rather than reviving the closed runtime shim from #90321.
