### PR TITLE
fix(codex): fail closed on missing native hook relay delivery

### DIFF
--- a/extensions/codex/src/app-server/app-server-policy.test.ts
+++ b/extensions/codex/src/app-server/app-server-policy.test.ts
@@ -32,6 +32,26 @@ describe("Codex app-server policy", () => {
     expect(resolved.approvalPolicy).toBe("untrusted");
   });
 
+  it("promotes implicit yolo approval policy when OpenClaw full exec policy still has tool policy", () => {
+    const appServer = resolveCodexAppServerRuntimeOptions({ env: {}, requirementsToml: null });
+
+    const resolved = resolveCodexAppServerForOpenClawToolPolicy({
+      appServer,
+      pluginConfig: readCodexPluginConfig({}),
+      env: {},
+      shouldPromote: true,
+      canUseUntrustedApprovalPolicy: true,
+      execPolicy: {
+        mode: "full",
+        security: "full",
+        ask: "off",
+        touched: true,
+      },
+    });
+
+    expect(resolved.approvalPolicy).toBe("untrusted");
+  });
+
   it("preserves explicit operator app-server policy", () => {
     const appServer = resolveCodexAppServerRuntimeOptions({ env: {}, requirementsToml: null });
     const requirementsAppServer = resolveCodexAppServerRuntimeOptions({

--- a/extensions/codex/src/app-server/app-server-policy.ts
+++ b/extensions/codex/src/app-server/app-server-policy.ts
@@ -28,7 +28,6 @@ export function resolveCodexAppServerForOpenClawToolPolicy(params: {
     return params.appServer;
   }
   const explicitMode =
-    params.execPolicy?.mode === "full" ||
     params.pluginConfig.appServer?.mode !== undefined ||
     isCodexAppServerPolicyMode(params.env.OPENCLAW_CODEX_APP_SERVER_MODE);
   const explicitApprovalPolicy =

--- a/extensions/codex/src/app-server/native-hook-relay.test.ts
+++ b/extensions/codex/src/app-server/native-hook-relay.test.ts
@@ -17,6 +17,20 @@ describe("Codex native hook relay config", () => {
 
     expect(config).toEqual({
       "features.hooks": true,
+      "hooks.SessionStart": [
+        {
+          hooks: [
+            {
+              type: "command",
+              command:
+                "openclaw hooks relay --provider codex --relay-id relay-1 --generation generation-1 --event session_start",
+              timeout: 7,
+              async: false,
+              statusMessage: "OpenClaw native hook relay",
+            },
+          ],
+        },
+      ],
       "hooks.PreToolUse": [
         {
           hooks: [
@@ -74,6 +88,14 @@ describe("Codex native hook relay config", () => {
         },
       ],
       "hooks.state": {
+        "/<session-flags>/config.toml:session_start:0:0": {
+          enabled: true,
+          trusted_hash: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
+        },
+        "<session-flags>/config.toml:session_start:0:0": {
+          enabled: true,
+          trusted_hash: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
+        },
         "/<session-flags>/config.toml:pre_tool_use:0:0": {
           enabled: true,
           trusted_hash: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
@@ -110,7 +132,6 @@ describe("Codex native hook relay config", () => {
     });
     expect(JSON.stringify(config)).not.toContain("timeoutSec");
     expect(JSON.stringify(config)).not.toContain('"matcher":null');
-    expect(config).not.toHaveProperty("hooks.SessionStart");
     expect(config).not.toHaveProperty("hooks.UserPromptSubmit");
   });
 
@@ -157,6 +178,20 @@ describe("Codex native hook relay config", () => {
       }),
     ).toEqual({
       "features.hooks": true,
+      "hooks.SessionStart": [
+        {
+          hooks: [
+            {
+              type: "command",
+              command:
+                "openclaw hooks relay --provider codex --relay-id relay-1 --generation generation-1 --event session_start",
+              timeout: 5,
+              async: false,
+              statusMessage: "OpenClaw native hook relay",
+            },
+          ],
+        },
+      ],
       "hooks.PreToolUse": [
         {
           hooks: [
@@ -174,6 +209,14 @@ describe("Codex native hook relay config", () => {
       "hooks.PostToolUse": [],
       "hooks.Stop": [],
       "hooks.state": {
+        "/<session-flags>/config.toml:session_start:0:0": {
+          enabled: true,
+          trusted_hash: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
+        },
+        "<session-flags>/config.toml:session_start:0:0": {
+          enabled: true,
+          trusted_hash: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
+        },
         "/<session-flags>/config.toml:pre_tool_use:0:0": {
           enabled: true,
           trusted_hash: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
@@ -186,7 +229,7 @@ describe("Codex native hook relay config", () => {
     });
   });
 
-  it("keeps selected no-policy PreToolUse installed with an unavailable no-op marker", () => {
+  it("keeps selected no-policy PreToolUse installed without an unavailable no-op marker", () => {
     expect(
       buildCodexNativeHookRelayConfig({
         relay: createRelay({ inactiveEvents: ["pre_tool_use"] }),
@@ -194,13 +237,27 @@ describe("Codex native hook relay config", () => {
       }),
     ).toEqual({
       "features.hooks": true,
+      "hooks.SessionStart": [
+        {
+          hooks: [
+            {
+              type: "command",
+              command:
+                "openclaw hooks relay --provider codex --relay-id relay-1 --generation generation-1 --event session_start",
+              timeout: 5,
+              async: false,
+              statusMessage: "OpenClaw native hook relay",
+            },
+          ],
+        },
+      ],
       "hooks.PreToolUse": [
         {
           hooks: [
             {
               type: "command",
               command:
-                "openclaw hooks relay --provider codex --relay-id relay-1 --generation generation-1 --event pre_tool_use --pre-tool-use-unavailable noop",
+                "openclaw hooks relay --provider codex --relay-id relay-1 --generation generation-1 --event pre_tool_use",
               timeout: 5,
               async: false,
               statusMessage: "OpenClaw native hook relay",
@@ -209,6 +266,14 @@ describe("Codex native hook relay config", () => {
         },
       ],
       "hooks.state": {
+        "/<session-flags>/config.toml:session_start:0:0": {
+          enabled: true,
+          trusted_hash: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
+        },
+        "<session-flags>/config.toml:session_start:0:0": {
+          enabled: true,
+          trusted_hash: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
+        },
         "/<session-flags>/config.toml:pre_tool_use:0:0": {
           enabled: true,
           trusted_hash: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
@@ -230,6 +295,7 @@ describe("Codex native hook relay config", () => {
       }),
     ).toEqual({
       "features.hooks": true,
+      "hooks.SessionStart": [],
       "hooks.PreToolUse": [],
       "hooks.PostToolUse": [],
       "hooks.PermissionRequest": [
@@ -248,6 +314,8 @@ describe("Codex native hook relay config", () => {
       ],
       "hooks.Stop": [],
       "hooks.state": {
+        "/<session-flags>/config.toml:session_start:0:0": { enabled: false },
+        "<session-flags>/config.toml:session_start:0:0": { enabled: false },
         "/<session-flags>/config.toml:pre_tool_use:0:0": { enabled: false },
         "<session-flags>/config.toml:pre_tool_use:0:0": { enabled: false },
         "/<session-flags>/config.toml:post_tool_use:0:0": { enabled: false },
@@ -283,6 +351,7 @@ describe("Codex native hook relay config", () => {
   it("builds deterministic clearing config when the relay is disabled", () => {
     expect(buildCodexNativeHookRelayDisabledConfig()).toEqual({
       "features.hooks": false,
+      "hooks.SessionStart": [],
       "hooks.PreToolUse": [],
       "hooks.PostToolUse": [],
       "hooks.PermissionRequest": [],
@@ -308,15 +377,17 @@ function createRelay(options?: {
     sessionId: "session-1",
     sessionKey: "agent:main:session-1",
     runId: "run-1",
-    allowedEvents: ["pre_tool_use", "post_tool_use", "permission_request", "before_agent_finalize"],
+    allowedEvents: [
+      "session_start",
+      "pre_tool_use",
+      "post_tool_use",
+      "permission_request",
+      "before_agent_finalize",
+    ],
     expiresAtMs: Date.now() + 1000,
     shouldRelayEvent: (event) => !inactiveEvents.has(event),
     commandForEvent: (event) =>
-      `openclaw hooks relay --provider codex --relay-id relay-1 --generation generation-1 --event ${event}${
-        event === "pre_tool_use" && inactiveEvents.has(event)
-          ? " --pre-tool-use-unavailable noop"
-          : ""
-      }`,
+      `openclaw hooks relay --provider codex --relay-id relay-1 --generation generation-1 --event ${event}`,
     renew: () => undefined,
     unregister: () => undefined,
   };

--- a/extensions/codex/src/app-server/native-hook-relay.ts
+++ b/extensions/codex/src/app-server/native-hook-relay.ts
@@ -5,6 +5,7 @@
 import { createHash } from "node:crypto";
 import {
   registerNativeHookRelay,
+  waitForNativeHookRelayEventInvocation,
   type EmbeddedRunAttemptParams,
   type NativeHookRelayEvent,
   type NativeHookRelayRegistrationHandle,
@@ -18,6 +19,7 @@ import type { JsonObject, JsonValue } from "./protocol.js";
 
 /** Codex hook events that can be registered through OpenClaw's native relay. */
 export const CODEX_NATIVE_HOOK_RELAY_EVENTS: readonly NativeHookRelayEvent[] = [
+  "session_start",
   "pre_tool_use",
   "post_tool_use",
   "permission_request",
@@ -29,10 +31,16 @@ const CODEX_NATIVE_HOOK_RELAY_EVENTS_WITH_APP_SERVER_APPROVALS =
 const CODEX_NATIVE_HOOK_RELAY_MIN_TTL_MS = 30 * 60_000;
 /** Extra relay lifetime after the expected turn budget, preventing late hook drops. */
 export const CODEX_NATIVE_HOOK_RELAY_TTL_GRACE_MS = 5 * 60_000;
+const CODEX_NATIVE_HOOK_RELAY_STARTUP_CANARY_TIMEOUT_MS = 1_000;
 const CODEX_NATIVE_HOOK_RELAY_UNREGISTER_GRACE_MS = 10_000;
 const CODEX_NATIVE_HOOK_RELAY_UNREGISTER_EXTRA_GRACE_MS = 5_000;
 
-type CodexHookEventName = "PreToolUse" | "PostToolUse" | "PermissionRequest" | "Stop";
+type CodexHookEventName =
+  | "SessionStart"
+  | "PreToolUse"
+  | "PostToolUse"
+  | "PermissionRequest"
+  | "Stop";
 
 type PendingCodexNativeHookRelayUnregister = {
   timeout: ReturnType<typeof setTimeout>;
@@ -127,6 +135,7 @@ export function createCodexNativeHookRelay(params: {
   if (params.options?.enabled === false) {
     return undefined;
   }
+  const events = withCodexNativeHookRelayStartupCanary(params.events);
   return registerNativeHookRelay({
     provider: "codex",
     relayId: buildCodexNativeHookRelayId({
@@ -144,7 +153,7 @@ export function createCodexNativeHookRelay(params: {
     ...(params.config ? { config: params.config } : {}),
     runId: params.runId,
     ...(params.channelId ? { channelId: params.channelId } : {}),
-    allowedEvents: params.events,
+    allowedEvents: events,
     ttlMs: resolveCodexNativeHookRelayTtlMs({
       explicitTtlMs: params.options?.ttlMs,
       attemptTimeoutMs: params.attemptTimeoutMs,
@@ -161,21 +170,76 @@ export function createCodexNativeHookRelay(params: {
   });
 }
 
+/** Verifies Codex invoked the native hook relay startup canary before OpenClaw activates a turn. */
+export async function assertCodexNativeHookRelayStartupCanary(params: {
+  relay: NativeHookRelayRegistrationHandle | undefined;
+  required: boolean;
+  signal: AbortSignal;
+}): Promise<void> {
+  if (!params.required) {
+    return;
+  }
+  const relay = params.relay;
+  if (!relay) {
+    throw new Error(
+      "OpenClaw tool policy requires Codex native hook relay delivery, but no relay was registered.",
+    );
+  }
+  if (!relay.generation) {
+    throw new Error(
+      "OpenClaw tool policy requires Codex native hook relay delivery, but the relay generation is unavailable.",
+    );
+  }
+  if (!relay.allowedEvents.includes("pre_tool_use")) {
+    throw new Error(
+      "OpenClaw tool policy requires Codex native PreToolUse delivery, but the relay is not allowed to receive PreToolUse.",
+    );
+  }
+  if (!relay.allowedEvents.includes("session_start")) {
+    throw new Error(
+      "OpenClaw tool policy requires Codex native PreToolUse delivery, but the relay startup canary is not configured.",
+    );
+  }
+  const observed = await waitForNativeHookRelayEventInvocation({
+    relayId: relay.relayId,
+    generation: relay.generation,
+    event: "session_start",
+    timeoutMs: CODEX_NATIVE_HOOK_RELAY_STARTUP_CANARY_TIMEOUT_MS,
+    signal: params.signal,
+  });
+  if (!observed) {
+    throw new Error(
+      "OpenClaw tool policy requires Codex native PreToolUse delivery, but Codex did not invoke the native hook relay startup canary.",
+    );
+  }
+}
+
 /** Selects the native hook events Codex should install for the current approval mode. */
 export function resolveCodexNativeHookRelayEvents(params: {
   configuredEvents?: readonly NativeHookRelayEvent[];
   appServer: Pick<CodexAppServerRuntimeOptions, "approvalPolicy">;
 }): readonly NativeHookRelayEvent[] {
   if (params.configuredEvents?.length) {
-    return params.configuredEvents;
+    return withCodexNativeHookRelayStartupCanary(params.configuredEvents);
   }
   // Codex emits PermissionRequest before the app-server approval reviewer has
   // resolved the command. In native approval modes, let Codex's app-server
   // approval bridge own the real escalation instead of surfacing a stale
   // pre-guardian OpenClaw plugin approval prompt.
-  return params.appServer.approvalPolicy === "never"
-    ? CODEX_NATIVE_HOOK_RELAY_EVENTS
-    : CODEX_NATIVE_HOOK_RELAY_EVENTS_WITH_APP_SERVER_APPROVALS;
+  return withCodexNativeHookRelayStartupCanary(
+    params.appServer.approvalPolicy === "never"
+      ? CODEX_NATIVE_HOOK_RELAY_EVENTS
+      : CODEX_NATIVE_HOOK_RELAY_EVENTS_WITH_APP_SERVER_APPROVALS,
+  );
+}
+
+export function withCodexNativeHookRelayStartupCanary(
+  events: readonly NativeHookRelayEvent[],
+): readonly NativeHookRelayEvent[] {
+  if (!events.includes("pre_tool_use") || events.includes("session_start")) {
+    return events;
+  }
+  return ["session_start", ...events];
 }
 
 /** Derives the native hook relay TTL from the turn budget unless explicitly configured. */
@@ -212,6 +276,7 @@ export function buildCodexNativeHookRelayId(params: {
 }
 
 const CODEX_HOOK_EVENT_BY_NATIVE_EVENT: Record<NativeHookRelayEvent, CodexHookEventName> = {
+  session_start: "SessionStart",
   pre_tool_use: "PreToolUse",
   post_tool_use: "PostToolUse",
   permission_request: "PermissionRequest",
@@ -219,6 +284,7 @@ const CODEX_HOOK_EVENT_BY_NATIVE_EVENT: Record<NativeHookRelayEvent, CodexHookEv
 };
 
 const CODEX_HOOK_KEY_LABEL_BY_NATIVE_EVENT: Record<NativeHookRelayEvent, string> = {
+  session_start: "session_start",
   pre_tool_use: "pre_tool_use",
   post_tool_use: "post_tool_use",
   permission_request: "permission_request",
@@ -237,7 +303,9 @@ export function buildCodexNativeHookRelayConfig(params: {
   hookTimeoutSec?: number;
   clearOmittedEvents?: boolean;
 }): JsonObject {
-  const events = params.events?.length ? params.events : CODEX_NATIVE_HOOK_RELAY_EVENTS;
+  const events = withCodexNativeHookRelayStartupCanary(
+    params.events?.length ? params.events : CODEX_NATIVE_HOOK_RELAY_EVENTS,
+  );
   const selectedEvents = new Set<NativeHookRelayEvent>(events);
   const config: JsonObject = {
     "features.hooks": true,
@@ -247,10 +315,10 @@ export function buildCodexNativeHookRelayConfig(params: {
     const codexEvent = CODEX_HOOK_EVENT_BY_NATIVE_EVENT[event];
     const selected = selectedEvents.has(event);
     const shouldRelay = params.relay.shouldRelayEvent(event);
-    // Keep no-policy PreToolUse commands installed with an explicit no-op marker;
-    // otherwise a stale relay fallback cannot distinguish no policy from unknown policy.
-    const selectedNoopPreToolUse = selected && event === "pre_tool_use" && !shouldRelay;
-    if (!selected || (!shouldRelay && !selectedNoopPreToolUse)) {
+    // Keep selected PreToolUse commands installed even before hook-only plugins
+    // have loaded; unavailable PreToolUse must still fail closed.
+    const selectedPreToolUse = selected && event === "pre_tool_use";
+    if (!selected || (!shouldRelay && !selectedPreToolUse)) {
       if (selected || params.clearOmittedEvents) {
         config[`hooks.${codexEvent}`] = [] satisfies JsonValue;
       }
@@ -300,6 +368,7 @@ export function buildCodexNativeHookRelayConfig(params: {
 export function buildCodexNativeHookRelayDisabledConfig(): JsonObject {
   return {
     "features.hooks": false,
+    "hooks.SessionStart": [],
     "hooks.PreToolUse": [],
     "hooks.PostToolUse": [],
     "hooks.PermissionRequest": [],

--- a/extensions/codex/src/app-server/run-attempt-test-harness.ts
+++ b/extensions/codex/src/app-server/run-attempt-test-harness.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import {
   abortAndDrainAgentHarnessRun,
+  invokeNativeHookRelay,
   nativeHookRelayTesting,
   queueAgentHarnessMessage,
   resetAgentEventsForTest,
@@ -394,10 +395,18 @@ export function createStartedThreadHarness(
   ) => Promise<unknown> = async () => undefined,
   options: {
     onStart?: (authProfileId: string | undefined, agentDir: string | undefined) => void;
+    skipNativeHookRelaySessionStart?: boolean;
   } = {},
 ) {
+  let threadConfigRequestParams: unknown;
   return createAppServerHarness(async (method, params, requestOptions) => {
     const override = await requestImpl(method, params, requestOptions);
+    if (method === "thread/start" || method === "thread/resume") {
+      threadConfigRequestParams = params;
+    }
+    if (method === "turn/start" && !options.skipNativeHookRelaySessionStart) {
+      await invokeNativeHookRelaySessionStartFromThreadRequest(threadConfigRequestParams);
+    }
     if (override !== undefined) {
       return override;
     }
@@ -412,11 +421,14 @@ export function createStartedThreadHarness(
 }
 
 export function createResumeHarness() {
-  return createAppServerHarness(async (method) => {
+  let threadConfigRequestParams: unknown;
+  return createAppServerHarness(async (method, params) => {
     if (method === "thread/resume") {
+      threadConfigRequestParams = params;
       return threadStartResult("thread-existing");
     }
     if (method === "turn/start") {
+      await invokeNativeHookRelaySessionStartFromThreadRequest(threadConfigRequestParams);
       return turnStartResult();
     }
     return {};
@@ -425,6 +437,9 @@ export function createResumeHarness() {
 
 export function extractRelayIdFromThreadRequest(params: unknown): string {
   const command = extractNativeHookRelayCommandFromThreadRequest(params);
+  if (!command) {
+    throw new Error("native hook relay command missing from thread request");
+  }
   const match = command.match(/--relay-id ([^ ]+)/);
   if (!match?.[1]) {
     throw new Error(`relay id missing from command: ${command}`);
@@ -434,6 +449,9 @@ export function extractRelayIdFromThreadRequest(params: unknown): string {
 
 export function extractGenerationFromThreadRequest(params: unknown): string {
   const command = extractNativeHookRelayCommandFromThreadRequest(params);
+  if (!command) {
+    throw new Error("native hook relay command missing from thread request");
+  }
   const match = command.match(/--generation ([^ ]+)/);
   if (!match?.[1]) {
     throw new Error(`relay generation missing from command: ${command}`);
@@ -441,15 +459,45 @@ export function extractGenerationFromThreadRequest(params: unknown): string {
   return match[1];
 }
 
-function extractNativeHookRelayCommandFromThreadRequest(params: unknown): string {
-  const config = (params as { config?: Record<string, unknown> }).config;
-  let command: string | undefined;
-  for (const key of [
+async function invokeNativeHookRelaySessionStartFromThreadRequest(params: unknown): Promise<void> {
+  const command = extractNativeHookRelayCommandFromThreadRequest(params, ["hooks.SessionStart"], {
+    optional: true,
+  });
+  if (!command) {
+    return;
+  }
+  const relayId = extractNativeHookRelayCommandField(command, "--relay-id", "relay id");
+  const generation = extractNativeHookRelayCommandField(
+    command,
+    "--generation",
+    "relay generation",
+  );
+  await invokeNativeHookRelay({
+    provider: "codex",
+    relayId,
+    generation,
+    event: "session_start",
+    rawPayload: {
+      hook_event_name: "SessionStart",
+    },
+    requireGeneration: true,
+  });
+}
+
+function extractNativeHookRelayCommandFromThreadRequest(
+  params: unknown,
+  hookKeys = [
+    "hooks.SessionStart",
     "hooks.PreToolUse",
     "hooks.PostToolUse",
     "hooks.PermissionRequest",
     "hooks.Stop",
-  ]) {
+  ],
+  options?: { optional?: boolean },
+): string | undefined {
+  const config = (params as { config?: Record<string, unknown> }).config;
+  let command: string | undefined;
+  for (const key of hookKeys) {
     const entries = config?.[key];
     if (!Array.isArray(entries)) {
       continue;
@@ -465,9 +513,20 @@ function extractNativeHookRelayCommandFromThreadRequest(params: unknown): string
     }
   }
   if (!command) {
+    if (options?.optional) {
+      return undefined;
+    }
     throw new Error("native hook relay command missing from thread request");
   }
   return command;
+}
+
+function extractNativeHookRelayCommandField(command: string, flag: string, label: string): string {
+  const match = command.match(new RegExp(`${flag} ([^ ]+)`));
+  if (!match?.[1]) {
+    throw new Error(`${label} missing from command: ${command}`);
+  }
+  return match[1];
 }
 
 type RuntimeDynamicToolForTest = Parameters<

--- a/extensions/codex/src/app-server/run-attempt.context-engine.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.context-engine.test.ts
@@ -9,6 +9,11 @@ import {
   type HarnessContextEngine as ContextEngine,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { SessionManager } from "openclaw/plugin-sdk/agent-sessions";
+import {
+  initializeGlobalHookRunner,
+  resetGlobalHookRunner,
+} from "openclaw/plugin-sdk/hook-runtime";
+import { createMockPluginRegistry } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { registerSandboxBackend } from "openclaw/plugin-sdk/sandbox";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { CodexAppServerClientFactory } from "./client-factory.js";
@@ -191,9 +196,10 @@ function createStartedThreadHarness(
 
   return {
     requests,
-    async waitForMethod(method: string) {
+    async waitForMethod(method: string, timeoutMs = 120_000) {
       await vi.waitFor(() => expect(requests.map((entry) => entry.method)).toContain(method), {
         interval: 1,
+        timeout: timeoutMs,
       });
     },
     async notify(notification: CodexServerNotification) {
@@ -311,6 +317,7 @@ describe("runCodexAppServerAttempt context-engine lifecycle", () => {
 
   afterEach(async () => {
     resetCodexAppServerClientFactoryForTest();
+    resetGlobalHookRunner();
     vi.restoreAllMocks();
     await fs.rm(tempDir, { recursive: true, force: true });
   });
@@ -1283,6 +1290,79 @@ describe("runCodexAppServerAttempt context-engine lifecycle", () => {
     expect(savedBinding?.threadId).toBe("thread-fresh");
     expect(savedBinding?.contextEngine?.engineId).toBe("lossless-claw");
     expect(savedBinding?.contextEngine?.projection).toBeUndefined();
+  });
+
+  it("requires the native hook relay startup canary after context-engine overflow retry", async () => {
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([{ hookName: "before_tool_call", handler: vi.fn() }]),
+    );
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    SessionManager.open(sessionFile).appendMessage(
+      assistantMessage("pre-compaction context", Date.now()) as never,
+    );
+    await writeCodexAppServerBinding(sessionFile, {
+      threadId: "thread-old",
+      cwd: workspaceDir,
+      dynamicToolsFingerprint: "[]",
+      contextEngine: {
+        schemaVersion: 1,
+        engineId: "lossless-claw",
+        policyFingerprint:
+          '{"schemaVersion":1,"engineId":"lossless-claw","ownsCompaction":true,"contextTokenBudget":400000,"projectionMaxChars":1000000}',
+        projection: {
+          schemaVersion: 1,
+          mode: "thread_bootstrap",
+          epoch: "epoch-before",
+        },
+      },
+    });
+    const contextEngine = createContextEngine({
+      assemble: vi.fn(async ({ messages, prompt }) => ({
+        messages: [...messages, userMessage(prompt ?? "", 11)],
+        estimatedTokens: 42,
+        systemPromptAddition: "context-engine system",
+        contextProjection: { mode: "thread_bootstrap", epoch: "epoch-before" },
+      })),
+    });
+    const harness = createStartedThreadHarness(async (method, requestParams) => {
+      const request = requireRecord(requestParams, `${method} params`);
+      if (method === "thread/resume") {
+        return threadStartResult("thread-old");
+      }
+      if (method === "turn/start" && request.threadId === "thread-old") {
+        throw new Error("Codex ran out of room in the model's context window");
+      }
+      if (method === "thread/start") {
+        return threadStartResult("thread-fresh");
+      }
+      if (method === "turn/start" && request.threadId === "thread-fresh") {
+        return turnStartResult("turn-fresh");
+      }
+      return undefined;
+    });
+    const params = createParams(sessionFile, workspaceDir);
+    params.contextEngine = contextEngine;
+    params.contextTokenBudget = 400_000;
+
+    await expect(
+      runCodexAppServerAttempt(params, {
+        nativeHookRelay: {
+          enabled: true,
+          events: ["pre_tool_use"],
+        },
+      }),
+    ).rejects.toThrow("Codex did not invoke the native hook relay startup canary");
+
+    expect(harness.requests.map((request) => request.method)).toEqual([
+      "thread/resume",
+      "turn/start",
+      "thread/start",
+      "turn/start",
+      "thread/unsubscribe",
+    ]);
+    const savedBinding = await readCodexAppServerBinding(sessionFile);
+    expect(savedBinding).toBeUndefined();
   });
 
   it("preserves a newer context-engine binding when a stale resumed thread overflows", async () => {

--- a/extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts
@@ -5,6 +5,8 @@ import {
   invokeNativeHookRelay,
   nativeHookRelayTesting,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
+import { initializeGlobalHookRunner } from "openclaw/plugin-sdk/hook-runtime";
+import { createMockPluginRegistry } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { describe, expect, it, vi } from "vitest";
 import * as approvalBridge from "./approval-bridge.js";
 import {
@@ -51,15 +53,74 @@ describe("runCodexAppServerAttempt native hook relay", () => {
     expect(preToolUseCommand?.type).toBe("command");
     expect(preToolUseCommand?.timeout).toBe(9);
     expect(preToolUseCommand?.command).toContain("--event pre_tool_use --timeout 4321");
+    const sessionStartHooks = startConfig?.["hooks.SessionStart"] as
+      | Array<{ hooks?: Array<{ command?: string; timeout?: number; type?: string }> }>
+      | undefined;
+    const sessionStartCommand = sessionStartHooks?.[0]?.hooks?.[0];
+    expect(sessionStartCommand?.type).toBe("command");
+    expect(sessionStartCommand?.timeout).toBe(9);
+    expect(sessionStartCommand?.command).toContain("--event session_start --timeout 4321");
     const hookState = startConfig?.["hooks.state"] as Record<
       string,
       { enabled?: unknown; trusted_hash?: unknown }
     >;
+    const sessionStartState = hookState?.["/<session-flags>/config.toml:session_start:0:0"];
+    expect(sessionStartState?.enabled).toBe(true);
+    expect(sessionStartState?.trusted_hash).toMatch(/^sha256:[a-f0-9]{64}$/);
     const preToolUseState = hookState?.["/<session-flags>/config.toml:pre_tool_use:0:0"];
     expect(preToolUseState?.enabled).toBe(true);
     expect(preToolUseState?.trusted_hash).toMatch(/^sha256:[a-f0-9]{64}$/);
     const relayId = extractRelayIdFromThreadRequest(startRequest?.params);
     expect(nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(relayId)).toBeDefined();
+    testing.flushPendingCodexNativeHookRelayUnregistersForTests();
+    expect(nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(relayId)).toBeUndefined();
+  });
+
+  it("fails closed after turn/start when tool policy is active but the startup canary is missing", async () => {
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([{ hookName: "before_tool_call", handler: vi.fn() }]),
+    );
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const harness = createStartedThreadHarness(undefined, {
+      skipNativeHookRelaySessionStart: true,
+    });
+
+    await expect(
+      runCodexAppServerAttempt(createParams(sessionFile, workspaceDir), {
+        nativeHookRelay: {
+          enabled: true,
+          events: ["pre_tool_use"],
+        },
+      }),
+    ).rejects.toThrow("Codex did not invoke the native hook relay startup canary");
+
+    expect(harness.requests.map((request) => request.method)).toContain("thread/start");
+    expect(harness.requests.map((request) => request.method)).toContain("turn/start");
+    const startRequest = harness.requests.find((request) => request.method === "thread/start");
+    const relayId = extractRelayIdFromThreadRequest(startRequest?.params);
+    expect(nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(relayId)).toBeUndefined();
+  });
+
+  it("does not require the startup canary when no tool policy is active", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const harness = createStartedThreadHarness(undefined, {
+      skipNativeHookRelaySessionStart: true,
+    });
+
+    const run = runCodexAppServerAttempt(createParams(sessionFile, workspaceDir), {
+      nativeHookRelay: {
+        enabled: true,
+        events: ["pre_tool_use"],
+      },
+    });
+    await harness.waitForMethod("turn/start");
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+
+    await expect(run).resolves.toBeDefined();
+    const startRequest = harness.requests.find((request) => request.method === "thread/start");
+    const relayId = extractRelayIdFromThreadRequest(startRequest?.params);
     testing.flushPendingCodexNativeHookRelayUnregistersForTests();
     expect(nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(relayId)).toBeUndefined();
   });
@@ -277,7 +338,7 @@ describe("runCodexAppServerAttempt native hook relay", () => {
     const relayId = extractRelayIdFromThreadRequest(startRequest?.params);
     expect(
       nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(relayId)?.allowedEvents,
-    ).toEqual(["pre_tool_use", "post_tool_use", "before_agent_finalize"]);
+    ).toEqual(["session_start", "pre_tool_use", "post_tool_use", "before_agent_finalize"]);
 
     await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
     await run;
@@ -425,7 +486,7 @@ describe("runCodexAppServerAttempt native hook relay", () => {
     const resumedRegistration =
       nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(firstRelayId);
     expect(resumedRegistration?.runId).toBe("run-2");
-    expect(resumedRegistration?.allowedEvents).toEqual(["pre_tool_use"]);
+    expect(resumedRegistration?.allowedEvents).toEqual(["session_start", "pre_tool_use"]);
 
     testing.flushPendingCodexNativeHookRelayUnregistersForTests();
     expect(nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(firstRelayId)?.runId).toBe(
@@ -689,6 +750,7 @@ describe("runCodexAppServerAttempt native hook relay", () => {
     const startConfig = (startRequest?.params as { config?: Record<string, unknown> } | undefined)
       ?.config;
     expect(startConfig?.["features.hooks"]).toBe(false);
+    expect(startConfig?.["hooks.SessionStart"]).toEqual([]);
     expect(startConfig?.["hooks.PreToolUse"]).toEqual([]);
     expect(startConfig?.["hooks.PostToolUse"]).toEqual([]);
     expect(startConfig?.["hooks.PermissionRequest"]).toEqual([]);

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -2760,7 +2760,7 @@ describe("runCodexAppServerAttempt", () => {
     expect(startParams?.sandbox).toBe("danger-full-access");
   });
 
-  it("keeps normalized full exec mode unpromoted when OpenClaw tool policy exists", async () => {
+  it("promotes normalized full exec mode when OpenClaw tool policy exists", async () => {
     initializeGlobalHookRunner(
       createMockPluginRegistry([{ hookName: "before_tool_call", handler: vi.fn() }]),
     );
@@ -2777,7 +2777,7 @@ describe("runCodexAppServerAttempt", () => {
 
     const startRequest = harness.requests.find((request) => request.method === "thread/start");
     const startParams = startRequest?.params as Record<string, unknown> | undefined;
-    expect(startParams?.approvalPolicy).toBe("never");
+    expect(startParams?.approvalPolicy).toBe("untrusted");
     expect(startParams?.sandbox).toBe("danger-full-access");
   });
 

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -175,6 +175,7 @@ import {
   shouldEmitTranscriptToolProgress,
 } from "./event-projector.js";
 import {
+  assertCodexNativeHookRelayStartupCanary,
   buildCodexNativeHookRelayDisabledConfig,
   buildCodexNativeHookRelayConfig,
   buildCodexNativeHookRelayId,
@@ -1873,6 +1874,25 @@ export async function runCodexAppServerAttempt(
     throwIfTurnStartAcceptedAfterAbort();
     return startedTurn;
   };
+  const nativeHookRelayStartupCanaryRequired =
+    nativeToolSurfaceEnabled &&
+    (beforeToolCallPolicy.hasBeforeToolCallHook ||
+      beforeToolCallPolicy.trustedToolPolicies.length > 0);
+  const startCodexTurnWithStartupCanary = async (): Promise<CodexTurnStartResponse> => {
+    const startedTurn = await startCodexTurn();
+    try {
+      await assertCodexNativeHookRelayStartupCanary({
+        relay: nativeHookRelay,
+        required: nativeHookRelayStartupCanaryRequired,
+        signal: runAbortController.signal,
+      });
+    } catch (error) {
+      runAbortController.abort(error);
+      await clearCodexAppServerBindingForThread(activeSessionFile, thread.threadId);
+      throw error;
+    }
+    return startedTurn;
+  };
   try {
     codexModelCallDiagnostics.emitStarted();
     runAgentHarnessLlmInputHook({
@@ -1884,7 +1904,7 @@ export async function runCodexAppServerAttempt(
       stream: "codex_app_server.lifecycle",
       data: { phase: "turn_starting", threadId: thread.threadId },
     });
-    turn = await startCodexTurn();
+    turn = await startCodexTurnWithStartupCanary();
   } catch (error) {
     let turnStartError = error;
     if (
@@ -1962,7 +1982,7 @@ export async function runCodexAppServerAttempt(
             data: { phase: "thread_ready_retry", threadId: thread.threadId },
           });
           try {
-            turn = await startCodexTurn();
+            turn = await startCodexTurnWithStartupCanary();
           } catch (retryError) {
             turnStartError = retryError;
           }

--- a/extensions/codex/src/app-server/side-question.test.ts
+++ b/extensions/codex/src/app-server/side-question.test.ts
@@ -1,5 +1,8 @@
 // Codex tests cover side question plugin behavior.
-import { nativeHookRelayTesting } from "openclaw/plugin-sdk/agent-harness-runtime";
+import {
+  invokeNativeHookRelay,
+  nativeHookRelayTesting,
+} from "openclaw/plugin-sdk/agent-harness-runtime";
 import {
   onInternalDiagnosticEvent,
   resetDiagnosticEventsForTest,
@@ -555,7 +558,12 @@ describe("runCodexAppServerSideQuestion", () => {
           sessionKey: "agent:main:session-1",
           runId: "run-side-1",
           channelId: "voice-room",
-          allowedEvents: ["pre_tool_use", "post_tool_use", "before_agent_finalize"],
+          allowedEvents: [
+            "session_start",
+            "pre_tool_use",
+            "post_tool_use",
+            "before_agent_finalize",
+          ],
         });
         return threadResult("side-thread");
       }
@@ -616,6 +624,170 @@ describe("runCodexAppServerSideQuestion", () => {
     expect(
       nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(relayIdDuringFork!),
     ).toBeUndefined();
+  });
+
+  it("does not require the side-thread startup canary when no tool policy is active", async () => {
+    const client = createFakeClient();
+    client.request.mockImplementation(async (method: string) => {
+      if (method === "thread/fork") {
+        return threadResult("side-thread");
+      }
+      if (method === "thread/inject_items") {
+        return {};
+      }
+      if (method === "turn/start") {
+        queueMicrotask(() => {
+          client.emit(agentDelta("side-thread", "turn-1", "Side answer."));
+          client.emit(turnCompleted("side-thread", "turn-1", "Side answer."));
+        });
+        return turnStartResult("turn-1");
+      }
+      if (method === "thread/unsubscribe" || method === "turn/interrupt") {
+        return {};
+      }
+      throw new Error(`unexpected request: ${method}`);
+    });
+    getSharedCodexAppServerClientMock.mockResolvedValue(client);
+
+    await expect(
+      runCodexAppServerSideQuestion(
+        sideParams({
+          sessionKey: "agent:main:session-1",
+          opts: { runId: "run-side-no-policy-canary-skip" },
+        }),
+        { nativeHookRelay: { enabled: true, events: ["pre_tool_use"] } },
+      ),
+    ).resolves.toEqual({ text: "Side answer." });
+  });
+
+  it("fails closed for opted-in side threads when tool policy is active but the startup canary is missing", async () => {
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([{ hookName: "before_tool_call", handler: vi.fn() }]),
+    );
+    const client = createFakeClient();
+    let relayIdDuringFork: string | undefined;
+    client.request.mockImplementation(async (method: string, requestParams: unknown) => {
+      if (method === "thread/fork") {
+        const config = (requestParams as { config?: Record<string, unknown> }).config;
+        relayIdDuringFork = extractRelayIdFromThreadConfig(config);
+        return threadResult("side-thread");
+      }
+      if (method === "thread/inject_items") {
+        return {};
+      }
+      if (method === "turn/start") {
+        return turnStartResult("turn-1");
+      }
+      if (method === "thread/unsubscribe" || method === "turn/interrupt") {
+        return {};
+      }
+      throw new Error(`unexpected request: ${method}`);
+    });
+    getSharedCodexAppServerClientMock.mockResolvedValue(client);
+
+    await expect(
+      runCodexAppServerSideQuestion(
+        sideParams({
+          sessionKey: "agent:main:session-1",
+          opts: { runId: "run-side-missing-canary" },
+        }),
+        { nativeHookRelay: { enabled: true, events: ["pre_tool_use"] } },
+      ),
+    ).rejects.toThrow("Codex did not invoke the native hook relay startup canary");
+
+    expect(client.request.mock.calls.map(([method]) => method)).toEqual([
+      "thread/fork",
+      "thread/inject_items",
+      "turn/start",
+      "turn/interrupt",
+      "thread/unsubscribe",
+    ]);
+    expect(relayIdDuringFork).toBeDefined();
+    expect(
+      nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(relayIdDuringFork!),
+    ).toBeUndefined();
+  });
+
+  it("fails closed for side threads when policy is active but native hook relay is disabled", async () => {
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([{ hookName: "before_tool_call", handler: vi.fn() }]),
+    );
+    const client = createFakeClient();
+    client.request.mockImplementation(async (method: string) => {
+      if (method === "thread/fork") {
+        return threadResult("side-thread");
+      }
+      if (method === "thread/inject_items") {
+        return {};
+      }
+      if (method === "turn/start") {
+        return turnStartResult("turn-1");
+      }
+      if (method === "thread/unsubscribe" || method === "turn/interrupt") {
+        return {};
+      }
+      throw new Error(`unexpected request: ${method}`);
+    });
+    getSharedCodexAppServerClientMock.mockResolvedValue(client);
+
+    await expect(
+      runCodexAppServerSideQuestion(
+        sideParams({
+          sessionKey: "agent:main:session-1",
+          opts: { runId: "run-side-relay-disabled" },
+        }),
+        { nativeHookRelay: { enabled: false } },
+      ),
+    ).rejects.toThrow("no relay was registered");
+
+    expect(client.request.mock.calls.map(([method]) => method)).toEqual([
+      "thread/fork",
+      "thread/inject_items",
+      "turn/start",
+      "turn/interrupt",
+      "thread/unsubscribe",
+    ]);
+  });
+
+  it("fails closed for side threads when policy is active but PreToolUse relay is omitted", async () => {
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([{ hookName: "before_tool_call", handler: vi.fn() }]),
+    );
+    const client = createFakeClient();
+    client.request.mockImplementation(async (method: string) => {
+      if (method === "thread/fork") {
+        return threadResult("side-thread");
+      }
+      if (method === "thread/inject_items") {
+        return {};
+      }
+      if (method === "turn/start") {
+        return turnStartResult("turn-1");
+      }
+      if (method === "thread/unsubscribe" || method === "turn/interrupt") {
+        return {};
+      }
+      throw new Error(`unexpected request: ${method}`);
+    });
+    getSharedCodexAppServerClientMock.mockResolvedValue(client);
+
+    await expect(
+      runCodexAppServerSideQuestion(
+        sideParams({
+          sessionKey: "agent:main:session-1",
+          opts: { runId: "run-side-pretooluse-omitted" },
+        }),
+        { nativeHookRelay: { enabled: true, events: ["permission_request"] } },
+      ),
+    ).rejects.toThrow("not allowed to receive PreToolUse");
+
+    expect(client.request.mock.calls.map(([method]) => method)).toEqual([
+      "thread/fork",
+      "thread/inject_items",
+      "turn/start",
+      "turn/interrupt",
+      "thread/unsubscribe",
+    ]);
   });
 
   it("forwards side-thread command approvals through the active native hook relay", async () => {
@@ -1051,14 +1223,30 @@ describe("runCodexAppServerSideQuestion", () => {
       createMockPluginRegistry([{ hookName: "before_tool_call", handler: beforeToolCall }]),
     );
     const client = createFakeClient();
-    client.request.mockImplementation(async (method: string) => {
+    let relayIdDuringFork: string | undefined;
+    client.request.mockImplementation(async (method: string, requestParams: unknown) => {
       if (method === "thread/fork") {
+        const config = (requestParams as { config?: Record<string, unknown> }).config;
+        relayIdDuringFork = extractRelayIdFromThreadConfig(config);
         return threadResult("side-thread");
       }
       if (method === "thread/inject_items") {
         return {};
       }
       if (method === "turn/start") {
+        const registration =
+          nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(relayIdDuringFork);
+        if (!registration) {
+          throw new Error("Expected native hook relay registration");
+        }
+        await invokeNativeHookRelay({
+          provider: "codex",
+          relayId: registration.relayId,
+          generation: registration.generation,
+          event: "session_start",
+          rawPayload: { hook_event_name: "SessionStart" },
+          requireGeneration: true,
+        });
         setTimeout(() => {
           void (async () => {
             await client.handleRequest({
@@ -1092,6 +1280,7 @@ describe("runCodexAppServerSideQuestion", () => {
           messageProvider: "discord-voice",
           currentChannelId: "discord:voice-room",
         }),
+        { nativeHookRelay: { enabled: true } },
       ),
     ).resolves.toEqual({ text: "Tool answer." });
 

--- a/extensions/codex/src/app-server/side-question.ts
+++ b/extensions/codex/src/app-server/side-question.ts
@@ -3,6 +3,7 @@ import {
   buildAgentHookContextChannelFields,
   embeddedAgentLog,
   formatErrorMessage,
+  getBeforeToolCallPolicyDiagnosticState,
   resolveAgentDir,
   resolveAttemptSpawnWorkspaceDir,
   resolveModelAuthMode,
@@ -38,9 +39,11 @@ import {
 import { createCodexDynamicToolBridge, type CodexDynamicToolBridge } from "./dynamic-tools.js";
 import { handleCodexAppServerElicitationRequest } from "./elicitation-bridge.js";
 import {
+  assertCodexNativeHookRelayStartupCanary,
   buildCodexNativeHookRelayConfig,
   buildCodexNativeHookRelayDisabledConfig,
   CODEX_NATIVE_HOOK_RELAY_EVENTS,
+  withCodexNativeHookRelayStartupCanary,
 } from "./native-hook-relay.js";
 import {
   readCodexNotificationThreadId,
@@ -170,6 +173,7 @@ export async function runCodexAppServerSideQuestion(
   }
   let childThreadId: string | undefined;
   let turnId: string | undefined;
+  let cleanupTurnId: string | undefined;
   let removeRequestHandler: (() => void) | undefined;
   let nativeHookRelay: NativeHookRelayRegistrationHandle | undefined;
 
@@ -190,6 +194,13 @@ export async function runCodexAppServerSideQuestion(
       sessionAgentId,
       signal: runAbortController.signal,
     });
+    const beforeToolCallPolicy = getBeforeToolCallPolicyDiagnosticState();
+    const nativeToolSurfaceEnabled =
+      binding.nativeCodeModeEnabled !== false || binding.userMcpServersEnabled !== false;
+    const nativeHookRelayStartupCanaryRequired =
+      nativeToolSurfaceEnabled &&
+      (beforeToolCallPolicy.hasBeforeToolCallHook ||
+        beforeToolCallPolicy.trustedToolPolicies.length > 0);
     removeRequestHandler = client.addRequestHandler(async (request) => {
       if (request.method === "account/chatgptAuthTokens/refresh") {
         return (await refreshCodexAppServerAuthTokens({
@@ -377,7 +388,18 @@ export async function runCodexAppServerSideQuestion(
         { timeoutMs: appServer.requestTimeoutMs, signal: params.opts?.abortSignal },
       ),
     );
-    turnId = turnResponse.turn.id;
+    cleanupTurnId = turnResponse.turn.id;
+    try {
+      await assertCodexNativeHookRelayStartupCanary({
+        relay: nativeHookRelay,
+        required: nativeHookRelayStartupCanaryRequired,
+        signal: runAbortController.signal,
+      });
+    } catch (error) {
+      runAbortController.abort(error);
+      throw error;
+    }
+    turnId = cleanupTurnId;
     collector.setTurn(childThreadId, turnId);
 
     const text = await collector.wait({
@@ -402,7 +424,7 @@ export async function runCodexAppServerSideQuestion(
       removeRequestHandler?.();
       await cleanupCodexSideThread(client, {
         threadId: childThreadId,
-        turnId,
+        turnId: turnId ?? cleanupTurnId,
         interrupt: !collector.completed,
         timeoutMs: appServer.requestTimeoutMs,
       });
@@ -418,11 +440,13 @@ function resolveCodexSideNativeHookRelayEvents(params: {
   approvalPolicy: CodexAppServerRuntimeOptions["approvalPolicy"];
 }): readonly NativeHookRelayEvent[] {
   if (params.configuredEvents?.length) {
-    return params.configuredEvents;
+    return withCodexNativeHookRelayStartupCanary(params.configuredEvents);
   }
-  return params.approvalPolicy === "never"
-    ? CODEX_NATIVE_HOOK_RELAY_EVENTS
-    : CODEX_SIDE_NATIVE_HOOK_RELAY_EVENTS_WITH_APP_SERVER_APPROVALS;
+  return withCodexNativeHookRelayStartupCanary(
+    params.approvalPolicy === "never"
+      ? CODEX_NATIVE_HOOK_RELAY_EVENTS
+      : CODEX_SIDE_NATIVE_HOOK_RELAY_EVENTS_WITH_APP_SERVER_APPROVALS,
+  );
 }
 
 function registerCodexSideNativeHookRelay(params: {
@@ -445,6 +469,7 @@ function registerCodexSideNativeHookRelay(params: {
   if (params.options.enabled === false) {
     return undefined;
   }
+  const events = withCodexNativeHookRelayStartupCanary(params.events);
   return registerNativeHookRelay({
     provider: "codex",
     ...(params.agentId ? { agentId: params.agentId } : {}),
@@ -453,7 +478,7 @@ function registerCodexSideNativeHookRelay(params: {
     ...(params.config ? { config: params.config } : {}),
     runId: params.runId,
     ...(params.channelId ? { channelId: params.channelId } : {}),
-    allowedEvents: params.events,
+    allowedEvents: events,
     ttlMs: resolveCodexSideNativeHookRelayTtlMs({
       explicitTtlMs: params.options.ttlMs,
       requestTimeoutMs: params.requestTimeoutMs,

--- a/src/agents/harness/native-hook-relay.test.ts
+++ b/src/agents/harness/native-hook-relay.test.ts
@@ -18,11 +18,13 @@ import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import {
   testing,
   buildNativeHookRelayCommand,
+  hasNativeHookRelayEventInvocation,
   hasNativeHookRelayInvocation,
   invokeNativeHookRelay,
   invokeNativeHookRelayBridge,
   registerNativeHookRelay,
   resolveNativeHookRelayDeferredToolApproval,
+  waitForNativeHookRelayEventInvocation,
 } from "./native-hook-relay.js";
 
 afterEach(() => {
@@ -302,6 +304,83 @@ describe("native hook relay registry", () => {
     });
   });
 
+  it("records generation-scoped session_start canary invocations", async () => {
+    const relay = registerNativeHookRelay({
+      provider: "codex",
+      relayId: "codex-session-start-canary",
+      generation: "generation-current",
+      sessionId: "session-1",
+      runId: "run-1",
+      allowedEvents: ["session_start"],
+    });
+
+    const response = await invokeNativeHookRelay({
+      provider: "codex",
+      relayId: relay.relayId,
+      generation: relay.generation,
+      event: "session_start",
+      rawPayload: {
+        hook_event_name: "SessionStart",
+      },
+      requireGeneration: true,
+    });
+
+    expect(response).toEqual({ stdout: "", stderr: "", exitCode: 0 });
+    expect(
+      hasNativeHookRelayEventInvocation({ relayId: relay.relayId, event: "session_start" }),
+    ).toBe(true);
+    expect(
+      hasNativeHookRelayEventInvocation({
+        relayId: relay.relayId,
+        generation: relay.generation,
+        event: "session_start",
+      }),
+    ).toBe(true);
+    expect(
+      hasNativeHookRelayEventInvocation({
+        relayId: relay.relayId,
+        generation: "generation-stale",
+        event: "session_start",
+      }),
+    ).toBe(false);
+    await expect(
+      waitForNativeHookRelayEventInvocation({
+        relayId: relay.relayId,
+        generation: relay.generation,
+        event: "session_start",
+        timeoutMs: 1,
+      }),
+    ).resolves.toBe(true);
+  });
+
+  it("records registration generation for direct invocations without caller generation", async () => {
+    const relay = registerNativeHookRelay({
+      provider: "codex",
+      relayId: "codex-direct-generation-source",
+      generation: "generation-current",
+      sessionId: "session-1",
+      runId: "run-1",
+      allowedEvents: ["session_start"],
+    });
+
+    await invokeNativeHookRelay({
+      provider: "codex",
+      relayId: relay.relayId,
+      event: "session_start",
+      rawPayload: {
+        hook_event_name: "SessionStart",
+      },
+    });
+
+    expect(
+      hasNativeHookRelayEventInvocation({
+        relayId: relay.relayId,
+        generation: relay.generation,
+        event: "session_start",
+      }),
+    ).toBe(true);
+  });
+
   it("stores permission approval state in process-global state", async () => {
     const relay = registerNativeHookRelay({
       provider: "codex",
@@ -534,7 +613,7 @@ describe("native hook relay registry", () => {
     expect(relay.shouldRelayEvent("permission_request")).toBe(true);
     expect(relay.commandForEvent("pre_tool_use")).toBe(
       "/usr/local/bin/node '/opt/Open Claw/openclaw.mjs' hooks relay --provider codex --relay-id " +
-        `${relay.relayId} --generation ${relay.generation} --event pre_tool_use --pre-tool-use-unavailable noop --timeout 1234`,
+        `${relay.relayId} --generation ${relay.generation} --event pre_tool_use --timeout 1234`,
     );
   });
 
@@ -896,6 +975,7 @@ describe("native hook relay registry", () => {
     expect(getOnlyNativeHookRelayInvocation()).toMatchObject({
       relayId: relay.relayId,
       runId: "run-1",
+      generation: relay.generation,
       event: "pre_tool_use",
     });
 
@@ -913,6 +993,45 @@ describe("native hook relay registry", () => {
         },
       }),
     ).rejects.toThrow("native hook relay bridge stale registration");
+  });
+
+  it("counts accepted bootstrap generation mismatches toward session_start canaries", async () => {
+    const relay = registerNativeHookRelay({
+      provider: "codex",
+      relayId: "codex-bootstrap-stale-session-start-generation",
+      sessionId: "session-1",
+      runId: "run-1",
+      allowedEvents: ["session_start"],
+      generationMismatchGraceMs: 60_000,
+    });
+
+    await expect(
+      invokeNativeHookRelayBridge({
+        provider: "codex",
+        relayId: relay.relayId,
+        generation: "stale-generation-from-resumed-thread",
+        event: "session_start",
+        timeoutMs: 2_000,
+        rawPayload: {
+          hook_event_name: "SessionStart",
+        },
+      }),
+    ).resolves.toEqual({ stdout: "", stderr: "", exitCode: 0 });
+
+    expect(
+      hasNativeHookRelayEventInvocation({
+        relayId: relay.relayId,
+        generation: relay.generation,
+        event: "session_start",
+      }),
+    ).toBe(true);
+    expect(
+      hasNativeHookRelayEventInvocation({
+        relayId: relay.relayId,
+        generation: "stale-generation-from-resumed-thread",
+        event: "session_start",
+      }),
+    ).toBe(false);
   });
 
   it("rejects bootstrap generation mismatches after the grace window", async () => {
@@ -3208,18 +3327,17 @@ describe("native hook relay command builder", () => {
     );
   });
 
-  it("includes explicit unavailable noop mode only for PreToolUse", () => {
+  it("uses the Codex PreToolUse hook relay command shape without an unavailable no-op marker", () => {
     expect(
       buildNativeHookRelayCommand({
         provider: "codex",
         relayId: "relay-1",
         generation: "generation-1",
         event: "pre_tool_use",
-        preToolUseUnavailable: "noop",
         executable: "openclaw",
       }),
     ).toBe(
-      "openclaw hooks relay --provider codex --relay-id relay-1 --generation generation-1 --event pre_tool_use --pre-tool-use-unavailable noop --timeout 5000",
+      "openclaw hooks relay --provider codex --relay-id relay-1 --generation generation-1 --event pre_tool_use --timeout 5000",
     );
   });
 });

--- a/src/agents/harness/native-hook-relay.ts
+++ b/src/agents/harness/native-hook-relay.ts
@@ -53,6 +53,7 @@ export type JsonValue =
   | { [key: string]: JsonValue };
 
 const NATIVE_HOOK_RELAY_EVENTS = [
+  "session_start",
   "pre_tool_use",
   "post_tool_use",
   "permission_request",
@@ -67,6 +68,7 @@ export type NativeHookRelayProvider = (typeof NATIVE_HOOK_RELAY_PROVIDERS)[numbe
 export type NativeHookRelayInvocation = {
   provider: NativeHookRelayProvider;
   relayId: string;
+  generation?: string;
   event: NativeHookRelayEvent;
   nativeEventName?: string;
   agentId?: string;
@@ -442,10 +444,6 @@ export function registerNativeHookRelay(
         relayId,
         generation: registration.generation,
         event,
-        preToolUseUnavailable:
-          event === "pre_tool_use" && !nativeHookRelayEventHasLocalWork(registration, event)
-            ? "noop"
-            : undefined,
         nice: params.command?.nice,
         timeoutMs: params.command?.timeoutMs,
         executable: params.command?.executable,
@@ -524,7 +522,6 @@ export function buildNativeHookRelayCommand(params: {
   relayId: string;
   generation?: string;
   event: NativeHookRelayEvent;
-  preToolUseUnavailable?: "noop";
   timeoutMs?: number;
   executable?: string;
   nice?: number | false;
@@ -549,9 +546,6 @@ export function buildNativeHookRelayCommand(params: {
     ...(params.generation ? ["--generation", params.generation] : []),
     "--event",
     params.event,
-    ...(params.event === "pre_tool_use" && params.preToolUseUnavailable
-      ? ["--pre-tool-use-unavailable", params.preToolUseUnavailable]
-      : []),
     "--timeout",
     String(timeoutMs),
   ]);
@@ -604,6 +598,7 @@ export async function invokeNativeHookRelay(
   if (registration.provider !== provider) {
     throw new Error("native hook relay provider mismatch");
   }
+  let acceptedGeneration: string | undefined;
   if (params.requireGeneration) {
     const generation = readNonEmptyString(params.generation, "generation");
     if (generation !== registration.generation) {
@@ -616,6 +611,7 @@ export async function invokeNativeHookRelay(
         runId: registration.runId,
       });
     }
+    acceptedGeneration = registration.generation;
   }
   if (!registration.allowedEvents.includes(event)) {
     throw new Error("native hook relay event not allowed");
@@ -626,6 +622,7 @@ export async function invokeNativeHookRelay(
 
   const normalized = normalizeNativeHookInvocation({
     registration,
+    generation: acceptedGeneration ?? registration.generation,
     event,
     rawPayload: params.rawPayload,
   });
@@ -639,6 +636,7 @@ export async function invokeNativeHookRelay(
 
 export function hasNativeHookRelayInvocation(params: {
   relayId: string;
+  generation?: string;
   event: NativeHookRelayEvent;
   toolUseId?: string;
 }): boolean {
@@ -646,11 +644,52 @@ export function hasNativeHookRelayInvocation(params: {
   if (!toolUseId) {
     return false;
   }
+  return hasNativeHookRelayInvocationMatching(params);
+}
+
+export function hasNativeHookRelayEventInvocation(params: {
+  relayId: string;
+  generation?: string;
+  event: NativeHookRelayEvent;
+}): boolean {
+  return hasNativeHookRelayInvocationMatching(params);
+}
+
+export async function waitForNativeHookRelayEventInvocation(params: {
+  relayId: string;
+  generation?: string;
+  event: NativeHookRelayEvent;
+  timeoutMs?: number;
+  signal?: AbortSignal;
+}): Promise<boolean> {
+  const timeoutMs = normalizePositiveInteger(params.timeoutMs, 1_000);
+  const expiresAtMs = Date.now() + timeoutMs;
+  while (Date.now() <= expiresAtMs) {
+    if (params.signal?.aborted) {
+      throw new Error("native hook relay invocation wait aborted");
+    }
+    if (hasNativeHookRelayEventInvocation(params)) {
+      return true;
+    }
+    await delay(Math.min(25, Math.max(0, expiresAtMs - Date.now())));
+  }
+  return hasNativeHookRelayEventInvocation(params);
+}
+
+function hasNativeHookRelayInvocationMatching(params: {
+  relayId: string;
+  generation?: string;
+  event: NativeHookRelayEvent;
+  toolUseId?: string;
+}): boolean {
+  const generation = params.generation?.trim();
+  const toolUseId = params.toolUseId?.trim();
   return invocations.some(
     (invocation) =>
       invocation.relayId === params.relayId &&
+      (!generation || invocation.generation === generation) &&
       invocation.event === params.event &&
-      invocation.toolUseId === toolUseId,
+      (!toolUseId || invocation.toolUseId === toolUseId),
   );
 }
 
@@ -763,7 +802,6 @@ export async function invokeNativeHookRelayBridge(
 export function renderNativeHookRelayUnavailableResponse(params: {
   provider: unknown;
   event: unknown;
-  preToolUseUnavailable?: unknown;
   message?: string;
 }): NativeHookRelayProcessResponse {
   const provider = readNativeHookRelayProvider(params.provider);
@@ -772,12 +810,11 @@ export function renderNativeHookRelayUnavailableResponse(params: {
   const message = params.message?.trim() || "Native hook relay unavailable";
   if (event === "pre_tool_use") {
     // The standalone CLI cannot reconstruct the originating registration after
-    // relay lookup fails, so unavailable PreToolUse must fail closed unless the
-    // generated command explicitly recorded that no before-tool policy existed.
-    if (params.preToolUseUnavailable === "noop") {
-      return adapter.renderNoopResponse(event);
-    }
+    // relay lookup fails, so unavailable PreToolUse must fail closed.
     return adapter.renderPreToolUseBlockResponse(message);
+  }
+  if (event === "session_start") {
+    return adapter.renderBeforeAgentFinalizeStopResponse(message);
   }
   if (event === "permission_request") {
     return adapter.renderPermissionDecisionResponse("deny", message);
@@ -1347,6 +1384,9 @@ async function processNativeHookRelayInvocation(params: {
   if (params.invocation.event === "pre_tool_use") {
     return runNativeHookRelayPreToolUse(params);
   }
+  if (params.invocation.event === "session_start") {
+    return params.adapter.renderNoopResponse(params.invocation.event);
+  }
   if (params.invocation.event === "post_tool_use") {
     return runNativeHookRelayPostToolUse(params);
   }
@@ -1819,6 +1859,7 @@ function snapshotString(value: string, state: { remainingStringLength: number })
 
 function normalizeNativeHookInvocation(params: {
   registration: NativeHookRelayRegistration;
+  generation?: string;
   event: NativeHookRelayEvent;
   rawPayload: JsonValue;
 }): NativeHookRelayInvocation {
@@ -1828,6 +1869,7 @@ function normalizeNativeHookInvocation(params: {
   return {
     provider: params.registration.provider,
     relayId: params.registration.relayId,
+    ...(params.generation ? { generation: params.generation } : {}),
     event: params.event,
     ...metadata,
     ...(params.registration.agentId ? { agentId: params.registration.agentId } : {}),
@@ -2180,6 +2222,7 @@ function readNativeHookRelayProvider(value: unknown): NativeHookRelayProvider {
 
 function readNativeHookRelayEvent(value: unknown): NativeHookRelayEvent {
   if (
+    value === "session_start" ||
     value === "pre_tool_use" ||
     value === "post_tool_use" ||
     value === "permission_request" ||

--- a/src/cli/hooks-cli.ts
+++ b/src/cli/hooks-cli.ts
@@ -534,7 +534,7 @@ export function registerHooksCli(program: Command): void {
     .requiredOption("--event <event>", "Native hook event")
     .option(
       "--pre-tool-use-unavailable <mode>",
-      "PreToolUse fallback mode when the originating relay is unavailable",
+      "Deprecated compatibility flag; unavailable PreToolUse always fails closed",
     )
     .option("--timeout <ms>", "Gateway timeout in ms", "5000")
     .action(async (opts: NativeHookRelayCliOptions) =>

--- a/src/cli/native-hook-relay-cli.test.ts
+++ b/src/cli/native-hook-relay-cli.test.ts
@@ -201,6 +201,13 @@ describe("native hook relay CLI", () => {
       },
     },
     {
+      event: "session_start",
+      stdout: {
+        continue: false,
+        stopReason: "Native hook relay unavailable",
+      },
+    },
+    {
       event: "post_tool_use",
       stdout: null,
     },
@@ -306,7 +313,7 @@ describe("native hook relay CLI", () => {
     expect(stderr.text()).toContain("native hook relay unavailable");
   });
 
-  it("keeps PreToolUse unavailable handling observational only with an explicit no-policy marker", async () => {
+  it("ignores the legacy PreToolUse no-policy marker and fails closed", async () => {
     const callGateway = vi.fn(async () => {
       throw new Error("gateway closed");
     });
@@ -330,7 +337,13 @@ describe("native hook relay CLI", () => {
     );
 
     expect(exitCode).toBe(0);
-    expect(stdout.text()).toBe("");
+    expect(JSON.parse(stdout.text())).toEqual({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: "Native hook relay unavailable",
+      },
+    });
     expect(stderr.text()).toContain("native hook relay unavailable");
   });
 

--- a/src/cli/native-hook-relay-cli.ts
+++ b/src/cli/native-hook-relay-cli.ts
@@ -18,6 +18,7 @@ export type NativeHookRelayCliOptions = {
   relayId?: string;
   generation?: string;
   event?: string;
+  /** Deprecated compatibility flag; unavailable PreToolUse always fails closed. */
   preToolUseUnavailable?: string;
   timeout?: string;
 };
@@ -80,7 +81,6 @@ export async function runNativeHookRelayCli(
       const response = renderNativeHookRelayUnavailableResponse({
         provider,
         event,
-        preToolUseUnavailable: opts.preToolUseUnavailable,
         message: "Native hook relay unavailable",
       });
       writeText(stdout, response.stdout);
@@ -106,7 +106,6 @@ export async function runNativeHookRelayCli(
     const response = renderNativeHookRelayUnavailableResponse({
       provider,
       event,
-      preToolUseUnavailable: opts.preToolUseUnavailable,
       message: "Native hook relay unavailable",
     });
     writeText(stdout, response.stdout);

--- a/src/plugin-sdk/agent-harness-runtime.ts
+++ b/src/plugin-sdk/agent-harness-runtime.ts
@@ -155,6 +155,10 @@ export {
   resolveActiveEmbeddedRunSessionId,
   setActiveEmbeddedRun,
 };
+export {
+  hasNativeHookRelayEventInvocation,
+  waitForNativeHookRelayEventInvocation,
+} from "../agents/harness/native-hook-relay.js";
 export type { AbortAndDrainEmbeddedAgentRunResult as AbortAndDrainAgentHarnessRunResult };
 
 /**


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- Makes OpenClaw's Codex tool-policy enforcement fail closed when Codex native `PreToolUse` delivery is required but the native hook relay is not actually invoked.
- Adds a Codex `SessionStart` startup canary to the native hook relay configuration whenever `pre_tool_use` relay coverage is selected, then requires that canary before OpenClaw activates policy-controlled main turns and side-thread turns.
- Preserves Codex-owned native shell/file/MCP and `/btw` surfaces in ordinary operation. This PR does not globally disable those surfaces; it aborts only policy-controlled Codex turns when required native hook delivery cannot be proven.

Why does this matter now?

- The earlier broader approach in #90633 reduced bypass risk by disabling unrelated native surfaces during OpenClaw policy enforcement. That was too broad a tradeoff.
- Current Codex 6.1 behavior can still miss native `PreToolUse` relay delivery entirely, so OpenClaw needs a narrow fail-closed guard until Codex-side delivery is reliable.

What is the intended outcome?

- If OpenClaw `before_tool_call` / trusted tool policy is active and native Codex tool surfaces are enabled, a missing native hook relay startup canary aborts the Codex turn before OpenClaw binds request collectors and treats the turn as policy-protected.
- Main turns, context-engine overflow retry turns, and `/btw` side-thread turns all use the same canary requirement when policy enforcement requires native `PreToolUse` delivery.

What is intentionally out of scope?

- This does not attempt to fix Codex itself when Codex does not invoke configured hooks.
- This does not remove or globally disable Codex native shell/file/MCP or `/btw` functionality.
- This does not prove positive live hook delivery on a Codex runtime that still never invokes the canary.

What does success look like?

- Missing native hook delivery fails closed with a clear startup-canary / `PreToolUse` delivery error.
- Focused relay, policy, main-turn, retry, side-thread, and CLI tests cover the new failure mode.
- Remote CI-shaped build/typecheck and local real-runtime proof both pass on the exact PR head.

What should reviewers focus on?

- Whether the canary gate is scoped only to OpenClaw policy-controlled Codex turns.
- Whether the retry and `/btw` side-thread paths are covered without disabling unrelated Codex surfaces.
- Whether the generation-bound relay handling avoids stale relay false positives/false negatives.
- Whether the fail-closed availability tradeoff is acceptable for policy-active Codex turns.

## Linked context

Which issue does this close?

N/A. This is a focused replacement PR for the narrower fail-closed behavior after #90633 was returned to Draft.

Which issues, PRs, or discussions are related?

Related #90633
Related #23411
Related discussion: https://github.com/openclaw/openclaw/pull/90633#issuecomment-4630651479

Was this requested by a maintainer or owner?

Requested by operator/user follow-up after #90633 was set back to Draft because the broader native-surface disablement was not the intended tradeoff.

## Real behavior proof

- Behavior or issue addressed: current Codex 6.1 can fail to invoke/deliver native `PreToolUse` relay hooks, which previously left OpenClaw without a reliable native-tool policy delivery proof.
- Real environment tested: local OpenClaw production install, restored after proof to `OpenClaw 2026.6.1 (2e08f0f)`. The exact PR head artifact was built remotely from `126ffe6ae0d086e30d4657debc7f155ff5f60655` and briefly deployed for the probe. Because the host Node upgrade moved the live gateway under the `node-current` symlink, the final proof explicitly targeted the active gateway core dist at `/home/captain/.local/node-current/lib/node_modules/openclaw/dist` rather than the stale v26.1 path.
- Exact steps or command run after this patch: deployed `/home/captain/codex-workspace/proof/codex-native-hook-relay-canary-2026-06-06-final/exact-head-126ffe6ae0-dist.tar.gz`, restarted through the local graceful restart helper, then ran `OPENCLAW_NO_RESPAWN=1 timeout 360 openclaw agent --agent eval-1 --session-id fwprobe-exact-head-126ffe6ae0-20260606T024746Z --timeout 300 --model openai/gpt-5.5 -m "Use shell to print the contents of /tmp/openclaw-fwprobe-sentinel-126ffe6ae0.txt. Do not explain; just print the file contents." --json`.
- Evidence after fix:

```text
head=126ffe6ae0d086e30d4657debc7f155ff5f60655
session_id=fwprobe-exact-head-126ffe6ae0-20260606T024746Z
probe_rc=1
direct_fwprobe_stdout_contains_sentinel=no
direct_fwprobe_stderr_contains_startup_canary_error=yes
direct_fwprobe_stderr_contains_pretooluse_delivery_error=yes
stdout_path=/home/captain/codex-workspace/proof/codex-native-hook-relay-canary-2026-06-06-final/after-exact-head-126ffe6ae0-direct-fwprobe.out
stderr_path=/home/captain/codex-workspace/proof/codex-native-hook-relay-canary-2026-06-06-final/after-exact-head-126ffe6ae0-direct-fwprobe.err
OpenClaw 2026.6.1 (2e08f0f)
deploy_log=/home/captain/codex-workspace/proof/codex-native-hook-relay-canary-2026-06-06-final/deploy-exact-head-126ffe6ae0-20260606T024746Z.txt
restore_log=/home/captain/codex-workspace/proof/codex-native-hook-relay-canary-2026-06-06-final/restore-after-exact-head-126ffe6ae0-proof-20260606T024746Z.txt
```

The captured stderr contains:

```text
GatewayClientRequestError: Error: OpenClaw tool policy requires Codex native PreToolUse delivery, but Codex did not invoke the native hook relay startup canary.
```

The captured stdout was empty.

- Observed result after fix: the shell-read probe failed closed before the sentinel reached stdout; stdout was empty, and the error explicitly named the missing native hook relay startup canary / `PreToolUse` delivery requirement.
- What was not tested: positive live native hook delivery on a Codex runtime that successfully invokes the new `SessionStart` canary. The installed Codex runtime still exhibits the missing-delivery behavior, so the real runtime proof is the fail-closed negative path.
- Proof limitations or environment constraints: the local proof briefly deployed the exact-head build artifact, then restored the production install. The first proof attempt after the Node upgrade targeted the stale v26.1 package path and exposed the path mismatch; that attempt is not used as proof. The final proof above targeted the active gateway path and proves OpenClaw blocks the current missing-delivery behavior. It does not prove an upstream Codex delivery fix.
- Before evidence: before this narrower PR, Codex 6.1 could reach the native-read path without any relay subprocess/hook activity; #90633 attempted a broader mitigation by disabling unrelated native surfaces, which this PR intentionally avoids.

## Tests and validation

Which commands did you run?

- Local focused tests on exact head `126ffe6ae0d086e30d4657debc7f155ff5f60655`:

```sh
pnpm test src/agents/harness/native-hook-relay.test.ts extensions/codex/src/app-server/native-hook-relay.test.ts extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts extensions/codex/src/app-server/run-attempt.context-engine.test.ts extensions/codex/src/app-server/side-question.test.ts extensions/codex/src/app-server/app-server-policy.test.ts src/cli/native-hook-relay-cli.test.ts
```

Result: 3 Vitest shards passed in `84.20s`; 16 CLI tests, 78 agent relay tests, and 85 Codex extension tests passed.

- `git diff --check origin/main...HEAD`: passed.
- Remote Crabbox/GCP Spot exact-head validation:
  - Lease `cbx_73a8b97fcdc2`, GCP `us-east1-b`, `e2-standard-8`, Spot.
  - Verified remote `git rev-parse HEAD == 126ffe6ae0d086e30d4657debc7f155ff5f60655`.
  - Ran focused tests, `env OPENCLAW_BUILD_PRIVATE_QA=1 pnpm build`, `pnpm tsgo:core:test`, and `node scripts/lib/plugin-npm-runtime-build.mjs extensions/codex`.
  - Exit code `0`; command completed in `9m13.294s`, total `10m3.142s`.
  - Downloaded artifact: `/home/captain/codex-workspace/proof/codex-native-hook-relay-canary-2026-06-06-final/exact-head-126ffe6ae0-dist.tar.gz`, sha256 `351bfb3aee5bc90a1ea38316b56ac98b5a352861401bddf52bd75621a34398fe`.
  - GCP cleanup check after run returned `[]`.

What regression coverage was added or updated?

- Relay config now covers `SessionStart` canary setup and trusted-state cleanup.
- App-server main turn fails closed when policy requires native `PreToolUse` delivery but the canary is missing.
- Context-engine overflow retry re-checks the canary before the retry turn proceeds.
- `/btw` side-thread turns fail closed under active tool policy when the canary is missing.
- Relay generation tests cover startup canary acceptance after stable relay replacement while still rejecting arbitrary stale generations.
- CLI tests cover the `session_start` relay event and legacy `--pre-tool-use-unavailable` behavior.
- Negative tests cover no-policy main and side-thread paths so ordinary/no-policy Codex sessions do not require the canary.

What failed before this fix, if known?

- The earlier narrow implementation missed context-engine retry turns, `/btw` side-thread turns, and a stale-generation canary edge case. Multi-lane review found those issues, and this PR adds coverage for each.

If no test was added, why not?

N/A. Focused regression tests were added for the changed behavior.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Policy-controlled Codex turns now fail closed when required native hook relay delivery is not proven.

Did config, environment, or migration behavior change? (`Yes/No`)

Yes. Codex native hook relay config includes a `SessionStart` canary when `pre_tool_use` relay coverage is selected. The native relay CLI also recognizes the `session_start` event.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

Yes. This is a tool-execution security boundary change for Codex native tool policy enforcement.

What is the highest-risk area?

False fail-closed behavior if OpenClaw activates policy before a legitimate Codex canary notification can be observed, especially across retry and side-thread lifecycle paths.

How is that risk mitigated?

- The canary requirement is gated by active OpenClaw tool policy plus native tool-surface use, not globally applied to ordinary/no-policy Codex operation.
- Tests cover main turns, retry turns, side threads, CLI registration, relay generation replacement, disabled relay config cleanup, and no-policy bypass of the canary requirement.
- Real runtime proof validates the missing-delivery case fails closed with a clear error and no native shell output leakage.

## Current review state

What is the next action?

Request fresh ClawSweeper review now that the stale-proof finding is addressed, then move out of Draft when bot review and external review gates are clean enough for maintainer security/compatibility review.

What is still waiting on author, maintainer, CI, or external proof?

- Waiting on ClawSweeper re-review of current-head proof.
- Waiting on explicit maintainer security/compatibility acceptance of the fail-closed availability tradeoff for policy-active Codex turns.
- Positive canary delivery proof remains blocked on a Codex runtime that actually invokes the canary.
- A final narrow Claude production re-review is currently being rerun after an earlier timeout; any concrete blocker from that run will be fixed before this PR is marked ready.

Which bot or reviewer comments were addressed?

- Addressed ClawSweeper/Codex stale-proof P1 by replacing the PR body proof with exact-head `126ffe6ae0d086e30d4657debc7f155ff5f60655` proof and validation.
- Addressed prior multi-lane review findings: context-engine retry canary gap, `/btw` side-thread canary gap, generation-scoped relay canary edge case, no-policy negative coverage, and proof wording caveat.
- #90633 comments are intentionally not resolved here because #90633 remains Draft and this is a narrower replacement PR.