### PR TITLE
fix(memory): write deep summaries into DREAMS.md

### DIFF
--- a/extensions/memory-core/src/dreaming-markdown.test.ts
+++ b/extensions/memory-core/src/dreaming-markdown.test.ts
@@ -160,6 +160,51 @@ describe("dreaming markdown storage", () => {
     expect(content).toContain("# Deep Sleep");
     expect(content).toContain("- Promoted: durable preference");
 
+    const dreamsContent = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8");
+    expect(dreamsContent).toContain("## Deep Sleep");
+    expect(dreamsContent).toContain("- Promoted: durable preference");
+  });
+
+  it("writes deep summaries into an existing dreams.md without disturbing the diary block", async () => {
+    const workspaceDir = await createTempWorkspace("openclaw-dreaming-markdown-");
+    const dreamsPath = path.join(workspaceDir, "dreams.md");
+    await fs.writeFile(
+      dreamsPath,
+      [
+        "# Dream Diary",
+        "",
+        "<!-- openclaw:dreaming:diary:start -->",
+        "---",
+        "",
+        "*April 5, 2026*",
+        "",
+        "A diary entry.",
+        "",
+        "<!-- openclaw:dreaming:diary:end -->",
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const reportPath = await writeDeepDreamingReport({
+      workspaceDir,
+      bodyLines: ["- Promoted: durable preference"],
+      storage: {
+        mode: "inline",
+        separateReports: false,
+      },
+      nowMs: Date.parse("2026-04-05T10:00:00Z"),
+      timezone: "UTC",
+    });
+
+    expect(reportPath).toBeUndefined();
     await expectPathMissing(path.join(workspaceDir, "DREAMS.md"));
+
+    const content = await fs.readFile(dreamsPath, "utf-8");
+    expect(content).toContain("## Deep Sleep");
+    expect(content).toContain("- Promoted: durable preference");
+    expect(content).toContain("<!-- openclaw:dreaming:diary:start -->");
+    expect(content).toContain("<!-- openclaw:dreaming:diary:end -->");
+    expect(content).toContain("A diary entry.");
   });
 });

--- a/extensions/memory-core/src/dreaming-markdown.ts
+++ b/extensions/memory-core/src/dreaming-markdown.ts
@@ -11,12 +11,17 @@ import {
   replaceManagedMarkdownBlock,
   withTrailingNewline,
 } from "openclaw/plugin-sdk/memory-host-markdown";
+import { replaceDreamsManagedBlock } from "./dreaming-narrative.js";
 import { resolveMemoryCoreNowMs, resolveMemoryCoreTimestamp } from "./time.js";
 
 const DAILY_PHASE_HEADINGS: Record<Exclude<MemoryDreamingPhaseName, "deep">, string> = {
   light: "## Light Sleep",
   rem: "## REM Sleep",
 };
+
+const DEEP_SLEEP_HEADING = "## Deep Sleep";
+const DEEP_SLEEP_START_MARKER = "<!-- openclaw:dreaming:deep:start -->";
+const DEEP_SLEEP_END_MARKER = "<!-- openclaw:dreaming:deep:end -->";
 
 const DAILY_PHASE_LABELS: Record<Exclude<MemoryDreamingPhaseName, "deep">, string> = {
   light: "light",
@@ -130,14 +135,37 @@ export async function writeDeepDreamingReport(params: {
   timezone?: string;
   storage: MemoryDreamingStorageConfig;
 }): Promise<string | undefined> {
+  const nowMs = resolveMemoryCoreNowMs(params.nowMs);
   if (!shouldWriteSeparate(params.storage)) {
+    const body =
+      params.bodyLines.length > 0 ? params.bodyLines.join("\n") : "- No durable changes.";
+    await replaceDreamsManagedBlock({
+      workspaceDir: params.workspaceDir,
+      heading: DEEP_SLEEP_HEADING,
+      startMarker: DEEP_SLEEP_START_MARKER,
+      endMarker: DEEP_SLEEP_END_MARKER,
+      body,
+    });
+    await appendMemoryHostEvent(params.workspaceDir, {
+      type: "memory.dream.completed",
+      timestamp: resolveMemoryCoreTimestamp(nowMs),
+      phase: "deep",
+      lineCount: params.bodyLines.length,
+      storageMode: params.storage.mode,
+    });
     return undefined;
   }
-  const nowMs = resolveMemoryCoreNowMs(params.nowMs);
   const reportPath = resolveSeparateReportPath(params.workspaceDir, "deep", nowMs, params.timezone);
   await fs.mkdir(path.dirname(reportPath), { recursive: true });
   const body = params.bodyLines.length > 0 ? params.bodyLines.join("\n") : "- No durable changes.";
   await fs.writeFile(reportPath, `# Deep Sleep\n\n${body}\n`, "utf-8");
+  await replaceDreamsManagedBlock({
+    workspaceDir: params.workspaceDir,
+    heading: DEEP_SLEEP_HEADING,
+    startMarker: DEEP_SLEEP_START_MARKER,
+    endMarker: DEEP_SLEEP_END_MARKER,
+    body,
+  });
   await appendMemoryHostEvent(params.workspaceDir, {
     type: "memory.dream.completed",
     timestamp: resolveMemoryCoreTimestamp(nowMs),

--- a/extensions/memory-core/src/dreaming-narrative.ts
+++ b/extensions/memory-core/src/dreaming-narrative.ts
@@ -13,6 +13,7 @@ import {
 } from "openclaw/plugin-sdk/error-runtime";
 import { resolveGlobalMap } from "openclaw/plugin-sdk/global-singleton";
 import { resolveStateDir } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
+import { replaceManagedMarkdownBlock } from "openclaw/plugin-sdk/memory-host-markdown";
 import { getRuntimeConfig } from "openclaw/plugin-sdk/runtime-config-snapshot";
 import { pathExists, replaceFileAtomic } from "openclaw/plugin-sdk/security-runtime";
 import {
@@ -566,6 +567,28 @@ async function updateDreamsFile<T>(params: {
       dreamsFileLocks.delete(dreamsPath);
     }
   }
+}
+
+export async function replaceDreamsManagedBlock(params: {
+  workspaceDir: string;
+  heading: string;
+  startMarker: string;
+  endMarker: string;
+  body: string;
+}): Promise<string> {
+  return await updateDreamsFile({
+    workspaceDir: params.workspaceDir,
+    updater: (existing, dreamsPath) => ({
+      content: replaceManagedMarkdownBlock({
+        original: existing,
+        heading: params.heading,
+        startMarker: params.startMarker,
+        endMarker: params.endMarker,
+        body: params.body,
+      }),
+      result: dreamsPath,
+    }),
+  });
 }
 
 async function withNarrativeSessionLock<T>(sessionKey: string, fn: () => Promise<T>): Promise<T> {


### PR DESCRIPTION
## Summary
- write the deep-phase summary into `DREAMS.md` (or an existing `dreams.md`) using a managed `## Deep Sleep` block
- keep the existing per-phase deep report output under `memory/dreaming/deep/YYYY-MM-DD.md` when separate reports are enabled
- add coverage that the deep summary is written and that existing dream diary markers/content are preserved

## Testing
- `pnpm exec tsx verify-deep-dreaming-summary.ts` *(temporary smoke script run locally, then removed)*
