### PR TITLE
feat(google): add Antigravity CLI backend

### DIFF
--- a/extensions/google/cli-backend.test.ts
+++ b/extensions/google/cli-backend.test.ts
@@ -1,0 +1,45 @@
+// Google CLI backend tests cover bundled CLI runtime descriptors.
+import { describe, expect, it } from "vitest";
+import { buildGoogleAntigravityCliBackend, buildGoogleGeminiCliBackend } from "./cli-backend.js";
+
+describe("google cli backends", () => {
+  it("keeps the Gemini CLI backend configured for JSON sessions", () => {
+    const backend = buildGoogleGeminiCliBackend();
+
+    expect(backend.id).toBe("google-gemini-cli");
+    expect(backend.modelProvider).toBe("google");
+    expect(backend.config.command).toBe("gemini");
+    expect(backend.config.output).toBe("json");
+    expect(backend.config.sessionMode).toBe("existing");
+  });
+
+  it("builds the Antigravity CLI backend around agy text output", () => {
+    const backend = buildGoogleAntigravityCliBackend();
+
+    expect(backend.id).toBe("google-antigravity-cli");
+    expect(backend.modelProvider).toBe("google");
+    expect(backend.nativeToolMode).toBe("always-on");
+    expect(backend.liveTest).toMatchObject({
+      defaultModelRef: "google-antigravity-cli/gemini-3.5-flash",
+      defaultImageProbe: false,
+      defaultMcpProbe: false,
+      docker: { binaryName: "agy" },
+    });
+    expect(backend.config).toMatchObject({
+      command: "agy",
+      args: ["--print", "{prompt}"],
+      output: "text",
+      input: "arg",
+      modelArg: "--model",
+      modelAliases: {
+        flash: "gemini-3.5-flash",
+        pro: "gemini-3.1-pro-preview",
+      },
+      sessionMode: "none",
+      serialize: true,
+    });
+    expect(backend.config).not.toHaveProperty("parseToolCalls");
+    expect(backend.config).not.toHaveProperty("imageArg");
+    expect(backend.config).not.toHaveProperty("imagePathScope");
+  });
+});

--- a/extensions/google/cli-backend.ts
+++ b/extensions/google/cli-backend.ts
@@ -11,6 +11,11 @@ const GEMINI_MODEL_ALIASES: Record<string, string> = {
   "flash-lite": "gemini-3.1-flash-lite",
 };
 const GEMINI_CLI_DEFAULT_MODEL_REF = "google-gemini-cli/gemini-3-flash-preview";
+const ANTIGRAVITY_MODEL_ALIASES: Record<string, string> = {
+  pro: "gemini-3.1-pro-preview",
+  flash: "gemini-3.5-flash",
+};
+const ANTIGRAVITY_CLI_DEFAULT_MODEL_REF = "google-antigravity-cli/gemini-3.5-flash";
 
 export function buildGoogleGeminiCliBackend(): CliBackendPlugin {
   return {
@@ -48,6 +53,38 @@ export function buildGoogleGeminiCliBackend(): CliBackendPlugin {
       modelAliases: GEMINI_MODEL_ALIASES,
       sessionMode: "existing",
       sessionIdFields: ["session_id", "sessionId"],
+      reliability: {
+        watchdog: {
+          fresh: { ...CLI_FRESH_WATCHDOG_DEFAULTS },
+          resume: { ...CLI_RESUME_WATCHDOG_DEFAULTS },
+        },
+      },
+      serialize: true,
+    },
+  };
+}
+
+export function buildGoogleAntigravityCliBackend(): CliBackendPlugin {
+  return {
+    id: "google-antigravity-cli",
+    modelProvider: "google",
+    liveTest: {
+      defaultModelRef: ANTIGRAVITY_CLI_DEFAULT_MODEL_REF,
+      defaultImageProbe: false,
+      defaultMcpProbe: false,
+      docker: {
+        binaryName: "agy",
+      },
+    },
+    nativeToolMode: "always-on",
+    config: {
+      command: "agy",
+      args: ["--print", "{prompt}"],
+      output: "text",
+      input: "arg",
+      modelArg: "--model",
+      modelAliases: ANTIGRAVITY_MODEL_ALIASES,
+      sessionMode: "none",
       reliability: {
         watchdog: {
           fresh: { ...CLI_FRESH_WATCHDOG_DEFAULTS },

--- a/extensions/google/index.ts
+++ b/extensions/google/index.ts
@@ -12,7 +12,7 @@ import type {
 import { normalizeResolvedSecretInputString } from "openclaw/plugin-sdk/secret-input";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { VideoGenerationProvider } from "openclaw/plugin-sdk/video-generation";
-import { buildGoogleGeminiCliBackend } from "./cli-backend.js";
+import { buildGoogleAntigravityCliBackend, buildGoogleGeminiCliBackend } from "./cli-backend.js";
 import { registerGoogleGeminiCliProvider } from "./gemini-cli-provider.js";
 import {
   createGoogleMusicGenerationProviderMetadata,
@@ -341,6 +341,7 @@ export default definePluginEntry({
   description: "Bundled Google plugin",
   register(api) {
     api.registerCliBackend(buildGoogleGeminiCliBackend());
+    api.registerCliBackend(buildGoogleAntigravityCliBackend());
     registerGoogleGeminiCliProvider(api);
     registerGoogleProvider(api);
     api.registerMemoryEmbeddingProvider(geminiMemoryEmbeddingProviderAdapter);

--- a/extensions/google/openclaw.plugin.json
+++ b/extensions/google/openclaw.plugin.json
@@ -658,17 +658,6 @@
       "groupLabel": "Google",
       "groupHint": "Gemini API key + OAuth",
       "onboardingFeatured": true
-    },
-    {
-      "provider": "google-antigravity-cli",
-      "method": "oauth",
-      "choiceId": "google-antigravity-cli",
-      "choiceLabel": "Antigravity CLI OAuth",
-      "choiceHint": "Google OAuth delegated to the agy CLI",
-      "groupId": "google",
-      "groupLabel": "Google",
-      "groupHint": "Gemini API key + OAuth",
-      "onboardingFeatured": true
     }
   ],
   "uiHints": {

--- a/extensions/google/openclaw.plugin.json
+++ b/extensions/google/openclaw.plugin.json
@@ -4,9 +4,9 @@
     "onStartup": false
   },
   "enabledByDefault": true,
-  "providers": ["google", "google-gemini-cli", "google-vertex"],
+  "providers": ["google", "google-antigravity-cli", "google-gemini-cli", "google-vertex"],
   "providerCatalogEntry": "./provider-discovery.ts",
-  "autoEnableWhenConfiguredProviders": ["google-gemini-cli"],
+  "autoEnableWhenConfiguredProviders": ["google-antigravity-cli", "google-gemini-cli"],
   "modelIdNormalization": {
     "providers": {
       "google": {
@@ -29,6 +29,16 @@
           "gemini-3.1-flash-lite-preview": "gemini-3.1-flash-lite",
           "gemini-3.1-flash": "gemini-3-flash-preview",
           "gemini-3.1-flash-preview": "gemini-3-flash-preview"
+        }
+      },
+      "google-antigravity-cli": {
+        "aliases": {
+          "gemini-3-pro": "gemini-3.1-pro-preview",
+          "gemini-3-pro-preview": "gemini-3.1-pro-preview",
+          "gemini-3.1-pro": "gemini-3.1-pro-preview",
+          "gemini-3.5-Flash": "gemini-3.5-flash",
+          "gemini-3.5-flash-preview": "gemini-3.5-flash",
+          "gemini-3-5-flash": "gemini-3.5-flash"
         }
       },
       "google-vertex": {
@@ -545,6 +555,14 @@
   },
   "modelPricing": {
     "providers": {
+      "google-antigravity-cli": {
+        "openRouter": {
+          "provider": "google"
+        },
+        "liteLLM": {
+          "provider": "google"
+        }
+      },
       "google-gemini-cli": {
         "openRouter": {
           "provider": "google"
@@ -574,6 +592,9 @@
   "providerRequest": {
     "providers": {
       "google": {
+        "family": "google"
+      },
+      "google-antigravity-cli": {
         "family": "google"
       },
       "google-gemini-cli": {
@@ -611,7 +632,7 @@
       }
     ]
   },
-  "cliBackends": ["google-gemini-cli"],
+  "cliBackends": ["google-antigravity-cli", "google-gemini-cli"],
   "providerAuthChoices": [
     {
       "provider": "google",
@@ -633,6 +654,17 @@
       "choiceId": "google-gemini-cli",
       "choiceLabel": "Gemini CLI OAuth",
       "choiceHint": "Google OAuth with project-aware token payload",
+      "groupId": "google",
+      "groupLabel": "Google",
+      "groupHint": "Gemini API key + OAuth",
+      "onboardingFeatured": true
+    },
+    {
+      "provider": "google-antigravity-cli",
+      "method": "oauth",
+      "choiceId": "google-antigravity-cli",
+      "choiceLabel": "Antigravity CLI OAuth",
+      "choiceHint": "Google OAuth delegated to the agy CLI",
       "groupId": "google",
       "groupLabel": "Google",
       "groupHint": "Gemini API key + OAuth",

--- a/extensions/google/setup-api.test.ts
+++ b/extensions/google/setup-api.test.ts
@@ -19,6 +19,6 @@ describe("google setup entry", () => {
     } as never);
 
     expect(providerIds).toEqual(["google-vertex"]);
-    expect(cliBackendIds).toEqual(["google-gemini-cli"]);
+    expect(cliBackendIds).toEqual(["google-gemini-cli", "google-antigravity-cli"]);
   });
 });

--- a/extensions/google/setup-api.ts
+++ b/extensions/google/setup-api.ts
@@ -1,6 +1,6 @@
 // Google API module exposes the plugin public contract.
 import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
-import { buildGoogleGeminiCliBackend } from "./cli-backend.js";
+import { buildGoogleAntigravityCliBackend, buildGoogleGeminiCliBackend } from "./cli-backend.js";
 import { createGoogleVertexProvider } from "./provider-contract-api.js";
 
 export default definePluginEntry({
@@ -10,5 +10,6 @@ export default definePluginEntry({
   register(api) {
     api.registerProvider(createGoogleVertexProvider());
     api.registerCliBackend(buildGoogleGeminiCliBackend());
+    api.registerCliBackend(buildGoogleAntigravityCliBackend());
   },
 });

--- a/src/config/model-input.ts
+++ b/src/config/model-input.ts
@@ -72,7 +72,12 @@ export function toAgentModelListLike(model?: AgentModelConfig): AgentModelListLi
   return model;
 }
 
-const GOOGLE_PROVIDER_IDS = new Set(["google", "google-gemini-cli", "google-vertex"]);
+const GOOGLE_PROVIDER_IDS = new Set([
+  "google",
+  "google-antigravity-cli",
+  "google-gemini-cli",
+  "google-vertex",
+]);
 
 /** Canonicalizes provider/model refs before they are persisted to config. */
 export function normalizeAgentModelRefForConfig(model: string): string {

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -428,6 +428,7 @@ const BUILT_IN_MODEL_PROVIDER_OVERLAY_IDS = new Set([
   "github-copilot",
   "google",
   "google-antigravity",
+  "google-antigravity-cli",
   "google-gemini-cli",
   "google-vertex",
   "groq",

--- a/src/plugin-sdk/test-helpers/plugin-registration-contract-cases.ts
+++ b/src/plugin-sdk/test-helpers/plugin-registration-contract-cases.ts
@@ -71,7 +71,7 @@ export const pluginRegistrationContractCases = {
   },
   google: {
     pluginId: "google",
-    providerIds: ["google", "google-gemini-cli", "google-vertex"],
+    providerIds: ["google", "google-antigravity-cli", "google-gemini-cli", "google-vertex"],
     webSearchProviderIds: ["gemini"],
     realtimeVoiceProviderIds: ["google"],
     speechProviderIds: ["google"],

--- a/src/plugins/config-state.ts
+++ b/src/plugins/config-state.ts
@@ -35,6 +35,7 @@ export type PluginActivationConfigSource = {
 export type NormalizedPluginsConfig = SharedNormalizedPluginsConfig;
 
 const BUILT_IN_PLUGIN_ALIAS_FALLBACKS: ReadonlyArray<readonly [alias: string, pluginId: string]> = [
+  ["google-antigravity-cli", "google"],
   ["google-gemini-cli", "google"],
   ["minimax-portal", "minimax"],
   ["minimax-portal-auth", "minimax"],

--- a/src/status/agent-runtime-label.ts
+++ b/src/status/agent-runtime-label.ts
@@ -15,6 +15,7 @@ const AGENT_RUNTIME_LABELS: Readonly<Record<string, string>> = {
   codex: "OpenAI Codex",
   "codex-cli": "OpenAI Codex",
   "claude-cli": "Claude CLI",
+  "google-antigravity-cli": "Antigravity CLI",
   "google-gemini-cli": "Gemini CLI",
 };
 


### PR DESCRIPTION
## Summary

Adds a Google Antigravity CLI runtime backend that delegates OAuth and execution to the local `agy` binary while keeping the user-facing model identity on the existing Google provider.

Fixes #84527.

## Scope

Plugin surface:

- `extensions/google/cli-backend.ts` adds `buildGoogleAntigravityCliBackend()`.
- `extensions/google/index.ts` registers the backend in the bundled Google plugin.
- `extensions/google/setup-api.ts` registers the backend in setup hooks.
- `extensions/google/openclaw.plugin.json` advertises the backend, aliases, and Google-family metadata.
- `src/status/agent-runtime-label.ts` adds the display label `Antigravity CLI`.

Minimal core adds:

- `src/config/zod-schema.core.ts` allows `google-antigravity-cli` as a provider overlay id.
- `src/plugins/config-state.ts` maps the CLI backend id to the Google plugin.
- `src/config/model-input.ts` treats `google-antigravity-cli` as a Google-family provider for model ref normalization.

## Deliberately Out Of Scope

These are known follow-up issues for separate upstream PRs:

- Status display should resolve runtime labels via the same CLI runtime resolver used by execution.
- `session_status` should handle runtime refs explicitly or provide a clearer runtime override path.
- Compaction should not bind blindly to the current session provider/model; user config can pin a working compaction model meanwhile.
- TUI sticky error state after Gateway restart should reset on connection restoration.
- `current` vs explicit session store key behavior should be documented or made consistent in session status tooling.

## Phase 12 Follow-Up

This PR intentionally does **not** add a SQLite tool-call reader for `agy`. `agy --print` currently returns text, and any SQLite reader would be heuristic and tied to internal Antigravity storage formats. Tool-call rendering should be handled as a separate Phase 12 design/PR after this runtime path is stable.

## Real behavior proof

**Behavior or issue addressed:** OpenClaw could not delegate Google chat completions to a local `agy` (Antigravity CLI) install. This PR wires the `google-antigravity-cli` provider end-to-end so a chat call routes through the CLI's already-authenticated OAuth session and returns a real Gemini response.

**Real environment tested:** macOS Darwin 25.5.0. Globally installed `openclaw` (dist v2026.6.1) patched with the PR's plugin + core changes. `agy` 1.0.6 with valid `~/.gemini/oauth_creds.json` (auto-refreshed during run after 16h expiry). User config `~/.openclaw/openclaw.json` enabling `google-antigravity-cli` with `gemini-3.5-flash`.

**Exact steps or command run after this patch:**

```
openclaw agent \
  --model google-antigravity-cli/gemini-3.5-flash \
  --message "Reply exactly OK"
```

**Evidence after fix:** Live runtime `executionTrace` captured from the actual CLI invocation against the real Google OAuth backend (terminal output from a real OpenClaw setup, not a mock and not a unit-test stub):

```
duration: 13s (cli turn 4498ms)
executionTrace:
  winnerProvider: google-antigravity-cli
  winnerModel:    gemini-3.5-flash
  runner:         cli
  result:         success
  finalAssistantVisibleText: OK
```

Routing chain verified end-to-end: OpenClaw embedded -> `buildGoogleAntigravityCliBackend` factory -> `agy --print` -> `~/.gemini/oauth_creds.json` (auto-refreshed) -> Google Gemini API -> response `OK`.

Direct `agy` sanity outside OpenClaw (terminal output):

```
$ agy --model gemini-3.5-flash --print "Reply exactly OK"
OK
```

**Observed result after fix:** OpenClaw returns the live Gemini response (`OK`) via the new CLI runtime. `winnerProvider`, `winnerModel`, and `runner` all match the requested route. OAuth refresh completed inside the same invocation without manual re-auth.

**What was not tested:**

- Tool-call rendering through the CLI runtime (deferred to Phase 12; `agy --print` currently does not emit machine-parseable tool events).
- Vertex / API-key fallbacks for the same provider id (out of scope; this PR is OAuth-via-`agy` only).
- Windows / Linux paths (verified macOS only).
