### PR TITLE
fix(imessage): coalesce split-sends without delaying normal DMs

### DIFF
--- a/docs/channels/imessage.md
+++ b/docs/channels/imessage.md
@@ -641,7 +641,7 @@ When a user types a command and a URL together — e.g. `Dump https://example.co
 
 The two rows arrive at OpenClaw ~0.8-2.0 s apart on most setups. Without coalescing, the agent receives the command alone on turn 1, replies (often "send me the URL"), and only sees the URL on turn 2 — at which point the command context is already lost. This is Apple's send pipeline, not anything OpenClaw or `imsg` introduces.
 
-`channels.imessage.coalesceSameSenderDms` opts a DM into merging consecutive same-sender rows into a single agent turn. Group chats continue to dispatch per-message so multi-user turn structure is preserved.
+`channels.imessage.coalesceSameSenderDms` opts a DM into merging Apple's split-send — a short command or caption row followed by a URL or attachment — into one agent turn. Only short bare fragments (≤ 3 words, no URL, no attachment, no terminal punctuation — e.g. `Dump`, `Save this`) are briefly held to wait for a payload follow-up; everything else (prose, questions, lone URLs, longer text) dispatches instantly. Group chats continue to dispatch per-message so multi-user turn structure is preserved.
 
 <Tabs>
   <Tab title="When to enable">
@@ -649,11 +649,11 @@ The two rows arrive at OpenClaw ~0.8-2.0 s apart on most setups. Without coalesc
 
     - You ship skills that expect `command + payload` in one message (dump, paste, save, queue, etc.).
     - Your users paste URLs, images, or long content alongside commands.
-    - You can accept the added DM turn latency (see below).
+    - You can accept a brief hold on short bare DM fragments (see below).
 
     Leave disabled when:
 
-    - You need minimum command latency for single-word DM triggers.
+    - You need zero-latency dispatch even for short single-word DM triggers.
     - All your flows are one-shot commands without payload follow-ups.
 
   </Tab>
@@ -689,7 +689,7 @@ The two rows arrive at OpenClaw ~0.8-2.0 s apart on most setups. Without coalesc
 
   </Tab>
   <Tab title="Trade-offs">
-    - **Added latency for DM messages.** With the flag on, every DM (including standalone control commands and single-text follow-ups) waits up to the debounce window before dispatching, in case a payload row is coming. Group-chat messages keep instant dispatch.
+    - **Brief hold on short lead-in fragments only.** A DM that looks like the lead-in row of a split-send — short bare text (≤ 3 words, no URL, no attachment, no terminal punctuation, e.g. `Dump`, `Save this`, `ok`) — is held up to the debounce window in case a payload row follows. The matching payload row flushes the bucket the moment it lands, so a real split-send adds only Apple's cross-row gap (~0.8-2.0 s), not the full window. Everything else — prose, questions, lone URLs, longer text, anything ending in `.`, `?`, or `!` — dispatches instantly. Group-chat messages also keep instant dispatch.
     - **Merged output is bounded.** Merged text caps at 4000 chars with an explicit `…[truncated]` marker; attachments cap at 20; source entries cap at 10 (first-plus-latest retained beyond that). Every source GUID is tracked in `coalescedMessageGuids` for downstream telemetry.
     - **DM-only.** Group chats fall through to per-message dispatch so the bot stays responsive when multiple people are typing.
     - **Opt-in, per-channel.** Other channels (Telegram, WhatsApp, Slack, …) are unaffected. Legacy BlueBubbles configs that set `channels.bluebubbles.coalesceSameSenderDms` should migrate that value to `channels.imessage.coalesceSameSenderDms`.
@@ -703,10 +703,12 @@ The two rows arrive at OpenClaw ~0.8-2.0 s apart on most setups. Without coalesc
 | ------------------------------------------------------------------ | --------------------- | --------------------------------------- | ----------------------------------------------------------------------- |
 | `Dump https://example.com` (one send)                              | 2 rows ~1 s apart     | Two agent turns: "Dump" alone, then URL | One turn: merged text `Dump https://example.com`                        |
 | `Save this 📎image.jpg caption` (attachment + text)                | 2 rows                | Two turns (attachment dropped on merge) | One turn: text + image preserved                                        |
-| `/status` (standalone command)                                     | 1 row                 | Instant dispatch                        | **Wait up to window, then dispatch**                                    |
-| URL pasted alone                                                   | 1 row                 | Instant dispatch                        | Instant dispatch (only one entry in bucket)                             |
+| `ok` / `Dump` (short bare fragment, no follow-up)                  | 1 row                 | Instant dispatch                        | Hold up to window, then dispatch (matches lead-in shape)                |
+| Single prose DM (`what's for dinner?`, `see you at 5pm tomorrow`)  | 1 row                 | Instant dispatch                        | Instant dispatch (has punctuation or >3 words)                          |
+| URL pasted alone                                                   | 1 row                 | Instant dispatch                        | Instant dispatch (no pending lead-in)                                   |
 | Text + URL sent as two deliberate separate messages, minutes apart | 2 rows outside window | Two turns                               | Two turns (window expires between them)                                 |
-| Rapid flood (>10 small DMs inside window)                          | N rows                | N turns                                 | One turn, bounded output (first + latest, text/attachment caps applied) |
+| Rapid flood of short bare fragments (`hi`, `ok`, `hmm`)            | N rows                | N turns                                 | One turn, bounded output (first + latest, text/attachment caps applied) |
+| Rapid flood of prose/questions inside window                       | N rows                | N turns                                 | N turns (each row dispatches instantly)                                 |
 | Two people typing in a group chat                                  | N rows from M senders | M+ turns (one per sender bucket)        | M+ turns — group chats are not coalesced                                |
 
 ## Catching up after gateway downtime

--- a/extensions/imessage/src/monitor.last-route.test.ts
+++ b/extensions/imessage/src/monitor.last-route.test.ts
@@ -87,6 +87,17 @@ vi.mock("openclaw/plugin-sdk/channel-inbound", async (importOriginal) => {
             await opts.onFlush(entries);
           };
         },
+        // Mirrors the prod debouncer's flushKey contract: drain whatever
+        // entries the mock is currently holding so the new `payload-join`
+        // path in monitor-provider.ts has a real method to await instead of
+        // throwing a swallowed TypeError.
+        flushKey: async (_key: string) => {
+          if (debouncerControl.entries.length === 0) {
+            return;
+          }
+          const entries = debouncerControl.entries.splice(0);
+          await opts.onFlush(entries);
+        },
       },
     })),
     shouldDebounceTextInbound: vi.fn(() => false),

--- a/extensions/imessage/src/monitor.media-policy.test.ts
+++ b/extensions/imessage/src/monitor.media-policy.test.ts
@@ -33,6 +33,7 @@ vi.mock("openclaw/plugin-sdk/channel-inbound", async (importOriginal) => {
     createChannelInboundDebouncer: vi.fn((opts) => ({
       debouncer: {
         enqueue: async (entry: unknown) => await opts.onFlush([entry]),
+        flushKey: async (_key: string) => {},
       },
     })),
     shouldDebounceTextInbound: vi.fn(() => false),

--- a/extensions/imessage/src/monitor.plugin-payload.test.ts
+++ b/extensions/imessage/src/monitor.plugin-payload.test.ts
@@ -24,6 +24,7 @@ vi.mock("openclaw/plugin-sdk/channel-inbound", async (importOriginal) => {
           enqueue: async (entry: unknown) => {
             opts.shouldDebounce(entry);
           },
+          flushKey: async (_key: string) => {},
         },
       }),
     ),

--- a/extensions/imessage/src/monitor/coalesce.test.ts
+++ b/extensions/imessage/src/monitor/coalesce.test.ts
@@ -2,6 +2,8 @@
 import { describe, expect, it } from "vitest";
 import {
   combineIMessagePayloads,
+  iMessageTextHasUrl,
+  isIMessageSplitLeadIn,
   MAX_COALESCED_ATTACHMENTS,
   MAX_COALESCED_ENTRIES,
   MAX_COALESCED_TEXT_CHARS,
@@ -158,5 +160,54 @@ describe("combineIMessagePayloads", () => {
 
   it("respects the documented entry cap value", () => {
     expect(MAX_COALESCED_ENTRIES).toBeGreaterThan(1);
+  });
+});
+
+describe("iMessageTextHasUrl", () => {
+  it("detects http and https URLs anywhere in the text", () => {
+    expect(iMessageTextHasUrl("https://stocks.apple.com/A16n5gO09T5y1YRM")).toBe(true);
+    expect(iMessageTextHasUrl("check this http://example.com out")).toBe(true);
+  });
+
+  it("returns false for plain text and empty input", () => {
+    expect(iMessageTextHasUrl("Dump")).toBe(false);
+    expect(iMessageTextHasUrl("look at this")).toBe(false);
+    expect(iMessageTextHasUrl("")).toBe(false);
+    expect(iMessageTextHasUrl(null)).toBe(false);
+    expect(iMessageTextHasUrl(undefined)).toBe(false);
+  });
+});
+
+describe("isIMessageSplitLeadIn", () => {
+  it("treats short bare command fragments as lead-ins", () => {
+    expect(isIMessageSplitLeadIn({ text: "Dump", hasMedia: false })).toBe(true);
+    expect(isIMessageSplitLeadIn({ text: "Save this", hasMedia: false })).toBe(true);
+    expect(isIMessageSplitLeadIn({ text: "look at", hasMedia: false })).toBe(true);
+  });
+
+  it("does not hold complete one-liners (terminal punctuation)", () => {
+    expect(isIMessageSplitLeadIn({ text: "what's for dinner?", hasMedia: false })).toBe(false);
+    expect(isIMessageSplitLeadIn({ text: "thanks.", hasMedia: false })).toBe(false);
+    expect(isIMessageSplitLeadIn({ text: "got it!", hasMedia: false })).toBe(false);
+  });
+
+  it("does not hold longer messages beyond the word cap", () => {
+    expect(isIMessageSplitLeadIn({ text: "can you look at this for me", hasMedia: false })).toBe(
+      false,
+    );
+  });
+
+  it("does not hold messages that already carry the payload", () => {
+    expect(isIMessageSplitLeadIn({ text: "Dump https://example.com", hasMedia: false })).toBe(
+      false,
+    );
+    expect(isIMessageSplitLeadIn({ text: "https://example.com", hasMedia: false })).toBe(false);
+    expect(isIMessageSplitLeadIn({ text: "Dump", hasMedia: true })).toBe(false);
+  });
+
+  it("does not hold empty or whitespace-only text", () => {
+    expect(isIMessageSplitLeadIn({ text: "", hasMedia: false })).toBe(false);
+    expect(isIMessageSplitLeadIn({ text: "   ", hasMedia: false })).toBe(false);
+    expect(isIMessageSplitLeadIn({ text: null, hasMedia: false })).toBe(false);
   });
 });

--- a/extensions/imessage/src/monitor/coalesce.ts
+++ b/extensions/imessage/src/monitor/coalesce.ts
@@ -17,6 +17,56 @@ export const MAX_COALESCED_TEXT_CHARS = 4000;
 export const MAX_COALESCED_ATTACHMENTS = 20;
 export const MAX_COALESCED_ENTRIES = 10;
 
+/**
+ * Longest text (in whitespace-delimited words) still treated as a split
+ * lead-in. Apple peels short command fragments — `Dump`, `Save this`,
+ * `look at` — off the front of a `<command> <payload>` send; anything longer
+ * reads as a self-contained message and dispatches instantly.
+ */
+export const LEAD_IN_MAX_WORDS = 3;
+
+const URL_PATTERN = /\bhttps?:\/\/\S+/i;
+
+/** True when the text carries an http(s) URL — the typical split-send payload. */
+export function iMessageTextHasUrl(text: string | null | undefined): boolean {
+  return URL_PATTERN.test(text ?? "");
+}
+
+/**
+ * A "split lead-in" is the short text fragment Apple delivers as its own
+ * `chat.db` row just before the payload row of a `<command> <URL/attachment>`
+ * send (e.g. `Dump` ahead of `https://…`, or a bare caption typed just before
+ * an image). It is the ONLY DM shape the monitor holds back to wait for a
+ * follow-up; every other shape dispatches instantly so normal conversation
+ * carries zero added latency.
+ *
+ * Heuristic: non-empty short text (≤ {@link LEAD_IN_MAX_WORDS} words), no URL,
+ * no media, and no terminal sentence punctuation. The dangling, unpunctuated
+ * shape is what separates a lead-in (`Dump`) from a complete one-liner
+ * (`what's for dinner?`). The cost of a false positive is bounded: a lone
+ * short fragment with no follow-up still flushes after the coalesce window.
+ */
+export function isIMessageSplitLeadIn(params: {
+  text: string | null | undefined;
+  hasMedia: boolean;
+}): boolean {
+  if (params.hasMedia) {
+    return false;
+  }
+  const text = (params.text ?? "").trim();
+  if (!text) {
+    return false;
+  }
+  if (iMessageTextHasUrl(text)) {
+    return false;
+  }
+  if (/[.?!…]$/.test(text)) {
+    return false;
+  }
+  const words = text.split(/\s+/).filter(Boolean);
+  return words.length >= 1 && words.length <= LEAD_IN_MAX_WORDS;
+}
+
 export type CoalescedIMessagePayload = IMessagePayload & {
   /**
    * Source GUIDs folded into this merged payload, in arrival order. Includes

--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -1127,7 +1127,14 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
     const dm = classifyDmCoalesce(repairedMessage) ?? undefined;
     if (dm?.mode === "lead-in") {
       // Remember this lead-in so the payload row that follows merges into it
-      // instead of dispatching on its own.
+      // instead of dispatching on its own. Ordering invariant: for an active
+      // chat (chat_id/chat_guid/chat_identifier already set), repair takes the
+      // synchronous early-return in `repairIMessageConversationAnchor`, so two
+      // notifications arriving in order resolve their awaits in the same order
+      // and the lead-in registers before the payload classifies. The narrow
+      // race — asymmetric RPC latency on an anchorless lead-in followed by an
+      // anchored payload — degrades to two separate turns (the same outcome
+      // as `coalesceSameSenderDms: false`), so it is not a contract regression.
       pendingLeadInKeys.add(dm.key);
     }
     await inboundDebouncer.enqueue({ message: repairedMessage, dm });

--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -66,7 +66,7 @@ import { normalizeIMessageHandle } from "../targets.js";
 import { attachIMessageMonitorAbortHandler } from "./abort-handler.js";
 import { runIMessageCatchup } from "./catchup-bridge.js";
 import { advanceIMessageCatchupCursor, resolveCatchupConfig } from "./catchup.js";
-import { combineIMessagePayloads } from "./coalesce.js";
+import { combineIMessagePayloads, iMessageTextHasUrl, isIMessageSplitLeadIn } from "./coalesce.js";
 import { repairIMessageConversationAnchor } from "./conversation-repair.js";
 import { createIMessageEchoCachingSend, deliverReplies } from "./deliver.js";
 import { resolveIMessageDmHistoryContext, resolveIMessageDmHistoryLimit } from "./dm-history.js";
@@ -346,11 +346,21 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
     ? await resolveIMessageStartupRowidWatermark(watchSourceDbPath)
     : null;
 
-  // When `coalesceSameSenderDms` is enabled and the user has not set an
-  // explicit inbound debounce for this channel, widen the window to 2500 ms.
-  // Apple's split-send for `<command> <URL>` arrives ~0.8-2.0 s apart on most
-  // setups, so the legacy 0 ms default would flush the command alone before
-  // the URL row reaches the debouncer.
+  // `coalesceSameSenderDms` merges Apple's split-send — a `<command> <URL>` or
+  // `<caption> <image>` send that arrives as two `chat.db` rows ~0.8-2.0 s
+  // apart — into one agent turn, WITHOUT taxing normal conversation. Rather
+  // than debounce every DM (which delayed every reply by the full window), the
+  // monitor classifies each DM:
+  //   - "lead-in"      — a short bare fragment (`Dump`) that plausibly precedes
+  //                      a payload. Held until the payload arrives or the window
+  //                      elapses.
+  //   - "payload-join" — a URL/attachment that completes a pending lead-in.
+  //                      Merged into the held lead-in and flushed immediately.
+  //   - "instant"      — everything else (prose, questions, lone URLs). Zero
+  //                      added latency.
+  // The window only bounds how long a lead-in waits for a follow-up, so it must
+  // still exceed Apple's max split gap; real split-sends flush as soon as the
+  // payload row lands.
   const coalesceSameSenderDms = imessageCfg.coalesceSameSenderDms === true;
   const inboundCfg = cfg.messages?.inbound;
   const hasExplicitInboundDebounce =
@@ -359,8 +369,59 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
   const debounceMsOverride =
     coalesceSameSenderDms && !hasExplicitInboundDebounce ? 2500 : undefined;
 
+  // Keys of DM lead-ins currently buffered, awaiting a payload follow-up. A
+  // payload that matches a pending key merges into the held lead-in instead of
+  // dispatching on its own.
+  const pendingLeadInKeys = new Set<string>();
+
+  const buildDmCoalesceKey = (msg: IMessagePayload): string | null => {
+    const sender = msg.sender?.trim();
+    if (!sender) {
+      return null;
+    }
+    const conversationId =
+      msg.chat_id != null
+        ? `chat:${msg.chat_id}`
+        : (msg.chat_guid ?? msg.chat_identifier ?? "unknown");
+    return `imessage:${accountInfo.accountId}:dm:${conversationId}:${sender}`;
+  };
+
+  type DmCoalesceMode = "lead-in" | "payload-join" | "instant";
+  type DmCoalesceDecision = { mode: DmCoalesceMode; key: string };
+
+  // Classify a DM for split-send coalescing. Returns null when coalescing does
+  // not apply (disabled, group chat, reaction, or a from-me echo), so the
+  // legacy/group path handles the message.
+  const classifyDmCoalesce = (msg: IMessagePayload): DmCoalesceDecision | null => {
+    if (!coalesceSameSenderDms || msg.is_group === true) {
+      return null;
+    }
+    if (msg.is_from_me === true) {
+      return null;
+    }
+    if (resolveIMessageReactionContext(msg, (msg.text ?? "").trim())) {
+      return null;
+    }
+    const key = buildDmCoalesceKey(msg);
+    if (!key) {
+      return null;
+    }
+    const hasMedia = Boolean(
+      msg.attachments?.some((attachment) => !isIMessagePluginPayloadAttachment(attachment)),
+    );
+    const isPayload = hasMedia || iMessageTextHasUrl(msg.text);
+    if (isPayload && pendingLeadInKeys.has(key)) {
+      return { mode: "payload-join", key };
+    }
+    if (isIMessageSplitLeadIn({ text: msg.text, hasMedia })) {
+      return { mode: "lead-in", key };
+    }
+    return { mode: "instant", key };
+  };
+
   const { debouncer: inboundDebouncer } = createChannelInboundDebouncer<{
     message: IMessagePayload;
+    dm?: DmCoalesceDecision;
   }>({
     cfg,
     channel: "imessage",
@@ -371,21 +432,17 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
       if (!sender) {
         return null;
       }
+      // DM coalesce path: key on chat:sender so a lead-in and its payload
+      // follow-up fall into the same bucket and merge into one agent turn.
+      if (entry.dm) {
+        return entry.dm.key;
+      }
+      // Group chats / coalesce-disabled use the legacy key so multi-user turn
+      // structure is preserved.
       const conversationId =
         msg.chat_id != null
           ? `chat:${msg.chat_id}`
           : (msg.chat_guid ?? msg.chat_identifier ?? "unknown");
-
-      // With coalesceSameSenderDms enabled, DMs key on chat:sender so two
-      // distinct user sends — `Dump` followed by a pasted URL that Apple
-      // delivers as a separate row — fall into the same bucket and merge
-      // into one agent turn. Group chats fall through to the legacy key so
-      // shouldDebounce can route them to the instant-dispatch path and
-      // preserve multi-user turn structure.
-      if (coalesceSameSenderDms && msg.is_group !== true) {
-        return `imessage:${accountInfo.accountId}:dm:${conversationId}:${sender}`;
-      }
-
       return `imessage:${accountInfo.accountId}:${conversationId}:${sender}`;
     },
     shouldDebounce: (entry) => {
@@ -397,16 +454,16 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
       if (msg.is_from_me === true) {
         return false;
       }
-
-      // With coalesceSameSenderDms enabled, debounce DM messages aggressively
-      // (text, media, control commands) so split-sends — `Dump <URL>`,
-      // `Save 📎image caption`, and rapid floods — merge into one agent
-      // turn. Group chats keep instant dispatch so the bot stays responsive
-      // when multiple people are typing.
-      if (coalesceSameSenderDms) {
-        return msg.is_group !== true;
+      // DM coalesce path: only hold lead-ins and the payloads that join them;
+      // everything else dispatches instantly.
+      if (entry.dm) {
+        return entry.dm.mode !== "instant";
       }
-
+      // Group chats keep instant dispatch when coalescing is enabled so the bot
+      // stays responsive when multiple people are typing.
+      if (coalesceSameSenderDms) {
+        return false;
+      }
       // Legacy gate: text-only, no control commands, no media.
       return shouldDebounceTextInbound({
         text: msg.text,
@@ -419,6 +476,13 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
     onFlush: async (entries) => {
       if (entries.length === 0) {
         return;
+      }
+      // A flushing bucket is no longer pending — clear any lead-in keys it held
+      // so a later payload is classified fresh.
+      for (const entry of entries) {
+        if (entry.dm) {
+          pendingLeadInKeys.delete(entry.dm.key);
+        }
       }
       if (entries.length === 1) {
         await handleMessageNow(entries[0].message);
@@ -433,6 +497,13 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
         logVerbose(`[imessage] coalesced ${entries.length} messages: "${preview}${ellipsis}"`);
       }
       await handleMessageNow(combined);
+    },
+    onCancel: (entries) => {
+      for (const entry of entries) {
+        if (entry.dm) {
+          pendingLeadInKeys.delete(entry.dm.key);
+        }
+      }
     },
     onError: (err) => {
       runtime.error?.(`imessage debounce flush failed: ${String(err)}`);
@@ -1053,7 +1124,18 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
     if (!repairedMessage) {
       return;
     }
-    await inboundDebouncer.enqueue({ message: repairedMessage });
+    const dm = classifyDmCoalesce(repairedMessage) ?? undefined;
+    if (dm?.mode === "lead-in") {
+      // Remember this lead-in so the payload row that follows merges into it
+      // instead of dispatching on its own.
+      pendingLeadInKeys.add(dm.key);
+    }
+    await inboundDebouncer.enqueue({ message: repairedMessage, dm });
+    if (dm?.mode === "payload-join") {
+      // The payload has merged into the buffered lead-in; flush now so the
+      // combined turn dispatches immediately rather than waiting out the window.
+      await inboundDebouncer.flushKey(dm.key);
+    }
   };
 
   await waitForTransportReady({


### PR DESCRIPTION
## Problem

`coalesceSameSenderDms` debounced **every** DM for the full window (2500ms) before replying, because the monitor couldn't know mid-stream whether a second bubble was coming. Two symptoms:

1. **Latency on every reply** — even a single normal message ("ok thanks") waited out the full debounce window before the agent began.
2. **Split-sends could still miss** — when Apple delivers `Dump <URL>` as two `chat.db` rows and the payload row arrives late (e.g. attachment-transfer lag pushing it past the window), the lead-in flushed alone → two turns → a stray "send me the URL" bubble.

## Fix

Classify each DM instead of holding all of them:

- **lead-in** — a short bare command-style fragment (`Dump`, `Save this`) that plausibly precedes a payload. Briefly held.
- **payload-join** — a URL/attachment that completes a pending lead-in. Merged into the held lead-in and flushed **immediately**.
- **instant** — everything else (prose, questions, lone URLs). Zero added latency.

Net effect: normal conversation replies instantly; real split-sends still coalesce into one agent turn and now flush as soon as the payload row lands rather than waiting out the window. The debounce window now only bounds how long a lone lead-in waits for a follow-up.

Group chats and the `coalesceSameSenderDms: false` path are unchanged.

## Implementation

- New pure helpers in `coalesce.ts`: `iMessageTextHasUrl` and `isIMessageSplitLeadIn` (heuristic: short, no URL, no media, no terminal punctuation), with unit tests.
- `monitor-provider.ts` classifies each DM (`classifyDmCoalesce`), tracks pending lead-in keys, tags the debouncer entry, and flushes the merged turn immediately on payload-join. The shared `inbound-debounce` flush-then-separate semantics are left untouched (intentional for control commands).

## Tests

- `coalesce.test.ts`: +7 cases covering URL detection and lead-in classification (bare commands, terminal punctuation, word-cap, payload-carrying, media, empty).
- Full iMessage monitor suite green (225 tests); extension typecheck + oxlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)