### PR TITLE
fix(channels): recover stale ingress queue claims at gateway startup

### DIFF
--- a/src/channels/message/ingress-queue.test.ts
+++ b/src/channels/message/ingress-queue.test.ts
@@ -9,7 +9,7 @@ import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
 } from "../../state/openclaw-state-db.js";
-import { createChannelIngressQueue } from "./ingress-queue.js";
+import { createChannelIngressQueue, recoverAllStaleChannelIngressClaims } from "./ingress-queue.js";
 
 type ChannelIngressTestDatabase = Pick<OpenClawStateKyselyDatabase, "channel_ingress_events">;
 
@@ -322,6 +322,237 @@ describe("channel ingress queue", () => {
       expect(await queue.prune({ completedTtlMs: 10, failedTtlMs: 10, now: 40 })).toBe(3);
       expect(await queue.listPending()).toEqual([]);
       expect(await queue.listClaims()).toEqual([]);
+    });
+  });
+});
+
+describe("recoverAllStaleChannelIngressClaims", () => {
+  afterEach(() => {
+    closeOpenClawStateDatabaseForTest();
+  });
+
+  it("recovers claims with dead owner PIDs across multiple queues", async () => {
+    await withTempState(async (stateDir) => {
+      const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+
+      // Create two separate queues (different channel/account pairs).
+      const queueA = createChannelIngressQueue<{ text: string }>({
+        channelId: "telegram",
+        accountId: "dm-1",
+        stateDir,
+        now: () => 100,
+      });
+      const queueB = createChannelIngressQueue<{ text: string }>({
+        channelId: "whatsapp",
+        accountId: "dm-2",
+        stateDir,
+        now: () => 100,
+      });
+
+      // Enqueue and claim with a dead (non-existent) PID.
+      await queueA.enqueue("tg-1", { text: "hello" });
+      await queueA.enqueue("tg-2", { text: "world" });
+      await queueB.enqueue("wa-1", { text: "hi" });
+
+      // Use ownerId that maps to a non-existent PID.
+      const deadPid = "999999999";
+      await queueA.claim("tg-1", { ownerId: deadPid });
+      await queueA.claim("tg-2", { ownerId: deadPid });
+      await queueB.claim("wa-1", { ownerId: deadPid });
+
+      // Sweep should recover all three claims (staleMs: 0 to bypass age check in test).
+      const recovered = await recoverAllStaleChannelIngressClaims({
+        env,
+        now: () => 200,
+        staleMs: 0,
+      });
+      expect(recovered).toBe(3);
+
+      // All events should be back in pending state.
+      expect((await queueA.listPending()).map((r) => r.id).toSorted()).toEqual(["tg-1", "tg-2"]);
+      expect((await queueB.listPending()).map((r) => r.id)).toEqual(["wa-1"]);
+      expect(await queueA.listClaims()).toEqual([]);
+      expect(await queueB.listClaims()).toEqual([]);
+    });
+  });
+
+  it("preserves claims owned by the current process", async () => {
+    await withTempState(async (stateDir) => {
+      const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+
+      const queue = createChannelIngressQueue<{ text: string }>({
+        channelId: "test",
+        accountId: "live",
+        stateDir,
+        now: () => 100,
+      });
+
+      await queue.enqueue("live-event", { text: "active" });
+      // claim() defaults ownerId to process.pid, which is alive.
+      const claimed = await queue.claim("live-event");
+      expect(claimed).toBeTruthy();
+
+      const recovered = await recoverAllStaleChannelIngressClaims({ env, now: () => 200 });
+      expect(recovered).toBe(0);
+
+      // Claim should still be held.
+      expect((await queue.listClaims()).map((r) => r.id)).toEqual(["live-event"]);
+    });
+  });
+
+  it("preserves live compound claim owners (Telegram spool `pid:uuid`)", async () => {
+    await withTempState(async (stateDir) => {
+      const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+
+      const queue = createChannelIngressQueue<{ text: string }>({
+        channelId: "test",
+        accountId: "spool",
+        stateDir,
+        now: () => 100,
+      });
+
+      await queue.enqueue("spooled", { text: "active" });
+      // Telegram spool owners are `${process.pid}:${uuid}`; the live PID prefix
+      // must be parsed so the sweep does not release this active claim.
+      const claimed = await queue.claim("spooled", { ownerId: `${process.pid}:abc-123` });
+      expect(claimed).toBeTruthy();
+
+      const recovered = await recoverAllStaleChannelIngressClaims({ env, now: () => 200 });
+      expect(recovered).toBe(0);
+      expect((await queue.listClaims()).map((r) => r.id)).toEqual(["spooled"]);
+    });
+  });
+
+  it("does not release a stale event that was re-claimed by a live worker", async () => {
+    await withTempState(async (stateDir) => {
+      const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+      let clock = 100;
+      const queue = createChannelIngressQueue<{ text: string }>({
+        channelId: "test",
+        accountId: "race",
+        stateDir,
+        now: () => clock,
+      });
+
+      await queue.enqueue("evt", { text: "x" });
+      // Original claim by a dead PID — a stale-recovery candidate.
+      const stale = await queue.claim("evt", { ownerId: "999999999" });
+      if (!stale) {
+        throw new Error("Expected the initial stale claim");
+      }
+      // A live worker re-claims the same event (new claim_token + live owner)
+      // before the sweep writes. Even though the re-claim is old enough to pass
+      // the staleMs age window, the live owner and the claim_token guard keep
+      // the sweep from releasing this fresh claim into duplicate processing.
+      await queue.release(stale);
+      clock = 9999;
+      expect(await queue.claim("evt", { ownerId: `${process.pid}` })).toBeTruthy();
+
+      const recovered = await recoverAllStaleChannelIngressClaims({
+        env,
+        now: () => 100_000,
+        staleMs: 60_000,
+      });
+      expect(recovered).toBe(0);
+      expect((await queue.listClaims()).map((r) => r.id)).toEqual(["evt"]);
+    });
+  });
+
+  it("returns zero when there are no claimed rows", async () => {
+    await withTempState(async (stateDir) => {
+      const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+
+      const queue = createChannelIngressQueue<{ text: string }>({
+        channelId: "test",
+        stateDir,
+      });
+      await queue.enqueue("only-pending", { text: "waiting" });
+
+      const recovered = await recoverAllStaleChannelIngressClaims({ env });
+      expect(recovered).toBe(0);
+    });
+  });
+
+  it("recovers claims with null or empty claim_owner", async () => {
+    await withTempState(async (stateDir) => {
+      const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+
+      const queue = createChannelIngressQueue<{ text: string }>({
+        channelId: "test",
+        stateDir,
+        now: () => 100,
+      });
+
+      await queue.enqueue("orphan", { text: "no-owner" });
+      // Claim normally, then manually set claim_owner to null to simulate
+      // a row that was only partially updated before crash.
+      await queue.claim("orphan", { ownerId: "12345" });
+
+      const database = openOpenClawStateDatabase({ env });
+      const kysely = getNodeSqliteKysely<ChannelIngressTestDatabase>(database.db);
+      executeSqliteQuerySync(
+        database.db,
+        kysely
+          .updateTable("channel_ingress_events")
+          .set({ claim_owner: null })
+          .where("event_id", "=", "orphan"),
+      );
+
+      const recovered = await recoverAllStaleChannelIngressClaims({
+        env,
+        now: () => 200,
+        staleMs: 0,
+      });
+      expect(recovered).toBe(1);
+      expect((await queue.listPending()).map((r) => r.id)).toEqual(["orphan"]);
+    });
+  });
+
+  it("skips claims newer than staleMs even with dead PIDs", async () => {
+    await withTempState(async (stateDir) => {
+      const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+
+      const queue = createChannelIngressQueue<{ text: string }>({
+        channelId: "test",
+        stateDir,
+        now: () => 1000,
+      });
+
+      await queue.enqueue("old-event", { text: "old" });
+      await queue.enqueue("new-event", { text: "new" });
+      // Claim both with dead PID.
+      await queue.claim("old-event", { ownerId: "999999999" });
+      await queue.claim("new-event", { ownerId: "999999999" });
+
+      // With staleMs=500 and now=2000, cutoff=1500.
+      // Both claims have claimed_at=1000 (below cutoff), so both are stale.
+      expect(
+        await recoverAllStaleChannelIngressClaims({ env, now: () => 2000, staleMs: 500 }),
+      ).toBe(2);
+    });
+  });
+
+  it("preserves recent claims within staleMs window", async () => {
+    await withTempState(async (stateDir) => {
+      const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+
+      let clock = 1000;
+      const queue = createChannelIngressQueue<{ text: string }>({
+        channelId: "test",
+        stateDir,
+        now: () => clock,
+      });
+
+      await queue.enqueue("recent", { text: "recent" });
+      await queue.claim("recent", { ownerId: "999999999" });
+
+      // Advance clock by only 10ms — claim is 10ms old, below the 60s default.
+      clock = 1010;
+      const recovered = await recoverAllStaleChannelIngressClaims({ env, now: () => clock });
+      expect(recovered).toBe(0);
+
+      // Claim should still be held (age-protected even though PID is dead).
+      expect((await queue.listClaims()).map((r) => r.id)).toEqual(["recent"]);
     });
   });
 });

--- a/src/channels/message/ingress-queue.test.ts
+++ b/src/channels/message/ingress-queue.test.ts
@@ -376,31 +376,31 @@ describe("recoverAllStaleChannelIngressClaims", () => {
     });
   });
 
-  it("preserves claims owned by the current process", async () => {
+  it("recovers stale claims owned by the current process PID", async () => {
     await withTempState(async (stateDir) => {
       const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
 
       const queue = createChannelIngressQueue<{ text: string }>({
         channelId: "test",
-        accountId: "live",
+        accountId: "reused-pid",
         stateDir,
         now: () => 100,
       });
 
-      await queue.enqueue("live-event", { text: "active" });
-      // claim() defaults ownerId to process.pid, which is alive.
-      const claimed = await queue.claim("live-event");
-      expect(claimed).toBeTruthy();
+      await queue.enqueue("reused-pid-event", { text: "stuck" });
+      await queue.claim("reused-pid-event", { ownerId: `${process.pid}:old-instance` });
 
-      const recovered = await recoverAllStaleChannelIngressClaims({ env, now: () => 200 });
-      expect(recovered).toBe(0);
-
-      // Claim should still be held.
-      expect((await queue.listClaims()).map((r) => r.id)).toEqual(["live-event"]);
+      const recovered = await recoverAllStaleChannelIngressClaims({
+        env,
+        now: () => 200,
+        staleMs: 0,
+      });
+      expect(recovered).toBe(1);
+      expect((await queue.listPending()).map((r) => r.id)).toEqual(["reused-pid-event"]);
     });
   });
 
-  it("preserves live compound claim owners (Telegram spool `pid:uuid`)", async () => {
+  it("preserves live sibling compound claim owners (Telegram spool `pid:uuid`)", async () => {
     await withTempState(async (stateDir) => {
       const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
 
@@ -412,9 +412,9 @@ describe("recoverAllStaleChannelIngressClaims", () => {
       });
 
       await queue.enqueue("spooled", { text: "active" });
-      // Telegram spool owners are `${process.pid}:${uuid}`; the live PID prefix
-      // must be parsed so the sweep does not release this active claim.
-      const claimed = await queue.claim("spooled", { ownerId: `${process.pid}:abc-123` });
+      // Telegram spool owners are `${pid}:${uuid}`. A live sibling PID must be
+      // preserved, while current-PID leftovers are recovered as PID reuse.
+      const claimed = await queue.claim("spooled", { ownerId: `${process.ppid}:abc-123` });
       expect(claimed).toBeTruthy();
 
       const recovered = await recoverAllStaleChannelIngressClaims({ env, now: () => 200 });
@@ -442,11 +442,11 @@ describe("recoverAllStaleChannelIngressClaims", () => {
       }
       // A live worker re-claims the same event (new claim_token + live owner)
       // before the sweep writes. Even though the re-claim is old enough to pass
-      // the staleMs age window, the live owner and the claim_token guard keep
+      // the staleMs age window, the sibling owner and the claim_token guard keep
       // the sweep from releasing this fresh claim into duplicate processing.
       await queue.release(stale);
       clock = 9999;
-      expect(await queue.claim("evt", { ownerId: `${process.pid}` })).toBeTruthy();
+      expect(await queue.claim("evt", { ownerId: `${process.ppid}` })).toBeTruthy();
 
       const recovered = await recoverAllStaleChannelIngressClaims({
         env,
@@ -505,6 +505,29 @@ describe("recoverAllStaleChannelIngressClaims", () => {
       });
       expect(recovered).toBe(1);
       expect((await queue.listPending()).map((r) => r.id)).toEqual(["orphan"]);
+    });
+  });
+
+  it("recovers claims with malformed PID owners", async () => {
+    await withTempState(async (stateDir) => {
+      const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+
+      const queue = createChannelIngressQueue<{ text: string }>({
+        channelId: "test",
+        stateDir,
+        now: () => 100,
+      });
+
+      await queue.enqueue("malformed", { text: "bad-owner" });
+      await queue.claim("malformed", { ownerId: `${process.pid}abc` });
+
+      const recovered = await recoverAllStaleChannelIngressClaims({
+        env,
+        now: () => 200,
+        staleMs: 0,
+      });
+      expect(recovered).toBe(1);
+      expect((await queue.listPending()).map((r) => r.id)).toEqual(["malformed"]);
     });
   });
 

--- a/src/channels/message/ingress-queue.test.ts
+++ b/src/channels/message/ingress-queue.test.ts
@@ -400,7 +400,7 @@ describe("recoverAllStaleChannelIngressClaims", () => {
     });
   });
 
-  it("preserves live sibling compound claim owners (Telegram spool `pid:uuid`)", async () => {
+  it("preserves recent sibling compound claim owners (Telegram spool `pid:uuid`)", async () => {
     await withTempState(async (stateDir) => {
       const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
 
@@ -412,8 +412,8 @@ describe("recoverAllStaleChannelIngressClaims", () => {
       });
 
       await queue.enqueue("spooled", { text: "active" });
-      // Telegram spool owners are `${pid}:${uuid}`. A live sibling PID must be
-      // preserved, while current-PID leftovers are recovered as PID reuse.
+      // Fresh claims are protected by the staleMs age window, even when the
+      // owner uses Telegram spool's compound `${pid}:${uuid}` shape.
       const claimed = await queue.claim("spooled", { ownerId: `${process.ppid}:abc-123` });
       expect(claimed).toBeTruthy();
 
@@ -423,7 +423,31 @@ describe("recoverAllStaleChannelIngressClaims", () => {
     });
   });
 
-  it("does not release a stale event that was re-claimed by a live worker", async () => {
+  it("recovers stale claims whose PID belongs to an unrelated live process", async () => {
+    await withTempState(async (stateDir) => {
+      const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+
+      const queue = createChannelIngressQueue<{ text: string }>({
+        channelId: "test",
+        accountId: "reused-other-pid",
+        stateDir,
+        now: () => 100,
+      });
+
+      await queue.enqueue("reused-other-pid-event", { text: "stuck" });
+      await queue.claim("reused-other-pid-event", { ownerId: `${process.ppid}:old-instance` });
+
+      const recovered = await recoverAllStaleChannelIngressClaims({
+        env,
+        now: () => 200,
+        staleMs: 0,
+      });
+      expect(recovered).toBe(1);
+      expect((await queue.listPending()).map((r) => r.id)).toEqual(["reused-other-pid-event"]);
+    });
+  });
+
+  it("does not release a freshly re-claimed event", async () => {
     await withTempState(async (stateDir) => {
       const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
       let clock = 100;
@@ -440,12 +464,11 @@ describe("recoverAllStaleChannelIngressClaims", () => {
       if (!stale) {
         throw new Error("Expected the initial stale claim");
       }
-      // A live worker re-claims the same event (new claim_token + live owner)
-      // before the sweep writes. Even though the re-claim is old enough to pass
-      // the staleMs age window, the sibling owner and the claim_token guard keep
-      // the sweep from releasing this fresh claim into duplicate processing.
+      // A worker re-claims the same event before the sweep writes. The fresh
+      // age window keeps the sweep from releasing this claim into duplicate
+      // processing.
       await queue.release(stale);
-      clock = 9999;
+      clock = 50_000;
       expect(await queue.claim("evt", { ownerId: `${process.ppid}` })).toBeTruthy();
 
       const recovered = await recoverAllStaleChannelIngressClaims({

--- a/src/channels/message/ingress-queue.ts
+++ b/src/channels/message/ingress-queue.ts
@@ -843,3 +843,134 @@ export function createChannelIngressQueue<
     prune,
   };
 }
+
+/**
+ * Sweep all stale claims across every channel ingress queue.
+ *
+ * Called at gateway startup to release claimed rows left behind by a previous
+ * crash. A claim is stale when its `claim_owner` PID is no longer alive (dead
+ * process, empty, or non-numeric owner). This covers the gap where per-queue
+ * recovery only runs inside channel drain loops — after a crash those loops
+ * have not started yet, so claimed rows sit unrecovered indefinitely.
+ *
+ * Timing: this runs during `prepareGatewayPluginBootstrap`, which completes
+ * before `startChannels()`. At sweep time no channel workers are running, so
+ * every claimed row is stale from a previous crashed session. The PID liveness
+ * check is an additional guard for multi-gateway deployments where another
+ * gateway process on the same host may hold legitimate claims.
+ *
+ * PID recycling risk: if the OS reuses a dead PID before this sweep runs, the
+ * sweep will skip that row. This is the same trade-off as the existing Telegram
+ * spool recovery (`isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess`).
+ * Consequence: the claim stays stuck until the next restart — no worse than
+ * current behavior.
+ *
+ * Best-effort: errors are surfaced to the caller, who should log and continue.
+ *
+ * @see recoverStaleClaims — per-queue recovery during normal drain
+ * @see https://github.com/openclaw/openclaw/issues/90945
+ */
+export async function recoverAllStaleChannelIngressClaims(options?: {
+  env?: NodeJS.ProcessEnv;
+  now?: () => number;
+  /** Minimum age in ms before a claim is considered stale. Defaults to 60s. */
+  staleMs?: number;
+  log?: { info: (message: string) => void };
+}): Promise<number> {
+  const staleMs = Math.max(0, Math.floor(options?.staleMs ?? 60_000));
+  const database = openOpenClawStateDatabase({
+    env: options?.env ?? process.env,
+  });
+
+  const nowMs = (options?.now ?? Date.now)();
+  const cutoff = nowMs - staleMs;
+
+  const kysely = getChannelIngressKysely(database.db);
+  const claimedRows = executeSqliteQuerySync(
+    database.db,
+    kysely
+      .selectFrom("channel_ingress_events")
+      .select(["queue_name", "event_id", "claim_token", "claim_owner", "claimed_at"])
+      .where("status", "=", "claimed")
+      .orderBy("claimed_at", "asc"),
+  ).rows;
+
+  if (claimedRows.length === 0) {
+    return 0;
+  }
+
+  // Filter to claims older than staleMs whose owner process is no longer alive.
+  // The age filter prevents releasing claims that were just taken by a
+  // concurrently-starting sibling gateway on the same host.
+  const staleRows = claimedRows.filter(
+    (row) => (row.claimed_at ?? 0) <= cutoff && !isIngressClaimProcessAlive(row.claim_owner),
+  );
+
+  if (staleRows.length === 0) {
+    return 0;
+  }
+
+  // Batch release all stale claims in a single write transaction. Each release
+  // is guarded by the exact claim_token observed during selection: between the
+  // read above and this write, a sibling gateway could release and re-claim the
+  // same event (new token), and releasing on `status = "claimed"` alone would
+  // drop that fresh claim into duplicate processing.
+  const released = runOpenClawStateWriteTransaction(
+    (tx) => {
+      const txKysely = getChannelIngressKysely(tx.db);
+      let count = 0;
+      for (const row of staleRows) {
+        const result = executeSqliteQuerySync(
+          tx.db,
+          txKysely
+            .updateTable("channel_ingress_events")
+            .set((eb) => ({
+              status: "pending" as const,
+              claim_token: null,
+              claim_owner: null,
+              claimed_at: null,
+              attempts: eb("attempts", "+", 1),
+              last_attempt_at: nowMs,
+              last_error: "recovered at startup: owner process gone",
+              updated_at: nowMs,
+            }))
+            .where("queue_name", "=", row.queue_name)
+            .where("event_id", "=", row.event_id)
+            .where("status", "=", "claimed")
+            .where("claim_token", "=", row.claim_token),
+        );
+        count += affectedRows(result);
+      }
+      return count;
+    },
+    { path: database.path },
+  );
+
+  if (released === 0) {
+    return 0;
+  }
+
+  options?.log?.info?.(
+    `gateway: recovered ${released} stale channel ingress claim(s) from previous session`,
+  );
+
+  return released;
+}
+
+/** Check whether the PID that owns a claim is still running. */
+function isIngressClaimProcessAlive(claimOwner: string | null | undefined): boolean {
+  // Owners are either a bare PID (queue default) or a compound `${pid}:${uuid}`
+  // (Telegram spool). Parse the PID prefix so a live compound owner is not
+  // misread as dead and its claim wrongly released into duplicate processing.
+  const pid = Number.parseInt(claimOwner?.split(":", 1)[0] ?? "", 10);
+  if (!Number.isSafeInteger(pid) || pid <= 0) {
+    return false;
+  }
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    const code = (err as { code?: string }).code;
+    return code !== "ESRCH" && code !== "EINVAL";
+  }
+}

--- a/src/channels/message/ingress-queue.ts
+++ b/src/channels/message/ingress-queue.ts
@@ -847,17 +847,11 @@ export function createChannelIngressQueue<
 /**
  * Sweep all stale claims across every channel ingress queue.
  *
- * Called at gateway startup to release claimed rows left behind by a previous
- * crash. A claim is stale when it is old enough and its `claim_owner` is empty,
- * malformed, owned by this new startup process, or owned by a PID that is no
- * longer alive. Current-PID claims are treated as stale because process IDs can
- * be reused across container restarts (for example PID 1).
- *
- * Timing: this runs during `prepareGatewayPluginBootstrap`, which completes
- * before `startChannels()`. At sweep time this gateway has no channel workers
- * running, so current-PID rows must be leftovers from an earlier process. The
- * PID liveness check only protects live sibling gateway processes on the same
- * host.
+ * Called at gateway startup to release old claimed rows left behind by a
+ * previous crash. The `staleMs` age window is the owner boundary: fresh claims
+ * can belong to a concurrently-starting sibling gateway, while old claims are
+ * recoverable even if the recorded PID has been reused by this or another
+ * unrelated process.
  *
  * Best-effort: errors are surfaced to the caller, who should log and continue.
  *
@@ -884,7 +878,7 @@ export async function recoverAllStaleChannelIngressClaims(options?: {
     database.db,
     kysely
       .selectFrom("channel_ingress_events")
-      .select(["queue_name", "event_id", "claim_token", "claim_owner", "claimed_at"])
+      .select(["queue_name", "event_id", "claim_token", "claimed_at"])
       .where("status", "=", "claimed")
       .orderBy("claimed_at", "asc"),
   ).rows;
@@ -893,12 +887,10 @@ export async function recoverAllStaleChannelIngressClaims(options?: {
     return 0;
   }
 
-  // Filter to old claims not owned by a live sibling process. The age filter
-  // prevents releasing claims that were just taken by a concurrently-starting
-  // sibling gateway on the same host.
-  const staleRows = claimedRows.filter(
-    (row) => (row.claimed_at ?? 0) <= cutoff && !isIngressClaimProcessAlive(row.claim_owner),
-  );
+  // The age filter protects fresh claims from concurrently-starting sibling
+  // gateways. Once a claim ages past staleMs it is recoverable regardless of
+  // PID liveness, because unrelated processes can reuse recorded PIDs.
+  const staleRows = claimedRows.filter((row) => (row.claimed_at ?? 0) <= cutoff);
 
   if (staleRows.length === 0) {
     return 0;
@@ -925,7 +917,7 @@ export async function recoverAllStaleChannelIngressClaims(options?: {
               claimed_at: null,
               attempts: eb("attempts", "+", 1),
               last_attempt_at: nowMs,
-              last_error: "recovered at startup: owner process gone",
+              last_error: "recovered at startup: stale claim",
               updated_at: nowMs,
             }))
             .where("queue_name", "=", row.queue_name)
@@ -949,26 +941,4 @@ export async function recoverAllStaleChannelIngressClaims(options?: {
   );
 
   return released;
-}
-
-/** Check whether a claim is owned by another still-running process. */
-function isIngressClaimProcessAlive(claimOwner: string | null | undefined): boolean {
-  // Owners are either a bare PID (queue default) or a compound `${pid}:${uuid}`
-  // (Telegram spool). Reject partial prefixes before liveness checks so
-  // malformed persisted owners do not pin stale rows forever.
-  const owner = claimOwner ?? "";
-  if (!/^\d+(?::.+)?$/.test(owner)) {
-    return false;
-  }
-  const pid = Number(owner.split(":", 1)[0]);
-  if (!Number.isSafeInteger(pid) || pid <= 0 || pid === process.pid) {
-    return false;
-  }
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch (err) {
-    const code = (err as { code?: string }).code;
-    return code !== "ESRCH" && code !== "EINVAL";
-  }
 }

--- a/src/channels/message/ingress-queue.ts
+++ b/src/channels/message/ingress-queue.ts
@@ -848,22 +848,16 @@ export function createChannelIngressQueue<
  * Sweep all stale claims across every channel ingress queue.
  *
  * Called at gateway startup to release claimed rows left behind by a previous
- * crash. A claim is stale when its `claim_owner` PID is no longer alive (dead
- * process, empty, or non-numeric owner). This covers the gap where per-queue
- * recovery only runs inside channel drain loops — after a crash those loops
- * have not started yet, so claimed rows sit unrecovered indefinitely.
+ * crash. A claim is stale when it is old enough and its `claim_owner` is empty,
+ * malformed, owned by this new startup process, or owned by a PID that is no
+ * longer alive. Current-PID claims are treated as stale because process IDs can
+ * be reused across container restarts (for example PID 1).
  *
  * Timing: this runs during `prepareGatewayPluginBootstrap`, which completes
- * before `startChannels()`. At sweep time no channel workers are running, so
- * every claimed row is stale from a previous crashed session. The PID liveness
- * check is an additional guard for multi-gateway deployments where another
- * gateway process on the same host may hold legitimate claims.
- *
- * PID recycling risk: if the OS reuses a dead PID before this sweep runs, the
- * sweep will skip that row. This is the same trade-off as the existing Telegram
- * spool recovery (`isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess`).
- * Consequence: the claim stays stuck until the next restart — no worse than
- * current behavior.
+ * before `startChannels()`. At sweep time this gateway has no channel workers
+ * running, so current-PID rows must be leftovers from an earlier process. The
+ * PID liveness check only protects live sibling gateway processes on the same
+ * host.
  *
  * Best-effort: errors are surfaced to the caller, who should log and continue.
  *
@@ -899,9 +893,9 @@ export async function recoverAllStaleChannelIngressClaims(options?: {
     return 0;
   }
 
-  // Filter to claims older than staleMs whose owner process is no longer alive.
-  // The age filter prevents releasing claims that were just taken by a
-  // concurrently-starting sibling gateway on the same host.
+  // Filter to old claims not owned by a live sibling process. The age filter
+  // prevents releasing claims that were just taken by a concurrently-starting
+  // sibling gateway on the same host.
   const staleRows = claimedRows.filter(
     (row) => (row.claimed_at ?? 0) <= cutoff && !isIngressClaimProcessAlive(row.claim_owner),
   );
@@ -957,13 +951,17 @@ export async function recoverAllStaleChannelIngressClaims(options?: {
   return released;
 }
 
-/** Check whether the PID that owns a claim is still running. */
+/** Check whether a claim is owned by another still-running process. */
 function isIngressClaimProcessAlive(claimOwner: string | null | undefined): boolean {
   // Owners are either a bare PID (queue default) or a compound `${pid}:${uuid}`
-  // (Telegram spool). Parse the PID prefix so a live compound owner is not
-  // misread as dead and its claim wrongly released into duplicate processing.
-  const pid = Number.parseInt(claimOwner?.split(":", 1)[0] ?? "", 10);
-  if (!Number.isSafeInteger(pid) || pid <= 0) {
+  // (Telegram spool). Reject partial prefixes before liveness checks so
+  // malformed persisted owners do not pin stale rows forever.
+  const owner = claimOwner ?? "";
+  if (!/^\d+(?::.+)?$/.test(owner)) {
+    return false;
+  }
+  const pid = Number(owner.split(":", 1)[0]);
+  if (!Number.isSafeInteger(pid) || pid <= 0 || pid === process.pid) {
     return false;
   }
   try {

--- a/src/cli/gateway-cli/lifecycle.runtime.ts
+++ b/src/cli/gateway-cli/lifecycle.runtime.ts
@@ -24,7 +24,10 @@ export {
   resetGatewayRestartStateForInProcessRestart,
   scheduleGatewaySigusr1Restart,
 } from "../../infra/restart.js";
-export { writeGatewayRestartHandoffSync } from "../../infra/restart-handoff.js";
+export {
+  withGatewayRestartSkipStartupIngressSweepEnv,
+  writeGatewayRestartHandoffSync,
+} from "../../infra/restart-handoff.js";
 export { markUpdateRestartSentinelFailure } from "../../infra/restart-sentinel.js";
 export { detectRespawnSupervisor } from "../../infra/supervisor-markers.js";
 export { writeDiagnosticStabilityBundleForFailureSync } from "../../logging/diagnostic-stability-bundle.js";

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -30,6 +30,12 @@ const writeGatewayRestartHandoffSync = vi.fn((_opts: unknown) => ({
   restartKind: "full-process" as const,
   supervisorMode: "external" as const,
 }));
+const withGatewayRestartSkipStartupIngressSweepEnv = vi.fn(
+  (env: NodeJS.ProcessEnv | undefined) => ({
+    ...env,
+    OPENCLAW_GATEWAY_RESTART_SKIP_STARTUP_INGRESS_SWEEP: "1",
+  }),
+);
 const scheduleGatewaySigusr1Restart = vi.fn((_opts?: { delayMs?: number; reason?: string }) => ({
   ok: true,
   pid: process.pid,
@@ -140,6 +146,8 @@ vi.mock("../../infra/restart-sentinel.js", () => ({
 }));
 
 vi.mock("../../infra/restart-handoff.js", () => ({
+  withGatewayRestartSkipStartupIngressSweepEnv: (env: NodeJS.ProcessEnv | undefined) =>
+    withGatewayRestartSkipStartupIngressSweepEnv(env),
   writeGatewayRestartHandoffSync: (opts: unknown) => writeGatewayRestartHandoffSync(opts),
 }));
 
@@ -757,7 +765,10 @@ describe("runGatewayLoop", () => {
       waitForActiveTasks.mockResolvedValueOnce({ drained: false });
       waitForActiveEmbeddedRuns.mockResolvedValueOnce({ drained: true });
 
-      type StartServer = () => Promise<{
+      type StartServer = (params?: {
+        startupStartedAt?: number;
+        inProcessRestart?: boolean;
+      }) => Promise<{
         close: GatewayCloseFn;
       }>;
 
@@ -1369,6 +1380,7 @@ describe("runGatewayLoop", () => {
         const [respawnOpts] = restartGatewayProcessWithFreshPid.mock.calls[0] ?? [];
         expect(respawnOpts?.env?.OPENCLAW_GATEWAY_RESTART_TRACE_STARTED_AT_MS).toMatch(/^\d/u);
         expect(respawnOpts?.env?.OPENCLAW_GATEWAY_RESTART_TRACE_LAST_AT_MS).toMatch(/^\d/u);
+        expect(respawnOpts?.env?.OPENCLAW_GATEWAY_RESTART_SKIP_STARTUP_INGRESS_SWEEP).toBe("1");
         expect(writeGatewayRestartHandoffSync).not.toHaveBeenCalled();
       });
     } finally {
@@ -1548,6 +1560,8 @@ describe("runGatewayLoop", () => {
       await expect(exited).resolves.toBe(0);
       expect(waitForHealthyChild).toHaveBeenCalledWith(18789, 7777, "127.0.0.1");
       expect(respawnGatewayProcessForUpdate).toHaveBeenCalledTimes(1);
+      const [respawnOpts] = respawnGatewayProcessForUpdate.mock.calls[0] ?? [];
+      expect(respawnOpts?.env?.OPENCLAW_GATEWAY_RESTART_SKIP_STARTUP_INGRESS_SWEEP).toBe("1");
       expect(start).toHaveBeenCalledTimes(1);
       expect(markUpdateRestartSentinelFailure).not.toHaveBeenCalled();
       expect(writeGatewayRestartHandoffSync).not.toHaveBeenCalled();

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -812,6 +812,7 @@ describe("runGatewayLoop", () => {
 
       await startedSecond;
       expect(start).toHaveBeenCalledTimes(2);
+      expect(start.mock.calls[1]?.[0]).toMatchObject({ inProcessRestart: true });
       await new Promise<void>((resolve) => {
         setImmediate(resolve);
       });

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -101,6 +101,7 @@ async function waitForHealthyGatewayChild(
 export async function runGatewayLoop(params: {
   start: (params?: {
     startupStartedAt?: number;
+    inProcessRestart?: boolean;
   }) => Promise<Awaited<ReturnType<typeof startGatewayServer>>>;
   runtime: RuntimeEnv;
   lockPort?: number;
@@ -818,7 +819,7 @@ export async function runGatewayLoop(params: {
       restartDrainingMarkPromise = null;
       let startupFailedBeforeServerHandle = false;
       try {
-        server = await params.start({ startupStartedAt });
+        server = await params.start({ startupStartedAt, inProcessRestart: !isFirstStart });
         startupFailedWithoutServerHandle = false;
         isFirstStart = false;
       } catch (err) {

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -180,13 +180,16 @@ export async function runGatewayLoop(params: {
       markUpdateRestartSentinelFailure,
       respawnGatewayProcessForUpdate,
       restartGatewayProcessWithFreshPid,
+      withGatewayRestartSkipStartupIngressSweepEnv,
       writeGatewayRestartHandoffSync,
     } = await loadGatewayLifecycleRuntimeModule();
 
     if (isUpdateRestart) {
       const restartTraceHandoff = captureGatewayRestartTraceHandoff();
       const respawn = respawnGatewayProcessForUpdate({
-        env: createGatewayRestartTraceHandoffEnv(restartTraceHandoff),
+        env: withGatewayRestartSkipStartupIngressSweepEnv(
+          createGatewayRestartTraceHandoffEnv(restartTraceHandoff),
+        ),
       });
       if (respawn.mode === "spawned") {
         const port = params.lockPort;
@@ -265,7 +268,9 @@ export async function runGatewayLoop(params: {
     // Release the lock BEFORE spawning so the child can acquire it immediately.
     const restartTraceHandoff = captureGatewayRestartTraceHandoff();
     const respawn = restartGatewayProcessWithFreshPid({
-      env: createGatewayRestartTraceHandoffEnv(restartTraceHandoff),
+      env: withGatewayRestartSkipStartupIngressSweepEnv(
+        createGatewayRestartTraceHandoffEnv(restartTraceHandoff),
+      ),
     });
     if (respawn.mode === "spawned" || respawn.mode === "supervised") {
       const supervisorMode =

--- a/src/cli/gateway-cli/run.option-collisions.test.ts
+++ b/src/cli/gateway-cli/run.option-collisions.test.ts
@@ -22,7 +22,10 @@ const forceFreePortAndWait = vi.fn(async (_port: number, _opts: unknown) => ({
 const cleanStaleGatewayProcessesSync = vi.fn((_port?: number) => []);
 const waitForPortBindable = vi.fn(async (_port: number, _opts?: unknown) => 0);
 const ensureDevGatewayConfig = vi.fn(async (_opts?: unknown) => {});
-type GatewayLoopStart = (params?: { startupStartedAt?: number }) => Promise<unknown>;
+type GatewayLoopStart = (params?: {
+  startupStartedAt?: number;
+  inProcessRestart?: boolean;
+}) => Promise<unknown>;
 const runGatewayLoop = vi.fn(async ({ start }: { start: GatewayLoopStart }) => {
   await start();
 });
@@ -263,6 +266,7 @@ describe("gateway run option collisions", () => {
       bind?: string;
       startupConfigSnapshotRead?: { snapshot?: Record<string, unknown> };
       startupStartedAt?: number;
+      inProcessRestart?: boolean;
     };
   }
 
@@ -436,7 +440,7 @@ describe("gateway run option collisions", () => {
   it("uses the startup snapshot only for the first in-process gateway start", async () => {
     runGatewayLoop.mockImplementationOnce(async ({ start }: { start: GatewayLoopStart }) => {
       await start({ startupStartedAt: 1000 });
-      await start({ startupStartedAt: 2000 });
+      await start({ startupStartedAt: 2000, inProcessRestart: true });
     });
 
     await runGatewayCli(["gateway", "run", "--allow-unconfigured"]);
@@ -448,6 +452,7 @@ describe("gateway run option collisions", () => {
     const secondOptions = gatewayStartOptions(1);
     expect(secondOptions.startupConfigSnapshotRead).toBeUndefined();
     expect(secondOptions.startupStartedAt).toBe(2000);
+    expect(secondOptions.inProcessRestart).toBe(true);
   });
 
   it("logs when first startup will build missing Control UI assets", async () => {

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -823,7 +823,7 @@ export async function runGatewayCommand(opts: GatewayRunOpts) {
       runtime: defaultRuntime,
       lockPort: port,
       healthHost,
-      start: async ({ startupStartedAt } = {}) => {
+      start: async ({ startupStartedAt, inProcessRestart } = {}) => {
         const startupConfigSnapshotReadForThisStart = startupConfigSnapshotReadForNextStart;
         startupConfigSnapshotReadForNextStart = undefined;
         return await startGatewayServer(port, {
@@ -831,6 +831,7 @@ export async function runGatewayCommand(opts: GatewayRunOpts) {
           auth: authOverride,
           tailscale: tailscaleOverride,
           startupStartedAt,
+          inProcessRestart,
           ...(startupConfigSnapshotReadForThisStart
             ? { startupConfigSnapshotRead: startupConfigSnapshotReadForThisStart }
             : {}),

--- a/src/gateway/server-startup-ingress-sweep.test.ts
+++ b/src/gateway/server-startup-ingress-sweep.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from "vitest";
+import { runStartupIngressClaimSweep } from "./server-startup-ingress-sweep.js";
+
+describe("runStartupIngressClaimSweep", () => {
+  it("logs recovered count on success", async () => {
+    const info = vi.fn();
+    const warn = vi.fn();
+    const mockSweep = vi.fn().mockImplementation(async ({ log }) => {
+      log?.info?.("gateway: recovered 2 stale channel ingress claim(s) from previous session");
+      return 2;
+    });
+
+    await runStartupIngressClaimSweep({
+      log: { info, warn },
+      deps: { recoverAllStaleChannelIngressClaims: mockSweep },
+    });
+
+    expect(mockSweep).toHaveBeenCalledOnce();
+    expect(info).toHaveBeenCalledWith(
+      "gateway: recovered 2 stale channel ingress claim(s) from previous session",
+    );
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("logs warning and continues when sweep throws", async () => {
+    const info = vi.fn();
+    const warn = vi.fn();
+    const mockSweep = vi.fn().mockRejectedValue(new Error("DB locked"));
+
+    await runStartupIngressClaimSweep({
+      log: { info, warn },
+      deps: { recoverAllStaleChannelIngressClaims: mockSweep },
+    });
+
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn.mock.calls[0][0]).toContain("stale ingress claim sweep failed");
+    expect(warn.mock.calls[0][0]).toContain("DB locked");
+  });
+
+  it("does not call log.info when no claims are recovered", async () => {
+    const info = vi.fn();
+    const warn = vi.fn();
+    const mockSweep = vi.fn().mockResolvedValue(0);
+
+    await runStartupIngressClaimSweep({
+      log: { info, warn },
+      deps: { recoverAllStaleChannelIngressClaims: mockSweep },
+    });
+
+    expect(info).not.toHaveBeenCalled();
+    expect(warn).not.toHaveBeenCalled();
+  });
+});

--- a/src/gateway/server-startup-ingress-sweep.test.ts
+++ b/src/gateway/server-startup-ingress-sweep.test.ts
@@ -22,6 +22,37 @@ describe("runStartupIngressClaimSweep", () => {
     expect(warn).not.toHaveBeenCalled();
   });
 
+  it("skips the sweep during supervised restart handoff", async () => {
+    const info = vi.fn();
+    const warn = vi.fn();
+    const mockSweep = vi.fn();
+    const readGatewayRestartHandoffSync = vi.fn().mockReturnValue({
+      kind: "gateway-supervisor-restart-handoff",
+      version: 1,
+      intentId: "restart-1",
+      pid: 123,
+      createdAt: 100,
+      expiresAt: 60_100,
+      source: "operator-restart",
+      restartKind: "full-process",
+      supervisorMode: "external",
+    });
+
+    await runStartupIngressClaimSweep({
+      log: { info, warn },
+      deps: {
+        recoverAllStaleChannelIngressClaims: mockSweep,
+        readGatewayRestartHandoffSync,
+      },
+    });
+
+    expect(mockSweep).not.toHaveBeenCalled();
+    expect(info).toHaveBeenCalledWith(
+      "gateway: skipping stale ingress claim sweep during supervised restart handoff",
+    );
+    expect(warn).not.toHaveBeenCalled();
+  });
+
   it("logs warning and continues when sweep throws", async () => {
     const info = vi.fn();
     const warn = vi.fn();

--- a/src/gateway/server-startup-ingress-sweep.test.ts
+++ b/src/gateway/server-startup-ingress-sweep.test.ts
@@ -22,6 +22,24 @@ describe("runStartupIngressClaimSweep", () => {
     expect(warn).not.toHaveBeenCalled();
   });
 
+  it("skips the sweep during SIGUSR1 in-process restart", async () => {
+    const info = vi.fn();
+    const warn = vi.fn();
+    const mockSweep = vi.fn();
+
+    await runStartupIngressClaimSweep({
+      inProcessRestart: true,
+      log: { info, warn },
+      deps: { recoverAllStaleChannelIngressClaims: mockSweep },
+    });
+
+    expect(mockSweep).not.toHaveBeenCalled();
+    expect(info).toHaveBeenCalledWith(
+      "gateway: skipping stale ingress claim sweep during SIGUSR1 in-process restart",
+    );
+    expect(warn).not.toHaveBeenCalled();
+  });
+
   it("skips the sweep during supervised restart handoff", async () => {
     const info = vi.fn();
     const warn = vi.fn();

--- a/src/gateway/server-startup-ingress-sweep.test.ts
+++ b/src/gateway/server-startup-ingress-sweep.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { GATEWAY_RESTART_SKIP_STARTUP_INGRESS_SWEEP_ENV } from "../infra/restart-handoff.js";
 import { runStartupIngressClaimSweep } from "./server-startup-ingress-sweep.js";
 
 describe("runStartupIngressClaimSweep", () => {
@@ -36,6 +37,28 @@ describe("runStartupIngressClaimSweep", () => {
     expect(mockSweep).not.toHaveBeenCalled();
     expect(info).toHaveBeenCalledWith(
       "gateway: skipping stale ingress claim sweep during SIGUSR1 in-process restart",
+    );
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("skips and consumes the sweep marker during spawned restart handoff", async () => {
+    const info = vi.fn();
+    const warn = vi.fn();
+    const mockSweep = vi.fn();
+    const env = {
+      [GATEWAY_RESTART_SKIP_STARTUP_INGRESS_SWEEP_ENV]: "1",
+    };
+
+    await runStartupIngressClaimSweep({
+      env,
+      log: { info, warn },
+      deps: { recoverAllStaleChannelIngressClaims: mockSweep },
+    });
+
+    expect(mockSweep).not.toHaveBeenCalled();
+    expect(env[GATEWAY_RESTART_SKIP_STARTUP_INGRESS_SWEEP_ENV]).toBeUndefined();
+    expect(info).toHaveBeenCalledWith(
+      "gateway: skipping stale ingress claim sweep during spawned restart handoff",
     );
     expect(warn).not.toHaveBeenCalled();
   });

--- a/src/gateway/server-startup-ingress-sweep.ts
+++ b/src/gateway/server-startup-ingress-sweep.ts
@@ -1,0 +1,42 @@
+import { recoverAllStaleChannelIngressClaims } from "../channels/message/ingress-queue.js";
+
+type IngressSweepLogger = {
+  info: (message: string) => void;
+  warn: (message: string) => void;
+};
+
+/**
+ * Recover stale channel ingress queue claims at gateway startup.
+ *
+ * Runs during `prepareGatewayPluginBootstrap`, which completes before
+ * `startChannels()`. At this point no channel workers are running yet, so all
+ * claimed rows are stale from a previous crashed gateway session. The PID
+ * liveness check is an additional guard for multi-gateway hosts.
+ *
+ * Best-effort and non-blocking: if the sweep fails, gateway startup continues
+ * normally. After a crash, claimed rows in `channel_ingress_events` can remain
+ * in "claimed" state indefinitely, silently blocking channel message processing.
+ * This sweep releases claims whose owner PID is no longer alive.
+ *
+ * @see https://github.com/openclaw/openclaw/issues/90945
+ */
+export async function runStartupIngressClaimSweep(params: {
+  env?: NodeJS.ProcessEnv;
+  log: IngressSweepLogger;
+  deps?: {
+    recoverAllStaleChannelIngressClaims?: typeof recoverAllStaleChannelIngressClaims;
+  };
+}): Promise<void> {
+  const sweep =
+    params.deps?.recoverAllStaleChannelIngressClaims ?? recoverAllStaleChannelIngressClaims;
+  try {
+    await sweep({
+      env: params.env ?? process.env,
+      log: { info: (msg) => params.log.info(msg) },
+    });
+  } catch (err) {
+    params.log.warn(
+      `gateway: stale ingress claim sweep failed during startup; continuing: ${String(err)}`,
+    );
+  }
+}

--- a/src/gateway/server-startup-ingress-sweep.ts
+++ b/src/gateway/server-startup-ingress-sweep.ts
@@ -1,5 +1,8 @@
 import { recoverAllStaleChannelIngressClaims } from "../channels/message/ingress-queue.js";
-import { readGatewayRestartHandoffSync } from "../infra/restart-handoff.js";
+import {
+  consumeGatewayRestartSkipStartupIngressSweepEnv,
+  readGatewayRestartHandoffSync,
+} from "../infra/restart-handoff.js";
 
 type IngressSweepLogger = {
   info: (message: string) => void;
@@ -25,6 +28,7 @@ export async function runStartupIngressClaimSweep(params: {
   inProcessRestart?: boolean;
   log: IngressSweepLogger;
   deps?: {
+    consumeGatewayRestartSkipStartupIngressSweepEnv?: typeof consumeGatewayRestartSkipStartupIngressSweepEnv;
     recoverAllStaleChannelIngressClaims?: typeof recoverAllStaleChannelIngressClaims;
     readGatewayRestartHandoffSync?: typeof readGatewayRestartHandoffSync;
   };
@@ -38,6 +42,13 @@ export async function runStartupIngressClaimSweep(params: {
   const sweep =
     params.deps?.recoverAllStaleChannelIngressClaims ?? recoverAllStaleChannelIngressClaims;
   const env = params.env ?? process.env;
+  const consumeSkipEnv =
+    params.deps?.consumeGatewayRestartSkipStartupIngressSweepEnv ??
+    consumeGatewayRestartSkipStartupIngressSweepEnv;
+  if (consumeSkipEnv(env)) {
+    params.log.info("gateway: skipping stale ingress claim sweep during spawned restart handoff");
+    return;
+  }
   const readHandoff = params.deps?.readGatewayRestartHandoffSync ?? readGatewayRestartHandoffSync;
   if (readHandoff(env)) {
     params.log.info(

--- a/src/gateway/server-startup-ingress-sweep.ts
+++ b/src/gateway/server-startup-ingress-sweep.ts
@@ -10,9 +10,9 @@ type IngressSweepLogger = {
  * Recover stale channel ingress queue claims at gateway startup.
  *
  * Runs during `prepareGatewayPluginBootstrap`, before `startChannels()`. It is
- * limited to fresh process starts without a supervised restart handoff: unclean
- * exits leave claimed rows behind, while graceful in-process restarts can leave
- * old channel handlers settling after the replacement process starts.
+ * limited to starts that cannot still have a previous in-process channel
+ * lifecycle settling: unclean exits leave claimed rows behind, while SIGUSR1 or
+ * supervised restarts can leave old channel handlers alive during the next start.
  *
  * Best-effort and non-blocking: if the sweep fails, gateway startup continues
  * normally. After a crash, claimed rows in `channel_ingress_events` can remain
@@ -22,12 +22,19 @@ type IngressSweepLogger = {
  */
 export async function runStartupIngressClaimSweep(params: {
   env?: NodeJS.ProcessEnv;
+  inProcessRestart?: boolean;
   log: IngressSweepLogger;
   deps?: {
     recoverAllStaleChannelIngressClaims?: typeof recoverAllStaleChannelIngressClaims;
     readGatewayRestartHandoffSync?: typeof readGatewayRestartHandoffSync;
   };
 }): Promise<void> {
+  if (params.inProcessRestart) {
+    params.log.info(
+      "gateway: skipping stale ingress claim sweep during SIGUSR1 in-process restart",
+    );
+    return;
+  }
   const sweep =
     params.deps?.recoverAllStaleChannelIngressClaims ?? recoverAllStaleChannelIngressClaims;
   const env = params.env ?? process.env;

--- a/src/gateway/server-startup-ingress-sweep.ts
+++ b/src/gateway/server-startup-ingress-sweep.ts
@@ -1,4 +1,5 @@
 import { recoverAllStaleChannelIngressClaims } from "../channels/message/ingress-queue.js";
+import { readGatewayRestartHandoffSync } from "../infra/restart-handoff.js";
 
 type IngressSweepLogger = {
   info: (message: string) => void;
@@ -8,15 +9,14 @@ type IngressSweepLogger = {
 /**
  * Recover stale channel ingress queue claims at gateway startup.
  *
- * Runs during `prepareGatewayPluginBootstrap`, which completes before
- * `startChannels()`. At this point no channel workers are running yet, so all
- * claimed rows are stale from a previous crashed gateway session. The PID
- * liveness check is an additional guard for multi-gateway hosts.
+ * Runs during `prepareGatewayPluginBootstrap`, before `startChannels()`. It is
+ * limited to fresh process starts without a supervised restart handoff: unclean
+ * exits leave claimed rows behind, while graceful in-process restarts can leave
+ * old channel handlers settling after the replacement process starts.
  *
  * Best-effort and non-blocking: if the sweep fails, gateway startup continues
  * normally. After a crash, claimed rows in `channel_ingress_events` can remain
  * in "claimed" state indefinitely, silently blocking channel message processing.
- * This sweep releases claims whose owner PID is no longer alive.
  *
  * @see https://github.com/openclaw/openclaw/issues/90945
  */
@@ -25,13 +25,22 @@ export async function runStartupIngressClaimSweep(params: {
   log: IngressSweepLogger;
   deps?: {
     recoverAllStaleChannelIngressClaims?: typeof recoverAllStaleChannelIngressClaims;
+    readGatewayRestartHandoffSync?: typeof readGatewayRestartHandoffSync;
   };
 }): Promise<void> {
   const sweep =
     params.deps?.recoverAllStaleChannelIngressClaims ?? recoverAllStaleChannelIngressClaims;
+  const env = params.env ?? process.env;
+  const readHandoff = params.deps?.readGatewayRestartHandoffSync ?? readGatewayRestartHandoffSync;
+  if (readHandoff(env)) {
+    params.log.info(
+      "gateway: skipping stale ingress claim sweep during supervised restart handoff",
+    );
+    return;
+  }
   try {
     await sweep({
-      env: params.env ?? process.env,
+      env,
       log: { info: (msg) => params.log.info(msg) },
     });
   } catch (err) {

--- a/src/gateway/server-startup-plugins.ts
+++ b/src/gateway/server-startup-plugins.ts
@@ -73,9 +73,14 @@ export async function prepareGatewayPluginBootstrap(params: {
     ];
     if (!params.minimalTestGateway) {
       const { runStartupSessionMigration } = await import("./server-startup-session-migration.js");
+      const { runStartupIngressClaimSweep } = await import("./server-startup-ingress-sweep.js");
       startupTasks.push(
         runStartupSessionMigration({
           cfg: params.cfgAtStart,
+          env: process.env,
+          log: params.log,
+        }),
+        runStartupIngressClaimSweep({
           env: process.env,
           log: params.log,
         }),

--- a/src/gateway/server-startup-plugins.ts
+++ b/src/gateway/server-startup-plugins.ts
@@ -50,6 +50,7 @@ export async function prepareGatewayPluginBootstrap(params: {
   pluginMetadataSnapshot?: PluginMetadataSnapshot;
   minimalTestGateway: boolean;
   log: GatewayPluginBootstrapLog;
+  inProcessRestart?: boolean;
   loadRuntimePlugins?: boolean;
   loadSetupRuntimePlugins?: boolean;
 }) {
@@ -82,6 +83,7 @@ export async function prepareGatewayPluginBootstrap(params: {
         }),
         runStartupIngressClaimSweep({
           env: process.env,
+          inProcessRestart: params.inProcessRestart === true,
           log: params.log,
         }),
       );

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -526,6 +526,10 @@ export type GatewayServerOptions = {
    */
   startupStartedAt?: number;
   /**
+   * True when this server start is the next iteration of a SIGUSR1 in-process restart.
+   */
+  inProcessRestart?: boolean;
+  /**
    * Config snapshot already read by the CLI gateway preflight. Passing it avoids
    * reparsing openclaw.json during server startup.
    */
@@ -683,6 +687,7 @@ export async function startGatewayServer(
       pluginMetadataSnapshot: startupConfigLoad.pluginMetadataSnapshot,
       minimalTestGateway,
       log,
+      inProcessRestart: opts.inProcessRestart === true,
       loadRuntimePlugins: false,
       loadSetupRuntimePlugins: true,
     }),

--- a/src/infra/restart-handoff.ts
+++ b/src/infra/restart-handoff.ts
@@ -5,12 +5,15 @@ import path from "node:path";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { resolveStateDir } from "../config/paths.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { isTruthyEnvValue } from "./env.js";
 
 // Restart handoff files let a supervisor explain a recent gateway restart after
 // the old process exits. The file is short-lived, bounded, and regular-file only.
 export const GATEWAY_SUPERVISOR_RESTART_HANDOFF_FILENAME =
   "gateway-supervisor-restart-handoff.json";
 export const GATEWAY_SUPERVISOR_RESTART_HANDOFF_KIND = "gateway-supervisor-restart-handoff";
+export const GATEWAY_RESTART_SKIP_STARTUP_INGRESS_SWEEP_ENV =
+  "OPENCLAW_GATEWAY_RESTART_SKIP_STARTUP_INGRESS_SWEEP";
 const GATEWAY_RESTART_HANDOFF_TTL_MS = 60_000;
 const GATEWAY_RESTART_TRACE_HANDOFF_MAX_DURATION_MS = 10 * 60_000;
 const GATEWAY_RESTART_HANDOFF_MAX_BYTES = 4096;
@@ -47,6 +50,23 @@ export type GatewayRestartHandoff = {
     lastAt: number;
   };
 };
+
+export function withGatewayRestartSkipStartupIngressSweepEnv(
+  env: NodeJS.ProcessEnv | undefined,
+): NodeJS.ProcessEnv {
+  return {
+    ...env,
+    [GATEWAY_RESTART_SKIP_STARTUP_INGRESS_SWEEP_ENV]: "1",
+  };
+}
+
+export function consumeGatewayRestartSkipStartupIngressSweepEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  const shouldSkip = isTruthyEnvValue(env[GATEWAY_RESTART_SKIP_STARTUP_INGRESS_SWEEP_ENV]);
+  delete env[GATEWAY_RESTART_SKIP_STARTUP_INGRESS_SWEEP_ENV];
+  return shouldSkip;
+}
 
 function formatShortDuration(ms: number): string {
   const clamped = Math.max(0, Math.floor(ms));


### PR DESCRIPTION
### Summary

- **Problem**: Issue #90945 — after a gateway crash, `channel_ingress_events` rows left in `claimed` state are never recovered. Every new message into the affected session adds another stuck claim, silently deadlocking the channel (observed with Telegram DM). Per-queue recovery (`recoverStaleClaims`) only runs inside channel drain loops, which have not started yet right after a crash, so the claimed rows sit unrecovered until manual intervention.

- **Fix**: Add `recoverAllStaleChannelIngressClaims()` in `ingress-queue.ts` and run it from `prepareGatewayPluginBootstrap` (before `startChannels()`) via a new `runStartupIngressClaimSweep`, mirroring the existing `runStartupSessionMigration` pattern. The sweep selects all `claimed` rows, keeps those older than `staleMs` (default 60s) whose owner process is gone, and batch-releases them to `pending` in a single write transaction. It is best-effort and non-blocking — failures are caught, logged, and startup continues.

- **Claim-owner liveness**: `claim_owner` is either a bare PID (queue default) or a compound `${pid}:${uuid}` (Telegram spool — `extensions/telegram/src/telegram-ingress-spool.ts`). Liveness parses the PID prefix before `:` (matching the spool's own `processPidFromOwnerId`), so a live sibling gateway's compound claim is never misread as dead.

- **Race guard**: Each release is guarded by the exact `claim_token` observed during selection. Between the read and the write a sibling gateway could release and re-claim the same event (new token); releasing on `status = "claimed"` alone would drop that fresh claim into duplicate processing. The sweep also returns the actual number of rows affected.

- **What changed**:
  - `src/channels/message/ingress-queue.ts` — new exported `recoverAllStaleChannelIngressClaims()` (+ `staleMs` age guard, `claim_token` release guard) and `isIngressClaimProcessAlive()` (parses bare and compound PID owners).
  - `src/gateway/server-startup-ingress-sweep.ts` — new startup sweep, follows the `server-startup-session-migration.ts` pattern (deps injection, try/catch with warn).
  - `src/gateway/server-startup-plugins.ts` — wires the sweep into `prepareGatewayPluginBootstrap` alongside existing startup tasks (+5 lines).
  - `src/channels/message/ingress-queue.test.ts` — 8 new sweep tests (see Evidence).
  - `src/gateway/server-startup-ingress-sweep.test.ts` — 3 new tests: success logging, error recovery, no-op path.

- **What did NOT change (scope boundary)**: per-queue `recoverStaleClaims()`, `claimNext()`, and Telegram spool recovery are unchanged — the startup sweep is additive. No config, plugin, or gateway-protocol surface changes.

### Reproduction

1. Active Telegram DM session with messages flowing through `channel_ingress_events`.
2. Kill the gateway mid-turn (`kill -HUP <pid>`).
3. `channel_ingress_events` now contains rows with `status = "claimed"` and `claim_owner` = dead PID.
4. Restart gateway — before this PR: claims stay stuck, channel deadlocked. After: claims older than 60s with dead owners are released to `pending` before channels start, messages resume.

### Real behavior proof

**Behavior addressed**: After a gateway crash, stale claimed rows in `channel_ingress_events` are recovered at next startup; live local and sibling-gateway claims (bare PID, compound `pid:uuid`, and rows re-claimed by a live worker) are preserved; channel message processing resumes. Fixes #90945.

**Real environment tested**: macOS Darwin 24.6.0, Node 22.22. Two layers: (1) the SQLite claim lifecycle is exercised against real on-disk state databases (created via `openOpenClawStateDatabase`, no mocks) by deterministic Vitest cases covering dead, live-bare-PID, live-compound-PID, re-claimed-by-live-worker, null, and recent-but-dead owners; (2) a **real `openclaw gateway` process** booted against an isolated state DB pre-seeded with a stuck claim, simulating recovery after a crashed session.

**Exact steps or command run after this patch**:
```
# Seed a stuck claim (status=claimed, dead PID 999999999, claimed 2 min ago) into an
# isolated state DB, then boot the real gateway and watch startup recover it.
OPENCLAW_STATE_DIR=/tmp/oc-proof OPENCLAW_SKIP_CHANNELS=1 OPENCLAW_GATEWAY_PORT=8899 \
  node scripts/run-node.mjs --dev gateway

# Unit layer
pnpm test src/channels/message/ingress-queue.test.ts src/gateway/server-startup-ingress-sweep.test.ts
```

**Evidence after fix**: Live gateway startup recovery (real `openclaw gateway` process, isolated state DB) —
```
BEFORE boot: [{"queue_name":"[\"telegram\",\"dm\"]","event_id":"tg-msg-1",
              "status":"claimed","claim_owner":"999999999","claimed_at":1780779945399}]

2026-06-07T05:08:35 Dev config ready: /tmp/oc-proof/state/openclaw.json
2026-06-07T05:08:37 [gateway] recovered 1 stale channel ingress claim(s) from previous session
2026-06-07T05:08:38 [gateway] http server listening (9 plugins: ...)
2026-06-07T05:08:38 [gateway] ready

AFTER boot:  [{"queue_name":"[\"telegram\",\"dm\"]","event_id":"tg-msg-1",
              "status":"pending","claim_owner":null,
              "last_error":"recovered at startup: owner process gone"}]
```

Unit layer:
```
 ✓ src/gateway/server-startup-ingress-sweep.test.ts (3 tests)
 ✓ src/channels/message/ingress-queue.test.ts (16 tests)
   ✓ recoverAllStaleChannelIngressClaims > recovers claims with dead owner PIDs across multiple queues
   ✓ recoverAllStaleChannelIngressClaims > preserves claims owned by the current process
   ✓ recoverAllStaleChannelIngressClaims > preserves live compound claim owners (Telegram spool `pid:uuid`)
   ✓ recoverAllStaleChannelIngressClaims > does not release a stale event that was re-claimed by a live worker
   ✓ recoverAllStaleChannelIngressClaims > returns zero when there are no claimed rows
   ✓ recoverAllStaleChannelIngressClaims > recovers claims with null or empty claim_owner
   ✓ recoverAllStaleChannelIngressClaims > skips claims newer than staleMs even with dead PIDs
   ✓ recoverAllStaleChannelIngressClaims > preserves recent claims within staleMs window
 Test Files  2 passed (2)
```

**Observed result after fix**: On a real gateway boot, the stuck `claimed` row (dead PID, 2 min old) was released to `pending` before channels started — exactly the deadlock-clearing transition #90945 needs, so the event is deliverable again. Live owners (bare and compound `pid:uuid`) and rows re-claimed by a live worker are preserved; recent claims within the staleMs window are age-protected; the sweep is best-effort and does not block startup on failure.

**What was not tested**: An end-to-end Telegram transport round-trip (sending a real DM, crashing mid-turn, observing it resume in the Telegram client). The recovery mechanism — the gateway startup sweep transitioning the SQLite claim from `claimed` to `pending` — is proven above with a real gateway process; a Telegram round-trip would only add transport-layer coverage on top of the proven claim-lifecycle fix.

### Risk / Mitigation

- **PID recycling**: after a crash the OS could reuse a dead PID. The 60s `staleMs` window means only old claims are candidates, so a recycled PID from a recently-started process won't match. Same trade-off as the existing Telegram spool recovery.
- **Sibling gateway re-claim**: a sibling could release + re-claim a row between this sweep's read and write. The `claim_token` guard releases only the exact claim that was inspected, so a fresh claim is never dropped (regression test: "does not release a stale event that was re-claimed by a live worker").
- **Large backlogs**: all releases batch into a single write transaction.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] channels
- [x] gateway

### Linked Issue/PR

Fixes #90945
