### PR TITLE
[codex] fix discord missing voice state handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Docs: https://docs.openclaw.ai
 - **IRC Unicode messages:** split outbound PRIVMSG payloads on UTF-16 code-point boundaries so emoji cannot be cut into lone surrogates. (#96572) Thanks @llagy009.
 - **OpenAI realtime voice greetings:** prevent server VAD from creating a second outbound greeting while an explicit greeting response owns the turn, without disabling caller interruption. (#86285) Thanks @giodl73-repo.
 - **iOS Voice Wake cleanup:** avoid initializing the microphone audio pipeline while disabling inactive Voice Wake, preventing simulator launch aborts and unnecessary audio setup.
+- **Discord voice status:** return an explicit absent state for Discord error 10065 while preserving unrelated 404 failures. (#90969) Thanks @asock.
 - **Cron duration validation:** reject positive durations that truncate below one millisecond instead of silently scheduling a zero-duration interval. (#100311) Thanks @qingminglong.
 - **Skill workshop proposals:** preserve the terminal newline in generated proposal Markdown while still rejecting blank raw content. (#100293) Thanks @anyech.
 - **Agent tool inputs and LSP startup:** treat blank optional integer arguments as absent, and fail embedded LSP startup immediately when its child process cannot spawn. (#100273, #99922) Thanks @snotty and @cxbAsDev.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,6 @@ Docs: https://docs.openclaw.ai
 - **IRC Unicode messages:** split outbound PRIVMSG payloads on UTF-16 code-point boundaries so emoji cannot be cut into lone surrogates. (#96572) Thanks @llagy009.
 - **OpenAI realtime voice greetings:** prevent server VAD from creating a second outbound greeting while an explicit greeting response owns the turn, without disabling caller interruption. (#86285) Thanks @giodl73-repo.
 - **iOS Voice Wake cleanup:** avoid initializing the microphone audio pipeline while disabling inactive Voice Wake, preventing simulator launch aborts and unnecessary audio setup.
-- **Discord voice status:** return an explicit absent state for Discord error 10065 while preserving unrelated 404 failures. (#90969) Thanks @asock.
 - **Cron duration validation:** reject positive durations that truncate below one millisecond instead of silently scheduling a zero-duration interval. (#100311) Thanks @qingminglong.
 - **Skill workshop proposals:** preserve the terminal newline in generated proposal Markdown while still rejecting blank raw content. (#100293) Thanks @anyech.
 - **Agent tool inputs and LSP startup:** treat blank optional integer arguments as absent, and fail embedded LSP startup immediately when its child process cannot spawn. (#100273, #99922) Thanks @snotty and @cxbAsDev.

--- a/extensions/discord/src/internal/rest-errors.ts
+++ b/extensions/discord/src/internal/rest-errors.ts
@@ -1,6 +1,9 @@
 // Discord plugin module implements rest errors behavior.
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { parseStrictNonNegativeInteger } from "openclaw/plugin-sdk/number-runtime";
 import { parseDiscordRetryAfterBodySeconds, parseRetryAfterHeaderSeconds } from "../retry-after.js";
+
+const DISCORD_UNKNOWN_VOICE_STATE = 10065;
 
 export function readDiscordCode(body: unknown): number | undefined {
   const value =
@@ -16,6 +19,17 @@ export function readDiscordMessage(body: unknown, fallback: string): string {
       ? (body as { message?: unknown }).message
       : undefined;
   return typeof value === "string" && value.trim() ? value : fallback;
+}
+
+export function isUnknownDiscordVoiceStateError(err: unknown): boolean {
+  const discordCode =
+    err && typeof err === "object" && "discordCode" in err
+      ? parseStrictNonNegativeInteger(err.discordCode)
+      : undefined;
+  return (
+    discordCode === DISCORD_UNKNOWN_VOICE_STATE ||
+    /unknown voice state/i.test(formatErrorMessage(err))
+  );
 }
 
 export function readRetryAfter(body: unknown, response: Response, fallbackSeconds = 0): number {

--- a/extensions/discord/src/internal/rest.ts
+++ b/extensions/discord/src/internal/rest.ts
@@ -24,7 +24,7 @@ import {
 } from "./rest-scheduler.js";
 import { isDiscordRateLimitBody } from "./schemas.js";
 
-export { DiscordError, RateLimitError } from "./rest-errors.js";
+export { DiscordError, isUnknownDiscordVoiceStateError, RateLimitError } from "./rest-errors.js";
 
 export type RuntimeProfile = "serverless" | "persistent";
 export type RequestPriority = RestRequestPriority;

--- a/extensions/discord/src/send.guild.test.ts
+++ b/extensions/discord/src/send.guild.test.ts
@@ -1,0 +1,80 @@
+import { Routes } from "discord-api-types/v10";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const restMock = {
+  get: vi.fn(),
+};
+
+vi.mock("./send.shared.js", () => ({
+  resolveDiscordRest: () => restMock,
+}));
+
+vi.mock("openclaw/plugin-sdk/web-media", () => ({
+  loadWebMediaRaw: vi.fn(),
+}));
+
+const { fetchVoiceStatusDiscord } = await import("./send.guild.js");
+
+describe("fetchVoiceStatusDiscord", () => {
+  beforeEach(() => {
+    restMock.get.mockReset();
+  });
+
+  it("returns active voice states from the REST client", async () => {
+    const voiceState = {
+      guild_id: "g1",
+      user_id: "u1",
+      channel_id: "c1",
+      session_id: "s1",
+      deaf: false,
+      mute: false,
+      self_deaf: false,
+      self_mute: false,
+      suppress: false,
+    };
+    restMock.get.mockResolvedValueOnce(voiceState);
+
+    const result = await fetchVoiceStatusDiscord("g1", "u1", { cfg: {} as never });
+
+    expect(result).toEqual(voiceState);
+    expect(restMock.get).toHaveBeenCalledWith(Routes.guildVoiceState("g1", "u1"));
+  });
+
+  it("returns an absent status when Discord reports an unknown voice state", async () => {
+    restMock.get.mockRejectedValueOnce(new Error("DiscordError: Unknown Voice State"));
+
+    const result = await fetchVoiceStatusDiscord("g1", "u1", { cfg: {} as never });
+
+    expect(result).toEqual({
+      guild_id: "g1",
+      user_id: "u1",
+      channel_id: null,
+      connected: false,
+      absent: true,
+      reason: "unknown_voice_state",
+    });
+  });
+
+  it("returns an absent status for Discord 404 voice-state lookups", async () => {
+    restMock.get.mockRejectedValueOnce(Object.assign(new Error("Not Found"), { status: 404 }));
+
+    const result = await fetchVoiceStatusDiscord("g1", "u1", { cfg: {} as never });
+
+    expect(result).toMatchObject({
+      guild_id: "g1",
+      user_id: "u1",
+      channel_id: null,
+      connected: false,
+      absent: true,
+      reason: "unknown_voice_state",
+    });
+  });
+
+  it("propagates non-voice-state REST failures", async () => {
+    restMock.get.mockRejectedValueOnce(new Error("Discord API error"));
+
+    await expect(fetchVoiceStatusDiscord("g1", "u1", { cfg: {} as never })).rejects.toThrow(
+      "Discord API error",
+    );
+  });
+});

--- a/extensions/discord/src/send.guild.test.ts
+++ b/extensions/discord/src/send.guild.test.ts
@@ -41,7 +41,9 @@ describe("fetchVoiceStatusDiscord", () => {
   });
 
   it("returns an absent status when Discord reports an unknown voice state", async () => {
-    restMock.get.mockRejectedValueOnce(new Error("DiscordError: Unknown Voice State"));
+    restMock.get.mockRejectedValueOnce(
+      Object.assign(new Error("Not Found"), { status: 404, discordCode: 10065 }),
+    );
 
     const result = await fetchVoiceStatusDiscord("g1", "u1", { cfg: {} as never });
 
@@ -55,8 +57,8 @@ describe("fetchVoiceStatusDiscord", () => {
     });
   });
 
-  it("returns an absent status for Discord 404 voice-state lookups", async () => {
-    restMock.get.mockRejectedValueOnce(Object.assign(new Error("Not Found"), { status: 404 }));
+  it("recognizes legacy unknown voice state error messages", async () => {
+    restMock.get.mockRejectedValueOnce(new Error("DiscordError: Unknown Voice State"));
 
     const result = await fetchVoiceStatusDiscord("g1", "u1", { cfg: {} as never });
 
@@ -70,11 +72,13 @@ describe("fetchVoiceStatusDiscord", () => {
     });
   });
 
-  it("propagates non-voice-state REST failures", async () => {
-    restMock.get.mockRejectedValueOnce(new Error("Discord API error"));
+  it.each([
+    Object.assign(new Error("Unknown Guild"), { status: 404, discordCode: 10004 }),
+    Object.assign(new Error("Not Found"), { status: 404 }),
+    new Error("Discord API error"),
+  ])("propagates non-voice-state REST failures", async (error) => {
+    restMock.get.mockRejectedValueOnce(error);
 
-    await expect(fetchVoiceStatusDiscord("g1", "u1", { cfg: {} as never })).rejects.toThrow(
-      "Discord API error",
-    );
+    await expect(fetchVoiceStatusDiscord("g1", "u1", { cfg: {} as never })).rejects.toBe(error);
   });
 });

--- a/extensions/discord/src/send.guild.ts
+++ b/extensions/discord/src/send.guild.ts
@@ -7,6 +7,7 @@ import type {
   APIVoiceState,
   RESTPostAPIGuildScheduledEventJSONBody,
 } from "discord-api-types/v10";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import {
   resolveExpiresAtMsFromDurationMs,
   timestampMsToIsoString,
@@ -37,6 +38,14 @@ import type {
   DiscordTimeoutTarget,
 } from "./send.types.js";
 import { DISCORD_MAX_EVENT_COVER_BYTES } from "./send.types.js";
+
+export type DiscordAbsentVoiceState = Pick<APIVoiceState, "guild_id" | "user_id" | "channel_id"> & {
+  connected: false;
+  absent: true;
+  reason: "unknown_voice_state";
+};
+
+export type DiscordVoiceStatus = APIVoiceState | DiscordAbsentVoiceState;
 
 export async function fetchMemberInfoDiscord(
   guildId: string,
@@ -95,9 +104,31 @@ export async function fetchVoiceStatusDiscord(
   guildId: string,
   userId: string,
   opts: DiscordReactOpts,
-): Promise<APIVoiceState> {
+): Promise<DiscordVoiceStatus> {
   const rest = resolveDiscordRest(opts);
-  return await getGuildVoiceState(rest, guildId, userId);
+  try {
+    return await getGuildVoiceState(rest, guildId, userId);
+  } catch (err) {
+    if (!isUnknownDiscordVoiceStateError(err)) {
+      throw err;
+    }
+    return {
+      guild_id: guildId,
+      user_id: userId,
+      channel_id: null,
+      connected: false,
+      absent: true,
+      reason: "unknown_voice_state",
+    };
+  }
+}
+
+function isUnknownDiscordVoiceStateError(err: unknown): boolean {
+  const status =
+    err && typeof err === "object" && "status" in err && typeof err.status === "number"
+      ? err.status
+      : undefined;
+  return status === 404 || /unknown voice state/i.test(formatErrorMessage(err));
 }
 
 export async function listScheduledEventsDiscord(

--- a/extensions/discord/src/send.guild.ts
+++ b/extensions/discord/src/send.guild.ts
@@ -7,7 +7,6 @@ import type {
   APIVoiceState,
   RESTPostAPIGuildScheduledEventJSONBody,
 } from "discord-api-types/v10";
-import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import {
   resolveExpiresAtMsFromDurationMs,
   timestampMsToIsoString,
@@ -22,6 +21,7 @@ import {
   getGuild,
   getGuildMember,
   getGuildVoiceState,
+  isUnknownDiscordVoiceStateError,
   listGuildChannels,
   listGuildRoles,
   listGuildScheduledEvents,
@@ -121,14 +121,6 @@ export async function fetchVoiceStatusDiscord(
       reason: "unknown_voice_state",
     };
   }
-}
-
-function isUnknownDiscordVoiceStateError(err: unknown): boolean {
-  const status =
-    err && typeof err === "object" && "status" in err && typeof err.status === "number"
-      ? err.status
-      : undefined;
-  return status === 404 || /unknown voice state/i.test(formatErrorMessage(err));
 }
 
 export async function listScheduledEventsDiscord(

--- a/extensions/discord/src/voice/manager.ts
+++ b/extensions/discord/src/voice/manager.ts
@@ -10,6 +10,7 @@ import {
   type APIVoiceState,
   type Client,
   getGuildVoiceState,
+  isUnknownDiscordVoiceStateError,
   ReadyListener,
   ResumedListener,
   VoiceStateUpdateListener,
@@ -201,14 +202,6 @@ function isFatalAutoJoinFailure(message: string): boolean {
   return DISCORD_VOICE_FATAL_AUTOJOIN_ERROR_PATTERNS.some((pattern) =>
     normalized.includes(pattern),
   );
-}
-
-function isUnknownDiscordVoiceStateError(err: unknown): boolean {
-  const status =
-    err && typeof err === "object" && "status" in err && typeof err.status === "number"
-      ? err.status
-      : undefined;
-  return status === 404 || /unknown voice state/i.test(formatErrorMessage(err));
 }
 
 function startAutoJoin(manager: Pick<DiscordVoiceManager, "autoJoin">) {


### PR DESCRIPTION
## What Problem This Solves

Discord returns REST error code 10065 when a guild member has no current voice state. OpenClaw treated that normal disconnected state as a command/gateway failure. The original patch also treated every HTTP 404 as absent, which could hide unrelated unknown-guild, unknown-channel, permission, or transport failures.

## Why This Change Was Made

The Discord plugin now recognizes only the provider's semantic `Unknown Voice State` code, with a narrow explicit-message fallback for legacy error shapes. Guild status and voice manager lookup share that predicate; generic 404 handling is removed.

## User Impact

Voice status for a disconnected Discord user returns an explicit absent/disconnected result. Other Discord REST errors continue to surface for diagnosis. No configuration or command changes are required.

## Evidence

- Live authenticated Discord REST proof returned code 10065 for a disconnected member and preserved code 10004 for an invalid guild.
- Official Discord API error documentation and `discord-api-types` distinguish those error codes.
- Focused Blacksmith Testbox run passed 128 manager and send tests: https://github.com/openclaw/openclaw/actions/runs/28750612160
- Tests cover active state, code 10065, the legacy explicit message, code 10004, status-only HTTP 404, and generic failures.
- Exact changed-surface gate passed: https://github.com/openclaw/openclaw/actions/runs/28750616630
- Fresh Codex autoreview found no actionable issues; confidence 0.97.
- Exact-head hosted CI passed at `7bc8b18ef69c638c2f49375bf808a99ba2e9548e`: https://github.com/openclaw/openclaw/actions/runs/28754711389

## Implementation

- Add one internal Discord REST predicate for unknown voice state.
- Reuse it in guild status and voice manager paths.
- Preserve every non-10065 exception.
- Preserve release-note context and contributor credit in this PR; the changelog bullet is queued with the final batch to avoid active-main ordering races.
