### PR TITLE
feat: add plugin sdk deprecation baseline metadata

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-a3ab01b572937539e563aa320ad80135bc701e20fffc43c0351d799590b7a0e0  plugin-sdk-api-baseline.json
-9d49587923f8fc4abb16d981bcab54acbf90a3e74ab05933761049e2da0cffe1  plugin-sdk-api-baseline.jsonl
+6096f614762ff6c19b2046038e3ead87fbc06cf7b316c7e65c7999a802c3626b  plugin-sdk-api-baseline.json
+499718fba8d2a099b9618e47985989dbe09241e6f46a54628539843462932c45  plugin-sdk-api-baseline.jsonl

--- a/src/plugin-sdk/api-baseline.test.ts
+++ b/src/plugin-sdk/api-baseline.test.ts
@@ -2,11 +2,101 @@
  * Tests the plugin SDK public API baseline.
  */
 import path from "node:path";
+import ts from "typescript";
 import { describe, expect, it } from "vitest";
 import {
+  collectPluginSdkApiDeprecatedMembers,
   normalizePluginSdkApiDeclarationText,
   normalizePluginSdkApiSourcePath,
+  readPluginSdkApiExportDeprecation,
+  readPluginSdkApiDeprecationFromNode,
+  readPluginSdkApiModuleDeprecationFromSourceFile,
 } from "./api-baseline.js";
+
+/** Build an in-memory TypeScript program for deprecation metadata tests. */
+function createDeprecationFixtureProgram(): {
+  checker: ts.TypeChecker;
+  currentSourceFile: ts.SourceFile;
+  fixtureSourceFile: ts.SourceFile;
+  program: ts.Program;
+} {
+  const repoRoot = process.cwd();
+  const currentFileName = path.join(repoRoot, "src", "plugin-sdk", "current.ts");
+  const fixtureFileName = path.join(repoRoot, "src", "plugin-sdk", "fixture.ts");
+  const externalFileName = path.join(repoRoot, "node_modules", "external-pkg", "index.d.ts");
+  const files = new Map([
+    [
+      currentFileName,
+      [
+        "import type { ExternalOptions } from 'external-pkg';",
+        "export type CurrentOptions = {",
+        "  /** @deprecated Use target.sessionId. */",
+        "  sessionFile?: string;",
+        "  target?: CurrentTarget;",
+        "};",
+        "export type CurrentTarget = {",
+        "  session?: CurrentSession;",
+        "};",
+        "export type CurrentSession = {",
+        "  /** @deprecated Use target.sessionId. */",
+        "  sessionFile?: string;",
+        "};",
+        "export function defineThing(options: CurrentOptions): void {}",
+        "export function defineExternal(options: ExternalOptions): void {}",
+      ].join("\n"),
+    ],
+    [
+      fixtureFileName,
+      [
+        "/** @deprecated Use CurrentOptions. */",
+        "export type { CurrentOptions as LegacyOptions } from './current.js';",
+        "export { defineThing } from './current.js';",
+      ].join("\n"),
+    ],
+    [
+      externalFileName,
+      [
+        "export interface ExternalOptions {",
+        "  /** @deprecated External package internals are not SDK deprecations. */",
+        "  oldExternalField?: string;",
+        "}",
+      ].join("\n"),
+    ],
+  ]);
+  const options: ts.CompilerOptions = {
+    module: ts.ModuleKind.NodeNext,
+    moduleResolution: ts.ModuleResolutionKind.NodeNext,
+    skipLibCheck: true,
+    target: ts.ScriptTarget.Latest,
+  };
+  const host = ts.createCompilerHost(options);
+  const readFile = host.readFile.bind(host);
+  const fileExists = host.fileExists.bind(host);
+  host.readFile = (fileName) => files.get(path.resolve(fileName)) ?? readFile(fileName);
+  host.fileExists = (fileName) => files.has(path.resolve(fileName)) || fileExists(fileName);
+  host.getSourceFile = (fileName, languageVersion) => {
+    const sourceText = files.get(path.resolve(fileName));
+    if (sourceText !== undefined) {
+      return ts.createSourceFile(fileName, sourceText, languageVersion, true, ts.ScriptKind.TS);
+    }
+    const fallbackText = readFile(fileName);
+    return fallbackText === undefined
+      ? undefined
+      : ts.createSourceFile(fileName, fallbackText, languageVersion, true);
+  };
+  const program = ts.createProgram([fixtureFileName], options, host);
+  const currentSourceFile = program.getSourceFile(currentFileName);
+  const fixtureSourceFile = program.getSourceFile(fixtureFileName);
+  if (!currentSourceFile || !fixtureSourceFile) {
+    throw new Error("Fixture source files were not loaded");
+  }
+  return {
+    checker: program.getTypeChecker(),
+    currentSourceFile,
+    fixtureSourceFile,
+    program,
+  };
+}
 
 describe("Plugin SDK API baseline", () => {
   it("normalizes declaration import paths to repo-relative paths", () => {
@@ -59,5 +149,153 @@ describe("Plugin SDK API baseline", () => {
     const sourcePath = path.join(repoRoot, "src", "plugin-sdk", "core.ts");
 
     expect(normalizePluginSdkApiSourcePath(repoRoot, sourcePath)).toBe("src/plugin-sdk/core.ts");
+  });
+
+  it("extracts deprecated module, export, and nested member metadata", () => {
+    const sourceFile = ts.createSourceFile(
+      path.join(process.cwd(), "src", "plugin-sdk", "fixture.ts"),
+      [
+        "/** @deprecated Compatibility subpath. Use `openclaw/plugin-sdk/current`. */",
+        "export * from './current.js';",
+        "",
+        "/** @deprecated Use NEW_EXPORT. */",
+        "export const OLD_EXPORT = 'old';",
+        "",
+        "export type FixtureOptions = {",
+        "  /** @deprecated Use target.sessionId. */",
+        "  sessionFile?: string;",
+        "  nested?: {",
+        "    /** @deprecated Use sessions. */",
+        "    sessionFiles?: string[];",
+        "  };",
+        "};",
+      ].join("\n"),
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TS,
+    );
+
+    expect(readPluginSdkApiDeprecationFromNode(sourceFile.statements[0])?.message).toBe(
+      "Compatibility subpath. Use `openclaw/plugin-sdk/current`.",
+    );
+    expect(readPluginSdkApiDeprecationFromNode(sourceFile.statements[1])?.message).toBe(
+      "Use NEW_EXPORT.",
+    );
+
+    const importBackedModuleSourceFile = ts.createSourceFile(
+      path.join(process.cwd(), "src", "plugin-sdk", "import-backed-fixture.ts"),
+      [
+        "/**",
+        " * @deprecated Compatibility subpath.",
+        " * Use `openclaw/plugin-sdk/current`.",
+        " */",
+        "import { current } from './current.js';",
+        "export { current };",
+      ].join("\n"),
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TS,
+    );
+    expect(
+      readPluginSdkApiModuleDeprecationFromSourceFile(importBackedModuleSourceFile)?.message,
+    ).toBe("Compatibility subpath. Use `openclaw/plugin-sdk/current`.");
+
+    const optionsDeclaration = sourceFile.statements[2];
+    expect(ts.isTypeAliasDeclaration(optionsDeclaration)).toBe(true);
+    if (!ts.isTypeAliasDeclaration(optionsDeclaration)) {
+      return;
+    }
+
+    expect(
+      collectPluginSdkApiDeprecatedMembers(process.cwd(), optionsDeclaration).map((member) => ({
+        kind: member.kind,
+        name: member.name,
+        message: member.deprecated.message,
+      })),
+    ).toStrictEqual([
+      {
+        kind: "property",
+        name: "sessionFile",
+        message: "Use target.sessionId.",
+      },
+      {
+        kind: "property",
+        name: "nested.sessionFiles",
+        message: "Use sessions.",
+      },
+    ]);
+  });
+
+  it("extracts deprecated alias exports and referenced option types", () => {
+    const { checker, currentSourceFile, fixtureSourceFile } = createDeprecationFixtureProgram();
+    const moduleSymbol = checker.getSymbolAtLocation(fixtureSourceFile);
+    expect(moduleSymbol).toBeDefined();
+    if (!moduleSymbol) {
+      return;
+    }
+
+    const legacySymbol = checker
+      .getExportsOfModule(moduleSymbol)
+      .find((symbol) => symbol.getName() === "LegacyOptions");
+    expect(legacySymbol).toBeDefined();
+    if (!legacySymbol) {
+      return;
+    }
+    const resolvedLegacySymbol = checker.getAliasedSymbol(legacySymbol);
+    const legacyDeclaration = resolvedLegacySymbol.declarations?.[0];
+    expect(legacyDeclaration).toBeDefined();
+    if (!legacyDeclaration) {
+      return;
+    }
+
+    expect(
+      readPluginSdkApiExportDeprecation({
+        declaration: legacyDeclaration,
+        resolvedSymbol: resolvedLegacySymbol,
+        symbol: legacySymbol,
+      })?.message,
+    ).toBe("Use CurrentOptions.");
+
+    const defineThingDeclaration = currentSourceFile.statements.find(
+      (statement): statement is ts.FunctionDeclaration =>
+        ts.isFunctionDeclaration(statement) && statement.name?.text === "defineThing",
+    );
+    expect(defineThingDeclaration).toBeDefined();
+    if (!defineThingDeclaration) {
+      return;
+    }
+
+    expect(
+      collectPluginSdkApiDeprecatedMembers(process.cwd(), defineThingDeclaration, checker).map(
+        (member) => ({
+          kind: member.kind,
+          name: member.name,
+          message: member.deprecated.message,
+        }),
+      ),
+    ).toStrictEqual([
+      {
+        kind: "property",
+        name: "options.sessionFile",
+        message: "Use target.sessionId.",
+      },
+      {
+        kind: "property",
+        name: "options.target.session.sessionFile",
+        message: "Use target.sessionId.",
+      },
+    ]);
+
+    const defineExternalDeclaration = currentSourceFile.statements.find(
+      (statement): statement is ts.FunctionDeclaration =>
+        ts.isFunctionDeclaration(statement) && statement.name?.text === "defineExternal",
+    );
+    expect(defineExternalDeclaration).toBeDefined();
+    if (!defineExternalDeclaration) {
+      return;
+    }
+    expect(
+      collectPluginSdkApiDeprecatedMembers(process.cwd(), defineExternalDeclaration, checker),
+    ).toStrictEqual([]);
   });
 });

--- a/src/plugin-sdk/api-baseline.ts
+++ b/src/plugin-sdk/api-baseline.ts
@@ -32,8 +32,33 @@ export type PluginSdkApiSourceLink = {
   path: string;
 };
 
+/** Parsed @deprecated metadata for a public SDK surface. */
+export type PluginSdkApiDeprecation = {
+  /** Human-readable migration guidance from the @deprecated JSDoc tag. */
+  message: string | null;
+};
+
+/** Kind of nested public declaration member marked deprecated. */
+export type PluginSdkApiDeprecatedMemberKind = "method" | "parameter" | "property";
+
+/** One deprecated nested member from an exported SDK declaration. */
+export type PluginSdkApiDeprecatedMember = {
+  /** Parsed @deprecated JSDoc metadata for the member. */
+  deprecated: PluginSdkApiDeprecation;
+  /** Member kind used by downstream inspection tools. */
+  kind: PluginSdkApiDeprecatedMemberKind;
+  /** Dot-delimited member path relative to the exported declaration. */
+  name: string;
+  /** Repo source for the deprecated member. */
+  source: PluginSdkApiSourceLink;
+};
+
 /** One named export captured from a public SDK entrypoint. */
 export type PluginSdkApiExport = {
+  /** Parsed @deprecated metadata for the exported symbol, when present. */
+  deprecated: PluginSdkApiDeprecation | null;
+  /** Deprecated nested members from the exported declaration. */
+  deprecatedMembers: PluginSdkApiDeprecatedMember[];
   /** Normalized TypeScript declaration text, or null when TypeScript cannot print it. */
   declaration: string | null;
   /** Exported symbol name as plugin authors import it. */
@@ -48,6 +73,8 @@ export type PluginSdkApiExport = {
 export type PluginSdkApiModule = {
   /** Documentation category used to group SDK entrypoints. */
   category: PluginSdkDocCategory;
+  /** Parsed @deprecated metadata for the SDK module/subpath, when present. */
+  deprecated: PluginSdkApiDeprecation | null;
   /** Entry point metadata from the SDK docs registry. */
   entrypoint: PluginSdkDocEntrypoint;
   /** Public exports discovered from the TypeScript program. */
@@ -198,6 +225,415 @@ function buildSourceLink(
     line,
     path: relativePath(repoRoot, filePath),
   };
+}
+
+/** Build repo-relative source evidence for a nested declaration. */
+function buildDeclarationSourceLink(
+  repoRoot: string,
+  declaration: ts.Declaration,
+): PluginSdkApiSourceLink {
+  const sourceFile = declaration.getSourceFile();
+  const line = sourceFile.getLineAndCharacterOfPosition(declaration.getStart(sourceFile)).line + 1;
+  return {
+    line,
+    path: relativePath(repoRoot, sourceFile.fileName),
+  };
+}
+
+/** Normalize JSDoc text for stable machine-readable baseline output. */
+function normalizeJSDocText(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+/** Convert TypeScript symbol-display JSDoc text into baseline text. */
+function normalizeJSDocTagInfoText(text: ts.SymbolDisplayPart[] | undefined): string | null {
+  const message = normalizeJSDocText((text ?? []).map((part) => part.text).join(""));
+  return message.length > 0 ? message : null;
+}
+
+/** Convert AST JSDoc tag comments into baseline text. */
+function normalizeJSDocTagComment(
+  comment: string | ts.NodeArray<ts.JSDocComment> | undefined,
+): string | null {
+  if (typeof comment === "string") {
+    const message = normalizeJSDocText(comment);
+    return message.length > 0 ? message : null;
+  }
+  if (!comment) {
+    return null;
+  }
+  const message = normalizeJSDocText(
+    [...comment]
+      .map((part) => part.getText())
+      .join(" ")
+      .replaceAll(/^\s*\/\*\*?/g, "")
+      .replaceAll(/\*\/\s*$/g, ""),
+  );
+  return message.length > 0 ? message : null;
+}
+
+/** Convert a leading JSDoc block into baseline deprecation metadata. */
+function deprecationFromJSDocCommentText(commentText: string): PluginSdkApiDeprecation | null {
+  const lines = commentText
+    .replace(/^\/\*\*?/, "")
+    .replace(/\*\/$/, "")
+    .split(/\r?\n/)
+    .map((line) => line.replace(/^\s*\*\s?/, "").trim());
+  const deprecatedLineIndex = lines.findIndex((line) => line.startsWith("@deprecated"));
+  if (deprecatedLineIndex < 0) {
+    return null;
+  }
+  const messageParts = [lines[deprecatedLineIndex]?.replace(/^@deprecated\b\s*/, "") ?? ""];
+  for (const line of lines.slice(deprecatedLineIndex + 1)) {
+    if (line.startsWith("@")) {
+      break;
+    }
+    messageParts.push(line);
+  }
+  const message = normalizeJSDocText(messageParts.join(" "));
+  return { message: message.length > 0 ? message : null };
+}
+
+/** Convert one TypeScript @deprecated symbol tag into baseline metadata. */
+function deprecationFromJSDocTagInfo(
+  tag: ts.JSDocTagInfo | undefined,
+): PluginSdkApiDeprecation | null {
+  if (!tag || tag.name !== "deprecated") {
+    return null;
+  }
+  return { message: normalizeJSDocTagInfoText(tag.text) };
+}
+
+/** Read a file-leading @deprecated JSDoc block used for SDK subpath modules. */
+function readPluginSdkApiLeadingCommentDeprecation(
+  sourceFile: ts.SourceFile,
+): PluginSdkApiDeprecation | null {
+  const ranges = ts.getLeadingCommentRanges(sourceFile.text, 0) ?? [];
+  for (const range of ranges) {
+    if (range.kind !== ts.SyntaxKind.MultiLineCommentTrivia) {
+      continue;
+    }
+    const deprecation = deprecationFromJSDocCommentText(
+      sourceFile.text.slice(range.pos, range.end),
+    );
+    if (deprecation) {
+      return deprecation;
+    }
+  }
+  return null;
+}
+
+/** Read parsed @deprecated metadata from a TypeScript AST node. */
+export function readPluginSdkApiDeprecationFromNode(node: ts.Node): PluginSdkApiDeprecation | null {
+  const tag = ts.getJSDocTags(node).find((candidate) => candidate.tagName.text === "deprecated");
+  if (!tag) {
+    return null;
+  }
+  return { message: normalizeJSDocTagComment(tag.comment) };
+}
+
+/** Read module/subpath-level @deprecated metadata from a public SDK source file. */
+export function readPluginSdkApiModuleDeprecationFromSourceFile(
+  sourceFile: ts.SourceFile,
+): PluginSdkApiDeprecation | null {
+  const fileLeadingDeprecation = readPluginSdkApiLeadingCommentDeprecation(sourceFile);
+  if (fileLeadingDeprecation) {
+    return fileLeadingDeprecation;
+  }
+  const firstStatement = sourceFile.statements[0];
+  if (!firstStatement || !ts.isExportDeclaration(firstStatement) || firstStatement.exportClause) {
+    return null;
+  }
+  return readPluginSdkApiDeprecationFromNode(firstStatement);
+}
+
+/** Read parsed @deprecated metadata from a TypeScript symbol. */
+function readPluginSdkApiDeprecationFromSymbol(symbol: ts.Symbol): PluginSdkApiDeprecation | null {
+  return (
+    symbol
+      .getJsDocTags()
+      .map(deprecationFromJSDocTagInfo)
+      .find((deprecation): deprecation is PluginSdkApiDeprecation => deprecation !== null) ?? null
+  );
+}
+
+/** Read @deprecated metadata from export-specifier declarations and their parent export. */
+function readPluginSdkApiDeprecationFromExportDeclarations(
+  symbol: ts.Symbol,
+): PluginSdkApiDeprecation | null {
+  for (const declaration of symbol.declarations ?? []) {
+    const deprecated = readPluginSdkApiDeprecationFromNode(declaration);
+    if (deprecated) {
+      return deprecated;
+    }
+    if (ts.isExportSpecifier(declaration)) {
+      const exportDeclaration = declaration.parent.parent;
+      const exportDeprecated = readPluginSdkApiDeprecationFromNode(exportDeclaration);
+      if (exportDeprecated) {
+        return exportDeprecated;
+      }
+    }
+  }
+  return null;
+}
+
+/** Read export-level @deprecated metadata without losing alias re-export comments. */
+export function readPluginSdkApiExportDeprecation(params: {
+  declaration: ts.Declaration | undefined;
+  resolvedSymbol: ts.Symbol;
+  symbol: ts.Symbol;
+}): PluginSdkApiDeprecation | null {
+  const { declaration, resolvedSymbol, symbol } = params;
+  return (
+    readPluginSdkApiDeprecationFromSymbol(symbol) ??
+    readPluginSdkApiDeprecationFromExportDeclarations(symbol) ??
+    readPluginSdkApiDeprecationFromSymbol(resolvedSymbol) ??
+    (declaration ? readPluginSdkApiDeprecationFromNode(declaration) : null)
+  );
+}
+
+/** Read a simple identifier declaration name from a member-like AST node. */
+function declarationName(node: ts.Node): string | null {
+  const named = node as { name?: ts.Node };
+  if (!named.name || !ts.isIdentifier(named.name)) {
+    return null;
+  }
+  return named.name.text;
+}
+
+/** Classify the deprecated member kind for downstream inspectors. */
+function deprecatedMemberKind(node: ts.Node): PluginSdkApiDeprecatedMemberKind | null {
+  if (ts.isMethodSignature(node) || ts.isMethodDeclaration(node)) {
+    return "method";
+  }
+  if (ts.isParameter(node)) {
+    return "parameter";
+  }
+  if (ts.isPropertySignature(node) || ts.isPropertyDeclaration(node)) {
+    return "property";
+  }
+  return null;
+}
+
+/** Recurse into type-literal declarations to find deprecated nested members. */
+function collectTypeDeprecatedMembers(params: {
+  activeTypes: Set<string>;
+  checker?: ts.TypeChecker;
+  members: PluginSdkApiDeprecatedMember[];
+  node: ts.TypeNode | undefined;
+  pathPrefix: string[];
+  repoRoot: string;
+}): void {
+  const { activeTypes, checker, members, node, pathPrefix, repoRoot } = params;
+  if (!node) {
+    return;
+  }
+  if (ts.isTypeLiteralNode(node)) {
+    collectNodeMembers({
+      activeTypes,
+      checker,
+      members,
+      nodes: node.members,
+      pathPrefix,
+      repoRoot,
+    });
+    return;
+  }
+  if (ts.isIntersectionTypeNode(node)) {
+    for (const intersectionType of node.types) {
+      collectTypeDeprecatedMembers({
+        checker,
+        members,
+        node: intersectionType,
+        pathPrefix,
+        repoRoot,
+        activeTypes,
+      });
+    }
+    return;
+  }
+  if (checker && ts.isTypeReferenceNode(node)) {
+    collectReferencedTypeDeprecatedMembers({
+      activeTypes,
+      checker,
+      members,
+      node,
+      pathPrefix,
+      repoRoot,
+    });
+  }
+}
+
+/** Return true when a declaration belongs to this repository rather than dependencies. */
+function isRepoOwnedDeclaration(repoRoot: string, declaration: ts.Declaration): boolean {
+  const sourcePath = relativePath(repoRoot, declaration.getSourceFile().fileName);
+  return !sourcePath.startsWith("..") && !sourcePath.startsWith("node_modules/");
+}
+
+/** Resolve referenced type aliases/interfaces before collecting deprecated members. */
+function collectReferencedTypeDeprecatedMembers(params: {
+  activeTypes: Set<string>;
+  checker: ts.TypeChecker;
+  members: PluginSdkApiDeprecatedMember[];
+  node: ts.TypeReferenceNode;
+  pathPrefix: string[];
+  repoRoot: string;
+}): void {
+  const { activeTypes, checker, members, node, pathPrefix, repoRoot } = params;
+  const type = checker.getTypeAtLocation(node);
+  const symbol = type.aliasSymbol ?? type.getSymbol() ?? checker.getSymbolAtLocation(node.typeName);
+  const declarations = [...(symbol?.declarations ?? [])].sort((left, right) =>
+    compareDeclarations(repoRoot, left, right),
+  );
+
+  for (const declaration of declarations) {
+    if (!isRepoOwnedDeclaration(repoRoot, declaration)) {
+      continue;
+    }
+    const visitKey = [declaration.getSourceFile().fileName, declaration.pos, declaration.end].join(
+      ":",
+    );
+    if (activeTypes.has(visitKey)) {
+      continue;
+    }
+    activeTypes.add(visitKey);
+
+    if (ts.isTypeAliasDeclaration(declaration)) {
+      collectTypeDeprecatedMembers({
+        activeTypes,
+        checker,
+        members,
+        node: declaration.type,
+        pathPrefix,
+        repoRoot,
+      });
+    }
+    if (ts.isInterfaceDeclaration(declaration) || ts.isClassDeclaration(declaration)) {
+      collectNodeMembers({
+        activeTypes,
+        checker,
+        members,
+        nodes: declaration.members,
+        pathPrefix,
+        repoRoot,
+      });
+    }
+    activeTypes.delete(visitKey);
+  }
+}
+
+/** Walk member-like AST nodes and collect deprecated declarations. */
+function collectNodeMembers(params: {
+  activeTypes: Set<string>;
+  checker?: ts.TypeChecker;
+  members: PluginSdkApiDeprecatedMember[];
+  nodes: readonly ts.Node[];
+  pathPrefix: string[];
+  repoRoot: string;
+}): void {
+  const { activeTypes, checker, members, nodes, pathPrefix, repoRoot } = params;
+  for (const node of nodes) {
+    const name = declarationName(node);
+    const memberPath = name ? [...pathPrefix, name] : pathPrefix;
+    const deprecated = readPluginSdkApiDeprecationFromNode(node);
+    const kind = deprecatedMemberKind(node);
+
+    // Record direct member deprecations before recursing so output follows source order.
+    if (name && deprecated && kind) {
+      members.push({
+        deprecated,
+        kind,
+        name: memberPath.join("."),
+        source: buildDeclarationSourceLink(repoRoot, node as ts.Declaration),
+      });
+    }
+
+    // Object-shaped properties can contain nested deprecated payload fields.
+    if (ts.isPropertySignature(node) || ts.isPropertyDeclaration(node)) {
+      collectTypeDeprecatedMembers({
+        activeTypes,
+        checker,
+        members,
+        node: node.type,
+        pathPrefix: memberPath,
+        repoRoot,
+      });
+    }
+
+    // Function-like members can deprecate individual parameters.
+    if (
+      ts.isMethodSignature(node) ||
+      ts.isMethodDeclaration(node) ||
+      ts.isFunctionDeclaration(node)
+    ) {
+      collectNodeMembers({
+        activeTypes,
+        checker,
+        members,
+        nodes: node.parameters,
+        pathPrefix: memberPath,
+        repoRoot,
+      });
+    }
+
+    // Object-literal parameters can contain nested deprecated option keys.
+    if (ts.isParameter(node)) {
+      collectTypeDeprecatedMembers({
+        activeTypes,
+        checker,
+        members,
+        node: node.type,
+        pathPrefix: memberPath,
+        repoRoot,
+      });
+    }
+  }
+}
+
+/** Collect deprecated nested public members from one exported SDK declaration. */
+export function collectPluginSdkApiDeprecatedMembers(
+  repoRoot: string,
+  declaration: ts.Declaration,
+  checker?: ts.TypeChecker,
+): PluginSdkApiDeprecatedMember[] {
+  const members: PluginSdkApiDeprecatedMember[] = [];
+  const activeTypes = new Set<string>();
+  if (ts.isInterfaceDeclaration(declaration) || ts.isClassDeclaration(declaration)) {
+    collectNodeMembers({
+      activeTypes,
+      checker,
+      members,
+      nodes: declaration.members,
+      pathPrefix: [],
+      repoRoot,
+    });
+  }
+  if (ts.isTypeAliasDeclaration(declaration)) {
+    collectTypeDeprecatedMembers({
+      activeTypes,
+      checker,
+      members,
+      node: declaration.type,
+      pathPrefix: [],
+      repoRoot,
+    });
+  }
+  if (ts.isFunctionDeclaration(declaration)) {
+    collectNodeMembers({
+      activeTypes,
+      checker,
+      members,
+      nodes: declaration.parameters,
+      pathPrefix: [],
+      repoRoot,
+    });
+  }
+  return members.sort(
+    (left, right) =>
+      compareText(left.source.path, right.source.path) ||
+      left.source.line - right.source.line ||
+      compareText(left.name, right.name),
+  );
 }
 
 function inferExportKind(
@@ -396,7 +832,12 @@ function buildExportSurface(params: {
 }): PluginSdkApiExport {
   const { checker, printer, program, repoRoot, symbol } = params;
   const { declaration, resolvedSymbol } = resolveSymbolAndDeclaration(checker, repoRoot, symbol);
+  const deprecated = readPluginSdkApiExportDeprecation({ declaration, resolvedSymbol, symbol });
   return {
+    deprecated,
+    deprecatedMembers: declaration
+      ? collectPluginSdkApiDeprecatedMembers(repoRoot, declaration, checker)
+      : [],
     declaration: declaration ? printNode(repoRoot, checker, printer, declaration) : null,
     exportName: symbol.getName(),
     kind: inferExportKind(resolvedSymbol, declaration),
@@ -464,6 +905,7 @@ function buildModuleSurface(params: {
 
   return {
     category: metadata.category,
+    deprecated: readPluginSdkApiModuleDeprecationFromSourceFile(sourceFile),
     entrypoint,
     exports,
     importSpecifier,
@@ -478,6 +920,7 @@ function buildJsonlLines(baseline: PluginSdkApiBaseline): string[] {
     lines.push(
       JSON.stringify({
         category: moduleSurface.category,
+        deprecated: moduleSurface.deprecated,
         entrypoint: moduleSurface.entrypoint,
         importSpecifier: moduleSurface.importSpecifier,
         recordType: "module",
@@ -489,6 +932,8 @@ function buildJsonlLines(baseline: PluginSdkApiBaseline): string[] {
     for (const exportSurface of moduleSurface.exports) {
       lines.push(
         JSON.stringify({
+          deprecated: exportSurface.deprecated,
+          deprecatedMembers: exportSurface.deprecatedMembers,
           declaration: exportSurface.declaration,
           entrypoint: moduleSurface.entrypoint,
           exportName: exportSurface.exportName,


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- Adds machine-readable deprecation metadata to the generated Plugin SDK API baseline.
- Captures deprecated SDK modules/subpaths, named exports, alias re-exports, and nested public members from existing `@deprecated` JSDoc.
- Keeps the change support-only: it does not add SQLite migration deprecations or change runtime behavior.

Why does this matter now?

- Plugin-inspector needs a source-driven way to report SDK deprecations instead of hardcoding migration-specific rules.
- OpenClaw already has many `@deprecated` comments in SDK-facing surfaces; this makes that existing source metadata available to downstream tools.

What is the intended outcome?

- Generated baseline JSON/JSONL includes `deprecated` and `deprecatedMembers` fields.
- SDK API hash checks detect deprecation metadata drift.
- Downstream tooling can consume OpenClaw-owned deprecation guidance from the SDK baseline.

What is intentionally out of scope?

- Adding SQLite/session/transcript migration deprecation comments.
- Emitting plugin-inspector warnings.
- Runtime behavior, SDK type shape, or public import changes.

What does success look like?

- Existing SDK `@deprecated` comments appear in generated baseline output.
- Dependency-owned deprecated members are excluded from nested SDK metadata.
- Baseline hash check remains deterministic.

What should reviewers focus on?

- Whether the metadata extraction captures useful public SDK surfaces without overreporting dependency internals.
- Whether adding fields to generated baseline records is acceptable for downstream consumers.
- Whether the tests cover alias re-exports and referenced option/member types sufficiently.

## Linked context

Which issue does this close?

Closes N/A

Which issues, PRs, or discussions are related?

Related: plugin-inspector SDK deprecation warning support work.

Was this requested by a maintainer or owner?

Requested by Josh during plugin-inspector SDK deprecation support planning.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Plugin SDK API baseline now exposes real `@deprecated` metadata from existing OpenClaw SDK sources.
- Real environment tested: Local OpenClaw checkout on branch `josh/plugin-sdk-deprecation-baseline-metadata` at `c6c90e7ab458ccfd62d7e6ca7339c04beb1f2e01`.
- Exact steps or command run after this patch:
  - `node scripts/run-vitest.mjs src/plugin-sdk/api-baseline.test.ts`
  - `pnpm plugin-sdk:api:check`
  - JSONL inspection script reading `docs/.generated/plugin-sdk-api-baseline.jsonl`
- Evidence after fix:
  - Focused tests: `Test Files 1 passed (1)`, `Tests 5 passed (5)`.
  - Baseline check: `OK docs/.generated/plugin-sdk-api-baseline.sha256`.
  - JSONL output showed:
    - deprecated module: `openclaw/plugin-sdk/agent-runtime`
    - deprecated alias export: `ClawdbotConfig` with `Use OpenClawConfig instead`
    - deprecated option member: `definePluginEntry.kind` from `src/plugin-sdk/plugin-entry.ts`
    - dependency deprecated member noise count: `0`
    - SQLite `sessionFile/sessionFiles` deprecation comment matches: `0`
- Observed result after fix: Existing SDK deprecation comments are now visible in generated baseline records while SQLite-specific migration deprecations remain absent.
- What was not tested: Full `npm test`; plugin-inspector consumption; runtime OpenClaw app behavior.
- Proof limitations or environment constraints: This PR changes generator/baseline metadata only, so the relevant real behavior is generated API baseline output rather than an end-user runtime flow.
- Before evidence: Baseline records did not include structured `deprecated` or `deprecatedMembers` metadata.

## Tests and validation

Which commands did you run?

- `node scripts/run-vitest.mjs src/plugin-sdk/api-baseline.test.ts`
- `pnpm plugin-sdk:api:check`
- `git diff --check`
- `/Users/phaedrus/Projects/prompts/skills/autoreview/scripts/autoreview --mode branch --base main --parallel-tests "node scripts/run-vitest.mjs src/plugin-sdk/api-baseline.test.ts"`

What regression coverage was added or updated?

- Added focused API baseline tests for:
  - module-level `@deprecated` comments
  - export-level `@deprecated` comments
  - alias re-export deprecations
  - nested deprecated members in public object types
  - referenced option/member types
  - excluding deprecated members from dependency-owned declarations

What failed before this fix, if known?

- The generated baseline had no structured deprecation metadata, so downstream tools could not source deprecation warnings from OpenClaw SDK JSDoc.

If no test was added, why not?

- Tests were added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

No.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

- Generated baseline schema expansion and potential downstream tooling noise if consumers treat every metadata occurrence as a direct usage warning.

How is that risk mitigated?

- The PR only changes generated metadata, not runtime behavior.
- Tests cover dependency exclusion and alias/reference cases.
- Downstream plugin-inspector work should dedupe and match actual usage before warning.

## Current review state

What is the next action?

- Maintainer review.

What is still waiting on author, maintainer, CI, or external proof?

- Waiting on CI and maintainer feedback.

Which bot or reviewer comments were addressed?

- Pre-PR autoreview completed cleanly with no accepted/actionable findings.
