### PR TITLE
fix(gateway): honor profile auth for SecretRef model entries

### DIFF
--- a/src/gateway/server-methods/models-list-result.ts
+++ b/src/gateway/server-methods/models-list-result.ts
@@ -206,7 +206,6 @@ async function resolveModelsListEntryAvailability(
 
 async function buildPublicModelsListEntry(params: {
   entry: ModelCatalogEntry;
-  cfg: OpenClawConfig;
   providerAuthChecker?: ModelsListProviderAuthChecker;
 }): Promise<ModelsListEntry> {
   const publicEntry = omitRuntimeModelParams(params.entry);
@@ -234,7 +233,6 @@ async function buildPublicModelsListEntries(params: {
     params.catalog.map((entry) =>
       buildPublicModelsListEntry({
         entry,
-        cfg: params.cfg,
         providerAuthChecker,
       }),
     ),

--- a/src/gateway/server-methods/models-list-result.ts
+++ b/src/gateway/server-methods/models-list-result.ts
@@ -14,7 +14,6 @@ import {
   type AuthProfileStore,
 } from "../../agents/auth-profiles.js";
 import { DEFAULT_PROVIDER } from "../../agents/defaults.js";
-import { NON_ENV_SECRETREF_MARKER } from "../../agents/model-auth-markers.js";
 import { hasRuntimeAvailableProviderAuth } from "../../agents/model-auth.js";
 import {
   loadModelCatalogForBrowse,
@@ -55,18 +54,6 @@ function omitRuntimeModelParams(entry: ModelCatalogEntry): ModelCatalogEntry {
     params?: Record<string, unknown>;
   };
   return rest;
-}
-
-function modelCatalogEntryHasUnknownSecretRefAvailability(
-  cfg: OpenClawConfig,
-  entry: ModelCatalogEntry,
-): boolean {
-  const providerId = normalizeProviderId(entry.provider);
-  const provider = Object.entries(cfg.models?.providers ?? {}).find(
-    ([id]) => normalizeProviderId(id) === providerId,
-  )?.[1];
-  const apiKey = provider?.apiKey;
-  return apiKey === NON_ENV_SECRETREF_MARKER || (isSecretRef(apiKey) && apiKey.source !== "env");
 }
 
 function createInFlightProviderAuthChecker(
@@ -223,12 +210,6 @@ async function buildPublicModelsListEntry(params: {
   providerAuthChecker?: ModelsListProviderAuthChecker;
 }): Promise<ModelsListEntry> {
   const publicEntry = omitRuntimeModelParams(params.entry);
-  if (modelCatalogEntryHasUnknownSecretRefAvailability(params.cfg, params.entry)) {
-    return {
-      ...publicEntry,
-      available: false,
-    };
-  }
   if (!params.providerAuthChecker) {
     return publicEntry;
   }

--- a/src/gateway/server-methods/models.test.ts
+++ b/src/gateway/server-methods/models.test.ts
@@ -565,6 +565,89 @@ describe("models.list", () => {
     );
   });
 
+  it("marks auth profiles available even when provider config uses non-env SecretRef markers", async () => {
+    for (const fixture of [
+      {
+        name: "file",
+        apiKey: {
+          source: "file",
+          provider: "mounted-json",
+          id: "/providers/vllm/apiKey",
+        },
+      },
+      { name: "managed-marker", apiKey: "secretref-managed" },
+    ] as const) {
+      await withOpenClawTestState(
+        {
+          layout: "state-only",
+          prefix: `openclaw-models-list-provider-${fixture.name}-profile-`,
+          agentEnv: "main",
+          env: {
+            VLLM_API_KEY: "test-token",
+          },
+        },
+        async (state) => {
+          await state.writeAuthProfiles({
+            version: 1,
+            profiles: {
+              "vllm:env": {
+                type: "api_key",
+                provider: "vllm",
+                keyRef: {
+                  source: "env",
+                  provider: "default",
+                  id: "VLLM_API_KEY",
+                },
+              },
+            },
+          });
+
+          const cfg = {
+            agents: {
+              defaults: {
+                models: {
+                  "vllm/*": {},
+                },
+              },
+            },
+            models: {
+              providers: {
+                vllm: {
+                  apiKey: fixture.apiKey,
+                },
+              },
+            },
+          } as unknown as OpenClawConfig;
+
+          const { request, respond } = requestModelsList({
+            view: "all",
+            runtimeConfig: cfg,
+            loadGatewayModelCatalog: vi.fn(() =>
+              Promise.resolve([{ id: "llama-secure", name: "Llama Secure", provider: "vllm" }]),
+            ),
+            reqId: `req-models-list-provider-${fixture.name}-profile`,
+          });
+          await request;
+
+          expect(respond).toHaveBeenCalledWith(
+            true,
+            {
+              models: [
+                {
+                  id: "llama-secure",
+                  name: "Llama Secure",
+                  provider: "vllm",
+                  available: true,
+                },
+              ],
+            },
+            undefined,
+          );
+        },
+      );
+    }
+  });
+
   it("preserves catalog load errors before the timeout fallback wins", async () => {
     const { request, respond } = requestModelsList({
       view: "configured",

--- a/src/gateway/server-methods/models.test.ts
+++ b/src/gateway/server-methods/models.test.ts
@@ -583,7 +583,8 @@ describe("models.list", () => {
           prefix: `openclaw-models-list-provider-${fixture.name}-profile-`,
           agentEnv: "main",
           env: {
-            VLLM_API_KEY: "test-token",
+            OPENCLAW_TEST_PROFILE_API_KEY: "test-token",
+            VLLM_API_KEY: undefined,
           },
         },
         async (state) => {
@@ -596,7 +597,7 @@ describe("models.list", () => {
                 keyRef: {
                   source: "env",
                   provider: "default",
-                  id: "VLLM_API_KEY",
+                  id: "OPENCLAW_TEST_PROFILE_API_KEY",
                 },
               },
             },


### PR DESCRIPTION
## Summary

Fixes #90685.

- Remove the duplicate early SecretRef availability guard from `models.list`.
- Let the existing provider auth checker decide availability, so auth-profile-backed credentials can mark matching provider rows available.
- Preserve fail-closed behavior when a non-env SecretRef is the only credential source.
- Add isolated regression coverage for file SecretRefs and the literal `secretref-managed` marker.

## Root cause

`buildPublicModelsListEntry(...)` returned `available: false` as soon as provider config contained a non-env SecretRef. That bypassed the existing checker which combines runtime auth with read-only auth-profile availability.

## Real behavior proof

Behavior addressed: `models.list` now reports a model available when provider config uses a non-env SecretRef and a matching auth profile has a usable credential.

Real environment tested: local OpenClaw production gateway code with a temporary real state directory, SQLite-backed persisted auth profile, a `vllm` provider using a file SecretRef, and an env-backed `vllm:env` profile. `VLLM_API_KEY` was explicitly absent, so runtime provider env auth could not bypass the profile path.

Exact steps or command run after this patch:

```bash
node --import tsx --input-type=module < production models.list proof script
```

Evidence after fix: terminal output from direct `buildModelsListResult` execution against the persisted profile:

```json
{
  "providerConfigAuth": "file SecretRef",
  "recognizedProviderEnvAuthPresent": false,
  "persistedProfile": "vllm:env via env SecretRef",
  "model": "llama-secure",
  "available": true
}
```

Observed result after fix: the production gateway model-list builder returned `available: true` from the persisted profile while the provider's recognized env credential was absent. The regression suite separately proves both file SecretRef and `secretref-managed` inputs, plus the no-profile negative cases.

What was not tested: no live VLLM inference request was sent. Provider invocation is unchanged; this patch only removes a duplicate gateway browse short-circuit.

## Verification

```bash
node scripts/run-vitest.mjs \
  src/gateway/server-methods/models.test.ts \
  src/agents/model-auth.profiles.test.ts \
  extensions/openai/openai-provider.test.ts \
  extensions/anthropic/index.test.ts \
  src/agents/anthropic-transport-stream.test.ts \
  src/llm/providers/openai-responses-shared.test.ts \
  src/llm/providers/openai-completions.test.ts \
  src/llm/providers/openai-chatgpt-responses.test.ts
node scripts/run-tsgo.mjs -p tsconfig.core.json
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json
pnpm exec oxfmt --check src/gateway/server-methods/models-list-result.ts src/gateway/server-methods/models.test.ts
git diff --check
```

Results:

- 283 focused gateway/auth/OpenAI/Anthropic tests passed.
- Production and test typechecks passed.
- Fresh forced OpenAI Responses tool call passed with `gpt-5.4-mini`.
- Fresh forced Anthropic Messages tool call passed with `claude-sonnet-4-6`.
- Remote changed gate passed: `run_e279989a80a2`.
- Remote live Docker OpenAI Chat Completions tools E2E passed: `run_f9c4061573dd`.
- Final autoreview found no actionable findings.

## Compatibility and risk

The change consolidates availability policy onto the existing auth checker. Non-env SecretRef-only providers remain unavailable unless an existing runtime or auth-profile path proves usable auth. Official OpenAI and Anthropic tool conversion/runtime code is untouched and separately verified above.
