### PR TITLE
fix(agents): coerce non-text/image MCP tool-result blocks to text (fixes #90710)

### DIFF
--- a/src/agents/agent-bundle-mcp-materialize.ts
+++ b/src/agents/agent-bundle-mcp-materialize.ts
@@ -1,5 +1,5 @@
 import crypto from "node:crypto";
-import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { CallToolResult, ContentBlock } from "@modelcontextprotocol/sdk/types.js";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { logWarn } from "../logger.js";
@@ -19,13 +19,49 @@ import { normalizeToolParameterSchema } from "./agent-tools-parameter-schema.js"
 import type { AgentToolResult } from "./runtime/index.js";
 import type { AnyAgentTool } from "./tools/common.js";
 
+type ToolResultContentBlock = AgentToolResult<unknown>["content"][number];
+
+// AgentToolResult only carries text/image, but an MCP CallToolResult can also
+// return resource_link, resource, and audio blocks (MCP SDK ContentBlock union).
+// Coercing those into the text/image contract here keeps the boundary honest so
+// downstream provider converters never build an image block with undefined
+// data/media_type, which makes Anthropic 400 and poisons the whole session
+// history (every later turn replays the bad block and 400s too). See #90710.
+function mcpContentBlockToToolResult(block: ContentBlock): ToolResultContentBlock {
+  switch (block.type) {
+    case "text":
+      return { type: "text", text: block.text };
+    case "image":
+      // Only emit an image when the base64 source is actually present.
+      if (block.data && block.mimeType) {
+        return { type: "image", data: block.data, mimeType: block.mimeType };
+      }
+      return { type: "text", text: JSON.stringify(block) };
+    case "audio":
+      return { type: "text", text: `[audio ${block.mimeType}]` };
+    case "resource_link": {
+      const label = block.title ?? block.name;
+      return { type: "text", text: label ? `[${label}] ${block.uri}` : block.uri };
+    }
+    case "resource": {
+      const resource = block.resource;
+      const text = "text" in resource ? resource.text : undefined;
+      return { type: "text", text: text ?? resource.uri };
+    }
+    default:
+      // Forward-compat / untrusted-server guard: stringify any block type the
+      // installed MCP SDK union does not cover instead of dropping it.
+      return { type: "text", text: JSON.stringify(block) };
+  }
+}
+
 function toAgentToolResult(params: {
   serverName: string;
   toolName: string;
   result: CallToolResult;
 }): AgentToolResult<unknown> {
-  const content = Array.isArray(params.result.content)
-    ? (params.result.content as AgentToolResult<unknown>["content"])
+  const content: AgentToolResult<unknown>["content"] = Array.isArray(params.result.content)
+    ? params.result.content.map(mcpContentBlockToToolResult)
     : [];
   const structuredContentBlock =
     params.result.structuredContent !== undefined

--- a/src/agents/agent-bundle-mcp-tools.materialize.test.ts
+++ b/src/agents/agent-bundle-mcp-tools.materialize.test.ts
@@ -155,6 +155,72 @@ describe("createBundleMcpToolRuntime", () => {
     });
   });
 
+  it("coerces non-text/image MCP tool-result blocks to text (resource_link/resource/audio)", async () => {
+    // resource_link/resource/audio blocks have no base64 image source; if they
+    // leaked into the provider image branch Anthropic would 400 on an image with
+    // undefined data/media_type and poison the whole session history (#90710).
+    const runtime = await materializeBundleMcpToolsForRun({
+      runtime: makeToolRuntime({
+        result: {
+          content: [
+            { type: "text", text: "intro" },
+            {
+              type: "resource_link",
+              uri: "https://example.com/a.docx",
+              name: "a.docx",
+              title: "Quarterly report",
+            },
+            {
+              type: "resource_link",
+              uri: "https://example.com/bare",
+              name: "",
+            },
+            {
+              type: "resource",
+              resource: { uri: "memo://one", text: "memo body" },
+            },
+            {
+              type: "resource",
+              resource: { uri: "blob://two", blob: "AAAA", mimeType: "application/pdf" },
+            },
+            { type: "audio", data: "AAAA", mimeType: "audio/mpeg" },
+            { type: "image", data: "iVBOR", mimeType: "image/png" },
+          ],
+          isError: false,
+        } as CallToolResult,
+      }),
+    });
+
+    const result = await runtime.tools[0].execute("call-bundle-probe", {}, undefined, undefined);
+
+    expect(result.content).toEqual([
+      { type: "text", text: "intro" },
+      { type: "text", text: "[Quarterly report] https://example.com/a.docx" },
+      { type: "text", text: "https://example.com/bare" },
+      { type: "text", text: "memo body" },
+      { type: "text", text: "blob://two" },
+      { type: "text", text: "[audio audio/mpeg]" },
+      { type: "image", data: "iVBOR", mimeType: "image/png" },
+    ]);
+  });
+
+  it("coerces a malformed image block (missing base64 source) to text", async () => {
+    // A real-world poison case: image block with undefined data/media_type.
+    const runtime = await materializeBundleMcpToolsForRun({
+      runtime: makeToolRuntime({
+        result: {
+          content: [{ type: "image" } as unknown as CallToolResult["content"][number]],
+          isError: false,
+        } as CallToolResult,
+      }),
+    });
+
+    const result = await runtime.tools[0].execute("call-bundle-probe", {}, undefined, undefined);
+
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0]).toEqual({ type: "text", text: JSON.stringify({ type: "image" }) });
+  });
+
   it("disambiguates bundle MCP tools that collide with existing tool names", async () => {
     const runtime = await materializeBundleMcpToolsForRun({
       runtime: makeToolRuntime(),


### PR DESCRIPTION
## Summary

MCP `CallToolResult.content[]` can include `resource_link`, `resource`, and `audio` blocks (MCP SDK `ContentBlock` union), but `toAgentToolResult` in `agent-bundle-mcp-materialize.ts` cast that array straight into `AgentToolResult.content`, whose contract is only `(TextContent | ImageContent)[]`. That cast lied to the type system, so the bad blocks flowed downstream where the Anthropic provider/transport "non-text ⇒ image" branch built an `image` block with `undefined` `data`/`media_type`. Anthropic rejects that with **HTTP 400**, and because the malformed block stays in conversation history, **every subsequent turn replays it and 400s too** — the session is permanently poisoned until history is reset.

- Fix at the **materialize boundary** so the `text`/`image` contract stays honest, instead of patching each downstream provider converter. This fixes **all providers**, not just Anthropic.
- Pass through valid images unchanged; coerce `resource_link` → `[title|name] uri`, `resource` → `resource.text ?? uri`, `audio` → `[audio <mime>]`, and malformed/unknown blocks → stringified text.
- Discriminated-union handling means a future MCP SDK block type surfaces here rather than silently mis-coercing.
- Out of scope: the provider-side `convertContentBlocks` keep their honest `text|image` signatures; they no longer receive wider MCP blocks, so they are intentionally untouched.

## Linked context

Closes #90710

Reporter: @RanSHammer (clear repro + root-cause diagnosis).

## Real behavior proof (required for external PRs)

- Behavior addressed: a real MCP server returning non-text/image blocks (`resource_link` for a `.docx`, plus `resource`/`audio`) no longer leaks those blocks into the agent tool result. They are coerced to text at the materialize boundary, so the Anthropic image branch never builds an empty `image` block (no 400, no poisoned history).
- Real environment tested: ran the actual OpenClaw bundle-MCP runtime (`createBundleMcpToolRuntime` → `createSessionMcpRuntime`) against a real spawned **stdio MCP server subprocess** (MCP SDK 1.29.0 `McpServer`) over real JSON-RPC. No vitest, no mocks — production code paths, executed on both `origin/main` (before) and this branch (after). Node 22.22.2, macOS.
- Exact steps or command run after this patch: spawned a real stdio MCP server whose `get_attachment` tool returns `[text, resource_link(.docx), resource(memo), audio]`, then drove the real runtime and printed the materialized `AgentToolResult.content`:
  `node --import tsx drive.mts <repoRoot>` (driver dynamically imports `src/agents/agent-bundle-mcp-materialize.ts` from the given checkout and calls the materialized tool).
- Evidence after fix: copied live console output from the real runtime run on this branch (`f70dccf33e`):

```
=== materialized AgentToolResult.content ===
[
  { "type": "text", "text": "Here is the attachment:" },
  { "type": "text", "text": "[Quarterly report] https://mail.example.com/att/quarterly.docx" },
  { "type": "text", "text": "inline memo body" },
  { "type": "text", "text": "[audio audio/mpeg]" }
]
```

  Before (same driver + same real MCP server against unfixed `origin/main` materialize), the array carried raw non-text/image blocks — exactly what the Anthropic image branch then turns into an empty `image` source and 400s on:

```
=== materialized AgentToolResult.content ===
[
  { "type": "text", "text": "Here is the attachment:" },
  { "name": "quarterly.docx", "title": "Quarterly report",
    "uri": "https://mail.example.com/att/quarterly.docx",
    "mimeType": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
    "type": "resource_link" },
  { "type": "resource", "resource": { "uri": "memo://note", "text": "inline memo body" } },
  { "type": "audio", "data": "QUFBQQ==", "mimeType": "audio/mpeg" }
]
```

- Observed result after fix: every non-text/image block is now a text block; the valid image case (not shown above) still passes through as an `image`. The `resource_link`/`resource`/`audio` blocks that previously sat illegally inside the `(text|image)[]` array are gone, so the provider can no longer build a `data:undefined / media_type:undefined` image block.
- What was not tested: a live round-trip against the hosted Anthropic API to observe the literal HTTP 400 (no Anthropic credentials wired in this checkout). The 400 trigger is shown structurally — the before output contains the exact malformed blocks the provider's `image` branch consumes (`src/llm/providers/anthropic.ts:140`, `src/agents/anthropic-transport-stream.ts:287`).
- Proof limitations or environment constraints: ran on a local source checkout via `tsx`; the spawned MCP server is a minimal real SDK server rather than the reporter's Superhuman Mail remote MCP, but it emits the same `ContentBlock` shapes.

## Tests and validation

Which commands did you run?

- Real-runtime repro above (before/after) — production paths, real MCP subprocess.
- `node scripts/run-vitest.mjs src/agents/agent-bundle-mcp-tools.materialize.test.ts` → 13 passed (supplemental)
- `tsgo` core + test:src lanes → exit 0; `oxfmt --check` + oxlint on changed files → clean (supplemental)

What regression coverage was added or updated?

Two new cases in `agent-bundle-mcp-tools.materialize.test.ts`:
- `resource_link` / `resource` (text + blob) / `audio` blocks coerce to text while a valid `image` passes through.
- A malformed `image` block (missing base64 source) coerces to text instead of an empty image block.
