### PR TITLE
fix(tui): show immediate feedback while loading models

### DIFF
--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -280,6 +280,39 @@ describe("tui command handlers", () => {
     expect(setActivityStatus).toHaveBeenCalledWith("waiting");
   });
 
+  it("shows immediate feedback before /models finishes listing", async () => {
+    let resolveModels: (value: Array<{ provider: string; id: string; name?: string }>) => void =
+      () => {
+        throw new Error("listModels promise resolver was not initialized");
+      };
+    const listModels = vi.fn(
+      () =>
+        new Promise<Array<{ provider: string; id: string; name?: string }>>((resolve) => {
+          resolveModels = resolve;
+        }),
+    );
+    const setActivityStatus = vi.fn();
+
+    const { handleCommand, requestRender, openOverlay } = createHarness({
+      listModels,
+      setActivityStatus,
+    });
+
+    const pending = handleCommand("/models");
+    await Promise.resolve();
+
+    expect(setActivityStatus).toHaveBeenCalledWith("loading models");
+    const loadingOrder = setActivityStatus.mock.invocationCallOrder[0] ?? 0;
+    expect(requestRender.mock.invocationCallOrder.some((order) => order > loadingOrder)).toBe(true);
+    expect(openOverlay).not.toHaveBeenCalled();
+
+    resolveModels([{ provider: "openai", id: "gpt-5.4", name: "GPT-5.4" }]);
+    await pending;
+
+    expect(openOverlay).toHaveBeenCalledTimes(1);
+    expect(setActivityStatus).toHaveBeenLastCalledWith("idle");
+  });
+
   it("forwards unknown slash commands to the gateway", async () => {
     const { handleCommand, sendChat, addPendingUser, addSystem, requestRender } = createHarness();
 

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -164,6 +164,11 @@ export function createCommandHandlers(context: CommandHandlerContext) {
   };
 
   const openModelSelector = async () => {
+    const loadingStatus = "loading models";
+    const previousActivityStatus = state.activityStatus;
+    state.activityStatus = loadingStatus;
+    setActivityStatus(loadingStatus);
+    tui.requestRender();
     try {
       const models = await client.listModels();
       if (models.length === 0) {
@@ -196,6 +201,12 @@ export function createCommandHandlers(context: CommandHandlerContext) {
     } catch (err) {
       chatLog.addSystem(`model list failed: ${String(err)}`);
       tui.requestRender();
+    } finally {
+      if (state.activityStatus === loadingStatus) {
+        const restoredStatus = previousActivityStatus || "idle";
+        state.activityStatus = restoredStatus;
+        setActivityStatus(restoredStatus);
+      }
     }
   };
 


### PR DESCRIPTION
## Summary
- set an immediate TUI loading status before awaiting `client.listModels()`
- restore the prior activity status once loading completes
- add a regression test covering delayed `/models` listing feedback

Closes #90720