### PR TITLE
fix(tasks): allow cancellation of cron tasks with child sessions

### DIFF
--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -3449,6 +3449,48 @@ describe("task-registry", () => {
     });
   });
 
+  it("cancels cron tasks through the ACP session manager", async () => {
+    await withTaskRegistryTempDir(async () => {
+      hoisted.cancelSessionMock.mockResolvedValue(undefined);
+
+      const task = createTaskRecord({
+        runtime: "cron",
+        ownerKey: "system:cron:task-90630",
+        scopeKind: "system",
+        requesterOrigin: {
+          channel: "notifychat",
+          to: "notifychat:123",
+        },
+        childSessionKey: "agent:cron:task:child",
+        runId: "run-cancel-cron",
+        task: "Daily digest",
+        status: "running",
+        deliveryStatus: "pending",
+      });
+
+      const result = await cancelTaskById({
+        cfg: {} as never,
+        taskId: task.taskId,
+      });
+
+      const cancelArgs = firstMockArg(hoisted.cancelSessionMock, "cancelSession");
+      expectRecordFields(cancelArgs, {
+        cfg: {},
+        sessionKey: "agent:cron:task:child",
+        reason: "task-cancel",
+      });
+      expectRecordFields(result, {
+        found: true,
+        cancelled: true,
+      });
+      expectRecordFields(result.task, {
+        taskId: task.taskId,
+        status: "cancelled",
+        error: "Cancelled by operator.",
+      });
+    });
+  });
+
   it("cancels CLI-tracked tasks in the registry without ACP or subagent teardown", async () => {
     await withTaskRegistryTempDir(async () => {
       hoisted.cancelSessionMock.mockClear();

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -2094,7 +2094,7 @@ export async function cancelTaskById(params: {
         // Codex native subagents are mirrored from the Codex app server and do
         // not have OpenClaw child sessions to terminate. Cancellation clears
         // the stale task-registry record only.
-      } else if (task.runtime === "acp") {
+      } else if (task.runtime === "acp" || task.runtime === "cron") {
         const { getAcpSessionManager } = await loadTaskRegistryControlRuntime();
         await getAcpSessionManager().cancelSession({
           cfg: params.cfg,


### PR DESCRIPTION
## Summary

Fixes #90630: Cron tasks could not be cancelled via `openclaw tasks cancel <taskId>`, returning "Task runtime does not support cancellation yet." This made it impossible to stop runaway cron jobs consuming large token budgets or unhealthy MCP servers.

The fix adds `task.runtime === "cron"` to the existing ACP session cancellation path in `cancelTaskById`. Cron-backed agent sessions use the same session manager infrastructure as ACP sessions, so the same `cancelSession` call works for both.

### Change

[src/tasks/task-registry.ts](src/tasks/task-registry.ts): Added `|| task.runtime === "cron"` to the ACP cancellation branch so cron tasks with child sessions can be cancelled.

## Real behavior proof

**Behavior addressed:** `openclaw tasks cancel <taskId>` returns "Task runtime does not support cancellation yet." for cron tasks.

**Real environment tested:** macOS 26.1, Node.js 24, Vitest.

**Exact steps or command run after this patch:**
```
npx vitest run src/tasks/task-registry.test.ts --no-color
```

**Evidence after fix:**
```
Test Files  1 passed (1)
     Tests  75 passed (75)
```

New test: "cancels cron tasks through the ACP session manager" verifies:
- Cron task with `runtime: "cron"` and `childSessionKey` is cancelled successfully
- `cancelSession` is called with correct session key and reason
- Task status transitions to `cancelled` with error "Cancelled by operator."

**Observed result after fix:** Cron tasks with child sessions can be cancelled. The `cancelSession` path terminates the underlying cron agent session, same as ACP sessions.

**What was not tested:** Live end-to-end cancellation of a real running cron job with MCP server integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)