### PR TITLE
fix(cron): recover no-deliver tool warnings

### DIFF
--- a/src/cron/isolated-agent/channel-output-policy.test.ts
+++ b/src/cron/isolated-agent/channel-output-policy.test.ts
@@ -45,6 +45,19 @@ describe("cron channel output policy", () => {
     });
   });
 
+  it("prefers final visible text only for unresolved no-delivery runs", async () => {
+    await expect(
+      resolveCronChannelOutputPolicy(undefined, { deliveryRequested: false }),
+    ).resolves.toEqual({
+      preferFinalAssistantVisibleText: true,
+    });
+    await expect(
+      resolveCronChannelOutputPolicy(undefined, { deliveryRequested: true }),
+    ).resolves.toEqual({
+      preferFinalAssistantVisibleText: false,
+    });
+  });
+
   it("lets channel plugins format current tool context targets", async () => {
     await expect(
       resolveCurrentChannelTarget({

--- a/src/cron/isolated-agent/channel-output-policy.ts
+++ b/src/cron/isolated-agent/channel-output-policy.ts
@@ -13,12 +13,15 @@ async function loadChannelPluginRuntime() {
 }
 
 /** Resolves channel-specific cron output preferences from loaded channel plugins. */
-export async function resolveCronChannelOutputPolicy(channel: string | undefined): Promise<{
+export async function resolveCronChannelOutputPolicy(
+  channel: string | undefined,
+  opts?: { deliveryRequested?: boolean },
+): Promise<{
   preferFinalAssistantVisibleText: boolean;
 }> {
   const channelId = normalizeOptionalLowercaseString(channel);
   if (!channelId) {
-    return { preferFinalAssistantVisibleText: false };
+    return { preferFinalAssistantVisibleText: opts?.deliveryRequested === false };
   }
   const { getChannelPlugin } = await loadChannelPluginRuntime();
   return {

--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -141,6 +141,7 @@ export function createCronPromptExecutor(params: {
     to?: string;
     threadId?: string | number;
   };
+  deliveryRequested?: boolean;
   sourceDelivery: SourceDeliveryPlan;
   skillsSnapshot: SkillSnapshot;
   agentPayload: AgentTurnPayload;
@@ -378,6 +379,7 @@ export async function executeCronRun(params: {
     to?: string;
     threadId?: string | number;
   };
+  deliveryRequested?: boolean;
   sourceDelivery: SourceDeliveryPlan;
   skillsSnapshot: SkillSnapshot;
   agentPayload: AgentTurnPayload;
@@ -429,6 +431,7 @@ export async function executeCronRun(params: {
     runTimeoutOverrideMs: params.runTimeoutOverrideMs,
     suppressExecNotifyOnExit: params.suppressExecNotifyOnExit,
     resolvedDelivery: params.resolvedDelivery,
+    deliveryRequested: params.deliveryRequested,
     sourceDelivery: params.sourceDelivery,
     skillsSnapshot: params.skillsSnapshot,
     agentPayload: params.agentPayload,
@@ -501,7 +504,9 @@ export async function executeCronRun(params: {
       failureSignal: runResult.meta?.failureSignal,
       finalAssistantVisibleText: runResult.meta?.finalAssistantVisibleText,
       preferFinalAssistantVisibleText: (
-        await resolveCronChannelOutputPolicy(params.resolvedDelivery.channel)
+        await resolveCronChannelOutputPolicy(params.resolvedDelivery.channel, {
+          deliveryRequested: params.deliveryRequested,
+        })
       ).preferFinalAssistantVisibleText,
     });
     const interimText = interimOutputText?.trim() ?? "";

--- a/src/cron/isolated-agent/run.message-tool-policy.test.ts
+++ b/src/cron/isolated-agent/run.message-tool-policy.test.ts
@@ -395,6 +395,52 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
     expect(embeddedRun.messageTo).toBeUndefined();
   });
 
+  it("uses final assistant text to recover tool warnings for bare no-deliver runs", async () => {
+    mockRunCronFallbackPassthrough();
+    resolveCronDeliveryPlanMock.mockReturnValue({
+      requested: false,
+      mode: "none",
+    });
+    resolveCronPayloadOutcomeMock.mockReturnValue({
+      summary: "Final cron report from the agent.",
+      outputText: "Final cron report from the agent.",
+      synthesizedText: "Final cron report from the agent.",
+      deliveryPayload: { text: "Final cron report from the agent." },
+      deliveryPayloads: [{ text: "Final cron report from the agent." }],
+      deliveryPayloadHasStructuredContent: false,
+      hasFatalErrorPayload: false,
+      hasFatalStructuredErrorPayload: false,
+      embeddedRunError: undefined,
+    });
+    runEmbeddedAgentMock.mockResolvedValue({
+      payloads: [{ text: "⚠️ 🛠️ show > (agent) failed", isError: true }],
+      meta: {
+        finalAssistantVisibleText: "Final cron report from the agent.",
+        agentMeta: { usage: { input: 10, output: 20 } },
+      },
+    });
+
+    const result = await runCronIsolatedAgentTurn({
+      ...makeParams(),
+      job: makeMessageToolPolicyJob({ mode: "none" }),
+    });
+
+    expect(result.status).toBe("ok");
+    expect(result.error).toBeUndefined();
+    expect(result.summary).toBe("Final cron report from the agent.");
+    expect(result.outputText).toBe("Final cron report from the agent.");
+    expect(resolveCronPayloadOutcomeMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        finalAssistantVisibleText: "Final cron report from the agent.",
+        preferFinalAssistantVisibleText: true,
+      }),
+    );
+    expectDispatchFields({
+      deliveryRequested: false,
+      deliveryPayloads: [{ text: "Final cron report from the agent." }],
+    });
+  });
+
   it('suppresses automatic exec completion notifications when delivery.mode is "none"', async () => {
     mockRunCronFallbackPassthrough();
     resolveCronDeliveryPlanMock.mockReturnValue({

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -1049,7 +1049,9 @@ async function finalizeCronRun(params: {
     failureSignal: finalRunResult.meta?.failureSignal,
     finalAssistantVisibleText: finalRunResult.meta?.finalAssistantVisibleText,
     preferFinalAssistantVisibleText: (
-      await resolveCronChannelOutputPolicy(prepared.resolvedDelivery.channel)
+      await resolveCronChannelOutputPolicy(prepared.resolvedDelivery.channel, {
+        deliveryRequested: prepared.deliveryRequested,
+      })
     ).preferFinalAssistantVisibleText,
   });
   const {
@@ -1323,6 +1325,7 @@ export async function runCronIsolatedAgentTurn(params: {
         accountId: prepared.context.resolvedDelivery.accountId,
         threadId: prepared.context.resolvedDelivery.threadId,
       },
+      deliveryRequested: prepared.context.deliveryRequested,
       sourceDelivery: prepared.context.sourceDelivery,
       skillsSnapshot: prepared.context.skillsSnapshot,
       agentPayload: prepared.context.agentPayload,


### PR DESCRIPTION
## Summary

- Treat unresolved cron output policy as final-text-preferred only when delivery is explicitly disabled.
- Preserve the existing channel-plugin preference path for resolved delivery channels.
- Pass the delivery-requested fact into final and interim isolated cron outcome classification.

Refs #90664

## Verification

- `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=<temp-cache> pnpm test src/cron/isolated-agent/channel-output-policy.test.ts src/cron/isolated-agent/run.message-tool-policy.test.ts src/cron/isolated-agent.helpers.test.ts`
- `node_modules/.bin/oxfmt --check --threads=1 src/cron/isolated-agent/channel-output-policy.ts src/cron/isolated-agent/run.ts src/cron/isolated-agent/run-executor.ts src/cron/isolated-agent/channel-output-policy.test.ts src/cron/isolated-agent/run.message-tool-policy.test.ts`
- `node_modules/.bin/oxlint src/cron/isolated-agent/channel-output-policy.ts src/cron/isolated-agent/run.ts src/cron/isolated-agent/run-executor.ts src/cron/isolated-agent/channel-output-policy.test.ts src/cron/isolated-agent/run.message-tool-policy.test.ts`
- `git diff --check`
- `pnpm tsgo:core`

## Real behavior proof

behavior: A bare `delivery.mode: "none"` isolated cron run with a trailing tool warning and final assistant-visible text should record the final assistant text as the successful cron result instead of treating the tool warning as fatal.

environment: Ubuntu source checkout, Node 22.22.2, fixed branch `ai-hpc/fix-cron-no-deliver-tool-warning`.

steps:

1. On unchanged current main, classify a no-channel cron payload with one tool warning and populated final assistant-visible text.
2. Confirm current main returns `preferFinalAssistantVisibleText: false`, marks the warning fatal, and uses the warning as summary/output.
3. On the fixed branch, classify the same shape with explicit `deliveryRequested: false`.
4. Confirm the warning is non-fatal and summary/output use final assistant-visible text.

before:

```json
{
  "behavior": "main no-channel cron tool warning classification",
  "policy": {
    "preferFinalAssistantVisibleText": false
  },
  "finalAssistantVisibleTextPresent": true,
  "hasFatalErrorPayload": true,
  "embeddedRunError": "⚠️ 🛠️ show > (agent) failed",
  "summary": "⚠️ 🛠️ show > (agent) failed",
  "outputText": "⚠️ 🛠️ show > (agent) failed"
}
```

after:

```json
{
  "behavior": "fixed no-delivery cron tool warning classification",
  "policy": {
    "preferFinalAssistantVisibleText": true
  },
  "finalAssistantVisibleTextPresent": true,
  "hasFatalErrorPayload": false,
  "summary": "Final cron report from the agent.",
  "outputText": "Final cron report from the agent.",
  "deliveryPayloads": [
    {
      "text": "Final cron report from the agent."
    }
  ]
}
```

observedResult: The fixed branch keeps unresolved delivery-requested runs conservative, but lets explicit no-delivery cron runs recover plain tool warnings with final assistant-visible text.

notTested: Full installed cron dispatch with the reporter's live `claude-cascade` job was not replayed locally. Focused proof covers the classifier path that misclassified the run; regression tests cover policy resolution, helper behavior, and isolated cron run finalization.
