### PR TITLE
fix(microsoft-foundry): exclude alias providers from DeepSeek V4 thinking wrapper (fixes #90520)

### DIFF
--- a/src/agents/embedded-agent-runner-extraparams.test.ts
+++ b/src/agents/embedded-agent-runner-extraparams.test.ts
@@ -766,6 +766,26 @@ describe("applyExtraParamsToAgent", () => {
     expect(payload).not.toHaveProperty("thinking");
   });
 
+  it("does not add DeepSeek V4 thinking params on Foundry alias provider paths", () => {
+    const payload = runResponsesPayloadMutationCase({
+      applyProvider: "microsoft-foundry-9433",
+      applyModelId: "deepseek-v4-pro",
+      thinkingLevel: "high",
+      model: {
+        api: "openai-completions",
+        provider: "microsoft-foundry-9433",
+        id: "deepseek-v4-pro",
+      } as Model<"openai-completions">,
+      payload: {
+        reasoning_effort: "high",
+        messages: [{ role: "user", content: "hello" }],
+      },
+    });
+
+    expect(payload.reasoning_effort).toBe("high");
+    expect(payload).not.toHaveProperty("thinking");
+  });
+
   it("fills MiMo V2.6 reasoning_content for unowned OpenAI-compatible proxy models", () => {
     const payload = runResponsesPayloadMutationCase({
       applyProvider: "opencode",

--- a/src/agents/embedded-agent-runner/extra-params.ts
+++ b/src/agents/embedded-agent-runner/extra-params.ts
@@ -923,7 +923,7 @@ function isDeepSeekV4OpenAICompatibleModel(model: Parameters<StreamFn>[0]): bool
   const normalizedModelId = normalizeDeepSeekV4CandidateId(model.id);
   return (
     model.api === "openai-completions" &&
-    model.provider !== "microsoft-foundry" &&
+    !model.provider?.startsWith("microsoft-foundry") &&
     (normalizedModelId === "deepseek-v4-flash" || normalizedModelId === "deepseek-v4-pro")
   );
 }


### PR DESCRIPTION
## Summary

The `isDeepSeekV4OpenAICompatibleModel` guard used an exact provider-id match (`model.provider !== "microsoft-foundry"`) to skip Foundry providers that handle thinking via their own `normalizeResolvedModel` hook. Alias providers (e.g. `microsoft-foundry-9433`) did not match the exact check, causing the shared DeepSeek V4 thinking wrapper to inject a `thinking` field that the Foundry API rejects with HTTP 400. This PR switches the check to a prefix match (`startsWith`) so all `microsoft-foundry*` variant providers are excluded. Fixes #90520.

## Root Cause

In `src/agents/embedded-agent-runner/extra-params.ts`, `isDeepSeekV4OpenAICompatibleModel` is the predicate that gates `createDeepSeekV4OpenAICompatibleThinkingWrapper`. It checks that the model's API is `openai-completions` and the provider is NOT `microsoft-foundry` — because the microsoft-foundry plugin already suppresses DeepSeek V4 thinking via its own `normalizeResolvedModel` hook.

The exact string comparison `model.provider !== "microsoft-foundry"` fails to catch alias providers like `microsoft-foundry-9433`. When those aliases route DeepSeek V4 Pro requests:
- `model.api` = `"openai-completions"` ✓ (alias providers may not go through the plugin's normalizeResolvedModel)
- `model.provider` = `"microsoft-foundry-9433"` — does NOT match `"microsoft-foundry"`, so the exclusion fails
- Result: the wrapper injects a top-level `thinking` property → Foundry API returns `400 Unrecognized request argument supplied: thinking`

The fix uses `!model.provider?.startsWith("microsoft-foundry")` which handles all alias variants (e.g. `microsoft-foundry-9433`, `microsoft-foundry-ai`, etc.) correctly.

**Invariant violated**: The guard intended to exclude ALL microsoft-foundry family providers from the shared thinking wrapper. The exact-match check was too narrow.

**Code path**: `applyExtraParamsToAgent` → `createDeepSeekV4OpenAICompatibleThinkingWrapper` → `isDeepSeekV4OpenAICompatibleModel` predicate.

## Verification

```
pnpm test src/agents/embedded-agent-runner-extraparams.test.ts
```
Result: 1 test file, 132 tests passed (includes the new alias-provider test case).

## Real Behavior Proof

**Behavior or issue addressed**: Microsoft Foundry alias providers (e.g. `microsoft-foundry-9433`) incorrectly received a `thinking` payload field from the shared DeepSeek V4 wrapper, causing the Foundry API to reject requests with HTTP 400 "Unrecognized request argument supplied: thinking". After the fix, the `isDeepSeekV4OpenAICompatibleModel` guard uses `startsWith` so all `microsoft-foundry*` providers are excluded from the shared wrapper.

**Real environment tested**: Ubuntu 26.04, Node v22.22.0, pnpm 10.25.0, OpenClaw main @ 983b65b0e011

**Exact steps or command run after this patch**:
1. `pnpm build` — exits 0 (full project build with all 153 workspace packages)
2. `pnpm test src/agents/embedded-agent-runner-extraparams.test.ts` — 132 tests passed including the new alias case
3. `pnpm check` — all structural checks pass (only pre-existing npm-shrinkwrap staleness noted)

**Evidence after fix**:

Source change (`src/agents/embedded-agent-runner/extra-params.ts` L926):
```typescript
// Before (exact match — misses aliases):
model.provider !== "microsoft-foundry" &&

// After (prefix match — covers all variants):
!model.provider?.startsWith("microsoft-foundry") &&
```

New test case (`src/agents/embedded-agent-runner-extraparams.test.ts` L769-787) validates the alias path:
```typescript
it("does not add DeepSeek V4 thinking params on Foundry alias provider paths", () => {
    const payload = runResponsesPayloadMutationCase({
      applyProvider: "microsoft-foundry-9433",
      applyModelId: "deepseek-v4-pro",
      thinkingLevel: "high",
      model: {
        api: "openai-completions",
        provider: "microsoft-foundry-9433",
        id: "deepseek-v4-pro",
      } as Model<"openai-completions">,
      payload: {
        reasoning_effort: "high",
        messages: [{ role: "user", content: "hello" }],
      },
    });

    expect(payload.reasoning_effort).toBe("high");
    expect(payload).not.toHaveProperty("thinking");
  });
```

Terminal output from test run:
```
$ pnpm test src/agents/embedded-agent-runner-extraparams.test.ts

 RUN  v4.1.7 /home/0668001395/openclawProject1

 Test Files  1 passed (1)
      Tests  132 passed (132)
   Start at  08:55:15
   Duration  3.54s
```

**Observed result after fix**: The new "does not add DeepSeek V4 thinking params on Foundry alias provider paths" test passes alongside 131 existing tests. The alias-provider payload (`microsoft-foundry-9433`) correctly has no `thinking` property while retaining `reasoning_effort`.

**What was not tested**: End-to-end gateway integration with a real Microsoft Foundry resource (requires Azure subscription with managed identity/Entra ID). The reporter's A/B proof in #90520 confirms the fix shape addresses the root cause by isolating the provider-id matching gap.

## Review Findings Addressed

N/A — no automated review findings on this PR yet.

## Regression Test Plan

- Primary: `pnpm test src/agents/embedded-agent-runner-extraparams.test.ts` — 132 tests covering all extra parameter application paths including DeepSeek V4, Foundry, and now Foundry aliases
- Related: `pnpm test src/plugin-sdk/provider-stream-shared.test.ts` — tests the `createDeepSeekV4OpenAICompatibleThinkingWrapper` behavior
- In CI: the full `pnpm test` suite will catch any regressions in provider parameter handling

## Merge Risk

Low. Single-line change from exact match to prefix match in a predicate function. The `startsWith` check is strictly broader than the original exact comparison — all existing exclusions are preserved, and new ones are added for alias variants. Both the legacy case (`microsoft-foundry`) and the new case (`microsoft-foundry-9433`) are covered by explicit tests.
