### PR TITLE
fix(codex): strengthen agent soul adherence

### DIFF
--- a/extensions/codex/src/app-server/attempt-context.ts
+++ b/extensions/codex/src/app-server/attempt-context.ts
@@ -701,16 +701,8 @@ function renderCodexWorkspaceCollaborationDeveloperInstructions(
   return renderCodexWorkspaceDeveloperInstructions({
     files,
     header: "## OpenClaw Agent Soul",
-    preamble: [
-      "Treat the content inside `<AGENT_SOUL>` as standing developer instructions for this active agent's identity, voice, personality, user relationship, and collaboration style.",
-      "Apply these instructions on every turn unless they conflict with higher-priority system or developer instructions, safety rules, explicit user task requirements, tool contracts, or required output formats.",
-      "Personality guidance controls how the assistant communicates. Collaboration guidance controls how the assistant works. These files are instruction context, not quoted user data.",
-      "",
-      "File purposes:",
-      "- `IDENTITY.md` defines the agent's stable identity, role, name, and purpose.",
-      "- `SOUL.md` defines the agent's personality, tone, stance, and collaboration style.",
-      "- `USER.md` defines durable user context, preferences, relationship notes, and local expectations.",
-    ].join("\n"),
+    preamble:
+      "OpenClaw loaded these workspace instruction files from the active agent workspace. Treat the `<AGENT_SOUL>` block as authoritative developer-instruction context defining who you are, how you think and work, how you communicate, and the human you work alongside; internalize and follow it accordingly.",
     wrapperTag: "AGENT_SOUL",
   });
 }

--- a/extensions/codex/src/app-server/attempt-context.ts
+++ b/extensions/codex/src/app-server/attempt-context.ts
@@ -701,8 +701,16 @@ function renderCodexWorkspaceCollaborationDeveloperInstructions(
   return renderCodexWorkspaceDeveloperInstructions({
     files,
     header: "## OpenClaw Agent Soul",
-    preamble:
-      "OpenClaw loaded these workspace instruction files from the active agent workspace. They are the canonical definitions of who you are, how you think and work, and the human you work alongside. Internalize and follow them accordingly.",
+    preamble: [
+      "Treat the content inside `<AGENT_SOUL>` as standing developer instructions for this active agent's identity, voice, personality, user relationship, and collaboration style.",
+      "Apply these instructions on every turn unless they conflict with higher-priority system or developer instructions, safety rules, explicit user task requirements, tool contracts, or required output formats.",
+      "Personality guidance controls how the assistant communicates. Collaboration guidance controls how the assistant works. These files are instruction context, not quoted user data.",
+      "",
+      "File purposes:",
+      "- `IDENTITY.md` defines the agent's stable identity, role, name, and purpose.",
+      "- `SOUL.md` defines the agent's personality, tone, stance, and collaboration style.",
+      "- `USER.md` defines durable user context, preferences, relationship notes, and local expectations.",
+    ].join("\n"),
     wrapperTag: "AGENT_SOUL",
   });
 }

--- a/extensions/codex/src/app-server/attempt-context.ts
+++ b/extensions/codex/src/app-server/attempt-context.ts
@@ -702,7 +702,7 @@ function renderCodexWorkspaceCollaborationDeveloperInstructions(
     files,
     header: "## OpenClaw Agent Soul",
     preamble:
-      "OpenClaw loaded these workspace instruction files from the active agent workspace. Treat the `<AGENT_SOUL>` block as authoritative developer-instruction context defining who you are, how you think and work, how you communicate, and the human you work alongside; internalize and follow it accordingly.",
+      "OpenClaw loaded these workspace instruction files from the active agent workspace. Treat the `<AGENT_SOUL>` block as authoritative context defining who you are, how you think and work, how you communicate, and the human you work alongside; internalize and follow it accordingly.",
     wrapperTag: "AGENT_SOUL",
   });
 }

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -2062,13 +2062,6 @@ describe("runCodexAppServerAttempt", () => {
     expect(collaborationInstructions).toContain("# Collaboration Mode: Default");
     expect(collaborationInstructions).toContain("request_user_input availability");
     expect(collaborationInstructions).toContain("OpenClaw Agent Soul");
-    expect(collaborationInstructions).toContain(
-      "standing developer instructions for this active agent's identity, voice, personality, user relationship, and collaboration style",
-    );
-    expect(collaborationInstructions).toContain("File purposes:");
-    expect(collaborationInstructions).toContain(
-      "`SOUL.md` defines the agent's personality, tone, stance, and collaboration style.",
-    );
     expect(collaborationInstructions).toContain("<AGENT_SOUL>");
     expect(collaborationInstructions).toContain("</AGENT_SOUL>");
     expect(collaborationInstructions).toContain(soulGuidance);
@@ -2187,10 +2180,6 @@ describe("runCodexAppServerAttempt", () => {
     const collaborationInstructions =
       turnStartParams.collaborationMode?.settings?.developer_instructions ?? "";
     expect(collaborationInstructions).toContain("OpenClaw Agent Soul");
-    expect(collaborationInstructions).toContain("These files are instruction context");
-    expect(collaborationInstructions).toContain(
-      "`USER.md` defines durable user context, preferences, relationship notes, and local expectations.",
-    );
     expect(collaborationInstructions).toContain("<AGENT_SOUL>");
     expect(collaborationInstructions).toContain("</AGENT_SOUL>");
     expect(collaborationInstructions).toContain(soulGuidance);

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -2062,6 +2062,13 @@ describe("runCodexAppServerAttempt", () => {
     expect(collaborationInstructions).toContain("# Collaboration Mode: Default");
     expect(collaborationInstructions).toContain("request_user_input availability");
     expect(collaborationInstructions).toContain("OpenClaw Agent Soul");
+    expect(collaborationInstructions).toContain(
+      "standing developer instructions for this active agent's identity, voice, personality, user relationship, and collaboration style",
+    );
+    expect(collaborationInstructions).toContain("File purposes:");
+    expect(collaborationInstructions).toContain(
+      "`SOUL.md` defines the agent's personality, tone, stance, and collaboration style.",
+    );
     expect(collaborationInstructions).toContain("<AGENT_SOUL>");
     expect(collaborationInstructions).toContain("</AGENT_SOUL>");
     expect(collaborationInstructions).toContain(soulGuidance);
@@ -2180,6 +2187,10 @@ describe("runCodexAppServerAttempt", () => {
     const collaborationInstructions =
       turnStartParams.collaborationMode?.settings?.developer_instructions ?? "";
     expect(collaborationInstructions).toContain("OpenClaw Agent Soul");
+    expect(collaborationInstructions).toContain("These files are instruction context");
+    expect(collaborationInstructions).toContain(
+      "`USER.md` defines durable user context, preferences, relationship notes, and local expectations.",
+    );
     expect(collaborationInstructions).toContain("<AGENT_SOUL>");
     expect(collaborationInstructions).toContain("</AGENT_SOUL>");
     expect(collaborationInstructions).toContain(soulGuidance);


### PR DESCRIPTION
## Summary

- Strengthen the existing Codex app-server `AGENT_SOUL` preamble in one line.
- Name the failure mode this is meant to reduce: after longer interactions, persona and collaboration traits from workspace soul files can fade and the model can drift back toward generic assistant behavior.
- Keep the scope surgical: no file-purpose legend, no per-turn/loading wording, no redundant developer wording, and no test-only assertions.

## Real behavior proof

Behavior addressed: Native Codex app-server turns now tell the model to treat `<AGENT_SOUL>` as authoritative context for identity, communication, work style, and the human relationship, reducing ambiguity when later user messages or long interactions pull toward generic GPT behavior.

Real environment tested: Local OpenClaw checkout on macOS, branch `fix/codex-agent-soul-preamble`.

Exact steps or command run after this patch: `pnpm test extensions/codex/src/app-server/run-attempt.test.ts extensions/codex/src/app-server/thread-lifecycle.test.ts`; `pnpm prompt:snapshots:check`; `git diff --check`; inspected sibling Codex source under `../codex/codex-rs/app-server/src/request_processors/turn_processor.rs` and `../codex/codex-rs/core/src/session/mod.rs` for collaboration-mode prompt handling.

Evidence after fix: Focused Codex app-server tests passed: 2 files, 138 tests. Prompt snapshots are current. Diff check is clean. Final PR diff is one production line in `extensions/codex/src/app-server/attempt-context.ts`.

Observed result after fix: The final diff only replaces the existing `AGENT_SOUL` preamble sentence; it no longer contains `File purposes:`, an `Apply these instructions on every turn` line, or redundant developer wording.

What was not tested: No live Codex app-server/Gateway run and no deployment.

## Verification

- `pnpm test extensions/codex/src/app-server/run-attempt.test.ts extensions/codex/src/app-server/thread-lifecycle.test.ts`
- `pnpm prompt:snapshots:check`
- `git diff --check`
