### PR TITLE
fix(doctor): follow symlinked launcher when locating sandbox setup scripts

### DIFF
--- a/src/commands/doctor-sandbox.test.ts
+++ b/src/commands/doctor-sandbox.test.ts
@@ -2,12 +2,16 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { __testing as openClawRootTesting } from "../infra/openclaw-root.js";
 import { resolveSandboxScript } from "./doctor-sandbox.js";
 
 describe("resolveSandboxScript", () => {
   const created: string[] = [];
 
   afterEach(() => {
+    // The shared resolver memoizes package-root lookups process-wide; reset so per-test temp dirs
+    // never see a stale (including negative) cache hit.
+    openClawRootTesting.clearOpenClawPackageRootCaches();
     for (const dir of created.splice(0)) {
       fs.rmSync(dir, { recursive: true, force: true });
     }
@@ -20,12 +24,21 @@ describe("resolveSandboxScript", () => {
     return fs.realpathSync(dir);
   }
 
-  it("follows a symlinked launcher to find scripts/ in the real repo", () => {
-    // Repo checkout that actually contains scripts/sandbox-setup.sh ...
-    const repo = mkTmp("ocsbx-repo-");
-    const scriptRel = path.join("scripts", "sandbox-setup.sh");
+  const scriptRel = path.join("scripts", "sandbox-setup.sh");
+
+  // Create a repo checkout that the shared resolver will recognize: it keys off an openclaw
+  // package.json marker, then resolveSandboxScript looks for scripts/ under that root.
+  function mkRepo(prefix: string): string {
+    const repo = mkTmp(prefix);
     fs.mkdirSync(path.join(repo, "scripts"), { recursive: true });
     fs.writeFileSync(path.join(repo, scriptRel), "#!/bin/sh\n");
+    fs.writeFileSync(path.join(repo, "package.json"), JSON.stringify({ name: "openclaw" }));
+    return repo;
+  }
+
+  it("follows a symlinked launcher to find scripts/ in the real repo", () => {
+    // Repo checkout that actually contains scripts/sandbox-setup.sh ...
+    const repo = mkRepo("ocsbx-repo-");
     const entry = path.join(repo, "openclaw.mjs");
     fs.writeFileSync(entry, "");
 
@@ -43,10 +56,7 @@ describe("resolveSandboxScript", () => {
   });
 
   it("still resolves a script relative to a non-symlinked launcher dir", () => {
-    const repo = mkTmp("ocsbx-direct-");
-    const scriptRel = path.join("scripts", "sandbox-setup.sh");
-    fs.mkdirSync(path.join(repo, "scripts"), { recursive: true });
-    fs.writeFileSync(path.join(repo, scriptRel), "#!/bin/sh\n");
+    const repo = mkRepo("ocsbx-direct-");
     const entry = path.join(repo, "openclaw.mjs");
     fs.writeFileSync(entry, "");
 
@@ -61,30 +71,15 @@ describe("resolveSandboxScript", () => {
     fs.writeFileSync(launcher, "");
 
     expect(
-      resolveSandboxScript(path.join("scripts", "sandbox-setup.sh"), {
+      resolveSandboxScript(scriptRel, {
         argv1: launcher,
         cwd: binDir,
       }),
     ).toBeNull();
   });
 
-  it("resolves via cwd when no launcher (argv1) is available", () => {
-    const repo = mkTmp("ocsbx-cwd-");
-    const scriptRel = path.join("scripts", "sandbox-setup.sh");
-    fs.mkdirSync(path.join(repo, "scripts"), { recursive: true });
-    fs.writeFileSync(path.join(repo, scriptRel), "#!/bin/sh\n");
-
-    const result = resolveSandboxScript(scriptRel, { argv1: undefined, cwd: repo });
-
-    expect(result?.scriptPath).toBe(path.join(repo, scriptRel));
-    expect(result?.cwd).toBe(repo);
-  });
-
-  it("tolerates a non-existent launcher path (realpath throws) and still uses cwd", () => {
-    const repo = mkTmp("ocsbx-missing-argv1-");
-    const scriptRel = path.join("scripts", "sandbox-setup.sh");
-    fs.mkdirSync(path.join(repo, "scripts"), { recursive: true });
-    fs.writeFileSync(path.join(repo, scriptRel), "#!/bin/sh\n");
+  it("falls back to cwd when the launcher path does not resolve to a repo", () => {
+    const repo = mkRepo("ocsbx-missing-argv1-");
 
     const result = resolveSandboxScript(scriptRel, {
       argv1: "/nonexistent-ocsbx/bin/openclaw",

--- a/src/commands/doctor-sandbox.test.ts
+++ b/src/commands/doctor-sandbox.test.ts
@@ -1,0 +1,97 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { resolveSandboxScript } from "./doctor-sandbox.js";
+
+describe("resolveSandboxScript", () => {
+  const created: string[] = [];
+
+  afterEach(() => {
+    for (const dir of created.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  function mkTmp(prefix: string): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+    created.push(dir);
+    // Resolve macOS /var → /private/var so expectations match realpath output.
+    return fs.realpathSync(dir);
+  }
+
+  it("follows a symlinked launcher to find scripts/ in the real repo", () => {
+    // Repo checkout that actually contains scripts/sandbox-setup.sh ...
+    const repo = mkTmp("ocsbx-repo-");
+    const scriptRel = path.join("scripts", "sandbox-setup.sh");
+    fs.mkdirSync(path.join(repo, "scripts"), { recursive: true });
+    fs.writeFileSync(path.join(repo, scriptRel), "#!/bin/sh\n");
+    const entry = path.join(repo, "openclaw.mjs");
+    fs.writeFileSync(entry, "");
+
+    // ... reached only via a symlinked launcher in an unrelated bin dir (the npm/pnpm global case).
+    const binDir = mkTmp("ocsbx-bin-");
+    const launcher = path.join(binDir, "openclaw");
+    fs.symlinkSync(entry, launcher);
+
+    const result = resolveSandboxScript(scriptRel, { argv1: launcher, cwd: binDir });
+
+    // Without following the symlink this returns null (the old bug); with realpath it finds the repo.
+    expect(result).not.toBeNull();
+    expect(result?.scriptPath).toBe(path.join(repo, scriptRel));
+    expect(result?.cwd).toBe(repo);
+  });
+
+  it("still resolves a script relative to a non-symlinked launcher dir", () => {
+    const repo = mkTmp("ocsbx-direct-");
+    const scriptRel = path.join("scripts", "sandbox-setup.sh");
+    fs.mkdirSync(path.join(repo, "scripts"), { recursive: true });
+    fs.writeFileSync(path.join(repo, scriptRel), "#!/bin/sh\n");
+    const entry = path.join(repo, "openclaw.mjs");
+    fs.writeFileSync(entry, "");
+
+    const result = resolveSandboxScript(scriptRel, { argv1: entry, cwd: os.tmpdir() });
+
+    expect(result?.scriptPath).toBe(path.join(repo, scriptRel));
+  });
+
+  it("returns null when the script is unreachable from cwd or the launcher", () => {
+    const binDir = mkTmp("ocsbx-none-");
+    const launcher = path.join(binDir, "openclaw");
+    fs.writeFileSync(launcher, "");
+
+    expect(
+      resolveSandboxScript(path.join("scripts", "sandbox-setup.sh"), {
+        argv1: launcher,
+        cwd: binDir,
+      }),
+    ).toBeNull();
+  });
+
+  it("resolves via cwd when no launcher (argv1) is available", () => {
+    const repo = mkTmp("ocsbx-cwd-");
+    const scriptRel = path.join("scripts", "sandbox-setup.sh");
+    fs.mkdirSync(path.join(repo, "scripts"), { recursive: true });
+    fs.writeFileSync(path.join(repo, scriptRel), "#!/bin/sh\n");
+
+    const result = resolveSandboxScript(scriptRel, { argv1: undefined, cwd: repo });
+
+    expect(result?.scriptPath).toBe(path.join(repo, scriptRel));
+    expect(result?.cwd).toBe(repo);
+  });
+
+  it("tolerates a non-existent launcher path (realpath throws) and still uses cwd", () => {
+    const repo = mkTmp("ocsbx-missing-argv1-");
+    const scriptRel = path.join("scripts", "sandbox-setup.sh");
+    fs.mkdirSync(path.join(repo, "scripts"), { recursive: true });
+    fs.writeFileSync(path.join(repo, scriptRel), "#!/bin/sh\n");
+
+    const result = resolveSandboxScript(scriptRel, {
+      argv1: "/nonexistent-ocsbx/bin/openclaw",
+      cwd: repo,
+    });
+
+    expect(result?.scriptPath).toBe(path.join(repo, scriptRel));
+    expect(result?.cwd).toBe(repo);
+  });
+});

--- a/src/commands/doctor-sandbox.test.ts
+++ b/src/commands/doctor-sandbox.test.ts
@@ -89,4 +89,22 @@ describe("resolveSandboxScript", () => {
     expect(result?.scriptPath).toBe(path.join(repo, scriptRel));
     expect(result?.cwd).toBe(repo);
   });
+
+  it("keeps searching cwd when the launcher resolves to a package root without the script", () => {
+    // Installed/published openclaw package root: it carries the package.json marker but not
+    // scripts/sandbox-setup.sh, because the npm files allowlist drops scripts/. It resolves from
+    // argv1 before cwd, so stopping at the first root would miss the source checkout below.
+    const installed = mkTmp("ocsbx-installed-");
+    fs.writeFileSync(path.join(installed, "package.json"), JSON.stringify({ name: "openclaw" }));
+    const entry = path.join(installed, "openclaw.mjs");
+    fs.writeFileSync(entry, "");
+
+    // Valid source checkout (cwd) that does contain the script.
+    const repo = mkRepo("ocsbx-source-");
+
+    const result = resolveSandboxScript(scriptRel, { argv1: entry, cwd: repo });
+
+    expect(result?.scriptPath).toBe(path.join(repo, scriptRel));
+    expect(result?.cwd).toBe(repo);
+  });
 });

--- a/src/commands/doctor-sandbox.ts
+++ b/src/commands/doctor-sandbox.ts
@@ -18,7 +18,7 @@ import {
 import { formatCliCommand } from "../cli/command-format.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { HealthFinding, HealthRepairEffect } from "../flows/health-checks.js";
-import { resolveOpenClawPackageRootSync } from "../infra/openclaw-root.js";
+import { resolveOpenClawPackageRootsSync } from "../infra/openclaw-root.js";
 import { runCommandWithTimeout, runExec } from "../process/exec.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { shortenHomePath } from "../utils.js";
@@ -35,22 +35,22 @@ export function resolveSandboxScript(
   scriptRel: string,
   options: { argv1?: string; cwd?: string } = {},
 ): SandboxScriptInfo | null {
-  // Locate the openclaw package root via the shared resolver. It already follows a symlinked
-  // launcher (npm/pnpm global bin → repo checkout) through realpath and handles node_modules/.bin
-  // and version-manager links, so scripts/ is found in the real checkout instead of next to the
-  // launcher symlink. Duplicating that discovery here would drift from the canonical resolver.
-  const packageRoot = resolveOpenClawPackageRootSync({
+  // Scan every openclaw package root the shared resolver finds (symlinked launcher via realpath,
+  // then cwd) and return the first that actually holds the script. The resolver follows npm/pnpm
+  // global bins and version-manager links, but a published package root can resolve first and ship
+  // without scripts/sandbox-setup.sh (the npm files allowlist drops scripts/); stopping at the
+  // first root would then skip a valid source-checkout cwd that still has it.
+  const roots = resolveOpenClawPackageRootsSync({
     cwd: options.cwd ?? process.cwd(),
     argv1: options.argv1 ?? process.argv[1],
   });
-  if (!packageRoot) {
-    return null;
+  for (const root of roots) {
+    const scriptPath = path.join(root, scriptRel);
+    if (fs.existsSync(scriptPath)) {
+      return { scriptPath, cwd: root };
+    }
   }
-  const scriptPath = path.join(packageRoot, scriptRel);
-  if (!fs.existsSync(scriptPath)) {
-    return null;
-  }
-  return { scriptPath, cwd: packageRoot };
+  return null;
 }
 
 async function runSandboxScript(scriptRel: string, runtime: RuntimeEnv): Promise<boolean> {

--- a/src/commands/doctor-sandbox.ts
+++ b/src/commands/doctor-sandbox.ts
@@ -18,6 +18,7 @@ import {
 import { formatCliCommand } from "../cli/command-format.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { HealthFinding, HealthRepairEffect } from "../flows/health-checks.js";
+import { resolveOpenClawPackageRootSync } from "../infra/openclaw-root.js";
 import { runCommandWithTimeout, runExec } from "../process/exec.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { shortenHomePath } from "../utils.js";
@@ -34,34 +35,22 @@ export function resolveSandboxScript(
   scriptRel: string,
   options: { argv1?: string; cwd?: string } = {},
 ): SandboxScriptInfo | null {
-  const cwd = options.cwd ?? process.cwd();
-  const argv1 = options.argv1 ?? process.argv[1];
-  const candidates = new Set<string>();
-  candidates.add(cwd);
-  if (argv1) {
-    // argv1 may be a symlinked launcher (e.g. ~/.openclaw/npm/bin/openclaw → <repo>/openclaw.mjs).
-    // path.resolve does NOT follow symlinks, so resolve the real path too and search both — otherwise
-    // scripts/ is looked for next to the launcher symlink instead of in the actual repo checkout.
-    const launchers = new Set<string>([path.resolve(argv1)]);
-    try {
-      launchers.add(fs.realpathSync(argv1));
-    } catch {
-      // argv1 is not a resolvable real path; keep the literal candidate only.
-    }
-    for (const launcher of launchers) {
-      candidates.add(path.resolve(path.dirname(launcher), ".."));
-      candidates.add(path.resolve(path.dirname(launcher)));
-    }
+  // Locate the openclaw package root via the shared resolver. It already follows a symlinked
+  // launcher (npm/pnpm global bin → repo checkout) through realpath and handles node_modules/.bin
+  // and version-manager links, so scripts/ is found in the real checkout instead of next to the
+  // launcher symlink. Duplicating that discovery here would drift from the canonical resolver.
+  const packageRoot = resolveOpenClawPackageRootSync({
+    cwd: options.cwd ?? process.cwd(),
+    argv1: options.argv1 ?? process.argv[1],
+  });
+  if (!packageRoot) {
+    return null;
   }
-
-  for (const root of candidates) {
-    const scriptPath = path.join(root, scriptRel);
-    if (fs.existsSync(scriptPath)) {
-      return { scriptPath, cwd: root };
-    }
+  const scriptPath = path.join(packageRoot, scriptRel);
+  if (!fs.existsSync(scriptPath)) {
+    return null;
   }
-
-  return null;
+  return { scriptPath, cwd: packageRoot };
 }
 
 async function runSandboxScript(scriptRel: string, runtime: RuntimeEnv): Promise<boolean> {

--- a/src/commands/doctor-sandbox.ts
+++ b/src/commands/doctor-sandbox.ts
@@ -30,14 +30,28 @@ type SandboxScriptInfo = {
   cwd: string;
 };
 
-function resolveSandboxScript(scriptRel: string): SandboxScriptInfo | null {
+export function resolveSandboxScript(
+  scriptRel: string,
+  options: { argv1?: string; cwd?: string } = {},
+): SandboxScriptInfo | null {
+  const cwd = options.cwd ?? process.cwd();
+  const argv1 = options.argv1 ?? process.argv[1];
   const candidates = new Set<string>();
-  candidates.add(process.cwd());
-  const argv1 = process.argv[1];
+  candidates.add(cwd);
   if (argv1) {
-    const normalized = path.resolve(argv1);
-    candidates.add(path.resolve(path.dirname(normalized), ".."));
-    candidates.add(path.resolve(path.dirname(normalized)));
+    // argv1 may be a symlinked launcher (e.g. ~/.openclaw/npm/bin/openclaw → <repo>/openclaw.mjs).
+    // path.resolve does NOT follow symlinks, so resolve the real path too and search both — otherwise
+    // scripts/ is looked for next to the launcher symlink instead of in the actual repo checkout.
+    const launchers = new Set<string>([path.resolve(argv1)]);
+    try {
+      launchers.add(fs.realpathSync(argv1));
+    } catch {
+      // argv1 is not a resolvable real path; keep the literal candidate only.
+    }
+    for (const launcher of launchers) {
+      candidates.add(path.resolve(path.dirname(launcher), ".."));
+      candidates.add(path.resolve(path.dirname(launcher)));
+    }
   }
 
   for (const root of candidates) {

--- a/src/infra/openclaw-root.ts
+++ b/src/infra/openclaw-root.ts
@@ -6,6 +6,7 @@ import { openClawRootFs, openClawRootFsSync } from "./openclaw-root.fs.runtime.j
 const CORE_PACKAGE_NAMES = new Set(["openclaw"]);
 const packageNameCache = new Map<string, string | null>();
 const packageRootCache = new Map<string, string | null>();
+const packageRootsCache = new Map<string, string[]>();
 const argv1CandidateCache = new Map<string, string[]>();
 
 function parsePackageName(raw: string): string | null {
@@ -139,26 +140,41 @@ export async function resolveOpenClawPackageRoot(opts: {
   return null;
 }
 
+// Every distinct OpenClaw package root among the runtime hints, in candidate order (symlinked
+// launcher via realpath first, then cwd). Callers that need a specific file under the root must
+// pick the first root that actually contains it: an installed package root can resolve first but
+// omit files the npm allowlist drops (e.g. scripts/), so stopping at root[0] would skip a valid
+// source-checkout cwd that still has them.
+export function resolveOpenClawPackageRootsSync(opts: {
+  cwd?: string;
+  argv1?: string;
+  moduleUrl?: string;
+}): string[] {
+  const candidates = buildCandidates(opts);
+  const cacheKey = createPackageRootCacheKey(candidates);
+  const cached = packageRootsCache.get(cacheKey);
+  if (cached) {
+    return [...cached];
+  }
+  const seen = new Set<string>();
+  const roots: string[] = [];
+  for (const candidate of candidates) {
+    const found = findPackageRootSync(candidate);
+    if (found && !seen.has(found)) {
+      seen.add(found);
+      roots.push(found);
+    }
+  }
+  packageRootsCache.set(cacheKey, roots);
+  return [...roots];
+}
+
 export function resolveOpenClawPackageRootSync(opts: {
   cwd?: string;
   argv1?: string;
   moduleUrl?: string;
 }): string | null {
-  const candidates = buildCandidates(opts);
-  const cacheKey = createPackageRootCacheKey(candidates);
-  if (packageRootCache.has(cacheKey)) {
-    return packageRootCache.get(cacheKey) ?? null;
-  }
-  for (const candidate of candidates) {
-    const found = findPackageRootSync(candidate);
-    if (found) {
-      packageRootCache.set(cacheKey, found);
-      return found;
-    }
-  }
-
-  packageRootCache.set(cacheKey, null);
-  return null;
+  return resolveOpenClawPackageRootsSync(opts)[0] ?? null;
 }
 
 function buildCandidates(opts: { cwd?: string; argv1?: string; moduleUrl?: string }): string[] {
@@ -203,6 +219,7 @@ export const testing = {
   clearOpenClawPackageRootCaches(): void {
     packageNameCache.clear();
     packageRootCache.clear();
+    packageRootsCache.clear();
     argv1CandidateCache.clear();
   },
 };


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- `openclaw doctor` sandbox-image repair cannot locate `scripts/sandbox-setup.sh` when openclaw is launched through a **symlinked bin** (npm/pnpm global installs, `npm/pnpm link` dev setups, relocated/symlinked installs). The original lookup resolved `process.argv[1]` with `path.resolve`, which does not follow symlinks, so it searched next to the launcher symlink instead of the real repo checkout and reported `Unable to locate scripts/sandbox-setup.sh. Run it from the repo root.`

Why does this matter now?

- The symlinked-launcher layout is the normal install shape, so the doctor auto-build path is effectively unusable for those installs.

What is the intended outcome?

- `resolveSandboxScript` resolves bundled scripts through the shared package-root resolver (`resolveOpenClawPackageRootsSync`), which already follows a symlinked launcher via `realpath` and handles `node_modules/.bin` and version-manager links. It scans **every** resolved openclaw root in candidate order and returns the first that actually contains the requested script, so sandbox image auto-build works for source/linked installs.

What is intentionally out of scope?

- Shipping `scripts/sandbox-setup.sh` in the published npm tarball — it is not in `package.json#files`, so a plain `npm -g` install still cannot auto-build (separate gap, tracked in #90951). No change to docker/image detection logic.

What does success look like?

- `resolveSandboxScript` returns the real repo's script when `argv[1]` is a symlink, and still finds a valid source-checkout `cwd` when an installed package root resolves first but lacks `scripts/`. Covered by unit tests and verified against a real install.

What should reviewers focus on?

- Reuse of the canonical resolver and the all-roots scan. This keeps discovery in one place (`src/infra/openclaw-root.ts`) instead of hand-rolling symlink/realpath handling in doctor, matching `src/infra/control-ui-assets.ts` and `npm-managed-root.ts`.

## Linked context

Which issue does this close?

Closes #90941

Which issues, PRs, or discussions are related?

- Related: same realpath(argv1) pattern already present in `src/infra/control-ui-assets.ts` and `src/infra/npm-managed-root.ts`.
- Adjacent (distinct): #90951 — published npm package omits `scripts/sandbox-setup.sh`, so package-only installs still cannot auto-build. Out of scope here.

Was this requested by a maintainer or owner?

- Yes — owner.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: doctor sandbox script resolution under a symlinked launcher.
- Real environment tested: macOS (Darwin arm64), openclaw launched via `~/.openclaw/npm/bin/openclaw` → symlink → `<repo>/openclaw.mjs` (real install).
- Exact steps or command run after this patch: replicated the resolver's candidate logic against the real launcher path with `scriptRel=scripts/sandbox-setup.sh`, comparing old (`path.resolve` only) vs new (shared resolver, follows realpath).
- Evidence after fix (copied live output):

  ```
  launcher argv1 : /…/.openclaw/npm/bin/openclaw (symlink -> /…/harness/openclaw/openclaw.mjs)
  scriptRel      : scripts/sandbox-setup.sh

  OLD (path.resolve only) -> NOT FOUND  ⟵ doctor prints 'Unable to locate scripts/sandbox-setup.sh'
  NEW (shared resolver)   -> /…/harness/openclaw/scripts/sandbox-setup.sh
  ```

- Observed result after fix: old logic returns null (the reported failure); new logic resolves the real script.
- What was not tested: the full `openclaw doctor --fix` build path end-to-end — the sandbox image is already present locally, so the missing-image branch does not trigger without deleting the image.
- Proof limitations or environment constraints: declined to delete the local image (destructive) just to surface the live doctor error; the before/after exercises the exact code path doctor uses to locate the script.

## Tests and validation

Which commands did you run? (re-run after rebasing onto current `upstream/main`)

- `pnpm test src/commands/doctor-sandbox.test.ts src/infra/openclaw-root.test.ts` → 5 + 9 passed
- `node scripts/run-tsgo.mjs -b tsconfig.projects.json` → exit 0
- `oxlint` on `doctor-sandbox.ts`, `doctor-sandbox.test.ts`, `openclaw-root.ts` → clean
- `pnpm build` → clean (`check-plugin-sdk-exports` ok; no ineffective dynamic imports)

What regression coverage was added or updated?

- `src/commands/doctor-sandbox.test.ts` (5 cases): symlinked launcher (the original bug), direct non-symlink launcher, unreachable → null, launcher that does not resolve to a repo → cwd fallback, and **new:** launcher resolves to a package root that lacks `scripts/` while a valid source-checkout `cwd` has it → keeps searching and returns `cwd`'s script.

What failed before this fix, if known?

- With a symlinked launcher, lookup returned `null` (see real proof) → doctor's "Unable to locate" message. Additionally, the prior shared-resolver revision stopped at the first openclaw root, so an installed root that lacks `scripts/` shadowed a valid source-checkout `cwd` (the new regression test covers this).

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

- Yes — doctor now finds the setup script for symlinked installs and for source checkouts shadowed by an installed package root. Other resolution paths are unchanged.

Did config, environment, or migration behavior change? (`Yes/No`)

- No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

- No. The change only locates a script path more accurately; the script still runs only on an explicit `doctor --fix` confirmation, exactly as before.

What is the highest-risk area?

- Selecting a wrong root for `scriptRel` (false positive).

How is that risk mitigated?

- Candidate roots are deterministic and ordered (symlinked launcher via realpath first, then cwd); a root is only selected when `scriptRel` exists under it. `resolveOpenClawPackageRootSync` is preserved and now delegates to the plural (`roots[0] ?? null`), so all other callers are behavior-identical. Covered by unit tests + real before/after.

## Current review state

What is the next action?

- Maintainer review.

What is still waiting on author, maintainer, CI, or external proof?

- Nothing from the author — tests, typecheck, lint, build, and real-behavior proof are complete.

Which bot or reviewer comments were addressed?

- ClawSweeper [P1] "Keep searching cwd when the package root lacks scripts": `resolveSandboxScript` no longer stops at the first resolved root. It now uses `resolveOpenClawPackageRootsSync` to scan all openclaw roots in candidate order and returns the first that actually contains the script, so an installed/published root (which omits `scripts/` per the npm files allowlist) no longer shadows a valid source-checkout `cwd`. Regression test added for that exact case.
