### PR TITLE
fix(tui): show loading feedback for model selector

### DIFF
--- a/src/tui/tui-pty-harness.e2e.test.ts
+++ b/src/tui/tui-pty-harness.e2e.test.ts
@@ -83,6 +83,7 @@ async function writeTuiPtyFixtureScript(dir: string) {
 
       const actionLogPath = process.env.OPENCLAW_TUI_PTY_LOG_PATH;
       const gatewayStatus = process.env.OPENCLAW_TUI_PTY_GATEWAY_STATUS ?? "fixture gateway ok";
+      const modelListDelayMs = process.env.OPENCLAW_TUI_PTY_SLOW_MODELS === "true" ? 750 : 0;
       const xaiLimitError = '403 {"code":"The caller does not have permission to execute the specified operation","error":"Your team team-redacted has either used all available credits or reached its monthly spending limit. To continue making API requests, please purchase more credits or raise your spending limit."}';
       let currentModel = "fixture-provider/fixture-model";
       let fastMode = process.env.OPENCLAW_TUI_PTY_FAST_MODE === "true";
@@ -287,6 +288,10 @@ async function writeTuiPtyFixtureScript(dir: string) {
         }
 
         async listModels() {
+          record("listModels");
+          if (modelListDelayMs > 0) {
+            await new Promise((resolve) => setTimeout(resolve, modelListDelayMs));
+          }
           return [
             { id: "fixture-provider/fixture-model", name: "Fixture", provider: "fixture-provider" },
             { id: "fixture-provider/fixture-model-2", name: "Fixture 2", provider: "fixture-provider" },
@@ -484,6 +489,26 @@ describe.sequential("TUI PTY harness", () => {
       await fixture.waitForLogEntry((entry) => entry.method === "getGatewayStatus");
     },
     TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "renders /models loading feedback before a slow model list resolves",
+    async () => {
+      const slowFixture = await startTuiFixture({
+        env: { OPENCLAW_TUI_PTY_SLOW_MODELS: "true" },
+      });
+      try {
+        await slowFixture.run.waitForOutput("local ready", STARTUP_TIMEOUT_MS);
+        await slowFixture.run.write("/models\r", { delay: false });
+        await slowFixture.waitForLogEntry((entry) => entry.method === "listModels");
+        await slowFixture.run.waitForOutput("loading models", 500);
+        await slowFixture.run.waitForOutput("fixture-provider/fixture-model-2", OUTPUT_TIMEOUT_MS);
+      } finally {
+        slowFixture.run.dispose();
+        await slowFixture.cleanup();
+      }
+    },
+    STARTUP_TEST_TIMEOUT_MS,
   );
 
   it(

--- a/src/tui/tui-pty-local.e2e.test.ts
+++ b/src/tui/tui-pty-local.e2e.test.ts
@@ -287,6 +287,22 @@ describe("TUI PTY local mode", () => {
   });
 
   it(
+    "renders model loading feedback in local mode",
+    async () => {
+      const fixture = await startLocalModeTui();
+      try {
+        await fixture.run.waitForOutput("local ready", LOCAL_STARTUP_TIMEOUT_MS);
+        await fixture.run.write("/models\r", { delay: false });
+        await fixture.run.waitForOutput("loading models...");
+        await fixture.run.waitForOutput("tui-pty-mock/gpt-5.5");
+      } finally {
+        await fixture.cleanup();
+      }
+    },
+    LOCAL_TEST_TIMEOUT_MS,
+  );
+
+  it(
     "drives the real local backend with a mocked model endpoint",
     async () => {
       const fixture = await startLocalModeTui();


### PR DESCRIPTION
## Summary

- Show immediate TUI loading feedback when `/models` or empty `/model` starts model listing.
- Request a render before awaiting `client.listModels()` so slow model catalog/auth/provider work no longer looks like a frozen command.
- Add focused unit and PTY regression coverage: one verifies the command handler renders before `listModels()` resolves; the other starts the real TUI terminal loop and delays model listing.

Closes #90720.
Refs #90722, which was reviewed as a duplicate of #90720.

## Root cause

`openModelSelector()` awaited `client.listModels()` before any visible acknowledgement:

```ts
const models = await client.listModels();
```

The selector overlay and render request happened only after that promise resolved. When listing was slow, the TUI had no activity status, overlay, or system message to show the user that `/models` was still working.

## Fix

The model selector path now:

1. sets `loading models` immediately;
2. requests a render before awaiting the backend model list;
3. clears the status to `idle` after a successful model list result;
4. marks `error` if model listing fails.

This stays scoped to TUI feedback. It does not change model resolution, model catalog filtering, auth discovery, provider routing, or session patching behavior.

## Real behavior proof

Behavior addressed: `/models` should acknowledge slow model listing immediately instead of leaving the TUI with no visible feedback while `client.listModels()` is pending.

Real environment tested: Local Linux OpenClaw source checkout on this PR branch, plus GitHub-hosted Ubuntu Actions for the before-fix reproducer and PR validation. No production OpenClaw state, user credentials, or live provider keys were used.

Exact steps or command run after this patch:

```sh
node scripts/run-vitest.mjs run --config test/vitest/vitest.tui.config.ts src/tui/tui-command-handlers.test.ts
OPENCLAW_TUI_PTY_INCLUDE_LOCAL=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts src/tui/tui-pty-harness.e2e.test.ts
pnpm check:test-types
pnpm exec oxfmt --check src/tui/tui-command-handlers.ts src/tui/tui-command-handlers.test.ts src/tui/tui-pty-harness.e2e.test.ts
git diff --check
```

Evidence after fix:

Before-fix GitHub Actions proof on current `main` plus a test-only reproduction commit:

- Branch: `snowzlm/openclaw:analysis/tui-models-command-latency-repro`
- Commit: `0ca6b55b34bde817f69dc9950a05b97b51793d6e`
- Run: https://github.com/snowzlm/openclaw/actions/runs/27029248002
- Job: https://github.com/snowzlm/openclaw/actions/runs/27029248002/job/79777124966
- Result: failure, expected on current `main` plus the focused reproducer.

Key before-fix failure:

```text
src/tui/tui-command-handlers.test.ts (53 tests | 1 failed)
× renders model loading feedback before listModels resolves
AssertionError: expected "vi.fn()" to be called with arguments: [ 'loading models' ]
Number of calls: 0
```

After-fix local evidence from this branch:

```text
src/tui/tui-command-handlers.test.ts (53 tests) passed
src/tui/tui-pty-harness.e2e.test.ts (14 tests) passed
✓ renders /models loading feedback before a slow model list resolves
pnpm check:test-types passed
oxfmt --check passed
git diff --check passed
```

The PTY proof starts the TUI terminal loop, makes the fixture backend delay `listModels()` by 750ms, types `/models`, waits for the backend to receive `listModels`, and verifies the terminal output contains `loading models` before the selector list is available.

Observed result after fix: After the patch, `/models` immediately renders `loading models` while model listing is pending, then proceeds to the selector when models arrive. The regression that failed on current `main` now passes, and the PTY proof confirms the visible terminal behavior rather than only the unit-level handler call.

What was not tested: I did not run a production gateway or live provider catalog with real credentials. This change is intentionally limited to TUI feedback around an existing async call; live provider discovery, auth, model routing, and session patch semantics are unchanged.

GitHub Actions after-fix proof: Real behavior proof passed on PR #90725 at https://github.com/openclaw/openclaw/actions/runs/27030336703/job/79780796023. The PR check rollup also shows `tui-pty`, `checks-node-core-ui`, `check-test-types`, `check-lint`, security high checks, `security-fast`, and `actionlint` passing on head `4f12eea9007712a7210507a05133af77b617544d`.

## Risk

Low. The patch only adds status/render feedback around an existing async model-list operation. The selector contents and model selection behavior are unchanged.

Potential UI nuance: successful listing clears the status to `idle` just before opening the selector overlay, so the status line does not remain stuck on `loading models` while the selector is visible.
