### PR TITLE
fix #90452: Regression: Heartbeat exec completion still shows generic fallback text instead of actual output

### DIFF
--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -2969,6 +2969,7 @@ export async function runEmbeddedAgent(
             lastToolError: attempt.lastToolError,
             config: params.config,
             isCronTrigger: params.trigger === "cron",
+            isHeartbeatTrigger: params.trigger === "heartbeat",
             sessionKey: params.sessionKey ?? params.sessionId,
             provider: activeErrorContext.provider,
             model: activeErrorContext.model,

--- a/src/agents/embedded-agent-runner/run/payloads.test.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.test.ts
@@ -447,6 +447,24 @@ describe("buildEmbeddedRunPayloads tool-error warnings", () => {
     });
   });
 
+  it("surfaces heartbeat exec tool output details when the task run fails", () => {
+    const payloads = buildPayloads({
+      lastToolError: {
+        toolName: "exec",
+        meta: "show last 20 lines of ~/.openclaw/workspace/memory/2026-06-04.md",
+        error:
+          "tail: cannot open '/home/user/.openclaw/workspace/memory/2026-06-04.md' for reading: No such file or directory",
+      },
+      isHeartbeatTrigger: true,
+      verboseLevel: "off",
+    });
+
+    expectSingleToolErrorPayload(payloads, {
+      title: "show last 20 lines",
+      detail: "No such file or directory",
+    });
+  });
+
   it("surfaces non-timeout exec tool errors for cron sessions without raw details", () => {
     const payloads = buildPayloads({
       lastToolError: { toolName: "exec", error: "Command not found" },

--- a/src/agents/embedded-agent-runner/run/payloads.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.ts
@@ -138,11 +138,17 @@ function shouldIncludeToolErrorDetails(params: {
   if (isVerboseToolDetailEnabled(params.verboseLevel)) {
     return true;
   }
+  if (!isExecLikeToolName(params.lastToolError.toolName)) {
+    return false;
+  }
+  // Heartbeat runs usually have no assistant reply to carry the command
+  // output, so keep exec details in the warning instead of a generic label.
+  if (params.isHeartbeatTrigger === true) {
+    return true;
+  }
   return (
-    isExecLikeToolName(params.lastToolError.toolName) &&
-    (params.isHeartbeatTrigger === true ||
-      (params.lastToolError.timedOut === true &&
-        (params.isCronTrigger === true || isCronSessionKey(params.sessionKey))))
+    params.lastToolError.timedOut === true &&
+    (params.isCronTrigger === true || isCronSessionKey(params.sessionKey))
   );
 }
 

--- a/src/agents/embedded-agent-runner/run/payloads.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.ts
@@ -131,6 +131,7 @@ function normalizeReplyTextForComparison(text: string): string {
 function shouldIncludeToolErrorDetails(params: {
   lastToolError: ToolErrorSummary;
   isCronTrigger?: boolean;
+  isHeartbeatTrigger?: boolean;
   sessionKey: string;
   verboseLevel?: VerboseLevel;
 }): boolean {
@@ -139,8 +140,9 @@ function shouldIncludeToolErrorDetails(params: {
   }
   return (
     isExecLikeToolName(params.lastToolError.toolName) &&
-    params.lastToolError.timedOut === true &&
-    (params.isCronTrigger === true || isCronSessionKey(params.sessionKey))
+    (params.isHeartbeatTrigger === true ||
+      (params.lastToolError.timedOut === true &&
+        (params.isCronTrigger === true || isCronSessionKey(params.sessionKey))))
   );
 }
 
@@ -161,6 +163,7 @@ function resolveToolErrorWarningPolicy(params: {
   suppressToolErrors: boolean;
   suppressToolErrorWarnings?: boolean | (() => boolean | undefined);
   isCronTrigger?: boolean;
+  isHeartbeatTrigger?: boolean;
   sessionKey: string;
   verboseLevel?: VerboseLevel;
 }): ToolErrorWarningPolicy {
@@ -221,6 +224,7 @@ export function buildEmbeddedRunPayloads(params: {
   lastToolError?: ToolErrorSummary;
   config?: OpenClawConfig;
   isCronTrigger?: boolean;
+  isHeartbeatTrigger?: boolean;
   sessionKey: string;
   provider?: string;
   model?: string;
@@ -521,6 +525,7 @@ export function buildEmbeddedRunPayloads(params: {
       suppressToolErrors: Boolean(params.config?.messages?.suppressToolErrors),
       suppressToolErrorWarnings: params.suppressToolErrorWarnings,
       isCronTrigger: params.isCronTrigger,
+      isHeartbeatTrigger: params.isHeartbeatTrigger,
       sessionKey: params.sessionKey,
       verboseLevel: params.verboseLevel,
     });


### PR DESCRIPTION
## Summary

- Problem: heartbeat-triggered exec task failures could still be summarized as a generic `🛠️ ... failed` fallback instead of showing the command's captured error/output.
- Solution: mark embedded runner payload construction when the trigger is `heartbeat` and allow exec-like heartbeat tool failures to include the collected error details.
- What changed: `buildEmbeddedRunPayloads` now receives `isHeartbeatTrigger`, threads it into the tool-error warning policy, and has a regression test for the HEARTBEAT.md tail failure shape from the issue.
- What did NOT change: cron timeout handling, non-heartbeat compact tool-error behavior, channel delivery, and heartbeat scheduling are unchanged.

Fixes #90452

## Real behavior proof

- **Behavior or issue addressed:** Heartbeat exec task failures now surface the actual exec error details in the generated payload instead of only emitting the generic fallback text.
- **Real environment tested:** Local Linux OpenClaw worktree at `/media/vdc/code/ai/aispace/openclaw-worktrees/issue-90452`, calling the production embedded-runner payload builder with `node --import tsx`.
- **Exact steps or command run after this patch:**
  ```bash
  env -C "/media/vdc/code/ai/aispace/openclaw-worktrees/issue-90452" node --import tsx -e 'import { buildEmbeddedRunPayloads } from "./src/agents/embedded-agent-runner/run/payloads.ts"; const payloads = buildEmbeddedRunPayloads({ assistantTexts: [], toolMetas: [], lastAssistant: undefined, currentAssistant: undefined, lastToolError: { toolName: "exec", meta: "show last 20 lines of ~/.openclaw/workspace/memory/2026-06-04.md", error: "tail: cannot open '\''/home/user/.openclaw/workspace/memory/2026-06-04.md'\'' for reading: No such file or directory" }, isCronTrigger: false, isHeartbeatTrigger: true, sessionKey: "session:heartbeat", inlineToolResultsAllowed: false, verboseLevel: "off", reasoningLevel: "off", toolResultFormat: "plain" }); console.log(JSON.stringify(payloads, null, 2)); if (!payloads[0]?.text?.includes("No such file or directory")) process.exit(1);'
  ```
- **Evidence after fix:**
  ```json
  [
    {
      "text": "⚠️ 🛠️ show last 20 lines of ~/.openclaw/workspace/memory/2026-06-04.md failed: tail: cannot open '/home/user/.openclaw/workspace/memory/2026-06-04.md' for reading: No such file or directory",
      "isError": true
    }
  ]
  ```
- **Observed result after fix:** The heartbeat exec failure payload includes the real `tail` error and `No such file or directory` detail that the previous generic fallback omitted.
- **What was not tested:** I did not wait for a wall-clock HEARTBEAT.md interval or deliver through an external messaging channel; the proof exercises the local embedded-runner heartbeat payload path that formats the exec failure before channel delivery.

## Regression Test Plan

- Coverage level: focused regression test plus related heartbeat/agent shards.
- Target test file: `src/agents/embedded-agent-runner/run/payloads.test.ts`.
- Scenario locked in: heartbeat-triggered exec failure for `show last 20 lines of ~/.openclaw/workspace/memory/2026-06-04.md` includes `No such file or directory` in the payload.
- Why this is the smallest reliable guardrail: the bug was in the embedded-runner payload warning policy, so this directly covers the formatting decision that previously dropped the exec error details.

Commands run:

```bash
env -C "/media/vdc/code/ai/aispace/openclaw-worktrees/issue-90452" node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/payloads.test.ts src/infra/heartbeat-events-filter.test.ts src/infra/heartbeat-runner.ghost-reminder.test.ts src/agents/bash-tools.test.ts
env -C "/media/vdc/code/ai/aispace/openclaw-worktrees/issue-90452" ./node_modules/.bin/oxfmt --check --threads=1 src/agents/embedded-agent-runner/run.ts src/agents/embedded-agent-runner/run/payloads.ts src/agents/embedded-agent-runner/run/payloads.test.ts
env -C "/media/vdc/code/ai/aispace/openclaw-worktrees/issue-90452" node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo
git -C "/media/vdc/code/ai/aispace/openclaw-worktrees/issue-90452" diff --check
```

Observed test output:

```text
[test] passed 3 Vitest shards in 34.97s

Checking formatting...

All matched files use the correct format.
```

`tsgo:core` and `git diff --check` completed with no output and exit code 0.

## Merge risk

- **Why it matters / User impact:** HEARTBEAT.md exec tasks that fail should tell the user what the command reported, especially for filesystem or shell errors where the command output is the actionable part.
- **Risk labels considered:** `merge-risk:runtime-behavior`, `merge-risk:low`.
- **Risk explanation:** The change only affects embedded-runner tool-error payload formatting when the active trigger is `heartbeat`; cron timeout handling and ordinary compact tool-error behavior keep their existing conditions.
- **Why acceptable:** The output was already collected in `lastToolError.error`; this only makes heartbeat exec-like failures eligible to surface that existing detail instead of dropping it.
- **Fix classification:** Root-cause regression fix with a focused regression test.
- **Maintainer-ready confidence:** High for the local payload-formatting path: production function proof, focused regression test, related heartbeat tests, formatting, typecheck, and diff whitespace checks all pass.
- **Patch quality notes:** Small 3-file patch, no public API, config, schema, dependency, channel delivery, or scheduler changes.
- **Why this is root-cause fix:** The missing trigger classification in the payload warning policy caused the real exec error to be omitted; threading `isHeartbeatTrigger` through that policy fixes the decision point directly.

## Root Cause

- Root cause: embedded runner payloads only included exec tool error details for verbose mode or cron timeout cases; heartbeat-triggered exec failures were not marked as a detail-eligible trigger, so `lastToolError.error` was dropped.
- Missing detection / guardrail: there was no regression test covering heartbeat-triggered exec-like tool failures with captured stderr/stdout details.
