### PR TITLE
fix(memory-core): surface empty narrative generation instead of silent fallback (#90781)

### DIFF
--- a/extensions/memory-core/src/dreaming-narrative.test.ts
+++ b/extensions/memory-core/src/dreaming-narrative.test.ts
@@ -18,6 +18,7 @@ import {
   buildNarrativePrompt,
   dedupeDreamDiaryEntries,
   extractNarrativeText,
+  summarizeNarrativeMessages,
   formatNarrativeDate,
   formatBackfillDiaryDate,
   generateAndAppendDreamNarrative,
@@ -212,6 +213,53 @@ describe("extractNarrativeText", () => {
       { role: "assistant", content: "Final response." },
     ];
     expect(extractNarrativeText(messages)).toBe("Final response.");
+  });
+});
+
+describe("summarizeNarrativeMessages", () => {
+  it("reports empty when there are no messages", () => {
+    expect(summarizeNarrativeMessages([])).toBe("messages=0");
+  });
+
+  it("flags whitespace-only assistant string content", () => {
+    const summary = summarizeNarrativeMessages([{ role: "assistant", content: "   " }]);
+    expect(summary).toContain("assistant=1");
+    expect(summary).toContain("whitespaceOnly=1");
+    expect(summary).toContain("withText=0");
+    expect(summary).toContain("lastAssistantContent=string");
+  });
+
+  it("flags tool-only assistant turns so operators see the real cause", () => {
+    const summary = summarizeNarrativeMessages([
+      { role: "user", content: "go" },
+      {
+        role: "assistant",
+        content: [{ type: "tool_use", id: "t1", name: "search", input: {} }],
+      },
+    ]);
+    expect(summary).toContain("toolOnly=1");
+    expect(summary).toContain("withText=0");
+    expect(summary).toContain("lastAssistantContent=array");
+  });
+
+  it("does not flag tool-only when the assistant also has text", () => {
+    const summary = summarizeNarrativeMessages([
+      {
+        role: "assistant",
+        content: [
+          { type: "tool_use", id: "t1", name: "search", input: {} },
+          { type: "text", text: "Here is the entry." },
+        ],
+      },
+    ]);
+    expect(summary).toContain("withText=1");
+    expect(summary).toContain("toolOnly=0");
+  });
+
+  it("reports no assistant when only user messages are present", () => {
+    const summary = summarizeNarrativeMessages([{ role: "user", content: "hello" }]);
+    expect(summary).toContain("assistant=0");
+    expect(summary).toContain("lastAssistantContent=none");
   });
 });
 

--- a/extensions/memory-core/src/dreaming-narrative.test.ts
+++ b/extensions/memory-core/src/dreaming-narrative.test.ts
@@ -936,7 +936,7 @@ describe("generateAndAppendDreamNarrative", () => {
       expect(subagent.getSessionMessages).toHaveBeenCalledTimes(5);
       const content = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8");
       expect(content).toContain(
-        "(Fallback entry: narrative generation produced no usable text for this run.) A memory trace surfaced, but details were unavailable.",
+        "(Fallback entry: this run could not generate a diary narrative.) A memory trace surfaced, but details were unavailable.",
       );
       expectLogIncludes(logger.warn, "produced no text");
     } finally {
@@ -1105,7 +1105,7 @@ describe("generateAndAppendDreamNarrative", () => {
     // placeholder is written on fallback.
     expect(content).not.toContain("some memory");
     expect(content).toContain(
-      "(Fallback entry: narrative generation produced no usable text for this run.) A memory trace surfaced, but details were unavailable.",
+      "(Fallback entry: this run could not generate a diary narrative.) A memory trace surfaced, but details were unavailable.",
     );
     expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("status=timeout"));
   });
@@ -1138,7 +1138,7 @@ describe("generateAndAppendDreamNarrative", () => {
     expect(content).not.toContain("Session Key:");
     expect(content).not.toContain("agent:main:dashboard");
     expect(content).toContain(
-      "(Fallback entry: narrative generation produced no usable text for this run.) A memory trace surfaced, but details were unavailable.",
+      "(Fallback entry: this run could not generate a diary narrative.) A memory trace surfaced, but details were unavailable.",
     );
   });
 
@@ -1203,7 +1203,7 @@ describe("generateAndAppendDreamNarrative", () => {
     // Raw staging snippets must never leak into the diary on fallback.
     expect(content).not.toContain("API endpoints need authentication");
     expect(content).toContain(
-      "(Fallback entry: narrative generation produced no usable text for this run.) A memory trace surfaced, but details were unavailable.",
+      "(Fallback entry: this run could not generate a diary narrative.) A memory trace surfaced, but details were unavailable.",
     );
     expectLogIncludes(logger.info, "request-scoped");
     expectLogExcludes(logger.warn, "request-scoped");
@@ -1237,7 +1237,7 @@ describe("generateAndAppendDreamNarrative", () => {
     // Raw staging promotions must never leak into the diary on fallback.
     expect(content).not.toContain("A durable candidate surfaced.");
     expect(content).toContain(
-      "(Fallback entry: narrative generation produced no usable text for this run.) A memory trace surfaced, but details were unavailable.",
+      "(Fallback entry: this run could not generate a diary narrative.) A memory trace surfaced, but details were unavailable.",
     );
     expectLogIncludes(logger.info, "request-scoped");
     expectLogExcludes(logger.warn, "request-scoped");

--- a/extensions/memory-core/src/dreaming-narrative.test.ts
+++ b/extensions/memory-core/src/dreaming-narrative.test.ts
@@ -242,6 +242,18 @@ describe("summarizeNarrativeMessages", () => {
     expect(summary).toContain("lastAssistantContent=array");
   });
 
+  it("classifies the canonical normalized toolCall shape as tool-only", () => {
+    const summary = summarizeNarrativeMessages([
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "t1", name: "search", arguments: {} }],
+      },
+    ]);
+    expect(summary).toContain("toolOnly=1");
+    expect(summary).toContain("nonTextParts=0");
+    expect(summary).toContain("withText=0");
+  });
+
   it("does not flag tool-only when the assistant also has text", () => {
     const summary = summarizeNarrativeMessages([
       {
@@ -924,7 +936,7 @@ describe("generateAndAppendDreamNarrative", () => {
       expect(subagent.getSessionMessages).toHaveBeenCalledTimes(5);
       const content = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8");
       expect(content).toContain(
-        "A memory trace surfaced, but details were unavailable in this run.",
+        "(Fallback entry: narrative generation produced no usable text for this run.) A memory trace surfaced, but details were unavailable.",
       );
       expectLogIncludes(logger.warn, "produced no text");
     } finally {
@@ -1092,7 +1104,9 @@ describe("generateAndAppendDreamNarrative", () => {
     // Raw staging snippets must never leak into the diary; only the generic
     // placeholder is written on fallback.
     expect(content).not.toContain("some memory");
-    expect(content).toContain("A memory trace surfaced, but details were unavailable in this run.");
+    expect(content).toContain(
+      "(Fallback entry: narrative generation produced no usable text for this run.) A memory trace surfaced, but details were unavailable.",
+    );
     expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("status=timeout"));
   });
 
@@ -1123,7 +1137,9 @@ describe("generateAndAppendDreamNarrative", () => {
     }
     expect(content).not.toContain("Session Key:");
     expect(content).not.toContain("agent:main:dashboard");
-    expect(content).toContain("A memory trace surfaced, but details were unavailable in this run.");
+    expect(content).toContain(
+      "(Fallback entry: narrative generation produced no usable text for this run.) A memory trace surfaced, but details were unavailable.",
+    );
   });
 
   it("skips extra settle waits after timeout and still attempts cleanup", async () => {
@@ -1186,7 +1202,9 @@ describe("generateAndAppendDreamNarrative", () => {
     const content = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8");
     // Raw staging snippets must never leak into the diary on fallback.
     expect(content).not.toContain("API endpoints need authentication");
-    expect(content).toContain("A memory trace surfaced, but details were unavailable in this run.");
+    expect(content).toContain(
+      "(Fallback entry: narrative generation produced no usable text for this run.) A memory trace surfaced, but details were unavailable.",
+    );
     expectLogIncludes(logger.info, "request-scoped");
     expectLogExcludes(logger.warn, "request-scoped");
     expectLogExcludes(logger.warn, workspaceDir);
@@ -1218,7 +1236,9 @@ describe("generateAndAppendDreamNarrative", () => {
     const content = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8");
     // Raw staging promotions must never leak into the diary on fallback.
     expect(content).not.toContain("A durable candidate surfaced.");
-    expect(content).toContain("A memory trace surfaced, but details were unavailable in this run.");
+    expect(content).toContain(
+      "(Fallback entry: narrative generation produced no usable text for this run.) A memory trace surfaced, but details were unavailable.",
+    );
     expectLogIncludes(logger.info, "request-scoped");
     expectLogExcludes(logger.warn, "request-scoped");
     expect(subagent.deleteSession).toHaveBeenCalledOnce();

--- a/extensions/memory-core/src/dreaming-narrative.ts
+++ b/extensions/memory-core/src/dreaming-narrative.ts
@@ -147,7 +147,7 @@ function formatFallbackWriteFailure(err: unknown): string {
 }
 
 const REQUEST_SCOPED_FALLBACK_NARRATIVE =
-  "A memory trace surfaced, but details were unavailable in this run.";
+  "(Fallback entry: narrative generation produced no usable text for this run.) A memory trace surfaced, but details were unavailable.";
 
 export async function appendFallbackNarrativeEntry(params: {
   workspaceDir: string;
@@ -459,8 +459,13 @@ export function summarizeNarrativeMessages(messages: unknown[]): string {
       if (hasText) {
         assistantWithText += 1;
       } else if (
+        // Covers the canonical OpenClaw normalized shape (toolCall) plus the
+        // provider-native camel/snake variants that can reach session files.
+        partTypes.has("toolCall") ||
+        partTypes.has("toolUse") ||
         partTypes.has("tool_use") ||
         partTypes.has("tool_call") ||
+        partTypes.has("functionCall") ||
         partTypes.has("function_call")
       ) {
         assistantToolOnly += 1;

--- a/extensions/memory-core/src/dreaming-narrative.ts
+++ b/extensions/memory-core/src/dreaming-narrative.ts
@@ -146,8 +146,11 @@ function formatFallbackWriteFailure(err: unknown): string {
   return "unknown error";
 }
 
+// Cause-neutral marker: this fallback covers no-text completions, failed
+// runs, and request-scoped runtime unavailability alike — the specific cause
+// belongs in the gateway log line, never in DREAMS.md.
 const REQUEST_SCOPED_FALLBACK_NARRATIVE =
-  "(Fallback entry: narrative generation produced no usable text for this run.) A memory trace surfaced, but details were unavailable.";
+  "(Fallback entry: this run could not generate a diary narrative.) A memory trace surfaced, but details were unavailable.";
 
 export async function appendFallbackNarrativeEntry(params: {
   workspaceDir: string;

--- a/extensions/memory-core/src/dreaming-narrative.ts
+++ b/extensions/memory-core/src/dreaming-narrative.ts
@@ -368,34 +368,121 @@ function waitForNarrativeMessagesToSettle(delayMs: number): Promise<void> {
   });
 }
 
+// Carries the last-read messages alongside the extracted narrative so the
+// caller can diagnose an empty result (#90781) without re-fetching the session.
+type SettledNarrative = { narrative: string | null; messages: unknown[] };
+
 async function readNarrativeText(params: {
   subagent: SubagentSurface;
   sessionKey: string;
-}): Promise<string | null> {
+}): Promise<SettledNarrative> {
   const { messages } = await params.subagent.getSessionMessages({
     sessionKey: params.sessionKey,
     limit: NARRATIVE_MESSAGE_FETCH_LIMIT,
   });
-  return extractNarrativeText(messages);
+  return { narrative: extractNarrativeText(messages), messages };
 }
 
 async function readSettledNarrativeText(params: {
   subagent: SubagentSurface;
   sessionKey: string;
-}): Promise<string | null> {
-  const immediateNarrative = await readNarrativeText(params);
-  if (immediateNarrative) {
-    return immediateNarrative;
+}): Promise<SettledNarrative> {
+  let last = await readNarrativeText(params);
+  if (last.narrative) {
+    return last;
   }
 
   for (const delayMs of NARRATIVE_MESSAGE_SETTLE_DELAYS_MS) {
     await waitForNarrativeMessagesToSettle(delayMs);
-    const narrative = await readNarrativeText(params);
-    if (narrative) {
-      return narrative;
+    last = await readNarrativeText(params);
+    if (last.narrative) {
+      return last;
     }
   }
-  return null;
+  // Return the most recently read messages so the empty-result diagnostic
+  // reflects what the model actually produced after settling.
+  return last;
+}
+
+// Returns a short diagnostic string that explains *why* extractNarrativeText
+// returned null for a given message array. Used to enrich the "produced no
+// text" warning (#90781) so operators can tell whether the model returned an
+// empty completion, a tool-only assistant turn, refused content, etc., instead
+// of seeing a bare "produced no text" log.
+export function summarizeNarrativeMessages(messages: unknown[]): string {
+  if (!Array.isArray(messages) || messages.length === 0) {
+    return "messages=0";
+  }
+  let assistantCount = 0;
+  let assistantWithText = 0;
+  let assistantWhitespaceOnly = 0;
+  let assistantToolOnly = 0;
+  let assistantNonTextParts = 0;
+  let lastAssistantContentType = "none";
+  for (const msg of messages) {
+    if (!msg || typeof msg !== "object" || Array.isArray(msg)) {
+      continue;
+    }
+    const record = msg as Record<string, unknown>;
+    if (record.role !== "assistant") {
+      continue;
+    }
+    assistantCount += 1;
+    const content = record.content;
+    if (typeof content === "string") {
+      lastAssistantContentType = "string";
+      if (content.trim().length > 0) {
+        assistantWithText += 1;
+      } else {
+        assistantWhitespaceOnly += 1;
+      }
+      continue;
+    }
+    if (Array.isArray(content)) {
+      lastAssistantContentType = "array";
+      const partTypes = new Set<string>();
+      let hasText = false;
+      for (const part of content) {
+        if (!part || typeof part !== "object" || Array.isArray(part)) {
+          continue;
+        }
+        const rawType = (part as Record<string, unknown>).type;
+        const type = typeof rawType === "string" ? rawType : "unknown";
+        partTypes.add(type);
+        if (type === "text" || type === "output_text") {
+          const text = (part as Record<string, unknown>).text;
+          if (typeof text === "string" && text.trim().length > 0) {
+            hasText = true;
+          }
+        }
+      }
+      if (hasText) {
+        assistantWithText += 1;
+      } else if (
+        partTypes.has("tool_use") ||
+        partTypes.has("tool_call") ||
+        partTypes.has("function_call")
+      ) {
+        assistantToolOnly += 1;
+      } else if (partTypes.size > 0) {
+        assistantNonTextParts += 1;
+      } else {
+        assistantWhitespaceOnly += 1;
+      }
+      continue;
+    }
+    lastAssistantContentType = content == null ? "null" : typeof content;
+    assistantNonTextParts += 1;
+  }
+  return [
+    `messages=${messages.length}`,
+    `assistant=${assistantCount}`,
+    `withText=${assistantWithText}`,
+    `whitespaceOnly=${assistantWhitespaceOnly}`,
+    `toolOnly=${assistantToolOnly}`,
+    `nonTextParts=${assistantNonTextParts}`,
+    `lastAssistantContent=${lastAssistantContentType}`,
+  ].join(" ");
 }
 
 // ── Date formatting ────────────────────────────────────────────────────
@@ -928,13 +1015,17 @@ export async function generateAndAppendDreamNarrative(params: {
         return;
       }
 
-      const narrative = await readSettledNarrativeText({
+      const { narrative, messages } = await readSettledNarrativeText({
         subagent: params.subagent,
         sessionKey: successfulSessionKey,
       });
       if (!narrative) {
+        // #90781: enrich the diagnostic so operators can tell why the run
+        // produced no text (empty completion, tool-only assistant turn,
+        // refusal, etc.) instead of just seeing "produced no text".
+        const diagnostic = summarizeNarrativeMessages(messages);
         params.logger.warn(
-          `memory-core: narrative generation produced no text for ${params.data.phase} phase; writing fallback diary entry.`,
+          `memory-core: narrative generation produced no text for ${params.data.phase} phase; writing fallback diary entry [${diagnostic}].`,
         );
         await appendFallbackNarrativeEntry({
           workspaceDir: params.workspaceDir,
@@ -942,7 +1033,7 @@ export async function generateAndAppendDreamNarrative(params: {
           nowMs,
           timezone: params.timezone,
           logger: params.logger,
-          reason: "the narrative run produced no text",
+          reason: `the narrative run produced no text [${diagnostic}]`,
         });
         return;
       }

--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -427,7 +427,7 @@ describe("memory-core dreaming phases", () => {
 
     const dreams = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8");
     expect(dreams).toContain(
-      "(Fallback entry: narrative generation produced no usable text for this run.) A memory trace surfaced, but details were unavailable.",
+      "(Fallback entry: this run could not generate a diary narrative.) A memory trace surfaced, but details were unavailable.",
     );
     expect(dreams).not.toContain("Move backups to S3 Glacier.");
     expect(logger.error).not.toHaveBeenCalled();

--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -426,7 +426,9 @@ describe("memory-core dreaming phases", () => {
     ).resolves.toBeUndefined();
 
     const dreams = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8");
-    expect(dreams).toContain("A memory trace surfaced, but details were unavailable in this run.");
+    expect(dreams).toContain(
+      "(Fallback entry: narrative generation produced no usable text for this run.) A memory trace surfaced, but details were unavailable.",
+    );
     expect(dreams).not.toContain("Move backups to S3 Glacier.");
     expect(logger.error).not.toHaveBeenCalled();
     expectIncludesSubstring(mockStringMessages(logger.info), "request-scoped");

--- a/extensions/memory-core/src/dreaming.test.ts
+++ b/extensions/memory-core/src/dreaming.test.ts
@@ -2385,7 +2385,7 @@ describe("short-term dreaming trigger", () => {
     const dreamsText = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8");
     expect(dreamsText).toContain("<!-- openclaw:dreaming:diary:start -->");
     expect(dreamsText).toContain(
-      "A memory trace surfaced, but details were unavailable in this run.",
+      "(Fallback entry: narrative generation produced no usable text for this run.) A memory trace surfaced, but details were unavailable.",
     );
     expect(dreamsText).not.toContain("Move backups to S3 Glacier.");
     expect(logger.info).toHaveBeenCalledWith(

--- a/extensions/memory-core/src/dreaming.test.ts
+++ b/extensions/memory-core/src/dreaming.test.ts
@@ -2385,7 +2385,7 @@ describe("short-term dreaming trigger", () => {
     const dreamsText = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8");
     expect(dreamsText).toContain("<!-- openclaw:dreaming:diary:start -->");
     expect(dreamsText).toContain(
-      "(Fallback entry: narrative generation produced no usable text for this run.) A memory trace surfaced, but details were unavailable.",
+      "(Fallback entry: this run could not generate a diary narrative.) A memory trace surfaced, but details were unavailable.",
     );
     expect(dreamsText).not.toContain("Move backups to S3 Glacier.");
     expect(logger.info).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary

When a Dreaming narrative run produces no usable text, memory-core writes a
fallback diary entry and logs a bare `narrative generation produced no text`
warning — giving operators no signal about *why* (empty completion, tool-only
assistant turn, refusal, non-text parts, etc.). Issue #90781.

This adds `summarizeNarrativeMessages`, which inspects the assistant messages and
produces a compact diagnostic (`messages=… assistant=… withText=… toolOnly=…
nonTextParts=… lastAssistantContent=…`). The diagnostic is appended to both the
warning log and the fallback entry reason.

## Rebase note

Rebased onto current `main`. Main has since refactored narrative reading into
`readSettledNarrativeText` (retry-with-settle), which no longer exposed the raw
`messages` at the empty-result site. To keep the diagnostic accurate without an
extra session fetch, `readNarrativeText`/`readSettledNarrativeText` now return
the last-read messages alongside the narrative (`SettledNarrative`), and the
empty-result branch summarizes those settled messages.

## Verification

- `node scripts/run-vitest.mjs extensions/memory-core/src/dreaming-narrative.test.ts` → 63 passed.
- `pnpm tsgo:extensions` → clean.
- `oxfmt --check` / `oxlint` clean on changed files.

Closes #90781
