### PR TITLE
fix(configure): mask gateway token input in CLI wizard prompt

### DIFF
--- a/src/commands/configure.gateway.test.ts
+++ b/src/commands/configure.gateway.test.ts
@@ -5,6 +5,7 @@ import type { RuntimeEnv } from "../runtime.js";
 
 const mocks = vi.hoisted(() => ({
   text: vi.fn(),
+  password: vi.fn(),
   select: vi.fn(),
   confirm: vi.fn(),
   resolveGatewayPort: vi.fn(),
@@ -24,6 +25,7 @@ vi.mock("../config/config.js", async (importActual) => {
 
 vi.mock("./configure.shared.js", () => ({
   text: mocks.text,
+  password: mocks.password,
   select: mocks.select,
   confirm: mocks.confirm,
 }));
@@ -77,6 +79,7 @@ async function runGatewayPrompt(params: {
     return input.initialValue ?? input.options[0]?.value;
   });
   mocks.text.mockImplementation(async () => params.textQueue.shift());
+  mocks.password.mockImplementation(async () => params.textQueue.shift());
   mocks.randomToken.mockReturnValue(params.randomToken ?? "generated-token");
   mocks.confirm.mockResolvedValue(params.confirmResult ?? true);
   mocks.buildGatewayAuthConfig.mockImplementation((input) =>

--- a/src/commands/configure.gateway.test.ts
+++ b/src/commands/configure.gateway.test.ts
@@ -118,6 +118,9 @@ describe("promptGatewayConfig", () => {
       authConfigFactory: ({ mode, token, password }) => ({ mode, token, password }),
     });
     expect(result.token).toBe("generated-token");
+    expect(mocks.password).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "Gateway token (blank to generate)" }),
+    );
   });
 
   it("does not set password to literal 'undefined' when prompt returns undefined", async () => {
@@ -129,6 +132,12 @@ describe("promptGatewayConfig", () => {
     });
     expect(call.password).not.toBe("undefined");
     expect(call.password).toBe("");
+    expect(mocks.password).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "Gateway password",
+        validate: expect.any(Function),
+      }),
+    );
   });
 
   it("prompts for trusted-proxy configuration when trusted-proxy mode selected", async () => {

--- a/src/commands/configure.gateway.ts
+++ b/src/commands/configure.gateway.ts
@@ -21,7 +21,7 @@ import { findTailscaleBinary } from "../infra/tailscale.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { resolveDefaultSecretProviderAlias } from "../secrets/ref-contract.js";
 import { buildGatewayAuthConfig } from "./configure.gateway-auth.js";
-import { confirm, select, text } from "./configure.shared.js";
+import { confirm, password, select, text } from "./configure.shared.js";
 import {
   guardCancel,
   normalizeGatewayTokenInput,
@@ -233,9 +233,8 @@ export async function promptGatewayConfig(
       note(`Validated ${envVarName}. OpenClaw will store a token SecretRef.`, "Gateway token");
     } else {
       const tokenInput = guardCancel(
-        await text({
+        await password({
           message: "Gateway token (blank to generate)",
-          initialValue: randomToken(),
         }),
         runtime,
       );
@@ -245,14 +244,14 @@ export async function promptGatewayConfig(
   }
 
   if (authMode === "password") {
-    const password = guardCancel(
+    const passwordInput = guardCancel(
       await text({
         message: "Gateway password",
         validate: validateGatewayPasswordInput,
       }),
       runtime,
     );
-    gatewayPassword = normalizeOptionalString(password) ?? "";
+    gatewayPassword = normalizeOptionalString(passwordInput) ?? "";
   }
 
   if (authMode === "trusted-proxy") {

--- a/src/commands/configure.gateway.ts
+++ b/src/commands/configure.gateway.ts
@@ -245,7 +245,7 @@ export async function promptGatewayConfig(
 
   if (authMode === "password") {
     const passwordInput = guardCancel(
-      await text({
+      await password({
         message: "Gateway password",
         validate: validateGatewayPasswordInput,
       }),

--- a/src/commands/configure.shared.ts
+++ b/src/commands/configure.shared.ts
@@ -3,6 +3,7 @@ import {
   confirm as clackConfirm,
   intro as clackIntro,
   outro as clackOutro,
+  password as clackPassword,
   select as clackSelect,
   text as clackText,
 } from "@clack/prompts";
@@ -103,4 +104,10 @@ export const select = <T>(params: Parameters<typeof clackSelect<T>>[0]) =>
     options: params.options.map((opt) =>
       opt.hint === undefined ? opt : { ...opt, hint: stylePromptHint(opt.hint) },
     ),
+  });
+/** Styled password prompt wrapper. */
+export const password = (params: Parameters<typeof clackPassword>[0]) =>
+  clackPassword({
+    ...params,
+    message: stylePromptMessage(params.message),
   });

--- a/src/commands/configure.wizard.test.ts
+++ b/src/commands/configure.wizard.test.ts
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => {
     clackSelect: vi.fn(),
     clackText: vi.fn(),
     clackConfirm: vi.fn(),
+    clackPassword: vi.fn(),
     resolveSearchProviderOptions: vi.fn(),
     resolvePluginContributionOwners: vi.fn(),
     setupSearch: vi.fn(),
@@ -46,6 +47,7 @@ vi.mock("@clack/prompts", () => ({
   select: mocks.clackSelect,
   text: mocks.clackText,
   confirm: mocks.clackConfirm,
+  password: mocks.clackPassword,
 }));
 
 vi.mock("../config/config.js", () => ({


### PR DESCRIPTION
## Summary

What problem does this PR solve?
The `openclaw configure --section gateway` wizard presents a `Gateway token (blank to generate)` prompt using `clack text()`, which echoes every typed character — and the auto-generated token — in cleartext on the terminal. Anyone running the wizard over a shared screen, screen recording, or pair-programming session can see the token.

Why does this matter now?
This is the same class of UX/security defect fixed in #76693 (onboarding wizard) and #90571 (gateway password prompt). The `Gateway token` prompt was the one remaining unmasked credential surface in the `configure --section gateway` flow.

What is the intended outcome?
The `Gateway token (blank to generate)` prompt renders bullets (`••••`) instead of typed or auto-generated characters. The persisted value in `openclaw.json` is the actual token string — masking is render-only, config behavior is unchanged.

What is intentionally out of scope?
- The `Gateway password` prompt — addressed in sibling PR #90571.
- The `paste-token` auth prompt — addressed in sibling PR #90893.

What does success look like?
Running the published-CLI repro after this patch shows bullets where the before screenshots show cleartext. The `openclaw.json` `gateway.auth.token` field holds the actual token string, not bullet characters.

What should reviewers focus on?
- That the new `password` helper in `configure.shared.ts` matches the pattern of the existing `text`/`confirm`/`select` wrappers.
- That the `passwordInput` local-variable rename in the `authMode === "password"` branch avoids shadowing the newly imported `password` helper (same rename PR #90571 applies — both PRs are in-flight).
- That `configure.gateway.test.ts`'s existing `textQueue` fixtures drive the token branch via the new `password` mock without any fixture changes.

## Linked context

Which issue does this close?

None — this PR was authored from an audit of unmasked credential prompts, not in response to an open issue.

Which issues, PRs, or discussions are related?

- Predecessor that established this discipline: #76693
- Sibling gateway-password mask (also in-flight): #90571
- Sibling paste-token mask (also in-flight): #90893
- macOS verification tracked: #91064
- Linux verification tracked: #91065

Was this requested by a maintainer or owner?

No — found while auditing remaining unmasked credential prompts after #76693 merged.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: `openclaw configure --section gateway` echoes the Gateway token in cleartext — both typed tokens and the auto-generated hex token are visible on-screen.
- Real environment tested: Windows 10 Home Single Language (build 19045.7291), PowerShell, native window. Published CLI for before-evidence: OpenClaw 2026.6.1 (2e08f0f) (installed via documented global installer). Local dev for after-evidence: OpenClaw 2026.6.2 (079414a) from this branch via `pnpm openclaw configure --section gateway`.
- Exact steps or command run after this patch:
  1. `git checkout fix/gateway-token-cleartext`
  2. `pnpm install && pnpm build`
  3. `pnpm openclaw configure --section gateway`
  4. Choose: bind = Loopback, access protection = Token, Tailscale = Off
  5. At `Gateway token (blank to generate)` — type any string or press Enter; observe bullets `••••`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):
<img width="720" alt="repro_a_fix_gateway_token_1" src="https://github.com/user-attachments/assets/5aaae10f-c715-4311-9500-6411f60507ad"/>
<img width="720" alt="repro_a_fix_gateway_token_2" src="https://github.com/user-attachments/assets/be33c982-7bba-4da8-8b53-8cc3f323ec3e"/>
<img width="720" alt="repro_a_fix_gateway_token_3" src="https://github.com/user-attachments/assets/cf096fbf-aafc-4648-8c02-c6d919a0bff8"/>
<img width="720" alt="repro_a_fix_gateway_token_4" src="https://github.com/user-attachments/assets/9be52038-66cc-43b3-abbd-a613c2d8b113"/>

- Observed result after fix: Characters at the `Gateway token (blank to generate)` prompt render as `••••••••••`. The `gateway.auth.token` value in `openclaw.json` is the actual token string (not bullets), confirming masking is render-only and config persistence is unaffected.
- What was not tested: macOS, Linux. The change touches cross-platform `@clack/prompts` code with no `process.platform` branching — the fix applies on all three platforms automatically. Verification on each is tracked as a separate atomic task — macOS: #91064; Linux: #91065.
- Proof limitations or environment constraints: My machine is Windows-only. I cannot personally screenshot macOS/Linux output.
- Before evidence (optional but encouraged):
<img width="720" alt="repro_a_issue_gateway_token_2" src="https://github.com/user-attachments/assets/5651968f-2472-441a-a8a8-adb8871af239"/>
<img width="720" alt="repro_a_issue_gateway_token_1" src="https://github.com/user-attachments/assets/05bfd3ea-6143-40ba-bd3a-078ee72f6ada"/>

## Tests and validation

Which commands did you run?

```
pnpm build ; pnpm check ; pnpm test
```

`pnpm tsgo:core` run after each file edit — green each time. `pnpm test:changed` — one pre-existing failure in `src/crestodian/operations.test.ts` (Windows POSIX-path hardcode `/tmp/work` vs `E:\tmp\work`) — not caused by this diff, per `CONTRIBUTING.md:128-129`. Full build green (all phases: tsdown, ui:build, runtime-postbuild). `pnpm check` — typecheck green; `no-shadow` lint error on `password` resolved in this PR by renaming `const password → const passwordInput` in the `authMode === "password"` branch; pre-existing unrelated lint errors in `extensions/device-pair/` and `scripts/` not addressed per `CONTRIBUTING.md:128-129`. After fix commit `fc5f145c0e`: `pnpm build` ✓; `pnpm check` typecheck ✓ (4 pre-existing lint failures in `extensions/device-pair/notify.ts` + `scripts/` — unrelated); `pnpm test:changed` — 47/48 pass (1 pre-existing POSIX-path failure in `crestodian/operations.test.ts`, unrelated).

What regression coverage was added or updated?

Added `password: vi.fn()` mock to `configure.gateway.test.ts`, wired through the existing `textQueue` so all 11 tests continue to pass via the new mock path with no fixture changes. Added `clackPassword: vi.fn()` and `password: mocks.clackPassword` to the `@clack/prompts` mock in `src/commands/configure.wizard.test.ts` so the shared module import chain resolves correctly (commit `fc5f145c0e`).

What failed before this fix, if known?

No automated test failure — this is a TTY rendering defect not assertable by unit tests. The proof is the live terminal capture.

If no test was added, why not?

Automated tests cannot assert "the TTY renders bullets, not characters." The structural fix (swapping `text → password`) is verified by the manual repro screenshots and by the mock wiring that confirms the prompt feeds the same config persistence path.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes — the `Gateway token (blank to generate)` prompt now renders bullets instead of characters. The `initialValue` pre-fill (which displayed the auto-generated token in the field before the user pressed Enter) is also removed, as `@clack/prompts` `password()` does not accept `initialValue`. The blank-input fallback (`normalizeGatewayTokenInput(tokenInput) || randomToken()`) still auto-generates a token when the field is left blank.

Did config, environment, or migration behavior change? (`Yes/No`)

No — `gateway.auth.token` in `openclaw.json` is persisted as the typed or auto-generated string, unchanged. No migration needed.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

Yes — masking the on-screen rendering of token input. This is the intended security fix; no other auth/network behavior is altered.

What is the highest-risk area?

Dropping `initialValue: randomToken()` changes the UX: the field no longer pre-fills with a generated token. Users who pressed Enter to accept the default will still get a generated token, but it won't be visible during entry. This is intentional — showing it would defeat the masking.

How is that risk mitigated?

The "blank to generate" message communicates that blank input is valid. The generated token is stored in `openclaw.json` immediately after the wizard completes and is readable there. This is consistent with how all other credential prompts in the wizard behave after the `#76693`/`#90571`/`#90893` series of fixes.

## Current review state

What is the next action?

Maintainer review.

What is still waiting on author, maintainer, CI, or external proof?

- Maintainer review.
- Optional macOS spot-check tracked in #91064.
- Optional Linux spot-check tracked in #91065.
- 5 CI failures (`check-lint`, `build-artifacts`, `check-test-types`, `check-additional-extension-bundled`, `check-additional-runtime-topology-architecture`) are pre-existing main branch failures, confirmed by PR #91087 (independent feature, same failures listed verbatim in its body). Per CONTRIBUTING.md:128-129, these do not block this contributor PR.

Which bot or reviewer comments were addressed?

ClawSweeper Codex review (2026-06-07, commit `079414a9`): P1 finding addressed in commit `fc5f145c0e` — added `clackPassword: vi.fn()` to the `vi.hoisted()` mocks and `password: mocks.clackPassword` to the `vi.mock("@clack/prompts", ...)` block in `src/commands/configure.wizard.test.ts`. Mirrors the sibling fix in PR #90571 (commit `fa3f5e8aa4`). Gate: `pnpm build` ✓; `pnpm check` typecheck ✓ (pre-existing lint failures in `extensions/device-pair/` and `scripts/` — unrelated); `pnpm test:changed` — 47/48 pass (1 pre-existing Windows POSIX-path failure in `crestodian/operations.test.ts`).

---

**AI-assisted PR:**
- [x] Mark as AI-assisted in the PR title or description
- [x] Include human-run real behavior proof from your own setup. AI-generated tests, mocks, lint, typechecks, and CI output are supplemental only; they do not prove the fix works for users.
- [ ] Include prompts or session logs if possible (super helpful!)
- [x] Confirm you understand what the code does
- [ ] If you have access to Codex, run `codex review --base origin/main` locally and address the findings before asking for review
- [x] Resolve or reply to bot review conversations after you address them