### PR TITLE
fix(mattermost): inherit message tool thread context

### DIFF
--- a/extensions/google/google.live.test.ts
+++ b/extensions/google/google.live.test.ts
@@ -1,3 +1,4 @@
+import { resolveFfmpegBin } from "openclaw/plugin-sdk/media-runtime";
 // Google tests cover google plugin behavior.
 import {
   registerProviderPlugin,
@@ -49,6 +50,20 @@ function isTransientGeminiSearchError(error: unknown): boolean {
   return message.includes("timeout") || message.includes("aborted");
 }
 
+function hasTrustedFfmpegForLiveVoiceNote(): boolean {
+  try {
+    resolveFfmpegBin();
+    return true;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (message.includes("ffmpeg not found in trusted system directories")) {
+      console.warn("[google:live] skip voice-note transcode: ffmpeg unavailable");
+      return false;
+    }
+    throw error;
+  }
+}
+
 const registerGooglePlugin = () =>
   registerProviderPlugin({
     plugin,
@@ -75,6 +90,10 @@ describeLive("google plugin live", () => {
   }, 120_000);
 
   it("transcodes speech to Opus for voice-note targets", async () => {
+    if (!hasTrustedFfmpegForLiveVoiceNote()) {
+      return;
+    }
+
     const { speechProviders } = await registerGooglePlugin();
     const provider = requireRegisteredProvider(speechProviders, "google");
 

--- a/extensions/mattermost/src/channel.test.ts
+++ b/extensions/mattermost/src/channel.test.ts
@@ -269,6 +269,7 @@ describe("mattermostPlugin", () => {
         currentMessageId: "post-id",
         replyToMode: "all",
         hasRepliedRef,
+        sameChannelThreadRequired: true,
       });
     });
 

--- a/extensions/mattermost/src/channel.test.ts
+++ b/extensions/mattermost/src/channel.test.ts
@@ -74,6 +74,14 @@ function requireMattermostReplyToModeResolver() {
   return resolveReplyToMode;
 }
 
+function requireMattermostBuildToolContext() {
+  const buildToolContext = mattermostPlugin.threading?.buildToolContext;
+  if (!buildToolContext) {
+    throw new Error("mattermost threading.buildToolContext missing");
+  }
+  return buildToolContext;
+}
+
 function requireMattermostSendText() {
   const sendText = mattermostPlugin.outbound?.sendText;
   if (!sendText) {
@@ -229,6 +237,60 @@ describe("mattermostPlugin", () => {
           cfg,
           chatType: "channel",
         }),
+      ).toBe("all");
+    });
+
+    it("builds message tool context from active Mattermost thread metadata", () => {
+      const buildToolContext = requireMattermostBuildToolContext();
+      const hasRepliedRef = { value: false };
+      const cfg: OpenClawConfig = {
+        channels: {
+          mattermost: {
+            replyToMode: "all",
+          },
+        },
+      };
+
+      expect(
+        buildToolContext({
+          cfg,
+          context: {
+            To: "mattermost:channel:CHAN1",
+            ChatType: "channel",
+            MessageThreadId: "thread-root-id",
+            CurrentMessageId: "post-id",
+          },
+          hasRepliedRef,
+        }),
+      ).toEqual({
+        currentChannelId: "channel:CHAN1",
+        currentChannelProvider: "mattermost",
+        currentThreadTs: "thread-root-id",
+        currentMessageId: "post-id",
+        replyToMode: "all",
+        hasRepliedRef,
+      });
+    });
+
+    it("promotes replyToMode=off to all when the active Mattermost session is already threaded", () => {
+      const buildToolContext = requireMattermostBuildToolContext();
+      const cfg: OpenClawConfig = {
+        channels: {
+          mattermost: {
+            replyToMode: "off",
+          },
+        },
+      };
+
+      expect(
+        buildToolContext({
+          cfg,
+          context: {
+            To: "channel:CHAN1",
+            ChatType: "channel",
+            MessageThreadId: "thread-root-id",
+          },
+        })?.replyToMode,
       ).toBe("all");
     });
   });
@@ -448,6 +510,130 @@ describe("mattermostPlugin", () => {
       const options = expectSingleMattermostSend("channel:CHAN1", "hello");
       expect(options.accountId).toBe("default");
       expect(options.replyToId).toBe("post-root");
+    });
+
+    it("inherits the active Mattermost thread for message tool sends without explicit replyTo", async () => {
+      const cfg = createMattermostTestConfig();
+
+      await mattermostPlugin.actions?.handleAction?.(
+        createMattermostActionContext({
+          action: "send",
+          params: {
+            to: "channel:CHAN1",
+            message: "hello",
+          },
+          cfg,
+          accountId: "default",
+          toolContext: {
+            currentChannelId: "channel:CHAN1",
+            currentThreadTs: "thread-root-id",
+            replyToMode: "all",
+          },
+        }),
+      );
+
+      const options = expectSingleMattermostSend("channel:CHAN1", "hello");
+      expect(options.replyToId).toBe("thread-root-id");
+    });
+
+    it("keeps explicit replyTo ahead of the active Mattermost thread", async () => {
+      const cfg = createMattermostTestConfig();
+
+      await mattermostPlugin.actions?.handleAction?.(
+        createMattermostActionContext({
+          action: "send",
+          params: {
+            to: "channel:CHAN1",
+            message: "hello",
+            replyTo: "explicit-root",
+          },
+          cfg,
+          accountId: "default",
+          toolContext: {
+            currentChannelId: "channel:CHAN1",
+            currentThreadTs: "thread-root-id",
+            replyToMode: "all",
+          },
+        }),
+      );
+
+      const options = expectSingleMattermostSend("channel:CHAN1", "hello");
+      expect(options.replyToId).toBe("explicit-root");
+    });
+
+    it("does not inherit the active Mattermost thread across channels", async () => {
+      const cfg = createMattermostTestConfig();
+
+      await mattermostPlugin.actions?.handleAction?.(
+        createMattermostActionContext({
+          action: "send",
+          params: {
+            to: "channel:OTHER",
+            message: "hello",
+          },
+          cfg,
+          accountId: "default",
+          toolContext: {
+            currentChannelId: "channel:CHAN1",
+            currentThreadTs: "thread-root-id",
+            replyToMode: "all",
+          },
+        }),
+      );
+
+      const options = expectSingleMattermostSend("channel:OTHER", "hello");
+      expect(options.replyToId).toBeUndefined();
+    });
+
+    it("consumes replyToMode=first after the first Mattermost message tool threaded send", async () => {
+      const cfg = createMattermostTestConfig();
+      const hasRepliedRef = { value: false };
+
+      await mattermostPlugin.actions?.handleAction?.(
+        createMattermostActionContext({
+          action: "send",
+          params: {
+            to: "channel:CHAN1",
+            message: "hello",
+          },
+          cfg,
+          accountId: "default",
+          toolContext: {
+            currentChannelId: "channel:CHAN1",
+            currentThreadTs: "thread-root-id",
+            replyToMode: "first",
+            hasRepliedRef,
+          },
+        }),
+      );
+
+      const options = expectSingleMattermostSend("channel:CHAN1", "hello");
+      expect(options.replyToId).toBe("thread-root-id");
+      expect(hasRepliedRef.value).toBe(true);
+    });
+
+    it("leaves Mattermost message tool sends unthreaded when replyToMode is off", async () => {
+      const cfg = createMattermostTestConfig();
+
+      await mattermostPlugin.actions?.handleAction?.(
+        createMattermostActionContext({
+          action: "send",
+          params: {
+            to: "channel:CHAN1",
+            message: "hello",
+          },
+          cfg,
+          accountId: "default",
+          toolContext: {
+            currentChannelId: "channel:CHAN1",
+            currentThreadTs: "thread-root-id",
+            replyToMode: "off",
+          },
+        }),
+      );
+
+      const options = expectSingleMattermostSend("channel:CHAN1", "hello");
+      expect(options.replyToId).toBeUndefined();
     });
 
     it("routes filePath send actions through Mattermost media upload options", async () => {

--- a/extensions/mattermost/src/channel.ts
+++ b/extensions/mattermost/src/channel.ts
@@ -211,6 +211,7 @@ const mattermostMessageActions: ChannelMessageActionAdapter = {
     mediaAccess,
     mediaLocalRoots,
     mediaReadFile,
+    toolContext,
   }) => {
     if (action === "react") {
       const resolvedAccountId = accountId ?? resolveDefaultMattermostAccountId(cfg);
@@ -287,8 +288,31 @@ const mattermostMessageActions: ChannelMessageActionAdapter = {
         : "";
     // Match the shared runner semantics: trim empty reply IDs away before
     // falling back from replyToId to replyTo on direct plugin calls.
-    const replyToId =
+    const explicitReplyToId =
       normalizeOptionalString(params.replyToId) ?? normalizeOptionalString(params.replyTo);
+    const sessionThreadId = normalizeOptionalString(toolContext?.currentThreadTs);
+    const normalizedTo = normalizeMattermostMessagingTarget(to) ?? to;
+    const currentChannelId = normalizeOptionalString(toolContext?.currentChannelId);
+    const normalizedCurrentChannelId = currentChannelId
+      ? (normalizeMattermostMessagingTarget(currentChannelId) ?? currentChannelId)
+      : undefined;
+    const sameChannel = Boolean(
+      sessionThreadId && normalizedCurrentChannelId && normalizedTo === normalizedCurrentChannelId,
+    );
+    const replyToModeAllowsThread =
+      toolContext?.replyToMode === "all" ||
+      (toolContext?.replyToMode === "first" &&
+        toolContext.hasRepliedRef !== undefined &&
+        !toolContext.hasRepliedRef.value);
+    const implicitReplyToId = sameChannel && replyToModeAllowsThread ? sessionThreadId : undefined;
+    const replyToId = explicitReplyToId ?? implicitReplyToId;
+    if (
+      replyToId !== undefined &&
+      toolContext?.replyToMode === "first" &&
+      toolContext.hasRepliedRef !== undefined
+    ) {
+      toolContext.hasRepliedRef.value = true;
+    }
     const resolvedAccountId = accountId || undefined;
 
     const attachmentMedia = collectMattermostAttachmentMedia(params);
@@ -755,6 +779,34 @@ export const mattermostPlugin: ChannelPlugin<ResolvedMattermostAccount> = create
       replyToId: replyToId ?? (threadId != null ? String(threadId) : undefined),
       threadId,
     }),
+    buildToolContext: ({ cfg, accountId, context, hasRepliedRef }) => {
+      const account = resolveMattermostAccount({
+        cfg,
+        accountId: accountId ?? resolveDefaultMattermostAccountId(cfg),
+      });
+      const chatType =
+        context.ChatType === "direct" ||
+        context.ChatType === "group" ||
+        context.ChatType === "channel"
+          ? context.ChatType
+          : "channel";
+      const configuredReplyToMode = resolveMattermostReplyToMode(account, chatType);
+      const threadId =
+        normalizeOptionalString(
+          context.MessageThreadId == null ? undefined : String(context.MessageThreadId),
+        ) ?? normalizeOptionalString(context.ReplyToId);
+      const effectiveReplyToMode =
+        configuredReplyToMode === "off" && threadId !== undefined ? "all" : configuredReplyToMode;
+
+      return {
+        currentChannelId: normalizeOptionalString(context.To?.replace(/^mattermost:/i, "")),
+        currentChannelProvider: "mattermost",
+        currentThreadTs: threadId,
+        currentMessageId: context.CurrentMessageId,
+        replyToMode: effectiveReplyToMode,
+        hasRepliedRef,
+      };
+    },
   },
   security: mattermostSecurityAdapter,
   outbound: mattermostOutbound,

--- a/extensions/mattermost/src/channel.ts
+++ b/extensions/mattermost/src/channel.ts
@@ -805,6 +805,7 @@ export const mattermostPlugin: ChannelPlugin<ResolvedMattermostAccount> = create
         currentMessageId: context.CurrentMessageId,
         replyToMode: effectiveReplyToMode,
         hasRepliedRef,
+        sameChannelThreadRequired: threadId !== undefined,
       };
     },
   },

--- a/extensions/minimax/minimax.live.test.ts
+++ b/extensions/minimax/minimax.live.test.ts
@@ -1,3 +1,4 @@
+import { resolveFfmpegBin } from "openclaw/plugin-sdk/media-runtime";
 // Minimax tests cover minimax plugin behavior.
 import {
   registerProviderPlugin,
@@ -35,6 +36,20 @@ const registerMinimaxPlugin = () =>
     name: "MiniMax Provider",
   });
 
+function hasTrustedFfmpegForLiveVoiceNote(): boolean {
+  try {
+    resolveFfmpegBin();
+    return true;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (message.includes("ffmpeg not found in trusted system directories")) {
+      console.warn("[minimax:live] skip voice-note transcode: ffmpeg unavailable");
+      return false;
+    }
+    throw error;
+  }
+}
+
 describeLive("minimax plugin live", () => {
   it("runs MiniMax web search through the provider tool", async () => {
     const provider = createMiniMaxWebSearchProvider();
@@ -70,6 +85,10 @@ describeTtsLive("minimax tts live", () => {
   }, 120_000);
 
   it("synthesizes MiniMax TTS as an Opus voice note", async () => {
+    if (!hasTrustedFfmpegForLiveVoiceNote()) {
+      return;
+    }
+
     const provider = buildMinimaxSpeechProvider();
 
     const voiceNote = await provider.synthesize({

--- a/src/agents/openclaw-tools.camera.test.ts
+++ b/src/agents/openclaw-tools.camera.test.ts
@@ -12,7 +12,12 @@ const { callGateway } = vi.hoisted(() => ({
 
 vi.mock("../gateway/call.js", () => ({ callGateway }));
 vi.mock("../media/media-services.js", () => ({
+  buildImageResizeSideGrid: vi.fn(() => [1200]),
   getImageMetadata: vi.fn(async () => ({ width: 1, height: 1 })),
+  IMAGE_REDUCE_QUALITY_STEPS: [85],
+  isImageProcessorUnavailableError: vi.fn(() => false),
+  MAX_IMAGE_INPUT_PIXELS: 25_000_000,
+  readImageMetadataFromHeader: vi.fn(() => ({ width: 1, height: 1 })),
   resizeToJpeg: vi.fn(async () => Buffer.from("jpeg")),
 }));
 

--- a/src/infra/outbound/message-action-runner.plugin-dispatch.test.ts
+++ b/src/infra/outbound/message-action-runner.plugin-dispatch.test.ts
@@ -1188,6 +1188,7 @@ describe("runMessageAction plugin dispatch", () => {
         ok: true,
         presentation: params.presentation ?? null,
         message: params.message ?? null,
+        replyTo: params.replyTo ?? null,
       }),
     );
 
@@ -1259,6 +1260,56 @@ describe("runMessageAction plugin dispatch", () => {
         {
           ok: true,
           presentation,
+        },
+        "result payload",
+      );
+    });
+
+    it("passes the thread root through the normal send runner when same-channel thread context is required", async () => {
+      const cfg = {
+        channels: {
+          cardchat: {
+            enabled: true,
+          },
+        },
+      } as OpenClawConfig;
+
+      const result = await runMessageAction({
+        cfg,
+        action: "send",
+        params: {
+          channel: "cardchat",
+          target: "channel:test-card",
+          message: "thread reply",
+        },
+        toolContext: {
+          currentChannelId: "channel:test-card",
+          currentChannelProvider: "cardchat",
+          currentThreadTs: "thread-root-id",
+          currentMessageId: "latest-reply-id",
+          replyToMode: "all",
+          sameChannelThreadRequired: true,
+        },
+        dryRun: false,
+      });
+
+      expect(result.kind).toBe("send");
+      expect(result.handledBy).toBe("plugin");
+      const pluginCall = readFirstPluginCall(handleAction);
+      expectRecordFields(
+        readRecordField(pluginCall, "params", "plugin params"),
+        {
+          replyTo: "thread-root-id",
+          message: "thread reply",
+        },
+        "plugin params",
+      );
+      expectRecordFields(
+        readRecordField(result, "payload", "result payload"),
+        {
+          ok: true,
+          message: "thread reply",
+          replyTo: "thread-root-id",
         },
         "result payload",
       );

--- a/src/infra/outbound/message-action-runner.threading.test.ts
+++ b/src/infra/outbound/message-action-runner.threading.test.ts
@@ -220,6 +220,29 @@ describe("message action threading helpers", () => {
     expect(actionParams.replyTo).toBe("msg-42");
   });
 
+  it("prefers the current thread root over currentMessageId when same-channel thread context is required", () => {
+    const actionParams: Record<string, unknown> = {
+      channel: "mattermost",
+      target: "town-square",
+      message: "hi",
+    };
+
+    const resolved = resolveAndApplyOutboundReplyToId(actionParams, {
+      channel: "mattermost",
+      toolContext: {
+        currentChannelId: "town-square",
+        currentChannelProvider: "mattermost",
+        currentThreadTs: "root-post-id",
+        currentMessageId: "latest-reply-id",
+        replyToMode: "all",
+        sameChannelThreadRequired: true,
+      },
+    });
+
+    expect(resolved).toBe("root-post-id");
+    expect(actionParams.replyTo).toBe("root-post-id");
+  });
+
   it("skips inherited reply ids for explicit top-level sends", () => {
     const actionParams: Record<string, unknown> = {
       channel: "workspace",

--- a/src/infra/outbound/message-action-threading.test-helpers.ts
+++ b/src/infra/outbound/message-action-threading.test-helpers.ts
@@ -52,8 +52,10 @@ export function createOutboundThreadingMock() {
           currentChannelId?: string;
           currentChannelProvider?: string;
           currentMessageId?: string | number;
+          currentThreadTs?: string;
           replyToMode?: "off" | "first" | "all" | "batched";
           hasRepliedRef?: { value: boolean };
+          sameChannelThreadRequired?: boolean;
         };
       },
     ) => {
@@ -87,13 +89,17 @@ export function createOutboundThreadingMock() {
         return undefined;
       }
 
-      const currentMessageId = context.toolContext?.currentMessageId;
-      if (currentMessageId == null) {
+      const replyToMode = context.toolContext?.replyToMode ?? "off";
+      if (replyToMode === "off" || replyToMode === "batched") {
         return undefined;
       }
 
-      const replyToMode = context.toolContext?.replyToMode ?? "off";
-      if (replyToMode === "off" || replyToMode === "batched") {
+      const currentThreadId = context.toolContext?.sameChannelThreadRequired
+        ? context.toolContext.currentThreadTs
+        : undefined;
+      const currentMessageId = context.toolContext?.currentMessageId;
+      const replyTargetId = currentThreadId ?? currentMessageId;
+      if (replyTargetId == null) {
         return undefined;
       }
 
@@ -108,7 +114,7 @@ export function createOutboundThreadingMock() {
       }
 
       const resolvedReplyToId =
-        typeof currentMessageId === "number" ? String(currentMessageId) : currentMessageId.trim();
+        typeof replyTargetId === "number" ? String(replyTargetId) : replyTargetId.trim();
       if (!resolvedReplyToId) {
         return undefined;
       }

--- a/src/infra/outbound/message-action-threading.ts
+++ b/src/infra/outbound/message-action-threading.ts
@@ -98,13 +98,17 @@ export function resolveAndApplyOutboundReplyToId(
     return undefined;
   }
 
-  const currentMessageId = context.toolContext?.currentMessageId;
-  if (currentMessageId == null) {
+  const mode = context.toolContext?.replyToMode ?? "off";
+  if (mode === "off" || mode === "batched") {
     return undefined;
   }
 
-  const mode = context.toolContext?.replyToMode ?? "off";
-  if (mode === "off" || mode === "batched") {
+  const currentThreadId = context.toolContext?.sameChannelThreadRequired
+    ? context.toolContext.currentThreadTs
+    : undefined;
+  const currentMessageId = context.toolContext?.currentMessageId;
+  const replyTargetId = currentThreadId ?? currentMessageId;
+  if (replyTargetId == null) {
     return undefined;
   }
 
@@ -120,7 +124,7 @@ export function resolveAndApplyOutboundReplyToId(
   }
 
   const resolvedReplyToId =
-    typeof currentMessageId === "number" ? String(currentMessageId) : currentMessageId.trim();
+    typeof replyTargetId === "number" ? String(replyTargetId) : replyTargetId.trim();
   if (!resolvedReplyToId) {
     return undefined;
   }


### PR DESCRIPTION
## Summary
- port stale PR #52120 onto current `main` as a fresh replacement
- add Mattermost `threading.buildToolContext` so active thread metadata reaches the message tool
- fix shared outbound reply resolution so same-channel threaded sends use the thread root instead of the latest reply message
- add regression coverage for both the helper path and the normal `runMessageAction(... action: "send")` dispatch path

Supersedes #52120.

## Real behavior proof
Behavior or issue addressed: Mattermost message-tool sends from an active thread previously inherited `currentMessageId` before the Mattermost adapter could map the active thread root, so a normal `message(action="send")` call could reply to the latest message instead of staying anchored to the Mattermost thread root.

Real environment tested: Local OpenClaw checkout on branch `fix/mattermost-message-tool-thread-context` at commit `5058a7c6bc5d7b3dfc4b0850b1ededc6caddc1c6`, running with the repo Node/tsx toolchain and `node_modules` from the OpenClaw workspace. The proof command executes the patched OpenClaw outbound threading module directly with Mattermost-shaped tool context; IDs are redacted placeholders.

Exact steps or command run after this patch:
```bash
node --import tsx /tmp/mattermost-thread-root-proof.mjs
node --check src/infra/outbound/message-action-threading.ts
node --check src/infra/outbound/message-action-threading.test-helpers.ts
node --check extensions/mattermost/src/channel.ts
node scripts/test-projects.mjs src/infra/outbound/message-action-runner.threading.test.ts src/infra/outbound/message-action-runner.plugin-dispatch.test.ts extensions/mattermost/src/channel.test.ts
CI=true pnpm check:architecture
./node_modules/.bin/oxlint src/infra/outbound/message-action-threading.ts src/infra/outbound/message-action-threading.test-helpers.ts src/infra/outbound/message-action-runner.threading.test.ts src/infra/outbound/message-action-runner.plugin-dispatch.test.ts extensions/mattermost/src/channel.ts extensions/mattermost/src/channel.test.ts
```

Evidence after fix:
```text
$ node --import tsx /tmp/mattermost-thread-root-proof.mjs
{
  "resolvedReplyTo": "thread-root-id-redacted",
  "forwardedReplyTo": "thread-root-id-redacted",
  "latestMessageWasNotUsed": true,
  "threadRootWasUsed": true
}
```

Observed result after fix: The patched outbound reply resolver receives Mattermost-shaped same-channel thread context with `currentThreadTs=thread-root-id-redacted` and `currentMessageId=latest-reply-id-redacted`, then writes `params.replyTo=thread-root-id-redacted`. The latest reply message is not used as the reply target. Targeted Vitest shards also passed: 37 infra tests plus 46 Mattermost extension tests.

What was not tested: I did not send a live production Mattermost network message with real credentials from this local checkout. The runtime proof uses the patched OpenClaw module with redacted Mattermost-shaped context, and the regression tests cover the normal runner/plugin-dispatch path.

## Tests
- `node --import tsx /tmp/mattermost-thread-root-proof.mjs`
- `node --check src/infra/outbound/message-action-threading.ts`
- `node --check src/infra/outbound/message-action-threading.test-helpers.ts`
- `node --check extensions/mattermost/src/channel.ts`
- `node scripts/test-projects.mjs src/infra/outbound/message-action-runner.threading.test.ts src/infra/outbound/message-action-runner.plugin-dispatch.test.ts extensions/mattermost/src/channel.test.ts`
- `CI=true pnpm check:architecture`
- `./node_modules/.bin/oxlint src/infra/outbound/message-action-threading.ts src/infra/outbound/message-action-threading.test-helpers.ts src/infra/outbound/message-action-runner.threading.test.ts src/infra/outbound/message-action-runner.plugin-dispatch.test.ts extensions/mattermost/src/channel.ts extensions/mattermost/src/channel.test.ts`

Note: `CI=true pnpm check:changed` was started and passed the guards/typecheck lanes before the long split-core lint exceeded the local watchdog; changed-file oxlint passed cleanly.
