### PR TITLE
fix(diagnostics): evict orphaned tool/model activity on owner-less run end

### DIFF
--- a/docs/gateway/opentelemetry.md
+++ b/docs/gateway/opentelemetry.md
@@ -258,6 +258,14 @@ Recovery emits structured `session.recovery.requested` and
 only after a mutating recovery outcome (`aborted` or `released`) and only if the
 same processing generation is still current.
 
+When a run ends and no embedded-run owner remains for the session, any leftover
+native tool or model-call activity is orphaned (it can never report completion).
+OpenClaw evicts those markers and emits a structured `session.activity.evicted`
+event (`reason=orphaned_no_owner`, with `evictedTools`/`evictedModelCalls`
+counts) so operators can distinguish recovered stale state from a real active
+tool. This prevents an orphaned `tool_call` record from surviving to re-block
+later turns on the same session key as `blocked_tool_call`.
+
 Only `session.stuck` emits the `openclaw.session.stuck` counter, the
 `openclaw.session.stuck_age_ms` histogram, and the `openclaw.session.stuck`
 span. Repeated `session.stuck` diagnostics back off while the session remains

--- a/docs/gateway/opentelemetry.md
+++ b/docs/gateway/opentelemetry.md
@@ -229,6 +229,7 @@ message bodies are also approved for export.
 - `openclaw.session.recovery.requested` (counter, attrs: `openclaw.state`, `openclaw.action`, `openclaw.active_work_kind`, `openclaw.reason`)
 - `openclaw.session.recovery.completed` (counter, attrs: `openclaw.state`, `openclaw.action`, `openclaw.status`, `openclaw.active_work_kind`, `openclaw.reason`)
 - `openclaw.session.recovery.age_ms` (histogram, attrs: same as the matching recovery counter)
+- `openclaw.session.activity.evicted` (counter, attrs: `openclaw.reason`; counts orphaned tool/model activity markers evicted when no embedded owner remains)
 - `openclaw.run.attempt` (counter, attrs: `openclaw.attempt`)
 
 ### Session liveness telemetry
@@ -262,9 +263,10 @@ When a run ends and no embedded-run owner remains for the session, any leftover
 native tool or model-call activity is orphaned (it can never report completion).
 OpenClaw evicts those markers and emits a structured `session.activity.evicted`
 event (`reason=orphaned_no_owner`, with `evictedTools`/`evictedModelCalls`
-counts) so operators can distinguish recovered stale state from a real active
-tool. This prevents an orphaned `tool_call` record from surviving to re-block
-later turns on the same session key as `blocked_tool_call`.
+counts), exported as the `openclaw.session.activity.evicted` counter, so
+operators can distinguish recovered stale state from a real active tool. This
+prevents an orphaned `tool_call` record from surviving to re-block later turns
+on the same session key as `blocked_tool_call`.
 
 Only `session.stuck` emits the `openclaw.session.stuck` counter, the
 `openclaw.session.stuck_age_ms` histogram, and the `openclaw.session.stuck`

--- a/docs/gateway/prometheus.md
+++ b/docs/gateway/prometheus.md
@@ -127,6 +127,7 @@ For traces, logs, OTLP push, and OpenTelemetry GenAI semantic attributes, see [O
 | `openclaw_session_stuck_age_seconds`             | histogram | `reason`, `state`                                                                         |
 | `openclaw_session_recovery_total`                | counter   | `action`, `active_work_kind`, `state`, `status`                                           |
 | `openclaw_session_recovery_age_seconds`          | histogram | `action`, `active_work_kind`, `state`, `status`                                           |
+| `openclaw_session_activity_evicted_total`        | counter   | `reason`                                                                                  |
 | `openclaw_liveness_warning_total`                | counter   | `reason`                                                                                  |
 | `openclaw_liveness_sessions`                     | gauge     | `state`                                                                                   |
 | `openclaw_liveness_event_loop_delay_p99_seconds` | histogram | `reason`                                                                                  |

--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -3972,6 +3972,32 @@ describe("diagnostics-otel service", () => {
     await service.stop?.(ctx);
   });
 
+  test("exports evicted orphaned activity counter by total markers", async () => {
+    const service = createDiagnosticsOtelService();
+    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { metrics: true });
+    await service.start(ctx);
+
+    emitTrustedDiagnosticEvent({
+      type: "session.activity.evicted",
+      sessionId: "session-should-not-export",
+      sessionKey: "key-should-not-export",
+      reason: "orphaned_no_owner",
+      evictedTools: 2,
+      evictedModelCalls: 1,
+    });
+    await flushDiagnosticEvents();
+
+    const evictedCall = firstCounterAddCall("openclaw.session.activity.evicted");
+    expect(evictedCall[0]).toBe(3);
+    expect(evictedCall[1]?.["openclaw.reason"]).toBe("orphaned_no_owner");
+    const evictedCalls = JSON.stringify(
+      telemetryState.counters.get("openclaw.session.activity.evicted")?.add.mock.calls,
+    );
+    expect(evictedCalls).not.toContain("session-should-not-export");
+    expect(evictedCalls).not.toContain("key-should-not-export");
+    await service.stop?.(ctx);
+  });
+
   test("does not export model or tool content unless capture is explicitly enabled", async () => {
     const service = createDiagnosticsOtelService();
     const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true, metrics: true });

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -1425,6 +1425,13 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
           description: "Age of sessions selected for recovery",
         },
       );
+      const sessionActivityEvictedCounter = meter.createCounter(
+        "openclaw.session.activity.evicted",
+        {
+          unit: "1",
+          description: "Orphaned tool/model activity markers evicted with no remaining owner",
+        },
+      );
       const talkEventCounter = meter.createCounter("openclaw.talk.event", {
         unit: "1",
         description: "Talk events emitted by type",
@@ -2437,6 +2444,16 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         sessionRecoveryAgeHistogram.record(evt.ageMs, attrs);
       };
 
+      const recordSessionActivityEvicted = (
+        evt: Extract<DiagnosticEventPayload, { type: "session.activity.evicted" }>,
+      ) => {
+        const evicted = evt.evictedTools + evt.evictedModelCalls;
+        if (evicted <= 0) {
+          return;
+        }
+        sessionActivityEvictedCounter.add(evicted, { "openclaw.reason": evt.reason });
+      };
+
       const talkEventAttrs = (evt: TalkDiagnosticEvent): Record<string, string> => ({
         "openclaw.talk.brain": lowCardinalityAttr(evt.brain),
         "openclaw.talk.event_type": lowCardinalityAttr(evt.talkEventType),
@@ -3382,9 +3399,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
               recordSessionRecoveryCompleted(evt);
               return;
             case "session.activity.evicted":
-              // Orphaned tool/model eviction is captured by stability records and
-              // the recovery counters; no dedicated OTel metric (parity with
-              // session.long_running / session.stalled).
+              recordSessionActivityEvicted(evt);
               return;
             case "run.attempt":
               recordRunAttempt(evt);

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -3381,6 +3381,11 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
             case "session.recovery.completed":
               recordSessionRecoveryCompleted(evt);
               return;
+            case "session.activity.evicted":
+              // Orphaned tool/model eviction is captured by stability records and
+              // the recovery counters; no dedicated OTel metric (parity with
+              // session.long_running / session.stalled).
+              return;
             case "run.attempt":
               recordRunAttempt(evt);
               return;

--- a/extensions/diagnostics-prometheus/src/service.test.ts
+++ b/extensions/diagnostics-prometheus/src/service.test.ts
@@ -1,6 +1,5 @@
 // Diagnostics Prometheus tests cover service plugin behavior.
 import type { DiagnosticEventPrivateData } from "openclaw/plugin-sdk/diagnostic-runtime";
-// Diagnostics Prometheus tests cover service plugin behavior.
 import { describe, expect, it, vi } from "vitest";
 import type { DiagnosticEventMetadata, DiagnosticEventPayload } from "../api.js";
 import { createDiagnosticsPrometheusExporter, testApi } from "./service.js";
@@ -638,6 +637,32 @@ describe("diagnostics-prometheus service", () => {
     expect(rendered).not.toContain("key-should-not-export");
     expect(rendered).not.toContain("talk-session-should-not-export");
     expect(rendered).not.toContain("turn-should-not-export");
+  });
+
+  it("counts evicted orphaned activity markers without exporting raw ids", () => {
+    const store = testApi.createPrometheusMetricStore();
+
+    testApi.recordDiagnosticEvent(
+      store,
+      {
+        ...baseEvent(),
+        type: "session.activity.evicted",
+        sessionId: "session-should-not-export",
+        sessionKey: "key-should-not-export",
+        reason: "orphaned_no_owner",
+        evictedTools: 2,
+        evictedModelCalls: 1,
+      },
+      trusted,
+    );
+
+    const rendered = testApi.renderPrometheusMetrics(store);
+
+    expect(rendered).toContain(
+      'openclaw_session_activity_evicted_total{reason="orphaned_no_owner"} 3',
+    );
+    expect(rendered).not.toContain("session-should-not-export");
+    expect(rendered).not.toContain("key-should-not-export");
   });
 
   it("caps metric series growth and reports dropped series", () => {

--- a/extensions/diagnostics-prometheus/src/service.ts
+++ b/extensions/diagnostics-prometheus/src/service.ts
@@ -784,6 +784,18 @@ function recordDiagnosticEvent(
         seconds(evt.ageMs),
       );
       return;
+    case "session.activity.evicted": {
+      const evicted = evt.evictedTools + evt.evictedModelCalls;
+      if (evicted > 0) {
+        store.counter(
+          "openclaw_session_activity_evicted_total",
+          "Orphaned tool/model activity markers evicted with no remaining owner.",
+          { reason: evt.reason },
+          evicted,
+        );
+      }
+      return;
+    }
     case "queue.lane.enqueue":
     case "queue.lane.dequeue":
       store.gauge(

--- a/src/auto-reply/reply/reply-run-registry.test.ts
+++ b/src/auto-reply/reply/reply-run-registry.test.ts
@@ -1,7 +1,10 @@
 // Tests active reply run registry add, lookup, and cleanup behavior.
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { DiagnosticEventPayload } from "../../infra/diagnostic-events.js";
+import { onInternalDiagnosticEvent } from "../../infra/diagnostic-events.js";
 import {
   getDiagnosticSessionActivitySnapshot,
+  markDiagnosticToolStartedForTest,
   resetDiagnosticRunActivityForTest,
 } from "../../logging/diagnostic-run-activity.js";
 import { MAX_TIMER_TIMEOUT_MS } from "../../shared/number-coercion.js";
@@ -89,6 +92,49 @@ describe("reply run registry", () => {
         sessionKey: "agent:main:telegram:direct:chat-1",
       }).activeWorkKind,
     ).toBeUndefined();
+  });
+
+  it("evicts an orphaned native tool when a reply run completes without its completion", () => {
+    const sessionKey = "agent:main:slack:channel:chat-1";
+    const evicted: DiagnosticEventPayload[] = [];
+    const unsubscribe = onInternalDiagnosticEvent((event) => {
+      if (event.type === "session.activity.evicted") {
+        evicted.push(event);
+      }
+    });
+    try {
+      const operation = createReplyOperation({
+        sessionKey,
+        sessionId: "session-1",
+        resetTriggered: false,
+      });
+      // A native tool starts but never emits completion (e.g. Codex app-server
+      // tool whose owner is torn down before the completion event arrives).
+      markDiagnosticToolStartedForTest({
+        sessionId: "session-1",
+        sessionKey,
+        runId: "run-1",
+        toolName: "bash",
+        toolCallId: "t1",
+      });
+
+      operation.complete();
+
+      // The orphaned tool marker must not survive to re-block later turns on the
+      // same session key as blocked_tool_call.
+      expect(getDiagnosticSessionActivitySnapshot({ sessionKey }).activeWorkKind).toBeUndefined();
+    } finally {
+      unsubscribe();
+    }
+
+    expect(evicted).toHaveLength(1);
+    expect(evicted[0]).toMatchObject({
+      type: "session.activity.evicted",
+      sessionKey,
+      reason: "orphaned_no_owner",
+      evictedTools: 1,
+      evictedModelCalls: 0,
+    });
   });
 
   it("clears queued operations immediately on user abort", () => {

--- a/src/auto-reply/reply/reply-run-registry.test.ts
+++ b/src/auto-reply/reply/reply-run-registry.test.ts
@@ -1,7 +1,11 @@
 // Tests active reply run registry add, lookup, and cleanup behavior.
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { DiagnosticEventPayload } from "../../infra/diagnostic-events.js";
-import { onInternalDiagnosticEvent } from "../../infra/diagnostic-events.js";
+import {
+  emitInternalDiagnosticEvent,
+  onInternalDiagnosticEvent,
+  waitForDiagnosticEventsDrained,
+} from "../../infra/diagnostic-events.js";
 import {
   getDiagnosticSessionActivitySnapshot,
   markDiagnosticToolStartedForTest,
@@ -135,6 +139,31 @@ describe("reply run registry", () => {
       evictedTools: 1,
       evictedModelCalls: 0,
     });
+  });
+
+  it("ignores a tool start that drains after an owner-less reply completion", async () => {
+    const sessionKey = "agent:main:slack:channel:chat-2";
+    const sessionId = "session-1";
+    const op = createReplyOperation({ sessionKey, sessionId, resetTriggered: false });
+
+    // A native tool start is emitted while the run is active but stays queued in
+    // the async diagnostic pipeline (not yet drained into activity state).
+    emitInternalDiagnosticEvent({
+      type: "tool.execution.started",
+      runId: "run-1",
+      sessionId,
+      sessionKey,
+      toolName: "bash",
+      toolCallId: "t1",
+    });
+
+    // The reply run completes (owner-less teardown) before the start drains.
+    op.complete();
+    expect(getDiagnosticSessionActivitySnapshot({ sessionKey }).activeWorkKind).toBeUndefined();
+
+    // Draining the queued start must NOT re-arm an owner-less marker.
+    await waitForDiagnosticEventsDrained();
+    expect(getDiagnosticSessionActivitySnapshot({ sessionKey }).activeWorkKind).toBeUndefined();
   });
 
   it("clears queued operations immediately on user abort", () => {

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -257,6 +257,24 @@ export type DiagnosticSessionRecoveryCompletedEvent = DiagnosticSessionRecoveryB
   stale?: boolean;
 };
 
+/** Reasons orphaned diagnostic run activity is evicted without its own completion. */
+export type DiagnosticSessionActivityEvictedReason = "orphaned_no_owner";
+
+/**
+ * Emitted when stale native tool/model activity is evicted for a session because
+ * no embedded-run owner remains to complete it. Distinguishes recovered orphaned
+ * state (which previously survived to re-block later turns as `blocked_tool_call`)
+ * from a real active tool that is still owned.
+ */
+export type DiagnosticSessionActivityEvictedEvent = DiagnosticBaseEvent & {
+  type: "session.activity.evicted";
+  sessionKey?: string;
+  sessionId?: string;
+  reason: DiagnosticSessionActivityEvictedReason;
+  evictedTools: number;
+  evictedModelCalls: number;
+};
+
 export type DiagnosticSessionTurnCreatedEvent = DiagnosticBaseEvent & {
   type: "session.turn.created";
   runId: string;
@@ -664,6 +682,7 @@ export type DiagnosticEventPayload =
   | DiagnosticSessionStuckEvent
   | DiagnosticSessionRecoveryRequestedEvent
   | DiagnosticSessionRecoveryCompletedEvent
+  | DiagnosticSessionActivityEvictedEvent
   | DiagnosticSessionTurnCreatedEvent
   | DiagnosticLaneEnqueueEvent
   | DiagnosticLaneDequeueEvent

--- a/src/logging/diagnostic-run-activity.ts
+++ b/src/logging/diagnostic-run-activity.ts
@@ -1,6 +1,7 @@
 // Diagnostic run activity helpers summarize run lifecycle activity for diagnostics.
 import {
   emitInternalDiagnosticEvent,
+  getInternalDiagnosticEventSequence,
   onInternalDiagnosticEvent,
   type DiagnosticEventPayload,
   type DiagnosticSessionActiveWorkKind,
@@ -331,10 +332,56 @@ export function markDiagnosticEmbeddedRunEnded(params: {
   // emitted completion would otherwise survive and re-block later turns on the
   // same sessionKey as blocked_tool_call. A still-active inner run keeps them.
   const clearAllActivity = params.clearRunActivity !== false;
-  if (clearAllActivity || activity.activeEmbeddedRuns.size === 0) {
-    clearActiveRunMarkers(activity, clearAllActivity ? undefined : "orphaned_no_owner");
+  if (clearAllActivity) {
+    clearActiveRunMarkers(activity, undefined);
+  } else if (activity.activeEmbeddedRuns.size === 0) {
+    evictOrphanedActivityMarkers(activity, params);
   }
   touchSessionActivity(activity, "embedded_run:ended");
+}
+
+// Owner-less reply-run teardown: the embedded owner is gone, so any leftover
+// tool/model markers are orphaned and must be evicted. Tool/model start events
+// are async-queued, so a start emitted before this teardown can still drain
+// after it; without a sequence cutoff that late start would re-arm an owner-less
+// marker and restore the blocked_tool_call leak. Fence the session owner refs at
+// the current event sequence (mirrors stuck-session recovery) before clearing.
+function evictOrphanedActivityMarkers(
+  activity: SessionActivity,
+  params: { sessionId?: string; sessionKey?: string },
+): void {
+  rememberRecoveredOwnerStartEventCutoffs(
+    activity,
+    collectOrphanOwnerRefs(activity, params),
+    getInternalDiagnosticEventSequence(),
+  );
+  clearActiveRunMarkers(activity, "orphaned_no_owner");
+}
+
+function collectOrphanOwnerRefs(
+  activity: SessionActivity,
+  params: { sessionId?: string },
+): Set<string> {
+  const refs = new Set<string>();
+  const add = (ref: string | undefined) => {
+    const trimmed = ref?.trim();
+    if (trimmed) {
+      refs.add(trimmed);
+    }
+  };
+  // The session id covers a late start for this run even if no marker has been
+  // recorded yet; marker run/session ids cover starts that key off a run id.
+  add(params.sessionId);
+  add(activity.sessionId);
+  for (const tool of activity.activeTools.values()) {
+    add(tool.runId);
+    add(tool.sessionId);
+  }
+  for (const modelCall of activity.activeModelCalls.values()) {
+    add(modelCall.runId);
+    add(modelCall.sessionId);
+  }
+  return refs;
 }
 
 // Clears all tool/model markers for a session. When an evictReason is given the

--- a/src/logging/diagnostic-run-activity.ts
+++ b/src/logging/diagnostic-run-activity.ts
@@ -1,8 +1,10 @@
 // Diagnostic run activity helpers summarize run lifecycle activity for diagnostics.
 import {
+  emitInternalDiagnosticEvent,
   onInternalDiagnosticEvent,
   type DiagnosticEventPayload,
   type DiagnosticSessionActiveWorkKind,
+  type DiagnosticSessionActivityEvictedReason,
 } from "../infra/diagnostic-events.js";
 
 type SessionActivity = {
@@ -321,11 +323,41 @@ export function markDiagnosticEmbeddedRunEnded(params: {
     return;
   }
   activity.activeEmbeddedRuns.delete(resolveEmbeddedRunWorkKey(params));
-  if (params.clearRunActivity !== false) {
-    activity.activeTools.clear();
-    activity.activeModelCalls.clear();
+  // clearRunActivity defaults to true: the caller owns the canonical run
+  // teardown and clears tool/model markers outright. A caller opts out only
+  // when an inner embedded run may still be draining under the same session
+  // (the reply-run wrapper). Even then, once NO embedded owner remains we must
+  // evict leftover tool/model markers: a native tool/model record that never
+  // emitted completion would otherwise survive and re-block later turns on the
+  // same sessionKey as blocked_tool_call. A still-active inner run keeps them.
+  const clearAllActivity = params.clearRunActivity !== false;
+  if (clearAllActivity || activity.activeEmbeddedRuns.size === 0) {
+    clearActiveRunMarkers(activity, clearAllActivity ? undefined : "orphaned_no_owner");
   }
   touchSessionActivity(activity, "embedded_run:ended");
+}
+
+// Clears all tool/model markers for a session. When an evictReason is given the
+// markers are orphaned (no embedded owner can complete them); emit a structured
+// event so operators can tell recovered stale state from a real active tool.
+function clearActiveRunMarkers(
+  activity: SessionActivity,
+  evictReason: DiagnosticSessionActivityEvictedReason | undefined,
+): void {
+  const evictedTools = activity.activeTools.size;
+  const evictedModelCalls = activity.activeModelCalls.size;
+  activity.activeTools.clear();
+  activity.activeModelCalls.clear();
+  if (evictReason && evictedTools + evictedModelCalls > 0) {
+    emitInternalDiagnosticEvent({
+      type: "session.activity.evicted",
+      sessionId: activity.sessionId,
+      sessionKey: activity.sessionKey,
+      reason: evictReason,
+      evictedTools,
+      evictedModelCalls,
+    });
+  }
 }
 
 function resolveEmbeddedRunWorkKey(params: { sessionId: string; workKey?: string }): string {

--- a/src/logging/diagnostic-stability.ts
+++ b/src/logging/diagnostic-stability.ts
@@ -321,6 +321,11 @@ function sanitizeDiagnosticEvent(event: DiagnosticEventPayload): DiagnosticStabi
       }
       assignReasonCode(record, event.outcomeReason ?? event.reason);
       break;
+    case "session.activity.evicted":
+      record.level = "warning";
+      record.count = event.evictedTools + event.evictedModelCalls;
+      assignReasonCode(record, event.reason);
+      break;
     case "session.turn.created":
       record.source = event.agentId;
       record.channel = event.channel;

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -285,6 +285,104 @@ describe("diagnostic session activity aliases", () => {
       getDiagnosticSessionActivitySnapshot({ sessionId: "s1", sessionKey: "main" }).activeWorkKind,
     ).toBeUndefined();
   });
+
+  it("evicts orphaned tool/model markers when the last owner ends without clearing run activity", () => {
+    const evicted: DiagnosticEventPayload[] = [];
+    const unsubscribe = onDiagnosticEvent((event) => {
+      if (event.type === "session.activity.evicted") {
+        evicted.push(event);
+      }
+    });
+    try {
+      markDiagnosticEmbeddedRunStarted({
+        sessionId: "s1",
+        sessionKey: "main",
+        workKey: "reply:main",
+      });
+      // Native tool + model call that never emit completion events.
+      markDiagnosticToolStartedForTest({
+        sessionId: "s1",
+        sessionKey: "main",
+        toolName: "bash",
+        toolCallId: "t1",
+      });
+      markDiagnosticModelStartedForTest({
+        sessionId: "s1",
+        sessionKey: "main",
+        runId: "run-1",
+        provider: "openai",
+        model: "gpt-5.5",
+      });
+
+      // The reply-run wrapper ends and opts out of clearing run activity, but it
+      // is the last owner: the orphaned markers must be evicted, not leaked.
+      markDiagnosticEmbeddedRunEnded({
+        sessionId: "s1",
+        sessionKey: "main",
+        workKey: "reply:main",
+        clearRunActivity: false,
+      });
+
+      expect(
+        getDiagnosticSessionActivitySnapshot({ sessionId: "s1", sessionKey: "main" })
+          .activeWorkKind,
+      ).toBeUndefined();
+    } finally {
+      unsubscribe();
+    }
+
+    expect(evicted).toHaveLength(1);
+    expect(evicted[0]).toMatchObject({
+      type: "session.activity.evicted",
+      sessionKey: "main",
+      reason: "orphaned_no_owner",
+      evictedTools: 1,
+      evictedModelCalls: 1,
+    });
+  });
+
+  it("keeps tool markers when an inner embedded run is still active", () => {
+    const evicted: DiagnosticEventPayload[] = [];
+    const unsubscribe = onDiagnosticEvent((event) => {
+      if (event.type === "session.activity.evicted") {
+        evicted.push(event);
+      }
+    });
+    try {
+      // Inner embedded run (keyed by sessionId) plus the reply-run wrapper.
+      markDiagnosticEmbeddedRunStarted({ sessionId: "s1", sessionKey: "main" });
+      markDiagnosticEmbeddedRunStarted({
+        sessionId: "s1",
+        sessionKey: "main",
+        workKey: "reply:main",
+      });
+      markDiagnosticToolStartedForTest({
+        sessionId: "s1",
+        sessionKey: "main",
+        toolName: "bash",
+        toolCallId: "t1",
+      });
+
+      // The wrapper ends first while the inner run is still draining; its tool
+      // markers must be preserved as genuinely active work.
+      markDiagnosticEmbeddedRunEnded({
+        sessionId: "s1",
+        sessionKey: "main",
+        workKey: "reply:main",
+        clearRunActivity: false,
+      });
+
+      const snapshot = getDiagnosticSessionActivitySnapshot({
+        sessionId: "s1",
+        sessionKey: "main",
+      });
+      expect(snapshot.activeWorkKind).toBe("tool_call");
+      expect(snapshot.hasActiveEmbeddedRun).toBe(true);
+    } finally {
+      unsubscribe();
+    }
+    expect(evicted).toHaveLength(0);
+  });
 });
 
 describe("logger import side effects", () => {


### PR DESCRIPTION
## Summary

Stale native `tool_call` diagnostic activity could survive a clean run teardown and re-block later turns on the same `sessionKey` as `blocked_tool_call` (#87310).

`markDiagnosticEmbeddedRunEnded({ clearRunActivity: false })` — used by the reply-run wrapper so it does not clobber a still-draining inner embedded run — removed only the embedded-run marker and left tool/model markers untouched. When a native tool never emitted its matching `tool.execution.completed` event (e.g. the embedded Codex app-server tool whose owner is torn down first), that marker leaked into the per-session activity (keyed by `sessionKey`). A later turn then saw `activeWorkKind=tool_call` with a very large `activeToolAgeMs`, was classified `blocked_tool_call`, and produced repeated `session.stalled` diagnostics — and recovery could even abort the fresh, healthy run.

### Fix

- `src/logging/diagnostic-run-activity.ts`: when an embedded/reply run ends and **no embedded-run owner remains** for the session, leftover tool/model markers are now evicted (they can never report completion). A still-active inner run keeps its markers, preserving the original reason `clearRunActivity: false` existed.
- New structured `session.activity.evicted` event (`reason=orphaned_no_owner`, `evictedTools`/`evictedModelCalls`) so operators can distinguish recovered stale state from a real active tool (issue items 3 & 5). Recorded in the stability ring buffer and exported as the `openclaw.session.activity.evicted` (OTel) / `openclaw_session_activity_evicted_total` (Prometheus) counter.
- Docs updated in `docs/gateway/opentelemetry.md` and `docs/gateway/prometheus.md`.

Recovery-driven cleanup (`clearDiagnosticEmbeddedRunActivityForSession`) is unchanged and remains observable via the existing `session.recovery.completed` event; this change targets the non-recovery clean-teardown path that previously evicted nothing and leaked silently.

### Real behavior proof (runtime diagnostics)

- **Behavior addressed:** Orphaned native `tool_call` (and `model_call`) diagnostic activity surviving a clean reply-run completion and re-blocking the next turn on the same `sessionKey` as `blocked_tool_call`.
- **Real environment tested:** An in-process runtime harness exercising the real diagnostic runtime — `startDiagnosticHeartbeat` (30s warn / 60s abort) wired to the real `recoverStuckDiagnosticSession` from `diagnostic-stuck-session-recovery.runtime.ts` and the real `reply-run-registry` — on macOS, Node 22.22.2. The `diagnosticLogger.warn` output below is the actual emitted runtime log, not a mocked assertion.
- **Exact steps or command run after this patch:** Drove the real heartbeat: turn 1 opened a reply operation on `agent:main:slack:channel:REDACTED`, started a native `bash` tool that never emits `tool.execution.completed`, then completed the reply run and marked the session idle; turn 2 queued a new message on the same session key and went `processing`; advanced 8 heartbeat cycles past the 60s abort threshold and captured `diagnosticLogger.warn`. The same harness was run once with the patch reverted to capture the "before" lines.
- **Observed result after fix:** The `reason=blocked_tool_call classification=blocked_tool_call` line no longer appears for the follow-up turn; the orphaned `bash` marker is evicted at reply completion and the follow-up turn is handled as a recoverable stale lane (`release_lane`), so the session converges instead of repeatedly re-blocking.
- **Evidence after fix:** Redacted runtime diagnostic logger output captured from the real diagnostic heartbeat + stuck-session recovery runtime (synthetic session ids):

```
BEFORE (patch reverted) — turn 2 is misclassified off the orphaned tool from turn 1:
stalled session: sessionId=SESSION-2 sessionKey=agent:main:slack:channel:REDACTED state=processing age=60s queueDepth=1 reason=blocked_tool_call classification=blocked_tool_call activeWorkKind=tool_call lastProgress=embedded_run:ended lastProgressAge=60s activeTool=bash activeToolCallId=T1 activeToolAge=60s terminalProgressStale=true recovery=checking

AFTER (this patch) — the orphaned bash marker is evicted on reply completion; turn 2 is a recoverable stale lane, never blocked_tool_call:
stuck session: sessionId=SESSION-2 sessionKey=agent:main:slack:channel:REDACTED state=processing age=60s queueDepth=1 reason=queued_work_without_active_run classification=stale_session_state lastProgress=embedded_run:ended lastProgressAge=60s terminalProgressStale=true recovery=checking
stuck session recovery: sessionId=SESSION-2 sessionKey=agent:main:slack:channel:REDACTED age=60s action=release_lane aborted=false drained=true released=0
stuck session recovery outcome: status=released action=release_lane sessionId=SESSION-2 sessionKey=agent:main:slack:channel:REDACTED lane=session:agent:main:slack:channel:REDACTED released=0
```

- **What was not tested:** A live external systemd gateway + Slack socket-mode deployment was not stood up; the timing-sensitive hung-native-tool condition is non-deterministic in production and was reproduced deterministically through the real in-process runtime path. OTel/Prometheus exporter wiring is covered by exporter tests rather than a scraped live collector.

## Verification

Suites run after the patch: `diagnostic`, `reply-run-registry`, `diagnostic-stability`, `diagnostic-stuck-session-recovery.runtime`/`.integration`, `diagnostic-session-attention`, `diagnostics-otel`, `diagnostics-prometheus` — all green. `tsgo` core + core-test + extensions + extensions-test clean; oxlint/oxfmt clean. New regression tests:
- `reply-run-registry`: evicts an orphaned native tool when a reply run completes without its completion.
- `diagnostic`: evicts orphaned tool/model markers when the last owner ends without clearing run activity; keeps tool markers when an inner embedded run is still active.
- `diagnostics-otel` / `diagnostics-prometheus`: export the `session.activity.evicted` counter by total markers without leaking raw ids.

Closes #87310
