### PR TITLE
fix(export-session): copy html templates to dist/export-html

### DIFF
--- a/scripts/build-all.mjs
+++ b/scripts/build-all.mjs
@@ -132,7 +132,7 @@ export const BUILD_ALL_STEPS = [
         "scripts/lib/copy-assets.ts",
         "src/auto-reply/reply/export-html",
       ],
-      outputs: ["dist/auto-reply/reply/export-html"],
+      outputs: ["dist/export-html"],
     },
   },
   {

--- a/scripts/copy-export-html-templates.ts
+++ b/scripts/copy-export-html-templates.ts
@@ -19,8 +19,6 @@ const exportHtmlSrcDir = path.join(
 const exportHtmlDistDir = path.join(
   context.projectRoot,
   "dist",
-  "auto-reply",
-  "reply",
   "export-html",
 );
 


### PR DESCRIPTION
## What

Fix `/export-session` (alias `/export`) which always fails with `ENOENT` because the runtime resolves `EXPORT_HTML_DIR` relative to the bundle at `dist/`, but the build script was copying template assets to `dist/auto-reply/reply/export-html/`.

## Root Cause

In `scripts/copy-export-html-templates.ts`, the dist target was:

```
dist/auto-reply/reply/export-html/
```

But the runtime in `commands-export-session.ts` resolves via:

```js
const EXPORT_HTML_DIR = path.join(path.dirname(fileURLToPath(import.meta.url)), export-html);
```

Since the bundled JS lives at `dist/`, this resolves to `dist/export-html/` — which didn't exist.

## Fix

Change the copy script output target from `dist/auto-reply/reply/export-html/` to `dist/export-html/`, aligning the asset location with the runtime's path resolution.

Also update the corresponding `outputs` cache key in `build-all.mjs`.

## Impact

- `/export-session` no longer throws `ENOENT`
- No runtime code changes — only build-time asset placement
- 2 files changed, +1/-3

Closes #90843