### PR TITLE
fix(gateway): guard secrets.resolve handler against undefined fields

### DIFF
--- a/src/gateway/server-methods/secrets.test.ts
+++ b/src/gateway/server-methods/secrets.test.ts
@@ -217,6 +217,32 @@ describe("secrets handlers", () => {
     });
   });
 
+  it("handles undefined commandName without crashing", async () => {
+    const handlers = createHandlers();
+    const respond = vi.fn();
+    await invokeSecretsResolve({
+      handlers,
+      respond,
+      commandName: undefined,
+      targetIds: ["talk.providers.*.apiKey"],
+    });
+    // Should not crash; validator or guard catches it cleanly.
+    expectRespondError(respond, { code: "INVALID_REQUEST" });
+  });
+
+  it("handles undefined targetIds without crashing", async () => {
+    const handlers = createHandlers();
+    const respond = vi.fn();
+    await invokeSecretsResolve({
+      handlers,
+      respond,
+      commandName: "message send",
+      targetIds: undefined,
+    });
+    // Should not crash; validator or guard catches it cleanly.
+    expectRespondError(respond, { code: "INVALID_REQUEST" });
+  });
+
   it("rejects unknown secrets.resolve target ids", async () => {
     const resolveSecrets = vi.fn();
     const handlers = createHandlers({ resolveSecrets });

--- a/src/gateway/server-methods/secrets.ts
+++ b/src/gateway/server-methods/secrets.ts
@@ -97,7 +97,8 @@ export function createSecretsHandlers(params: {
         );
         return;
       }
-      const commandName = requestParams.commandName.trim();
+      const commandName =
+        typeof requestParams.commandName === "string" ? requestParams.commandName.trim() : "";
       if (!commandName) {
         respond(
           false,
@@ -106,8 +107,8 @@ export function createSecretsHandlers(params: {
         );
         return;
       }
-      const targetIds = requestParams.targetIds
-        .map((entry) => entry.trim())
+      const targetIds = (Array.isArray(requestParams.targetIds) ? requestParams.targetIds : [])
+        .map((entry) => (typeof entry === "string" ? entry.trim() : ""))
         .filter((entry) => entry.length > 0);
       // Normalize allow/force/optional path lists before resolving so secrets
       // code receives policy paths, not UI whitespace artifacts.


### PR DESCRIPTION
## Summary

Fixes #90654: CLI write commands (`openclaw message send`, `broadcast`, `probe`) crash the gateway with `TypeError: Cannot read properties of undefined (reading 'trim')` during the `secrets.resolve` handshake.

Root cause: `commandName` and `targetIds` in the `secrets.resolve` handler were accessed with unguarded `.trim()` and `.map()` calls, unlike sibling fields (`allowedPaths`, `forcedActivePaths`, `optionalActivePaths`) which already use `?.` optional chaining. When the CLI sends a request where these fields are undefined, the handler throws inside the parse path, the WebSocket closes, and the CLI falls back to local resolution which cannot complete the send.

## Linked context

Closes #90654

## Real behavior proof (required for external PRs)

- **Behavior or issue addressed:** CLI write commands crash the gateway WebSocket handshake when `commandName` or `targetIds` are undefined in the `secrets.resolve` request frame.
- **Real environment tested:** macOS, Node v22.22.3, latest upstream/main
- **Exact steps or command run after this patch:**

```bash
node scripts/run-vitest.mjs run src/gateway/server-methods/secrets.test.ts --reporter=verbose
```

- **Evidence after fix (copied live output):**

```
 ✓ secrets handlers > handles undefined commandName without crashing
 ✓ secrets handlers > handles undefined targetIds without crashing
 ✓ secrets handlers > rejects secrets.resolve params when targetIds entries are not strings
 ...
 Test Files  2 passed (2)
      Tests  20 passed (20)
```

- **Observed result after fix:** When `commandName` or `targetIds` is undefined, the handler no longer throws `TypeError`. Instead it returns a clean `INVALID_REQUEST` error via the validator. Two new regression tests cover both undefined cases.
- **What was not tested:** Live gateway with real CLI WebSocket connection (the handler is tested directly with real `createSecretsHandlers` instantiation).

## Tests and validation

**Which commands did you run?**
```bash
node scripts/run-vitest.mjs run src/gateway/server-methods/secrets.test.ts
# 20 passed (2 test files)
```

**What regression coverage was added or updated?**
Two tests added:
- `"handles undefined commandName without crashing"` — verifies undefined commandName returns INVALID_REQUEST instead of crashing
- `"handles undefined targetIds without crashing"` — verifies undefined targetIds returns INVALID_REQUEST instead of crashing

## Risk checklist

**Did user-visible behavior change?** Yes — CLI commands no longer crash the gateway when secrets.resolve fields are undefined
**Did config, environment, or migration behavior change?** No
**Did security, auth, secrets, network, or tool execution behavior change?** No
**What is the highest-risk area?** Guarding input could mask genuine programming errors. Mitigation: the handler returns INVALID_REQUEST which is visible in logs.
**How is that risk mitigated?** Follows the same defensive pattern already used by sibling fields.

## Current review state

**What is the next action?** Maintainer review.
**What is still waiting on author, maintainer, CI, or external proof?** None.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Code <noreply@anthropic.com>
