### PR TITLE
fix(agent): stale replies after queued user turns

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.prompt-helpers.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.prompt-helpers.ts
@@ -17,7 +17,9 @@ import type {
   PluginHookBeforePromptBuildResult,
 } from "../../../plugins/types.js";
 import { isCronSessionKey, isSubagentSessionKey } from "../../../routing/session-key.js";
+import { shouldPreserveUserFacingSessionStateForInputProvenance } from "../../../sessions/input-provenance.js";
 import { joinPresentTextSegments } from "../../../shared/text/join-segments.js";
+import { truncateUtf16Safe } from "../../../utils.js";
 import { resolveProcessToolScopeKey } from "../../agent-tools.js";
 import { listActiveProcessSessionReferences } from "../../bash-process-references.js";
 import { resolveHeartbeatPromptForSystemPrompt } from "../../heartbeat-system-prompt.js";
@@ -30,7 +32,6 @@ import { buildActiveVideoGenerationTaskPromptContextForSession } from "../../vid
 import { buildEmbeddedCompactionRuntimeContext } from "../compaction-runtime-context.js";
 import { resolveContextEngineCapabilities } from "../context-engine-capabilities.js";
 import { log } from "../logger.js";
-import { truncateUtf16Safe } from "../../../utils.js";
 import { shouldInjectHeartbeatPromptForTrigger } from "./trigger-policy.js";
 import type { EmbeddedRunAttemptParams } from "./types.js";
 
@@ -498,6 +499,16 @@ function promptAlreadyIncludesQueuedUserMessage(prompt: string, orphanText: stri
   );
 }
 
+function shouldDropStaleInternalOrphanedUserPrompt(params: {
+  prompt: string;
+  leafMessage: { provenance?: unknown };
+}): boolean {
+  return (
+    params.prompt.trim().length > 0 &&
+    shouldPreserveUserFacingSessionStateForInputProvenance(params.leafMessage.provenance)
+  );
+}
+
 /**
  * Merges a trailing user message that was queued in transcript history but not
  * present in the active prompt. The leaf is removed whether merged or already
@@ -506,13 +517,21 @@ function promptAlreadyIncludesQueuedUserMessage(prompt: string, orphanText: stri
 export function mergeOrphanedTrailingUserPrompt(params: {
   prompt: string;
   trigger: EmbeddedRunAttemptParams["trigger"];
-  leafMessage: { content?: unknown };
+  leafMessage: { content?: unknown; provenance?: unknown };
 }): { prompt: string; merged: boolean; removeLeaf: boolean } {
   const orphanText = extractUserMessagePromptText(params.leafMessage.content);
   if (!orphanText) {
     return { prompt: params.prompt, merged: false, removeLeaf: true };
   }
   if (promptAlreadyIncludesQueuedUserMessage(params.prompt, orphanText)) {
+    return { prompt: params.prompt, merged: false, removeLeaf: true };
+  }
+  if (
+    shouldDropStaleInternalOrphanedUserPrompt({
+      prompt: params.prompt,
+      leafMessage: params.leafMessage,
+    })
+  ) {
     return { prompt: params.prompt, merged: false, removeLeaf: true };
   }
 

--- a/src/agents/embedded-agent-runner/run/attempt.prompt-helpers.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.prompt-helpers.ts
@@ -317,7 +317,8 @@ function hasNonEmptyContent(content: unknown): boolean {
 }
 
 const QUEUED_USER_MESSAGE_MARKER =
-  "[Queued user message that arrived while the previous turn was still active]";
+  "[Queued user message from a previous active turn; preserved as context only. " +
+  "Continue with the active prompt below.]";
 const MAX_STRUCTURED_MEDIA_REF_CHARS = 300;
 const MAX_STRUCTURED_JSON_STRING_CHARS = 300;
 const MAX_STRUCTURED_JSON_DEPTH = 4;

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -1438,22 +1438,58 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
     const olderPrompt = "OLD_TURN_76888: answer the orphaned queued turn";
     const latestPrompt = "LATEST_TURN_76888: answer only the active channel prompt";
     const repairedPrompt = `${marker}\n${olderPrompt}\n\n${latestPrompt}`;
+    const modelSnapshotData = { provider: "deepseek", modelId: "deepseek-chat" };
     const orphanLeaf = {
       id: "orphan-leaf",
       parentId: "parent-leaf",
       type: "message",
       message: { role: "user", content: olderPrompt, timestamp: 1 },
     };
-    hoisted.sessionManager.getLeafEntry.mockReturnValueOnce({
-      id: "model-snapshot-leaf",
+    const thinkingEntry = {
+      id: "thinking-leaf",
       parentId: "orphan-leaf",
+      type: "thinking_level_change",
+      thinkingLevel: "high",
+    };
+    const modelEntry = {
+      id: "model-leaf",
+      parentId: "thinking-leaf",
+      type: "model_change",
+      provider: "deepseek",
+      modelId: "deepseek-chat",
+    };
+    const modelSnapshotEntry = {
+      id: "model-snapshot-leaf",
+      parentId: "model-leaf",
       type: "custom",
       customType: "model-snapshot",
-      data: { provider: "deepseek", modelId: "deepseek-chat" },
+      data: modelSnapshotData,
+    };
+    hoisted.sessionManager.getLeafEntry.mockReturnValueOnce(modelSnapshotEntry);
+    hoisted.sessionManager.getEntry.mockImplementation((id: unknown) => {
+      if (id === "model-leaf") {
+        return modelEntry;
+      }
+      if (id === "thinking-leaf") {
+        return thinkingEntry;
+      }
+      return id === "orphan-leaf" ? orphanLeaf : undefined;
     });
-    hoisted.sessionManager.getEntry.mockImplementation((id: unknown) =>
-      id === "orphan-leaf" ? orphanLeaf : undefined,
-    );
+    const replayedEntries: string[] = [];
+    hoisted.sessionManager.appendThinkingLevelChange.mockImplementation((...args: unknown[]) => {
+      replayedEntries.push(`thinking:${String(args[0])}`);
+      return "replayed-thinking";
+    });
+    hoisted.sessionManager.appendModelChange.mockImplementation((...args: unknown[]) => {
+      replayedEntries.push(`model:${String(args[0])}/${String(args[1])}`);
+      return "replayed-model";
+    });
+    hoisted.sessionManager.appendCustomEntry.mockImplementation((...args: unknown[]) => {
+      if (args[0] === "model-snapshot") {
+        replayedEntries.push(`custom:${args[0]}:${JSON.stringify(args[1])}`);
+      }
+      return "replayed-custom";
+    });
     const seen: { modelInputPrompt?: string } = {};
 
     const result = await createContextEngineAttemptRunner({
@@ -1484,6 +1520,11 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
     );
     expect(finalAssistant.content).toBe(`stub-provider-target=${latestPrompt}`);
     expect(hoisted.sessionManager.branch).toHaveBeenCalledWith("parent-leaf");
+    expect(replayedEntries).toEqual([
+      "thinking:high",
+      "model:deepseek/deepseek-chat",
+      `custom:model-snapshot:${JSON.stringify(modelSnapshotData)}`,
+    ]);
   });
 
   it("keeps hidden runtime context hidden when orphan repair merges a transcript prompt", async () => {

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -1621,22 +1621,32 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
       type: "message",
       message: { role: "user", content: olderPrompt, timestamp: 1 },
     });
-    const seen: { prompt?: string; messages?: AgentMessage[] } = {};
+    const seen: {
+      prompt?: string;
+      assembledPrompt?: string;
+      assembledMessages?: AgentMessage[];
+      messages?: AgentMessage[];
+    } = {};
 
     await createContextEngineAttemptRunner({
       contextEngine: createTestContextEngine({
         bootstrap: async () => ({ bootstrapped: true }),
-        assemble: async ({ messages }: { messages: AgentMessage[] }) => ({
-          messages: [
-            ...messages,
-            { role: "user", content: latestPrompt, timestamp: 2 } as AgentMessage,
-          ],
-          estimatedTokens: 1,
-        }),
+        assemble: async ({ messages, prompt }: { messages: AgentMessage[]; prompt?: string }) => {
+          seen.assembledPrompt = prompt;
+          seen.assembledMessages = [...messages];
+          return {
+            messages: [
+              ...messages,
+              { role: "user", content: latestPrompt, timestamp: 2 } as AgentMessage,
+            ],
+            estimatedTokens: 1,
+          };
+        },
       }),
       sessionKey,
       tempPaths,
       sessionMessages: [{ role: "user", content: olderPrompt, timestamp: 1 } as AgentMessage],
+      sessionMessagesAfterRepair: [],
       attemptOverrides: {
         prompt: latestPrompt,
       },
@@ -1651,6 +1661,8 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
     });
 
     expect(seen.prompt).toBe(`${marker}\n${olderPrompt}\n\n${latestPrompt}`);
+    expect(seen.assembledPrompt).toBe(seen.prompt);
+    expect(JSON.stringify(seen.assembledMessages)).not.toContain(olderPrompt);
     expect(JSON.stringify(seen.messages)).not.toContain(olderPrompt);
     expect(JSON.stringify(seen.messages)).toContain(latestPrompt);
     expect(hoisted.sessionManager.branch).toHaveBeenCalledWith("parent-leaf");

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -1451,7 +1451,7 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
       customType: "model-snapshot",
       data: { provider: "deepseek", modelId: "deepseek-chat" },
     });
-    hoisted.sessionManager.getEntry.mockImplementation((id: string) =>
+    hoisted.sessionManager.getEntry.mockImplementation((id: unknown) =>
       id === "orphan-leaf" ? orphanLeaf : undefined,
     );
     const seen: { modelInputPrompt?: string } = {};

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -1465,8 +1465,18 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
       customType: "model-snapshot",
       data: modelSnapshotData,
     };
-    hoisted.sessionManager.getLeafEntry.mockReturnValueOnce(modelSnapshotEntry);
+    const labelEntry = {
+      id: "label-leaf",
+      parentId: "model-snapshot-leaf",
+      type: "label",
+      targetId: "model-snapshot-leaf",
+      label: "model snapshot",
+    };
+    hoisted.sessionManager.getLeafEntry.mockReturnValueOnce(labelEntry);
     hoisted.sessionManager.getEntry.mockImplementation((id: unknown) => {
+      if (id === "model-snapshot-leaf") {
+        return modelSnapshotEntry;
+      }
       if (id === "model-leaf") {
         return modelEntry;
       }
@@ -1489,6 +1499,10 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
         replayedEntries.push(`custom:${args[0]}:${JSON.stringify(args[1])}`);
       }
       return "replayed-custom";
+    });
+    hoisted.sessionManager.appendLabelChange.mockImplementation((...args: unknown[]) => {
+      replayedEntries.push(`label:${String(args[0])}/${String(args[1])}`);
+      return "replayed-label";
     });
     const seen: { modelInputPrompt?: string } = {};
 
@@ -1524,6 +1538,7 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
       "thinking:high",
       "model:deepseek/deepseek-chat",
       `custom:model-snapshot:${JSON.stringify(modelSnapshotData)}`,
+      "label:replayed-custom/model snapshot",
     ]);
   });
 

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -1367,6 +1367,71 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
     expect(hoisted.sessionManager.branch).toHaveBeenCalledWith("parent-leaf");
   });
 
+  it("targets the latest active prompt after orphan repair reaches the embedded provider", async () => {
+    const marker =
+      "[Queued user message from a previous active turn; preserved as context only. Continue with the active prompt below.]";
+    const olderPrompt = "OLD_TURN: answer the earlier short request";
+    const latestPrompt = "LATEST_TURN: answer only this active instruction";
+    const repairedPrompt = `${marker}\n${olderPrompt}\n\n${latestPrompt}`;
+    const runBeforePromptBuild = vi.fn(async () => ({
+      prependContext: "provider-side context",
+    }));
+    const seen: { modelInputPrompt?: string; modelMessages?: AgentMessage[] } = {};
+    hoisted.getGlobalHookRunnerMock.mockReturnValue({
+      hasHooks: vi.fn((name: string) => name === "before_prompt_build"),
+      runBeforePromptBuild,
+      runBeforeAgentStart: vi.fn(),
+    });
+    hoisted.sessionManager.getLeafEntry.mockReturnValueOnce({
+      id: "orphan-leaf",
+      parentId: "parent-leaf",
+      type: "message",
+      message: { role: "user", content: olderPrompt, timestamp: 1 },
+    });
+
+    const result = await createContextEngineAttemptRunner({
+      contextEngine: createContextEngineBootstrapAndAssemble(),
+      sessionKey,
+      tempPaths,
+      attemptOverrides: {
+        prompt: latestPrompt,
+      },
+      sessionPrompt: async (session, prompt) => {
+        seen.modelInputPrompt = prompt;
+        const transformContext = (
+          session.agent as {
+            transformContext?: (messages: AgentMessage[]) => Promise<AgentMessage[]>;
+          }
+        ).transformContext;
+        seen.modelMessages = await transformContext?.([
+          { role: "user", content: [{ type: "text", text: prompt }], timestamp: 1 },
+        ]);
+        const activePrompt = prompt.startsWith(`${marker}\n${olderPrompt}\n\n`)
+          ? prompt.slice(`${marker}\n${olderPrompt}\n\n`.length)
+          : "missing-active-prompt";
+        session.messages = [
+          ...session.messages,
+          { role: "assistant", content: `stub-provider-target=${activePrompt}`, timestamp: 2 },
+        ];
+      },
+    });
+
+    expect(result.finalPromptText).toBe(repairedPrompt);
+    expect(seen.modelInputPrompt).toBe(repairedPrompt);
+    const serializedModelMessages = JSON.stringify(seen.modelMessages);
+    expect(serializedModelMessages).toContain(marker);
+    expect(serializedModelMessages).toContain(olderPrompt);
+    expect(serializedModelMessages).toContain(latestPrompt);
+    const finalAssistant = findRecord(
+      requireRecords(result.messagesSnapshot, "messages snapshot"),
+      (message) => message.role === "assistant",
+      "final assistant",
+    );
+    expect(finalAssistant.content).toBe(`stub-provider-target=${latestPrompt}`);
+    expect(finalAssistant.content).not.toContain("OLD_TURN");
+    expect(hoisted.sessionManager.branch).toHaveBeenCalledWith("parent-leaf");
+  });
+
   it("keeps hidden runtime context hidden when orphan repair merges a transcript prompt", async () => {
     hoisted.sessionManager.getLeafEntry.mockReturnValueOnce({
       id: "orphan-leaf",

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -1432,6 +1432,60 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
     expect(hoisted.sessionManager.branch).toHaveBeenCalledWith("parent-leaf");
   });
 
+  it("repairs an orphaned user message behind non-message session metadata before the provider", async () => {
+    const marker =
+      "[Queued user message from a previous active turn; preserved as context only. Continue with the active prompt below.]";
+    const olderPrompt = "OLD_TURN_76888: answer the orphaned queued turn";
+    const latestPrompt = "LATEST_TURN_76888: answer only the active channel prompt";
+    const repairedPrompt = `${marker}\n${olderPrompt}\n\n${latestPrompt}`;
+    const orphanLeaf = {
+      id: "orphan-leaf",
+      parentId: "parent-leaf",
+      type: "message",
+      message: { role: "user", content: olderPrompt, timestamp: 1 },
+    };
+    hoisted.sessionManager.getLeafEntry.mockReturnValueOnce({
+      id: "model-snapshot-leaf",
+      parentId: "orphan-leaf",
+      type: "custom",
+      customType: "model-snapshot",
+      data: { provider: "deepseek", modelId: "deepseek-chat" },
+    });
+    hoisted.sessionManager.getEntry.mockImplementation((id: string) =>
+      id === "orphan-leaf" ? orphanLeaf : undefined,
+    );
+    const seen: { modelInputPrompt?: string } = {};
+
+    const result = await createContextEngineAttemptRunner({
+      contextEngine: createContextEngineBootstrapAndAssemble(),
+      sessionKey,
+      tempPaths,
+      attemptOverrides: {
+        prompt: latestPrompt,
+      },
+      sessionPrompt: async (session, prompt) => {
+        seen.modelInputPrompt = prompt;
+        const activePrompt = prompt.startsWith(`${marker}\n${olderPrompt}\n\n`)
+          ? prompt.slice(`${marker}\n${olderPrompt}\n\n`.length)
+          : "missing-active-prompt";
+        session.messages = [
+          ...session.messages,
+          { role: "assistant", content: `stub-provider-target=${activePrompt}`, timestamp: 2 },
+        ];
+      },
+    });
+
+    expect(result.finalPromptText).toBe(repairedPrompt);
+    expect(seen.modelInputPrompt).toBe(repairedPrompt);
+    const finalAssistant = findRecord(
+      requireRecords(result.messagesSnapshot, "messages snapshot"),
+      (message) => message.role === "assistant",
+      "final assistant",
+    );
+    expect(finalAssistant.content).toBe(`stub-provider-target=${latestPrompt}`);
+    expect(hoisted.sessionManager.branch).toHaveBeenCalledWith("parent-leaf");
+  });
+
   it("keeps hidden runtime context hidden when orphan repair merges a transcript prompt", async () => {
     hoisted.sessionManager.getLeafEntry.mockReturnValueOnce({
       id: "orphan-leaf",

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -1542,6 +1542,74 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
     ]);
   });
 
+  it("does not abort orphan repair for a dangling trailing label", async () => {
+    const marker =
+      "[Queued user message from a previous active turn; preserved as context only. Continue with the active prompt below.]";
+    const olderPrompt = "OLD_TURN_76888: dangling label repair";
+    const latestPrompt = "LATEST_TURN_76888: answer after dangling label";
+    const orphanLeaf = {
+      id: "orphan-leaf",
+      parentId: "parent-leaf",
+      type: "message",
+      message: { role: "user", content: olderPrompt, timestamp: 1 },
+    };
+    const thinkingEntry = {
+      id: "thinking-leaf",
+      parentId: "orphan-leaf",
+      type: "thinking_level_change",
+      thinkingLevel: "high",
+    };
+    const labelEntry = {
+      id: "label-leaf",
+      parentId: "thinking-leaf",
+      type: "label",
+      targetId: "missing-entry",
+      label: "stale label",
+    };
+    hoisted.sessionManager.getLeafEntry.mockReturnValueOnce(labelEntry);
+    hoisted.sessionManager.getEntry.mockImplementation((id: unknown) => {
+      if (id === "thinking-leaf") {
+        return thinkingEntry;
+      }
+      return id === "orphan-leaf" ? orphanLeaf : undefined;
+    });
+    hoisted.sessionManager.appendThinkingLevelChange.mockReturnValue("replayed-thinking");
+    hoisted.sessionManager.appendLabelChange.mockImplementation((targetId: unknown) => {
+      throw new Error(`Entry ${String(targetId)} not found`);
+    });
+    const seen: { modelInputPrompt?: string } = {};
+
+    const result = await createContextEngineAttemptRunner({
+      contextEngine: createContextEngineBootstrapAndAssemble(),
+      sessionKey,
+      tempPaths,
+      attemptOverrides: {
+        prompt: latestPrompt,
+      },
+      sessionPrompt: async (session, prompt) => {
+        seen.modelInputPrompt = prompt;
+        const activePrompt = prompt.startsWith(`${marker}\n${olderPrompt}\n\n`)
+          ? prompt.slice(`${marker}\n${olderPrompt}\n\n`.length)
+          : "missing-active-prompt";
+        session.messages = [
+          ...session.messages,
+          { role: "assistant", content: `stub-provider-target=${activePrompt}`, timestamp: 2 },
+        ];
+      },
+    });
+
+    expect(result.finalPromptText).toBe(`${marker}\n${olderPrompt}\n\n${latestPrompt}`);
+    expect(seen.modelInputPrompt).toBe(result.finalPromptText);
+    const finalAssistant = findRecord(
+      requireRecords(result.messagesSnapshot, "messages snapshot"),
+      (message) => message.role === "assistant",
+      "final assistant",
+    );
+    expect(finalAssistant.content).toBe(`stub-provider-target=${latestPrompt}`);
+    expect(hoisted.sessionManager.branch).toHaveBeenCalledWith("parent-leaf");
+    expect(hoisted.sessionManager.appendLabelChange).not.toHaveBeenCalled();
+  });
+
   it("removes the repaired orphan from assembled history when the context engine appends the active prompt", async () => {
     const marker =
       "[Queued user message from a previous active turn; preserved as context only. Continue with the active prompt below.]";

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -1527,6 +1527,52 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
     ]);
   });
 
+  it("removes the repaired orphan from assembled history when the context engine appends the active prompt", async () => {
+    const marker =
+      "[Queued user message from a previous active turn; preserved as context only. Continue with the active prompt below.]";
+    const olderPrompt = "OLD_TURN_76888: stale assembled history";
+    const latestPrompt = "LATEST_TURN_76888: active assembled prompt";
+    hoisted.sessionManager.getLeafEntry.mockReturnValueOnce({
+      id: "orphan-leaf",
+      parentId: "parent-leaf",
+      type: "message",
+      message: { role: "user", content: olderPrompt, timestamp: 1 },
+    });
+    const seen: { prompt?: string; messages?: AgentMessage[] } = {};
+
+    await createContextEngineAttemptRunner({
+      contextEngine: createTestContextEngine({
+        bootstrap: async () => ({ bootstrapped: true }),
+        assemble: async ({ messages }: { messages: AgentMessage[] }) => ({
+          messages: [
+            ...messages,
+            { role: "user", content: latestPrompt, timestamp: 2 } as AgentMessage,
+          ],
+          estimatedTokens: 1,
+        }),
+      }),
+      sessionKey,
+      tempPaths,
+      sessionMessages: [{ role: "user", content: olderPrompt, timestamp: 1 } as AgentMessage],
+      attemptOverrides: {
+        prompt: latestPrompt,
+      },
+      sessionPrompt: async (session, prompt) => {
+        seen.prompt = prompt;
+        seen.messages = [...session.messages] as AgentMessage[];
+        session.messages = [
+          ...session.messages,
+          { role: "assistant", content: "done", timestamp: 3 },
+        ];
+      },
+    });
+
+    expect(seen.prompt).toBe(`${marker}\n${olderPrompt}\n\n${latestPrompt}`);
+    expect(JSON.stringify(seen.messages)).not.toContain(olderPrompt);
+    expect(JSON.stringify(seen.messages)).toContain(latestPrompt);
+    expect(hoisted.sessionManager.branch).toHaveBeenCalledWith("parent-leaf");
+  });
+
   it("keeps hidden runtime context hidden when orphan repair merges a transcript prompt", async () => {
     hoisted.sessionManager.getLeafEntry.mockReturnValueOnce({
       id: "orphan-leaf",

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
@@ -54,6 +54,7 @@ function normalizeMockProviderId(providerId?: string): string {
 
 type SessionManagerMocks = {
   getLeafEntry: UnknownMock;
+  getEntry: UnknownMock;
   branch: UnknownMock;
   resetLeaf: UnknownMock;
   buildSessionContext: Mock<() => { messages: AgentMessage[] }>;
@@ -209,6 +210,7 @@ const hoisted = vi.hoisted((): AttemptSpawnWorkspaceHoisted => {
   const embeddedSystemPromptInputs: unknown[] = [];
   const sessionManager = {
     getLeafEntry: vi.fn(() => null),
+    getEntry: vi.fn(() => undefined),
     branch: vi.fn(),
     resetLeaf: vi.fn(),
     buildSessionContext: vi.fn<() => { messages: AgentMessage[] }>(() => ({ messages: [] })),
@@ -1050,6 +1052,7 @@ export function resetEmbeddedAttemptHarness(
   hoisted.systemPromptTexts.length = 0;
   hoisted.embeddedSystemPromptInputs.length = 0;
   hoisted.sessionManager.getLeafEntry.mockReset().mockReturnValue(null);
+  hoisted.sessionManager.getEntry.mockReset().mockReturnValue(undefined);
   hoisted.sessionManager.branch.mockReset();
   hoisted.sessionManager.resetLeaf.mockReset();
   hoisted.sessionManager.buildSessionContext

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
@@ -1259,6 +1259,7 @@ export async function createContextEngineAttemptRunner(params: {
   attemptOverrides?: Partial<Parameters<Awaited<ReturnType<typeof loadRunEmbeddedAttempt>>>[0]>;
   createSession?: () => MutableSession;
   sessionMessages?: AgentMessage[];
+  sessionMessagesAfterRepair?: AgentMessage[];
   sessionPrompt?: SessionPromptOverride;
   sessionKey: string;
   tempPaths: string[];
@@ -1289,7 +1290,7 @@ export async function createContextEngineAttemptRunner(params: {
 
   hoisted.sessionManager.buildSessionContext
     .mockReset()
-    .mockReturnValue({ messages: seedMessages });
+    .mockReturnValue({ messages: params.sessionMessagesAfterRepair ?? seedMessages });
 
   hoisted.createAgentSessionMock.mockImplementation(async () => ({
     session:

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
@@ -58,7 +58,11 @@ type SessionManagerMocks = {
   branch: UnknownMock;
   resetLeaf: UnknownMock;
   buildSessionContext: Mock<() => { messages: AgentMessage[] }>;
+  appendThinkingLevelChange: UnknownMock;
+  appendModelChange: UnknownMock;
   appendCustomEntry: UnknownMock;
+  appendSessionInfo: UnknownMock;
+  appendLabelChange: UnknownMock;
   rewriteFile: UnknownMock;
   flushPendingToolResults: UnknownMock;
   clearPendingToolResults: UnknownMock;
@@ -214,7 +218,11 @@ const hoisted = vi.hoisted((): AttemptSpawnWorkspaceHoisted => {
     branch: vi.fn(),
     resetLeaf: vi.fn(),
     buildSessionContext: vi.fn<() => { messages: AgentMessage[] }>(() => ({ messages: [] })),
+    appendThinkingLevelChange: vi.fn(),
+    appendModelChange: vi.fn(),
     appendCustomEntry: vi.fn(),
+    appendSessionInfo: vi.fn(),
+    appendLabelChange: vi.fn(),
     rewriteFile: vi.fn(),
     flushPendingToolResults: vi.fn(),
     clearPendingToolResults: vi.fn(),
@@ -1058,7 +1066,11 @@ export function resetEmbeddedAttemptHarness(
   hoisted.sessionManager.buildSessionContext
     .mockReset()
     .mockReturnValue({ messages: params.sessionMessages ?? [] });
+  hoisted.sessionManager.appendThinkingLevelChange.mockReset();
+  hoisted.sessionManager.appendModelChange.mockReset();
   hoisted.sessionManager.appendCustomEntry.mockReset();
+  hoisted.sessionManager.appendSessionInfo.mockReset();
+  hoisted.sessionManager.appendLabelChange.mockReset();
   hoisted.sessionManager.rewriteFile.mockReset();
   if (params.subscribeImpl) {
     hoisted.subscribeEmbeddedAgentSessionMock.mockImplementation(params.subscribeImpl);

--- a/src/agents/embedded-agent-runner/run/attempt.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.test.ts
@@ -357,7 +357,7 @@ describe("mergeOrphanedTrailingUserPrompt", () => {
       merged: true,
       removeLeaf: true,
       prompt:
-        "[Queued user message that arrived while the previous turn was still active]\n" +
+        "[Queued user message from a previous active turn; preserved as context only. Continue with the active prompt below.]\n" +
         "older active-turn message\n\nnewest inbound message",
     });
   });
@@ -391,7 +391,7 @@ describe("mergeOrphanedTrailingUserPrompt", () => {
       merged: true,
       removeLeaf: true,
       prompt:
-        "[Queued user message that arrived while the previous turn was still active]\n" +
+        "[Queued user message from a previous active turn; preserved as context only. Continue with the active prompt below.]\n" +
         "ok\n\nplease inspect this token",
     });
   });
@@ -413,7 +413,7 @@ describe("mergeOrphanedTrailingUserPrompt", () => {
       merged: true,
       removeLeaf: true,
       prompt:
-        "[Queued user message that arrived while the previous turn was still active]\n" +
+        "[Queued user message from a previous active turn; preserved as context only. Continue with the active prompt below.]\n" +
         "please inspect this\n" +
         "[image_url] https://example.test/cat.png\n" +
         "[input_audio] https://example.test/cat.wav\n\n" +
@@ -499,7 +499,7 @@ describe("mergeOrphanedTrailingUserPrompt", () => {
       merged: true,
       removeLeaf: true,
       prompt:
-        "[Queued user message that arrived while the previous turn was still active]\n" +
+        "[Queued user message from a previous active turn; preserved as context only. Continue with the active prompt below.]\n" +
         "older active-turn message\n\nHEARTBEAT_OK",
     });
   });

--- a/src/agents/embedded-agent-runner/run/attempt.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.test.ts
@@ -362,6 +362,42 @@ describe("mergeOrphanedTrailingUserPrompt", () => {
     });
   });
 
+  it("drops stale internal orphan context when a fresh prompt is present", () => {
+    expect(
+      mergeOrphanedTrailingUserPrompt({
+        prompt: "newest inbound message",
+        trigger: "user",
+        leafMessage: {
+          content: "NO_REPLY stale subagent completion",
+          provenance: { kind: "inter_session", sourceTool: "subagent_announce" },
+        },
+      }),
+    ).toEqual({
+      merged: false,
+      removeLeaf: true,
+      prompt: "newest inbound message",
+    });
+  });
+
+  it("preserves user-directed inter-session orphan context", () => {
+    expect(
+      mergeOrphanedTrailingUserPrompt({
+        prompt: "newest inbound message",
+        trigger: "user",
+        leafMessage: {
+          content: "forwarded user request",
+          provenance: { kind: "inter_session", sourceTool: "sessions_send" },
+        },
+      }),
+    ).toEqual({
+      merged: true,
+      removeLeaf: true,
+      prompt:
+        "[Queued user message from a previous active turn; preserved as context only. Continue with the active prompt below.]\n" +
+        "forwarded user request\n\nnewest inbound message",
+    });
+  });
+
   it("does not duplicate orphaned user text already present in the next prompt", () => {
     expect(
       mergeOrphanedTrailingUserPrompt({

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -731,25 +731,27 @@ function findTrailingMessageEntryForOrphanRepair(
 function appendTrailingEntryForOrphanRepair(
   sessionManager: OrphanRepairSessionManager,
   entry: SessionManagerEntry,
+  replayedEntryIds: Map<string, string>,
 ): void {
   if (entry.type === "thinking_level_change") {
-    sessionManager.appendThinkingLevelChange(entry.thinkingLevel);
+    replayedEntryIds.set(entry.id, sessionManager.appendThinkingLevelChange(entry.thinkingLevel));
     return;
   }
   if (entry.type === "model_change") {
-    sessionManager.appendModelChange(entry.provider, entry.modelId);
+    replayedEntryIds.set(entry.id, sessionManager.appendModelChange(entry.provider, entry.modelId));
     return;
   }
   if (entry.type === "custom") {
-    sessionManager.appendCustomEntry(entry.customType, entry.data);
+    replayedEntryIds.set(entry.id, sessionManager.appendCustomEntry(entry.customType, entry.data));
     return;
   }
   if (entry.type === "session_info") {
-    sessionManager.appendSessionInfo(entry.name ?? "");
+    replayedEntryIds.set(entry.id, sessionManager.appendSessionInfo(entry.name ?? ""));
     return;
   }
   if (entry.type === "label") {
-    sessionManager.appendLabelChange(entry.targetId, entry.label);
+    const targetId = replayedEntryIds.get(entry.targetId) ?? entry.targetId;
+    replayedEntryIds.set(entry.id, sessionManager.appendLabelChange(targetId, entry.label));
   }
 }
 
@@ -757,8 +759,9 @@ function replayTrailingEntriesForOrphanRepair(
   sessionManager: OrphanRepairSessionManager,
   trailingEntries: SessionManagerEntry[],
 ): void {
+  const replayedEntryIds = new Map<string, string>();
   for (const entry of trailingEntries) {
-    appendTrailingEntryForOrphanRepair(sessionManager, entry);
+    appendTrailingEntryForOrphanRepair(sessionManager, entry, replayedEntryIds);
   }
 }
 

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -684,8 +684,19 @@ function flushSessionManagerFile(sessionManager: ReturnType<typeof guardSessionM
 
 type OrphanRepairSessionManager = Pick<
   ReturnType<typeof guardSessionManager>,
-  "getLeafEntry" | "getEntry"
+  | "getLeafEntry"
+  | "getEntry"
+  | "appendThinkingLevelChange"
+  | "appendModelChange"
+  | "appendCustomEntry"
+  | "appendSessionInfo"
+  | "appendLabelChange"
 >;
+
+type OrphanRepairCandidate = {
+  messageEntry: SessionMessageEntry;
+  trailingEntries: SessionEntry[];
+};
 
 function canSkipTrailingEntryForOrphanRepair(entry: SessionEntry): boolean {
   return (
@@ -699,17 +710,55 @@ function canSkipTrailingEntryForOrphanRepair(entry: SessionEntry): boolean {
 
 function findTrailingMessageEntryForOrphanRepair(
   sessionManager: OrphanRepairSessionManager,
-): SessionMessageEntry | undefined {
+): OrphanRepairCandidate | undefined {
   const visited = new Set<string>();
+  const trailingEntries: SessionEntry[] = [];
   let entry = sessionManager.getLeafEntry();
   while (entry && entry.type !== "message" && canSkipTrailingEntryForOrphanRepair(entry)) {
     if (visited.has(entry.id)) {
       return undefined;
     }
     visited.add(entry.id);
+    trailingEntries.push(entry);
     entry = entry.parentId ? sessionManager.getEntry(entry.parentId) : undefined;
   }
-  return entry?.type === "message" ? entry : undefined;
+  return entry?.type === "message"
+    ? { messageEntry: entry, trailingEntries: trailingEntries.toReversed() }
+    : undefined;
+}
+
+function appendTrailingEntryForOrphanRepair(
+  sessionManager: OrphanRepairSessionManager,
+  entry: SessionEntry,
+): void {
+  if (entry.type === "thinking_level_change") {
+    sessionManager.appendThinkingLevelChange(entry.thinkingLevel);
+    return;
+  }
+  if (entry.type === "model_change") {
+    sessionManager.appendModelChange(entry.provider, entry.modelId);
+    return;
+  }
+  if (entry.type === "custom") {
+    sessionManager.appendCustomEntry(entry.customType, entry.data);
+    return;
+  }
+  if (entry.type === "session_info") {
+    sessionManager.appendSessionInfo(entry.name ?? "");
+    return;
+  }
+  if (entry.type === "label") {
+    sessionManager.appendLabelChange(entry.targetId, entry.label);
+  }
+}
+
+function replayTrailingEntriesForOrphanRepair(
+  sessionManager: OrphanRepairSessionManager,
+  trailingEntries: SessionEntry[],
+): void {
+  for (const entry of trailingEntries) {
+    appendTrailingEntryForOrphanRepair(sessionManager, entry);
+  }
 }
 
 function contentValuesEqual(left: unknown, right: unknown): boolean {
@@ -4343,9 +4392,10 @@ export async function runEmbeddedAttempt(
         let transcriptPromptForRuntimeSplit = effectiveTranscriptPrompt;
         let promptForRuntimeContextSplit = promptBeforePromptBuildHooks;
         // Repair orphaned trailing user messages so new prompts don't violate role ordering.
-        const leafEntry = isRawModelRun
-          ? null
+        const orphanRepair = isRawModelRun
+          ? undefined
           : findTrailingMessageEntryForOrphanRepair(sessionManager);
+        const leafEntry = orphanRepair?.messageEntry;
         if (leafEntry?.message.role === "user") {
           const messageMergeStrategy = resolveMessageMergeStrategy();
           const orphanPromptMerge = messageMergeStrategy.mergeOrphanedTrailingUserPrompt({
@@ -4377,6 +4427,10 @@ export async function runEmbeddedAttempt(
             } else {
               sessionManager.resetLeaf();
             }
+            replayTrailingEntriesForOrphanRepair(
+              sessionManager,
+              orphanRepair?.trailingEntries ?? [],
+            );
             activeSession.agent.state.messages = removeTrailingUserMessageForOrphanRepair(
               activeSession.messages,
               leafEntry.message,

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -215,7 +215,11 @@ import {
 import { guardSessionManager } from "../../session-tool-result-guard-wrapper.js";
 import { sanitizeToolUseResultPairing } from "../../session-transcript-repair.js";
 import { acquireSessionWriteLock } from "../../session-write-lock.js";
-import { createAgentSession, SessionManager } from "../../sessions/index.js";
+import {
+  createAgentSession,
+  SessionManager,
+  type SessionMessageEntry,
+} from "../../sessions/index.js";
 import { wrapToolDefinition } from "../../sessions/tools/tool-definition-wrapper.js";
 import { detectRuntimeShell } from "../../shell-utils.js";
 import { buildActiveSubagentSystemPromptAddition } from "../../subagent-active-context.js";
@@ -676,6 +680,58 @@ function sessionMessagesContainIdempotencyKey(
 
 function flushSessionManagerFile(sessionManager: ReturnType<typeof guardSessionManager>): void {
   (sessionManager as unknown as { rewriteFile?: () => void }).rewriteFile?.();
+}
+
+type OrphanRepairSessionManager = Pick<
+  ReturnType<typeof guardSessionManager>,
+  "getLeafEntry" | "getEntry"
+>;
+
+function canSkipTrailingEntryForOrphanRepair(entry: SessionEntry): boolean {
+  return (
+    entry.type === "thinking_level_change" ||
+    entry.type === "model_change" ||
+    entry.type === "custom" ||
+    entry.type === "label" ||
+    entry.type === "session_info"
+  );
+}
+
+function findTrailingMessageEntryForOrphanRepair(
+  sessionManager: OrphanRepairSessionManager,
+): SessionMessageEntry | undefined {
+  const visited = new Set<string>();
+  let entry = sessionManager.getLeafEntry();
+  while (entry && entry.type !== "message" && canSkipTrailingEntryForOrphanRepair(entry)) {
+    if (visited.has(entry.id)) {
+      return undefined;
+    }
+    visited.add(entry.id);
+    entry = entry.parentId ? sessionManager.getEntry(entry.parentId) : undefined;
+  }
+  return entry?.type === "message" ? entry : undefined;
+}
+
+function contentValuesEqual(left: unknown, right: unknown): boolean {
+  try {
+    return JSON.stringify(left) === JSON.stringify(right);
+  } catch {
+    return false;
+  }
+}
+
+function removeTrailingUserMessageForOrphanRepair(
+  messages: AgentMessage[],
+  orphanMessage: SessionMessageEntry["message"],
+): AgentMessage[] {
+  const lastMessage = messages.at(-1);
+  if (
+    lastMessage?.role === "user" &&
+    contentValuesEqual(lastMessage.content, orphanMessage.content)
+  ) {
+    return messages.slice(0, -1);
+  }
+  return messages;
 }
 
 function repairAttemptToolUseResultPairing(
@@ -4282,8 +4338,10 @@ export async function runEmbeddedAttempt(
         let transcriptPromptForRuntimeSplit = effectiveTranscriptPrompt;
         let promptForRuntimeContextSplit = promptBeforePromptBuildHooks;
         // Repair orphaned trailing user messages so new prompts don't violate role ordering.
-        const leafEntry = isRawModelRun ? null : sessionManager.getLeafEntry();
-        if (leafEntry?.type === "message" && leafEntry.message.role === "user") {
+        const leafEntry = isRawModelRun
+          ? null
+          : findTrailingMessageEntryForOrphanRepair(sessionManager);
+        if (leafEntry?.message.role === "user") {
           const messageMergeStrategy = resolveMessageMergeStrategy();
           const orphanPromptMerge = messageMergeStrategy.mergeOrphanedTrailingUserPrompt({
             prompt: effectivePrompt,
@@ -4314,8 +4372,10 @@ export async function runEmbeddedAttempt(
             } else {
               sessionManager.resetLeaf();
             }
-            const sessionContext = sessionManager.buildSessionContext();
-            activeSession.agent.state.messages = sessionContext.messages;
+            activeSession.agent.state.messages = removeTrailingUserMessageForOrphanRepair(
+              activeSession.messages,
+              leafEntry.message,
+            );
           }
           const orphanRepairMessage =
             `${

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -512,7 +512,10 @@ import {
   resolveLlmIdleTimeoutMs,
   streamWithIdleTimeout,
 } from "./llm-idle-timeout.js";
-import { resolveMessageMergeStrategy } from "./message-merge-strategy.js";
+import {
+  resolveMessageMergeStrategy,
+  type MessageMergeStrategy,
+} from "./message-merge-strategy.js";
 import { installMessageToolOnlyTerminalHook } from "./message-tool-terminal.js";
 import { wrapStreamFnWithMessageTransform } from "./message-transform-stream-wrapper.js";
 import {
@@ -769,51 +772,41 @@ function replayTrailingEntriesForOrphanRepair(
   }
 }
 
-function contentValuesEqual(left: unknown, right: unknown): boolean {
-  try {
-    return JSON.stringify(left) === JSON.stringify(right);
-  } catch {
-    return false;
+type OrphanRepairPlan = Omit<OrphanRepairCandidate, "messageEntry"> & {
+  contextEnginePrompt: string;
+  messageEntry: SessionMessageEntry & { message: UserMessage };
+  strategy: MessageMergeStrategy;
+  removeLeaf: boolean;
+};
+
+function isUserSessionMessageEntry(
+  entry: SessionMessageEntry,
+): entry is SessionMessageEntry & { message: UserMessage } {
+  return entry.message.role === "user";
+}
+
+function resolveOrphanRepairPlan(params: {
+  sessionManager: OrphanRepairSessionManager;
+  prompt: string;
+  trigger: EmbeddedRunAttemptParams["trigger"];
+}): OrphanRepairPlan | undefined {
+  const candidate = findTrailingMessageEntryForOrphanRepair(params.sessionManager);
+  if (!candidate || !isUserSessionMessageEntry(candidate.messageEntry)) {
+    return undefined;
   }
-}
-
-function isUserAgentMessage(message: AgentMessage | undefined): message is UserMessage {
-  return message?.role === "user";
-}
-
-function optionalMessageFieldMatches(
-  left: AgentMessage,
-  right: UserMessage,
-  field: string,
-): boolean {
-  const leftValue = (left as unknown as Record<string, unknown>)[field];
-  const rightValue = (right as unknown as Record<string, unknown>)[field];
-  return rightValue === undefined || leftValue === undefined || leftValue === rightValue;
-}
-
-function isMatchingUserMessageForOrphanRepair(
-  message: AgentMessage | undefined,
-  orphanMessage: SessionMessageEntry["message"],
-): message is UserMessage {
-  return (
-    isUserAgentMessage(message) &&
-    isUserAgentMessage(orphanMessage) &&
-    contentValuesEqual(message.content, orphanMessage.content) &&
-    optionalMessageFieldMatches(message, orphanMessage, "timestamp") &&
-    optionalMessageFieldMatches(message, orphanMessage, "id")
-  );
-}
-
-function removeUserMessageForOrphanRepair(
-  messages: AgentMessage[],
-  orphanMessage: SessionMessageEntry["message"],
-): AgentMessage[] {
-  for (let index = messages.length - 1; index >= 0; index -= 1) {
-    if (isMatchingUserMessageForOrphanRepair(messages[index], orphanMessage)) {
-      return [...messages.slice(0, index), ...messages.slice(index + 1)];
-    }
-  }
-  return messages;
+  const strategy = resolveMessageMergeStrategy();
+  const merge = strategy.mergeOrphanedTrailingUserPrompt({
+    prompt: params.prompt,
+    trigger: params.trigger,
+    leafMessage: candidate.messageEntry.message,
+  });
+  return {
+    contextEnginePrompt: merge.prompt,
+    messageEntry: candidate.messageEntry,
+    trailingEntries: candidate.trailingEntries,
+    strategy,
+    removeLeaf: merge.removeLeaf,
+  };
 }
 
 function repairAttemptToolUseResultPairing(
@@ -2780,6 +2773,22 @@ export async function runEmbeddedAttempt(
         activeSession.agent.reset();
         setActiveSessionSystemPrompt("");
       }
+      const orphanRepair = isRawModelRun
+        ? undefined
+        : resolveOrphanRepairPlan({
+            sessionManager,
+            prompt: params.prompt,
+            trigger: params.trigger,
+          });
+      if (orphanRepair?.removeLeaf) {
+        if (orphanRepair.messageEntry.parentId) {
+          sessionManager.branch(orphanRepair.messageEntry.parentId);
+        } else {
+          sessionManager.resetLeaf();
+        }
+        replayTrailingEntriesForOrphanRepair(sessionManager, orphanRepair.trailingEntries);
+        activeSession.agent.state.messages = sessionManager.buildSessionContext().messages;
+      }
       // Single source for the per-message timestamp prefix (issue #3658):
       // normal embedded runs stamp every user message from its own timestamp.
       // Raw model probes must keep the requested prompt text exact.
@@ -3628,10 +3637,12 @@ export async function runEmbeddedAttempt(
               1,
               contextEngineAssembleContextTokenBudget - contextEngineAssembleReserveTokens,
             );
+            const contextEngineAssemblePrompt =
+              orphanRepair?.contextEnginePrompt ?? params.prompt ?? "";
             const contextEngineAssembleRenderedPromptTokens =
               estimateRenderedLlmBoundaryTokenPressure({
                 systemPrompt: systemPromptText,
-                prompt: params.prompt ?? "",
+                prompt: contextEngineAssemblePrompt,
               });
             const contextEngineAssembleMessageBudget = Math.max(
               1,
@@ -3652,7 +3663,7 @@ export async function runEmbeddedAttempt(
               requestedModelId: params.requestedModelId,
               fallbackReason: params.fallbackReason,
               degradedReason: params.degradedReason,
-              ...(params.prompt !== undefined ? { prompt: params.prompt } : {}),
+              ...(params.prompt !== undefined ? { prompt: contextEngineAssemblePrompt } : {}),
             });
             if (!assembled) {
               throw new Error("context engine assemble returned no result");
@@ -4419,13 +4430,9 @@ export async function runEmbeddedAttempt(
           params.transcriptPrompt === undefined ? undefined : params.transcriptPrompt;
         let transcriptPromptForRuntimeSplit = effectiveTranscriptPrompt;
         let promptForRuntimeContextSplit = promptBeforePromptBuildHooks;
-        // Repair orphaned trailing user messages so new prompts don't violate role ordering.
-        const orphanRepair = isRawModelRun
-          ? undefined
-          : findTrailingMessageEntryForOrphanRepair(sessionManager);
         const leafEntry = orphanRepair?.messageEntry;
-        if (leafEntry?.message.role === "user") {
-          const messageMergeStrategy = resolveMessageMergeStrategy();
+        if (leafEntry) {
+          const messageMergeStrategy = orphanRepair.strategy;
           const orphanPromptMerge = messageMergeStrategy.mergeOrphanedTrailingUserPrompt({
             prompt: effectivePrompt,
             trigger: params.trigger,
@@ -4449,30 +4456,15 @@ export async function runEmbeddedAttempt(
           if (transcriptPromptMerge) {
             transcriptPromptForRuntimeSplit = transcriptPromptMerge.prompt;
           }
-          if (orphanPromptMerge.removeLeaf) {
-            if (leafEntry.parentId) {
-              sessionManager.branch(leafEntry.parentId);
-            } else {
-              sessionManager.resetLeaf();
-            }
-            replayTrailingEntriesForOrphanRepair(
-              sessionManager,
-              orphanRepair?.trailingEntries ?? [],
-            );
-            activeSession.agent.state.messages = removeUserMessageForOrphanRepair(
-              activeSession.messages,
-              leafEntry.message,
-            );
-          }
           const orphanRepairMessage =
             `${
-              orphanPromptMerge.removeLeaf
+              orphanRepair.removeLeaf
                 ? orphanPromptMerge.merged
                   ? "Merged and removed"
                   : "Removed already-queued"
                 : "Preserved"
             } orphaned user message` +
-            (orphanPromptMerge.removeLeaf
+            (orphanRepair.removeLeaf
               ? " to prevent consecutive user turns. "
               : " without removing the active session leaf. ") +
             `runId=${params.runId} sessionId=${params.sessionId} trigger=${params.trigger}`;

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -25,7 +25,7 @@ import {
   type OwnedSessionTranscriptWriteOptions,
   withOwnedSessionTranscriptWrites,
 } from "../../../config/sessions/transcript-write-context.js";
-import type { SessionEntry } from "../../../config/sessions/types.js";
+import type { SessionEntry as ConfigSessionEntry } from "../../../config/sessions/types.js";
 import {
   assertContextEngineHostSupport,
   OPENCLAW_EMBEDDED_CONTEXT_ENGINE_HOST,
@@ -218,6 +218,7 @@ import { acquireSessionWriteLock } from "../../session-write-lock.js";
 import {
   createAgentSession,
   SessionManager,
+  type SessionEntry as SessionManagerEntry,
   type SessionMessageEntry,
 } from "../../sessions/index.js";
 import { wrapToolDefinition } from "../../sessions/tools/tool-definition-wrapper.js";
@@ -695,10 +696,10 @@ type OrphanRepairSessionManager = Pick<
 
 type OrphanRepairCandidate = {
   messageEntry: SessionMessageEntry;
-  trailingEntries: SessionEntry[];
+  trailingEntries: SessionManagerEntry[];
 };
 
-function canSkipTrailingEntryForOrphanRepair(entry: SessionEntry): boolean {
+function canSkipTrailingEntryForOrphanRepair(entry: SessionManagerEntry): boolean {
   return (
     entry.type === "thinking_level_change" ||
     entry.type === "model_change" ||
@@ -712,7 +713,7 @@ function findTrailingMessageEntryForOrphanRepair(
   sessionManager: OrphanRepairSessionManager,
 ): OrphanRepairCandidate | undefined {
   const visited = new Set<string>();
-  const trailingEntries: SessionEntry[] = [];
+  const trailingEntries: SessionManagerEntry[] = [];
   let entry = sessionManager.getLeafEntry();
   while (entry && entry.type !== "message" && canSkipTrailingEntryForOrphanRepair(entry)) {
     if (visited.has(entry.id)) {
@@ -729,7 +730,7 @@ function findTrailingMessageEntryForOrphanRepair(
 
 function appendTrailingEntryForOrphanRepair(
   sessionManager: OrphanRepairSessionManager,
-  entry: SessionEntry,
+  entry: SessionManagerEntry,
 ): void {
   if (entry.type === "thinking_level_change") {
     sessionManager.appendThinkingLevelChange(entry.thinkingLevel);
@@ -754,7 +755,7 @@ function appendTrailingEntryForOrphanRepair(
 
 function replayTrailingEntriesForOrphanRepair(
   sessionManager: OrphanRepairSessionManager,
-  trailingEntries: SessionEntry[],
+  trailingEntries: SessionManagerEntry[],
 ): void {
   for (const entry of trailingEntries) {
     appendTrailingEntryForOrphanRepair(sessionManager, entry);
@@ -774,8 +775,8 @@ function isUserAgentMessage(message: AgentMessage | undefined): message is UserM
 }
 
 function optionalMessageFieldMatches(left: AgentMessage, right: UserMessage, field: string): boolean {
-  const leftValue = (left as Record<string, unknown>)[field];
-  const rightValue = (right as Record<string, unknown>)[field];
+  const leftValue = (left as unknown as Record<string, unknown>)[field];
+  const rightValue = (right as unknown as Record<string, unknown>)[field];
   return rightValue === undefined || leftValue === undefined || leftValue === rightValue;
 }
 
@@ -950,7 +951,7 @@ function collectAttemptExplicitToolAllowlistSources(params: {
 async function loadAttemptSessionEntryAfterQuotaMaintenance(params: {
   storePath: string;
   sessionKey: string;
-}): Promise<SessionEntry | undefined> {
+}): Promise<ConfigSessionEntry | undefined> {
   const entry = loadSessionEntry({
     storePath: params.storePath,
     sessionKey: params.sessionKey,

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -773,17 +773,33 @@ function isUserAgentMessage(message: AgentMessage | undefined): message is UserM
   return message?.role === "user";
 }
 
-function removeTrailingUserMessageForOrphanRepair(
+function optionalMessageFieldMatches(left: AgentMessage, right: UserMessage, field: string): boolean {
+  const leftValue = (left as Record<string, unknown>)[field];
+  const rightValue = (right as Record<string, unknown>)[field];
+  return rightValue === undefined || leftValue === undefined || leftValue === rightValue;
+}
+
+function isMatchingUserMessageForOrphanRepair(
+  message: AgentMessage | undefined,
+  orphanMessage: SessionMessageEntry["message"],
+): message is UserMessage {
+  return (
+    isUserAgentMessage(message) &&
+    isUserAgentMessage(orphanMessage) &&
+    contentValuesEqual(message.content, orphanMessage.content) &&
+    optionalMessageFieldMatches(message, orphanMessage, "timestamp") &&
+    optionalMessageFieldMatches(message, orphanMessage, "id")
+  );
+}
+
+function removeUserMessageForOrphanRepair(
   messages: AgentMessage[],
   orphanMessage: SessionMessageEntry["message"],
 ): AgentMessage[] {
-  const lastMessage = messages.at(-1);
-  if (
-    isUserAgentMessage(lastMessage) &&
-    isUserAgentMessage(orphanMessage) &&
-    contentValuesEqual(lastMessage.content, orphanMessage.content)
-  ) {
-    return messages.slice(0, -1);
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    if (isMatchingUserMessageForOrphanRepair(messages[index], orphanMessage)) {
+      return [...messages.slice(0, index), ...messages.slice(index + 1)];
+    }
   }
   return messages;
 }
@@ -4431,7 +4447,7 @@ export async function runEmbeddedAttempt(
               sessionManager,
               orphanRepair?.trailingEntries ?? [],
             );
-            activeSession.agent.state.messages = removeTrailingUserMessageForOrphanRepair(
+            activeSession.agent.state.messages = removeUserMessageForOrphanRepair(
               activeSession.messages,
               leafEntry.message,
             );

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -750,7 +750,11 @@ function appendTrailingEntryForOrphanRepair(
     return;
   }
   if (entry.type === "label") {
-    const targetId = replayedEntryIds.get(entry.targetId) ?? entry.targetId;
+    const replayedTargetId = replayedEntryIds.get(entry.targetId);
+    if (!replayedTargetId && !sessionManager.getEntry(entry.targetId)) {
+      return;
+    }
+    const targetId = replayedTargetId ?? entry.targetId;
     replayedEntryIds.set(entry.id, sessionManager.appendLabelChange(targetId, entry.label));
   }
 }
@@ -777,7 +781,11 @@ function isUserAgentMessage(message: AgentMessage | undefined): message is UserM
   return message?.role === "user";
 }
 
-function optionalMessageFieldMatches(left: AgentMessage, right: UserMessage, field: string): boolean {
+function optionalMessageFieldMatches(
+  left: AgentMessage,
+  right: UserMessage,
+  field: string,
+): boolean {
   const leftValue = (left as unknown as Record<string, unknown>)[field];
   const rightValue = (right as unknown as Record<string, unknown>)[field];
   return rightValue === undefined || leftValue === undefined || leftValue === rightValue;

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -54,7 +54,7 @@ import { resolveHeartbeatSummaryForAgent } from "../../../infra/heartbeat-summar
 import { getMachineDisplayName } from "../../../infra/machine-name.js";
 import { resolveRuntimeOsLabel } from "../../../infra/os-summary.js";
 import { createCodexNativeWebSearchWrapper } from "../../../llm/providers/stream-wrappers/openai.js";
-import type { AssistantMessage } from "../../../llm/types.js";
+import type { AssistantMessage, UserMessage } from "../../../llm/types.js";
 import { listRegisteredPluginAgentPromptGuidance } from "../../../plugins/command-registry-state.js";
 import { getCurrentPluginMetadataSnapshot } from "../../../plugins/current-plugin-metadata-snapshot.js";
 import {
@@ -720,13 +720,18 @@ function contentValuesEqual(left: unknown, right: unknown): boolean {
   }
 }
 
+function isUserAgentMessage(message: AgentMessage | undefined): message is UserMessage {
+  return message?.role === "user";
+}
+
 function removeTrailingUserMessageForOrphanRepair(
   messages: AgentMessage[],
   orphanMessage: SessionMessageEntry["message"],
 ): AgentMessage[] {
   const lastMessage = messages.at(-1);
   if (
-    lastMessage?.role === "user" &&
+    isUserAgentMessage(lastMessage) &&
+    isUserAgentMessage(orphanMessage) &&
     contentValuesEqual(lastMessage.content, orphanMessage.content)
   ) {
     return messages.slice(0, -1);

--- a/src/agents/embedded-agent-runner/run/message-merge-strategy.test.ts
+++ b/src/agents/embedded-agent-runner/run/message-merge-strategy.test.ts
@@ -24,17 +24,16 @@ describe("message merge strategy registry", () => {
     const strategy = resolveMessageMergeStrategy();
 
     expect(strategy.id).toBe(DEFAULT_MESSAGE_MERGE_STRATEGY_ID);
-    expect(
-      strategy.mergeOrphanedTrailingUserPrompt({
-        prompt: "newest inbound message",
-        trigger: "user",
-        leafMessage: { content: "older active-turn message" },
-      }),
-    ).toEqual({
+    const result = strategy.mergeOrphanedTrailingUserPrompt({
+      prompt: "newest inbound message",
+      trigger: "user",
+      leafMessage: { content: "older active-turn message" },
+    });
+    expect(result).toEqual({
       merged: true,
       removeLeaf: true,
       prompt:
-        "[Queued user message that arrived while the previous turn was still active]\n" +
+        "[Queued user message from a previous active turn; preserved as context only. Continue with the active prompt below.]\n" +
         "older active-turn message\n\nnewest inbound message",
     });
   });

--- a/src/agents/embedded-agent-runner/run/message-merge-strategy.ts
+++ b/src/agents/embedded-agent-runner/run/message-merge-strategy.ts
@@ -8,7 +8,7 @@ import type { EmbeddedRunAttemptParams } from "./types.js";
 type OrphanedTrailingUserPromptMergeParams = {
   prompt: string;
   trigger: EmbeddedRunAttemptParams["trigger"];
-  leafMessage: { content?: unknown };
+  leafMessage: { content?: unknown; provenance?: unknown };
 };
 
 /** Result of merging or dropping a trailing user leaf before provider submission. */

--- a/src/plugin-sdk/test-helpers/agents/transcript-repair-runtime-contract.ts
+++ b/src/plugin-sdk/test-helpers/agents/transcript-repair-runtime-contract.ts
@@ -2,7 +2,8 @@
 import type { AgentMessage } from "../../../agents/runtime/index.js";
 
 export const QUEUED_USER_MESSAGE_MARKER =
-  "[Queued user message that arrived while the previous turn was still active]";
+  "[Queued user message from a previous active turn; preserved as context only. " +
+  "Continue with the active prompt below.]";
 
 export function textOrphanLeaf(text = "older active-turn message"): { content: string } {
   return { content: text };


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users in channel-backed embedded-agent sessions could receive a visible reply to an older queued user message after sending a newer active prompt.

Closes #76888

The failure shape is that orphan repair only checked the current session leaf. Real sessions can append non-message metadata entries such as thinking/model snapshots after the orphaned user message before prompt submission, which hid the older user message from repair and left it eligible as an active instruction.

## Why This Change Was Made

The embedded runner now looks past trailing non-message metadata that does not contribute LLM content, repairs the older user turn as context-only prompt material, branches away from that orphaned user entry, replays the skipped state entries, and keeps the already-sanitized active session messages for provider submission.

This keeps the fix scoped to the embedded-agent/session/provider boundary. It does not change Discord delivery, queue semantics, provider routing, model selection, public config/schema/protocol, API keys/auth, storage format migrations, or session persistence format. The remaining maintainer-owned decision is whether this preserve-as-context strategy should be canonical versus the alternative candidate in #96533, which uses different stale-prompt semantics.

## User Impact

When an active channel prompt follows an orphaned queued user turn, the older turn is preserved only as prior-turn context and the latest active prompt remains the answer target. Users should no longer see the assistant answer the stale queued turn in this session-state shape.

The highest-risk area is embedded-runner session-state/prompt-shape compatibility. The mitigation is focused coverage for the metadata-skipping repair, state replay, label target remap, provider-seam prompt order, and the shared queued-user marker contract. Exact marker wording and final cross-PR session-state semantics remain maintainer review decisions.

## Evidence

Current HEAD validation:

```text
Validation `plugin-sdk-dts-after-dangling-label-commit` (pass, exit_code=0):
node scripts/run-tsgo.mjs -p tsconfig.plugin-sdk.dts.json --declaration true

Validation `orphan-repair-label-focused-after-dangling-label-commit` (pass, exit_code=0):
pnpm exec vitest run src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts -t "repairs an orphaned user message behind non-message session metadata before the provider|does not abort orphan repair for a dangling trailing label"

Focused result: 2 files passed, 4 tests passed, 144 skipped.
```

The current focused regressions prove the issue-specific provider-boundary behavior:

```text
olderPrompt = OLD_TURN_76888: answer the orphaned queued turn
latestPrompt = LATEST_TURN_76888: answer only the active channel prompt
provider prompt = queued-context-marker + OLD_TURN_76888 + LATEST_TURN_76888
assistant content = stub-provider-target=LATEST_TURN_76888
branch target = parent-leaf
replayed entries = thinking:high -> model:deepseek/deepseek-chat -> custom:model-snapshot -> label:replayed-custom/model snapshot
dangling trailing label = skipped when original target is absent; orphan repair still branches to parent-leaf and provider receives LATEST_TURN_76888
```

Reviewer-visible live behavior proof previously recorded for this PR:

```text
Validation `live-orphaned-user-proof-local-provider` (pass, exit_code=0, 232638ms):

[agent/embedded] Merged and removed orphaned user message to prevent consecutive user turns. runId=issue-76888-live-proof sessionId=issue-76888-live-proof trigger=user
runtime=production runEmbeddedAgent
agent_harness=openclaw
channel_metadata=messageChannel:discord messageProvider:discord trigger:user
provider_model=[redacted configured OpenAI-compatible provider]
model_prompt_trace=prompt:before
prompt_trace_count=1
prompt_trace_match_index=0
model_prompt_order=queued-context-marker -> OLD_TURN_76888 -> LATEST_TURN_76888
visible_reply=LATEST_TURN_TARGET_76888
assert_latest_target_present=true
assert_old_target_absent=true
post_run_leaf_role=assistant
payload_count=1
```

Additional validation already recorded on this PR:

```text
focused-agent-tests-after-orphan-history-filter: pass, 2 Vitest shards passed.
changed-tests-after-orphan-history-filter: pass, changed test selection completed successfully.
plugin-sdk-dts-after-session-entry-alias: pass.
orphan-repair-focused-after-session-entry-alias: pass.
```

What was not tested: I did not send an actual Discord message through the live Discord transport, and I did not reproduce the original stochastic production stale reply end to end. The live proof used production `runEmbeddedAgent` with Discord channel metadata, a real JSONL session fixture, and a configured provider; the post-sync current-head follow-up reran the focused embedded-runner/provider-seam regressions and the plugin SDK declaration shard after rebasing onto current main and after the dangling-label replay guard.
