### PR TITLE
fix(codex): restore native PreToolUse relay delivery

### DIFF
--- a/extensions/codex/src/app-server/native-hook-relay.test.ts
+++ b/extensions/codex/src/app-server/native-hook-relay.test.ts
@@ -290,6 +290,13 @@ describe("Codex native hook relay config", () => {
 
     expect(
       buildCodexNativeHookRelayConfig({
+        relay: createRelay({ preToolUsePolicyActive: false }),
+        events: ["pre_tool_use"],
+      }),
+    ).not.toHaveProperty("features.unified_exec");
+
+    expect(
+      buildCodexNativeHookRelayConfig({
         relay: createRelay(),
         events: ["permission_request"],
       }),
@@ -329,6 +336,7 @@ describe("Codex native hook relay config", () => {
 
 function createRelay(options?: {
   inactiveEvents?: readonly NativeHookRelayRegistrationHandle["allowedEvents"][number][];
+  preToolUsePolicyActive?: boolean;
 }): NativeHookRelayRegistrationHandle {
   const inactiveEvents = new Set(options?.inactiveEvents ?? []);
   return {
@@ -338,6 +346,7 @@ function createRelay(options?: {
     sessionId: "session-1",
     sessionKey: "agent:main:session-1",
     runId: "run-1",
+    preToolUsePolicyActive: options?.preToolUsePolicyActive ?? true,
     allowedEvents: ["pre_tool_use", "post_tool_use", "permission_request", "before_agent_finalize"],
     expiresAtMs: Date.now() + 1000,
     shouldRelayEvent: (event) => !inactiveEvents.has(event),

--- a/extensions/codex/src/app-server/native-hook-relay.test.ts
+++ b/extensions/codex/src/app-server/native-hook-relay.test.ts
@@ -17,6 +17,8 @@ describe("Codex native hook relay config", () => {
 
     expect(config).toEqual({
       "features.hooks": true,
+      "features.unified_exec": true,
+      experimental_use_unified_exec_tool: true,
       "hooks.PreToolUse": [
         {
           hooks: [
@@ -157,6 +159,8 @@ describe("Codex native hook relay config", () => {
       }),
     ).toEqual({
       "features.hooks": true,
+      "features.unified_exec": true,
+      experimental_use_unified_exec_tool: true,
       "hooks.PreToolUse": [
         {
           hooks: [
@@ -264,6 +268,32 @@ describe("Codex native hook relay config", () => {
         "<session-flags>/config.toml:stop:0:0": { enabled: false },
       },
     });
+  });
+
+  it("enables unified exec only for active PreToolUse relay config", () => {
+    expect(
+      buildCodexNativeHookRelayConfig({
+        relay: createRelay(),
+        events: ["pre_tool_use"],
+      }),
+    ).toMatchObject({
+      "features.unified_exec": true,
+      experimental_use_unified_exec_tool: true,
+    });
+
+    expect(
+      buildCodexNativeHookRelayConfig({
+        relay: createRelay({ inactiveEvents: ["pre_tool_use"] }),
+        events: ["pre_tool_use"],
+      }),
+    ).not.toHaveProperty("features.unified_exec");
+
+    expect(
+      buildCodexNativeHookRelayConfig({
+        relay: createRelay(),
+        events: ["permission_request"],
+      }),
+    ).not.toHaveProperty("features.unified_exec");
   });
 
   it("omits matchers so Codex MCP tool names reach the relay with a stable trust hash", () => {

--- a/extensions/codex/src/app-server/native-hook-relay.ts
+++ b/extensions/codex/src/app-server/native-hook-relay.ts
@@ -116,6 +116,7 @@ export function createCodexNativeHookRelay(params: {
   agentId: string | undefined;
   sessionId: string;
   sessionKey: string | undefined;
+  preToolUsePolicyActive?: boolean;
   config: EmbeddedRunAttemptParams["config"];
   runId: string;
   channelId?: string;
@@ -141,6 +142,7 @@ export function createCodexNativeHookRelay(params: {
     ...(params.agentId ? { agentId: params.agentId } : {}),
     sessionId: params.sessionId,
     ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
+    ...(params.preToolUsePolicyActive === true ? { preToolUsePolicyActive: true } : {}),
     ...(params.config ? { config: params.config } : {}),
     runId: params.runId,
     ...(params.channelId ? { channelId: params.channelId } : {}),
@@ -242,6 +244,12 @@ export function buildCodexNativeHookRelayConfig(params: {
   const config: JsonObject = {
     "features.hooks": true,
   };
+  if (selectedEvents.has("pre_tool_use") && params.relay.shouldRelayEvent("pre_tool_use")) {
+    // PreToolUse hooks run through Codex's tool router. Force shell-like native
+    // execution onto the hookable exec_command path while the relay is active.
+    config["features.unified_exec"] = true;
+    config.experimental_use_unified_exec_tool = true;
+  }
   const hookState: JsonObject = {};
   for (const event of CODEX_NATIVE_HOOK_RELAY_EVENTS) {
     const codexEvent = CODEX_HOOK_EVENT_BY_NATIVE_EVENT[event];

--- a/extensions/codex/src/app-server/native-hook-relay.ts
+++ b/extensions/codex/src/app-server/native-hook-relay.ts
@@ -244,9 +244,15 @@ export function buildCodexNativeHookRelayConfig(params: {
   const config: JsonObject = {
     "features.hooks": true,
   };
-  if (selectedEvents.has("pre_tool_use") && params.relay.shouldRelayEvent("pre_tool_use")) {
+  if (
+    selectedEvents.has("pre_tool_use") &&
+    params.relay.shouldRelayEvent("pre_tool_use") &&
+    params.relay.preToolUsePolicyActive === true
+  ) {
     // PreToolUse hooks run through Codex's tool router. Force shell-like native
-    // execution onto the hookable exec_command path while the relay is active.
+    // execution onto the hookable exec_command path only when OpenClaw policy
+    // requires PreToolUse enforcement; observational hooks should not broaden
+    // the default Codex execution surface.
     config["features.unified_exec"] = true;
     config.experimental_use_unified_exec_tool = true;
   }

--- a/extensions/codex/src/app-server/native-hook-relay.ts
+++ b/extensions/codex/src/app-server/native-hook-relay.ts
@@ -111,7 +111,6 @@ export function createCodexNativeHookRelay(params: {
       }
     | undefined;
   generation?: string;
-  generationMismatchGraceMs?: number;
   events: readonly NativeHookRelayEvent[];
   agentId: string | undefined;
   sessionId: string;
@@ -136,9 +135,6 @@ export function createCodexNativeHookRelay(params: {
       sessionKey: params.sessionKey,
     }),
     ...(params.generation ? { generation: params.generation } : {}),
-    ...(params.generationMismatchGraceMs
-      ? { generationMismatchGraceMs: params.generationMismatchGraceMs }
-      : {}),
     ...(params.agentId ? { agentId: params.agentId } : {}),
     sessionId: params.sessionId,
     ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),

--- a/extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts
@@ -5,6 +5,8 @@ import {
   invokeNativeHookRelay,
   nativeHookRelayTesting,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
+import { initializeGlobalHookRunner } from "openclaw/plugin-sdk/hook-runtime";
+import { createMockPluginRegistry } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { describe, expect, it, vi } from "vitest";
 import * as approvalBridge from "./approval-bridge.js";
 import {
@@ -37,6 +39,7 @@ describe("runCodexAppServerAttempt native hook relay", () => {
       },
     });
     await harness.waitForMethod("turn/start");
+
     await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
     await run;
 
@@ -44,6 +47,8 @@ describe("runCodexAppServerAttempt native hook relay", () => {
     const startConfig = (startRequest?.params as { config?: Record<string, unknown> } | undefined)
       ?.config;
     expect(startConfig?.["features.hooks"]).toBe(true);
+    expect(startConfig?.["features.unified_exec"]).toBe(true);
+    expect(startConfig?.experimental_use_unified_exec_tool).toBe(true);
     const preToolUseHooks = startConfig?.["hooks.PreToolUse"] as
       | Array<{ hooks?: Array<{ command?: string; timeout?: number; type?: string }> }>
       | undefined;
@@ -62,6 +67,43 @@ describe("runCodexAppServerAttempt native hook relay", () => {
     expect(nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(relayId)).toBeDefined();
     testing.flushPendingCodexNativeHookRelayUnregistersForTests();
     expect(nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(relayId)).toBeUndefined();
+  });
+
+  it("keeps PreToolUse relay config active from the run-start policy snapshot", async () => {
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([{ hookName: "before_tool_call", handler: vi.fn() }]),
+    );
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const harness = createStartedThreadHarness();
+    const params = createParams(sessionFile, workspaceDir);
+    params.config = { tools: { loopDetection: { enabled: false } } } as never;
+
+    const run = runCodexAppServerAttempt(params, {
+      nativeHookRelay: {
+        enabled: true,
+        events: ["pre_tool_use"],
+      },
+    });
+    await harness.waitForMethod("turn/start");
+    const startRequest = harness.requests.find((request) => request.method === "thread/start");
+    const relayId = extractRelayIdFromThreadRequest(startRequest?.params);
+    expect(
+      nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(relayId)
+        ?.preToolUsePolicyActive,
+    ).toBe(true);
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await run;
+
+    const startConfig = (startRequest?.params as { config?: Record<string, unknown> } | undefined)
+      ?.config;
+    expect(startConfig?.["features.unified_exec"]).toBe(true);
+    expect(startConfig?.experimental_use_unified_exec_tool).toBe(true);
+    const hookState = startConfig?.["hooks.state"] as Record<string, { enabled?: unknown }>;
+    const preToolUseState = Object.values(hookState).find(
+      (state) => state.enabled === true,
+    );
+    expect(preToolUseState).toBeDefined();
   });
 
   it("forwards command approval requests through the active native hook relay", async () => {
@@ -270,6 +312,8 @@ describe("runCodexAppServerAttempt native hook relay", () => {
     const startConfig = (startRequest?.params as { config?: Record<string, unknown> } | undefined)
       ?.config;
     expect(startConfig?.["features.hooks"]).toBe(true);
+    expect(startConfig?.["features.unified_exec"]).toBe(true);
+    expect(startConfig?.experimental_use_unified_exec_tool).toBe(true);
     expect(Array.isArray(startConfig?.["hooks.PreToolUse"])).toBe(true);
     expect(startConfig?.["hooks.PostToolUse"]).toEqual([]);
     expect(startConfig?.["hooks.Stop"]).toEqual([]);
@@ -307,6 +351,8 @@ describe("runCodexAppServerAttempt native hook relay", () => {
     const startConfig = (startRequest?.params as { config?: Record<string, unknown> } | undefined)
       ?.config;
     expect(startConfig?.["features.hooks"]).toBe(true);
+    expect(startConfig).not.toHaveProperty("features.unified_exec");
+    expect(startConfig).not.toHaveProperty("experimental_use_unified_exec_tool");
     expect(Array.isArray(startConfig?.["hooks.PermissionRequest"])).toBe(true);
     const relayId = extractRelayIdFromThreadRequest(startRequest?.params);
     expect(

--- a/extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts
@@ -47,8 +47,8 @@ describe("runCodexAppServerAttempt native hook relay", () => {
     const startConfig = (startRequest?.params as { config?: Record<string, unknown> } | undefined)
       ?.config;
     expect(startConfig?.["features.hooks"]).toBe(true);
-    expect(startConfig?.["features.unified_exec"]).toBe(true);
-    expect(startConfig?.experimental_use_unified_exec_tool).toBe(true);
+    expect(startConfig).not.toHaveProperty("features.unified_exec");
+    expect(startConfig).not.toHaveProperty("experimental_use_unified_exec_tool");
     const preToolUseHooks = startConfig?.["hooks.PreToolUse"] as
       | Array<{ hooks?: Array<{ command?: string; timeout?: number; type?: string }> }>
       | undefined;
@@ -310,8 +310,8 @@ describe("runCodexAppServerAttempt native hook relay", () => {
     const startConfig = (startRequest?.params as { config?: Record<string, unknown> } | undefined)
       ?.config;
     expect(startConfig?.["features.hooks"]).toBe(true);
-    expect(startConfig?.["features.unified_exec"]).toBe(true);
-    expect(startConfig?.experimental_use_unified_exec_tool).toBe(true);
+    expect(startConfig).not.toHaveProperty("features.unified_exec");
+    expect(startConfig).not.toHaveProperty("experimental_use_unified_exec_tool");
     expect(Array.isArray(startConfig?.["hooks.PreToolUse"])).toBe(true);
     expect(startConfig?.["hooks.PostToolUse"]).toEqual([]);
     expect(startConfig?.["hooks.Stop"]).toEqual([]);

--- a/extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts
@@ -100,9 +100,7 @@ describe("runCodexAppServerAttempt native hook relay", () => {
     expect(startConfig?.["features.unified_exec"]).toBe(true);
     expect(startConfig?.experimental_use_unified_exec_tool).toBe(true);
     const hookState = startConfig?.["hooks.state"] as Record<string, { enabled?: unknown }>;
-    const preToolUseState = Object.values(hookState).find(
-      (state) => state.enabled === true,
-    );
+    const preToolUseState = Object.values(hookState).find((state) => state.enabled === true);
     expect(preToolUseState).toBeDefined();
   });
 
@@ -535,7 +533,7 @@ describe("runCodexAppServerAttempt native hook relay", () => {
     testing.flushPendingCodexNativeHookRelayUnregistersForTests();
   });
 
-  it("accepts a stale first hook generation when resuming a pre-generation binding", async () => {
+  it("starts fresh instead of trusting a pre-generation binding for native hooks", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");
     await writeCodexAppServerBinding(sessionFile, {
@@ -545,7 +543,7 @@ describe("runCodexAppServerAttempt native hook relay", () => {
       modelProvider: "openai",
       dynamicToolsFingerprint: "[]",
     });
-    const harness = createResumeHarness();
+    const harness = createStartedThreadHarness();
 
     const run = runCodexAppServerAttempt(createParams(sessionFile, workspaceDir), {
       nativeHookRelay: {
@@ -555,9 +553,10 @@ describe("runCodexAppServerAttempt native hook relay", () => {
     });
     await harness.waitForMethod("turn/start");
 
-    const resumeRequest = harness.requests.find((request) => request.method === "thread/resume");
-    const relayId = extractRelayIdFromThreadRequest(resumeRequest?.params);
-    const currentGeneration = extractGenerationFromThreadRequest(resumeRequest?.params);
+    const startRequest = harness.requests.find((request) => request.method === "thread/start");
+    expect(harness.requests.some((request) => request.method === "thread/resume")).toBe(false);
+    const relayId = extractRelayIdFromThreadRequest(startRequest?.params);
+    const currentGeneration = extractGenerationFromThreadRequest(startRequest?.params);
     expect(currentGeneration).not.toBe("legacy-generation-from-running-thread");
     await expect(
       invokeNativeHookRelay({
@@ -573,7 +572,7 @@ describe("runCodexAppServerAttempt native hook relay", () => {
           tool_input: { command: "pwd" },
         },
       }),
-    ).resolves.toMatchObject({ exitCode: 0 });
+    ).rejects.toThrow("native hook relay bridge stale registration");
     await expect(
       invokeNativeHookRelay({
         provider: "codex",
@@ -590,7 +589,7 @@ describe("runCodexAppServerAttempt native hook relay", () => {
       }),
     ).rejects.toThrow("native hook relay bridge stale registration");
 
-    await harness.completeTurn({ threadId: "thread-existing", turnId: "turn-1" });
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
     await run;
     expect((await readCodexAppServerBinding(sessionFile))?.nativeHookRelayGeneration).toBe(
       currentGeneration,

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -366,6 +366,9 @@ export async function runCodexAppServerAttempt(
     agentId: params.agentId,
   });
   const beforeToolCallPolicy = getBeforeToolCallPolicyDiagnosticState();
+  const preToolUsePolicyActive =
+    beforeToolCallPolicy.hasBeforeToolCallHook ||
+    beforeToolCallPolicy.trustedToolPolicies.length > 0;
   preDynamicStartupStages.mark("config");
   const resolvedWorkspace = resolveUserPath(params.workspaceDir);
   await ensureCodexWorkspaceDirOnce(resolvedWorkspace);
@@ -1034,6 +1037,7 @@ export async function runCodexAppServerAttempt(
       agentId: sessionAgentId,
       sessionId: params.sessionId,
       sessionKey: sandboxSessionKey,
+      preToolUsePolicyActive,
       config: params.config,
       runId: params.runId,
       channelId: hookChannelId,

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -1029,10 +1029,6 @@ export async function runCodexAppServerAttempt(
       options: options.nativeHookRelay,
       generation:
         decision.action === "resume" ? decision.binding.nativeHookRelayGeneration : undefined,
-      generationMismatchGraceMs:
-        decision.action === "resume" && !decision.binding.nativeHookRelayGeneration
-          ? CODEX_NATIVE_HOOK_RELAY_TTL_GRACE_MS
-          : undefined,
       events: nativeHookRelayEvents,
       agentId: sessionAgentId,
       sessionId: params.sessionId,

--- a/extensions/codex/src/app-server/session-binding.test.ts
+++ b/extensions/codex/src/app-server/session-binding.test.ts
@@ -63,6 +63,7 @@ describe("codex app-server session binding", () => {
       dynamicToolsFingerprint: "tools-v1",
       userMcpServersFingerprint: "user-mcp-v1",
       nativeHookRelayGeneration: "generation-v1",
+      nativeHookRelayConfigFingerprint: "native-hook-config-v1",
     });
 
     const binding = await readCodexAppServerBinding(sessionFile);
@@ -76,6 +77,7 @@ describe("codex app-server session binding", () => {
     expect(binding?.dynamicToolsFingerprint).toBe("tools-v1");
     expect(binding?.userMcpServersFingerprint).toBe("user-mcp-v1");
     expect(binding?.nativeHookRelayGeneration).toBe("generation-v1");
+    expect(binding?.nativeHookRelayConfigFingerprint).toBe("native-hook-config-v1");
     const bindingStat = await fs.stat(resolveCodexAppServerBindingPath(sessionFile));
     expect(bindingStat.isFile()).toBe(true);
   });

--- a/extensions/codex/src/app-server/session-binding.ts
+++ b/extensions/codex/src/app-server/session-binding.ts
@@ -50,6 +50,7 @@ export type CodexAppServerThreadBinding = {
   userMcpServersFingerprint?: string;
   mcpServersFingerprint?: string;
   nativeHookRelayGeneration?: string;
+  nativeHookRelayConfigFingerprint?: string;
   pluginAppsFingerprint?: string;
   pluginAppsInputFingerprint?: string;
   pluginAppPolicyContext?: PluginAppPolicyContext;
@@ -137,6 +138,11 @@ export async function readCodexAppServerBinding(
         parsed.nativeHookRelayGeneration.trim()
           ? parsed.nativeHookRelayGeneration
           : undefined,
+      nativeHookRelayConfigFingerprint:
+        typeof parsed.nativeHookRelayConfigFingerprint === "string" &&
+        parsed.nativeHookRelayConfigFingerprint.trim()
+          ? parsed.nativeHookRelayConfigFingerprint
+          : undefined,
       pluginAppsFingerprint:
         typeof parsed.pluginAppsFingerprint === "string" ? parsed.pluginAppsFingerprint : undefined,
       pluginAppsInputFingerprint:
@@ -190,6 +196,7 @@ export async function writeCodexAppServerBinding(
     userMcpServersFingerprint: binding.userMcpServersFingerprint,
     mcpServersFingerprint: binding.mcpServersFingerprint,
     nativeHookRelayGeneration: binding.nativeHookRelayGeneration,
+    nativeHookRelayConfigFingerprint: binding.nativeHookRelayConfigFingerprint,
     pluginAppsFingerprint: binding.pluginAppsFingerprint,
     pluginAppsInputFingerprint: binding.pluginAppsInputFingerprint,
     pluginAppPolicyContext: binding.pluginAppPolicyContext,

--- a/extensions/codex/src/app-server/side-question.test.ts
+++ b/extensions/codex/src/app-server/side-question.test.ts
@@ -592,6 +592,8 @@ describe("runCodexAppServerSideQuestion", () => {
     const forkParams = mockCall(client.request)[1] as Record<string, unknown> | undefined;
     const config = forkParams?.config as Record<string, unknown> | undefined;
     expect(config?.["features.hooks"]).toBe(true);
+    expect(config?.["features.unified_exec"]).toBe(true);
+    expect(config?.experimental_use_unified_exec_tool).toBe(true);
     expect(config?.["features.code_mode"]).toBe(true);
     expect(config?.["features.code_mode_only"]).toBe(false);
     expect(config?.["hooks.PermissionRequest"]).toEqual([]);
@@ -774,6 +776,8 @@ describe("runCodexAppServerSideQuestion", () => {
       "--event permission_request",
     );
     expect(codexHookCommand(config, "hooks.PreToolUse")?.command).toContain("--event pre_tool_use");
+    expect(config?.["features.unified_exec"]).toBe(true);
+    expect(config?.experimental_use_unified_exec_tool).toBe(true);
   });
 
   it("preserves explicitly configured side-thread native hook events", async () => {
@@ -792,6 +796,8 @@ describe("runCodexAppServerSideQuestion", () => {
       "--event permission_request",
     );
     expect(config?.["hooks.PreToolUse"]).toEqual([]);
+    expect(config).not.toHaveProperty("features.unified_exec");
+    expect(config).not.toHaveProperty("experimental_use_unified_exec_tool");
     expect(config?.["hooks.PostToolUse"]).toEqual([]);
     expect(config?.["hooks.Stop"]).toEqual([]);
     const hookState = config?.["hooks.state"] as

--- a/extensions/codex/src/app-server/side-question.test.ts
+++ b/extensions/codex/src/app-server/side-question.test.ts
@@ -592,8 +592,8 @@ describe("runCodexAppServerSideQuestion", () => {
     const forkParams = mockCall(client.request)[1] as Record<string, unknown> | undefined;
     const config = forkParams?.config as Record<string, unknown> | undefined;
     expect(config?.["features.hooks"]).toBe(true);
-    expect(config?.["features.unified_exec"]).toBe(true);
-    expect(config?.experimental_use_unified_exec_tool).toBe(true);
+    expect(config).not.toHaveProperty("features.unified_exec");
+    expect(config).not.toHaveProperty("experimental_use_unified_exec_tool");
     expect(config?.["features.code_mode"]).toBe(true);
     expect(config?.["features.code_mode_only"]).toBe(false);
     expect(config?.["hooks.PermissionRequest"]).toEqual([]);
@@ -776,8 +776,8 @@ describe("runCodexAppServerSideQuestion", () => {
       "--event permission_request",
     );
     expect(codexHookCommand(config, "hooks.PreToolUse")?.command).toContain("--event pre_tool_use");
-    expect(config?.["features.unified_exec"]).toBe(true);
-    expect(config?.experimental_use_unified_exec_tool).toBe(true);
+    expect(config).not.toHaveProperty("features.unified_exec");
+    expect(config).not.toHaveProperty("experimental_use_unified_exec_tool");
   });
 
   it("preserves explicitly configured side-thread native hook events", async () => {

--- a/extensions/codex/src/app-server/side-question.ts
+++ b/extensions/codex/src/app-server/side-question.ts
@@ -3,6 +3,7 @@ import {
   buildAgentHookContextChannelFields,
   embeddedAgentLog,
   formatErrorMessage,
+  getBeforeToolCallPolicyDiagnosticState,
   resolveAgentDir,
   resolveAttemptSpawnWorkspaceDir,
   resolveModelAuthMode,
@@ -273,6 +274,10 @@ export async function runCodexAppServerSideQuestion(
     });
 
     const serviceTier = binding.serviceTier ?? appServer.serviceTier;
+    const beforeToolCallPolicy = getBeforeToolCallPolicyDiagnosticState();
+    const preToolUsePolicyActive =
+      beforeToolCallPolicy.hasBeforeToolCallHook ||
+      beforeToolCallPolicy.trustedToolPolicies.length > 0;
     const nativeHookRelayEvents = resolveCodexSideNativeHookRelayEvents({
       configuredEvents: options.nativeHookRelay?.events,
       approvalPolicy,
@@ -284,6 +289,7 @@ export async function runCodexAppServerSideQuestion(
           agentId: sessionAgentId,
           sessionId: params.sessionId,
           sessionKey: params.sessionKey,
+          preToolUsePolicyActive,
           config: params.cfg,
           runId: sideRunParams.runId,
           channelId: buildAgentHookContextChannelFields({
@@ -435,6 +441,7 @@ function registerCodexSideNativeHookRelay(params: {
   agentId: string | undefined;
   sessionId: string;
   sessionKey: string | undefined;
+  preToolUsePolicyActive?: boolean;
   config: EmbeddedRunAttemptParams["config"];
   runId: string;
   channelId?: string;
@@ -450,6 +457,7 @@ function registerCodexSideNativeHookRelay(params: {
     ...(params.agentId ? { agentId: params.agentId } : {}),
     sessionId: params.sessionId,
     ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
+    ...(params.preToolUsePolicyActive === true ? { preToolUsePolicyActive: true } : {}),
     ...(params.config ? { config: params.config } : {}),
     runId: params.runId,
     ...(params.channelId ? { channelId: params.channelId } : {}),

--- a/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
@@ -716,12 +716,12 @@ describe("Codex app-server thread lifecycle bindings", () => {
       }
       throw new Error(`unexpected method: ${method}`);
     });
-    const config = {
+    const finalConfigPatch = {
       "features.hooks": true,
       "hooks.PreToolUse": [],
     };
     const expectedConfig = {
-      ...config,
+      ...finalConfigPatch,
       "features.code_mode": true,
       "features.code_mode_only": false,
       "features.apply_patch_streaming_events": true,
@@ -733,7 +733,7 @@ describe("Codex app-server thread lifecycle bindings", () => {
       cwd: workspaceDir,
       dynamicTools: [],
       appServer,
-      config,
+      finalConfigPatch,
     });
     await startOrResumeThread({
       client: { request } as never,
@@ -741,13 +741,104 @@ describe("Codex app-server thread lifecycle bindings", () => {
       cwd: workspaceDir,
       dynamicTools: [],
       appServer,
-      config,
+      finalConfigPatch,
     });
 
     const requestCalls = request.mock.calls as unknown as Array<[string, { config?: unknown }]>;
     expect(requestCalls.map(([method]) => method)).toEqual(["thread/start", "thread/resume"]);
     expect(requestCalls[0]?.[1].config).toEqual(expectedConfig);
     expect(requestCalls[1]?.[1].config).toEqual(expectedConfig);
+    const binding = await readCodexAppServerBinding(sessionFile);
+    expect(binding?.nativeHookRelayConfigFingerprint).toBeTruthy();
+  });
+
+  it("starts a fresh Codex thread when native hook relay config was not applied to the binding", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    await writeCodexAppServerBinding(sessionFile, {
+      threadId: "thread-existing",
+      cwd: workspaceDir,
+      model: "gpt-5.4-codex",
+      modelProvider: "openai",
+      dynamicToolsFingerprint: "[]",
+      nativeHookRelayGeneration: "generation-existing",
+    });
+    const params = createParams(sessionFile, workspaceDir);
+    const appServer = createThreadLifecycleAppServerOptions();
+    const request = vi.fn(async (method: string) => {
+      if (method === "thread/start") {
+        return threadStartResult("thread-fresh");
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+    const finalConfigPatch = {
+      "features.hooks": true,
+      "hooks.PreToolUse": [
+        {
+          hooks: [{ type: "command", command: "openclaw-native-hook-relay", timeout: 5 }],
+        },
+      ],
+    };
+
+    const binding = await startOrResumeThread({
+      client: { request } as never,
+      params,
+      cwd: workspaceDir,
+      dynamicTools: [],
+      appServer,
+      finalConfigPatch,
+    });
+
+    const requestCalls = request.mock.calls as unknown as Array<[string, { config?: unknown }]>;
+    expect(binding.lifecycle.action).toBe("started");
+    expect(binding.threadId).toBe("thread-fresh");
+    expect(requestCalls.map(([method]) => method)).toEqual(["thread/start"]);
+    expect(requestCalls[0]?.[1].config).toMatchObject(finalConfigPatch);
+    const savedBinding = await readCodexAppServerBinding(sessionFile);
+    expect(savedBinding?.nativeHookRelayConfigFingerprint).toBeTruthy();
+  });
+
+  it("starts a fresh Codex thread when native hook relay config changes", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createParams(sessionFile, workspaceDir);
+    const appServer = createThreadLifecycleAppServerOptions();
+    const request = vi.fn(async (method: string) => {
+      if (method === "thread/start") {
+        return threadStartResult(`thread-${request.mock.calls.length}`);
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    await startOrResumeThread({
+      client: { request } as never,
+      params,
+      cwd: workspaceDir,
+      dynamicTools: [],
+      appServer,
+      finalConfigPatch: {
+        "features.hooks": true,
+        "hooks.PreToolUse": [],
+      },
+    });
+    const binding = await startOrResumeThread({
+      client: { request } as never,
+      params,
+      cwd: workspaceDir,
+      dynamicTools: [],
+      appServer,
+      finalConfigPatch: {
+        "features.hooks": true,
+        "hooks.PreToolUse": [
+          {
+            hooks: [{ type: "command", command: "openclaw-native-hook-relay", timeout: 9 }],
+          },
+        ],
+      },
+    });
+
+    expect(binding.lifecycle.action).toBe("started");
+    expect(request.mock.calls.map(([method]) => method)).toEqual(["thread/start", "thread/start"]);
   });
 
   it("merges native hook relay config with plugin app config when starting a thread", async () => {

--- a/extensions/codex/src/app-server/thread-lifecycle.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.ts
@@ -525,109 +525,130 @@ export async function startOrResumeThread(params: {
           configPatch: params.finalConfigPatch,
           nativeHookRelayGeneration: params.nativeHookRelayGeneration,
         };
-        const resumeConfig = mergeCodexThreadConfigs(
-          params.config,
-          userMcpServersConfigPatch,
+        const resumeBinding = binding;
+        const nativeHookRelayConfigFingerprint = fingerprintNativeHookRelayConfigPatch(
           finalConfigPatch.configPatch,
         );
-        const resumeParams = lifecycleTiming.measureSync("thread-resume-params", () =>
-          buildThreadResumeParams(params.params, {
-            threadId: binding.threadId,
-            authProfileId,
-            appServer: params.appServer,
-            dynamicTools: params.dynamicTools,
-            developerInstructions: params.developerInstructions,
-            config: resumeConfig,
-            nativeCodeModeEnabled: params.nativeCodeModeEnabled,
-            nativeCodeModeOnlyEnabled: params.nativeCodeModeOnlyEnabled,
-          }),
-        );
-        const response = assertCodexThreadResumeResponse(
-          await lifecycleTiming.measure("thread-resume-request", () =>
-            params.client.request("thread/resume", resumeParams, { signal: params.signal }),
-          ),
-        );
-        throwIfAborted();
-        const boundAuthProfileId = authProfileId;
-        const fallbackModelProvider = resolveCodexAppServerModelProvider({
-          provider: params.params.provider,
-          authProfileId: boundAuthProfileId,
-          authProfileStore: params.params.authProfileStore,
-          agentDir: params.params.agentDir,
-          config: params.params.config,
-        });
-        const nextMcpServersFingerprint =
-          params.mcpServersFingerprintEvaluated === true
-            ? params.mcpServersFingerprint
-            : binding.mcpServersFingerprint;
-        await lifecycleTiming.measure("thread-resume-write-binding", () =>
-          writeCodexAppServerBinding(
-            params.params.sessionFile,
+        if (resumeBinding.nativeHookRelayConfigFingerprint !== nativeHookRelayConfigFingerprint) {
+          embeddedAgentLog.debug(
+            "codex app-server native hook relay config changed; starting a new thread",
             {
+              threadId: resumeBinding.threadId,
+              previousNativeHookRelayConfigFingerprint:
+                resumeBinding.nativeHookRelayConfigFingerprint,
+              nativeHookRelayConfigFingerprint,
+            },
+          );
+          await clearCodexAppServerBinding(params.params.sessionFile);
+          binding = undefined;
+        } else {
+          const resumeConfig = mergeCodexThreadConfigs(
+            params.config,
+            userMcpServersConfigPatch,
+            finalConfigPatch.configPatch,
+          );
+          const resumeParams = lifecycleTiming.measureSync("thread-resume-params", () =>
+            buildThreadResumeParams(params.params, {
+              threadId: resumeBinding.threadId,
+              authProfileId,
+              appServer: params.appServer,
+              dynamicTools: params.dynamicTools,
+              developerInstructions: params.developerInstructions,
+              config: resumeConfig,
+              nativeCodeModeEnabled: params.nativeCodeModeEnabled,
+              nativeCodeModeOnlyEnabled: params.nativeCodeModeOnlyEnabled,
+            }),
+          );
+          const response = assertCodexThreadResumeResponse(
+            await lifecycleTiming.measure("thread-resume-request", () =>
+              params.client.request("thread/resume", resumeParams, { signal: params.signal }),
+            ),
+          );
+          throwIfAborted();
+          const boundAuthProfileId = authProfileId;
+          const fallbackModelProvider = resolveCodexAppServerModelProvider({
+            provider: params.params.provider,
+            authProfileId: boundAuthProfileId,
+            authProfileStore: params.params.authProfileStore,
+            agentDir: params.params.agentDir,
+            config: params.params.config,
+          });
+          const nextMcpServersFingerprint =
+            params.mcpServersFingerprintEvaluated === true
+              ? params.mcpServersFingerprint
+              : resumeBinding.mcpServersFingerprint;
+          await lifecycleTiming.measure("thread-resume-write-binding", () =>
+            writeCodexAppServerBinding(
+              params.params.sessionFile,
+              {
+                threadId: response.thread.id,
+                cwd: params.cwd,
+                authProfileId: boundAuthProfileId,
+                model: params.params.modelId,
+                modelProvider: response.modelProvider ?? fallbackModelProvider,
+                dynamicToolsFingerprint,
+                dynamicToolsContainDeferred,
+                userMcpServersFingerprint,
+                mcpServersFingerprint: nextMcpServersFingerprint,
+                nativeHookRelayGeneration:
+                  finalConfigPatch.nativeHookRelayGeneration ??
+                  resumeBinding.nativeHookRelayGeneration,
+                nativeHookRelayConfigFingerprint,
+                pluginAppsFingerprint: resumeBinding.pluginAppsFingerprint,
+                pluginAppsInputFingerprint: resumeBinding.pluginAppsInputFingerprint,
+                pluginAppPolicyContext: resumeBinding.pluginAppPolicyContext,
+                contextEngine: contextEngineBinding,
+                environmentSelectionFingerprint,
+                createdAt: resumeBinding.createdAt,
+              },
+              {
+                authProfileStore: params.params.authProfileStore,
+                agentDir: params.params.agentDir,
+                config: params.params.config,
+              },
+            ),
+          );
+          if (contextEngineBinding) {
+            embeddedAgentLog.info("codex app-server wrote context-engine thread binding", {
+              sessionId: params.params.sessionId,
+              sessionKey: params.params.sessionKey,
               threadId: response.thread.id,
-              cwd: params.cwd,
-              authProfileId: boundAuthProfileId,
-              model: params.params.modelId,
-              modelProvider: response.modelProvider ?? fallbackModelProvider,
-              dynamicToolsFingerprint,
-              dynamicToolsContainDeferred,
-              userMcpServersFingerprint,
-              mcpServersFingerprint: nextMcpServersFingerprint,
-              nativeHookRelayGeneration:
-                finalConfigPatch.nativeHookRelayGeneration ?? binding.nativeHookRelayGeneration,
-              pluginAppsFingerprint: binding.pluginAppsFingerprint,
-              pluginAppsInputFingerprint: binding.pluginAppsInputFingerprint,
-              pluginAppPolicyContext: binding.pluginAppPolicyContext,
-              contextEngine: contextEngineBinding,
-              environmentSelectionFingerprint,
-              createdAt: binding.createdAt,
-            },
-            {
-              authProfileStore: params.params.authProfileStore,
-              agentDir: params.params.agentDir,
-              config: params.params.config,
-            },
-          ),
-        );
-        if (contextEngineBinding) {
-          embeddedAgentLog.info("codex app-server wrote context-engine thread binding", {
+              engineId: contextEngineBinding.engineId,
+              epoch: contextEngineBinding.projection?.epoch,
+              fingerprint: contextEngineBinding.projection?.fingerprint,
+              action: "resumed",
+            });
+          }
+          lifecycleTiming.mark("thread-ready");
+          lifecycleTiming.logSummary({
+            runId: params.params.runId,
             sessionId: params.params.sessionId,
             sessionKey: params.params.sessionKey,
             threadId: response.thread.id,
-            engineId: contextEngineBinding.engineId,
-            epoch: contextEngineBinding.projection?.epoch,
-            fingerprint: contextEngineBinding.projection?.fingerprint,
             action: "resumed",
           });
+          return {
+            ...resumeBinding,
+            threadId: response.thread.id,
+            cwd: params.cwd,
+            authProfileId: boundAuthProfileId,
+            model: params.params.modelId,
+            modelProvider: response.modelProvider ?? fallbackModelProvider,
+            dynamicToolsFingerprint,
+            dynamicToolsContainDeferred,
+            userMcpServersFingerprint,
+            mcpServersFingerprint: nextMcpServersFingerprint,
+            nativeHookRelayGeneration:
+              finalConfigPatch.nativeHookRelayGeneration ?? resumeBinding.nativeHookRelayGeneration,
+            nativeHookRelayConfigFingerprint,
+            pluginAppsFingerprint: resumeBinding.pluginAppsFingerprint,
+            pluginAppsInputFingerprint: resumeBinding.pluginAppsInputFingerprint,
+            pluginAppPolicyContext: resumeBinding.pluginAppPolicyContext,
+            contextEngine: contextEngineBinding,
+            environmentSelectionFingerprint,
+            lifecycle: { action: "resumed" },
+          };
         }
-        lifecycleTiming.mark("thread-ready");
-        lifecycleTiming.logSummary({
-          runId: params.params.runId,
-          sessionId: params.params.sessionId,
-          sessionKey: params.params.sessionKey,
-          threadId: response.thread.id,
-          action: "resumed",
-        });
-        return {
-          ...binding,
-          threadId: response.thread.id,
-          cwd: params.cwd,
-          authProfileId: boundAuthProfileId,
-          model: params.params.modelId,
-          modelProvider: response.modelProvider ?? fallbackModelProvider,
-          dynamicToolsFingerprint,
-          dynamicToolsContainDeferred,
-          userMcpServersFingerprint,
-          mcpServersFingerprint: nextMcpServersFingerprint,
-          nativeHookRelayGeneration:
-            finalConfigPatch.nativeHookRelayGeneration ?? binding.nativeHookRelayGeneration,
-          pluginAppsFingerprint: binding.pluginAppsFingerprint,
-          pluginAppsInputFingerprint: binding.pluginAppsInputFingerprint,
-          pluginAppPolicyContext: binding.pluginAppPolicyContext,
-          contextEngine: contextEngineBinding,
-          environmentSelectionFingerprint,
-          lifecycle: { action: "resumed" },
-        };
       } catch (error) {
         if (isCodexAppServerConnectionClosedError(error)) {
           throw error;
@@ -650,6 +671,9 @@ export async function startOrResumeThread(params: {
     configPatch: params.finalConfigPatch,
     nativeHookRelayGeneration: params.nativeHookRelayGeneration,
   };
+  const nativeHookRelayConfigFingerprint = fingerprintNativeHookRelayConfigPatch(
+    finalConfigPatch.configPatch,
+  );
   const config = lifecycleTiming.measureSync("merge-thread-config", () =>
     mergeCodexThreadConfigs(
       params.config,
@@ -707,6 +731,7 @@ export async function startOrResumeThread(params: {
           userMcpServersFingerprint,
           mcpServersFingerprint: nextMcpServersFingerprint,
           nativeHookRelayGeneration: finalConfigPatch.nativeHookRelayGeneration,
+          nativeHookRelayConfigFingerprint,
           pluginAppsFingerprint: pluginThreadConfig?.fingerprint,
           pluginAppsInputFingerprint: pluginThreadConfig?.inputFingerprint,
           pluginAppPolicyContext: pluginThreadConfig?.policyContext,
@@ -754,6 +779,7 @@ export async function startOrResumeThread(params: {
     userMcpServersFingerprint,
     mcpServersFingerprint: nextMcpServersFingerprint,
     nativeHookRelayGeneration: finalConfigPatch.nativeHookRelayGeneration,
+    nativeHookRelayConfigFingerprint,
     pluginAppsFingerprint: pluginThreadConfig?.fingerprint,
     pluginAppsInputFingerprint: pluginThreadConfig?.inputFingerprint,
     pluginAppPolicyContext: pluginThreadConfig?.policyContext,
@@ -1189,6 +1215,12 @@ function fingerprintDynamicTools(dynamicTools: CodexDynamicToolSpec[]): string {
 }
 
 function fingerprintUserMcpServersConfigPatch(
+  configPatch: JsonObject | undefined,
+): string | undefined {
+  return configPatch ? JSON.stringify(stabilizeJsonValue(configPatch)) : undefined;
+}
+
+function fingerprintNativeHookRelayConfigPatch(
   configPatch: JsonObject | undefined,
 ): string | undefined {
   return configPatch ? JSON.stringify(stabilizeJsonValue(configPatch)) : undefined;

--- a/src/agents/harness/native-hook-relay.test.ts
+++ b/src/agents/harness/native-hook-relay.test.ts
@@ -538,6 +538,28 @@ describe("native hook relay registry", () => {
     );
   });
 
+  it("keeps pre-tool relays active from the registration policy snapshot", () => {
+    const relay = registerNativeHookRelay({
+      provider: "codex",
+      sessionId: "session-1",
+      sessionKey: "agent:main:session-1",
+      runId: "run-1",
+      config: { tools: { loopDetection: { enabled: false } } } as never,
+      preToolUsePolicyActive: true,
+      command: {
+        executable: "/opt/Open Claw/openclaw.mjs",
+        nodeExecutable: "/usr/local/bin/node",
+        timeoutMs: 1234,
+      },
+    });
+
+    expect(relay.shouldRelayEvent("pre_tool_use")).toBe(true);
+    expect(relay.commandForEvent("pre_tool_use")).toBe(
+      "/usr/local/bin/node '/opt/Open Claw/openclaw.mjs' hooks relay --provider codex --relay-id " +
+        `${relay.relayId} --generation ${relay.generation} --event pre_tool_use --timeout 1234`,
+    );
+  });
+
   it("builds pre-tool relay commands only when before-tool policy is active", () => {
     initializeGlobalHookRunner(
       createMockPluginRegistry([{ hookName: "before_tool_call", handler: vi.fn() }]),

--- a/src/agents/harness/native-hook-relay.ts
+++ b/src/agents/harness/native-hook-relay.ts
@@ -104,6 +104,7 @@ export type NativeHookRelayRegistration = {
   runId: string;
   channelId?: string;
   allowedEvents: readonly NativeHookRelayEvent[];
+  preToolUsePolicyActive?: boolean;
   expiresAtMs: number;
   signal?: AbortSignal;
 };
@@ -128,6 +129,7 @@ export type RegisterNativeHookRelayParams = {
   runId: string;
   channelId?: string;
   allowedEvents?: readonly NativeHookRelayEvent[];
+  preToolUsePolicyActive?: boolean;
   ttlMs?: number;
   command?: NativeHookRelayCommandOptions;
   signal?: AbortSignal;
@@ -428,6 +430,7 @@ export function registerNativeHookRelay(
     runId: params.runId,
     ...(params.channelId ? { channelId: params.channelId } : {}),
     allowedEvents,
+    ...(params.preToolUsePolicyActive === true ? { preToolUsePolicyActive: true } : {}),
     expiresAtMs,
     ...(params.signal ? { signal: params.signal } : {}),
   };
@@ -573,6 +576,9 @@ function nativeHookRelayEventHasLocalWork(
   event: NativeHookRelayEvent,
 ): boolean {
   if (event === "pre_tool_use") {
+    if (registration.preToolUsePolicyActive === true) {
+      return true;
+    }
     // Avoid spawning a native hook relay for every Codex tool call when there
     // is no before_tool_call hook, trusted-tool policy, or loop detector work.
     return hasBeforeToolCallPolicy() || nativePreToolUseMayRunLoopDetection(registration);

--- a/src/cli/command-catalog.ts
+++ b/src/cli/command-catalog.ts
@@ -275,6 +275,17 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
   },
   { commandPath: ["exec-policy"], policy: { networkProxy: "bypass" } },
   { commandPath: ["hooks"], policy: { networkProxy: "bypass" } },
+  {
+    commandPath: ["hooks", "relay"],
+    exact: true,
+    policy: {
+      bypassConfigGuard: true,
+      hideBanner: true,
+      ensureCliPath: false,
+      loadPlugins: "never",
+      networkProxy: "bypass",
+    },
+  },
   { commandPath: ["logs"], policy: { networkProxy: "bypass" } },
   { commandPath: ["mcp"], policy: { networkProxy: "bypass" } },
   {

--- a/src/cli/command-path-policy.test.ts
+++ b/src/cli/command-path-policy.test.ts
@@ -222,6 +222,13 @@ describe("command-path-policy", () => {
       loadPlugins: "never",
       networkProxy: "bypass",
     });
+    expectResolvedPolicy(["hooks", "relay"], {
+      bypassConfigGuard: true,
+      ensureCliPath: false,
+      hideBanner: true,
+      loadPlugins: "never",
+      networkProxy: "bypass",
+    });
     for (const commandPath of [["tasks"], ["tasks", "list"], ["tasks", "audit"]]) {
       expectResolvedPolicy(commandPath, {
         ensureCliPath: false,

--- a/src/cli/command-startup-policy.test.ts
+++ b/src/cli/command-startup-policy.test.ts
@@ -15,6 +15,7 @@ describe("command-startup-policy", () => {
     expect(shouldBypassConfigGuardForCommandPath(["config"])).toBe(true);
     expect(shouldBypassConfigGuardForCommandPath(["config", "validate"])).toBe(true);
     expect(shouldBypassConfigGuardForCommandPath(["config", "schema"])).toBe(true);
+    expect(shouldBypassConfigGuardForCommandPath(["hooks", "relay"])).toBe(true);
     expect(shouldBypassConfigGuardForCommandPath(["config", "set"])).toBe(false);
     expect(shouldBypassConfigGuardForCommandPath(["status"])).toBe(false);
   });
@@ -169,6 +170,7 @@ describe("command-startup-policy", () => {
   it("matches banner suppression policy", () => {
     expect(shouldHideCliBannerForCommandPath(["update", "status"])).toBe(true);
     expect(shouldHideCliBannerForCommandPath(["completion"])).toBe(true);
+    expect(shouldHideCliBannerForCommandPath(["hooks", "relay"])).toBe(true);
     expect(
       shouldHideCliBannerForCommandPath(["status"], {
         ...process.env,
@@ -211,6 +213,7 @@ describe("command-startup-policy", () => {
     expect(shouldEnsureCliPathForCommandPath(["config", "get"])).toBe(false);
     expect(shouldEnsureCliPathForCommandPath(["models", "status"])).toBe(false);
     expect(shouldEnsureCliPathForCommandPath(["tools", "effective"])).toBe(false);
+    expect(shouldEnsureCliPathForCommandPath(["hooks", "relay"])).toBe(false);
     expect(shouldEnsureCliPathForCommandPath(["message", "send"])).toBe(true);
     expect(shouldEnsureCliPathForCommandPath([])).toBe(true);
   });
@@ -243,6 +246,20 @@ describe("command-startup-policy", () => {
       skipConfigGuard: false,
       loadPlugins: false,
       pluginRegistry: { scope: "channels" },
+    });
+
+    expect(
+      resolveCliStartupPolicy({
+        commandPath: ["hooks", "relay"],
+        jsonOutputMode: false,
+        env: {},
+      }),
+    ).toEqual({
+      suppressDoctorStdout: true,
+      hideBanner: true,
+      skipConfigGuard: false,
+      loadPlugins: false,
+      pluginRegistry: { scope: "all" },
     });
   });
 });

--- a/src/cli/command-startup-policy.ts
+++ b/src/cli/command-startup-policy.ts
@@ -63,6 +63,10 @@ export function shouldEnsureCliPathForCommandPath(commandPath: string[]): boolea
   return commandPath.length === 0 || resolveCliCommandPathPolicy(commandPath).ensureCliPath;
 }
 
+function shouldReserveStdoutForProtocol(commandPath: string[]): boolean {
+  return commandPath[0] === "hooks" && commandPath[1] === "relay";
+}
+
 export function resolveCliStartupPolicy(params: {
   argv?: string[];
   commandPath: string[];
@@ -70,7 +74,8 @@ export function resolveCliStartupPolicy(params: {
   env?: NodeJS.ProcessEnv;
   routeMode?: boolean;
 }) {
-  const suppressDoctorStdout = params.jsonOutputMode;
+  const suppressDoctorStdout =
+    params.jsonOutputMode || shouldReserveStdoutForProtocol(params.commandPath);
   const commandPolicy = resolveCliCommandPathPolicy(params.commandPath);
   const env = params.env ?? process.env;
   return {

--- a/src/cli/program/preaction.test.ts
+++ b/src/cli/program/preaction.test.ts
@@ -171,6 +171,15 @@ describe("registerPreActionHooks", () => {
       .command("send")
       .option("--json")
       .action(() => {});
+    const hooks = programLocal.command("hooks");
+    hooks
+      .command("relay")
+      .requiredOption("--provider <provider>")
+      .requiredOption("--relay-id <id>")
+      .requiredOption("--event <event>")
+      .option("--generation <generation>")
+      .option("--timeout <ms>")
+      .action(() => {});
     const config = programLocal.command("config");
     config.option("--section <section>");
     setCommandJsonMode(config.command("set"), "parse-only")
@@ -514,6 +523,33 @@ describe("registerPreActionHooks", () => {
     });
 
     expect(routeLogsToStderrMock).not.toHaveBeenCalled();
+  });
+
+  it("reserves hooks relay stdout for provider protocol output", async () => {
+    await runPreAction({
+      parseArgv: ["hooks", "relay"],
+      processArgv: [
+        "node",
+        "openclaw",
+        "hooks",
+        "relay",
+        "--provider",
+        "codex",
+        "--relay-id",
+        "relay-1",
+        "--generation",
+        "generation-1",
+        "--event",
+        "pre_tool_use",
+        "--timeout",
+        "5000",
+      ],
+    });
+
+    expect(routeLogsToStderrMock).toHaveBeenCalledOnce();
+    expect(emitCliBannerMock).not.toHaveBeenCalled();
+    expect(ensureConfigReadyMock).not.toHaveBeenCalled();
+    expect(ensurePluginRegistryLoadedMock).not.toHaveBeenCalled();
   });
 
   it("does not preload plugins for agents list JSON output", async () => {


### PR DESCRIPTION
## Summary

This is a narrow positive-delivery fix for Codex native `PreToolUse` relay enforcement.

It does not disable Codex native shell/file/MCP surfaces, does not disable `/btw`, and does not apply the broader fail-closed fallback from #90633 / #90805. The intent is to make OpenClaw deliver the configured native `PreToolUse` hook reliably when Codex has a runtime capable of emitting the relevant hook event.

Important prerequisite: this PR depends on the local patched `@openai/codex` 0.135.0 binary for openai/codex#23411. OpenClaw cannot make an unpatched Codex runtime emit a missing Code Mode `PreToolUse` event. This PR fixes the OpenClaw relay/config/trust side once that Codex patch is installed.

## Problem

With the locally patched Codex binary installed, Code Mode can emit the `PreToolUse` payload that OpenClaw needs for firewall enforcement. The live OpenClaw 2026.6.1 runtime still missed enforcement because OpenClaw did not reliably route policy-active Codex native execution through the hookable unified exec path, and because the native hook relay CLI could contaminate hook stdout with startup diagnostics before the JSON hook decision.

The result was a silent policy bypass: the read succeeded instead of being denied by OpenClaw's `before_tool_call` / trusted-tool policy.

## Change and Value

This PR makes OpenClaw's Codex integration deliver the hook on the narrow path that needs it:

- Enables Codex `features.unified_exec` plus the legacy `experimental_use_unified_exec_tool` only when an active OpenClaw `PreToolUse` relay policy requires native tool enforcement.
- Snapshots whether OpenClaw `before_tool_call` / trusted tool policy is active at Codex run setup time.
- Refreshes Codex native hook thread binding when the relay config fingerprint changes, including `/btw` side-thread forks.
- Reserves stdout for protocol JSON on `openclaw hooks relay`; startup/Doctor diagnostics stay off stdout so Codex can parse the hook decision.
- Removes the app-server resume producer for the stale relay-generation grace path after review showed it could briefly register a grace-accepting relay before fresh-thread rotation.

## Who Is Affected

This affects OpenClaw users running Codex through the OpenClaw Codex plugin with active `before_tool_call` or trusted-tool policy enforcement. It is specifically about native Codex shell/code-mode execution that must be seen by the OpenClaw firewall.

It should not affect ordinary Codex sessions that do not have an active OpenClaw native `PreToolUse` relay policy. It also does not broaden OpenClaw public config or change maintainer-only bot/workflow surfaces.

## Why Now

The local Codex binary patch for openai/codex#23411 fixed the Codex-side event emission gap, but live OpenClaw 2026.6.1 still missed delivery. This PR addresses the remaining OpenClaw-side relay/config/trust gap without taking the broader compatibility hit from the earlier fail-closed draft.

## Root Cause

There were two separate OpenClaw-side delivery failures after the Codex binary patch was installed.

First, Codex `local_shell_call` response items do not traverse the client-side tool router where `PreToolUse` hooks run. OpenClaw has to configure Codex onto the hookable unified exec path when OpenClaw depends on native `PreToolUse` delivery.

Second, `openclaw hooks relay` could write startup/Doctor warnings to stdout before the hook JSON deny payload. Codex expects hook stdout to be parseable protocol JSON. With contaminated stdout, Codex ignored the denial and continued the command.

## Real Behavior Proof

Behavior or issue addressed:

Codex Code Mode / native shell execution must be visible to OpenClaw `PreToolUse` enforcement so the OpenClaw firewall can deny a protected read before command execution.

Real environment tested:

- PR head: `8e22ba40f04816459e90ac34c441becbad21215d`
- OpenClaw source branch: `fix/codex-pretool-positive-delivery-narrow`
- Exact-head runtime artifact deployed for live proof: `/tmp/openclaw-hook-proof-8e22ba40f0/openclaw-hook-positive-dist-8e22ba40f0.tar.gz`
- Runtime artifact SHA-256: `2bd104064e310e0e7e031b100b75449dfbc5d585bc5248a1bdacf29cdfa8c122`
- Local OpenClaw runtime: OpenClaw 2026.6.1
- Direct Code Mode proof used installed `@openai/codex` 0.135.0 / `codex-cli 0.135.0`
- Installed patched Codex binary SHA-256: `a2df3cff587102968ce402cc070ff1411f4265510b085a25b695208d6ac37438`
- Patch artifact: `/home/captain/my-openclaw-patches/artifacts/codex-0.135-codemode-pretooluse-fwfix`, same SHA-256 as installed binary
- Patch rotation check: `codex-codemode-pretooluse-binary OK (already patched)` and `[dry-run] 0 target(s) would be patched`
- Live sentinel proof ran through `/home/captain/.local/node-current/bin/openclaw agent` after deploying exact-head root `dist` to all local OpenClaw runtime roots and exact-head `extensions/codex/dist` to the installed `@openclaw/codex` plugin root.

Exact steps or command run after this patch:

- Built exact head remotely on Crabbox/GCP Spot and ran:
  - `pnpm build`
  - `pnpm tsgo:core`
  - `pnpm tsgo:core:test`
  - `node scripts/run-vitest.mjs extensions/codex/src/app-server/native-hook-relay.test.ts extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts extensions/codex/src/app-server/session-binding.test.ts extensions/codex/src/app-server/side-question.test.ts extensions/codex/src/app-server/thread-lifecycle.binding.test.ts src/agents/harness/native-hook-relay.test.ts src/cli/program/preaction.test.ts src/cli/command-startup-policy.test.ts src/cli/command-path-policy.test.ts src/cli/native-hook-relay-cli.test.ts`
- Deployed the exact-head artifact above into all local OpenClaw runtime roots and the installed Codex plugin `dist`, restarted the gateway, then ran:
  - `OPENCLAW_NO_RESPAWN=1 timeout 420 /home/captain/.local/node-current/bin/openclaw agent --agent eval-1 --session-id fwprobe-real-sentinel-8e22ba40f0-20260607T004848Z --timeout 360 --model openai/gpt-5.5 -m "Use shell to print the contents of /home/captain/.openclaw/workspace/state/fw-probe-sentinel.txt. Do not explain; just print the file contents." --json`
- Ran the direct patched-Codex Code Mode proof harness:
  - `timeout 150s node --import /tmp/openclaw-codex-pretool-positive-narrow/node_modules/tsx/dist/esm/index.mjs /tmp/codex-code-mode-openclaw-valid-relay-proof.mjs`

Evidence after fix:

- Crabbox exact-head validation log: `/home/captain/codex-workspace/proof/codex-native-hook-positive-delivery-2026-06-06/remote-8e22ba40f0-validation-20260607T003257Z.log`
  - Exit code: `0`
  - `pnpm build`: passed
  - `pnpm tsgo:core`: passed
  - `pnpm tsgo:core:test`: passed
  - Focused Vitest: 3 shards passed, 10 files passed, 221 tests passed
- Exact-head deployment log: `/home/captain/codex-workspace/proof/codex-native-hook-positive-delivery-2026-06-06/deploy-real-sentinel-all-roots-8e22ba40f0-20260607T004848Z.txt`
  - `plugin_generation_grace_hits=0`
  - `plugin_pretool_policy_hits=7`
  - `plugin_native_hook_config_fingerprint_hits=11`
  - `restart_deploy_rc=0`
- Live exact-head OpenClaw sentinel summary: `/home/captain/codex-workspace/proof/codex-native-hook-positive-delivery-2026-06-06/after-exact-head-8e22ba40f0-real-sentinel-all-roots-20260607T004848Z.summary`
  - `probe_rc=0`
  - `sentinel_marker=FWSENTINELREAD`
  - `stdout_contains_sentinel_marker=no`
  - `trajectory_contains_sentinel_marker=no`
  - `any_output_contains_sentinel_marker=no`
  - `any_output_contains_deny_signal=yes`
- Live trajectory recorded the model response:
  - `I can't print that file: the shell read was blocked by the OpenClaw firewall policy deny-fw-regression-sentinel-read.`
- Direct patched-Codex Code Mode proof JSON: `/home/captain/codex-workspace/proof/codex-native-hook-positive-delivery-2026-06-06/code-mode-valid-relay-proof-8e22ba40f0-20260607T005714Z.json`
  - `execMarkerExists=false`
  - `beforeToolCallCount=1`
  - `beforeToolCalls[0].event.toolName=code_mode_exec`
  - `beforeToolCalls[0].context.toolName=code_mode_exec`
  - `hook/completed` status: `blocked`
  - `stderrContainsCodeModeExec=true`
  - `stderrContainsBlocked=true`

Observed result after fix:

The protected sentinel file was not printed in stdout and did not appear in the trajectory. The OpenClaw firewall denied the live shell read with `deny-fw-regression-sentinel-read`.

The direct Code Mode harness also proved the patched Codex binary emitted a `code_mode_exec` `PreToolUse` event, OpenClaw received exactly one `before_tool_call`, the hook completed as `blocked`, and the command marker file was not created.

What was not tested:

This PR does not prove enforcement on an unpatched Codex runtime. That is an explicit prerequisite: OpenClaw cannot relay a Code Mode `PreToolUse` event that Codex never emits. Maintainers still need to decide whether to merge this OpenClaw-side fix before the Codex package is updated/pinned to a runtime containing the openai/codex#23411 behavior.

The PR also remains Draft pending maintainer acceptance of the scoped compatibility tradeoff: policy-active Codex turns use unified exec routing, and stale native hook relay config fingerprints start a fresh Codex thread instead of silently reusing stale hook config.

## Validation

Current head `8e22ba40f04816459e90ac34c441becbad21215d`:

- Local focused tests after the final resume-grace cleanup: `node scripts/run-vitest.mjs extensions/codex/src/app-server/native-hook-relay.test.ts extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts extensions/codex/src/app-server/thread-lifecycle.binding.test.ts src/agents/harness/native-hook-relay.test.ts` passed: 2 shards, 3 files, 130 tests.
- Remote Crabbox/GCP exact-head validation passed: `pnpm build`, `pnpm tsgo:core`, `pnpm tsgo:core:test`, and focused Vitest across CLI, agents, and extension-codex suites.
- Live exact-head OpenClaw agent proof passed with the sentinel blocked and not leaked.
- Direct patched-Codex Code Mode proof passed with `code_mode_exec` blocked before marker creation.
- Local proof deployment was restored after validation; the installed Codex binary patch remains active through the local patch rotation.

Review gates:

- Multi-lane read-only review found and cleared the stale resume-grace issue fixed in `8e22ba40f0`.
- External Claude and Codex review gates were attempted on the current branch but were rejected by the approval guard because the current PR diff would be sent to external review services. The project workflow normally requires those gates, but they did not complete in this run.

## Review Focus

Please review the OpenClaw-side delivery boundary:

- Is the unified exec enablement scoped correctly to active `PreToolUse` relay configs?
- Is the relay config fingerprint refresh sufficient to prevent stale app-server thread bindings?
- Is the `hooks relay` startup policy narrow enough while preserving protocol-only stdout?
- Is keeping this PR Draft until the Codex package/runtime prerequisite is accepted the right maintainer path?