### PR TITLE
fix(acpx): reset disabled Claude effort controls

### DIFF
--- a/extensions/acpx/src/claude-acp-config.ts
+++ b/extensions/acpx/src/claude-acp-config.ts
@@ -1,0 +1,26 @@
+const CLAUDE_ACP_OPENCLAW_PREFIX = "anthropic/";
+const CLAUDE_ACP_EFFORT_CONFIG_KEYS = new Set([
+  "effort",
+  "reasoning_effort",
+  "thinking",
+  "thought_level",
+]);
+const CLAUDE_ACP_DISABLED_EFFORT_VALUES = new Set(["none", "off"]);
+
+export function isDisabledClaudeAcpEffortConfig(key: string, value: string): boolean {
+  return (
+    CLAUDE_ACP_EFFORT_CONFIG_KEYS.has(key) &&
+    CLAUDE_ACP_DISABLED_EFFORT_VALUES.has(value.trim().toLowerCase())
+  );
+}
+
+export function normalizeClaudeAcpModelOverride(rawModel: string | undefined): string | undefined {
+  const raw = rawModel?.trim();
+  if (!raw) {
+    return undefined;
+  }
+  if (!raw.toLowerCase().startsWith(CLAUDE_ACP_OPENCLAW_PREFIX)) {
+    return raw;
+  }
+  return raw.slice(CLAUDE_ACP_OPENCLAW_PREFIX.length).trim() || undefined;
+}

--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -1544,6 +1544,90 @@ describe("AcpxRuntime fresh reset wrapper", () => {
     expect(setConfigOption).not.toHaveBeenCalled();
   });
 
+  it.each([
+    ["effort", "none"],
+    ["effort", "off"],
+    ["thinking", "off"],
+  ])("resets disabled Claude ACP %s config controls", async (key, value) => {
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async () => ({
+        acpxRecordId: "agent:claude:acp:test",
+        agentCommand: "npx @agentclientprotocol/claude-agent-acp",
+      })),
+      save: vi.fn(async () => {}),
+    };
+    const { runtime, delegate } = makeRuntime(baseStore);
+    const setConfigOption = vi.spyOn(delegate, "setConfigOption").mockResolvedValue(undefined);
+    const handle: Parameters<NonNullable<AcpRuntime["setConfigOption"]>>[0]["handle"] = {
+      sessionKey: "agent:claude:acp:test",
+      backend: "acpx",
+      runtimeSessionName: "agent:claude:acp:test",
+      acpxRecordId: "agent:claude:acp:test",
+    };
+
+    await runtime.setConfigOption({ handle, key, value });
+
+    expect(setConfigOption).toHaveBeenCalledWith({
+      handle,
+      key: "effort",
+      value: "default",
+    });
+  });
+
+  it("preserves supported Claude ACP effort config controls", async () => {
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async () => ({
+        acpxRecordId: "agent:claude:acp:test",
+        agentCommand: "npx @agentclientprotocol/claude-agent-acp",
+      })),
+      save: vi.fn(async () => {}),
+    };
+    const { runtime, delegate } = makeRuntime(baseStore);
+    const setConfigOption = vi.spyOn(delegate, "setConfigOption").mockResolvedValue(undefined);
+    const handle: Parameters<NonNullable<AcpRuntime["setConfigOption"]>>[0]["handle"] = {
+      sessionKey: "agent:claude:acp:test",
+      backend: "acpx",
+      runtimeSessionName: "agent:claude:acp:test",
+      acpxRecordId: "agent:claude:acp:test",
+    };
+
+    await runtime.setConfigOption({ handle, key: "effort", value: "medium" });
+
+    expect(setConfigOption).toHaveBeenCalledWith({ handle, key: "effort", value: "medium" });
+  });
+
+  it("clears an existing Claude ACP effort override when effort is disabled", async () => {
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async () => ({
+        acpxRecordId: "agent:claude:acp:test",
+        agentCommand: "npx @agentclientprotocol/claude-agent-acp",
+      })),
+      save: vi.fn(async () => {}),
+    };
+    const { runtime, delegate } = makeRuntime(baseStore);
+    const setConfigOption = vi.spyOn(delegate, "setConfigOption").mockResolvedValue(undefined);
+    const handle: Parameters<NonNullable<AcpRuntime["setConfigOption"]>>[0]["handle"] = {
+      sessionKey: "agent:claude:acp:test",
+      backend: "acpx",
+      runtimeSessionName: "agent:claude:acp:test",
+      acpxRecordId: "agent:claude:acp:test",
+    };
+
+    await runtime.setConfigOption({ handle, key: "effort", value: "medium" });
+    await runtime.setConfigOption({ handle, key: "effort", value: "off" });
+
+    expect(setConfigOption).toHaveBeenNthCalledWith(1, {
+      handle,
+      key: "effort",
+      value: "medium",
+    });
+    expect(setConfigOption).toHaveBeenNthCalledWith(2, {
+      handle,
+      key: "effort",
+      value: "default",
+    });
+  });
+
   it("normalizes model config controls for claude-agent-acp", async () => {
     const baseStore: TestSessionStore = {
       load: vi.fn(async () => ({

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -29,6 +29,10 @@ import { redactSensitiveText } from "openclaw/plugin-sdk/security-runtime";
 import { normalizeStringEntries } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { AcpRuntimeError, type AcpRuntime, type AcpRuntimeErrorCode } from "../runtime-api.js";
+import {
+  isDisabledClaudeAcpEffortConfig,
+  normalizeClaudeAcpModelOverride,
+} from "./claude-acp-config.js";
 import { CODEX_ACP_PACKAGE, OPENCLAW_CODEX_CONFIG_ARG } from "./codex-adapter.js";
 import { splitCommandParts } from "./command-line.js";
 import {
@@ -374,7 +378,7 @@ const OPENCLAW_BRIDGE_EXECUTABLE = "openclaw";
 const OPENCLAW_BRIDGE_SUBCOMMAND = "acp";
 const CODEX_ACP_AGENT_ID = "codex";
 const CODEX_ACP_OPENCLAW_PREFIX = "openai/";
-const CLAUDE_ACP_OPENCLAW_PREFIX = "anthropic/";
+const CODEX_ACP_REASONING_EFFORTS = new Set(["low", "medium", "high", "xhigh"]);
 const CODEX_ACP_THINKING_ALIASES = new Map<string, string | undefined>([
   ["off", undefined],
   ["minimal", "low"],
@@ -635,17 +639,6 @@ function withCodexSessionModel<T extends { model?: string }>(
     delete next.model;
   }
   return next;
-}
-
-function normalizeClaudeAcpModelOverride(rawModel: string | undefined): string | undefined {
-  const raw = rawModel?.trim();
-  if (!raw) {
-    return undefined;
-  }
-  if (!raw.toLowerCase().startsWith(CLAUDE_ACP_OPENCLAW_PREFIX)) {
-    return raw;
-  }
-  return raw.slice(CLAUDE_ACP_OPENCLAW_PREFIX.length).trim() || undefined;
 }
 
 function withAcpxSessionOptions(input: OpenClawRuntimeEnsureInput): AcpxDelegateEnsureInput {
@@ -1707,6 +1700,14 @@ export class AcpxRuntime implements AcpRuntime {
     const key = input.key.trim().toLowerCase();
     const isCodexAcp = isCodexAcpCommand(command);
     if (WIRE_TIMEOUT_CONFIG_KEYS.has(key) && (isCodexAcp || isClaudeAcpCommand(command))) {
+      return;
+    }
+    if (isClaudeAcpCommand(command) && isDisabledClaudeAcpEffortConfig(key, input.value)) {
+      await delegate.setConfigOption({
+        ...input,
+        key: "effort",
+        value: "default",
+      });
       return;
     }
     if (isCodexAcp) {


### PR DESCRIPTION
## What Problem This Solves

Managed Claude ACP sessions can fail before producing a response when OpenClaw forwards a disabled generic thinking value as a Claude `effort` config option. The installed Claude ACP adapter accepts `default`, `low`, `medium`, and `high`; values such as `off` and `none` are rejected.

## Why This Change Was Made

The failure belongs at the ACPX compatibility boundary: OpenClaw has valid cross-provider semantics for disabling thinking, while Claude ACP represents that state as `effort: default`.

This patch translates only disabled effort values for recognised Claude ACP effort/thinking aliases to the canonical `effort: default` reset. It preserves supported effort values, existing Claude model normalisation, and all non-Claude behaviour.

## User Impact

Managed Claude ACP sessions no longer fail with `Invalid value for config option effort: none` or `off` when thinking is disabled or inherited as disabled. Disabling effort also clears a previously applied explicit effort on persistent sessions instead of leaving it active.

## Evidence

- Red-first regression: the disabled-value and persistent-session transition cases failed before the runtime change.
- Focused ACPX suite: 14 files, 174 tests passed.
- Repository-wide test type check passed on current `main`.
- Scoped ACPX lint passed.
- LOC ratchet passed; the oversized runtime file does not grow.
- Formatting and `git diff --check` passed.
- Full repository build passed.
- Independent autoreview found no actionable defects after its persistent-session reset finding was fixed.
- Pre-fix live managed Claude ACP reproduced `Invalid value for config option effort: none`; explicit `low` and `medium` managed checks completed successfully.

The source patch itself was not installed into the live gateway for this PR validation, so no restart or deployment was performed. Runtime activation remains with the normal OpenClaw release path.

## Scope and Compatibility

- Changes only the ACPX adapter for recognised Claude ACP commands.
- Maps only `off`/`none` on effort aliases to `effort: default`.
- Preserves valid effort and model overrides.
- No config, schema, migration, session-storage, gateway, or product-code changes.

## Verification Notes

The patch is rebased onto current upstream `main`. Focused tests, repository-wide test types, scoped lint, the LOC gate, formatting, and the full build are clean.
