### PR TITLE
fix(agents): inherit default agent model catalog for secondary agents

### DIFF
--- a/src/agents/agent-model-discovery.ts
+++ b/src/agents/agent-model-discovery.ts
@@ -38,6 +38,11 @@ type DiscoverModelsOptions = {
   pluginMetadataSnapshot?: PluginModelCatalogMetadataSnapshot;
   workspaceDir?: string;
   normalizeModels?: boolean;
+  /**
+   * Default/main agent directory used as a read-through fallback for a secondary agent's
+   * generated plugin model catalogs. See `ModelRegistry` `inheritedAgentDir`.
+   */
+  inheritedAgentDir?: string;
 };
 
 /** Applies plugin model normalization and transport hooks to discovered agent models. */
@@ -102,7 +107,10 @@ function createOpenClawModelRegistry(
     allowWorkspaceScopedCurrent: options?.workspaceDir === undefined,
     useRuntimeConfig: options?.config === undefined,
   });
-  const registryOptions = pluginMetadataSnapshot ? { pluginMetadataSnapshot } : {};
+  const registryOptions = {
+    ...(pluginMetadataSnapshot ? { pluginMetadataSnapshot } : {}),
+    ...(options?.inheritedAgentDir ? { inheritedAgentDir: options.inheritedAgentDir } : {}),
+  };
   const registry = ModelRegistry.create(authStorage, modelsJsonPath, registryOptions);
   const getAll = registry.getAll.bind(registry);
   const getAvailable = registry.getAvailable.bind(registry);

--- a/src/agents/embedded-agent-runner/model-discovery-cache.ts
+++ b/src/agents/embedded-agent-runner/model-discovery-cache.ts
@@ -91,6 +91,11 @@ function discoveryFingerprint(
     modelsJson: fileFingerprint(path.join(params.agentDir, "models.json")),
     pluginMetadata: pluginMetadataFingerprint(params.pluginMetadataSnapshot),
     pluginModelCatalogs: pluginModelCatalogFingerprint(params.agentDir),
+    // Secondary agents read through to the default agent's plugin catalogs, so changes to
+    // those inherited catalogs must invalidate this agent's cached discovery snapshot.
+    inheritedPluginModelCatalogs: inheritedAuthDir
+      ? pluginModelCatalogFingerprint(inheritedAuthDir)
+      : undefined,
   });
 }
 
@@ -137,12 +142,20 @@ function discoverFreshAgentStores(
   agentDir: string,
   options: Pick<DiscoverCachedAgentStoresOptions, "config" | "workspaceDir">,
   pluginMetadataSnapshot: PluginMetadataSnapshot | undefined,
+  inheritedAgentDir: string | undefined,
 ): DiscoveryStores {
   const authStorage = discoverAuthStorage(agentDir);
+  // Only inherit when the default agent dir is genuinely distinct, so the default agent
+  // never reads through to itself.
+  const inheritDir =
+    inheritedAgentDir && path.resolve(inheritedAgentDir) !== path.resolve(agentDir)
+      ? inheritedAgentDir
+      : undefined;
   const modelRegistry = discoverModels(authStorage, agentDir, {
     ...(options.config ? { config: options.config } : {}),
     ...(pluginMetadataSnapshot ? { pluginMetadataSnapshot } : {}),
     ...(options.workspaceDir ? { workspaceDir: options.workspaceDir } : {}),
+    ...(inheritDir ? { inheritedAgentDir: inheritDir } : {}),
   });
   return { authStorage, modelRegistry };
 }
@@ -162,6 +175,7 @@ export function discoverCachedAgentStores(
       agentDir,
       options,
       resolvePluginMetadataSnapshotForDiscovery(options),
+      inheritedAuthDir,
     );
   }
   const pluginMetadataSnapshot = resolvePluginMetadataSnapshotForDiscovery(options);
@@ -177,7 +191,12 @@ export function discoverCachedAgentStores(
     };
   }
 
-  const stores = discoverFreshAgentStores(agentDir, options, pluginMetadataSnapshot);
+  const stores = discoverFreshAgentStores(
+    agentDir,
+    options,
+    pluginMetadataSnapshot,
+    inheritedAuthDir,
+  );
   DISCOVERY_STORE_CACHE.set(cacheKey, {
     authStorage: stores.authStorage,
     fingerprint,

--- a/src/agents/sessions/model-registry.test.ts
+++ b/src/agents/sessions/model-registry.test.ts
@@ -226,3 +226,257 @@ describe("ModelRegistry models.json auth", () => {
     expect(registry.find("zai", "glm-5.1")).toBeUndefined();
   });
 });
+
+describe("ModelRegistry default-agent catalog inheritance", () => {
+  // Model discovery only runs for the default agent at gateway startup, so a freshly
+  // created secondary agent has an apiKey-only google catalog with no models. Without
+  // read-through inheritance it fails at runtime with "Unknown model: google/...".
+  function writeGoogleCatalogAgentDir(params: { withModels: boolean; modelName?: string }): string {
+    return writeModelsJsonWithPluginCatalog({
+      root: { providers: {} },
+      pluginRelativePath: join("plugins", "google", PLUGIN_MODEL_CATALOG_FILE),
+      pluginCatalog: {
+        generatedBy: PLUGIN_MODEL_CATALOG_GENERATED_BY,
+        providers: {
+          google: params.withModels
+            ? {
+                baseUrl: "https://generativelanguage.googleapis.com/v1beta",
+                api: "openai-responses",
+                apiKey: "GEMINI_API_KEY",
+                models: [
+                  { id: "gemini-2.5-flash", name: params.modelName ?? "Gemini 2.5 Flash" },
+                ],
+              }
+            : { apiKey: "GEMINI_API_KEY" },
+        },
+      },
+    });
+  }
+
+  it("inherits the default agent's generated catalog models for a secondary agent", () => {
+    const defaultAgentDir = dirname(writeGoogleCatalogAgentDir({ withModels: true }));
+    const secondaryModelsPath = writeGoogleCatalogAgentDir({ withModels: false });
+
+    const registry = ModelRegistry.create(
+      AuthStorage.inMemory({ google: { type: "api_key", key: "sk-test" } }),
+      secondaryModelsPath,
+      {
+        pluginMetadataSnapshot: pluginOwnerSnapshot("google", "google"),
+        inheritedAgentDir: defaultAgentDir,
+      },
+    );
+
+    expect(registry.getError()).toBeUndefined();
+    expect(registry.find("google", "gemini-2.5-flash")?.name).toBe("Gemini 2.5 Flash");
+  });
+
+  it("does not inherit without an inheritedAgentDir (reproduces the bug)", () => {
+    const secondaryModelsPath = writeGoogleCatalogAgentDir({ withModels: false });
+
+    const registry = ModelRegistry.create(
+      AuthStorage.inMemory({ google: { type: "api_key", key: "sk-test" } }),
+      secondaryModelsPath,
+      { pluginMetadataSnapshot: pluginOwnerSnapshot("google", "google") },
+    );
+
+    expect(registry.getError()).toBeUndefined();
+    expect(registry.find("google", "gemini-2.5-flash")).toBeUndefined();
+  });
+
+  it("prefers the secondary agent's own catalog over inherited models", () => {
+    const defaultAgentDir = dirname(
+      writeGoogleCatalogAgentDir({ withModels: true, modelName: "Gemini 2.5 Flash (default)" }),
+    );
+    const secondaryModelsPath = writeGoogleCatalogAgentDir({
+      withModels: true,
+      modelName: "Gemini 2.5 Flash (local)",
+    });
+
+    const registry = ModelRegistry.create(
+      AuthStorage.inMemory({ google: { type: "api_key", key: "sk-test" } }),
+      secondaryModelsPath,
+      {
+        pluginMetadataSnapshot: pluginOwnerSnapshot("google", "google"),
+        inheritedAgentDir: defaultAgentDir,
+      },
+    );
+
+    expect(registry.getError()).toBeUndefined();
+    expect(registry.find("google", "gemini-2.5-flash")?.name).toBe("Gemini 2.5 Flash (local)");
+  });
+
+  it("does not let an inherited catalog override a local provider's config/headers or leak sibling models", async () => {
+    // Regression: a provider the secondary agent defines in its own models.json must keep
+    // its local request config (headers/auth) and must NOT gain sibling models from the
+    // default agent's catalog — otherwise a local model would run with the default agent's
+    // credentials/transport (a cross-agent boundary violation), and inheritance would no
+    // longer be "local always wins".
+    const defaultAgentDir = dirname(
+      writeModelsJsonWithPluginCatalog({
+        root: { providers: {} },
+        pluginRelativePath: join("plugins", "google", PLUGIN_MODEL_CATALOG_FILE),
+        pluginCatalog: {
+          generatedBy: PLUGIN_MODEL_CATALOG_GENERATED_BY,
+          providers: {
+            google: {
+              baseUrl: "https://default.example/v1beta",
+              api: "openai-responses",
+              apiKey: "GEMINI_API_KEY",
+              headers: { "x-source": "default" },
+              models: [
+                { id: "gemini-2.5-flash", name: "Flash (default)" },
+                { id: "gemini-3-flash-preview", name: "3 Flash (default)" },
+              ],
+            },
+          },
+        },
+      }),
+    );
+
+    // Secondary agent owns google via its OWN models.json (not a plugin catalog).
+    const secondaryModelsPath = writeModelsJson({
+      providers: {
+        google: {
+          baseUrl: "https://local.example/v1beta",
+          api: "openai-responses",
+          apiKey: "GEMINI_API_KEY",
+          headers: { "x-source": "local" },
+          models: [{ id: "gemini-2.5-flash", name: "Flash (local)" }],
+        },
+      },
+    });
+
+    const registry = ModelRegistry.create(
+      AuthStorage.inMemory({ google: { type: "api_key", key: "sk-test" } }),
+      secondaryModelsPath,
+      {
+        pluginMetadataSnapshot: pluginOwnerSnapshot("google", "google"),
+        inheritedAgentDir: defaultAgentDir,
+      },
+    );
+
+    expect(registry.getError()).toBeUndefined();
+
+    const local = registry.find("google", "gemini-2.5-flash");
+    expect(local?.name).toBe("Flash (local)");
+    // Per-provider gating: the default agent's sibling model must not leak in.
+    expect(registry.find("google", "gemini-3-flash-preview")).toBeUndefined();
+
+    // Local provider request config (headers) must survive inherited loading.
+    const resolved = await registry.getApiKeyAndHeaders(local!);
+    if (!resolved.ok) {
+      throw new Error(`expected resolved auth, got error: ${resolved.error}`);
+    }
+    expect(resolved.headers?.["x-source"]).toBe("local");
+  });
+
+  it("resolves local request config when the local provider comes from a local plugin catalog", async () => {
+    // Same guarantee as above, but the local provider is owned via a local plugin catalog
+    // (not root models.json) — covers the other registration path end-to-end.
+    const defaultAgentDir = dirname(
+      writeModelsJsonWithPluginCatalog({
+        root: { providers: {} },
+        pluginRelativePath: join("plugins", "google", PLUGIN_MODEL_CATALOG_FILE),
+        pluginCatalog: {
+          generatedBy: PLUGIN_MODEL_CATALOG_GENERATED_BY,
+          providers: {
+            google: {
+              baseUrl: "https://default.example/v1beta",
+              api: "openai-responses",
+              apiKey: "GEMINI_API_KEY",
+              headers: { "x-source": "default" },
+              models: [
+                { id: "gemini-2.5-flash", name: "Flash (default)" },
+                { id: "gemini-3-flash-preview", name: "3 Flash (default)" },
+              ],
+            },
+          },
+        },
+      }),
+    );
+
+    const secondaryModelsPath = writeModelsJsonWithPluginCatalog({
+      root: { providers: {} },
+      pluginRelativePath: join("plugins", "google", PLUGIN_MODEL_CATALOG_FILE),
+      pluginCatalog: {
+        generatedBy: PLUGIN_MODEL_CATALOG_GENERATED_BY,
+        providers: {
+          google: {
+            baseUrl: "https://local.example/v1beta",
+            api: "openai-responses",
+            apiKey: "GEMINI_API_KEY",
+            headers: { "x-source": "local" },
+            models: [{ id: "gemini-2.5-flash", name: "Flash (local)" }],
+          },
+        },
+      },
+    });
+
+    const registry = ModelRegistry.create(
+      AuthStorage.inMemory({ google: { type: "api_key", key: "sk-test" } }),
+      secondaryModelsPath,
+      {
+        pluginMetadataSnapshot: pluginOwnerSnapshot("google", "google"),
+        inheritedAgentDir: defaultAgentDir,
+      },
+    );
+
+    expect(registry.getError()).toBeUndefined();
+
+    const local = registry.find("google", "gemini-2.5-flash");
+    expect(local?.name).toBe("Flash (local)");
+    expect(registry.find("google", "gemini-3-flash-preview")).toBeUndefined();
+
+    const resolved = await registry.getApiKeyAndHeaders(local!);
+    if (!resolved.ok) {
+      throw new Error(`expected resolved auth, got error: ${resolved.error}`);
+    }
+    expect(resolved.headers?.["x-source"]).toBe("local");
+  });
+
+  it("resolves an inherited-only provider with the inherited baseUrl and headers", async () => {
+    // For a provider the secondary agent does not configure at all, inheritance must supply
+    // the default agent's baseUrl/api and request headers so the model is actually usable.
+    const defaultAgentDir = dirname(
+      writeModelsJsonWithPluginCatalog({
+        root: { providers: {} },
+        pluginRelativePath: join("plugins", "google", PLUGIN_MODEL_CATALOG_FILE),
+        pluginCatalog: {
+          generatedBy: PLUGIN_MODEL_CATALOG_GENERATED_BY,
+          providers: {
+            google: {
+              baseUrl: "https://inherited.example/v1beta",
+              api: "openai-responses",
+              apiKey: "GEMINI_API_KEY",
+              headers: { "x-source": "inherited" },
+              models: [{ id: "gemini-2.5-flash", name: "Flash (inherited)" }],
+            },
+          },
+        },
+      }),
+    );
+
+    // Secondary agent configures no provider of its own (lives on inheritance).
+    const secondaryModelsPath = writeModelsJson({ providers: {} });
+
+    const registry = ModelRegistry.create(
+      AuthStorage.inMemory({ google: { type: "api_key", key: "sk-test" } }),
+      secondaryModelsPath,
+      {
+        pluginMetadataSnapshot: pluginOwnerSnapshot("google", "google"),
+        inheritedAgentDir: defaultAgentDir,
+      },
+    );
+
+    expect(registry.getError()).toBeUndefined();
+
+    const model = registry.find("google", "gemini-2.5-flash");
+    expect(model?.baseUrl).toBe("https://inherited.example/v1beta");
+
+    const resolved = await registry.getApiKeyAndHeaders(model!);
+    if (!resolved.ok) {
+      throw new Error(`expected resolved auth, got error: ${resolved.error}`);
+    }
+    expect(resolved.headers?.["x-source"]).toBe("inherited");
+  });
+});

--- a/src/agents/sessions/model-registry.ts
+++ b/src/agents/sessions/model-registry.ts
@@ -3,7 +3,7 @@
  */
 
 import { existsSync, readFileSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { type Static, Type } from "typebox";
 import { Compile } from "typebox/compile";
 import type { TLocalizedValidationError } from "typebox/error";
@@ -251,6 +251,13 @@ function emptyCustomModelsResult(error?: string): CustomModelsResult {
 type ModelRegistryOptions = {
   pluginMetadataSnapshot?: PluginModelCatalogMetadataSnapshot;
   workspaceDir?: string;
+  /**
+   * Default/main agent directory whose generated plugin model catalogs are used as a
+   * read-through fallback for this (secondary) agent. Mirrors auth-profile read-through:
+   * model discovery only runs for the default agent at gateway startup, so secondary
+   * agents would otherwise have empty plugin catalogs and fail with "Unknown model".
+   */
+  inheritedAgentDir?: string;
 };
 
 function mergeCompat(
@@ -303,6 +310,7 @@ export class ModelRegistry {
   private loadError: string | undefined = undefined;
   readonly authStorage: AuthStorage;
   private modelsJsonPath: string | undefined;
+  private inheritedAgentDir: string | undefined;
   private pluginMetadataSnapshot: PluginModelCatalogMetadataSnapshot | undefined;
 
   private constructor(
@@ -312,6 +320,7 @@ export class ModelRegistry {
   ) {
     this.authStorage = authStorage;
     this.modelsJsonPath = modelsJsonPath;
+    this.inheritedAgentDir = options.inheritedAgentDir;
     this.pluginMetadataSnapshot = resolveModelPluginMetadataSnapshot({
       ...(options.pluginMetadataSnapshot
         ? { pluginMetadataSnapshot: options.pluginMetadataSnapshot }
@@ -392,6 +401,13 @@ export class ModelRegistry {
       catalogPluginId?: string;
       includePluginCatalogs?: boolean;
       requireGeneratedCatalog?: boolean;
+      /**
+       * Providers the local agent already owns. Used when loading inherited (default-agent)
+       * catalogs so inheritance is a pure per-provider gap-fill: excluded providers register
+       * no request config, no per-model headers, and contribute no models. The local agent's
+       * configuration is never read or overwritten across the agent boundary.
+       */
+      excludeProviders?: ReadonlySet<string>;
     } = {
       includePluginCatalogs: true,
     },
@@ -437,14 +453,21 @@ export class ModelRegistry {
       this.validateConfig(configForUse);
 
       for (const [providerName, providerConfig] of Object.entries(configForUse.providers)) {
+        if (options.excludeProviders?.has(providerName)) {
+          continue;
+        }
         if ((providerConfig.models ?? []).length > 0) {
           this.storeProviderRequestConfig(providerName, providerConfig);
         }
       }
 
-      const models = this.parseModels(configForUse);
+      const models = this.parseModels(configForUse, options.excludeProviders);
       if (options.includePluginCatalogs !== false) {
-        for (const pluginCatalog of listPluginModelCatalogFiles(dirname(modelsJsonPath))) {
+        const localAgentDir = dirname(modelsJsonPath);
+
+        // Load this agent's OWN plugin catalogs first so its full local state (models +
+        // provider request config + per-model headers) is established before inheritance.
+        for (const pluginCatalog of listPluginModelCatalogFiles(localAgentDir)) {
           const pluginResult = this.loadCustomModels(pluginCatalog.path, {
             catalogPluginId: pluginCatalog.pluginId,
             includePluginCatalogs: false,
@@ -454,6 +477,47 @@ export class ModelRegistry {
             return pluginResult;
           }
           models.push(...pluginResult.models);
+        }
+
+        // Read-through inheritance from the default/main agent. Model discovery only runs
+        // for the default agent at gateway startup, so a freshly created secondary agent
+        // has no local plugin-catalog models and would otherwise fail with "Unknown model".
+        //
+        // Inheritance is per-PROVIDER: a provider the local agent already has any model for
+        // is fully local-owned and never inherited. Provider request config (baseUrl, api,
+        // auth, headers) is per-provider with a single slot, so blending a local model with
+        // an inherited sibling under the same provider would force one shared
+        // credential/transport across agents — a cross-agent boundary violation. Local
+        // always wins.
+        if (this.inheritedAgentDir && resolve(this.inheritedAgentDir) !== resolve(localAgentDir)) {
+          // Providers the local agent already owns (configured via root models.json or a
+          // local plugin catalog). These are excluded from inherited loading entirely, so
+          // local-wins never depends on write order and the inherited catalog can neither
+          // read nor overwrite local request config/headers.
+          const localProviders = new Set(models.map((entry) => entry.provider));
+          const seen = new Set(models.map((entry) => `${entry.provider}/${entry.id}`));
+
+          for (const pluginCatalog of listPluginModelCatalogFiles(this.inheritedAgentDir)) {
+            const inheritedResult = this.loadCustomModels(pluginCatalog.path, {
+              catalogPluginId: pluginCatalog.pluginId,
+              includePluginCatalogs: false,
+              requireGeneratedCatalog: true,
+              excludeProviders: localProviders,
+            });
+            // A broken inherited catalog must never break the local agent.
+            if (inheritedResult.error) {
+              continue;
+            }
+            // Excluded providers contributed no models, config, or headers above, so what
+            // remains is a pure gap-fill of providers the local agent does not have.
+            for (const inheritedModel of inheritedResult.models) {
+              const key = `${inheritedModel.provider}/${inheritedModel.id}`;
+              if (!seen.has(key)) {
+                seen.add(key);
+                models.push(inheritedModel);
+              }
+            }
+          }
         }
       }
 
@@ -517,10 +581,13 @@ export class ModelRegistry {
     }
   }
 
-  private parseModels(config: ModelsConfig): Model[] {
+  private parseModels(config: ModelsConfig, excludeProviders?: ReadonlySet<string>): Model[] {
     const models: Model[] = [];
 
     for (const [providerName, providerConfig] of Object.entries(config.providers)) {
+      if (excludeProviders?.has(providerName)) {
+        continue;
+      }
       const modelDefs = providerConfig.models ?? [];
       if (modelDefs.length === 0) {
         continue;


### PR DESCRIPTION
# fix(agents): inherit default agent model catalog for secondary agents

## Summary

Secondary (non-default) agents created with `openclaw agents add` fail at runtime
with `FailoverError: Unknown model: google/gemini-2.5-flash` when using a
Google/Gemini model authenticated via `GEMINI_API_KEY`. The default/`main` agent
works with the same model and key.

**Root cause:** model discovery only runs for the default agent at gateway
startup, so generated plugin model catalogs (`plugins/<provider>/catalog.json`)
are only populated under the default agent dir. A secondary agent gets an
apiKey-only google catalog with **no models**. `ModelRegistry.loadCustomModels()`
loads plugin catalogs only from the current agent dir, with no read-through to
the default agent — unlike auth profiles, which already inherit via
`inheritedAuthDir`.

## The fix

Add read-through inheritance for generated plugin model catalogs, mirroring the
existing auth-profile read-through (`inheritedAuthDir`). Implementation is
**local-first with a per-provider gap-fill gate**:

- `ModelRegistry` accepts an optional `inheritedAgentDir`. The agent's OWN
  catalogs (root models.json + local plugin catalogs) load first and establish
  its full local state (models + provider request config + per-model headers).
- Inheritance is **gated per provider**: a provider the local agent already has
  any model for is excluded from the inherited load entirely — it contributes no
  provider request config, no per-model headers, and no models. So "local always
  wins" never depends on write order, and the inherited catalog can neither read
  nor overwrite the local agent's request config/headers (closes the
  cross-agent boundary concern). Provider request config (baseUrl/api/auth/
  headers) is per-provider with a single slot, so this also avoids pairing an
  inherited model with a local provider's credential.
- Only providers the secondary agent does not configure at all are inherited
  (config + headers + models) — exactly the agent living on inheritance. `apiKey`
  values in catalogs are env refs (e.g. `GEMINI_API_KEY`) resolved per-agent, so
  no secret material crosses the agent boundary.
- A broken/invalid inherited catalog is skipped, never breaking the local agent.
- `discoverModels` threads `inheritedAgentDir` through to the registry.
- `discoverCachedAgentStores` passes the resolved default agent dir, and the
  inherited catalog files are folded into the discovery-cache fingerprint so
  changes to the default agent's catalog invalidate the secondary agent's cached
  snapshot.

The default agent never inherits from itself (path-equality guard), so its
behavior is unchanged.

A heavier alternative — running model discovery for every agent at startup — is
the deeper root-cause fix but is costly (per-agent network discovery, needs to
be lazy) and much larger in scope; noting it as a possible follow-up.

## Files

- `src/agents/sessions/model-registry.ts` — `inheritedAgentDir` option + read-through merge
- `src/agents/agent-model-discovery.ts` — thread option through `discoverModels`
- `src/agents/embedded-agent-runner/model-discovery-cache.ts` — pass default dir + fingerprint
- `src/agents/sessions/model-registry.test.ts` — 6 new tests

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: A secondary agent created with `openclaw agents add`
  could not use `google/gemini-2.5-flash` (authed via `GEMINI_API_KEY`) and failed
  every turn with `Unknown model: google/gemini-2.5-flash`, while the default
  `main` agent worked with the same model and key.
- Real environment tested: Local OpenClaw 2026.6.2 install on macOS (launchd
  gateway), Google Gemini via `GEMINI_API_KEY`, default model
  `google/gemini-2.5-flash`, with a real `main` agent plus a secondary agent
  (`english-tutor`).
- Exact steps or command run after this patch: Applied the patch to my install,
  ran `pnpm build`, restarted the gateway, emptied the secondary agent's google
  plugin catalog to the apiKey-only state (the state `agents add` leaves behind),
  then ran a turn through the running gateway — the same lane a Telegram DM uses:
  `openclaw agent --agent english-tutor -m "Hi Lexi, correct this: I has two cats yesterday." --json`
- Evidence after fix (copied live output from the running gateway):
  ```
  $ cat ~/.openclaw/agents/english-tutor/agent/plugins/google/catalog.json
  {"generatedBy":"openclaw-plugin-model-catalog-v1","providers":{"google":{"apiKey":"GEMINI_API_KEY"}}}   # no models

  $ openclaw agent --agent english-tutor -m "Hi Lexi, correct this: I has two cats yesterday." --json
  "status": "ok"
  "text": "...Câu đúng phải là: \"I **had** two cats yesterday.\" ... (real model reply)"
  ```
  And the patched discovery path exercised directly against the real on-disk agent
  dirs (`discoverModels`):
  ```
  secondary agent dir : ~/.openclaw/agents/english-tutor/agent   (catalog: apiKey-only, no models)
  BEFORE (no inheritance): Unknown model (undefined)
  AFTER  (inherit main)  : google/gemini-2.5-flash  api=google-generative-ai  baseUrl=https://generativelanguage.googleapis.com/v1beta
  ```
- Observed result after fix: The secondary agent resolved
  `google/gemini-2.5-flash` via read-through inheritance, through the native
  `google-generative-ai` transport, and produced a real model reply — with **no
  manual catalog seeding**. Before the patch the identical gateway turn returned
  `Unknown model: google/gemini-2.5-flash`. Re-verified end-to-end on the final
  build with the per-provider gating: a secondary agent that configures no
  provider of its own inherits the default agent's google catalog and resolves
  the model (a provider the secondary configures itself would instead be
  local-owned and not inherited).
- What was not tested: A second independent reproduction on a non-macOS host.
  Full `pnpm test` was run; 4 shards each reported 1 failing test, all unrelated
  to this change (macOS `/private/var` path-normalization / packaged-worker /
  fixture assertions; none of those files reference the changed modules).
- Proof limitations or environment constraints: Verified on a single macOS
  workstation. The live gateway turn was invoked via the CLI `agent` command
  (which routes through the running gateway on the same agent lane as a Telegram
  DM) rather than by sending an actual Telegram message.
- Before evidence (optional): `openclaw agent --agent <secondary> -m "..."` →
  `GatewayClientRequestError: FailoverError: Unknown model: google/gemini-2.5-flash`
  (default `main` agent returned `"status": "ok"` for the same model).

## Tests and validation

Supplemental (not a substitute for the real behavior proof above):

```
pnpm build        # exit 0
pnpm tsgo:all     # full prod + test typecheck, all projects — exit 0, 0 errors
npx oxlint <4 touched files>   # no warnings
npx vitest run src/agents/sessions/model-registry.test.ts src/agents/agent-model-discovery*.test.ts   # all pass
```
New tests cover: (1) a secondary agent inherits the default agent's catalog
models; (2) no inheritance without `inheritedAgentDir`; (3) the secondary agent's
own catalog wins over inherited models; (4)+(5) an inherited catalog never
overwrites a local provider's request config/headers and never leaks sibling
models into a provider the local agent owns — asserted at the **request
resolution** level (`getApiKeyAndHeaders` returns the local headers), for both the
**root models.json** and **local plugin catalog** paths; (6) an inherited-only
provider resolves with the inherited `baseUrl` and headers.

## CI status (rebased onto current `origin/main` `e5a9c60851`)

This branch is rebased onto `origin/main` HEAD (`e5a9c60851`). Most of the CI
failures present on the earlier base have since been fixed upstream. Current state:

| Check | CI result | Local on this branch |
| --- | --- | --- |
| `check-lint` | ✅ pass | `pnpm lint:core` exit 0 |
| `check-additional-runtime-topology-architecture` | ✅ pass | `pnpm check:architecture` — 0 cycles |
| `check-additional-extension-bundled` | ✅ pass | `pnpm lint:extensions:bundled` exit 0 |
| `build-artifacts` | ✅ pass | — |
| `check-test-types` | ❌ fail | reproduces identically on **clean `origin/main`** |

The single remaining `check-test-types` failure is **pre-existing on `main`** and
unrelated to this PR — it is two type errors in an extension test:

```
extensions/qa-lab/src/live-transports/whatsapp/cli.runtime.test.ts(48,5): error TS2322
extensions/qa-lab/src/live-transports/whatsapp/cli.runtime.test.ts(72,5): error TS2322
```

Verified by checking out clean `origin/main` (`e5a9c60851`) with none of this PR's
commits and running `pnpm tsgo:extensions:test` → the identical two errors, exit 2.
This PR changes only `src/agents/**` and does not touch `extensions/qa-lab/**`
(`git diff --name-only origin/main HEAD` lists four files, all under `src/agents/`),
so it cannot introduce this failure. The change's own surface is green: targeted
`vitest` for `model-registry`/`agent-model-discovery` passes and `tsgo` reports no
errors in the changed files.

## AI assistance

Drafted with Claude Code (Opus); reviewed and validated by me. Session log
available on request.
