### PR TITLE
fix(memory-core): exclude soft-deleted .jsonl.deleted paths from dreaming corpus (#90466)

### DIFF
--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -1665,6 +1665,122 @@ describe("memory-core dreaming phases", () => {
     expect(corpus).not.toContain("Run the qmd sync");
   });
 
+  it("excludes soft-deleted .jsonl.deleted.* transcripts from the dreaming session corpus", async () => {
+    const workspaceDir = await createDreamingWorkspace();
+    vi.stubEnv("OPENCLAW_TEST_FAST", "1");
+    vi.stubEnv("OPENCLAW_STATE_DIR", path.join(workspaceDir, ".state"));
+    const sessionsDir = resolveSessionTranscriptsDirForAgent("main");
+    await fs.mkdir(sessionsDir, { recursive: true });
+
+    // Soft-deleted archive carrying ordinary prose (no cron/heartbeat marker)
+    // — the same shape that contaminated 2026.6.1 dreaming corpora.
+    await fs.writeFile(
+      path.join(sessionsDir, "stale.jsonl.deleted.2026-04-16T18-06-16.529Z"),
+      [
+        JSON.stringify({
+          type: "message",
+          message: {
+            role: "user",
+            timestamp: "2026-04-16T18:01:00.000Z",
+            content: "DELETED_ARCHIVE_USER_PROMPT should never reach the corpus",
+          },
+        }),
+        JSON.stringify({
+          type: "message",
+          message: {
+            role: "assistant",
+            timestamp: "2026-04-16T18:02:00.000Z",
+            content: "DELETED_ARCHIVE_ASSISTANT_REPLY should never reach the corpus",
+          },
+        }),
+      ].join("\n") + "\n",
+      "utf-8",
+    );
+    // Reset archives are equivalent and must also be skipped.
+    await fs.writeFile(
+      path.join(sessionsDir, "stale.jsonl.reset.2026-04-16T18-07-16.529Z"),
+      JSON.stringify({
+        type: "message",
+        message: {
+          role: "user",
+          timestamp: "2026-04-16T18:03:00.000Z",
+          content: "RESET_ARCHIVE_PROMPT should never reach the corpus",
+        },
+      }) + "\n",
+      "utf-8",
+    );
+    // A live transcript should still flow through.
+    await fs.writeFile(
+      path.join(sessionsDir, "live.jsonl"),
+      [
+        JSON.stringify({
+          type: "message",
+          message: {
+            role: "user",
+            timestamp: "2026-04-16T18:08:00.000Z",
+            content: "Document the Ollama provider setup.",
+          },
+        }),
+        JSON.stringify({
+          type: "message",
+          message: {
+            role: "assistant",
+            timestamp: "2026-04-16T18:09:00.000Z",
+            content: "I documented the Ollama provider setup in the workspace notes.",
+          },
+        }),
+      ].join("\n") + "\n",
+      "utf-8",
+    );
+
+    const { beforeAgentReply } = createHarness(
+      {
+        agents: {
+          defaults: { workspace: workspaceDir },
+          list: [{ id: "main", workspace: workspaceDir }],
+        },
+        plugins: {
+          entries: {
+            "memory-core": {
+              config: {
+                dreaming: {
+                  enabled: true,
+                  phases: {
+                    light: { enabled: true, limit: 20, lookbackDays: 7 },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      workspaceDir,
+    );
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-16T19:00:00.000Z"));
+    try {
+      await beforeAgentReply(
+        { cleanedBody: "__openclaw_memory_core_light_sleep__" },
+        { trigger: "heartbeat", workspaceDir },
+      );
+    } finally {
+      vi.useRealTimers();
+      vi.unstubAllEnvs();
+    }
+
+    const corpus = await fs.readFile(
+      path.join(workspaceDir, "memory", ".dreams", "session-corpus", "2026-04-16.txt"),
+      "utf-8",
+    );
+    expect(corpus).toContain("Document the Ollama provider setup.");
+    expect(corpus).not.toContain("DELETED_ARCHIVE_USER_PROMPT");
+    expect(corpus).not.toContain("DELETED_ARCHIVE_ASSISTANT_REPLY");
+    expect(corpus).not.toContain("RESET_ARCHIVE_PROMPT");
+    expect(corpus).not.toContain(".jsonl.deleted.");
+    expect(corpus).not.toContain(".jsonl.reset.");
+  });
+
   it("ignores chat scaffolding tags when building rem reflections", () => {
     const preview = testing.previewRemDreaming({
       entries: [

--- a/extensions/memory-core/src/dreaming-phases.ts
+++ b/extensions/memory-core/src/dreaming-phases.ts
@@ -100,6 +100,11 @@ const SESSION_INGESTION_MIN_MESSAGES_PER_FILE = 12;
 const SESSION_INGESTION_MAX_TRACKED_MESSAGES_PER_SESSION = 4096;
 const SESSION_INGESTION_MAX_TRACKED_SCOPES = 2048;
 const SESSION_CHECKPOINT_TRANSCRIPT_FILENAME_RE = /\.checkpoint\..+\.jsonl$/i;
+// Soft-deleted/reset session archives stay on disk for usage accounting
+// (see isUsageCountedSessionTranscriptFileName) but must never feed the
+// dreaming session corpus — their contents are stale and contaminate later
+// dreaming candidates (issue #90466).
+const SESSION_ARCHIVED_TRANSCRIPT_FILENAME_RE = /\.jsonl\.(?:deleted|reset)\.[^/]+$/i;
 const GENERIC_DAY_HEADING_RE =
   /^(?:(?:mon|monday|tue|tues|tuesday|wed|wednesday|thu|thur|thurs|thursday|fri|friday|sat|saturday|sun|sunday)(?:,\s+)?)?(?:(?:jan|january|feb|february|mar|march|apr|april|may|jun|june|jul|july|aug|august|sep|sept|september|oct|october|nov|november|dec|december)\s+\d{1,2}(?:st|nd|rd|th)?(?:,\s*\d{4})?|\d{1,2}[/-]\d{1,2}(?:[/-]\d{2,4})?|\d{4}[/-]\d{2}[/-]\d{2})$/i;
 const MANAGED_DAILY_DREAMING_BLOCKS = [
@@ -673,6 +678,10 @@ function isCheckpointSessionTranscriptPath(absolutePath: string): boolean {
   return SESSION_CHECKPOINT_TRANSCRIPT_FILENAME_RE.test(path.basename(absolutePath));
 }
 
+function isArchivedSessionTranscriptPath(absolutePath: string): boolean {
+  return SESSION_ARCHIVED_TRANSCRIPT_FILENAME_RE.test(path.basename(absolutePath));
+}
+
 function buildSessionRenderedLine(params: {
   agentId: string;
   sessionPath: string;
@@ -803,6 +812,12 @@ async function collectSessionIngestionBatches(params: {
           };
     for (const absolutePath of files) {
       if (isCheckpointSessionTranscriptPath(absolutePath)) {
+        continue;
+      }
+      // listSessionFilesForAgent returns soft-deleted/reset archives for
+      // usage accounting; their contents are stale and must not seed the
+      // dreaming session corpus (issue #90466).
+      if (isArchivedSessionTranscriptPath(absolutePath)) {
         continue;
       }
       const normalizedPath = normalizeSessionTranscriptPathForComparison(absolutePath);


### PR DESCRIPTION
## Summary

Closes #90466.

`extensions/memory-core/src/dreaming-phases.ts` builds the dreaming session corpus by iterating `listSessionFilesForAgent(agentId)`. That SDK helper intentionally returns `*.jsonl.deleted.*` and `*.jsonl.reset.*` archives because `isUsageCountedSessionTranscriptFileName` in `src/config/sessions/artifacts.ts` keeps them counted for usage accounting (`extensions/memory-core/src/dreaming-phases.ts:805`, `src/config/sessions/artifacts.ts:115`). The plugin only filtered `*.checkpoint.*.jsonl`; soft-deleted/reset archives flowed straight into `memory/.dreams/session-corpus/<day>.txt`, causing the contamination reported on 2026.6.1 (operators saw `[<agent>/sessions/<agent>/<uuid>.jsonl.deleted.<ts>#L<n>]` prefixes in corpus lines and `rem-harness --grounded` candidates).

This change adds a sibling `SESSION_ARCHIVED_TRANSCRIPT_FILENAME_RE` / `isArchivedSessionTranscriptPath` skip alongside the existing checkpoint skip, so the corpus only ingests live `<id>.jsonl` transcripts. Live transcripts and the rest of the dreaming pipeline are unchanged.

This complements #90827, which improved narrative empty-text observability — once the corpus stops being poisoned by stale archives, the fallback diary path the user observed should also recede in production.

## Real behavior proof

Behavior addressed: Dreaming session corpus contained entries sourced from `.jsonl.deleted.*` and `.jsonl.reset.*` archives, contaminating later REM/light-sleep candidates and DREAMS.md entries.

Real environment tested: Local macOS, Node 25, openclaw worktree at `origin/main`.

Exact steps or command run after this patch:
- `node scripts/run-vitest.mjs extensions/memory-core/src/dreaming-phases.test.ts`
- `node scripts/run-vitest.mjs extensions/memory-core`
- `npx oxfmt extensions/memory-core/src/dreaming-phases.ts extensions/memory-core/src/dreaming-phases.test.ts`

Evidence after fix: New test `excludes soft-deleted .jsonl.deleted.* transcripts from the dreaming session corpus` seeds both a `.jsonl.deleted.*` archive (ordinary prose, no cron/heartbeat marker) and a `.jsonl.reset.*` archive in the sessions dir alongside a live `.jsonl` transcript, then asserts the corpus excludes the archived sentinel strings and contains the live prose.

Observed result after fix: `Test Files 1 passed (1)`, `Tests 46 passed (46)` for `dreaming-phases.test.ts`; `Test Files 61 passed (61)`, `Tests 843 passed (843)` for the full memory-core suite.

What was not tested: No live multi-agent install repro on Ubuntu 24.04; relying on unit coverage plus the existing archive/cron-heartbeat regression test still passing.