### PR TITLE
docs(channel-inbound): document per-inbound cfg re-resolve contract for live bindings

### DIFF
--- a/docs/plugins/sdk-channel-inbound.md
+++ b/docs/plugins/sdk-channel-inbound.md
@@ -55,6 +55,50 @@ Compatibility dispatchers should assemble `dispatchChannelInboundReply(...)`
 inputs and keep platform delivery in the delivery adapter. New send paths should
 prefer message adapters and durable message helpers.
 
+## Routing and live bindings
+
+CLI binding edits (`openclaw agents bind add/remove`, `agents add`, and any
+config write touching `bindings[]`, `agents.*`, or `routing.*`) must take effect
+on the next inbound message **without a gateway restart**. The reload planner
+intentionally classifies these config paths as `kind: "none"` in
+`src/gateway/config-reload-plan.ts` so that channel restarts and heartbeat
+restarts are not triggered for routing-only edits; the contract is that channel
+plugins re-resolve routing per inbound against a fresh runtime cfg.
+
+What this means for channel plugin authors:
+
+- Do **not** capture the `cfg` reference handed to your plugin at `start(...)`
+  / `register(...)` time and reuse it inside long-lived inbound handlers. That
+  reference becomes stale the moment the next config write swaps the runtime
+  snapshot.
+- On every inbound event, fetch the current cfg via
+  `getRuntimeConfig()` from `openclaw/plugin-sdk/runtime-config-snapshot` (or
+  `ctx.getRuntimeConfig()` where the SDK injects it). Pass that fresh
+  reference into `resolveAgentRoute(...)` and any downstream dispatch.
+- Do **not** use the deprecated `api.runtime.config.loadConfig()` on inbound
+  paths; it warns at runtime and is exempt from the runtime-owned snapshot
+  refresh. See `## Config loading and writes` in
+  [`sdk-runtime.md`](./sdk-runtime.md) for the broader runtime config contract.
+
+The routing layer caches evaluated bindings in a
+`WeakMap<OpenClawConfig, EvaluatedBindingsCache>` keyed by cfg reference (see
+`src/routing/resolve-route.ts`). A stale cfg reference returns a stale routing
+result by construction — there is no time-based invalidation. Per-inbound
+`getRuntimeConfig()` is the single mechanism that keeps the WeakMap honest.
+
+Reference implementations in this tree:
+
+- `extensions/telegram/src/bot-handlers.runtime.ts` — `cfg:
+  telegramDeps.getRuntimeConfig()` // "Fresh config for bindings lookup"
+- `extensions/qqbot/src/engine/gateway/active-cfg.ts` — `ActiveCfgProvider`
+  helper, used per inbound in `gateway.ts` (added in #73567 to close the
+  same-shape regression #69546)
+
+A channel plugin that violates this contract will appear to work in tests
+(static cfg) and on a fresh gateway, then silently route messages to the wrong
+agent (or fall back to `agent:main`) after any CLI binding edit, until the
+gateway is restarted.
+
 ## Migration
 
 The old `runtime.channel.turn.*` runtime aliases were removed. Use:

--- a/src/gateway/config-reload-plan.ts
+++ b/src/gateway/config-reload-plan.ts
@@ -122,6 +122,12 @@ const BASE_RELOAD_RULES_TAIL: ReloadRule[] = [
   { prefix: "identity", kind: "none" },
   { prefix: "wizard", kind: "none" },
   { prefix: "logging", kind: "none" },
+  // Routing-only paths (`agents`, `bindings`, `routing`) are `kind: "none"` by
+  // design: the channel plugin contract is to re-resolve routing per inbound
+  // against a fresh runtime cfg (see docs/plugins/sdk-channel-inbound.md
+  // "Routing and live bindings"), so no global reload action is needed when
+  // these paths change. CLI binding edits take effect on the next inbound
+  // without a gateway restart.
   { prefix: "agents", kind: "none" },
   { prefix: "tools", kind: "none" },
   { prefix: "bindings", kind: "none" },

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -202,6 +202,13 @@ type EvaluatedBindingsCache = {
   byChannelAccountIndex: Map<string, EvaluatedBindingsIndex>;
 };
 
+// Both caches are keyed on cfg object identity (WeakMap). A stale cfg
+// reference returns a stale routing result by construction — there is no
+// time-based invalidation. Channel plugins must pass the current runtime cfg
+// (via `getRuntimeConfig()` from `openclaw/plugin-sdk/runtime-config-snapshot`,
+// per inbound) so cache lookups miss on the new ref and bindings get
+// re-evaluated. See docs/plugins/sdk-channel-inbound.md "Routing and live
+// bindings" for the full channel plugin contract.
 const evaluatedBindingsCacheByCfg = new WeakMap<OpenClawConfig, EvaluatedBindingsCache>();
 const MAX_EVALUATED_BINDINGS_CACHE_KEYS = 2000;
 const resolvedRouteCacheByCfg = new WeakMap<


### PR DESCRIPTION
## Summary

What problem does this PR solve?

The "channel plugins must re-resolve routing per inbound against a fresh runtime cfg" contract is real and load-bearing in current `main` — `bindings`/`agents`/`routing` are deliberately `kind: "none"` in the reload plan, and `resolve-route.ts` caches evaluated bindings in a `WeakMap<OpenClawConfig, ...>` keyed on cfg object identity. But this contract is not written down anywhere a channel plugin author would find it, so authors keep re-discovering it the hard way (shipped regression → bug report → ~80-line per-event fix).

Why does this matter now?

Three plugins in or adjacent to this tree have independently re-rolled the same fix: telegram inlined it from the start, qqbot shipped without it and recovered via #73567 (closing #69546), and at least one third-party channel plugin is currently broken because of the same omission. Each repeat costs a real regression and a small `ActiveCfgProvider`-shaped patch. Writing the contract down once breaks the cycle for the next plugin author.

What is the intended outcome?

A channel plugin author reading `docs/plugins/sdk-channel-inbound.md` learns the per-inbound `getRuntimeConfig()` contract before shipping, instead of after. Future readers of `config-reload-plan.ts:120-140` and `resolve-route.ts:205` find inline comments pointing back to the doc, so neither source-level surprise drops a channel author into a stale-routing debug session.

What is intentionally out of scope?

- Centralizing the per-event cfg lookup into a public plugin SDK helper (`createActiveCfgProvider`) — that is the "Option B" in #90842 and needs a separate maintainer call on the SDK API surface. Held as a sibling branch on the fork; will open as a follow-up draft only if maintainers want that direction.
- Touching `qqbot` or `telegram` to dedup their inlined patterns — leaving in place; this PR is documentation only.
- Revisiting #7747 / #27706 — those proposed flipping the reload plan kinds; they were closed by the maintainers and the per-event re-resolve direction is what this PR documents.

What does success look like?

Merged docs that a channel author can find via the existing `sdk-channel-inbound.md` reading order, plus two inline source comments that survive future refactors of the reload planner and the routing WeakMap.

What should reviewers focus on?

- Is `docs/plugins/sdk-channel-inbound.md` the right home for this section, or would you prefer it in `sdk-runtime.md`, a new `channel-routing.md`, or split across both?
- The inline comments on `config-reload-plan.ts:120-140` and `resolve-route.ts:205` — phrasing acceptable, or too prescriptive?
- Naming of `getRuntimeConfig` import path — used `openclaw/plugin-sdk/runtime-config-snapshot` per existing `sdk-runtime.md` guidance; confirm that is the canonical name.

## Linked context

Which issue does this close?

Refs #90842 (does not auto-close; this is the docs-only "Option A" direction from that issue, and maintainers may also want the SDK helper "Option B" before closing).

Which issues, PRs, or discussions are related?

- Related #73567 — qqbot per-inbound cfg fix that this doc cites as the in-tree reference implementation
- Related #69546 — the original qqbot regression that #73567 closed
- Related #43935 — documents the cost of "restart channel as a workaround" path, the alternative this contract avoids
- Related #7747 — prior attempt to flip `bindings` to `kind: "hot"` (closed); this PR documents the chosen per-event direction instead
- Related #27706 — prior `config.reload-bindings` RPC proposal (closed); same direction note

Was this requested by a maintainer or owner?

No — this is a contributor proposal in response to ClawSweeper's review on #90842 (`fix-shape-clear` + `needs-maintainer-review`). Filed as draft so maintainers can shape the direction (or close in favor of a different placement / wording) before any merge.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Channel plugin authors capture the start-time `cfg` reference and reuse it inside long-lived inbound handlers, causing CLI binding edits to be silently ignored until gateway restart.
- Real environment tested: macOS 15.x (Darwin 25.3.0), OpenClaw `main` at commit `c1ddfccf65c9cf3708771b356090b7331c543f58` at time of investigation.
- Exact steps or command run after this patch: This is a docs-only patch. The behavior being documented is reproducible at source level per ClawSweeper's own review on #90842 — they trace `bindings`/`routing` reload classification, the `WeakMap<OpenClawConfig, EvaluatedBindingsCache>` cache, and the qqbot `ActiveCfgProvider` consumer pattern; that timeline carries the `clawsweeper:source-repro` label.
- Evidence after fix: ClawSweeper review on #90842 confirmed both the bug shape and the docs-fix-shape ("fix-shape-clear" label). The diff in this PR is the doc text plus two short cross-link comments; rendered output not attached because the change is plain Markdown without new MDX components.
- Observed result after fix: Cross-links between `sdk-channel-inbound.md` → `config-reload-plan.ts:120-140` → `resolve-route.ts:205` form a closed loop so a reader landing on either source file is pointed back to the doc.
- What was not tested: Did not run `pnpm docs:check-mdx` locally — dependencies are not installed in the fork checkout and the run requires `pnpm install --frozen-lockfile` first. Relying on CI to catch any MDX render breakage; happy to install deps and re-verify if CI flags anything.
- Proof limitations or environment constraints: No live runtime repro is feasible for a docs-only change. The source-level repro that motivates the doc is already on the linked issue under `clawsweeper:source-repro`. If a maintainer wants the live-route repro for their own records, the steps are in #90842's "Real environment we tested in" section.

## Tests and validation

Which commands did you run?

- `git diff --stat` — confirmed the change is 3 files, +57 / -0 (docs + two small source comments, no code paths altered).
- `grep` for broken cross-links — verified `docs/plugins/sdk-channel-inbound.md` references resolve (`sdk-runtime.md`, `config-reload-plan.ts`, `resolve-route.ts`, `extensions/telegram/...`, `extensions/qqbot/...`) and that the source-side cross-references to `docs/plugins/sdk-channel-inbound.md` "Routing and live bindings" anchor match the section header.
- Did not run the project's full test suite — this PR introduces no executable code; CI is the right surface for any docs-render or link-check validation.

What regression coverage was added or updated?

None — docs-only. The behavior being documented already has source-level evidence on #90842 and a merged unit-test analogue at `extensions/qqbot/src/engine/gateway/stages/access-stage.test.ts` (added in #73567), which already locks in the routing layer's per-event re-resolve invariant.
