### PR TITLE
fix(microsoft-foundry): suppress DeepSeek V4 thinking on alias provider ids (#90520)

### DIFF
--- a/src/agents/embedded-agent-runner-extraparams.test.ts
+++ b/src/agents/embedded-agent-runner-extraparams.test.ts
@@ -766,6 +766,26 @@ describe("applyExtraParamsToAgent", () => {
     expect(payload).not.toHaveProperty("thinking");
   });
 
+  it("does not add DeepSeek V4 thinking params on Foundry alias provider ids", () => {
+    const payload = runResponsesPayloadMutationCase({
+      applyProvider: "microsoft-foundry-9433",
+      applyModelId: "deepseek-v4-pro",
+      thinkingLevel: "high",
+      model: {
+        api: "openai-completions",
+        provider: "microsoft-foundry-9433",
+        id: "deepseek-v4-pro",
+      } as Model<"openai-completions">,
+      payload: {
+        reasoning_effort: "high",
+        messages: [{ role: "user", content: "hello" }],
+      },
+    });
+
+    expect(payload.reasoning_effort).toBe("high");
+    expect(payload).not.toHaveProperty("thinking");
+  });
+
   it("fills MiMo V2.6 reasoning_content for unowned OpenAI-compatible proxy models", () => {
     const payload = runResponsesPayloadMutationCase({
       applyProvider: "opencode",

--- a/src/agents/embedded-agent-runner/extra-params.ts
+++ b/src/agents/embedded-agent-runner/extra-params.ts
@@ -919,11 +919,21 @@ function normalizeDeepSeekV4CandidateId(modelId: unknown): string | undefined {
   return withoutSuffix.split("/").pop();
 }
 
+function isMicrosoftFoundryProvider(provider: unknown): boolean {
+  // Foundry alias/instance providers reuse `microsoft-foundry-<suffix>` ids
+  // (for example `microsoft-foundry-9433`) and share the same OpenAI-compatible
+  // gateway that rejects the non-standard top-level `thinking` argument.
+  if (typeof provider !== "string") {
+    return false;
+  }
+  return provider === "microsoft-foundry" || provider.startsWith("microsoft-foundry-");
+}
+
 function isDeepSeekV4OpenAICompatibleModel(model: Parameters<StreamFn>[0]): boolean {
   const normalizedModelId = normalizeDeepSeekV4CandidateId(model.id);
   return (
     model.api === "openai-completions" &&
-    model.provider !== "microsoft-foundry" &&
+    !isMicrosoftFoundryProvider(model.provider) &&
     (normalizedModelId === "deepseek-v4-flash" || normalizedModelId === "deepseek-v4-pro")
   );
 }


### PR DESCRIPTION
## Summary

Fixes #90520. The prior fix in `0c74f18a1c0` ([commit](https://github.com/openclaw/openclaw/commit/0c74f18a1c0)) suppressed the OpenAI-compat `thinking` wrapper for DeepSeek V4 Pro/Flash on Microsoft Foundry by gating on `model.provider !== "microsoft-foundry"`. Foundry alias/instance provider ids such as `microsoft-foundry-9433` share the same Foundry gateway but did not match the literal id, so the request still failed with `400 Unrecognized request argument supplied: thinking`.

This change extends the gate to recognize `microsoft-foundry-<suffix>` provider ids as Foundry. The fix is local to `isDeepSeekV4OpenAICompatibleModel` and matches the prior fix's shape and ownership.

Refs:
- Issue: openclaw/openclaw#90520
- Prior fix: `0c74f18a1c0` (`src/agents/embedded-agent-runner/extra-params.ts:917`)
- Touched: `src/agents/embedded-agent-runner/extra-params.ts`, `src/agents/embedded-agent-runner-extraparams.test.ts`

## Real behavior proof

Behavior addressed: Foundry alias provider ids (for example `microsoft-foundry-9433`) backing DeepSeek V4 Pro/Flash deployments no longer receive the non-standard top-level `thinking` argument that Foundry's OpenAI-compatible gateway rejects.

Real environment tested: Unit test against the embedded-agent-runner extra-params pipeline, exercising the exact same payload-mutation entrypoint as the prior `microsoft-foundry` Foundry test (`runResponsesPayloadMutationCase`).

Exact steps or command run after this patch:
```
node scripts/run-vitest.mjs src/agents/embedded-agent-runner-extraparams.test.ts
node scripts/run-vitest.mjs src/agents/embedded-agent-runner-extraparams.test.ts -t "Foundry alias"
```

Evidence after fix: `Test Files 1 passed (1) | Tests 132 passed (132)`. The new `does not add DeepSeek V4 thinking params on Foundry alias provider ids` case asserts `payload.reasoning_effort === "high"` and `!payload.thinking` for `provider: "microsoft-foundry-9433"` + `id: "deepseek-v4-pro"`.

Observed result after fix: Foundry alias path now skips the OpenAI-compat `thinking` wrapper; `reasoning_effort` still propagates unchanged. Literal `microsoft-foundry` behavior preserved.

What was not tested: Live request against an actual Microsoft Foundry tenant. The reporter's A/B repro confirms the failure mode and provider-id key; this PR closes the alias gap exactly where the prior fix added the suppression.