### PR TITLE
[codex] Prepare iPhone-only iOS App Store release

### DIFF
--- a/apps/ios/CHANGELOG.md
+++ b/apps/ios/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## 2026.6.2 - 2026-06-02
 
-Maintenance update for the current OpenClaw release.
+OpenClaw is now available on iPhone.
+
+Connect to your OpenClaw Gateway to chat with your assistant, use realtime Talk mode, review approvals, share content from iOS, and bring device capabilities like camera, location, screen, and notifications into your private automation workflows.
 
 ## 2026.6.1 - 2026-06-01
 

--- a/apps/ios/Sources/Info.plist
+++ b/apps/ios/Sources/Info.plist
@@ -107,12 +107,5 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>UISupportedInterfaceOrientations~ipad</key>
-	<array>
-		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationPortraitUpsideDown</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
-	</array>
 </dict>
 </plist>

--- a/apps/ios/fastlane/metadata/en-US/description.txt
+++ b/apps/ios/fastlane/metadata/en-US/description.txt
@@ -1,12 +1,12 @@
 OpenClaw is a personal AI assistant you run on your own devices.
 
-Pair this iOS app with your OpenClaw Gateway to use your iPhone or iPad as a secure node for chat, voice, approvals, sharing, and device-aware automation.
+Pair this iOS app with your OpenClaw Gateway to use your iPhone as a secure node for chat, voice, approvals, sharing, and device-aware automation.
 
 What you can do:
 - Pair with your private OpenClaw Gateway by QR code or setup code
-- Chat with your assistant from iPhone or iPad
+- Chat with your assistant from iPhone
 - Use realtime Talk mode and push-to-talk
-- Review Gateway action approvals from your iPhone or iPad
+- Review Gateway action approvals from your iPhone
 - Share text, links, and media directly from iOS into OpenClaw
 - Enable device capabilities such as camera, screen, location, photos, contacts, calendar, and reminders when you choose
 - Receive push wakes and node status updates for connected workflows
@@ -16,4 +16,4 @@ OpenClaw is local-first: you control your gateway, keys, configuration, and perm
 Getting started:
 1) Set up your OpenClaw Gateway
 2) Open the iOS app and pair with your gateway
-3) Start using chat, Talk mode, approvals, and automations from your iPhone or iPad
+3) Start using chat, Talk mode, approvals, and automations from your iPhone

--- a/apps/ios/fastlane/metadata/en-US/promotional_text.txt
+++ b/apps/ios/fastlane/metadata/en-US/promotional_text.txt
@@ -1,1 +1,1 @@
-Pair your iPhone or iPad with your OpenClaw Gateway for chat, realtime voice, approvals, device capabilities, and private automation.
+Pair your iPhone with your OpenClaw Gateway for chat, realtime voice, approvals, device capabilities, and private automation.

--- a/apps/ios/fastlane/metadata/en-US/release_notes.txt
+++ b/apps/ios/fastlane/metadata/en-US/release_notes.txt
@@ -1,1 +1,3 @@
-Maintenance update for the current OpenClaw release.
+OpenClaw is now available on iPhone.
+
+Connect to your OpenClaw Gateway to chat with your assistant, use realtime Talk mode, review approvals, share content from iOS, and bring device capabilities like camera, location, screen, and notifications into your private automation workflows.

--- a/apps/ios/project.yml
+++ b/apps/ios/project.yml
@@ -97,7 +97,7 @@ targets:
         DEVELOPMENT_TEAM: "$(OPENCLAW_DEVELOPMENT_TEAM)"
         PRODUCT_BUNDLE_IDENTIFIER: "$(OPENCLAW_APP_BUNDLE_ID)"
         PROVISIONING_PROFILE_SPECIFIER: "$(OPENCLAW_APP_PROFILE)"
-        TARGETED_DEVICE_FAMILY: "1,2"
+        TARGETED_DEVICE_FAMILY: "1"
         SWIFT_VERSION: "6.0"
         SWIFT_STRICT_CONCURRENCY: complete
         SUPPORTS_LIVE_ACTIVITIES: YES
@@ -163,12 +163,6 @@ targets:
           - UIInterfaceOrientationPortraitUpsideDown
           - UIInterfaceOrientationLandscapeLeft
           - UIInterfaceOrientationLandscapeRight
-        UISupportedInterfaceOrientations~ipad:
-          - UIInterfaceOrientationPortrait
-          - UIInterfaceOrientationPortraitUpsideDown
-          - UIInterfaceOrientationLandscapeLeft
-          - UIInterfaceOrientationLandscapeRight
-
   OpenClawShareExtension:
     type: app-extension
     platform: iOS
@@ -189,6 +183,7 @@ targets:
         ENABLE_APP_INTENTS_METADATA_GENERATION: NO
         PRODUCT_BUNDLE_IDENTIFIER: "$(OPENCLAW_SHARE_BUNDLE_ID)"
         PROVISIONING_PROFILE_SPECIFIER: "$(OPENCLAW_SHARE_PROFILE)"
+        TARGETED_DEVICE_FAMILY: "1"
         SWIFT_VERSION: "6.0"
         SWIFT_STRICT_CONCURRENCY: complete
     info:
@@ -225,6 +220,7 @@ targets:
         CODE_SIGN_STYLE: "$(OPENCLAW_CODE_SIGN_STYLE)"
         DEVELOPMENT_TEAM: "$(OPENCLAW_DEVELOPMENT_TEAM)"
         PRODUCT_BUNDLE_IDENTIFIER: "$(OPENCLAW_ACTIVITY_WIDGET_BUNDLE_ID)"
+        TARGETED_DEVICE_FAMILY: "1"
         SWIFT_VERSION: "6.0"
         SWIFT_STRICT_CONCURRENCY: complete
         SUPPORTS_LIVE_ACTIVITIES: YES


### PR DESCRIPTION
## Summary

- pins the iOS release train to the current gateway version `2026.6.2`
- makes the iOS app, share extension, and live activity widget iPhone-only for App Store submission
- removes the iPad-specific orientation override from the app Info.plist
- updates App Store metadata and iOS release-note source to describe the first iPhone release

## App Store Connect

- uploaded metadata for draft App Store version `2026.5.28`
- uploaded TestFlight build `2026.6.2 (1)`
- confirmed App Store Connect latest TestFlight build for `2026.6.2` is build `1`
- confirmed age rating is set to `FOUR_PLUS`
- confirmed content rights are set to `DOES_NOT_USE_THIRD_PARTY_CONTENT`
- confirmed uploaded metadata no longer mentions iPad
- confirmed archived app has `UIDeviceFamily = [1]`

## Verification

- `node --import tsx scripts/ios-sync-versioning.ts --check`
- `plutil -lint apps/ios/Sources/Info.plist`
- `git diff --check`
- `rg -n "iPhone or iPad|iPad|ipad|UISupportedInterfaceOrientations~ipad" apps/ios/project.yml apps/ios/Sources/Info.plist apps/ios/fastlane/metadata/en-US apps/ios/Sources/Assets.xcassets/AppIcon.appiconset/Contents.json` returned no matches
- `pnpm ios:gen`
- `pnpm ios:beta`

## Follow-up

Before App Store review, provide Apple with review access to a running OpenClaw Gateway or a review-only gateway/demo code in App Review notes so they can exercise login and core flows.