### PR TITLE
i18n(fr): expand French glossary with page titles and common terms

### DIFF
--- a/docs/.i18n/glossary.fr.json
+++ b/docs/.i18n/glossary.fr.json
@@ -74,5 +74,175 @@
   {
     "source": "Webhook",
     "target": "Webhook"
+  },
+  {
+    "source": "Getting Started",
+    "target": "Prise en main",
+    "ignore_case": true
+  },
+  {
+    "source": "Quick Start",
+    "target": "Démarrage rapide",
+    "ignore_case": true
+  },
+  {
+    "source": "Install overview",
+    "target": "Vue d'ensemble de l'installation",
+    "ignore_case": true
+  },
+  {
+    "source": "SDK overview",
+    "target": "Vue d'ensemble du SDK",
+    "ignore_case": true
+  },
+  {
+    "source": "Model Providers",
+    "target": "Fournisseurs de modèles",
+    "ignore_case": true
+  },
+  {
+    "source": "Provider directory",
+    "target": "Répertoire des fournisseurs",
+    "ignore_case": true
+  },
+  {
+    "source": "Channel Routing",
+    "target": "Routage des canaux",
+    "ignore_case": true
+  },
+  {
+    "source": "Web tools",
+    "target": "Outils web",
+    "ignore_case": true
+  },
+  {
+    "source": "Secure file operations",
+    "target": "Opérations sécurisées sur les fichiers",
+    "ignore_case": true
+  },
+  {
+    "source": "Creating skills",
+    "target": "Créer des skills",
+    "ignore_case": true
+  },
+  {
+    "source": "Setup Wizard Reference",
+    "target": "Référence de l'assistant de configuration",
+    "ignore_case": true
+  },
+  {
+    "source": "CLI Setup Reference",
+    "target": "Référence de configuration de la CLI",
+    "ignore_case": true
+  },
+  {
+    "source": "macOS platform notes",
+    "target": "Notes sur la plateforme macOS",
+    "ignore_case": true
+  },
+  {
+    "source": "Linux server",
+    "target": "Serveur Linux",
+    "ignore_case": true
+  },
+  {
+    "source": "VPS hosting",
+    "target": "Hébergement VPS",
+    "ignore_case": true
+  },
+  {
+    "source": "Code mode",
+    "target": "Mode code",
+    "ignore_case": true
+  },
+  {
+    "source": "Overview",
+    "target": "Vue d'ensemble",
+    "ignore_case": true,
+    "whole_word": true
+  },
+  {
+    "source": "Platforms",
+    "target": "Plateformes",
+    "ignore_case": true
+  },
+  {
+    "source": "Models",
+    "target": "Modèles",
+    "ignore_case": true,
+    "whole_word": true
+  },
+  {
+    "source": "Sessions",
+    "target": "Sessions",
+    "ignore_case": true,
+    "whole_word": true
+  },
+  {
+    "source": "Status",
+    "target": "État",
+    "ignore_case": true,
+    "whole_word": true
+  },
+  {
+    "source": "Logging",
+    "target": "Journalisation",
+    "ignore_case": true
+  },
+  {
+    "source": "Settings",
+    "target": "Paramètres",
+    "ignore_case": true,
+    "whole_word": true
+  },
+  {
+    "source": "Credentials",
+    "target": "Identifiants",
+    "ignore_case": true,
+    "whole_word": true
+  },
+  {
+    "source": "Deployment",
+    "target": "Déploiement",
+    "ignore_case": true,
+    "whole_word": true
+  },
+  {
+    "source": "Channel",
+    "target": "Canal",
+    "ignore_case": true,
+    "whole_word": true
+  },
+  {
+    "source": "Channels",
+    "target": "Canaux",
+    "ignore_case": true,
+    "whole_word": true
+  },
+  {
+    "source": "Agent runtimes",
+    "target": "Environnements d'exécution des agents",
+    "ignore_case": true
+  },
+  {
+    "source": "Talk mode",
+    "target": "Mode vocal",
+    "ignore_case": true
+  },
+  {
+    "source": "Capability Cookbook",
+    "target": "Recueil de capacités",
+    "ignore_case": true
+  },
+  {
+    "source": "Steering queue",
+    "target": "File de pilotage",
+    "ignore_case": true
+  },
+  {
+    "source": "Steer",
+    "target": "Piloter",
+    "ignore_case": true,
+    "whole_word": true
   }
 ]

--- a/docs/.i18n/glossary.fr.json
+++ b/docs/.i18n/glossary.fr.json
@@ -77,172 +77,130 @@
   },
   {
     "source": "Getting Started",
-    "target": "Prise en main",
-    "ignore_case": true
+    "target": "Prise en main"
   },
   {
     "source": "Quick Start",
-    "target": "Démarrage rapide",
-    "ignore_case": true
+    "target": "Démarrage rapide"
   },
   {
     "source": "Install overview",
-    "target": "Vue d'ensemble de l'installation",
-    "ignore_case": true
+    "target": "Vue d'ensemble de l'installation"
   },
   {
     "source": "SDK overview",
-    "target": "Vue d'ensemble du SDK",
-    "ignore_case": true
+    "target": "Vue d'ensemble du SDK"
   },
   {
     "source": "Model Providers",
-    "target": "Fournisseurs de modèles",
-    "ignore_case": true
+    "target": "Fournisseurs de modèles"
   },
   {
     "source": "Provider directory",
-    "target": "Répertoire des fournisseurs",
-    "ignore_case": true
+    "target": "Répertoire des fournisseurs"
   },
   {
     "source": "Channel Routing",
-    "target": "Routage des canaux",
-    "ignore_case": true
+    "target": "Routage des canaux"
   },
   {
     "source": "Web tools",
-    "target": "Outils web",
-    "ignore_case": true
+    "target": "Outils web"
   },
   {
     "source": "Secure file operations",
-    "target": "Opérations sécurisées sur les fichiers",
-    "ignore_case": true
+    "target": "Opérations sécurisées sur les fichiers"
   },
   {
     "source": "Creating skills",
-    "target": "Créer des skills",
-    "ignore_case": true
+    "target": "Créer des skills"
   },
   {
     "source": "Setup Wizard Reference",
-    "target": "Référence de l'assistant de configuration",
-    "ignore_case": true
+    "target": "Référence de l'assistant de configuration"
   },
   {
     "source": "CLI Setup Reference",
-    "target": "Référence de configuration de la CLI",
-    "ignore_case": true
+    "target": "Référence de configuration de la CLI"
   },
   {
     "source": "macOS platform notes",
-    "target": "Notes sur la plateforme macOS",
-    "ignore_case": true
+    "target": "Notes sur la plateforme macOS"
   },
   {
     "source": "Linux server",
-    "target": "Serveur Linux",
-    "ignore_case": true
+    "target": "Serveur Linux"
   },
   {
     "source": "VPS hosting",
-    "target": "Hébergement VPS",
-    "ignore_case": true
+    "target": "Hébergement VPS"
   },
   {
     "source": "Code mode",
-    "target": "Mode code",
-    "ignore_case": true
+    "target": "Mode code"
   },
   {
     "source": "Overview",
-    "target": "Vue d'ensemble",
-    "ignore_case": true,
-    "whole_word": true
+    "target": "Vue d'ensemble"
   },
   {
     "source": "Platforms",
-    "target": "Plateformes",
-    "ignore_case": true
+    "target": "Plateformes"
   },
   {
     "source": "Models",
-    "target": "Modèles",
-    "ignore_case": true,
-    "whole_word": true
+    "target": "Modèles"
   },
   {
     "source": "Sessions",
-    "target": "Sessions",
-    "ignore_case": true,
-    "whole_word": true
+    "target": "Sessions"
   },
   {
     "source": "Status",
-    "target": "État",
-    "ignore_case": true,
-    "whole_word": true
+    "target": "État"
   },
   {
     "source": "Logging",
-    "target": "Journalisation",
-    "ignore_case": true
+    "target": "Journalisation"
   },
   {
     "source": "Settings",
-    "target": "Paramètres",
-    "ignore_case": true,
-    "whole_word": true
+    "target": "Paramètres"
   },
   {
     "source": "Credentials",
-    "target": "Identifiants",
-    "ignore_case": true,
-    "whole_word": true
+    "target": "Identifiants"
   },
   {
     "source": "Deployment",
-    "target": "Déploiement",
-    "ignore_case": true,
-    "whole_word": true
+    "target": "Déploiement"
   },
   {
     "source": "Channel",
-    "target": "Canal",
-    "ignore_case": true,
-    "whole_word": true
+    "target": "Canal"
   },
   {
     "source": "Channels",
-    "target": "Canaux",
-    "ignore_case": true,
-    "whole_word": true
+    "target": "Canaux"
   },
   {
     "source": "Agent runtimes",
-    "target": "Environnements d'exécution des agents",
-    "ignore_case": true
+    "target": "Environnements d'exécution des agents"
   },
   {
     "source": "Talk mode",
-    "target": "Mode vocal",
-    "ignore_case": true
+    "target": "Mode vocal"
   },
   {
     "source": "Capability Cookbook",
-    "target": "Recueil de capacités",
-    "ignore_case": true
+    "target": "Recueil de capacités"
   },
   {
     "source": "Steering queue",
-    "target": "File de pilotage",
-    "ignore_case": true
+    "target": "File de pilotage"
   },
   {
     "source": "Steer",
-    "target": "Piloter",
-    "ignore_case": true,
-    "whole_word": true
+    "target": "Piloter"
   }
 ]

--- a/docs/.i18n/glossary.fr.json
+++ b/docs/.i18n/glossary.fr.json
@@ -164,6 +164,10 @@
     "target": "Journalisation"
   },
   {
+    "source": "troubleshooting",
+    "target": "Dépannage"
+  },
+  {
     "source": "Settings",
     "target": "Paramètres"
   },


### PR DESCRIPTION
## What

Expands `docs/.i18n/glossary.fr.json` from 19 to 52 entries.

The French glossary previously held only proper nouns kept in English (OpenClaw, CLI, Gateway, etc.), so the translation pipeline had no guidance for how to render descriptive page titles or common terms in French. This adds mappings so French output stays consistent across the localized docs.

## Changes

- **Page titles**: Getting Started, Quick Start, Model Providers, Provider directory, Channel Routing, Install overview, SDK overview, Setup Wizard Reference, CLI Setup Reference, macOS platform notes, Linux server, VPS hosting, Code mode, Creating skills, Web tools, Secure file operations, Agent runtimes, Talk mode, Steering queue, Capability Cookbook.
- **Common UI/technical terms**: troubleshooting → Dépannage, Settings → Paramètres, Credentials → Identifiants, Deployment → Déploiement, Overview → Vue d'ensemble, Status → État, Logging → Journalisation, Models → Modèles, Platforms → Plateformes.
- **Channel → Canal** (and Channels → Canaux) as the standard French rendering, since "channel" appears throughout the docs.

Product and protocol nouns (Skills, Plugin, Gateway, Webhook, ACP, TUI, …) are left in English, keeping the existing convention. All entries are plain `{source, target}` pairs — the shape the glossary loader supports — matching the existing 19 entries.

Native French speaker; happy to extend coverage further.
