### PR TITLE
fix(agent): exclude Microsoft Foundry alias providers from DeepSeek V4 thinking wrapper

### DIFF
--- a/src/agents/embedded-agent-runner-extraparams.test.ts
+++ b/src/agents/embedded-agent-runner-extraparams.test.ts
@@ -766,6 +766,26 @@ describe("applyExtraParamsToAgent", () => {
     expect(payload).not.toHaveProperty("thinking");
   });
 
+  it("does not add DeepSeek V4 thinking params on Foundry alias providers (#90520)", () => {
+    const payload = runResponsesPayloadMutationCase({
+      applyProvider: "microsoft-foundry-9433",
+      applyModelId: "deepseek-v4-pro",
+      thinkingLevel: "high",
+      model: {
+        api: "openai-completions",
+        provider: "microsoft-foundry-9433",
+        id: "deepseek-v4-pro",
+      } as Model<"openai-completions">,
+      payload: {
+        reasoning_effort: "high",
+        messages: [{ role: "user", content: "hello" }],
+      },
+    });
+
+    expect(payload.reasoning_effort).toBe("high");
+    expect(payload).not.toHaveProperty("thinking");
+  });
+
   it("fills MiMo V2.6 reasoning_content for unowned OpenAI-compatible proxy models", () => {
     const payload = runResponsesPayloadMutationCase({
       applyProvider: "opencode",

--- a/src/agents/embedded-agent-runner/extra-params.ts
+++ b/src/agents/embedded-agent-runner/extra-params.ts
@@ -928,10 +928,12 @@ function isDeepSeekV4OpenAICompatibleModel(model: Parameters<StreamFn>[0]): bool
   );
 }
 
-function isMicrosoftFoundryProvider(provider?: string): boolean {
-  if (!provider) return false;
+const isMicrosoftFoundryProvider = (provider?: string): boolean => {
+  if (!provider) {
+    return false;
+  }
   return provider === "microsoft-foundry" || provider.startsWith("microsoft-foundry-");
-}
+};
 
 const MIMO_REASONING_OPENAI_COMPATIBLE_MODEL_IDS = new Set([
   "mimo-v2-pro",

--- a/src/agents/embedded-agent-runner/extra-params.ts
+++ b/src/agents/embedded-agent-runner/extra-params.ts
@@ -923,9 +923,14 @@ function isDeepSeekV4OpenAICompatibleModel(model: Parameters<StreamFn>[0]): bool
   const normalizedModelId = normalizeDeepSeekV4CandidateId(model.id);
   return (
     model.api === "openai-completions" &&
-    model.provider !== "microsoft-foundry" &&
+    !isMicrosoftFoundryProvider(model.provider) &&
     (normalizedModelId === "deepseek-v4-flash" || normalizedModelId === "deepseek-v4-pro")
   );
+}
+
+function isMicrosoftFoundryProvider(provider?: string): boolean {
+  if (!provider) return false;
+  return provider === "microsoft-foundry" || provider.startsWith("microsoft-foundry-");
 }
 
 const MIMO_REASONING_OPENAI_COMPATIBLE_MODEL_IDS = new Set([


### PR DESCRIPTION
## Summary

- Microsoft Foundry alias providers (e.g. `microsoft-foundry-9433`) were not excluded from the DeepSeek V4 thinking wrapper, causing HTTP 400 errors (`Unrecognized request argument supplied: thinking`)
- The exclusion only checked for the literal provider id `microsoft-foundry`, missing alias variants
- Added `isMicrosoftFoundryProvider()` helper that matches both the base provider and alias patterns (`microsoft-foundry-*`)
- Added test coverage for Foundry alias provider exclusion

## Verification

- All 132 existing tests pass in `src/agents/embedded-agent-runner-extraparams.test.ts`
- Added new test case: "does not add DeepSeek V4 thinking params on Foundry alias providers (#90520)"

## Real behavior proof

**Behavior addressed:** DeepSeek V4 models routed through Microsoft Foundry alias providers (e.g. `microsoft-foundry-9433`) no longer receive a top-level `thinking` field that causes HTTP 400.

**Environment tested:** Node 22.x on Linux, `node --import tsx` calling the actual production `applyExtraParamsToAgent` function from the fix branch.

**Steps run after the patch:**

```bash
node --import tsx --no-warnings -e "
import { applyExtraParamsToAgent } from './src/agents/embedded-agent-runner/extra-params.js';

// Foundry alias — should skip thinking
const p1 = {};
const a1 = { streamFn: (m, c, o) => { o?.onPayload?.(p1, m); return {}; } };
applyExtraParamsToAgent(a1, undefined, 'microsoft-foundry-9433', 'deepseek-v4-pro', undefined, 'high');
a1.streamFn?.({ api: 'openai-completions', provider: 'microsoft-foundry-9433', id: 'deepseek-v4-pro' }, { messages: [] }, {});
console.log('FOUNDRY_ALIAS:', 'thinking' in p1 ? 'FAIL' : 'PASS');

// Non-Foundry — should inject thinking
const p2 = { messages: [] };
const a2 = { streamFn: (m, c, o) => { o?.onPayload?.(p2, m); return {}; } };
applyExtraParamsToAgent(a2, undefined, 'opencode', 'deepseek-v4-pro', undefined, 'high');
a2.streamFn?.({ api: 'openai-completions', provider: 'opencode', id: 'deepseek-v4-pro' }, { messages: [] }, {});
console.log('NON_FOUNDRY:', 'thinking' in p2 ? 'PASS' : 'FAIL');
"
```

**Evidence after fix:**

```text
FOUNDRY_ALIAS: PASS
NON_FOUNDRY: PASS
```

**Observed result:** The production `applyExtraParamsToAgent` correctly skips the DeepSeek V4 thinking wrapper for `microsoft-foundry-9433` while still injecting it for non-Foundry providers (`opencode`). The fix works at the actual production function level.

**Not tested:** Live Microsoft Foundry gateway session with real Entra ID OAuth and a `microsoft-foundry-9433` alias provider deployment. The reporter's A/B proof in the linked issue (swapping `microsoft-foundry-9433` to `microsoft-foundry` fixed the request) provides additional evidence.

Ref #90520
