### PR TITLE
fix(imessage): gate split-send coalescing on imsg metadata

### DIFF
--- a/docs/channels/imessage.md
+++ b/docs/channels/imessage.md
@@ -713,14 +713,16 @@ The two rows arrive at OpenClaw ~0.8-2.0 s apart on most setups. Without coalesc
 
 ### Scenarios and what the agent sees
 
-| User composes                                                      | `chat.db` produces                  | Flag off (default)                      | Flag on + 2500 ms window                         |
+The "Flag on" column shows behavior on an `imsg` build that emits `balloon_bundle_id`. On older `imsg` builds that emit no balloon metadata at all, the rows below marked "Two turns" / "N turns" instead fall back to a legacy merge (one turn): OpenClaw cannot structurally tell a split-send from separate sends, so it preserves the pre-metadata merge. Precise separation activates once the build emits balloon metadata.
+
+| User composes                                                      | `chat.db` produces                  | Flag off (default)                      | Flag on + window (imsg emits balloon metadata)   |
 | ------------------------------------------------------------------ | ----------------------------------- | --------------------------------------- | ------------------------------------------------ |
 | `Dump https://example.com` (one send)                              | 2 rows ~1 s apart                   | Two agent turns: "Dump" alone, then URL | One turn: merged text `Dump https://example.com` |
-| `Save this 📎image.jpg caption` (attachment + text)                | 2 rows without URL balloon metadata | Two turns                               | Two turns                                        |
+| `Save this 📎image.jpg caption` (attachment + text)                | 2 rows without URL balloon metadata | Two turns                               | Two turns (legacy merge on metadata-less builds) |
 | `/status` (standalone command)                                     | 1 row                               | Instant dispatch                        | **Wait up to window, then dispatch**             |
 | URL pasted alone                                                   | 1 row                               | Instant dispatch                        | Wait up to window, then dispatch                 |
 | Text + URL sent as two deliberate separate messages, minutes apart | 2 rows outside window               | Two turns                               | Two turns (window expires between them)          |
-| Rapid flood (>10 small DMs inside window)                          | N rows without URL balloon metadata | N turns                                 | N turns after the debounce window                |
+| Rapid flood (>10 small DMs inside window)                          | N rows without URL balloon metadata | N turns                                 | N turns (legacy merge on metadata-less builds)   |
 | Two people typing in a group chat                                  | N rows from M senders               | M+ turns (one per sender bucket)        | M+ turns — group chats are not coalesced         |
 
 ## Catching up after gateway downtime

--- a/docs/channels/imessage.md
+++ b/docs/channels/imessage.md
@@ -654,14 +654,14 @@ When a user types a command and a URL together — e.g. `Dump https://example.co
 
 The two rows arrive at OpenClaw ~0.8-2.0 s apart on most setups. Without coalescing, the agent receives the command alone on turn 1, replies (often "send me the URL"), and only sees the URL on turn 2 — at which point the command context is already lost. This is Apple's send pipeline, not anything OpenClaw or `imsg` introduces.
 
-`channels.imessage.coalesceSameSenderDms` opts a DM into merging consecutive same-sender rows into a single agent turn. Group chats continue to dispatch per-message so multi-user turn structure is preserved.
+`channels.imessage.coalesceSameSenderDms` opts a DM into buffering consecutive same-sender rows, but OpenClaw only merges a bucket when `imsg` exposes the structural URL-preview marker `balloon_bundle_id: "com.apple.messages.URLBalloonProvider"` on one of the source rows. Buckets without that marker flush as separate agent turns, so older `imsg` builds and ordinary rapid DMs do not merge based on text shape. Group chats continue to dispatch per-message so multi-user turn structure is preserved.
 
 <Tabs>
   <Tab title="When to enable">
     Enable when:
 
     - You ship skills that expect `command + payload` in one message (dump, paste, save, queue, etc.).
-    - Your users paste URLs, images, or long content alongside commands.
+    - Your users paste URLs alongside commands.
     - You can accept the added DM turn latency (see below).
 
     Leave disabled when:
@@ -702,7 +702,8 @@ The two rows arrive at OpenClaw ~0.8-2.0 s apart on most setups. Without coalesc
 
   </Tab>
   <Tab title="Trade-offs">
-    - **Added latency for DM messages.** With the flag on, every DM (including standalone control commands and single-text follow-ups) waits up to the debounce window before dispatching, in case a payload row is coming. Group-chat messages keep instant dispatch.
+    - **Requires current `imsg` payload metadata.** Split-send merging only activates when the URL row includes `balloon_bundle_id`. If the installed `imsg` build does not expose that field, buffered DMs flush separately after the window instead of being guessed from short text or URL shape.
+    - **Added latency for DM messages.** With the flag on, every DM (including standalone control commands and single-text follow-ups) waits up to the debounce window before dispatching, in case a URL-preview row is coming. Group-chat messages keep instant dispatch.
     - **Merged output is bounded.** Merged text caps at 4000 chars with an explicit `…[truncated]` marker; attachments cap at 20; source entries cap at 10 (first-plus-latest retained beyond that). Every source GUID is tracked in `coalescedMessageGuids` for downstream telemetry.
     - **DM-only.** Group chats fall through to per-message dispatch so the bot stays responsive when multiple people are typing.
     - **Opt-in, per-channel.** Other channels (Telegram, WhatsApp, Slack, …) are unaffected. Legacy BlueBubbles configs that set `channels.bluebubbles.coalesceSameSenderDms` should migrate that value to `channels.imessage.coalesceSameSenderDms`.
@@ -712,15 +713,15 @@ The two rows arrive at OpenClaw ~0.8-2.0 s apart on most setups. Without coalesc
 
 ### Scenarios and what the agent sees
 
-| User composes                                                      | `chat.db` produces    | Flag off (default)                      | Flag on + 2500 ms window                                                |
-| ------------------------------------------------------------------ | --------------------- | --------------------------------------- | ----------------------------------------------------------------------- |
-| `Dump https://example.com` (one send)                              | 2 rows ~1 s apart     | Two agent turns: "Dump" alone, then URL | One turn: merged text `Dump https://example.com`                        |
-| `Save this 📎image.jpg caption` (attachment + text)                | 2 rows                | Two turns (attachment dropped on merge) | One turn: text + image preserved                                        |
-| `/status` (standalone command)                                     | 1 row                 | Instant dispatch                        | **Wait up to window, then dispatch**                                    |
-| URL pasted alone                                                   | 1 row                 | Instant dispatch                        | Instant dispatch (only one entry in bucket)                             |
-| Text + URL sent as two deliberate separate messages, minutes apart | 2 rows outside window | Two turns                               | Two turns (window expires between them)                                 |
-| Rapid flood (>10 small DMs inside window)                          | N rows                | N turns                                 | One turn, bounded output (first + latest, text/attachment caps applied) |
-| Two people typing in a group chat                                  | N rows from M senders | M+ turns (one per sender bucket)        | M+ turns — group chats are not coalesced                                |
+| User composes                                                      | `chat.db` produces                  | Flag off (default)                      | Flag on + 2500 ms window                         |
+| ------------------------------------------------------------------ | ----------------------------------- | --------------------------------------- | ------------------------------------------------ |
+| `Dump https://example.com` (one send)                              | 2 rows ~1 s apart                   | Two agent turns: "Dump" alone, then URL | One turn: merged text `Dump https://example.com` |
+| `Save this 📎image.jpg caption` (attachment + text)                | 2 rows without URL balloon metadata | Two turns                               | Two turns                                        |
+| `/status` (standalone command)                                     | 1 row                               | Instant dispatch                        | **Wait up to window, then dispatch**             |
+| URL pasted alone                                                   | 1 row                               | Instant dispatch                        | Wait up to window, then dispatch                 |
+| Text + URL sent as two deliberate separate messages, minutes apart | 2 rows outside window               | Two turns                               | Two turns (window expires between them)          |
+| Rapid flood (>10 small DMs inside window)                          | N rows without URL balloon metadata | N turns                                 | N turns after the debounce window                |
+| Two people typing in a group chat                                  | N rows from M senders               | M+ turns (one per sender bucket)        | M+ turns — group chats are not coalesced         |
 
 ## Catching up after gateway downtime
 

--- a/docs/channels/imessage.md
+++ b/docs/channels/imessage.md
@@ -654,7 +654,7 @@ When a user types a command and a URL together — e.g. `Dump https://example.co
 
 The two rows arrive at OpenClaw ~0.8-2.0 s apart on most setups. Without coalescing, the agent receives the command alone on turn 1, replies (often "send me the URL"), and only sees the URL on turn 2 — at which point the command context is already lost. This is Apple's send pipeline, not anything OpenClaw or `imsg` introduces.
 
-`channels.imessage.coalesceSameSenderDms` opts a DM into buffering consecutive same-sender rows, but OpenClaw only merges a bucket when `imsg` exposes the structural URL-preview marker `balloon_bundle_id: "com.apple.messages.URLBalloonProvider"` on one of the source rows. Buckets without that marker flush as separate agent turns, so older `imsg` builds and ordinary rapid DMs do not merge based on text shape. Group chats continue to dispatch per-message so multi-user turn structure is preserved.
+`channels.imessage.coalesceSameSenderDms` opts a DM into buffering consecutive same-sender rows. When `imsg` exposes the structural URL-preview marker `balloon_bundle_id: "com.apple.messages.URLBalloonProvider"` on one of the source rows, OpenClaw merges only that real split-send and keeps any other buffered rows as separate turns. On older `imsg` builds that emit no balloon metadata at all, OpenClaw cannot tell a split-send from separate sends, so it falls back to merging the bucket. That preserves the pre-metadata behavior rather than regressing `Dump <url>` split-sends into two turns. Group chats continue to dispatch per-message so multi-user turn structure is preserved.
 
 <Tabs>
   <Tab title="When to enable">
@@ -702,7 +702,7 @@ The two rows arrive at OpenClaw ~0.8-2.0 s apart on most setups. Without coalesc
 
   </Tab>
   <Tab title="Trade-offs">
-    - **Requires current `imsg` payload metadata.** Split-send merging only activates when the URL row includes `balloon_bundle_id`. If the installed `imsg` build does not expose that field, buffered DMs flush separately after the window instead of being guessed from short text or URL shape.
+    - **Precise merging needs current `imsg` payload metadata.** When the URL row includes `balloon_bundle_id`, only that real split-send merges and other buffered rows stay separate. On older `imsg` builds that expose no balloon metadata, OpenClaw falls back to merging the buffered bucket so `Dump <url>` split-sends are not regressed into two turns (interim back-compat, removed once `imsg` coalesces split-sends upstream).
     - **Added latency for DM messages.** With the flag on, every DM (including standalone control commands and single-text follow-ups) waits up to the debounce window before dispatching, in case a URL-preview row is coming. Group-chat messages keep instant dispatch.
     - **Merged output is bounded.** Merged text caps at 4000 chars with an explicit `…[truncated]` marker; attachments cap at 20; source entries cap at 10 (first-plus-latest retained beyond that). Every source GUID is tracked in `coalescedMessageGuids` for downstream telemetry.
     - **DM-only.** Group chats fall through to per-message dispatch so the bot stays responsive when multiple people are typing.

--- a/extensions/imessage/src/monitor.last-route.test.ts
+++ b/extensions/imessage/src/monitor.last-route.test.ts
@@ -1107,7 +1107,12 @@ describe("iMessage monitor last-route updates", () => {
     });
   });
 
-  it("does not merge coalesce buckets without imsg URL balloon metadata", async () => {
+  it("legacy-merges coalesce buckets when imsg emits no balloon metadata (older builds)", async () => {
+    // Back-compat: older imsg builds emit no balloon_bundle_id, so a Dump + URL
+    // split-send arrives as two fieldless rows. We cannot structurally tell that
+    // apart from separate sends, so we preserve the pre-metadata merge rather
+    // than regress split-send users to two turns. Removed once imsg coalesces
+    // upstream (openclaw/imsg#141, tracked by #91243).
     debouncerControl.holdEntries = true;
 
     let onNotification: ((message: { method: string; params: unknown }) => void) | undefined;
@@ -1173,11 +1178,10 @@ describe("iMessage monitor last-route updates", () => {
       runtime: { error: vi.fn(), exit: vi.fn(), log: vi.fn() },
     });
 
-    expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(2);
-    expect(dispatchInboundMessageMock.mock.calls[0]?.[0].ctx.Body).toContain(": Dump");
-    expect(dispatchInboundMessageMock.mock.calls[1]?.[0].ctx.Body).toContain(
-      ": https://example.com",
-    );
+    expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+    const mergedBody = dispatchInboundMessageMock.mock.calls[0]?.[0].ctx.Body ?? "";
+    expect(mergedBody).toContain("Dump");
+    expect(mergedBody).toContain("https://example.com");
   });
 
   it("merges coalesce buckets when imsg marks the URL balloon row structurally", async () => {

--- a/extensions/imessage/src/monitor.last-route.test.ts
+++ b/extensions/imessage/src/monitor.last-route.test.ts
@@ -1053,6 +1053,7 @@ describe("iMessage monitor last-route updates", () => {
             id: 78,
             guid: "LIVE-GUID-78",
             text: "https://example.com",
+            balloon_bundle_id: "com.apple.messages.URLBalloonProvider",
             created_at: "2026-05-22T15:30:01.000Z",
           },
         ]) {
@@ -1104,5 +1105,151 @@ describe("iMessage monitor last-route updates", () => {
     await vi.waitFor(async () => {
       expect((await loadIMessageCatchupCursor("default"))?.lastSeenRowid).toBe(78);
     });
+  });
+
+  it("does not merge coalesce buckets without imsg URL balloon metadata", async () => {
+    debouncerControl.holdEntries = true;
+
+    let onNotification: ((message: { method: string; params: unknown }) => void) | undefined;
+    const client = {
+      request: vi.fn(async (method: string) => {
+        if (method === "watch.subscribe") {
+          return { subscription: 1 };
+        }
+        throw new Error(`unexpected imsg method ${method}`);
+      }),
+      waitForClose: vi.fn(async () => {
+        for (const row of [
+          { id: 91, guid: "LIVE-GUID-91", text: "Dump", created_at: "2026-05-22T15:30:00.000Z" },
+          {
+            id: 92,
+            guid: "LIVE-GUID-92",
+            text: "https://example.com",
+            created_at: "2026-05-22T15:30:01.000Z",
+          },
+        ]) {
+          onNotification?.({
+            method: "message",
+            params: {
+              message: {
+                ...row,
+                chat_id: 123,
+                sender: "+15550001111",
+                is_from_me: false,
+                is_group: false,
+              },
+            },
+          });
+        }
+        await vi.waitFor(() => {
+          expect(debouncerControl.flush).toBeDefined();
+        });
+        await debouncerControl.flush?.();
+        await Promise.resolve();
+      }),
+      stop: vi.fn(async () => {}),
+    };
+    createIMessageRpcClientMock.mockImplementation(async (params) => {
+      if (!params?.onNotification) {
+        throw new Error("expected iMessage notification handler");
+      }
+      onNotification = params.onNotification;
+      return client as never;
+    });
+
+    await monitorIMessageProvider({
+      config: {
+        channels: {
+          imessage: {
+            coalesceSameSenderDms: true,
+            dmPolicy: "allowlist",
+            allowFrom: ["+15550001111"],
+            sendReadReceipts: false,
+          },
+        },
+        messages: { inbound: { debounceMs: 2500 } },
+        session: { mainKey: "main" },
+      } as never,
+      runtime: { error: vi.fn(), exit: vi.fn(), log: vi.fn() },
+    });
+
+    expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(2);
+    expect(dispatchInboundMessageMock.mock.calls[0]?.[0].ctx.Body).toContain(": Dump");
+    expect(dispatchInboundMessageMock.mock.calls[1]?.[0].ctx.Body).toContain(
+      ": https://example.com",
+    );
+  });
+
+  it("merges coalesce buckets when imsg marks the URL balloon row structurally", async () => {
+    debouncerControl.holdEntries = true;
+
+    let onNotification: ((message: { method: string; params: unknown }) => void) | undefined;
+    const client = {
+      request: vi.fn(async (method: string) => {
+        if (method === "watch.subscribe") {
+          return { subscription: 1 };
+        }
+        throw new Error(`unexpected imsg method ${method}`);
+      }),
+      waitForClose: vi.fn(async () => {
+        for (const row of [
+          { id: 93, guid: "LIVE-GUID-93", text: "Dump", created_at: "2026-05-22T15:30:00.000Z" },
+          {
+            id: 94,
+            guid: "LIVE-GUID-94",
+            text: "https://example.com",
+            balloon_bundle_id: "com.apple.messages.URLBalloonProvider",
+            created_at: "2026-05-22T15:30:01.000Z",
+          },
+        ]) {
+          onNotification?.({
+            method: "message",
+            params: {
+              message: {
+                ...row,
+                chat_id: 123,
+                sender: "+15550001111",
+                is_from_me: false,
+                is_group: false,
+              },
+            },
+          });
+        }
+        await vi.waitFor(() => {
+          expect(debouncerControl.flush).toBeDefined();
+        });
+        await debouncerControl.flush?.();
+        await Promise.resolve();
+      }),
+      stop: vi.fn(async () => {}),
+    };
+    createIMessageRpcClientMock.mockImplementation(async (params) => {
+      if (!params?.onNotification) {
+        throw new Error("expected iMessage notification handler");
+      }
+      onNotification = params.onNotification;
+      return client as never;
+    });
+
+    await monitorIMessageProvider({
+      config: {
+        channels: {
+          imessage: {
+            coalesceSameSenderDms: true,
+            dmPolicy: "allowlist",
+            allowFrom: ["+15550001111"],
+            sendReadReceipts: false,
+          },
+        },
+        messages: { inbound: { debounceMs: 2500 } },
+        session: { mainKey: "main" },
+      } as never,
+      runtime: { error: vi.fn(), exit: vi.fn(), log: vi.fn() },
+    });
+
+    expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+    expect(dispatchInboundMessageMock.mock.calls[0]?.[0].ctx.Body).toContain(
+      "Dump https://example.com",
+    );
   });
 });

--- a/extensions/imessage/src/monitor/coalesce.test.ts
+++ b/extensions/imessage/src/monitor/coalesce.test.ts
@@ -2,9 +2,12 @@
 import { describe, expect, it } from "vitest";
 import {
   combineIMessagePayloads,
+  hasIMessageUrlBalloonBundleID,
+  IMESSAGE_URL_BALLOON_BUNDLE_ID,
   MAX_COALESCED_ATTACHMENTS,
   MAX_COALESCED_ENTRIES,
   MAX_COALESCED_TEXT_CHARS,
+  shouldCombineIMessagePayloadBucket,
 } from "./coalesce.js";
 import type { IMessagePayload } from "./types.js";
 
@@ -21,6 +24,19 @@ const makePayload = (overrides: Partial<IMessagePayload> = {}): IMessagePayload 
 });
 
 describe("combineIMessagePayloads", () => {
+  it("recognizes URL balloon rows from imsg structural metadata", () => {
+    const text = makePayload({ text: "Dump" });
+    const balloon = makePayload({
+      text: "https://example.com/article",
+      balloon_bundle_id: IMESSAGE_URL_BALLOON_BUNDLE_ID,
+    });
+
+    expect(hasIMessageUrlBalloonBundleID(text)).toBe(false);
+    expect(hasIMessageUrlBalloonBundleID(balloon)).toBe(true);
+    expect(shouldCombineIMessagePayloadBucket([text, balloon])).toBe(true);
+    expect(shouldCombineIMessagePayloadBucket([text, makePayload({ text: "ok" })])).toBe(false);
+  });
+
   it("throws on empty input", () => {
     expect(() => combineIMessagePayloads([])).toThrow(
       "combineIMessagePayloads: cannot combine empty payloads",
@@ -44,6 +60,7 @@ describe("combineIMessagePayloads", () => {
     const balloon = makePayload({
       id: 42,
       text: "https://example.com/article",
+      balloon_bundle_id: IMESSAGE_URL_BALLOON_BUNDLE_ID,
       guid: "row-2",
       created_at: "2025-01-01T00:00:01.500Z",
     });

--- a/extensions/imessage/src/monitor/coalesce.test.ts
+++ b/extensions/imessage/src/monitor/coalesce.test.ts
@@ -33,8 +33,41 @@ describe("combineIMessagePayloads", () => {
 
     expect(hasIMessageUrlBalloonBundleID(text)).toBe(false);
     expect(hasIMessageUrlBalloonBundleID(balloon)).toBe(true);
-    expect(shouldCombineIMessagePayloadBucket([text, balloon])).toBe(true);
-    expect(shouldCombineIMessagePayloadBucket([text, makePayload({ text: "ok" })])).toBe(false);
+    // A real URL split-send merges regardless of the session capability latch.
+    expect(shouldCombineIMessagePayloadBucket([text, balloon], false)).toBe(true);
+    expect(shouldCombineIMessagePayloadBucket([text, balloon], true)).toBe(true);
+  });
+
+  it("falls back to a legacy merge when the build has never emitted balloon metadata (older imsg)", () => {
+    // Older imsg builds emit no balloon_bundle_id at all. We cannot tell a URL
+    // split-send from separate sends, so we preserve the pre-metadata merge
+    // rather than regress split-send users to two turns. Back-compat path,
+    // removed once imsg coalesces upstream (openclaw/imsg#141, tracked by #91243).
+    const text = makePayload({ text: "Dump" });
+    const url = makePayload({ text: "https://example.com/article" });
+    expect(shouldCombineIMessagePayloadBucket([text, url], false)).toBe(true);
+  });
+
+  it("keeps a plain bucket separate once the build is known to emit balloon metadata", () => {
+    // Capability latch is true (a prior row this session carried metadata), so a
+    // plain bucket with no URL marker is genuinely not a split-send. imsg omits
+    // the field for plain rows, so this case is indistinguishable per-bucket and
+    // depends on the session-level signal.
+    const a = makePayload({ text: "first" });
+    const b = makePayload({ text: "second" });
+    expect(shouldCombineIMessagePayloadBucket([a, b], true)).toBe(false);
+  });
+
+  it("keeps a bucket separate when imsg exposes balloon metadata in the bucket but no URL marker", () => {
+    // New imsg surfaced balloon metadata in this very bucket, proving this build
+    // emits the field, but the bucket is not a URL split-send. Keep separate even
+    // if the latch had not flipped yet.
+    const text = makePayload({ text: "hi" });
+    const nonUrlBalloon = makePayload({
+      text: "tap to vote",
+      balloon_bundle_id: "com.apple.messages.MSMessageExtensionBalloonPlugin",
+    });
+    expect(shouldCombineIMessagePayloadBucket([text, nonUrlBalloon], false)).toBe(false);
   });
 
   it("throws on empty input", () => {

--- a/extensions/imessage/src/monitor/coalesce.ts
+++ b/extensions/imessage/src/monitor/coalesce.ts
@@ -22,8 +22,53 @@ export function hasIMessageUrlBalloonBundleID(payload: IMessagePayload): boolean
   return payload.balloon_bundle_id === IMESSAGE_URL_BALLOON_BUNDLE_ID;
 }
 
-export function shouldCombineIMessagePayloadBucket(payloads: readonly IMessagePayload[]): boolean {
-  return payloads.some(hasIMessageUrlBalloonBundleID);
+// imsg only emits `balloon_bundle_id` for rows that actually carry a balloon
+// (the nil case is omitted on the wire), so a present, non-empty value is the
+// signal that this build exposes balloon metadata at all.
+export function hasIMessageBalloonMetadata(payload: IMessagePayload): boolean {
+  return typeof payload.balloon_bundle_id === "string" && payload.balloon_bundle_id.length > 0;
+}
+
+/**
+ * Decide whether a debounced same-sender bucket should merge into one turn.
+ *
+ * `buildEmitsBalloonMetadata` is a session-level capability latch: once any
+ * inbound row from this imsg build has carried balloon metadata, absence of a
+ * URL marker is meaningful (the row genuinely is not a URL split-send), so we
+ * can keep ordinary buffered DMs separate. It must be session-scoped, not
+ * per-bucket: imsg omits `balloon_bundle_id` on the wire for non-balloon rows,
+ * so a bucket of plain text rows looks identical on old and new builds.
+ */
+export function shouldCombineIMessagePayloadBucket(
+  payloads: readonly IMessagePayload[],
+  buildEmitsBalloonMetadata: boolean,
+): boolean {
+  // Precise path: a real Apple URL-preview split-send carries the URL-balloon
+  // marker on the preview row — merge it into one turn.
+  if (payloads.some(hasIMessageUrlBalloonBundleID)) {
+    return true;
+  }
+  // Metadata-capable build (observed earlier this session or in this bucket):
+  // the missing URL marker is trustworthy, so keep ordinary buffered DMs as
+  // separate turns. This is the precision the structural gate exists for.
+  if (buildEmitsBalloonMetadata || payloads.some(hasIMessageBalloonMetadata)) {
+    return false;
+  }
+  // Back-compat (remove once imsg coalesces split-sends upstream — see
+  // openclaw/imsg#141, tracked by #91243): a build that has never emitted any
+  // balloon metadata cannot structurally tell a `Dump <url>` split-send from
+  // separate sends. Preserve the pre-metadata merge so split-send users do not
+  // regress to two turns on a released imsg that lacks the field.
+  //
+  // This never merges more than the shipped behavior already did: with
+  // `coalesceSameSenderDms` enabled, `main` debounces every same-sender DM and
+  // merges each multi-entry bucket unconditionally. So an unlatched session
+  // (old build, or a metadata-capable build before its first balloon row) is
+  // identical to today, not a new regression. Flushing these buckets instead
+  // would re-break old-imsg split-sends — the very case this guards. Fully
+  // closing the pre-latch window needs an imsg-advertised capability flag, which
+  // is part of the upstream #141 work.
+  return true;
 }
 
 export type CoalescedIMessagePayload = IMessagePayload & {

--- a/extensions/imessage/src/monitor/coalesce.ts
+++ b/extensions/imessage/src/monitor/coalesce.ts
@@ -16,6 +16,15 @@ import type { IMessagePayload } from "./types.js";
 export const MAX_COALESCED_TEXT_CHARS = 4000;
 export const MAX_COALESCED_ATTACHMENTS = 20;
 export const MAX_COALESCED_ENTRIES = 10;
+export const IMESSAGE_URL_BALLOON_BUNDLE_ID = "com.apple.messages.URLBalloonProvider";
+
+export function hasIMessageUrlBalloonBundleID(payload: IMessagePayload): boolean {
+  return payload.balloon_bundle_id === IMESSAGE_URL_BALLOON_BUNDLE_ID;
+}
+
+export function shouldCombineIMessagePayloadBucket(payloads: readonly IMessagePayload[]): boolean {
+  return payloads.some(hasIMessageUrlBalloonBundleID);
+}
 
 export type CoalescedIMessagePayload = IMessagePayload & {
   /**

--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -66,7 +66,7 @@ import { normalizeIMessageHandle } from "../targets.js";
 import { attachIMessageMonitorAbortHandler } from "./abort-handler.js";
 import { runIMessageCatchup } from "./catchup-bridge.js";
 import { advanceIMessageCatchupCursor, resolveCatchupConfig } from "./catchup.js";
-import { combineIMessagePayloads } from "./coalesce.js";
+import { combineIMessagePayloads, shouldCombineIMessagePayloadBucket } from "./coalesce.js";
 import { repairIMessageConversationAnchor } from "./conversation-repair.js";
 import { createIMessageEchoCachingSend, deliverReplies } from "./deliver.js";
 import { resolveIMessageDmHistoryContext, resolveIMessageDmHistoryLimit } from "./dm-history.js";
@@ -376,12 +376,10 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
           ? `chat:${msg.chat_id}`
           : (msg.chat_guid ?? msg.chat_identifier ?? "unknown");
 
-      // With coalesceSameSenderDms enabled, DMs key on chat:sender so two
-      // distinct user sends — `Dump` followed by a pasted URL that Apple
-      // delivers as a separate row — fall into the same bucket and merge
-      // into one agent turn. Group chats fall through to the legacy key so
-      // shouldDebounce can route them to the instant-dispatch path and
-      // preserve multi-user turn structure.
+      // With coalesceSameSenderDms enabled, DMs key on chat:sender so Apple's
+      // split text row and URL-balloon row land in the same bucket. The flush
+      // path still requires imsg's structural balloon metadata before merging.
+      // Group chats keep the legacy key to preserve multi-user turn structure.
       if (coalesceSameSenderDms && msg.is_group !== true) {
         return `imessage:${accountInfo.accountId}:dm:${conversationId}:${sender}`;
       }
@@ -398,11 +396,10 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
         return false;
       }
 
-      // With coalesceSameSenderDms enabled, debounce DM messages aggressively
-      // (text, media, control commands) so split-sends — `Dump <URL>`,
-      // `Save 📎image caption`, and rapid floods — merge into one agent
-      // turn. Group chats keep instant dispatch so the bot stays responsive
-      // when multiple people are typing.
+      // Hold opt-in DMs long enough for a following URL-balloon row to arrive.
+      // Buckets without imsg's balloon_bundle_id marker flush as separate
+      // messages, so ordinary rapid DMs and older imsg builds are not merged
+      // from text shape alone.
       if (coalesceSameSenderDms) {
         return msg.is_group !== true;
       }
@@ -425,7 +422,15 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
         return;
       }
 
-      const combined = combineIMessagePayloads(entries.map((e) => e.message));
+      const messages = entries.map((e) => e.message);
+      if (!shouldCombineIMessagePayloadBucket(messages)) {
+        for (const message of messages) {
+          await handleMessageNow(message);
+        }
+        return;
+      }
+
+      const combined = combineIMessagePayloads(messages);
       if (shouldLogVerbose()) {
         const text = combined.text ?? "";
         const preview = text.slice(0, 50);

--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -66,7 +66,11 @@ import { normalizeIMessageHandle } from "../targets.js";
 import { attachIMessageMonitorAbortHandler } from "./abort-handler.js";
 import { runIMessageCatchup } from "./catchup-bridge.js";
 import { advanceIMessageCatchupCursor, resolveCatchupConfig } from "./catchup.js";
-import { combineIMessagePayloads, shouldCombineIMessagePayloadBucket } from "./coalesce.js";
+import {
+  combineIMessagePayloads,
+  hasIMessageBalloonMetadata,
+  shouldCombineIMessagePayloadBucket,
+} from "./coalesce.js";
 import { repairIMessageConversationAnchor } from "./conversation-repair.js";
 import { createIMessageEchoCachingSend, deliverReplies } from "./deliver.js";
 import { resolveIMessageDmHistoryContext, resolveIMessageDmHistoryLimit } from "./dm-history.js";
@@ -359,6 +363,12 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
   const debounceMsOverride =
     coalesceSameSenderDms && !hasExplicitInboundDebounce ? 2500 : undefined;
 
+  // Session capability latch: flips true once any inbound row from this imsg
+  // build carries balloon metadata. The coalesce flush gate needs a build-level
+  // (not per-bucket) signal because imsg omits `balloon_bundle_id` for plain
+  // rows, so a bucket of plain text looks identical on old and new builds.
+  let imsgEmitsBalloonMetadata = false;
+
   const { debouncer: inboundDebouncer } = createChannelInboundDebouncer<{
     message: IMessagePayload;
   }>({
@@ -397,9 +407,9 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
       }
 
       // Hold opt-in DMs long enough for a following URL-balloon row to arrive.
-      // Buckets without imsg's balloon_bundle_id marker flush as separate
-      // messages, so ordinary rapid DMs and older imsg builds are not merged
-      // from text shape alone.
+      // The flush gate (shouldCombineIMessagePayloadBucket) decides merge vs.
+      // separate: it merges precisely on imsg's balloon marker, and falls back
+      // to a legacy merge only when the build emits no balloon metadata at all.
       if (coalesceSameSenderDms) {
         return msg.is_group !== true;
       }
@@ -423,7 +433,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
       }
 
       const messages = entries.map((e) => e.message);
-      if (!shouldCombineIMessagePayloadBucket(messages)) {
+      if (!shouldCombineIMessagePayloadBucket(messages, imsgEmitsBalloonMetadata)) {
         for (const message of messages) {
           await handleMessageNow(message);
         }
@@ -1042,6 +1052,11 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
           : typeof raw;
       runtime.error?.(`imessage: dropping malformed RPC message payload (keys=${shape})`);
       return;
+    }
+    // Latch build capability from any row that carries balloon metadata so the
+    // coalesce flush gate can trust a missing URL marker on later plain buckets.
+    if (!imsgEmitsBalloonMetadata && hasIMessageBalloonMetadata(message)) {
+      imsgEmitsBalloonMetadata = true;
     }
     if (
       watchStartupRowidWatermark !== null &&

--- a/extensions/imessage/src/monitor/parse-notification.test.ts
+++ b/extensions/imessage/src/monitor/parse-notification.test.ts
@@ -68,6 +68,28 @@ describe("parseIMessageNotification", () => {
     expect(parsed?.reacted_to_guid).toBe("target-guid");
   });
 
+  it("preserves imsg balloon bundle metadata when present", () => {
+    const parsed = parseIMessageNotification({
+      message: {
+        id: 1,
+        guid: "link-preview-guid",
+        chat_id: 2,
+        sender: "+10000000000",
+        is_from_me: false,
+        text: "https://example.com/article",
+        balloon_bundle_id: "com.apple.messages.URLBalloonProvider",
+        attachments: null,
+        chat_identifier: null,
+        chat_guid: null,
+        chat_name: null,
+        participants: null,
+        is_group: false,
+      },
+    });
+
+    expect(parsed?.balloon_bundle_id).toBe("com.apple.messages.URLBalloonProvider");
+  });
+
   it("accepts iMessage attachment transfer_name and uti metadata", () => {
     const parsed = parseIMessageNotification({
       message: {

--- a/extensions/imessage/src/monitor/parse-notification.ts
+++ b/extensions/imessage/src/monitor/parse-notification.ts
@@ -66,6 +66,7 @@ export function parseIMessageNotification(raw: unknown): IMessagePayload | null 
     !isOptionalNumber(message.chat_id) ||
     !isOptionalString(message.sender) ||
     !isOptionalString(message.destination_caller_id) ||
+    !isOptionalString(message.balloon_bundle_id) ||
     !isOptionalBoolean(message.is_from_me) ||
     !isOptionalString(message.text) ||
     !isOptionalStringOrNumber(message.reply_to_id) ||

--- a/extensions/imessage/src/monitor/types.ts
+++ b/extensions/imessage/src/monitor/types.ts
@@ -17,6 +17,7 @@ export type IMessagePayload = {
   chat_id?: number | null;
   sender?: string | null;
   destination_caller_id?: string | null;
+  balloon_bundle_id?: string | null;
   is_from_me?: boolean | null;
   text?: string | null;
   reply_to_id?: number | string | null;


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- Replaces iMessage split-send merge decisions with the new `imsg` structural URL-balloon metadata from openclaw/imsg#137.
- Preserves `balloon_bundle_id` at the OpenClaw iMessage RPC payload boundary.
- Merges an opt-in coalesce bucket precisely when a source row carries `balloon_bundle_id: "com.apple.messages.URLBalloonProvider"`.
- Keeps a capability-gated back-compat path so existing `coalesceSameSenderDms` users on a released `imsg` (no balloon metadata yet) are not regressed while the dependency rolls out.

How the merge decision works (capability-gated, three-way)

- **URL-balloon marker present** in the bucket: merge it — this is a real Apple URL-preview split-send.
- **Build known to emit balloon metadata** (a session-level capability latch, flipped once any inbound row this session carried `balloon_bundle_id`): a bucket with no URL marker is genuinely not a split-send, so keep the rows as separate turns. This is the precision the structural gate exists for.
- **Build has never emitted balloon metadata** (older `imsg`): we cannot structurally tell a `Dump <url>` split-send from separate sends, so preserve the pre-metadata merge rather than regress split-send users to two turns.

Why a session-level latch instead of a per-bucket check?

- `imsg` omits `balloon_bundle_id` on the wire for non-balloon rows, so a bucket of plain text rows looks identical on old and new builds. Absence of metadata in one bucket does not prove the build lacks the field. The capability signal therefore has to be session-scoped (`monitor-provider.ts`), not inferred per-bucket. (Caught by autoreview — see below.)

Important invariant: this never merges more than the shipped behavior already does. With `coalesceSameSenderDms` enabled, `main` debounces every same-sender DM and merges each multi-entry bucket unconditionally. An unlatched session (older build, or a metadata-capable build before its first balloon row) is therefore identical to today, not a new regression; once capability is observed it merges strictly *less* (more precise).

Why does this matter now?

- The previous OpenClaw workaround guessed from short messages/timing before another row arrived. The corresponding `imsg` PR gives OpenClaw a structural signal instead — and the back-compat path lets this ship ahead of the `imsg` release without regressing anyone.

What is intentionally out of scope?

- No text-shape or URL-shape heuristic. The only fallback is "preserve the existing unconditional merge until the build proves it emits balloon metadata."
- No non-URL attachment split-send merge, because the new `imsg` field only proves URL-preview balloon rows.
- Fully closing the pre-latch window (a metadata-capable session before its first balloon row) needs an `imsg`-advertised capability flag, which is part of the upstream coalescing work (openclaw/imsg#141).

What does success look like?

- URL-balloon buckets merge; on metadata-capable builds non-URL buckets stay separate; on metadata-less builds the existing merge is preserved; docs describe the metadata requirement, the back-compat fallback, and the latency tradeoff.

What should reviewers focus on?

- Whether the capability latch is at the right boundary (`monitor-provider.ts` `handleMessage` ingress) and whether the three-way gate in `coalesce.ts` correctly preserves shipped behavior for metadata-less builds.

## Linked context

Which issue does this close?

Closes #90795

Which issues, PRs, or discussions are related?

- Related openclaw/imsg#137 (the `balloon_bundle_id` metadata this consumes).
- openclaw/imsg#141 — upstream coalescing that makes this client-side path unnecessary.
- #91243 — tracks removing this client-side coalescing (config + debouncer + gate) once `imsg` coalesces upstream, including the `openclaw doctor --fix` migration to drop `coalesceSameSenderDms`.

Was this requested by a maintainer or owner?

Requested by maintainer in chat after closing #90795 in favor of the `imsg` contract fix.

## Real behavior proof (required for external PRs)

- Behavior addressed: iMessage DM split-send coalescing now uses `imsg` `balloon_bundle_id` metadata instead of short-message/string-shape inference, with a capability-gated back-compat path that preserves shipped merge behavior on metadata-less `imsg` builds.
- Real environment tested:
  - **Live end-to-end:** the patched OpenClaw gateway from this PR head (`11c4454ba3`) ran on a real macOS 26.4.1 host, watching the real Messages `chat.db` through a real imsg #137 build (`fix/expose-imessage-balloon-metadata`, `e223709`) that emits `balloon_bundle_id`. A real `Dump <url>` split-send sent from an iPhone (Messages UI) was merged into one agent turn.
  - Local OpenClaw source checkout with the iMessage monitor through mocked `imsg` JSON-RPC notifications; sibling `imsg` source inspected directly for the output-field contract (`balloon_bundle_id` is `String?`, omitted on the wire when nil).
- Exact steps or command run after this patch:
  - `node scripts/run-vitest.mjs extensions/imessage/src/monitor/coalesce.test.ts extensions/imessage/src/monitor/parse-notification.test.ts extensions/imessage/src/monitor.last-route.test.ts`
  - `node scripts/run-oxlint.mjs extensions/imessage/src/monitor/coalesce.ts extensions/imessage/src/monitor/monitor-provider.ts extensions/imessage/src/monitor/coalesce.test.ts`
  - `npx oxfmt --check --threads=1 <changed .ts files>`
  - `pnpm tsgo:extensions && pnpm tsgo:extensions:test`
  - `.agents/skills/autoreview/scripts/autoreview --mode local`
- Evidence after fix: 37 focused Vitest tests passed; oxlint exit 0; oxfmt clean; `tsgo:extensions` and `tsgo:extensions:test` clean.
- Observed result after fix:
  - **Live capture:** real inbound split-send (`text="Dump"` no marker, then the URL with `balloon_bundle_id="com.apple.messages.URLBalloonProvider"` 1s later) → patched gateway logged `[PROOF] MERGED bucket size=2 markers=1 buildCapable=true text="Dump https://www.theverge.com/news/..."` — debounced into one bucket, saw the marker, latch flipped, merged into one turn. (`[PROOF]` was a temporary unconditional log added only on the throwaway host checkout, reverted; host restored to production.) See the live-proof comment.
  - A fieldless `Dump` + URL bucket (metadata-less build) dispatches as one legacy-merged turn — matches shipped `main`, no regression.
  - A bucket where a row carries `balloon_bundle_id: "com.apple.messages.URLBalloonProvider"` dispatches as one merged turn.
  - On a session known to emit balloon metadata, a plain two-row bucket dispatches as two separate turns (the precision win).
- What was not tested: behavior against a *released* `imsg` containing openclaw/imsg#137 (still pre-release) — but the live capture above used a build with the exact #137 read-path, so runtime behavior is identical; on metadata-less released `imsg` the back-compat path preserves shipped `main` (no regression).
- Before evidence: old behavior merged coalesced buckets based on timing/text shape without proving the later row was a URL balloon from `imsg`.

## Tests and validation

Which commands did you run?

- `node scripts/run-vitest.mjs extensions/imessage/src/monitor/coalesce.test.ts extensions/imessage/src/monitor/parse-notification.test.ts extensions/imessage/src/monitor.last-route.test.ts`
- `node scripts/run-oxlint.mjs <changed monitor .ts files>`
- `npx oxfmt --check --threads=1 <changed .ts files>`
- `pnpm tsgo:extensions && pnpm tsgo:extensions:test`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

What regression coverage was added or updated?

- Parser test for preserving `balloon_bundle_id`.
- Coalesce gate tests for: URL-balloon recognition; legacy merge when the build has never emitted balloon metadata; plain bucket kept separate once the build is known to emit metadata (capability latch); non-URL balloon bucket kept separate.
- Monitor notification-path tests: fieldless bucket legacy-merges into one turn; URL-balloon bucket merges.

Which bot or reviewer comments were addressed?

- Autoreview round 1 (P1): a per-bucket absence check would over-merge plain DMs on metadata-capable builds. Fixed by introducing the session-level capability latch.
- Autoreview round 2 (P2): residual pre-latch transient over-merge. Rejected with a recorded inline invariant — it is identical to shipped `main` behavior (verified `main` merges every multi-entry bucket unconditionally), and the suggested alternative would re-break old-`imsg` split-sends; fully closing it needs the `imsg` capability flag scoped into #141.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. On metadata-capable `imsg` builds, opt-in split-send coalescing becomes precise (only real URL split-sends merge). On metadata-less builds, behavior is unchanged from shipped `main`.

Did config, environment, or migration behavior change? (`Yes/No`)

No config shape or migration change. Existing `channels.imessage.coalesceSameSenderDms` remains the switch. (Its eventual removal + `doctor --fix` migration is tracked in #91243.)

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

The capability latch and the back-compat merge decision. Mis-scoping the latch (per-bucket instead of session) would reintroduce over-merging on new builds.

How is that risk mitigated?

The latch is session-scoped at the message ingress; the gate is unit-tested across all three branches; the back-compat path provably never merges more than shipped `main`, so there is no regression for current users.

## Current review state

What is the next action?

Maintainer review. Safe to land ahead of the `imsg` release because the back-compat path preserves shipped behavior; precision activates automatically once an `imsg` build with openclaw/imsg#137 reaches users.

What is still waiting on author, maintainer, CI, or external proof?

Nothing outstanding: CI is green, and live end-to-end proof against a real imsg #137 build has been captured (see proof comment). Only the imsg #137 *release* remains, which gates real-user activation but not correctness — the back-compat path keeps released-`imsg` behavior identical to shipped `main`.

