### PR TITLE
fix(sandbox): bound Docker exec with a deadline so a wedged engine can't hang the gateway

### DIFF
--- a/src/agents/sandbox/config-hash.test.ts
+++ b/src/agents/sandbox/config-hash.test.ts
@@ -134,6 +134,28 @@ describe("computeSandboxConfigHash", () => {
 
     expect(withoutSkills).not.toBe(withSkills);
   });
+
+  it("ignores initTimeoutMs (operational timeout, not container identity)", () => {
+    // The init deadline is a client-side timeout; it must never change the reuse
+    // hash, or upgrades would needlessly recreate existing containers.
+    const shared = {
+      workspaceAccess: "rw" as const,
+      workspaceDir: "/tmp/workspace",
+      agentWorkspaceDir: "/tmp/workspace",
+      mountFormatVersion: SANDBOX_MOUNT_FORMAT_VERSION,
+    };
+    const without = computeSandboxConfigHash({ ...shared, docker: createDockerConfig() });
+    const with60s = computeSandboxConfigHash({
+      ...shared,
+      docker: createDockerConfig({ initTimeoutMs: 60_000 }),
+    });
+    const with5s = computeSandboxConfigHash({
+      ...shared,
+      docker: createDockerConfig({ initTimeoutMs: 5_000 }),
+    });
+    expect(with60s).toBe(without);
+    expect(with5s).toBe(without);
+  });
 });
 
 describe("computeSandboxBrowserConfigHash", () => {

--- a/src/agents/sandbox/config-hash.ts
+++ b/src/agents/sandbox/config-hash.ts
@@ -67,14 +67,22 @@ function normalizeForHash(value: unknown): unknown {
   return value;
 }
 
+// initTimeoutMs is a client-side operational timeout, not container identity, so
+// it must not enter the reuse hash (else it would force recreation on upgrade).
+function stripDockerNonIdentityFields(docker: SandboxDockerConfig): SandboxDockerConfig {
+  const rest = { ...docker };
+  delete rest.initTimeoutMs;
+  return rest;
+}
+
 /** Computes the sandbox container config hash. */
 export function computeSandboxConfigHash(input: SandboxHashInput): string {
-  return computeHash(input);
+  return computeHash({ ...input, docker: stripDockerNonIdentityFields(input.docker) });
 }
 
 /** Computes the browser-enabled sandbox container config hash. */
 export function computeSandboxBrowserConfigHash(input: SandboxBrowserHashInput): string {
-  return computeHash(input);
+  return computeHash({ ...input, docker: stripDockerNonIdentityFields(input.docker) });
 }
 
 function computeHash(input: unknown): string {

--- a/src/agents/sandbox/config.ts
+++ b/src/agents/sandbox/config.ts
@@ -18,6 +18,7 @@ import {
   DEFAULT_SANDBOX_BROWSER_PREFIX,
   DEFAULT_SANDBOX_BROWSER_VNC_PORT,
   DEFAULT_SANDBOX_CONTAINER_PREFIX,
+  DEFAULT_SANDBOX_DOCKER_INIT_TIMEOUT_MS,
   DEFAULT_SANDBOX_IDLE_HOURS,
   DEFAULT_SANDBOX_IMAGE,
   DEFAULT_SANDBOX_MAX_AGE_DAYS,
@@ -122,6 +123,10 @@ export function resolveSandboxDockerConfig(params: {
     capDrop: agentDocker?.capDrop ?? globalDocker?.capDrop ?? ["ALL"],
     env,
     setupCommand: agentDocker?.setupCommand ?? globalDocker?.setupCommand,
+    initTimeoutMs: resolveTimerTimeoutMs(
+      agentDocker?.initTimeoutMs ?? globalDocker?.initTimeoutMs,
+      DEFAULT_SANDBOX_DOCKER_INIT_TIMEOUT_MS,
+    ),
     pidsLimit: agentDocker?.pidsLimit ?? globalDocker?.pidsLimit,
     memory: agentDocker?.memory ?? globalDocker?.memory,
     memorySwap: agentDocker?.memorySwap ?? globalDocker?.memorySwap,

--- a/src/agents/sandbox/constants.ts
+++ b/src/agents/sandbox/constants.ts
@@ -15,6 +15,13 @@ export const DEFAULT_SANDBOX_WORKDIR = "/workspace";
 export const DEFAULT_SANDBOX_IDLE_HOURS = 24;
 export const DEFAULT_SANDBOX_MAX_AGE_DAYS = 7;
 
+/**
+ * Default deadline (ms) for Docker control-plane calls during sandbox init
+ * (inspect/create/start/rm), so a wedged engine fails fast instead of hanging.
+ * Override via agents.defaults.sandbox.docker.initTimeoutMs.
+ */
+export const DEFAULT_SANDBOX_DOCKER_INIT_TIMEOUT_MS = 60_000;
+
 export const DEFAULT_TOOL_ALLOW = [
   "exec",
   "process",

--- a/src/agents/sandbox/docker-backend.ts
+++ b/src/agents/sandbox/docker-backend.ts
@@ -3,6 +3,7 @@
  *
  * Creates/reuses Docker containers and exposes backend-neutral exec and shell-command handles.
  */
+import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { buildDockerExecArgs } from "../bash-tools.shared.js";
 import type { SandboxBackendCommandParams } from "./backend-handle.types.js";
 import type {
@@ -16,7 +17,10 @@ import {
   ensureSandboxContainer,
   execDocker,
   execDockerRaw,
+  isDockerExecTimeoutError,
 } from "./docker.js";
+
+const log = createSubsystemLogger("docker");
 
 function resolveConfiguredDockerRuntimeImage(params: {
   config: CreateSandboxBackendParams["cfg"] | import("../../config/config.js").OpenClawConfig;
@@ -35,12 +39,27 @@ function resolveConfiguredDockerRuntimeImage(params: {
 export async function createDockerSandboxBackend(
   params: CreateSandboxBackendParams,
 ): Promise<SandboxBackendHandle> {
-  const containerName = await ensureSandboxContainer({
-    sessionKey: params.sessionKey,
-    workspaceDir: params.workspaceDir,
-    agentWorkspaceDir: params.agentWorkspaceDir,
-    cfg: params.cfg,
-  });
+  let containerName: string;
+  try {
+    containerName = await ensureSandboxContainer({
+      sessionKey: params.sessionKey,
+      workspaceDir: params.workspaceDir,
+      agentWorkspaceDir: params.agentWorkspaceDir,
+      cfg: params.cfg,
+    });
+  } catch (error) {
+    if (isDockerExecTimeoutError(error)) {
+      // Fail soft: surface a clear timeout failure for this run instead of
+      // hanging; the gateway and non-sandboxed agents keep serving.
+      log.error(
+        `Sandbox unavailable: Docker did not respond within ${error.timeoutMs}ms during sandbox ` +
+          `init for session "${params.sessionKey}". The Docker engine may be wedged. Sandboxed runs ` +
+          `will fail until Docker responds; non-sandboxed agents are unaffected. Restart Docker or ` +
+          `set agents.defaults.sandbox.mode=off.`,
+      );
+    }
+    throw error;
+  }
   return createDockerSandboxBackendHandle({
     containerName,
     workdir: params.cfg.docker.workdir,

--- a/src/agents/sandbox/docker.execDockerRaw.timeout.test.ts
+++ b/src/agents/sandbox/docker.execDockerRaw.timeout.test.ts
@@ -1,0 +1,128 @@
+// Regression for the sandbox-init hang (#90980): a wedged Docker engine (child
+// emits nothing, never closes) must reject via the execDockerRaw deadline, not
+// pend forever (existing docker tests only cover the ENOENT path). Mock-based;
+// Windows-safe — the mock drives behavior via hoisted state and ignores the
+// resolved command path.
+import { EventEmitter } from "node:events";
+import { Readable } from "node:stream";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type MockDockerChild = EventEmitter & {
+  stdout: Readable;
+  stderr: Readable;
+  stdin: { end: (input?: string | Buffer) => void };
+  kill: (signal?: NodeJS.Signals) => boolean;
+};
+
+const spawnState = vi.hoisted(() => ({
+  behavior: "hang" as "hang" | "close" | "closeOnKill",
+  exitCode: 0,
+  killSignals: [] as (NodeJS.Signals | undefined)[],
+}));
+
+function createMockDockerChild(): MockDockerChild {
+  const child = new EventEmitter() as MockDockerChild;
+  child.stdout = new Readable({ read() {} });
+  child.stderr = new Readable({ read() {} });
+  child.stdin = { end: () => undefined };
+  child.kill = (signal?: NodeJS.Signals) => {
+    spawnState.killSignals.push(signal);
+    if (spawnState.behavior === "closeOnKill") {
+      // Simulate a killable child: SIGTERM terminates it, so `close` fires.
+      queueMicrotask(() => child.emit("close", null));
+    }
+    return true;
+  };
+  return child;
+}
+
+function spawnMockDockerProcess() {
+  // Ignore command/args: on Windows the command is the resolved docker.exe path.
+  const child = createMockDockerChild();
+  if (spawnState.behavior === "close") {
+    queueMicrotask(() => child.emit("close", spawnState.exitCode));
+  }
+  // "hang"/"closeOnKill": never emit `close` on its own. For "hang" the deadline
+  // is the only thing that can settle the promise (the wedged-engine case).
+  return child;
+}
+
+async function createChildProcessMock() {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return { ...actual, spawn: spawnMockDockerProcess };
+}
+
+vi.mock("node:child_process", async () => createChildProcessMock());
+
+let execDockerRaw: typeof import("./docker.js").execDockerRaw;
+let isDockerExecTimeoutError: typeof import("./docker.js").isDockerExecTimeoutError;
+
+async function loadFreshDockerModule() {
+  vi.resetModules();
+  vi.doMock("node:child_process", async () => createChildProcessMock());
+  ({ execDockerRaw, isDockerExecTimeoutError } = await import("./docker.js"));
+}
+
+describe("execDockerRaw deadline", () => {
+  beforeEach(async () => {
+    spawnState.behavior = "hang";
+    spawnState.exitCode = 0;
+    spawnState.killSignals.length = 0;
+    await loadFreshDockerModule();
+  });
+
+  it("rejects via the deadline when Docker is present but unresponsive", async () => {
+    // Wedged engine: the child never emits data, error, or close. Without a
+    // deadline this promise would pend forever — the still-open hang of #5135.
+    spawnState.behavior = "hang";
+
+    let caught: unknown;
+    try {
+      await execDockerRaw(["version"], { timeoutMs: 25 });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    expect(isDockerExecTimeoutError(caught)).toBe(true);
+    expect((caught as { code?: string }).code).toBe("SANDBOX_DOCKER_TIMEOUT");
+    expect((caught as { timeoutMs?: number }).timeoutMs).toBe(25);
+    // The wedged child must be killed on timeout, not leaked.
+    expect(spawnState.killSignals).toContain("SIGTERM");
+  });
+
+  it("resolves on the success path before the deadline (unchanged behavior)", async () => {
+    spawnState.behavior = "close";
+    spawnState.exitCode = 0;
+
+    await expect(execDockerRaw(["version"], { timeoutMs: 5_000 })).resolves.toMatchObject({
+      code: 0,
+    });
+    expect(spawnState.killSignals).toHaveLength(0);
+  });
+
+  it("lets a caller abort win over the deadline (AbortError, not a timeout error)", async () => {
+    // First-to-fire-wins: the abort settles the promise; the deadline must not
+    // also reject (no double-settle) and must be cleared.
+    spawnState.behavior = "closeOnKill";
+
+    let caught: unknown;
+    try {
+      await execDockerRaw(["version"], { signal: AbortSignal.abort(), timeoutMs: 5_000 });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).name).toBe("AbortError");
+    expect(isDockerExecTimeoutError(caught)).toBe(false);
+    expect(spawnState.killSignals).toContain("SIGTERM");
+  });
+
+  it("does not arm a deadline when timeoutMs is omitted (back-compat, no spurious kill)", async () => {
+    spawnState.behavior = "close";
+
+    await expect(execDockerRaw(["version"]).then((result) => result.code)).resolves.toBe(0);
+    expect(spawnState.killSignals).toHaveLength(0);
+  });
+});

--- a/src/agents/sandbox/docker.init-timeout.test.ts
+++ b/src/agents/sandbox/docker.init-timeout.test.ts
@@ -1,0 +1,163 @@
+// Fail-soft for #90980: a wedged Docker engine makes sandbox container init
+// reject fast with a typed timeout (bounded by docker.initTimeoutMs) instead of
+// hanging — proving the deadline threads ensureSandboxContainer -> execDockerRaw.
+// Mock-based; Windows-safe (behavior via hoisted state, command path ignored).
+import { EventEmitter } from "node:events";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { Readable } from "node:stream";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SandboxConfig } from "./types.js";
+
+type MockDockerChild = EventEmitter & {
+  stdout: Readable;
+  stderr: Readable;
+  stdin: { end: (input?: string | Buffer) => void };
+  kill: (signal?: NodeJS.Signals) => boolean;
+};
+
+const spawnState = vi.hoisted(() => ({
+  // When true, the docker child never emits close/error (wedged engine).
+  hang: true,
+  killSignals: [] as (NodeJS.Signals | undefined)[],
+}));
+
+const registryMocks = vi.hoisted(() => ({
+  readRegistryEntry: vi.fn(),
+  updateRegistry: vi.fn(),
+}));
+
+vi.mock("./registry.js", () => ({
+  readRegistryEntry: registryMocks.readRegistryEntry,
+  updateRegistry: registryMocks.updateRegistry,
+}));
+
+function createMockDockerChild(): MockDockerChild {
+  const child = new EventEmitter() as MockDockerChild;
+  child.stdout = new Readable({ read() {} });
+  child.stderr = new Readable({ read() {} });
+  child.stdin = { end: () => undefined };
+  child.kill = (signal?: NodeJS.Signals) => {
+    spawnState.killSignals.push(signal);
+    return true;
+  };
+  return child;
+}
+
+function spawnMockDockerProcess() {
+  const child = createMockDockerChild();
+  if (!spawnState.hang) {
+    queueMicrotask(() => child.emit("close", 0));
+  }
+  return child;
+}
+
+async function createChildProcessMock() {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return { ...actual, spawn: spawnMockDockerProcess };
+}
+
+vi.mock("node:child_process", async () => createChildProcessMock());
+
+let ensureSandboxContainer: typeof import("./docker.js").ensureSandboxContainer;
+let isDockerExecTimeoutError: typeof import("./docker.js").isDockerExecTimeoutError;
+
+async function loadFreshDockerModule() {
+  vi.resetModules();
+  vi.doMock("./registry.js", () => ({
+    readRegistryEntry: registryMocks.readRegistryEntry,
+    updateRegistry: registryMocks.updateRegistry,
+  }));
+  vi.doMock("node:child_process", async () => createChildProcessMock());
+  ({ ensureSandboxContainer, isDockerExecTimeoutError } = await import("./docker.js"));
+}
+
+const tmpDirs: string[] = [];
+function makeTempDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-init-timeout-"));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+function createSandboxConfig(initTimeoutMs: number): SandboxConfig {
+  return {
+    mode: "all",
+    backend: "docker",
+    scope: "shared",
+    workspaceAccess: "rw",
+    workspaceRoot: "~/.openclaw/sandboxes",
+    docker: {
+      image: "openclaw-sandbox:test",
+      containerPrefix: "oc-test-",
+      workdir: "/workspace",
+      readOnlyRoot: true,
+      tmpfs: ["/tmp", "/var/tmp", "/run"],
+      network: "none",
+      capDrop: ["ALL"],
+      env: { LANG: "C.UTF-8" },
+      initTimeoutMs,
+    },
+    ssh: {
+      command: "ssh",
+      workspaceRoot: "/tmp/openclaw-sandboxes",
+      strictHostKeyChecking: true,
+      updateHostKeys: true,
+    },
+    browser: {
+      enabled: false,
+      image: "openclaw-browser:test",
+      containerPrefix: "oc-browser-",
+      network: "openclaw-sandbox-browser",
+      cdpPort: 9222,
+      vncPort: 5900,
+      noVncPort: 6080,
+      headless: true,
+      enableNoVnc: false,
+      allowHostControl: false,
+      autoStart: false,
+      autoStartTimeoutMs: 5000,
+    },
+    tools: { allow: [], deny: [] },
+    prune: { idleHours: 24, maxAgeDays: 7 },
+  };
+}
+
+describe("ensureSandboxContainer fail-soft on unresponsive Docker", () => {
+  afterEach(() => {
+    for (const dir of tmpDirs.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  beforeEach(async () => {
+    spawnState.hang = true;
+    spawnState.killSignals.length = 0;
+    registryMocks.readRegistryEntry.mockReset().mockResolvedValue(null);
+    registryMocks.updateRegistry.mockReset().mockResolvedValue(undefined);
+    await loadFreshDockerModule();
+  });
+
+  it("rejects with a typed timeout (not a hang) when the first docker call wedges", async () => {
+    const workspaceDir = makeTempDir();
+
+    let caught: unknown;
+    try {
+      await ensureSandboxContainer({
+        sessionKey: "agent:main:session-1",
+        workspaceDir,
+        agentWorkspaceDir: workspaceDir,
+        cfg: createSandboxConfig(25),
+      });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    expect(isDockerExecTimeoutError(caught)).toBe(true);
+    expect((caught as { code?: string }).code).toBe("SANDBOX_DOCKER_TIMEOUT");
+    // The wedged child was killed, and we never reached the registry write.
+    expect(spawnState.killSignals).toContain("SIGTERM");
+    expect(registryMocks.updateRegistry).not.toHaveBeenCalled();
+  });
+});

--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -19,6 +19,12 @@ type ExecDockerRawOptions = {
   allowFailure?: boolean;
   input?: Buffer | string;
   signal?: AbortSignal;
+  /**
+   * Deadline (ms). When set, a wedged engine (no output, never closes) is killed
+   * and rejected with a typed timeout instead of pending forever. Composes with
+   * `signal` (first to fire wins). Unset on the exec path so long commands live.
+   */
+  timeoutMs?: number;
 };
 
 export type ExecDockerRawResult = {
@@ -36,6 +42,29 @@ type ExecDockerRawError = Error & {
 function createAbortError(): Error {
   const err = new Error("Aborted");
   err.name = "AbortError";
+  return err;
+}
+
+/** Typed error thrown when a Docker invocation exceeds its deadline. */
+export type DockerExecTimeoutError = Error & {
+  code: "SANDBOX_DOCKER_TIMEOUT";
+  timeoutMs: number;
+};
+
+/** True for a Docker exec deadline timeout (not abort/ENOENT/exit failure). */
+export function isDockerExecTimeoutError(error: unknown): error is DockerExecTimeoutError {
+  return error instanceof Error && (error as { code?: unknown }).code === "SANDBOX_DOCKER_TIMEOUT";
+}
+
+function createDockerTimeoutError(args: string[], timeoutMs: number): DockerExecTimeoutError {
+  const err = new Error(
+    `Docker did not respond within ${timeoutMs}ms while running \`docker ${args.join(" ")}\`. ` +
+      "The Docker engine may be present but unresponsive. Start or restart Docker, or set " +
+      "`agents.defaults.sandbox.mode=off` to disable sandboxing.",
+  ) as DockerExecTimeoutError;
+  err.name = "DockerExecTimeoutError";
+  err.code = "SANDBOX_DOCKER_TIMEOUT";
+  err.timeoutMs = timeoutMs;
   return err;
 }
 
@@ -86,8 +115,16 @@ export function execDockerRaw(
     const stdoutChunks: Buffer[] = [];
     const stderrChunks: Buffer[] = [];
     let aborted = false;
+    // Guards against double-settle (deadline vs abort/close); cleanup() frees timer + listener.
+    let settled = false;
 
     const signal = opts?.signal;
+    const timeoutMs =
+      typeof opts?.timeoutMs === "number" && Number.isFinite(opts.timeoutMs) && opts.timeoutMs > 0
+        ? opts.timeoutMs
+        : undefined;
+    let deadline: ReturnType<typeof setTimeout> | undefined;
+
     const handleAbort = () => {
       if (aborted) {
         return;
@@ -95,12 +132,34 @@ export function execDockerRaw(
       aborted = true;
       child.kill("SIGTERM");
     };
+    const cleanup = () => {
+      if (deadline !== undefined) {
+        clearTimeout(deadline);
+        deadline = undefined;
+      }
+      if (signal) {
+        signal.removeEventListener("abort", handleAbort);
+      }
+    };
+
     if (signal) {
       if (signal.aborted) {
         handleAbort();
       } else {
         signal.addEventListener("abort", handleAbort, { once: true });
       }
+    }
+    if (timeoutMs !== undefined) {
+      deadline = setTimeout(() => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        cleanup();
+        // Kill the wedged child (don't leak it), then reject.
+        child.kill("SIGTERM");
+        reject(createDockerTimeoutError(args, timeoutMs));
+      }, timeoutMs);
     }
 
     child.stdout?.on("data", (chunk) => {
@@ -111,9 +170,11 @@ export function execDockerRaw(
     });
 
     child.on("error", (error) => {
-      if (signal) {
-        signal.removeEventListener("abort", handleAbort);
+      if (settled) {
+        return;
       }
+      settled = true;
+      cleanup();
       if (
         error &&
         typeof error === "object" &&
@@ -133,9 +194,11 @@ export function execDockerRaw(
     });
 
     child.on("close", (code) => {
-      if (signal) {
-        signal.removeEventListener("abort", handleAbort);
+      if (settled) {
+        return;
       }
+      settled = true;
+      cleanup();
       const stdout = Buffer.concat(stdoutChunks);
       const stderr = Buffer.concat(stderrChunks);
       if (aborted || signal?.aborted) {
@@ -177,7 +240,7 @@ import {
   computeSandboxConfigHash,
   SANDBOX_DOCKER_EXPLICIT_ENV_POLICY_EPOCH,
 } from "./config-hash.js";
-import { DEFAULT_SANDBOX_IMAGE } from "./constants.js";
+import { DEFAULT_SANDBOX_DOCKER_INIT_TIMEOUT_MS, DEFAULT_SANDBOX_IMAGE } from "./constants.js";
 import { readRegistryEntry, updateRegistry } from "./registry.js";
 import { resolveSandboxAgentId, resolveSandboxScopeKey, slugifySessionKey } from "./shared.js";
 import type { SandboxConfig, SandboxDockerConfig, SandboxWorkspaceAccess } from "./types.js";
@@ -337,9 +400,13 @@ export function formatDockerDaemonUnavailableError(stderr: string): string {
     .join(" ");
 }
 
-async function inspectDockerImage(image: string): Promise<"exists" | "missing"> {
+async function inspectDockerImage(
+  image: string,
+  opts?: { timeoutMs?: number },
+): Promise<"exists" | "missing"> {
   const result = await execDocker(["image", "inspect", image], {
     allowFailure: true,
+    timeoutMs: opts?.timeoutMs,
   });
   if (result.code === 0) {
     return "exists";
@@ -354,8 +421,8 @@ async function inspectDockerImage(image: string): Promise<"exists" | "missing"> 
   throw new Error(`Failed to inspect sandbox image: ${stderr}`);
 }
 
-export async function ensureDockerImage(image: string) {
-  const imageState = await inspectDockerImage(image);
+export async function ensureDockerImage(image: string, opts?: { timeoutMs?: number }) {
+  const imageState = await inspectDockerImage(image, opts);
   if (imageState === "exists") {
     return;
   }
@@ -367,9 +434,10 @@ export async function ensureDockerImage(image: string) {
   throw new Error(`Sandbox image not found: ${image}. Build or pull it first.`);
 }
 
-export async function dockerContainerState(name: string) {
+export async function dockerContainerState(name: string, opts?: { timeoutMs?: number }) {
   const result = await execDocker(["inspect", "-f", "{{.State.Running}}", name], {
     allowFailure: true,
+    timeoutMs: opts?.timeoutMs,
   });
   if (result.code !== 0) {
     return { exists: false, running: false };
@@ -567,9 +635,11 @@ async function createSandboxContainer(params: {
   scopeKey: string;
   configHash?: string;
   readOnlyWorkspaceSkillMounts: readonly ReadOnlyWorkspaceSkillMount[];
+  initTimeoutMs?: number;
 }) {
   const { name, cfg, workspaceDir, scopeKey } = params;
-  await ensureDockerImage(cfg.image);
+  const timeoutMs = params.initTimeoutMs;
+  await ensureDockerImage(cfg.image, { timeoutMs });
 
   const args = buildSandboxCreateArgs({
     name,
@@ -596,10 +666,11 @@ async function createSandboxContainer(params: {
   });
   args.push(cfg.image, "sleep", "infinity");
 
-  await execDocker(args);
-  await execDocker(["start", name]);
+  await execDocker(args, { timeoutMs });
+  await execDocker(["start", name], { timeoutMs });
 
   if (cfg.setupCommand?.trim()) {
+    // Unbounded: setupCommand is user-defined and may run long; init deadline must not kill it.
     await execDocker(["exec", "-i", name, "/bin/sh", "-lc", cfg.setupCommand]);
   }
 }
@@ -629,6 +700,8 @@ export async function ensureSandboxContainer(params: {
   const slug = params.cfg.scope === "shared" ? "shared" : slugifySessionKey(scopeKey);
   const name = `${params.cfg.docker.containerPrefix}${slug}`;
   const containerName = name.slice(0, 63);
+  // Bound the control-plane calls below so a wedged engine fails fast, not hangs.
+  const initTimeoutMs = params.cfg.docker.initTimeoutMs ?? DEFAULT_SANDBOX_DOCKER_INIT_TIMEOUT_MS;
   const readOnlyWorkspaceSkillMounts = resolveReadOnlyWorkspaceSkillMounts({
     workspaceDir: params.workspaceDir,
     agentWorkspaceDir: params.agentWorkspaceDir,
@@ -647,7 +720,7 @@ export async function ensureSandboxContainer(params: {
     ),
   });
   const now = Date.now();
-  const state = await dockerContainerState(containerName);
+  const state = await dockerContainerState(containerName, { timeoutMs: initTimeoutMs });
   let hasContainer = state.exists;
   let running = state.running;
   let currentHash: string | null = null;
@@ -676,7 +749,10 @@ export async function ensureSandboxContainer(params: {
           `Sandbox config changed for ${containerName} (recently used). Recreate to apply: ${hint}`,
         );
       } else {
-        await execDocker(["rm", "-f", containerName], { allowFailure: true });
+        await execDocker(["rm", "-f", containerName], {
+          allowFailure: true,
+          timeoutMs: initTimeoutMs,
+        });
         hasContainer = false;
         running = false;
       }
@@ -692,9 +768,10 @@ export async function ensureSandboxContainer(params: {
       scopeKey,
       configHash: expectedHash,
       readOnlyWorkspaceSkillMounts,
+      initTimeoutMs,
     });
   } else if (!running) {
-    await execDocker(["start", containerName]);
+    await execDocker(["start", containerName], { timeoutMs: initTimeoutMs });
   }
   await updateRegistry({
     containerName,

--- a/src/commands/doctor-sandbox.ts
+++ b/src/commands/doctor-sandbox.ts
@@ -72,14 +72,21 @@ async function runSandboxScript(scriptRel: string, runtime: RuntimeEnv): Promise
   return true;
 }
 
-async function isDockerAvailable(): Promise<boolean> {
+type DockerProbeStatus = "available" | "unresponsive" | "unavailable";
+
+async function probeDockerAvailability(): Promise<DockerProbeStatus> {
   try {
     await runExec("docker", ["version", "--format", "{{.Server.Version}}"], {
       timeoutMs: 5_000,
     });
-    return true;
-  } catch {
-    return false;
+    return "available";
+  } catch (error) {
+    // A wedged engine is killed at the execFile timeout (killed===true) rather
+    // than returning a "daemon not running" stderr; distinguish it for the message.
+    if (error && typeof error === "object" && (error as { killed?: boolean }).killed === true) {
+      return "unresponsive";
+    }
+    return "unavailable";
   }
 }
 
@@ -294,17 +301,30 @@ export async function maybeRepairSandboxImages(
     return cfg;
   }
 
-  const dockerAvailable = await isDockerAvailable();
-  if (!dockerAvailable) {
-    const lines = [
-      `Sandbox mode is enabled (mode: "${mode}") but Docker is not available.`,
-      "Docker is required for sandbox mode to function.",
-      "Isolated sessions (cron jobs, sub-agents) will fail without Docker.",
-      "",
-      "Options:",
-      "- Install Docker and restart the gateway",
-      "- Disable sandbox mode: openclaw config set agents.defaults.sandbox.mode off",
-    ];
+  const dockerStatus = await probeDockerAvailability();
+  if (dockerStatus !== "available") {
+    const lines =
+      dockerStatus === "unresponsive"
+        ? [
+            `Sandbox mode is enabled (mode: "${mode}") but the Docker engine did not respond within 5s.`,
+            "Docker appears installed but the engine may be wedged/unresponsive.",
+            "Sandbox init is bounded by agents.defaults.sandbox.docker.initTimeoutMs (default 60s),",
+            "so sandboxed sessions (cron jobs, sub-agents) fail fast with a clear error instead of",
+            "hanging the gateway; non-sandboxed agents keep serving.",
+            "",
+            "Options:",
+            "- Restart Docker (or the Docker daemon/VM) and re-run",
+            "- Disable sandbox mode: openclaw config set agents.defaults.sandbox.mode off",
+          ]
+        : [
+            `Sandbox mode is enabled (mode: "${mode}") but Docker is not available.`,
+            "Docker is required for sandbox mode to function.",
+            "Isolated sessions (cron jobs, sub-agents) will fail without Docker.",
+            "",
+            "Options:",
+            "- Install Docker and restart the gateway",
+            "- Disable sandbox mode: openclaw config set agents.defaults.sandbox.mode off",
+          ];
     note(lines.join("\n"), "Sandbox");
     return cfg;
   }

--- a/src/config/types.sandbox.ts
+++ b/src/config/types.sandbox.ts
@@ -22,6 +22,12 @@ export type SandboxDockerSettings = {
   env?: Record<string, string>;
   /** Optional setup command run once after container creation (array entries are joined by newline). */
   setupCommand?: string;
+  /**
+   * Deadline (ms) for Docker control-plane calls during sandbox init
+   * (inspect/create/start/rm) so a wedged engine fails fast instead of hanging.
+   * Default 60000. Does not bound setupCommand or the command exec path.
+   */
+  initTimeoutMs?: number;
   /** Limit container PIDs (0 = Docker default). */
   pidsLimit?: number;
   /** Limit container memory (e.g. 512m, 2g, or bytes as number). */

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -205,6 +205,7 @@ const SandboxDockerSchema = z
     dns: z.array(z.string()).optional(),
     extraHosts: z.array(z.string()).optional(),
     binds: z.array(z.string()).optional(),
+    initTimeoutMs: z.number().int().positive().optional(),
     dangerouslyAllowReservedContainerTargets: z.boolean().optional(),
     dangerouslyAllowExternalBindSources: z.boolean().optional(),
     dangerouslyAllowContainerNamespaceJoin: z.boolean().optional(),


### PR DESCRIPTION
## What / why

A present-but-unresponsive Docker engine (the socket accepts the connection but never answers — distinct from "daemon not running", which returns a stderr quickly) makes `docker …` emit nothing and never exit. `execDockerRaw` awaited that child with **no timeout**, so sandbox container init pended forever; with `sandbox.mode=all` every agent run hung — the "all agents offline / blocked at initializing sandboxed agents" symptom of #90980. This is the still-open hang half of #5135.

## Why non-sandboxed agents were also offline

The gateway process stays reachable throughout (a hung `docker` spawn is async I/O and doesn't block the event loop); readiness/health key only on sidecars + channel health + event-loop and **never observe sandbox/docker** (`src/gateway/server/readiness.ts`, `src/gateway/server-methods/health.ts`, and `server-startup-post-attach.ts` awaits no sandbox op). So this fix targets the **agent-run path** — with `sandbox.mode=all` a wedged engine made *every* run hang, which presents as all agents offline.

## Restart loop (inferred / external)

The ~5-min restart loop in the report is external/operator-side — there is **no in-repo health check gated on sandbox/docker** (`gateway status --deep` and the post-restart probe don't touch docker). Stated as inference, not an asserted in-repo cause. Converting the infinite hang into a fast, clear failure removes the no-reply condition an external uptime probe (or a frequent sandboxed cron job) would have tripped.

## Layer 1 — bound the exec

- `execDockerRaw` gains an opt-in `timeoutMs`; on deadline it kills the child (SIGTERM) and rejects with a typed `SANDBOX_DOCKER_TIMEOUT` error. A single `settled` guard composes the caller `AbortSignal` **OR** the deadline (first to fire wins) with no double-settle and no timer/listener leak. The success, ENOENT, daemon-unavailable, and abort paths are unchanged.
- New `agents.defaults.sandbox.docker.initTimeoutMs` (default **60000**) is threaded **per-call** through the init control-plane ops (inspect/create/start/rm). It is a per-call deadline, not a total budget: a fully wedged engine is bounded to ~one timeout (the first `dockerContainerState` inspect rejects and the rest short-circuit); a slow-but-progressing host could see up to N× across sequential calls. `ensureDockerImage` runs before `docker create` and throws on a missing image, so create never triggers an implicit pull under the deadline. The user-defined `setupCommand` and the long-running command exec path stay **unbounded** so legitimate long work is not killed.

## Layer 2 — fail soft

- On timeout the sandboxed run fails with a clear "sandbox unavailable" error, logged loudly; `openclaw doctor` distinguishes a present-but-unresponsive engine from a not-running daemon.
- Also: `initTimeoutMs` is excluded from the container-reuse config hash, so this operational timeout never forces container recreation on upgrade.

## Tests (mock-based, no real Docker)

- Hung-engine deadline regression (rejects via the deadline + kills the child) plus abort-wins and back-compat (no `timeoutMs` ⇒ no timer armed).
- `ensureSandboxContainer` init-timeout fail-soft (rejects fast, not a hang).
- Config-hash guard that `initTimeoutMs` does not change container identity.
- The existing ENOENT test stays green.

## Verification (gates already passed locally)

Hook-verified locally: **oxfmt** (lockfile-pinned v0.52.0, run via the pre-commit hook) clean; **oxlint = 0** on all changed files; **tsgo** `core` + `core:test` = 0.

## Testing notes

Two pre-existing sandbox spawn-mock tests (`docker.test.ts`, `docker.config-hash-recreate.test.ts`) fail **only on Windows with Docker Desktop installed** — their mocks assume a bare `docker` command, but Windows resolves it to the full `…\docker.exe` path. This is unrelated to this change and they pass on Linux/CI (the Windows-specific `docker.windows.test.ts` passes locally).

Fixes #90980
Refs #5135
