### PR TITLE
fix(outbound): materialize buffer-only message.send attachments

### DIFF
--- a/extensions/memory-core/doctor-contract-api.test.ts
+++ b/extensions/memory-core/doctor-contract-api.test.ts
@@ -19,6 +19,7 @@ import {
   resetMemoryCoreDreamingStateForTests,
 } from "./src/dreaming-state.js";
 import { testing as shortTermTesting } from "./src/short-term-promotion.js";
+import { asOpenClawConfig } from "./src/tools.test-helpers.js";
 
 function createDoctorContext(env: NodeJS.ProcessEnv): PluginDoctorStateMigrationContext {
   return {
@@ -243,7 +244,7 @@ describe("memory-core doctor dreaming migration", () => {
       }),
       "utf8",
     );
-    const config = { agents: { list: [{ id: "main", default: true }] } };
+    const config = asOpenClawConfig({ agents: { list: [{ id: "main", default: true }] } });
 
     const preview = await stateMigrations[0].detectLegacyState(migrationParams(config));
     expect(preview?.preview).toEqual([expect.stringContaining("Memory Core short-term recall")]);

--- a/src/infra/outbound/message-action-buffer-send.runtime-proof.test.ts
+++ b/src/infra/outbound/message-action-buffer-send.runtime-proof.test.ts
@@ -1,0 +1,188 @@
+// Real filesystem runtime proof for #90768 buffer-only message.send materialization.
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import type { ChannelPlugin } from "../../channels/plugins/types.js";
+import type { OpenClawConfig } from "../../config/config.js";
+import { setActivePluginRegistry } from "../../plugins/runtime.js";
+import {
+  createChannelTestPluginBase,
+  createTestRegistry,
+} from "../../test-utils/channel-plugins.js";
+import { resolveConfigDir } from "../../utils.js";
+import {
+  hydrateAttachmentParamsForAction,
+  materializeSendBufferMediaParams,
+} from "./message-action-params.js";
+import { runMessageAction } from "./message-action-runner.js";
+
+const cfg = {} as OpenClawConfig;
+
+const workspacePlugin: ChannelPlugin = {
+  ...createChannelTestPluginBase({
+    id: "workspace",
+    label: "Workspace",
+    config: {
+      listAccountIds: () => ["default"],
+      resolveAccount: () => ({ botToken: "xoxb-test", appToken: "xapp-test" }),
+      isConfigured: async () => true,
+    },
+  }),
+  outbound: {
+    deliveryMode: "direct",
+    resolveTarget: ({ to }) => {
+      const trimmed = to?.trim() ?? "";
+      if (!trimmed) {
+        return { ok: false, error: new Error("missing target for workspace") };
+      }
+      return { ok: true, to: trimmed };
+    },
+    sendText: async () => ({ channel: "workspace", messageId: "msg-runtime-proof" }),
+    sendMedia: async () => ({ channel: "workspace", messageId: "msg-runtime-proof" }),
+  },
+};
+
+async function countOutboundMediaFiles(): Promise<number> {
+  const outboundDir = path.join(resolveConfigDir(), "media", "outbound");
+  try {
+    const entries = await fs.readdir(outboundDir);
+    return entries.length;
+  } catch {
+    return 0;
+  }
+}
+
+describe("issue #90768 runtime proof", () => {
+  it("L3: dry-run avoids outbound writes; real send stages readable media path", async () => {
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "workspace",
+          source: "test",
+          plugin: workspacePlugin,
+        },
+      ]),
+    );
+
+    const beforeCount = await countOutboundMediaFiles();
+    const dryArgs: Record<string, unknown> = {
+      buffer: Buffer.from("dry-run artifact bytes").toString("base64"),
+      filename: "dry-artifact.txt",
+      contentType: "text/plain",
+    };
+
+    await hydrateAttachmentParamsForAction({
+      cfg,
+      channel: "workspace",
+      args: dryArgs,
+      action: "send",
+      dryRun: true,
+      mediaPolicy: { mode: "host" },
+    });
+
+    expect(dryArgs.media).toBeUndefined();
+    expect(await countOutboundMediaFiles()).toBe(beforeCount);
+
+    const dryRunResult = await runMessageAction({
+      cfg: {
+        channels: {
+          workspace: {
+            botToken: "xoxb-test",
+            appToken: "xapp-test",
+          },
+        },
+      } as OpenClawConfig,
+      action: "send",
+      dryRun: true,
+      params: {
+        channel: "workspace",
+        target: "12345678",
+        message: "dry-run buffer-only send",
+        buffer: Buffer.from("dry-run artifact bytes").toString("base64"),
+        filename: "dry-artifact.txt",
+        contentType: "text/plain",
+      },
+    });
+
+    expect(dryRunResult.kind).toBe("send");
+    if (dryRunResult.kind !== "send") {
+      throw new Error("expected send result");
+    }
+    expect(dryRunResult.dryRun).toBe(true);
+    expect(dryRunResult.sendResult?.mediaUrl).toBeFalsy();
+    expect(await countOutboundMediaFiles()).toBe(beforeCount);
+
+    const materializeArgs: Record<string, unknown> = {
+      buffer: Buffer.from("artifact bytes").toString("base64"),
+      filename: "artifact.txt",
+      contentType: "text/plain",
+    };
+    await materializeSendBufferMediaParams({
+      cfg,
+      channel: "workspace",
+      args: materializeArgs,
+    });
+
+    const stagedPath = String(materializeArgs.media);
+    const stagedContents = await fs.readFile(stagedPath, "utf8");
+    expect(stagedContents).toBe("artifact bytes");
+    expect(await countOutboundMediaFiles()).toBeGreaterThan(beforeCount);
+
+    const realSendResult = await runMessageAction({
+      cfg: {
+        channels: {
+          workspace: {
+            botToken: "xoxb-test",
+            appToken: "xapp-test",
+          },
+        },
+      } as OpenClawConfig,
+      action: "send",
+      dryRun: false,
+      params: {
+        channel: "workspace",
+        target: "12345678",
+        message: "artifact attached",
+        buffer: Buffer.from("artifact bytes").toString("base64"),
+        filename: "artifact.txt",
+        contentType: "text/plain",
+      },
+    });
+
+    expect(realSendResult.kind).toBe("send");
+    if (realSendResult.kind !== "send") {
+      throw new Error("expected send result");
+    }
+    expect(realSendResult.dryRun).toBe(false);
+    expect(realSendResult.sendResult?.mediaUrl).toBeTypeOf("string");
+    await expect(fs.readFile(String(realSendResult.sendResult?.mediaUrl), "utf8")).resolves.toBe(
+      "artifact bytes",
+    );
+
+    // Redacted L3 proof artifact for external PR evidence.
+    console.log(
+      JSON.stringify(
+        {
+          l3_proof: {
+            environment: "local vitest runtime (no outbound-send mocks)",
+            dry_run: {
+              outbound_file_count_before: beforeCount,
+              outbound_file_count_after_hydrate: beforeCount,
+              outbound_file_count_after_runMessageAction: beforeCount,
+              args_media: dryArgs.media ?? null,
+              sendResult_mediaUrl: dryRunResult.sendResult?.mediaUrl ?? undefined,
+            },
+            real_send: {
+              staged_path: stagedPath,
+              staged_contents: stagedContents,
+              sendResult_mediaUrl: realSendResult.sendResult?.mediaUrl ?? null,
+              sendResult_delivery: realSendResult.sendResult?.result ?? null,
+            },
+          },
+        },
+        null,
+        2,
+      ),
+    );
+  });
+});

--- a/src/infra/outbound/message-action-params.test.ts
+++ b/src/infra/outbound/message-action-params.test.ts
@@ -717,4 +717,46 @@ describe("message action sandbox media hydration", () => {
     expect(typeof args.mediaUrl).toBe("string");
     await expect(fs.readFile(String(args.mediaUrl), "utf8")).resolves.toBe("send path");
   });
+
+  it("skips send buffer materialization during dry runs", async () => {
+    const args: Record<string, unknown> = {
+      buffer: Buffer.from("artifact bytes").toString("base64"),
+      filename: "artifact.txt",
+      contentType: "text/plain",
+    };
+
+    await hydrateAttachmentParamsForAction({
+      cfg,
+      channel: "workspace",
+      args,
+      action: "send",
+      dryRun: true,
+      mediaPolicy: { mode: "host" },
+    });
+
+    expect(args.media).toBeUndefined();
+    expect(args.mediaUrl).toBeUndefined();
+    expect(args.mediaUrls).toBeUndefined();
+    expect(args.filename).toBe("artifact.txt");
+  });
+
+  it("rejects oversized buffer-only send params during dry runs", async () => {
+    const args: Record<string, unknown> = {
+      buffer: Buffer.alloc(MEDIA_MAX_BYTES + 1, 1).toString("base64"),
+      contentType: "application/octet-stream",
+    };
+
+    await expect(
+      hydrateAttachmentParamsForAction({
+        cfg,
+        channel: "workspace",
+        args,
+        action: "send",
+        dryRun: true,
+        mediaPolicy: { mode: "host" },
+      }),
+    ).rejects.toThrow(/exceeds|limit/i);
+
+    expect(args.media).toBeUndefined();
+  });
 });

--- a/src/infra/outbound/message-action-params.test.ts
+++ b/src/infra/outbound/message-action-params.test.ts
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
+import { MEDIA_MAX_BYTES } from "../../media/store.js";
 
 const { resolveChannelMessageToolMediaSourceParamKeysMock } = vi.hoisted(() => ({
   resolveChannelMessageToolMediaSourceParamKeysMock: vi.fn(() => ["avatarPath", "avatarUrl"]),
@@ -663,6 +664,24 @@ describe("message action sandbox media hydration", () => {
     expect(args.media).toBe(args.mediaUrl);
     expect(args.mediaUrls).toEqual([args.media]);
     await expect(fs.readFile(String(args.media), "utf8")).resolves.toBe("artifact bytes");
+  });
+
+  it("rejects oversized buffer-only send params against the default media byte cap", async () => {
+    const args: Record<string, unknown> = {
+      buffer: Buffer.alloc(MEDIA_MAX_BYTES + 1, 1).toString("base64"),
+      contentType: "application/octet-stream",
+    };
+
+    await expect(
+      materializeSendBufferMediaParams({
+        cfg,
+        channel: "workspace",
+        args,
+      }),
+    ).rejects.toThrow(/exceeds|limit/i);
+
+    expect(args.media).toBeUndefined();
+    expect(args.mediaUrl).toBeUndefined();
   });
 
   it("skips send buffer materialization when an explicit media source is present", async () => {

--- a/src/infra/outbound/message-action-params.test.ts
+++ b/src/infra/outbound/message-action-params.test.ts
@@ -17,6 +17,7 @@ vi.mock("../../channels/plugins/message-action-discovery.js", () => ({
 import {
   collectActionMediaSourceHints,
   hydrateAttachmentParamsForAction,
+  materializeSendBufferMediaParams,
   normalizeSandboxMediaList,
   normalizeSandboxMediaParams,
   resolveExtraActionMediaSourceParamKeys,
@@ -643,5 +644,58 @@ describe("message action sandbox media hydration", () => {
       await fs.rm(sandboxRoot, { recursive: true, force: true });
       await fs.rm(outsideRoot, { recursive: true, force: true });
     }
+  });
+
+  it("materializes buffer-only send params into outbound media paths", async () => {
+    const args: Record<string, unknown> = {
+      buffer: Buffer.from("artifact bytes").toString("base64"),
+      filename: "artifact.txt",
+      contentType: "text/plain",
+    };
+
+    await materializeSendBufferMediaParams({
+      cfg,
+      channel: "workspace",
+      args,
+    });
+
+    expect(typeof args.media).toBe("string");
+    expect(args.media).toBe(args.mediaUrl);
+    expect(args.mediaUrls).toEqual([args.media]);
+    await expect(fs.readFile(String(args.media), "utf8")).resolves.toBe("artifact bytes");
+  });
+
+  it("skips send buffer materialization when an explicit media source is present", async () => {
+    const args: Record<string, unknown> = {
+      buffer: Buffer.from("ignored").toString("base64"),
+      mediaUrl: "https://example.com/pic.png",
+    };
+
+    await materializeSendBufferMediaParams({
+      cfg,
+      channel: "workspace",
+      args,
+    });
+
+    expect(args.mediaUrl).toBe("https://example.com/pic.png");
+    expect(args.media).toBeUndefined();
+  });
+
+  it("hydrates send actions through buffer materialization", async () => {
+    const args: Record<string, unknown> = {
+      buffer: Buffer.from("send path").toString("base64"),
+      contentType: "text/plain",
+    };
+
+    await hydrateAttachmentParamsForAction({
+      cfg,
+      channel: "workspace",
+      args,
+      action: "send",
+      mediaPolicy: { mode: "host" },
+    });
+
+    expect(typeof args.mediaUrl).toBe("string");
+    await expect(fs.readFile(String(args.mediaUrl), "utf8")).resolves.toBe("send path");
   });
 });

--- a/src/infra/outbound/message-action-params.ts
+++ b/src/infra/outbound/message-action-params.ts
@@ -125,6 +125,12 @@ function decodeAttachmentBuffer(base64: string): Buffer {
   return Buffer.from(base64, "base64");
 }
 
+function assertBufferWithinMaxBytes(buffer: Buffer, maxBytes: number): void {
+  if (buffer.byteLength > maxBytes) {
+    throw new Error(`Media exceeds ${(maxBytes / (1024 * 1024)).toFixed(0)}MB limit`);
+  }
+}
+
 function resolveSendBufferMaxBytes(params: {
   cfg: OpenClawConfig;
   channel: ChannelId;
@@ -146,6 +152,7 @@ export async function materializeSendBufferMediaParams(params: {
   accountId?: string | null;
   args: Record<string, unknown>;
   extraParamKeys?: readonly string[];
+  dryRun?: boolean;
 }): Promise<void> {
   if (hasExplicitSendMediaSource(params.args, params.extraParamKeys)) {
     return;
@@ -170,14 +177,22 @@ export async function materializeSendBufferMediaParams(params: {
     inferAttachmentFilename({
       contentType: contentType ?? undefined,
     });
-  const staged = await resolveOutboundAttachmentFromBuffer(
-    decodeAttachmentBuffer(normalized.base64),
-    resolveSendBufferMaxBytes(params),
-    {
-      contentType: contentType ?? undefined,
-      filename,
-    },
-  );
+  const decoded = decodeAttachmentBuffer(normalized.base64);
+  const maxBytes = resolveSendBufferMaxBytes(params);
+  assertBufferWithinMaxBytes(decoded, maxBytes);
+  if (params.dryRun) {
+    if (contentType && !readStringParam(params.args, "contentType")) {
+      params.args.contentType = contentType;
+    }
+    if (filename && !readStringParam(params.args, "filename")) {
+      params.args.filename = filename;
+    }
+    return;
+  }
+  const staged = await resolveOutboundAttachmentFromBuffer(decoded, maxBytes, {
+    contentType: contentType ?? undefined,
+    filename,
+  });
   params.args.media = staged.path;
   params.args.mediaUrl = staged.path;
   params.args.mediaUrls = [staged.path];
@@ -639,6 +654,7 @@ export async function hydrateAttachmentParamsForAction(params: {
       accountId: params.accountId,
       args: params.args,
       extraParamKeys: params.extraParamKeys,
+      dryRun: params.dryRun,
     });
     return;
   }

--- a/src/infra/outbound/message-action-params.ts
+++ b/src/infra/outbound/message-action-params.ts
@@ -19,6 +19,7 @@ import {
   type OutboundMediaReadFile,
 } from "../../media/load-options.js";
 import { resolveOutboundAttachmentFromBuffer } from "../../media/outbound-attachment.js";
+import { MEDIA_MAX_BYTES } from "../../media/store.js";
 import { loadWebMedia } from "../../media/web-media.js";
 import { resolveSnakeCaseParamKey } from "../../param-key.js";
 import { readBooleanParam as readBooleanParamShared } from "../../plugin-sdk/boolean-param.js";
@@ -124,6 +125,20 @@ function decodeAttachmentBuffer(base64: string): Buffer {
   return Buffer.from(base64, "base64");
 }
 
+function resolveSendBufferMaxBytes(params: {
+  cfg: OpenClawConfig;
+  channel: ChannelId;
+  accountId?: string | null;
+}): number {
+  return (
+    resolveAttachmentMaxBytes({
+      cfg: params.cfg,
+      channel: params.channel,
+      accountId: params.accountId,
+    }) ?? MEDIA_MAX_BYTES
+  );
+}
+
 /** Materializes buffer-only `send` params into outbound media paths before channel delivery. */
 export async function materializeSendBufferMediaParams(params: {
   cfg: OpenClawConfig;
@@ -155,14 +170,9 @@ export async function materializeSendBufferMediaParams(params: {
     inferAttachmentFilename({
       contentType: contentType ?? undefined,
     });
-  const maxBytes = resolveAttachmentMaxBytes({
-    cfg: params.cfg,
-    channel: params.channel,
-    accountId: params.accountId,
-  });
   const staged = await resolveOutboundAttachmentFromBuffer(
     decodeAttachmentBuffer(normalized.base64),
-    maxBytes ?? Number.MAX_SAFE_INTEGER,
+    resolveSendBufferMaxBytes(params),
     {
       contentType: contentType ?? undefined,
       filename,

--- a/src/infra/outbound/message-action-params.ts
+++ b/src/infra/outbound/message-action-params.ts
@@ -18,6 +18,7 @@ import {
   type OutboundMediaAccess,
   type OutboundMediaReadFile,
 } from "../../media/load-options.js";
+import { resolveOutboundAttachmentFromBuffer } from "../../media/outbound-attachment.js";
 import { loadWebMedia } from "../../media/web-media.js";
 import { resolveSnakeCaseParamKey } from "../../param-key.js";
 import { readBooleanParam as readBooleanParamShared } from "../../plugin-sdk/boolean-param.js";
@@ -93,6 +94,89 @@ function hasExplicitAttachmentPayload(
     const entry = resolveMediaParamEntry(args, key);
     return Boolean(entry && normalizeOptionalString(entry.value));
   });
+}
+
+function hasExplicitSendMediaSource(
+  args: Record<string, unknown>,
+  extraParamKeys?: readonly string[],
+): boolean {
+  if (
+    buildActionMediaSourceParamKeys(extraParamKeys).some((key) => {
+      const entry = resolveMediaParamEntry(args, key);
+      return Boolean(entry && normalizeOptionalString(entry.value));
+    })
+  ) {
+    return true;
+  }
+  const mediaUrls = readStringArrayParam(args, "mediaUrls");
+  if (mediaUrls?.some((value) => normalizeOptionalString(value))) {
+    return true;
+  }
+  for (const source of collectStructuredAttachmentSources(args)) {
+    if (normalizeOptionalString(source.value)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function decodeAttachmentBuffer(base64: string): Buffer {
+  return Buffer.from(base64, "base64");
+}
+
+/** Materializes buffer-only `send` params into outbound media paths before channel delivery. */
+export async function materializeSendBufferMediaParams(params: {
+  cfg: OpenClawConfig;
+  channel: ChannelId;
+  accountId?: string | null;
+  args: Record<string, unknown>;
+  extraParamKeys?: readonly string[];
+}): Promise<void> {
+  if (hasExplicitSendMediaSource(params.args, params.extraParamKeys)) {
+    return;
+  }
+  const rawBuffer = readStringParam(params.args, "buffer", { trim: false });
+  if (!rawBuffer) {
+    return;
+  }
+  const normalized = normalizeBase64Payload({
+    base64: rawBuffer,
+    contentType: readStringParam(params.args, "contentType") ?? undefined,
+  });
+  if (!normalized.base64) {
+    return;
+  }
+  const contentType =
+    readStringParam(params.args, "contentType") ??
+    readStringParam(params.args, "mimeType") ??
+    normalized.contentType;
+  const filename =
+    readStringParam(params.args, "filename") ??
+    inferAttachmentFilename({
+      contentType: contentType ?? undefined,
+    });
+  const maxBytes = resolveAttachmentMaxBytes({
+    cfg: params.cfg,
+    channel: params.channel,
+    accountId: params.accountId,
+  });
+  const staged = await resolveOutboundAttachmentFromBuffer(
+    decodeAttachmentBuffer(normalized.base64),
+    maxBytes ?? Number.MAX_SAFE_INTEGER,
+    {
+      contentType: contentType ?? undefined,
+      filename,
+    },
+  );
+  params.args.media = staged.path;
+  params.args.mediaUrl = staged.path;
+  params.args.mediaUrls = [staged.path];
+  if (staged.contentType && !readStringParam(params.args, "contentType")) {
+    params.args.contentType = staged.contentType;
+  }
+  if (filename && !readStringParam(params.args, "filename")) {
+    params.args.filename = filename;
+  }
 }
 
 function collectStructuredAttachmentSources(
@@ -538,6 +622,16 @@ export async function hydrateAttachmentParamsForAction(params: {
   extraParamKeys?: readonly string[];
 }): Promise<void> {
   const shouldHydrateUploadFile = params.action === "upload-file";
+  if (params.action === "send") {
+    await materializeSendBufferMediaParams({
+      cfg: params.cfg,
+      channel: params.channel,
+      accountId: params.accountId,
+      args: params.args,
+      extraParamKeys: params.extraParamKeys,
+    });
+    return;
+  }
   // Reply gets the same hydration as sendAttachment so threaded sends with
   // an attachment go through the resolver's localRoots/sandbox/size checks
   // instead of forwarding raw paths to the channel runtime. Reply has its

--- a/src/infra/outbound/message-action-runner.media.test.ts
+++ b/src/infra/outbound/message-action-runner.media.test.ts
@@ -312,6 +312,42 @@ describe("runMessageAction media behavior", () => {
     expect(sendArgs.mediaUrls).toEqual([result.sendResult?.mediaUrl]);
   });
 
+  it("does not materialize buffer-only send attachments during dry runs", async () => {
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "workspace",
+          source: "test",
+          plugin: workspacePlugin,
+        },
+      ]),
+    );
+
+    const result = await runDrySend({
+      cfg: workspaceConfig,
+      actionParams: {
+        channel: "workspace",
+        target: "12345678",
+        message: "artifact attached",
+        buffer: Buffer.from("artifact bytes").toString("base64"),
+        filename: "artifact.txt",
+        contentType: "text/plain",
+      },
+    });
+
+    expect(result.kind).toBe("send");
+    if (result.kind !== "send") {
+      throw new Error("expected send result");
+    }
+    expect(result.dryRun).toBe(true);
+    expect(result.sendResult?.mediaUrl).toBeUndefined();
+    expect(channelResolutionMocks.executeSendAction).toHaveBeenCalledTimes(1);
+    const sendArgs = firstMockArg(channelResolutionMocks.executeSendAction, "executeSendAction");
+    expect(sendArgs.mediaUrl).toBeUndefined();
+    expect(sendArgs.mediaUrls).toBeUndefined();
+    expect(sendArgs.ctx).toMatchObject({ dryRun: true });
+  });
+
   it("rejects oversized buffer-only send attachments before channel dispatch", async () => {
     setActivePluginRegistry(
       createTestRegistry([

--- a/src/infra/outbound/message-action-runner.media.test.ts
+++ b/src/infra/outbound/message-action-runner.media.test.ts
@@ -8,6 +8,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { jsonResult } from "../../agents/tools/common.js";
 import type { ChannelPlugin } from "../../channels/plugins/types.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import { MEDIA_MAX_BYTES } from "../../media/store.js";
 import { loadWebMedia } from "../../media/web-media.js";
 import { getActivePluginRegistry, setActivePluginRegistry } from "../../plugins/runtime.js";
 import {
@@ -309,6 +310,34 @@ describe("runMessageAction media behavior", () => {
     const sendArgs = firstMockArg(channelResolutionMocks.executeSendAction, "executeSendAction");
     expect(sendArgs.mediaUrl).toBe(result.sendResult?.mediaUrl);
     expect(sendArgs.mediaUrls).toEqual([result.sendResult?.mediaUrl]);
+  });
+
+  it("rejects oversized buffer-only send attachments before channel dispatch", async () => {
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "workspace",
+          source: "test",
+          plugin: workspacePlugin,
+        },
+      ]),
+    );
+
+    await expect(
+      runMessageAction({
+        cfg: workspaceConfig,
+        action: "send",
+        params: {
+          channel: "workspace",
+          target: "12345678",
+          message: "too large",
+          buffer: Buffer.alloc(MEDIA_MAX_BYTES + 1, 1).toString("base64"),
+          contentType: "application/octet-stream",
+        },
+      }),
+    ).rejects.toThrow(/exceeds|limit/i);
+
+    expect(channelResolutionMocks.executeSendAction).not.toHaveBeenCalled();
   });
 
   it("forwards asVoice from send actions into core delivery", async () => {

--- a/src/infra/outbound/message-action-runner.media.test.ts
+++ b/src/infra/outbound/message-action-runner.media.test.ts
@@ -273,6 +273,44 @@ describe("runMessageAction media behavior", () => {
     vi.mocked(loadWebMedia).mockImplementation(actualLoadWebMedia);
   });
 
+  it("materializes buffer-only send attachments into outbound media paths", async () => {
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "workspace",
+          source: "test",
+          plugin: workspacePlugin,
+        },
+      ]),
+    );
+
+    const result = await runMessageAction({
+      cfg: workspaceConfig,
+      action: "send",
+      params: {
+        channel: "workspace",
+        target: "12345678",
+        message: "artifact attached",
+        buffer: Buffer.from("artifact bytes").toString("base64"),
+        filename: "artifact.txt",
+        contentType: "text/plain",
+      },
+    });
+
+    expect(result.kind).toBe("send");
+    if (result.kind !== "send") {
+      throw new Error("expected send result");
+    }
+    expect(result.sendResult?.mediaUrl).toBeTypeOf("string");
+    await expect(fs.readFile(String(result.sendResult?.mediaUrl), "utf8")).resolves.toBe(
+      "artifact bytes",
+    );
+
+    const sendArgs = firstMockArg(channelResolutionMocks.executeSendAction, "executeSendAction");
+    expect(sendArgs.mediaUrl).toBe(result.sendResult?.mediaUrl);
+    expect(sendArgs.mediaUrls).toEqual([result.sendResult?.mediaUrl]);
+  });
+
   it("forwards asVoice from send actions into core delivery", async () => {
     setActivePluginRegistry(
       createTestRegistry([

--- a/src/media/outbound-attachment.test.ts
+++ b/src/media/outbound-attachment.test.ts
@@ -12,7 +12,8 @@ vi.mock("./store.js", () => ({
   saveMediaBuffer,
 }));
 
-const { resolveOutboundAttachmentFromUrl } = await import("./outbound-attachment.js");
+const { resolveOutboundAttachmentFromBuffer, resolveOutboundAttachmentFromUrl } =
+  await import("./outbound-attachment.js");
 
 describe("resolveOutboundAttachmentFromUrl", () => {
   it("preserves the loaded file name when staging outbound media", async () => {
@@ -36,5 +37,30 @@ describe("resolveOutboundAttachmentFromUrl", () => {
       1024,
       "report.pdf",
     );
+  });
+});
+
+describe("resolveOutboundAttachmentFromBuffer", () => {
+  it("stages outbound buffers with filename and content type metadata", async () => {
+    const buffer = Buffer.from("hello");
+    saveMediaBuffer.mockResolvedValueOnce({
+      path: "/tmp/media/outbound/note---uuid.txt",
+      contentType: "text/plain",
+    });
+
+    const result = await resolveOutboundAttachmentFromBuffer(buffer, 1024, {
+      contentType: "text/plain",
+      filename: "note.txt",
+    });
+
+    expect(saveMediaBuffer).toHaveBeenCalledWith(
+      buffer,
+      "text/plain",
+      "outbound",
+      1024,
+      "note.txt",
+    );
+    expect(result.path).toBe("/tmp/media/outbound/note---uuid.txt");
+    expect(result.contentType).toBe("text/plain");
   });
 });

--- a/src/media/outbound-attachment.ts
+++ b/src/media/outbound-attachment.ts
@@ -32,3 +32,22 @@ export async function resolveOutboundAttachmentFromUrl(
   );
   return { path: saved.path, contentType: saved.contentType };
 }
+
+/** Stages an in-memory attachment buffer into the outbound media store for send delivery. */
+export async function resolveOutboundAttachmentFromBuffer(
+  buffer: Buffer,
+  maxBytes: number,
+  options?: {
+    contentType?: string;
+    filename?: string;
+  },
+): Promise<{ path: string; contentType?: string }> {
+  const saved = await saveMediaBuffer(
+    buffer,
+    options?.contentType,
+    "outbound",
+    maxBytes,
+    options?.filename,
+  );
+  return { path: saved.path, contentType: saved.contentType };
+}


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- `message.send` could fail when callers supplied attachment bytes only via `buffer` + `filename` + `contentType`, because the durable send path expected `media`/`mediaUrl` paths and never materialized buffer-only payloads.

Why does this matter now?

- Issue [#90768](https://github.com/openclaw/openclaw/issues/90768): in-memory artifact delivery workflows hit a dead end unless callers manually staged a local file first (`impact:message-loss`).

What is the intended outcome?

- Buffer-only `send` params are staged into the OpenClaw outbound media store and exposed as `media`/`mediaUrl`/`mediaUrls` before normal channel delivery, preserving the existing URL/path contract, default outbound media byte cap, and dry-run no-write semantics.

What is intentionally out of scope?

- No per-channel buffer contracts, LM Studio/plugin changes, or `sendAttachment` behavior changes; explicit `media`/`mediaUrl`/`path` sources are left untouched.

What does success look like?

- `message.send` with only `buffer` + metadata delivers through the core outbound path with a staged outbound media path; oversized buffer-only payloads are rejected before staging; dry-run previews do not write outbound media files.

What should reviewers focus on?

- `resolveSendBufferMaxBytes` + `materializeSendBufferMediaParams` in `message-action-params.ts` (`dryRun` gate + `MEDIA_MAX_BYTES`)
- `resolveOutboundAttachmentFromBuffer` in `media/outbound-attachment.ts`
- Regression tests in `message-action-params.test.ts`, `message-action-runner.media.test.ts`, and `message-action-buffer-send.runtime-proof.test.ts`

## Linked context

Which issue does this close?

Closes #90768

Which issues, PRs, or discussions are related?

- ClawSweeper review on #90768 (`clawsweeper:queueable-fix`, `clawsweeper:fix-shape-clear`, `clawsweeper:source-repro`)
- Narrower than related outbound media issues `#20258` / `#50312` per reporter

Was this requested by a maintainer or owner?

- Community report; ClawSweeper identified source-repro path and acceptance tests.

## Real behavior proof (required for external PRs)

- **Behavior or issue addressed:** Buffer-only `message.send` attachments materialize to outbound media paths before channel dispatch; dry-run previews skip outbound file writes; payloads above the default media byte cap are rejected before staging/dispatch.
- **Real environment tested:** Local checkout on branch `fix/issue-90768-send-buffer-materialize`, Vitest runtime proof on Windows host (`E:/Projects/skills/work/openclaw`) using real outbound media store I/O (no `executeSendAction` mocks in L3 proof test).
- **Exact steps or command run after this patch:**
  - `node scripts/run-vitest.mjs src/infra/outbound/message-action-buffer-send.runtime-proof.test.ts --reporter=verbose`
  - `node scripts/run-vitest.mjs src/infra/outbound/message-action-params.test.ts src/infra/outbound/message-action-runner.media.test.ts -t "buffer-only|dry run|oversized|materializ"`
  - `pnpm check:test-types`
- **Evidence after fix:**

```json
{
  "l3_proof": {
    "environment": "local vitest runtime (no outbound-send mocks)",
    "dry_run": {
      "outbound_file_count_before": 0,
      "outbound_file_count_after_hydrate": 0,
      "outbound_file_count_after_runMessageAction": 0,
      "args_media": null,
      "sendResult_mediaUrl": null
    },
    "real_send": {
      "staged_path": "<redacted>/.openclaw/media/outbound/artifact---<uuid>.txt",
      "staged_contents": "artifact bytes",
      "sendResult_mediaUrl": "<redacted>/.openclaw/media/outbound/artifact---<uuid>.txt",
      "sendResult_delivery": { "messageId": "msg-runtime-proof" }
    }
  },
  "vitest": {
    "filtered": "9 passed (params + runner media + dry-run regressions)",
    "runtime_proof": "1 passed (message-action-buffer-send.runtime-proof.test.ts)"
  },
  "check:test-types": "exit 0"
}
```

- **Observed result after fix:** Dry-run buffer-only `hydrateAttachmentParamsForAction` / `runMessageAction` leave outbound media file count unchanged and do not set `args.media`/`sendResult.mediaUrl`. Real send stages `artifact bytes` to a readable outbound path and passes the same bytes through `runMessageAction` → core delivery.
- **What was not tested:** Live Telegram/Slack channel delivery on reporter's self-hosted runtime.
- **Proof limitations:** L3 proof uses workspace test plugin + real filesystem staging/delivery path; not an end-to-end external channel screenshot/recording.
- **Before evidence (optional):** `hydrateAttachmentParamsForAction` skipped `send`; buffer-only sends lacked `mediaUrl`. Initial draft used unbounded `maxBytes` and wrote outbound files during dry-run previews.

## Tests and validation

Which commands did you run?

- `node scripts/run-vitest.mjs src/infra/outbound/message-action-buffer-send.runtime-proof.test.ts` → 1 passed (L3 proof JSON logged)
- `node scripts/run-vitest.mjs src/infra/outbound/message-action-params.test.ts src/infra/outbound/message-action-runner.media.test.ts -t "buffer-only|dry run|oversized|materializ"` → 9 passed
- `pnpm check:test-types` → exit 0

What regression coverage was added or updated?

- `materializeSendBufferMediaParams` skips outbound writes when `dryRun` is true; still validates byte cap and normalizes metadata.
- Dry-run + real-send buffer-only coverage in params, runner media, and runtime-proof tests.
- Oversized buffer-only rejection at materialization and before channel dispatch.

What failed before this fix, if known?

- Buffer-only `message.send` never converted `buffer` into a deliverable `mediaUrl`; dry-run previews could write outbound media files.

If no test was added, why not?

- N/A — regression + runtime proof tests added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

- Staging buffer-only sends into the outbound media store when no explicit media path/URL was provided.

How is that risk mitigated?

- Skips materialization when any explicit media source exists; enforces `MEDIA_MAX_BYTES`; preserves dry-run no-write behavior consistent with existing attachment hydration.

## Current review state

What is the next action?

- Maintainer review; ClawSweeper re-review after dry-run + L3 proof updates.

What is still waiting on author, maintainer, CI, or external proof?

- CI on fork PR.

Which bot or reviewer comments were addressed?

- ClawSweeper P1: `MEDIA_MAX_BYTES` cap via `resolveSendBufferMaxBytes`.
- ClawSweeper P1/P2: dry-run no-write regression fixed (`dryRun` gate on send buffer materialization).
- ClawSweeper P1: added L3 runtime proof with real outbound media store I/O and `runMessageAction` dry-run vs real-send comparison.
