### PR TITLE
fix(cron): route failure alerts to thread ids

### DIFF
--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -225,6 +225,7 @@ Failure notifications follow a separate destination path:
 - `job.delivery.failureDestination` overrides that per job.
 - If neither is set and the job already delivers via `announce`, failure notifications now fall back to that primary announce target.
 - `delivery.failureDestination` is only supported on `sessionTarget="isolated"` jobs unless the primary delivery mode is `webhook`.
+- Per-job `failureAlert.threadId` routes announce alerts to a chat thread or topic. When it is omitted, announce alerts inherit `delivery.threadId` only if the alert uses the same channel and target as the job's primary announce delivery. Webhook alerts ignore thread ids. From the CLI, use `openclaw cron edit <jobId> --failure-alert-thread-id 79`.
 - `failureAlert.includeSkipped: true` opts a job or global cron alert policy into repeated skipped-run alerts. Skipped runs keep a separate consecutive skip counter, so they do not affect execution-error backoff.
 
 ## CLI examples

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -1355,6 +1355,7 @@ One-shot jobs stay enabled until retry attempts are exhausted, then disable whil
 - `includeSkipped`: count consecutive skipped runs toward the alert threshold (default: `false`). Skipped runs are tracked separately and do not affect execution-error backoff.
 - `mode`: delivery mode - `"announce"` sends via a channel message; `"webhook"` posts to the configured webhook.
 - `accountId`: optional account or channel id to scope alert delivery.
+- Per-job `failureAlert.threadId` is set on the cron job, not in global `cron.failureAlert`. Announce alerts use it for chat threads/topics; webhook alerts do not.
 
 ### `cron.failureDestination`
 

--- a/packages/gateway-protocol/src/cron-validators.test.ts
+++ b/packages/gateway-protocol/src/cron-validators.test.ts
@@ -162,6 +162,40 @@ describe("cron protocol validators", () => {
     ).toBe(true);
   });
 
+  it("accepts failure alert threadId on add and update params", () => {
+    expect(
+      validateCronAddParams({
+        ...minimalAddParams,
+        failureAlert: {
+          after: 1,
+          channel: "telegram",
+          to: "-100123",
+          threadId: 79,
+        },
+      }),
+    ).toBe(true);
+    expect(
+      validateCronUpdateParams({
+        id: "job-1",
+        patch: {
+          failureAlert: {
+            threadId: "topic-79",
+          },
+        },
+      }),
+    ).toBe(true);
+    expect(
+      validateCronUpdateParams({
+        id: "job-1",
+        patch: {
+          failureAlert: {
+            threadId: null,
+          },
+        },
+      }),
+    ).toBe(true);
+  });
+
   it("accepts nullable delivery clears on update params", () => {
     expect(
       validateCronUpdateParams({

--- a/packages/gateway-protocol/src/schema/cron.ts
+++ b/packages/gateway-protocol/src/schema/cron.ts
@@ -264,6 +264,21 @@ export const CronFailureAlertSchema = Type.Object(
     after: Type.Optional(Type.Integer({ minimum: 1 })),
     channel: Type.Optional(CronAnnounceChannelSchema),
     to: Type.Optional(NonBlankString),
+    threadId: Type.Optional(Type.Union([Type.String(), Type.Number()])),
+    cooldownMs: Type.Optional(Type.Integer({ minimum: 0 })),
+    includeSkipped: Type.Optional(Type.Boolean()),
+    mode: Type.Optional(Type.Union([Type.Literal("announce"), Type.Literal("webhook")])),
+    accountId: Type.Optional(NonEmptyString),
+  },
+  { additionalProperties: false },
+);
+
+const CronFailureAlertPatchSchema = Type.Object(
+  {
+    after: Type.Optional(Type.Integer({ minimum: 1 })),
+    channel: Type.Optional(CronAnnounceChannelSchema),
+    to: Type.Optional(NonBlankString),
+    threadId: Type.Optional(Type.Union([Type.String(), Type.Number(), Type.Null()])),
     cooldownMs: Type.Optional(Type.Integer({ minimum: 0 })),
     includeSkipped: Type.Optional(Type.Boolean()),
     mode: Type.Optional(Type.Union([Type.Literal("announce"), Type.Literal("webhook")])),
@@ -498,7 +513,7 @@ export const CronJobPatchSchema = Type.Object(
     wakeMode: Type.Optional(CronWakeModeSchema),
     payload: Type.Optional(CronPayloadPatchSchema),
     delivery: Type.Optional(CronDeliveryPatchSchema),
-    failureAlert: Type.Optional(Type.Union([Type.Literal(false), CronFailureAlertSchema])),
+    failureAlert: Type.Optional(Type.Union([Type.Literal(false), CronFailureAlertPatchSchema])),
     state: Type.Optional(CronJobStatePatchSchema),
   },
   { additionalProperties: false },

--- a/src/agents/tools/cron-tool.schema.test.ts
+++ b/src/agents/tools/cron-tool.schema.test.ts
@@ -185,9 +185,18 @@ describe("CronToolSchema", () => {
     );
   });
 
-  it("job.failureAlert exposes after, channel, to, cooldownMs, includeSkipped, mode, accountId", () => {
+  it("job.failureAlert exposes after, channel, to, threadId, cooldownMs, includeSkipped, mode, accountId", () => {
     expect(keysAt(schemaRecord, "job.failureAlert")).toEqual(
-      ["accountId", "after", "channel", "cooldownMs", "includeSkipped", "mode", "to"].toSorted(),
+      [
+        "accountId",
+        "after",
+        "channel",
+        "cooldownMs",
+        "includeSkipped",
+        "mode",
+        "threadId",
+        "to",
+      ].toSorted(),
     );
   });
 

--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -599,16 +599,31 @@ describe("cron tool", () => {
     );
   });
 
-  it("advertises delivery threadId in the tool schema", () => {
+  it("advertises delivery and failure-alert threadId in the tool schema", () => {
     const tool = createTestCronTool();
     const parameters = tool.parameters as SchemaLike;
     const jobThreadId = parameters.properties?.job?.properties?.delivery?.properties?.threadId;
     const patchThreadId = parameters.properties?.patch?.properties?.delivery?.properties?.threadId;
+    const jobFailureAlertThreadId =
+      parameters.properties?.job?.properties?.failureAlert?.properties?.threadId;
+    const patchFailureAlertThreadId =
+      parameters.properties?.patch?.properties?.failureAlert?.properties?.threadId;
 
     expect(jobThreadId?.description).toContain("Thread/topic id");
     expect(jobThreadId?.anyOf?.map((entry) => entry.type)).toEqual(["string", "number"]);
     expect(patchThreadId?.description).toContain("Thread/topic id");
     expect(patchThreadId?.anyOf?.map((entry) => entry.type)).toEqual(["string", "number", "null"]);
+    expect(jobFailureAlertThreadId?.description).toContain("Thread/topic id");
+    expect(jobFailureAlertThreadId?.anyOf?.map((entry) => entry.type)).toEqual([
+      "string",
+      "number",
+    ]);
+    expect(patchFailureAlertThreadId?.description).toContain("Thread/topic id");
+    expect(patchFailureAlertThreadId?.anyOf?.map((entry) => entry.type)).toEqual([
+      "string",
+      "number",
+      "null",
+    ]);
   });
 
   it("advertises nullable cron update clears in the tool schema", () => {
@@ -834,7 +849,7 @@ describe("cron tool", () => {
       lightContext: true,
       fallbacks: [" openrouter/gpt-4.1-mini ", "anthropic/claude-haiku-3-5"],
       toolsAllow: [" exec ", " read "],
-      failureAlert: { after: 3, cooldownMs: 60_000 },
+      failureAlert: { after: 3, cooldownMs: 60_000, threadId: 79 },
     });
 
     const params = expectSingleGatewayCallMethod("cron.add") as
@@ -846,7 +861,7 @@ describe("cron tool", () => {
             fallbacks?: string[];
             toolsAllow?: string[];
           };
-          failureAlert?: { after?: number; cooldownMs?: number };
+          failureAlert?: { after?: number; cooldownMs?: number; threadId?: number };
         }
       | undefined;
     expect(params?.payload).toEqual({
@@ -856,7 +871,7 @@ describe("cron tool", () => {
       fallbacks: ["openrouter/gpt-4.1-mini", "anthropic/claude-haiku-3-5"],
       toolsAllow: ["exec", "read"],
     });
-    expect(params?.failureAlert).toEqual({ after: 3, cooldownMs: 60_000 });
+    expect(params?.failureAlert).toEqual({ after: 3, cooldownMs: 60_000, threadId: 79 });
   });
 
   it("recovers concatenated cron add keys from local tool-call parsers", async () => {
@@ -1584,7 +1599,7 @@ describe("cron tool", () => {
       action: "update",
       id: "job-2",
       sessionTarget: "main",
-      failureAlert: { after: 3, cooldownMs: 60_000 },
+      failureAlert: { after: 3, cooldownMs: 60_000, threadId: 79 },
     });
 
     const params = expectSingleGatewayCallMethod("cron.update") as
@@ -1592,13 +1607,13 @@ describe("cron tool", () => {
           id?: string;
           patch?: {
             sessionTarget?: string;
-            failureAlert?: { after?: number; cooldownMs?: number };
+            failureAlert?: { after?: number; cooldownMs?: number; threadId?: number };
           };
         }
       | undefined;
     expect(params?.id).toBe("job-2");
     expect(params?.patch?.sessionTarget).toBe("main");
-    expect(params?.patch?.failureAlert).toEqual({ after: 3, cooldownMs: 60_000 });
+    expect(params?.patch?.failureAlert).toEqual({ after: 3, cooldownMs: 60_000, threadId: 79 });
   });
   it("passes through failureAlert=false for update", async () => {
     callGatewayMock.mockResolvedValueOnce({ ok: true });

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -218,7 +218,7 @@ function createCronDeliveryPatchSchema(): TSchema {
 // The schema declares `type: "object"` to stay compatible with providers that
 // enforce an OpenAPI 3.0 subset (e.g. Gemini via GitHub Copilot).  The
 // description tells the LLM that `false` is also accepted.
-function createCronFailureAlertSchema(): TSchema {
+function createCronFailureAlertSchema(params: { nullableThreadIdClear: boolean }): TSchema {
   return Type.Optional(
     Type.Unsafe<Record<string, unknown> | false>({
       type: "object",
@@ -226,6 +226,7 @@ function createCronFailureAlertSchema(): TSchema {
         after: optionalPositiveIntegerSchema({ description: "Failures before alert" }),
         channel: Type.Optional(Type.String({ description: "Alert channel" })),
         to: Type.Optional(Type.String({ description: "Alert target" })),
+        threadId: deliveryThreadIdSchema({ nullableClears: params.nullableThreadIdClear }),
         cooldownMs: optionalNonNegativeIntegerSchema({ description: "Alert cooldown ms" }),
         includeSkipped: Type.Optional(
           Type.Boolean({ description: "Skipped runs count toward alert" }),
@@ -258,7 +259,7 @@ function createCronJobObjectSchema(): TSchema {
         enabled: Type.Optional(Type.Boolean()),
         deleteAfterRun: Type.Optional(Type.Boolean({ description: "Delete after first run" })),
         sessionKey: nullableStringSchema("Explicit session key, or null to clear it"),
-        failureAlert: createCronFailureAlertSchema(),
+        failureAlert: createCronFailureAlertSchema({ nullableThreadIdClear: false }),
       },
       { additionalProperties: true },
     ),
@@ -285,7 +286,7 @@ function createCronPatchObjectSchema(): TSchema {
         deleteAfterRun: Type.Optional(Type.Boolean()),
         agentId: nullableStringSchema("Agent id, or null to clear it"),
         sessionKey: nullableStringSchema("Explicit session key, or null to clear it"),
-        failureAlert: createCronFailureAlertSchema(),
+        failureAlert: createCronFailureAlertSchema({ nullableThreadIdClear: true }),
       },
       { additionalProperties: true },
     ),

--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -83,6 +83,16 @@ type CronUpdatePatch = {
       accountId?: string;
       bestEffort?: boolean;
     };
+    failureAlert?: {
+      after?: number;
+      cooldownMs?: number;
+      channel?: string;
+      to?: string;
+      threadId?: number;
+      mode?: "announce" | "webhook";
+      accountId?: string;
+      includeSkipped?: boolean;
+    };
   };
 };
 
@@ -1670,6 +1680,8 @@ describe("cron cli", () => {
         "telegram",
         "--failure-alert-to",
         "19098680",
+        "--failure-alert-thread-id",
+        "79",
       ],
       { from: "user" },
     );
@@ -1677,7 +1689,13 @@ describe("cron cli", () => {
     const updateCall = callGatewayFromCli.mock.calls.find((call) => call[0] === "cron.update");
     const patch = updateCall?.[2] as {
       patch?: {
-        failureAlert?: { after?: number; cooldownMs?: number; channel?: string; to?: string };
+        failureAlert?: {
+          after?: number;
+          cooldownMs?: number;
+          channel?: string;
+          to?: string;
+          threadId?: number;
+        };
       };
     };
 
@@ -1685,11 +1703,22 @@ describe("cron cli", () => {
     expect(patch?.patch?.failureAlert?.cooldownMs).toBe(3_600_000);
     expect(patch?.patch?.failureAlert?.channel).toBe("telegram");
     expect(patch?.patch?.failureAlert?.to).toBe("19098680");
+    expect(patch?.patch?.failureAlert?.threadId).toBe(79);
   });
 
   it("rejects partial failure alert threshold on cron edit", async () => {
     await expectCronCommandExit(["cron", "edit", "job-1", "--failure-alert-after", "3x"]);
     expectRuntimeErrorContaining("Invalid --failure-alert-after");
+    expect(callGatewayFromCli).not.toHaveBeenCalledWith(
+      "cron.update",
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
+  it("rejects invalid --failure-alert-thread-id on cron edit", async () => {
+    await expectCronCommandExit(["cron", "edit", "job-1", "--failure-alert-thread-id", "topic-79"]);
+    expectRuntimeErrorContaining("--failure-alert-thread-id must be a positive integer");
     expect(callGatewayFromCli).not.toHaveBeenCalledWith(
       "cron.update",
       expect.anything(),

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -139,6 +139,7 @@ export function registerCronEditCommand(cron: Command) {
         `Failure alert channel (${getCronChannelOptions()})`,
       )
       .option("--failure-alert-to <dest>", "Failure alert destination")
+      .option("--failure-alert-thread-id <id>", "Telegram forum topic thread id for failure alerts")
       .option("--failure-alert-cooldown <duration>", "Minimum time between alerts (e.g. 1h, 30m)")
       .option("--failure-alert-include-skipped", "Count consecutive skipped runs toward alerts")
       .option("--failure-alert-exclude-skipped", "Alert only on execution errors")
@@ -440,6 +441,11 @@ export function registerCronEditCommand(cron: Command) {
           const hasFailureAlertAfter = typeof opts.failureAlertAfter === "string";
           const hasFailureAlertChannel = typeof opts.failureAlertChannel === "string";
           const hasFailureAlertTo = typeof opts.failureAlertTo === "string";
+          const failureAlertThreadId = parseCronThreadIdOption(
+            opts.failureAlertThreadId,
+            "--failure-alert-thread-id",
+          );
+          const hasFailureAlertThreadId = typeof failureAlertThreadId === "number";
           const hasFailureAlertCooldown = typeof opts.failureAlertCooldown === "string";
           const hasFailureAlertIncludeSkipped =
             typeof opts.failureAlertIncludeSkipped === "boolean";
@@ -456,6 +462,7 @@ export function registerCronEditCommand(cron: Command) {
             hasFailureAlertAfter ||
             hasFailureAlertChannel ||
             hasFailureAlertTo ||
+            hasFailureAlertThreadId ||
             hasFailureAlertCooldown ||
             hasFailureAlertIncludeSkipped ||
             hasFailureAlertExcludeSkipped ||
@@ -483,6 +490,9 @@ export function registerCronEditCommand(cron: Command) {
             if (hasFailureAlertTo) {
               const to = normalizeOptionalString(opts.failureAlertTo) ?? "";
               failureAlert.to = to ? to : undefined;
+            }
+            if (hasFailureAlertThreadId) {
+              failureAlert.threadId = failureAlertThreadId;
             }
             if (hasFailureAlertCooldown) {
               const cooldownMs = parseDurationMs(String(opts.failureAlertCooldown));

--- a/src/cli/cron-cli/thread-id-shared.ts
+++ b/src/cli/cron-cli/thread-id-shared.ts
@@ -4,17 +4,20 @@ import {
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
 
-export function parseCronThreadIdOption(value: unknown): number | undefined {
+export function parseCronThreadIdOption(
+  value: unknown,
+  flagName = "--thread-id",
+): number | undefined {
   const raw = normalizeOptionalString(value);
   if (!raw) {
     return undefined;
   }
   if (!/^\d+$/.test(raw)) {
-    throw new Error("--thread-id must be a positive integer Telegram topic thread id");
+    throw new Error(`${flagName} must be a positive integer Telegram topic thread id`);
   }
   const parsed = Number.parseInt(raw, 10);
   if (!Number.isSafeInteger(parsed) || parsed <= 0) {
-    throw new Error("--thread-id must be a safe positive integer Telegram topic thread id");
+    throw new Error(`${flagName} must be a safe positive integer Telegram topic thread id`);
   }
   return parsed;
 }

--- a/src/cron/delivery.failure-notify.test.ts
+++ b/src/cron/delivery.failure-notify.test.ts
@@ -49,7 +49,7 @@ type DeliveryRequest = {
   identity?: unknown;
   payloads?: unknown;
   session?: unknown;
-  threadId?: number;
+  threadId?: string | number;
   to?: string;
 };
 
@@ -91,13 +91,14 @@ describe("sendFailureNotificationAnnounce", () => {
       cfg,
       "main",
       "job-1",
-      { channel: "telegram", to: "123", accountId: "bot-a" },
+      { channel: "telegram", to: "123", threadId: 79, accountId: "bot-a" },
       "Cron failed",
     );
 
     expect(mocks.resolveDeliveryTarget).toHaveBeenCalledWith(cfg, "main", {
       channel: "telegram",
       to: "123",
+      threadId: 79,
       accountId: "bot-a",
     });
     expect(mocks.buildOutboundSessionContext).toHaveBeenCalledWith({
@@ -136,6 +137,7 @@ describe("sendFailureNotificationAnnounce", () => {
     expect(mocks.resolveDeliveryTarget).toHaveBeenCalledWith({} as never, "main", {
       channel: "telegram",
       to: undefined,
+      threadId: undefined,
       accountId: undefined,
       sessionKey: "agent:main:telegram:direct:123:thread:99",
     });

--- a/src/cron/delivery.ts
+++ b/src/cron/delivery.ts
@@ -36,6 +36,7 @@ const cronDeliveryLogger = getChildLogger({ subsystem: "cron-delivery" });
 export type CronAnnounceTarget = {
   channel?: string;
   to?: string;
+  threadId?: string | number;
   accountId?: string;
   sessionKey?: string;
 };
@@ -61,6 +62,7 @@ async function resolveCronAnnounceDelivery(params: {
   const resolvedTarget = await resolveDeliveryTarget(params.cfg, params.agentId, {
     channel: params.target.channel as CronMessageChannel | undefined,
     to: params.target.to,
+    threadId: params.target.threadId,
     accountId: params.target.accountId,
     sessionKey: params.target.sessionKey,
   });

--- a/src/cron/normalize.test.ts
+++ b/src/cron/normalize.test.ts
@@ -895,6 +895,71 @@ describe("normalizeCronJobPatch", () => {
     expect(validateCronUpdateParams({ id: "job", patch: normalized })).toBe(true);
   });
 
+  it("preserves nullable failure alert thread clears in patches", () => {
+    const normalized = normalizeCronJobPatch({
+      failureAlert: {
+        threadId: null,
+      },
+    }) as unknown as Record<string, unknown>;
+
+    expect(normalized.failureAlert).toEqual({
+      threadId: null,
+    });
+    expect(validateCronUpdateParams({ id: "job", patch: normalized })).toBe(true);
+  });
+
+  it("preserves invalid failure alert thread ids for protocol validation", () => {
+    const normalized = normalizeCronJobPatch({
+      failureAlert: {
+        threadId: {},
+      },
+    }) as unknown as Record<string, unknown>;
+
+    expect(normalized.failureAlert).toEqual({
+      threadId: {},
+    });
+    expect(validateCronUpdateParams({ id: "job", patch: normalized })).toBe(false);
+  });
+
+  it("preserves invalid failure alert fields for protocol validation", () => {
+    const normalized = normalizeCronJobPatch({
+      failureAlert: {
+        channel: "   ",
+        mode: "webook",
+        to: "   ",
+      },
+    }) as unknown as Record<string, unknown>;
+
+    expect(normalized.failureAlert).toEqual({
+      channel: "   ",
+      mode: "webook",
+      to: "   ",
+    });
+    expect(validateCronUpdateParams({ id: "job", patch: normalized })).toBe(false);
+  });
+
+  it("preserves invalid failure alert fields on create for protocol validation", () => {
+    const normalized = normalizeCronJobCreate({
+      name: "bad alert",
+      enabled: true,
+      schedule: { kind: "cron", expr: "* * * * *" },
+      sessionTarget: "isolated",
+      wakeMode: "now",
+      payload: {
+        kind: "agentTurn",
+        message: "hi",
+      },
+      failureAlert: {
+        mode: "webook",
+      },
+    }) as unknown as Record<string, unknown>;
+
+    expect(normalized.failureAlert).toEqual({
+      mode: "webook",
+    });
+    expect(validateCronAddParams(normalized)).toBe(false);
+  });
+
   it("normalizes cron stagger values in patch schedules", () => {
     const normalized = normalizeCronJobPatch({
       schedule: { kind: "cron", expr: "0 * * * *", staggerMs: "30000" },

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -10,6 +10,7 @@ import { sanitizeAgentId } from "../routing/session-key.js";
 import { isRecord } from "../utils.js";
 import {
   TimeoutSecondsFieldSchema,
+  DeliveryThreadIdFieldSchema,
   TrimmedNonEmptyStringFieldSchema,
   parseDeliveryInput,
   parseOptionalField,
@@ -439,6 +440,66 @@ function coerceFailureDestination(value: UnknownRecord) {
   return next;
 }
 
+function coerceFailureAlert(
+  value: UnknownRecord,
+  options: { preserveThreadIdNull?: boolean } = {},
+) {
+  const next: UnknownRecord = { ...value };
+  if ("channel" in next) {
+    if (next.channel === undefined) {
+      delete next.channel;
+    } else {
+      const channel = normalizeOptionalLowercaseString(next.channel);
+      if (channel) {
+        next.channel = channel;
+      }
+    }
+  }
+  if ("to" in next) {
+    if (next.to === undefined) {
+      delete next.to;
+    } else {
+      const to = normalizeOptionalString(next.to);
+      if (to) {
+        next.to = to;
+      }
+    }
+  }
+  if ("threadId" in next) {
+    if (next.threadId === undefined) {
+      delete next.threadId;
+    } else if (options.preserveThreadIdNull && next.threadId === null) {
+      next.threadId = null;
+    } else {
+      const threadId = parseOptionalField(DeliveryThreadIdFieldSchema, next.threadId);
+      if (threadId !== undefined) {
+        next.threadId = threadId;
+      }
+    }
+  }
+  if ("mode" in next) {
+    if (next.mode === undefined) {
+      delete next.mode;
+    } else {
+      const mode = normalizeOptionalLowercaseString(next.mode);
+      if (mode === "announce" || mode === "webhook") {
+        next.mode = mode;
+      }
+    }
+  }
+  if ("accountId" in next) {
+    if (next.accountId === undefined) {
+      delete next.accountId;
+    } else {
+      const accountId = normalizeOptionalString(next.accountId);
+      if (accountId) {
+        next.accountId = accountId;
+      }
+    }
+  }
+  return next;
+}
+
 function normalizeSessionTarget(raw: unknown) {
   if (typeof raw !== "string") {
     return undefined;
@@ -549,6 +610,18 @@ export function normalizeCronJobInput(
 
   if (isRecord(base.delivery)) {
     next.delivery = coerceDelivery(base.delivery);
+  }
+
+  if ("failureAlert" in base) {
+    if (base.failureAlert === false) {
+      next.failureAlert = false;
+    } else if (isRecord(base.failureAlert)) {
+      next.failureAlert = coerceFailureAlert(base.failureAlert, {
+        preserveThreadIdNull: !options.applyDefaults,
+      });
+    } else {
+      delete next.failureAlert;
+    }
   }
 
   if (options.applyDefaults) {

--- a/src/cron/service.failure-alert.test.ts
+++ b/src/cron/service.failure-alert.test.ts
@@ -3,6 +3,8 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plugins/runtime.js";
+import { createChannelTestPluginBase, createTestRegistry } from "../test-utils/channel-plugins.js";
 import { CronService } from "./service.js";
 
 type CronServiceParams = ConstructorParameters<typeof CronService>[0];
@@ -40,6 +42,21 @@ function createFailureAlertCron(params: {
     runIsolatedAgentJob: params.runIsolatedAgentJob,
     sendCronFailureAlert: params.sendCronFailureAlert,
   });
+}
+
+function setCronFailureAlertTestRegistry(): void {
+  setActivePluginRegistry(
+    createTestRegistry([
+      {
+        pluginId: "telegram",
+        source: "test:telegram",
+        plugin: {
+          ...createChannelTestPluginBase({ id: "telegram" }),
+          messaging: { targetPrefixes: ["telegram", "tg"] },
+        },
+      },
+    ]),
+  );
 }
 
 function alertCallArg(
@@ -90,6 +107,7 @@ describe("CronService failure alerts", () => {
 
   afterEach(() => {
     vi.useRealTimers();
+    resetPluginRuntimeStateForTest();
   });
 
   it("alerts after configured consecutive failures and honors cooldown", async () => {
@@ -194,6 +212,180 @@ describe("CronService failure alerts", () => {
     await store.cleanup();
   });
 
+  it("routes failure alert thread ids by explicit override, inherited delivery target, and mode", async () => {
+    const store = await makeStorePath();
+    const sendCronFailureAlert = vi.fn(async () => undefined);
+    const runIsolatedAgentJob = vi.fn(async () => ({
+      status: "error" as const,
+      error: "send failed",
+    }));
+
+    const cron = createFailureAlertCron({
+      storePath: store.storePath,
+      cronConfig: {
+        failureAlert: {
+          enabled: true,
+          after: 1,
+        },
+      },
+      runIsolatedAgentJob,
+      sendCronFailureAlert,
+    });
+
+    await cron.start();
+    const inherited = await cron.add({
+      name: "inherits thread from implicit announce delivery",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "run report" },
+      delivery: { channel: "telegram", to: "chat-1", threadId: 79 },
+    });
+    const explicit = await cron.add({
+      name: "explicit thread",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "run report" },
+      delivery: { mode: "announce", channel: "telegram", to: "chat-1", threadId: 79 },
+      failureAlert: { after: 1, threadId: 80 },
+    });
+    const changedTarget = await cron.add({
+      name: "changed target",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "run report" },
+      delivery: { mode: "announce", channel: "telegram", to: "chat-1", threadId: 79 },
+      failureAlert: { after: 1, channel: "telegram", to: "chat-2" },
+    });
+    const accountMismatch = await cron.add({
+      name: "account mismatch",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "run report" },
+      delivery: {
+        mode: "announce",
+        channel: "telegram",
+        to: "chat-1",
+        threadId: 79,
+        accountId: "bot-a",
+      },
+      failureAlert: { after: 1, accountId: "bot-b" },
+    });
+    const accountMatch = await cron.add({
+      name: "account match",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "run report" },
+      delivery: {
+        mode: "announce",
+        channel: "telegram",
+        to: "chat-1",
+        threadId: 79,
+        accountId: "bot-a",
+      },
+      failureAlert: { after: 1, accountId: "bot-a" },
+    });
+    const webhook = await cron.add({
+      name: "webhook thread",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "run report" },
+      delivery: { mode: "announce", channel: "telegram", to: "chat-1", threadId: 79 },
+      failureAlert: {
+        after: 1,
+        mode: "webhook",
+        to: "https://example.invalid/cron-failure",
+        threadId: 80,
+      },
+    });
+
+    await cron.run(inherited.id, "force");
+    await cron.run(explicit.id, "force");
+    await cron.run(changedTarget.id, "force");
+    await cron.run(accountMismatch.id, "force");
+    await cron.run(accountMatch.id, "force");
+    await cron.run(webhook.id, "force");
+
+    expectAlertFields(sendCronFailureAlert, { threadId: 79 }, 0);
+    expectAlertFields(sendCronFailureAlert, { threadId: "80" }, 1);
+    expectAlertFields(sendCronFailureAlert, { to: "chat-2", threadId: undefined }, 2);
+    expectAlertFields(sendCronFailureAlert, { accountId: "bot-b", threadId: undefined }, 3);
+    expectAlertFields(sendCronFailureAlert, { accountId: "bot-a", threadId: "79" }, 4);
+    expectAlertFields(
+      sendCronFailureAlert,
+      {
+        mode: "webhook",
+        to: "https://example.invalid/cron-failure",
+        threadId: undefined,
+      },
+      5,
+    );
+
+    cron.stop();
+    await store.cleanup();
+  });
+
+  it("inherits delivery thread ids for provider-prefixed announce targets", async () => {
+    setCronFailureAlertTestRegistry();
+    const store = await makeStorePath();
+    const sendCronFailureAlert = vi.fn(async () => undefined);
+    const runIsolatedAgentJob = vi.fn(async () => ({
+      status: "error" as const,
+      error: "send failed",
+    }));
+
+    const cron = createFailureAlertCron({
+      storePath: store.storePath,
+      cronConfig: {
+        failureAlert: {
+          enabled: true,
+          after: 1,
+        },
+      },
+      runIsolatedAgentJob,
+      sendCronFailureAlert,
+    });
+
+    await cron.start();
+    const job = await cron.add({
+      name: "prefixed target inherits thread",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "run report" },
+      delivery: {
+        mode: "announce",
+        channel: "last",
+        to: "telegram:chat-1",
+        threadId: 79,
+      },
+      failureAlert: { after: 1, channel: "telegram" },
+    });
+
+    await cron.run(job.id, "force");
+
+    expectAlertFields(sendCronFailureAlert, {
+      channel: "telegram",
+      to: "telegram:chat-1",
+      threadId: 79,
+    });
+
+    cron.stop();
+    await store.cleanup();
+  });
+
   it("respects per-job failureAlert=false and suppresses alerts", async () => {
     const store = await makeStorePath();
     const sendCronFailureAlert = vi.fn(async () => undefined);
@@ -265,6 +457,7 @@ describe("CronService failure alerts", () => {
         after: 1,
         channel: "telegram",
         to: "12345",
+        threadId: 79,
       },
     });
 
@@ -280,17 +473,76 @@ describe("CronService failure alerts", () => {
     expect(updatedFailureAlert.after).toBe(1);
     expect(updatedFailureAlert.channel).toBe("telegram");
     expect(updatedFailureAlert.to).toBe("12345");
+    expect(updatedFailureAlert.threadId).toBe(79);
     expect(updatedFailureAlert.includeSkipped).toBe(true);
 
     await cron.run(job.id, "force");
     expectAlertFields(sendCronFailureAlert, {
       channel: "telegram",
       to: "12345",
+      threadId: 79,
     });
     expectAlertTextContaining(
       sendCronFailureAlert,
       'Cron job "updated skipped alert job" skipped 1 times',
     );
+
+    const cleared = await cron.update(job.id, {
+      failureAlert: { threadId: null },
+    });
+    const clearedFailureAlert = cleared?.failureAlert;
+    if (!clearedFailureAlert) {
+      throw new Error("expected cleared failure alert config");
+    }
+    expect(clearedFailureAlert.after).toBe(1);
+    expect(clearedFailureAlert.threadId).toBeUndefined();
+
+    cron.stop();
+    await store.cleanup();
+  });
+
+  it("does not create failure alerts when clearing a missing thread override", async () => {
+    const store = await makeStorePath();
+    const sendCronFailureAlert = vi.fn(async () => undefined);
+    const runIsolatedAgentJob = vi.fn(async () => ({
+      status: "error" as const,
+      error: "send failed",
+    }));
+
+    const cron = createFailureAlertCron({
+      storePath: store.storePath,
+      runIsolatedAgentJob,
+      sendCronFailureAlert,
+    });
+
+    await cron.start();
+    const absent = await cron.add({
+      name: "absent alert job",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "run report" },
+    });
+    const disabled = await cron.add({
+      name: "disabled alert job",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "run report" },
+      failureAlert: false,
+    });
+
+    const absentUpdated = await cron.update(absent.id, {
+      failureAlert: { threadId: null },
+    });
+    const disabledUpdated = await cron.update(disabled.id, {
+      failureAlert: { threadId: null },
+    });
+
+    expect(absentUpdated?.failureAlert).toBeUndefined();
+    expect(disabledUpdated?.failureAlert).toBe(false);
 
     cron.stop();
     await store.cleanup();

--- a/src/cron/service/failure-alerts.ts
+++ b/src/cron/service/failure-alerts.ts
@@ -1,6 +1,14 @@
 /** Resolves and emits cron failure-alert notifications. */
-import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
+import {
+  normalizeOptionalLowercaseString,
+  normalizeOptionalThreadValue,
+} from "@openclaw/normalization-core/string-coerce";
 import { resolveFailoverReasonFromError } from "../../agents/failover-error.js";
+import {
+  resolveTargetPrefixedChannel,
+  stripTargetProviderPrefix,
+} from "../../infra/outbound/channel-target-prefix.js";
+import { resolveCronDeliveryPlan } from "../delivery-plan.js";
 import type { CronFailureNotificationDelivery, CronJob, CronMessageChannel } from "../types.js";
 import type { CronServiceState } from "./state.js";
 
@@ -12,6 +20,7 @@ type ResolvedFailureAlert = {
   cooldownMs: number;
   channel: CronMessageChannel;
   to?: string;
+  threadId?: string | number;
   mode?: "announce" | "webhook";
   accountId?: string;
   includeSkipped: boolean;
@@ -43,6 +52,78 @@ function normalizeTo(input: unknown): string | undefined {
   }
   const to = input.trim();
   return to ? to : undefined;
+}
+
+function resolveAnnounceComparisonChannel(params: {
+  channel?: CronMessageChannel;
+  to?: string;
+}): CronMessageChannel {
+  if (params.channel && params.channel !== "last") {
+    return params.channel;
+  }
+  return (
+    (resolveTargetPrefixedChannel(params.to) as CronMessageChannel | undefined) ??
+    params.channel ??
+    "last"
+  );
+}
+
+function normalizeComparisonTarget(params: {
+  channel: CronMessageChannel;
+  to?: string;
+}): string | undefined {
+  if (!params.to) {
+    return undefined;
+  }
+  const target =
+    params.channel === "last" ? params.to : stripTargetProviderPrefix(params.to, params.channel);
+  return normalizeTo(target);
+}
+
+function resolveDeliveryThreadForFailureAlert(params: {
+  job: CronJob;
+  mode?: "announce" | "webhook";
+  alertChannel: CronMessageChannel;
+  alertTo?: string;
+  alertAccountId?: string;
+  explicitThreadId?: string | number;
+}): string | number | undefined {
+  if (params.mode === "webhook") {
+    return undefined;
+  }
+  if (params.explicitThreadId !== undefined) {
+    return params.explicitThreadId;
+  }
+  const deliveryPlan = resolveCronDeliveryPlan(params.job);
+  if (deliveryPlan.mode !== "announce") {
+    return undefined;
+  }
+  const rawDeliveryTo = normalizeTo(deliveryPlan.to);
+  const deliveryChannel = resolveAnnounceComparisonChannel({
+    channel: deliveryPlan.channel,
+    to: rawDeliveryTo,
+  });
+  const alertChannel = resolveAnnounceComparisonChannel({
+    channel: params.alertChannel,
+    to: params.alertTo,
+  });
+  const deliveryTo = normalizeComparisonTarget({
+    channel: deliveryChannel,
+    to: rawDeliveryTo,
+  });
+  const alertTo = normalizeComparisonTarget({
+    channel: alertChannel,
+    to: params.alertTo,
+  });
+  const deliveryAccountId = normalizeTo(deliveryPlan.accountId);
+  if (
+    alertChannel !== deliveryChannel ||
+    alertTo !== deliveryTo ||
+    params.alertAccountId !== deliveryAccountId
+  ) {
+    return undefined;
+  }
+  return normalizeOptionalThreadValue(deliveryPlan.threadId);
 }
 
 function clampPositiveInt(value: unknown, fallback: number): number {
@@ -77,7 +158,14 @@ export function resolveFailureAlert(
   }
 
   const mode = jobConfig?.mode ?? globalConfig?.mode;
+  const channel =
+    normalizeCronMessageChannel(jobConfig?.channel) ??
+    normalizeCronMessageChannel(job.delivery?.channel) ??
+    "last";
   const explicitTo = normalizeTo(jobConfig?.to);
+  const to = mode === "webhook" ? explicitTo : (explicitTo ?? normalizeTo(job.delivery?.to));
+  const explicitThreadId = normalizeOptionalThreadValue(jobConfig?.threadId);
+  const accountId = jobConfig?.accountId ?? globalConfig?.accountId;
 
   // Announce alerts inherit the job delivery target; webhook alerts require an
   // explicit alert target so chat recipients are not reused as URLs.
@@ -87,13 +175,18 @@ export function resolveFailureAlert(
       jobConfig?.cooldownMs ?? globalConfig?.cooldownMs,
       DEFAULT_FAILURE_ALERT_COOLDOWN_MS,
     ),
-    channel:
-      normalizeCronMessageChannel(jobConfig?.channel) ??
-      normalizeCronMessageChannel(job.delivery?.channel) ??
-      "last",
-    to: mode === "webhook" ? explicitTo : (explicitTo ?? normalizeTo(job.delivery?.to)),
+    channel,
+    to,
+    threadId: resolveDeliveryThreadForFailureAlert({
+      job,
+      mode,
+      alertChannel: channel,
+      alertTo: to,
+      alertAccountId: accountId,
+      explicitThreadId,
+    }),
     mode,
-    accountId: jobConfig?.accountId ?? globalConfig?.accountId,
+    accountId,
     includeSkipped: jobConfig?.includeSkipped ?? globalConfig?.includeSkipped ?? false,
   };
 }
@@ -106,6 +199,7 @@ function emitFailureAlert(
     consecutiveErrors: number;
     channel: CronMessageChannel;
     to?: string;
+    threadId?: string | number;
     mode?: "announce" | "webhook";
     accountId?: string;
     status: "error" | "skipped";
@@ -135,6 +229,7 @@ function emitFailureAlert(
         text,
         channel: params.channel,
         to: params.to,
+        threadId: params.threadId,
         mode: params.mode,
         accountId: params.accountId,
       })
@@ -191,6 +286,7 @@ export function maybeEmitFailureAlert(
     consecutiveErrors: params.consecutiveCount,
     channel: params.alertConfig.channel,
     to: params.alertConfig.to,
+    threadId: params.alertConfig.threadId,
     mode: params.alertConfig.mode,
     accountId: params.alertConfig.accountId,
     status: params.status,

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -21,6 +21,7 @@ import type {
   CronDelivery,
   CronDeliveryPatch,
   CronFailureAlert,
+  CronFailureAlertPatch,
   CronJob,
   CronJobCreate,
   CronJobPatch,
@@ -1121,12 +1122,20 @@ function mergeCronDelivery(
 
 function mergeCronFailureAlert(
   existing: CronFailureAlert | false | undefined,
-  patch: CronFailureAlert | false | undefined,
+  patch: CronFailureAlertPatch | false | undefined,
 ): CronFailureAlert | false | undefined {
   if (patch === false) {
     return false;
   }
   if (patch === undefined) {
+    return existing;
+  }
+  if (
+    (existing === undefined || existing === false) &&
+    Object.keys(patch).length === 1 &&
+    Object.hasOwn(patch, "threadId") &&
+    normalizeOptionalThreadValue(patch.threadId) === undefined
+  ) {
     return existing;
   }
   const base = existing === false || existing === undefined ? {} : existing;
@@ -1141,6 +1150,9 @@ function mergeCronFailureAlert(
   }
   if ("to" in patch) {
     next.to = normalizeOptionalString(patch.to);
+  }
+  if ("threadId" in patch) {
+    next.threadId = normalizeOptionalThreadValue(patch.threadId);
   }
   if ("cooldownMs" in patch) {
     const cooldownMs =

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -163,6 +163,7 @@ export type CronServiceDeps = {
     text: string;
     channel: CronMessageChannel;
     to?: string;
+    threadId?: string | number;
     mode?: "announce" | "webhook";
     accountId?: string;
   }) => Promise<void>;

--- a/src/cron/store.test.ts
+++ b/src/cron/store.test.ts
@@ -583,6 +583,36 @@ describe("cron store", () => {
     });
   });
 
+  it("round-trips failure alert thread ids through SQLite columns", async () => {
+    const { storePath } = await makeStorePath();
+    const job = makeStore("sqlite-failure-alert-thread-job", true).jobs[0];
+    job.sessionTarget = "isolated";
+    job.payload = { kind: "agentTurn", message: "hello" };
+    job.failureAlert = {
+      after: 2,
+      channel: "telegram",
+      to: "telegram:chat-1",
+      threadId: 79,
+      cooldownMs: 60_000,
+      includeSkipped: true,
+      mode: "announce",
+      accountId: "bot-1",
+    };
+
+    await saveCronStore(storePath, { version: 1, jobs: [job] });
+
+    expect((await loadCronStore(storePath)).jobs[0]?.failureAlert).toEqual({
+      after: 2,
+      channel: "telegram",
+      to: "telegram:chat-1",
+      threadId: "79",
+      cooldownMs: 60_000,
+      includeSkipped: true,
+      mode: "announce",
+      accountId: "bot-1",
+    });
+  });
+
   it("round-trips explicit failure destination field clears through SQLite delivery columns", async () => {
     const { storePath } = await makeStorePath();
     const job = makeStore("sqlite-failure-destination-clear-job", true).jobs[0];

--- a/src/cron/store/failure-alert-codec.ts
+++ b/src/cron/store/failure-alert-codec.ts
@@ -15,6 +15,7 @@ export function bindFailureAlertColumns(
   | "failure_alert_disabled"
   | "failure_alert_include_skipped"
   | "failure_alert_mode"
+  | "failure_alert_thread_id"
   | "failure_alert_to"
 > {
   if (failureAlert === false) {
@@ -23,6 +24,7 @@ export function bindFailureAlertColumns(
       failure_alert_after: null,
       failure_alert_channel: null,
       failure_alert_to: null,
+      failure_alert_thread_id: null,
       failure_alert_cooldown_ms: null,
       failure_alert_include_skipped: null,
       failure_alert_mode: null,
@@ -34,6 +36,8 @@ export function bindFailureAlertColumns(
     failure_alert_after: failureAlert?.after ?? null,
     failure_alert_channel: failureAlert?.channel ?? null,
     failure_alert_to: failureAlert?.to ?? null,
+    failure_alert_thread_id:
+      failureAlert?.threadId === undefined ? null : String(failureAlert.threadId),
     failure_alert_cooldown_ms: failureAlert?.cooldownMs ?? null,
     failure_alert_include_skipped: booleanToInteger(failureAlert?.includeSkipped),
     failure_alert_mode: failureAlert?.mode ?? null,
@@ -50,6 +54,7 @@ export function failureAlertFromRow(row: CronJobRow): CronFailureAlert | false |
     row.failure_alert_after == null &&
     !row.failure_alert_channel &&
     !row.failure_alert_to &&
+    !row.failure_alert_thread_id &&
     row.failure_alert_cooldown_ms == null &&
     row.failure_alert_include_skipped == null &&
     !row.failure_alert_mode &&
@@ -63,6 +68,7 @@ export function failureAlertFromRow(row: CronJobRow): CronFailureAlert | false |
       ? { channel: row.failure_alert_channel as CronFailureAlert["channel"] }
       : {}),
     ...(row.failure_alert_to ? { to: row.failure_alert_to } : {}),
+    ...(row.failure_alert_thread_id ? { threadId: row.failure_alert_thread_id } : {}),
     ...(row.failure_alert_cooldown_ms != null
       ? { cooldownMs: normalizeNumber(row.failure_alert_cooldown_ms) }
       : {}),

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -212,6 +212,8 @@ export type CronFailureAlert = {
   after?: number;
   channel?: CronMessageChannel;
   to?: string;
+  /** Explicit thread/topic id for announce alerts that support threaded delivery. */
+  threadId?: string | number;
   cooldownMs?: number;
   /** When true, consecutive skipped runs count toward the alert threshold. */
   includeSkipped?: boolean;
@@ -219,6 +221,11 @@ export type CronFailureAlert = {
   mode?: "announce" | "webhook";
   /** Account ID for multi-account channel configurations. */
   accountId?: string;
+};
+
+/** Partial failure-alert update shape; null clears the explicit thread override. */
+export type CronFailureAlertPatch = Omit<CronFailureAlert, "threadId"> & {
+  threadId?: string | number | null;
 };
 
 /** Payload variants cron can execute in main-session or detached modes. */
@@ -341,9 +348,10 @@ export type CronJobCreate = Omit<CronJob, "id" | "createdAtMs" | "updatedAtMs" |
 
 /** Patch input accepted by cron APIs without allowing immutable identity fields. */
 export type CronJobPatch = Partial<
-  Omit<CronJob, "id" | "createdAtMs" | "state" | "payload" | "delivery">
+  Omit<CronJob, "id" | "createdAtMs" | "state" | "payload" | "delivery" | "failureAlert">
 > & {
   payload?: CronPayloadPatch;
   delivery?: CronDeliveryPatch;
+  failureAlert?: CronFailureAlertPatch | false;
   state?: Partial<CronJobState>;
 };

--- a/src/gateway/server-cron-notifications.test.ts
+++ b/src/gateway/server-cron-notifications.test.ts
@@ -3,9 +3,74 @@
 import { describe, expect, it, vi } from "vitest";
 import type { CliDeps } from "../cli/deps.types.js";
 import type { CronJob } from "../cron/types.js";
-import { dispatchGatewayCronFinishedNotifications } from "./server-cron-notifications.js";
+
+const mocks = vi.hoisted(() => ({
+  resolveCronDeliveryPlan: vi.fn(),
+  resolveFailureDestination: vi.fn(),
+  sendCronAnnouncePayloadStrict: vi.fn(async () => undefined),
+  sendFailureNotificationAnnounce: vi.fn(),
+}));
+
+vi.mock("../cron/delivery.js", () => ({
+  resolveCronDeliveryPlan: mocks.resolveCronDeliveryPlan,
+  resolveFailureDestination: mocks.resolveFailureDestination,
+  sendCronAnnouncePayloadStrict: mocks.sendCronAnnouncePayloadStrict,
+  sendFailureNotificationAnnounce: mocks.sendFailureNotificationAnnounce,
+}));
+
+import {
+  dispatchGatewayCronFinishedNotifications,
+  sendGatewayCronFailureAlert,
+} from "./server-cron-notifications.js";
 
 describe("dispatchGatewayCronFinishedNotifications", () => {
+  it("passes failure alert thread ids to announce delivery", async () => {
+    const deps = {} as CliDeps;
+    const cfg = {};
+    const logger = { warn: vi.fn() };
+    const job = {
+      id: "cron-thread",
+      name: "thread",
+      enabled: true,
+      createdAtMs: 1,
+      updatedAtMs: 1,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "hello" },
+      state: {},
+    } satisfies CronJob;
+
+    await sendGatewayCronFailureAlert({
+      deps,
+      logger,
+      resolveCronAgent: () => ({ agentId: "main", cfg }),
+      job,
+      text: "Cron failed",
+      channel: "telegram",
+      to: "123",
+      threadId: 79,
+      mode: "announce",
+      accountId: "bot-a",
+    });
+
+    expect(mocks.sendCronAnnouncePayloadStrict).toHaveBeenCalledWith({
+      deps,
+      cfg,
+      agentId: "main",
+      jobId: "cron-thread",
+      target: {
+        channel: "telegram",
+        to: "123",
+        threadId: 79,
+        accountId: "bot-a",
+        sessionKey: undefined,
+      },
+      message: "Cron failed",
+      abortSignal: expect.any(AbortSignal),
+    });
+  });
+
   it("redacts invalid completion webhook targets in warnings", () => {
     const logger = {
       warn: vi.fn(),

--- a/src/gateway/server-cron-notifications.ts
+++ b/src/gateway/server-cron-notifications.ts
@@ -152,6 +152,7 @@ export async function sendGatewayCronFailureAlert(params: {
   text: string;
   channel: CronMessageChannel;
   to?: string;
+  threadId?: string | number;
   mode?: "announce" | "webhook";
   accountId?: string;
 }): Promise<void> {
@@ -203,6 +204,7 @@ export async function sendGatewayCronFailureAlert(params: {
     target: {
       channel: params.channel,
       to: params.to,
+      threadId: params.threadId,
       accountId: params.accountId,
       sessionKey: resolveCronDeliverySessionKey(params.job),
     },

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -534,7 +534,7 @@ export function buildGatewayCronService(params: {
         },
       }).catch(() => {});
     },
-    sendCronFailureAlert: async ({ job, text, channel, to, mode, accountId }) =>
+    sendCronFailureAlert: async ({ job, text, channel, to, threadId, mode, accountId }) =>
       await sendGatewayCronFailureAlert({
         deps: params.deps,
         logger: cronLogger,
@@ -544,6 +544,7 @@ export function buildGatewayCronService(params: {
         text,
         channel,
         to,
+        threadId,
         mode,
         accountId,
       }),

--- a/src/state/openclaw-state-db.generated.d.ts
+++ b/src/state/openclaw-state-db.generated.d.ts
@@ -262,6 +262,7 @@ export interface CronJobs {
   failure_alert_disabled: number | null;
   failure_alert_include_skipped: number | null;
   failure_alert_mode: string | null;
+  failure_alert_thread_id: string | null;
   failure_alert_to: string | null;
   failure_delivery_account_id: string | null;
   failure_delivery_channel: string | null;

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -90,7 +90,7 @@ describe("openclaw state database", () => {
         bestEffort: true,
         failureDestination: { to: "https://example.invalid/hook" },
       },
-      failureAlert: { mode: "announce", channel: "discord", to: "ops", after: 2 },
+      failureAlert: { mode: "announce", channel: "discord", to: "ops", threadId: 79, after: 2 },
     });
     db.exec(`
       CREATE TABLE cron_jobs (
@@ -121,7 +121,7 @@ describe("openclaw state database", () => {
                   payload_model, agent_id, session_key, session_target, wake_mode, delivery_mode, delivery_channel,
                   delivery_to, delivery_account_id, delivery_best_effort, failure_delivery_mode,
                   failure_delivery_channel, failure_delivery_to, failure_delivery_account_id,
-                  failure_alert_mode, failure_alert_channel, failure_alert_to,
+                  failure_alert_mode, failure_alert_channel, failure_alert_to, failure_alert_thread_id,
                   failure_alert_after
              FROM cron_jobs
             WHERE job_id = ?`,
@@ -148,6 +148,7 @@ describe("openclaw state database", () => {
       failure_alert_after: 2,
       failure_alert_channel: "discord",
       failure_alert_mode: "announce",
+      failure_alert_thread_id: "79",
       failure_alert_to: "ops",
       failure_delivery_account_id: null,
       failure_delivery_channel: null,

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -406,6 +406,14 @@ function numberField(record: Record<string, unknown>, key: string): number | nul
   return typeof value === "number" && Number.isFinite(value) ? value : null;
 }
 
+function threadIdField(record: Record<string, unknown>, key: string): string | null {
+  const value = record[key];
+  if (typeof value === "string" && value.trim()) {
+    return value;
+  }
+  return typeof value === "number" && Number.isFinite(value) ? String(Math.trunc(value)) : null;
+}
+
 function recordField(record: Record<string, unknown>, key: string): Record<string, unknown> | null {
   const value = record[key];
   return value && typeof value === "object" && !Array.isArray(value)
@@ -520,6 +528,7 @@ function backfillCronJobsFromJobJson(db: DatabaseSync): void {
             failure_alert_after = ?,
             failure_alert_channel = ?,
             failure_alert_to = ?,
+            failure_alert_thread_id = ?,
             failure_alert_cooldown_ms = ?,
             failure_alert_include_skipped = ?,
             failure_alert_mode = ?,
@@ -599,7 +608,7 @@ function backfillCronJobsFromJobJson(db: DatabaseSync): void {
       delivery ? textField(delivery, "mode") : null,
       delivery ? textField(delivery, "channel") : null,
       delivery ? textField(delivery, "to") : null,
-      delivery ? textField(delivery, "threadId") : null,
+      delivery ? threadIdField(delivery, "threadId") : null,
       delivery ? textField(delivery, "accountId") : null,
       delivery && typeof delivery.bestEffort === "boolean" ? (delivery.bestEffort ? 1 : 0) : null,
       completionDestination ? textField(completionDestination, "mode") : null,
@@ -612,6 +621,7 @@ function backfillCronJobsFromJobJson(db: DatabaseSync): void {
       failureAlert ? numberField(failureAlert, "after") : null,
       failureAlert ? textField(failureAlert, "channel") : null,
       failureAlert ? textField(failureAlert, "to") : null,
+      failureAlert ? threadIdField(failureAlert, "threadId") : null,
       failureAlert ? numberField(failureAlert, "cooldownMs") : null,
       failureAlert && typeof failureAlert.includeSkipped === "boolean"
         ? failureAlert.includeSkipped
@@ -772,6 +782,7 @@ function ensureAdditiveStateColumns(db: DatabaseSync): void {
   ensureColumn(db, "cron_jobs", "failure_alert_after INTEGER");
   ensureColumn(db, "cron_jobs", "failure_alert_channel TEXT");
   ensureColumn(db, "cron_jobs", "failure_alert_to TEXT");
+  ensureColumn(db, "cron_jobs", "failure_alert_thread_id TEXT");
   ensureColumn(db, "cron_jobs", "failure_alert_cooldown_ms INTEGER");
   ensureColumn(db, "cron_jobs", "failure_alert_include_skipped INTEGER");
   ensureColumn(db, "cron_jobs", "failure_alert_mode TEXT");

--- a/src/state/openclaw-state-schema.generated.ts
+++ b/src/state/openclaw-state-schema.generated.ts
@@ -900,6 +900,7 @@ CREATE TABLE IF NOT EXISTS cron_jobs (
   failure_alert_after INTEGER,
   failure_alert_channel TEXT,
   failure_alert_to TEXT,
+  failure_alert_thread_id TEXT,
   failure_alert_cooldown_ms INTEGER,
   failure_alert_include_skipped INTEGER,
   failure_alert_mode TEXT,

--- a/src/state/openclaw-state-schema.sql
+++ b/src/state/openclaw-state-schema.sql
@@ -895,6 +895,7 @@ CREATE TABLE IF NOT EXISTS cron_jobs (
   failure_alert_after INTEGER,
   failure_alert_channel TEXT,
   failure_alert_to TEXT,
+  failure_alert_thread_id TEXT,
   failure_alert_cooldown_ms INTEGER,
   failure_alert_include_skipped INTEGER,
   failure_alert_mode TEXT,


### PR DESCRIPTION
## Summary
- Fixes #89848 by adding per-job `failureAlert.threadId` through cron schemas, CLI edit, storage, gateway send plumbing, and agent tool exposure.
- Route announce failure alerts to the explicit thread id, or inherit the primary delivery thread only when channel, target, and account match.
- Keep webhook failure alerts threadless and preserve invalid failure-alert fields for protocol validation.

## Real behavior proof
- Behavior addressed: cron failure alerts can store and preserve a Telegram topic/thread id separate from primary delivery.
- Real setup tested: local dev Gateway with a temporary OpenClaw profile. No live Telegram send.
- Steps run after the patch: added a cron with Telegram announce delivery using `--thread-id 79`; edited it with `--failure-alert --failure-alert-after 1 --failure-alert-thread-id 79`; ran `cron get` for the job.
- Evidence: copied terminal output from `pnpm openclaw cron get` showed:

```json
"delivery": {
  "mode": "announce",
  "channel": "telegram",
  "to": "-1001234567890",
  "threadId": 79
},
"failureAlert": {
  "after": 1,
  "threadId": 79
}
```

- Observed result: the saved job kept both `delivery.threadId` and `failureAlert.threadId` as `79`.
- Not tested: live Telegram delivery.

## Tests
- `node scripts/generate-kysely-types.mjs`
- `pnpm docs:list`
- `node scripts/run-vitest.mjs src/cron/service.failure-alert.test.ts src/cron/delivery.failure-notify.test.ts src/gateway/server-cron-notifications.test.ts src/gateway/server.cron.test.ts src/agents/tools/cron-tool.schema.test.ts src/agents/tools/cron-tool.test.ts src/cli/cron-cli.test.ts src/cron/store.test.ts src/state/openclaw-state-db.test.ts packages/gateway-protocol/src/cron-validators.test.ts src/cron/normalize.test.ts`
- `pnpm exec oxfmt --check --threads=1 $(git diff --name-only origin/main)`
- `git diff --check`
- `codex review --base origin/main` (addressed findings from completed runs; final rerun hit my local usage limit)

AI-assisted: yes.