### PR TITLE
fix(codex): report completion timeout diagnostics

### DIFF
--- a/docs/plugins/codex-harness-reference.md
+++ b/docs/plugins/codex-harness-reference.md
@@ -347,11 +347,13 @@ the session lane. Replay-safe stdio app-server failures, including
 turn-completion idle timeouts without assistant, tool, active-item, or
 side-effect evidence, are retried once on a fresh app-server attempt. Unsafe
 timeouts still retire the stuck app-server client and release the OpenClaw
-session lane. They also clear the stale native thread binding and surface a
-recoverable timeout message for user or maintainer judgment instead of being
-replayed automatically. Timeout diagnostics include the last app-server
-notification method and, for raw assistant response items, the item type, role,
-id, and a bounded assistant text preview.
+session lane. They also clear the stale native thread binding instead of being
+replayed automatically. Completion-watch timeouts surface Codex-specific timeout
+text: replay-safe cases say the response may be incomplete, while unsafe cases
+tell the user to verify current state before retrying. Public timeout diagnostics
+include structural fields such as the last app-server notification method,
+raw assistant response item id/type/role, active request/item counts, and armed
+watch state; they do not include raw prompt, assistant, or tool content.
 
 ## Model discovery
 

--- a/docs/plugins/codex-harness-reference.md
+++ b/docs/plugins/codex-harness-reference.md
@@ -353,7 +353,9 @@ text: replay-safe cases say the response may be incomplete, while unsafe cases
 tell the user to verify current state before retrying. Public timeout diagnostics
 include structural fields such as the last app-server notification method,
 raw assistant response item id/type/role, active request/item counts, and armed
-watch state; they do not include raw prompt, assistant, or tool content.
+watch state. When the last notification is a raw assistant response item, they
+also include a bounded assistant text preview. They do not include raw prompt or
+tool content.
 
 ## Model discovery
 

--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -588,11 +588,13 @@ releases the session lane. Replay-safe stdio app-server failures, including
 turn-completion idle timeouts without assistant, tool, active-item, or
 side-effect evidence, are retried once on a fresh app-server attempt. Unsafe
 timeouts still retire the stuck app-server client and release the OpenClaw
-session lane. They also clear the stale native thread binding and surface a
-recoverable timeout message for user or maintainer judgment instead of being
-replayed automatically. Timeout diagnostics include the last app-server
-notification method and, for raw assistant response items, the item type, role,
-id, and a bounded assistant text preview.
+session lane. They also clear the stale native thread binding instead of being
+replayed automatically. Completion-watch timeouts surface Codex-specific timeout
+text: replay-safe cases say the response may be incomplete, while unsafe cases
+tell the user to verify current state before retrying. Public timeout diagnostics
+include structural fields such as the last app-server notification method,
+raw assistant response item id/type/role, active request/item counts, and armed
+watch state; they do not include raw prompt, assistant, or tool content.
 
 Environment overrides remain available for local testing:
 

--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -594,7 +594,9 @@ text: replay-safe cases say the response may be incomplete, while unsafe cases
 tell the user to verify current state before retrying. Public timeout diagnostics
 include structural fields such as the last app-server notification method,
 raw assistant response item id/type/role, active request/item counts, and armed
-watch state; they do not include raw prompt, assistant, or tool content.
+watch state. When the last notification is a raw assistant response item, they
+also include a bounded assistant text preview. They do not include raw prompt or
+tool content.
 
 Environment overrides remain available for local testing:
 

--- a/extensions/codex/src/app-server/attempt-notifications.ts
+++ b/extensions/codex/src/app-server/attempt-notifications.ts
@@ -40,6 +40,7 @@ export function describeNotificationActivity(
     lastNotificationItemId: readString(item, "id"),
     lastNotificationItemType: readString(item, "type"),
     lastNotificationItemRole: readString(item, "role"),
+    lastAssistantTextPreview: readRawAssistantTextPreview(item),
   };
 }
 

--- a/extensions/codex/src/app-server/attempt-notifications.ts
+++ b/extensions/codex/src/app-server/attempt-notifications.ts
@@ -40,7 +40,6 @@ export function describeNotificationActivity(
     lastNotificationItemId: readString(item, "id"),
     lastNotificationItemType: readString(item, "type"),
     lastNotificationItemRole: readString(item, "role"),
-    lastAssistantTextPreview: readRawAssistantTextPreview(item),
   };
 }
 

--- a/extensions/codex/src/app-server/attempt-results.test.ts
+++ b/extensions/codex/src/app-server/attempt-results.test.ts
@@ -61,14 +61,25 @@ describe("Codex app-server attempt results", () => {
       buildCodexAppServerPromptTimeoutOutcome({
         result: createResult(),
         turnCompletionIdleTimedOut: true,
+        turnWatchTimeoutKind: "progress",
       }),
     ).toBeUndefined();
     expect(
       buildCodexAppServerPromptTimeoutOutcome({
         result: createResult({
-          itemLifecycle: { startedCount: 1, completedCount: 1, activeCount: 0 },
+          toolMetas: [{ toolName: "exec" }],
         }),
         turnCompletionIdleTimedOut: true,
+        turnWatchTimeoutKind: "terminal",
+      }),
+    ).toBeUndefined();
+    expect(
+      buildCodexAppServerPromptTimeoutOutcome({
+        result: createResult({
+          itemLifecycle: { startedCount: 0, completedCount: 0, activeCount: 0 },
+        }),
+        turnCompletionIdleTimedOut: true,
+        turnWatchTimeoutKind: "completion",
       }),
     ).toEqual({
       message:
@@ -83,6 +94,7 @@ describe("Codex app-server attempt results", () => {
           },
         }),
         turnCompletionIdleTimedOut: true,
+        turnWatchTimeoutKind: "completion",
       }),
     ).toEqual({
       message:
@@ -96,10 +108,13 @@ describe("Codex app-server attempt results", () => {
           assistantTexts: ["I am changing the data model now..."],
         }),
         turnCompletionIdleTimedOut: true,
+        turnWatchTimeoutKind: "completion",
       }),
     ).toEqual({
       message:
         "Codex stopped before confirming the turn was complete. The response may be incomplete; retry if needed.",
+      replayInvalid: true,
+      livenessState: "abandoned",
     });
     expect(
       buildCodexAppServerPromptTimeoutOutcome({
@@ -107,10 +122,13 @@ describe("Codex app-server attempt results", () => {
           toolMetas: [{ toolName: "exec" }],
         }),
         turnCompletionIdleTimedOut: true,
+        turnWatchTimeoutKind: "completion",
       }),
     ).toEqual({
       message:
-        "Codex stopped before confirming the turn was complete. The response may be incomplete; retry if needed.",
+        "Codex stopped before confirming the turn was complete. Some work may already have been performed; verify the current state before retrying.",
+      replayInvalid: true,
+      livenessState: "abandoned",
     });
   });
 

--- a/extensions/codex/src/app-server/attempt-results.ts
+++ b/extensions/codex/src/app-server/attempt-results.ts
@@ -8,6 +8,7 @@ import type {
   EmbeddedRunAttemptResult,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import type { CodexSystemPromptReport } from "./attempt-context.js";
+import type { CodexAttemptTurnWatchTimeoutKind } from "./attempt-turn-watches.js";
 
 const CODEX_APP_SERVER_MISSING_TERMINAL_EVENT_USER_MESSAGE =
   "Codex stopped before confirming the turn was complete. The response may be incomplete; retry if needed.";
@@ -19,13 +20,6 @@ export function collectTerminalAssistantText(result: EmbeddedRunAttemptResult): 
   return result.assistantTexts.join("\n\n").trim();
 }
 
-/** Returns whether attempt metadata saw potential side effects. */
-export function hasCodexAppServerPotentialSideEffectEvidence(
-  result: EmbeddedRunAttemptResult,
-): boolean {
-  return result.replayMetadata.hadPotentialSideEffects;
-}
-
 /**
  * Builds the user-facing timeout outcome when Codex stops without a terminal
  * turn event.
@@ -33,24 +27,24 @@ export function hasCodexAppServerPotentialSideEffectEvidence(
 export function buildCodexAppServerPromptTimeoutOutcome(params: {
   result: EmbeddedRunAttemptResult;
   turnCompletionIdleTimedOut: boolean;
+  turnWatchTimeoutKind?: CodexAttemptTurnWatchTimeoutKind;
 }): EmbeddedRunAttemptResult["promptTimeoutOutcome"] {
-  const completionIdleTimeoutHadPotentialSideEffects = hasCodexAppServerPotentialSideEffectEvidence(
-    params.result,
-  );
-  const replayBlockedReason = resolveCodexAppServerReplayBlockedReason(params.result);
-  if (
-    !params.turnCompletionIdleTimedOut ||
-    (params.result.itemLifecycle.completedCount === 0 &&
-      !completionIdleTimeoutHadPotentialSideEffects &&
-      replayBlockedReason === undefined)
-  ) {
+  if (!params.turnCompletionIdleTimedOut) {
     return undefined;
   }
+  if (params.turnWatchTimeoutKind !== undefined && params.turnWatchTimeoutKind !== "completion") {
+    return undefined;
+  }
+  const replayBlockedReason = resolveCodexAppServerReplayBlockedReason(params.result);
+  const completionIdleTimeoutHadPotentialSideEffects =
+    replayBlockedReason === "tool_activity" ||
+    replayBlockedReason === "potential_side_effect" ||
+    replayBlockedReason === "active_item";
   return {
     message: completionIdleTimeoutHadPotentialSideEffects
       ? CODEX_APP_SERVER_MISSING_TERMINAL_EVENT_SIDE_EFFECT_USER_MESSAGE
       : CODEX_APP_SERVER_MISSING_TERMINAL_EVENT_USER_MESSAGE,
-    ...(completionIdleTimeoutHadPotentialSideEffects
+    ...(replayBlockedReason
       ? {
           replayInvalid: true,
           livenessState: "abandoned" as const,

--- a/extensions/codex/src/app-server/attempt-turn-watches.test.ts
+++ b/extensions/codex/src/app-server/attempt-turn-watches.test.ts
@@ -89,6 +89,14 @@ describe("Codex app-server attempt turn watches", () => {
         idleMs: 10,
         timeoutMs: 10,
         lastActivityReason: "turn:start",
+        details: {
+          activeAppServerTurnRequests: 0,
+          activeTurnItemCount: 0,
+          terminalTurnNotificationQueued: false,
+          completionIdleWatchArmed: true,
+          assistantCompletionIdleWatchArmed: false,
+          terminalIdleWatchArmed: false,
+        },
       },
     ]);
     expect(harness.abortController.signal.reason).toBe("turn_completion_idle_timeout");

--- a/extensions/codex/src/app-server/attempt-turn-watches.ts
+++ b/extensions/codex/src/app-server/attempt-turn-watches.ts
@@ -312,12 +312,21 @@ export function createCodexAttemptTurnWatchController(params: {
       scheduleCompletionIdleWatch();
       return;
     }
+    const details = {
+      ...completionLastActivityDetails,
+      activeAppServerTurnRequests: params.getActiveAppServerTurnRequests(),
+      activeTurnItemCount: params.getActiveTurnItemCount(),
+      terminalTurnNotificationQueued: params.isTerminalTurnNotificationQueued(),
+      completionIdleWatchArmed,
+      assistantCompletionIdleWatchArmed,
+      terminalIdleWatchArmed,
+    };
     const timeout = {
       kind: "completion" as const,
       idleMs,
       timeoutMs,
       lastActivityReason: completionLastActivityReason,
-      details: completionLastActivityDetails,
+      details,
     };
     params.onTimeout(timeout);
     params.onMarkTimedOut();

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -2701,6 +2701,9 @@ function buildCodexAppServerTimeoutDiagnostics(params: {
     ...(readString("lastNotificationItemRole")
       ? { lastNotificationItemRole: readString("lastNotificationItemRole") }
       : {}),
+    ...(readString("lastAssistantTextPreview")
+      ? { lastAssistantTextPreview: readString("lastAssistantTextPreview") }
+      : {}),
     ...(readNumber("activeAppServerTurnRequests") !== undefined
       ? { activeAppServerTurnRequests: readNumber("activeAppServerTurnRequests") }
       : {}),

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -1131,6 +1131,10 @@ export async function runCodexAppServerAttempt(
   let timedOut = false;
   let turnCompletionIdleTimedOut = false;
   let turnWatchTimeoutKind: CodexAttemptTurnWatchTimeoutKind | undefined;
+  let turnWatchTimeoutIdleMs: number | undefined;
+  let turnWatchTimeoutMs: number | undefined;
+  let turnWatchTimeoutLastActivityReason: string | undefined;
+  let turnWatchTimeoutDetails: Record<string, unknown> | undefined;
   let turnCompletionIdleTimeoutMessage: string | undefined;
   let clientClosedPromptError: string | undefined;
   let clientClosedAbort = false;
@@ -1221,6 +1225,10 @@ export async function runCodexAppServerAttempt(
       timedOut = true;
       turnCompletionIdleTimedOut = true;
       turnWatchTimeoutKind = timeout.kind;
+      turnWatchTimeoutIdleMs = timeout.idleMs;
+      turnWatchTimeoutMs = timeout.timeoutMs;
+      turnWatchTimeoutLastActivityReason = timeout.lastActivityReason;
+      turnWatchTimeoutDetails = timeout.details;
       turnCompletionIdleTimeoutMessage =
         "codex app-server turn idle timed out waiting for turn/completed";
     },
@@ -2293,7 +2301,18 @@ export async function runCodexAppServerAttempt(
     const promptTimeoutOutcome = buildCodexAppServerPromptTimeoutOutcome({
       result,
       turnCompletionIdleTimedOut,
+      turnWatchTimeoutKind,
     });
+    const codexAppServerFailureDiagnostics =
+      codexAppServerFailureKind === "turn_completion_idle_timeout" &&
+      turnWatchTimeoutKind === "completion"
+        ? buildCodexAppServerTimeoutDiagnostics({
+            idleMs: turnWatchTimeoutIdleMs,
+            timeoutMs: turnWatchTimeoutMs,
+            lastActivityReason: turnWatchTimeoutLastActivityReason,
+            details: turnWatchTimeoutDetails,
+          })
+        : undefined;
     const modelCallFailureKind =
       classifyCodexModelCallFailureKind({
         error: finalPromptError,
@@ -2460,6 +2479,9 @@ export async function runCodexAppServerAttempt(
               replaySafe: codexAppServerReplayBlockedReason === undefined,
               ...(codexAppServerReplayBlockedReason
                 ? { replayBlockedReason: codexAppServerReplayBlockedReason }
+                : {}),
+              ...(codexAppServerFailureDiagnostics
+                ? { diagnostics: codexAppServerFailureDiagnostics }
                 : {}),
             },
           }
@@ -2643,6 +2665,61 @@ function waitForCodexNotificationDispatchTurn(): Promise<void> {
   return new Promise((resolve) => {
     setImmediate(resolve);
   });
+}
+
+function buildCodexAppServerTimeoutDiagnostics(params: {
+  idleMs?: number;
+  timeoutMs?: number;
+  lastActivityReason?: string;
+  details?: Record<string, unknown>;
+}): NonNullable<EmbeddedRunAttemptResult["codexAppServerFailure"]>["diagnostics"] {
+  const readString = (key: string) => {
+    const value = params.details?.[key];
+    return typeof value === "string" && value.trim() ? value : undefined;
+  };
+  const readNumber = (key: string) => {
+    const value = params.details?.[key];
+    return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+  };
+  const readBoolean = (key: string) => {
+    const value = params.details?.[key];
+    return typeof value === "boolean" ? value : undefined;
+  };
+  return {
+    ...(params.idleMs !== undefined ? { idleMs: params.idleMs } : {}),
+    ...(params.timeoutMs !== undefined ? { timeoutMs: params.timeoutMs } : {}),
+    ...(params.lastActivityReason ? { lastActivityReason: params.lastActivityReason } : {}),
+    ...(readString("lastNotificationMethod")
+      ? { lastNotificationMethod: readString("lastNotificationMethod") }
+      : {}),
+    ...(readString("lastNotificationItemId")
+      ? { lastNotificationItemId: readString("lastNotificationItemId") }
+      : {}),
+    ...(readString("lastNotificationItemType")
+      ? { lastNotificationItemType: readString("lastNotificationItemType") }
+      : {}),
+    ...(readString("lastNotificationItemRole")
+      ? { lastNotificationItemRole: readString("lastNotificationItemRole") }
+      : {}),
+    ...(readNumber("activeAppServerTurnRequests") !== undefined
+      ? { activeAppServerTurnRequests: readNumber("activeAppServerTurnRequests") }
+      : {}),
+    ...(readNumber("activeTurnItemCount") !== undefined
+      ? { activeTurnItemCount: readNumber("activeTurnItemCount") }
+      : {}),
+    ...(readBoolean("terminalTurnNotificationQueued") !== undefined
+      ? { terminalTurnNotificationQueued: readBoolean("terminalTurnNotificationQueued") }
+      : {}),
+    ...(readBoolean("completionIdleWatchArmed") !== undefined
+      ? { completionIdleWatchArmed: readBoolean("completionIdleWatchArmed") }
+      : {}),
+    ...(readBoolean("assistantCompletionIdleWatchArmed") !== undefined
+      ? { assistantCompletionIdleWatchArmed: readBoolean("assistantCompletionIdleWatchArmed") }
+      : {}),
+    ...(readBoolean("terminalIdleWatchArmed") !== undefined
+      ? { terminalIdleWatchArmed: readBoolean("terminalIdleWatchArmed") }
+      : {}),
+  };
 }
 
 function handleApprovalRequest(params: {

--- a/extensions/codex/src/app-server/run-attempt.turn-watches.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.turn-watches.test.ts
@@ -1743,11 +1743,16 @@ describe("runCodexAppServerAttempt turn watches", () => {
     const completionWarnData = completionWarnCall?.[1] as
       | {
           lastActivityReason?: string;
+          lastAssistantTextPreview?: string;
           timeoutMs?: number;
         }
       | undefined;
     expect(completionWarnData?.timeoutMs).toBe(100);
     expect(completionWarnData?.lastActivityReason).toBe("notification:rawResponseItem/completed");
+    expect(completionWarnData?.lastAssistantTextPreview).toBe("I'm writing the report now.");
+    expect(result.codexAppServerFailure?.diagnostics?.lastAssistantTextPreview).toBe(
+      "I'm writing the report now.",
+    );
   });
 
   it("uses the post-tool timeout for commentary raw assistant progress", async () => {
@@ -2449,6 +2454,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
     const terminalWarnData = terminalWarnCall?.[1] as
       | {
           lastActivityReason?: string;
+          lastAssistantTextPreview?: string;
           lastNotificationItemId?: string;
           lastNotificationItemRole?: string;
           lastNotificationItemType?: string;
@@ -2466,6 +2472,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
     expect(terminalWarnData?.lastNotificationItemId).toBe("raw-status-1");
     expect(terminalWarnData?.lastNotificationItemType).toBe("message");
     expect(terminalWarnData?.lastNotificationItemRole).toBe("assistant");
+    expect(terminalWarnData?.lastAssistantTextPreview).toBe("I'm writing the report now.");
     expect(
       warn.mock.calls.some(
         ([message]) => message === "codex app-server turn idle timed out waiting for completion",

--- a/extensions/codex/src/app-server/run-attempt.turn-watches.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.turn-watches.test.ts
@@ -320,7 +320,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
     });
   });
 
-  it("marks started mutating item timeouts as replay-invalid", async () => {
+  it("does not use completion timeout outcome for terminal timeout with active mutating item", async () => {
     const harness = createStartedThreadHarness();
     const params = createParams(
       path.join(tempDir, "session.jsonl"),
@@ -351,15 +351,14 @@ describe("runCodexAppServerAttempt turn watches", () => {
 
     expect(result.timedOut).toBe(true);
     expect(result.itemLifecycle).toMatchObject({ activeCount: 1, completedCount: 0 });
-    expect(result.promptTimeoutOutcome).toEqual({
-      message:
-        "Codex stopped before confirming the turn was complete. Some work may already have been performed; verify the current state before retrying.",
-      replayInvalid: true,
-      livenessState: "abandoned",
-    });
+    expect(result.codexAppServerFailure?.turnWatchTimeoutKind).toBe("terminal");
+    expect(result.codexAppServerFailure?.replaySafe).toBe(false);
+    expect(result.codexAppServerFailure?.replayBlockedReason).toBe("potential_side_effect");
+    expect(result.codexAppServerFailure?.diagnostics).toBeUndefined();
+    expect(result.promptTimeoutOutcome).toBeUndefined();
   });
 
-  it("does not mark assistant-only completion timeouts as replay-invalid", async () => {
+  it("does not use completion timeout outcome for non-completion timeout with assistant output", async () => {
     const harness = createStartedThreadHarness();
     const params = createParams(
       path.join(tempDir, "session.jsonl"),
@@ -392,10 +391,11 @@ describe("runCodexAppServerAttempt turn watches", () => {
     expect(result.timedOut).toBe(true);
     expect(result.itemLifecycle.completedCount).toBe(1);
     expect(result.toolMetas).toEqual([]);
-    expect(result.promptTimeoutOutcome).toEqual({
-      message:
-        "Codex stopped before confirming the turn was complete. The response may be incomplete; retry if needed.",
-    });
+    expect(result.codexAppServerFailure?.turnWatchTimeoutKind).not.toBe("completion");
+    expect(result.codexAppServerFailure?.replaySafe).toBe(false);
+    expect(result.codexAppServerFailure?.replayBlockedReason).toBe("assistant_output");
+    expect(result.codexAppServerFailure?.diagnostics).toBeUndefined();
+    expect(result.promptTimeoutOutcome).toBeUndefined();
   });
 
   it("unsubscribes and closes the app-server client when the active turn goes idle past the attempt timeout", async () => {
@@ -2449,7 +2449,6 @@ describe("runCodexAppServerAttempt turn watches", () => {
     const terminalWarnData = terminalWarnCall?.[1] as
       | {
           lastActivityReason?: string;
-          lastAssistantTextPreview?: string;
           lastNotificationItemId?: string;
           lastNotificationItemRole?: string;
           lastNotificationItemType?: string;
@@ -2467,7 +2466,6 @@ describe("runCodexAppServerAttempt turn watches", () => {
     expect(terminalWarnData?.lastNotificationItemId).toBe("raw-status-1");
     expect(terminalWarnData?.lastNotificationItemType).toBe("message");
     expect(terminalWarnData?.lastNotificationItemRole).toBe("assistant");
-    expect(terminalWarnData?.lastAssistantTextPreview).toBe("I'm writing the report now.");
     expect(
       warn.mock.calls.some(
         ([message]) => message === "codex app-server turn idle timed out waiting for completion",
@@ -2829,11 +2827,16 @@ describe("runCodexAppServerAttempt turn watches", () => {
       aborted: result.aborted,
       timedOut: result.timedOut,
       promptError: result.promptError,
+      promptTimeoutOutcome: result.promptTimeoutOutcome,
       codexAppServerFailure: result.codexAppServerFailure,
-    }).toEqual({
+    }).toMatchObject({
       aborted: true,
       timedOut: true,
       promptError: "codex app-server turn idle timed out waiting for turn/completed",
+      promptTimeoutOutcome: {
+        message:
+          "Codex stopped before confirming the turn was complete. The response may be incomplete; retry if needed.",
+      },
       codexAppServerFailure: {
         kind: "turn_completion_idle_timeout",
         turnWatchTimeoutKind: "completion",
@@ -2841,6 +2844,16 @@ describe("runCodexAppServerAttempt turn watches", () => {
         threadId: "thread-1",
         turnId: "turn-1",
         replaySafe: true,
+        diagnostics: {
+          timeoutMs: 15,
+          lastActivityReason: "turn:start",
+          activeAppServerTurnRequests: 0,
+          activeTurnItemCount: 0,
+          terminalTurnNotificationQueued: false,
+          completionIdleWatchArmed: true,
+          assistantCompletionIdleWatchArmed: false,
+          terminalIdleWatchArmed: true,
+        },
       },
     });
     await vi.waitFor(

--- a/src/agents/embedded-agent-runner/run.codex-app-server-recovery.test.ts
+++ b/src/agents/embedded-agent-runner/run.codex-app-server-recovery.test.ts
@@ -14,6 +14,9 @@ import type { EmbeddedRunAttemptResult } from "./run/types.js";
 
 let runEmbeddedAgent: typeof import("./run.js").runEmbeddedAgent;
 
+const CODEX_MISSING_TERMINAL_MESSAGE =
+  "Codex stopped before confirming the turn was complete. The response may be incomplete; retry if needed.";
+
 function codexClientClosedAttempt(
   overrides: Partial<EmbeddedRunAttemptResult> = {},
 ): EmbeddedRunAttemptResult {
@@ -45,6 +48,9 @@ function codexTurnCompletionIdleTimeoutAttempt(
     timedOut: true,
     promptError: new Error("codex app-server turn idle timed out waiting for turn/completed"),
     promptErrorSource: "prompt",
+    promptTimeoutOutcome: {
+      message: CODEX_MISSING_TERMINAL_MESSAGE,
+    },
     codexAppServerFailure: {
       kind: "turn_completion_idle_timeout",
       turnWatchTimeoutKind: "completion",
@@ -151,6 +157,7 @@ describe("runEmbeddedAgent Codex app-server recovery", () => {
           turnId: "turn-1",
           replaySafe: true,
         },
+        promptTimeoutOutcome: undefined,
       }),
     );
 
@@ -191,6 +198,7 @@ describe("runEmbeddedAgent Codex app-server recovery", () => {
           turnId: "turn-1",
           replaySafe: true,
         },
+        promptTimeoutOutcome: undefined,
       }),
     );
 
@@ -223,7 +231,7 @@ describe("runEmbeddedAgent Codex app-server recovery", () => {
 
     expect(result.payloads?.[0]).toMatchObject({
       isError: true,
-      text: "Request timed out before a response was generated. Please try again, or increase `agents.defaults.timeoutSeconds` in your config.",
+      text: CODEX_MISSING_TERMINAL_MESSAGE,
     });
     expect(result.meta.timeoutPhase).toBe("provider");
     expect(result.meta.providerStarted).toBe(true);
@@ -254,7 +262,7 @@ describe("runEmbeddedAgent Codex app-server recovery", () => {
 
     expect(result.payloads?.[0]).toMatchObject({
       isError: true,
-      text: "Request timed out before a response was generated. Please try again, or increase `agents.defaults.timeoutSeconds` in your config.",
+      text: CODEX_MISSING_TERMINAL_MESSAGE,
     });
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
     expect(mockedMarkAuthProfileFailure).not.toHaveBeenCalled();

--- a/src/agents/embedded-agent-runner/run/types.ts
+++ b/src/agents/embedded-agent-runner/run/types.ts
@@ -148,6 +148,7 @@ export type EmbeddedRunAttemptResult = {
       lastNotificationItemId?: string;
       lastNotificationItemType?: string;
       lastNotificationItemRole?: string;
+      lastAssistantTextPreview?: string;
       activeAppServerTurnRequests?: number;
       activeTurnItemCount?: number;
       terminalTurnNotificationQueued?: boolean;

--- a/src/agents/embedded-agent-runner/run/types.ts
+++ b/src/agents/embedded-agent-runner/run/types.ts
@@ -140,6 +140,21 @@ export type EmbeddedRunAttemptResult = {
       | "tool_activity"
       | "potential_side_effect"
       | "active_item";
+    diagnostics?: {
+      idleMs?: number;
+      timeoutMs?: number;
+      lastActivityReason?: string;
+      lastNotificationMethod?: string;
+      lastNotificationItemId?: string;
+      lastNotificationItemType?: string;
+      lastNotificationItemRole?: string;
+      activeAppServerTurnRequests?: number;
+      activeTurnItemCount?: number;
+      terminalTurnNotificationQueued?: boolean;
+      completionIdleWatchArmed?: boolean;
+      assistantCompletionIdleWatchArmed?: boolean;
+      terminalIdleWatchArmed?: boolean;
+    };
   };
   bootstrapPromptWarningSignaturesSeen?: string[];
   bootstrapPromptWarningSignature?: string;


### PR DESCRIPTION
## Summary

- Surface Codex-specific timeout text for completion-watch idle timeouts after the existing retry path is exhausted.
- Add `codexAppServerFailure.diagnostics` for completion-watch timeouts, including structural watch fields and a bounded assistant text preview when the last notification is raw assistant output, without raw prompt or tool content.
- Preserve the existing replay-safe stdio retry gate and keep progress/terminal watch timeouts on the generic timeout path.
- Update Codex harness docs and focused tests for safe, unsafe, non-stdio, retry-exhausted, non-completion timeout, and assistant-preview diagnostic cases.

## Verification

- [x] `node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.turn-watches.test.ts`
- [x] `node scripts/run-vitest.mjs extensions/codex/src/app-server/attempt-results.test.ts extensions/codex/src/app-server/attempt-turn-watches.test.ts extensions/codex/src/app-server/run-attempt.turn-watches.test.ts src/agents/embedded-agent-runner/run.codex-app-server-recovery.test.ts`
- [x] `node scripts/run-oxlint.mjs extensions/codex/src/app-server/attempt-notifications.ts extensions/codex/src/app-server/attempt-results.ts extensions/codex/src/app-server/attempt-turn-watches.ts extensions/codex/src/app-server/run-attempt.ts src/agents/embedded-agent-runner/run/types.ts`
- [x] `git diff --check`
- [x] `pnpm docs:list`
- [x] `python3 /Users/kevinlin/.codex/skills/specy/scripts/validate_flow_doc.py --kind flow-doc --doc /Users/kevinlin/code/openclaw/.mem/main/specs/29-codex-harness-terminal-timeout-recovery/flows/codex-completion-timeout-diagnostics.md`
- [x] `uvx showboat verify /Users/kevinlin/code/openclaw/.mem/main/proofs/demo-90117-dev-codex-completion-timeout-diagnostics/raw/showboat-summary.md`
- [x] Live dev Codex harness proof: `node /Users/kevinlin/code/openclaw/.mem/main/proofs/demo-90117-dev-codex-completion-timeout-diagnostics/scripts/summarize-live-proof.mjs` returned `proofPassed: true` for run `56deed94-b527-47cc-987b-92373b61a627`.

## Proof Artifacts

- Spec: `/Users/kevinlin/code/openclaw/.mem/main/specs/29-codex-harness-terminal-timeout-recovery/spec.md`
- Flow doc: `/Users/kevinlin/code/openclaw/.mem/main/specs/29-codex-harness-terminal-timeout-recovery/flows/codex-completion-timeout-diagnostics.md`
- Live proof: `/Users/kevinlin/code/openclaw/.mem/main/proofs/demo-90117-dev-codex-completion-timeout-diagnostics/proof.md`
