### PR TITLE
fix(tui): show loading while models hydrate

### DIFF
--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -5,6 +5,7 @@ import {
   TUI_RECENT_SESSIONS_ACTIVE_MINUTES,
   TUI_SESSION_PICKER_LIMIT,
 } from "./tui-session-list-policy.js";
+import { isTuiBusyActivityStatus } from "./tui.js";
 
 type LoadHistoryMock = ReturnType<typeof vi.fn> & (() => Promise<void>);
 type RunAuthFlow = NonNullable<Parameters<typeof createCommandHandlers>[0]["runAuthFlow"]>;
@@ -118,7 +119,6 @@ function createHarness(params?: {
   const refreshSessionInfo = params?.refreshSessionInfo ?? vi.fn().mockResolvedValue(undefined);
   const applySessionInfoFromPatch = params?.applySessionInfoFromPatch ?? vi.fn();
   const applySessionMutationResult = params?.applySessionMutationResult ?? vi.fn();
-  const setActivityStatus = params?.setActivityStatus ?? (vi.fn() as SetActivityStatusMock);
   const forgetLocalRunId = vi.fn();
   const openOverlay = vi.fn();
   const closeOverlay = vi.fn();
@@ -142,6 +142,11 @@ function createHarness(params?: {
     isConnected: params?.isConnected ?? true,
     sessionInfo: {},
   };
+  const setActivityStatus =
+    params?.setActivityStatus ??
+    (vi.fn((next: string) => {
+      state.activityStatus = next;
+    }) as SetActivityStatusMock);
 
   const { handleCommand, openSessionSelector } = createCommandHandlers({
     client: {
@@ -1147,5 +1152,68 @@ describe("tui command handlers", () => {
     expect(applySessionInfoFromPatch).toHaveBeenCalledWith({ model: "openrouter/auto" });
     expect(refreshSessionInfo).toHaveBeenCalledTimes(1);
     expect(closeOverlay).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows loading feedback before /models listing resolves", async () => {
+    let resolveModels: (
+      value: Array<{ provider: string; id: string; name?: string }>,
+    ) => void = () => {
+      throw new Error("resolveModels not initialized");
+    };
+    const listModels = vi.fn(
+      () =>
+        new Promise<Array<{ provider: string; id: string; name?: string }>>((resolve) => {
+          resolveModels = resolve;
+        }),
+    );
+    const harness = createHarness({
+      listModels,
+      activityStatus: "idle",
+    });
+
+    const pending = harness.handleCommand("/models");
+    await Promise.resolve();
+
+    const busyCallIndex = harness.setActivityStatus.mock.calls.findIndex((call) =>
+      isTuiBusyActivityStatus(call[0]),
+    );
+    expect(busyCallIndex).toBeGreaterThanOrEqual(0);
+    const busyOrder = harness.setActivityStatus.mock.invocationCallOrder[busyCallIndex] ?? 0;
+    expect(harness.requestRender.mock.invocationCallOrder.some((order) => order > busyOrder)).toBe(
+      true,
+    );
+
+    resolveModels([]);
+    await pending;
+    expect(harness.state.activityStatus).toBe("idle");
+  });
+
+  it("does not replace streaming status while /models listing resolves", async () => {
+    let resolveModels: (
+      value: Array<{ provider: string; id: string; name?: string }>,
+    ) => void = () => {
+      throw new Error("resolveModels not initialized");
+    };
+    const listModels = vi.fn(
+      () =>
+        new Promise<Array<{ provider: string; id: string; name?: string }>>((resolve) => {
+          resolveModels = resolve;
+        }),
+    );
+    const harness = createHarness({
+      listModels,
+      activityStatus: "streaming",
+      activeChatRunId: "run-active",
+    });
+
+    const pending = harness.handleCommand("/models");
+    await Promise.resolve();
+
+    expect(harness.setActivityStatus).not.toHaveBeenCalledWith("loading models");
+    expect(harness.state.activityStatus).toBe("streaming");
+
+    resolveModels([{ provider: "openrouter", id: "openrouter/auto" }]);
+    await pending;
+    expect(harness.state.activityStatus).toBe("streaming");
   });
 });

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -39,6 +39,8 @@ import type {
   TuiStateAccess,
 } from "./tui-types.js";
 
+const MODEL_LIST_LOADING_ACTIVITY_STATUS = "loading models";
+
 type CommandHandlerContext = {
   client: TuiBackend;
   chatLog: ChatLog;
@@ -164,8 +166,17 @@ export function createCommandHandlers(context: CommandHandlerContext) {
   };
 
   const openModelSelector = async () => {
+    const previousActivityStatus = state.activityStatus;
+    const shouldShowLoadingStatus = previousActivityStatus === "idle";
+    if (shouldShowLoadingStatus) {
+      setActivityStatus(MODEL_LIST_LOADING_ACTIVITY_STATUS);
+      tui.requestRender();
+    }
     try {
       const models = await client.listModels();
+      if (shouldShowLoadingStatus && state.activityStatus === MODEL_LIST_LOADING_ACTIVITY_STATUS) {
+        setActivityStatus(previousActivityStatus);
+      }
       if (models.length === 0) {
         chatLog.addSystem("no models available");
         tui.requestRender();
@@ -194,6 +205,9 @@ export function createCommandHandlers(context: CommandHandlerContext) {
         }
       });
     } catch (err) {
+      if (shouldShowLoadingStatus && state.activityStatus === MODEL_LIST_LOADING_ACTIVITY_STATUS) {
+        setActivityStatus(previousActivityStatus);
+      }
       chatLog.addSystem(`model list failed: ${String(err)}`);
       tui.requestRender();
     }

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -386,6 +386,7 @@ export function canSubmitTuiChatMessage(params: {
 }
 
 const TUI_BUSY_ACTIVITY_STATUSES = new Set([
+  "loading models",
   "sending",
   "waiting",
   "streaming",


### PR DESCRIPTION
## Summary

What problem does this PR solve?


Why does this matter now?


What is the intended outcome?


What is intentionally out of scope?


What does success look like?


What should reviewers focus on?

<details>
<summary>Summary guidance</summary>

This PR description is the contributor's durable explanation of the change. Write it for human maintainers first; ClawSweeper and Barnacle use the same text to understand intent, proof, risk, and current review state.

Describe the intent and outcome in 2-5 bullets. Avoid restating the diff; reviewers and bots can read the changed files.

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

</details>

## Linked context

Which issue does this close?

Closes #

Which issues, PRs, or discussions are related?

Related #

Was this requested by a maintainer or owner?

<details>
<summary>Linked context guidance</summary>

Link the issue, PR, discussion, maintainer request, or owner request that explains why this PR should exist. Maintainer context helps reviewers and automation distinguish intended work from drive-by churn.

</details>

## Real behavior proof (required for external PRs)

- Behavior or issue addressed:
- Real environment tested:
- Exact steps or command run after this patch:
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):
- Observed result after fix:
- What was not tested:
- Proof limitations or environment constraints:
- Before evidence (optional but encouraged):

<details>
<summary>Real behavior proof guidance</summary>

External contributors must show after-fix evidence from a real OpenClaw setup. Unit tests, mocks, lint, typechecks, snapshots, and CI are supplemental only.

Screenshots are encouraged even for CLI, console, text, or log changes. Terminal screenshots, copied live output, redacted runtime logs, recordings, and linked artifacts count.

If your environment cannot produce the ideal proof, explain that under `Proof limitations or environment constraints` so reviewers and ClawSweeper can direct the next step properly.

Be mindful of private information like IP addresses, API keys, phone numbers, non-public endpoints, or other private details when providing evidence.

</details>

## Tests and validation

Which commands did you run?


What regression coverage was added or updated?


What failed before this fix, if known?


If no test was added, why not?

<details>
<summary>Testing guidance</summary>

List focused commands, not every incidental check. CI is useful support, but external PRs still need real behavior proof above when behavior changes.

</details>

## Risk checklist

Did user-visible behavior change? (`Yes/No`)


Did config, environment, or migration behavior change? (`Yes/No`)


Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)


What is the highest-risk area?


How is that risk mitigated?

<details>
<summary>Risk guidance</summary>

Use this for author judgment that is not obvious from the diff. ClawSweeper can see touched files, but it cannot know which behavior you think is risky, why the risk is acceptable, or what mitigation reviewers should verify.

</details>

## Current review state

What is the next action?


What is still waiting on author, maintainer, CI, or external proof?


Which bot or reviewer comments were addressed?

<details>
<summary>Review state guidance</summary>

Keep this as the durable state for review progress. If useful information appears in comments, fold the current next action or blocker back here so maintainers and ClawSweeper do not need to reconstruct state from comment history.

</details>
