### PR TITLE
fix(cli): preserve sessions_yield over MCP

### DIFF
--- a/src/agents/cli-output.ts
+++ b/src/agents/cli-output.ts
@@ -34,6 +34,7 @@ export type CliOutput = {
   messagingToolSentMediaUrls?: string[];
   messagingToolSentTargets?: MessagingToolSend[];
   messagingToolSourceReplyPayloads?: MessagingToolSourceReplyPayload[];
+  yielded?: true;
 };
 
 /** Incremental assistant text emitted while parsing a streaming CLI response. */

--- a/src/agents/cli-runner.reliability.test.ts
+++ b/src/agents/cli-runner.reliability.test.ts
@@ -1687,6 +1687,37 @@ describe("runCliAgent reliability", () => {
     expect(completion.refusal).toBe(false);
   });
 
+  it("marks CLI runs as yielded when bundle MCP records sessions_yield", async () => {
+    const exit = {
+      reason: "exit" as const,
+      exitCode: 0,
+      exitSignal: null,
+      durationMs: 50,
+      stdout: "yield acknowledged",
+      stderr: "",
+      timedOut: false,
+      noOutputTimedOut: false,
+    };
+    supervisorSpawnMock.mockResolvedValueOnce({
+      ...createManagedRun(exit),
+      wait: vi.fn(async () => {
+        const runtime = await import("../gateway/mcp-http.loopback-runtime.js");
+        await runtime.resolveMcpLoopbackYieldHandler("s1")?.("waiting on subagents");
+        return exit;
+      }),
+    });
+
+    const result = await runPreparedCliAgent(buildPreparedContext());
+
+    expect(result.meta.yielded).toBe(true);
+    expect(result.meta.livenessState).toBe("paused");
+    expect(result.meta.stopReason).toBe("end_turn");
+    const completion = requireRecord(result.meta.completion, "completion");
+    expect(completion.finishReason).toBe("end_turn");
+    expect(completion.stopReason).toBe("end_turn");
+    expect(completion.refusal).toBe(false);
+  });
+
   it("seeds fresh CLI sessions from the OpenClaw transcript", async () => {
     supervisorSpawnMock.mockResolvedValueOnce(
       createManagedRun({

--- a/src/agents/cli-runner.reliability.test.ts
+++ b/src/agents/cli-runner.reliability.test.ts
@@ -14,10 +14,12 @@ import { CURRENT_SESSION_VERSION } from "../config/sessions/version.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   markMcpLoopbackRequestClassified,
+  markMcpLoopbackRequestFinished,
   markMcpLoopbackRequestStarted,
   markMcpLoopbackToolCallFinished,
   markMcpLoopbackToolCallStarted,
   recordMcpLoopbackToolCallResult,
+  resolveMcpLoopbackYieldContext,
   updateMcpLoopbackToolCallCapture,
 } from "../gateway/mcp-http.loopback-runtime.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
@@ -1687,35 +1689,39 @@ describe("runCliAgent reliability", () => {
     expect(completion.refusal).toBe(false);
   });
 
-  it("marks CLI runs as yielded when bundle MCP records sessions_yield", async () => {
-    const exit = {
-      reason: "exit" as const,
-      exitCode: 0,
-      exitSignal: null,
-      durationMs: 50,
-      stdout: "yield acknowledged",
-      stderr: "",
-      timedOut: false,
-      noOutputTimedOut: false,
-    };
-    supervisorSpawnMock.mockResolvedValueOnce({
-      ...createManagedRun(exit),
-      wait: vi.fn(async () => {
-        const runtime = await import("../gateway/mcp-http.loopback-runtime.js");
-        runtime.resolveMcpLoopbackYieldHandler("s1")?.("waiting on subagents");
-        return exit;
-      }),
+  it("marks CLI runs as paused after sessions_yield", async () => {
+    supervisorSpawnMock.mockImplementationOnce(async (...args: unknown[]) => {
+      const input = args[0] as Parameters<ReturnType<typeof getProcessSupervisor>["spawn"]>[0];
+      const captureHandle = markMcpLoopbackRequestStarted(input.env?.OPENCLAW_MCP_CLI_CAPTURE_KEY);
+      await resolveMcpLoopbackYieldContext(captureHandle)?.onYield("waiting on subagents");
+      markMcpLoopbackRequestFinished(captureHandle);
+      input.onStdout?.("yield acknowledged");
+      return createManagedRun({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 50,
+        stdout: "",
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      });
     });
+    const context = buildPreparedContext();
+    context.mcpDeliveryCapture = true;
 
-    const result = await runPreparedCliAgent(buildPreparedContext());
+    const result = await runPreparedCliAgent(context);
 
-    expect(result.meta.yielded).toBe(true);
-    expect(result.meta.livenessState).toBe("paused");
-    expect(result.meta.stopReason).toBe("end_turn");
-    const completion = requireRecord(result.meta.completion, "completion");
-    expect(completion.finishReason).toBe("end_turn");
-    expect(completion.stopReason).toBe("end_turn");
-    expect(completion.refusal).toBe(false);
+    expect(result.meta).toMatchObject({
+      yielded: true,
+      livenessState: "paused",
+      stopReason: "end_turn",
+      completion: {
+        finishReason: "end_turn",
+        stopReason: "end_turn",
+        refusal: false,
+      },
+    });
   });
 
   it("seeds fresh CLI sessions from the OpenClaw transcript", async () => {

--- a/src/agents/cli-runner.reliability.test.ts
+++ b/src/agents/cli-runner.reliability.test.ts
@@ -1702,7 +1702,7 @@ describe("runCliAgent reliability", () => {
       ...createManagedRun(exit),
       wait: vi.fn(async () => {
         const runtime = await import("../gateway/mcp-http.loopback-runtime.js");
-        await runtime.resolveMcpLoopbackYieldHandler("s1")?.("waiting on subagents");
+        runtime.resolveMcpLoopbackYieldHandler("s1")?.("waiting on subagents");
         return exit;
       }),
     });

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -5,20 +5,14 @@ import { setReplyPayloadMetadata, type ReplyPayload } from "../auto-reply/reply-
 import { SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import { appendExactAssistantMessageToSessionTranscript } from "../config/sessions/transcript.js";
 import {
-  assertAgentRunLifecycleGenerationCurrent,
-  captureAgentRunLifecycleGeneration,
-  withAgentRunLifecycleGeneration,
-} from "../infra/agent-events.js";
+  clearMcpLoopbackYieldContext,
+  registerMcpLoopbackYieldContext,
+} from "../gateway/mcp-http.loopback-runtime.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { buildAgentHookContextChannelFields } from "../plugins/hook-agent-context.js";
 import { resolveBlockMessage } from "../plugins/hook-decision-types.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
-import type { CliOutput } from "./cli-output.js";
-import {
-  attachCliMessagingDeliveryEvidence,
-  getCliMessagingDeliveryEvidence,
-} from "./cli-runner/delivery-evidence.js";
 import { cliBackendLog, formatCliBackendOutputDigest } from "./cli-runner/log.js";
 import {
   loadCliSessionContextEngineMessages,
@@ -28,7 +22,6 @@ import type { PreparedCliRunContext, RunCliAgentParams } from "./cli-runner/type
 import { claudeCliSessionTranscriptHasContent as claudeCliSessionTranscriptHasContentImpl } from "./command/attempt-execution.helpers.js";
 import { classifyFailoverReason, isFailoverErrorMessage } from "./embedded-agent-helpers.js";
 import type { EmbeddedAgentRunResult } from "./embedded-agent-runner.js";
-import { buildEmbeddedRunPayloads } from "./embedded-agent-runner/run/payloads.js";
 import { FailoverError, isFailoverError, resolveFailoverStatus } from "./failover-error.js";
 import {
   awaitAgentEndSideEffects,
@@ -359,19 +352,7 @@ async function finalizeCliContextEngineTurn(params: {
 }
 
 /** Prepares and runs one CLI-backed agent turn. */
-export function runCliAgent(paramsInput: RunCliAgentParams): Promise<EmbeddedAgentRunResult> {
-  const lifecycleGeneration =
-    paramsInput.lifecycleGeneration ?? captureAgentRunLifecycleGeneration(paramsInput.runId);
-  return withAgentRunLifecycleGeneration(lifecycleGeneration, () =>
-    runCliAgentInternal({
-      ...paramsInput,
-      lifecycleGeneration,
-    }),
-  );
-}
-
-async function runCliAgentInternal(params: RunCliAgentParams): Promise<EmbeddedAgentRunResult> {
-  assertAgentRunLifecycleGenerationCurrent(params.lifecycleGeneration!);
+export async function runCliAgent(params: RunCliAgentParams): Promise<EmbeddedAgentRunResult> {
   // Cron gate must fire before prepareCliRunContext — that call allocates
   // backend resources released only by runPreparedCliAgent's try…finally.
   params.onExecutionStarted?.();
@@ -426,46 +407,19 @@ async function runCliAgentInternal(params: RunCliAgentParams): Promise<EmbeddedA
   }
   const { prepareCliRunContext } = await import("./cli-runner/prepare.runtime.js");
   const context = await prepareCliRunContext(params);
-  let result: EmbeddedAgentRunResult | undefined;
-  let runError: unknown;
   try {
-    result = await runPreparedCliAgent(context);
-  } catch (error) {
-    runError = error;
-  }
-  let cleanupError: unknown;
-  const recordCleanupError = (error: unknown) => {
-    cleanupError ??= error;
-  };
-  if (params.cleanupCliLiveSessionOnRunEnd === true) {
-    try {
+    return await runPreparedCliAgent(context);
+  } finally {
+    if (params.cleanupCliLiveSessionOnRunEnd === true) {
       const { closeClaudeLiveSessionForContext } =
         await import("./cli-runner/claude-live-session.js");
       await closeClaudeLiveSessionForContext(context);
-    } catch (error) {
-      recordCleanupError(error);
     }
-  }
-  if (params.cleanupBundleMcpOnRunEnd === true) {
-    try {
+    if (params.cleanupBundleMcpOnRunEnd === true) {
       const { closeMcpLoopbackServer } = await import("../gateway/mcp-http.js");
       await closeMcpLoopbackServer();
-    } catch (error) {
-      recordCleanupError(error);
     }
   }
-  if (cleanupError) {
-    if (runError || result?.didSendViaMessagingTool === true) {
-      log.warn(`cli run cleanup failed after completion: ${formatErrorMessage(cleanupError)}`);
-    } else {
-      runError =
-        cleanupError instanceof Error ? cleanupError : new Error(formatErrorMessage(cleanupError));
-    }
-  }
-  if (runError) {
-    throw runError instanceof Error ? runError : new Error(formatErrorMessage(runError));
-  }
-  return result as EmbeddedAgentRunResult;
 }
 
 /** Runs an already-prepared CLI agent context through hooks and execution. */
@@ -475,6 +429,7 @@ export async function runPreparedCliAgent(
   const { executePreparedCliRun } = await import("./cli-runner/execute.runtime.js");
   const { params } = context;
   const hookRunner = getGlobalHookRunner();
+  const loopbackYieldContext = registerMcpLoopbackYieldContext(params.sessionId);
   const hasLlmInputHooks = hookRunner?.hasHooks("llm_input") === true;
   const hasLlmOutputHooks = hookRunner?.hasHooks("llm_output") === true;
   const hasAgentEndHooks = hookRunner?.hasHooks("agent_end") === true;
@@ -590,115 +545,6 @@ export async function runPreparedCliAgent(
     },
   });
 
-  let deliveredMessagingSideEffect = false;
-  const buildCliSourceReplyMirrorPayloads = (
-    evidence: Pick<
-      CliOutput,
-      | "didSendViaMessagingTool"
-      | "didDeliverSourceReplyViaMessageTool"
-      | "messagingToolSourceReplyPayloads"
-    >,
-  ): ReplyPayload[] => {
-    return buildEmbeddedRunPayloads({
-      assistantTexts: [],
-      toolMetas: [],
-      lastAssistant: undefined,
-      inlineToolResultsAllowed: false,
-      sessionKey: params.sessionKey ?? "",
-      provider: params.provider,
-      model: context.modelId,
-      didSendViaMessagingTool: evidence.didSendViaMessagingTool,
-      didDeliverSourceReplyViaMessageTool: evidence.didDeliverSourceReplyViaMessageTool,
-      messagingToolSourceReplyPayloads: evidence.messagingToolSourceReplyPayloads,
-      sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
-      agentId: params.agentId,
-      runId: params.runId,
-    });
-  };
-
-  const resolveCliSourceReplyMirror = (
-    evidence: Pick<
-      CliOutput,
-      | "didSendViaMessagingTool"
-      | "didDeliverSourceReplyViaMessageTool"
-      | "messagingToolSourceReplyPayloads"
-    >,
-  ) => {
-    const payloads = buildCliSourceReplyMirrorPayloads(evidence);
-    const delivered =
-      payloads.length > 0 ||
-      (params.sourceReplyDeliveryMode === "message_tool_only" &&
-        evidence.didDeliverSourceReplyViaMessageTool === true);
-    const visibleText =
-      payloads
-        .map((payload) => payload.text?.trim() ?? "")
-        .filter(Boolean)
-        .join("\n\n") || undefined;
-    return { payloads, delivered, visibleText };
-  };
-
-  const buildDeliveredFailureResult = (
-    error: unknown,
-    evidence: NonNullable<ReturnType<typeof getCliMessagingDeliveryEvidence>>,
-  ): EmbeddedAgentRunResult => {
-    const message = formatErrorMessage(error);
-    const { payloads } = resolveCliSourceReplyMirror(evidence);
-    deliveredMessagingSideEffect = true;
-    return {
-      ...(payloads.length > 0 ? { payloads } : {}),
-      meta: {
-        durationMs: Date.now() - context.started,
-        systemPromptReport: context.systemPromptReport,
-        stopReason: "error",
-        executionTrace: {
-          winnerProvider: params.provider,
-          winnerModel: context.modelId,
-          attempts: [
-            {
-              provider: params.provider,
-              model: context.modelId,
-              result: "error",
-              reason: message,
-            },
-          ],
-          fallbackUsed: false,
-          runner: "cli",
-        },
-        requestShaping: {
-          ...(params.thinkLevel ? { thinking: params.thinkLevel } : {}),
-          ...(context.effectiveAuthProfileId ? { authMode: "auth-profile" } : {}),
-        },
-        completion: {
-          finishReason: "error",
-          stopReason: "error",
-          refusal: false,
-        },
-        agentMeta: {
-          sessionId: "",
-          provider: params.provider,
-          model: context.modelId,
-          ...(context.reusableCliSession.sessionId ? { clearCliSessionBinding: true } : {}),
-        },
-      },
-      didSendViaMessagingTool: true,
-      ...(evidence.didDeliverSourceReplyViaMessageTool
-        ? { didDeliverSourceReplyViaMessageTool: true }
-        : {}),
-      ...(evidence.messagingToolSentTexts?.length
-        ? { messagingToolSentTexts: evidence.messagingToolSentTexts }
-        : {}),
-      ...(evidence.messagingToolSentMediaUrls?.length
-        ? { messagingToolSentMediaUrls: evidence.messagingToolSentMediaUrls }
-        : {}),
-      ...(evidence.messagingToolSentTargets?.length
-        ? { messagingToolSentTargets: evidence.messagingToolSentTargets }
-        : {}),
-      ...(evidence.messagingToolSourceReplyPayloads?.length
-        ? { messagingToolSourceReplyPayloads: evidence.messagingToolSourceReplyPayloads }
-        : {}),
-    };
-  };
-
   const persistBlockedBeforeAgentRun = async (block: {
     message: string;
     pluginId: string;
@@ -760,25 +606,15 @@ export async function runPreparedCliAgent(
             },
           };
     const output = await executePreparedCliRun(attemptContext, cliSessionIdToUse);
-    const sourceReplyMirror = resolveCliSourceReplyMirror(output);
-    const assistantText = sourceReplyMirror.delivered
-      ? (sourceReplyMirror.visibleText ?? "")
-      : output.text.trim();
-    if (
-      !assistantText &&
-      !output.didSendViaMessagingTool &&
-      params.allowEmptyAssistantReplyAsSilent !== true
-    ) {
-      throw attachCliMessagingDeliveryEvidence(
-        new FailoverError("CLI backend returned an empty response.", {
-          reason: "empty_response",
-          provider: params.provider,
-          model: context.modelId,
-          sessionId: params.sessionId,
-          lane: params.lane,
-        }),
-        output,
-      );
+    const assistantText = output.text.trim();
+    if (!assistantText && params.allowEmptyAssistantReplyAsSilent !== true) {
+      throw new FailoverError("CLI backend returned an empty response.", {
+        reason: "empty_response",
+        provider: params.provider,
+        model: context.modelId,
+        sessionId: params.sessionId,
+        lane: params.lane,
+      });
     }
     const assistantTexts = assistantText ? [assistantText] : [];
     const lastAssistant =
@@ -815,12 +651,7 @@ export async function runPreparedCliAgent(
         hookRunner,
       });
     }
-    return {
-      output,
-      assistantText,
-      lastAssistant,
-      sourceReplyWasDelivered: sourceReplyMirror.delivered,
-    };
+    return { output, assistantText, lastAssistant };
   };
 
   const buildCliRunResult = (resultParams: {
@@ -831,27 +662,15 @@ export async function runPreparedCliAgent(
   }): EmbeddedAgentRunResult => {
     const text = resultParams.output.text?.trim();
     const rawText = resultParams.output.rawText?.trim();
-    const sourceReplyMirror = resolveCliSourceReplyMirror(resultParams.output);
-    const finalAssistantVisibleText = sourceReplyMirror.delivered
-      ? sourceReplyMirror.visibleText
-      : text;
-    const payloads =
-      sourceReplyMirror.payloads.length > 0
-        ? sourceReplyMirror.payloads
-        : sourceReplyMirror.delivered
-          ? undefined
-          : text
-            ? [
-                resultParams.assistantTranscriptOwned
-                  ? setReplyPayloadMetadata({ text }, { assistantTranscriptOwned: true })
-                  : { text },
-              ]
-            : params.allowEmptyAssistantReplyAsSilent === true
-              ? [{ text: SILENT_REPLY_TOKEN }]
-              : undefined;
-    if (resultParams.output.didSendViaMessagingTool) {
-      deliveredMessagingSideEffect = true;
-    }
+    const payloads = text
+      ? [
+          resultParams.assistantTranscriptOwned
+            ? setReplyPayloadMetadata({ text }, { assistantTranscriptOwned: true })
+            : { text },
+        ]
+      : params.allowEmptyAssistantReplyAsSilent === true
+        ? [{ text: SILENT_REPLY_TOKEN }]
+        : undefined;
     const unflushedCliSessionId =
       resultParams.effectiveCliSessionId && resultParams.bindingFlushOk === false
         ? resultParams.effectiveCliSessionId
@@ -862,6 +681,9 @@ export async function runPreparedCliAgent(
     const agentSessionId = unflushedCliSessionId
       ? ""
       : (resultParams.effectiveCliSessionId ?? params.sessionId ?? "");
+    const yielded = loopbackYieldContext.yielded === true;
+    const stopReason = yielded ? "end_turn" : "completed";
+    const finishReason = yielded ? "end_turn" : "stop";
 
     return {
       payloads,
@@ -870,13 +692,14 @@ export async function runPreparedCliAgent(
         ...(resultParams.output.finalPromptText
           ? { finalPromptText: resultParams.output.finalPromptText }
           : {}),
-        ...(finalAssistantVisibleText || rawText
+        ...(text || rawText
           ? {
-              ...(finalAssistantVisibleText ? { finalAssistantVisibleText } : {}),
+              ...(text ? { finalAssistantVisibleText: text } : {}),
               ...(rawText ? { finalAssistantRawText: rawText } : {}),
             }
           : {}),
         systemPromptReport: context.systemPromptReport,
+        ...(yielded ? { yielded: true, livenessState: "paused" as const, stopReason } : {}),
         executionTrace: {
           winnerProvider: params.provider,
           winnerModel: context.modelId,
@@ -895,8 +718,8 @@ export async function runPreparedCliAgent(
           ...(context.effectiveAuthProfileId ? { authMode: "auth-profile" } : {}),
         },
         completion: {
-          finishReason: "stop",
-          stopReason: "completed",
+          finishReason,
+          stopReason,
           refusal: false,
         },
         agentMeta: {
@@ -917,9 +740,6 @@ export async function runPreparedCliAgent(
                   ...(context.extraSystemPromptHash
                     ? { extraSystemPromptHash: context.extraSystemPromptHash }
                     : {}),
-                  ...(context.messageToolPolicyHash
-                    ? { messageToolPolicyHash: context.messageToolPolicyHash }
-                    : {}),
                   ...(context.promptToolNamesHash
                     ? { promptToolNamesHash: context.promptToolNamesHash }
                     : {}),
@@ -936,26 +756,10 @@ export async function runPreparedCliAgent(
           ...(unflushedCliSessionId ? { clearCliSessionBinding: true } : {}),
         },
       },
-      ...(resultParams.output.didSendViaMessagingTool ? { didSendViaMessagingTool: true } : {}),
-      ...(resultParams.output.didDeliverSourceReplyViaMessageTool
-        ? { didDeliverSourceReplyViaMessageTool: true }
-        : {}),
-      ...(resultParams.output.messagingToolSentTexts?.length
-        ? { messagingToolSentTexts: resultParams.output.messagingToolSentTexts }
-        : {}),
-      ...(resultParams.output.messagingToolSentMediaUrls?.length
-        ? { messagingToolSentMediaUrls: resultParams.output.messagingToolSentMediaUrls }
-        : {}),
-      ...(resultParams.output.messagingToolSentTargets?.length
-        ? { messagingToolSentTargets: resultParams.output.messagingToolSentTargets }
-        : {}),
-      ...(resultParams.output.messagingToolSourceReplyPayloads?.length
-        ? { messagingToolSourceReplyPayloads: resultParams.output.messagingToolSourceReplyPayloads }
-        : {}),
     };
   };
 
-  const executeRun = async (): Promise<EmbeddedAgentRunResult> => {
+  try {
     await bootstrapHarnessContextEngine({
       hadSessionFile: context.hadSessionFile,
       contextEngine: context.contextEngine,
@@ -978,61 +782,41 @@ export async function runPreparedCliAgent(
       result: Awaited<ReturnType<typeof executeCliAttempt>>,
       fallbackCliSessionId?: string,
     ) => {
-      const { output, assistantText, lastAssistant, sourceReplyWasDelivered } = result;
-      try {
-        const effectiveCliSessionId = output.sessionId ?? fallbackCliSessionId;
-        await finalizeCliContextEngineTurn({
-          context,
-          historyMessages: context.contextEngine ? contextEngineHistoryMessages : historyMessages,
-          assistantText,
-          output,
-        });
-        const assistantTranscriptOwned = await persistCliAssistantTranscript({
-          runParams: params,
-          // Dispatch owns source-reply transcript mirrors and their idempotency keys.
-          // Persisting them here would duplicate the same visible assistant reply.
-          text: sourceReplyWasDelivered ? "" : assistantText,
-          modelId: context.modelId,
-          usage: output.usage,
-        });
-        const bindingFlushOk = await isCliBindingFlushed(
-          effectiveCliSessionId,
-          params.provider,
-          context.cwd ?? context.workspaceDir,
-        );
-        await runCliAgentEndHook(params, {
-          event: {
-            messages: buildAgentEndMessages(lastAssistant),
-            success: true,
-            durationMs: Date.now() - context.started,
-          },
-          ctx: hookContext,
-          hookRunner,
-        });
-        return buildCliRunResult({
-          output,
-          effectiveCliSessionId,
-          bindingFlushOk,
-          assistantTranscriptOwned,
-        });
-      } catch (error) {
-        throw attachCliMessagingDeliveryEvidence(error, output);
-      }
-    };
-
-    const finishDeliveredFailure = async (
-      error: unknown,
-    ): Promise<EmbeddedAgentRunResult | undefined> => {
-      const evidence = getCliMessagingDeliveryEvidence(error);
-      if (!evidence) {
-        return undefined;
-      }
+      const { output, lastAssistant } = result;
+      const assistantText = output.text.trim();
+      const effectiveCliSessionId = output.sessionId ?? fallbackCliSessionId;
+      await finalizeCliContextEngineTurn({
+        context,
+        historyMessages: context.contextEngine ? contextEngineHistoryMessages : historyMessages,
+        assistantText,
+        output,
+      });
+      const assistantTranscriptOwned = await persistCliAssistantTranscript({
+        runParams: params,
+        text: assistantText,
+        modelId: context.modelId,
+        usage: output.usage,
+      });
+      const bindingFlushOk = await isCliBindingFlushed(
+        effectiveCliSessionId,
+        params.provider,
+        context.cwd ?? context.workspaceDir,
+      );
       await runCliAgentEndHook(params, {
-        event: buildFailedAgentEndEvent(formatErrorMessage(error)),
+        event: {
+          messages: buildAgentEndMessages(lastAssistant),
+          success: true,
+          durationMs: Date.now() - context.started,
+        },
         ctx: hookContext,
         hookRunner,
       });
-      return buildDeliveredFailureResult(error, evidence);
+      return buildCliRunResult({
+        output,
+        effectiveCliSessionId,
+        bindingFlushOk,
+        assistantTranscriptOwned,
+      });
     };
 
     if (hasBeforeAgentRunHooks && hookRunner) {
@@ -1102,10 +886,6 @@ export async function runPreparedCliAgent(
         context.reusableCliSession.sessionId,
       );
     } catch (err) {
-      const deliveredFailure = await finishDeliveredFailure(err);
-      if (deliveredFailure) {
-        return deliveredFailure;
-      }
       if (isFailoverError(err)) {
         const retryableSessionId = context.reusableCliSession.sessionId;
         if (
@@ -1136,10 +916,6 @@ export async function runPreparedCliAgent(
             );
             return await finishCliAttempt(await executeCliAttempt(undefined, retryTimeoutMs));
           } catch (retryErr) {
-            const deliveredRetryFailure = await finishDeliveredFailure(retryErr);
-            if (deliveredRetryFailure) {
-              return deliveredRetryFailure;
-            }
             const retryMessage = formatErrorMessage(retryErr);
             await runCliAgentEndHook(params, {
               event: buildFailedAgentEndEvent(retryMessage),
@@ -1164,39 +940,10 @@ export async function runPreparedCliAgent(
       });
       return toCliRunFailure(err);
     }
-  };
-
-  let runResult: EmbeddedAgentRunResult | undefined;
-  let runError: unknown;
-  let runFailed = false;
-  try {
-    runResult = await executeRun();
-  } catch (error) {
-    runFailed = true;
-    runError = error;
-  }
-  try {
+  } finally {
+    clearMcpLoopbackYieldContext(params.sessionId, loopbackYieldContext);
     await context.preparedBackend.cleanup?.();
-  } catch (cleanupError) {
-    if (!deliveredMessagingSideEffect) {
-      if (runFailed) {
-        cliBackendLog.warn(
-          `CLI run also failed before backend cleanup: ${formatErrorMessage(runError)}`,
-        );
-      }
-      throw cleanupError;
-    }
-    cliBackendLog.warn(
-      `CLI backend cleanup failed after confirmed message delivery: ${formatErrorMessage(cleanupError)}`,
-    );
   }
-  if (runFailed) {
-    throw runError;
-  }
-  if (!runResult) {
-    throw new Error("CLI run completed without a result");
-  }
-  return runResult;
 }
 
 /** Legacy Claude-specific wrapper params for the generic CLI runner. */
@@ -1231,7 +978,6 @@ export function buildRunClaudeCliAgentParams(params: RunClaudeCliAgentParams): R
     extraSystemPrompt: params.extraSystemPrompt,
     inputProvenance: params.inputProvenance,
     sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
-    requireExplicitMessageTarget: params.requireExplicitMessageTarget,
     silentReplyPromptMode: params.silentReplyPromptMode,
     extraSystemPromptStatic: params.extraSystemPromptStatic,
     ownerNumbers: params.ownerNumbers,

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -5,14 +5,20 @@ import { setReplyPayloadMetadata, type ReplyPayload } from "../auto-reply/reply-
 import { SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import { appendExactAssistantMessageToSessionTranscript } from "../config/sessions/transcript.js";
 import {
-  clearMcpLoopbackYieldContext,
-  registerMcpLoopbackYieldContext,
-} from "../gateway/mcp-http.loopback-runtime.js";
+  assertAgentRunLifecycleGenerationCurrent,
+  captureAgentRunLifecycleGeneration,
+  withAgentRunLifecycleGeneration,
+} from "../infra/agent-events.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { buildAgentHookContextChannelFields } from "../plugins/hook-agent-context.js";
 import { resolveBlockMessage } from "../plugins/hook-decision-types.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
+import type { CliOutput } from "./cli-output.js";
+import {
+  attachCliMessagingDeliveryEvidence,
+  getCliMessagingDeliveryEvidence,
+} from "./cli-runner/delivery-evidence.js";
 import { cliBackendLog, formatCliBackendOutputDigest } from "./cli-runner/log.js";
 import {
   loadCliSessionContextEngineMessages,
@@ -22,6 +28,7 @@ import type { PreparedCliRunContext, RunCliAgentParams } from "./cli-runner/type
 import { claudeCliSessionTranscriptHasContent as claudeCliSessionTranscriptHasContentImpl } from "./command/attempt-execution.helpers.js";
 import { classifyFailoverReason, isFailoverErrorMessage } from "./embedded-agent-helpers.js";
 import type { EmbeddedAgentRunResult } from "./embedded-agent-runner.js";
+import { buildEmbeddedRunPayloads } from "./embedded-agent-runner/run/payloads.js";
 import { FailoverError, isFailoverError, resolveFailoverStatus } from "./failover-error.js";
 import {
   awaitAgentEndSideEffects,
@@ -352,7 +359,19 @@ async function finalizeCliContextEngineTurn(params: {
 }
 
 /** Prepares and runs one CLI-backed agent turn. */
-export async function runCliAgent(params: RunCliAgentParams): Promise<EmbeddedAgentRunResult> {
+export function runCliAgent(paramsInput: RunCliAgentParams): Promise<EmbeddedAgentRunResult> {
+  const lifecycleGeneration =
+    paramsInput.lifecycleGeneration ?? captureAgentRunLifecycleGeneration(paramsInput.runId);
+  return withAgentRunLifecycleGeneration(lifecycleGeneration, () =>
+    runCliAgentInternal({
+      ...paramsInput,
+      lifecycleGeneration,
+    }),
+  );
+}
+
+async function runCliAgentInternal(params: RunCliAgentParams): Promise<EmbeddedAgentRunResult> {
+  assertAgentRunLifecycleGenerationCurrent(params.lifecycleGeneration!);
   // Cron gate must fire before prepareCliRunContext — that call allocates
   // backend resources released only by runPreparedCliAgent's try…finally.
   params.onExecutionStarted?.();
@@ -407,19 +426,46 @@ export async function runCliAgent(params: RunCliAgentParams): Promise<EmbeddedAg
   }
   const { prepareCliRunContext } = await import("./cli-runner/prepare.runtime.js");
   const context = await prepareCliRunContext(params);
+  let result: EmbeddedAgentRunResult | undefined;
+  let runError: unknown;
   try {
-    return await runPreparedCliAgent(context);
-  } finally {
-    if (params.cleanupCliLiveSessionOnRunEnd === true) {
+    result = await runPreparedCliAgent(context);
+  } catch (error) {
+    runError = error;
+  }
+  let cleanupError: unknown;
+  const recordCleanupError = (error: unknown) => {
+    cleanupError ??= error;
+  };
+  if (params.cleanupCliLiveSessionOnRunEnd === true) {
+    try {
       const { closeClaudeLiveSessionForContext } =
         await import("./cli-runner/claude-live-session.js");
       await closeClaudeLiveSessionForContext(context);
-    }
-    if (params.cleanupBundleMcpOnRunEnd === true) {
-      const { closeMcpLoopbackServer } = await import("../gateway/mcp-http.js");
-      await closeMcpLoopbackServer();
+    } catch (error) {
+      recordCleanupError(error);
     }
   }
+  if (params.cleanupBundleMcpOnRunEnd === true) {
+    try {
+      const { closeMcpLoopbackServer } = await import("../gateway/mcp-http.js");
+      await closeMcpLoopbackServer();
+    } catch (error) {
+      recordCleanupError(error);
+    }
+  }
+  if (cleanupError) {
+    if (runError || result?.didSendViaMessagingTool === true) {
+      log.warn(`cli run cleanup failed after completion: ${formatErrorMessage(cleanupError)}`);
+    } else {
+      runError =
+        cleanupError instanceof Error ? cleanupError : new Error(formatErrorMessage(cleanupError));
+    }
+  }
+  if (runError) {
+    throw runError instanceof Error ? runError : new Error(formatErrorMessage(runError));
+  }
+  return result as EmbeddedAgentRunResult;
 }
 
 /** Runs an already-prepared CLI agent context through hooks and execution. */
@@ -429,7 +475,6 @@ export async function runPreparedCliAgent(
   const { executePreparedCliRun } = await import("./cli-runner/execute.runtime.js");
   const { params } = context;
   const hookRunner = getGlobalHookRunner();
-  const loopbackYieldContext = registerMcpLoopbackYieldContext(params.sessionId);
   const hasLlmInputHooks = hookRunner?.hasHooks("llm_input") === true;
   const hasLlmOutputHooks = hookRunner?.hasHooks("llm_output") === true;
   const hasAgentEndHooks = hookRunner?.hasHooks("agent_end") === true;
@@ -545,6 +590,115 @@ export async function runPreparedCliAgent(
     },
   });
 
+  let deliveredMessagingSideEffect = false;
+  const buildCliSourceReplyMirrorPayloads = (
+    evidence: Pick<
+      CliOutput,
+      | "didSendViaMessagingTool"
+      | "didDeliverSourceReplyViaMessageTool"
+      | "messagingToolSourceReplyPayloads"
+    >,
+  ): ReplyPayload[] => {
+    return buildEmbeddedRunPayloads({
+      assistantTexts: [],
+      toolMetas: [],
+      lastAssistant: undefined,
+      inlineToolResultsAllowed: false,
+      sessionKey: params.sessionKey ?? "",
+      provider: params.provider,
+      model: context.modelId,
+      didSendViaMessagingTool: evidence.didSendViaMessagingTool,
+      didDeliverSourceReplyViaMessageTool: evidence.didDeliverSourceReplyViaMessageTool,
+      messagingToolSourceReplyPayloads: evidence.messagingToolSourceReplyPayloads,
+      sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
+      agentId: params.agentId,
+      runId: params.runId,
+    });
+  };
+
+  const resolveCliSourceReplyMirror = (
+    evidence: Pick<
+      CliOutput,
+      | "didSendViaMessagingTool"
+      | "didDeliverSourceReplyViaMessageTool"
+      | "messagingToolSourceReplyPayloads"
+    >,
+  ) => {
+    const payloads = buildCliSourceReplyMirrorPayloads(evidence);
+    const delivered =
+      payloads.length > 0 ||
+      (params.sourceReplyDeliveryMode === "message_tool_only" &&
+        evidence.didDeliverSourceReplyViaMessageTool === true);
+    const visibleText =
+      payloads
+        .map((payload) => payload.text?.trim() ?? "")
+        .filter(Boolean)
+        .join("\n\n") || undefined;
+    return { payloads, delivered, visibleText };
+  };
+
+  const buildDeliveredFailureResult = (
+    error: unknown,
+    evidence: NonNullable<ReturnType<typeof getCliMessagingDeliveryEvidence>>,
+  ): EmbeddedAgentRunResult => {
+    const message = formatErrorMessage(error);
+    const { payloads } = resolveCliSourceReplyMirror(evidence);
+    deliveredMessagingSideEffect = true;
+    return {
+      ...(payloads.length > 0 ? { payloads } : {}),
+      meta: {
+        durationMs: Date.now() - context.started,
+        systemPromptReport: context.systemPromptReport,
+        stopReason: "error",
+        executionTrace: {
+          winnerProvider: params.provider,
+          winnerModel: context.modelId,
+          attempts: [
+            {
+              provider: params.provider,
+              model: context.modelId,
+              result: "error",
+              reason: message,
+            },
+          ],
+          fallbackUsed: false,
+          runner: "cli",
+        },
+        requestShaping: {
+          ...(params.thinkLevel ? { thinking: params.thinkLevel } : {}),
+          ...(context.effectiveAuthProfileId ? { authMode: "auth-profile" } : {}),
+        },
+        completion: {
+          finishReason: "error",
+          stopReason: "error",
+          refusal: false,
+        },
+        agentMeta: {
+          sessionId: "",
+          provider: params.provider,
+          model: context.modelId,
+          ...(context.reusableCliSession.sessionId ? { clearCliSessionBinding: true } : {}),
+        },
+      },
+      didSendViaMessagingTool: true,
+      ...(evidence.didDeliverSourceReplyViaMessageTool
+        ? { didDeliverSourceReplyViaMessageTool: true }
+        : {}),
+      ...(evidence.messagingToolSentTexts?.length
+        ? { messagingToolSentTexts: evidence.messagingToolSentTexts }
+        : {}),
+      ...(evidence.messagingToolSentMediaUrls?.length
+        ? { messagingToolSentMediaUrls: evidence.messagingToolSentMediaUrls }
+        : {}),
+      ...(evidence.messagingToolSentTargets?.length
+        ? { messagingToolSentTargets: evidence.messagingToolSentTargets }
+        : {}),
+      ...(evidence.messagingToolSourceReplyPayloads?.length
+        ? { messagingToolSourceReplyPayloads: evidence.messagingToolSourceReplyPayloads }
+        : {}),
+    };
+  };
+
   const persistBlockedBeforeAgentRun = async (block: {
     message: string;
     pluginId: string;
@@ -606,15 +760,25 @@ export async function runPreparedCliAgent(
             },
           };
     const output = await executePreparedCliRun(attemptContext, cliSessionIdToUse);
-    const assistantText = output.text.trim();
-    if (!assistantText && params.allowEmptyAssistantReplyAsSilent !== true) {
-      throw new FailoverError("CLI backend returned an empty response.", {
-        reason: "empty_response",
-        provider: params.provider,
-        model: context.modelId,
-        sessionId: params.sessionId,
-        lane: params.lane,
-      });
+    const sourceReplyMirror = resolveCliSourceReplyMirror(output);
+    const assistantText = sourceReplyMirror.delivered
+      ? (sourceReplyMirror.visibleText ?? "")
+      : output.text.trim();
+    if (
+      !assistantText &&
+      !output.didSendViaMessagingTool &&
+      params.allowEmptyAssistantReplyAsSilent !== true
+    ) {
+      throw attachCliMessagingDeliveryEvidence(
+        new FailoverError("CLI backend returned an empty response.", {
+          reason: "empty_response",
+          provider: params.provider,
+          model: context.modelId,
+          sessionId: params.sessionId,
+          lane: params.lane,
+        }),
+        output,
+      );
     }
     const assistantTexts = assistantText ? [assistantText] : [];
     const lastAssistant =
@@ -651,7 +815,12 @@ export async function runPreparedCliAgent(
         hookRunner,
       });
     }
-    return { output, assistantText, lastAssistant };
+    return {
+      output,
+      assistantText,
+      lastAssistant,
+      sourceReplyWasDelivered: sourceReplyMirror.delivered,
+    };
   };
 
   const buildCliRunResult = (resultParams: {
@@ -662,15 +831,27 @@ export async function runPreparedCliAgent(
   }): EmbeddedAgentRunResult => {
     const text = resultParams.output.text?.trim();
     const rawText = resultParams.output.rawText?.trim();
-    const payloads = text
-      ? [
-          resultParams.assistantTranscriptOwned
-            ? setReplyPayloadMetadata({ text }, { assistantTranscriptOwned: true })
-            : { text },
-        ]
-      : params.allowEmptyAssistantReplyAsSilent === true
-        ? [{ text: SILENT_REPLY_TOKEN }]
-        : undefined;
+    const sourceReplyMirror = resolveCliSourceReplyMirror(resultParams.output);
+    const finalAssistantVisibleText = sourceReplyMirror.delivered
+      ? sourceReplyMirror.visibleText
+      : text;
+    const payloads =
+      sourceReplyMirror.payloads.length > 0
+        ? sourceReplyMirror.payloads
+        : sourceReplyMirror.delivered
+          ? undefined
+          : text
+            ? [
+                resultParams.assistantTranscriptOwned
+                  ? setReplyPayloadMetadata({ text }, { assistantTranscriptOwned: true })
+                  : { text },
+              ]
+            : params.allowEmptyAssistantReplyAsSilent === true
+              ? [{ text: SILENT_REPLY_TOKEN }]
+              : undefined;
+    if (resultParams.output.didSendViaMessagingTool) {
+      deliveredMessagingSideEffect = true;
+    }
     const unflushedCliSessionId =
       resultParams.effectiveCliSessionId && resultParams.bindingFlushOk === false
         ? resultParams.effectiveCliSessionId
@@ -681,9 +862,8 @@ export async function runPreparedCliAgent(
     const agentSessionId = unflushedCliSessionId
       ? ""
       : (resultParams.effectiveCliSessionId ?? params.sessionId ?? "");
-    const yielded = loopbackYieldContext.yielded;
+    const yielded = resultParams.output.yielded === true;
     const stopReason = yielded ? "end_turn" : "completed";
-    const finishReason = yielded ? "end_turn" : "stop";
 
     return {
       payloads,
@@ -692,9 +872,9 @@ export async function runPreparedCliAgent(
         ...(resultParams.output.finalPromptText
           ? { finalPromptText: resultParams.output.finalPromptText }
           : {}),
-        ...(text || rawText
+        ...(finalAssistantVisibleText || rawText
           ? {
-              ...(text ? { finalAssistantVisibleText: text } : {}),
+              ...(finalAssistantVisibleText ? { finalAssistantVisibleText } : {}),
               ...(rawText ? { finalAssistantRawText: rawText } : {}),
             }
           : {}),
@@ -718,7 +898,7 @@ export async function runPreparedCliAgent(
           ...(context.effectiveAuthProfileId ? { authMode: "auth-profile" } : {}),
         },
         completion: {
-          finishReason,
+          finishReason: yielded ? "end_turn" : "stop",
           stopReason,
           refusal: false,
         },
@@ -740,6 +920,9 @@ export async function runPreparedCliAgent(
                   ...(context.extraSystemPromptHash
                     ? { extraSystemPromptHash: context.extraSystemPromptHash }
                     : {}),
+                  ...(context.messageToolPolicyHash
+                    ? { messageToolPolicyHash: context.messageToolPolicyHash }
+                    : {}),
                   ...(context.promptToolNamesHash
                     ? { promptToolNamesHash: context.promptToolNamesHash }
                     : {}),
@@ -756,10 +939,26 @@ export async function runPreparedCliAgent(
           ...(unflushedCliSessionId ? { clearCliSessionBinding: true } : {}),
         },
       },
+      ...(resultParams.output.didSendViaMessagingTool ? { didSendViaMessagingTool: true } : {}),
+      ...(resultParams.output.didDeliverSourceReplyViaMessageTool
+        ? { didDeliverSourceReplyViaMessageTool: true }
+        : {}),
+      ...(resultParams.output.messagingToolSentTexts?.length
+        ? { messagingToolSentTexts: resultParams.output.messagingToolSentTexts }
+        : {}),
+      ...(resultParams.output.messagingToolSentMediaUrls?.length
+        ? { messagingToolSentMediaUrls: resultParams.output.messagingToolSentMediaUrls }
+        : {}),
+      ...(resultParams.output.messagingToolSentTargets?.length
+        ? { messagingToolSentTargets: resultParams.output.messagingToolSentTargets }
+        : {}),
+      ...(resultParams.output.messagingToolSourceReplyPayloads?.length
+        ? { messagingToolSourceReplyPayloads: resultParams.output.messagingToolSourceReplyPayloads }
+        : {}),
     };
   };
 
-  try {
+  const executeRun = async (): Promise<EmbeddedAgentRunResult> => {
     await bootstrapHarnessContextEngine({
       hadSessionFile: context.hadSessionFile,
       contextEngine: context.contextEngine,
@@ -782,41 +981,61 @@ export async function runPreparedCliAgent(
       result: Awaited<ReturnType<typeof executeCliAttempt>>,
       fallbackCliSessionId?: string,
     ) => {
-      const { output, lastAssistant } = result;
-      const assistantText = output.text.trim();
-      const effectiveCliSessionId = output.sessionId ?? fallbackCliSessionId;
-      await finalizeCliContextEngineTurn({
-        context,
-        historyMessages: context.contextEngine ? contextEngineHistoryMessages : historyMessages,
-        assistantText,
-        output,
-      });
-      const assistantTranscriptOwned = await persistCliAssistantTranscript({
-        runParams: params,
-        text: assistantText,
-        modelId: context.modelId,
-        usage: output.usage,
-      });
-      const bindingFlushOk = await isCliBindingFlushed(
-        effectiveCliSessionId,
-        params.provider,
-        context.cwd ?? context.workspaceDir,
-      );
+      const { output, assistantText, lastAssistant, sourceReplyWasDelivered } = result;
+      try {
+        const effectiveCliSessionId = output.sessionId ?? fallbackCliSessionId;
+        await finalizeCliContextEngineTurn({
+          context,
+          historyMessages: context.contextEngine ? contextEngineHistoryMessages : historyMessages,
+          assistantText,
+          output,
+        });
+        const assistantTranscriptOwned = await persistCliAssistantTranscript({
+          runParams: params,
+          // Dispatch owns source-reply transcript mirrors and their idempotency keys.
+          // Persisting them here would duplicate the same visible assistant reply.
+          text: sourceReplyWasDelivered ? "" : assistantText,
+          modelId: context.modelId,
+          usage: output.usage,
+        });
+        const bindingFlushOk = await isCliBindingFlushed(
+          effectiveCliSessionId,
+          params.provider,
+          context.cwd ?? context.workspaceDir,
+        );
+        await runCliAgentEndHook(params, {
+          event: {
+            messages: buildAgentEndMessages(lastAssistant),
+            success: true,
+            durationMs: Date.now() - context.started,
+          },
+          ctx: hookContext,
+          hookRunner,
+        });
+        return buildCliRunResult({
+          output,
+          effectiveCliSessionId,
+          bindingFlushOk,
+          assistantTranscriptOwned,
+        });
+      } catch (error) {
+        throw attachCliMessagingDeliveryEvidence(error, output);
+      }
+    };
+
+    const finishDeliveredFailure = async (
+      error: unknown,
+    ): Promise<EmbeddedAgentRunResult | undefined> => {
+      const evidence = getCliMessagingDeliveryEvidence(error);
+      if (!evidence) {
+        return undefined;
+      }
       await runCliAgentEndHook(params, {
-        event: {
-          messages: buildAgentEndMessages(lastAssistant),
-          success: true,
-          durationMs: Date.now() - context.started,
-        },
+        event: buildFailedAgentEndEvent(formatErrorMessage(error)),
         ctx: hookContext,
         hookRunner,
       });
-      return buildCliRunResult({
-        output,
-        effectiveCliSessionId,
-        bindingFlushOk,
-        assistantTranscriptOwned,
-      });
+      return buildDeliveredFailureResult(error, evidence);
     };
 
     if (hasBeforeAgentRunHooks && hookRunner) {
@@ -886,6 +1105,10 @@ export async function runPreparedCliAgent(
         context.reusableCliSession.sessionId,
       );
     } catch (err) {
+      const deliveredFailure = await finishDeliveredFailure(err);
+      if (deliveredFailure) {
+        return deliveredFailure;
+      }
       if (isFailoverError(err)) {
         const retryableSessionId = context.reusableCliSession.sessionId;
         if (
@@ -916,6 +1139,10 @@ export async function runPreparedCliAgent(
             );
             return await finishCliAttempt(await executeCliAttempt(undefined, retryTimeoutMs));
           } catch (retryErr) {
+            const deliveredRetryFailure = await finishDeliveredFailure(retryErr);
+            if (deliveredRetryFailure) {
+              return deliveredRetryFailure;
+            }
             const retryMessage = formatErrorMessage(retryErr);
             await runCliAgentEndHook(params, {
               event: buildFailedAgentEndEvent(retryMessage),
@@ -940,10 +1167,39 @@ export async function runPreparedCliAgent(
       });
       return toCliRunFailure(err);
     }
-  } finally {
-    clearMcpLoopbackYieldContext(params.sessionId, loopbackYieldContext);
-    await context.preparedBackend.cleanup?.();
+  };
+
+  let runResult: EmbeddedAgentRunResult | undefined;
+  let runError: unknown;
+  let runFailed = false;
+  try {
+    runResult = await executeRun();
+  } catch (error) {
+    runFailed = true;
+    runError = error;
   }
+  try {
+    await context.preparedBackend.cleanup?.();
+  } catch (cleanupError) {
+    if (!deliveredMessagingSideEffect) {
+      if (runFailed) {
+        cliBackendLog.warn(
+          `CLI run also failed before backend cleanup: ${formatErrorMessage(runError)}`,
+        );
+      }
+      throw cleanupError;
+    }
+    cliBackendLog.warn(
+      `CLI backend cleanup failed after confirmed message delivery: ${formatErrorMessage(cleanupError)}`,
+    );
+  }
+  if (runFailed) {
+    throw runError;
+  }
+  if (!runResult) {
+    throw new Error("CLI run completed without a result");
+  }
+  return runResult;
 }
 
 /** Legacy Claude-specific wrapper params for the generic CLI runner. */
@@ -978,6 +1234,7 @@ export function buildRunClaudeCliAgentParams(params: RunClaudeCliAgentParams): R
     extraSystemPrompt: params.extraSystemPrompt,
     inputProvenance: params.inputProvenance,
     sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
+    requireExplicitMessageTarget: params.requireExplicitMessageTarget,
     silentReplyPromptMode: params.silentReplyPromptMode,
     extraSystemPromptStatic: params.extraSystemPromptStatic,
     ownerNumbers: params.ownerNumbers,

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -681,7 +681,7 @@ export async function runPreparedCliAgent(
     const agentSessionId = unflushedCliSessionId
       ? ""
       : (resultParams.effectiveCliSessionId ?? params.sessionId ?? "");
-    const yielded = loopbackYieldContext.yielded === true;
+    const yielded = loopbackYieldContext.yielded;
     const stopReason = yielded ? "end_turn" : "completed";
     const finishReason = yielded ? "end_turn" : "stop";
 

--- a/src/agents/cli-runner/execute.supervisor-capture.test.ts
+++ b/src/agents/cli-runner/execute.supervisor-capture.test.ts
@@ -2,9 +2,12 @@
 // disabled and the runner must parse streamed chunks without relying on tails.
 import { beforeEach, describe, expect, it } from "vitest";
 import {
+  markMcpLoopbackRequestFinished,
+  markMcpLoopbackRequestStarted,
   markMcpLoopbackToolCallFinished,
   markMcpLoopbackToolCallStarted,
   recordMcpLoopbackToolCallResult as recordMcpLoopbackToolCallResultForHandle,
+  resolveMcpLoopbackYieldContext,
 } from "../../gateway/mcp-http.loopback-runtime.js";
 import { onAgentEvent, resetAgentEventsForTest } from "../../infra/agent-events.js";
 import type { getProcessSupervisor } from "../../process/supervisor/index.js";
@@ -709,6 +712,32 @@ describe("executePreparedCliRun supervisor output capture", () => {
 
     expect(result.didSendViaMessagingTool).toBeUndefined();
     expect(result.messagingToolSentTargets).toBeUndefined();
+  });
+
+  it("records sessions_yield through the serialized MCP capture", async () => {
+    const context = buildPreparedCliRunContext({ output: "text", provider: "google-gemini-cli" });
+    context.mcpDeliveryCapture = true;
+    supervisorSpawnMock.mockImplementationOnce(async (...args: unknown[]) => {
+      const input = args[0] as SupervisorSpawnInput;
+      const captureHandle = markMcpLoopbackRequestStarted(input.env?.OPENCLAW_MCP_CLI_CAPTURE_KEY);
+      await resolveMcpLoopbackYieldContext(captureHandle)?.onYield("waiting on subagents");
+      markMcpLoopbackRequestFinished(captureHandle);
+      input.onStdout?.("yield acknowledged");
+      return createManagedRun({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 50,
+        stdout: "",
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      });
+    });
+
+    const result = await executePreparedCliRun(context);
+
+    expect(result.yielded).toBe(true);
   });
 
   it("keeps mutation delivery out of sent-reply dedupe evidence", async () => {

--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -560,6 +560,7 @@ export async function executePreparedCliRun(
         : undefined;
       let gatewayCaptureKey: string | undefined;
       let cleanupMcpCaptureAttempt: (() => Promise<void>) | undefined;
+      let yielded = false;
       let didSendViaMessagingTool = false;
       let didDeliverSourceReplyViaMessageTool = false;
       let inFlightUnclassifiedMcpRequests = 0;
@@ -612,9 +613,10 @@ export async function executePreparedCliRun(
         runFailed = true;
         runError = error;
       };
-      const withMessagingDeliveryEvidence = (output: CliOutput): CliOutput => {
+      const withExecutionEvidence = (output: CliOutput): CliOutput => {
         return {
           ...output,
+          ...(yielded ? { yielded: true as const } : {}),
           ...(didSendViaMessagingTool ? { didSendViaMessagingTool: true } : {}),
           ...(didDeliverSourceReplyViaMessageTool
             ? { didDeliverSourceReplyViaMessageTool: true }
@@ -818,6 +820,9 @@ export async function executePreparedCliRun(
           };
           beginMcpLoopbackToolCallCapture({
             captureKey: gatewayCaptureKey,
+            onYield: () => {
+              yielded = true;
+            },
             onRequestStart: () => {
               inFlightUnclassifiedMcpRequests += 1;
             },
@@ -1424,7 +1429,7 @@ export async function executePreparedCliRun(
       if (!runOutput) {
         throw new Error("CLI run completed without output");
       }
-      return withMessagingDeliveryEvidence(runOutput);
+      return withExecutionEvidence(runOutput);
     });
     return completedOutput;
   } catch (error) {

--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -1501,7 +1501,6 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
 
       expect(resolveMcpLoopbackScopedTools).toHaveBeenCalledWith({
         cfg: expect.any(Object),
-        sessionId: "session-test",
         sessionKey: "agent:main:test",
         messageProvider: undefined,
         currentChannelId: undefined,

--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -117,6 +117,7 @@ function createTestMcpLoopbackServerConfig(port: number) {
         headers: {
           Authorization: "Bearer ${OPENCLAW_MCP_TOKEN}",
           "x-session-key": "${OPENCLAW_MCP_SESSION_KEY}",
+          "x-openclaw-session-id": "${OPENCLAW_MCP_SESSION_ID}",
           "x-openclaw-agent-id": "${OPENCLAW_MCP_AGENT_ID}",
           "x-openclaw-account-id": "${OPENCLAW_MCP_ACCOUNT_ID}",
           "x-openclaw-message-channel": "${OPENCLAW_MCP_MESSAGE_CHANNEL}",
@@ -1500,6 +1501,7 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
 
       expect(resolveMcpLoopbackScopedTools).toHaveBeenCalledWith({
         cfg: expect.any(Object),
+        sessionId: "session-test",
         sessionKey: "agent:main:test",
         messageProvider: undefined,
         currentChannelId: undefined,
@@ -1672,6 +1674,7 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
       });
 
       expect(context.preparedBackend.env).toMatchObject({
+        OPENCLAW_MCP_SESSION_ID: "session-test",
         OPENCLAW_MCP_MESSAGE_CHANNEL: "telegram",
         OPENCLAW_MCP_CURRENT_CHANNEL_ID: "telegram:-100123:topic:42",
         OPENCLAW_MCP_CURRENT_THREAD_TS: "42",

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -484,7 +484,6 @@ export async function prepareCliRunContext(
       ? prepareDeps.resolveMcpLoopbackScopedTools({
           cfg: params.config ?? getRuntimeConfig(),
           sessionKey: params.sessionKey ?? "",
-          sessionId: params.sessionId,
           messageProvider: params.messageChannel ?? params.messageProvider,
           currentChannelId: params.currentChannelId,
           currentThreadTs: params.currentThreadTs,

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -392,6 +392,7 @@ export async function prepareCliRunContext(
           OPENCLAW_MCP_AGENT_ID: sessionAgentId ?? "",
           OPENCLAW_MCP_ACCOUNT_ID: params.agentAccountId ?? "",
           OPENCLAW_MCP_SESSION_KEY: params.sessionKey ?? "",
+          OPENCLAW_MCP_SESSION_ID: params.sessionId,
           OPENCLAW_MCP_MESSAGE_CHANNEL: params.messageChannel ?? params.messageProvider ?? "",
           OPENCLAW_MCP_CURRENT_CHANNEL_ID: params.currentChannelId ?? "",
           OPENCLAW_MCP_CURRENT_THREAD_TS: params.currentThreadTs ?? "",
@@ -483,6 +484,7 @@ export async function prepareCliRunContext(
       ? prepareDeps.resolveMcpLoopbackScopedTools({
           cfg: params.config ?? getRuntimeConfig(),
           sessionKey: params.sessionKey ?? "",
+          sessionId: params.sessionId,
           messageProvider: params.messageChannel ?? params.messageProvider,
           currentChannelId: params.currentChannelId,
           currentThreadTs: params.currentThreadTs,

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -2000,7 +2000,69 @@ describe("subagent registry seam flow", () => {
     expect(replacement?.endedAt).toBeUndefined();
   });
 
-  it("keeps CLI lifecycle-yielded subagent runs paused instead of completing cleanup", async () => {
+  it("keeps yield terminals paused when the lifecycle event also signals abort (#92448)", async () => {
+    // sessions_yield ends the turn by aborting the run signal, so a depth-1
+    // subagent's yield terminal can arrive carrying yielded plus aborted (or
+    // stopReason="aborted"). The event handler must still pause the run, not
+    // settle it `cancelled` and deliver a false notice to the requester.
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        return { status: "pending" };
+      }
+      return {};
+    });
+
+    const cases = [
+      { runId: "run-yield-stopreason-aborted", extra: { stopReason: "aborted" } },
+      { runId: "run-yield-aborted-flag", extra: { aborted: true } },
+    ];
+
+    for (const testCase of cases) {
+      mod.registerSubagentRun({
+        runId: testCase.runId,
+        childSessionKey: `agent:main:subagent:${testCase.runId}`,
+        requesterSessionKey: "agent:main:main",
+        requesterDisplayKey: "main",
+        task: "wait for child continuation",
+        cleanup: "keep",
+      });
+
+      const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
+        mocks.onAgentEvent.mock.calls.length - 1
+      ] as unknown as
+        | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
+        | undefined;
+      const lifecycleHandler = lastOnAgentEventCall?.[0];
+      expect(lifecycleHandler).toBeTypeOf("function");
+
+      lifecycleHandler?.({
+        runId: testCase.runId,
+        stream: "lifecycle",
+        data: {
+          phase: "end",
+          startedAt: 111,
+          endedAt: 222,
+          yielded: true,
+          ...testCase.extra,
+        },
+      });
+
+      await waitForFast(() => {
+        const run = mod
+          .listSubagentRunsForRequester("agent:main:main")
+          .find((entry) => entry.runId === testCase.runId);
+        expect(run?.pauseReason).toBe("sessions_yield");
+        expect(run?.outcome?.status).not.toBe("error");
+      });
+    }
+
+    // Paused, never killed → no farewell/cancellation notice reaches the requester.
+    expect(mocks.runSubagentAnnounceFlow).not.toHaveBeenCalled();
+  });
+
+  it("cancels a pending grace timer when a yield follows an intermediate aborted terminal (#92448)", async () => {
+    // An earlier aborted terminal schedules a deferred kill grace timer; a
+    // following yield must clear it, or it fires and settles the now-paused run.
     mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
       if (request.method === "agent.wait") {
         return { status: "pending" };
@@ -2009,13 +2071,81 @@ describe("subagent registry seam flow", () => {
     });
 
     mod.registerSubagentRun({
-      runId: "run-cli-lifecycle-yield-paused",
-      childSessionKey: "agent:main:subagent:child",
+      runId: "run-yield-after-pending-timeout",
+      childSessionKey: "agent:main:subagent:pending-timeout",
       requesterSessionKey: "agent:main:main",
       requesterDisplayKey: "main",
-      task: "pause after CLI lifecycle yield",
-      cleanup: "delete",
-      expectsCompletionMessage: true,
+      task: "wait for child continuation",
+      cleanup: "keep",
+    });
+
+    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
+      mocks.onAgentEvent.mock.calls.length - 1
+    ] as unknown as
+      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
+      | undefined;
+    const lifecycleHandler = lastOnAgentEventCall?.[0];
+    expect(lifecycleHandler).toBeTypeOf("function");
+
+    // Intermediate aborted terminal → schedules the deferred kill grace timer.
+    lifecycleHandler?.({
+      runId: "run-yield-after-pending-timeout",
+      stream: "lifecycle",
+      data: { phase: "end", startedAt: 111, endedAt: 222, aborted: true },
+    });
+    // Yield terminal → must pause and cancel the pending grace timer.
+    lifecycleHandler?.({
+      runId: "run-yield-after-pending-timeout",
+      stream: "lifecycle",
+      data: { phase: "end", startedAt: 111, endedAt: 333, yielded: true },
+    });
+
+    await waitForFast(() => {
+      const run = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-yield-after-pending-timeout");
+      expect(run?.pauseReason).toBe("sessions_yield");
+    });
+
+    // Advancing well past the 15s grace window must not undo the pause.
+    await vi.advanceTimersByTimeAsync(60_000);
+    const run = mod
+      .listSubagentRunsForRequester("agent:main:main")
+      .find((entry) => entry.runId === "run-yield-after-pending-timeout");
+    expect(run?.pauseReason).toBe("sessions_yield");
+    expect(run?.outcome?.status).not.toBe("error");
+    expect(mocks.runSubagentAnnounceFlow).not.toHaveBeenCalled();
+  });
+
+  it("cancels a pending grace timer when agent.wait observes the yield after an aborted terminal (#92448)", async () => {
+    let resolveWait: (value: {
+      status: "ok";
+      startedAt: number;
+      endedAt: number;
+      yielded: true;
+    }) => void = () => {};
+    const waitResult = new Promise<{
+      status: "ok";
+      startedAt: number;
+      endedAt: number;
+      yielded: true;
+    }>((resolve) => {
+      resolveWait = resolve;
+    });
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        return waitResult;
+      }
+      return {};
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-wait-yield-after-pending-timeout",
+      childSessionKey: "agent:main:subagent:pending-wait-timeout",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "wait for child continuation through wait",
+      cleanup: "keep",
     });
 
     const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
@@ -2027,29 +2157,26 @@ describe("subagent registry seam flow", () => {
     expect(lifecycleHandler).toBeTypeOf("function");
 
     lifecycleHandler?.({
-      runId: "run-cli-lifecycle-yield-paused",
+      runId: "run-wait-yield-after-pending-timeout",
       stream: "lifecycle",
-      data: {
-        phase: "end",
-        startedAt: 333,
-        endedAt: 444,
-        yielded: true,
-        livenessState: "paused",
-        stopReason: "end_turn",
-      },
+      data: { phase: "end", startedAt: 111, endedAt: 222, aborted: true },
     });
+    resolveWait({ status: "ok", startedAt: 111, endedAt: 333, yielded: true });
 
     await waitForFast(() => {
       const run = mod
         .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-cli-lifecycle-yield-paused");
-      expect(run?.endedAt).toBe(444);
+        .find((entry) => entry.runId === "run-wait-yield-after-pending-timeout");
       expect(run?.pauseReason).toBe("sessions_yield");
-      expect(run?.outcome).toBeUndefined();
     });
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    const run = mod
+      .listSubagentRunsForRequester("agent:main:main")
+      .find((entry) => entry.runId === "run-wait-yield-after-pending-timeout");
+    expect(run?.pauseReason).toBe("sessions_yield");
+    expect(run?.outcome?.status).not.toBe("timeout");
     expect(mocks.runSubagentAnnounceFlow).not.toHaveBeenCalled();
-    expect(mocks.cleanupBrowserSessionsForLifecycleEnd).not.toHaveBeenCalled();
-    expect(mod.countPendingDescendantRuns("agent:main:main")).toBe(1);
   });
 
   it("announces blocked agent.wait snapshots as errors instead of success", async () => {
@@ -2648,6 +2775,101 @@ describe("subagent registry seam flow", () => {
 
     await vi.advanceTimersByTimeAsync(20_000);
     expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+  });
+
+  it("announces restart lifecycle end events as killed subagent failures", async () => {
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        return { status: "pending" };
+      }
+      return {};
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-restart-end",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "restart task",
+      cleanup: "keep",
+      expectsCompletionMessage: true,
+    });
+
+    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
+      mocks.onAgentEvent.mock.calls.length - 1
+    ] as unknown as
+      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
+      | undefined;
+    const lifecycleHandler = lastOnAgentEventCall?.[0];
+    lifecycleHandler?.({
+      runId: "run-restart-end",
+      stream: "lifecycle",
+      data: {
+        phase: "end",
+        startedAt: 10,
+        endedAt: 20,
+        aborted: true,
+        stopReason: "restart",
+      },
+    });
+
+    await waitForFast(() => {
+      const run = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-restart-end");
+      expect(run?.endedReason).toBe("subagent-killed");
+      expect(run?.outcome?.status).toBe("error");
+      expect(run?.cleanupCompletedAt).toBeTypeOf("number");
+      expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("announces restart lifecycle error events as killed subagent failures", async () => {
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        return { status: "pending" };
+      }
+      return {};
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-restart-error",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "restart error task",
+      cleanup: "keep",
+      expectsCompletionMessage: true,
+    });
+
+    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
+      mocks.onAgentEvent.mock.calls.length - 1
+    ] as unknown as
+      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
+      | undefined;
+    const lifecycleHandler = lastOnAgentEventCall?.[0];
+    lifecycleHandler?.({
+      runId: "run-restart-error",
+      stream: "lifecycle",
+      data: {
+        phase: "error",
+        startedAt: 10,
+        endedAt: 20,
+        error: "ACP turn failed before completion",
+        aborted: true,
+        stopReason: "restart",
+      },
+    });
+
+    await waitForFast(() => {
+      const run = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-restart-error");
+      expect(run?.endedReason).toBe("subagent-killed");
+      expect(run?.outcome?.status).toBe("error");
+      expect(run?.cleanupCompletedAt).toBeTypeOf("number");
+      expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+    });
   });
 
   it("resumes ended cleanup when lifecycle killed completion rejects before cleanup", async () => {

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -2000,69 +2000,7 @@ describe("subagent registry seam flow", () => {
     expect(replacement?.endedAt).toBeUndefined();
   });
 
-  it("keeps yield terminals paused when the lifecycle event also signals abort (#92448)", async () => {
-    // sessions_yield ends the turn by aborting the run signal, so a depth-1
-    // subagent's yield terminal can arrive carrying yielded plus aborted (or
-    // stopReason="aborted"). The event handler must still pause the run, not
-    // settle it `cancelled` and deliver a false notice to the requester.
-    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
-      if (request.method === "agent.wait") {
-        return { status: "pending" };
-      }
-      return {};
-    });
-
-    const cases = [
-      { runId: "run-yield-stopreason-aborted", extra: { stopReason: "aborted" } },
-      { runId: "run-yield-aborted-flag", extra: { aborted: true } },
-    ];
-
-    for (const testCase of cases) {
-      mod.registerSubagentRun({
-        runId: testCase.runId,
-        childSessionKey: `agent:main:subagent:${testCase.runId}`,
-        requesterSessionKey: "agent:main:main",
-        requesterDisplayKey: "main",
-        task: "wait for child continuation",
-        cleanup: "keep",
-      });
-
-      const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
-        mocks.onAgentEvent.mock.calls.length - 1
-      ] as unknown as
-        | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
-        | undefined;
-      const lifecycleHandler = lastOnAgentEventCall?.[0];
-      expect(lifecycleHandler).toBeTypeOf("function");
-
-      lifecycleHandler?.({
-        runId: testCase.runId,
-        stream: "lifecycle",
-        data: {
-          phase: "end",
-          startedAt: 111,
-          endedAt: 222,
-          yielded: true,
-          ...testCase.extra,
-        },
-      });
-
-      await waitForFast(() => {
-        const run = mod
-          .listSubagentRunsForRequester("agent:main:main")
-          .find((entry) => entry.runId === testCase.runId);
-        expect(run?.pauseReason).toBe("sessions_yield");
-        expect(run?.outcome?.status).not.toBe("error");
-      });
-    }
-
-    // Paused, never killed → no farewell/cancellation notice reaches the requester.
-    expect(mocks.runSubagentAnnounceFlow).not.toHaveBeenCalled();
-  });
-
-  it("cancels a pending grace timer when a yield follows an intermediate aborted terminal (#92448)", async () => {
-    // An earlier aborted terminal schedules a deferred kill grace timer; a
-    // following yield must clear it, or it fires and settles the now-paused run.
+  it("keeps CLI lifecycle-yielded subagent runs paused instead of completing cleanup", async () => {
     mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
       if (request.method === "agent.wait") {
         return { status: "pending" };
@@ -2071,81 +2009,13 @@ describe("subagent registry seam flow", () => {
     });
 
     mod.registerSubagentRun({
-      runId: "run-yield-after-pending-timeout",
-      childSessionKey: "agent:main:subagent:pending-timeout",
+      runId: "run-cli-lifecycle-yield-paused",
+      childSessionKey: "agent:main:subagent:child",
       requesterSessionKey: "agent:main:main",
       requesterDisplayKey: "main",
-      task: "wait for child continuation",
-      cleanup: "keep",
-    });
-
-    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
-      mocks.onAgentEvent.mock.calls.length - 1
-    ] as unknown as
-      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
-      | undefined;
-    const lifecycleHandler = lastOnAgentEventCall?.[0];
-    expect(lifecycleHandler).toBeTypeOf("function");
-
-    // Intermediate aborted terminal → schedules the deferred kill grace timer.
-    lifecycleHandler?.({
-      runId: "run-yield-after-pending-timeout",
-      stream: "lifecycle",
-      data: { phase: "end", startedAt: 111, endedAt: 222, aborted: true },
-    });
-    // Yield terminal → must pause and cancel the pending grace timer.
-    lifecycleHandler?.({
-      runId: "run-yield-after-pending-timeout",
-      stream: "lifecycle",
-      data: { phase: "end", startedAt: 111, endedAt: 333, yielded: true },
-    });
-
-    await waitForFast(() => {
-      const run = mod
-        .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-yield-after-pending-timeout");
-      expect(run?.pauseReason).toBe("sessions_yield");
-    });
-
-    // Advancing well past the 15s grace window must not undo the pause.
-    await vi.advanceTimersByTimeAsync(60_000);
-    const run = mod
-      .listSubagentRunsForRequester("agent:main:main")
-      .find((entry) => entry.runId === "run-yield-after-pending-timeout");
-    expect(run?.pauseReason).toBe("sessions_yield");
-    expect(run?.outcome?.status).not.toBe("error");
-    expect(mocks.runSubagentAnnounceFlow).not.toHaveBeenCalled();
-  });
-
-  it("cancels a pending grace timer when agent.wait observes the yield after an aborted terminal (#92448)", async () => {
-    let resolveWait: (value: {
-      status: "ok";
-      startedAt: number;
-      endedAt: number;
-      yielded: true;
-    }) => void = () => {};
-    const waitResult = new Promise<{
-      status: "ok";
-      startedAt: number;
-      endedAt: number;
-      yielded: true;
-    }>((resolve) => {
-      resolveWait = resolve;
-    });
-    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
-      if (request.method === "agent.wait") {
-        return waitResult;
-      }
-      return {};
-    });
-
-    mod.registerSubagentRun({
-      runId: "run-wait-yield-after-pending-timeout",
-      childSessionKey: "agent:main:subagent:pending-wait-timeout",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
-      task: "wait for child continuation through wait",
-      cleanup: "keep",
+      task: "pause after CLI lifecycle yield",
+      cleanup: "delete",
+      expectsCompletionMessage: true,
     });
 
     const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
@@ -2157,26 +2027,29 @@ describe("subagent registry seam flow", () => {
     expect(lifecycleHandler).toBeTypeOf("function");
 
     lifecycleHandler?.({
-      runId: "run-wait-yield-after-pending-timeout",
+      runId: "run-cli-lifecycle-yield-paused",
       stream: "lifecycle",
-      data: { phase: "end", startedAt: 111, endedAt: 222, aborted: true },
+      data: {
+        phase: "end",
+        startedAt: 333,
+        endedAt: 444,
+        yielded: true,
+        livenessState: "paused",
+        stopReason: "end_turn",
+      },
     });
-    resolveWait({ status: "ok", startedAt: 111, endedAt: 333, yielded: true });
 
     await waitForFast(() => {
       const run = mod
         .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-wait-yield-after-pending-timeout");
+        .find((entry) => entry.runId === "run-cli-lifecycle-yield-paused");
+      expect(run?.endedAt).toBe(444);
       expect(run?.pauseReason).toBe("sessions_yield");
+      expect(run?.outcome).toBeUndefined();
     });
-
-    await vi.advanceTimersByTimeAsync(60_000);
-    const run = mod
-      .listSubagentRunsForRequester("agent:main:main")
-      .find((entry) => entry.runId === "run-wait-yield-after-pending-timeout");
-    expect(run?.pauseReason).toBe("sessions_yield");
-    expect(run?.outcome?.status).not.toBe("timeout");
     expect(mocks.runSubagentAnnounceFlow).not.toHaveBeenCalled();
+    expect(mocks.cleanupBrowserSessionsForLifecycleEnd).not.toHaveBeenCalled();
+    expect(mod.countPendingDescendantRuns("agent:main:main")).toBe(1);
   });
 
   it("announces blocked agent.wait snapshots as errors instead of success", async () => {
@@ -2775,101 +2648,6 @@ describe("subagent registry seam flow", () => {
 
     await vi.advanceTimersByTimeAsync(20_000);
     expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
-  });
-
-  it("announces restart lifecycle end events as killed subagent failures", async () => {
-    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
-      if (request.method === "agent.wait") {
-        return { status: "pending" };
-      }
-      return {};
-    });
-
-    mod.registerSubagentRun({
-      runId: "run-restart-end",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
-      task: "restart task",
-      cleanup: "keep",
-      expectsCompletionMessage: true,
-    });
-
-    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
-      mocks.onAgentEvent.mock.calls.length - 1
-    ] as unknown as
-      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
-      | undefined;
-    const lifecycleHandler = lastOnAgentEventCall?.[0];
-    lifecycleHandler?.({
-      runId: "run-restart-end",
-      stream: "lifecycle",
-      data: {
-        phase: "end",
-        startedAt: 10,
-        endedAt: 20,
-        aborted: true,
-        stopReason: "restart",
-      },
-    });
-
-    await waitForFast(() => {
-      const run = mod
-        .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-restart-end");
-      expect(run?.endedReason).toBe("subagent-killed");
-      expect(run?.outcome?.status).toBe("error");
-      expect(run?.cleanupCompletedAt).toBeTypeOf("number");
-      expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  it("announces restart lifecycle error events as killed subagent failures", async () => {
-    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
-      if (request.method === "agent.wait") {
-        return { status: "pending" };
-      }
-      return {};
-    });
-
-    mod.registerSubagentRun({
-      runId: "run-restart-error",
-      childSessionKey: "agent:main:subagent:child",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
-      task: "restart error task",
-      cleanup: "keep",
-      expectsCompletionMessage: true,
-    });
-
-    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
-      mocks.onAgentEvent.mock.calls.length - 1
-    ] as unknown as
-      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
-      | undefined;
-    const lifecycleHandler = lastOnAgentEventCall?.[0];
-    lifecycleHandler?.({
-      runId: "run-restart-error",
-      stream: "lifecycle",
-      data: {
-        phase: "error",
-        startedAt: 10,
-        endedAt: 20,
-        error: "ACP turn failed before completion",
-        aborted: true,
-        stopReason: "restart",
-      },
-    });
-
-    await waitForFast(() => {
-      const run = mod
-        .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-restart-error");
-      expect(run?.endedReason).toBe("subagent-killed");
-      expect(run?.outcome?.status).toBe("error");
-      expect(run?.cleanupCompletedAt).toBeTypeOf("number");
-      expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
-    });
   });
 
   it("resumes ended cleanup when lifecycle killed completion rejects before cleanup", async () => {

--- a/src/auto-reply/reply/agent-runner-cli-dispatch.test.ts
+++ b/src/auto-reply/reply/agent-runner-cli-dispatch.test.ts
@@ -1,38 +1,113 @@
 // Tests CLI dispatch arguments and runtime selection for agent runner turns.
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { EmbeddedAgentRunResult } from "../../agents/embedded-agent-runner/types.js";
+import { createAgentRunRestartAbortError } from "../../agents/run-termination.js";
+
+const cliDispatchMocks = vi.hoisted(() => ({
+  emitAgentEvent: vi.fn(),
+  runCliAgent: vi.fn(),
+}));
+
+vi.mock("../../agents/cli-runner.js", () => ({
+  runCliAgent: (...args: unknown[]) => cliDispatchMocks.runCliAgent(...args),
+}));
+
+vi.mock("../../infra/agent-events.js", () => ({
+  emitAgentEvent: (...args: unknown[]) => cliDispatchMocks.emitAgentEvent(...args),
+  onAgentEvent: vi.fn(() => () => undefined),
+  withAgentRunLifecycleGeneration: (_generation: string, run: () => unknown) => run(),
+}));
+
 import {
   createCliToolSummaryTracker,
   keepCliSessionBindingOnlyWhenReused,
   runCliAgentWithLifecycle,
 } from "./agent-runner-cli-dispatch.js";
 
-const cliDispatchMocks = vi.hoisted(() => ({
-  emitAgentEvent: vi.fn(),
-  onAgentEvent: vi.fn(() => () => undefined),
-  runCliAgent: vi.fn(),
-}));
-
-vi.mock("../../agents/cli-runner.js", () => ({
-  runCliAgent: cliDispatchMocks.runCliAgent,
-}));
-
-vi.mock("../../infra/agent-events.js", () => ({
-  emitAgentEvent: cliDispatchMocks.emitAgentEvent,
-  onAgentEvent: cliDispatchMocks.onAgentEvent,
-}));
-
-beforeEach(() => {
-  vi.clearAllMocks();
-  cliDispatchMocks.onAgentEvent.mockReturnValue(() => undefined);
-});
-
 describe("runCliAgentWithLifecycle", () => {
-  it("propagates yielded CLI result state on lifecycle end events", async () => {
-    cliDispatchMocks.runCliAgent.mockResolvedValue({
+  it("keeps the captured lifecycle generation on start and terminal events", async () => {
+    cliDispatchMocks.emitAgentEvent.mockClear();
+    cliDispatchMocks.runCliAgent.mockResolvedValueOnce({
+      payloads: [],
+      meta: { durationMs: 1 },
+    } satisfies EmbeddedAgentRunResult);
+
+    await runCliAgentWithLifecycle({
+      runId: "run-before-restart",
+      lifecycleGeneration: "pre-restart-generation",
+      provider: "claude-cli",
+      runParams: {
+        sessionId: "session-1",
+        sessionFile: "/tmp/session.jsonl",
+        workspaceDir: "/tmp/workspace",
+        prompt: "hello",
+        provider: "claude-cli",
+        model: "claude",
+        thinkLevel: "off",
+        timeoutMs: 1_000,
+        runId: "run-before-restart",
+      },
+    });
+
+    const lifecycleEvents = cliDispatchMocks.emitAgentEvent.mock.calls
+      .map(([event]) => event as { stream?: string; lifecycleGeneration?: string })
+      .filter((event) => event.stream === "lifecycle");
+    expect(lifecycleEvents).toHaveLength(2);
+    expect(
+      lifecycleEvents.every((event) => event.lifecycleGeneration === "pre-restart-generation"),
+    ).toBe(true);
+  });
+
+  it("preserves restart ownership when the CLI resolves after cancellation", async () => {
+    cliDispatchMocks.emitAgentEvent.mockClear();
+    const controller = new AbortController();
+    cliDispatchMocks.runCliAgent.mockImplementationOnce(async () => {
+      controller.abort(createAgentRunRestartAbortError());
+      return {
+        payloads: [{ text: "stale result" }],
+        meta: { durationMs: 1 },
+      } satisfies EmbeddedAgentRunResult;
+    });
+
+    await expect(
+      runCliAgentWithLifecycle({
+        runId: "run-restart",
+        provider: "claude-cli",
+        runParams: {
+          sessionId: "session-1",
+          sessionFile: "/tmp/session.jsonl",
+          workspaceDir: "/tmp/workspace",
+          prompt: "hello",
+          provider: "claude-cli",
+          model: "claude",
+          thinkLevel: "off",
+          timeoutMs: 1_000,
+          runId: "run-restart",
+          abortSignal: controller.signal,
+        },
+      }),
+    ).rejects.toThrow("agent run aborted for restart");
+
+    const terminal = cliDispatchMocks.emitAgentEvent.mock.calls
+      .map(([event]) => event as { stream?: string; data?: Record<string, unknown> })
+      .find((event) => event.stream === "lifecycle" && event.data?.phase === "error");
+    expect(terminal?.data).toMatchObject({
+      aborted: true,
+      stopReason: "restart",
+    });
+    expect(
+      cliDispatchMocks.emitAgentEvent.mock.calls.some(
+        ([event]) => (event as { stream?: string }).stream === "assistant",
+      ),
+    ).toBe(false);
+  });
+
+  it("propagates yielded result metadata on lifecycle end", async () => {
+    cliDispatchMocks.emitAgentEvent.mockClear();
+    cliDispatchMocks.runCliAgent.mockResolvedValueOnce({
       payloads: [],
       meta: {
-        durationMs: 12,
+        durationMs: 1,
         yielded: true,
         livenessState: "paused",
         stopReason: "end_turn",
@@ -40,32 +115,25 @@ describe("runCliAgentWithLifecycle", () => {
     } satisfies EmbeddedAgentRunResult);
 
     await runCliAgentWithLifecycle({
-      runId: "run-yielded-cli",
+      runId: "run-yielded",
       provider: "claude-cli",
-      startedAt: 1_000,
       runParams: {
-        sessionId: "session-yielded-cli",
-        sessionFile: "/tmp/session-yielded-cli.jsonl",
-        workspaceDir: "/tmp",
-        prompt: "yield now",
+        sessionId: "session-1",
+        sessionFile: "/tmp/session.jsonl",
+        workspaceDir: "/tmp/workspace",
+        prompt: "hello",
         provider: "claude-cli",
+        model: "claude",
+        thinkLevel: "off",
         timeoutMs: 1_000,
-        runId: "run-yielded-cli",
+        runId: "run-yielded",
       },
     });
 
-    const lifecycleEndEvent = cliDispatchMocks.emitAgentEvent.mock.calls
-      .map(([event]) => event as { runId: string; stream: string; data: Record<string, unknown> })
-      .find(
-        (event) =>
-          event.runId === "run-yielded-cli" &&
-          event.stream === "lifecycle" &&
-          event.data.phase === "end",
-      );
-
-    expect(lifecycleEndEvent?.data).toMatchObject({
-      phase: "end",
-      startedAt: 1_000,
+    const terminal = cliDispatchMocks.emitAgentEvent.mock.calls
+      .map(([event]) => event as { stream?: string; data?: Record<string, unknown> })
+      .find((event) => event.stream === "lifecycle" && event.data?.phase === "end");
+    expect(terminal?.data).toMatchObject({
       yielded: true,
       livenessState: "paused",
       stopReason: "end_turn",

--- a/src/auto-reply/reply/agent-runner-cli-dispatch.test.ts
+++ b/src/auto-reply/reply/agent-runner-cli-dispatch.test.ts
@@ -1,105 +1,75 @@
 // Tests CLI dispatch arguments and runtime selection for agent runner turns.
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { EmbeddedAgentRunResult } from "../../agents/embedded-agent-runner/types.js";
-import { createAgentRunRestartAbortError } from "../../agents/run-termination.js";
-
-const cliDispatchMocks = vi.hoisted(() => ({
-  emitAgentEvent: vi.fn(),
-  runCliAgent: vi.fn(),
-}));
-
-vi.mock("../../agents/cli-runner.js", () => ({
-  runCliAgent: (...args: unknown[]) => cliDispatchMocks.runCliAgent(...args),
-}));
-
-vi.mock("../../infra/agent-events.js", () => ({
-  emitAgentEvent: (...args: unknown[]) => cliDispatchMocks.emitAgentEvent(...args),
-  onAgentEvent: vi.fn(() => () => undefined),
-  withAgentRunLifecycleGeneration: (_generation: string, run: () => unknown) => run(),
-}));
-
 import {
   createCliToolSummaryTracker,
   keepCliSessionBindingOnlyWhenReused,
   runCliAgentWithLifecycle,
 } from "./agent-runner-cli-dispatch.js";
 
+const cliDispatchMocks = vi.hoisted(() => ({
+  emitAgentEvent: vi.fn(),
+  onAgentEvent: vi.fn(() => () => undefined),
+  runCliAgent: vi.fn(),
+}));
+
+vi.mock("../../agents/cli-runner.js", () => ({
+  runCliAgent: cliDispatchMocks.runCliAgent,
+}));
+
+vi.mock("../../infra/agent-events.js", () => ({
+  emitAgentEvent: cliDispatchMocks.emitAgentEvent,
+  onAgentEvent: cliDispatchMocks.onAgentEvent,
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  cliDispatchMocks.onAgentEvent.mockReturnValue(() => undefined);
+});
+
 describe("runCliAgentWithLifecycle", () => {
-  it("keeps the captured lifecycle generation on start and terminal events", async () => {
-    cliDispatchMocks.emitAgentEvent.mockClear();
-    cliDispatchMocks.runCliAgent.mockResolvedValueOnce({
+  it("propagates yielded CLI result state on lifecycle end events", async () => {
+    cliDispatchMocks.runCliAgent.mockResolvedValue({
       payloads: [],
-      meta: { durationMs: 1 },
+      meta: {
+        durationMs: 12,
+        yielded: true,
+        livenessState: "paused",
+        stopReason: "end_turn",
+      },
     } satisfies EmbeddedAgentRunResult);
 
     await runCliAgentWithLifecycle({
-      runId: "run-before-restart",
-      lifecycleGeneration: "pre-restart-generation",
+      runId: "run-yielded-cli",
       provider: "claude-cli",
+      startedAt: 1_000,
       runParams: {
-        sessionId: "session-1",
-        sessionFile: "/tmp/session.jsonl",
-        workspaceDir: "/tmp/workspace",
-        prompt: "hello",
+        sessionId: "session-yielded-cli",
+        sessionFile: "/tmp/session-yielded-cli.jsonl",
+        workspaceDir: "/tmp",
+        prompt: "yield now",
         provider: "claude-cli",
-        model: "claude",
-        thinkLevel: "off",
         timeoutMs: 1_000,
-        runId: "run-before-restart",
+        runId: "run-yielded-cli",
       },
     });
 
-    const lifecycleEvents = cliDispatchMocks.emitAgentEvent.mock.calls
-      .map(([event]) => event as { stream?: string; lifecycleGeneration?: string })
-      .filter((event) => event.stream === "lifecycle");
-    expect(lifecycleEvents).toHaveLength(2);
-    expect(
-      lifecycleEvents.every((event) => event.lifecycleGeneration === "pre-restart-generation"),
-    ).toBe(true);
-  });
+    const lifecycleEndEvent = cliDispatchMocks.emitAgentEvent.mock.calls
+      .map(([event]) => event as { runId: string; stream: string; data: Record<string, unknown> })
+      .find(
+        (event) =>
+          event.runId === "run-yielded-cli" &&
+          event.stream === "lifecycle" &&
+          event.data.phase === "end",
+      );
 
-  it("preserves restart ownership when the CLI resolves after cancellation", async () => {
-    cliDispatchMocks.emitAgentEvent.mockClear();
-    const controller = new AbortController();
-    cliDispatchMocks.runCliAgent.mockImplementationOnce(async () => {
-      controller.abort(createAgentRunRestartAbortError());
-      return {
-        payloads: [{ text: "stale result" }],
-        meta: { durationMs: 1 },
-      } satisfies EmbeddedAgentRunResult;
+    expect(lifecycleEndEvent?.data).toMatchObject({
+      phase: "end",
+      startedAt: 1_000,
+      yielded: true,
+      livenessState: "paused",
+      stopReason: "end_turn",
     });
-
-    await expect(
-      runCliAgentWithLifecycle({
-        runId: "run-restart",
-        provider: "claude-cli",
-        runParams: {
-          sessionId: "session-1",
-          sessionFile: "/tmp/session.jsonl",
-          workspaceDir: "/tmp/workspace",
-          prompt: "hello",
-          provider: "claude-cli",
-          model: "claude",
-          thinkLevel: "off",
-          timeoutMs: 1_000,
-          runId: "run-restart",
-          abortSignal: controller.signal,
-        },
-      }),
-    ).rejects.toThrow("agent run aborted for restart");
-
-    const terminal = cliDispatchMocks.emitAgentEvent.mock.calls
-      .map(([event]) => event as { stream?: string; data?: Record<string, unknown> })
-      .find((event) => event.stream === "lifecycle" && event.data?.phase === "error");
-    expect(terminal?.data).toMatchObject({
-      aborted: true,
-      stopReason: "restart",
-    });
-    expect(
-      cliDispatchMocks.emitAgentEvent.mock.calls.some(
-        ([event]) => (event as { stream?: string }).stream === "assistant",
-      ),
-    ).toBe(false);
   });
 });
 

--- a/src/auto-reply/reply/agent-runner-cli-dispatch.ts
+++ b/src/auto-reply/reply/agent-runner-cli-dispatch.ts
@@ -10,10 +10,20 @@ import { clearCliSession } from "../../agents/cli-session.js";
 import { extractToolResultText } from "../../agents/embedded-agent-subscribe.tools.js";
 import { inferToolMetaFromArgs } from "../../agents/embedded-agent-utils.js";
 import type { EmbeddedAgentRunResult } from "../../agents/embedded-agent.js";
-import { updateSessionStore, type SessionEntry } from "../../config/sessions.js";
+import {
+  isAgentRunRestartAbortReason,
+  resolveAgentRunAbortLifecycleFields,
+} from "../../agents/run-termination.js";
+import type { SessionEntry } from "../../config/sessions.js";
+import { updateSessionEntry } from "../../config/sessions/session-accessor.js";
 import type { AgentEventPayload } from "../../infra/agent-events.js";
-import { emitAgentEvent, onAgentEvent } from "../../infra/agent-events.js";
+import {
+  emitAgentEvent,
+  onAgentEvent,
+  withAgentRunLifecycleGeneration,
+} from "../../infra/agent-events.js";
 import { formatToolAggregate } from "../tool-meta.js";
+import { resolveAgentLifecycleTerminalMetadata } from "./agent-lifecycle-terminal.js";
 
 function isClaudeCliProvider(provider: string): boolean {
   return normalizeLowercaseStringOrEmpty(provider) === "claude-cli";
@@ -181,9 +191,13 @@ export async function clearDroppedCliSessionBinding(params: {
   if (!params.storePath || !params.sessionKey) {
     return;
   }
-  await updateSessionStore(params.storePath, (store) => {
-    clearEntry(store[params.sessionKey!]);
-  });
+  await updateSessionEntry(
+    { storePath: params.storePath, sessionKey: params.sessionKey },
+    (entry) => {
+      clearEntry(entry);
+      return entry;
+    },
+  );
 }
 
 function createToolEventBridge(params: {
@@ -288,8 +302,9 @@ function createCommentaryEventBridge(params: {
   });
 }
 
-export async function runCliAgentWithLifecycle(params: {
+type RunCliAgentWithLifecycleParams = {
   runId: string;
+  lifecycleGeneration?: string;
   provider: string;
   runParams: RunCliAgentParams;
   startedAt?: number;
@@ -303,7 +318,22 @@ export async function runCliAgentWithLifecycle(params: {
   onCommentaryText?: (payload: { text: string; itemId?: string }) => Promise<void>;
   onErrorBeforeLifecycle?: (err: unknown) => Promise<void>;
   transformResult?: (result: EmbeddedAgentRunResult) => EmbeddedAgentRunResult;
-}): Promise<EmbeddedAgentRunResult> {
+};
+
+export function runCliAgentWithLifecycle(
+  params: RunCliAgentWithLifecycleParams,
+): Promise<EmbeddedAgentRunResult> {
+  if (!params.lifecycleGeneration) {
+    return runCliAgentWithLifecycleInternal(params);
+  }
+  return withAgentRunLifecycleGeneration(params.lifecycleGeneration, () =>
+    runCliAgentWithLifecycleInternal(params),
+  );
+}
+
+async function runCliAgentWithLifecycleInternal(
+  params: RunCliAgentWithLifecycleParams,
+): Promise<EmbeddedAgentRunResult> {
   const startedAt = params.startedAt ?? Date.now();
   const emitLifecycleStart = params.emitLifecycleStart ?? true;
   const emitLifecycleTerminal = params.emitLifecycleTerminal ?? true;
@@ -311,6 +341,9 @@ export async function runCliAgentWithLifecycle(params: {
   if (emitLifecycleStart) {
     emitAgentEvent({
       runId: params.runId,
+      ...(params.runParams.sessionKey ? { sessionKey: params.runParams.sessionKey } : {}),
+      ...(params.runParams.sessionId ? { sessionId: params.runParams.sessionId } : {}),
+      ...(params.lifecycleGeneration ? { lifecycleGeneration: params.lifecycleGeneration } : {}),
       stream: "lifecycle",
       data: {
         phase: "start",
@@ -349,6 +382,10 @@ export async function runCliAgentWithLifecycle(params: {
       ...params.runParams,
       emitCommentaryText: Boolean(params.onCommentaryText),
     });
+    const restartAbortReason = params.runParams.abortSignal?.reason;
+    if (isAgentRunRestartAbortReason(restartAbortReason)) {
+      throw restartAbortReason;
+    }
     const result = params.transformResult?.(rawResult) ?? rawResult;
     await stopAgentEventBridges(bridges);
 
@@ -362,22 +399,18 @@ export async function runCliAgentWithLifecycle(params: {
     }
 
     if (emitLifecycleTerminal) {
-      const yieldedLifecycleData =
-        result.meta.yielded === true
-          ? {
-              yielded: true,
-              livenessState: result.meta.livenessState,
-              stopReason: result.meta.stopReason,
-            }
-          : {};
       emitAgentEvent({
         runId: params.runId,
+        ...(params.runParams.sessionKey ? { sessionKey: params.runParams.sessionKey } : {}),
+        ...(params.runParams.sessionId ? { sessionId: params.runParams.sessionId } : {}),
+        ...(params.lifecycleGeneration ? { lifecycleGeneration: params.lifecycleGeneration } : {}),
         stream: "lifecycle",
         data: {
           phase: "end",
           startedAt,
           endedAt: Date.now(),
-          ...yieldedLifecycleData,
+          ...resolveAgentLifecycleTerminalMetadata(result.meta),
+          ...resolveAgentRunAbortLifecycleFields(params.runParams.abortSignal),
         },
       });
       lifecycleTerminalEmitted = true;
@@ -389,12 +422,16 @@ export async function runCliAgentWithLifecycle(params: {
     if (emitLifecycleTerminal) {
       emitAgentEvent({
         runId: params.runId,
+        ...(params.runParams.sessionKey ? { sessionKey: params.runParams.sessionKey } : {}),
+        ...(params.runParams.sessionId ? { sessionId: params.runParams.sessionId } : {}),
+        ...(params.lifecycleGeneration ? { lifecycleGeneration: params.lifecycleGeneration } : {}),
         stream: "lifecycle",
         data: {
           phase: "error",
           startedAt,
           endedAt: Date.now(),
           error: String(err),
+          ...resolveAgentRunAbortLifecycleFields(params.runParams.abortSignal),
         },
       });
       lifecycleTerminalEmitted = true;
@@ -407,12 +444,16 @@ export async function runCliAgentWithLifecycle(params: {
     if (emitLifecycleTerminal && !lifecycleTerminalEmitted) {
       emitAgentEvent({
         runId: params.runId,
+        ...(params.runParams.sessionKey ? { sessionKey: params.runParams.sessionKey } : {}),
+        ...(params.runParams.sessionId ? { sessionId: params.runParams.sessionId } : {}),
+        ...(params.lifecycleGeneration ? { lifecycleGeneration: params.lifecycleGeneration } : {}),
         stream: "lifecycle",
         data: {
           phase: "error",
           startedAt,
           endedAt: Date.now(),
           error: "CLI run completed without lifecycle terminal event",
+          ...resolveAgentRunAbortLifecycleFields(params.runParams.abortSignal),
         },
       });
     }

--- a/src/auto-reply/reply/agent-runner-cli-dispatch.ts
+++ b/src/auto-reply/reply/agent-runner-cli-dispatch.ts
@@ -10,18 +10,9 @@ import { clearCliSession } from "../../agents/cli-session.js";
 import { extractToolResultText } from "../../agents/embedded-agent-subscribe.tools.js";
 import { inferToolMetaFromArgs } from "../../agents/embedded-agent-utils.js";
 import type { EmbeddedAgentRunResult } from "../../agents/embedded-agent.js";
-import {
-  isAgentRunRestartAbortReason,
-  resolveAgentRunAbortLifecycleFields,
-} from "../../agents/run-termination.js";
-import type { SessionEntry } from "../../config/sessions.js";
-import { updateSessionEntry } from "../../config/sessions/session-accessor.js";
+import { updateSessionStore, type SessionEntry } from "../../config/sessions.js";
 import type { AgentEventPayload } from "../../infra/agent-events.js";
-import {
-  emitAgentEvent,
-  onAgentEvent,
-  withAgentRunLifecycleGeneration,
-} from "../../infra/agent-events.js";
+import { emitAgentEvent, onAgentEvent } from "../../infra/agent-events.js";
 import { formatToolAggregate } from "../tool-meta.js";
 
 function isClaudeCliProvider(provider: string): boolean {
@@ -190,13 +181,9 @@ export async function clearDroppedCliSessionBinding(params: {
   if (!params.storePath || !params.sessionKey) {
     return;
   }
-  await updateSessionEntry(
-    { storePath: params.storePath, sessionKey: params.sessionKey },
-    (entry) => {
-      clearEntry(entry);
-      return entry;
-    },
-  );
+  await updateSessionStore(params.storePath, (store) => {
+    clearEntry(store[params.sessionKey!]);
+  });
 }
 
 function createToolEventBridge(params: {
@@ -301,9 +288,8 @@ function createCommentaryEventBridge(params: {
   });
 }
 
-type RunCliAgentWithLifecycleParams = {
+export async function runCliAgentWithLifecycle(params: {
   runId: string;
-  lifecycleGeneration?: string;
   provider: string;
   runParams: RunCliAgentParams;
   startedAt?: number;
@@ -317,22 +303,7 @@ type RunCliAgentWithLifecycleParams = {
   onCommentaryText?: (payload: { text: string; itemId?: string }) => Promise<void>;
   onErrorBeforeLifecycle?: (err: unknown) => Promise<void>;
   transformResult?: (result: EmbeddedAgentRunResult) => EmbeddedAgentRunResult;
-};
-
-export function runCliAgentWithLifecycle(
-  params: RunCliAgentWithLifecycleParams,
-): Promise<EmbeddedAgentRunResult> {
-  if (!params.lifecycleGeneration) {
-    return runCliAgentWithLifecycleInternal(params);
-  }
-  return withAgentRunLifecycleGeneration(params.lifecycleGeneration, () =>
-    runCliAgentWithLifecycleInternal(params),
-  );
-}
-
-async function runCliAgentWithLifecycleInternal(
-  params: RunCliAgentWithLifecycleParams,
-): Promise<EmbeddedAgentRunResult> {
+}): Promise<EmbeddedAgentRunResult> {
   const startedAt = params.startedAt ?? Date.now();
   const emitLifecycleStart = params.emitLifecycleStart ?? true;
   const emitLifecycleTerminal = params.emitLifecycleTerminal ?? true;
@@ -340,9 +311,6 @@ async function runCliAgentWithLifecycleInternal(
   if (emitLifecycleStart) {
     emitAgentEvent({
       runId: params.runId,
-      ...(params.runParams.sessionKey ? { sessionKey: params.runParams.sessionKey } : {}),
-      ...(params.runParams.sessionId ? { sessionId: params.runParams.sessionId } : {}),
-      ...(params.lifecycleGeneration ? { lifecycleGeneration: params.lifecycleGeneration } : {}),
       stream: "lifecycle",
       data: {
         phase: "start",
@@ -381,10 +349,6 @@ async function runCliAgentWithLifecycleInternal(
       ...params.runParams,
       emitCommentaryText: Boolean(params.onCommentaryText),
     });
-    const restartAbortReason = params.runParams.abortSignal?.reason;
-    if (isAgentRunRestartAbortReason(restartAbortReason)) {
-      throw restartAbortReason;
-    }
     const result = params.transformResult?.(rawResult) ?? rawResult;
     await stopAgentEventBridges(bridges);
 
@@ -398,17 +362,22 @@ async function runCliAgentWithLifecycleInternal(
     }
 
     if (emitLifecycleTerminal) {
+      const yieldedLifecycleData =
+        result.meta.yielded === true
+          ? {
+              yielded: true,
+              livenessState: result.meta.livenessState,
+              stopReason: result.meta.stopReason,
+            }
+          : {};
       emitAgentEvent({
         runId: params.runId,
-        ...(params.runParams.sessionKey ? { sessionKey: params.runParams.sessionKey } : {}),
-        ...(params.runParams.sessionId ? { sessionId: params.runParams.sessionId } : {}),
-        ...(params.lifecycleGeneration ? { lifecycleGeneration: params.lifecycleGeneration } : {}),
         stream: "lifecycle",
         data: {
           phase: "end",
           startedAt,
           endedAt: Date.now(),
-          ...resolveAgentRunAbortLifecycleFields(params.runParams.abortSignal),
+          ...yieldedLifecycleData,
         },
       });
       lifecycleTerminalEmitted = true;
@@ -420,16 +389,12 @@ async function runCliAgentWithLifecycleInternal(
     if (emitLifecycleTerminal) {
       emitAgentEvent({
         runId: params.runId,
-        ...(params.runParams.sessionKey ? { sessionKey: params.runParams.sessionKey } : {}),
-        ...(params.runParams.sessionId ? { sessionId: params.runParams.sessionId } : {}),
-        ...(params.lifecycleGeneration ? { lifecycleGeneration: params.lifecycleGeneration } : {}),
         stream: "lifecycle",
         data: {
           phase: "error",
           startedAt,
           endedAt: Date.now(),
           error: String(err),
-          ...resolveAgentRunAbortLifecycleFields(params.runParams.abortSignal),
         },
       });
       lifecycleTerminalEmitted = true;
@@ -442,16 +407,12 @@ async function runCliAgentWithLifecycleInternal(
     if (emitLifecycleTerminal && !lifecycleTerminalEmitted) {
       emitAgentEvent({
         runId: params.runId,
-        ...(params.runParams.sessionKey ? { sessionKey: params.runParams.sessionKey } : {}),
-        ...(params.runParams.sessionId ? { sessionId: params.runParams.sessionId } : {}),
-        ...(params.lifecycleGeneration ? { lifecycleGeneration: params.lifecycleGeneration } : {}),
         stream: "lifecycle",
         data: {
           phase: "error",
           startedAt,
           endedAt: Date.now(),
           error: "CLI run completed without lifecycle terminal event",
-          ...resolveAgentRunAbortLifecycleFields(params.runParams.abortSignal),
         },
       });
     }

--- a/src/gateway/mcp-http.loopback-runtime.ts
+++ b/src/gateway/mcp-http.loopback-runtime.ts
@@ -1,319 +1,49 @@
 // Process-local MCP loopback runtime state for owner/non-owner HTTP access.
+type McpLoopbackYieldContext = {
+  yielded: boolean;
+  message?: string;
+};
+
 type McpLoopbackRuntime = {
   port: number;
   ownerToken: string;
   nonOwnerToken: string;
 };
 
-export type McpLoopbackToolCallResult = {
-  toolName: string;
-  args: Record<string, unknown>;
-  result?: unknown;
-  isError: boolean;
-};
-
-export type McpLoopbackToolCallStart = Pick<McpLoopbackToolCallResult, "toolName" | "args">;
-
-type McpLoopbackToolCallCapture = {
-  onRequestStart?: () => void;
-  onRequestClassified?: () => void;
-  onRequestFinish?: () => void;
-  onToolCallStart?: (call: McpLoopbackToolCallStart) => void;
-  onToolCallUpdate?: (calls: {
-    previous: McpLoopbackToolCallStart;
-    current: McpLoopbackToolCallStart;
-  }) => void;
-  onToolCallFinish?: (call: McpLoopbackToolCallStart, state: { prepared: boolean }) => void;
-  onToolCallResult: (call: McpLoopbackToolCallResult) => void;
-  inFlight: number;
-  activityVersion: number;
-  activityWaiters: Set<() => void>;
-};
-
-export type McpLoopbackRequestCaptureHandle = {
-  capture: McpLoopbackToolCallCapture;
-  classified: boolean;
-  finished: boolean;
-};
-
-export type McpLoopbackToolCallCaptureHandle = {
-  capture: McpLoopbackToolCallCapture;
-  call: McpLoopbackToolCallStart;
-  prepared: boolean;
-  finished: boolean;
-};
-
 let activeRuntime: McpLoopbackRuntime | undefined;
-const toolCallCaptures = new Map<string, McpLoopbackToolCallCapture>();
+const activeYieldContexts = new Map<string, McpLoopbackYieldContext>();
 
-function deleteMcpLoopbackToolCallCapture(captureKey: string): void {
-  const capture = toolCallCaptures.get(captureKey);
-  if (!capture) {
-    return;
-  }
-  toolCallCaptures.delete(captureKey);
-  for (const resolve of capture.activityWaiters) {
-    resolve();
-  }
-  capture.activityWaiters.clear();
+/** Register yield state for the CLI run that owns a loopback MCP session id. */
+export function registerMcpLoopbackYieldContext(sessionId: string): McpLoopbackYieldContext {
+  const context: McpLoopbackYieldContext = { yielded: false };
+  activeYieldContexts.set(sessionId, context);
+  return context;
 }
 
-function notifyMcpLoopbackToolCallCaptureActivity(capture: McpLoopbackToolCallCapture): void {
-  capture.activityVersion += 1;
-  for (const resolve of capture.activityWaiters) {
-    resolve();
-  }
-  capture.activityWaiters.clear();
-}
-
-/** Start loopback tool-call result capture for one serialized CLI invocation. */
-export function beginMcpLoopbackToolCallCapture(params: {
-  captureKey: string;
-  onRequestStart?: () => void;
-  onRequestClassified?: () => void;
-  onRequestFinish?: () => void;
-  onToolCallStart?: (call: McpLoopbackToolCallStart) => void;
-  onToolCallUpdate?: (calls: {
-    previous: McpLoopbackToolCallStart;
-    current: McpLoopbackToolCallStart;
-  }) => void;
-  onToolCallFinish?: (call: McpLoopbackToolCallStart, state: { prepared: boolean }) => void;
-  onToolCallResult: (call: McpLoopbackToolCallResult) => void;
-}): void {
-  const captureKey = params.captureKey.trim();
-  if (!captureKey) {
-    return;
-  }
-  toolCallCaptures.set(captureKey, {
-    onRequestStart: params.onRequestStart,
-    onRequestClassified: params.onRequestClassified,
-    onRequestFinish: params.onRequestFinish,
-    onToolCallStart: params.onToolCallStart,
-    onToolCallUpdate: params.onToolCallUpdate,
-    onToolCallFinish: params.onToolCallFinish,
-    onToolCallResult: params.onToolCallResult,
-    inFlight: 0,
-    activityVersion: 0,
-    activityWaiters: new Set(),
-  });
-}
-
-/** Bind an authenticated HTTP request to the active capture generation before reading its body. */
-export function markMcpLoopbackRequestStarted(
-  captureKey: string | undefined,
-): McpLoopbackRequestCaptureHandle | undefined {
-  const normalizedKey = captureKey?.trim() ?? "";
-  if (!normalizedKey) {
+/** Resolve the yield callback visible to loopback-scoped sessions_yield tools. */
+export function resolveMcpLoopbackYieldHandler(
+  sessionId: string | undefined,
+): ((message: string) => void) | undefined {
+  if (!sessionId) {
     return undefined;
   }
-  const capture = toolCallCaptures.get(normalizedKey);
-  if (!capture) {
+  const context = activeYieldContexts.get(sessionId);
+  if (!context) {
     return undefined;
   }
-  capture.inFlight += 1;
-  notifyMcpLoopbackToolCallCaptureActivity(capture);
-  try {
-    capture.onRequestStart?.();
-  } catch {
-    // Delivery observation is diagnostic state; it must not alter request handling.
-  }
-  return { capture, classified: false, finished: false };
+  return (message: string) => {
+    context.yielded = true;
+    context.message = message;
+  };
 }
 
-/** Mark a request body as parsed so it no longer represents an unknown possible send. */
-export function markMcpLoopbackRequestClassified(
-  captureHandle: McpLoopbackRequestCaptureHandle | undefined,
+/** Clear yield state without removing a newer run that reused the same session id. */
+export function clearMcpLoopbackYieldContext(
+  sessionId: string,
+  context: McpLoopbackYieldContext,
 ): void {
-  if (!captureHandle || captureHandle.classified || captureHandle.finished) {
-    return;
-  }
-  captureHandle.classified = true;
-  try {
-    captureHandle.capture.onRequestClassified?.();
-  } catch {
-    // Delivery observation is diagnostic state; it must not alter request handling.
-  }
-}
-
-/** Mark an authenticated request as settled and wake capture drains. */
-export function markMcpLoopbackRequestFinished(
-  captureHandle: McpLoopbackRequestCaptureHandle | undefined,
-): void {
-  if (!captureHandle || captureHandle.finished) {
-    return;
-  }
-  markMcpLoopbackRequestClassified(captureHandle);
-  captureHandle.finished = true;
-  const { capture } = captureHandle;
-  try {
-    capture.onRequestFinish?.();
-  } catch {
-    // Delivery observation is diagnostic state; it must not alter request handling.
-  }
-  capture.inFlight = Math.max(0, capture.inFlight - 1);
-  notifyMcpLoopbackToolCallCaptureActivity(capture);
-}
-
-/** Mark a captured loopback tool call as in flight. */
-export function markMcpLoopbackToolCallStarted(params: {
-  captureKey?: string;
-  requestCaptureHandle?: McpLoopbackRequestCaptureHandle;
-  toolName: string;
-  args: Record<string, unknown>;
-}): McpLoopbackToolCallCaptureHandle | undefined {
-  const toolName = params.toolName.trim();
-  if (!toolName || params.requestCaptureHandle?.finished) {
-    return undefined;
-  }
-  const captureKey = params.captureKey?.trim() ?? "";
-  const capture = params.requestCaptureHandle?.capture ?? toolCallCaptures.get(captureKey);
-  if (!capture) {
-    return undefined;
-  }
-  const call = { toolName, args: params.args };
-  capture.inFlight += 1;
-  notifyMcpLoopbackToolCallCaptureActivity(capture);
-  try {
-    capture.onToolCallStart?.(call);
-  } catch {
-    // Delivery observation is diagnostic state; it must not alter tool execution.
-  }
-  return { capture, call, prepared: false, finished: false };
-}
-
-/** Update an admitted call with the final arguments produced by gateway hooks. */
-export function updateMcpLoopbackToolCallCapture(
-  captureHandle: McpLoopbackToolCallCaptureHandle | undefined,
-  call: McpLoopbackToolCallStart,
-): void {
-  if (!captureHandle || captureHandle.finished) {
-    return;
-  }
-  const previous = captureHandle.call;
-  captureHandle.call = call;
-  captureHandle.prepared = true;
-  try {
-    captureHandle.capture.onToolCallUpdate?.({ previous, current: call });
-  } catch {
-    // Delivery observation is diagnostic state; it must not alter tool execution.
-  }
-}
-
-/** Report a completed call without letting observer failures alter tool execution. */
-export function recordMcpLoopbackToolCallResult(params: {
-  captureHandle: McpLoopbackToolCallCaptureHandle;
-  toolName: string;
-  args: Record<string, unknown>;
-  result?: unknown;
-  isError: boolean;
-}): void {
-  const toolName = params.toolName.trim();
-  if (!toolName) {
-    return;
-  }
-  try {
-    params.captureHandle.capture.onToolCallResult({
-      toolName,
-      args: params.args,
-      result: params.result,
-      isError: params.isError,
-    });
-  } catch {
-    // Delivery observation is diagnostic state; it must not turn a successful tool call into error.
-  }
-}
-
-/** Mark a captured loopback tool call as settled and wake idle drains. */
-export function markMcpLoopbackToolCallFinished(
-  captureHandle: McpLoopbackToolCallCaptureHandle | undefined,
-): void {
-  if (!captureHandle || captureHandle.finished) {
-    return;
-  }
-  captureHandle.finished = true;
-  const { capture } = captureHandle;
-  try {
-    capture.onToolCallFinish?.(captureHandle.call, { prepared: captureHandle.prepared });
-  } catch {
-    // Delivery observation is diagnostic state; it must not alter tool execution.
-  }
-  capture.inFlight = Math.max(0, capture.inFlight - 1);
-  notifyMcpLoopbackToolCallCaptureActivity(capture);
-}
-
-async function waitForMcpLoopbackToolCallCaptureActivity(
-  capture: McpLoopbackToolCallCapture,
-  timeoutMs: number,
-): Promise<boolean> {
-  return await new Promise<boolean>((resolve) => {
-    let settled = false;
-    const finish = (active: boolean) => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      clearTimeout(timer);
-      capture.activityWaiters.delete(resolveActivity);
-      resolve(active);
-    };
-    const resolveActivity = () => finish(true);
-    const timer = setTimeout(() => finish(false), Math.max(0, timeoutMs));
-    timer.unref?.();
-    capture.activityWaiters.add(resolveActivity);
-  });
-}
-
-/** Wait for admitted calls to settle and for a quiet request-admission grace. */
-export async function waitForMcpLoopbackToolCallCaptureIdle(
-  captureKey: string,
-  options: {
-    timeoutMs: number;
-    admissionGraceMs: number;
-  },
-): Promise<boolean> {
-  const normalizedKey = captureKey.trim();
-  const capture = toolCallCaptures.get(normalizedKey);
-  if (!capture) {
-    return true;
-  }
-  const deadline = Date.now() + Math.max(0, options.timeoutMs);
-  while (toolCallCaptures.get(normalizedKey) === capture) {
-    const remainingMs = deadline - Date.now();
-    if (remainingMs <= 0) {
-      return false;
-    }
-    if (capture.inFlight > 0) {
-      await waitForMcpLoopbackToolCallCaptureActivity(capture, remainingMs);
-      continue;
-    }
-    const admissionGraceMs = Math.max(0, options.admissionGraceMs);
-    if (admissionGraceMs === 0) {
-      return true;
-    }
-    const activityVersion = capture.activityVersion;
-    const quietWaitMs = Math.min(admissionGraceMs, remainingMs);
-    const sawActivity = await waitForMcpLoopbackToolCallCaptureActivity(capture, quietWaitMs);
-    if (
-      !sawActivity &&
-      quietWaitMs === admissionGraceMs &&
-      capture.inFlight === 0 &&
-      capture.activityVersion === activityVersion
-    ) {
-      return true;
-    }
-  }
-  return true;
-}
-
-/** Clear an unfinished invocation capture. Attempt keys are unique per CLI execution. */
-export function clearMcpLoopbackToolCallCapture(captureKey: string): void {
-  deleteMcpLoopbackToolCallCapture(captureKey.trim());
-}
-
-/** Clear transient capture state between isolated tests. */
-export function clearMcpLoopbackToolCallCapturesForTest(): void {
-  for (const captureKey of toolCallCaptures.keys()) {
-    deleteMcpLoopbackToolCallCapture(captureKey);
+  if (activeYieldContexts.get(sessionId) === context) {
+    activeYieldContexts.delete(sessionId);
   }
 }
 
@@ -352,6 +82,7 @@ export function createMcpLoopbackServerConfig(port: number) {
         headers: {
           Authorization: "Bearer ${OPENCLAW_MCP_TOKEN}",
           "x-session-key": "${OPENCLAW_MCP_SESSION_KEY}",
+          "x-openclaw-session-id": "${OPENCLAW_MCP_SESSION_ID}",
           "x-openclaw-agent-id": "${OPENCLAW_MCP_AGENT_ID}",
           "x-openclaw-account-id": "${OPENCLAW_MCP_ACCOUNT_ID}",
           "x-openclaw-message-channel": "${OPENCLAW_MCP_MESSAGE_CHANNEL}",
@@ -361,9 +92,6 @@ export function createMcpLoopbackServerConfig(port: number) {
           "x-openclaw-current-inbound-audio": "${OPENCLAW_MCP_CURRENT_INBOUND_AUDIO}",
           "x-openclaw-inbound-event-kind": "${OPENCLAW_MCP_INBOUND_EVENT_KIND}",
           "x-openclaw-source-reply-delivery-mode": "${OPENCLAW_MCP_SOURCE_REPLY_DELIVERY_MODE}",
-          "x-openclaw-require-explicit-message-target":
-            "${OPENCLAW_MCP_REQUIRE_EXPLICIT_MESSAGE_TARGET}",
-          "x-openclaw-cli-capture-key": "${OPENCLAW_MCP_CLI_CAPTURE_KEY}",
         },
       },
     },

--- a/src/gateway/mcp-http.loopback-runtime.ts
+++ b/src/gateway/mcp-http.loopback-runtime.ts
@@ -1,65 +1,344 @@
 // Process-local MCP loopback runtime state for owner/non-owner HTTP access.
-type McpLoopbackYieldContext = {
-  yielded: boolean;
-  message?: string;
-  cacheKey: string;
-};
-
 type McpLoopbackRuntime = {
   port: number;
   ownerToken: string;
   nonOwnerToken: string;
 };
 
+export type McpLoopbackToolCallResult = {
+  toolName: string;
+  args: Record<string, unknown>;
+  result?: unknown;
+  isError: boolean;
+};
+
+export type McpLoopbackToolCallStart = Pick<McpLoopbackToolCallResult, "toolName" | "args">;
+
+type McpLoopbackToolCallCapture = {
+  generation: number;
+  onYield?: (message: string) => Promise<void> | void;
+  onRequestStart?: () => void;
+  onRequestClassified?: () => void;
+  onRequestFinish?: () => void;
+  onToolCallStart?: (call: McpLoopbackToolCallStart) => void;
+  onToolCallUpdate?: (calls: {
+    previous: McpLoopbackToolCallStart;
+    current: McpLoopbackToolCallStart;
+  }) => void;
+  onToolCallFinish?: (call: McpLoopbackToolCallStart, state: { prepared: boolean }) => void;
+  onToolCallResult: (call: McpLoopbackToolCallResult) => void;
+  inFlight: number;
+  activityVersion: number;
+  activityWaiters: Set<() => void>;
+};
+
+export type McpLoopbackRequestCaptureHandle = {
+  capture: McpLoopbackToolCallCapture;
+  classified: boolean;
+  finished: boolean;
+};
+
+export type McpLoopbackToolCallCaptureHandle = {
+  capture: McpLoopbackToolCallCapture;
+  call: McpLoopbackToolCallStart;
+  prepared: boolean;
+  finished: boolean;
+};
+
 let activeRuntime: McpLoopbackRuntime | undefined;
-let nextYieldContextSequence = 0;
-const activeYieldContexts = new Map<string, McpLoopbackYieldContext>();
+let nextToolCallCaptureGeneration = 0;
+const toolCallCaptures = new Map<string, McpLoopbackToolCallCapture>();
 
-/** Register yield state for the CLI run that owns a loopback MCP session id. */
-export function registerMcpLoopbackYieldContext(sessionId: string): McpLoopbackYieldContext {
-  nextYieldContextSequence += 1;
-  const context: McpLoopbackYieldContext = {
-    yielded: false,
-    cacheKey: `${sessionId}:${nextYieldContextSequence}`,
+function deleteMcpLoopbackToolCallCapture(captureKey: string): void {
+  const capture = toolCallCaptures.get(captureKey);
+  if (!capture) {
+    return;
+  }
+  toolCallCaptures.delete(captureKey);
+  for (const resolve of capture.activityWaiters) {
+    resolve();
+  }
+  capture.activityWaiters.clear();
+}
+
+function notifyMcpLoopbackToolCallCaptureActivity(capture: McpLoopbackToolCallCapture): void {
+  capture.activityVersion += 1;
+  for (const resolve of capture.activityWaiters) {
+    resolve();
+  }
+  capture.activityWaiters.clear();
+}
+
+/** Start loopback tool-call result capture for one serialized CLI invocation. */
+export function beginMcpLoopbackToolCallCapture(params: {
+  captureKey: string;
+  onYield?: (message: string) => Promise<void> | void;
+  onRequestStart?: () => void;
+  onRequestClassified?: () => void;
+  onRequestFinish?: () => void;
+  onToolCallStart?: (call: McpLoopbackToolCallStart) => void;
+  onToolCallUpdate?: (calls: {
+    previous: McpLoopbackToolCallStart;
+    current: McpLoopbackToolCallStart;
+  }) => void;
+  onToolCallFinish?: (call: McpLoopbackToolCallStart, state: { prepared: boolean }) => void;
+  onToolCallResult: (call: McpLoopbackToolCallResult) => void;
+}): void {
+  const captureKey = params.captureKey.trim();
+  if (!captureKey) {
+    return;
+  }
+  nextToolCallCaptureGeneration += 1;
+  toolCallCaptures.set(captureKey, {
+    generation: nextToolCallCaptureGeneration,
+    onYield: params.onYield,
+    onRequestStart: params.onRequestStart,
+    onRequestClassified: params.onRequestClassified,
+    onRequestFinish: params.onRequestFinish,
+    onToolCallStart: params.onToolCallStart,
+    onToolCallUpdate: params.onToolCallUpdate,
+    onToolCallFinish: params.onToolCallFinish,
+    onToolCallResult: params.onToolCallResult,
+    inFlight: 0,
+    activityVersion: 0,
+    activityWaiters: new Set(),
+  });
+}
+
+/** Resolve yield state bound to the request's admitted CLI capture generation. */
+export function resolveMcpLoopbackYieldContext(
+  captureHandle: McpLoopbackRequestCaptureHandle | undefined,
+): { cacheKey: string; onYield: (message: string) => Promise<void> } | undefined {
+  const capture = captureHandle?.capture;
+  if (!capture?.onYield) {
+    return undefined;
+  }
+  return {
+    cacheKey: String(capture.generation),
+    onYield: async (message: string) => {
+      await capture.onYield?.(message);
+    },
   };
-  activeYieldContexts.set(sessionId, context);
-  return context;
 }
 
-/** Resolve the yield callback visible to loopback-scoped sessions_yield tools. */
-export function resolveMcpLoopbackYieldHandler(
-  sessionId: string | undefined,
-): ((message: string) => void) | undefined {
-  if (!sessionId) {
+/** Bind an authenticated HTTP request to the active capture generation before reading its body. */
+export function markMcpLoopbackRequestStarted(
+  captureKey: string | undefined,
+): McpLoopbackRequestCaptureHandle | undefined {
+  const normalizedKey = captureKey?.trim() ?? "";
+  if (!normalizedKey) {
     return undefined;
   }
-  const context = activeYieldContexts.get(sessionId);
-  if (!context) {
+  const capture = toolCallCaptures.get(normalizedKey);
+  if (!capture) {
     return undefined;
   }
-  return (message: string) => {
-    context.yielded = true;
-    context.message = message;
-  };
+  capture.inFlight += 1;
+  notifyMcpLoopbackToolCallCaptureActivity(capture);
+  try {
+    capture.onRequestStart?.();
+  } catch {
+    // Delivery observation is diagnostic state; it must not alter request handling.
+  }
+  return { capture, classified: false, finished: false };
 }
 
-export function resolveMcpLoopbackYieldContextCacheKey(
-  sessionId: string | undefined,
-): string | undefined {
-  if (!sessionId) {
-    return undefined;
-  }
-  return activeYieldContexts.get(sessionId)?.cacheKey;
-}
-
-/** Clear yield state without removing a newer run that reused the same session id. */
-export function clearMcpLoopbackYieldContext(
-  sessionId: string,
-  context: McpLoopbackYieldContext,
+/** Mark a request body as parsed so it no longer represents an unknown possible send. */
+export function markMcpLoopbackRequestClassified(
+  captureHandle: McpLoopbackRequestCaptureHandle | undefined,
 ): void {
-  if (activeYieldContexts.get(sessionId) === context) {
-    activeYieldContexts.delete(sessionId);
+  if (!captureHandle || captureHandle.classified || captureHandle.finished) {
+    return;
   }
+  captureHandle.classified = true;
+  try {
+    captureHandle.capture.onRequestClassified?.();
+  } catch {
+    // Delivery observation is diagnostic state; it must not alter request handling.
+  }
+}
+
+/** Mark an authenticated request as settled and wake capture drains. */
+export function markMcpLoopbackRequestFinished(
+  captureHandle: McpLoopbackRequestCaptureHandle | undefined,
+): void {
+  if (!captureHandle || captureHandle.finished) {
+    return;
+  }
+  markMcpLoopbackRequestClassified(captureHandle);
+  captureHandle.finished = true;
+  const { capture } = captureHandle;
+  try {
+    capture.onRequestFinish?.();
+  } catch {
+    // Delivery observation is diagnostic state; it must not alter request handling.
+  }
+  capture.inFlight = Math.max(0, capture.inFlight - 1);
+  notifyMcpLoopbackToolCallCaptureActivity(capture);
+}
+
+/** Mark a captured loopback tool call as in flight. */
+export function markMcpLoopbackToolCallStarted(params: {
+  captureKey?: string;
+  requestCaptureHandle?: McpLoopbackRequestCaptureHandle;
+  toolName: string;
+  args: Record<string, unknown>;
+}): McpLoopbackToolCallCaptureHandle | undefined {
+  const toolName = params.toolName.trim();
+  if (!toolName || params.requestCaptureHandle?.finished) {
+    return undefined;
+  }
+  const captureKey = params.captureKey?.trim() ?? "";
+  const capture = params.requestCaptureHandle?.capture ?? toolCallCaptures.get(captureKey);
+  if (!capture) {
+    return undefined;
+  }
+  const call = { toolName, args: params.args };
+  capture.inFlight += 1;
+  notifyMcpLoopbackToolCallCaptureActivity(capture);
+  try {
+    capture.onToolCallStart?.(call);
+  } catch {
+    // Delivery observation is diagnostic state; it must not alter tool execution.
+  }
+  return { capture, call, prepared: false, finished: false };
+}
+
+/** Update an admitted call with the final arguments produced by gateway hooks. */
+export function updateMcpLoopbackToolCallCapture(
+  captureHandle: McpLoopbackToolCallCaptureHandle | undefined,
+  call: McpLoopbackToolCallStart,
+): void {
+  if (!captureHandle || captureHandle.finished) {
+    return;
+  }
+  const previous = captureHandle.call;
+  captureHandle.call = call;
+  captureHandle.prepared = true;
+  try {
+    captureHandle.capture.onToolCallUpdate?.({ previous, current: call });
+  } catch {
+    // Delivery observation is diagnostic state; it must not alter tool execution.
+  }
+}
+
+/** Report a completed call without letting observer failures alter tool execution. */
+export function recordMcpLoopbackToolCallResult(params: {
+  captureHandle: McpLoopbackToolCallCaptureHandle;
+  toolName: string;
+  args: Record<string, unknown>;
+  result?: unknown;
+  isError: boolean;
+}): void {
+  const toolName = params.toolName.trim();
+  if (!toolName) {
+    return;
+  }
+  try {
+    params.captureHandle.capture.onToolCallResult({
+      toolName,
+      args: params.args,
+      result: params.result,
+      isError: params.isError,
+    });
+  } catch {
+    // Delivery observation is diagnostic state; it must not turn a successful tool call into error.
+  }
+}
+
+/** Mark a captured loopback tool call as settled and wake idle drains. */
+export function markMcpLoopbackToolCallFinished(
+  captureHandle: McpLoopbackToolCallCaptureHandle | undefined,
+): void {
+  if (!captureHandle || captureHandle.finished) {
+    return;
+  }
+  captureHandle.finished = true;
+  const { capture } = captureHandle;
+  try {
+    capture.onToolCallFinish?.(captureHandle.call, { prepared: captureHandle.prepared });
+  } catch {
+    // Delivery observation is diagnostic state; it must not alter tool execution.
+  }
+  capture.inFlight = Math.max(0, capture.inFlight - 1);
+  notifyMcpLoopbackToolCallCaptureActivity(capture);
+}
+
+async function waitForMcpLoopbackToolCallCaptureActivity(
+  capture: McpLoopbackToolCallCapture,
+  timeoutMs: number,
+): Promise<boolean> {
+  return await new Promise<boolean>((resolve) => {
+    let settled = false;
+    const finish = (active: boolean) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      capture.activityWaiters.delete(resolveActivity);
+      resolve(active);
+    };
+    const resolveActivity = () => finish(true);
+    const timer = setTimeout(() => finish(false), Math.max(0, timeoutMs));
+    timer.unref?.();
+    capture.activityWaiters.add(resolveActivity);
+  });
+}
+
+/** Wait for admitted calls to settle and for a quiet request-admission grace. */
+export async function waitForMcpLoopbackToolCallCaptureIdle(
+  captureKey: string,
+  options: {
+    timeoutMs: number;
+    admissionGraceMs: number;
+  },
+): Promise<boolean> {
+  const normalizedKey = captureKey.trim();
+  const capture = toolCallCaptures.get(normalizedKey);
+  if (!capture) {
+    return true;
+  }
+  const deadline = Date.now() + Math.max(0, options.timeoutMs);
+  while (toolCallCaptures.get(normalizedKey) === capture) {
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) {
+      return false;
+    }
+    if (capture.inFlight > 0) {
+      await waitForMcpLoopbackToolCallCaptureActivity(capture, remainingMs);
+      continue;
+    }
+    const admissionGraceMs = Math.max(0, options.admissionGraceMs);
+    if (admissionGraceMs === 0) {
+      return true;
+    }
+    const activityVersion = capture.activityVersion;
+    const quietWaitMs = Math.min(admissionGraceMs, remainingMs);
+    const sawActivity = await waitForMcpLoopbackToolCallCaptureActivity(capture, quietWaitMs);
+    if (
+      !sawActivity &&
+      quietWaitMs === admissionGraceMs &&
+      capture.inFlight === 0 &&
+      capture.activityVersion === activityVersion
+    ) {
+      return true;
+    }
+  }
+  return true;
+}
+
+/** Clear an unfinished invocation capture. Attempt keys are unique per CLI execution. */
+export function clearMcpLoopbackToolCallCapture(captureKey: string): void {
+  deleteMcpLoopbackToolCallCapture(captureKey.trim());
+}
+
+/** Clear transient capture state between isolated tests. */
+export function clearMcpLoopbackToolCallCapturesForTest(): void {
+  for (const captureKey of toolCallCaptures.keys()) {
+    deleteMcpLoopbackToolCallCapture(captureKey);
+  }
+  nextToolCallCaptureGeneration = 0;
 }
 
 /** Return a copy of the active loopback runtime, if one has been installed. */
@@ -107,6 +386,9 @@ export function createMcpLoopbackServerConfig(port: number) {
           "x-openclaw-current-inbound-audio": "${OPENCLAW_MCP_CURRENT_INBOUND_AUDIO}",
           "x-openclaw-inbound-event-kind": "${OPENCLAW_MCP_INBOUND_EVENT_KIND}",
           "x-openclaw-source-reply-delivery-mode": "${OPENCLAW_MCP_SOURCE_REPLY_DELIVERY_MODE}",
+          "x-openclaw-require-explicit-message-target":
+            "${OPENCLAW_MCP_REQUIRE_EXPLICIT_MESSAGE_TARGET}",
+          "x-openclaw-cli-capture-key": "${OPENCLAW_MCP_CLI_CAPTURE_KEY}",
         },
       },
     },

--- a/src/gateway/mcp-http.loopback-runtime.ts
+++ b/src/gateway/mcp-http.loopback-runtime.ts
@@ -2,6 +2,7 @@
 type McpLoopbackYieldContext = {
   yielded: boolean;
   message?: string;
+  cacheKey: string;
 };
 
 type McpLoopbackRuntime = {
@@ -11,11 +12,16 @@ type McpLoopbackRuntime = {
 };
 
 let activeRuntime: McpLoopbackRuntime | undefined;
+let nextYieldContextSequence = 0;
 const activeYieldContexts = new Map<string, McpLoopbackYieldContext>();
 
 /** Register yield state for the CLI run that owns a loopback MCP session id. */
 export function registerMcpLoopbackYieldContext(sessionId: string): McpLoopbackYieldContext {
-  const context: McpLoopbackYieldContext = { yielded: false };
+  nextYieldContextSequence += 1;
+  const context: McpLoopbackYieldContext = {
+    yielded: false,
+    cacheKey: `${sessionId}:${nextYieldContextSequence}`,
+  };
   activeYieldContexts.set(sessionId, context);
   return context;
 }
@@ -35,6 +41,15 @@ export function resolveMcpLoopbackYieldHandler(
     context.yielded = true;
     context.message = message;
   };
+}
+
+export function resolveMcpLoopbackYieldContextCacheKey(
+  sessionId: string | undefined,
+): string | undefined {
+  if (!sessionId) {
+    return undefined;
+  }
+  return activeYieldContexts.get(sessionId)?.cacheKey;
 }
 
 /** Clear yield state without removing a newer run that reused the same session id. */

--- a/src/gateway/mcp-http.request.ts
+++ b/src/gateway/mcp-http.request.ts
@@ -50,6 +50,7 @@ function logMcpLoopbackHttp(step: string, details: Record<string, unknown>): voi
 
 type McpRequestContext = {
   sessionKey: string;
+  sessionId: string | undefined;
   messageProvider: string | undefined;
   currentChannelId: string | undefined;
   currentThreadTs: string | undefined;
@@ -365,6 +366,7 @@ export function resolveMcpRequestContext(
 ): McpRequestContext {
   return {
     sessionKey: resolveScopedSessionKey(cfg, getHeader(req, "x-session-key")),
+    sessionId: normalizeOptionalString(getHeader(req, "x-openclaw-session-id")),
     messageProvider:
       normalizeMessageChannel(getHeader(req, "x-openclaw-message-channel")) ?? undefined,
     currentChannelId: normalizeOptionalString(getHeader(req, "x-openclaw-current-channel-id")),

--- a/src/gateway/mcp-http.runtime.ts
+++ b/src/gateway/mcp-http.runtime.ts
@@ -28,6 +28,8 @@ type CachedScopedTools = {
 type McpLoopbackScopeParams = {
   cfg: OpenClawConfig;
   sessionKey: string;
+  sessionId?: string;
+  onYield?: (message: string) => Promise<void> | void;
   messageProvider: string | undefined;
   currentChannelId: string | undefined;
   currentThreadTs: string | undefined;
@@ -63,6 +65,7 @@ export class McpLoopbackToolCache {
   resolve(params: McpLoopbackScopeParams): CachedScopedTools {
     const cacheKey = [
       params.sessionKey,
+      params.sessionId ?? "",
       params.messageProvider ?? "",
       params.currentChannelId ?? "",
       params.currentThreadTs ?? "",

--- a/src/gateway/mcp-http.runtime.ts
+++ b/src/gateway/mcp-http.runtime.ts
@@ -29,6 +29,7 @@ type McpLoopbackScopeParams = {
   cfg: OpenClawConfig;
   sessionKey: string;
   sessionId?: string;
+  yieldContextCacheKey?: string;
   onYield?: (message: string) => Promise<void> | void;
   messageProvider: string | undefined;
   currentChannelId: string | undefined;
@@ -66,6 +67,7 @@ export class McpLoopbackToolCache {
     const cacheKey = [
       params.sessionKey,
       params.sessionId ?? "",
+      params.yieldContextCacheKey ?? "",
       params.messageProvider ?? "",
       params.currentChannelId ?? "",
       params.currentThreadTs ?? "",

--- a/src/gateway/mcp-http.test.ts
+++ b/src/gateway/mcp-http.test.ts
@@ -22,6 +22,7 @@ type MockBeforeToolCallHookResult =
   | { blocked: false; params: unknown };
 
 type ScopedToolsCall = {
+  sessionId?: string;
   sessionKey?: string;
   accountId?: string;
   messageProvider?: string;
@@ -31,7 +32,6 @@ type ScopedToolsCall = {
   currentInboundAudio?: boolean;
   inboundEventKind?: string;
   sourceReplyDeliveryMode?: string;
-  requireExplicitMessageTarget?: boolean;
   senderIsOwner?: boolean;
   surface?: string;
   excludeToolNames?: Iterable<string>;
@@ -106,15 +106,6 @@ import {
   ensureMcpLoopbackServer,
   startMcpLoopbackServer,
 } from "./mcp-http.js";
-import {
-  beginMcpLoopbackToolCallCapture,
-  clearMcpLoopbackToolCallCapture,
-  clearMcpLoopbackToolCallCapturesForTest,
-  markMcpLoopbackToolCallFinished,
-  markMcpLoopbackToolCallStarted,
-  recordMcpLoopbackToolCallResult,
-  waitForMcpLoopbackToolCallCaptureIdle,
-} from "./mcp-http.loopback-runtime.js";
 import { McpLoopbackToolCache } from "./mcp-http.runtime.js";
 
 let server: Awaited<ReturnType<typeof startMcpLoopbackServer>> | undefined;
@@ -563,7 +554,6 @@ function buildMockMcpToolSchema(tools: MockGatewayTool[]) {
 }
 
 beforeEach(() => {
-  clearMcpLoopbackToolCallCapturesForTest();
   resolveGatewayScopedToolsMock.mockClear();
   runBeforeToolCallHookMock.mockClear();
   runBeforeToolCallHookMock.mockImplementation(
@@ -683,6 +673,7 @@ describe("mcp loopback server", () => {
       token: runtime?.nonOwnerToken,
       headers: jsonHeaders({
         "x-session-key": "agent:main:telegram:group:chat123",
+        "x-openclaw-session-id": "run-session-123",
         "x-openclaw-account-id": "work",
         "x-openclaw-message-channel": "telegram",
         "x-openclaw-current-channel-id": "telegram:chat123",
@@ -691,7 +682,6 @@ describe("mcp loopback server", () => {
         "x-openclaw-current-inbound-audio": "true",
         "x-openclaw-inbound-event-kind": "room_event",
         "x-openclaw-source-reply-delivery-mode": "message_tool_only",
-        "x-openclaw-require-explicit-message-target": "true",
       }),
       body: mcpToolsListBody(),
     });
@@ -699,6 +689,7 @@ describe("mcp loopback server", () => {
     expect(response.status).toBe(200);
     const call = getScopedToolsCall(0);
     expect(call.sessionKey).toBe("agent:main:telegram:group:chat123");
+    expect(call.sessionId).toBe("run-session-123");
     expect(call.accountId).toBe("work");
     expect(call.messageProvider).toBe("telegram");
     expect(call.currentChannelId).toBe("telegram:chat123");
@@ -707,7 +698,6 @@ describe("mcp loopback server", () => {
     expect(call.currentInboundAudio).toBe(true);
     expect(call.inboundEventKind).toBe("room_event");
     expect(call.sourceReplyDeliveryMode).toBe("message_tool_only");
-    expect(call.requireExplicitMessageTarget).toBe(true);
     expect(call.surface).toBe("loopback");
     expect(Array.from(call.excludeToolNames ?? [])).toEqual([
       "read",
@@ -719,13 +709,32 @@ describe("mcp loopback server", () => {
     ]);
   });
 
-  it("keeps loopback tool cache entries separate by inbound event, delivery, audio, and target policy", async () => {
+  it("keeps loopback tool cache entries separate by session id", async () => {
+    const { runtime } = await startLoopbackServerForTest();
+    const sendToolsList = async (sessionId: string) =>
+      await sendLoopbackToolsList({
+        token: runtime?.ownerToken,
+        headers: {
+          "x-session-key": "agent:main:telegram:group:chat123",
+          "x-openclaw-session-id": sessionId,
+          "x-openclaw-message-channel": "telegram",
+        },
+      });
+
+    expect((await sendToolsList("run-session-a")).status).toBe(200);
+    expect((await sendToolsList("run-session-b")).status).toBe(200);
+
+    expect(resolveGatewayScopedToolsMock).toHaveBeenCalledTimes(2);
+    expect(getScopedToolsCall(0).sessionId).toBe("run-session-a");
+    expect(getScopedToolsCall(1).sessionId).toBe("run-session-b");
+  });
+
+  it("keeps loopback tool cache entries separate by inbound event kind, delivery mode, and inbound audio", async () => {
     const { runtime } = await startLoopbackServerForTest();
     const sendToolsList = async (
       inboundEventKind: string,
       sourceReplyDeliveryMode?: string,
       currentInboundAudio?: boolean,
-      requireExplicitMessageTarget?: boolean,
     ) =>
       await sendLoopbackToolsList({
         token: runtime?.ownerToken,
@@ -737,9 +746,6 @@ describe("mcp loopback server", () => {
             ? { "x-openclaw-source-reply-delivery-mode": sourceReplyDeliveryMode }
             : {}),
           ...(currentInboundAudio ? { "x-openclaw-current-inbound-audio": "true" } : {}),
-          ...(requireExplicitMessageTarget
-            ? { "x-openclaw-require-explicit-message-target": "true" }
-            : {}),
         },
       });
 
@@ -747,14 +753,12 @@ describe("mcp loopback server", () => {
     expect((await sendToolsList("room_event")).status).toBe(200);
     expect((await sendToolsList("room_event", "message_tool_only")).status).toBe(200);
     expect((await sendToolsList("room_event", "message_tool_only", true)).status).toBe(200);
-    expect((await sendToolsList("room_event", "message_tool_only", true, true)).status).toBe(200);
 
-    expect(resolveGatewayScopedToolsMock).toHaveBeenCalledTimes(5);
+    expect(resolveGatewayScopedToolsMock).toHaveBeenCalledTimes(4);
     expect(getScopedToolsCall(0).inboundEventKind).toBe("user_request");
     expect(getScopedToolsCall(1).inboundEventKind).toBe("room_event");
     expect(getScopedToolsCall(2).sourceReplyDeliveryMode).toBe("message_tool_only");
     expect(getScopedToolsCall(3).currentInboundAudio).toBe(true);
-    expect(getScopedToolsCall(4).requireExplicitMessageTarget).toBe(true);
   });
 
   it("keeps explicit non-owner and unknown-owner loopback cache entries separate", () => {
@@ -946,358 +950,6 @@ describe("mcp loopback server", () => {
 
     expect(cronExecute).toHaveBeenCalledTimes(1);
     expectMcpResultText(payload, "CRON_EXECUTED");
-  });
-
-  it("captures only successful calls with an explicit CLI capture key", async () => {
-    const captureKey = "google-gemini-cli";
-    const captured: Array<{ toolName: string; args: Record<string, unknown> }> = [];
-    const startedTargets: unknown[] = [];
-    const finishedTargets: unknown[] = [];
-    beginMcpLoopbackToolCallCapture({
-      captureKey,
-      onToolCallStart: ({ args }) => startedTargets.push(args.target),
-      onToolCallFinish: ({ args }) => finishedTargets.push(args.target),
-      onToolCallResult: ({ toolName, args }) => {
-        if (toolName === "message" && args.action === "send") {
-          captured.push({ toolName, args });
-        }
-      },
-    });
-    const { runtime } = await startLoopbackServerForTest();
-
-    expect(
-      (
-        await sendLoopbackToolCall({
-          token: runtime.ownerToken,
-          name: "message",
-          args: { action: "send", target: "chat123", message: "sent" },
-          headers: { "x-openclaw-cli-capture-key": captureKey },
-        })
-      ).status,
-    ).toBe(200);
-
-    runBeforeToolCallHookMock.mockResolvedValueOnce({
-      blocked: true,
-      reason: "blocked for test",
-    });
-    expect(
-      (
-        await sendLoopbackToolCall({
-          token: runtime.ownerToken,
-          name: "message",
-          args: { action: "send", target: "blocked", message: "not sent" },
-          headers: { "x-openclaw-cli-capture-key": captureKey },
-        })
-      ).status,
-    ).toBe(200);
-
-    expect(
-      (
-        await sendLoopbackToolCall({
-          token: runtime.ownerToken,
-          name: "message",
-          args: { action: "send", target: "implicit-main", message: "not captured" },
-        })
-      ).status,
-    ).toBe(200);
-
-    expect(captured).toEqual([
-      expect.objectContaining({
-        toolName: "message",
-        args: { action: "send", target: "chat123", message: "sent" },
-      }),
-    ]);
-    expect(startedTargets).toEqual(["chat123", "blocked"]);
-    expect(finishedTargets).toEqual(["chat123", "blocked"]);
-  });
-
-  it("updates capture accounting with hook-rewritten tool arguments", async () => {
-    const captureKey = "hook-rewritten-send";
-    const updatedCalls = vi.fn();
-    const finishedCalls = vi.fn();
-    beginMcpLoopbackToolCallCapture({
-      captureKey,
-      onToolCallUpdate: updatedCalls,
-      onToolCallFinish: finishedCalls,
-      onToolCallResult: vi.fn(),
-    });
-    runBeforeToolCallHookMock.mockResolvedValueOnce({
-      blocked: false,
-      params: {
-        action: "send",
-        target: "rewritten-target",
-        message: "rewritten send",
-      },
-    });
-    const { runtime } = await startLoopbackServerForTest();
-
-    await sendLoopbackToolCall({
-      token: runtime.ownerToken,
-      name: "message",
-      args: { action: "react", target: "original-target" },
-      headers: { "x-openclaw-cli-capture-key": captureKey },
-    });
-
-    expect(updatedCalls).toHaveBeenCalledWith({
-      previous: {
-        toolName: "message",
-        args: { action: "react", target: "original-target" },
-      },
-      current: {
-        toolName: "message",
-        args: {
-          action: "send",
-          target: "rewritten-target",
-          message: "rewritten send",
-        },
-      },
-    });
-    expect(finishedCalls).toHaveBeenCalledWith(
-      {
-        toolName: "message",
-        args: {
-          action: "send",
-          target: "rewritten-target",
-          message: "rewritten send",
-        },
-      },
-      { prepared: true },
-    );
-  });
-
-  it("reports oversized successful calls without retaining their payloads", () => {
-    const captureKey = "oversized-capture";
-    const captured = vi.fn();
-    beginMcpLoopbackToolCallCapture({
-      captureKey,
-      onToolCallResult: captured,
-    });
-
-    const captureHandle = markMcpLoopbackToolCallStarted({
-      captureKey,
-      toolName: "message",
-      args: { action: "send", target: "chat123" },
-    });
-    if (!captureHandle) {
-      throw new Error("Expected active MCP capture");
-    }
-    recordMcpLoopbackToolCallResult({
-      captureHandle,
-      toolName: "message",
-      args: { action: "send", target: "chat123" },
-      result: { content: "x".repeat(20 * 1024) },
-      isError: false,
-    });
-    markMcpLoopbackToolCallFinished(captureHandle);
-
-    expect(captured).toHaveBeenCalledWith(
-      expect.objectContaining({
-        toolName: "message",
-        args: { action: "send", target: "chat123" },
-      }),
-    );
-  });
-
-  it("keeps admitted calls bound to their original capture generation", () => {
-    const captureKey = "generation-bound-capture";
-    const firstCapture = vi.fn();
-    const secondCapture = vi.fn();
-    beginMcpLoopbackToolCallCapture({
-      captureKey,
-      onToolCallResult: firstCapture,
-    });
-    const firstHandle = markMcpLoopbackToolCallStarted({
-      captureKey,
-      toolName: "message",
-      args: { action: "send", target: "first-turn" },
-    });
-    if (!firstHandle) {
-      throw new Error("Expected first MCP capture generation");
-    }
-    beginMcpLoopbackToolCallCapture({
-      captureKey,
-      onToolCallResult: secondCapture,
-    });
-
-    recordMcpLoopbackToolCallResult({
-      captureHandle: firstHandle,
-      toolName: "message",
-      args: { action: "send", target: "first-turn" },
-      result: { status: "sent" },
-      isError: false,
-    });
-    markMcpLoopbackToolCallFinished(firstHandle);
-
-    expect(firstCapture).toHaveBeenCalledOnce();
-    expect(secondCapture).not.toHaveBeenCalled();
-  });
-
-  it("binds slow request bodies to their capture generation at header acceptance", async () => {
-    const captureKey = "slow-request-generation";
-    const requestClassified = vi.fn();
-    const requestStarted = vi.fn();
-    const captured = vi.fn();
-    let resolveRequestStarted: (() => void) | undefined;
-    const requestStartedPromise = new Promise<void>((resolve) => {
-      resolveRequestStarted = resolve;
-    });
-    beginMcpLoopbackToolCallCapture({
-      captureKey,
-      onRequestStart: () => {
-        requestStarted();
-        resolveRequestStarted?.();
-      },
-      onRequestClassified: requestClassified,
-      onToolCallResult: captured,
-    });
-    const { runtime, port } = await startLoopbackServerForTest();
-    const responsePromise = new Promise<{ status: number | undefined; body: string }>(
-      (resolve, reject) => {
-        const req = request(
-          {
-            hostname: "127.0.0.1",
-            port,
-            path: "/mcp",
-            method: "POST",
-            headers: {
-              authorization: `Bearer ${runtime.ownerToken}`,
-              "content-type": "application/json",
-              "transfer-encoding": "chunked",
-              "x-openclaw-cli-capture-key": captureKey,
-            },
-          },
-          (res) => {
-            let body = "";
-            res.setEncoding("utf8");
-            res.on("data", (chunk) => {
-              body += chunk;
-            });
-            res.on("end", () => resolve({ status: res.statusCode, body }));
-          },
-        );
-        req.on("error", reject);
-        req.flushHeaders();
-        void requestStartedPromise.then(() => {
-          clearMcpLoopbackToolCallCapture(captureKey);
-          req.end(mcpToolCallBody("message", { action: "send", target: "late-body" }));
-        });
-      },
-    );
-
-    await requestStartedPromise;
-    expect(requestStarted).toHaveBeenCalledOnce();
-    expect(requestClassified).not.toHaveBeenCalled();
-    const response = await responsePromise;
-
-    expect(response.status).toBe(200);
-    expect(requestClassified).toHaveBeenCalledOnce();
-    expect(captured).toHaveBeenCalledWith(
-      expect.objectContaining({
-        toolName: "message",
-        args: { action: "send", target: "late-body" },
-        isError: false,
-      }),
-    );
-  });
-
-  it("waits through a quiet admission grace before clearing a failed-turn capture", async () => {
-    const captureKey = "admission-grace";
-    beginMcpLoopbackToolCallCapture({
-      captureKey,
-      onToolCallResult: vi.fn(),
-    });
-    const idlePromise = waitForMcpLoopbackToolCallCaptureIdle(captureKey, {
-      timeoutMs: 500,
-      admissionGraceMs: 40,
-    });
-    await new Promise<void>((resolve) => {
-      setTimeout(resolve, 10);
-    });
-    const captureHandle = markMcpLoopbackToolCallStarted({
-      captureKey,
-      toolName: "message",
-      args: { action: "send", target: "late-admission" },
-    });
-    if (!captureHandle) {
-      throw new Error("Expected late MCP capture admission");
-    }
-    setTimeout(() => markMcpLoopbackToolCallFinished(captureHandle), 10);
-
-    await expect(idlePromise).resolves.toBe(true);
-  });
-
-  it("keeps capture observer errors from changing tool success", async () => {
-    const captureKey = "throwing-observer";
-    beginMcpLoopbackToolCallCapture({
-      captureKey,
-      onToolCallResult: () => {
-        throw new Error("observer failed");
-      },
-    });
-    const { runtime } = await startLoopbackServerForTest();
-
-    const response = await sendLoopbackToolCall({
-      token: runtime.ownerToken,
-      name: "message",
-      args: { action: "send", target: "chat123", message: "sent" },
-      headers: { "x-openclaw-cli-capture-key": captureKey },
-    });
-
-    expect(response.status).toBe(200);
-    const payload = await readMcpPayload(response);
-    expect(payload.result?.isError).toBe(false);
-  });
-
-  it("captures partial-delivery errors before returning the tool failure", async () => {
-    const captureKey = "partial-delivery";
-    const captured = vi.fn();
-    beginMcpLoopbackToolCallCapture({
-      captureKey,
-      onToolCallResult: captured,
-    });
-    mockScopedTools([
-      makeMessageTool({
-        execute: async () => {
-          throw Object.assign(new Error("second chunk failed"), { sentBeforeError: true });
-        },
-      }),
-    ]);
-    const { runtime } = await startLoopbackServerForTest();
-
-    const response = await sendLoopbackToolCall({
-      token: runtime.ownerToken,
-      name: "message",
-      args: { action: "send", target: "chat123", message: "sent partly" },
-      headers: { "x-openclaw-cli-capture-key": captureKey },
-    });
-
-    const payload = await readMcpPayload(response);
-    expect(payload.result?.isError).toBe(true);
-    expect(captured).toHaveBeenCalledWith(
-      expect.objectContaining({
-        toolName: "message",
-        isError: true,
-        result: expect.objectContaining({ sentBeforeError: true }),
-      }),
-    );
-  });
-
-  it("ignores calls after a capture is cleared", () => {
-    const captureKey = "cleared-capture";
-    const captured = vi.fn();
-    beginMcpLoopbackToolCallCapture({
-      captureKey,
-      onToolCallResult: captured,
-    });
-    clearMcpLoopbackToolCallCapturesForTest();
-    const captureHandle = markMcpLoopbackToolCallStarted({
-      captureKey,
-      toolName: "message",
-      args: { action: "send", target: "old-turn" },
-    });
-
-    expect(captureHandle).toBeUndefined();
-    expect(captured).not.toHaveBeenCalled();
   });
 
   it("calls healthy tools when an earlier loopback tool name is unreadable", async () => {
@@ -1630,6 +1282,9 @@ describe("createMcpLoopbackServerConfig", () => {
     expect(config.mcpServers?.openclaw?.headers?.Authorization).toBe(
       "Bearer ${OPENCLAW_MCP_TOKEN}",
     );
+    expect(config.mcpServers?.openclaw?.headers?.["x-openclaw-session-id"]).toBe(
+      "${OPENCLAW_MCP_SESSION_ID}",
+    );
     expect(config.mcpServers?.openclaw?.headers?.["x-openclaw-message-channel"]).toBe(
       "${OPENCLAW_MCP_MESSAGE_CHANNEL}",
     );
@@ -1647,12 +1302,6 @@ describe("createMcpLoopbackServerConfig", () => {
     );
     expect(config.mcpServers?.openclaw?.headers?.["x-openclaw-source-reply-delivery-mode"]).toBe(
       "${OPENCLAW_MCP_SOURCE_REPLY_DELIVERY_MODE}",
-    );
-    expect(
-      config.mcpServers?.openclaw?.headers?.["x-openclaw-require-explicit-message-target"],
-    ).toBe("${OPENCLAW_MCP_REQUIRE_EXPLICIT_MESSAGE_TARGET}");
-    expect(config.mcpServers?.openclaw?.headers?.["x-openclaw-cli-capture-key"]).toBe(
-      "${OPENCLAW_MCP_CLI_CAPTURE_KEY}",
     );
     expect(config.mcpServers?.openclaw?.headers).not.toHaveProperty("x-openclaw-sender-is-owner");
   });

--- a/src/gateway/mcp-http.test.ts
+++ b/src/gateway/mcp-http.test.ts
@@ -22,9 +22,10 @@ type MockBeforeToolCallHookResult =
   | { blocked: false; params: unknown };
 
 type ScopedToolsCall = {
-  sessionId?: string;
-  onYield?: (message: string) => Promise<void> | void;
   sessionKey?: string;
+  sessionId?: string;
+  yieldContextCacheKey?: string;
+  onYield?: (message: string) => Promise<void> | void;
   accountId?: string;
   messageProvider?: string;
   currentChannelId?: string;
@@ -33,6 +34,7 @@ type ScopedToolsCall = {
   currentInboundAudio?: boolean;
   inboundEventKind?: string;
   sourceReplyDeliveryMode?: string;
+  requireExplicitMessageTarget?: boolean;
   senderIsOwner?: boolean;
   surface?: string;
   excludeToolNames?: Iterable<string>;
@@ -82,10 +84,8 @@ const resolveGatewayScopedToolsMock = vi.hoisted(() =>
   })),
 );
 
-const runtimeConfigMock = vi.hoisted(() => ({ session: { mainKey: "main" } }));
-
 vi.mock("../config/io.js", () => ({
-  getRuntimeConfig: () => runtimeConfigMock,
+  getRuntimeConfig: () => ({ session: { mainKey: "main" } }),
 }));
 
 vi.mock("../config/sessions.js", () => ({
@@ -110,8 +110,13 @@ import {
   startMcpLoopbackServer,
 } from "./mcp-http.js";
 import {
-  clearMcpLoopbackYieldContext,
-  registerMcpLoopbackYieldContext,
+  beginMcpLoopbackToolCallCapture,
+  clearMcpLoopbackToolCallCapture,
+  clearMcpLoopbackToolCallCapturesForTest,
+  markMcpLoopbackToolCallFinished,
+  markMcpLoopbackToolCallStarted,
+  recordMcpLoopbackToolCallResult,
+  waitForMcpLoopbackToolCallCaptureIdle,
 } from "./mcp-http.loopback-runtime.js";
 import { McpLoopbackToolCache } from "./mcp-http.runtime.js";
 
@@ -561,6 +566,7 @@ function buildMockMcpToolSchema(tools: MockGatewayTool[]) {
 }
 
 beforeEach(() => {
+  clearMcpLoopbackToolCallCapturesForTest();
   resolveGatewayScopedToolsMock.mockClear();
   runBeforeToolCallHookMock.mockClear();
   runBeforeToolCallHookMock.mockImplementation(
@@ -680,7 +686,7 @@ describe("mcp loopback server", () => {
       token: runtime?.nonOwnerToken,
       headers: jsonHeaders({
         "x-session-key": "agent:main:telegram:group:chat123",
-        "x-openclaw-session-id": "run-session-123",
+        "x-openclaw-session-id": "session-123",
         "x-openclaw-account-id": "work",
         "x-openclaw-message-channel": "telegram",
         "x-openclaw-current-channel-id": "telegram:chat123",
@@ -689,6 +695,7 @@ describe("mcp loopback server", () => {
         "x-openclaw-current-inbound-audio": "true",
         "x-openclaw-inbound-event-kind": "room_event",
         "x-openclaw-source-reply-delivery-mode": "message_tool_only",
+        "x-openclaw-require-explicit-message-target": "true",
       }),
       body: mcpToolsListBody(),
     });
@@ -696,7 +703,7 @@ describe("mcp loopback server", () => {
     expect(response.status).toBe(200);
     const call = getScopedToolsCall(0);
     expect(call.sessionKey).toBe("agent:main:telegram:group:chat123");
-    expect(call.sessionId).toBe("run-session-123");
+    expect(call.sessionId).toBe("session-123");
     expect(call.accountId).toBe("work");
     expect(call.messageProvider).toBe("telegram");
     expect(call.currentChannelId).toBe("telegram:chat123");
@@ -705,6 +712,7 @@ describe("mcp loopback server", () => {
     expect(call.currentInboundAudio).toBe(true);
     expect(call.inboundEventKind).toBe("room_event");
     expect(call.sourceReplyDeliveryMode).toBe("message_tool_only");
+    expect(call.requireExplicitMessageTarget).toBe(true);
     expect(call.surface).toBe("loopback");
     expect(Array.from(call.excludeToolNames ?? [])).toEqual([
       "read",
@@ -716,97 +724,72 @@ describe("mcp loopback server", () => {
     ]);
   });
 
-  it("keeps loopback tool cache entries separate by session id", async () => {
-    const { runtime } = await startLoopbackServerForTest();
-    const sendToolsList = async (sessionId: string) =>
-      await sendLoopbackToolsList({
-        token: runtime?.ownerToken,
-        headers: {
-          "x-session-key": "agent:main:telegram:group:chat123",
-          "x-openclaw-session-id": sessionId,
-          "x-openclaw-message-channel": "telegram",
-        },
-      });
-
-    expect((await sendToolsList("run-session-a")).status).toBe(200);
-    expect((await sendToolsList("run-session-b")).status).toBe(200);
-
-    expect(resolveGatewayScopedToolsMock).toHaveBeenCalledTimes(2);
-    expect(getScopedToolsCall(0).sessionId).toBe("run-session-a");
-    expect(getScopedToolsCall(1).sessionId).toBe("run-session-b");
-  });
-
-  it("refreshes cached yield tools for consecutive runs with the same session id", async () => {
-    const { runtime } = await startLoopbackServerForTest();
-    resolveGatewayScopedToolsMock.mockImplementation((params): MockGatewayScopedTools => {
-      const call = params as ScopedToolsCall;
+  it("routes sessions_yield to the current CLI capture", async () => {
+    resolveGatewayScopedToolsMock.mockImplementation((input): MockGatewayScopedTools => {
+      const call = input as ScopedToolsCall;
       return {
         agentId: "main",
         tools: [
-          {
+          makeMockTool({
             name: "sessions_yield",
-            description: "yield current run",
-            parameters: { type: "object", properties: {} },
             execute: async (_toolCallId, args) => {
-              const message = (args as { message?: string }).message ?? "yielded";
-              await Promise.resolve(call.onYield?.(message));
+              if (!call.sessionId) {
+                throw new Error("No session context");
+              }
+              if (!call.onYield) {
+                throw new Error("Yield not supported in this context");
+              }
+              const message = (args as { message?: string }).message ?? "Turn yielded.";
+              await call.onYield(message);
               return {
                 content: [{ type: "text", text: JSON.stringify({ status: "yielded", message }) }],
               };
             },
-          },
+          }),
         ],
       };
     });
-    const headers = {
-      "x-session-key": "agent:main:telegram:group:chat123",
-      "x-openclaw-session-id": "run-session-reused",
-      "x-openclaw-message-channel": "telegram",
+    const { runtime } = await startLoopbackServerForTest();
+    const firstYield = vi.fn();
+    const secondYield = vi.fn();
+    const sendYield = async (
+      captureKey: string,
+      message: string,
+      onYield: (message: string) => void,
+    ) => {
+      beginMcpLoopbackToolCallCapture({
+        captureKey,
+        onYield,
+        onToolCallResult: vi.fn(),
+      });
+      return await sendLoopbackToolCall({
+        token: runtime.ownerToken,
+        name: "sessions_yield",
+        args: { message },
+        headers: {
+          "x-session-key": "agent:main:main",
+          "x-openclaw-session-id": "session-reused",
+          "x-openclaw-cli-capture-key": captureKey,
+        },
+      });
     };
 
-    const firstContext = registerMcpLoopbackYieldContext("run-session-reused");
-    try {
-      expect(
-        (
-          await sendLoopbackToolCall({
-            token: runtime?.ownerToken,
-            name: "sessions_yield",
-            args: { message: "first yield" },
-            headers,
-          })
-        ).status,
-      ).toBe(200);
-      expect(firstContext).toMatchObject({ yielded: true, message: "first yield" });
-    } finally {
-      clearMcpLoopbackYieldContext("run-session-reused", firstContext);
-    }
+    const captureKey = "capture-reused";
+    expect((await sendYield(captureKey, "first yield", firstYield)).status).toBe(200);
+    expect((await sendYield(captureKey, "second yield", secondYield)).status).toBe(200);
 
-    const secondContext = registerMcpLoopbackYieldContext("run-session-reused");
-    try {
-      expect(
-        (
-          await sendLoopbackToolCall({
-            token: runtime?.ownerToken,
-            name: "sessions_yield",
-            args: { message: "second yield" },
-            headers,
-          })
-        ).status,
-      ).toBe(200);
-      expect(secondContext).toMatchObject({ yielded: true, message: "second yield" });
-    } finally {
-      clearMcpLoopbackYieldContext("run-session-reused", secondContext);
-    }
-
+    expect(firstYield).toHaveBeenCalledWith("first yield");
+    expect(secondYield).toHaveBeenCalledWith("second yield");
     expect(resolveGatewayScopedToolsMock).toHaveBeenCalledTimes(2);
   });
 
-  it("keeps loopback tool cache entries separate by inbound event kind, delivery mode, and inbound audio", async () => {
+  it("keeps loopback tool cache entries separate by inbound event, delivery, audio, and target policy", async () => {
     const { runtime } = await startLoopbackServerForTest();
     const sendToolsList = async (
       inboundEventKind: string,
       sourceReplyDeliveryMode?: string,
       currentInboundAudio?: boolean,
+      requireExplicitMessageTarget?: boolean,
     ) =>
       await sendLoopbackToolsList({
         token: runtime?.ownerToken,
@@ -818,6 +801,9 @@ describe("mcp loopback server", () => {
             ? { "x-openclaw-source-reply-delivery-mode": sourceReplyDeliveryMode }
             : {}),
           ...(currentInboundAudio ? { "x-openclaw-current-inbound-audio": "true" } : {}),
+          ...(requireExplicitMessageTarget
+            ? { "x-openclaw-require-explicit-message-target": "true" }
+            : {}),
         },
       });
 
@@ -825,12 +811,14 @@ describe("mcp loopback server", () => {
     expect((await sendToolsList("room_event")).status).toBe(200);
     expect((await sendToolsList("room_event", "message_tool_only")).status).toBe(200);
     expect((await sendToolsList("room_event", "message_tool_only", true)).status).toBe(200);
+    expect((await sendToolsList("room_event", "message_tool_only", true, true)).status).toBe(200);
 
-    expect(resolveGatewayScopedToolsMock).toHaveBeenCalledTimes(4);
+    expect(resolveGatewayScopedToolsMock).toHaveBeenCalledTimes(5);
     expect(getScopedToolsCall(0).inboundEventKind).toBe("user_request");
     expect(getScopedToolsCall(1).inboundEventKind).toBe("room_event");
     expect(getScopedToolsCall(2).sourceReplyDeliveryMode).toBe("message_tool_only");
     expect(getScopedToolsCall(3).currentInboundAudio).toBe(true);
+    expect(getScopedToolsCall(4).requireExplicitMessageTarget).toBe(true);
   });
 
   it("keeps explicit non-owner and unknown-owner loopback cache entries separate", () => {
@@ -1022,6 +1010,358 @@ describe("mcp loopback server", () => {
 
     expect(cronExecute).toHaveBeenCalledTimes(1);
     expectMcpResultText(payload, "CRON_EXECUTED");
+  });
+
+  it("captures only successful calls with an explicit CLI capture key", async () => {
+    const captureKey = "google-gemini-cli";
+    const captured: Array<{ toolName: string; args: Record<string, unknown> }> = [];
+    const startedTargets: unknown[] = [];
+    const finishedTargets: unknown[] = [];
+    beginMcpLoopbackToolCallCapture({
+      captureKey,
+      onToolCallStart: ({ args }) => startedTargets.push(args.target),
+      onToolCallFinish: ({ args }) => finishedTargets.push(args.target),
+      onToolCallResult: ({ toolName, args }) => {
+        if (toolName === "message" && args.action === "send") {
+          captured.push({ toolName, args });
+        }
+      },
+    });
+    const { runtime } = await startLoopbackServerForTest();
+
+    expect(
+      (
+        await sendLoopbackToolCall({
+          token: runtime.ownerToken,
+          name: "message",
+          args: { action: "send", target: "chat123", message: "sent" },
+          headers: { "x-openclaw-cli-capture-key": captureKey },
+        })
+      ).status,
+    ).toBe(200);
+
+    runBeforeToolCallHookMock.mockResolvedValueOnce({
+      blocked: true,
+      reason: "blocked for test",
+    });
+    expect(
+      (
+        await sendLoopbackToolCall({
+          token: runtime.ownerToken,
+          name: "message",
+          args: { action: "send", target: "blocked", message: "not sent" },
+          headers: { "x-openclaw-cli-capture-key": captureKey },
+        })
+      ).status,
+    ).toBe(200);
+
+    expect(
+      (
+        await sendLoopbackToolCall({
+          token: runtime.ownerToken,
+          name: "message",
+          args: { action: "send", target: "implicit-main", message: "not captured" },
+        })
+      ).status,
+    ).toBe(200);
+
+    expect(captured).toEqual([
+      expect.objectContaining({
+        toolName: "message",
+        args: { action: "send", target: "chat123", message: "sent" },
+      }),
+    ]);
+    expect(startedTargets).toEqual(["chat123", "blocked"]);
+    expect(finishedTargets).toEqual(["chat123", "blocked"]);
+  });
+
+  it("updates capture accounting with hook-rewritten tool arguments", async () => {
+    const captureKey = "hook-rewritten-send";
+    const updatedCalls = vi.fn();
+    const finishedCalls = vi.fn();
+    beginMcpLoopbackToolCallCapture({
+      captureKey,
+      onToolCallUpdate: updatedCalls,
+      onToolCallFinish: finishedCalls,
+      onToolCallResult: vi.fn(),
+    });
+    runBeforeToolCallHookMock.mockResolvedValueOnce({
+      blocked: false,
+      params: {
+        action: "send",
+        target: "rewritten-target",
+        message: "rewritten send",
+      },
+    });
+    const { runtime } = await startLoopbackServerForTest();
+
+    await sendLoopbackToolCall({
+      token: runtime.ownerToken,
+      name: "message",
+      args: { action: "react", target: "original-target" },
+      headers: { "x-openclaw-cli-capture-key": captureKey },
+    });
+
+    expect(updatedCalls).toHaveBeenCalledWith({
+      previous: {
+        toolName: "message",
+        args: { action: "react", target: "original-target" },
+      },
+      current: {
+        toolName: "message",
+        args: {
+          action: "send",
+          target: "rewritten-target",
+          message: "rewritten send",
+        },
+      },
+    });
+    expect(finishedCalls).toHaveBeenCalledWith(
+      {
+        toolName: "message",
+        args: {
+          action: "send",
+          target: "rewritten-target",
+          message: "rewritten send",
+        },
+      },
+      { prepared: true },
+    );
+  });
+
+  it("reports oversized successful calls without retaining their payloads", () => {
+    const captureKey = "oversized-capture";
+    const captured = vi.fn();
+    beginMcpLoopbackToolCallCapture({
+      captureKey,
+      onToolCallResult: captured,
+    });
+
+    const captureHandle = markMcpLoopbackToolCallStarted({
+      captureKey,
+      toolName: "message",
+      args: { action: "send", target: "chat123" },
+    });
+    if (!captureHandle) {
+      throw new Error("Expected active MCP capture");
+    }
+    recordMcpLoopbackToolCallResult({
+      captureHandle,
+      toolName: "message",
+      args: { action: "send", target: "chat123" },
+      result: { content: "x".repeat(20 * 1024) },
+      isError: false,
+    });
+    markMcpLoopbackToolCallFinished(captureHandle);
+
+    expect(captured).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolName: "message",
+        args: { action: "send", target: "chat123" },
+      }),
+    );
+  });
+
+  it("keeps admitted calls bound to their original capture generation", () => {
+    const captureKey = "generation-bound-capture";
+    const firstCapture = vi.fn();
+    const secondCapture = vi.fn();
+    beginMcpLoopbackToolCallCapture({
+      captureKey,
+      onToolCallResult: firstCapture,
+    });
+    const firstHandle = markMcpLoopbackToolCallStarted({
+      captureKey,
+      toolName: "message",
+      args: { action: "send", target: "first-turn" },
+    });
+    if (!firstHandle) {
+      throw new Error("Expected first MCP capture generation");
+    }
+    beginMcpLoopbackToolCallCapture({
+      captureKey,
+      onToolCallResult: secondCapture,
+    });
+
+    recordMcpLoopbackToolCallResult({
+      captureHandle: firstHandle,
+      toolName: "message",
+      args: { action: "send", target: "first-turn" },
+      result: { status: "sent" },
+      isError: false,
+    });
+    markMcpLoopbackToolCallFinished(firstHandle);
+
+    expect(firstCapture).toHaveBeenCalledOnce();
+    expect(secondCapture).not.toHaveBeenCalled();
+  });
+
+  it("binds slow request bodies to their capture generation at header acceptance", async () => {
+    const captureKey = "slow-request-generation";
+    const requestClassified = vi.fn();
+    const requestStarted = vi.fn();
+    const captured = vi.fn();
+    let resolveRequestStarted: (() => void) | undefined;
+    const requestStartedPromise = new Promise<void>((resolve) => {
+      resolveRequestStarted = resolve;
+    });
+    beginMcpLoopbackToolCallCapture({
+      captureKey,
+      onRequestStart: () => {
+        requestStarted();
+        resolveRequestStarted?.();
+      },
+      onRequestClassified: requestClassified,
+      onToolCallResult: captured,
+    });
+    const { runtime, port } = await startLoopbackServerForTest();
+    const responsePromise = new Promise<{ status: number | undefined; body: string }>(
+      (resolve, reject) => {
+        const req = request(
+          {
+            hostname: "127.0.0.1",
+            port,
+            path: "/mcp",
+            method: "POST",
+            headers: {
+              authorization: `Bearer ${runtime.ownerToken}`,
+              "content-type": "application/json",
+              "transfer-encoding": "chunked",
+              "x-openclaw-cli-capture-key": captureKey,
+            },
+          },
+          (res) => {
+            let body = "";
+            res.setEncoding("utf8");
+            res.on("data", (chunk) => {
+              body += chunk;
+            });
+            res.on("end", () => resolve({ status: res.statusCode, body }));
+          },
+        );
+        req.on("error", reject);
+        req.flushHeaders();
+        void requestStartedPromise.then(() => {
+          clearMcpLoopbackToolCallCapture(captureKey);
+          req.end(mcpToolCallBody("message", { action: "send", target: "late-body" }));
+        });
+      },
+    );
+
+    await requestStartedPromise;
+    expect(requestStarted).toHaveBeenCalledOnce();
+    expect(requestClassified).not.toHaveBeenCalled();
+    const response = await responsePromise;
+
+    expect(response.status).toBe(200);
+    expect(requestClassified).toHaveBeenCalledOnce();
+    expect(captured).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolName: "message",
+        args: { action: "send", target: "late-body" },
+        isError: false,
+      }),
+    );
+  });
+
+  it("waits through a quiet admission grace before clearing a failed-turn capture", async () => {
+    const captureKey = "admission-grace";
+    beginMcpLoopbackToolCallCapture({
+      captureKey,
+      onToolCallResult: vi.fn(),
+    });
+    const idlePromise = waitForMcpLoopbackToolCallCaptureIdle(captureKey, {
+      timeoutMs: 500,
+      admissionGraceMs: 40,
+    });
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 10);
+    });
+    const captureHandle = markMcpLoopbackToolCallStarted({
+      captureKey,
+      toolName: "message",
+      args: { action: "send", target: "late-admission" },
+    });
+    if (!captureHandle) {
+      throw new Error("Expected late MCP capture admission");
+    }
+    setTimeout(() => markMcpLoopbackToolCallFinished(captureHandle), 10);
+
+    await expect(idlePromise).resolves.toBe(true);
+  });
+
+  it("keeps capture observer errors from changing tool success", async () => {
+    const captureKey = "throwing-observer";
+    beginMcpLoopbackToolCallCapture({
+      captureKey,
+      onToolCallResult: () => {
+        throw new Error("observer failed");
+      },
+    });
+    const { runtime } = await startLoopbackServerForTest();
+
+    const response = await sendLoopbackToolCall({
+      token: runtime.ownerToken,
+      name: "message",
+      args: { action: "send", target: "chat123", message: "sent" },
+      headers: { "x-openclaw-cli-capture-key": captureKey },
+    });
+
+    expect(response.status).toBe(200);
+    const payload = await readMcpPayload(response);
+    expect(payload.result?.isError).toBe(false);
+  });
+
+  it("captures partial-delivery errors before returning the tool failure", async () => {
+    const captureKey = "partial-delivery";
+    const captured = vi.fn();
+    beginMcpLoopbackToolCallCapture({
+      captureKey,
+      onToolCallResult: captured,
+    });
+    mockScopedTools([
+      makeMessageTool({
+        execute: async () => {
+          throw Object.assign(new Error("second chunk failed"), { sentBeforeError: true });
+        },
+      }),
+    ]);
+    const { runtime } = await startLoopbackServerForTest();
+
+    const response = await sendLoopbackToolCall({
+      token: runtime.ownerToken,
+      name: "message",
+      args: { action: "send", target: "chat123", message: "sent partly" },
+      headers: { "x-openclaw-cli-capture-key": captureKey },
+    });
+
+    const payload = await readMcpPayload(response);
+    expect(payload.result?.isError).toBe(true);
+    expect(captured).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolName: "message",
+        isError: true,
+        result: expect.objectContaining({ sentBeforeError: true }),
+      }),
+    );
+  });
+
+  it("ignores calls after a capture is cleared", () => {
+    const captureKey = "cleared-capture";
+    const captured = vi.fn();
+    beginMcpLoopbackToolCallCapture({
+      captureKey,
+      onToolCallResult: captured,
+    });
+    clearMcpLoopbackToolCallCapturesForTest();
+    const captureHandle = markMcpLoopbackToolCallStarted({
+      captureKey,
+      toolName: "message",
+      args: { action: "send", target: "old-turn" },
+    });
+
+    expect(captureHandle).toBeUndefined();
+    expect(captured).not.toHaveBeenCalled();
   });
 
   it("calls healthy tools when an earlier loopback tool name is unreadable", async () => {
@@ -1374,6 +1714,12 @@ describe("createMcpLoopbackServerConfig", () => {
     );
     expect(config.mcpServers?.openclaw?.headers?.["x-openclaw-source-reply-delivery-mode"]).toBe(
       "${OPENCLAW_MCP_SOURCE_REPLY_DELIVERY_MODE}",
+    );
+    expect(
+      config.mcpServers?.openclaw?.headers?.["x-openclaw-require-explicit-message-target"],
+    ).toBe("${OPENCLAW_MCP_REQUIRE_EXPLICIT_MESSAGE_TARGET}");
+    expect(config.mcpServers?.openclaw?.headers?.["x-openclaw-cli-capture-key"]).toBe(
+      "${OPENCLAW_MCP_CLI_CAPTURE_KEY}",
     );
     expect(config.mcpServers?.openclaw?.headers).not.toHaveProperty("x-openclaw-sender-is-owner");
   });

--- a/src/gateway/mcp-http.test.ts
+++ b/src/gateway/mcp-http.test.ts
@@ -23,6 +23,7 @@ type MockBeforeToolCallHookResult =
 
 type ScopedToolsCall = {
   sessionId?: string;
+  onYield?: (message: string) => Promise<void> | void;
   sessionKey?: string;
   accountId?: string;
   messageProvider?: string;
@@ -81,8 +82,10 @@ const resolveGatewayScopedToolsMock = vi.hoisted(() =>
   })),
 );
 
+const runtimeConfigMock = vi.hoisted(() => ({ session: { mainKey: "main" } }));
+
 vi.mock("../config/io.js", () => ({
-  getRuntimeConfig: () => ({ session: { mainKey: "main" } }),
+  getRuntimeConfig: () => runtimeConfigMock,
 }));
 
 vi.mock("../config/sessions.js", () => ({
@@ -106,6 +109,10 @@ import {
   ensureMcpLoopbackServer,
   startMcpLoopbackServer,
 } from "./mcp-http.js";
+import {
+  clearMcpLoopbackYieldContext,
+  registerMcpLoopbackYieldContext,
+} from "./mcp-http.loopback-runtime.js";
 import { McpLoopbackToolCache } from "./mcp-http.runtime.js";
 
 let server: Awaited<ReturnType<typeof startMcpLoopbackServer>> | undefined;
@@ -727,6 +734,71 @@ describe("mcp loopback server", () => {
     expect(resolveGatewayScopedToolsMock).toHaveBeenCalledTimes(2);
     expect(getScopedToolsCall(0).sessionId).toBe("run-session-a");
     expect(getScopedToolsCall(1).sessionId).toBe("run-session-b");
+  });
+
+  it("refreshes cached yield tools for consecutive runs with the same session id", async () => {
+    const { runtime } = await startLoopbackServerForTest();
+    resolveGatewayScopedToolsMock.mockImplementation((params): MockGatewayScopedTools => {
+      const call = params as ScopedToolsCall;
+      return {
+        agentId: "main",
+        tools: [
+          {
+            name: "sessions_yield",
+            description: "yield current run",
+            parameters: { type: "object", properties: {} },
+            execute: async (_toolCallId, args) => {
+              const message = (args as { message?: string }).message ?? "yielded";
+              await Promise.resolve(call.onYield?.(message));
+              return {
+                content: [{ type: "text", text: JSON.stringify({ status: "yielded", message }) }],
+              };
+            },
+          },
+        ],
+      };
+    });
+    const headers = {
+      "x-session-key": "agent:main:telegram:group:chat123",
+      "x-openclaw-session-id": "run-session-reused",
+      "x-openclaw-message-channel": "telegram",
+    };
+
+    const firstContext = registerMcpLoopbackYieldContext("run-session-reused");
+    try {
+      expect(
+        (
+          await sendLoopbackToolCall({
+            token: runtime?.ownerToken,
+            name: "sessions_yield",
+            args: { message: "first yield" },
+            headers,
+          })
+        ).status,
+      ).toBe(200);
+      expect(firstContext).toMatchObject({ yielded: true, message: "first yield" });
+    } finally {
+      clearMcpLoopbackYieldContext("run-session-reused", firstContext);
+    }
+
+    const secondContext = registerMcpLoopbackYieldContext("run-session-reused");
+    try {
+      expect(
+        (
+          await sendLoopbackToolCall({
+            token: runtime?.ownerToken,
+            name: "sessions_yield",
+            args: { message: "second yield" },
+            headers,
+          })
+        ).status,
+      ).toBe(200);
+      expect(secondContext).toMatchObject({ yielded: true, message: "second yield" });
+    } finally {
+      clearMcpLoopbackYieldContext("run-session-reused", secondContext);
+    }
+
+    expect(resolveGatewayScopedToolsMock).toHaveBeenCalledTimes(2);
   });
 
   it("keeps loopback tool cache entries separate by inbound event kind, delivery mode, and inbound audio", async () => {

--- a/src/gateway/mcp-http.ts
+++ b/src/gateway/mcp-http.ts
@@ -14,21 +14,14 @@ import { logDebug, logWarn } from "../logger.js";
 import { handleMcpJsonRpc } from "./mcp-http.handlers.js";
 import {
   clearActiveMcpLoopbackRuntimeByOwnerToken,
-  markMcpLoopbackRequestClassified,
-  markMcpLoopbackRequestFinished,
-  markMcpLoopbackRequestStarted,
-  markMcpLoopbackToolCallFinished,
-  markMcpLoopbackToolCallStarted,
-  recordMcpLoopbackToolCallResult,
+  resolveMcpLoopbackYieldHandler,
   setActiveMcpLoopbackRuntime,
-  updateMcpLoopbackToolCallCapture,
 } from "./mcp-http.loopback-runtime.js";
 import { jsonRpcError, type JsonRpcRequest } from "./mcp-http.protocol.js";
 import {
   isMcpHttpBodyTooLargeError,
   isMcpHttpBodyTimeoutError,
   readMcpHttpBody,
-  resolveMcpCliCaptureKey,
   resolveMcpHttpBodyTimeoutMs,
   resolveMcpRequestContext,
   validateMcpLoopbackRequest,
@@ -188,45 +181,20 @@ export async function startMcpLoopbackServer(port = 0): Promise<{
       return;
     }
 
-    // Bind the request before body parsing/tool resolution. A CLI may exit while
-    // an accepted request is still uploading, and retries must not outrun it.
-    const cliRequestCaptureHandle = markMcpLoopbackRequestStarted(resolveMcpCliCaptureKey(req));
     const requestAbort = createRequestAbortSignal(req, res);
     void (async () => {
       let parsed: JsonRpcRequest | JsonRpcRequest[] | undefined;
-      let cliCaptureHandles: Array<ReturnType<typeof markMcpLoopbackToolCallStarted>> = [];
       try {
         const body = await readMcpHttpBody(req, { timeoutMs: resolveMcpHttpBodyTimeoutMs() });
         parsed = parseMcpJsonBody(body);
-        const messages = Array.isArray(parsed) ? parsed : [parsed];
-        cliCaptureHandles = messages.map((message) => {
-          if (
-            !cliRequestCaptureHandle ||
-            !isJsonRpcRequest(message) ||
-            message.method !== "tools/call"
-          ) {
-            return undefined;
-          }
-          const admittedToolName =
-            isRecord(message.params) && typeof message.params.name === "string"
-              ? message.params.name
-              : "";
-          const toolArgs =
-            isRecord(message.params) && isRecord(message.params.arguments)
-              ? message.params.arguments
-              : {};
-          return markMcpLoopbackToolCallStarted({
-            requestCaptureHandle: cliRequestCaptureHandle,
-            toolName: admittedToolName,
-            args: toolArgs,
-          });
-        });
-        markMcpLoopbackRequestClassified(cliRequestCaptureHandle);
         const cfg = getRuntimeConfig();
         const requestContext = resolveMcpRequestContext(req, cfg, auth);
+        const onYield = resolveMcpLoopbackYieldHandler(requestContext.sessionId);
         const scopedTools = toolCache.resolve({
           cfg,
           sessionKey: requestContext.sessionKey,
+          ...(requestContext.sessionId ? { sessionId: requestContext.sessionId } : {}),
+          ...(onYield ? { onYield } : {}),
           messageProvider: requestContext.messageProvider,
           currentChannelId: requestContext.currentChannelId,
           currentThreadTs: requestContext.currentThreadTs,
@@ -235,10 +203,10 @@ export async function startMcpLoopbackServer(port = 0): Promise<{
           accountId: requestContext.accountId,
           inboundEventKind: requestContext.inboundEventKind,
           sourceReplyDeliveryMode: requestContext.sourceReplyDeliveryMode,
-          requireExplicitMessageTarget: requestContext.requireExplicitMessageTarget,
           senderIsOwner: requestContext.senderIsOwner,
         });
 
+        const messages = Array.isArray(parsed) ? parsed : [parsed];
         logMcpLoopbackTraffic("request", {
           batchSize: messages.length,
           methods: messages.map((message) =>
@@ -251,49 +219,24 @@ export async function startMcpLoopbackServer(port = 0): Promise<{
           cronVisible: scopedTools.toolSchema.some((tool) => tool.name === "cron"),
         });
         const responses: object[] = [];
-        for (const [messageIndex, message] of messages.entries()) {
+        for (const message of messages) {
           if (!isJsonRpcRequest(message)) {
             responses.push(jsonRpcError(readJsonRpcRequestId(message), -32600, "Invalid Request"));
             continue;
           }
-          const cliCaptureHandle = cliCaptureHandles[messageIndex];
-          let response: object | null;
-          try {
-            response = await handleMcpJsonRpc({
-              message,
-              tools: scopedTools.tools,
-              toolSchema: scopedTools.toolSchema,
-              hookContext: {
-                agentId: scopedTools.agentId,
-                config: cfg,
-                sessionKey: requestContext.sessionKey,
-              },
-              signal: requestAbort.signal,
-              onToolCallPrepared: cliCaptureHandle
-                ? ({ toolName: preparedToolName, args }) => {
-                    updateMcpLoopbackToolCallCapture(cliCaptureHandle, {
-                      toolName: preparedToolName,
-                      args,
-                    });
-                  }
-                : undefined,
-              onToolCallResult: cliCaptureHandle
-                ? ({ toolName: resultToolName, args, result, isError }) => {
-                    recordMcpLoopbackToolCallResult({
-                      captureHandle: cliCaptureHandle,
-                      toolName: resultToolName,
-                      args,
-                      result,
-                      isError,
-                    });
-                  }
-                : undefined,
-            });
-          } finally {
-            markMcpLoopbackToolCallFinished(cliCaptureHandle);
-          }
+          const response = await handleMcpJsonRpc({
+            message,
+            tools: scopedTools.tools,
+            toolSchema: scopedTools.toolSchema,
+            hookContext: {
+              agentId: scopedTools.agentId,
+              config: cfg,
+              sessionKey: requestContext.sessionKey,
+            },
+            signal: requestAbort.signal,
+          });
           if (response !== null) {
-            const responseToolName =
+            const toolName =
               message.method === "tools/call" && isRecord(message.params)
                 ? message.params.name
                 : undefined;
@@ -301,7 +244,7 @@ export async function startMcpLoopbackServer(port = 0): Promise<{
               isRecord(response) && isRecord(response.result) && response.result.isError === true;
             logMcpLoopbackTraffic("response", {
               method: message.method,
-              toolName: typeof responseToolName === "string" ? responseToolName : undefined,
+              toolName: typeof toolName === "string" ? toolName : undefined,
               isError,
             });
             responses.push(response);
@@ -345,10 +288,6 @@ export async function startMcpLoopbackServer(port = 0): Promise<{
         }
       } finally {
         requestAbort.cleanup();
-        for (const captureHandle of cliCaptureHandles) {
-          markMcpLoopbackToolCallFinished(captureHandle);
-        }
-        markMcpLoopbackRequestFinished(cliRequestCaptureHandle);
       }
     })();
   });

--- a/src/gateway/mcp-http.ts
+++ b/src/gateway/mcp-http.ts
@@ -14,15 +14,22 @@ import { logDebug, logWarn } from "../logger.js";
 import { handleMcpJsonRpc } from "./mcp-http.handlers.js";
 import {
   clearActiveMcpLoopbackRuntimeByOwnerToken,
-  resolveMcpLoopbackYieldContextCacheKey,
-  resolveMcpLoopbackYieldHandler,
+  markMcpLoopbackRequestClassified,
+  markMcpLoopbackRequestFinished,
+  markMcpLoopbackRequestStarted,
+  markMcpLoopbackToolCallFinished,
+  markMcpLoopbackToolCallStarted,
+  recordMcpLoopbackToolCallResult,
+  resolveMcpLoopbackYieldContext,
   setActiveMcpLoopbackRuntime,
+  updateMcpLoopbackToolCallCapture,
 } from "./mcp-http.loopback-runtime.js";
 import { jsonRpcError, type JsonRpcRequest } from "./mcp-http.protocol.js";
 import {
   isMcpHttpBodyTooLargeError,
   isMcpHttpBodyTimeoutError,
   readMcpHttpBody,
+  resolveMcpCliCaptureKey,
   resolveMcpHttpBodyTimeoutMs,
   resolveMcpRequestContext,
   validateMcpLoopbackRequest,
@@ -182,24 +189,50 @@ export async function startMcpLoopbackServer(port = 0): Promise<{
       return;
     }
 
+    // Bind the request before body parsing/tool resolution. A CLI may exit while
+    // an accepted request is still uploading, and retries must not outrun it.
+    const cliCaptureKey = resolveMcpCliCaptureKey(req);
+    const cliRequestCaptureHandle = markMcpLoopbackRequestStarted(cliCaptureKey);
     const requestAbort = createRequestAbortSignal(req, res);
     void (async () => {
       let parsed: JsonRpcRequest | JsonRpcRequest[] | undefined;
+      let cliCaptureHandles: Array<ReturnType<typeof markMcpLoopbackToolCallStarted>> = [];
       try {
         const body = await readMcpHttpBody(req, { timeoutMs: resolveMcpHttpBodyTimeoutMs() });
         parsed = parseMcpJsonBody(body);
+        const messages = Array.isArray(parsed) ? parsed : [parsed];
+        cliCaptureHandles = messages.map((message) => {
+          if (
+            !cliRequestCaptureHandle ||
+            !isJsonRpcRequest(message) ||
+            message.method !== "tools/call"
+          ) {
+            return undefined;
+          }
+          const admittedToolName =
+            isRecord(message.params) && typeof message.params.name === "string"
+              ? message.params.name
+              : "";
+          const toolArgs =
+            isRecord(message.params) && isRecord(message.params.arguments)
+              ? message.params.arguments
+              : {};
+          return markMcpLoopbackToolCallStarted({
+            requestCaptureHandle: cliRequestCaptureHandle,
+            toolName: admittedToolName,
+            args: toolArgs,
+          });
+        });
+        markMcpLoopbackRequestClassified(cliRequestCaptureHandle);
         const cfg = getRuntimeConfig();
         const requestContext = resolveMcpRequestContext(req, cfg, auth);
-        const onYield = resolveMcpLoopbackYieldHandler(requestContext.sessionId);
-        const yieldContextCacheKey = resolveMcpLoopbackYieldContextCacheKey(
-          requestContext.sessionId,
-        );
+        const yieldContext = resolveMcpLoopbackYieldContext(cliRequestCaptureHandle);
         const scopedTools = toolCache.resolve({
           cfg,
           sessionKey: requestContext.sessionKey,
-          ...(requestContext.sessionId ? { sessionId: requestContext.sessionId } : {}),
-          ...(yieldContextCacheKey ? { yieldContextCacheKey } : {}),
-          ...(onYield ? { onYield } : {}),
+          sessionId: requestContext.sessionId,
+          yieldContextCacheKey: yieldContext?.cacheKey,
+          onYield: yieldContext?.onYield,
           messageProvider: requestContext.messageProvider,
           currentChannelId: requestContext.currentChannelId,
           currentThreadTs: requestContext.currentThreadTs,
@@ -208,10 +241,10 @@ export async function startMcpLoopbackServer(port = 0): Promise<{
           accountId: requestContext.accountId,
           inboundEventKind: requestContext.inboundEventKind,
           sourceReplyDeliveryMode: requestContext.sourceReplyDeliveryMode,
+          requireExplicitMessageTarget: requestContext.requireExplicitMessageTarget,
           senderIsOwner: requestContext.senderIsOwner,
         });
 
-        const messages = Array.isArray(parsed) ? parsed : [parsed];
         logMcpLoopbackTraffic("request", {
           batchSize: messages.length,
           methods: messages.map((message) =>
@@ -224,24 +257,49 @@ export async function startMcpLoopbackServer(port = 0): Promise<{
           cronVisible: scopedTools.toolSchema.some((tool) => tool.name === "cron"),
         });
         const responses: object[] = [];
-        for (const message of messages) {
+        for (const [messageIndex, message] of messages.entries()) {
           if (!isJsonRpcRequest(message)) {
             responses.push(jsonRpcError(readJsonRpcRequestId(message), -32600, "Invalid Request"));
             continue;
           }
-          const response = await handleMcpJsonRpc({
-            message,
-            tools: scopedTools.tools,
-            toolSchema: scopedTools.toolSchema,
-            hookContext: {
-              agentId: scopedTools.agentId,
-              config: cfg,
-              sessionKey: requestContext.sessionKey,
-            },
-            signal: requestAbort.signal,
-          });
+          const cliCaptureHandle = cliCaptureHandles[messageIndex];
+          let response: object | null;
+          try {
+            response = await handleMcpJsonRpc({
+              message,
+              tools: scopedTools.tools,
+              toolSchema: scopedTools.toolSchema,
+              hookContext: {
+                agentId: scopedTools.agentId,
+                config: cfg,
+                sessionKey: requestContext.sessionKey,
+              },
+              signal: requestAbort.signal,
+              onToolCallPrepared: cliCaptureHandle
+                ? ({ toolName: preparedToolName, args }) => {
+                    updateMcpLoopbackToolCallCapture(cliCaptureHandle, {
+                      toolName: preparedToolName,
+                      args,
+                    });
+                  }
+                : undefined,
+              onToolCallResult: cliCaptureHandle
+                ? ({ toolName: resultToolName, args, result, isError }) => {
+                    recordMcpLoopbackToolCallResult({
+                      captureHandle: cliCaptureHandle,
+                      toolName: resultToolName,
+                      args,
+                      result,
+                      isError,
+                    });
+                  }
+                : undefined,
+            });
+          } finally {
+            markMcpLoopbackToolCallFinished(cliCaptureHandle);
+          }
           if (response !== null) {
-            const toolName =
+            const responseToolName =
               message.method === "tools/call" && isRecord(message.params)
                 ? message.params.name
                 : undefined;
@@ -249,7 +307,7 @@ export async function startMcpLoopbackServer(port = 0): Promise<{
               isRecord(response) && isRecord(response.result) && response.result.isError === true;
             logMcpLoopbackTraffic("response", {
               method: message.method,
-              toolName: typeof toolName === "string" ? toolName : undefined,
+              toolName: typeof responseToolName === "string" ? responseToolName : undefined,
               isError,
             });
             responses.push(response);
@@ -293,6 +351,10 @@ export async function startMcpLoopbackServer(port = 0): Promise<{
         }
       } finally {
         requestAbort.cleanup();
+        for (const captureHandle of cliCaptureHandles) {
+          markMcpLoopbackToolCallFinished(captureHandle);
+        }
+        markMcpLoopbackRequestFinished(cliRequestCaptureHandle);
       }
     })();
   });

--- a/src/gateway/mcp-http.ts
+++ b/src/gateway/mcp-http.ts
@@ -14,6 +14,7 @@ import { logDebug, logWarn } from "../logger.js";
 import { handleMcpJsonRpc } from "./mcp-http.handlers.js";
 import {
   clearActiveMcpLoopbackRuntimeByOwnerToken,
+  resolveMcpLoopbackYieldContextCacheKey,
   resolveMcpLoopbackYieldHandler,
   setActiveMcpLoopbackRuntime,
 } from "./mcp-http.loopback-runtime.js";
@@ -190,10 +191,14 @@ export async function startMcpLoopbackServer(port = 0): Promise<{
         const cfg = getRuntimeConfig();
         const requestContext = resolveMcpRequestContext(req, cfg, auth);
         const onYield = resolveMcpLoopbackYieldHandler(requestContext.sessionId);
+        const yieldContextCacheKey = resolveMcpLoopbackYieldContextCacheKey(
+          requestContext.sessionId,
+        );
         const scopedTools = toolCache.resolve({
           cfg,
           sessionKey: requestContext.sessionKey,
           ...(requestContext.sessionId ? { sessionId: requestContext.sessionId } : {}),
+          ...(yieldContextCacheKey ? { yieldContextCacheKey } : {}),
           ...(onYield ? { onYield } : {}),
           messageProvider: requestContext.messageProvider,
           currentChannelId: requestContext.currentChannelId,

--- a/src/gateway/tool-resolution.test.ts
+++ b/src/gateway/tool-resolution.test.ts
@@ -1,7 +1,7 @@
 /**
  * Gateway tool-resolution tests.
  */
-import { beforeAll, describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveGatewayScopedTools } from "./tool-resolution.js";
 
@@ -72,14 +72,12 @@ describe("resolveGatewayScopedTools", () => {
   });
 
   it("passes loopback yield context into sessions_yield", async () => {
-    const yieldedMessages: string[] = [];
+    const onYield = vi.fn();
     const result = resolveGatewayScopedTools({
       cfg: { tools: { profile: "minimal", alsoAllow: ["sessions_yield"] } } as OpenClawConfig,
       sessionKey: "agent:main:telegram:group:-100123",
-      sessionId: "run-session-123",
-      onYield: (message: string) => {
-        yieldedMessages.push(message);
-      },
+      sessionId: "session-123",
+      onYield,
       surface: "loopback",
     });
     const yieldTool = result.tools.find((tool) => tool.name === "sessions_yield");
@@ -87,9 +85,14 @@ describe("resolveGatewayScopedTools", () => {
       throw new Error("expected sessions_yield tool");
     }
 
-    const toolResult = await yieldTool.execute("tool-call-1", { message: "wait for subagents" });
+    const toolResult = await yieldTool.execute("tool-call-1", {
+      message: "waiting on subagents",
+    });
 
-    expect(yieldedMessages).toEqual(["wait for subagents"]);
-    expect(toolResult.details).toEqual({ status: "yielded", message: "wait for subagents" });
+    expect(onYield).toHaveBeenCalledWith("waiting on subagents");
+    expect(toolResult.details).toEqual({
+      status: "yielded",
+      message: "waiting on subagents",
+    });
   });
 });

--- a/src/gateway/tool-resolution.test.ts
+++ b/src/gateway/tool-resolution.test.ts
@@ -70,4 +70,26 @@ describe("resolveGatewayScopedTools", () => {
 
     expect(result.tools.some((tool) => tool.name === "message")).toBe(false);
   });
+
+  it("passes loopback yield context into sessions_yield", async () => {
+    const yieldedMessages: string[] = [];
+    const result = resolveGatewayScopedTools({
+      cfg: { tools: { profile: "minimal", alsoAllow: ["sessions_yield"] } } as OpenClawConfig,
+      sessionKey: "agent:main:telegram:group:-100123",
+      sessionId: "run-session-123",
+      onYield: (message: string) => {
+        yieldedMessages.push(message);
+      },
+      surface: "loopback",
+    });
+    const yieldTool = result.tools.find((tool) => tool.name === "sessions_yield");
+    if (!yieldTool) {
+      throw new Error("expected sessions_yield tool");
+    }
+
+    const toolResult = await yieldTool.execute("tool-call-1", { message: "wait for subagents" });
+
+    expect(yieldedMessages).toEqual(["wait for subagents"]);
+    expect(toolResult.details).toEqual({ status: "yielded", message: "wait for subagents" });
+  });
 });

--- a/src/gateway/tool-resolution.ts
+++ b/src/gateway/tool-resolution.ts
@@ -24,10 +24,6 @@ import {
   resolveToolProfilePolicy,
 } from "../agents/tool-policy.js";
 import type { AnyAgentTool } from "../agents/tools/common.js";
-import {
-  replaceWithEffectiveCronCreatorToolAllowlist,
-  type CronCreatorToolAllowlistEntry,
-} from "../agents/tools/cron-tool.js";
 import type { SourceReplyDeliveryMode } from "../auto-reply/get-reply-options.types.js";
 import type { InboundEventKind } from "../channels/inbound-event/kind.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -44,6 +40,8 @@ type GatewayScopedToolSurface = "http" | "loopback";
 export function resolveGatewayScopedTools(params: {
   cfg: OpenClawConfig;
   sessionKey: string;
+  sessionId?: string;
+  onYield?: (message: string) => Promise<void> | void;
   messageProvider?: string;
   currentChannelId?: string;
   currentThreadTs?: string;
@@ -52,7 +50,6 @@ export function resolveGatewayScopedTools(params: {
   accountId?: string;
   inboundEventKind?: InboundEventKind;
   sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
-  requireExplicitMessageTarget?: boolean;
   agentTo?: string;
   agentThreadId?: string;
   senderIsOwner?: boolean;
@@ -148,7 +145,6 @@ export function resolveGatewayScopedTools(params: {
   // Passed by reference to sessions_spawn and populated after the final policy
   // pass so child sessions inherit the actual parent tool surface.
   const inheritedToolAllowlist: string[] = [];
-  const cronCreatorToolAllowlist: CronCreatorToolAllowlistEntry[] = [];
   const shouldInheritEffectiveToolAllowlist = [
     profilePolicy,
     providerProfilePolicy,
@@ -161,10 +157,6 @@ export function resolveGatewayScopedTools(params: {
     inheritedToolPolicy,
     gatewayRequestedTools.length > 0 ? { allow: gatewayRequestedTools } : undefined,
   ].some(hasRestrictiveAllowPolicy);
-  const shouldCaptureCronCreatorToolAllowlist =
-    shouldInheritEffectiveToolAllowlist ||
-    explicitDenylist.length > 0 ||
-    excludedToolNames.length > 0;
 
   const allTools = createOpenClawTools({
     agentSessionKey: params.sessionKey,
@@ -178,7 +170,8 @@ export function resolveGatewayScopedTools(params: {
     currentThreadTs: params.currentThreadTs ?? params.agentThreadId,
     currentMessageId: params.currentMessageId,
     currentInboundAudio: params.currentInboundAudio,
-    requireExplicitMessageTarget: params.requireExplicitMessageTarget,
+    ...(params.sessionId ? { sessionId: params.sessionId } : {}),
+    ...(params.onYield ? { onYield: params.onYield } : {}),
     senderIsOwner: params.senderIsOwner,
     allowGatewaySubagentBinding: params.allowGatewaySubagentBinding,
     allowMediaInvokeCommands: params.allowMediaInvokeCommands,
@@ -199,9 +192,6 @@ export function resolveGatewayScopedTools(params: {
       gatewayRequestedTools.length > 0 ? { allow: gatewayRequestedTools } : undefined,
     ]),
     pluginToolDenylist: explicitDenylist,
-    cronCreatorToolAllowlist: shouldCaptureCronCreatorToolAllowlist
-      ? cronCreatorToolAllowlist
-      : undefined,
     inheritedToolAllowlist,
     inheritedToolDenylist,
   });
@@ -239,11 +229,6 @@ export function resolveGatewayScopedTools(params: {
   const tools = policyFiltered.filter((tool) => !gatewayDenySet.has(tool.name));
   if (shouldInheritEffectiveToolAllowlist) {
     replaceWithEffectiveToolAllowlist(inheritedToolAllowlist, tools);
-  }
-  if (shouldCaptureCronCreatorToolAllowlist) {
-    replaceWithEffectiveCronCreatorToolAllowlist(cronCreatorToolAllowlist, tools, (tool) =>
-      getPluginToolMeta(tool),
-    );
   }
 
   return {

--- a/src/gateway/tool-resolution.ts
+++ b/src/gateway/tool-resolution.ts
@@ -24,6 +24,10 @@ import {
   resolveToolProfilePolicy,
 } from "../agents/tool-policy.js";
 import type { AnyAgentTool } from "../agents/tools/common.js";
+import {
+  replaceWithEffectiveCronCreatorToolAllowlist,
+  type CronCreatorToolAllowlistEntry,
+} from "../agents/tools/cron-tool.js";
 import type { SourceReplyDeliveryMode } from "../auto-reply/get-reply-options.types.js";
 import type { InboundEventKind } from "../channels/inbound-event/kind.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -50,6 +54,7 @@ export function resolveGatewayScopedTools(params: {
   accountId?: string;
   inboundEventKind?: InboundEventKind;
   sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
+  requireExplicitMessageTarget?: boolean;
   agentTo?: string;
   agentThreadId?: string;
   senderIsOwner?: boolean;
@@ -145,6 +150,7 @@ export function resolveGatewayScopedTools(params: {
   // Passed by reference to sessions_spawn and populated after the final policy
   // pass so child sessions inherit the actual parent tool surface.
   const inheritedToolAllowlist: string[] = [];
+  const cronCreatorToolAllowlist: CronCreatorToolAllowlistEntry[] = [];
   const shouldInheritEffectiveToolAllowlist = [
     profilePolicy,
     providerProfilePolicy,
@@ -157,6 +163,10 @@ export function resolveGatewayScopedTools(params: {
     inheritedToolPolicy,
     gatewayRequestedTools.length > 0 ? { allow: gatewayRequestedTools } : undefined,
   ].some(hasRestrictiveAllowPolicy);
+  const shouldCaptureCronCreatorToolAllowlist =
+    shouldInheritEffectiveToolAllowlist ||
+    explicitDenylist.length > 0 ||
+    excludedToolNames.length > 0;
 
   const allTools = createOpenClawTools({
     agentSessionKey: params.sessionKey,
@@ -170,8 +180,9 @@ export function resolveGatewayScopedTools(params: {
     currentThreadTs: params.currentThreadTs ?? params.agentThreadId,
     currentMessageId: params.currentMessageId,
     currentInboundAudio: params.currentInboundAudio,
-    ...(params.sessionId ? { sessionId: params.sessionId } : {}),
-    ...(params.onYield ? { onYield: params.onYield } : {}),
+    sessionId: params.sessionId,
+    onYield: params.onYield,
+    requireExplicitMessageTarget: params.requireExplicitMessageTarget,
     senderIsOwner: params.senderIsOwner,
     allowGatewaySubagentBinding: params.allowGatewaySubagentBinding,
     allowMediaInvokeCommands: params.allowMediaInvokeCommands,
@@ -192,6 +203,9 @@ export function resolveGatewayScopedTools(params: {
       gatewayRequestedTools.length > 0 ? { allow: gatewayRequestedTools } : undefined,
     ]),
     pluginToolDenylist: explicitDenylist,
+    cronCreatorToolAllowlist: shouldCaptureCronCreatorToolAllowlist
+      ? cronCreatorToolAllowlist
+      : undefined,
     inheritedToolAllowlist,
     inheritedToolDenylist,
   });
@@ -229,6 +243,11 @@ export function resolveGatewayScopedTools(params: {
   const tools = policyFiltered.filter((tool) => !gatewayDenySet.has(tool.name));
   if (shouldInheritEffectiveToolAllowlist) {
     replaceWithEffectiveToolAllowlist(inheritedToolAllowlist, tools);
+  }
+  if (shouldCaptureCronCreatorToolAllowlist) {
+    replaceWithEffectiveCronCreatorToolAllowlist(cronCreatorToolAllowlist, tools, (tool) =>
+      getPluginToolMeta(tool),
+    );
   }
 
   return {


### PR DESCRIPTION
## Summary

`sessions_yield` on CLI-backed MCP turns was created without the active run session id or yield callback, so it returned `No session context` instead of pausing the run.

This change keeps yield ownership inside the existing per-CLI MCP capture:

- injects the run session id into the loopback MCP request
- binds the yield callback to the admitted capture generation
- includes that generation in the short-lived tool cache key, preventing stale callbacks when a capture key is reused
- records yielded CLI output as `paused` / `end_turn`
- projects the same terminal metadata into lifecycle events

No user config, migration, provider routing, or embedded-runner behavior changes.

Closes #77426

## Real behavior proof

- Behavior addressed: CLI-backed MCP `sessions_yield` now yields the active run instead of returning `No session context`.
- Real environment tested: The production OpenClaw MCP loopback HTTP server and gateway-scoped tool resolver, started from the rebased PR head with an isolated `OPENCLAW_STATE_DIR`.
- Exact steps or command run after this patch: Started `src/gateway/mcp-http.ts` through `node --import tsx --input-type=module`, registered a real CLI capture, and sent an authenticated HTTP `tools/call` request for `sessions_yield` with `x-openclaw-session-id` and `x-openclaw-cli-capture-key`.
- Evidence after fix: Console output from the after-fix production loopback run:

```text
{"httpStatus":200,"rpcIsError":false,"toolResult":{"status":"yielded","message":"real loopback yield"},"yielded":true,"yieldedMessage":"real loopback yield"}
```

- Observed result after fix: The production loopback endpoint returned HTTP 200 and `status: "yielded"`; the admitted CLI capture received the same yield message.
- What was not tested: A separately installed external Claude CLI binary initiating the MCP call.

## Verification

- Focused Vitest: 3 shards, 12 files, and 372 tests passed after the final rebase.
- `git diff --check`: passed.
- Targeted oxlint for all changed TypeScript files: passed.
- Remote changed gate: `pnpm check:changed` passed on AWS Crabbox `cbx_9c668236f0f7`, run `run_d5de9a775bf2`.
- Autoreview: `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` returned no findings; overall confidence 0.84.

## Risk

The sensitive boundary is reuse of short-lived loopback tool objects. Requests bind to their admitted capture generation, and the generation is part of the cache key, so an older request cannot yield a newer CLI turn.
