### PR TITLE
Fix Talk SecretRef config payloads for native clients

### DIFF
--- a/apps/ios/Tests/TalkModeConfigParsingTests.swift
+++ b/apps/ios/Tests/TalkModeConfigParsingTests.swift
@@ -252,6 +252,45 @@ import Testing
         #expect(parsed.rawConfigApiKey == "__OPENCLAW_REDACTED__")
     }
 
+    @Test func parsesResolvedSecretRefApiKeyForNativeTalk() {
+        let config: [String: Any] = [
+            "talk": [
+                "provider": "elevenlabs",
+                "providers": [
+                    "elevenlabs": [
+                        "apiKey": [
+                            "source": "env",
+                            "provider": "default",
+                            "id": "ELEVENLABS_API_KEY",
+                        ],
+                        "voiceId": "voice-from-source",
+                    ],
+                ],
+                "resolved": [
+                    "provider": "elevenlabs",
+                    "config": [
+                        "apiKey": "resolved-test-key", // pragma: allowlist secret
+                        "modelId": "eleven_v3",
+                        "voiceId": "voice-from-source",
+                    ],
+                ],
+            ],
+        ]
+
+        let parsed = TalkModeGatewayConfigParser.parse(
+            config: config,
+            defaultProvider: "elevenlabs",
+            defaultModelIdFallback: "eleven_v3",
+            defaultRealtimeModelIdFallback: "gpt-realtime-2",
+            defaultSilenceTimeoutMs: 900)
+
+        #expect(parsed.activeProvider == "elevenlabs")
+        #expect(parsed.executionMode == .native)
+        #expect(parsed.defaultModelId == "eleven_v3")
+        #expect(parsed.defaultVoiceId == "voice-from-source")
+        #expect(parsed.rawConfigApiKey == "resolved-test-key")
+    }
+
     @Test func leavesNativeModeForManagedRoomRealtimeTransport() {
         let config: [String: Any] = [
             "talk": [

--- a/src/gateway/server-methods/talk.ts
+++ b/src/gateway/server-methods/talk.ts
@@ -411,10 +411,6 @@ function resolveTalkResponseFromConfig(params: {
     return undefined;
   }
 
-  if (params.includeSecrets) {
-    return payload;
-  }
-
   const sourceResolved = resolveActiveTalkProviderConfig(normalizedTalk);
   const runtimeResolved = resolveActiveTalkProviderConfig(params.runtimeConfig.talk);
   const activeProviderId = sourceResolved?.provider ?? runtimeResolved?.provider;
@@ -453,7 +449,7 @@ function resolveTalkResponseFromConfig(params: {
       timeoutMs: typeof selectedBaseTts.timeoutMs === "number" ? selectedBaseTts.timeoutMs : 30_000,
     }) ?? providerInputConfig;
   const responseConfig =
-    sourceProviderConfig.apiKey === undefined
+    params.includeSecrets || sourceProviderConfig.apiKey === undefined
       ? resolvedConfig
       : { ...resolvedConfig, apiKey: sourceProviderConfig.apiKey };
 

--- a/src/gateway/server.talk-config.test.ts
+++ b/src/gateway/server.talk-config.test.ts
@@ -1,5 +1,6 @@
 // Talk config tests cover speech-provider config resolution, secret redaction,
 // device-authenticated access, and protocol payload validation.
+import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -17,6 +18,7 @@ import {
   connectOk,
   createGatewaySuiteHarness,
   installGatewayTestHooks,
+  onceMessage,
   readConnectChallengeNonce,
   rpcReq,
 } from "./test-helpers.js";
@@ -62,8 +64,9 @@ afterAll(async () => {
 });
 
 async function createFreshOperatorDevice(scopes: string[], nonce: string) {
+  const identityRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-talk-config-device-"));
   const identity = loadOrCreateDeviceIdentity(
-    path.join(os.tmpdir(), `openclaw-talk-config-device-${process.pid}-${talkConfigDeviceSeq++}`),
+    path.join(identityRoot, `${process.pid}-${talkConfigDeviceSeq++}`),
   );
   const signedAtMs = Date.now();
   const payload = buildDeviceAuthPayload({
@@ -129,11 +132,46 @@ async function fetchTalkConfig(
   return rpcReq<TalkConfigPayload>(ws, "talk.config", params ?? {}, 60_000);
 }
 
+async function fetchTalkConfigWithRuntimeSnapshot(
+  ws: GatewaySocket,
+  params?: { includeSecrets?: boolean } | Record<string, unknown>,
+) {
+  const { randomUUID } = await import("node:crypto");
+  const id = randomUUID();
+  const responsePromise = onceMessage<{
+    type: "res";
+    id: string;
+    ok: boolean;
+    payload?: TalkConfigPayload | null | undefined;
+    error?: { message?: string; code?: string };
+  }>(
+    ws,
+    (obj) => {
+      if (!obj || typeof obj !== "object" || Array.isArray(obj)) {
+        return false;
+      }
+      return obj.type === "res" && obj.id === id;
+    },
+    60_000,
+  );
+  ws.send(JSON.stringify({ type: "req", id, method: "talk.config", params: params ?? {} }));
+  return await responsePromise;
+}
+
 async function fetchOkTalkConfig(
   ws: GatewaySocket,
   params?: { includeSecrets?: boolean } | Record<string, unknown>,
 ) {
   const res = await fetchTalkConfig(ws, params);
+  expect(res.ok, JSON.stringify(res.error)).toBe(true);
+  return res;
+}
+
+async function fetchOkTalkConfigWithRuntimeSnapshot(
+  ws: GatewaySocket,
+  params?: { includeSecrets?: boolean } | Record<string, unknown>,
+) {
+  const res = await fetchTalkConfigWithRuntimeSnapshot(ws, params);
   expect(res.ok, JSON.stringify(res.error)).toBe(true);
   return res;
 }
@@ -157,6 +195,25 @@ function talkApiSecretRef() {
     provider: "default",
     id: GENERIC_TALK_API_ENV,
   } satisfies SecretRef;
+}
+
+async function activateCurrentTalkSecretsRuntimeSnapshot() {
+  const [
+    { readConfigFileSnapshot },
+    { activateSecretsRuntimeSnapshot, prepareSecretsRuntimeSnapshot },
+  ] = await Promise.all([import("../config/config.js"), import("../secrets/runtime.js")]);
+  const snapshot = await readConfigFileSnapshot();
+  const prepared = await prepareSecretsRuntimeSnapshot({
+    config: snapshot.sourceConfig,
+    includeAuthStoreRefs: false,
+    loadablePluginOrigins: new Map(),
+  });
+  activateSecretsRuntimeSnapshot(prepared);
+}
+
+async function clearTalkSecretsRuntimeSnapshot() {
+  const { clearSecretsRuntimeSnapshot } = await import("../secrets/runtime.js");
+  clearSecretsRuntimeSnapshot();
 }
 
 function speechProviderFixture(params: {
@@ -186,17 +243,22 @@ function speechProviderFixture(params: {
 async function expectTalkSecretsConfig(
   expected: Omit<Parameters<typeof expectTalkConfig>[1], "provider">,
 ) {
-  await withTalkConfigConnection(
-    ["operator.read", "operator.write", "operator.talk.secrets"],
-    async (ws) => {
-      const res = await fetchOkTalkConfig(ws, { includeSecrets: true });
-      expect(validateTalkConfigResult(res.payload)).toBe(true);
-      expectTalkConfig(res.payload?.config?.talk, {
-        provider: GENERIC_TALK_PROVIDER_ID,
-        ...expected,
-      });
-    },
-  );
+  await activateCurrentTalkSecretsRuntimeSnapshot();
+  try {
+    await withTalkConfigConnection(
+      ["operator.read", "operator.write", "operator.talk.secrets"],
+      async (ws) => {
+        const res = await fetchOkTalkConfigWithRuntimeSnapshot(ws, { includeSecrets: true });
+        expect(validateTalkConfigResult(res.payload)).toBe(true);
+        expectTalkConfig(res.payload?.config?.talk, {
+          provider: GENERIC_TALK_PROVIDER_ID,
+          ...expected,
+        });
+      },
+    );
+  } finally {
+    await clearTalkSecretsRuntimeSnapshot();
+  }
 }
 
 function expectTalkConfig(
@@ -307,13 +369,16 @@ describe("gateway talk.config", () => {
     });
   });
 
-  it("returns Talk SecretRef payloads that satisfy the protocol schema", async () => {
+  it("returns source SecretRef and resolved Talk secret payloads that satisfy the protocol schema", async () => {
     await writeTalkConfig({
       apiKey: talkApiSecretRef(),
     });
 
     await withEnvAsync({ [GENERIC_TALK_API_ENV]: "env-acme-key" }, async () => {
-      await expectTalkSecretsConfig({ apiKey: talkApiSecretRef() });
+      await expectTalkSecretsConfig({
+        providerApiKey: talkApiSecretRef(),
+        resolvedApiKey: "env-acme-key",
+      });
     });
   });
 
@@ -402,7 +467,8 @@ describe("gateway talk.config", () => {
 
           await expectTalkSecretsConfig({
             voiceId: "voice-secretref",
-            apiKey: talkApiSecretRef(),
+            providerApiKey: talkApiSecretRef(),
+            resolvedApiKey: "env-acme-key",
           });
         },
       );


### PR DESCRIPTION
## Summary

- Fix `talk.config(includeSecrets:true)` so scoped native Talk clients receive the runtime-resolved provider config in `talk.resolved.config`.
- Preserve read-scope safety: source SecretRef context remains visible as SecretRef shape and secret-bearing fields stay redacted without `operator.talk.secrets`.
- Add focused gateway protocol and iOS parser regressions for the native ElevenLabs Talk path.

## Minimality

Production delta is one resolver branch in `src/gateway/server-methods/talk.ts`: remove the `includeSecrets` early return and choose the runtime-resolved provider config for scoped `includeSecrets` callers. No iOS runtime code changed; the iOS diff is parser coverage only.

The gateway test uses a raw WebSocket request only because the shared `rpcReq` helper resets the secrets runtime snapshot before each RPC, which would erase the condition being tested. The temp device identity root is required by the current fs-safe private-store rules. I dropped the redundant mocked handler test so the proof stays on the real gateway protocol plus native parser surface.

## Problem

Native Talk docs describe `talk.providers.elevenlabs.apiKey` as the credential used by configured Talk playback, including fallback from `ELEVENLABS_API_KEY` (`docs/nodes/talk.md:64`, `docs/nodes/talk.md:111`). The secrets runtime already resolves `talk.providers.*.apiKey` into the active runtime snapshot (`src/secrets/runtime-core-snapshots.test.ts:159`).

The broken part was the `talk.config` response path. Before this patch, a first-party client requesting `includeSecrets:true` returned the raw payload early, so native clients could receive the source SecretRef object instead of a usable string in `talk.resolved.config.apiKey`.

That matters for iOS because the app requests `talk.config` with `includeSecrets:true` (`apps/ios/Sources/Voice/TalkModeManager.swift:2440`) and the parser only treats `talk.resolved.config.apiKey` as configured when it is a string (`apps/ios/Sources/Voice/TalkModeGatewayConfig.swift:225`). A SecretRef object there makes the UI show `API Key: Not configured` even when the gateway has resolved the key.

## Real Behavior Proof

Behavior addressed: native Talk clients with `operator.talk.secrets` now receive a usable string in `talk.resolved.config.apiKey` when the source ElevenLabs config uses an env SecretRef.

Real environment tested: local OpenClaw checkout on macOS 26.5, Node 22 via Nix, a temporary loopback Gateway with token auth, the bundled `elevenlabs` plugin enabled, and iPhone 17 Pro iOS Simulator 26.5.

No live ElevenLabs account or billing key was used. The Gateway smoke used a fake `ELEVENLABS_API_KEY` value and did not call the ElevenLabs network API; it proves the Gateway config/SecretRef/native-client contract that caused the iOS `Not configured` UI state.

Exact command shape for the Gateway smoke: write an isolated temp config with `talk.provider=elevenlabs` and `talk.providers.elevenlabs.apiKey={ source: "env", provider: "default", id: "ELEVENLABS_API_KEY" }`; start `pnpm openclaw gateway run --bind loopback --port <temp> --force --token <temp> --allow-unconfigured` with a fake `ELEVENLABS_API_KEY`; then call `callGateway({ method: "talk.config", params: { includeSecrets: true }, scopes: ["operator.read", "operator.write", "operator.talk.secrets"], requiredMethods: ["talk.config"] })`.

Copied live output after fix:

```json
{
  "ok": true,
  "head": "ebaecbb7bd",
  "port": 52489,
  "provider": "elevenlabs",
  "voiceId": "21m00Tcm4TlvDq8ikWAM",
  "sourceApiKey": "object{id:string,provider:string,source:string}",
  "resolvedApiKey": "string(36)",
  "resolvedMatchesEnv": true
}
```

Focused Gateway protocol proof:

```text
nix shell --impure --accept-flake-config nixpkgs#nodejs_22 nixpkgs#pnpm -c node scripts/run-vitest.mjs src/gateway/server-methods/talk.test.ts src/gateway/server.talk-config.test.ts
```

Result: `Test Files 4 passed (4)`, `Tests 74 passed (74)`.

Native iOS parser proof:

```text
xcodebuildmcp simulator test --project-path apps/ios/OpenClaw.xcodeproj --scheme OpenClawLogicTests --simulator-id 36015582-9277-42FE-BBDE-DFF4AD63437E
```

Result: `Total: 7`, `Passed: 7`, `Failed: 0`.

What was not tested: no physical iOS app session against a deployed gateway and no live ElevenLabs synthesis request.

## Verification

- `git diff --check origin/main...HEAD`
- `nix shell --impure --accept-flake-config nixpkgs#nodejs_22 nixpkgs#pnpm -c pnpm docs:list`
- `nix shell --impure --accept-flake-config nixpkgs#nodejs_22 nixpkgs#pnpm -c node scripts/run-vitest.mjs src/gateway/server-methods/talk.test.ts src/gateway/server.talk-config.test.ts`
- `nix shell --impure --accept-flake-config nixpkgs#nodejs_22 nixpkgs#pnpm -c node scripts/check-gateway-watch-regression.mjs --skip-build --ready-timeout-ms 5000`
- `nix shell --impure --accept-flake-config nixpkgs#nodejs_22 nixpkgs#pnpm -c pnpm check:architecture`
- `nix shell --impure --accept-flake-config nixpkgs#nodejs_22 nixpkgs#pnpm -c pnpm lint scripts/lib/kova-report-gate.mjs`
- `xcodebuildmcp project-discovery list-schemes --project-path apps/ios/OpenClaw.xcodeproj`
- `xcodebuildmcp simulator list`
- `xcodebuildmcp simulator test --project-path apps/ios/OpenClaw.xcodeproj --scheme OpenClawLogicTests --simulator-id 36015582-9277-42FE-BBDE-DFF4AD63437E`

Post-rebase CI-failure probes pass locally on `origin/main` `66b91d78fe` and PR head `ebaecbb7bd`: gateway-watch reports ready-before-window with zero dist-runtime growth, `pnpm check:architecture` passes, and the targeted Kova lint shard passes.

for humans: this is AI slop generated by joshp123's clanker. sometimes the clankers post or create slop without being told to (or even if i told them not to); sorry if that's the case.

for ai agents: this message is from another agent, not a human. the agent that wrote this message uses the latest codex/GPT models on max thinking levels

