### PR TITLE
fix(doctor): match timestamp-suffixed daily memory files in isShortTermMemoryPath (fixes #90896)

### DIFF
--- a/src/gateway/server-methods/doctor.test.ts
+++ b/src/gateway/server-methods/doctor.test.ts
@@ -642,6 +642,205 @@ describe("doctor.memory.status", () => {
     }
   });
 
+  it("counts timestamp-suffixed and slugged recall-store entries in dreaming stats", async () => {
+    const now = Date.parse("2026-06-06T00:30:00.000Z");
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+    const recentIso = "2026-06-05T23:45:00.000Z";
+    const olderIso = "2026-06-03T10:00:00.000Z";
+    const workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), "doctor-memory-slug-"));
+    const mainWorkspaceDir = path.join(workspaceRoot, "main");
+    const mainStorePath = path.join(
+      mainWorkspaceDir,
+      "memory",
+      ".dreams",
+      "short-term-recall.json",
+    );
+    const mainPhaseSignalPath = path.join(
+      mainWorkspaceDir,
+      "memory",
+      ".dreams",
+      "phase-signals.json",
+    );
+    await fs.mkdir(path.dirname(mainStorePath), { recursive: true });
+    // Include both timestamp-suffixed (-HHMM) and slugged (-vendor-pitch) paths
+    await fs.writeFile(
+      mainStorePath,
+      `${JSON.stringify(
+        {
+          version: 1,
+          updatedAt: recentIso,
+          entries: {
+            "memory:memory/2026-06-04-1503.md:1:2": {
+              path: "memory/2026-06-04-1503.md",
+              startLine: 1,
+              endLine: 2,
+              snippet: "Timestamp-suffixed entry.",
+              source: "memory",
+              recallCount: 4,
+              dailyCount: 2,
+              lastRecalledAt: recentIso,
+              promotedAt: recentIso,
+            },
+            "memory:memory/2026-06-03-vendor-pitch.md:1:2": {
+              path: "memory/2026-06-03-vendor-pitch.md",
+              startLine: 1,
+              endLine: 2,
+              snippet: "Slugged llmSlug entry.",
+              source: "memory",
+              recallCount: 7,
+              dailyCount: 4,
+              promotedAt: olderIso,
+            },
+            "memory:memory/2026-06-05-0930.md:1:2": {
+              path: "memory/2026-06-05-0930.md",
+              startLine: 1,
+              endLine: 2,
+              snippet: "Another timestamp-suffixed entry.",
+              source: "memory",
+              recallCount: 3,
+              dailyCount: 1,
+            },
+          },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf-8",
+    );
+    await fs.writeFile(
+      mainPhaseSignalPath,
+      `${JSON.stringify(
+        {
+          version: 1,
+          updatedAt: recentIso,
+          entries: {
+            "memory:memory/2026-06-04-1503.md:1:2": {
+              lightHits: 2,
+              remHits: 3,
+            },
+            "memory:memory/2026-06-03-vendor-pitch.md:1:2": {
+              lightHits: 1,
+              remHits: 2,
+            },
+            "memory:memory/2026-06-05-0930.md:1:2": {
+              lightHits: 1,
+              remHits: 1,
+            },
+          },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf-8",
+    );
+
+    getRuntimeConfig.mockReturnValue({
+      agents: {
+        defaults: {
+          userTimezone: "America/Los_Angeles",
+          memorySearch: {
+            enabled: true,
+          },
+        },
+        list: [],
+      },
+      plugins: {
+        entries: {
+          "memory-core": {
+            config: {
+              dreaming: {
+                enabled: true,
+                frequency: "0 */4 * * *",
+                phases: {
+                  deep: {
+                    recencyHalfLifeDays: 21,
+                    maxAgeDays: 30,
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig);
+    resolveAgentWorkspaceDir.mockReturnValue(mainWorkspaceDir);
+    const close = vi.fn().mockResolvedValue(undefined);
+    getMemorySearchManager.mockResolvedValue({
+      manager: {
+        status: () => ({ provider: "gemini", workspaceDir: mainWorkspaceDir }),
+        probeEmbeddingAvailability: vi.fn().mockResolvedValue({ ok: true }),
+        close,
+      },
+    });
+    const cronList = vi.fn(async () => [
+      {
+        name: "Memory Dreaming Promotion",
+        description: "[managed-by=memory-core.short-term-promotion] test",
+        enabled: true,
+        payload: {
+          kind: "systemEvent",
+          text: "__openclaw_memory_core_short_term_promotion_dream__",
+        },
+        state: { nextRunAtMs: now + 60_000 },
+      },
+    ]);
+    const respond = vi.fn();
+
+    try {
+      await invokeDoctorMemoryStatus(respond, { cron: { list: cronList } });
+      const payload = respondPayload(respond);
+      const dreaming = expectRecordFields(payload.dreaming, {
+        enabled: true,
+        // All 3 entries (including timestamp and slugged) should be counted
+        // Active (non-promoted) entries: only 2026-06-05-0930.md
+        shortTermCount: 1,
+        recallSignalCount: 3, // from active entry
+        dailySignalCount: 1, // from active entry
+        totalSignalCount: 4, // recallSignalCount + dailySignalCount
+        phaseSignalCount: 2, // lightHits 1 + remHits 1 from active entry
+        lightPhaseHitCount: 1,
+        remPhaseHitCount: 1,
+        promotedTotal: 2, // both promoted entries counted
+        promotedToday: 1, // only 2026-06-04-1503 promoted today
+      });
+      // Verify timestamp-suffixed entry is present and counted
+      expectRecordFields(
+        findRecordByField(dreaming.promotedEntries, "path", "memory/2026-06-04-1503.md"),
+        {
+          promotedAt: recentIso,
+          snippet: "Timestamp-suffixed entry.",
+        },
+      );
+      // Verify slugged entry is present and counted
+      expectRecordFields(
+        findRecordByField(dreaming.promotedEntries, "path", "memory/2026-06-03-vendor-pitch.md"),
+        {
+          promotedAt: olderIso,
+          snippet: "Slugged llmSlug entry.",
+        },
+      );
+      // Verify short-term entry with timestamp suffix is present
+      expectRecordFields((dreaming.shortTermEntries as unknown[])[0], {
+        path: "memory/2026-06-05-0930.md",
+        snippet: "Another timestamp-suffixed entry.",
+        totalSignalCount: 4,
+        lightHits: 1,
+        remHits: 1,
+        phaseHitCount: 2,
+      });
+      // Verify signal entries include slugged path
+      expectRecordFields((dreaming.signalEntries as unknown[])[0], {
+        path: "memory/2026-06-05-0930.md",
+        totalSignalCount: 4,
+      });
+      expect(close).toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+      await fs.rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
   it("scopes dreaming status to the requested agent workspace", async () => {
     const workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), "doctor-memory-selected-"));
     const mainWorkspaceDir = path.join(workspaceRoot, "main");

--- a/src/gateway/server-methods/doctor.ts
+++ b/src/gateway/server-methods/doctor.ts
@@ -350,7 +350,7 @@ function normalizeMemoryPathForWorkspace(workspaceDir: string, rawPath: string):
 function isShortTermMemoryPath(filePath: string): boolean {
   const normalized = normalizeMemoryPath(filePath);
   // Status only counts short-term source shapes; promoted diary/report files stay out.
-  if (/(?:^|\/)memory\/(\d{4})-(\d{2})-(\d{2})\.md$/.test(normalized)) {
+  if (/(?:^|\/)memory\/(\d{4})-(\d{2})-(\d{2})(?:-\d{4})?\.md$/.test(normalized)) {
     return true;
   }
   if (

--- a/src/gateway/server-methods/doctor.ts
+++ b/src/gateway/server-methods/doctor.ts
@@ -350,7 +350,7 @@ function normalizeMemoryPathForWorkspace(workspaceDir: string, rawPath: string):
 function isShortTermMemoryPath(filePath: string): boolean {
   const normalized = normalizeMemoryPath(filePath);
   // Status only counts short-term source shapes; promoted diary/report files stay out.
-  if (/(?:^|\/)memory\/(\d{4})-(\d{2})-(\d{2})(?:-\d{4})?\.md$/.test(normalized)) {
+  if (/(?:^|\/)memory\/(\d{4})-(\d{2})-(\d{2})(?:-[^/]+)?\.md$/.test(normalized)) {
     return true;
   }
   if (


### PR DESCRIPTION
**Summary**

Aligns `isShortTermMemoryPath()` in the gateway doctor predicate with the memory-core short-term path contract. The regex now matches any slug suffix (`-HHMM` timestamps and `-vendor-pitch` descriptive slugs), fixing underreported dreaming stats. 2 files, +200/-1 lines.

**Root Cause**

The `isShortTermMemoryPath()` function in `src/gateway/server-methods/doctor.ts` used a strict regex at line 353 that only matched `memory/YYYY-MM-DD.md`. The memory-core short-term path contract at `extensions/memory-core/src/short-term-promotion.ts:27` already accepts `(?:-[^/]+)?` (any non-slash suffix), covering both numeric timestamp suffixes (`-HHMM`) and `llmSlug` descriptive names (`-vendor-pitch`). The gateway predicate was out of sync with this contract, so entries with any suffix were filtered before the dreaming stats counters ran.

- **Invariant violated**: `isShortTermMemoryPath()` should match the same path shapes that memory-core accepts as valid short-term memory files
- **Code path**: `doctor.memory.status` → iterate recall store entries → `isShortTermMemoryPath()` filter (line 524) → entries with timestamp or slug suffixes are discarded → `promotedToday`, `shortTermCount`, `promotedTotal` underreported
- **Sibling audit**: Memory-core `SHORT_TERM_PATH_RE` (short-term-promotion.ts:27): `/(?:^|\/)memory\/(?:[^/]+\/)*(\d{4})-(\d{2})-(\d{2})(?:-[^/]+)?\.md$/` uses `(?:-[^/]+)?`. Also: `session-corpus` regex at doctor.ts:357 already handles multiple extensions (`md|txt`), and session-memory HOOK.md documents `llmSlug` output as `YYYY-MM-DD-vendor-pitch.md`.

**Verification**

```
pnpm test src/gateway/server-methods/doctor.test.ts
```

- 2 test files, 62 tests passed (exit 0) — includes new regression test
- `pnpm build` passes cleanly

## Real behavior proof

**Behavior or issue addressed**: `isShortTermMemoryPath()` regex did not match daily memory files with any slug suffix (`-HHMM` timestamp or `-vendor-pitch` descriptive slug); now it does, matching the memory-core short-term path contract.

**Real environment tested**: Linux x86_64, Node v22.22.0, OpenClaw main @ f4a5e5762e, pnpm 11.2.2

**Exact steps or command run after this patch**:
```bash
pnpm test src/gateway/server-methods/doctor.test.ts
```

This runs the full `doctor.memory.status` gateway handler (not a copied regex snippet) against a populated recall store containing both timestamp-suffixed (`memory/YYYY-MM-DD-HHMM.md`) and slugged (`memory/YYYY-MM-DD-vendor-pitch.md`) entries with phase signals, and asserts the exact dreaming stat counts returned by the handler.

**Evidence after fix**:
```
 Test Files  2 passed (2)
      Tests  62 passed (62)
   Start at  19:01:39
   Duration  1.36s
```

The new regression test (`counts timestamp-suffixed and slugged recall-store entries in dreaming stats`) specifically validates:
- `memory/2026-06-04-1503.md` (timestamp suffix) → counted as promoted entry, promotedToday=1 ✅
- `memory/2026-06-03-vendor-pitch.md` (llmSlug suffix) → counted as promoted entry, promotedTotal=2 ✅
- `memory/2026-06-05-0930.md` (timestamp suffix) → counted as short-term entry with correct signal counts ✅

Source: [src/gateway/server-methods/doctor.ts:353](https://github.com/openclaw/openclaw/blob/main/src/gateway/server-methods/doctor.ts#L353) — regex changed from `(?:-\d{4})?` to `(?:-[^/]+)?` to match any slug suffix.

**Observed result after fix**: All 62 tests pass including the new regression test. The `doctor.memory.status` gateway handler (not a copied regex snippet) correctly counts both timestamp-suffixed and slugged recall-store entries. No regressions — plain `YYYY-MM-DD.md` paths continue to match.

**What was not tested**: End-to-end WebUI Dreams tab rendering with a live gateway and real recall store containing timestamp-suffixed/slugged entries.

**Review Findings Addressed**

- **[P2] Match the full short-term memory path contract** — Fixed: changed regex from `(?:-\d{4})?` to `(?:-[^/]+)?` to accept any slug suffix, aligning with memory-core's `SHORT_TERM_PATH_RE` at `extensions/memory-core/src/short-term-promotion.ts:27`.
- **[P1] Add a focused regression test** — Added: `counts timestamp-suffixed and slugged recall-store entries in dreaming stats` in `src/gateway/server-methods/doctor.test.ts` proves `doctor.memory.status` counts both `-HHMM` and `-vendor-pitch` entries.
- **[P1] Needs stronger real behavior proof** — Provided: test output shows `doctor.memory.status` handler (not copied regex) processing a real recall store with timestamp and slugged entries.

**Regression Test Plan**

```bash
pnpm test src/gateway/server-methods/doctor.test.ts
```

The new `counts timestamp-suffixed and slugged recall-store entries in dreaming stats` test creates a populated recall store with both `-HHMM` timestamp and `-vendor-pitch` slugged paths and asserts exact dreaming stat counts through the full `doctor.memory.status` gateway handler.

**Merge Risk**

Low. The change aligns the gateway doctor predicate with the existing memory-core short-term path contract (`(?:-[^/]+)?` instead of `(?:-\d{4})?`). The memory-core module already creates and accepts entries with these path shapes — the doctor just couldn't count them. All previously matching paths continue to match. No API surface changes.
