### PR TITLE
fix(doctor): match short-term memory paths with timestamp suffixes

### DIFF
--- a/src/gateway/server-methods/doctor.ts
+++ b/src/gateway/server-methods/doctor.ts
@@ -350,7 +350,7 @@ function normalizeMemoryPathForWorkspace(workspaceDir: string, rawPath: string):
 function isShortTermMemoryPath(filePath: string): boolean {
   const normalized = normalizeMemoryPath(filePath);
   // Status only counts short-term source shapes; promoted diary/report files stay out.
-  if (/(?:^|\/)memory\/(\d{4})-(\d{2})-(\d{2})\.md$/.test(normalized)) {
+  if (/(?:^|\/)memory\/(\d{4})-(\d{2})-(\d{2})(?:-\d{4})?\.md$/.test(normalized)) {
     return true;
   }
   if (
@@ -360,7 +360,7 @@ function isShortTermMemoryPath(filePath: string): boolean {
   ) {
     return true;
   }
-  return /^(\d{4})-(\d{2})-(\d{2})\.md$/.test(normalized);
+  return /^(\d{4})-(\d{2})-(\d{2})(?:-\d{4})?\.md$/.test(normalized);
 }
 
 type DreamingStoreStats = Pick<


### PR DESCRIPTION
## What

Fix `isShortTermMemoryPath()` in `doctor.memory.status` to also match daily memory files with timestamp suffixes (e.g. `memory/2026-05-28-1503.md`).

## Root Cause

The regex `/(?:^|\/)memory\/(\d{4})-(\d{2})-(\d{2})\.md$/` only matched bare date filenames (e.g. `memory/2026-05-28.md`), skipping the 226 of 512 recall-store entries that use timestamp-suffixed paths.

## Fix

Add optional `(?:-\d{4})?` suffix to both the path regex and the basename regex, aligning with the memory-core extension's existing `SHORT_TERM_PATH_RE` which already allows `(?:-[^/]+)?`.

## Impact

- `promotedToday` now correctly counts timestamp-suffixed promotions
- `shortTermCount` and `promotedTotal` values are accurate
- Actual dreaming functionality was unaffected — only the status/UI reporting

Closes #90896