### PR TITLE
fix(agents): align custom provider auth labels with runtime (#82020)

### DIFF
--- a/src/agents/model-auth-label.test.ts
+++ b/src/agents/model-auth-label.test.ts
@@ -1,6 +1,19 @@
 // Verifies safe, user-facing auth labels without exposing credential values.
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ModelDefinitionConfig } from "../config/types.models.js";
 import { resolveModelAuthLabel } from "./model-auth-label.js";
+
+function testModelDefinition(id: string): ModelDefinitionConfig {
+  return {
+    id,
+    name: id,
+    reasoning: false,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 8192,
+    maxTokens: 4096,
+  };
+}
 
 const mocks = vi.hoisted(() => ({
   ensureAuthProfileStore: vi.fn(),
@@ -331,6 +344,72 @@ describe("resolveModelAuthLabel", () => {
     });
 
     expect(label).toBe("api-key (openrouter:key-b)");
+    expect(mocks.resolveUsableCustomProviderApiKey).not.toHaveBeenCalled();
+  });
+
+  it("prefers literal per-entry apiKey labels over env fallbacks (#82020)", () => {
+    mocks.ensureAuthProfileStore.mockReturnValue({
+      version: 1,
+      profiles: {},
+    } as never);
+    mocks.resolveAuthProfileOrder.mockReturnValue([]);
+    mocks.resolveProviderEntryApiKeyProfileReference.mockReturnValue({
+      kind: "literal",
+      apiKey: "sk-light-only",
+      source: "models.json",
+    });
+    mocks.resolveEnvApiKey.mockReturnValue({
+      apiKey: "zai-env-key",
+      source: "env: ZAI_API_KEY",
+    });
+
+    const label = resolveModelAuthLabel({
+      provider: "zai-light",
+      cfg: {
+        models: {
+          providers: {
+            zai: {
+              api: "openai-completions",
+              baseUrl: "https://open.bigmodel.cn/api/coding/paas/v4",
+              models: [],
+            },
+            "zai-light": {
+              api: "openai-completions",
+              baseUrl: "https://open.bigmodel.cn/api/coding/paas/v4",
+              apiKey: "sk-light-only",
+              models: [testModelDefinition("glm-5-turbo")],
+            },
+          },
+        },
+      },
+    });
+
+    expect(label).toBe("api-key (models.json)");
+    expect(mocks.resolveEnvApiKey).not.toHaveBeenCalled();
+  });
+
+  it("keeps env labels ahead of late custom-key fallbacks when runtime uses env (#82020)", () => {
+    mocks.ensureAuthProfileStore.mockReturnValue({
+      version: 1,
+      profiles: {},
+    } as never);
+    mocks.resolveAuthProfileOrder.mockReturnValue([]);
+    mocks.resolveProviderEntryApiKeyProfileReference.mockReturnValue({ kind: "none" });
+    mocks.resolveUsableCustomProviderApiKey.mockReturnValue({
+      apiKey: "sk-light-only",
+      source: "models.json",
+    });
+    mocks.resolveEnvApiKey.mockReturnValue({
+      apiKey: "zai-env-key",
+      source: "env: ZAI_API_KEY",
+    });
+
+    const label = resolveModelAuthLabel({
+      provider: "zai-light",
+      cfg: {},
+    });
+
+    expect(label).toBe("api-key (env: ZAI_API_KEY)");
     expect(mocks.resolveUsableCustomProviderApiKey).not.toHaveBeenCalled();
   });
 

--- a/src/agents/model-auth-label.ts
+++ b/src/agents/model-auth-label.ts
@@ -24,8 +24,8 @@ import {
 import { normalizeProviderId } from "./model-selection.js";
 
 // Builds concise auth labels for UI/status surfaces without exposing credential
-// values. Resolution follows profile override, provider profiles, env, CLI, then
-// custom provider config.
+// values. Resolution follows profile override, provider profiles, per-entry
+// provider apiKey bindings, env, CLI, then custom provider config.
 /** Resolve the display label that describes how a provider is authenticated. */
 export function resolveModelAuthLabel(params: {
   provider?: string;
@@ -117,6 +117,9 @@ export function resolveModelAuthLabel(params: {
     // Preserve the fact that config pointed at a profile while avoiding a
     // misleading auth mode for an incompatible provider/profile pairing.
     return "unknown";
+  }
+  if (providerEntryProfileRef.kind === "literal") {
+    return "api-key (models.json)";
   }
 
   if (

--- a/src/agents/model-auth.profiles.test.ts
+++ b/src/agents/model-auth.profiles.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import type { Model } from "openclaw/plugin-sdk/llm";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ModelDefinitionConfig } from "../config/types.models.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
@@ -13,6 +14,7 @@ import {
 } from "./auth-profiles/store.js";
 import type { OAuthCredential } from "./auth-profiles/types.js";
 import type { ClaudeCliCredential } from "./cli-credentials.js";
+import { resolveModelAuthLabel } from "./model-auth-label.js";
 import {
   createRuntimeProviderAuthLookup,
   getApiKeyForModel,
@@ -61,6 +63,18 @@ function testModelDefinition(id: string): Model {
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
     contextWindow: 128_000,
     maxTokens: 8192,
+  };
+}
+
+function testModelConfig(id: string): ModelDefinitionConfig {
+  return {
+    id,
+    name: id,
+    reasoning: false,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 8192,
+    maxTokens: 4096,
   };
 }
 
@@ -1959,5 +1973,39 @@ describe("resolveApiKeyForProvider — per-entry apiKey as profile ID reference"
         },
       }),
     ).rejects.toThrow(/matched a stored profile but failed to resolve/);
+  });
+});
+
+describe("resolveModelAuthLabel — custom provider keys (#82020)", () => {
+  const sharedBaseUrl = "https://open.bigmodel.cn/api/coding/paas/v4";
+
+  it("labels zai-light models.json keys before shared ZAI env vars", async () => {
+    await withEnvAsync({ ZAI_API_KEY: "zai-env-key" }, async () => {
+      const cfg: OpenClawConfig = {
+        models: {
+          providers: {
+            zai: {
+              api: "openai-completions",
+              baseUrl: sharedBaseUrl,
+              apiKey: "zai-api-key",
+              models: [],
+            },
+            "zai-light": {
+              api: "openai-completions",
+              baseUrl: sharedBaseUrl,
+              apiKey: "sk-light-only",
+              models: [testModelConfig("glm-5-turbo")],
+            },
+          },
+        },
+      };
+
+      const auth = await resolveApiKeyForProvider({ provider: "zai-light", cfg });
+      const label = resolveModelAuthLabel({ provider: "zai-light", cfg });
+
+      expect(auth.apiKey).toBe("sk-light-only");
+      expect(auth.source).toBe("models.json");
+      expect(label).toBe("api-key (models.json)");
+    });
   });
 });

--- a/src/auto-reply/reply/directive-handling.auth.test.ts
+++ b/src/auto-reply/reply/directive-handling.auth.test.ts
@@ -15,6 +15,9 @@ const resolveEnvApiKeyMock = vi.hoisted(() =>
     ) => null as { apiKey: string; source: string } | null,
   ),
 );
+const resolveProviderEntryApiKeyProfileReferenceMock = vi.hoisted(() =>
+  vi.fn(() => ({ kind: "none" as const })),
+);
 const githubCopilotTokenRefProfile: AuthProfileStore["profiles"][string] = {
   type: "token",
   provider: "github-copilot",
@@ -65,6 +68,9 @@ vi.mock("../../agents/model-auth.js", () => ({
   ensureAuthProfileStore: () => mockStore,
   resolveUsableCustomProviderApiKey: () => null,
   resolveAuthProfileOrder: () => mockOrder,
+  resolveProviderEntryApiKeyProfileReference: (
+    ...args: Parameters<typeof resolveProviderEntryApiKeyProfileReferenceMock>
+  ) => resolveProviderEntryApiKeyProfileReferenceMock(...args),
   resolveEnvApiKey: (
     provider?: string,
     env?: NodeJS.ProcessEnv,
@@ -105,6 +111,8 @@ describe("resolveAuthLabel ref-aware labels", () => {
     mockOrder = [];
     resolveEnvApiKeyMock.mockReset();
     resolveEnvApiKeyMock.mockReturnValue(null);
+    resolveProviderEntryApiKeyProfileReferenceMock.mockReset();
+    resolveProviderEntryApiKeyProfileReferenceMock.mockReturnValue({ kind: "none" });
   });
 
   it("shows api-key (ref) for keyRef-only profiles in compact mode", async () => {
@@ -249,5 +257,29 @@ describe("resolveAuthLabel ref-aware labels", () => {
       workspaceDir: "/tmp/workspace",
     });
     expect(result.source).toBe("workspace credentials");
+  });
+
+  it("prefers literal provider-entry apiKey labels over env fallbacks for /model status (#82020)", async () => {
+    resolveProviderEntryApiKeyProfileReferenceMock.mockReturnValue({
+      kind: "literal",
+      apiKey: "sk-light-only",
+      source: "models.json",
+    });
+    resolveEnvApiKeyMock.mockReturnValue({
+      apiKey: "zai-env-key",
+      source: "env: ZAI_API_KEY",
+    });
+
+    const result = await resolveAuthLabel(
+      "zai-light",
+      {} as OpenClawConfig,
+      "/tmp/models.json",
+      undefined,
+      "verbose",
+    );
+
+    expect(result.label).toBe("sk...ly");
+    expect(result.source).toBe("models.json: /tmp/models.json");
+    expect(resolveEnvApiKeyMock).not.toHaveBeenCalled();
   });
 });

--- a/src/auto-reply/reply/directive-handling.auth.test.ts
+++ b/src/auto-reply/reply/directive-handling.auth.test.ts
@@ -16,7 +16,7 @@ const resolveEnvApiKeyMock = vi.hoisted(() =>
   ),
 );
 const resolveProviderEntryApiKeyProfileReferenceMock = vi.hoisted(() =>
-  vi.fn(() => ({ kind: "none" as const })),
+  vi.fn<() => unknown>(() => ({ kind: "none" })),
 );
 const githubCopilotTokenRefProfile: AuthProfileStore["profiles"][string] = {
   type: "token",

--- a/src/auto-reply/reply/directive-handling.auth.ts
+++ b/src/auto-reply/reply/directive-handling.auth.ts
@@ -12,6 +12,7 @@ import {
   ensureAuthProfileStore,
   resolveAuthProfileOrder,
   resolveEnvApiKey,
+  resolveProviderEntryApiKeyProfileReference,
   resolveUsableCustomProviderApiKey,
 } from "../../agents/model-auth.js";
 import { findNormalizedProviderValue, normalizeProviderId } from "../../agents/model-selection.js";
@@ -229,6 +230,54 @@ export const resolveAuthLabel = async (
       label: labels.join(", "),
       source: `auth-profiles.json: ${formatPath(resolveAuthStorePathForDisplay(agentDir))}`,
     };
+  }
+
+  const providerEntryProfileRef = resolveProviderEntryApiKeyProfileReference({
+    cfg,
+    provider: providerKey,
+    store,
+  });
+  if (providerEntryProfileRef.kind === "literal") {
+    return {
+      label: maskApiKey(providerEntryProfileRef.apiKey),
+      source: mode === "verbose" ? `models.json: ${formatPath(modelsPath)}` : "",
+    };
+  }
+  if (providerEntryProfileRef.kind === "profile-incompatible") {
+    return { label: "missing", source: "missing" };
+  }
+  if (providerEntryProfileRef.kind === "profile") {
+    const profileId = providerEntryProfileRef.profileId;
+    const profile = store.profiles[profileId];
+    if (profile?.type === "api_key") {
+      const keyLabel = resolveStoredCredentialLabel({
+        value: profile.key,
+        refValue: profile.keyRef,
+        mode,
+      });
+      return {
+        label: `${profileId} api-key ${keyLabel}`,
+        source: "",
+      };
+    }
+    if (profile?.type === "token") {
+      const tokenLabel = resolveStoredCredentialLabel({
+        value: profile.token,
+        refValue: profile.tokenRef,
+        mode,
+      });
+      const exp = formatExpirationLabel(profile.expires, now, formatUntil);
+      return {
+        label: `${profileId} token ${tokenLabel}${exp}`,
+        source: "",
+      };
+    }
+    if (profile) {
+      const display = resolveAuthProfileDisplayLabel({ cfg, store, profileId });
+      const label = display === profileId ? profileId : display;
+      const exp = formatExpirationLabel(profile.expires, now, formatUntil);
+      return { label: `${label} oauth${exp}`, source: "" };
+    }
   }
 
   // Auth profiles win over environment/config keys because they encode provider order.


### PR DESCRIPTION
﻿## Summary

- Fix `resolveModelAuthLabel` so `/status` and other UI surfaces show the same auth source as runtime resolution for custom providers like `zai-light`.
- Keep per-entry literal `apiKey` bindings labeled as `api-key (models.json)` when runtime also resolves that provider entry from `models.json`, while leaving the late generic custom-key fallback behind env/CLI labels.

Closes #82020

## Real behavior proof

Behavior addressed: `/status` and other UI/status surfaces could show the wrong auth source for a custom provider when `zai` and `zai-light` share a base URL. The fix makes `resolveModelAuthLabel` agree with `resolveApiKeyForProvider`: the `zai-light` per-entry literal key is reported as `api-key (models.json)`, and generic late custom-key fallback no longer masks env labels.

Real environment tested: Local Windows checkout (`D:\WorkSpace\AI\openclaw`) with Node `v24.13.1` and pnpm `11.2.2`, using the PR branch `fix/provider-auth-label-82020` after the patch.

Exact steps or command run after this patch:

```powershell
pnpm exec tsx -e "(async()=>{const { resolveModelAuthLabel } = await import('./src/agents/model-auth-label.ts'); const { resolveApiKeyForProvider } = await import('./src/agents/model-auth.ts'); const cfg={models:{providers:{zai:{api:'openai-completions',baseUrl:'https://open.bigmodel.cn/api/coding/paas/v4',apiKey:'zai-api-key',models:[]},'zai-light':{api:'openai-completions',baseUrl:'https://open.bigmodel.cn/api/coding/paas/v4',apiKey:'sk-light-only',models:[{id:'glm-5-turbo',name:'glm-5-turbo',reasoning:false,input:['text'],cost:{input:0,output:0,cacheRead:0,cacheWrite:0},contextWindow:8192,maxTokens:4096}]}}}}; process.env.ZAI_API_KEY='zai-env-key'; const auth=await resolveApiKeyForProvider({provider:'zai-light',cfg}); const label=resolveModelAuthLabel({provider:'zai-light',cfg}); console.log(JSON.stringify({authSource:auth.source,authKey:auth.apiKey,label},null,2));})();"
```

Evidence after fix:

```json
{
  "authSource": "models.json",
  "authKey": "sk-light-only",
  "label": "api-key (models.json)"
}
```

Observed result after fix: With `ZAI_API_KEY` also set, runtime auth for `zai-light` resolves the literal per-entry `models.json` key and the status label reports `api-key (models.json)`, so the displayed auth source matches the credential source that runtime uses.

What was not tested: I did not run a live Telegram `/status` transcript. The visible Telegram behavior is covered by the shared `resolveModelAuthLabel` status helper plus the terminal runtime/label proof above; maintainers can still request Mantis Telegram proof if they want transport-visible confirmation.

## Tests

- `pnpm tsgo:test`
- `node --no-maglev node_modules/vitest/vitest.mjs run --config test/vitest/vitest.agents-core.config.ts src/agents/model-auth-label.test.ts src/agents/model-auth.profiles.test.ts -t "custom provider keys|late custom-key|literal per-entry" --reporter=dot`

## Test plan

- [x] Scoped Vitest regression for `zai-light` + shared `ZAI_API_KEY`
- [x] Terminal proof that runtime key and status label agree
- [x] Typecheck proof for test fixtures with `pnpm tsgo:test`
- [ ] Maintainer: Telegram `/status` on a config with `zai` + `zai-light` shows `api-key (models.json)` for the custom provider
