### PR TITLE
fix(mcp): include image source for screenshot results

### DIFF
--- a/src/mcp/plugin-tools-handlers.ts
+++ b/src/mcp/plugin-tools-handlers.ts
@@ -25,6 +25,10 @@ function toMcpContentBlock(block: unknown): unknown {
     return block;
   }
 
+  if (typeof block.data === "string" && typeof block.mimeType === "string") {
+    return block;
+  }
+
   const source = block.source;
   if (
     isRecord(source) &&
@@ -32,17 +36,10 @@ function toMcpContentBlock(block: unknown): unknown {
     typeof source.data === "string" &&
     typeof source.media_type === "string"
   ) {
-    return block;
-  }
-
-  if (typeof block.data === "string" && typeof block.mimeType === "string") {
     return {
       type: "image",
-      source: {
-        type: "base64",
-        media_type: block.mimeType,
-        data: block.data,
-      },
+      data: source.data,
+      mimeType: source.media_type,
     };
   }
 

--- a/src/mcp/plugin-tools-handlers.ts
+++ b/src/mcp/plugin-tools-handlers.ts
@@ -13,6 +13,42 @@ type CallPluginToolParams = {
   arguments?: unknown;
 };
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function toMcpContentBlock(block: unknown): unknown {
+  if (!isRecord(block)) {
+    return { type: "text", text: coerceChatContentText(block) };
+  }
+  if (block.type !== "image") {
+    return block;
+  }
+
+  const source = block.source;
+  if (
+    isRecord(source) &&
+    source.type === "base64" &&
+    typeof source.data === "string" &&
+    typeof source.media_type === "string"
+  ) {
+    return block;
+  }
+
+  if (typeof block.data === "string" && typeof block.mimeType === "string") {
+    return {
+      type: "image",
+      source: {
+        type: "base64",
+        media_type: block.mimeType,
+        data: block.data,
+      },
+    };
+  }
+
+  return { type: "text", text: coerceChatContentText(block) };
+}
+
 function resolveJsonSchemaForTool(tool: AnyAgentTool): Record<string, unknown> {
   const params = tool.parameters;
   if (params && typeof params === "object" && "type" in params) {
@@ -59,7 +95,7 @@ export function createPluginToolsMcpHandlers(tools: AnyAgentTool[]) {
             : result;
         return {
           content: Array.isArray(rawContent)
-            ? rawContent
+            ? rawContent.map(toMcpContentBlock)
             : [{ type: "text", text: coerceChatContentText(rawContent) }],
         };
       } catch (err) {

--- a/src/mcp/plugin-tools-serve.test.ts
+++ b/src/mcp/plugin-tools-serve.test.ts
@@ -1,4 +1,5 @@
 // Plugin MCP serve tests cover serving plugin tools over MCP.
+import { CallToolResultSchema } from "@modelcontextprotocol/sdk/types.js";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   type HookContext,
@@ -180,11 +181,18 @@ describe("plugin tools MCP server", () => {
     expect(result.content).toEqual([{ type: "text", text: "Stored." }]);
   });
 
-  it("serializes image tool content with MCP base64 source blocks", async () => {
+  it("serializes source-shaped image tool content with pinned MCP image blocks", async () => {
     const execute = vi.fn().mockResolvedValue({
       content: [
         { type: "text", text: "browser screenshot" },
-        { type: "image", data: "iVBORw0KGgo=", mimeType: "image/png" },
+        {
+          type: "image",
+          source: {
+            type: "base64",
+            media_type: "image/png",
+            data: "iVBORw0KGgo=",
+          },
+        },
       ],
     });
     const tool = {
@@ -202,15 +210,9 @@ describe("plugin tools MCP server", () => {
 
     expect(result.content).toEqual([
       { type: "text", text: "browser screenshot" },
-      {
-        type: "image",
-        source: {
-          type: "base64",
-          media_type: "image/png",
-          data: "iVBORw0KGgo=",
-        },
-      },
+      { type: "image", data: "iVBORw0KGgo=", mimeType: "image/png" },
     ]);
+    expect(() => CallToolResultSchema.parse(result)).not.toThrow();
   });
 
   it("serializes plugin tool results that do not use the MCP content envelope", async () => {

--- a/src/mcp/plugin-tools-serve.test.ts
+++ b/src/mcp/plugin-tools-serve.test.ts
@@ -1,4 +1,6 @@
 // Plugin MCP serve tests cover serving plugin tools over MCP.
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { CallToolResultSchema } from "@modelcontextprotocol/sdk/types.js";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
@@ -213,6 +215,48 @@ describe("plugin tools MCP server", () => {
       { type: "image", data: "iVBORw0KGgo=", mimeType: "image/png" },
     ]);
     expect(() => CallToolResultSchema.parse(result)).not.toThrow();
+  });
+
+  it("delivers source-shaped images through a real MCP client", async () => {
+    const execute = vi.fn().mockResolvedValue({
+      content: [
+        { type: "text", text: "browser screenshot" },
+        {
+          type: "image",
+          source: {
+            type: "base64",
+            media_type: "image/png",
+            data: "iVBORw0KGgo=",
+          },
+        },
+      ],
+    });
+    const tool = {
+      name: "browser_screenshot",
+      description: "Capture a browser screenshot",
+      parameters: { type: "object", properties: {} },
+      execute,
+    } as unknown as AnyAgentTool;
+    const { createToolsMcpServer } =
+      await vi.importActual<typeof import("./tools-stdio-server.js")>("./tools-stdio-server.js");
+    const server = createToolsMcpServer({ name: "plugin-tools-image-test", tools: [tool] });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const client = new Client(
+      { name: "plugin-tools-image-test-client", version: "0.0.0" },
+      { capabilities: {} },
+    );
+
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+    try {
+      const result = await client.callTool({ name: "browser_screenshot", arguments: {} });
+      expect(result.content).toEqual([
+        { type: "text", text: "browser screenshot" },
+        { type: "image", data: "iVBORw0KGgo=", mimeType: "image/png" },
+      ]);
+    } finally {
+      await client.close();
+      await server.close();
+    }
   });
 
   it("serializes plugin tool results that do not use the MCP content envelope", async () => {

--- a/src/mcp/plugin-tools-serve.test.ts
+++ b/src/mcp/plugin-tools-serve.test.ts
@@ -180,6 +180,39 @@ describe("plugin tools MCP server", () => {
     expect(result.content).toEqual([{ type: "text", text: "Stored." }]);
   });
 
+  it("serializes image tool content with MCP base64 source blocks", async () => {
+    const execute = vi.fn().mockResolvedValue({
+      content: [
+        { type: "text", text: "browser screenshot" },
+        { type: "image", data: "iVBORw0KGgo=", mimeType: "image/png" },
+      ],
+    });
+    const tool = {
+      name: "browser_screenshot",
+      description: "Capture a browser screenshot",
+      parameters: { type: "object", properties: {} },
+      execute,
+    } as unknown as AnyAgentTool;
+
+    const handlers = createPluginToolsMcpHandlers([tool]);
+    const result = await handlers.callTool({
+      name: "browser_screenshot",
+      arguments: {},
+    });
+
+    expect(result.content).toEqual([
+      { type: "text", text: "browser screenshot" },
+      {
+        type: "image",
+        source: {
+          type: "base64",
+          media_type: "image/png",
+          data: "iVBORw0KGgo=",
+        },
+      },
+    ]);
+  });
+
   it("serializes plugin tool results that do not use the MCP content envelope", async () => {
     const execute = vi.fn().mockResolvedValue({
       provider: "kitchen-sink-search",


### PR DESCRIPTION
## Summary

- Fixes #90743.
- The plugin tools MCP bridge now returns image content in the repository's pinned `@modelcontextprotocol/sdk` 1.29.0 result schema: `{ type: "image", data, mimeType }`.
- Source-shaped image blocks from tool implementations are normalized at the plugin-tools MCP serialization boundary before `callTool()` returns, while already-valid pinned SDK image blocks are preserved.
- **Fix classification:** Root-cause protocol/data-format boundary fix for MCP tool content serialization.
- **Why it matters / User impact:** Browser screenshot-style plugin tools could emit image content that failed the pinned MCP SDK result validation before the caller could consume the screenshot. Keeping the response in the pinned SDK schema restores screenshot usability on the affected MCP tool path.
- **What did NOT change:** Screenshot capture, browser extension behavior, image data generation, image sanitization, provider adapters, non-image tool content handling, MCP SDK internals, and user configuration are unchanged.
- **Architecture / source-of-truth check:** The source of truth for this repository's installed MCP result schema is the pinned SDK dependency. In `@modelcontextprotocol/sdk` 1.29.0, `CallToolResultSchema` rejects `source`-shaped image blocks and accepts image blocks with top-level `data` and `mimeType`; the bridge should not emit the incompatible `source` shape while the repo is pinned to that contract.
- **Scope boundary:** This PR changes only `src/mcp/plugin-tools-handlers.ts` and the regression coverage in `src/mcp/plugin-tools-serve.test.ts`.
- **Out of scope:** No MCP SDK upgrade, no schema migration to the `source` image shape, no live browser extension session, and no provider image-format changes.

## Real behavior proof

**Behavior or issue addressed:** MCP plugin tool image content could be returned in a shape that the repository's pinned MCP SDK rejects for `callTool()` results. The failing issue path expects screenshot image content to satisfy the installed SDK schema, but `source`-shaped image content is invalid under the pinned 1.29.0 `CallToolResultSchema`.

**Real environment tested:** Linux local PR worktree at head `94beb3f25779e41a1d8e787da05221544cbe16bd`, Node `v22.22.0`, pnpm `11.2.2`, installed `@modelcontextprotocol/sdk` version `1.29.0`. The proof runs the production `createToolsMcpServer()` MCP server with the SDK `Client` over `InMemoryTransport`, calls a screenshot-like plugin tool through the MCP client path, and validates the returned result with the pinned SDK `CallToolResultSchema`.

**Exact steps or command run after this patch:**

```bash
cd <repo-root>
node --input-type=module --import tsx <<'JS'
import { readFileSync } from "node:fs";
import { Client } from "@modelcontextprotocol/sdk/client/index.js";
import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
import { CallToolResultSchema } from "@modelcontextprotocol/sdk/types.js";
import { createToolsMcpServer } from "./src/mcp/tools-stdio-server.ts";

const sourceContent = [
  { type: "text", text: "browser screenshot" },
  {
    type: "image",
    source: { type: "base64", media_type: "image/png", data: "iVBORw0KGgo=" },
  },
];

const tool = {
  name: "browser_screenshot",
  description: "Capture a browser screenshot",
  parameters: { type: "object", properties: {} },
  execute: async () => ({ content: sourceContent }),
};

const server = createToolsMcpServer({ name: "openclaw-plugin-tools", tools: [tool] });
const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
const client = new Client(
  { name: "openclaw-mcp-client-proof", version: "1.0.0" },
  { capabilities: {} },
);

await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
try {
  const rawSource = { content: sourceContent };
  const raw = CallToolResultSchema.safeParse(rawSource);
  const result = await client.callTool(
    { name: "browser_screenshot", arguments: {} },
    CallToolResultSchema,
  );
  const normalized = CallToolResultSchema.safeParse(result);
  const sdkPkg = JSON.parse(
    readFileSync("node_modules/@modelcontextprotocol/sdk/package.json", "utf8"),
  );
  const proof = {
    pinnedSdkVersion: sdkPkg.version,
    clientCallPath:
      "@modelcontextprotocol/sdk Client -> InMemoryTransport -> createToolsMcpServer -> tool.execute",
    rawSourceAcceptedByPinnedSdk: raw.success,
    clientResultAcceptedByPinnedSdk: normalized.success,
    clientResultContent: result.content,
    rawSourceErrorPaths: raw.success
      ? []
      : raw.error.issues.map((issue) => ({
          path: issue.path.join("."),
          message: issue.message,
        })),
  };
  console.log(JSON.stringify(proof, null, 2));
  if (proof.pinnedSdkVersion !== "1.29.0") {
    throw new Error(`unexpected MCP SDK version ${proof.pinnedSdkVersion}`);
  }
  if (raw.success) {
    throw new Error("raw source-shaped image content unexpectedly passed pinned SDK schema");
  }
  if (!normalized.success) {
    throw new Error("MCP client result did not pass pinned SDK schema");
  }
} finally {
  await client.close();
  await server.close();
}
JS

node scripts/run-vitest.mjs src/mcp/plugin-tools-serve.test.ts
pnpm format:check -- src/mcp/plugin-tools-handlers.ts src/mcp/plugin-tools-serve.test.ts
pnpm tsgo:core
git diff --check origin/main...HEAD
```

**Evidence after fix:**

```json
{
  "pinnedSdkVersion": "1.29.0",
  "clientCallPath": "@modelcontextprotocol/sdk Client -> InMemoryTransport -> createToolsMcpServer -> tool.execute",
  "rawSourceAcceptedByPinnedSdk": false,
  "clientResultAcceptedByPinnedSdk": true,
  "clientResultContent": [
    {
      "type": "text",
      "text": "browser screenshot"
    },
    {
      "type": "image",
      "data": "iVBORw0KGgo=",
      "mimeType": "image/png"
    }
  ],
  "rawSourceErrorPaths": [
    {
      "path": "content.1",
      "message": "Invalid input"
    }
  ]
}
```

```text
MCP regression: src/mcp/plugin-tools-serve.test.ts passed, 8 tests passed.
Format check: all matched files use the correct format.
tsgo:core and git diff --check passed.
```

**Observed result after fix:** The raw `source` image content is rejected by the pinned SDK, while the production MCP server path now returns `{ type: "image", data, mimeType }` to an MCP SDK client and `CallToolResultSchema` accepts the client result.

**What was not tested:** I did not run a live Chrome/CDP browser screenshot session or a separate external MCP client process. The added proof exercises the local MCP SDK client/server transport and production plugin-tools MCP server boundary; final acceptance still depends on maintainers accepting the pinned SDK 1.29.0 result contract until an SDK upgrade changes that contract.

## Review findings addressed

- **RF-001 — Status: maintainer decision disclosed with dependency-contract proof.** This PR intentionally follows the repository's installed `@modelcontextprotocol/sdk` 1.29.0 `CallToolResultSchema`: `source`-shaped image content is rejected, and top-level `{ data, mimeType }` image content is accepted. I did not attempt a broader MCP image-shape migration because that would require an SDK upgrade decision outside this focused bug fix.
- **RF-002 — Status: local MCP client proof supplied; live browser proof gap disclosed.** The new proof calls the production MCP server through the SDK `Client` and validates the returned screenshot-like image content. I still did not run a live browser extension screenshot over Chrome/CDP, so that final live-browser acceptance remains a maintainer proof/risk decision rather than something this local source-level update claims to have completed.

## Regression Test Plan

- **Target test file:** `src/mcp/plugin-tools-serve.test.ts`
- **Scenario locked in:** A plugin/browser screenshot-like tool returns mixed text plus a source-shaped image block; `createPluginToolsMcpHandlers().callTool()` must return text unchanged and normalize the image to `{ type: "image", data, mimeType }`, then the pinned SDK `CallToolResultSchema.parse(result)` must accept the output.
- **Why this is the smallest reliable guardrail:** The failure happens at the MCP bridge serialization boundary, so the regression test targets that boundary directly and validates against the installed SDK contract instead of asserting a hand-written shape only.
- **Patch quality notes:** The production change is limited to image blocks and leaves non-image content and malformed image-like content behavior unchanged.

## Merge risk

- **Risk labels considered:** `merge-risk: compatibility`, `data_format`, `schema/protocol boundary`, `size: S`.
- **Risk explanation:** The externally visible behavior for this pinned-SDK bridge changes from emitting invalid `source` image blocks to emitting image blocks accepted by the installed MCP SDK schema. Existing valid `{ type: "image", data, mimeType }` blocks are preserved, non-image content is returned as before, and malformed image-like blocks still fall back to text coercion.
- **Why acceptable:** This matches the repository's current pinned dependency contract and avoids a partial SDK-shape migration. Any future upgrade to a different MCP image shape should happen with the SDK version/schema change as the source of truth.

## Root Cause

- **Root cause:** The MCP plugin tools handler could pass through source-shaped image content while the repository is pinned to `@modelcontextprotocol/sdk` 1.29.0, whose `CallToolResultSchema` requires image blocks with top-level `data` and `mimeType`. That made screenshot-style image content contradict the installed SDK contract at the plugin-tools MCP boundary.
- **Why this is root-cause fix:** The MCP boundary now returns the exact image shape accepted by the installed SDK. It preserves already-valid pinned SDK image blocks and normalizes source-shaped inputs only at the boundary, rather than relying on callers or external clients to accept a schema not provided by the current dependency.
