### PR TITLE
fix: clarify cron task cancellation

### DIFF
--- a/docs/automation/tasks.md
+++ b/docs/automation/tasks.md
@@ -59,7 +59,7 @@ Not every agent run creates a task. Heartbeat turns and normal interactive chat 
   </Tab>
   <Tab title="Cancel and notify">
     ```bash
-    # Cancel a running task (kills the child session)
+    # Cancel a cancellable running task
     openclaw tasks cancel <lookup>
 
     # Change notification policy for a task
@@ -213,6 +213,8 @@ openclaw tasks notify <lookup> state_changes
     ```
 
     For ACP and subagent tasks, this kills the child session. For CLI-tracked tasks, cancellation is recorded in the task registry (there is no separate child runtime handle). Status transitions to `cancelled` and a delivery notification is sent when applicable.
+
+    Cron task records are ledger entries for cron runs, not the scheduler handle itself. `openclaw tasks cancel` does not stop an active cron run; use `openclaw cron list` to find the job, `openclaw cron disable <job-id>` or `openclaw cron remove <job-id>` to prevent future runs, and `openclaw cron runs --id <job-id>` to inspect run results.
 
   </Accordion>
   <Accordion title="tasks notify">

--- a/docs/cli/tasks.md
+++ b/docs/cli/tasks.md
@@ -69,6 +69,8 @@ openclaw tasks cancel <lookup>
 
 Cancels a running background task.
 
+`tasks cancel` can cancel ACP, subagent, and CLI-tracked task records. Cron task records track cron runs in the task ledger; they do not own the scheduler handle. To stop future cron runs, find the job with `openclaw cron list`, then run `openclaw cron disable <job-id>` or `openclaw cron remove <job-id>`. Use `openclaw cron runs --id <job-id>` to inspect the current run's result.
+
 ### `audit`
 
 ```bash

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -3527,6 +3527,39 @@ describe("task-registry", () => {
     });
   });
 
+  it("returns an actionable reason when active cron tasks cannot be cancelled", async () => {
+    await withTaskRegistryTempDir(async () => {
+      const task = createTaskRecord({
+        runtime: "cron",
+        ownerKey: "",
+        scopeKind: "system",
+        childSessionKey: "agent:main:cron:daily-digest",
+        sourceId: "cron:daily-digest",
+        runId: "run-cron-active",
+        task: "Daily digest",
+        status: "running",
+        deliveryStatus: "not_applicable",
+      });
+
+      const result = await cancelTaskById({
+        cfg: {} as never,
+        taskId: task.taskId,
+      });
+
+      expect(result).toEqual({
+        found: true,
+        cancelled: false,
+        reason:
+          "Active cron runs cannot be cancelled from the task ledger yet. The run will continue; use `openclaw cron list` to find the job, then `openclaw cron disable <job-id>` or `openclaw cron remove <job-id>` to prevent future runs, and `openclaw cron runs --id <job-id>` to inspect results.",
+        task,
+      });
+      expectRecordFields(getTaskById(task.taskId), {
+        taskId: task.taskId,
+        status: "running",
+      });
+    });
+  });
+
   it("cancels childless codex-native tasks without routing through OpenClaw subagent sessions", async () => {
     await withTaskRegistryTempDir(async () => {
       resetTaskRegistryForTests();

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -2030,6 +2030,9 @@ export function updateTaskNotifyPolicyById(params: {
   });
 }
 
+const CRON_TASK_CANCEL_UNSUPPORTED_REASON =
+  "Active cron runs cannot be cancelled from the task ledger yet. The run will continue; use `openclaw cron list` to find the job, then `openclaw cron disable <job-id>` or `openclaw cron remove <job-id>` to prevent future runs, and `openclaw cron runs --id <job-id>` to inspect results.";
+
 export function linkTaskToFlowById(params: { taskId: string; flowId: string }): TaskRecord | null {
   ensureTaskRegistryReady();
   const flowId = params.flowId.trim();
@@ -2080,6 +2083,14 @@ export async function cancelTaskById(params: {
   const childSessionKey = task.childSessionKey?.trim();
   try {
     if (task.runtime !== "cli") {
+      if (task.runtime === "cron") {
+        return {
+          found: true,
+          cancelled: false,
+          reason: CRON_TASK_CANCEL_UNSUPPORTED_REASON,
+          task: cloneTaskRecord(task),
+        };
+      }
       if (!childSessionKey) {
         if (!isChildlessCodexNativeSubagentTask(task)) {
           return {


### PR DESCRIPTION
## Summary

This PR makes active cron task cancellation feedback actionable instead of returning a generic unsupported-runtime response.

- Cancelling a running cron-backed task ledger record now returns a cron-specific reason with the next commands to use.
- The cron task record is left running because this PR does not implement runtime cancellation for active cron runs.
- Docs now explain that `tasks cancel` does not cancel cron runs and point users to cron list/disable/remove/runs commands.
- Reviewers should focus on whether this is the right user-facing boundary for cron-owned execution state.

## Linked context

Closes #

Related #

Was this requested by a maintainer or owner? No maintainer request; selected as a small focused UX/error-message improvement from local repository review.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Cancelling an active cron task ledger record should explain that the run cannot be cancelled from the task ledger, tell the user how to prevent future runs and inspect the current run, and keep the active cron task record running.
- Real environment tested: Local OpenClaw source checkout on macOS through Codex desktop, branch `fix/cron-cancel-message`, Node `v24.16.0`, built `dist/` output from this patch, isolated `OPENCLAW_STATE_DIR` under `/private/tmp`.
- Exact steps or command run after this patch: Ran a local Node command against the built OpenClaw task registry. The command created a running cron task record in an isolated state directory, called `cancelTaskById`, then read the task record back with `getTaskById`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Copied terminal output from the local command:

```json
{
  "createdTask": {
    "taskId": "7f89e3ce-79bc-4005-bcf3-71649bcb9930",
    "runtime": "cron",
    "status": "running",
    "runId": "cron:daily-digest:2026-06-06T04:30:00Z"
  },
  "cancelResult": {
    "found": true,
    "cancelled": false,
    "reason": "Active cron runs cannot be cancelled from the task ledger yet. The run will continue; use `openclaw cron list` to find the job, then `openclaw cron disable <job-id>` or `openclaw cron remove <job-id>` to prevent future runs, and `openclaw cron runs --id <job-id>` to inspect results."
  },
  "statusAfterCancel": "running"
}
```

- Observed result after fix: The cancellation result is found but not cancelled, the reason names the cron commands to use next, and the task status remains `running`.
- What was not tested: I did not run a live scheduled cron job end to end or capture a screenshot/recording. This proof exercises the built OpenClaw task registry behavior directly with isolated local state.
- Proof limitations or environment constraints: The proof uses a local built checkout and direct registry call rather than a human-driven CLI session because the bug is in the shared task cancellation path and the CLI delegates to that path.
- Before evidence (optional but encouraged): Before this patch, active cron tasks reached the generic unsupported-runtime cancellation response instead of the cron-specific actionable reason.

## Tests and validation

Passed:

- `pnpm docs:list`
- `pnpm test src/tasks/task-registry.test.ts` (75 tests)
- `pnpm build`
- `pnpm check`
- `git diff --check`
- `codex -s danger-full-access review --base origin/main` (no actionable regressions found)

Also run:

- `pnpm test`

The full suite did not complete green in this local Codex desktop environment. The failures were outside this PR's touched area and were concentrated in environment-dependent shards: Chromium sandbox/MachPort launch failures, writes blocked under `/Users/xinmiao`, `os.uptime()` / process-spawn permission errors, one shadow-trial date expectation, and two Telegram channel media-group tests. The relevant task and cron shards passed, including `vitest.tasks.config.ts` and `vitest.cron.config.ts`.

Regression coverage added:

- `src/tasks/task-registry.test.ts` now covers the active cron cancellation response and confirms the task remains running.

## Risk checklist

Did user-visible behavior change? (`Yes/No`) Yes. Users now get a cron-specific cancellation explanation.

Did config, environment, or migration behavior change? (`Yes/No`) No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`) No.

What is the highest-risk area? Misstating cron cancellation support.

How is that risk mitigated? The new message explicitly says active cron runs cannot be cancelled from the task ledger yet and points to existing cron commands for future-run control and inspection.

## Current review state

What is the next action? Waiting for CI, ClawSweeper, and maintainer/community review.

What is still waiting on author, maintainer, CI, or external proof? Author supplied local real behavior proof and validation notes; maintainers may still request stronger CLI/end-to-end proof.

Which bot or reviewer comments were addressed? Initial `Real behavior proof` gate failure was addressed by filling the exact required proof fields and adding copied local terminal output.

## Codex usage

- AI-assisted PR using Codex desktop.
- Codex was used to inspect the codebase, implement the patch, run validation, prepare proof, and review the diff.
- `codex -s danger-full-access review --base origin/main` was run after the patch.
- I understand the final code changes.

## Risks / notes for reviewers

- This does not implement cron run cancellation; it only makes the unsupported cancellation path more actionable.
- Existing ACP/subagent cancellation behavior is unchanged.
- No `CHANGELOG.md` edits.
