### PR TITLE
Fix OpenAI audio auth to use API keys

### DIFF
--- a/src/media-understanding/openai-audio-api.ts
+++ b/src/media-understanding/openai-audio-api.ts
@@ -1,0 +1,2 @@
+// Shared API contract id for OpenAI-compatible /audio/transcriptions requests.
+export const OPENAI_AUDIO_TRANSCRIPTIONS_API = "openai-audio-transcriptions";

--- a/src/media-understanding/openai-audio-api.ts
+++ b/src/media-understanding/openai-audio-api.ts
@@ -1,2 +1,14 @@
+import type { MediaUnderstandingCapability } from "./types.js";
+
 // Shared API contract id for OpenAI-compatible /audio/transcriptions requests.
 export const OPENAI_AUDIO_TRANSCRIPTIONS_API = "openai-audio-transcriptions";
+
+export function resolveOpenAiAudioAuthModelApi(params: {
+  capability: MediaUnderstandingCapability;
+  providerId: string;
+}): string | undefined {
+  if (params.capability === "audio" && params.providerId.trim().toLowerCase() === "openai") {
+    return OPENAI_AUDIO_TRANSCRIPTIONS_API;
+  }
+  return undefined;
+}

--- a/src/media-understanding/openai-compatible-audio.ts
+++ b/src/media-understanding/openai-compatible-audio.ts
@@ -1,3 +1,4 @@
+import { OPENAI_AUDIO_TRANSCRIPTIONS_API } from "./openai-audio-api.js";
 // OpenAI-compatible audio transcription adapter for providers exposing the
 // /audio/transcriptions API shape.
 import {
@@ -43,7 +44,7 @@ export async function transcribeOpenAiCompatibleAudio(
       request: params.request,
       defaultHeaders,
       provider: params.provider,
-      api: "openai-audio-transcriptions",
+      api: OPENAI_AUDIO_TRANSCRIPTIONS_API,
       capability: "audio",
       transport: "media-understanding",
     });

--- a/src/media-understanding/runner.auto-audio.test.ts
+++ b/src/media-understanding/runner.auto-audio.test.ts
@@ -107,6 +107,96 @@ describe("runCapability auto audio entries", () => {
     expect(result.decision.outcome).toBe("success");
   });
 
+  it("skips OpenAI audio auto-selection when only ChatGPT OAuth is available", async () => {
+    const modelAuth = await import("../agents/model-auth.js");
+    const hasAvailableAuthForProvider = vi.mocked(modelAuth.hasAvailableAuthForProvider);
+    const resolveApiKeyForProvider = vi.mocked(modelAuth.resolveApiKeyForProvider);
+    hasAvailableAuthForProvider.mockImplementation(async (params) => {
+      if (params.provider === "openai") {
+        return params.modelApi === undefined;
+      }
+      return params.provider === "mistral";
+    });
+    resolveApiKeyForProvider.mockImplementation(async (params) => ({
+      apiKey: `${params.provider}-key`,
+      source: "test",
+      mode: "api-key",
+    }));
+
+    try {
+      await withAudioFixture("openclaw-auto-audio-oauth-skip", async ({ ctx, media, cache }) => {
+        const openAiTranscribe = vi.fn(async (req: AudioTranscriptionRequest) => ({
+          text: "openai",
+          model: req.model ?? "unknown",
+        }));
+        const mistralTranscribe = vi.fn(async (req: AudioTranscriptionRequest) => ({
+          text: `mistral:${req.apiKey}`,
+          model: req.model ?? "unknown",
+        }));
+
+        const result = await runCapability({
+          capability: "audio",
+          cfg: {
+            models: {
+              providers: {
+                openai: {
+                  models: [],
+                },
+                mistral: {
+                  models: [],
+                },
+              },
+            },
+          } as unknown as OpenClawConfig,
+          ctx,
+          attachments: cache,
+          media,
+          providerRegistry: createProviderRegistry({
+            openai: {
+              id: "openai",
+              capabilities: ["audio"],
+              defaultModels: { audio: "gpt-4o-transcribe" },
+              transcribeAudio: openAiTranscribe,
+            },
+            mistral: {
+              id: "mistral",
+              capabilities: ["audio"],
+              defaultModels: { audio: "voxtral-mini-latest" },
+              transcribeAudio: mistralTranscribe,
+            },
+          }),
+        });
+
+        expect(result.decision.outcome).toBe("success");
+        expect(requireCapabilityOutput(result, 0)).toEqual({
+          kind: "audio.transcription",
+          attachmentIndex: 0,
+          provider: "mistral",
+          model: "voxtral-mini-latest",
+          text: "mistral:mistral-key",
+        });
+        expect(openAiTranscribe).not.toHaveBeenCalled();
+        expect(mistralTranscribe).toHaveBeenCalledTimes(1);
+      });
+
+      expect(hasAvailableAuthForProvider).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: "openai",
+          modelApi: "openai-audio-transcriptions",
+        }),
+      );
+    } finally {
+      hasAvailableAuthForProvider.mockReset();
+      hasAvailableAuthForProvider.mockResolvedValue(true);
+      resolveApiKeyForProvider.mockReset();
+      resolveApiKeyForProvider.mockResolvedValue({
+        apiKey: "test-key",
+        source: "test",
+        mode: "api-key",
+      });
+    }
+  });
+
   it("passes workspaceDir to auto-selected audio provider execution auth", async () => {
     const modelAuth = await import("../agents/model-auth.js");
     const resolveApiKeyForProvider = vi.mocked(modelAuth.resolveApiKeyForProvider);

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -41,6 +41,7 @@ import { MediaUnderstandingSkipError } from "./errors.js";
 import { fileExists } from "./fs.js";
 import { normalizeImageDescriptionInput } from "./image-input-normalize.js";
 import { describeImageWithModel } from "./image-runtime.js";
+import { OPENAI_AUDIO_TRANSCRIPTIONS_API } from "./openai-audio-api.js";
 import { extractGeminiResponse } from "./output-extract.js";
 import { normalizeMediaExecutionProviderId } from "./provider-id.js";
 import { getMediaUnderstandingProvider, normalizeMediaProviderId } from "./provider-registry.js";
@@ -444,17 +445,14 @@ type ProviderExecutionAuth =
       providerConfig?: ModelProviderConfig;
     };
 
-const OPENAI_AUDIO_TRANSCRIPTIONS_API = "openai-audio-transcriptions";
-
 function resolveProviderExecutionAuthModelApi(params: {
   capability: MediaUnderstandingCapability;
   providerId: string;
-  providerConfig?: ModelProviderConfig;
 }): string | undefined {
   if (params.capability === "audio" && params.providerId === "openai") {
     return OPENAI_AUDIO_TRANSCRIPTIONS_API;
   }
-  return typeof params.providerConfig?.api === "string" ? params.providerConfig.api : undefined;
+  return undefined;
 }
 
 async function resolveProviderExecutionAuth(params: {
@@ -470,7 +468,6 @@ async function resolveProviderExecutionAuth(params: {
   const modelApi = resolveProviderExecutionAuthModelApi({
     capability: params.capability,
     providerId: params.providerId,
-    providerConfig,
   });
   const literalApiKey = resolveLiteralProviderApiKey({
     cfg: params.cfg,

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -444,7 +444,21 @@ type ProviderExecutionAuth =
       providerConfig?: ModelProviderConfig;
     };
 
+const OPENAI_AUDIO_TRANSCRIPTIONS_API = "openai-audio-transcriptions";
+
+function resolveProviderExecutionAuthModelApi(params: {
+  capability: MediaUnderstandingCapability;
+  providerId: string;
+  providerConfig?: ModelProviderConfig;
+}): string | undefined {
+  if (params.capability === "audio" && params.providerId === "openai") {
+    return OPENAI_AUDIO_TRANSCRIPTIONS_API;
+  }
+  return typeof params.providerConfig?.api === "string" ? params.providerConfig.api : undefined;
+}
+
 async function resolveProviderExecutionAuth(params: {
+  capability: MediaUnderstandingCapability;
   providerId: string;
   provider?: MediaUnderstandingProvider;
   cfg: OpenClawConfig;
@@ -453,6 +467,11 @@ async function resolveProviderExecutionAuth(params: {
   workspaceDir?: string;
 }): Promise<ProviderExecutionAuth> {
   const providerConfig = params.cfg.models?.providers?.[params.providerId];
+  const modelApi = resolveProviderExecutionAuthModelApi({
+    capability: params.capability,
+    providerId: params.providerId,
+    providerConfig,
+  });
   const literalApiKey = resolveLiteralProviderApiKey({
     cfg: params.cfg,
     providerId: params.providerId,
@@ -521,6 +540,7 @@ async function resolveProviderExecutionAuth(params: {
       preferredProfile: params.entry.preferredProfile,
       agentDir: params.agentDir,
       workspaceDir: params.workspaceDir,
+      modelApi,
     });
     const apiKey = requireApiKey(auth, params.providerId);
     return {
@@ -548,6 +568,7 @@ async function resolveProviderExecutionAuth(params: {
 }
 
 async function resolveProviderExecutionContext(params: {
+  capability: MediaUnderstandingCapability;
   providerId: string;
   provider?: MediaUnderstandingProvider;
   cfg: OpenClawConfig;
@@ -557,6 +578,7 @@ async function resolveProviderExecutionContext(params: {
   workspaceDir?: string;
 }) {
   const auth = await resolveProviderExecutionAuth({
+    capability: params.capability,
     providerId: params.providerId,
     provider: params.provider,
     cfg: params.cfg,
@@ -742,6 +764,7 @@ export async function runProviderEntry(params: {
     });
     assertMinAudioSize({ size: media.size, attachmentIndex: params.attachmentIndex });
     const { auth, baseUrl, headers, request } = await resolveProviderExecutionContext({
+      capability,
       providerId,
       provider,
       cfg,
@@ -824,6 +847,7 @@ export async function runProviderEntry(params: {
     );
   }
   const { auth, baseUrl, headers, request } = await resolveProviderExecutionContext({
+    capability,
     providerId,
     provider,
     cfg,

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -41,7 +41,7 @@ import { MediaUnderstandingSkipError } from "./errors.js";
 import { fileExists } from "./fs.js";
 import { normalizeImageDescriptionInput } from "./image-input-normalize.js";
 import { describeImageWithModel } from "./image-runtime.js";
-import { OPENAI_AUDIO_TRANSCRIPTIONS_API } from "./openai-audio-api.js";
+import { resolveOpenAiAudioAuthModelApi } from "./openai-audio-api.js";
 import { extractGeminiResponse } from "./output-extract.js";
 import { normalizeMediaExecutionProviderId } from "./provider-id.js";
 import { getMediaUnderstandingProvider, normalizeMediaProviderId } from "./provider-registry.js";
@@ -449,10 +449,7 @@ function resolveProviderExecutionAuthModelApi(params: {
   capability: MediaUnderstandingCapability;
   providerId: string;
 }): string | undefined {
-  if (params.capability === "audio" && params.providerId === "openai") {
-    return OPENAI_AUDIO_TRANSCRIPTIONS_API;
-  }
-  return undefined;
+  return resolveOpenAiAudioAuthModelApi(params);
 }
 
 async function resolveProviderExecutionAuth(params: {

--- a/src/media-understanding/runner.local-no-auth.test.ts
+++ b/src/media-understanding/runner.local-no-auth.test.ts
@@ -234,6 +234,56 @@ describe("runCapability local no-auth audio providers", () => {
     });
   });
 
+  it("uses OpenAI API key auth for audio when the default OpenAI profile is OAuth", async () => {
+    await withIsolatedAgentDir(async (agentDir) => {
+      await withEnvAsync({ ...AUTH_ENV, OPENAI_API_KEY: "env-openai-audio-key" }, async () => {
+        saveAuthProfileStore(
+          {
+            version: 1,
+            profiles: {
+              "openai:default": {
+                type: "oauth",
+                provider: "openai",
+                access: "oauth-chat-token",
+                refresh: "oauth-refresh-token",
+                expires: Date.now() + 60_000,
+              },
+            },
+          },
+          agentDir,
+          { filterExternalAuthProfiles: false, syncExternalCli: false },
+        );
+        await withAudioFixture(
+          "openclaw-openai-audio-oauth-env-key",
+          async ({ ctx, media, cache }) => {
+            const transcribeAudio = vi.fn(async (req: AudioTranscriptionRequest) => ({
+              text: `auth:${req.apiKey}`,
+              model: req.model,
+            }));
+            const cfg = createAudioCfg({ provider: "openai", model: "whisper-1" });
+
+            const result = await runCapability({
+              capability: "audio",
+              cfg,
+              ctx,
+              attachments: cache,
+              media,
+              agentDir,
+              providerRegistry: buildProviderRegistry({
+                openai: createAudioProvider("openai", transcribeAudio),
+              }),
+            });
+
+            expect(result.decision.outcome).toBe("success");
+            expect(result.outputs[0]?.text).toBe("auth:env-openai-audio-key");
+            expect(transcribeAudio).toHaveBeenCalledTimes(1);
+            expect(transcribeAudio.mock.calls[0]?.[0].apiKey).toBe("env-openai-audio-key");
+          },
+        );
+      });
+    });
+  });
+
   it("prefers stored auth profile credentials over plugin-only media no-auth", async () => {
     await withIsolatedAgentDir(async (agentDir) => {
       await withEnvAsync(AUTH_ENV, async () => {

--- a/src/media-understanding/runner.ts
+++ b/src/media-understanding/runner.ts
@@ -42,6 +42,7 @@ import type { ActiveMediaModel } from "./active-model.types.js";
 import { MediaAttachmentCache, selectAttachments } from "./attachments.js";
 import { isMediaUnderstandingSkipError } from "./errors.js";
 import { fileExists } from "./fs.js";
+import { resolveOpenAiAudioAuthModelApi } from "./openai-audio-api.js";
 import { normalizeMediaExecutionProviderId, normalizeMediaProviderId } from "./provider-id.js";
 import {
   buildMediaUnderstandingRegistry,
@@ -95,6 +96,7 @@ function resolveLiteralProviderApiKey(
 }
 
 async function hasProviderAuthAvailable(params: {
+  capability: MediaUnderstandingCapability;
   provider: string;
   cfg?: OpenClawConfig;
   agentDir?: string;
@@ -107,7 +109,13 @@ async function hasProviderAuthAvailable(params: {
   }
   cachedHasAvailableAuthForProvider ??= (await import("../agents/model-auth.js"))
     .hasAvailableAuthForProvider;
-  return await cachedHasAvailableAuthForProvider(params);
+  return await cachedHasAvailableAuthForProvider({
+    ...params,
+    modelApi: resolveOpenAiAudioAuthModelApi({
+      capability: params.capability,
+      providerId: params.provider,
+    }),
+  });
 }
 
 function resolveConfiguredKeyProviderOrder(params: {
@@ -606,6 +614,7 @@ async function resolveKeyEntry(params: {
     }
     if (
       !(await hasProviderAuthAvailable({
+        capability,
         provider: providerId,
         cfg,
         agentDir,
@@ -843,6 +852,7 @@ async function resolveActiveModelEntry(params: {
     return null;
   }
   const hasAuth = await hasProviderAuthAvailable({
+    capability: params.capability,
     provider: providerId,
     cfg: params.cfg,
     agentDir: params.agentDir,

--- a/src/media-understanding/runner.video.test.ts
+++ b/src/media-understanding/runner.video.test.ts
@@ -24,6 +24,11 @@ vi.mock("../plugins/capability-provider-runtime.js", async () => {
   return createEmptyCapabilityProviderMockModule();
 });
 
+vi.mock("../agents/model-auth.js", async () => {
+  const { createAvailableModelAuthMockModule } = await import("./runner.test-mocks.js");
+  return createAvailableModelAuthMockModule();
+});
+
 type CapabilityResult = Awaited<ReturnType<typeof runCapability>>;
 
 function requireCapabilityOutput(result: CapabilityResult, index: number) {
@@ -173,5 +178,64 @@ describe("runCapability video provider wiring", () => {
         },
       );
     });
+  });
+
+  it("does not use provider api config as video auth modelApi", async () => {
+    const modelAuth = await import("../agents/model-auth.js");
+    const resolveApiKeyForProvider = vi.mocked(modelAuth.resolveApiKeyForProvider);
+    resolveApiKeyForProvider.mockClear();
+
+    await withTempDir({ prefix: "openclaw-video-provider-api-" }, async (isolatedAgentDir) => {
+      await withVideoFixture("openclaw-video-provider-api", async ({ ctx, media, cache }) => {
+        let seenApiKey: string | undefined;
+        const cfg = {
+          models: {
+            providers: {
+              openai: {
+                api: "openai-responses",
+                models: [],
+              },
+            },
+          },
+          tools: {
+            media: {
+              video: {
+                enabled: true,
+                models: [{ provider: "openai", model: "video-model" }],
+              },
+            },
+          },
+        } as unknown as OpenClawConfig;
+
+        const result = await runCapability({
+          capability: "video",
+          cfg,
+          ctx,
+          agentDir: isolatedAgentDir,
+          attachments: cache,
+          media,
+          providerRegistry: new Map([
+            [
+              "openai",
+              {
+                id: "openai",
+                capabilities: ["video"],
+                describeVideo: async (req) => {
+                  seenApiKey = req.apiKey;
+                  return { text: "video ok", model: req.model };
+                },
+              },
+            ],
+          ]),
+        });
+
+        expect(result.decision.outcome).toBe("success");
+        expect(seenApiKey).toBe("test-key");
+      });
+    });
+
+    const firstCall = resolveApiKeyForProvider.mock.calls[0]?.[0];
+    expect(firstCall?.provider).toBe("openai");
+    expect(firstCall?.modelApi).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

- Route OpenAI media-understanding audio auth through the `openai-audio-transcriptions` API contract.
- This makes the auth resolver reject ChatGPT/Codex OAuth profiles for OpenAI audio transcription and continue to the configured OpenAI platform API key.
- Add a regression test for the mixed setup where `openai:default` is OAuth but `OPENAI_API_KEY` is available for audio.

## Why

OpenAI chat/Codex OAuth can be valid for model turns, but `/audio/transcriptions` requires an OpenAI platform API key. Media-understanding audio previously resolved provider auth without a `modelApi`, so the generic OpenAI OAuth profile could be selected before the API key path. That made audio transcription fail even on hosts that had a valid platform key configured for transcription.

## Real behavior proof

Behavior addressed: OpenAI audio transcription must use a platform API key even when the OpenAI provider also has an OAuth `openai:default` profile configured for chat/Codex use.

Real environment tested: Local OpenClaw source checkout on this branch, real OpenAI HTTPS calls, real `OPENAI_API_KEY` loaded from the gateway environment, and an isolated temporary agent auth store containing an intentionally invalid OAuth `openai:default` profile.

Exact steps or command run after this patch: Ran a source-level `node --import tsx --input-type=module` proof script that generated a short MP3 through OpenAI `/audio/speech`, saved an isolated invalid OAuth auth profile for `openai:default`, then called `runCapability({ capability: "audio" })` with the real bundled OpenAI media-understanding provider and `model: "whisper-1"`.

Evidence after fix:

```json
{
  "ok": true,
  "provider": "openai",
  "model": "whisper-1",
  "transcript": "Open CLAW Audio API Keyproof.",
  "outcome": "success",
  "attempts": [
    {
      "provider": "openai",
      "model": "whisper-1",
      "outcome": "success"
    }
  ],
  "oauthProfilePresent": true,
  "envApiKeyPresent": true
}
```

Observed result after fix: The audio transcription succeeded through OpenAI with a real platform API key even though the configured `openai:default` OAuth profile was present and intentionally invalid.

What was not tested: No packaged gateway restart or channel voice-note round trip was run for this PR; the live proof covered the source media-understanding auth/transcription path that this patch changes.

## Verification

- `node_modules/.bin/oxfmt src/media-understanding/runner.entries.ts src/media-understanding/runner.local-no-auth.test.ts`
- `node_modules/.bin/oxlint src/media-understanding/runner.entries.ts src/media-understanding/runner.local-no-auth.test.ts`
- `node scripts/run-vitest.mjs src/media-understanding/runner.local-no-auth.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local` -> clean, no accepted/actionable findings
