### PR TITLE
[pho-8679] Ignore Artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,9 @@ USER.md
 *.tgz
 *.tar.gz
 *.zip
+*.toon
+*.wav
+*.xlsx
 .idea
 .vscode/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 - UI/mobile: add Workboard keyboard movement controls, tighten Workboard card operations, improve Android companion-first shell UX, and document chat ACK timing metadata. (#89802) Thanks @vincentkoc.
 - Release metadata: align the root package, publishable plugin manifests, generated shrinkwraps, appcast, iOS, Android, macOS, Matrix plugin changelog, and docs/generated baselines with the 2026.6.2 beta train.
 - Release/packaging: promote Windows node installer publishing, require verified Windows release asset links, and document GitHub release-note edits.
+- Git: ignore local `.toon`, `.wav`, and `.xlsx` artifacts.
 - Docs: refresh Windows Hub setup guidance and document Gateway, CLI, and plugin SDK helper contracts.
 
 ### Fixes


### PR DESCRIPTION
## Summary
- Ignore local `.toon`, `.wav`, and `.xlsx` artifact files in the root `.gitignore`.
- Add an active-version changelog note for the ignore-rule update.

## Verification
- `git diff --check`
- `git check-ignore -v sample.toon sample.wav sample.xlsx`

## Real behavior proof
Behavior addressed: Local `.toon`, `.wav`, and `.xlsx` artifacts no longer appear as untracked files.
Real environment tested: Local OpenClaw checkout on branch `openclaw/pho-8679-ignore-artifacts`.
Exact steps or command run after this patch: `git check-ignore -v sample.toon sample.wav sample.xlsx`
Evidence after fix: `.gitignore` matched all three sample paths at lines 108-110.
Observed result after fix: Git reports `sample.toon`, `sample.wav`, and `sample.xlsx` as ignored.
What was not tested: Runtime tests were not run because this only changes Git ignore rules and the changelog.
