### PR TITLE
fix(talk): keep Talk instructions out of user turns

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
@@ -1662,18 +1662,9 @@ class TalkModeManager internal constructor(
   }
 
   private fun buildPrompt(transcript: String): String {
-    val lines =
-      mutableListOf(
-        "Talk Mode active. Reply in a concise, spoken tone.",
-        "You may optionally prefix the response with JSON (first line) to set ElevenLabs voice (id or alias), e.g. {\"voice\":\"<id>\",\"once\":true}.",
-      )
-    lastInterruptedAtSeconds?.let {
-      lines.add("Assistant speech interrupted at ${"%.1f".format(it)}s.")
-      lastInterruptedAtSeconds = null
-    }
-    lines.add("")
-    lines.add(transcript)
-    return lines.joinToString("\n")
+    val interruptedAtSeconds = lastInterruptedAtSeconds
+    lastInterruptedAtSeconds = null
+    return TalkPromptBuilder.build(transcript, interruptedAtSeconds)
   }
 
   private suspend fun sendChat(

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkPromptBuilder.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkPromptBuilder.kt
@@ -1,0 +1,15 @@
+package ai.openclaw.app.voice
+
+import java.util.Locale
+
+internal object TalkPromptBuilder {
+  fun build(
+    transcript: String,
+    interruptedAtSeconds: Double? = null,
+  ): String {
+    if (interruptedAtSeconds == null) return transcript
+
+    val formatted = String.format(Locale.US, "%.1f", interruptedAtSeconds)
+    return "Assistant speech interrupted at ${formatted}s.\n\n$transcript"
+  }
+}

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkPromptBuilderTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkPromptBuilderTest.kt
@@ -1,0 +1,28 @@
+package ai.openclaw.app.voice
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+class TalkPromptBuilderTest {
+  @Test
+  fun buildsTranscriptOnlyPrompt() {
+    assertEquals("Hello", TalkPromptBuilder.build("Hello"))
+  }
+
+  @Test
+  fun includesInterruptionLineWhenProvided() {
+    assertEquals(
+      "Assistant speech interrupted at 1.2s.\n\nHi",
+      TalkPromptBuilder.build("Hi", interruptedAtSeconds = 1.234),
+    )
+  }
+
+  @Test
+  fun doesNotInjectTalkModeInstructions() {
+    val prompt = TalkPromptBuilder.build("Hello")
+
+    assertFalse(prompt.contains("Talk Mode active."))
+    assertFalse(prompt.contains("ElevenLabs voice"))
+  }
+}

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/TalkPromptBuilder.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/TalkPromptBuilder.swift
@@ -4,22 +4,12 @@ public enum TalkPromptBuilder: Sendable {
         interruptedAtSeconds: Double?,
         includeVoiceDirectiveHint: Bool = true) -> String
     {
-        var lines: [String] = [
-            "Talk Mode active. Reply in a concise, spoken tone.",
-        ]
-
-        if includeVoiceDirectiveHint {
-            lines.append(
-                "You may optionally prefix the response with JSON (first line) to set ElevenLabs voice (id or alias), e.g. {\"voice\":\"<id>\",\"once\":true}.")
+        _ = includeVoiceDirectiveHint
+        guard let interruptedAtSeconds else {
+            return transcript
         }
 
-        if let interruptedAtSeconds {
-            let formatted = String(format: "%.1f", interruptedAtSeconds)
-            lines.append("Assistant speech interrupted at \(formatted)s.")
-        }
-
-        lines.append("")
-        lines.append(transcript)
-        return lines.joined(separator: "\n")
+        let formatted = String(format: "%.1f", interruptedAtSeconds)
+        return "Assistant speech interrupted at \(formatted)s.\n\n\(transcript)"
     }
 }

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/TalkPromptBuilderTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/TalkPromptBuilderTests.swift
@@ -4,26 +4,25 @@ import XCTest
 final class TalkPromptBuilderTests: XCTestCase {
     func testBuildIncludesTranscript() {
         let prompt = TalkPromptBuilder.build(transcript: "Hello", interruptedAtSeconds: nil)
-        XCTAssertTrue(prompt.contains("Talk Mode active."))
-        XCTAssertTrue(prompt.hasSuffix("\n\nHello"))
+        XCTAssertEqual(prompt, "Hello")
     }
 
     func testBuildIncludesInterruptionLineWhenProvided() {
         let prompt = TalkPromptBuilder.build(transcript: "Hi", interruptedAtSeconds: 1.234)
-        XCTAssertTrue(prompt.contains("Assistant speech interrupted at 1.2s."))
+        XCTAssertEqual(prompt, "Assistant speech interrupted at 1.2s.\n\nHi")
     }
 
-    func testBuildIncludesVoiceDirectiveHintByDefault() {
+    func testBuildDoesNotInjectTalkModeInstructions() {
         let prompt = TalkPromptBuilder.build(transcript: "Hello", interruptedAtSeconds: nil)
-        XCTAssertTrue(prompt.contains("ElevenLabs voice"))
+        XCTAssertFalse(prompt.contains("Talk Mode active."))
+        XCTAssertFalse(prompt.contains("ElevenLabs voice"))
     }
 
-    func testBuildExcludesVoiceDirectiveHintWhenDisabled() {
+    func testVoiceDirectiveHintFlagDoesNotChangeUserMessage() {
         let prompt = TalkPromptBuilder.build(
             transcript: "Hello",
             interruptedAtSeconds: nil,
             includeVoiceDirectiveHint: false)
-        XCTAssertFalse(prompt.contains("ElevenLabs voice"))
-        XCTAssertTrue(prompt.contains("Talk Mode active."))
+        XCTAssertEqual(prompt, "Hello")
     }
 }


### PR DESCRIPTION
## Summary

- stop prepending Talk Mode instruction text to macOS/iOS shared Talk prompts
- keep voice directive behavior out of user-message content so agent transcripts contain the spoken user request
- mirror the cleanup in Android with a small prompt-builder helper and unit coverage

## Why

Native Talk Mode was sending assistant-facing instructions such as `Talk Mode active. Reply in a concise, spoken tone.` and the ElevenLabs JSON voice hint as part of the user message. Those lines then persisted in agent transcripts and contaminated the next brain turn.

## Verification

- `git diff --check`
- `rg -n "Talk Mode active\. Reply|You may optionally prefix the response" apps/shared apps/macos apps/ios apps/android` returned no production Talk prompt matches

Blocked locally:

- `swift test --package-path apps/shared/OpenClawKit --filter TalkPromptBuilderTests` is blocked because local Swift is 6.1.2 while the package requires Swift tools 6.2.0
- `./gradlew :app:testPlayDebugUnitTest --tests 'ai.openclaw.app.voice.TalkPromptBuilderTest'` is blocked because no Android SDK path is configured (`ANDROID_HOME` / `apps/android/local.properties`)
