### PR TITLE
fix(docker): scope prod-store seed to the build platform

### DIFF
--- a/scripts/list-prod-store-packages.mjs
+++ b/scripts/list-prod-store-packages.mjs
@@ -7,6 +7,53 @@ const parsed = JSON.parse(fs.readFileSync(0, "utf8"));
 const roots = Array.isArray(parsed) ? parsed : [parsed];
 const specs = new Set();
 
+// Seed only packages whose lockfile platform metadata matches this build. The
+// `pnpm store add` that consumes this list exists solely to satisfy the offline
+// `pnpm prune` that immediately follows, and that prune is already scoped to the
+// target os/cpu (Dockerfile `--config.supportedArchitectures.*`). Seeding
+// tarballs for other platforms is wasted network that can time out the build.
+// We only drop packages this platform's prune also drops, so the seed stays a
+// superset of what prune keeps and no needed package is lost. libc is left to
+// prune (keeping all libc variants here only over-seeds, never under-seeds).
+//
+// `matchesList` mirrors npm/pnpm `checkList` (npm-install-checks): "any" always
+// matches; "!x" denies value x; a list with positive entries requires a
+// positive match; an all-negation list matches anything not explicitly denied.
+function matchesList(value, list) {
+  if (list.length === 1 && list[0] === "any") {
+    return true;
+  }
+  let negated = 0;
+  let match = false;
+  for (const entry of list) {
+    if (typeof entry !== "string") {
+      continue;
+    }
+    if (entry.charAt(0) === "!") {
+      negated += 1;
+      if (entry.slice(1) === value) {
+        return false;
+      }
+    } else if (entry === value) {
+      match = true;
+    }
+  }
+  return match || negated === list.length;
+}
+
+function matchesBuildPlatform(meta) {
+  if (!meta) {
+    return true;
+  }
+  if (Array.isArray(meta.os) && meta.os.length > 0 && !matchesList(process.platform, meta.os)) {
+    return false;
+  }
+  if (Array.isArray(meta.cpu) && meta.cpu.length > 0 && !matchesList(process.arch, meta.cpu)) {
+    return false;
+  }
+  return true;
+}
+
 function packageSpec(name, version) {
   if (!name || !version || typeof version !== "string") {
     return undefined;
@@ -98,4 +145,5 @@ const lockfile = readLockfile();
 addSnapshotClosure(lockfile);
 addLockfilePackages(lockfile);
 
-process.stdout.write([...specs].toSorted((a, b) => a.localeCompare(b)).join("\n"));
+const outputSpecs = [...specs].filter((spec) => matchesBuildPlatform(lockfile?.packages?.[spec]));
+process.stdout.write(outputSpecs.toSorted((a, b) => a.localeCompare(b)).join("\n"));

--- a/test/scripts/list-prod-store-packages.test.ts
+++ b/test/scripts/list-prod-store-packages.test.ts
@@ -121,4 +121,52 @@ describe("list-prod-store-packages", () => {
     expect(result.status).toBe(0);
     expect(result.stdout).toBe("recma-jsx@1.0.1");
   });
+
+  it("drops lockfile packages whose os/cpu metadata excludes the build platform", () => {
+    const cwd = makeTempRepoRoot(tempDirs, "openclaw-prod-store-packages-");
+    writeFileSync(
+      join(cwd, "pnpm-lock.yaml"),
+      [
+        "lockfileVersion: '10.0'",
+        "",
+        "packages:",
+        "  portable-pkg@1.0.0:",
+        "    resolution: {integrity: sha512-test}",
+        "  matching-os-pkg@1.0.0:",
+        "    resolution: {integrity: sha512-test}",
+        `    os: [${process.platform}]`,
+        "  foreign-os-pkg@1.0.0:",
+        "    resolution: {integrity: sha512-test}",
+        "    os: [__nonexistent_os__]",
+        "  foreign-cpu-pkg@1.0.0:",
+        "    resolution: {integrity: sha512-test}",
+        "    cpu: [__nonexistent_cpu__]",
+        "  negated-other-os-pkg@1.0.0:",
+        "    resolution: {integrity: sha512-test}",
+        "    os: ['!__nonexistent_os__']",
+        `  negated-this-os-pkg@1.0.0:`,
+        "    resolution: {integrity: sha512-test}",
+        `    os: ['!${process.platform}']`,
+        "  any-os-pkg@1.0.0:",
+        "    resolution: {integrity: sha512-test}",
+        "    os: [any]",
+        "",
+        "snapshots: {}",
+        "",
+      ].join("\n"),
+    );
+    const result = runListProdStorePackages({ dependencies: {} }, cwd);
+
+    expect(result.status).toBe(0);
+    const specs = result.stdout.split("\n").filter(Boolean);
+    // Kept: no constraint, matching os, all-negation that doesn't deny us, "any".
+    expect(specs).toContain("portable-pkg@1.0.0");
+    expect(specs).toContain("matching-os-pkg@1.0.0");
+    expect(specs).toContain("negated-other-os-pkg@1.0.0");
+    expect(specs).toContain("any-os-pkg@1.0.0");
+    // Dropped: non-matching positive os/cpu, or a negation that denies us.
+    expect(specs).not.toContain("foreign-os-pkg@1.0.0");
+    expect(specs).not.toContain("foreign-cpu-pkg@1.0.0");
+    expect(specs).not.toContain("negated-this-os-pkg@1.0.0");
+  });
 });


### PR DESCRIPTION
## Summary

The `runtime-assets` Docker stage seeds the pnpm store for the entire prod graph and then runs an offline prune:

```dockerfile
pnpm list --prod --depth Infinity --json | node scripts/list-prod-store-packages.mjs | xargs -r pnpm store add && \
CI=true pnpm prune --prod \
  --config.offline=true \
  --config.supportedArchitectures.os=linux \
  --config.supportedArchitectures.cpu="$(node -p 'process.arch')" \
  --config.supportedArchitectures.libc=glibc && ...
```

`list-prod-store-packages.mjs` emits **every** prod package, including other‑platform binaries (darwin/win32/foreign‑arch optional deps such as `fsevents`, `@esbuild/*`, `@rollup/rollup-*`). `pnpm store add` then fetches tarballs for all of them — but the very next `pnpm prune` is already scoped to `os=linux/cpu=$arch/glibc` and discards exactly those packages. On constrained networks the wasted fetches time out and fail the whole build:

```
[ERR_PNPM_STORE_ADD_FAILURE] Some packages have not been added correctly
TimeoutError: The operation was aborted due to timeout
```

## Fix

Filter the seed list to packages whose lockfile `os`/`cpu` metadata matches the build platform (`process.platform` / `process.arch`, which equal the target inside the build stage, including QEMU `buildx` cross‑builds where `node -p process.arch` already reports the target — the same value prune uses).

Matching uses the canonical npm/pnpm `checkList` semantics (from `npm-install-checks`): `"any"` always matches, `"!x"` denies value `x`, a list with positive entries needs a positive match, and an all‑negation list matches anything not explicitly denied. This avoids over‑filtering packages like `os: ["!win32"]`.

The filtered set is a **superset** of what the following prune keeps for this platform (we filter `os`/`cpu` only; `libc` is left to prune, so musl/glibc variants are still seeded), so no package prune needs is ever dropped. Packages without `os`/`cpu` constraints are unaffected.

- No new env vars / config surface.
- No Dockerfile change — the script self‑determines the platform.
- Only `scripts/list-prod-store-packages.mjs` (+ its test) change.

## Known limitation

Lockfile `packages:` keys can carry peer suffixes (e.g. `recma-jsx@1.0.1(acorn@8.16.0)`) while `specs` are stored as stripped `name@version`, so a platform‑constrained **peer‑suffixed** package would be looked up as `undefined` and kept (under‑filtered). This is safe (it only over‑seeds, never under‑seeds); platform binary packages are leaf optional deps without peer suffixes, so the timeout culprits are still filtered. A stripped‑key map could close this gap as a follow‑up if desired.

## Verification

- `node --check scripts/list-prod-store-packages.mjs` — passes.
- New regression test `test/scripts/list-prod-store-packages.test.ts`: covers matching os, foreign os, foreign cpu, negated‑other (`!x`, kept), negated‑self (`!platform`, dropped), and `any` — host‑independent (derived from `process.platform`).
- Existing tests unchanged in behavior (no‑lockfile and no‑os/cpu cases keep all packages).

### Real behavior proof

- **Behavior addressed:** `pnpm store add` timeout in the `runtime-assets` stage caused by seeding other‑platform tarballs the immediately‑following offline prune discards.
- **Real environment tested:** Docker build (`linux/amd64`) of the image from release `v2026.6.1`; Node 22; standalone runs of the script with crafted `pnpm-lock.yaml` fixtures (linux/x64 host).
- **Exact steps or command run after this patch:**
  - Reproduced the failure on stock `v2026.6.1`: the `runtime-assets` `RUN` failed twice at `pnpm store add` with `ERR_PNPM_STORE_ADD_FAILURE` / `TimeoutError`.
  - Applied the equivalent platform filter and rebuilt: the stage completed and the image built successfully.
  - Ran the script directly against fixtures: `printf '{"dependencies":{}}' | (cd fixture && node scripts/list-prod-store-packages.mjs)`.
- **Evidence after fix:** With a lockfile containing `os: [darwin]`, `os: ['!<platform>']`, `cpu: [<foreign>]`, `os: ['!<foreign>']`, `os: [any]`, and a metadata‑less package, output kept only platform‑compatible specs.
- **Observed result after fix:** Dropped `foreign-os`, `foreign-cpu`, `negated-this-os`; kept `portable`, `matching-os`, `negated-other-os`, `any-os`. Docker build that previously failed now succeeds.
- **What was not tested:** Full `pnpm test` / `pnpm check` were not run in this worktree (no `node_modules`; project builds in Docker). Behavior validated via `node --check` and direct fixture runs; CI runs the Vitest suite. ARM/QEMU cross‑build not exercised locally (reasoned from `process.arch` parity with the prune step).
