### PR TITLE
fix(talk): resolve realtime provider secret refs

### DIFF
--- a/docs/reference/secretref-credential-surface.md
+++ b/docs/reference/secretref-credential-surface.md
@@ -38,6 +38,7 @@ Scope intent:
 - `agents.list[].tts.providers.*.apiKey`
 - `agents.list[].memorySearch.remote.apiKey`
 - `talk.providers.*.apiKey`
+- `talk.realtime.providers.*.apiKey`
 - `messages.tts.providers.*.apiKey`
 - `tools.web.fetch.firecrawl.apiKey`
 - `plugins.entries.acpx.config.mcpServers.*.env.*`

--- a/docs/reference/secretref-user-supplied-credentials-matrix.json
+++ b/docs/reference/secretref-user-supplied-credentials-matrix.json
@@ -660,6 +660,13 @@
       "optIn": true
     },
     {
+      "id": "talk.realtime.providers.*.apiKey",
+      "configFile": "openclaw.json",
+      "path": "talk.realtime.providers.*.apiKey",
+      "secretShape": "secret_input",
+      "optIn": true
+    },
+    {
       "id": "tools.web.fetch.firecrawl.apiKey",
       "configFile": "openclaw.json",
       "path": "tools.web.fetch.firecrawl.apiKey",

--- a/src/secrets/runtime-config-collectors-core.ts
+++ b/src/secrets/runtime-config-collectors-core.ts
@@ -212,17 +212,37 @@ function collectTalkAssignments(params: {
       talk.apiKey = value;
     },
   });
-  const providers = talk.providers;
-  if (!isRecord(providers)) {
+  collectTalkProviderApiKeyAssignments({
+    providers: talk.providers,
+    pathPrefix: "talk.providers",
+    defaults: params.defaults,
+    context: params.context,
+  });
+  const realtime = isRecord(talk.realtime) ? talk.realtime : undefined;
+  collectTalkProviderApiKeyAssignments({
+    providers: realtime?.providers,
+    pathPrefix: "talk.realtime.providers",
+    defaults: params.defaults,
+    context: params.context,
+  });
+}
+
+function collectTalkProviderApiKeyAssignments(params: {
+  providers: unknown;
+  pathPrefix: string;
+  defaults: SecretDefaults | undefined;
+  context: ResolverContext;
+}): void {
+  if (!isRecord(params.providers)) {
     return;
   }
-  for (const [providerId, providerConfig] of Object.entries(providers)) {
+  for (const [providerId, providerConfig] of Object.entries(params.providers)) {
     if (!isRecord(providerConfig)) {
       continue;
     }
     collectSecretInputAssignment({
       value: providerConfig.apiKey,
-      path: `talk.providers.${providerId}.apiKey`,
+      path: `${params.pathPrefix}.${providerId}.apiKey`,
       expected: "string",
       defaults: params.defaults,
       context: params.context,

--- a/src/secrets/runtime-provider-and-media-surfaces.test.ts
+++ b/src/secrets/runtime-provider-and-media-surfaces.test.ts
@@ -63,6 +63,36 @@ async function prepareMediaModelAuthSnapshot(params: {
 }
 
 describe("secrets runtime provider and media surfaces", () => {
+  it("resolves talk realtime provider api key refs", async () => {
+    const snapshot = await prepareSecretsRuntimeSnapshot({
+      config: asConfig({
+        talk: {
+          realtime: {
+            provider: "openai",
+            providers: {
+              openai: {
+                apiKey: {
+                  source: "env",
+                  provider: "default",
+                  id: "OPENAI_REALTIME_API_KEY",
+                },
+                model: "gpt-realtime-2",
+              },
+            },
+          },
+        },
+      }),
+      env: {
+        OPENAI_REALTIME_API_KEY: "sk-realtime-test",
+      },
+      agentDirs: ["/tmp/openclaw-agent-main"],
+      loadAuthStore: () => ({ version: 1, profiles: {} }),
+    });
+
+    expect(snapshot.config.talk?.realtime?.providers?.openai?.apiKey).toBe("sk-realtime-test");
+    expect(snapshot.config.talk?.realtime?.providers?.openai?.model).toBe("gpt-realtime-2");
+  });
+
   it("resolves file refs via configured file provider", async () => {
     if (process.platform === "win32") {
       return;

--- a/src/secrets/target-registry-data.ts
+++ b/src/secrets/target-registry-data.ts
@@ -428,6 +428,18 @@ const CORE_SECRET_TARGET_REGISTRY: SecretTargetRegistryEntry[] = [
     providerIdPathSegmentIndex: 2,
   },
   {
+    id: "talk.realtime.providers.*.apiKey",
+    targetType: "talk.realtime.providers.*.apiKey",
+    configFile: "openclaw.json",
+    pathPattern: "talk.realtime.providers.*.apiKey",
+    secretShape: SECRET_INPUT_SHAPE,
+    expectedResolvedValue: "string",
+    includeInPlan: true,
+    includeInConfigure: true,
+    includeInAudit: true,
+    providerIdPathSegmentIndex: 3,
+  },
+  {
     id: "tools.web.search.apiKey",
     targetType: "tools.web.search.apiKey",
     configFile: "openclaw.json",

--- a/src/secrets/target-registry.test.ts
+++ b/src/secrets/target-registry.test.ts
@@ -38,6 +38,19 @@ describe("secret target registry", () => {
     expect(target?.refPathSegments).toEqual(["channels", "googlechat", "serviceAccountRef"]);
   });
 
+  it("resolves talk realtime provider api key targets", () => {
+    const target = resolveConfigSecretTargetByPath([
+      "talk",
+      "realtime",
+      "providers",
+      "openai",
+      "apiKey",
+    ]);
+
+    expect(target?.entry?.id).toBe("talk.realtime.providers.*.apiKey");
+    expect(target?.providerId).toBe("openai");
+  });
+
   it("returns null when no config target path matches", () => {
     const target = resolveConfigSecretTargetByPath(["gateway", "auth", "mode"]);
 


### PR DESCRIPTION
## Summary

- Resolve SecretRefs under `talk.realtime.providers.*.apiKey` during runtime secret snapshot preparation.
- Register `talk.realtime.providers.*.apiKey` as a supported SecretRef target for configure/apply/audit flows.
- Add focused runtime and registry coverage, and update the canonical SecretRef credential docs.

## Root Cause

`talk.realtime.providers.openai.apiKey` was valid in config/docs, but the runtime secret collector only walked `talk.providers.*.apiKey`. Realtime Talk sessions could therefore receive an unresolved SecretRef object instead of the API key string and fail before opening the realtime provider session.

## Verification

- `node scripts/run-vitest.mjs src/secrets/runtime-provider-and-media-surfaces.test.ts src/secrets/target-registry.test.ts`
- `node scripts/run-vitest.mjs src/secrets/target-registry.docs.test.ts`
- `node scripts/run-vitest.mjs src/secrets/runtime-provider-and-media-surfaces.test.ts src/secrets/target-registry.test.ts src/secrets/target-registry.docs.test.ts`
- `pnpm build`
- `git diff --check`
- `bash ~/.codex/skills/codex-review/scripts/codex-review --parallel-tests "node scripts/run-vitest.mjs src/secrets/runtime-provider-and-media-surfaces.test.ts src/secrets/target-registry.test.ts src/secrets/target-registry.docs.test.ts"`
