### PR TITLE
fix(models): mask paste-token input in CLI auth prompt

### DIFF
--- a/src/commands/models/auth.test.ts
+++ b/src/commands/models/auth.test.ts
@@ -1288,7 +1288,7 @@ describe("modelsAuthLoginCommand", () => {
     }) as typeof process.exit);
     try {
       const cancelSymbol = Symbol.for("clack:cancel");
-      mocks.clackText.mockResolvedValue(cancelSymbol);
+      mocks.clackPassword.mockResolvedValue(cancelSymbol);
       mocks.clackIsCancel.mockImplementation((value: unknown) => value === cancelSymbol);
 
       await expect(modelsAuthPasteTokenCommand({ provider: "openai" }, runtime)).rejects.toThrow(
@@ -1303,9 +1303,24 @@ describe("modelsAuthLoginCommand", () => {
     }
   });
 
+  it("reads the pasted token through the masked password prompt", async () => {
+    const runtime = createRuntime();
+    mocks.clackPassword.mockResolvedValue("openai-token");
+
+    await modelsAuthPasteTokenCommand({ provider: "openai" }, runtime);
+
+    expect(mocks.clackPassword).toHaveBeenCalledTimes(1);
+    expect(mocks.clackText).not.toHaveBeenCalled();
+    expect(mocks.upsertAuthProfileWithLock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        credential: expect.objectContaining({ type: "token", token: "openai-token" }),
+      }),
+    );
+  });
+
   it("writes pasted Anthropic setup-tokens and logs the preference note", async () => {
     const runtime = createRuntime();
-    mocks.clackText.mockResolvedValue(`sk-ant-oat01-${"a".repeat(80)}`);
+    mocks.clackPassword.mockResolvedValue(`sk-ant-oat01-${"a".repeat(80)}`);
 
     await modelsAuthPasteTokenCommand({ provider: "anthropic" }, runtime);
 
@@ -1332,7 +1347,7 @@ describe("modelsAuthLoginCommand", () => {
   it("writes pasted tokens to the requested agent store", async () => {
     const runtime = createRuntime();
     useCoderAgentConfig();
-    mocks.clackText.mockResolvedValue("openai-token");
+    mocks.clackPassword.mockResolvedValue("openai-token");
 
     await modelsAuthPasteTokenCommand({ provider: "openai", agent: "coder" }, runtime);
 
@@ -1351,7 +1366,7 @@ describe("modelsAuthLoginCommand", () => {
   it("rejects pasted token expiries that cannot fit in the Date timestamp range", async () => {
     const runtime = createRuntime();
     const nowSpy = vi.spyOn(Date, "now").mockReturnValue(MAX_DATE_TIMESTAMP_MS);
-    mocks.clackText.mockResolvedValue("openai-token");
+    mocks.clackPassword.mockResolvedValue("openai-token");
     try {
       await expect(
         modelsAuthPasteTokenCommand({ provider: "openai", expiresIn: "1ms" }, runtime),
@@ -1367,7 +1382,7 @@ describe("modelsAuthLoginCommand", () => {
   it("rejects OpenAI API keys pasted as OpenAI Codex token material", async () => {
     const runtime = createRuntime();
     const validateMessages: string[] = [];
-    mocks.clackText.mockImplementation(
+    mocks.clackPassword.mockImplementation(
       async (params: { validate?: (value: string) => string | undefined }) => {
         const message = params.validate?.("sk-openai-chatgpt-api-key-value");
         if (message) {
@@ -1398,7 +1413,7 @@ describe("modelsAuthLoginCommand", () => {
       "paste-api-key --provider openai",
     );
 
-    expect(mocks.clackText).not.toHaveBeenCalled();
+    expect(mocks.clackPassword).not.toHaveBeenCalled();
     expect(mocks.upsertAuthProfileWithLock).not.toHaveBeenCalled();
     expect(mocks.updateConfig).not.toHaveBeenCalled();
   });
@@ -1412,7 +1427,7 @@ describe("modelsAuthLoginCommand", () => {
       "paste-api-key --provider openai",
     );
 
-    expect(mocks.clackText).not.toHaveBeenCalled();
+    expect(mocks.clackPassword).not.toHaveBeenCalled();
     expect(mocks.upsertAuthProfileWithLock).not.toHaveBeenCalled();
     expect(mocks.updateConfig).not.toHaveBeenCalled();
   });
@@ -1523,7 +1538,7 @@ describe("modelsAuthLoginCommand", () => {
       'Unknown agent id "missing". Use "openclaw agents list" to see configured agents.',
     );
 
-    expect(mocks.clackText).not.toHaveBeenCalled();
+    expect(mocks.clackPassword).not.toHaveBeenCalled();
     expect(mocks.upsertAuthProfileWithLock).not.toHaveBeenCalled();
     expect(mocks.updateConfig).not.toHaveBeenCalled();
   });
@@ -1659,10 +1674,8 @@ describe("modelsAuthLoginCommand", () => {
     useCoderAgentConfig();
     mocks.resolvePluginProviders.mockReturnValue([]);
     mocks.clackSelect.mockResolvedValue("custom");
-    mocks.clackText
-      .mockResolvedValueOnce("openai")
-      .mockResolvedValueOnce("openai:manual")
-      .mockResolvedValueOnce("openai-token");
+    mocks.clackText.mockResolvedValueOnce("openai").mockResolvedValueOnce("openai:manual");
+    mocks.clackPassword.mockResolvedValue("openai-token");
     mocks.clackConfirm.mockResolvedValue(false);
 
     await modelsAuthAddCommand({ agent: "coder" }, runtime);

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -679,7 +679,7 @@ export async function modelsAuthPasteTokenCommand(
   };
   const tokenInput = await readPastedSecret({
     message: `Paste token for ${provider}`,
-    masked: false,
+    masked: true,
     validate: validateTokenInput,
   });
   const token =


### PR DESCRIPTION
## Summary

What problem does this PR solve?
`openclaw models auth paste-token --provider <p>` echoes the pasted bearer/setup token in cleartext at the TTY prompt, exposing the secret to anyone who can see the screen.

Why does this matter now?
This is the third and last of three audited credential-prompt TTY echo leak sites. The first two were fixed in PR #76693 (onboarding) and PR #90571 (gateway password / Repro B). This closes Repro C.

What is the intended outcome?
The `paste-token` prompt renders as masked bullets, matching the already-masked sibling command `paste-api-key`.

What is intentionally out of scope?
No changes to stored values — masking is render-only; the persisted auth profile value remains the real typed string.

What does success look like?
Running `openclaw models auth paste-token --provider anthropic` shows a masked (bullet) prompt instead of cleartext echo.

What should reviewers focus on?
The one-line change in `modelsAuthPasteTokenCommand` (`masked: false → true`). Test reroutes from `clackText` to `clackPassword` mock. The new regression test that locks the masked routing.

## Linked context

Which issue does this close?

Closes # (none — discovered during credential-prompt audit)

Which issues, PRs, or discussions are related?

Related #76693 (onboarding password mask, merged)
Related #90571 (Repro B — gateway password mask, open)
Related #91059 (Repro A — gateway token mask, open)
Related #90894 ([verify] macOS TTY rendering)
Related #90895 ([verify] Linux TTY rendering)

Was this requested by a maintainer or owner?

No — discovered and fixed as part of a self-initiated credential-prompt audit.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: `paste-token` echoes typed token in cleartext at the TTY prompt
- Real environment tested: Windows 10 (build 19045.7291), native PowerShell window
- Exact steps or command run after this patch: `pnpm openclaw models auth paste-token --provider anthropic` — prompt renders bullets
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): <img width="1067" height="540" alt="repro-c_fix_model_token" src="https://github.com/user-attachments/assets/84551afb-bf14-4b33-a9b8-aa2b5c70c172"/>

- Observed result after fix: Token input renders as masked bullets instead of cleartext
- What was not tested: macOS and Linux TTY rendering (see #90894, #90895)
- Proof limitations or environment constraints: Windows-only repro environment. `@clack/prompts` `password()` is cross-platform; verify issues track macOS/Linux rendering separately.
- Before evidence (optional but encouraged): <img width="964" height="544" alt="repro-c_issue_model_token" src="https://github.com/user-attachments/assets/c4e78691-9796-441a-be07-6b326f221539"/>


## Tests and validation

Which commands did you run?

```
pnpm build ; pnpm check ; pnpm test
```

`pnpm check` failed on pre-existing TypeScript errors in `extensions/discord/src/` (unrelated to this diff — confirmed via `git diff origin/main --name-only` showing only `src/commands/models/auth.ts` and `src/commands/models/auth.test.ts`).

What regression coverage was added or updated?

Added `"reads the pasted token through the masked password prompt"` test that asserts `clackPassword` is called and `clackText` is not called. Rerouted 9 existing paste-token tests from `clackText` mock to `clackPassword` mock.

What failed before this fix, if known?

After flipping `masked: true`, all 9 paste-token tests that primed `clackText` failed. Fixed by rerouting each to `clackPassword`.

If no test was added, why not?

A regression test was added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes — the `paste-token` TTY prompt now masks input as bullets. The stored auth profile value is unchanged (masking is render-only; `normalizeSecretInput` runs in both paths).

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

Yes — improved: token is no longer visible in the terminal during entry. No behavioral change to auth logic.

What is the highest-risk area?

`readPastedSecret` dispatches to `password()` vs `text()` purely off the `masked` boolean. No other call site or stored value is affected.

How is that risk mitigated?

The regression test locks the masked routing. The sibling `paste-api-key` already uses `masked: true` as the reference implementation.

## Current review state

What is the next action?

Confirm CI is green, then flip to Ready for Review.

What is still waiting on author, maintainer, CI, or external proof?

- macOS TTY rendering verification — #90894
- Linux TTY rendering verification — #90895

Which bot or reviewer comments were addressed?

None yet (draft PR).

---

**AI-assisted PR:**
- [x] Marked as AI-assisted in the description
- [x] Human-run real behavior proof from your own setup (before/after screenshots attached above)
- [ ] Prompts or session logs (session logs available on request)
- [x] Confirmed understanding of the code change
- [x] Will resolve bot review conversations after addressing them