### PR TITLE
feat(seltz): add Seltz as a bundled web_search provider

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -464,6 +464,11 @@
       - any-glob-to-any-file:
           - "extensions/senseaudio/**"
           - "docs/providers/senseaudio.md"
+"extensions: seltz":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/seltz/**"
+          - "docs/tools/seltz-search.md"
 "extensions: synthetic":
   - changed-files:
       - any-glob-to-any-file:

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1334,6 +1334,7 @@
                       "tools/parallel-search",
                       "tools/perplexity-search",
                       "tools/searxng-search",
+                      "tools/seltz-search",
                       "tools/tavily"
                     ]
                   }

--- a/docs/reference/secretref-credential-surface.md
+++ b/docs/reference/secretref-credential-surface.md
@@ -52,6 +52,7 @@ Scope intent:
 - `plugins.entries.minimax.config.webSearch.apiKey`
 - `plugins.entries.tavily.config.webSearch.apiKey`
 - `plugins.entries.parallel.config.webSearch.apiKey`
+- `plugins.entries.seltz.config.webSearch.apiKey`
 - `plugins.entries.voice-call.config.realtime.providers.*.apiKey`
 - `plugins.entries.voice-call.config.streaming.providers.*.apiKey`
 - `plugins.entries.voice-call.config.tts.providers.*.apiKey`

--- a/docs/reference/secretref-user-supplied-credentials-matrix.json
+++ b/docs/reference/secretref-user-supplied-credentials-matrix.json
@@ -604,6 +604,13 @@
       "optIn": true
     },
     {
+      "id": "plugins.entries.seltz.config.webSearch.apiKey",
+      "configFile": "openclaw.json",
+      "path": "plugins.entries.seltz.config.webSearch.apiKey",
+      "secretShape": "secret_input",
+      "optIn": true
+    },
+    {
       "id": "plugins.entries.tavily.config.webSearch.apiKey",
       "configFile": "openclaw.json",
       "path": "plugins.entries.tavily.config.webSearch.apiKey",

--- a/docs/tools/seltz-search.md
+++ b/docs/tools/seltz-search.md
@@ -1,0 +1,93 @@
+---
+summary: "Seltz search -- context-engineered web documents for AI reasoning"
+read_when:
+  - You want to use Seltz for web_search
+  - You need a SELTZ_API_KEY
+  - You want context-engineered web documents for AI agents
+title: "Seltz search"
+---
+
+OpenClaw supports [Seltz](https://seltz.ai/) as a `web_search` provider.
+Seltz returns source-backed web documents shaped for AI reasoning.
+
+## Get an API key
+
+<Steps>
+  <Step title="Create an account">
+    Sign up at [seltz.ai](https://seltz.ai/) or open the
+    [Seltz console](https://console.seltz.ai), then generate an API key.
+  </Step>
+  <Step title="Store the key">
+    Set `SELTZ_API_KEY` in the Gateway environment, or configure via:
+
+    ```bash
+    openclaw configure --section web
+    ```
+
+  </Step>
+</Steps>
+
+## Config
+
+```json5
+{
+  plugins: {
+    entries: {
+      seltz: {
+        config: {
+          webSearch: {
+            apiKey: "your-api-key", // optional if SELTZ_API_KEY is set
+            baseUrl: "https://api.seltz.ai", // optional; OpenClaw appends /v1/search
+          },
+        },
+      },
+    },
+  },
+  tools: {
+    web: {
+      search: {
+        provider: "seltz",
+      },
+    },
+  },
+}
+```
+
+**Environment alternative:** set `SELTZ_API_KEY` in the Gateway environment.
+For a gateway install, put it in `~/.openclaw/.env`.
+
+## Base URL override
+
+Set `plugins.entries.seltz.config.webSearch.baseUrl` when Seltz search
+requests should go through a compatible proxy or alternate Seltz endpoint.
+OpenClaw normalizes bare hosts by prepending `https://` and appends
+`/v1/search` unless the path already ends there. The resolved endpoint is
+included in the search cache key, so results from different Seltz endpoints are
+not shared.
+
+## Tool parameters
+
+<ParamField path="query" type="string" required>
+Search query.
+</ParamField>
+
+<ParamField path="count" type="number">
+Results to return (1-10).
+</ParamField>
+
+## Notes
+
+- OpenClaw calls Seltz's `POST /v1/search` endpoint with `query` and
+  `max_results`
+- Result documents are returned as `results[]` with source URLs and wrapped
+  document content in `description`
+- OpenClaw sends an explicit result count so Seltz uses the same default result
+  volume as the generic `web_search` tool: 5 results unless overridden
+- Results are cached for 15 minutes by default (configurable via
+  `cacheTtlMinutes`)
+
+## Related
+
+- [Web Search overview](/tools/web) -- all providers and auto-detection
+- [Exa search](/tools/exa-search) -- neural search with content extraction
+- [Parallel search](/tools/parallel-search) -- dense excerpts ranked for LLM context

--- a/docs/tools/web.md
+++ b/docs/tools/web.md
@@ -93,6 +93,9 @@ local while `web_search` and `x_search` can use xAI Responses under the hood.
   <Card title="SearXNG" icon="server" href="/tools/searxng-search">
     Self-hosted meta-search. No API key needed. Aggregates Google, Bing, DuckDuckGo, and more.
   </Card>
+  <Card title="Seltz" icon="search" href="/tools/seltz-search">
+    Context-engineered web documents with source URLs for AI reasoning.
+  </Card>
   <Card title="Tavily" icon="globe" href="/tools/tavily">
     Structured results with search depth, topic filtering, and `tavily_extract` for URL extraction.
   </Card>
@@ -114,6 +117,7 @@ local while `web_search` and `x_search` can use xAI Responses under the hood.
 | [Parallel](/tools/parallel-search)        | Dense excerpts ranked for LLM context                          | --                                               | `PARALLEL_API_KEY`                                                                      |
 | [Perplexity](/tools/perplexity-search)    | Structured snippets                                            | Country, language, time, domains, content limits | `PERPLEXITY_API_KEY` / `OPENROUTER_API_KEY`                                             |
 | [SearXNG](/tools/searxng-search)          | Structured snippets                                            | Categories, language                             | None (self-hosted)                                                                      |
+| [Seltz](/tools/seltz-search)              | Context-engineered documents                                   | --                                               | `SELTZ_API_KEY`                                                                         |
 | [Tavily](/tools/tavily)                   | Structured snippets                                            | Via `tavily_search` tool                         | `TAVILY_API_KEY`                                                                        |
 
 ## Auto-detection
@@ -189,12 +193,13 @@ API-backed providers first:
 8. **Exa** -- `EXA_API_KEY` or `plugins.entries.exa.config.webSearch.apiKey`; optional `plugins.entries.exa.config.webSearch.baseUrl` overrides the Exa endpoint (order 65)
 9. **Tavily** -- `TAVILY_API_KEY` or `plugins.entries.tavily.config.webSearch.apiKey` (order 70)
 10. **Parallel** -- `PARALLEL_API_KEY` or `plugins.entries.parallel.config.webSearch.apiKey`; optional `plugins.entries.parallel.config.webSearch.baseUrl` overrides the Parallel endpoint (order 75)
+11. **Seltz** -- `SELTZ_API_KEY` or `plugins.entries.seltz.config.webSearch.apiKey`; optional `plugins.entries.seltz.config.webSearch.baseUrl` overrides the Seltz endpoint (order 80)
 
 Key-free fallbacks after that:
 
-11. **DuckDuckGo** -- key-free HTML fallback with no account or API key (order 100)
-12. **Ollama Web Search** -- key-free fallback via your configured local Ollama host when it is reachable and signed in with `ollama signin`; can reuse Ollama provider bearer auth when the host needs it, and can call direct `https://ollama.com` search when configured with `OLLAMA_API_KEY` (order 110)
-13. **SearXNG** -- `SEARXNG_BASE_URL` or `plugins.entries.searxng.config.webSearch.baseUrl` (order 200)
+12. **DuckDuckGo** -- key-free HTML fallback with no account or API key (order 100)
+13. **Ollama Web Search** -- key-free fallback via your configured local Ollama host when it is reachable and signed in with `ollama signin`; can reuse Ollama provider bearer auth when the host needs it, and can call direct `https://ollama.com` search when configured with `OLLAMA_API_KEY` (order 110)
+14. **SearXNG** -- `SEARXNG_BASE_URL` or `plugins.entries.searxng.config.webSearch.baseUrl` (order 200)
 
 If no provider is detected, it falls back to Brave (you will get a missing-key
 error prompting you to configure one).
@@ -203,7 +208,7 @@ error prompting you to configure one).
   All provider key fields support SecretRef objects. Plugin-scoped SecretRefs
   under `plugins.entries.<plugin>.config.webSearch.apiKey` are resolved for the
   bundled API-backed web search providers, including Brave, Exa, Firecrawl,
-  Gemini, Grok, Kimi, MiniMax, Parallel, Perplexity, and Tavily,
+  Gemini, Grok, Kimi, MiniMax, Parallel, Perplexity, Seltz, and Tavily,
   whether the provider is picked explicitly via `tools.web.search.provider` or
   selected through auto-detect. In auto-detect mode, OpenClaw resolves only the
   selected provider key -- non-selected SecretRefs stay inactive, so you can

--- a/extensions/seltz/index.ts
+++ b/extensions/seltz/index.ts
@@ -1,0 +1,11 @@
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+import { createSeltzWebSearchProvider } from "./src/seltz-web-search-provider.js";
+
+export default definePluginEntry({
+  id: "seltz",
+  name: "Seltz Plugin",
+  description: "Bundled Seltz web search plugin",
+  register(api) {
+    api.registerWebSearchProvider(createSeltzWebSearchProvider());
+  },
+});

--- a/extensions/seltz/openclaw.plugin.json
+++ b/extensions/seltz/openclaw.plugin.json
@@ -1,0 +1,50 @@
+{
+  "id": "seltz",
+  "activation": {
+    "onStartup": false
+  },
+  "setup": {
+    "providers": [
+      {
+        "id": "seltz",
+        "envVars": ["SELTZ_API_KEY"]
+      }
+    ]
+  },
+  "uiHints": {
+    "webSearch.apiKey": {
+      "label": "Seltz API Key",
+      "help": "Seltz Search API key (fallback: SELTZ_API_KEY env var).",
+      "sensitive": true,
+      "placeholder": "your-api-key"
+    },
+    "webSearch.baseUrl": {
+      "label": "Seltz Search Base URL",
+      "help": "Optional Seltz API base URL override. OpenClaw appends /v1/search when the URL does not already end there."
+    }
+  },
+  "contracts": {
+    "webSearchProviders": ["seltz"]
+  },
+  "configContracts": {
+    "compatibilityRuntimePaths": ["tools.web.search.apiKey"]
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "webSearch": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "apiKey": {
+            "type": ["string", "object"]
+          },
+          "baseUrl": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/extensions/seltz/package.json
+++ b/extensions/seltz/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@openclaw/seltz-plugin",
+  "version": "2026.6.2",
+  "private": true,
+  "description": "OpenClaw Seltz web search plugin",
+  "type": "module",
+  "devDependencies": {
+    "@openclaw/plugin-sdk": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/seltz/seltz.live.test.ts
+++ b/extensions/seltz/seltz.live.test.ts
@@ -1,0 +1,42 @@
+import { isLiveTestEnabled } from "openclaw/plugin-sdk/test-env";
+import { describe, expect, it } from "vitest";
+import { createSeltzWebSearchProvider } from "./src/seltz-web-search-provider.js";
+
+const SELTZ_API_KEY = process.env.SELTZ_API_KEY?.trim() ?? "";
+const describeLive = isLiveTestEnabled() && SELTZ_API_KEY.length > 0 ? describe : describe.skip;
+
+const SELTZ_LIVE_TIMEOUT_MS = 120_000;
+
+describeLive("seltz plugin live", () => {
+  it(
+    "runs Seltz web search through the provider tool",
+    async () => {
+      const provider = createSeltzWebSearchProvider();
+      const tool = provider.createTool?.({
+        config: {},
+        searchConfig: { seltz: { apiKey: SELTZ_API_KEY } },
+      });
+      if (!tool) {
+        throw new Error("Expected Seltz provider tool");
+      }
+
+      const result = (await tool.execute({
+        query: "OpenClaw GitHub repository",
+        count: 3,
+      })) as {
+        provider?: string;
+        count?: number;
+        results?: Array<{ url?: string; title?: string; description?: string }>;
+      };
+
+      expect(result.provider).toBe("seltz");
+      expect(typeof result.count).toBe("number");
+      expect(Array.isArray(result.results)).toBe(true);
+      expect((result.results ?? []).length).toBeGreaterThan(0);
+      const first = result.results?.[0];
+      expect((first?.url ?? "").startsWith("http")).toBe(true);
+      expect(typeof first?.description).toBe("string");
+    },
+    SELTZ_LIVE_TIMEOUT_MS,
+  );
+});

--- a/extensions/seltz/src/seltz-web-search-provider.runtime.ts
+++ b/extensions/seltz/src/seltz-web-search-provider.runtime.ts
@@ -1,0 +1,279 @@
+import { createRequire } from "node:module";
+import { readPluginPackageVersion } from "openclaw/plugin-sdk/extension-shared";
+import {
+  buildSearchCacheKey,
+  DEFAULT_SEARCH_COUNT,
+  mergeScopedSearchConfig,
+  readCachedSearchPayload,
+  readConfiguredSecretString,
+  readNumberParam,
+  readProviderEnvValue,
+  readStringParam,
+  resolveProviderWebSearchPluginConfig,
+  resolveSearchCacheTtlMs,
+  resolveSearchCount,
+  resolveSearchTimeoutSeconds,
+  resolveSiteName,
+  type SearchConfigRecord,
+  withTrustedWebSearchEndpoint,
+  wrapWebContent,
+  writeCachedSearchPayload,
+} from "openclaw/plugin-sdk/provider-web-search";
+import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+
+const SELTZ_BASE_URL = "https://api.seltz.ai";
+const SELTZ_SEARCH_PATHNAME = "/v1/search";
+
+const require = createRequire(import.meta.url);
+const PLUGIN_VERSION = readPluginPackageVersion({ require });
+const USER_AGENT = `openclaw-seltz/${PLUGIN_VERSION} (${process.platform})`;
+
+type SeltzConfig = {
+  apiKey?: string;
+  baseUrl?: string;
+};
+
+type SeltzSearchResult = {
+  title?: unknown;
+  url?: unknown;
+  content?: unknown;
+  publishedDate?: unknown;
+  published_date?: unknown;
+};
+
+type SeltzSearchResponse = {
+  documents?: unknown;
+};
+
+function resolveSeltzConfig(searchConfig?: SearchConfigRecord): SeltzConfig {
+  const seltz = searchConfig?.seltz;
+  return seltz && typeof seltz === "object" && !Array.isArray(seltz) ? (seltz as SeltzConfig) : {};
+}
+
+function resolveSeltzApiKey(seltz?: SeltzConfig): string | undefined {
+  return (
+    readConfiguredSecretString(seltz?.apiKey, "tools.web.search.seltz.apiKey") ??
+    readProviderEnvValue(["SELTZ_API_KEY"])
+  );
+}
+
+function invalidBaseUrlPayload(value: string) {
+  return {
+    error: "invalid_base_url",
+    message: `plugins.entries.seltz.config.webSearch.baseUrl must be a valid http(s) URL. Got: ${value}`,
+    docs: "https://docs.openclaw.ai/tools/seltz-search",
+  };
+}
+
+function resolveSeltzSearchEndpoint(
+  seltz?: SeltzConfig,
+): { endpoint: string } | { error: string; message: string; docs: string } {
+  const configured = normalizeOptionalString(seltz?.baseUrl);
+  if (!configured) {
+    return { endpoint: `${SELTZ_BASE_URL}${SELTZ_SEARCH_PATHNAME}` };
+  }
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(configured) && !/^https?:\/\//i.test(configured)) {
+    return invalidBaseUrlPayload(configured);
+  }
+  const candidate = /^https?:\/\//i.test(configured) ? configured : `https://${configured}`;
+  let parsed: URL;
+  try {
+    parsed = new URL(candidate);
+  } catch {
+    return invalidBaseUrlPayload(configured);
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return invalidBaseUrlPayload(configured);
+  }
+  const pathname = parsed.pathname.replace(/\/+$/, "");
+  parsed.pathname = pathname.endsWith(SELTZ_SEARCH_PATHNAME)
+    ? pathname
+    : `${pathname === "" ? "" : pathname}${SELTZ_SEARCH_PATHNAME}`;
+  parsed.hash = "";
+  return { endpoint: parsed.toString() };
+}
+
+function normalizeSeltzQuery(value: string | undefined): string | undefined {
+  const trimmed = normalizeOptionalString(value);
+  return trimmed || undefined;
+}
+
+function invalidQueryPayload() {
+  return {
+    error: "invalid_query",
+    message: "query must be a non-empty search string.",
+    docs: "https://docs.openclaw.ai/tools/seltz-search",
+  };
+}
+
+function normalizeSeltzResults(payload: unknown): SeltzSearchResult[] {
+  if (!payload || typeof payload !== "object") {
+    return [];
+  }
+  const documents = (payload as SeltzSearchResponse).documents;
+  if (!Array.isArray(documents)) {
+    return [];
+  }
+  return documents.filter((entry): entry is SeltzSearchResult =>
+    Boolean(
+      entry &&
+      typeof entry === "object" &&
+      !Array.isArray(entry) &&
+      typeof (entry as SeltzSearchResult).url === "string" &&
+      (entry as SeltzSearchResult).url,
+    ),
+  );
+}
+
+function buildSeltzCacheKey(params: { endpoint: string; query: string; count: number }): string {
+  return buildSearchCacheKey(["seltz", params.endpoint, params.query, params.count]);
+}
+
+function missingSeltzKeyPayload() {
+  return {
+    error: "missing_seltz_api_key",
+    message:
+      "web_search (seltz) needs a Seltz API key. Set SELTZ_API_KEY in the Gateway environment, or configure plugins.entries.seltz.config.webSearch.apiKey.",
+    docs: "https://docs.openclaw.ai/tools/seltz-search",
+  };
+}
+
+async function runSeltzSearch(params: {
+  apiKey: string;
+  endpoint: string;
+  query: string;
+  maxResults: number;
+  timeoutSeconds: number;
+}): Promise<SeltzSearchResponse> {
+  const body: Record<string, unknown> = {
+    query: params.query,
+    max_results: params.maxResults,
+  };
+
+  return withTrustedWebSearchEndpoint(
+    {
+      url: params.endpoint,
+      timeoutSeconds: params.timeoutSeconds,
+      init: {
+        method: "POST",
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+          "x-api-key": params.apiKey,
+          "User-Agent": USER_AGENT,
+        },
+        body: JSON.stringify(body),
+      },
+    },
+    async (res) => {
+      if (!res.ok) {
+        const detail = await res.text().catch(() => "");
+        throw new Error(`Seltz API error (${res.status}): ${detail || res.statusText}`);
+      }
+      try {
+        return (await res.json()) as SeltzSearchResponse;
+      } catch (cause) {
+        throw new Error("Seltz API returned malformed JSON", { cause });
+      }
+    },
+  );
+}
+
+export async function executeSeltzWebSearchProviderTool(
+  ctx: { config?: Record<string, unknown>; searchConfig?: SearchConfigRecord },
+  args: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  const searchConfig = mergeScopedSearchConfig(
+    ctx.searchConfig,
+    "seltz",
+    resolveProviderWebSearchPluginConfig(ctx.config, "seltz"),
+  ) as SearchConfigRecord | undefined;
+  const seltzConfig = resolveSeltzConfig(searchConfig);
+  const apiKey = resolveSeltzApiKey(seltzConfig);
+  if (!apiKey) {
+    return missingSeltzKeyPayload();
+  }
+  const endpointResult = resolveSeltzSearchEndpoint(seltzConfig);
+  if ("error" in endpointResult) {
+    return endpointResult;
+  }
+  const endpoint = endpointResult.endpoint;
+
+  const query = normalizeSeltzQuery(readStringParam(args, "query"));
+  if (!query) {
+    return invalidQueryPayload();
+  }
+  const requestedCount =
+    readNumberParam(args, "count", { integer: true }) ??
+    (typeof searchConfig?.maxResults === "number" ? searchConfig.maxResults : undefined);
+  const count = resolveSearchCount(requestedCount, DEFAULT_SEARCH_COUNT);
+  const cacheKey = buildSeltzCacheKey({
+    endpoint,
+    query,
+    count,
+  });
+  const cached = readCachedSearchPayload(cacheKey);
+  if (cached) {
+    return cached;
+  }
+
+  const start = Date.now();
+  const response = await runSeltzSearch({
+    apiKey,
+    endpoint,
+    query,
+    maxResults: count,
+    timeoutSeconds: resolveSearchTimeoutSeconds(searchConfig),
+  });
+  const results = normalizeSeltzResults(response).map((entry) => {
+    const url = typeof entry.url === "string" ? entry.url : "";
+    const siteName = resolveSiteName(url) || undefined;
+    const title = typeof entry.title === "string" ? entry.title : (siteName ?? url);
+    const published =
+      typeof entry.publishedDate === "string" && entry.publishedDate
+        ? entry.publishedDate
+        : typeof entry.published_date === "string" && entry.published_date
+          ? entry.published_date
+          : undefined;
+    const description = typeof entry.content === "string" ? entry.content : "";
+    return Object.assign(
+      {
+        title: title ? wrapWebContent(title, "web_search") : "",
+        url,
+        description: description ? wrapWebContent(description, "web_search") : "",
+        siteName,
+      },
+      published ? { published } : {},
+    );
+  });
+
+  const payload: Record<string, unknown> = {
+    query,
+    provider: "seltz",
+    count: results.length,
+    tookMs: Date.now() - start,
+    externalContent: {
+      untrusted: true,
+      source: "web_search",
+      provider: "seltz",
+      wrapped: true,
+    },
+    results,
+  };
+  writeCachedSearchPayload(cacheKey, payload, resolveSearchCacheTtlMs(searchConfig));
+  return payload;
+}
+
+export const testing = {
+  buildSeltzCacheKey,
+  invalidQueryPayload,
+  missingSeltzKeyPayload,
+  normalizeSeltzQuery,
+  normalizeSeltzResults,
+  resolveSeltzApiKey,
+  resolveSeltzConfig,
+  resolveSeltzSearchEndpoint,
+  USER_AGENT,
+} as const;
+
+export { testing as __testing };

--- a/extensions/seltz/src/seltz-web-search-provider.shared.ts
+++ b/extensions/seltz/src/seltz-web-search-provider.shared.ts
@@ -1,0 +1,26 @@
+import { createWebSearchProviderContractFields } from "openclaw/plugin-sdk/provider-web-search-contract";
+
+const SELTZ_CREDENTIAL_PATH = "plugins.entries.seltz.config.webSearch.apiKey";
+const SELTZ_ONBOARDING_SCOPES: Array<"text-inference"> = ["text-inference"];
+
+export function createSeltzWebSearchProviderBase() {
+  return {
+    id: "seltz",
+    label: "Seltz Search",
+    hint: "Context-engineered web documents for AI reasoning",
+    onboardingScopes: [...SELTZ_ONBOARDING_SCOPES],
+    credentialLabel: "Seltz API key",
+    envVars: ["SELTZ_API_KEY"],
+    placeholder: "your-api-key",
+    signupUrl: "https://console.seltz.ai",
+    docsUrl: "https://docs.openclaw.ai/tools/seltz-search",
+    autoDetectOrder: 80,
+    credentialPath: SELTZ_CREDENTIAL_PATH,
+    ...createWebSearchProviderContractFields({
+      credentialPath: SELTZ_CREDENTIAL_PATH,
+      searchCredential: { type: "scoped", scopeId: "seltz" },
+      configuredCredential: { pluginId: "seltz" },
+      selectionPluginId: "seltz",
+    }),
+  };
+}

--- a/extensions/seltz/src/seltz-web-search-provider.test.ts
+++ b/extensions/seltz/src/seltz-web-search-provider.test.ts
@@ -1,0 +1,345 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type EndpointCall = {
+  url: string;
+  timeoutSeconds: number;
+  init: RequestInit;
+};
+
+const endpointMockState = vi.hoisted(() => ({
+  calls: [] as EndpointCall[],
+  responses: [] as Response[],
+}));
+
+vi.mock("openclaw/plugin-sdk/provider-web-search", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/provider-web-search")>();
+  const runEndpoint = async (
+    params: EndpointCall,
+    run: (response: Response) => Promise<unknown>,
+  ) => {
+    endpointMockState.calls.push(params);
+    const response = endpointMockState.responses.shift();
+    if (!response) {
+      throw new Error("Missing mocked Seltz response.");
+    }
+    return await run(response);
+  };
+  return {
+    ...actual,
+    withTrustedWebSearchEndpoint: vi.fn(runEndpoint),
+  };
+});
+
+function readMockedBody(call: EndpointCall | undefined): unknown {
+  if (!call || typeof call.init.body !== "string") {
+    throw new Error("Expected mocked Seltz request to carry a JSON string body.");
+  }
+  return JSON.parse(call.init.body);
+}
+
+import { testing } from "../test-api.js";
+import { createSeltzWebSearchProvider as createContractSeltzWebSearchProvider } from "../web-search-contract-api.js";
+import { createSeltzWebSearchProvider } from "./seltz-web-search-provider.js";
+
+describe("seltz web search provider", () => {
+  beforeEach(() => {
+    endpointMockState.calls = [];
+    endpointMockState.responses = [];
+  });
+
+  it("exposes the expected metadata and selection wiring", () => {
+    const provider = createSeltzWebSearchProvider();
+    if (!provider.applySelectionConfig) {
+      throw new Error("Expected applySelectionConfig to be defined");
+    }
+    const applied = provider.applySelectionConfig({});
+
+    expect(provider.id).toBe("seltz");
+    expect(provider.onboardingScopes).toEqual(["text-inference"]);
+    expect(provider.credentialPath).toBe("plugins.entries.seltz.config.webSearch.apiKey");
+    expect(provider.envVars).toEqual(["SELTZ_API_KEY"]);
+    expect(provider.autoDetectOrder).toBe(80);
+    const pluginEntry = applied.plugins?.entries?.seltz;
+    if (!pluginEntry) {
+      throw new Error("expected Seltz plugin entry");
+    }
+    expect(pluginEntry.enabled).toBe(true);
+  });
+
+  it("keeps the lightweight contract surface aligned with provider metadata", () => {
+    const provider = createSeltzWebSearchProvider();
+    const contractProvider = createContractSeltzWebSearchProvider();
+    if (!contractProvider.applySelectionConfig) {
+      throw new Error("Expected contract applySelectionConfig to be defined");
+    }
+    const applied = contractProvider.applySelectionConfig({});
+
+    expect({
+      id: contractProvider.id,
+      label: contractProvider.label,
+      hint: contractProvider.hint,
+      onboardingScopes: contractProvider.onboardingScopes,
+      credentialLabel: contractProvider.credentialLabel,
+      envVars: contractProvider.envVars,
+      placeholder: contractProvider.placeholder,
+      signupUrl: contractProvider.signupUrl,
+      docsUrl: contractProvider.docsUrl,
+      autoDetectOrder: contractProvider.autoDetectOrder,
+      credentialPath: contractProvider.credentialPath,
+    }).toEqual({
+      id: provider.id,
+      label: provider.label,
+      hint: provider.hint,
+      onboardingScopes: provider.onboardingScopes,
+      credentialLabel: provider.credentialLabel,
+      envVars: provider.envVars,
+      placeholder: provider.placeholder,
+      signupUrl: provider.signupUrl,
+      docsUrl: provider.docsUrl,
+      autoDetectOrder: provider.autoDetectOrder,
+      credentialPath: provider.credentialPath,
+    });
+    expect(contractProvider.createTool({ config: {}, searchConfig: {} })).toBeNull();
+    const pluginEntry = applied.plugins?.entries?.seltz;
+    if (!pluginEntry) {
+      throw new Error("expected contract Seltz plugin entry");
+    }
+    expect(pluginEntry.enabled).toBe(true);
+  });
+
+  it("prefers scoped configured api keys over environment fallbacks", () => {
+    expect(testing.resolveSeltzApiKey({ apiKey: "seltz-secret" })).toBe("seltz-secret");
+  });
+
+  it("resolves Seltz search base URL overrides", () => {
+    expect(testing.resolveSeltzSearchEndpoint()).toEqual({
+      endpoint: "https://api.seltz.ai/v1/search",
+    });
+    expect(testing.resolveSeltzSearchEndpoint({ baseUrl: "https://proxy.example/seltz" })).toEqual({
+      endpoint: "https://proxy.example/seltz/v1/search",
+    });
+    expect(
+      testing.resolveSeltzSearchEndpoint({ baseUrl: "proxy.example/seltz/v1/search/" }),
+    ).toEqual({
+      endpoint: "https://proxy.example/seltz/v1/search",
+    });
+    expect(testing.resolveSeltzSearchEndpoint({ baseUrl: "ftp://proxy.example/seltz" })).toEqual({
+      docs: "https://docs.openclaw.ai/tools/seltz-search",
+      error: "invalid_base_url",
+      message:
+        "plugins.entries.seltz.config.webSearch.baseUrl must be a valid http(s) URL. Got: ftp://proxy.example/seltz",
+    });
+  });
+
+  it("partitions Seltz cache keys by endpoint, query, and count", () => {
+    const base = {
+      endpoint: "https://api.seltz.ai/v1/search",
+      query: "openclaw github",
+      count: 5,
+    };
+    expect(testing.buildSeltzCacheKey(base)).not.toBe(
+      testing.buildSeltzCacheKey({ ...base, endpoint: "https://proxy.example/seltz/v1/search" }),
+    );
+    expect(testing.buildSeltzCacheKey(base)).not.toBe(
+      testing.buildSeltzCacheKey({ ...base, query: "openclaw release notes" }),
+    );
+    expect(testing.buildSeltzCacheKey(base)).not.toBe(
+      testing.buildSeltzCacheKey({ ...base, count: 10 }),
+    );
+  });
+
+  it("normalizes queries by trimming blanks", () => {
+    expect(testing.normalizeSeltzQuery("  OpenClaw GitHub  ")).toBe("OpenClaw GitHub");
+    expect(testing.normalizeSeltzQuery(undefined)).toBeUndefined();
+    expect(testing.normalizeSeltzQuery("")).toBeUndefined();
+    expect(testing.normalizeSeltzQuery("   ")).toBeUndefined();
+  });
+
+  it("normalizes the Seltz /v1/search response document shape", () => {
+    expect(
+      testing.normalizeSeltzResults({
+        documents: [
+          {
+            url: "https://example.com/a",
+            content: "sample content",
+            publishedDate: "2026-04-01",
+          },
+          { content: "missing url" },
+          "not-an-object",
+        ],
+      }),
+    ).toEqual([
+      {
+        url: "https://example.com/a",
+        content: "sample content",
+        publishedDate: "2026-04-01",
+      },
+    ]);
+    expect(testing.normalizeSeltzResults({})).toEqual([]);
+    expect(testing.normalizeSeltzResults(null)).toEqual([]);
+  });
+
+  it("returns stable setup error payloads", () => {
+    expect(testing.missingSeltzKeyPayload()).toEqual({
+      error: "missing_seltz_api_key",
+      message:
+        "web_search (seltz) needs a Seltz API key. Set SELTZ_API_KEY in the Gateway environment, or configure plugins.entries.seltz.config.webSearch.apiKey.",
+      docs: "https://docs.openclaw.ai/tools/seltz-search",
+    });
+    expect(testing.invalidQueryPayload()).toEqual({
+      error: "invalid_query",
+      message: "query must be a non-empty search string.",
+      docs: "https://docs.openclaw.ai/tools/seltz-search",
+    });
+  });
+
+  it("identifies the plugin via a versioned User-Agent header", () => {
+    expect(testing.USER_AGENT).toMatch(/^openclaw-seltz\/\d+\.\d+\.\d+/);
+  });
+
+  it("returns an error payload when query is missing or empty", async () => {
+    const provider = createSeltzWebSearchProvider();
+    const tool = provider.createTool({
+      config: {},
+      searchConfig: { seltz: { apiKey: "seltz-secret" } },
+    });
+    if (!tool) {
+      throw new Error("Expected tool definition");
+    }
+    expect(await tool.execute({})).toMatchObject({ error: "invalid_query" });
+    expect(await tool.execute({ query: " " })).toMatchObject({ error: "invalid_query" });
+    expect(endpointMockState.calls).toHaveLength(0);
+  });
+
+  it("sends the documented Seltz REST payload shape", async () => {
+    endpointMockState.responses.push(
+      new Response(
+        JSON.stringify({
+          documents: [
+            {
+              url: "https://example.com/a",
+              content: "alpha",
+              publishedDate: "2026-04-01",
+            },
+          ],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    const provider = createSeltzWebSearchProvider();
+    const tool = provider.createTool({
+      config: {},
+      searchConfig: {
+        seltz: { apiKey: "seltz-secret" },
+        maxResults: 3,
+        timeoutSeconds: 5,
+      },
+    });
+    if (!tool) {
+      throw new Error("Expected tool definition");
+    }
+    const result = await tool.execute({
+      query: "OpenClaw GitHub",
+    });
+
+    expect(endpointMockState.calls).toHaveLength(1);
+    const [call] = endpointMockState.calls;
+    expect(call.url).toBe("https://api.seltz.ai/v1/search");
+    expect(call.timeoutSeconds).toBe(5);
+    expect(readMockedBody(call)).toEqual({
+      query: "OpenClaw GitHub",
+      max_results: 3,
+    });
+    const headers = (call.init.headers ?? {}) as Record<string, string>;
+    expect(headers["x-api-key"]).toBe("seltz-secret");
+    expect(headers["User-Agent"]).toMatch(/^openclaw-seltz\//);
+    expect(result).toMatchObject({
+      query: "OpenClaw GitHub",
+      provider: "seltz",
+      count: 1,
+      results: [
+        {
+          title: expect.stringContaining("example.com"),
+          url: "https://example.com/a",
+          description: expect.stringContaining("alpha"),
+          siteName: "example.com",
+          published: "2026-04-01",
+        },
+      ],
+    });
+  });
+
+  it("uses OpenClaw's default result count when no count is provided", async () => {
+    endpointMockState.responses.push(
+      new Response(JSON.stringify({ documents: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    const provider = createSeltzWebSearchProvider();
+    const tool = provider.createTool({
+      config: {},
+      searchConfig: { seltz: { apiKey: "seltz-secret" } },
+    });
+    if (!tool) {
+      throw new Error("Expected tool definition");
+    }
+    await tool.execute({ query: `seltz-default-count-${Date.now()}` });
+    expect(readMockedBody(endpointMockState.calls[0])).toMatchObject({
+      max_results: 5,
+    });
+  });
+
+  it("clamps requested count through the shared web search limit", async () => {
+    endpointMockState.responses.push(
+      new Response(JSON.stringify({ documents: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    const provider = createSeltzWebSearchProvider();
+    const tool = provider.createTool({
+      config: {},
+      searchConfig: { seltz: { apiKey: "seltz-secret" } },
+    });
+    if (!tool) {
+      throw new Error("Expected tool definition");
+    }
+    await tool.execute({ query: `seltz-clamp-${Date.now()}`, count: 99 });
+    expect(readMockedBody(endpointMockState.calls[0])).toMatchObject({
+      max_results: 10,
+    });
+  });
+
+  it("caches identical Seltz searches", async () => {
+    const query = `seltz-cache-${Date.now()}-${Math.random()}`;
+    endpointMockState.responses.push(
+      new Response(
+        JSON.stringify({
+          documents: [{ url: "https://example.com/a", content: "alpha" }],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    const provider = createSeltzWebSearchProvider();
+    const tool = provider.createTool({
+      config: {},
+      searchConfig: { seltz: { apiKey: "seltz-secret" } },
+    });
+    if (!tool) {
+      throw new Error("Expected tool definition");
+    }
+    await tool.execute({ query });
+    const cached = await tool.execute({ query });
+    expect(endpointMockState.calls).toHaveLength(1);
+    expect(cached).toMatchObject({
+      provider: "seltz",
+      results: [
+        {
+          url: "https://example.com/a",
+          description: expect.stringContaining("alpha"),
+        },
+      ],
+    });
+  });
+});

--- a/extensions/seltz/src/seltz-web-search-provider.ts
+++ b/extensions/seltz/src/seltz-web-search-provider.ts
@@ -1,0 +1,46 @@
+import type { WebSearchProviderPlugin } from "openclaw/plugin-sdk/provider-web-search-contract";
+import { createSeltzWebSearchProviderBase } from "./seltz-web-search-provider.shared.js";
+
+const SELTZ_MAX_SEARCH_COUNT = 10;
+
+type SeltzWebSearchRuntime = typeof import("./seltz-web-search-provider.runtime.js");
+
+let seltzWebSearchRuntimePromise: Promise<SeltzWebSearchRuntime> | undefined;
+
+function loadSeltzWebSearchRuntime(): Promise<SeltzWebSearchRuntime> {
+  seltzWebSearchRuntimePromise ??= import("./seltz-web-search-provider.runtime.js");
+  return seltzWebSearchRuntimePromise;
+}
+
+const SeltzSearchSchema = {
+  type: "object",
+  properties: {
+    query: {
+      type: "string",
+      description: "Search query string.",
+    },
+    count: {
+      type: "integer",
+      description: "Number of results to return (1-10).",
+      minimum: 1,
+      maximum: SELTZ_MAX_SEARCH_COUNT,
+    },
+  },
+  required: ["query"],
+  additionalProperties: false,
+} satisfies Record<string, unknown>;
+
+export function createSeltzWebSearchProvider(): WebSearchProviderPlugin {
+  return {
+    ...createSeltzWebSearchProviderBase(),
+    createTool: (ctx) => ({
+      description:
+        "Search the web using Seltz. Returns context-engineered web documents with source URLs for AI reasoning.",
+      parameters: SeltzSearchSchema,
+      execute: async (args) => {
+        const { executeSeltzWebSearchProviderTool } = await loadSeltzWebSearchRuntime();
+        return await executeSeltzWebSearchProviderTool(ctx, args);
+      },
+    }),
+  };
+}

--- a/extensions/seltz/test-api.ts
+++ b/extensions/seltz/test-api.ts
@@ -1,0 +1,1 @@
+export { testing, testing as __testing } from "./src/seltz-web-search-provider.runtime.js";

--- a/extensions/seltz/tsconfig.json
+++ b/extensions/seltz/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../tsconfig.package-boundary.base.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["./*.ts", "./src/**/*.ts"],
+  "exclude": [
+    "./**/*.test.ts",
+    "./dist/**",
+    "./node_modules/**",
+    "./src/test-support/**",
+    "./src/**/*test-helpers.ts",
+    "./src/**/*test-harness.ts",
+    "./src/**/*test-support.ts"
+  ]
+}

--- a/extensions/seltz/web-search-contract-api.ts
+++ b/extensions/seltz/web-search-contract-api.ts
@@ -1,0 +1,9 @@
+import type { WebSearchProviderPlugin } from "openclaw/plugin-sdk/provider-web-search-contract";
+import { createSeltzWebSearchProviderBase } from "./src/seltz-web-search-provider.shared.js";
+
+export function createSeltzWebSearchProvider(): WebSearchProviderPlugin {
+  return {
+    ...createSeltzWebSearchProviderBase(),
+    createTool: () => null,
+  };
+}

--- a/extensions/seltz/web-search-provider.ts
+++ b/extensions/seltz/web-search-provider.ts
@@ -1,0 +1,1 @@
+export { createSeltzWebSearchProvider } from "./src/seltz-web-search-provider.js";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1420,6 +1420,12 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
 
+  extensions/seltz:
+    devDependencies:
+      '@openclaw/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../packages/plugin-sdk
+
   extensions/sglang:
     devDependencies:
       '@openclaw/plugin-sdk':

--- a/src/commands/doctor/shared/legacy-web-search-migrate.ts
+++ b/src/commands/doctor/shared/legacy-web-search-migrate.ts
@@ -23,12 +23,13 @@ const BUNDLED_LEGACY_WEB_SEARCH_OWNERS = new Map<string, string>([
   ["parallel", "parallel"],
   ["perplexity", "perplexity"],
   ["searxng", "searxng"],
+  ["seltz", "seltz"],
   ["tavily", "tavily"],
 ]);
 
-// Tavily and Parallel only ever used the plugin-owned config path, so there is
-// no legacy `tools.web.search.<id>.*` shape to migrate for them.
-const NON_MIGRATED_LEGACY_WEB_SEARCH_PROVIDER_IDS = new Set(["parallel", "tavily"]);
+// Tavily, Parallel, and Seltz only ever used the plugin-owned config path, so
+// there is no legacy `tools.web.search.<id>.*` shape to migrate for them.
+const NON_MIGRATED_LEGACY_WEB_SEARCH_PROVIDER_IDS = new Set(["parallel", "seltz", "tavily"]);
 const LEGACY_GLOBAL_WEB_SEARCH_PROVIDER_ID = "brave";
 
 function getBundledLegacyWebSearchOwners(): ReadonlyMap<string, string> {

--- a/src/plugin-sdk/test-helpers/plugin-registration-contract-cases.ts
+++ b/src/plugin-sdk/test-helpers/plugin-registration-contract-cases.ts
@@ -223,6 +223,10 @@ export const pluginRegistrationContractCases = {
     pluginId: "senseaudio",
     mediaUnderstandingProviderIds: ["senseaudio"],
   },
+  seltz: {
+    pluginId: "seltz",
+    webSearchProviderIds: ["seltz"],
+  },
   tavily: {
     pluginId: "tavily",
     webSearchProviderIds: ["tavily"],

--- a/src/plugins/contracts/plugin-registration.seltz.contract.test.ts
+++ b/src/plugins/contracts/plugin-registration.seltz.contract.test.ts
@@ -1,0 +1,4 @@
+import { pluginRegistrationContractCases } from "openclaw/plugin-sdk/plugin-test-contracts";
+import { describePluginRegistrationContract } from "openclaw/plugin-sdk/plugin-test-contracts";
+
+describePluginRegistrationContract(pluginRegistrationContractCases.seltz);

--- a/src/plugins/contracts/providers.contract.test.ts
+++ b/src/plugins/contracts/providers.contract.test.ts
@@ -25,6 +25,7 @@ for (const providerId of [
   "moonshot",
   "parallel",
   "perplexity",
+  "seltz",
   "tavily",
   "xai",
 ] as const) {

--- a/src/plugins/web-search-providers.runtime.test.ts
+++ b/src/plugins/web-search-providers.runtime.test.ts
@@ -22,6 +22,7 @@ const BUNDLED_WEB_SEARCH_PROVIDERS = [
   { pluginId: "exa", id: "exa", order: 65 },
   { pluginId: "tavily", id: "tavily", order: 70 },
   { pluginId: "parallel", id: "parallel", order: 75 },
+  { pluginId: "seltz", id: "seltz", order: 80 },
   { pluginId: "duckduckgo", id: "duckduckgo", order: 100 },
 ] as const;
 
@@ -54,6 +55,7 @@ const EXPECTED_BUNDLED_RUNTIME_WEB_SEARCH_PROVIDER_KEYS = [
   "moonshot:kimi",
   "parallel:parallel",
   "perplexity:perplexity",
+  "seltz:seltz",
   "tavily:tavily",
 ] as const;
 

--- a/test/vitest/vitest.extension-misc-paths.mjs
+++ b/test/vitest/vitest.extension-misc-paths.mjs
@@ -19,6 +19,7 @@ export const miscExtensionTestRoots = [
   "extensions/perplexity",
   "extensions/phone-control",
   "extensions/searxng",
+  "extensions/seltz",
   "extensions/synthetic",
   "extensions/tavily",
   "extensions/thread-ownership",


### PR DESCRIPTION

gif showing seltz search in action: 
<img width="1280" height="692" alt="seltz-openclaw" src="https://github.com/user-attachments/assets/f73fda51-5db0-4b25-b6c8-a12f42e1b60a" />


gif selecting seltz as the web search provider:
<img width="1280" height="692" alt="seltz-openclaw-config" src="https://github.com/user-attachments/assets/b91b2b5e-c793-4e99-8735-86a72877ba0e" />


## Summary

- **Problem:** OpenClaw does not have a bundled `web_search` provider for Seltz.
- **Solution:** Add `extensions/seltz/` as a bundled web-search provider. It authenticates with `SELTZ_API_KEY` or `plugins.entries.seltz.config.webSearch.apiKey`, calls Seltz `POST /v1/search`, and returns source-backed documents through OpenClaw's generic `web_search` contract.
- **What changed:** New plugin package, runtime provider, unit/live tests, registration contract coverage, provider registry coverage, docs page, docs nav, labeler entry, SecretRef matrix entry, and legacy web-search migration bookkeeping.
- **What did NOT change:** No core architecture changes. No new SDK surface. Existing web-search providers are untouched. `CHANGELOG.md` left to release automation.

## Motivation

Seltz provides real-time web knowledge APIs for agents, returning source URLs and document content that fits OpenClaw's existing `web_search` result shape. This adds Seltz as another selectable provider alongside Brave, Exa, Parallel, Perplexity, SearXNG, Tavily, and the other bundled providers.

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Real behavior proof

<!-- Attach screenshot: configure/onboard search provider list showing Seltz -->
<!-- Attach screenshot: TUI web_search run showing provider: seltz -->

Behavior addressed: Added Seltz as a selectable `web_search` provider in OpenClaw.

Real environment tested: Local OpenClaw checkout on branch `feat/seltz-web-search`, using a real Seltz API key via `SELTZ_API_KEY`, local embedded TUI, and `openclaw infer web search`.

Exact steps or command run after this patch:

```bash
pnpm openclaw config set tools.web.search.enabled true --strict-json
pnpm openclaw config set tools.web.search.provider seltz
pnpm openclaw config set tools.web.search.openaiCodex.enabled false --strict-json
pnpm openclaw config set tools.web.fetch.enabled false --strict-json
pnpm openclaw config set tools.allow '["web_search"]' --strict-json

pnpm openclaw infer web search \
  --provider seltz \
  --query "latest news about Seltz AI" \
  --limit 3 \
  --json
```

Evidence after fix: `openclaw infer web search --provider seltz` returned `ok: true`, `capability: "web.search"`, `transport: "local"`, `provider: "seltz"`, and `result.provider: "seltz"`. A TUI run with managed `web_search` also returned `provider: seltz` from the tool result.

Observed result after fix: Web search routes through Seltz and returns normalized results with title, URL, wrapped document content in `description`, `count`, and `externalContent.provider: "seltz"`.

What was not tested: Non-TUI channel paths such as Discord/Telegram. Long-running cache TTL expiry. Alternate `baseUrl` against a real proxy.

## Regression Test Plan

Coverage added:

- Unit: `extensions/seltz/src/seltz-web-search-provider.test.ts`
- Live: `extensions/seltz/seltz.live.test.ts`
- Plugin registration contract: `src/plugins/contracts/plugin-registration.seltz.contract.test.ts`
- Web-search provider registry contract: `src/plugins/contracts/providers.contract.test.ts`
- Runtime bundled provider list: `src/plugins/web-search-providers.runtime.test.ts`
- Legacy web-search migration bookkeeping: `src/commands/doctor/shared/legacy-web-search-migrate.test.ts`

Verification run:

```bash
node scripts/run-vitest.mjs \
  extensions/seltz/src/seltz-web-search-provider.test.ts \
  src/plugins/contracts/plugin-registration.seltz.contract.test.ts \
  src/plugins/contracts/providers.contract.test.ts \
  src/plugins/web-search-providers.runtime.test.ts \
  src/commands/doctor/shared/legacy-web-search-migrate.test.ts

OPENCLAW_LIVE_TEST=1 node scripts/run-vitest.mjs \
  --config test/vitest/vitest.live.config.ts \
  extensions/seltz/seltz.live.test.ts

git diff --check
node scripts/docs-list.js | rg 'tools/seltz-search|tools/web.md|seltz'
```

## User-visible / Behavior Changes

- New `web_search` provider option: `seltz`
- New env var support: `SELTZ_API_KEY`
- New plugin config path: `plugins.entries.seltz.config.webSearch.apiKey`
- Optional base URL override: `plugins.entries.seltz.config.webSearch.baseUrl`
- New docs page: `https://docs.openclaw.ai/tools/seltz-search`
- Search provider picker can discover Seltz through the provider registration contract.

## Security Impact

- **New permissions/capabilities?** No.
- **Secrets/tokens handling changed?** No. Seltz uses the existing plugin web-search credential path and `SELTZ_API_KEY`.
- **New/changed network calls?** Yes, outbound HTTPS to `api.seltz.ai` or a configured Seltz-compatible base URL.
- **Command/tool execution surface changed?** No.
- **Data access scope changed?** No.
- **Risk + mitigation:** Adds one outbound search API host. Requests go through OpenClaw's trusted web-search endpoint guard, and returned web content is wrapped as untrusted external content before reaching the model.

## Compatibility / Migration

- **Backward compatible?** Yes, purely additive.
- **Config/env changes?** Optional `SELTZ_API_KEY` and optional plugin-owned `webSearch` config.
- **Migration needed?** No user migration. Seltz did not have a shipped legacy provider path.
- **Upgrade steps:** None.