### PR TITLE
fix: store acpx process state in sqlite

### DIFF
--- a/extensions/acpx/doctor-contract-api.test.ts
+++ b/extensions/acpx/doctor-contract-api.test.ts
@@ -1,0 +1,280 @@
+// ACPX tests cover doctor migration of legacy runtime state.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  createPluginStateKeyedStoreForTests,
+  resetPluginStateStoreForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import type {
+  OpenKeyedStoreOptions,
+  PluginDoctorStateMigrationContext,
+} from "openclaw/plugin-sdk/runtime-doctor";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { stateMigrations } from "./doctor-contract-api.js";
+import { openAcpxProcessLeaseStateStore, type AcpxProcessLease } from "./src/process-lease.js";
+import {
+  ACPX_GATEWAY_INSTANCE_KEY,
+  ACPX_GATEWAY_INSTANCE_MAX_ENTRIES,
+  ACPX_GATEWAY_INSTANCE_NAMESPACE,
+  ACPX_LEGACY_GATEWAY_INSTANCE_FILE,
+  ACPX_LEGACY_PROCESS_LEASE_FILE,
+  type AcpxGatewayInstanceRecord,
+} from "./src/state.js";
+
+function createDoctorContext(env: NodeJS.ProcessEnv): PluginDoctorStateMigrationContext {
+  return {
+    openPluginStateKeyedStore<T>(options: OpenKeyedStoreOptions) {
+      return createPluginStateKeyedStoreForTests<T>("acpx", {
+        ...options,
+        env: options.env ?? env,
+      });
+    },
+  };
+}
+
+describe("acpx doctor state migration", () => {
+  let stateDir = "";
+  let env: NodeJS.ProcessEnv;
+
+  beforeEach(async () => {
+    resetPluginStateStoreForTests();
+    stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-acpx-doctor-"));
+    env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+  });
+
+  afterEach(async () => {
+    await fs.rm(stateDir, { recursive: true, force: true });
+  });
+
+  function migrationParams() {
+    return {
+      config: {},
+      env,
+      stateDir,
+      oauthDir: path.join(stateDir, "oauth"),
+      context: createDoctorContext(env),
+    };
+  }
+
+  it("imports legacy gateway identity and open process leases into plugin state", async () => {
+    const gatewayPath = path.join(stateDir, ACPX_LEGACY_GATEWAY_INSTANCE_FILE);
+    const leasePath = path.join(stateDir, "acpx", ACPX_LEGACY_PROCESS_LEASE_FILE);
+    const lease: AcpxProcessLease = {
+      leaseId: "lease-1",
+      gatewayInstanceId: "gw-test",
+      sessionKey: "agent:codex:acp:test",
+      wrapperRoot: path.join(stateDir, "acpx"),
+      wrapperPath: path.join(stateDir, "acpx", "codex-acp-wrapper.mjs"),
+      rootPid: 101,
+      commandHash: "hash",
+      startedAt: 1,
+      state: "open",
+    };
+    await fs.mkdir(path.dirname(leasePath), { recursive: true });
+    await fs.writeFile(gatewayPath, "gw-test\n", "utf8");
+    await fs.writeFile(
+      leasePath,
+      JSON.stringify({
+        version: 1,
+        leases: [
+          lease,
+          {
+            ...lease,
+            leaseId: "closed-lease",
+            state: "closed",
+          },
+        ],
+      }),
+      "utf8",
+    );
+
+    const migration = stateMigrations[0];
+    await expect(migration.detectLegacyState(migrationParams())).resolves.toMatchObject({
+      preview: [
+        expect.stringContaining("ACPX gateway instance id"),
+        expect.stringContaining("1 open lease"),
+      ],
+    });
+
+    const result = await migration.migrateLegacyState(migrationParams());
+
+    expect(result.warnings).toEqual([]);
+    expect(result.changes).toEqual([
+      "Migrated ACPX gateway instance id -> plugin state",
+      expect.stringContaining("Archived ACPX gateway-instance-id legacy source"),
+      "Migrated ACPX process leases -> plugin state (1 imported, 0 already present)",
+      expect.stringContaining("Archived ACPX process-leases legacy source"),
+    ]);
+    await expect(fs.access(gatewayPath)).rejects.toThrow();
+    await expect(fs.access(`${gatewayPath}.migrated`)).resolves.toBeUndefined();
+    await expect(fs.access(leasePath)).rejects.toThrow();
+    await expect(fs.access(`${leasePath}.migrated`)).resolves.toBeUndefined();
+    await expect(
+      createDoctorContext(env)
+        .openPluginStateKeyedStore<AcpxGatewayInstanceRecord>({
+          namespace: ACPX_GATEWAY_INSTANCE_NAMESPACE,
+          maxEntries: ACPX_GATEWAY_INSTANCE_MAX_ENTRIES,
+        })
+        .lookup(ACPX_GATEWAY_INSTANCE_KEY),
+    ).resolves.toMatchObject({ instanceId: "gw-test" });
+    await expect(
+      openAcpxProcessLeaseStateStore(createDoctorContext(env).openPluginStateKeyedStore).lookup(
+        "lease-1",
+      ),
+    ).resolves.toEqual(lease);
+    await expect(
+      openAcpxProcessLeaseStateStore(createDoctorContext(env).openPluginStateKeyedStore).lookup(
+        "closed-lease",
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it("ignores legacy process lease files without open cleanup work", async () => {
+    const leasePath = path.join(stateDir, "acpx", ACPX_LEGACY_PROCESS_LEASE_FILE);
+    await fs.mkdir(path.dirname(leasePath), { recursive: true });
+    await fs.writeFile(
+      leasePath,
+      JSON.stringify({
+        version: 1,
+        leases: [
+          {
+            leaseId: "closed-lease",
+            gatewayInstanceId: "gw-test",
+            sessionKey: "agent:codex:acp:test",
+            wrapperRoot: path.join(stateDir, "acpx"),
+            wrapperPath: path.join(stateDir, "acpx", "codex-acp-wrapper.mjs"),
+            rootPid: 101,
+            commandHash: "hash",
+            startedAt: 1,
+            state: "closed",
+          },
+        ],
+      }),
+      "utf8",
+    );
+
+    const migration = stateMigrations[0];
+
+    await expect(migration.detectLegacyState(migrationParams())).resolves.toBeNull();
+    await expect(migration.migrateLegacyState(migrationParams())).resolves.toEqual({
+      changes: [],
+      warnings: [],
+    });
+    await expect(fs.access(leasePath)).resolves.toBeUndefined();
+  });
+
+  it("leaves legacy leases in place when the canonical gateway id would not reap them", async () => {
+    const gatewayPath = path.join(stateDir, ACPX_LEGACY_GATEWAY_INSTANCE_FILE);
+    const leasePath = path.join(stateDir, "acpx", ACPX_LEGACY_PROCESS_LEASE_FILE);
+    await fs.mkdir(path.dirname(leasePath), { recursive: true });
+    await fs.writeFile(gatewayPath, "legacy-gw\n", "utf8");
+    await fs.writeFile(
+      leasePath,
+      JSON.stringify({
+        version: 1,
+        leases: [
+          {
+            leaseId: "lease-1",
+            gatewayInstanceId: "legacy-gw",
+            sessionKey: "agent:codex:acp:test",
+            wrapperRoot: path.join(stateDir, "acpx"),
+            wrapperPath: path.join(stateDir, "acpx", "codex-acp-wrapper.mjs"),
+            rootPid: 101,
+            commandHash: "hash",
+            startedAt: 1,
+            state: "open",
+          },
+        ],
+      }),
+      "utf8",
+    );
+    await createDoctorContext(env)
+      .openPluginStateKeyedStore<AcpxGatewayInstanceRecord>({
+        namespace: ACPX_GATEWAY_INSTANCE_NAMESPACE,
+        maxEntries: ACPX_GATEWAY_INSTANCE_MAX_ENTRIES,
+      })
+      .register(ACPX_GATEWAY_INSTANCE_KEY, {
+        instanceId: "current-gw",
+        createdAt: 2,
+      });
+    await openAcpxProcessLeaseStateStore(
+      createDoctorContext(env).openPluginStateKeyedStore,
+    ).register("current-lease", {
+      leaseId: "current-lease",
+      gatewayInstanceId: "current-gw",
+      sessionKey: "agent:codex:acp:current",
+      wrapperRoot: path.join(stateDir, "acpx"),
+      wrapperPath: path.join(stateDir, "acpx", "codex-acp-wrapper.mjs"),
+      rootPid: 202,
+      commandHash: "hash-current",
+      startedAt: 2,
+      state: "open",
+    });
+
+    const result = await stateMigrations[0].migrateLegacyState(migrationParams());
+
+    expect(result.changes).toEqual([]);
+    expect(result.warnings).toEqual([
+      "Skipped ACPX process lease migration because legacy leases do not match the canonical gateway instance id; left legacy sources in place for manual cleanup",
+    ]);
+    await expect(fs.access(gatewayPath)).resolves.toBeUndefined();
+    await expect(fs.access(leasePath)).resolves.toBeUndefined();
+    await expect(
+      openAcpxProcessLeaseStateStore(createDoctorContext(env).openPluginStateKeyedStore).lookup(
+        "lease-1",
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it("adopts the legacy gateway id when upgraded startup created only an empty sqlite id", async () => {
+    const gatewayPath = path.join(stateDir, ACPX_LEGACY_GATEWAY_INSTANCE_FILE);
+    const leasePath = path.join(stateDir, "acpx", ACPX_LEGACY_PROCESS_LEASE_FILE);
+    const legacyLease: AcpxProcessLease = {
+      leaseId: "legacy-lease",
+      gatewayInstanceId: "legacy-gw",
+      sessionKey: "agent:codex:acp:test",
+      wrapperRoot: path.join(stateDir, "acpx"),
+      wrapperPath: path.join(stateDir, "acpx", "codex-acp-wrapper.mjs"),
+      rootPid: 101,
+      commandHash: "hash",
+      startedAt: 1,
+      state: "open",
+    };
+    await fs.mkdir(path.dirname(leasePath), { recursive: true });
+    await fs.writeFile(gatewayPath, "legacy-gw\n", "utf8");
+    await fs.writeFile(leasePath, JSON.stringify({ version: 1, leases: [legacyLease] }), "utf8");
+    await createDoctorContext(env)
+      .openPluginStateKeyedStore<AcpxGatewayInstanceRecord>({
+        namespace: ACPX_GATEWAY_INSTANCE_NAMESPACE,
+        maxEntries: ACPX_GATEWAY_INSTANCE_MAX_ENTRIES,
+      })
+      .register(ACPX_GATEWAY_INSTANCE_KEY, {
+        instanceId: "fresh-empty-gw",
+        createdAt: 2,
+      });
+
+    const result = await stateMigrations[0].migrateLegacyState(migrationParams());
+
+    expect(result.warnings).toEqual([]);
+    expect(result.changes).toEqual([
+      "Migrated ACPX gateway instance id -> plugin state",
+      expect.stringContaining("Archived ACPX gateway-instance-id legacy source"),
+      "Migrated ACPX process leases -> plugin state (1 imported, 0 already present)",
+      expect.stringContaining("Archived ACPX process-leases legacy source"),
+    ]);
+    await expect(
+      createDoctorContext(env)
+        .openPluginStateKeyedStore<AcpxGatewayInstanceRecord>({
+          namespace: ACPX_GATEWAY_INSTANCE_NAMESPACE,
+          maxEntries: ACPX_GATEWAY_INSTANCE_MAX_ENTRIES,
+        })
+        .lookup(ACPX_GATEWAY_INSTANCE_KEY),
+    ).resolves.toMatchObject({ instanceId: "legacy-gw" });
+    await expect(
+      openAcpxProcessLeaseStateStore(createDoctorContext(env).openPluginStateKeyedStore).lookup(
+        "legacy-lease",
+      ),
+    ).resolves.toEqual(legacyLease);
+  });
+});

--- a/extensions/acpx/doctor-contract-api.ts
+++ b/extensions/acpx/doctor-contract-api.ts
@@ -1,0 +1,207 @@
+// ACPX doctor contract migrates shipped plugin-owned runtime state.
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { PluginDoctorStateMigration } from "openclaw/plugin-sdk/runtime-doctor";
+import {
+  normalizeAcpxProcessLease,
+  normalizeAcpxProcessLeaseFile,
+  openAcpxProcessLeaseStateStore,
+  type AcpxProcessLease,
+} from "./src/process-lease.js";
+import {
+  ACPX_GATEWAY_INSTANCE_KEY,
+  ACPX_GATEWAY_INSTANCE_MAX_ENTRIES,
+  ACPX_GATEWAY_INSTANCE_NAMESPACE,
+  ACPX_LEGACY_GATEWAY_INSTANCE_FILE,
+  ACPX_LEGACY_PROCESS_LEASE_FILE,
+  normalizeAcpxGatewayInstanceRecord,
+  type AcpxGatewayInstanceRecord,
+} from "./src/state.js";
+
+function resolveLegacyGatewayInstancePath(stateDir: string): string {
+  return path.join(stateDir, ACPX_LEGACY_GATEWAY_INSTANCE_FILE);
+}
+
+function resolveLegacyProcessLeasePath(stateDir: string): string {
+  return path.join(stateDir, "acpx", ACPX_LEGACY_PROCESS_LEASE_FILE);
+}
+
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    const stat = await fs.stat(filePath);
+    return stat.isFile();
+  } catch {
+    return false;
+  }
+}
+
+async function readLegacyGatewayInstanceId(filePath: string): Promise<string | null> {
+  try {
+    const value = (await fs.readFile(filePath, "utf8")).trim();
+    return value || null;
+  } catch {
+    return null;
+  }
+}
+
+async function readLegacyOpenProcessLeases(filePath: string): Promise<AcpxProcessLease[]> {
+  try {
+    const leaseFile = normalizeAcpxProcessLeaseFile(
+      JSON.parse(await fs.readFile(filePath, "utf8")) as unknown,
+    );
+    return leaseFile.leases.filter((lease) => lease.state === "open" || lease.state === "closing");
+  } catch {
+    return [];
+  }
+}
+
+async function archiveLegacySource(params: {
+  filePath: string;
+  label: string;
+  changes: string[];
+  warnings: string[];
+}): Promise<void> {
+  const archivedPath = `${params.filePath}.migrated`;
+  if (await fileExists(archivedPath)) {
+    params.warnings.push(
+      `Left migrated ACPX ${params.label} source in place because ${archivedPath} already exists`,
+    );
+    return;
+  }
+  try {
+    await fs.rename(params.filePath, archivedPath);
+    params.changes.push(`Archived ACPX ${params.label} legacy source -> ${archivedPath}`);
+  } catch (err) {
+    params.warnings.push(`Failed archiving ACPX ${params.label} legacy source: ${String(err)}`);
+  }
+}
+
+export const stateMigrations: PluginDoctorStateMigration[] = [
+  {
+    id: "acpx-runtime-state-to-plugin-state",
+    label: "ACPX runtime state",
+    async detectLegacyState(params) {
+      const gatewayInstanceId = await readLegacyGatewayInstanceId(
+        resolveLegacyGatewayInstancePath(params.stateDir),
+      );
+      const openLeases = await readLegacyOpenProcessLeases(
+        resolveLegacyProcessLeasePath(params.stateDir),
+      );
+      if (!gatewayInstanceId && openLeases.length === 0) {
+        return null;
+      }
+      const preview: string[] = [];
+      if (gatewayInstanceId) {
+        preview.push(
+          `- ACPX gateway instance id: ${resolveLegacyGatewayInstancePath(params.stateDir)} -> plugin state (${ACPX_GATEWAY_INSTANCE_NAMESPACE})`,
+        );
+      }
+      if (openLeases.length > 0) {
+        preview.push(
+          `- ACPX process leases: ${resolveLegacyProcessLeasePath(params.stateDir)} -> plugin state (${openLeases.length} open lease(s))`,
+        );
+      }
+      return { preview };
+    },
+    async migrateLegacyState(params) {
+      const changes: string[] = [];
+      const warnings: string[] = [];
+      const gatewayInstancePath = resolveLegacyGatewayInstancePath(params.stateDir);
+      const gatewayInstanceId = await readLegacyGatewayInstanceId(gatewayInstancePath);
+      const processLeasePath = resolveLegacyProcessLeasePath(params.stateDir);
+      const openLeases = await readLegacyOpenProcessLeases(processLeasePath);
+      const processLeaseStore = openAcpxProcessLeaseStateStore(
+        params.context.openPluginStateKeyedStore,
+      );
+      const gatewayStore = params.context.openPluginStateKeyedStore<AcpxGatewayInstanceRecord>({
+        namespace: ACPX_GATEWAY_INSTANCE_NAMESPACE,
+        maxEntries: ACPX_GATEWAY_INSTANCE_MAX_ENTRIES,
+      });
+      const existingGateway = normalizeAcpxGatewayInstanceRecord(
+        await gatewayStore.lookup(ACPX_GATEWAY_INSTANCE_KEY),
+      );
+      const existingLiveLeases = (await processLeaseStore.entries())
+        .map((entry) => normalizeAcpxProcessLease(entry.value))
+        .filter(
+          (lease): lease is AcpxProcessLease =>
+            Boolean(lease) && (lease.state === "open" || lease.state === "closing"),
+        );
+      const leaseGatewayIds = new Set(openLeases.map((lease) => lease.gatewayInstanceId));
+      const onlyLeaseGatewayId = leaseGatewayIds.size === 1 ? [...leaseGatewayIds][0] : null;
+      const canAdoptLegacyGateway =
+        existingGateway &&
+        gatewayInstanceId &&
+        existingGateway.instanceId !== gatewayInstanceId &&
+        onlyLeaseGatewayId === gatewayInstanceId &&
+        existingLiveLeases.length === 0;
+      const canonicalGatewayInstanceId =
+        canAdoptLegacyGateway || !existingGateway
+          ? (gatewayInstanceId ?? onlyLeaseGatewayId)
+          : existingGateway.instanceId;
+
+      if (
+        openLeases.length > 0 &&
+        (!canonicalGatewayInstanceId ||
+          [...leaseGatewayIds].some(
+            (leaseGatewayId) => leaseGatewayId !== canonicalGatewayInstanceId,
+          ))
+      ) {
+        warnings.push(
+          "Skipped ACPX process lease migration because legacy leases do not match the canonical gateway instance id; left legacy sources in place for manual cleanup",
+        );
+        return { changes, warnings };
+      }
+
+      if (canAdoptLegacyGateway && canonicalGatewayInstanceId) {
+        await gatewayStore.register(ACPX_GATEWAY_INSTANCE_KEY, {
+          instanceId: canonicalGatewayInstanceId,
+          createdAt: Date.now(),
+        });
+        changes.push("Migrated ACPX gateway instance id -> plugin state");
+      } else if (canonicalGatewayInstanceId && !existingGateway) {
+        await gatewayStore.register(ACPX_GATEWAY_INSTANCE_KEY, {
+          instanceId: canonicalGatewayInstanceId,
+          createdAt: Date.now(),
+        });
+        changes.push("Migrated ACPX gateway instance id -> plugin state");
+      } else if (gatewayInstanceId && existingGateway?.instanceId !== gatewayInstanceId) {
+        warnings.push(
+          "Skipped ACPX gateway instance id import because plugin state already differs",
+        );
+      }
+
+      if (gatewayInstanceId) {
+        await archiveLegacySource({
+          filePath: gatewayInstancePath,
+          label: "gateway-instance-id",
+          changes,
+          warnings,
+        });
+      }
+
+      if (openLeases.length > 0) {
+        let imported = 0;
+        let alreadyPresent = 0;
+        for (const lease of openLeases) {
+          const inserted = await processLeaseStore.registerIfAbsent(lease.leaseId, lease);
+          if (inserted) {
+            imported++;
+          } else {
+            alreadyPresent++;
+          }
+        }
+        changes.push(
+          `Migrated ACPX process leases -> plugin state (${imported} imported, ${alreadyPresent} already present)`,
+        );
+        await archiveLegacySource({
+          filePath: processLeasePath,
+          label: "process-leases",
+          changes,
+          warnings,
+        });
+      }
+
+      return { changes, warnings };
+    },
+  },
+];

--- a/extensions/acpx/index.test.ts
+++ b/extensions/acpx/index.test.ts
@@ -45,9 +45,11 @@ describe("acpx plugin", () => {
   it("registers the runtime service and reply_dispatch hook", () => {
     const service = { id: "acpx-service", start: vi.fn() };
     createAcpxRuntimeServiceMock.mockReturnValue(service);
+    const openKeyedStore = vi.fn();
 
     const api = {
       pluginConfig: { stateDir: "/tmp/acpx" },
+      runtime: { state: { openKeyedStore } },
       registerService: vi.fn(),
       on: vi.fn(),
     };
@@ -56,9 +58,30 @@ describe("acpx plugin", () => {
 
     expect(createAcpxRuntimeServiceMock).toHaveBeenCalledWith({
       pluginConfig: api.pluginConfig,
+      openKeyedStore: expect.any(Function),
     });
+    const params = createAcpxRuntimeServiceMock.mock.calls[0]?.[0] as {
+      openKeyedStore: typeof openKeyedStore;
+    };
+    params.openKeyedStore({ namespace: "test", maxEntries: 1 });
+    expect(openKeyedStore).toHaveBeenCalledWith({ namespace: "test", maxEntries: 1 });
     expect(api.registerService).toHaveBeenCalledWith(service);
     expect(api.on).toHaveBeenCalledWith("reply_dispatch", tryDispatchAcpReplyHookMock);
+  });
+
+  it("does not touch runtime state while registering metadata-only plugin APIs", () => {
+    const service = { id: "acpx-service", start: vi.fn() };
+    createAcpxRuntimeServiceMock.mockReturnValue(service);
+
+    const api = {
+      pluginConfig: {},
+      runtime: {},
+      registerService: vi.fn(),
+      on: vi.fn(),
+    };
+
+    expect(() => plugin.register(api as never)).not.toThrow();
+    expect(api.registerService).toHaveBeenCalledWith(service);
   });
 
   it("preserves the ACP reply_dispatch runtime path through the registered hook", async () => {
@@ -71,8 +94,10 @@ describe("acpx plugin", () => {
     });
 
     const on = vi.fn();
+    const openKeyedStore = vi.fn();
     const api = createTestPluginApi({
       pluginConfig: { stateDir: "/tmp/acpx" },
+      runtime: { state: { openKeyedStore } } as never,
       registerService: vi.fn(),
       on,
     });

--- a/extensions/acpx/index.ts
+++ b/extensions/acpx/index.ts
@@ -14,6 +14,7 @@ const plugin = {
     api.registerService(
       createAcpxRuntimeService({
         pluginConfig: api.pluginConfig,
+        openKeyedStore: (options) => api.runtime.state.openKeyedStore(options),
       }),
     );
     api.on("reply_dispatch", tryDispatchAcpReplyHook);

--- a/extensions/acpx/src/process-lease.test.ts
+++ b/extensions/acpx/src/process-lease.test.ts
@@ -2,9 +2,14 @@
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import {
+  createPluginStateKeyedStoreForTests,
+  resetPluginStateStoreForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   createAcpxProcessLeaseStore,
+  openAcpxProcessLeaseStateStore,
   OPENCLAW_ACPX_LEASE_ID_ARG,
   OPENCLAW_ACPX_LEASE_ID_ENV,
   OPENCLAW_GATEWAY_INSTANCE_ID_ARG,
@@ -28,19 +33,48 @@ function makeLease(index: number): AcpxProcessLease {
 }
 
 describe("createAcpxProcessLeaseStore", () => {
-  it("serializes concurrent lease saves without dropping records", async () => {
-    const stateDir = await mkdtemp(path.join(tmpdir(), "openclaw-acpx-leases-"));
-    try {
-      const store = createAcpxProcessLeaseStore({ stateDir });
-      await Promise.all(Array.from({ length: 25 }, (_, index) => store.save(makeLease(index))));
+  let stateDir = "";
+  let env: NodeJS.ProcessEnv;
 
-      const leases = await store.listOpen("gateway-test");
-      expect(leases.map((lease) => lease.leaseId).toSorted()).toEqual(
-        Array.from({ length: 25 }, (_, index) => `lease-${index}`).toSorted(),
-      );
-    } finally {
-      await rm(stateDir, { recursive: true, force: true });
-    }
+  beforeEach(async () => {
+    resetPluginStateStoreForTests();
+    stateDir = await mkdtemp(path.join(tmpdir(), "openclaw-acpx-leases-"));
+    env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+  });
+
+  afterEach(async () => {
+    await rm(stateDir, { recursive: true, force: true });
+  });
+
+  function createStore() {
+    return createAcpxProcessLeaseStore({
+      store: openAcpxProcessLeaseStateStore((options) =>
+        createPluginStateKeyedStoreForTests("acpx", { ...options, env }),
+      ),
+    });
+  }
+
+  it("serializes concurrent lease saves without dropping records", async () => {
+    const store = createStore();
+    await Promise.all(Array.from({ length: 25 }, (_, index) => store.save(makeLease(index))));
+
+    const leases = await store.listOpen("gateway-test");
+    expect(leases.map((lease) => lease.leaseId).toSorted()).toEqual(
+      Array.from({ length: 25 }, (_, index) => `lease-${index}`).toSorted(),
+    );
+  });
+
+  it("removes terminal leases from the live lease namespace", async () => {
+    const store = createStore();
+    const openLease = makeLease(1);
+    const closedLease = makeLease(2);
+    await store.save(openLease);
+    await store.save(closedLease);
+
+    await store.markState(closedLease.leaseId, "closed");
+
+    await expect(store.load(closedLease.leaseId)).resolves.toBeUndefined();
+    await expect(store.listOpen("gateway-test")).resolves.toEqual([openLease]);
   });
 });
 

--- a/extensions/acpx/src/process-lease.ts
+++ b/extensions/acpx/src/process-lease.ts
@@ -3,9 +3,11 @@
  * gateway/session identity to spawned ACP processes and clean them up later.
  */
 import { randomUUID, createHash } from "node:crypto";
-import fs from "node:fs/promises";
-import path from "node:path";
-import { readJsonFileWithFallback, writeJsonFileAtomically } from "openclaw/plugin-sdk/json-store";
+import type {
+  OpenKeyedStoreOptions,
+  PluginStateKeyedStore,
+} from "openclaw/plugin-sdk/plugin-state-runtime";
+import { ACPX_PROCESS_LEASE_MAX_ENTRIES, ACPX_PROCESS_LEASE_NAMESPACE } from "./state.js";
 
 /** Environment variable carrying the ACPX process lease id. */
 export const OPENCLAW_ACPX_LEASE_ID_ENV = "OPENCLAW_ACPX_LEASE_ID";
@@ -41,14 +43,12 @@ export type AcpxProcessLeaseStore = {
   markState(leaseId: string, state: AcpxProcessLeaseState): Promise<void>;
 };
 
-type LeaseFile = {
+export type AcpxProcessLeaseFile = {
   version: 1;
   leases: AcpxProcessLease[];
 };
 
-const LEASE_FILE = "process-leases.json";
-
-function normalizeLease(value: unknown): AcpxProcessLease | undefined {
+export function normalizeAcpxProcessLease(value: unknown): AcpxProcessLease | undefined {
   if (typeof value !== "object" || value === null) {
     return undefined;
   }
@@ -80,69 +80,77 @@ function normalizeLease(value: unknown): AcpxProcessLease | undefined {
   };
 }
 
-async function readLeaseFile(filePath: string): Promise<LeaseFile> {
-  const { value } = await readJsonFileWithFallback<Partial<LeaseFile>>(filePath, {
-    version: 1,
-    leases: [],
-  });
-  const leases = Array.isArray(value.leases)
-    ? value.leases.map(normalizeLease).filter((lease): lease is AcpxProcessLease => Boolean(lease))
+export function normalizeAcpxProcessLeaseFile(value: unknown): AcpxProcessLeaseFile {
+  const root =
+    typeof value === "object" && value !== null ? (value as Record<string, unknown>) : {};
+  const leases = Array.isArray(root.leases)
+    ? root.leases
+        .map(normalizeAcpxProcessLease)
+        .filter((lease): lease is AcpxProcessLease => Boolean(lease))
     : [];
   return { version: 1, leases };
 }
 
-function writeLeaseFile(filePath: string, value: LeaseFile): Promise<void> {
-  return writeJsonFileAtomically(filePath, value);
+export function openAcpxProcessLeaseStateStore(
+  openKeyedStore: <T>(options: OpenKeyedStoreOptions) => PluginStateKeyedStore<T>,
+): PluginStateKeyedStore<AcpxProcessLease> {
+  return openKeyedStore<AcpxProcessLease>({
+    namespace: ACPX_PROCESS_LEASE_NAMESPACE,
+    maxEntries: ACPX_PROCESS_LEASE_MAX_ENTRIES,
+  });
 }
 
-/** Create a serialized JSON-backed ACPX process lease store. */
-export function createAcpxProcessLeaseStore(params: { stateDir: string }): AcpxProcessLeaseStore {
-  const filePath = path.join(params.stateDir, LEASE_FILE);
+/** Create a serialized SQLite-backed ACPX process lease store. */
+export function createAcpxProcessLeaseStore(params: {
+  store: PluginStateKeyedStore<AcpxProcessLease>;
+}): AcpxProcessLeaseStore {
   let updateQueue: Promise<void> = Promise.resolve();
 
-  async function update(
-    mutator: (leases: AcpxProcessLease[]) => AcpxProcessLease[],
-  ): Promise<void> {
+  async function update(mutator: () => Promise<void>): Promise<void> {
     const run = updateQueue.then(async () => {
-      await fs.mkdir(params.stateDir, { recursive: true });
-      const current = await readLeaseFile(filePath);
-      await writeLeaseFile(filePath, {
-        version: 1,
-        leases: mutator(current.leases),
-      });
+      await mutator();
     });
     updateQueue = run.catch(() => {});
     await run;
   }
 
-  async function readCurrent(): Promise<LeaseFile> {
+  async function readCurrent(): Promise<AcpxProcessLease[]> {
     await updateQueue;
-    return await readLeaseFile(filePath);
+    const entries = await params.store.entries();
+    return entries
+      .map((entry) => normalizeAcpxProcessLease(entry.value))
+      .filter((lease): lease is AcpxProcessLease => Boolean(lease));
   }
 
   return {
     async load(leaseId) {
-      const current = await readCurrent();
-      return current.leases.find((lease) => lease.leaseId === leaseId);
+      await updateQueue;
+      return normalizeAcpxProcessLease(await params.store.lookup(leaseId));
     },
     async listOpen(gatewayInstanceId) {
-      const current = await readCurrent();
-      return current.leases.filter(
+      const leases = await readCurrent();
+      return leases.filter(
         (lease) =>
           (lease.state === "open" || lease.state === "closing") &&
           (!gatewayInstanceId || lease.gatewayInstanceId === gatewayInstanceId),
       );
     },
     async save(lease) {
-      await update((leases) => [
-        ...leases.filter((entry) => entry.leaseId !== lease.leaseId),
-        lease,
-      ]);
+      await update(async () => {
+        await params.store.register(lease.leaseId, lease);
+      });
     },
     async markState(leaseId, state) {
-      await update((leases) =>
-        leases.map((lease) => (lease.leaseId === leaseId ? { ...lease, state } : lease)),
-      );
+      await update(async () => {
+        if (state === "closed" || state === "lost") {
+          await params.store.delete(leaseId);
+          return;
+        }
+        const lease = normalizeAcpxProcessLease(await params.store.lookup(leaseId));
+        if (lease) {
+          await params.store.register(leaseId, { ...lease, state });
+        }
+      });
     },
   };
 }

--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -115,6 +115,10 @@ function makeLeaseStore() {
         leases.set(String(lease.leaseId), lease);
       }),
       markState: vi.fn(async (leaseId: string, state: string) => {
+        if (state === "closed" || state === "lost") {
+          leases.delete(leaseId);
+          return;
+        }
         const lease = leases.get(leaseId);
         if (lease) {
           lease.state = state;
@@ -1465,6 +1469,104 @@ describe("AcpxRuntime fresh reset wrapper", () => {
               pid: 920,
               ppid: 1,
               command: 'node "/tmp/other-gateway/acpx/codex-acp-wrapper.mjs"',
+            },
+          ]),
+          killProcess: vi.fn((pid, signal) => {
+            killed.push({ pid, signal });
+          }),
+          sleep: vi.fn(async () => {}),
+        },
+      },
+    );
+    vi.spyOn(delegate, "close").mockResolvedValue(undefined);
+
+    await runtime.close({
+      handle: {
+        sessionKey: "agent:codex:acp:binding:test",
+        backend: "acpx",
+        runtimeSessionName: "agent:codex:acp:binding:test",
+      },
+      reason: "user-close",
+    });
+
+    expect(killed).toStrictEqual([]);
+  });
+
+  it("cleans up non-lease-aware wrapper commands through fallback close cleanup", async () => {
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async () => ({
+        acpxRecordId: "agent:codex:acp:binding:test",
+        agentCommand: CODEX_ACP_WRAPPER_COMMAND,
+        pid: 920,
+      })),
+      save: vi.fn(async () => {}),
+    };
+    const killed: Array<{ pid: number; signal: NodeJS.Signals }> = [];
+    const { runtime, delegate } = makeRuntime(
+      baseStore,
+      {
+        openclawGatewayInstanceId: "gateway-test",
+        openclawWrapperRoot: "/tmp/openclaw/acpx",
+      },
+      {
+        openclawProcessCleanup: {
+          listProcesses: vi.fn(async () => [
+            {
+              pid: 920,
+              ppid: 1,
+              command: CODEX_ACP_WRAPPER_COMMAND,
+            },
+            { pid: 921, ppid: 920, command: "node child.js" },
+          ]),
+          killProcess: vi.fn((pid, signal) => {
+            killed.push({ pid, signal });
+          }),
+          sleep: vi.fn(async () => {}),
+        },
+      },
+    );
+    vi.spyOn(delegate, "close").mockResolvedValue(undefined);
+
+    await runtime.close({
+      handle: {
+        sessionKey: "agent:codex:acp:binding:test",
+        backend: "acpx",
+        runtimeSessionName: "agent:codex:acp:binding:test",
+      },
+      reason: "user-close",
+    });
+
+    expect(killed.slice(0, 2)).toEqual([
+      { pid: 921, signal: "SIGTERM" },
+      { pid: 920, signal: "SIGTERM" },
+    ]);
+  });
+
+  it("uses session lease metadata for fallback close cleanup identity checks", async () => {
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async () => ({
+        acpxRecordId: "agent:codex:acp:binding:test",
+        agentCommand: 'node "/tmp/openclaw/acpx/codex-acp-wrapper.mjs"',
+        openclawGatewayInstanceId: "gateway-test",
+        openclawLeaseId: "lease-record",
+        pid: 920,
+      })),
+      save: vi.fn(async () => {}),
+    };
+    const killed: Array<{ pid: number; signal: NodeJS.Signals }> = [];
+    const { runtime, delegate } = makeRuntime(
+      baseStore,
+      {
+        openclawGatewayInstanceId: "gateway-test",
+        openclawWrapperRoot: "/tmp/openclaw/acpx",
+      },
+      {
+        openclawProcessCleanup: {
+          listProcesses: vi.fn(async () => [
+            {
+              pid: 920,
+              ppid: 1,
+              command: `${CODEX_ACP_WRAPPER_COMMAND} ${OPENCLAW_ACPX_LEASE_ID_ARG} other-lease ${OPENCLAW_GATEWAY_INSTANCE_ID_ARG} gateway-test`,
             },
           ]),
           killProcess: vi.fn((pid, signal) => {

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -198,6 +198,16 @@ function readOpenClawLeaseIdFromRecord(record: unknown): string | undefined {
   return typeof openclawLeaseId === "string" ? openclawLeaseId.trim() || undefined : undefined;
 }
 
+function readOpenClawGatewayInstanceIdFromRecord(record: unknown): string | undefined {
+  if (typeof record !== "object" || record === null) {
+    return undefined;
+  }
+  const { openclawGatewayInstanceId } = record as { openclawGatewayInstanceId?: unknown };
+  return typeof openclawGatewayInstanceId === "string"
+    ? openclawGatewayInstanceId.trim() || undefined
+    : undefined;
+}
+
 function extractGeneratedWrapperPath(command: string | undefined): string {
   const parts = splitCommandParts(command ?? "");
   return (
@@ -906,9 +916,12 @@ export class AcpxRuntime implements AcpRuntime {
     if (!rootPid || !rootCommand) {
       return;
     }
+    const expectedGatewayInstanceId = readOpenClawGatewayInstanceIdFromRecord(record);
     await cleanupOpenClawOwnedAcpxProcessTree({
       rootPid,
       rootCommand,
+      ...(leaseId ? { expectedLeaseId: leaseId } : {}),
+      ...(expectedGatewayInstanceId ? { expectedGatewayInstanceId } : {}),
       wrapperRoot: this.wrapperRoot,
       deps: this.processCleanupDeps,
     });

--- a/extensions/acpx/src/service.test.ts
+++ b/extensions/acpx/src/service.test.ts
@@ -3,6 +3,11 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
+import type { OpenKeyedStoreOptions } from "openclaw/plugin-sdk/plugin-state-runtime";
+import {
+  createPluginStateKeyedStoreForTests,
+  resetPluginStateStoreForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const { runtimeRegistry } = vi.hoisted(() => ({
@@ -92,7 +97,17 @@ vi.mock("./process-reaper.js", () => ({
 
 import { getAcpRuntimeBackend } from "../runtime-api.js";
 import type { OpenClawPluginServiceContext } from "../runtime-api.js";
-import { createAcpxRuntimeService, resolveAcpxTimerTimeoutMs } from "./service.js";
+import { openAcpxProcessLeaseStateStore, type AcpxProcessLease } from "./process-lease.js";
+import {
+  createAcpxRuntimeService as createRealAcpxRuntimeService,
+  resolveAcpxTimerTimeoutMs,
+} from "./service.js";
+import {
+  ACPX_GATEWAY_INSTANCE_KEY,
+  ACPX_GATEWAY_INSTANCE_MAX_ENTRIES,
+  ACPX_GATEWAY_INSTANCE_NAMESPACE,
+  type AcpxGatewayInstanceRecord,
+} from "./state.js";
 
 const tempDirs: string[] = [];
 const previousEnv = {
@@ -117,6 +132,7 @@ async function makeTempDir(): Promise<string> {
 }
 
 afterEach(async () => {
+  resetPluginStateStoreForTests();
   runtimeRegistry.clear();
   prepareAcpxCodexAuthConfigMock.mockClear();
   cleanupOpenClawOwnedAcpxProcessTreeMock.mockClear();
@@ -144,6 +160,36 @@ function createServiceContext(workspaceDir: string): OpenClawPluginServiceContex
       debug: vi.fn(),
     },
   };
+}
+
+function createOpenKeyedStore(ctx: OpenClawPluginServiceContext) {
+  const env = { ...process.env, OPENCLAW_STATE_DIR: ctx.stateDir };
+  return <T>(options: OpenKeyedStoreOptions) =>
+    createPluginStateKeyedStoreForTests<T>("acpx", {
+      ...options,
+      env: options.env ?? env,
+    });
+}
+
+function createAcpxRuntimeService(
+  ctx: OpenClawPluginServiceContext,
+  params: Parameters<typeof createRealAcpxRuntimeService>[0] = {},
+) {
+  return createRealAcpxRuntimeService({
+    ...params,
+    openKeyedStore: params.openKeyedStore ?? createOpenKeyedStore(ctx),
+  });
+}
+
+function openGatewayInstanceStore(ctx: OpenClawPluginServiceContext) {
+  return createOpenKeyedStore(ctx)<AcpxGatewayInstanceRecord>({
+    namespace: ACPX_GATEWAY_INSTANCE_NAMESPACE,
+    maxEntries: ACPX_GATEWAY_INSTANCE_MAX_ENTRIES,
+  });
+}
+
+function openProcessLeaseStore(ctx: OpenClawPluginServiceContext) {
+  return openAcpxProcessLeaseStateStore(createOpenKeyedStore(ctx));
 }
 
 function createMockRuntime(overrides: Record<string, unknown> = {}) {
@@ -207,7 +253,7 @@ describe("createAcpxRuntimeService", () => {
     const workspaceDir = await makeTempDir();
     const ctx = createServiceContext(workspaceDir);
     const runtime = createMockRuntime();
-    const service = createAcpxRuntimeService({
+    const service = createAcpxRuntimeService(ctx, {
       runtimeFactory: () => runtime as never,
     });
 
@@ -234,7 +280,7 @@ describe("createAcpxRuntimeService", () => {
       isHealthy: () => false,
       probeAvailability,
     });
-    const service = createAcpxRuntimeService({
+    const service = createAcpxRuntimeService(ctx, {
       pluginConfig: { stateDir },
       runtimeFactory: () => runtime as never,
     });
@@ -265,7 +311,7 @@ describe("createAcpxRuntimeService", () => {
       probeAvailability,
       isHealthy: () => true,
     });
-    const service = createAcpxRuntimeService({
+    const service = createAcpxRuntimeService(ctx, {
       runtimeFactory: () => runtime as never,
     });
 
@@ -297,7 +343,7 @@ describe("createAcpxRuntimeService", () => {
     const trace = createStartupTraceRecorder();
     ctx.startupTrace = trace.startupTrace;
     const runtime = createMockRuntime();
-    const service = createAcpxRuntimeService({
+    const service = createAcpxRuntimeService(ctx, {
       runtimeFactory: () => runtime as never,
     });
 
@@ -335,32 +381,28 @@ describe("createAcpxRuntimeService", () => {
     const ctx = createServiceContext(workspaceDir);
     const runtime = createMockRuntime();
     const processCleanupDeps = { sleep: vi.fn(async () => {}) };
-    await fs.mkdir(path.join(ctx.stateDir, "acpx"), { recursive: true });
-    await fs.writeFile(path.join(ctx.stateDir, "gateway-instance-id"), "gw-test\n");
-    await fs.writeFile(
-      path.join(ctx.stateDir, "acpx", "process-leases.json"),
-      JSON.stringify({
-        version: 1,
-        leases: [
-          {
-            leaseId: "lease-1",
-            gatewayInstanceId: "gw-test",
-            sessionKey: "agent:codex:acp:test",
-            wrapperRoot: path.join(ctx.stateDir, "acpx"),
-            wrapperPath: path.join(ctx.stateDir, "acpx", "codex-acp-wrapper.mjs"),
-            rootPid: 101,
-            commandHash: "hash",
-            startedAt: 1,
-            state: "open",
-          },
-        ],
-      }),
-    );
+    const wrapperRoot = path.join(ctx.stateDir, "acpx");
+    await openGatewayInstanceStore(ctx).register(ACPX_GATEWAY_INSTANCE_KEY, {
+      instanceId: "gw-test",
+      createdAt: 1,
+    });
+    const lease: AcpxProcessLease = {
+      leaseId: "lease-1",
+      gatewayInstanceId: "gw-test",
+      sessionKey: "agent:codex:acp:test",
+      wrapperRoot,
+      wrapperPath: path.join(wrapperRoot, "codex-acp-wrapper.mjs"),
+      rootPid: 101,
+      commandHash: "hash",
+      startedAt: 1,
+      state: "open",
+    };
+    await openProcessLeaseStore(ctx).register(lease.leaseId, lease);
     cleanupOpenClawOwnedAcpxProcessTreeMock.mockResolvedValueOnce({
       inspectedPids: [101, 102],
       terminatedPids: [101, 102],
     });
-    const service = createAcpxRuntimeService({
+    const service = createAcpxRuntimeService(ctx, {
       runtimeFactory: () => runtime as never,
       processCleanupDeps,
     });
@@ -371,7 +413,7 @@ describe("createAcpxRuntimeService", () => {
       rootPid: 101,
       expectedLeaseId: "lease-1",
       expectedGatewayInstanceId: "gw-test",
-      wrapperRoot: path.join(ctx.stateDir, "acpx"),
+      wrapperRoot,
       deps: processCleanupDeps,
     });
     expect(ctx.logger.info).toHaveBeenCalledWith("reaped 2 stale OpenClaw-owned ACPX processes");
@@ -386,31 +428,27 @@ describe("createAcpxRuntimeService", () => {
     const processCleanupDeps = { sleep: vi.fn(async () => {}) };
     const wrapperRoot = path.join(ctx.stateDir, "acpx");
     await fs.mkdir(wrapperRoot, { recursive: true });
-    await fs.writeFile(path.join(ctx.stateDir, "gateway-instance-id"), "gw-test\n");
-    await fs.writeFile(
-      path.join(wrapperRoot, "process-leases.json"),
-      JSON.stringify({
-        version: 1,
-        leases: [
-          {
-            leaseId: "lease-pending",
-            gatewayInstanceId: "gw-test",
-            sessionKey: "agent:codex:acp:test",
-            wrapperRoot,
-            wrapperPath: path.join(wrapperRoot, "codex-acp-wrapper.mjs"),
-            rootPid: 0,
-            commandHash: "hash",
-            startedAt: 1,
-            state: "open",
-          },
-        ],
-      }),
-    );
+    await openGatewayInstanceStore(ctx).register(ACPX_GATEWAY_INSTANCE_KEY, {
+      instanceId: "gw-test",
+      createdAt: 1,
+    });
+    const lease: AcpxProcessLease = {
+      leaseId: "lease-pending",
+      gatewayInstanceId: "gw-test",
+      sessionKey: "agent:codex:acp:test",
+      wrapperRoot,
+      wrapperPath: path.join(wrapperRoot, "codex-acp-wrapper.mjs"),
+      rootPid: 0,
+      commandHash: "hash",
+      startedAt: 1,
+      state: "open",
+    };
+    await openProcessLeaseStore(ctx).register(lease.leaseId, lease);
     reapStaleOpenClawOwnedAcpxOrphansMock.mockResolvedValueOnce({
       inspectedPids: [201, 202],
       terminatedPids: [201, 202],
     });
-    const service = createAcpxRuntimeService({
+    const service = createAcpxRuntimeService(ctx, {
       runtimeFactory: () => runtime as never,
       processCleanupDeps,
     });
@@ -423,10 +461,7 @@ describe("createAcpxRuntimeService", () => {
       deps: processCleanupDeps,
     });
     expect(ctx.logger.info).toHaveBeenCalledWith("reaped 2 stale OpenClaw-owned ACPX processes");
-    const leaseFile = JSON.parse(
-      await fs.readFile(path.join(wrapperRoot, "process-leases.json"), "utf8"),
-    );
-    expect(leaseFile.leases[0].state).toBe("closed");
+    await expect(openProcessLeaseStore(ctx).lookup("lease-pending")).resolves.toBeUndefined();
 
     await service.stop?.(ctx);
   });
@@ -435,7 +470,7 @@ describe("createAcpxRuntimeService", () => {
     const workspaceDir = await makeTempDir();
     const ctx = createServiceContext(workspaceDir);
     const runtime = createMockRuntime();
-    const service = createAcpxRuntimeService({
+    const service = createAcpxRuntimeService(ctx, {
       runtimeFactory: () => runtime as never,
     });
 
@@ -452,7 +487,7 @@ describe("createAcpxRuntimeService", () => {
     delete process.env.OPENCLAW_SKIP_ACPX_RUNTIME_PROBE;
     const workspaceDir = await makeTempDir();
     const ctx = createServiceContext(workspaceDir);
-    const service = createAcpxRuntimeService();
+    const service = createAcpxRuntimeService(ctx);
 
     await service.start(ctx);
 
@@ -507,7 +542,7 @@ describe("createAcpxRuntimeService", () => {
         __options: options,
       };
     });
-    const service = createAcpxRuntimeService();
+    const service = createAcpxRuntimeService(ctx);
 
     await service.start(ctx);
 
@@ -561,7 +596,7 @@ describe("createAcpxRuntimeService", () => {
     process.env.OPENCLAW_ACPX_RUNTIME_STARTUP_PROBE = "0";
     const workspaceDir = await makeTempDir();
     const ctx = createServiceContext(workspaceDir);
-    const service = createAcpxRuntimeService({
+    const service = createAcpxRuntimeService(ctx, {
       pluginConfig: { timeoutSeconds: 0.001 },
     });
 
@@ -591,7 +626,7 @@ describe("createAcpxRuntimeService", () => {
     process.env.OPENCLAW_ACPX_RUNTIME_STARTUP_PROBE = "0";
     const workspaceDir = await makeTempDir();
     const ctx = createServiceContext(workspaceDir);
-    const service = createAcpxRuntimeService({
+    const service = createAcpxRuntimeService(ctx, {
       pluginConfig: { timeoutSeconds: Number.MAX_SAFE_INTEGER },
     });
 
@@ -626,7 +661,7 @@ describe("createAcpxRuntimeService", () => {
       probeAvailability,
       isHealthy: () => true,
     });
-    const service = createAcpxRuntimeService({
+    const service = createAcpxRuntimeService(ctx, {
       runtimeFactory: () => runtime as never,
     });
 
@@ -647,7 +682,7 @@ describe("createAcpxRuntimeService", () => {
       probeAvailability,
       isHealthy: () => false,
     });
-    const service = createAcpxRuntimeService({
+    const service = createAcpxRuntimeService(ctx, {
       pluginConfig: { timeoutSeconds: 0.001 },
       runtimeFactory: () => runtime as never,
     });
@@ -668,7 +703,7 @@ describe("createAcpxRuntimeService", () => {
     const ctx = createServiceContext(workspaceDir);
     const runtime = createMockRuntime();
     const runtimeFactory = vi.fn(() => runtime as never);
-    const service = createAcpxRuntimeService({
+    const service = createAcpxRuntimeService(ctx, {
       runtimeFactory,
     });
 
@@ -692,7 +727,7 @@ describe("createAcpxRuntimeService", () => {
       doctor: vi.fn(async () => ({ ok: true, message: "ok" })),
     };
     const runtimeFactory = vi.fn(() => runtime as never);
-    const service = createAcpxRuntimeService({
+    const service = createAcpxRuntimeService(ctx, {
       pluginConfig: { probeAgent: "opencode" },
       runtimeFactory,
     });
@@ -714,7 +749,7 @@ describe("createAcpxRuntimeService", () => {
     };
     const runtime = createMockRuntime();
     const runtimeFactory = vi.fn(() => runtime as never);
-    const service = createAcpxRuntimeService({
+    const service = createAcpxRuntimeService(ctx, {
       runtimeFactory,
     });
 
@@ -735,7 +770,7 @@ describe("createAcpxRuntimeService", () => {
     };
     const runtime = createMockRuntime();
     const runtimeFactory = vi.fn(() => runtime as never);
-    const service = createAcpxRuntimeService({
+    const service = createAcpxRuntimeService(ctx, {
       pluginConfig: { probeAgent: "codex" },
       runtimeFactory,
     });
@@ -751,7 +786,7 @@ describe("createAcpxRuntimeService", () => {
     const workspaceDir = await makeTempDir();
     const ctx = createServiceContext(workspaceDir);
     const runtime = createMockRuntime();
-    const service = createAcpxRuntimeService({
+    const service = createAcpxRuntimeService(ctx, {
       pluginConfig: {
         queueOwnerTtlSeconds: 30,
         strictWindowsCmdWrapper: false,
@@ -779,7 +814,7 @@ describe("createAcpxRuntimeService", () => {
       isHealthy: () => false,
       probeAvailability,
     });
-    const service = createAcpxRuntimeService({
+    const service = createAcpxRuntimeService(ctx, {
       runtimeFactory: () => runtime as never,
     });
 
@@ -804,7 +839,7 @@ describe("createAcpxRuntimeService", () => {
       }),
       isHealthy: () => false,
     });
-    const service = createAcpxRuntimeService({
+    const service = createAcpxRuntimeService(ctx, {
       runtimeFactory: () => runtime as never,
     });
 
@@ -824,7 +859,7 @@ describe("createAcpxRuntimeService", () => {
     const runtimeFactory = vi.fn(() => {
       throw new Error("runtime factory should not run when ACPX is skipped");
     });
-    const service = createAcpxRuntimeService({
+    const service = createAcpxRuntimeService(ctx, {
       runtimeFactory: runtimeFactory as never,
     });
 

--- a/extensions/acpx/src/service.ts
+++ b/extensions/acpx/src/service.ts
@@ -9,6 +9,10 @@ import { inspect } from "node:util";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { finiteSecondsToTimerSafeMilliseconds } from "openclaw/plugin-sdk/number-runtime";
 import type {
+  OpenKeyedStoreOptions,
+  PluginStateKeyedStore,
+} from "openclaw/plugin-sdk/plugin-state-runtime";
+import type {
   AcpRuntime,
   OpenClawPluginService,
   OpenClawPluginServiceContext,
@@ -22,13 +26,24 @@ import {
   toAcpMcpServers,
   type ResolvedAcpxPluginConfig,
 } from "./config.js";
-import { createAcpxProcessLeaseStore, type AcpxProcessLeaseStore } from "./process-lease.js";
+import {
+  createAcpxProcessLeaseStore,
+  openAcpxProcessLeaseStateStore,
+  type AcpxProcessLeaseStore,
+} from "./process-lease.js";
 import {
   cleanupOpenClawOwnedAcpxProcessTree,
   reapStaleOpenClawOwnedAcpxOrphans,
   type AcpxProcessCleanupDeps,
 } from "./process-reaper.js";
 import { createLazyAcpRuntimeProxy } from "./runtime-proxy.js";
+import {
+  ACPX_GATEWAY_INSTANCE_KEY,
+  ACPX_GATEWAY_INSTANCE_MAX_ENTRIES,
+  ACPX_GATEWAY_INSTANCE_NAMESPACE,
+  normalizeAcpxGatewayInstanceRecord,
+  type AcpxGatewayInstanceRecord,
+} from "./state.js";
 
 type AcpxRuntimeLike = AcpRuntime & {
   probeAvailability(): Promise<void>;
@@ -56,6 +71,7 @@ type AcpxRuntimeFactoryParams = {
 
 type CreateAcpxRuntimeServiceParams = {
   pluginConfig?: unknown;
+  openKeyedStore?: <T>(options: OpenKeyedStoreOptions) => PluginStateKeyedStore<T>;
   runtimeFactory?: (params: AcpxRuntimeFactoryParams) => AcpxRuntimeLike | Promise<AcpxRuntimeLike>;
   processCleanupDeps?: AcpxProcessCleanupDeps;
 };
@@ -233,21 +249,30 @@ async function withStartupProbeTimeout<T>(params: {
   }
 }
 
-async function resolveGatewayInstanceId(stateDir: string): Promise<string> {
-  const filePath = path.join(stateDir, "gateway-instance-id");
-  try {
-    const existing = (await fs.readFile(filePath, "utf8")).trim();
-    if (existing) {
-      return existing;
-    }
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
-      throw error;
-    }
+function openGatewayInstanceStateStore(
+  openKeyedStore: <T>(options: OpenKeyedStoreOptions) => PluginStateKeyedStore<T>,
+): PluginStateKeyedStore<AcpxGatewayInstanceRecord> {
+  return openKeyedStore<AcpxGatewayInstanceRecord>({
+    namespace: ACPX_GATEWAY_INSTANCE_NAMESPACE,
+    maxEntries: ACPX_GATEWAY_INSTANCE_MAX_ENTRIES,
+  });
+}
+
+async function resolveGatewayInstanceId(
+  openKeyedStore: <T>(options: OpenKeyedStoreOptions) => PluginStateKeyedStore<T>,
+): Promise<string> {
+  const store = openGatewayInstanceStateStore(openKeyedStore);
+  const existing = normalizeAcpxGatewayInstanceRecord(
+    await store.lookup(ACPX_GATEWAY_INSTANCE_KEY),
+  );
+  if (existing) {
+    return existing.instanceId;
   }
   const next = randomUUID();
-  await fs.mkdir(stateDir, { recursive: true });
-  await fs.writeFile(filePath, `${next}\n`, { mode: 0o600 });
+  await store.register(ACPX_GATEWAY_INSTANCE_KEY, {
+    instanceId: next,
+    createdAt: Date.now(),
+  });
   return next;
 }
 
@@ -314,6 +339,10 @@ export function createAcpxRuntimeService(
         ctx.logger.info("skipping embedded acpx runtime backend (OPENCLAW_SKIP_ACPX_RUNTIME=1)");
         return;
       }
+      const openKeyedStore = params.openKeyedStore;
+      if (!openKeyedStore) {
+        throw new Error("ACPX runtime service requires plugin keyed state");
+      }
 
       const basePluginConfig = await measureAcpxStartup(ctx, "config.resolve", () =>
         resolveAcpxPluginConfig({
@@ -338,9 +367,11 @@ export function createAcpxRuntimeService(
         await fs.mkdir(wrapperRoot, { recursive: true });
       });
       const gatewayInstanceId = await measureAcpxStartup(ctx, "gateway-instance-id", () =>
-        resolveGatewayInstanceId(ctx.stateDir),
+        resolveGatewayInstanceId(openKeyedStore),
       );
-      const processLeaseStore = createAcpxProcessLeaseStore({ stateDir: wrapperRoot });
+      const processLeaseStore = createAcpxProcessLeaseStore({
+        store: openAcpxProcessLeaseStateStore(openKeyedStore),
+      });
       const startupReap = await measureAcpxStartup(ctx, "process-leases.reap", () =>
         reapOpenAcpxProcessLeases({
           gatewayInstanceId,

--- a/extensions/acpx/src/state.ts
+++ b/extensions/acpx/src/state.ts
@@ -1,0 +1,34 @@
+// ACPX plugin state keys shared by runtime and doctor migration.
+export const ACPX_PROCESS_LEASE_NAMESPACE = "process-leases";
+export const ACPX_PROCESS_LEASE_MAX_ENTRIES = 4096;
+export const ACPX_LEGACY_PROCESS_LEASE_FILE = "process-leases.json";
+
+export const ACPX_GATEWAY_INSTANCE_NAMESPACE = "gateway-instance";
+export const ACPX_GATEWAY_INSTANCE_KEY = "current";
+export const ACPX_GATEWAY_INSTANCE_MAX_ENTRIES = 1;
+export const ACPX_LEGACY_GATEWAY_INSTANCE_FILE = "gateway-instance-id";
+
+export type AcpxGatewayInstanceRecord = {
+  instanceId: string;
+  createdAt: number;
+};
+
+export function normalizeAcpxGatewayInstanceRecord(
+  value: unknown,
+): AcpxGatewayInstanceRecord | undefined {
+  if (typeof value !== "object" || value === null) {
+    return undefined;
+  }
+  const record = value as Record<string, unknown>;
+  if (typeof record.instanceId !== "string" || !record.instanceId.trim()) {
+    return undefined;
+  }
+  const createdAt =
+    typeof record.createdAt === "number" && Number.isFinite(record.createdAt)
+      ? Math.trunc(record.createdAt)
+      : 0;
+  return {
+    instanceId: record.instanceId.trim(),
+    createdAt,
+  };
+}


### PR DESCRIPTION
Summary
- Move ACPX gateway instance id and live process leases from legacy files into SQLite-backed plugin keyed state.
- Add doctor migration for legacy gateway identity plus open/closing process leases, including upgrade-order handling when the new runtime created an empty SQLite gateway id before doctor ran.
- Keep closed/lost leases out of the bounded live lease namespace while preserving cleanup identity checks through persisted session metadata.

Verification
- node scripts/run-vitest.mjs extensions/acpx/src/process-lease.test.ts extensions/acpx/src/service.test.ts extensions/acpx/src/runtime.test.ts extensions/acpx/index.test.ts extensions/acpx/register.runtime.test.ts extensions/acpx/doctor-contract-api.test.ts
- pnpm exec oxfmt --check extensions/acpx/index.ts extensions/acpx/index.test.ts extensions/acpx/src/process-lease.ts extensions/acpx/src/process-lease.test.ts extensions/acpx/src/service.ts extensions/acpx/src/service.test.ts extensions/acpx/src/runtime.ts extensions/acpx/src/runtime.test.ts extensions/acpx/src/state.ts extensions/acpx/doctor-contract-api.ts extensions/acpx/doctor-contract-api.test.ts
- autoreview --mode local --parallel-tests "node scripts/run-vitest.mjs extensions/acpx/src/process-lease.test.ts extensions/acpx/src/service.test.ts extensions/acpx/src/runtime.test.ts extensions/acpx/index.test.ts extensions/acpx/register.runtime.test.ts extensions/acpx/doctor-contract-api.test.ts" clean after accepted fixes
