### PR TITLE
fix(gemini): accept empty grounding metadata

### DIFF
--- a/extensions/google/src/gemini-web-search-provider.runtime.ts
+++ b/extensions/google/src/gemini-web-search-provider.runtime.ts
@@ -235,8 +235,12 @@ async function runGeminiSearch(params: {
       const groundingChunks =
         groundingMetadata === undefined
           ? []
-          : isRecord(groundingMetadata) && Array.isArray(groundingMetadata.groundingChunks)
-            ? groundingMetadata.groundingChunks
+          : isRecord(groundingMetadata)
+            ? groundingMetadata.groundingChunks === undefined
+              ? []
+              : Array.isArray(groundingMetadata.groundingChunks)
+                ? groundingMetadata.groundingChunks
+                : undefined
             : undefined;
       if (!groundingChunks) {
         throwMalformedGeminiResponse();

--- a/extensions/google/web-search-provider.test.ts
+++ b/extensions/google/web-search-provider.test.ts
@@ -195,6 +195,54 @@ describe("google web search provider", () => {
     );
   });
 
+  it("accepts Gemini success JSON with empty grounding metadata", async () => {
+    vi.stubGlobal(
+      "fetch",
+      withFetchPreconnect(
+        vi.fn(() =>
+          Promise.resolve(
+            new Response(
+              JSON.stringify({
+                candidates: [
+                  {
+                    content: { parts: [{ text: "Today's date is Sunday, June 7, 2026." }] },
+                    groundingMetadata: {},
+                  },
+                ],
+              }),
+            ),
+          ),
+        ),
+      ),
+    );
+    const provider = createGeminiWebSearchProvider();
+    const tool = provider.createTool({
+      config: {
+        plugins: {
+          entries: {
+            google: {
+              config: {
+                webSearch: {
+                  apiKey: "AIza-plugin-test",
+                },
+              },
+            },
+          },
+        },
+      },
+      searchConfig: { provider: "gemini" },
+    });
+
+    const result = await tool?.execute({ query: "current date today" });
+
+    expect(result).toMatchObject({
+      citations: [],
+      model: "gemini-2.5-flash",
+      provider: "gemini",
+    });
+    expect(String(result?.content)).toContain("Today's date is Sunday, June 7, 2026.");
+  });
+
   it("reports malformed Gemini API JSON with a stable provider error", async () => {
     vi.stubGlobal(
       "fetch",


### PR DESCRIPTION
## Summary
Fixes #88528.

Gemini web search can return a successful `generateContent` response with text and `groundingMetadata: {}` but no `groundingChunks`. The provider already allowed missing `groundingMetadata`; this makes the empty metadata object follow the same path and returns usable wrapped content with an empty citation list instead of throwing `Gemini API error: malformed JSON response`.

## Verification
- Direct live Gemini API call with the issue request shape returned HTTP 200 JSON: `candidates` present, candidate text present, `groundingMetadata` present with no keys, `groundingChunks` not an array.
- Before this patch, the OpenClaw Gemini provider path with the same live key/query returned `Gemini API error: malformed JSON response`.
- After this patch, the same live provider path returned success: provider `gemini`, model `gemini-2.5-flash`, wrapped content, `citationCount: 0`.
- `node scripts/run-vitest.mjs extensions/google/web-search-provider.test.ts`
- `pnpm lint:web-search-provider-boundaries`
- `pnpm exec oxfmt --check extensions/google/src/gemini-web-search-provider.runtime.ts extensions/google/web-search-provider.test.ts`
- `git diff --check`
- `/Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

## Real behavior proof

Behavior addressed: Gemini web_search plain queries returned `Gemini API error: malformed JSON response` when Gemini returned valid text plus empty grounding metadata.
Real environment tested: macOS local checkout, Node via repo test wrapper, live Gemini API key from 1Password.
Exact steps or command run after this patch: Ran a direct Gemini `generateContent` request with `tools: [{ google_search: {} }]`, then ran the OpenClaw Gemini web-search provider through `node --import tsx` using the same live key.
Evidence after fix: Live direct API shape was HTTP 200 with candidate text and empty `groundingMetadata`; live provider path returned success with wrapped content and zero citations.
Observed result after fix: Plain Gemini web_search no longer throws for empty `groundingMetadata`; it returns normalized content and `citations: []`.
What was not tested: Full OpenClaw CLI on Windows; the issue's separate Windows libuv assertion after the provider error was not exercised.

## Risk
User-visible behavior changes for Gemini web_search only. The parser still rejects non-object metadata, missing text, missing candidates, and non-array `groundingChunks` when the property is present.
