### PR TITLE
docs(imessage): require DisableLibraryValidation on modern macOS; document macOS 26 injection gates

### DIFF
--- a/docs/channels/imessage.md
+++ b/docs/channels/imessage.md
@@ -216,20 +216,22 @@ Treat this as a deliberate operational choice, not a default. If your threat mod
    sudo defaults write /Library/Preferences/com.apple.security.libraryvalidation.plist DisableLibraryValidation -bool true
    ```
 
-   **macOS 26 (Tahoe) specifics:**
-   - **26.0-26.4.x:** SIP off plus the `DisableLibraryValidation` command above is sufficient to inject the helper. No boot-args needed. This is the most common missing step when injection fails on Tahoe.
-   - **26.5 and later:** Apple tightened AMFI further. SIP-off plus library-validation-disable is no longer enough, and `imsg launch` fails at load with the AMFI rejection above. Getting injection working again requires disabling AMFI signature enforcement system-wide via boot-args, which is **unsupported and a significant security tradeoff** (it weakens code-signing across the whole OS):
+   **macOS 26 (Tahoe), verified on 26.5.1:** SIP off **plus** the `DisableLibraryValidation` command above is sufficient to inject the helper across 26.0 through 26.5.x. **No boot-args are required.** The plist is the decisive factor and the most common missing step when injection fails on Tahoe:
+   - **With the plist:** `imsg launch` injects and `imsg status` reports `advanced_features: true`.
+   - **Without the plist (even with SIP off):** `imsg launch` fails with `Failed to launch: Timeout waiting for Messages.app to initialize`. AMFI rejects the adhoc helper at load, so the bridge never becomes ready and the launch times out. That timeout is the symptom most people hit on Tahoe, and the fix is the plist above, not anything more drastic.
 
-     ```bash
-     sudo nvram boot-args="amfi_get_out_of_my_way=1 -arm64e_preview_abi"
-     # reboot, then re-sign the helper and launch
-     codesign -f -s - "$(brew --prefix)/opt/imsg/libexec/imsg-bridge-helper.dylib"
-     imsg launch
-     ```
+   This was confirmed with a controlled before/after on macOS 26.5.1 (Apple Silicon): with the plist, the dylib maps into `Messages.app` and the bridge comes up; remove the plist and reboot, and `imsg launch` produces the timeout failure above with the dylib not mapped.
 
-     If that tradeoff is unacceptable, stay on basic mode (below) on 26.5, or keep the iMessage host on 26.4.x.
+   **Last resort (rarely needed, unsupported):** if SIP-off plus the `DisableLibraryValidation` plist still is not enough on a specific host (some bare-metal or beta configurations have reported needing more), you can disable AMFI signature enforcement system-wide via boot-args. This weakens code-signing across the whole OS, so treat it as a last resort, not a routine Tahoe step:
 
-   - If `imsg launch` injection or specific `selectors` start returning false after a macOS upgrade, this gate is the usual cause. Check your SIP and library-validation state (and `imsg` release notes) before assuming the SIP step itself failed.
+   ```bash
+   sudo nvram boot-args="amfi_get_out_of_my_way=1 -arm64e_preview_abi"
+   # reboot, then re-sign the helper and launch
+   codesign -f -s - "$(brew --prefix)/opt/imsg/libexec/imsg-bridge-helper.dylib"
+   imsg launch
+   ```
+
+   - If `imsg launch` injection or specific `selectors` start returning false after a macOS upgrade, this gate is the usual cause. Check your SIP and library-validation state before assuming the SIP step itself failed.
 
    Follow Apple's Recovery-mode flow for your Mac to disable SIP before running `imsg launch`.
 

--- a/docs/channels/imessage.md
+++ b/docs/channels/imessage.md
@@ -205,11 +205,31 @@ Treat this as a deliberate operational choice, not a default. If your threat mod
 
    The `imsg status --json` output reports `bridge_version`, `rpc_methods`, and per-method `selectors` so you can see what the current build supports before you start.
 
-2. **Disable System Integrity Protection.** This is macOS-version-specific because the underlying Apple requirement depends on the OS and hardware:
-   - **macOS 10.13–10.15 (Sierra–Catalina):** disable Library Validation via Terminal, reboot to Recovery Mode, run `csrutil disable`, restart.
+2. **Disable System Integrity Protection, and (on modern macOS) Library Validation.** Injecting a non-Apple helper dylib into the Apple-signed `Messages.app` needs SIP off **and** library validation relaxed. The Recovery-mode SIP step is macOS-version-specific:
+   - **macOS 10.13-10.15 (Sierra-Catalina):** disable Library Validation via Terminal, reboot to Recovery Mode, run `csrutil disable`, restart.
    - **macOS 11+ (Big Sur and later), Intel:** Recovery Mode (or Internet Recovery), `csrutil disable`, restart.
-   - **macOS 11+, Apple Silicon:** power-button startup sequence to enter Recovery; on recent macOS versions hold the **Left Shift** key when you click Continue, then `csrutil disable`. Virtual-machine setups follow a separate flow — take a VM snapshot first.
-   - **macOS 26 / Tahoe:** library-validation policies and `imagent` private-entitlement checks have tightened further; `imsg` may need an updated build to keep up. If `imsg launch` injection or specific `selectors` start returning false after a macOS major upgrade, check `imsg`'s release notes before assuming the SIP step succeeded.
+   - **macOS 11+, Apple Silicon:** power-button startup sequence to enter Recovery; on recent macOS versions hold the **Left Shift** key when you click Continue, then `csrutil disable`. Virtual-machine setups follow a separate flow, so take a VM snapshot first.
+
+   **On macOS 11 and later, `csrutil disable` alone is usually not enough.** Apple still enforces library validation against `Messages.app` as a platform binary, so an adhoc-signed helper is rejected (`Library Validation failed: ... platform binary, but mapped file is not`) even with SIP off. After disabling SIP, also disable library validation and reboot:
+
+   ```bash
+   sudo defaults write /Library/Preferences/com.apple.security.libraryvalidation.plist DisableLibraryValidation -bool true
+   ```
+
+   **macOS 26 (Tahoe) specifics:**
+   - **26.0-26.4.x:** SIP off plus the `DisableLibraryValidation` command above is sufficient to inject the helper. No boot-args needed. This is the most common missing step when injection fails on Tahoe.
+   - **26.5 and later:** Apple tightened AMFI further. SIP-off plus library-validation-disable is no longer enough, and `imsg launch` fails at load with the AMFI rejection above. Getting injection working again requires disabling AMFI signature enforcement system-wide via boot-args, which is **unsupported and a significant security tradeoff** (it weakens code-signing across the whole OS):
+
+     ```bash
+     sudo nvram boot-args="amfi_get_out_of_my_way=1 -arm64e_preview_abi"
+     # reboot, then re-sign the helper and launch
+     codesign -f -s - "$(brew --prefix)/opt/imsg/libexec/imsg-bridge-helper.dylib"
+     imsg launch
+     ```
+
+     If that tradeoff is unacceptable, stay on basic mode (below) on 26.5, or keep the iMessage host on 26.4.x.
+
+   - If `imsg launch` injection or specific `selectors` start returning false after a macOS upgrade, this gate is the usual cause. Check your SIP and library-validation state (and `imsg` release notes) before assuming the SIP step itself failed.
 
    Follow Apple's Recovery-mode flow for your Mac to disable SIP before running `imsg launch`.
 

--- a/docs/channels/imessage.md
+++ b/docs/channels/imessage.md
@@ -222,16 +222,7 @@ Treat this as a deliberate operational choice, not a default. If your threat mod
 
    This was confirmed with a controlled before/after on macOS 26.5.1 (Apple Silicon): with the plist, the dylib maps into `Messages.app` and the bridge comes up; remove the plist and reboot, and `imsg launch` produces the timeout failure above with the dylib not mapped.
 
-   **Last resort (rarely needed, unsupported):** if SIP-off plus the `DisableLibraryValidation` plist still is not enough on a specific host (some bare-metal or beta configurations have reported needing more), you can disable AMFI signature enforcement system-wide via boot-args. This weakens code-signing across the whole OS, so treat it as a last resort, not a routine Tahoe step:
-
-   ```bash
-   sudo nvram boot-args="amfi_get_out_of_my_way=1 -arm64e_preview_abi"
-   # reboot, then re-sign the helper and launch
-   codesign -f -s - "$(brew --prefix)/opt/imsg/libexec/imsg-bridge-helper.dylib"
-   imsg launch
-   ```
-
-   - If `imsg launch` injection or specific `selectors` start returning false after a macOS upgrade, this gate is the usual cause. Check your SIP and library-validation state before assuming the SIP step itself failed.
+   If `imsg launch` injection or specific `selectors` start returning false after a macOS upgrade, this gate is the usual cause. Check your SIP and library-validation state before assuming the SIP step itself failed. If those settings are correct and the bridge still cannot inject, collect `imsg status --json` plus the `imsg launch` output and report it to the `imsg` project instead of weakening additional system-wide security controls.
 
    Follow Apple's Recovery-mode flow for your Mac to disable SIP before running `imsg launch`.
 


### PR DESCRIPTION
## Summary

The iMessage private-API setup docs scoped the `DisableLibraryValidation` step to **macOS 10.13-10.15 only**, implying modern macOS does not need it. That is wrong: on macOS 11+ (and on macOS 26 / Tahoe), `csrutil disable` alone is not enough because Apple still enforces library validation against `Messages.app` as a platform binary. The adhoc helper dylib can be rejected with `Library Validation failed: ... platform binary, but mapped file is not` even with SIP off.

This rewrites the setup step in `docs/channels/imessage.md` to:

- State that on **macOS 11+**, disabling SIP must be paired with disabling Library Validation, and give the exact `defaults write ... DisableLibraryValidation` command plus the AMFI rejection string to recognize.
- Add a **macOS 26 (Tahoe) breakdown** verified on 26.5.1:
  - SIP off + the `DisableLibraryValidation` plist is sufficient across 26.0 through 26.5.x.
  - No boot-args are required.
  - Without the plist, `imsg launch` can time out while AMFI rejects the helper before the bridge becomes ready.
- Remove the unsupported AMFI boot-args fallback from the public docs. If SIP and Library Validation are correct but injection still fails, the docs now tell operators to collect `imsg status --json` plus `imsg launch` output and report it upstream instead of weakening additional system-wide security controls.

Docs-only change. No runtime/behavior changes.

## Verification

- `pnpm docs:list`
- `git diff --check`
- `pnpm check:docs`
- Setup guidance cross-checked against a working host on macOS 26.4.1 and a controlled before/after on macOS 26.5.1: SIP off + `DisableLibraryValidation = 1` allows bridge injection; removing the plist and rebooting produces the documented `imsg launch` timeout with the helper dylib not mapped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
