### PR TITLE
fix #90850: iMessage send can wedge on long-lived RPC; add one-shot send-rich fallback and receive-side troubleshooting

### DIFF
--- a/docs/channels/imessage.md
+++ b/docs/channels/imessage.md
@@ -803,6 +803,31 @@ openclaw channels status --probe --channel imessage
 
   </Accordion>
 
+  <Accordion title="Messages send but inbound iMessages do not arrive">
+    First prove whether the message reached the local Mac. If `chat.db` does not change, OpenClaw cannot receive the message even when `imsg status --json` reports a healthy bridge.
+
+```bash
+imsg chats --limit 10 --json
+imsg watch --chat-id <chat-id> --json
+sqlite3 ~/Library/Messages/chat.db \
+  "select datetime(max(date)/1000000000 + 978307200, 'unixepoch', 'localtime'), max(ROWID) from message;"
+```
+
+    If phone-sent messages create no new rows, repair the macOS Messages and Apple Push layer before changing OpenClaw config. A one-shot service refresh is often enough:
+
+```bash
+launchctl kickstart -k system/com.apple.apsd
+launchctl kickstart -k gui/$(id -u)/com.apple.CommCenter
+launchctl kickstart -k gui/$(id -u)/com.apple.identityservicesd
+launchctl kickstart -k gui/$(id -u)/com.apple.imagent
+imsg launch
+openclaw gateway restart
+```
+
+    Send a fresh iMessage from the phone and confirm a new `chat.db` row or `imsg watch` event before debugging OpenClaw sessions. Do not run this as a periodic bridge-relaunch loop; repeated `imsg launch` plus gateway restarts during active work can interrupt deliveries and strand in-flight channel runs.
+
+  </Accordion>
+
   <Accordion title="DMs are ignored">
     Check:
 

--- a/extensions/imessage/src/monitor/deliver.test.ts
+++ b/extensions/imessage/src/monitor/deliver.test.ts
@@ -31,7 +31,6 @@ let createIMessageEchoCachingSend: typeof import("./deliver.js").createIMessageE
 describe("deliverReplies", () => {
   const IMESSAGE_TEST_CFG = { channels: { imessage: { accounts: { default: {} } } } };
   const runtime = { log: vi.fn(), error: vi.fn() } as unknown as RuntimeEnv;
-  const client = {} as Awaited<ReturnType<typeof import("../client.js").createIMessageRpcClient>>;
 
   beforeAll(async () => {
     ({ createIMessageEchoCachingSend, deliverReplies } = await import("./deliver.js"));
@@ -48,14 +47,13 @@ describe("deliverReplies", () => {
     vi.resetModules();
   });
 
-  it("propagates payload replyToId through all text chunks", async () => {
+  it("sends monitor text chunks without reusing the watch rpc client", async () => {
     chunkTextWithModeMock.mockImplementation((text: string) => text.split("|"));
 
     await deliverReplies({
       cfg: IMESSAGE_TEST_CFG,
       replies: [{ text: "first|second", replyToId: "reply-1" }],
       target: "chat_id:10",
-      client,
       accountId: "default",
       runtime,
       maxBytes: 4096,
@@ -70,7 +68,6 @@ describe("deliverReplies", () => {
         {
           config: IMESSAGE_TEST_CFG,
           maxBytes: 4096,
-          client,
           accountId: "default",
           replyToId: "reply-1",
         },
@@ -81,7 +78,6 @@ describe("deliverReplies", () => {
         {
           config: IMESSAGE_TEST_CFG,
           maxBytes: 4096,
-          client,
           accountId: "default",
           replyToId: "reply-1",
         },
@@ -100,7 +96,6 @@ describe("deliverReplies", () => {
         },
       ],
       target: "chat_id:20",
-      client,
       accountId: "acct-2",
       runtime,
       maxBytes: 8192,
@@ -116,7 +111,6 @@ describe("deliverReplies", () => {
           config: IMESSAGE_TEST_CFG,
           mediaUrl: "https://example.com/a.jpg",
           maxBytes: 8192,
-          client,
           accountId: "acct-2",
           replyToId: "reply-2",
         },
@@ -128,7 +122,6 @@ describe("deliverReplies", () => {
           config: IMESSAGE_TEST_CFG,
           mediaUrl: "https://example.com/b.jpg",
           maxBytes: 8192,
-          client,
           accountId: "acct-2",
           replyToId: "reply-2",
         },
@@ -139,7 +132,6 @@ describe("deliverReplies", () => {
   it("records durable outbound sends in the sent-message cache", async () => {
     const remember = vi.fn();
     const send = createIMessageEchoCachingSend({
-      client,
       accountId: "acct-5",
       sentMessageCache: { remember },
     });
@@ -160,7 +152,6 @@ describe("deliverReplies", () => {
         {
           config: IMESSAGE_TEST_CFG,
           accountId: "acct-ignored",
-          client,
         },
       ],
     ]);
@@ -173,7 +164,6 @@ describe("deliverReplies", () => {
   it("sanitizes durable outbound text before sending", async () => {
     const remember = vi.fn();
     const send = createIMessageEchoCachingSend({
-      client,
       accountId: "acct-6",
       sentMessageCache: { remember },
     });
@@ -194,7 +184,6 @@ describe("deliverReplies", () => {
         {
           config: IMESSAGE_TEST_CFG,
           accountId: "acct-ignored",
-          client,
         },
       ],
     ]);
@@ -218,7 +207,6 @@ describe("deliverReplies", () => {
       cfg: IMESSAGE_TEST_CFG,
       replies: [{ text: "first|second" }],
       target: "chat_id:30",
-      client,
       accountId: "acct-3",
       runtime,
       maxBytes: 2048,
@@ -250,7 +238,6 @@ describe("deliverReplies", () => {
       cfg: IMESSAGE_TEST_CFG,
       replies: [{ mediaUrls: ["https://example.com/a.jpg"] }],
       target: "chat_id:40",
-      client,
       accountId: "acct-4",
       runtime,
       maxBytes: 2048,

--- a/extensions/imessage/src/monitor/deliver.ts
+++ b/extensions/imessage/src/monitor/deliver.ts
@@ -6,7 +6,6 @@ import {
 } from "openclaw/plugin-sdk/reply-payload";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
-import type { IMessageRpcClient } from "../client.js";
 import { sendMessageIMessage } from "../send.js";
 import {
   chunkTextWithMode,
@@ -21,15 +20,13 @@ export async function deliverReplies(params: {
   cfg: OpenClawConfig;
   replies: ReplyPayload[];
   target: string;
-  client: IMessageRpcClient;
   accountId?: string;
   runtime: RuntimeEnv;
   maxBytes: number;
   textLimit: number;
   sentMessageCache?: Pick<SentMessageCache, "remember">;
 }) {
-  const { replies, target, client, runtime, maxBytes, textLimit, accountId, sentMessageCache } =
-    params;
+  const { replies, target, runtime, maxBytes, textLimit, accountId, sentMessageCache } = params;
   const scope = `${accountId ?? ""}:${target}`;
   const { cfg } = params;
   const tableMode = resolveMarkdownTableMode({
@@ -51,7 +48,6 @@ export async function deliverReplies(params: {
         const sent = await sendMessageIMessage(target, chunk, {
           config: params.cfg,
           maxBytes,
-          client,
           accountId,
           replyToId: payload.replyToId,
         });
@@ -69,7 +65,6 @@ export async function deliverReplies(params: {
           config: params.cfg,
           mediaUrl,
           maxBytes,
-          client,
           accountId,
           replyToId: payload.replyToId,
         });
@@ -86,16 +81,12 @@ export async function deliverReplies(params: {
 }
 
 export function createIMessageEchoCachingSend(params: {
-  client: IMessageRpcClient;
   accountId?: string;
   sentMessageCache?: Pick<SentMessageCache, "remember">;
 }): typeof sendMessageIMessage {
   return async (target, text, opts) => {
     const sanitizedText = sanitizeOutboundText(text);
-    const sent = await sendMessageIMessage(target, sanitizedText, {
-      ...opts,
-      client: params.client,
-    });
+    const sent = await sendMessageIMessage(target, sanitizedText, opts);
     const scope = `${params.accountId ?? opts.accountId ?? ""}:${target}`;
     params.sentMessageCache?.remember(scope, {
       text: sent.echoText ?? (sent.sentText || undefined),

--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -874,7 +874,6 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
           to: target,
           deps: {
             imessage: createIMessageEchoCachingSend({
-              client: getActiveClient(),
               accountId: accountInfo.accountId,
               sentMessageCache,
             }),
@@ -890,7 +889,6 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
           cfg,
           replies: [payload],
           target,
-          client: getActiveClient(),
           accountId: accountInfo.accountId,
           runtime,
           maxBytes: mediaMaxBytes,

--- a/extensions/imessage/src/send.test.ts
+++ b/extensions/imessage/src/send.test.ts
@@ -796,10 +796,112 @@ describe("sendMessageIMessage receipts", () => {
     });
   });
 
-  it("throws the rpc timeout without resending for generic text", async () => {
+  it("recovers generic text sends already written by a timed-out rpc send", async () => {
     const client = createRejectingClient(new Error("imsg rpc timeout (send)"));
     const runCliJson = vi.fn();
-    const resolveSentMessageGuidImpl = vi.fn(async () => "p:0/stale-guid");
+    const resolveSentMessageGuidImpl = vi.fn(async () => "p:0/recovered-guid");
+
+    const result = await sendMessageIMessage("chat_id:42", "hello", {
+      config: IMESSAGE_TEST_CFG,
+      client,
+      runCliJson,
+      dbPath: "/Users/me/Library/Messages/chat.db",
+      resolveSentMessageGuidImpl,
+    });
+
+    expect(result.messageId).toBe("p:0/recovered-guid");
+    expect(result.guid).toBe("p:0/recovered-guid");
+    expect(runCliJson).not.toHaveBeenCalled();
+    expect(resolveSentMessageGuidImpl).toHaveBeenCalledWith({
+      dbPath: "/Users/me/Library/Messages/chat.db",
+      target: expect.objectContaining({ kind: "chat_id", chatId: 42 }),
+      text: "hello",
+      sentAfterMs: expect.any(Number),
+    });
+  });
+
+  it("falls back to one-shot send-rich when rpc text send times out before writing chat.db", async () => {
+    const client = createRejectingClient(new Error("imsg rpc timeout (send)"));
+    const runCliJson = vi
+      .fn()
+      .mockResolvedValueOnce({ guid: "iMessage;-;+15551234567" })
+      .mockResolvedValueOnce({ messageId: "p:0/rich-guid" });
+    const resolveSentMessageGuidImpl = vi.fn(async () => null);
+    const nowSpy = vi.spyOn(Date, "now");
+    nowSpy
+      .mockReturnValueOnce(1_000)
+      .mockReturnValueOnce(1_000)
+      .mockReturnValueOnce(1_000)
+      .mockReturnValueOnce(6_001);
+
+    const result = await sendMessageIMessage("chat_id:42", "**hello**", {
+      config: IMESSAGE_TEST_CFG,
+      createClient: async () => client,
+      runCliJson,
+      dbPath: "/Users/me/Library/Messages/chat.db",
+      replyToId: "p:0/reply-guid",
+      resolveSentMessageGuidImpl,
+    });
+
+    expect(result.messageId).toBe("p:0/rich-guid");
+    expect(result.guid).toBe("p:0/rich-guid");
+    expect(result.sentText).toBe("hello");
+    expect(result.echoText).toBe("hello");
+    expect(result.receipt.replyToId).toBe("p:0/reply-guid");
+    expect(getClientMocks(client).stop).toHaveBeenCalledTimes(1);
+    expect(runCliJson.mock.calls).toEqual([
+      [["group", "--chat-id", "42"]],
+      [
+        [
+          "send-rich",
+          "--chat",
+          "iMessage;-;+15551234567",
+          "--text",
+          "hello",
+          "--reply-to",
+          "p:0/reply-guid",
+          "--format",
+          JSON.stringify([{ start: 0, length: 5, styles: ["bold"] }]),
+        ],
+      ],
+    ]);
+  });
+
+  it("throws the rpc timeout when one-shot send-rich fallback is unavailable", async () => {
+    const client = createRejectingClient(new Error("imsg rpc timeout (send)"));
+    const runCliJson = vi.fn().mockRejectedValueOnce(new Error("unknown command group"));
+    const resolveSentMessageGuidImpl = vi.fn(async () => null);
+    const nowSpy = vi.spyOn(Date, "now");
+    nowSpy
+      .mockReturnValueOnce(1_000)
+      .mockReturnValueOnce(1_000)
+      .mockReturnValueOnce(1_000)
+      .mockReturnValueOnce(6_001);
+
+    await expect(
+      sendMessageIMessage("chat_id:42", "hello", {
+        config: IMESSAGE_TEST_CFG,
+        createClient: async () => client,
+        runCliJson,
+        dbPath: "/Users/me/Library/Messages/chat.db",
+        resolveSentMessageGuidImpl,
+      }),
+    ).rejects.toThrow("imsg rpc timeout (send)");
+
+    expect(getClientMocks(client).stop).toHaveBeenCalledTimes(1);
+    expect(runCliJson.mock.calls).toEqual([[["group", "--chat-id", "42"]]]);
+  });
+
+  it("does not fallback to send-rich for caller-owned rpc clients", async () => {
+    const client = createRejectingClient(new Error("imsg rpc timeout (send)"));
+    const runCliJson = vi.fn();
+    const resolveSentMessageGuidImpl = vi.fn(async () => null);
+    const nowSpy = vi.spyOn(Date, "now");
+    nowSpy
+      .mockReturnValueOnce(1_000)
+      .mockReturnValueOnce(1_000)
+      .mockReturnValueOnce(1_000)
+      .mockReturnValueOnce(6_001);
 
     await expect(
       sendMessageIMessage("chat_id:42", "hello", {
@@ -812,7 +914,23 @@ describe("sendMessageIMessage receipts", () => {
     ).rejects.toThrow("imsg rpc timeout (send)");
 
     expect(runCliJson).not.toHaveBeenCalled();
-    expect(resolveSentMessageGuidImpl).not.toHaveBeenCalled();
+    expect(getClientMocks(client).stop).not.toHaveBeenCalled();
+  });
+
+  it("throws the rpc timeout without resending when sent-row checks are unavailable", async () => {
+    const client = createRejectingClient(new Error("imsg rpc timeout (send)"));
+    const runCliJson = vi.fn();
+
+    await expect(
+      sendMessageIMessage("chat_id:42", "hello", {
+        config: IMESSAGE_TEST_CFG,
+        client,
+        runCliJson,
+        dbPath: "/Users/me/Library/Messages/chat.db",
+      }),
+    ).rejects.toThrow("imsg rpc timeout (send)");
+
+    expect(runCliJson).not.toHaveBeenCalled();
   });
 
   it("throws the rpc timeout without resending when approval GUID recovery misses", async () => {

--- a/extensions/imessage/src/send.ts
+++ b/extensions/imessage/src/send.ts
@@ -25,7 +25,7 @@ import {
 } from "./approval-reactions.js";
 import { appendIMessageCliStderrTail, appendIMessageCliStdout } from "./cli-output.js";
 import { createIMessageRpcClient, type IMessageRpcClient } from "./client.js";
-import { extractMarkdownFormatRuns } from "./markdown-format.js";
+import { extractMarkdownFormatRuns, type IMessageFormatRange } from "./markdown-format.js";
 import { rememberIMessageReplyCache } from "./monitor-reply-cache.js";
 import { rememberPersistedIMessageEcho } from "./monitor/persisted-echo-cache.js";
 import {
@@ -451,16 +451,25 @@ async function resolveFallbackSentMessageGuid(params: {
   return null;
 }
 
+function isIMessageApprovalPromptMessage(message: string): boolean {
+  return Boolean(message.trim()) && Boolean(extractIMessageApprovalPromptBinding(message));
+}
+
 function shouldRecoverApprovalPromptGuid(params: {
   message: string;
   filePath?: string;
   replyToId?: string | null;
 }): boolean {
+  return !params.filePath && !params.replyToId && isIMessageApprovalPromptMessage(params.message);
+}
+
+function canCheckSentMessageAfterRpcTimeout(params: {
+  dbPath?: string;
+  resolveSentMessageGuidImpl?: IMessageSendOpts["resolveSentMessageGuidImpl"];
+}): boolean {
   return (
-    !params.filePath &&
-    !params.replyToId &&
-    Boolean(params.message.trim()) &&
-    Boolean(extractIMessageApprovalPromptBinding(params.message))
+    Boolean(params.resolveSentMessageGuidImpl) ||
+    canResolveLatestSentMessageGuidFromChatDb(params.dbPath)
   );
 }
 
@@ -723,6 +732,61 @@ async function resolveAttachmentChatTarget(params: {
   return stringValue(result.guid) ?? stringValue(result.chat_guid) ?? null;
 }
 
+async function trySendRichTextForTarget(params: {
+  target: ReturnType<typeof parseIMessageTarget>;
+  service?: IMessageService;
+  message: string;
+  replyToId?: string;
+  formatRanges?: readonly IMessageFormatRange[];
+  runCliJson: (args: readonly string[]) => Promise<Record<string, unknown>>;
+}): Promise<Record<string, unknown> | null> {
+  if (!params.message.trim()) {
+    return null;
+  }
+  let chatTarget: string | null;
+  try {
+    chatTarget = await resolveAttachmentChatTarget({
+      target: params.target,
+      service: params.service,
+      runCliJson: params.runCliJson,
+    });
+  } catch (error) {
+    if (isAttachmentCommandFallbackError(error)) {
+      return null;
+    }
+    throw error;
+  }
+  if (!chatTarget) {
+    return null;
+  }
+
+  const args = ["send-rich", "--chat", chatTarget, "--text", params.message];
+  if (params.replyToId) {
+    args.push("--reply-to", params.replyToId);
+  }
+  if (params.formatRanges?.length) {
+    args.push("--format", JSON.stringify(params.formatRanges));
+  }
+
+  try {
+    const result = await params.runCliJson(args);
+    const failure = resolveIMessageCliFailure(result);
+    if (failure) {
+      const error = new Error(failure);
+      if (isAttachmentCommandFallbackError(error)) {
+        return null;
+      }
+      throw error;
+    }
+    return result;
+  } catch (error) {
+    if (isAttachmentCommandFallbackError(error)) {
+      return null;
+    }
+    throw error;
+  }
+}
+
 async function trySendAttachmentForTarget(params: {
   accountId: string;
   dbPath?: string;
@@ -978,6 +1042,14 @@ export async function sendMessageIMessage(
       ? await opts.createClient({ cliPath, dbPath })
       : await createIMessageRpcClient({ cliPath, dbPath }));
   const shouldClose = !opts.client;
+  let closedClient = false;
+  const stopOwnedClient = async () => {
+    if (!shouldClose || closedClient) {
+      return;
+    }
+    closedClient = true;
+    await client.stop();
+  };
   let result: Record<string, unknown>;
   const sendStartedAtMs = Date.now();
   try {
@@ -986,18 +1058,23 @@ export async function sendMessageIMessage(
         timeoutMs,
       });
     } catch (error) {
-      if (filePath || resolvedReplyToId || !isIMessageRpcSendTimeout(error)) {
+      if (filePath || !isIMessageRpcSendTimeout(error)) {
         throw error;
       }
       if (
-        !shouldRecoverApprovalPromptGuid({
-          message,
-          filePath,
-          replyToId: resolvedReplyToId,
+        !canCheckSentMessageAfterRpcTimeout({
+          dbPath: chatDbLookupPath,
+          resolveSentMessageGuidImpl: opts.resolveSentMessageGuidImpl,
         })
       ) {
         throw error;
       }
+
+      const canUseSendRichFallback = shouldClose && !isIMessageApprovalPromptMessage(message);
+      if (canUseSendRichFallback) {
+        await stopOwnedClient();
+      }
+
       const recoveredGuid = await resolveFallbackSentMessageGuid({
         dbPath: chatDbLookupPath,
         target,
@@ -1005,10 +1082,24 @@ export async function sendMessageIMessage(
         sentAfterMs: sendStartedAtMs,
         resolveSentMessageGuidImpl: opts.resolveSentMessageGuidImpl,
       });
-      if (!recoveredGuid) {
+      if (recoveredGuid) {
+        result = { guid: recoveredGuid, status: "sent" };
+      } else if (!canUseSendRichFallback) {
         throw error;
+      } else {
+        const richFallbackResult = await trySendRichTextForTarget({
+          target,
+          service,
+          message,
+          ...(resolvedReplyToId ? { replyToId: resolvedReplyToId } : {}),
+          formatRanges: formatted.ranges,
+          runCliJson,
+        });
+        if (!richFallbackResult) {
+          throw error;
+        }
+        result = richFallbackResult;
       }
-      result = { guid: recoveredGuid, status: "sent" };
     }
     const resolvedId = resolveMessageId(result);
     const messageId =
@@ -1097,8 +1188,6 @@ export async function sendMessageIMessage(
       }),
     };
   } finally {
-    if (shouldClose) {
-      await client.stop();
-    }
+    await stopOwnedClient();
   }
 }


### PR DESCRIPTION
## Summary

- Add guarded recovery for iMessage RPC text sends that time out after dispatch.
- Recover already-persisted outbound rows before considering any fallback send.
- Limit one-shot `imsg send-rich` fallback to send clients owned by the current send call, after the owned client is stopped, and keep non-owned external clients from resending.
- Route monitor-owned outbound replies through a fresh send RPC client instead of reusing the long-lived watch RPC client, so live agent replies can use the same safe recovery/fallback boundary without stopping the watch subscription.
- Add receive-side troubleshooting for the case where inbound iMessages never reach local `chat.db`.

Fixes #90850

## Maintainer readiness

- **Fix classification:** Root-cause bug fix for iMessage message-delivery timeout recovery.
- **Maintainer-ready confidence:** 90/100 for the code path available from this Linux environment. The review-flagged monitor-owned long-lived client path is now covered by code and focused tests; the remaining gap is live macOS Messages delivery proof, which this environment cannot provide.
- **Why it matters / User impact:** When the iMessage RPC sender wedges, agent replies can be generated but never reach Messages. Users then see a configured and apparently healthy iMessage channel while outbound replies fail or cannot be correlated back to the sent GUID.
- **Scope boundary:** This only changes iMessage text-send timeout recovery, monitor outbound reply client ownership, and iMessage troubleshooting docs. It does not change media upload transport, channel routing, gateway lifecycle, account configuration, receive implementation, or non-iMessage channels.
- **What did NOT change:** Successful RPC send behavior, media attachment transport selection, channel routing, gateway lifecycle, account configuration, receive implementation, non-iMessage channels, schema, config, protocol, migrations, and defaults are not changed.
- **Source-of-truth boundary:** `chat.db` remains the source of truth for proving an outbound send already landed. The patch does not introduce a new message schema, config key, provider protocol, or persistence format.
- **Architecture / source-of-truth check:** Public contract surface is unchanged. The canonical confirmation source remains `chat.db`; Apple Push and macOS Messages sync repair remain outside OpenClaw send-path ownership and are documented as troubleshooting steps.
- **Compatibility / default behavior:** Existing successful RPC sends keep the same path. Timeout fallback requires a sent-row check first; one-shot `send-rich` is only attempted for a client created by the current call after that owned client is stopped. Non-owned external RPC clients keep the previous no-resend behavior on ambiguous timeouts. Monitor outbound replies no longer pass the watch RPC client into sends, so the send call creates and owns a separate RPC client that can be stopped before fallback.
- **Related open PR scan:** daily-fix linked-PR and public-contract scans found no related open PR for this issue or the detected `send.rich` / `chat.db` contract terms.
- **Out-of-scope boundary:** This does not attempt to repair Apple Push, macOS Messages sync, SIP/private bridge launch state, or stale inbound delivery; the docs add troubleshooting steps for those receive-side conditions.
- **Patch quality notes:** The fallback helper returns `null` only for unsupported/unavailable CLI fallback errors, preserving the original RPC timeout otherwise. Timeout regression tests mock `Date.now()` so the chat.db polling path is deterministic. The monitor reply test now asserts that text chunks are sent without reusing the watch RPC client, preserving the watch subscription while allowing self-owned send recovery.

## Review findings addressed

- **RF-001 live macOS proof:** Not available from this Linux environment; see the explicit proof gap below. The closest local proof exercises the real iMessage send decision boundary and monitor reply wrapper through the repository test harness.
- **RF-002 monitor-owned long-lived client path:** Addressed by removing `getActiveClient()` from monitor outbound sends. `deliverReplies` and `createIMessageEchoCachingSend` no longer pass the watch RPC client to `sendMessageIMessage`.
- **RF-003 real behavior proof before merge:** Local deterministic behavior proof is supplied below. Live macOS Messages proof remains untested and is disclosed rather than simulated.
- **RF-004 main long-lived reply failure unresolved:** Addressed by making monitor replies use a separate self-owned send RPC client, so the existing timeout recovery/fallback logic can run without stopping or wedging the watch client.
- **RF-005 duplicate delivery risk after ambiguous timeout:** Addressed by preserving the sent-row-first check and requiring the owned send client to be stopped before one-shot `send-rich` fallback. Non-owned external clients still do not fallback.
- **RF-006 maintainer ownership/fallback strategy:** The strategy is now explicit: watch RPC clients are receive-side state and are not reused for outbound monitor replies; outbound monitor sends own their send client and can safely stop it before fallback.
- **RF-007 long-lived monitor client fallback coverage:** Covered by `extensions/imessage/src/monitor/deliver.test.ts`, which verifies monitor text chunks call `sendMessageIMessage` without a `client` option.

## Real behavior proof

- **Behavior addressed:** A timed-out iMessage RPC text send can now recover the original persisted GUID, and one-shot `send-rich` fallback only runs after a sent-row miss when the current send call owns and has stopped its RPC client. Monitor outbound replies no longer reuse the long-lived watch RPC client, so they enter that self-owned send-client path.
- **Behavior or issue addressed:** A long-lived iMessage RPC `send` timeout no longer leaves generic text sends with only a hard failure when the original sent row can be recovered, and live monitor replies are no longer pinned to the watch RPC client path that skipped the fallback.
- **Real environment tested:** Local Linux checkout exercising the iMessage extension send path and monitor reply send wrapper with the repository's Vitest extension harness, plus docs, lint, typecheck, format, and whitespace checks. No live macOS Messages account, real Messages bridge, or real `~/Library/Messages/chat.db` was available in this environment.
- **Exact steps or command run after this patch:**

```bash
node scripts/run-vitest.mjs extensions/imessage/src/send.test.ts extensions/imessage/src/monitor/deliver.test.ts --reporter=verbose
corepack pnpm format:check -- extensions/imessage/src/send.ts extensions/imessage/src/send.test.ts extensions/imessage/src/monitor/deliver.ts extensions/imessage/src/monitor/deliver.test.ts extensions/imessage/src/monitor/monitor-provider.ts docs/channels/imessage.md
corepack pnpm docs:check-mdx
corepack pnpm lint:extensions -- extensions/imessage/src/send.ts extensions/imessage/src/send.test.ts extensions/imessage/src/monitor/deliver.ts extensions/imessage/src/monitor/deliver.test.ts extensions/imessage/src/monitor/monitor-provider.ts
corepack pnpm tsgo:extensions
git diff --check
uname -a
command -v imsg || true
test -d "$HOME/Library/Messages" && printf 'Messages dir exists\n' || printf 'Messages dir unavailable\n'
```

- **Evidence after fix:**

```text
extensions/imessage/src/monitor/deliver.test.ts > deliverReplies > sends monitor text chunks without reusing the watch rpc client
extensions/imessage/src/send.test.ts > sendMessageIMessage receipts > recovers generic text sends already written by a timed-out rpc send
extensions/imessage/src/send.test.ts > sendMessageIMessage receipts > falls back to one-shot send-rich when rpc text send times out before writing chat.db
extensions/imessage/src/send.test.ts > sendMessageIMessage receipts > throws the rpc timeout when one-shot send-rich fallback is unavailable
extensions/imessage/src/send.test.ts > sendMessageIMessage receipts > does not fallback to send-rich for caller-owned rpc clients
extensions/imessage/src/send.test.ts > sendMessageIMessage receipts > throws the rpc timeout without resending when sent-row checks are unavailable

Test Files  2 passed (2)
Tests  41 passed (41)

All matched files use the correct format.
Docs MDX check passed (677 files, 10635ms).
corepack pnpm lint:extensions -- extensions/imessage/src/send.ts extensions/imessage/src/send.test.ts extensions/imessage/src/monitor/deliver.ts extensions/imessage/src/monitor/deliver.test.ts extensions/imessage/src/monitor/monitor-provider.ts
corepack pnpm tsgo:extensions
git diff --check
Linux LIN-957860A9F2D.zte.intra 4.19.112-2.el8.x86_64 #1 SMP Wed Jun 10 09:04:49 EDT 2020 x86_64 x86_64 x86_64 GNU/Linux
Messages dir unavailable
```

- **Observed result after fix:** The focused iMessage send and monitor delivery tests pass with coverage for recovered persisted sends, self-owned `send-rich` fallback, unavailable fallback, non-owned no-resend behavior, missing sent-row check no-resend behavior, and monitor text chunks not reusing the watch RPC client. Formatting, MDX docs validation, extension lint, extension typecheck, and whitespace checks all pass.
- **What was not tested:** Live outbound or inbound iMessage delivery on macOS was not tested because this Linux environment cannot run the Messages bridge, access a real `~/Library/Messages/chat.db`, or receive Apple Push/iMessage traffic. No live duplicate-delivery proof against a real Messages account is claimed.

## Regression Test Plan

- **Target test file:** `extensions/imessage/src/send.test.ts` and `extensions/imessage/src/monitor/deliver.test.ts`.
- **Scenario locked in:** RPC `send` timeout for generic text now covers persisted-row recovery, self-owned `send-rich` fallback, unavailable fallback, non-owned no-resend behavior, unavailable sent-row checks, approval prompt no-resend behavior, and monitor outbound text sending without the watch RPC client.
- **Why this is the smallest reliable guardrail:** `sendMessageIMessage` is the boundary that decides whether a timed-out RPC send is recovered, retried through one-shot CLI, or surfaced as the original timeout; `deliverReplies` is the monitor outbound reply boundary that previously supplied the long-lived watch client. Together they lock the duplicate-send safety rules and the monitor ownership strategy.

## Root Cause

- **Root cause:** The root cause is an invariant gap in the iMessage text-send timeout path and its monitor caller: generic text RPC timeouts were treated as unrecoverable unless they were approval prompts, and monitor outbound replies reused the long-lived watch RPC client, which prevented the self-owned fallback branch from running.
- **Why this is root-cause fix:** The invariant is that an ambiguous timeout must not resend unless the original in-flight sender is under this call's ownership and has been stopped. The send flow now checks for an already-persisted sent row first, returns that GUID without resending when found, and only invokes `send-rich` after stopping an owned RPC client. Monitor replies now create an owned send client instead of passing the watch client, while external non-owned clients keep the original timeout behavior to avoid duplicates.

## Merge risk

- **Risk labels considered:** `merge-risk:message-delivery`.
- **Risk explanation:** The patch changes iMessage outbound timeout behavior and monitor reply client ownership, so the main risk is duplicate outbound messages after an ambiguous RPC timeout or unintended disruption of the watch subscription.
- **Why acceptable:** The fallback is intentionally gated: sent-row recovery runs first, approval prompts do not fallback, non-owned external RPC clients do not fallback, and self-owned send clients are stopped before one-shot `send-rich` is attempted. Monitor replies no longer reuse the watch RPC client, so fallback does not require stopping the receive/watch subscription. Regression tests cover the safe recovery path, no-resend boundaries, and monitor no-watch-client boundary.
