### PR TITLE
fix(imessage): self-explaining private-API failures and dedicated send timeout

### DIFF
--- a/extensions/imessage/src/actions.ts
+++ b/extensions/imessage/src/actions.ts
@@ -430,11 +430,17 @@ export const imessageMessageActions: ChannelMessageActionAdapter = {
         // disappeared — they only see "channel: running" in `channels status`.
         // Common cause: gateway restart un-injects the imsg-bridge-helper.dylib
         // from Messages.app while imsg rpc keeps running.
+        // imsg's status message names the actual blocker (SIP, library
+        // validation, macOS 26 AMFI gate) — append it so the operator isn't
+        // told to "run imsg launch" when the OS is rejecting the dylib.
+        const reason = privateApiStatus?.statusMessage
+          ? ` imsg reports: ${privateApiStatus.statusMessage}`
+          : "";
         log.warn(
-          `iMessage ${action} blocked: private API bridge unavailable (accountId=${account.accountId}, cliPath=${cliPathForProbe}). Run \`imsg launch\` to re-inject the dylib, then \`openclaw channels status\` to refresh.`,
+          `iMessage ${action} blocked: private API bridge unavailable (accountId=${account.accountId}, cliPath=${cliPathForProbe}). Run \`imsg launch\` to re-inject the dylib, then \`openclaw channels status\` to refresh.${reason}`,
         );
         throw new Error(
-          `iMessage ${action} requires the imsg private API bridge. Run imsg launch, then openclaw channels status to refresh capability detection.`,
+          `iMessage ${action} requires the imsg private API bridge. Run imsg launch, then openclaw channels status to refresh capability detection.${reason}`,
         );
       }
     };

--- a/extensions/imessage/src/constants.ts
+++ b/extensions/imessage/src/constants.ts
@@ -1,2 +1,11 @@
 /** Default timeout for iMessage probe/RPC operations (10 seconds). */
 export const DEFAULT_IMESSAGE_PROBE_TIMEOUT_MS = 10_000;
+
+// Sends get a much longer default than probes: on macOS 26 (Tahoe) the private
+// API bridge intermittently stalls up to ~124s before the send completes. The
+// 10s probe timeout aborts those mid-flight, and non-recoverable shapes
+// (attachment/reply) are then lost. This must clear the observed upper bound
+// plus headroom, otherwise the long tail of stalls still loses sends — 150s
+// covers 124s with margin. Decoupling keeps probes/health checks fast while
+// letting real sends ride out the stall. Akin to the BlueBubbles fix (#69193).
+export const DEFAULT_IMESSAGE_SEND_TIMEOUT_MS = 150_000;

--- a/extensions/imessage/src/private-api-status.ts
+++ b/extensions/imessage/src/private-api-status.ts
@@ -12,6 +12,10 @@ export type IMessagePrivateApiStatus = {
   cliCapabilities?: {
     sendRichSupportsAttachment?: boolean;
   };
+  // imsg's own `status --json` `message` field. When advanced features are off
+  // it explains why (SIP enabled, library validation, macOS 26 AMFI gate), so
+  // callers can surface a real reason instead of a generic "run imsg launch".
+  statusMessage?: string;
   error?: string;
 };
 

--- a/extensions/imessage/src/probe.ts
+++ b/extensions/imessage/src/probe.ts
@@ -237,6 +237,9 @@ export async function probeIMessagePrivateApi(
     const rpcMethods = payload ? rpcMethodsFromPayload(payload) : [];
     const advancedFeatures = payload?.advanced_features === true;
     const v2Ready = payload?.v2_ready === true;
+    // imsg explains an unavailable bridge here (SIP, library validation, macOS
+    // 26 AMFI gate). Carry it forward so blocked actions can show the reason.
+    const statusMessage = typeof payload?.message === "string" ? payload.message : undefined;
     // Probe `imsg send-rich --help` for the `--file` flag added by
     // openclaw/imsg#114. We do this even when the bridge is unavailable
     // because the help output ships with the CLI binary itself, and the
@@ -250,6 +253,7 @@ export async function probeIMessagePrivateApi(
       selectors,
       rpcMethods,
       cliCapabilities: { sendRichSupportsAttachment },
+      ...(statusMessage ? { statusMessage } : {}),
       ...(result.code === 0
         ? !payload && firstLineSnippet
           ? {

--- a/extensions/imessage/src/send.test.ts
+++ b/extensions/imessage/src/send.test.ts
@@ -121,6 +121,19 @@ describe("sendMessageIMessage receipts", () => {
     expect(result.receipt.sentAt).toBeGreaterThan(0);
   });
 
+  it("uses the dedicated send timeout (covers macOS 26 stalls), not the 10s probe default", async () => {
+    const client = createClient({ guid: "p:0/imsg-1" });
+
+    await sendMessageIMessage("chat_id:42", "hello", {
+      config: IMESSAGE_TEST_CFG,
+      client,
+    });
+
+    expect(getClientMocks(client).request).toHaveBeenCalledWith("send", expect.any(Object), {
+      timeoutMs: 150_000,
+    });
+  });
+
   it("sends explicit chat media-only payloads through send-attachment auto transport", async () => {
     const client = createClient({ message_id: 12345 });
     const runCliJson = vi

--- a/extensions/imessage/src/send.ts
+++ b/extensions/imessage/src/send.ts
@@ -25,6 +25,7 @@ import {
 } from "./approval-reactions.js";
 import { appendIMessageCliStderrTail, appendIMessageCliStdout } from "./cli-output.js";
 import { createIMessageRpcClient, type IMessageRpcClient } from "./client.js";
+import { DEFAULT_IMESSAGE_SEND_TIMEOUT_MS } from "./constants.js";
 import { extractMarkdownFormatRuns } from "./markdown-format.js";
 import { rememberIMessageReplyCache } from "./monitor-reply-cache.js";
 import { rememberPersistedIMessageEcho } from "./monitor/persisted-echo-cache.js";
@@ -857,7 +858,11 @@ export async function sendMessageIMessage(
     opts.service ??
     resolveTargetService(target) ??
     (account.config.service as IMessageService | undefined);
-  const timeoutMs = opts.timeoutMs ?? account.config.probeTimeoutMs;
+  // Sends use a dedicated longer default (not the 10s probe timeout) so macOS 26
+  // bridge stalls aren't aborted mid-send. Explicit opts/probeTimeoutMs still win
+  // for callers that tuned them. See DEFAULT_IMESSAGE_SEND_TIMEOUT_MS.
+  const timeoutMs =
+    opts.timeoutMs ?? account.config.probeTimeoutMs ?? DEFAULT_IMESSAGE_SEND_TIMEOUT_MS;
   const region = opts.region?.trim() || account.config.region?.trim() || "US";
   const maxBytes =
     typeof opts.maxBytes === "number"

--- a/extensions/imessage/src/status.test.ts
+++ b/extensions/imessage/src/status.test.ts
@@ -420,6 +420,39 @@ describe("probeIMessage", () => {
     expect(runCommand).toHaveBeenCalledTimes(4);
   });
 
+  it("propagates imsg's status message when advanced features are unavailable", async () => {
+    const note =
+      "System Integrity Protection (SIP) is enabled.\nAdvanced IMCore features are intentionally disabled.";
+    vi.spyOn(processRuntime, "runCommandWithTimeout")
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({
+          advanced_features: false,
+          v2_ready: false,
+          selectors: {},
+          rpc_methods: ["chats.list"],
+          message: note,
+        }),
+        stderr: "",
+        code: 0,
+        signal: null,
+        killed: false,
+        termination: "exit",
+      })
+      .mockResolvedValueOnce({
+        stdout: "send-rich --help",
+        stderr: "",
+        code: 0,
+        signal: null,
+        killed: false,
+        termination: "exit",
+      });
+
+    await expect(probeIMessagePrivateApi("imsg-status-message-test", 1000)).resolves.toMatchObject({
+      available: false,
+      statusMessage: note,
+    });
+  });
+
   it("fails fast for default local imsg probes on non-mac hosts", async () => {
     const createIMessageRpcClientMock = vi
       .spyOn(clientModule, "createIMessageRpcClient")


### PR DESCRIPTION
## Summary

Two macOS-26-resilience fixes for the iMessage channel:

1. **Surface *why* the private API is unavailable.** The probe now carries imsg's own `status --json` `message` (SIP / library validation / macOS 26 AMFI gate) into `IMessagePrivateApiStatus.statusMessage`, and blocked actions append it. Operators on macOS 26.5 stop getting the misleading "run imsg launch" with no reason.

2. **Decouple the send timeout from the probe timeout.** Sends inherited the 10s probe default via `client.request`. On macOS 26 the private-API bridge intermittently stalls up to ~124s; the 10s abort dropped attachment/reply sends (non-recoverable shapes). New `DEFAULT_IMESSAGE_SEND_TIMEOUT_MS = 150_000` for sends only (covers the observed upper bound + headroom); probes/health checks stay fast. **No new config surface** — explicit opts/`probeTimeoutMs` still win. Mirrors the BlueBubbles send-timeout fix (#69193).

3. **Companion imsg bridge fix.** ClawSweeper correctly found that OpenClaw's 150s client wait was incomplete while upstream `imsg` bridge sends still defaulted to 10s. Companion PR open: openclaw/imsg#139 at `4c85d165c31f4711f75d7bfda4c31723219ebadd` changes send-style bridge actions (`send-message`, `send-multipart`, `send-attachment`, `send-poll`, `send-reaction`) to use a 150s bridge response timeout while keeping non-send RPC waits at 10s and preserving explicit timeout overrides. `send-reaction` is included because tapbacks build an `IMMessage` and dispatch through `sendMessage:`; `notify-anyways` intentionally stays at 10s because it is a message-item mutation path.

## Verification

- `pnpm tsgo:extensions` clean.
- Full imessage extension suite: **548 tests pass**, incl. 2 new tests (statusMessage propagation; 150s send default).
- `node scripts/run-vitest.mjs extensions/imessage/src/status.test.ts extensions/imessage/src/actions.test.ts extensions/imessage/src/send.test.ts` (3 files, 81 tests passed).
- Codex `$autoreview` clean (it caught an initial 60s-too-short default vs the documented 124s stall window; fixed to 150s).
- **Dependency source inspected:** local sibling imsg source had `IMsgBridgeProtocol.defaultResponseTimeout = 10.0`, and `RPCServer` / CLI bridge send paths called `IMsgBridgeClient.shared.invoke` without a longer send timeout. Companion openclaw/imsg#139 fixes that dependency-layer timeout contract.
- **Companion imsg verification for openclaw/imsg#139 (`4c85d165c31f4711f75d7bfda4c31723219ebadd`):**
  - `swift format lint Sources/IMsgCore/IMsgBridgeProtocol.swift Tests/IMsgCoreTests/IMsgBridgeProtocolTests.swift`
  - `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter IMsgBridgeProtocolTests` (7 tests passed)
  - `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer make test` (325 tests in 2 suites passed)
  - GitHub CI: `macos` and `linux-read-core` passed
- **Timeout tradeoff:** The 150s default is intentional for send-style private API bridge actions because the observed macOS 26 stalls reached about 124s. A bridge send that never returns can now hold the caller up to 150s; probes, health checks, explicit overrides, and non-send bridge actions keep the short timeout.
- **Live macOS 26.4.1 healthy-host status proof on this machine:** `imsg status --json` returned `message: "Connected to Messages.app. IMCore features available."`, `v2_ready: true`, and `bridge_version: 2`; `pnpm openclaw channels status --probe imessage --json` reported iMessage configured/running with `probe.ok: true` and `privateApi.available: true`.
- **Live macOS 26.5.1 blocked-action proof in a clean VM:** OpenClaw built from this PR was installed and run as a gateway with imsg 0.11.0 present but the private-API bridge intentionally not injected. A real CLI `openclaw message react --channel imessage ...` dispatch returned the blocked-action error with imsg's own reason appended: `imsg reports: SIP is disabled and the helper dylib is present, but Messages.app is not currently injected. Run \`imsg launch\` to enable advanced IMCore features.` See the proof comment: https://github.com/openclaw/openclaw/pull/91041#issuecomment-4641260341
- **Live regression smoke on macOS 26.4.1 (lobster):** built 2026.6.1 + this fix, deployed to the gateway, restarted (PID bounced), iMessage + Telegram both healthy, no startup errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
