### PR TITLE
[codex] fix status summary runtime model ref normalization

### DIFF
--- a/src/commands/status.summary.runtime.test.ts
+++ b/src/commands/status.summary.runtime.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { statusSummaryRuntime } from "./status.summary.runtime.js";
+
+describe("statusSummaryRuntime.resolveSessionModelRef", () => {
+  it("normalizes shorthand runtime model refs without an explicit provider override", () => {
+    const resolved = statusSummaryRuntime.resolveSessionModelRef(
+      {},
+      {
+        model: "anthropic/sonnet-4.6",
+      },
+    );
+
+    expect(resolved).toEqual({
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+    });
+  });
+});

--- a/src/commands/status.summary.runtime.ts
+++ b/src/commands/status.summary.runtime.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
+import { parseModelRef } from "../agents/model-selection.js";
 import { resolveAgentModelPrimaryValue } from "../config/model-input.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.js";
@@ -7,20 +8,7 @@ function parseStatusModelRef(
   raw: string,
   defaultProvider: string,
 ): { provider: string; model: string } | null {
-  const trimmed = raw.trim();
-  if (!trimmed) {
-    return null;
-  }
-  const slash = trimmed.indexOf("/");
-  if (slash === -1) {
-    return { provider: defaultProvider, model: trimmed };
-  }
-  const provider = trimmed.slice(0, slash).trim();
-  const model = trimmed.slice(slash + 1).trim();
-  if (!provider || !model) {
-    return null;
-  }
-  return { provider, model };
+  return parseModelRef(raw, defaultProvider);
 }
 
 function resolveStatusModelRefFromRaw(params: {


### PR DESCRIPTION
## What changed
- normalize `statusSummaryRuntime.resolveSessionModelRef` through the shared model-ref parser
- add a focused regression test for shorthand runtime refs like `anthropic/sonnet-4.6`

## Why
The March status startup refactor extracted model resolution into `src/commands/status.summary.runtime.ts`, but that helper no longer normalized slash-qualified shorthand refs the way `session-utils` previously did. That left a narrow untested path where status could report the wrong runtime model identity and miss config-backed context window lookups.

## Validation
- `pnpm.cmd vitest run src/commands/status.summary.runtime.test.ts src/commands/status.summary.test.ts`
