### PR TITLE
Implement durable system-event fallback for subagent completion when handoff is still pending

### DIFF
--- a/src/agents/embedded-agent-runner/sessions-yield.orchestration.test.ts
+++ b/src/agents/embedded-agent-runner/sessions-yield.orchestration.test.ts
@@ -3,7 +3,17 @@
  * with no pending tool calls, so the parent session is idle when subagent
  * results arrive.
  */
-import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  drainSystemEvents,
+  peekSystemEvents,
+  resetSystemEventsForTest,
+} from "../../infra/system-events.js";
+import {
+  deliverSubagentAnnouncement,
+  testing as subagentAnnounceTesting,
+} from "../subagent-announce-delivery.js";
+import { callGateway as runtimeCallGateway } from "../subagent-announce-delivery.runtime.js";
 import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
 import {
   loadRunOverflowCompactionHarness,
@@ -126,4 +136,117 @@ describe("sessions_yield orchestration", () => {
     expect(result.meta.stopReason).toBeUndefined();
     expect(result.meta.pendingToolCalls).toBeUndefined();
   });
+
+  // ──────────────────────────────────────────────────────────────────────
+  // Integration repro: parent yield → child completion → durable inbox →
+  // next-turn drain. End-to-end coverage of the failure class that
+  // produced today's `delivery_failed` audit findings: a yielded parent
+  // session has no active embedded run, so the gateway agent-call dispatch
+  // returns a non-terminal `accepted/started/in_flight` status. The patch
+  // routes through the durable in-process system-event inbox keyed by the
+  // announce idempotency key; the parent drains the inbox at next
+  // turn-start. This test verifies the loop closes — the trigger message
+  // is in the inbox after the announce, and `drainSystemEvents` returns it
+  // for the next prompt build.
+  // ──────────────────────────────────────────────────────────────────────
+  it("end-to-end: yielded parent + child completion via direct-pending → durable inbox → next-turn drain", async () => {
+    // Use a canonical sessionKey (starts with 'agent:') so
+    // resolveRequesterStoreKey leaves it untouched.
+    const parentSessionKey = "agent:main:session:yield-integration-parent-key";
+    const parentSessionId = "yield-integration-parent-session";
+
+    // Stage 1: parent yields. After this attempt resolves with
+    // yieldDetected=true, the parent is removed from ACTIVE_EMBEDDED_RUNS
+    // and isStreaming() returns false — exactly the `not_streaming` state
+    // that makes embedded steer fail and triggers the patched fallback.
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        promptError: null,
+        sessionIdUsed: parentSessionId,
+        yieldDetected: true,
+      }),
+    );
+
+    const yieldResult = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      sessionId: parentSessionId,
+      sessionKey: parentSessionKey,
+      runId: "run-yield-integration",
+    });
+
+    expect(yieldResult.meta.stopReason).toBe("end_turn");
+    expect(yieldResult.meta.pendingToolCalls).toBeUndefined();
+    expect(isEmbeddedAgentRunActive(parentSessionId)).toBe(false);
+
+    // Sanity: a steer attempt now would fail with no_active_run — same
+    // condition that drives the announce flow's direct-dispatch branch.
+    const steerProbe = queueEmbeddedAgentMessageWithOutcome(parentSessionId, "would-be-steer");
+    expect(steerProbe.queued).toBe(false);
+
+    // Stage 2: child completion fires via deliverSubagentAnnouncement.
+    // Stub callGateway to mimic the `not_streaming` path: the gateway
+    // accepts the run but returns a non-terminal status, which is the
+    // exact bug-class signature in today's audit drops (4 of 4 had error
+    // "completion agent handoff is still pending").
+    resetSystemEventsForTest();
+    const callGatewayStub = vi.fn(async () => ({
+      runId: "agent:main:run:integration-pending",
+      status: "accepted" as const,
+      acceptedAt: Date.now(),
+    })) as unknown as typeof runtimeCallGateway;
+    subagentAnnounceTesting.setDepsForTest({
+      callGateway: callGatewayStub,
+      getRequesterSessionActivity: () => ({
+        sessionId: parentSessionId,
+        isActive: false, // mirrors yielded/non-streaming reality
+      }),
+    });
+
+    const triggerText = "child cipher:integration-test done: APPROVE — durable-queue integration";
+    const announceOrigin = {
+      channel: "discord",
+      to: "channel:integration-test",
+      accountId: "acct-integration",
+    } as const;
+
+    const announceResult = await deliverSubagentAnnouncement({
+      requesterSessionKey: parentSessionKey,
+      targetRequesterSessionKey: parentSessionKey,
+      triggerMessage: triggerText,
+      steerMessage: triggerText,
+      requesterOrigin: announceOrigin,
+      requesterSessionOrigin: announceOrigin,
+      completionDirectOrigin: announceOrigin,
+      directOrigin: announceOrigin,
+      requesterIsSubagent: false,
+      expectsCompletionMessage: true,
+      bestEffortDeliver: true,
+      directIdempotencyKey: "integration-durable-queue",
+      sourceTool: "sessions_spawn",
+    });
+
+    // Stage 3: announce was redirected to durable_queue (not failed).
+    expect(announceResult.delivered).toBe(true);
+    expect(announceResult.path).toBe("durable_queue");
+    expect(announceResult.error).toBeUndefined();
+
+    // The trigger message is in the parent's durable inbox before drain.
+    const queuedBeforeDrain = peekSystemEvents(parentSessionKey);
+    expect(queuedBeforeDrain).toEqual([triggerText]);
+
+    // Stage 4: simulate next-turn drain. drainSystemEvents is the
+    // primitive that the auto-reply pipeline calls when building the
+    // next prompt for an idle parent.
+    const drained = drainSystemEvents(parentSessionKey);
+    expect(drained).toEqual([triggerText]);
+
+    // Inbox is empty after drain; the parent's next prompt would carry
+    // the child completion as a System: line.
+    expect(peekSystemEvents(parentSessionKey)).toEqual([]);
+
+    // Cleanup: leaving stubbed deps in place would leak into any
+    // subsequent suite that imports subagent-announce-delivery.
+    subagentAnnounceTesting.setDepsForTest();
+    resetSystemEventsForTest();
+  }, 20_000);
 });

--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -1,11 +1,16 @@
 // Subagent announce delivery tests cover the last-mile routing used when child
 // runs report progress or completion back to the requester session.
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { OutboundDeliveryError } from "../infra/outbound/deliver-types.js";
 import {
   testing as sessionBindingServiceTesting,
   registerSessionBindingAdapter,
 } from "../infra/outbound/session-binding-service.js";
+import {
+  drainSystemEvents,
+  peekSystemEvents,
+  resetSystemEventsForTest,
+} from "../infra/system-events.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
 import { createChannelTestPluginBase, createTestRegistry } from "../test-utils/channel-plugins.js";
 import type {
@@ -4630,5 +4635,155 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       threadId: "171.222",
       bestEffortDeliver: true,
     });
+  });
+});
+
+describe("durable-queue fallback when direct handoff is pending", () => {
+  beforeEach(() => {
+    resetSystemEventsForTest();
+  });
+
+  afterEach(() => {
+    resetSystemEventsForTest();
+  });
+
+  // The canonical requester store key (resolveRequesterStoreKey) leaves keys
+  // that already start with "agent:" untouched. Using a canonical key in the
+  // test avoids the "agent:<inferred>:<raw>" remap and keeps the assertions
+  // clean.
+  const parentSessionKey = "agent:main:session:durable-queue-test-parent";
+
+  function pendingHandoffArgs(
+    overrides: Partial<Parameters<typeof deliverSubagentAnnouncement>[0]> = {},
+  ): Parameters<typeof deliverSubagentAnnouncement>[0] {
+    const callGateway = vi.fn(async () => ({
+      runId: "agent:main:run:announce-pending",
+      status: "accepted" as const,
+      acceptedAt: 4_000,
+    })) as unknown as typeof runtimeCallGateway;
+    testing.setDepsForTest({
+      callGateway,
+      getRequesterSessionActivity: () => ({
+        sessionId: "durable-queue-test-parent-session",
+        isActive: false,
+      }),
+      queueEmbeddedAgentMessageWithOutcome: createQueueOutcomeMock(false),
+    });
+
+    return {
+      requesterSessionKey: parentSessionKey,
+      targetRequesterSessionKey: parentSessionKey,
+      triggerMessage: "child cipher:abc done: APPROVE",
+      steerMessage: "child cipher:abc done: APPROVE",
+      requesterOrigin: slackThreadOrigin,
+      requesterSessionOrigin: slackThreadOrigin,
+      completionDirectOrigin: slackThreadOrigin,
+      directOrigin: slackThreadOrigin,
+      requesterIsSubagent: false,
+      expectsCompletionMessage: true,
+      bestEffortDeliver: true,
+      directIdempotencyKey: "durable-queue-test-idem",
+      sourceTool: "sessions_spawn",
+      ...overrides,
+    } as Parameters<typeof deliverSubagentAnnouncement>[0];
+  }
+
+  it("enqueues into the durable inbox when direct handoff is pending and parent is non-streaming", async () => {
+    const result = await deliverSubagentAnnouncement(pendingHandoffArgs());
+
+    expect(result.delivered).toBe(true);
+    expect(result.path).toBe("durable_queue");
+    expect(result.error).toBeUndefined();
+    expect(peekSystemEvents(parentSessionKey)).toEqual(["child cipher:abc done: APPROVE"]);
+  });
+
+  it("is idempotent on duplicate fallback fires for the same idempotency key", async () => {
+    const args = pendingHandoffArgs({
+      directIdempotencyKey: "durable-queue-test-dup",
+    });
+    const r1 = await deliverSubagentAnnouncement(args);
+    const r2 = await deliverSubagentAnnouncement(args);
+
+    expect(r1.path).toBe("durable_queue");
+    expect(r2.path).toBe("durable_queue");
+    // Inbox dedupes on (text, contextKey, deliveryContext); duplicate fires
+    // collapse to one entry.
+    expect(peekSystemEvents(parentSessionKey)).toEqual(["child cipher:abc done: APPROVE"]);
+  });
+
+  it("does not invoke durable fallback when parent is active-streaming (steered path wins)", async () => {
+    const callGateway = vi.fn(async () => ({
+      runId: "agent:main:run:announce-pending",
+      status: "accepted" as const,
+      acceptedAt: 4_000,
+    })) as unknown as typeof runtimeCallGateway;
+    testing.setDepsForTest({
+      callGateway,
+      getRequesterSessionActivity: () => ({
+        sessionId: "durable-queue-test-parent-session",
+        isActive: true,
+      }),
+      queueEmbeddedAgentMessageWithOutcome: createQueueOutcomeMock(true),
+    });
+
+    const result = await deliverSubagentAnnouncement({
+      requesterSessionKey: parentSessionKey,
+      targetRequesterSessionKey: parentSessionKey,
+      triggerMessage: "child active",
+      steerMessage: "child active",
+      requesterOrigin: slackThreadOrigin,
+      requesterIsSubagent: false,
+      expectsCompletionMessage: true,
+      directIdempotencyKey: "durable-queue-test-active",
+    });
+
+    expect(result.path).toBe("steered");
+    expect(peekSystemEvents(parentSessionKey)).toEqual([]);
+  });
+
+  it("does NOT redirect to durable_queue when expectedMediaUrls is non-empty (existing direct/media path preserved)", async () => {
+    const args = pendingHandoffArgs({
+      directIdempotencyKey: "durable-queue-test-media",
+      internalEvents: [
+        {
+          type: "task_completion",
+          source: "image_generation",
+          childSessionKey: "image_generate:task-test",
+          childSessionId: "task-test",
+          announceType: "image generation task",
+          taskLabel: "test image",
+          status: "ok",
+          statusLabel: "completed successfully",
+          result: "Generated.\nMEDIA:/tmp/generated-test.png",
+          mediaUrls: ["/tmp/generated-test.png"],
+          replyInstruction: "Deliver the generated image.",
+        },
+      ],
+    });
+    const result = await deliverSubagentAnnouncement(args);
+
+    // Either the existing direct/media path returns delivered:true
+    // (downstream of the patched branch) or the existing pending give-up
+    // returns delivered:false; the contract this test enforces is simply
+    // that the durable_queue branch is NOT taken when media is in play.
+    expect(result.path).not.toBe("durable_queue");
+    expect(peekSystemEvents(parentSessionKey)).toEqual([]);
+  });
+
+  it("records the result envelope shape consumers can route on", async () => {
+    const result = await deliverSubagentAnnouncement(
+      pendingHandoffArgs({
+        directIdempotencyKey: "durable-queue-test-shape",
+      }),
+    );
+
+    expect(result).toEqual({
+      delivered: true,
+      path: "durable_queue",
+      phases: expect.any(Array),
+    });
+    // Drain confirms the next-turn prompt would receive the trigger.
+    expect(drainSystemEvents(parentSessionKey)).toEqual(["child cipher:abc done: APPROVE"]);
+    expect(peekSystemEvents(parentSessionKey)).toEqual([]);
   });
 });

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -18,6 +18,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isOutboundDeliveryError } from "../infra/outbound/deliver-types.js";
 import type { ConversationRef } from "../infra/outbound/session-binding-service.js";
 import { sourceDeliveryTargetsMatch } from "../infra/outbound/source-delivery-plan.js";
+import { enqueueSystemEvent } from "../infra/system-events.js";
 import { stringifyRouteThreadId } from "../plugin-sdk/channel-route.js";
 import { normalizeAccountId } from "../routing/session-key.js";
 import { defaultRuntime } from "../runtime.js";
@@ -1499,12 +1500,46 @@ async function sendSubagentAnnounceDirectly(params: {
         expectedMediaUrls.length === 0 &&
         !requiresMessageToolDelivery
       ) {
-        return {
-          delivered: false,
-          path: "direct",
-          reason: "completion_handoff_pending",
-          error: "completion agent handoff is still pending",
-        };
+        // The gateway accepted the agent run but it has not yet reached a
+        // streaming/terminal state. This commonly happens when the
+        // requester parent is registered in ACTIVE_EMBEDDED_RUNS but its
+        // handle.isStreaming() is false (yielded, queued behind work,
+        // compaction-prep, or tool-result truncation). Returning
+        // {delivered:false} here is what produces today's `delivery_failed`
+        // audit findings: the requester is stuck waiting for an event that
+        // already arrived in the gateway but cannot deliver back.
+        //
+        // Instead, enqueue the trigger message into the requester's
+        // in-process durable system-event inbox keyed by the announce's
+        // direct idempotency key (which uniquely identifies this child
+        // announce). The inbox is drained on the requester's next
+        // turn-start (the same path used by jobs, hooks, restart
+        // sentinels, ACP child spawns, monitor events, and the
+        // group/channel completion path in task-registry). Idempotent on
+        // (text, contextKey, deliveryContext); MAX_EVENTS=20 per session.
+        try {
+          const durableContextKey = `subagent-announce:${params.directIdempotencyKey}`;
+          const durableDeliveryContext =
+            requesterSessionOrigin ?? completionExternalFallbackOrigin ?? directOrigin;
+          enqueueSystemEvent(params.triggerMessage, {
+            sessionKey: canonicalRequesterSessionKey,
+            contextKey: durableContextKey,
+            deliveryContext: durableDeliveryContext,
+          });
+          return {
+            delivered: true,
+            path: "durable_queue",
+          };
+        } catch {
+          // Fall through to the original give-up shape so existing
+          // retry/give-up bookkeeping stays as the safety net.
+          return {
+            delivered: false,
+            path: "direct",
+            reason: "completion_handoff_pending",
+            error: "completion agent handoff is still pending",
+          };
+        }
       }
       return {
         delivered: true,

--- a/src/agents/subagent-announce-dispatch.ts
+++ b/src/agents/subagent-announce-dispatch.ts
@@ -4,7 +4,20 @@
  * Completion handoff and requester-visible replies use this to choose between
  * steering a subagent and directly delivering a message, with phase evidence.
  */
-type SubagentDeliveryPath = "steered" | "direct" | "none";
+type SubagentDeliveryPath =
+  | "steered"
+  | "direct"
+  | "none"
+  /**
+   * The trigger message was committed to the requester's in-process
+   * durable system-event inbox because the direct agent-call dispatch
+   * returned a non-terminal pending status (e.g., gateway accepted but
+   * parent is yielded/queued/compaction-prep). The parent drains the
+   * inbox at next turn-start. Treated as a delivered path; downstream
+   * consumers that previously short-circuited on `direct`/`steered`
+   * should treat `durable_queue` as durable as well.
+   */
+  | "durable_queue";
 /** Stable reasons an announcement delivery can fail without throwing. */
 export type SubagentAnnounceDeliveryFailureReason =
   | "completion_handoff_pending"

--- a/src/plugin-sdk/agent-harness-task-runtime.test.ts
+++ b/src/plugin-sdk/agent-harness-task-runtime.test.ts
@@ -201,4 +201,25 @@ describe("agent-harness-task-runtime", () => {
       }),
     ).toBe(false);
   });
+
+  it("treats durable-queue path as a durable delivery", () => {
+    // The durable in-process system-event inbox is idempotent and bounded;
+    // the parent drains it on next turn-start. Once the announce flow
+    // commits to this path, monitor retry would just churn (the inbox
+    // dedupes duplicates but bookkeeping is wasted).
+    expect(
+      isDurableAgentHarnessCompletionDelivery({
+        delivered: true,
+        path: "durable_queue",
+      }),
+    ).toBe(true);
+    // delivered:false should still fail-fast even if the path field is
+    // unexpectedly "durable_queue" (defensive).
+    expect(
+      isDurableAgentHarnessCompletionDelivery({
+        delivered: false,
+        path: "durable_queue",
+      } as Parameters<typeof isDurableAgentHarnessCompletionDelivery>[0]),
+    ).toBe(false);
+  });
 });

--- a/src/plugin-sdk/agent-harness-task-runtime.ts
+++ b/src/plugin-sdk/agent-harness-task-runtime.ts
@@ -263,6 +263,15 @@ export function isDurableAgentHarnessCompletionDelivery(
   if (delivery.path === "steered") {
     return true;
   }
+  if (delivery.path === "durable_queue") {
+    // The durable in-process system-event inbox idempotently holds the
+    // trigger message until the parent's next turn-start drains it. Once
+    // the announce flow returns this path, the completion is committed —
+    // monitor retry would only enqueue a duplicate (which the inbox
+    // dedupes by `(text, contextKey, deliveryContext)`, but the
+    // bookkeeping churn is wasted).
+    return true;
+  }
   if (delivery.path !== "direct") {
     return false;
   }


### PR DESCRIPTION
## Summary

Replace the give-up branch in `subagent-announce-delivery.ts` (when the direct subagent-announce handoff fires `completion_handoff_pending`) with a durable fallback that enqueues the completion trigger into the requester's in-process system-event inbox via the existing `enqueueSystemEvent` primitive (`src/infra/system-events.ts`). The original `{delivered:false, error:"completion agent handoff is still pending"}` shape is preserved as a try/catch safety net if the enqueue itself fails.

## Motivation

Today's `openclaw tasks audit --json` on a self-hosted gateway (`srv1355327`, OpenClaw `2026.5.26`) showed **34 `delivery_failed` + 37 `stale_blocked`** rows, all with error `"completion agent handoff is still pending"`. RCA traced every one to the same code path: when the parent session is active but non-streaming (yielded, queued behind work, mid compaction-prep), the gateway accepts the agent-run dispatch but returns a non-terminal status. The existing give-up logic exhausted its retries and discarded the child's completion content — even though the content was preserved on disk in the child's worktree the whole time.

The new durable-fallback path uses the same primitive (`enqueueSystemEvent`) that's already used for:
- Cron job firings
- Hook events
- Restart-sentinel deliveries
- ACP child-spawn announcements
- Cross-session monitor events

So no new infrastructure surface is introduced. The fallback is keyed `subagent-announce:${params.directIdempotencyKey}`, idempotent on `(text, contextKey, deliveryContext)`, and drained by the parent on next turn-start via the standard `drainSystemEvents` consumer.

## Changes

6 files, +365/-9:

- `src/agents/subagent-announce-delivery.ts` — replace the give-up return with durable-queue enqueue + try/catch safety net
- `src/agents/subagent-announce-dispatch.ts` — extend `SubagentDeliveryPath` union from `"steered" | "direct" | "none"` to include `"durable_queue"`
- `src/plugin-sdk/agent-harness-task-runtime.ts` — extend `isDurableAgentHarnessCompletionDelivery` to treat `durable_queue` path as durable (so monitor retry does not re-fire)
- `src/agents/subagent-announce-delivery.test.ts` — 5 new unit tests covering the durable-queue branch + counterfactual probes
- `src/agents/embedded-agent-runner/sessions-yield.orchestration.test.ts` — 1 new integration test reproducing the original bug + verifying the fix end-to-end
- `src/plugin-sdk/agent-harness-task-runtime.test.ts` — 1 new test for `isDurableAgentHarnessCompletionDelivery(durable_queue)`

## Architectural invariant

The fix is **self-contained at runtime**: no code path reads `warden-status`, `workspace/memory`, or `.openclaw/` ledger paths to make a delivery decision. Status files remain observability-only, not load-bearing. Verified via grep gate in CI patch.

## Tests

Local on commit `49e43d03` (6.2 lane), re-run on rebased `c9dc427a`:
- `subagent-announce-delivery.test.ts`: 102/102 pass (97 pre-existing + 5 new)
- `sessions-yield.orchestration.test.ts`: 5/5 pass (4 pre-existing + 1 new)
- `agent-harness-task-runtime.test.ts`: 7/7 pass (6 pre-existing + 1 new)
- Typecheck: 0 errors in all 6 touched files. (Pre-existing TS4058 on `src/secrets/config-io.ts:12` is unchanged from main.)

## Independent review

A second-pass review on the 6.2 lane found **all 11 checklist items + all 6 counterfactual probes green**. Notable items probed:
1. Empty `directIdempotencyKey` collision risk: not exploitable in practice — `enqueueSystemEvent` dedupes on the full `(text, contextKey, deliveryContext)` triple, not `contextKey` alone, so worst case is degraded observability not lost delivery.
2. Crash window between `enqueueSystemEvent` returning success and parent's next `drainSystemEvents` call: thin silent-loss window exists at parent process death; recommended as follow-up enhancement (TTL/staleness sweep over `peekSystemEventEntries`) but **not a regression of current behavior** since the give-up branch already lost deliveries during this window.
3. Existing 5.26 give-up shape (no `reason` field) exactly preserved in the catch fallback — no behavior delta for callers that match on `error` text only.

## Compatibility

- Backward-compatible: the durable-queue path is a NEW positive-delivery shape (`{delivered:true, path:"durable_queue"}`), not a change to existing failure shapes.
- Existing retry/give-up bookkeeping continues to fire if `enqueueSystemEvent` itself throws (try/catch safety net).
- Migration: no schema/state migration. The system-event inbox is already populated and drained by every running gateway.

## Related

Reported as a recurring class of zombie task-runs in self-hosted deployments. Operator-side watchdog cron `b03ce892-ed27-4b1b-a3c5-8abde6c0660a` exists as a downstream mitigation; can be retired once this fix ships in the next release.
