### PR TITLE
docs(windows): fix WSL gateway-autostart recipe for WSL ≥ 2.6.1.0 idle-termination

### DIFF
--- a/docs/platforms/windows.md
+++ b/docs/platforms/windows.md
@@ -191,7 +191,7 @@ openclaw gateway install
 In PowerShell as Administrator:
 
 ```powershell
-schtasks /create /tn "WSL Boot" /tr "wsl.exe -d Ubuntu --exec /bin/true" /sc onstart /ru SYSTEM
+schtasks /create /tn "WSL Boot" /tr "wsl.exe -d Ubuntu --exec dbus-launch true" /sc onstart /ru "$env:USERNAME"
 ```
 
 Replace `Ubuntu` with your distro name from:
@@ -199,6 +199,11 @@ Replace `Ubuntu` with your distro name from:
 ```powershell
 wsl --list --verbose
 ```
+
+> **Note:** Two changes from older recipes:
+>
+> - **`dbus-launch true` instead of `/bin/true`** — On WSL ≥ 2.6.1.0 a regression ([microsoft/WSL #13416](https://github.com/microsoft/WSL/issues/13416)) causes the distro to idle-terminate 15–20 seconds after the last client exits, even with linger enabled. `dbus-launch true` keeps a child-of-init process alive as a workaround ([community discussion, microsoft/WSL #9245](https://github.com/microsoft/WSL/discussions/9245)).
+> - **`/ru "$env:USERNAME"` instead of `/ru SYSTEM`** — Per-user WSL distros (the default setup) are not visible to the SYSTEM account; the task appears to run but the distro is never started. Running as your own account avoids this. Windows will prompt for your password when the task is created.
 
 After reboot, verify from WSL:
 

--- a/docs/platforms/windows.md
+++ b/docs/platforms/windows.md
@@ -184,6 +184,7 @@ into Windows.
 Inside WSL:
 
 ```bash
+sudo apt-get install -y dbus-x11
 sudo loginctl enable-linger "$(whoami)"
 openclaw gateway install
 ```


### PR DESCRIPTION
## Problem

The documented headless-boot recipe for WSL2 ("Gateway auto-start before Windows login") contains two issues:

**1. `/bin/true` causes idle-termination on WSL ≥ 2.6.1.0**

On WSL ≥ 2.6.1.0 ([microsoft/WSL #13416](https://github.com/microsoft/WSL/issues/13416)), the distro idle-terminates 15–20 seconds after the last `wsl.exe` client exits — even with `loginctl enable-linger` active and a user service running. The documented `/bin/true` action exits immediately, triggering this regression. Community workaround: [microsoft/WSL discussion #9245](https://github.com/microsoft/WSL/discussions/9245).

**2. `/ru SYSTEM` silently fails for per-user distros**

Per-user WSL distros (the default setup) are not enumerable by the SYSTEM account. The scheduled task runs but never starts the distro.

## Fix

- Replace `/bin/true` with `dbus-launch true` (child-of-init keepalive)
- Replace `/ru SYSTEM` with `/ru "$env:USERNAME"` (PowerShell expands before passing to `schtasks`; Windows prompts for password at task creation time)
- Add an inline note explaining both changes

## Real behavior proof

**Behavior or issue addressed**: On WSL ≥ 2.6.1.0, the documented `/bin/true` keepalive causes the distro to idle-terminate ~18 s after the scheduled task completes, even with `loginctl enable-linger` and an active gateway user service. The gateway boots at startup then goes unreachable (HTTP 502). `/ru SYSTEM` silently skips per-user distros — task shows success in Task Scheduler but `wsl --list --running` shows the distro was never started.

**Real environment tested**: lapclaw (headless node, no interactive Windows login), WSL 2.7.3.0, Ubuntu 22.04, per-user distro, systemd enabled, `loginctl enable-linger "$(whoami)"` active, OpenClaw gateway service installed via `openclaw gateway install`.

**Exact steps or command run after this patch**: Replaced scheduled task action with `dbus-launch true` and `/ru <user-account>`. Rebooted Windows (no interactive login). Polled gateway health every 10 s for 240 s from a remote machine immediately after boot.

**Evidence after fix**:
```
# 24 polls × 10 s = 240 s fully detached after task exited
$ for i in $(seq 1 24); do
    curl -s -o /dev/null -w "t=%{time_total}s http=%{http_code}\n" http://lapclaw:PORT/health
    sleep 10
  done
t=0.003s http=200
t=0.003s http=200
t=0.003s http=200
t=0.004s http=200
t=0.003s http=200
t=0.003s http=200
t=0.003s http=200
t=0.003s http=200
t=0.003s http=200
t=0.003s http=200
t=0.003s http=200
t=0.004s http=200
t=0.003s http=200
t=0.003s http=200
t=0.003s http=200
t=0.003s http=200
t=0.003s http=200
t=0.003s http=200
t=0.003s http=200
t=0.003s http=200
t=0.003s http=200
t=0.003s http=200
t=0.003s http=200
t=0.003s http=200
```
With old `/bin/true` on the same setup: gateway returned HTTP 502 at t≈18 s. With `/ru SYSTEM`: `wsl --list --running` showed empty after task ran; switched to `/ru <user>`: distro listed as running.

**Observed result after fix**: Gateway remains reachable for the full 240 s observation window with no idle termination. Per-user distro starts correctly when task runs as the user account.

**What was not tested**: Windows 10. ARM64 Windows. Distros registered system-wide (non-per-user). The `/ru` fix was confirmed by presence/absence in `wsl --list --running`, not by timing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)