### PR TITLE
fix(uninstall): refuse to remove current working directory during cleanup

### DIFF
--- a/docs/install/uninstall.md
+++ b/docs/install/uninstall.md
@@ -21,7 +21,13 @@ openclaw uninstall
 
 When using the CLI, state removal preserves configured workspace directories unless you also select `--workspace`.
 
-Non-interactive (automation / npx):
+Preview what will be removed (safe):
+
+```bash
+openclaw uninstall --dry-run --all
+```
+
+Non-interactive (automation / npx). Use with caution and only after confirming scopes:
 
 ```bash
 openclaw uninstall --all --yes --non-interactive

--- a/src/commands/cleanup-utils.test.ts
+++ b/src/commands/cleanup-utils.test.ts
@@ -213,4 +213,27 @@ describe("cleanup path removals", () => {
     expect(runtime.error.mock.calls[0][0]).toMatch(/Refusing to remove unsafe path/);
     expect(runtime.log.mock.calls.length).toBe(0);
   });
+
+  it("refuses to remove a directory containing the current working directory", async () => {
+    const runtime = createRuntimeMock();
+    const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cleanup-cwd-"));
+    const nestedCwd = path.join(tmpRoot, "nested");
+    const cwdSpy = vi.spyOn(process, "cwd");
+
+    try {
+      await fs.mkdir(nestedCwd);
+      cwdSpy.mockReturnValue(nestedCwd);
+
+      const result = await removePath(tmpRoot, runtime, { dryRun: true });
+
+      expect(result.ok).toBe(false);
+      expect(result.skipped).toBeUndefined();
+      expect(runtime.error.mock.calls.length).toBe(1);
+      expect(runtime.error.mock.calls[0][0]).toMatch(/Refusing to remove unsafe path/);
+      expect(runtime.log.mock.calls.length).toBe(0);
+    } finally {
+      cwdSpy.mockRestore();
+      await fs.rm(tmpRoot, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/commands/cleanup-utils.test.ts
+++ b/src/commands/cleanup-utils.test.ts
@@ -9,6 +9,7 @@ import type { RuntimeEnv } from "../runtime.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import {
   buildCleanupPlan,
+  removePath,
   removeStateAndLinkedPaths,
   removeWorkspaceAttestationPaths,
   removeWorkspaceDirs,
@@ -200,5 +201,16 @@ describe("cleanup path removals", () => {
     } finally {
       await fs.rm(tmpRoot, { recursive: true, force: true });
     }
+  });
+
+  it("refuses to remove the current working directory", async () => {
+    const runtime = createRuntimeMock();
+    const result = await removePath(process.cwd(), runtime, { dryRun: true });
+
+    expect(result.ok).toBe(false);
+    expect(result.skipped).toBeUndefined();
+    expect(runtime.error.mock.calls.length).toBe(1);
+    expect(runtime.error.mock.calls[0][0]).toMatch(/Refusing to remove unsafe path/);
+    expect(runtime.log.mock.calls.length).toBe(0);
   });
 });

--- a/src/commands/cleanup-utils.ts
+++ b/src/commands/cleanup-utils.ts
@@ -83,7 +83,7 @@ function isUnsafeRemovalTarget(target: string): boolean {
   if (home && resolved === path.resolve(home)) {
     return true;
   }
-  if (resolved === path.resolve(process.cwd())) {
+  if (isPathWithin(path.resolve(process.cwd()), resolved)) {
     return true;
   }
   return false;

--- a/src/commands/cleanup-utils.ts
+++ b/src/commands/cleanup-utils.ts
@@ -83,6 +83,9 @@ function isUnsafeRemovalTarget(target: string): boolean {
   if (home && resolved === path.resolve(home)) {
     return true;
   }
+  if (resolved === path.resolve(process.cwd())) {
+    return true;
+  }
   return false;
 }
 


### PR DESCRIPTION
## Summary

Fixes #90806.

`openclaw uninstall --all --yes --non-interactive` could delete the caller's current working directory when the resolved workspace or state path matched `process.cwd()` or contained it. The `removePath` helper already rejected empty strings, filesystem root, and the home directory, but it did not guard against the active working directory.

Changes:
- `src/commands/cleanup-utils.ts`: `isUnsafeRemovalTarget` now refuses targets that are or contain `process.cwd()`.
- `src/commands/cleanup-utils.test.ts`: regression tests proving `removePath` rejects cwd and a directory containing cwd with `ok: false` and logs an error.
- `docs/install/uninstall.md`: moves `--dry-run --all` ahead of the non-interactive stanza and adds a caution note.

## Verification

- `node scripts/run-vitest.mjs src/commands/cleanup-utils.test.ts --run` passes (10/10).
- `node scripts/run-oxlint.mjs src/commands/cleanup-utils.ts src/commands/cleanup-utils.test.ts` passes.
- `pnpm exec oxfmt --write src/commands/cleanup-utils.ts src/commands/cleanup-utils.test.ts docs/install/uninstall.md` applied.
- Crabbox local-container command-level proof on PR head `8cfb48d7d9e6c264ce0a407bea3efeb604f5ecf7` passed: built the CLI on Node.js v24.16.0, ran `openclaw uninstall --all --yes --non-interactive` from inside a configured workspace, observed the unsafe-path refusal, and verified the workspace still existed.

## Real behavior proof

**Behavior addressed:** `openclaw uninstall --all --yes --non-interactive` could delete the current working directory (#90806).

**Real environment tested:** Local OpenClaw source checkout on branch `fix/uninstall-cwd-guard`, Linux, Node.js 22.

**Exact steps or command run after this patch:**

```bash
node --import tsx -e '
import { removePath } from "./src/commands/cleanup-utils.js";
import path from "node:path";
import fs from "node:fs/promises";
import os from "node:os";

const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-uninstall-cwd-"));
const originalCwd = process.cwd();
process.chdir(tmpDir);

const runtime = {
  log: (msg) => console.log("LOG:", msg),
  error: (msg) => console.log("ERROR:", msg),
};

const result = await removePath(process.cwd(), runtime, { dryRun: false });

console.log("result.ok:", result.ok);
console.log("result.skipped:", result.skipped);

const stillExists = await fs.access(tmpDir).then(() => true).catch(() => false);
console.log("cwd still exists:", stillExists);

process.chdir(originalCwd);
await fs.rm(tmpDir, { recursive: true, force: true });
'
```

**Evidence after fix:** Terminal capture from running the patched `removePath` against the current working directory:

```text
ERROR: Refusing to remove unsafe path: /tmp/openclaw-uninstall-cwd-MhMtZz
result.ok: false
result.skipped: undefined
cwd still exists: true
```

**Observed result after fix:**
- `removePath(process.cwd())` returns `{ ok: false }` instead of deleting the directory.
- An error is logged: `Refusing to remove unsafe path: ...`.
- The temporary cwd directory still exists after the call.

**Additional maintainer proof:** Command-level uninstall proof in Crabbox local-container.

**Real environment tested:** Crabbox local-container via Podman, `node:24-bookworm`, Node.js v24.16.0, PR head `8cfb48d7d9e6c264ce0a407bea3efeb604f5ecf7`.

**Exact steps or command run after this patch:**

```bash
node scripts/crabbox-wrapper.mjs run \
  --provider local-container \
  --local-container-runtime podman \
  --local-container-image node:24-bookworm \
  --fresh-pr openclaw/openclaw#90813 \
  --idle-timeout 30m \
  --ttl 60m \
  --timing-json \
  --shell -- 'set -euo pipefail; repo=$(pwd); echo PROOF_NODE=$(node -v); echo PROOF_HEAD=$(git rev-parse HEAD); git merge-base --is-ancestor 8cfb48d7d9e6c264ce0a407bea3efeb604f5ecf7 HEAD; env CI=1 corepack pnpm install --frozen-lockfile >/tmp/openclaw-install.log; env CI=1 corepack pnpm build >/tmp/openclaw-build.log; tmp=$(mktemp -d); home=$tmp/home; state=$tmp/state; workspace=$tmp/workspace; nested=$workspace/nested; mkdir -p "$home" "$state" "$nested"; printf "{\"agents\":{\"defaults\":{\"workspace\":\"%s\"}}}\n" "$workspace" > "$state/openclaw.json"; echo PROOF_WORKSPACE=$workspace; echo PROOF_CWD=$nested; set +e; output=$(cd "$nested" && env HOME="$home" OPENCLAW_STATE_DIR="$state" OPENCLAW_CONFIG_PATH="$state/openclaw.json" OPENCLAW_WORKSPACE_DIR="$workspace" node "$repo/dist/entry.js" uninstall --all --yes --non-interactive 2>&1); status=$?; set -e; echo PROOF_EXIT=$status; printf "%s\n" "$output"; printf "%s\n" "$output" | grep -F "Refusing to remove unsafe path: $workspace"; test -d "$workspace"; test -d "$nested"; echo PROOF_WORKSPACE_STILL_EXISTS=1; rm -rf "$tmp"'
```

**Evidence after fix:** Terminal capture from running the built CLI against a workspace that contains the command's current working directory:

```text
PROOF_NODE=v24.16.0
PROOF_HEAD=8cfb48d7d9e6c264ce0a407bea3efeb604f5ecf7
PROOF_WORKSPACE=/tmp/tmp.oniUmE1Nc8/workspace
PROOF_CWD=/tmp/tmp.oniUmE1Nc8/workspace/nested
PROOF_EXIT=0
Recommended first: openclaw backup create
Gateway service disabled.
Removed /tmp/tmp.oniUmE1Nc8/state
Refusing to remove unsafe path: /tmp/tmp.oniUmE1Nc8/workspace
CLI still installed. Remove via npm/pnpm if desired.
Refusing to remove unsafe path: /tmp/tmp.oniUmE1Nc8/workspace
PROOF_WORKSPACE_STILL_EXISTS=1
```

**Observed result after fix:**
- `openclaw uninstall --all --yes --non-interactive` refuses to remove the configured workspace when the command runs from a nested directory inside that workspace.
- The command logs `Refusing to remove unsafe path: ...`.
- The workspace and nested cwd still exist after the command.

**What was not tested:** A packaged global npm install. The proof built this PR's CLI from source in an isolated container and exercised the same `uninstall --all --yes --non-interactive` command path.
