### PR TITLE
fix(plugins): cache plugin setup registry to kill the /models CPU storm

### DIFF
--- a/src/plugins/setup-registry.test.ts
+++ b/src/plugins/setup-registry.test.ts
@@ -931,4 +931,206 @@ describe("setup-registry module loader", () => {
     expect(loadSetupModule).toHaveBeenCalledTimes(1);
     expect(registerSetup).toHaveBeenCalledTimes(7);
   });
+
+  describe("result cache (ambient process.env)", () => {
+    function mockOpenAiProviderPlugin(): void {
+      mocks.loadPluginManifestRegistry.mockReturnValue({
+        plugins: [
+          {
+            id: "openai",
+            origin: "bundled",
+            rootDir: makeTempDir(),
+            setup: { providers: [{ id: "openai" }] },
+          },
+        ],
+        diagnostics: [],
+      });
+    }
+
+    it("memoizes no-config resolutions without rescanning manifests", () => {
+      mockOpenAiProviderPlugin();
+      mocks.loadPluginManifestRegistry.mockClear();
+      const first = resolvePluginSetupRegistry();
+      const second = resolvePluginSetupRegistry();
+      expect(second).toEqual(first);
+      expect(second).not.toBe(first);
+      expect(mocks.loadPluginManifestRegistry).toHaveBeenCalledTimes(1);
+    });
+
+    it("recomputes after clearPluginSetupRegistryCache (reset contract)", () => {
+      mockOpenAiProviderPlugin();
+      mocks.loadPluginManifestRegistry.mockClear();
+      const first = resolvePluginSetupRegistry();
+      expect(mocks.loadPluginManifestRegistry).toHaveBeenCalledTimes(1);
+      clearPluginSetupRegistryCache();
+      // A hit also returns a fresh clone; only the loader call count proves invalidation.
+      const second = resolvePluginSetupRegistry();
+      expect(mocks.loadPluginManifestRegistry).toHaveBeenCalledTimes(2);
+      expect(second).toEqual(first);
+    });
+
+    it("recomputes after clearPluginMetadataLifecycleCaches (install/reload/doctor)", async () => {
+      const { clearPluginMetadataLifecycleCaches } = await import("./plugin-metadata-lifecycle.js");
+      mockOpenAiProviderPlugin();
+      mocks.loadPluginManifestRegistry.mockClear();
+      const first = resolvePluginSetupRegistry();
+      expect(mocks.loadPluginManifestRegistry).toHaveBeenCalledTimes(1);
+      clearPluginMetadataLifecycleCaches();
+      const second = resolvePluginSetupRegistry();
+      expect(mocks.loadPluginManifestRegistry).toHaveBeenCalledTimes(2);
+      expect(second).toEqual(first);
+    });
+
+    it("keys distinct plugin-id scopes without collision", () => {
+      mockOpenAiProviderPlugin();
+      const all = resolvePluginSetupRegistry();
+      const scoped = resolvePluginSetupRegistry({ pluginIds: ["__no_such_plugin__"] });
+      expect(scoped).not.toBe(all);
+      expect(scoped.providers).toStrictEqual([]);
+      const scopedAgain = resolvePluginSetupRegistry({ pluginIds: ["__no_such_plugin__"] });
+      expect(scopedAgain).toEqual(scoped);
+      expect(scopedAgain).not.toBe(scoped);
+    });
+
+    it("does not let returned entries mutate cached setup results", () => {
+      const pluginRoot = makeTempDir();
+      writeSetupApiStub(pluginRoot);
+      mocks.loadPluginManifestRegistry.mockReturnValue({
+        plugins: [
+          {
+            id: "openai",
+            origin: "bundled",
+            rootDir: pluginRoot,
+            setup: {
+              providers: [{ id: "openai" }],
+              cliBackends: ["codex-cli"],
+              requiresRuntime: true,
+            },
+          },
+        ],
+        diagnostics: [],
+      });
+      mocks.createJiti.mockImplementation(() => {
+        return () => ({
+          default: {
+            register(api: {
+              registerProvider: (provider: {
+                id: string;
+                label: string;
+                aliases: string[];
+                auth: [];
+              }) => void;
+              registerCliBackend: (backend: {
+                id: string;
+                config: { command: string; args: string[] };
+              }) => void;
+            }) {
+              api.registerProvider({
+                id: "openai",
+                label: "OpenAI",
+                aliases: ["openai"],
+                auth: [],
+              });
+              api.registerCliBackend({
+                id: "codex-cli",
+                config: { command: "codex", args: ["run"] },
+              });
+            },
+          },
+        });
+      });
+
+      const first = resolvePluginSetupRegistry();
+      const firstProvider = first.providers[0]?.provider;
+      const firstBackend = first.cliBackends[0]?.backend;
+      if (!firstProvider || !firstBackend) {
+        throw new Error("Expected setup provider and CLI backend");
+      }
+      firstProvider.label = "Mutated";
+      firstProvider.aliases?.push("mutated");
+      const firstBackendConfig = firstBackend.config as { command: string; args: string[] };
+      firstBackendConfig.command = "mutated";
+      firstBackendConfig.args.push("mutated");
+
+      const second = resolvePluginSetupRegistry();
+      expect(second.providers[0]?.provider).toMatchObject({
+        id: "openai",
+        label: "OpenAI",
+        aliases: ["openai"],
+      });
+      expect(second.cliBackends[0]?.backend.config).toMatchObject({
+        command: "codex",
+        args: ["run"],
+      });
+
+      second.providers[0]?.provider.aliases?.push("mutated-again");
+      const secondBackendConfig = second.cliBackends[0]?.backend.config as {
+        command: string;
+        args: string[];
+      };
+      secondBackendConfig.args.push("mutated-again");
+
+      const third = resolvePluginSetupRegistry();
+      expect(third.providers[0]?.provider.aliases).toEqual(["openai"]);
+      expect(third.cliBackends[0]?.backend.config).toMatchObject({
+        command: "codex",
+        args: ["run"],
+      });
+      expect(mocks.loadPluginManifestRegistry).toHaveBeenCalledTimes(1);
+    });
+
+    it("keys ambient entries by discovery environment", () => {
+      const firstRoot = makeTempDir();
+      const secondRoot = makeTempDir();
+      writeSetupApiStub(firstRoot);
+      writeSetupApiStub(secondRoot);
+      mocks.loadPluginManifestRegistry.mockImplementation(
+        (params?: { env?: NodeJS.ProcessEnv }) => {
+          const id = params?.env?.OPENCLAW_BUNDLED_PLUGINS_DIR === secondRoot ? "second" : "first";
+          return {
+            plugins: [
+              {
+                id,
+                origin: "bundled",
+                rootDir: id === "second" ? secondRoot : firstRoot,
+                setup: { providers: [{ id }] },
+              },
+            ],
+            diagnostics: [],
+          };
+        },
+      );
+      mocks.createJiti.mockImplementation((modulePath: string) => {
+        const id = modulePath.includes(secondRoot) ? "second" : "first";
+        return () => ({
+          default: {
+            register(api: {
+              registerProvider: (provider: { id: string; label: string; auth: [] }) => void;
+            }) {
+              api.registerProvider({ id, label: id, auth: [] });
+            },
+          },
+        });
+      });
+      const previousBundledDir = process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
+
+      try {
+        process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = firstRoot;
+        expect(resolvePluginSetupRegistry().providers.map((entry) => entry.provider.id)).toEqual([
+          "first",
+        ]);
+        process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = secondRoot;
+        expect(resolvePluginSetupRegistry().providers.map((entry) => entry.provider.id)).toEqual([
+          "second",
+        ]);
+      } finally {
+        if (previousBundledDir === undefined) {
+          delete process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
+        } else {
+          process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = previousBundledDir;
+        }
+      }
+      expect(mocks.loadPluginManifestRegistry).toHaveBeenCalledTimes(2);
+    });
+  });
 });

--- a/src/plugins/setup-registry.ts
+++ b/src/plugins/setup-registry.ts
@@ -10,7 +10,12 @@ import {
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { buildPluginApi } from "./api-builder.js";
 import { collectPluginConfigContractMatches } from "./config-contracts.js";
+import { getCurrentPluginMetadataSnapshotState } from "./current-plugin-metadata-state.js";
 import type { PluginManifestRecord, PluginManifestRegistry } from "./manifest-registry.js";
+import { createPluginCacheKey, PluginLruCache } from "./plugin-cache-primitives.js";
+import { resolvePluginControlPlaneFingerprint } from "./plugin-control-plane-context.js";
+import { registerPluginMetadataProcessMemoLifecycleClear } from "./plugin-metadata-lifecycle.js";
+import { resolvePluginMetadataSnapshotMemoEnvFingerprint } from "./plugin-metadata-snapshot.js";
 import {
   createPluginModuleLoaderCache,
   getCachedPluginModuleLoader,
@@ -95,15 +100,30 @@ const NOOP_LOGGER: PluginLogger = {
 const moduleLoaders: PluginModuleLoaderCache = createPluginModuleLoaderCache();
 let moduleLoaderFactoryForTest: PluginModuleLoaderFactory | undefined;
 
+const MAX_SETUP_REGISTRY_CACHE_ENTRIES = 16;
+let setupRegistrySnapshotIdSeq = 0;
+let setupRegistrySnapshotIds = new WeakMap<object, string>();
+const setupManifestRegistryCache = new PluginLruCache<PluginManifestRegistry>(
+  MAX_SETUP_REGISTRY_CACHE_ENTRIES,
+);
+const pluginSetupRegistryCache = new PluginLruCache<PluginSetupRegistry>(
+  MAX_SETUP_REGISTRY_CACHE_ENTRIES,
+);
+
 export function clearPluginSetupRegistryCache(): void {
   moduleLoaders.clear();
+  setupRegistrySnapshotIds = new WeakMap();
+  setupManifestRegistryCache.clear();
+  pluginSetupRegistryCache.clear();
 }
+registerPluginMetadataProcessMemoLifecycleClear(clearPluginSetupRegistryCache);
 
 export function setPluginSetupRegistryModuleLoaderFactoryForTest(
   factory: PluginModuleLoaderFactory | undefined,
 ): void {
   moduleLoaderFactoryForTest = factory;
-  moduleLoaders.clear();
+  // Cached results were built through the previous factory; drop them too.
+  clearPluginSetupRegistryCache();
 }
 
 function getModuleLoader(modulePath: string) {
@@ -336,6 +356,109 @@ function matchesProvider(provider: ProviderPlugin, providerId: string): boolean 
   );
 }
 
+function resolveSetupRegistryCacheKey(params?: {
+  config?: OpenClawConfig;
+  workspaceDir?: string;
+  env?: NodeJS.ProcessEnv;
+  pluginIds?: readonly string[];
+}): string | null {
+  const env = params?.env ?? process.env;
+  if (env !== process.env) {
+    return null;
+  }
+  return createPluginCacheKey([
+    "setup-registry",
+    resolvePluginControlPlaneFingerprint({
+      config: params?.config,
+      env,
+      workspaceDir: params?.workspaceDir,
+    }),
+    resolvePluginMetadataSnapshotMemoEnvFingerprint(env),
+    resolveCurrentSetupSnapshotCacheId(),
+    process.cwd(),
+    params?.pluginIds ? [...params.pluginIds].toSorted() : null,
+  ]);
+}
+
+function resolveCurrentSetupSnapshotCacheId(): string {
+  const { snapshot } = getCurrentPluginMetadataSnapshotState();
+  if (!snapshot || typeof snapshot !== "object") {
+    return "nosnap";
+  }
+  let id = setupRegistrySnapshotIds.get(snapshot);
+  if (id === undefined) {
+    id = `s${++setupRegistrySnapshotIdSeq}`;
+    setupRegistrySnapshotIds.set(snapshot, id);
+  }
+  return id;
+}
+
+function cloneSetupRegistryValue<T>(value: T, seen = new WeakMap<object, unknown>()): T {
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+  const cached = seen.get(value);
+  if (cached !== undefined) {
+    return cached as T;
+  }
+  if (value instanceof Date) {
+    const clone = new Date(value);
+    seen.set(value, clone);
+    return clone as T;
+  }
+  if (value instanceof RegExp) {
+    const clone = new RegExp(value.source, value.flags);
+    clone.lastIndex = value.lastIndex;
+    seen.set(value, clone);
+    return clone as T;
+  }
+  if (Array.isArray(value)) {
+    const clone: unknown[] = [];
+    seen.set(value, clone);
+    clone.push(...value.map((entry) => cloneSetupRegistryValue(entry, seen)));
+    return clone as T;
+  }
+  if (value instanceof Map) {
+    const clone = new Map<unknown, unknown>();
+    seen.set(value, clone);
+    for (const [key, entry] of value.entries()) {
+      clone.set(cloneSetupRegistryValue(key, seen), cloneSetupRegistryValue(entry, seen));
+    }
+    return clone as T;
+  }
+  if (value instanceof Set) {
+    const clone = new Set<unknown>();
+    seen.set(value, clone);
+    for (const entry of value.values()) {
+      clone.add(cloneSetupRegistryValue(entry, seen));
+    }
+    return clone as T;
+  }
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) {
+    // Class-prototyped values are shared by reference: setup registrations must
+    // treat them as immutable, or a caller mutation corrupts later cache hits.
+    return value;
+  }
+  const clone = Object.create(prototype) as Record<PropertyKey, unknown>;
+  seen.set(value, clone);
+  for (const key of Reflect.ownKeys(value)) {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    if (!descriptor) {
+      continue;
+    }
+    if ("value" in descriptor) {
+      descriptor.value = cloneSetupRegistryValue(descriptor.value, seen);
+    }
+    Object.defineProperty(clone, key, descriptor);
+  }
+  return clone as T;
+}
+
+function cloneSetupRegistry(registry: PluginSetupRegistry): PluginSetupRegistry {
+  return cloneSetupRegistryValue(registry);
+}
+
 function loadSetupManifestRegistry(params?: {
   config?: OpenClawConfig;
   workspaceDir?: string;
@@ -343,13 +466,24 @@ function loadSetupManifestRegistry(params?: {
   pluginIds?: readonly string[];
 }) {
   const env = params?.env ?? process.env;
-  return loadPluginManifestRegistryForPluginRegistry({
+  const cacheKey = resolveSetupRegistryCacheKey(params);
+  if (cacheKey !== null) {
+    const cached = setupManifestRegistryCache.get(cacheKey);
+    if (cached) {
+      return cached;
+    }
+  }
+  const registry = loadPluginManifestRegistryForPluginRegistry({
     config: params?.config,
     workspaceDir: params?.workspaceDir,
     env,
     pluginIds: params?.pluginIds,
     includeDisabled: true,
   });
+  if (cacheKey !== null) {
+    setupManifestRegistryCache.set(cacheKey, registry);
+  }
+  return registry;
 }
 
 function findUniqueSetupManifestOwner(params: {
@@ -474,6 +608,15 @@ export function resolvePluginSetupRegistry(params?: {
     return empty;
   }
 
+  // Cache only self-scanned results; a caller-supplied manifestRegistry owns the derivation.
+  const resultCacheKey = params?.manifestRegistry ? null : resolveSetupRegistryCacheKey(params);
+  if (resultCacheKey !== null) {
+    const cached = pluginSetupRegistryCache.get(resultCacheKey);
+    if (cached) {
+      return cloneSetupRegistry(cached);
+    }
+  }
+
   const providers: SetupProviderEntry[] = [];
   const cliBackends: SetupCliBackendEntry[] = [];
   const configMigrations: SetupConfigMigrationEntry[] = [];
@@ -576,6 +719,10 @@ export function resolvePluginSetupRegistry(params?: {
     autoEnableProbes,
     diagnostics,
   } satisfies PluginSetupRegistry;
+  if (resultCacheKey === null) {
+    return registry;
+  }
+  pluginSetupRegistryCache.set(resultCacheKey, cloneSetupRegistry(registry));
   return registry;
 }
 


### PR DESCRIPTION
## Summary

What problem does this PR solve?

TL;DR: `/model` command in the chat (author tested on Telegram) was runinng for dozen seconds at 100% CPU at VPS, the same after picking provider from the list, the same after picking model. The whole process of picking model was slightly below the whole minute

- A shipped regression that breaks the chat `/models` workflow. Since #85341 (2026-05-27, first shipped in v2026.5.28), the per-model visibility helpers in `src/auto-reply/reply/commands-models.ts` probe with `isCliRuntimeProvider(normalized, { includeSetupRegistry: true })` where they previously called plain `isCliRuntimeProvider(normalized)`. Every probe now calls `resolvePluginSetupRegistry` → `loadSetupManifestRegistry`, which re-scans all plugin manifests and re-executes plugin setup modules — a synchronous ~65ms rebuild, issued hundreds of times per listing. On the stock bundled plugin set with an **empty config**, one `/models` data build pins a CPU core at 100% for ~49s (measured below); each step of the list → pick provider → pick model flow pays it again (~15–20s per step observed live on a real config).

Why does this matter now?

- This is current-stable behavior, not an edge case: every install on ≥ v2026.5.28 — including 2026.6.5 — has it, in every chat channel, since the handler is channel-agnostic. The workflow is effectively broken (three steps ≈ three long stalls while the gateway burns a core on synchronous rebuilds), and the cost scales with configured providers/models, so it keeps getting worse.

What is the intended outcome?

- Setup-registry resolution becomes O(1) after the first build: two bounded (16-entry) `PluginLruCache` result caches (manifest scan + resolved registry), keyed by the plugin control-plane fingerprint, the discovery-env fingerprint, the current metadata-snapshot identity, `process.cwd()`, and the sorted `pluginIds` scope. Output is identical; only the recomputation goes away.

What is intentionally out of scope?

- No config, schema, or default changes; no provider/auth/routing changes. The separate `readOnly:false` model-catalog build cost (plugin-metadata snapshot memo) is not addressed here.

What does success look like?

- `/models`, provider pick, and model pick respond immediately; the setup registry is rebuilt only on install/reload/doctor or when a key input actually changes.

What should reviewers focus on?

- Cache-key completeness versus the inputs that can change the result (control-plane fingerprint incl. plugins policy hash, env fingerprint, snapshot identity, cwd, scope).
- Mutation isolation: clone-on-store and clone-on-hit, mirroring `src/channels/plugins/read-only.ts`; function entries (`migrate`/`probe`/auth hooks) pass by reference and receive fresh config at call time.
- Invalidation riding the existing plugin-metadata lifecycle (`registerPluginMetadataProcessMemoLifecycleClear`), the same mechanism the sibling plugin-metadata snapshot memo uses.

## Linked context

Which issue does this close?

- None — no tracking issue; found, profiled, and fixed while dogfooding a live install.

Which issues, PRs, or discussions are related?

- #85341 introduced the regression: it switched `isModelsBrowseVisibleProvider` and `usesUnfilteredCatalogModels` to probe with `{ includeSetupRegistry: true }`, making every per-model visibility check rebuild the setup registry. First release tag carrying it: v2026.5.28.
- `a52c4d101a` (`perf(agents): avoid full setup registry for runtime aliases`, 2026-05-31) already removed the same rebuild from a sibling hot path. This PR fixes it at the registry-resolution layer instead, so `/models` and every other ambient caller are covered by one bounded cache rather than per-call-site workarounds.

Was this requested by a maintainer or owner?

- No; self-found while dogfooding. CPU profile + strace on the live gateway pointed at `resolvePluginSetupRegistry` rebuilds issued per model from `isCliRuntimeProvider({ includeSetupRegistry: true })`.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: the shipped `/models` regression above (since v2026.5.28, introduced by #85341) — list → pick provider → pick model no longer pins a CPU core for ~15–20s per step; the per-model setup-registry probe is served from a bounded process cache with identical output.
- Real environment tested: my live OpenClaw dogfood install — Oracle Linux Server 10.1 aarch64, Node v26.0.0, gateway running from this source checkout as a systemd user service with two Telegram bot providers. Same box where the storm was originally hit and profiled. Measurements were taken at `53471df2ef`; the current head `7ad7958539` is that exact patch rebased onto current `main` (`git range-diff` reports the commit unchanged, and none of the commits between the measurement base and current `main` touch the measured files).
- Exact steps or command run after this patch: `bash run-proof.sh` (script below). It checks out the comparison base (`e386e60025`, the 2026.6.5 release commit this branch sat on) and the fix into two throwaway git worktrees, then runs one and the same measurement file — sha256 printed on both sides, identical — against each checkout. The measurement file imports the production modules straight from `src/` and times the two calls behind the chat `/models` command: `resolvePluginSetupRegistry()` (the call `/models` issues once per model) ×100, and `buildModelsProviderData(cfg, undefined, { view: "all" })` (the full `/models` data build). The plugin discovery underneath is the real loader scanning this checkout's real plugin set — 35 providers come back on both sides. Every command is echoed before it executes and all output prints directly to the console.

  _Both harness files and the full copyable terminal output are in the first comment below (sha256-pinned in the run)._

- Evidence after fix: the four `MEASURED` lines below are the result (warmup excluded, labeled in the run):

  ```
  [e386e60025] MEASURED probe x100 — the per-model call of /models: total=6438.7ms perCall=64.387ms
  [e386e60025] MEASURED /models data build — buildModelsProviderData(view=all): 49315.0ms (providers=35)

  [53471df2ef] MEASURED probe x100 — the per-model call of /models: total=23.0ms perCall=0.230ms
  [53471df2ef] MEASURED /models data build — buildModelsProviderData(view=all): 149.6ms (providers=35)
  ```

  | timed production call | base `e386e60025` | this fix | speedup |
    |---|---:|---:|---:|
  | `resolvePluginSetupRegistry()` — the per-model probe | 64.4 ms/call | 0.23 ms/call | ~280× |
  | `buildModelsProviderData(view: "all")` — the `/models` build | 49,315 ms | 150 ms | ~330× |

  Screenshot of the full terminal run:

  <img width="1106" height="1329" alt="Terminal run of run-proof.sh: both worktrees checked out, identical proof.mts sha256 on both sides, MEASURED lines showing 64.387ms→0.230ms per probe and 49315.0ms→149.6ms for the /models build" src="https://github.com/user-attachments/assets/c76f321b-2382-401b-a3d6-24d65acc7c41" />

- Observed result after fix: the `/models` data build dropped from ~49s of pinned CPU to ~0.15s; the per-model probe from ~64ms to ~0.23ms; provider output identical on both sides (`providers=35`). The live gateway on this box runs this exact change and Telegram `/models` answers instantly where it used to pin a core for ~15–20s per step.
- What was not tested: other chat channels (Discord/WhatsApp) were not exercised live — the command handler is channel-agnostic; the desktop/web app model picker was not exercised. The measurement file passes a minimal config object to `buildModelsProviderData`; the cost it measures (setup-registry rebuild per probe) does not depend on config contents, and the `resolvePluginSetupRegistry()` probe is exactly the production no-config, ambient-env call.
- Proof limitations or environment constraints: a second independent run of the same script on this box reproduced the numbers within a few percent (49,486ms / 149.6ms, 65.6ms / 0.22ms per probe). Numbers are from a shared-tenancy ARM VM; relative improvement is the meaningful part.
- Before evidence (optional but encouraged): the base-side `MEASURED` lines above; the original incident was one core pinned at 100% for ~15–20s per `/models` step with near-zero file I/O (manifests already OS-cached — a pure recomputation loop).

## Tests and validation

Which commands did you run?

- `pnpm test src/plugins/setup-registry.test.ts` — 29 passed (includes 6 new cache tests), re-run on the rebased head `7ad7958539`
- `node scripts/run-tsgo.mjs -p tsconfig.core.json` (core typecheck) — clean
- `pnpm check:import-cycles` — 0 runtime value cycles
- `oxfmt` on the touched files
- Structured review: `autoreview --mode commit --commit HEAD --engine claude --model claude=claude-fable-5 --thinking claude=medium` → `autoreview clean: no accepted/actionable findings reported`, overall `patch is correct (0.85)`

What regression coverage was added or updated?

- Memoizes no-config resolutions without rescanning manifests (manifest-loader call count).
- Recomputes after `clearPluginSetupRegistryCache` and after `clearPluginMetadataLifecycleCaches` (call-count proof, not object identity).
- Distinct `pluginIds` scopes do not collide.
- Returned entries cannot mutate cached results (nested `aliases`/`config.args` mutation attempts across hits).
- Ambient entries are keyed by the discovery environment; a custom `env` or caller-supplied `manifestRegistry` bypasses the cache entirely.

What failed before this fix, if known?

- The `/models` workflow regression above, shipped since v2026.5.28: output stayed correct, but every probe re-scanned plugin manifests and re-executed plugin setup modules, so each workflow step stalled the gateway for the duration of hundreds of synchronous rebuilds.

If no test was added, why not?

- n/a — tests added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

- No. Output is identical; only latency/CPU improve.

Did config, environment, or migration behavior change? (`Yes/No`)

- No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

- No.

What is the highest-risk area?

- A stale setup registry inside a long-lived gateway process (cache returning pre-reload state after plugin/config changes).

How is that risk mitigated?

- The cache key includes the current plugin-metadata snapshot identity plus the control-plane/policy and env fingerprints, so reloads and config changes change the key; install/reload/doctor flows clear it via `registerPluginMetadataProcessMemoLifecycleClear` (the same lifecycle the plugin-metadata snapshot memo uses); calls with a custom `env` or a caller-supplied `manifestRegistry` bypass the cache entirely. Residual cross-process staleness matches the repo's documented process-stable plugin-metadata policy.

## Current review state

What is the next action?

- Maintainer review + ClawSweeper re-review. The head was rebased onto current `main` (`418d7e1e83`) as `7ad7958539`; the patch is unchanged from the previously reviewed `53471df2ef` (`git range-diff` shows the commit as identical).

What is still waiting on author, maintainer, CI, or external proof?

- CI + ClawSweeper on the new head.

Which bot or reviewer comments were addressed?

- ClawSweeper's two rank-up moves: (1) env/discovery-sensitive cache-key coverage — the `result cache (ambient process.env)` block in `src/plugins/setup-registry.test.ts` covers env-keyed entries, lifecycle invalidation asserted by manifest-loader call counts, scope separation, and mutation isolation across hits; (2) real `/models` proof from an OpenClaw setup — the terminal run, screenshot, and live-gateway result above. Earlier structured Claude review found 3 P3s (vacuous invalidation assertions, test-only loader-factory swap not clearing result caches, undocumented clone sharing contract) — all fixed; re-run came back clean. No human review comments yet.
