### PR TITLE
fix(memory): resolve adapter default model in plain status identity check

### DIFF
--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -493,6 +493,39 @@ describe("memory index", () => {
     }
   });
 
+  it("keeps status clean when configured model defaults to the adapter model (#90413)", async () => {
+    const dbPath = path.join(workspaceDir, "index-default-model-status.sqlite");
+    // Index under the provider's resolved default model, as provider init does.
+    const indexCfg = createCfg({
+      storePath: dbPath,
+      provider: "gemini",
+      model: "gemini-embed",
+      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
+    });
+    const indexManager = await getFreshManager(indexCfg);
+    await indexManager.sync({ reason: "test", force: true });
+    await indexManager.close?.();
+
+    // Plain status path before provider init: settings.model is the empty
+    // default, so identity must resolve the adapter model instead of comparing
+    // meta against a blank "expected" model.
+    const statusCfg = createCfg({
+      storePath: dbPath,
+      provider: "gemini",
+      model: "",
+      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
+    });
+    const statusManager = await getFreshManager(statusCfg, "status");
+    try {
+      const status = statusManager.status();
+
+      expect(status.dirty).toBe(false);
+      expect(status.custom?.indexIdentity).toEqual({ status: "valid" });
+    } finally {
+      await statusManager.close?.();
+    }
+  });
+
   it("does not search stale rows when index metadata is missing", async () => {
     const dbPath = path.join(workspaceDir, "index-missing-meta-cutover.sqlite");
     const cfg = createCfg({

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -40,6 +40,7 @@ import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coer
 import {
   createEmbeddingProvider,
   resolveEmbeddingProviderAdapterId,
+  resolveEmbeddingProviderFallbackModel,
   type EmbeddingProvider,
   type EmbeddingProviderId,
   type EmbeddingProviderRuntime,
@@ -299,6 +300,14 @@ export abstract class MemoryManagerSyncOps {
     hasIndexedChunks?: boolean;
   }): MemoryIndexIdentityState {
     const hasProviderOverride = params && "provider" in params;
+    // The plain `memory status` path resolves identity before the provider is
+    // initialized, so settings.model is still the unresolved default: an empty
+    // string when no explicit model is configured. Mirror provider init's model
+    // resolution here (configured model, else adapter default) so identity does
+    // not falsely report a mismatch against meta with a blank "expected" model.
+    const configuredModel =
+      this.settings.model.trim() ||
+      resolveEmbeddingProviderFallbackModel(this.settings.provider, "", this.cfg);
     const configuredProvider =
       this.settings.provider === "none"
         ? null
@@ -306,7 +315,7 @@ export abstract class MemoryManagerSyncOps {
             id:
               resolveEmbeddingProviderAdapterId(this.settings.provider, this.cfg) ??
               this.settings.provider,
-            model: this.settings.model,
+            model: configuredModel,
           };
     const provider = hasProviderOverride
       ? params.provider!


### PR DESCRIPTION
## Summary

`openclaw memory status` always printed `Index identity: index was built for model <X>, expected` (blank expected) and `Vector search: paused until memory is rebuilt`, even right after a successful `openclaw memory index --force`. As a result `memory_search` tool calls returned `disabled: true, error: "index metadata is missing"`. `openclaw memory status --deep` reported the system healthy — only the plain status path was broken.

Fixes #90413.

### Root cause

`MemoryManagerSyncOps.resolveCurrentIndexIdentityState` built the *configured* provider identity from `this.settings.model` directly. For an agent with the default `memorySearch.model` (the empty string `""`), the plain `memory status` path runs **before** the provider is initialized, so `settings.model` is still that unresolved empty default. The empty string survives the existing `??`/direct assignment, so identity compared `meta.model` (e.g. `text-embedding-3-small`) against `""`, declared a mismatch, and printed a blank "expected" model. The `--deep` / index paths initialize the provider first, where the adapter default model is resolved, so they were unaffected.

### Fix

Resolve the configured model the same way provider initialization does — use the trimmed configured model when set, otherwise fall back to the adapter's default via the existing `resolveEmbeddingProviderFallbackModel` helper. This keeps the plain status identity check symmetric with the initialized path. The `refreshIndexIdentityDirty` uninitialized branch delegates to this same function, so it is fixed in one place; the initialized branch already carries the resolved `provider.model`.

### Automated tests (supplemental)

- `node scripts/run-vitest.mjs extensions/memory-core/src/memory/index.test.ts` — new regression test passes; all identity tests pass (5 passed).
- `oxfmt --check` clean on both changed files.

### Real behavior proof

Real `openclaw` CLI built from this source tree (`OpenClaw 2026.6.2`), isolated `OPENCLAW_HOME`, agent `main` with `memorySearch.provider: "openai"` and **no explicit model** (the empty-string default that triggers the bug), pointed at a local OpenAI-compatible `/v1/embeddings` endpoint so indexing runs fully offline. The exact same on-disk index is reused for both captures — only the patched binary differs, no reindex between them.

- **Behavior addressed:** plain `openclaw memory status` falsely reporting an `Index identity` mismatch with a blank "expected" model and `Vector search: paused` when `memorySearch.model` is the empty default, which in turn reports `memory_search` as disabled.
- **Real environment tested:** real `openclaw` CLI built from this source tree, run against a live local `/v1/embeddings` endpoint with an isolated `OPENCLAW_HOME`; the index was built once with `openclaw memory index --agent main --force` (`Memory index updated (main).`).
- **Exact steps or command run after this patch:** `OPENCLAW_HOME=… openclaw memory status --agent main` (identical index on disk; the only difference between the two captures below is the patched binary).
- **Evidence after fix:** Before the patch, plain `openclaw memory status --agent main` printed the false identity mismatch and pause:

  ```
  Memory Search (main)
  Provider: openai (requested: openai)
  Indexed: 1/1 files · 1 chunks
  Dirty: yes
  Index identity: index was built for model text-embedding-3-small, expected 
  Vector search: paused until memory is rebuilt
  Fix: Run: openclaw memory status --index --agent main
  ```

  After the patch, the same on-disk index (no reindex) reports healthy — the `Index identity` and `Vector search: paused` lines are gone and `Dirty` flips to `no`:

  ```
  Memory Search (main)
  Provider: openai (requested: openai)
  Sources: memory
  Dirty: no
  By source:
  Vector store: unknown
  Vector dims: 16
  FTS: ready
  ```

- **Observed result after fix:** plain `memory status` reports the existing index as valid, so `memory_search` is no longer reported as `disabled`/`index metadata is missing`. `openclaw memory search "fallback embedding provider" --agent main` returns the indexed chunk (`0.627 memory/notes.md:1-5`) in both builds, matching the report that CLI search keeps working while plain status falsely pauses.
- **What was not tested:** a Homebrew-packaged install (verified against a source build instead) and a hosted embedding endpoint (a local OpenAI-compatible `/v1/embeddings` endpoint stood in for `text-embedding-3-small`, which only affects the stored vectors, not the identity-resolution path under test).
