### PR TITLE
docs(ios): clarify there is no official App Store app and link build sources

### DIFF
--- a/docs/platforms/ios.md
+++ b/docs/platforms/ios.md
@@ -7,7 +7,9 @@ read_when:
 title: "iOS app"
 ---
 
-Availability: iPhone app builds are distributed through Apple channels when enabled for a release. Local development builds can also run from source.
+<Note>
+There is currently no official OpenClaw app on the App Store. Similarly named apps in App Store search results are not official OpenClaw builds. The iOS app is super-alpha and is distributed only through internal TestFlight beta or by building from source. It is a companion node and requires a running OpenClaw Gateway. The source code lives in the [OpenClaw repository](https://github.com/openclaw/openclaw) under `apps/ios`; see [apps/ios/README.md](https://github.com/openclaw/openclaw/blob/main/apps/ios/README.md) for build instructions.
+</Note>
 
 ## What it does
 


### PR DESCRIPTION
## Summary

The public iOS platform page (`docs/platforms/ios.md`) opened with a vague "iPhone app builds are distributed through Apple channels" line, which reads as "look on the App Store." There is no official OpenClaw app on the App Store today (Apple's lookup API returns `resultCount: 0` for the beta bundle id `ai.openclaw.client`), and App Store search surfaces several similarly named third‑party apps. The reporter in #90835 could not tell which app, if any, is official.

This PR replaces that line with a `<Note>` (mirroring the existing pattern at the top of `docs/platforms/android.md`) that states the real, repo‑backed distribution status: no official App Store app, internal TestFlight beta or build‑from‑source only, companion node requiring a Gateway, with a link to `apps/ios/README.md` for build steps.

- Intent: close the App Store discoverability gap the reporter hit, using only facts already in the repo.
- Out of scope: any product change, and inventing a TestFlight invite or future App Store link not backed by the repo (the iOS app README states public distribution is not available).
- Reviewers should focus on `docs/platforms/ios.md` line 10 and confirm the wording matches `apps/ios/README.md` ("Distribution Status").

## Linked context

Closes #90835

Was this requested by a maintainer or owner? The issue carries `clawsweeper:queueable-fix` + `clawsweeper:fix-shape-clear`, and the ClawSweeper review explicitly recommended "a narrow docs note near the top of the iOS platform page, using the existing iOS README as the source of truth and avoiding unsupported App Store or TestFlight promises." This PR follows that fix shape.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: public iOS docs did not state that no official App Store app exists, so users could not distinguish the official path from similarly named third‑party apps.
- Real environment tested: local source checkout, OpenClaw 2026.6.2, Linux (WSL2), Node 22; docs toolchain via `pnpm`.
- Exact steps or command run after this patch:
  - `git diff docs/platforms/ios.md`
  - `git diff --check`
  - `pnpm docs:check-mdx`
  - `pnpm docs:list | grep platforms/ios`
- Evidence after fix:
  - `git diff --check` → no whitespace errors.
  - `pnpm docs:check-mdx` → `Docs MDX check passed (677 files ...)` — confirms the new `<Note>` block parses/renders as valid MDX.
  - `pnpm docs:list` → `platforms/ios.md - iOS node app: ...` (page still registered).
  - Source‑of‑truth match: `apps/ios/README.md` "Distribution Status" — "Public distribution: not available. Internal beta distribution: ... TestFlight ... Local/manual deploy from source via Xcode remains the default development path."
- Observed result after fix: the iOS page now opens with an unambiguous availability note that no official App Store app exists and points to the supported TestFlight/source paths and the build README.
- What was not tested: I did not run the hosted Mintlify renderer to screenshot the page; the MDX check validates the component, and the change is pure prose.
- Proof limitations or environment constraints: docs‑only change; no runtime behavior to exercise.
- Before evidence: previous line read "iPhone app builds are distributed through Apple channels when enabled for a release. Local development builds can also run from source."

## Tests and validation

Which commands did you run? `git diff --check`, `pnpm docs:check-mdx`, `pnpm docs:list`.

What regression coverage was added or updated? None — docs‑content only; no code path to cover.

If no test was added, why not? This is a prose clarification on a single docs page; the MDX check is the relevant guard and passes.

## Risk checklist

Did user-visible behavior change? No (documentation wording only).
Did config, environment, or migration behavior change? No.
Did security, auth, secrets, network, or tool execution behavior change? No.
What is the highest-risk area? Stating an availability claim that could go stale if an official App Store app ships later.
How is that risk mitigated? The note uses only the current repo source of truth (`apps/ios/README.md`) and invents no TestFlight/App Store links, so it stays accurate until that README changes.

---

AI-assisted (Claude). The wording and the commands above were reviewed and run by me in a real local checkout.
