### PR TITLE
fix(agents): re-probe single-provider primary during cooldown

### DIFF
--- a/src/agents/model-fallback.probe.test.ts
+++ b/src/agents/model-fallback.probe.test.ts
@@ -356,6 +356,44 @@ describe("runWithModelFallback – probe logic", () => {
     await expectPrimarySkippedAfterLongCooldown("billing");
   });
 
+  it("re-probes a single-provider primary blocked by a far-future subscription_limit (#90702)", () => {
+    // fallbacks:[] + a multi-day subscription_limit reset must still re-probe on
+    // the throttle instead of suspending until blockedUntil literally arrives,
+    // since the rolling cap usually recovers earlier. Multi-fallback setups keep
+    // preferring the fallback chain (covered above).
+    const sixDays = 6 * 24 * 60 * 60 * 1000;
+    const usageStats = {
+      "openai-profile-1": {
+        blockedUntil: NOW + sixDays,
+        blockedReason: "subscription_limit",
+        blockedSource: "wham",
+      },
+    } satisfies AuthProfileStore["usageStats"];
+
+    expect(
+      resolveOpenAiCooldownDecision({
+        reason: "rate_limit",
+        soonest: NOW + sixDays,
+        hasFallbackCandidates: false,
+        usageStats,
+      }),
+    ).toEqual({ type: "attempt", reason: "rate_limit", markProbe: true });
+
+    // The 30s probe throttle is still honored so recovery probing cannot hammer
+    // the upstream: a recent probe on the same key suspends until the slot opens.
+    probeThrottleInternals.lastProbeAttempt.set("recent-openai", NOW - 10_000);
+    expectOpenAiProbeSuspension(
+      resolveOpenAiCooldownDecision({
+        reason: "rate_limit",
+        soonest: NOW + sixDays,
+        hasFallbackCandidates: false,
+        throttleKey: "recent-openai",
+        usageStats,
+      }),
+      "rate_limit",
+    );
+  });
+
   it("decides when cooldowned primary probes are allowed", () => {
     expect(
       resolveOpenAiCooldownDecision({
@@ -670,7 +708,7 @@ describe("runWithModelFallback – probe logic", () => {
     }
   });
 
-  it("single candidate skips with rate_limit and exhausts candidates", async () => {
+  it("re-probes a single-provider rate-limited primary instead of suspending", async () => {
     const cfg = makeCfg({
       agents: {
         defaults: {
@@ -682,22 +720,26 @@ describe("runWithModelFallback – probe logic", () => {
       },
     } as Partial<OpenClawConfig>);
 
-    const almostExpired = NOW + 30 * 1000;
-    mockedGetSoonestCooldownExpiry.mockReturnValue(almostExpired);
+    // Far-future cooldown with no fallback chain: the primary must still be
+    // probed so a recovered rolling cap resumes work instead of staying silent
+    // until blockedUntil arrives. See #90702.
+    mockedGetSoonestCooldownExpiry.mockReturnValue(NOW + 6 * 24 * 60 * 60 * 1000);
 
-    const run = vi.fn().mockResolvedValue("unreachable");
+    const run = vi.fn().mockResolvedValue("probed-ok");
 
-    await expect(
-      runWithModelFallback({
-        cfg,
-        provider: "openai",
-        model: "gpt-4.1-mini",
-        fallbacksOverride: [],
-        run,
-      }),
-    ).rejects.toThrow("All models failed");
+    const result = await runWithModelFallback({
+      cfg,
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      fallbacksOverride: [],
+      run,
+    });
 
-    expect(run).not.toHaveBeenCalled();
+    expect(result.result).toBe("probed-ok");
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(run).toHaveBeenCalledWith("openai", "gpt-4.1-mini", {
+      allowTransientCooldownProbe: true,
+    });
   });
 
   it("scopes probe throttling by agentDir to avoid cross-agent suppression", () => {

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -1060,12 +1060,22 @@ function shouldProbePrimaryDuringCooldown(params: {
   profileIds: string[];
   model: string;
 }): boolean {
-  if (!params.isPrimary || !params.hasFallbackCandidates) {
+  if (!params.isPrimary) {
     return false;
   }
 
   if (!isProbeThrottleOpen(params.now, params.throttleKey)) {
     return false;
+  }
+
+  // A single-provider primary has no fallback chain to prefer, so every open
+  // throttle slot is a recovery probe: "is the primary callable yet?" is a
+  // recovery question independent of fallback configuration. Without this, a
+  // fallbacks:[] setup that hits a rate/subscription cap stays suspended until
+  // the provider-reported reset (which can be days out) even though the rolling
+  // cap usually recovers earlier. See #90702.
+  if (!params.hasFallbackCandidates) {
+    return true;
   }
 
   const soonest = params.authRuntime.getSoonestCooldownExpiry(params.authStore, params.profileIds, {
@@ -1163,15 +1173,11 @@ function resolveCooldownDecision(params: {
   }
 
   // Billing is semi-persistent: the user may fix their balance, or a transient
-  // 402 might have been misclassified. Probe single-provider setups on the
-  // standard throttle so they can recover without a restart; when fallbacks
-  // exist, only probe near cooldown expiry so the fallback chain stays preferred.
+  // 402 might have been misclassified. shouldProbe already re-probes
+  // single-provider setups on the throttle (no fallback chain to prefer) and
+  // multi-fallback setups near cooldown expiry, so both recover without a restart.
   if (inferredReason === "billing") {
-    const shouldProbeSingleProviderBilling =
-      params.isPrimary &&
-      !params.hasFallbackCandidates &&
-      isProbeThrottleOpen(params.now, params.probeThrottleKey);
-    if (params.isPrimary && (shouldProbe || shouldProbeSingleProviderBilling)) {
+    if (params.isPrimary && shouldProbe) {
       return { type: "attempt", reason: inferredReason, markProbe: true };
     }
     return {


### PR DESCRIPTION
## Summary

Fixes #90702

When `fallbacks: []`, a rate/subscription-limited primary stayed suspended until the provider-reported `blockedUntil` timestamp literally arrived — which can be days out for subscription caps (e.g. "Next reset in 6 days"). The root cause: `shouldProbePrimaryDuringCooldown` returned `false` on `!hasFallbackCandidates` before checking any recovery condition, so a single-provider agent went silent for days even after the rolling cap recovered.

### What changed

- **Split the early-return guard** in `shouldProbePrimaryDuringCooldown` (`src/agents/model-fallback.ts`): a non-primary candidate still returns `false` immediately, but a single-provider primary (`!hasFallbackCandidates`) now returns `true` (probe allowed) while the 30-second throttle slot is open. A single-provider primary has no fallback chain to prefer, so "is the primary callable yet?" is a recovery question independent of fallback configuration.
- **Simplified the billing branch** in `resolveCooldownDecision`: removed the duplicated single-provider probe check (`shouldProbeSingleProviderBilling`); the unified `shouldProbe` now covers single-provider recovery for all reasons including billing. Net: one fewer special-case branch.
- **Updated the existing case** that asserted the primary was never invoked with `fallbacks: []` + rate-limit cooldown — it now expects the primary to be probed and succeed.
- **Added a regression case** proving a far-future `subscription_limit` block with `fallbacks: []` yields a probe attempt rather than `suspend_lanes`, while the 30-second probe throttle is still honored.

Multi-fallback setups are unchanged: they keep preferring the fallback chain and only probe the primary near cooldown expiry.

## Verification

Focused suites (`src/agents/model-fallback.probe.test.ts` 14, `model-fallback.test.ts` 76, `auth-profiles.cooldown-auto-expiry.test.ts` 6) pass; `tsgo -p tsconfig.core.json` exits 0; `oxfmt --check` clean. These are supplemental to the runtime proof below.

## Real behavior proof

**Behavior addressed**: With a single configured provider (`fallbacks: []`) whose only auth profile carries a far-future `subscription_limit` block, the model-fallback layer now re-probes the primary and serves the recovered call, instead of suspending lanes until `blockedUntil`.

**Real environment tested**: Local OpenClaw runtime, Node 22.22.2, isolated `OPENCLAW_HOME`, driving the production `runWithModelFallback` path. A real on-disk auth-profile store was seeded with the exact reported state (`blockedUntil = now + 6 days`, `blockedReason: "subscription_limit"`, `blockedSource: "wham"`, `fallbacks: []`); the real auth runtime loaded it (`isProfileInCooldown(openai:acct-123)=true`).

**Exact steps or command run after this patch**: on the fixed branch, `OPENCLAW_HOME=$(mktemp -d) node --import tsx repro-90702.mts`; then for contrast `git checkout origin/main -- src/agents/model-fallback.ts` and rerun, then `git checkout HEAD -- src/agents/model-fallback.ts`.

**Evidence after fix**: console output / redacted runtime log captured from the local `node` OpenClaw runtime on the fixed branch — the primary is probed and serves the call:

```
[model-fallback/decision] decision=probe_cooldown_candidate requested=openai/gpt-4.1-mini candidate=openai/gpt-4.1-mini reason=rate_limit next=none
>>> upstream invoked: openai/gpt-4.1-mini (rolling cap recovered) -> OK
[model-fallback/decision] decision=candidate_succeeded requested=openai/gpt-4.1-mini candidate=openai/gpt-4.1-mini next=none
>>> runWithModelFallback result = "RECOVERED-OK"
```

Same seeded state on current `main` (before the change) — the primary is never called, matching the reporter's logs:

```
[model-fallback/decision] decision=skip_candidate requested=openai/gpt-4.1-mini candidate=openai/gpt-4.1-mini reason=rate_limit next=none detail=Provider openai is in cooldown (suspending lanes)
FallbackSummaryError: All models failed (1): openai/gpt-4.1-mini: Provider openai is in cooldown (suspending lanes) (rate_limit)
```

**Observed result after fix**: the cooldown decision flips from `skip_candidate` / `suspend_lanes` (the bug: indefinite silence and `All models failed`) to `probe_cooldown_candidate`; the primary is actually invoked and the recovered rolling cap resumes serving (`RECOVERED-OK`). The 30-second probe throttle is still honored, so recovery probing cannot hammer the upstream.

**What was not tested**: a fully live OAuth/WHAM run against a real ChatGPT subscription in a hard-capped state. The decision pipeline and auth-profile cooldown reads exercised here are the production code paths; only the auth-profile store contents were seeded to reproduce the reported block.
