### PR TITLE
fix(macos): ignore task state for connected gateway

### DIFF
--- a/apps/macos/Tests/OpenClawIPCTests/GatewayChannelConnectTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayChannelConnectTests.swift
@@ -355,4 +355,24 @@ struct GatewayChannelConnectTests {
             Issue.record("unexpected error: \(error)")
         }
     }
+
+    @Test func `connect is no-op when already connected regardless of task state`() async throws {
+        let session = self.makeSession(response: .helloOk(delayMs: 0))
+        let channel = try GatewayChannelActor(
+            url: #require(URL(string: "ws://example.invalid")),
+            token: nil,
+            session: WebSocketSessionBox(session: session))
+
+        // First connect succeeds
+        try await channel.connect()
+        #expect(session.snapshotMakeCount() == 1)
+
+        // Simulate the macOS bug: task state flips to non-.running while connected is still true
+        let task = try #require(session.latestTask())
+        task.state = .suspended
+
+        // Second connect should be a no-op (guard returns early on self.connected)
+        try await channel.connect()
+        #expect(session.snapshotMakeCount() == 1)
+    }
 }

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
@@ -340,7 +340,7 @@ public actor GatewayChannelActor {
     }
 
     public func connect() async throws {
-        if self.connected, self.task?.state == .running { return }
+        if self.connected { return }
         if self.isConnecting {
             try await withCheckedThrowingContinuation { cont in
                 self.connectWaiters.append(cont)


### PR DESCRIPTION
## What changed
- Treats `GatewayChannelActor.connected` as the source of truth for duplicate `connect()` calls.
- Avoids reconnecting a healthy macOS node-mode direct gateway channel just because the underlying `URLSessionWebSocketTask.state` reports a non-running state.
- Adds a regression test that simulates a connected channel whose task state flips to `.suspended`, then verifies a second `connect()` does not create a new WebSocket task.

Fixes #90668.

## Real behavior proof

Behavior addressed: A healthy macOS node-mode gateway session should not repeatedly reconnect and log `mac node connected to gateway` while the channel is already marked connected. This patch makes repeat `connect()` calls no-op on the actor's connected state rather than also depending on `URLSessionWebSocketTask.state`.

Real environment tested: macOS arm64 worktree on branch `fastino-90668-macos-node-direct-reconnect`, based on `origin/main` commit `520992a1`; Swift toolchain `swift-driver version: 1.148.6 Apple Swift version 6.3.2`.

Exact steps or command run after the patch:
```shell
git diff --check
swiftc -parse apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
swiftc -parse apps/macos/Tests/OpenClawIPCTests/GatewayChannelConnectTests.swift
cd apps/macos && swift test --filter "GatewayChannelConnectTests"
```

Evidence after fix:
```shell
$ git diff -- apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift apps/macos/Tests/OpenClawIPCTests/GatewayChannelConnectTests.swift
@@
     public func connect() async throws {
-        if self.connected, self.task?.state == .running { return }
+        if self.connected { return }
@@
+    @Test func `connect is no-op when already connected regardless of task state`() async throws {
+        let session = self.makeSession(response: .helloOk(delayMs: 0))
+        let channel = try GatewayChannelActor(
+            url: #require(URL(string: "ws://example.invalid")),
+            token: nil,
+            session: WebSocketSessionBox(session: session))
+
+        try await channel.connect()
+        #expect(session.snapshotMakeCount() == 1)
+
+        let task = try #require(session.latestTask())
+        task.state = .suspended
+
+        try await channel.connect()
+        #expect(session.snapshotMakeCount() == 1)
+    }

$ git diff --check

$ swiftc -parse apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift

$ swiftc -parse apps/macos/Tests/OpenClawIPCTests/GatewayChannelConnectTests.swift
```

The focused test command reached dependency setup and then timed out on the Sparkle binary artifact download path:
```shell
$ cd apps/macos && swift test --filter "GatewayChannelConnectTests"
Downloading binary artifact https://github.com/sparkle-project/Sparkle/releases/download/2.9.1/Sparkle-for-Swift-Package-Manager.zip
<shell_metadata>
shell tool terminated command after exceeding timeout 300000 ms.
</shell_metadata>
```

Observed result after fix: The changed actor guard now returns immediately whenever `connected` is already true, and the regression test models the reported macOS state drift by setting the mock task to `.suspended` while the actor remains connected. Whitespace and Swift parser checks completed successfully for the changed files. The local focused Swift test did not reach execution because package setup timed out on the Sparkle binary artifact.

Not tested: I did not reproduce a live remote `wss://` macOS node-mode session with repeated `mac node connected to gateway` logs. The focused Swift test was attempted but did not reach test execution locally because SwiftPM stalled on the Sparkle binary artifact download in this Command Line Tools environment.

## Platforms tested
- macOS arm64, Apple Swift 6.3.2 Command Line Tools.



## Additional CI proof

After the local SwiftPM Sparkle artifact timeout noted above, GitHub Actions completed the macOS Swift validation on this branch.

```text
$ swift test --package-path apps/macos --parallel --enable-code-coverage --show-codecov-path
/Users/runner/_work/openclaw/openclaw/apps/macos/.build/arm64-apple-macosx/debug/codecov/OpenClaw.json
```

Check: `macos-swift` on pull request #90687 passed on GitHub Actions run `27019323443`, job `79742739374`. That job builds the macOS package and then runs the macOS Swift test suite, which includes the added `GatewayChannelConnectTests` regression in this PR.
