### PR TITLE
fix(cron): cancel active cron task runs

### DIFF
--- a/src/commands/tasks.test.ts
+++ b/src/commands/tasks.test.ts
@@ -18,7 +18,20 @@ import * as taskRegistryMaintenance from "../tasks/task-registry.maintenance.js"
 import type { TaskRecord } from "../tasks/task-registry.types.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import type { OpenClawTestState } from "../test-utils/openclaw-test-state.js";
-import { tasksAuditCommand, tasksMaintenanceCommand, tasksShowCommand } from "./tasks.js";
+import {
+  tasksAuditCommand,
+  tasksCancelCommand,
+  tasksMaintenanceCommand,
+  tasksShowCommand,
+} from "./tasks.js";
+
+const gatewayMocks = vi.hoisted(() => ({
+  callGateway: vi.fn(),
+}));
+
+vi.mock("../gateway/call.js", () => ({
+  callGateway: gatewayMocks.callGateway,
+}));
 
 function createRuntime(): RuntimeEnv {
   return {
@@ -96,6 +109,7 @@ describe("tasks commands", () => {
     resetTaskRegistryDeliveryRuntimeForTests();
     resetTaskRegistryForTests({ persist: false });
     resetTaskFlowRegistryForTests({ persist: false });
+    gatewayMocks.callGateway.mockReset();
   });
 
   it("keeps audit JSON stable and sorts combined findings before limiting", async () => {
@@ -166,6 +180,40 @@ describe("tasks commands", () => {
           flow: jsonRoundTrip(runningFlow),
         },
       ]);
+    });
+  });
+
+  it("routes cron task cancellation through the live Gateway", async () => {
+    await withTaskCommandStateDir(async () => {
+      const task = createTaskRecord({
+        runtime: "cron",
+        ownerKey: "",
+        scopeKind: "system",
+        childSessionKey: "agent:main:cron:daily:run:1",
+        runId: "cron:daily:1",
+        task: "Daily cron",
+        status: "running",
+        deliveryStatus: "not_applicable",
+      });
+      gatewayMocks.callGateway.mockResolvedValueOnce({
+        found: true,
+        cancelled: true,
+        task: { ...task, status: "cancelled" },
+      });
+
+      const runtime = createRuntime();
+      await tasksCancelCommand({ lookup: task.taskId }, runtime);
+
+      expect(gatewayMocks.callGateway).toHaveBeenCalledWith({
+        method: "tasks.cancel",
+        params: {
+          taskId: task.taskId,
+          reason: "Cancelled by operator.",
+        },
+        timeoutMs: 5_000,
+      });
+      expect(runtime.error).not.toHaveBeenCalled();
+      expect(runtime.log).toHaveBeenCalledWith(`Cancelled ${task.taskId} (cron) run cron:daily:1.`);
     });
   });
 

--- a/src/commands/tasks.ts
+++ b/src/commands/tasks.ts
@@ -16,6 +16,7 @@ import {
   type SessionEntry,
 } from "../config/sessions.js";
 import { loadCronJobsStoreSync, resolveCronJobsStorePath } from "../cron/store.js";
+import { callGateway } from "../gateway/call.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { parseAgentSessionKey } from "../sessions/session-key-utils.js";
 import { getTaskById, updateTaskNotifyPolicyById } from "../tasks/runtime-internal.js";
@@ -76,6 +77,38 @@ function formatTaskTimestamp(value: number | undefined): string {
 
 async function loadTaskCancelConfig() {
   return getRuntimeConfig();
+}
+
+type TaskCancelResult = {
+  found?: boolean;
+  cancelled?: boolean;
+  reason?: string;
+  task?: Pick<TaskRecord, "taskId" | "runtime" | "runId">;
+};
+
+async function cancelCronTaskThroughGateway(task: TaskRecord): Promise<TaskCancelResult> {
+  try {
+    return await callGateway<TaskCancelResult>({
+      method: "tasks.cancel",
+      params: {
+        taskId: task.taskId,
+        reason: "Cancelled by operator.",
+      },
+      timeoutMs: 5_000,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      found: true,
+      cancelled: false,
+      reason: [
+        "Cron task cancellation requires the live Gateway process that owns the cron run.",
+        `Gateway cancellation failed: ${message}`,
+        `Try ${formatCliCommand("openclaw gateway status --deep --require-rpc")} or restart the Gateway if the run is stuck.`,
+      ].join("\n"),
+      task,
+    };
+  }
 }
 
 function configureTaskMaintenanceFromConfig(): void {
@@ -498,10 +531,13 @@ export async function tasksCancelCommand(opts: { lookup: string }, runtime: Runt
     runtime.exit(1);
     return;
   }
-  const result = await cancelDetachedTaskRunById({
-    cfg: await loadTaskCancelConfig(),
-    taskId: task.taskId,
-  });
+  const result =
+    task.runtime === "cron"
+      ? await cancelCronTaskThroughGateway(task)
+      : await cancelDetachedTaskRunById({
+          cfg: await loadTaskCancelConfig(),
+          taskId: task.taskId,
+        });
   if (!result.found) {
     runtime.error(result.reason ?? formatTaskLookupMiss(opts.lookup));
     runtime.exit(1);
@@ -512,7 +548,7 @@ export async function tasksCancelCommand(opts: { lookup: string }, runtime: Runt
     runtime.exit(1);
     return;
   }
-  const updated = getTaskById(task.taskId);
+  const updated = result.task ?? getTaskById(task.taskId);
   runtime.log(
     `Cancelled ${updated?.taskId ?? task.taskId} (${updated?.runtime ?? task.runtime})${updated?.runId ? ` run ${updated.runId}` : ""}.`,
   );

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -3,6 +3,7 @@ import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/st
 import { enqueueCommandInLane } from "../../process/command-queue.js";
 import { CommandLane } from "../../process/lanes.js";
 import { DEFAULT_AGENT_ID } from "../../routing/session-key.js";
+import { registerActiveCronTaskRun } from "../../tasks/cron-task-cancel.js";
 import {
   completeTaskRunByRunId,
   createRunningTaskRun,
@@ -808,11 +809,16 @@ async function finishPreparedManualRun(
   const jobId = prepared.jobId;
   const taskRunId = prepared.taskRunId;
   const runId = prepared.runId;
+  const runAbortController = new AbortController();
+  const releaseCronTaskRun = registerActiveCronTaskRun({
+    runId: executionJob.sessionTarget === "main" ? undefined : taskRunId,
+    controller: runAbortController,
+  });
 
   try {
     let coreResult: Awaited<ReturnType<typeof executeJobCoreWithTimeout>>;
     try {
-      coreResult = await executeJobCoreWithTimeout(state, executionJob);
+      coreResult = await executeJobCoreWithTimeout(state, executionJob, runAbortController);
     } catch (err) {
       coreResult = { status: "error", error: normalizeCronRunErrorText(err) };
     }
@@ -899,6 +905,7 @@ async function finishPreparedManualRun(
       armTimer(state);
     });
   } finally {
+    releaseCronTaskRun?.();
     clearCronJobActive(jobId);
   }
 }

--- a/src/cron/service/timer.test.ts
+++ b/src/cron/service/timer.test.ts
@@ -4,10 +4,12 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { setupCronServiceSuite, writeCronStoreSnapshot } from "../../cron/service.test-harness.js";
 import { createCronServiceState } from "../../cron/service/state.js";
-import { executeJobCore, onTimer } from "../../cron/service/timer.js";
+import { executeJobCore, executeJobCoreWithTimeout, onTimer } from "../../cron/service/timer.js";
 import { loadCronStore } from "../../cron/store.js";
 import type { CronJob } from "../../cron/types.js";
+import { resetActiveCronTaskRunsForTests } from "../../tasks/cron-task-cancel.js";
 import * as detachedTaskRuntime from "../../tasks/detached-task-runtime.js";
+import { cancelDetachedTaskRunById } from "../../tasks/task-executor.js";
 import { findTaskByRunId, resetTaskRegistryForTests } from "../../tasks/task-registry.js";
 import { formatTaskStatusDetail } from "../../tasks/task-status.js";
 
@@ -48,6 +50,7 @@ function createDueIsolatedAgentJob(params: { now: number }): CronJob {
 }
 
 afterEach(() => {
+  resetActiveCronTaskRunsForTests();
   resetTaskRegistryForTests();
 });
 
@@ -269,6 +272,150 @@ describe("cron service timer seam coverage", () => {
     expect(formatTaskStatusDetail(task)).toBe("Running cron job.");
 
     resolveRun?.({ status: "ok", summary: "done" });
+    await timerRun;
+  });
+
+  it("cancels an active scheduled isolated cron task through the task ledger", async () => {
+    const { storePath } = await makeStorePath();
+    const now = Date.parse("2026-03-23T12:00:00.000Z");
+    const enqueueSystemEvent = vi.fn();
+    const requestHeartbeat = vi.fn();
+    let capturedAbortSignal: AbortSignal | undefined;
+    let resolveRun: ((value: { status: "ok"; summary: string }) => void) | undefined;
+    const runIsolatedAgentJob = vi.fn(
+      ({ abortSignal }: { abortSignal?: AbortSignal }) =>
+        new Promise<{ status: "ok"; summary: string }>((resolve) => {
+          capturedAbortSignal = abortSignal;
+          resolveRun = resolve;
+        }),
+    );
+
+    await writeCronStoreSnapshot({
+      storePath,
+      jobs: [createDueIsolatedAgentJob({ now })],
+    });
+
+    const state = createCronServiceState({
+      storePath,
+      cronEnabled: true,
+      log: logger,
+      nowMs: () => now,
+      enqueueSystemEvent,
+      requestHeartbeat,
+      runIsolatedAgentJob,
+    });
+
+    const timerRun = onTimer(state);
+    await vi.waitFor(() => {
+      expect(runIsolatedAgentJob).toHaveBeenCalledTimes(1);
+    });
+
+    const task = findTaskByRunId(`cron:isolated-agent-job:${now}`);
+    if (!task) {
+      throw new Error("expected active cron task ledger record");
+    }
+
+    const cancelled = await cancelDetachedTaskRunById({
+      cfg: {} as never,
+      taskId: task.taskId,
+    });
+
+    expect(cancelled.cancelled).toBe(true);
+    expect(capturedAbortSignal?.aborted).toBe(true);
+    expect(findTaskByRunId(`cron:isolated-agent-job:${now}`)?.status).toBe("cancelled");
+
+    resolveRun?.({ status: "ok", summary: "done" });
+    await timerRun;
+    expect(findTaskByRunId(`cron:isolated-agent-job:${now}`)?.status).toBe("cancelled");
+  });
+
+  it("keeps timeout watchdog as a backstop after operator cancellation", async () => {
+    vi.useFakeTimers();
+    const { storePath } = await makeStorePath();
+    const now = Date.parse("2026-03-23T12:00:00.000Z");
+    const controller = new AbortController();
+    const runIsolatedAgentJob = vi.fn(({ onExecutionStarted }) => {
+      onExecutionStarted?.({ phase: "running" });
+      return new Promise<never>(() => {});
+    });
+    const state = createCronServiceState({
+      storePath,
+      cronEnabled: true,
+      log: logger,
+      nowMs: () => now,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob,
+      cleanupTimedOutAgentRun: vi.fn(async () => {}),
+    });
+    const job: CronJob = {
+      ...createDueIsolatedAgentJob({ now }),
+      payload: { kind: "agentTurn", message: "ignore abort", timeoutSeconds: 1 },
+    };
+
+    const resultPromise = executeJobCoreWithTimeout(state, job, controller);
+    await vi.waitFor(() => {
+      expect(runIsolatedAgentJob).toHaveBeenCalledTimes(1);
+    });
+    controller.abort("Cancelled by operator.");
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    await expect(resultPromise).resolves.toMatchObject({
+      status: "error",
+      error: expect.stringContaining("timed out"),
+    });
+    expect(state.deps.cleanupTimedOutAgentRun).toHaveBeenCalled();
+  });
+
+  it("does not report main-session cron tasks as cancelled after enqueue", async () => {
+    const { storePath } = await makeStorePath();
+    const now = Date.parse("2026-03-23T12:00:00.000Z");
+    const enqueueSystemEvent = vi.fn();
+    const requestHeartbeat = vi.fn();
+    let resolveHeartbeat: ((value: { status: "ran"; durationMs: number }) => void) | undefined;
+    const runHeartbeatOnce = vi.fn(
+      () =>
+        new Promise<{ status: "ran"; durationMs: number }>((resolve) => {
+          resolveHeartbeat = resolve;
+        }),
+    );
+
+    await writeCronStoreSnapshot({
+      storePath,
+      jobs: [createDueMainJob({ now, wakeMode: "now" })],
+    });
+
+    const state = createCronServiceState({
+      storePath,
+      cronEnabled: true,
+      log: logger,
+      nowMs: () => now,
+      enqueueSystemEvent,
+      requestHeartbeat,
+      runHeartbeatOnce,
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+    });
+
+    const timerRun = onTimer(state);
+    await vi.waitFor(() => {
+      expect(runHeartbeatOnce).toHaveBeenCalledTimes(1);
+    });
+
+    const task = findTaskByRunId(`cron:main-heartbeat-job:${now}`);
+    if (!task) {
+      throw new Error("expected active main-session cron task ledger record");
+    }
+
+    const cancelled = await cancelDetachedTaskRunById({
+      cfg: {} as never,
+      taskId: task.taskId,
+    });
+
+    expect(cancelled.cancelled).toBe(false);
+    expect(cancelled.reason).toContain("main-session cron jobs enqueue work");
+    expect(findTaskByRunId(`cron:main-heartbeat-job:${now}`)?.status).toBe("running");
+
+    resolveHeartbeat?.({ status: "ran", durationMs: 1 });
     await timerRun;
   });
 

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -13,6 +13,7 @@ import {
   normalizeAgentId,
   resolveAgentIdFromSessionKey,
 } from "../../routing/session-key.js";
+import { registerActiveCronTaskRun } from "../../tasks/cron-task-cancel.js";
 import { deliveryContextFromSession } from "../../utils/delivery-context.shared.js";
 import type { DeliveryContext } from "../../utils/delivery-context.types.js";
 import { clearCronJobActive, markCronJobActive } from "../active-jobs.js";
@@ -121,13 +122,13 @@ type StartupCatchupPlan = {
 export async function executeJobCoreWithTimeout(
   state: CronServiceState,
   job: CronJob,
+  runAbortController = new AbortController(),
 ): Promise<Awaited<ReturnType<typeof executeJobCore>>> {
   const jobTimeoutMs = resolveCronJobTimeoutMs(job);
   if (typeof jobTimeoutMs !== "number") {
-    return await executeJobCore(state, job);
+    return await executeJobCore(state, job, runAbortController.signal);
   }
 
-  const runAbortController = new AbortController();
   let timeoutReason: string | undefined;
   const timeoutMarker = Symbol("cron-timeout");
   let resolveTimeout: ((value: typeof timeoutMarker) => void) | undefined;
@@ -141,6 +142,8 @@ export async function executeJobCoreWithTimeout(
     job.sessionTarget !== "main" && job.payload.kind === "agentTurn";
   const triggerTimeout = (reason: string) => {
     if (runAbortController.signal.aborted) {
+      timeoutReason = reason;
+      resolveTimeout?.(timeoutMarker);
       return;
     }
     timeoutReason = reason;
@@ -842,9 +845,14 @@ export async function onTimer(state: CronServiceState) {
       emit(state, { jobId: job.id, action: "started", job, runAtMs: startedAt });
       const jobTimeoutMs = resolveCronJobTimeoutMs(job);
       const taskRunId = tryCreateCronTaskRun({ state, job, startedAt });
+      const runAbortController = new AbortController();
+      const releaseCronTaskRun = registerActiveCronTaskRun({
+        runId: job.sessionTarget === "main" ? undefined : taskRunId,
+        controller: runAbortController,
+      });
 
       try {
-        const result = await executeJobCoreWithTimeout(state, job);
+        const result = await executeJobCoreWithTimeout(state, job, runAbortController);
         return {
           jobId: id,
           job,
@@ -871,6 +879,8 @@ export async function onTimer(state: CronServiceState) {
           startedAt,
           endedAt: state.deps.nowMs(),
         };
+      } finally {
+        releaseCronTaskRun?.();
       }
     };
 
@@ -1231,6 +1241,11 @@ async function runStartupCatchupCandidate(
     job: candidate.job,
     startedAt,
   });
+  const runAbortController = new AbortController();
+  const releaseCronTaskRun = registerActiveCronTaskRun({
+    runId: candidate.job.sessionTarget === "main" ? undefined : taskRunId,
+    controller: runAbortController,
+  });
   emit(state, {
     jobId: candidate.job.id,
     action: "started",
@@ -1238,7 +1253,7 @@ async function runStartupCatchupCandidate(
     runAtMs: startedAt,
   });
   try {
-    const result = await executeJobCoreWithTimeout(state, candidate.job);
+    const result = await executeJobCoreWithTimeout(state, candidate.job, runAbortController);
     return {
       jobId: candidate.jobId,
       job: candidate.job,
@@ -1269,6 +1284,8 @@ async function runStartupCatchupCandidate(
       startedAt,
       endedAt: state.deps.nowMs(),
     };
+  } finally {
+    releaseCronTaskRun?.();
   }
 }
 
@@ -1418,7 +1435,7 @@ async function executeMainSessionCronJob(
     let heartbeatResult: HeartbeatRunResult;
     for (;;) {
       if (abortSignal?.aborted) {
-        return { status: "error", error: timeoutErrorMessage() };
+        return { status: "error", error: abortErrorMessage(abortSignal) };
       }
       heartbeatResult = await state.deps.runHeartbeatOnce({
         source: "cron",
@@ -1447,11 +1464,11 @@ async function executeMainSessionCronJob(
         return { status: "ok", summary: text, sessionKey: cronRunSessionKey };
       }
       if (abortSignal?.aborted) {
-        return { status: "error", error: timeoutErrorMessage() };
+        return { status: "error", error: abortErrorMessage(abortSignal) };
       }
       if (state.deps.nowMs() - waitStartedAt > maxWaitMs) {
         if (abortSignal?.aborted) {
-          return { status: "error", error: timeoutErrorMessage() };
+          return { status: "error", error: abortErrorMessage(abortSignal) };
         }
         state.deps.requestHeartbeat({
           source: "cron",
@@ -1486,7 +1503,7 @@ async function executeMainSessionCronJob(
   }
 
   if (abortSignal?.aborted) {
-    return { status: "error", error: timeoutErrorMessage() };
+    return { status: "error", error: abortErrorMessage(abortSignal) };
   }
   state.deps.requestHeartbeat({
     source: "cron",

--- a/src/gateway/server-methods/tasks.test.ts
+++ b/src/gateway/server-methods/tasks.test.ts
@@ -6,6 +6,10 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  registerActiveCronTaskRun,
+  resetActiveCronTaskRunsForTests,
+} from "../../tasks/cron-task-cancel.js";
+import {
   createTaskRecord as createTaskRecordOrNull,
   markTaskTerminalById,
   recordTaskProgressByRunId,
@@ -37,10 +41,12 @@ beforeEach(async () => {
   stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gateway-tasks-"));
   process.env.OPENCLAW_STATE_DIR = stateDir;
   resetTaskRegistryForTests();
+  resetActiveCronTaskRunsForTests();
 });
 
 afterEach(async () => {
   resetTaskRegistryForTests();
+  resetActiveCronTaskRunsForTests();
   if (ORIGINAL_STATE_DIR === undefined) {
     delete process.env.OPENCLAW_STATE_DIR;
   } else {
@@ -212,5 +218,40 @@ describe("tasks gateway handlers", () => {
     expect(payload?.task?.id).toBe(task.taskId);
     expect(payload?.task?.status).toBe("cancelled");
     expect(payload?.task?.error).toBe("user stopped task");
+  });
+
+  it("cancels active cron task records through the owning Gateway process", async () => {
+    const controller = new AbortController();
+    const task = createTaskRecord({
+      runtime: "cron",
+      ownerKey: "",
+      scopeKind: "system",
+      childSessionKey: "agent:main:cron:daily:run:1",
+      runId: "cron:daily:1",
+      task: "Daily cron",
+      status: "running",
+      deliveryStatus: "not_applicable",
+    });
+    const release = registerActiveCronTaskRun({
+      runId: task.runId,
+      controller,
+    });
+
+    try {
+      const { calls, payload } = await runTaskHandler("tasks.cancel", {
+        taskId: task.taskId,
+        reason: "operator stopped cron",
+      });
+
+      expect(calls[0]?.[0]).toBe(true);
+      expect(payload?.found).toBe(true);
+      expect(payload?.cancelled).toBe(true);
+      expect(controller.signal.aborted).toBe(true);
+      expect(controller.signal.reason).toBe("operator stopped cron");
+      expect(payload?.task?.id).toBe(task.taskId);
+      expect(payload?.task?.status).toBe("cancelled");
+    } finally {
+      release?.();
+    }
   });
 });

--- a/src/tasks/cron-task-cancel.ts
+++ b/src/tasks/cron-task-cancel.ts
@@ -1,0 +1,45 @@
+// Process-local cancellation handles for live cron task runs.
+
+type CronTaskCancelHandle = {
+  controller: AbortController;
+};
+
+const activeCronTaskRunsByRunId = new Map<string, CronTaskCancelHandle>();
+
+export function registerActiveCronTaskRun(params: {
+  runId: string | undefined;
+  controller: AbortController;
+}): (() => void) | undefined {
+  const runId = params.runId?.trim();
+  if (!runId) {
+    return undefined;
+  }
+  activeCronTaskRunsByRunId.set(runId, { controller: params.controller });
+  return () => {
+    if (activeCronTaskRunsByRunId.get(runId)?.controller === params.controller) {
+      activeCronTaskRunsByRunId.delete(runId);
+    }
+  };
+}
+
+export function cancelActiveCronTaskRun(params: {
+  runId: string | undefined;
+  reason?: string;
+}): boolean {
+  const runId = params.runId?.trim();
+  if (!runId) {
+    return false;
+  }
+  const handle = activeCronTaskRunsByRunId.get(runId);
+  if (!handle) {
+    return false;
+  }
+  if (!handle.controller.signal.aborted) {
+    handle.controller.abort(params.reason?.trim() || "Cancelled by operator.");
+  }
+  return true;
+}
+
+export function resetActiveCronTaskRunsForTests(): void {
+  activeCronTaskRunsByRunId.clear();
+}

--- a/src/tasks/task-executor.test.ts
+++ b/src/tasks/task-executor.test.ts
@@ -5,6 +5,7 @@ import { resetHeartbeatWakeStateForTests } from "../infra/heartbeat-wake.js";
 import { resetSystemEventsForTest } from "../infra/system-events.js";
 import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
 import { captureEnv } from "../test-utils/env.js";
+import { registerActiveCronTaskRun, resetActiveCronTaskRunsForTests } from "./cron-task-cancel.js";
 import {
   getDetachedTaskLifecycleRuntime,
   resetDetachedTaskLifecycleRuntimeForTests,
@@ -126,6 +127,7 @@ async function withTaskExecutorStateDir(run: (stateDir: string) => Promise<void>
       resetAgentEventsForTest();
       resetTaskRegistryDeliveryRuntimeForTests();
       resetTaskRegistryControlRuntimeForTests();
+      resetActiveCronTaskRunsForTests();
       resetAgentRunContextForTest();
       resetTaskRegistryForTests({ persist: false });
       resetTaskFlowRegistryForTests({ persist: false });
@@ -217,6 +219,7 @@ describe("task-executor", () => {
     resetAgentEventsForTest();
     resetTaskRegistryDeliveryRuntimeForTests();
     resetTaskRegistryControlRuntimeForTests();
+    resetActiveCronTaskRunsForTests();
     resetAgentRunContextForTest();
     resetTaskRegistryForTests({ persist: false });
     resetTaskFlowRegistryForTests({ persist: false });
@@ -772,6 +775,64 @@ describe("task-executor", () => {
       expect(task?.taskId).toBe(child.taskId);
       expect(task?.status).toBe("running");
       expect(hoisted.cancelSessionMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it("aborts active cron task runs before marking the task cancelled", async () => {
+    await withTaskExecutorStateDir(async () => {
+      const controller = new AbortController();
+      const task = createRunningTaskRun({
+        runtime: "cron",
+        ownerKey: "",
+        scopeKind: "system",
+        runId: "cron:nightly:1",
+        task: "Nightly cron",
+        startedAt: 10,
+        deliveryStatus: "not_applicable",
+      });
+      const release = registerActiveCronTaskRun({
+        runId: task.runId,
+        controller,
+      });
+
+      try {
+        const cancelled = await cancelDetachedTaskRunById({
+          cfg: {} as never,
+          taskId: task.taskId,
+        });
+
+        expect(cancelled.found).toBe(true);
+        expect(cancelled.cancelled).toBe(true);
+        expect(controller.signal.aborted).toBe(true);
+        expect(controller.signal.reason).toBe("Cancelled by operator.");
+        expect(getTaskById(task.taskId)?.status).toBe("cancelled");
+      } finally {
+        release?.();
+      }
+    });
+  });
+
+  it("explains cron task cancellation when this process does not own the run", async () => {
+    await withTaskExecutorStateDir(async () => {
+      const task = createRunningTaskRun({
+        runtime: "cron",
+        ownerKey: "",
+        scopeKind: "system",
+        runId: "cron:nightly:1",
+        task: "Nightly cron",
+        startedAt: 10,
+        deliveryStatus: "not_applicable",
+      });
+
+      const cancelled = await cancelDetachedTaskRunById({
+        cfg: {} as never,
+        taskId: task.taskId,
+      });
+
+      expect(cancelled.found).toBe(true);
+      expect(cancelled.cancelled).toBe(false);
+      expect(cancelled.reason).toContain("not currently cancellable by this Gateway process");
+      expect(getTaskById(task.taskId)?.status).toBe("running");
     });
   });
 

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -18,6 +18,7 @@ import { parseAgentSessionKey } from "../routing/session-key.js";
 import { normalizeDeliveryContext } from "../utils/delivery-context.shared.js";
 import { isDeliverableMessageChannel } from "../utils/message-channel.js";
 import { isChildlessCodexNativeSubagentTask } from "./codex-native-subagent-task.js";
+import { cancelActiveCronTaskRun } from "./cron-task-cancel.js";
 import {
   formatTaskBlockedFollowupMessage,
   formatTaskStateChangeMessage,
@@ -2080,7 +2081,17 @@ export async function cancelTaskById(params: {
   const childSessionKey = task.childSessionKey?.trim();
   try {
     if (task.runtime !== "cli") {
-      if (!childSessionKey) {
+      if (task.runtime === "cron") {
+        if (!cancelActiveCronTaskRun({ runId: task.runId, reason: params.reason })) {
+          return {
+            found: true,
+            cancelled: false,
+            reason:
+              "Cron task is not currently cancellable by this Gateway process. Isolated cron agent runs can be cancelled while active; main-session cron jobs enqueue work into their target session. Stop the target session or restart the Gateway if it is stuck.",
+            task: cloneTaskRecord(task),
+          };
+        }
+      } else if (!childSessionKey) {
         if (!isChildlessCodexNativeSubagentTask(task)) {
           return {
             found: true,
@@ -2090,7 +2101,9 @@ export async function cancelTaskById(params: {
           };
         }
       }
-      if (!childSessionKey) {
+      if (task.runtime === "cron") {
+        // Cron cancellation already aborted the active controller above.
+      } else if (!childSessionKey) {
         // Codex native subagents are mirrored from the Codex app server and do
         // not have OpenClaw child sessions to terminate. Cancellation clears
         // the stale task-registry record only.


### PR DESCRIPTION
## Summary

Fixes #90630.

- routes `openclaw tasks cancel` for cron task records through the live Gateway `tasks.cancel` method, because the active cron abort signal is process-owned
- registers cancellable handles for active isolated cron agent runs and finalizes the existing task record through the task registry cancellation path
- keeps main-session cron jobs explicitly non-cancellable from the cron task row, because those jobs enqueue work into the target session rather than owning an isolated run
- preserves the cron timeout watchdog after operator cancellation so a runner that ignores abort still gets timeout cleanup

This is an alternative focused fix to #90666 and #90669. #90669 only routes cron through the ACP branch. #90666 is closer, but it couples cancellation state to the duplicate-run active job marker and returns early from the timeout trigger after operator abort, which can remove the watchdog cleanup path for runners that ignore abort.

## Verification

- `node scripts/run-vitest.mjs src/tasks/task-executor.test.ts src/gateway/server-methods/tasks.test.ts src/cron/service/timer.test.ts src/commands/tasks.test.ts`
- `node scripts/run-vitest.mjs src/cli/program/register.status-health-sessions.test.ts src/commands/tasks.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/tasks/cron-task-cancel.ts src/tasks/task-registry.ts src/cron/service/timer.ts src/cron/service/ops.ts src/commands/tasks.ts src/tasks/task-executor.test.ts src/gateway/server-methods/tasks.test.ts src/cron/service/timer.test.ts src/commands/tasks.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

## Real behavior proof

Behavior addressed: a running isolated cron task listed by the task ledger can now be cancelled through the Gateway-owned cron runtime instead of falling through to `Task runtime does not support cancellation yet.`

Real environment tested: local OpenClaw source checkout on this branch, exercising the real task ledger, active cron cancellation handle, and cancellation executor in a non-test Node process with an isolated `OPENCLAW_STATE_DIR`.

Exact steps or command run after this patch: `OPENCLAW_STATE_DIR=$(mktemp -d /tmp/openclaw-cron-proof-XXXXXX) node --import tsx -e '<script creating a running cron task row, registering its active cron abort handle, then calling cancelDetachedTaskRunById>'`.

Evidence after fix:

```text
stateDir=/tmp/openclaw-cron-proof-gmSRfe
before taskId=5a77ee32-509f-48de-ac6d-3cdf5b6c622b runtime=cron status=running runId=cron:proof-cron-job:live
cancel found=true cancelled=true reason=
signal aborted=true reason=Cancelled by operator.
after taskId=5a77ee32-509f-48de-ac6d-3cdf5b6c622b runtime=cron status=cancelled error=Cancelled by operator.
```

Observed result after fix: the running cron task row was cancelled, the underlying AbortSignal was aborted with `Cancelled by operator.`, and the task ledger status became `cancelled` with the same terminal error. Focused regression shards also passed and cover Gateway cancellation of an active cron handle, childless active cron task cancellation, explicit non-cancellable main-session cron behavior, CLI Gateway routing, and watchdog timeout cleanup after operator abort.

What was not tested: a live installed `openclaw gateway` smoke on this laptop was blocked by an already-running local Gateway/dist startup timeout, and Testbox-through-Crabbox was blocked by the local `crabbox` binary failing basic sanity checks before lease creation.
