### PR TITLE
fix(telegram): keep tool progress after non-final commentary

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -2424,6 +2424,54 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(draftStream.update).toHaveBeenCalledWith("Shelling\n\n`🛠️ Exec`\n• _Checking files_");
   });
 
+  it("keeps tool progress after inter-tool commentary in non-persist progress mode", async () => {
+    // Regression for #90962. In progress mode with commentary enabled, inter-tool
+    // commentary arrives as assistant partial text (onPartialReply -> ingestDraftLaneSegments).
+    // It must accumulate into the shared progress draft, not tear the lane down, otherwise the
+    // tool-progress lines that follow are dropped. Drives the dispatcher with the
+    // commentary -> tool -> commentary -> tool interleave the #90883 producer emits.
+    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
+      await replyOptions?.onReplyStart?.();
+      await replyOptions?.onAssistantMessageStart?.();
+      await replyOptions?.onPartialReply?.({ text: "Let me check the config file" });
+      // onToolStart primes the live progress draft (startImmediately), which is the
+      // precondition for the suppress that #90962 triggers on the next commentary.
+      await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+      await replyOptions?.onAssistantMessageStart?.();
+      await replyOptions?.onPartialReply?.({ text: "Now running the tests" });
+      // The tool line #90962 drops: it arrives after the commentary suppressed the draft.
+      await replyOptions?.onItemEvent?.({
+        kind: "command",
+        name: "exec",
+        progressText: "pnpm test",
+      });
+      return { queuedFinal: false };
+    });
+
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "progress",
+      telegramCfg: {
+        streaming: {
+          mode: "progress",
+          progress: { label: "Cracking", commentary: true },
+        },
+      },
+    });
+
+    // Both tool-progress lines must survive the interleaved commentary; the second one is the
+    // line #90962 drops on main once commentary suppresses the draft.
+    expect(answerDraftStream.update).toHaveBeenCalledWith(expect.stringContaining("Exec"));
+    expect(answerDraftStream.update).toHaveBeenCalledWith(expect.stringContaining("pnpm test"));
+    // The final draft holds every tool line and the commentary together in one open draft.
+    const lastDraft = answerDraftStream.update.mock.calls.at(-1)?.[0];
+    expect(lastDraft).toContain("Exec");
+    expect(lastDraft).toContain("pnpm test");
+    expect(lastDraft).toContain("Let me check the config file");
+    expect(lastDraft).toContain("Now running the tests");
+  });
+
   it("renders configured Telegram commentary progress from preamble item events", async () => {
     const draftStream = createSequencedDraftStream(2001);
     createTelegramDraftStream.mockReturnValue(draftStream);

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -967,6 +967,9 @@ export const dispatchTelegramMessage = async ({
       : undefined;
   let lastAnswerPartialText = "";
   let activeAnswerDraftIsToolProgressOnly = false;
+  // Per-assistant-message id for progress-mode inter-tool commentary lines so they
+  // accumulate one-per-block in the shared draft (see ingestDraftLaneSegments).
+  let progressCommentaryItemSeq = 0;
   function resetAnswerToolProgressDraft() {
     activeAnswerDraftIsToolProgressOnly = false;
   }
@@ -1165,6 +1168,16 @@ export const dispatchTelegramMessage = async ({
     const split = splitTextIntoLaneSegments(update, isReasoning);
     for (const segment of split.segments) {
       if (segment.lane === "answer") {
+        if (streamMode === "progress" && progressDraft.commentaryProgressEnabled) {
+          // Progress mode delivers the answer separately, so inter-tool partial answer text is
+          // commentary. With commentary enabled, route it into the shared progress draft's
+          // commentary lane (keyed per assistant message) so it coexists with tool progress
+          // instead of suppressing the answer lane and dropping the tool lines after it. #90962.
+          await progressDraft.pushCommentaryProgress(segment.update.text, {
+            itemId: `partial-commentary:${progressCommentaryItemSeq}`,
+          });
+          continue;
+        }
         await prepareAnswerLaneForText();
       }
       if (segment.lane === "reasoning") {
@@ -2021,6 +2034,10 @@ export const dispatchTelegramMessage = async ({
                           finalAnswerDelivered = false;
                           if (streamMode !== "progress") {
                             resetProgressDraftState();
+                          } else {
+                            // New assistant message => new progress-mode commentary block,
+                            // so its inter-tool commentary lands on a fresh draft line.
+                            progressCommentaryItemSeq += 1;
                           }
                           if (answerLane.finalized) {
                             await rotateLaneForNewMessage(answerLane);


### PR DESCRIPTION
## Summary

In non-persist `progress` streaming mode with `streaming.progress.commentary`
enabled, Telegram drops the tool-progress lines that follow inter-tool
commentary: the live progress draft shows the model's "Let me check X…"
commentary, but the subsequent `📖 Read …` / tool lines never appear. Every
other streaming channel keeps tool progress and commentary coexisting.

## Root cause

Non-final inter-tool commentary suppressed the progress draft via
`prepareAnswerLaneForText`. In `progress` mode commentary arrives as assistant
partial text (`onPartialReply` → `ingestDraftLaneSegments`); for an answer-lane
segment that path calls `prepareAnswerLaneForText` →
`rotateAnswerLaneAfterToolProgress`, which `clear()`s the draft and calls
`suppressProgressDraftState()`. The next tool's `pushStreamToolProgress` is then
dropped inside the compositor on the `progressSuppressed` guard, so the
tool-progress lines after commentary vanish.

(For precision: the lane is not "finalized" — `rotateAnswerLaneAfterToolProgress`
resets `finalized` to `false` and *suppresses* the compositor; the drop is the
`progressSuppressed` guard, not the `finalized` guard.)

## Fix

In `progress` mode, when commentary is enabled, route non-final answer-lane
partial text into the shared progress draft's commentary lane
(`progressDraft.pushCommentaryProgress`, keyed per assistant message) so
commentary and tool progress accumulate together in one open draft instead of
tearing the lane down. This reuses the same commentary lane the `onItemEvent`
preamble path already uses.

Deliberately unchanged:
- The `pushStreamToolProgress` `finalized` / final-delivery guard — it is correct
  for real final delivery and is **not** relaxed.
- The final-answer cleanup path — the draft still rotates into its own final
  message on completion.
- No new config field or accessor; the branch is gated on the existing
  `progressDraft.commentaryProgressEnabled`.

## Trigger conditions / scope

Reproduces only when all three hold within one turn:
1. `streaming.progress.commentary` enabled (default: **off**)
2. non-persist `progress` streaming mode
3. inter-tool commentary and tool calls interleave in the turn

**Default config is unaffected.** The diverting branch is gated on commentary
being enabled; with commentary off, the answer-lane path is unchanged from `main`
(`prepareAnswerLaneForText`), so users on defaults see no behavior change.

## Testing

- New dispatch regression in `bot-message-dispatch.test.ts` drives the
  `commentary → tool → commentary → tool` interleave and asserts every
  tool-progress line (and the commentary) stays in the draft. It fails on `main`
  (the second tool line is dropped) and passes with this change.
- Green locally: `extensions/telegram/src/bot-message-dispatch.test.ts`,
  `src/plugin-sdk/channel-streaming.test.ts`,
  `extensions/discord/src/monitor/message-handler.process.test.ts`; plus
  `tsgo:extensions` (+ `:test`), `lint:extensions`, and `oxfmt --check` clean.
- Observed a pre-existing, unrelated failure in the prompt-context-cache test
  under Windows (`/tmp` path resolution); it reproduces on clean `main` and is
  out of scope for this PR.
- Live Telegram Desktop capture to follow once the #90883 producer path lands —
  that's what surfaces real inter-tool commentary to reproduce this end to end.

## Relation to #90883

This is the Telegram **consumer-side** fix and is independent of #90883 (the
commentary **producer**). It should land **first**: once #90883 merges, every
user with commentary + non-persist progress would immediately hit this clobber,
so shipping this guard ahead of it prevents the regression.

Fixes #90962
