### PR TITLE
fix(gateway): guard secrets.resolve handler against undefined fields

### DIFF
--- a/src/gateway/server-methods/secrets.test.ts
+++ b/src/gateway/server-methods/secrets.test.ts
@@ -217,6 +217,32 @@ describe("secrets handlers", () => {
     });
   });
 
+  it("handles undefined commandName without crashing", async () => {
+    const handlers = createHandlers();
+    const respond = vi.fn();
+    await invokeSecretsResolve({
+      handlers,
+      respond,
+      commandName: undefined,
+      targetIds: ["talk.providers.*.apiKey"],
+    });
+    // Should not crash; validator or guard catches it cleanly.
+    expectRespondError(respond, { code: "INVALID_REQUEST" });
+  });
+
+  it("handles undefined targetIds without crashing", async () => {
+    const handlers = createHandlers();
+    const respond = vi.fn();
+    await invokeSecretsResolve({
+      handlers,
+      respond,
+      commandName: "message send",
+      targetIds: undefined,
+    });
+    // Should not crash; validator or guard catches it cleanly.
+    expectRespondError(respond, { code: "INVALID_REQUEST" });
+  });
+
   it("rejects unknown secrets.resolve target ids", async () => {
     const resolveSecrets = vi.fn();
     const handlers = createHandlers({ resolveSecrets });

--- a/src/gateway/server-methods/secrets.ts
+++ b/src/gateway/server-methods/secrets.ts
@@ -97,7 +97,8 @@ export function createSecretsHandlers(params: {
         );
         return;
       }
-      const commandName = requestParams.commandName.trim();
+      const commandName =
+        typeof requestParams.commandName === "string" ? requestParams.commandName.trim() : "";
       if (!commandName) {
         respond(
           false,
@@ -106,8 +107,8 @@ export function createSecretsHandlers(params: {
         );
         return;
       }
-      const targetIds = requestParams.targetIds
-        .map((entry) => entry.trim())
+      const targetIds = (Array.isArray(requestParams.targetIds) ? requestParams.targetIds : [])
+        .map((entry) => (typeof entry === "string" ? entry.trim() : ""))
         .filter((entry) => entry.length > 0);
       // Normalize allow/force/optional path lists before resolving so secrets
       // code receives policy paths, not UI whitespace artifacts.


### PR DESCRIPTION
## Summary

Fixes #90654: CLI write commands `openclaw message send`, `broadcast`, and `probe` crash the gateway with `TypeError: Cannot read properties of undefined (reading 'trim')` during the connect handshake.

Root cause: the `secrets.resolve` handler called `.trim()` on `commandName` and `.map()` on `targetIds` without the same `typeof === "string"` / `Array.isArray()` guards used by sibling fields (`allowedPaths`, `forcedActivePaths`, `optionalActivePaths`). When the CLI sends a malformed or legacy-format request, the handler threw inside the parse path, the WebSocket was closed, and the CLI fell back to local resolution which cannot complete the send.

### Changes

[src/gateway/server-methods/secrets.ts](src/gateway/server-methods/secrets.ts):
- `commandName`: guarded with `typeof requestParams.commandName === "string" ? requestParams.commandName.trim() : ""`
- `targetIds`: guarded with `Array.isArray(requestParams.targetIds) ? requestParams.targetIds : []` and per-entry `typeof entry === "string"` check
- Matches the existing defensive pattern used by `allowedPaths?.map(...)`, `forcedActivePaths?.map(...)`, and `optionalActivePaths?.map(...)`

## Real behavior proof

**Behavior addressed:** CLI write commands (message send, broadcast, probe) crash gateway handshake with `TypeError: Cannot read properties of undefined (reading 'trim')` when `commandName` or `targetIds` are undefined in the `secrets.resolve` request.

**Real environment tested:** macOS 26.1, Node.js 24, Vitest via `pnpm test`.

**Exact steps or command run after this patch:**
```
npx vitest run src/gateway/server-methods/secrets.test.ts --no-color
```

**Evidence after fix:**
```
Test Files  2 passed (2)
     Tests  20 passed (20)
```

New regression tests (2 added):
1. `"handles undefined commandName without crashing"` — sends `commandName: undefined`, responds with `INVALID_REQUEST` instead of throwing
2. `"handles undefined targetIds without crashing"` — sends `targetIds: undefined`, responds with `INVALID_REQUEST` instead of throwing

Existing tests continue to pass:
- `"rejects invalid secrets.resolve params"` — empty commandName, bad targetIds
- `"rejects secrets.resolve params when targetIds entries are not strings"` — non-string entries

**Observed result after fix:**
- Before: `requestParams.commandName.trim()` on `undefined` → `TypeError` → WS socket closed (1000) → CLI cannot send
- After: `typeof requestParams.commandName === "string" ? requestParams.commandName.trim() : ""` → empty string → `INVALID_REQUEST` error response → clean rejection without crash

**What was not tested:** A live gateway smoke with actual `openclaw message send` against a running daemon was not performed on this machine. The defensive guards are exercised through the full `createSecretsHandlers` pipeline in the test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)