### PR TITLE
fix(llm): preserve streamed tool args when Responses done omits arguments

### DIFF
--- a/src/llm/providers/openai-responses-shared.test.ts
+++ b/src/llm/providers/openai-responses-shared.test.ts
@@ -1,8 +1,8 @@
 // OpenAI Responses shared tests cover tool conversion and response item mapping.
 import type { Tool as OpenAIResponsesTool } from "openai/resources/responses/responses.js";
-import { describe, expect, it } from "vitest";
-import type { Context, Model, Tool } from "../types.js";
-import { convertResponsesMessages } from "./openai-responses-shared.js";
+import { describe, expect, it, vi } from "vitest";
+import type { AssistantMessage, Context, Model, Tool } from "../types.js";
+import { convertResponsesMessages, processResponsesStream } from "./openai-responses-shared.js";
 import { convertResponsesTools } from "./openai-responses-tools.js";
 
 type ResponsesFunctionTool = Extract<OpenAIResponsesTool, { type: "function" }>;
@@ -31,6 +31,134 @@ const proxyOpenAIModel = {
   name: "Custom Model",
   baseUrl: "https://proxy.example.com/v1",
 } satisfies Model<"openai-responses">;
+
+async function* streamChunks(chunks: readonly unknown[]) {
+  for (const chunk of chunks) {
+    yield chunk;
+  }
+}
+
+function createResponsesAssistantOutput(model: Model<"openai-responses">): AssistantMessage {
+  return {
+    role: "assistant",
+    content: [],
+    api: model.api,
+    provider: model.provider,
+    model: model.id,
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: "stop",
+    timestamp: Date.now(),
+  };
+}
+
+describe("processResponsesStream", () => {
+  it("preserves streamed tool call arguments when done event omits arguments", async () => {
+    const model = proxyOpenAIModel;
+    const output = createResponsesAssistantOutput(model);
+
+    await processResponsesStream(
+      streamChunks([
+        {
+          type: "response.output_item.added",
+          item: {
+            type: "function_call",
+            id: "fc_1",
+            call_id: "call_1",
+            name: "read",
+            arguments: "",
+          },
+        },
+        { type: "response.function_call_arguments.delta", delta: '{"path":' },
+        { type: "response.function_call_arguments.delta", delta: '"/tmp/file.txt"}' },
+        { type: "response.function_call_arguments.done" },
+        {
+          type: "response.output_item.done",
+          item: {
+            type: "function_call",
+            id: "fc_1",
+            call_id: "call_1",
+            name: "read",
+          },
+        },
+        {
+          type: "response.completed",
+          response: { id: "resp_1", status: "completed" },
+        },
+      ]),
+      output,
+      { push: vi.fn() },
+      model,
+    );
+
+    expect(output.stopReason).toBe("toolUse");
+    expect(output.content).toEqual([
+      {
+        type: "toolCall",
+        id: "call_1|fc_1",
+        name: "read",
+        arguments: { path: "/tmp/file.txt" },
+      },
+    ]);
+  });
+
+  it("still applies full arguments from done events when providers include them", async () => {
+    const model = proxyOpenAIModel;
+    const output = createResponsesAssistantOutput(model);
+
+    await processResponsesStream(
+      streamChunks([
+        {
+          type: "response.output_item.added",
+          item: {
+            type: "function_call",
+            id: "fc_2",
+            call_id: "call_2",
+            name: "exec",
+            arguments: "",
+          },
+        },
+        { type: "response.function_call_arguments.delta", delta: '{"command":' },
+        {
+          type: "response.function_call_arguments.done",
+          arguments: '{"command":"echo hi"}',
+        },
+        {
+          type: "response.output_item.done",
+          item: {
+            type: "function_call",
+            id: "fc_2",
+            call_id: "call_2",
+            name: "exec",
+            arguments: '{"command":"echo hi"}',
+          },
+        },
+        {
+          type: "response.completed",
+          response: { id: "resp_2", status: "completed" },
+        },
+      ]),
+      output,
+      { push: vi.fn() },
+      model,
+    );
+
+    expect(output.content).toEqual([
+      {
+        type: "toolCall",
+        id: "call_2|fc_2",
+        name: "exec",
+        arguments: { command: "echo hi" },
+      },
+    ]);
+  });
+});
 
 describe("convertResponsesTools", () => {
   it("enables native strict OpenAI Responses tools and normalizes schemas", () => {

--- a/src/llm/providers/openai-responses-shared.ts
+++ b/src/llm/providers/openai-responses-shared.ts
@@ -667,19 +667,26 @@ export async function processResponsesStream<TApi extends Api>(
     } else if (event.type === "response.function_call_arguments.done") {
       if (currentItem?.type === "function_call" && currentBlock?.type === "toolCall") {
         const previousPartialJson = currentBlock.partialJson;
-        currentBlock.partialJson = event.arguments;
-        currentBlock.arguments = parseStreamingJson(currentBlock.partialJson);
+        const doneArguments = typeof event.arguments === "string" ? event.arguments : undefined;
 
-        if (event.arguments.startsWith(previousPartialJson)) {
-          const delta = event.arguments.slice(previousPartialJson.length);
-          if (delta.length > 0) {
-            stream.push({
-              type: "toolcall_delta",
-              contentIndex: blockIndex(),
-              delta,
-              partial: output,
-            });
+        if (doneArguments !== undefined && doneArguments.length > 0) {
+          currentBlock.partialJson = doneArguments;
+          currentBlock.arguments = parseStreamingJson(currentBlock.partialJson);
+
+          if (doneArguments.startsWith(previousPartialJson)) {
+            const delta = doneArguments.slice(previousPartialJson.length);
+            if (delta.length > 0) {
+              stream.push({
+                type: "toolcall_delta",
+                contentIndex: blockIndex(),
+                delta,
+                partial: output,
+              });
+            }
           }
+        } else {
+          // LM Studio and some proxies emit done without arguments after deltas.
+          currentBlock.arguments = parseStreamingJson(previousPartialJson);
         }
       }
     } else if (event.type === "response.output_item.done") {


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- LM Studio (and similar OpenAI Responses proxies) stream tool-call argument deltas, then emit `response.function_call_arguments.done` without a usable `arguments` string. The shared parser overwrote the buffered JSON with that empty/missing payload, so argument-bearing tools reached the executor as `{}`.

Why does this matter now?

- Issue #90585: Regression since 2026.5.27 — LM Studio-backed agents could call parameterless tools but `read`, `exec`, and other argument-bearing tools failed.

What is the intended outcome?

- Preserve streamed `partialJson` when the done event omits arguments; keep existing behavior when providers send the full arguments string on done.

What is intentionally out of scope?

- No LM Studio plugin changes, config flags, or agent-layer argument repair toggles. No changes to openai-completions or ChatGPT Responses paths.

What does success look like?

- After streamed deltas, final `toolCall.arguments` contains the parsed object (e.g. `{ path: "/tmp/file.txt" }`) even when done/output_item events omit `arguments`.

What should reviewers focus on?

- `src/llm/providers/openai-responses-shared.ts` done-handler guard
- Regression tests in `src/llm/providers/openai-responses-shared.test.ts` (LM Studio-style event sequence)

## Linked context

Which issue does this close?

Closes #90585

Which issues, PRs, or discussions are related?

- Related #90585 (reporter hot patch and ClawSweeper review with source-level repro path)

Was this requested by a maintainer or owner?

- ClawSweeper marked `clawsweeper:queueable-fix` / `clawsweeper:fix-shape-clear` with acceptance tests pointing at this file.

## Real behavior proof (required for external PRs)

- **Behavior or issue addressed:** Tool calls with arguments arriving as `{}` for LM Studio openai-responses streams.
- **Real environment tested:** Local checkout on branch `fix/issue-90585-lmstudio-tool-args`; Vitest unit harness simulating LM Studio Responses SSE event order.
- **Exact steps or command run after this patch:**
  - `node scripts/run-vitest.mjs src/llm/providers/openai-responses-shared.test.ts`
  - `node scripts/run-vitest.mjs extensions/lmstudio/src/stream.test.ts`
- **Evidence after fix:**

```json
{
  "test": "preserves streamed tool call arguments when done event omits arguments",
  "output": {
    "stopReason": "toolUse",
    "content": [
      {
        "type": "toolCall",
        "id": "call_1|fc_1",
        "name": "read",
        "arguments": { "path": "/tmp/file.txt" }
      }
    ]
  },
  "vitest": "9 passed (openai-responses-shared), 12 passed (lmstudio stream)"
}
```

- **Observed result after fix:** Streamed deltas `{"path":` + `"/tmp/file.txt"}` survive a done event with no `arguments` and finalize to `{ path: "/tmp/file.txt" }`.
- **What was not tested:** Live LM Studio model on reporter hardware; openai-responses against api.openai.com in this run.
- **Proof limitations:** Source-level regression via deterministic event fixtures; matches reporter hot patch and ClawSweeper diagnosis.
- **Before evidence (optional):** Before fix, assigning `event.arguments` (undefined/empty) to `partialJson` wiped buffered deltas; `output_item.done` then fell back to `item.arguments || "{}"` → `{}`.

## Tests and validation

Which commands did you run?

- `node scripts/run-vitest.mjs src/llm/providers/openai-responses-shared.test.ts` → 9 passed
- `node scripts/run-vitest.mjs extensions/lmstudio/src/stream.test.ts` → 12 passed

What regression coverage was added or updated?

- `processResponsesStream` test: deltas + done without arguments + output_item without arguments
- `processResponsesStream` test: done with full arguments string (existing OpenAI-style path)

What failed before this fix, if known?

- New regression test would have produced `arguments: {}` when done overwrote `partialJson`.

If no test was added, why not?

- N/A — regression tests added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

- Shared OpenAI Responses stream parser used by LM Studio, proxy routes, and other openai-responses consumers.

How is that risk mitigated?

- Narrow guard: only skip overwriting `partialJson` when done `arguments` is missing or empty; full-string done events unchanged; two focused Vitest cases.

## Current review state

What is the next action?

- Maintainer review

What is still waiting on author, maintainer, CI, or external proof?

- CI on PR; optional live LM Studio proof from reporter environment

Which bot or reviewer comments were addressed?

- Implements ClawSweeper-suggested parser repair and acceptance test targets from #90585 review comment.
