### PR TITLE
fix: allow stopping manual compaction

### DIFF
--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -1,6 +1,7 @@
 // Hook integration coverage for direct and queued embedded compaction.
 import type { AgentMessage } from "openclaw/plugin-sdk/agent-core";
 import { beforeAll, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+import { createReplyOperation } from "../../auto-reply/reply/reply-run-registry.js";
 import {
   applyExtraParamsToAgentMock,
   applyAgentCompactionSettingsFromConfigMock,
@@ -41,6 +42,7 @@ import {
   abortEmbeddedAgentRun,
   clearActiveEmbeddedRun,
   isEmbeddedAgentRunActive,
+  isEmbeddedAgentRunHandleActive,
   setActiveEmbeddedRun,
 } from "./runs.js";
 
@@ -81,6 +83,42 @@ function createDeferred<T>(): Deferred<T> {
     throw new Error("Expected compaction deferred resolver to be initialized");
   }
   return { promise, resolve };
+}
+
+function mockPendingContextEngineCompaction() {
+  const pending = {
+    signal: undefined as AbortSignal | undefined,
+    started: createDeferred<void>(),
+    release: createDeferred<void>(),
+  };
+  contextEngineCompactMock.mockImplementationOnce(async (...args: unknown[]) => {
+    const [params] = args;
+    pending.signal = (params as { abortSignal?: AbortSignal }).abortSignal;
+    pending.started.resolve(undefined);
+    await pending.release.promise;
+    return {
+      ok: true,
+      compacted: true,
+      reason: undefined,
+      result: { summary: "engine-summary", tokensAfter: 50 },
+    };
+  });
+  return pending;
+}
+
+function mockPendingNativeCompaction() {
+  const pending = {
+    signal: undefined as AbortSignal | undefined,
+    started: createDeferred<void>(),
+    terminal: createDeferred<{ ok: false; compacted: false; reason: string }>(),
+  };
+  maybeCompactAgentHarnessSessionMock.mockImplementationOnce(async (...args: unknown[]) => {
+    const [params] = args;
+    pending.signal = (params as { abortSignal?: AbortSignal }).abortSignal;
+    pending.started.resolve(undefined);
+    return await pending.terminal.promise;
+  });
+  return pending;
 }
 
 function expectRecordFields(record: unknown, expected: Record<string, unknown>) {
@@ -2623,107 +2661,171 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
     });
   });
 
-  it("forwards the caller abort signal into the engine compact() call", async () => {
-    const controller = new AbortController();
-    let compactSignal: AbortSignal | undefined;
-    const compactionStarted = createDeferred<void>();
-    const compactionReleased = createDeferred<void>();
-    contextEngineCompactMock.mockImplementationOnce(async (...args: unknown[]) => {
-      const [params] = args;
-      compactSignal = (params as { abortSignal?: AbortSignal }).abortSignal;
-      compactionStarted.resolve(undefined);
-      await compactionReleased.promise;
-      return {
-        ok: true,
-        compacted: true,
-        reason: undefined,
-        result: { summary: "engine-summary", tokensAfter: 50 },
-      };
-    });
+  it("aborts manual compaction before its queued global task starts", async () => {
+    let startQueuedTask: (() => void) | undefined;
+    const enqueue = <T>(task: () => Promise<T> | T): Promise<T> =>
+      new Promise<T>((resolve, reject) => {
+        startQueuedTask = () => {
+          void Promise.resolve().then(task).then(resolve, reject);
+        };
+      });
 
     const resultPromise = compactEmbeddedAgentSession(
-      wrappedCompactionArgs({ abortSignal: controller.signal }),
+      wrappedCompactionArgs({ enqueue, trigger: "manual" }),
     );
 
-    await compactionStarted.promise;
-    expect(compactSignal).toBeInstanceOf(AbortSignal);
-    expect(compactSignal).not.toBe(controller.signal);
-    controller.abort("caller_abort");
-    expect(compactSignal?.aborted).toBe(true);
-    expect(compactSignal?.reason).toBe("caller_abort");
-    compactionReleased.resolve(undefined);
+    await vi.waitFor(() => {
+      expect(startQueuedTask).toBeTypeOf("function");
+    });
+    expect(isEmbeddedAgentRunHandleActive(TEST_SESSION_ID)).toBe(true);
+    expect(abortEmbeddedAgentRun(undefined, { mode: "compacting", reason: "restart" })).toBe(true);
 
-    const result = await resultPromise;
+    const start = startQueuedTask;
+    if (!start) {
+      throw new Error("Expected queued compaction task");
+    }
+    start();
 
-    expect(result.ok).toBe(false);
-    expect(result.reason).toContain("aborted");
+    await expect(resultPromise).resolves.toMatchObject({
+      ok: false,
+      compacted: false,
+      reason: expect.stringContaining("aborted"),
+    });
+    expect(contextEngineCompactMock).not.toHaveBeenCalled();
+    expect(hookRunner.runBeforeCompaction).not.toHaveBeenCalled();
+    expect(hookRunner.runAfterCompaction).not.toHaveBeenCalled();
+    expect(isEmbeddedAgentRunHandleActive(TEST_SESSION_ID)).toBe(false);
   });
 
-  it("registers queued context-engine compaction as an abortable active run", async () => {
-    let compactSignal: AbortSignal | undefined;
-    const compactionStarted = createDeferred<void>();
-    const compactAborted = createDeferred<void>();
-    contextEngineCompactMock.mockImplementationOnce(async (...args: unknown[]) => {
-      const [params] = args;
-      compactSignal = (params as { abortSignal?: AbortSignal }).abortSignal;
-      compactionStarted.resolve(undefined);
-      await compactAborted.promise;
-      return {
-        ok: false,
-        compacted: false,
-        reason: "aborted",
-        result: undefined,
-      };
+  it.each([
+    { position: "primary", ownsCompaction: false, abortReason: "user_abort", resultOk: false },
+    { position: "secondary", ownsCompaction: true, abortReason: "restart", resultOk: true },
+  ] as const)(
+    "aborts $position native harness compaction through the registered handle",
+    async ({ ownsCompaction, abortReason, resultOk }) => {
+      resolveContextEngineMock.mockResolvedValue({
+        info: { ownsCompaction },
+        compact: contextEngineCompactMock,
+      });
+      resolveAgentHarnessPolicyMock.mockReturnValue({
+        runtime: "codex",
+        runtimeSource: "model",
+      } as never);
+      const pending = mockPendingNativeCompaction();
+      const resultPromise = compactEmbeddedAgentSession(
+        wrappedCompactionArgs({
+          provider: "openai",
+          model: "gpt-5.4",
+          agentHarnessId: "codex",
+          trigger: "manual",
+        }),
+      );
+
+      await pending.started.promise;
+      const aborted =
+        abortReason === "restart"
+          ? abortEmbeddedAgentRun(undefined, { mode: "compacting", reason: "restart" })
+          : abortEmbeddedAgentRun(TEST_SESSION_ID);
+      expect(aborted).toBe(true);
+      expect(pending.signal?.reason).toBe(abortReason);
+      pending.terminal.resolve({ ok: false, compacted: false, reason: "aborted" });
+
+      await expect(resultPromise).resolves.toMatchObject({ ok: resultOk });
+      expect(contextEngineCompactMock).toHaveBeenCalledTimes(ownsCompaction ? 1 : 0);
+      expect(isEmbeddedAgentRunHandleActive(TEST_SESSION_ID)).toBe(false);
+    },
+  );
+
+  it("registers manual compaction alongside its active reply operation", async () => {
+    const replyOperation = createReplyOperation({
+      sessionKey: TEST_SESSION_KEY,
+      sessionId: TEST_SESSION_ID,
+      resetTriggered: false,
+    });
+    replyOperation.setPhase("preflight_compacting");
+    expect(isEmbeddedAgentRunActive(TEST_SESSION_ID)).toBe(true);
+    expect(isEmbeddedAgentRunHandleActive(TEST_SESSION_ID)).toBe(false);
+    const pending = mockPendingContextEngineCompaction();
+
+    try {
+      const resultPromise = compactEmbeddedAgentSession(
+        wrappedCompactionArgs({
+          abortSignal: replyOperation.abortSignal,
+          trigger: "manual",
+        }),
+      );
+
+      await pending.started.promise;
+      expect(isEmbeddedAgentRunActive(TEST_SESSION_ID)).toBe(true);
+      expect(isEmbeddedAgentRunHandleActive(TEST_SESSION_ID)).toBe(true);
+      expect(replyOperation.abortByUser()).toBe(true);
+      expect(pending.signal?.aborted).toBe(true);
+      expect(pending.signal?.reason).toBe(replyOperation.abortSignal.reason);
+      pending.release.resolve(undefined);
+
+      await expect(resultPromise).resolves.toMatchObject({ ok: false, compacted: false });
+      expect(isEmbeddedAgentRunHandleActive(TEST_SESSION_ID)).toBe(false);
+      expect(isEmbeddedAgentRunActive(TEST_SESSION_ID)).toBe(true);
+    } finally {
+      replyOperation.complete();
+    }
+  });
+
+  it("clears the manual handle when setup rejects", async () => {
+    resolveModelMock.mockImplementationOnce(() => {
+      throw new Error("model failed");
     });
 
-    const resultPromise = compactEmbeddedAgentSession(wrappedCompactionArgs({ trigger: "manual" }));
-
-    await compactionStarted.promise;
-    expect(isEmbeddedAgentRunActive(TEST_SESSION_ID)).toBe(true);
-    expect(abortEmbeddedAgentRun(TEST_SESSION_ID)).toBe(true);
-    expect(compactSignal?.aborted).toBe(true);
-    compactAborted.resolve(undefined);
-
-    const result = await resultPromise;
-
-    expect(result.ok).toBe(false);
-    expect(isEmbeddedAgentRunActive(TEST_SESSION_ID)).toBe(false);
+    await expect(
+      compactEmbeddedAgentSession(wrappedCompactionArgs({ trigger: "manual" })),
+    ).rejects.toThrow("model failed");
+    expect(isEmbeddedAgentRunHandleActive(TEST_SESSION_ID)).toBe(false);
   });
 
-  it("does not replace an existing active run handle during budget compaction", async () => {
-    const existingAbort = vi.fn();
+  it.each([
+    {
+      identity: "session key",
+      activeSessionKey: TEST_SESSION_KEY,
+      activeSessionFile: "/tmp/other-session.jsonl",
+    },
+    {
+      identity: "session file",
+      activeSessionKey: "agent:main:other-session",
+      activeSessionFile: TEST_SESSION_FILE,
+    },
+  ])("rejects manual compaction matching an active $identity", async (active) => {
+    const activeSessionId = "other-session";
     const existingHandle = {
       kind: "embedded" as const,
       queueMessage: async () => {},
       isStreaming: () => true,
       isCompacting: () => false,
-      abort: existingAbort,
+      abort: vi.fn(),
     };
-    setActiveEmbeddedRun(TEST_SESSION_ID, existingHandle, TEST_SESSION_KEY, TEST_SESSION_FILE);
-    let compactSignal: AbortSignal | undefined;
-    contextEngineCompactMock.mockImplementationOnce(async (...args: unknown[]) => {
-      const [params] = args;
-      compactSignal = (params as { abortSignal?: AbortSignal }).abortSignal;
-      return {
-        ok: true,
-        compacted: true,
-        reason: undefined,
-        result: { summary: "engine-summary", tokensAfter: 50 },
-      };
-    });
-
+    setActiveEmbeddedRun(
+      activeSessionId,
+      existingHandle,
+      active.activeSessionKey,
+      active.activeSessionFile,
+    );
     try {
-      const result = await compactEmbeddedAgentSession(
-        wrappedCompactionArgs({ trigger: "budget" }),
-      );
-
-      expect(result.ok).toBe(true);
-      expect(isEmbeddedAgentRunActive(TEST_SESSION_ID)).toBe(true);
-      expect(abortEmbeddedAgentRun(TEST_SESSION_ID)).toBe(true);
-      expect(existingAbort).toHaveBeenCalledOnce();
-      expect(compactSignal?.aborted).toBe(false);
+      await expect(
+        compactEmbeddedAgentSession(wrappedCompactionArgs({ trigger: "manual" })),
+      ).resolves.toMatchObject({
+        ok: false,
+        compacted: false,
+        failure: { reason: "active_run" },
+      });
+      expect(contextEngineCompactMock).not.toHaveBeenCalled();
+      expect(maybeCompactAgentHarnessSessionMock).not.toHaveBeenCalled();
+      expect(isEmbeddedAgentRunHandleActive(activeSessionId)).toBe(true);
     } finally {
-      clearActiveEmbeddedRun(TEST_SESSION_ID, existingHandle, TEST_SESSION_KEY, TEST_SESSION_FILE);
+      clearActiveEmbeddedRun(
+        activeSessionId,
+        existingHandle,
+        active.activeSessionKey,
+        active.activeSessionFile,
+      );
     }
   });
 

--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -37,6 +37,12 @@ import {
   sessionCompactImpl,
   triggerInternalHook,
 } from "./compact.hooks.harness.js";
+import {
+  abortEmbeddedAgentRun,
+  clearActiveEmbeddedRun,
+  isEmbeddedAgentRunActive,
+  setActiveEmbeddedRun,
+} from "./runs.js";
 
 let compactEmbeddedAgentSessionDirect: typeof import("./compact.js").compactEmbeddedAgentSessionDirect;
 let compactEmbeddedAgentSession: typeof import("./compact.queued.js").compactEmbeddedAgentSession;
@@ -2617,16 +2623,108 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
     });
   });
 
-  it("threads the caller abort signal into the engine compact() call", async () => {
+  it("forwards the caller abort signal into the engine compact() call", async () => {
     const controller = new AbortController();
+    let compactSignal: AbortSignal | undefined;
+    const compactionStarted = createDeferred<void>();
+    const compactionReleased = createDeferred<void>();
+    contextEngineCompactMock.mockImplementationOnce(async (...args: unknown[]) => {
+      const [params] = args;
+      compactSignal = (params as { abortSignal?: AbortSignal }).abortSignal;
+      compactionStarted.resolve(undefined);
+      await compactionReleased.promise;
+      return {
+        ok: true,
+        compacted: true,
+        reason: undefined,
+        result: { summary: "engine-summary", tokensAfter: 50 },
+      };
+    });
 
-    const result = await compactEmbeddedAgentSession(
+    const resultPromise = compactEmbeddedAgentSession(
       wrappedCompactionArgs({ abortSignal: controller.signal }),
     );
 
-    expect(result.ok).toBe(true);
-    const compactArg = mockCallArg(contextEngineCompactMock) as { abortSignal?: AbortSignal };
-    expect(compactArg.abortSignal).toBe(controller.signal);
+    await compactionStarted.promise;
+    expect(compactSignal).toBeInstanceOf(AbortSignal);
+    expect(compactSignal).not.toBe(controller.signal);
+    controller.abort("caller_abort");
+    expect(compactSignal?.aborted).toBe(true);
+    expect(compactSignal?.reason).toBe("caller_abort");
+    compactionReleased.resolve(undefined);
+
+    const result = await resultPromise;
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain("aborted");
+  });
+
+  it("registers queued context-engine compaction as an abortable active run", async () => {
+    let compactSignal: AbortSignal | undefined;
+    const compactionStarted = createDeferred<void>();
+    const compactAborted = createDeferred<void>();
+    contextEngineCompactMock.mockImplementationOnce(async (...args: unknown[]) => {
+      const [params] = args;
+      compactSignal = (params as { abortSignal?: AbortSignal }).abortSignal;
+      compactionStarted.resolve(undefined);
+      await compactAborted.promise;
+      return {
+        ok: false,
+        compacted: false,
+        reason: "aborted",
+        result: undefined,
+      };
+    });
+
+    const resultPromise = compactEmbeddedAgentSession(wrappedCompactionArgs({ trigger: "manual" }));
+
+    await compactionStarted.promise;
+    expect(isEmbeddedAgentRunActive(TEST_SESSION_ID)).toBe(true);
+    expect(abortEmbeddedAgentRun(TEST_SESSION_ID)).toBe(true);
+    expect(compactSignal?.aborted).toBe(true);
+    compactAborted.resolve(undefined);
+
+    const result = await resultPromise;
+
+    expect(result.ok).toBe(false);
+    expect(isEmbeddedAgentRunActive(TEST_SESSION_ID)).toBe(false);
+  });
+
+  it("does not replace an existing active run handle during budget compaction", async () => {
+    const existingAbort = vi.fn();
+    const existingHandle = {
+      kind: "embedded" as const,
+      queueMessage: async () => {},
+      isStreaming: () => true,
+      isCompacting: () => false,
+      abort: existingAbort,
+    };
+    setActiveEmbeddedRun(TEST_SESSION_ID, existingHandle, TEST_SESSION_KEY, TEST_SESSION_FILE);
+    let compactSignal: AbortSignal | undefined;
+    contextEngineCompactMock.mockImplementationOnce(async (...args: unknown[]) => {
+      const [params] = args;
+      compactSignal = (params as { abortSignal?: AbortSignal }).abortSignal;
+      return {
+        ok: true,
+        compacted: true,
+        reason: undefined,
+        result: { summary: "engine-summary", tokensAfter: 50 },
+      };
+    });
+
+    try {
+      const result = await compactEmbeddedAgentSession(
+        wrappedCompactionArgs({ trigger: "budget" }),
+      );
+
+      expect(result.ok).toBe(true);
+      expect(isEmbeddedAgentRunActive(TEST_SESSION_ID)).toBe(true);
+      expect(abortEmbeddedAgentRun(TEST_SESSION_ID)).toBe(true);
+      expect(existingAbort).toHaveBeenCalledOnce();
+      expect(compactSignal?.aborted).toBe(false);
+    } finally {
+      clearActiveEmbeddedRun(TEST_SESSION_ID, existingHandle, TEST_SESSION_KEY, TEST_SESSION_FILE);
+    }
   });
 
   it("does not duplicate transcript updates or sync in the wrapper when the engine delegates compaction", async () => {

--- a/src/agents/embedded-agent-runner/compact.queued.ts
+++ b/src/agents/embedded-agent-runner/compact.queued.ts
@@ -58,6 +58,8 @@ import { resolveGlobalLane, resolveSessionLane } from "./lanes.js";
 import { log } from "./logger.js";
 import { readAgentModelContextTokens } from "./model-context-tokens.js";
 import { resolveModelAsync } from "./model.js";
+import type { EmbeddedAgentQueueHandle } from "./run-state.js";
+import { clearActiveEmbeddedRun, isEmbeddedAgentRunActive, setActiveEmbeddedRun } from "./runs.js";
 import type { EmbeddedAgentCompactResult } from "./types.js";
 import { normalizeContextTokenBudget } from "./utils.js";
 
@@ -87,6 +89,49 @@ function shouldDeferOwningContextEngineBudgetCompaction(params: {
     params.contextEngine.info.turnMaintenanceMode === "background" &&
     typeof params.contextEngine.maintain === "function"
   );
+}
+
+function createQueuedCompactionAbort(params: {
+  sessionId: string;
+  sessionKey?: string;
+  sessionFile?: string;
+  abortSignal?: AbortSignal;
+  registerActiveRun?: boolean;
+}): {
+  signal: AbortSignal;
+  dispose: () => void;
+} {
+  const controller = new AbortController();
+  const forwardAbort = () => controller.abort(params.abortSignal?.reason);
+  if (params.abortSignal) {
+    if (params.abortSignal.aborted) {
+      forwardAbort();
+    } else {
+      params.abortSignal.addEventListener("abort", forwardAbort, { once: true });
+    }
+  }
+  const handle: EmbeddedAgentQueueHandle = {
+    kind: "embedded",
+    queueMessage: async () => {},
+    isStreaming: () => true,
+    isCompacting: () => true,
+    abort: () => controller.abort("user_abort"),
+    cancel: (reason) => controller.abort(reason),
+  };
+  const registered =
+    params.registerActiveRun === true && !isEmbeddedAgentRunActive(params.sessionId);
+  if (registered) {
+    setActiveEmbeddedRun(params.sessionId, handle, params.sessionKey, params.sessionFile);
+  }
+  return {
+    signal: controller.signal,
+    dispose: () => {
+      params.abortSignal?.removeEventListener("abort", forwardAbort);
+      if (registered) {
+        clearActiveEmbeddedRun(params.sessionId, handle, params.sessionKey, params.sessionFile);
+      }
+    },
+  };
 }
 
 async function disposeContextEngine(contextEngine: ContextEngine): Promise<void> {
@@ -345,6 +390,13 @@ export async function compactEmbeddedAgentSession(
     enqueueGlobal(async () => {
       let checkpointSnapshot: CapturedCompactionCheckpointSnapshot | null | undefined;
       let checkpointSnapshotRetained = false;
+      const queuedCompactionAbort = createQueuedCompactionAbort({
+        sessionId: params.sessionId,
+        sessionKey: params.sessionKey,
+        sessionFile: params.sessionFile,
+        abortSignal: params.abortSignal,
+        registerActiveRun: params.trigger === "manual",
+      });
       try {
         // When the context engine owns compaction, its compact() implementation
         // bypasses compactEmbeddedAgentSessionDirect (which fires the hooks internally).
@@ -429,7 +481,7 @@ export async function compactEmbeddedAgentSession(
               runtimeSettings: contextEngineRuntimeSettings,
             },
             resolveCompactionTimeoutMs(params.config),
-            params.abortSignal,
+            queuedCompactionAbort.signal,
           );
         } catch (compactErr) {
           log.warn("context-engine compaction failed", {
@@ -620,6 +672,7 @@ export async function compactEmbeddedAgentSession(
             : undefined,
         };
       } finally {
+        queuedCompactionAbort.dispose();
         if (!checkpointSnapshotRetained) {
           await compactionCheckpointStore.cleanupSnapshot(checkpointSnapshot);
         }

--- a/src/agents/embedded-agent-runner/compact.queued.ts
+++ b/src/agents/embedded-agent-runner/compact.queued.ts
@@ -21,6 +21,7 @@ import {
   resolveSessionCompactionCheckpointReason,
   type CapturedCompactionCheckpointSnapshot,
 } from "../../gateway/session-compaction-checkpoints.js";
+import { mergeAbortSignals } from "../../infra/abort-signal.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
@@ -59,7 +60,13 @@ import { log } from "./logger.js";
 import { readAgentModelContextTokens } from "./model-context-tokens.js";
 import { resolveModelAsync } from "./model.js";
 import type { EmbeddedAgentQueueHandle } from "./run-state.js";
-import { clearActiveEmbeddedRun, isEmbeddedAgentRunActive, setActiveEmbeddedRun } from "./runs.js";
+import {
+  clearActiveEmbeddedRun,
+  isEmbeddedAgentRunHandleActive,
+  resolveActiveEmbeddedRunHandleSessionId,
+  resolveActiveEmbeddedRunHandleSessionIdBySessionFile,
+  setActiveEmbeddedRun,
+} from "./runs.js";
 import type { EmbeddedAgentCompactResult } from "./types.js";
 import { normalizeContextTokenBudget } from "./utils.js";
 
@@ -73,6 +80,27 @@ function shouldFallbackAfterHarnessCompaction(
 
 const DEFERRED_CONTEXT_ENGINE_COMPACTION_SCHEDULE_FAILURE_REASON =
   "failed to schedule background context-engine maintenance";
+const MANUAL_COMPACTION_ACTIVE_RUN_REASON =
+  "manual compaction unavailable while another embedded run is active";
+const COMPACTION_ABORTED_REASON = "compaction aborted";
+
+function createCompactionAbortedResult(): EmbeddedAgentCompactResult {
+  return {
+    ok: false,
+    compacted: false,
+    reason: COMPACTION_ABORTED_REASON,
+  };
+}
+
+function resolveManualCompactionActiveRunSessionId(
+  params: CompactEmbeddedAgentSessionParams,
+): string | undefined {
+  return (
+    (isEmbeddedAgentRunHandleActive(params.sessionId) ? params.sessionId : undefined) ??
+    (params.sessionKey ? resolveActiveEmbeddedRunHandleSessionId(params.sessionKey) : undefined) ??
+    resolveActiveEmbeddedRunHandleSessionIdBySessionFile(params.sessionFile)
+  );
+}
 
 function shouldDeferOwningContextEngineBudgetCompaction(params: {
   compactParams: CompactEmbeddedAgentSessionParams;
@@ -89,49 +117,6 @@ function shouldDeferOwningContextEngineBudgetCompaction(params: {
     params.contextEngine.info.turnMaintenanceMode === "background" &&
     typeof params.contextEngine.maintain === "function"
   );
-}
-
-function createQueuedCompactionAbort(params: {
-  sessionId: string;
-  sessionKey?: string;
-  sessionFile?: string;
-  abortSignal?: AbortSignal;
-  registerActiveRun?: boolean;
-}): {
-  signal: AbortSignal;
-  dispose: () => void;
-} {
-  const controller = new AbortController();
-  const forwardAbort = () => controller.abort(params.abortSignal?.reason);
-  if (params.abortSignal) {
-    if (params.abortSignal.aborted) {
-      forwardAbort();
-    } else {
-      params.abortSignal.addEventListener("abort", forwardAbort, { once: true });
-    }
-  }
-  const handle: EmbeddedAgentQueueHandle = {
-    kind: "embedded",
-    queueMessage: async () => {},
-    isStreaming: () => true,
-    isCompacting: () => true,
-    abort: () => controller.abort("user_abort"),
-    cancel: (reason) => controller.abort(reason),
-  };
-  const registered =
-    params.registerActiveRun === true && !isEmbeddedAgentRunActive(params.sessionId);
-  if (registered) {
-    setActiveEmbeddedRun(params.sessionId, handle, params.sessionKey, params.sessionFile);
-  }
-  return {
-    signal: controller.signal,
-    dispose: () => {
-      params.abortSignal?.removeEventListener("abort", forwardAbort);
-      if (registered) {
-        clearActiveEmbeddedRun(params.sessionId, handle, params.sessionKey, params.sessionFile);
-      }
-    },
-  };
 }
 
 async function disposeContextEngine(contextEngine: ContextEngine): Promise<void> {
@@ -236,6 +221,48 @@ function mergeSecondaryNativeHarnessCompactionDetails(params: {
 export async function compactEmbeddedAgentSession(
   params: CompactEmbeddedAgentSessionParams,
 ): Promise<EmbeddedAgentCompactResult> {
+  if (params.trigger !== "manual") {
+    return await compactEmbeddedAgentSessionImpl(params);
+  }
+  // Reply operations and embedded handles are separate lifecycle owners. A
+  // /compact reply may coexist with this handle, but another embedded writer may not.
+  if (resolveManualCompactionActiveRunSessionId(params)) {
+    return {
+      ok: false,
+      compacted: false,
+      reason: MANUAL_COMPACTION_ACTIVE_RUN_REASON,
+      failure: { reason: "active_run" },
+    };
+  }
+
+  const controller = new AbortController();
+  const mergedAbort = mergeAbortSignals([params.abortSignal, controller.signal]);
+  const handle: EmbeddedAgentQueueHandle = {
+    kind: "embedded",
+    queueMessage: async () => {},
+    isStreaming: () => true,
+    isCompacting: () => true,
+    abort: (reason) => controller.abort(reason ?? "user_abort"),
+    cancel: (reason) => controller.abort(reason ?? "user_abort"),
+  };
+  setActiveEmbeddedRun(params.sessionId, handle, params.sessionKey, params.sessionFile);
+  try {
+    return await compactEmbeddedAgentSessionImpl({
+      ...params,
+      abortSignal: mergedAbort.signal,
+    });
+  } finally {
+    mergedAbort.dispose();
+    clearActiveEmbeddedRun(params.sessionId, handle, params.sessionKey, params.sessionFile);
+  }
+}
+
+async function compactEmbeddedAgentSessionImpl(
+  params: CompactEmbeddedAgentSessionParams,
+): Promise<EmbeddedAgentCompactResult> {
+  if (params.abortSignal?.aborted) {
+    return createCompactionAbortedResult();
+  }
   ensureRuntimePluginsLoaded({
     config: params.config,
     workspaceDir: params.workspaceDir,
@@ -390,14 +417,10 @@ export async function compactEmbeddedAgentSession(
     enqueueGlobal(async () => {
       let checkpointSnapshot: CapturedCompactionCheckpointSnapshot | null | undefined;
       let checkpointSnapshotRetained = false;
-      const queuedCompactionAbort = createQueuedCompactionAbort({
-        sessionId: params.sessionId,
-        sessionKey: params.sessionKey,
-        sessionFile: params.sessionFile,
-        abortSignal: params.abortSignal,
-        registerActiveRun: params.trigger === "manual",
-      });
       try {
+        if (params.abortSignal?.aborted) {
+          return createCompactionAbortedResult();
+        }
         // When the context engine owns compaction, its compact() implementation
         // bypasses compactEmbeddedAgentSessionDirect (which fires the hooks internally).
         // Fire before_compaction / after_compaction hooks here so plugin subscribers
@@ -481,7 +504,7 @@ export async function compactEmbeddedAgentSession(
               runtimeSettings: contextEngineRuntimeSettings,
             },
             resolveCompactionTimeoutMs(params.config),
-            queuedCompactionAbort.signal,
+            params.abortSignal,
           );
         } catch (compactErr) {
           log.warn("context-engine compaction failed", {
@@ -672,7 +695,6 @@ export async function compactEmbeddedAgentSession(
             : undefined,
         };
       } finally {
-        queuedCompactionAbort.dispose();
         if (!checkpointSnapshotRetained) {
           await compactionCheckpointStore.cleanupSnapshot(checkpointSnapshot);
         }

--- a/src/auto-reply/reply/commands-compact.test.ts
+++ b/src/auto-reply/reply/commands-compact.test.ts
@@ -18,7 +18,7 @@ vi.mock("./commands-compact.runtime.js", () => ({
   resolveFreshSessionTotalTokens: vi.fn(() => 12_345),
   resolveSessionFilePath: vi.fn(() => "/tmp/session.json"),
   resolveSessionFilePathOptions: vi.fn(() => ({})),
-  waitForEmbeddedAgentRunEnd: vi.fn().mockResolvedValue(undefined),
+  waitForEmbeddedAgentRunEnd: vi.fn().mockResolvedValue(true),
 }));
 
 const {
@@ -254,6 +254,36 @@ describe("handleCompactCommand", () => {
     expect(vi.mocked(abortEmbeddedAgentRun)).toHaveBeenCalledWith("session-1");
     expect(vi.mocked(waitForEmbeddedAgentRunEnd)).toHaveBeenCalledWith("session-1", 15_000);
     expect(vi.mocked(compactEmbeddedAgentSession)).toHaveBeenCalledOnce();
+  });
+
+  it("does not replace an active run when abort drain times out", async () => {
+    vi.mocked(isEmbeddedAgentRunAbortableForCompaction).mockReturnValueOnce(true);
+    vi.mocked(waitForEmbeddedAgentRunEnd).mockResolvedValueOnce(false);
+
+    const result = await handleCompactCommand(
+      {
+        ...buildCompactParams("/compact", {
+          commands: { text: true },
+          channels: { whatsapp: { allowFrom: ["*"] } },
+        } as OpenClawConfig),
+        sessionEntry: {
+          sessionId: "session-1",
+          updatedAt: Date.now(),
+        },
+      } as HandleCommandsParams,
+      true,
+    );
+
+    expect(result).toEqual({
+      shouldContinue: false,
+      reply: {
+        text: "⚙️ Compaction unavailable: the previous run is still stopping.",
+        isStatusNotice: true,
+      },
+    });
+    expect(vi.mocked(abortEmbeddedAgentRun)).toHaveBeenCalledWith("session-1");
+    expect(vi.mocked(waitForEmbeddedAgentRunEnd)).toHaveBeenCalledWith("session-1", 15_000);
+    expect(vi.mocked(compactEmbeddedAgentSession)).not.toHaveBeenCalled();
   });
 
   it("treats already-under-target manual compaction as skipped", async () => {

--- a/src/auto-reply/reply/commands-compact.ts
+++ b/src/auto-reply/reply/commands-compact.ts
@@ -206,7 +206,16 @@ export const handleCompactCommand: CommandHandler = async (params) => {
   const sessionId = targetSessionEntry.sessionId;
   if (runtime.isEmbeddedAgentRunAbortableForCompaction(sessionId)) {
     runtime.abortEmbeddedAgentRun(sessionId);
-    await runtime.waitForEmbeddedAgentRunEnd(sessionId, 15_000);
+    const drained = await runtime.waitForEmbeddedAgentRunEnd(sessionId, 15_000);
+    if (!drained) {
+      return {
+        shouldContinue: false,
+        reply: {
+          text: "⚙️ Compaction unavailable: the previous run is still stopping.",
+          isStatusNotice: true,
+        },
+      };
+    }
   }
   const sessionAgentId = params.sessionKey
     ? resolveSessionAgentId({ sessionKey: params.sessionKey, config: params.cfg })


### PR DESCRIPTION
Closes #66535

## What Problem This Solves

Fixes an issue where users running manual `/compact` could not stop a slow or stuck compaction with `/stop`. The work was not discoverable through the active-run lifecycle, so cancellation was a no-op until compaction completed or timed out.

## Why This Change Was Made

Manual compaction now owns one exact embedded-run handle before setup, native compaction, or lane waiting begins. The handle preserves any existing embedded writer, merges caller and lifecycle abort signals, carries cancellation through context-engine and native-harness compaction, and clears itself on every exit. The command also refuses to start a second writer when a previously aborted run does not drain within 15 seconds.

Budget and preflight compaction keep their existing owner and behavior.

## User Impact

Users can stop an in-progress manual compaction through the same `/stop` path used for other active agent work. A stop issued before the queued compaction begins also prevents hooks and compaction work from starting.

## Evidence

Exact reviewed head: `ce88c48092afd6cca9e537477311d84cbf666b3b`.

- [CI run 29107478969, attempt 2](https://github.com/openclaw/openclaw/actions/runs/29107478969): success. Attempt 1's only failure was an unrelated Telegram proof process-timing flake; [the failed job rerun](https://github.com/openclaw/openclaw/actions/runs/29107478969/job/86413906108) succeeded.
- [Real behavior proof](https://github.com/openclaw/openclaw/actions/runs/29107477300): success.
- Focused coverage proves cancellation before the queued task starts; context-engine cancellation; primary and secondary native-harness cancellation; coexistence with the command reply operation; active session-key/session-file rejection; setup-failure cleanup; and abort-drain timeout refusal.
- Fresh `gpt-5.5` xhigh autoreview against current `origin/main`: no accepted or actionable findings.

Direct Codex contract review confirms the native path is cancellable through this signal:

- `codex-rs/app-server/src/request_processors/thread_processor.rs:1820-1831` submits `Op::Compact` from `thread/compact/start` and returns.
- `codex-rs/app-server/src/request_processors/turn_processor.rs:1346-1408` submits `Op::Interrupt` and holds a normal interrupt response until terminal abort handling.
- `extensions/codex/src/app-server/compact.ts:117-159,268-278` issues `turn/interrupt` when the passed signal aborts and retains its terminal/retirement lifecycle fence.
- `extensions/codex/harness.ts:92-105` routes both primary and post-context-engine native compaction through that bridge.

Remaining gap: no live Control UI or TUI `/stop` trace against a controllably slow queued or Codex-native compaction. The production cancellation lifecycle and native bridge are covered at source and exact-head CI/Real-proof level.
