### PR TITLE
fix(memory): refresh rebuilt index handles

### DIFF
--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -529,6 +529,76 @@ describe("memory index", () => {
     }
   });
 
+  it("reopens a stale handle after another manager atomically rebuilds missing metadata", async () => {
+    vi.stubEnv("OPENCLAW_TEST_MEMORY_UNSAFE_REINDEX", "0");
+    const dbPath = path.join(workspaceDir, "index-missing-meta-external-rebuild.sqlite");
+    const cfg = createCfg({
+      storePath: dbPath,
+      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
+    });
+    const liveManager = await getFreshManager(cfg);
+    try {
+      await liveManager.sync({ reason: "test", force: true });
+      (
+        liveManager as unknown as {
+          db: { exec: (sql: string) => void };
+        }
+      ).db.exec(`DELETE FROM meta WHERE key = 'memory_index_meta_v1'`);
+
+      expect(liveManager.status().custom?.indexIdentity).toEqual({
+        status: "missing",
+        reason: "index metadata is missing",
+      });
+
+      const cliManager = await getFreshManager(cfg, "cli");
+      try {
+        await cliManager.sync({ reason: "cli", force: true });
+        expect(cliManager.status().custom?.indexIdentity).toEqual({ status: "valid" });
+      } finally {
+        await cliManager.close?.();
+      }
+
+      expect(liveManager.status().custom?.indexIdentity).toEqual({ status: "valid" });
+      const results = await liveManager.search("alpha");
+
+      expect(results[0]?.path).toContain("memory/2026-01-12.md");
+    } finally {
+      await liveManager.close?.();
+    }
+  });
+
+  it("reopens a stale handle after another manager atomically rebuilds valid metadata", async () => {
+    vi.stubEnv("OPENCLAW_TEST_MEMORY_UNSAFE_REINDEX", "0");
+    const dbPath = path.join(workspaceDir, "index-valid-meta-external-rebuild.sqlite");
+    const cfg = createCfg({
+      storePath: dbPath,
+      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
+    });
+    const liveManager = await getFreshManager(cfg);
+    try {
+      await liveManager.sync({ reason: "test", force: true });
+      expect(liveManager.status().custom?.indexIdentity).toEqual({ status: "valid" });
+
+      await fs.writeFile(
+        path.join(memoryDir, "2026-01-12.md"),
+        "# Log\nBeta memory line.\nZebra memory line.",
+      );
+      const cliManager = await getFreshManager(cfg, "cli");
+      try {
+        await cliManager.sync({ reason: "cli", force: true });
+        expect(cliManager.status().custom?.indexIdentity).toEqual({ status: "valid" });
+      } finally {
+        await cliManager.close?.();
+      }
+
+      const results = await liveManager.search("beta");
+
+      expect(results[0]?.snippet).toContain("Beta memory line");
+    } finally {
+      await liveManager.close?.();
+    }
+  });
+
   it("does not search stale provider rows after embeddings become unavailable", async () => {
     const dbPath = path.join(workspaceDir, "index-provider-unavailable-cutover.sqlite");
     const oldCfg = createCfg({

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -2034,6 +2034,7 @@ export abstract class MemoryManagerSyncOps {
       vectorDims: this.vector.dims,
       vectorDegradedWriteWarningShown: this.vectorDegradedWriteWarningShown,
       vectorReady: this.vectorReady,
+      lastMetaSerialized: this.lastMetaSerialized,
     };
 
     const restoreOriginalState = () => {
@@ -2049,9 +2050,11 @@ export abstract class MemoryManagerSyncOps {
       this.vector.dims = originalState.vectorDims;
       this.vectorDegradedWriteWarningShown = originalState.vectorDegradedWriteWarningShown;
       this.vectorReady = originalDbClosed ? null : originalState.vectorReady;
+      this.lastMetaSerialized = originalState.lastMetaSerialized;
     };
 
     this.db = tempDb;
+    this.lastMetaSerialized = null;
     this.resetVectorState();
     this.fts.available = false;
     this.fts.loadError = undefined;

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -1,4 +1,5 @@
 // Memory Core plugin module implements manager behavior.
+import { statSync } from "node:fs";
 import type { DatabaseSync } from "node:sqlite";
 import type { FSWatcher } from "chokidar";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
@@ -7,6 +8,7 @@ import {
   resolveAgentDir,
   resolveAgentWorkspaceDir,
   resolveMemorySearchConfig,
+  resolveUserPath,
   type OpenClawConfig,
   type ResolvedMemorySearchConfig,
 } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
@@ -70,6 +72,12 @@ const MEMORY_INDEX_MANAGER_CACHE_KEY = Symbol.for("openclaw.memoryIndexManagerCa
 export const EMBEDDING_PROBE_CACHE_TTL_MS = 30_000;
 const log = createSubsystemLogger("memory");
 type MemoryIndexManagerPurpose = "default" | "status" | "cli";
+type MemoryDatabaseIdentity = {
+  dev: number;
+  ino: number;
+  size: number;
+  mtimeMs: number;
+};
 
 const { cache: INDEX_CACHE, pending: INDEX_CACHE_PENDING } =
   resolveSingletonManagedCache<MemoryIndexManager>(MEMORY_INDEX_MANAGER_CACHE_KEY);
@@ -81,6 +89,21 @@ type EmbeddingProbeCacheEntry = {
 };
 
 const EMBEDDING_PROBE_CACHE = new Map<string, EmbeddingProbeCacheEntry>();
+
+function memoryDatabaseIdentityEquals(
+  left: MemoryDatabaseIdentity | null,
+  right: MemoryDatabaseIdentity | null,
+): boolean {
+  if (!left || !right) {
+    return left === right;
+  }
+  return (
+    left.dev === right.dev &&
+    left.ino === right.ino &&
+    left.size === right.size &&
+    left.mtimeMs === right.mtimeMs
+  );
+}
 
 export async function closeAllMemoryIndexManagers(): Promise<void> {
   EMBEDDING_PROBE_CACHE.clear();
@@ -205,6 +228,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
   private readonlyRecoverySuccesses = 0;
   private readonlyRecoveryFailures = 0;
   private readonlyRecoveryLastError?: string;
+  private dbIdentity: MemoryDatabaseIdentity | null = null;
   private indexIdentityState: MemoryIndexIdentityState = {
     status: "missing",
     reason: "index metadata is missing",
@@ -285,6 +309,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     };
     this.fts = { enabled: effectiveSettings.query.hybrid.enabled, available: false };
     this.ensureSchema();
+    this.dbIdentity = this.resolveDatabaseIdentity();
     this.vector = {
       enabled: effectiveSettings.store.vector.enabled,
       available: null,
@@ -422,7 +447,62 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     }
   }
 
+  private resolveDatabaseIdentity(): MemoryDatabaseIdentity | null {
+    try {
+      const stats = statSync(resolveUserPath(this.settings.store.path));
+      return {
+        dev: stats.dev,
+        ino: stats.ino,
+        size: stats.size,
+        mtimeMs: stats.mtimeMs,
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  private refreshDatabaseHandleIfPathChanged(): boolean {
+    if (this.closed || this.syncing !== null) {
+      return false;
+    }
+    const currentIdentity = this.resolveDatabaseIdentity();
+    if (!currentIdentity) {
+      return false;
+    }
+    if (memoryDatabaseIdentityEquals(this.dbIdentity, currentIdentity)) {
+      return false;
+    }
+
+    const previousDb = this.db;
+    const previousIdentity = this.dbIdentity;
+    let nextDb: DatabaseSync | null = null;
+    try {
+      nextDb = this.openDatabase();
+      this.db = nextDb;
+      this.dbIdentity = this.resolveDatabaseIdentity();
+      this.resetVectorState();
+      this.fts.available = false;
+      this.fts.loadError = undefined;
+      this.ensureSchema();
+      const meta = this.readMeta();
+      this.vector.dims = meta?.vectorDims;
+      closeMemoryDatabase(previousDb);
+      return true;
+    } catch (err) {
+      this.db = previousDb;
+      this.dbIdentity = previousIdentity;
+      try {
+        if (nextDb) {
+          closeMemoryDatabase(nextDb);
+        }
+      } catch {}
+      log.warn(`memory index refresh reopen failed: ${formatErrorMessage(err)}`);
+      return false;
+    }
+  }
+
   private refreshIndexIdentityDirty(params?: { providerKeyKnown?: boolean }) {
+    this.refreshDatabaseHandleIfPathChanged();
     const provider =
       this.settings.provider === "none"
         ? null
@@ -455,6 +535,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     },
   ): Promise<MemorySearchResult[]> {
     opts?.onDebug?.({ backend: "builtin" });
+    this.refreshDatabaseHandleIfPathChanged();
     let hasIndexedContent = this.hasIndexedContent();
     if (!hasIndexedContent) {
       try {
@@ -475,16 +556,6 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       return [];
     }
     const cleaned = preflight.normalizedQuery;
-    void this.warmSession(opts?.sessionKey);
-    startAsyncSearchSync({
-      enabled: this.settings.sync.onSearch,
-      dirty: this.dirty,
-      sessionsDirty: this.sessionsDirty,
-      sync: async (params) => await this.sync(params),
-      onError: (err) => {
-        log.warn(`memory sync failed (search): ${String(err)}`);
-      },
-    });
     if (preflight.shouldInitializeProvider) {
       await this.ensureProviderInitialized();
     }
@@ -509,6 +580,16 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     if (indexIdentity.status !== "valid") {
       return [];
     }
+    void this.warmSession(opts?.sessionKey);
+    startAsyncSearchSync({
+      enabled: this.settings.sync.onSearch,
+      dirty: this.dirty,
+      sessionsDirty: this.sessionsDirty,
+      sync: async (params) => await this.sync(params),
+      onError: (err) => {
+        log.warn(`memory sync failed (search): ${String(err)}`);
+      },
+    });
     const minScore = opts?.minScore ?? this.settings.query.minScore;
     const maxResults = opts?.maxResults ?? this.settings.query.maxResults;
     const searchSources =
@@ -823,8 +904,13 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       return this.syncing;
     }
     this.syncing = (async () => {
-      await this.ensureProviderInitialized();
-      await this.runSyncWithReadonlyRecovery(params);
+      try {
+        this.refreshDatabaseHandleIfPathChanged();
+        await this.ensureProviderInitialized();
+        await this.runSyncWithReadonlyRecovery(params);
+      } finally {
+        this.dbIdentity = this.resolveDatabaseIdentity();
+      }
     })().finally(() => {
       this.syncing = null;
     });
@@ -857,6 +943,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     const getDb = () => this.db;
     const setDb = (value: DatabaseSync) => {
       this.db = value;
+      this.dbIdentity = this.resolveDatabaseIdentity();
     };
     const getReadonlyRecoveryAttempts = () => this.readonlyRecoveryAttempts;
     const setReadonlyRecoveryAttempts = (value: number) => {


### PR DESCRIPTION
## Summary

- Fixes a persistent live-manager failure where the injected memory search path can keep reporting `index metadata is missing` after a separate CLI/status manager has rebuilt the durable SQLite index successfully.
- Ensures safe atomic reindex writes `memory_index_meta_v1` into the fresh temp DB even when the previous DB had the same serialized metadata cached.
- Tracks the memory DB file identity and reopens the live SQLite handle before status/search/sync when another manager has atomically swapped the index file underneath it.
- Defers search warmup and on-search background sync until provider and index identity are valid, reducing self-induced dirty-state work before a search has passed readiness checks.
- Out of scope: fully serializing searches while an active safe reindex is mid-build. That related transient guard still belongs with #90453 if maintainers want a separate in-progress reindex state.

## Linked context

Closes #90414

Related #90361
Related #90338
Related #90395
Related #90453

Requested by an affected owner/user during live troubleshooting of a local OpenClaw install.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: live injected `memory_search` / `openclaw.memory_search` could report `index metadata is missing` even though the durable disk index was healthy and CLI/fresh-manager search worked.
- Real environment tested: macOS local OpenClaw gateway, OpenClaw `2026.6.2-beta.1 (f03f57a)`, Node `v25.6.1`, builtin memory index, installed global npm runtime.
- Exact steps or command run after this patch:
  1. Applied the same manager changes locally to `/usr/local/lib/node_modules/openclaw/dist/manager-B5STWg-k.js`.
  2. Verified the patched installed bundle with `node --check /usr/local/lib/node_modules/openclaw/dist/manager-B5STWg-k.js`.
  3. Restarted the gateway with `openclaw gateway stop` and `openclaw gateway start`.
  4. Warmed the cached live gateway manager through the injected-tool dispatcher:
     `openclaw gateway call tools.invoke --json --params '{"name":"memory_search","args":{"query":"openclaw memory_search metadata","maxResults":1,"corpus":"memory"},"agentId":"main","sessionKey":"agent:main:main","idempotencyKey":"memory-pr-proof-warm-2"}' --timeout 30000`
  5. Forced an external CLI rebuild while the gateway live manager was already warmed:
     `openclaw memory index --agent main --force`
  6. Confirmed the rebuilt durable index with:
     `openclaw memory status --agent main --index --json`
  7. Invoked the gateway-injected tool again after the external rebuild:
     `openclaw gateway call tools.invoke --json --params '{"name":"memory_search","args":{"query":"openclaw memory_search metadata","maxResults":1,"corpus":"memory"},"agentId":"main","sessionKey":"agent:main:main","idempotencyKey":"memory-pr-proof-after-rebuild"}' --timeout 30000`
- Evidence after fix (redacted from real terminal output):

```text
OpenClaw 2026.6.2-beta.1 (f03f57a)
node --version: v25.6.1
Gateway version: 2026.6.2-beta.1
Runtime: running
Connectivity probe: ok
Capability: admin-capable
Listening: 127.0.0.1:18789, [::1]:18789

Warm injected gateway tool call before external rebuild:
{
  "ok": true,
  "toolName": "memory_search",
  "source": "plugin",
  "output.details.provider": "openai",
  "output.details.model": "text-embedding-3-small",
  "output.details.debug.backend": "builtin",
  "output.details.debug.hits": 1,
  "output.details.debug.searchMs": 695,
  "output.details.results[0].path": "memory/2026-06-05.md",
  "output.details.results[0].citation": "memory/2026-06-05.md#L14"
}

External rebuild:
Memory index updated (main).

Fresh CLI status after rebuild:
{
  "agentId": "main",
  "status.backend": "builtin",
  "status.files": 115,
  "status.chunks": 1806,
  "status.dirty": false,
  "status.provider": "openai",
  "status.model": "text-embedding-3-small",
  "status.vector.semanticAvailable": true,
  "status.vector.dims": 1536,
  "status.custom.indexIdentity.status": "valid",
  "embeddingProbe.ok": true
}

Injected gateway tool call after external rebuild:
{
  "ok": true,
  "toolName": "memory_search",
  "source": "plugin",
  "output.details.provider": "openai",
  "output.details.model": "text-embedding-3-small",
  "output.details.debug.backend": "builtin",
  "output.details.debug.hits": 1,
  "output.details.debug.searchMs": 1327,
  "output.details.results[0].path": "memory/2026-06-05.md",
  "output.details.results[0].citation": "memory/2026-06-05.md#L14"
}
```

- Observed result after fix: after the warmed live gateway manager and an external CLI full rebuild, the injected gateway `memory_search` tool returned `ok: true` with provider/model/debug hit details instead of `disabled=true`, `unavailable=true`, or `error="index metadata is missing"`.
- What was not tested: a live Discord message that lets an LLM choose the memory tool organically. The direct `tools.invoke` gateway path exercises the same gateway-visible injected tool dispatcher without depending on model tool-choice behavior.
- Proof limitations or environment constraints: broad repository type-aware checks are blocked in this checkout by unrelated missing optional extension deps and plugin-sdk boundary generation issues; focused memory checks pass.
- Before evidence: live troubleshooting showed the disk memory index was healthy and CLI memory search returned results, while the live injected tool still failed with `index metadata is missing` after gateway restart. One matching memory record from `2026-06-05 11:54 CDT` documents a prior live `openclaw.memory_search` call returning `disabled=true`, `unavailable=true`, `error="index metadata is missing"` while CLI status showed `indexIdentity.status=valid`, vector/FTS ready, and embedding probe OK.

## Tests and validation

Focused commands run after rebasing onto current `origin/main`:

```text
git diff --check origin/main...HEAD
node_modules/.bin/oxlint extensions/memory-core/src/memory/manager.ts extensions/memory-core/src/memory/manager-sync-ops.ts extensions/memory-core/src/memory/index.test.ts --report-unused-disable-directives-severity error --threads=1
OPENCLAW_VITEST_INCLUDE_FILE=/private/tmp/openclaw-memory-include.json node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-memory.config.ts
  Test Files  1 passed (1)
  Tests       36 passed (36)
```

Regression coverage added:

- `index.test.ts` now covers a live manager reopening after another manager atomically rebuilds an index that had missing metadata.
- `index.test.ts` also covers a live manager reopening after another manager atomically rebuilds a valid index with changed content, proving the stale handle is not kept after file replacement.

What failed before this fix:

- `runSafeReindex()` could switch to a fresh temp DB while `lastMetaSerialized` still matched the previous DB, causing `writeMeta()` to skip writing metadata into the new DB.
- A cached live manager could hold a SQLite handle to the old/unlinked DB after another manager atomically replaced `main.sqlite`, so status/search could keep seeing missing or stale metadata while disk and CLI were healthy.

## Risk checklist

Did user-visible behavior change? (`Yes/No`): Yes, memory search should recover from externally rebuilt indexes instead of staying paused on stale live manager state.

Did config, environment, or migration behavior change? (`Yes/No`): No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`): No.

What is the highest-risk area?

- Reopening the SQLite handle when the index file identity changes while the live manager is otherwise idle.

How is that risk mitigated?

- The refresh is skipped while the manager is closed or already syncing.
- The old handle is kept unless the new handle opens, schema is ensured, metadata can be read, and vector/FTS state is reset consistently.
- On failure, the code restores the previous DB handle and identity and logs a warning.
- Focused tests cover both missing-meta and valid-meta external rebuild cases.
- Real runtime proof now covers a warmed injected gateway `memory_search` call succeeding after an external CLI full rebuild.

## Current review state

What is the next action?

- Maintainer review, CI, and ClawSweeper re-review with direct injected-tool proof now added.

What is still waiting on author, maintainer, CI, or external proof?

- Waiting on maintainer/CI. A maintainer may choose whether this should also close the broader canonical #90361, or only close the persistent manager-cache report #90414.

Which bot or reviewer comments were addressed?

- Addressed ClawSweeper's P1 proof request by adding redacted real output from a gateway-injected `memory_search` call after an external CLI rebuild showing the missing-metadata error is gone.
