### PR TITLE
fix(parallel): send openclaw-parallel User-Agent on free Search MCP requests

### DIFF
--- a/extensions/parallel/src/parallel-mcp-search.runtime.test.ts
+++ b/extensions/parallel/src/parallel-mcp-search.runtime.test.ts
@@ -201,6 +201,10 @@ describe("runParallelMcpSearch", () => {
     expect(headerOf(endpointMockState.calls[2], "MCP-Protocol-Version")).toBe("2025-06-18");
     // No bearer token on the anonymous free path.
     expect(headerOf(endpointMockState.calls[0], "Authorization")).toBeUndefined();
+    // Every call identifies OpenClaw at the HTTP layer (not just node).
+    for (const call of endpointMockState.calls) {
+      expect(headerOf(call, "User-Agent")).toMatch(/^openclaw-parallel\//);
+    }
     // tools/call carries the documented web_search args.
     const callArgs = (readBody(endpointMockState.calls[2]).params as Record<string, unknown>)
       .arguments as Record<string, unknown>;

--- a/extensions/parallel/src/parallel-mcp-search.runtime.ts
+++ b/extensions/parallel/src/parallel-mcp-search.runtime.ts
@@ -14,6 +14,10 @@ const MCP_TIMEOUT_SECONDS = 30;
 
 const require = createRequire(import.meta.url);
 const PLUGIN_VERSION = readPluginPackageVersion({ require });
+// Identify free-tier traffic at the HTTP layer (mirrors the paid REST path);
+// without this, undici sends a generic `node` UA and OpenClaw usage is only
+// visible via the JSON-RPC `clientInfo` payload.
+const USER_AGENT = `openclaw-parallel/${PLUGIN_VERSION} (${process.platform})`;
 
 type JsonRpcMessage = Record<string, unknown>;
 
@@ -38,6 +42,7 @@ function mcpHeaders(params: {
 }): Record<string, string> {
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
+    "User-Agent": USER_AGENT,
     // The Search MCP may answer either as a single JSON object or as an SSE
     // stream; advertise both so the server can pick.
     Accept: "application/json, text/event-stream",


### PR DESCRIPTION
## Summary

What problem does this PR solve?

The free **Parallel Search (Free)** (`parallel-free`) MCP client set no `User-Agent` header, so Node's `undici` fetch sent a generic `User-Agent: node`. Since `parallel-free` is the zero-config `web_search` default, the path most installs hit was the *least* identifiable at the HTTP layer — OpenClaw usage was only visible via the JSON-RPC `clientInfo` payload, not the request's User-Agent.

What is the intended outcome?

The free MCP client now sends the same `openclaw-parallel/<version> (<platform>)` User-Agent the paid REST path (`parallel`) already uses, so free-tier traffic is attributable at the HTTP layer (useful for analytics and rate-limiting alongside source IP).

What is intentionally out of scope?

No behavior change beyond the added header; the request stays anonymous (no `Authorization`), the JSON-RPC `clientInfo` is unchanged, and the paid REST path is untouched. Follow-up to #90849 (which added the free provider).

## Linked context

Which issues, PRs, or discussions are related?

Follow-up to #90849 (added the `parallel-free` provider and its hand-rolled MCP client).

Was this requested by a maintainer or owner?

No. This is an external contribution from the Parallel team, following up on #90849 (the merged PR that added the `parallel-free` provider) to make free-tier traffic identifiable at the HTTP layer.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: free Search MCP requests now carry an `openclaw-parallel/<version>` User-Agent instead of the default `node`.
- Real environment tested: macOS; live anonymous calls to `https://search.parallel.ai/mcp`.
- Exact steps or command run after this patch: drive the full handshake (`initialize` → `notifications/initialized` → `tools/call web_search`) against the live free MCP with the new User-Agent and confirm it is accepted and returns live results:

```bash
UA="openclaw-parallel/$(node -e "console.log(require('./extensions/parallel/package.json').version)") (darwin)"
# initialize (capture mcp-session-id) -> notifications/initialized -> tools/call web_search,
# every request sent with: curl -A "$UA" ... https://search.parallel.ai/mcp
```

- Evidence after fix: the live free MCP accepted the new User-Agent and returned real results (anonymous, no key):

```
User-Agent under test: openclaw-parallel/2026.5.21 (darwin)
HTTP UA accepted; live results: 10
top result: France's Capital - GraphicMaps.com -> http://graphicmaps.com/france/capital
```

  Before this patch, the same path sent `User-Agent: node` (Node v24 `undici` default), verified via a local echo server.

- Observed result after fix: server serves results normally with the OpenClaw-identifying UA; no 4xx from the new header.
- What was not tested: server-side log attribution (requires Parallel's own logs); cross-OS UA string beyond `darwin`.
- Proof limitations or environment constraints: free MCP results vary over time.

## Tests and validation

Which commands did you run?

`pnpm build` (no `[INEFFECTIVE_DYNAMIC_IMPORT]`); `pnpm tsgo:extensions`; `oxfmt`/`oxlint`; `pnpm test` on `extensions/parallel` (MCP-client + free-provider suites). `codex review --base origin/main`: no actionable findings.

What regression coverage was added or updated?

Extended `parallel-mcp-search.runtime.test.ts` to assert every handshake request (`initialize`, `notifications/initialized`, `tools/call`) carries a `User-Agent` matching `openclaw-parallel/`.

## Risk checklist

Did user-visible behavior change? No agent-visible change; only an outbound HTTP request header is added.

Did config, environment, or migration behavior change? No.

Did security, auth, secrets, network, or tool execution behavior change? Adds a `User-Agent` header to existing anonymous requests to `search.parallel.ai` (already routed through the `withTrustedWebSearchEndpoint` SSRF guard). No credentials added.

What is the highest-risk area?

A server rejecting the new UA — ruled out by the live call above (HTTP 200 + results).

## Current review state

What is the next action?

Ready for review.

What is still waiting on author, maintainer, CI, or external proof?

Nothing — local checks + codex clean; live proof included above.

