### PR TITLE
fix(vertex): retry pre-stream transport failures

### DIFF
--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -887,6 +887,94 @@ describe("google transport stream", () => {
     expect(new Headers(guardedInit.headers).has("x-goog-api-key")).toBe(false);
   });
 
+  it("retries retryable Google Vertex pre-stream HTTP failures before parsing SSE", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-google-vertex-stream-retry-"));
+    vi.stubEnv("GOOGLE_APPLICATION_CREDENTIALS", "");
+    vi.stubEnv("HOME", path.join(tempDir, "home"));
+    vi.stubEnv("APPDATA", "");
+    vi.stubEnv("GOOGLE_CLOUD_PROJECT", "vertex-project");
+    vi.stubEnv("GOOGLE_CLOUD_LOCATION", "us-central1");
+    vi.stubEnv("OPENCLAW_GOOGLE_VERTEX_STREAM_RETRY_BASE_DELAY_MS", "0");
+    vi.stubEnv("OPENCLAW_GOOGLE_VERTEX_STREAM_RETRY_MAX_DELAY_MS", "0");
+    googleAuthGetAccessTokenMock.mockResolvedValueOnce("ya29.retry-token");
+    guardedFetchMock
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: { message: "temporarily unavailable" } }), {
+          status: 503,
+          headers: { "content-type": "application/json", "retry-after": "0" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ error: { message: "quota exceeded", status: "RESOURCE_EXHAUSTED" } }),
+          { status: 429, headers: { "content-type": "application/json" } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        buildSseResponse([
+          {
+            candidates: [{ content: { parts: [{ text: "recovered" }] }, finishReason: "STOP" }],
+          },
+        ]),
+      );
+
+    const streamFn = createGoogleVertexTransportStreamFn();
+    const stream = await Promise.resolve(
+      streamFn(
+        buildGoogleVertexModel(),
+        {
+          messages: [{ role: "user", content: "hello", timestamp: 0 }],
+        } as Parameters<typeof streamFn>[1],
+        {
+          apiKey: "gcp-vertex-credentials",
+        } as Parameters<typeof streamFn>[2],
+      ),
+    );
+    const result = await stream.result();
+
+    expect(guardedFetchMock).toHaveBeenCalledTimes(3);
+    expect(result.stopReason).toBe("stop");
+    expect(result.content).toEqual([{ type: "text", text: "recovered" }]);
+  });
+
+  it("does not retry Google Vertex stream errors after an SSE chunk arrives", async () => {
+    const tempDir = await mkdtemp(
+      path.join(os.tmpdir(), "openclaw-google-vertex-partial-stream-error-"),
+    );
+    vi.stubEnv("GOOGLE_APPLICATION_CREDENTIALS", "");
+    vi.stubEnv("HOME", path.join(tempDir, "home"));
+    vi.stubEnv("APPDATA", "");
+    vi.stubEnv("GOOGLE_CLOUD_PROJECT", "vertex-project");
+    vi.stubEnv("GOOGLE_CLOUD_LOCATION", "us-central1");
+    vi.stubEnv("OPENCLAW_GOOGLE_VERTEX_STREAM_RETRY_BASE_DELAY_MS", "0");
+    vi.stubEnv("OPENCLAW_GOOGLE_VERTEX_STREAM_RETRY_MAX_DELAY_MS", "0");
+    googleAuthGetAccessTokenMock.mockResolvedValueOnce("ya29.partial-token");
+    guardedFetchMock.mockResolvedValueOnce(
+      buildRawSseResponse(
+        'data: {"candidates":[{"content":{"parts":[{"text":"partial"}]}}]}\n\ndata: {bad json\n\n',
+      ),
+    );
+
+    const streamFn = createGoogleVertexTransportStreamFn();
+    const stream = await Promise.resolve(
+      streamFn(
+        buildGoogleVertexModel(),
+        {
+          messages: [{ role: "user", content: "hello", timestamp: 0 }],
+        } as Parameters<typeof streamFn>[1],
+        {
+          apiKey: "gcp-vertex-credentials",
+        } as Parameters<typeof streamFn>[2],
+      ),
+    );
+    const result = await stream.result();
+
+    expect(guardedFetchMock).toHaveBeenCalledTimes(1);
+    expect(result.stopReason).toBe("error");
+    expect(result.errorMessage).toBe("Google SSE stream returned malformed JSON");
+    expect(result.content).toEqual([{ type: "text", text: "partial" }]);
+  });
+
   it("refreshes authorized_user ADC before Google Vertex requests", async () => {
     const tempDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-google-vertex-adc-"));
     const credentialsPath = path.join(tempDir, "application_default_credentials.json");
@@ -953,6 +1041,85 @@ describe("google transport stream", () => {
     });
     expect(result.api).toBe("google-vertex");
     expect(result.provider).toBe("google-vertex");
+    expect(result.stopReason).toBe("stop");
+    expect(result.content).toEqual([{ type: "text", text: "ok" }]);
+  });
+
+  it("clears cached Vertex ADC tokens and retries once after unauthenticated responses", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-google-vertex-adc-401-"));
+    const credentialsPath = path.join(tempDir, "application_default_credentials.json");
+    await writeFile(
+      credentialsPath,
+      JSON.stringify({
+        type: "authorized_user",
+        client_id: "client-id",
+        client_secret: "client-secret",
+        refresh_token: "refresh-token",
+      }),
+      "utf8",
+    );
+    vi.stubEnv("GOOGLE_APPLICATION_CREDENTIALS", credentialsPath);
+    vi.stubEnv("GOOGLE_CLOUD_PROJECT", "vertex-project");
+    vi.stubEnv("GOOGLE_CLOUD_LOCATION", "global");
+    const tokenFetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ access_token: "ya29.stale-token", expires_in: 3600 }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ access_token: "ya29.fresh-token", expires_in: 3600 }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+    guardedFetchMock
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            error: {
+              message: "Request had invalid authentication credentials.",
+              status: "UNAUTHENTICATED",
+            },
+          }),
+          { status: 401, headers: { "content-type": "application/json" } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        buildSseResponse([
+          {
+            candidates: [{ content: { parts: [{ text: "ok" }] }, finishReason: "STOP" }],
+          },
+        ]),
+      );
+
+    const streamFn = createGoogleVertexTransportStreamFn();
+    const stream = await Promise.resolve(
+      streamFn(
+        buildGoogleVertexModel(),
+        {
+          messages: [{ role: "user", content: "hello", timestamp: 0 }],
+        } as Parameters<typeof streamFn>[1],
+        {
+          apiKey: "gcp-vertex-credentials",
+          fetch: tokenFetchMock,
+        } as Parameters<typeof streamFn>[2],
+      ),
+    );
+    const result = await stream.result();
+
+    expect(tokenFetchMock).toHaveBeenCalledTimes(2);
+    expect(guardedFetchMock).toHaveBeenCalledTimes(2);
+    expectHeaders(
+      requireRequestInit(requireMockCall(guardedFetchMock, 0, "guarded fetch"), "guarded fetch"),
+      { Authorization: "Bearer ya29.stale-token" },
+    );
+    expectHeaders(
+      requireRequestInit(requireMockCall(guardedFetchMock, 1, "guarded fetch"), "guarded fetch"),
+      { Authorization: "Bearer ya29.fresh-token" },
+    );
     expect(result.stopReason).toBe("stop");
     expect(result.content).toEqual([{ type: "text", text: "ok" }]);
   });

--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -39,6 +39,7 @@ import {
   type GoogleThinkingLevel,
 } from "./thinking-api.js";
 import {
+  clearGoogleVertexAdcTokenCache,
   isGoogleVertexCredentialsMarker,
   resolveGoogleVertexAuthorizedUserHeaders,
 } from "./vertex-adc.js";
@@ -82,6 +83,13 @@ type GoogleGenerateContentRequest = {
 
 const GOOGLE_GEMINI3_FIRST_RESPONSE_RETRY_DEFAULT_MS = 45_000;
 const GOOGLE_GEMINI3_FIRST_RESPONSE_RETRY_ENV = "OPENCLAW_GOOGLE_GEMINI_FIRST_RESPONSE_RETRY_MS";
+const GOOGLE_VERTEX_STREAM_MAX_RETRIES_DEFAULT = 2;
+const GOOGLE_VERTEX_STREAM_RETRY_BASE_DELAY_DEFAULT_MS = 250;
+const GOOGLE_VERTEX_STREAM_RETRY_MAX_DELAY_DEFAULT_MS = 2_000;
+const GOOGLE_VERTEX_STREAM_MAX_RETRIES_ENV = "OPENCLAW_GOOGLE_VERTEX_STREAM_MAX_RETRIES";
+const GOOGLE_VERTEX_STREAM_RETRY_BASE_DELAY_ENV =
+  "OPENCLAW_GOOGLE_VERTEX_STREAM_RETRY_BASE_DELAY_MS";
+const GOOGLE_VERTEX_STREAM_RETRY_MAX_DELAY_ENV = "OPENCLAW_GOOGLE_VERTEX_STREAM_RETRY_MAX_DELAY_MS";
 
 type GoogleTransportContentBlock =
   | { type: "text"; text: string; textSignature?: string }
@@ -820,6 +828,110 @@ export function resolveGoogleGemini3FirstResponseRetryMs(env = process.env): num
   return parseStrictNonNegativeInteger(raw) ?? GOOGLE_GEMINI3_FIRST_RESPONSE_RETRY_DEFAULT_MS;
 }
 
+function resolveGoogleVertexStreamRetryInteger(params: {
+  env: NodeJS.ProcessEnv;
+  name: string;
+  defaultValue: number;
+}): number {
+  const raw = params.env[params.name];
+  if (raw === undefined || raw.trim() === "") {
+    return params.defaultValue;
+  }
+  return parseStrictNonNegativeInteger(raw) ?? params.defaultValue;
+}
+
+function resolveGoogleVertexStreamRetryConfig(env = process.env): {
+  maxRetries: number;
+  baseDelayMs: number;
+  maxDelayMs: number;
+} {
+  const maxRetries = resolveGoogleVertexStreamRetryInteger({
+    env,
+    name: GOOGLE_VERTEX_STREAM_MAX_RETRIES_ENV,
+    defaultValue: GOOGLE_VERTEX_STREAM_MAX_RETRIES_DEFAULT,
+  });
+  const baseDelayMs = resolveGoogleVertexStreamRetryInteger({
+    env,
+    name: GOOGLE_VERTEX_STREAM_RETRY_BASE_DELAY_ENV,
+    defaultValue: GOOGLE_VERTEX_STREAM_RETRY_BASE_DELAY_DEFAULT_MS,
+  });
+  const rawMaxDelayMs = resolveGoogleVertexStreamRetryInteger({
+    env,
+    name: GOOGLE_VERTEX_STREAM_RETRY_MAX_DELAY_ENV,
+    defaultValue: GOOGLE_VERTEX_STREAM_RETRY_MAX_DELAY_DEFAULT_MS,
+  });
+  return {
+    maxRetries,
+    baseDelayMs,
+    maxDelayMs: Math.max(baseDelayMs, rawMaxDelayMs),
+  };
+}
+
+function parseGoogleVertexRetryAfterMs(value: string | null): number | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  if (/^\d+$/.test(trimmed)) {
+    return Number.parseInt(trimmed, 10) * 1_000;
+  }
+  const timestampMs = Date.parse(trimmed);
+  if (!Number.isFinite(timestampMs)) {
+    return undefined;
+  }
+  return Math.max(0, timestampMs - Date.now());
+}
+
+function resolveGoogleVertexStreamRetryDelayMs(params: {
+  response: Response;
+  retryIndex: number;
+  baseDelayMs: number;
+  maxDelayMs: number;
+}): number {
+  const retryAfterMs = parseGoogleVertexRetryAfterMs(params.response.headers.get("retry-after"));
+  if (retryAfterMs !== undefined) {
+    return retryAfterMs;
+  }
+  const exponentialDelayMs = params.baseDelayMs * 2 ** Math.max(params.retryIndex - 1, 0);
+  const jitterMs = exponentialDelayMs * 0.25 * Math.random();
+  return Math.min(params.maxDelayMs, Math.round(exponentialDelayMs + jitterMs));
+}
+
+function isRetryableGoogleVertexPreStreamResponse(response: Response): boolean {
+  return response.status === 429 || response.status === 503;
+}
+
+async function sleepGoogleVertexStreamRetry(ms: number, signal?: AbortSignal): Promise<void> {
+  if (ms <= 0) {
+    return;
+  }
+  await new Promise<void>((resolve, reject) => {
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    const abort = () => {
+      if (timeout) {
+        clearTimeout(timeout);
+        timeout = undefined;
+      }
+      signal?.removeEventListener("abort", abort);
+      reject(new Error("aborted", { cause: signal?.reason }));
+    };
+    if (signal?.aborted) {
+      abort();
+      return;
+    }
+    signal?.addEventListener("abort", abort, { once: true });
+    timeout = setTimeout(() => {
+      timeout = undefined;
+      signal?.removeEventListener("abort", abort);
+      resolve();
+    }, ms);
+    timeout.unref?.();
+  });
+}
+
 function shouldRetryGoogleGemini3FirstResponse(params: {
   kind: CanonicalGoogleTransportApi;
   model: GoogleTransportModel;
@@ -994,6 +1106,51 @@ async function openGoogleSseAttempt(params: {
   }
 }
 
+async function fetchGooglePreStreamResponse(params: {
+  kind: CanonicalGoogleTransportApi;
+  guardedFetch: ReturnType<typeof buildGuardedModelFetch>;
+  url: string;
+  headers: Record<string, string>;
+  request: GoogleGenerateContentRequest;
+  signal?: AbortSignal;
+  errorPrefix: string;
+}): Promise<Response> {
+  const retryConfig =
+    params.kind === "google-vertex" ? resolveGoogleVertexStreamRetryConfig() : undefined;
+  const maxRetries = retryConfig?.maxRetries ?? 0;
+  let retryIndex = 0;
+
+  for (;;) {
+    const response = await params.guardedFetch(params.url, {
+      method: "POST",
+      headers: params.headers,
+      body: JSON.stringify(params.request),
+      signal: params.signal,
+    });
+    if (response.ok) {
+      return response;
+    }
+    if (
+      params.kind !== "google-vertex" ||
+      retryIndex >= maxRetries ||
+      !isRetryableGoogleVertexPreStreamResponse(response) ||
+      params.signal?.aborted
+    ) {
+      throw await createProviderHttpError(response, params.errorPrefix);
+    }
+
+    retryIndex += 1;
+    const delayMs = resolveGoogleVertexStreamRetryDelayMs({
+      response,
+      retryIndex,
+      baseDelayMs: retryConfig?.baseDelayMs ?? GOOGLE_VERTEX_STREAM_RETRY_BASE_DELAY_DEFAULT_MS,
+      maxDelayMs: retryConfig?.maxDelayMs ?? GOOGLE_VERTEX_STREAM_RETRY_MAX_DELAY_DEFAULT_MS,
+    });
+    await response.body?.cancel().catch(() => undefined);
+    await sleepGoogleVertexStreamRetry(delayMs, params.signal);
+  }
+}
+
 async function openGoogleSseChunks(params: {
   kind: CanonicalGoogleTransportApi;
   model: GoogleTransportModel;
@@ -1008,15 +1165,15 @@ async function openGoogleSseChunks(params: {
       ? "Google Vertex AI API error"
       : "Google Generative AI API error";
   if (!shouldRetryGoogleGemini3FirstResponse({ kind: params.kind, model: params.model })) {
-    const response = await params.guardedFetch(params.url, {
-      method: "POST",
+    const response = await fetchGooglePreStreamResponse({
+      kind: params.kind,
+      guardedFetch: params.guardedFetch,
+      url: params.url,
       headers: params.headers,
-      body: JSON.stringify(params.request),
+      request: params.request,
       signal: params.options?.signal,
+      errorPrefix,
     });
-    if (!response.ok) {
-      throw await createProviderHttpError(response, errorPrefix);
-    }
     return {
       type: "ready",
       chunks: parseGoogleSseChunks(response, params.options?.signal),
@@ -1032,15 +1189,15 @@ async function openGoogleSseChunks(params: {
         })
       : undefined;
   if (!retryRequest) {
-    const response = await params.guardedFetch(params.url, {
-      method: "POST",
+    const response = await fetchGooglePreStreamResponse({
+      kind: params.kind,
+      guardedFetch: params.guardedFetch,
+      url: params.url,
       headers: params.headers,
-      body: JSON.stringify(params.request),
+      request: params.request,
       signal: params.options?.signal,
+      errorPrefix,
     });
-    if (!response.ok) {
-      throw await createProviderHttpError(response, errorPrefix);
-    }
     return {
       type: "ready",
       chunks: parseGoogleSseChunks(response, params.options?.signal),
@@ -1090,6 +1247,39 @@ async function buildGoogleTransportHeaders(params: {
         params.fetchImpl,
       )
     : buildGoogleHeaders(params.model, params.apiKey, params.optionHeaders);
+}
+
+function isGoogleVertexUnauthenticatedError(error: unknown): boolean {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+  const record = error as {
+    status?: unknown;
+    statusCode?: unknown;
+    code?: unknown;
+    errorCode?: unknown;
+    message?: unknown;
+  };
+  const status = typeof record.status === "number" ? record.status : record.statusCode;
+  if (status !== 401) {
+    return false;
+  }
+  const code = normalizeLowercaseStringOrEmpty(
+    typeof record.errorCode === "string"
+      ? record.errorCode
+      : typeof record.code === "string"
+        ? record.code
+        : undefined,
+  );
+  const message = normalizeLowercaseStringOrEmpty(
+    typeof record.message === "string" ? record.message : undefined,
+  );
+  return (
+    code.includes("unauthenticated") ||
+    message.includes("unauthenticated") ||
+    message.includes("invalid authentication credentials") ||
+    message.includes("invalid auth credentials")
+  );
 }
 
 async function* parseGoogleSseChunks(
@@ -1222,22 +1412,50 @@ function createGoogleTransportStreamFn(kind: CanonicalGoogleTransportApi): Strea
           params = nextParams as GoogleGenerateContentRequest;
         }
         const requestUrl = buildGoogleTransportRequestUrl(kind, model, options);
-        const requestHeaders = await buildGoogleTransportHeaders({
+        let requestHeaders = await buildGoogleTransportHeaders({
           kind,
           model,
           apiKey,
           optionHeaders: options?.headers,
           fetchImpl: (options as { fetch?: typeof fetch } | undefined)?.fetch,
         });
-        const sse = await openGoogleSseChunks({
-          kind,
-          model,
-          options,
-          guardedFetch,
-          url: requestUrl,
-          headers: requestHeaders,
-          request: params,
-        });
+        let sse: Extract<GoogleSseAttempt, { type: "ready" }>;
+        try {
+          sse = await openGoogleSseChunks({
+            kind,
+            model,
+            options,
+            guardedFetch,
+            url: requestUrl,
+            headers: requestHeaders,
+            request: params,
+          });
+        } catch (error) {
+          if (
+            kind !== "google-vertex" ||
+            !isGoogleVertexCredentialsMarker(apiKey) ||
+            !isGoogleVertexUnauthenticatedError(error)
+          ) {
+            throw error;
+          }
+          clearGoogleVertexAdcTokenCache();
+          requestHeaders = await buildGoogleTransportHeaders({
+            kind,
+            model,
+            apiKey,
+            optionHeaders: options?.headers,
+            fetchImpl: (options as { fetch?: typeof fetch } | undefined)?.fetch,
+          });
+          sse = await openGoogleSseChunks({
+            kind,
+            model,
+            options,
+            guardedFetch,
+            url: requestUrl,
+            headers: requestHeaders,
+            request: params,
+          });
+        }
         stream.push({ type: "start", partial: output as never });
         let currentBlockIndex = -1;
         const chunks =

--- a/extensions/google/vertex-adc.ts
+++ b/extensions/google/vertex-adc.ts
@@ -81,10 +81,14 @@ function resolveGoogleAuthLibraryTokenExpiresAtMs(nowRaw = Date.now()): number |
     : resolveExpiresAtMsFromDurationMs(GOOGLE_VERTEX_AUTHLIB_TOKEN_CACHE_MS, { nowMs });
 }
 
-export function resetGoogleVertexAuthorizedUserTokenCacheForTest(): void {
+export function clearGoogleVertexAdcTokenCache(): void {
   cachedGoogleVertexAuthorizedUserToken = undefined;
   cachedGoogleAuthClient = undefined;
   cachedGoogleVertexAdcToken = undefined;
+}
+
+export function resetGoogleVertexAuthorizedUserTokenCacheForTest(): void {
+  clearGoogleVertexAdcTokenCache();
 }
 
 export function isGoogleVertexCredentialsMarker(


### PR DESCRIPTION
## Summary
- Retry Google Vertex HTTP 429/503 responses before the first SSE chunk, with exponential backoff, jitter, and `Retry-After` support.
- Clear cached ADC / GoogleAuth token state on Vertex 401 unauthenticated responses and retry once with fresh credentials.
- Add regression coverage for pre-stream retry, no retry after streamed output starts, and ADC token refresh.

## Validation
- `node scripts/run-vitest.mjs run extensions/google/transport-stream.test.ts` (64 passed)

## Deployment notes
Deploy this transport change before Stem fallback rendering. After deploy, monitor Vertex 429/401 counts, retry successes, fallback attempts, and final surfaced failures.

Made with [Cursor](https://cursor.com)



## Real behavior proof

Behavior or issue addressed: Google Vertex streaming requests retry HTTP 429/503 only before SSE parsing begins, and Vertex 401 unauthenticated responses clear cached ADC/GoogleAuth token state before one retry with fresh credentials.

Real environment tested: Hydrated local OpenClaw checkout rebased on current `origin/main` with this PR applied: `/Users/damianfinol/Documents/Code/openclaw-vertex-transport-reliability`.

Exact steps or command run after this patch:
1. `pnpm install --frozen-lockfile`
2. `node scripts/run-vitest.mjs run extensions/google/transport-stream.test.ts`
3. Reviewed the implementation path to confirm the HTTP retry wrapper returns a `Response` before `parseGoogleSseChunks(...)`, so streamed chunks are never replayed.

Evidence after fix:
```text
$ node scripts/run-vitest.mjs run extensions/google/transport-stream.test.ts
[test] starting test/vitest/vitest.extension-providers.config.ts
RUN  v4.1.7 /Users/damianfinol/Documents/Code/openclaw-vertex-transport-reliability
Test Files  1 passed (1)
Tests  64 passed (64)
[test] passed 1 Vitest shard in 7.48s
```

Observed result after fix: The focused run verifies 503 then 429 pre-stream responses recover on the third fetch with content `recovered`; malformed SSE after a first `partial` chunk makes exactly one fetch and returns partial content with `stopReason=error`; and a 401 unauthenticated response causes two token fetches and two guarded Vertex fetches, first with `Bearer ya29.stale-token`, then with `Bearer ya29.fresh-token`. No secrets or real token values are logged.

What was not tested: I did not force real Vertex 429/503/401 responses against production credentials from this environment. Post-deploy runtime verification should monitor Vertex `429`, `401`, retry success, fallback attempts, and final surfaced failures; specifically confirm rate-limit logs no longer end in `next=none` without a pre-stream retry attempt.
