### PR TITLE
fix(amazon-bedrock): skip IMDS during credential auto-detection (#64891)

### DIFF
--- a/extensions/amazon-bedrock/embedding-provider.test.ts
+++ b/extensions/amazon-bedrock/embedding-provider.test.ts
@@ -1,8 +1,11 @@
 // Amazon Bedrock tests cover embedding provider plugin behavior.
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { testing, hasAwsCredentials } from "./embedding-provider.js";
 
 describe("hasAwsCredentials", () => {
+  afterEach(() => {
+    testing.resetAwsCredentialProbeCacheForTesting();
+  });
   it("accepts static AWS key credentials without loading the credential chain", async () => {
     const loadCredentialProvider = vi.fn();
 
@@ -62,6 +65,144 @@ describe("hasAwsCredentials", () => {
     const loadCredentialProvider = vi.fn().mockResolvedValue(null);
 
     await expect(hasAwsCredentials({}, loadCredentialProvider)).resolves.toBe(false);
+  });
+
+  it("skips the credential chain when no AWS probe signals are present (#64891)", async () => {
+    const loadCredentialProvider = vi.fn();
+
+    await expect(hasAwsCredentials({}, loadCredentialProvider)).resolves.toBe(false);
+
+    expect(loadCredentialProvider).not.toHaveBeenCalled();
+  });
+
+  it("returns false immediately when AWS_EC2_METADATA_DISABLED is set without probe signals", async () => {
+    const loadCredentialProvider = vi.fn();
+
+    await expect(
+      hasAwsCredentials({ AWS_EC2_METADATA_DISABLED: "true" }, loadCredentialProvider),
+    ).resolves.toBe(false);
+
+    expect(loadCredentialProvider).not.toHaveBeenCalled();
+  });
+
+  it("preserves the default credential chain for explicit Bedrock configs", async () => {
+    const env = {} as NodeJS.ProcessEnv;
+    const defaultProvider = vi.fn(() => async () => {
+      expect(env.AWS_EC2_METADATA_DISABLED).toBeUndefined();
+      return { accessKeyId: "resolved-access-key" };
+    });
+    const loadCredentialProvider = vi.fn().mockResolvedValue({ defaultProvider });
+
+    await expect(hasAwsCredentials(env, loadCredentialProvider, { allowImds: true })).resolves.toBe(
+      true,
+    );
+
+    expect(defaultProvider).toHaveBeenCalledOnce();
+  });
+
+  it("disables IMDS during defaultProvider probing and restores env", async () => {
+    const env = { AWS_PROFILE: "work" } as NodeJS.ProcessEnv;
+    const defaultProvider = vi.fn(() => async () => {
+      expect(env.AWS_EC2_METADATA_DISABLED).toBe("true");
+      return { accessKeyId: "resolved-access-key" };
+    });
+    const loadCredentialProvider = vi.fn().mockResolvedValue({ defaultProvider });
+
+    await expect(hasAwsCredentials(env, loadCredentialProvider)).resolves.toBe(true);
+
+    expect(env.AWS_EC2_METADATA_DISABLED).toBeUndefined();
+    expect(defaultProvider).toHaveBeenCalledOnce();
+  });
+
+  it("memoizes process.env credential probes and coalesces concurrent calls", async () => {
+    const defaultProvider = vi.fn(() => async () => ({ accessKeyId: "resolved-access-key" }));
+    const loadCredentialProvider = vi.fn().mockResolvedValue({ defaultProvider });
+    const previousProfile = process.env.AWS_PROFILE;
+    process.env.AWS_PROFILE = "work";
+
+    try {
+      const [first, second] = await Promise.all([
+        hasAwsCredentials(process.env, loadCredentialProvider),
+        hasAwsCredentials(process.env, loadCredentialProvider),
+      ]);
+
+      expect(first).toBe(true);
+      expect(second).toBe(true);
+      expect(loadCredentialProvider).toHaveBeenCalledOnce();
+      expect(defaultProvider).toHaveBeenCalledOnce();
+    } finally {
+      if (previousProfile === undefined) {
+        delete process.env.AWS_PROFILE;
+      } else {
+        process.env.AWS_PROFILE = previousProfile;
+      }
+      testing.resetAwsCredentialProbeCacheForTesting();
+    }
+  });
+
+  it("keeps IMDS enabled when explicit Bedrock probing allows it", async () => {
+    const env = {} as NodeJS.ProcessEnv;
+    const defaultProvider = vi.fn(() => async () => {
+      expect(env.AWS_EC2_METADATA_DISABLED).toBeUndefined();
+      return { accessKeyId: "imds-access-key" };
+    });
+    const loadCredentialProvider = vi.fn().mockResolvedValue({ defaultProvider });
+
+    await expect(hasAwsCredentials(env, loadCredentialProvider, { allowImds: true })).resolves.toBe(
+      true,
+    );
+
+    expect(defaultProvider).toHaveBeenCalledOnce();
+  });
+
+  it("serializes overlapping IMDS-disabled and allow-IMDS probes on process.env", async () => {
+    let releaseProfileProbe!: () => void;
+    const profileProbeGate = new Promise<void>((resolve) => {
+      releaseProfileProbe = resolve;
+    });
+    const imdsDisabledDuringAllowProbe: Array<string | undefined> = [];
+
+    const defaultProvider = vi.fn(() => async () => {
+      if (process.env.AWS_EC2_METADATA_DISABLED === "true") {
+        expect(process.env.AWS_PROFILE).toBe("work");
+        await profileProbeGate;
+        return { accessKeyId: "profile-key" };
+      }
+      imdsDisabledDuringAllowProbe.push(process.env.AWS_EC2_METADATA_DISABLED);
+      return { accessKeyId: "imds-key" };
+    });
+    const loadCredentialProvider = vi.fn().mockResolvedValue({ defaultProvider });
+
+    const previousProfile = process.env.AWS_PROFILE;
+    process.env.AWS_PROFILE = "work";
+
+    try {
+      const profileProbe = hasAwsCredentials(process.env, loadCredentialProvider);
+      await vi.waitFor(() => {
+        expect(defaultProvider).toHaveBeenCalledOnce();
+      });
+
+      const allowImdsProbe = hasAwsCredentials(process.env, loadCredentialProvider, {
+        allowImds: true,
+      });
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 10);
+      });
+      expect(imdsDisabledDuringAllowProbe).toEqual([]);
+
+      releaseProfileProbe();
+      await expect(Promise.all([profileProbe, allowImdsProbe])).resolves.toEqual([true, true]);
+      expect(imdsDisabledDuringAllowProbe).toEqual([undefined]);
+      expect(process.env.AWS_EC2_METADATA_DISABLED).toBeUndefined();
+      expect(defaultProvider).toHaveBeenCalledTimes(2);
+    } finally {
+      if (previousProfile === undefined) {
+        delete process.env.AWS_PROFILE;
+      } else {
+        process.env.AWS_PROFILE = previousProfile;
+      }
+      testing.resetAwsCredentialProbeCacheForTesting();
+    }
   });
 });
 
@@ -129,9 +270,7 @@ describe("stripInferenceProfilePrefix", () => {
   });
 
   it("strips apac prefix", () => {
-    expect(testing.stripInferenceProfilePrefix("apac.cohere.embed-v4:0")).toBe(
-      "cohere.embed-v4:0",
-    );
+    expect(testing.stripInferenceProfilePrefix("apac.cohere.embed-v4:0")).toBe("cohere.embed-v4:0");
   });
 
   it("strips au prefix", () => {

--- a/extensions/amazon-bedrock/embedding-provider.ts
+++ b/extensions/amazon-bedrock/embedding-provider.ts
@@ -315,12 +315,6 @@ function parseCohereBatch(family: Family, raw: string): number[][] {
   return asNumberArrayBatch(embeddings);
 }
 
-export const testing = {
-  parseCohereBatch,
-  parseSingle,
-  stripInferenceProfilePrefix,
-};
-
 // ---------------------------------------------------------------------------
 // Provider
 // ---------------------------------------------------------------------------
@@ -452,20 +446,78 @@ function resolveBedrockEmbeddingClient(
 // Credential detection
 // ---------------------------------------------------------------------------
 
-export async function hasAwsCredentials(
-  env: NodeJS.ProcessEnv = process.env,
-  loadCredentialProvider: AwsCredentialProviderLoader = loadCredentialProviderSdk,
+const CREDENTIAL_CHAIN_PROBE_ENV_VARS = ["AWS_PROFILE"] as const;
+
+const CONTAINER_OR_ROLE_CREDENTIAL_SIGNALS = [
+  "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+  "AWS_CONTAINER_CREDENTIALS_FULL_URI",
+  "AWS_WEB_IDENTITY_TOKEN_FILE",
+  "AWS_ROLE_ARN",
+] as const;
+
+const AWS_CREDENTIAL_PROBE_CACHE_TTL_MS = 5 * 60 * 1000;
+
+let cachedCredentialProbeResult: boolean | undefined;
+let cachedCredentialProbeTimestamp: number | undefined;
+let cachedCredentialProbeAllowsImds: boolean | undefined;
+let credentialProbeLock: Promise<void> = Promise.resolve();
+
+type AwsCredentialProbeOptions = {
+  allowImds?: boolean;
+};
+
+function isAwsEc2MetadataExplicitlyDisabled(env: NodeJS.ProcessEnv): boolean {
+  return env.AWS_EC2_METADATA_DISABLED?.trim().toLowerCase() === "true";
+}
+
+function hasAwsCredentialProbeSignals(env: NodeJS.ProcessEnv): boolean {
+  if (CREDENTIAL_CHAIN_PROBE_ENV_VARS.some((key) => env[key]?.trim())) {
+    return true;
+  }
+  return CONTAINER_OR_ROLE_CREDENTIAL_SIGNALS.some((key) => env[key]?.trim());
+}
+
+function shouldProbeAwsCredentialChain(
+  env: NodeJS.ProcessEnv,
+  options: AwsCredentialProbeOptions,
+): boolean {
+  return options.allowImds === true || hasAwsCredentialProbeSignals(env);
+}
+
+// Serialize process.env probes so temporary AWS_EC2_METADATA_DISABLED mutations
+// from IMDS-disabled auto-detection cannot leak into concurrent allow-IMDS probes.
+async function withCredentialProbeLock<T>(fn: () => Promise<T>): Promise<T> {
+  let releaseLock!: () => void;
+  const acquired = new Promise<void>((resolve) => {
+    releaseLock = resolve;
+  });
+  const waitFor = credentialProbeLock;
+  credentialProbeLock = acquired;
+  await waitFor;
+  try {
+    return await fn();
+  } finally {
+    releaseLock();
+  }
+}
+
+async function probeAwsCredentials(
+  env: NodeJS.ProcessEnv,
+  loadCredentialProvider: AwsCredentialProviderLoader,
+  options: AwsCredentialProbeOptions,
 ): Promise<boolean> {
-  if (env.AWS_ACCESS_KEY_ID?.trim() && env.AWS_SECRET_ACCESS_KEY?.trim()) {
-    return true;
-  }
-  if (env.AWS_BEARER_TOKEN_BEDROCK?.trim()) {
-    return true;
-  }
   const credentialProviderSdk = await loadCredentialProvider();
   if (!credentialProviderSdk) {
     return false;
   }
+
+  const previousImdsDisabled = env.AWS_EC2_METADATA_DISABLED;
+  const shouldTemporarilyDisableImds =
+    !isAwsEc2MetadataExplicitlyDisabled(env) && options.allowImds !== true;
+  if (shouldTemporarilyDisableImds) {
+    env.AWS_EC2_METADATA_DISABLED = "true";
+  }
+
   try {
     const credentials = await credentialProviderSdk.defaultProvider({
       timeout: 1000,
@@ -474,6 +526,71 @@ export async function hasAwsCredentials(
     return typeof credentials.accessKeyId === "string" && credentials.accessKeyId.trim().length > 0;
   } catch {
     return false;
+  } finally {
+    if (shouldTemporarilyDisableImds) {
+      if (previousImdsDisabled === undefined) {
+        delete env.AWS_EC2_METADATA_DISABLED;
+      } else {
+        env.AWS_EC2_METADATA_DISABLED = previousImdsDisabled;
+      }
+    }
   }
 }
+
+/** @internal Resets memoized credential probe state for tests. */
+function resetAwsCredentialProbeCacheForTesting(): void {
+  cachedCredentialProbeResult = undefined;
+  cachedCredentialProbeTimestamp = undefined;
+  cachedCredentialProbeAllowsImds = undefined;
+  credentialProbeLock = Promise.resolve();
+}
+
+export async function hasAwsCredentials(
+  env: NodeJS.ProcessEnv = process.env,
+  loadCredentialProvider?: AwsCredentialProviderLoader,
+  options: AwsCredentialProbeOptions = {},
+): Promise<boolean> {
+  if (env.AWS_ACCESS_KEY_ID?.trim() && env.AWS_SECRET_ACCESS_KEY?.trim()) {
+    return true;
+  }
+  if (env.AWS_BEARER_TOKEN_BEDROCK?.trim()) {
+    return true;
+  }
+  if (isAwsEc2MetadataExplicitlyDisabled(env) && !shouldProbeAwsCredentialChain(env, options)) {
+    return false;
+  }
+  if (!shouldProbeAwsCredentialChain(env, options)) {
+    return false;
+  }
+
+  const credentialProviderLoader = loadCredentialProvider ?? loadCredentialProviderSdk;
+  const allowImds = options.allowImds === true;
+  if (env === process.env) {
+    return withCredentialProbeLock(async () => {
+      if (
+        cachedCredentialProbeResult !== undefined &&
+        cachedCredentialProbeTimestamp !== undefined &&
+        cachedCredentialProbeAllowsImds === allowImds &&
+        Date.now() - cachedCredentialProbeTimestamp < AWS_CREDENTIAL_PROBE_CACHE_TTL_MS
+      ) {
+        return cachedCredentialProbeResult;
+      }
+      const result = await probeAwsCredentials(env, credentialProviderLoader, options);
+      cachedCredentialProbeResult = result;
+      cachedCredentialProbeTimestamp = Date.now();
+      cachedCredentialProbeAllowsImds = allowImds;
+      return result;
+    });
+  }
+
+  return probeAwsCredentials(env, credentialProviderLoader, options);
+}
+
+export const testing = {
+  parseCohereBatch,
+  parseSingle,
+  resetAwsCredentialProbeCacheForTesting,
+  stripInferenceProfilePrefix,
+};
+
 export { testing as __testing };

--- a/extensions/amazon-bedrock/memory-embedding-adapter.test.ts
+++ b/extensions/amazon-bedrock/memory-embedding-adapter.test.ts
@@ -68,6 +68,9 @@ describe("bedrockMemoryEmbeddingProviderAdapter", () => {
       bedrockMemoryEmbeddingProviderAdapter.create(defaultCreateOptions()),
     ).rejects.toThrow(/AWS credentials are not available/);
 
+    expect(hasAwsCredentialsMock).toHaveBeenCalledWith(process.env, undefined, {
+      allowImds: false,
+    });
     expect(createBedrockEmbeddingProviderMock).not.toHaveBeenCalled();
   });
 
@@ -88,6 +91,119 @@ describe("bedrockMemoryEmbeddingProviderAdapter", () => {
       },
     });
     expect(createBedrockEmbeddingProviderMock).toHaveBeenCalledOnce();
+  });
+
+  it("allows IMDS credential probing for explicitly selected Bedrock", async () => {
+    hasAwsCredentialsMock.mockResolvedValue(true);
+    stubCreate({ region: "us-east-1", model: "amazon.titan-embed-text-v2:0" });
+
+    await bedrockMemoryEmbeddingProviderAdapter.create({
+      ...defaultCreateOptions(),
+      provider: "bedrock",
+    });
+
+    expect(hasAwsCredentialsMock).toHaveBeenCalledWith(process.env, undefined, {
+      allowImds: true,
+    });
+  });
+
+  it("allows IMDS credential probing when Bedrock is explicitly configured in memorySearch", async () => {
+    hasAwsCredentialsMock.mockResolvedValue(true);
+    stubCreate({ region: "us-east-1", model: "amazon.titan-embed-text-v2:0" });
+
+    await bedrockMemoryEmbeddingProviderAdapter.create({
+      ...defaultCreateOptions(),
+      config: {
+        agents: {
+          defaults: {
+            memorySearch: { provider: "bedrock" },
+          },
+        },
+      },
+    });
+
+    expect(hasAwsCredentialsMock).toHaveBeenCalledWith(process.env, undefined, {
+      allowImds: true,
+    });
+  });
+
+  it("allows IMDS credential probing for a configured Bedrock provider alias selected by id", async () => {
+    hasAwsCredentialsMock.mockResolvedValue(true);
+    stubCreate({ region: "us-east-1", model: "amazon.titan-embed-text-v2:0" });
+
+    await bedrockMemoryEmbeddingProviderAdapter.create({
+      ...defaultCreateOptions(),
+      provider: "my-bedrock",
+      config: {
+        models: {
+          providers: {
+            "my-bedrock": {
+              baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+              api: "bedrock-converse-stream",
+              models: [],
+            },
+          },
+        },
+      },
+    });
+
+    expect(hasAwsCredentialsMock).toHaveBeenCalledWith(process.env, undefined, {
+      allowImds: true,
+    });
+  });
+
+  it("allows IMDS credential probing when a Bedrock provider alias is configured in memorySearch", async () => {
+    hasAwsCredentialsMock.mockResolvedValue(true);
+    stubCreate({ region: "us-east-1", model: "amazon.titan-embed-text-v2:0" });
+
+    await bedrockMemoryEmbeddingProviderAdapter.create({
+      ...defaultCreateOptions(),
+      config: {
+        agents: {
+          defaults: {
+            memorySearch: { provider: "my-bedrock" },
+          },
+        },
+        models: {
+          providers: {
+            "my-bedrock": {
+              baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+              api: "bedrock-converse-stream",
+              models: [],
+            },
+          },
+        },
+      },
+    });
+
+    expect(hasAwsCredentialsMock).toHaveBeenCalledWith(process.env, undefined, {
+      allowImds: true,
+    });
+  });
+
+  it("does not allow IMDS probing for a non-Bedrock provider alias with the same selected id", async () => {
+    hasAwsCredentialsMock.mockResolvedValue(true);
+    stubCreate({ region: "us-east-1", model: "amazon.titan-embed-text-v2:0" });
+
+    await bedrockMemoryEmbeddingProviderAdapter.create({
+      ...defaultCreateOptions(),
+      provider: "my-openai",
+      config: {
+        models: {
+          providers: {
+            "my-openai": {
+              baseUrl: "https://api.openai.com/v1",
+              api: "openai-completions",
+              models: [],
+            },
+          },
+        },
+      },
+    });
+
+    expect(hasAwsCredentialsMock).toHaveBeenCalledWith(process.env, undefined, {
+      allowImds: false,
+    });
   });
 
   it("lets the auto-select loop skip bedrock when credentials are unavailable", async () => {

--- a/extensions/amazon-bedrock/memory-embedding-adapter.test.ts
+++ b/extensions/amazon-bedrock/memory-embedding-adapter.test.ts
@@ -152,6 +152,60 @@ describe("bedrockMemoryEmbeddingProviderAdapter", () => {
     });
   });
 
+  it("allows IMDS credential probing when a Bedrock alias config key differs by case from the selected id", async () => {
+    hasAwsCredentialsMock.mockResolvedValue(true);
+    stubCreate({ region: "us-east-1", model: "amazon.titan-embed-text-v2:0" });
+
+    await bedrockMemoryEmbeddingProviderAdapter.create({
+      ...defaultCreateOptions(),
+      provider: "my-bedrock",
+      config: {
+        models: {
+          providers: {
+            "My-Bedrock": {
+              baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+              api: "bedrock-converse-stream",
+              models: [],
+            },
+          },
+        },
+      },
+    });
+
+    expect(hasAwsCredentialsMock).toHaveBeenCalledWith(process.env, undefined, {
+      allowImds: true,
+    });
+  });
+
+  it("allows IMDS credential probing when memorySearch selects a normalized Bedrock alias id", async () => {
+    hasAwsCredentialsMock.mockResolvedValue(true);
+    stubCreate({ region: "us-east-1", model: "amazon.titan-embed-text-v2:0" });
+
+    await bedrockMemoryEmbeddingProviderAdapter.create({
+      ...defaultCreateOptions(),
+      config: {
+        agents: {
+          defaults: {
+            memorySearch: { provider: " my-bedrock " },
+          },
+        },
+        models: {
+          providers: {
+            "My-Bedrock": {
+              baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+              api: "bedrock-converse-stream",
+              models: [],
+            },
+          },
+        },
+      },
+    });
+
+    expect(hasAwsCredentialsMock).toHaveBeenCalledWith(process.env, undefined, {
+      allowImds: true,
+    });
+  });
+
   it("allows IMDS credential probing when a Bedrock provider alias is configured in memorySearch", async () => {
     hasAwsCredentialsMock.mockResolvedValue(true);
     stubCreate({ region: "us-east-1", model: "amazon.titan-embed-text-v2:0" });

--- a/extensions/amazon-bedrock/memory-embedding-adapter.ts
+++ b/extensions/amazon-bedrock/memory-embedding-adapter.ts
@@ -5,12 +5,45 @@
 import {
   isMissingEmbeddingApiKeyError,
   type MemoryEmbeddingProviderAdapter,
+  type MemoryEmbeddingProviderCreateOptions,
 } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
 import {
   createBedrockEmbeddingProvider,
   DEFAULT_BEDROCK_EMBEDDING_MODEL,
   hasAwsCredentials,
 } from "./embedding-provider.js";
+
+// A memory provider id resolves to Bedrock when it is the literal id "bedrock"
+// or when it is a configured provider alias whose `api` adapter is the Bedrock
+// runtime api ("bedrock-converse-stream", see ModelApi). Both shapes must allow
+// the AWS SDK default credential chain, or an explicit alias setup loses
+// IMDS/shared-config/SSO resolution that the literal id keeps.
+function resolvesToBedrock(
+  config: MemoryEmbeddingProviderCreateOptions["config"],
+  providerId: unknown,
+): boolean {
+  if (typeof providerId !== "string" || providerId.trim() === "") {
+    return false;
+  }
+  if (providerId.trim().toLowerCase() === "bedrock") {
+    return true;
+  }
+  return config.models?.providers?.[providerId]?.api === "bedrock-converse-stream";
+}
+
+function shouldAllowAwsImdsCredentialProbe(options: MemoryEmbeddingProviderCreateOptions): boolean {
+  if (resolvesToBedrock(options.config, options.provider)) {
+    return true;
+  }
+  if (resolvesToBedrock(options.config, options.config.agents?.defaults?.memorySearch?.provider)) {
+    return true;
+  }
+  return (
+    options.config.agents?.list?.some((agent) =>
+      resolvesToBedrock(options.config, agent.memorySearch?.provider),
+    ) ?? false
+  );
+}
 
 /** Memory-core adapter descriptor for Bedrock embeddings. */
 export const bedrockMemoryEmbeddingProviderAdapter: MemoryEmbeddingProviderAdapter = {
@@ -22,7 +55,11 @@ export const bedrockMemoryEmbeddingProviderAdapter: MemoryEmbeddingProviderAdapt
   allowExplicitWhenConfiguredAuto: true,
   shouldContinueAutoSelection: isMissingEmbeddingApiKeyError,
   create: async (options) => {
-    if (!(await hasAwsCredentials())) {
+    if (
+      !(await hasAwsCredentials(process.env, undefined, {
+        allowImds: shouldAllowAwsImdsCredentialProbe(options),
+      }))
+    ) {
       throw new Error(
         'No API key found for provider "bedrock". ' +
           "AWS credentials are not available. " +

--- a/extensions/amazon-bedrock/memory-embedding-adapter.ts
+++ b/extensions/amazon-bedrock/memory-embedding-adapter.ts
@@ -7,11 +7,34 @@ import {
   type MemoryEmbeddingProviderAdapter,
   type MemoryEmbeddingProviderCreateOptions,
 } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
+import { normalizeProviderId } from "openclaw/plugin-sdk/provider-model-shared";
 import {
   createBedrockEmbeddingProvider,
   DEFAULT_BEDROCK_EMBEDDING_MODEL,
   hasAwsCredentials,
 } from "./embedding-provider.js";
+
+type ConfiguredModelProvider = NonNullable<
+  NonNullable<MemoryEmbeddingProviderCreateOptions["config"]["models"]>["providers"]
+>[string];
+
+// Match OpenClaw's normalized provider-id lookup so alias keys like My-Bedrock
+// still resolve when callers pass my-bedrock through memory provider routing.
+function readConfiguredProviderEntry(
+  providers: Record<string, ConfiguredModelProvider> | undefined,
+  providerId: string,
+): ConfiguredModelProvider | undefined {
+  if (!providers) {
+    return undefined;
+  }
+  const normalized = normalizeProviderId(providerId);
+  for (const [key, value] of Object.entries(providers)) {
+    if (normalizeProviderId(key) === normalized) {
+      return value;
+    }
+  }
+  return undefined;
+}
 
 // A memory provider id resolves to Bedrock when it is the literal id "bedrock"
 // or when it is a configured provider alias whose `api` adapter is the Bedrock
@@ -25,10 +48,13 @@ function resolvesToBedrock(
   if (typeof providerId !== "string" || providerId.trim() === "") {
     return false;
   }
-  if (providerId.trim().toLowerCase() === "bedrock") {
+  if (normalizeProviderId(providerId) === "bedrock") {
     return true;
   }
-  return config.models?.providers?.[providerId]?.api === "bedrock-converse-stream";
+  return (
+    readConfiguredProviderEntry(config.models?.providers, providerId)?.api ===
+    "bedrock-converse-stream"
+  );
 }
 
 function shouldAllowAwsImdsCredentialProbe(options: MemoryEmbeddingProviderCreateOptions): boolean {


### PR DESCRIPTION
﻿## Summary

- Stop Bedrock memory auto-detection from probing AWS IMDS (`169.254.169.254`) when no AWS credential signals are configured.
- Keep the AWS SDK default credential chain available for explicitly selected/configured Bedrock memory providers, including shared config/profile, SSO, web identity, ECS, and EC2/IMDS role setups.
- During non-IMDS profile/container/web-identity probes, temporarily set `AWS_EC2_METADATA_DISABLED=true` so `defaultProvider()` skips instance metadata while still resolving configured non-IMDS sources.
- Memoize `process.env` credential probes for 5 minutes and coalesce concurrent calls without sharing cached results across IMDS-enabled and IMDS-disabled probe modes.

Closes #64891

## Real behavior proof

Behavior addressed: Bedrock memory auto-detection no longer loads the AWS SDK credential chain, and therefore does not reach IMDS, when there are no AWS credential signals. Explicit Bedrock memory configuration still allows the full AWS SDK default chain.

Real environment tested: Windows local OpenClaw source checkout, running the patched Amazon Bedrock provider code directly through Node 22/tsx with AWS credential environment variables cleared.

Exact steps or command run after this patch:

```powershell
node --import tsx -e "const awsKeys=['AWS_ACCESS_KEY_ID','AWS_SECRET_ACCESS_KEY','AWS_SESSION_TOKEN','AWS_PROFILE','AWS_BEARER_TOKEN_BEDROCK','AWS_CONTAINER_CREDENTIALS_RELATIVE_URI','AWS_CONTAINER_CREDENTIALS_FULL_URI','AWS_WEB_IDENTITY_TOKEN_FILE','AWS_ROLE_ARN','AWS_EC2_METADATA_DISABLED']; for (const key of awsKeys) delete process.env[key]; const { hasAwsCredentials } = await import('./extensions/amazon-bedrock/embedding-provider.ts'); const started=Date.now(); const result=await hasAwsCredentials(); console.log(JSON.stringify({setup:'local OpenClaw source checkout',command:'hasAwsCredentials() with AWS credential env cleared',awsCredentialEnvPresent:awsKeys.filter((key)=>process.env[key]),result,elapsedMs:Date.now()-started,metadataDisabledAfter:process.env.AWS_EC2_METADATA_DISABLED ?? null},null,2));"
```

Evidence after fix: Console output from the local OpenClaw source checkout:

```json
{
  "setup": "local OpenClaw source checkout",
  "command": "hasAwsCredentials() with AWS credential env cleared",
  "awsCredentialEnvPresent": [],
  "result": false,
  "elapsedMs": 0,
  "metadataDisabledAfter": null
}
```

Observed result after fix: With AWS credential environment cleared, the real provider code returned `false` immediately from the no-signal auto-detection path. The command completed without setting `AWS_EC2_METADATA_DISABLED` and without waiting on the AWS SDK metadata timeout path.

What was not tested: A live AWS EC2/ECS/default-chain credential setup and the original non-AWS sandbox packet trace were not available in this environment; those remain maintainer/live-environment proof gaps.

## Tests

- `pnpm exec vitest run extensions/amazon-bedrock/embedding-provider.test.ts extensions/amazon-bedrock/memory-embedding-adapter.test.ts --config test/vitest/vitest.extension-providers.config.ts`
- `pnpm exec tsgo -p test/tsconfig/tsconfig.extensions.test.json --pretty false`
- `pnpm exec tsgo -p tsconfig.extensions.json --pretty false`
- `OPENCLAW_EXTENSION_BOUNDARY_CONCURRENCY=1 pnpm run test:extensions:package-boundary:compile`
- `OPENCLAW_EXTENSION_BOUNDARY_CONCURRENCY=1 pnpm run test:extensions:package-boundary:canary`
- `pnpm exec oxfmt --check --threads=1 extensions/amazon-bedrock/embedding-provider.ts extensions/amazon-bedrock/embedding-provider.test.ts extensions/amazon-bedrock/memory-embedding-adapter.ts extensions/amazon-bedrock/memory-embedding-adapter.test.ts`
- `git diff --check`

## Test plan

- [x] Empty env skips credential SDK load
- [x] `AWS_EC2_METADATA_DISABLED=true` exits without SDK when no probe signals
- [x] `AWS_PROFILE` probe disables IMDS temporarily and restores env
- [x] Explicit Bedrock provider/config preserves full AWS SDK default chain probing
- [x] `process.env` probes are memoized and coalesced per IMDS mode
- [ ] Maintainer/live env: non-AWS sandbox startup shows no repeated `169.254.169.254` traffic
- [ ] Maintainer/live env: EC2/ECS/default-chain Bedrock memory credentials still resolve
