### PR TITLE
fix(ui): scope local assistant avatar overrides per agent (#90890)

### DIFF
--- a/ui/src/ui/controllers/assistant-identity.test.ts
+++ b/ui/src/ui/controllers/assistant-identity.test.ts
@@ -96,4 +96,63 @@ describe("setAssistantAvatarOverride", () => {
     expect(state.assistantAvatarReason).toBeNull();
     expect(loadLocalAssistantIdentity().avatar).toBeNull();
   });
+
+  it("scopes local avatar overrides per agent", () => {
+    const mainState: Parameters<typeof setAssistantAvatarOverride>[0] = {
+      assistantAgentId: "main",
+    };
+    const workerState: Parameters<typeof setAssistantAvatarOverride>[0] = {
+      assistantAgentId: "worker",
+    };
+
+    setAssistantAvatarOverride(mainState, "data:image/png;base64,main");
+    setAssistantAvatarOverride(workerState, "data:image/png;base64,worker");
+
+    expect(loadLocalAssistantIdentity("main").avatar).toBe("data:image/png;base64,main");
+    expect(loadLocalAssistantIdentity("worker").avatar).toBe("data:image/png;base64,worker");
+
+    setAssistantAvatarOverride(mainState, null);
+
+    expect(loadLocalAssistantIdentity("main").avatar).toBeNull();
+    expect(loadLocalAssistantIdentity("worker").avatar).toBe("data:image/png;base64,worker");
+  });
+
+  it("applies the local override only for the matching agent on load", async () => {
+    const mainState: Parameters<typeof setAssistantAvatarOverride>[0] = {
+      assistantAgentId: "main",
+    };
+    const workerState: Parameters<typeof setAssistantAvatarOverride>[0] = {
+      assistantAgentId: "worker",
+    };
+    setAssistantAvatarOverride(mainState, "data:image/png;base64,main");
+    setAssistantAvatarOverride(workerState, "data:image/png;base64,worker");
+
+    const request = vi.fn().mockResolvedValue({
+      agentId: "main",
+      name: "Main",
+      avatar: "server-main.png",
+    });
+    const state: Parameters<typeof loadAssistantIdentity>[0] = {
+      client: { request } as never,
+      connected: true,
+      sessionKey: "agent:main:main",
+      assistantName: "Main",
+      assistantAvatar: null,
+      assistantAgentId: "main",
+    };
+
+    await loadAssistantIdentity(state);
+    expect(state.assistantAvatar).toBe("data:image/png;base64,main");
+
+    request.mockResolvedValue({
+      agentId: "worker",
+      name: "Worker",
+      avatar: "server-worker.png",
+    });
+    state.sessionKey = "agent:worker:main";
+    state.assistantAgentId = "worker";
+
+    await loadAssistantIdentity(state);
+    expect(state.assistantAvatar).toBe("data:image/png;base64,worker");
+  });
 });

--- a/ui/src/ui/controllers/assistant-identity.ts
+++ b/ui/src/ui/controllers/assistant-identity.ts
@@ -68,7 +68,9 @@ export async function loadAssistantIdentity(
     state.assistantAvatarReason = normalized.avatarReason ?? null;
     state.assistantAgentId = normalized.agentId ?? null;
     // Local override always wins — same pattern as the user avatar.
-    const localAvatar = loadLocalAssistantIdentity().avatar;
+    // Scope the override to the current agent so different agents can have
+    // different avatars without clobbering each other.
+    const localAvatar = loadLocalAssistantIdentity(normalized.agentId ?? null).avatar;
     if (localAvatar) {
       state.assistantAvatar = localAvatar;
       state.assistantAvatarSource = localAvatar;
@@ -81,10 +83,10 @@ export async function loadAssistantIdentity(
 }
 
 export function setAssistantAvatarOverride(
-  state: AssistantAvatarOverrideState,
+  state: AssistantAvatarOverrideState & { assistantAgentId?: string | null },
   avatar: string | null,
 ) {
-  saveLocalAssistantIdentity({ avatar });
+  saveLocalAssistantIdentity({ avatar }, state.assistantAgentId ?? null);
   if (avatar) {
     state.assistantAvatar = avatar;
     state.assistantAvatarSource = avatar;

--- a/ui/src/ui/storage.ts
+++ b/ui/src/ui/storage.ts
@@ -350,28 +350,76 @@ export function saveLocalUserIdentity(next: LocalUserIdentity) {
 
 export type LocalAssistantIdentity = { avatar: string | null };
 
-export function loadLocalAssistantIdentity(): LocalAssistantIdentity {
+type PersistedLocalAssistantIdentity = {
+  // Legacy flat avatar stored before per-agent isolation.
+  avatar?: string | null;
+  // Per-agent avatar overrides. Key is the normalized agent id.
+  agents?: Record<string, LocalAssistantIdentity>;
+};
+
+export function loadLocalAssistantIdentity(agentId?: string | null): LocalAssistantIdentity {
   const storage = getSafeLocalStorage();
+  const normalizedAgentId = normalizeOptionalString(agentId) ?? "main";
   try {
     const raw = storage?.getItem(LOCAL_ASSISTANT_IDENTITY_KEY);
     if (!raw) {
       return { avatar: null };
     }
-    const parsed = JSON.parse(raw) as Partial<LocalAssistantIdentity>;
-    return { avatar: typeof parsed.avatar === "string" ? parsed.avatar : null };
+    const parsed = JSON.parse(raw) as Partial<PersistedLocalAssistantIdentity>;
+    // Per-agent storage takes precedence.
+    if (parsed.agents && typeof parsed.agents === "object") {
+      const agentEntry = parsed.agents[normalizedAgentId];
+      if (agentEntry && typeof agentEntry.avatar === "string") {
+        return { avatar: agentEntry.avatar };
+      }
+    }
+    // Legacy flat fallback: migrate on save, but for now treat the legacy
+    // avatar as belonging to the requested agent so existing users do not
+    // suddenly lose their override.
+    if (typeof parsed.avatar === "string") {
+      return { avatar: parsed.avatar };
+    }
+    return { avatar: null };
   } catch {
     return { avatar: null };
   }
 }
 
-export function saveLocalAssistantIdentity(next: LocalAssistantIdentity) {
+export function saveLocalAssistantIdentity(next: LocalAssistantIdentity, agentId?: string | null) {
   const storage = getSafeLocalStorage();
+  const normalizedAgentId = normalizeOptionalString(agentId) ?? "main";
   try {
+    let parsed: PersistedLocalAssistantIdentity = {};
+    try {
+      const raw = storage?.getItem(LOCAL_ASSISTANT_IDENTITY_KEY);
+      if (raw) {
+        parsed = JSON.parse(raw) as PersistedLocalAssistantIdentity;
+      }
+    } catch {
+      // ignore parse errors; start fresh
+    }
+
+    const nextAgents: Record<string, LocalAssistantIdentity> =
+      parsed.agents && typeof parsed.agents === "object" ? { ...parsed.agents } : {};
+
     if (!next.avatar) {
+      delete nextAgents[normalizedAgentId];
+    } else {
+      nextAgents[normalizedAgentId] = { avatar: next.avatar };
+    }
+
+    const persisted: PersistedLocalAssistantIdentity = {
+      ...parsed,
+      agents: nextAgents,
+    };
+    // Once migrated to per-agent storage, drop the legacy flat key.
+    delete persisted.avatar;
+
+    if (Object.keys(persisted.agents ?? {}).length === 0) {
       storage?.removeItem(LOCAL_ASSISTANT_IDENTITY_KEY);
       return;
     }
-    storage?.setItem(LOCAL_ASSISTANT_IDENTITY_KEY, JSON.stringify({ avatar: next.avatar }));
+    storage?.setItem(LOCAL_ASSISTANT_IDENTITY_KEY, JSON.stringify(persisted));
   } catch {
     // best-effort — quota exceeded or security restrictions should not
     // prevent in-memory identity updates from being applied


### PR DESCRIPTION
Fixes #90890

# Comment for Issue #90890 — Agent avatar changes overwrite all agents

## Summary

The Control UI stores the assistant avatar override in `localStorage` under a single global key (`openclaw.control.assistant.v1`). Because the key is not scoped by agent, setting an avatar for one agent overwrites the avatar for every other agent.

## Root Cause

`ui/src/ui/storage.ts:351-379` defines:

```typescript
const LOCAL_ASSISTANT_IDENTITY_KEY = "openclaw.control.assistant.v1";

export function loadLocalAssistantIdentity(): LocalAssistantIdentity { ... }
export function saveLocalAssistantIdentity(next: LocalAssistantIdentity) { ... }
```

And `assistant-identity.ts:83-98` calls these without passing an agent id.

## Proposed Fix

Scope the localStorage entry by agent id while preserving backward compatibility for legacy flat entries.

### `storage.ts`

```typescript
type PersistedLocalAssistantIdentity = {
  avatar?: string | null;          // legacy flat value
  agents?: Record<string, LocalAssistantIdentity>;
};

export function loadLocalAssistantIdentity(agentId?: string | null): LocalAssistantIdentity {
  // 1. Try per-agent storage first
  // 2. Fall back to legacy flat value for existing users
  // 3. Default to null
}

export function saveLocalAssistantIdentity(
  next: LocalAssistantIdentity,
  agentId?: string | null,
) {
  // Merge into agents map, drop legacy flat key on save
}
```

### `assistant-identity.ts`

```typescript
const localAvatar = loadLocalAssistantIdentity(normalized.agentId ?? null).avatar;

export function setAssistantAvatarOverride(
  state: AssistantAvatarOverrideState & { assistantAgentId?: string | null },
  avatar: string | null,
) {
  saveLocalAssistantIdentity({ avatar }, state.assistantAgentId ?? null);
  // ...
}
```

## Files Changed

| File | Change |
|------|--------|
| `ui/src/ui/storage.ts` | Per-agent `loadLocalAssistantIdentity` / `saveLocalAssistantIdentity` |
| `ui/src/ui/controllers/assistant-identity.ts` | Pass current agent id to storage helpers |
| `ui/src/ui/controllers/assistant-identity.test.ts` | Add per-agent isolation regression tests |

## Test Results

```
$ pnpm test ui/src/ui/controllers/assistant-identity.test.ts

✓ |ui| ui/src/ui/controllers/assistant-identity.test.ts (5 tests) 13ms

Test Files  1 passed (1)
     Tests  5 passed (5)
```

New tests verify:
- `main` and `worker` agents can have different local avatars
- Clearing `main`'s avatar does not affect `worker`
- `loadAssistantIdentity` applies the override only for the matching agent

## Verification Command

```bash
pnpm test ui/src/ui/controllers/assistant-identity.test.ts
```

## Next Step

Ready branch with the fix and regression tests. I can open a PR immediately if this looks good.
