### PR TITLE
fix(doctor): surface plugin version drift warnings in doctor output (fixes #90891)

### DIFF
--- a/src/commands/doctor-workspace-status.test.ts
+++ b/src/commands/doctor-workspace-status.test.ts
@@ -66,7 +66,7 @@ async function runNoteWorkspaceStatusForTest(
   );
 
   const noteSpy = vi.spyOn(noteModule, "note").mockImplementation(() => {});
-  noteWorkspaceStatus({});
+  await noteWorkspaceStatus({});
   return noteSpy;
 }
 

--- a/src/commands/doctor-workspace-status.test.ts
+++ b/src/commands/doctor-workspace-status.test.ts
@@ -16,6 +16,10 @@ const mocks = vi.hoisted(() => ({
   buildPluginCompatibilityWarnings: vi.fn(),
   listTaskFlowRecords: vi.fn<() => unknown[]>(() => []),
   listTasksForFlowId: vi.fn<(flowId: string) => unknown[]>((_flowId: string) => []),
+  loadInstalledPluginIndexInstallRecords: vi.fn<() => Promise<Record<string, unknown>>>(() =>
+    Promise.resolve({}),
+  ),
+  VERSION: "2026.6.1",
 }));
 
 vi.mock("../agents/agent-scope.js", () => ({
@@ -34,6 +38,15 @@ vi.mock("../plugins/status.js", () => ({
     mocks.buildPluginCompatibilityWarnings(...args),
 }));
 
+vi.mock("../plugins/installed-plugin-index-records.js", () => ({
+  loadInstalledPluginIndexInstallRecords: (...args: unknown[]) =>
+    mocks.loadInstalledPluginIndexInstallRecords(...args),
+}));
+
+vi.mock("../version.js", () => ({
+  VERSION: mocks.VERSION,
+}));
+
 vi.mock("../tasks/task-flow-runtime-internal.js", () => ({
   listTaskFlowRecords: () => mocks.listTaskFlowRecords(),
 }));
@@ -48,6 +61,7 @@ async function runNoteWorkspaceStatusForTest(
   opts?: {
     flows?: unknown[];
     tasksByFlowId?: (flowId: string) => unknown[];
+    env?: Record<string, string>;
   },
 ) {
   mocks.resolveDefaultAgentId.mockReturnValue("default");
@@ -66,7 +80,7 @@ async function runNoteWorkspaceStatusForTest(
   );
 
   const noteSpy = vi.spyOn(noteModule, "note").mockImplementation(() => {});
-  await noteWorkspaceStatus({});
+  await noteWorkspaceStatus({}, opts?.env ? { env: opts.env as NodeJS.ProcessEnv } : undefined);
   return noteSpy;
 }
 
@@ -234,6 +248,44 @@ describe("noteWorkspaceStatus", () => {
       expect(body).toContain("openclaw tasks flow show <flow-id>");
     } finally {
       noteSpy.mockRestore();
+    }
+  });
+
+  it("reports plugin version drift when an official plugin version mismatches the gateway", async () => {
+    mocks.loadInstalledPluginIndexInstallRecords.mockResolvedValue({
+      codex: {
+        source: "npm",
+        spec: "@openclaw/codex@latest",
+        resolvedName: "@openclaw/codex",
+        resolvedVersion: "2026.5.30-beta.1",
+      },
+    });
+
+    const noteSpy = await runNoteWorkspaceStatusForTest(
+      createPluginLoadResult({
+        plugins: [
+          createPluginRecord({
+            id: "codex",
+            name: "Codex",
+            status: "loaded",
+            format: "bundle",
+            bundleCapabilities: ["provider:codex"],
+          }),
+        ],
+      }),
+      [],
+      { env: { OPENCLAW_HOME: "/tmp/test-openclaw" } },
+    );
+    try {
+      const driftCalls = noteSpy.mock.calls.filter(([, title]) => title === "Plugin version drift");
+      expect(driftCalls).toHaveLength(1);
+      const [[body]] = driftCalls;
+      expect(body).toContain("not on gateway 2026.6.1");
+      expect(body).toContain("codex: 2026.5.30-beta.1 -> expected 2026.6.1");
+      expect(body).toContain("openclaw plugins update <plugin-id>");
+    } finally {
+      noteSpy.mockRestore();
+      mocks.loadInstalledPluginIndexInstallRecords.mockResolvedValue({});
     }
   });
 });

--- a/src/commands/doctor-workspace-status.ts
+++ b/src/commands/doctor-workspace-status.ts
@@ -3,6 +3,8 @@ import { note } from "../../packages/terminal-core/src/note.js";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { loadInstalledPluginIndexInstallRecords } from "../plugins/installed-plugin-index-records.js";
+import { detectPluginVersionDrift } from "../plugins/plugin-version-drift.js";
 import {
   buildPluginCompatibilityWarnings,
   buildPluginRegistrySnapshotReport,
@@ -10,6 +12,7 @@ import {
 import { buildWorkspaceSkillStatus } from "../skills/discovery/status.js";
 import { listTasksForFlowId } from "../tasks/runtime-internal.js";
 import { listTaskFlowRecords } from "../tasks/task-flow-runtime-internal.js";
+import { VERSION } from "../version.js";
 import { detectLegacyWorkspaceDirs, formatLegacyWorkspaceWarning } from "./doctor-workspace.js";
 
 function noteFlowRecoveryHints() {
@@ -54,7 +57,7 @@ function noteFlowRecoveryHints() {
 }
 
 /** Emits workspace, skills, plugin, and TaskFlow recovery status notes for doctor. */
-export function noteWorkspaceStatus(cfg: OpenClawConfig) {
+export async function noteWorkspaceStatus(cfg: OpenClawConfig, opts?: { env?: NodeJS.ProcessEnv }) {
   const workspaceDir = resolveAgentWorkspaceDir(cfg, resolveDefaultAgentId(cfg));
   const legacyWorkspace = detectLegacyWorkspaceDirs({ workspaceDir });
   if (legacyWorkspace.legacyDirs.length > 0) {
@@ -123,6 +126,33 @@ export function noteWorkspaceStatus(cfg: OpenClawConfig) {
       return `- ${prefix}${plugin}: ${diag.message}${source}`;
     });
     note(lines.join("\n"), "Plugin diagnostics");
+  }
+
+  // Plugin version drift detection — best-effort, non-fatal.
+  // Reuses the same drift detector as `openclaw gateway status --deep`.
+  if (opts?.env) {
+    try {
+      const installRecords = await loadInstalledPluginIndexInstallRecords({
+        env: opts.env,
+      });
+      const drift = detectPluginVersionDrift({
+        gatewayVersion: VERSION,
+        installRecords,
+        config: cfg,
+      });
+      if (drift.drifts.length > 0) {
+        const lines = [
+          `${drift.drifts.length} active official plugin${drift.drifts.length === 1 ? "" : "s"} not on gateway ${drift.gatewayVersion}`,
+          ...drift.drifts.map(
+            (d) => `- ${d.pluginId}: ${d.installedVersion} -> expected ${d.gatewayVersion}`,
+          ),
+          `Fix: ${formatCliCommand("openclaw plugins update <plugin-id>")} for each drifted plugin, then ${formatCliCommand("openclaw gateway restart")}.`,
+        ];
+        note(lines.join("\n"), "Plugin version drift");
+      }
+    } catch {
+      // Install records unavailable — skip drift detection silently.
+    }
   }
 
   noteFlowRecoveryHints();

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -728,7 +728,7 @@ async function runSystemdLingerHealth(ctx: DoctorHealthFlowContext): Promise<voi
 
 async function runWorkspaceStatusHealth(ctx: DoctorHealthFlowContext): Promise<void> {
   const { noteWorkspaceStatus } = await import("../commands/doctor-workspace-status.js");
-  noteWorkspaceStatus(ctx.cfg);
+  await noteWorkspaceStatus(ctx.cfg, { env: ctx.env });
 }
 
 async function runSkillsHealth(ctx: DoctorHealthFlowContext): Promise<void> {

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -728,7 +728,7 @@ async function runSystemdLingerHealth(ctx: DoctorHealthFlowContext): Promise<voi
 
 async function runWorkspaceStatusHealth(ctx: DoctorHealthFlowContext): Promise<void> {
   const { noteWorkspaceStatus } = await import("../commands/doctor-workspace-status.js");
-  await noteWorkspaceStatus(ctx.cfg, { env: ctx.env });
+  await noteWorkspaceStatus(ctx.cfg, { env: ctx.env ?? process.env });
 }
 
 async function runSkillsHealth(ctx: DoctorHealthFlowContext): Promise<void> {


### PR DESCRIPTION
## Summary

`openclaw doctor --non-interactive` now surfaces official managed plugin version drift warnings, reusing the same `detectPluginVersionDrift` function already used by `openclaw gateway status --deep`.

**Before**: Doctor only reported plugin counts (loaded/imported/disabled/errors), missing plugin version mismatches.
**After**: Doctor detects and reports active official plugin version drift with exact version gaps and repair commands.

**Changes**: 3 files, +87 lines
- `src/commands/doctor-workspace-status.ts` — add async drift detection to `noteWorkspaceStatus`
- `src/flows/doctor-health-contributions.ts` — pass `ctx.env ?? process.env` so drift detection works in normal runs
- `src/commands/doctor-workspace-status.test.ts` — add regression test with seeded drifted install records

Closes #90891

## Root Cause

**Invariant violated**: `openclaw doctor` should provide production health visibility equivalent to `openclaw gateway status --deep`. Official managed plugin version drift — where a runtime-critical plugin (e.g. `codex`) is on a different version than the gateway — is a production health issue, but doctor did not surface it.

**Code path**: The `detectPluginVersionDrift` function (`src/plugins/plugin-version-drift.ts`) has existed since `4a285d529a` and is correctly used by `src/cli/daemon-cli/status.gather.ts` for `gateway status --deep`, but `noteWorkspaceStatus` in `src/commands/doctor-workspace-status.ts` only called `buildPluginRegistrySnapshotReport` (which reports counts) without invoking drift detection.

**v2 fix**: The initial version passed `ctx.env` which was `undefined` in the normal doctor path (the doctor flow context builder in `doctor-health.ts` never sets `env`). Fixed by using `ctx.env ?? process.env` so the drift check works for both daemon-mode and CLI-mode doctor runs.

**Sibling Surface Audit**: 
- `src/cli/daemon-cli/status.gather.ts` — **uses** `detectPluginVersionDrift` ✅
- `src/commands/doctor-workspace-status.ts` — **did not use** `detectPluginVersionDrift` ❌ (fixed)
- No other callers in the codebase

**Scope**:
- **In scope**: Doctor --non-interactive reporting of official managed plugin version drift
- **Out of scope**: Hook version drift (#90418, #90474), external (non-official) plugin version checks

## Verification

```
pnpm build && pnpm test src/commands/doctor-workspace-status.test.ts src/plugins/plugin-version-drift.test.ts src/commands/doctor-workspace.test.ts src/commands/doctor-plugin-manifests.test.ts
```

- `pnpm build`: ✅ passed
- `src/commands/doctor-workspace-status.test.ts`: ✅ 7 tests (including new drift regression)
- `src/commands/doctor-workspace.test.ts`: ✅ 3 tests
- `src/commands/doctor-plugin-manifests.test.ts`: ✅ 5 tests
- `src/plugins/plugin-version-drift.test.ts`: ✅ 17 tests
- Total: **4 files, 32 tests passed**
- `pnpm exec oxlint` on changed files: ✅ clean

## Real behavior proof

**Behavior or issue addressed**: `openclaw doctor --non-interactive` now detects and reports active official plugin version drift that was previously only visible through `openclaw gateway status --deep`. The env wiring uses `ctx.env ?? process.env` so the drift check works in all doctor invocation modes.

**Real environment tested**: Linux x86_64, Node v22.22.0, pnpm 10.25.0, OpenClaw main @ `74331f632b`

**Exact steps or command run after this patch**:
```bash
pnpm build
pnpm test src/commands/doctor-workspace-status.test.ts src/plugins/plugin-version-drift.test.ts src/commands/doctor-workspace.test.ts src/commands/doctor-plugin-manifests.test.ts
pnpm openclaw doctor --non-interactive
```

**Evidence after fix**:
1. **32 tests pass** across 4 test files (CI-level)
2. **New regression test**: `reports plugin version drift when an official plugin version mismatches the gateway` — seeds drifted `codex` install record (2026.5.30-beta.1 vs gateway 2026.6.1), calls `noteWorkspaceStatus` with env, asserts "Plugin version drift" note appears with exact version gap and repair command
3. **Existing tests unaffected**: all 6 original tests continue to pass
4. **`pnpm openclaw doctor --non-interactive`** runs without errors (no crash, no regression in output)
5. **Source evidence**: drift detector is the same `detectPluginVersionDrift` from `plugin-version-drift.ts` (17 unit tests cover normalization, exact-version skip, official install comparison, build-qualifier matching, etc.)

```json
{
  "behaviorAddressed": "Doctor now detects and reports official plugin version drift using ctx.env ?? process.env, with regression test proving drift note emission",
  "assertions": [
    { "path": "src/plugins/plugin-version-drift.test.ts", "behavior": "17 tests verify drift detection logic (normalization, exact-version skip, official comparison, build-qualifier)" },
    { "path": "src/commands/doctor-workspace-status.test.ts", "behavior": "7 tests verify doctor workspace status output, including new regression that seeds drifted records and asserts drift note" },
    { "path": "src/commands/doctor-workspace-status.test.ts (new test)", "behavior": "reports plugin version drift when an official plugin version mismatches the gateway — seeds codex@2026.5.30-beta.1, asserts note with version gap and repair command" }
  ],
  "observedResult": "pnpm test exited 0 for all 4 test files (32 tests total)",
  "testSummary": "4 test files, 32 tests passed including 1 new drift regression"
}
```

**Observed result after fix**: Doctor runs successfully. With `process.env` fallback, the drift check now loads real install records and calls `detectPluginVersionDrift`. If drift is detected, it emits a "Plugin version drift" note with version gaps and repair commands. If install records are unavailable, detection is gracefully skipped (try-catch).

**What was not tested**: End-to-end test with an actual version-drifted plugin on a live production gateway (requires managing real plugin installs to create the drifted state). The drift detection function itself is fully covered by 17 unit tests, and the doctor integration path is covered by the new regression test with mocked install records.

## Review Findings Addressed

- **[P1] Pass a real env to the drift check** (`src/flows/doctor-health-contributions.ts:731`): Fixed. Changed from `ctx.env` to `ctx.env ?? process.env` so the drift check works in normal doctor CLI runs where the context builder doesn't set `env`.
- **[P1] Add regression test**: Added `reports plugin version drift when an official plugin version mismatches the gateway` — seeds drifted `codex` install record, calls `noteWorkspaceStatus` with env, asserts drift note with exact version gap and repair command.

## Regression Test Plan

```bash
pnpm test src/commands/doctor-workspace-status.test.ts
pnpm test src/plugins/plugin-version-drift.test.ts
pnpm test src/commands/doctor-workspace.test.ts
pnpm test src/commands/doctor-plugin-manifests.test.ts
```

To verify in a live environment:
```bash
pnpm openclaw doctor --non-interactive
# Observe that no crash occurs and plugin version drift section appears if applicable
```

## Merge Risk

**Risk**: Low. The change is entirely additive — a best-effort drift detection block wrapped in try-catch. Uses `process.env` fallback so it works in all doctor invocation modes. The only signature change is making `noteWorkspaceStatus` async, which is transparent to its single caller that was already in an async context. Regression test proves the new code path executes correctly.

**Note on CI failures**: The `build-artifacts` / `core-support-boundary` CI failure is a pre-existing infrastructure issue affecting multiple PRs today (e.g., also failing on #90907). Not caused by these changes.