### PR TITLE
fix(macos): defer voice wake overlay resizing

### DIFF
--- a/apps/macos/Sources/OpenClaw/VoiceWakeOverlayController+Window.swift
+++ b/apps/macos/Sources/OpenClaw/VoiceWakeOverlayController+Window.swift
@@ -92,7 +92,10 @@ extension VoiceWakeOverlayController {
 
         let contentHeight = ceil(used.height + (textInset.height * 2))
         let total = contentHeight + self.verticalPadding * 2
-        self.model.isOverflowing = total > self.maxHeight
+        let newOverflowing = total > self.maxHeight
+        if newOverflowing != self.model.isOverflowing {
+            self.model.isOverflowing = newOverflowing
+        }
         return max(self.minHeight, min(total, self.maxHeight))
     }
 

--- a/apps/macos/Sources/OpenClaw/VoiceWakeOverlayView.swift
+++ b/apps/macos/Sources/OpenClaw/VoiceWakeOverlayView.swift
@@ -110,7 +110,9 @@ struct VoiceWakeOverlayView: View {
             self.updateFocusState(visible: self.controller.model.isVisible, editing: editing)
         }
         .onChange(of: self.controller.model.attributed) { _, _ in
-            self.controller.updateWindowFrame(animate: true)
+            DispatchQueue.main.async {
+                self.controller.updateWindowFrame(animate: true)
+            }
         }
     }
 

--- a/apps/macos/Tests/OpenClawIPCTests/VoiceWakeOverlayControllerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/VoiceWakeOverlayControllerTests.swift
@@ -65,4 +65,21 @@ struct VoiceWakeOverlayControllerTests {
     @Test func `overlay controller exercises helpers`() async {
         await VoiceWakeOverlayController.exerciseForTesting()
     }
+
+    @Test func `measuredHeight does not mutate isOverflowing when unchanged`() {
+        let controller = VoiceWakeOverlayController(enableUI: false)
+        _ = controller.startSession(
+            source: .wakeWord,
+            transcript: "short",
+            attributed: nil,
+            forwardEnabled: true,
+            isFinal: false)
+        // First call sets isOverflowing when it changes.
+        let h1 = controller.measuredHeight()
+        let overflowAfterFirst = controller.model.isOverflowing
+        // Second call with same content must not flip isOverflowing again (no-op guard).
+        let h2 = controller.measuredHeight()
+        #expect(h1 == h2)
+        #expect(controller.model.isOverflowing == overflowAfterFirst)
+    }
 }


### PR DESCRIPTION
## What changed
- Defers the VoiceWake overlay window resize triggered by attributed text changes onto the next main-queue turn.
- Avoids redundant `isOverflowing` writes from `measuredHeight()` when the overflow state is unchanged.
- Adds regression coverage for repeated `measuredHeight()` calls with unchanged overflow state.

Fixes #43480.

## Real behavior proof

Behavior addressed: VoiceWake overlay attributed-text changes no longer run `updateWindowFrame(animate:)` synchronously from SwiftUI's `onChange` callback. Repeated height measurement also no longer writes `model.isOverflowing` again when the overflow state is unchanged.

Real environment tested: macOS arm64 worktree on branch `fastino-43480-voice-wake-render-loop`, based on `origin/main` commit `520992a1`; Swift toolchain `swift-driver version: 1.148.6 Apple Swift version 6.3.2`.

Exact steps or command run after the patch:
```shell
git show origin/main:apps/macos/Sources/OpenClaw/VoiceWakeOverlayController+Window.swift | rg -n 'isOverflowing|measuredHeight'
rg -n 'isOverflowing|DispatchQueue.main.async|onChange\(of: self.controller.model.attributed|measuredHeight does not mutate' apps/macos/Sources/OpenClaw/VoiceWakeOverlayController+Window.swift apps/macos/Sources/OpenClaw/VoiceWakeOverlayView.swift apps/macos/Tests/OpenClawIPCTests/VoiceWakeOverlayControllerTests.swift
git diff --check
swiftc -parse apps/macos/Sources/OpenClaw/VoiceWakeOverlayController+Window.swift
swiftc -parse apps/macos/Sources/OpenClaw/VoiceWakeOverlayView.swift
swiftc -parse apps/macos/Tests/OpenClawIPCTests/VoiceWakeOverlayControllerTests.swift
```

Evidence after fix:
```shell
$ git show origin/main:apps/macos/Sources/OpenClaw/VoiceWakeOverlayController+Window.swift | rg -n 'isOverflowing|measuredHeight'
59:        let height = self.measuredHeight()
72:    func measuredHeight() -> CGFloat {
95:        self.model.isOverflowing = total > self.maxHeight

$ rg -n 'isOverflowing|DispatchQueue.main.async|onChange\(of: self.controller.model.attributed|measuredHeight does not mutate' apps/macos/Sources/OpenClaw/VoiceWakeOverlayController+Window.swift apps/macos/Sources/OpenClaw/VoiceWakeOverlayView.swift apps/macos/Tests/OpenClawIPCTests/VoiceWakeOverlayControllerTests.swift
apps/macos/Sources/OpenClaw/VoiceWakeOverlayView.swift:112:        .onChange(of: self.controller.model.attributed) { _, _ in
apps/macos/Sources/OpenClaw/VoiceWakeOverlayView.swift:113:            DispatchQueue.main.async {
apps/macos/Sources/OpenClaw/VoiceWakeOverlayController+Window.swift:96:        if newOverflowing != self.model.isOverflowing {
apps/macos/Sources/OpenClaw/VoiceWakeOverlayController+Window.swift:97:            self.model.isOverflowing = newOverflowing
apps/macos/Tests/OpenClawIPCTests/VoiceWakeOverlayControllerTests.swift:69:    @Test func `measuredHeight does not mutate isOverflowing when unchanged`() {

$ git diff --check

$ swiftc -parse apps/macos/Sources/OpenClaw/VoiceWakeOverlayController+Window.swift

$ swiftc -parse apps/macos/Sources/OpenClaw/VoiceWakeOverlayView.swift

$ swiftc -parse apps/macos/Tests/OpenClawIPCTests/VoiceWakeOverlayControllerTests.swift
```

Observed result after fix: The branch removes the direct synchronous resize call from the attributed-text `onChange` handler, moves the resize onto `DispatchQueue.main.async`, and changes `measuredHeight()` so unchanged overflow state does not write to the observable model again. The changed Swift source and test files parsed successfully, and `git diff --check` emitted no errors.

Not tested: I did not reproduce the interactive macOS pinwheel in a full signed app bundle. `xcodebuild test` was not available locally because the active developer directory is `/Library/Developer/CommandLineTools`, not full Xcode. `swift test --filter VoiceWakeOverlayControllerTests` and `swift build` were attempted from `apps/macos`, but local SwiftPM package setup stalled while resolving/downloading the Sparkle binary artifact, so no focused test execution result is claimed here.

## Platforms tested
- macOS arm64, Apple Swift 6.3.2 Command Line Tools.
