### PR TITLE
Support compat reasoning levels for thinking xhigh

### DIFF
--- a/packages/ai/src/model-utils.ts
+++ b/packages/ai/src/model-utils.ts
@@ -98,7 +98,10 @@ function supportsCompatExtendedThinkingLevel<TApi extends Api>(
   const mapped = normalizeReasoningEffort(mappedValue);
 
   if (level === "max") {
-    return hasCompatMapping && mapped === "xhigh" && supported.has("xhigh");
+    if (hasCompatMapping) {
+      return supported.size > 0 && Boolean(mapped) && supported.has(mapped);
+    }
+    return supported.has(level);
   }
   if (hasCompatMapping && !mapped) {
     return false;
@@ -116,6 +119,10 @@ export function getSupportedThinkingLevels<TApi extends Api>(
   const mandatoryAdaptiveContract =
     model.api === "anthropic-messages" && requiresClaudeMandatoryAdaptiveThinking(model);
   if (!model.reasoning && !mandatoryAdaptiveContract) {
+    return ["off"];
+  }
+  const compat = getCompatReasoningConfig(model);
+  if (compat?.supportsReasoningEffort === false) {
     return ["off"];
   }
   const thinkingLevelMap = resolveThinkingLevelMap(model);

--- a/packages/ai/src/model-utils.ts
+++ b/packages/ai/src/model-utils.ts
@@ -4,14 +4,7 @@ import {
   requiresClaudeMandatoryAdaptiveThinking,
 } from "@openclaw/llm-core";
 import { normalizeOpenAIReasoningEffort } from "./providers/openai-reasoning-effort.js";
-import type {
-  Api,
-  Model,
-  ModelThinkingLevel,
-  OpenAICompletionsCompat,
-  OpenAIResponsesCompat,
-  Usage,
-} from "./types.js";
+import type { Api, Model, ModelThinkingLevel, Usage } from "./types.js";
 
 /** Calculates and stores model cost fields from token usage and per-million pricing. */
 export function calculateCost<TApi extends Api>(model: Model<TApi>, usage: Usage): Usage["cost"] {
@@ -52,13 +45,23 @@ function resolveThinkingLevelMap<TApi extends Api>(model: Model<TApi>) {
     : model.thinkingLevelMap;
 }
 
+type OpenAIReasoningCompat = {
+  supportsReasoningEffort?: boolean;
+  supportedReasoningEfforts?: string[];
+  reasoningEffortMap?: Record<string, string>;
+};
+
 function getCompatReasoningConfig<TApi extends Api>(
   model: Model<TApi>,
-): OpenAICompletionsCompat | OpenAIResponsesCompat | undefined {
+): OpenAIReasoningCompat | undefined {
   if (model.api !== "openai-completions" && model.api !== "openai-responses") {
     return undefined;
   }
-  return model.compat as OpenAICompletionsCompat | OpenAIResponsesCompat | undefined;
+  const compat = model.compat;
+  if (!compat || typeof compat !== "object" || !("supportsReasoningEffort" in compat)) {
+    return undefined;
+  }
+  return compat;
 }
 
 function normalizeReasoningEffort(value: unknown): string {
@@ -81,8 +84,7 @@ function supportsCompatExtendedThinkingLevel<TApi extends Api>(
       .filter((effort) => effort.length > 0),
   );
   const compatEffortMap = compat?.reasoningEffortMap;
-  const hasCompatMapping =
-    compatEffortMap !== undefined && Object.prototype.hasOwnProperty.call(compatEffortMap, level);
+  const hasCompatMapping = compatEffortMap !== undefined && Object.hasOwn(compatEffortMap, level);
   const mappedValue = hasCompatMapping ? compatEffortMap[level] : thinkingLevelMapValue;
   if (mappedValue === null) {
     return false;

--- a/packages/ai/src/model-utils.ts
+++ b/packages/ai/src/model-utils.ts
@@ -58,10 +58,16 @@ function getCompatReasoningConfig<TApi extends Api>(
     return undefined;
   }
   const compat = model.compat;
-  if (!compat || typeof compat !== "object" || !("supportsReasoningEffort" in compat)) {
+  if (!compat || typeof compat !== "object") {
     return undefined;
   }
-  return compat;
+  return {
+    supportsReasoningEffort:
+      "supportsReasoningEffort" in compat ? compat.supportsReasoningEffort : undefined,
+    supportedReasoningEfforts:
+      "supportedReasoningEfforts" in compat ? compat.supportedReasoningEfforts : undefined,
+    reasoningEffortMap: "reasoningEffortMap" in compat ? compat.reasoningEffortMap : undefined,
+  };
 }
 
 function normalizeReasoningEffort(value: unknown): string {

--- a/packages/ai/src/model-utils.ts
+++ b/packages/ai/src/model-utils.ts
@@ -3,7 +3,15 @@ import {
   resolveClaudeNativeThinkingLevelMap,
   requiresClaudeMandatoryAdaptiveThinking,
 } from "@openclaw/llm-core";
-import type { Api, Model, ModelThinkingLevel, Usage } from "./types.js";
+import { normalizeOpenAIReasoningEffort } from "./providers/openai-reasoning-effort.js";
+import type {
+  Api,
+  Model,
+  ModelThinkingLevel,
+  OpenAICompletionsCompat,
+  OpenAIResponsesCompat,
+  Usage,
+} from "./types.js";
 
 /** Calculates and stores model cost fields from token usage and per-million pricing. */
 export function calculateCost<TApi extends Api>(model: Model<TApi>, usage: Usage): Usage["cost"] {
@@ -44,6 +52,55 @@ function resolveThinkingLevelMap<TApi extends Api>(model: Model<TApi>) {
     : model.thinkingLevelMap;
 }
 
+function getCompatReasoningConfig<TApi extends Api>(
+  model: Model<TApi>,
+): OpenAICompletionsCompat | OpenAIResponsesCompat | undefined {
+  if (model.api !== "openai-completions" && model.api !== "openai-responses") {
+    return undefined;
+  }
+  return model.compat as OpenAICompletionsCompat | OpenAIResponsesCompat | undefined;
+}
+
+function normalizeReasoningEffort(value: unknown): string {
+  return typeof value === "string" ? normalizeOpenAIReasoningEffort(value) : "";
+}
+
+function supportsCompatExtendedThinkingLevel<TApi extends Api>(
+  model: Model<TApi>,
+  level: "xhigh" | "max",
+  thinkingLevelMapValue: string | null | undefined,
+): boolean {
+  const compat = getCompatReasoningConfig(model);
+  if (compat?.supportsReasoningEffort === false) {
+    return false;
+  }
+
+  const supported = new Set(
+    (compat?.supportedReasoningEfforts ?? [])
+      .map(normalizeReasoningEffort)
+      .filter((effort) => effort.length > 0),
+  );
+  const compatEffortMap = compat?.reasoningEffortMap;
+  const hasCompatMapping =
+    compatEffortMap !== undefined && Object.prototype.hasOwnProperty.call(compatEffortMap, level);
+  const mappedValue = hasCompatMapping ? compatEffortMap[level] : thinkingLevelMapValue;
+  if (mappedValue === null) {
+    return false;
+  }
+  const mapped = normalizeReasoningEffort(mappedValue);
+
+  if (level === "max") {
+    return hasCompatMapping && mapped === "xhigh" && supported.has("xhigh");
+  }
+  if (hasCompatMapping && !mapped) {
+    return false;
+  }
+  if (mapped) {
+    return supported.size === 0 ? !hasCompatMapping : supported.has(mapped);
+  }
+  return supported.has(level);
+}
+
 /** Returns thinking levels exposed by a reasoning-capable model. */
 export function getSupportedThinkingLevels<TApi extends Api>(
   model: Model<TApi>,
@@ -61,7 +118,14 @@ export function getSupportedThinkingLevels<TApi extends Api>(
       return false;
     }
     if (level === "xhigh" || level === "max") {
-      return mapped !== undefined;
+      const compat = getCompatReasoningConfig(model);
+      if (compat === undefined) {
+        return mapped !== undefined;
+      }
+      if (compat.supportsReasoningEffort === false) {
+        return false;
+      }
+      return supportsCompatExtendedThinkingLevel(model, level, mapped);
     }
     return true;
   });

--- a/packages/ai/src/model-utils.ts
+++ b/packages/ai/src/model-utils.ts
@@ -121,8 +121,8 @@ export function getSupportedThinkingLevels<TApi extends Api>(
   if (!model.reasoning && !mandatoryAdaptiveContract) {
     return ["off"];
   }
-  const compat = getCompatReasoningConfig(model);
-  if (compat?.supportsReasoningEffort === false) {
+  const reasoningCompat = getCompatReasoningConfig(model);
+  if (reasoningCompat?.supportsReasoningEffort === false) {
     return ["off"];
   }
   const thinkingLevelMap = resolveThinkingLevelMap(model);

--- a/packages/ai/src/model-utils.ts
+++ b/packages/ai/src/model-utils.ts
@@ -47,7 +47,7 @@ function resolveThinkingLevelMap<TApi extends Api>(model: Model<TApi>) {
 
 type OpenAIReasoningCompat = {
   supportsReasoningEffort?: boolean;
-  supportedReasoningEfforts?: string[];
+  supportedReasoningEfforts?: readonly string[] | null;
   reasoningEffortMap?: Record<string, string>;
 };
 

--- a/packages/ai/src/providers/openai-completions.test.ts
+++ b/packages/ai/src/providers/openai-completions.test.ts
@@ -320,6 +320,47 @@ describe("OpenAI-compatible completions params", () => {
     expect(mockOpenAIOptionsRef.payloads[0]).not.toHaveProperty("reasoning_effort");
   });
 
+  it("preserves a supported mapped max effort through simple completions", async () => {
+    mockChunksRef.chunks = [makeTextChunk("ok"), makeFinishChunk("stop")];
+    const compatibleModel = {
+      ...reasoningModel,
+      provider: "custom-openai-compatible",
+      baseUrl: "https://third-party.test/v1",
+      compat: {
+        supportsReasoningEffort: true,
+        supportedReasoningEfforts: ["provider-low", "provider-max"],
+        reasoningEffortMap: { low: "provider-low", max: "provider-max" },
+      },
+    } satisfies Model<"openai-completions">;
+
+    await streamSimpleOpenAICompletions(compatibleModel, context, {
+      apiKey: "sk-test",
+      reasoning: "max",
+    }).result();
+
+    expect(mockOpenAIOptionsRef.payloads[0]).toMatchObject({ reasoning_effort: "provider-max" });
+  });
+
+  it("falls back unsupported simple max to xhigh", async () => {
+    mockChunksRef.chunks = [makeTextChunk("ok"), makeFinishChunk("stop")];
+    const compatibleModel = {
+      ...reasoningModel,
+      provider: "custom-openai-compatible",
+      baseUrl: "https://third-party.test/v1",
+      compat: {
+        supportsReasoningEffort: true,
+        supportedReasoningEfforts: ["high", "xhigh"],
+      },
+    } satisfies Model<"openai-completions">;
+
+    await streamSimpleOpenAICompletions(compatibleModel, context, {
+      apiKey: "sk-test",
+      reasoning: "max",
+    }).result();
+
+    expect(mockOpenAIOptionsRef.payloads[0]).toMatchObject({ reasoning_effort: "xhigh" });
+  });
+
   it.each([
     { name: "model compat mapping", reasoningEffort: "low", expected: "high" },
     { name: "thinkingLevelMap fallback", reasoningEffort: "medium", expected: "xhigh" },

--- a/packages/ai/src/providers/openai-completions.test.ts
+++ b/packages/ai/src/providers/openai-completions.test.ts
@@ -284,7 +284,7 @@ describe("OpenAI-compatible completions params", () => {
     expect(mockOpenAIOptionsRef.payloads[0]).toMatchObject({ reasoning_effort: "high" });
   });
 
-  it("omits reasoning_effort for an explicitly disabled thinking level at the provider boundary", async () => {
+  it("clamps a null-mapped thinking level at the provider boundary", async () => {
     mockChunksRef.chunks = [makeTextChunk("ok"), makeFinishChunk("stop")];
     const compatibleModel = {
       ...reasoningModel,
@@ -299,10 +299,10 @@ describe("OpenAI-compatible completions params", () => {
       reasoningEffort: "high",
     }).result();
 
-    expect(mockOpenAIOptionsRef.payloads[0]).not.toHaveProperty("reasoning_effort");
+    expect(mockOpenAIOptionsRef.payloads[0]).toMatchObject({ reasoning_effort: "medium" });
   });
 
-  it("preserves an explicit thinking-level null opt-out through simple completions", async () => {
+  it("clamps a null-mapped thinking level through simple completions", async () => {
     mockChunksRef.chunks = [makeTextChunk("ok"), makeFinishChunk("stop")];
     const compatibleModel = {
       ...reasoningModel,
@@ -317,7 +317,7 @@ describe("OpenAI-compatible completions params", () => {
       reasoning: "high",
     }).result();
 
-    expect(mockOpenAIOptionsRef.payloads[0]).not.toHaveProperty("reasoning_effort");
+    expect(mockOpenAIOptionsRef.payloads[0]).toMatchObject({ reasoning_effort: "medium" });
   });
 
   it("preserves Grok 4.5 off-to-low clamping through simple completions", async () => {

--- a/packages/ai/src/providers/openai-completions.test.ts
+++ b/packages/ai/src/providers/openai-completions.test.ts
@@ -320,6 +320,33 @@ describe("OpenAI-compatible completions params", () => {
     expect(mockOpenAIOptionsRef.payloads[0]).not.toHaveProperty("reasoning_effort");
   });
 
+  it("preserves Grok 4.5 off-to-low clamping through simple completions", async () => {
+    mockChunksRef.chunks = [makeTextChunk("ok"), makeFinishChunk("stop")];
+    const compatibleModel = {
+      ...reasoningModel,
+      provider: "custom-openai-compatible",
+      baseUrl: "https://third-party.test/v1",
+      compat: {
+        supportsReasoningEffort: true,
+        supportedReasoningEfforts: ["low", "medium", "high"],
+      },
+      thinkingLevelMap: {
+        off: null,
+        minimal: "low",
+        low: "low",
+        medium: "medium",
+        high: "high",
+      },
+    } satisfies Model<"openai-completions">;
+
+    await streamSimpleOpenAICompletions(compatibleModel, context, {
+      apiKey: "sk-test",
+      reasoning: "off",
+    }).result();
+
+    expect(mockOpenAIOptionsRef.payloads[0]).toMatchObject({ reasoning_effort: "low" });
+  });
+
   it("preserves a supported mapped max effort through simple completions", async () => {
     mockChunksRef.chunks = [makeTextChunk("ok"), makeFinishChunk("stop")];
     const compatibleModel = {

--- a/packages/ai/src/providers/openai-completions.test.ts
+++ b/packages/ai/src/providers/openai-completions.test.ts
@@ -263,6 +263,63 @@ describe("OpenAI-compatible completions params", () => {
     expect(mockOpenAIOptionsRef.payloads[0]).not.toHaveProperty("reasoning_effort");
   });
 
+  it("falls back from an unsupported mapped xhigh effort at the provider boundary", async () => {
+    mockChunksRef.chunks = [makeTextChunk("ok"), makeFinishChunk("stop")];
+    const compatibleModel = {
+      ...reasoningModel,
+      provider: "custom-openai-compatible",
+      baseUrl: "https://third-party.test/v1",
+      compat: {
+        supportsReasoningEffort: true,
+        supportedReasoningEfforts: ["low", "medium", "high"],
+        reasoningEffortMap: { high: "xhigh" },
+      },
+    } satisfies Model<"openai-completions">;
+
+    await streamOpenAICompletions(compatibleModel, context, {
+      apiKey: "sk-test",
+      reasoningEffort: "high",
+    }).result();
+
+    expect(mockOpenAIOptionsRef.payloads[0]).toMatchObject({ reasoning_effort: "high" });
+  });
+
+  it("omits reasoning_effort for an explicitly disabled thinking level at the provider boundary", async () => {
+    mockChunksRef.chunks = [makeTextChunk("ok"), makeFinishChunk("stop")];
+    const compatibleModel = {
+      ...reasoningModel,
+      provider: "custom-openai-compatible",
+      baseUrl: "https://third-party.test/v1",
+      compat: { supportsReasoningEffort: true },
+      thinkingLevelMap: { high: null },
+    } satisfies Model<"openai-completions">;
+
+    await streamOpenAICompletions(compatibleModel, context, {
+      apiKey: "sk-test",
+      reasoningEffort: "high",
+    }).result();
+
+    expect(mockOpenAIOptionsRef.payloads[0]).not.toHaveProperty("reasoning_effort");
+  });
+
+  it("preserves an explicit thinking-level null opt-out through simple completions", async () => {
+    mockChunksRef.chunks = [makeTextChunk("ok"), makeFinishChunk("stop")];
+    const compatibleModel = {
+      ...reasoningModel,
+      provider: "custom-openai-compatible",
+      baseUrl: "https://third-party.test/v1",
+      compat: { supportsReasoningEffort: true },
+      thinkingLevelMap: { high: null },
+    } satisfies Model<"openai-completions">;
+
+    await streamSimpleOpenAICompletions(compatibleModel, context, {
+      apiKey: "sk-test",
+      reasoning: "high",
+    }).result();
+
+    expect(mockOpenAIOptionsRef.payloads[0]).not.toHaveProperty("reasoning_effort");
+  });
+
   it.each([
     { name: "model compat mapping", reasoningEffort: "low", expected: "high" },
     { name: "thinkingLevelMap fallback", reasoningEffort: "medium", expected: "xhigh" },

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -698,16 +698,19 @@ export const streamSimpleOpenAICompletions: StreamFunction<
   }
 
   const base = buildBaseOptions(model, options, apiKey);
+  const requestedReasoning = options?.reasoning;
   const explicitlyDisabledByThinkingLevel =
-    options?.reasoning !== undefined &&
+    requestedReasoning !== undefined &&
     model.thinkingLevelMap !== undefined &&
-    Object.hasOwn(model.thinkingLevelMap, options.reasoning) &&
-    model.thinkingLevelMap[options.reasoning] === null;
+    Object.hasOwn(model.thinkingLevelMap, requestedReasoning) &&
+    model.thinkingLevelMap[requestedReasoning] === null;
   const clampedReasoning =
-    options?.reasoning && !explicitlyDisabledByThinkingLevel
-      ? clampThinkingLevel(model, options.reasoning)
-      : undefined;
-  const reasoningEffort = clampedReasoning === "off" ? undefined : clampedReasoning;
+    requestedReasoning !== undefined ? clampThinkingLevel(model, requestedReasoning) : undefined;
+  const shouldDisableReasoning =
+    explicitlyDisabledByThinkingLevel &&
+    (requestedReasoning !== "off" || clampedReasoning === "off");
+  const reasoningEffort =
+    shouldDisableReasoning || clampedReasoning === "off" ? undefined : clampedReasoning;
   const toolChoice = (options as OpenAICompletionsOptions | undefined)?.toolChoice;
 
   return streamOpenAICompletions(model, context, {

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -699,18 +699,9 @@ export const streamSimpleOpenAICompletions: StreamFunction<
 
   const base = buildBaseOptions(model, options, apiKey);
   const requestedReasoning = options?.reasoning;
-  const explicitlyDisabledByThinkingLevel =
-    requestedReasoning !== undefined &&
-    model.thinkingLevelMap !== undefined &&
-    Object.hasOwn(model.thinkingLevelMap, requestedReasoning) &&
-    model.thinkingLevelMap[requestedReasoning] === null;
   const clampedReasoning =
     requestedReasoning !== undefined ? clampThinkingLevel(model, requestedReasoning) : undefined;
-  const shouldDisableReasoning =
-    explicitlyDisabledByThinkingLevel &&
-    (requestedReasoning !== "off" || clampedReasoning === "off");
-  const reasoningEffort =
-    shouldDisableReasoning || clampedReasoning === "off" ? undefined : clampedReasoning;
+  const reasoningEffort = clampedReasoning === "off" ? undefined : clampedReasoning;
   const toolChoice = (options as OpenAICompletionsOptions | undefined)?.toolChoice;
 
   return streamOpenAICompletions(model, context, {
@@ -916,23 +907,30 @@ function buildParams(
     ...reasoningEffortMap,
   };
   const requestedReasoningEffort = options?.reasoningEffort;
-  const explicitlyDisabledByThinkingLevel =
+  const requestedCanonicalReasoning =
     requestedReasoningEffort !== undefined &&
-    thinkingLevelMap !== undefined &&
-    Object.hasOwn(thinkingLevelMap, requestedReasoningEffort) &&
-    thinkingLevelMap[requestedReasoningEffort] === null;
+    (requestedReasoningEffort === "minimal" ||
+      requestedReasoningEffort === "low" ||
+      requestedReasoningEffort === "medium" ||
+      requestedReasoningEffort === "high" ||
+      requestedReasoningEffort === "xhigh" ||
+      requestedReasoningEffort === "max")
+      ? requestedReasoningEffort
+      : undefined;
+  const clampedReasoning = requestedCanonicalReasoning
+    ? clampThinkingLevel(model, requestedCanonicalReasoning)
+    : undefined;
+  const effectiveReasoningEffort = clampedReasoning ?? requestedReasoningEffort;
   const reasoningEffort =
-    requestedReasoningEffort === undefined || explicitlyDisabledByThinkingLevel
+    effectiveReasoningEffort === undefined
       ? undefined
       : resolveOpenAIReasoningEffortForModel({
           model,
-          effort: requestedReasoningEffort,
+          effort: effectiveReasoningEffort,
           fallbackMap: reasoningEffortFallbackMap,
         });
   const requestedThinkingEnabled =
-    requestedReasoningEffort !== undefined &&
-    requestedReasoningEffort !== "none" &&
-    !explicitlyDisabledByThinkingLevel;
+    requestedReasoningEffort !== undefined && requestedReasoningEffort !== "none";
   const resolvedReasoningEnabled =
     requestedThinkingEnabled && reasoningEffort !== undefined && reasoningEffort !== "none";
   const offReasoningEffort = reasoningEffortMap.off ?? model.thinkingLevelMap?.off;

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -707,12 +707,7 @@ export const streamSimpleOpenAICompletions: StreamFunction<
     options?.reasoning && !explicitlyDisabledByThinkingLevel
       ? clampThinkingLevel(model, options.reasoning)
       : undefined;
-  const reasoningEffort =
-    clampedReasoning === "off"
-      ? undefined
-      : clampedReasoning === "max"
-        ? "xhigh"
-        : clampedReasoning;
+  const reasoningEffort = clampedReasoning === "off" ? undefined : clampedReasoning;
   const toolChoice = (options as OpenAICompletionsOptions | undefined)?.toolChoice;
 
   return streamOpenAICompletions(model, context, {

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -72,6 +72,7 @@ import {
   finalizeOpenAICompletionsToolCalls,
 } from "./openai-completions-tool-calls.js";
 import { clampOpenAIPromptCacheKey } from "./openai-prompt-cache.js";
+import { resolveOpenAIReasoningEffortForModel } from "./openai-reasoning-effort.js";
 import {
   resolveOpenAICompletionsResponseFormat,
   shouldOmitOllamaCompatResponseFormat,
@@ -697,9 +698,15 @@ export const streamSimpleOpenAICompletions: StreamFunction<
   }
 
   const base = buildBaseOptions(model, options, apiKey);
-  const clampedReasoning = options?.reasoning
-    ? clampThinkingLevel(model, options.reasoning)
-    : undefined;
+  const explicitlyDisabledByThinkingLevel =
+    options?.reasoning !== undefined &&
+    model.thinkingLevelMap !== undefined &&
+    Object.hasOwn(model.thinkingLevelMap, options.reasoning) &&
+    model.thinkingLevelMap[options.reasoning] === null;
+  const clampedReasoning =
+    options?.reasoning && !explicitlyDisabledByThinkingLevel
+      ? clampThinkingLevel(model, options.reasoning)
+      : undefined;
   const reasoningEffort =
     clampedReasoning === "off"
       ? undefined
@@ -902,35 +909,56 @@ function buildParams(
   const thinkingLevelMap = model.thinkingLevelMap as
     | Partial<Record<NonNullable<OpenAICompletionsOptions["reasoningEffort"]>, string | null>>
     | undefined;
+  const reasoningEffortFallbackMap: Record<string, string> = {
+    ...Object.fromEntries(
+      Object.entries(thinkingLevelMap ?? {}).filter(
+        (entry): entry is [string, string] => typeof entry[1] === "string",
+      ),
+    ),
+    ...reasoningEffortMap,
+  };
+  const requestedReasoningEffort = options?.reasoningEffort;
+  const explicitlyDisabledByThinkingLevel =
+    requestedReasoningEffort !== undefined &&
+    thinkingLevelMap !== undefined &&
+    Object.hasOwn(thinkingLevelMap, requestedReasoningEffort) &&
+    thinkingLevelMap[requestedReasoningEffort] === null;
   const reasoningEffort =
-    options?.reasoningEffort === undefined
+    requestedReasoningEffort === undefined || explicitlyDisabledByThinkingLevel
       ? undefined
-      : (reasoningEffortMap[options.reasoningEffort] ??
-        thinkingLevelMap?.[options.reasoningEffort] ??
-        options.reasoningEffort);
-  const reasoningEnabled = reasoningEffort !== undefined && reasoningEffort !== "none";
+      : resolveOpenAIReasoningEffortForModel({
+          model,
+          effort: requestedReasoningEffort,
+          fallbackMap: reasoningEffortFallbackMap,
+        });
+  const requestedThinkingEnabled =
+    requestedReasoningEffort !== undefined &&
+    requestedReasoningEffort !== "none" &&
+    !explicitlyDisabledByThinkingLevel;
+  const resolvedReasoningEnabled =
+    requestedThinkingEnabled && reasoningEffort !== undefined && reasoningEffort !== "none";
   const offReasoningEffort = reasoningEffortMap.off ?? model.thinkingLevelMap?.off;
 
   if (compat.thinkingFormat === "zai" && model.reasoning) {
-    params.thinking = reasoningEnabled
+    params.thinking = requestedThinkingEnabled
       ? { type: "enabled", clear_thinking: false }
       : { type: "disabled" };
   } else if (compat.thinkingFormat === "qwen" && model.reasoning) {
-    params.enable_thinking = reasoningEnabled;
+    params.enable_thinking = requestedThinkingEnabled;
   } else if (compat.thinkingFormat === "qwen-chat-template" && model.reasoning) {
     params.chat_template_kwargs = {
-      enable_thinking: reasoningEnabled,
+      enable_thinking: requestedThinkingEnabled,
       preserve_thinking: true,
     };
   } else if (compat.thinkingFormat === "deepseek" && model.reasoning) {
-    params.thinking = { type: reasoningEnabled ? "enabled" : "disabled" };
-    if (reasoningEnabled && compat.supportsReasoningEffort) {
+    params.thinking = { type: requestedThinkingEnabled ? "enabled" : "disabled" };
+    if (resolvedReasoningEnabled && compat.supportsReasoningEffort) {
       params.reasoning_effort = reasoningEffort;
     }
   } else if (compat.thinkingFormat === "openrouter" && model.reasoning) {
     // OpenRouter normalizes reasoning across providers via a nested reasoning object.
     const openRouterParams = params as typeof params & { reasoning?: { effort?: string } };
-    if (reasoningEnabled) {
+    if (resolvedReasoningEnabled) {
       openRouterParams.reasoning = { effort: reasoningEffort };
     } else if (offReasoningEffort !== null) {
       openRouterParams.reasoning = { effort: offReasoningEffort ?? "none" };
@@ -940,11 +968,11 @@ function buildParams(
       reasoning?: { enabled: boolean };
       reasoning_effort?: string;
     };
-    togetherParams.reasoning = { enabled: reasoningEnabled };
-    if (reasoningEnabled && compat.supportsReasoningEffort) {
+    togetherParams.reasoning = { enabled: requestedThinkingEnabled };
+    if (resolvedReasoningEnabled && compat.supportsReasoningEffort) {
       togetherParams.reasoning_effort = reasoningEffort;
     }
-  } else if (reasoningEnabled && model.reasoning && compat.supportsReasoningEffort) {
+  } else if (resolvedReasoningEnabled && model.reasoning && compat.supportsReasoningEffort) {
     // OpenAI-style reasoning_effort
     params.reasoning_effort = reasoningEffort;
   } else if (model.reasoning && compat.supportsReasoningEffort) {

--- a/packages/ai/src/providers/openai-reasoning-effort.test.ts
+++ b/packages/ai/src/providers/openai-reasoning-effort.test.ts
@@ -101,6 +101,26 @@ describe("OpenAI reasoning effort support", () => {
     ).toBe("none");
   });
 
+  it("preserves map-only provider-native values mapped from canonical efforts", () => {
+    const model = {
+      provider: "example",
+      id: "custom-reasoning",
+      compat: {
+        reasoningEffortMap: {
+          high: "xhigh",
+        },
+      },
+    };
+
+    expect(
+      resolveOpenAIReasoningEffortForModel({
+        model,
+        effort: "high",
+        fallbackMap: model.compat.reasoningEffortMap,
+      }),
+    ).toBe("xhigh");
+  });
+
   it("preserves provider-native compat values mapped from canonical efforts", () => {
     const model = {
       provider: "example",
@@ -213,6 +233,25 @@ describe("OpenAI reasoning effort support", () => {
 
     expect(resolveOpenAISupportedReasoningEfforts(model)).toEqual([]);
     expect(resolveOpenAIReasoningEffortForModel({ model, effort: "high" })).toBeUndefined();
+  });
+
+  it("does not let map-only compat bypass disabled reasoning effort payloads", () => {
+    const model = {
+      provider: "xai",
+      id: "grok-4.20-0309-reasoning",
+      compat: {
+        supportsReasoningEffort: false,
+        reasoningEffortMap: { high: "xhigh" },
+      },
+    };
+
+    expect(
+      resolveOpenAIReasoningEffortForModel({
+        model,
+        effort: "high",
+        fallbackMap: model.compat.reasoningEffortMap,
+      }),
+    ).toBeUndefined();
   });
 
   it("passes disabled reasoning when xAI compat explicitly supports none", () => {

--- a/packages/ai/src/providers/openai-reasoning-effort.test.ts
+++ b/packages/ai/src/providers/openai-reasoning-effort.test.ts
@@ -121,6 +121,25 @@ describe("OpenAI reasoning effort support", () => {
     ).toBe("xhigh");
   });
 
+  it("falls back to the requested supported effort when a mapping is unsupported", () => {
+    const model = {
+      provider: "example",
+      id: "custom-reasoning",
+      compat: {
+        supportedReasoningEfforts: ["low", "medium", "high"],
+        reasoningEffortMap: { high: "xhigh" },
+      },
+    };
+
+    expect(
+      resolveOpenAIReasoningEffortForModel({
+        model,
+        effort: "high",
+        fallbackMap: model.compat.reasoningEffortMap,
+      }),
+    ).toBe("high");
+  });
+
   it("preserves provider-native compat values mapped from canonical efforts", () => {
     const model = {
       provider: "example",

--- a/packages/ai/src/providers/openai-reasoning-effort.ts
+++ b/packages/ai/src/providers/openai-reasoning-effort.ts
@@ -187,6 +187,24 @@ export function resolveOpenAIReasoningEffortForModel(params: {
   // Fallback maps emit provider-native payload labels; keep their case for exact compat lists.
   const normalized = mapped === undefined ? requested : mapped.trim();
   const supported = resolveOpenAISupportedReasoningEfforts(params.model);
+  const compat = params.model.compat;
+  const hasDisabledReasoningEffort =
+    compat !== null &&
+    typeof compat === "object" &&
+    (compat as { supportsReasoningEffort?: unknown }).supportsReasoningEffort === false;
+  const hasExplicitSupportedEfforts =
+    compat !== null &&
+    typeof compat === "object" &&
+    Array.isArray((compat as { supportedReasoningEfforts?: unknown }).supportedReasoningEfforts);
+  if (
+    mapped !== undefined &&
+    normalized.length > 0 &&
+    !hasDisabledReasoningEffort &&
+    !hasExplicitSupportedEfforts &&
+    !isDisabledReasoningEffort(normalized)
+  ) {
+    return normalized as OpenAIApiReasoningEffort;
+  }
   if (supported.includes(normalized as OpenAIApiReasoningEffort)) {
     return normalized as OpenAIApiReasoningEffort;
   }

--- a/packages/ai/src/providers/openai-reasoning-effort.ts
+++ b/packages/ai/src/providers/openai-reasoning-effort.ts
@@ -209,7 +209,7 @@ export function resolveOpenAIReasoningEffortForModel(params: {
   ) {
     return normalized as OpenAIApiReasoningEffort;
   }
-  if (supported.includes(normalized as OpenAIApiReasoningEffort)) {
+  if (supported.some((supportedEffort) => supportedEffort === normalized)) {
     return normalized as OpenAIApiReasoningEffort;
   }
   if (requested === "off" && supported.includes("none")) {

--- a/packages/ai/src/providers/openai-reasoning-effort.ts
+++ b/packages/ai/src/providers/openai-reasoning-effort.ts
@@ -103,6 +103,13 @@ function isDisabledReasoningEffort(effort: string): boolean {
   return effort === "none" || effort === "off";
 }
 
+function readCompatProperty(compat: unknown, key: string): unknown {
+  if (!compat || typeof compat !== "object" || !Object.hasOwn(compat, key)) {
+    return undefined;
+  }
+  return Reflect.get(compat, key);
+}
+
 /** Resolve the reasoning efforts accepted by a specific OpenAI-compatible model. */
 export function resolveOpenAISupportedReasoningEfforts(
   model: OpenAIReasoningModel,
@@ -189,13 +196,10 @@ export function resolveOpenAIReasoningEffortForModel(params: {
   const supported = resolveOpenAISupportedReasoningEfforts(params.model);
   const compat = params.model.compat;
   const hasDisabledReasoningEffort =
-    compat !== null &&
-    typeof compat === "object" &&
-    (compat as { supportsReasoningEffort?: unknown }).supportsReasoningEffort === false;
-  const hasExplicitSupportedEfforts =
-    compat !== null &&
-    typeof compat === "object" &&
-    Array.isArray((compat as { supportedReasoningEfforts?: unknown }).supportedReasoningEfforts);
+    readCompatProperty(compat, "supportsReasoningEffort") === false;
+  const hasExplicitSupportedEfforts = Array.isArray(
+    readCompatProperty(compat, "supportedReasoningEfforts"),
+  );
   if (
     mapped !== undefined &&
     normalized.length > 0 &&

--- a/packages/ai/src/providers/openai-reasoning-effort.ts
+++ b/packages/ai/src/providers/openai-reasoning-effort.ts
@@ -212,6 +212,10 @@ export function resolveOpenAIReasoningEffortForModel(params: {
   if (supported.some((supportedEffort) => supportedEffort === normalized)) {
     return normalized as OpenAIApiReasoningEffort;
   }
+  const requestedSupported = supported.find((supportedEffort) => supportedEffort === requested);
+  if (mapped !== undefined && requestedSupported !== undefined) {
+    return requestedSupported;
+  }
   if (requested === "off" && supported.includes("none")) {
     return "none";
   }

--- a/packages/ai/src/providers/openai-responses-shared.test.ts
+++ b/packages/ai/src/providers/openai-responses-shared.test.ts
@@ -375,6 +375,38 @@ describe("Responses reasoning effort", () => {
     expect(params.reasoning).toMatchObject({ effort: "high", summary: "auto" });
   });
 
+  it("falls back when a compat mapping is not listed as supported", () => {
+    const params = {} as ResponseCreateParamsStreaming;
+    const compatModel = {
+      ...nativeOpenAIModel,
+      compat: {
+        supportsReasoningEffort: true,
+        supportedReasoningEfforts: ["high"],
+        reasoningEffortMap: { xhigh: "provider-xhigh" },
+      },
+    } satisfies Model<"openai-responses">;
+
+    applyCommonResponsesParams(params, compatModel, { messages: [] }, { reasoningEffort: "xhigh" });
+
+    expect(params.reasoning).toMatchObject({ effort: "high", summary: "auto" });
+  });
+
+  it("preserves a supported provider-native max mapping", () => {
+    const params = {} as ResponseCreateParamsStreaming;
+    const compatModel = {
+      ...nativeOpenAIModel,
+      compat: {
+        supportsReasoningEffort: true,
+        supportedReasoningEfforts: ["provider-max"],
+        reasoningEffortMap: { max: "provider-max" },
+      },
+    } satisfies Model<"openai-responses">;
+
+    applyCommonResponsesParams(params, compatModel, { messages: [] }, { reasoningEffort: "max" });
+
+    expect(params.reasoning).toMatchObject({ effort: "provider-max", summary: "auto" });
+  });
+
   it("omits Responses reasoning when compat explicitly disables it", () => {
     const params = {} as ResponseCreateParamsStreaming;
     const compatModel = {

--- a/packages/ai/src/providers/openai-responses-shared.test.ts
+++ b/packages/ai/src/providers/openai-responses-shared.test.ts
@@ -375,6 +375,23 @@ describe("Responses reasoning effort", () => {
     expect(params.reasoning).toMatchObject({ effort: "high", summary: "auto" });
   });
 
+  it("preserves map-only canonical effort mappings in Responses payloads", () => {
+    const params = {} as ResponseCreateParamsStreaming;
+    const compatModel = {
+      ...nativeOpenAIModel,
+      provider: "custom-openai-compatible",
+      baseUrl: "https://proxy.example.com/v1",
+      compat: {
+        supportsReasoningEffort: true,
+        reasoningEffortMap: { high: "xhigh" },
+      },
+    } satisfies Model<"openai-responses">;
+
+    applyCommonResponsesParams(params, compatModel, { messages: [] }, { reasoningEffort: "high" });
+
+    expect(params.reasoning).toMatchObject({ effort: "xhigh", summary: "auto" });
+  });
+
   it("falls back when a compat mapping is not listed as supported", () => {
     const params = {} as ResponseCreateParamsStreaming;
     const compatModel = {

--- a/packages/ai/src/providers/openai-responses-shared.test.ts
+++ b/packages/ai/src/providers/openai-responses-shared.test.ts
@@ -370,12 +370,7 @@ describe("Responses reasoning effort", () => {
       },
     } satisfies Model<"openai-responses">;
 
-    applyCommonResponsesParams(
-      params,
-      compatModel,
-      { messages: [] },
-      { reasoningEffort: "xhigh" },
-    );
+    applyCommonResponsesParams(params, compatModel, { messages: [] }, { reasoningEffort: "xhigh" });
 
     expect(params.reasoning).toMatchObject({ effort: "high", summary: "auto" });
   });
@@ -387,12 +382,7 @@ describe("Responses reasoning effort", () => {
       compat: { supportsReasoningEffort: false },
     } satisfies Model<"openai-responses">;
 
-    applyCommonResponsesParams(
-      params,
-      compatModel,
-      { messages: [] },
-      { reasoningEffort: "high" },
-    );
+    applyCommonResponsesParams(params, compatModel, { messages: [] }, { reasoningEffort: "high" });
 
     expect(params).not.toHaveProperty("reasoning");
     expect(params).not.toHaveProperty("include");
@@ -410,12 +400,7 @@ describe("Responses reasoning effort", () => {
       },
     } satisfies Model<"openai-responses">;
 
-    applyCommonResponsesParams(
-      params,
-      compatModel,
-      { messages: [] },
-      { reasoningEffort: "xhigh" },
-    );
+    applyCommonResponsesParams(params, compatModel, { messages: [] }, { reasoningEffort: "xhigh" });
 
     expect(params).not.toHaveProperty("reasoning");
     expect(params).not.toHaveProperty("include");

--- a/packages/ai/src/providers/openai-responses-shared.test.ts
+++ b/packages/ai/src/providers/openai-responses-shared.test.ts
@@ -358,6 +358,68 @@ describe("Responses reasoning effort", () => {
 
     expect(resolveResponsesReasoningEffort(gpt55WithXHigh, "max")).toBe("xhigh");
   });
+
+  it("maps compat reasoning effort before serializing Responses payload", () => {
+    const params = {} as ResponseCreateParamsStreaming;
+    const compatModel = {
+      ...nativeOpenAIModel,
+      compat: {
+        supportsReasoningEffort: true,
+        supportedReasoningEfforts: ["low", "medium", "high"],
+        reasoningEffortMap: { xhigh: "high" },
+      },
+    } satisfies Model<"openai-responses">;
+
+    applyCommonResponsesParams(
+      params,
+      compatModel,
+      { messages: [] },
+      { reasoningEffort: "xhigh" },
+    );
+
+    expect(params.reasoning).toMatchObject({ effort: "high", summary: "auto" });
+  });
+
+  it("omits Responses reasoning when compat explicitly disables it", () => {
+    const params = {} as ResponseCreateParamsStreaming;
+    const compatModel = {
+      ...nativeOpenAIModel,
+      compat: { supportsReasoningEffort: false },
+    } satisfies Model<"openai-responses">;
+
+    applyCommonResponsesParams(
+      params,
+      compatModel,
+      { messages: [] },
+      { reasoningEffort: "high" },
+    );
+
+    expect(params).not.toHaveProperty("reasoning");
+    expect(params).not.toHaveProperty("include");
+  });
+
+  it("honors a thinkingLevelMap null opt-out over compat mapping", () => {
+    const params = {} as ResponseCreateParamsStreaming;
+    const compatModel = {
+      ...nativeOpenAIModel,
+      thinkingLevelMap: { xhigh: null },
+      compat: {
+        supportsReasoningEffort: true,
+        supportedReasoningEfforts: ["high"],
+        reasoningEffortMap: { xhigh: "high" },
+      },
+    } satisfies Model<"openai-responses">;
+
+    applyCommonResponsesParams(
+      params,
+      compatModel,
+      { messages: [] },
+      { reasoningEffort: "xhigh" },
+    );
+
+    expect(params).not.toHaveProperty("reasoning");
+    expect(params).not.toHaveProperty("include");
+  });
 });
 
 describe("convertResponsesMessages", () => {

--- a/packages/ai/src/providers/openai-responses-shared.test.ts
+++ b/packages/ai/src/providers/openai-responses-shared.test.ts
@@ -433,6 +433,23 @@ describe("Responses reasoning effort", () => {
     expect(params).not.toHaveProperty("include");
   });
 
+  it("maps default-off Responses reasoning through compat metadata", () => {
+    const params = {} as ResponseCreateParamsStreaming;
+    const compatModel = {
+      ...nativeOpenAIModel,
+      compat: {
+        supportsReasoningEffort: true,
+        supportedReasoningEfforts: ["provider-off"],
+        reasoningEffortMap: { off: "provider-off" },
+      },
+    } satisfies Model<"openai-responses">;
+
+    applyCommonResponsesParams(params, compatModel, { messages: [] });
+
+    expect(params).toMatchObject({ reasoning: { effort: "provider-off" } });
+    expect(params).not.toHaveProperty("include");
+  });
+
   it("honors a thinkingLevelMap null opt-out over compat mapping", () => {
     const params = {} as ResponseCreateParamsStreaming;
     const compatModel = {

--- a/packages/ai/src/providers/openai-responses-shared.test.ts
+++ b/packages/ai/src/providers/openai-responses-shared.test.ts
@@ -388,6 +388,19 @@ describe("Responses reasoning effort", () => {
     expect(params).not.toHaveProperty("include");
   });
 
+  it("omits default-off Responses reasoning when compat explicitly disables it", () => {
+    const params = {} as ResponseCreateParamsStreaming;
+    const compatModel = {
+      ...nativeOpenAIModel,
+      compat: { supportsReasoningEffort: false },
+    } satisfies Model<"openai-responses">;
+
+    applyCommonResponsesParams(params, compatModel, { messages: [] });
+
+    expect(params).not.toHaveProperty("reasoning");
+    expect(params).not.toHaveProperty("include");
+  });
+
   it("honors a thinkingLevelMap null opt-out over compat mapping", () => {
     const params = {} as ResponseCreateParamsStreaming;
     const compatModel = {

--- a/packages/ai/src/providers/openai-responses-shared.test.ts
+++ b/packages/ai/src/providers/openai-responses-shared.test.ts
@@ -359,13 +359,21 @@ describe("Responses reasoning effort", () => {
     expect(resolveResponsesReasoningEffort(gpt55WithXHigh, "max")).toBe("xhigh");
   });
 
-  it("returns undefined for a null thinking-level opt-out", () => {
-    const optOutModel = {
+  it("clamps a null-mapped thinking level before serializing Responses reasoning", () => {
+    const cappedModel = {
       ...nativeOpenAIModel,
       thinkingLevelMap: { high: null },
     } satisfies Model<"openai-responses">;
 
-    expect(resolveResponsesReasoningEffort(optOutModel, "high")).toBeUndefined();
+    expect(resolveResponsesReasoningEffort(cappedModel, "high")).toBe("medium");
+
+    const params = {} as ResponseCreateParamsStreaming;
+    applyCommonResponsesParams(params, cappedModel, { messages: [] }, { reasoningEffort: "high" });
+
+    expect(params).toMatchObject({
+      reasoning: { effort: "medium", summary: "auto" },
+      include: ["reasoning.encrypted_content"],
+    });
   });
 
   it("preserves Grok 4.5 off-to-low clamping despite an off null map entry", () => {
@@ -497,7 +505,7 @@ describe("Responses reasoning effort", () => {
     expect(params).not.toHaveProperty("include");
   });
 
-  it("honors a thinkingLevelMap null opt-out over compat mapping", () => {
+  it("clamps a null-mapped extended level before applying compat mapping", () => {
     const params = {} as ResponseCreateParamsStreaming;
     const compatModel = {
       ...nativeOpenAIModel,
@@ -511,8 +519,10 @@ describe("Responses reasoning effort", () => {
 
     applyCommonResponsesParams(params, compatModel, { messages: [] }, { reasoningEffort: "xhigh" });
 
-    expect(params).not.toHaveProperty("reasoning");
-    expect(params).not.toHaveProperty("include");
+    expect(params).toMatchObject({
+      reasoning: { effort: "high", summary: "auto" },
+      include: ["reasoning.encrypted_content"],
+    });
   });
 });
 

--- a/packages/ai/src/providers/openai-responses-shared.test.ts
+++ b/packages/ai/src/providers/openai-responses-shared.test.ts
@@ -368,6 +368,27 @@ describe("Responses reasoning effort", () => {
     expect(resolveResponsesReasoningEffort(optOutModel, "high")).toBeUndefined();
   });
 
+  it("preserves Grok 4.5 off-to-low clamping despite an off null map entry", () => {
+    const grok45Model = {
+      ...nativeOpenAIModel,
+      provider: "xai",
+      id: "grok-4.5",
+      thinkingLevelMap: {
+        off: null,
+        minimal: "low",
+        low: "low",
+        medium: "medium",
+        high: "high",
+      },
+      compat: {
+        supportsReasoningEffort: true,
+        supportedReasoningEfforts: ["low", "medium", "high"],
+      },
+    } satisfies Model<"openai-responses">;
+
+    expect(resolveResponsesReasoningEffort(grok45Model, "off")).toBe("low");
+  });
+
   it("maps compat reasoning effort before serializing Responses payload", () => {
     const params = {} as ResponseCreateParamsStreaming;
     const compatModel = {

--- a/packages/ai/src/providers/openai-responses-shared.test.ts
+++ b/packages/ai/src/providers/openai-responses-shared.test.ts
@@ -359,6 +359,15 @@ describe("Responses reasoning effort", () => {
     expect(resolveResponsesReasoningEffort(gpt55WithXHigh, "max")).toBe("xhigh");
   });
 
+  it("returns undefined for a null thinking-level opt-out", () => {
+    const optOutModel = {
+      ...nativeOpenAIModel,
+      thinkingLevelMap: { high: null },
+    } satisfies Model<"openai-responses">;
+
+    expect(resolveResponsesReasoningEffort(optOutModel, "high")).toBeUndefined();
+  });
+
   it("maps compat reasoning effort before serializing Responses payload", () => {
     const params = {} as ResponseCreateParamsStreaming;
     const compatModel = {

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -183,6 +183,7 @@ function isModelThinkingLevel(value: string): value is ModelThinkingLevel {
 function resolveResponsesApiReasoningEffort<TApi extends Api>(
   model: Model<TApi>,
   reasoning: string,
+  fallback = reasoning,
 ): OpenAIApiReasoningEffort | undefined {
   if (isResponsesReasoningEffortDisabled(model)) {
     return undefined;
@@ -205,7 +206,7 @@ function resolveResponsesApiReasoningEffort<TApi extends Api>(
       fallbackMap: compatReasoningEffortMap,
     });
   }
-  return isCanonicalReasoning ? (model.thinkingLevelMap?.[reasoning] ?? reasoning) : reasoning;
+  return isCanonicalReasoning ? (model.thinkingLevelMap?.[reasoning] ?? fallback) : reasoning;
 }
 
 export function resolveResponsesReasoningEffort(
@@ -282,10 +283,12 @@ export function applyCommonResponsesParams<TApi extends Api>(
     };
     params.include = ["reasoning.encrypted_content"];
   } else if ((config?.setDefaultReasoningOff ?? true) && model.thinkingLevelMap?.off !== null) {
+    const effort = resolveResponsesApiReasoningEffort(model, "off", "none");
+    if (effort === undefined) {
+      return;
+    }
     params.reasoning = {
-      effort: (model.thinkingLevelMap?.off ?? "none") as NonNullable<
-        typeof params.reasoning
-      >["effort"],
+      effort: effort as NonNullable<typeof params.reasoning>["effort"],
     };
   }
 }

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -233,10 +233,10 @@ export function applyCommonResponsesParams<TApi extends Api>(
     return;
   }
 
-  if (options?.reasoningEffort || options?.reasoningSummary) {
-    const effort = options?.reasoningEffort
-      ? resolveResponsesApiReasoningEffort(model, options.reasoningEffort)
-      : "medium";
+  const requestedEffort =
+    options?.reasoningEffort ?? (options?.reasoningSummary ? "medium" : undefined);
+  if (requestedEffort !== undefined) {
+    const effort = resolveResponsesApiReasoningEffort(model, requestedEffort);
     if (effort === undefined) {
       return;
     }

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -180,9 +180,7 @@ function resolveResponsesApiReasoningEffort<TApi extends Api>(
     return undefined;
   }
   const compatMapped =
-    compat && "reasoningEffortMap" in compat
-      ? compat.reasoningEffortMap?.[reasoning]
-      : undefined;
+    compat && "reasoningEffortMap" in compat ? compat.reasoningEffortMap?.[reasoning] : undefined;
   return compatMapped ?? model.thinkingLevelMap?.[reasoning] ?? reasoning;
 }
 

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -28,6 +28,7 @@ import type {
   AssistantMessage,
   Context,
   Model,
+  ModelThinkingLevel,
   SimpleStreamOptions,
   StreamOptions,
   Usage,
@@ -166,20 +167,23 @@ export function applyResponsesServiceTierPricing(
 
 function resolveResponsesApiReasoningEffort<TApi extends Api>(
   model: Model<TApi>,
-  reasoning: ResponsesReasoningEffort,
+  reasoning: ModelThinkingLevel,
 ): string | undefined {
-  const compat = model.api === "openai-responses" ? model.compat : undefined;
-  if (compat?.supportsReasoningEffort === false) {
+  const compat =
+    model.api === "openai-responses" && model.compat && typeof model.compat === "object"
+      ? model.compat
+      : undefined;
+  if (compat && "supportsReasoningEffort" in compat && compat.supportsReasoningEffort === false) {
     return undefined;
   }
   if (model.thinkingLevelMap?.[reasoning] === null) {
     return undefined;
   }
-  return (
-    compat?.reasoningEffortMap?.[reasoning] ??
-    model.thinkingLevelMap?.[reasoning] ??
-    reasoning
-  );
+  const compatMapped =
+    compat && "reasoningEffortMap" in compat
+      ? compat.reasoningEffortMap?.[reasoning]
+      : undefined;
+  return compatMapped ?? model.thinkingLevelMap?.[reasoning] ?? reasoning;
 }
 
 export function resolveResponsesReasoningEffort<TApi extends Api>(

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -164,10 +164,31 @@ export function applyResponsesServiceTierPricing(
     usage.cost.input + usage.cost.output + usage.cost.cacheRead + usage.cost.cacheWrite;
 }
 
+function resolveResponsesApiReasoningEffort<TApi extends Api>(
+  model: Model<TApi>,
+  reasoning: ResponsesReasoningEffort,
+): string | undefined {
+  const compat = model.api === "openai-responses" ? model.compat : undefined;
+  if (compat?.supportsReasoningEffort === false) {
+    return undefined;
+  }
+  if (model.thinkingLevelMap?.[reasoning] === null) {
+    return undefined;
+  }
+  return (
+    compat?.reasoningEffortMap?.[reasoning] ??
+    model.thinkingLevelMap?.[reasoning] ??
+    reasoning
+  );
+}
+
 export function resolveResponsesReasoningEffort<TApi extends Api>(
   model: Model<TApi>,
   reasoning: SimpleStreamOptions["reasoning"] | undefined,
 ): ResponsesReasoningEffort | undefined {
+  if (reasoning && resolveResponsesApiReasoningEffort(model, reasoning) === undefined) {
+    return undefined;
+  }
   const clampedReasoning = reasoning ? clampThinkingLevel(model, reasoning) : undefined;
   if (!clampedReasoning || clampedReasoning === "off") {
     return undefined;
@@ -214,8 +235,11 @@ export function applyCommonResponsesParams<TApi extends Api>(
 
   if (options?.reasoningEffort || options?.reasoningSummary) {
     const effort = options?.reasoningEffort
-      ? (model.thinkingLevelMap?.[options.reasoningEffort] ?? options.reasoningEffort)
+      ? resolveResponsesApiReasoningEffort(model, options.reasoningEffort)
       : "medium";
+    if (effort === undefined) {
+      return;
+    }
     params.reasoning = {
       effort: effort as NonNullable<typeof params.reasoning>["effort"],
       summary: options?.reasoningSummary || "auto",

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -165,15 +165,21 @@ export function applyResponsesServiceTierPricing(
     usage.cost.input + usage.cost.output + usage.cost.cacheRead + usage.cost.cacheWrite;
 }
 
-function resolveResponsesApiReasoningEffort<TApi extends Api>(
-  model: Model<TApi>,
-  reasoning: ModelThinkingLevel,
-): string | undefined {
+function isResponsesReasoningEffortDisabled<TApi extends Api>(model: Model<TApi>): boolean {
   const compat =
     model.api === "openai-responses" && model.compat && typeof model.compat === "object"
       ? model.compat
       : undefined;
-  if (compat && "supportsReasoningEffort" in compat && compat.supportsReasoningEffort === false) {
+  return Boolean(
+    compat && "supportsReasoningEffort" in compat && compat.supportsReasoningEffort === false,
+  );
+}
+
+function resolveResponsesApiReasoningEffort<TApi extends Api>(
+  model: Model<TApi>,
+  reasoning: ModelThinkingLevel,
+): string | undefined {
+  if (isResponsesReasoningEffortDisabled(model)) {
     return undefined;
   }
   if (model.thinkingLevelMap?.[reasoning] === null) {
@@ -231,7 +237,7 @@ export function applyCommonResponsesParams<TApi extends Api>(
     }
   }
 
-  if (!model.reasoning) {
+  if (!model.reasoning || isResponsesReasoningEffortDisabled(model)) {
     return;
   }
 

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -185,6 +185,10 @@ function resolveResponsesApiReasoningEffort<TApi extends Api>(
   if (model.thinkingLevelMap?.[reasoning] === null) {
     return undefined;
   }
+  const compat =
+    model.api === "openai-responses" && model.compat && typeof model.compat === "object"
+      ? model.compat
+      : undefined;
   const compatMapped =
     compat && "reasoningEffortMap" in compat ? compat.reasoningEffortMap?.[reasoning] : undefined;
   return compatMapped ?? model.thinkingLevelMap?.[reasoning] ?? reasoning;

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -188,11 +188,11 @@ export function resolveResponsesReasoningEffort<TApi extends Api>(
   model: Model<TApi>,
   reasoning: SimpleStreamOptions["reasoning"] | undefined,
 ): ResponsesReasoningEffort | undefined {
-  if (reasoning && resolveResponsesApiReasoningEffort(model, reasoning) === undefined) {
-    return undefined;
-  }
   const clampedReasoning = reasoning ? clampThinkingLevel(model, reasoning) : undefined;
   if (!clampedReasoning || clampedReasoning === "off") {
+    return undefined;
+  }
+  if (resolveResponsesApiReasoningEffort(model, clampedReasoning) === undefined) {
     return undefined;
   }
   if (clampedReasoning === "max") {

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -45,6 +45,7 @@ import {
   resolveOpenAIReasoningEffortForModel,
   supportsOpenAIReasoningEffort,
   supportsOpenAITemperature,
+  type OpenAIApiReasoningEffort,
 } from "./openai-reasoning-effort.js";
 import { convertResponsesToolPayload } from "./openai-responses-tools.js";
 
@@ -118,7 +119,7 @@ function isResponsesReasoningEffort(
 type ResponsesReasoningSummary = "auto" | "detailed" | "concise" | null;
 
 type ResponsesCommonParamsOptions = Pick<StreamOptions, "maxTokens" | "temperature"> & {
-  reasoningEffort?: ResponsesReasoningEffort;
+  reasoningEffort?: OpenAIApiReasoningEffort;
   reasoningSummary?: ResponsesReasoningSummary;
 };
 
@@ -175,14 +176,19 @@ function isResponsesReasoningEffortDisabled<TApi extends Api>(model: Model<TApi>
   );
 }
 
+function isModelThinkingLevel(value: string): value is ModelThinkingLevel {
+  return value === "off" || isResponsesReasoningEffort(value);
+}
+
 function resolveResponsesApiReasoningEffort<TApi extends Api>(
   model: Model<TApi>,
-  reasoning: ModelThinkingLevel,
-): string | undefined {
+  reasoning: string,
+): OpenAIApiReasoningEffort | undefined {
   if (isResponsesReasoningEffortDisabled(model)) {
     return undefined;
   }
-  if (model.thinkingLevelMap?.[reasoning] === null) {
+  const isCanonicalReasoning = isModelThinkingLevel(reasoning);
+  if (isCanonicalReasoning && model.thinkingLevelMap?.[reasoning] === null) {
     return undefined;
   }
   const compat =
@@ -190,33 +196,52 @@ function resolveResponsesApiReasoningEffort<TApi extends Api>(
       ? model.compat
       : undefined;
   const compatMapped =
-    compat && "reasoningEffortMap" in compat ? compat.reasoningEffortMap?.[reasoning] : undefined;
-  return compatMapped ?? model.thinkingLevelMap?.[reasoning] ?? reasoning;
+    isCanonicalReasoning && compat && "reasoningEffortMap" in compat
+      ? compat.reasoningEffortMap?.[reasoning]
+      : undefined;
+  if (compatMapped !== undefined) {
+    return resolveOpenAIReasoningEffortForModel({
+      model,
+      effort: reasoning,
+      fallbackMap: compat.reasoningEffortMap,
+    });
+  }
+  return isCanonicalReasoning ? (model.thinkingLevelMap?.[reasoning] ?? reasoning) : reasoning;
 }
 
+export function resolveResponsesReasoningEffort(
+  model: Model<"openai-responses">,
+  reasoning: SimpleStreamOptions["reasoning"] | undefined,
+): OpenAIApiReasoningEffort | undefined;
+export function resolveResponsesReasoningEffort<TApi extends Exclude<Api, "openai-responses">>(
+  model: Model<TApi>,
+  reasoning: SimpleStreamOptions["reasoning"] | undefined,
+): ResponsesReasoningEffort | undefined;
 export function resolveResponsesReasoningEffort<TApi extends Api>(
   model: Model<TApi>,
   reasoning: SimpleStreamOptions["reasoning"] | undefined,
-): ResponsesReasoningEffort | undefined {
+): OpenAIApiReasoningEffort | undefined {
   const clampedReasoning = reasoning ? clampThinkingLevel(model, reasoning) : undefined;
   if (!clampedReasoning || clampedReasoning === "off") {
     return undefined;
   }
-  if (resolveResponsesApiReasoningEffort(model, clampedReasoning) === undefined) {
+  const resolvedApiReasoning = resolveResponsesApiReasoningEffort(model, clampedReasoning);
+  if (resolvedApiReasoning === undefined) {
     return undefined;
   }
-  if (clampedReasoning === "max") {
+  if (clampedReasoning === "max" && resolvedApiReasoning === "max") {
     return supportsOpenAIReasoningEffort(model, "max") ? "max" : "xhigh";
   }
   if (
     clampedReasoning === "minimal" &&
+    resolvedApiReasoning === "minimal" &&
     model.provider === "openai" &&
     supportsOpenAIReasoningEffort(model, "max")
   ) {
     const effort = resolveOpenAIReasoningEffortForModel({ model, effort: "minimal" });
     return isResponsesReasoningEffort(effort) ? effort : undefined;
   }
-  return clampedReasoning;
+  return resolvedApiReasoning;
 }
 
 export function applyCommonResponsesParams<TApi extends Api>(

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -195,15 +195,14 @@ function resolveResponsesApiReasoningEffort<TApi extends Api>(
     model.api === "openai-responses" && model.compat && typeof model.compat === "object"
       ? model.compat
       : undefined;
-  const compatMapped =
-    isCanonicalReasoning && compat && "reasoningEffortMap" in compat
-      ? compat.reasoningEffortMap?.[reasoning]
-      : undefined;
+  const compatReasoningEffortMap: Record<string, string> | undefined =
+    compat && "reasoningEffortMap" in compat ? compat.reasoningEffortMap : undefined;
+  const compatMapped = isCanonicalReasoning ? compatReasoningEffortMap?.[reasoning] : undefined;
   if (compatMapped !== undefined) {
     return resolveOpenAIReasoningEffortForModel({
       model,
       effort: reasoning,
-      fallbackMap: compat.reasoningEffortMap,
+      fallbackMap: compatReasoningEffortMap,
     });
   }
   return isCanonicalReasoning ? (model.thinkingLevelMap?.[reasoning] ?? reasoning) : reasoning;

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -177,26 +177,17 @@ function isResponsesReasoningEffortDisabled<TApi extends Api>(model: Model<TApi>
   );
 }
 
-function hasNullThinkingLevelOptOut<TApi extends Api>(
-  model: Model<TApi>,
-  reasoning: string | undefined,
-): boolean {
-  if (reasoning === undefined || model.thinkingLevelMap === undefined) {
-    return false;
-  }
-  return Object.entries(model.thinkingLevelMap).some(
-    ([level, value]) => level === reasoning && value === null,
-  );
-}
-
 export function shouldDisableResponsesReasoningSerialization<TApi extends Api>(
   model: Model<TApi>,
   reasoning: string | undefined,
 ): boolean {
-  if (!hasNullThinkingLevelOptOut(model, reasoning)) {
+  if (reasoning === undefined || !isModelThinkingLevel(reasoning)) {
     return false;
   }
-  return reasoning !== "off" || clampThinkingLevel(model, reasoning) === "off";
+  const clampedReasoning = clampThinkingLevel(model, reasoning);
+  return (
+    clampedReasoning === "off" && (reasoning !== "off" || model.thinkingLevelMap?.off === null)
+  );
 }
 
 function isModelThinkingLevel(value: string): value is ModelThinkingLevel {
@@ -211,8 +202,14 @@ function resolveResponsesApiReasoningEffort<TApi extends Api>(
   if (isResponsesReasoningEffortDisabled(model)) {
     return undefined;
   }
-  const isCanonicalReasoning = isModelThinkingLevel(reasoning);
-  if (isCanonicalReasoning && hasNullThinkingLevelOptOut(model, reasoning)) {
+  if (!isModelThinkingLevel(reasoning)) {
+    return reasoning;
+  }
+  const effectiveReasoning = clampThinkingLevel(model, reasoning);
+  if (effectiveReasoning === "off" && reasoning !== "off") {
+    return undefined;
+  }
+  if (effectiveReasoning === "off" && reasoning === "off" && model.thinkingLevelMap?.off === null) {
     return undefined;
   }
   const compat =
@@ -221,15 +218,19 @@ function resolveResponsesApiReasoningEffort<TApi extends Api>(
       : undefined;
   const compatReasoningEffortMap: Record<string, string> | undefined =
     compat && "reasoningEffortMap" in compat ? compat.reasoningEffortMap : undefined;
-  const compatMapped = isCanonicalReasoning ? compatReasoningEffortMap?.[reasoning] : undefined;
+  const compatMapped = compatReasoningEffortMap?.[effectiveReasoning];
   if (compatMapped !== undefined) {
     return resolveOpenAIReasoningEffortForModel({
       model,
-      effort: reasoning,
+      effort: effectiveReasoning,
       fallbackMap: compatReasoningEffortMap,
     });
   }
-  return isCanonicalReasoning ? (model.thinkingLevelMap?.[reasoning] ?? fallback) : reasoning;
+  if (effectiveReasoning === "off") {
+    return model.thinkingLevelMap?.off ?? fallback;
+  }
+  const mappedThinkingLevel = model.thinkingLevelMap?.[effectiveReasoning];
+  return mappedThinkingLevel ?? effectiveReasoning;
 }
 
 export function resolveResponsesReasoningEffort(

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -121,6 +121,7 @@ type ResponsesReasoningSummary = "auto" | "detailed" | "concise" | null;
 type ResponsesCommonParamsOptions = Pick<StreamOptions, "maxTokens" | "temperature"> & {
   reasoningEffort?: OpenAIApiReasoningEffort;
   reasoningSummary?: ResponsesReasoningSummary;
+  disableReasoningSerialization?: boolean;
 };
 
 type ResponsesLifecycleRequest = OpenAIResponsesRequestParams;
@@ -176,6 +177,18 @@ function isResponsesReasoningEffortDisabled<TApi extends Api>(model: Model<TApi>
   );
 }
 
+export function hasNullThinkingLevelOptOut<TApi extends Api>(
+  model: Model<TApi>,
+  reasoning: string | undefined,
+): boolean {
+  if (reasoning === undefined || model.thinkingLevelMap === undefined) {
+    return false;
+  }
+  return Object.entries(model.thinkingLevelMap).some(
+    ([level, value]) => level === reasoning && value === null,
+  );
+}
+
 function isModelThinkingLevel(value: string): value is ModelThinkingLevel {
   return value === "off" || isResponsesReasoningEffort(value);
 }
@@ -189,7 +202,7 @@ function resolveResponsesApiReasoningEffort<TApi extends Api>(
     return undefined;
   }
   const isCanonicalReasoning = isModelThinkingLevel(reasoning);
-  if (isCanonicalReasoning && model.thinkingLevelMap?.[reasoning] === null) {
+  if (isCanonicalReasoning && hasNullThinkingLevelOptOut(model, reasoning)) {
     return undefined;
   }
   const compat =
@@ -221,6 +234,9 @@ export function resolveResponsesReasoningEffort<TApi extends Api>(
   model: Model<TApi>,
   reasoning: SimpleStreamOptions["reasoning"] | undefined,
 ): OpenAIApiReasoningEffort | undefined {
+  if (hasNullThinkingLevelOptOut(model, reasoning)) {
+    return undefined;
+  }
   const clampedReasoning = reasoning ? clampThinkingLevel(model, reasoning) : undefined;
   if (!clampedReasoning || clampedReasoning === "off") {
     return undefined;
@@ -266,7 +282,11 @@ export function applyCommonResponsesParams<TApi extends Api>(
     }
   }
 
-  if (!model.reasoning || isResponsesReasoningEffortDisabled(model)) {
+  if (
+    !model.reasoning ||
+    isResponsesReasoningEffortDisabled(model) ||
+    options?.disableReasoningSerialization
+  ) {
     return;
   }
 

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -177,7 +177,7 @@ function isResponsesReasoningEffortDisabled<TApi extends Api>(model: Model<TApi>
   );
 }
 
-export function hasNullThinkingLevelOptOut<TApi extends Api>(
+function hasNullThinkingLevelOptOut<TApi extends Api>(
   model: Model<TApi>,
   reasoning: string | undefined,
 ): boolean {
@@ -187,6 +187,16 @@ export function hasNullThinkingLevelOptOut<TApi extends Api>(
   return Object.entries(model.thinkingLevelMap).some(
     ([level, value]) => level === reasoning && value === null,
   );
+}
+
+export function shouldDisableResponsesReasoningSerialization<TApi extends Api>(
+  model: Model<TApi>,
+  reasoning: string | undefined,
+): boolean {
+  if (!hasNullThinkingLevelOptOut(model, reasoning)) {
+    return false;
+  }
+  return reasoning !== "off" || clampThinkingLevel(model, reasoning) === "off";
 }
 
 function isModelThinkingLevel(value: string): value is ModelThinkingLevel {
@@ -234,7 +244,7 @@ export function resolveResponsesReasoningEffort<TApi extends Api>(
   model: Model<TApi>,
   reasoning: SimpleStreamOptions["reasoning"] | undefined,
 ): OpenAIApiReasoningEffort | undefined {
-  if (hasNullThinkingLevelOptOut(model, reasoning)) {
+  if (shouldDisableResponsesReasoningSerialization(model, reasoning)) {
     return undefined;
   }
   const clampedReasoning = reasoning ? clampThinkingLevel(model, reasoning) : undefined;

--- a/packages/ai/src/providers/openai-responses.test.ts
+++ b/packages/ai/src/providers/openai-responses.test.ts
@@ -140,4 +140,33 @@ describe("OpenAI Responses provider", () => {
       include: ["reasoning.encrypted_content"],
     });
   });
+
+  it("preserves Grok 4.5 off-to-low serialization through simple Responses", async () => {
+    const result = await streamSimpleOpenAIResponses(
+      model({
+        provider: "xai",
+        id: "grok-4.5",
+        baseUrl: "https://api.x.ai/v1",
+        thinkingLevelMap: {
+          off: null,
+          minimal: "low",
+          low: "low",
+          medium: "medium",
+          high: "high",
+        },
+        compat: {
+          supportsReasoningEffort: true,
+          supportedReasoningEfforts: ["low", "medium", "high"],
+        },
+      }),
+      context,
+      { apiKey: "proof-key", reasoning: "off" },
+    ).result();
+
+    expect(result.stopReason).toBe("error");
+    expect(openAiMockState.params[0]).toMatchObject({
+      reasoning: { effort: "low", summary: "auto" },
+      include: ["reasoning.encrypted_content"],
+    });
+  });
 });

--- a/packages/ai/src/providers/openai-responses.test.ts
+++ b/packages/ai/src/providers/openai-responses.test.ts
@@ -24,7 +24,7 @@ vi.mock("openai", () => ({
   },
 }));
 
-import { streamOpenAIResponses } from "./openai-responses.js";
+import { streamOpenAIResponses, streamSimpleOpenAIResponses } from "./openai-responses.js";
 
 const context = {
   messages: [{ role: "user", content: "hello", timestamp: 0 }],
@@ -101,5 +101,43 @@ describe("OpenAI Responses provider", () => {
     expect(result.stopReason).toBe("error");
     expect(openAiMockState.params[0]).toMatchObject({ max_output_tokens: 16, store: false });
     expect(openAiMockState.requestOptions[0]).toMatchObject({ maxRetries: 0 });
+  });
+
+  it("omits reasoning serialization for a null thinking-level opt-out", async () => {
+    const result = await streamSimpleOpenAIResponses(
+      model({
+        provider: "proof-provider",
+        baseUrl: "https://proof.invalid/v1",
+        compat: { supportsReasoningEffort: true },
+        thinkingLevelMap: { high: null },
+      }),
+      context,
+      { apiKey: "proof-key", reasoning: "high" },
+    ).result();
+
+    expect(result.stopReason).toBe("error");
+    expect(openAiMockState.params[0]).not.toHaveProperty("reasoning");
+    expect(openAiMockState.params[0]).not.toHaveProperty("include");
+  });
+
+  it("preserves ordinary high reasoning serialization through simple completions", async () => {
+    const result = await streamSimpleOpenAIResponses(
+      model({
+        provider: "proof-provider",
+        baseUrl: "https://proof.invalid/v1",
+        compat: {
+          supportsReasoningEffort: true,
+          supportedReasoningEfforts: ["low", "medium", "high"],
+        },
+      }),
+      context,
+      { apiKey: "proof-key", reasoning: "high" },
+    ).result();
+
+    expect(result.stopReason).toBe("error");
+    expect(openAiMockState.params[0]).toMatchObject({
+      reasoning: { effort: "high", summary: "auto" },
+      include: ["reasoning.encrypted_content"],
+    });
   });
 });

--- a/packages/ai/src/providers/openai-responses.test.ts
+++ b/packages/ai/src/providers/openai-responses.test.ts
@@ -103,7 +103,7 @@ describe("OpenAI Responses provider", () => {
     expect(openAiMockState.requestOptions[0]).toMatchObject({ maxRetries: 0 });
   });
 
-  it("omits reasoning serialization for a null thinking-level opt-out", async () => {
+  it("clamps a null-mapped thinking level through simple Responses", async () => {
     const result = await streamSimpleOpenAIResponses(
       model({
         provider: "proof-provider",
@@ -116,8 +116,10 @@ describe("OpenAI Responses provider", () => {
     ).result();
 
     expect(result.stopReason).toBe("error");
-    expect(openAiMockState.params[0]).not.toHaveProperty("reasoning");
-    expect(openAiMockState.params[0]).not.toHaveProperty("include");
+    expect(openAiMockState.params[0]).toMatchObject({
+      reasoning: { effort: "medium", summary: "auto" },
+      include: ["reasoning.encrypted_content"],
+    });
   });
 
   it("preserves ordinary high reasoning serialization through simple completions", async () => {

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -19,7 +19,10 @@ import { resolveCacheRetention } from "./cache-retention.js";
 import { isCloudflareProvider, resolveCloudflareBaseUrl } from "./cloudflare.js";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copilot-headers.js";
 import { clampOpenAIPromptCacheKey } from "./openai-prompt-cache.js";
-import { supportsOpenAITemperature } from "./openai-reasoning-effort.js";
+import {
+  supportsOpenAITemperature,
+  type OpenAIApiReasoningEffort,
+} from "./openai-reasoning-effort.js";
 import {
   applyCommonResponsesParams,
   applyResponsesServiceTierPricing,
@@ -52,7 +55,7 @@ function getPromptCacheRetention(
 
 // OpenAI Responses-specific options
 export interface OpenAIResponsesOptions extends BaseOpenAIStreamOptions {
-  reasoningEffort?: "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
+  reasoningEffort?: OpenAIApiReasoningEffort;
   reasoningSummary?: "auto" | "detailed" | "concise" | null;
   replayResponsesItemIds?: boolean;
   serviceTier?: ResponseCreateParamsStreaming["service_tier"];

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -28,6 +28,7 @@ import {
   applyResponsesServiceTierPricing,
   convertResponsesMessages,
   createResponsesAssistantOutput,
+  hasNullThinkingLevelOptOut,
   resolveResponsesReasoningEffort,
   runResponsesStreamLifecycle,
 } from "./openai-responses-shared.js";
@@ -59,6 +60,7 @@ export interface OpenAIResponsesOptions extends BaseOpenAIStreamOptions {
   reasoningSummary?: "auto" | "detailed" | "concise" | null;
   replayResponsesItemIds?: boolean;
   serviceTier?: ResponseCreateParamsStreaming["service_tier"];
+  disableReasoningSerialization?: boolean;
 }
 
 type OpenAIResponsesReplayOptions = SimpleStreamOptions & {
@@ -111,11 +113,14 @@ export const streamSimpleOpenAIResponses: StreamFunction<
 
   const base = buildBaseOptions(model, options, apiKey);
   const replayOptions = options as OpenAIResponsesReplayOptions | undefined;
+  const disableReasoningSerialization =
+    options?.reasoning !== undefined && hasNullThinkingLevelOptOut(model, options.reasoning);
 
   return streamOpenAIResponses(model, context, {
     ...base,
     authProfileId: replayOptions?.authProfileId,
     reasoningEffort: resolveResponsesReasoningEffort(model, options?.reasoning),
+    disableReasoningSerialization,
     replayResponsesItemIds: replayOptions?.replayResponsesItemIds,
   } satisfies OpenAIResponsesOptions);
 };

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -28,7 +28,7 @@ import {
   applyResponsesServiceTierPricing,
   convertResponsesMessages,
   createResponsesAssistantOutput,
-  hasNullThinkingLevelOptOut,
+  shouldDisableResponsesReasoningSerialization,
   resolveResponsesReasoningEffort,
   runResponsesStreamLifecycle,
 } from "./openai-responses-shared.js";
@@ -113,8 +113,10 @@ export const streamSimpleOpenAIResponses: StreamFunction<
 
   const base = buildBaseOptions(model, options, apiKey);
   const replayOptions = options as OpenAIResponsesReplayOptions | undefined;
-  const disableReasoningSerialization =
-    options?.reasoning !== undefined && hasNullThinkingLevelOptOut(model, options.reasoning);
+  const disableReasoningSerialization = shouldDisableResponsesReasoningSerialization(
+    model,
+    options?.reasoning,
+  );
 
   return streamOpenAIResponses(model, context, {
     ...base,

--- a/packages/ai/src/transports/openai-completions-compat.ts
+++ b/packages/ai/src/transports/openai-completions-compat.ts
@@ -48,10 +48,16 @@ type DetectedOpenAICompletionsCompat = {
 
 export type ResolvedOpenAICompletionsCompat = Omit<
   Required<OpenAICompletionsCompat>,
-  "cacheControlFormat" | "openRouterRouting" | "sendSessionAffinityHeaders"
+  | "cacheControlFormat"
+  | "openRouterRouting"
+  | "sendSessionAffinityHeaders"
+  | "supportedReasoningEfforts"
+  | "reasoningEffortMap"
 > & {
   cacheControlFormat?: OpenAICompletionsCompat["cacheControlFormat"];
   openRouterRouting?: OpenAICompletionsCompat["openRouterRouting"];
+  supportedReasoningEfforts?: OpenAICompletionsCompat["supportedReasoningEfforts"];
+  reasoningEffortMap?: OpenAICompletionsCompat["reasoningEffortMap"];
   sessionAffinity: OpenAICompletionsSessionAffinity;
   visibleReasoningDetailTypes: string[];
   requiresNonEmptyUserOrAssistantMessage: boolean;
@@ -252,6 +258,8 @@ export function resolveOpenAICompletionsCompat(
     supportsDeveloperRole: configured?.supportsDeveloperRole ?? defaults.supportsDeveloperRole,
     supportsReasoningEffort:
       configured?.supportsReasoningEffort ?? defaults.supportsReasoningEffort,
+    supportedReasoningEfforts: configured?.supportedReasoningEfforts,
+    reasoningEffortMap: configured?.reasoningEffortMap,
     supportsUsageInStreaming:
       configured?.supportsUsageInStreaming ?? defaults.supportsUsageInStreaming,
     maxTokensField: configured?.maxTokensField ?? defaults.maxTokensField,

--- a/packages/ai/src/transports/openai-completions-params.reasoning.test.ts
+++ b/packages/ai/src/transports/openai-completions-params.reasoning.test.ts
@@ -298,6 +298,31 @@ describe("openai completions params", () => {
     expect(disabled.reasoning_effort).toBe("none");
   });
 
+  it("preserves map-only canonical effort mappings in Completions payloads", () => {
+    const model = {
+      id: "custom-reasoning",
+      name: "Custom Reasoning",
+      api: "openai-completions",
+      provider: "custom-openai-compatible",
+      baseUrl: "https://proxy.example.com/v1",
+      reasoning: true,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 131072,
+      maxTokens: 8192,
+      compat: {
+        supportsReasoningEffort: true,
+        reasoningEffortMap: { high: "xhigh" },
+      },
+    } as unknown as Model<"openai-completions">;
+
+    const params = buildOpenAICompletionsParams(model, emptyContext(), {
+      reasoning: "high",
+    } as never) as { reasoning_effort?: unknown };
+
+    expect(params.reasoning_effort).toBe("xhigh");
+  });
+
   it("maps qwen thinking format to top-level enable_thinking", () => {
     const baseModel = {
       id: "qwen3.5-32b",

--- a/packages/ai/src/transports/openai-completions-params.reasoning.test.ts
+++ b/packages/ai/src/transports/openai-completions-params.reasoning.test.ts
@@ -323,6 +323,55 @@ describe("openai completions params", () => {
     expect(params.reasoning_effort).toBe("xhigh");
   });
 
+  it("falls back from an unsupported mapped xhigh effort to the requested supported effort", () => {
+    const model = {
+      id: "custom-reasoning",
+      name: "Custom Reasoning",
+      api: "openai-completions",
+      provider: "custom-openai-compatible",
+      baseUrl: "https://proxy.example.com/v1",
+      reasoning: true,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 131072,
+      maxTokens: 8192,
+      compat: {
+        supportsReasoningEffort: true,
+        supportedReasoningEfforts: ["low", "medium", "high"],
+        reasoningEffortMap: { high: "xhigh" },
+      },
+    } satisfies Model<"openai-completions">;
+
+    const params = buildOpenAICompletionsParams(model, emptyContext(), {
+      reasoning: "high",
+    } as never) as { reasoning_effort?: unknown };
+
+    expect(params.reasoning_effort).toBe("high");
+  });
+
+  it("omits reasoning_effort when a thinking level is explicitly disabled", () => {
+    const model = {
+      id: "custom-reasoning",
+      name: "Custom Reasoning",
+      api: "openai-completions",
+      provider: "custom-openai-compatible",
+      baseUrl: "https://proxy.example.com/v1",
+      reasoning: true,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 131072,
+      maxTokens: 8192,
+      compat: { supportsReasoningEffort: true },
+      thinkingLevelMap: { high: null },
+    } satisfies Model<"openai-completions">;
+
+    const params = buildOpenAICompletionsParams(model, emptyContext(), {
+      reasoning: "high",
+    } as never) as { reasoning_effort?: unknown };
+
+    expect(params).not.toHaveProperty("reasoning_effort");
+  });
+
   it("maps qwen thinking format to top-level enable_thinking", () => {
     const baseModel = {
       id: "qwen3.5-32b",

--- a/packages/ai/src/transports/openai-completions-params.reasoning.test.ts
+++ b/packages/ai/src/transports/openai-completions-params.reasoning.test.ts
@@ -349,7 +349,7 @@ describe("openai completions params", () => {
     expect(params.reasoning_effort).toBe("high");
   });
 
-  it("omits reasoning_effort when a thinking level is explicitly disabled", () => {
+  it("clamps null-mapped thinking levels before serializing reasoning_effort", () => {
     const model = {
       id: "custom-reasoning",
       name: "Custom Reasoning",
@@ -369,7 +369,7 @@ describe("openai completions params", () => {
       reasoning: "high",
     } as never) as { reasoning_effort?: unknown };
 
-    expect(params).not.toHaveProperty("reasoning_effort");
+    expect(params.reasoning_effort).toBe("medium");
   });
 
   it("maps qwen thinking format to top-level enable_thinking", () => {

--- a/packages/ai/src/transports/openai-completions-params.ts
+++ b/packages/ai/src/transports/openai-completions-params.ts
@@ -1,4 +1,5 @@
-import type { Context, Model } from "@openclaw/llm-core";
+import type { Context, Model, ModelThinkingLevel } from "@openclaw/llm-core";
+import { clampThinkingLevel } from "../model-utils.js";
 import { convertMessages, hasToolCallHistory } from "../openai-completions-messages.js";
 import type { OpenAICompletionsOptions } from "../provider-options.js";
 import { resolveCacheRetention } from "../providers/cache-retention.js";
@@ -66,6 +67,18 @@ function isKnownOpenAICompletionsEndpoint(model: Pick<Model, "baseUrl">): boolea
 
 function resolveOpenAICompletionsReasoningEffort(options: OpenAICompletionsOptions | undefined) {
   return options?.reasoningEffort ?? options?.reasoning ?? "high";
+}
+
+function isModelThinkingLevel(value: unknown): value is ModelThinkingLevel {
+  return (
+    value === "off" ||
+    value === "minimal" ||
+    value === "low" ||
+    value === "medium" ||
+    value === "high" ||
+    value === "xhigh" ||
+    value === "max"
+  );
 }
 
 function resolveOpenAICompletionsMaxTokens(
@@ -448,19 +461,18 @@ export function buildOpenAICompletionsParams(
     }
   }
   const completionsReasoningEffort = resolveOpenAICompletionsReasoningEffort(options);
-  const explicitThinkingLevelMapOptOut =
-    model.thinkingLevelMap !== undefined &&
-    Object.entries(model.thinkingLevelMap).some(
-      ([level, value]) => level === completionsReasoningEffort && value === null,
-    );
-  const resolvedCompletionsReasoningEffort =
-    completionsReasoningEffort && !explicitThinkingLevelMapOptOut
-      ? resolveOpenAIReasoningEffortForModel({
-          model,
-          effort: completionsReasoningEffort,
-          fallbackMap: compat.reasoningEffortMap,
-        })
-      : undefined;
+  const canonicalReasoningEffort = isModelThinkingLevel(completionsReasoningEffort)
+    ? completionsReasoningEffort
+    : undefined;
+  const clampModel = { ...model, compat: model.compat ?? undefined } satisfies Model;
+  const effectiveCompletionsReasoningEffort = canonicalReasoningEffort
+    ? clampThinkingLevel(clampModel, canonicalReasoningEffort)
+    : completionsReasoningEffort;
+  const resolvedCompletionsReasoningEffort = resolveOpenAIReasoningEffortForModel({
+    model,
+    effort: effectiveCompletionsReasoningEffort,
+    fallbackMap: compat.reasoningEffortMap,
+  });
   const omitChatCompletionsToolReasoningEffort =
     Array.isArray(params.tools) &&
     params.tools.length > 0 &&

--- a/packages/ai/src/transports/openai-completions-params.ts
+++ b/packages/ai/src/transports/openai-completions-params.ts
@@ -448,13 +448,19 @@ export function buildOpenAICompletionsParams(
     }
   }
   const completionsReasoningEffort = resolveOpenAICompletionsReasoningEffort(options);
-  const resolvedCompletionsReasoningEffort = completionsReasoningEffort
-    ? resolveOpenAIReasoningEffortForModel({
-        model,
-        effort: completionsReasoningEffort,
-        fallbackMap: compat.reasoningEffortMap,
-      })
-    : undefined;
+  const explicitThinkingLevelMapOptOut =
+    model.thinkingLevelMap !== undefined &&
+    Object.entries(model.thinkingLevelMap).some(
+      ([level, value]) => level === completionsReasoningEffort && value === null,
+    );
+  const resolvedCompletionsReasoningEffort =
+    completionsReasoningEffort && !explicitThinkingLevelMapOptOut
+      ? resolveOpenAIReasoningEffortForModel({
+          model,
+          effort: completionsReasoningEffort,
+          fallbackMap: compat.reasoningEffortMap,
+        })
+      : undefined;
   const omitChatCompletionsToolReasoningEffort =
     Array.isArray(params.tools) &&
     params.tools.length > 0 &&

--- a/packages/llm-core/src/types.ts
+++ b/packages/llm-core/src/types.ts
@@ -481,6 +481,10 @@ export interface OpenAICompletionsCompat {
   supportsDeveloperRole?: boolean;
   /** Whether the provider supports `reasoning_effort`. Default: auto-detected from URL. */
   supportsReasoningEffort?: boolean;
+  /** Provider-accepted reasoning effort labels. Overrides model-family defaults when present. */
+  supportedReasoningEfforts?: string[];
+  /** Maps OpenClaw reasoning effort labels to provider-specific labels. */
+  reasoningEffortMap?: Record<string, string>;
   /** Whether the provider supports `stream_options: { include_usage: true }` for token usage in streaming responses. Default: true. */
   supportsUsageInStreaming?: boolean;
   /** Which field to use for max tokens. Default: auto-detected from URL. */
@@ -528,6 +532,12 @@ export interface OpenAIResponsesCompat {
   supportsDeveloperRole?: boolean;
   /** Whether the model accepts the `temperature` parameter. Default: true. */
   supportsTemperature?: boolean;
+  /** Whether the provider supports `reasoning_effort`. Default: auto-detected from the model. */
+  supportsReasoningEffort?: boolean;
+  /** Provider-accepted reasoning effort labels. */
+  supportedReasoningEfforts?: string[];
+  /** Maps OpenClaw reasoning effort labels to provider-specific labels. */
+  reasoningEffortMap?: Record<string, string>;
   /** Whether to send the OpenAI `session_id` cache-affinity header from `options.sessionId` when caching is enabled. Default: true. */
   sendSessionIdHeader?: boolean;
   /** Whether the provider supports `prompt_cache_retention: "24h"`. Default: true. */

--- a/packages/llm-core/src/types.ts
+++ b/packages/llm-core/src/types.ts
@@ -482,7 +482,7 @@ export interface OpenAICompletionsCompat {
   /** Whether the provider supports `reasoning_effort`. Default: auto-detected from URL. */
   supportsReasoningEffort?: boolean;
   /** Provider-accepted reasoning effort labels. Overrides model-family defaults when present. */
-  supportedReasoningEfforts?: string[];
+  supportedReasoningEfforts?: readonly string[] | null;
   /** Maps OpenClaw reasoning effort labels to provider-specific labels. */
   reasoningEffortMap?: Record<string, string>;
   /** Whether the provider supports `stream_options: { include_usage: true }` for token usage in streaming responses. Default: true. */
@@ -535,7 +535,7 @@ export interface OpenAIResponsesCompat {
   /** Whether the provider supports `reasoning_effort`. Default: auto-detected from the model. */
   supportsReasoningEffort?: boolean;
   /** Provider-accepted reasoning effort labels. */
-  supportedReasoningEfforts?: string[];
+  supportedReasoningEfforts?: readonly string[] | null;
   /** Maps OpenClaw reasoning effort labels to provider-specific labels. */
   reasoningEffortMap?: Record<string, string>;
   /** Whether to send the OpenAI `session_id` cache-affinity header from `options.sessionId` when caching is enabled. Default: true. */

--- a/src/agents/sessions/model-registry.test.ts
+++ b/src/agents/sessions/model-registry.test.ts
@@ -163,6 +163,35 @@ describe("ModelRegistry models.json auth", () => {
     });
   });
 
+  it("preserves compat reasoning metadata from models.json", () => {
+    const modelsPath = writeModelsJson({
+      providers: {
+        custom: {
+          baseUrl: "https://models.example/v1",
+          api: "openai-responses",
+          models: [
+            {
+              id: "reasoning-model",
+              compat: {
+                supportsReasoningEffort: true,
+                supportedReasoningEfforts: ["low", "medium", "high", "xhigh"],
+                reasoningEffortMap: { xhigh: "high" },
+              },
+            },
+          ],
+        },
+      },
+    });
+
+    const registry = ModelRegistry.create(AuthStorage.inMemory(), modelsPath);
+    expect(registry.getError()).toBeUndefined();
+    expect(registry.find("custom", "reasoning-model")?.compat).toEqual({
+      supportsReasoningEffort: true,
+      supportedReasoningEfforts: ["low", "medium", "high", "xhigh"],
+      reasoningEffortMap: { xhigh: "high" },
+    });
+  });
+
   it("uses stored auth for custom models without an inline apiKey", async () => {
     const modelsPath = writeModelsJson({
       providers: {

--- a/src/agents/sessions/model-registry.ts
+++ b/src/agents/sessions/model-registry.ts
@@ -108,6 +108,8 @@ const OpenAICompletionsCompatSchema = Type.Object({
   supportsStore: Type.Optional(Type.Boolean()),
   supportsDeveloperRole: Type.Optional(Type.Boolean()),
   supportsReasoningEffort: Type.Optional(Type.Boolean()),
+  supportedReasoningEfforts: Type.Optional(Type.Array(Type.String())),
+  reasoningEffortMap: Type.Optional(Type.Record(Type.String(), Type.String())),
   supportsUsageInStreaming: Type.Optional(Type.Boolean()),
   maxTokensField: Type.Optional(
     Type.Union([Type.Literal("max_completion_tokens"), Type.Literal("max_tokens")]),
@@ -137,6 +139,9 @@ const OpenAICompletionsCompatSchema = Type.Object({
 
 const OpenAIResponsesCompatSchema = Type.Object({
   supportsTemperature: Type.Optional(Type.Boolean()),
+  supportsReasoningEffort: Type.Optional(Type.Boolean()),
+  supportedReasoningEfforts: Type.Optional(Type.Array(Type.String())),
+  reasoningEffortMap: Type.Optional(Type.Record(Type.String(), Type.String())),
   sendSessionIdHeader: Type.Optional(Type.Boolean()),
   supportsLongCacheRetention: Type.Optional(Type.Boolean()),
 });

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -31,6 +31,8 @@ type SupportedOpenAICompatFields = Pick<
   | "supportsStore"
   | "supportsDeveloperRole"
   | "supportsReasoningEffort"
+  | "supportedReasoningEfforts"
+  | "reasoningEffortMap"
   | "supportsUsageInStreaming"
   | "supportsStrictMode"
   | "supportsJsonSchemaResponseFormat"
@@ -49,7 +51,12 @@ type SupportedOpenAICompatFields = Pick<
 
 type SupportedOpenAIResponsesCompatFields = Pick<
   OpenAIResponsesCompat,
-  "sendSessionIdHeader" | "supportsLongCacheRetention" | "supportsTemperature"
+  | "sendSessionIdHeader"
+  | "supportsLongCacheRetention"
+  | "supportsTemperature"
+  | "supportsReasoningEffort"
+  | "supportedReasoningEfforts"
+  | "reasoningEffortMap"
 >;
 
 type SupportedAnthropicMessagesCompatFields = Pick<

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -93,7 +93,7 @@ export type ModelCompatConfig = SupportedOpenAICompatFields &
     /** Reasoning/thinking payload dialect for provider-compatible APIs. */
     thinkingFormat?: SupportedThinkingFormat;
     /** Provider-accepted reasoning effort labels. */
-    supportedReasoningEfforts?: string[];
+    supportedReasoningEfforts?: readonly string[] | null;
     /** Maps OpenClaw reasoning effort labels to provider-specific labels. */
     reasoningEffortMap?: Record<string, string>;
     /** Reasoning detail block types safe to expose in visible transcripts. */

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -256,7 +256,11 @@ const ModelCompatSchema = z
     requiresStringContent: z.boolean().optional(),
     strictMessageKeys: z.boolean().optional(),
     visibleReasoningDetailTypes: z.array(z.string().min(1)).optional(),
-    supportedReasoningEfforts: z.array(z.string().min(1)).optional(),
+    supportedReasoningEfforts: z
+      .array(z.string().min(1))
+      .transform((values): readonly string[] => values)
+      .nullable()
+      .optional(),
     reasoningEffortMap: z.record(z.string().min(1), z.string().min(1)).optional(),
     maxTokensField: z
       .union([z.literal("max_completion_tokens"), z.literal("max_tokens")])

--- a/src/llm/model-utils.test.ts
+++ b/src/llm/model-utils.test.ts
@@ -2,6 +2,27 @@ import { clampThinkingLevel, getSupportedThinkingLevels } from "@openclaw/ai/int
 import { describe, expect, it } from "vitest";
 import type { Model } from "./types.js";
 
+type TestOpenAICompletionsModel = Model<"openai-completions">;
+type TestOpenAIResponsesModel = Model<"openai-responses">;
+
+const baseOpenAICompletionsModel = {
+  id: "test-completions-model",
+  name: "Test Completions Model",
+  api: "openai-completions",
+  provider: "custom",
+  baseUrl: "https://example.com/v1",
+  reasoning: true,
+  input: ["text"],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 128_000,
+  maxTokens: 4096,
+} satisfies TestOpenAICompletionsModel;
+
+const baseOpenAIResponsesModel = {
+  ...baseOpenAICompletionsModel,
+  api: "openai-responses",
+} satisfies TestOpenAIResponsesModel;
+
 function makeModel(
   thinkingLevelMap: Model["thinkingLevelMap"],
   overrides: Partial<Model> = {},
@@ -39,6 +60,81 @@ describe("clampThinkingLevel", () => {
       reasoning: false,
       params: { canonicalModelId: "claude-fable-5" },
     });
+
+    expect(getSupportedThinkingLevels(model)).toContain("max");
+    expect(clampThinkingLevel(model, "max")).toBe("max");
+  });
+
+  it("exposes xhigh when OpenAI-compatible metadata declares xhigh", () => {
+    const model = {
+      ...baseOpenAICompletionsModel,
+      compat: {
+        supportsReasoningEffort: true,
+        supportedReasoningEfforts: ["low", "medium", "high", "xhigh"],
+      },
+    } satisfies TestOpenAICompletionsModel;
+
+    expect(getSupportedThinkingLevels(model)).toEqual([
+      "off",
+      "minimal",
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+    ]);
+    expect(clampThinkingLevel(model, "xhigh")).toBe("xhigh");
+  });
+
+  it("exposes xhigh when compat maps it to a declared provider effort", () => {
+    const model = {
+      ...baseOpenAIResponsesModel,
+      compat: {
+        supportsReasoningEffort: true,
+        supportedReasoningEfforts: ["low", "medium", "high"],
+        reasoningEffortMap: { xhigh: "high" },
+      },
+    } satisfies TestOpenAIResponsesModel;
+
+    expect(getSupportedThinkingLevels(model)).toContain("xhigh");
+    expect(clampThinkingLevel(model, "xhigh")).toBe("xhigh");
+  });
+
+  it("does not expose mapped extended levels unless the provider value is declared", () => {
+    const model = {
+      ...baseOpenAICompletionsModel,
+      compat: {
+        supportsReasoningEffort: true,
+        supportedReasoningEfforts: ["xhigh"],
+        reasoningEffortMap: { xhigh: "provider-xhigh" },
+      },
+    } satisfies TestOpenAICompletionsModel;
+
+    expect(getSupportedThinkingLevels(model)).not.toContain("xhigh");
+    expect(clampThinkingLevel(model, "xhigh")).toBe("high");
+  });
+
+  it("keeps extended levels hidden when compat reasoning is explicitly disabled", () => {
+    const model = {
+      ...baseOpenAIResponsesModel,
+      compat: {
+        supportsReasoningEffort: false,
+        supportedReasoningEfforts: ["low", "medium", "high", "xhigh"],
+      },
+    } satisfies TestOpenAIResponsesModel;
+
+    expect(getSupportedThinkingLevels(model)).not.toContain("xhigh");
+    expect(clampThinkingLevel(model, "xhigh")).toBe("high");
+  });
+
+  it("exposes max only with an explicit compat max-to-xhigh mapping", () => {
+    const model = {
+      ...baseOpenAICompletionsModel,
+      compat: {
+        supportsReasoningEffort: true,
+        supportedReasoningEfforts: ["low", "medium", "high", "xhigh"],
+        reasoningEffortMap: { max: "xhigh" },
+      },
+    } satisfies TestOpenAICompletionsModel;
 
     expect(getSupportedThinkingLevels(model)).toContain("max");
     expect(clampThinkingLevel(model, "max")).toBe("max");

--- a/src/llm/model-utils.test.ts
+++ b/src/llm/model-utils.test.ts
@@ -113,7 +113,7 @@ describe("clampThinkingLevel", () => {
     expect(clampThinkingLevel(model, "xhigh")).toBe("high");
   });
 
-  it("keeps extended levels hidden when compat reasoning is explicitly disabled", () => {
+  it("exposes only off when compat reasoning is explicitly disabled", () => {
     const model = {
       ...baseOpenAIResponsesModel,
       compat: {
@@ -122,8 +122,36 @@ describe("clampThinkingLevel", () => {
       },
     } satisfies TestOpenAIResponsesModel;
 
-    expect(getSupportedThinkingLevels(model)).not.toContain("xhigh");
-    expect(clampThinkingLevel(model, "xhigh")).toBe("high");
+    expect(getSupportedThinkingLevels(model)).toEqual(["off"]);
+    expect(clampThinkingLevel(model, "high")).toBe("off");
+    expect(clampThinkingLevel(model, "xhigh")).toBe("off");
+  });
+
+  it("exposes max when compat declares a native max effort", () => {
+    const model = {
+      ...baseOpenAICompletionsModel,
+      compat: {
+        supportsReasoningEffort: true,
+        supportedReasoningEfforts: ["low", "medium", "high", "max"],
+      },
+    } satisfies TestOpenAICompletionsModel;
+
+    expect(getSupportedThinkingLevels(model)).toContain("max");
+    expect(clampThinkingLevel(model, "max")).toBe("max");
+  });
+
+  it("exposes max when compat maps it to a declared provider effort", () => {
+    const model = {
+      ...baseOpenAICompletionsModel,
+      compat: {
+        supportsReasoningEffort: true,
+        supportedReasoningEfforts: ["low", "medium", "high", "provider-max"],
+        reasoningEffortMap: { max: "provider-max" },
+      },
+    } satisfies TestOpenAICompletionsModel;
+
+    expect(getSupportedThinkingLevels(model)).toContain("max");
+    expect(clampThinkingLevel(model, "max")).toBe("max");
   });
 
   it("exposes max only with an explicit compat max-to-xhigh mapping", () => {

--- a/src/llm/model-utils.test.ts
+++ b/src/llm/model-utils.test.ts
@@ -127,6 +127,17 @@ describe("clampThinkingLevel", () => {
     expect(clampThinkingLevel(model, "xhigh")).toBe("off");
   });
 
+  it("accepts null compat effort metadata without exposing extended levels", () => {
+    const model = {
+      ...baseOpenAIResponsesModel,
+      compat: { supportedReasoningEfforts: null },
+    } satisfies TestOpenAIResponsesModel;
+
+    expect(getSupportedThinkingLevels(model)).not.toContain("xhigh");
+    expect(getSupportedThinkingLevels(model)).not.toContain("max");
+    expect(clampThinkingLevel(model, "xhigh")).toBe("high");
+  });
+
   it("exposes max when compat declares a native max effort", () => {
     const model = {
       ...baseOpenAICompletionsModel,


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- Allows OpenAI-compatible reasoning models to expose `xhigh` thinking when the model configuration explicitly declares API support through `compat.supportedReasoningEfforts`.
- Keeps `xhigh` hidden for reasoning models that do not declare extended compatible reasoning effort support.
- Keeps `max` conservative: it is surfaced only when compat metadata explicitly supports `max` (for example `reasoningEffortMap.max`), while plain `supportedReasoningEfforts: ["xhigh"]` surfaces only `xhigh`.

Why does this matter now?

- Some OpenAI-compatible providers support reasoning efforts beyond OpenAI's standard `minimal`/`low`/`medium`/`high` set, but OpenClaw's UI/runtime capability calculation filtered those levels out before consulting explicit compat support.
- That makes valid configured models look like they cannot use `xhigh`, even when the provider explicitly lists that effort in compat metadata.

What is the intended outcome?

- Configured compatible models can advertise and use `xhigh` only when `compat.supportedReasoningEfforts` explicitly includes it, and can advertise `max` only when explicit compat metadata says `max` is supported.
- Default reasoning-model behavior remains conservative for providers without explicit extended effort support.

What is intentionally out of scope?

- No new config fields.
- No change to model definitions that do not opt into extended compatible reasoning efforts.
- No local installed-runtime hotfix; this is the durable source-level change.

What does success look like?

- Existing OpenAI reasoning models keep the previous supported thinking levels.
- OpenAI-compatible models with explicit `supportedReasoningEfforts` can surface `xhigh`; `reasoningEffortMap` can map supported levels but does not by itself expose new extended levels; `max` requires explicit `max` support in compat metadata.
- OpenAI-compatible models without explicit extended effort support still do not surface `xhigh`.

What should reviewers focus on?

- The compatibility gate around extended reasoning efforts.
- Whether `max` is gated strictly enough for compatible-provider reasoning effort checks.
- Regression coverage in `src/llm/model-utils.test.ts`.

## Linked context

Which issue does this close?

Closes #

Which issues, PRs, or discussions are related?

Related #59416
Related #74273
Related #84902

Was this requested by a maintainer or owner?

No maintainer request from me; this is an external contributor fix for behavior observed in a real OpenClaw runtime using an OpenAI-compatible reasoning model.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: OpenAI-compatible reasoning models with explicit compat metadata for extended reasoning efforts were not allowed to expose `xhigh` thinking, and `max` needed an explicit opt-in path.
- Real environment tested: Local OpenClaw runtime on Linux, current session using model `codex-lb-2455/gpt-5.5` with `Think: xhigh` visible in `session_status` output.
- Exact steps or command run after this patch:
  - `session_status(model="", sessionKey="current")`
  - Focused source tests and changed-file checks listed below.
  - On exact HEAD `2bdf86f08f8cee323e84465782a8845d043febf5`, in a dependency-complete checkout, temporary seven-arm probes were run from `packages/ai/src/providers/` with `pnpm exec tsx .completions-boundary-proof.mts` and `pnpm exec tsx .responses-boundary-proof.mts`.
  - Each probe dynamically recorded `git rev-parse HEAD`, configured `configureAiTransportHost({ buildModelFetch })`, called the real simple streaming provider entry point, constructed `new Request(input, init)`, asserted exactly one POST to the expected endpoint and the expected model id, parsed the outgoing JSON, and returned a mock SSE response so the stream completed. Auth headers and tokens were not printed.
- Evidence after fix (redacted terminal capture and inspectable request-boundary output):
  - `session_status` output included: `OpenClaw 2026.6.1`, `Model: codex-lb-2455/gpt-5.5`, and `Think: xhigh`.
  - Targeted regression tests in `src/llm/model-utils.test.ts` pass locally. The new `openai-completions` regression verifies Grok 4.5 `off:null → low` clamping through simple Completions.
  - New Completions and Responses regression tests cover strict mapped-effort fallback, mapped `max`, and `thinkingLevelMap[level] === null` serialization opt-outs.
- Final-head Completions capture: seven arms through real `streamSimpleOpenAICompletions`:

    | arm | outgoing `reasoning_effort` |
    | --- | --- |
    | ordinary `high` control | `"high"` |
    | mapped `high → xhigh`, supported list includes `xhigh` | `"xhigh"` |
    | same mapping, supported list excludes `xhigh` | `"high"` fallback |
    | `supportsReasoningEffort: false` | field absent |
    | `thinkingLevelMap.high === null` | `"medium"` (canonical clamp) |
    | mapped `max → provider-max`, supported list includes `provider-max` | `"provider-max"` |

  - Final-head Responses capture: seven arms through real `streamSimpleOpenAIResponses`:

    | arm | outgoing `reasoning` / `include` |
    | --- | --- |
    | ordinary `high` control | `{ "effort": "high", "summary": "auto" }` / `["reasoning.encrypted_content"]` |
    | mapped `high → xhigh`, supported list includes `xhigh` | `{ "effort": "xhigh", "summary": "auto" }` / `["reasoning.encrypted_content"]` |
    | same mapping, supported list excludes `xhigh` | `{ "effort": "high", "summary": "auto" }` / `["reasoning.encrypted_content"]` |
    | `supportsReasoningEffort: false` | both fields absent |
    | `thinkingLevelMap.high === null` | `{ "effort": "medium", "summary": "auto" }` / `["reasoning.encrypted_content"]` |
    | mapped `max → provider-max`, supported list includes `provider-max` | `{ "effort": "provider-max", "summary": "auto" }` / `["reasoning.encrypted_content"]` |
    | Grok 4.5 `off`, `off: null` clamped to `low` | `{ "effort": "low", "summary": "auto" }` / `["reasoning.encrypted_content"]` |

  - All fourteen arms verify one fetch call, `POST`, exact endpoint (`/chat/completions` or `/responses`), and the expected model id (`custom-reasoner` for proof arms; `grok-4.5` for the xAI fixture).
  - Raw non-secret outputs and probe sources were preserved during validation. SHA-256:
    ```text
    8981791d4f2eb02f0138793822222fefd31831a7d2fc9db1df5553b152f76616  completions raw output
    e6259f782ae83e820c854ff498f7e749bfda5b4a9a1eb17ec9d48496bfe844db  responses raw output
    13220754422f33e16ab6c7a2dcb85f790ed845e33465cdb296e50e562ff048fd  completions probe source
    ef1db05c446cd8fad74d5ca0e2a441dd40f9004382a2be4b37a337a7b44b07de  responses probe source
    ```
  - Full raw redacted JSON output is included below for inspectability.

<details>
<summary>Full exact-head Completions probe output</summary>

```text
{
  "exactHead": "2bdf86f08f8cee323e84465782a8845d043febf5",
  "transport": "openai-completions",
  "boundary": "configureAiTransportHost(buildModelFetch) -> real streamSimpleOpenAICompletions -> fetch Request JSON",
  "results": [
    {
      "arm": "high control",
      "request": {
        "url": "https://proof.invalid/v1/chat/completions",
        "method": "POST",
        "body": {
          "model": "custom-reasoner",
          "messages": [
            {
              "role": "user",
              "content": "proof"
            }
          ],
          "stream": true,
          "stream_options": {
            "include_usage": true
          },
          "store": false,
          "reasoning_effort": "high"
        }
      }
    },
    {
      "arm": "declared mapped xhigh",
      "request": {
        "url": "https://proof.invalid/v1/chat/completions",
        "method": "POST",
        "body": {
          "model": "custom-reasoner",
          "messages": [
            {
              "role": "user",
              "content": "proof"
            }
          ],
          "stream": true,
          "stream_options": {
            "include_usage": true
          },
          "store": false,
          "reasoning_effort": "xhigh"
        }
      }
    },
    {
      "arm": "mapped xhigh excluded from supported list",
      "request": {
        "url": "https://proof.invalid/v1/chat/completions",
        "method": "POST",
        "body": {
          "model": "custom-reasoner",
          "messages": [
            {
              "role": "user",
              "content": "proof"
            }
          ],
          "stream": true,
          "stream_options": {
            "include_usage": true
          },
          "store": false,
          "reasoning_effort": "high"
        }
      }
    },
    {
      "arm": "reasoning hard opt-out",
      "request": {
        "url": "https://proof.invalid/v1/chat/completions",
        "method": "POST",
        "body": {
          "model": "custom-reasoner",
          "messages": [
            {
              "role": "user",
              "content": "proof"
            }
          ],
          "stream": true,
          "stream_options": {
            "include_usage": true
          },
          "store": false
        }
      }
    },
    {
      "arm": "null-capped high clamps to medium",
      "request": {
        "url": "https://proof.invalid/v1/chat/completions",
        "method": "POST",
        "body": {
          "model": "custom-reasoner",
          "messages": [
            {
              "role": "user",
              "content": "proof"
            }
          ],
          "stream": true,
          "stream_options": {
            "include_usage": true
          },
          "store": false,
          "reasoning_effort": "medium"
        }
      }
    },
    {
      "arm": "Grok 4.5 off clamps to low",
      "request": {
        "url": "https://proof.invalid/v1/chat/completions",
        "method": "POST",
        "body": {
          "model": "custom-reasoner",
          "messages": [
            {
              "role": "user",
              "content": "proof"
            }
          ],
          "stream": true,
          "stream_options": {
            "include_usage": true
          },
          "store": false,
          "reasoning_effort": "low"
        }
      }
    },
    {
      "arm": "declared mapped max",
      "request": {
        "url": "https://proof.invalid/v1/chat/completions",
        "method": "POST",
        "body": {
          "model": "custom-reasoner",
          "messages": [
            {
              "role": "user",
              "content": "proof"
            }
          ],
          "stream": true,
          "stream_options": {
            "include_usage": true
          },
          "store": false,
          "reasoning_effort": "provider-max"
        }
      }
    }
  ]
}

```
</details>

<details>
<summary>Full exact-head Responses probe output</summary>

```text
{
  "exactHead": "2bdf86f08f8cee323e84465782a8845d043febf5",
  "transport": "openai-responses",
  "boundary": "configureAiTransportHost(buildModelFetch) -> real streamSimpleOpenAIResponses -> fetch Request JSON",
  "results": [
    {
      "arm": "high control",
      "request": {
        "url": "https://proof.invalid/v1/responses",
        "method": "POST",
        "body": {
          "model": "custom-reasoner",
          "input": [
            {
              "type": "message",
              "role": "user",
              "content": [
                {
                  "type": "input_text",
                  "text": "proof"
                }
              ]
            }
          ],
          "stream": true,
          "store": false,
          "reasoning": {
            "effort": "high",
            "summary": "auto"
          },
          "include": [
            "reasoning.encrypted_content"
          ]
        }
      }
    },
    {
      "arm": "declared mapped xhigh",
      "request": {
        "url": "https://proof.invalid/v1/responses",
        "method": "POST",
        "body": {
          "model": "custom-reasoner",
          "input": [
            {
              "type": "message",
              "role": "user",
              "content": [
                {
                  "type": "input_text",
                  "text": "proof"
                }
              ]
            }
          ],
          "stream": true,
          "store": false,
          "reasoning": {
            "effort": "xhigh",
            "summary": "auto"
          },
          "include": [
            "reasoning.encrypted_content"
          ]
        }
      }
    },
    {
      "arm": "mapped xhigh excluded from supported list",
      "request": {
        "url": "https://proof.invalid/v1/responses",
        "method": "POST",
        "body": {
          "model": "custom-reasoner",
          "input": [
            {
              "type": "message",
              "role": "user",
              "content": [
                {
                  "type": "input_text",
                  "text": "proof"
                }
              ]
            }
          ],
          "stream": true,
          "store": false,
          "reasoning": {
            "effort": "high",
            "summary": "auto"
          },
          "include": [
            "reasoning.encrypted_content"
          ]
        }
      }
    },
    {
      "arm": "reasoning hard opt-out",
      "request": {
        "url": "https://proof.invalid/v1/responses",
        "method": "POST",
        "body": {
          "model": "custom-reasoner",
          "input": [
            {
              "type": "message",
              "role": "user",
              "content": [
                {
                  "type": "input_text",
                  "text": "proof"
                }
              ]
            }
          ],
          "stream": true,
          "store": false
        }
      }
    },
    {
      "arm": "null-capped high clamps to medium",
      "request": {
        "url": "https://proof.invalid/v1/responses",
        "method": "POST",
        "body": {
          "model": "custom-reasoner",
          "input": [
            {
              "type": "message",
              "role": "user",
              "content": [
                {
                  "type": "input_text",
                  "text": "proof"
                }
              ]
            }
          ],
          "stream": true,
          "store": false,
          "reasoning": {
            "effort": "medium",
            "summary": "auto"
          },
          "include": [
            "reasoning.encrypted_content"
          ]
        }
      }
    },
    {
      "arm": "declared mapped max",
      "request": {
        "url": "https://proof.invalid/v1/responses",
        "method": "POST",
        "body": {
          "model": "custom-reasoner",
          "input": [
            {
              "type": "message",
              "role": "user",
              "content": [
                {
                  "type": "input_text",
                  "text": "proof"
                }
              ]
            }
          ],
          "stream": true,
          "store": false,
          "reasoning": {
            "effort": "provider-max",
            "summary": "auto"
          },
          "include": [
            "reasoning.encrypted_content"
          ]
        }
      }
    },
    {
      "arm": "Grok 4.5 off clamps to low",
      "request": {
        "url": "https://api.x.ai/v1/responses",
        "method": "POST",
        "body": {
          "model": "grok-4.5",
          "input": [
            {
              "type": "message",
              "role": "user",
              "content": [
                {
                  "type": "input_text",
                  "text": "proof"
                }
              ]
            }
          ],
          "stream": true,
          "store": false,
          "reasoning": {
            "effort": "low",
            "summary": "auto"
          },
          "include": [
            "reasoning.encrypted_content"
          ]
        }
      }
    }
  ]
}

```
</details>

<details>
<summary>Full Completions probe source (non-secret)</summary>

```ts
import assert from "node:assert/strict";
import { execFileSync } from "node:child_process";
import { configureAiTransportHost, getAiTransportHost } from "../host.js";
import type { Context, Model } from "../types.js";
import { streamSimpleOpenAICompletions } from "./openai-completions.js";

type ProofModel = Model<"openai-completions">;
type Reasoning = "high" | "max" | "off";
type CapturedRequest = { url: string; method: string; body: Record<string, unknown> };
type Arm = { name: string; reasoning: Reasoning; model: ProofModel; expectedReasoningEffort?: string };

const exactHead = execFileSync("git", ["rev-parse", "HEAD"], { encoding: "utf8" }).trim();
const context = { messages: [{ role: "user", content: "proof", timestamp: 1 }] } satisfies Context;

function model(overrides: Partial<ProofModel>): ProofModel {
  return {
    id: "custom-reasoner", name: "Custom Reasoner", api: "openai-completions",
    provider: "proof-provider", baseUrl: "https://proof.invalid/v1", reasoning: true,
    input: ["text"], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
    contextWindow: 128_000, maxTokens: 4096, ...overrides,
  } as ProofModel;
}

function streamResponse(): Response {
  const chunks = [
    { id: "chatcmpl-proof", object: "chat.completion.chunk", created: 1, model: "custom-reasoner", choices: [{ index: 0, delta: { role: "assistant", content: "ok" }, finish_reason: null }] },
    { id: "chatcmpl-proof", object: "chat.completion.chunk", created: 1, model: "custom-reasoner", choices: [{ index: 0, delta: {}, finish_reason: "stop" }], usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 } },
  ];
  const sse = `${chunks.map((chunk) => `data: ${JSON.stringify(chunk)}

`).join("")}data: [DONE]

`;
  return new Response(sse, { status: 200, headers: { "content-type": "text/event-stream" } });
}

const arms: Arm[] = [
  { name: "high control", reasoning: "high", model: model({ compat: { supportsReasoningEffort: true } }), expectedReasoningEffort: "high" },
  { name: "declared mapped xhigh", reasoning: "high", model: model({ compat: { supportsReasoningEffort: true, supportedReasoningEfforts: ["low", "medium", "high", "xhigh"], reasoningEffortMap: { high: "xhigh" } } }), expectedReasoningEffort: "xhigh" },
  { name: "mapped xhigh excluded from supported list", reasoning: "high", model: model({ compat: { supportsReasoningEffort: true, supportedReasoningEfforts: ["low", "medium", "high"], reasoningEffortMap: { high: "xhigh" } } }), expectedReasoningEffort: "high" },
  { name: "reasoning hard opt-out", reasoning: "high", model: model({ compat: { supportsReasoningEffort: false } }) },
  { name: "null-capped high clamps to medium", reasoning: "high", model: model({ compat: { supportsReasoningEffort: true }, thinkingLevelMap: { high: null } }), expectedReasoningEffort: "medium" },
  { name: "Grok 4.5 off clamps to low", reasoning: "off", model: model({ compat: { supportsReasoningEffort: true, supportedReasoningEfforts: ["low", "medium", "high"] }, thinkingLevelMap: { off: null, minimal: "low", low: "low", medium: "medium", high: "high" } }), expectedReasoningEffort: "low" },
  { name: "declared mapped max", reasoning: "max", model: model({ compat: { supportsReasoningEffort: true, supportedReasoningEfforts: ["provider-low", "provider-max"], reasoningEffortMap: { low: "provider-low", max: "provider-max" } } }), expectedReasoningEffort: "provider-max" },
];

const previousHost = getAiTransportHost();
const results: Array<{ arm: string; request: CapturedRequest }> = [];
try {
  for (const arm of arms) {
    const requests: CapturedRequest[] = [];
    const modelFetch: typeof fetch = async (input, init) => {
      const request = new Request(input, init);
      const body = (await request.clone().json()) as Record<string, unknown>;
      requests.push({ url: request.url, method: request.method, body });
      return streamResponse();
    };
    configureAiTransportHost({ buildModelFetch: () => modelFetch });
    await streamSimpleOpenAICompletions(arm.model, context, { apiKey: "sk-proof-only", reasoning: arm.reasoning, timeoutMs: 2_000, maxRetries: 0 }).result();
    assert.equal(requests.length, 1, `${arm.name}: expected exactly one fetch`);
    const request = requests[0]!;
    assert.equal(request.method, "POST", `${arm.name}: expected POST`);
    assert.equal(request.url, "https://proof.invalid/v1/chat/completions", `${arm.name}: unexpected URL`);
    assert.equal(request.body.model, "custom-reasoner", `${arm.name}: wrong model at wire boundary`);
    if (arm.expectedReasoningEffort === undefined) {
      assert.equal("reasoning_effort" in request.body, false, `${arm.name}: reasoning_effort should be absent`);
    } else {
      assert.equal(request.body.reasoning_effort, arm.expectedReasoningEffort, `${arm.name}: unexpected reasoning_effort`);
    }
    results.push({ arm: arm.name, request });
  }
} finally {
  configureAiTransportHost(previousHost);
}
console.log(JSON.stringify({ exactHead, transport: "openai-completions", boundary: "configureAiTransportHost(buildModelFetch) -> real streamSimpleOpenAICompletions -> fetch Request JSON", results }, null, 2));

```
</details>

<details>
<summary>Full Responses probe source (non-secret)</summary>

```ts
import assert from "node:assert/strict";
import { execFileSync } from "node:child_process";
import { configureAiTransportHost, getAiTransportHost } from "../host.js";
import type { Context, Model } from "../types.js";
import { streamSimpleOpenAIResponses } from "./openai-responses.js";

type ProofModel = Model<"openai-responses">;
type Reasoning = "high" | "max" | "off";
type CapturedRequest = { url: string; method: string; body: Record<string, unknown> };
type Arm = { name: string; reasoning: Reasoning; model: ProofModel; expectedEffort?: string };

const exactHead = execFileSync("git", ["rev-parse", "HEAD"], { encoding: "utf8" }).trim();
const context = { messages: [{ role: "user", content: "proof", timestamp: 1 }] } satisfies Context;

function model(overrides: Partial<ProofModel>): ProofModel {
  return {
    id: "custom-reasoner", name: "Custom Reasoner", api: "openai-responses",
    provider: "proof-provider", baseUrl: "https://proof.invalid/v1", reasoning: true,
    input: ["text"], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
    contextWindow: 128_000, maxTokens: 4096, ...overrides,
  } as ProofModel;
}

function streamResponse(): Response {
  const response = {
    id: "resp-proof", object: "response", status: "completed", model: "custom-reasoner",
    output: [{ id: "msg-proof", type: "message", role: "assistant", status: "completed", content: [{ type: "output_text", text: "ok", annotations: [] }] }],
    usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
  };
  const created = { ...response, output: [], status: "in_progress" };
  const events = [{ type: "response.created", response: created }, { type: "response.completed", response }];
  const sse = `${events.map((event) => `data: ${JSON.stringify(event)}

`).join("")}data: [DONE]

`;
  return new Response(sse, { status: 200, headers: { "content-type": "text/event-stream" } });
}

const arms: Arm[] = [
  { name: "high control", reasoning: "high", model: model({ compat: { supportsReasoningEffort: true, supportedReasoningEfforts: ["low", "medium", "high"] } }), expectedEffort: "high" },
  { name: "declared mapped xhigh", reasoning: "high", model: model({ compat: { supportsReasoningEffort: true, supportedReasoningEfforts: ["low", "medium", "high", "xhigh"], reasoningEffortMap: { high: "xhigh" } } }), expectedEffort: "xhigh" },
  { name: "mapped xhigh excluded from supported list", reasoning: "high", model: model({ compat: { supportsReasoningEffort: true, supportedReasoningEfforts: ["low", "medium", "high"], reasoningEffortMap: { high: "xhigh" } } }), expectedEffort: "high" },
  { name: "reasoning hard opt-out", reasoning: "high", model: model({ compat: { supportsReasoningEffort: false } }) },
  { name: "null-capped high clamps to medium", reasoning: "high", model: model({ compat: { supportsReasoningEffort: true }, thinkingLevelMap: { high: null } }), expectedEffort: "medium" },
  { name: "declared mapped max", reasoning: "max", model: model({ compat: { supportsReasoningEffort: true, supportedReasoningEfforts: ["provider-low", "provider-max"], reasoningEffortMap: { low: "provider-low", max: "provider-max" } } }), expectedEffort: "provider-max" },
  { name: "Grok 4.5 off clamps to low", reasoning: "off", model: model({ provider: "xai", id: "grok-4.5", baseUrl: "https://api.x.ai/v1", thinkingLevelMap: { off: null, minimal: "low", low: "low", medium: "medium", high: "high" }, compat: { supportsReasoningEffort: true, supportedReasoningEfforts: ["low", "medium", "high"] } }), expectedEffort: "low" },
];

const previousHost = getAiTransportHost();
const results: Array<{ arm: string; request: CapturedRequest }> = [];
try {
  for (const arm of arms) {
    const requests: CapturedRequest[] = [];
    const modelFetch: typeof fetch = async (input, init) => {
      const request = new Request(input, init);
      const body = (await request.clone().json()) as Record<string, unknown>;
      requests.push({ url: request.url, method: request.method, body });
      return streamResponse();
    };
    configureAiTransportHost({ buildModelFetch: () => modelFetch });
    await streamSimpleOpenAIResponses(arm.model, context, { apiKey: "sk-proof-only", reasoning: arm.reasoning, timeoutMs: 2_000, maxRetries: 0 }).result();
    assert.equal(requests.length, 1, `${arm.name}: expected exactly one fetch`);
    const request = requests[0]!;
    assert.equal(request.method, "POST", `${arm.name}: expected POST`);
    assert.equal(
      request.url,
      `${arm.model.baseUrl.replace(/\/+$/u, "")}/responses`,
      `${arm.name}: unexpected URL`,
    );
    assert.equal(request.body.model, arm.model.id, `${arm.name}: wrong model at wire boundary`);
    const reasoning = request.body.reasoning;
    if (arm.expectedEffort === undefined) {
      assert.equal("reasoning" in request.body, false, `${arm.name}: reasoning should be absent`);
      assert.equal("include" in request.body, false, `${arm.name}: include should be absent`);
    } else {
      assert.deepEqual(reasoning, { effort: arm.expectedEffort, summary: "auto" }, `${arm.name}: unexpected reasoning`);
      assert.deepEqual(request.body.include, ["reasoning.encrypted_content"], `${arm.name}: unexpected include`);
    }
    results.push({ arm: arm.name, request });
  }
} finally {
  configureAiTransportHost(previousHost);
}
console.log(JSON.stringify({ exactHead, transport: "openai-responses", boundary: "configureAiTransportHost(buildModelFetch) -> real streamSimpleOpenAIResponses -> fetch Request JSON", results }, null, 2));

```
</details>

- Observed result after fix: Compatible reasoning-level capability calculation includes `xhigh` only for explicitly supported compatible models, preserves valid provider-native mappings including `max`, falls back conservatively when a mapped effort is not supported, and keeps explicit disablement out of both transport payloads while preserving canonical null-cap clamping.
- Proof boundary and limitation: These are exact-head request-boundary fetch-interception captures using `https://proof.invalid` and a mock SSE response. They prove the source-level transports serialize the expected redacted JSON at the egress boundary; they do not claim that an external provider accepts every value. The probes were run from a dependency-complete local checkout with Node `v26.7.0`, pnpm `11.15.1`, and filtered frozen-lockfile installation. The temporary probe files were removed from the checkout afterward.
- What was not tested: The repository's delegated Blacksmith Testbox changed-file gate could not complete from this host because the Blacksmith CLI is not authenticated to an organization.
- Proof limitations or environment constraints: Blacksmith browser auth completed to a `No Organizations Found` page because this GitHub account has no organization with the Blacksmith GitHub App installed. `blacksmith auth status` reports `Not authenticated to any organization. Run 'blacksmith auth login' to get started.`
- Before evidence (optional but encouraged): The original runtime issue was that `xhigh` was not surfaced for an OpenAI-compatible reasoning model even though compat metadata mapped/supported the provider effort.

## Tests and validation

Which commands did you run?

```bash
pnpm dlx --package=oxfmt@0.60.0 oxfmt --check --threads=1 <changed files>
pnpm exec oxlint <changed files>
node scripts/run-vitest.mjs run \
  packages/ai/src/providers/openai-responses.test.ts \
  packages/ai/src/providers/openai-responses-shared.test.ts \
  packages/ai/src/providers/openai-completions.test.ts \
  packages/ai/src/providers/openai-reasoning-effort.test.ts \
  packages/ai/src/transports/openai-completions-params.reasoning.test.ts \
  --maxWorkers=1
pnpm test:extension xai
pnpm check:assertion-safety
pnpm tsgo:core
pnpm tsgo:test:src
pnpm check:changed -- <changed files>
blacksmith auth status || true
```

Results:

- `oxfmt`: passed for the changed files.
- `oxlint`: passed for the changed files with 0 warnings and 0 errors.
- Focused Vitest: passed, 6 reasoning/transport unit files / 221 tests. The xAI extension runner passed 29 files / 483 tests.
- Assertion-safety ratchet: passed.
- `pnpm tsgo:core`: passed.
- `pnpm tsgo:test:src`: passed.
- `pnpm check:changed`: blocked by Blacksmith CLI auth/org infrastructure, not by a code/test failure:

```text
[check:changed] delegating to Blacksmith Testbox via `pnpm crabbox:run`.
[crabbox] bin=../crabbox/bin/crabbox version=0.26.0-1-gc6fef7c provider=blacksmith-testbox providers=apple-container,ascii-box,aws,azure,azure-dynamic-sessions,blacksmith-testbox,cloudflare,daytona,e2b,exe-dev,gcp,hetzner,islo,local-container,modal,multipass,namespace-devbox,parallels,proxmox,railway,runpod,semaphore,sprites,ssh,tensorlake,upstash-box,wandb
Error: not authenticated — run 'blacksmith auth login' first
not authenticated — run 'blacksmith auth login' first
blacksmith testbox warmup failed: blacksmith failed: exit status 1; if the delegated queue is unavailable, rerun with a coordinator-backed provider such as --provider aws
```

`blacksmith auth status`:

```text
Not authenticated to any organization. Run 'blacksmith auth login' to get started.
```

What regression coverage was added or updated?

- Added tests for OpenAI-compatible reasoning models that explicitly support `xhigh` via `compat.supportedReasoningEfforts`.
- Added tests for conservative `compat.reasoningEffortMap` / `max` alias behavior, including map-only aliases that must not expose new extended levels.
- Added tests that reasoning models without explicit extended compat support still do not expose `xhigh`.

What failed before this fix, if known?

- Capability calculation filtered out `xhigh`/`max` for compatible reasoning models before explicit compat reasoning effort support was considered; the follow-up also prevents map-only aliases from exposing new extended levels.

If no test was added, why not?

- Tests were added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes, for explicitly configured OpenAI-compatible reasoning models only.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

- Accidentally exposing unsupported thinking levels for providers that do not really accept extended reasoning efforts.

How is that risk mitigated?

- The new behavior is gated on explicit compat support (`supportedReasoningEfforts` / `reasoningEffortMap`).
- Regression tests cover both opted-in and non-opted-in reasoning models.

## Current review state

What is the next action?

- Maintainer review. Exact-head Completions and Responses request-boundary captures are supplied for `2977d8895d`; the new CI run and automatic ClawSweeper verdict are pending. The mapped-max finding was fixed in commit `9a9f70834a`, and the Grok 4.5 `off → low` regression was fixed in `2977d8895d`; delegated local Blacksmith Testbox validation remains unavailable in this external contributor environment.

What is still waiting on author, maintainer, CI, or external proof?

- The external contributor environment cannot complete the delegated `pnpm check:changed` Blacksmith Testbox gate because Blacksmith auth has no available organization. Exact-head transport proof is supplied for both adapters, including canonical `high:null → medium` clamping and Grok 4.5 `off:null → low`. A live compatible-provider acceptance trace is not available in this environment and is not claimed. Await exact-head CI and automatic review; do not infer status from older runs.

Which bot or reviewer comments were addressed?

- ClawSweeper's mapped-max finding was addressed in commit `9a9f70834a` by preserving canonical `max` until the shared resolver applies `reasoningEffortMap.max`; the Grok 4.5 `off → low` regression was addressed in `2977d8895d`; final captures verify both behaviors.








