### PR TITLE
fix(agents): do not misclassify client-disconnect abort as run timeout

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -151,7 +151,7 @@ import {
 } from "../../embedded-agent-helpers.js";
 import { countActiveToolExecutions } from "../../embedded-agent-subscribe.handlers.tools.js";
 import { subscribeEmbeddedAgentSession } from "../../embedded-agent-subscribe.js";
-import { isTimeoutError } from "../../failover-error.js";
+import { isSignalTimeoutReason } from "../../failover-error.js";
 import { runAgentEndSideEffects } from "../../harness/agent-end-side-effects.js";
 import { runAgentHarnessBeforeAgentFinalizeHook } from "../../harness/lifecycle-hook-helpers.js";
 import { resolveHeartbeatPromptForSystemPrompt } from "../../heartbeat-system-prompt.js";
@@ -986,7 +986,7 @@ export async function runEmbeddedAttempt(
     }
     externalAbort = true;
     const reason = getAbortReason(signal);
-    const timeout = reason ? isTimeoutError(reason) : false;
+    const timeout = reason ? isSignalTimeoutReason(reason) : false;
     if (
       shouldFlagCompactionTimeout({
         isTimeout: timeout,
@@ -3482,7 +3482,7 @@ export async function runEmbeddedAttempt(
       const onAbort = () => {
         externalAbort = true;
         const reason = params.abortSignal ? getAbortReason(params.abortSignal) : undefined;
-        const timeout = reason ? isTimeoutError(reason) : false;
+        const timeout = reason ? isSignalTimeoutReason(reason) : false;
         if (
           shouldFlagCompactionTimeout({
             isTimeout: timeout,

--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -11,6 +11,7 @@ import {
   describeFailoverError,
   FailoverError,
   isNonProviderRuntimeCoordinationError,
+  isSignalTimeoutReason,
   isTimeoutError,
   resolveFailoverReasonFromError,
   resolveFailoverStatus,
@@ -1313,5 +1314,36 @@ describe("buildFailoverRemediationHint", () => {
     expect(buildFailoverRemediationHint(new Error("oops"))).toBeUndefined();
     expect(buildFailoverRemediationHint(undefined)).toBeUndefined();
     expect(buildFailoverRemediationHint("just a string")).toBeUndefined();
+  });
+});
+
+describe("isSignalTimeoutReason", () => {
+  it("returns false for plain AbortController.abort() DOMException (client disconnect)", () => {
+    // watchClientDisconnect calls abort() with no args → DOMException("This operation was aborted", "AbortError")
+    // This must not be classified as a run timeout (#90764).
+    const err = new DOMException("This operation was aborted", "AbortError");
+    expect(isSignalTimeoutReason(err)).toBe(false);
+  });
+
+  it("returns false for AbortError whose message matches ABORT_TIMEOUT_RE", () => {
+    // Old isTimeoutError returned true here via ABORT_TIMEOUT_RE (/request.*aborted/i).
+    const err = Object.assign(new Error("request aborted"), { name: "AbortError" });
+    expect(isSignalTimeoutReason(err)).toBe(false);
+  });
+
+  it("returns true for AbortSignal.timeout() DOMException", () => {
+    const err = new DOMException("signal timed out", "TimeoutError");
+    expect(isSignalTimeoutReason(err)).toBe(true);
+  });
+
+  it("returns true for makeTimeoutAbortReason()-style Error", () => {
+    // makeTimeoutAbortReason() in attempt.ts: Error("request timed out", name="TimeoutError")
+    const err = Object.assign(new Error("request timed out"), { name: "TimeoutError" });
+    expect(isSignalTimeoutReason(err)).toBe(true);
+  });
+
+  it("returns false for null and undefined", () => {
+    expect(isSignalTimeoutReason(null)).toBe(false);
+    expect(isSignalTimeoutReason(undefined)).toBe(false);
   });
 });

--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -1319,7 +1319,7 @@ describe("buildFailoverRemediationHint", () => {
 
 describe("isSignalTimeoutReason", () => {
   it("returns false for plain AbortController.abort() DOMException (client disconnect)", () => {
-    // watchClientDisconnect calls abort() with no args → DOMException("This operation was aborted", "AbortError")
+    // watchClientDisconnect calls abort() with no args, producing AbortError.
     // This must not be classified as a run timeout (#90764).
     const err = new DOMException("This operation was aborted", "AbortError");
     expect(isSignalTimeoutReason(err)).toBe(false);

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -376,6 +376,11 @@ export function isTimeoutError(err: unknown): boolean {
   return hasTimeoutHint(cause) || hasTimeoutHint(reason);
 }
 
+/** Return true when an abort-signal reason is an intentional timeout; plain AbortError is a cancellation, not a timeout. */
+export function isSignalTimeoutReason(reason: unknown): boolean {
+  return readErrorName(reason) === "TimeoutError";
+}
+
 function failoverReasonFromClassification(
   classification: FailoverClassification | null,
 ): FailoverReason | null {


### PR DESCRIPTION
### Summary

- **Problem**: Issue #90764 reports that embedded agent runs abort at ~165–180 s wall-clock regardless of `agents.defaults.timeoutSeconds` or `models.providers.*.timeoutSeconds`. The run exits with "Request timed out before a response was generated." and the message advises increasing `timeoutSeconds`, but increasing it has no effect on the abort timing.
- **Root Cause**: `onAbort` and `onExternalAbortSignal` in `src/agents/embedded-agent-runner/run/attempt.ts` call `isTimeoutError(reason)` on the abort-signal reason to decide whether to set `timedOut = true`. `isTimeoutError` calls `hasTimeoutHint`, which calls `isTimeoutErrorMessage` — that function matches the pattern `/\boperation was aborted\b/i` against the error message. `AbortController.abort()` with no arguments produces `DOMException("This operation was aborted", "AbortError")`; that message matches the pattern, so `hasTimeoutHint` returns `true` and `isTimeoutError` returns `true` for what is actually a plain client cancellation, setting `timedOut = true` erroneously. `watchClientDisconnect` in `src/gateway/http-common.ts` calls `abortController.abort()` with no args whenever the HTTP socket closes — for example, when a reverse-proxy or keepalive layer evicts the connection after a long period of no SSE output during a thinking phase. This fires `params.abortSignal`, which triggers `onAbort`, which then sets `timedOut = true` with no relation to the configured timeout values.
- **Fix**: Replace `isTimeoutError` with a new `isSignalTimeoutReason` export from `src/agents/failover-error.ts`. `isSignalTimeoutReason` checks only `readErrorName(reason) === "TimeoutError"` — the name produced exclusively by `AbortSignal.timeout()` and `makeTimeoutAbortReason()`, the two intentional timeout-creation paths. Plain `AbortError` (`name = "AbortError"`) is a cancellation and returns `false`. `isTimeoutError` is unchanged for all other callers that classify general LLM error messages, where the Ollama NDJSON / stream-abort patterns still apply.
- **What changed**:
  - `src/agents/failover-error.ts` — export `isSignalTimeoutReason`: checks only `name === "TimeoutError"`, no text-matching heuristic.
  - `src/agents/embedded-agent-runner/run/attempt.ts` — replace `isTimeoutError` import and both abort-signal handler call sites (`onExternalAbortSignal` and `onAbort`) with `isSignalTimeoutReason`.
  - `src/agents/failover-error.test.ts` — add `isSignalTimeoutReason` describe block: plain `AbortError` DOMException, ABORT_TIMEOUT_RE `AbortError`, `AbortSignal.timeout()` DOMException, `makeTimeoutAbortReason()`-style Error, null/undefined.
- **What did NOT change (scope boundary)**:
  - `isTimeoutError` and its text-matching heuristics are unchanged; the change is scoped to the two abort-signal handler call sites.
  - Config surface unchanged (no schema, defaults, doctor migrations, or `docs/reference/config`).
  - Plugin surface unchanged (no plugin SDK, manifest, `extensions/*` api/runtime-api, registry/loader).
  - Gateway protocol unchanged.

### Reproduction

1. Configure `agents.defaults.timeoutSeconds: 600` and `models.providers.custom-api-anthropic-com.timeoutSeconds: 600`.
2. Start a run that completes several tool calls, then enters a thinking phase that produces no SSE output for long enough to trigger the client's HTTP connection idle timeout.
3. The reverse proxy or keepalive layer evicts the idle connection; `watchClientDisconnect` fires `abortController.abort()` with no args.
4. **Before this PR**: `onAbort` calls `isTimeoutError(DOMException("This operation was aborted", "AbortError"))` — `hasTimeoutHint` matches the message via `isTimeoutErrorMessage` (`/\boperation was aborted\b/i`), returns `true`; `timedOut = true`; run exits at ~165–180 s with "Request timed out before a response was generated."; increasing `timeoutSeconds` has no effect.
5. **After this PR**: `isSignalTimeoutReason(DOMException("This operation was aborted", "AbortError"))` checks `readErrorName(reason) === "TimeoutError"` → `false`; `timedOut` is not set; the abort is treated as an external cancellation, not a run timeout.

### Real behavior proof

**Behavior addressed (#90764)**: after the fix, a client-disconnect abort no longer sets `timedOut = true` in the embedded attempt; only abort-signal reasons with `name === "TimeoutError"` (from `AbortSignal.timeout()` or `makeTimeoutAbortReason()`) are treated as run timeouts.

**Real environment tested (Linux, Node 22 — Vitest against the production `isSignalTimeoutReason` and the two production abort-signal handler paths)**: `isSignalTimeoutReason` driven directly with each discriminating input; `onAbort` / `onExternalAbortSignal` call sites exercised via the existing full-runner `attempt.test.ts` suite.

**Exact steps or command run after this patch**: `pnpm test src/agents/failover-error.test.ts`; `pnpm test src/agents/embedded-agent-runner/run/attempt.test.ts`; `pnpm format:check` and `node scripts/run-oxlint.mjs` on the three changed files; `pnpm tsgo`.

**Evidence after fix**:

```
failover-error.test.ts   Tests  88 passed (88)
attempt.test.ts          Tests  121 passed (121)
```

The `isSignalTimeoutReason` describe covers: `DOMException("This operation was aborted", "AbortError")` → `false` (watchClientDisconnect regression case; old `isTimeoutError` returned `true` via `isTimeoutErrorMessage` matching `/\boperation was aborted\b/i`); `Error("request aborted", name="AbortError")` → `false` (old `isTimeoutError` returned `true` via `ABORT_TIMEOUT_RE`); `DOMException("signal timed out", "TimeoutError")` → `true`; `Error("request timed out", name="TimeoutError")` → `true`; null/undefined → `false`.

**Observed result after fix**: `isSignalTimeoutReason(new DOMException("This operation was aborted", "AbortError"))` returns `false`; the abort-signal handlers classify client disconnections as `externalAbort=true / timedOut=false`; the run does not surface "Request timed out" for network-layer connection evictions.

**What was not tested**: live gateway repro with a real reverse-proxy idle eviction end-to-end; the abort-signal handler logic and the `isSignalTimeoutReason` discriminator are covered deterministically against the production functions, but a full network-layer round-trip was not driven.

### Risk / Mitigation

- **Risk**: `isSignalTimeoutReason` is strictly narrower than `isTimeoutError` for the two affected call sites; a timeout path that passes `params.abortSignal` with an error whose `name` is not `"TimeoutError"` will no longer be classified as a timeout.
- **Mitigation**: both intentional internal timeout-creation paths (`makeTimeoutAbortReason()` and `AbortSignal.timeout()`) produce `name === "TimeoutError"`; `isTimeoutError` is unchanged for all LLM error classification callers where the broader text-matching heuristic is appropriate.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Agent runtime
- [x] Tests

### Linked Issue/PR

Fixes #90764