### PR TITLE
Recover stale pending final deliveries

### DIFF
--- a/src/agents/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-restart-recovery.test.ts
@@ -616,6 +616,51 @@ describe("main-session-restart-recovery", () => {
     );
   });
 
+  it("resumes Slack DM pending finals through the native DM channel when stored target is user-scoped", async () => {
+    const sessionsDir = await makeSessionsDir();
+    const pendingPayload = "The final answer is 42.";
+    await writeStore(sessionsDir, {
+      "agent:main:slack:direct:u039p2yjr29": {
+        sessionId: "main-session",
+        updatedAt: Date.now() - 10_000,
+        status: "running",
+        abortedLastRun: true,
+        pendingFinalDelivery: true,
+        pendingFinalDeliveryText: pendingPayload,
+        pendingFinalDeliveryContext: {
+          channel: "slack",
+          to: "user:U039P2YJR29",
+          accountId: "son-of-anton",
+        },
+        pendingFinalDeliveryCreatedAt: Date.now() - 5_000,
+        origin: {
+          provider: "slack",
+          chatType: "direct",
+          to: "user:U039P2YJR29",
+          nativeChannelId: "D0ACL8LRTJP",
+          accountId: "son-of-anton",
+        },
+      },
+    });
+    await writeTranscript(sessionsDir, "main-session", [
+      { role: "user", content: "calculate the answer" },
+      { role: "assistant", content: [{ type: "toolCall", id: "call-1", name: "calc" }] },
+      { role: "toolResult", content: "42" },
+    ]);
+
+    const result = await recoverRestartAbortedMainSessions({ stateDir: tmpDir });
+
+    expect(result).toEqual({ recovered: 1, failed: 0, skipped: 0 });
+    expect(firstGatewayParams()).toMatchObject({
+      deliver: true,
+      bestEffortDeliver: true,
+      channel: "slack",
+      to: "channel:D0ACL8LRTJP",
+      accountId: "son-of-anton",
+    });
+    expect(firstGatewayParams().message).toContain(pendingPayload);
+  });
+
   it("sanitizes durable pending final delivery payloads before resume prompts", async () => {
     const sessionsDir = await makeSessionsDir();
     const pendingPayload = [

--- a/src/agents/main-session-restart-recovery.ts
+++ b/src/agents/main-session-restart-recovery.ts
@@ -6,7 +6,10 @@ import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import { sanitizePendingFinalDeliveryText } from "../auto-reply/reply/pending-final-delivery.js";
+import {
+  resolveSlackDirectPendingFinalDeliveryContext,
+  sanitizePendingFinalDeliveryText,
+} from "../auto-reply/reply/pending-final-delivery.js";
 import { resolveStateDir } from "../config/paths.js";
 import {
   type SessionEntry,
@@ -369,11 +372,22 @@ function resolveRestartRecoveryDeliveryContext(params: {
   ) {
     return undefined;
   }
-  return {
-    ...deliveryContext,
-    channel,
-    to,
-  };
+  return (
+    resolveSlackDirectPendingFinalDeliveryContext({
+      context: {
+        ...deliveryContext,
+        channel,
+        to,
+      },
+      nativeChannelId: params.entry.origin?.nativeChannelId,
+      chatType: params.entry.origin?.chatType,
+      directUserTarget: params.entry.origin?.to,
+    }) ?? {
+      ...deliveryContext,
+      channel,
+      to,
+    }
+  );
 }
 
 async function resumeMainSession(params: {

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -34,6 +34,9 @@ const state = vi.hoisted(() => ({
   queueEmbeddedAgentMessageMock: vi.fn(),
   runEmbeddedAgentMock: vi.fn(),
 }));
+const diagnosticMocks = vi.hoisted(() => ({
+  markDiagnosticSessionPendingFinalDelivery: vi.fn(),
+}));
 
 function countMatching<T>(items: readonly T[], predicate: (item: T) => boolean): number {
   let count = 0;
@@ -111,6 +114,16 @@ vi.mock("./queue.js", () => ({
   refreshQueuedFollowupSession: vi.fn(),
   scheduleFollowupDrain: vi.fn(),
 }));
+vi.mock("../../logging/diagnostic.js", async () => {
+  const actual = await vi.importActual<typeof import("../../logging/diagnostic.js")>(
+    "../../logging/diagnostic.js",
+  );
+  return {
+    ...actual,
+    markDiagnosticSessionPendingFinalDelivery:
+      diagnosticMocks.markDiagnosticSessionPendingFinalDelivery,
+  };
+});
 
 beforeAll(async () => {
   // Avoid attributing the initial agent-runner import cost to the first test case.
@@ -134,6 +147,7 @@ beforeEach(() => {
   });
   state.queueEmbeddedAgentMessageMock.mockReset();
   state.queueEmbeddedAgentMessageMock.mockReturnValue(false);
+  diagnosticMocks.markDiagnosticSessionPendingFinalDelivery.mockReset();
   vi.mocked(enqueueFollowupRun).mockClear();
   vi.mocked(refreshQueuedFollowupSession).mockClear();
   vi.mocked(scheduleFollowupDrain).mockClear();
@@ -517,6 +531,11 @@ describe("runReplyAgent pending final delivery capture", () => {
     const stored = await readStoredMainSession(storePath);
     expect(stored.pendingFinalDelivery).toBe(true);
     expect(stored.pendingFinalDeliveryText).toBe("visible final");
+    expect(stored.pendingFinalDeliveryIntentId).toBe("msg");
+    expect(diagnosticMocks.markDiagnosticSessionPendingFinalDelivery).toHaveBeenCalledWith({
+      sessionKey: "main",
+      pending: true,
+    });
   });
 
   it("persists auto-reply delivery context for restart recovery", async () => {
@@ -568,6 +587,7 @@ describe("runReplyAgent pending final delivery capture", () => {
       accountId: "work",
       threadId: "1503645939964055592",
     });
+    expect(stored.pendingFinalDeliveryIntentId).toBe("1503645939964055592");
     expect(stored.restartRecoveryDeliveryContext).toBeUndefined();
     expect(stored.restartRecoveryDeliveryRunId).toBeUndefined();
   });

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -40,6 +40,7 @@ import {
 } from "../../infra/diagnostic-trace-context.js";
 import { measureDiagnosticsTimelineSpan } from "../../infra/diagnostics-timeline.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
+import { markDiagnosticSessionPendingFinalDelivery } from "../../logging/diagnostic.js";
 import { CommandLaneClearedError, GatewayDrainingError } from "../../process/command-queue.js";
 import { shouldPreserveUserFacingSessionStateForInputProvenance } from "../../sessions/input-provenance.js";
 import { resolveSendPolicy } from "../../sessions/send-policy.js";
@@ -93,7 +94,10 @@ import { resolveEffectiveReplyRoute } from "./effective-reply-route.js";
 import { createFollowupRunner } from "./followup-runner.js";
 import { REPLY_RUN_STILL_SHUTTING_DOWN_TEXT } from "./get-reply-run-queue.js";
 import { resolveOriginMessageProvider, resolveOriginMessageTo } from "./origin-routing.js";
-import { sanitizePendingFinalDeliveryText } from "./pending-final-delivery.js";
+import {
+  resolveSlackDirectPendingFinalDeliveryContext,
+  sanitizePendingFinalDeliveryText,
+} from "./pending-final-delivery.js";
 import { drainPendingToolTasks } from "./pending-tool-task-drain.js";
 import { readPostCompactionContext } from "./post-compaction-context.js";
 import {
@@ -196,12 +200,20 @@ function resolveReplyRunDeliveryContext(params: {
     normalizeOptionalString(
       parseSessionThreadInfoFast(params.sessionCtx.SessionKey ?? params.sessionKey).threadId,
     );
-  return normalizeDeliveryContext({
+  const context = normalizeDeliveryContext({
     ...resolveEffectiveReplyRoute({
       ctx: params.sessionCtx,
       entry: params.sessionEntry,
     }),
     threadId,
+  });
+  return resolveSlackDirectPendingFinalDeliveryContext({
+    context,
+    nativeChannelId: normalizeOptionalString(params.sessionCtx.NativeChannelId),
+    chatType: normalizeOptionalString(params.sessionCtx.ChatType),
+    directUserTarget: normalizeOptionalString(
+      params.sessionCtx.OriginatingTo ?? params.sessionCtx.To,
+    ),
   });
 }
 
@@ -2334,6 +2346,9 @@ export async function runReplyAgent(params: {
         });
       }
       const pendingText = sourceReplyPolicy.suppressDelivery ? "" : finalDeliveryText;
+      const pendingFinalDeliveryIntentId = normalizeOptionalString(
+        sessionCtx.MessageSidFull ?? sessionCtx.MessageSid,
+      );
       const agentId = followupRun.run.agentId;
       const heartbeatAgentCfg = agentId ? resolveAgentConfig(cfg, agentId)?.heartbeat : undefined;
       const heartbeatAckMaxChars = Math.max(
@@ -2369,10 +2384,12 @@ export async function runReplyAgent(params: {
             pendingFinalDelivery: true,
             pendingFinalDeliveryText: resolvedPendingText,
             pendingFinalDeliveryContext,
+            pendingFinalDeliveryIntentId,
             pendingFinalDeliveryCreatedAt: Date.now(),
             updatedAt: Date.now(),
           },
         });
+        markDiagnosticSessionPendingFinalDelivery({ sessionKey, pending: true });
       }
     }
 

--- a/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
@@ -263,6 +263,59 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
     expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryIntentId).toBeUndefined();
   });
 
+  it("replays old Slack user-scoped pending finals through the concrete DM channel", async () => {
+    hookMocks.runner.hasHooks.mockReturnValue(false);
+    sessionStoreMocks.currentEntry = {
+      sessionKey: "agent:test:session",
+      pendingFinalDelivery: true,
+      pendingFinalDeliveryText: "lost final answer",
+      pendingFinalDeliveryCreatedAt: 1,
+      pendingFinalDeliveryContext: {
+        channel: "slack",
+        to: "user:U039P2YJR29",
+        accountId: "son-of-anton",
+      },
+      pendingFinalDeliveryIntentId: "1780718204.607",
+      origin: {
+        provider: "slack",
+        chatType: "direct",
+        to: "user:U039P2YJR29",
+        nativeChannelId: "D0ACL8LRTJP",
+        accountId: "son-of-anton",
+      },
+    };
+    sessionStoreMocks.resolveSessionStoreEntry.mockReturnValue({
+      existing: sessionStoreMocks.currentEntry,
+    });
+    const dispatcher = createDispatcher();
+    const replyResolver = vi.fn(async () => ({ text: "regenerated answer" }));
+
+    const result = await dispatchReplyFromConfig({
+      ctx: createHookCtx({
+        Provider: "slack",
+        Surface: "slack",
+        OriginatingChannel: "slack",
+        OriginatingTo: "user:U039P2YJR29",
+        AccountId: "son-of-anton",
+        To: "user:U039P2YJR29",
+        ChatType: "direct",
+        NativeChannelId: "D0ACL8LRTJP",
+        MessageSid: "1780718204.607",
+      }),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+    });
+
+    expect(result.queuedFinal).toBe(true);
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledOnce();
+    expect(vi.mocked(dispatcher.sendFinalReply).mock.calls[0]?.[0]).toMatchObject({
+      text: "lost final answer",
+    });
+    expect(replyResolver).not.toHaveBeenCalled();
+    expect(sessionStoreMocks.currentEntry?.pendingFinalDelivery).toBeUndefined();
+  });
+
   it("does not replay pending final delivery when the current route differs", async () => {
     hookMocks.runner.hasHooks.mockReturnValue(false);
     sessionStoreMocks.currentEntry = {
@@ -301,6 +354,53 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
     expect(sessionStoreMocks.updateSessionStoreEntry).not.toHaveBeenCalled();
     expect(sessionStoreMocks.currentEntry?.pendingFinalDelivery).toBe(true);
     expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryText).toBe("lost final answer");
+  });
+
+  it("includes replayed pending final accounting when reply_dispatch handles the turn", async () => {
+    hookMocks.runner.hasHooks.mockImplementation(
+      (hookName?: string) => hookName === "reply_dispatch",
+    );
+    hookMocks.runner.runReplyDispatch.mockResolvedValue({
+      handled: true,
+      queuedFinal: false,
+      counts: { tool: 0, block: 0, final: 0 },
+    });
+    sessionStoreMocks.currentEntry = {
+      sessionKey: "agent:test:session",
+      pendingFinalDelivery: true,
+      pendingFinalDeliveryText: "lost final answer",
+      pendingFinalDeliveryCreatedAt: 1,
+      pendingFinalDeliveryContext: {
+        channel: "slack",
+        to: "D0ACL8LRTJP",
+        accountId: "son-of-anton",
+      },
+      pendingFinalDeliveryIntentId: "previous-message",
+    };
+    sessionStoreMocks.resolveSessionStoreEntry.mockReturnValue({
+      existing: sessionStoreMocks.currentEntry,
+    });
+    const dispatcher = createDispatcher();
+
+    const result = await dispatchReplyFromConfig({
+      ctx: createHookCtx({
+        Provider: "slack",
+        Surface: "slack",
+        OriginatingChannel: "slack",
+        OriginatingTo: "D0ACL8LRTJP",
+        AccountId: "son-of-anton",
+        To: "D0ACL8LRTJP",
+        ChatType: "direct",
+        MessageSid: "new-message",
+      }),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver: async () => ({ text: "plugin handled" }),
+    });
+
+    expect(result.queuedFinal).toBe(true);
+    expect(result.counts.final).toBe(0);
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledOnce();
   });
 
   it("preserves pending final delivery when final dispatch fails", async () => {

--- a/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
@@ -112,6 +112,7 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
     diagnosticMocks.logMessageProcessed.mockReset();
     diagnosticMocks.logSessionStateChange.mockReset();
     diagnosticMocks.markDiagnosticSessionProgress.mockReset();
+    diagnosticMocks.markDiagnosticSessionPendingFinalDelivery.mockReset();
     runtimePluginMocks.ensureRuntimePluginsLoaded.mockReset();
     resetPluginTtsAndThreadMocks();
   });
@@ -212,6 +213,94 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
     expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryAttemptCount).toBeUndefined();
     expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryLastError).toBeUndefined();
     expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryContext).toBeUndefined();
+  });
+
+  it("replays a same-route pending final delivery before model work", async () => {
+    hookMocks.runner.hasHooks.mockReturnValue(false);
+    sessionStoreMocks.currentEntry = {
+      sessionKey: "agent:test:session",
+      pendingFinalDelivery: true,
+      pendingFinalDeliveryText: "lost final answer",
+      pendingFinalDeliveryCreatedAt: 1,
+      pendingFinalDeliveryLastAttemptAt: 2,
+      pendingFinalDeliveryAttemptCount: 3,
+      pendingFinalDeliveryLastError: "gateway restarted",
+      pendingFinalDeliveryContext: {
+        channel: "slack",
+        to: "D0ACL8LRTJP",
+        accountId: "son-of-anton",
+      },
+      pendingFinalDeliveryIntentId: "intent-1",
+    };
+    sessionStoreMocks.resolveSessionStoreEntry.mockReturnValue({
+      existing: sessionStoreMocks.currentEntry,
+    });
+    const dispatcher = createDispatcher();
+
+    const result = await dispatchReplyFromConfig({
+      ctx: createHookCtx({
+        Provider: "slack",
+        Surface: "slack",
+        OriginatingChannel: "slack",
+        OriginatingTo: "D0ACL8LRTJP",
+        AccountId: "son-of-anton",
+        To: "D0ACL8LRTJP",
+        ChatType: "direct",
+      }),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver: async () => undefined,
+    });
+
+    expect(result.queuedFinal).toBe(true);
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledOnce();
+    expect(vi.mocked(dispatcher.sendFinalReply).mock.calls[0]?.[0]).toMatchObject({
+      text: "lost final answer",
+    });
+    expect(sessionStoreMocks.updateSessionStoreEntry).toHaveBeenCalledOnce();
+    expect(sessionStoreMocks.currentEntry?.pendingFinalDelivery).toBeUndefined();
+    expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryText).toBeUndefined();
+    expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryIntentId).toBeUndefined();
+  });
+
+  it("does not replay pending final delivery when the current route differs", async () => {
+    hookMocks.runner.hasHooks.mockReturnValue(false);
+    sessionStoreMocks.currentEntry = {
+      sessionKey: "agent:test:session",
+      pendingFinalDelivery: true,
+      pendingFinalDeliveryText: "lost final answer",
+      pendingFinalDeliveryCreatedAt: 1,
+      pendingFinalDeliveryContext: {
+        channel: "slack",
+        to: "D0ACL8LRTJP",
+        accountId: "son-of-anton",
+      },
+    };
+    sessionStoreMocks.resolveSessionStoreEntry.mockReturnValue({
+      existing: sessionStoreMocks.currentEntry,
+    });
+    const dispatcher = createDispatcher();
+
+    const result = await dispatchReplyFromConfig({
+      ctx: createHookCtx({
+        Provider: "slack",
+        Surface: "slack",
+        OriginatingChannel: "slack",
+        OriginatingTo: "D0OTHER",
+        AccountId: "son-of-anton",
+        To: "D0OTHER",
+        ChatType: "direct",
+      }),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver: async () => undefined,
+    });
+
+    expect(result.queuedFinal).toBe(false);
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+    expect(sessionStoreMocks.updateSessionStoreEntry).not.toHaveBeenCalled();
+    expect(sessionStoreMocks.currentEntry?.pendingFinalDelivery).toBe(true);
+    expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryText).toBe("lost final answer");
   });
 
   it("preserves pending final delivery when final dispatch fails", async () => {

--- a/src/auto-reply/reply/dispatch-from-config.shared.test-harness.ts
+++ b/src/auto-reply/reply/dispatch-from-config.shared.test-harness.ts
@@ -32,6 +32,7 @@ const diagnosticMocks = vi.hoisted(() => ({
   logMessageProcessed: vi.fn(),
   logSessionStateChange: vi.fn(),
   markDiagnosticSessionProgress: vi.fn(),
+  markDiagnosticSessionPendingFinalDelivery: vi.fn(),
 }));
 const hookMocks = vi.hoisted(() => ({
   registry: {
@@ -205,6 +206,8 @@ vi.mock("../../logging/diagnostic.js", () => ({
   logMessageProcessed: diagnosticMocks.logMessageProcessed,
   logSessionStateChange: diagnosticMocks.logSessionStateChange,
   markDiagnosticSessionProgress: diagnosticMocks.markDiagnosticSessionProgress,
+  markDiagnosticSessionPendingFinalDelivery:
+    diagnosticMocks.markDiagnosticSessionPendingFinalDelivery,
 }));
 vi.mock("../../config/sessions/thread-info.js", () => ({
   parseSessionThreadInfo: (sessionKey: string | undefined) =>
@@ -414,7 +417,7 @@ export function setDiscordTestRegistry() {
   );
 }
 
-export function createHookCtx() {
+export function createHookCtx(overrides: Parameters<typeof buildTestCtx>[0] = {}) {
   return buildTestCtx({
     Body: "hello",
     BodyForAgent: "hello",
@@ -423,5 +426,6 @@ export function createHookCtx() {
     Surface: "telegram",
     ChatType: "private",
     SessionKey: "agent:test:session",
+    ...overrides,
   });
 }

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -63,6 +63,7 @@ const diagnosticMocks = vi.hoisted(() => ({
   logMessageProcessed: vi.fn(),
   logSessionStateChange: vi.fn(),
   markDiagnosticSessionProgress: vi.fn(),
+  markDiagnosticSessionPendingFinalDelivery: vi.fn(),
 }));
 const hookMocks = vi.hoisted(() => ({
   registry: {
@@ -407,6 +408,8 @@ vi.mock("../../logging/diagnostic.js", () => ({
   logMessageProcessed: diagnosticMocks.logMessageProcessed,
   logSessionStateChange: diagnosticMocks.logSessionStateChange,
   markDiagnosticSessionProgress: diagnosticMocks.markDiagnosticSessionProgress,
+  markDiagnosticSessionPendingFinalDelivery:
+    diagnosticMocks.markDiagnosticSessionPendingFinalDelivery,
 }));
 vi.mock("../../config/sessions/thread-info.js", () => ({
   parseSessionThreadInfo: (sessionKey: string | undefined) =>
@@ -949,6 +952,7 @@ describe("dispatchReplyFromConfig", () => {
     diagnosticMocks.logMessageProcessed.mockClear();
     diagnosticMocks.logSessionStateChange.mockClear();
     diagnosticMocks.markDiagnosticSessionProgress.mockClear();
+    diagnosticMocks.markDiagnosticSessionPendingFinalDelivery.mockClear();
     diagnosticMocks.logMessageDispatchStarted.mockClear();
     diagnosticMocks.logMessageDispatchCompleted.mockClear();
     hookMocks.runner.hasHooks.mockClear();

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -65,6 +65,7 @@ import {
   logMessageDispatchCompleted,
   logMessageDispatchStarted,
   markDiagnosticSessionProgress,
+  markDiagnosticSessionPendingFinalDelivery,
 } from "../../logging/diagnostic.js";
 import { createDiagnosticMessageLifecycle } from "../../logging/message-lifecycle.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
@@ -91,6 +92,7 @@ import {
   shouldCleanTtsDirectiveText,
   shouldAttemptTtsPayload,
 } from "../../tts/tts-config.js";
+import { normalizeDeliveryContext } from "../../utils/delivery-context.shared.js";
 import { INTERNAL_MESSAGE_CHANNEL, normalizeMessageChannel } from "../../utils/message-channel.js";
 import {
   isNativeCommandTurn,
@@ -132,6 +134,11 @@ import { withFullRuntimeReplyConfig } from "./get-reply-fast-path.js";
 import { claimInboundDedupe, commitInboundDedupe, releaseInboundDedupe } from "./inbound-dedupe.js";
 import { hasInboundAudio } from "./inbound-media.js";
 import { resolveOriginMessageProvider } from "./origin-routing.js";
+import {
+  isSameRoutePendingFinalDeliveryReplaySafe,
+  pendingFinalDeliveryClearedPatch,
+  sanitizePendingFinalDeliveryText,
+} from "./pending-final-delivery.js";
 import { waitForReplyDispatcherIdle } from "./reply-dispatcher.js";
 import type {
   DispatcherOutcomeCountsView,
@@ -710,17 +717,12 @@ async function clearPendingFinalDeliveryAfterSuccess(params: {
       if (!entry.pendingFinalDelivery && !entry.pendingFinalDeliveryText) {
         return null;
       }
-      return {
-        pendingFinalDelivery: undefined,
-        pendingFinalDeliveryText: undefined,
-        pendingFinalDeliveryCreatedAt: undefined,
-        pendingFinalDeliveryLastAttemptAt: undefined,
-        pendingFinalDeliveryAttemptCount: undefined,
-        pendingFinalDeliveryLastError: undefined,
-        pendingFinalDeliveryContext: undefined,
-        updatedAt: Date.now(),
-      };
+      return pendingFinalDeliveryClearedPatch();
     },
+  });
+  markDiagnosticSessionPendingFinalDelivery({
+    sessionKey: params.sessionKey,
+    pending: false,
   });
 }
 
@@ -1147,6 +1149,13 @@ export async function dispatchReplyFromConfig(
   const sessionStoreEntry = boundAcpDispatchSessionKey
     ? resolveSessionStoreLookup({ ...ctx, SessionKey: boundAcpDispatchSessionKey }, cfg)
     : initialSessionStoreEntry;
+  markDiagnosticSessionPendingFinalDelivery({
+    sessionKey: sessionStoreEntry.sessionKey ?? sessionKey,
+    pending: Boolean(
+      sessionStoreEntry.entry?.pendingFinalDelivery ||
+      sessionStoreEntry.entry?.pendingFinalDeliveryText,
+    ),
+  });
   const sessionAgentId = resolveSessionAgentId({
     sessionKey: acpDispatchSessionKey,
     config: cfg,
@@ -2078,6 +2087,58 @@ export async function dispatchReplyFromConfig(
       };
     };
 
+    const replayPendingFinalDeliveryForCurrentRoute = async (): Promise<{
+      queuedFinal: boolean;
+      routedFinalCount: number;
+    }> => {
+      const entry = sessionStoreEntry.entry;
+      if (
+        !entry?.pendingFinalDelivery ||
+        typeof entry.pendingFinalDeliveryText !== "string" ||
+        suppressDelivery ||
+        sendPolicyDenied
+      ) {
+        return { queuedFinal: false, routedFinalCount: 0 };
+      }
+      const text = sanitizePendingFinalDeliveryText(entry.pendingFinalDeliveryText);
+      if (!text) {
+        await clearPendingFinalDeliveryAfterSuccess({
+          storePath: sessionStoreEntry.storePath,
+          sessionKey: sessionStoreEntry.sessionKey ?? sessionKey,
+        });
+        return { queuedFinal: false, routedFinalCount: 0 };
+      }
+      const currentContext = normalizeDeliveryContext({
+        channel: shouldRouteToOriginating
+          ? routeReplyChannel
+          : (replyRoute.channel ?? deliveryChannel),
+        to: shouldRouteToOriginating ? routeReplyTo : replyRoute.to,
+        accountId: replyRoute.accountId,
+        threadId: routeReplyThreadId,
+      });
+      if (
+        !isSameRoutePendingFinalDeliveryReplaySafe({
+          pendingContext: entry.pendingFinalDeliveryContext,
+          currentContext,
+        })
+      ) {
+        return { queuedFinal: false, routedFinalCount: 0 };
+      }
+      const result = await sendFinalPayload({ text }, { abortSignal: getPreDispatchAbortSignal() });
+      if (result.queuedFinal || result.routedFinalCount > 0) {
+        await clearPendingFinalDeliveryAfterSuccess({
+          storePath: sessionStoreEntry.storePath,
+          sessionKey: sessionStoreEntry.sessionKey ?? sessionKey,
+        });
+        logVerbose(
+          `dispatch-from-config: replayed pending final delivery for session=${sessionStoreEntry.sessionKey ?? sessionKey ?? "unknown"}`,
+        );
+      }
+      return result;
+    };
+
+    const replayedPendingFinalDelivery = await replayPendingFinalDeliveryForCurrentRoute();
+
     // Run before_dispatch hook — let plugins inspect or handle before model dispatch.
     if (hookRunner?.hasHooks("before_dispatch")) {
       const beforeDispatchResult = await traceReplyPhase("reply.before_dispatch_hooks", () =>
@@ -2120,6 +2181,8 @@ export async function dispatchReplyFromConfig(
           queuedFinal = handledReply.queuedFinal;
           routedFinalCount += handledReply.routedFinalCount;
         }
+        queuedFinal = replayedPendingFinalDelivery.queuedFinal || queuedFinal;
+        routedFinalCount += replayedPendingFinalDelivery.routedFinalCount;
         const counts = dispatcher.getQueuedCounts();
         counts.final += routedFinalCount;
         recordProcessed("completed", { reason: "before_dispatch_handled" });
@@ -2821,8 +2884,8 @@ export async function dispatchReplyFromConfig(
       (reply) => getReplyPayloadMetadata(reply)?.beforeAgentRunBlocked === true,
     );
 
-    let queuedFinal = false;
-    let routedFinalCount = 0;
+    let queuedFinal = replayedPendingFinalDelivery.queuedFinal;
+    let routedFinalCount = replayedPendingFinalDelivery.routedFinalCount;
     let attemptedFinalDelivery = false;
     let finalDeliveryFailed = false;
     // Explicit command turns (native or authorized text-slash like /compact) are

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -137,6 +137,7 @@ import { resolveOriginMessageProvider } from "./origin-routing.js";
 import {
   isSameRoutePendingFinalDeliveryReplaySafe,
   pendingFinalDeliveryClearedPatch,
+  resolveSlackDirectPendingFinalDeliveryContext,
   sanitizePendingFinalDeliveryText,
 } from "./pending-final-delivery.js";
 import { waitForReplyDispatcherIdle } from "./reply-dispatcher.js";
@@ -2090,7 +2091,13 @@ export async function dispatchReplyFromConfig(
     const replayPendingFinalDeliveryForCurrentRoute = async (): Promise<{
       queuedFinal: boolean;
       routedFinalCount: number;
+      replayedCurrentTurnFinal: boolean;
     }> => {
+      const noReplay = {
+        queuedFinal: false,
+        routedFinalCount: 0,
+        replayedCurrentTurnFinal: false,
+      };
       const entry = sessionStoreEntry.entry;
       if (
         !entry?.pendingFinalDelivery ||
@@ -2098,7 +2105,14 @@ export async function dispatchReplyFromConfig(
         suppressDelivery ||
         sendPolicyDenied
       ) {
-        return { queuedFinal: false, routedFinalCount: 0 };
+        return noReplay;
+      }
+      if (
+        !dispatchReplyOperation &&
+        preDispatchAbortOperation &&
+        !preDispatchAbortOperation.result
+      ) {
+        return noReplay;
       }
       const text = sanitizePendingFinalDeliveryText(entry.pendingFinalDeliveryText);
       if (!text) {
@@ -2106,23 +2120,36 @@ export async function dispatchReplyFromConfig(
           storePath: sessionStoreEntry.storePath,
           sessionKey: sessionStoreEntry.sessionKey ?? sessionKey,
         });
-        return { queuedFinal: false, routedFinalCount: 0 };
+        return noReplay;
       }
-      const currentContext = normalizeDeliveryContext({
-        channel: shouldRouteToOriginating
-          ? routeReplyChannel
-          : (replyRoute.channel ?? deliveryChannel),
-        to: shouldRouteToOriginating ? routeReplyTo : replyRoute.to,
-        accountId: replyRoute.accountId,
-        threadId: routeReplyThreadId,
+      const currentContext = resolveSlackDirectPendingFinalDeliveryContext({
+        context: normalizeDeliveryContext({
+          channel: shouldRouteToOriginating
+            ? routeReplyChannel
+            : (replyRoute.channel ?? deliveryChannel),
+          to: shouldRouteToOriginating ? routeReplyTo : replyRoute.to,
+          accountId: replyRoute.accountId,
+          threadId: routeReplyThreadId,
+        }),
+        nativeChannelId: normalizeOptionalString(ctx.NativeChannelId),
+        chatType: normalizeOptionalString(ctx.ChatType),
+        directUserTarget: normalizeOptionalString(ctx.OriginatingTo ?? ctx.To),
+      });
+      const pendingContext = resolveSlackDirectPendingFinalDeliveryContext({
+        context: entry.pendingFinalDeliveryContext,
+        nativeChannelId: normalizeOptionalString(
+          entry.origin?.nativeChannelId ?? ctx.NativeChannelId,
+        ),
+        chatType: normalizeOptionalString(entry.origin?.chatType ?? ctx.ChatType),
+        directUserTarget: normalizeOptionalString(entry.origin?.to ?? ctx.OriginatingTo ?? ctx.To),
       });
       if (
         !isSameRoutePendingFinalDeliveryReplaySafe({
-          pendingContext: entry.pendingFinalDeliveryContext,
+          pendingContext,
           currentContext,
         })
       ) {
-        return { queuedFinal: false, routedFinalCount: 0 };
+        return noReplay;
       }
       const result = await sendFinalPayload({ text }, { abortSignal: getPreDispatchAbortSignal() });
       if (result.queuedFinal || result.routedFinalCount > 0) {
@@ -2134,10 +2161,34 @@ export async function dispatchReplyFromConfig(
           `dispatch-from-config: replayed pending final delivery for session=${sessionStoreEntry.sessionKey ?? sessionKey ?? "unknown"}`,
         );
       }
-      return result;
+      const pendingIntentId = normalizeOptionalString(
+        entry.pendingFinalDeliveryIntentId ?? undefined,
+      );
+      const currentIntentId = normalizeOptionalString(ctx.MessageSidFull ?? ctx.MessageSid);
+      return {
+        ...result,
+        replayedCurrentTurnFinal: Boolean(
+          (result.queuedFinal || result.routedFinalCount > 0) &&
+          pendingIntentId &&
+          currentIntentId &&
+          pendingIntentId === currentIntentId,
+        ),
+      };
     };
 
     const replayedPendingFinalDelivery = await replayPendingFinalDeliveryForCurrentRoute();
+    if (replayedPendingFinalDelivery.replayedCurrentTurnFinal) {
+      const counts = dispatcher.getQueuedCounts();
+      counts.final += replayedPendingFinalDelivery.routedFinalCount;
+      recordProcessed("completed", { reason: "pending_final_delivery_replayed" });
+      markIdle("message_completed");
+      commitInboundDedupeIfClaimed();
+      completeDispatchReplyOperation();
+      return attachSourceReplyDeliveryMode({
+        queuedFinal: replayedPendingFinalDelivery.queuedFinal,
+        counts,
+      });
+    }
 
     // Run before_dispatch hook — let plugins inspect or handle before model dispatch.
     if (hookRunner?.hasHooks("before_dispatch")) {
@@ -2229,11 +2280,13 @@ export async function dispatchReplyFromConfig(
         ),
       );
       if (replyDispatchResult?.handled) {
+        const counts = { ...replyDispatchResult.counts };
+        counts.final += replayedPendingFinalDelivery.routedFinalCount;
         commitInboundDedupeIfClaimed();
         completeDispatchReplyOperation();
         return attachSourceReplyDeliveryMode({
-          queuedFinal: replyDispatchResult.queuedFinal,
-          counts: replyDispatchResult.counts,
+          queuedFinal: replyDispatchResult.queuedFinal || replayedPendingFinalDelivery.queuedFinal,
+          counts,
         });
       }
     }

--- a/src/auto-reply/reply/pending-final-delivery.test.ts
+++ b/src/auto-reply/reply/pending-final-delivery.test.ts
@@ -4,7 +4,10 @@ import {
   INTERNAL_RUNTIME_CONTEXT_BEGIN,
   INTERNAL_RUNTIME_CONTEXT_END,
 } from "../../agents/internal-runtime-context.js";
-import { sanitizePendingFinalDeliveryText } from "./pending-final-delivery.js";
+import {
+  isSameRoutePendingFinalDeliveryReplaySafe,
+  sanitizePendingFinalDeliveryText,
+} from "./pending-final-delivery.js";
 
 describe("sanitizePendingFinalDeliveryText", () => {
   it("strips internal metadata from durable pending delivery text", () => {
@@ -37,5 +40,61 @@ describe("sanitizePendingFinalDeliveryText", () => {
 
   it("preserves heartbeat ack text for ack-aware classification", () => {
     expect(sanitizePendingFinalDeliveryText("HEARTBEAT_OK short")).toBe("HEARTBEAT_OK short");
+  });
+});
+
+describe("isSameRoutePendingFinalDeliveryReplaySafe", () => {
+  it("allows replay only when channel, target, account, and thread match", () => {
+    expect(
+      isSameRoutePendingFinalDeliveryReplaySafe({
+        pendingContext: {
+          channel: "slack",
+          to: "D123",
+          accountId: "son-of-anton",
+          threadId: "1780719008.053929",
+        },
+        currentContext: {
+          channel: "SLACK",
+          to: "D123",
+          accountId: "son-of-anton",
+          threadId: "1780719008.053929",
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("blocks replay when the saved route lacks exact destination proof", () => {
+    expect(
+      isSameRoutePendingFinalDeliveryReplaySafe({
+        pendingContext: { channel: "slack", to: "D123" },
+        currentContext: { channel: "slack", to: "D123", accountId: "son-of-anton" },
+      }),
+    ).toBe(false);
+    expect(
+      isSameRoutePendingFinalDeliveryReplaySafe({
+        pendingContext: { channel: "slack", to: "D123", accountId: "son-of-anton" },
+        currentContext: {
+          channel: "slack",
+          to: "D123",
+          accountId: "son-of-anton",
+          threadId: "1780719008.053929",
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("blocks replay to a different channel target", () => {
+    expect(
+      isSameRoutePendingFinalDeliveryReplaySafe({
+        pendingContext: { channel: "slack", to: "D123", accountId: "son-of-anton" },
+        currentContext: { channel: "telegram", to: "D123", accountId: "son-of-anton" },
+      }),
+    ).toBe(false);
+    expect(
+      isSameRoutePendingFinalDeliveryReplaySafe({
+        pendingContext: { channel: "slack", to: "D123", accountId: "son-of-anton" },
+        currentContext: { channel: "slack", to: "D999", accountId: "son-of-anton" },
+      }),
+    ).toBe(false);
   });
 });

--- a/src/auto-reply/reply/pending-final-delivery.test.ts
+++ b/src/auto-reply/reply/pending-final-delivery.test.ts
@@ -6,6 +6,7 @@ import {
 } from "../../agents/internal-runtime-context.js";
 import {
   isSameRoutePendingFinalDeliveryReplaySafe,
+  resolveSlackDirectPendingFinalDeliveryContext,
   sanitizePendingFinalDeliveryText,
 } from "./pending-final-delivery.js";
 
@@ -96,5 +97,64 @@ describe("isSameRoutePendingFinalDeliveryReplaySafe", () => {
         currentContext: { channel: "slack", to: "D999", accountId: "son-of-anton" },
       }),
     ).toBe(false);
+  });
+});
+
+describe("resolveSlackDirectPendingFinalDeliveryContext", () => {
+  it("uses the concrete Slack DM channel for direct user-scoped pending targets", () => {
+    expect(
+      resolveSlackDirectPendingFinalDeliveryContext({
+        context: {
+          channel: "slack",
+          to: "user:U039P2YJR29",
+          accountId: "son-of-anton",
+          threadId: "1780718204.607",
+        },
+        nativeChannelId: "D0ACL8LRTJP",
+        chatType: "direct",
+        directUserTarget: "user:U039P2YJR29",
+      }),
+    ).toEqual({
+      channel: "slack",
+      to: "channel:D0ACL8LRTJP",
+      accountId: "son-of-anton",
+      threadId: "1780718204.607",
+    });
+  });
+
+  it("does not rewrite Slack DM targets when the proven user differs", () => {
+    expect(
+      resolveSlackDirectPendingFinalDeliveryContext({
+        context: {
+          channel: "slack",
+          to: "user:U039P2YJR29",
+          accountId: "son-of-anton",
+        },
+        nativeChannelId: "D0ACL8LRTJP",
+        chatType: "direct",
+        directUserTarget: "user:UOTHER",
+      }),
+    ).toEqual({
+      channel: "slack",
+      to: "user:U039P2YJR29",
+      accountId: "son-of-anton",
+    });
+  });
+
+  it("leaves non-Slack and non-direct targets unchanged", () => {
+    expect(
+      resolveSlackDirectPendingFinalDeliveryContext({
+        context: { channel: "discord", to: "user:U039P2YJR29" },
+        nativeChannelId: "D0ACL8LRTJP",
+        chatType: "direct",
+      }),
+    ).toEqual({ channel: "discord", to: "user:U039P2YJR29", accountId: undefined });
+    expect(
+      resolveSlackDirectPendingFinalDeliveryContext({
+        context: { channel: "slack", to: "user:U039P2YJR29" },
+        nativeChannelId: "D0ACL8LRTJP",
+        chatType: "group",
+      }),
+    ).toEqual({ channel: "slack", to: "user:U039P2YJR29", accountId: undefined });
   });
 });

--- a/src/auto-reply/reply/pending-final-delivery.ts
+++ b/src/auto-reply/reply/pending-final-delivery.ts
@@ -51,6 +51,65 @@ function routeFieldMatches(
   return String(left) === String(right);
 }
 
+function normalizeSlackDirectUserTarget(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const withoutPrefix = trimmed.toLowerCase().startsWith("user:")
+    ? trimmed.slice("user:".length).trim()
+    : trimmed;
+  return /^U[A-Z0-9]+$/i.test(withoutPrefix) ? withoutPrefix.toUpperCase() : undefined;
+}
+
+function normalizeSlackDmChannelTarget(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const withoutPrefix = trimmed.toLowerCase().startsWith("channel:")
+    ? trimmed.slice("channel:".length).trim()
+    : trimmed;
+  return /^D[A-Z0-9]+$/i.test(withoutPrefix) ? withoutPrefix.toUpperCase() : undefined;
+}
+
+/**
+ * Slack text-only DM sends can persist as user-scoped targets (`user:U...`),
+ * while the already-received event also proves the concrete DM channel (`D...`).
+ * Prefer the concrete channel for pending-final recovery so replay uses the
+ * same address family as normal Slack DM replies.
+ */
+export function resolveSlackDirectPendingFinalDeliveryContext(params: {
+  context?: DeliveryContext;
+  nativeChannelId?: string;
+  chatType?: string;
+  directUserTarget?: string;
+}): DeliveryContext | undefined {
+  const context = normalizeDeliveryContext(params.context);
+  if (!context || context.channel !== "slack") {
+    return context;
+  }
+  if (params.chatType?.trim().toLowerCase() !== "direct") {
+    return context;
+  }
+  const nativeDmChannelId = normalizeSlackDmChannelTarget(params.nativeChannelId);
+  if (!nativeDmChannelId) {
+    return context;
+  }
+  const contextUser = normalizeSlackDirectUserTarget(context.to);
+  if (!contextUser) {
+    return context;
+  }
+  const expectedUser = normalizeSlackDirectUserTarget(params.directUserTarget);
+  if (expectedUser && expectedUser !== contextUser) {
+    return context;
+  }
+  return normalizeDeliveryContext({
+    ...context,
+    to: `channel:${nativeDmChannelId}`,
+  });
+}
+
 /**
  * Pending final replay is only safe when the saved target and the current
  * source-reply target prove the same channel destination.

--- a/src/auto-reply/reply/pending-final-delivery.ts
+++ b/src/auto-reply/reply/pending-final-delivery.ts
@@ -1,5 +1,9 @@
 /** Sanitizes pending final delivery text before channel-visible output. */
 import {
+  normalizeDeliveryContext,
+  type DeliveryContext,
+} from "../../utils/delivery-context.shared.js";
+import {
   isSilentReplyPayloadText,
   isSilentReplyText,
   SILENT_REPLY_TOKEN,
@@ -32,4 +36,57 @@ export function sanitizePendingFinalDeliveryText(text: string): string {
     return "";
   }
   return isSilentReplyPayloadText(stripped, SILENT_REPLY_TOKEN) ? "" : stripped.trim();
+}
+
+function routeFieldMatches(
+  left: string | number | undefined,
+  right: string | number | undefined,
+): boolean {
+  if (left === undefined && right === undefined) {
+    return true;
+  }
+  if (left === undefined || right === undefined) {
+    return false;
+  }
+  return String(left) === String(right);
+}
+
+/**
+ * Pending final replay is only safe when the saved target and the current
+ * source-reply target prove the same channel destination.
+ */
+export function isSameRoutePendingFinalDeliveryReplaySafe(params: {
+  pendingContext?: DeliveryContext;
+  currentContext?: DeliveryContext;
+}): boolean {
+  const pendingContext = normalizeDeliveryContext(params.pendingContext);
+  const currentContext = normalizeDeliveryContext(params.currentContext);
+  if (
+    !pendingContext?.channel ||
+    !pendingContext.to ||
+    !currentContext?.channel ||
+    !currentContext.to
+  ) {
+    return false;
+  }
+  return (
+    pendingContext.channel === currentContext.channel &&
+    pendingContext.to === currentContext.to &&
+    routeFieldMatches(pendingContext.accountId, currentContext.accountId) &&
+    routeFieldMatches(pendingContext.threadId, currentContext.threadId)
+  );
+}
+
+export function pendingFinalDeliveryClearedPatch(updatedAt = Date.now()) {
+  return {
+    pendingFinalDelivery: undefined,
+    pendingFinalDeliveryText: undefined,
+    pendingFinalDeliveryCreatedAt: undefined,
+    pendingFinalDeliveryLastAttemptAt: undefined,
+    pendingFinalDeliveryAttemptCount: undefined,
+    pendingFinalDeliveryLastError: undefined,
+    pendingFinalDeliveryContext: undefined,
+    pendingFinalDeliveryIntentId: undefined,
+    updatedAt,
+  };
 }

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -208,6 +208,7 @@ type DiagnosticSessionAttentionBaseEvent = DiagnosticBaseEvent & {
   activeToolCallId?: string;
   activeToolAgeMs?: number;
   terminalProgressStale?: boolean;
+  pendingFinalDelivery?: boolean;
 };
 
 export type DiagnosticSessionLongRunningEvent = DiagnosticSessionAttentionBaseEvent & {

--- a/src/infra/heartbeat-runner.model-override.test.ts
+++ b/src/infra/heartbeat-runner.model-override.test.ts
@@ -285,6 +285,35 @@ describe("runHeartbeatOnce – heartbeat model override", () => {
     });
   });
 
+  it("does not use lightweight bootstrap context from stale token totals", async () => {
+    await withHeartbeatFixture(async ({ tmpDir, storePath, replySpy, seedSession }) => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: {
+              every: "5m",
+              target: "whatsapp",
+            },
+          },
+        },
+        channels: { whatsapp: { allowFrom: ["*"] } },
+        session: { store: storePath },
+      };
+      const sessionKey = resolveMainSessionKey(cfg);
+      const result = await runHeartbeatWithSeed({
+        seedSession,
+        cfg,
+        sessionKey,
+        replySpy,
+        seedInput: { totalTokens: 800_000, totalTokensFresh: false },
+      });
+
+      const replyOptions = expectReplyOptions(result.opts, { isHeartbeat: true });
+      expect(replyOptions.bootstrapContextMode).toBeUndefined();
+    });
+  });
+
   it("honors explicit heartbeat lightContext false for huge sessions", async () => {
     await withHeartbeatFixture(async ({ tmpDir, storePath, replySpy, seedSession }) => {
       const cfg: OpenClawConfig = {

--- a/src/infra/heartbeat-runner.model-override.test.ts
+++ b/src/infra/heartbeat-runner.model-override.test.ts
@@ -17,6 +17,8 @@ vi.mock("./outbound/deliver.js", () => ({
 type SeedSessionInput = {
   lastChannel: string;
   lastTo: string;
+  totalTokens?: number;
+  totalTokensFresh?: boolean;
   updatedAt?: number;
 };
 type AgentDefaultsConfig = NonNullable<NonNullable<OpenClawConfig["agents"]>["defaults"]>;
@@ -53,6 +55,8 @@ async function withHeartbeatFixture(
           lastChannel: input.lastChannel,
           lastProvider: input.lastChannel,
           lastTo: input.lastTo,
+          totalTokens: input.totalTokens,
+          totalTokensFresh: input.totalTokensFresh,
         });
       };
       return run({ tmpDir, storePath, replySpy, seedSession });
@@ -72,8 +76,13 @@ describe("runHeartbeatOnce – heartbeat model override", () => {
     sessionKey: string;
     replySpy: HeartbeatReplySpy;
     agentId?: string;
+    seedInput?: Partial<SeedSessionInput>;
   }) {
-    await params.seedSession(params.sessionKey, { lastChannel: "whatsapp", lastTo: "+1555" });
+    await params.seedSession(params.sessionKey, {
+      lastChannel: "whatsapp",
+      lastTo: "+1555",
+      ...params.seedInput,
+    });
 
     params.replySpy.mockResolvedValue({ text: "HEARTBEAT_OK" });
 
@@ -242,6 +251,67 @@ describe("runHeartbeatOnce – heartbeat model override", () => {
     expectReplyOptions(replyOpts, {
       isHeartbeat: true,
       bootstrapContextMode: "lightweight",
+    });
+  });
+
+  it("uses lightweight bootstrap context when heartbeat session context is already huge", async () => {
+    await withHeartbeatFixture(async ({ tmpDir, storePath, replySpy, seedSession }) => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: {
+              every: "5m",
+              target: "whatsapp",
+            },
+          },
+        },
+        channels: { whatsapp: { allowFrom: ["*"] } },
+        session: { store: storePath },
+      };
+      const sessionKey = resolveMainSessionKey(cfg);
+      const result = await runHeartbeatWithSeed({
+        seedSession,
+        cfg,
+        sessionKey,
+        replySpy,
+        seedInput: { totalTokens: 800_000, totalTokensFresh: true },
+      });
+
+      expectReplyOptions(result.opts, {
+        isHeartbeat: true,
+        bootstrapContextMode: "lightweight",
+      });
+    });
+  });
+
+  it("honors explicit heartbeat lightContext false for huge sessions", async () => {
+    await withHeartbeatFixture(async ({ tmpDir, storePath, replySpy, seedSession }) => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: {
+              every: "5m",
+              target: "whatsapp",
+              lightContext: false,
+            },
+          },
+        },
+        channels: { whatsapp: { allowFrom: ["*"] } },
+        session: { store: storePath },
+      };
+      const sessionKey = resolveMainSessionKey(cfg);
+      const result = await runHeartbeatWithSeed({
+        seedSession,
+        cfg,
+        sessionKey,
+        replySpy,
+        seedInput: { totalTokens: 800_000, totalTokensFresh: true },
+      });
+
+      const replyOptions = expectReplyOptions(result.opts, { isHeartbeat: true });
+      expect(replyOptions.bootstrapContextMode).toBeUndefined();
     });
   });
 

--- a/src/infra/heartbeat-runner.test-utils.ts
+++ b/src/infra/heartbeat-runner.test-utils.ts
@@ -23,6 +23,8 @@ type HeartbeatSessionSeed = {
   pendingFinalDeliveryCreatedAt?: number;
   pendingFinalDeliveryAttemptCount?: number;
   pendingFinalDeliveryLastError?: string | null;
+  totalTokens?: number;
+  totalTokensFresh?: boolean;
   agentHarnessId?: string;
   agentRuntimeOverride?: string;
   model?: string;

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -169,6 +169,7 @@ function loadHeartbeatRunnerRuntime() {
 
 const HEARTBEAT_ALWAYS_BUSY_LANES = [CommandLane.Cron, CommandLane.CronNested] as const;
 const DEFAULT_HEARTBEAT_TIMEOUT_SECONDS = 10 * 60;
+const HEARTBEAT_CONTEXT_SPIRAL_LIGHT_CONTEXT_TOKENS = 750_000;
 
 function hasQueuedWorkInLanes(
   lanes: readonly string[],
@@ -522,6 +523,24 @@ function resolveHeartbeatAckMaxChars(cfg: OpenClawConfig, heartbeat?: HeartbeatC
     heartbeat?.ackMaxChars ??
       cfg.agents?.defaults?.heartbeat?.ackMaxChars ??
       DEFAULT_HEARTBEAT_ACK_MAX_CHARS,
+  );
+}
+
+function shouldUseHeartbeatLightContext(params: {
+  heartbeat?: HeartbeatConfig;
+  entry?: SessionEntry;
+}): boolean {
+  if (params.heartbeat?.lightContext === true) {
+    return true;
+  }
+  if (params.heartbeat?.lightContext === false) {
+    return false;
+  }
+  const totalTokens = params.entry?.totalTokens;
+  return (
+    typeof totalTokens === "number" &&
+    Number.isFinite(totalTokens) &&
+    totalTokens >= HEARTBEAT_CONTEXT_SPIRAL_LIGHT_CONTEXT_TOKENS
   );
 }
 
@@ -1776,8 +1795,12 @@ export async function runHeartbeatOnce(opts: {
     const heartbeatModelOverride = normalizeOptionalString(heartbeat?.model);
     const suppressToolErrorWarnings = heartbeat?.suppressToolErrorWarnings === true;
     const timeoutOverrideSeconds = resolveHeartbeatTimeoutOverrideSeconds(cfg, heartbeat);
-    const bootstrapContextMode: "lightweight" | undefined =
-      heartbeat?.lightContext === true ? "lightweight" : undefined;
+    const bootstrapContextMode: "lightweight" | undefined = shouldUseHeartbeatLightContext({
+      heartbeat,
+      entry: recentSessionEntry,
+    })
+      ? "lightweight"
+      : undefined;
     const replyOpts = {
       isHeartbeat: true,
       ...(heartbeatModelOverride ? { heartbeatModelOverride } : {}),

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -74,7 +74,7 @@ import {
 import { resolveStorePath } from "../config/sessions/paths.js";
 import { loadSessionStore } from "../config/sessions/store-load.js";
 import { archiveRemovedSessionTranscripts, updateSessionStore } from "../config/sessions/store.js";
-import type { SessionEntry } from "../config/sessions/types.js";
+import { resolveFreshSessionTotalTokens, type SessionEntry } from "../config/sessions/types.js";
 import type { AgentDefaultsConfig } from "../config/types.agent-defaults.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { hasActiveCronJobs } from "../cron/active-jobs.js";
@@ -536,7 +536,7 @@ function shouldUseHeartbeatLightContext(params: {
   if (params.heartbeat?.lightContext === false) {
     return false;
   }
-  const totalTokens = params.entry?.totalTokens;
+  const totalTokens = resolveFreshSessionTotalTokens(params.entry);
   return (
     typeof totalTokens === "number" &&
     Number.isFinite(totalTokens) &&

--- a/src/logging/diagnostic-session-attention.test.ts
+++ b/src/logging/diagnostic-session-attention.test.ts
@@ -155,13 +155,65 @@ describe("classifySessionAttention", () => {
         recoveryEligible: false,
       },
     },
-  ])("$name", ({ activity, expected, queueDepth, state }) => {
+    {
+      name: "queued stale processing session with pending final delivery is recoverable",
+      state: "processing" as const,
+      queueDepth: 1,
+      hasPendingFinalDelivery: true,
+      activity: {
+        activeWorkKind: "model_call" as const,
+        hasActiveEmbeddedRun: false,
+        lastProgressAgeMs: 31_000,
+      },
+      expected: {
+        eventType: "session.stuck",
+        reason: "queued_pending_final_delivery",
+        classification: "stale_session_state",
+        recoveryEligible: true,
+      },
+    },
+    {
+      name: "queued terminal embedded progress with pending final delivery is recoverable",
+      state: "processing" as const,
+      queueDepth: 1,
+      hasPendingFinalDelivery: true,
+      activity: {
+        activeWorkKind: "embedded_run" as const,
+        lastProgressAgeMs: 100,
+        lastProgressReason: "codex_app_server:notification:rawResponseItem/completed",
+      },
+      expected: {
+        eventType: "session.stuck",
+        reason: "queued_pending_final_delivery",
+        classification: "stale_session_state",
+        recoveryEligible: true,
+      },
+    },
+    {
+      name: "blocked tool call with pending final delivery remains non-recoverable",
+      queueDepth: 1,
+      hasPendingFinalDelivery: true,
+      activity: {
+        activeWorkKind: "tool_call" as const,
+        activeToolAgeMs: 31_000,
+        lastProgressAgeMs: 31_000,
+      },
+      expected: {
+        eventType: "session.stalled",
+        reason: "blocked_tool_call",
+        classification: "blocked_tool_call",
+        activeWorkKind: "tool_call",
+        recoveryEligible: false,
+      },
+    },
+  ])("$name", ({ activity, expected, hasPendingFinalDelivery, queueDepth, state }) => {
     expect(
       classifySessionAttention({
         state,
         queueDepth,
         activity,
         staleMs: 30_000,
+        hasPendingFinalDelivery,
       }),
     ).toEqual(expected);
   });

--- a/src/logging/diagnostic-session-attention.ts
+++ b/src/logging/diagnostic-session-attention.ts
@@ -30,8 +30,23 @@ export function classifySessionAttention(params: {
   queueDepth: number;
   activity: DiagnosticSessionActivitySnapshot;
   staleMs: number;
+  hasPendingFinalDelivery?: boolean;
 }): SessionAttentionClassification {
   if (params.activity.activeWorkKind) {
+    const lastProgressStale = (params.activity.lastProgressAgeMs ?? 0) > params.staleMs;
+    if (
+      params.hasPendingFinalDelivery === true &&
+      params.queueDepth > 0 &&
+      params.activity.activeWorkKind !== "tool_call" &&
+      (lastProgressStale || isTerminalDiagnosticProgressReason(params.activity.lastProgressReason))
+    ) {
+      return {
+        eventType: "session.stuck",
+        reason: "queued_pending_final_delivery",
+        classification: "stale_session_state",
+        recoveryEligible: true,
+      };
+    }
     // Idle session with queued work and stale orphaned activity (no active
     // embedded owner) should be classified as recoverable stuck state, not as
     // stalled active work. This prevents orphaned model_call or tool_call
@@ -40,7 +55,7 @@ export function classifySessionAttention(params: {
       params.state === "idle" &&
       params.queueDepth > 0 &&
       params.activity.hasActiveEmbeddedRun !== true &&
-      (params.activity.lastProgressAgeMs ?? 0) > params.staleMs
+      lastProgressStale
     ) {
       return {
         eventType: "session.stuck",
@@ -75,7 +90,7 @@ export function classifySessionAttention(params: {
         recoveryEligible: false,
       };
     }
-    if ((params.activity.lastProgressAgeMs ?? 0) > params.staleMs) {
+    if (lastProgressStale) {
       return {
         eventType: "session.stalled",
         reason: "active_work_without_progress",

--- a/src/logging/diagnostic-session-state.ts
+++ b/src/logging/diagnostic-session-state.ts
@@ -13,6 +13,7 @@ export type SessionState = {
   state: SessionStateValue;
   queueDepth: number;
   activeQueuedTurn?: boolean;
+  hasPendingFinalDelivery?: boolean;
   toolCallHistory?: ToolCallRecord[];
   toolLoopWarningBuckets?: Map<string, number>;
   commandPollCounts?: Map<string, { count: number; lastPollAt: number }>;
@@ -118,6 +119,12 @@ function mergeSessionState(target: SessionState, source: SessionState): void {
   // Queue depth is additive when session id/key aliases collapse into one diagnostic entry.
   target.queueDepth += source.queueDepth;
   target.activeQueuedTurn ||= source.activeQueuedTurn;
+  if (
+    source.hasPendingFinalDelivery !== undefined &&
+    (sourceIsNewer || target.hasPendingFinalDelivery === undefined)
+  ) {
+    target.hasPendingFinalDelivery = source.hasPendingFinalDelivery;
+  }
   target.lastStuckWarnAgeMs =
     target.lastStuckWarnAgeMs === undefined || source.lastStuckWarnAgeMs === undefined
       ? undefined

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -919,6 +919,17 @@ export function markDiagnosticSessionProgress(params: SessionRef) {
   markActivity();
 }
 
+export function markDiagnosticSessionPendingFinalDelivery(
+  params: SessionRef & { pending: boolean },
+) {
+  if (!areDiagnosticsEnabledForProcess()) {
+    return;
+  }
+  const state = getDiagnosticSessionState(params);
+  state.hasPendingFinalDelivery = params.pending;
+  markActivity();
+}
+
 function sessionAttentionFields(params: {
   classification: SessionAttentionClassification;
   activity: DiagnosticSessionActivitySnapshot;
@@ -991,6 +1002,7 @@ export function logSessionAttention(
     queueDepth: state.queueDepth,
     activity,
     staleMs: params.thresholdMs,
+    hasPendingFinalDelivery: state.hasPendingFinalDelivery === true,
   });
   const recoveryEligible =
     classification.recoveryEligible ||
@@ -1041,7 +1053,9 @@ export function logSessionAttention(
     state.queueDepth
   } reason=${classification.reason} classification=${classification.classification}${
     classification.activeWorkKind ? ` activeWorkKind=${classification.activeWorkKind}` : ""
-  }${detailFields ? ` ${detailFields}` : ""} recovery=${recoveryEligible ? "checking" : "none"}`;
+  }${state.hasPendingFinalDelivery ? " pendingFinalDelivery=true" : ""}${
+    detailFields ? ` ${detailFields}` : ""
+  } recovery=${recoveryEligible ? "checking" : "none"}`;
   if (classification.eventType === "session.long_running" && state.queueDepth <= 0) {
     diag.debug(message);
   } else {
@@ -1054,6 +1068,7 @@ export function logSessionAttention(
     ageMs: params.ageMs,
     queueDepth: state.queueDepth,
     reason: classification.reason,
+    ...(state.hasPendingFinalDelivery ? { pendingFinalDelivery: true } : {}),
     ...sessionAttentionFields({ classification, activity }),
   };
   if (classification.eventType === "session.long_running") {


### PR DESCRIPTION
## Summary
- replay durable pending final-delivery text only when the saved delivery context exactly matches the current source-reply route
- mark pending final-delivery state in diagnostics and classify queued stale work with pending final delivery as recoverable
- auto-enable lightweight heartbeat bootstrap context for already-huge sessions to avoid context spiral, while preserving explicit `lightContext: false`

## Real behavior proof

- Behavior or issue addressed: Slack/source-channel sessions that generated a final reply but stalled with `pendingFinalDelivery=true` can now safely replay that pending final on the same route instead of staying stuck; huge heartbeat sessions now switch to lightweight bootstrap context to avoid another compaction/context spiral.
- Real environment tested: MBA HQ local OpenClaw checkout/worktree at exact head `4ff5e4d2cb24f936f84fd868be70e4c53e2629ea`; before-state was confirmed read-only from the Contabo/OpenClaw production session/log store for the June 5 incident.
- Exact steps or command run after this patch: `git rev-parse HEAD`; `git diff --check origin/main...HEAD`; `node scripts/test-projects.mjs src/auto-reply/reply/pending-final-delivery.test.ts src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts src/logging/diagnostic-session-attention.test.ts src/infra/heartbeat-runner.model-override.test.ts -- --reporter=verbose`; `pnpm check:test-types`; `pnpm build`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Copied terminal output from the exact-head local OpenClaw setup:
  ```text
  $ git rev-parse HEAD
  4ff5e4d2cb24f936f84fd868be70e4c53e2629ea

  $ git diff --check origin/main...HEAD
  # exit 0

  $ node scripts/test-projects.mjs src/auto-reply/reply/pending-final-delivery.test.ts src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts src/logging/diagnostic-session-attention.test.ts src/infra/heartbeat-runner.model-override.test.ts -- --reporter=verbose
  [test] passed 3 Vitest shards in 16.26s

  $ pnpm check:test-types
  $ pnpm tsgo:test
  $ pnpm tsgo:core:test && pnpm tsgo:extensions:test
  # exit 0

  $ pnpm build
  [build-all] phase timings: total 907.9s; slowest tsdown 885.9s; write-cli-startup-metadata 11.7s; build:plugin-sdk:dts (cached) 2.43s; ui:build 2.02s; plugins:assets:build 1.75s; runtime-postbuild 1.52s; plugins:assets:copy 581ms; check-cli-bootstrap-imports 465ms; write-plugin-sdk-entry-dts (cached) 461ms; check-plugin-sdk-exports 408ms; write-cli-compat 142ms; write-build-info 130ms; copy-hook-metadata 118ms; build-stamp 106ms; runtime-postbuild-stamp 104ms; copy-export-html-templates (cached) 8ms
  # exit 0
  ```
- Observed result after fix: Exact-head local validation passed. Focused replay/route-safety, diagnostics, heartbeat light-context coverage, and the full dispatch shard passed; test typecheck passed after adding the session-store fixture token fields; full build completed successfully before the final test-only mock export patch.
- What was not tested: No production deployment, gateway restart, live Slack delivery replay, live session-store mutation, or live heartbeat run was performed.
- Proof limitations or environment constraints: This PR intentionally stops at code + local exact-head validation. The Contabo evidence was gathered read-only; applying the behavior to the live incident would require a separate approved deploy/restart path.
- Before evidence (optional but encouraged): Read-only Contabo pass showed `agent:main:slack:direct:u039p2yjr29` still had `pendingFinalDelivery=true` after generated final output, while the `mc-gateway...:main` lane had an estimated `2,530,988` prompt tokens against a `1,000,000` budget and prior `context_length_exceeded` during compaction.

## Tests and validation

Which commands did you run?

- `git diff --check origin/main...HEAD`
- `node scripts/test-projects.mjs src/auto-reply/reply/pending-final-delivery.test.ts src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts src/logging/diagnostic-session-attention.test.ts src/infra/heartbeat-runner.model-override.test.ts -- --reporter=verbose`
- `pnpm check:test-types`
- `pnpm build`

What regression coverage was added or updated?

- Added same-route pending-final replay checks, route mismatch non-replay coverage, pending final clearing coverage, diagnostic attention classification coverage, and huge heartbeat session lightweight-context coverage.

What failed before this fix, if known?

- CI `check-test-types` initially failed because the shared heartbeat test fixture type did not include the newly seeded `totalTokens` fields. Fixed in this head.
- Real behavior proof initially failed because this external fork PR body did not include the required proof section. Added here.

If no test was added, why not?

- Tests were added/updated.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. A stalled pending final can now be replayed to the exact same route before new model work.

Did config, environment, or migration behavior change? (`Yes/No`)

No config/env/migration shape change. Heartbeat runtime now auto-selects lightweight bootstrap context for huge sessions unless explicitly disabled.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No auth/secrets/tool execution change. Network/send behavior changes only for same-route pending final replay after existing send-policy and suppression checks.

What is the highest-risk area?

Duplicate or wrong-route final delivery.

How is that risk mitigated?

Replay is gated by exact channel/target/account/thread context matching, send-policy/suppression checks, sanitized non-empty text, and pending state is cleared only after a successful final dispatch.