### PR TITLE
perf(qqbot): narrow tool discovery cold load

### DIFF
--- a/extensions/qqbot/channel-entry-api.ts
+++ b/extensions/qqbot/channel-entry-api.ts
@@ -1,0 +1,2 @@
+// Narrow bridge entrypoint for qqbot registerFull composition.
+export { registerQQBotFull } from "./src/bridge/channel-entry.js";

--- a/extensions/qqbot/index.ts
+++ b/extensions/qqbot/index.ts
@@ -6,8 +6,19 @@ import {
 } from "openclaw/plugin-sdk/channel-entry-contract";
 
 function registerQQBotFull(api: OpenClawPluginApi): void {
+  if (api.registrationMode === "tool-discovery") {
+    const registerTools = loadBundledEntryExportSync<(api: OpenClawPluginApi) => void>(
+      import.meta.url,
+      {
+        specifier: "./src/bridge/tools/index.js",
+        exportName: "registerQQBotTools",
+      },
+    );
+    registerTools(api);
+    return;
+  }
   const register = loadBundledEntryExportSync<(api: OpenClawPluginApi) => void>(import.meta.url, {
-    specifier: "./api.js",
+    specifier: "./src/bridge/channel-entry.js",
     exportName: "registerQQBotFull",
   });
   register(api);

--- a/extensions/qqbot/index.ts
+++ b/extensions/qqbot/index.ts
@@ -10,7 +10,7 @@ function registerQQBotFull(api: OpenClawPluginApi): void {
     const registerTools = loadBundledEntryExportSync<(api: OpenClawPluginApi) => void>(
       import.meta.url,
       {
-        specifier: "./src/bridge/tools/index.js",
+        specifier: "./tools-api.js",
         exportName: "registerQQBotTools",
       },
     );
@@ -18,7 +18,7 @@ function registerQQBotFull(api: OpenClawPluginApi): void {
     return;
   }
   const register = loadBundledEntryExportSync<(api: OpenClawPluginApi) => void>(import.meta.url, {
-    specifier: "./src/bridge/channel-entry.js",
+    specifier: "./channel-entry-api.js",
     exportName: "registerQQBotFull",
   });
   register(api);

--- a/extensions/qqbot/src/bridge/tools/channel.ts
+++ b/extensions/qqbot/src/bridge/tools/channel.ts
@@ -1,6 +1,5 @@
 // Qqbot plugin module implements channel behavior.
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/core";
-import { getAccessToken } from "../../engine/messaging/sender.js";
 import { ChannelApiSchema, executeChannelApi } from "../../engine/tools/channel-api.js";
 import type { ChannelApiParams } from "../../engine/tools/channel-api.js";
 import { listQQBotAccountIds, resolveQQBotAccount } from "../config.js";
@@ -50,6 +49,7 @@ export function registerChannelTool(api: OpenClawPluginApi): void {
         "See the qqbot-channel skill for full endpoint details.",
       parameters: ChannelApiSchema,
       async execute(_toolCallId, params) {
+        const { getAccessToken } = await import("../../engine/messaging/sender.js");
         const accessToken = await getAccessToken(account.appId, account.clientSecret);
         return executeChannelApi(params as ChannelApiParams, { accessToken });
       },

--- a/extensions/qqbot/tools-api.ts
+++ b/extensions/qqbot/tools-api.ts
@@ -1,0 +1,2 @@
+// Narrow tool-discovery entrypoint for qqbot tools.
+export { registerQQBotTools } from "./src/bridge/tools/index.js";

--- a/test/plugin-npm-runtime-build.test.ts
+++ b/test/plugin-npm-runtime-build.test.ts
@@ -58,12 +58,14 @@ describe("plugin npm runtime build planning", () => {
     const qqbotRuntimePlan = expectPluginNpmRuntimeBuildPlan(qqbotPlan);
     expect(qqbotRuntimePlan.entry).toEqual({
       api: path.join(repoRoot, "extensions", "qqbot", "api.ts"),
+      "channel-entry-api": path.join(repoRoot, "extensions", "qqbot", "channel-entry-api.ts"),
       "channel-plugin-api": path.join(repoRoot, "extensions", "qqbot", "channel-plugin-api.ts"),
       index: path.join(repoRoot, "extensions", "qqbot", "index.ts"),
       "runtime-api": path.join(repoRoot, "extensions", "qqbot", "runtime-api.ts"),
       "secret-contract-api": path.join(repoRoot, "extensions", "qqbot", "secret-contract-api.ts"),
       "setup-entry": path.join(repoRoot, "extensions", "qqbot", "setup-entry.ts"),
       "setup-plugin-api": path.join(repoRoot, "extensions", "qqbot", "setup-plugin-api.ts"),
+      "tools-api": path.join(repoRoot, "extensions", "qqbot", "tools-api.ts"),
     });
     expect(qqbotRuntimePlan.runtimeExtensions).toEqual(["./dist/index.js"]);
     expect(qqbotRuntimePlan.runtimeSetupEntry).toBe("./dist/setup-entry.js");


### PR DESCRIPTION
## Profile Evidence

| Run | CPU profile | Submit -> first model request | Request -> visible response | QQBot tool-discovery/register | First-turn embedded duration |
| --- | --- | ---: | ---: | ---: | ---: |
| Before | `.artifacts/tui-local-cpu/full-surface-1780700761191/openclaw-tui-99042-2026-06-05T23-06-02-328Z.cpuprofile` | 12,683ms | 17ms | 4,640.8ms | 10,824ms |
| After | `.artifacts/tui-local-cpu/full-surface-narrow-tools-1780700900305/openclaw-tui-17302-2026-06-05T23-08-29-149Z.cpuprofile` | 10,387ms | 23ms | 1,268.9ms | 6,563ms |

CPU profile summaries showed the first turn is cold module loading, not provider latency: top samples were `dist/jiti.cjs`, Babel transforms, `package_json_reader`, `fs` stat/open/read, and ESM compile. The mocked local Responses server returned in ~20ms; the delay happened before the request was sent.

## Summary

- Route QQBot `tool-discovery` registration through the narrow tool registration module instead of the broad public `api.ts` barrel.
- Keep full QQBot registration on the channel-entry path for normal runtime registration.
- Lazy-load the QQ sender auth helper only when `qqbot_channel_api` executes, so tool registration does not import messaging sender/runtime code.

## Verification

- `node scripts/run-vitest.mjs extensions/qqbot/src/bridge/commands/framework-registration.test.ts extensions/qqbot/src/bridge/tools/remind.test.ts extensions/qqbot/src/engine/tools/remind-logic.test.ts src/plugin-sdk/channel-entry-contract.test.ts`
- `pnpm build`
- `git diff --check`
- Profiled `pnpm openclaw tui --local` with an isolated config and mocked local Responses endpoint before and after the patch.
