### PR TITLE
fix(mac-gateway): write launchd stderr to a log file and surface it in diagnostics (#90711)

### DIFF
--- a/docs/platforms/mac/bundled-gateway.md
+++ b/docs/platforms/mac/bundled-gateway.md
@@ -60,7 +60,8 @@ Logging:
 
 - launchd stdout: `~/Library/Logs/openclaw/gateway.log` (profiles use
   `gateway-<profile>.log`)
-- launchd stderr: suppressed
+- launchd stderr: `~/Library/Logs/openclaw/gateway.err.log` (profiles use
+  `gateway-<profile>.err.log`)
 
 ## Version compatibility
 

--- a/src/cli/daemon-cli/status.print.test.ts
+++ b/src/cli/daemon-cli/status.print.test.ts
@@ -300,7 +300,7 @@ describe("printDaemonStatus", () => {
     expectMockLineContains(runtime.error, formatCliCommand("openclaw gateway restart"));
   });
 
-  it("prints macOS launchd stdout and suppressed stderr when gateway is not listening", () => {
+  it("prints macOS launchd stdout and stderr log paths when gateway is not listening", () => {
     const originalPlatform = process.platform;
     Object.defineProperty(process, "platform", { value: "darwin" });
     try {
@@ -345,7 +345,10 @@ describe("printDaemonStatus", () => {
 
     expectMockLineContains(runtime.error, "Gateway port 18789 is not listening");
     expectMockLineContains(runtime.error, "/Users/test/Library/Logs/openclaw/gateway.log");
-    expectMockLineContains(runtime.error, "Errors: suppressed");
+    expectMockLineContains(
+      runtime.error,
+      "Errors: /Users/test/Library/Logs/openclaw/gateway.err.log",
+    );
     const errors = runtime.error.mock.calls.map(([line]) => line).join("\n");
     expect(errors.match(/Last gateway error:/g)).toHaveLength(1);
   });

--- a/src/cli/daemon-cli/status.print.ts
+++ b/src/cli/daemon-cli/status.print.ts
@@ -489,7 +489,7 @@ export function printDaemonStatus(status: DaemonStatus, opts: { json: boolean; d
     } else if (process.platform === "darwin") {
       const logs = resolveGatewaySupervisorLogPaths(serviceEnv, { platform: "darwin" });
       defaultRuntime.error(`${errorText("Logs:")} ${shortenHomePath(logs.stdoutPath)}`);
-      defaultRuntime.error(`${errorText("Errors:")} suppressed`);
+      defaultRuntime.error(`${errorText("Errors:")} ${shortenHomePath(logs.stderrPath)}`);
     }
     defaultRuntime.error(
       `${errorText("Restart log:")} ${shortenHomePath(resolveGatewayRestartLogPath(serviceEnv))}`,

--- a/src/commands/status-all/diagnosis.test.ts
+++ b/src/commands/status-all/diagnosis.test.ts
@@ -375,7 +375,7 @@ describe("status-all diagnosis port checks", () => {
     expect(output).not.toContain("Inbound delivery telemetry: unavailable");
   });
 
-  it("does not read or display stale stderr tails on Darwin", async () => {
+  it("summarizes the launchd stderr tail on Darwin now that stderr is a real log file", async () => {
     const originalPlatform = process.platform;
     Object.defineProperty(process, "platform", { value: "darwin" });
     try {
@@ -392,7 +392,7 @@ describe("status-all diagnosis port checks", () => {
           return ["gateway stdout current"];
         }
         if (filePath.endsWith("gateway.err.log")) {
-          return ["failed to bind gateway socket stale"];
+          return ["refusing to bind gateway to 0.0.0.0:8080 without auth"];
         }
         return [];
       });
@@ -401,14 +401,41 @@ describe("status-all diagnosis port checks", () => {
       await appendStatusAllDiagnosis(params);
 
       const output = params.lines.join("\n");
-      expect(gatewayMocks.readFileTailLines).not.toHaveBeenCalledWith(
+      expect(gatewayMocks.readFileTailLines).toHaveBeenCalledWith(
         "/Users/test/Library/Logs/openclaw/gateway.err.log",
         40,
       );
+      expect(output).toContain("# stderr: /Users/test/Library/Logs/openclaw/gateway.err.log");
+      expect(output).toContain("refusing to bind gateway to 0.0.0.0:8080 without auth");
       expect(output).toContain("# stdout: /Users/test/Library/Logs/openclaw/gateway.log");
       expect(output).toContain("gateway stdout current");
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform });
+    }
+  });
+
+  it("omits the stderr section when the stderr log is empty", async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    try {
+      restartLogMocks.resolveGatewaySupervisorLogPaths.mockReturnValue({
+        logDir: "/Users/test/Library/Logs/openclaw",
+        stdoutPath: "/Users/test/Library/Logs/openclaw/gateway.log",
+        stderrPath: "/Users/test/Library/Logs/openclaw/gateway.err.log",
+      });
+      restartLogMocks.resolveGatewayRestartLogPath.mockReturnValue(
+        "/tmp/openclaw/logs/gateway-restart.log",
+      );
+      gatewayMocks.readFileTailLines.mockImplementation(async (filePath: string) =>
+        filePath.endsWith("gateway.log") ? ["gateway stdout current"] : [],
+      );
+      const params = createBaseParams([]);
+
+      await appendStatusAllDiagnosis(params);
+
+      const output = params.lines.join("\n");
+      expect(output).toContain("# stdout: /Users/test/Library/Logs/openclaw/gateway.log");
       expect(output).not.toContain("# stderr:");
-      expect(output).not.toContain("failed to bind gateway socket stale");
     } finally {
       Object.defineProperty(process, "platform", { value: originalPlatform });
     }

--- a/src/commands/status-all/diagnosis.ts
+++ b/src/commands/status-all/diagnosis.ts
@@ -397,16 +397,17 @@ export async function appendStatusAllDiagnosis(params: {
   if (logPaths) {
     params.progress.setLabel("Reading logs…");
     const restartLogPath = resolveGatewayRestartLogPath(process.env);
-    const readStderr = process.platform !== "darwin";
+    // launchd now routes the supervised gateway's stderr to gateway.err.log
+    // (no longer /dev/null), so every platform has a real stderr tail.
     const [stderrTail, stdoutTail, restartTail] = await Promise.all([
-      readStderr ? readFileTailLines(logPaths.stderrPath, 40).catch(() => []) : [],
+      readFileTailLines(logPaths.stderrPath, 40).catch(() => []),
       readFileTailLines(logPaths.stdoutPath, 40).catch(() => []),
       readFileTailLines(restartLogPath, 30).catch(() => []),
     ]);
     if (stderrTail.length > 0 || stdoutTail.length > 0) {
       lines.push("");
       lines.push(muted(`Gateway logs (tail, summarized): ${logPaths.logDir}`));
-      if (readStderr) {
+      if (stderrTail.length > 0) {
         lines.push(`  ${muted(`# stderr: ${logPaths.stderrPath}`)}`);
         for (const line of summarizeLogTail(stderrTail, { maxLines: 22 }).map(redactSecrets)) {
           lines.push(`  ${muted(line)}`);

--- a/src/daemon/diagnostics.test.ts
+++ b/src/daemon/diagnostics.test.ts
@@ -30,19 +30,23 @@ function makeTempStateDir(): string {
 }
 
 describe("readLastGatewayErrorLine", () => {
-  it("ignores stale launchd stderr when stderr is suppressed", async () => {
+  it("reads the launchd supervisor stderr now that it is a real log file", async () => {
     const stateDir = makeTempStateDir();
     const homeDir = makeTempStateDir();
     const env = { HOME: homeDir, OPENCLAW_STATE_DIR: stateDir };
-    const stateLogs = resolveGatewayLogPaths(env);
     const launchdLogs = resolveGatewaySupervisorLogPaths(env, { platform: "darwin" });
-    fs.mkdirSync(stateLogs.logDir, { recursive: true });
     fs.mkdirSync(launchdLogs.logDir, { recursive: true });
-    fs.writeFileSync(stateLogs.stderrPath, "failed to bind gateway socket stale\n", "utf8");
+    // launchd now routes the supervised gateway's stderr to gateway.err.log, so
+    // the most recent stderr failure must win over older stdout output.
     fs.writeFileSync(launchdLogs.stdoutPath, "gateway stdout current\n", "utf8");
+    fs.writeFileSync(
+      launchdLogs.stderrPath,
+      "refusing to bind gateway to 0.0.0.0:8080 without auth\n",
+      "utf8",
+    );
 
     await expect(readLastGatewayErrorLine(env, { platform: "darwin" })).resolves.toBe(
-      "gateway stdout current",
+      "refusing to bind gateway to 0.0.0.0:8080 without auth",
     );
   });
 

--- a/src/daemon/diagnostics.ts
+++ b/src/daemon/diagnostics.ts
@@ -88,18 +88,18 @@ export async function readLastGatewayErrorLine(
   options?: { platform?: NodeJS.Platform; requirePatternMatch?: boolean },
 ): Promise<string | null> {
   const platform = options?.platform ?? process.platform;
-  const readStderr = platform !== "darwin";
-  // launchd supervisor mode combines child stderr into stdout; other platforms
-  // keep stderr as the strongest failure signal.
+  // launchd now routes the supervised gateway's stderr to a real log file
+  // (gateway.err.log) instead of /dev/null, matching systemd/schtasks, so
+  // stderr is the strongest failure signal on every platform.
   const { stdoutPath, stderrPath } =
     platform === "darwin"
       ? resolveGatewaySupervisorLogPaths(env, { platform })
       : resolveGatewayLogPaths(env);
-  const stderrLines = readStderr ? await readGatewayLogTailLines(stderrPath).catch(() => []) : [];
+  const stderrLines = await readGatewayLogTailLines(stderrPath).catch(() => []);
   const stdoutLines = await readGatewayLogTailLines(stdoutPath).catch(() => []);
-  // stderr is the strongest failure signal on non-darwin platforms, so place it
-  // last and scan from the end: the most recent stderr error line then wins over
-  // any (possibly stale) stdout match, matching the stderr-first fallback below.
+  // stderr is the strongest failure signal, so place it last and scan from the
+  // end: the most recent stderr error line then wins over any (possibly stale)
+  // stdout match, matching the stderr-first fallback below.
   const lines = [...stdoutLines, ...stderrLines].map((line) => line.trim());
   for (let i = lines.length - 1; i >= 0; i -= 1) {
     const line = lines[i];
@@ -113,7 +113,5 @@ export async function readLastGatewayErrorLine(
   if (options?.requirePatternMatch) {
     return null;
   }
-  return readStderr
-    ? (findLastNonEmptyLine(stderrLines) ?? findLastNonEmptyLine(stdoutLines))
-    : findLastNonEmptyLine(stdoutLines);
+  return findLastNonEmptyLine(stderrLines) ?? findLastNonEmptyLine(stdoutLines);
 }

--- a/src/daemon/launchd-stderr-cap.test.ts
+++ b/src/daemon/launchd-stderr-cap.test.ts
@@ -1,0 +1,57 @@
+// Bounded retention for the launchd supervisor stderr sink (gateway.err.log).
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { capLaunchAgentStderrLogTail } from "./launchd.js";
+
+const tempRoots: string[] = [];
+
+async function makeStderrFile(content: string): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-launchd-stderr-"));
+  tempRoots.push(root);
+  const stderrPath = path.join(root, "gateway.err.log");
+  await fs.writeFile(stderrPath, content, "utf8");
+  return stderrPath;
+}
+
+describe("capLaunchAgentStderrLogTail", () => {
+  afterEach(async () => {
+    while (tempRoots.length > 0) {
+      const root = tempRoots.pop();
+      if (root) {
+        await fs.rm(root, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it("keeps files at or under the cap untouched", async () => {
+    const content = "small stderr content\n";
+    const stderrPath = await makeStderrFile(content);
+
+    await capLaunchAgentStderrLogTail(stderrPath);
+
+    await expect(fs.readFile(stderrPath, "utf8")).resolves.toBe(content);
+  });
+
+  it("truncates an oversized stderr log to its most recent tail", async () => {
+    // 2.5MB of numbered lines; the newest bytes must survive, oldest must go.
+    const line = (n: number) => `stderr line ${String(n).padStart(8, "0")}\n`;
+    const lines = Array.from({ length: 120_000 }, (_, n) => line(n)).join("");
+    expect(Buffer.byteLength(lines)).toBeGreaterThan(2_000_000);
+    const stderrPath = await makeStderrFile(lines);
+
+    await capLaunchAgentStderrLogTail(stderrPath);
+
+    const after = await fs.readFile(stderrPath, "utf8");
+    expect(Buffer.byteLength(after)).toBe(1_000_000);
+    expect(after).toContain(line(119_999).trim());
+    expect(after).not.toContain("stderr line 00000000");
+  });
+
+  it("silently no-ops when the stderr log does not exist", async () => {
+    await expect(
+      capLaunchAgentStderrLogTail("/nonexistent/openclaw/gateway.err.log"),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -348,7 +348,7 @@ vi.mock("node:fs/promises", async () => {
       if (state.files.has(key)) {
         return {
           mode: state.fileModes.get(key) ?? 0o666,
-          size: Buffer.byteLength(String(state.files.get(key) ?? "")),
+          size: Buffer.byteLength(state.files.get(key) ?? ""),
         };
       }
       throw new Error(`ENOENT: no such file or directory, stat '${key}'`);
@@ -358,7 +358,7 @@ vi.mock("node:fs/promises", async () => {
       if (data === undefined) {
         throw new Error(`ENOENT: no such file or directory, open '${p}'`);
       }
-      const source = Buffer.from(String(data));
+      const source = Buffer.from(data);
       return {
         read: async (buffer: Buffer, offset: number, length: number, position: number) => {
           const bytesRead = source.copy(buffer, offset, position, position + length);

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -13,6 +13,7 @@ import {
 } from "./launchd-plist.js";
 import {
   installLaunchAgent,
+  stageLaunchAgent,
   disableCurrentOpenClawUpdateLaunchdJob,
   disableOpenClawUpdateLaunchdJob,
   findStaleOpenClawUpdateLaunchdJobs,
@@ -345,9 +346,26 @@ vi.mock("node:fs/promises", async () => {
         return { mode: state.dirModes.get(key) ?? 0o777 };
       }
       if (state.files.has(key)) {
-        return { mode: state.fileModes.get(key) ?? 0o666 };
+        return {
+          mode: state.fileModes.get(key) ?? 0o666,
+          size: Buffer.byteLength(String(state.files.get(key) ?? "")),
+        };
       }
       throw new Error(`ENOENT: no such file or directory, stat '${key}'`);
+    }),
+    open: vi.fn(async (p: string) => {
+      const data = state.files.get(p);
+      if (data === undefined) {
+        throw new Error(`ENOENT: no such file or directory, open '${p}'`);
+      }
+      const source = Buffer.from(String(data));
+      return {
+        read: async (buffer: Buffer, offset: number, length: number, position: number) => {
+          const bytesRead = source.copy(buffer, offset, position, position + length);
+          return { bytesRead, buffer };
+        },
+        close: async () => {},
+      };
     }),
     chmod: vi.fn(async (p: string, mode: number) => {
       const key = p;
@@ -1167,6 +1185,32 @@ describe("launchd install", () => {
     expect(installKickstartIndex).toBe(-1);
   });
 
+  it("compacts an oversized stderr log only after the agent is booted out", async () => {
+    const env = createDefaultLaunchdEnv();
+    const stderrPath = "/Users/test/Library/Logs/openclaw/gateway.err.log";
+    const oversized = "x".repeat(2_000_001 - 25) + "newest stderr tail marker";
+    state.files.set(stderrPath, oversized);
+
+    // Staging only writes the plist while the previous agent may still be
+    // appending to the stderr sink: it must not be truncated here.
+    await stageLaunchAgent({
+      env,
+      stdout: new PassThrough(),
+      programArguments: defaultProgramArguments,
+    });
+    expect(state.files.get(stderrPath)).toBe(oversized);
+
+    // Install boots the agent out before bootstrap; compaction runs there.
+    await installLaunchAgent({
+      env,
+      stdout: new PassThrough(),
+      programArguments: defaultProgramArguments,
+    });
+    const after = String(state.files.get(stderrPath));
+    expect(Buffer.byteLength(after)).toBe(1_000_000);
+    expect(after.endsWith("newest stderr tail marker")).toBe(true);
+  });
+
   it("writes LaunchAgent environment to an owner-only env file when provided", async () => {
     const env = createDefaultLaunchdEnv();
     const tmpDir = "/Users/test/.openclaw/tmp";
@@ -1461,9 +1505,7 @@ describe("launchd install", () => {
     expect(plist).toContain("<key>StandardErrorPath</key>");
     expect(plist).toContain("<string>/Users/test/Library/Logs/openclaw/gateway.err.log</string>");
     // Regression #90711: stderr must not be silenced to /dev/null. Stdin is still /dev/null.
-    expect(plist).not.toMatch(
-      /<key>StandardErrorPath<\/key>\s*<string>\/dev\/null<\/string>/,
-    );
+    expect(plist).not.toMatch(/<key>StandardErrorPath<\/key>\s*<string>\/dev\/null<\/string>/);
     expect(plist).toContain("<key>KeepAlive</key>");
     expect(plist).toContain("<string>node</string>");
     const rewriteIndex = state.fileWrites.findIndex((write) => write.path === plistPath);

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -1459,7 +1459,11 @@ describe("launchd install", () => {
     expect(plist).toContain("<key>StandardOutPath</key>");
     expect(plist).toContain("<string>/Users/test/Library/Logs/openclaw/gateway.log</string>");
     expect(plist).toContain("<key>StandardErrorPath</key>");
-    expect(plist).toContain("<string>/dev/null</string>");
+    expect(plist).toContain("<string>/Users/test/Library/Logs/openclaw/gateway.err.log</string>");
+    // Regression #90711: stderr must not be silenced to /dev/null. Stdin is still /dev/null.
+    expect(plist).not.toMatch(
+      /<key>StandardErrorPath<\/key>\s*<string>\/dev\/null<\/string>/,
+    );
     expect(plist).toContain("<key>KeepAlive</key>");
     expect(plist).toContain("<string>node</string>");
     const rewriteIndex = state.fileWrites.findIndex((write) => write.path === plistPath);

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -50,7 +50,6 @@ const LAUNCH_AGENT_PRIVATE_DIR_MODE = 0o700;
 const LAUNCH_AGENT_ENV_FILE_MODE = 0o600;
 const LAUNCH_AGENT_ENV_WRAPPER_MODE = 0o700;
 const LAUNCH_AGENT_ENV_DIR_NAME = "service-env";
-const LAUNCH_AGENT_STDERR_PATH = "/dev/null";
 const OPENCLAW_UPDATE_LAUNCHD_LABEL_PREFIX = "ai.openclaw.update.";
 const OPENCLAW_MANUAL_UPDATE_LAUNCHD_LABEL_PATTERN = /^ai\.openclaw\.manual-update\.\d+$/;
 const OPENCLAW_PROFILE_UPDATE_LAUNCHD_LABEL_PATTERN =
@@ -1073,7 +1072,9 @@ async function writeLaunchAgentPlist({
   stdout,
   warn,
 }: GatewayServiceInstallArgs): Promise<{ plistPath: string; stdoutPath: string }> {
-  const { logDir, stdoutPath } = resolveGatewaySupervisorLogPaths(env, { platform: "darwin" });
+  const { logDir, stdoutPath, stderrPath } = resolveGatewaySupervisorLogPaths(env, {
+    platform: "darwin",
+  });
   await ensureSecureDirectory(logDir);
 
   const domain = resolveGuiDomain();
@@ -1112,7 +1113,7 @@ async function writeLaunchAgentPlist({
     programArguments: prepared.programArguments,
     workingDirectory,
     stdoutPath,
-    stderrPath: LAUNCH_AGENT_STDERR_PATH,
+    stderrPath,
     environment: prepared.inlineEnvironment,
   });
   await fs.writeFile(plistPath, plist, { encoding: "utf8", mode: LAUNCH_AGENT_PLIST_MODE });
@@ -1191,7 +1192,9 @@ async function rewriteLaunchAgentPlistForRestart({
     return false;
   }
 
-  const { logDir, stdoutPath } = resolveGatewaySupervisorLogPaths(env, { platform: "darwin" });
+  const { logDir, stdoutPath, stderrPath } = resolveGatewaySupervisorLogPaths(env, {
+    platform: "darwin",
+  });
   await ensureSecureDirectory(logDir);
 
   const serviceDescription = resolveGatewayServiceDescription({
@@ -1212,7 +1215,7 @@ async function rewriteLaunchAgentPlistForRestart({
     programArguments: prepared.programArguments,
     workingDirectory: existing.workingDirectory,
     stdoutPath,
-    stderrPath: LAUNCH_AGENT_STDERR_PATH,
+    stderrPath,
     environment: prepared.inlineEnvironment,
   });
   const previousPlist = await fs.readFile(plistPath, "utf8").catch(() => "");

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -1064,10 +1064,11 @@ export async function stopLaunchAgent({
 }
 
 // Bounded retention for the supervisor stderr sink: launchd appends to
-// gateway.err.log across relaunches and nothing else rotates it, so cap it to
-// a tail whenever OpenClaw (re)writes the plist — fresh installs, gateway
-// restarts, and update handoffs. Growth between operator actions is bounded
-// only by launchd's relaunch throttle until broader log retention lands.
+// gateway.err.log across relaunches and nothing else rotates it. Only call
+// this while the agent is booted out (between bootout and bootstrap):
+// truncating under an active non-append writer would leave a sparse file at
+// the writer's old offset. Growth between operator actions is bounded only by
+// launchd's relaunch throttle until broader log retention lands.
 const LAUNCH_AGENT_STDERR_CAP_BYTES = 2_000_000;
 const LAUNCH_AGENT_STDERR_KEEP_BYTES = 1_000_000;
 
@@ -1108,7 +1109,6 @@ async function writeLaunchAgentPlist({
     platform: "darwin",
   });
   await ensureSecureDirectory(logDir);
-  await capLaunchAgentStderrLogTail(stderrPath);
 
   const domain = resolveGuiDomain();
   const label = resolveLaunchAgentLabel({ env });
@@ -1176,6 +1176,11 @@ async function activateLaunchAgent(params: { env: GatewayServiceEnv; plistPath: 
 
   await execLaunchctl(["bootout", domain, params.plistPath]);
   await execLaunchctl(["unload", params.plistPath]);
+  // The agent is booted out here: nothing is appending to the stderr sink, so
+  // this is the one safe point in the install flow to compact it.
+  await capLaunchAgentStderrLogTail(
+    resolveGatewaySupervisorLogPaths(params.env, { platform: "darwin" }).stderrPath,
+  );
   // launchd can persist "disabled" state even after bootout + plist removal; clear it before bootstrap.
   await bootstrapLaunchAgentOrThrow({
     domain,
@@ -1229,7 +1234,6 @@ async function rewriteLaunchAgentPlistForRestart({
     platform: "darwin",
   });
   await ensureSecureDirectory(logDir);
-  await capLaunchAgentStderrLogTail(stderrPath);
 
   const serviceDescription = resolveGatewayServiceDescription({
     env,
@@ -1346,6 +1350,10 @@ export async function restartLaunchAgent({
     if (bootout.code !== 0 && !isLaunchctlNotLoaded(bootout)) {
       throw new Error(`launchctl bootout failed: ${formatLaunchctlResultDetail(bootout)}`);
     }
+    // Booted out: safe to compact the stderr sink before the relaunch.
+    await capLaunchAgentStderrLogTail(
+      resolveGatewaySupervisorLogPaths(serviceEnv, { platform: "darwin" }).stderrPath,
+    );
     await bootstrapLaunchAgentOrThrow({
       domain,
       serviceTarget,

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -1063,6 +1063,38 @@ export async function stopLaunchAgent({
   stdout.write(`${formatLine("Stopped LaunchAgent", serviceTarget)}\n`);
 }
 
+// Bounded retention for the supervisor stderr sink: launchd appends to
+// gateway.err.log across relaunches and nothing else rotates it, so cap it to
+// a tail whenever OpenClaw (re)writes the plist — fresh installs, gateway
+// restarts, and update handoffs. Growth between operator actions is bounded
+// only by launchd's relaunch throttle until broader log retention lands.
+const LAUNCH_AGENT_STDERR_CAP_BYTES = 2_000_000;
+const LAUNCH_AGENT_STDERR_KEEP_BYTES = 1_000_000;
+
+export async function capLaunchAgentStderrLogTail(stderrPath: string): Promise<void> {
+  try {
+    const stat = await fs.stat(stderrPath);
+    if (stat.size <= LAUNCH_AGENT_STDERR_CAP_BYTES) {
+      return;
+    }
+    const handle = await fs.open(stderrPath, "r");
+    const tail = Buffer.alloc(LAUNCH_AGENT_STDERR_KEEP_BYTES);
+    try {
+      await handle.read(
+        tail,
+        0,
+        LAUNCH_AGENT_STDERR_KEEP_BYTES,
+        stat.size - LAUNCH_AGENT_STDERR_KEEP_BYTES,
+      );
+    } finally {
+      await handle.close();
+    }
+    await fs.writeFile(stderrPath, tail);
+  } catch {
+    // Best-effort: retention must never block install or restart.
+  }
+}
+
 async function writeLaunchAgentPlist({
   env,
   programArguments,
@@ -1076,6 +1108,7 @@ async function writeLaunchAgentPlist({
     platform: "darwin",
   });
   await ensureSecureDirectory(logDir);
+  await capLaunchAgentStderrLogTail(stderrPath);
 
   const domain = resolveGuiDomain();
   const label = resolveLaunchAgentLabel({ env });
@@ -1196,6 +1229,7 @@ async function rewriteLaunchAgentPlistForRestart({
     platform: "darwin",
   });
   await ensureSecureDirectory(logDir);
+  await capLaunchAgentStderrLogTail(stderrPath);
 
   const serviceDescription = resolveGatewayServiceDescription({
     env,

--- a/src/daemon/runtime-hints.test.ts
+++ b/src/daemon/runtime-hints.test.ts
@@ -17,7 +17,7 @@ describe("buildPlatformRuntimeLogHints", () => {
       }),
     ).toEqual([
       "Launchd stdout (if installed): /Users/test/Library/Logs/openclaw/gateway.log",
-      "Launchd stderr (if installed): suppressed",
+      "Launchd stderr (if installed): /Users/test/Library/Logs/openclaw/gateway.err.log",
       "Restart attempts: /tmp/openclaw-state/logs/gateway-restart.log",
     ]);
   });

--- a/src/daemon/runtime-hints.ts
+++ b/src/daemon/runtime-hints.ts
@@ -21,7 +21,7 @@ export function buildPlatformRuntimeLogHints(params: {
     // where mocked env values may carry Windows drive prefixes.
     return [
       `Launchd stdout (if installed): ${toDarwinDisplayPath(logs.stdoutPath)}`,
-      "Launchd stderr (if installed): suppressed",
+      `Launchd stderr (if installed): ${toDarwinDisplayPath(logs.stderrPath)}`,
       `Restart attempts: ${toDarwinDisplayPath(resolveGatewayRestartLogPath(env))}`,
     ];
   }

--- a/src/daemon/runtime-hints.windows-paths.test.ts
+++ b/src/daemon/runtime-hints.windows-paths.test.ts
@@ -37,7 +37,7 @@ describe("buildPlatformRuntimeLogHints", () => {
       }),
     ).toEqual([
       "Launchd stdout (if installed): /Users/test/Library/Logs/openclaw/gateway.log",
-      "Launchd stderr (if installed): suppressed",
+      "Launchd stderr (if installed): /Users/test/Library/Logs/openclaw/gateway.err.log",
       "Restart attempts: /tmp/openclaw-state/logs/gateway-restart.log",
     ]);
   });


### PR DESCRIPTION
## Summary

The macOS LaunchAgent plist hard-coded `StandardErrorPath` to `/dev/null`, so a
gateway that crashed on a thrown startup error (e.g. `refusing to bind gateway …
without auth`, `failed to bind gateway socket …`) left **no trace on disk** —
operators saw a dead service with nothing to diagnose (issue #90711).

This routes launchd stderr to the resolved `gateway.err.log` for both fresh
installs and restart-rewrites, and then aligns OpenClaw's own macOS diagnostics
with that new logging contract.

## What changed since the first revision

The first revision only flipped the plist `StandardErrorPath`. As the review
noted, that left a real stderr file that OpenClaw's status tooling still treated
as suppressed. This revision fixes that mismatch:

- **`readLastGatewayErrorLine`** now reads the launchd supervisor stderr on
  darwin (it's the strongest failure signal, matching systemd/schtasks), so
  `openclaw gateway status`, `status --all`, doctor, and onboarding surface the
  real startup error instead of only stdout.
- **`gateway status`** and the daemon runtime-log hints print the
  `gateway.err.log` path instead of `Errors: suppressed`.

The stale "launchd supervisor combines child stderr into stdout" comment is
removed — the plist routes `StandardOutPath`/`StandardErrorPath` separately (no
`2>&1` merge), so stderr is a genuine, separate signal.

## Verification

- `node scripts/run-vitest.mjs src/daemon/diagnostics.test.ts src/daemon/runtime-hints.test.ts src/daemon/runtime-hints.windows-paths.test.ts src/cli/daemon-cli/status.print.test.ts src/daemon/launchd.test.ts` → all pass (updated for the new behavior).
- `node scripts/run-vitest.mjs src/cli/daemon-cli/status.gather.test.ts src/commands/doctor-gateway-daemon-flow.test.ts` → pass (downstream consumers of `readLastGatewayErrorLine`).
- `oxfmt --check` / `oxlint` clean on changed files. Rebased onto current `main`.

### Real behavior proof

- **Behavior addressed:** launchd stderr is captured to `gateway.err.log`, and
  macOS status/diagnostics surface it instead of reporting it as suppressed.
- **Real environment tested:** local Vitest (daemon + CLI status suites).
- **Exact steps or command run after this patch:** the Vitest commands above.
- **Evidence after fix:** updated tests assert the stderr path appears in the
  status output and that `readLastGatewayErrorLine` returns the launchd stderr
  error line on darwin.
- **What was not tested:** an end-to-end install/crash on a real macOS host
  (would require installing the LaunchAgent and forcing a bind failure).

Closes #90711
