### PR TITLE
feat(skills): add webwright skill

### DIFF
--- a/skills/webwright/SKILL.md
+++ b/skills/webwright/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: webwright
+description: "Run long-horizon, multi-step browser automation by delegating to the Microsoft webwright CLI, which writes and executes Playwright scripts to drive a real Chromium browser. Use for logins, multi-page forms, checkout/wizard flows, and repeatable site navigation; not for simple single-page reads."
+homepage: https://github.com/microsoft/webwright
+license: MIT
+metadata:
+  {
+    "openclaw":
+      {
+        "emoji": "🕸️",
+        "requires": { "bins": ["webwright"], "config": ["skills.entries.webwright.enabled"] },
+        "os": ["darwin", "linux"],
+      },
+  }
+---
+
+# Webwright
+
+Delegate browser tasks to the `webwright` CLI. Webwright is a code-as-action web
+agent: an LLM writes and runs Playwright scripts to drive a real Chromium browser,
+which is more robust and repeatable than click-by-click automation.
+
+## When to use
+
+- Multi-step web flows: logins, multi-page forms, checkout/wizard flows.
+- Long-horizon navigation across several pages where state must be carried.
+- Repeatable site tasks where you want a reusable generated script as the artifact.
+
+## When NOT to use
+
+- Simple single-page reads or extraction — use `web_fetch` / built-in web tools.
+- Anything that does not actually require a driven browser.
+
+## Preflight (do this before the first run)
+
+Run `webwright doctor` first — it checks Python, Playwright, Chromium, the
+provider key, and plugins in one shot. Then confirm:
+
+1. `webwright` is on PATH (this skill is gated on it). If missing, see
+   `references/setup.md`.
+2. Chromium is installed for Playwright: `playwright install chromium`.
+3. A provider API key is set in the environment for the model config you pick:
+   `OPENAI_API_KEY` (default `model_openai.yaml`), `ANTHROPIC_API_KEY`
+   (`model_claude.yaml`), or `OPENROUTER_API_KEY` (`model_openrouter.yaml`).
+4. The `python`, `python3`, and `playwright` that webwright's generated scripts
+   will invoke must be webwright's own install (with Chromium). If you installed
+   webwright in a venv, activate it (or prepend its `bin` to `PATH`) before
+   running — otherwise generated scripts can pick up a different system Python
+   that lacks the browser. See `references/setup.md`.
+5. Choose an output directory INSIDE the current workspace. Never write into
+   `~/.openclaw`, `$OPENCLAW_STATE_DIR`, or any active OpenClaw state directory.
+
+## Invocation
+
+The CLI uses a `main` subcommand:
+
+```bash
+webwright main \
+  -t "TASK INSTRUCTION" \
+  --start-url "https://example.com" \
+  -c base.yaml -c model_openai.yaml \
+  --task-id my_task \
+  -o ./webwright-out/my_task
+```
+
+`-c` defaults to `base.yaml model_openai.yaml`. You can also stack inline
+overrides, e.g. `-c agent.step_limit=20` to cap the agent's step budget.
+
+Then read the run artifacts (generated `final_script.py`, `plan.md`, step logs,
+screenshots under `final_runs/run_<id>/`) from the `-o` directory and report the
+generated script path to the user.
+
+See `references/cli.md` for every flag, config stacking, and the output layout.
+
+## Hard rules
+
+- Always pass `-o` pointing inside the workspace; never inside OpenClaw state dirs.
+- Always pass `--start-url` and a specific, scoped `-t` task.
+- Browser runs take real actions on live sites and spend API tokens. Only run on
+  user-authorized tasks and sites. Do not perform destructive actions or submit
+  credentials unless the user explicitly provided them for this task.
+- Pick exactly one model config (`model_openai.yaml`, `model_claude.yaml`,
+  `model_openrouter.yaml`) whose matching API key is present in the environment.
+
+## Examples
+
+Search flights and read the results:
+
+```bash
+webwright main -t "Search flights SEA to JFK departing 2026-08-15 returning 2026-08-20" \
+  --start-url "https://www.google.com/flights" \
+  -c base.yaml -c model_openai.yaml --task-id flights -o ./webwright-out/flights
+```
+
+Extract a table behind a multi-step navigation (Claude model):
+
+```bash
+webwright main -t "Open the docs, go to the pricing page, and list every plan and price" \
+  --start-url "https://example.com" \
+  -c base.yaml -c model_claude.yaml --task-id pricing -o ./webwright-out/pricing
+```

--- a/skills/webwright/SKILL.md
+++ b/skills/webwright/SKILL.md
@@ -33,8 +33,18 @@ which is more robust and repeatable than click-by-click automation.
 
 ## Preflight (do this before the first run)
 
-Run `webwright doctor` first — it checks Python, Playwright, Chromium, the
-provider key, and plugins in one shot. Then confirm:
+This skill is opt-in. It only becomes available once
+`skills.entries.webwright.enabled` is `true` (an unset value counts as off), so
+enable it first:
+
+```bash
+openclaw config set skills.entries.webwright.enabled true
+```
+
+Run `webwright doctor` next as a setup check. Note its key check is
+OpenAI-specific: it always runs an `OpenAI Key` check, so if you intend to use
+Anthropic or OpenRouter, a doctor `OpenAI Key FAIL` is expected and is NOT a
+blocker — verify your chosen provider's key separately (step 3). Then confirm:
 
 1. `webwright` is on PATH (this skill is gated on it). If missing, see
    `references/setup.md`.
@@ -77,8 +87,13 @@ See `references/cli.md` for every flag, config stacking, and the output layout.
 - Always pass `-o` pointing inside the workspace; never inside OpenClaw state dirs.
 - Always pass `--start-url` and a specific, scoped `-t` task.
 - Browser runs take real actions on live sites and spend API tokens. Only run on
-  user-authorized tasks and sites. Do not perform destructive actions or submit
-  credentials unless the user explicitly provided them for this task.
+  user-authorized tasks and sites, and avoid destructive actions.
+- Never put secrets in the `-t` task text. The task is sent to the model provider
+  and recorded in run artifacts (trajectories, logs, process args), so passwords
+  or tokens placed there are exposed. For login-walled tasks, pass credentials via
+  environment variables and tell the agent the env var NAMES to read in its
+  generated script (e.g. "log in using $SITE_USER / $SITE_PASS"), or pre-authenticate
+  a persistent browser profile — never the literal secret values.
 - Pick exactly one model config (`model_openai.yaml`, `model_claude.yaml`,
   `model_openrouter.yaml`) whose matching API key is present in the environment.
 

--- a/skills/webwright/references/cli.md
+++ b/skills/webwright/references/cli.md
@@ -44,11 +44,24 @@ and any screenshots captured for page inspection. After a run:
 2. Summarize the result from the logs / final output in the directory.
 3. The generated script can be re-run or adapted for repeatable automation.
 
+## Secrets
+
+Never place credentials or tokens in the `-t` task text or in a config file.
+Webwright sends the task to the model provider and records run artifacts
+(trajectories, logs, process args), so anything in `-t` is exposed. For
+login-walled tasks, export credentials as environment variables and instruct the
+agent (in the task) to read them by NAME inside its generated script — e.g.
+"log in with the values in $SITE_USER and $SITE_PASS" — or pre-authenticate a
+persistent browser profile. Never pass the literal secret values.
+
 ## Troubleshooting
 
 - `webwright: command not found` → not installed; see `setup.md`.
 - Browser fails to launch / missing Chromium → run `playwright install chromium`.
+- `webwright doctor` shows `OpenAI Key FAIL` but you use Anthropic/OpenRouter →
+  expected. doctor's key check is OpenAI-only; verify your chosen provider's key
+  is exported instead.
 - Auth/401 from the model → the provider API key for the chosen `-c` model config
   is missing or wrong.
-- Task stalls on a login wall → webwright will not invent credentials; supply them
-  explicitly in the task only when the user authorized it.
+- Task stalls on a login wall → webwright will not invent credentials; provide
+  them via environment variable names (see Secrets), only when the user authorized it.

--- a/skills/webwright/references/cli.md
+++ b/skills/webwright/references/cli.md
@@ -1,0 +1,54 @@
+# Webwright CLI reference
+
+Commands:
+
+- `webwright doctor` — validate the local setup (Python, Playwright, Chromium,
+  provider key, plugins). Run this first.
+- `webwright main [OPTIONS]` — run a task. This is the command the skill uses.
+
+## `webwright main` flags
+
+| Flag                 | Meaning                                                             |
+| -------------------- | ------------------------------------------------------------------- |
+| `-t`, `--task`       | The natural-language task instruction (quote it). Required.         |
+| `--start-url`        | The URL the browser opens first.                                    |
+| `--task-id`          | A short id used in the output directory name.                       |
+| `-c`, `--config`     | Config spec. Repeatable; later specs override earlier.              |
+| `-o`, `--output-dir` | Output directory for run artifacts. Keep this inside the workspace. |
+| `--debug`            | Launch a headed browser with devtools and keep it open.             |
+
+`-c` defaults to `base.yaml model_openai.yaml`. Run `webwright main --help` for
+the full, version-specific flag list.
+
+## Config stacking and inline overrides
+
+A `-c` spec is resolved as a file path, then as a builtin config name (e.g.
+`base.yaml`), and otherwise as an inline `key=value` override (dotted keys nest).
+
+```bash
+# base + model + an inline override that caps the agent step budget
+webwright main -c base.yaml -c model_openai.yaml -c agent.step_limit=20 \
+  -t "..." --start-url "..." -o ./out
+```
+
+Pick exactly one model config (`model_openai.yaml`, `model_claude.yaml`, or
+`model_openrouter.yaml`) and ensure its provider API key is exported.
+
+## Output artifacts
+
+Webwright writes run artifacts into the `-o` directory, including the generated
+Python/Playwright script (the durable, reusable "code-as-action" output), run logs,
+and any screenshots captured for page inspection. After a run:
+
+1. Report the generated script path to the user.
+2. Summarize the result from the logs / final output in the directory.
+3. The generated script can be re-run or adapted for repeatable automation.
+
+## Troubleshooting
+
+- `webwright: command not found` → not installed; see `setup.md`.
+- Browser fails to launch / missing Chromium → run `playwright install chromium`.
+- Auth/401 from the model → the provider API key for the chosen `-c` model config
+  is missing or wrong.
+- Task stalls on a login wall → webwright will not invent credentials; supply them
+  explicitly in the task only when the user authorized it.

--- a/skills/webwright/references/setup.md
+++ b/skills/webwright/references/setup.md
@@ -48,8 +48,18 @@ The webwright repo ships builtin configs (e.g. `base.yaml`, `model_openai.yaml`,
 edit them, or keep project-specific configs in your workspace. Later `-c` specs
 override earlier ones, and a `key=value` spec applies an inline override.
 
+## Enable the skill
+
+This bundled skill is opt-in: it stays hidden from the model until you enable it
+(an unset `skills.entries.webwright.enabled` counts as off):
+
+```bash
+openclaw config set skills.entries.webwright.enabled true
+```
+
 ## Requirements summary
 
+- `skills.entries.webwright.enabled: true` (the opt-in above)
 - Python >= 3.10
 - Playwright >= 1.45 with Chromium (`playwright install chromium`)
 - A provider API key in the environment

--- a/skills/webwright/references/setup.md
+++ b/skills/webwright/references/setup.md
@@ -1,0 +1,55 @@
+# Webwright setup
+
+Webwright is a Python CLI (Python 3.10+) that drives Chromium via Playwright.
+
+## Install the CLI
+
+Webwright is distributed from source (MIT, https://github.com/microsoft/webwright):
+
+```bash
+git clone https://github.com/microsoft/webwright
+cd webwright
+python3 -m venv .venv && source .venv/bin/activate   # recommended: isolate the install
+pip install -e .
+playwright install chromium
+```
+
+After install, the `webwright` console command is available. Confirm the setup:
+
+```bash
+webwright doctor
+```
+
+> Environment gotcha: webwright runs the agent's generated scripts in a shell
+> subprocess and they call `python`/`python3`/`playwright` from `PATH`. Make sure
+> the install above is the one on `PATH` when you run a task (activate the venv,
+> or prepend its `bin` to `PATH`). Otherwise generated scripts may use a different
+> system Python that has no Chromium, and the browser launch fails.
+
+## Provider API keys
+
+Set the key matching the model config you pass with `-c`:
+
+- OpenAI configs: `export OPENAI_API_KEY=...`
+- Anthropic configs: `export ANTHROPIC_API_KEY=...`
+- OpenRouter configs: `export OPENROUTER_API_KEY=...`
+
+## Config files
+
+Webwright reads stackable YAML config files via repeated `-c` flags. A typical run
+stacks a base config with a model config:
+
+```bash
+webwright main -c base.yaml -c model_openai.yaml ...
+```
+
+The webwright repo ships builtin configs (e.g. `base.yaml`, `model_openai.yaml`,
+`model_claude.yaml`, `model_openrouter.yaml`). Reference them by name, copy and
+edit them, or keep project-specific configs in your workspace. Later `-c` specs
+override earlier ones, and a `key=value` spec applies an inline override.
+
+## Requirements summary
+
+- Python >= 3.10
+- Playwright >= 1.45 with Chromium (`playwright install chromium`)
+- A provider API key in the environment


### PR DESCRIPTION
## Summary

Adds a bundled `webwright` skill that teaches the agent to delegate long-horizon,
multi-step browser automation to Microsoft's [`webwright`](https://github.com/microsoft/webwright)
CLI (MIT). Webwright is a code-as-action web agent: an LLM writes and runs
Playwright scripts to drive a real Chromium browser, which is more robust and
repeatable than click-by-click automation.

- Pure `SKILL.md` + `references/` (no runtime code); the agent shells out to the
  `webwright` CLI. Same pattern as the existing `coding-agent` skill.
- Gated on the `webwright` binary and `skills.entries.webwright.enabled`.
- Files: `skills/webwright/{SKILL.md,references/setup.md,references/cli.md}`.
- No `CHANGELOG.md` edit (release-only per `AGENTS.md`).

There is currently no bundled browser-automation skill in `skills/` (the
`openclaw browser` CLI is a separate core surface), so this fills that gap with a
long-horizon, script-generating approach.

## Policy note (please read)

I'm aware of the ClawSweeper guidance that optional skill bundles often route to
ClawHub. This skill is **already published to ClawHub** at
`https://clawhub.ai/hansraj316/webwright` (`webwright@1.0.0`). I'm opening this PR
in case maintainers would prefer it bundled in core given there's no existing
bundled browser-automation skill — happy to close in favor of ClawHub if that's
the call.

## Verification

- `python3 skills/skill-creator/scripts/quick_validate.py skills/webwright` → `Skill is valid!`
- `pnpm test src/skills/loading/frontmatter.test.ts` → 8/8 pass
- Real frontmatter loader + `resolveOpenClawManifestRequires` confirm gating
  resolves to `bins:[webwright]`, `config:[skills.entries.webwright.enabled]`.

## Real behavior proof

- **Behavior addressed:** new bundled `webwright` skill for browser automation.
- **Real environment tested:** macOS (Darwin 25.3.0); webwright 0.1.0 in a venv,
  Playwright Chromium 1223, model gpt-5.4 via `OPENAI_API_KEY`.
- **Exact steps or command run after this patch:**
  `webwright main -t "Open the page, then report its title and main heading text." --start-url https://example.com -c base.yaml -c model_openai.yaml -c agent.step_limit=6 -c agent.require_self_reflection_success=false --task-id proof2 -o ./webwright-out/proof2`
- **Evidence after fix:** generated `final_script.py`, step logs, and a rendered
  screenshot under `final_runs/run_2/`; CLI exited 0 with `Task finished.`
  (Screenshot not committed per `AGENTS.md` proof-image rule; available on request.)
- **Observed result after fix:** extracted `Title=Example Domain; heading=Example Domain`.
- **What was not tested:** Anthropic/OpenRouter model configs (no keys at test
  time); Linux; a full `self_reflection` PASS (the run was intentionally bounded
  for cost, so the strict benchmark judge returned `predicted_label: 0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
