### PR TITLE
fix(gateway): sanitize assistant reasoning before history truncation

### DIFF
--- a/src/gateway/chat-display-projection.ts
+++ b/src/gateway/chat-display-projection.ts
@@ -18,6 +18,7 @@ import {
   parseAssistantTextSignature,
   resolveAssistantMessagePhase,
 } from "../shared/chat-message-content.js";
+import { sanitizeAssistantVisibleTextWithProfile } from "../shared/text/assistant-visible-text.js";
 import { isOpenClawDeliveryMirrorAssistantMessage } from "../shared/transcript-only-openclaw-assistant.js";
 import { stripInlineDirectiveTagsForDisplay } from "../utils/directive-tags.js";
 import { stripEnvelopeFromMessages } from "./chat-sanitize.js";
@@ -58,6 +59,15 @@ function truncateChatHistoryText(
   return {
     text: `${text.slice(0, maxChars)}\n...(truncated)...`,
     truncated: true,
+  };
+}
+
+function sanitizeAssistantHistoryDisplayText(text: string): { text: string; changed: boolean } {
+  const stripped = stripInlineDirectiveTagsForDisplay(text);
+  const sanitized = sanitizeAssistantVisibleTextWithProfile(stripped.text, "history");
+  return {
+    text: sanitized,
+    changed: stripped.changed || sanitized !== stripped.text,
   };
 }
 
@@ -251,7 +261,7 @@ export function augmentChatHistoryWithCanvasBlocks(messages: unknown[]): unknown
 
 function sanitizeChatHistoryContentBlock(
   block: unknown,
-  opts?: { preserveExactToolPayload?: boolean; maxChars?: number },
+  opts?: { assistantDisplayText?: boolean; preserveExactToolPayload?: boolean; maxChars?: number },
 ): { block: unknown; changed: boolean } {
   if (!block || typeof block !== "object") {
     return { block, changed: false };
@@ -261,8 +271,12 @@ function sanitizeChatHistoryContentBlock(
   const preserveExactToolPayload =
     opts?.preserveExactToolPayload === true || isToolHistoryBlockType(entry.type);
   const maxChars = opts?.maxChars ?? DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS;
+  const sanitizeAssistantDisplayText =
+    opts?.assistantDisplayText === true && !preserveExactToolPayload;
   if (typeof entry.text === "string") {
-    const stripped = stripInlineDirectiveTagsForDisplay(entry.text);
+    const stripped = sanitizeAssistantDisplayText
+      ? sanitizeAssistantHistoryDisplayText(entry.text)
+      : stripInlineDirectiveTagsForDisplay(entry.text);
     if (preserveExactToolPayload) {
       entry.text = stripped.text;
       changed ||= stripped.changed;
@@ -273,7 +287,9 @@ function sanitizeChatHistoryContentBlock(
     }
   }
   if (typeof entry.content === "string") {
-    const stripped = stripInlineDirectiveTagsForDisplay(entry.content);
+    const stripped = sanitizeAssistantDisplayText
+      ? sanitizeAssistantHistoryDisplayText(entry.content)
+      : stripInlineDirectiveTagsForDisplay(entry.content);
     if (preserveExactToolPayload) {
       entry.content = stripped.text;
       changed ||= stripped.changed;
@@ -383,7 +399,7 @@ function projectAssistantTextFromMixedToolContent(
     if (entry.type !== "text" || typeof entry.text !== "string" || !entry.text.trim()) {
       continue;
     }
-    const stripped = stripInlineDirectiveTagsForDisplay(entry.text);
+    const stripped = sanitizeAssistantHistoryDisplayText(entry.text);
     const truncated = truncateChatHistoryText(stripped.text, maxChars);
     if (truncated.text.trim()) {
       textBlocks.push({ type: "text", text: truncated.text });
@@ -504,8 +520,13 @@ function sanitizeChatHistoryMessage(
     }
   }
 
+  const isAssistant = entry.role === "assistant";
+  const sanitizeAssistantDisplayText = isAssistant && !preserveExactToolPayload;
+
   if (typeof entry.content === "string") {
-    const stripped = stripInlineDirectiveTagsForDisplay(entry.content);
+    const stripped = sanitizeAssistantDisplayText
+      ? sanitizeAssistantHistoryDisplayText(entry.content)
+      : stripInlineDirectiveTagsForDisplay(entry.content);
     if (preserveExactToolPayload) {
       entry.content = stripped.text;
       changed ||= stripped.changed;
@@ -516,7 +537,11 @@ function sanitizeChatHistoryMessage(
     }
   } else if (Array.isArray(entry.content)) {
     const updated = entry.content.map((block) =>
-      sanitizeChatHistoryContentBlock(block, { preserveExactToolPayload, maxChars }),
+      sanitizeChatHistoryContentBlock(block, {
+        assistantDisplayText: isAssistant,
+        preserveExactToolPayload,
+        maxChars,
+      }),
     );
     if (updated.some((item) => item.changed)) {
       entry.content = updated.map((item) => item.block);
@@ -541,7 +566,9 @@ function sanitizeChatHistoryMessage(
   }
 
   if (typeof entry.text === "string") {
-    const stripped = stripInlineDirectiveTagsForDisplay(entry.text);
+    const stripped = sanitizeAssistantDisplayText
+      ? sanitizeAssistantHistoryDisplayText(entry.text)
+      : stripInlineDirectiveTagsForDisplay(entry.text);
     if (preserveExactToolPayload) {
       entry.text = stripped.text;
       changed ||= stripped.changed;

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -845,6 +845,68 @@ describe("sanitizeChatHistoryMessages", () => {
     ]);
   });
 
+  it("sanitizes assistant reasoning tags before truncating history text", () => {
+    const visibleAnswer = "Visible answer ".repeat(12);
+    const result = sanitizeChatHistoryMessages(
+      [
+        {
+          role: "assistant",
+          text: ["<thinking>", "private chain of thought", "<final>", visibleAnswer].join("\n"),
+          timestamp: 1,
+        },
+      ],
+      48,
+    ) as Array<{ text?: string }>;
+
+    expect(result[0]?.text).toContain("Visible answer");
+    expect(result[0]?.text).toContain("...(truncated)...");
+    expect(result[0]?.text).not.toContain("private chain of thought");
+    expect(result[0]?.text).not.toContain("<thinking>");
+    expect(result[0]?.text).not.toContain("<final>");
+  });
+
+  it("sanitizes assistant reasoning tags in content blocks before history truncation", () => {
+    const visibleAnswer = "Block visible answer ".repeat(12);
+    const result = sanitizeChatHistoryMessages(
+      [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "text",
+              text: ["<thinking>", "private block reasoning", "<final>", visibleAnswer].join("\n"),
+            },
+          ],
+          timestamp: 1,
+        },
+      ],
+      54,
+    ) as Array<{ content?: Array<{ text?: string }> }>;
+
+    const text = result[0]?.content?.[0]?.text;
+    expect(text).toContain("Block visible answer");
+    expect(text).toContain("...(truncated)...");
+    expect(text).not.toContain("private block reasoning");
+    expect(text).not.toContain("<thinking>");
+    expect(text).not.toContain("<final>");
+  });
+
+  it("preserves tool payload text that looks like reasoning markup", () => {
+    const result = sanitizeChatHistoryMessages(
+      [
+        {
+          role: "tool",
+          toolName: "read",
+          content: "<thinking>payload tag from tool output</thinking>",
+          timestamp: 1,
+        },
+      ],
+      12,
+    ) as Array<{ content?: string }>;
+
+    expect(result[0]?.content).toBe("<thinking>payload tag from tool output</thinking>");
+  });
+
   it("drops commentary-only assistant entries when phase exists only in textSignature", () => {
     const result = sanitizeChatHistoryMessages([
       {

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -2176,6 +2176,37 @@ describe("gateway server chat", () => {
     });
   });
 
+  test("chat.history sanitizes assistant reasoning before applying maxChars", async () => {
+    await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
+      const sessionDir = await prepareMainHistoryHarness({ ws, createSessionDir });
+      const visibleAnswer = "Visible answer after reasoning. ".repeat(20);
+      await writeMainSessionTranscript(sessionDir, [
+        JSON.stringify({
+          message: {
+            role: "assistant",
+            content: [
+              {
+                type: "text",
+                text: ["<thinking>", "private reload reasoning", "<final>", visibleAnswer].join(
+                  "\n",
+                ),
+              },
+            ],
+            timestamp: Date.now(),
+          },
+        }),
+      ]);
+
+      const messages = await fetchHistoryMessages(ws, { maxChars: 96 });
+      const serialized = JSON.stringify(messages);
+      expect(serialized).toContain("Visible answer after reasoning");
+      expect(serialized).toContain("...(truncated)...");
+      expect(serialized).not.toContain("private reload reasoning");
+      expect(serialized).not.toContain("<thinking>");
+      expect(serialized).not.toContain("<final>");
+    });
+  });
+
   test("chat.history keeps visible assistant progress text from mixed tool-use transcript messages", async () => {
     await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
       const sessionDir = await prepareMainHistoryHarness({ ws, createSessionDir });

--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -873,6 +873,34 @@ describe("sanitizeAssistantVisibleText", () => {
     );
   });
 
+  it("uses final tags as the visible boundary for unclosed reasoning", () => {
+    const input = ["<thinking>", "private chain of thought", "<final>", "Visible answer"].join(
+      "\n",
+    );
+
+    expect(sanitizeAssistantVisibleText(input)).toBe("Visible answer");
+  });
+
+  it("uses self-closing final tags as the visible boundary for unclosed reasoning", () => {
+    const input = ["<thinking>", "private chain of thought", "<final/>", "Visible answer"].join(
+      "\n",
+    );
+
+    expect(sanitizeAssistantVisibleText(input)).toBe("Visible answer");
+  });
+
+  it("continues to sanitize reasoning tags after a recovered final boundary", () => {
+    const input = [
+      "<thinking>",
+      "private chain of thought",
+      "<final>",
+      "Visible answer",
+      "<think>second private note</think>",
+    ].join("\n");
+
+    expect(sanitizeAssistantVisibleText(input)).toBe("Visible answer");
+  });
+
   it("keeps unclosed trailing reasoning hidden when visible text already exists", () => {
     expect(sanitizeAssistantVisibleText("Visible prefix <think>private reasoning tail")).toBe(
       "Visible prefix",
@@ -894,6 +922,34 @@ describe("sanitizeAssistantVisibleTextWithProfile", () => {
         "history",
       ),
     ).toBe(" Visible answer");
+  });
+
+  it("uses the history profile to preserve visible-answer whitespace after unclosed reasoning", () => {
+    const input = ["<thinking>", "private chain of thought", "<final>", "  Visible answer"].join(
+      "\n",
+    );
+
+    expect(sanitizeAssistantVisibleTextWithProfile(input, "history")).toBe("\n  Visible answer");
+  });
+
+  it("uses the history profile to recover after self-closing final tags", () => {
+    const input = ["<thinking>", "private chain of thought", "<final/>", "  Visible answer"].join(
+      "\n",
+    );
+
+    expect(sanitizeAssistantVisibleTextWithProfile(input, "history")).toBe("\n  Visible answer");
+  });
+
+  it("uses the history profile to sanitize reasoning after a recovered final boundary", () => {
+    const input = [
+      "<thinking>",
+      "private chain of thought",
+      "<final>",
+      "  Visible answer",
+      "<think>second private note</think>",
+    ].join("\n");
+
+    expect(sanitizeAssistantVisibleTextWithProfile(input, "history")).toBe("\n  Visible answer\n");
   });
 
   it("uses the internal-scaffolding profile to preserve downgraded tool text behavior", () => {

--- a/src/shared/text/reasoning-tags.ts
+++ b/src/shared/text/reasoning-tags.ts
@@ -45,6 +45,7 @@ export function stripReasoningTagsFromText(
   const trimMode = options?.trim ?? "both";
 
   let cleaned = text;
+  const originalCleaned = cleaned;
   const matches = findFinalTagMatches(cleaned);
   THINKING_TAG_RE.lastIndex = 0;
   const hasThinkingTag = THINKING_TAG_RE.test(cleaned);
@@ -130,6 +131,20 @@ export function stripReasoningTagsFromText(
     firstUnclosedContentIndex !== undefined &&
     cleaned.trim()
   ) {
+    const originalCodeRegions = findCodeRegions(originalCleaned);
+    const finalBoundary = matches.find(
+      (match) =>
+        !match.isClose &&
+        match.index >= firstUnclosedContentIndex &&
+        !isInsideCode(match.index, originalCodeRegions),
+    );
+    if (finalBoundary) {
+      const visibleTail = stripReasoningTagsFromText(
+        originalCleaned.slice(finalBoundary.index + finalBoundary.text.length),
+        { mode, trim: "none" },
+      );
+      return applyTrim(visibleTail, trimMode);
+    }
     return applyTrim(cleaned.slice(firstUnclosedContentIndex), trimMode);
   }
 


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- Fixes WebChat/history projection leaking raw assistant reasoning scaffolding when a stored assistant message contains malformed or unclosed thinking tags and is reloaded/truncated.
- Routes assistant display text through the existing assistant-visible `history` sanitizer before applying the chat-history text cap.
- Treats `<final>` and `<final/>` as visible-answer boundaries for strict unclosed reasoning recovery, while recursively sanitizing any later reasoning tags.
- Preserves exact tool payload text; tool outputs that happen to contain reasoning-like XML are not rewritten.

Why does this matter now?

- #90692 reports completed assistant replies later reappearing with visible `<thinking>` content and `...(truncated)...` after a history reload/heartbeat.

What is the intended outcome?

- History reloads show only the visible final answer text, with truncation applied after reasoning/final scaffolding is removed.

What is intentionally out of scope?

- No config/env surface changes.
- No frontend parser behavior changes.
- No changes to structured tool payload preservation.

What does success look like?

- `chat.history` no longer returns raw thinking/final tags or private reasoning text for the reported malformed transcript shape.
- Existing history truncation, content-block projection, and tool-payload preservation continue to work.

What should reviewers focus on?

- `src/gateway/chat-display-projection.ts` assistant display text path vs. exact tool payload path.
- `src/shared/text/reasoning-tags.ts` strict-mode recovery for unclosed reasoning followed by final tags.

## Linked context

Which issue does this close?

Closes #90692

Which issues, PRs, or discussions are related?

Related #90692

Was this requested by a maintainer or owner?

Maintainer follow-up from the ClawSweeper source-repro review on #90692.

## Real behavior proof (required for external PRs)

- Behavior addressed: WebChat `chat.history` reload/projection sanitizes assistant reasoning/final scaffolding before truncating history text, preventing raw `<thinking>` tags or private reasoning text from appearing after reload.
- Real environment tested: Local OpenClaw source checkout on macOS with Node 24.15.0; actual OpenClaw gateway projection module loaded through `tsx` and run against a transcript-shaped assistant message.
- Exact steps or command run after this patch: `node --import tsx - <<'EOF' ... import { projectChatDisplayMessages } from './src/gateway/chat-display-projection.ts'; ... EOF`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): copied console output from the command above:

```json
{
  "projectedText": "\nVisible answer after reasoning. Visible answer after reasoning. Visible answer after reasoning.\n...(truncated)...",
  "hasThinkingTag": false,
  "hasFinalTag": false,
  "hasPrivateReasoning": false,
  "hasTruncationMarker": true
}
```

- Observed result after fix: The projected history text keeps visible answer content and the truncation marker, while `hasThinkingTag`, `hasFinalTag`, and `hasPrivateReasoning` are all `false`.
- What was not tested: A live Windows WebChat heartbeat with Google Gemini 3.5 Flash was not reproduced end-to-end.
- Proof limitations or environment constraints: Crabbox/Testbox changed gate could not run because no usable `crabbox` binary was available in PATH or at `../crabbox/bin/crabbox`; focused local gateway/shared/UI checks, oxlint, tsgo, and autoreview were run instead.
- Before evidence (optional but encouraged): #90692 and the ClawSweeper source-repro comment identify current main truncating assistant text after directive-only stripping in `chat-display-projection`, which can expose malformed reasoning tags on history reload.

## Tests and validation

Which commands did you run?

- `node --import tsx - <<'EOF' ... projectChatDisplayMessages(...) ... EOF`
- `node scripts/run-vitest.mjs src/shared/text/assistant-visible-text.test.ts`
- `node --no-maglev node_modules/vitest/vitest.mjs run --config test/vitest/vitest.gateway-methods.config.ts src/gateway/server-methods/server-methods.test.ts -t "sanitizeChatHistoryMessages" --reporter=dot`
- `node --no-maglev node_modules/vitest/vitest.mjs run --config test/vitest/vitest.gateway-server.config.ts src/gateway/server.chat.gateway-server-chat-b.test.ts -t "chat.history" --reporter=dot`
- `node --no-maglev node_modules/vitest/vitest.mjs run --config test/vitest/vitest.ui.config.ts ui/src/ui/format.test.ts --reporter=dot`
- `git diff --check upstream/main...HEAD`
- `node_modules/.bin/oxlint src/gateway/chat-display-projection.ts src/gateway/server-methods/server-methods.test.ts src/gateway/server.chat.gateway-server-chat-b.test.ts src/shared/text/assistant-visible-text.test.ts src/shared/text/reasoning-tags.ts`
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main`

What regression coverage was added or updated?

- Shared assistant-visible sanitizer tests for unclosed reasoning followed by `<final>` and `<final/>`, including later nested reasoning tags after the recovered final boundary.
- Gateway projection tests for assistant `text`, assistant text content blocks, truncation after sanitization, and exact tool payload preservation.
- Gateway `chat.history` RPC test for transcript-backed reload projection with `maxChars`.

What failed before this fix, if known?

- Source-level behavior: assistant history text was truncated after directive-only stripping, leaving malformed reasoning/final scaffolding available to the UI on reload.

If no test was added, why not?

- N/A. Focused regression tests were added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Assistant history display hides reasoning/final scaffolding before truncation.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

Yes, security-relevant display sanitization changed to reduce reasoning leakage in history projection. No auth/secrets/network/tool execution behavior changed.

What is the highest-risk area?

Over-sanitizing non-assistant or tool payload text that should remain exact.

How is that risk mitigated?

The new sanitizer is only applied to assistant display text paths and mixed assistant text projection; exact tool payload branches continue to use the previous directive-only path and have regression coverage.

## Current review state

What is the next action?

Ready for maintainer and ClawSweeper review.

What review or CI state should maintainers know about?

Local focused checks, oxlint, core tsgo, and autoreview are clean. Crabbox/Testbox changed gate is not available in this environment because the Crabbox binary is missing.
