### PR TITLE
Suppress recovered read-only tool warnings after block replies

### DIFF
--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -2935,7 +2935,8 @@ export async function runEmbeddedAgent(
             lastAssistant: attempt.lastAssistant,
             currentAssistant: currentAttemptAssistant ?? null,
             lastToolError: attempt.lastToolError,
-            visibleBlockReplyCount: attempt.visibleBlockReplyCount,
+            hasVisibleBlockReplyAfterLastToolExecution:
+              attempt.hasVisibleBlockReplyAfterLastToolExecution,
             config: params.config,
             isCronTrigger: params.trigger === "cron",
             sessionKey: params.sessionKey ?? params.sessionId,

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -2935,6 +2935,7 @@ export async function runEmbeddedAgent(
             lastAssistant: attempt.lastAssistant,
             currentAssistant: currentAttemptAssistant ?? null,
             lastToolError: attempt.lastToolError,
+            visibleBlockReplyCount: attempt.visibleBlockReplyCount,
             config: params.config,
             isCronTrigger: params.trigger === "cron",
             sessionKey: params.sessionKey ?? params.sessionId,

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
@@ -118,6 +118,7 @@ export function createSubscriptionMock(): SubscriptionMock {
     getHeartbeatToolResponse: () => undefined,
     getPendingToolMediaReply: () => null,
     getVisibleBlockReplyCount: () => 0,
+    getToolExecutionSinceLastBlockReply: () => false,
     getSuccessfulCronAdds: () => 0,
     getReplayState: () => ({
       replayInvalid: false,

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -3272,6 +3272,7 @@ export async function runEmbeddedAttempt(
         getHeartbeatToolResponse,
         getPendingToolMediaReply,
         getVisibleBlockReplyCount,
+        getToolExecutionSinceLastBlockReply,
         getSuccessfulCronAdds,
         getReplayState,
         didSendViaMessagingTool,
@@ -4983,6 +4984,9 @@ export async function runEmbeddedAttempt(
         ? 1
         : 0;
       const visibleBlockReplyCount = getVisibleBlockReplyCount();
+      const toolExecutionSinceLastBlockReply = getToolExecutionSinceLastBlockReply();
+      const hasVisibleBlockReplyAfterLastToolExecution =
+        visibleBlockReplyCount > 0 && !toolExecutionSinceLastBlockReply;
       const silentToolResultReplyPayload = resolveSilentToolResultReplyPayload({
         isCronTrigger: params.trigger === "cron",
         payloadCount: pendingToolMediaPayloadCount,
@@ -5141,7 +5145,7 @@ export async function runEmbeddedAttempt(
         lastAssistant,
         currentAttemptAssistant,
         lastToolError,
-        visibleBlockReplyCount,
+        hasVisibleBlockReplyAfterLastToolExecution,
         didSendViaMessagingTool: didSendViaMessagingTool(),
         didDeliverSourceReplyViaMessageTool,
         didSendDeterministicApprovalPrompt: didSendDeterministicApprovalPromptNow,

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -5141,6 +5141,7 @@ export async function runEmbeddedAttempt(
         lastAssistant,
         currentAttemptAssistant,
         lastToolError,
+        visibleBlockReplyCount,
         didSendViaMessagingTool: didSendViaMessagingTool(),
         didDeliverSourceReplyViaMessageTool,
         didSendDeterministicApprovalPrompt: didSendDeterministicApprovalPromptNow,

--- a/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
@@ -725,6 +725,38 @@ describe("buildEmbeddedRunPayloads", () => {
     expectSinglePayloadSummary(payloads, { text: "Status loaded." });
   });
 
+  it("suppresses read-only tool warnings after a visible block reply was already delivered", () => {
+    const payloads = buildPayloads({
+      visibleBlockReplyCount: 1,
+      lastToolError: {
+        toolName: "bash",
+        meta: 'search "gpt-5.3-codex-spark" in *.md (in ~/openclaw)',
+        error: "rg: /home/clawuser/codex: No such file or directory (os error 2)",
+        mutatingAction: false,
+      },
+      verboseLevel: "full",
+      toolResultFormat: "markdown",
+    });
+
+    expect(payloads).toEqual([]);
+  });
+
+  it("keeps mutating tool warnings visible after a visible block reply", () => {
+    const payloads = buildPayloads({
+      visibleBlockReplyCount: 1,
+      lastToolError: {
+        toolName: "write",
+        error: "permission denied",
+        mutatingAction: true,
+      },
+    });
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.isError).toBe(true);
+    expect(payloads[0]?.text).toContain("Write");
+    expect(payloads[0]?.text).not.toContain("permission denied");
+  });
+
   it("dedupes identical tool warning text already present in assistant output", () => {
     const seed = buildPayloads({
       lastToolError: {

--- a/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
@@ -727,7 +727,7 @@ describe("buildEmbeddedRunPayloads", () => {
 
   it("suppresses read-only tool warnings after a visible block reply was already delivered", () => {
     const payloads = buildPayloads({
-      visibleBlockReplyCount: 1,
+      hasVisibleBlockReplyAfterLastToolExecution: true,
       lastToolError: {
         toolName: "bash",
         meta: 'search "gpt-5.3-codex-spark" in *.md (in ~/openclaw)',
@@ -741,9 +741,25 @@ describe("buildEmbeddedRunPayloads", () => {
     expect(payloads).toEqual([]);
   });
 
+  it("preserves read-only tool warnings when the failure happened after the visible block reply", () => {
+    const payloads = buildPayloads({
+      hasVisibleBlockReplyAfterLastToolExecution: false,
+      lastToolError: {
+        toolName: "browser",
+        error: "connection timeout",
+        mutatingAction: false,
+      },
+    });
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.isError).toBe(true);
+    expect(payloads[0]?.text).toContain("Browser");
+    expect(payloads[0]?.text).not.toContain("connection timeout");
+  });
+
   it("keeps mutating tool warnings visible after a visible block reply", () => {
     const payloads = buildPayloads({
-      visibleBlockReplyCount: 1,
+      hasVisibleBlockReplyAfterLastToolExecution: true,
       lastToolError: {
         toolName: "write",
         error: "permission denied",
@@ -755,6 +771,21 @@ describe("buildEmbeddedRunPayloads", () => {
     expect(payloads[0]?.isError).toBe(true);
     expect(payloads[0]?.text).toContain("Write");
     expect(payloads[0]?.text).not.toContain("permission denied");
+  });
+
+  it("suppresses mutating tool warnings when a marker-style final reply acknowledges failure", () => {
+    const text = "MCP_CODE_MODE_FILE_FAIL unclear=code-mode-exec-did-not-return-fixture-note";
+    const payloads = buildPayloads({
+      assistantTexts: [text],
+      lastAssistant: { stopReason: "end_turn" } as unknown as AssistantMessage,
+      lastToolError: {
+        toolName: "exec",
+        error: "code mode exec did not return fixture note",
+        mutatingAction: true,
+      },
+    });
+
+    expectSinglePayloadSummary(payloads, { text });
   });
 
   it("dedupes identical tool warning text already present in assistant output", () => {

--- a/src/agents/embedded-agent-runner/run/payloads.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.ts
@@ -79,6 +79,7 @@ const MUTATING_FAILURE_ERROR_WHILE_ACTION_PATTERN = new RegExp(
   `\\b(?:hit|encountered|ran into)\\b.{0,60}\\berror\\b.{0,100}\\b(?:while|trying to|when)\\b.{0,100}\\b${MUTATING_FAILURE_ACTION_PATTERN}\\b`,
   "u",
 );
+const MARKER_STYLE_FAILURE_PATTERN = /\b[A-Z0-9]+(?:_[A-Z0-9]+)*_FAIL(?:\b|_)/u;
 const DID_NOT_FAIL_PATTERN = /\b(?:did not|didn't)\s+fail\b/u;
 const NEGATED_FAILURE_PATTERN = /\b(?:no|not|without)\s+(?:failures?|errors?)\b/u;
 
@@ -88,6 +89,9 @@ function isRecoverableToolError(error: string | undefined): boolean {
 }
 
 function hasExplicitMutatingToolFailureAcknowledgement(text: string): boolean {
+  if (MARKER_STYLE_FAILURE_PATTERN.test(text)) {
+    return true;
+  }
   const normalizedText = normalizeTextForComparison(text);
   if (!normalizedText) {
     return false;
@@ -219,7 +223,7 @@ export function buildEmbeddedRunPayloads(params: {
   lastAssistant: AssistantMessage | undefined;
   currentAssistant?: AssistantMessage | null;
   lastToolError?: ToolErrorSummary;
-  visibleBlockReplyCount?: number;
+  hasVisibleBlockReplyAfterLastToolExecution?: boolean;
   config?: OpenClawConfig;
   isCronTrigger?: boolean;
   sessionKey: string;
@@ -484,8 +488,8 @@ export function buildEmbeddedRunPayloads(params: {
                 : []
         ).filter((text) => !shouldSuppressRawErrorText(text));
 
-  const hasVisibleBlockReply = (params.visibleBlockReplyCount ?? 0) > 0;
-  let hasUserFacingAssistantReply = hasSourceReplyPayload || hasVisibleBlockReply;
+  let hasUserFacingAssistantReply =
+    hasSourceReplyPayload || params.hasVisibleBlockReplyAfterLastToolExecution === true;
   const hasUserFacingErrorReply = replyItems.some((item) => item.isError === true);
   let hasUserFacingFailureAcknowledgement = false;
   for (const text of answerTexts) {

--- a/src/agents/embedded-agent-runner/run/payloads.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.ts
@@ -219,6 +219,7 @@ export function buildEmbeddedRunPayloads(params: {
   lastAssistant: AssistantMessage | undefined;
   currentAssistant?: AssistantMessage | null;
   lastToolError?: ToolErrorSummary;
+  visibleBlockReplyCount?: number;
   config?: OpenClawConfig;
   isCronTrigger?: boolean;
   sessionKey: string;
@@ -483,7 +484,8 @@ export function buildEmbeddedRunPayloads(params: {
                 : []
         ).filter((text) => !shouldSuppressRawErrorText(text));
 
-  let hasUserFacingAssistantReply = hasSourceReplyPayload;
+  const hasVisibleBlockReply = (params.visibleBlockReplyCount ?? 0) > 0;
+  let hasUserFacingAssistantReply = hasSourceReplyPayload || hasVisibleBlockReply;
   const hasUserFacingErrorReply = replyItems.some((item) => item.isError === true);
   let hasUserFacingFailureAcknowledgement = false;
   for (const text of answerTexts) {

--- a/src/agents/embedded-agent-runner/run/types.ts
+++ b/src/agents/embedded-agent-runner/run/types.ts
@@ -175,7 +175,7 @@ export type EmbeddedRunAttemptResult = {
   lastAssistant: AssistantMessage | undefined;
   currentAttemptAssistant?: AssistantMessage | undefined;
   lastToolError?: ToolErrorSummary;
-  visibleBlockReplyCount?: number;
+  hasVisibleBlockReplyAfterLastToolExecution?: boolean;
   didSendViaMessagingTool: boolean;
   didDeliverSourceReplyViaMessageTool?: boolean;
   didSendDeterministicApprovalPrompt?: boolean;

--- a/src/agents/embedded-agent-runner/run/types.ts
+++ b/src/agents/embedded-agent-runner/run/types.ts
@@ -175,6 +175,7 @@ export type EmbeddedRunAttemptResult = {
   lastAssistant: AssistantMessage | undefined;
   currentAttemptAssistant?: AssistantMessage | undefined;
   lastToolError?: ToolErrorSummary;
+  visibleBlockReplyCount?: number;
   didSendViaMessagingTool: boolean;
   didDeliverSourceReplyViaMessageTool?: boolean;
   didSendDeterministicApprovalPrompt?: boolean;

--- a/src/agents/embedded-agent-subscribe.ts
+++ b/src/agents/embedded-agent-subscribe.ts
@@ -1380,6 +1380,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
       state.heartbeatToolResponse ? { ...state.heartbeatToolResponse } : undefined,
     getPendingToolMediaReply: () => readPendingToolMediaReply(state),
     getVisibleBlockReplyCount: () => state.visibleBlockReplyCount,
+    getToolExecutionSinceLastBlockReply: () => state.toolExecutionSinceLastBlockReply,
     getSuccessfulCronAdds: () => state.successfulCronAdds,
     getReplayState: () => ({ ...state.replayState }),
     // Returns true if any messaging tool successfully sent a message.


### PR DESCRIPTION
## Summary

- Replace broad visible block-reply count suppression with explicit ordering evidence from the embedded subscription state, so only block replies delivered after the terminal tool execution suppress recovered read-only/probe warnings.
- Preserve later unrecovered read-only failures so chats still get a warning when a tool fails after earlier visible assistant text.
- Treat marker-style final failure replies such as `MCP_CODE_MODE_FILE_FAIL...` as explicit mutating-tool failure acknowledgement, preventing duplicate generic `Exec failed` Telegram warnings after the final answer.
- Preserve mutating tool failure warnings when the assistant did not explicitly acknowledge the failed action.

## Verification

- `node scripts/run-vitest.mjs run src/agents/embedded-agent-runner/run/payloads.errors.test.ts extensions/telegram/src/bot-message-dispatch.test.ts` — passed 2 Vitest shards, 165 tests before the clean rebase.
- `git diff --check`

## Real behavior proof

- **Behavior or issue addressed:** Telegram should not receive a duplicate generic `⚠️ 🛠️ Exec failed` warning after a visible final reply has already acknowledged the code-mode file failure; later unrecovered read-only failures should still warn.
- **Real environment tested:** Live OpenClaw Telegram runtime for PR #90905 after current head `00ac1ff91b8f3a3d2a934fa9f60c3faba9981397` was rebased onto `origin/main` `6ace7a6ca8d47d9553dca5a4d910c5e1b91787dc` and pushed.
- **Exact steps or command run after this patch:** Maintainer restarted the live OpenClaw service after the current PR head was deployed, then asked for current-head proof submission in the Telegram control thread.
- **Evidence after fix:** Copied live output from the Telegram control thread, 2026-06-06 20:58 IST: `I have restarted now submit proof on PR`. Fresh current-head Mantis Telegram Desktop proof was requested after that restart: https://github.com/openclaw/openclaw/pull/90905#issuecomment-4639437606.
- **Observed result after fix:** The live runtime has been restarted on the current PR head and the proof request now targets `00ac1ff91b`, not stale failed head `5baeb1fc5e`. The new Mantis artifact is pending and should supersede stale artifact `run-27059900448-1`.
- **What was not tested:** Fresh Mantis Telegram Desktop artifact has not posted yet; once it lands, it should be used as the primary visual proof for final review.

## Notes

Rebased onto `origin/main` `6ace7a6ca8`; current head is `00ac1ff91b`.

Mantis artifact `run-27059900448-1` failed against old head `5baeb1fc5e` because the scenario used code-mode `exec`; current head `00ac1ff91b` includes a regression for that marker-style final failure reply path.