### PR TITLE
fix(gateway): preserve stale channel restart diagnostics

### DIFF
--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -433,6 +433,50 @@ describe("server-channels auto restart", () => {
     expect(hoisted.sleepWithAbort).not.toHaveBeenCalled();
   });
 
+  it("keeps recovery timeout diagnostics when a stale task reports connected after abort", async () => {
+    let emitLateStatus: (() => void) | undefined;
+    const startAccount = vi.fn(async (ctx: ChannelGatewayContext<TestAccount>) => {
+      ctx.setStatus({
+        accountId: DEFAULT_ACCOUNT_ID,
+        connected: true,
+        lastError: null,
+      });
+      await new Promise<void>(() => {
+        ctx.abortSignal.addEventListener(
+          "abort",
+          () => {
+            emitLateStatus = () =>
+              ctx.setStatus({
+                accountId: DEFAULT_ACCOUNT_ID,
+                connected: true,
+                lastError: null,
+              });
+          },
+          { once: true },
+        );
+      });
+    });
+    installTestRegistry(createTestPlugin({ startAccount }));
+    const manager = createManager();
+
+    await manager.startChannels();
+    const recoveryStopTask = manager.stopChannel("discord", DEFAULT_ACCOUNT_ID, {
+      manual: false,
+    });
+    await vi.advanceTimersByTimeAsync(5_000);
+    await recoveryStopTask;
+    await manager.startChannel("discord", DEFAULT_ACCOUNT_ID);
+
+    emitLateStatus?.();
+    const account = manager.getRuntimeSnapshot().channelAccounts.discord?.[DEFAULT_ACCOUNT_ID];
+    expect(startAccount).toHaveBeenCalledTimes(1);
+    expect(account?.running).toBe(false);
+    expect(account?.connected).toBe(false);
+    expect(account?.restartPending).toBe(true);
+    expect(account?.reconnectAttempts).toBe(0);
+    expect(account?.lastError).toContain("channel stop timed out");
+  });
+
   it("restarts immediately when recovery stop timeout settles with an error", async () => {
     const rejectFirstTask = createDeferred();
     let startCount = 0;

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -300,6 +300,40 @@ describe("server-channels auto restart", () => {
     expect(account?.lastError).toBeNull();
   });
 
+  it("lets stop hooks update status after aborting the running task", async () => {
+    const startAccount = vi.fn(async (ctx: ChannelGatewayContext<TestAccount>) => {
+      ctx.setStatus({
+        accountId: DEFAULT_ACCOUNT_ID,
+        running: true,
+        connected: true,
+        lastError: "startup warning",
+      });
+      await new Promise<void>((resolve) => {
+        ctx.abortSignal.addEventListener("abort", () => resolve(), { once: true });
+      });
+    });
+    const stopAccount = vi.fn(async (ctx: ChannelGatewayContext<TestAccount>) => {
+      ctx.setStatus({
+        accountId: DEFAULT_ACCOUNT_ID,
+        connected: false,
+        lastError: null,
+      });
+    });
+    installTestRegistry(createTestPlugin({ startAccount, stopAccount }));
+    const manager = createManager();
+
+    await manager.startChannels();
+    await flushMicrotasks();
+    await manager.stopChannel("discord", DEFAULT_ACCOUNT_ID);
+
+    const snapshot = manager.getRuntimeSnapshot();
+    const account = snapshot.channelAccounts.discord?.[DEFAULT_ACCOUNT_ID];
+    expect(stopAccount).toHaveBeenCalledTimes(1);
+    expect(account?.running).toBe(false);
+    expect(account?.connected).toBe(false);
+    expect(account?.lastError).toBeNull();
+  });
+
   it("does not enumerate configured accounts when stopping a never-started channel", async () => {
     const listAccountIds = vi.fn(() => [DEFAULT_ACCOUNT_ID]);
     const resolveAccount = vi.fn(() => ({ enabled: true, configured: true }));

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -52,6 +52,37 @@ type ChannelRuntimeStore = {
   runtimes: Map<string, ChannelAccountSnapshot>;
 };
 
+function sanitizeAbortedTaskStatusPatch(
+  patch: ChannelAccountSnapshot,
+  current: ChannelAccountSnapshot,
+): ChannelAccountSnapshot {
+  const next = { ...patch };
+  delete next.running;
+  delete next.restartPending;
+  delete next.reconnectAttempts;
+  delete next.lastStartAt;
+  delete next.lastStopAt;
+
+  // A stale task may still emit a late "connected" heartbeat after the gateway
+  // has already aborted it and marked restart recovery pending. Do not let that
+  // old task make the stopped runtime look connected again.
+  if (next.connected === true) {
+    delete next.connected;
+    delete next.lastConnectedAt;
+    delete next.lastEventAt;
+    delete next.lastTransportActivityAt;
+  }
+
+  // Preserve actionable lifecycle diagnostics (for example a stop-timeout
+  // recovery error) against late stale-task status patches that merely clear
+  // plugin transport errors.
+  if (next.lastError === null && current.lastError) {
+    delete next.lastError;
+  }
+
+  return next;
+}
+
 type HealthMonitorConfig = {
   healthMonitor?: {
     enabled?: boolean;
@@ -336,6 +367,32 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
     return next;
   };
 
+  const setRuntimeFromTaskStatus = (
+    channelId: ChannelId,
+    accountId: string,
+    patch: ChannelAccountSnapshot,
+    abortSignal?: AbortSignal,
+  ): ChannelAccountSnapshot => {
+    const safePatch = abortSignal?.aborted
+      ? sanitizeAbortedTaskStatusPatch(patch, getRuntime(channelId, accountId))
+      : patch;
+    return setRuntime(channelId, accountId, safePatch);
+  };
+
+  const setStoppedRuntime = (
+    channelId: ChannelId,
+    accountId: string,
+    patch: Omit<ChannelAccountSnapshot, "accountId" | "running"> = {},
+  ): ChannelAccountSnapshot => {
+    const current = getRuntime(channelId, accountId);
+    return setRuntime(channelId, accountId, {
+      accountId,
+      running: false,
+      ...(typeof current.connected === "boolean" ? { connected: false } : {}),
+      ...patch,
+    });
+  };
+
   const getChannelRuntime = async (): Promise<PluginRuntimeChannel | undefined> => {
     if (channelRuntime) {
       return channelRuntime;
@@ -492,9 +549,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
           }
 
           if (abort.signal.aborted || manuallyStopped.has(rKey)) {
-            setRuntime(channelId, id, {
-              accountId: id,
-              running: false,
+            setStoppedRuntime(channelId, id, {
               restartPending: false,
               lastStopAt: Date.now(),
             });
@@ -559,7 +614,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
                   abortSignal: abort.signal,
                   log,
                   getStatus: () => getRuntime(channelId, id),
-                  setStatus: (next) => setRuntime(channelId, id, next),
+                  setStatus: (next) => setRuntimeFromTaskStatus(channelId, id, next, abort.signal),
                   ...(channelRuntimeForTask ? { channelRuntime: channelRuntimeForTask } : {}),
                 });
               const routeRegistry = getPluginHttpRouteRegistry?.();
@@ -588,9 +643,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
             })
             .then(async () => {
               await cleanupTaskScopedApprovalRuntime("channel cleanup failed");
-              setRuntime(channelId, id, {
-                accountId: id,
-                running: false,
+              setStoppedRuntime(channelId, id, {
                 lastStopAt: Date.now(),
               });
             })
@@ -689,9 +742,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
           store.tasks.set(id, trackedPromise);
         } catch (error) {
           if (!handedOffTask) {
-            setRuntime(channelId, id, {
-              accountId: id,
-              running: false,
+            setStoppedRuntime(channelId, id, {
               restartPending: false,
               lastError: formatErrorMessage(error),
             });
@@ -774,7 +825,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
             abortSignal: abort?.signal ?? new AbortController().signal,
             log,
             getStatus: () => getRuntime(channelId, id),
-            setStatus: (next) => setRuntime(channelId, id, next),
+            setStatus: (next) => setRuntimeFromTaskStatus(channelId, id, next, abort?.signal),
           });
         }
         const stoppedCleanly = await waitForChannelStopGracefully(
@@ -785,12 +836,19 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
           log.warn?.(
             `[${id}] channel stop exceeded ${CHANNEL_STOP_ABORT_TIMEOUT_MS}ms after abort; continuing shutdown`,
           );
-          setRuntime(channelId, id, {
-            accountId: id,
-            running: manual,
+          const stoppedPatch = {
             restartPending: !manual,
             lastError: `channel stop timed out after ${CHANNEL_STOP_ABORT_TIMEOUT_MS}ms`,
-          });
+          };
+          if (manual) {
+            setRuntime(channelId, id, {
+              accountId: id,
+              running: true,
+              ...stoppedPatch,
+            });
+          } else {
+            setStoppedRuntime(channelId, id, stoppedPatch);
+          }
           if (!manual) {
             recoveryStopTimedOut.add(rKey);
           }
@@ -800,9 +858,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
         recoveryStartRequested.delete(rKey);
         store.aborts.delete(id);
         store.tasks.delete(id);
-        setRuntime(channelId, id, {
-          accountId: id,
-          running: false,
+        setStoppedRuntime(channelId, id, {
           restartPending: false,
           lastStopAt: Date.now(),
         });

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -825,7 +825,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
             abortSignal: abort?.signal ?? new AbortController().signal,
             log,
             getStatus: () => getRuntime(channelId, id),
-            setStatus: (next) => setRuntimeFromTaskStatus(channelId, id, next, abort?.signal),
+            setStatus: (next) => setRuntime(channelId, id, next),
           });
         }
         const stoppedCleanly = await waitForChannelStopGracefully(


### PR DESCRIPTION
## Summary

Fixes #90901.

This keeps gateway-owned lifecycle state authoritative after a channel task has been aborted. A stale Telegram/polling-style task can still emit a late status patch after a recovery stop timeout. Before this change, that late patch could re-mark the account as `connected=true` and clear `lastError` while the manager still had `running=false`, `restartPending=true`, and `reconnectAttempts=0`.

The fix:

- sanitizes status patches emitted by aborted channel tasks so they cannot overwrite gateway-owned lifecycle fields;
- prevents late stale-task patches from re-marking a stopped runtime as connected;
- preserves actionable lifecycle diagnostics such as `channel stop timed out after 5000ms` instead of allowing `lastError=null`;
- marks stopped runtimes as disconnected when the runtime previously had a connection state.

## Current branch state

The PR branch was refreshed on top of the latest `openclaw/openclaw@main` after the earlier CI failure in `checks-node-agentic-agents-core-tools`. ClawSweeper then ran its automerge repair lane and kept the fix on the contributor branch.

- Base used for the refreshed branch: `b8adc11977ab9dc1eb558dc070bfe63df75911c5` (`feat(cron): support command jobs`)
- Current head: `53b37e50739078238b0b582c4db5da61ddd66cb8`
- Current branch delta is limited to the gateway lifecycle fix and its regression tests:
  - `src/gateway/server-channels.ts`
  - `src/gateway/server-channels.test.ts`

The earlier failing CI shard was reproduced against the refreshed branch and now passes:

```text
OPENCLAW_VITEST_INCLUDE_FILE=/tmp/pr90937-agentic-agents-core-tools-includes.json \
OPENCLAW_VITEST_SHARD_NAME=agentic-agents-core-tools \
OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 \
OPENCLAW_TEST_PROJECTS_PARALLEL=2 \
NODE_OPTIONS=--max-old-space-size=8192 \
pnpm exec node scripts/test-projects.mjs test/vitest/vitest.agents-core.config.ts

# 64 test files passed
# 1125 tests passed, 4 skipped
```

That confirms the earlier camera inline-image failures were from the old PR branch being behind the current mainline test/runtime baseline, not from this gateway lifecycle change.

## Review feedback addressed

ClawSweeper's latest review did not identify a code defect. The remaining P1 blocker was proof quality:

- It requested redacted real-runtime proof from Telegram polling, LaunchAgent gateway recovery, or a comparable non-mock channel lifecycle run.
- It marked the patch quality strong, but capped the PR at proof-limited readiness because Vitest/CI output alone was considered supplemental.
- It paused automerge for human review because the change affects the gateway lifecycle path used by all channel plugins.

This update adds a redacted real gateway runtime diagnostic-channel run below. It uses the actual patched `createChannelManager` runtime path, real timers, a real channel plugin registered through the plugin registry, and no Vitest/fake-timer harness. It exercises the stale aborted task sequence after the 5000ms stop-timeout path.

## Reproduction / before evidence

Added regression coverage for the reported shape:

1. start a managed account task;
2. abort it through a non-manual recovery stop;
3. let the stop timeout leave recovery restart pending;
4. request a restart while the stale task is still present;
5. have the stale task emit a late `connected=true` / `lastError=null` status patch.

Before the fix, the new regression fails because the stale task revives `connected=true` in the stopped runtime:

- GitHub Actions before-fix run: https://github.com/snowzlm/openclaw/actions/runs/27063237738
- Before-fix commit: `6739bbf06eda1740878cfcc2097f39609d18de69`
- Failure: `src/gateway/server-channels.test.ts > keeps recovery timeout diagnostics when a stale task reports connected after abort`
- Observed assertion: `expected true to be false`

## After evidence

With the fix, the same regression passes and the runtime keeps the actionable timeout diagnostic instead of returning to `connected=true` / `lastError=null`.

Focused verification on the refreshed latest-main branch:

```text
node scripts/run-vitest.mjs run \
  --config test/vitest/vitest.gateway.config.ts \
  src/gateway/server-channels.test.ts \
  -t "keeps recovery timeout diagnostics"
# 1 passed

node scripts/run-vitest.mjs run \
  --config test/vitest/vitest.gateway.config.ts \
  src/gateway/server-channels.test.ts \
  src/gateway/channel-health-monitor.test.ts \
  src/gateway/server-methods/channels.status.test.ts
# 6 files passed, 155 tests passed

node scripts/run-tsgo.mjs \
  -p test/tsconfig/tsconfig.core.test.json \
  --incremental \
  --tsBuildInfoFile .artifacts/tsgo-cache/core-test-pr90937-latest.tsbuildinfo
# passed

./node_modules/.bin/oxfmt --check --threads=1 \
  src/gateway/server-channels.ts \
  src/gateway/server-channels.test.ts
# passed
```

Cloud proof after refreshing the branch:

- Real behavior proof: https://github.com/openclaw/openclaw/actions/runs/27114714749
- Status: passed on refreshed head `53b37e50739078238b0b582c4db5da61ddd66cb8`

Cloud CI for the current head is green after ClawSweeper refreshed the contributor branch. `gh pr checks 90937 --repo openclaw/openclaw` exits 0, including `checks-node-agentic-agents-core-tools`, gateway shards, CodeQL security-high shards, OpenGrep, build artifacts, and Real behavior proof.

## Real behavior proof

- **Behavior or issue addressed**: after a recovery stop timeout, a stale aborted channel task must not re-mark the runtime as connected or clear the actionable timeout error while restart remains pending.
- **Real environment tested**: Linux source checkout, Node.js v24, patched OpenClaw gateway lifecycle manager running from current head `53b37e50739078238b0b582c4db5da61ddd66cb8`.
- **Exact steps or command run after this patch**: ran a standalone real gateway runtime diagnostic-channel script against the patched source. The script registers a real local channel plugin through the plugin registry, starts it through `createChannelManager`, performs a non-manual stop that reaches the real 5000ms recovery timeout, requests restart while the stale task is still present, and then emits the late stale `connected=true` / `lastError=null` task status patch.

```text
node --import tsx .artifacts/pr-90937/real-runtime-proof.mts
```

- **Evidence after fix**: the diagnostic-channel run exits 0 and shows the runtime keeps the stopped/restart-pending diagnostic shape after the late stale task patch:

```json
{
  "proof": "pr-90937-real-gateway-runtime-diagnostic-channel",
  "head": "53b37e50739078238b0b582c4db5da61ddd66cb8",
  "durationMs": 5255,
  "startCount": 1,
  "capturedAbort": true,
  "afterStart": {
    "running": true,
    "connected": true,
    "lastError": null
  },
  "beforeLateStatusPatch": {
    "running": false,
    "connected": false,
    "restartPending": true,
    "reconnectAttempts": 0,
    "lastError": "channel stop timed out after 5000ms"
  },
  "afterLateStaleStatusPatch": {
    "running": false,
    "connected": false,
    "restartPending": true,
    "reconnectAttempts": 0,
    "lastError": "channel stop timed out after 5000ms"
  }
}
```

Runtime stderr also emitted the expected gateway timeout diagnostic:

```text
[pr-90937-real-runtime-proof] [default] channel stop exceeded 5000ms after abort; continuing shutdown
```

Additional focused regression evidence on the same code path:

```text
node scripts/run-vitest.mjs run \
  --config test/vitest/vitest.gateway.config.ts \
  src/gateway/server-channels.test.ts \
  -t "keeps recovery timeout diagnostics"

# 1 passed
```

Additional cloud proof on the refreshed PR line:

```text
Real behavior proof  pass  https://github.com/openclaw/openclaw/actions/runs/27114768550
```

- **Observed result after fix**: the visible runtime no longer returns to the reported false-positive shape (`connected=true`, `lastError=null`) after the stale aborted task emits its late status patch; it remains `running=false`, `connected=false`, `restartPending=true`, `reconnectAttempts=0`, with `lastError="channel stop timed out after 5000ms"`.
- **What was not tested**: live Telegram Bot API polling and macOS LaunchAgent supervisor behavior still require a credentialed maintainer-owned environment; the added proof uses a local diagnostic channel to exercise the same gateway manager lifecycle state without network secrets.

## Risk / behavior notes

- This does **not** force-start a duplicate runner while an old task is still present; that remains safer for polling transports.
- If an old task never exits, status now retains a concrete recovery timeout diagnostic instead of silently returning to `lastError=null` with a stale connected marker.
- The fix is channel-agnostic and stays in the gateway lifecycle manager rather than Telegram-specific code.

