### PR TITLE
fix: refresh prompt fence after compaction writes

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
@@ -1,4 +1,5 @@
 // Coverage for embedded attempt session-file ownership and write locks.
+import { appendFileSync } from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -9,6 +10,7 @@ import {
   runWithOwnedSessionTranscriptWritePublication,
   withOwnedSessionTranscriptWrites,
 } from "../../../config/sessions/transcript-write-context.js";
+import { guardSessionManager } from "../../session-tool-result-guard-wrapper.js";
 import {
   SessionWriteLockStaleError,
   SessionWriteLockTimeoutError,
@@ -17,6 +19,7 @@ import {
   acquireSessionWriteLock,
   resetSessionWriteLockStateForTest,
 } from "../../session-write-lock.js";
+import { SessionManager } from "../../sessions/session-manager.js";
 import {
   acquireEmbeddedAttemptSessionFileOwner,
   createEmbeddedAttemptSessionLockController,
@@ -902,6 +905,273 @@ describe("embedded attempt session lock lifecycle", () => {
 
     await expect(controller.withSessionWriteLock(() => "finalize")).resolves.toBe("finalize");
     expect(controller.hasSessionTakeover()).toBe(false);
+  });
+
+  it("refreshes the prompt fence after an owned session manager compaction append", async () => {
+    const sessionFile = await createTempSessionFile();
+    const release = vi.fn(async () => {});
+    const acquireSessionWriteLockLocal2 = vi.fn(async () => ({ release }));
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock: acquireSessionWriteLockLocal2,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+    const sessionManager = guardSessionManager(SessionManager.open(sessionFile), {
+      withCompactionPersistence: (append, validateAppend) =>
+        controller.withOwnedSessionFileWrite(append, validateAppend),
+    });
+    const firstKeptEntryId = sessionManager.appendMessage({
+      role: "user",
+      content: "old question",
+      timestamp: 1,
+    });
+    sessionManager.appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "old answer" }],
+      api: "messages",
+      provider: "openclaw",
+      model: "session-lock-test",
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: "stop",
+      timestamp: 2,
+    });
+
+    await controller.releaseForPrompt();
+    sessionManager.appendCompaction("threshold summary", firstKeptEntryId, 160_001);
+
+    await expect(controller.withSessionWriteLock(() => "finalize")).resolves.toBe("finalize");
+    expect(controller.hasSessionTakeover()).toBe(false);
+  });
+
+  it("still rejects unowned external compaction appends before the prompt stream lock is reacquired", async () => {
+    const sessionFile = await createTempSessionFile();
+    const release = vi.fn(async () => {});
+    const acquireSessionWriteLockLocal1 = vi.fn(async () => ({ release }));
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock: acquireSessionWriteLockLocal1,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+
+    await controller.releaseForPrompt();
+    await fs.appendFile(
+      sessionFile,
+      JSON.stringify({
+        type: "compaction",
+        id: "external-compaction",
+        parentId: "session",
+        timestamp: new Date().toISOString(),
+        summary: "external summary",
+        firstKeptEntryId: "session",
+        tokensBefore: 160_001,
+      }) + "\n",
+      "utf8",
+    );
+
+    await expect(controller.withSessionWriteLock(() => "finalize")).rejects.toBeInstanceOf(
+      EmbeddedAttemptSessionTakeoverError,
+    );
+    expect(controller.hasSessionTakeover()).toBe(true);
+  });
+
+  it("still rejects an external edit that happens before an owned session manager compaction append", async () => {
+    const sessionFile = await createTempSessionFile();
+    const release = vi.fn(async () => {});
+    const acquireSessionWriteLockLocal0 = vi.fn(async () => ({ release }));
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock: acquireSessionWriteLockLocal0,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+    const sessionManager = guardSessionManager(SessionManager.open(sessionFile), {
+      withCompactionPersistence: (append, validateAppend) =>
+        controller.withOwnedSessionFileWrite(append, validateAppend),
+    });
+    const firstKeptEntryId = sessionManager.appendMessage({
+      role: "user",
+      content: "old question",
+      timestamp: 1,
+    });
+    sessionManager.appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "old answer" }],
+      api: "messages",
+      provider: "openclaw",
+      model: "session-lock-test",
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: "stop",
+      timestamp: 2,
+    });
+
+    await controller.releaseForPrompt();
+    await fs.appendFile(sessionFile, '{"type":"message","id":"external-edit"}\n', "utf8");
+    sessionManager.appendCompaction("threshold summary", firstKeptEntryId, 160_001);
+
+    await expect(controller.withSessionWriteLock(() => "finalize")).rejects.toBeInstanceOf(
+      EmbeddedAttemptSessionTakeoverError,
+    );
+    expect(controller.hasSessionTakeover()).toBe(true);
+  });
+
+  it("still rejects an external edit interleaved inside an owned session manager compaction append", async () => {
+    const sessionFile = await createTempSessionFile();
+    const release = vi.fn(async () => {});
+    const acquireSessionWriteLockLocal30 = vi.fn(async () => ({ release }));
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock: acquireSessionWriteLockLocal30,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+    const sessionManager = guardSessionManager(SessionManager.open(sessionFile), {
+      withCompactionPersistence: (append, validateAppend) =>
+        controller.withOwnedSessionFileWrite(() => {
+          appendFileSync(sessionFile, '{"type":"message","id":"external-edit"}\n', "utf8");
+          return append();
+        }, validateAppend),
+    });
+    const firstKeptEntryId = sessionManager.appendMessage({
+      role: "user",
+      content: "old question",
+      timestamp: 1,
+    });
+    sessionManager.appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "old answer" }],
+      api: "messages",
+      provider: "openclaw",
+      model: "session-lock-test",
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: "stop",
+      timestamp: 2,
+    });
+
+    await controller.releaseForPrompt();
+    sessionManager.appendCompaction("threshold summary", firstKeptEntryId, 160_001);
+
+    await expect(controller.withSessionWriteLock(() => "finalize")).rejects.toBeInstanceOf(
+      EmbeddedAttemptSessionTakeoverError,
+    );
+    expect(controller.hasSessionTakeover()).toBe(true);
+  });
+
+  it("allows owned session manager compaction after a later controller advances the prompt fence", async () => {
+    const sessionFile = await createTempSessionFile();
+    const firstController = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock: vi.fn(async () => ({ release: vi.fn(async () => {}) })),
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+    await firstController.releaseForPrompt();
+    await firstController.dispose();
+
+    const release = vi.fn(async () => {});
+    const acquireSessionWriteLockLocal29 = vi.fn(async () => ({ release }));
+    const secondController = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock: acquireSessionWriteLockLocal29,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+    const sessionManager = guardSessionManager(SessionManager.open(sessionFile), {
+      withCompactionPersistence: (append, validateAppend) =>
+        secondController.withOwnedSessionFileWrite(append, validateAppend),
+    });
+    const firstKeptEntryId = await secondController.withSessionWriteLock(() => {
+      const entryId = sessionManager.appendMessage({
+        role: "user",
+        content: "new question",
+        timestamp: 1,
+      });
+      sessionManager.appendMessage({
+        role: "assistant",
+        content: [{ type: "text", text: "new answer" }],
+        api: "messages",
+        provider: "openclaw",
+        model: "session-lock-test",
+        usage: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 0,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+        stopReason: "stop",
+        timestamp: 2,
+      });
+      return entryId;
+    });
+
+    await secondController.releaseForPrompt();
+    sessionManager.appendCompaction("threshold summary", firstKeptEntryId, 160_001);
+
+    await expect(secondController.withSessionWriteLock(() => "finalize")).resolves.toBe("finalize");
+    expect(secondController.hasSessionTakeover()).toBe(false);
+  });
+
+  it("allows owned session manager compaction after another controller publishes an owned write", async () => {
+    const sessionFile = await createTempSessionFile();
+    const firstController = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock: vi.fn(async () => ({ release: vi.fn(async () => {}) })),
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+    const sessionManager = guardSessionManager(SessionManager.open(sessionFile), {
+      withCompactionPersistence: (append, validateAppend) =>
+        firstController.withOwnedSessionFileWrite(append, validateAppend),
+    });
+    const firstKeptEntryId = sessionManager.appendMessage({
+      role: "user",
+      content: "old question",
+      timestamp: 1,
+    });
+    sessionManager.appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "old answer" }],
+      api: "messages",
+      provider: "openclaw",
+      model: "session-lock-test",
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: "stop",
+      timestamp: 2,
+    });
+    await firstController.releaseForPrompt();
+
+    const secondController = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock: vi.fn(async () => ({ release: vi.fn(async () => {}) })),
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+    await secondController.releaseForPrompt();
+    await secondController.withSessionWriteLock(
+      async () => {
+        await fs.appendFile(sessionFile, '{"type":"message","id":"owned-other"}\n', "utf8");
+      },
+      { publishOwnedWrite: true },
+    );
+    sessionManager.appendCompaction("threshold summary", firstKeptEntryId, 160_001);
+
+    await expect(firstController.withSessionWriteLock(() => "finalize")).resolves.toBe("finalize");
+    expect(firstController.hasSessionTakeover()).toBe(false);
   });
 
   it("allows post-prompt writes after the prompt context publishes an owned transcript write", async () => {

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
@@ -2,7 +2,7 @@
  * Coordinates embedded-attempt session ownership, takeover, and prompt locks.
  */
 import { AsyncLocalStorage } from "node:async_hooks";
-import { statSync } from "node:fs";
+import { readFileSync, statSync } from "node:fs";
 import fs from "node:fs/promises";
 import { isDeepStrictEqual } from "node:util";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
@@ -28,6 +28,8 @@ type LockOptions = {
 type SessionWriteLockRunOptions = {
   publishOwnedWrite?: boolean;
 };
+
+type SessionFileWriteAppendValidator<T> = (result: T, appendedText: string) => boolean;
 
 type SessionWithAgentPrompt = {
   agent?: {
@@ -575,6 +577,10 @@ export type EmbeddedAttemptSessionLockController = {
   releaseForPrompt(): Promise<void>;
   releaseHeldLockForAbort(): Promise<void>;
   refreshAfterOwnedSessionWrite(): void;
+  withOwnedSessionFileWrite<T>(
+    run: () => T,
+    validateAppend?: SessionFileWriteAppendValidator<T>,
+  ): T;
   reacquireAfterPrompt(): Promise<void>;
   waitForSessionEvents(session: unknown): Promise<void>;
   withSessionWriteLock<T>(
@@ -787,6 +793,42 @@ export async function createEmbeddedAttemptSessionLockController(params: {
     }
   }
 
+  // Synchronous append paths cannot await withSessionWriteLock. Only publish
+  // their post-write fingerprint when the pre-write state was already trusted.
+  function publishOwnedSessionFileFenceSync<T>(write: {
+    beforeWrite: SessionFileFingerprint;
+    result: T;
+    beforeText?: string;
+    validateAppend?: SessionFileWriteAppendValidator<T>;
+  }): void {
+    if (takeoverDetected) {
+      return;
+    }
+    const fingerprint = readSessionFileFingerprintSync(params.lockOptions.sessionFile);
+    const beforeWriteIsTrusted =
+      (fenceActive && sameSessionFileFingerprint(fenceFingerprint, write.beforeWrite)) ||
+      isTrustedSessionFileState(sessionFileFenceKey, write.beforeWrite);
+    if (sameSessionFileFingerprint(write.beforeWrite, fingerprint) || !beforeWriteIsTrusted) {
+      return;
+    }
+    if (write.validateAppend) {
+      const afterText = readFileSync(params.lockOptions.sessionFile, "utf8");
+      if (
+        write.beforeText === undefined ||
+        !afterText.startsWith(write.beforeText) ||
+        !write.validateAppend(write.result, afterText.slice(write.beforeText.length))
+      ) {
+        return;
+      }
+    }
+    const generation = recordOwnedSessionFileWrite(sessionFileFenceKey, fingerprint);
+    if (fenceActive) {
+      fenceFingerprint = fingerprint;
+      fenceSnapshot = { fingerprint };
+      fenceGeneration = generation;
+    }
+  }
+
   const noopLock: SessionLock = { release: async () => {} };
 
   async function releaseHeldLockWithFence(): Promise<void> {
@@ -912,6 +954,23 @@ export async function createEmbeddedAttemptSessionLockController(params: {
         fenceFingerprint = readSessionFileFingerprintSync(params.lockOptions.sessionFile);
         fenceSnapshot = { fingerprint: fenceFingerprint };
       }
+    },
+    withOwnedSessionFileWrite<T>(
+      run: () => T,
+      validateAppend?: SessionFileWriteAppendValidator<T>,
+    ): T {
+      const beforeWrite = readSessionFileFingerprintSync(params.lockOptions.sessionFile);
+      const beforeText = validateAppend
+        ? readFileSync(params.lockOptions.sessionFile, "utf8")
+        : undefined;
+      const result = run();
+      publishOwnedSessionFileFenceSync({
+        beforeWrite,
+        result,
+        ...(beforeText !== undefined ? { beforeText } : {}),
+        ...(validateAppend ? { validateAppend } : {}),
+      });
+      return result;
     },
     async reacquireAfterPrompt(): Promise<void> {
       await waitForHeldLockDrain();

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -2005,6 +2005,8 @@ export async function runEmbeddedAttempt(
         onMessagePersisted: () => {
           sessionLockController.refreshAfterOwnedSessionWrite();
         },
+        withCompactionPersistence: (append, validateAppend) =>
+          sessionLockController.withOwnedSessionFileWrite(append, validateAppend),
         onUserMessagePersisted: (message) => {
           params.onUserMessagePersisted?.(message);
         },

--- a/src/agents/session-tool-result-guard-wrapper.ts
+++ b/src/agents/session-tool-result-guard-wrapper.ts
@@ -49,6 +49,10 @@ export function guardSessionManager(
       message: Extract<AgentMessage, { role: "user" }>,
     ) => void | Promise<void>;
     onMessagePersisted?: (message: AgentMessage) => void | Promise<void>;
+    withCompactionPersistence?: (
+      append: () => string,
+      validateAppend: (entryId: string, appendedText: string) => boolean,
+    ) => string;
     onAssistantErrorMessagePersisted?: (
       message: Extract<AgentMessage, { role: "assistant" }>,
     ) => void | Promise<void>;
@@ -140,6 +144,7 @@ export function guardSessionManager(
     suppressTranscriptOnlyAssistantPersistence: opts?.suppressTranscriptOnlyAssistantPersistence,
     suppressAssistantErrorPersistence: opts?.suppressAssistantErrorPersistence,
     onMessagePersisted: opts?.onMessagePersisted,
+    withCompactionPersistence: opts?.withCompactionPersistence,
     onUserMessagePersisted: opts?.onUserMessagePersisted,
     onAssistantErrorMessagePersisted: opts?.onAssistantErrorMessagePersisted,
   });

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -58,9 +58,26 @@ function resolveMaxToolResultChars(opts?: { maxToolResultChars?: number }): numb
 }
 
 type UserAgentMessage = Extract<AgentMessage, { role: "user" }>;
+type CompactionAppendValidator = (entryId: string, appendedText: string) => boolean;
 
 function isUserAgentMessage(message: AgentMessage): message is UserAgentMessage {
   return message.role === "user";
+}
+
+function isExpectedCompactionAppend(entryId: string, appendedText: string): boolean {
+  const lines = appendedText
+    .trimEnd()
+    .split("\n")
+    .filter((line) => line.length > 0);
+  if (lines.length !== 1) {
+    return false;
+  }
+  try {
+    const entry = JSON.parse(lines[0]) as { type?: unknown; id?: unknown };
+    return entry.type === "compaction" && entry.id === entryId;
+  } catch {
+    return false;
+  }
 }
 
 type TranscriptSeqByEntryId = Map<string, number>;
@@ -568,6 +585,10 @@ export function installSessionToolResultGuard(
       message: Extract<AgentMessage, { role: "user" }>,
     ) => void | Promise<void>;
     onMessagePersisted?: (message: AgentMessage) => void | Promise<void>;
+    withCompactionPersistence?: (
+      append: () => string,
+      validateAppend: CompactionAppendValidator,
+    ) => string;
     onAssistantErrorMessagePersisted?: (
       message: Extract<AgentMessage, { role: "assistant" }>,
     ) => void | Promise<void>;
@@ -625,6 +646,15 @@ export function installSessionToolResultGuard(
       }),
     };
   };
+  const originalAppendCompaction = sessionManager.appendCompaction.bind(sessionManager);
+  const guardedAppendCompaction = ((
+    ...args: Parameters<SessionManager["appendCompaction"]>
+  ): string => {
+    const append = () => originalAppendCompaction(...args);
+    return opts?.withCompactionPersistence
+      ? opts.withCompactionPersistence(append, isExpectedCompactionAppend)
+      : append();
+  }) as SessionManager["appendCompaction"];
 
   /**
    * Run the before_message_write hook. Returns the (possibly modified) message,
@@ -821,6 +851,7 @@ export function installSessionToolResultGuard(
 
   // Monkey-patch appendMessage with our guarded version.
   sessionManager.appendMessage = guardedAppend as SessionManager["appendMessage"];
+  sessionManager.appendCompaction = guardedAppendCompaction;
 
   return {
     flushPendingToolResults,


### PR DESCRIPTION
## Summary

- Fixes embedded attempts that falsely report session takeover after OpenClaw-owned auto-compaction writes a `type: "compaction"` session entry while the prompt fence is released.
- Threads compaction persistence through the existing guarded `SessionManager` owned-write callback path, matching the existing message-persisted fence refresh behavior.
- Keeps external raw compaction-looking JSONL edits rejected; this does not broaden the benign rewrite whitelist.
- Reviewers should focus on the ownership boundary in `guardSessionManager` and the session-lock regression coverage.

## Linked context

Closes #90729

Related #88348 and #88653 for prior benign rewrite handling; those do not cover same-file owned compaction appends.

Requested by Josh in this maintainer thread.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: OpenClaw-owned compaction appends no longer trip `EmbeddedAttemptSessionTakeoverError` when the embedded prompt fence is released.
- Real environment tested: Blacksmith Testbox through Crabbox, provider `blacksmith-testbox`.
- Exact steps or command run after this patch: `node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox -- env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed`
- Evidence after fix: Testbox `tbx_01ktcyq66htgrbs2yer89p0s7f`, Actions run `https://github.com/openclaw/openclaw/actions/runs/27043607767`, exit 0.
- Observed result after fix: changed gate selected `core, coreTests`; core typecheck, core test typecheck, lint on changed files, import-cycle guard, and related runtime guards passed.
- What was not tested: no live provider turn was run after the patch; this change is covered by focused session-lock regression tests and remote type/lint/guard proof.
- Proof limitations or environment constraints: direct AWS Crabbox was blocked earlier by coordinator auth, so the broad remote proof used delegated Blacksmith Testbox through the Crabbox wrapper.
- Before evidence: the original issue was reproduced before the patch on Testbox `tbx_01ktcnjft8yk11w7ar9mdnv1yr`, Actions run `https://github.com/openclaw/openclaw/actions/runs/27036822896`, with `EmbeddedAttemptSessionTakeoverError`.

## Tests and validation

- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts -- --reporter=verbose`
- `node scripts/run-vitest.mjs src/agents/session-tool-result-guard.test.ts src/agents/session-tool-result-guard.transcript-events.test.ts -- --reporter=verbose`
- `git diff --check`
- `node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox -- env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

Regression coverage added:
- Owned `SessionManager.appendCompaction(...)` refreshes the prompt fence before post-prompt cleanup reacquires the session lock.
- Unowned external raw `type: "compaction"` JSONL appends still throw `EmbeddedAttemptSessionTakeoverError`.

Failed before fix:
- The RED regression failed with `EmbeddedAttemptSessionTakeoverError` before the compaction persistence hook was wired.
- Autoreview initially found the regression fixture was too weak after a test simplification; the fixture now seeds a persisted assistant entry before compaction and the final autoreview is clean.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Auto-compaction during embedded attempts should no longer produce a false takeover error.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

The session-file ownership boundary while an embedded attempt has released the prompt lock.

How is that risk mitigated?

The hook only marks writes made through the guarded `SessionManager.appendCompaction` path as owned. The negative test proves raw external compaction-looking writes remain takeover errors.

## Current review state

What is the next action?

Review and CI.

What is still waiting on author, maintainer, CI, or external proof?

Waiting on PR CI after creation.

Which bot or reviewer comments were addressed?

Local autoreview P3 finding about a weak compaction persistence fixture was accepted and fixed. Final autoreview reported no accepted/actionable findings.
