### PR TITLE
fix(tui): preserve Python underscore identifiers

### DIFF
--- a/src/agents/openclaw-tools.camera.test.ts
+++ b/src/agents/openclaw-tools.camera.test.ts
@@ -22,9 +22,11 @@ vi.mock("../media/media-services.js", () => ({
 }));
 
 const NODE_ID = "mac-1";
+const TINY_JPEG_BASE64 =
+  "/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAP//////////////////////////////////////////////////////////////////////////////////////2wBDAf//////////////////////////////////////////////////////////////////////////////////////wAARCAABAAEDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAX/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIQAxAAAAH/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/9oACAEBAAEFAqf/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oACAEDAQE/ASP/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oACAECAQE/ASP/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/9oACAEBAAY/Aqf/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/9oACAEBAAE/IV//2gAMAwEAAgADAAAAEP/EFBQRAQAAAAAAAAAAAAAAAAAAABD/2gAIAQMBAT8QH//EFBQRAQAAAAAAAAAAAAAAAAAAABD/2gAIAQIBAT8QH//EFBABAQAAAAAAAAAAAAAAAAAAABD/2gAIAQEAAT8QH//Z";
 const JPG_PAYLOAD = {
   format: "jpg",
-  base64: "aGVsbG8=",
+  base64: TINY_JPEG_BASE64,
   width: 1,
   height: 1,
 } as const;
@@ -38,7 +40,7 @@ const PHOTOS_LATEST_PAYLOAD = {
   photos: [
     {
       format: "jpeg",
-      base64: "aGVsbG8=",
+      base64: TINY_JPEG_BASE64,
       width: 1,
       height: 1,
       createdAt: "2026-03-04T00:00:00Z",

--- a/src/tui/components/chat-log.test.ts
+++ b/src/tui/components/chat-log.test.ts
@@ -127,21 +127,19 @@ describe("ChatLog", () => {
     expect(rendered).not.toContain("\\_\\_init\\_\\_");
   });
 
-  it("keeps underscore markdown emphasis available outside code identifiers", () => {
+  it("escapes all dunder patterns including those that look like markdown emphasis", () => {
     const chatLog = new ChatLog(40);
     chatLog.finalizeAssistant(
-      "Markdown __bold__, __name__, and _italic_ still render.",
+      "Use **bold** for emphasis, not __bold__. Also __name__ is an identifier.",
       "run-emphasis",
     );
 
     const rendered = normalizeTestText(chatLog.render(120).join("\n"));
-    expect(rendered).toContain("Markdown bold, name, and italic still render.");
-    expect(rendered).not.toContain("__bold__");
-    expect(rendered).not.toContain("__name__");
-    expect(rendered).not.toContain("_italic_");
+    expect(rendered).toContain("bold for emphasis, not __bold__. Also __name__ is an identifier.");
+    expect(rendered).not.toContain("not bold. Also name");
   });
 
-  it("preserves common Python dunder method names in prose", () => {
+  it("preserves Python dunder method names in prose", () => {
     const chatLog = new ChatLog(40);
     chatLog.finalizeAssistant(
       "Implement __enter__, __exit__, __repr__, __fspath__, __length_hint__, and __getnewargs_ex__.",

--- a/src/tui/components/chat-log.test.ts
+++ b/src/tui/components/chat-log.test.ts
@@ -167,6 +167,19 @@ describe("ChatLog", () => {
     expect(rendered).not.toContain("prop\\_name");
   });
 
+  it("preserves underscore identifiers in tool result output", () => {
+    const chatLog = new ChatLog(40);
+    chatLog.startTool("tool-1", "read_file", { path: "a.py" });
+    chatLog.updateToolResult("tool-1", {
+      content: [{ type: "text", text: "def __init__(self):\n    self.is_ready = False" }],
+    });
+
+    const rendered = normalizeTestText(chatLog.render(120).join("\n"));
+    expect(rendered).toContain("def __init__(self):");
+    expect(rendered).toContain("self.is_ready = False");
+    expect(rendered).not.toContain("def init(self)");
+  });
+
   it("reserves assistant position without clearing existing streamed text", () => {
     const chatLog = new ChatLog(40);
     chatLog.startAssistant("partial", "run-active");

--- a/src/tui/components/chat-log.test.ts
+++ b/src/tui/components/chat-log.test.ts
@@ -75,6 +75,100 @@ describe("ChatLog", () => {
     expect(chatLog.children.length).toBe(1);
   });
 
+  it("renders Python underscore identifiers without markdown emphasis loss", () => {
+    const chatLog = new ChatLog(40);
+    chatLog.finalizeAssistant(
+      [
+        'Use __name__ == "__main__" before calling __init__().',
+        "",
+        "```python",
+        'if __name__ == "__main__":',
+        "    __init__()",
+        "def is_palindrome(s: str) -> bool:",
+        "    return True",
+        "```",
+        "",
+        "Inline `__name__` and `is_palindrome` stay literal.",
+        "Markdown **bold** still renders.",
+      ].join("\n"),
+      "run-python",
+    );
+
+    const rendered = normalizeTestText(chatLog.render(120).join("\n"));
+    expect(rendered).toContain('Use __name__ == "__main__" before calling __init__().');
+    expect(rendered).toContain('if __name__ == "__main__":');
+    expect(rendered).toContain("    __init__()");
+    expect(rendered).toContain("def is_palindrome(s: str) -> bool:");
+    expect(rendered).toContain("Inline __name__ and is_palindrome stay literal.");
+    expect(rendered).toContain("Markdown bold still renders.");
+    expect(rendered).not.toContain('Use name == "main"');
+  });
+
+  it("does not escape underscore identifiers inside longer fenced code blocks", () => {
+    const chatLog = new ChatLog(40);
+    chatLog.finalizeAssistant(
+      [
+        "````markdown",
+        "```python",
+        'if __name__ == "__main__":',
+        "    __init__()",
+        "```",
+        "````",
+        "",
+        "Use __name__ after the nested example.",
+      ].join("\n"),
+      "run-long-fence",
+    );
+
+    const rendered = normalizeTestText(chatLog.render(120).join("\n"));
+    expect(rendered).toContain('if __name__ == "__main__":');
+    expect(rendered).toContain("    __init__()");
+    expect(rendered).toContain("Use __name__ after the nested example.");
+    expect(rendered).not.toContain("\\_\\_init\\_\\_");
+  });
+
+  it("keeps underscore markdown emphasis available outside code identifiers", () => {
+    const chatLog = new ChatLog(40);
+    chatLog.finalizeAssistant(
+      "Markdown __bold__, __name__, and _italic_ still render.",
+      "run-emphasis",
+    );
+
+    const rendered = normalizeTestText(chatLog.render(120).join("\n"));
+    expect(rendered).toContain("Markdown bold, name, and italic still render.");
+    expect(rendered).not.toContain("__bold__");
+    expect(rendered).not.toContain("__name__");
+    expect(rendered).not.toContain("_italic_");
+  });
+
+  it("preserves common Python dunder method names in prose", () => {
+    const chatLog = new ChatLog(40);
+    chatLog.finalizeAssistant(
+      "Implement __enter__, __exit__, __repr__, __fspath__, __length_hint__, and __getnewargs_ex__.",
+      "run-dunder-methods",
+    );
+
+    const rendered = normalizeTestText(chatLog.render(120).join("\n"));
+    expect(rendered).toContain(
+      "Implement __enter__, __exit__, __repr__, __fspath__, __length_hint__, and __getnewargs_ex__.",
+    );
+    expect(rendered).not.toContain("Implement enter, exit, repr, fspath");
+  });
+
+  it("does not escape underscores inside raw HTML-like tags", () => {
+    const chatLog = new ChatLog(40);
+    chatLog.finalizeAssistant(
+      ['<my_component prop_name="x">', '<div prop_name="x">__name__</div>'].join("\n"),
+      "run-html",
+    );
+
+    const rendered = normalizeTestText(chatLog.render(120).join("\n"));
+    expect(rendered).toContain('<my_component prop_name="x">');
+    expect(rendered).toContain('<div prop_name="x">__name__</div>');
+    expect(rendered).not.toContain("my\\_component");
+    expect(rendered).not.toContain("prop\\_name");
+  });
+
   it("reserves assistant position without clearing existing streamed text", () => {
     const chatLog = new ChatLog(40);
     chatLog.startAssistant("partial", "run-active");

--- a/src/tui/components/hyperlink-markdown.ts
+++ b/src/tui/components/hyperlink-markdown.ts
@@ -3,44 +3,21 @@ import type { Component, DefaultTextStyle, MarkdownTheme } from "@earendil-works
 import { Markdown } from "@earendil-works/pi-tui";
 import { addOsc8Hyperlinks, extractUrls } from "../osc8-hyperlinks.js";
 
+// Matches snake_case identifiers (is_palindrome) and dunder identifiers (__init__).
+// Lookbehind/ahead prevent matching inside words or already-escaped underscores.
+const UNDERSCORE_ID_RE =
+  /(?<![\\\w])(?:[A-Za-z][A-Za-z0-9]*_[A-Za-z0-9_]*[A-Za-z0-9]|__[A-Za-z][A-Za-z0-9_]*__)(?![\w])/g;
+
+// Regions where underscores must not be touched: inline code, raw HTML blocks, HTML tags, links, URLs.
+const INLINE_PROTECTED_RE =
+  /(`+)(?:(?!\1)[\s\S])*?\1|<[A-Za-z][A-Za-z0-9]*(?:\s+[^<>\n]*)?>[\s\S]*?<\/[A-Za-z][A-Za-z0-9]*>|<\/?[A-Za-z_][A-Za-z0-9_.:-]*(?:\s+[^<>\n]*)?>|\[[^\]\n]+\]\([^)]+\)|https?:\/\/[^\s<)]+/gi;
+
 const FENCED_CODE_OPEN_RE = /(^|\n)( {0,3})(`{3,}|~{3,})[^\n]*(?:\n|$)/g;
-const INLINE_PROTECTED_MARKDOWN_RE =
-  /(`+)(?:(?!\1)[\s\S])*?\1|<\/?[A-Za-z_][A-Za-z0-9_.:-]*(?:\s+[^<>\n]*)?>|\[[^\]\n]+\]\([^)]+\)|https?:\/\/[^\s<)]+/g;
-const RAW_HTML_SPAN_RE =
-  /<(a|article|aside|blockquote|body|code|div|em|footer|h[1-6]|head|header|html|li|main|nav|ol|p|pre|script|section|span|strong|style|table|tbody|td|tfoot|th|thead|tr|ul)(?:\s+[^<>\n]*)?>[\s\S]*?<\/\1>/gi;
-const SNAKE_CASE_IDENTIFIER_RE =
-  /(?<![\\\w])[A-Za-z][A-Za-z0-9]*_[A-Za-z0-9_]*[A-Za-z0-9](?![\w])/g;
-const DUNDER_IDENTIFIER_RE = /(?<![\\\w])__[A-Za-z][A-Za-z0-9_]*__(?![\w])/g;
-const DUNDER_CODE_CONTEXT_BEFORE_RE =
-  /\b(?:call(?:ing)?|class|dunder|implement(?:ed|ing|s)?|identifier|method|python|use|using)\b[\s\S]{0,96}$/i;
-const DUNDER_CODE_CONTEXT_MARK_RE = /^[\s]*[=()[\]{}:+\-*/<>'"`]/;
-const DUNDER_CODE_CONTEXT_PREV_RE = /[=()[\]{}:+\-*/<>'"`]\s*$/;
-const PYTHON_DUNDER_VALUE_NAMES = new Set(
-  [
-    "abs add aenter aexit all annotations aiter and annotate anext await bases bool buffer",
-    "builtins bytes call cached ceil class class_getitem complex contains debug del delattr",
-    "delete delitem dict dir divmod doc enter eq exit file firstlineno float floor floordiv",
-    "format fspath ge get getattr getattribute getitem getnewargs getnewargs_ex getstate",
-    "gt hash iadd iand ifloordiv ilshift imatmul imod imul index init init_subclass",
-    "instancecheck int invert ior ipow irshift isabstractmethod isub iter itruediv ixor",
-    "le len length_hint loader lshift lt main match_args matmul missing mod module mro",
-    "mro_entries mul name ne neg new next or orig_bases package parameters path pos pow",
-    "prepare qualname radd rand rdivmod reduce reduce_ex repr reversed rfloordiv rlshift",
-    "rmatmul rmod rmul ror round rpow rrshift rshift rsub rtruediv rxor set set_name",
-    "setattr setitem setstate sizeof slots spec static_attributes str sub subclasscheck",
-    "subclasshook subclasses text_signature truediv trunc type_params version weakref xor",
-  ]
-    .join(" ")
-    .split(" "),
-);
 
-type MarkdownSegment = {
-  text: string;
-  protected: boolean;
-};
+type Segment = { text: string; protected: boolean };
 
-function partitionProtectedMarkdown(text: string): MarkdownSegment[] {
-  const segments: MarkdownSegment[] = [];
+function partitionFencedCode(text: string): Segment[] {
+  const segments: Segment[] = [];
   let lastIndex = 0;
   for (const match of text.matchAll(FENCED_CODE_OPEN_RE)) {
     const matchStart = match.index ?? 0;
@@ -81,61 +58,26 @@ function findFencedCodeEnd(text: string, from: number, marker: string): number {
   return text.length;
 }
 
-function escapeUnderscoreIdentifier(identifier: string): string {
+function escapeUnderscores(identifier: string): string {
   return identifier.replaceAll("_", "\\_");
 }
 
-function protectDunderIdentifier(identifier: string, index: number, source: string): string {
-  const name = identifier.slice(2, -2);
-  const before = source.slice(Math.max(0, index - 96), index);
-  const after = source.slice(index + identifier.length, index + identifier.length + 16);
-  const hasCodeContext =
-    DUNDER_CODE_CONTEXT_BEFORE_RE.test(before) ||
-    DUNDER_CODE_CONTEXT_PREV_RE.test(before) ||
-    DUNDER_CODE_CONTEXT_MARK_RE.test(after);
-  if (PYTHON_DUNDER_VALUE_NAMES.has(name) && hasCodeContext) {
-    return escapeUnderscoreIdentifier(identifier);
-  }
-  return identifier;
-}
-
-function protectInlineMarkdown(segment: string): string {
-  return segment
-    .replace(DUNDER_IDENTIFIER_RE, protectDunderIdentifier)
-    .replace(SNAKE_CASE_IDENTIFIER_RE, escapeUnderscoreIdentifier);
-}
-
-function protectUnderscoredIdentifiersOutsideInlineMarkdown(text: string): string {
+function escapeIdentifiersOutsideInlineProtected(text: string): string {
   let result = "";
   let lastIndex = 0;
-  for (const match of text.matchAll(INLINE_PROTECTED_MARKDOWN_RE)) {
+  for (const match of text.matchAll(INLINE_PROTECTED_RE)) {
     const start = match.index ?? 0;
-    result += protectInlineMarkdown(text.slice(lastIndex, start));
+    result += text.slice(lastIndex, start).replace(UNDERSCORE_ID_RE, escapeUnderscores);
     result += match[0];
     lastIndex = start + match[0].length;
   }
-  result += protectInlineMarkdown(text.slice(lastIndex));
+  result += text.slice(lastIndex).replace(UNDERSCORE_ID_RE, escapeUnderscores);
   return result;
 }
 
-function protectUnderscoredIdentifiersOutsideRawHtml(text: string): string {
-  let result = "";
-  let lastIndex = 0;
-  for (const match of text.matchAll(RAW_HTML_SPAN_RE)) {
-    const start = match.index ?? 0;
-    result += protectUnderscoredIdentifiersOutsideInlineMarkdown(text.slice(lastIndex, start));
-    result += match[0];
-    lastIndex = start + match[0].length;
-  }
-  result += protectUnderscoredIdentifiersOutsideInlineMarkdown(text.slice(lastIndex));
-  return result;
-}
-
-function protectUnderscoredIdentifiers(text: string): string {
-  return partitionProtectedMarkdown(text)
-    .map((segment) =>
-      segment.protected ? segment.text : protectUnderscoredIdentifiersOutsideRawHtml(segment.text),
-    )
+function escapeUnderscoreIdentifiers(text: string): string {
+  return partitionFencedCode(text)
+    .map((seg) => (seg.protected ? seg.text : escapeIdentifiersOutsideInlineProtected(seg.text)))
     .join("");
 }
 
@@ -156,7 +98,7 @@ export class HyperlinkMarkdown implements Component {
     options?: DefaultTextStyle,
   ) {
     this.inner = new Markdown(
-      protectUnderscoredIdentifiers(text),
+      escapeUnderscoreIdentifiers(text),
       paddingX,
       paddingY,
       theme,
@@ -170,7 +112,7 @@ export class HyperlinkMarkdown implements Component {
   }
 
   setText(text: string): void {
-    this.inner.setText(protectUnderscoredIdentifiers(text));
+    this.inner.setText(escapeUnderscoreIdentifiers(text));
     this.urls = extractUrls(text);
   }
 

--- a/src/tui/components/hyperlink-markdown.ts
+++ b/src/tui/components/hyperlink-markdown.ts
@@ -3,6 +3,142 @@ import type { Component, DefaultTextStyle, MarkdownTheme } from "@earendil-works
 import { Markdown } from "@earendil-works/pi-tui";
 import { addOsc8Hyperlinks, extractUrls } from "../osc8-hyperlinks.js";
 
+const FENCED_CODE_OPEN_RE = /(^|\n)( {0,3})(`{3,}|~{3,})[^\n]*(?:\n|$)/g;
+const INLINE_PROTECTED_MARKDOWN_RE =
+  /(`+)(?:(?!\1)[\s\S])*?\1|<\/?[A-Za-z_][A-Za-z0-9_.:-]*(?:\s+[^<>\n]*)?>|\[[^\]\n]+\]\([^)]+\)|https?:\/\/[^\s<)]+/g;
+const RAW_HTML_SPAN_RE =
+  /<(a|article|aside|blockquote|body|code|div|em|footer|h[1-6]|head|header|html|li|main|nav|ol|p|pre|script|section|span|strong|style|table|tbody|td|tfoot|th|thead|tr|ul)(?:\s+[^<>\n]*)?>[\s\S]*?<\/\1>/gi;
+const SNAKE_CASE_IDENTIFIER_RE =
+  /(?<![\\\w])[A-Za-z][A-Za-z0-9]*_[A-Za-z0-9_]*[A-Za-z0-9](?![\w])/g;
+const DUNDER_IDENTIFIER_RE = /(?<![\\\w])__[A-Za-z][A-Za-z0-9_]*__(?![\w])/g;
+const DUNDER_CODE_CONTEXT_BEFORE_RE =
+  /\b(?:call(?:ing)?|class|dunder|implement(?:ed|ing|s)?|identifier|method|python|use|using)\b[\s\S]{0,96}$/i;
+const DUNDER_CODE_CONTEXT_MARK_RE = /^[\s]*[=()[\]{}:+\-*/<>'"`]/;
+const DUNDER_CODE_CONTEXT_PREV_RE = /[=()[\]{}:+\-*/<>'"`]\s*$/;
+const PYTHON_DUNDER_VALUE_NAMES = new Set(
+  [
+    "abs add aenter aexit all annotations aiter and annotate anext await bases bool buffer",
+    "builtins bytes call cached ceil class class_getitem complex contains debug del delattr",
+    "delete delitem dict dir divmod doc enter eq exit file firstlineno float floor floordiv",
+    "format fspath ge get getattr getattribute getitem getnewargs getnewargs_ex getstate",
+    "gt hash iadd iand ifloordiv ilshift imatmul imod imul index init init_subclass",
+    "instancecheck int invert ior ipow irshift isabstractmethod isub iter itruediv ixor",
+    "le len length_hint loader lshift lt main match_args matmul missing mod module mro",
+    "mro_entries mul name ne neg new next or orig_bases package parameters path pos pow",
+    "prepare qualname radd rand rdivmod reduce reduce_ex repr reversed rfloordiv rlshift",
+    "rmatmul rmod rmul ror round rpow rrshift rshift rsub rtruediv rxor set set_name",
+    "setattr setitem setstate sizeof slots spec static_attributes str sub subclasscheck",
+    "subclasshook subclasses text_signature truediv trunc type_params version weakref xor",
+  ]
+    .join(" ")
+    .split(" "),
+);
+
+type MarkdownSegment = {
+  text: string;
+  protected: boolean;
+};
+
+function partitionProtectedMarkdown(text: string): MarkdownSegment[] {
+  const segments: MarkdownSegment[] = [];
+  let lastIndex = 0;
+  for (const match of text.matchAll(FENCED_CODE_OPEN_RE)) {
+    const matchStart = match.index ?? 0;
+    const start = matchStart + (match[1] ? 1 : 0);
+    const openerEnd = matchStart + match[0].length;
+    if (start < lastIndex) {
+      continue;
+    }
+    if (start > lastIndex) {
+      segments.push({ text: text.slice(lastIndex, start), protected: false });
+    }
+    const marker = match[3] ?? "";
+    const end = findFencedCodeEnd(text, openerEnd, marker);
+    segments.push({ text: text.slice(start, end), protected: true });
+    lastIndex = end;
+  }
+  if (lastIndex < text.length) {
+    segments.push({ text: text.slice(lastIndex), protected: false });
+  }
+  return segments;
+}
+
+function findFencedCodeEnd(text: string, from: number, marker: string): number {
+  const fenceChar = marker[0];
+  const fenceLength = marker.length;
+  let lineStart = from;
+  while (lineStart < text.length) {
+    const lineEnd = text.indexOf("\n", lineStart);
+    const end = lineEnd === -1 ? text.length : lineEnd + 1;
+    const line = text.slice(lineStart, lineEnd === -1 ? text.length : lineEnd);
+    const closeMatch = /^( {0,3})(`+|~+)[ \t]*$/u.exec(line);
+    const closeMarker = closeMatch?.[2] ?? "";
+    if (closeMarker[0] === fenceChar && closeMarker.length >= fenceLength) {
+      return end;
+    }
+    lineStart = end;
+  }
+  return text.length;
+}
+
+function escapeUnderscoreIdentifier(identifier: string): string {
+  return identifier.replaceAll("_", "\\_");
+}
+
+function protectDunderIdentifier(identifier: string, index: number, source: string): string {
+  const name = identifier.slice(2, -2);
+  const before = source.slice(Math.max(0, index - 96), index);
+  const after = source.slice(index + identifier.length, index + identifier.length + 16);
+  const hasCodeContext =
+    DUNDER_CODE_CONTEXT_BEFORE_RE.test(before) ||
+    DUNDER_CODE_CONTEXT_PREV_RE.test(before) ||
+    DUNDER_CODE_CONTEXT_MARK_RE.test(after);
+  if (PYTHON_DUNDER_VALUE_NAMES.has(name) && hasCodeContext) {
+    return escapeUnderscoreIdentifier(identifier);
+  }
+  return identifier;
+}
+
+function protectInlineMarkdown(segment: string): string {
+  return segment
+    .replace(DUNDER_IDENTIFIER_RE, protectDunderIdentifier)
+    .replace(SNAKE_CASE_IDENTIFIER_RE, escapeUnderscoreIdentifier);
+}
+
+function protectUnderscoredIdentifiersOutsideInlineMarkdown(text: string): string {
+  let result = "";
+  let lastIndex = 0;
+  for (const match of text.matchAll(INLINE_PROTECTED_MARKDOWN_RE)) {
+    const start = match.index ?? 0;
+    result += protectInlineMarkdown(text.slice(lastIndex, start));
+    result += match[0];
+    lastIndex = start + match[0].length;
+  }
+  result += protectInlineMarkdown(text.slice(lastIndex));
+  return result;
+}
+
+function protectUnderscoredIdentifiersOutsideRawHtml(text: string): string {
+  let result = "";
+  let lastIndex = 0;
+  for (const match of text.matchAll(RAW_HTML_SPAN_RE)) {
+    const start = match.index ?? 0;
+    result += protectUnderscoredIdentifiersOutsideInlineMarkdown(text.slice(lastIndex, start));
+    result += match[0];
+    lastIndex = start + match[0].length;
+  }
+  result += protectUnderscoredIdentifiersOutsideInlineMarkdown(text.slice(lastIndex));
+  return result;
+}
+
+function protectUnderscoredIdentifiers(text: string): string {
+  return partitionProtectedMarkdown(text)
+    .map((segment) =>
+      segment.protected ? segment.text : protectUnderscoredIdentifiersOutsideRawHtml(segment.text),
+    )
+    .join("");
+}
+
 /**
  * Wrapper around pi-tui's Markdown component that adds OSC 8 terminal
  * hyperlinks to rendered output, making URLs clickable even when broken
@@ -19,7 +155,13 @@ export class HyperlinkMarkdown implements Component {
     theme: MarkdownTheme,
     options?: DefaultTextStyle,
   ) {
-    this.inner = new Markdown(text, paddingX, paddingY, theme, options);
+    this.inner = new Markdown(
+      protectUnderscoredIdentifiers(text),
+      paddingX,
+      paddingY,
+      theme,
+      options,
+    );
     this.urls = extractUrls(text);
   }
 
@@ -28,7 +170,7 @@ export class HyperlinkMarkdown implements Component {
   }
 
   setText(text: string): void {
-    this.inner.setText(text);
+    this.inner.setText(protectUnderscoredIdentifiers(text));
     this.urls = extractUrls(text);
   }
 

--- a/src/tui/components/hyperlink-markdown.ts
+++ b/src/tui/components/hyperlink-markdown.ts
@@ -1,4 +1,3 @@
-// Hyperlink markdown helpers render markdown links with TUI hyperlink styling.
 import type { Component, DefaultTextStyle, MarkdownTheme } from "@earendil-works/pi-tui";
 import { Markdown } from "@earendil-works/pi-tui";
 import { addOsc8Hyperlinks, extractUrls } from "../osc8-hyperlinks.js";
@@ -75,7 +74,7 @@ function escapeIdentifiersOutsideInlineProtected(text: string): string {
   return result;
 }
 
-function escapeUnderscoreIdentifiers(text: string): string {
+export function escapeUnderscoreIdentifiers(text: string): string {
   return partitionFencedCode(text)
     .map((seg) => (seg.protected ? seg.text : escapeIdentifiersOutsideInlineProtected(seg.text)))
     .join("");

--- a/src/tui/components/tool-execution.ts
+++ b/src/tui/components/tool-execution.ts
@@ -3,6 +3,7 @@ import { Box, Container, Markdown, Spacer, Text } from "@earendil-works/pi-tui";
 import { formatToolDetail, resolveToolDisplay } from "../../agents/tool-display.js";
 import { markdownTheme, theme } from "../theme/theme.js";
 import { sanitizeRenderableText } from "../tui-formatters.js";
+import { escapeUnderscoreIdentifiers } from "./hyperlink-markdown.js";
 
 // Rendering model for live tool calls in the chat log.
 type ToolResultContent = {
@@ -134,13 +135,14 @@ export class ToolExecutionComponent extends Container {
 
     const raw = extractText(this.result);
     const text = raw || (this.isPartial ? "…" : "");
-    if (!this.expanded && text) {
-      const lines = text.split("\n");
+    const escaped = escapeUnderscoreIdentifiers(text);
+    if (!this.expanded && escaped) {
+      const lines = escaped.split("\n");
       const preview =
-        lines.length > PREVIEW_LINES ? `${lines.slice(0, PREVIEW_LINES).join("\n")}\n…` : text;
+        lines.length > PREVIEW_LINES ? `${lines.slice(0, PREVIEW_LINES).join("\n")}\n…` : escaped;
       this.output.setText(preview);
     } else {
-      this.output.setText(text);
+      this.output.setText(escaped);
     }
   }
 }

--- a/src/tui/tui-pty-harness.e2e.test.ts
+++ b/src/tui/tui-pty-harness.e2e.test.ts
@@ -174,6 +174,7 @@ async function writeTuiPtyFixtureScript(dir: string) {
           }
           const isSourceReplyProof = opts.message === "message tool only source reply proof";
           const isXaiLimitProof = opts.message === "xai limit proof";
+          const isPythonDunderProof = opts.message === "python dunder proof";
           setTimeout(() => {
             if (isXaiLimitProof) {
               this.onEvent?.({
@@ -207,7 +208,25 @@ async function writeTuiPtyFixtureScript(dir: string) {
               ? assistantMessageFromSourceReplyPayloads(sourceReplyPayloads)
               : {
                   role: "assistant",
-                  content: [{ type: "text", text: "PTY_RESPONSE: " + opts.message }],
+                  content: [
+                    {
+                      type: "text",
+                      text: isPythonDunderProof
+                        ? [
+                            'Use __name__ == "__main__" before calling __init__().',
+                            "",
+                            "\`\`\`python",
+                            'if __name__ == "__main__":',
+                            "    __init__()",
+                            "def is_palindrome(s: str) -> bool:",
+                            "    return True",
+                            "\`\`\`",
+                            "",
+                            "Inline \`__name__\` and \`is_palindrome\` stay literal.",
+                          ].join("\\n")
+                        : "PTY_RESPONSE: " + opts.message,
+                    },
+                  ],
                   timestamp: Date.now(),
                 };
             this.onEvent?.({
@@ -408,6 +427,26 @@ describe.sequential("TUI PTY harness", () => {
         (entry) =>
           entry.method === "sourceReplyMetadata" &&
           objectFieldEquals(entry, "text", "VISIBLE_TUI_SOURCE_REPLY_PROOF"),
+      );
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "renders Python dunder identifiers through the terminal markdown path",
+    async () => {
+      await fixture.run.write("python dunder proof\r");
+      await fixture.run.waitForOutput('Use __name__ == "__main__" before calling __init__().');
+      await fixture.run.waitForOutput('if __name__ == "__main__":');
+      await fixture.run.waitForOutput("def is_palindrome(s: str) -> bool:");
+      await fixture.run.waitForOutput("Inline ");
+      await fixture.run.waitForOutput("__name__");
+      await fixture.run.waitForOutput("is_palindrome");
+      await fixture.run.waitForOutput("stay literal.");
+      expect(fixture.run.output()).not.toContain('Use name == "main"');
+      await fixture.waitForLogEntry(
+        (entry) =>
+          entry.method === "sendChat" && objectFieldEquals(entry, "message", "python dunder proof"),
       );
     },
     TEST_TIMEOUT_MS,


### PR DESCRIPTION
## Summary

- Preserve underscore identifiers (`__init__`, `is_palindrome`) in TUI Markdown rendering by escaping underscores before pi-tui/marked can treat them as emphasis.
- Generic single-regex approach: one `UNDERSCORE_ID_RE` catches both `snake_case` and `__dunder__` patterns, no language-specific dictionary or context heuristics needed.
- Protected regions (fenced code, inline code, HTML tags, links, URLs) are excluded from escaping so existing Markdown features continue to work.

**Behavior tradeoff:** `__word__` Markdown strong emphasis is intentionally rendered literally in TUI chat/tool Markdown rows. `**bold**` emphasis still works and is the preferred form. This PR chooses copyable code identifiers over underscore-strong syntax for these code-heavy rows.

Fixes #90769.

## Verification

- `pnpm exec oxfmt --check src/tui/components/hyperlink-markdown.ts src/tui/components/chat-log.test.ts src/tui/components/tool-execution.ts src/tui/tui-pty-harness.e2e.test.ts src/agents/openclaw-tools.camera.test.ts`
- `node scripts/run-vitest.mjs run src/tui/components/chat-log.test.ts` — 25/25 passed
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts` — 14/14 passed
- `git diff --check upstream/main...HEAD` — clean
- Rebased onto latest `upstream/main`

## Real behavior proof

Behavior addressed: TUI Markdown rendering now preserves Python dunder identifiers (`__name__`, `__init__`) and snake_case identifiers (`is_palindrome`) without consuming underscores as emphasis markup.
Real environment tested: local macOS source checkout with the OpenClaw fake-backend TUI PTY harness running the real `runTui()` terminal loop.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts`.
Evidence after fix: PTY harness test `renders Python dunder identifiers through the terminal markdown path` waits for visible terminal output containing `Use __name__ == "__main__" before calling __init__().`, `if __name__ == "__main__":`, `def is_palindrome(s: str) -> bool:`, `__name__`, `is_palindrome`, and `stay literal.`.
Observed result after fix: the PTY lane passed with 14 tests, and the ChatLog component lane passed with 25 tests covering fenced code, inline code, dunder prose, long fences, raw HTML tags, tool-result output, and identifier escaping.
What was not tested: live provider calls were not run locally because they require live provider credentials.
