### PR TITLE
fix(cron): require HTTP context for server_error retry classification

### DIFF
--- a/src/cron/retry-hint.test.ts
+++ b/src/cron/retry-hint.test.ts
@@ -36,4 +36,38 @@ describe("resolveCronExecutionRetryHint", () => {
       retryable: false,
     });
   });
+
+  it("does not classify bare 5xx-looking numbers as server_error", () => {
+    for (const message of [
+      "context limit 512 exceeded",
+      "process exited with 503 lines of output",
+      "ENOENT: no such file '/var/run/app-540.sock'",
+      "killed worker pid 511 after deadline",
+      "assertion failed: expected 500 got 0",
+      "error 500 got 0",
+      "process exited with code 500",
+    ]) {
+      expect(resolveCronExecutionRetryHint(message, ["server_error"])).toEqual({
+        retryable: false,
+      });
+    }
+  });
+
+  it("classifies genuine HTTP 5xx errors as server_error", () => {
+    for (const message of [
+      "HTTP 503 Service Unavailable",
+      "received status 500 from upstream",
+      "500 Internal Server Error",
+      "502 Bad Gateway",
+      "upstream returned 5xx",
+      "response code: 502",
+      "503",
+      "500",
+    ]) {
+      expect(resolveCronExecutionRetryHint(message, ["server_error"])).toEqual({
+        retryable: true,
+        category: "server_error",
+      });
+    }
+  });
 });

--- a/src/cron/retry-hint.ts
+++ b/src/cron/retry-hint.ts
@@ -7,6 +7,17 @@ export type CronRetryHint = {
   category?: CronRetryOn;
 };
 
+// A bare 5xx-looking number embedded in prose is not an HTTP server error: cron
+// failure messages routinely contain such numbers ("context limit 512 exceeded",
+// "exited with 503 lines", "pid 511 killed", a "...-540.sock" path), and
+// /\b5\d{2}\b/ matched all of them, wrongly marking permanent failures retryable.
+// Match a 5xx number only with HTTP/status context, a canonical 5xx phrase, or
+// when it is the entire message (a terse "503"), so genuine
+// "500 Internal Server Error" / "502 Bad Gateway" / "5xx" still classify while
+// incidental numbers in longer messages do not.
+const SERVER_ERROR_PATTERN =
+  /\b(?:https?|status(?:[ _]code)?|response(?:[ _]code)?|http(?:[ _]status)?)\b[\s:=#"']{0,4}5\d{2}\b|\b5\d{2}\b[\s:)\].,-]*(?:internal server error|server error|bad gateway|service unavailable|gateway time-?out)\b|\binternal server error\b|\bbad gateway\b|\bservice unavailable\b|\bgateway time-?out\b|\b5xx\b|^\s*5\d{2}\s*$/i;
+
 const TRANSIENT_PATTERNS: Record<CronRetryOn, RegExp> = {
   rate_limit:
     /(rate[_ ]limit|too many requests|429|resource has been exhausted|cloudflare|tokens per day)/i,
@@ -15,7 +26,7 @@ const TRANSIENT_PATTERNS: Record<CronRetryOn, RegExp> = {
   network:
     /(network|fetch failed|socket|econnreset|econnrefused|eai_again|enetdown|ehostunreach|ehostdown|enetreset|enetunreach|epipe)/i,
   timeout: /(timeout|etimedout)/i,
-  server_error: /\b5\d{2}\b/,
+  server_error: SERVER_ERROR_PATTERN,
 };
 
 /** Classifies cron execution errors against the configured retryable transient categories. */


### PR DESCRIPTION
## Problem

`resolveCronExecutionRetryHint` (`src/cron/retry-hint.ts`) classifies a failed cron run as a retryable `server_error` whenever its message contains a bare number in 500-599. The pattern is `server_error: /\b5\d{2}\b/`. Unlike the sibling entries in `TRANSIENT_PATTERNS` (rate_limit, overloaded, network, timeout), which require contextual keywords or specific codes like 429/529, this matches a plain integer anywhere in the text. `server_error` is in the default key set when `retryOn` is unset, so it fires for any cron without an explicit `retryOn`.

Fixes #90947.

## Impact

Permanent failures whose message incidentally contains a 5xx-range number are returned as `{ retryable: true, category: "server_error" }`, so the job retries with backoff and reports a misleading category to operators.

## Fix

Match a 5xx number only when it has HTTP/status context, a canonical 5xx phrase, or is the entire message (a terse `503`). Incidental numbers in longer messages no longer classify as server errors.

Notes addressing the review:

- The structured `classifiedReason` path is untouched, so structured provider classifications still win over the message regex.
- Genuine HTTP/status 5xx still retry: `HTTP 503 Service Unavailable`, `received status 500 from upstream`, `500 Internal Server Error`, `502 Bad Gateway`, `5xx`, and bare standalone codes `503` / `500`.
- Cron failure messages on this path are formatted text (`normalizeCronRunErrorText` returns `String(err)` style strings, timeout messages, `schedule error: ...`), so genuine 5xx carry HTTP/status context and the standalone-code branch covers the terse case. Incidental mid-sentence numbers with no context are now non-retryable. I can widen the context set if maintainers prefer more recall.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: cron `server_error` retry classifier marks permanent failures retryable when the error text incidentally contains a 500-599 number.
- Real environment tested: installed OpenClaw `2026.6.1` build (`/opt/homebrew/lib/node_modules/openclaw/dist/server-cron-CJwAiILI.js`), Node v26, macOS.
- Exact steps or command run after this patch: extracted the shipped `TRANSIENT_PATTERNS` verbatim from the installed build and ran `resolveCronExecutionRetryHint` against real cron failure strings, comparing the shipped `server_error` regex against this patch's pattern.
- Evidence after fix (console output):

```
# installed openclaw 2026.6.1 classifier (BEFORE) - permanent cron errors:
  {"retryable":true,"category":"server_error"}  <- "context limit 512 exceeded"
  {"retryable":true,"category":"server_error"}  <- "Error: process exited with 503 lines of output"
  {"retryable":true,"category":"server_error"}  <- "killed worker pid 511 after deadline"
  {"retryable":true,"category":"server_error"}  <- "assertion failed: expected 500 got 0"

# with this patch (AFTER) - same permanent cron errors:
  {"retryable":false}  <- "context limit 512 exceeded"
  {"retryable":false}  <- "Error: process exited with 503 lines of output"
  {"retryable":false}  <- "killed worker pid 511 after deadline"
  {"retryable":false}  <- "assertion failed: expected 500 got 0"

# with this patch (AFTER) - genuine HTTP 5xx still retry:
  {"retryable":true,"category":"server_error"}  <- "Error: Request failed with status code 503"
  {"retryable":true,"category":"server_error"}  <- "503 Service Unavailable"
  {"retryable":true,"category":"server_error"}  <- "500 Internal Server Error"
```

- Observed result after fix: the four permanent cron errors are no longer retried as `server_error`, while genuine HTTP 5xx errors still classify as retryable `server_error`.
- What was not tested: a full live gateway cron retry loop (scheduler picking up a deliberately failing job and backing off). The classifier is pure and was exercised directly with the real shipped regex.
- Proof limitations or environment constraints: I ran the shipped classifier extracted from the installed build rather than triggering an end-to-end cron retry against a running gateway, because reproducing the retry scheduling needs a live gateway plus a deliberately failing cron job. The local vitest `src/cron/retry-hint.test.ts` also passes (supplemental).
- Before evidence (optional but encouraged): see the BEFORE block above, produced from the unpatched installed `2026.6.1` classifier.

## Tests and validation

Which commands did you run? `node scripts/run-vitest.mjs src/cron/retry-hint.test.ts` (the test file passes under vitest), plus the real-classifier run shown above.

What regression coverage was added or updated? Two cases in `src/cron/retry-hint.test.ts`: incidental 5xx-looking numbers are not retryable, and genuine HTTP/status 5xx (including bare standalone codes) are.

What failed before this fix, if known? The new "does not classify bare 5xx-looking numbers" case fails on the unpatched classifier (the incidental numbers were classified retryable `server_error`).
