### PR TITLE
fix(imessage): frame rpc stdout on LF only

### DIFF
--- a/extensions/imessage/src/client.ts
+++ b/extensions/imessage/src/client.ts
@@ -1,6 +1,6 @@
 // Imessage plugin module implements client behavior.
 import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
-import { createInterface, type Interface } from "node:readline";
+import { StringDecoder } from "node:string_decoder";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -68,7 +68,8 @@ export class IMessageRpcClient {
   private readonly closed: Promise<void>;
   private closedResolve: (() => void) | null = null;
   private child: ChildProcessWithoutNullStreams | null = null;
-  private reader: Interface | null = null;
+  private stdoutBuffer = "";
+  private readonly stdoutDecoder = new StringDecoder("utf8");
   private nextId = 1;
   private publicProcessError: string | null = null;
 
@@ -97,14 +98,12 @@ export class IMessageRpcClient {
       stdio: ["pipe", "pipe", "pipe"],
     });
     this.child = child;
-    this.reader = createInterface({ input: child.stdout });
 
-    this.reader.on("line", (line) => {
-      const trimmed = line.trim();
-      if (!trimmed) {
+    child.stdout.on("data", (chunk) => {
+      if (this.child !== child) {
         return;
       }
-      this.handleLine(trimmed);
+      this.handleStdoutChunk(chunk);
     });
 
     child.stderr?.on("data", (chunk) => {
@@ -131,6 +130,9 @@ export class IMessageRpcClient {
     });
 
     child.on("close", (code, signal) => {
+      if (this.child === child) {
+        this.flushStdoutBuffer();
+      }
       this.failAll(this.buildCloseError(code, signal));
       this.closedResolve?.();
     });
@@ -140,8 +142,8 @@ export class IMessageRpcClient {
     if (!this.child) {
       return;
     }
-    this.reader?.close();
-    this.reader = null;
+    this.stdoutBuffer = "";
+    this.stdoutDecoder.end();
     this.child.stdin?.end();
     const child = this.child;
     this.child = null;
@@ -213,6 +215,40 @@ export class IMessageRpcClient {
       }
     });
     return await response;
+  }
+
+  private handleStdoutChunk(chunk: Buffer | string) {
+    const text = typeof chunk === "string" ? chunk : this.stdoutDecoder.write(chunk);
+    this.stdoutBuffer += text;
+
+    let newlineIndex = this.stdoutBuffer.indexOf("\n");
+    while (newlineIndex !== -1) {
+      const line = this.stdoutBuffer.slice(0, newlineIndex);
+      this.stdoutBuffer = this.stdoutBuffer.slice(newlineIndex + 1);
+      this.handleStdoutLine(line);
+      newlineIndex = this.stdoutBuffer.indexOf("\n");
+    }
+  }
+
+  private flushStdoutBuffer() {
+    const tail = this.stdoutDecoder.end();
+    if (tail) {
+      this.stdoutBuffer += tail;
+    }
+    if (!this.stdoutBuffer) {
+      return;
+    }
+    const line = this.stdoutBuffer;
+    this.stdoutBuffer = "";
+    this.handleStdoutLine(line);
+  }
+
+  private handleStdoutLine(line: string) {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      return;
+    }
+    this.handleLine(trimmed);
   }
 
   private handleLine(line: string) {

--- a/extensions/imessage/src/status.test.ts
+++ b/extensions/imessage/src/status.test.ts
@@ -67,6 +67,77 @@ describe("createIMessageRpcClient", () => {
 
     expect(internals.buildCloseError(1, null).message).toBe(PUBLIC_IMESSAGE_FULL_DISK_ACCESS_ERROR);
   });
+
+  it.each([
+    ["U+2028", "\u2028"],
+    ["U+2029", "\u2029"],
+  ])(
+    "frames stdout on LF only so raw %s inside JSON strings stays intact",
+    async (_, separator) => {
+      const { IMessageRpcClient } = await import("./client.js");
+      const client = new IMessageRpcClient();
+      const internals = client as unknown as {
+        handleStdoutChunk: (chunk: Buffer | string) => void;
+        pending: Map<
+          string,
+          {
+            resolve: (value: unknown) => void;
+            reject: (error: Error) => void;
+          }
+        >;
+      };
+      const result = new Promise((resolve, reject) => {
+        internals.pending.set("1", { resolve, reject });
+      });
+      const text = `line one${separator}line two`;
+      const payload = `${JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        result: { messages: [{ text }] },
+      })}\n`;
+      const bytes = Buffer.from(payload, "utf8");
+      const separatorIndex = bytes.indexOf(Buffer.from(separator, "utf8"));
+
+      internals.handleStdoutChunk(bytes.subarray(0, separatorIndex + 1));
+      internals.handleStdoutChunk(bytes.subarray(separatorIndex + 1));
+
+      await expect(result).resolves.toEqual({
+        messages: [{ text }],
+      });
+    },
+  );
+
+  it("handles multiple LF-delimited stdout responses in one chunk", async () => {
+    const { IMessageRpcClient } = await import("./client.js");
+    const client = new IMessageRpcClient();
+    const internals = client as unknown as {
+      handleStdoutChunk: (chunk: Buffer | string) => void;
+      pending: Map<
+        string,
+        {
+          resolve: (value: unknown) => void;
+          reject: (error: Error) => void;
+        }
+      >;
+    };
+    const first = new Promise((resolve, reject) => {
+      internals.pending.set("1", { resolve, reject });
+    });
+    const second = new Promise((resolve, reject) => {
+      internals.pending.set("2", { resolve, reject });
+    });
+
+    internals.handleStdoutChunk(
+      `${JSON.stringify({ jsonrpc: "2.0", id: 1, result: { ok: "first" } })}\n${JSON.stringify({
+        jsonrpc: "2.0",
+        id: 2,
+        result: { ok: "second" },
+      })}\n`,
+    );
+
+    await expect(first).resolves.toEqual({ ok: "first" });
+    await expect(second).resolves.toEqual({ ok: "second" });
+  });
 });
 
 describe("imessage setup status", () => {

--- a/extensions/imessage/src/status.test.ts
+++ b/extensions/imessage/src/status.test.ts
@@ -1,4 +1,6 @@
 // Imessage tests cover status plugin behavior.
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
 import { createPluginSetupWizardStatus } from "openclaw/plugin-sdk/plugin-test-runtime";
 import * as processRuntime from "openclaw/plugin-sdk/process-runtime";
 import * as setupRuntime from "openclaw/plugin-sdk/setup";
@@ -19,6 +21,26 @@ const getIMessageSetupStatus = createPluginSetupWizardStatus({
 } as never);
 
 const spawnMock = vi.hoisted(() => vi.fn());
+
+function createMockChildProcess() {
+  const child = new EventEmitter() as EventEmitter & {
+    stdin: PassThrough;
+    stdout: PassThrough;
+    stderr: PassThrough;
+    killed: boolean;
+    kill: (signal?: string) => boolean;
+  };
+  child.stdin = new PassThrough();
+  child.stdout = new PassThrough();
+  child.stderr = new PassThrough();
+  child.killed = false;
+  child.kill = (signal?: string) => {
+    child.killed = true;
+    child.emit("close", 0, signal ?? null);
+    return true;
+  };
+  return child;
+}
 
 vi.mock("node:child_process", async () => {
   const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
@@ -137,6 +159,25 @@ describe("createIMessageRpcClient", () => {
 
     await expect(first).resolves.toEqual({ ok: "first" });
     await expect(second).resolves.toEqual({ ok: "second" });
+  });
+
+  it("ignores stdout from a stale child after stop so late notifications cannot leak (#89830)", async () => {
+    vi.stubEnv("VITEST", "");
+    vi.stubEnv("NODE_ENV", "");
+    const child = createMockChildProcess();
+    spawnMock.mockReturnValue(child);
+    const onNotification = vi.fn();
+    const { IMessageRpcClient } = await import("./client.js");
+    const client = new IMessageRpcClient({ onNotification });
+
+    await client.start();
+    await client.stop();
+
+    // A not-yet-exited imsg child emits a complete notification after stop().
+    // The `this.child !== child` guard must drop it before handleStdoutChunk.
+    child.stdout.write('{"jsonrpc":"2.0","method":"messages.changed","params":{}}\n');
+
+    expect(onNotification).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- Fixes iMessage RPC stdout framing when `imsg rpc --json` returns a valid JSON-RPC response containing raw U+2028/U+2029 inside JSON string values.
- The previous `node:readline` reader split those characters as line breaks, so one valid response became fragments that all failed `JSON.parse`.

Why does this matter now?

- Issue #89830 reports a head-of-line iMessage receive jam with repeated parse errors and pending RPC requests timing out.
- The bug can block the iMessage channel while the offending message remains in the poll window.

What is the intended outcome?

- OpenClaw frames `imsg` JSON-RPC stdout on LF only, matching the `imsg rpc --json` one-object-per-newline transport contract.
- Raw U+2028/U+2029 inside message text remains part of the JSON string and no longer breaks response parsing.

What is intentionally out of scope?

- No `imsg` CLI encoder changes.
- No iMessage cursor, catchup, delivery, stderr, config, or setup behavior changes.
- No live macOS/iMessage proof is included yet; this draft exists so Lobster can test the branch.

What does success look like?

- A JSON-RPC response containing raw U+2028 resolves the pending request instead of timing out.
- Normal LF-delimited batching still parses multiple responses from one stdout chunk.
- After Lobster testing, redacted live proof can be added before making the PR ready for review.

What should reviewers focus on?

- Whether LF-only stdout framing is the right iMessage RPC client fix.
- Whether the `StringDecoder` buffering correctly handles chunk boundaries and does not regress normal newline-delimited responses.

## Linked context

Which issue does this close?

Closes #89830

Which issues, PRs, or discussions are related?

Related #90159

Was this requested by a maintainer or owner?

Requested by Omar to publish a branch for Lobster testing.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: iMessage channel parse failures and request timeouts when a valid `imsg rpc --json` response contains raw U+2028/U+2029 inside JSON strings (#89830).
- Real environment tested: macOS 26.5, Node v26.0.0 (the runtime the issue reports in the live logs). The **actual shipped `IMessageRpcClient`** from both `origin/main` (readline) and this branch (LF framing) was executed verbatim and driven over a **real OS pipe**: `client.start()` → real `spawn()` → a stand-in `imsg` child that emits a genuine non-line-safe JSON-RPC response (raw `E2 80 A8` bytes inside a string value, single trailing LF), exactly like the bridge does for chat_id 63. Only four unrelated leaf SDK utilities (`formatErrorMessage`, `normalizeLowercaseStringOrEmpty`, `resolveUserPath`, the `RuntimeEnv` type) are shimmed — none are on the framing/parse/dispatch path under test.
- Exact steps or command run after this patch:
  ```
  # 1) Root-cause mechanism (pure Node readline, zero OpenClaw code)
  node mechanism.mjs
  # 2) End-to-end through the REAL client over a real spawned child + pipe
  node --loader ./sdk-loader.mjs run.mjs OLD   # origin/main readline client
  node --loader ./sdk-loader.mjs run.mjs NEW   # this branch, LF framing
  # 3) Branch unit tests
  pnpm exec vitest run extensions/imessage/src/status.test.ts
  ```
- Evidence after fix (terminal capture / live console output):
  ```
  # (1) mechanism.mjs — one valid object containing raw U+2028
  whole-buffer JSON.parse: OK (valid JSON per RFC 8259)
  raw 0x0A inside payload (excl. trailing): 0
  raw U+2028 (E2 80 A8) count: 3
  Node readline emitted 4 'line' events from ONE object; JSON.parse OK=0 FAIL=4
  => Node readline splits on U+2028. LF-only framing does not.

  # (2a) OLD readline client (origin/main) — bug reproduced
  [OLD] RESULT: { "resolved": false, "error": "imsg rpc timeout (messages.history)" }
  [OLD] parse-error log lines emitted: 4
  [OLD]   ↳ imsg rpc: failed to parse {"jsonrpc":"2.0","id":1,"result":{"messages":[{"rowid":38523,"ch
  [OLD]   ↳ imsg rpc: failed to parse ✦ Promo line two (offer): Unexpected token '✦', "✦ Promo li"...
  [OLD]   ↳ imsg rpc: failed to parse ✦ Promo line three: Unexpected token '✦', "✦ Promo line three" i
  [OLD]   ↳ imsg rpc: failed to parse Reply STOP to opt out"}]}}: Unexpected token 'R', "Reply STOP"..
  [OLD] VERDICT: BUG REPRODUCED (request did NOT resolve; fragments failed JSON.parse)

  # (2b) NEW LF-framing client (this branch) — fixed
  [NEW] RESULT: {
    "resolved": true,
    "messageCount": 1,
    "u2028PreservedInText": 3,
    "textSample": "\"✦ Promo line one:<U+2028>✦ Promo line two (offer)<U+2028>✦ Promo line three<U+2028>Reply STOP to opt"
  }
  [NEW] parse-error log lines emitted: 0
  [NEW] VERDICT: PASS (resolved, U+2028 intact, zero parse errors)

  # (3) Unit tests
  ✓ createIMessageRpcClient > frames stdout on LF only so raw U+2028 inside JSON strings stays intact
  ✓ createIMessageRpcClient > frames stdout on LF only so raw U+2029 inside JSON strings stays intact
  ✓ createIMessageRpcClient > handles multiple LF-delimited stdout responses in one chunk
  Test Files  1 passed (1)
       Tests  15 passed (15)
  ```
- Observed result after fix: the same real spawned-child scenario that **timed out with 4 `failed to parse` fragments** on the `origin/main` readline client now **resolves the request with the single message intact, all 3 U+2028 separators preserved, and zero parse errors emitted** on this branch. The head-of-line jam is gone.
- What was not tested: not exercised against the real `imsg` binary on a live `chat.db` thread (the stand-in child reproduces the exact non-line-safe byte stream and LF framing of the bridge). U+2029 is covered by focused automated regression coverage but was not separately driven end-to-end. No `imsg` CLI encoder changes.
- Proof limitations or environment constraints: leaf SDK utilities off the code path are shimmed so the real `client.ts` can be loaded without a full monorepo build; the framing logic (`handleStdoutChunk` / `flushStdoutBuffer` / `handleStdoutLine`) is the byte-for-byte shipped code.
- Before evidence (optional but encouraged): Issue #89830 contains before evidence showing valid whole-buffer JSON that `node:readline` splits into unparseable fragments; the OLD-client run above reproduces that signature exactly.

## Tests and validation

Which commands did you run?

- `pnpm test extensions/imessage/src/status.test.ts`
- `pnpm exec oxfmt --check --threads=1 extensions/imessage/src/client.ts extensions/imessage/src/status.test.ts`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/imessage/src/client.ts extensions/imessage/src/status.test.ts`
- `pnpm tsgo:test:extensions`
- `git diff --check`

What regression coverage was added or updated?

- Added coverage that stdout framing preserves raw U+2028 and raw U+2029 inside JSON strings, including a split UTF-8 chunk boundary.
- Added coverage that multiple LF-delimited JSON-RPC responses in one stdout chunk still resolve independently.

What failed before this fix, if known?

- A local Node source-level probe reproduced the core failure: the whole JSON payload parsed, but `node:readline` emitted fragments and none of the fragments parsed.
- Current `main` used `node:readline` for `imsg` stdout, matching the failure path in #89830.

If no test was added, why not?

- Tests were added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

- iMessage message delivery, because the shared iMessage RPC client is used by monitor, actions, probes, chat resolution, and catchup flows.

How is that risk mitigated?

- The change is plugin-local and limited to stdout framing.
- Request resolution/error handling remains in the existing `handleLine` path.
- Tests cover the reported U+2028 case, the sibling U+2029 separator case, and the ordinary batched LF-delimited response case.
- Draft state keeps the PR blocked on live Lobster proof before review/merge readiness.

## Current review state

What is the next action?

- Real-behavior proof attached above (before/after on the real `IMessageRpcClient` over a real spawned child + pipe, Node v26). Optional follow-up: a redacted capture against the real `imsg` binary on a live thread.

What is still waiting on author, maintainer, CI, or external proof?

- CI on the latest push.

Which bot or reviewer comments were addressed?

- None yet.

