### PR TITLE
fix(agents): preserve ImageContent.data from transcript redaction

### DIFF
--- a/src/agents/transcript-redact.test.ts
+++ b/src/agents/transcript-redact.test.ts
@@ -406,4 +406,57 @@ describe("redactTranscriptMessage", () => {
     } as unknown as AgentMessage;
     expect(() => redactTranscriptMessage(msg, cfg("tools"))).not.toThrow();
   });
+
+  it("preserves image content data field containing token-like sequences", () => {
+    // Base64 image payloads can contain sequences matching credential patterns
+    // (e.g. AKID<10+> for Alibaba Cloud keys). Redacting corrupts the bytes and
+    // permanently breaks provider replay for every subsequent session turn.
+    const imageData = "iVBORw0KGgoAAAANSUhEUgAKIDxyz123456789abcdefghijkl";
+    const msg = {
+      role: "user",
+      content: [{ type: "image", data: imageData, mimeType: "image/png" }],
+    } as unknown as AgentMessage;
+    const result = redactTranscriptMessage(msg, cfg("tools"));
+    const block = (
+      msgContent(result) as Array<{ type: string; data: string; mimeType: string }>
+    )[0];
+    expect(block.data).toBe(imageData);
+    expect(block.mimeType).toBe("image/png");
+  });
+
+  it("still redacts non-image data string fields containing token patterns", () => {
+    const msg = {
+      role: "toolResult",
+      toolCallId: "call_1",
+      toolName: "check",
+      content: [{ type: "text", text: "ok" }],
+      details: { data: "AKIDxyz123456789abcdefghijkl" },
+      isError: false,
+      timestamp: Date.now(),
+    } as unknown as AgentMessage;
+    const result = redactTranscriptMessage(msg, cfg("tools")) as unknown as {
+      details: { data: string };
+    };
+    expect(result.details.data).not.toBe("AKIDxyz123456789abcdefghijkl");
+    expect(result.details.data).toContain("…");
+  });
+
+  it("still redacts data on image-typed objects without a valid mimeType", () => {
+    // An arbitrary tool payload shaped { type:"image", data:"credential" }
+    // without a confirming image/* mimeType must not escape redaction.
+    const msg = {
+      role: "toolResult",
+      toolCallId: "call_1",
+      toolName: "check",
+      content: [{ type: "text", text: "ok" }],
+      details: { type: "image", data: "AKIDxyz123456789abcdefghijkl" },
+      isError: false,
+      timestamp: Date.now(),
+    } as unknown as AgentMessage;
+    const result = redactTranscriptMessage(msg, cfg("tools")) as unknown as {
+      details: { data: string };
+    };
+    expect(result.details.data).not.toBe("AKIDxyz123456789abcdefghijkl");
+    expect(result.details.data).toContain("…");
+  });
 });

--- a/src/agents/transcript-redact.ts
+++ b/src/agents/transcript-redact.ts
@@ -98,6 +98,18 @@ function redactTranscriptStructuredValue(
   const source = value;
   let next: Record<string, unknown> | null = null;
   for (const [key, item] of Object.entries(source)) {
+    // ImageContent.data is opaque base64; redacting it corrupts the bytes and
+    // breaks provider replay. Require an image/* mimeType so arbitrary tool
+    // payloads shaped { type:"image", data:"credential" } are still redacted.
+    if (
+      key === "data" &&
+      source["type"] === "image" &&
+      typeof item === "string" &&
+      typeof source["mimeType"] === "string" &&
+      source["mimeType"].toLowerCase().startsWith("image/")
+    ) {
+      continue;
+    }
     const redacted = redactTranscriptStructuredValue(item, cfg, key, seen);
     if (redacted === item) {
       continue;


### PR DESCRIPTION
### Summary

- **Problem**: Issue #90760 reports that sessions containing user image blocks become permanently broken after the first message — every subsequent turn fails with a provider 422 because the persisted transcript carries a corrupted image payload.
- **Root cause**: `redactTranscriptStructuredValue` in `src/agents/transcript-redact.ts` recursively walks every string field in persisted agent messages and passes each one through `redactSensitiveFieldValue`. `ImageContent.data` is opaque base64; long base64 payloads can naturally contain sequences matching credential patterns (e.g., `AKID[A-Za-z0-9]{10+}` — Alibaba Cloud AccessKeyId prefix, `src/logging/redact.ts:93`). When matched, the redactor inserts a U+2026 ellipsis marker, corrupting the bytes. The damaged field is then written to the session JSONL by `appendSessionTranscriptMessageLocked` (`src/config/sessions/transcript-append.ts:354`) and replayed verbatim to the provider on every subsequent turn, causing an unrecoverable 422.
- **Fix**: In the object-field iterator of `redactTranscriptStructuredValue`, skip the `data` field when the parent object satisfies both `source.type === "image"` and `source.mimeType.toLowerCase().startsWith("image/")`. The lowercase normalisation follows the existing `hasImageMime` helper in `payload-redaction.ts` and handles providers that capitalise MIME types (e.g. `"Image/JPEG"`). This avoids exempting arbitrary `{ type:"image", data:"credential" }` tool-result detail payloads that lack a confirming MIME type.
- **What changed**:
  - `src/agents/transcript-redact.ts` — guard in the object-field iterator inside `redactTranscriptStructuredValue`: skips `data` on `type:"image"` blocks with an `image/*` MIME type (checked case-insensitively via `.toLowerCase()`).
  - `src/agents/transcript-redact.test.ts` — three new regression tests: image data preserved when containing AKID-like token sequence; non-image `data` string field still redacted; `type:"image"` object without `image/*` mimeType still redacted.
- **What did NOT change (scope boundary)**:
  - The `redactSensitiveFieldValue` call for all other fields (including `mimeType`, `type`, tool arguments, thinking blocks) is unchanged.
  - Config surface unchanged. Plugin surface unchanged. Gateway protocol unchanged.

### Reproduction

1. Send a user message with `content: [{ type: "image", data: <base64>, mimeType: "image/jpeg" }]` where the base64 payload contains a sequence matching `AKID[A-Za-z0-9]{10,}`.
2. Observe session JSONL: `data` field now contains `AKID…` with U+2026 marker — the bytes are corrupted on disk.
3. Send any follow-up message.
4. **Before this PR**: provider rejects the replayed transcript with 422; every turn fails identically; the session is unrecoverable without deleting the JSONL file.
5. **After this PR**: `data` field is written verbatim; provider accepts the replay; session continues normally.

### Real behavior proof

**Behavior addressed (#90760)**: after a user message with an image block whose base64 data contains an AKID-like sequence, the transcript JSONL `data` field is no longer corrupted; subsequent turns succeed.

**Real environment tested (Linux, Node 22 — Vitest against the production `redactTranscriptStructuredValue`, `redactSensitiveFieldValue`, and `getDefaultRedactPatterns` paths with no mocks on the redaction layer)**:

**Exact steps or command run after this patch**:
```
node scripts/run-vitest.mjs src/agents/transcript-redact.test.ts
```

**Evidence after fix**:
```
Test Files  1 passed (1)
     Tests  23 passed (23)
```

The three new cases cover: `preserves image content data field containing token-like sequences` (positive — AKID sequence preserved), `still redacts non-image data string fields containing token patterns` (negative — non-image data still redacted), `still redacts data on image-typed objects without a valid mimeType` (boundary — tool payload without image/* MIME still redacted).

**Observed result after fix**: `block.data` equals the original base64 string exactly; the image block's `mimeType` is still processed normally; non-image `data` string fields and `type:"image"` objects without `image/*` mimeType are still fully redacted by the existing path.

**What was not tested**: live provider round-trip with a real JPEG/PNG whose base64 encoding contains an AKID-like or similar prefix sequence. The redaction path is covered deterministically; a full gateway round-trip was not driven.

**Repro confirmation**: the `preserves image content data field` test fails on an unpatched tree (data becomes `iVBORw0KGgoAAAANS…ijkl` with U+2026) and passes with the fix, so the test covers the exact production change.

### Risk / Mitigation

- **Risk**: Legitimate credential in a `{ type:"image", mimeType:"image/jpeg", data:"credential" }` block could escape redaction. **Mitigation**: `ImageContent.data` is defined as base64-encoded image bytes (`packages/llm-core/src/types.ts:246`), not a credential field; the mimeType guard additionally rejects any object without a confirmed `image/*` type, matching the precedent in `payload-redaction.ts`.
- **Risk**: Case-insensitive MIME check could widen the exemption. **Mitigation**: `.toLowerCase().startsWith("image/")` only affects the exemption gate — it does not change what gets redacted when the gate is not met. The check mirrors `hasImageMime` in `payload-redaction.ts` exactly.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] agents

### Linked Issue/PR

Fixes #90760