### PR TITLE
fix(agents): hydrate allowlisted dynamic model metadata

### DIFF
--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -51,7 +51,26 @@ const state = vi.hoisted(() => ({
   isThinkingLevelSupportedMock: vi.fn((_args: unknown) => true),
   resolveSupportedThinkingLevelMock: vi.fn(({ level }: { level?: string }) => level),
   resolveThinkingDefaultMock: vi.fn((_args: unknown) => "low"),
-  loadManifestModelCatalogMock: vi.fn(() => []),
+  loadManifestModelCatalogMock: vi.fn(
+    (): Array<{
+      provider: string;
+      id: string;
+      name?: string;
+      reasoning?: boolean;
+      compat?: unknown;
+    }> => [],
+  ),
+  loadModelCatalogMock: vi.fn(
+    async (): Promise<
+      Array<{
+        provider: string;
+        id: string;
+        name?: string;
+        reasoning?: boolean;
+        compat?: unknown;
+      }>
+    > => [],
+  ),
   buildWorkspaceSkillSnapshotMock: vi.fn((..._args: unknown[]): unknown => ({
     prompt: "",
     skills: [],
@@ -414,6 +433,7 @@ vi.mock("./lanes.js", () => ({
 
 vi.mock("./model-catalog.js", () => ({
   loadManifestModelCatalog: state.loadManifestModelCatalogMock,
+  loadModelCatalog: state.loadModelCatalogMock,
 }));
 
 vi.mock("./model-selection.js", () => {
@@ -942,6 +962,7 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     state.resolveThinkingDefaultMock.mockReturnValue("low");
     state.resolveAgentSkillsFilterMock.mockReturnValue(undefined);
     state.loadManifestModelCatalogMock.mockReturnValue([]);
+    state.loadModelCatalogMock.mockResolvedValue([]);
     state.hasLegacyAutoFallbackWithoutOriginMock.mockReturnValue(false);
     state.resolveAutoFallbackPrimaryProbeMock.mockReturnValue(undefined);
     state.resolveChannelModelOverrideMock.mockImplementation((params: unknown) => {
@@ -2308,6 +2329,80 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
       provider: "gmn",
       id: "gpt-5.4",
       compat: { supportedReasoningEfforts: ["low", "medium", "high", "xhigh"] },
+    });
+  });
+
+  it("hydrates allowlisted model metadata before rejecting explicit thinking", async () => {
+    state.runtimeConfigMock = {
+      agents: {
+        defaults: {
+          model: { primary: "ollama/minimax-m3:cloud" },
+          models: {
+            "ollama/minimax-m3:cloud": {},
+          },
+        },
+      },
+      models: {
+        providers: {
+          ollama: {
+            api: "ollama",
+            baseUrl: "http://127.0.0.1:11434",
+          },
+        },
+      },
+    };
+    state.loadManifestModelCatalogMock.mockReturnValue([
+      {
+        provider: "ollama",
+        id: "minimax-m3:cloud",
+        name: "minimax-m3:cloud",
+      },
+    ]);
+    state.loadModelCatalogMock.mockResolvedValue([
+      {
+        provider: "ollama",
+        id: "minimax-m3:cloud",
+        name: "minimax-m3:cloud",
+        reasoning: true,
+        compat: { supportedReasoningEfforts: ["low", "medium", "high"] },
+      },
+    ]);
+    state.isThinkingLevelSupportedMock.mockImplementation((args: unknown) => {
+      const input = args as { catalog?: Array<{ reasoning?: boolean }> };
+      return input.catalog?.some((entry) => entry.reasoning === true) ?? false;
+    });
+    state.runWithModelFallbackMock.mockImplementation(async (params: FallbackRunnerParams) => {
+      const result = await params.run(params.provider, params.model);
+      return {
+        result,
+        provider: params.provider,
+        model: params.model,
+        attempts: [],
+      };
+    });
+    state.runAgentAttemptMock.mockResolvedValue(makeSuccessResult("ollama", "minimax-m3:cloud"));
+
+    await agentCommand({
+      message: "hello",
+      to: "+1234567890",
+      thinking: "low",
+      provider: "ollama",
+      model: "minimax-m3:cloud",
+    });
+
+    expect(state.loadModelCatalogMock).toHaveBeenCalledWith({
+      config: state.runtimeConfigMock,
+    });
+    expect(state.isThinkingLevelSupportedMock).toHaveBeenCalledTimes(2);
+    const hydratedThinkingArgs = requireRecord(
+      mockCallArg(state.isThinkingLevelSupportedMock, 1),
+      "hydrated thinking args",
+    );
+    const catalog = requireArray(hydratedThinkingArgs.catalog, "hydrated thinking catalog");
+    expectRecordFields(catalog[0], {
+      provider: "ollama",
+      id: "minimax-m3:cloud",
+      reasoning: true,
     });
   });
 

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -101,7 +101,7 @@ import { resolveAvailableAgentHarnessPolicy } from "./harness/selection.js";
 import { prepareInternalSessionEffectsTranscript } from "./internal-session-effects.js";
 import { AGENT_LANE_SUBAGENT } from "./lanes.js";
 import { LiveSessionModelSwitchError } from "./live-model-switch.js";
-import { loadManifestModelCatalog } from "./model-catalog.js";
+import { loadManifestModelCatalog, loadModelCatalog } from "./model-catalog.js";
 import { runWithModelFallback } from "./model-fallback.js";
 import { normalizeConfiguredProviderCatalogModelId } from "./model-ref-shared.js";
 import type { ModelManifestNormalizationContext } from "./model-selection-normalize.js";
@@ -155,6 +155,15 @@ function hasConfiguredProvider(params: { cfg: OpenClawConfig; provider: string }
   return Object.keys(params.cfg.models?.providers ?? {}).some(
     (providerId) => normalizeProviderId(providerId) === normalizedProvider,
   );
+}
+
+function findCatalogEntry(
+  catalog: readonly { provider: string; id: string; reasoning?: boolean }[] | undefined,
+  provider: string,
+  model: string,
+): { provider: string; id: string; reasoning?: boolean } | undefined {
+  const selectedKey = modelKey(normalizeProviderId(provider), model);
+  return catalog?.find((entry) => modelKey(entry.provider, entry.id) === selectedKey);
 }
 
 function allowPluginModelNormalizationForRef(params: {
@@ -1513,13 +1522,13 @@ async function agentCommandInternal(
       }
     }
 
-    const catalogForThinking =
+    let catalogForThinking =
       allowedModelCatalog.length > 0
         ? allowedModelCatalog
         : modelCatalog && modelCatalog.length > 0
           ? modelCatalog
           : configuredThinkingCatalog;
-    const thinkingCatalog = catalogForThinking.length > 0 ? catalogForThinking : undefined;
+    let thinkingCatalog = catalogForThinking.length > 0 ? catalogForThinking : undefined;
     if (!resolvedThinkLevel) {
       resolvedThinkLevel =
         normalizeThinkLevel(resolveAgentConfig(cfg, sessionAgentId)?.thinkingDefault) ??
@@ -1530,14 +1539,41 @@ async function agentCommandInternal(
           catalog: thinkingCatalog,
         });
     }
+    let thinkingLevelSupported = isThinkingLevelSupported({
+      provider,
+      model,
+      level: resolvedThinkLevel,
+      catalog: thinkingCatalog,
+    });
+    const selectedThinkingEntry = findCatalogEntry(thinkingCatalog, provider, model);
     if (
-      !isThinkingLevelSupported({
+      !thinkingLevelSupported &&
+      resolvedThinkLevel &&
+      selectedThinkingEntry?.reasoning === undefined
+    ) {
+      // Agent-command validates explicit thinking before reply-run model selection;
+      // exact allowlist rows can be sparse until the full catalog hydrates provider metadata.
+      modelCatalog = await loadModelCatalog({ config: cfg });
+      const fullVisibilityPolicy = createModelVisibilityPolicy({
+        cfg,
+        catalog: modelCatalog,
+        defaultProvider,
+        defaultModel,
+        agentId: sessionAgentId,
+        allowManifestNormalization: true,
+        allowPluginNormalization: pluginsEnabled,
+        ...modelManifestContext,
+      });
+      catalogForThinking = hasAllowlist ? fullVisibilityPolicy.allowedCatalog : modelCatalog;
+      thinkingCatalog = catalogForThinking.length > 0 ? catalogForThinking : undefined;
+      thinkingLevelSupported = isThinkingLevelSupported({
         provider,
         model,
         level: resolvedThinkLevel,
         catalog: thinkingCatalog,
-      })
-    ) {
+      });
+    }
+    if (!thinkingLevelSupported) {
       const explicitThink = Boolean(thinkOnce || thinkOverride);
       if (explicitThink) {
         throw new Error(

--- a/src/agents/model-catalog.test.ts
+++ b/src/agents/model-catalog.test.ts
@@ -1738,6 +1738,60 @@ describe("loadModelCatalog", () => {
     );
   });
 
+  it("hydrates exact allowlisted rows that discovery already returned without metadata", async () => {
+    mockAgentDiscoveryModels([
+      {
+        id: "minimax-m3:cloud",
+        provider: "ollama",
+        name: "minimax-m3:cloud",
+      },
+    ]);
+    runDynamicModelMock.mockReturnValueOnce({
+      id: "minimax-m3:cloud",
+      name: "minimax-m3:cloud",
+      provider: "ollama",
+      api: "ollama",
+      baseUrl: "http://127.0.0.1:11434",
+      reasoning: true,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 1_048_576,
+      maxTokens: 8192,
+      compat: { supportsTools: true },
+      mediaInput: { image: { maxBytes: 1_000_000 } },
+    });
+
+    const result = await loadModelCatalog({
+      config: {
+        agents: {
+          defaults: {
+            models: {
+              "ollama/minimax-m3:cloud": {},
+            },
+          },
+        },
+        models: {
+          providers: {
+            ollama: {
+              api: "ollama",
+              baseUrl: "http://127.0.0.1:11434",
+              models: [],
+            },
+          },
+        },
+      } as OpenClawConfig,
+    });
+
+    const entry = requireCatalogEntry(result, "ollama", "minimax-m3:cloud");
+    expect(entry.reasoning).toBe(true);
+    expect(entry.contextWindow).toBe(1_048_576);
+    expect(entry.api).toBe("ollama");
+    expect(entry.input).toEqual(["text"]);
+    expect(entry.compat).toEqual({ supportsTools: true });
+    expect(entry.mediaInput).toEqual({ image: { maxBytes: 1_000_000 } });
+    expect(runDynamicModelMock).toHaveBeenCalledTimes(1);
+  });
+
   it("keeps discovered catalog entries when dynamic allowlist metadata fails", async () => {
     mockAgentDiscoveryModels([{ id: "llama3.2", provider: "ollama", name: "Llama 3.2" }]);
     runDynamicModelMock
@@ -1782,6 +1836,15 @@ describe("loadModelCatalog", () => {
 
   it("retries exact allowlisted dynamic model metadata after a partial cache load", async () => {
     mockAgentDiscoveryModels([{ id: "llama3.2", provider: "ollama", name: "Llama 3.2" }]);
+    const stateCache = new Map<string, ModelCatalogEntry[]>();
+    readCachedAgentModelCatalogMock.mockImplementation(({ catalogKey }: { catalogKey: string }) =>
+      stateCache.get(catalogKey),
+    );
+    writeCachedAgentModelCatalogMock.mockImplementation(
+      ({ catalogKey, entries }: { catalogKey: string; entries: ModelCatalogEntry[] }) => {
+        stateCache.set(catalogKey, entries);
+      },
+    );
     runDynamicModelMock
       .mockImplementationOnce(() => {
         throw new Error("show failed");
@@ -1813,10 +1876,12 @@ describe("loadModelCatalog", () => {
       const partial = await loadModelCatalog({ config });
       expect(requireCatalogEntry(partial, "ollama", "llama3.2").name).toBe("Llama 3.2");
       expectNoCatalogEntry(partial, "ollama", "minimax-m3:cloud");
+      expect(writeCachedAgentModelCatalogMock).not.toHaveBeenCalled();
 
       const retry = await loadModelCatalog({ config });
       expect(requireCatalogEntry(retry, "ollama", "minimax-m3:cloud").reasoning).toBe(true);
       expect(runDynamicModelMock).toHaveBeenCalledTimes(2);
+      expect(writeCachedAgentModelCatalogMock).toHaveBeenCalledTimes(1);
     } finally {
       resetLogger();
     }

--- a/src/agents/model-catalog.test.ts
+++ b/src/agents/model-catalog.test.ts
@@ -16,6 +16,8 @@ let modelSupportsInput: typeof import("./model-catalog.js").modelSupportsInput;
 let resetModelCatalogCacheForTest: typeof import("./model-catalog.js").resetModelCatalogCacheForTest;
 let augmentCatalogMock: ReturnType<typeof vi.fn>;
 let prepareOpenClawModelsJsonSourceMock: ReturnType<typeof vi.fn>;
+let prepareDynamicModelMock: ReturnType<typeof vi.fn>;
+let runDynamicModelMock: ReturnType<typeof vi.fn>;
 let currentPluginMetadataSnapshotMock: ReturnType<typeof vi.fn<(...args: unknown[]) => unknown>>;
 let loadPluginMetadataSnapshotMock: ReturnType<typeof vi.fn<(...args: unknown[]) => unknown>>;
 let readFileMock: ReturnType<typeof vi.fn<(pathname: string) => Promise<string>>>;
@@ -284,6 +286,10 @@ describe("loadModelCatalog", () => {
     vi.doMock("../plugins/provider-runtime.runtime.js", () => ({
       augmentModelCatalogWithProviderPlugins: vi.fn().mockResolvedValue([]),
     }));
+    vi.doMock("../plugins/provider-runtime.js", () => ({
+      prepareProviderDynamicModel: vi.fn().mockResolvedValue(undefined),
+      runProviderDynamicModel: vi.fn(),
+    }));
     currentPluginMetadataSnapshotMock = vi.fn(() => emptyPluginMetadataSnapshot());
     loadPluginMetadataSnapshotMock = vi.fn(() => emptyPluginMetadataSnapshot());
     vi.doMock("../plugins/current-plugin-metadata-snapshot.js", () => ({
@@ -325,6 +331,9 @@ describe("loadModelCatalog", () => {
     } = await import("./model-catalog.js"));
     const providerRuntime = await import("../plugins/provider-runtime.runtime.js");
     augmentCatalogMock = vi.mocked(providerRuntime.augmentModelCatalogWithProviderPlugins);
+    const dynamicRuntime = await import("../plugins/provider-runtime.js");
+    prepareDynamicModelMock = vi.mocked(dynamicRuntime.prepareProviderDynamicModel);
+    runDynamicModelMock = vi.mocked(dynamicRuntime.runProviderDynamicModel);
   });
 
   beforeEach(() => {
@@ -341,6 +350,8 @@ describe("loadModelCatalog", () => {
       wrote: false,
     });
     augmentCatalogMock.mockClear();
+    prepareDynamicModelMock.mockClear();
+    runDynamicModelMock.mockReset();
     currentPluginMetadataSnapshotMock.mockReset();
     currentPluginMetadataSnapshotMock.mockReturnValue(undefined);
     loadPluginMetadataSnapshotMock.mockReset();
@@ -369,6 +380,7 @@ describe("loadModelCatalog", () => {
     vi.doUnmock("./model-catalog-state-cache.js");
     vi.doUnmock("./agent-scope.js");
     vi.doUnmock("../plugins/provider-runtime.runtime.js");
+    vi.doUnmock("../plugins/provider-runtime.js");
     vi.doUnmock("../plugins/current-plugin-metadata-snapshot.js");
     vi.doUnmock("../plugins/plugin-metadata-snapshot.js");
     vi.doUnmock("../plugins/manifest-contract-eligibility.js");
@@ -1660,6 +1672,193 @@ describe("loadModelCatalog", () => {
     expect(entry.input).toEqual(["text", "image"]);
     expect(entry.reasoning).toBe(true);
     expect(entry.contextWindow).toBe(128_000);
+  });
+
+  it("materializes exact allowlisted dynamic models with provider metadata", async () => {
+    mockAgentDiscoveryModels([{ id: "llama3.2", provider: "ollama", name: "Llama 3.2" }]);
+    runDynamicModelMock.mockReturnValueOnce({
+      id: "minimax-m3:cloud",
+      name: "minimax-m3:cloud",
+      provider: "ollama",
+      api: "ollama",
+      baseUrl: "http://127.0.0.1:11434",
+      reasoning: true,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 1_048_576,
+      maxTokens: 8192,
+      compat: { supportsTools: true, supportsUsageInStreaming: true },
+      mediaInput: { image: { maxBytes: 1_000_000 } },
+    });
+
+    const result = await loadModelCatalog({
+      config: {
+        agents: {
+          defaults: {
+            models: {
+              "ollama/minimax-m3:cloud": {},
+            },
+          },
+        },
+        models: {
+          providers: {
+            ollama: {
+              api: "ollama",
+              baseUrl: "http://127.0.0.1:11434",
+              models: [],
+            },
+          },
+        },
+      } as OpenClawConfig,
+    });
+
+    const entry = requireCatalogEntry(result, "ollama", "minimax-m3:cloud");
+    expect(entry.api).toBe("ollama");
+    expect(entry.reasoning).toBe(true);
+    expect(entry.contextWindow).toBe(1_048_576);
+    expect(entry.compat).toEqual({ supportsTools: true, supportsUsageInStreaming: true });
+    expect(entry.mediaInput).toEqual({ image: { maxBytes: 1_000_000 } });
+    expect(prepareDynamicModelMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "ollama",
+        context: expect.objectContaining({
+          modelId: "minimax-m3:cloud",
+          provider: "ollama",
+        }),
+      }),
+    );
+    expect(runDynamicModelMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "ollama",
+        context: expect.objectContaining({
+          modelId: "minimax-m3:cloud",
+          provider: "ollama",
+        }),
+      }),
+    );
+  });
+
+  it("keeps discovered catalog entries when dynamic allowlist metadata fails", async () => {
+    mockAgentDiscoveryModels([{ id: "llama3.2", provider: "ollama", name: "Llama 3.2" }]);
+    runDynamicModelMock
+      .mockImplementationOnce(() => {
+        throw new Error("show failed");
+      })
+      .mockReturnValueOnce({
+        id: "glm-5.1:cloud",
+        name: "glm-5.1:cloud",
+        provider: "ollama",
+        api: "ollama",
+        baseUrl: "http://127.0.0.1:11434",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 202_752,
+        maxTokens: 8192,
+      });
+    setLoggerOverride({ level: "silent", consoleLevel: "warn" });
+    try {
+      const result = await loadModelCatalog({
+        config: {
+          agents: {
+            defaults: {
+              models: {
+                "ollama/minimax-m3:cloud": {},
+                "ollama/glm-5.1:cloud": {},
+              },
+            },
+          },
+        } as OpenClawConfig,
+      });
+
+      expect(requireCatalogEntry(result, "ollama", "llama3.2").name).toBe("Llama 3.2");
+      expectNoCatalogEntry(result, "ollama", "minimax-m3:cloud");
+      expect(requireCatalogEntry(result, "ollama", "glm-5.1:cloud").reasoning).toBe(true);
+      expect(runDynamicModelMock).toHaveBeenCalledTimes(2);
+    } finally {
+      resetLogger();
+    }
+  });
+
+  it("retries exact allowlisted dynamic model metadata after a partial cache load", async () => {
+    mockAgentDiscoveryModels([{ id: "llama3.2", provider: "ollama", name: "Llama 3.2" }]);
+    runDynamicModelMock
+      .mockImplementationOnce(() => {
+        throw new Error("show failed");
+      })
+      .mockReturnValueOnce({
+        id: "minimax-m3:cloud",
+        name: "minimax-m3:cloud",
+        provider: "ollama",
+        api: "ollama",
+        baseUrl: "http://127.0.0.1:11434",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 1_048_576,
+        maxTokens: 8192,
+      });
+    const config = {
+      agents: {
+        defaults: {
+          models: {
+            "ollama/minimax-m3:cloud": {},
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    setLoggerOverride({ level: "silent", consoleLevel: "warn" });
+    try {
+      const partial = await loadModelCatalog({ config });
+      expect(requireCatalogEntry(partial, "ollama", "llama3.2").name).toBe("Llama 3.2");
+      expectNoCatalogEntry(partial, "ollama", "minimax-m3:cloud");
+
+      const retry = await loadModelCatalog({ config });
+      expect(requireCatalogEntry(retry, "ollama", "minimax-m3:cloud").reasoning).toBe(true);
+      expect(runDynamicModelMock).toHaveBeenCalledTimes(2);
+    } finally {
+      resetLogger();
+    }
+  });
+
+  it("does not share partial dynamic hydration promises with cacheable callers", async () => {
+    mockAgentDiscoveryModels([{ id: "llama3.2", provider: "ollama", name: "Llama 3.2" }]);
+    let releaseHydration: (() => void) | undefined;
+    const hydrationStarted = new Promise<void>((resolve) => {
+      releaseHydration = resolve;
+    });
+    const failAfterHydration = () =>
+      hydrationStarted.then(() => {
+        throw new Error("show failed");
+      });
+    runDynamicModelMock
+      .mockReturnValueOnce(failAfterHydration())
+      .mockReturnValueOnce(failAfterHydration());
+    const config = {
+      agents: {
+        defaults: {
+          models: {
+            "ollama/minimax-m3:cloud": {},
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    setLoggerOverride({ level: "silent", consoleLevel: "warn" });
+    try {
+      const normalLoad = loadModelCatalog({ config });
+      const cacheableLoad = loadModelCatalog({ config, requireCacheableResult: true });
+      releaseHydration?.();
+
+      await expect(normalLoad).resolves.toEqual([
+        expect.objectContaining({ id: "llama3.2", provider: "ollama" }),
+      ]);
+      await expect(cacheableLoad).rejects.toMatchObject({ name: "PartialModelCatalogError" });
+      expect(runDynamicModelMock).toHaveBeenCalledTimes(2);
+    } finally {
+      resetLogger();
+    }
   });
 
   it("overlays configured model compat onto discovered catalog rows", async () => {

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -24,6 +24,7 @@ import { augmentModelCatalogWithProviderPlugins } from "../plugins/provider-runt
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
 import { resolveDefaultAgentDir } from "./agent-scope.js";
 import { ensureAuthProfileStoreWithoutExternalProfiles } from "./auth-profiles.js";
+import { appendPrioritizedDynamicLiveModels } from "./live-model-dynamic-candidates.js";
 import { modelSupportsInput as modelCatalogEntrySupportsInput } from "./model-catalog-lookup.js";
 import {
   buildAgentModelCatalogCacheKey,
@@ -40,6 +41,7 @@ import {
 import {
   buildConfiguredModelCatalog,
   hasConfiguredProviderModelRows,
+  parseConfiguredModelVisibilityEntries,
 } from "./model-selection-shared.js";
 import {
   buildModelsJsonSourceFingerprint,
@@ -65,16 +67,36 @@ type DiscoveredModel = {
   id: string;
   name?: string;
   provider: string;
-  api?: ModelCatalogEntry["api"];
+  alias?: string;
+  api?: ModelCatalogEntry["api"] | null;
   contextWindow?: number;
   contextTokens?: number;
   reasoning?: boolean;
   input?: ModelInputType[];
   params?: ModelCatalogEntry["params"];
   compat?: ModelCatalogEntry["compat"];
+  mediaInput?: ModelCatalogEntry["mediaInput"];
 };
+type DynamicLiveModel = Parameters<typeof appendPrioritizedDynamicLiveModels>[0]["models"][number];
+type DynamicLiveModelRegistry = Parameters<
+  typeof appendPrioritizedDynamicLiveModels
+>[0]["modelRegistry"];
 
 type AgentDiscoveryModule = typeof import("./agent-model-discovery.js");
+
+class PartialModelCatalogError extends Error {
+  readonly catalog: ModelCatalogEntry[];
+
+  constructor(message: string, catalog: ModelCatalogEntry[]) {
+    super(message);
+    this.name = "PartialModelCatalogError";
+    this.catalog = catalog;
+  }
+}
+
+function isPartialModelCatalogError(error: unknown): error is PartialModelCatalogError {
+  return error instanceof PartialModelCatalogError;
+}
 
 let modelCatalogPromise: Promise<ModelCatalogEntry[]> | null = null;
 let hasLoggedModelCatalogError = false;
@@ -543,6 +565,7 @@ export async function loadModelCatalog(params?: {
   useCache?: boolean;
   readOnly?: boolean;
   metadataSnapshot?: PluginMetadataSnapshot;
+  requireCacheableResult?: boolean;
 }): Promise<ModelCatalogEntry[]> {
   const readOnly = params?.readOnly === true;
   if (readOnly) {
@@ -557,7 +580,7 @@ export async function loadModelCatalog(params?: {
   if (!readOnly && params?.useCache === false) {
     modelCatalogPromise = null;
   }
-  const useSharedCache = !readOnly && !params?.metadataSnapshot;
+  const useSharedCache = !readOnly && !params?.metadataSnapshot && !params?.requireCacheableResult;
   if (useSharedCache && modelCatalogPromise) {
     return modelCatalogPromise;
   }
@@ -658,11 +681,45 @@ export async function loadModelCatalog(params?: {
       logStage("registry-ready");
       const entries = registry.getAll() as DiscoveredModel[];
       logStage("registry-read", `entries=${entries.length}`);
+      let liveEntries = entries;
+      let dynamicAllowlistHydrationFailed = false;
+      if (!readOnly) {
+        const configuredExactRefs = parseConfiguredModelVisibilityEntries({
+          cfg,
+        }).exactModelRefs.flatMap((raw) => {
+          const separator = raw.indexOf("/");
+          if (separator <= 0 || separator === raw.length - 1) {
+            return [];
+          }
+          return [{ provider: raw.slice(0, separator), id: raw.slice(separator + 1) }];
+        });
+        for (const ref of configuredExactRefs) {
+          try {
+            const augmented = await appendPrioritizedDynamicLiveModels({
+              models: liveEntries as DynamicLiveModel[],
+              config: cfg,
+              agentDir,
+              workspaceDir,
+              env: process.env,
+              modelRegistry: registry as DynamicLiveModelRegistry,
+              normalizeModel: (model) => model,
+              refs: [ref],
+            });
+            liveEntries = augmented.models as DiscoveredModel[];
+            logStage("dynamic-allowlist-models", `added=${augmented.added.length}`);
+          } catch (error) {
+            dynamicAllowlistHydrationFailed = true;
+            log.warn(
+              `Failed to hydrate dynamic allowlisted model metadata for ${ref.provider}/${ref.id}: ${String(error)}`,
+            );
+          }
+        }
+      }
 
       const shouldSuppressBuiltInModel = buildShouldSuppressBuiltInModel({ config: cfg });
       logStage("suppress-resolver-ready");
 
-      for (const entry of entries) {
+      for (const entry of liveEntries) {
         const rawId = normalizeOptionalString(entry?.id) ?? "";
         if (!rawId) {
           continue;
@@ -678,6 +735,8 @@ export async function loadModelCatalog(params?: {
           continue;
         }
         const name = normalizeOptionalString(entry?.name ?? id) || id;
+        const alias = normalizeOptionalString(entry?.alias);
+        const api = normalizeOptionalString(entry?.api) as ModelCatalogEntry["api"] | undefined;
         const contextWindow =
           typeof entry?.contextWindow === "number" && entry.contextWindow > 0
             ? entry.contextWindow
@@ -687,15 +746,17 @@ export async function loadModelCatalog(params?: {
             ? entry.contextTokens
             : undefined;
         const reasoning = typeof entry?.reasoning === "boolean" ? entry.reasoning : undefined;
-        const api = typeof entry?.api === "string" ? entry.api : undefined;
         const input = Array.isArray(entry?.input) ? entry.input : undefined;
         const modelParams =
           entry?.params && typeof entry.params === "object" ? entry.params : undefined;
         const compat = entry?.compat && typeof entry.compat === "object" ? entry.compat : undefined;
+        const mediaInput =
+          entry?.mediaInput && typeof entry.mediaInput === "object" ? entry.mediaInput : undefined;
         models.push({
           id,
           name,
           provider,
+          ...(alias ? { alias } : {}),
           ...(api ? { api } : {}),
           contextWindow,
           ...(contextTokens !== undefined ? { contextTokens } : {}),
@@ -703,6 +764,7 @@ export async function loadModelCatalog(params?: {
           input,
           ...(modelParams ? { params: modelParams } : {}),
           compat,
+          ...(mediaInput ? { mediaInput } : {}),
         });
       }
       mergeCatalogEntries(
@@ -787,9 +849,25 @@ export async function loadModelCatalog(params?: {
           entries: sorted,
         });
       }
+      if (dynamicAllowlistHydrationFailed) {
+        // Current callers can still use discovered rows, but provider metadata is incomplete.
+        // Do not let shared or gateway catalog caches treat this partial load as stable.
+        if (useSharedCache) {
+          modelCatalogPromise = null;
+        }
+        if (params?.requireCacheableResult) {
+          throw new PartialModelCatalogError(
+            "Dynamic allowlisted model metadata hydration failed",
+            sorted,
+          );
+        }
+      }
       logStage("complete", `entries=${sorted.length}`);
       return sorted;
     } catch (error) {
+      if (isPartialModelCatalogError(error)) {
+        throw error;
+      }
       if (!hasLoggedModelCatalogError) {
         hasLoggedModelCatalogError = true;
         log.warn(`Failed to load model catalog: ${String(error)}`);
@@ -805,7 +883,7 @@ export async function loadModelCatalog(params?: {
     }
   };
 
-  if (readOnly || params?.metadataSnapshot) {
+  if (readOnly || params?.metadataSnapshot || params?.requireCacheableResult) {
     return loadCatalog();
   }
 

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -204,6 +204,7 @@ function overlayCatalogMetadata(
   const params = mergeCatalogParams(base.params, overlay.params);
   return {
     ...base,
+    ...(overlay.alias !== undefined ? { alias: overlay.alias } : {}),
     ...(overlay.api !== undefined ? { api: overlay.api } : {}),
     ...(overlay.contextWindow !== undefined ? { contextWindow: overlay.contextWindow } : {}),
     ...(overlay.contextTokens !== undefined ? { contextTokens: overlay.contextTokens } : {}),
@@ -211,6 +212,7 @@ function overlayCatalogMetadata(
     ...(overlay.input !== undefined ? { input: overlay.input } : {}),
     ...(params ? { params } : {}),
     compat: mergeCatalogCompat(base.compat, overlay.compat),
+    ...(overlay.mediaInput !== undefined ? { mediaInput: overlay.mediaInput } : {}),
   };
 }
 
@@ -238,6 +240,35 @@ function mergeCatalogEntries(models: ModelCatalogEntry[], entries: ModelCatalogE
     }
     models[existingIndex] = overlayCatalogMetadata(models[existingIndex], entry);
   }
+}
+
+function dynamicLiveModelNeedsMetadata(entry: DynamicLiveModel): boolean {
+  return (
+    entry.reasoning === undefined ||
+    (entry.contextWindow === undefined && entry.contextTokens === undefined) ||
+    !entry.api ||
+    !Array.isArray(entry.input) ||
+    !entry.compat
+  );
+}
+
+function filterDynamicHydrationBaseModels(
+  models: DynamicLiveModel[],
+  ref: { provider: string; id: string },
+): { models: DynamicLiveModel[]; hadIncompleteMatch: boolean } {
+  const refKey = catalogEntryDedupeKey(ref.provider, ref.id);
+  let hadIncompleteMatch = false;
+  const filtered = models.filter((entry) => {
+    if (catalogEntryDedupeKey(entry.provider, entry.id) !== refKey) {
+      return true;
+    }
+    if (!dynamicLiveModelNeedsMetadata(entry)) {
+      return true;
+    }
+    hadIncompleteMatch = true;
+    return false;
+  });
+  return { models: filtered, hadIncompleteMatch };
 }
 
 export function loadManifestModelCatalog(params: {
@@ -695,8 +726,12 @@ export async function loadModelCatalog(params?: {
         });
         for (const ref of configuredExactRefs) {
           try {
+            const hydrationBase = filterDynamicHydrationBaseModels(
+              liveEntries as DynamicLiveModel[],
+              ref,
+            );
             const augmented = await appendPrioritizedDynamicLiveModels({
-              models: liveEntries as DynamicLiveModel[],
+              models: hydrationBase.models,
               config: cfg,
               agentDir,
               workspaceDir,
@@ -705,7 +740,10 @@ export async function loadModelCatalog(params?: {
               normalizeModel: (model) => model,
               refs: [ref],
             });
-            liveEntries = augmented.models as DiscoveredModel[];
+            liveEntries =
+              augmented.added.length > 0 || !hydrationBase.hadIncompleteMatch
+                ? (augmented.models as DiscoveredModel[])
+                : liveEntries;
             logStage("dynamic-allowlist-models", `added=${augmented.added.length}`);
           } catch (error) {
             dynamicAllowlistHydrationFailed = true;
@@ -842,7 +880,7 @@ export async function loadModelCatalog(params?: {
       }
 
       const sorted = sortModels(models);
-      if (!readOnly) {
+      if (!readOnly && !dynamicAllowlistHydrationFailed) {
         writeCachedAgentModelCatalog({
           agentDir,
           catalogKey,

--- a/src/gateway/server-model-catalog.test.ts
+++ b/src/gateway/server-model-catalog.test.ts
@@ -19,6 +19,13 @@ function model(id: string): GatewayModelChoice {
   return { id, name: id, provider: "openai" } as GatewayModelChoice;
 }
 
+function partialCatalogError(catalog: GatewayModelChoice[]): Error {
+  return Object.assign(new Error("partial catalog"), {
+    name: "PartialModelCatalogError",
+    catalog,
+  });
+}
+
 const getConfig = () => ({}) as OpenClawConfig;
 
 function createRefreshingCatalogLoader(
@@ -95,6 +102,7 @@ describe("loadGatewayModelCatalog", () => {
     expect(loadModelCatalog).toHaveBeenNthCalledWith(2, {
       config: getConfig(),
       readOnly: false,
+      requireCacheableResult: true,
     });
   });
 
@@ -123,6 +131,30 @@ describe("loadGatewayModelCatalog", () => {
     await expectCatalog(loadModelCatalog, freshCatalog, false);
 
     expect(loadModelCatalog).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not cache partial full catalog loads", async () => {
+    const partialCatalog = [model("llama3.2")];
+    const freshCatalog = [model("minimax-m3:cloud")];
+    const loadModelCatalog = vi
+      .fn<LoadModelCatalogForTest>()
+      .mockRejectedValueOnce(partialCatalogError(partialCatalog))
+      .mockResolvedValueOnce(freshCatalog);
+
+    await expectCatalog(loadModelCatalog, partialCatalog, false);
+    await expectCatalog(loadModelCatalog, freshCatalog, false);
+
+    expect(loadModelCatalog).toHaveBeenCalledTimes(2);
+    expect(loadModelCatalog).toHaveBeenNthCalledWith(1, {
+      config: getConfig(),
+      readOnly: false,
+      requireCacheableResult: true,
+    });
+    expect(loadModelCatalog).toHaveBeenNthCalledWith(2, {
+      config: getConfig(),
+      readOnly: false,
+      requireCacheableResult: true,
+    });
   });
 
   it("returns the last catalog while a stale reload refresh is still pending", async () => {

--- a/src/gateway/server-model-catalog.ts
+++ b/src/gateway/server-model-catalog.ts
@@ -8,6 +8,7 @@ type GatewayModelCatalogConfig = ReturnType<typeof getRuntimeConfig>;
 type LoadModelCatalog = (params: {
   config: GatewayModelCatalogConfig;
   readOnly?: boolean;
+  requireCacheableResult?: boolean;
 }) => Promise<GatewayModelChoice[]>;
 type LoadGatewayModelCatalogParams = {
   getConfig?: () => GatewayModelCatalogConfig;
@@ -23,6 +24,14 @@ type GatewayModelCatalogCache = {
 };
 
 const loadModelCatalogModule = async () => await import("../agents/model-catalog.js");
+
+function partialModelCatalogFromError(error: unknown): GatewayModelChoice[] | null {
+  if (!(error instanceof Error) || error.name !== "PartialModelCatalogError") {
+    return null;
+  }
+  const catalog = (error as { catalog?: unknown }).catalog;
+  return Array.isArray(catalog) ? (catalog as GatewayModelChoice[]) : null;
+}
 
 function createGatewayModelCatalogCache(): GatewayModelCatalogCache {
   return {
@@ -73,9 +82,30 @@ function startGatewayModelCatalogRefresh(
   const readOnly = params?.readOnly !== false;
   const refreshGeneration = cache.staleGeneration;
   const refresh = resolveLoadModelCatalog(params)
-    .then((loadModelCatalog) => loadModelCatalog({ config, readOnly }))
-    .then((catalog) => {
-      if ((readOnly || catalog.length > 0) && refreshGeneration === cache.staleGeneration) {
+    .then(async (loadModelCatalog) => {
+      try {
+        return {
+          catalog: await loadModelCatalog({
+            config,
+            readOnly,
+            ...(readOnly ? {} : { requireCacheableResult: true }),
+          }),
+          cacheable: true,
+        };
+      } catch (error) {
+        const partialCatalog = partialModelCatalogFromError(error);
+        if (partialCatalog) {
+          return { catalog: partialCatalog, cacheable: false };
+        }
+        throw error;
+      }
+    })
+    .then(({ catalog, cacheable }) => {
+      if (
+        cacheable &&
+        (readOnly || catalog.length > 0) &&
+        refreshGeneration === cache.staleGeneration
+      ) {
         cache.lastSuccessfulCatalog = catalog;
         cache.appliedGeneration = cache.staleGeneration;
       }

--- a/src/gateway/server.sessions.thinking-e2e.test.ts
+++ b/src/gateway/server.sessions.thinking-e2e.test.ts
@@ -89,7 +89,7 @@ async function listMainSessionWithThinking(params: {
   primaryModel: string;
   sessionModelProvider: string;
   sessionModel: string;
-  loadGatewayModelCatalog?: () => Promise<
+  loadGatewayModelCatalog?: (params?: { readOnly?: boolean }) => Promise<
     Array<{
       provider: string;
       id: string;

--- a/src/gateway/sessions-patch.test.ts
+++ b/src/gateway/sessions-patch.test.ts
@@ -1,6 +1,6 @@
 // Session patch tests cover model/provider edits, subagent patching, provider
 // aliases, model catalog validation, and rejected invalid patch payloads.
-import { afterEach, describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import { resetProviderAuthAliasMapCacheForTest } from "../agents/provider-auth-aliases.js";
 import type { OpenClawConfig } from "../config/config.js";
 import type { SessionEntry } from "../config/sessions.js";
@@ -556,6 +556,17 @@ describe("gateway sessions patch", () => {
     });
     setActivePluginRegistry(registry);
 
+    const loadGatewayModelCatalog = vi.fn<
+      NonNullable<ApplySessionsPatchArgs["loadGatewayModelCatalog"]>
+    >(async () => [
+      {
+        provider: "ollama",
+        id: "qwen3:0.6b",
+        name: "qwen3:0.6b",
+        reasoning: true,
+      },
+    ]);
+
     const entry = expectPatchOk(
       await runPatch({
         cfg: {
@@ -569,18 +580,12 @@ describe("gateway sessions patch", () => {
           key: MAIN_SESSION_KEY,
           thinkingLevel: "medium",
         },
-        loadGatewayModelCatalog: async () => [
-          {
-            provider: "ollama",
-            id: "qwen3:0.6b",
-            name: "qwen3:0.6b",
-            reasoning: true,
-          },
-        ],
+        loadGatewayModelCatalog,
       }),
     );
 
     expect(entry.thinkingLevel).toBe("medium");
+    expect(loadGatewayModelCatalog).toHaveBeenCalledWith({ readOnly: false });
   });
 
   test("accepts xhigh thinking patches from configured catalog compat", async () => {

--- a/src/gateway/sessions-patch.ts
+++ b/src/gateway/sessions-patch.ts
@@ -137,7 +137,7 @@ export async function applySessionsPatchToStore(params: {
   storeKey: string;
   agentId?: string;
   patch: SessionsPatchParams;
-  loadGatewayModelCatalog?: () => Promise<ModelCatalogEntry[]>;
+  loadGatewayModelCatalog?: (params?: { readOnly?: boolean }) => Promise<ModelCatalogEntry[]>;
 }): Promise<{ ok: true; entry: SessionEntry } | { ok: false; error: ErrorShape }> {
   const { cfg, store, storeKey, patch } = params;
   const now = Date.now();
@@ -157,7 +157,9 @@ export async function applySessionsPatchToStore(params: {
     if (!params.loadGatewayModelCatalog) {
       return undefined;
     }
-    const catalog = await params.loadGatewayModelCatalog();
+    // Model/thinking patches need live metadata; read-only catalog can omit
+    // exact allowlisted rows that provider hooks hydrate on full loads.
+    const catalog = await params.loadGatewayModelCatalog({ readOnly: false });
     loadedModelCatalog = Array.isArray(catalog) ? catalog : [];
     return loadedModelCatalog;
   };


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- Fixes gateway/model catalog metadata for exact allowlisted dynamic models such as `ollama/minimax-m3:cloud`.
- Full catalog loads now hydrate exact `agents.defaults.models` refs even when discovery already returned a sparse provider/id row, so live `/api/show` metadata carries `reasoning: true` into catalog and thinking validation.
- Gateway/session patch validation and agent-command early thinking validation now request or hydrate full catalog metadata before rejecting explicit thinking levels.

Why does this matter now?

- Issue #90315 reports that local Ollama dynamic resolution accepts `--thinking low`, while the gateway path rejects the same model as off-only unless users duplicate metadata under `models.providers.ollama.models[]`.

What is the intended outcome?

- An exact allowlisted dynamic Ollama model can keep provider-discovered thinking metadata in the runtime catalog without adding manual provider model rows.
- Existing discovered catalog entries remain available even if one dynamic allowlist metadata lookup fails.

What is intentionally out of scope?

- No new config, env var, migration, or Ollama-specific hardcoded model id.
- No change to read-only catalog browse behavior; dynamic provider hooks still run only on full catalog loads.

What does success look like?

- Gateway thinking validation can see the same `reasoning: true` metadata that dynamic provider resolution discovers for an exact allowlisted model.

What should reviewers focus on?

- Whether full catalog load is the right owner boundary for materializing exact allowlisted dynamic model metadata.
- Whether per-ref failure isolation and non-cacheable partial gateway catalog handling are sufficient for transient provider/API failures.

## Linked context

Which issue does this close?

Closes #90315

Which issues, PRs, or discussions are related?

Related #90138, but that PR fixes MiniMax provider thinking behavior and does not touch the Ollama gateway catalog path.

Was this requested by a maintainer or owner?

No direct maintainer request; issue is labeled queueable/fix-shape-clear.

## Real behavior proof (required for external PRs)

- Behavior addressed: Exact allowlisted dynamic Ollama models can lose live-discovered `reasoning` metadata in the gateway catalog and agent-command thinking validation paths, making `--thinking low` fail as unsupported even though dynamic provider resolution can run the model.
- Real environment tested: Local OpenClaw gateway from this branch on macOS, with an isolated temporary `HOME` / `OPENCLAW_HOME` / `OPENCLAW_CONFIG_PATH` and a temporary local Ollama-compatible HTTP server. The server returned `minimax-m3:cloud` from `/api/tags`, returned `/api/show` metadata with `model_info["llama.context_length"] = 1048576` and `capabilities: ["thinking", "tools", "completion"]`, and returned a native Ollama `/api/chat` streaming response.
- Exact steps or command run after this patch:
  1. Start a local Ollama-compatible server on `127.0.0.1:<temp-port>`.
  2. Write temporary config with only `agents.defaults.models["ollama/minimax-m3:cloud"] = {}` and provider `models.providers.ollama.baseUrl = http://127.0.0.1:<temp-port>`.
  3. Start gateway with `node dist/index.js gateway run --allow-unconfigured --bind loopback --port <temp-gateway-port> --auth token --token <local-proof-token> --compact`.
  4. Run:
     ```sh
     OPENCLAW_GATEWAY_URL=ws://127.0.0.1:<temp-gateway-port> \
     OPENCLAW_GATEWAY_TOKEN=<local-proof-token> \
     node dist/index.js infer model run --gateway \
       --model ollama/minimax-m3:cloud \
       --thinking low \
       --prompt "Reply with exactly: pong" \
       --json
     ```
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):
  Terminal capture copied live output from the gateway proof:

  ```json
  {
    "status": 0,
    "stdout": {
      "ok": true,
      "capability": "model.run",
      "transport": "gateway",
      "provider": "ollama",
      "model": "minimax-m3:cloud",
      "attempts": [],
      "outputs": [
        {
          "text": "pong",
          "mediaUrl": null
        }
      ]
    },
    "requestUrls": [
      "/api/tags",
      "/api/show",
      "/api/show body:{\"name\":\"minimax-m3:cloud\"}",
      "/api/tags",
      "/api/show",
      "/api/show body:{\"name\":\"minimax-m3:cloud\"}",
      "/api/chat"
    ],
    "chatBody": {
      "model": "minimax-m3:cloud",
      "stream": true,
      "options": {},
      "think": "low"
    }
  }
  ```
- Observed result after fix: The gateway command accepted `--thinking low`, hydrated `/api/show` metadata for the exact allowlisted `minimax-m3:cloud` model, called `/api/chat` with `think: "low"`, and returned `ok: true` with `pong`.
- What was not tested: Live Ollama Cloud credentials/service for real `minimax-m3:cloud` were not used; the gateway proof used a local Ollama-compatible server.
- Proof limitations or environment constraints: The proof server is local and intentionally synthetic, but it exercises the real OpenClaw gateway, catalog hydration, agent-command thinking validation, Ollama provider hook, and Ollama chat request path.
- Before evidence (optional but encouraged): The issue includes the before failure: gateway rejects `--thinking low` with `Thinking level "low" is not supported for ollama/minimax-m3:cloud. Use one of: off.` when only `agents.defaults.models` contains the model.

## Tests and validation

Which commands did you run?

- `node scripts/run-vitest.mjs src/agents/agent-command.live-model-switch.test.ts src/agents/model-catalog.test.ts`
- `node scripts/run-vitest.mjs src/gateway/sessions-patch.test.ts src/gateway/server.sessions.thinking-e2e.test.ts src/gateway/server-model-catalog.test.ts`
- `./node_modules/.bin/oxfmt --check src/agents/agent-command.ts src/agents/agent-command.live-model-switch.test.ts src/agents/model-catalog.ts src/agents/model-catalog.test.ts src/gateway/sessions-patch.ts src/gateway/sessions-patch.test.ts src/gateway/server.sessions.thinking-e2e.test.ts src/gateway/server-model-catalog.ts src/gateway/server-model-catalog.test.ts`
- `node scripts/run-oxlint.mjs src/agents/agent-command.ts src/agents/agent-command.live-model-switch.test.ts src/agents/model-catalog.ts src/agents/model-catalog.test.ts src/gateway/sessions-patch.ts src/gateway/sessions-patch.test.ts src/gateway/server.sessions.thinking-e2e.test.ts src/gateway/server-model-catalog.ts src/gateway/server-model-catalog.test.ts`
- `git diff --check`
- `pnpm tsgo:prod`
- `pnpm check:test-types`
- `pnpm openclaw --help` (rebuilt local dist before gateway proof)
- Local gateway proof command above
- `.agents/skills/autoreview/scripts/autoreview --mode local`

What regression coverage was added or updated?

- `src/agents/model-catalog.test.ts` covers exact allowlisted dynamic metadata hydration when the model is missing and when discovery already returned a sparse row.
- `src/agents/agent-command.live-model-switch.test.ts` covers early explicit thinking validation hydrating full catalog metadata before rejection.
- `src/gateway/sessions-patch.test.ts` covers session thinking validation requesting the full gateway catalog.
- `src/gateway/server-model-catalog.test.ts` covers not caching partial full catalog loads.

What failed before this fix, if known?

- Gateway model runs could reject `ollama/minimax-m3:cloud --thinking low` as off-only because early validation saw only sparse configured/allowlist catalog rows.

If no test was added, why not?

- Regression tests were added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No new auth or secret surfaces. Full catalog loads may call existing provider dynamic model hooks for exact configured model refs; read-only browse paths remain side-effect-free.

What is the highest-risk area?

Full model catalog loads and early agent-command thinking validation now perform optional dynamic metadata hydration for exact allowlisted refs.

How is that risk mitigated?

The behavior is limited to non-read-only/full metadata paths, uses existing provider dynamic hooks, avoids caching partial gateway full-catalog failures, and isolates per-ref hydration failures so base catalog entries and other dynamic refs remain available.

## Current review state

What is the next action?

CI and ClawSweeper re-review.

What is still waiting on author, maintainer, CI, or external proof?

CI and ClawSweeper re-review. A maintainer or reporter with Ollama Cloud credentials can add true cloud-service proof for `minimax-m3:cloud`.

Which bot or reviewer comments were addressed?

- Local autoreview was clean after the latest patch.
- ClawSweeper proof feedback was addressed with a real local gateway proof that reaches `/api/show`, sends `/api/chat` with `think: "low"`, and returns `pong`.
