### PR TITLE
fix(cron): no-deliver runs now recover from tool warnings via final assistant text

### DIFF
--- a/src/cron/isolated-agent/channel-output-policy.test.ts
+++ b/src/cron/isolated-agent/channel-output-policy.test.ts
@@ -36,6 +36,13 @@ describe("cron channel output policy", () => {
     channelPluginMocks.getChannelPlugin.mockClear();
   });
 
+  it("prefers final assistant text when no channel is resolved", async () => {
+    await expect(resolveCronChannelOutputPolicy(undefined)).resolves.toEqual({
+      preferFinalAssistantVisibleText: true,
+    });
+    expect(channelPluginMocks.getChannelPlugin).not.toHaveBeenCalled();
+  });
+
   it("reads final visible text preference from the channel plugin", async () => {
     await expect(resolveCronChannelOutputPolicy("topicchat")).resolves.toEqual({
       preferFinalAssistantVisibleText: true,

--- a/src/cron/isolated-agent/channel-output-policy.ts
+++ b/src/cron/isolated-agent/channel-output-policy.ts
@@ -18,7 +18,8 @@ export async function resolveCronChannelOutputPolicy(channel: string | undefined
 }> {
   const channelId = normalizeOptionalLowercaseString(channel);
   if (!channelId) {
-    return { preferFinalAssistantVisibleText: false };
+    // No channel means no structured delivery; final assistant text is the only output.
+    return { preferFinalAssistantVisibleText: true };
   }
   const { getChannelPlugin } = await loadChannelPluginRuntime();
   return {


### PR DESCRIPTION
### Summary

- **Problem**: `--no-deliver` cron runs that produce only non-fatal tool warnings followed by a valid final assistant reply are incorrectly recorded as fatal errors. The run ledger shows an error payload and `hasFatalErrorPayload = true` even though the agent recovered cleanly.
- **Root Cause**: `resolveCronChannelOutputPolicy` returns `{ preferFinalAssistantVisibleText: false }` when `channel` is `undefined` — which is exactly the value `run.ts` passes when `deliveryPlan.mode === "none"` sets `resolvedDelivery.channel = undefined`. Both downstream recovery gates in `resolveCronPayloadOutcome` require `preferFinalAssistantVisibleText === true`: `hasRecoveredToolWarning` (checks all error payloads are tool-warning strings plus a non-empty final text) and `shouldUseFinalAssistantVisibleText`. With the flag `false`, `hasRecoveredToolWarning` is always `false`, `hasFatalStructuredErrorPayload` includes the tool warnings as fatal, and the run is marked `status: "error"` regardless of whether the agent recovered.
- **Fix**: Return `{ preferFinalAssistantVisibleText: true }` when no `channelId` is resolved. Without a channel there is no structured delivery target; the final assistant text is the only meaningful output, so preferring it is unconditionally correct for the no-channel path. The downstream guards (`!runLevelError`, `failureSignal?.fatalForCron !== true`, `!hasStructuredDeliveryPayloads`) remain intact and prevent false recovery for genuine errors.
- **What changed**:
  - `src/cron/isolated-agent/channel-output-policy.ts` — flip the no-channel early-exit from `false` to `true`; add a one-line comment explaining the semantic reason.
  - `src/cron/isolated-agent/channel-output-policy.test.ts` — add `"prefers final assistant text when no channel is resolved"` test case; asserts the channel plugin runtime is not consulted (function returns before the lazy import).
- **What did NOT change (scope boundary)**:
  - The has-channel path is unchanged: channel plugins that set `preferFinalAssistantVisibleText: true` or omit it still resolve exactly as before.
  - `delivery-dispatch.ts` dispatch is gated on `params.deliveryRequested && …`; since `deliveryRequested: false` in the no-deliver case, `deliverViaDirect` is never called even though `resolvedDeliveryPayloads` now contains the final text. No actual channel message is sent.
  - Config surface unchanged (no schema, defaults, doctor migrations, or `docs/reference/config`).
  - Plugin surface unchanged (no plugin SDK, manifest, `extensions/*` api/runtime-api, registry/loader).
  - Gateway protocol unchanged.

### Reproduction

1. Configure a cron job with `--no-deliver` (or `deliveryPlan.mode = "none"` with no explicit target).
2. Run an agent that emits one or more `⚠️ 🛠️ …` tool-warning payloads and then produces a non-empty final assistant reply.
3. Inspect `hasFatalErrorPayload` / `status` from `resolveCronPayloadOutcome`.
4. **Before this PR**: `preferFinalAssistantVisibleText` is `false`; `hasRecoveredToolWarning` is always `false`; `hasFatalStructuredErrorPayload` is `true`; run is recorded as `status: "error"` with the tool-warning text as `embeddedRunError`.
5. **After this PR**: `preferFinalAssistantVisibleText` is `true`; `hasRecoveredToolWarning` is `true`; `hasFatalStructuredErrorPayload` is `false`; run is recorded as `status: "ok"` with the final assistant text as `outputText`.

### Real behavior proof

**Behavior addressed (#90664)**: `resolveCronChannelOutputPolicy` no longer returns `false` for the no-channel/no-deliver path; `hasRecoveredToolWarning` can now be satisfied; a no-deliver run that produces only non-fatal tool warnings followed by a final assistant reply is recorded as `ok` with the assistant text, not as a fatal error.

**Real environment tested (Linux, Node 22 — Vitest against the production `resolveCronChannelOutputPolicy`, `resolveCronPayloadOutcome`, and the adjacent message-tool-policy helpers)**: the new test drives `resolveCronChannelOutputPolicy(undefined)` directly and asserts that the channel plugin runtime lazy import is never triggered; the existing helpers suite confirms that `preferFinalAssistantVisibleText: true` produces recovery as expected.

**Exact steps or command run after this patch**: `node scripts/run-vitest.mjs src/cron/isolated-agent/channel-output-policy.test.ts src/cron/isolated-agent.helpers.test.ts src/cron/isolated-agent/run.message-tool-policy.test.ts`

**Evidence after fix (Vitest output for the three touched suites)**:

```text
channel-output-policy.test.ts   Tests  3 passed (3)
isolated-agent.helpers.test.ts  Tests  60 passed (60)
run.message-tool-policy.test.ts Tests  7 passed (7)
```

**Observed result after fix**: `resolveCronChannelOutputPolicy(undefined)` resolves to `{ preferFinalAssistantVisibleText: true }` without consulting the channel plugin runtime. The existing `"lets preferred final assistant text recover a plain tool warning"` case in the helpers suite (which passes `preferFinalAssistantVisibleText: true` explicitly) confirms the downstream recovery path works correctly once the flag is `true`.

**What was not tested**: a live gateway cron run with `--no-deliver` plus a tool-warning-emitting agent. The policy function, the recovery gate logic, and the helpers are covered deterministically against the production functions; a full gateway round-trip was not driven.

**Repro confirmation**: the new `"prefers final assistant text when no channel is resolved"` test case fails on `origin/main` before the patch (returns `false`) and passes after; the mock assertion that the channel plugin runtime is never called confirms the early-exit path is exercised, not the lazy-load path.

### Risk / Mitigation

- **Risk**: A no-deliver run with only non-tool-warning error payloads could be misclassified as recovered. **Mitigation**: `hasRecoveredToolWarning` requires `errorPayloads.every(payload => isCronToolWarning(payload?.text))`; any non-tool-warning error payload keeps the run fatal regardless of the flag.
- **Risk**: `resolvedDeliveryPayloads` now contains the final text in no-deliver mode, which could trigger unexpected delivery. **Mitigation**: `dispatchCronDelivery` is gated on `params.deliveryRequested && …`; `deliveryRequested` is `false` in the no-deliver case, so `deliverViaDirect` is never called.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] cron

### Linked Issue/PR

Fixes #90664