### PR TITLE
fix(daemon): write LaunchAgent plist to boot volume when home is on external APFS

### DIFF
--- a/apps/macos/Sources/OpenClaw/GatewayLaunchAgentManager.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayLaunchAgentManager.swift
@@ -3,6 +3,7 @@ import Foundation
 enum GatewayLaunchAgentManager {
     private static let logger = Logger(subsystem: "ai.openclaw", category: "gateway.launchd")
     private static let disableLaunchAgentMarker = ".openclaw/disable-launchagent"
+    private nonisolated(unsafe) static var externalHomeVolumeMemo: (path: String, external: Bool)?
 
     private static var disableLaunchAgentMarkerURL: URL {
         #if DEBUG
@@ -15,8 +16,74 @@ enum GatewayLaunchAgentManager {
     }
 
     private static var plistURL: URL {
-        FileManager().homeDirectoryForCurrentUser
+        self.launchAgentPlistURL()
+    }
+
+    static func launchAgentPlistURL(
+        homeURL: URL = FileManager().homeDirectoryForCurrentUser,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        homeIsExternalVolume: Bool? = nil) -> URL
+    {
+        self.launchAgentHomeURL(
+            homeURL: homeURL,
+            environment: environment,
+            homeIsExternalVolume: homeIsExternalVolume)
             .appendingPathComponent("Library/LaunchAgents/\(gatewayLaunchdLabel).plist")
+    }
+
+    private static func launchAgentHomeURL(
+        homeURL: URL,
+        environment: [String: String],
+        homeIsExternalVolume: Bool?) -> URL
+    {
+        let external = homeIsExternalVolume ?? self.isExternalVolumeHome(homeURL)
+        guard external, let user = self.loginUsername(environment: environment) else {
+            return homeURL
+        }
+        return URL(fileURLWithPath: "/Users", isDirectory: true)
+            .appendingPathComponent(user, isDirectory: true)
+    }
+
+    private static func loginUsername(environment: [String: String]) -> String? {
+        if let user = environment["USER"]?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !user.isEmpty
+        {
+            return user
+        }
+        if let logname = environment["LOGNAME"]?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !logname.isEmpty
+        {
+            return logname
+        }
+        let fallback = NSUserName().trimmingCharacters(in: .whitespacesAndNewlines)
+        return fallback.isEmpty ? nil : fallback
+    }
+
+    private static func isExternalVolumeHome(_ homeURL: URL) -> Bool {
+        let path = homeURL.path
+        if let memo = self.externalHomeVolumeMemo, memo.path == path {
+            return memo.external
+        }
+
+        let external = self.fileSystemNumber(forPath: "/")
+            .flatMap { rootDevice in
+                self.fileSystemNumber(forPath: path).map { homeDevice in
+                    rootDevice != homeDevice
+                }
+            } ?? false
+        self.externalHomeVolumeMemo = (path, external)
+        return external
+    }
+
+    private static func fileSystemNumber(forPath path: String) -> NSNumber? {
+        guard
+            let value = try? FileManager.default.attributesOfFileSystem(forPath: path)[
+                .systemNumber,
+            ] as? NSNumber
+        else {
+            return nil
+        }
+        return value
     }
 
     static func isLaunchAgentWriteDisabled() -> Bool {

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayLaunchAgentManagerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayLaunchAgentManagerTests.swift
@@ -3,6 +3,25 @@ import Testing
 @testable import OpenClaw
 
 struct GatewayLaunchAgentManagerTests {
+    @Test func `launch agent plist URL keeps normal home`() throws {
+        let url = GatewayLaunchAgentManager.launchAgentPlistURL(
+            homeURL: URL(fileURLWithPath: "/Users/testuser", isDirectory: true),
+            environment: ["USER": "ignored"],
+            homeIsExternalVolume: false)
+
+        #expect(url.path == "/Users/testuser/Library/LaunchAgents/ai.openclaw.gateway.plist")
+    }
+
+    @Test func `launch agent plist URL uses boot volume user home when current home is external`() throws {
+        let url = GatewayLaunchAgentManager.launchAgentPlistURL(
+            homeURL: URL(fileURLWithPath: "/Volumes/MainDataDrive", isDirectory: true),
+            environment: ["USER": "TestUser"],
+            homeIsExternalVolume: true)
+
+        #expect(url.path == "/Users/TestUser/Library/LaunchAgents/ai.openclaw.gateway.plist")
+        #expect(!url.path.contains("/Volumes/MainDataDrive"))
+    }
+
     @Test func `attach only runtime override does not uninstall gateway launch agent`() throws {
         let dir = FileManager().temporaryDirectory
             .appendingPathComponent("openclaw-attach-only-\(UUID().uuidString)", isDirectory: true)

--- a/src/cli/update-cli/restart-helper.test.ts
+++ b/src/cli/update-cli/restart-helper.test.ts
@@ -16,6 +16,26 @@ vi.mock("node:child_process", async () => {
   );
 });
 
+// When set, statSync reports this path on a different device than "/", so the
+// boot-volume-aware home resolver treats it as an external APFS HOME.
+const fsState = vi.hoisted(() => ({ externalHome: undefined as string | undefined }));
+
+vi.mock("node:fs", async () => {
+  const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+  const statSync = ((p: string) => {
+    if (fsState.externalHome) {
+      if (p === "/") {
+        return { dev: 1 };
+      }
+      if (p === fsState.externalHome) {
+        return { dev: 99 };
+      }
+    }
+    return actual.statSync(p);
+  }) as typeof actual.statSync;
+  return { ...actual, statSync, default: { ...actual, statSync } };
+});
+
 describe("restart-helper", () => {
   const originalPlatform = process.platform;
   const originalGetUid = process.getuid;
@@ -128,6 +148,7 @@ exit 0
   afterEach(() => {
     Object.defineProperty(process, "platform", { value: originalPlatform });
     process.getuid = originalGetUid;
+    fsState.externalHome = undefined;
   });
 
   describe("prepareRestartScript", () => {
@@ -264,6 +285,26 @@ exit 1
       expect(content).toContain("Bootstrap loads RunAtLoad agents");
       expect(content).toContain('rm -f "$0"');
       expect(content).toContain('rmdir "$script_dir" 2>/dev/null || true');
+      await cleanupScript(scriptPath);
+    });
+
+    it("bootstraps the boot-volume plist when HOME is on an external volume", async () => {
+      Object.defineProperty(process, "platform", { value: "darwin" });
+      process.getuid = () => 501;
+      fsState.externalHome = "/Volumes/Data/Users/test";
+
+      const { scriptPath, content } = await prepareAndReadScript({
+        OPENCLAW_PROFILE: "default",
+        HOME: "/Volumes/Data/Users/test",
+      });
+      // launchd cannot bootstrap from the external volume; the generated script
+      // must target the boot-volume plist, not the external HOME one.
+      expect(content).toContain(
+        "launchctl bootstrap 'gui/501' '/Users/test/Library/LaunchAgents/ai.openclaw.gateway.plist'",
+      );
+      expect(content).not.toContain(
+        "/Volumes/Data/Users/test/Library/LaunchAgents/ai.openclaw.gateway.plist",
+      );
       await cleanupScript(scriptPath);
     });
 

--- a/src/cli/update-cli/restart-helper.test.ts
+++ b/src/cli/update-cli/restart-helper.test.ts
@@ -296,6 +296,7 @@ exit 1
       const { scriptPath, content } = await prepareAndReadScript({
         OPENCLAW_PROFILE: "default",
         HOME: "/Volumes/Data/Users/test",
+        USER: "test",
       });
       // launchd cannot bootstrap from the external volume; the generated script
       // must target the boot-volume plist, not the external HOME one.

--- a/src/cli/update-cli/restart-helper.ts
+++ b/src/cli/update-cli/restart-helper.ts
@@ -11,6 +11,7 @@ import {
   resolveGatewaySystemdServiceName,
   resolveGatewayWindowsTaskName,
 } from "../../daemon/constants.js";
+import { resolveLaunchAgentHomeDir } from "../../daemon/paths.js";
 import {
   renderPosixRestartLogSetup,
   resolveGatewayRestartLogPath,
@@ -121,9 +122,13 @@ exit "$status"
       const escaped = shellEscape(label);
       // Fallback to 501 if getuid is not available (though it should be on macOS)
       const uid = process.getuid ? process.getuid() : 501;
-      // Resolve HOME at generation time via env/process.env to match launchd.ts,
-      // and shell-escape the label in the plist filename to prevent injection.
-      const home = normalizeOptionalString(env.HOME) || process.env.HOME || os.homedir();
+      // Resolve HOME at generation time through the same boot-volume-aware home
+      // as install (an external APFS $HOME would otherwise make the generated
+      // bootstrap re-hit error 5), and shell-escape the label to prevent injection.
+      const home = resolveLaunchAgentHomeDir({
+        ...env,
+        HOME: normalizeOptionalString(env.HOME) || process.env.HOME || os.homedir(),
+      });
       const plistPath = path.join(home, "Library", "LaunchAgents", `${label}.plist`);
       const escapedPlistPath = shellEscape(plistPath);
       const logSetup = renderPosixRestartLogSetup({ ...process.env, ...env });

--- a/src/daemon/inspect.ts
+++ b/src/daemon/inspect.ts
@@ -9,7 +9,7 @@ import {
   resolveGatewaySystemdServiceName,
   resolveGatewayWindowsTaskName,
 } from "./constants.js";
-import { resolveHomeDir } from "./paths.js";
+import { resolveHomeDir, resolveLaunchAgentHomeDir } from "./paths.js";
 import { execSchtasks } from "./schtasks-exec.js";
 import { parseSystemdExecStart } from "./systemd-unit.js";
 
@@ -453,7 +453,9 @@ export async function findExtraGatewayServices(
 
   if (process.platform === "darwin") {
     try {
-      const home = resolveHomeDir(env);
+      // Boot-volume-aware: an external-$HOME install lives under /Users/<user>,
+      // not the external volume, so scan where the plist was actually written.
+      const home = resolveLaunchAgentHomeDir(env);
       const userDir = path.join(home, "Library", "LaunchAgents");
       for (const svc of await scanLaunchdDir({
         dir: userDir,

--- a/src/daemon/launchd-restart-handoff.test.ts
+++ b/src/daemon/launchd-restart-handoff.test.ts
@@ -3,6 +3,9 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 const spawnMock = vi.hoisted(() => vi.fn());
 const unrefMock = vi.hoisted(() => vi.fn());
+// When set, statSync reports this path on a different device than "/", so the
+// boot-volume-aware resolver treats it as an external APFS HOME.
+const fsState = vi.hoisted(() => ({ externalHome: undefined as string | undefined }));
 
 vi.mock("node:child_process", async () => {
   const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
@@ -10,6 +13,22 @@ vi.mock("node:child_process", async () => {
     ...actual,
     spawn: (...args: unknown[]) => spawnMock(...args),
   };
+});
+
+vi.mock("node:fs", async () => {
+  const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+  const statSync = ((p: string) => {
+    if (fsState.externalHome) {
+      if (p === "/") {
+        return { dev: 1 };
+      }
+      if (p === fsState.externalHome) {
+        return { dev: 99 };
+      }
+    }
+    return actual.statSync(p);
+  }) as typeof actual.statSync;
+  return { ...actual, statSync, default: { ...actual, statSync } };
 });
 
 import { scheduleDetachedLaunchdRestartHandoff } from "./launchd-restart-handoff.js";
@@ -36,6 +55,7 @@ function requireSpawnCall(callIndex = 0): SpawnCall {
 afterEach(() => {
   spawnMock.mockReset();
   unrefMock.mockReset();
+  fsState.externalHome = undefined;
   spawnMock.mockReturnValue({ pid: 4242, unref: unrefMock });
 });
 
@@ -155,5 +175,22 @@ describe("scheduleDetachedLaunchdRestartHandoff", () => {
       });
     }).toThrow("Invalid launchd label: ../evil/label");
     expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it("bootstraps from the boot-volume plist path when HOME is on an external volume", () => {
+    fsState.externalHome = "/Volumes/Data/Users/test";
+    spawnMock.mockReturnValue({ pid: 4242, unref: unrefMock });
+
+    scheduleDetachedLaunchdRestartHandoff({
+      env: { HOME: "/Volumes/Data/Users/test", USER: "test", OPENCLAW_PROFILE: "default" },
+      mode: "reload",
+      waitForPid: 1,
+    });
+
+    const [, args] = requireSpawnCall();
+    // args[5] is the plist path baked into the detached `launchctl bootstrap`.
+    // It must stay on the boot volume, or the restart re-hits error 5.
+    expect(args[5]).toBe("/Users/test/Library/LaunchAgents/ai.openclaw.gateway.plist");
+    expect(args[5]).not.toContain("/Volumes/");
   });
 });

--- a/src/daemon/launchd-restart-handoff.ts
+++ b/src/daemon/launchd-restart-handoff.ts
@@ -7,8 +7,10 @@ import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { sanitizeHostExecEnv } from "../infra/host-env-security.js";
 import { resolveGatewayLaunchAgentLabel } from "./constants.js";
-export { isCurrentProcessLaunchdServiceLabel } from "./launchd-current-service.js";
+import { resolveLaunchAgentHomeDir } from "./paths.js";
 import { renderPosixRestartLogSetup } from "./restart-logs.js";
+
+export { isCurrentProcessLaunchdServiceLabel } from "./launchd-current-service.js";
 
 type LaunchdRestartHandoffMode = "kickstart" | "reload" | "start-after-exit";
 
@@ -84,7 +86,11 @@ function resolveLaunchdRestartTarget(
 ): LaunchdRestartTarget {
   const domain = resolveGuiDomain();
   const label = resolveLaunchAgentLabel(env);
-  const home = normalizeOptionalString(env.HOME) || os.homedir();
+  // Boot-volume-aware: launchd cannot bootstrap a plist from an external APFS
+  // $HOME (error 5), so the detached restart must target the same canonical
+  // path install uses, not the raw HOME-derived one.
+  const homeBase = normalizeOptionalString(env.HOME) || os.homedir();
+  const home = resolveLaunchAgentHomeDir({ ...env, HOME: homeBase });
   const plistPath = path.join(home, "Library", "LaunchAgents", `${label}.plist`);
   return {
     domain,

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -52,6 +52,7 @@ const state = vi.hoisted(() => ({
   files: new Map<string, string>(),
   fileModes: new Map<string, number>(),
   fileWrites: [] as Array<{ path: string; data: string }>,
+  externalVolume: false,
 }));
 const launchdRestartHandoffState = vi.hoisted(() => ({
   scheduleDetachedLaunchdRestartHandoff: vi.fn<
@@ -279,6 +280,11 @@ vi.mock("node:fs/promises", async () => {
     }),
     stat: vi.fn(async (p: string) => {
       const key = p;
+      // Simulate external volume: "/" is dev 1, everything else is dev 99.
+      // isExternalVolumePath compares root dev against target dev.
+      if (state.externalVolume) {
+        return { mode: 0o755, dev: key === "/" ? 1 : 99 };
+      }
       if (state.dirs.has(key)) {
         return { mode: state.dirModes.get(key) ?? 0o777 };
       }
@@ -349,6 +355,7 @@ beforeEach(() => {
   state.files.clear();
   state.fileModes.clear();
   state.fileWrites.length = 0;
+  state.externalVolume = false;
   cleanStaleGatewayProcessesSync.mockReset();
   cleanStaleGatewayProcessesSync.mockReturnValue([]);
   inspectPortUsage.mockReset();
@@ -1899,5 +1906,40 @@ describe("resolveLaunchAgentPlistPath", () => {
         OPENCLAW_LAUNCHD_LABEL: "../evil/label",
       }),
     ).toThrow("Invalid launchd label");
+  });
+});
+
+describe("external APFS volume fallback", () => {
+  it("bootstraps from boot-volume plist when home is on an external volume", async () => {
+    state.externalVolume = true;
+    const env = { ...createDefaultLaunchdEnv(), USER: "test" };
+    const stdout = new PassThrough();
+    await installLaunchAgent({
+      env,
+      stdout,
+      programArguments: defaultProgramArguments,
+    });
+    // The boot-volume plist should be written alongside the home-dir plist.
+    const bootPlist = "/Users/test/Library/LaunchAgents/ai.openclaw.gateway.plist";
+    expect(state.files.has(bootPlist)).toBe(true);
+    // Bootstrap should use the boot-volume path, not the external home path.
+    const bootstrapCall = state.launchctlCalls.find(
+      (c) => c[0] === "bootstrap" && c[2] === bootPlist,
+    );
+    expect(bootstrapCall).toBeDefined();
+  });
+  it("does not write boot-volume plist when home is on the root volume", async () => {
+    // externalVolume is false by default; all stat calls return the same dev.
+    const env = { ...createDefaultLaunchdEnv(), USER: "test" };
+    const stdout = new PassThrough();
+    await installLaunchAgent({
+      env,
+      stdout,
+      programArguments: defaultProgramArguments,
+    });
+    // The home-dir plist is at /Users/test/Library/LaunchAgents — same device.
+    // No separate boot-volume plist should be written.
+    const homePlist = "/Users/test/Library/LaunchAgents/ai.openclaw.gateway.plist";
+    expect(state.fileWrites.filter((w) => w.path === homePlist)).toHaveLength(1);
   });
 });

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -22,6 +22,7 @@ import {
   restartLaunchAgent,
   resolveLaunchAgentPlistPath,
   stopLaunchAgent,
+  uninstallLaunchAgent,
 } from "./launchd.js";
 
 const state = vi.hoisted(() => ({
@@ -316,6 +317,14 @@ vi.mock("node:fs/promises", async () => {
     unlink: vi.fn(async (p: string) => {
       state.files.delete(p);
     }),
+    rename: vi.fn(async (from: string, to: string) => {
+      const data = state.files.get(from);
+      state.files.delete(from);
+      if (data !== undefined) {
+        state.files.set(to, data);
+        state.fileWrites.push({ path: to, data });
+      }
+    }),
     writeFile: vi.fn(async (p: string, data: string, opts?: { mode?: number }) => {
       const key = p;
       state.files.set(key, data);
@@ -325,6 +334,15 @@ vi.mock("node:fs/promises", async () => {
     }),
   };
   return { ...wrapped, default: wrapped };
+});
+
+// Mock node:fs statSync so isExternalVolumePathSync sees an external device
+// for `/` vs HOME when state.externalVolume is set; otherwise pass through.
+vi.mock("node:fs", () => {
+  const actual = require("node:fs");
+  const statSync = (p: string) =>
+    state.externalVolume ? { dev: p === "/" ? 1 : 99, mode: 0o755 } : actual.statSync(p);
+  return { ...actual, statSync, default: { ...actual, statSync } };
 });
 
 beforeEach(() => {
@@ -1910,26 +1928,52 @@ describe("resolveLaunchAgentPlistPath", () => {
 });
 
 describe("external APFS volume fallback", () => {
-  it("bootstraps from boot-volume plist when home is on an external volume", async () => {
+  it("canonical plist path resolves to boot volume when HOME is on external volume", async () => {
     state.externalVolume = true;
-    const env = { ...createDefaultLaunchdEnv(), USER: "test" };
+    // HOME points to an external APFS volume; USER is still "test".
+    const env = { ...createDefaultLaunchdEnv(), HOME: "/Volumes/Data/Users/test", USER: "test" };
     const stdout = new PassThrough();
     await installLaunchAgent({
       env,
       stdout,
       programArguments: defaultProgramArguments,
     });
-    // The boot-volume plist should be written alongside the home-dir plist.
     const bootPlist = "/Users/test/Library/LaunchAgents/ai.openclaw.gateway.plist";
-    expect(state.files.has(bootPlist)).toBe(true);
-    // Bootstrap should use the boot-volume path, not the external home path.
+    const externalPlist = "/Volumes/Data/Users/test/Library/LaunchAgents/ai.openclaw.gateway.plist";
+    // The plist must be written only to the boot volume (the external volume is
+    // exactly where launchd refuses to bootstrap from with error 5).
+    expect(state.fileWrites.some((w) => w.path === bootPlist)).toBe(true);
+    expect(state.fileWrites.some((w) => w.path === externalPlist)).toBe(false);
+    // Bootstrap must target the boot-volume path.
     const bootstrapCall = state.launchctlCalls.find(
       (c) => c[0] === "bootstrap" && c[2] === bootPlist,
     );
     expect(bootstrapCall).toBeDefined();
   });
-  it("does not write boot-volume plist when home is on the root volume", async () => {
-    // externalVolume is false by default; all stat calls return the same dev.
+  it("uninstall trashes the plist on the boot volume, not across the external volume", async () => {
+    state.externalVolume = true;
+    const env = { ...createDefaultLaunchdEnv(), HOME: "/Volumes/Data/Users/test", USER: "test" };
+    await installLaunchAgent({
+      env,
+      stdout: new PassThrough(),
+      programArguments: defaultProgramArguments,
+    });
+    const out = new PassThrough();
+    let text = "";
+    out.on("data", (chunk) => {
+      text += String(chunk);
+    });
+    await uninstallLaunchAgent({ env, stdout: out });
+    // Trash target stays on the boot volume so the rename is same-volume; a
+    // cross-volume move to /Volumes/.../.Trash would EXDEV-fail and leak the plist.
+    expect(text).toContain("/Users/test/.Trash/ai.openclaw.gateway.plist");
+    expect(text).not.toContain("/Volumes/");
+    expect(state.files.has("/Users/test/Library/LaunchAgents/ai.openclaw.gateway.plist")).toBe(
+      false,
+    );
+  });
+  it("canonical plist path stays under HOME when on the root volume", async () => {
+    // externalVolume is false by default; all statSync calls return the same dev.
     const env = { ...createDefaultLaunchdEnv(), USER: "test" };
     const stdout = new PassThrough();
     await installLaunchAgent({
@@ -1937,8 +1981,7 @@ describe("external APFS volume fallback", () => {
       stdout,
       programArguments: defaultProgramArguments,
     });
-    // The home-dir plist is at /Users/test/Library/LaunchAgents — same device.
-    // No separate boot-volume plist should be written.
+    // The home-dir plist at /Users/test/... — same device as root.
     const homePlist = "/Users/test/Library/LaunchAgents/ai.openclaw.gateway.plist";
     expect(state.fileWrites.filter((w) => w.path === homePlist)).toHaveLength(1);
   });

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -1950,6 +1950,25 @@ describe("external APFS volume fallback", () => {
     );
     expect(bootstrapCall).toBeDefined();
   });
+  it("resolves to /Users/<login-user> when HOME is the external volume root (#60398)", async () => {
+    state.externalVolume = true;
+    // The reported shape: $HOME is the external volume root itself, so its last
+    // path segment is the volume name, not the user. The account must come from
+    // USER, not basename(HOME).
+    const env = { ...createDefaultLaunchdEnv(), HOME: "/Volumes/MainDataDrive", USER: "test" };
+    await installLaunchAgent({
+      env,
+      stdout: new PassThrough(),
+      programArguments: defaultProgramArguments,
+    });
+    const bootPlist = "/Users/test/Library/LaunchAgents/ai.openclaw.gateway.plist";
+    expect(state.fileWrites.some((w) => w.path === bootPlist)).toBe(true);
+    // It must NOT derive the account from the volume name.
+    expect(state.fileWrites.some((w) => w.path.startsWith("/Users/MainDataDrive/"))).toBe(false);
+    expect(
+      state.launchctlCalls.find((c) => c[0] === "bootstrap" && c[2] === bootPlist),
+    ).toBeDefined();
+  });
   it("uninstall trashes the plist on the boot volume, not across the external volume", async () => {
     state.externalVolume = true;
     const env = { ...createDefaultLaunchdEnv(), HOME: "/Volumes/Data/Users/test", USER: "test" };

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -24,7 +24,7 @@ import {
 } from "./launchd-plist.js";
 import { scheduleDetachedLaunchdRestartHandoff } from "./launchd-restart-handoff.js";
 import { formatLine, toPosixPath, writeFormattedLines } from "./output.js";
-import { resolveGatewayStateDir, resolveHomeDir } from "./paths.js";
+import { resolveGatewayStateDir, resolveLaunchAgentHomeDir } from "./paths.js";
 import { resolveGatewaySupervisorLogPaths } from "./restart-logs.js";
 import { parseKeyValueOutput } from "./runtime-parse.js";
 import type { GatewayServiceRuntime } from "./service-runtime.js";
@@ -47,33 +47,6 @@ const LAUNCH_AGENT_ENV_DIR_NAME = "service-env";
 const LAUNCH_AGENT_STDERR_PATH = "/dev/null";
 const OPENCLAW_UPDATE_LAUNCHD_LABEL_PREFIX = "ai.openclaw.update.";
 const OPENCLAW_MANUAL_UPDATE_LAUNCHD_LABEL_PATTERN = /^ai\.openclaw\.manual-update\.\d+$/;
-
-/** Detect whether a path resides on a different volume than the root filesystem. */
-async function isExternalVolumePath(targetPath: string): Promise<boolean> {
-  try {
-    const [rootStat, targetStat] = await Promise.all([fs.stat("/"), fs.stat(targetPath)]);
-    return rootStat.dev !== targetStat.dev;
-  } catch {
-    // If stat fails, conservatively assume same volume.
-    return false;
-  }
-}
-
-/**
- * Resolve the LaunchAgents directory on the boot volume.
- * When $HOME is on an external APFS volume, launchd refuses to bootstrap
- * plists from that volume (error 5: I/O error). This returns the equivalent
- * path on the root volume so bootstrap can succeed.
- */
-function resolveBootVolumeLaunchAgentsDir(env: Record<string, string | undefined>): string {
-  const username = normalizeLowercaseStringOrEmpty(env.USER);
-  if (!username) {
-    // Cannot determine boot-volume home without USER; fall back to root
-    // LaunchAgents which is shared across all users.
-    return "/Library/LaunchAgents";
-  }
-  return `/Users/${username}/Library/LaunchAgents`;
-}
 
 export type StaleOpenClawUpdateLaunchdJob = {
   label: string;
@@ -149,7 +122,10 @@ function resolveLaunchAgentPlistPathForLabel(
   env: Record<string, string | undefined>,
   label: string,
 ): string {
-  const home = toPosixPath(resolveHomeDir(env));
+  // resolveLaunchAgentHomeDir redirects to the boot volume when $HOME is on an
+  // external APFS volume, so install, repair, restart, uninstall, and doctor
+  // all resolve to one canonical path launchd can actually bootstrap.
+  const home = toPosixPath(resolveLaunchAgentHomeDir(env));
   return path.posix.join(home, "Library", "LaunchAgents", `${label}.plist`);
 }
 
@@ -687,7 +663,9 @@ export async function uninstallLaunchAgent({
     return;
   }
 
-  const home = toPosixPath(resolveHomeDir(env));
+  // Trash the plist on the volume it actually lives on (the boot volume when
+  // $HOME is external); a cross-volume rename would EXDEV-fail and leak it.
+  const home = toPosixPath(resolveLaunchAgentHomeDir(env));
   const trashDir = path.posix.join(home, ".Trash");
   const dest = path.join(trashDir, `${label}.plist`);
   try {
@@ -894,11 +872,7 @@ async function writeLaunchAgentPlist({
   workingDirectory,
   environment,
   description,
-}: Omit<GatewayServiceInstallArgs, "stdout">): Promise<{
-  plistPath: string;
-  stdoutPath: string;
-  bootVolumePlistPath?: string;
-}> {
+}: Omit<GatewayServiceInstallArgs, "stdout">): Promise<{ plistPath: string; stdoutPath: string }> {
   const { logDir, stdoutPath } = resolveGatewaySupervisorLogPaths(env, { platform: "darwin" });
   await ensureSecureDirectory(logDir);
 
@@ -916,7 +890,7 @@ async function writeLaunchAgentPlist({
   }
 
   const plistPath = resolveLaunchAgentPlistPathForLabel(env, label);
-  const home = toPosixPath(resolveHomeDir(env));
+  const home = toPosixPath(resolveLaunchAgentHomeDir(env));
   const libraryDir = path.posix.join(home, "Library");
   await ensureSecureDirectory(home);
   await ensureSecureDirectory(libraryDir);
@@ -940,22 +914,7 @@ async function writeLaunchAgentPlist({
   });
   await fs.writeFile(plistPath, plist, { encoding: "utf8", mode: LAUNCH_AGENT_PLIST_MODE });
   await fs.chmod(plistPath, LAUNCH_AGENT_PLIST_MODE).catch(() => undefined);
-  // When $HOME is on an external APFS volume, launchd refuses to bootstrap
-  // plists from that volume (error 5). Write a copy to the boot volume so
-  // activateLaunchAgent can bootstrap from there instead.
-  const externalHome = await isExternalVolumePath(home);
-  let bootVolumePlistPath: string | undefined;
-  if (externalHome) {
-    const bootDir = resolveBootVolumeLaunchAgentsDir(env);
-    await ensureSecureDirectory(bootDir);
-    bootVolumePlistPath = path.posix.join(bootDir, `${label}.plist`);
-    await fs.writeFile(bootVolumePlistPath, plist, {
-      encoding: "utf8",
-      mode: LAUNCH_AGENT_PLIST_MODE,
-    });
-    await fs.chmod(bootVolumePlistPath, LAUNCH_AGENT_PLIST_MODE).catch(() => undefined);
-  }
-  return { plistPath, stdoutPath, bootVolumePlistPath };
+  return { plistPath, stdoutPath };
 }
 
 export async function stageLaunchAgent({
@@ -974,27 +933,16 @@ export async function stageLaunchAgent({
   return { plistPath };
 }
 
-async function activateLaunchAgent(params: {
-  env: GatewayServiceEnv;
-  plistPath: string;
-  bootVolumePlistPath?: string;
-}) {
+async function activateLaunchAgent(params: { env: GatewayServiceEnv; plistPath: string }) {
   const domain = resolveGuiDomain();
   const label = resolveLaunchAgentLabel({ env: params.env });
-  // Use the boot-volume plist for bootstrap when available — launchd cannot
-  // bootstrap from external APFS volumes (error 5: I/O error).
-  const bootstrapPath = params.bootVolumePlistPath ?? params.plistPath;
   await execLaunchctl(["bootout", domain, params.plistPath]);
   await execLaunchctl(["unload", params.plistPath]);
-  if (params.bootVolumePlistPath) {
-    await execLaunchctl(["bootout", domain, params.bootVolumePlistPath]);
-    await execLaunchctl(["unload", params.bootVolumePlistPath]);
-  }
   // launchd can persist "disabled" state even after bootout + plist removal; clear it before bootstrap.
   await bootstrapLaunchAgentOrThrow({
     domain,
     serviceTarget: `${domain}/${label}`,
-    plistPath: bootstrapPath,
+    plistPath: params.plistPath,
     actionHint: "openclaw gateway install --force",
   });
 }
@@ -1002,22 +950,19 @@ async function activateLaunchAgent(params: {
 export async function installLaunchAgent(
   args: GatewayServiceInstallArgs,
 ): Promise<{ plistPath: string }> {
-  const { plistPath, stdoutPath, bootVolumePlistPath } = await writeLaunchAgentPlist(args);
-  await activateLaunchAgent({ env: args.env, plistPath, bootVolumePlistPath });
+  const { plistPath, stdoutPath } = await writeLaunchAgentPlist(args);
+  await activateLaunchAgent({ env: args.env, plistPath });
   // `bootstrap` already loads RunAtLoad agents. Avoid `kickstart -k` here:
   // on slow macOS guests it SIGTERMs the freshly booted gateway and pushes the
   // real listener startup past setup's health deadline.
-  const installInfo: Array<{ label: string; value: string }> = [
-    { label: "Installed LaunchAgent", value: plistPath },
-    { label: "Logs", value: stdoutPath },
-  ];
-  if (bootVolumePlistPath) {
-    installInfo.push({
-      label: "Boot-volume plist",
-      value: bootVolumePlistPath,
-    });
-  }
-  writeFormattedLines(args.stdout, installInfo, { leadingBlankLine: true });
+  writeFormattedLines(
+    args.stdout,
+    [
+      { label: "Installed LaunchAgent", value: plistPath },
+      { label: "Logs", value: stdoutPath },
+    ],
+    { leadingBlankLine: true },
+  );
   return { plistPath };
 }
 

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -48,6 +48,33 @@ const LAUNCH_AGENT_STDERR_PATH = "/dev/null";
 const OPENCLAW_UPDATE_LAUNCHD_LABEL_PREFIX = "ai.openclaw.update.";
 const OPENCLAW_MANUAL_UPDATE_LAUNCHD_LABEL_PATTERN = /^ai\.openclaw\.manual-update\.\d+$/;
 
+/** Detect whether a path resides on a different volume than the root filesystem. */
+async function isExternalVolumePath(targetPath: string): Promise<boolean> {
+  try {
+    const [rootStat, targetStat] = await Promise.all([fs.stat("/"), fs.stat(targetPath)]);
+    return rootStat.dev !== targetStat.dev;
+  } catch {
+    // If stat fails, conservatively assume same volume.
+    return false;
+  }
+}
+
+/**
+ * Resolve the LaunchAgents directory on the boot volume.
+ * When $HOME is on an external APFS volume, launchd refuses to bootstrap
+ * plists from that volume (error 5: I/O error). This returns the equivalent
+ * path on the root volume so bootstrap can succeed.
+ */
+function resolveBootVolumeLaunchAgentsDir(env: Record<string, string | undefined>): string {
+  const username = normalizeLowercaseStringOrEmpty(env.USER);
+  if (!username) {
+    // Cannot determine boot-volume home without USER; fall back to root
+    // LaunchAgents which is shared across all users.
+    return "/Library/LaunchAgents";
+  }
+  return `/Users/${username}/Library/LaunchAgents`;
+}
+
 export type StaleOpenClawUpdateLaunchdJob = {
   label: string;
   pid?: number;
@@ -897,7 +924,6 @@ async function writeLaunchAgentPlist({
     programArguments,
     environment,
   });
-
   const serviceDescription = resolveGatewayServiceDescription({ env, environment, description });
   const plist = buildLaunchAgentPlist({
     label,
@@ -910,7 +936,22 @@ async function writeLaunchAgentPlist({
   });
   await fs.writeFile(plistPath, plist, { encoding: "utf8", mode: LAUNCH_AGENT_PLIST_MODE });
   await fs.chmod(plistPath, LAUNCH_AGENT_PLIST_MODE).catch(() => undefined);
-  return { plistPath, stdoutPath };
+  // When $HOME is on an external APFS volume, launchd refuses to bootstrap
+  // plists from that volume (error 5). Write a copy to the boot volume so
+  // activateLaunchAgent can bootstrap from there instead.
+  const externalHome = await isExternalVolumePath(home);
+  let bootVolumePlistPath: string | undefined;
+  if (externalHome) {
+    const bootDir = resolveBootVolumeLaunchAgentsDir(env);
+    await ensureSecureDirectory(bootDir);
+    bootVolumePlistPath = path.posix.join(bootDir, `${label}.plist`);
+    await fs.writeFile(bootVolumePlistPath, plist, {
+      encoding: "utf8",
+      mode: LAUNCH_AGENT_PLIST_MODE,
+    });
+    await fs.chmod(bootVolumePlistPath, LAUNCH_AGENT_PLIST_MODE).catch(() => undefined);
+  }
+  return { plistPath, stdoutPath, bootVolumePlistPath };
 }
 
 export async function stageLaunchAgent({
@@ -929,17 +970,27 @@ export async function stageLaunchAgent({
   return { plistPath };
 }
 
-async function activateLaunchAgent(params: { env: GatewayServiceEnv; plistPath: string }) {
+async function activateLaunchAgent(params: {
+  env: GatewayServiceEnv;
+  plistPath: string;
+  bootVolumePlistPath?: string;
+}) {
   const domain = resolveGuiDomain();
   const label = resolveLaunchAgentLabel({ env: params.env });
-
+  // Use the boot-volume plist for bootstrap when available — launchd cannot
+  // bootstrap from external APFS volumes (error 5: I/O error).
+  const bootstrapPath = params.bootVolumePlistPath ?? params.plistPath;
   await execLaunchctl(["bootout", domain, params.plistPath]);
   await execLaunchctl(["unload", params.plistPath]);
+  if (params.bootVolumePlistPath) {
+    await execLaunchctl(["bootout", domain, params.bootVolumePlistPath]);
+    await execLaunchctl(["unload", params.bootVolumePlistPath]);
+  }
   // launchd can persist "disabled" state even after bootout + plist removal; clear it before bootstrap.
   await bootstrapLaunchAgentOrThrow({
     domain,
     serviceTarget: `${domain}/${label}`,
-    plistPath: params.plistPath,
+    plistPath: bootstrapPath,
     actionHint: "openclaw gateway install --force",
   });
 }
@@ -947,19 +998,22 @@ async function activateLaunchAgent(params: { env: GatewayServiceEnv; plistPath: 
 export async function installLaunchAgent(
   args: GatewayServiceInstallArgs,
 ): Promise<{ plistPath: string }> {
-  const { plistPath, stdoutPath } = await writeLaunchAgentPlist(args);
-  await activateLaunchAgent({ env: args.env, plistPath });
+  const { plistPath, stdoutPath, bootVolumePlistPath } = await writeLaunchAgentPlist(args);
+  await activateLaunchAgent({ env: args.env, plistPath, bootVolumePlistPath });
   // `bootstrap` already loads RunAtLoad agents. Avoid `kickstart -k` here:
   // on slow macOS guests it SIGTERMs the freshly booted gateway and pushes the
   // real listener startup past setup's health deadline.
-  writeFormattedLines(
-    args.stdout,
-    [
-      { label: "Installed LaunchAgent", value: plistPath },
-      { label: "Logs", value: stdoutPath },
-    ],
-    { leadingBlankLine: true },
-  );
+  const installInfo: Array<{ label: string; value: string }> = [
+    { label: "Installed LaunchAgent", value: plistPath },
+    { label: "Logs", value: stdoutPath },
+  ];
+  if (bootVolumePlistPath) {
+    installInfo.push({
+      label: "Boot-volume plist",
+      value: bootVolumePlistPath,
+    });
+  }
+  writeFormattedLines(args.stdout, installInfo, { leadingBlankLine: true });
   return { plistPath };
 }
 

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -894,7 +894,11 @@ async function writeLaunchAgentPlist({
   workingDirectory,
   environment,
   description,
-}: Omit<GatewayServiceInstallArgs, "stdout">): Promise<{ plistPath: string; stdoutPath: string }> {
+}: Omit<GatewayServiceInstallArgs, "stdout">): Promise<{
+  plistPath: string;
+  stdoutPath: string;
+  bootVolumePlistPath?: string;
+}> {
   const { logDir, stdoutPath } = resolveGatewaySupervisorLogPaths(env, { platform: "darwin" });
   await ensureSecureDirectory(logDir);
 

--- a/src/daemon/paths.ts
+++ b/src/daemon/paths.ts
@@ -1,5 +1,6 @@
 /** Resolves daemon state, home, and generated task-script paths. */
 import fsSync from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { resolveGatewayProfileSuffix } from "./constants.js";
@@ -35,22 +36,38 @@ function isExternalVolumePathSync(targetPath: string): boolean {
   return external;
 }
 
+// The boot-volume account name comes from the login identity, not from HOME's
+// structure: an external $HOME may be the volume root itself (e.g.
+// `/Volumes/MainDataDrive`, the shape in issue #60398) whose last path segment
+// is the volume name, not the user. USER/LOGNAME are case-preserved; fall back
+// to the process owner when the launchd-sanitized env drops them.
+function resolveLoginUsername(env: Record<string, string | undefined>): string | undefined {
+  const fromEnv = normalizeOptionalString(env.USER) || normalizeOptionalString(env.LOGNAME);
+  if (fromEnv) {
+    return fromEnv;
+  }
+  try {
+    return normalizeOptionalString(os.userInfo().username);
+  } catch {
+    return undefined;
+  }
+}
+
 /**
  * Home dir whose `Library/LaunchAgents` launchd should manage. When $HOME is on
  * an external APFS volume, launchd refuses to bootstrap plists from it (error 5:
- * I/O error), so fall back to the boot-volume home `/Users/<user>`. The plist
- * path, its uninstall trash target, and doctor's service scan all derive from
- * this single source so they stay on one volume and on the path launchd loaded.
+ * I/O error), so fall back to the boot-volume home `/Users/<login-user>`. The
+ * plist path, its uninstall trash target, and doctor's service scan all derive
+ * from this single source so they stay on one volume and on the path launchd
+ * loaded. Keeps $HOME when the login user is undeterminable (no worse than the
+ * pre-fix behavior).
  */
 export function resolveLaunchAgentHomeDir(env: Record<string, string | undefined>): string {
   const home = resolveHomeDir(env);
   if (!isExternalVolumePathSync(home)) {
     return home;
   }
-  // Derive the boot-volume home from HOME's own basename (case-preserving),
-  // which is the user folder name; this always lands under /Users on the boot
-  // volume regardless of env.USER casing or a sudo-changed USER.
-  const user = path.basename(home);
+  const user = resolveLoginUsername(env);
   return user ? path.join(path.sep, "Users", user) : home;
 }
 

--- a/src/daemon/paths.ts
+++ b/src/daemon/paths.ts
@@ -1,4 +1,5 @@
 /** Resolves daemon state, home, and generated task-script paths. */
+import fsSync from "node:fs";
 import path from "node:path";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { resolveGatewayProfileSuffix } from "./constants.js";
@@ -13,6 +14,44 @@ export function resolveHomeDir(env: Record<string, string | undefined>): string 
     throw new Error("Missing HOME");
   }
   return home;
+}
+
+// A path's volume is process-stable, so cache the one decision we make per run
+// (single slot) rather than re-statting on every status/restart poll.
+let externalVolumeMemo: { path: string; external: boolean } | undefined;
+
+/** Whether targetPath lives on a different volume than the root filesystem. */
+function isExternalVolumePathSync(targetPath: string): boolean {
+  if (externalVolumeMemo?.path === targetPath) {
+    return externalVolumeMemo.external;
+  }
+  let external = false;
+  try {
+    external = fsSync.statSync("/").dev !== fsSync.statSync(targetPath).dev;
+  } catch {
+    // If stat fails, conservatively keep the same-volume default above.
+  }
+  externalVolumeMemo = { path: targetPath, external };
+  return external;
+}
+
+/**
+ * Home dir whose `Library/LaunchAgents` launchd should manage. When $HOME is on
+ * an external APFS volume, launchd refuses to bootstrap plists from it (error 5:
+ * I/O error), so fall back to the boot-volume home `/Users/<user>`. The plist
+ * path, its uninstall trash target, and doctor's service scan all derive from
+ * this single source so they stay on one volume and on the path launchd loaded.
+ */
+export function resolveLaunchAgentHomeDir(env: Record<string, string | undefined>): string {
+  const home = resolveHomeDir(env);
+  if (!isExternalVolumePathSync(home)) {
+    return home;
+  }
+  // Derive the boot-volume home from HOME's own basename (case-preserving),
+  // which is the user folder name; this always lands under /Users on the boot
+  // volume regardless of env.USER casing or a sudo-changed USER.
+  const user = path.basename(home);
+  return user ? path.join(path.sep, "Users", user) : home;
 }
 
 function resolveUserPathWithHome(input: string, home?: string): string {

--- a/src/infra/restart.test.ts
+++ b/src/infra/restart.test.ts
@@ -262,6 +262,7 @@ describe("triggerOpenClawRestart", () => {
         VITEST: undefined,
         NODE_ENV: undefined,
         HOME: "/Volumes/Data/Users/test",
+        USER: "test",
         OPENCLAW_PROFILE: "default",
       },
       () => {

--- a/src/infra/restart.test.ts
+++ b/src/infra/restart.test.ts
@@ -24,6 +24,26 @@ vi.mock("node:child_process", async () => {
   );
 });
 
+// When set, statSync reports this path on a different device than "/", so the
+// boot-volume-aware home resolver treats it as an external APFS HOME.
+const fsState = vi.hoisted(() => ({ externalHome: undefined as string | undefined }));
+
+vi.mock("node:fs", async () => {
+  const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+  const statSync = ((p: string) => {
+    if (fsState.externalHome) {
+      if (p === "/") {
+        return { dev: 1 };
+      }
+      if (p === fsState.externalHome) {
+        return { dev: 99 };
+      }
+    }
+    return actual.statSync(p);
+  }) as typeof actual.statSync;
+  return { ...actual, statSync, default: { ...actual, statSync } };
+});
+
 vi.mock("./ports-lsof.js", () => ({
   resolveLsofCommandSync: (...args: unknown[]) => resolveLsofCommandSyncMock(...args),
 }));
@@ -46,6 +66,7 @@ beforeEach(() => {
   spawnSyncMock.mockReset();
   resolveLsofCommandSyncMock.mockReset();
   resolveGatewayPortMock.mockReset();
+  fsState.externalHome = undefined;
 
   currentTimeMs = 0;
   resolveLsofCommandSyncMock.mockReturnValue("/usr/sbin/lsof");
@@ -229,6 +250,41 @@ describe("triggerOpenClawRestart", () => {
             `launchctl bootstrap gui/${uid} /Users/test/Library/LaunchAgents/ai.openclaw.gateway.plist`,
           ],
         });
+      },
+    );
+  });
+
+  it("bootstraps the boot-volume plist when HOME is on an external volume", () => {
+    setPlatform("darwin");
+    fsState.externalHome = "/Volumes/Data/Users/test";
+    withEnv(
+      {
+        VITEST: undefined,
+        NODE_ENV: undefined,
+        HOME: "/Volumes/Data/Users/test",
+        OPENCLAW_PROFILE: "default",
+      },
+      () => {
+        const uid = typeof process.getuid === "function" ? process.getuid() : 501;
+        spawnSyncMock.mockImplementation((command: string, args: string[]) => {
+          if (command === "launchctl" && args[0] === "kickstart" && args[1] === "-k") {
+            return { error: undefined, status: 113, stderr: "service not loaded" };
+          }
+          if (command === "launchctl" && args[0] === "bootstrap") {
+            return { error: undefined, status: 0, stderr: "" };
+          }
+          return { error: undefined, status: 1, stdout: "" };
+        });
+
+        const result = triggerOpenClawRestart();
+
+        // Fallback bootstrap must target the boot volume; the external plist
+        // path would re-hit launchd error 5.
+        const tried = result.tried ?? [];
+        expect(tried).toContain(
+          `launchctl bootstrap gui/${uid} /Users/test/Library/LaunchAgents/ai.openclaw.gateway.plist`,
+        );
+        expect(tried.join("\n")).not.toContain("/Volumes/");
       },
     );
   });

--- a/src/infra/restart.ts
+++ b/src/infra/restart.ts
@@ -9,6 +9,7 @@ import {
   resolveGatewayLaunchAgentLabel,
   resolveGatewaySystemdServiceName,
 } from "../daemon/constants.js";
+import { resolveLaunchAgentHomeDir } from "../daemon/paths.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { resolveTimerTimeoutMs } from "../shared/number-coercion.js";
 import { replaceFileAtomicSync } from "./replace-file.js";
@@ -728,8 +729,12 @@ export function triggerOpenClawRestart(): RestartAttempt {
 
   // kickstart fails when the service was previously booted out (deregistered from launchd).
   // Fall back to bootstrap, which loads RunAtLoad agents without a follow-up kickstart.
-  // Use env HOME to match how launchd.ts resolves the plist install path.
-  const home = process.env.HOME?.trim() || os.homedir();
+  // Resolve through the same boot-volume-aware home as install, or an external
+  // APFS $HOME makes this bootstrap re-hit `Bootstrap failed: 5`.
+  const home = resolveLaunchAgentHomeDir({
+    ...process.env,
+    HOME: process.env.HOME?.trim() || os.homedir(),
+  });
   const plistPath = path.join(home, "Library", "LaunchAgents", `${label}.plist`);
   const bootstrapArgs = ["bootstrap", domain, plistPath];
   tried.push(`launchctl ${bootstrapArgs.join(" ")}`);

--- a/src/infra/update-managed-service-handoff.test.ts
+++ b/src/infra/update-managed-service-handoff.test.ts
@@ -18,6 +18,23 @@ const { spawnMock } = vi.hoisted(() => ({
     unref: vi.fn(),
   })),
 }));
+const fsState = vi.hoisted(() => ({ externalHome: undefined as string | undefined }));
+
+vi.mock("node:fs", async () => {
+  const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+  const statSync = ((p: string) => {
+    if (fsState.externalHome) {
+      if (p === "/") {
+        return { dev: 1 };
+      }
+      if (p === fsState.externalHome) {
+        return { dev: 99 };
+      }
+    }
+    return actual.statSync(p);
+  }) as typeof actual.statSync;
+  return { ...actual, statSync, default: { ...actual, statSync } };
+});
 
 vi.mock("node:child_process", async () => {
   const { mockNodeChildProcessModule } =
@@ -31,6 +48,7 @@ const tempDirs = new Set<string>();
 
 afterEach(async () => {
   spawnMock.mockClear();
+  fsState.externalHome = undefined;
   await Promise.all([...tempDirs].map((dir) => fs.rm(dir, { recursive: true, force: true })));
   tempDirs.clear();
 });
@@ -475,6 +493,40 @@ describe("managed service update handoff", () => {
       };
       expect(helperParams.serviceRecovery).toEqual(testCase.expected);
     }
+  });
+
+  it("uses the boot-volume LaunchAgent plist for launchd handoff recovery when HOME is external", async () => {
+    const { startManagedServiceUpdateHandoff } =
+      await import("./update-managed-service-handoff.js");
+    fsState.externalHome = "/Volumes/Data/Users/external";
+
+    const result = await startManagedServiceUpdateHandoff({
+      root: "/tmp/openclaw",
+      timeoutMs: 1_800_000,
+      restartDelayMs: 500,
+      parentPid: 12345,
+      execPath: "/usr/local/bin/node",
+      argv1: "/opt/openclaw/openclaw.mjs",
+      supervisor: "launchd",
+      env: {
+        HOME: fsState.externalHome,
+        USER: "testuser",
+        OPENCLAW_LAUNCHD_LABEL: "ai.openclaw.gateway",
+      },
+      meta: { sessionKey: "agent:test:webchat:dm:user-123" },
+    });
+
+    expect(result.status).toBe("started");
+    const [, args] = spawnMock.mock.calls.at(-1) as unknown as [string, string[]];
+    tempDirs.add(path.dirname(args[0] ?? ""));
+    const helperParams = JSON.parse(await fs.readFile(args[1] ?? "", "utf-8")) as {
+      serviceRecovery?: { kind?: string; plistPath?: string };
+    };
+    expect(helperParams.serviceRecovery).toMatchObject({
+      kind: "launchd",
+      plistPath: "/Users/testuser/Library/LaunchAgents/ai.openclaw.gateway.plist",
+    });
+    expect(helperParams.serviceRecovery?.plistPath).not.toContain("/Volumes/Data");
   });
 
   it("does not overwrite a restart sentinel owned by another startup task", async () => {

--- a/src/infra/update-managed-service-handoff.ts
+++ b/src/infra/update-managed-service-handoff.ts
@@ -9,6 +9,7 @@ import {
   resolveGatewaySystemdServiceName,
   resolveGatewayWindowsTaskName,
 } from "../daemon/constants.js";
+import { resolveLaunchAgentHomeDir } from "../daemon/paths.js";
 import { resolveRestartSentinelPath } from "./restart-sentinel.js";
 import { SUPERVISOR_HINT_ENV_VARS, type RespawnSupervisor } from "./supervisor-markers.js";
 import {
@@ -384,7 +385,10 @@ function resolveGatewayServiceRecovery(
     const label =
       env.OPENCLAW_LAUNCHD_LABEL?.trim() || resolveGatewayLaunchAgentLabel(env.OPENCLAW_PROFILE);
     const uid = typeof process.getuid === "function" ? process.getuid() : 501;
-    const home = env.HOME?.trim() || os.homedir();
+    const home = resolveLaunchAgentHomeDir({
+      ...env,
+      HOME: env.HOME?.trim() || os.homedir(),
+    });
     return {
       kind: "launchd",
       uid,


### PR DESCRIPTION
## Summary

macOS `launchd` refuses to bootstrap a LaunchAgent plist that lives on an external APFS volume (`Bootstrap failed: 5: Input/output error`). When a user's `$HOME` is on an external drive, `openclaw gateway install` always fails.

This PR makes the macOS LaunchAgent path resolution **boot-volume-aware**. A single helper, `resolveLaunchAgentHomeDir(env)` (in `src/daemon/paths.ts`), returns `$HOME` normally but falls back to the boot-volume home `/Users/<user>` when `$HOME` is on an external volume (detected by comparing `statSync("/").dev` vs `statSync(home).dev`). Every launchd lifecycle path derives from this one source, so install, repair, restart, uninstall, status/audit, and doctor service detection all converge on the same path launchd can actually bootstrap.

### Why this shape (vs. an install-only copy)

An earlier revision wrote a second boot-volume plist only at install time. That left `repair`, `restart`, and `uninstall` still bootstrapping from the external path (which fails with the same error 5), and split state across two plists. Making the resolver canonical avoids a second path and keeps every lifecycle command consistent. Correctness details handled:

- **Uninstall trash** now targets `/Users/<user>/.Trash` (same volume as the plist) instead of the external `$HOME/.Trash`; a cross-volume `rename` would `EXDEV`-fail and leak the plist.
- **Doctor service detection** (`src/daemon/inspect.ts`) scans the boot-volume `Library/LaunchAgents` so an external-home install is actually detected.
- **Detached restart handoff** (`src/daemon/launchd-restart-handoff.ts`) routes through the same resolver, so an in-band reload/kickstart fallback bootstraps the boot-volume plist instead of re-hitting error 5 against the external volume.
- **Supervisor restart fallback** (`src/infra/restart.ts`) and the **update restart helper script** (`src/cli/update-cli/restart-helper.ts`) also `launchctl bootstrap` the plist; both now resolve through the same boot-volume-aware home. Logs and state stay under the user's real `$HOME`.
- The boot-volume account folder is derived from the **login identity** (`USER`/`LOGNAME`, else the process owner via `os.userInfo()`), not from `$HOME`'s structure — the reported `$HOME` is the external volume root itself (`/Volumes/MainDataDrive`), whose last path segment is the volume name, not the user. Case is preserved.
- The external-volume decision is memoized (single slot; a path's volume is process-stable), so the status/restart polling loops do not re-`stat` on every poll.

**Behavior on a normal Mac (HOME on the boot volume): unchanged.** `/` and `$HOME` report the same `st_dev` (macOS firmlinks), so the resolver returns `$HOME` exactly as before — no extra plist, no path change.

**Changed files:**
- `src/daemon/paths.ts` — `resolveLaunchAgentHomeDir()` + memoized external-volume detection.
- `src/daemon/launchd.ts` — plist path, plist write, and uninstall trash all derive from the boot-volume-aware home (removed the install-only double-write helpers).
- `src/daemon/inspect.ts` — darwin user-scope service scan uses the boot-volume-aware home.
- `src/daemon/launchd-restart-handoff.ts` — detached restart plist path uses the boot-volume-aware home.
- `src/infra/restart.ts` / `src/cli/update-cli/restart-helper.ts` — supervisor and update restart bootstrap fallbacks use the boot-volume-aware home.
- Tests: external-volume canonical-path test using a real external `/Volumes/.../Users/test` HOME, plus uninstall-trash, restart-handoff, supervisor-restart, and update-restart-script external-HOME regression tests.

Rebased onto current `main`.

## Verification

```
node scripts/run-vitest.mjs src/daemon/launchd.test.ts   # 82/82 passed
node scripts/run-vitest.mjs src/daemon/inspect.test.ts    # passed
oxfmt --check / oxlint / tsgo (prod types)                # clean
```

### Real behavior proof (live macOS launchd + real APFS volume)

- **Behavior addressed:** `openclaw gateway install` fails with `Bootstrap failed: 5: Input/output error` when `$HOME` is on an external APFS volume, because launchd cannot bootstrap a plist from that volume. The fix resolves the plist (and its lifecycle siblings) to the boot volume.
- **Real environment tested:** macOS (Darwin 24.6.0), real APFS disk image attached as an external volume (`hdiutil`), real `launchctl` in the `gui/<uid>` domain, and the real `resolveLaunchAgentPlistPath` from `src/daemon/launchd.ts`. A harmless plist running `/usr/bin/true` was used so no real gateway was started; everything was booted out and the image detached afterward.
- **Exact steps or command run after this patch:**
  1. Create + attach a real external APFS volume; confirm its `st_dev` differs from `/`.
  2. `launchctl bootstrap gui/$UID <plist-on-external-volume>` → observe error 5.
  3. `launchctl bootstrap gui/$UID <plist-on-boot-volume>` → observe success + `launchctl print`.
  4. Run the patched `resolveLaunchAgentPlistPath` with `HOME` on the external volume and assert it returns the boot-volume path.
- **Evidence after fix:**

```text
=== 1. Real external APFS volume ===
root '/' device id: 16777220
'/Volumes/OCExtHome' device id: 16777234
-> confirmed: external volume is a DIFFERENT device than root

=== 3. BEFORE FIX behavior: bootstrap FROM the external volume ===
$ launchctl bootstrap gui/501 /Volumes/OCExtHome/Users/<user>/Library/LaunchAgents/ai.openclaw.proof.exthome60398.plist
Bootstrap failed: 5: Input/output error
launchctl exit code: 5   (the reported #60398 failure)

=== 4. AFTER FIX behavior: bootstrap FROM the boot volume ===
$ launchctl bootstrap gui/501 /Users/<user>/Library/LaunchAgents/ai.openclaw.proof.exthome60398.plist
launchctl exit code: 0   (success)
$ launchctl print gui/501/ai.openclaw.proof.exthome60398
	path = /Users/<user>/Library/LaunchAgents/ai.openclaw.proof.exthome60398.plist
	state = not running
	program = /usr/bin/true

=== patched resolver against the real external volume (both HOME shapes) ===
external volume device: 16777234, root device: 16777220
nested external HOME: HOME=/Volumes/OCExtHome2/Users/<user>
  -> /Users/<user>/Library/LaunchAgents/ai.openclaw.gateway.plist PASS
volume-root external HOME (#60398 shape): HOME=/Volumes/OCExtHome2
  -> /Users/<user>/Library/LaunchAgents/ai.openclaw.gateway.plist PASS
ALL PASS: both external HOME shapes resolve to the boot-volume plist (derived
from the login user, not the volume name)
```

- **Observed result after fix:** bootstrapping the plist from the external APFS volume reproduces `Bootstrap failed: 5: Input/output error`; the identical plist on the boot volume bootstraps with exit code 0 and is visible via `launchctl print`; and the patched `resolveLaunchAgentPlistPath` redirects an external `$HOME` to the boot-volume path while leaving a normal boot-volume `$HOME` unchanged.
- **What was not tested:** a full end-to-end `openclaw gateway install` of the real gateway service on an external home (avoided to not register a real launchd gateway on the test machine); a physically separate USB/Thunderbolt enclosure (an attached APFS disk image was used, which is a real, distinct APFS volume with a distinct `st_dev`).

Fixes #60398
