### PR TITLE
fix(agents): keep auto-compaction appends owned during prompt lock release

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
@@ -17,6 +17,7 @@ import {
   acquireSessionWriteLock,
   resetSessionWriteLockStateForTest,
 } from "../../session-write-lock.js";
+import { SessionManager } from "../../sessions/session-manager.js";
 import {
   acquireEmbeddedAttemptSessionFileOwner,
   createEmbeddedAttemptSessionLockController,
@@ -899,6 +900,43 @@ describe("embedded attempt session lock lifecycle", () => {
     await controller.releaseForPrompt();
     await fs.appendFile(sessionFile, '{"type":"message","id":"owned-session-manager"}\n', "utf8");
     controller.refreshAfterOwnedSessionWrite();
+
+    await expect(controller.withSessionWriteLock(() => "finalize")).resolves.toBe("finalize");
+    expect(controller.hasSessionTakeover()).toBe(false);
+  });
+
+  it("keeps threshold compaction appends owned while the prompt lock is released", async () => {
+    const sessionFile = await createTempSessionFile();
+    const sessionManager = SessionManager.open(sessionFile);
+    const userId = sessionManager.appendMessage({ role: "user", content: "hello" });
+    sessionManager.appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "long enough to compact" }],
+      provider: "openclaw",
+      model: "test",
+      timestamp: Date.now(),
+    });
+
+    const release = vi.fn(async () => {});
+    const acquireSessionWriteLockLocal3 = vi.fn(async () => ({ release }));
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock: acquireSessionWriteLockLocal3,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+
+    await controller.releaseForPrompt();
+    await withOwnedSessionTranscriptWrites(
+      {
+        sessionFile,
+        sessionKey: "agent:main:whatsapp:direct:peer",
+        refreshAfterOwnedSessionWrite: () => controller.refreshAfterOwnedSessionWrite(),
+        withSessionWriteLock: (operation, options) =>
+          controller.withSessionWriteLock(operation, options),
+      },
+      async () => {
+        sessionManager.appendCompaction("summary", userId, 120_000);
+      },
+    );
 
     await expect(controller.withSessionWriteLock(() => "finalize")).resolves.toBe("finalize");
     expect(controller.hasSessionTakeover()).toBe(false);

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
@@ -54,6 +54,34 @@ async function createTempSessionFile(): Promise<string> {
   return sessionFile;
 }
 
+function createUserMessage(content = "hello") {
+  return {
+    role: "user" as const,
+    content,
+    timestamp: Date.now(),
+  };
+}
+
+function createAssistantMessage(text = "long enough to compact") {
+  return {
+    role: "assistant" as const,
+    content: [{ type: "text" as const, text }],
+    api: "openai-responses" as const,
+    provider: "openclaw",
+    model: "test",
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: "stop" as const,
+    timestamp: Date.now(),
+  };
+}
+
 describe("embedded attempt session lock lifecycle", () => {
   it("serializes embedded attempts that share a session file owner", async () => {
     const sessionFile = await createTempSessionFile();
@@ -908,14 +936,8 @@ describe("embedded attempt session lock lifecycle", () => {
   it("keeps threshold compaction appends owned while the prompt lock is released", async () => {
     const sessionFile = await createTempSessionFile();
     const sessionManager = SessionManager.open(sessionFile);
-    const userId = sessionManager.appendMessage({ role: "user", content: "hello" });
-    sessionManager.appendMessage({
-      role: "assistant",
-      content: [{ type: "text", text: "long enough to compact" }],
-      provider: "openclaw",
-      model: "test",
-      timestamp: Date.now(),
-    });
+    const userId = sessionManager.appendMessage(createUserMessage());
+    sessionManager.appendMessage(createAssistantMessage());
 
     const release = vi.fn(async () => {});
     const acquireSessionWriteLockLocal3 = vi.fn(async () => ({ release }));
@@ -929,7 +951,7 @@ describe("embedded attempt session lock lifecycle", () => {
       {
         sessionFile,
         sessionKey: "agent:main:whatsapp:direct:peer",
-        refreshAfterOwnedSessionWrite: () => controller.refreshAfterOwnedSessionWrite(),
+        beginOwnedSessionTranscriptWrite: () => controller.beginOwnedSessionWritePublication(),
         withSessionWriteLock: (operation, options) =>
           controller.withSessionWriteLock(operation, options),
       },
@@ -940,6 +962,44 @@ describe("embedded attempt session lock lifecycle", () => {
 
     await expect(controller.withSessionWriteLock(() => "finalize")).resolves.toBe("finalize");
     expect(controller.hasSessionTakeover()).toBe(false);
+  });
+
+  it("still rejects external edits before owned threshold compaction appends", async () => {
+    const sessionFile = await createTempSessionFile();
+    const sessionManager = SessionManager.open(sessionFile);
+    const userId = sessionManager.appendMessage(createUserMessage());
+    sessionManager.appendMessage(createAssistantMessage());
+
+    const release = vi.fn(async () => {});
+    const acquireSessionWriteLockLocal3 = vi.fn(async () => ({ release }));
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock: acquireSessionWriteLockLocal3,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+
+    await controller.releaseForPrompt();
+    await fs.appendFile(
+      sessionFile,
+      '{"type":"message","id":"external-before-compaction"}\n',
+      "utf8",
+    );
+    await withOwnedSessionTranscriptWrites(
+      {
+        sessionFile,
+        sessionKey: "agent:main:whatsapp:direct:peer",
+        beginOwnedSessionTranscriptWrite: () => controller.beginOwnedSessionWritePublication(),
+        withSessionWriteLock: (operation, options) =>
+          controller.withSessionWriteLock(operation, options),
+      },
+      async () => {
+        sessionManager.appendCompaction("summary", userId, 120_000);
+      },
+    );
+
+    await expect(controller.withSessionWriteLock(() => "finalize")).rejects.toBeInstanceOf(
+      EmbeddedAttemptSessionTakeoverError,
+    );
+    expect(controller.hasSessionTakeover()).toBe(true);
   });
 
   it("allows post-prompt writes after the prompt context publishes an owned transcript write", async () => {

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
@@ -1018,6 +1018,7 @@ export function installPromptSubmissionLockRelease(params: {
   reacquireAfterPrompt: () => Promise<void>;
   sessionFile?: string;
   sessionKey?: string;
+  refreshAfterOwnedSessionWrite?: () => void;
   withSessionWriteLock?: <T>(
     run: () => Promise<T> | T,
     options?: SessionWriteLockRunOptions,
@@ -1041,6 +1042,7 @@ export function installPromptSubmissionLockRelease(params: {
           {
             sessionFile: params.sessionFile,
             sessionKey: params.sessionKey,
+            refreshAfterOwnedSessionWrite: params.refreshAfterOwnedSessionWrite,
             withSessionWriteLock: params.withSessionWriteLock,
           },
           async () => await originalStreamFn(...args),

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
@@ -575,6 +575,7 @@ export type EmbeddedAttemptSessionLockController = {
   releaseForPrompt(): Promise<void>;
   releaseHeldLockForAbort(): Promise<void>;
   refreshAfterOwnedSessionWrite(): void;
+  beginOwnedSessionWritePublication(): () => void;
   reacquireAfterPrompt(): Promise<void>;
   waitForSessionEvents(session: unknown): Promise<void>;
   withSessionWriteLock<T>(
@@ -787,6 +788,25 @@ export async function createEmbeddedAttemptSessionLockController(params: {
     }
   }
 
+  function publishOwnedSessionFileFenceSync(beforeWrite: SessionFileFingerprint): void {
+    if (takeoverDetected) {
+      return;
+    }
+    const fingerprint = readSessionFileFingerprintSync(params.lockOptions.sessionFile);
+    if (sameSessionFileFingerprint(beforeWrite, fingerprint)) {
+      return;
+    }
+    if (!isTrustedSessionFileState(sessionFileFenceKey, beforeWrite)) {
+      return;
+    }
+    const generation = recordOwnedSessionFileWrite(sessionFileFenceKey, fingerprint);
+    if (fenceActive) {
+      fenceFingerprint = fingerprint;
+      fenceSnapshot = { fingerprint };
+      fenceGeneration = generation;
+    }
+  }
+
   const noopLock: SessionLock = { release: async () => {} };
 
   async function releaseHeldLockWithFence(): Promise<void> {
@@ -913,6 +933,10 @@ export async function createEmbeddedAttemptSessionLockController(params: {
         fenceSnapshot = { fingerprint: fenceFingerprint };
       }
     },
+    beginOwnedSessionWritePublication(): () => void {
+      const beforeWrite = readSessionFileFingerprintSync(params.lockOptions.sessionFile);
+      return () => publishOwnedSessionFileFenceSync(beforeWrite);
+    },
     async reacquireAfterPrompt(): Promise<void> {
       await waitForHeldLockDrain();
       if (takeoverDetected || heldLock) {
@@ -1018,7 +1042,7 @@ export function installPromptSubmissionLockRelease(params: {
   reacquireAfterPrompt: () => Promise<void>;
   sessionFile?: string;
   sessionKey?: string;
-  refreshAfterOwnedSessionWrite?: () => void;
+  beginOwnedSessionTranscriptWrite?: () => (() => void) | undefined;
   withSessionWriteLock?: <T>(
     run: () => Promise<T> | T,
     options?: SessionWriteLockRunOptions,
@@ -1042,7 +1066,7 @@ export function installPromptSubmissionLockRelease(params: {
           {
             sessionFile: params.sessionFile,
             sessionKey: params.sessionKey,
-            refreshAfterOwnedSessionWrite: params.refreshAfterOwnedSessionWrite,
+            beginOwnedSessionTranscriptWrite: params.beginOwnedSessionTranscriptWrite,
             withSessionWriteLock: params.withSessionWriteLock,
           },
           async () => await originalStreamFn(...args),

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -3992,6 +3992,8 @@ export async function runEmbeddedAttempt(
               reacquireAfterPrompt: () => sessionLockController.reacquireAfterPrompt(),
               sessionKey: params.sessionKey,
               sessionFile: params.sessionFile,
+              refreshAfterOwnedSessionWrite: () =>
+                sessionLockController.refreshAfterOwnedSessionWrite(),
               withSessionWriteLock: (run, options) =>
                 sessionLockController.withSessionWriteLock(run, options),
             });

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -3992,8 +3992,8 @@ export async function runEmbeddedAttempt(
               reacquireAfterPrompt: () => sessionLockController.reacquireAfterPrompt(),
               sessionKey: params.sessionKey,
               sessionFile: params.sessionFile,
-              refreshAfterOwnedSessionWrite: () =>
-                sessionLockController.refreshAfterOwnedSessionWrite(),
+              beginOwnedSessionTranscriptWrite: () =>
+                sessionLockController.beginOwnedSessionWritePublication(),
               withSessionWriteLock: (run, options) =>
                 sessionLockController.withSessionWriteLock(run, options),
             });

--- a/src/agents/sessions/session-manager.ts
+++ b/src/agents/sessions/session-manager.ts
@@ -22,6 +22,7 @@ import {
   appendJsonlEntrySync,
   writeJsonlEntriesSync,
 } from "../../config/sessions/transcript-jsonl.js";
+import { publishOwnedSessionTranscriptWrite } from "../../config/sessions/transcript-write-context.js";
 import { CURRENT_SESSION_VERSION } from "../../config/sessions/version.js";
 import type { ImageContent, Message, TextContent } from "../../llm/types.js";
 import { getAgentDir as getDefaultAgentDir, getSessionsDir } from "../config.js";
@@ -920,6 +921,7 @@ export class SessionManager {
     this.byId.set(entry.id, entry);
     this.leafId = entry.id;
     this.persist(entry);
+    publishOwnedSessionTranscriptWrite({ sessionFile: this.sessionFile });
   }
 
   /** Append a message as child of current leaf, then advance leaf. Returns entry id.

--- a/src/agents/sessions/session-manager.ts
+++ b/src/agents/sessions/session-manager.ts
@@ -22,7 +22,7 @@ import {
   appendJsonlEntrySync,
   writeJsonlEntriesSync,
 } from "../../config/sessions/transcript-jsonl.js";
-import { publishOwnedSessionTranscriptWrite } from "../../config/sessions/transcript-write-context.js";
+import { beginOwnedSessionTranscriptWrite } from "../../config/sessions/transcript-write-context.js";
 import { CURRENT_SESSION_VERSION } from "../../config/sessions/version.js";
 import type { ImageContent, Message, TextContent } from "../../llm/types.js";
 import { getAgentDir as getDefaultAgentDir, getSessionsDir } from "../config.js";
@@ -920,8 +920,12 @@ export class SessionManager {
     this.fileEntries.push(entry);
     this.byId.set(entry.id, entry);
     this.leafId = entry.id;
-    this.persist(entry);
-    publishOwnedSessionTranscriptWrite({ sessionFile: this.sessionFile });
+    const publishOwnedWrite = beginOwnedSessionTranscriptWrite({ sessionFile: this.sessionFile });
+    try {
+      this.persist(entry);
+    } finally {
+      publishOwnedWrite?.();
+    }
   }
 
   /** Append a message as child of current leaf, then advance leaf. Returns entry id.

--- a/src/config/sessions/transcript-write-context.ts
+++ b/src/config/sessions/transcript-write-context.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 type OwnedSessionTranscriptWriteContext = {
   sessionFile?: string;
   sessionKey?: string;
+  refreshAfterOwnedSessionWrite?: () => void;
   withSessionWriteLock: <T>(
     run: () => Promise<T> | T,
     options?: { publishOwnedWrite?: boolean },
@@ -82,6 +83,17 @@ export function resolveOwnedSessionTranscriptWriteLockRunner(params: {
     return undefined;
   }
   return context.withSessionWriteLock;
+}
+
+export function publishOwnedSessionTranscriptWrite(params: {
+  sessionFile?: string;
+  sessionKey?: string;
+}): void {
+  const context = ownedTranscriptWriteContext.getStore();
+  if (!context || !contextMatches({ context, ...params })) {
+    return;
+  }
+  context.refreshAfterOwnedSessionWrite?.();
 }
 
 async function runWithOwnedSessionTranscriptWriteContext<T>(

--- a/src/config/sessions/transcript-write-context.ts
+++ b/src/config/sessions/transcript-write-context.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 type OwnedSessionTranscriptWriteContext = {
   sessionFile?: string;
   sessionKey?: string;
-  refreshAfterOwnedSessionWrite?: () => void;
+  beginOwnedSessionTranscriptWrite?: () => (() => void) | undefined;
   withSessionWriteLock: <T>(
     run: () => Promise<T> | T,
     options?: { publishOwnedWrite?: boolean },
@@ -85,15 +85,15 @@ export function resolveOwnedSessionTranscriptWriteLockRunner(params: {
   return context.withSessionWriteLock;
 }
 
-export function publishOwnedSessionTranscriptWrite(params: {
+export function beginOwnedSessionTranscriptWrite(params: {
   sessionFile?: string;
   sessionKey?: string;
-}): void {
+}): (() => void) | undefined {
   const context = ownedTranscriptWriteContext.getStore();
   if (!context || !contextMatches({ context, ...params })) {
-    return;
+    return undefined;
   }
-  context.refreshAfterOwnedSessionWrite?.();
+  return context.beginOwnedSessionTranscriptWrite?.();
 }
 
 async function runWithOwnedSessionTranscriptWriteContext<T>(


### PR DESCRIPTION
Summary
- Fixes an owned-write publication gap in the embedded prompt-lock path when `SessionManager` appends session JSONL entries during provider streaming.
- Publishes matching `SessionManager` appends back to the active owned transcript-write context only when the pre-append session fingerprint is already trusted, so threshold auto-compaction does not look like an external session takeover.
- Adds regression coverage for both the owned compaction append and the external-edit interleaving that must still report takeover.

Fixes #90729

Verification
- `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-90729-vitest-cache node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts`
- `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-90729-vitest-cache node node_modules/vitest/vitest.mjs run src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts --config test/vitest/vitest.agents.config.ts --reporter verbose`
- `./node_modules/.bin/oxfmt --check src/config/sessions/transcript-write-context.ts src/agents/sessions/session-manager.ts src/agents/embedded-agent-runner/run/attempt.session-lock.ts src/agents/embedded-agent-runner/run/attempt.ts src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts`
- `./node_modules/.bin/oxlint src/config/sessions/transcript-write-context.ts src/agents/sessions/session-manager.ts src/agents/embedded-agent-runner/run/attempt.session-lock.ts src/agents/embedded-agent-runner/run/attempt.ts src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts`
- `git diff --check`

Real behavior proof
- behavior: Reproduced the false takeover in the shared embedded session-lock path by releasing the prompt lock, appending a threshold compaction through `SessionManager.appendCompaction(...)`, then attempting a post-prompt session write.
- environment: Local OpenClaw source checkout on Node 22 with the agents Vitest config.
- steps: Added the regression test first on current main, ran the focused agents test, applied the fix, then added and passed an external-edit interleaving regression before rerunning the same focused test plus format/lint/whitespace checks.
- evidence: On current main, the new focused test failed with `EmbeddedAttemptSessionTakeoverError: session file changed while embedded prompt lock was released`. On the fixed branch, the same file passes with 45 tests, including `keeps threshold compaction appends owned while the prompt lock is released` and `still rejects external edits before owned threshold compaction appends`.
- observedResult: Threshold compaction appends through the shared session manager are treated as owned writes only when the pre-append fingerprint is trusted; an external edit before the compaction append still triggers `EmbeddedAttemptSessionTakeoverError`.
- notTested: Full live WhatsApp/Docker threshold auto-compaction E2E was not run locally. The focused proof covers the shared session-manager/prompt-lock path that produces the false takeover in #90729.
