### PR TITLE
fix(gateway): pin plugin workspace dir during sessions.list to stop O(rows) metadata scans under concurrency

### DIFF
--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -70,6 +70,7 @@ import {
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { openRootFileSync } from "../infra/boundary-file-read.js";
 import { projectPluginSessionExtensionsSync } from "../plugins/host-hook-state.js";
+import { withPinnedActivePluginRegistryWorkspaceDir } from "../plugins/runtime-workspace-state.js";
 import {
   DEFAULT_AGENT_ID,
   normalizeAgentId,
@@ -2774,64 +2775,72 @@ export async function listSessionsFromStoreAsync(params: {
     (entries.length > 1 ? buildSessionListRowMetadataContext({ now }) : undefined);
 
   const sessions: GatewaySessionRow[] = [];
-  for (let i = 0; i < entries.length; i++) {
-    const [key, entry] = entries[i];
-    const includeTranscriptFields = i < sessionListTranscriptFieldRows;
-    const rowAgentId =
-      key === "global" && typeof opts.agentId === "string"
-        ? normalizeAgentId(opts.agentId)
-        : undefined;
-    const storeChildSessionsByKey =
-      fullRowContext?.storeChildSessionsByKey ??
-      buildSingleRowStoreChildSessionsByKey({ store, storePath, key, now });
-    const row = buildGatewaySessionRow({
-      cfg,
-      storePath,
-      store,
-      key,
-      entry,
-      agentId: rowAgentId,
-      modelCatalog: params.modelCatalog,
-      now,
-      includeDerivedTitles: false,
-      includeLastMessage: false,
-      transcriptUsageMaxBytes: sessionListTranscriptUsageMaxBytes,
-      storeChildSessionsByKey,
-      rowContext: sharedRowContext,
-      skipTranscriptUsageFallback: true,
-      lightweightListRow: true,
-    });
-    if (
-      entry?.sessionId &&
-      includeTranscriptFields &&
-      (includeDerivedTitles || includeLastMessage)
-    ) {
-      const parsed = parseAgentSessionKey(key);
-      const sessionAgentId =
-        rowAgentId ??
-        (parsed?.agentId ? normalizeAgentId(parsed.agentId) : resolveDefaultAgentId(cfg));
-      const fields = await readSessionTitleFieldsFromTranscriptAsync(
-        entry.sessionId,
+  // Pin the active plugin-registry workspace dir for the whole row-building
+  // batch. Each row resolves plugin metadata (model-id normalization) keyed by
+  // the active workspaceDir; this loop yields to the event loop between batches,
+  // and concurrent agent-turns/crons mutate the global workspaceDir during those
+  // yields. Without the pin, the plugin-metadata-snapshot memo key changes per
+  // row and never hits, turning one list into O(rows) full plugin scans.
+  await withPinnedActivePluginRegistryWorkspaceDir(async () => {
+    for (let i = 0; i < entries.length; i++) {
+      const [key, entry] = entries[i];
+      const includeTranscriptFields = i < sessionListTranscriptFieldRows;
+      const rowAgentId =
+        key === "global" && typeof opts.agentId === "string"
+          ? normalizeAgentId(opts.agentId)
+          : undefined;
+      const storeChildSessionsByKey =
+        fullRowContext?.storeChildSessionsByKey ??
+        buildSingleRowStoreChildSessionsByKey({ store, storePath, key, now });
+      const row = buildGatewaySessionRow({
+        cfg,
         storePath,
-        entry.sessionFile,
-        sessionAgentId,
-      );
-      if (includeDerivedTitles) {
-        row.derivedTitle = deriveSessionTitle(entry, fields.firstUserMessage);
-      }
-      if (includeLastMessage && fields.lastMessagePreview) {
-        row.lastMessagePreview = fields.lastMessagePreview;
-      }
-    }
-    sessions.push(row);
-    // Yield to the event loop between batches so WebSocket heartbeats,
-    // channel I/O, and concurrent RPC calls are not starved.
-    if ((i + 1) % SESSIONS_LIST_YIELD_BATCH_SIZE === 0 && i + 1 < entries.length) {
-      await new Promise<void>((resolve) => {
-        setImmediate(resolve);
+        store,
+        key,
+        entry,
+        agentId: rowAgentId,
+        modelCatalog: params.modelCatalog,
+        now,
+        includeDerivedTitles: false,
+        includeLastMessage: false,
+        transcriptUsageMaxBytes: sessionListTranscriptUsageMaxBytes,
+        storeChildSessionsByKey,
+        rowContext: sharedRowContext,
+        skipTranscriptUsageFallback: true,
+        lightweightListRow: true,
       });
+      if (
+        entry?.sessionId &&
+        includeTranscriptFields &&
+        (includeDerivedTitles || includeLastMessage)
+      ) {
+        const parsed = parseAgentSessionKey(key);
+        const sessionAgentId =
+          rowAgentId ??
+          (parsed?.agentId ? normalizeAgentId(parsed.agentId) : resolveDefaultAgentId(cfg));
+        const fields = await readSessionTitleFieldsFromTranscriptAsync(
+          entry.sessionId,
+          storePath,
+          entry.sessionFile,
+          sessionAgentId,
+        );
+        if (includeDerivedTitles) {
+          row.derivedTitle = deriveSessionTitle(entry, fields.firstUserMessage);
+        }
+        if (includeLastMessage && fields.lastMessagePreview) {
+          row.lastMessagePreview = fields.lastMessagePreview;
+        }
+      }
+      sessions.push(row);
+      // Yield to the event loop between batches so WebSocket heartbeats,
+      // channel I/O, and concurrent RPC calls are not starved.
+      if ((i + 1) % SESSIONS_LIST_YIELD_BATCH_SIZE === 0 && i + 1 < entries.length) {
+        await new Promise<void>((resolve) => {
+          setImmediate(resolve);
+        });
+      }
     }
-  }
+  });
 
   return {
     ts: now,

--- a/src/plugins/runtime-workspace-state.test.ts
+++ b/src/plugins/runtime-workspace-state.test.ts
@@ -1,0 +1,78 @@
+// Verifies the active plugin-registry workspace dir pin is stable under concurrent mutation.
+import { afterEach, describe, expect, it } from "vitest";
+import { createEmptyPluginRegistry } from "./registry-empty.js";
+import {
+  getActivePluginRegistryWorkspaceDirFromState,
+  withPinnedActivePluginRegistryWorkspaceDir,
+} from "./runtime-workspace-state.js";
+import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "./runtime.js";
+
+function setActiveWorkspace(workspaceDir: string): void {
+  setActivePluginRegistry(
+    createEmptyPluginRegistry(),
+    workspaceDir,
+    "gateway-bindable",
+    workspaceDir,
+  );
+}
+
+describe("runtime workspace state pin", () => {
+  afterEach(() => {
+    resetPluginRuntimeStateForTest();
+  });
+
+  it("reads the live global workspace dir when no pin is active", () => {
+    setActiveWorkspace("/workspace/a");
+    expect(getActivePluginRegistryWorkspaceDirFromState()).toBe("/workspace/a");
+    setActiveWorkspace("/workspace/b");
+    expect(getActivePluginRegistryWorkspaceDirFromState()).toBe("/workspace/b");
+  });
+
+  it("keeps the workspace dir stable inside a pinned scope despite concurrent mutation", async () => {
+    setActiveWorkspace("/workspace/a");
+
+    const observed: Array<string | undefined> = [];
+    await withPinnedActivePluginRegistryWorkspaceDir(async () => {
+      observed.push(getActivePluginRegistryWorkspaceDirFromState());
+      // Simulate a concurrent agent-turn/cron mutating the global mid-batch,
+      // across an event-loop yield like sessions.list performs between batches.
+      setActiveWorkspace("/workspace/b");
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      observed.push(getActivePluginRegistryWorkspaceDirFromState());
+    });
+
+    // Both reads inside the pinned scope return the value captured at scope entry,
+    // immune to the mid-batch mutation.
+    expect(observed).toEqual(["/workspace/a", "/workspace/a"]);
+    // Once the scope exits, reads observe the live (mutated) global again.
+    expect(getActivePluginRegistryWorkspaceDirFromState()).toBe("/workspace/b");
+  });
+
+  it("reuses the outer pin for nested scopes", async () => {
+    setActiveWorkspace("/workspace/a");
+
+    await withPinnedActivePluginRegistryWorkspaceDir(async () => {
+      setActiveWorkspace("/workspace/b");
+      await withPinnedActivePluginRegistryWorkspaceDir(async () => {
+        // Nested scope must reuse the outer pin, not re-capture the mutated global.
+        expect(getActivePluginRegistryWorkspaceDirFromState()).toBe("/workspace/a");
+      });
+    });
+  });
+
+  it("propagates rejections and leaves no sticky pinned context", async () => {
+    setActiveWorkspace("/workspace/a");
+
+    await expect(
+      withPinnedActivePluginRegistryWorkspaceDir(async () => {
+        setActiveWorkspace("/workspace/b");
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+
+    // After the failed scope exits, reads observe the live global again — no leak.
+    expect(getActivePluginRegistryWorkspaceDirFromState()).toBe("/workspace/b");
+  });
+});

--- a/src/plugins/runtime-workspace-state.ts
+++ b/src/plugins/runtime-workspace-state.ts
@@ -1,4 +1,6 @@
 // Shares plugin runtime workspace state across module reloads.
+import { AsyncLocalStorage } from "node:async_hooks";
+
 const PLUGIN_REGISTRY_STATE = Symbol.for("openclaw.pluginRegistryState");
 
 type GlobalRegistryWorkspaceState = typeof globalThis & {
@@ -7,9 +9,37 @@ type GlobalRegistryWorkspaceState = typeof globalThis & {
   };
 };
 
+// Pins the active workspace dir for the duration of a batch (e.g. gateway
+// sessions.list, which resolves plugin metadata once per row). The underlying
+// global is mutated by concurrent agent-turns/crons via setActivePluginRegistry;
+// without a pin, a batch that yields the event loop between rows reads a
+// different workspaceDir each row, so the plugin-metadata-snapshot memo key
+// changes every row and never hits — turning one list into O(rows) full scans.
+// AsyncLocalStorage scopes the pin to the batch's async context only, so other
+// concurrent contexts still observe the live global.
+const pinnedWorkspaceDirStorage = new AsyncLocalStorage<{ workspaceDir: string | undefined }>();
+
 /** Reads the active plugin registry workspace directory from global runtime state. */
 export function getActivePluginRegistryWorkspaceDirFromState(): string | undefined {
+  const pinned = pinnedWorkspaceDirStorage.getStore();
+  if (pinned) {
+    return pinned.workspaceDir;
+  }
   return (
     (globalThis as GlobalRegistryWorkspaceState)[PLUGIN_REGISTRY_STATE]?.workspaceDir ?? undefined
   );
+}
+
+/**
+ * Runs `fn` with the active plugin registry workspace dir pinned to its current
+ * value, so reads inside `fn` (and its awaited continuations) are stable even if
+ * concurrent work mutates the global. Nested calls reuse the outer pin.
+ */
+export function withPinnedActivePluginRegistryWorkspaceDir<T>(fn: () => T): T {
+  if (pinnedWorkspaceDirStorage.getStore()) {
+    return fn();
+  }
+  const workspaceDir =
+    (globalThis as GlobalRegistryWorkspaceState)[PLUGIN_REGISTRY_STATE]?.workspaceDir ?? undefined;
+  return pinnedWorkspaceDirStorage.run({ workspaceDir }, fn);
 }


### PR DESCRIPTION
## Summary

Fixes the residual concurrency facet of #76562, tracked in #90814.

`sessions.list` becomes O(rows) slow — tens of seconds — **only when other agents/crons run concurrently**; on an idle gateway it is fast. The per-row plugin model-id-normalization lookup reads a **process-global "active plugin-registry workspace dir"**. `listSessionsFromStoreAsync` yields to the event loop every `SESSIONS_LIST_YIELD_BATCH_SIZE` rows, and during those yields concurrent agent-turns/crons call `setActivePluginRegistry(...)`, mutating that global. The plugin-metadata-snapshot memo key includes `workspaceDir`, so it changes on essentially every row, the memo never hits, and each row triggers a fresh full `loadPluginMetadataSnapshot` scan (~100 ms).

Evidence on a busy gateway (one call, `OPENCLAW_DIAGNOSTICS=1`):

```
gateway.sessions.list:            ~10100 ms
  └─ rows:                        ~10100 ms   <-- ~100%
plugins.metadata.scan: 112–319 spans, 0 cacheHit, avg ~100 ms each
```

Bumping the snapshot memo to a 512-slot LRU still produced **0 hits** — the key never repeats, so this is not a cache-size/eviction problem; it is global-mutable-state-under-concurrency.

## Fix

Pin the active plugin-registry workspace dir for the duration of the row-building batch via `AsyncLocalStorage`, so every row in one `sessions.list` reads a stable value, immune to concurrent global mutation, while other concurrent async contexts still observe the live global. This collapses the O(rows) scans to one, independent of concurrent agent/cron activity.

- `src/plugins/runtime-workspace-state.ts` — add `withPinnedActivePluginRegistryWorkspaceDir<T>(fn: () => T): T`; `getActivePluginRegistryWorkspaceDirFromState()` returns the pinned value when a scope is active, else the live global. Nested calls reuse the outer pin.
- `src/gateway/session-utils.ts` — wrap the `listSessionsFromStoreAsync` row loop (including its inter-batch `setImmediate` yields) in the pin.
- `src/plugins/runtime-workspace-state.test.ts` — regression tests: pass-through when unpinned; stability inside a pinned scope across a `setImmediate` yield while `setActivePluginRegistry` mutates the global mid-scope; live again after exit; nested-scope reuse; and rejection propagation with no sticky context.

## Notes

- The pin only wraps a batch that does not spawn detached/fire-and-forget async work (the row loop awaits everything), so the pinned context cannot outlive the call.
- Semantically this is *more* correct than before: the old per-row "live" read was a race where row N could normalize against workspace A and row N+1 against workspace B purely because an unrelated task mutated the global mid-yield. Snapshotting at batch start removes that nondeterminism.

## Validation

- `node scripts/run-tsgo.mjs` — clean
- `node scripts/run-oxlint.mjs` — clean (changed files)
- pin + manifest-model-id-normalization tests: pass
- gateway session-utils tests (plugin-runtime + perf + single-row-cache): 24/24 pass

## Real behavior proof

**Behavior or issue addressed**: `sessions.list` triggered O(rows) full `loadPluginMetadataSnapshot` scans whenever concurrent agents/crons flipped the process-global active workspace dir during the row loop's `setImmediate` yields (issue #90814). This pins the workspace for the batch so per-row plugin-metadata lookups hit the memo regardless of concurrent mutation.

**Real environment tested**: Linux x64, Node v22.22.0, this branch's real source modules (no mocks/stubs): the real `normalizeProviderModelIdWithManifest` → `resolvePluginMetadataSnapshot` → `loadPluginMetadataSnapshot` resolver path, a real on-disk installed-plugin index + manifest, and the real `OPENCLAW_DIAGNOSTICS=1` timeline emitting `plugins.metadata.scan` spans. A concurrent task flips the global active workspace dir on every event-loop tick, exactly as parallel agent-turns/crons do, while the harness reproduces the `listSessionsFromStoreAsync` per-row loop (resolve per row, yield every 10 rows).

**Exact steps or command run after this patch**: drove 200 rows through the real resolver path with the concurrent workspace-flipping actor running, once with the pre-fix code path (no pin) and once through this PR's `withPinnedActivePluginRegistryWorkspaceDir`, counting `plugins.metadata.scan` spans with `cacheHit !== true` (i.e. real full scans) parsed from the diagnostics timeline JSONL:

```
$ node node_modules/.bin/tsx scripts/repro-90814.mts
```

**Evidence after fix**: copied live console output of that run:

```
# repro #90814 — real resolver path, real diagnostics timeline, 200 rows
pre-fix (no pin)         rows=200 workspaceFlips=21 scanSpans=400 fullScans(cacheMiss)=40 elapsedMs=157
this PR (withPinned)     rows=200 workspaceFlips=21 scanSpans=400 fullScans(cacheMiss)=2 elapsedMs=61
```

**Observed result after fix**: with the pin, real full plugin-metadata scans drop from **40 → 2** (just the cold-start resolves) and stay flat regardless of the 21 concurrent workspace flips; wall time falls **157 ms → 61 ms** for the batch. Pre-fix, the full-scan count tracks the concurrent flip count (each flip across a yield invalidates the per-row memo key); post-fix it is constant and independent of concurrency, confirming the O(rows-under-concurrency) → O(1) collapse. (The total `scanSpans=400` is unchanged because cache *hits* still emit a span — a separate cosmetic concern, #86790; the meaningful metric is the cache-miss full scans.)

**What was not tested**: not exercised against a live multi-tenant production gateway over WebSocket in this run (the harness drives the same real resolver + diagnostics modules in-process); the upstream end-to-end symptom under real concurrent load is documented in #90814 and the now-closed #76562.
