### PR TITLE
docs: add ForAI provider setup guide

### DIFF
--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -256,6 +256,10 @@
     "target": "DeepInfra"
   },
   {
+    "source": "ForAI",
+    "target": "ForAI"
+  },
+  {
     "source": "Qwen",
     "target": "Qwen"
   },

--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -354,6 +354,37 @@ Gateway model capability checks also read explicit `models.providers.<id>.models
 
 `agents.defaults.models["provider/model"]` only controls model visibility, aliases, and per-model metadata for agents. It does not register a new runtime model by itself. For custom provider models, also add `models.providers.<provider>.models[]` with at least the matching `id`.
 
+### ForAI
+
+ForAI can be configured as an OpenAI-compatible provider through `models.providers`.
+
+- Provider id: `forai`
+- API: `openai-completions`
+- Base URL: `https://www.forai.ai/v1`
+- API key: your ForAI API key
+- Website: <https://www.forai.ai>
+
+```json5
+{
+  agents: {
+    defaults: { model: { primary: "forai/your-model-id" } },
+  },
+  models: {
+    mode: "merge",
+    providers: {
+      forai: {
+        baseUrl: "https://www.forai.ai/v1",
+        apiKey: "${FORAI_API_KEY}",
+        api: "openai-completions",
+        models: [{ id: "your-model-id", name: "ForAI model", input: ["text"] }],
+      },
+    },
+  },
+}
+```
+
+See [/providers/forai](/providers/forai) for setup details.
+
 ### Moonshot AI (Kimi)
 
 Moonshot ships as a bundled provider plugin. Use the built-in provider by default, and add an explicit `models.providers.moonshot` entry only when you need to override the base URL or model metadata:

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1414,6 +1414,7 @@
                   "providers/elevenlabs",
                   "providers/fal",
                   "providers/fireworks",
+                  "providers/forai",
                   "providers/github-copilot",
                   "providers/gmi",
                   "providers/google",

--- a/docs/providers/forai.md
+++ b/docs/providers/forai.md
@@ -1,0 +1,78 @@
+---
+summary: "Use ForAI as an OpenAI-compatible model gateway in OpenClaw"
+title: "ForAI"
+read_when:
+  - You want to use ForAI with OpenClaw
+  - You need an OpenAI-compatible base URL example for ForAI
+---
+
+[ForAI](https://www.forai.ai) is an OpenAI-compatible AI model gateway for developers and AI agent builders. Configure it as a custom OpenAI-compatible provider through `models.providers`.
+
+| Property      | Value                          |
+| ------------- | ------------------------------ |
+| Provider id   | `forai`                        |
+| Provider type | OpenAI-compatible              |
+| API           | `openai-completions`           |
+| Base URL      | `https://www.forai.ai/v1`      |
+| API key       | Your ForAI API key             |
+| Docs          | <https://www.forai.ai/docs>    |
+| Sign up       | <https://www.forai.ai/sign-up> |
+
+<Tip>
+Use `https://www.forai.ai/v1` as the base URL. If the chat completions endpoint is `https://www.forai.ai/v1/chat/completions`, the base URL should include `/v1` and should not stop at `https://www.forai.ai`.
+</Tip>
+
+## Configuration
+
+Add ForAI under `models.providers`, then select a model with the `forai/<model-id>` ref. Replace `your-model-id` with a model ID available from your ForAI account.
+
+```json5
+{
+  agents: {
+    defaults: {
+      model: { primary: "forai/your-model-id" },
+    },
+  },
+  models: {
+    mode: "merge",
+    providers: {
+      forai: {
+        baseUrl: "https://www.forai.ai/v1",
+        apiKey: "${FORAI_API_KEY}",
+        api: "openai-completions",
+        models: [
+          {
+            id: "your-model-id",
+            name: "ForAI model",
+            input: ["text"],
+          },
+        ],
+      },
+    },
+  },
+}
+```
+
+For OpenAI SDK-compatible tools outside OpenClaw, the equivalent environment variables are:
+
+```bash
+export OPENAI_API_KEY="your_forai_api_key"
+export OPENAI_BASE_URL="https://www.forai.ai/v1"
+```
+
+## Notes
+
+- ForAI supports OpenAI-compatible chat completions and can be used with agent workflows that support custom OpenAI-compatible providers.
+- Configure image-capable ForAI models with `input: ["text", "image"]` so OpenClaw can pass images natively.
+- Get an API key from [ForAI](https://www.forai.ai).
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Model providers" href="/concepts/model-providers" icon="layers">
+    Choosing providers, model refs, and custom base URLs.
+  </Card>
+  <Card title="Tools and custom providers" href="/gateway/config-tools#custom-providers-and-base-urls" icon="gear">
+    Full custom provider configuration reference.
+  </Card>
+</CardGroup>

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -40,6 +40,7 @@ Looking for chat channel docs (WhatsApp/Telegram/Discord/Slack/Mattermost (plugi
 - [ElevenLabs](/providers/elevenlabs)
 - [fal](/providers/fal)
 - [Fireworks](/providers/fireworks)
+- [ForAI](/providers/forai)
 - [GitHub Copilot](/providers/github-copilot)
 - [GMI Cloud](/providers/gmi)
 - [Google (Gemini)](/providers/google)

--- a/docs/providers/models.md
+++ b/docs/providers/models.md
@@ -32,6 +32,7 @@ model as `provider/model`.
 - [DeepInfra](/providers/deepinfra)
 - [fal](/providers/fal)
 - [Fireworks](/providers/fireworks)
+- [ForAI](/providers/forai)
 - [MiniMax](/providers/minimax)
 - [Mistral](/providers/mistral)
 - [Moonshot AI (Kimi + Kimi Coding)](/providers/moonshot)


### PR DESCRIPTION
## Summary

This PR adds documentation for configuring ForAI as an OpenAI-compatible provider.

## What is included

- Provider setup instructions
- Base URL configuration examples
- API key setup guidance
- OpenAI-compatible endpoint examples

## Why

Many OpenClaw users rely on OpenAI-compatible providers. This guide helps users configure ForAI using the same workflow as other supported providers.

## Scope

Documentation only. No code changes.