### PR TITLE
fix(agents): use appropriate log levels in model-resolver fallback paths

### DIFF
--- a/src/agents/sessions/model-resolver.ts
+++ b/src/agents/sessions/model-resolver.ts
@@ -584,7 +584,7 @@ export async function restoreModelFromSession(
   const reason = !restoredModel ? "model no longer exists" : "no auth configured";
 
   if (shouldPrintMessages) {
-    console.error(
+    console.warn(
       chalk.yellow(
         `Warning: Could not restore model ${savedProvider}/${savedModelId} (${reason}).`,
       ),
@@ -594,7 +594,7 @@ export async function restoreModelFromSession(
   // If we already have a model, use it as fallback
   if (currentModel) {
     if (shouldPrintMessages) {
-      console.log(chalk.dim(`Falling back to: ${currentModel.provider}/${currentModel.id}`));
+      console.info(chalk.dim(`Falling back to: ${currentModel.provider}/${currentModel.id}`));
     }
     return {
       model: currentModel,
@@ -615,7 +615,7 @@ export async function restoreModelFromSession(
     }
 
     if (shouldPrintMessages) {
-      console.log(chalk.dim(`Falling back to: ${fallbackModel.provider}/${fallbackModel.id}`));
+      console.info(chalk.dim(`Falling back to: ${fallbackModel.provider}/${fallbackModel.id}`));
     }
 
     return {


### PR DESCRIPTION
## Summary

Fix severity misclassification of log statements in `model-resolver.ts` fallback paths. This is a follow-up to the log-level cleanup in `tools-manager.ts` and `resource-loader.ts` (PR #89982), completing the same fix pattern across the remaining affected file in the same subsystem.

## Changes

Three log-level corrections in `src/agents/sessions/model-resolver.ts`:

1. **Line 587** — `console.error` → `console.warn`: The model restoration failure is recoverable (runtime continues with a fallback model), not a fatal error
2. **Line 597** — `console.log` → `console.info`: Routine fallback progress message
3. **Line 618** — `console.log` → `console.info`: Second fallback path progress message

## Severity Classification

The project maps `console.log` → `"info"` level, `console.warn` → `"warn"` level, `console.error` → `"error"` level (see `src/logging/console.ts:302-305`). The fixes align the severity with the actual impact:

| Location | Before | After | Reason |
|---|---|---|---|
| L587 | `console.error` | `console.warn` | Recoverable fallback — runtime continues with fallback model |
| L597 | `console.log` | `console.info` | Routine progress (user already saw the warning, no new action needed) |
| L618 | `console.log` | `console.info` | Routine progress (same) |

## Verification

TypeScript syntax verified. Full type checking via CI pipeline.