### PR TITLE
fix(OpenAI Responses): disable item id replay for storeless providers

### DIFF
--- a/src/agents/embedded-agent-runner-extraparams.test.ts
+++ b/src/agents/embedded-agent-runner-extraparams.test.ts
@@ -3079,6 +3079,59 @@ describe("applyExtraParamsToAgent", () => {
     expect(capturedOptions?.replayResponsesItemIds).toBe(true);
   });
 
+  it("keeps Responses replay item ids enabled for Azure OpenAI store-enabled requests", () => {
+    let capturedOptions:
+      | (SimpleStreamOptions & {
+          replayResponsesItemIds?: boolean;
+        })
+      | undefined;
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      capturedOptions = options;
+      return {} as ReturnType<StreamFn>;
+    };
+    const streamFn = createOpenAIResponsesContextManagementWrapper(baseStreamFn, undefined);
+
+    void streamFn(
+      {
+        api: "openai-responses",
+        provider: "azure-openai",
+        id: "gpt-5-mini",
+        baseUrl: "https://example.openai.azure.com/openai/v1",
+      } as unknown as Model<"openai-responses">,
+      { messages: [] },
+      {},
+    );
+
+    expect(capturedOptions?.replayResponsesItemIds).toBe(true);
+  });
+
+  it("does not disable replay defaults for store-capable third-party Responses routes", () => {
+    let capturedOptions:
+      | (SimpleStreamOptions & {
+          replayResponsesItemIds?: boolean;
+        })
+      | undefined;
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      capturedOptions = options;
+      return {} as ReturnType<StreamFn>;
+    };
+    const streamFn = createOpenAIResponsesContextManagementWrapper(baseStreamFn, undefined);
+
+    void streamFn(
+      {
+        api: "openai-responses",
+        provider: "custom-openai-responses",
+        id: "store-capable-model",
+        baseUrl: "https://custom.example.invalid/v1",
+        compat: { supportsStore: true },
+      } as unknown as Model<"openai-responses">,
+      { messages: [] },
+      { replayResponsesItemIds: true } as never,
+    );
+
+    expect(capturedOptions?.replayResponsesItemIds).toBe(true);
+  });
+
   it("disables Responses replay item ids when custom Responses routes strip store", () => {
     let capturedOptions:
       | (SimpleStreamOptions & {

--- a/src/agents/embedded-agent-runner-extraparams.test.ts
+++ b/src/agents/embedded-agent-runner-extraparams.test.ts
@@ -3079,6 +3079,33 @@ describe("applyExtraParamsToAgent", () => {
     expect(capturedOptions?.replayResponsesItemIds).toBe(true);
   });
 
+  it("disables Responses replay item ids when custom Responses routes strip store", () => {
+    let capturedOptions:
+      | (SimpleStreamOptions & {
+          replayResponsesItemIds?: boolean;
+        })
+      | undefined;
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      capturedOptions = options;
+      return {} as ReturnType<StreamFn>;
+    };
+    const streamFn = createOpenAIResponsesContextManagementWrapper(baseStreamFn, undefined);
+
+    void streamFn(
+      {
+        api: "openai-responses",
+        provider: "custom-openai-responses",
+        id: "gpt-5.5",
+        baseUrl: "https://custom.example.invalid/v1",
+        compat: { supportsStore: false },
+      } as unknown as Model<"openai-responses">,
+      { messages: [] },
+      {},
+    );
+
+    expect(capturedOptions?.replayResponsesItemIds).toBe(false);
+  });
+
   it("forces store=true for azure-openai provider with openai-responses API (#42800)", () => {
     const payload = runResponsesPayloadMutationCase({
       applyProvider: "azure-openai",

--- a/src/agents/embedded-agent-runner-extraparams.test.ts
+++ b/src/agents/embedded-agent-runner-extraparams.test.ts
@@ -512,6 +512,50 @@ describe("applyExtraParamsToAgent", () => {
     };
   }
 
+  type OpenAIResponsesWrapperOptions = SimpleStreamOptions & {
+    replayResponsesItemIds?: boolean;
+  };
+
+  const buildResponsesWrapperModel = (params: {
+    provider: string;
+    id: string;
+    baseUrl: string;
+    compat?: Model<"openai-responses">["compat"];
+  }): Model<"openai-responses"> => ({
+    api: "openai-responses",
+    provider: params.provider,
+    id: params.id,
+    name: params.id,
+    baseUrl: params.baseUrl,
+    reasoning: true,
+    input: ["text"],
+    cost: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+    },
+    contextWindow: 128_000,
+    maxTokens: 4096,
+    ...(params.compat ? { compat: params.compat } : {}),
+  });
+
+  const captureOpenAIResponsesWrapperReplay = (params: {
+    model: Model<"openai-responses">;
+    options?: OpenAIResponsesWrapperOptions;
+  }): boolean | undefined => {
+    let capturedOptions: OpenAIResponsesWrapperOptions | undefined;
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      capturedOptions = options;
+      return createAssistantMessageEventStream();
+    };
+    const streamFn = createOpenAIResponsesContextManagementWrapper(baseStreamFn, undefined);
+
+    void streamFn(params.model, { messages: [] }, params.options);
+
+    return capturedOptions?.replayResponsesItemIds;
+  };
+
   it("passes agentDir and workspaceDir to provider stream wrappers", () => {
     let capturedContext: WrapProviderStreamFnParams["context"] | undefined;
     extraParamsTesting.setProviderRuntimeDepsForTest({
@@ -3054,109 +3098,58 @@ describe("applyExtraParamsToAgent", () => {
   });
 
   it("keeps Responses replay item ids enabled for direct OpenAI store-enabled requests", () => {
-    let capturedOptions:
-      | (SimpleStreamOptions & {
-          replayResponsesItemIds?: boolean;
-        })
-      | undefined;
-    const baseStreamFn: StreamFn = (_model, _context, options) => {
-      capturedOptions = options;
-      return {} as ReturnType<StreamFn>;
-    };
-    const streamFn = createOpenAIResponsesContextManagementWrapper(baseStreamFn, undefined);
-
-    void streamFn(
-      {
-        api: "openai-responses",
-        provider: "openai",
-        id: "gpt-5",
-        baseUrl: "https://api.openai.com/v1",
-      } as unknown as Model<"openai-responses">,
-      { messages: [] },
-      {},
-    );
-
-    expect(capturedOptions?.replayResponsesItemIds).toBe(true);
+    expect(
+      captureOpenAIResponsesWrapperReplay({
+        model: buildResponsesWrapperModel({
+          provider: "openai",
+          id: "gpt-5",
+          baseUrl: "https://api.openai.com/v1",
+        }),
+        options: {},
+      }),
+    ).toBe(true);
   });
 
-  it("keeps Responses replay item ids enabled for Azure OpenAI store-enabled requests", () => {
-    let capturedOptions:
-      | (SimpleStreamOptions & {
-          replayResponsesItemIds?: boolean;
-        })
-      | undefined;
-    const baseStreamFn: StreamFn = (_model, _context, options) => {
-      capturedOptions = options;
-      return {} as ReturnType<StreamFn>;
-    };
-    const streamFn = createOpenAIResponsesContextManagementWrapper(baseStreamFn, undefined);
-
-    void streamFn(
-      {
-        api: "openai-responses",
+  it.each([
+    {
+      name: "Azure OpenAI store-enabled requests",
+      model: buildResponsesWrapperModel({
         provider: "azure-openai",
         id: "gpt-5-mini",
         baseUrl: "https://example.openai.azure.com/openai/v1",
-      } as unknown as Model<"openai-responses">,
-      { messages: [] },
-      {},
-    );
-
-    expect(capturedOptions?.replayResponsesItemIds).toBe(true);
-  });
-
-  it("does not disable replay defaults for store-capable third-party Responses routes", () => {
-    let capturedOptions:
-      | (SimpleStreamOptions & {
-          replayResponsesItemIds?: boolean;
-        })
-      | undefined;
-    const baseStreamFn: StreamFn = (_model, _context, options) => {
-      capturedOptions = options;
-      return {} as ReturnType<StreamFn>;
-    };
-    const streamFn = createOpenAIResponsesContextManagementWrapper(baseStreamFn, undefined);
-
-    void streamFn(
-      {
-        api: "openai-responses",
+      }),
+      options: {},
+      expectedReplay: true,
+    },
+    {
+      name: "store-capable third-party Responses routes",
+      model: buildResponsesWrapperModel({
         provider: "custom-openai-responses",
         id: "store-capable-model",
         baseUrl: "https://custom.example.invalid/v1",
         compat: { supportsStore: true },
-      } as unknown as Model<"openai-responses">,
-      { messages: [] },
-      { replayResponsesItemIds: true } as never,
-    );
-
-    expect(capturedOptions?.replayResponsesItemIds).toBe(true);
-  });
-
-  it("disables Responses replay item ids when custom Responses routes strip store", () => {
-    let capturedOptions:
-      | (SimpleStreamOptions & {
-          replayResponsesItemIds?: boolean;
-        })
-      | undefined;
-    const baseStreamFn: StreamFn = (_model, _context, options) => {
-      capturedOptions = options;
-      return {} as ReturnType<StreamFn>;
-    };
-    const streamFn = createOpenAIResponsesContextManagementWrapper(baseStreamFn, undefined);
-
-    void streamFn(
-      {
-        api: "openai-responses",
+      }),
+      options: { replayResponsesItemIds: true },
+      expectedReplay: true,
+    },
+    {
+      name: "storeless custom Responses routes",
+      model: buildResponsesWrapperModel({
         provider: "custom-openai-responses",
         id: "gpt-5.5",
         baseUrl: "https://custom.example.invalid/v1",
         compat: { supportsStore: false },
-      } as unknown as Model<"openai-responses">,
-      { messages: [] },
-      {},
-    );
-
-    expect(capturedOptions?.replayResponsesItemIds).toBe(false);
+      }),
+      options: {},
+      expectedReplay: false,
+    },
+  ] satisfies Array<{
+    name: string;
+    model: Model<"openai-responses">;
+    options: OpenAIResponsesWrapperOptions;
+    expectedReplay: boolean;
+  }>)("sets replay item ids for $name", ({ model, options, expectedReplay }) => {
+    expect(captureOpenAIResponsesWrapperReplay({ model, options })).toBe(expectedReplay);
   });
 
   it("forces store=true for azure-openai provider with openai-responses API (#42800)", () => {

--- a/src/agents/embedded-agent-runner-extraparams.test.ts
+++ b/src/agents/embedded-agent-runner-extraparams.test.ts
@@ -515,12 +515,15 @@ describe("applyExtraParamsToAgent", () => {
   type OpenAIResponsesWrapperOptions = SimpleStreamOptions & {
     replayResponsesItemIds?: boolean;
   };
+  type OpenAIResponsesWrapperCompat = NonNullable<Model<"openai-responses">["compat"]> & {
+    supportsStore?: boolean;
+  };
 
   const buildResponsesWrapperModel = (params: {
     provider: string;
     id: string;
     baseUrl: string;
-    compat?: Model<"openai-responses">["compat"];
+    compat?: OpenAIResponsesWrapperCompat;
   }): Model<"openai-responses"> => ({
     api: "openai-responses",
     provider: params.provider,

--- a/src/agents/openai-responses.reasoning-replay.test.ts
+++ b/src/agents/openai-responses.reasoning-replay.test.ts
@@ -20,6 +20,17 @@ function buildModel(): Model<"openai-responses"> {
   };
 }
 
+function buildStorelessCustomModel(): Model<"openai-responses"> {
+  return {
+    ...buildModel(),
+    provider: "custom-openai-responses",
+    baseUrl: "https://custom.example.invalid/v1",
+    compat: {
+      supportsStore: false,
+    } as never,
+  };
+}
+
 function extractInput(payload: Record<string, unknown> | undefined) {
   return Array.isArray(payload?.input) ? payload.input : [];
 }
@@ -88,6 +99,8 @@ async function runAbortedOpenAIResponsesStream(params: {
     parameters: ReturnType<typeof Type.Object>;
   }>;
   replayResponsesItemIds?: boolean;
+  usePolicyReplayDefault?: boolean;
+  model?: Model<"openai-responses">;
 }) {
   // Abort after payload capture so tests inspect serialization without network I/O.
   const controller = new AbortController();
@@ -95,7 +108,7 @@ async function runAbortedOpenAIResponsesStream(params: {
   let payload: Record<string, unknown> | undefined;
 
   const responseStream = stream(
-    buildModel(),
+    params.model ?? buildModel(),
     {
       systemPrompt: "system",
       messages: params.messages,
@@ -103,7 +116,9 @@ async function runAbortedOpenAIResponsesStream(params: {
     },
     {
       apiKey: "test",
-      replayResponsesItemIds: params.replayResponsesItemIds ?? true,
+      ...(params.usePolicyReplayDefault
+        ? {}
+        : { replayResponsesItemIds: params.replayResponsesItemIds ?? true }),
       signal: controller.signal,
       onPayload: (nextPayload: unknown) => {
         payload = nextPayload as Record<string, unknown>;
@@ -120,6 +135,83 @@ async function runAbortedOpenAIResponsesStream(params: {
 }
 
 describe("openai-responses reasoning replay", () => {
+  it("omits Responses item ids for storeless custom providers while preserving tool call ids", async () => {
+    const assistantToolOnly = buildAssistantMessage({
+      stopReason: "toolUse",
+      content: [
+        buildReasoningPart("rs_storeless"),
+        {
+          type: "text",
+          text: "Checking.",
+          textSignature: JSON.stringify({ v: 1, id: "msg_storeless", phase: "final_answer" }),
+        },
+        {
+          type: "toolCall",
+          id: "call_storeless|fc_storeless",
+          name: "noop",
+          arguments: {},
+        },
+      ],
+    });
+
+    const toolResult: ToolResultMessage = {
+      role: "toolResult",
+      toolCallId: "call_storeless|fc_storeless",
+      toolName: "noop",
+      content: [{ type: "text", text: "ok" }],
+      isError: false,
+      timestamp: Date.now(),
+    };
+
+    const { input, types } = await runAbortedOpenAIResponsesStream({
+      model: buildStorelessCustomModel(),
+      usePolicyReplayDefault: true,
+      messages: [
+        { role: "user", content: "Call noop.", timestamp: Date.now() },
+        assistantToolOnly,
+        toolResult,
+        { role: "user", content: "Now reply with ok.", timestamp: Date.now() },
+      ],
+      tools: [
+        {
+          name: "noop",
+          description: "no-op",
+          parameters: Type.Object({}, { additionalProperties: false }),
+        },
+      ],
+    });
+
+    expect(types).toContain("message");
+    expect(types).toContain("function_call");
+    expect(types).toContain("function_call_output");
+
+    const replayedItemIds = input.filter(
+      (item): item is Record<string, unknown> =>
+        Boolean(item) &&
+        typeof item === "object" &&
+        ["reasoning", "message", "function_call"].includes(
+          String((item as Record<string, unknown>).type),
+        ) &&
+        typeof (item as Record<string, unknown>).id === "string",
+    );
+    expect(replayedItemIds).toEqual([]);
+
+    const functionCall = input.find(
+      (item) =>
+        item &&
+        typeof item === "object" &&
+        (item as Record<string, unknown>).type === "function_call",
+    ) as Record<string, unknown> | undefined;
+    const functionCallOutput = input.find(
+      (item) =>
+        item &&
+        typeof item === "object" &&
+        (item as Record<string, unknown>).type === "function_call_output",
+    ) as Record<string, unknown> | undefined;
+    expect(functionCall?.call_id).toBeTruthy();
+    expect(functionCallOutput?.call_id).toBe(functionCall?.call_id);
+  });
+
   it("replays reasoning for tool-call-only turns (OpenAI requires it)", async () => {
     const assistantToolOnly = buildAssistantMessage({
       stopReason: "toolUse",

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -3517,6 +3517,104 @@ describe("openai transport stream", () => {
     });
   });
 
+  it("preserves Responses replay item ids for store-capable third-party opt-in routes", () => {
+    const params = buildOpenAIResponsesParams(
+      {
+        id: "store-capable-model",
+        name: "Store-capable model",
+        api: "openai-responses",
+        provider: "custom-openai-responses",
+        baseUrl: "https://custom.example.com/v1",
+        compat: { supportsStore: true } as never,
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } satisfies Model<"openai-responses">,
+      {
+        systemPrompt: "system",
+        messages: [
+          {
+            role: "assistant",
+            api: "openai-responses",
+            provider: "custom-openai-responses",
+            model: "store-capable-model",
+            usage: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 0,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+            },
+            stopReason: "toolUse",
+            timestamp: 1,
+            content: [
+              {
+                type: "thinking",
+                thinking: "Need a tool.",
+                thinkingSignature: JSON.stringify({
+                  type: "reasoning",
+                  id: "rs_prior",
+                  summary: [],
+                }),
+              },
+              {
+                type: "text",
+                text: "Checking the price.",
+                textSignature: JSON.stringify({
+                  v: 1,
+                  id: "msg_prior",
+                  phase: "commentary",
+                }),
+              },
+              {
+                type: "toolCall",
+                id: "call_abc|fc_prior",
+                name: "price_lookup",
+                arguments: { symbol: "SOL" },
+              },
+            ],
+          },
+        ],
+        tools: [],
+      } as never,
+      { replayResponsesItemIds: true, sessionId: "session-123" },
+    ) as {
+      input?: Array<{
+        type?: string;
+        role?: string;
+        id?: string;
+        call_id?: string;
+        phase?: string;
+        summary?: unknown;
+      }>;
+    };
+
+    const reasoningItem = params.input?.find((item) => item.type === "reasoning");
+    expectRecordFields(reasoningItem, {
+      type: "reasoning",
+      id: "rs_prior",
+      summary: [],
+    });
+    const assistantMessage = params.input?.find(
+      (item) => item.type === "message" && item.role === "assistant",
+    );
+    expectRecordFields(assistantMessage, {
+      type: "message",
+      role: "assistant",
+      id: "msg_prior",
+      phase: "commentary",
+    });
+    const functionCall = params.input?.find((item) => item.type === "function_call");
+    expectRecordFields(functionCall, {
+      type: "function_call",
+      id: "fc_prior",
+      call_id: "call_abc",
+    });
+  });
+
   it("omits prior Responses replay item ids when store is disabled for custom Codex-compatible responses", () => {
     const model = {
       id: "gpt-5.4",

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -2205,7 +2205,8 @@ export function buildOpenAIResponsesParams(
   const payloadPolicy = resolveOpenAIResponsesPayloadPolicy(model, {
     storeMode: "disable",
   });
-  const policyAllowsReplayIds = payloadPolicy.explicitStore !== false;
+  const policyAllowsReplayIds =
+    payloadPolicy.explicitStore !== false && !payloadPolicy.shouldStripStore;
   const replayResponsesItemIds =
     !isNativeCodexResponses && (options?.replayResponsesItemIds ?? policyAllowsReplayIds);
   const messages = convertResponsesMessages(

--- a/src/llm/providers/stream-wrappers/openai.ts
+++ b/src/llm/providers/stream-wrappers/openai.ts
@@ -397,12 +397,10 @@ export function createOpenAIResponsesContextManagementWrapper(
     }
 
     const originalOnPayload = options?.onPayload;
+    const effectiveStore = policy.shouldStripStore ? false : policy.explicitStore;
     const replayResponsesItemIds =
-      policy.explicitStore === true
-        ? true
-        : policy.explicitStore === false || policy.shouldStripStore
-          ? false
-          : (options as OpenAIResponsesReplayOptions | undefined)?.replayResponsesItemIds;
+      effectiveStore ??
+      (options as OpenAIResponsesReplayOptions | undefined)?.replayResponsesItemIds;
     const nextOptions: OpenAIResponsesReplayOptions = {
       ...options,
       ...(replayResponsesItemIds === undefined ? {} : { replayResponsesItemIds }),

--- a/src/llm/providers/stream-wrappers/openai.ts
+++ b/src/llm/providers/stream-wrappers/openai.ts
@@ -398,9 +398,11 @@ export function createOpenAIResponsesContextManagementWrapper(
 
     const originalOnPayload = options?.onPayload;
     const replayResponsesItemIds =
-      policy.explicitStore === undefined
-        ? (options as OpenAIResponsesReplayOptions | undefined)?.replayResponsesItemIds
-        : policy.explicitStore;
+      policy.explicitStore === true
+        ? true
+        : policy.explicitStore === false || policy.shouldStripStore
+          ? false
+          : (options as OpenAIResponsesReplayOptions | undefined)?.replayResponsesItemIds;
     const nextOptions: OpenAIResponsesReplayOptions = {
       ...options,
       ...(replayResponsesItemIds === undefined ? {} : { replayResponsesItemIds }),


### PR DESCRIPTION
## Summary

Fixes #89728.
Supersedes duplicate PR #89729.
Refs #90657 as the narrow storeless Responses replay lane from the Actions-backed tracking matrix.

Custom OpenAI Responses-compatible providers can have effective Responses `store` support stripped (`compat.supportsStore=false`). In that storeless mode, replaying prior Responses item ids is unsafe because the provider cannot resolve server-stored items from prior turns.

This PR was refreshed from latest `openclaw/openclaw:main` and now consolidates the useful coverage from both open duplicate PRs:

- #90706 direct Responses builder fix/test.
- #89729 OpenAI Responses context-management wrapper fix/test.

## Latest main check

Latest `main` checked: `66b91d78feb3`.

Current `main` is still incomplete for this bug class:

- Direct builder still computes replay eligibility with only `payloadPolicy.explicitStore !== false`.
- Context-management wrapper still passes through an undefined `replayResponsesItemIds` value when `policy.shouldStripStore === true`.
- For custom `openai-responses` models with `compat.supportsStore=false`, payload policy resolves to:

```text
explicitStore === undefined
shouldStripStore === true
```

That means current `main` can still replay prior Responses item ids on a route where store support was stripped.

## Root cause

The previous guard only checked whether `store` had been explicitly disabled:

```ts
payloadPolicy.explicitStore !== false
```

For custom providers that strip store support via compatibility policy, `explicitStore` remains `undefined`, so the old guard treats replay as safe even though the effective payload is storeless.

The same issue existed in the provider-owned context-management wrapper: it preserved an undefined replay option instead of forcing replay off when `policy.shouldStripStore` was true.

## Changes

- Disable Responses item-id replay when the resolved payload policy strips `store`.
- Apply the same storeless replay gate in the OpenAI Responses context-management wrapper.
- Add a stream-level regression test for a custom `openai-responses` model with `compat.supportsStore=false`.
- Add a wrapper regression test proving custom store-stripped Responses routes pass `replayResponsesItemIds: false` to the underlying stream.
- Preserve existing store-enabled OpenAI Responses replay behavior.

## Compatibility contract

This PR treats `compat.supportsStore=false` as a storeless Responses route. For that route OpenClaw must not replay server-side Responses item ids (`reasoning.id`, assistant `message.id`, or `function_call.id`) because the backend cannot resolve prior stored response items. Stateless tool linking remains valid through `call_id` and `function_call_output.call_id`.

Store-enabled direct OpenAI Responses behavior is unchanged. Provider-owned wrappers can still explicitly opt back in for known exceptions that support storeless encrypted reasoning replay, such as the existing Microsoft Foundry override.

Rollback: revert the two replay-gate changes in `src/agents/openai-transport-stream.ts` and `src/llm/providers/stream-wrappers/openai.ts`; tests added in this PR document the expected storeless contract.

## Compatibility regression matrix

This patch now has explicit regression coverage that the storeless fix does not break previously valid official or third-party routes:

- Official OpenAI Responses store-enabled route: context wrapper still sets `replayResponsesItemIds: true`.
- Azure OpenAI Responses store-enabled route: context wrapper still sets `replayResponsesItemIds: true`.
- Store-capable third-party Responses route with explicit opt-in: replay item ids are preserved.
- Storeless custom Responses route with `compat.supportsStore=false`: replay item ids are disabled.
- Microsoft Foundry provider-owned override: existing extension test still confirms Foundry encrypted reasoning continuations keep `replayResponsesItemIds: true` despite `supportsStore=false`.

Focused validation added after the compatibility matrix:

```text
node scripts/run-vitest.mjs run src/agents/embedded-agent-runner-extraparams.test.ts
# 139 tests passed

node scripts/run-vitest.mjs run src/agents/openai-transport-stream.test.ts
# 243 tests passed

node scripts/run-vitest.mjs run extensions/microsoft-foundry/index.test.ts
# 43 tests passed

pnpm exec oxlint src/agents/openai-transport-stream.test.ts src/agents/embedded-agent-runner-extraparams.test.ts extensions/microsoft-foundry/index.test.ts
# 0 warnings, 0 errors
```

## Real behavior proof

Behavior addressed: Storeless custom `openai-responses` providers must not receive replayed prior Responses item ids. The user-visible failure class is provider-side continuation/tool-turn failure when a custom-compatible provider cannot resolve prior item ids that were never stored server-side.

Real environment tested: Latest local OpenClaw checkout on Linux, reset to `openclaw/openclaw:main` at `66b91d78feb3`, then patched from new branch head `bfea37e66676`. The before/after proof uses the production `createOpenAIResponsesTransportStreamFn()` path against a local HTTP Responses-compatible endpoint that rejects replayed server item ids but accepts stateless `call_id` pairing.

Exact steps or command run after this patch: reverse only the two production replay-gate hunks, run `node --import tsx ../live-storeless-before-after-proof.mjs BEFORE`, restore the patch, then run `node --import tsx ../live-storeless-before-after-proof.mjs AFTER`. Supplemental checks: `node scripts/run-vitest.mjs run src/agents/openai-responses.reasoning-replay.test.ts src/agents/embedded-agent-runner-extraparams.test.ts` and `pnpm exec oxlint src/agents/openai-transport-stream.ts src/llm/providers/stream-wrappers/openai.ts src/agents/openai-responses.reasoning-replay.test.ts src/agents/embedded-agent-runner-extraparams.test.ts`.

Evidence after fix: The real before/after stream invocation captured the following outbound requests/results from the production transport path:

```text
=== BEFORE current-main-equivalent without storeless replay gate ===
BEFORE_CAPTURE request_path=/responses
BEFORE_CAPTURE store_present=false
BEFORE_CAPTURE replay_items=[{"type":"message","role":"system"},{"type":"message","role":"user"},{"type":"reasoning","id":"rs_prior"},{"type":"message","id":"msg_prior","role":"assistant"},{"type":"function_call","id":"fc_prior","call_id":"call_live"},{"type":"message","role":"user"}]
BEFORE_CAPTURE tool_output_call_id="call_live"
BEFORE_RESULT unsafe_replayed_ids=3
BEFORE_RESULT call_id_preserved=true
BEFORE_BACKEND accepts_payload=false
[openai-transport] [responses] error provider=openai api=openai-responses model=gpt-5.5 name=Error status=400 code=undefined type=undefined causeName=undefined causeCode=undefined message=400 storeless backend rejected replayed Responses item ids
BEFORE_STREAM stop_reason=error
BEFORE_STREAM text=""
BEFORE_SUMMARY rejected_before_or_accepted_after=true
=== AFTER patched head bfea37e66676 with storeless replay gate ===
AFTER_CAPTURE request_path=/responses
AFTER_CAPTURE store_present=false
AFTER_CAPTURE replay_items=[{"type":"message","role":"system"},{"type":"message","role":"user"},{"type":"reasoning"},{"type":"message","role":"assistant"},{"type":"function_call","call_id":"call_live"},{"type":"message","role":"user"}]
AFTER_CAPTURE tool_output_call_id="call_live"
AFTER_RESULT unsafe_replayed_ids=0
AFTER_RESULT call_id_preserved=true
AFTER_BACKEND accepts_payload=true
AFTER_STREAM stop_reason=stop
AFTER_STREAM text="ok"
AFTER_SUMMARY rejected_before_or_accepted_after=true
```

Supplemental focused Vitest passed 2 shards: `openai-responses.reasoning-replay.test.ts` passed 10 tests, including the storeless custom provider replay regression; `embedded-agent-runner-extraparams.test.ts` passed 137 tests, including the context-management wrapper regression. `oxlint` reported 0 warnings and 0 errors on touched source/test files.

Observed result after fix: The current-main-equivalent path sent three unsafe replayed item ids (`rs_prior`, `msg_prior`, `fc_prior`) and the storeless backend rejected the payload with HTTP 400. The patched head sent zero unsafe replayed ids, preserved `call_id` pairing, and the same backend accepted the payload and completed the stream with text `ok`.

What was not tested: No external third-party custom Responses provider was called; the live proof used a local Responses-compatible endpoint to capture the actual OpenClaw outbound request without exposing credentials or relying on a vendor account. Repository-wide GitHub Actions CI is green for the refreshed branch, and the latest `Real behavior proof` check is passing.

## Duplicate PR handling

PR #89729 covers the same issue but was based on an older branch and is now superseded. This PR is the canonical refreshed branch from latest `main` and includes both the direct builder and wrapper fixes.




