### PR TITLE
fix(agents): apply default provider catalog timeout in all environments

### DIFF
--- a/src/agents/models-config.providers.implicit.discovery-scope.test.ts
+++ b/src/agents/models-config.providers.implicit.discovery-scope.test.ts
@@ -351,4 +351,126 @@ describe("resolveImplicitProviders startup discovery scope", () => {
       "discovered-model",
     ]);
   });
+
+  it("applies a default catalog timeout in non-live environments when no explicit timeout is set", async () => {
+    await resolveImplicitProviders({
+      agentDir: "/tmp/openclaw-agent",
+      config: {},
+      env: {} as NodeJS.ProcessEnv,
+      explicitProviders: {},
+    });
+
+    const catalogOptions = firstMockArg(mocks.runProviderCatalog, "provider catalog") as {
+      timeoutMs?: number;
+    };
+    expect(catalogOptions?.timeoutMs).toBe(30_000);
+  });
+
+  it("applies a stricter catalog timeout in live test environments when no explicit timeout is set", async () => {
+    await resolveImplicitProviders({
+      agentDir: "/tmp/openclaw-agent",
+      config: {},
+      env: { OPENCLAW_LIVE_TEST: "1" } as NodeJS.ProcessEnv,
+      explicitProviders: {},
+    });
+
+    const catalogOptions = firstMockArg(mocks.runProviderCatalog, "provider catalog") as {
+      timeoutMs?: number;
+    };
+    expect(catalogOptions?.timeoutMs).toBe(15_000);
+  });
+
+  it("respects OPENCLAW_LIVE_PROVIDER_DISCOVERY_TIMEOUT_MS override in any environment", async () => {
+    await resolveImplicitProviders({
+      agentDir: "/tmp/openclaw-agent",
+      config: {},
+      env: { OPENCLAW_LIVE_PROVIDER_DISCOVERY_TIMEOUT_MS: "5000" } as NodeJS.ProcessEnv,
+      explicitProviders: {},
+    });
+
+    const catalogOptions = firstMockArg(mocks.runProviderCatalog, "provider catalog") as {
+      timeoutMs?: number;
+    };
+    expect(catalogOptions?.timeoutMs).toBe(5_000);
+  });
+
+  it("falls back to default timeout when OPENCLAW_LIVE_PROVIDER_DISCOVERY_TIMEOUT_MS is invalid", async () => {
+    for (const invalid of ["abc", "0", "-5", "1.5"]) {
+      vi.clearAllMocks();
+      mocks.resolveRuntimePluginDiscoveryProviders.mockResolvedValue([createProvider("openai")]);
+      mocks.runProviderCatalog.mockResolvedValue(null);
+      await resolveImplicitProviders({
+        agentDir: "/tmp/openclaw-agent",
+        config: {},
+        env: { OPENCLAW_LIVE_PROVIDER_DISCOVERY_TIMEOUT_MS: invalid } as NodeJS.ProcessEnv,
+        explicitProviders: {},
+      });
+      const catalogOptions = firstMockArg(mocks.runProviderCatalog, "provider catalog") as {
+        timeoutMs?: number;
+      };
+      expect(catalogOptions?.timeoutMs, `invalid value "${invalid}"`).toBe(30_000);
+    }
+  });
+
+  it("falls back to live timeout when OPENCLAW_LIVE_PROVIDER_DISCOVERY_TIMEOUT_MS is invalid in a live environment", async () => {
+    await resolveImplicitProviders({
+      agentDir: "/tmp/openclaw-agent",
+      config: {},
+      env: {
+        OPENCLAW_LIVE_PROVIDER_DISCOVERY_TIMEOUT_MS: "bad",
+        LIVE: "1",
+      } as NodeJS.ProcessEnv,
+      explicitProviders: {},
+    });
+
+    const catalogOptions = firstMockArg(mocks.runProviderCatalog, "provider catalog") as {
+      timeoutMs?: number;
+    };
+    expect(catalogOptions?.timeoutMs).toBe(15_000);
+  });
+
+  it("uses OPENCLAW_LIVE_PROVIDER_DISCOVERY_TIMEOUT_MS override even in live environments", async () => {
+    await resolveImplicitProviders({
+      agentDir: "/tmp/openclaw-agent",
+      config: {},
+      env: {
+        OPENCLAW_LIVE_PROVIDER_DISCOVERY_TIMEOUT_MS: "7000",
+        LIVE: "1",
+      } as NodeJS.ProcessEnv,
+      explicitProviders: {},
+    });
+
+    const catalogOptions = firstMockArg(mocks.runProviderCatalog, "provider catalog") as {
+      timeoutMs?: number;
+    };
+    expect(catalogOptions?.timeoutMs).toBe(7_000);
+  });
+
+  it("applies a stricter catalog timeout when OPENCLAW_LIVE_GATEWAY=1", async () => {
+    await resolveImplicitProviders({
+      agentDir: "/tmp/openclaw-agent",
+      config: {},
+      env: { OPENCLAW_LIVE_GATEWAY: "1" } as NodeJS.ProcessEnv,
+      explicitProviders: {},
+    });
+
+    const catalogOptions = firstMockArg(mocks.runProviderCatalog, "provider catalog") as {
+      timeoutMs?: number;
+    };
+    expect(catalogOptions?.timeoutMs).toBe(15_000);
+  });
+
+  it("applies a stricter catalog timeout when LIVE=1", async () => {
+    await resolveImplicitProviders({
+      agentDir: "/tmp/openclaw-agent",
+      config: {},
+      env: { LIVE: "1" } as NodeJS.ProcessEnv,
+      explicitProviders: {},
+    });
+
+    const catalogOptions = firstMockArg(mocks.runProviderCatalog, "provider catalog") as {
+      timeoutMs?: number;
+    };
+    expect(catalogOptions?.timeoutMs).toBe(15_000);
+  });
 });

--- a/src/agents/models-config.providers.implicit.ts
+++ b/src/agents/models-config.providers.implicit.ts
@@ -73,18 +73,25 @@ type ImplicitProviderContext = ImplicitProviderParams & {
   resolveProviderAuth: ProviderAuthResolver;
 };
 
-function resolveLiveProviderCatalogTimeoutMs(env: NodeJS.ProcessEnv): number | null {
+const DEFAULT_PROVIDER_CATALOG_TIMEOUT_MS = 30_000;
+const LIVE_PROVIDER_CATALOG_TIMEOUT_MS = 15_000;
+
+// Provider catalog calls without an explicit providerDiscoveryTimeoutMs get this
+// default. Keeps uncredentialed or slow providers from blocking any discovery
+// caller — gateway startup, CLI model commands, background plan resolution —
+// when no caller-scoped timeout is set.
+// OPENCLAW_LIVE_PROVIDER_DISCOVERY_TIMEOUT_MS overrides the default in any environment.
+function resolveDefaultProviderCatalogTimeoutMs(env: NodeJS.ProcessEnv): number {
+  const raw = env.OPENCLAW_LIVE_PROVIDER_DISCOVERY_TIMEOUT_MS?.trim();
+  if (raw) {
+    const parsed = Number(raw);
+    if (/^[+]?\d+$/.test(raw) && Number.isSafeInteger(parsed) && parsed > 0) {
+      return parsed;
+    }
+  }
   const live =
     env.OPENCLAW_LIVE_TEST === "1" || env.OPENCLAW_LIVE_GATEWAY === "1" || env.LIVE === "1";
-  if (!live) {
-    return null;
-  }
-  const raw = env.OPENCLAW_LIVE_PROVIDER_DISCOVERY_TIMEOUT_MS?.trim();
-  if (!raw) {
-    return 15_000;
-  }
-  const parsed = Number(raw);
-  return /^[+]?\d+$/.test(raw) && Number.isSafeInteger(parsed) && parsed > 0 ? parsed : 15_000;
+  return live ? LIVE_PROVIDER_CATALOG_TIMEOUT_MS : DEFAULT_PROVIDER_CATALOG_TIMEOUT_MS;
 }
 
 function resolveProviderDiscoveryFilter(params: {
@@ -425,7 +432,8 @@ async function resolvePluginImplicitProviders(
           resolveProviderApiKey: resolveCatalogProviderApiKey,
           resolveProviderAuth: (providerId, options) =>
             ctx.resolveProviderAuth(providerId?.trim() || provider.id, options),
-          timeoutMs: ctx.providerDiscoveryTimeoutMs ?? resolveLiveProviderCatalogTimeoutMs(ctx.env),
+          timeoutMs:
+            ctx.providerDiscoveryTimeoutMs ?? resolveDefaultProviderCatalogTimeoutMs(ctx.env),
         });
     if (!result && !useStaticCatalog && provider.staticCatalog) {
       result = await runProviderStaticCatalog({
@@ -491,21 +499,15 @@ function buildPluginCatalogConfig(ctx: ImplicitProviderContext): OpenClawConfig 
 
 async function runProviderCatalogWithTimeout(
   params: Parameters<typeof runProviderCatalog>[0] & {
-    timeoutMs: number | null;
+    timeoutMs: number;
   },
 ): Promise<Awaited<ReturnType<typeof runProviderCatalog>> | undefined> {
-  const catalogRun = runProviderCatalog(params);
-  const timeoutMs = params.timeoutMs ?? undefined;
-  if (!timeoutMs) {
-    return await catalogRun;
-  }
-
-  // Live discovery should not hang startup; timeout means skip this provider,
-  // while non-timeout catalog failures still surface to the caller.
+  const { timeoutMs } = params;
+  // Timeout means skip this provider; non-timeout catalog failures still surface to the caller.
   let timer: ReturnType<typeof setTimeout> | undefined;
   try {
     return await Promise.race([
-      catalogRun,
+      runProviderCatalog(params),
       new Promise<never>((_, reject) => {
         timer = setTimeout(() => {
           reject(


### PR DESCRIPTION
### Summary

- **Problem**: Gateway hangs indefinitely at `[gateway] starting...` when a declared provider (e.g. `openai`, `github-copilot`) has no configured credentials. Regression from v2026.4.26 (`cba92f893d`, "fix(gateway): await startup sidecars by default"), which changed sidecar waiting from opt-in to opt-out; any unresolved provider catalog call in the startup sidecar chain now blocks until SIGKILL.
- **Root Cause**: `resolveLiveProviderCatalogTimeoutMs` returned `null` in non-live environments, and `runProviderCatalogWithTimeout` had a fast path (`if (!timeoutMs) return await catalogRun`) that skipped the race timer entirely. A catalog call for a provider with no credentials — where discovery hits a network endpoint or auth probe that never completes — runs without any time limit. The caller (`resolveImplicitProviders`) has no timeout of its own.
- **Fix**: Rename `resolveLiveProviderCatalogTimeoutMs` to `resolveDefaultProviderCatalogTimeoutMs` and make it always return a `number`: 30 s for non-live environments, 15 s for live (unchanged). `OPENCLAW_LIVE_PROVIDER_DISCOVERY_TIMEOUT_MS` continues to override in any environment. Remove the dead null fast-path from `runProviderCatalogWithTimeout` and narrow the `timeoutMs` parameter type from `number | null` to `number`.
- **What changed**:
  - `src/agents/models-config.providers.implicit.ts` — add `DEFAULT_PROVIDER_CATALOG_TIMEOUT_MS = 30_000` and `LIVE_PROVIDER_CATALOG_TIMEOUT_MS = 15_000` constants; rename and rewrite the timeout resolver; remove the null fast-path; tighten the parameter type.
  - `src/agents/models-config.providers.implicit.discovery-scope.test.ts` — 8 new test cases covering the timeout resolution matrix: default non-live, each of the three live sentinels (`OPENCLAW_LIVE_TEST`, `OPENCLAW_LIVE_GATEWAY`, `LIVE`), valid env-var override, invalid env-var fallback in non-live, invalid env-var fallback in live, and valid override combined with a live flag.
- **What did NOT change (scope boundary)**:
  - Gateway startup callers (`prewarmConfiguredPrimaryModel`, `schedulePrimaryModelPrewarm`) already pass explicit `providerDiscoveryTimeoutMs: 5000` and are unaffected by the new default.
  - On timeout the catalog call logs a WARN and returns `undefined` (provider silently skipped) — this behavior is unchanged; only the previously absent timer is new for non-live callers.
  - Config surface unchanged (no schema, defaults, doctor migrations, or `docs/reference/config`).
  - Plugin surface unchanged (no plugin SDK, manifest, `extensions/*` api/runtime-api, registry/loader).
  - Gateway protocol unchanged.

### Reproduction

1. Declare `openai` or `github-copilot` in `openclaw.json` with no credentials configured.
2. Start gateway: `pnpm openclaw gateway`.
3. **Before this PR**: gateway prints `[gateway] starting...` and hangs; provider catalog call for the uncredentialed provider has no timer; K8s `/readyz` returns 503 (`startupSidecarsReady=false`) and SIGKILL fires after 190 s.
4. **After this PR**: uncredentialed provider catalog call races against a 30 s timer; on timeout a WARN is logged and the provider is skipped; gateway startup continues.

### Real behavior proof

**Behavior addressed (#90886)**: provider catalog calls without an explicit `providerDiscoveryTimeoutMs` now race against a 30 s default timer in production environments; uncredentialed or unresponsive providers are skipped after timeout rather than blocking startup or CLI model resolution indefinitely.

**Real environment tested (Linux, Node 22 — source inspection against HEAD and test execution against the production `resolveImplicitProviders` / `runProviderCatalogWithTimeout` path with mocked `runProviderCatalog`)**: the timeout value passed to the mocked catalog call is asserted directly for every environment combination.

**Exact steps or command run after this patch**: `pnpm test src/agents/models-config.providers.implicit.discovery-scope.test.ts`; `pnpm format:check src/agents/models-config.providers.implicit.ts src/agents/models-config.providers.implicit.discovery-scope.test.ts`; `node scripts/run-oxlint.mjs src/agents/models-config.providers.implicit.ts`.

**Evidence after fix**:

```text
 Test Files  1 passed (1)
      Tests  16 passed (16)
```

The 8 new cases cover: default 30 s in non-live, 15 s for each live sentinel, valid env-var override in non-live, valid override in live, invalid env-var fallback to 30 s in non-live, invalid env-var fallback to 15 s in live.

**Observed result after fix**: `runProviderCatalogWithTimeout` has no null-bypass path; every catalog call without an explicit caller timeout now races against `resolveDefaultProviderCatalogTimeoutMs`; gateway startup callers remain on their existing 5 s explicit timeout and are unaffected.

**What was not tested**: live gateway repro with an uncredentialed provider against a real network endpoint.

### Risk / Mitigation

- **Risk**: callers without an explicit `providerDiscoveryTimeoutMs` that previously waited indefinitely now have a 30 s limit; a slow self-hosted or VPN-gated provider may be skipped on first boot. **Mitigation**: 30 s is generous for provider discovery; operators can shorten or extend it with `OPENCLAW_LIVE_PROVIDER_DISCOVERY_TIMEOUT_MS`; on timeout the provider is skipped with a WARN, not a crash; the next model-config refresh will retry.
- **Risk**: `OPENCLAW_LIVE_PROVIDER_DISCOVERY_TIMEOUT_MS` now applies in production where it previously had no effect. **Mitigation**: the change is additive and backward-compatible; operators who set this variable in live environments are unaffected; the variable name is documented in the function comment.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Core

### Linked Issue/PR

Fixes #90886