### PR TITLE
fix(control-ui): validate Telegram cron To against full target contract (#90467)

### DIFF
--- a/ui/src/i18n/.i18n/ar.meta.json
+++ b/ui/src/i18n/.i18n/ar.meta.json
@@ -30,6 +30,9 @@
     "chat.workspaceFiles.summary",
     "chat.workspaceFiles.truncated",
     "chat.workspaceFiles.workspace",
+    "cron.errors.telegramChatIdInvalid",
+    "cron.form.toHelpTelegram",
+    "cron.form.toPlaceholderTelegram",
     "cron.jobDetail.command",
     "cron.jobDetail.cwd",
     "skillWorkshop.header.useCurrentChat",
@@ -64,12 +67,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-14T04:03:18.297Z",
+  "generatedAt": "2026-06-14T20:26:50.985Z",
   "locale": "ar",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "cea79b090b14fca4ad1e3e07dc5dcd7f964b1f199fd028938e41054dc5167457",
-  "totalKeys": 1377,
+  "sourceHash": "a6a1b9475b3e850cfffb54c596a9461455dc5e73ec6f64d22132a6d56206304e",
+  "totalKeys": 1380,
   "translatedKeys": 1314,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/de.meta.json
+++ b/ui/src/i18n/.i18n/de.meta.json
@@ -30,6 +30,9 @@
     "chat.workspaceFiles.summary",
     "chat.workspaceFiles.truncated",
     "chat.workspaceFiles.workspace",
+    "cron.errors.telegramChatIdInvalid",
+    "cron.form.toHelpTelegram",
+    "cron.form.toPlaceholderTelegram",
     "cron.jobDetail.command",
     "cron.jobDetail.cwd",
     "skillWorkshop.header.useCurrentChat",
@@ -64,12 +67,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-14T04:03:17.952Z",
+  "generatedAt": "2026-06-14T20:26:50.552Z",
   "locale": "de",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "cea79b090b14fca4ad1e3e07dc5dcd7f964b1f199fd028938e41054dc5167457",
-  "totalKeys": 1377,
+  "sourceHash": "a6a1b9475b3e850cfffb54c596a9461455dc5e73ec6f64d22132a6d56206304e",
+  "totalKeys": 1380,
   "translatedKeys": 1314,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/es.meta.json
+++ b/ui/src/i18n/.i18n/es.meta.json
@@ -30,6 +30,9 @@
     "chat.workspaceFiles.summary",
     "chat.workspaceFiles.truncated",
     "chat.workspaceFiles.workspace",
+    "cron.errors.telegramChatIdInvalid",
+    "cron.form.toHelpTelegram",
+    "cron.form.toPlaceholderTelegram",
     "cron.jobDetail.command",
     "cron.jobDetail.cwd",
     "skillWorkshop.header.useCurrentChat",
@@ -64,12 +67,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-14T04:03:18.021Z",
+  "generatedAt": "2026-06-14T20:26:50.641Z",
   "locale": "es",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "cea79b090b14fca4ad1e3e07dc5dcd7f964b1f199fd028938e41054dc5167457",
-  "totalKeys": 1377,
+  "sourceHash": "a6a1b9475b3e850cfffb54c596a9461455dc5e73ec6f64d22132a6d56206304e",
+  "totalKeys": 1380,
   "translatedKeys": 1314,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/fa.meta.json
+++ b/ui/src/i18n/.i18n/fa.meta.json
@@ -30,6 +30,9 @@
     "chat.workspaceFiles.summary",
     "chat.workspaceFiles.truncated",
     "chat.workspaceFiles.workspace",
+    "cron.errors.telegramChatIdInvalid",
+    "cron.form.toHelpTelegram",
+    "cron.form.toPlaceholderTelegram",
     "cron.jobDetail.command",
     "cron.jobDetail.cwd",
     "skillWorkshop.header.useCurrentChat",
@@ -64,12 +67,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-14T04:03:18.916Z",
+  "generatedAt": "2026-06-14T20:26:51.768Z",
   "locale": "fa",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "cea79b090b14fca4ad1e3e07dc5dcd7f964b1f199fd028938e41054dc5167457",
-  "totalKeys": 1377,
+  "sourceHash": "a6a1b9475b3e850cfffb54c596a9461455dc5e73ec6f64d22132a6d56206304e",
+  "totalKeys": 1380,
   "translatedKeys": 1314,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/fr.meta.json
+++ b/ui/src/i18n/.i18n/fr.meta.json
@@ -30,6 +30,9 @@
     "chat.workspaceFiles.summary",
     "chat.workspaceFiles.truncated",
     "chat.workspaceFiles.workspace",
+    "cron.errors.telegramChatIdInvalid",
+    "cron.form.toHelpTelegram",
+    "cron.form.toPlaceholderTelegram",
     "cron.jobDetail.command",
     "cron.jobDetail.cwd",
     "skillWorkshop.header.useCurrentChat",
@@ -64,12 +67,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-14T04:03:18.227Z",
+  "generatedAt": "2026-06-14T20:26:50.898Z",
   "locale": "fr",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "cea79b090b14fca4ad1e3e07dc5dcd7f964b1f199fd028938e41054dc5167457",
-  "totalKeys": 1377,
+  "sourceHash": "a6a1b9475b3e850cfffb54c596a9461455dc5e73ec6f64d22132a6d56206304e",
+  "totalKeys": 1380,
   "translatedKeys": 1314,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/id.meta.json
+++ b/ui/src/i18n/.i18n/id.meta.json
@@ -30,6 +30,9 @@
     "chat.workspaceFiles.summary",
     "chat.workspaceFiles.truncated",
     "chat.workspaceFiles.workspace",
+    "cron.errors.telegramChatIdInvalid",
+    "cron.form.toHelpTelegram",
+    "cron.form.toPlaceholderTelegram",
     "cron.jobDetail.command",
     "cron.jobDetail.cwd",
     "skillWorkshop.header.useCurrentChat",
@@ -64,12 +67,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-14T04:03:18.574Z",
+  "generatedAt": "2026-06-14T20:26:51.334Z",
   "locale": "id",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "cea79b090b14fca4ad1e3e07dc5dcd7f964b1f199fd028938e41054dc5167457",
-  "totalKeys": 1377,
+  "sourceHash": "a6a1b9475b3e850cfffb54c596a9461455dc5e73ec6f64d22132a6d56206304e",
+  "totalKeys": 1380,
   "translatedKeys": 1314,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/it.meta.json
+++ b/ui/src/i18n/.i18n/it.meta.json
@@ -30,6 +30,9 @@
     "chat.workspaceFiles.summary",
     "chat.workspaceFiles.truncated",
     "chat.workspaceFiles.workspace",
+    "cron.errors.telegramChatIdInvalid",
+    "cron.form.toHelpTelegram",
+    "cron.form.toPlaceholderTelegram",
     "cron.jobDetail.command",
     "cron.jobDetail.cwd",
     "skillWorkshop.header.useCurrentChat",
@@ -64,12 +67,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-14T04:03:18.366Z",
+  "generatedAt": "2026-06-14T20:26:51.070Z",
   "locale": "it",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "cea79b090b14fca4ad1e3e07dc5dcd7f964b1f199fd028938e41054dc5167457",
-  "totalKeys": 1377,
+  "sourceHash": "a6a1b9475b3e850cfffb54c596a9461455dc5e73ec6f64d22132a6d56206304e",
+  "totalKeys": 1380,
   "translatedKeys": 1314,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ja-JP.meta.json
+++ b/ui/src/i18n/.i18n/ja-JP.meta.json
@@ -30,6 +30,9 @@
     "chat.workspaceFiles.summary",
     "chat.workspaceFiles.truncated",
     "chat.workspaceFiles.workspace",
+    "cron.errors.telegramChatIdInvalid",
+    "cron.form.toHelpTelegram",
+    "cron.form.toPlaceholderTelegram",
     "cron.jobDetail.command",
     "cron.jobDetail.cwd",
     "skillWorkshop.header.useCurrentChat",
@@ -64,12 +67,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-14T04:03:18.090Z",
+  "generatedAt": "2026-06-14T20:26:50.727Z",
   "locale": "ja-JP",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "cea79b090b14fca4ad1e3e07dc5dcd7f964b1f199fd028938e41054dc5167457",
-  "totalKeys": 1377,
+  "sourceHash": "a6a1b9475b3e850cfffb54c596a9461455dc5e73ec6f64d22132a6d56206304e",
+  "totalKeys": 1380,
   "translatedKeys": 1314,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ko.meta.json
+++ b/ui/src/i18n/.i18n/ko.meta.json
@@ -30,6 +30,9 @@
     "chat.workspaceFiles.summary",
     "chat.workspaceFiles.truncated",
     "chat.workspaceFiles.workspace",
+    "cron.errors.telegramChatIdInvalid",
+    "cron.form.toHelpTelegram",
+    "cron.form.toPlaceholderTelegram",
     "cron.jobDetail.command",
     "cron.jobDetail.cwd",
     "skillWorkshop.header.useCurrentChat",
@@ -64,12 +67,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-14T04:03:18.160Z",
+  "generatedAt": "2026-06-14T20:26:50.813Z",
   "locale": "ko",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "cea79b090b14fca4ad1e3e07dc5dcd7f964b1f199fd028938e41054dc5167457",
-  "totalKeys": 1377,
+  "sourceHash": "a6a1b9475b3e850cfffb54c596a9461455dc5e73ec6f64d22132a6d56206304e",
+  "totalKeys": 1380,
   "translatedKeys": 1314,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/nl.meta.json
+++ b/ui/src/i18n/.i18n/nl.meta.json
@@ -30,6 +30,9 @@
     "chat.workspaceFiles.summary",
     "chat.workspaceFiles.truncated",
     "chat.workspaceFiles.workspace",
+    "cron.errors.telegramChatIdInvalid",
+    "cron.form.toHelpTelegram",
+    "cron.form.toPlaceholderTelegram",
     "cron.jobDetail.command",
     "cron.jobDetail.cwd",
     "skillWorkshop.header.useCurrentChat",
@@ -64,12 +67,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-14T04:03:18.847Z",
+  "generatedAt": "2026-06-14T20:26:51.679Z",
   "locale": "nl",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "cea79b090b14fca4ad1e3e07dc5dcd7f964b1f199fd028938e41054dc5167457",
-  "totalKeys": 1377,
+  "sourceHash": "a6a1b9475b3e850cfffb54c596a9461455dc5e73ec6f64d22132a6d56206304e",
+  "totalKeys": 1380,
   "translatedKeys": 1314,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/pl.meta.json
+++ b/ui/src/i18n/.i18n/pl.meta.json
@@ -30,6 +30,9 @@
     "chat.workspaceFiles.summary",
     "chat.workspaceFiles.truncated",
     "chat.workspaceFiles.workspace",
+    "cron.errors.telegramChatIdInvalid",
+    "cron.form.toHelpTelegram",
+    "cron.form.toPlaceholderTelegram",
     "cron.jobDetail.command",
     "cron.jobDetail.cwd",
     "skillWorkshop.header.useCurrentChat",
@@ -64,12 +67,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-14T04:03:18.642Z",
+  "generatedAt": "2026-06-14T20:26:51.422Z",
   "locale": "pl",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "cea79b090b14fca4ad1e3e07dc5dcd7f964b1f199fd028938e41054dc5167457",
-  "totalKeys": 1377,
+  "sourceHash": "a6a1b9475b3e850cfffb54c596a9461455dc5e73ec6f64d22132a6d56206304e",
+  "totalKeys": 1380,
   "translatedKeys": 1314,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/pt-BR.meta.json
+++ b/ui/src/i18n/.i18n/pt-BR.meta.json
@@ -30,6 +30,9 @@
     "chat.workspaceFiles.summary",
     "chat.workspaceFiles.truncated",
     "chat.workspaceFiles.workspace",
+    "cron.errors.telegramChatIdInvalid",
+    "cron.form.toHelpTelegram",
+    "cron.form.toPlaceholderTelegram",
     "cron.jobDetail.command",
     "cron.jobDetail.cwd",
     "skillWorkshop.header.useCurrentChat",
@@ -64,12 +67,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-14T04:03:17.881Z",
+  "generatedAt": "2026-06-14T20:26:50.464Z",
   "locale": "pt-BR",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "cea79b090b14fca4ad1e3e07dc5dcd7f964b1f199fd028938e41054dc5167457",
-  "totalKeys": 1377,
+  "sourceHash": "a6a1b9475b3e850cfffb54c596a9461455dc5e73ec6f64d22132a6d56206304e",
+  "totalKeys": 1380,
   "translatedKeys": 1314,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/th.meta.json
+++ b/ui/src/i18n/.i18n/th.meta.json
@@ -30,6 +30,9 @@
     "chat.workspaceFiles.summary",
     "chat.workspaceFiles.truncated",
     "chat.workspaceFiles.workspace",
+    "cron.errors.telegramChatIdInvalid",
+    "cron.form.toHelpTelegram",
+    "cron.form.toPlaceholderTelegram",
     "cron.jobDetail.command",
     "cron.jobDetail.cwd",
     "skillWorkshop.header.useCurrentChat",
@@ -64,12 +67,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-14T04:03:18.710Z",
+  "generatedAt": "2026-06-14T20:26:51.508Z",
   "locale": "th",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "cea79b090b14fca4ad1e3e07dc5dcd7f964b1f199fd028938e41054dc5167457",
-  "totalKeys": 1377,
+  "sourceHash": "a6a1b9475b3e850cfffb54c596a9461455dc5e73ec6f64d22132a6d56206304e",
+  "totalKeys": 1380,
   "translatedKeys": 1314,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/tr.meta.json
+++ b/ui/src/i18n/.i18n/tr.meta.json
@@ -30,6 +30,9 @@
     "chat.workspaceFiles.summary",
     "chat.workspaceFiles.truncated",
     "chat.workspaceFiles.workspace",
+    "cron.errors.telegramChatIdInvalid",
+    "cron.form.toHelpTelegram",
+    "cron.form.toPlaceholderTelegram",
     "cron.jobDetail.command",
     "cron.jobDetail.cwd",
     "skillWorkshop.header.useCurrentChat",
@@ -64,12 +67,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-14T04:03:18.435Z",
+  "generatedAt": "2026-06-14T20:26:51.160Z",
   "locale": "tr",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "cea79b090b14fca4ad1e3e07dc5dcd7f964b1f199fd028938e41054dc5167457",
-  "totalKeys": 1377,
+  "sourceHash": "a6a1b9475b3e850cfffb54c596a9461455dc5e73ec6f64d22132a6d56206304e",
+  "totalKeys": 1380,
   "translatedKeys": 1314,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/uk.meta.json
+++ b/ui/src/i18n/.i18n/uk.meta.json
@@ -30,6 +30,9 @@
     "chat.workspaceFiles.summary",
     "chat.workspaceFiles.truncated",
     "chat.workspaceFiles.workspace",
+    "cron.errors.telegramChatIdInvalid",
+    "cron.form.toHelpTelegram",
+    "cron.form.toPlaceholderTelegram",
     "cron.jobDetail.command",
     "cron.jobDetail.cwd",
     "skillWorkshop.header.useCurrentChat",
@@ -64,12 +67,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-14T04:03:18.507Z",
+  "generatedAt": "2026-06-14T20:26:51.249Z",
   "locale": "uk",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "cea79b090b14fca4ad1e3e07dc5dcd7f964b1f199fd028938e41054dc5167457",
-  "totalKeys": 1377,
+  "sourceHash": "a6a1b9475b3e850cfffb54c596a9461455dc5e73ec6f64d22132a6d56206304e",
+  "totalKeys": 1380,
   "translatedKeys": 1314,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/vi.meta.json
+++ b/ui/src/i18n/.i18n/vi.meta.json
@@ -30,6 +30,9 @@
     "chat.workspaceFiles.summary",
     "chat.workspaceFiles.truncated",
     "chat.workspaceFiles.workspace",
+    "cron.errors.telegramChatIdInvalid",
+    "cron.form.toHelpTelegram",
+    "cron.form.toPlaceholderTelegram",
     "cron.jobDetail.command",
     "cron.jobDetail.cwd",
     "skillWorkshop.header.useCurrentChat",
@@ -64,12 +67,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-14T04:03:18.780Z",
+  "generatedAt": "2026-06-14T20:26:51.595Z",
   "locale": "vi",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "cea79b090b14fca4ad1e3e07dc5dcd7f964b1f199fd028938e41054dc5167457",
-  "totalKeys": 1377,
+  "sourceHash": "a6a1b9475b3e850cfffb54c596a9461455dc5e73ec6f64d22132a6d56206304e",
+  "totalKeys": 1380,
   "translatedKeys": 1314,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/zh-CN.meta.json
+++ b/ui/src/i18n/.i18n/zh-CN.meta.json
@@ -30,6 +30,9 @@
     "chat.workspaceFiles.summary",
     "chat.workspaceFiles.truncated",
     "chat.workspaceFiles.workspace",
+    "cron.errors.telegramChatIdInvalid",
+    "cron.form.toHelpTelegram",
+    "cron.form.toPlaceholderTelegram",
     "cron.jobDetail.command",
     "cron.jobDetail.cwd",
     "skillWorkshop.header.useCurrentChat",
@@ -64,12 +67,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-14T04:03:17.740Z",
+  "generatedAt": "2026-06-14T20:26:50.290Z",
   "locale": "zh-CN",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "cea79b090b14fca4ad1e3e07dc5dcd7f964b1f199fd028938e41054dc5167457",
-  "totalKeys": 1377,
+  "sourceHash": "a6a1b9475b3e850cfffb54c596a9461455dc5e73ec6f64d22132a6d56206304e",
+  "totalKeys": 1380,
   "translatedKeys": 1314,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/zh-TW.meta.json
+++ b/ui/src/i18n/.i18n/zh-TW.meta.json
@@ -30,6 +30,9 @@
     "chat.workspaceFiles.summary",
     "chat.workspaceFiles.truncated",
     "chat.workspaceFiles.workspace",
+    "cron.errors.telegramChatIdInvalid",
+    "cron.form.toHelpTelegram",
+    "cron.form.toPlaceholderTelegram",
     "cron.jobDetail.command",
     "cron.jobDetail.cwd",
     "skillWorkshop.header.useCurrentChat",
@@ -64,12 +67,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-14T04:03:17.811Z",
+  "generatedAt": "2026-06-14T20:26:50.378Z",
   "locale": "zh-TW",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "cea79b090b14fca4ad1e3e07dc5dcd7f964b1f199fd028938e41054dc5167457",
-  "totalKeys": 1377,
+  "sourceHash": "a6a1b9475b3e850cfffb54c596a9461455dc5e73ec6f64d22132a6d56206304e",
+  "totalKeys": 1380,
   "translatedKeys": 1314,
   "workflow": 1
 }

--- a/ui/src/i18n/locales/ar.ts
+++ b/ui/src/i18n/locales/ar.ts
@@ -1588,7 +1588,9 @@ export const ar: TranslationMap = {
       webhookHelp: "أرسل ملخصات التشغيل إلى نقطة نهاية webhook.",
       to: "إلى",
       toPlaceholder: "+1555... أو معرّف الدردشة",
+      toPlaceholderTelegram: "-1001234567890 or @channel",
       toHelp: "تجاوز اختياري للمستلم (معرّف الدردشة، أو الهاتف، أو معرّف المستخدم).",
+      toHelpTelegram: "Telegram chat.id (e.g. -1001234567890), @username, or t.me link.",
       advanced: "متقدم",
       advancedHelp:
         "تجاوزات اختيارية لضمانات التسليم، وتباين الجدول العشوائي، وعناصر التحكم في النموذج.",
@@ -1663,6 +1665,8 @@ export const ar: TranslationMap = {
       timeoutInvalid: "إذا تم تعيينها، يجب أن تكون المهلة أكبر من 0 ثانية.",
       webhookUrlRequired: "عنوان URL للـ Webhook مطلوب.",
       webhookUrlInvalid: "يجب أن يبدأ عنوان URL للـ Webhook بـ http:// أو https://.",
+      telegramChatIdInvalid:
+        "Telegram To must be a chat.id (e.g. -1001234567890), @username, or t.me link (optional :topicId).",
       invalidRunTime: "وقت التشغيل غير صالح.",
       invalidIntervalAmount: "مقدار الفاصل غير صالح.",
       cronExprRequiredShort: "تعبير Cron مطلوب.",

--- a/ui/src/i18n/locales/de.ts
+++ b/ui/src/i18n/locales/de.ts
@@ -1623,7 +1623,9 @@ export const de: TranslationMap = {
       webhookHelp: "Sendet Ausführungszusammenfassungen an einen Webhook-Endpunkt.",
       to: "An",
       toPlaceholder: "+1555... oder Chat-ID",
+      toPlaceholderTelegram: "-1001234567890 or @channel",
       toHelp: "Optionale Empfängerüberschreibung (Chat-ID, Telefonnummer oder Benutzer-ID).",
+      toHelpTelegram: "Telegram chat.id (e.g. -1001234567890), @username, or t.me link.",
       advanced: "Erweitert",
       advancedHelp:
         "Optionale Überschreibungen für Zustellungsgarantien, Zeitplan-Jitter und Modellsteuerung.",
@@ -1701,6 +1703,8 @@ export const de: TranslationMap = {
       timeoutInvalid: "Falls gesetzt, muss das Timeout größer als 0 Sekunden sein.",
       webhookUrlRequired: "Webhook-URL ist erforderlich.",
       webhookUrlInvalid: "Die Webhook-URL muss mit http:// oder https:// beginnen.",
+      telegramChatIdInvalid:
+        "Telegram To must be a chat.id (e.g. -1001234567890), @username, or t.me link (optional :topicId).",
       invalidRunTime: "Ungültige Ausführungszeit.",
       invalidIntervalAmount: "Ungültiger Intervallwert.",
       cronExprRequiredShort: "Cron-Ausdruck erforderlich.",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -1596,7 +1596,9 @@ export const en: TranslationMap = {
       webhookHelp: "Send run summaries to a webhook endpoint.",
       to: "To",
       toPlaceholder: "+1555... or chat id",
+      toPlaceholderTelegram: "-1001234567890 or @channel",
       toHelp: "Optional recipient override (chat id, phone, or user id).",
+      toHelpTelegram: "Telegram chat.id (e.g. -1001234567890), @username, or t.me link.",
       advanced: "Advanced",
       advancedHelp:
         "Optional overrides for delivery guarantees, schedule jitter, and model controls.",
@@ -1671,6 +1673,8 @@ export const en: TranslationMap = {
       timeoutInvalid: "If set, timeout must be greater than 0 seconds.",
       webhookUrlRequired: "Webhook URL is required.",
       webhookUrlInvalid: "Webhook URL must start with http:// or https://.",
+      telegramChatIdInvalid:
+        "Telegram To must be a chat.id (e.g. -1001234567890), @username, or t.me link (optional :topicId).",
       invalidRunTime: "Invalid run time.",
       invalidIntervalAmount: "Invalid interval amount.",
       cronExprRequiredShort: "Cron expression required.",

--- a/ui/src/i18n/locales/es.ts
+++ b/ui/src/i18n/locales/es.ts
@@ -1617,7 +1617,9 @@ export const es: TranslationMap = {
       webhookHelp: "Envía resúmenes de ejecución a un endpoint webhook.",
       to: "Para",
       toPlaceholder: "+1555... o ID de chat",
+      toPlaceholderTelegram: "-1001234567890 or @channel",
       toHelp: "Anulación opcional del destinatario (ID de chat, teléfono o ID de usuario).",
+      toHelpTelegram: "Telegram chat.id (e.g. -1001234567890), @username, or t.me link.",
       advanced: "Avanzado",
       advancedHelp:
         "Anulaciones opcionales para garantías de entrega, variación de programación y controles del modelo.",
@@ -1695,6 +1697,8 @@ export const es: TranslationMap = {
       timeoutInvalid: "Si se establece, el tiempo de espera debe ser mayor a 0 segundos.",
       webhookUrlRequired: "La URL del webhook es requerida.",
       webhookUrlInvalid: "La URL del webhook debe comenzar con http:// o https://.",
+      telegramChatIdInvalid:
+        "Telegram To must be a chat.id (e.g. -1001234567890), @username, or t.me link (optional :topicId).",
       invalidRunTime: "Tiempo de ejecución inválido.",
       invalidIntervalAmount: "Cantidad de intervalo inválida.",
       cronExprRequiredShort: "Expresión Cron requerida.",

--- a/ui/src/i18n/locales/fa.ts
+++ b/ui/src/i18n/locales/fa.ts
@@ -1607,7 +1607,9 @@ export const fa: TranslationMap = {
       webhookHelp: "خلاصه‌های اجرا را به یک نقطه پایانی وب‌هوک ارسال کنید.",
       to: "به",
       toPlaceholder: "+1555... یا شناسه چت",
+      toPlaceholderTelegram: "-1001234567890 or @channel",
       toHelp: "بازنویسی اختیاری گیرنده (شناسه چت، تلفن یا شناسه کاربر).",
+      toHelpTelegram: "Telegram chat.id (e.g. -1001234567890), @username, or t.me link.",
       advanced: "پیشرفته",
       advancedHelp: "بازنویسی‌های اختیاری برای تضمین‌های تحویل، نوسان زمان‌بندی و کنترل‌های مدل.",
       deleteAfterRun: "حذف پس از اجرا",
@@ -1681,6 +1683,8 @@ export const fa: TranslationMap = {
       timeoutInvalid: "اگر تنظیم شود، مهلت زمانی باید بیشتر از 0 ثانیه باشد.",
       webhookUrlRequired: "URL وب‌هوک ضروری است.",
       webhookUrlInvalid: "URL وب‌هوک باید با http:// یا https:// شروع شود.",
+      telegramChatIdInvalid:
+        "Telegram To must be a chat.id (e.g. -1001234567890), @username, or t.me link (optional :topicId).",
       invalidRunTime: "زمان اجرا نامعتبر است.",
       invalidIntervalAmount: "مقدار فاصله نامعتبر است.",
       cronExprRequiredShort: "عبارت Cron ضروری است.",

--- a/ui/src/i18n/locales/fr.ts
+++ b/ui/src/i18n/locales/fr.ts
@@ -1625,7 +1625,9 @@ export const fr: TranslationMap = {
       webhookHelp: "Envoyez les résumés d’exécution vers un endpoint webhook.",
       to: "À",
       toPlaceholder: "+1555... ou ID de chat",
+      toPlaceholderTelegram: "-1001234567890 or @channel",
       toHelp: "Remplacement facultatif du destinataire (ID de chat, téléphone ou ID utilisateur).",
+      toHelpTelegram: "Telegram chat.id (e.g. -1001234567890), @username, or t.me link.",
       advanced: "Avancé",
       advancedHelp:
         "Remplacements facultatifs pour les garanties de distribution, le jitter de planification et les contrôles du modèle.",
@@ -1701,6 +1703,8 @@ export const fr: TranslationMap = {
       timeoutInvalid: "S’il est défini, le délai d’expiration doit être supérieur à 0 seconde.",
       webhookUrlRequired: "L’URL du webhook est obligatoire.",
       webhookUrlInvalid: "L’URL du webhook doit commencer par http:// ou https://.",
+      telegramChatIdInvalid:
+        "Telegram To must be a chat.id (e.g. -1001234567890), @username, or t.me link (optional :topicId).",
       invalidRunTime: "Heure d’exécution invalide.",
       invalidIntervalAmount: "Montant d’intervalle invalide.",
       cronExprRequiredShort: "Expression cron obligatoire.",

--- a/ui/src/i18n/locales/id.ts
+++ b/ui/src/i18n/locales/id.ts
@@ -1605,7 +1605,9 @@ export const id: TranslationMap = {
       webhookHelp: "Kirim ringkasan proses ke endpoint webhook.",
       to: "Ke",
       toPlaceholder: "+1555... atau ID chat",
+      toPlaceholderTelegram: "-1001234567890 or @channel",
       toHelp: "Penggantian penerima opsional (ID chat, telepon, atau ID pengguna).",
+      toHelpTelegram: "Telegram chat.id (e.g. -1001234567890), @username, or t.me link.",
       advanced: "Lanjutan",
       advancedHelp:
         "Penggantian opsional untuk jaminan pengiriman, jitter jadwal, dan kontrol model.",
@@ -1680,6 +1682,8 @@ export const id: TranslationMap = {
       timeoutInvalid: "Jika diatur, batas waktu harus lebih besar dari 0 detik.",
       webhookUrlRequired: "URL Webhook wajib diisi.",
       webhookUrlInvalid: "URL Webhook harus diawali dengan http:// atau https://.",
+      telegramChatIdInvalid:
+        "Telegram To must be a chat.id (e.g. -1001234567890), @username, or t.me link (optional :topicId).",
       invalidRunTime: "Waktu proses tidak valid.",
       invalidIntervalAmount: "Jumlah interval tidak valid.",
       cronExprRequiredShort: "Ekspresi cron wajib diisi.",

--- a/ui/src/i18n/locales/it.ts
+++ b/ui/src/i18n/locales/it.ts
@@ -1619,7 +1619,9 @@ export const it: TranslationMap = {
       webhookHelp: "Invia i riepiloghi delle esecuzioni a un endpoint webhook.",
       to: "A",
       toPlaceholder: "+1555... o ID chat",
+      toPlaceholderTelegram: "-1001234567890 or @channel",
       toHelp: "Override facoltativo del destinatario (ID chat, telefono o ID utente).",
+      toHelpTelegram: "Telegram chat.id (e.g. -1001234567890), @username, or t.me link.",
       advanced: "Avanzate",
       advancedHelp:
         "Override facoltativi per garanzie di consegna, jitter di pianificazione e controlli del modello.",
@@ -1695,6 +1697,8 @@ export const it: TranslationMap = {
       timeoutInvalid: "Se impostato, il timeout deve essere maggiore di 0 secondi.",
       webhookUrlRequired: "L'URL webhook è obbligatorio.",
       webhookUrlInvalid: "L'URL webhook deve iniziare con http:// o https://.",
+      telegramChatIdInvalid:
+        "Telegram To must be a chat.id (e.g. -1001234567890), @username, or t.me link (optional :topicId).",
       invalidRunTime: "Ora di esecuzione non valida.",
       invalidIntervalAmount: "Importo intervallo non valido.",
       cronExprRequiredShort: "Espressione cron obbligatoria.",

--- a/ui/src/i18n/locales/ja-JP.ts
+++ b/ui/src/i18n/locales/ja-JP.ts
@@ -1614,7 +1614,9 @@ export const ja_JP: TranslationMap = {
       webhookHelp: "実行結果の概要を Webhook エンドポイントに送信します。",
       to: "宛先",
       toPlaceholder: "+1555... または chat id",
+      toPlaceholderTelegram: "-1001234567890 or @channel",
       toHelp: "任意の受信者上書きです（chat id、電話番号、または user id）。",
+      toHelpTelegram: "Telegram chat.id (e.g. -1001234567890), @username, or t.me link.",
       advanced: "詳細",
       advancedHelp: "配信保証、スケジュールのジッター、モデル制御の任意の上書き設定。",
       deleteAfterRun: "実行後に削除",
@@ -1688,6 +1690,8 @@ export const ja_JP: TranslationMap = {
       timeoutInvalid: "設定する場合、タイムアウトは 0 秒より大きくする必要があります。",
       webhookUrlRequired: "Webhook URL は必須です。",
       webhookUrlInvalid: "Webhook URL は http:// または https:// で始まる必要があります。",
+      telegramChatIdInvalid:
+        "Telegram To must be a chat.id (e.g. -1001234567890), @username, or t.me link (optional :topicId).",
       invalidRunTime: "無効な実行時刻です。",
       invalidIntervalAmount: "無効な間隔の値です。",
       cronExprRequiredShort: "Cron 式は必須です。",

--- a/ui/src/i18n/locales/ko.ts
+++ b/ui/src/i18n/locales/ko.ts
@@ -1596,7 +1596,9 @@ export const ko: TranslationMap = {
       webhookHelp: "실행 요약을 webhook 엔드포인트로 보냅니다.",
       to: "받는 사람",
       toPlaceholder: "+1555... 또는 chat id",
+      toPlaceholderTelegram: "-1001234567890 or @channel",
       toHelp: "선택적 수신자 재정의(chat id, 전화번호 또는 user id).",
+      toHelpTelegram: "Telegram chat.id (e.g. -1001234567890), @username, or t.me link.",
       advanced: "고급",
       advancedHelp: "전달 보장, 일정 지터, 모델 제어를 위한 선택적 재정의입니다.",
       deleteAfterRun: "실행 후 삭제",
@@ -1670,6 +1672,8 @@ export const ko: TranslationMap = {
       timeoutInvalid: "설정하는 경우 타임아웃은 0초보다 커야 합니다.",
       webhookUrlRequired: "Webhook URL은 필수입니다.",
       webhookUrlInvalid: "Webhook URL은 http:// 또는 https://로 시작해야 합니다.",
+      telegramChatIdInvalid:
+        "Telegram To must be a chat.id (e.g. -1001234567890), @username, or t.me link (optional :topicId).",
       invalidRunTime: "잘못된 실행 시간입니다.",
       invalidIntervalAmount: "잘못된 간격 값입니다.",
       cronExprRequiredShort: "Cron 표현식이 필요합니다.",

--- a/ui/src/i18n/locales/nl.ts
+++ b/ui/src/i18n/locales/nl.ts
@@ -1612,7 +1612,9 @@ export const nl: TranslationMap = {
       webhookHelp: "Verzend runsamenvattingen naar een webhook-eindpunt.",
       to: "Aan",
       toPlaceholder: "+1555... of chat-id",
+      toPlaceholderTelegram: "-1001234567890 or @channel",
       toHelp: "Optionele ontvanger-override (chat-id, telefoonnummer of gebruikers-id).",
+      toHelpTelegram: "Telegram chat.id (e.g. -1001234567890), @username, or t.me link.",
       advanced: "Geavanceerd",
       advancedHelp: "Optionele overrides voor leveringsgaranties, schemajitter en modelbesturing.",
       deleteAfterRun: "Verwijderen na run",
@@ -1687,6 +1689,8 @@ export const nl: TranslationMap = {
       timeoutInvalid: "Als ingesteld, moet timeout groter zijn dan 0 seconden.",
       webhookUrlRequired: "Webhook-URL is verplicht.",
       webhookUrlInvalid: "Webhook-URL moet beginnen met http:// of https://.",
+      telegramChatIdInvalid:
+        "Telegram To must be a chat.id (e.g. -1001234567890), @username, or t.me link (optional :topicId).",
       invalidRunTime: "Ongeldige uitvoeringstijd.",
       invalidIntervalAmount: "Ongeldige intervalwaarde.",
       cronExprRequiredShort: "Cron-expressie vereist.",

--- a/ui/src/i18n/locales/pl.ts
+++ b/ui/src/i18n/locales/pl.ts
@@ -1615,8 +1615,10 @@ export const pl: TranslationMap = {
       webhookHelp: "Wysyłaj podsumowania uruchomień do endpointu webhooka.",
       to: "Do",
       toPlaceholder: "+1555... lub identyfikator czatu",
+      toPlaceholderTelegram: "-1001234567890 or @channel",
       toHelp:
         "Opcjonalne nadpisanie odbiorcy (identyfikator czatu, numer telefonu lub identyfikator użytkownika).",
+      toHelpTelegram: "Telegram chat.id (e.g. -1001234567890), @username, or t.me link.",
       advanced: "Zaawansowane",
       advancedHelp:
         "Opcjonalne nadpisania gwarancji dostarczenia, losowego rozrzutu harmonogramu i ustawień modelu.",
@@ -1693,6 +1695,8 @@ export const pl: TranslationMap = {
       timeoutInvalid: "Jeśli ustawiono, limit czasu musi być większy niż 0 sekund.",
       webhookUrlRequired: "URL webhooka jest wymagany.",
       webhookUrlInvalid: "URL webhooka musi zaczynać się od http:// lub https://.",
+      telegramChatIdInvalid:
+        "Telegram To must be a chat.id (e.g. -1001234567890), @username, or t.me link (optional :topicId).",
       invalidRunTime: "Nieprawidłowy czas uruchomienia.",
       invalidIntervalAmount: "Nieprawidłowa wartość interwału.",
       cronExprRequiredShort: "Wyrażenie Cron jest wymagane.",

--- a/ui/src/i18n/locales/pt-BR.ts
+++ b/ui/src/i18n/locales/pt-BR.ts
@@ -1610,7 +1610,9 @@ export const pt_BR: TranslationMap = {
       webhookHelp: "Envie resumos de execução para um endpoint de webhook.",
       to: "Para",
       toPlaceholder: "+1555... ou ID do chat",
+      toPlaceholderTelegram: "-1001234567890 or @channel",
       toHelp: "Substituição opcional do destinatário (ID do chat, telefone ou ID do usuário).",
+      toHelpTelegram: "Telegram chat.id (e.g. -1001234567890), @username, or t.me link.",
       advanced: "Avançado",
       advancedHelp:
         "Substituições opcionais para garantias de entrega, jitter de agendamento e controles de modelo.",
@@ -1685,6 +1687,8 @@ export const pt_BR: TranslationMap = {
       timeoutInvalid: "Se definido, o tempo limite deve ser maior que 0 segundos.",
       webhookUrlRequired: "A URL do webhook é obrigatória.",
       webhookUrlInvalid: "A URL do webhook deve começar com http:// ou https://.",
+      telegramChatIdInvalid:
+        "Telegram To must be a chat.id (e.g. -1001234567890), @username, or t.me link (optional :topicId).",
       invalidRunTime: "Horário de execução inválido.",
       invalidIntervalAmount: "Quantidade de intervalo inválida.",
       cronExprRequiredShort: "Expressão cron obrigatória.",

--- a/ui/src/i18n/locales/th.ts
+++ b/ui/src/i18n/locales/th.ts
@@ -1573,7 +1573,9 @@ export const th: TranslationMap = {
       webhookHelp: "ส่งสรุปผลการทำงานไปยังปลายทาง webhook",
       to: "ถึง",
       toPlaceholder: "+1555... หรือ chat id",
+      toPlaceholderTelegram: "-1001234567890 or @channel",
       toHelp: "ตัวเลือกแทนที่ผู้รับ (chat id, โทรศัพท์ หรือ user id)",
+      toHelpTelegram: "Telegram chat.id (e.g. -1001234567890), @username, or t.me link.",
       advanced: "ขั้นสูง",
       advancedHelp: "ตัวเลือกแทนที่สำหรับการรับประกันการส่ง, schedule jitter และการควบคุมโมเดล",
       deleteAfterRun: "ลบหลังทำงาน",
@@ -1647,6 +1649,8 @@ export const th: TranslationMap = {
       timeoutInvalid: "หากกำหนดค่าไว้ timeout ต้องมากกว่า 0 วินาที",
       webhookUrlRequired: "ต้องระบุ Webhook URL",
       webhookUrlInvalid: "Webhook URL ต้องขึ้นต้นด้วย http:// หรือ https://",
+      telegramChatIdInvalid:
+        "Telegram To must be a chat.id (e.g. -1001234567890), @username, or t.me link (optional :topicId).",
       invalidRunTime: "เวลารันไม่ถูกต้อง",
       invalidIntervalAmount: "จำนวนช่วงเวลาไม่ถูกต้อง",
       cronExprRequiredShort: "ต้องระบุ Cron expression",

--- a/ui/src/i18n/locales/tr.ts
+++ b/ui/src/i18n/locales/tr.ts
@@ -1614,7 +1614,9 @@ export const tr: TranslationMap = {
       webhookHelp: "Çalıştırma özetlerini bir webhook uç noktasına gönderin.",
       to: "Kime",
       toPlaceholder: "+1555... veya sohbet kimliği",
+      toPlaceholderTelegram: "-1001234567890 or @channel",
       toHelp: "İsteğe bağlı alıcı geçersiz kılma (sohbet kimliği, telefon veya kullanıcı kimliği).",
+      toHelpTelegram: "Telegram chat.id (e.g. -1001234567890), @username, or t.me link.",
       advanced: "Gelişmiş",
       advancedHelp:
         "Teslimat garantileri, zamanlama jitter'ı ve model kontrolleri için isteğe bağlı geçersiz kılmalar.",
@@ -1690,6 +1692,8 @@ export const tr: TranslationMap = {
       timeoutInvalid: "Ayarlanırsa zaman aşımı 0 saniyeden büyük olmalıdır.",
       webhookUrlRequired: "Webhook URL gerekli.",
       webhookUrlInvalid: "Webhook URL http:// veya https:// ile başlamalıdır.",
+      telegramChatIdInvalid:
+        "Telegram To must be a chat.id (e.g. -1001234567890), @username, or t.me link (optional :topicId).",
       invalidRunTime: "Geçersiz çalıştırma zamanı.",
       invalidIntervalAmount: "Geçersiz aralık miktarı.",
       cronExprRequiredShort: "Cron ifadesi gerekli.",

--- a/ui/src/i18n/locales/uk.ts
+++ b/ui/src/i18n/locales/uk.ts
@@ -1612,7 +1612,9 @@ export const uk: TranslationMap = {
       webhookHelp: "Надсилати підсумки запусків до endpoint webhook.",
       to: "Кому",
       toPlaceholder: "+1555... або id чату",
+      toPlaceholderTelegram: "-1001234567890 or @channel",
       toHelp: "Необов’язкове перевизначення одержувача (id чату, телефон або id користувача).",
+      toHelpTelegram: "Telegram chat.id (e.g. -1001234567890), @username, or t.me link.",
       advanced: "Додатково",
       advancedHelp:
         "Необов’язкові перевизначення для гарантій доставки, джитера розкладу та керування моделлю.",
@@ -1688,6 +1690,8 @@ export const uk: TranslationMap = {
       timeoutInvalid: "Якщо задано, тайм-аут має бути більшим за 0 секунд.",
       webhookUrlRequired: "URL webhook є обов’язковим.",
       webhookUrlInvalid: "URL webhook має починатися з http:// або https://.",
+      telegramChatIdInvalid:
+        "Telegram To must be a chat.id (e.g. -1001234567890), @username, or t.me link (optional :topicId).",
       invalidRunTime: "Недійсний час запуску.",
       invalidIntervalAmount: "Недійсне значення інтервалу.",
       cronExprRequiredShort: "Потрібен вираз Cron.",

--- a/ui/src/i18n/locales/vi.ts
+++ b/ui/src/i18n/locales/vi.ts
@@ -1599,7 +1599,9 @@ export const vi: TranslationMap = {
       webhookHelp: "Gửi tóm tắt lần chạy tới endpoint webhook.",
       to: "Đến",
       toPlaceholder: "+1555... hoặc id trò chuyện",
+      toPlaceholderTelegram: "-1001234567890 or @channel",
       toHelp: "Ghi đè người nhận tùy chọn (id trò chuyện, số điện thoại hoặc id người dùng).",
+      toHelpTelegram: "Telegram chat.id (e.g. -1001234567890), @username, or t.me link.",
       advanced: "Nâng cao",
       advancedHelp: "Ghi đè tùy chọn cho đảm bảo gửi, độ lệch lịch và điều khiển mô hình.",
       deleteAfterRun: "Xóa sau khi chạy",
@@ -1673,6 +1675,8 @@ export const vi: TranslationMap = {
       timeoutInvalid: "Nếu đặt, thời gian chờ phải lớn hơn 0 giây.",
       webhookUrlRequired: "Bắt buộc nhập URL webhook.",
       webhookUrlInvalid: "URL webhook phải bắt đầu bằng http:// hoặc https://.",
+      telegramChatIdInvalid:
+        "Telegram To must be a chat.id (e.g. -1001234567890), @username, or t.me link (optional :topicId).",
       invalidRunTime: "Thời gian chạy không hợp lệ.",
       invalidIntervalAmount: "Khoảng lặp không hợp lệ.",
       cronExprRequiredShort: "Bắt buộc nhập biểu thức cron.",

--- a/ui/src/i18n/locales/zh-CN.ts
+++ b/ui/src/i18n/locales/zh-CN.ts
@@ -1568,7 +1568,9 @@ export const zh_CN: TranslationMap = {
       webhookHelp: "将运行摘要发送到 Webhook 端点。",
       to: "收件人",
       toPlaceholder: "+1555... 或聊天 ID",
+      toPlaceholderTelegram: "-1001234567890 or @channel",
       toHelp: "可选收件人覆盖（聊天 ID、电话或用户 ID）。",
+      toHelpTelegram: "Telegram chat.id (e.g. -1001234567890), @username, or t.me link.",
       advanced: "高级",
       advancedHelp: "投递保证、调度抖动和模型控制的可选覆盖。",
       deleteAfterRun: "运行后删除",
@@ -1642,6 +1644,8 @@ export const zh_CN: TranslationMap = {
       timeoutInvalid: "若设置超时，必须大于 0 秒。",
       webhookUrlRequired: "Webhook URL 为必填项。",
       webhookUrlInvalid: "Webhook URL 必须以 http:// 或 https:// 开头。",
+      telegramChatIdInvalid:
+        "Telegram To must be a chat.id (e.g. -1001234567890), @username, or t.me link (optional :topicId).",
       invalidRunTime: "无效的运行时间。",
       invalidIntervalAmount: "无效的间隔值。",
       cronExprRequiredShort: "Cron 表达式为必填。",

--- a/ui/src/i18n/locales/zh-TW.ts
+++ b/ui/src/i18n/locales/zh-TW.ts
@@ -1570,7 +1570,9 @@ export const zh_TW: TranslationMap = {
       webhookHelp: "將執行摘要傳送到 webhook 端點。",
       to: "傳送至",
       toPlaceholder: "+1555... 或 chat id",
+      toPlaceholderTelegram: "-1001234567890 or @channel",
       toHelp: "選填的收件者覆寫值（chat id、電話號碼或 user id）。",
+      toHelpTelegram: "Telegram chat.id (e.g. -1001234567890), @username, or t.me link.",
       advanced: "進階",
       advancedHelp: "用於傳送保證、排程抖動和模型控制的選用覆寫設定。",
       deleteAfterRun: "執行後刪除",
@@ -1644,6 +1646,8 @@ export const zh_TW: TranslationMap = {
       timeoutInvalid: "若有設定，逾時必須大於 0 秒。",
       webhookUrlRequired: "Webhook URL 為必填。",
       webhookUrlInvalid: "Webhook URL 必須以 http:// 或 https:// 開頭。",
+      telegramChatIdInvalid:
+        "Telegram To must be a chat.id (e.g. -1001234567890), @username, or t.me link (optional :topicId).",
       invalidRunTime: "執行時間無效。",
       invalidIntervalAmount: "間隔數值無效。",
       cronExprRequiredShort: "Cron 運算式為必填。",

--- a/ui/src/ui/controllers/cron.test.ts
+++ b/ui/src/ui/controllers/cron.test.ts
@@ -1181,6 +1181,70 @@ describe("cron controller", () => {
     expect(errors.deliveryTo).toBe("cron.errors.webhookUrlInvalid");
   });
 
+  it("flags unsendable Telegram announce To targets before save (#90467)", () => {
+    // A phone number, a hyphenated name, and a too-short handle cannot resolve
+    // through the Telegram target contract, so block them before save.
+    for (const target of ["+15551234567", "gmail-cleaner", "@abc"]) {
+      const errors = validateCronForm({
+        ...DEFAULT_CRON_FORM,
+        name: "tg",
+        payloadKind: "agentTurn",
+        payloadText: "ping",
+        sessionTarget: "isolated",
+        deliveryMode: "announce",
+        deliveryChannel: "telegram",
+        deliveryTo: target,
+      });
+      expect(errors.deliveryTo).toBe("cron.errors.telegramChatIdInvalid");
+    }
+  });
+
+  it("accepts every Telegram target form runtime delivery resolves (#90467)", () => {
+    // Mirrors the forms normalizeTelegramMessagingTarget accepts: numeric chat
+    // ids, @username / bare usernames, t.me links, telegram:/tg: prefixes, and
+    // optional :topicId / :topic:topicId suffixes.
+    const accepted = [
+      "-1001234567890",
+      "123456789",
+      "-1001234567890:42",
+      "-100123:topic:7",
+      "@mychannel",
+      "mychannel",
+      "https://t.me/mychannel",
+      "t.me/mychannel",
+      "telegram:123456789",
+      "tg:@mychannel",
+      "@mychannel:42",
+    ];
+    for (const target of accepted) {
+      const errors = validateCronForm({
+        ...DEFAULT_CRON_FORM,
+        name: "tg",
+        payloadKind: "agentTurn",
+        payloadText: "ping",
+        sessionTarget: "isolated",
+        deliveryMode: "announce",
+        deliveryChannel: "telegram",
+        deliveryTo: target,
+      });
+      expect(errors.deliveryTo).toBeUndefined();
+    }
+  });
+
+  it("ignores Telegram chat id format on non-telegram channels", () => {
+    const errors = validateCronForm({
+      ...DEFAULT_CRON_FORM,
+      name: "discord",
+      payloadKind: "agentTurn",
+      payloadText: "ping",
+      sessionTarget: "isolated",
+      deliveryMode: "announce",
+      deliveryChannel: "discord",
+      deliveryTo: "ops",
+    });
+    expect(errors.deliveryTo).toBeUndefined();
+  });
+
   it("blocks add/update submit when validation errors exist", async () => {
     const request = vi.fn(async () => ({}));
     const state = createState({

--- a/ui/src/ui/controllers/cron.ts
+++ b/ui/src/ui/controllers/cron.ts
@@ -116,6 +116,23 @@ export function normalizeCronFormState(form: CronFormState): CronFormState {
   };
 }
 
+// Mirrors the Telegram delivery target contract that cron announce delivery
+// resolves through normalizeTargetForProvider -> the Telegram plugin's
+// normalizeTelegramMessagingTarget (extensions/telegram/src/targets.ts,
+// parseTelegramTarget + normalizeTelegramLookupTarget). Accept the same forms
+// runtime can send to — numeric chat ids, @username / bare usernames, and t.me
+// links — with optional telegram:/tg: prefix and optional :topicId /
+// :topic:topicId suffix. Anything else (e.g. a phone number) cannot resolve at
+// send time, so it is caught before the cron job is saved. The plugin owns the
+// canonical contract; this is a save-time UX mirror, not a second source.
+const TELEGRAM_USERNAME_PATTERN = "[A-Za-z0-9_]{5,}";
+const TELEGRAM_TARGET_PATTERN = new RegExp(
+  `^(?:(?:telegram|tg):)?` +
+    `(?:-?\\d+|@?${TELEGRAM_USERNAME_PATTERN}|(?:https?:\\/\\/)?t\\.me\\/${TELEGRAM_USERNAME_PATTERN})` +
+    `(?::topic:\\d+|:\\d+)?$`,
+  "i",
+);
+
 export function validateCronForm(form: CronFormState): CronFieldErrors {
   const errors: CronFieldErrors = {};
   if (!form.name.trim()) {
@@ -166,6 +183,12 @@ export function validateCronForm(form: CronFormState): CronFieldErrors {
       errors.deliveryTo = "cron.errors.webhookUrlRequired";
     } else if (!/^https?:\/\//i.test(target)) {
       errors.deliveryTo = "cron.errors.webhookUrlInvalid";
+    }
+  }
+  if (form.deliveryMode === "announce" && form.deliveryChannel === "telegram") {
+    const target = form.deliveryTo.trim();
+    if (target && !TELEGRAM_TARGET_PATTERN.test(target)) {
+      errors.deliveryTo = "cron.errors.telegramChatIdInvalid";
     }
   }
   if (form.failureAlertMode === "custom") {

--- a/ui/src/ui/views/cron.ts
+++ b/ui/src/ui/views/cron.ts
@@ -1092,13 +1092,29 @@ export function renderCron(props: CronProps) {
                                     id="cron-delivery-to"
                                     .value=${props.form.deliveryTo}
                                     list="cron-delivery-to-suggestions"
+                                    aria-invalid=${props.fieldErrors.deliveryTo ? "true" : "false"}
+                                    aria-describedby=${ifDefined(
+                                      props.fieldErrors.deliveryTo
+                                        ? errorIdForField("deliveryTo")
+                                        : undefined,
+                                    )}
                                     @input=${(e: Event) =>
                                       props.onFormChange({
                                         deliveryTo: (e.target as HTMLInputElement).value,
                                       })}
-                                    placeholder=${t("cron.form.toPlaceholder")}
+                                    placeholder=${props.form.deliveryChannel === "telegram"
+                                      ? t("cron.form.toPlaceholderTelegram")
+                                      : t("cron.form.toPlaceholder")}
                                   />
-                                  <div class="cron-help">${t("cron.form.toHelp")}</div>
+                                  <div class="cron-help">
+                                    ${props.form.deliveryChannel === "telegram"
+                                      ? t("cron.form.toHelpTelegram")
+                                      : t("cron.form.toHelp")}
+                                  </div>
+                                  ${renderFieldError(
+                                    props.fieldErrors.deliveryTo,
+                                    errorIdForField("deliveryTo"),
+                                  )}
                                 </label>
                               `
                             : nothing}


### PR DESCRIPTION
## Summary

Adds save-time Control UI validation for the cron **announce → To** field when
the delivery channel is Telegram, so a cron job cannot be saved with a recipient
Telegram can never deliver to. Previously the announce `To` field accepted any
string and the failure only surfaced at runtime (issue #90467).

### What changed since the first revision

The first revision validated **numeric chat ids only**. That was too narrow:
cron announce delivery resolves the target through
`normalizeTargetForProvider("telegram", to)` → the Telegram plugin's
`normalizeTelegramMessagingTarget` (`extensions/telegram/src/targets.ts`,
`parseTelegramTarget` + `normalizeTelegramLookupTarget`), which accepts more than
numeric ids. A numeric-only check would have blocked valid recipients such as
`@mychat`, `https://t.me/mychannel`, and `telegram:123` before save.

Validation now mirrors the full delivery contract:

- numeric chat ids (`-1001234567890`, `123456789`)
- `@username` and bare usernames (`[A-Za-z0-9_]{5,}`)
- `t.me` links (`t.me/...`, `https://t.me/...`)
- `telegram:` / `tg:` prefixes
- optional `:topicId` / `:topic:topicId` suffix on any of the above

Anything else (e.g. a phone number from the generic placeholder, or a hyphenated
name) is rejected before save. The Telegram plugin remains the canonical owner of
the contract; the UI regex is a documented save-time UX mirror, not a second
source of truth (the UI package cannot import plugin internals across the
`extensions/**` boundary).

Also in this PR:
- Telegram-specific placeholder/help copy on the announce `To` field.
- Inline error rendering + `aria-invalid` / `aria-describedby` on the announce
  `To` field (previously only the webhook field rendered its error).
- Regenerated i18n locale bundles + `.i18n` metadata for the new English strings
  (`pnpm ui:i18n:sync`), so the UI i18n drift gate stays green.

## Verification

- `node scripts/run-vitest.mjs ui/src/ui/controllers/cron.test.ts` → 43 passed
  (new cases: rejects phone/hyphenated/short-handle targets; accepts every
  Telegram form runtime resolves; ignores the format on non-Telegram channels).
- `node --import tsx scripts/control-ui-i18n.ts check` → all locales clean.
- `oxfmt --check` and `oxlint` clean on the changed source files.

### Real behavior proof

- **Behavior addressed:** cron announce `To` for Telegram now blocks unsendable
  targets at save time and accepts every form Telegram delivery resolves.
- **Real environment tested:** local Vitest (Control UI controller) + i18n gate.
- **Exact steps or command run after this patch:**
  `node scripts/run-vitest.mjs ui/src/ui/controllers/cron.test.ts`;
  `node --import tsx scripts/control-ui-i18n.ts check`.
- **Evidence after fix:** 43/43 controller tests pass; i18n check reports all
  locales clean.
- **Observed result after fix:** valid Telegram targets save; invalid ones show
  the inline `telegramChatIdInvalid` error.
- **What was not tested:** browser-rendered screenshot of the cron form
  helper/error states (logic is covered by controller unit tests; a maintainer
  can request Mantis visual proof if required before merge).

Closes #90467
