### PR TITLE
fix(auto-reply): warn when /export-session only contains user messages (backend-delegated)

### DIFF
--- a/src/auto-reply/reply/commands-export-session.test.ts
+++ b/src/auto-reply/reply/commands-export-session.test.ts
@@ -164,6 +164,14 @@ function writtenHtml(): string {
   return value;
 }
 
+function sessionDataFromHtml(html: string): Record<string, unknown> {
+  const match = html.match(/id="session-data"[^>]*>([^<]+)</);
+  if (!match) {
+    throw new Error("Expected session-data script in exported HTML");
+  }
+  return JSON.parse(Buffer.from(match[1].trim(), "base64").toString("utf-8"));
+}
+
 describe("buildExportSessionReply", () => {
   afterEach(() => {
     vi.useRealTimers();
@@ -549,5 +557,55 @@ describe("buildExportSessionReply", () => {
       "⚠️ Skipped 1 malformed transcript row that was not a session entry. rows 4",
     );
     expect(reply.text).not.toMatch(/Unexpected|SyntaxError|position/i);
+  });
+
+  it("warns when the session only contains user messages (backend-delegated transcript)", async () => {
+    hoisted.sessionTranscriptContent = [
+      JSON.stringify({ type: "session", version: 3, id: "session-1" }),
+      JSON.stringify({
+        type: "message",
+        id: "entry-1",
+        timestamp: "2026-05-16T00:00:00.000Z",
+        message: { role: "user", content: "hello" },
+      }),
+      JSON.stringify({
+        type: "message",
+        id: "entry-2",
+        timestamp: "2026-05-16T00:00:01.000Z",
+        message: { role: "user", content: "world" },
+      }),
+    ].join("\n");
+
+    const reply = await buildExportSessionReply(makeParams());
+
+    expect(reply.text).toContain("backend runtime");
+    expect(reply.text).toContain("not included in this export");
+    const data = sessionDataFromHtml(writtenHtml());
+    expect(typeof data.warning).toBe("string");
+    expect(data.warning).toContain("backend runtime");
+  });
+
+  it("does not warn when the transcript includes assistant messages", async () => {
+    hoisted.sessionTranscriptContent = [
+      JSON.stringify({ type: "session", version: 3, id: "session-1" }),
+      JSON.stringify({
+        type: "message",
+        id: "entry-1",
+        timestamp: "2026-05-16T00:00:00.000Z",
+        message: { role: "user", content: "hello" },
+      }),
+      JSON.stringify({
+        type: "message",
+        id: "entry-2",
+        timestamp: "2026-05-16T00:00:01.000Z",
+        message: { role: "assistant", content: "hi" },
+      }),
+    ].join("\n");
+
+    const reply = await buildExportSessionReply(makeParams());
+
+    expect(reply.text).not.toContain("backend runtime");
+    expect(reply.text).not.toContain("not included in this export");
+    expect(sessionDataFromHtml(writtenHtml()).warning).toBeUndefined();
   });
 });

--- a/src/auto-reply/reply/commands-export-session.test.ts
+++ b/src/auto-reply/reply/commands-export-session.test.ts
@@ -22,10 +22,17 @@ const hoisted = await vi.hoisted(async () => {
     accessMock: vi.fn(async (_filePath: string) => undefined),
     pathExistsMock: vi.fn(async (_filePath: string) => true),
     migrateSessionEntriesMock: vi.fn((_entries: unknown[]) => undefined),
+    readAcpSessionMetaForEntryMock: vi.fn<
+      (params: { sessionKey: string; entry?: { sessionId?: string } }) => unknown
+    >(() => undefined),
     exportHtmlTemplateContents: new Map<string, string>(),
     sessionTranscriptContent: "",
   };
 });
+
+vi.mock("../../acp/runtime/session-meta.js", () => ({
+  readAcpSessionMetaForEntry: hoisted.readAcpSessionMetaForEntryMock,
+}));
 
 vi.mock("../../config/sessions/paths.js", () => ({
   resolveDefaultSessionStorePath: hoisted.resolveDefaultSessionStorePathMock,
@@ -200,6 +207,7 @@ describe("buildExportSessionReply", () => {
     });
     hoisted.accessMock.mockResolvedValue(undefined);
     hoisted.pathExistsMock.mockResolvedValue(true);
+    hoisted.readAcpSessionMetaForEntryMock.mockReturnValue(undefined);
     hoisted.exportHtmlTemplateContents.clear();
     hoisted.sessionTranscriptContent = "";
   });
@@ -592,6 +600,38 @@ describe("buildExportSessionReply", () => {
     const data = sessionDataFromHtml(writtenHtml());
     expect(typeof data.warning).toBe("string");
     expect(data.warning).toContain("backend runtime");
+  });
+
+  it("warns when persisted ACP metadata is stored outside the session entry", async () => {
+    hoisted.readAcpSessionMetaForEntryMock.mockReturnValue({
+      backend: "acpx",
+      mode: "persistent",
+      agent: "claude",
+      runtimeSessionName: "backend-session-1",
+      state: "idle",
+      lastActivityAt: 1,
+    });
+    hoisted.sessionTranscriptContent = [
+      JSON.stringify({ type: "session", version: 3, id: "session-1" }),
+      JSON.stringify({
+        type: "message",
+        id: "entry-1",
+        timestamp: "2026-05-16T00:00:00.000Z",
+        message: { role: "user", content: "hello" },
+      }),
+    ].join("\n");
+
+    const reply = await buildExportSessionReply(makeParams());
+
+    expect(hoisted.readAcpSessionMetaForEntryMock).toHaveBeenCalledWith({
+      sessionKey: "agent:target:session",
+      entry: {
+        sessionId: "session-1",
+        updatedAt: 1,
+      },
+    });
+    expect(reply.text).toContain("backend runtime");
+    expect(sessionDataFromHtml(writtenHtml()).warning).toContain("backend runtime");
   });
 
   it("does not warn for a normal user-only transcript without backend session metadata", async () => {

--- a/src/auto-reply/reply/commands-export-session.test.ts
+++ b/src/auto-reply/reply/commands-export-session.test.ts
@@ -634,6 +634,27 @@ describe("buildExportSessionReply", () => {
     expect(sessionDataFromHtml(writtenHtml()).warning).toContain("backend runtime");
   });
 
+  it("continues exporting when persisted ACP metadata cannot be read", async () => {
+    hoisted.readAcpSessionMetaForEntryMock.mockImplementation(() => {
+      throw new Error("state database unavailable");
+    });
+    hoisted.sessionTranscriptContent = [
+      JSON.stringify({ type: "session", version: 3, id: "session-1" }),
+      JSON.stringify({
+        type: "message",
+        id: "entry-1",
+        timestamp: "2026-05-16T00:00:00.000Z",
+        message: { role: "user", content: "hello" },
+      }),
+    ].join("\n");
+
+    const reply = await buildExportSessionReply(makeParams());
+
+    expect(reply.text).toContain("Session exported");
+    expect(reply.text).not.toContain("backend runtime");
+    expect(sessionDataFromHtml(writtenHtml()).warning).toBeUndefined();
+  });
+
   it("does not warn for a normal user-only transcript without backend session metadata", async () => {
     hoisted.sessionTranscriptContent = [
       JSON.stringify({ type: "session", version: 3, id: "session-1" }),

--- a/src/auto-reply/reply/commands-export-session.test.ts
+++ b/src/auto-reply/reply/commands-export-session.test.ts
@@ -560,6 +560,15 @@ describe("buildExportSessionReply", () => {
   });
 
   it("warns when the session only contains user messages (backend-delegated transcript)", async () => {
+    hoisted.loadSessionStoreMock.mockReturnValue({
+      "agent:target:session": {
+        sessionId: "session-1",
+        updatedAt: 1,
+        cliSessionBindings: {
+          "claude-cli": { sessionId: "backend-session-1" },
+        },
+      },
+    });
     hoisted.sessionTranscriptContent = [
       JSON.stringify({ type: "session", version: 3, id: "session-1" }),
       JSON.stringify({
@@ -585,7 +594,68 @@ describe("buildExportSessionReply", () => {
     expect(data.warning).toContain("backend runtime");
   });
 
+  it("does not warn for a normal user-only transcript without backend session metadata", async () => {
+    hoisted.sessionTranscriptContent = [
+      JSON.stringify({ type: "session", version: 3, id: "session-1" }),
+      JSON.stringify({
+        type: "message",
+        id: "entry-1",
+        timestamp: "2026-05-16T00:00:00.000Z",
+        message: { role: "user", content: "hello" },
+      }),
+    ].join("\n");
+
+    const reply = await buildExportSessionReply(makeParams());
+
+    expect(reply.text).not.toContain("backend runtime");
+    expect(sessionDataFromHtml(writtenHtml()).warning).toBeUndefined();
+  });
+
+  it("ignores malformed persisted backend session metadata", async () => {
+    hoisted.loadSessionStoreMock.mockReturnValue({
+      "agent:target:session": {
+        sessionId: "session-1",
+        updatedAt: 1,
+        claudeCliSessionId: 123,
+        cliSessionBindings: {
+          "claude-cli": null,
+        },
+        cliSessionIds: {
+          acpx: 123,
+        },
+      },
+    } as never);
+    hoisted.sessionTranscriptContent = [
+      JSON.stringify({ type: "session", version: 3, id: "session-1" }),
+      JSON.stringify({
+        type: "message",
+        id: "entry-1",
+        timestamp: "2026-05-16T00:00:00.000Z",
+        message: { role: "user", content: "hello" },
+      }),
+    ].join("\n");
+
+    const reply = await buildExportSessionReply(makeParams());
+
+    expect(reply.text).not.toContain("backend runtime");
+    expect(sessionDataFromHtml(writtenHtml()).warning).toBeUndefined();
+  });
+
   it("does not warn when the transcript includes assistant messages", async () => {
+    hoisted.loadSessionStoreMock.mockReturnValue({
+      "agent:target:session": {
+        sessionId: "session-1",
+        updatedAt: 1,
+        acp: {
+          backend: "acpx",
+          mode: "persistent",
+          agent: "claude",
+          runtimeSessionName: "backend-session-1",
+          state: "idle",
+          lastActivityAt: 1,
+        },
+      },
+    });
     hoisted.sessionTranscriptContent = [
       JSON.stringify({ type: "session", version: 3, id: "session-1" }),
       JSON.stringify({

--- a/src/auto-reply/reply/commands-export-session.ts
+++ b/src/auto-reply/reply/commands-export-session.ts
@@ -82,9 +82,12 @@ function isBackendDelegatedSession(
     return false;
   }
   const messages = entries.filter(
-    (entry): entry is SessionMessageEntry => entry.type === "message",
+    (transcriptEntry): transcriptEntry is SessionMessageEntry => transcriptEntry.type === "message",
   );
-  return messages.length > 0 && messages.every((entry) => entry.message.role === "user");
+  return (
+    messages.length > 0 &&
+    messages.every((transcriptEntry) => transcriptEntry.message.role === "user")
+  );
 }
 
 type SessionExportWarningSummary = {

--- a/src/auto-reply/reply/commands-export-session.ts
+++ b/src/auto-reply/reply/commands-export-session.ts
@@ -12,6 +12,7 @@ import {
   type SessionHeader,
   type SessionMessageEntry,
 } from "../../agents/sessions/session-manager.js";
+import { readAcpSessionMetaForEntry } from "../../acp/runtime/session-meta.js";
 import { scanSessionTranscriptTree } from "../../config/sessions/transcript-tree.js";
 import type { SessionEntry as StoredSessionEntry } from "../../config/sessions/types.js";
 import { pathExists } from "../../infra/fs-safe.js";
@@ -44,9 +45,9 @@ function hasNonEmptyString(value: unknown): boolean {
   return typeof value === "string" && value.trim().length > 0;
 }
 
-function hasBackendSession(entry: StoredSessionEntry): boolean {
+function hasBackendSession(entry: StoredSessionEntry, hasStoredAcpSession: boolean): boolean {
   return (
-    Boolean(entry.acp) ||
+    hasStoredAcpSession ||
     hasNonEmptyString(entry.claudeCliSessionId) ||
     Object.values(entry.cliSessionBindings ?? {}).some(
       (binding) => hasNonEmptyString(binding?.sessionId),
@@ -58,8 +59,9 @@ function hasBackendSession(entry: StoredSessionEntry): boolean {
 function isBackendDelegatedSession(
   entry: StoredSessionEntry,
   entries: AgentSessionEntry[],
+  hasStoredAcpSession: boolean,
 ): boolean {
-  if (!hasBackendSession(entry)) {
+  if (!hasBackendSession(entry, hasStoredAcpSession)) {
     return false;
   }
   if (entries.length === 0) {
@@ -298,7 +300,15 @@ export async function buildExportSessionReply(params: HandleCommandsParams): Pro
   });
 
   // 4. Prepare session data
-  const backendWarning = isBackendDelegatedSession(entry, entries)
+  const hasStoredAcpSession =
+    Boolean(entry.acp) ||
+    Boolean(
+      readAcpSessionMetaForEntry({
+        sessionKey: params.sessionKey,
+        entry,
+      }),
+    );
+  const backendWarning = isBackendDelegatedSession(entry, entries, hasStoredAcpSession)
     ? BACKEND_DELEGATED_WARNING
     : undefined;
   const sessionData: SessionData = {

--- a/src/auto-reply/reply/commands-export-session.ts
+++ b/src/auto-reply/reply/commands-export-session.ts
@@ -2,6 +2,7 @@
 import fsp from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { readAcpSessionMetaForEntry } from "../../acp/runtime/session-meta.js";
 import {
   parseSessionFileEntriesWithWarnings,
   type SessionFileParseWarning,
@@ -12,7 +13,6 @@ import {
   type SessionHeader,
   type SessionMessageEntry,
 } from "../../agents/sessions/session-manager.js";
-import { readAcpSessionMetaForEntry } from "../../acp/runtime/session-meta.js";
 import { scanSessionTranscriptTree } from "../../config/sessions/transcript-tree.js";
 import type { SessionEntry as StoredSessionEntry } from "../../config/sessions/types.js";
 import { pathExists } from "../../infra/fs-safe.js";
@@ -49,11 +49,25 @@ function hasBackendSession(entry: StoredSessionEntry, hasStoredAcpSession: boole
   return (
     hasStoredAcpSession ||
     hasNonEmptyString(entry.claudeCliSessionId) ||
-    Object.values(entry.cliSessionBindings ?? {}).some(
-      (binding) => hasNonEmptyString(binding?.sessionId),
+    Object.values(entry.cliSessionBindings ?? {}).some((binding) =>
+      hasNonEmptyString(binding?.sessionId),
     ) ||
     Object.values(entry.cliSessionIds ?? {}).some(hasNonEmptyString)
   );
+}
+
+function hasPersistedAcpSession(params: {
+  sessionKey: string;
+  entry: StoredSessionEntry;
+}): boolean {
+  if (params.entry.acp) {
+    return true;
+  }
+  try {
+    return Boolean(readAcpSessionMetaForEntry(params));
+  } catch {
+    return false;
+  }
 }
 
 function isBackendDelegatedSession(
@@ -300,14 +314,10 @@ export async function buildExportSessionReply(params: HandleCommandsParams): Pro
   });
 
   // 4. Prepare session data
-  const hasStoredAcpSession =
-    Boolean(entry.acp) ||
-    Boolean(
-      readAcpSessionMetaForEntry({
-        sessionKey: params.sessionKey,
-        entry,
-      }),
-    );
+  const hasStoredAcpSession = hasPersistedAcpSession({
+    sessionKey: params.sessionKey,
+    entry,
+  });
   const backendWarning = isBackendDelegatedSession(entry, entries, hasStoredAcpSession)
     ? BACKEND_DELEGATED_WARNING
     : undefined;

--- a/src/auto-reply/reply/commands-export-session.ts
+++ b/src/auto-reply/reply/commands-export-session.ts
@@ -13,6 +13,7 @@ import {
   type SessionMessageEntry,
 } from "../../agents/sessions/session-manager.js";
 import { scanSessionTranscriptTree } from "../../config/sessions/transcript-tree.js";
+import type { SessionEntry as StoredSessionEntry } from "../../config/sessions/types.js";
 import { pathExists } from "../../infra/fs-safe.js";
 import type { ReplyPayload } from "../types.js";
 import {
@@ -39,7 +40,28 @@ interface SessionData {
 const BACKEND_DELEGATED_WARNING =
   "This session was handled by a backend runtime (e.g. CLI/ACP). Assistant replies, tool calls, and usage data are stored in the backend transcript and are not included in this export.";
 
-function isBackendDelegatedSession(entries: AgentSessionEntry[]): boolean {
+function hasNonEmptyString(value: unknown): boolean {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function hasBackendSession(entry: StoredSessionEntry): boolean {
+  return (
+    Boolean(entry.acp) ||
+    hasNonEmptyString(entry.claudeCliSessionId) ||
+    Object.values(entry.cliSessionBindings ?? {}).some(
+      (binding) => hasNonEmptyString(binding?.sessionId),
+    ) ||
+    Object.values(entry.cliSessionIds ?? {}).some(hasNonEmptyString)
+  );
+}
+
+function isBackendDelegatedSession(
+  entry: StoredSessionEntry,
+  entries: AgentSessionEntry[],
+): boolean {
+  if (!hasBackendSession(entry)) {
+    return false;
+  }
   if (entries.length === 0) {
     return false;
   }
@@ -276,7 +298,9 @@ export async function buildExportSessionReply(params: HandleCommandsParams): Pro
   });
 
   // 4. Prepare session data
-  const backendWarning = isBackendDelegatedSession(entries) ? BACKEND_DELEGATED_WARNING : undefined;
+  const backendWarning = isBackendDelegatedSession(entry, entries)
+    ? BACKEND_DELEGATED_WARNING
+    : undefined;
   const sessionData: SessionData = {
     header,
     entries,

--- a/src/auto-reply/reply/commands-export-session.ts
+++ b/src/auto-reply/reply/commands-export-session.ts
@@ -10,6 +10,7 @@ import {
   migrateSessionEntries,
   type SessionEntry as AgentSessionEntry,
   type SessionHeader,
+  type SessionMessageEntry,
 } from "../../agents/sessions/session-manager.js";
 import { scanSessionTranscriptTree } from "../../config/sessions/transcript-tree.js";
 import { pathExists } from "../../infra/fs-safe.js";
@@ -32,6 +33,20 @@ interface SessionData {
   hasLeafControl: boolean;
   systemPrompt?: string;
   tools?: Array<{ name: string; description?: string; parameters?: unknown }>;
+  warning?: string;
+}
+
+const BACKEND_DELEGATED_WARNING =
+  "This session was handled by a backend runtime (e.g. CLI/ACP). Assistant replies, tool calls, and usage data are stored in the backend transcript and are not included in this export.";
+
+function isBackendDelegatedSession(entries: AgentSessionEntry[]): boolean {
+  if (entries.length === 0) {
+    return false;
+  }
+  const messages = entries.filter(
+    (entry): entry is SessionMessageEntry => entry.type === "message",
+  );
+  return messages.length > 0 && messages.every((entry) => entry.message.role === "user");
 }
 
 type SessionExportWarningSummary = {
@@ -261,6 +276,7 @@ export async function buildExportSessionReply(params: HandleCommandsParams): Pro
   });
 
   // 4. Prepare session data
+  const backendWarning = isBackendDelegatedSession(entries) ? BACKEND_DELEGATED_WARNING : undefined;
   const sessionData: SessionData = {
     header,
     entries,
@@ -272,6 +288,7 @@ export async function buildExportSessionReply(params: HandleCommandsParams): Pro
       description: t.description,
       parameters: t.parameters,
     })),
+    warning: backendWarning,
   };
 
   // 5. Generate HTML
@@ -309,6 +326,7 @@ export async function buildExportSessionReply(params: HandleCommandsParams): Pro
       `📄 File: ${displayPath}`,
       `📊 Entries: ${entries.length}`,
       ...warnings.map(formatSessionExportWarning),
+      ...(backendWarning ? [`⚠️ ${backendWarning}`] : []),
       `🧠 System prompt: ${systemPrompt.length.toLocaleString()} chars`,
       `🔧 Tools: ${tools.length}`,
     ].join("\n"),

--- a/src/auto-reply/reply/commands-export-test-mocks.ts
+++ b/src/auto-reply/reply/commands-export-test-mocks.ts
@@ -1,5 +1,6 @@
 /** Test mocks for export-command session path and store helpers. */
 import type { vi } from "vitest";
+import type { SessionEntry } from "../../config/sessions/types.js";
 
 type ViLike = Pick<typeof vi, "fn">;
 
@@ -11,7 +12,7 @@ export function createExportCommandSessionMocks(viInstance: ViLike) {
     resolveSessionFilePathOptionsMock: viInstance.fn(
       (params: { agentId: string; storePath: string }) => params,
     ),
-    loadSessionStoreMock: viInstance.fn(() => ({
+    loadSessionStoreMock: viInstance.fn<() => Record<string, SessionEntry>>(() => ({
       "agent:target:session": {
         sessionId: "session-1",
         updatedAt: 1,

--- a/src/auto-reply/reply/export-html/template.css
+++ b/src/auto-reply/reply/export-html/template.css
@@ -256,6 +256,17 @@ body {
   border-color: var(--borderAccent);
 }
 
+/* Export warnings */
+.export-warning {
+  background: var(--userMsgBg);
+  border: 1px solid var(--warning);
+  border-radius: 4px;
+  color: var(--warning);
+  font-size: 12px;
+  margin-bottom: var(--line-height);
+  padding: var(--line-height);
+}
+
 /* Header */
 .header {
   background: var(--container-bg);

--- a/src/auto-reply/reply/export-html/template.js
+++ b/src/auto-reply/reply/export-html/template.js
@@ -21,6 +21,7 @@
     systemPrompt,
     tools,
     renderedTools,
+    warning,
   } = data;
 
   // ============================================================
@@ -1567,9 +1568,13 @@
       msgParts.push(`${globalStats.branchSummaries} branch summaries`);
     }
 
-    let html = `
+    let html = "";
+    if (warning) {
+      html += `<div class="export-warning">${escapeHtml(warning)}</div>`;
+    }
+    html += `
           <div class="header">
-            <h1>Session: ${escapeHtml(header?.id || "unknown")}</h1>
+            <h1>Session: ${escapeHtml(header?.id || "unknown")}</h1>`
             <div class="help-bar">
               <span>Ctrl+T toggle thinking · Ctrl+O toggle tools</span>
               <button class="download-json-btn" onclick="downloadSessionJson()" title="Download session as JSONL">↓ JSONL</button>

--- a/src/auto-reply/reply/export-html/template.js
+++ b/src/auto-reply/reply/export-html/template.js
@@ -1574,7 +1574,7 @@
     }
     html += `
           <div class="header">
-            <h1>Session: ${escapeHtml(header?.id || "unknown")}</h1>`
+            <h1>Session: ${escapeHtml(header?.id || "unknown")}</h1>
             <div class="help-bar">
               <span>Ctrl+T toggle thinking · Ctrl+O toggle tools</span>
               <button class="download-json-btn" onclick="downloadSessionJson()" title="Download session as JSONL">↓ JSONL</button>

--- a/src/auto-reply/reply/export-html/template.security.test.ts
+++ b/src/auto-reply/reply/export-html/template.security.test.ts
@@ -29,6 +29,7 @@ type SessionData = {
   hasLeafControl?: boolean;
   systemPrompt: string;
   tools: unknown[];
+  warning?: string;
 };
 
 type ParsedHtml = {
@@ -212,6 +213,42 @@ describe("export html sidebar trigger affordance", () => {
 });
 
 describe("export html security hardening", () => {
+  it("renders export warnings in the header without interpreting HTML", async () => {
+    const warning = 'Backend <img src=x onerror="alert(1)"> transcript is incomplete';
+    const session: SessionData = {
+      header: { id: "session-warning", timestamp: now() },
+      entries: [
+        {
+          id: "1",
+          parentId: null,
+          timestamp: now(),
+          type: "message",
+          message: { role: "user", content: "hello" },
+        },
+      ],
+      leafId: "1",
+      systemPrompt: "",
+      tools: [],
+      warning,
+    };
+
+    const { document } = await renderTemplate(session);
+    const header = requireElement(
+      document.getElementById("header-container"),
+      "header root missing",
+    );
+    const warningNode = requireElement(
+      header.querySelector(".export-warning"),
+      "export warning missing",
+    );
+
+    expect(warningNode.textContent).toBe(warning);
+    expect(warningNode.querySelector("img[onerror]")).toBeNull();
+    expect(warningNode.innerHTML).toContain(
+      'Backend &lt;img src=x onerror="alert(1)"&gt; transcript is incomplete',
+    );
+  });
+
   it("renders an explicitly selected empty branch without inactive messages", async () => {
     const session: SessionData = {
       header: { id: "session-empty", timestamp: now() },


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `/export-session` could report a successful export for sessions handled by a CLI/ACP backend even though OpenClaw's transcript contained only inbound user messages. The resulting HTML omitted assistant replies, tool calls, and usage data without explaining why.

Closes #90844.

## Why This Change Was Made

The export path now detects a backend-linked, user-only transcript and adds a clear warning to both the command reply and exported HTML. Mixed or normal transcripts remain unchanged, and the warning is escaped before rendering.

## User Impact

Users exporting a backend-delegated session are told that assistant replies, tool calls, and usage data live in the backend's own session store instead of receiving a misleadingly complete-looking export.

## Evidence

- Exact PR head: `1a3c33ecd67e5d7b16c8e56c2b1b041abeff84a7`
- Exact tree: `560f97fe591118df18918293ed8d345d1d1e5102`
- Guarded native sync base: live `refs/heads/main` at `e66b470ea53102f0fa1f8d0786047d51cc919749`
- Hosted validation: https://github.com/openclaw/clownfish/actions/runs/28788702630 on GitHub-hosted `ubuntu-latest`
- Static and focused proof: `oxfmt`, `oxlint`, `commands-export-session.test.ts`, and `template.security.test.ts`
- Production proof invoked `buildExportSessionReply` using `cliSessionBindings["claude-cli"].sessionId = "backend-session-1"` and a user-only transcript. The command reply contained the backend-runtime warning, the decoded HTML payload contained the same warning, and `.export-warning` CSS was present.
- Fresh branch autoreview against the exact guarded base used Codex `gpt-5.5` with high reasoning and reported no accepted or actionable findings (`patch is correct`, confidence `0.87`).
- The repo-native strict merge verifier will re-fetch literal `refs/heads/main` immediately before merge and reject relevant mainline drift.
