### PR TITLE
fix(gateway): stable workspaceDir snapshot for sessions.list per-row metadata lookup (#90814)

### DIFF
--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -70,6 +70,7 @@ import {
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { openRootFileSync } from "../infra/boundary-file-read.js";
 import { projectPluginSessionExtensionsSync } from "../plugins/host-hook-state.js";
+import { withPinnedActivePluginRegistryWorkspaceDir } from "../plugins/runtime-workspace-state.js";
 import {
   DEFAULT_AGENT_ID,
   normalizeAgentId,
@@ -2773,65 +2774,74 @@ export async function listSessionsFromStoreAsync(params: {
     fullRowContext ??
     (entries.length > 1 ? buildSessionListRowMetadataContext({ now }) : undefined);
 
-  const sessions: GatewaySessionRow[] = [];
-  for (let i = 0; i < entries.length; i++) {
-    const [key, entry] = entries[i];
-    const includeTranscriptFields = i < sessionListTranscriptFieldRows;
-    const rowAgentId =
-      key === "global" && typeof opts.agentId === "string"
-        ? normalizeAgentId(opts.agentId)
-        : undefined;
-    const storeChildSessionsByKey =
-      fullRowContext?.storeChildSessionsByKey ??
-      buildSingleRowStoreChildSessionsByKey({ store, storePath, key, now });
-    const row = buildGatewaySessionRow({
-      cfg,
-      storePath,
-      store,
-      key,
-      entry,
-      agentId: rowAgentId,
-      modelCatalog: params.modelCatalog,
-      now,
-      includeDerivedTitles: false,
-      includeLastMessage: false,
-      transcriptUsageMaxBytes: sessionListTranscriptUsageMaxBytes,
-      storeChildSessionsByKey,
-      rowContext: sharedRowContext,
-      skipTranscriptUsageFallback: true,
-      lightweightListRow: true,
-    });
-    if (
-      entry?.sessionId &&
-      includeTranscriptFields &&
-      (includeDerivedTitles || includeLastMessage)
-    ) {
-      const parsed = parseAgentSessionKey(key);
-      const sessionAgentId =
-        rowAgentId ??
-        (parsed?.agentId ? normalizeAgentId(parsed.agentId) : resolveDefaultAgentId(cfg));
-      const fields = await readSessionTitleFieldsFromTranscriptAsync(
-        entry.sessionId,
+  // Pin the active plugin-registry workspace dir for the whole row-building
+  // batch (including the inter-batch `setImmediate` yields below). Without
+  // this, concurrent agent-turns/crons that call `setActivePluginRegistry`
+  // mutate the process-global between yields, the metadata-snapshot memo key
+  // changes per row, and every row triggers a fresh ~100ms plugin-metadata
+  // scan. See issue #90814 (residual of #76562).
+  const sessions = await withPinnedActivePluginRegistryWorkspaceDir(async () => {
+    const rows: GatewaySessionRow[] = [];
+    for (let i = 0; i < entries.length; i++) {
+      const [key, entry] = entries[i];
+      const includeTranscriptFields = i < sessionListTranscriptFieldRows;
+      const rowAgentId =
+        key === "global" && typeof opts.agentId === "string"
+          ? normalizeAgentId(opts.agentId)
+          : undefined;
+      const storeChildSessionsByKey =
+        fullRowContext?.storeChildSessionsByKey ??
+        buildSingleRowStoreChildSessionsByKey({ store, storePath, key, now });
+      const row = buildGatewaySessionRow({
+        cfg,
         storePath,
-        entry.sessionFile,
-        sessionAgentId,
-      );
-      if (includeDerivedTitles) {
-        row.derivedTitle = deriveSessionTitle(entry, fields.firstUserMessage);
-      }
-      if (includeLastMessage && fields.lastMessagePreview) {
-        row.lastMessagePreview = fields.lastMessagePreview;
-      }
-    }
-    sessions.push(row);
-    // Yield to the event loop between batches so WebSocket heartbeats,
-    // channel I/O, and concurrent RPC calls are not starved.
-    if ((i + 1) % SESSIONS_LIST_YIELD_BATCH_SIZE === 0 && i + 1 < entries.length) {
-      await new Promise<void>((resolve) => {
-        setImmediate(resolve);
+        store,
+        key,
+        entry,
+        agentId: rowAgentId,
+        modelCatalog: params.modelCatalog,
+        now,
+        includeDerivedTitles: false,
+        includeLastMessage: false,
+        transcriptUsageMaxBytes: sessionListTranscriptUsageMaxBytes,
+        storeChildSessionsByKey,
+        rowContext: sharedRowContext,
+        skipTranscriptUsageFallback: true,
+        lightweightListRow: true,
       });
+      if (
+        entry?.sessionId &&
+        includeTranscriptFields &&
+        (includeDerivedTitles || includeLastMessage)
+      ) {
+        const parsed = parseAgentSessionKey(key);
+        const sessionAgentId =
+          rowAgentId ??
+          (parsed?.agentId ? normalizeAgentId(parsed.agentId) : resolveDefaultAgentId(cfg));
+        const fields = await readSessionTitleFieldsFromTranscriptAsync(
+          entry.sessionId,
+          storePath,
+          entry.sessionFile,
+          sessionAgentId,
+        );
+        if (includeDerivedTitles) {
+          row.derivedTitle = deriveSessionTitle(entry, fields.firstUserMessage);
+        }
+        if (includeLastMessage && fields.lastMessagePreview) {
+          row.lastMessagePreview = fields.lastMessagePreview;
+        }
+      }
+      rows.push(row);
+      // Yield to the event loop between batches so WebSocket heartbeats,
+      // channel I/O, and concurrent RPC calls are not starved.
+      if ((i + 1) % SESSIONS_LIST_YIELD_BATCH_SIZE === 0 && i + 1 < entries.length) {
+        await new Promise<void>((resolve) => {
+          setImmediate(resolve);
+        });
+      }
     }
-  }
+    return rows;
+  });
 
   return {
     ts: now,

--- a/src/plugins/runtime-workspace-state.pinned-snapshot.test.ts
+++ b/src/plugins/runtime-workspace-state.pinned-snapshot.test.ts
@@ -1,0 +1,84 @@
+// Regression for #90814: sessions.list per-row plugin-metadata lookup must
+// see a stable workspaceDir snapshot for the duration of the batch, even when
+// a concurrent agent-turn/cron mutates the global active-registry workspace
+// across the loop's `setImmediate` yields.
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  getActivePluginRegistryWorkspaceDirFromState,
+  withPinnedActivePluginRegistryWorkspaceDir,
+} from "./runtime-workspace-state.js";
+
+const PLUGIN_REGISTRY_STATE = Symbol.for("openclaw.pluginRegistryState");
+
+type GlobalWithRegistry = typeof globalThis & {
+  [PLUGIN_REGISTRY_STATE]?: { workspaceDir?: string | null };
+};
+
+function setGlobalWorkspaceDir(workspaceDir: string | undefined): void {
+  const g = globalThis as GlobalWithRegistry;
+  const existing = g[PLUGIN_REGISTRY_STATE];
+  if (existing) {
+    existing.workspaceDir = workspaceDir ?? null;
+  } else {
+    g[PLUGIN_REGISTRY_STATE] = { workspaceDir: workspaceDir ?? null };
+  }
+}
+
+function clearGlobalWorkspaceDir(): void {
+  const g = globalThis as GlobalWithRegistry;
+  delete g[PLUGIN_REGISTRY_STATE];
+}
+
+describe("withPinnedActivePluginRegistryWorkspaceDir", () => {
+  afterEach(() => {
+    clearGlobalWorkspaceDir();
+  });
+
+  it("keeps the workspaceDir stable across yields while the global is mutated", async () => {
+    setGlobalWorkspaceDir("/wsA");
+
+    const readsInsidePin: (string | undefined)[] = [];
+
+    const result = await withPinnedActivePluginRegistryWorkspaceDir(async () => {
+      // Simulate a concurrent agent-turn/cron mutating the global active
+      // plugin-registry workspace dir between row batches.
+      for (let i = 0; i < 5; i++) {
+        readsInsidePin.push(getActivePluginRegistryWorkspaceDirFromState());
+        setGlobalWorkspaceDir(`/wsConcurrent-${i}`);
+        await new Promise<void>((resolve) => setImmediate(resolve));
+      }
+      readsInsidePin.push(getActivePluginRegistryWorkspaceDirFromState());
+      return readsInsidePin.slice();
+    });
+
+    // Every read inside the pinned scope must return the snapshot captured
+    // at entry, regardless of concurrent global mutations.
+    expect(result.every((v) => v === "/wsA")).toBe(true);
+
+    // Outside the pin, reads observe the live (mutated) global.
+    expect(getActivePluginRegistryWorkspaceDirFromState()).toBe("/wsConcurrent-4");
+  });
+
+  it("nested calls reuse the outer pin snapshot", async () => {
+    setGlobalWorkspaceDir("/outer");
+
+    await withPinnedActivePluginRegistryWorkspaceDir(async () => {
+      expect(getActivePluginRegistryWorkspaceDirFromState()).toBe("/outer");
+      // Mutate global while inside the outer pin.
+      setGlobalWorkspaceDir("/changed");
+      await withPinnedActivePluginRegistryWorkspaceDir(() => {
+        // Nested call must keep the outer snapshot, not re-read the (now
+        // mutated) global.
+        expect(getActivePluginRegistryWorkspaceDirFromState()).toBe("/outer");
+      });
+      expect(getActivePluginRegistryWorkspaceDirFromState()).toBe("/outer");
+    });
+
+    expect(getActivePluginRegistryWorkspaceDirFromState()).toBe("/changed");
+  });
+
+  it("returns undefined when no global workspaceDir is set and no pin is active", () => {
+    clearGlobalWorkspaceDir();
+    expect(getActivePluginRegistryWorkspaceDirFromState()).toBeUndefined();
+  });
+});

--- a/src/plugins/runtime-workspace-state.ts
+++ b/src/plugins/runtime-workspace-state.ts
@@ -1,4 +1,6 @@
 // Shares plugin runtime workspace state across module reloads.
+import { AsyncLocalStorage } from "node:async_hooks";
+
 const PLUGIN_REGISTRY_STATE = Symbol.for("openclaw.pluginRegistryState");
 
 type GlobalRegistryWorkspaceState = typeof globalThis & {
@@ -7,9 +9,38 @@ type GlobalRegistryWorkspaceState = typeof globalThis & {
   };
 };
 
-/** Reads the active plugin registry workspace directory from global runtime state. */
-export function getActivePluginRegistryWorkspaceDirFromState(): string | undefined {
+type PinnedWorkspaceDirStore = { workspaceDir: string | undefined };
+
+// AsyncLocalStorage pins the active plugin-registry workspace dir for the
+// duration of a row-building batch (e.g. sessions.list). Without it, per-row
+// metadata lookups read a process-global that concurrent agent-turns/crons
+// mutate between async yields, defeating the metadata-snapshot memo and
+// forcing an O(rows) full plugin-metadata scan (issue #90814, residual of
+// #76562). The pin is async-context-scoped, so other concurrent contexts
+// still observe the live global.
+const pinnedWorkspaceDirStorage = new AsyncLocalStorage<PinnedWorkspaceDirStore>();
+
+function readGlobalWorkspaceDir(): string | undefined {
   return (
     (globalThis as GlobalRegistryWorkspaceState)[PLUGIN_REGISTRY_STATE]?.workspaceDir ?? undefined
   );
+}
+
+/** Reads the active plugin registry workspace directory from global runtime state. */
+export function getActivePluginRegistryWorkspaceDirFromState(): string | undefined {
+  const pinned = pinnedWorkspaceDirStorage.getStore();
+  if (pinned) return pinned.workspaceDir;
+  return readGlobalWorkspaceDir();
+}
+
+/**
+ * Pins the active plugin-registry workspace dir for the duration of `fn` so
+ * per-row metadata lookups within one async batch see a stable value, immune
+ * to concurrent global mutation across `await` yields. Nested calls reuse the
+ * outer pin so we do not re-snapshot mid-batch.
+ */
+export function withPinnedActivePluginRegistryWorkspaceDir<T>(fn: () => T): T {
+  if (pinnedWorkspaceDirStorage.getStore()) return fn();
+  const workspaceDir = readGlobalWorkspaceDir();
+  return pinnedWorkspaceDirStorage.run({ workspaceDir }, fn);
 }


### PR DESCRIPTION
## Summary
- `sessions.list` and other per-row control-plane RPCs become O(rows) slow under concurrent load. The per-row plugin-metadata lookup reads a process-global active plugin-registry `workspaceDir` that concurrent agent turns / crons mutate between `await` yields. The metadata-snapshot memo key includes `workspaceDir`, so it changes on essentially every row, the memo never hits, and each row triggers a full ~100 ms `loadPluginMetadataSnapshot` scan. Residual concurrency facet of #76562.
- Pin the active workspaceDir for the duration of one row-building batch using `AsyncLocalStorage`. `withPinnedActivePluginRegistryWorkspaceDir(fn)` snapshots the global once at batch start; `getActivePluginRegistryWorkspaceDirFromState()` consults the pin before falling back to the live global, so other concurrent contexts still observe the live global. Nested pins reuse the outer snapshot.

## Real behavior proof
Behavior addressed: `sessions.list` per-row plugin-metadata memo now stays stable across concurrent global `workspaceDir` mutation; the memo can actually hit and avoid the per-row full scan.
Real environment tested: local vitest in worktree
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/plugins/runtime-workspace-state.pinned-snapshot.test.ts src/gateway/session-utils.ts`
Evidence after fix: new `runtime-workspace-state.pinned-snapshot.test.ts` (84 lines) covers pin-takes-precedence, fallback when no pin, nested pin reuse, and immunity to global mutation across awaits.
Observed result after fix: with concurrent global writes between rows, the per-row lookup observes the pinned snapshot; the metadata-snapshot memo key stays constant for the batch.
What was not tested: live multi-cron gateway under sustained concurrency (would need Crabbox/Testbox).

Fixes #90814

Note: complements #76562. Other per-row RPCs that read the same global can adopt `withPinnedActivePluginRegistryWorkspaceDir` in follow-ups; this PR pins `sessions.list` and leaves other call sites unchanged.
