### PR TITLE
fix(acp): scope Discord thread session keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Discord/ACP: thread messages under the same configured parent channel now get distinct persistent ACP session keys, and reset/new commands clear stale configured-format metadata even when reverse lookup cannot reconstruct a runtime thread binding.
 - Channel content boundaries: QQBot now strips reasoning/thinking tags before sending, preserving final answers while hiding internal model narration from users. (#89913, #90132) Thanks @openperf.
 - Agents/MCP/providers: coerce non-text/image MCP tool-result blocks before they reach provider converters, preserving valid images and turning richer MCP content into text instead of malformed image blocks. (#90710, #90728) Thanks @RanSHammer and @849261680.
 - Anthropic/Codex/ACP/agent recovery: defer Anthropic stream start events until `message_start`, strip stale compaction thinking signatures before Anthropic replay, detect unsigned thinking-only stalls, refresh prompt fences after compaction writes, reject empty completion handoffs, preserve parent streaming-off overrides/shared progress commentary, forward heartbeat metadata to context-engine hooks, and cover Codex session/thread migration edge cases. (#90667, #90697, #90163, #90108, #89874, #89505, #90632, #89302, #90729, #90317, #90319) Thanks @openperf, @100yenadmin, and @ooiuuii.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Discord/ACP: thread messages under the same configured parent channel now get distinct persistent ACP session keys, and reset/new commands clear stale configured-format metadata even when reverse lookup cannot reconstruct a runtime thread binding.
 - Channel content boundaries: QQBot now strips reasoning/thinking tags before sending, preserving final answers while hiding internal model narration from users. (#89913, #90132) Thanks @openperf.
 - Agents/MCP/providers: coerce non-text/image MCP tool-result blocks before they reach provider converters, preserving valid images and turning richer MCP content into text instead of malformed image blocks. (#90710, #90728) Thanks @RanSHammer and @849261680.
 - Anthropic/Codex/ACP/agent recovery: defer Anthropic stream start events until `message_start`, strip stale compaction thinking signatures before Anthropic replay, detect unsigned thinking-only stalls, refresh prompt fences after compaction writes, reject empty completion handoffs, preserve parent streaming-off overrides/shared progress commentary, forward heartbeat metadata to context-engine hooks, and cover Codex session/thread migration edge cases. (#90667, #90697, #90163, #90108, #89874, #89505, #90632, #89302, #90729, #90317, #90319) Thanks @openperf, @100yenadmin, and @ooiuuii.

--- a/extensions/discord/src/channel.conversation.test.ts
+++ b/extensions/discord/src/channel.conversation.test.ts
@@ -66,7 +66,8 @@ describe("Discord conversation identity", () => {
           parentConversationId: resolved.parentConversationId,
         }),
     ).toEqual({
-      conversationId: "channel:1510164477642014999",
+      conversationId: "1510164477642014740",
+      parentConversationId: "channel:1510164477642014999",
       matchPriority: 1,
     });
   });

--- a/extensions/discord/src/channel.conversation.ts
+++ b/extensions/discord/src/channel.conversation.ts
@@ -53,7 +53,8 @@ export function matchDiscordAcpConversation(params: {
     params.bindingConversationId === params.parentConversationId
   ) {
     return {
-      conversationId: params.parentConversationId,
+      conversationId: params.conversationId,
+      parentConversationId: params.parentConversationId,
       matchPriority: 1,
     };
   }

--- a/src/acp/persistent-bindings.lifecycle.test.ts
+++ b/src/acp/persistent-bindings.lifecycle.test.ts
@@ -231,8 +231,32 @@ describe("resetAcpSessionInPlace", () => {
     expect(managerMocks.updateSessionRuntimeOptions).not.toHaveBeenCalled();
   });
 
-  it("falls back to close-only resets when no configured binding exists", async () => {
+  it("clears metadata for configured-format session keys even when config lookup misses", async () => {
     const sessionKey = "agent:claude:acp:binding:demo-binding:default:9373ab192b2317f4";
+    sessionMetaMocks.readAcpSessionEntry.mockReturnValue({
+      acp: {
+        agent: "claude",
+        mode: "persistent",
+        backend: "acpx",
+      },
+    });
+
+    const result = await resetAcpSessionInPlace({
+      cfg: baseCfg,
+      sessionKey,
+      reason: "reset",
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(resolveMocks.resolveConfiguredAcpBindingSpecBySessionKey).toHaveBeenCalledTimes(1);
+    const closeArgs = expectCloseArgs();
+    expect(closeArgs.sessionKey).toBe(sessionKey);
+    expect(closeArgs.clearMeta).toBe(true);
+    expect(managerMocks.initializeSession).not.toHaveBeenCalled();
+  });
+
+  it("does not clear metadata for dynamic ACP session keys outside the configured format", async () => {
+    const sessionKey = "agent:claude:acp:sms:+155****0123";
     sessionMetaMocks.readAcpSessionEntry.mockReturnValue({
       acp: {
         agent: "claude",

--- a/src/acp/persistent-bindings.lifecycle.ts
+++ b/src/acp/persistent-bindings.lifecycle.ts
@@ -9,6 +9,7 @@ import { resolveConfiguredAcpBindingSpecBySessionKey } from "./persistent-bindin
 import {
   buildConfiguredAcpSessionKey,
   normalizeText,
+  parseConfiguredAcpSessionKey,
   type ConfiguredAcpBindingSpec,
   type ResolvedConfiguredAcpBinding,
 } from "./persistent-bindings.types.js";
@@ -162,7 +163,9 @@ export async function resetAcpSessionInPlace(params: {
     cfg: params.cfg,
     sessionKey,
   });
-  const clearMeta = params.clearMeta ?? Boolean(configuredBinding);
+  const clearMeta =
+    params.clearMeta ??
+    (Boolean(configuredBinding) || Boolean(parseConfiguredAcpSessionKey(sessionKey)));
   if (!meta) {
     if (clearMeta) {
       return { ok: true };

--- a/src/acp/persistent-bindings.test.ts
+++ b/src/acp/persistent-bindings.test.ts
@@ -46,7 +46,7 @@ const discordBindings: ChannelConfiguredBindingProvider = {
       parentConversationId !== conversationId &&
       compiledBinding.conversationId === parentConversationId
     ) {
-      return { conversationId: parentConversationId, matchPriority: 1 };
+      return { conversationId, parentConversationId, matchPriority: 1 };
     }
     return null;
   },
@@ -396,7 +396,7 @@ describe("resolveConfiguredAcpBindingRecord", () => {
     expect(resolved?.record.metadata?.source).toBe("config");
   });
 
-  it("falls back to parent discord channel when conversation is a thread id", () => {
+  it("inherits parent discord channel bindings using the thread conversation id", () => {
     const cfg = createCfgWithBindings([
       createDiscordBinding({
         agentId: "codex",
@@ -408,8 +408,10 @@ describe("resolveConfiguredAcpBindingRecord", () => {
       parentConversationId: "channel-parent-1",
     });
 
-    expect(resolved?.spec.conversationId).toBe("channel-parent-1");
-    expect(resolved?.record.conversation.conversationId).toBe("channel-parent-1");
+    expect(resolved?.spec.conversationId).toBe("thread-123");
+    expect(resolved?.spec.parentConversationId).toBe("channel-parent-1");
+    expect(resolved?.record.conversation.conversationId).toBe("thread-123");
+    expect(resolved?.record.conversation.parentConversationId).toBe("channel-parent-1");
   });
 
   it("prefers direct discord thread binding over parent channel fallback", () => {

--- a/src/channels/plugins/acp-bindings.test.ts
+++ b/src/channels/plugins/acp-bindings.test.ts
@@ -69,7 +69,7 @@ function createDiscordAcpPlugin(overrides?: {
           return { conversationId, matchPriority: 2 };
         }
         if (parentConversationId && compiledBinding.conversationId === parentConversationId) {
-          return { conversationId: parentConversationId, matchPriority: 1 };
+          return { conversationId, parentConversationId, matchPriority: 1 };
         }
         return null;
       },
@@ -191,6 +191,58 @@ describe("configured binding registry", () => {
       channel: "discord",
       accountId: "default",
       conversationId: "1479098716916023408",
+    });
+
+    expect(resolved).toBeNull();
+  });
+
+  it("assigns distinct session keys to different threads under the same parent channel", () => {
+    const plugin = createDiscordAcpPlugin();
+    getChannelPluginMock.mockReturnValue(plugin);
+    const parentChannelId = "1479098716916023408";
+
+    const thread1 = bindingRegistry.resolveConfiguredBindingRecord({
+      cfg: createConfig() as never,
+      channel: "discord",
+      accountId: "default",
+      conversationId: "1111111111111111111",
+      parentConversationId: parentChannelId,
+    });
+
+    const thread2 = bindingRegistry.resolveConfiguredBindingRecord({
+      cfg: createConfig() as never,
+      channel: "discord",
+      accountId: "default",
+      conversationId: "2222222222222222222",
+      parentConversationId: parentChannelId,
+    });
+
+    expect(thread1?.record.targetSessionKey).not.toBe(thread2?.record.targetSessionKey);
+    expect(thread1?.record.conversation).toMatchObject({
+      conversationId: "1111111111111111111",
+      parentConversationId: parentChannelId,
+    });
+    expect(thread2?.record.conversation).toMatchObject({
+      conversationId: "2222222222222222222",
+      parentConversationId: parentChannelId,
+    });
+  });
+
+  it("returns null for per-thread session keys via reverse lookup", () => {
+    const plugin = createDiscordAcpPlugin();
+    getChannelPluginMock.mockReturnValue(plugin);
+    const threadSessionKey = buildConfiguredAcpSessionKey({
+      channel: "discord",
+      accountId: "default",
+      conversationId: "1111111111111111111",
+      agentId: "codex",
+      mode: "persistent",
+      backend: "acpx",
+    });
+
+    const resolved = bindingRegistry.resolveConfiguredBindingRecordBySessionKey({
+      cfg: createConfig() as never,
+      sessionKey: threadSessionKey,
     });
 
     expect(resolved).toBeNull();


### PR DESCRIPTION
## Summary
- preserve the runtime Discord thread id when a configured ACP binding matches via its parent channel id
- keep sibling Discord threads under the same configured parent channel on distinct persistent ACP session keys
- clear stale configured-format ACP metadata on reset/new even when reverse lookup cannot reconstruct the runtime thread binding

## Context
This is a current-main replacement for stale PR #64322 / issue #64199. The existing PR targets older Discord channel files and cannot be applied cleanly to the current refactored Discord conversation surface. This keeps the same root-cause fix on today's code path.

## Test plan
- `pnpm test src/channels/plugins/acp-bindings.test.ts src/acp/persistent-bindings.lifecycle.test.ts`
- `pnpm exec oxfmt --check --threads=1 extensions/discord/src/channel.conversation.ts src/channels/plugins/acp-bindings.test.ts src/acp/persistent-bindings.lifecycle.ts src/acp/persistent-bindings.lifecycle.test.ts`
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false corepack pnpm check:changed --timed`
