### PR TITLE
feat(control-ui): rename sessions from the sidebar via the server label patch (#90655)

### DIFF
--- a/ui/src/i18n/.i18n/ar.meta.json
+++ b/ui/src/i18n/.i18n/ar.meta.json
@@ -32,6 +32,7 @@
     "chat.workspaceFiles.workspace",
     "cron.jobDetail.command",
     "cron.jobDetail.cwd",
+    "sessionsView.rename",
     "skillWorkshop.header.useCurrentChat",
     "skillWorkshop.header.useCurrentChatAria",
     "skillWorkshop.header.useCurrentChatTooltip",
@@ -64,12 +65,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-14T04:03:18.297Z",
+  "generatedAt": "2026-06-15T22:30:37.954Z",
   "locale": "ar",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "cea79b090b14fca4ad1e3e07dc5dcd7f964b1f199fd028938e41054dc5167457",
-  "totalKeys": 1377,
+  "sourceHash": "665f087a6b842d14fb65a63f9d4a0d7b18478e432afe7cf2e5f0d832cfc0ebd0",
+  "totalKeys": 1378,
   "translatedKeys": 1314,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/de.meta.json
+++ b/ui/src/i18n/.i18n/de.meta.json
@@ -32,6 +32,7 @@
     "chat.workspaceFiles.workspace",
     "cron.jobDetail.command",
     "cron.jobDetail.cwd",
+    "sessionsView.rename",
     "skillWorkshop.header.useCurrentChat",
     "skillWorkshop.header.useCurrentChatAria",
     "skillWorkshop.header.useCurrentChatTooltip",
@@ -64,12 +65,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-14T04:03:17.952Z",
+  "generatedAt": "2026-06-15T22:30:37.534Z",
   "locale": "de",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "cea79b090b14fca4ad1e3e07dc5dcd7f964b1f199fd028938e41054dc5167457",
-  "totalKeys": 1377,
+  "sourceHash": "665f087a6b842d14fb65a63f9d4a0d7b18478e432afe7cf2e5f0d832cfc0ebd0",
+  "totalKeys": 1378,
   "translatedKeys": 1314,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/es.meta.json
+++ b/ui/src/i18n/.i18n/es.meta.json
@@ -32,6 +32,7 @@
     "chat.workspaceFiles.workspace",
     "cron.jobDetail.command",
     "cron.jobDetail.cwd",
+    "sessionsView.rename",
     "skillWorkshop.header.useCurrentChat",
     "skillWorkshop.header.useCurrentChatAria",
     "skillWorkshop.header.useCurrentChatTooltip",
@@ -64,12 +65,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-14T04:03:18.021Z",
+  "generatedAt": "2026-06-15T22:30:37.618Z",
   "locale": "es",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "cea79b090b14fca4ad1e3e07dc5dcd7f964b1f199fd028938e41054dc5167457",
-  "totalKeys": 1377,
+  "sourceHash": "665f087a6b842d14fb65a63f9d4a0d7b18478e432afe7cf2e5f0d832cfc0ebd0",
+  "totalKeys": 1378,
   "translatedKeys": 1314,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/fa.meta.json
+++ b/ui/src/i18n/.i18n/fa.meta.json
@@ -32,6 +32,7 @@
     "chat.workspaceFiles.workspace",
     "cron.jobDetail.command",
     "cron.jobDetail.cwd",
+    "sessionsView.rename",
     "skillWorkshop.header.useCurrentChat",
     "skillWorkshop.header.useCurrentChatAria",
     "skillWorkshop.header.useCurrentChatTooltip",
@@ -64,12 +65,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-14T04:03:18.916Z",
+  "generatedAt": "2026-06-15T22:30:38.727Z",
   "locale": "fa",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "cea79b090b14fca4ad1e3e07dc5dcd7f964b1f199fd028938e41054dc5167457",
-  "totalKeys": 1377,
+  "sourceHash": "665f087a6b842d14fb65a63f9d4a0d7b18478e432afe7cf2e5f0d832cfc0ebd0",
+  "totalKeys": 1378,
   "translatedKeys": 1314,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/fr.meta.json
+++ b/ui/src/i18n/.i18n/fr.meta.json
@@ -32,6 +32,7 @@
     "chat.workspaceFiles.workspace",
     "cron.jobDetail.command",
     "cron.jobDetail.cwd",
+    "sessionsView.rename",
     "skillWorkshop.header.useCurrentChat",
     "skillWorkshop.header.useCurrentChatAria",
     "skillWorkshop.header.useCurrentChatTooltip",
@@ -64,12 +65,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-14T04:03:18.227Z",
+  "generatedAt": "2026-06-15T22:30:37.870Z",
   "locale": "fr",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "cea79b090b14fca4ad1e3e07dc5dcd7f964b1f199fd028938e41054dc5167457",
-  "totalKeys": 1377,
+  "sourceHash": "665f087a6b842d14fb65a63f9d4a0d7b18478e432afe7cf2e5f0d832cfc0ebd0",
+  "totalKeys": 1378,
   "translatedKeys": 1314,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/id.meta.json
+++ b/ui/src/i18n/.i18n/id.meta.json
@@ -32,6 +32,7 @@
     "chat.workspaceFiles.workspace",
     "cron.jobDetail.command",
     "cron.jobDetail.cwd",
+    "sessionsView.rename",
     "skillWorkshop.header.useCurrentChat",
     "skillWorkshop.header.useCurrentChatAria",
     "skillWorkshop.header.useCurrentChatTooltip",
@@ -64,12 +65,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-14T04:03:18.574Z",
+  "generatedAt": "2026-06-15T22:30:38.307Z",
   "locale": "id",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "cea79b090b14fca4ad1e3e07dc5dcd7f964b1f199fd028938e41054dc5167457",
-  "totalKeys": 1377,
+  "sourceHash": "665f087a6b842d14fb65a63f9d4a0d7b18478e432afe7cf2e5f0d832cfc0ebd0",
+  "totalKeys": 1378,
   "translatedKeys": 1314,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/it.meta.json
+++ b/ui/src/i18n/.i18n/it.meta.json
@@ -32,6 +32,7 @@
     "chat.workspaceFiles.workspace",
     "cron.jobDetail.command",
     "cron.jobDetail.cwd",
+    "sessionsView.rename",
     "skillWorkshop.header.useCurrentChat",
     "skillWorkshop.header.useCurrentChatAria",
     "skillWorkshop.header.useCurrentChatTooltip",
@@ -64,12 +65,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-14T04:03:18.366Z",
+  "generatedAt": "2026-06-15T22:30:38.047Z",
   "locale": "it",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "cea79b090b14fca4ad1e3e07dc5dcd7f964b1f199fd028938e41054dc5167457",
-  "totalKeys": 1377,
+  "sourceHash": "665f087a6b842d14fb65a63f9d4a0d7b18478e432afe7cf2e5f0d832cfc0ebd0",
+  "totalKeys": 1378,
   "translatedKeys": 1314,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ja-JP.meta.json
+++ b/ui/src/i18n/.i18n/ja-JP.meta.json
@@ -32,6 +32,7 @@
     "chat.workspaceFiles.workspace",
     "cron.jobDetail.command",
     "cron.jobDetail.cwd",
+    "sessionsView.rename",
     "skillWorkshop.header.useCurrentChat",
     "skillWorkshop.header.useCurrentChatAria",
     "skillWorkshop.header.useCurrentChatTooltip",
@@ -64,12 +65,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-14T04:03:18.090Z",
+  "generatedAt": "2026-06-15T22:30:37.702Z",
   "locale": "ja-JP",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "cea79b090b14fca4ad1e3e07dc5dcd7f964b1f199fd028938e41054dc5167457",
-  "totalKeys": 1377,
+  "sourceHash": "665f087a6b842d14fb65a63f9d4a0d7b18478e432afe7cf2e5f0d832cfc0ebd0",
+  "totalKeys": 1378,
   "translatedKeys": 1314,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ko.meta.json
+++ b/ui/src/i18n/.i18n/ko.meta.json
@@ -32,6 +32,7 @@
     "chat.workspaceFiles.workspace",
     "cron.jobDetail.command",
     "cron.jobDetail.cwd",
+    "sessionsView.rename",
     "skillWorkshop.header.useCurrentChat",
     "skillWorkshop.header.useCurrentChatAria",
     "skillWorkshop.header.useCurrentChatTooltip",
@@ -64,12 +65,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-14T04:03:18.160Z",
+  "generatedAt": "2026-06-15T22:30:37.788Z",
   "locale": "ko",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "cea79b090b14fca4ad1e3e07dc5dcd7f964b1f199fd028938e41054dc5167457",
-  "totalKeys": 1377,
+  "sourceHash": "665f087a6b842d14fb65a63f9d4a0d7b18478e432afe7cf2e5f0d832cfc0ebd0",
+  "totalKeys": 1378,
   "translatedKeys": 1314,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/nl.meta.json
+++ b/ui/src/i18n/.i18n/nl.meta.json
@@ -32,6 +32,7 @@
     "chat.workspaceFiles.workspace",
     "cron.jobDetail.command",
     "cron.jobDetail.cwd",
+    "sessionsView.rename",
     "skillWorkshop.header.useCurrentChat",
     "skillWorkshop.header.useCurrentChatAria",
     "skillWorkshop.header.useCurrentChatTooltip",
@@ -64,12 +65,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-14T04:03:18.847Z",
+  "generatedAt": "2026-06-15T22:30:38.643Z",
   "locale": "nl",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "cea79b090b14fca4ad1e3e07dc5dcd7f964b1f199fd028938e41054dc5167457",
-  "totalKeys": 1377,
+  "sourceHash": "665f087a6b842d14fb65a63f9d4a0d7b18478e432afe7cf2e5f0d832cfc0ebd0",
+  "totalKeys": 1378,
   "translatedKeys": 1314,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/pl.meta.json
+++ b/ui/src/i18n/.i18n/pl.meta.json
@@ -32,6 +32,7 @@
     "chat.workspaceFiles.workspace",
     "cron.jobDetail.command",
     "cron.jobDetail.cwd",
+    "sessionsView.rename",
     "skillWorkshop.header.useCurrentChat",
     "skillWorkshop.header.useCurrentChatAria",
     "skillWorkshop.header.useCurrentChatTooltip",
@@ -64,12 +65,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-14T04:03:18.642Z",
+  "generatedAt": "2026-06-15T22:30:38.390Z",
   "locale": "pl",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "cea79b090b14fca4ad1e3e07dc5dcd7f964b1f199fd028938e41054dc5167457",
-  "totalKeys": 1377,
+  "sourceHash": "665f087a6b842d14fb65a63f9d4a0d7b18478e432afe7cf2e5f0d832cfc0ebd0",
+  "totalKeys": 1378,
   "translatedKeys": 1314,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/pt-BR.meta.json
+++ b/ui/src/i18n/.i18n/pt-BR.meta.json
@@ -32,6 +32,7 @@
     "chat.workspaceFiles.workspace",
     "cron.jobDetail.command",
     "cron.jobDetail.cwd",
+    "sessionsView.rename",
     "skillWorkshop.header.useCurrentChat",
     "skillWorkshop.header.useCurrentChatAria",
     "skillWorkshop.header.useCurrentChatTooltip",
@@ -64,12 +65,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-14T04:03:17.881Z",
+  "generatedAt": "2026-06-15T22:30:37.449Z",
   "locale": "pt-BR",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "cea79b090b14fca4ad1e3e07dc5dcd7f964b1f199fd028938e41054dc5167457",
-  "totalKeys": 1377,
+  "sourceHash": "665f087a6b842d14fb65a63f9d4a0d7b18478e432afe7cf2e5f0d832cfc0ebd0",
+  "totalKeys": 1378,
   "translatedKeys": 1314,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/th.meta.json
+++ b/ui/src/i18n/.i18n/th.meta.json
@@ -32,6 +32,7 @@
     "chat.workspaceFiles.workspace",
     "cron.jobDetail.command",
     "cron.jobDetail.cwd",
+    "sessionsView.rename",
     "skillWorkshop.header.useCurrentChat",
     "skillWorkshop.header.useCurrentChatAria",
     "skillWorkshop.header.useCurrentChatTooltip",
@@ -64,12 +65,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-14T04:03:18.710Z",
+  "generatedAt": "2026-06-15T22:30:38.476Z",
   "locale": "th",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "cea79b090b14fca4ad1e3e07dc5dcd7f964b1f199fd028938e41054dc5167457",
-  "totalKeys": 1377,
+  "sourceHash": "665f087a6b842d14fb65a63f9d4a0d7b18478e432afe7cf2e5f0d832cfc0ebd0",
+  "totalKeys": 1378,
   "translatedKeys": 1314,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/tr.meta.json
+++ b/ui/src/i18n/.i18n/tr.meta.json
@@ -32,6 +32,7 @@
     "chat.workspaceFiles.workspace",
     "cron.jobDetail.command",
     "cron.jobDetail.cwd",
+    "sessionsView.rename",
     "skillWorkshop.header.useCurrentChat",
     "skillWorkshop.header.useCurrentChatAria",
     "skillWorkshop.header.useCurrentChatTooltip",
@@ -64,12 +65,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-14T04:03:18.435Z",
+  "generatedAt": "2026-06-15T22:30:38.134Z",
   "locale": "tr",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "cea79b090b14fca4ad1e3e07dc5dcd7f964b1f199fd028938e41054dc5167457",
-  "totalKeys": 1377,
+  "sourceHash": "665f087a6b842d14fb65a63f9d4a0d7b18478e432afe7cf2e5f0d832cfc0ebd0",
+  "totalKeys": 1378,
   "translatedKeys": 1314,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/uk.meta.json
+++ b/ui/src/i18n/.i18n/uk.meta.json
@@ -32,6 +32,7 @@
     "chat.workspaceFiles.workspace",
     "cron.jobDetail.command",
     "cron.jobDetail.cwd",
+    "sessionsView.rename",
     "skillWorkshop.header.useCurrentChat",
     "skillWorkshop.header.useCurrentChatAria",
     "skillWorkshop.header.useCurrentChatTooltip",
@@ -64,12 +65,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-14T04:03:18.507Z",
+  "generatedAt": "2026-06-15T22:30:38.223Z",
   "locale": "uk",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "cea79b090b14fca4ad1e3e07dc5dcd7f964b1f199fd028938e41054dc5167457",
-  "totalKeys": 1377,
+  "sourceHash": "665f087a6b842d14fb65a63f9d4a0d7b18478e432afe7cf2e5f0d832cfc0ebd0",
+  "totalKeys": 1378,
   "translatedKeys": 1314,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/vi.meta.json
+++ b/ui/src/i18n/.i18n/vi.meta.json
@@ -32,6 +32,7 @@
     "chat.workspaceFiles.workspace",
     "cron.jobDetail.command",
     "cron.jobDetail.cwd",
+    "sessionsView.rename",
     "skillWorkshop.header.useCurrentChat",
     "skillWorkshop.header.useCurrentChatAria",
     "skillWorkshop.header.useCurrentChatTooltip",
@@ -64,12 +65,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-14T04:03:18.780Z",
+  "generatedAt": "2026-06-15T22:30:38.559Z",
   "locale": "vi",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "cea79b090b14fca4ad1e3e07dc5dcd7f964b1f199fd028938e41054dc5167457",
-  "totalKeys": 1377,
+  "sourceHash": "665f087a6b842d14fb65a63f9d4a0d7b18478e432afe7cf2e5f0d832cfc0ebd0",
+  "totalKeys": 1378,
   "translatedKeys": 1314,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/zh-CN.meta.json
+++ b/ui/src/i18n/.i18n/zh-CN.meta.json
@@ -32,6 +32,7 @@
     "chat.workspaceFiles.workspace",
     "cron.jobDetail.command",
     "cron.jobDetail.cwd",
+    "sessionsView.rename",
     "skillWorkshop.header.useCurrentChat",
     "skillWorkshop.header.useCurrentChatAria",
     "skillWorkshop.header.useCurrentChatTooltip",
@@ -64,12 +65,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-14T04:03:17.740Z",
+  "generatedAt": "2026-06-15T22:30:37.267Z",
   "locale": "zh-CN",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "cea79b090b14fca4ad1e3e07dc5dcd7f964b1f199fd028938e41054dc5167457",
-  "totalKeys": 1377,
+  "sourceHash": "665f087a6b842d14fb65a63f9d4a0d7b18478e432afe7cf2e5f0d832cfc0ebd0",
+  "totalKeys": 1378,
   "translatedKeys": 1314,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/zh-TW.meta.json
+++ b/ui/src/i18n/.i18n/zh-TW.meta.json
@@ -32,6 +32,7 @@
     "chat.workspaceFiles.workspace",
     "cron.jobDetail.command",
     "cron.jobDetail.cwd",
+    "sessionsView.rename",
     "skillWorkshop.header.useCurrentChat",
     "skillWorkshop.header.useCurrentChatAria",
     "skillWorkshop.header.useCurrentChatTooltip",
@@ -64,12 +65,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-14T04:03:17.811Z",
+  "generatedAt": "2026-06-15T22:30:37.365Z",
   "locale": "zh-TW",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "cea79b090b14fca4ad1e3e07dc5dcd7f964b1f199fd028938e41054dc5167457",
-  "totalKeys": 1377,
+  "sourceHash": "665f087a6b842d14fb65a63f9d4a0d7b18478e432afe7cf2e5f0d832cfc0ebd0",
+  "totalKeys": 1378,
   "translatedKeys": 1314,
   "workflow": 1
 }

--- a/ui/src/i18n/locales/ar.ts
+++ b/ui/src/i18n/locales/ar.ts
@@ -192,6 +192,7 @@ export const ar: TranslationMap = {
     verbose: "مطوّل",
     reasoning: "الاستدلال",
     actions: "الإجراءات",
+    rename: "Rename session",
     addToWorkboard: "إضافة إلى Workboard",
     openWorkboardCard: "فتح بطاقة Workboard",
     noSessions: "لم يتم العثور على جلسات.",

--- a/ui/src/i18n/locales/de.ts
+++ b/ui/src/i18n/locales/de.ts
@@ -196,6 +196,7 @@ export const de: TranslationMap = {
     verbose: "Ausführlich",
     reasoning: "Reasoning",
     actions: "Aktionen",
+    rename: "Rename session",
     addToWorkboard: "Zum Workboard hinzufügen",
     openWorkboardCard: "Workboard-Karte öffnen",
     noSessions: "Keine Sitzungen gefunden.",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -191,6 +191,7 @@ export const en: TranslationMap = {
     verbose: "Verbose",
     reasoning: "Reasoning",
     actions: "Actions",
+    rename: "Rename session",
     addToWorkboard: "Add to Workboard",
     openWorkboardCard: "Open Workboard card",
     noSessions: "No sessions found.",

--- a/ui/src/i18n/locales/es.ts
+++ b/ui/src/i18n/locales/es.ts
@@ -193,6 +193,7 @@ export const es: TranslationMap = {
     verbose: "Detallado",
     reasoning: "Razonamiento",
     actions: "Acciones",
+    rename: "Rename session",
     addToWorkboard: "Agregar al Workboard",
     openWorkboardCard: "Abrir tarjeta de Workboard",
     noSessions: "No se encontraron sesiones.",

--- a/ui/src/i18n/locales/fa.ts
+++ b/ui/src/i18n/locales/fa.ts
@@ -194,6 +194,7 @@ export const fa: TranslationMap = {
     verbose: "پرگویی",
     reasoning: "استدلال",
     actions: "اقدامات",
+    rename: "Rename session",
     addToWorkboard: "افزودن به Workboard",
     openWorkboardCard: "باز کردن کارت Workboard",
     noSessions: "هیچ نشستی پیدا نشد.",

--- a/ui/src/i18n/locales/fr.ts
+++ b/ui/src/i18n/locales/fr.ts
@@ -195,6 +195,7 @@ export const fr: TranslationMap = {
     verbose: "Détaillé",
     reasoning: "Raisonnement",
     actions: "Actions",
+    rename: "Rename session",
     addToWorkboard: "Ajouter au Workboard",
     openWorkboardCard: "Ouvrir la carte Workboard",
     noSessions: "Aucune session trouvée.",

--- a/ui/src/i18n/locales/id.ts
+++ b/ui/src/i18n/locales/id.ts
@@ -193,6 +193,7 @@ export const id: TranslationMap = {
     verbose: "Verbose",
     reasoning: "Penalaran",
     actions: "Tindakan",
+    rename: "Rename session",
     addToWorkboard: "Tambahkan ke Workboard",
     openWorkboardCard: "Buka kartu Workboard",
     noSessions: "Tidak ada sesi yang ditemukan.",

--- a/ui/src/i18n/locales/it.ts
+++ b/ui/src/i18n/locales/it.ts
@@ -193,6 +193,7 @@ export const it: TranslationMap = {
     verbose: "Dettagliato",
     reasoning: "Ragionamento",
     actions: "Azioni",
+    rename: "Rename session",
     addToWorkboard: "Aggiungi alla Workboard",
     openWorkboardCard: "Apri scheda Workboard",
     noSessions: "Nessuna sessione trovata.",

--- a/ui/src/i18n/locales/ja-JP.ts
+++ b/ui/src/i18n/locales/ja-JP.ts
@@ -196,6 +196,7 @@ export const ja_JP: TranslationMap = {
     verbose: "詳細",
     reasoning: "推論",
     actions: "アクション",
+    rename: "Rename session",
     addToWorkboard: "Workboardに追加",
     openWorkboardCard: "Workboardカードを開く",
     noSessions: "セッションが見つかりません。",

--- a/ui/src/i18n/locales/ko.ts
+++ b/ui/src/i18n/locales/ko.ts
@@ -192,6 +192,7 @@ export const ko: TranslationMap = {
     verbose: "상세",
     reasoning: "추론",
     actions: "작업",
+    rename: "Rename session",
     addToWorkboard: "Workboard에 추가",
     openWorkboardCard: "Workboard 카드 열기",
     noSessions: "세션을 찾을 수 없습니다.",

--- a/ui/src/i18n/locales/nl.ts
+++ b/ui/src/i18n/locales/nl.ts
@@ -195,6 +195,7 @@ export const nl: TranslationMap = {
     verbose: "Uitgebreid",
     reasoning: "Redenering",
     actions: "Acties",
+    rename: "Rename session",
     addToWorkboard: "Toevoegen aan Workboard",
     openWorkboardCard: "Workboard-kaart openen",
     noSessions: "Geen sessies gevonden.",

--- a/ui/src/i18n/locales/pl.ts
+++ b/ui/src/i18n/locales/pl.ts
@@ -194,6 +194,7 @@ export const pl: TranslationMap = {
     verbose: "Szczegółowo",
     reasoning: "Rozumowanie",
     actions: "Działania",
+    rename: "Rename session",
     addToWorkboard: "Dodaj do Workboard",
     openWorkboardCard: "Otwórz kartę Workboard",
     noSessions: "Nie znaleziono sesji.",

--- a/ui/src/i18n/locales/pt-BR.ts
+++ b/ui/src/i18n/locales/pt-BR.ts
@@ -193,6 +193,7 @@ export const pt_BR: TranslationMap = {
     verbose: "Detalhado",
     reasoning: "Raciocínio",
     actions: "Ações",
+    rename: "Rename session",
     addToWorkboard: "Adicionar ao Workboard",
     openWorkboardCard: "Abrir cartão do Workboard",
     noSessions: "Nenhuma sessão encontrada.",

--- a/ui/src/i18n/locales/th.ts
+++ b/ui/src/i18n/locales/th.ts
@@ -191,6 +191,7 @@ export const th: TranslationMap = {
     verbose: "ละเอียด",
     reasoning: "การให้เหตุผล",
     actions: "การดำเนินการ",
+    rename: "Rename session",
     addToWorkboard: "เพิ่มไปยัง Workboard",
     openWorkboardCard: "เปิดการ์ด Workboard",
     noSessions: "ไม่พบเซสชัน",

--- a/ui/src/i18n/locales/tr.ts
+++ b/ui/src/i18n/locales/tr.ts
@@ -195,6 +195,7 @@ export const tr: TranslationMap = {
     verbose: "Ayrıntılı",
     reasoning: "Akıl yürütme",
     actions: "Eylemler",
+    rename: "Rename session",
     addToWorkboard: "Workboard'a ekle",
     openWorkboardCard: "Workboard kartını aç",
     noSessions: "Oturum bulunamadı.",

--- a/ui/src/i18n/locales/uk.ts
+++ b/ui/src/i18n/locales/uk.ts
@@ -194,6 +194,7 @@ export const uk: TranslationMap = {
     verbose: "Докладно",
     reasoning: "Міркування",
     actions: "Дії",
+    rename: "Rename session",
     addToWorkboard: "Додати до Workboard",
     openWorkboardCard: "Відкрити картку Workboard",
     noSessions: "Сеансів не знайдено.",

--- a/ui/src/i18n/locales/vi.ts
+++ b/ui/src/i18n/locales/vi.ts
@@ -193,6 +193,7 @@ export const vi: TranslationMap = {
     verbose: "Chi tiết",
     reasoning: "Suy luận",
     actions: "Hành động",
+    rename: "Rename session",
     addToWorkboard: "Thêm vào Workboard",
     openWorkboardCard: "Mở thẻ Workboard",
     noSessions: "Không tìm thấy phiên nào.",

--- a/ui/src/i18n/locales/zh-CN.ts
+++ b/ui/src/i18n/locales/zh-CN.ts
@@ -191,6 +191,7 @@ export const zh_CN: TranslationMap = {
     verbose: "详细",
     reasoning: "推理",
     actions: "操作",
+    rename: "Rename session",
     addToWorkboard: "添加到 Workboard",
     openWorkboardCard: "打开 Workboard 卡片",
     noSessions: "未找到会话。",

--- a/ui/src/i18n/locales/zh-TW.ts
+++ b/ui/src/i18n/locales/zh-TW.ts
@@ -191,6 +191,7 @@ export const zh_TW: TranslationMap = {
     verbose: "詳細",
     reasoning: "推理",
     actions: "動作",
+    rename: "Rename session",
     addToWorkboard: "新增至 Workboard",
     openWorkboardCard: "開啟 Workboard 卡片",
     noSessions: "找不到工作階段。",

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -877,6 +877,84 @@
   box-shadow: 0 0 0 4px color-mix(in srgb, var(--ok) 12%, transparent);
 }
 
+/* Row wraps the session link and its rename affordance as siblings (the button
+   must not nest inside the <a>). The button is absolutely positioned so it
+   overlays the row's right edge without disturbing the link's grid. */
+.sidebar-recent-session-row {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.sidebar-recent-session-row > .sidebar-recent-session {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.sidebar-recent-session-row > .sidebar-recent-session__dot {
+  margin-left: 9px;
+}
+
+.sidebar-recent-session__rename {
+  position: absolute;
+  right: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--bg-elevated) 90%, transparent);
+  color: var(--muted);
+  cursor: pointer;
+  opacity: 0;
+  transition:
+    opacity var(--duration-fast) ease,
+    color var(--duration-fast) ease,
+    background var(--duration-fast) ease;
+}
+
+/* Reveal on hover or keyboard focus so the control is reachable without
+   crowding the session name at rest. */
+.sidebar-recent-session-row:hover .sidebar-recent-session__rename,
+.sidebar-recent-session__rename:focus-visible {
+  opacity: 1;
+}
+
+.sidebar-recent-session__rename:hover {
+  color: var(--text);
+  background: var(--bg-hover);
+  border-color: color-mix(in srgb, var(--border) 70%, transparent);
+}
+
+.sidebar-recent-session__rename svg {
+  width: 14px;
+  height: 14px;
+}
+
+.sidebar-recent-session__rename-input {
+  flex: 1 1 auto;
+  min-width: 0;
+  min-height: 40px;
+  margin: 0 9px;
+  padding: 6px 8px;
+  border: 1px solid color-mix(in srgb, var(--accent) 40%, var(--border));
+  border-radius: var(--radius-md);
+  background: var(--bg-elevated);
+  color: var(--text-strong);
+  font-size: 13px;
+  font-weight: 650;
+}
+
+.sidebar-recent-session__rename-input:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
 .sidebar-nav::-webkit-scrollbar {
   display: none;
 }
@@ -1484,7 +1562,8 @@
 }
 
 .dreaming-header-controls__mode:hover:not(:disabled) .dreaming-header-controls__mode-detail,
-.dreaming-header-controls__mode:focus-visible:not(:disabled) .dreaming-header-controls__mode-detail {
+.dreaming-header-controls__mode:focus-visible:not(:disabled)
+  .dreaming-header-controls__mode-detail {
   max-width: 220px;
   margin-left: 6px;
   opacity: 0.95;

--- a/ui/src/ui/app-render.assistant-avatar.test.ts
+++ b/ui/src/ui/app-render.assistant-avatar.test.ts
@@ -632,4 +632,83 @@ describe("renderApp assistant avatar routing", () => {
     );
     expect(labels).toEqual(["Main old", "Work new"]);
   });
+
+  function createSidebarRenameState(request: ReturnType<typeof vi.fn>): AppViewState {
+    return createState({
+      tab: "chat",
+      sessionKey: "agent:work:main",
+      assistantAgentId: "work",
+      connected: true,
+      client: { request } as unknown as AppViewState["client"],
+      agentsList: {
+        defaultId: "main",
+        agents: [
+          { id: "main", name: "Main" },
+          { id: "work", name: "Work" },
+        ],
+      } as AppViewState["agentsList"],
+      sessionsResult: {
+        ts: 0,
+        path: "",
+        count: 1,
+        defaults: { modelProvider: null, model: null, contextTokens: null },
+        sessions: [
+          { key: "agent:work:dashboard:new", kind: "direct", label: "Work new", updatedAt: 20 },
+        ],
+      } as AppViewState["sessionsResult"],
+    });
+  }
+
+  it("renames a sidebar session through the server label patch (#90655)", () => {
+    const container = document.createElement("div");
+    const request = vi.fn(async () => ({}));
+    const state = createSidebarRenameState(request);
+
+    render(renderApp(state), container);
+
+    const renameButton = container.querySelector<HTMLButtonElement>(
+      ".sidebar-recent-session__rename",
+    );
+    expect(renameButton).toBeInstanceOf(HTMLButtonElement);
+    // The rename control must be a sibling of the link, never nested inside it.
+    expect(renameButton?.closest("a")).toBeNull();
+
+    renameButton?.click();
+    render(renderApp(state), container);
+
+    const input = container.querySelector<HTMLInputElement>(
+      ".sidebar-recent-session__rename-input",
+    );
+    expect(input).toBeInstanceOf(HTMLInputElement);
+    input!.value = "Renamed";
+    input!.dispatchEvent(new Event("input", { bubbles: true }));
+    input!.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+
+    expect(request).toHaveBeenCalledWith(
+      "sessions.patch",
+      expect.objectContaining({ key: "agent:work:dashboard:new", label: "Renamed" }),
+    );
+  });
+
+  it("cancels a sidebar rename on Escape without patching, even if blur follows (#90655)", () => {
+    const container = document.createElement("div");
+    const request = vi.fn(async () => ({}));
+    const state = createSidebarRenameState(request);
+
+    render(renderApp(state), container);
+    container.querySelector<HTMLButtonElement>(".sidebar-recent-session__rename")?.click();
+    render(renderApp(state), container);
+
+    const input = container.querySelector<HTMLInputElement>(
+      ".sidebar-recent-session__rename-input",
+    );
+    expect(input).toBeInstanceOf(HTMLInputElement);
+    input!.value = "Discarded";
+    input!.dispatchEvent(new Event("input", { bubbles: true }));
+    input!.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    // Escape removes the editor; the trailing blur must not re-commit the draft.
+    input!.dispatchEvent(new FocusEvent("blur", { bubbles: false }));
+
+    expect(request).not.toHaveBeenCalled();
+  });
 });

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -1,6 +1,7 @@
 // Control UI module implements app render behavior.
 import { html, nothing } from "lit";
 import { guard } from "lit/directives/guard.js";
+import { ref } from "lit/directives/ref.js";
 import { styleMap } from "lit/directives/style-map.js";
 import { i18n, t } from "../i18n/index.ts";
 import { getSafeLocalStorage } from "../local-storage.ts";
@@ -620,47 +621,143 @@ function renderSidebarSessions(state: AppViewState) {
   `;
 }
 
+// Match the server-side session label cap so the inline editor cannot submit a
+// label the gateway would reject.
+const SIDEBAR_RENAME_MAX_LABEL_CHARS = 120;
+
+// Inline rename is transient view state, not persisted data: which row is being
+// edited and the in-progress draft. The committed label lives server-side
+// (sessions.patch), so this WeakMap only drives the editing affordance.
+type SidebarRenameState = { key: string; draft: string } | null;
+const sidebarSessionRenameStates = new WeakMap<AppViewState, SidebarRenameState>();
+
+function setSidebarRenameState(state: AppViewState, value: SidebarRenameState): void {
+  if (value === null) {
+    sidebarSessionRenameStates.delete(state);
+  } else {
+    sidebarSessionRenameStates.set(state, value);
+  }
+  pendingUpdate?.();
+}
+
+function renderSidebarSessionRenameInput(state: AppViewState, row: GatewaySessionRow) {
+  // Escape and blur race: clearing the edit state on Escape removes the input,
+  // which fires blur. Without this guard the blur handler would re-commit the
+  // draft the user just canceled, so a canceled rename must skip the commit.
+  let canceled = false;
+  const commit = (rawValue: string): void => {
+    if (canceled) {
+      return;
+    }
+    setSidebarRenameState(state, null);
+    const next = rawValue.trim().slice(0, SIDEBAR_RENAME_MAX_LABEL_CHARS);
+    // Empty clears the custom label (null); the sessions refresh inside
+    // patchSession re-renders the row from the server label, the single source.
+    void patchSession(state, row.key, { label: next.length > 0 ? next : null });
+  };
+  const cancel = (): void => {
+    canceled = true;
+    setSidebarRenameState(state, null);
+  };
+  const draft = sidebarSessionRenameStates.get(state)?.draft ?? "";
+  return html`
+    <input
+      class="sidebar-recent-session__rename-input"
+      type="text"
+      aria-label=${t("sessionsView.rename")}
+      maxlength=${SIDEBAR_RENAME_MAX_LABEL_CHARS}
+      .value=${draft}
+      @input=${(event: Event) =>
+        sidebarSessionRenameStates.set(state, {
+          key: row.key,
+          draft: (event.target as HTMLInputElement).value,
+        })}
+      @keydown=${(event: KeyboardEvent) => {
+        if (event.key === "Enter") {
+          event.preventDefault();
+          commit((event.target as HTMLInputElement).value);
+        } else if (event.key === "Escape") {
+          event.preventDefault();
+          cancel();
+        }
+      }}
+      @blur=${(event: FocusEvent) => commit((event.target as HTMLInputElement).value)}
+      ${ref((node?: Element) => {
+        if (node instanceof HTMLInputElement && document.activeElement !== node) {
+          node.focus();
+          node.select();
+        }
+      })}
+    />
+  `;
+}
+
 function renderSidebarRecentSession(state: AppViewState, row: GatewaySessionRow) {
   const active = row.key === state.sessionKey;
   const label = resolveSessionDisplayName(row.key, row);
   const meta = row.updatedAt ? formatRelativeTimestamp(row.updatedAt) : "n/a";
   const href = `${pathForTab("chat", state.basePath)}?session=${encodeURIComponent(row.key)}`;
+  const isRenaming = sidebarSessionRenameStates.get(state)?.key === row.key;
+  // The rename button is a sibling of the link, not a child: a <button> nested
+  // inside an <a> is invalid and produces ambiguous keyboard/AT behavior.
   return html`
-    <a
-      href=${href}
-      class="sidebar-recent-session ${active ? "sidebar-recent-session--active" : ""}"
-      data-session-key=${row.key}
-      title=${`${label} · ${row.key}`}
-      @click=${(event: MouseEvent) => {
-        if (
-          event.defaultPrevented ||
-          event.button !== 0 ||
-          event.metaKey ||
-          event.ctrlKey ||
-          event.shiftKey ||
-          event.altKey
-        ) {
-          return;
-        }
-        event.preventDefault();
-        if (row.key !== state.sessionKey) {
-          switchChatSession(state, row.key);
-        }
-        state.setTab("chat" as import("./navigation.ts").Tab);
-      }}
-    >
-      <span class="sidebar-recent-session__dot" aria-hidden="true"></span>
-      <span class="sidebar-recent-session__body">
-        <span class="sidebar-recent-session__name">${label}</span>
-        <span class="sidebar-recent-session__meta">${meta}</span>
-      </span>
-      ${row.hasActiveRun
-        ? html`<span
-            class="sidebar-recent-session__live"
-            aria-label=${t("sessions.sessionDetails.activeRun")}
-          ></span>`
-        : nothing}
-    </a>
+    <div class="sidebar-recent-session-row" data-session-key=${row.key}>
+      ${isRenaming
+        ? html`
+            <span class="sidebar-recent-session__dot" aria-hidden="true"></span>
+            ${renderSidebarSessionRenameInput(state, row)}
+          `
+        : html`
+            <a
+              href=${href}
+              class="sidebar-recent-session ${active ? "sidebar-recent-session--active" : ""}"
+              title=${`${label} · ${row.key}`}
+              @click=${(event: MouseEvent) => {
+                if (
+                  event.defaultPrevented ||
+                  event.button !== 0 ||
+                  event.metaKey ||
+                  event.ctrlKey ||
+                  event.shiftKey ||
+                  event.altKey
+                ) {
+                  return;
+                }
+                event.preventDefault();
+                if (row.key !== state.sessionKey) {
+                  switchChatSession(state, row.key);
+                }
+                state.setTab("chat" as import("./navigation.ts").Tab);
+              }}
+            >
+              <span class="sidebar-recent-session__dot" aria-hidden="true"></span>
+              <span class="sidebar-recent-session__body">
+                <span class="sidebar-recent-session__name">${label}</span>
+                <span class="sidebar-recent-session__meta">${meta}</span>
+              </span>
+              ${row.hasActiveRun
+                ? html`<span
+                    class="sidebar-recent-session__live"
+                    aria-label=${t("sessions.sessionDetails.activeRun")}
+                  ></span>`
+                : nothing}
+            </a>
+            <button
+              type="button"
+              class="sidebar-recent-session__rename"
+              aria-label=${t("sessionsView.rename")}
+              title=${t("sessionsView.rename")}
+              @click=${(event: MouseEvent) => {
+                event.preventDefault();
+                event.stopPropagation();
+                const current = row.label && row.label !== row.key ? row.label : "";
+                setSidebarRenameState(state, { key: row.key, draft: current });
+              }}
+            >
+              ${icons.edit}
+            </button>
+          `}
+    </div>
   `;
 }
 


### PR DESCRIPTION
## Summary

Adds an inline **rename** affordance to the Control UI sidebar session rows so a
session can be relabeled without opening the Sessions page (issue #90655).

## What changed since the first revision

The first revision stored renames in a browser-only `localStorage` map, which the
review correctly flagged as a **second source of truth**: sidebar labels could
disagree with the Sessions page, other browsers, and the gateway.

This revision routes renames through the **existing** `sessions.patch` label path
(`patchSession(state, key, { label })`), the same path the Sessions-page editor
and the thinking/fast toggles already use. The label is persisted server-side and
the session list refresh re-renders the row from the server label — the single
source of truth. The `localStorage` store is gone entirely.

Also addressed from the review:
- **Button not nested in the link:** the rename `<button>` is now a sibling of the
  session `<a>`, not a child (a button inside an anchor is invalid markup and
  ambiguous for keyboard/screen-reader users). The row is a `position: relative`
  wrapper; the button overlays the right edge and is revealed on hover/focus.
- **Escape vs blur race:** Escape cancels the edit and a guard prevents the
  trailing `blur` from re-committing the canceled draft.
- **Localized copy:** the "Rename session" label uses `sessionsView.rename`, and
  the i18n locale bundles + `.i18n` metadata are regenerated.
- Empty input clears the custom label (`patch label: null`).

## Verification

- `node scripts/run-vitest.mjs ui/src/ui/app-render.assistant-avatar.test.ts` →
  17 passed, including new cases: rename commits via `sessions.patch` with the
  label; the rename control is not nested inside the `<a>`; Escape-then-blur
  cancels without patching.
- `node --import tsx scripts/control-ui-i18n.ts check` → all locales clean.
- `pnpm tsgo:test:ui` → clean. `oxfmt --check` / `oxlint` clean on changed files.
- Rebased onto current `main` (re-implemented on top of it).

### Real behavior proof

- **Behavior addressed:** sidebar rename persists server-side via `sessions.patch`
  and re-renders from the server label; no client-only override.
- **Real environment tested:** local Vitest (jsdom app-render suite) + i18n gate +
  UI typecheck.
- **Exact steps or command run after this patch:** the commands above.
- **Evidence after fix:** 17/17 app-render tests pass; the rename test asserts the
  `sessions.patch` RPC is called with `{ key, label }`.
- **Observed result after fix:** renaming a sidebar session issues `sessions.patch`
  and the row reflects the new server label after refresh.
- **What was not tested:** a browser screenshot/recording of the hover affordance
  and inline editor styling (logic and markup are covered by the jsdom tests; a
  maintainer can request Mantis visual proof before merge).

Closes #90655
