### PR TITLE
fix(agents): guard CLI MCP resume reuse

### DIFF
--- a/src/agents/cli-session.test.ts
+++ b/src/agents/cli-session.test.ts
@@ -601,6 +601,29 @@ describe("cli-session helpers", () => {
     ).toEqual({ mode: "invalidate", invalidatedReason: "mcp" });
   });
 
+  it("invalidates resume-hash bindings when the current run cannot prove the resumed MCP topology", () => {
+    const binding = {
+      sessionId: "cli-session-1",
+      authProfileId: "anthropic:work",
+      authEpoch: "auth-epoch-a",
+      authEpochVersion: 2,
+      extraSystemPromptHash: "prompt-a",
+      mcpConfigHash: "mcp-config-a",
+      mcpResumeHash: "mcp-resume-a",
+    };
+
+    expect(
+      resolveCliSessionReuse({
+        binding,
+        authProfileId: "anthropic:work",
+        authEpoch: "auth-epoch-a",
+        authEpochVersion: 2,
+        extraSystemPromptHash: "prompt-a",
+        mcpConfigHash: "mcp-config-a",
+      }),
+    ).toEqual({ mode: "invalidate", invalidatedReason: "mcp" });
+  });
+
   it("clears provider-scoped and global CLI session state", () => {
     const entry: SessionEntry = {
       sessionId: "openclaw-session",

--- a/src/agents/cli-session.ts
+++ b/src/agents/cli-session.ts
@@ -185,6 +185,9 @@ export function resolveCliSessionReuse(params: {
     return { mode: "invalidate", invalidatedReason: "cwd" };
   }
   const storedMcpResumeHash = normalizeOptionalString(binding?.mcpResumeHash);
+  if (storedMcpResumeHash && !currentMcpResumeHash) {
+    return { mode: "invalidate", invalidatedReason: "mcp" };
+  }
   if (storedMcpResumeHash && currentMcpResumeHash) {
     // Resume hashes are stricter than raw MCP config hashes: a match proves the
     // exact resumed CLI tool topology still belongs to this session.


### PR DESCRIPTION
### Summary
- Invalidate stored CLI session bindings when they have a strict `mcpResumeHash` but the current run cannot provide one.
- Add regression coverage for the one-sided resume-hash case while keeping legacy `mcpConfigHash` fallback for bindings that never stored a resume hash.

### Latest main refresh

Current head `91b0c13` is rebased onto current `main`.

- `node scripts/run-vitest.mjs src/agents/cli-session.test.ts src/agents/cli-runner/bundle-mcp.resume.test.ts src/agents/cli-runner/bundle-mcp.test.ts --reporter=dot` — 37 passed
- `./node_modules/.bin/oxfmt --check src/agents/cli-session.ts src/agents/cli-session.test.ts` — passed
- `./node_modules/.bin/oxlint --tsconfig config/tsconfig/oxlint.core.json src/agents/cli-session.ts src/agents/cli-session.test.ts` — passed
- The current discriminated reuse result is `{ mode: "invalidate", invalidatedReason: "mcp" }`.

### Root cause
`resolveCliSessionReuse` only compared `mcpResumeHash` when both the stored binding and current run had one. If a stored CLI session had a strict resume hash but a later run could not compute the current resume hash, the helper fell back to the broader `mcpConfigHash` comparison and could reuse a session without proving the resumed MCP topology still matched.

### Real behavior proof
Behavior or issue addressed: CLI sessions created with a strict bundled-MCP resume hash should not be reused by a later run that cannot prove the same resumed MCP tool topology. The patch prevents a stored `mcpResumeHash` from silently downgrading to the less precise raw MCP config hash when the current run lacks `mcpResumeHash`.

Real environment tested: Local OpenClaw checkout at `/Users/stellarfish/.codex/worktrees/5db8/openclaw-next-agent`, branch `codex/agent-runtime-followup`, macOS shell, Node `v22.22.2`, corepack pnpm `11.2.2`. The live helper proof was captured on pre-rebase commit `b391908e`. The latest head `91b0c13` preserves that behavior while adapting it to the current discriminated `CliSessionReuseResult` contract.

Exact steps or command run after this patch: I ran the copied live terminal commands below after applying this patch. The first command directly invokes the changed helper and prints the observed runtime decision; the remaining commands cover regression tests, adjacent bundled-MCP resume hash behavior, and formatting.

```text
node --import tsx --input-type=module --eval '<imports resolveCliSessionReuse and calls it with stored mcpResumeHash but no current mcpResumeHash>'
node scripts/run-vitest.mjs run src/agents/cli-session.test.ts --reporter verbose
node scripts/run-vitest.mjs run src/agents/cli-runner/bundle-mcp.resume.test.ts src/agents/cli-runner/bundle-mcp.test.ts --reporter verbose
./node_modules/.bin/oxfmt --check --threads=1 src/agents/cli-session.ts src/agents/cli-session.test.ts
```

Evidence after fix: Copied terminal transcript / live output from the pre-rebase local OpenClaw checkout:

```text
$ git rev-parse --short HEAD
b391908e
$ node --import tsx --input-type=module --eval <resolveCliSessionReuse live proof>
{
  "observed": {
    "invalidatedReason": "mcp"
  }
}

$ node --version
v22.22.2
$ corepack pnpm --version
11.2.2
$ node scripts/run-vitest.mjs run src/agents/cli-session.test.ts --reporter verbose
RUN  v4.1.7 /Users/stellarfish/.codex/worktrees/5db8/openclaw-next-agent
✓ |unit-fast| ../../src/agents/cli-session.test.ts > cli-session helpers > invalidates resume-hash bindings when the current run cannot prove the resumed MCP topology 0ms

Test Files  1 passed (1)
Tests  17 passed (17)

$ node scripts/run-vitest.mjs run src/agents/cli-runner/bundle-mcp.resume.test.ts src/agents/cli-runner/bundle-mcp.test.ts --reporter verbose
RUN  v4.1.7 /Users/stellarfish/.codex/worktrees/5db8/openclaw-next-agent
✓ |unit-fast| ../../src/agents/cli-runner/bundle-mcp.resume.test.ts > prepareCliBundleMcpConfig resume hash > stabilizes the resume hash when only the OpenClaw loopback port changes 136ms
✓ |unit-fast| ../../src/agents/cli-runner/bundle-mcp.resume.test.ts > prepareCliBundleMcpConfig resume hash > changes the resume hash when stable MCP semantics change 18ms

Test Files  3 passed (3)
Tests  14 passed (14)

$ ./node_modules/.bin/oxfmt --check --threads=1 src/agents/cli-session.ts src/agents/cli-session.test.ts
Checking formatting...
All matched files use the correct format.
Finished in 9ms on 2 files using 1 threads.
```

Observed result after fix: The pre-rebase direct helper invocation returned `{ "invalidatedReason": "mcp" }`; on the current API, focused regression coverage verifies `{ "mode": "invalidate", "invalidatedReason": "mcp" }` for the same condition. Existing bundled-MCP resume hash behavior still passes: port-only loopback changes keep the same resume hash, semantic MCP changes produce a different resume hash, and formatting remains clean.

What was not tested: I did not run a real Claude CLI network turn. This patch is limited to OpenClaw's CLI session reuse decision helper and its bundled-MCP resume hash preparation tests.

### Verification
- `node --import tsx --input-type=module --eval '<imports resolveCliSessionReuse and calls it with stored mcpResumeHash but no current mcpResumeHash>'`
- `node scripts/run-vitest.mjs run src/agents/cli-session.test.ts --reporter verbose`
- `node scripts/run-vitest.mjs run src/agents/cli-runner/bundle-mcp.resume.test.ts src/agents/cli-runner/bundle-mcp.test.ts --reporter verbose`
- `./node_modules/.bin/oxfmt --check --threads=1 src/agents/cli-session.ts src/agents/cli-session.test.ts`
