### PR TITLE
fix(openai): preserve opaque reasoning transcript fields

### DIFF
--- a/src/agents/transcript-redact.test.ts
+++ b/src/agents/transcript-redact.test.ts
@@ -37,7 +37,8 @@ const BMP_BASE64_WITH_SECRET_TOKEN_SUBSTRING = Buffer.from(
 ).toString("base64");
 const CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES =
   "gAAAAABpQnQrXzzZqcAfo3unbAY-ku84xgsvB0fpLkbDvSh3WS5qzfSCmcgwr8_abcdefghijvK2RyV2GQ4ohzcfYwhRwTvY76TvR7Tvr_";
-const BASE64_TEXT_SIGNATURE = "QUJDREVGR0hJSktMTU5PUA==";
+const GOOGLE_THOUGHT_SIGNATURE = Buffer.from(`thought-${"x".repeat(32)}`).toString("base64");
+const SHORT_GOOGLE_THOUGHT_SIGNATURE = "c2ln";
 const COPILOT_CONNECTION_BOUND_ID = Buffer.from(`message-${"y".repeat(24)}`).toString("base64");
 const OPENAI_REASONING_REPLAY_METADATA = {
   v: 1,
@@ -45,9 +46,9 @@ const OPENAI_REASONING_REPLAY_METADATA = {
   provider: "openai",
   api: "openai-responses",
   model: "gpt-5.5",
-  baseUrlHash: "base-hash",
-  sessionHash: "session-hash",
-  authProfileHash: "auth-hash",
+  baseUrlHash: "0123456789abcdef",
+  sessionHash: "123456789abcdef0",
+  authProfileHash: "23456789abcdef01",
 } as const;
 
 describe("redactTranscriptMessage", () => {
@@ -73,7 +74,7 @@ describe("redactTranscriptMessage", () => {
 
   it("preserves OpenAI encrypted reasoning inside thinkingSignature", () => {
     const thinkingSignature = JSON.stringify({
-      id: "rs_secret_identifier",
+      id: "reasoning-1",
       type: "reasoning",
       encrypted_content: CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES,
       summary: [{ type: "summary_text", text: "secret sk-abcdef1234567890xyz" }],
@@ -85,6 +86,9 @@ describe("redactTranscriptMessage", () => {
     });
     const msg = {
       role: "assistant",
+      api: "openai-responses",
+      model: "gpt-5.5",
+      provider: "openai",
       content: [
         {
           type: "thinking",
@@ -104,13 +108,17 @@ describe("redactTranscriptMessage", () => {
             encrypted_content: CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES,
             summary: [{ type: "summary_text", text: "secret sk-abcdef1234567890xyz" }],
           }),
+          openclawReasoningReplay: {
+            ...OPENAI_REASONING_REPLAY_METADATA,
+            model: "sk-abcdef1234567890xyz",
+          },
         },
       ],
     } as unknown as AgentMessage;
 
     const result = redactTranscriptMessage(
       msg,
-      cfg("tools", [String.raw`rs_[A-Za-z0-9_]+`, "reasoning", "summary_text"]),
+      cfg("tools", ["reasoning-1", "reasoning", "summary_text"]),
     );
     const block = (msgContent(result) as Array<{ thinking: string; thinkingSignature: string }>)[0];
     const replayItem = JSON.parse(block.thinkingSignature) as {
@@ -126,7 +134,7 @@ describe("redactTranscriptMessage", () => {
     const rejectedSignature = (msgContent(result) as Array<{ thinkingSignature: string }>)[1]
       .thinkingSignature;
     expect(block.thinking).not.toContain("sk-abcdef1234567890xyz");
-    expect(replayItem.id).toBe("rs_secret_identifier");
+    expect(replayItem.id).toBe("reasoning-1");
     expect(replayItem.type).toBe("reasoning");
     expect(replayItem.encrypted_content).toBe(CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES);
     expect(replayItem.summary).toEqual([]);
@@ -136,11 +144,174 @@ describe("redactTranscriptMessage", () => {
     expect(block.thinkingSignature).not.toContain("sk-abcdef1234567890xyz");
     expect(JSON.stringify(blockMetadata)).not.toContain("sk-abcdef1234567890xyz");
     expect(rejectedSignature).not.toContain("sk-abcdef1234567890xyz");
+    expect(JSON.stringify(msgContent(result))).not.toContain("sk-abcdef1234567890xyz");
+  });
+
+  it.each([
+    {
+      api: "openclaw-openai-responses-transport",
+      provider: "openai",
+      block: {
+        type: "thinking",
+        thinking: "visible",
+        thinkingSignature: JSON.stringify({
+          type: "reasoning",
+          encrypted_content: CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES,
+          summary: [],
+        }),
+      },
+      signatureKey: "thinkingSignature",
+      expectedSignature: JSON.stringify({
+        type: "reasoning",
+        summary: [],
+        encrypted_content: CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES,
+      }),
+    },
+    {
+      api: "openclaw-anthropic-messages-transport",
+      provider: "anthropic",
+      block: {
+        type: "thinking",
+        thinking: "visible",
+        thinkingSignature: CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES,
+      },
+      signatureKey: "thinkingSignature",
+      expectedSignature: CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES,
+    },
+    {
+      api: "openclaw-google-generative-ai-transport",
+      provider: "google",
+      block: {
+        type: "toolCall",
+        id: "call_1",
+        name: "send_request",
+        arguments: {},
+        thoughtSignature: GOOGLE_THOUGHT_SIGNATURE,
+      },
+      signatureKey: "thoughtSignature",
+      expectedSignature: GOOGLE_THOUGHT_SIGNATURE,
+    },
+    {
+      api: "openai-completions",
+      provider: "google",
+      block: {
+        type: "toolCall",
+        id: "call_1",
+        name: "send_request",
+        arguments: {},
+        thoughtSignature: SHORT_GOOGLE_THOUGHT_SIGNATURE,
+      },
+      signatureKey: "thoughtSignature",
+      expectedSignature: SHORT_GOOGLE_THOUGHT_SIGNATURE,
+    },
+    {
+      api: "openclaw-openai-completions-transport",
+      provider: "google",
+      block: {
+        type: "toolCall",
+        id: "call_1",
+        name: "send_request",
+        arguments: {},
+        thoughtSignature: GOOGLE_THOUGHT_SIGNATURE,
+      },
+      signatureKey: "thoughtSignature",
+      expectedSignature: GOOGLE_THOUGHT_SIGNATURE,
+    },
+  ])(
+    "preserves replay signatures for managed transport $api",
+    ({ api, provider, block, signatureKey, expectedSignature }) => {
+      const msg = {
+        role: "assistant",
+        api,
+        model: "managed-model",
+        provider,
+        content: [block],
+      } as unknown as AgentMessage;
+
+      const result = redactTranscriptMessage(
+        msg,
+        cfg("tools", [
+          CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES,
+          GOOGLE_THOUGHT_SIGNATURE,
+          SHORT_GOOGLE_THOUGHT_SIGNATURE,
+        ]),
+      );
+      const preservedBlock = (msgContent(result) as Array<Record<string, string>>)[0];
+      expect(preservedBlock[signatureKey]).toBe(expectedSignature);
+    },
+  );
+
+  it("canonicalizes OpenAI-compatible encrypted tool reasoning", () => {
+    const thoughtSignature = JSON.stringify({
+      type: "reasoning.encrypted",
+      data: CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES,
+      id: "reasoning-encrypted-1",
+      format: "anthropic-claude-v1",
+      index: 1,
+      secret: "sk-abcdef1234567890xyz",
+    });
+    const msg = {
+      role: "assistant",
+      api: "openai-completions",
+      model: "anthropic/claude-sonnet-4.6",
+      provider: "openrouter",
+      content: [
+        {
+          type: "toolCall",
+          id: "call_1",
+          name: "send_request",
+          arguments: {},
+          thoughtSignature,
+        },
+      ],
+    } as unknown as AgentMessage;
+
+    const result = redactTranscriptMessage(msg, cfg("tools"));
+    const block = (msgContent(result) as Array<{ thoughtSignature: string }>)[0];
+    expect(JSON.parse(block.thoughtSignature)).toEqual({
+      type: "reasoning.encrypted",
+      data: CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES,
+      id: "reasoning-encrypted-1",
+      format: "anthropic-claude-v1",
+      index: 1,
+    });
+  });
+
+  it("preserves nullable OpenRouter encrypted reasoning format", () => {
+    const thoughtSignature = JSON.stringify({
+      type: "reasoning.encrypted",
+      data: CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES,
+      format: null,
+    });
+    const msg = {
+      role: "assistant",
+      api: "openai-completions",
+      provider: "openrouter",
+      content: [
+        {
+          type: "toolCall",
+          id: "call_1",
+          name: "send_request",
+          arguments: {},
+          thoughtSignature,
+        },
+      ],
+    } as unknown as AgentMessage;
+
+    const result = redactTranscriptMessage(msg, cfg("tools"));
+    const block = (msgContent(result) as Array<{ thoughtSignature: string }>)[0];
+    expect(JSON.parse(block.thoughtSignature)).toEqual({
+      type: "reasoning.encrypted",
+      data: CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES,
+      format: null,
+    });
   });
 
   it("preserves Google tool-call thought signatures while redacting arguments", () => {
     const msg = {
       role: "assistant",
+      api: "google-generative-ai",
+      provider: "google",
       content: [
         {
           type: "toolCall",
@@ -179,19 +350,16 @@ describe("redactTranscriptMessage", () => {
     expect(block.arguments.apiKey).toBe("plains…e123");
   });
 
-  it("preserves direct text and legacy thinking signatures", () => {
+  it("preserves Google text and legacy thinking signatures", () => {
     const msg = {
       role: "assistant",
+      api: "google-generative-ai",
+      provider: "google",
       content: [
         {
           type: "text",
           text: "secret sk-abcdef1234567890xyz",
-          textSignature: BASE64_TEXT_SIGNATURE,
-        },
-        {
-          type: "text",
-          text: "visible",
-          textSignature: JSON.stringify({ v: 1, id: COPILOT_CONNECTION_BOUND_ID }),
+          textSignature: GOOGLE_THOUGHT_SIGNATURE,
         },
         {
           type: "text",
@@ -206,28 +374,49 @@ describe("redactTranscriptMessage", () => {
       ],
     } as unknown as AgentMessage;
 
-    const result = redactTranscriptMessage(
-      msg,
-      cfg("tools", [BASE64_TEXT_SIGNATURE, COPILOT_CONNECTION_BOUND_ID]),
-    );
+    const result = redactTranscriptMessage(msg, cfg("tools", [GOOGLE_THOUGHT_SIGNATURE]));
     const blocks = msgContent(result) as Array<Record<string, string>>;
     expect(blocks[0].text).not.toContain("sk-abcdef1234567890xyz");
-    expect(blocks[0].textSignature).toBe(BASE64_TEXT_SIGNATURE);
-    expect(blocks[1].textSignature).toBe(JSON.stringify({ v: 1, id: COPILOT_CONNECTION_BOUND_ID }));
-    expect(blocks[2].textSignature).not.toContain("sk-abcdef1234567890xyz");
-    expect(blocks[3].thinking).not.toContain("sk-abcdef1234567890xyz");
-    expect(blocks[3].thought_signature).toBe(CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES);
+    expect(blocks[0].textSignature).toBe(GOOGLE_THOUGHT_SIGNATURE);
+    expect(blocks[1].textSignature).not.toContain("sk-abcdef1234567890xyz");
+    expect(blocks[2].thinking).not.toContain("sk-abcdef1234567890xyz");
+    expect(blocks[2].thought_signature).toBe(CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES);
   });
+
+  it.each(["openai-responses", "openclaw-openai-responses-transport"])(
+    "preserves structured OpenAI text signatures for %s",
+    (api) => {
+      const textSignature = JSON.stringify({ v: 1, id: COPILOT_CONNECTION_BOUND_ID });
+      const msg = {
+        role: "assistant",
+        api,
+        provider: "github-copilot",
+        content: [{ type: "text", text: "visible", textSignature }],
+      } as unknown as AgentMessage;
+
+      const result = redactTranscriptMessage(msg, cfg("tools", [COPILOT_CONNECTION_BOUND_ID]));
+      const block = (msgContent(result) as Array<{ textSignature: string }>)[0];
+      expect(block.textSignature).toBe(textSignature);
+    },
+  );
 
   it("preserves Anthropic redacted_thinking data while redacting siblings", () => {
     const msg = {
       role: "assistant",
+      api: "anthropic-messages",
+      provider: "anthropic",
       content: [
+        {
+          type: "thinking",
+          thinking: "secret sk-abcdef1234567890xyz",
+          thinkingSignature: CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES,
+          redacted: true,
+        },
         {
           type: "redacted_thinking",
           data: CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES,
+          signature: CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES,
           thinkingSignature: CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES,
-          thought_signature: CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES,
           metadata: {
             accessToken: "nestedplainsecret123",
           },
@@ -236,18 +425,170 @@ describe("redactTranscriptMessage", () => {
     } as unknown as AgentMessage;
 
     const result = redactTranscriptMessage(msg, cfg("tools"));
-    const block = (
+    const thinkingBlock = (
+      msgContent(result) as Array<{ thinking: string; thinkingSignature: string }>
+    )[0];
+    const redactedBlock = (
       msgContent(result) as Array<{
         data: string;
+        signature: string;
         thinkingSignature: string;
-        thought_signature: string;
         metadata: { accessToken: string };
       }>
-    )[0];
-    expect(block.data).toBe(CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES);
-    expect(block.thinkingSignature).toBe(CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES);
-    expect(block.thought_signature).toBe(CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES);
-    expect(block.metadata.accessToken).toBe("nested…t123");
+    )[1];
+    expect(thinkingBlock.thinking).not.toContain("sk-abcdef1234567890xyz");
+    expect(thinkingBlock.thinkingSignature).toBe(CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES);
+    expect(redactedBlock.data).toBe(CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES);
+    expect(redactedBlock.signature).toBe(CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES);
+    expect(redactedBlock.thinkingSignature).toBe(CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES);
+    expect(redactedBlock.metadata.accessToken).toBe("nested…t123");
+  });
+
+  it("redacts credential-shaped values even on provider signature fields", () => {
+    const googleApiKey = `AIza${"a".repeat(32)}`;
+    const githubToken = `ghp_${"b".repeat(36)}`;
+    const awsAccessKey = "AKIAIOSFODNN7EXAMPLE";
+    const encryptedDetail = JSON.stringify({
+      type: "reasoning.encrypted",
+      data: githubToken,
+      id: "reasoning-encrypted-1",
+    });
+    const googleMsg = {
+      role: "assistant",
+      api: "google-generative-ai",
+      provider: "google",
+      content: [
+        {
+          type: "toolCall",
+          id: "call_1",
+          name: "send_request",
+          arguments: {},
+          thoughtSignature: awsAccessKey,
+        },
+        {
+          type: "toolCall",
+          id: "call_2",
+          name: "send_request",
+          arguments: {},
+          thoughtSignature: googleApiKey,
+        },
+      ],
+    } as unknown as AgentMessage;
+    const anthropicMsg = {
+      role: "assistant",
+      api: "anthropic-messages",
+      provider: "anthropic",
+      content: [{ type: "redacted_thinking", data: githubToken }],
+    } as unknown as AgentMessage;
+    const openAICompletionsMsg = {
+      role: "assistant",
+      api: "openai-completions",
+      provider: "openrouter",
+      content: [
+        {
+          type: "toolCall",
+          id: "call_1",
+          name: "send_request",
+          arguments: {},
+          thoughtSignature: encryptedDetail,
+        },
+      ],
+    } as unknown as AgentMessage;
+    const customProviderMsg = {
+      role: "assistant",
+      api: "custom-provider-api",
+      model: "custom-model",
+      provider: "custom-provider",
+      content: [
+        {
+          type: "thinking",
+          thinking: "visible",
+          thinkingSignature: awsAccessKey,
+        },
+      ],
+    } as unknown as AgentMessage;
+
+    expect(
+      JSON.stringify(msgContent(redactTranscriptMessage(googleMsg, cfg("tools")))),
+    ).not.toContain(awsAccessKey);
+    expect(
+      JSON.stringify(msgContent(redactTranscriptMessage(googleMsg, cfg("tools")))),
+    ).not.toContain(googleApiKey);
+    expect(
+      JSON.stringify(msgContent(redactTranscriptMessage(anthropicMsg, cfg("tools")))),
+    ).not.toContain(githubToken);
+    expect(
+      JSON.stringify(msgContent(redactTranscriptMessage(openAICompletionsMsg, cfg("tools")))),
+    ).not.toContain(githubToken);
+    expect(
+      JSON.stringify(msgContent(redactTranscriptMessage(customProviderMsg, cfg("tools")))),
+    ).not.toContain(awsAccessKey);
+  });
+
+  it("redacts provider-shaped fields when the assistant route is missing", () => {
+    const msg = {
+      role: "assistant",
+      content: [
+        {
+          type: "thinking",
+          thinking: "visible",
+          thinkingSignature: CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES,
+        },
+        {
+          type: "toolCall",
+          id: "call_1",
+          name: "send_request",
+          arguments: {},
+          thoughtSignature: GOOGLE_THOUGHT_SIGNATURE,
+        },
+      ],
+    } as unknown as AgentMessage;
+
+    const result = redactTranscriptMessage(
+      msg,
+      cfg("tools", [CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES, GOOGLE_THOUGHT_SIGNATURE]),
+    );
+    const serialized = JSON.stringify(msgContent(result));
+    expect(serialized).not.toContain(CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES);
+    expect(serialized).not.toContain(GOOGLE_THOUGHT_SIGNATURE);
+  });
+
+  it("preserves validated replay signatures for custom provider APIs", () => {
+    const reasoningSignature = JSON.stringify({
+      type: "reasoning",
+      encrypted_content: CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES,
+      summary: [],
+    });
+    const msg = {
+      role: "assistant",
+      api: "custom-provider-api",
+      model: "custom-model",
+      provider: "custom-provider",
+      content: [
+        {
+          type: "thinking",
+          thinking: "visible",
+          thinkingSignature: reasoningSignature,
+        },
+        {
+          type: "toolCall",
+          id: "call_1",
+          name: "send_request",
+          arguments: {},
+          thoughtSignature: SHORT_GOOGLE_THOUGHT_SIGNATURE,
+        },
+      ],
+    } as unknown as AgentMessage;
+
+    const result = redactTranscriptMessage(
+      msg,
+      cfg("tools", [CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES, SHORT_GOOGLE_THOUGHT_SIGNATURE]),
+    );
+    const blocks = msgContent(result) as Array<Record<string, string>>;
+    expect(JSON.parse(blocks[0].thinkingSignature).encrypted_content).toBe(
+      CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES,
+    );
+    expect(blocks[1].thoughtSignature).toBe(SHORT_GOOGLE_THOUGHT_SIGNATURE);
   });
 
   it("redacts provider-shaped fields outside direct assistant content blocks", () => {

--- a/src/agents/transcript-redact.test.ts
+++ b/src/agents/transcript-redact.test.ts
@@ -95,6 +95,16 @@ describe("redactTranscriptMessage", () => {
             secret: "sk-abcdef1234567890xyz",
           },
         },
+        {
+          type: "thinking",
+          thinking: "visible",
+          thinkingSignature: JSON.stringify({
+            type: "reasoning",
+            status: "future",
+            encrypted_content: CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES,
+            summary: [{ type: "summary_text", text: "secret sk-abcdef1234567890xyz" }],
+          }),
+        },
       ],
     } as unknown as AgentMessage;
 
@@ -113,6 +123,8 @@ describe("redactTranscriptMessage", () => {
     };
     const blockMetadata = (block as unknown as { openclawReasoningReplay: Record<string, unknown> })
       .openclawReasoningReplay;
+    const rejectedSignature = (msgContent(result) as Array<{ thinkingSignature: string }>)[1]
+      .thinkingSignature;
     expect(block.thinking).not.toContain("sk-abcdef1234567890xyz");
     expect(replayItem.id).toBe("rs_secret_identifier");
     expect(replayItem.type).toBe("reasoning");
@@ -123,6 +135,7 @@ describe("redactTranscriptMessage", () => {
     expect(blockMetadata).toEqual(OPENAI_REASONING_REPLAY_METADATA);
     expect(block.thinkingSignature).not.toContain("sk-abcdef1234567890xyz");
     expect(JSON.stringify(blockMetadata)).not.toContain("sk-abcdef1234567890xyz");
+    expect(rejectedSignature).not.toContain("sk-abcdef1234567890xyz");
   });
 
   it("preserves Google tool-call thought signatures while redacting arguments", () => {

--- a/src/agents/transcript-redact.test.ts
+++ b/src/agents/transcript-redact.test.ts
@@ -1,8 +1,9 @@
 // Transcript redaction tests cover structured and text transcript fields so
 // secrets do not persist in logs or replay artifacts.
 import type { AgentMessage } from "openclaw/plugin-sdk/agent-core";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import * as loggingConfigModule from "../logging/config.js";
 import { redactTranscriptMessage } from "./transcript-redact.js";
 
 // AgentMessage includes custom message types without content; this accessor
@@ -36,6 +37,18 @@ const BMP_BASE64_WITH_SECRET_TOKEN_SUBSTRING = Buffer.from(
 ).toString("base64");
 const CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES =
   "gAAAAABpQnQrXzzZqcAfo3unbAY-ku84xgsvB0fpLkbDvSh3WS5qzfSCmcgwr8_abcdefghijvK2RyV2GQ4ohzcfYwhRwTvY76TvR7Tvr_";
+const BASE64_TEXT_SIGNATURE = "QUJDREVGR0hJSktMTU5PUA==";
+const COPILOT_CONNECTION_BOUND_ID = Buffer.from(`message-${"y".repeat(24)}`).toString("base64");
+const OPENAI_REASONING_REPLAY_METADATA = {
+  v: 1,
+  source: "openai-responses",
+  provider: "openai",
+  api: "openai-responses",
+  model: "gpt-5.5",
+  baseUrlHash: "base-hash",
+  sessionHash: "session-hash",
+  authProfileHash: "auth-hash",
+} as const;
 
 describe("redactTranscriptMessage", () => {
   it("redacts text block matching default patterns (sk- token)", () => {
@@ -60,9 +73,15 @@ describe("redactTranscriptMessage", () => {
 
   it("preserves OpenAI encrypted reasoning inside thinkingSignature", () => {
     const thinkingSignature = JSON.stringify({
+      id: "rs_secret_identifier",
       type: "reasoning",
       encrypted_content: CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES,
-      summary: [],
+      summary: [{ type: "summary_text", text: "secret sk-abcdef1234567890xyz" }],
+      content: [{ type: "reasoning_text", text: "secret sk-abcdef1234567890xyz" }],
+      __openclaw_replay: {
+        ...OPENAI_REASONING_REPLAY_METADATA,
+        secret: "sk-abcdef1234567890xyz",
+      },
     });
     const msg = {
       role: "assistant",
@@ -71,27 +90,65 @@ describe("redactTranscriptMessage", () => {
           type: "thinking",
           thinking: "secret sk-abcdef1234567890xyz",
           thinkingSignature,
+          openclawReasoningReplay: {
+            ...OPENAI_REASONING_REPLAY_METADATA,
+            secret: "sk-abcdef1234567890xyz",
+          },
         },
       ],
     } as unknown as AgentMessage;
 
-    const result = redactTranscriptMessage(msg, cfg("tools"));
+    const result = redactTranscriptMessage(
+      msg,
+      cfg("tools", [String.raw`rs_[A-Za-z0-9_]+`, "reasoning", "summary_text"]),
+    );
     const block = (msgContent(result) as Array<{ thinking: string; thinkingSignature: string }>)[0];
+    const replayItem = JSON.parse(block.thinkingSignature) as {
+      id: string;
+      type: string;
+      encrypted_content: string;
+      summary: unknown[];
+      content?: unknown[];
+      __openclaw_replay: Record<string, unknown>;
+    };
+    const blockMetadata = (block as unknown as { openclawReasoningReplay: Record<string, unknown> })
+      .openclawReasoningReplay;
     expect(block.thinking).not.toContain("sk-abcdef1234567890xyz");
-    expect(block.thinkingSignature).toBe(thinkingSignature);
-    expect(block.thinkingSignature).toContain(CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES);
-    expect(block.thinkingSignature).not.toContain("…");
+    expect(replayItem.id).toBe("rs_secret_identifier");
+    expect(replayItem.type).toBe("reasoning");
+    expect(replayItem.encrypted_content).toBe(CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES);
+    expect(replayItem.summary).toEqual([]);
+    expect(replayItem.content).toBeUndefined();
+    expect(replayItem["__openclaw_replay"]).toEqual(OPENAI_REASONING_REPLAY_METADATA);
+    expect(blockMetadata).toEqual(OPENAI_REASONING_REPLAY_METADATA);
+    expect(block.thinkingSignature).not.toContain("sk-abcdef1234567890xyz");
+    expect(JSON.stringify(blockMetadata)).not.toContain("sk-abcdef1234567890xyz");
   });
 
-  it("preserves opaque encrypted_content fields while redacting siblings", () => {
+  it("preserves Google tool-call thought signatures while redacting arguments", () => {
     const msg = {
       role: "assistant",
       content: [
         {
-          type: "gatewayCustom",
-          encrypted_content: CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES,
-          payload: {
+          type: "toolCall",
+          id: "call_1",
+          name: "send_request",
+          thoughtSignature: CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES,
+          arguments: {
             apiKey: "plainsecretvalue123",
+            thinkingSignature: "sk-abcdef1234567890xyz",
+            thoughtSignature: "sk-abcdef1234567890xyz",
+            thought_signature: "sk-abcdef1234567890xyz",
+            encrypted_content: "sk-abcdef1234567890xyz",
+            nestedAssistant: {
+              role: "assistant",
+              content: [
+                {
+                  type: "thinking",
+                  thinkingSignature: "sk-abcdef1234567890xyz",
+                },
+              ],
+            },
           },
         },
       ],
@@ -99,10 +156,54 @@ describe("redactTranscriptMessage", () => {
 
     const result = redactTranscriptMessage(msg, cfg("tools"));
     const block = (
-      msgContent(result) as Array<{ encrypted_content: string; payload: { apiKey: string } }>
+      msgContent(result) as Array<{
+        thoughtSignature: string;
+        arguments: Record<string, string>;
+      }>
     )[0];
-    expect(block.encrypted_content).toBe(CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES);
-    expect(block.payload.apiKey).toBe("plains…e123");
+    expect(block.thoughtSignature).toBe(CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES);
+    expect(JSON.stringify(block.arguments)).not.toContain("sk-abcdef1234567890xyz");
+    expect(block.arguments.apiKey).toBe("plains…e123");
+  });
+
+  it("preserves direct text and legacy thinking signatures", () => {
+    const msg = {
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: "secret sk-abcdef1234567890xyz",
+          textSignature: BASE64_TEXT_SIGNATURE,
+        },
+        {
+          type: "text",
+          text: "visible",
+          textSignature: JSON.stringify({ v: 1, id: COPILOT_CONNECTION_BOUND_ID }),
+        },
+        {
+          type: "text",
+          text: "visible",
+          textSignature: "sk-abcdef1234567890xyz",
+        },
+        {
+          type: "thinking",
+          thinking: "secret sk-abcdef1234567890xyz",
+          thought_signature: CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES,
+        },
+      ],
+    } as unknown as AgentMessage;
+
+    const result = redactTranscriptMessage(
+      msg,
+      cfg("tools", [BASE64_TEXT_SIGNATURE, COPILOT_CONNECTION_BOUND_ID]),
+    );
+    const blocks = msgContent(result) as Array<Record<string, string>>;
+    expect(blocks[0].text).not.toContain("sk-abcdef1234567890xyz");
+    expect(blocks[0].textSignature).toBe(BASE64_TEXT_SIGNATURE);
+    expect(blocks[1].textSignature).toBe(JSON.stringify({ v: 1, id: COPILOT_CONNECTION_BOUND_ID }));
+    expect(blocks[2].textSignature).not.toContain("sk-abcdef1234567890xyz");
+    expect(blocks[3].thinking).not.toContain("sk-abcdef1234567890xyz");
+    expect(blocks[3].thought_signature).toBe(CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES);
   });
 
   it("preserves Anthropic redacted_thinking data while redacting siblings", () => {
@@ -112,6 +213,8 @@ describe("redactTranscriptMessage", () => {
         {
           type: "redacted_thinking",
           data: CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES,
+          thinkingSignature: CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES,
+          thought_signature: CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES,
           metadata: {
             accessToken: "nestedplainsecret123",
           },
@@ -121,13 +224,20 @@ describe("redactTranscriptMessage", () => {
 
     const result = redactTranscriptMessage(msg, cfg("tools"));
     const block = (
-      msgContent(result) as Array<{ data: string; metadata: { accessToken: string } }>
+      msgContent(result) as Array<{
+        data: string;
+        thinkingSignature: string;
+        thought_signature: string;
+        metadata: { accessToken: string };
+      }>
     )[0];
     expect(block.data).toBe(CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES);
+    expect(block.thinkingSignature).toBe(CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES);
+    expect(block.thought_signature).toBe(CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES);
     expect(block.metadata.accessToken).toBe("nested…t123");
   });
 
-  it("redacts ordinary data and signature fields", () => {
+  it("redacts provider-shaped fields outside direct assistant content blocks", () => {
     const msg = {
       role: "assistant",
       content: [
@@ -135,14 +245,20 @@ describe("redactTranscriptMessage", () => {
           type: "gatewayCustom",
           data: "secret sk-abcdef1234567890xyz",
           signature: "secret sk-abcdef1234567890xyz",
+          thinkingSignature: "secret sk-abcdef1234567890xyz",
+          thoughtSignature: "secret sk-abcdef1234567890xyz",
+          thought_signature: "secret sk-abcdef1234567890xyz",
+          encrypted_content: "secret sk-abcdef1234567890xyz",
+          nested: {
+            type: "redacted_thinking",
+            data: "secret sk-abcdef1234567890xyz",
+          },
         },
       ],
     } as unknown as AgentMessage;
 
     const result = redactTranscriptMessage(msg, cfg("tools"));
-    const block = (msgContent(result) as Array<{ data: string; signature: string }>)[0];
-    expect(block.data).not.toContain("sk-abcdef1234567890xyz");
-    expect(block.signature).not.toContain("sk-abcdef1234567890xyz");
+    expect(JSON.stringify(msgContent(result))).not.toContain("sk-abcdef1234567890xyz");
   });
 
   it("redacts partialJson block", () => {
@@ -657,6 +773,33 @@ describe("redactTranscriptMessage", () => {
     const msg = textMessage("nothing sensitive here");
     const result = redactTranscriptMessage(msg, cfg("tools"));
     expect(result).toBe(msg);
+  });
+
+  it("passes through signatures unchanged when global redaction is off", () => {
+    const readLoggingConfig = vi
+      .spyOn(loggingConfigModule, "readLoggingConfig")
+      .mockReturnValue({ redactSensitive: "off" });
+    const msg = {
+      role: "assistant",
+      content: [
+        {
+          type: "thinking",
+          thinking: "secret sk-abcdef1234567890xyz",
+          thinkingSignature: JSON.stringify({
+            id: "rs_secret_identifier",
+            type: "reasoning",
+            summary: [{ type: "summary_text", text: "secret sk-abcdef1234567890xyz" }],
+            encrypted_content: CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES,
+          }),
+        },
+      ],
+    } as unknown as AgentMessage;
+
+    try {
+      expect(redactTranscriptMessage(msg)).toBe(msg);
+    } finally {
+      readLoggingConfig.mockRestore();
+    }
   });
 
   it("redacts with cfg=undefined (falls back to default patterns)", () => {

--- a/src/agents/transcript-redact.test.ts
+++ b/src/agents/transcript-redact.test.ts
@@ -34,6 +34,8 @@ const BMP_BASE64_WITH_SECRET_TOKEN_SUBSTRING = Buffer.from(
   "BMsk-abcdef1234567890xyz",
   "ascii",
 ).toString("base64");
+const CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES =
+  "gAAAAABpQnQrXzzZqcAfo3unbAY-ku84xgsvB0fpLkbDvSh3WS5qzfSCmcgwr8_abcdefghijvK2RyV2GQ4ohzcfYwhRwTvY76TvR7Tvr_";
 
 describe("redactTranscriptMessage", () => {
   it("redacts text block matching default patterns (sk- token)", () => {
@@ -54,6 +56,93 @@ describe("redactTranscriptMessage", () => {
     const result = redactTranscriptMessage(msg, cfg("tools"));
     const block = (msgContent(result) as Array<{ thinking: string }>)[0];
     expect(block.thinking).not.toContain("sk-abcdef1234567890xyz");
+  });
+
+  it("preserves OpenAI encrypted reasoning inside thinkingSignature", () => {
+    const thinkingSignature = JSON.stringify({
+      type: "reasoning",
+      encrypted_content: CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES,
+      summary: [],
+    });
+    const msg = {
+      role: "assistant",
+      content: [
+        {
+          type: "thinking",
+          thinking: "secret sk-abcdef1234567890xyz",
+          thinkingSignature,
+        },
+      ],
+    } as unknown as AgentMessage;
+
+    const result = redactTranscriptMessage(msg, cfg("tools"));
+    const block = (msgContent(result) as Array<{ thinking: string; thinkingSignature: string }>)[0];
+    expect(block.thinking).not.toContain("sk-abcdef1234567890xyz");
+    expect(block.thinkingSignature).toBe(thinkingSignature);
+    expect(block.thinkingSignature).toContain(CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES);
+    expect(block.thinkingSignature).not.toContain("…");
+  });
+
+  it("preserves opaque encrypted_content fields while redacting siblings", () => {
+    const msg = {
+      role: "assistant",
+      content: [
+        {
+          type: "gatewayCustom",
+          encrypted_content: CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES,
+          payload: {
+            apiKey: "plainsecretvalue123",
+          },
+        },
+      ],
+    } as unknown as AgentMessage;
+
+    const result = redactTranscriptMessage(msg, cfg("tools"));
+    const block = (
+      msgContent(result) as Array<{ encrypted_content: string; payload: { apiKey: string } }>
+    )[0];
+    expect(block.encrypted_content).toBe(CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES);
+    expect(block.payload.apiKey).toBe("plains…e123");
+  });
+
+  it("preserves Anthropic redacted_thinking data while redacting siblings", () => {
+    const msg = {
+      role: "assistant",
+      content: [
+        {
+          type: "redacted_thinking",
+          data: CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES,
+          metadata: {
+            accessToken: "nestedplainsecret123",
+          },
+        },
+      ],
+    } as unknown as AgentMessage;
+
+    const result = redactTranscriptMessage(msg, cfg("tools"));
+    const block = (
+      msgContent(result) as Array<{ data: string; metadata: { accessToken: string } }>
+    )[0];
+    expect(block.data).toBe(CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES);
+    expect(block.metadata.accessToken).toBe("nested…t123");
+  });
+
+  it("redacts ordinary data and signature fields", () => {
+    const msg = {
+      role: "assistant",
+      content: [
+        {
+          type: "gatewayCustom",
+          data: "secret sk-abcdef1234567890xyz",
+          signature: "secret sk-abcdef1234567890xyz",
+        },
+      ],
+    } as unknown as AgentMessage;
+
+    const result = redactTranscriptMessage(msg, cfg("tools"));
+    const block = (msgContent(result) as Array<{ data: string; signature: string }>)[0];
+    expect(block.data).not.toContain("sk-abcdef1234567890xyz");
+    expect(block.signature).not.toContain("sk-abcdef1234567890xyz");
   });
 
   it("redacts partialJson block", () => {

--- a/src/agents/transcript-redact.ts
+++ b/src/agents/transcript-redact.ts
@@ -180,6 +180,31 @@ function shouldPreserveNestedImageDataUrlFields(
   );
 }
 
+const OPAQUE_PROVIDER_FIELD_KEYS = new Set([
+  "encrypted_content",
+  "thinkingSignature",
+  "thoughtSignature",
+  "thought_signature",
+]);
+
+function shouldPreserveOpaqueProviderPayload(
+  source: Record<string, unknown>,
+  key: string,
+  item: unknown,
+): boolean {
+  if (typeof item !== "string") {
+    return false;
+  }
+  if (OPAQUE_PROVIDER_FIELD_KEYS.has(key)) {
+    return true;
+  }
+  const type = source.type;
+  return (
+    (type === "redacted_thinking" && key === "data") ||
+    ((type === "thinking" || type === "redacted_thinking") && key === "signature")
+  );
+}
+
 function redactTranscriptStructuredValue(
   value: unknown,
   cfg?: OpenClawConfig,
@@ -235,6 +260,10 @@ function redactTranscriptStructuredValue(
     next = { ...source };
   }
   for (const [key, item] of Object.entries(source)) {
+    // Provider-signed/encrypted bytes must remain exact or replayed tool turns fail.
+    if (shouldPreserveOpaqueProviderPayload(source, key, item)) {
+      continue;
+    }
     if (typeof item === "string") {
       const sanitizedDataUrl =
         preserveImageDataUrlFields && key === "url"

--- a/src/agents/transcript-redact.ts
+++ b/src/agents/transcript-redact.ts
@@ -35,6 +35,10 @@ function redactTranscriptOptions(cfg?: OpenClawConfig) {
   };
 }
 
+function isTranscriptRedactionDisabled(cfg?: OpenClawConfig): boolean {
+  return (cfg?.logging?.redactSensitive ?? readLoggingConfig()?.redactSensitive) === "off";
+}
+
 function redactTranscriptText(value: string, cfg?: OpenClawConfig): string {
   if (cfg?.logging?.redactSensitive === "off") {
     return value;
@@ -180,29 +184,169 @@ function shouldPreserveNestedImageDataUrlFields(
   );
 }
 
-const OPAQUE_PROVIDER_FIELD_KEYS = new Set([
-  "encrypted_content",
-  "thinkingSignature",
-  "thoughtSignature",
-  "thought_signature",
+type TranscriptValueLocation =
+  | "root"
+  | "assistant-content-array"
+  | "assistant-content-block"
+  | "nested";
+
+function isCanonicalBase64Signature(value: string): boolean {
+  const compact = value.trim().replace(/\s+/g, "");
+  if (!compact || !/^[A-Za-z0-9+/=_-]+$/.test(compact)) {
+    return false;
+  }
+  const encoding = compact.includes("-") || compact.includes("_") ? "base64url" : "base64";
+  try {
+    const encoded = Buffer.from(compact, encoding).toString(encoding);
+    return encoded.replace(/=+$/g, "") === compact.replace(/=+$/g, "");
+  } catch {
+    return false;
+  }
+}
+
+function isOpenAITextSignature(value: string): boolean {
+  if (value.startsWith("{")) {
+    try {
+      const parsed = JSON.parse(value) as unknown;
+      if (!parsed || typeof parsed !== "object" || !isPlainTranscriptObject(parsed)) {
+        return false;
+      }
+      if (!Object.keys(parsed).every((key) => key === "v" || key === "id" || key === "phase")) {
+        return false;
+      }
+      const id = typeof parsed.id === "string" && parsed.id.length > 0 ? parsed.id : undefined;
+      const phase =
+        parsed.phase === "commentary" || parsed.phase === "final_answer" ? parsed.phase : undefined;
+      return parsed.v === 1 && (id !== undefined || phase !== undefined);
+    } catch {
+      return false;
+    }
+  }
+  return /^msg_[A-Za-z0-9_-]+$/.test(value);
+}
+
+function isReplayableTextSignature(value: string): boolean {
+  return isOpenAITextSignature(value) || isCanonicalBase64Signature(value);
+}
+
+const OPENAI_REASONING_REPLAY_METADATA_KEYS = new Set([
+  "v",
+  "source",
+  "provider",
+  "api",
+  "model",
+  "baseUrlHash",
+  "sessionHash",
+  "authProfileHash",
 ]);
+const OPENAI_REASONING_REPLAY_METADATA_KEY = "__openclaw_replay";
+
+function sanitizeOpenAIReasoningReplayMetadata(
+  value: unknown,
+): Record<string, unknown> | undefined {
+  if (!value || typeof value !== "object" || !isPlainTranscriptObject(value)) {
+    return undefined;
+  }
+  if (
+    value.v !== 1 ||
+    value.source !== "openai-responses" ||
+    typeof value.provider !== "string" ||
+    typeof value.api !== "string" ||
+    typeof value.model !== "string" ||
+    (value.baseUrlHash !== undefined && typeof value.baseUrlHash !== "string") ||
+    (value.sessionHash !== undefined && typeof value.sessionHash !== "string") ||
+    (value.authProfileHash !== undefined && typeof value.authProfileHash !== "string")
+  ) {
+    return undefined;
+  }
+  if (Object.keys(value).every((key) => OPENAI_REASONING_REPLAY_METADATA_KEYS.has(key))) {
+    return value;
+  }
+  return {
+    v: 1,
+    source: "openai-responses",
+    provider: value.provider,
+    api: value.api,
+    model: value.model,
+    ...(value.baseUrlHash !== undefined ? { baseUrlHash: value.baseUrlHash } : {}),
+    ...(value.sessionHash !== undefined ? { sessionHash: value.sessionHash } : {}),
+    ...(value.authProfileHash !== undefined ? { authProfileHash: value.authProfileHash } : {}),
+  };
+}
 
 function shouldPreserveOpaqueProviderPayload(
   source: Record<string, unknown>,
   key: string,
   item: unknown,
+  location: TranscriptValueLocation,
 ): boolean {
-  if (typeof item !== "string") {
+  if (location !== "assistant-content-block" || typeof item !== "string") {
     return false;
-  }
-  if (OPAQUE_PROVIDER_FIELD_KEYS.has(key)) {
-    return true;
   }
   const type = source.type;
   return (
-    (type === "redacted_thinking" && key === "data") ||
-    ((type === "thinking" || type === "redacted_thinking") && key === "signature")
+    (type === "text" && key === "textSignature" && isReplayableTextSignature(item)) ||
+    (type === "thinking" &&
+      (key === "thinkingSignature" || key === "signature" || key === "thought_signature")) ||
+    (type === "redacted_thinking" &&
+      (key === "data" ||
+        key === "signature" ||
+        key === "thinkingSignature" ||
+        key === "thought_signature")) ||
+    (type === "toolCall" && key === "thoughtSignature")
   );
+}
+
+function sanitizeOpenAIReasoningSignature(value: string): string | undefined {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    return undefined;
+  }
+  if (
+    !parsed ||
+    typeof parsed !== "object" ||
+    !isPlainTranscriptObject(parsed) ||
+    parsed.type !== "reasoning" ||
+    (parsed.summary !== undefined && !Array.isArray(parsed.summary))
+  ) {
+    return undefined;
+  }
+  const encryptedContent = parsed.encrypted_content;
+  const hasEncryptedContent = Object.hasOwn(parsed, "encrypted_content");
+  if (
+    encryptedContent !== undefined &&
+    encryptedContent !== null &&
+    typeof encryptedContent !== "string"
+  ) {
+    return undefined;
+  }
+  if (parsed.id !== undefined && typeof parsed.id !== "string") {
+    return undefined;
+  }
+  if (
+    parsed.status !== undefined &&
+    parsed.status !== "in_progress" &&
+    parsed.status !== "completed" &&
+    parsed.status !== "incomplete"
+  ) {
+    return undefined;
+  }
+  if (!hasEncryptedContent && typeof parsed.id !== "string") {
+    return undefined;
+  }
+  const replayMetadata = sanitizeOpenAIReasoningReplayMetadata(
+    parsed[OPENAI_REASONING_REPLAY_METADATA_KEY],
+  );
+  return JSON.stringify({
+    ...(typeof parsed.id === "string" ? { id: parsed.id } : {}),
+    type: "reasoning",
+    summary: [],
+    ...(parsed.status !== undefined ? { status: parsed.status } : {}),
+    ...(hasEncryptedContent ? { encrypted_content: encryptedContent } : {}),
+    ...(replayMetadata ? { [OPENAI_REASONING_REPLAY_METADATA_KEY]: replayMetadata } : {}),
+  });
 }
 
 function redactTranscriptStructuredValue(
@@ -211,6 +355,7 @@ function redactTranscriptStructuredValue(
   fieldKey?: string,
   seen: WeakSet<object> = new WeakSet<object>(),
   preserveImageDataUrlFields = false,
+  location: TranscriptValueLocation = "nested",
 ): unknown {
   if (typeof value === "string") {
     if (fieldKey) {
@@ -231,6 +376,7 @@ function redactTranscriptStructuredValue(
         fieldKey,
         seen,
         preserveImageDataUrlFields,
+        location === "assistant-content-array" ? "assistant-content-block" : "nested",
       );
       changed ||= next !== item;
       return next;
@@ -260,8 +406,37 @@ function redactTranscriptStructuredValue(
     next = { ...source };
   }
   for (const [key, item] of Object.entries(source)) {
+    if (
+      location === "assistant-content-block" &&
+      source.type === "thinking" &&
+      key === "openclawReasoningReplay"
+    ) {
+      const sanitizedMetadata = sanitizeOpenAIReasoningReplayMetadata(item);
+      if (sanitizedMetadata !== undefined) {
+        if (sanitizedMetadata !== item) {
+          next ??= { ...source };
+          next[key] = sanitizedMetadata;
+        }
+        continue;
+      }
+    }
+    if (
+      location === "assistant-content-block" &&
+      source.type === "thinking" &&
+      key === "thinkingSignature" &&
+      typeof item === "string"
+    ) {
+      const sanitizedSignature = sanitizeOpenAIReasoningSignature(item);
+      if (sanitizedSignature !== undefined) {
+        if (sanitizedSignature !== item) {
+          next ??= { ...source };
+          next[key] = sanitizedSignature;
+        }
+        continue;
+      }
+    }
     // Provider-signed/encrypted bytes must remain exact or replayed tool turns fail.
-    if (shouldPreserveOpaqueProviderPayload(source, key, item)) {
+    if (shouldPreserveOpaqueProviderPayload(source, key, item, location)) {
       continue;
     }
     if (typeof item === "string") {
@@ -288,6 +463,9 @@ function redactTranscriptStructuredValue(
       key,
       seen,
       preserveImageDataUrlFields || shouldPreserveNestedImageDataUrlFields(source, key),
+      location === "root" && source.role === "assistant" && key === "content" && Array.isArray(item)
+        ? "assistant-content-array"
+        : "nested",
     );
     if (redacted === item) {
       continue;
@@ -301,8 +479,15 @@ function redactTranscriptStructuredValue(
 
 /** Return a redacted transcript message according to logging config. */
 export function redactTranscriptMessage(message: AgentMessage, cfg?: OpenClawConfig): AgentMessage {
-  if (cfg?.logging?.redactSensitive === "off") {
+  if (isTranscriptRedactionDisabled(cfg)) {
     return message;
   }
-  return redactTranscriptStructuredValue(message, cfg) as AgentMessage;
+  return redactTranscriptStructuredValue(
+    message,
+    cfg,
+    undefined,
+    new WeakSet<object>(),
+    false,
+    "root",
+  ) as AgentMessage;
 }

--- a/src/agents/transcript-redact.ts
+++ b/src/agents/transcript-redact.ts
@@ -287,7 +287,9 @@ function shouldPreserveOpaqueProviderPayload(
   return (
     (type === "text" && key === "textSignature" && isReplayableTextSignature(item)) ||
     (type === "thinking" &&
-      (key === "thinkingSignature" || key === "signature" || key === "thought_signature")) ||
+      ((key === "thinkingSignature" && !item.trimStart().startsWith("{")) ||
+        key === "signature" ||
+        key === "thought_signature")) ||
     (type === "redacted_thinking" &&
       (key === "data" ||
         key === "signature" ||

--- a/src/agents/transcript-redact.ts
+++ b/src/agents/transcript-redact.ts
@@ -190,21 +190,107 @@ type TranscriptValueLocation =
   | "assistant-content-block"
   | "nested";
 
-function isCanonicalBase64Signature(value: string): boolean {
-  const compact = value.trim().replace(/\s+/g, "");
-  if (!compact || !/^[A-Za-z0-9+/=_-]+$/.test(compact)) {
-    return false;
-  }
-  const encoding = compact.includes("-") || compact.includes("_") ? "base64url" : "base64";
-  try {
-    const encoded = Buffer.from(compact, encoding).toString(encoding);
-    return encoded.replace(/=+$/g, "") === compact.replace(/=+$/g, "");
-  } catch {
-    return false;
-  }
+type TranscriptAssistantRoute = {
+  api?: string;
+  model?: string;
+  provider?: string;
+};
+
+const OPENAI_RESPONSES_APIS = new Set([
+  "openai-responses",
+  "azure-openai-responses",
+  "openai-chatgpt-responses",
+  "openclaw-openai-responses-transport",
+  "openclaw-azure-openai-responses-transport",
+]);
+const GOOGLE_REASONING_APIS = new Set([
+  "google-generative-ai",
+  "google-vertex",
+  "google-gemini-cli",
+  "openclaw-google-generative-ai-transport",
+]);
+const ANTHROPIC_REASONING_APIS = new Set([
+  "anthropic-messages",
+  "bedrock-converse-stream",
+  "openclaw-anthropic-messages-transport",
+]);
+const OPENAI_COMPLETIONS_APIS = new Set([
+  "openai-completions",
+  "openclaw-openai-completions-transport",
+]);
+const OPAQUE_REPLAY_TOKEN_RE = /^[A-Za-z0-9+/_-]+={0,2}$/;
+const OPENAI_REPLAY_CONTEXT_HASH_RE = /^[a-f0-9]{16}$/;
+
+function isOpenAIResponsesRoute(route: TranscriptAssistantRoute | undefined): boolean {
+  return typeof route?.api === "string" && OPENAI_RESPONSES_APIS.has(route.api);
 }
 
-function isOpenAITextSignature(value: string): boolean {
+function isGoogleReasoningRoute(route: TranscriptAssistantRoute | undefined): boolean {
+  return typeof route?.api === "string" && GOOGLE_REASONING_APIS.has(route.api);
+}
+
+function isAnthropicReasoningRoute(route: TranscriptAssistantRoute | undefined): boolean {
+  return typeof route?.api === "string" && ANTHROPIC_REASONING_APIS.has(route.api);
+}
+
+function isOpenAICompletionsRoute(route: TranscriptAssistantRoute | undefined): boolean {
+  return typeof route?.api === "string" && OPENAI_COMPLETIONS_APIS.has(route.api);
+}
+
+function isCustomProviderRoute(route: TranscriptAssistantRoute | undefined): boolean {
+  return (
+    Boolean(route?.api && route.model && route.provider) &&
+    route?.api !== "mistral-conversations" &&
+    !isOpenAIResponsesRoute(route) &&
+    !isGoogleReasoningRoute(route) &&
+    !isAnthropicReasoningRoute(route) &&
+    !isOpenAICompletionsRoute(route)
+  );
+}
+
+function isGitHubCopilotResponsesRoute(route: TranscriptAssistantRoute | undefined): boolean {
+  return (
+    (route?.api === "openai-responses" || route?.api === "openclaw-openai-responses-transport") &&
+    route.provider === "github-copilot"
+  );
+}
+
+function isOpaqueReplayToken(value: string): boolean {
+  if (
+    value.length === 0 ||
+    value !== value.trim() ||
+    !OPAQUE_REPLAY_TOKEN_RE.test(value) ||
+    value.includes("\u2026")
+  ) {
+    return false;
+  }
+  // OpenAI encrypted reasoning is commonly Fernet-shaped and intentionally
+  // matches the generic gAAAA secret detector. Other known credential forms
+  // must never gain a transcript-redaction bypass.
+  return value.startsWith("gAAAA") || redactSensitiveText(value, { mode: "tools" }) === value;
+}
+
+function isSafeReplayIdentifier(value: string, maxLength = 512): boolean {
+  return (
+    value.length > 0 &&
+    value.length <= maxLength &&
+    value === value.trim() &&
+    /^[A-Za-z0-9+/_:.=-]+$/.test(value) &&
+    redactSensitiveText(value, { mode: "tools" }) === value
+  );
+}
+
+function isOpenAIResponseItemId(
+  value: string,
+  route: TranscriptAssistantRoute | undefined,
+): boolean {
+  return isSafeReplayIdentifier(value, isGitHubCopilotResponsesRoute(route) ? 64 : 512);
+}
+
+function isOpenAITextSignature(
+  value: string,
+  route: TranscriptAssistantRoute | undefined,
+): boolean {
   if (value.startsWith("{")) {
     try {
       const parsed = JSON.parse(value) as unknown;
@@ -214,19 +300,21 @@ function isOpenAITextSignature(value: string): boolean {
       if (!Object.keys(parsed).every((key) => key === "v" || key === "id" || key === "phase")) {
         return false;
       }
-      const id = typeof parsed.id === "string" && parsed.id.length > 0 ? parsed.id : undefined;
+      const id =
+        typeof parsed.id === "string" && isOpenAIResponseItemId(parsed.id, route)
+          ? parsed.id
+          : undefined;
       const phase =
         parsed.phase === "commentary" || parsed.phase === "final_answer" ? parsed.phase : undefined;
+      if (parsed.id !== undefined && id === undefined) {
+        return false;
+      }
       return parsed.v === 1 && (id !== undefined || phase !== undefined);
     } catch {
       return false;
     }
   }
-  return /^msg_[A-Za-z0-9_-]+$/.test(value);
-}
-
-function isReplayableTextSignature(value: string): boolean {
-  return isOpenAITextSignature(value) || isCanonicalBase64Signature(value);
+  return isOpenAIResponseItemId(value, route);
 }
 
 const OPENAI_REASONING_REPLAY_METADATA_KEYS = new Set([
@@ -243,19 +331,33 @@ const OPENAI_REASONING_REPLAY_METADATA_KEY = "__openclaw_replay";
 
 function sanitizeOpenAIReasoningReplayMetadata(
   value: unknown,
+  route: TranscriptAssistantRoute | undefined,
 ): Record<string, unknown> | undefined {
-  if (!value || typeof value !== "object" || !isPlainTranscriptObject(value)) {
+  if (
+    !value ||
+    typeof value !== "object" ||
+    !isPlainTranscriptObject(value) ||
+    !route?.api ||
+    !route.model ||
+    !route.provider
+  ) {
     return undefined;
   }
   if (
     value.v !== 1 ||
     value.source !== "openai-responses" ||
-    typeof value.provider !== "string" ||
-    typeof value.api !== "string" ||
-    typeof value.model !== "string" ||
-    (value.baseUrlHash !== undefined && typeof value.baseUrlHash !== "string") ||
-    (value.sessionHash !== undefined && typeof value.sessionHash !== "string") ||
-    (value.authProfileHash !== undefined && typeof value.authProfileHash !== "string")
+    value.provider !== route?.provider ||
+    value.api !== route.api ||
+    value.model !== route.model ||
+    (value.baseUrlHash !== undefined &&
+      (typeof value.baseUrlHash !== "string" ||
+        !OPENAI_REPLAY_CONTEXT_HASH_RE.test(value.baseUrlHash))) ||
+    (value.sessionHash !== undefined &&
+      (typeof value.sessionHash !== "string" ||
+        !OPENAI_REPLAY_CONTEXT_HASH_RE.test(value.sessionHash))) ||
+    (value.authProfileHash !== undefined &&
+      (typeof value.authProfileHash !== "string" ||
+        !OPENAI_REPLAY_CONTEXT_HASH_RE.test(value.authProfileHash)))
   ) {
     return undefined;
   }
@@ -279,27 +381,39 @@ function shouldPreserveOpaqueProviderPayload(
   key: string,
   item: unknown,
   location: TranscriptValueLocation,
+  route: TranscriptAssistantRoute | undefined,
 ): boolean {
-  if (location !== "assistant-content-block" || typeof item !== "string") {
+  if (
+    location !== "assistant-content-block" ||
+    typeof item !== "string" ||
+    !isOpaqueReplayToken(item)
+  ) {
     return false;
   }
   const type = source.type;
+  const customRoute = isCustomProviderRoute(route);
   return (
-    (type === "text" && key === "textSignature" && isReplayableTextSignature(item)) ||
+    (type === "text" &&
+      key === "textSignature" &&
+      (isGoogleReasoningRoute(route) || customRoute)) ||
     (type === "thinking" &&
-      ((key === "thinkingSignature" && !item.trimStart().startsWith("{")) ||
-        key === "signature" ||
-        key === "thought_signature")) ||
+      ((key === "thinkingSignature" &&
+        (isAnthropicReasoningRoute(route) || isGoogleReasoningRoute(route) || customRoute)) ||
+        (key === "signature" && (isAnthropicReasoningRoute(route) || customRoute)) ||
+        (key === "thought_signature" && (isGoogleReasoningRoute(route) || customRoute)))) ||
     (type === "redacted_thinking" &&
-      (key === "data" ||
-        key === "signature" ||
-        key === "thinkingSignature" ||
-        key === "thought_signature")) ||
-    (type === "toolCall" && key === "thoughtSignature")
+      (isAnthropicReasoningRoute(route) || customRoute) &&
+      (key === "data" || key === "signature" || key === "thinkingSignature")) ||
+    (type === "toolCall" &&
+      key === "thoughtSignature" &&
+      (isGoogleReasoningRoute(route) || isOpenAICompletionsRoute(route) || customRoute))
   );
 }
 
-function sanitizeOpenAIReasoningSignature(value: string): string | undefined {
+function sanitizeOpenAIReasoningSignature(
+  value: string,
+  route: TranscriptAssistantRoute | undefined,
+): string | undefined {
   let parsed: unknown;
   try {
     parsed = JSON.parse(value);
@@ -320,11 +434,14 @@ function sanitizeOpenAIReasoningSignature(value: string): string | undefined {
   if (
     encryptedContent !== undefined &&
     encryptedContent !== null &&
-    typeof encryptedContent !== "string"
+    (typeof encryptedContent !== "string" || !isOpaqueReplayToken(encryptedContent))
   ) {
     return undefined;
   }
-  if (parsed.id !== undefined && typeof parsed.id !== "string") {
+  if (
+    parsed.id !== undefined &&
+    (typeof parsed.id !== "string" || !isOpenAIResponseItemId(parsed.id, route))
+  ) {
     return undefined;
   }
   if (
@@ -340,6 +457,7 @@ function sanitizeOpenAIReasoningSignature(value: string): string | undefined {
   }
   const replayMetadata = sanitizeOpenAIReasoningReplayMetadata(
     parsed[OPENAI_REASONING_REPLAY_METADATA_KEY],
+    route,
   );
   return JSON.stringify({
     ...(typeof parsed.id === "string" ? { id: parsed.id } : {}),
@@ -351,6 +469,42 @@ function sanitizeOpenAIReasoningSignature(value: string): string | undefined {
   });
 }
 
+function sanitizeOpenAICompletionsToolSignature(value: string): string | undefined {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    return undefined;
+  }
+  if (
+    !parsed ||
+    typeof parsed !== "object" ||
+    !isPlainTranscriptObject(parsed) ||
+    parsed.type !== "reasoning.encrypted" ||
+    typeof parsed.data !== "string" ||
+    !isOpaqueReplayToken(parsed.data) ||
+    (parsed.id !== undefined &&
+      parsed.id !== null &&
+      (typeof parsed.id !== "string" || !isSafeReplayIdentifier(parsed.id))) ||
+    (parsed.format !== undefined &&
+      parsed.format !== null &&
+      (typeof parsed.format !== "string" ||
+        parsed.format.length > 64 ||
+        !/^[a-z0-9.-]+$/.test(parsed.format))) ||
+    (parsed.index !== undefined &&
+      (!Number.isSafeInteger(parsed.index) || (parsed.index as number) < 0))
+  ) {
+    return undefined;
+  }
+  return JSON.stringify({
+    type: "reasoning.encrypted",
+    data: parsed.data,
+    ...(parsed.id !== undefined ? { id: parsed.id } : {}),
+    ...(parsed.format !== undefined ? { format: parsed.format } : {}),
+    ...(parsed.index !== undefined ? { index: parsed.index } : {}),
+  });
+}
+
 function redactTranscriptStructuredValue(
   value: unknown,
   cfg?: OpenClawConfig,
@@ -358,6 +512,7 @@ function redactTranscriptStructuredValue(
   seen: WeakSet<object> = new WeakSet<object>(),
   preserveImageDataUrlFields = false,
   location: TranscriptValueLocation = "nested",
+  assistantRoute?: TranscriptAssistantRoute,
 ): unknown {
   if (typeof value === "string") {
     if (fieldKey) {
@@ -379,6 +534,7 @@ function redactTranscriptStructuredValue(
         seen,
         preserveImageDataUrlFields,
         location === "assistant-content-array" ? "assistant-content-block" : "nested",
+        assistantRoute,
       );
       changed ||= next !== item;
       return next;
@@ -403,6 +559,14 @@ function redactTranscriptStructuredValue(
   seen.add(value);
   const sanitizedImageRecord = sanitizeImageRecord(value);
   const source = sanitizedImageRecord ?? value;
+  const currentAssistantRoute =
+    location === "root" && source.role === "assistant"
+      ? {
+          ...(typeof source.api === "string" ? { api: source.api } : {}),
+          ...(typeof source.model === "string" ? { model: source.model } : {}),
+          ...(typeof source.provider === "string" ? { provider: source.provider } : {}),
+        }
+      : assistantRoute;
   let next: Record<string, unknown> | null = null;
   if (source !== value) {
     next = { ...source };
@@ -410,10 +574,12 @@ function redactTranscriptStructuredValue(
   for (const [key, item] of Object.entries(source)) {
     if (
       location === "assistant-content-block" &&
+      (isOpenAIResponsesRoute(currentAssistantRoute) ||
+        isCustomProviderRoute(currentAssistantRoute)) &&
       source.type === "thinking" &&
       key === "openclawReasoningReplay"
     ) {
-      const sanitizedMetadata = sanitizeOpenAIReasoningReplayMetadata(item);
+      const sanitizedMetadata = sanitizeOpenAIReasoningReplayMetadata(item, currentAssistantRoute);
       if (sanitizedMetadata !== undefined) {
         if (sanitizedMetadata !== item) {
           next ??= { ...source };
@@ -424,11 +590,41 @@ function redactTranscriptStructuredValue(
     }
     if (
       location === "assistant-content-block" &&
+      (isOpenAIResponsesRoute(currentAssistantRoute) ||
+        isCustomProviderRoute(currentAssistantRoute)) &&
       source.type === "thinking" &&
       key === "thinkingSignature" &&
       typeof item === "string"
     ) {
-      const sanitizedSignature = sanitizeOpenAIReasoningSignature(item);
+      const sanitizedSignature = sanitizeOpenAIReasoningSignature(item, currentAssistantRoute);
+      if (sanitizedSignature !== undefined) {
+        if (sanitizedSignature !== item) {
+          next ??= { ...source };
+          next[key] = sanitizedSignature;
+        }
+        continue;
+      }
+    }
+    if (
+      location === "assistant-content-block" &&
+      (isOpenAIResponsesRoute(currentAssistantRoute) ||
+        isCustomProviderRoute(currentAssistantRoute)) &&
+      source.type === "text" &&
+      key === "textSignature" &&
+      typeof item === "string" &&
+      isOpenAITextSignature(item, currentAssistantRoute)
+    ) {
+      continue;
+    }
+    if (
+      location === "assistant-content-block" &&
+      (isOpenAICompletionsRoute(currentAssistantRoute) ||
+        isCustomProviderRoute(currentAssistantRoute)) &&
+      source.type === "toolCall" &&
+      key === "thoughtSignature" &&
+      typeof item === "string"
+    ) {
+      const sanitizedSignature = sanitizeOpenAICompletionsToolSignature(item);
       if (sanitizedSignature !== undefined) {
         if (sanitizedSignature !== item) {
           next ??= { ...source };
@@ -438,7 +634,7 @@ function redactTranscriptStructuredValue(
       }
     }
     // Provider-signed/encrypted bytes must remain exact or replayed tool turns fail.
-    if (shouldPreserveOpaqueProviderPayload(source, key, item, location)) {
+    if (shouldPreserveOpaqueProviderPayload(source, key, item, location, currentAssistantRoute)) {
       continue;
     }
     if (typeof item === "string") {
@@ -468,6 +664,7 @@ function redactTranscriptStructuredValue(
       location === "root" && source.role === "assistant" && key === "content" && Array.isArray(item)
         ? "assistant-content-array"
         : "nested",
+      currentAssistantRoute,
     );
     if (redacted === item) {
       continue;


### PR DESCRIPTION
## Summary

- Prevent transcript redaction from corrupting provider-owned reasoning ciphertext, signatures, and replay identifiers.
- Preserve opaque replay fields only on direct assistant content blocks, only for a recognized provider/API route or an explicitly identified custom route, and only after schema and token validation.
- Keep ordinary secret redaction active for nested payloads, malformed replay metadata, unknown fields, and credential-shaped values.
- Cover OpenAI Responses/ChatGPT/Azure, Anthropic/Bedrock, Google/Vertex/Gemini CLI, OpenAI-compatible completions, managed transport aliases, GitHub Copilot, OpenRouter, and custom provider APIs without changing their tool-call payload construction.

This replaces the original broad field-name exemptions with route-bound canonical replay validation. Existing transcripts already containing a redaction marker inside ciphertext still require history cleanup; this change prevents new corruption.

## Linked context

Fixes #90093

Related #87151

## Real behavior proof

- Behavior or issue addressed: Multi-turn model sessions could persist corrupted encrypted reasoning or signature fields, causing later replay failures. The patch preserves valid provider replay metadata while continuing to redact secrets and malformed or untrusted lookalikes.
- Real environment tested: OpenClaw gateway with live `openai/gpt-5.5` and `anthropic/claude-sonnet-4-6` provider credentials, real model responses, filesystem tools, image input, and multi-turn continuation.
- Exact steps or command run after this patch: `node scripts/test-live.mjs -- src/gateway/gateway-models.profiles.live.test.ts` with the model selection restricted first to GPT-5.5 plus Claude Sonnet 4.6, then to Claude Sonnet 4.6 for credential rotation and completion.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Redacted live terminal captures showed GPT-5.5 completing prompt, tool-read, tool-exec, image, and tool-only continuation; Claude Sonnet 4.6 completing prompt, tool-read, tool-exec, image, refusal probe, and continuation. Both runs ended with `Tests 94 passed`. No `invalid_encrypted_content`, OpenAI retry, or Anthropic signature-invalid markers appeared. Testbox changed-gate proof: https://github.com/openclaw/openclaw/actions/runs/27488305201
- Observed result after fix: Official OpenAI and Anthropic live tool calling and continuation completed successfully while provider replay metadata remained valid. The Anthropic harness rotated past one depleted credential and completed with the next configured credential.
- What was not tested: No additional hosted provider was called live; Google, Bedrock, OpenRouter, Copilot, managed aliases, and custom provider paths are covered by focused replay/redaction tests.
- Proof limitations or environment constraints: Existing already-corrupted transcript entries are not repaired automatically.

## Tests and validation

- Focused Vitest matrix across transcript persistence, OpenAI replay, Anthropic transport, Google conversion, OpenAI transport, and Copilot connection-bound IDs: 5 shards, 423 tests passed.
- Fresh branch autoreview: no accepted or actionable findings.
- Testbox changed gate: `tbx_01kv268t70an6z2xg6rghkdmdt`, exit 0, including production/test type checks, lint, import cycles, guards, and core tests.
- Live provider E2E: GPT-5.5 and Claude Sonnet 4.6 passed real prompt, tool, image, and continuation scenarios.
- `git diff --check`: passed.

## Risk checklist

- User-visible behavior changed: Yes. Valid reasoning replay metadata survives transcript persistence instead of being corrupted by secret redaction.
- Config, environment, or migration behavior changed: No.
- Official OpenAI or Anthropic tool calling changed: No. The patch is confined to transcript redaction/persistence and is covered by focused transport tests plus live tool-call E2E.
