### PR TITLE
[codex] Add cron isolated context-token regression test

### DIFF
--- a/src/cron/isolated-agent/run.context-tokens.test.ts
+++ b/src/cron/isolated-agent/run.context-tokens.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { makeIsolatedAgentTurnParams, setupRunCronIsolatedAgentTurnSuite } from "./run.suite-helpers.js";
+import {
+  loadRunCronIsolatedAgentTurn,
+  lookupContextTokensMock,
+  runWithModelFallbackMock,
+} from "./run.test-harness.js";
+
+const runCronIsolatedAgentTurn = await loadRunCronIsolatedAgentTurn();
+
+describe("runCronIsolatedAgentTurn context token lookup", () => {
+  setupRunCronIsolatedAgentTurnSuite();
+
+  it("disables async context-token loading when recording isolated-run telemetry", async () => {
+    runWithModelFallbackMock.mockImplementation(async ({ provider, model, run }) => {
+      const result = await run(provider, model);
+      return { result, provider, model, attempts: [] };
+    });
+
+    const result = await runCronIsolatedAgentTurn(
+      makeIsolatedAgentTurnParams({
+        job: {
+          id: "cron-context-tokens",
+          payload: {
+            kind: "agentTurn",
+            agentId: "default",
+            message: "return a final answer",
+          },
+        },
+      }),
+    );
+
+    expect(result.status).toBe("ok");
+    expect(lookupContextTokensMock).toHaveBeenCalledWith("gpt-4", { allowAsyncLoad: false });
+  });
+});

--- a/src/cron/isolated-agent/run.test-harness.ts
+++ b/src/cron/isolated-agent/run.test-harness.ts
@@ -36,6 +36,7 @@ export const resolveThinkingDefaultMock = createMock();
 export const runWithModelFallbackMock = createMock();
 export const runEmbeddedPiAgentMock = createMock();
 export const runCliAgentMock = createMock();
+export const lookupContextTokensMock = createMock();
 export const getCliSessionIdMock = createMock();
 export const updateSessionStoreMock = createMock();
 export const resolveCronSessionMock = createMock();
@@ -125,7 +126,7 @@ vi.mock("../../agents/context.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../agents/context.js")>();
   return {
     ...actual,
-    lookupContextTokens: vi.fn().mockReturnValue(128000),
+    lookupContextTokens: lookupContextTokensMock,
   };
 });
 
@@ -374,6 +375,8 @@ export function resetRunCronIsolatedAgentTurnHarness(): void {
 
   runCliAgentMock.mockReset();
   getCliSessionIdMock.mockReturnValue(undefined);
+  lookupContextTokensMock.mockReset();
+  lookupContextTokensMock.mockReturnValue(128000);
 
   updateSessionStoreMock.mockReset();
   updateSessionStoreMock.mockResolvedValue(undefined);


### PR DESCRIPTION
## What changed
- add a focused cron isolated-agent regression test for context token lookup
- expose the mocked `lookupContextTokens` helper in the cron run test harness so the test can assert the async-load guard

## Why
A recent fix changed isolated cron runs to call `lookupContextTokens(modelUsed, { allowAsyncLoad: false })` so telemetry collection does not trigger async token warmup in isolated execution. That behavior had no regression test.

## Impact
- keeps the change scoped to cron isolated-agent tests only
- fails on the pre-fix implementation that omitted the `allowAsyncLoad: false` guard

## Validation
- `cmd /c node_modules\\.bin\\vitest.CMD run --config vitest.unit.config.ts src\\cron\\isolated-agent\\run.context-tokens.test.ts`
