### PR TITLE
fix(gateway): surface approval delivery failures

### DIFF
--- a/src/gateway/exec-approval-ios-push.test.ts
+++ b/src/gateway/exec-approval-ios-push.test.ts
@@ -163,7 +163,7 @@ describe("createExecApprovalIosPushDelivery", () => {
 
     const accepted = await delivery.handleRequested(approvalRequest("approval-1"));
 
-    expect(accepted).toBe(false);
+    expect(accepted).toEqual({ delivered: false, attempted: false });
     expect(loadApnsRegistrationsMock).not.toHaveBeenCalled();
     expect(sendApnsExecApprovalAlertMock).not.toHaveBeenCalled();
   });
@@ -175,7 +175,7 @@ describe("createExecApprovalIosPushDelivery", () => {
 
     const accepted = await delivery.handleRequested(approvalRequest("approval-2"));
 
-    expect(accepted).toBe(true);
+    expect(accepted).toEqual({ delivered: true, attempted: true });
     expect(loadApnsRegistrationsMock).toHaveBeenCalledWith(["ios-device-1"]);
     expect(sendApnsExecApprovalAlertMock).toHaveBeenCalledTimes(1);
   });
@@ -216,7 +216,7 @@ describe("createExecApprovalIosPushDelivery", () => {
       isTargetVisible,
     });
 
-    expect(accepted).toBe(false);
+    expect(accepted).toEqual({ delivered: false, attempted: false });
     expect(isTargetVisible).toHaveBeenCalledWith({
       deviceId: "ios-device-1",
       scopes: ["operator.approvals", "operator.read"],
@@ -242,7 +242,7 @@ describe("createExecApprovalIosPushDelivery", () => {
 
     const accepted = await delivery.handleRequested(approvalRequest("approval-dead-route"));
 
-    expect(accepted).toBe(false);
+    expect(accepted).toEqual({ delivered: false, attempted: true });
     expect(sendApnsExecApprovalAlertMock).toHaveBeenCalledTimes(1);
     expect(warn).toHaveBeenCalledWith(
       "exec approvals: iOS request push failed node=ios-device-1 status=410 reason=Unregistered",

--- a/src/gateway/exec-approval-ios-push.ts
+++ b/src/gateway/exec-approval-ios-push.ts
@@ -362,7 +362,7 @@ export function createExecApprovalIosPushDelivery(params: { log: GatewayLikeLogg
     async handleRequested(
       request: ExecApprovalRequest,
       opts?: { isTargetVisible?: (target: ApprovalPushTarget) => boolean },
-    ): Promise<boolean> {
+    ): Promise<{ delivered: boolean; attempted: boolean }> {
       const deliveryStatePromise = (async (): Promise<ApprovalDeliveryState | null> => {
         const plan = await resolveDeliveryPlan({
           requireApprovalScope: true,
@@ -394,7 +394,7 @@ export function createExecApprovalIosPushDelivery(params: { log: GatewayLikeLogg
         pendingDeliveryStateById.delete(request.id);
       }
       if (!deliveryState) {
-        return false;
+        return { delivered: false, attempted: false };
       }
 
       const { attempted, delivered } = await deliveryState.requestPushPromise;
@@ -408,9 +408,9 @@ export function createExecApprovalIosPushDelivery(params: { log: GatewayLikeLogg
         ) {
           approvalDeliveriesById.delete(request.id);
         }
-        return false;
+        return { delivered: false, attempted: true };
       }
-      return true;
+      return { delivered: true, attempted: true };
     },
 
     /** Sends cleanup wakes for resolved approval requests. */

--- a/src/gateway/server-methods/approval-shared.test.ts
+++ b/src/gateway/server-methods/approval-shared.test.ts
@@ -325,7 +325,7 @@ describe("handlePendingApprovalRequest", () => {
     await requestPromise;
   });
 
-  it("expires when explicit delivery fails instead of falling back to turn-source routing", async () => {
+  it("keeps turn-source approvals pending when explicit delivery fails", async () => {
     const manager = new ExecApprovalManager();
     const record = manager.create(
       {
@@ -360,26 +360,20 @@ describe("handlePendingApprovalRequest", () => {
     });
 
     await Promise.resolve();
-    let assertionError: Error | undefined;
-    try {
-      expect(hasApprovalTurnSourceRouteMock).not.toHaveBeenCalled();
-      expect(manager.getSnapshot(record.id)?.resolvedBy).toBe("no-approval-route");
-      expect(respond).toHaveBeenCalledWith(
-        true,
-        expect.objectContaining({ id: "approval-explicit-delivery-failed", decision: null }),
-        undefined,
-      );
-    } catch (err) {
-      assertionError = err instanceof Error ? err : new Error(String(err));
-    } finally {
-      if (manager.getSnapshot(record.id)?.resolvedAtMs === undefined) {
-        manager.resolve(record.id, "deny");
-      }
-      await requestPromise;
-    }
-    if (assertionError) {
-      throw assertionError;
-    }
+    expect(hasApprovalTurnSourceRouteMock).toHaveBeenCalledWith({
+      turnSourceChannel: "slack",
+      turnSourceAccountId: "work",
+      approvalKind: "exec",
+    });
+    expect(manager.getSnapshot(record.id)?.resolvedBy).not.toBe("no-approval-route");
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ id: "approval-explicit-delivery-failed", status: "accepted" }),
+      undefined,
+    );
+
+    expect(manager.resolve(record.id, "allow-once")).toBe(true);
+    await requestPromise;
   });
 
   it("targets requested approval events to visible approval clients when available", async () => {

--- a/src/gateway/server-methods/approval-shared.test.ts
+++ b/src/gateway/server-methods/approval-shared.test.ts
@@ -360,7 +360,7 @@ describe("handlePendingApprovalRequest", () => {
     });
 
     await Promise.resolve();
-    let assertionError: unknown;
+    let assertionError: Error | undefined;
     try {
       expect(hasApprovalTurnSourceRouteMock).not.toHaveBeenCalled();
       expect(manager.getSnapshot(record.id)?.resolvedBy).toBe("no-approval-route");
@@ -370,7 +370,7 @@ describe("handlePendingApprovalRequest", () => {
         undefined,
       );
     } catch (err) {
-      assertionError = err;
+      assertionError = err instanceof Error ? err : new Error(String(err));
     } finally {
       if (manager.getSnapshot(record.id)?.resolvedAtMs === undefined) {
         manager.resolve(record.id, "deny");

--- a/src/gateway/server-methods/approval-shared.test.ts
+++ b/src/gateway/server-methods/approval-shared.test.ts
@@ -325,6 +325,63 @@ describe("handlePendingApprovalRequest", () => {
     await requestPromise;
   });
 
+  it("expires when explicit delivery fails instead of falling back to turn-source routing", async () => {
+    const manager = new ExecApprovalManager();
+    const record = manager.create(
+      {
+        command: "echo ok",
+        turnSourceChannel: "slack",
+        turnSourceAccountId: "work",
+      },
+      60_000,
+      "approval-explicit-delivery-failed",
+    );
+    const decisionPromise = manager.register(record, 60_000);
+    const respond = vi.fn();
+    const requestPromise = handlePendingApprovalRequest({
+      manager,
+      record,
+      decisionPromise,
+      respond,
+      context: {
+        broadcast: vi.fn(),
+        hasExecApprovalClients: () => false,
+      } as unknown as GatewayRequestContext,
+      requestEventName: "exec.approval.requested",
+      requestEvent: {
+        id: record.id,
+        request: record.request,
+        createdAtMs: record.createdAtMs,
+        expiresAtMs: record.expiresAtMs,
+      },
+      twoPhase: true,
+      approvalKind: "exec",
+      deliverRequest: () => ({ delivered: false, attempted: true }),
+    });
+
+    await Promise.resolve();
+    let assertionError: unknown;
+    try {
+      expect(hasApprovalTurnSourceRouteMock).not.toHaveBeenCalled();
+      expect(manager.getSnapshot(record.id)?.resolvedBy).toBe("no-approval-route");
+      expect(respond).toHaveBeenCalledWith(
+        true,
+        expect.objectContaining({ id: "approval-explicit-delivery-failed", decision: null }),
+        undefined,
+      );
+    } catch (err) {
+      assertionError = err;
+    } finally {
+      if (manager.getSnapshot(record.id)?.resolvedAtMs === undefined) {
+        manager.resolve(record.id, "deny");
+      }
+      await requestPromise;
+    }
+    if (assertionError) {
+      throw assertionError;
+    }
+  });
+
   it("targets requested approval events to visible approval clients when available", async () => {
     const manager = new ExecApprovalManager();
     const record = manager.create(

--- a/src/gateway/server-methods/approval-shared.test.ts
+++ b/src/gateway/server-methods/approval-shared.test.ts
@@ -325,7 +325,7 @@ describe("handlePendingApprovalRequest", () => {
     await requestPromise;
   });
 
-  it("keeps turn-source approvals pending when explicit delivery fails", async () => {
+  it("expires turn-source approvals when explicit delivery fails", async () => {
     const manager = new ExecApprovalManager();
     const record = manager.create(
       {
@@ -338,7 +338,8 @@ describe("handlePendingApprovalRequest", () => {
     );
     const decisionPromise = manager.register(record, 60_000);
     const respond = vi.fn();
-    const requestPromise = handlePendingApprovalRequest({
+
+    await handlePendingApprovalRequest({
       manager,
       record,
       decisionPromise,
@@ -359,21 +360,13 @@ describe("handlePendingApprovalRequest", () => {
       deliverRequest: () => ({ delivered: false, attempted: true }),
     });
 
-    await Promise.resolve();
-    expect(hasApprovalTurnSourceRouteMock).toHaveBeenCalledWith({
-      turnSourceChannel: "slack",
-      turnSourceAccountId: "work",
-      approvalKind: "exec",
-    });
-    expect(manager.getSnapshot(record.id)?.resolvedBy).not.toBe("no-approval-route");
+    expect(hasApprovalTurnSourceRouteMock).not.toHaveBeenCalled();
+    expect(manager.getSnapshot(record.id)?.resolvedBy).toBe("no-approval-route");
     expect(respond).toHaveBeenCalledWith(
       true,
-      expect.objectContaining({ id: "approval-explicit-delivery-failed", status: "accepted" }),
+      expect.objectContaining({ id: "approval-explicit-delivery-failed", decision: null }),
       undefined,
     );
-
-    expect(manager.resolve(record.id, "allow-once")).toBe(true);
-    await requestPromise;
   });
 
   it("targets requested approval events to visible approval clients when available", async () => {

--- a/src/gateway/server-methods/approval-shared.ts
+++ b/src/gateway/server-methods/approval-shared.ts
@@ -458,7 +458,6 @@ export async function handlePendingApprovalRequest<
   const hasTurnSourceRoute =
     !hasApprovalClients &&
     !delivery.delivered &&
-    !delivery.attempted &&
     hasApprovalTurnSourceRoute({
       turnSourceChannel: params.record.request.turnSourceChannel,
       turnSourceAccountId: params.record.request.turnSourceAccountId,

--- a/src/gateway/server-methods/approval-shared.ts
+++ b/src/gateway/server-methods/approval-shared.ts
@@ -51,6 +51,13 @@ type RequestedApprovalEvent<TPayload extends ApprovalTurnSourceFields> = {
   expiresAtMs: number;
 };
 
+type ApprovalDeliveryResult =
+  | boolean
+  | {
+      delivered: boolean;
+      attempted?: boolean;
+    };
+
 type PendingApprovalListEntry<TPayload> = {
   id: string;
   request: TPayload;
@@ -82,6 +89,16 @@ type ApprovalRecordLookupResult<TPayload> =
 
 function isPromiseLike<T>(value: T | Promise<T>): value is Promise<T> {
   return typeof value === "object" && value !== null && "then" in value;
+}
+
+function normalizeApprovalDeliveryResult(result: ApprovalDeliveryResult): {
+  delivered: boolean;
+  attempted: boolean;
+} {
+  if (typeof result === "boolean") {
+    return { delivered: result, attempted: result };
+  }
+  return { delivered: result.delivered, attempted: result.attempted === true };
 }
 
 export function isApprovalDecision(value: string): value is ExecApprovalDecision {
@@ -394,7 +411,7 @@ export async function handlePendingApprovalRequest<
   requestEvent: RequestedApprovalEvent<TPayload>;
   twoPhase: boolean;
   approvalKind?: "exec" | "plugin";
-  deliverRequest: () => boolean | Promise<boolean>;
+  deliverRequest: () => ApprovalDeliveryResult | Promise<ApprovalDeliveryResult>;
   afterDecision?: (
     decision: ExecApprovalDecision | null,
     requestEvent: RequestedApprovalEvent<TPayload>,
@@ -433,12 +450,15 @@ export async function handlePendingApprovalRequest<
       ? approvalClientConnIds.size > 0
       : (params.context.hasExecApprovalClients?.(params.clientConnId) ?? false);
   const deliveredResult = suppressDelivery ? false : params.deliverRequest();
-  const delivered = isPromiseLike(deliveredResult) ? await deliveredResult : deliveredResult;
+  const delivery = normalizeApprovalDeliveryResult(
+    isPromiseLike(deliveredResult) ? await deliveredResult : deliveredResult,
+  );
   // A turn-source route can approve without an active approval client, so keep
   // the record alive when the originating channel/account can still receive it.
   const hasTurnSourceRoute =
     !hasApprovalClients &&
-    !delivered &&
+    !delivery.delivered &&
+    !delivery.attempted &&
     hasApprovalTurnSourceRoute({
       turnSourceChannel: params.record.request.turnSourceChannel,
       turnSourceAccountId: params.record.request.turnSourceAccountId,
@@ -450,7 +470,7 @@ export async function handlePendingApprovalRequest<
     !params.keepPendingWithoutRoute &&
     !hasApprovalClients &&
     !hasTurnSourceRoute &&
-    !delivered
+    !delivery.delivered
   ) {
     params.manager.expire(params.record.id, "no-approval-route");
     params.respond(

--- a/src/gateway/server-methods/approval-shared.ts
+++ b/src/gateway/server-methods/approval-shared.ts
@@ -449,28 +449,20 @@ export async function handlePendingApprovalRequest<
     : approvalClientConnIds !== null
       ? approvalClientConnIds.size > 0
       : (params.context.hasExecApprovalClients?.(params.clientConnId) ?? false);
+  const deliveredResult = suppressDelivery ? false : params.deliverRequest();
+  const delivery = normalizeApprovalDeliveryResult(
+    isPromiseLike(deliveredResult) ? await deliveredResult : deliveredResult,
+  );
   // A turn-source route can approve without an active approval client, so keep
-  // the record alive when the originating channel/account can still receive it.
+  // the record alive when no explicit delivery route was attempted.
   const hasTurnSourceRoute =
     !hasApprovalClients &&
+    !delivery.attempted &&
     hasApprovalTurnSourceRoute({
       turnSourceChannel: params.record.request.turnSourceChannel,
       turnSourceAccountId: params.record.request.turnSourceAccountId,
       approvalKind: params.approvalKind ?? "exec",
     });
-  const deliveredResult = suppressDelivery ? false : params.deliverRequest();
-  const delivery = hasTurnSourceRoute
-    ? { delivered: false, attempted: false }
-    : normalizeApprovalDeliveryResult(
-        isPromiseLike(deliveredResult) ? await deliveredResult : deliveredResult,
-      );
-  if (hasTurnSourceRoute && isPromiseLike(deliveredResult)) {
-    void deliveredResult.catch((err: unknown) => {
-      params.context.logGateway?.error?.(
-        `approval delivery failed while turn-source fallback is available: ${String(err)}`,
-      );
-    });
-  }
 
   if (
     params.requireDeliveryRoute !== false &&

--- a/src/gateway/server-methods/approval-shared.ts
+++ b/src/gateway/server-methods/approval-shared.ts
@@ -449,20 +449,28 @@ export async function handlePendingApprovalRequest<
     : approvalClientConnIds !== null
       ? approvalClientConnIds.size > 0
       : (params.context.hasExecApprovalClients?.(params.clientConnId) ?? false);
-  const deliveredResult = suppressDelivery ? false : params.deliverRequest();
-  const delivery = normalizeApprovalDeliveryResult(
-    isPromiseLike(deliveredResult) ? await deliveredResult : deliveredResult,
-  );
   // A turn-source route can approve without an active approval client, so keep
   // the record alive when the originating channel/account can still receive it.
   const hasTurnSourceRoute =
     !hasApprovalClients &&
-    !delivery.delivered &&
     hasApprovalTurnSourceRoute({
       turnSourceChannel: params.record.request.turnSourceChannel,
       turnSourceAccountId: params.record.request.turnSourceAccountId,
       approvalKind: params.approvalKind ?? "exec",
     });
+  const deliveredResult = suppressDelivery ? false : params.deliverRequest();
+  const delivery = hasTurnSourceRoute
+    ? { delivered: false, attempted: false }
+    : normalizeApprovalDeliveryResult(
+        isPromiseLike(deliveredResult) ? await deliveredResult : deliveredResult,
+      );
+  if (hasTurnSourceRoute && isPromiseLike(deliveredResult)) {
+    void deliveredResult.catch((err: unknown) => {
+      params.context.logGateway?.error?.(
+        `approval delivery failed while turn-source fallback is available: ${String(err)}`,
+      );
+    });
+  }
 
   if (
     params.requireDeliveryRoute !== false &&

--- a/src/gateway/server-methods/exec-approval.ts
+++ b/src/gateway/server-methods/exec-approval.ts
@@ -52,16 +52,37 @@ const APPROVAL_ALLOW_ALWAYS_UNAVAILABLE_DETAILS = {
 } as const;
 const RESERVED_PLUGIN_APPROVAL_ID_PREFIX = "plugin:";
 
+type ApprovalDeliveryTaskResult = {
+  delivered: boolean;
+  attempted: boolean;
+};
+
+type ApprovalDeliveryHandlerResult =
+  | boolean
+  | {
+      delivered: boolean;
+      attempted?: boolean;
+    };
+
 type ExecApprovalIosPushDelivery = {
   handleRequested?: (
     request: ExecApprovalRequest,
     opts?: {
       isTargetVisible?: (target: { deviceId: string; scopes: readonly string[] }) => boolean;
     },
-  ) => Promise<boolean>;
+  ) => Promise<ApprovalDeliveryHandlerResult>;
   handleResolved?: (resolved: ExecApprovalResolved) => Promise<void>;
   handleExpired?: (request: ExecApprovalRequest) => Promise<void>;
 };
+
+function normalizeDeliveryTaskResult(
+  result: ApprovalDeliveryHandlerResult,
+): ApprovalDeliveryTaskResult {
+  if (typeof result === "boolean") {
+    return { delivered: result, attempted: result };
+  }
+  return { delivered: result.delivered, attempted: result.attempted === true };
+}
 
 function normalizeCommandSpans(
   spans: { startIndex: number; endIndex: number }[] | undefined,
@@ -354,15 +375,18 @@ export function createExecApprovalHandlers(
         requireDeliveryRoute: p.requireDeliveryRoute,
         suppressDelivery: p.suppressDelivery,
         deliverRequest: () => {
-          const deliveryTasks: Array<Promise<boolean>> = [];
+          const deliveryTasks: Array<Promise<ApprovalDeliveryTaskResult>> = [];
           if (opts?.forwarder) {
             deliveryTasks.push(
-              opts.forwarder.handleRequested(requestEvent).catch((err: unknown) => {
-                context.logGateway?.error?.(
-                  `exec approvals: forward request failed: ${String(err)}`,
-                );
-                return false;
-              }),
+              opts.forwarder
+                .handleRequested(requestEvent)
+                .then(normalizeDeliveryTaskResult)
+                .catch((err: unknown) => {
+                  context.logGateway?.error?.(
+                    `exec approvals: forward request failed: ${String(err)}`,
+                  );
+                  return { delivered: false, attempted: true };
+                }),
             );
           }
           if (opts?.iosPushDelivery?.handleRequested) {
@@ -381,23 +405,27 @@ export function createExecApprovalHandlers(
                       } as GatewayClient,
                     }),
                 })
+                .then(normalizeDeliveryTaskResult)
                 .catch((err: unknown) => {
                   context.logGateway?.error?.(
                     `exec approvals: iOS push request failed: ${String(err)}`,
                   );
-                  return false;
+                  return { delivered: false, attempted: true };
                 }),
             );
           }
           if (deliveryTasks.length === 0) {
-            return false;
+            return { delivered: false, attempted: false };
           }
           return (async () => {
             let delivered = false;
+            let attempted = false;
             for (const task of deliveryTasks) {
-              delivered = (await task) || delivered;
+              const result = await task;
+              delivered = result.delivered || delivered;
+              attempted = result.attempted || attempted;
             }
-            return delivered;
+            return { delivered, attempted };
           })();
         },
         afterDecision: async (decision) => {

--- a/src/gateway/server-methods/plugin-approval.test.ts
+++ b/src/gateway/server-methods/plugin-approval.test.ts
@@ -382,7 +382,7 @@ describe("createPluginApprovalHandlers", () => {
       }
     });
 
-    it("expires plugin approvals when explicit forwarding fails despite originating chat routing", async () => {
+    it("keeps plugin approvals pending when explicit forwarding fails but originating chat can approve", async () => {
       const forwarder = {
         handleRequested: vi.fn(async () => false),
         handleResolved: vi.fn(async () => {}),
@@ -399,6 +399,7 @@ describe("createPluginApprovalHandlers", () => {
         {
           title: "Sensitive action",
           description: "Desc",
+          twoPhase: true,
           turnSourceChannel: "slack",
           turnSourceTo: "C123",
         },
@@ -408,10 +409,12 @@ describe("createPluginApprovalHandlers", () => {
         },
       );
 
-      await handlers["plugin.approval.request"](opts);
+      const requestPromise = handlers["plugin.approval.request"](opts);
+      const approvalId = await waitForAcceptedApproval(respond);
 
       expect(forwarder.handlePluginApprovalRequested).toHaveBeenCalledTimes(1);
-      expect(expectResponseOk(respond).decision).toBeNull();
+      manager.resolve(approvalId, "allow-once");
+      await requestPromise;
     });
 
     it.each(invalidRequestCases)("rejects $name", async ({ params }) => {

--- a/src/gateway/server-methods/plugin-approval.test.ts
+++ b/src/gateway/server-methods/plugin-approval.test.ts
@@ -382,7 +382,7 @@ describe("createPluginApprovalHandlers", () => {
       }
     });
 
-    it("keeps plugin approvals pending when explicit forwarding fails but originating chat can approve", async () => {
+    it("expires plugin approvals when explicit forwarding fails", async () => {
       const forwarder = {
         handleRequested: vi.fn(async () => false),
         handleResolved: vi.fn(async () => {}),
@@ -409,12 +409,12 @@ describe("createPluginApprovalHandlers", () => {
         },
       );
 
-      const requestPromise = handlers["plugin.approval.request"](opts);
-      const approvalId = await waitForAcceptedApproval(respond);
+      await handlers["plugin.approval.request"](opts);
 
       expect(forwarder.handlePluginApprovalRequested).toHaveBeenCalledTimes(1);
-      manager.resolve(approvalId, "allow-once");
-      await requestPromise;
+      const result = expectResponseOk(respond);
+      expect(result.decision).toBeNull();
+      expect(manager.getSnapshot(String(result.id))?.resolvedBy).toBe("no-approval-route");
     });
 
     it.each(invalidRequestCases)("rejects $name", async ({ params }) => {

--- a/src/gateway/server-methods/plugin-approval.test.ts
+++ b/src/gateway/server-methods/plugin-approval.test.ts
@@ -382,6 +382,38 @@ describe("createPluginApprovalHandlers", () => {
       }
     });
 
+    it("expires plugin approvals when explicit forwarding fails despite originating chat routing", async () => {
+      const forwarder = {
+        handleRequested: vi.fn(async () => false),
+        handleResolved: vi.fn(async () => {}),
+        handlePluginApprovalRequested: vi.fn(async () => {
+          throw new Error("plugin delivery failed");
+        }),
+        handlePluginApprovalResolved: vi.fn(async () => {}),
+        stop: vi.fn(),
+      };
+      const handlers = createPluginApprovalHandlers(manager, { forwarder });
+      const respond = vi.fn();
+      const opts = createMockOptions(
+        "plugin.approval.request",
+        {
+          title: "Sensitive action",
+          description: "Desc",
+          turnSourceChannel: "slack",
+          turnSourceTo: "C123",
+        },
+        {
+          respond,
+          context: createApprovalContext({ hasExecApprovalClients: () => false }),
+        },
+      );
+
+      await handlers["plugin.approval.request"](opts);
+
+      expect(forwarder.handlePluginApprovalRequested).toHaveBeenCalledTimes(1);
+      expect(expectResponseOk(respond).decision).toBeNull();
+    });
+
     it.each(invalidRequestCases)("rejects $name", async ({ params }) => {
       const handlers = createPluginApprovalHandlers(manager);
       const opts = createMockOptions("plugin.approval.request", params);

--- a/src/gateway/server-methods/plugin-approval.ts
+++ b/src/gateway/server-methods/plugin-approval.ts
@@ -125,15 +125,16 @@ export function createPluginApprovalHandlers(
         approvalKind: "plugin",
         deliverRequest: () => {
           if (!opts?.forwarder?.handlePluginApprovalRequested) {
-            return false;
+            return { delivered: false, attempted: false };
           }
           return opts.forwarder
             .handlePluginApprovalRequested(requestEvent)
+            .then((delivered) => ({ delivered, attempted: delivered }))
             .catch((err: unknown) => {
               context.logGateway?.error?.(
                 `plugin approvals: forward request failed: ${String(err)}`,
               );
-              return false;
+              return { delivered: false, attempted: true };
             });
         },
       });

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -3442,7 +3442,12 @@ describe("exec approval handlers", () => {
     const { manager, handlers, forwarder, respond, context } =
       createForwardingExecApprovalFixture();
     const expireSpy = vi.spyOn(manager, "expire");
-    forwarder.handleRequested.mockRejectedValueOnce(new Error("approval delivery failed"));
+    let rejectDelivery: (err: Error) => void = () => {};
+    forwarder.handleRequested.mockReturnValueOnce(
+      new Promise<boolean>((_, reject) => {
+        rejectDelivery = reject;
+      }),
+    );
 
     const requestPromise = requestExecApproval({
       handlers,
@@ -3469,6 +3474,9 @@ describe("exec approval handlers", () => {
 
     expect(forwarder.handleRequested).toHaveBeenCalledTimes(1);
     expect(expireSpy).not.toHaveBeenCalled();
+
+    rejectDelivery(new Error("approval delivery failed"));
+    await Promise.resolve();
 
     manager.resolve("approval-forwarding-failed", "allow-once");
     await requestPromise;

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -3438,7 +3438,7 @@ describe("exec approval handlers", () => {
     }
   });
 
-  it("keeps originating chat fallback when explicit exec forwarding fails", async () => {
+  it("expires approvals when explicit exec forwarding fails", async () => {
     const { manager, handlers, forwarder, respond, context } =
       createForwardingExecApprovalFixture();
     const expireSpy = vi.spyOn(manager, "expire");
@@ -3464,22 +3464,19 @@ describe("exec approval handlers", () => {
     });
 
     await vi.waitFor(() => {
-      expect(lastMockCallArg(respond)).toBe(true);
-      expectRecordFields(lastMockCallArg(respond, 1), {
-        status: "accepted",
-        id: "approval-forwarding-failed",
-      });
-      expect(lastMockCallArg(respond, 2)).toBeUndefined();
+      expect(forwarder.handleRequested).toHaveBeenCalledTimes(1);
     });
 
-    expect(forwarder.handleRequested).toHaveBeenCalledTimes(1);
-    expect(expireSpy).not.toHaveBeenCalled();
-
     rejectDelivery(new Error("approval delivery failed"));
-    await Promise.resolve();
-
-    manager.resolve("approval-forwarding-failed", "allow-once");
     await requestPromise;
+
+    expect(expireSpy).toHaveBeenCalledWith("approval-forwarding-failed", "no-approval-route");
+    expect(lastMockCallArg(respond)).toBe(true);
+    expectRecordFields(lastMockCallArg(respond, 1), {
+      id: "approval-forwarding-failed",
+      decision: null,
+    });
+    expect(lastMockCallArg(respond, 2)).toBeUndefined();
   });
 
   it("keeps approvals pending when the originating chat can handle /approve directly", async () => {

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -3438,6 +3438,36 @@ describe("exec approval handlers", () => {
     }
   });
 
+  it("expires when explicit exec forwarding fails instead of falling back to originating chat", async () => {
+    const { manager, handlers, forwarder, respond, context } =
+      createForwardingExecApprovalFixture();
+    const expireSpy = vi.spyOn(manager, "expire");
+    forwarder.handleRequested.mockRejectedValueOnce(new Error("approval delivery failed"));
+
+    await requestExecApproval({
+      handlers,
+      respond,
+      context,
+      params: {
+        twoPhase: true,
+        timeoutMs: 60_000,
+        id: "approval-forwarding-failed",
+        host: "gateway",
+        turnSourceChannel: "slack",
+        turnSourceTo: "D123",
+      },
+    });
+
+    expect(forwarder.handleRequested).toHaveBeenCalledTimes(1);
+    expect(expireSpy).toHaveBeenCalledWith("approval-forwarding-failed", "no-approval-route");
+    expect(lastMockCallArg(respond)).toBe(true);
+    expectRecordFields(lastMockCallArg(respond, 1), {
+      id: "approval-forwarding-failed",
+      decision: null,
+    });
+    expect(lastMockCallArg(respond, 2)).toBeUndefined();
+  });
+
   it("keeps approvals pending when the originating chat can handle /approve directly", async () => {
     vi.useFakeTimers();
     try {

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -3438,13 +3438,13 @@ describe("exec approval handlers", () => {
     }
   });
 
-  it("expires when explicit exec forwarding fails instead of falling back to originating chat", async () => {
+  it("keeps originating chat fallback when explicit exec forwarding fails", async () => {
     const { manager, handlers, forwarder, respond, context } =
       createForwardingExecApprovalFixture();
     const expireSpy = vi.spyOn(manager, "expire");
     forwarder.handleRequested.mockRejectedValueOnce(new Error("approval delivery failed"));
 
-    await requestExecApproval({
+    const requestPromise = requestExecApproval({
       handlers,
       respond,
       context,
@@ -3458,14 +3458,20 @@ describe("exec approval handlers", () => {
       },
     });
 
-    expect(forwarder.handleRequested).toHaveBeenCalledTimes(1);
-    expect(expireSpy).toHaveBeenCalledWith("approval-forwarding-failed", "no-approval-route");
-    expect(lastMockCallArg(respond)).toBe(true);
-    expectRecordFields(lastMockCallArg(respond, 1), {
-      id: "approval-forwarding-failed",
-      decision: null,
+    await vi.waitFor(() => {
+      expect(lastMockCallArg(respond)).toBe(true);
+      expectRecordFields(lastMockCallArg(respond, 1), {
+        status: "accepted",
+        id: "approval-forwarding-failed",
+      });
+      expect(lastMockCallArg(respond, 2)).toBeUndefined();
     });
-    expect(lastMockCallArg(respond, 2)).toBeUndefined();
+
+    expect(forwarder.handleRequested).toHaveBeenCalledTimes(1);
+    expect(expireSpy).not.toHaveBeenCalled();
+
+    manager.resolve("approval-forwarding-failed", "allow-once");
+    await requestPromise;
   });
 
   it("keeps approvals pending when the originating chat can handle /approve directly", async () => {

--- a/src/infra/exec-approval-forwarder.test.ts
+++ b/src/infra/exec-approval-forwarder.test.ts
@@ -423,6 +423,61 @@ describe("exec approval forwarder", () => {
     expect(deliver).toHaveBeenCalledTimes(2);
   });
 
+  it("reports request delivery failure when all approval targets fail", async () => {
+    vi.useFakeTimers();
+    const deliver = vi.fn().mockResolvedValue({
+      status: "failed",
+      error: new Error("Outbound not configured for channel: discord"),
+    });
+    const { forwarder } = createForwarder({
+      cfg: makeTargetsCfg([{ channel: "discord", to: "channel:123" }]),
+      deliver,
+    });
+
+    await expect(forwarder.handleRequested(baseRequest)).rejects.toThrow(
+      "exec approvals: failed to deliver request req-1",
+    );
+    expect(deliver).toHaveBeenCalledTimes(1);
+
+    await forwarder.handleResolved({
+      id: baseRequest.id,
+      decision: "allow-once",
+      resolvedBy: "discord:channel:123",
+      ts: 2000,
+    });
+    await vi.advanceTimersByTimeAsync(baseRequest.expiresAtMs - baseRequest.createdAtMs);
+    expect(deliver).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps approval pending when at least one request target delivers", async () => {
+    vi.useFakeTimers();
+    const deliver = vi
+      .fn()
+      .mockResolvedValueOnce({
+        status: "failed",
+        error: new Error("first target failed"),
+      })
+      .mockResolvedValue([]);
+    const { forwarder } = createForwarder({
+      cfg: makeTargetsCfg([
+        { channel: "discord", to: "channel:123" },
+        { channel: "slack", to: "U123" },
+      ]),
+      deliver,
+    });
+
+    await expect(forwarder.handleRequested(baseRequest)).resolves.toBe(true);
+    expect(deliver).toHaveBeenCalledTimes(2);
+
+    await forwarder.handleResolved({
+      id: baseRequest.id,
+      decision: "allow-once",
+      resolvedBy: "slack:U123",
+      ts: 2000,
+    });
+    expect(deliver).toHaveBeenCalledTimes(4);
+  });
+
   it("deduplicates session and explicit approval targets through normalized route identity", async () => {
     vi.useFakeTimers();
     const cfg = {

--- a/src/infra/exec-approval-forwarder.test.ts
+++ b/src/infra/exec-approval-forwarder.test.ts
@@ -478,6 +478,34 @@ describe("exec approval forwarder", () => {
     expect(deliver).toHaveBeenCalledTimes(4);
   });
 
+  it("keeps approval pending when partial_failed includes visible delivery results", async () => {
+    vi.useFakeTimers();
+    const deliver = vi
+      .fn()
+      .mockResolvedValueOnce({
+        status: "partial_failed",
+        results: [{ ok: true }],
+        error: new Error("later payload failed"),
+        sentBeforeError: true,
+      })
+      .mockResolvedValue([]);
+    const { forwarder } = createForwarder({
+      cfg: TARGETS_CFG,
+      deliver,
+    });
+
+    await expect(forwarder.handleRequested(baseRequest)).resolves.toBe(true);
+    expect(deliver).toHaveBeenCalledTimes(1);
+
+    await forwarder.handleResolved({
+      id: baseRequest.id,
+      decision: "allow-once",
+      resolvedBy: "slack:U123",
+      ts: 2000,
+    });
+    expect(deliver).toHaveBeenCalledTimes(2);
+  });
+
   it("deduplicates session and explicit approval targets through normalized route identity", async () => {
     vi.useFakeTimers();
     const cfg = {

--- a/src/infra/exec-approval-forwarder.ts
+++ b/src/infra/exec-approval-forwarder.ts
@@ -396,7 +396,7 @@ async function deliverToTargets(params: {
         payloads: [payload],
       });
       if (send.status === "failed" || send.status === "partial_failed") {
-        throw send.error;
+        throw send.error instanceof Error ? send.error : new Error(String(send.error));
       }
       return { attempted: true, delivered: true, failed: false };
     } catch (err) {

--- a/src/infra/exec-approval-forwarder.ts
+++ b/src/infra/exec-approval-forwarder.ts
@@ -59,6 +59,12 @@ type ResolveSessionTargetFn = (params: {
 type ApprovalKind = "exec" | "plugin";
 type ForwardTarget = ExecApprovalForwardTarget & { source: "session" | "target" };
 
+type DeliverySummary = {
+  attempted: number;
+  delivered: number;
+  failed: number;
+};
+
 type ApprovalRouteRequest = {
   agentId?: string | null;
   sessionKey?: string | null;
@@ -369,14 +375,14 @@ async function deliverToTargets(params: {
   deliver: DeliverApprovalPayloads;
   beforeDeliver?: (target: ForwardTarget, payload: ReplyPayload) => Promise<void> | void;
   shouldSend?: () => boolean;
-}) {
+}): Promise<DeliverySummary> {
   const deliveries = params.targets.map(async (target) => {
     if (params.shouldSend && !params.shouldSend()) {
-      return;
+      return { attempted: false, delivered: false, failed: false };
     }
     const channel = normalizeMessageChannel(target.channel) ?? target.channel;
     if (!isDeliverableMessageChannel(channel)) {
-      return;
+      return { attempted: false, delivered: false, failed: false };
     }
     try {
       const payload = params.buildPayload(target);
@@ -392,11 +398,21 @@ async function deliverToTargets(params: {
       if (send.status === "failed" || send.status === "partial_failed") {
         throw send.error;
       }
+      return { attempted: true, delivered: true, failed: false };
     } catch (err) {
       log.error(`exec approvals: failed to deliver to ${channel}:${target.to}: ${String(err)}`);
+      return { attempted: true, delivered: false, failed: true };
     }
   });
-  await Promise.allSettled(deliveries);
+  const results = await Promise.all(deliveries);
+  return results.reduce(
+    (summary, result) => ({
+      attempted: summary.attempted + (result.attempted ? 1 : 0),
+      delivered: summary.delivered + (result.delivered ? 1 : 0),
+      failed: summary.failed + (result.failed ? 1 : 0),
+    }),
+    { attempted: 0, delivered: 0, failed: 0 },
+  );
 }
 
 function buildApprovalRenderPayload<TParams>(params: {
@@ -604,7 +620,7 @@ function createApprovalHandlers<
       return false;
     }
 
-    void deliverToTargets({
+    const delivery = await deliverToTargets({
       cfg,
       targets: filteredTargets,
       buildPayload: (target) =>
@@ -632,11 +648,20 @@ function createApprovalHandlers<
       },
       deliver: params.deliver,
       shouldSend: () => pending.get(requestId) === pendingEntry,
-    }).catch((err: unknown) => {
-      log.error(
-        `${params.strategy.kind} approvals: failed to deliver request ${requestId}: ${String(err)}`,
-      );
     });
+    if (delivery.delivered === 0) {
+      const entry = pending.get(requestId);
+      if (entry === pendingEntry) {
+        pending.delete(requestId);
+        clearTimeout(timeoutId);
+      }
+      if (delivery.attempted > 0 && delivery.failed > 0) {
+        throw new Error(
+          `${params.strategy.kind} approvals: failed to deliver request ${requestId}`,
+        );
+      }
+      return false;
+    }
     return true;
   };
 

--- a/src/infra/exec-approval-forwarder.ts
+++ b/src/infra/exec-approval-forwarder.ts
@@ -395,7 +395,13 @@ async function deliverToTargets(params: {
         threadId: target.threadId,
         payloads: [payload],
       });
-      if (send.status === "failed" || send.status === "partial_failed") {
+      if (send.status === "failed") {
+        throw send.error instanceof Error ? send.error : new Error(String(send.error));
+      }
+      if (send.status === "partial_failed") {
+        if (send.results.length > 0) {
+          return { attempted: true, delivered: true, failed: true };
+        }
         throw send.error instanceof Error ? send.error : new Error(String(send.error));
       }
       return { attempted: true, delivered: true, failed: false };


### PR DESCRIPTION
## Summary

- Fixes #89217.
- Problem: explicit exec/plugin approval delivery failures were flattened into the same `false` value as an unconfigured delivery route. When the originating turn source could route approvals, the shared lifecycle could keep an approval pending even after a configured delivery path had actually been attempted and failed.
- Solution: carry delivery result metadata as `{ delivered, attempted }` through shared approval handling, exec approval forwarding, plugin approval forwarding, and iOS push delivery. A configured delivery path that is attempted and fails now expires the approval with `resolvedBy: "no-approval-route"` and `decision: null`; an unconfigured delivery path still allows the existing turn-source fallback.
- Architecture / source-of-truth check: `handlePendingApprovalRequest()` remains the lifecycle source of truth. Exec forwarding, plugin forwarding, and iOS push report canonical `{ delivered, attempted }` state; the shared handler decides whether to accept, expire, or allow unattempted turn-source fallback.
- Scope boundary: no approval decision semantics, approval IDs, payload fields, channel retry policy, APNs/Slack/Discord transport behavior, approval UI, plugin schema/config migration, or public user configuration changed.
- Related open PR scan: daily-fix issue-mode setup did not identify an open competing fix for #89217 before this branch was prepared; the later updates are all on this existing linked PR.

## Root Cause

- Root cause: the gateway approval lifecycle invariant was lost because the delivery contract used one boolean for two different states: no configured route and configured route attempted but failed.
- Why this is root-cause fix: delivery boundaries now report the missing invariant directly as `{ delivered, attempted }`, and the shared lifecycle checks the actual delivery result before considering turn-source fallback. Attempted delivery failure is surfaced as `no-approval-route`; unattempted delivery remains compatible with the existing originating chat route.
- Missing detection / guardrail: there was no regression coverage for an explicit delivery failure when an originating turn-source route was also available.

## What changed

- `src/gateway/server-methods/approval-shared.ts` now normalizes approval delivery results before evaluating turn-source fallback, and only allows fallback when no explicit delivery route was attempted.
- `src/gateway/server-methods/exec-approval.ts` aggregates forwarder and iOS push delivery results with attempted/delivered semantics.
- `src/gateway/server-methods/plugin-approval.ts` treats plugin forwarder exceptions as attempted delivery failures.
- `src/gateway/exec-approval-ios-push.ts` reports no eligible push target as unattempted, but reports all attempted push failures as attempted delivery failure.
- `src/infra/exec-approval-forwarder.ts` waits for request delivery, summarizes target outcomes, rejects all-target delivery failures, and still treats durable `partial_failed` results with visible delivery receipts as delivered.

## Real behavior proof

- **Behavior or issue addressed:** An exec approval request has an available originating `tui` turn-source route and a configured forwarder that throws at the delivery boundary. Because explicit delivery was attempted and failed, the request must resolve immediately as `no-approval-route` instead of remaining pending through turn-source fallback.

- **Real environment tested:** Local Linux OpenClaw worktree at `/media/vdc/code/ai/aispace/openclaw-worktrees/pr-90910`, running production `createExecApprovalHandlers()` with `ExecApprovalManager`, production `hasApprovalTurnSourceRoute()`, and a configured forwarder that fails at the delivery boundary.

- **Exact steps or command run after this patch:**

  ```bash
  env -C "/media/vdc/code/ai/aispace/openclaw-worktrees/pr-90910" node --import tsx -e 'import { createExecApprovalHandlers } from "./src/gateway/server-methods/exec-approval.ts"; import { ExecApprovalManager } from "./src/gateway/exec-approval-manager.ts"; import { hasApprovalTurnSourceRoute } from "./src/infra/approval-turn-source.ts"; const manager = new ExecApprovalManager(); const responses = []; const errors = []; let forwarderCalls = 0; const routeAvailable = hasApprovalTurnSourceRoute({ turnSourceChannel: "tui", approvalKind: "exec" }); const forwarder = { handleRequested: async () => { forwarderCalls += 1; throw new Error("configured delivery target failed"); }, handleResolved: async () => {}, stop: () => {} }; const handlers = createExecApprovalHandlers(manager, { forwarder }); await handlers["exec.approval.request"]({ params: { id: "approval-real-proof", command: "echo ok", host: "gateway", turnSourceChannel: "tui", twoPhase: true, timeoutMs: 60000 }, respond: (ok, result, error) => responses.push({ ok, result, error }), context: { broadcast: () => {}, hasExecApprovalClients: () => false, logGateway: { error: (message) => errors.push(String(message)) } }, client: null }); const snapshot = manager.getSnapshot("approval-real-proof"); const summary = { routeAvailableBeforeRequest: routeAvailable, forwarderCalls, resolvedBy: snapshot?.resolvedBy ?? null, decision: snapshot?.decision ?? null, acceptedResponses: responses.filter((entry) => entry.result?.status === "accepted").length, responses, errors }; console.log(JSON.stringify(summary, null, 2)); if (!routeAvailable) process.exit(2); if (forwarderCalls !== 1) process.exit(3); if (snapshot?.resolvedBy !== "no-approval-route") process.exit(4); if (summary.decision !== null) process.exit(5); if (!responses.some((entry) => entry.ok === true && entry.result?.decision === null)) process.exit(6); if (responses.some((entry) => entry.result?.status === "accepted")) process.exit(7);' > "/media/vdc/code/ai/aispace/openclaw-pr-90910-evidence/real-behavior-proof-fail-closed.log" 2>&1
  ```

- **Evidence after fix:**

  From `/media/vdc/code/ai/aispace/openclaw-pr-90910-evidence/real-behavior-proof-fail-closed.log` after local stale plugin config warnings:

  ```json
  {
    "routeAvailableBeforeRequest": true,
    "forwarderCalls": 1,
    "resolvedBy": "no-approval-route",
    "decision": null,
    "acceptedResponses": 0,
    "responses": [
      {
        "ok": true,
        "result": {
          "id": "approval-real-proof",
          "decision": null,
          "createdAtMs": 1780762452364,
          "expiresAtMs": 1780762512364
        }
      }
    ],
    "errors": [
      "exec approvals: forward request failed: Error: configured delivery target failed"
    ]
  }
  ```

- **Observed result after fix:** The originating `tui` route was available, the configured forwarder was called once and failed, the request resolved as `no-approval-route` with `decision: null`, and there were zero accepted/pending responses. This confirms the failed explicit delivery no longer silently falls back to turn-source routing.

- **What was not tested:** No live Slack, Discord, iOS, or APNs delivery was used. The patch is at the gateway/forwarder delivery-result boundary, so the local proof injects the delivery failure at that boundary and verifies the production handler behavior. The proof log also contains local stale plugin config warnings before the JSON result; they are unrelated to this approval path.

## Regression Test Plan

- Coverage level: gateway handler + forwarder behavior tests.
- Target test files: `src/gateway/server-methods/approval-shared.test.ts`, `src/gateway/server-methods/server-methods.test.ts`, `src/gateway/server-methods/plugin-approval.test.ts`, `src/infra/exec-approval-forwarder.test.ts`, and `src/gateway/exec-approval-ios-push.test.ts`.
- Scenario locked in: a two-phase approval request has an originating turn-source route available, but an explicitly configured exec/plugin delivery path is attempted and fails; the expected result is `decision: null` / `resolvedBy: "no-approval-route"`, not an accepted pending approval.
- New/updated regression coverage:
  - `src/gateway/server-methods/approval-shared.test.ts` verifies attempted explicit delivery failure expires before turn-source fallback is considered.
  - `src/gateway/server-methods/server-methods.test.ts` verifies exec forwarder rejection becomes `no-approval-route` even when an originating chat route exists.
  - `src/gateway/server-methods/plugin-approval.test.ts` verifies plugin approval forwarding failures return `decision: null` and expire as `no-approval-route`.
  - `src/infra/exec-approval-forwarder.test.ts` verifies all-target request delivery failure rejects, while per-target success and `partial_failed` results with visible delivery receipts keep the approval pending.
  - `src/gateway/exec-approval-ios-push.test.ts` verifies no eligible target remains unattempted, while all attempted push failures report attempted failure.
- Why this is the smallest reliable guardrail: the tests lock the delivery-result semantics at each boundary that can otherwise collapse explicit delivery failure back into a generic `false`.

## Verification

Passed after the latest repair:

```bash
env -C "/media/vdc/code/ai/aispace/openclaw-worktrees/pr-90910" node scripts/run-vitest.mjs src/infra/exec-approval-forwarder.test.ts src/gateway/server-methods/approval-shared.test.ts src/gateway/server-methods/server-methods.test.ts src/gateway/server-methods/plugin-approval.test.ts src/gateway/exec-approval-ios-push.test.ts
```

Result: 2 Vitest shards passed, 10 test files passed, 295 tests passed.

```bash
env -C "/media/vdc/code/ai/aispace/openclaw-worktrees/pr-90910" corepack pnpm format:check -- src/gateway/server-methods/approval-shared.ts src/gateway/server-methods/approval-shared.test.ts src/gateway/server-methods/server-methods.test.ts src/gateway/server-methods/plugin-approval.test.ts src/infra/exec-approval-forwarder.ts src/infra/exec-approval-forwarder.test.ts
```

Result: all matched files use the correct format.

```bash
env -C "/media/vdc/code/ai/aispace/openclaw-worktrees/pr-90910" corepack pnpm tsgo:core
```

Result: passed.

```bash
git -C "/media/vdc/code/ai/aispace/openclaw-worktrees/pr-90910" diff --check
```

Result: passed with no whitespace output.

## Review findings addressed

- **Stale closing claim — Status: fixed.** `Fixes #89217` now matches current head behavior: configured delivery attempted and failed resolves as `no-approval-route` instead of preserving the same fallback path that the issue asks to change.
- **Stale proof — Status: fixed.** The real behavior proof was regenerated against the current worktree and now shows `resolvedBy: "no-approval-route"`, `decision: null`, and zero accepted responses.
- **Resolve delivery before preserving fallback — Status: fixed.** `src/gateway/server-methods/approval-shared.ts` now observes the delivery result first, then only checks turn-source fallback when `attempted` is false.
- **Partial delivery accounting — Status: fixed.** `src/infra/exec-approval-forwarder.ts` still preserves approvals after durable `partial_failed` results when visible delivery receipts exist.

## Merge risk

- Why it matters / User impact: configured approval delivery failures now fail closed and surface immediately instead of leaving commands waiting for an approval path that already failed.
- Risk labels considered: compatibility and message delivery, because the result shape crosses gateway, forwarder, plugin approval, and iOS push boundaries.
- Risk explanation: this changes only approval request delivery classification after explicit delivery attempts; it does not change approval decisions, add channels, or remove the existing turn-source route for unconfigured delivery.
- Why acceptable: each modified boundary has regression coverage for the new attempted/delivered semantics, including all-target failure, partial delivery success, plugin forwarding failure, and iOS push no-target versus attempted-failure cases.
- Compatibility: unconfigured delivery remains compatible with the existing turn-source fallback because `{ delivered: false, attempted: false }` still permits that route.

## Maintainer-ready confidence

- Fix classification: root-cause behavioral bug fix for gateway approval delivery failure handling.
- Why this is root-cause fix: the change restores the missing lifecycle invariant instead of masking one channel path. Delivery boundaries report whether a route was attempted and/or visibly delivered, and `handlePendingApprovalRequest()` remains the only place that converts that state into accepted, pending, or `no-approval-route` outcomes.
- Maintainer-ready confidence: high after local production-handler proof plus focused gateway/infra regression shards.
- Patch quality notes: the broad catches are delivery-boundary error handling that converts transport/forwarder rejection into an attempted delivery failure; the default `return false` keeps unsupported targets unattempted; the `as unknown as GatewayRequestContext` cast is test fixture narrowing only; and the multi-file diff is kept together because the same delivery contract must be updated consistently across shared gateway handling, exec forwarding, plugin forwarding, iOS push, and their regression tests. No new public configuration, no new channel behavior, no feature flag, no approval decision rewrite, and no unrelated formatting or refactor is included.
