### PR TITLE
fix(sms): authorize text slash commands

### DIFF
--- a/extensions/sms/src/inbound.test.ts
+++ b/extensions/sms/src/inbound.test.ts
@@ -36,6 +36,8 @@ function createRuntime() {
   const readAllowFromStore = vi.fn(async () => [] as string[]);
   const upsertPairingRequest = vi.fn(async () => ({ code: "PAIR123", created: true }));
   const resolveAgentRoute = vi.fn();
+  const isControlCommandMessage = vi.fn((body: string) => body.trim().startsWith("/"));
+  const shouldComputeCommandAuthorized = vi.fn((body: string) => body.trim().startsWith("/"));
   const run = vi.fn<
     (params: {
       turnAdoptionLifecycle?: { onAdopted: () => void | Promise<void> };
@@ -56,6 +58,10 @@ function createRuntime() {
   const buildContext = vi.fn();
   const resolveStorePath = vi.fn();
   const runtime = {
+    commands: {
+      isControlCommandMessage,
+      shouldComputeCommandAuthorized,
+    },
     pairing: {
       readAllowFromStore,
       upsertPairingRequest,
@@ -80,10 +86,61 @@ function createRuntime() {
     readAllowFromStore,
     upsertPairingRequest,
     resolveAgentRoute,
+    isControlCommandMessage,
+    shouldComputeCommandAuthorized,
     run,
     buildContext,
     resolveStorePath,
   };
+}
+
+const SMS_FROM = "+15551234567";
+const SMS_TO = "+15557654321";
+const SMS_SESSION_KEY = `agent:main:sms:direct:${SMS_FROM}`;
+
+async function resolveAuthorizedSmsTurn(params: {
+  body: string;
+  messageSid: string;
+  commandRequested?: boolean;
+  isTextCommand?: boolean;
+  receivedAt?: number;
+  turnAdoptionLifecycle?: { onAdopted: () => void | Promise<void> };
+}) {
+  const mocks = createRuntime();
+  if (params.commandRequested !== undefined) {
+    mocks.shouldComputeCommandAuthorized.mockReturnValue(params.commandRequested);
+  }
+  if (params.isTextCommand !== undefined) {
+    mocks.isControlCommandMessage.mockReturnValue(params.isTextCommand);
+  }
+  mocks.resolveAgentRoute.mockReturnValue({
+    agentId: "main",
+    accountId: "default",
+    sessionKey: SMS_SESSION_KEY,
+  });
+  mocks.buildContext.mockReturnValue({ SessionKey: SMS_SESSION_KEY });
+
+  const msg = {
+    from: SMS_FROM,
+    to: SMS_TO,
+    body: params.body,
+    messageSid: params.messageSid,
+    accountSid: "AC123",
+  };
+  await dispatchSmsInboundEvent({
+    cfg: { commands: { useAccessGroups: true } },
+    account: createAccount({ dmPolicy: "allowlist", allowFrom: [SMS_FROM] }),
+    channelRuntime: mocks.runtime,
+    receivedAt: params.receivedAt ?? 1_700_000_000_123,
+    ...(params.turnAdoptionLifecycle
+      ? { turnAdoptionLifecycle: params.turnAdoptionLifecycle }
+      : {}),
+    msg,
+  });
+
+  const runParams = expectDefined(mocks.run.mock.calls[0]?.[0], "SMS inbound run parameters");
+  const turn = await runParams.adapter.resolveTurn(runParams.adapter.ingest(msg));
+  return { ...mocks, runParams, turn };
 }
 
 describe("dispatchSmsInboundEvent", () => {
@@ -124,63 +181,121 @@ describe("dispatchSmsInboundEvent", () => {
   });
 
   it("uses the canonical routed session key for authorized SMS turns", async () => {
-    const { runtime, resolveAgentRoute, run, buildContext, resolveStorePath } = createRuntime();
-    resolveAgentRoute.mockReturnValue({
-      agentId: "main",
-      accountId: "default",
-      sessionKey: "agent:main:sms:direct:+15551234567",
-    });
-    buildContext.mockReturnValue({ SessionKey: "agent:main:sms:direct:+15551234567" });
-    resolveStorePath.mockReturnValue("/tmp/openclaw-sessions");
     const turnAdoptionLifecycle = { onAdopted: vi.fn(async () => undefined) };
-
-    await dispatchSmsInboundEvent({
-      cfg: {},
-      account: createAccount({
-        dmPolicy: "allowlist",
-        allowFrom: ["+15551234567"],
-      }),
-      channelRuntime: runtime,
-      receivedAt: 1_700_000_000_123,
-      turnAdoptionLifecycle,
-      msg: {
-        from: "+15551234567",
-        to: "+15557654321",
-        body: "hello",
-        messageSid: "SM-inbound",
-        accountSid: "AC123",
-      },
-    });
-
-    const runParams = expectDefined(run.mock.calls[0]?.[0], "SMS inbound run parameters");
-    expect(runParams.turnAdoptionLifecycle).toBe(turnAdoptionLifecycle);
-    const ingested = runParams.adapter.ingest({
-      from: "+15551234567",
-      to: "+15557654321",
+    const { resolveAgentRoute, runParams, buildContext, turn } = await resolveAuthorizedSmsTurn({
       body: "hello",
       messageSid: "SM-inbound",
-      accountSid: "AC123",
+      receivedAt: 1_700_000_000_123,
+      turnAdoptionLifecycle,
     });
-    const turn = await runParams.adapter.resolveTurn(ingested);
 
+    expect(runParams.turnAdoptionLifecycle).toBe(turnAdoptionLifecycle);
     expect(resolveAgentRoute).toHaveBeenCalledWith(
       expect.objectContaining({
-        peer: { kind: "direct", id: "+15551234567" },
+        peer: { kind: "direct", id: SMS_FROM },
       }),
     );
     expect(buildContext).toHaveBeenCalledWith(
       expect.objectContaining({
         timestamp: 1_700_000_000_123,
-        from: "sms:+15551234567",
-        sender: expect.objectContaining({ id: "+15551234567" }),
-        conversation: expect.objectContaining({ id: "+15551234567" }),
-        reply: { to: "sms:+15551234567" },
+        from: `sms:${SMS_FROM}`,
+        sender: expect.objectContaining({ id: SMS_FROM }),
+        conversation: expect.objectContaining({ id: SMS_FROM }),
+        reply: { to: `sms:${SMS_FROM}` },
         route: expect.objectContaining({
-          routeSessionKey: "agent:main:sms:direct:+15551234567",
-          dispatchSessionKey: "agent:main:sms:direct:+15551234567",
+          routeSessionKey: SMS_SESSION_KEY,
+          dispatchSessionKey: SMS_SESSION_KEY,
         }),
       }),
     );
-    expect(turn.route.sessionKey).toBe("agent:main:sms:direct:+15551234567");
+    expect(turn.route.sessionKey).toBe(SMS_SESSION_KEY);
+  });
+
+  it("marks allowlisted SMS slash commands as text command turns", async () => {
+    const { shouldComputeCommandAuthorized, isControlCommandMessage, buildContext } =
+      await resolveAuthorizedSmsTurn({
+        body: "/status",
+        messageSid: "SM-command",
+        commandRequested: true,
+        isTextCommand: true,
+      });
+
+    expect(shouldComputeCommandAuthorized).toHaveBeenCalledWith(
+      "/status",
+      expect.objectContaining({
+        commands: expect.objectContaining({ useAccessGroups: true }),
+      }),
+    );
+    expect(isControlCommandMessage).toHaveBeenCalledWith(
+      "/status",
+      expect.objectContaining({
+        commands: expect.objectContaining({ useAccessGroups: true }),
+      }),
+    );
+
+    expect(buildContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.objectContaining({
+          rawBody: "/status",
+          commandBody: "/status",
+        }),
+        access: {
+          commands: {
+            authorized: true,
+          },
+        },
+        command: {
+          kind: "text-slash",
+          body: "/status",
+          authorized: true,
+        },
+        extra: expect.objectContaining({
+          MessageSid: "SM-command",
+          SenderE164: SMS_FROM,
+        }),
+      }),
+    );
+  });
+
+  it("checks SMS command authorization for inline slash tokens without marking text command turns", async () => {
+    const { shouldComputeCommandAuthorized, isControlCommandMessage, buildContext } =
+      await resolveAuthorizedSmsTurn({
+        body: "please inspect /tmp/foo",
+        messageSid: "SM-inline-token",
+        commandRequested: true,
+        isTextCommand: false,
+      });
+
+    expect(shouldComputeCommandAuthorized).toHaveBeenCalledWith(
+      "please inspect /tmp/foo",
+      expect.objectContaining({
+        commands: expect.objectContaining({ useAccessGroups: true }),
+      }),
+    );
+    expect(isControlCommandMessage).toHaveBeenCalledWith(
+      "please inspect /tmp/foo",
+      expect.objectContaining({
+        commands: expect.objectContaining({ useAccessGroups: true }),
+      }),
+    );
+
+    expect(buildContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.objectContaining({
+          rawBody: "please inspect /tmp/foo",
+          commandBody: "please inspect /tmp/foo",
+        }),
+        access: {
+          commands: {
+            authorized: true,
+          },
+        },
+        command: undefined,
+        extra: expect.objectContaining({
+          MessageSid: "SM-inline-token",
+          SenderE164: SMS_FROM,
+        }),
+      }),
+    );
   });
 });

--- a/extensions/sms/src/inbound.ts
+++ b/extensions/sms/src/inbound.ts
@@ -16,7 +16,7 @@ type SmsLog = {
 
 export type SmsChannelRuntime = Pick<
   PluginRuntime["channel"],
-  "inbound" | "pairing" | "reply" | "routing" | "session"
+  "commands" | "inbound" | "pairing" | "reply" | "routing" | "session"
 >;
 
 async function authorizeSmsSender(params: {
@@ -24,7 +24,12 @@ async function authorizeSmsSender(params: {
   account: ResolvedSmsAccount;
   channelRuntime: SmsChannelRuntime;
   from: string;
+  rawBody: string;
 }) {
+  const commandRequested = params.channelRuntime.commands.shouldComputeCommandAuthorized(
+    params.rawBody,
+    params.cfg,
+  );
   return await resolveStableChannelMessageIngress({
     channelId: CHANNEL_ID,
     accountId: params.account.accountId,
@@ -46,6 +51,12 @@ async function authorizeSmsSender(params: {
     event: { mayPair: true },
     dmPolicy: params.account.dmPolicy,
     allowFrom: params.account.allowFrom,
+    command: commandRequested
+      ? {
+          cfg: params.cfg,
+          modeWhenAccessGroupsOff: "configured",
+        }
+      : undefined,
   });
 }
 
@@ -101,6 +112,7 @@ export async function dispatchSmsInboundEvent(params: {
     account: params.account,
     channelRuntime: params.channelRuntime,
     from,
+    rawBody: params.msg.body,
   });
   if (!auth.senderAccess.allowed) {
     if (auth.senderAccess.decision === "pairing") {
@@ -126,6 +138,12 @@ export async function dispatchSmsInboundEvent(params: {
     },
   });
   const sessionKey = route.sessionKey;
+  const commandRequested = auth.commandAccess.requested;
+  const commandAuthorized = auth.commandAccess.authorized;
+  const isTextCommand = params.channelRuntime.commands.isControlCommandMessage(
+    params.msg.body,
+    params.cfg,
+  );
 
   await params.channelRuntime.inbound.run({
     channel: CHANNEL_ID,
@@ -172,8 +190,23 @@ export async function dispatchSmsInboundEvent(params: {
             commandBody: input.textForCommands,
             bodyForAgent: input.textForAgent,
           },
+          access: commandRequested
+            ? {
+                commands: {
+                  authorized: commandAuthorized,
+                },
+              }
+            : undefined,
+          command: isTextCommand
+            ? {
+                kind: "text-slash",
+                body: input.textForCommands,
+                authorized: commandAuthorized,
+              }
+            : undefined,
           extra: {
             MessageSid: params.msg.messageSid,
+            SenderE164: from,
             To: params.msg.to,
           },
         });


### PR DESCRIPTION
## Summary

Native SMS direct messages that begin with text slash commands now carry command-turn metadata and command authorization into the inbound reply pipeline. This makes allowlisted/pairing-approved SMS senders follow the same command handoff shape used by other text-capable channels instead of leaving `/status`-style messages as ordinary chat text.

## Motivation

The native SMS channel from #88476 passes the inbound body through `textForCommands`, but SMS did not resolve command access or include command metadata when building the channel context. That left SMS behind channels such as WhatsApp and QQBot, which already separate broad command authorization probing from exact text-command-turn metadata.

Related: #88476 and #88601.

## Root Cause

SMS only resolved sender access with `resolveStableChannelMessageIngress`. It did not ask the channel command runtime whether the raw body should compute command authorization, did not pass the command options into ingress resolution, and did not set `access.commands` or text-command metadata in `buildContext`.

## Changes

- Include `channelRuntime.commands` in the SMS inbound runtime contract.
- Resolve SMS command access with `shouldComputeCommandAuthorized` when the raw body may need command authorization.
- Gate `command: { kind: "text-slash", ... }` on the exact `isControlCommandMessage` detector, so inline slash-like text does not become a structured command turn.
- Pass `access.commands.authorized` into the SMS channel context when command authorization was requested.
- Preserve the normalized sender number as `SenderE164` in SMS inbound context extras.
- Add regressions for both the positive `/status` SMS path and the negative inline-token path (`please inspect /tmp/foo`).

## Non-goals / Scope Boundaries

- Does not change SMS pairing or sender allowlist behavior.
- Does not change command authorization policy globally.
- Does not add a live Twilio/Gateway integration test in this PR.

## Maintainer Fit

This follows the existing text-command handoff pattern from sibling channels: use broad command detection only to decide whether command auth should be computed, then use exact control-command detection before attaching explicit text-command-turn metadata. The PR is limited to the native SMS extension and nearby tests.

## Real behavior proof

- Behavior or issue addressed: Native SMS direct-message bodies that start with `/` now enter the inbound pipeline as authorized text-command turns when the SMS sender is allowlisted/pairing-approved, while normal SMS text with incidental slash-like tokens does not become a `text-slash` command turn.
- Real environment tested: Fresh local OpenClaw checkout based on current upstream `main`, running the patched native SMS inbound module directly through Node/tsx in the PR worktree. No live Twilio webhook, Gateway restart, or carrier SMS send was performed.
- Exact steps or command run after this patch: From the PR worktree, ran a Node/tsx terminal proof that imports `extensions/sms/src/inbound.ts`, dispatches an allowlisted `/status` SMS through `dispatchSmsInboundEvent`, and prints the context object received by `buildContext`. The focused Vitest regression also exercises the negative inline slash-token path.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Copied terminal output from the patched module proof:

```json
{
  "context": {
    "message": {
      "rawBody": "/status",
      "commandBody": "/status",
      "bodyForAgent": "/status"
    },
    "access": {
      "commands": {
        "authorized": true
      }
    },
    "command": {
      "kind": "text-slash",
      "body": "/status",
      "authorized": true
    },
    "extra": {
      "MessageSid": "SM-command-proof",
      "SenderE164": "+15551234567",
      "To": "+15557654321"
    }
  },
  "routeSessionKey": "agent:main:sms:direct:+15551234567",
  "storePath": "/tmp/openclaw-sessions"
}
```

- Observed result after fix: The SMS inbound context includes `message.commandBody="/status"`, `access.commands.authorized=true`, `command.kind="text-slash"`, `command.authorized=true`, and the normalized `SenderE164` value. The negative regression proves `please inspect /tmp/foo` still gets command authorization checked but does not attach a `command` fact.
- What was not tested: Live Twilio/Gateway SMS behavior and carrier delivery were not tested in this PR.
- Proof limitations or environment constraints: The proof intentionally avoids real webhook/config/runtime changes. The live carrier path should be proven separately after maintainers decide the code shape is acceptable and an operator has approved a live SMS/Gateway proof.
- Before evidence (optional but encouraged): Source/read-only investigation showed SMS previously built `commandBody` but did not pass `command` or `access.commands` into `buildContext`, so final context normalized command authorization to false.

## Release Note Context

Fixes native SMS text slash-command routing so allowlisted/pairing-approved SMS senders can invoke text Gateway commands instead of having `/status` treated as normal chat text.

## Testing

- [x] `node scripts/run-vitest.mjs extensions/sms/src/inbound.test.ts` — 1 file, 4 tests passed
- [x] `pnpm test:extension sms` — 10 files, 58 tests passed
- [x] `pnpm exec oxfmt --check extensions/sms/src/inbound.ts extensions/sms/src/inbound.test.ts`
- [x] `pnpm exec oxlint extensions/sms/src/inbound.ts extensions/sms/src/inbound.test.ts`
- [x] `node scripts/check-extension-plugin-sdk-boundary.mjs --mode=src-outside-plugin-sdk`
- [x] `node scripts/check-extension-plugin-sdk-boundary.mjs --mode=relative-outside-package`
- [x] `git diff --check`
- [ ] `pnpm check:changed` — not rerun for this follow-up; earlier local attempt was blocked by Testbox/crabbox sanity before project checks executed

## AI Assistance

This PR was prepared with AI assistance and reviewed before submission.
