### PR TITLE
fix(cli): bridge inter-tool commentary events to channel progress

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-8be695e0892078773d78dae5f4c5a20ee57f30c5df227be6a89cc316fc4b4e10  plugin-sdk-api-baseline.json
-45944cb6fa30a094c4f104d19eec7afc5822be05c88bbd2aa4a8b93a7cba9de8  plugin-sdk-api-baseline.jsonl
+de06fd99257e4b010e54578ea46605c3bc631c31cac5f68aaed4e301f924f8af  plugin-sdk-api-baseline.json
+1c7a5420c4bcb1ec08544ff43b83fa4d43f3c0dcda597a5a25aa5f5bab0cb199  plugin-sdk-api-baseline.jsonl

--- a/src/auto-reply/reply/agent-runner-cli-dispatch.ts
+++ b/src/auto-reply/reply/agent-runner-cli-dispatch.ts
@@ -58,6 +58,20 @@ function createAgentEventBridge<T>(params: {
   };
 }
 
+type AgentEventBridge = {
+  unsubscribe: () => void;
+  drain: () => Promise<void>;
+};
+
+async function stopAgentEventBridges(bridges: readonly AgentEventBridge[]): Promise<void> {
+  for (const bridge of bridges) {
+    bridge.unsubscribe();
+  }
+  for (const bridge of bridges) {
+    await bridge.drain();
+  }
+}
+
 function createAssistantTextBridge(params: {
   runId: string;
   suppressed?: boolean;
@@ -173,10 +187,6 @@ function createToolEventBridge(params: {
   });
 }
 
-// Bridges CLI inter-tool commentary (assistant text emitted before a tool call, surfaced by the
-// parser as a `stream:"item", kind:"preamble"` agent event) into a channel callback. Without this,
-// CLI commentary lands on the agent-event bus with no subscriber and is silently dropped — the
-// tool/assistant/reasoning streams each have a bridge, but the item/preamble stream had none.
 function createCommentaryEventBridge(params: {
   runId: string;
   suppressed?: boolean;
@@ -251,18 +261,12 @@ export async function runCliAgentWithLifecycle(params: {
     suppressed: params.suppressAssistantBridge,
     deliver: params.onCommentaryText,
   });
+  const bridges = [assistantBridge, reasoningBridge, toolBridge, commentaryBridge];
   let lifecycleTerminalEmitted = false;
   try {
     const rawResult = await runCliAgent(params.runParams);
     const result = params.transformResult?.(rawResult) ?? rawResult;
-    assistantBridge.unsubscribe();
-    reasoningBridge.unsubscribe();
-    toolBridge.unsubscribe();
-    commentaryBridge.unsubscribe();
-    await assistantBridge.drain();
-    await reasoningBridge.drain();
-    await toolBridge.drain();
-    await commentaryBridge.drain();
+    await stopAgentEventBridges(bridges);
 
     const cliText = normalizeOptionalString(result.payloads?.[0]?.text);
     if (cliText) {
@@ -287,14 +291,7 @@ export async function runCliAgentWithLifecycle(params: {
     }
     return result;
   } catch (err) {
-    assistantBridge.unsubscribe();
-    reasoningBridge.unsubscribe();
-    toolBridge.unsubscribe();
-    commentaryBridge.unsubscribe();
-    await assistantBridge.drain();
-    await reasoningBridge.drain();
-    await toolBridge.drain();
-    await commentaryBridge.drain();
+    await stopAgentEventBridges(bridges);
     await params.onErrorBeforeLifecycle?.(err);
     if (emitLifecycleTerminal) {
       emitAgentEvent({
@@ -311,9 +308,9 @@ export async function runCliAgentWithLifecycle(params: {
     }
     throw err;
   } finally {
-    assistantBridge.unsubscribe();
-    reasoningBridge.unsubscribe();
-    toolBridge.unsubscribe();
+    for (const bridge of bridges) {
+      bridge.unsubscribe();
+    }
     if (emitLifecycleTerminal && !lifecycleTerminalEmitted) {
       emitAgentEvent({
         runId: params.runId,

--- a/src/auto-reply/reply/agent-runner-cli-dispatch.ts
+++ b/src/auto-reply/reply/agent-runner-cli-dispatch.ts
@@ -173,6 +173,32 @@ function createToolEventBridge(params: {
   });
 }
 
+// Bridges CLI inter-tool commentary (assistant text emitted before a tool call, surfaced by the
+// parser as a `stream:"item", kind:"preamble"` agent event) into a channel callback. Without this,
+// CLI commentary lands on the agent-event bus with no subscriber and is silently dropped — the
+// tool/assistant/reasoning streams each have a bridge, but the item/preamble stream had none.
+function createCommentaryEventBridge(params: {
+  runId: string;
+  suppressed?: boolean;
+  deliver?: (payload: { text: string; itemId?: string }) => Promise<void>;
+}) {
+  return createAgentEventBridge({
+    runId: params.runId,
+    suppressed: params.suppressed,
+    deliver: params.deliver,
+    read: (evt) => {
+      if (evt.stream !== "item" || evt.data.kind !== "preamble") {
+        return undefined;
+      }
+      const text = typeof evt.data.progressText === "string" ? evt.data.progressText.trim() : "";
+      if (!text) {
+        return undefined;
+      }
+      return { text, itemId: typeof evt.data.itemId === "string" ? evt.data.itemId : undefined };
+    },
+  });
+}
+
 export async function runCliAgentWithLifecycle(params: {
   runId: string;
   provider: string;
@@ -185,6 +211,7 @@ export async function runCliAgentWithLifecycle(params: {
   onAssistantText?: (text: string) => Promise<void>;
   onReasoningText?: (text: string) => Promise<void>;
   onToolEvent?: (payload: CliToolEventPayload) => Promise<void>;
+  onCommentaryText?: (payload: { text: string; itemId?: string }) => Promise<void>;
   onErrorBeforeLifecycle?: (err: unknown) => Promise<void>;
   transformResult?: (result: EmbeddedAgentRunResult) => EmbeddedAgentRunResult;
 }): Promise<EmbeddedAgentRunResult> {
@@ -219,6 +246,11 @@ export async function runCliAgentWithLifecycle(params: {
     suppressed: params.suppressAssistantBridge,
     deliver: params.onToolEvent,
   });
+  const commentaryBridge = createCommentaryEventBridge({
+    runId: params.runId,
+    suppressed: params.suppressAssistantBridge,
+    deliver: params.onCommentaryText,
+  });
   let lifecycleTerminalEmitted = false;
   try {
     const rawResult = await runCliAgent(params.runParams);
@@ -226,9 +258,11 @@ export async function runCliAgentWithLifecycle(params: {
     assistantBridge.unsubscribe();
     reasoningBridge.unsubscribe();
     toolBridge.unsubscribe();
+    commentaryBridge.unsubscribe();
     await assistantBridge.drain();
     await reasoningBridge.drain();
     await toolBridge.drain();
+    await commentaryBridge.drain();
 
     const cliText = normalizeOptionalString(result.payloads?.[0]?.text);
     if (cliText) {
@@ -256,9 +290,11 @@ export async function runCliAgentWithLifecycle(params: {
     assistantBridge.unsubscribe();
     reasoningBridge.unsubscribe();
     toolBridge.unsubscribe();
+    commentaryBridge.unsubscribe();
     await assistantBridge.drain();
     await reasoningBridge.drain();
     await toolBridge.drain();
+    await commentaryBridge.drain();
     await params.onErrorBeforeLifecycle?.(err);
     if (emitLifecycleTerminal) {
       emitAgentEvent({

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -2405,6 +2405,67 @@ describe("runAgentTurnWithFallback", () => {
     expect(call?.args).toEqual({ command: "ls -la" });
   });
 
+  it("bridges CLI commentary agent events into onItemEvent for live preview", async () => {
+    state.isCliProviderMock.mockReturnValue(true);
+    state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({
+      result: await params.run("claude-cli", "claude-opus-4-6"),
+      provider: "claude-cli",
+      model: "claude-opus-4-6",
+      attempts: [],
+    }));
+    state.runCliAgentMock.mockImplementationOnce(async (params: { runId: string }) => {
+      const realAgentEvents = await vi.importActual<typeof import("../../infra/agent-events.js")>(
+        "../../infra/agent-events.js",
+      );
+      // Inter-tool commentary surfaces as a stream:"item", kind:"preamble" agent event.
+      realAgentEvents.emitAgentEvent({
+        runId: params.runId,
+        stream: "item",
+        data: {
+          kind: "preamble",
+          itemId: "commentary-1",
+          progressText: "Let me check the files.",
+        },
+      });
+      return { payloads: [{ text: "done" }], meta: {} };
+    });
+
+    const onItemEvent = vi.fn<NonNullable<GetReplyOptions["onItemEvent"]>>(async () => undefined);
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const followupRun = createFollowupRun();
+    followupRun.run.provider = "claude-cli";
+    followupRun.run.model = "claude-opus-4-6";
+
+    await runAgentTurnWithFallback({
+      commandBody: "hi",
+      followupRun,
+      sessionCtx: { Provider: "telegram", MessageSid: "msg" } as unknown as TemplateContext,
+      opts: { onItemEvent },
+      typingSignals: createMockTypingSignaler(),
+      blockReplyPipeline: null,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      applyReplyToMode: (payload) => payload,
+      shouldEmitToolResult: () => true,
+      shouldEmitToolOutput: () => false,
+      pendingToolTasks: new Set(),
+      resetSessionAfterRoleOrderingConflict: async () => false,
+      isHeartbeat: false,
+      sessionKey: "main",
+      getActiveSessionEntry: () => undefined,
+      resolvedVerboseLevel: "off",
+    });
+    await new Promise((resolve) => {
+      setImmediate(resolve);
+    });
+
+    expect(onItemEvent).toHaveBeenCalledTimes(1);
+    const call = onItemEvent.mock.calls[0]?.[0];
+    expect(call?.kind).toBe("preamble");
+    expect(call?.progressText).toBe("Let me check the files.");
+    expect(call?.itemId).toBe("commentary-1");
+  });
+
   it("does not bridge CLI tool deltas when silentExpected is set", async () => {
     state.isCliProviderMock.mockReturnValue(true);
     state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -2137,6 +2137,13 @@ export async function runAgentTurnWithFallback(params: {
                       }),
                     ]);
                   },
+                  onCommentaryText: async ({ text, itemId }) => {
+                    await params.opts?.onItemEvent?.({
+                      kind: "preamble",
+                      progressText: text,
+                      itemId,
+                    });
+                  },
                   onErrorBeforeLifecycle: async () => {
                     if (!rollbackFallbackCandidateSelection) {
                       return;

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -1380,6 +1380,74 @@ describe("createFollowupRunner runtime config", () => {
     expect(onToolStart).not.toHaveBeenCalled();
   });
 
+  it("bridges queued CLI inter-tool commentary into onItemEvent for live preview", async () => {
+    const realAgentEvents = await vi.importActual<typeof import("../../infra/agent-events.js")>(
+      "../../infra/agent-events.js",
+    );
+    const runtimeConfig: OpenClawConfig = {
+      agents: {
+        defaults: {
+          cliBackends: {
+            "claude-cli": { command: "claude" },
+          },
+          models: {
+            "anthropic/claude-opus-4-7": { agentRuntime: { id: "claude-cli" } },
+          },
+        },
+      },
+    };
+    const onItemEvent = vi.fn(async () => {});
+    runCliAgentMock.mockImplementationOnce(async (params: { runId: string }) => {
+      realAgentEvents.emitAgentEvent({
+        runId: params.runId,
+        stream: "item",
+        data: {
+          kind: "preamble",
+          itemId: "commentary-1",
+          progressText: "Let me check the files.",
+        },
+      });
+      return {
+        payloads: [{ text: "final" }],
+        meta: {
+          agentMeta: {
+            provider: "claude-cli",
+            model: "claude-opus-4-7",
+          },
+        },
+      };
+    });
+
+    const runner = createFollowupRunner({
+      opts: { onItemEvent },
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      defaultModel: "anthropic/claude-opus-4-7",
+    });
+
+    await runner(
+      createQueuedRun({
+        originatingChannel: "telegram",
+        run: {
+          config: runtimeConfig,
+          provider: "anthropic",
+          model: "claude-opus-4-7",
+          messageProvider: "telegram",
+          sourceReplyDeliveryMode: "message_tool_only",
+          verboseLevel: "on",
+        },
+      }),
+    );
+
+    expect(onItemEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "preamble",
+        progressText: "Let me check the files.",
+        itemId: "commentary-1",
+      }),
+    );
+  });
+
   it("defers queued CLI attempt terminal lifecycle events until fallback settles", async () => {
     const realAgentEvents = await vi.importActual<typeof import("../../infra/agent-events.js")>(
       "../../infra/agent-events.js",

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -784,6 +784,17 @@ export function createFollowupRunner(params: {
                       emitChannelProgress: shouldEmitToolResultProgress(),
                     });
                   },
+                  onCommentaryText: async ({ text, itemId }) => {
+                    await forwardFollowupProgressEvent({
+                      evt: {
+                        stream: "item",
+                        data: { kind: "preamble", progressText: text, itemId },
+                      },
+                      opts,
+                      detailMode: toolProgressDetail,
+                      emitChannelProgress: shouldEmitToolResultProgress(),
+                    });
+                  },
                   transformResult:
                     queued.currentInboundEventKind === "room_event"
                       ? (resultLocal) =>


### PR DESCRIPTION
## Summary

Bridge CLI-runtime `item`/`preamble` commentary events into the existing channel progress callback path.

Before this, `runCliAgentWithLifecycle` forwarded assistant, reasoning, and tool events, but not item/preamble commentary. A CLI backend could emit commentary progress on the agent-event bus and channels would never see it.

This PR keeps the fix in shared CLI/core plumbing:

- adds the commentary bridge next to the existing assistant/reasoning/tool bridges
- forwards primary CLI runs to `opts.onItemEvent`
- forwards queued follow-up CLI runs through the existing follow-up progress path
- keeps the branch bridge-only; renderer/noCompact behavior was removed as separate product/API scope

## Verification

- `node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-execution.test.ts src/auto-reply/reply/followup-runner.test.ts` — 254 tests passed
- `./node_modules/.bin/oxfmt --check src/auto-reply/reply/agent-runner-cli-dispatch.ts src/auto-reply/reply/agent-runner-execution.test.ts src/auto-reply/reply/agent-runner-execution.ts src/auto-reply/reply/followup-runner.test.ts src/auto-reply/reply/followup-runner.ts`
- `node --max-old-space-size=8192 --import tsx scripts/generate-plugin-sdk-api-baseline.ts --check`
- `git diff --check`
- `pnpm tsgo`

## Real behavior proof

Behavior addressed: CLI-runtime preamble/commentary progress events reach the existing channel progress path instead of being dropped by `runCliAgentWithLifecycle`.

Real environment tested: Local OpenClaw setup with the combined #90883 delivery bridge and #89834 Claude CLI producer, observed through the Telegram progress draft flow.

Exact steps or command run after this patch: Ran the existing Telegram/Mantis-style proof flow against the combined stack and triggered a Claude CLI turn that emitted inter-tool commentary while the channel progress draft was active.

Evidence after fix: Recording of the live progress draft showing commentary rendering during the run: https://raw.githubusercontent.com/anagnorisis2peripeteia/openclaw/proof/commentary-persist-v2/commentary-transient.gif

Observed result after fix: The transient progress draft includes the Claude CLI commentary text while the run is still in progress, confirming #90883 carries `item`/`preamble` commentary through the shared channel progress callback path.

What was not tested: #90883 by itself does not add the Claude CLI producer; #89834 remains the producer-side PR. Renderer/noCompact behavior is intentionally out of scope for this bridge-only PR.

## Notes

This is the delivery bridge only. The Claude CLI producer remains in #89834 and should be reviewed/landed after this if we want the complete Claude-visible path.
