### PR TITLE
fix(exec-approvals): resolve path/socket from the state dir (honor OPENCLAW_STATE_DIR)

### DIFF
--- a/docs/tools/exec-approvals.md
+++ b/docs/tools/exec-approvals.md
@@ -79,6 +79,13 @@ Approvals live in a local JSON file on the execution host:
 ~/.openclaw/exec-approvals.json
 ```
 
+The file and its companion socket resolve from the OpenClaw state directory, so
+the `~/.openclaw` paths shown here are the default location. When you relocate
+state with `OPENCLAW_STATE_DIR`, the approvals file and socket move with it (for
+example `$OPENCLAW_STATE_DIR/exec-approvals.json`). After upgrading, run
+`openclaw doctor --fix` to migrate an existing `~/.openclaw/exec-approvals.json`
+policy into the relocated state directory.
+
 Example schema:
 
 ```json

--- a/src/agents/bash-tools.exec.security-floor.test.ts
+++ b/src/agents/bash-tools.exec.security-floor.test.ts
@@ -50,11 +50,18 @@ describe("exec security floor", () => {
       "OPENCLAW_STATE_DIR",
       "SHELL",
     ]);
-    tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-exec-security-floor-"));
+    // realpath so fixture paths match the resolved (realpath'd) executable paths the allowlist
+    // compares against — os.tmpdir() is a symlink on macOS (/tmp -> /private/tmp).
+    tempRoot = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-exec-security-floor-")),
+    );
     process.env.HOME = tempRoot;
     process.env.USERPROFILE = tempRoot;
     process.env.OPENCLAW_HOME = tempRoot;
-    process.env.OPENCLAW_STATE_DIR = path.join(tempRoot, "state");
+    // The fixtures write exec-approvals.json under <tempRoot>/.openclaw, so point the state
+    // dir there too. exec-approvals now resolves via OPENCLAW_STATE_DIR (the state dir), so an
+    // unrelated state dir would leave the fixtures unread.
+    process.env.OPENCLAW_STATE_DIR = path.join(tempRoot, ".openclaw");
     if (process.platform === "win32") {
       const parsed = path.parse(tempRoot);
       process.env.HOMEDRIVE = parsed.root.slice(0, 2);

--- a/src/commands/doctor-security.ts
+++ b/src/commands/doctor-security.ts
@@ -14,6 +14,7 @@ import { isLoopbackHost, resolveGatewayBindHost } from "../gateway/net.js";
 import { resolveExecPolicyScopeSnapshot } from "../infra/exec-approvals-effective.js";
 import {
   loadExecApprovals,
+  resolveExecApprovalsPath,
   type ExecAsk,
   type ExecMode,
   type ExecSecurity,
@@ -22,6 +23,7 @@ import { isLikelySensitiveModelProviderHeaderName } from "../secrets/model-provi
 import { hasConfiguredPlaintextSecretValue } from "../secrets/secret-value.js";
 import { discoverConfigSecretTargets } from "../secrets/target-registry.js";
 import { collectExecFilesystemPolicyDriftHits } from "../security/exec-filesystem-policy.js";
+import { shortenHomePath } from "../utils.js";
 import { resolveDefaultChannelAccountContext } from "./channel-account-context.js";
 
 function collectImplicitHeartbeatDirectPolicyWarnings(cfg: OpenClawConfig): string[] {
@@ -246,7 +248,9 @@ export async function collectSecurityWarnings(
   if (cfg.approvals?.exec?.enabled === false) {
     warnings.push(
       "- Note: approvals.exec.enabled=false disables approval forwarding only.",
-      "  Host exec gating still comes from ~/.openclaw/exec-approvals.json.",
+      // Resolve the live path so relocated (OPENCLAW_STATE_DIR) installs point operators at the
+      // real policy file; shortenHomePath keeps default installs showing ~/.openclaw.
+      `  Host exec gating still comes from ${shortenHomePath(resolveExecApprovalsPath())}.`,
       `  Check local policy with: ${formatCliCommand("openclaw approvals get --gateway")}`,
     );
   }

--- a/src/commands/doctor/repair-sequencing.ts
+++ b/src/commands/doctor/repair-sequencing.ts
@@ -27,6 +27,7 @@ import {
 } from "./shared/config-mutation-state.js";
 import { maybeRepairContextEngineHostCompatibility } from "./shared/context-engine-host-compat.js";
 import { scanEmptyAllowlistPolicyWarnings } from "./shared/empty-allowlist-scan.js";
+import { relocateLegacyExecApprovalsStateFile } from "./shared/exec-approvals-state-dir-relocation.js";
 import { maybeRepairExecSafeBinProfiles } from "./shared/exec-safe-bins.js";
 import { maybeRepairInvalidPluginConfig } from "./shared/invalid-plugin-config.js";
 import { maybeRepairLegacyToolsBySenderKeys } from "./shared/legacy-tools-by-sender.js";
@@ -153,6 +154,13 @@ export async function runDoctorRepairSequence(params: {
 
   applyMutation(maybeRepairLegacyToolsBySenderKeys(state.candidate));
   applyMutation(maybeRepairExecSafeBinProfiles(state.candidate));
+  const execApprovalsRelocation = await relocateLegacyExecApprovalsStateFile({ env });
+  if (execApprovalsRelocation.changes.length > 0) {
+    changeNotes.push(sanitizeLines(execApprovalsRelocation.changes));
+  }
+  if (execApprovalsRelocation.warnings.length > 0) {
+    warningNotes.push(sanitizeLines(execApprovalsRelocation.warnings));
+  }
   const pluginDependencyCleanup = await cleanupLegacyPluginDependencyState({ env });
   if (pluginDependencyCleanup.changes.length > 0) {
     changeNotes.push(sanitizeLines(pluginDependencyCleanup.changes));

--- a/src/commands/doctor/shared/exec-approvals-state-dir-relocation.test.ts
+++ b/src/commands/doctor/shared/exec-approvals-state-dir-relocation.test.ts
@@ -1,0 +1,197 @@
+// Tests for the doctor migration that relocates a legacy home-relative exec-approvals
+// policy into the resolved state dir when OPENCLAW_STATE_DIR points elsewhere.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ensureExecApprovals, type ExecApprovalsFile } from "../../../infra/exec-approvals.js";
+import { captureEnv } from "../../../test-utils/env.js";
+import { relocateLegacyExecApprovalsStateFile } from "./exec-approvals-state-dir-relocation.js";
+
+const FILENAME = "exec-approvals.json";
+const SOCKET_FILENAME = "exec-approvals.sock";
+
+describe("exec-approvals state-dir relocation doctor migration", () => {
+  const envSnapshot = captureEnv(["OPENCLAW_STATE_DIR", "OPENCLAW_HOME"]);
+  let tempRoot = "";
+  let homeDir = "";
+  let stateDir = "";
+  let legacyPath = "";
+  let canonicalPath = "";
+
+  beforeEach(async () => {
+    tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-exec-approvals-relocate-"));
+    homeDir = path.join(tempRoot, "home");
+    stateDir = path.join(tempRoot, "state");
+    legacyPath = path.join(homeDir, ".openclaw", FILENAME);
+    canonicalPath = path.join(stateDir, FILENAME);
+    process.env.OPENCLAW_HOME = homeDir;
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+  });
+
+  afterEach(async () => {
+    envSnapshot.restore();
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  });
+
+  async function writeLegacyPolicy(security: string): Promise<void> {
+    await fs.mkdir(path.dirname(legacyPath), { recursive: true });
+    await fs.writeFile(
+      legacyPath,
+      `${JSON.stringify({ version: 1, defaults: { security }, agents: {} }, null, 2)}\n`,
+      { mode: 0o600 },
+    );
+  }
+
+  // Produce the legacy file the shipped runtime actually wrote: ensureExecApprovals with no
+  // OPENCLAW_STATE_DIR persists the policy plus the generated home-relative socket path/token
+  // at <home>/.openclaw, exercising the real persistence path rather than a hand-built fixture.
+  function writeLegacyPolicyViaRuntime(): ExecApprovalsFile {
+    const relocated = process.env.OPENCLAW_STATE_DIR;
+    delete process.env.OPENCLAW_STATE_DIR;
+    try {
+      return ensureExecApprovals();
+    } finally {
+      if (relocated === undefined) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = relocated;
+      }
+    }
+  }
+
+  async function readCanonicalPolicy(): Promise<ExecApprovalsFile> {
+    return JSON.parse(await fs.readFile(canonicalPath, "utf8")) as ExecApprovalsFile;
+  }
+
+  it("moves a legacy home policy into the relocated state dir", async () => {
+    await writeLegacyPolicy("deny");
+
+    const result = await relocateLegacyExecApprovalsStateFile({ env: process.env });
+
+    expect(result.warnings).toEqual([]);
+    expect(result.changes).toHaveLength(1);
+    expect(result.changes[0]).toContain("Moved exec-approvals policy");
+    await expect(fs.readFile(canonicalPath, "utf8")).resolves.toContain('"security": "deny"');
+    await expect(fs.access(legacyPath)).rejects.toThrow();
+  });
+
+  it("is a no-op for default installs where state dir equals the home location", async () => {
+    delete process.env.OPENCLAW_STATE_DIR;
+    process.env.OPENCLAW_HOME = homeDir;
+    await writeLegacyPolicy("deny");
+
+    const result = await relocateLegacyExecApprovalsStateFile({ env: process.env });
+
+    expect(result).toEqual({ changes: [], warnings: [] });
+    // Default-install file stays exactly where it was; nothing moved or removed.
+    await expect(fs.readFile(legacyPath, "utf8")).resolves.toContain('"security": "deny"');
+  });
+
+  it("does nothing when no legacy policy exists", async () => {
+    const result = await relocateLegacyExecApprovalsStateFile({ env: process.env });
+
+    expect(result).toEqual({ changes: [], warnings: [] });
+    await expect(fs.access(canonicalPath)).rejects.toThrow();
+  });
+
+  it("refuses to clobber an existing canonical policy and warns about the legacy file", async () => {
+    await writeLegacyPolicy("deny");
+    await fs.mkdir(stateDir, { recursive: true });
+    await fs.writeFile(
+      canonicalPath,
+      `${JSON.stringify({ version: 1, defaults: { security: "allowlist" }, agents: {} }, null, 2)}\n`,
+      { mode: 0o600 },
+    );
+
+    const result = await relocateLegacyExecApprovalsStateFile({ env: process.env });
+
+    expect(result.changes).toEqual([]);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain("Both");
+    // Canonical policy is preserved untouched; legacy file is left for manual reconciliation.
+    await expect(fs.readFile(canonicalPath, "utf8")).resolves.toContain('"security": "allowlist"');
+    await expect(fs.readFile(legacyPath, "utf8")).resolves.toContain('"security": "deny"');
+  });
+
+  it("rewrites the generated home socket path to the relocated state dir and keeps the token", async () => {
+    const legacy = writeLegacyPolicyViaRuntime();
+    // Sanity: the shipped persistence wrote the generated home-relative socket and a token.
+    expect(legacy.socket?.path).toBe(path.join(homeDir, ".openclaw", SOCKET_FILENAME));
+    const token = legacy.socket?.token;
+    expect(token).toBeTruthy();
+
+    const result = await relocateLegacyExecApprovalsStateFile({ env: process.env });
+
+    expect(result.warnings).toEqual([]);
+    expect(result.changes).toHaveLength(1);
+    expect(result.changes[0]).toContain("rewrote the generated socket path");
+    const moved = await readCanonicalPolicy();
+    expect(moved.socket?.path).toBe(path.join(stateDir, SOCKET_FILENAME));
+    expect(moved.socket?.token).toBe(token);
+    await expect(fs.access(legacyPath)).rejects.toThrow();
+  });
+
+  it("preserves an operator-chosen custom socket path during relocation", async () => {
+    const customSocket = path.join(tempRoot, "custom", "approvals.sock");
+    await fs.mkdir(path.dirname(legacyPath), { recursive: true });
+    await fs.writeFile(
+      legacyPath,
+      `${JSON.stringify(
+        {
+          version: 1,
+          socket: { path: customSocket, token: "operator-token" },
+          defaults: { security: "deny" },
+          agents: {},
+        },
+        null,
+        2,
+      )}\n`,
+      { mode: 0o600 },
+    );
+
+    const result = await relocateLegacyExecApprovalsStateFile({ env: process.env });
+
+    expect(result.warnings).toEqual([]);
+    expect(result.changes).toHaveLength(1);
+    expect(result.changes[0]).not.toContain("rewrote the generated socket path");
+    const moved = await readCanonicalPolicy();
+    expect(moved.socket?.path).toBe(customSocket);
+    expect(moved.socket?.token).toBe("operator-token");
+    expect(moved.defaults?.security).toBe("deny");
+  });
+
+  it("refuses to relocate into a symlinked state dir and keeps the legacy policy", async () => {
+    // A symlinked OPENCLAW_STATE_DIR is unsafe: runtime exec approvals refuse symlinked
+    // parents, so relocating there and deleting the legacy file would strand the policy.
+    const realState = path.join(tempRoot, "real-state");
+    await fs.mkdir(realState, { recursive: true });
+    const symlinkedState = path.join(tempRoot, "linked-state");
+    await fs.symlink(realState, symlinkedState);
+    process.env.OPENCLAW_STATE_DIR = symlinkedState;
+    await writeLegacyPolicy("deny");
+
+    const result = await relocateLegacyExecApprovalsStateFile({ env: process.env });
+
+    expect(result.changes).toEqual([]);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain("symlink");
+    // Legacy policy is preserved because the destination was rejected before any write.
+    await expect(fs.readFile(legacyPath, "utf8")).resolves.toContain('"security": "deny"');
+    await expect(fs.access(path.join(realState, FILENAME))).rejects.toThrow();
+  });
+
+  it("warns instead of following a symlinked legacy policy", async () => {
+    const outside = path.join(tempRoot, "outside-policy.json");
+    await fs.writeFile(outside, `${JSON.stringify({ version: 1, agents: {} })}\n`, { mode: 0o600 });
+    await fs.mkdir(path.dirname(legacyPath), { recursive: true });
+    await fs.symlink(outside, legacyPath);
+
+    const result = await relocateLegacyExecApprovalsStateFile({ env: process.env });
+
+    expect(result.changes).toEqual([]);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain("not a regular file");
+    await expect(fs.access(canonicalPath)).rejects.toThrow();
+  });
+});

--- a/src/commands/doctor/shared/exec-approvals-state-dir-relocation.test.ts
+++ b/src/commands/doctor/shared/exec-approvals-state-dir-relocation.test.ts
@@ -1,5 +1,6 @@
 // Tests for the doctor migration that relocates a legacy home-relative exec-approvals
 // policy into the resolved state dir when OPENCLAW_STATE_DIR points elsewhere.
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -75,6 +76,39 @@ describe("exec-approvals state-dir relocation doctor migration", () => {
     await expect(fs.readFile(canonicalPath, "utf8")).resolves.toContain('"security": "deny"');
     await expect(fs.access(legacyPath)).rejects.toThrow();
   });
+
+  // The migration writes a temp file inside the canonical dir then renames within it, so a
+  // legacy file on one device and a state dir on another must not hit EXDEV. Every other test
+  // shares a single tmpdir (same device); this forces a genuine cross-mount move using a tmpfs
+  // state dir (Linux /dev/shm), and skips where no second device is available (macOS/Windows).
+  it.skipIf(!fsSync.existsSync("/dev/shm"))(
+    "relocates across a device boundary when the state dir is on another mount (EXDEV-safe)",
+    async (ctx) => {
+      const tmpfsState = await fs.mkdtemp("/dev/shm/openclaw-exec-approvals-xdev-");
+      try {
+        const diskDev = fsSync.statSync(tempRoot).dev;
+        const tmpfsDev = fsSync.statSync(tmpfsState).dev;
+        if (diskDev === tmpfsDev) {
+          // os.tmpdir() is itself on tmpfs here, so there is no cross-device boundary to exercise.
+          ctx.skip();
+          return;
+        }
+        process.env.OPENCLAW_STATE_DIR = tmpfsState;
+        const tmpfsCanonical = path.join(tmpfsState, FILENAME);
+        await writeLegacyPolicy("deny");
+
+        const result = await relocateLegacyExecApprovalsStateFile({ env: process.env });
+
+        expect(result.warnings).toEqual([]);
+        expect(result.changes).toHaveLength(1);
+        expect(result.changes[0]).toContain("Moved exec-approvals policy");
+        await expect(fs.readFile(tmpfsCanonical, "utf8")).resolves.toContain('"security": "deny"');
+        await expect(fs.access(legacyPath)).rejects.toThrow();
+      } finally {
+        await fs.rm(tmpfsState, { recursive: true, force: true });
+      }
+    },
+  );
 
   it("is a no-op for default installs where state dir equals the home location", async () => {
     delete process.env.OPENCLAW_STATE_DIR;

--- a/src/commands/doctor/shared/exec-approvals-state-dir-relocation.ts
+++ b/src/commands/doctor/shared/exec-approvals-state-dir-relocation.ts
@@ -1,0 +1,174 @@
+// Doctor migration: relocate a legacy home-relative exec-approvals policy file into
+// the resolved state dir. Exec approvals now read only resolveStateDir()/exec-approvals.json,
+// but earlier versions always wrote ~/.openclaw/exec-approvals.json regardless of
+// OPENCLAW_STATE_DIR. Without this migration a relocated-state install would silently
+// fall back to the default full/off policy on upgrade, dropping an existing
+// deny/allowlist policy. Runtime stays canonical-only; legacy resolution lives here.
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { resolveNewStateDir, resolveStateDir } from "../../../config/paths.js";
+import {
+  EXEC_APPROVALS_FILENAME,
+  EXEC_APPROVALS_SOCKET_FILENAME,
+  type ExecApprovalsFile,
+} from "../../../infra/exec-approvals.js";
+import { assertNoSymlinkParentsSync } from "../../../infra/fs-safe-advanced.js";
+import { expandHomePrefix, resolveRequiredHomeDir } from "../../../infra/home-dir.js";
+import { shortenHomePath } from "../../../utils.js";
+
+const EXEC_APPROVALS_FILE_MODE = 0o600;
+
+function resolveCanonicalPath(env: NodeJS.ProcessEnv): string {
+  return path.join(resolveStateDir(env), EXEC_APPROVALS_FILENAME);
+}
+
+function resolveCanonicalSocketPath(env: NodeJS.ProcessEnv): string {
+  return path.join(resolveStateDir(env), EXEC_APPROVALS_SOCKET_FILENAME);
+}
+
+// The legacy location is always <home>/.openclaw, matching the historical
+// expandHomePrefix("~/.openclaw/...") that ignored OPENCLAW_STATE_DIR.
+function resolveLegacyHomePath(env: NodeJS.ProcessEnv): string {
+  const homedir = () => resolveRequiredHomeDir(env, os.homedir);
+  return path.join(resolveNewStateDir(homedir), EXEC_APPROVALS_FILENAME);
+}
+
+// The generated default socket the shipped runtime persisted alongside the legacy
+// policy: always <home>/.openclaw/exec-approvals.sock, matching the historical
+// resolveExecApprovalsSocketPath() that ignored OPENCLAW_STATE_DIR.
+function resolveLegacyDefaultSocketPath(env: NodeJS.ProcessEnv): string {
+  const homedir = () => resolveRequiredHomeDir(env, os.homedir);
+  return path.join(resolveNewStateDir(homedir), EXEC_APPROVALS_SOCKET_FILENAME);
+}
+
+async function isRegularFile(target: string): Promise<boolean> {
+  try {
+    const stat = await fs.lstat(target);
+    return stat.isFile();
+  } catch {
+    return false;
+  }
+}
+
+async function pathExists(target: string): Promise<boolean> {
+  try {
+    await fs.lstat(target);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// A relocated policy whose socket.path still points at the generated home default would
+// keep command-approval IPC on the old socket after the file moves, so the policy file and
+// approval socket disagree. Rewrite that one generated value to the canonical socket;
+// operator-chosen custom socket paths are left untouched.
+function rewriteLegacyDefaultSocketPath(params: { raw: string; env: NodeJS.ProcessEnv }): {
+  raw: string;
+  rewritten: boolean;
+} {
+  let parsed: ExecApprovalsFile;
+  try {
+    parsed = JSON.parse(params.raw) as ExecApprovalsFile;
+  } catch {
+    // Unparseable legacy content has no recognizable socket path; relocate it verbatim.
+    return { raw: params.raw, rewritten: false };
+  }
+  const persisted = parsed?.socket?.path?.trim();
+  if (!persisted) {
+    return { raw: params.raw, rewritten: false };
+  }
+  const homedir = () => resolveRequiredHomeDir(params.env, os.homedir);
+  const persistedAbs = path.resolve(expandHomePrefix(persisted, { env: params.env, homedir }));
+  const legacyDefaultAbs = path.resolve(resolveLegacyDefaultSocketPath(params.env));
+  if (persistedAbs !== legacyDefaultAbs) {
+    return { raw: params.raw, rewritten: false };
+  }
+  const next: ExecApprovalsFile = {
+    ...parsed,
+    socket: { ...parsed.socket, path: resolveCanonicalSocketPath(params.env) },
+  };
+  return { raw: `${JSON.stringify(next, null, 2)}\n`, rewritten: true };
+}
+
+// Write the relocated policy via a temp file in the canonical dir then rename, so the
+// move is atomic and stays on one device (the legacy file may live on another mount).
+// O_EXCL refuses to follow or clobber anything already at the canonical path.
+async function writeCanonicalPolicy(canonicalPath: string, raw: string): Promise<void> {
+  const dir = path.dirname(canonicalPath);
+  // Mirror the runtime exec-approvals write guard (ensureDir): refuse to relocate into a
+  // symlinked state dir. Without this the policy would land somewhere runtime later refuses
+  // to read while the legacy file is already removed, breaking exec approvals. Anchored at
+  // the dir's parent like the runtime guard so the final state-dir component is checked too.
+  assertNoSymlinkParentsSync({
+    rootDir: path.dirname(dir),
+    targetPath: dir,
+    allowOutsideRoot: true,
+    messagePrefix: "Refusing to relocate exec approvals into symlinked path",
+  });
+  await fs.mkdir(dir, { recursive: true });
+  const tempPath = path.join(dir, `.exec-approvals.${process.pid}.${crypto.randomUUID()}.tmp`);
+  try {
+    await fs.writeFile(tempPath, raw, { mode: EXEC_APPROVALS_FILE_MODE, flag: "wx" });
+    await fs.rename(tempPath, canonicalPath);
+  } finally {
+    await fs.rm(tempPath, { force: true });
+  }
+}
+
+/** Move a pre-existing home-relative exec-approvals policy file into the resolved state dir. */
+export async function relocateLegacyExecApprovalsStateFile(params?: {
+  env?: NodeJS.ProcessEnv;
+}): Promise<{ changes: string[]; warnings: string[] }> {
+  const env = params?.env ?? process.env;
+  const canonicalPath = path.resolve(resolveCanonicalPath(env));
+  const legacyPath = path.resolve(resolveLegacyHomePath(env));
+  const changes: string[] = [];
+  const warnings: string[] = [];
+
+  // Default installs already resolve to the legacy location, so there is nothing to move.
+  if (canonicalPath === legacyPath) {
+    return { changes, warnings };
+  }
+  if (!(await pathExists(legacyPath))) {
+    return { changes, warnings };
+  }
+  if (!(await isRegularFile(legacyPath))) {
+    warnings.push(
+      `Legacy exec-approvals policy at ${shortenHomePath(legacyPath)} is not a regular file; ` +
+        `move it to ${shortenHomePath(canonicalPath)} manually so the relocated state dir keeps your approval policy.`,
+    );
+    return { changes, warnings };
+  }
+  if (await pathExists(canonicalPath)) {
+    // Both present: the runtime already uses the canonical file, so refuse to clobber it.
+    // Surface the now-ignored legacy file instead of silently dropping or overwriting policy.
+    warnings.push(
+      `Both ${shortenHomePath(canonicalPath)} and the legacy ${shortenHomePath(legacyPath)} exec-approvals policies exist; ` +
+        `the relocated state dir file is authoritative. Reconcile and remove the legacy file.`,
+    );
+    return { changes, warnings };
+  }
+
+  try {
+    const legacyRaw = await fs.readFile(legacyPath, "utf8");
+    const { raw, rewritten } = rewriteLegacyDefaultSocketPath({ raw: legacyRaw, env });
+    await writeCanonicalPolicy(canonicalPath, raw);
+    await fs.unlink(legacyPath);
+    changes.push(
+      rewritten
+        ? `Moved exec-approvals policy from ${shortenHomePath(legacyPath)} to ${shortenHomePath(canonicalPath)} ` +
+            `and rewrote the generated socket path to ${shortenHomePath(resolveCanonicalSocketPath(env))} ` +
+            `so the relocated state dir keeps your approval policy and its IPC socket.`
+        : `Moved exec-approvals policy from ${shortenHomePath(legacyPath)} to ${shortenHomePath(canonicalPath)} so the relocated state dir keeps your approval policy.`,
+    );
+  } catch (error) {
+    warnings.push(
+      `Failed to move exec-approvals policy from ${shortenHomePath(legacyPath)} to ${shortenHomePath(canonicalPath)}: ${String(error)}`,
+    );
+  }
+
+  return { changes, warnings };
+}

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -3,8 +3,23 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { resolveHomeRelativePath, resolveRequiredHomeDir } from "../infra/home-dir.js";
+import {
+  normalizeStateDirEnv,
+  resolveLegacyStateDir,
+  resolveLegacyStateDirs,
+  resolveNewStateDir,
+  resolveStateDir,
+} from "../infra/state-dir.js";
 import { parseTcpPort } from "../infra/tcp-port.js";
 import type { OpenClawConfig } from "./types.js";
+
+export {
+  normalizeStateDirEnv,
+  resolveLegacyStateDir,
+  resolveLegacyStateDirs,
+  resolveNewStateDir,
+  resolveStateDir,
+};
 
 /**
  * Nix mode detection: When OPENCLAW_NIX_MODE=1, the gateway is running under Nix.
@@ -19,83 +34,12 @@ export function resolveIsNixMode(env: NodeJS.ProcessEnv = process.env): boolean 
 
 export const isNixMode = resolveIsNixMode();
 
-// Support the remaining legacy pre-rebrand state dir.
-const LEGACY_STATE_DIRNAMES = [".clawdbot"] as const;
-const NEW_STATE_DIRNAME = ".openclaw";
 const CONFIG_FILENAME = "openclaw.json";
 const LEGACY_CONFIG_FILENAMES = ["clawdbot.json"] as const;
-
-function resolveDefaultHomeDir(): string {
-  return resolveRequiredHomeDir(process.env, os.homedir);
-}
 
 /** Build a homedir thunk that respects OPENCLAW_HOME for the given env. */
 function envHomedir(env: NodeJS.ProcessEnv): () => string {
   return () => resolveRequiredHomeDir(env, os.homedir);
-}
-
-function legacyStateDirs(homedir: () => string = resolveDefaultHomeDir): string[] {
-  return LEGACY_STATE_DIRNAMES.map((dir) => path.join(homedir(), dir));
-}
-
-function newStateDir(homedir: () => string = resolveDefaultHomeDir): string {
-  return path.join(homedir(), NEW_STATE_DIRNAME);
-}
-
-export function resolveLegacyStateDir(homedir: () => string = resolveDefaultHomeDir): string {
-  return legacyStateDirs(homedir)[0] ?? newStateDir(homedir);
-}
-
-export function resolveLegacyStateDirs(homedir: () => string = resolveDefaultHomeDir): string[] {
-  return legacyStateDirs(homedir);
-}
-
-export function resolveNewStateDir(homedir: () => string = resolveDefaultHomeDir): string {
-  return newStateDir(homedir);
-}
-
-/**
- * State directory for mutable data (sessions, logs, caches).
- * Can be overridden via OPENCLAW_STATE_DIR.
- * Default: ~/.openclaw
- */
-export function resolveStateDir(
-  env: NodeJS.ProcessEnv = process.env,
-  homedir: () => string = envHomedir(env),
-): string {
-  const effectiveHomedir = () => resolveRequiredHomeDir(env, homedir);
-  const override = env.OPENCLAW_STATE_DIR?.trim();
-  if (override) {
-    return resolveUserPath(override, env, effectiveHomedir);
-  }
-  const newDir = newStateDir(effectiveHomedir);
-  if (env.OPENCLAW_TEST_FAST === "1") {
-    return newDir;
-  }
-  const legacyDirs = legacyStateDirs(effectiveHomedir);
-  const hasNew = fs.existsSync(newDir);
-  if (hasNew) {
-    return newDir;
-  }
-  const existingLegacy = legacyDirs.find((dir) => {
-    try {
-      return fs.existsSync(dir);
-    } catch {
-      return false;
-    }
-  });
-  if (existingLegacy) {
-    return existingLegacy;
-  }
-  return newDir;
-}
-
-export function normalizeStateDirEnv(env: NodeJS.ProcessEnv = process.env): void {
-  const effectiveHomedir = () => resolveRequiredHomeDir(env, envHomedir(env));
-  const openclawOverride = env.OPENCLAW_STATE_DIR?.trim();
-  if (openclawOverride) {
-    env.OPENCLAW_STATE_DIR = resolveUserPath(openclawOverride, env, effectiveHomedir);
-  }
 }
 
 function resolveUserPath(
@@ -253,7 +197,10 @@ export function resolveDefaultConfigCandidates(
     candidates.push(...LEGACY_CONFIG_FILENAMES.map((name) => path.join(resolved, name)));
   }
 
-  const defaultDirs = [newStateDir(effectiveHomedir), ...legacyStateDirs(effectiveHomedir)];
+  const defaultDirs = [
+    resolveNewStateDir(effectiveHomedir),
+    ...resolveLegacyStateDirs(effectiveHomedir),
+  ];
   for (const dir of defaultDirs) {
     candidates.push(path.join(dir, CONFIG_FILENAME));
     candidates.push(...LEGACY_CONFIG_FILENAMES.map((name) => path.join(dir, name)));

--- a/src/infra/exec-approvals-effective.ts
+++ b/src/infra/exec-approvals-effective.ts
@@ -2,6 +2,7 @@
 import { sortUniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { DEFAULT_AGENT_ID } from "../routing/session-key.js";
+import { shortenHomePath } from "../utils.js";
 import {
   DEFAULT_EXEC_APPROVAL_ASK_FALLBACK,
   resolveExecApprovalAllowedDecisions,
@@ -9,6 +10,7 @@ import {
   maxAsk,
   minSecurity,
   resolveExecApprovalsFromFile,
+  resolveExecApprovalsPath,
   resolveExecModeFromPolicy,
   resolveExecModePolicy,
   type ExecApprovalsFile,
@@ -20,7 +22,6 @@ import {
 
 const DEFAULT_REQUESTED_SECURITY: ExecSecurity = "full";
 const DEFAULT_REQUESTED_ASK: ExecAsk = "off";
-const DEFAULT_HOST_PATH = "~/.openclaw/exec-approvals.json";
 const REQUESTED_DEFAULT_LABEL = {
   security: DEFAULT_REQUESTED_SECURITY,
   ask: DEFAULT_REQUESTED_ASK,
@@ -367,7 +368,9 @@ export function resolveExecPolicyScopeSnapshot(params: {
       ask: requestedPolicy.ask,
     },
   });
-  const hostPath = params.hostPath ?? DEFAULT_HOST_PATH;
+  // No explicit snapshot path means resolve the live default, which now honors
+  // OPENCLAW_STATE_DIR; shortenHomePath keeps the default install showing ~/.openclaw.
+  const hostPath = params.hostPath ?? shortenHomePath(resolveExecApprovalsPath());
   const effectiveSecurity = minSecurity(requestedPolicy.security, resolved.agent.security);
   const effectiveAsk = maxAsk(requestedPolicy.ask, resolved.agent.ask);
   const effectiveAskFallback = minSecurity(effectiveSecurity, resolved.agent.askFallback);

--- a/src/infra/exec-approvals-state-dir.test.ts
+++ b/src/infra/exec-approvals-state-dir.test.ts
@@ -1,0 +1,89 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  resolveExecApprovalsPath,
+  resolveExecApprovalsSocketPath,
+  saveExecApprovals,
+} from "./exec-approvals.js";
+
+// exec-approvals must store its file/socket in the OpenClaw state dir, honoring
+// OPENCLAW_STATE_DIR like the rest of the runtime — not always under $HOME/.openclaw.
+//
+// Documented precedence (https://docs.openclaw.ai/help/environment): OPENCLAW_HOME replaces
+// $HOME as the foundation for path *defaults* (so the state dir defaults to
+// <OPENCLAW_HOME>/.openclaw), while an explicit OPENCLAW_STATE_DIR *takes precedence* over
+// that default. resolveStateDir() implements exactly this; the tests below pin both directions.
+describe("exec-approvals path honors OPENCLAW_STATE_DIR", () => {
+  const created: string[] = [];
+  const originalHome = process.env.OPENCLAW_HOME;
+  const originalStateDir = process.env.OPENCLAW_STATE_DIR;
+
+  afterEach(() => {
+    if (originalHome === undefined) {
+      delete process.env.OPENCLAW_HOME;
+    } else {
+      process.env.OPENCLAW_HOME = originalHome;
+    }
+    if (originalStateDir === undefined) {
+      delete process.env.OPENCLAW_STATE_DIR;
+    } else {
+      process.env.OPENCLAW_STATE_DIR = originalStateDir;
+    }
+    for (const dir of created.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  function mkTmp(): string {
+    const dir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "oc-exec-approvals-")));
+    created.push(dir);
+    return dir;
+  }
+
+  it("derives <OPENCLAW_HOME>/.openclaw when no explicit OPENCLAW_STATE_DIR is set", () => {
+    // OPENCLAW_HOME replaces $HOME for path defaults → state dir defaults to <home>/.openclaw.
+    const home = mkTmp();
+    process.env.OPENCLAW_HOME = home;
+    delete process.env.OPENCLAW_STATE_DIR;
+
+    expect(resolveExecApprovalsPath()).toBe(path.join(home, ".openclaw", "exec-approvals.json"));
+    expect(resolveExecApprovalsSocketPath()).toBe(
+      path.join(home, ".openclaw", "exec-approvals.sock"),
+    );
+  });
+
+  it("lets explicit OPENCLAW_STATE_DIR take precedence over the OPENCLAW_HOME default", () => {
+    // Both set to different dirs: the explicit OPENCLAW_STATE_DIR wins (per docs), not OPENCLAW_HOME.
+    const home = mkTmp();
+    const stateDir = mkTmp();
+    process.env.OPENCLAW_HOME = home;
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+
+    expect(resolveExecApprovalsPath()).toBe(path.join(stateDir, "exec-approvals.json"));
+    expect(resolveExecApprovalsSocketPath()).toBe(path.join(stateDir, "exec-approvals.sock"));
+    // ...and explicitly NOT the OPENCLAW_HOME-derived default, proving STATE_DIR precedence.
+    expect(resolveExecApprovalsPath()).not.toBe(
+      path.join(home, ".openclaw", "exec-approvals.json"),
+    );
+  });
+
+  it("still refuses a relocated state dir whose final component is a symlink", () => {
+    // OPENCLAW_STATE_DIR points at a symlinked `.openclaw` — the symlink guard must still
+    // bite on the relocated path (Option B keeps the parent-component check; allowOutsideRoot
+    // would otherwise skip it).
+    const base = mkTmp();
+    const realTarget = path.join(base, "real-state");
+    fs.mkdirSync(realTarget, { recursive: true });
+    const stateDir = path.join(base, ".openclaw");
+    fs.symlinkSync(realTarget, stateDir, "dir");
+    process.env.OPENCLAW_HOME = mkTmp();
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+
+    expect(() =>
+      saveExecApprovals({ version: 1, defaults: { security: "full" }, agents: {} }),
+    ).toThrow(/Refusing to traverse symlink in exec approvals path/);
+    expect(fs.existsSync(path.join(realTarget, "exec-approvals.json"))).toBe(false);
+  });
+});

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -15,8 +15,9 @@ import { analyzeShellCommand, type ExecCommandSegment } from "./exec-approvals-a
 import type { ExecAllowlistEntry } from "./exec-approvals.types.js";
 import { isShellWrapperInvocation } from "./exec-wrapper-resolution.js";
 import { assertNoSymlinkParentsSync } from "./fs-safe-advanced.js";
-import { expandHomePrefix, resolveRequiredHomeDir } from "./home-dir.js";
+import { expandHomePrefix } from "./home-dir.js";
 import { requestJsonlSocket } from "./jsonl-socket.js";
+import { resolveStateDir } from "./state-dir.js";
 export * from "./exec-approvals-analysis.js";
 export * from "./exec-approvals-allowlist.js";
 export type { ExecAllowlistEntry } from "./exec-approvals.types.js";
@@ -284,8 +285,12 @@ const DEFAULT_SECURITY: ExecSecurity = "full";
 const DEFAULT_ASK: ExecAsk = "off";
 export const DEFAULT_EXEC_APPROVAL_ASK_FALLBACK: ExecSecurity = "full";
 const DEFAULT_AUTO_ALLOW_SKILLS = false;
-const DEFAULT_SOCKET = "~/.openclaw/exec-approvals.sock";
-const DEFAULT_FILE = "~/.openclaw/exec-approvals.json";
+// Exported so the doctor state-dir relocation migration moves the same policy file
+// the runtime reads, without redefining the filename.
+export const EXEC_APPROVALS_FILENAME = "exec-approvals.json";
+// Exported so the doctor state-dir relocation migration can recognize and rewrite
+// the generated default socket path using the same filename the runtime persists.
+export const EXEC_APPROVALS_SOCKET_FILENAME = "exec-approvals.sock";
 
 function hashExecApprovalsRaw(raw: string | null): string {
   return crypto
@@ -294,12 +299,17 @@ function hashExecApprovalsRaw(raw: string | null): string {
     .digest("hex");
 }
 
+// exec-approvals state belongs in the OpenClaw state directory alongside the rest of
+// the runtime state. resolveStateDir() honors OPENCLAW_STATE_DIR and falls back to
+// <home>/.openclaw, so default installs are unchanged, while a relocated state dir
+// resolves to the real directory instead of always traversing $HOME/.openclaw (which
+// breaks when state is relocated or $HOME/.openclaw is a symlink).
 export function resolveExecApprovalsPath(): string {
-  return expandHomePrefix(DEFAULT_FILE);
+  return path.join(resolveStateDir(), EXEC_APPROVALS_FILENAME);
 }
 
 export function resolveExecApprovalsSocketPath(): string {
-  return expandHomePrefix(DEFAULT_SOCKET);
+  return path.join(resolveStateDir(), EXEC_APPROVALS_SOCKET_FILENAME);
 }
 
 function normalizeAllowlistPattern(value: string | undefined): string | null {
@@ -343,7 +353,7 @@ function mergeLegacyAgent(
 
 function ensureDir(filePath: string) {
   const dir = path.dirname(filePath);
-  assertNoExecApprovalsSymlinkParents(dir, resolveRequiredHomeDir());
+  assertNoExecApprovalsSymlinkParents(dir, path.dirname(dir));
   fs.mkdirSync(dir, { recursive: true });
   const dirStat = fs.lstatSync(dir);
   if (!dirStat.isDirectory() || dirStat.isSymbolicLink()) {
@@ -359,6 +369,10 @@ function ensureDir(filePath: string) {
   return dir;
 }
 
+// Callers pass the state dir's parent as `trustedRoot`, so the guard checks the final
+// state-dir component (e.g. `.openclaw`). When OPENCLAW_STATE_DIR is unset this equals
+// <home> — identical to the historical behavior — and when state is relocated it still
+// guards the state dir rather than skipping the check via allowOutsideRoot.
 function assertNoExecApprovalsSymlinkParents(targetPath: string, trustedRoot: string): void {
   assertNoSymlinkParentsSync({
     rootDir: trustedRoot,
@@ -837,7 +851,7 @@ export function ensureExecApprovals(): ExecApprovalsFile {
 
 function readExecApprovalsForNoPersistence(filePath: string): ExecApprovalsFile {
   const dir = path.dirname(filePath);
-  assertNoExecApprovalsSymlinkParents(dir, resolveRequiredHomeDir());
+  assertNoExecApprovalsSymlinkParents(dir, path.dirname(dir));
   assertSafeExecApprovalsDestination(filePath);
 
   let raw: string;

--- a/src/infra/state-dir.ts
+++ b/src/infra/state-dir.ts
@@ -1,0 +1,85 @@
+// Resolves OpenClaw mutable state directories without depending on config modules.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { resolveHomeRelativePath, resolveRequiredHomeDir } from "./home-dir.js";
+
+// Support the remaining legacy pre-rebrand state dir.
+const LEGACY_STATE_DIRNAMES = [".clawdbot"] as const;
+const NEW_STATE_DIRNAME = ".openclaw";
+
+function resolveDefaultHomeDir(): string {
+  return resolveRequiredHomeDir(process.env, os.homedir);
+}
+
+/** Build a homedir thunk that respects OPENCLAW_HOME for the given env. */
+function envHomedir(env: NodeJS.ProcessEnv): () => string {
+  return () => resolveRequiredHomeDir(env, os.homedir);
+}
+
+function legacyStateDirs(homedir: () => string = resolveDefaultHomeDir): string[] {
+  return LEGACY_STATE_DIRNAMES.map((dir) => path.join(homedir(), dir));
+}
+
+function newStateDir(homedir: () => string = resolveDefaultHomeDir): string {
+  return path.join(homedir(), NEW_STATE_DIRNAME);
+}
+
+export function resolveLegacyStateDir(homedir: () => string = resolveDefaultHomeDir): string {
+  return legacyStateDirs(homedir)[0] ?? newStateDir(homedir);
+}
+
+export function resolveLegacyStateDirs(homedir: () => string = resolveDefaultHomeDir): string[] {
+  return legacyStateDirs(homedir);
+}
+
+export function resolveNewStateDir(homedir: () => string = resolveDefaultHomeDir): string {
+  return newStateDir(homedir);
+}
+
+/**
+ * State directory for mutable data (sessions, logs, caches).
+ * Can be overridden via OPENCLAW_STATE_DIR.
+ * Default: ~/.openclaw
+ */
+export function resolveStateDir(
+  env: NodeJS.ProcessEnv = process.env,
+  homedir: () => string = envHomedir(env),
+): string {
+  const effectiveHomedir = () => resolveRequiredHomeDir(env, homedir);
+  const override = env.OPENCLAW_STATE_DIR?.trim();
+  if (override) {
+    return resolveHomeRelativePath(override, { env, homedir: effectiveHomedir });
+  }
+  const newDir = newStateDir(effectiveHomedir);
+  if (env.OPENCLAW_TEST_FAST === "1") {
+    return newDir;
+  }
+  const legacyDirs = legacyStateDirs(effectiveHomedir);
+  const hasNew = fs.existsSync(newDir);
+  if (hasNew) {
+    return newDir;
+  }
+  const existingLegacy = legacyDirs.find((dir) => {
+    try {
+      return fs.existsSync(dir);
+    } catch {
+      return false;
+    }
+  });
+  if (existingLegacy) {
+    return existingLegacy;
+  }
+  return newDir;
+}
+
+export function normalizeStateDirEnv(env: NodeJS.ProcessEnv = process.env): void {
+  const effectiveHomedir = () => resolveRequiredHomeDir(env, envHomedir(env));
+  const openclawOverride = env.OPENCLAW_STATE_DIR?.trim();
+  if (openclawOverride) {
+    env.OPENCLAW_STATE_DIR = resolveHomeRelativePath(openclawOverride, {
+      env,
+      homedir: effectiveHomedir,
+    });
+  }
+}


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- `exec-approvals.{json,sock}` were resolved from the home default instead of the canonical OpenClaw state dir.
- Relocated installs using `OPENCLAW_STATE_DIR` could split approval state or fail exec calls when `$HOME/.openclaw` was symlinked.
- Changed files: `src/infra/exec-approvals.ts`, `src/infra/exec-approvals-state-dir.test.ts`, `src/agents/bash-tools.exec.security-floor.test.ts`, `src/config/paths.ts`, `src/infra/state-dir.ts`.

Why does this matter now?

- `OPENCLAW_STATE_DIR` is documented and supported, but exec approvals were not honoring that state-dir override.

What is the intended outcome?

- Exec approvals resolve through `resolveStateDir()`.
- Default installs keep the same `<home>/.openclaw/exec-approvals.*` paths.
- Relocated installs use `$OPENCLAW_STATE_DIR` for approval storage.

What is intentionally out of scope?

- Approval policy, command analysis, socket protocol behavior, and config-supplied `socket.path` overrides.

What does success look like?

- Default installs keep existing behavior.
- Relocated installs keep approval files and sockets under the configured state dir.
- Symlinked state-dir components are still refused by the exec-approval symlink guard.

What should reviewers focus on?

- The state-dir ownership boundary in `src/infra/exec-approvals.ts`.
- The trusted-root selection for the symlink guard.
- The default-path and relocated-path regression coverage.

<details>
<summary>Summary guidance</summary>

This PR description is the contributor's durable explanation of the change. Write it for human maintainers first; ClawSweeper and Barnacle use the same text to understand intent, proof, risk, and current review state.

Describe the intent and outcome in 2-5 bullets. Avoid restating the diff; reviewers and bots can read the changed files.

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

</details>

## Linked context

Which issue does this close?

Closes #90971

Which issues, PRs, or discussions are related?

- Related state-dir consumers: `src/infra/device-auth-store.ts`, `src/infra/restart-sentinel.ts`, `src/infra/push-web.ts`.
- Related docs: https://docs.openclaw.ai/help/environment/

Was this requested by a maintainer or owner?

- Yes, owner request.

<details>
<summary>Linked context guidance</summary>

Link the issue, PR, discussion, maintainer request, or owner request that explains why this PR should exist. Maintainer context helps reviewers and automation distinguish intended work from drive-by churn.

</details>

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: exec-approvals path resolution under `OPENCLAW_STATE_DIR`, including symlinked-home relocated installs.
- Real environment tested: macOS local checkout, Node 24.16.0.
- Exact steps or command run after this patch: `node --import tsx scripts/check-import-cycles.ts`; `node scripts/run-vitest.mjs src/infra/exec-approvals-state-dir.test.ts src/agents/bash-tools.exec.security-floor.test.ts src/config/paths.test.ts`; `./node_modules/.bin/oxfmt --check --threads=1 src/infra/exec-approvals.ts src/infra/exec-approvals-state-dir.test.ts src/agents/bash-tools.exec.security-floor.test.ts src/config/paths.ts src/infra/state-dir.ts`; `git diff --check --cached`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): `Import cycle check: 0 runtime value cycle(s).`; `[test] passed 3 Vitest shards in 11.85s`; `All matched files use the correct format.`
- Observed result after fix: approvals resolve to the configured state dir, default installs keep the same paths, and the symlink guard still refuses a symlinked state-dir component.
- What was not tested: full multi-host gateway/live approval run.
- Proof limitations or environment constraints: local macOS proof only; GitHub CI will re-run on the pushed PR head. The broad Madge import-cycle check still reports an existing upstream-main SCC and is not claimed as passing here.
- Before evidence (optional but encouraged): relocated installs previously wrote approvals to `$HOME/.openclaw`, and symlinked-home setups could fail exec calls with `Refusing to traverse symlink in exec approvals path`.

<details>
<summary>Real behavior proof guidance</summary>

External contributors must show after-fix evidence from a real OpenClaw setup. Unit tests, mocks, lint, typechecks, snapshots, and CI are supplemental only.

Screenshots are encouraged even for CLI, console, text, or log changes. Terminal screenshots, copied live output, redacted runtime logs, recordings, and linked artifacts count.

If your environment cannot produce the ideal proof, explain that under `Proof limitations or environment constraints` so reviewers and ClawSweeper can direct the next step properly.

Be mindful of private information like IP addresses, API keys, phone numbers, non-public endpoints, or other private details when providing evidence.

</details>

## Tests and validation

Which commands did you run?

- `node --import tsx scripts/check-import-cycles.ts` -> `0 runtime value cycle(s)`.
- `node scripts/run-vitest.mjs src/infra/exec-approvals-state-dir.test.ts src/agents/bash-tools.exec.security-floor.test.ts src/config/paths.test.ts` -> 3 shards, 3 files, 42 tests passed.
- `./node_modules/.bin/oxfmt --check --threads=1 src/infra/exec-approvals.ts src/infra/exec-approvals-state-dir.test.ts src/agents/bash-tools.exec.security-floor.test.ts src/config/paths.ts src/infra/state-dir.ts` -> clean.
- `git diff --check --cached` -> clean.

What regression coverage was added or updated?

- Added `src/infra/exec-approvals-state-dir.test.ts` coverage for HOME-only defaults, `OPENCLAW_STATE_DIR` precedence, and relocated symlink refusal.
- Updated `src/agents/bash-tools.exec.security-floor.test.ts` expectations for state-dir-aware approval paths.

What failed before this fix, if known?

- Relocated installs used `$HOME/.openclaw` instead of `$OPENCLAW_STATE_DIR`.
- Symlinked-home relocated installs could fail exec calls with the symlink guard refusal.

If no test was added, why not?

- Tests were added and updated for the touched behavior.

<details>
<summary>Testing guidance</summary>

List focused commands, not every incidental check. CI is useful support, but external PRs still need real behavior proof above when behavior changes.

</details>

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

- Yes. Relocated-state installs now read and write exec approvals in `$OPENCLAW_STATE_DIR`; default installs keep the same paths.

Did config, environment, or migration behavior change? (`Yes/No`)

- Yes. `OPENCLAW_STATE_DIR` now controls exec-approval storage like the other state-owned files. No new config key or migration was added.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

- Yes. This touches command-execution approval storage only; approval policy and socket protocol are unchanged, and symlink refusal is preserved.

What is the highest-risk area?

- Trusted-root selection for the approval path symlink guard.

How is that risk mitigated?

- Default installs keep a trusted root equivalent to the previous home root.
- Relocated installs are covered by state-dir precedence and symlink-refusal tests.

<details>
<summary>Risk guidance</summary>

Use this for author judgment that is not obvious from the diff. ClawSweeper can see touched files, but it cannot know which behavior you think is risky, why the risk is acceptable, or what mitigation reviewers should verify.

</details>

## Current review state

What is the next action?

- CI and maintainer review on the scoped 5-file PR head.

What is still waiting on author, maintainer, CI, or external proof?

- GitHub CI on `3f7e17d2825f21184ce7fbf7c774171098661947`.

Which bot or reviewer comments were addressed?

- PR scope and body were repaired for the updated 5-file branch.

<details>
<summary>Review state guidance</summary>

Keep this as the durable state for review progress. If useful information appears in comments, fold the current next action or blocker back here so maintainers and ClawSweeper do not need to reconstruct state from comment history.

</details>


---

## Real behavior proof

**Behavior addressed:** `openclaw doctor --fix` now relocates a legacy `~/.openclaw/exec-approvals.json` into `OPENCLAW_STATE_DIR` **and** rewrites the generated home-relative `socket.path` (`~/.openclaw/exec-approvals.sock`) to the relocated state dir, so the approval policy file and the command-approval IPC socket no longer disagree after relocation. Operator-chosen custom socket paths are preserved. The `approvals.exec.enabled=false` doctor-security note now prints the resolved policy path instead of a hard-coded `~/.openclaw/...`.

**Real environment tested:** local macOS (darwin), Node 24, built CLI (`pnpm build`), isolated `HOME`/`OPENCLAW_HOME`/`OPENCLAW_STATE_DIR` temp dirs. Token redacted in all output.

**Exact steps or command run after this patch:**
1. Create a legacy policy the shipped runtime way (no `OPENCLAW_STATE_DIR`): `ensureExecApprovals()` wrote `<home>/.openclaw/exec-approvals.json` with `defaults.security=deny`, generated `socket.path=<home>/.openclaw/exec-approvals.sock`, and a token.
2. Relocate: `OPENCLAW_STATE_DIR=<state> openclaw doctor --fix`.
3. Inspect resolved policy: `OPENCLAW_STATE_DIR=<state> openclaw approvals get --json`.

**Evidence after fix:**
- doctor --fix change note: *"Moved exec-approvals policy from `$OPENCLAW_HOME/.openclaw/exec-approvals.json` to `<state>/exec-approvals.json` and rewrote the generated socket path to `<state>/exec-approvals.sock` so the relocated state dir keeps your approval policy and its IPC socket."*
- Legacy dir `<home>/.openclaw/` after fix: empty (`total 0`).
- Relocated `<state>/exec-approvals.json`: `socket.path = <state>/exec-approvals.sock`, token + `defaults.security=deny` preserved.
- `approvals get --json` resolved: both `path` and `socket.path` under `<state>`, deny policy intact.

**Observed result after fix:** policy file and socket both resolve to the relocated state dir; the deny policy and original token are preserved; the legacy file is removed. Regression tests cover the generated-default rewrite (fixture produced by the real `ensureExecApprovals` path) and the custom-socket preserve-untouched case.

**What was not tested:** live cross-device (EXDEV) relocation and Linux; the `approvals.exec.enabled=false` note path was covered by unit test, not a live run.
