### PR TITLE
fix(agents): reconnect streamable-HTTP MCP sessions on session loss [AI-assisted]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Docs: https://docs.openclaw.ai
 - Release/CI/E2E: fail PTY-backed E2E commands when transcript logs cannot be written instead of letting missing proof capture crash around a live child process.
 - Release/CI/E2E: fail mock OpenAI request-log write errors with clear HTTP responses instead of leaving provider proof clients waiting on a broken socket.
 - Release/CI/E2E: fail Parallels host-command log write errors through the command result path instead of leaving streaming smoke phases unresolved.
+- Agents/MCP: auto-reconnect a streamable-HTTP MCP server after it drops our session (for example when the remote restarts), retrying the tool call once on a fresh handshake instead of failing every call with "Session not found" until the agent session is reset.
 
 ## 2026.6.1
 

--- a/src/agents/agent-bundle-mcp-runtime.reconnect.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.reconnect.test.ts
@@ -1,0 +1,314 @@
+import { StreamableHTTPError } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Reconnect-on-session-loss coverage for `callTool`. This file mocks the MCP
+// SDK `Client`, the transport resolver, and the embedded MCP config so we can
+// deterministically simulate a server dropping our streamable-http session — a
+// path that is impractical to trigger with the real-server harness used by
+// `agent-bundle-mcp-runtime.test.ts`. Mocks are hoisted/module-wide, which is
+// why this lives in a dedicated file rather than extending the harness suite.
+// ---------------------------------------------------------------------------
+
+type CallToolHandler = (clientIndex: number, req: unknown) => Promise<unknown> | unknown;
+type ConnectHandler = (clientIndex: number) => Promise<void> | void;
+
+const hooks = vi.hoisted(() => {
+  type FakeClient = {
+    index: number;
+    connect: ReturnType<typeof vi.fn>;
+    getServerCapabilities: ReturnType<typeof vi.fn>;
+    listTools: ReturnType<typeof vi.fn>;
+    callTool: ReturnType<typeof vi.fn>;
+    close: ReturnType<typeof vi.fn>;
+  };
+  type FakeTransport = {
+    index: number;
+    transportType: "stdio" | "sse" | "streamable-http";
+    close: ReturnType<typeof vi.fn>;
+    terminateSession: ReturnType<typeof vi.fn>;
+  };
+
+  const clients: FakeClient[] = [];
+  const transports: FakeTransport[] = [];
+  const controller: {
+    callTool: CallToolHandler;
+    connect: ConnectHandler;
+    transportType: "stdio" | "sse" | "streamable-http";
+    servers: Record<string, unknown>;
+  } = {
+    // Default: every tool call succeeds.
+    callTool: () => ({ content: [{ type: "text", text: "ok" }] }),
+    // Default: every connect resolves immediately.
+    connect: () => {},
+    transportType: "streamable-http",
+    servers: { vault: { url: "https://example.test/mcp", transport: "streamable-http" } },
+  };
+
+  class ClientMock {
+    index: number;
+    connect: ReturnType<typeof vi.fn>;
+    getServerCapabilities: ReturnType<typeof vi.fn>;
+    listTools: ReturnType<typeof vi.fn>;
+    callTool: ReturnType<typeof vi.fn>;
+    close: ReturnType<typeof vi.fn>;
+    constructor() {
+      const index = clients.length;
+      this.index = index;
+      this.connect = vi.fn(async () => {
+        await controller.connect(index);
+      });
+      this.getServerCapabilities = vi.fn(() => undefined);
+      this.listTools = vi.fn(async () => ({
+        tools: [{ name: "do_thing", inputSchema: { type: "object" } }],
+        nextCursor: undefined,
+      }));
+      this.callTool = vi.fn(async (req: unknown) => controller.callTool(index, req));
+      this.close = vi.fn(async () => {});
+      clients.push(this as unknown as FakeClient);
+    }
+  }
+
+  const resolveMcpTransport = vi.fn((serverName: string) => {
+    const index = transports.length;
+    const transport: FakeTransport = {
+      index,
+      transportType: controller.transportType,
+      close: vi.fn(async () => {}),
+      terminateSession: vi.fn(async () => {}),
+    };
+    transports.push(transport);
+    return {
+      transport,
+      description: `fake:${serverName}`,
+      transportType: controller.transportType,
+      connectionTimeoutMs: 100_000,
+      requestTimeoutMs: 100_000,
+      supportsParallelToolCalls: false,
+      detachStderr: undefined,
+    };
+  });
+
+  const loadEmbeddedAgentMcpConfig = vi.fn(() => ({
+    mcpServers: controller.servers,
+    diagnostics: [],
+  }));
+
+  return {
+    clients,
+    transports,
+    controller,
+    ClientMock,
+    resolveMcpTransport,
+    loadEmbeddedAgentMcpConfig,
+  };
+});
+
+vi.mock("@modelcontextprotocol/sdk/client/index.js", () => ({ Client: hooks.ClientMock }));
+vi.mock("./mcp-transport.js", () => ({ resolveMcpTransport: hooks.resolveMcpTransport }));
+vi.mock("./embedded-agent-mcp.js", () => ({
+  loadEmbeddedAgentMcpConfig: hooks.loadEmbeddedAgentMcpConfig,
+}));
+
+import { __testing, createSessionMcpRuntime } from "./agent-bundle-mcp-runtime.js";
+
+const { isMcpSessionLostError } = __testing;
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function sessionLostHttpError() {
+  return new StreamableHTTPError(
+    404,
+    'Error POSTing to endpoint: {"jsonRpcError":{"code":-32603,"message":"Session not found: abc"}}',
+  );
+}
+
+function makeRuntime(sessionId: string) {
+  return createSessionMcpRuntime({ sessionId, workspaceDir: "/tmp/reconnect-test" });
+}
+
+afterEach(() => {
+  hooks.clients.length = 0;
+  hooks.transports.length = 0;
+  hooks.controller.callTool = () => ({ content: [{ type: "text", text: "ok" }] });
+  hooks.controller.connect = () => {};
+  hooks.controller.transportType = "streamable-http";
+  hooks.controller.servers = {
+    vault: { url: "https://example.test/mcp", transport: "streamable-http" },
+  };
+  vi.clearAllMocks();
+});
+
+describe("isMcpSessionLostError", () => {
+  it("flags a StreamableHTTPError with HTTP 404", () => {
+    expect(isMcpSessionLostError(new StreamableHTTPError(404, "gone"))).toBe(true);
+  });
+
+  it("flags a StreamableHTTPError whose body leaked 'Session not found' (non-404 status)", () => {
+    expect(
+      isMcpSessionLostError(
+        new StreamableHTTPError(500, "Error POSTing to endpoint: {... Session not found: x ...}"),
+      ),
+    ).toBe(true);
+  });
+
+  it("flags an McpError-shaped -32603 'Session not found' (HTTP-200 body)", () => {
+    expect(
+      isMcpSessionLostError({ code: -32603, message: "MCP error -32603: Session not found: abc" }),
+    ).toBe(true);
+  });
+
+  it("does not flag unrelated errors", () => {
+    expect(isMcpSessionLostError(new StreamableHTTPError(500, "internal boom"))).toBe(false);
+    expect(isMcpSessionLostError(new Error("Session not found"))).toBe(false); // generic Error, no code
+    expect(isMcpSessionLostError({ code: -32603, message: "some other internal error" })).toBe(
+      false,
+    );
+    expect(isMcpSessionLostError(null)).toBe(false);
+    expect(isMcpSessionLostError("Session not found")).toBe(false);
+  });
+});
+
+describe("callTool reconnect-on-session-loss", () => {
+  it("does not reconnect on a successful call", async () => {
+    const runtime = makeRuntime("happy");
+    const result = await runtime.callTool("vault", "do_thing", {});
+    expect((result as { content: unknown }).content).toBeDefined();
+    expect(hooks.clients).toHaveLength(1); // only the initial catalog client
+    expect(hooks.clients[0].callTool).toHaveBeenCalledTimes(1);
+    expect(hooks.transports[0].terminateSession).not.toHaveBeenCalled();
+    await runtime.dispose();
+  });
+
+  it("re-handshakes once and retries when the session is lost", async () => {
+    hooks.controller.callTool = (clientIndex) => {
+      if (clientIndex === 0) {
+        throw sessionLostHttpError();
+      }
+      return { content: [{ type: "text", text: "healed" }] };
+    };
+    const runtime = makeRuntime("heal");
+    const result = await runtime.callTool("vault", "do_thing", {});
+    expect((result as { content: [{ text: string }] }).content[0].text).toBe("healed");
+    // Exactly one reconnect: a fresh client + transport were built.
+    expect(hooks.clients).toHaveLength(2);
+    expect(hooks.transports).toHaveLength(2);
+    // The dead session was torn down.
+    expect(hooks.clients[0].close).toHaveBeenCalledTimes(1);
+    expect(hooks.transports[0].close).toHaveBeenCalledTimes(1);
+    // Dead-session teardown skips the guaranteed-404 DELETE.
+    expect(hooks.transports[0].terminateSession).not.toHaveBeenCalled();
+    // The retry ran on the fresh client.
+    expect(hooks.clients[1].callTool).toHaveBeenCalledTimes(1);
+    await runtime.dispose();
+  });
+
+  it("does not re-list tools on reconnect and keeps the cached catalog stable", async () => {
+    hooks.controller.callTool = (clientIndex) =>
+      clientIndex === 0 ? Promise.reject(sessionLostHttpError()) : { content: [] };
+    const runtime = makeRuntime("catalog");
+    const before = await runtime.getCatalog();
+    await runtime.callTool("vault", "do_thing", {});
+    const after = await runtime.getCatalog();
+    // Catalog identity is preserved across the reconnect (prompt-prefix stability).
+    expect(after).toBe(before);
+    // Only the initial catalog build listed tools; reconnect did not.
+    expect(hooks.clients[0].listTools).toHaveBeenCalledTimes(1);
+    expect(hooks.clients[1].listTools).not.toHaveBeenCalled();
+    await runtime.dispose();
+  });
+
+  it("propagates and does not loop when the retry also fails session-lost", async () => {
+    hooks.controller.callTool = () => Promise.reject(sessionLostHttpError());
+    const runtime = makeRuntime("loop");
+    await expect(runtime.callTool("vault", "do_thing", {})).rejects.toBeInstanceOf(
+      StreamableHTTPError,
+    );
+    // One reconnect only: clients = initial(0) + one reconnect(1). No storm.
+    expect(hooks.clients).toHaveLength(2);
+    await runtime.dispose();
+  });
+
+  it("rethrows a non-session error without reconnecting", async () => {
+    hooks.controller.callTool = () => Promise.reject(new StreamableHTTPError(500, "boom"));
+    const runtime = makeRuntime("nonsession");
+    await expect(runtime.callTool("vault", "do_thing", {})).rejects.toThrow("boom");
+    expect(hooks.clients).toHaveLength(1); // no reconnect
+    await runtime.dispose();
+  });
+
+  it("does not reconnect a non-streamable-http transport on a session-lost-looking error", async () => {
+    hooks.controller.transportType = "stdio";
+    hooks.controller.servers = { vault: { command: "fake" } };
+    hooks.controller.callTool = () => Promise.reject(sessionLostHttpError());
+    const runtime = makeRuntime("stdio");
+    await expect(runtime.callTool("vault", "do_thing", {})).rejects.toBeInstanceOf(
+      StreamableHTTPError,
+    );
+    expect(hooks.clients).toHaveLength(1); // transport gate prevents reconnect
+    await runtime.dispose();
+  });
+
+  it("surfaces the connect error and leaks nothing when reconnect fails", async () => {
+    hooks.controller.callTool = (clientIndex) =>
+      clientIndex === 0 ? Promise.reject(sessionLostHttpError()) : { content: [] };
+    hooks.controller.connect = (clientIndex) => {
+      if (clientIndex === 1) {
+        throw new Error("connection refused");
+      }
+    };
+    const runtime = makeRuntime("reconnect-fail");
+    await expect(runtime.callTool("vault", "do_thing", {})).rejects.toThrow("connection refused");
+    // The half-open reconnect client was disposed (no leak).
+    expect(hooks.clients).toHaveLength(2);
+    expect(hooks.clients[1].close).toHaveBeenCalledTimes(1);
+    await runtime.dispose();
+  });
+
+  it("dedupes concurrent reconnects on the same server", async () => {
+    hooks.controller.callTool = (clientIndex) =>
+      clientIndex === 0 ? Promise.reject(sessionLostHttpError()) : { content: [] };
+    const runtime = makeRuntime("concurrent");
+    const [a, b] = await Promise.all([
+      runtime.callTool("vault", "do_thing", {}),
+      runtime.callTool("vault", "do_thing", {}),
+    ]);
+    expect(a).toBeDefined();
+    expect(b).toBeDefined();
+    // Single reconnect shared by both callers: initial(0) + one reconnect(1).
+    expect(hooks.clients).toHaveLength(2);
+    // resolveMcpTransport: once for the initial catalog, once for the single reconnect.
+    expect(hooks.resolveMcpTransport).toHaveBeenCalledTimes(2);
+    // Dead session disposed exactly once.
+    expect(hooks.clients[0].close).toHaveBeenCalledTimes(1);
+    await runtime.dispose();
+  });
+
+  it("tears down the fresh client when disposed mid-reconnect", async () => {
+    const gate = deferred<void>();
+    hooks.controller.callTool = (clientIndex) =>
+      clientIndex === 0 ? Promise.reject(sessionLostHttpError()) : { content: [] };
+    hooks.controller.connect = async (clientIndex) => {
+      if (clientIndex === 1) {
+        await gate.promise; // hold the reconnect open
+      }
+    };
+    const runtime = makeRuntime("disposed-mid");
+    const call = runtime.callTool("vault", "do_thing", {});
+    // Let the call reach the pending reconnect connect.
+    await vi.waitFor(() => expect(hooks.clients).toHaveLength(2));
+    await runtime.dispose();
+    gate.resolve(); // connect resolves, but the runtime is now disposed
+    await expect(call).rejects.toThrow(/disposed/);
+    // Fresh reconnect client was torn down (no leak).
+    expect(hooks.clients[1].close).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/agents/agent-bundle-mcp-runtime.ts
+++ b/src/agents/agent-bundle-mcp-runtime.ts
@@ -1,7 +1,10 @@
 /** Session-scoped MCP runtime manager, catalog loader, and transport lifecycle. */
 import crypto from "node:crypto";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import {
+  StreamableHTTPClientTransport,
+  StreamableHTTPError,
+} from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import { ErrorCode, type CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import type { ServerCapabilities } from "@modelcontextprotocol/sdk/types.js";
@@ -234,6 +237,42 @@ function isMcpMethodNotFoundError(error: unknown): boolean {
   return message.includes("-32601") || /method not found/i.test(message);
 }
 
+const SESSION_LOST_MESSAGE = /session not found/i;
+
+/**
+ * Detects whether an MCP tool-call error means the server lost our session
+ * (typically because a remote streamable-HTTP server restarted and dropped its
+ * in-memory session map). The signal arrives in two shapes:
+ *  - `StreamableHTTPError` on a failed POST: HTTP 404 is the MCP-spec
+ *    session-terminated signal; some servers instead surface a
+ *    `-32603 "Session not found"` body that the SDK folds into the error
+ *    message regardless of the HTTP status.
+ *  - An `McpError`-shaped `-32603 "...Session not found..."` when the server
+ *    returns the JSON-RPC error inside an HTTP-200 body, which the SDK parses
+ *    as a structured error response rather than a transport error.
+ * Pure predicate over the error only; the streamable-http transport gate lives
+ * in `callTool`, so this stays trivially unit-testable.
+ */
+function isMcpSessionLostError(error: unknown): boolean {
+  if (error instanceof StreamableHTTPError) {
+    if (error.code === 404) {
+      return true;
+    }
+    return typeof error.message === "string" && SESSION_LOST_MESSAGE.test(error.message);
+  }
+  if (isMcpConfigRecord(error)) {
+    const { code, message } = error;
+    if (
+      code === ErrorCode.InternalError &&
+      typeof message === "string" &&
+      SESSION_LOST_MESSAGE.test(message)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
 async function listAllToolsBestEffort(params: {
   client: Client;
   timeoutMs: number;
@@ -380,13 +419,15 @@ function summarizeServerCapabilities(capabilities: ServerCapabilities | undefine
 // Safety net for hung MCP servers, not a tuning parameter.
 const DISPOSE_TIMEOUT_MS = 5_000;
 
-async function disposeSession(session: BundleMcpSession) {
+async function disposeSession(session: BundleMcpSession, options?: { terminateRemote?: boolean }) {
   session.detachStderr?.();
   let timer: ReturnType<typeof setTimeout> | undefined;
   let timedOut = false;
   await Promise.race([
     (async () => {
-      if (session.transportType === "streamable-http") {
+      // Skip the (guaranteed-404) DELETE round-trip when the remote session is
+      // already known to be gone — see the reconnect path.
+      if (session.transportType === "streamable-http" && options?.terminateRemote !== false) {
         await (session.transport as StreamableHTTPClientTransport)
           .terminateSession()
           .catch(() => {});
@@ -507,6 +548,9 @@ export function createSessionMcpRuntime(params: {
   let catalogInvalidationGeneration = 0;
   const sessions = new Map<string, BundleMcpSession>();
   const serverBackoff = new Map<string, McpServerBackoffState>();
+  // Dedupes concurrent reconnects per server so two tool calls that fail on the
+  // same lost session don't double-dispose or orphan a freshly opened client.
+  const reconnectInFlight = new Map<string, Promise<BundleMcpSession>>();
   const recordServerToolFailure = (serverName: string, nowMs: number) => {
     const previous = serverBackoff.get(serverName);
     const failures = (previous?.failures ?? 0) + 1;
@@ -541,6 +585,37 @@ export function createSessionMcpRuntime(params: {
       throw createDisposedError(params.sessionId);
     }
   };
+
+  // Builds an MCP client with the shared bundle config (schema validator +
+  // tools/list-changed invalidation). Used both for the initial catalog connect
+  // and for streamable-http session reconnects, so a reconnected client behaves
+  // identically to the one the catalog was built from.
+  const createServerClient = (serverName: string): Client =>
+    new Client(
+      {
+        name: "openclaw-bundle-mcp",
+        version: "0.0.0",
+      },
+      {
+        jsonSchemaValidator: createBundleMcpJsonSchemaValidator(),
+        listChanged: {
+          tools: {
+            autoRefresh: false,
+            debounceMs: 0,
+            onChanged: (error) => {
+              if (error) {
+                logWarn(
+                  `bundle-mcp: failed to refresh changed tool list for server "${serverName}": ${redactErrorUrls(error)}`,
+                );
+              }
+              catalogInvalidationGeneration += 1;
+              catalog = null;
+              catalogInFlight = undefined;
+            },
+          },
+        },
+      },
+    );
 
   const getCatalog = async (): Promise<McpToolCatalog> => {
     failIfDisposed();
@@ -584,31 +659,7 @@ export function createSessionMcpRuntime(params: {
           const reusedSession = Boolean(session);
           let connected = Boolean(session);
           if (!session) {
-            const client = new Client(
-              {
-                name: "openclaw-bundle-mcp",
-                version: "0.0.0",
-              },
-              {
-                jsonSchemaValidator: createBundleMcpJsonSchemaValidator(),
-                listChanged: {
-                  tools: {
-                    autoRefresh: false,
-                    debounceMs: 0,
-                    onChanged: (error) => {
-                      if (error) {
-                        logWarn(
-                          `bundle-mcp: failed to refresh changed tool list for server "${serverName}": ${redactErrorUrls(error)}`,
-                        );
-                      }
-                      catalogInvalidationGeneration += 1;
-                      catalog = null;
-                      catalogInFlight = undefined;
-                    },
-                  },
-                },
-              },
-            );
+            const client = createServerClient(serverName);
             session = {
               serverName,
               client,
@@ -744,6 +795,67 @@ export function createSessionMcpRuntime(params: {
     }
   };
 
+  // Re-handshakes a streamable-http server after it dropped our session. Reuses
+  // the cached catalog (no tools/list) so the model's tool payload — and thus
+  // the prompt prefix — stays byte-identical across a reconnect.
+  const reconnectSession = (
+    serverName: string,
+    deadSession: BundleMcpSession,
+  ): Promise<BundleMcpSession> => {
+    const existing = reconnectInFlight.get(serverName);
+    if (existing) {
+      return existing;
+    }
+    const promise = (async () => {
+      failIfDisposed();
+      if (sessions.get(serverName) === deadSession) {
+        sessions.delete(serverName);
+        // Remote session is already gone; don't pay for the 404 DELETE.
+        await disposeSession(deadSession, { terminateRemote: false });
+      } else {
+        const current = sessions.get(serverName);
+        if (current) {
+          // Someone already reconnected this server; reuse their session.
+          return current;
+        }
+      }
+      failIfDisposed();
+      const resolved = resolveMcpTransport(serverName, loaded.mcpServers[serverName]);
+      if (!resolved) {
+        throw new Error(`bundle-mcp server "${serverName}" is no longer resolvable`);
+      }
+      const client = createServerClient(serverName);
+      const session: BundleMcpSession = {
+        serverName,
+        client,
+        transport: resolved.transport,
+        transportType: resolved.transportType,
+        requestTimeoutMs: resolved.requestTimeoutMs,
+        supportsParallelToolCalls: resolved.supportsParallelToolCalls,
+        detachStderr: resolved.detachStderr,
+      };
+      try {
+        await connectWithTimeout(client, resolved.transport, resolved.connectionTimeoutMs);
+        failIfDisposed();
+      } catch (error) {
+        // Never leak a half-open client (connect failed or disposed mid-reconnect).
+        await disposeSession(session);
+        throw error;
+      }
+      sessions.set(serverName, session);
+      logWarn(`bundle-mcp: reconnected MCP session for "${serverName}" after lost session.`);
+      return session;
+    })();
+    const cleanup = () => {
+      if (reconnectInFlight.get(serverName) === promise) {
+        reconnectInFlight.delete(serverName);
+      }
+    };
+    promise.then(cleanup, cleanup);
+    reconnectInFlight.set(serverName, promise);
+    return promise;
+  };
+
   return {
     sessionId: params.sessionId,
     sessionKey: params.sessionKey,
@@ -783,18 +895,27 @@ export function createSessionMcpRuntime(params: {
       if (!session) {
         throw new Error(`bundle-mcp server "${serverName}" is not connected`);
       }
-      return await runGuardedServerRequest(
-        serverName,
-        async () =>
-          (await session.client.callTool(
-            {
-              name: toolName,
-              arguments: isMcpConfigRecord(input) ? input : {},
-            },
-            undefined,
-            { timeout: session.requestTimeoutMs },
-          )) as CallToolResult,
-      );
+      const args = isMcpConfigRecord(input) ? input : {};
+      return await runGuardedServerRequest(serverName, async () => {
+        try {
+          return (await session.client.callTool({ name: toolName, arguments: args }, undefined, {
+            timeout: session.requestTimeoutMs,
+          })) as CallToolResult;
+        } catch (error) {
+          if (session.transportType !== "streamable-http" || !isMcpSessionLostError(error)) {
+            throw error;
+          }
+          // The remote dropped our streamable-http session (e.g. server
+          // restart). Re-handshake once and retry on the fresh session. No
+          // recursion: at most one reconnect + one retry per call, so a
+          // flapping server can't loop.
+          const fresh = await reconnectSession(serverName, session);
+          failIfDisposed();
+          return (await fresh.client.callTool({ name: toolName, arguments: args }, undefined, {
+            timeout: fresh.requestTimeoutMs,
+          })) as CallToolResult;
+        }
+      });
     },
     async listResources(serverName) {
       failIfDisposed();
@@ -1151,6 +1272,7 @@ export const testing = {
   },
   setBundleMcpCatalogListTimeoutMsForTest,
   resolveSessionMcpRuntimeIdleTtlMs,
+  isMcpSessionLostError,
 };
 export { testing as __testing };
 


### PR DESCRIPTION
## Summary

- **Problem:** When a remote streamable-HTTP MCP server restarts, it drops the in-memory session it handed us. OpenClaw keeps using the stale session id, so every subsequent `callTool` fails — HTTP `404` (the MCP-spec session-terminated signal) or a `-32603 "Session not found"` body — until the whole agent session is reset. In practice this silently breaks an agent's MCP tools mid-conversation whenever the remote bounces.
- **Fix:** `callTool` now detects the lost-session signal, re-handshakes the server once on a fresh client, and retries the call on the new session.
- **Outcome:** MCP tools self-heal after a remote restart instead of failing every call until the session is reset.
- **Out of scope:** Only `callTool` is auto-healed (the hot path); `listResources` / `readResource` / `listPrompts` / `getPrompt` are unchanged (a subsequent `callTool` re-establishes the session anyway). Reconnect is gated to the `streamable-http` transport — stdio/SSE do not have this remote-session-drop failure mode.
- **Reviewer focus:** the `callTool` retry placement inside `runGuardedServerRequest` (a healed reconnect clears the backoff; a real failure still records one), and the loop/dedupe/leak guarantees in `reconnectSession`.

## Linked context

No existing issue — confirmed via issue/PR search (`MCP session not found`, `streamable session reconnect`); happy to open one if preferred.

Maintainer/owner requested: no — community contribution.

## Real behavior proof (required for external PRs)

- **Behavior addressed:** a self-hosted streamable-HTTP MCP server that periodically restarts; afterward every tool call against it returned `-32603 "Session not found"` until the agent session was reset.
- **Real environment tested:** a self-hosted production OpenClaw gateway (Docker), running the functionally identical fix.
- **Exact steps:** deployed the patched runtime; confirmed the gateway came back healthy; exercised the MCP-backed scheduled job that reads from the remote MCP server and then delivers the result.
- **Evidence after fix:** the scheduled run completed with `status: ok` and `delivered: true` and a payload fully sourced from live MCP reads — i.e. MCP reads succeed end-to-end post-fix (captured from the gateway's cron run-history).
- **Observed result after fix:** MCP-backed runs succeed instead of failing on a stale session.
- **What was not tested live:** forcing an actual mid-session remote restart in production to watch the reconnect+retry fire. That specific path is covered by the new deterministic tests (the mocked transport drops the session, and the tests assert exactly one reconnect + retry, dedupe of concurrent reconnects, no retry storm, and no client leak).
- **Proof limitations / constraints:** my checkout was behind `main`, so the deployed build carries the identical fix on the pre-rename file (`pi-bundle-mcp-runtime.ts`); this PR ports it onto the current `agent-bundle-mcp-runtime.ts`. The host is Docker-only and could not install the v2026.6.2 toolchain to run the full gate locally without risking the production box, so `pnpm tsgo` / `pnpm test` / `pnpm build` are left to CI on this branch.

## Tests and validation

- **Commands run:** `oxfmt --check` (clean on both changed files); the equivalent reconnect suite (same test logic, pre-rename module) ran green on the deployed build — 13 reconnect cases plus the existing 6-case runtime suite, with tsgo / oxfmt / oxlint / build all clean. The SDK contracts this relies on (`ErrorCode.InternalError === -32603`, `StreamableHTTPError` constructor + `.code`) were verified against the version-matched SDK `1.29.0`.
- **Regression coverage added:** `src/agents/agent-bundle-mcp-runtime.reconnect.test.ts` — the `isMcpSessionLostError` detector (404, leaked `Session not found` body, HTTP-200 `McpError`-shaped `-32603`, and negatives) plus the reconnect / retry / catalog-stability / no-loop / non-streamable-gate / connect-failure / concurrent-dedupe / mid-reconnect-disposal paths.
- **What failed before:** every `callTool` against the server after the remote dropped its session.
- **Full tsgo/test/build:** deferred to CI for the reasons under proof limitations.

## Risk checklist

- **User-visible behavior change?** Yes — MCP tool calls recover after a remote restart instead of failing until session reset.
- **Config / environment / migration change?** No.
- **Security / auth / secrets / network / tool-execution change?** Reconnect re-establishes the MCP transport from the same already-resolved server config; no new auth/secret handling. It performs at most one extra handshake + one retry per failed call.
- **Highest-risk area:** an unbounded reconnect loop, or a leaked half-open client.
- **Mitigation:** at most one reconnect + one retry per call (the retry is not re-wrapped, so a flapping server cannot loop); a per-server in-flight map dedupes concurrent reconnects; the reconnect path disposes the fresh client on connect failure or mid-reconnect disposal. Each of these has a dedicated test.

## Current review state

Next action: CI run + maintainer review.
