### PR TITLE
fix(telegram): report blocked group ingress in /status

### DIFF
--- a/extensions/telegram/src/bot-native-commands.group-auth.test.ts
+++ b/extensions/telegram/src/bot-native-commands.group-auth.test.ts
@@ -7,7 +7,9 @@ import {
   createNativeCommandsHarness,
   createTelegramDmCommandContext,
   createTelegramGroupCommandContext,
+  clearNativeCommandRuntimeMocksForTest,
   findNotAuthorizedCalls,
+  getFinalizedNativeCommandContextsForTest,
 } from "./bot-native-commands.test-helpers.js";
 
 describe("native command auth in groups", () => {
@@ -69,14 +71,21 @@ describe("native command auth in groups", () => {
   });
 
   it("authorizes native commands in groups from commands.allowFrom.telegram", async () => {
+    clearNativeCommandRuntimeMocksForTest();
     const { handlers, sendMessage } = setup({
       cfg: {
+        channels: {
+          telegram: {
+            groupPolicy: "allowlist",
+          },
+        },
         commands: {
           allowFrom: {
             telegram: ["12345"],
           },
         },
       } as OpenClawConfig,
+      telegramCfg: { groupPolicy: "allowlist" } as TelegramAccountConfig,
       allowFrom: ["99999"],
       groupAllowFrom: ["99999"],
       useAccessGroups: true,
@@ -88,6 +97,15 @@ describe("native command auth in groups", () => {
 
     const notAuthCalls = findNotAuthorizedCalls(sendMessage);
     expect(notAuthCalls).toHaveLength(0);
+
+    const contexts = getFinalizedNativeCommandContextsForTest();
+    expect(contexts.at(-1)).toMatchObject({
+      StatusNotes: [
+        expect.stringContaining(
+          "Telegram commands are authorized, but normal group messages are blocked by groupPolicy=allowlist: sender does not match allowFrom.",
+        ),
+      ],
+    });
   });
 
   it("uses commands.allowFrom.telegram as the sole auth source when configured", async () => {

--- a/extensions/telegram/src/bot-native-commands.group-auth.test.ts
+++ b/extensions/telegram/src/bot-native-commands.group-auth.test.ts
@@ -136,7 +136,8 @@ describe("native command auth in groups", () => {
     expect(contexts.at(-1)).toMatchObject({
       StatusNotes: [expect.stringContaining("no effective allowFrom entries")],
     });
-    expect(contexts.at(-1)?.StatusNotes?.[0]).not.toContain("sender allowed=");
+    const finalizedContext = contexts.at(-1) as { StatusNotes?: string[] } | undefined;
+    expect(finalizedContext?.StatusNotes?.[0]).not.toContain("sender allowed=");
   });
 
   it("uses commands.allowFrom.telegram as the sole auth source when configured", async () => {

--- a/extensions/telegram/src/bot-native-commands.group-auth.test.ts
+++ b/extensions/telegram/src/bot-native-commands.group-auth.test.ts
@@ -108,6 +108,37 @@ describe("native command auth in groups", () => {
     });
   });
 
+  it("omits sender-allowed status detail when normal ingress has an empty allowlist", async () => {
+    clearNativeCommandRuntimeMocksForTest();
+    const { handlers, sendMessage } = setup({
+      cfg: {
+        channels: {
+          telegram: {
+            groupPolicy: "allowlist",
+          },
+        },
+        commands: {
+          allowFrom: {
+            telegram: ["12345"],
+          },
+        },
+      } as OpenClawConfig,
+      telegramCfg: { groupPolicy: "allowlist" } as TelegramAccountConfig,
+      useAccessGroups: true,
+    });
+
+    const ctx = createTelegramGroupCommandContext();
+
+    await handlers.status?.(ctx);
+
+    expect(findNotAuthorizedCalls(sendMessage)).toHaveLength(0);
+    const contexts = getFinalizedNativeCommandContextsForTest();
+    expect(contexts.at(-1)).toMatchObject({
+      StatusNotes: [expect.stringContaining("no effective allowFrom entries")],
+    });
+    expect(contexts.at(-1)?.StatusNotes?.[0]).not.toContain("sender allowed=");
+  });
+
   it("uses commands.allowFrom.telegram as the sole auth source when configured", async () => {
     const { handlers, sendMessage } = setup({
       cfg: {

--- a/extensions/telegram/src/bot-native-commands.test-helpers.ts
+++ b/extensions/telegram/src/bot-native-commands.test-helpers.ts
@@ -244,3 +244,13 @@ export function findNotAuthorizedCalls(sendMessage: AnyAsyncMock) {
     (call) => typeof call[1] === "string" && call[1].includes("not authorized"),
   );
 }
+
+export function getFinalizedNativeCommandContextsForTest() {
+  return replyPipelineMocks.finalizeInboundContext.mock.calls.map((call) => call[0]);
+}
+
+export function clearNativeCommandRuntimeMocksForTest() {
+  replyPipelineMocks.finalizeInboundContext.mockClear();
+  replyPipelineMocks.dispatchReplyWithBufferedBlockDispatcher.mockClear();
+  replyPipelineMocks.recordInboundSessionMetaSafe.mockClear();
+}

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -53,7 +53,13 @@ import {
 import { expandTelegramAllowFromWithAccessGroups } from "./access-groups.js";
 import { resolveTelegramAccount } from "./accounts.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
-import { normalizeDmAllowFromWithStore, resolveTelegramEffectiveDmPolicy } from "./bot-access.js";
+import {
+  firstDefined,
+  isSenderAllowed,
+  normalizeDmAllowFromWithStore,
+  type NormalizedAllowFrom,
+  resolveTelegramEffectiveDmPolicy,
+} from "./bot-access.js";
 import type { TelegramBotDeps } from "./bot-deps.js";
 import type { TelegramMediaRef } from "./bot-message-context.js";
 import type { TelegramMessageContextOptions } from "./bot-message-context.types.js";
@@ -142,6 +148,7 @@ type TelegramCommandAuthResult = {
   topicConfig?: TelegramTopicConfig;
   commandAuthorized: boolean;
   senderIsOwner: boolean;
+  statusNotes?: string[];
 };
 
 type TelegramNativeCommandThreadContext = {
@@ -393,6 +400,85 @@ function resolveTelegramFastCommandState(params: {
   } catch {
     return fallback();
   }
+}
+
+function formatTelegramNormalIngressStatusNote(params: {
+  isGroup: boolean;
+  chatId: string | number;
+  cfg: OpenClawConfig;
+  telegramCfg: TelegramAccountConfig;
+  topicConfig?: TelegramTopicConfig;
+  groupConfig?: TelegramGroupConfig;
+  effectiveGroupAllow: NormalizedAllowFrom;
+  senderId: string;
+  senderUsername: string;
+  resolveGroupPolicy: (chatId: string | number) => ChannelGroupPolicy;
+  useAccessGroups: boolean;
+}): string | undefined {
+  if (!params.isGroup || !params.useAccessGroups) {
+    return undefined;
+  }
+  const policyAccess = evaluateTelegramGroupPolicyAccess({
+    isGroup: params.isGroup,
+    chatId: params.chatId,
+    cfg: params.cfg,
+    telegramCfg: params.telegramCfg,
+    topicConfig: params.topicConfig,
+    groupConfig: params.groupConfig,
+    effectiveGroupAllow: params.effectiveGroupAllow,
+    senderId: params.senderId,
+    senderUsername: params.senderUsername,
+    resolveGroupPolicy: params.resolveGroupPolicy,
+    enforcePolicy: true,
+    useTopicAndGroupOverrides: true,
+    enforceAllowlistAuthorization: true,
+    allowEmptyAllowlistEntries: false,
+    requireSenderForAllowlistAuthorization: true,
+    checkChatAllowlist: true,
+  });
+  if (policyAccess.allowed) {
+    return undefined;
+  }
+
+  const chatPolicy = params.resolveGroupPolicy(params.chatId);
+  const requireMention = firstDefined(
+    params.topicConfig?.requireMention,
+    params.groupConfig?.requireMention,
+    chatPolicy.groupConfig?.requireMention,
+    chatPolicy.defaultConfig?.requireMention,
+  );
+  const senderAllowedDetail = params.effectiveGroupAllow.hasEntries
+    ? [
+        `sender allowed=${isSenderAllowed({
+          allow: params.effectiveGroupAllow,
+          senderId: params.senderId,
+          senderUsername: params.senderUsername,
+        })}`,
+      ]
+    : [];
+  const reason = (() => {
+    if (policyAccess.reason === "group-policy-allowlist-empty") {
+      return "no effective allowFrom entries";
+    }
+    if (policyAccess.reason === "group-policy-allowlist-unauthorized") {
+      return "sender does not match allowFrom";
+    }
+    if (policyAccess.reason === "group-policy-allowlist-no-sender") {
+      return "message has no sender id";
+    }
+    if (policyAccess.reason === "group-chat-not-allowed") {
+      return "chat is not allowed by groups";
+    }
+    return "group messages are disabled";
+  })();
+
+  return [
+    `Telegram commands are authorized, but normal group messages are blocked by groupPolicy=${policyAccess.groupPolicy}: ${reason}.`,
+    `groups allowed=${chatPolicy.allowed}`,
+    `requireMention=${requireMention ?? "default"}`,
+    `allowFrom configured=${params.effectiveGroupAllow.hasEntries}`,
+    ...senderAllowedDetail,
+  ].join(" ");
 }
 
 async function resolveTelegramDefaultThinkingLevel(params: {
@@ -831,6 +917,19 @@ async function resolveTelegramCommandAuth(params: {
   if (requireAuth && !commandAuthorized) {
     return await rejectNotAuthorized();
   }
+  const normalIngressStatusNote = formatTelegramNormalIngressStatusNote({
+    isGroup,
+    chatId,
+    cfg,
+    telegramCfg,
+    topicConfig,
+    groupConfig,
+    effectiveGroupAllow,
+    senderId,
+    senderUsername,
+    resolveGroupPolicy,
+    useAccessGroups,
+  });
 
   return {
     chatId,
@@ -843,6 +942,7 @@ async function resolveTelegramCommandAuth(params: {
     topicConfig,
     commandAuthorized,
     senderIsOwner: ownerAccess.senderIsOwner,
+    statusNotes: normalIngressStatusNote ? [normalIngressStatusNote] : undefined,
   };
 }
 
@@ -1231,6 +1331,7 @@ export const registerTelegramNativeCommands = ({
         const executionCfg = getRuntimeConfigSnapshot() ?? cfg;
 
         const commandDefinition = findCommandByNativeName(command.name, "telegram");
+        const statusNotes = commandDefinition?.key === "status" ? auth.statusNotes : undefined;
         const rawText = ctx.match?.trim() ?? "";
         const commandArgs = commandDefinition
           ? parseCommandArgs(commandDefinition, rawText)
@@ -1535,6 +1636,7 @@ export const registerTelegramNativeCommands = ({
           Timestamp: msg.date ? msg.date * 1000 : undefined,
           WasMentioned: true,
           CommandAuthorized: commandAuthorized,
+          ...(statusNotes ? { StatusNotes: statusNotes } : {}),
           CommandTurn: {
             kind: "native" as const,
             source: "native" as const,

--- a/src/auto-reply/reply/commands-info.ts
+++ b/src/auto-reply/reply/commands-info.ts
@@ -284,6 +284,7 @@ export const handleStatusCommand: CommandHandler = async (params, allowTextComma
   const targetSessionEntry = params.sessionStore?.[params.sessionKey] ?? params.sessionEntry;
   const reply = await buildStatusReply({
     cfg: params.cfg,
+    ctx: params.ctx,
     command: params.command,
     sessionEntry: targetSessionEntry,
     sessionKey: params.sessionKey,

--- a/src/auto-reply/reply/commands-status.test.ts
+++ b/src/auto-reply/reply/commands-status.test.ts
@@ -107,6 +107,7 @@ async function buildStatusReplyForTest(params: { sessionKey?: string; verbose?: 
   const sessionKey = params.sessionKey ?? commandParams.sessionKey;
   return await buildStatusReply({
     cfg: baseCfg,
+    ctx: {},
     command: commandParams.command,
     sessionEntry: commandParams.sessionEntry,
     sessionKey,
@@ -119,6 +120,34 @@ async function buildStatusReplyForTest(params: { sessionKey?: string; verbose?: 
     resolvedThinkLevel: commandParams.resolvedThinkLevel,
     resolvedFastMode: false,
     resolvedVerboseLevel: params.verbose ? "on" : commandParams.resolvedVerboseLevel,
+    resolvedReasoningLevel: commandParams.resolvedReasoningLevel,
+    resolvedElevatedLevel: commandParams.resolvedElevatedLevel,
+    resolveDefaultThinkingLevel: commandParams.resolveDefaultThinkingLevel,
+    isGroup: commandParams.isGroup,
+    defaultGroupActivation: commandParams.defaultGroupActivation,
+    modelAuthOverride: "api-key",
+    activeModelAuthOverride: "api-key",
+  });
+}
+
+async function buildStatusReplyTextForTest(params: { statusNotes?: string[] }) {
+  const commandParams = buildCommandTestParams("/status", baseCfg);
+  const ctx = params.statusNotes ? { StatusNotes: params.statusNotes } : {};
+  return await buildStatusReply({
+    cfg: baseCfg,
+    ctx,
+    command: commandParams.command,
+    sessionEntry: commandParams.sessionEntry,
+    sessionKey: commandParams.sessionKey,
+    parentSessionKey: commandParams.sessionKey,
+    sessionScope: commandParams.sessionScope,
+    storePath: commandParams.storePath,
+    provider: "anthropic",
+    model: "claude-opus-4-6",
+    contextTokens: 0,
+    resolvedThinkLevel: commandParams.resolvedThinkLevel,
+    resolvedFastMode: false,
+    resolvedVerboseLevel: commandParams.resolvedVerboseLevel,
     resolvedReasoningLevel: commandParams.resolvedReasoningLevel,
     resolvedElevatedLevel: commandParams.resolvedElevatedLevel,
     resolveDefaultThinkingLevel: commandParams.resolveDefaultThinkingLevel,
@@ -308,6 +337,16 @@ describe("buildStatusReply subagent summary", () => {
     const reply = await buildStatusReplyForTest({});
 
     expect(reply?.text).toContain("🤖 Subagents: 1 active");
+  });
+
+  it("appends channel supplied status notes", async () => {
+    const reply = await buildStatusReplyTextForTest({
+      statusNotes: ["Telegram commands work, but normal group messages are blocked."],
+    });
+
+    expect(reply?.text).toContain(
+      "⚠️ Telegram commands work, but normal group messages are blocked.",
+    );
   });
 
   it("dedupes stale rows in the verbose subagent status summary", async () => {

--- a/src/auto-reply/reply/commands-status.thinking-default.test.ts
+++ b/src/auto-reply/reply/commands-status.thinking-default.test.ts
@@ -41,6 +41,7 @@ const { buildStatusReply } = await import("./commands-status.js");
 async function buildKiraStatusReply(cfg: OpenClawConfig) {
   return await buildStatusReply({
     cfg,
+    ctx: {},
     command: {
       isAuthorizedSender: true,
       channel: "whatsapp",

--- a/src/auto-reply/reply/commands-status.ts
+++ b/src/auto-reply/reply/commands-status.ts
@@ -4,11 +4,13 @@ import { formatDetailedPluginHealth } from "../../status/status-plugin-health.js
 import { buildStatusText } from "../../status/status-text.js";
 import type { BuildStatusTextParams } from "../../status/status-text.types.js";
 import type { ReplyPayload } from "../types.js";
+import type { MsgContext } from "../templating.js";
 import { requireCommandFlagEnabled } from "./command-gates.js";
 import type { CommandContext } from "./commands-types.js";
 export { buildStatusText } from "../../status/status-text.js";
 
 type BuildStatusReplyParams = Omit<BuildStatusTextParams, "statusChannel"> & {
+  ctx: MsgContext;
   command: CommandContext;
 };
 
@@ -27,6 +29,7 @@ export async function buildStatusReply(
       ...params,
       statusChannel: command.channel,
       statusAccountId: command.accountId,
+      statusNotes: params.ctx.StatusNotes,
     }),
   };
 }

--- a/src/auto-reply/reply/get-reply-directives-apply.ts
+++ b/src/auto-reply/reply/get-reply-directives-apply.ts
@@ -363,6 +363,7 @@ export async function applyInlineDirectiveOverrides(params: {
       const targetSessionEntry = sessionStore[sessionKey] ?? sessionEntry;
       statusReply = await buildStatusReply({
         cfg,
+        ctx,
         command,
         sessionEntry: targetSessionEntry,
         sessionKey,

--- a/src/auto-reply/reply/get-reply-inline-actions.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.ts
@@ -474,6 +474,7 @@ export async function handleInlineActions(params: {
     const { buildStatusReply } = await loadCommandsRuntime();
     const inlineStatusReply = await buildStatusReply({
       cfg,
+      ctx,
       command,
       sessionEntry: targetSessionEntry,
       sessionKey,

--- a/src/auto-reply/reply/get-reply-native-slash-fast-path.ts
+++ b/src/auto-reply/reply/get-reply-native-slash-fast-path.ts
@@ -165,6 +165,7 @@ export async function maybeResolveNativeSlashCommandFastReply(params: {
       reply: markCommandReplyForDelivery(
         await buildStatusReply({
           cfg: params.cfg,
+          ctx: params.ctx,
           command,
           sessionEntry: targetSessionEntry,
           sessionKey: sessionState.sessionKey,

--- a/src/auto-reply/templating.ts
+++ b/src/auto-reply/templating.ts
@@ -107,6 +107,8 @@ export type MsgContext = {
    */
   BodyForCommands?: string;
   CommandArgs?: CommandArgs;
+  /** Channel-supplied diagnostics appended to /status replies. */
+  StatusNotes?: string[];
   From?: string;
   To?: string;
   SessionKey?: string;

--- a/src/plugin-sdk/command-status.runtime.ts
+++ b/src/plugin-sdk/command-status.runtime.ts
@@ -126,6 +126,7 @@ export async function resolveDirectStatusReplyForSession(
 
   return await buildStatusReply({
     cfg: statusCfg,
+    ctx: {},
     command,
     sessionEntry: statusEntry,
     sessionKey: statusSessionKey,

--- a/src/status/status-message.ts
+++ b/src/status/status-message.ts
@@ -113,6 +113,7 @@ export type StatusArgs = {
   pluginHealthLine?: string;
   channelFeatureLine?: string;
   includeTranscriptUsage?: boolean;
+  statusNotes?: readonly string[];
   now?: number;
 };
 
@@ -1110,6 +1111,10 @@ export function buildStatusMessage(args: StatusArgs): string {
     usagePair && costLine ? `${usagePair} · ${costLine}` : (usagePair ?? costLine);
   const mediaLine = formatMediaUnderstandingLine(args.mediaDecisions);
   const voiceLine = formatVoiceModeLine(args.config, args.sessionEntry, args.agentId);
+  const statusNotes = (args.statusNotes ?? [])
+    .map((note) => note.trim())
+    .filter(Boolean)
+    .map((note) => `⚠️ ${note}`);
 
   return [
     versionLine,
@@ -1132,6 +1137,7 @@ export function buildStatusMessage(args: StatusArgs): string {
     pluginStatusLine ? `🧩 ${pluginStatusLine}` : null,
     voiceLine,
     activationLine,
+    ...statusNotes,
   ]
     .filter((line): line is string => Boolean(line))
     .join("\n");

--- a/src/status/status-text.ts
+++ b/src/status/status-text.ts
@@ -659,5 +659,6 @@ export async function buildStatusText(params: BuildStatusTextParams): Promise<st
     channelFeatureLine,
     mediaDecisions: params.mediaDecisions,
     includeTranscriptUsage: params.includeTranscriptUsage ?? true,
+    statusNotes: params.statusNotes,
   });
 }

--- a/src/status/status-text.types.ts
+++ b/src/status/status-text.types.ts
@@ -42,4 +42,5 @@ export type BuildStatusTextParams = {
   modelAuthOverride?: string;
   activeModelAuthOverride?: string;
   includeTranscriptUsage?: boolean;
+  statusNotes?: readonly string[];
 };


### PR DESCRIPTION
## Summary

- Adds a Telegram-only `/status` diagnostic for groups/topics where native commands are authorized but normal group-message ingress would be blocked by group access policy.
- Threads optional channel-supplied `StatusNotes` through the shared `/status` renderer so other channels can add similar diagnostics without changing normal status output.
- Uses the existing Telegram group policy evaluator for the normal-message check; this does not loosen authorization or change message dispatch.

## Linked context

Reported from a Telegram forum group where `/status@bot` worked but plain `@bot` mentions were delivered by Telegram and then dropped by OpenClaw group allowlist enforcement.

## Real behavior proof

- Behavior or issue addressed: Telegram `/status` could imply the group/topic was usable even when normal mentions were blocked by `groupPolicy: allowlist` and missing effective group/topic `allowFrom`.
- Real environment tested: Local Telegram bot `@sture_openclaw_bot` on OpenClaw Gateway built from this branch.
- Exact steps or command run after this patch: Sent `/status@sture_openclaw_bot` in a Telegram group/topic where command auth was allowed but normal group ingress was blocked.
- Evidence after fix: Live Telegram `/status` reply showed the new warning.
<img width="468" height="329" alt="screenshot-2026-06-05_15-00-40" src="https://github.com/user-attachments/assets/b959565a-1841-4803-83dd-8ad903529a7f" />

- Observed result after fix: `/status` still responded, and included the warning that normal group messages were blocked by `groupPolicy=allowlist` with the relevant allowlist details.
- What was not tested: Full release/package validation and cross-channel behavior.
- Proof limitations or environment constraints: Local proof used the maintainer's Telegram setup and was later reverted back to the normal installed Gateway after verification.

## Tests and validation

Focused tests run:

```sh
pnpm test src/auto-reply/reply/commands-status.test.ts extensions/telegram/src/bot-native-commands.group-auth.test.ts -- --reporter=verbose
```

Regression coverage added:

- Shared `/status` rendering appends channel-supplied status notes.
- Telegram native command auth test covers the split case where `commands.allowFrom.telegram` authorizes `/status`, while normal group ingress is blocked by the group allowlist.

## Risk checklist

Did user-visible behavior change? `Yes`

Did config, environment, or migration behavior change? `No`

Did security, auth, secrets, network, or tool execution behavior change? `No`

Highest-risk area: accidentally changing Telegram authorization semantics.

Mitigation: the new code only computes and renders a diagnostic note. It reuses the existing normal group-policy evaluator and does not alter command auth, group ingress, or dispatch decisions.

## Current review state

Next action: maintainer review.

Still waiting on: CI and reviewer confirmation.

Bot/reviewer comments addressed: none yet.

## Mantis proof setup

The standard Mantis Telegram Desktop harness allows normal group ingress by default via generated \`channels.telegram.groupAllowFrom\` and \`channels.telegram.groups[<groupId>].allowFrom\`. To prove this PR, Mantis must alter the generated SUT config for each baseline/candidate run after \`openclaw-telegram-user-crabbox-proof start\` and before sending \`/status\`:

- Read the session JSON and use \`session.localSut.configPath\` to patch the generated \`openclaw.json\`.
- Keep native command auth allowed by setting \`commands.allowFrom.telegram\` to the leased tester user id.
- Keep \`channels.telegram.groupPolicy = "allowlist"\`.
- Remove or empty \`channels.telegram.groupAllowFrom\` and the generated group entry's \`allowFrom\` for the leased group id so normal group ingress is blocked.
- Restart the local SUT if needed after editing the config, then send \`/status\` in the leased group/topic.

Expected baseline: \`/status\` responds without the blocked-group-ingress warning.

Expected candidate: \`/status\` responds and includes the blocked normal group messages warning.
