### PR TITLE
fix(codex): map Code Mode exec hooks to shell policy

### DIFF
--- a/extensions/codex/src/app-server/native-hook-relay.test.ts
+++ b/extensions/codex/src/app-server/native-hook-relay.test.ts
@@ -76,35 +76,43 @@ describe("Codex native hook relay config", () => {
       "hooks.state": {
         "/<session-flags>/config.toml:pre_tool_use:0:0": {
           enabled: true,
-          trusted_hash: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
+          trusted_hash:
+            "sha256:a4a57646848c61302267df95a0bd76f16d824cb1c9c2dc662c8bc20afae1fa56",
         },
         "<session-flags>/config.toml:pre_tool_use:0:0": {
           enabled: true,
-          trusted_hash: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
+          trusted_hash:
+            "sha256:a4a57646848c61302267df95a0bd76f16d824cb1c9c2dc662c8bc20afae1fa56",
         },
         "/<session-flags>/config.toml:post_tool_use:0:0": {
           enabled: true,
-          trusted_hash: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
+          trusted_hash:
+            "sha256:d0417a1d3dbb2e0932108324166e810ae9d49d502c4f50f7375c08f7044ad509",
         },
         "<session-flags>/config.toml:post_tool_use:0:0": {
           enabled: true,
-          trusted_hash: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
+          trusted_hash:
+            "sha256:d0417a1d3dbb2e0932108324166e810ae9d49d502c4f50f7375c08f7044ad509",
         },
         "/<session-flags>/config.toml:permission_request:0:0": {
           enabled: true,
-          trusted_hash: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
+          trusted_hash:
+            "sha256:104026bb88dc111501950002dee431aeff6c472e2cf90cfa514add13edd47715",
         },
         "<session-flags>/config.toml:permission_request:0:0": {
           enabled: true,
-          trusted_hash: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
+          trusted_hash:
+            "sha256:104026bb88dc111501950002dee431aeff6c472e2cf90cfa514add13edd47715",
         },
         "/<session-flags>/config.toml:stop:0:0": {
           enabled: true,
-          trusted_hash: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
+          trusted_hash:
+            "sha256:5805c416342c5d13e3566473230e2d2adfacb1473d346cfe190442bd0f2e6675",
         },
         "<session-flags>/config.toml:stop:0:0": {
           enabled: true,
-          trusted_hash: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
+          trusted_hash:
+            "sha256:5805c416342c5d13e3566473230e2d2adfacb1473d346cfe190442bd0f2e6675",
         },
       },
     });

--- a/extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts
@@ -379,6 +379,7 @@ describe("runCodexAppServerAttempt native hook relay", () => {
       nativeHookRelay: {
         enabled: true,
         events: ["pre_tool_use"],
+        hookTimeoutSec: 5,
       },
     });
     await firstHarness.waitForMethod("turn/start");
@@ -463,9 +464,9 @@ describe("runCodexAppServerAttempt native hook relay", () => {
 
     await firstHarness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
     await firstRun;
-    expect((await readCodexAppServerBinding(sessionFile))?.nativeHookRelayGeneration).toBe(
-      firstGeneration,
-    );
+    const firstBinding = await readCodexAppServerBinding(sessionFile);
+    expect(firstBinding?.nativeHookRelayGeneration).toBe(firstGeneration);
+    expect(firstBinding?.nativeHookRelayConfigFingerprint).toMatch(/^[a-f0-9]{64}$/);
 
     const secondHarness = createResumeHarness();
     const secondParams = createParams(sessionFile, workspaceDir);
@@ -486,10 +487,15 @@ describe("runCodexAppServerAttempt native hook relay", () => {
 
     await secondHarness.completeTurn({ threadId: "thread-existing", turnId: "turn-1" });
     await secondRun;
+    const secondBinding = await readCodexAppServerBinding(sessionFile);
+    expect(secondBinding?.nativeHookRelayGeneration).toBe(firstGeneration);
+    expect(secondBinding?.nativeHookRelayConfigFingerprint).toBe(
+      firstBinding?.nativeHookRelayConfigFingerprint,
+    );
     testing.flushPendingCodexNativeHookRelayUnregistersForTests();
   });
 
-  it("accepts a stale first hook generation when resuming a pre-generation binding", async () => {
+  it("starts a fresh thread when a native-hook binding predates config fingerprints", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");
     await writeCodexAppServerBinding(sessionFile, {
@@ -498,8 +504,14 @@ describe("runCodexAppServerAttempt native hook relay", () => {
       model: "gpt-5.4-codex",
       modelProvider: "openai",
       dynamicToolsFingerprint: "[]",
+      nativeHookRelayGeneration: "generation-from-unfingerprinted-thread",
     });
-    const harness = createResumeHarness();
+    const harness = createStartedThreadHarness(async (method) => {
+      if (method === "thread/resume") {
+        throw new Error("stale native hook config should not resume");
+      }
+      return undefined;
+    });
 
     const run = runCodexAppServerAttempt(createParams(sessionFile, workspaceDir), {
       nativeHookRelay: {
@@ -509,45 +521,76 @@ describe("runCodexAppServerAttempt native hook relay", () => {
     });
     await harness.waitForMethod("turn/start");
 
-    const resumeRequest = harness.requests.find((request) => request.method === "thread/resume");
-    const relayId = extractRelayIdFromThreadRequest(resumeRequest?.params);
-    const currentGeneration = extractGenerationFromThreadRequest(resumeRequest?.params);
-    expect(currentGeneration).not.toBe("legacy-generation-from-running-thread");
+    expect(harness.requests.some((request) => request.method === "thread/resume")).toBe(false);
+    const startRequest = harness.requests.find((request) => request.method === "thread/start");
+    const relayId = extractRelayIdFromThreadRequest(startRequest?.params);
+    const currentGeneration = extractGenerationFromThreadRequest(startRequest?.params);
+    expect(currentGeneration).not.toBe("generation-from-unfingerprinted-thread");
     await expect(
       invokeNativeHookRelay({
         provider: "codex",
         relayId,
-        generation: "legacy-generation-from-running-thread",
+        generation: "generation-from-unfingerprinted-thread",
         event: "pre_tool_use",
         requireGeneration: true,
         rawPayload: {
           hook_event_name: "PreToolUse",
           tool_name: "Bash",
-          tool_use_id: "first-tool-after-restart",
-          tool_input: { command: "pwd" },
-        },
-      }),
-    ).resolves.toMatchObject({ exitCode: 0 });
-    await expect(
-      invokeNativeHookRelay({
-        provider: "codex",
-        relayId,
-        generation: "different-legacy-generation",
-        event: "pre_tool_use",
-        requireGeneration: true,
-        rawPayload: {
-          hook_event_name: "PreToolUse",
-          tool_name: "Bash",
-          tool_use_id: "unexpected-stale-generation",
+          tool_use_id: "stale-thread-tool",
           tool_input: { command: "pwd" },
         },
       }),
     ).rejects.toThrow("native hook relay bridge stale registration");
 
-    await harness.completeTurn({ threadId: "thread-existing", turnId: "turn-1" });
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
     await run;
-    expect((await readCodexAppServerBinding(sessionFile))?.nativeHookRelayGeneration).toBe(
-      currentGeneration,
+    const binding = await readCodexAppServerBinding(sessionFile);
+    expect(binding?.nativeHookRelayGeneration).toBe(currentGeneration);
+    expect(binding?.nativeHookRelayConfigFingerprint).toMatch(/^[a-f0-9]{64}$/);
+    testing.flushPendingCodexNativeHookRelayUnregistersForTests();
+  });
+
+  it("starts a fresh thread when native hook relay config changes", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const firstHarness = createStartedThreadHarness();
+
+    const firstRun = runCodexAppServerAttempt(createParams(sessionFile, workspaceDir), {
+      nativeHookRelay: {
+        enabled: true,
+        events: ["pre_tool_use"],
+      },
+    });
+    await firstHarness.waitForMethod("turn/start");
+    await firstHarness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await firstRun;
+    const firstBinding = await readCodexAppServerBinding(sessionFile);
+    expect(firstBinding?.nativeHookRelayConfigFingerprint).toMatch(/^[a-f0-9]{64}$/);
+
+    const secondHarness = createStartedThreadHarness(async (method) => {
+      if (method === "thread/resume") {
+        throw new Error("changed native hook config should not resume");
+      }
+      return undefined;
+    });
+    const secondRun = runCodexAppServerAttempt(createParams(sessionFile, workspaceDir), {
+      nativeHookRelay: {
+        enabled: true,
+        events: ["pre_tool_use"],
+        hookTimeoutSec: 9,
+      },
+    });
+    await secondHarness.waitForMethod("turn/start");
+
+    expect(secondHarness.requests.some((request) => request.method === "thread/resume")).toBe(
+      false,
+    );
+    await secondHarness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await secondRun;
+    const secondBinding = await readCodexAppServerBinding(sessionFile);
+    expect(secondBinding?.nativeHookRelayConfigFingerprint).toMatch(/^[a-f0-9]{64}$/);
+    expect(secondBinding?.nativeHookRelayConfigFingerprint).not.toBe(
+      firstBinding?.nativeHookRelayConfigFingerprint,
     );
     testing.flushPendingCodexNativeHookRelayUnregistersForTests();
   });

--- a/extensions/codex/src/app-server/session-binding.test.ts
+++ b/extensions/codex/src/app-server/session-binding.test.ts
@@ -63,6 +63,7 @@ describe("codex app-server session binding", () => {
       dynamicToolsFingerprint: "tools-v1",
       userMcpServersFingerprint: "user-mcp-v1",
       nativeHookRelayGeneration: "generation-v1",
+      nativeHookRelayConfigFingerprint: "hook-config-v1",
     });
 
     const binding = await readCodexAppServerBinding(sessionFile);
@@ -76,6 +77,7 @@ describe("codex app-server session binding", () => {
     expect(binding?.dynamicToolsFingerprint).toBe("tools-v1");
     expect(binding?.userMcpServersFingerprint).toBe("user-mcp-v1");
     expect(binding?.nativeHookRelayGeneration).toBe("generation-v1");
+    expect(binding?.nativeHookRelayConfigFingerprint).toBe("hook-config-v1");
     const bindingStat = await fs.stat(resolveCodexAppServerBindingPath(sessionFile));
     expect(bindingStat.isFile()).toBe(true);
   });

--- a/extensions/codex/src/app-server/session-binding.ts
+++ b/extensions/codex/src/app-server/session-binding.ts
@@ -50,6 +50,7 @@ export type CodexAppServerThreadBinding = {
   userMcpServersFingerprint?: string;
   mcpServersFingerprint?: string;
   nativeHookRelayGeneration?: string;
+  nativeHookRelayConfigFingerprint?: string;
   pluginAppsFingerprint?: string;
   pluginAppsInputFingerprint?: string;
   pluginAppPolicyContext?: PluginAppPolicyContext;
@@ -137,6 +138,11 @@ export async function readCodexAppServerBinding(
         parsed.nativeHookRelayGeneration.trim()
           ? parsed.nativeHookRelayGeneration
           : undefined,
+      nativeHookRelayConfigFingerprint:
+        typeof parsed.nativeHookRelayConfigFingerprint === "string" &&
+        parsed.nativeHookRelayConfigFingerprint.trim()
+          ? parsed.nativeHookRelayConfigFingerprint
+          : undefined,
       pluginAppsFingerprint:
         typeof parsed.pluginAppsFingerprint === "string" ? parsed.pluginAppsFingerprint : undefined,
       pluginAppsInputFingerprint:
@@ -190,6 +196,7 @@ export async function writeCodexAppServerBinding(
     userMcpServersFingerprint: binding.userMcpServersFingerprint,
     mcpServersFingerprint: binding.mcpServersFingerprint,
     nativeHookRelayGeneration: binding.nativeHookRelayGeneration,
+    nativeHookRelayConfigFingerprint: binding.nativeHookRelayConfigFingerprint,
     pluginAppsFingerprint: binding.pluginAppsFingerprint,
     pluginAppsInputFingerprint: binding.pluginAppsInputFingerprint,
     pluginAppPolicyContext: binding.pluginAppPolicyContext,

--- a/extensions/codex/src/app-server/thread-lifecycle.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.ts
@@ -1,4 +1,5 @@
 // Codex plugin module implements thread lifecycle behavior.
+import { createHash } from "node:crypto";
 import {
   buildSkillWorkshopPromptSection,
   embeddedAgentLog,
@@ -516,126 +517,147 @@ export async function startOrResumeThread(params: {
         await clearCodexAppServerBinding(params.params.sessionFile);
       }
     } else {
-      try {
-        const authProfileId = params.params.authProfileId ?? binding.authProfileId;
-        const finalConfigPatch = params.buildFinalConfigPatch?.({
-          action: "resume",
-          binding,
-        }) ?? {
-          configPatch: params.finalConfigPatch,
-          nativeHookRelayGeneration: params.nativeHookRelayGeneration,
-        };
-        const resumeConfig = mergeCodexThreadConfigs(
-          params.config,
-          userMcpServersConfigPatch,
-          finalConfigPatch.configPatch,
-        );
-        const resumeParams = lifecycleTiming.measureSync("thread-resume-params", () =>
-          buildThreadResumeParams(params.params, {
+      const authProfileId = params.params.authProfileId ?? binding.authProfileId;
+      const finalConfigPatch = params.buildFinalConfigPatch?.({
+        action: "resume",
+        binding,
+      }) ?? {
+        configPatch: params.finalConfigPatch,
+        nativeHookRelayGeneration: params.nativeHookRelayGeneration,
+      };
+      const nativeHookRelayConfigFingerprint = fingerprintNativeHookRelayConfigPatch(
+        finalConfigPatch.configPatch,
+      );
+      if (
+        nativeHookRelayConfigFingerprint &&
+        binding.nativeHookRelayConfigFingerprint !== nativeHookRelayConfigFingerprint
+      ) {
+        embeddedAgentLog.debug(
+          "codex app-server native hook config changed; starting a new thread",
+          {
             threadId: binding.threadId,
-            authProfileId,
-            appServer: params.appServer,
-            dynamicTools: params.dynamicTools,
-            developerInstructions: params.developerInstructions,
-            config: resumeConfig,
-            nativeCodeModeEnabled: params.nativeCodeModeEnabled,
-            nativeCodeModeOnlyEnabled: params.nativeCodeModeOnlyEnabled,
-          }),
+          },
         );
-        const response = assertCodexThreadResumeResponse(
-          await lifecycleTiming.measure("thread-resume-request", () =>
-            params.client.request("thread/resume", resumeParams, { signal: params.signal }),
-          ),
-        );
-        throwIfAborted();
-        const boundAuthProfileId = authProfileId;
-        const fallbackModelProvider = resolveCodexAppServerModelProvider({
-          provider: params.params.provider,
-          authProfileId: boundAuthProfileId,
-          authProfileStore: params.params.authProfileStore,
-          agentDir: params.params.agentDir,
-          config: params.params.config,
-        });
-        const nextMcpServersFingerprint =
-          params.mcpServersFingerprintEvaluated === true
-            ? params.mcpServersFingerprint
-            : binding.mcpServersFingerprint;
-        await lifecycleTiming.measure("thread-resume-write-binding", () =>
-          writeCodexAppServerBinding(
-            params.params.sessionFile,
-            {
+        await clearCodexAppServerBinding(params.params.sessionFile);
+        binding = undefined;
+      } else {
+        try {
+          const resumeConfig = mergeCodexThreadConfigs(
+            params.config,
+            userMcpServersConfigPatch,
+            finalConfigPatch.configPatch,
+          );
+          const resumeParams = lifecycleTiming.measureSync("thread-resume-params", () =>
+            buildThreadResumeParams(params.params, {
+              threadId: binding.threadId,
+              authProfileId,
+              appServer: params.appServer,
+              dynamicTools: params.dynamicTools,
+              developerInstructions: params.developerInstructions,
+              config: resumeConfig,
+              nativeCodeModeEnabled: params.nativeCodeModeEnabled,
+              nativeCodeModeOnlyEnabled: params.nativeCodeModeOnlyEnabled,
+            }),
+          );
+          const response = assertCodexThreadResumeResponse(
+            await lifecycleTiming.measure("thread-resume-request", () =>
+              params.client.request("thread/resume", resumeParams, { signal: params.signal }),
+            ),
+          );
+          throwIfAborted();
+          const boundAuthProfileId = authProfileId;
+          const fallbackModelProvider = resolveCodexAppServerModelProvider({
+            provider: params.params.provider,
+            authProfileId: boundAuthProfileId,
+            authProfileStore: params.params.authProfileStore,
+            agentDir: params.params.agentDir,
+            config: params.params.config,
+          });
+          const nextMcpServersFingerprint =
+            params.mcpServersFingerprintEvaluated === true
+              ? params.mcpServersFingerprint
+              : binding.mcpServersFingerprint;
+          await lifecycleTiming.measure("thread-resume-write-binding", () =>
+            writeCodexAppServerBinding(
+              params.params.sessionFile,
+              {
+                threadId: response.thread.id,
+                cwd: params.cwd,
+                authProfileId: boundAuthProfileId,
+                model: params.params.modelId,
+                modelProvider: response.modelProvider ?? fallbackModelProvider,
+                dynamicToolsFingerprint,
+                dynamicToolsContainDeferred,
+                userMcpServersFingerprint,
+                mcpServersFingerprint: nextMcpServersFingerprint,
+                nativeHookRelayGeneration:
+                  finalConfigPatch.nativeHookRelayGeneration ?? binding.nativeHookRelayGeneration,
+                nativeHookRelayConfigFingerprint:
+                  nativeHookRelayConfigFingerprint ?? binding.nativeHookRelayConfigFingerprint,
+                pluginAppsFingerprint: binding.pluginAppsFingerprint,
+                pluginAppsInputFingerprint: binding.pluginAppsInputFingerprint,
+                pluginAppPolicyContext: binding.pluginAppPolicyContext,
+                contextEngine: contextEngineBinding,
+                environmentSelectionFingerprint,
+                createdAt: binding.createdAt,
+              },
+              {
+                authProfileStore: params.params.authProfileStore,
+                agentDir: params.params.agentDir,
+                config: params.params.config,
+              },
+            ),
+          );
+          if (contextEngineBinding) {
+            embeddedAgentLog.info("codex app-server wrote context-engine thread binding", {
+              sessionId: params.params.sessionId,
+              sessionKey: params.params.sessionKey,
               threadId: response.thread.id,
-              cwd: params.cwd,
-              authProfileId: boundAuthProfileId,
-              model: params.params.modelId,
-              modelProvider: response.modelProvider ?? fallbackModelProvider,
-              dynamicToolsFingerprint,
-              dynamicToolsContainDeferred,
-              userMcpServersFingerprint,
-              mcpServersFingerprint: nextMcpServersFingerprint,
-              nativeHookRelayGeneration:
-                finalConfigPatch.nativeHookRelayGeneration ?? binding.nativeHookRelayGeneration,
-              pluginAppsFingerprint: binding.pluginAppsFingerprint,
-              pluginAppsInputFingerprint: binding.pluginAppsInputFingerprint,
-              pluginAppPolicyContext: binding.pluginAppPolicyContext,
-              contextEngine: contextEngineBinding,
-              environmentSelectionFingerprint,
-              createdAt: binding.createdAt,
-            },
-            {
-              authProfileStore: params.params.authProfileStore,
-              agentDir: params.params.agentDir,
-              config: params.params.config,
-            },
-          ),
-        );
-        if (contextEngineBinding) {
-          embeddedAgentLog.info("codex app-server wrote context-engine thread binding", {
+              engineId: contextEngineBinding.engineId,
+              epoch: contextEngineBinding.projection?.epoch,
+              fingerprint: contextEngineBinding.projection?.fingerprint,
+              action: "resumed",
+            });
+          }
+          lifecycleTiming.mark("thread-ready");
+          lifecycleTiming.logSummary({
+            runId: params.params.runId,
             sessionId: params.params.sessionId,
             sessionKey: params.params.sessionKey,
             threadId: response.thread.id,
-            engineId: contextEngineBinding.engineId,
-            epoch: contextEngineBinding.projection?.epoch,
-            fingerprint: contextEngineBinding.projection?.fingerprint,
             action: "resumed",
           });
+          return {
+            ...binding,
+            threadId: response.thread.id,
+            cwd: params.cwd,
+            authProfileId: boundAuthProfileId,
+            model: params.params.modelId,
+            modelProvider: response.modelProvider ?? fallbackModelProvider,
+            dynamicToolsFingerprint,
+            dynamicToolsContainDeferred,
+            userMcpServersFingerprint,
+            mcpServersFingerprint: nextMcpServersFingerprint,
+            nativeHookRelayGeneration:
+              finalConfigPatch.nativeHookRelayGeneration ?? binding.nativeHookRelayGeneration,
+            nativeHookRelayConfigFingerprint:
+              nativeHookRelayConfigFingerprint ?? binding.nativeHookRelayConfigFingerprint,
+            pluginAppsFingerprint: binding.pluginAppsFingerprint,
+            pluginAppsInputFingerprint: binding.pluginAppsInputFingerprint,
+            pluginAppPolicyContext: binding.pluginAppPolicyContext,
+            contextEngine: contextEngineBinding,
+            environmentSelectionFingerprint,
+            lifecycle: { action: "resumed" },
+          };
+        } catch (error) {
+          if (isCodexAppServerConnectionClosedError(error)) {
+            throw error;
+          }
+          embeddedAgentLog.warn("codex app-server thread resume failed; starting a new thread", {
+            error,
+          });
+          await clearCodexAppServerBinding(params.params.sessionFile);
         }
-        lifecycleTiming.mark("thread-ready");
-        lifecycleTiming.logSummary({
-          runId: params.params.runId,
-          sessionId: params.params.sessionId,
-          sessionKey: params.params.sessionKey,
-          threadId: response.thread.id,
-          action: "resumed",
-        });
-        return {
-          ...binding,
-          threadId: response.thread.id,
-          cwd: params.cwd,
-          authProfileId: boundAuthProfileId,
-          model: params.params.modelId,
-          modelProvider: response.modelProvider ?? fallbackModelProvider,
-          dynamicToolsFingerprint,
-          dynamicToolsContainDeferred,
-          userMcpServersFingerprint,
-          mcpServersFingerprint: nextMcpServersFingerprint,
-          nativeHookRelayGeneration:
-            finalConfigPatch.nativeHookRelayGeneration ?? binding.nativeHookRelayGeneration,
-          pluginAppsFingerprint: binding.pluginAppsFingerprint,
-          pluginAppsInputFingerprint: binding.pluginAppsInputFingerprint,
-          pluginAppPolicyContext: binding.pluginAppPolicyContext,
-          contextEngine: contextEngineBinding,
-          environmentSelectionFingerprint,
-          lifecycle: { action: "resumed" },
-        };
-      } catch (error) {
-        if (isCodexAppServerConnectionClosedError(error)) {
-          throw error;
-        }
-        embeddedAgentLog.warn("codex app-server thread resume failed; starting a new thread", {
-          error,
-        });
-        await clearCodexAppServerBinding(params.params.sessionFile);
       }
     }
   }
@@ -650,6 +672,9 @@ export async function startOrResumeThread(params: {
     configPatch: params.finalConfigPatch,
     nativeHookRelayGeneration: params.nativeHookRelayGeneration,
   };
+  const nativeHookRelayConfigFingerprint = fingerprintNativeHookRelayConfigPatch(
+    finalConfigPatch.configPatch,
+  );
   const config = lifecycleTiming.measureSync("merge-thread-config", () =>
     mergeCodexThreadConfigs(
       params.config,
@@ -707,6 +732,7 @@ export async function startOrResumeThread(params: {
           userMcpServersFingerprint,
           mcpServersFingerprint: nextMcpServersFingerprint,
           nativeHookRelayGeneration: finalConfigPatch.nativeHookRelayGeneration,
+          nativeHookRelayConfigFingerprint,
           pluginAppsFingerprint: pluginThreadConfig?.fingerprint,
           pluginAppsInputFingerprint: pluginThreadConfig?.inputFingerprint,
           pluginAppPolicyContext: pluginThreadConfig?.policyContext,
@@ -754,6 +780,7 @@ export async function startOrResumeThread(params: {
     userMcpServersFingerprint,
     mcpServersFingerprint: nextMcpServersFingerprint,
     nativeHookRelayGeneration: finalConfigPatch.nativeHookRelayGeneration,
+    nativeHookRelayConfigFingerprint,
     pluginAppsFingerprint: pluginThreadConfig?.fingerprint,
     pluginAppsInputFingerprint: pluginThreadConfig?.inputFingerprint,
     pluginAppPolicyContext: pluginThreadConfig?.policyContext,
@@ -1198,6 +1225,16 @@ function fingerprintEnvironmentSelection(
   environments: CodexTurnEnvironmentParams[] | undefined,
 ): string | undefined {
   return environments ? JSON.stringify(environments.map(stabilizeJsonValue)) : undefined;
+}
+
+function fingerprintNativeHookRelayConfigPatch(
+  configPatch: JsonObject | undefined,
+): string | undefined {
+  return configPatch
+    ? createHash("sha256")
+        .update(JSON.stringify(stabilizeJsonValue(configPatch)))
+        .digest("hex")
+    : undefined;
 }
 
 function fingerprintDynamicToolSpec(tool: JsonValue): JsonValue {

--- a/src/agents/harness/native-hook-relay.test.ts
+++ b/src/agents/harness/native-hook-relay.test.ts
@@ -1722,6 +1722,54 @@ describe("native hook relay registry", () => {
     });
   });
 
+  it("maps Codex Code Mode exec payloads to OpenClaw shell policy", async () => {
+    const beforeToolCall = vi.fn(async () => ({
+      block: true,
+      blockReason: "code mode command blocked",
+    }));
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([{ hookName: "before_tool_call", handler: beforeToolCall }]),
+    );
+    const relay = registerNativeHookRelay({
+      provider: "codex",
+      agentId: "agent-1",
+      sessionId: "session-1",
+      sessionKey: "agent:main:session-1",
+      runId: "run-1",
+      channelId: "telegram",
+    });
+
+    const response = await invokeNativeHookRelay({
+      provider: "codex",
+      relayId: relay.relayId,
+      event: "pre_tool_use",
+      rawPayload: {
+        hook_event_name: "PreToolUse",
+        cwd: "/repo",
+        tool_name: "code_mode_exec",
+        tool_use_id: "native-code-mode-exec-1",
+        tool_input: { command: "cat /tmp/private_key" },
+      },
+    });
+
+    expect(JSON.parse(response.stdout)).toEqual({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: "code mode command blocked",
+      },
+    });
+    const event = getMockCallArg(beforeToolCall, 0, 0, "before tool call event");
+    expectRecordFields(event, {
+      toolName: "exec",
+      params: {
+        command: "cat /tmp/private_key",
+      },
+      runId: "run-1",
+      toolCallId: "native-code-mode-exec-1",
+    });
+  });
+
   it("prefers Codex exec_command cmd over a stale command field", async () => {
     const beforeToolCall = vi.fn(async (event: unknown) => {
       const command = (event as { params?: { command?: string } }).params?.command;

--- a/src/agents/harness/native-hook-relay.ts
+++ b/src/agents/harness/native-hook-relay.ts
@@ -338,6 +338,7 @@ let nativeHookRelayDeferredToolApprovalRequester: NativeHookRelayDeferredToolApp
   requestDeferredPluginToolApproval;
 
 const NATIVE_HOOK_TOOL_NAME_ALIASES: Record<string, string> = {
+  code_mode_exec: "exec",
   exec_command: "exec",
 };
 


### PR DESCRIPTION
## Summary

This is the narrower positive-delivery fix for the Codex Code Mode PreToolUse bypass.

- keeps the native hook relay path intact instead of disabling Codex-native surfaces
- maps Codex's patched `code_mode_exec` PreToolUse payload into OpenClaw's existing `exec` shell-policy path
- adds regression coverage for Code Mode exec relay payloads being blocked by `before_tool_call`
- tightens the Codex native relay config test to assert exact trusted-hash values for the session-flags hooks

## Root Cause

The local patched Codex binary now emits PreToolUse for Code Mode exec. A controlled app-server probe against the installed patched binary confirmed Codex emits `PreToolUse` with `tool_name: "code_mode_exec"` for the Code Mode custom tool call and also emits `PreToolUse` for the nested native `Bash` call.

OpenClaw's native hook relay normalized `exec_command` and `Bash`-style native shell payloads into `exec`, but did not normalize `code_mode_exec`. That meant the Code Mode wrapper payload could reach OpenClaw policy under a tool name that the shell/firewall policy did not treat as shell execution.

## Proof

Local controlled probes:

- `node /tmp/codex-hooks-list-probe.mjs /tmp/openclaw-codex-hook-positive-fix`
  - Codex listed the injected session-flags PreToolUse hook as `trustStatus: "trusted"` when the lower-snake `pre_tool_use` trusted hash is used.
- `node /tmp/codex-turn-hook-probe.mjs`
  - ordinary native shell PreToolUse delivery works; marker captured `tool_name: "Bash"` and hook notifications.
- `node /tmp/codex-appserver-code-mode-hook-probe.mjs`
  - Code Mode PreToolUse delivery works with the installed patched binary; marker captured `tool_name: "code_mode_exec"` and nested `tool_name: "Bash"`.

Remote Crabbox validation on exact local head `15fdd4a2f32f85480a98493ec6b456c6e50b8d14`:

- GCP Spot lease: `cbx_844e33635278` (`us-east1-b`, `e2-standard-8`)
- focused changed-path tests:
  - `src/agents/harness/native-hook-relay.test.ts`: 76 passed
  - `extensions/codex/src/app-server/thread-lifecycle.binding.test.ts`: 24 passed
  - `extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts`: 19 passed
  - `extensions/codex/src/app-server/native-hook-relay.test.ts`: 8 passed
  - `extensions/codex/src/app-server/session-binding.test.ts`: 11 passed
- `pnpm build`: passed
- `pnpm tsgo:core:test`: passed
- Crabbox exit code: 0
- cleanup check: no remaining `crabbox-*` GCP instances

Proof log is retained locally at:

`/home/captain/codex-workspace/proof/codex-native-hook-positive-delivery-2026-06-06/remote-15fdd4a2-validation-rerun-20260606T061547Z.log`

## Notes

This PR assumes the local Codex-side patch for openai/codex#23411 is present in the runtime, as expected for our OpenClaw deployment. This PR does not replace draft #90805's fail-closed guard; that remains a separate defense-in-depth option if Codex regresses and stops invoking hooks again.