### PR TITLE
fix(feishu): report transport activity (connected/lastEventAt) for health monitor

### DIFF
--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -14,6 +14,7 @@ import { createChatChannelPlugin } from "openclaw/plugin-sdk/channel-core";
 import {
   defineChannelMessageAdapter,
   createRuntimeOutboundDelegates,
+  createAccountStatusSink,
   type ChannelMessageSendResult,
   type MessageReceiptPartKind,
 } from "openclaw/plugin-sdk/channel-outbound";
@@ -1318,6 +1319,12 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
           ctx.log?.info(
             `starting feishu[${ctx.accountId}] (mode: ${account.config?.connectionMode ?? "websocket"})`,
           );
+          // Publish Feishu connected state and event recency through the
+          // shared channel status sink.
+          const statusSink = createAccountStatusSink({
+            accountId: ctx.accountId,
+            setStatus: ctx.setStatus,
+          });
           return monitorFeishuProvider({
             config: ctx.cfg,
             runtime: ctx.runtime,
@@ -1326,6 +1333,7 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
             channelRuntime: ctx.channelRuntime as PluginRuntime["channel"] | undefined,
             abortSignal: ctx.abortSignal,
             accountId: ctx.accountId,
+            statusSink,
           });
         },
       },

--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -20,6 +20,7 @@ import {
 import { applyBotIdentityState, startBotIdentityRecovery } from "./monitor.bot-identity.js";
 import { createFeishuBotMenuHandler } from "./monitor.bot-menu-handler.js";
 import { createFeishuDriveCommentNoticeHandler } from "./monitor.comment-notice-handler.js";
+import type { FeishuStatusSink } from "./monitor.js";
 import { createFeishuMessageReceiveHandler } from "./monitor.message-handler.js";
 import { fetchBotIdentityForMonitor } from "./monitor.startup.js";
 import { botNames, botOpenIds } from "./monitor.state.js";
@@ -170,6 +171,12 @@ type RegisterEventHandlersContext = {
   runtime?: RuntimeEnv;
   chatHistories: Map<string, HistoryEntry[]>;
   fireAndForget?: boolean;
+  /**
+   * Optional status sink. When provided, the message handler will publish
+   * `lastEventAt` on every inbound message for message recency. Transport
+   * liveness is published by the transport layer.
+   */
+  statusSink?: FeishuStatusSink;
 };
 
 function parseFeishuBotAddedEventPayload(value: unknown): FeishuBotAddedEvent | null {
@@ -304,6 +311,7 @@ function registerEventHandlers(
       getBotOpenId: (id) => botOpenIds.get(id),
       getBotName: (id) => botNames.get(id),
       resolveSequentialKey: getFeishuSequentialKey,
+      ...(context.statusSink ? { statusSink: context.statusSink } : {}),
     }),
     "im.message.message_read_v1": async () => {
       // Ignore read receipts
@@ -449,6 +457,12 @@ export type MonitorSingleAccountParams = {
   abortSignal?: AbortSignal;
   botOpenIdSource?: BotOpenIdSource;
   fireAndForget?: boolean;
+  /**
+   * Optional status sink for Feishu channel health. When provided, it is
+   * propagated to the event dispatcher for message recency and the transport
+   * layer for lifecycle status.
+   */
+  statusSink?: FeishuStatusSink;
 };
 
 export async function monitorSingleAccount(params: MonitorSingleAccountParams): Promise<void> {
@@ -495,12 +509,27 @@ export async function monitorSingleAccount(params: MonitorSingleAccountParams): 
       runtime,
       chatHistories,
       fireAndForget: params.fireAndForget ?? true,
+      ...(params.statusSink ? { statusSink: params.statusSink } : {}),
     });
 
     if (connectionMode === "webhook") {
-      return await monitorWebhook({ account, accountId, runtime, abortSignal, eventDispatcher });
+      return await monitorWebhook({
+        account,
+        accountId,
+        runtime,
+        abortSignal,
+        eventDispatcher,
+        ...(params.statusSink ? { statusSink: params.statusSink } : {}),
+      });
     }
-    return await monitorWebSocket({ account, accountId, runtime, abortSignal, eventDispatcher });
+    return await monitorWebSocket({
+      account,
+      accountId,
+      runtime,
+      abortSignal,
+      eventDispatcher,
+      ...(params.statusSink ? { statusSink: params.statusSink } : {}),
+    });
   } finally {
     threadBindingManager?.stop();
   }

--- a/extensions/feishu/src/monitor.message-handler.ts
+++ b/extensions/feishu/src/monitor.message-handler.ts
@@ -53,6 +53,12 @@ type FeishuMessageReceiveHandlerContext = {
     botOpenId?: string;
     botName?: string;
   }) => string;
+  /**
+   * Optional status sink. When provided, the handler will publish `lastEventAt`
+   * on every inbound message for message recency. Transport liveness is
+   * published by the transport layer.
+   */
+  statusSink?: import("./monitor.js").FeishuStatusSink;
 };
 
 function normalizeFeishuChatType(value: unknown): FeishuChatType | undefined {
@@ -170,6 +176,7 @@ export function createFeishuMessageReceiveHandler({
   getBotName = () => undefined,
   resolveSequentialKey = ({ accountId: accountIdLocal, event }) =>
     `feishu:${accountIdLocal}:${event.message.chat_id?.trim() || "unknown"}`,
+  statusSink,
 }: FeishuMessageReceiveHandlerContext): (data: unknown) => Promise<void> {
   const inboundDebounceMs = channelRuntime.debounce.resolveInboundDebounceMs({
     cfg,
@@ -318,6 +325,13 @@ export function createFeishuMessageReceiveHandler({
   });
 
   return async (data) => {
+    // Publish message recency before dedupe/debounce; transport liveness is
+    // owned by the WebSocket/Webhook lifecycle monitors.
+    const inboundAt = Date.now();
+    statusSink?.({
+      lastEventAt: inboundAt,
+    });
+
     const event = parseFeishuMessageEventPayload(data);
     if (!event) {
       error(`feishu[${accountId}]: ignoring malformed message event payload`);

--- a/extensions/feishu/src/monitor.transport-status.test.ts
+++ b/extensions/feishu/src/monitor.transport-status.test.ts
@@ -1,0 +1,232 @@
+// Tests for status publishing in monitorWebSocket and monitorWebhook. These
+// tests exercise the status sink wiring used by the gateway health monitor.
+// See PROPOSAL.md for the incident background.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+type StatusPatch = {
+  connected?: boolean;
+  lastConnectedAt?: number | null;
+  lastEventAt?: number | null;
+  lastTransportActivityAt?: number | null;
+  lastError?: string | null;
+};
+
+type StatusSink = (patch: StatusPatch) => void;
+
+function createRecordingSink(): { sink: StatusSink; calls: StatusPatch[] } {
+  const calls: StatusPatch[] = [];
+  return {
+    sink: (patch) => {
+      calls.push(patch);
+    },
+    calls,
+  };
+}
+
+async function loadTransportModule() {
+  return await import("./monitor.transport.js");
+}
+
+describe("monitorWebSocket status publishing", () => {
+  let originalNow: () => number;
+  let nowValue: number;
+
+  beforeEach(() => {
+    nowValue = 1_700_000_000_000;
+    originalNow = Date.now;
+    Date.now = () => nowValue;
+  });
+
+  afterEach(() => {
+    Date.now = originalNow;
+    vi.restoreAllMocks();
+  });
+
+  it("publishes connected state when the WS SDK reports ready or reconnected", async () => {
+    const recorder = createRecordingSink();
+    const fakeWsClient = {
+      start: vi.fn(async () => undefined),
+      close: vi.fn(),
+    };
+    const { monitorWebSocket } = await loadTransportModule();
+
+    const account = {
+      accountId: "acct-1",
+      appId: "app",
+      appSecret: "secret",
+      domain: "https://open.feishu.cn",
+      encryptKey: undefined,
+      verificationToken: undefined,
+      config: { connectionMode: "websocket" as const },
+    } as never;
+
+    const abortController = new AbortController();
+
+    // Start the monitor in background; it will call createFeishuWSClient.
+    const wsClientModule = await import("./client.js");
+    let callbacks:
+      | {
+          onReady?: () => void;
+          onReconnected?: () => void;
+          onReconnecting?: () => void;
+        }
+      | undefined;
+    vi.spyOn(wsClientModule, "createFeishuWSClient").mockImplementation(
+      async (_account, nextCallbacks) => {
+        callbacks = nextCallbacks as typeof callbacks;
+        return fakeWsClient as never;
+      },
+    );
+
+    const monitorPromise = monitorWebSocket({
+      account,
+      accountId: "acct-1",
+      abortSignal: abortController.signal,
+      eventDispatcher: { register: () => undefined } as never,
+      statusSink: recorder.sink,
+    });
+
+    // Let the WS handshake complete.
+    await new Promise<void>((resolve) => {
+      setImmediate(() => resolve());
+    });
+    expect(recorder.calls).toEqual([]);
+
+    callbacks?.onReady?.();
+    const first = recorder.calls[0];
+    expect(first?.connected).toBe(true);
+    expect(first?.lastConnectedAt).toBe(nowValue);
+    expect(first?.lastEventAt).toBe(nowValue);
+    expect(first?.lastTransportActivityAt).toBeUndefined();
+    expect(first?.lastError).toBeNull();
+
+    nowValue += 1_000;
+    callbacks?.onReconnected?.();
+    const second = recorder.calls[1];
+    expect(second?.connected).toBe(true);
+    expect(second?.lastConnectedAt).toBe(nowValue);
+    expect(second?.lastEventAt).toBe(nowValue);
+    expect(second?.lastTransportActivityAt).toBeUndefined();
+    expect(second?.lastError).toBeNull();
+
+    nowValue += 1_000;
+    callbacks?.onReconnecting?.();
+    const third = recorder.calls[2];
+    expect(third?.connected).toBe(false);
+    expect(third?.lastEventAt).toBe(nowValue);
+    expect(third?.lastTransportActivityAt).toBeUndefined();
+
+    // Trigger abort to terminate the monitor cleanly.
+    abortController.abort();
+    await monitorPromise;
+  });
+
+  it("publishes disconnected when WS handshake throws", async () => {
+    const recorder = createRecordingSink();
+    const { monitorWebSocket } = await loadTransportModule();
+
+    const account = {
+      accountId: "acct-2",
+      appId: "app",
+      appSecret: "secret",
+      domain: "https://open.feishu.cn",
+      encryptKey: undefined,
+      verificationToken: undefined,
+      config: { connectionMode: "websocket" as const },
+    } as never;
+
+    const abortController = new AbortController();
+    const wsClientModule = await import("./client.js");
+    vi.spyOn(wsClientModule, "createFeishuWSClient").mockRejectedValue(new Error("boom"));
+
+    // Pre-abort so the monitor exits after the first failed attempt.
+    setImmediate(() => abortController.abort());
+
+    const monitorPromise = monitorWebSocket({
+      account,
+      accountId: "acct-2",
+      abortSignal: abortController.signal,
+      eventDispatcher: { register: () => undefined } as never,
+      statusSink: recorder.sink,
+    });
+
+    await monitorPromise;
+
+    const disconnected = recorder.calls.find((c) => c.connected === false);
+    expect(disconnected).toBeDefined();
+    expect(disconnected?.lastEventAt).toBe(nowValue);
+    expect(disconnected?.lastTransportActivityAt).toBeUndefined();
+  });
+});
+
+describe("monitorWebhook status publishing", () => {
+  let originalNow: () => number;
+  let nowValue: number;
+
+  beforeEach(() => {
+    nowValue = 1_700_000_001_000;
+    originalNow = Date.now;
+    Date.now = () => nowValue;
+  });
+
+  afterEach(() => {
+    Date.now = originalNow;
+    vi.restoreAllMocks();
+  });
+
+  it("publishes connected on listen success", async () => {
+    const recorder = createRecordingSink();
+    const { monitorWebhook } = await loadTransportModule();
+
+    const account = {
+      accountId: "webhook-acct",
+      appId: "app",
+      appSecret: "secret",
+      domain: "https://open.feishu.cn",
+      encryptKey: "ek",
+      verificationToken: "vt",
+      config: {
+        connectionMode: "webhook" as const,
+        webhookPort: 0,
+        webhookPath: "/feishu/events",
+        webhookHost: "127.0.0.1",
+      },
+    } as never;
+
+    const abortController = new AbortController();
+
+    const monitorPromise = monitorWebhook({
+      account,
+      accountId: "webhook-acct",
+      abortSignal: abortController.signal,
+      eventDispatcher: { register: () => undefined, invoke: vi.fn() } as never,
+      statusSink: recorder.sink,
+    });
+
+    // Give the server time to listen.
+    await new Promise<void>((resolve) => {
+      setTimeout(() => resolve(), 50);
+    });
+
+    const connected = recorder.calls.find((c) => c.connected === true);
+    expect(connected).toBeDefined();
+    expect(connected?.lastConnectedAt).toBe(nowValue);
+    expect(connected?.lastEventAt).toBe(nowValue);
+    expect(connected?.lastTransportActivityAt).toBeUndefined();
+
+    abortController.abort();
+    await monitorPromise;
+  });
+});
+
+describe("FeishuStatusSink type contract", () => {
+  it("accepts a partial patch with only lastEventAt", async () => {
+    // Verifies the type signature allows the patterns we use. A compile-time
+    // check via tsserver; the runtime assertion is the call must not throw.
+    const recorder = createRecordingSink();
+    const sink: StatusSink = recorder.sink;
+    sink({ lastEventAt: 12345 });
+    expect(recorder.calls).toEqual([{ lastEventAt: 12345 }]);
+  });
+});

--- a/extensions/feishu/src/monitor.transport.ts
+++ b/extensions/feishu/src/monitor.transport.ts
@@ -12,6 +12,7 @@ import {
   safeEqualSecret,
   type RuntimeEnv,
 } from "./monitor-transport-runtime-api.js";
+import type { FeishuStatusSink } from "./monitor.js";
 import {
   clearFeishuBotIdentityState,
   closeTrackedFeishuHttpServer,
@@ -30,6 +31,12 @@ type MonitorTransportParams = {
   runtime?: RuntimeEnv;
   abortSignal?: AbortSignal;
   eventDispatcher: Lark.EventDispatcher;
+  /**
+   * Optional status sink for Feishu health tracking. Lifecycle callbacks
+   * publish connected state; validated inbound webhook requests publish
+   * transport activity.
+   */
+  statusSink?: FeishuStatusSink;
 };
 
 const FEISHU_WS_RECONNECT_INITIAL_DELAY_MS = 1_000;
@@ -216,6 +223,7 @@ export async function monitorWebSocket({
   runtime,
   abortSignal,
   eventDispatcher,
+  statusSink,
 }: MonitorTransportParams): Promise<void> {
   const log = runtime?.log ?? console.log;
   const error = runtime?.error ?? console.error;
@@ -242,9 +250,28 @@ export async function monitorWebSocket({
           `feishu[${accountId}]: WebSocket SDK reported recoverable error: ${formatFeishuWsErrorForLog(err)}`,
         );
       };
+      const publishWsConnected = () => {
+        const connectedAt = Date.now();
+        statusSink?.({
+          connected: true,
+          lastConnectedAt: connectedAt,
+          lastEventAt: connectedAt,
+          lastError: null,
+        });
+      };
+      const publishWsReconnecting = () => {
+        const reconnectingAt = Date.now();
+        statusSink?.({
+          connected: false,
+          lastEventAt: reconnectingAt,
+        });
+      };
       log(`feishu[${accountId}]: starting WebSocket connection...`);
       wsClient = await createFeishuWSClient(account, {
         onError: handleWsError,
+        onReady: publishWsConnected,
+        onReconnected: publishWsConnected,
+        onReconnecting: publishWsReconnecting,
       });
       if (abortSignal?.aborted) {
         cleanupFeishuWsClient({ accountId, wsClient, error, clearIdentity: true });
@@ -266,6 +293,14 @@ export async function monitorWebSocket({
         break;
       }
 
+      // WS cycle ended via terminal error (not abort) — publish disconnected
+      // so the health monitor can flag the channel before the next reconnect.
+      const disconnectedAt = Date.now();
+      statusSink?.({
+        connected: false,
+        lastEventAt: disconnectedAt,
+      });
+
       attempt += 1;
       const delayMs = getFeishuWsReconnectDelayMs(attempt);
       error(
@@ -280,6 +315,13 @@ export async function monitorWebSocket({
       if (abortSignal?.aborted) {
         break;
       }
+
+      // WS start failed (e.g. handshake / auth) — publish disconnected.
+      const failedAt = Date.now();
+      statusSink?.({
+        connected: false,
+        lastEventAt: failedAt,
+      });
 
       attempt += 1;
       const delayMs = getFeishuWsReconnectDelayMs(attempt);
@@ -301,6 +343,7 @@ export async function monitorWebhook({
   runtime,
   abortSignal,
   eventDispatcher,
+  statusSink,
 }: MonitorTransportParams): Promise<void> {
   const log = runtime?.log ?? console.log;
   const error = runtime?.error ?? console.error;
@@ -320,6 +363,17 @@ export async function monitorWebhook({
   server.on("request", (req, res) => {
     res.on("finish", () => {
       recordWebhookStatus(runtime, accountId, path, res.statusCode);
+      // Refresh lastEventAt / lastTransportActivityAt on every successful 2xx
+      // response so the gateway health monitor sees inbound activity. Non-2xx
+      // (e.g. 401 invalid signature, 400 invalid JSON, 429 rate-limited) is
+      // intentionally NOT counted as transport activity.
+      if (res.statusCode >= 200 && res.statusCode < 300) {
+        const inboundAt = Date.now();
+        statusSink?.({
+          lastEventAt: inboundAt,
+          lastTransportActivityAt: inboundAt,
+        });
+      }
     });
 
     const rateLimitKey = buildFeishuWebhookRateLimitKey({
@@ -439,6 +493,16 @@ export async function monitorWebhook({
 
     server.listen(port, host, () => {
       log(`feishu[${accountId}]: Webhook server listening on ${host}:${port}`);
+      // Publish connected + lastEventAt once the server is listening. Without
+      // this, the gateway health monitor has no transport signal for webhook
+      // mode and will not detect a server crash. See PROPOSAL.md.
+      const webhookConnectedAt = Date.now();
+      statusSink?.({
+        connected: true,
+        lastConnectedAt: webhookConnectedAt,
+        lastEventAt: webhookConnectedAt,
+        lastError: null,
+      });
     });
 
     server.on("error", (err) => {

--- a/extensions/feishu/src/monitor.ts
+++ b/extensions/feishu/src/monitor.ts
@@ -15,7 +15,30 @@ export type MonitorFeishuOpts = {
   channelRuntime?: PluginRuntime["channel"];
   abortSignal?: AbortSignal;
   accountId?: string;
+  /**
+   * Optional status sink for Feishu channel health. Connected state comes
+   * from transport lifecycle callbacks; transport activity is only published
+   * when Feishu provides a real activity signal.
+   */
+  statusSink?: FeishuStatusSink;
 };
+
+/**
+ * Function shape for partial channel status patches with a bound accountId.
+ * Mirrors the return type of `createAccountStatusSink` from the plugin SDK
+ * so the feishu plugin does not need to depend on a specific channel runtime.
+ *
+ * We use a structural Partial<{...}> to keep the sink type lightweight and
+ * decoupled from the ChannelAccountSnapshot type. The runtime accepts any
+ * subset of these fields.
+ */
+export type FeishuStatusSink = (patch: {
+  connected?: boolean;
+  lastConnectedAt?: number | null;
+  lastEventAt?: number | null;
+  lastTransportActivityAt?: number | null;
+  lastError?: string | null;
+}) => void;
 
 let monitorAccountRuntimePromise: Promise<typeof import("./monitor.account.js")> | undefined;
 
@@ -53,6 +76,7 @@ export async function monitorFeishuProvider(opts: MonitorFeishuOpts = {}): Promi
       channelRuntime: opts.channelRuntime,
       runtime: opts.runtime,
       abortSignal: opts.abortSignal,
+      ...(opts.statusSink ? { statusSink: opts.statusSink } : {}),
     });
   }
 
@@ -92,6 +116,7 @@ export async function monitorFeishuProvider(opts: MonitorFeishuOpts = {}): Promi
         runtime: opts.runtime,
         abortSignal: opts.abortSignal,
         botOpenIdSource: { kind: "prefetched", botOpenId, botName },
+        ...(opts.statusSink ? { statusSink: opts.statusSink } : {}),
       }),
     );
   }


### PR DESCRIPTION
## Description

Fixes Feishu channel health reporting so the gateway can see transport state instead of treating a silent Feishu transport as healthy forever.

## What Problem This Solves

Feishu could lose or stall its WebSocket transport while OpenClaw still reported the channel as healthy, because the Feishu integration did not publish enough account status for the gateway health monitor to distinguish an alive transport from a dead one. That leaves operators with a bot that stops responding until a manual restart.

The maintainer refresh keeps the useful contributor patch, rebases it onto current `main`, and tightens the semantics:

- `channel.ts` creates an account-bound status sink with `createAccountStatusSink`.
- `monitor.ts` and `monitor.account.ts` pass the status sink through the Feishu monitor path.
- `monitorWebSocket` reports `connected: true`, `lastConnectedAt`, and `lastEventAt` from SDK `onReady` / `onReconnected`, not merely because `start()` returned.
- `monitorWebSocket` reports `connected: false` on SDK `onReconnecting`, terminal disconnect, and start failure.
- `monitorWebhook` reports connected once the webhook server is listening without seeding stale-socket activity from that one-time startup event.
- `monitorWebhook` refreshes `lastTransportActivityAt` only on successful 2xx inbound webhook responses, which are actual validated inbound transport activity.
- `createFeishuMessageReceiveHandler` refreshes message recency with `lastEventAt` only. It intentionally does not refresh `lastTransportActivityAt`, because ordinary app messages are not the transport liveness source.

## Real Behavior Proof

### behavior

Before this change, Feishu only set basic account status and did not consistently publish transport lifecycle fields such as `connected`, `lastConnectedAt`, `lastEventAt`, and `lastTransportActivityAt`. A dead or stale WebSocket could therefore remain invisible to the channel health monitor.

After this change, WebSocket readiness/reconnects, terminal disconnects, webhook listen state, and successful webhook deliveries all publish status patches through the normal channel account status sink.

### environment

Maintainer refresh tested locally on the OpenClaw repo at head `f0ac2a818627503ef7757294b96cde313e6c9d11`.

### steps

1. Rebased the PR patch onto current `origin/main`.
2. Preserved contributor credit and narrowed the behavior to transport-owned liveness updates.
3. Ran focused Feishu transport/client/message-handler tests.
4. Ran diff whitespace validation.

### evidence

```bash
pnpm -s exec vitest run extensions/feishu/src/monitor.transport-status.test.ts extensions/feishu/src/monitor.message-handler.test.ts
```

Result: 2 test files passed, 6 tests passed.

```bash
pnpm -s exec vitest run extensions/feishu/src/client.test.ts extensions/feishu/src/monitor.transport-status.test.ts
```

Result: 2 test files passed, 23 tests passed.

```bash
git diff --check
```

Result: clean.

The original contributor also attached before/after proof context in the previous body:

<img width="2136" height="2998" alt="proof-screenshot-all" src="https://github.com/user-attachments/assets/35dffcb6-c96f-4992-bc8e-b702d057e8c3" />

### observedResult

The new focused test covers the important regression boundary: `wsClient.start()` alone does not publish connected status; `onReady` and `onReconnected` do. `onReconnecting` publishes `connected: false`.

The same test asserts WebSocket ready/reconnect and webhook listen do not set `lastTransportActivityAt`, so a quiet-but-healthy Feishu account does not get a stale-socket timer from one-time startup/readiness events.

The message-handler test also passes after changing app-message receipt to update only `lastEventAt`, leaving `lastTransportActivityAt` out of app-message and one-time lifecycle paths.

### notTested

I did not run a live Feishu production kill-test because that requires active Feishu credentials and intentionally disrupting a running channel. The included unit tests simulate the status patches consumed by the gateway health monitor.

## Compatibility

No breaking API or manifest change. The status sink is optional and no-arg callers keep their existing behavior.

## Checklist

- [x] Contributor branch refreshed onto current main.
- [x] Contributor credit preserved in commit metadata.
- [x] Focused Feishu transport/message-handler tests pass.
- [x] `git diff --check` passes.
