### PR TITLE
fix #90668: [Bug]: macOS node mode can silently self-reconnect in a healthy direct gateway session

### DIFF
--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeModeCoordinator.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeModeCoordinator.swift
@@ -2,6 +2,44 @@ import Foundation
 import OpenClawKit
 import OSLog
 
+struct MacNodeGatewayTLSSessionCache {
+    private typealias Key = (
+        url: URL,
+        required: Bool,
+        expectedFingerprint: String?,
+        allowTOFU: Bool,
+        storeKey: String?)
+
+    private var cachedKey: Key?
+    private var cachedBox: WebSocketSessionBox?
+
+    // GatewayNodeSession treats session identity changes as reconnect input.
+    mutating func sessionBox(url: URL, params: GatewayTLSParams?) -> WebSocketSessionBox? {
+        guard let params else {
+            self.invalidate()
+            return nil
+        }
+        let key = (
+            url: url,
+            required: params.required,
+            expectedFingerprint: params.expectedFingerprint,
+            allowTOFU: params.allowTOFU,
+            storeKey: params.storeKey)
+        if let cachedKey = self.cachedKey, cachedKey == key, let cachedBox = self.cachedBox {
+            return cachedBox
+        }
+        let box = WebSocketSessionBox(session: GatewayTLSPinningSession(params: params))
+        self.cachedKey = key
+        self.cachedBox = box
+        return box
+    }
+
+    mutating func invalidate() {
+        self.cachedKey = nil
+        self.cachedBox = nil
+    }
+}
+
 @MainActor
 final class MacNodeModeCoordinator {
     static let shared = MacNodeModeCoordinator()
@@ -11,6 +49,7 @@ final class MacNodeModeCoordinator {
     private let runtime: MacNodeRuntime
     private let session: GatewayNodeSession
     private var autoRepairedTLSFingerprintsByStoreKey: [String: String] = [:]
+    private var tlsSessionCache = MacNodeGatewayTLSSessionCache()
 
     private init() {
         let session = GatewayNodeSession()
@@ -268,16 +307,17 @@ final class MacNodeModeCoordinator {
     }
 
     private func buildSessionBox(url: URL, connectionMode: AppState.ConnectionMode) -> WebSocketSessionBox? {
-        guard url.scheme?.lowercased() == "wss" else { return nil }
+        guard url.scheme?.lowercased() == "wss" else {
+            self.tlsSessionCache.invalidate()
+            return nil
+        }
         let stableID = Self.tlsPinStoreKey(for: url)
         let stored = GatewayTLSStore.loadFingerprint(stableID: stableID)
-        guard let params = Self.tlsParams(
+        let params = Self.tlsParams(
             for: url,
             connectionMode: connectionMode,
             root: OpenClawConfigFile.loadDict(),
             storedFingerprint: stored)
-        else { return nil }
-        let session = GatewayTLSPinningSession(params: params)
-        return WebSocketSessionBox(session: session)
+        return self.tlsSessionCache.sessionBox(url: url, params: params)
     }
 }

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeModeCoordinator.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeModeCoordinator.swift
@@ -3,28 +3,31 @@ import OpenClawKit
 import OSLog
 
 struct MacNodeGatewayTLSSessionCache {
-    private typealias Key = (
-        url: URL,
-        required: Bool,
-        expectedFingerprint: String?,
-        allowTOFU: Bool,
-        storeKey: String?)
+    private struct Key: Equatable {
+        let url: URL
+        let required: Bool
+        let expectedFingerprint: String?
+        let allowTOFU: Bool
+        let storeKey: String?
+
+        init(url: URL, params: GatewayTLSParams) {
+            self.url = url
+            self.required = params.required
+            self.expectedFingerprint = params.expectedFingerprint
+            self.allowTOFU = params.allowTOFU
+            self.storeKey = params.storeKey
+        }
+    }
 
     private var cachedKey: Key?
     private var cachedBox: WebSocketSessionBox?
 
-    // GatewayNodeSession treats session identity changes as reconnect input.
     mutating func sessionBox(url: URL, params: GatewayTLSParams?) -> WebSocketSessionBox? {
         guard let params else {
             self.invalidate()
             return nil
         }
-        let key = (
-            url: url,
-            required: params.required,
-            expectedFingerprint: params.expectedFingerprint,
-            allowTOFU: params.allowTOFU,
-            storeKey: params.storeKey)
+        let key = Key(url: url, params: params)
         if let cachedKey = self.cachedKey, cachedKey == key, let cachedBox = self.cachedBox {
             return cachedBox
         }

--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeModeCoordinatorTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeModeCoordinatorTests.swift
@@ -89,6 +89,41 @@ struct MacNodeModeCoordinatorTests {
         #expect(params.allowTOFU == false)
     }
 
+    @Test func `tls session cache reuses session box for unchanged params`() throws {
+        let url = try #require(URL(string: "wss://gateway.example.com"))
+        var cache = MacNodeGatewayTLSSessionCache()
+        let params = try #require(MacNodeModeCoordinator.tlsParams(
+            for: url,
+            connectionMode: .remote,
+            root: ["gateway": ["remote": ["tlsFingerprint": "sha256:configured"]]],
+            storedFingerprint: "stored"))
+
+        let first = try #require(cache.sessionBox(url: url, params: params))
+        let second = try #require(cache.sessionBox(url: url, params: params))
+
+        #expect(ObjectIdentifier(first.session) == ObjectIdentifier(second.session))
+    }
+
+    @Test func `tls session cache rebuilds session box when params change`() throws {
+        let url = try #require(URL(string: "wss://gateway.example.com"))
+        var cache = MacNodeGatewayTLSSessionCache()
+        let firstParams = try #require(MacNodeModeCoordinator.tlsParams(
+            for: url,
+            connectionMode: .remote,
+            root: ["gateway": ["remote": ["tlsFingerprint": "sha256:configured"]]],
+            storedFingerprint: "stored"))
+        let secondParams = try #require(MacNodeModeCoordinator.tlsParams(
+            for: url,
+            connectionMode: .remote,
+            root: ["gateway": ["remote": ["tlsFingerprint": "sha256:rotated"]]],
+            storedFingerprint: "stored"))
+
+        let first = try #require(cache.sessionBox(url: url, params: firstParams))
+        let second = try #require(cache.sessionBox(url: url, params: secondParams))
+
+        #expect(ObjectIdentifier(first.session) != ObjectIdentifier(second.session))
+    }
+
     @Test func `auto repairs trusted tailscale serve pin mismatch`() throws {
         let url = try #require(URL(string: "wss://gateway.example.ts.net"))
         let failure = GatewayTLSValidationFailure(


### PR DESCRIPTION
## Summary

- Problem: Healthy macOS node-mode direct `wss://` gateway loops could rebuild the TLS-pinning WebSocket session object every pass, making `GatewayNodeSession` treat unchanged inputs as reconnect input and repeat connected notifications.
- Solution: Cache the macOS node-mode TLS session box by URL and TLS pin parameters so unchanged direct `wss://` inputs keep the same session identity while changed trust inputs still rebuild it.
- What changed: `apps/macos/Sources/OpenClaw/NodeMode/MacNodeModeCoordinator.swift` now owns a narrow TLS session cache, and `apps/macos/Tests/OpenClawIPCTests/MacNodeModeCoordinatorTests.swift` covers reuse and rebuild cases.
- What did NOT change: No gateway protocol, token handling, pairing behavior, TLS validation policy, non-`wss://` path, shared reconnect semantics, config shape, or non-macOS client behavior changed.

Fixes #90668

## Real behavior proof

- **Behavior addressed:** Healthy macOS node-mode direct `wss://` loops no longer supply a fresh TLS-pinning session identity on each pass, so unchanged connection inputs do not repeat `mac node connected to gateway` notifications.
- **Real environment tested:** macOS 26.5, Node v24.15.0, Apple Swift 6.3.2, OpenClaw v2026.6.2, worktree SHA `619590e`.
- **Exact steps or command run after this patch:**
  ```bash
  openssl req -x509 -newkey rsa:2048 -sha256 -days 7 -nodes \
    -keyout /Users/zhangguiping/daily_pr_work/proofs/openclaw-issue-90668-evidence/gateway-key.pem \
    -out /Users/zhangguiping/daily_pr_work/proofs/openclaw-issue-90668-evidence/gateway-cert.pem \
    -subj /CN=127.0.0.1 -addext subjectAltName=IP:127.0.0.1,DNS:localhost
  env -C /Users/zhangguiping/daily_pr_work/openclaw-90668 \
    OPENCLAW_CONFIG_PATH=/Users/zhangguiping/daily_pr_work/proofs/openclaw-issue-90668-evidence/openclaw.json \
    OPENCLAW_STATE_DIR=/Users/zhangguiping/daily_pr_work/proofs/openclaw-issue-90668-evidence/state \
    pnpm openclaw gateway --port 19891 --bind loopback --token proof-token-90668 \
      --allow-unconfigured --verbose --ws-log compact
  env PROOF_GATEWAY_URL=wss://127.0.0.1:19891 \
    PROOF_GATEWAY_TOKEN=proof-token-90668 \
    PROOF_GATEWAY_FINGERPRINT=c60afe1c23e7291a557b6ad32fea336e03d08d6466bacabcf4dd06c086e7d780 \
    swift run --package-path /Users/zhangguiping/daily_pr_work/proofs/openclaw-issue-90668-evidence OpenClawNodeProof
  gh pr checks 90736 --repo openclaw/openclaw
  ```
- **Evidence after fix:**
  ```text
  [gateway] ready
  [ws] ← connect client=openclaw-macos clientDisplayName=OpenClaw macOS proof version=dev mode=node clientId=openclaw-macos platform=macOS 26.5.0 auth=token
  [ws] → hello-ok methods=189 events=27 presence=2 stateVersion=2

  running before-style fresh TLS session loop
  before-style fresh TLS session: connect pass 1, sessionObject=ObjectIdentifier(0x00000001012145f0)
  before-style fresh TLS session: mac node connected to gateway callback #1 during connect pass 1
  before-style fresh TLS session: connect pass 2, sessionObject=ObjectIdentifier(0x0000000a1d038820)
  before-style fresh TLS session: mac node connected to gateway callback #2 during connect pass 2
  before-style fresh TLS session: connect pass 3, sessionObject=ObjectIdentifier(0x0000000a1d0386e0)
  before-style fresh TLS session: mac node connected to gateway callback #3 during connect pass 3
  before-style fresh TLS session connected callbacks: 3

  running after-fix cached TLS session loop
  after-fix cached TLS session: connect pass 1, sessionObject=ObjectIdentifier(0x0000000a1d038f00)
  after-fix cached TLS session: mac node connected to gateway callback #1 during connect pass 1
  after-fix cached TLS session: connect pass 2, sessionObject=ObjectIdentifier(0x0000000a1d038f00)
  after-fix cached TLS session: connect pass 3, sessionObject=ObjectIdentifier(0x0000000a1d038f00)
  after-fix cached TLS session connected callbacks: 1
  PASS: cached TLS session keeps healthy direct wss node session from repeating connected notifications

  [ws] ← open remoteAddr=127.0.0.1 remotePort=56083 localAddr=127.0.0.1 localPort=19891 endpoint=127.0.0.1:56083->127.0.0.1:19891
  [ws] ← connect client=openclaw-macos clientDisplayName=OpenClaw macOS proof version=dev mode=node clientId=openclaw-macos platform=macOS 26.5.0 auth=token
  [ws] → hello-ok methods=189 events=27 presence=2 stateVersion=8
  [ws] → event tick seq=per-client clients=1
  [ws] → close code=1001 durationMs=3860 handshake=connected
  ```
- **Observed result after fix:** The control loop that creates a fresh `GatewayTLSPinningSession` each pass produced three distinct session identities and three connected callbacks. The patched cache loop reused one session identity across three healthy direct `wss://` connect passes and produced exactly one connected callback while the gateway kept the WebSocket connected until the harness disconnected.
- **What was not tested:** The full packaged menu-bar app was not separately launched on this machine; the proof exercises the same shared `GatewayNodeSession` + `GatewayTLSPinningSession` macOS runtime path used by the coordinator against a real local OpenClaw WSS gateway. Local `swift test --package-path apps/macos --filter MacNodeModeCoordinatorTests` is blocked here by Command Line Tools missing SwiftUI preview macro plugins; the PR `macos-swift` check passed for this head.

## Regression Test Plan

- Coverage level: Swift unit test plus macOS WSS runtime proof
- Target test file: `apps/macos/Tests/OpenClawIPCTests/MacNodeModeCoordinatorTests.swift`
- Scenario locked in: Repeated macOS direct `wss://` node-mode loop passes with the same URL and TLS params reuse one session object; changed TLS fingerprint input rebuilds it.
- Why this is the smallest reliable guardrail: The regression lives at the macOS coordinator owner boundary before `GatewayNodeSession.connect(...)`, so it proves the exact identity-stability invariant without weakening the shared gateway reconnect contract.

## Root Cause

- Root cause: `MacNodeModeCoordinator.run()` called `buildSessionBox(...)` on every loop pass, and the `wss://` path created a fresh `GatewayTLSPinningSession` / `WebSocketSessionBox` for unchanged URL and TLS pin inputs.
- Missing detection / guardrail: Existing tests covered TLS parameter selection and shared session replacement behavior, but not the macOS coordinator invariant that unchanged TLS inputs must preserve the same session object identity across healthy run-loop passes.
