### PR TITLE
fix(config): warn for retired skill-workshop plugin entry instead of failing validation (#90244)

### DIFF
--- a/src/config/config.plugin-validation.test.ts
+++ b/src/config/config.plugin-validation.test.ts
@@ -1362,6 +1362,15 @@ describe("config plugin validation", () => {
     expectRemovedPluginWarnings(res, removedId, removedId);
   });
 
+  // Regression for #90244: skill-workshop was extracted into a built-in tool;
+  // upgraded configs that still reference plugins.entries.skill-workshop must warn,
+  // not block startup with "plugin not found".
+  it("warns for removed skill-workshop plugin id instead of failing validation", () => {
+    const removedId = "skill-workshop";
+    const res = validateRemovedPluginConfig(removedId);
+    expectRemovedPluginWarnings(res, removedId, removedId);
+  });
+
   it("does not auto-allow config-loaded overrides of bundled web search plugin ids", () => {
     const res = validateInSuite({
       plugins: {

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -50,7 +50,11 @@ import { coerceSecretRef } from "./types.secrets.js";
 import { isBuiltInModelProviderOverlayId } from "./zod-schema.core.js";
 import { OpenClawSchema } from "./zod-schema.js";
 
-const LEGACY_REMOVED_PLUGIN_IDS = new Set(["google-antigravity-auth", "google-gemini-cli-auth"]);
+const LEGACY_REMOVED_PLUGIN_IDS = new Set([
+  "google-antigravity-auth",
+  "google-gemini-cli-auth",
+  "skill-workshop",
+]);
 const BLOCKED_PLUGIN_CANDIDATE_PREFIX = "blocked plugin candidate:";
 
 type UnknownIssueRecord = Record<string, unknown>;


### PR DESCRIPTION
## Summary

Closes #90244.

The skill-workshop bundled plugin was intentionally removed in 308fdbe7fbf ("refactor: remove skill workshop plugin package"); its capability is now an in-core built-in tool (`src/agents/tools/skill-workshop-tool.ts` + `src/skills/workshop/**`) and the matching `extensions/skill-workshop` directory plus `docs/plugins/skill-workshop.md` no longer ship in the npm package on purpose. Direction B (drop the dangling reference) is therefore correct — restoring the dist files would re-introduce the deleted plugin.

The lingering symptom for users on 2026.6.1 with `plugins.entries.skill-workshop: {...}` in their config is the hard validation error `plugin not found: skill-workshop`. The codebase already has a clean migration seam — `LEGACY_REMOVED_PLUGIN_IDS` in `src/config/validation.ts` — which downgrades retired ids to a clearer `plugin removed: <id> (stale config entry ignored; remove it from plugins config)` warning, and the doctor's `scanStalePluginConfig`/`maybeRepairStalePluginConfig` (`src/commands/doctor/shared/stale-plugin-config.ts`) already prunes the entry on `openclaw doctor --fix`.

This change adds `skill-workshop` to that retired-id set so upgraded configs warn (and self-heal via doctor) instead of breaking startup, matching the existing handling for `google-antigravity-auth` and `google-gemini-cli-auth`. A regression test in `src/config/config.plugin-validation.test.ts` mirrors those siblings.

No CHANGELOG per CLAUDE.md.

## Real behavior proof

Behavior addressed: hard validation failure when a 2026.6.1 user leaves `plugins.entries.skill-workshop` in config after upgrading past the plugin removal.
Real environment tested: local worktree on `origin/main` + this branch.
Exact steps or command run after this patch:
  - `node scripts/run-vitest.mjs run src/config/config.plugin-validation.test.ts -t "skill-workshop"`
  - `node scripts/run-vitest.mjs run src/config/config.plugin-validation.test.ts`
  - `node scripts/run-vitest.mjs run src/config/io.compat.test.ts`
  - `./node_modules/.bin/oxfmt --check src/config/validation.ts src/config/config.plugin-validation.test.ts`
Evidence after fix:
  - New regression test "warns for removed skill-workshop plugin id instead of failing validation" passes (1/1).
  - Full `config.plugin-validation.test.ts` file: 55/55 pass.
  - `io.compat.test.ts` (covers the existing legacy-removed-id warning format): 9/9 pass.
  - oxfmt: "All matched files use the correct format."
Observed result after fix: `plugins.entries.skill-workshop` produces the same friendly retired-id warning as the other entries in `LEGACY_REMOVED_PLUGIN_IDS`, and `openclaw doctor --fix` removes it via the existing stale-plugin-config scanner. No remaining `plugins.entries.skill-workshop`, `dist/extensions/skill-workshop`, or `docs/plugins/skill-workshop.md` references exist in source after `308fdbe7fbf`.
What was not tested: full local `pnpm check` / build (network was flaky reconciling pnpm deps in this worktree, and CLAUDE.md prefers Crabbox for broad gates). Scope is narrow: one constant + one test sharing the existing assertion helper.

https://docs.openclaw.ai/docs/configuration
https://github.com/openclaw/openclaw/issues/90244