### PR TITLE
Refactor core fetch paths off guarded fetch

### DIFF
--- a/docs/gateway/config-tools.md
+++ b/docs/gateway/config-tools.md
@@ -274,7 +274,6 @@ If `warningThreshold >= criticalThreshold` or `criticalThreshold >= globalCircui
         maxResponseBytes: 2000000,
         timeoutSeconds: 30,
         cacheTtlMinutes: 15,
-        maxRedirects: 3,
         readability: true,
         userAgent: "custom-ua",
       },

--- a/docs/gateway/doctor.md
+++ b/docs/gateway/doctor.md
@@ -285,7 +285,7 @@ That stages grounded durable candidates into the short-term dreaming store while
     - remove `browser.relayBindHost` (legacy extension relay setting)
     - legacy `models.providers.*.api: "openai"` → `"openai-completions"` (gateway startup also skips providers whose `api` is set to a future or unknown enum value rather than failing closed)
     - remove `plugins.entries.codex.config.codexDynamicToolsProfile`; Codex app-server always keeps Codex-native workspace tools native
-    - remove deprecated generic fetch policy keys: `tools.web.fetch.maxRedirects`, `tools.web.fetch.useTrustedEnvProxy`, `tools.web.fetch.ssrfPolicy`, `gateway.http.endpoints.chatCompletions.images.maxRedirects`, `gateway.http.endpoints.responses.files.maxRedirects`, and `gateway.http.endpoints.responses.images.maxRedirects`
+    - remove deprecated generic fetch policy keys: `tools.web.fetch.maxRedirects`, `tools.web.fetch.useTrustedEnvProxy`, `tools.web.fetch.ssrfPolicy`, and positive gateway URL `maxRedirects` caps. Gateway `maxRedirects: 0` is preserved because it still rejects redirects.
 
     Doctor warnings also include account-default guidance for multi-account channels:
 

--- a/docs/gateway/doctor.md
+++ b/docs/gateway/doctor.md
@@ -285,6 +285,7 @@ That stages grounded durable candidates into the short-term dreaming store while
     - remove `browser.relayBindHost` (legacy extension relay setting)
     - legacy `models.providers.*.api: "openai"` → `"openai-completions"` (gateway startup also skips providers whose `api` is set to a future or unknown enum value rather than failing closed)
     - remove `plugins.entries.codex.config.codexDynamicToolsProfile`; Codex app-server always keeps Codex-native workspace tools native
+    - remove deprecated generic fetch policy keys: `tools.web.fetch.maxRedirects`, `tools.web.fetch.useTrustedEnvProxy`, `tools.web.fetch.ssrfPolicy`, `gateway.http.endpoints.chatCompletions.images.maxRedirects`, `gateway.http.endpoints.responses.files.maxRedirects`, and `gateway.http.endpoints.responses.images.maxRedirects`
 
     Doctor warnings also include account-default guidance for multi-account channels:
 

--- a/docs/gateway/doctor.md
+++ b/docs/gateway/doctor.md
@@ -285,7 +285,7 @@ That stages grounded durable candidates into the short-term dreaming store while
     - remove `browser.relayBindHost` (legacy extension relay setting)
     - legacy `models.providers.*.api: "openai"` → `"openai-completions"` (gateway startup also skips providers whose `api` is set to a future or unknown enum value rather than failing closed)
     - remove `plugins.entries.codex.config.codexDynamicToolsProfile`; Codex app-server always keeps Codex-native workspace tools native
-    - remove deprecated generic fetch policy keys: `tools.web.fetch.maxRedirects`, `tools.web.fetch.useTrustedEnvProxy`, `tools.web.fetch.ssrfPolicy`, and positive gateway URL `maxRedirects` caps. Gateway `maxRedirects: 0` is preserved because it still rejects redirects.
+    - remove deprecated generic fetch policy keys: `tools.web.fetch.maxRedirects`, `tools.web.fetch.useTrustedEnvProxy`, `tools.web.fetch.ssrfPolicy`, and gateway URL `maxRedirects` caps. Gateway input URL fetches now reject redirects by default, so `maxRedirects` no longer changes redirect behavior.
 
     Doctor warnings also include account-default guidance for multi-account channels:
 

--- a/docs/gateway/doctor.md
+++ b/docs/gateway/doctor.md
@@ -285,7 +285,7 @@ That stages grounded durable candidates into the short-term dreaming store while
     - remove `browser.relayBindHost` (legacy extension relay setting)
     - legacy `models.providers.*.api: "openai"` → `"openai-completions"` (gateway startup also skips providers whose `api` is set to a future or unknown enum value rather than failing closed)
     - remove `plugins.entries.codex.config.codexDynamicToolsProfile`; Codex app-server always keeps Codex-native workspace tools native
-    - remove deprecated generic fetch policy keys: `tools.web.fetch.maxRedirects`, `tools.web.fetch.useTrustedEnvProxy`, `tools.web.fetch.ssrfPolicy`, and gateway URL `maxRedirects` caps. Gateway input URL fetches now reject redirects by default, so `maxRedirects` no longer changes redirect behavior.
+    - remove deprecated generic fetch policy keys: `tools.web.fetch.maxRedirects`, `tools.web.fetch.useTrustedEnvProxy`, and gateway URL `maxRedirects` caps. Gateway input URL fetches now reject redirects by default, so `maxRedirects` no longer changes redirect behavior. `tools.web.fetch.ssrfPolicy` is preserved while remote media tools still read that shared key.
 
     Doctor warnings also include account-default guidance for multi-account channels:
 

--- a/docs/gateway/openresponses-http-api.md
+++ b/docs/gateway/openresponses-http-api.md
@@ -219,7 +219,6 @@ Defaults can be tuned under `gateway.http.endpoints.responses`:
             ],
             maxBytes: 5242880,
             maxChars: 200000,
-            maxRedirects: 3,
             timeoutMs: 10000,
             pdf: {
               maxPages: 4,
@@ -239,7 +238,6 @@ Defaults can be tuned under `gateway.http.endpoints.responses`:
               "image/heif",
             ],
             maxBytes: 10485760,
-            maxRedirects: 3,
             timeoutMs: 10000,
           },
         },
@@ -255,22 +253,22 @@ Defaults when omitted:
 - `maxUrlParts`: 8
 - `files.maxBytes`: 5MB
 - `files.maxChars`: 200k
-- `files.maxRedirects`: 3
 - `files.timeoutMs`: 10s
 - `files.pdf.maxPages`: 4
 - `files.pdf.maxPixels`: 4,000,000
 - `files.pdf.minTextChars`: 200
 - `images.maxBytes`: 10MB
-- `images.maxRedirects`: 3
 - `images.timeoutMs`: 10s
 - HEIC/HEIF `input_image` sources are accepted when a system converter is available and are normalized to JPEG before provider delivery. Supported converters are macOS `sips`, ImageMagick, GraphicsMagick, or ffmpeg.
 
 Security note:
 
-- URL allowlists are enforced before fetch and on redirect hops.
-- Allowlisting a hostname does not bypass private/internal IP blocking.
-- For internet-exposed gateways, apply network egress controls in addition to app-level guards.
-  See [Security](/gateway/security).
+- URL allowlists are enforced before fetch and on the final native-fetch URL
+  after redirects.
+- URL fetches use native fetch redirects. The former positive `maxRedirects`
+  caps are deprecated; run `openclaw doctor --fix` to remove them from config.
+- For internet-exposed gateways, use [Network proxy](/security/network-proxy)
+  when you need outbound destination policy.
 
 ## Streaming (SSE)
 

--- a/docs/gateway/openresponses-http-api.md
+++ b/docs/gateway/openresponses-http-api.md
@@ -266,7 +266,8 @@ Security note:
 - URL allowlists are enforced before fetch and on the final native-fetch URL
   after redirects.
 - URL fetches use native fetch redirects. The former positive `maxRedirects`
-  caps are deprecated; run `openclaw doctor --fix` to remove them from config.
+  caps are deprecated; set `maxRedirects: 0` only when you want URL fetches to
+  reject redirects.
 - For internet-exposed gateways, use [Network proxy](/security/network-proxy)
   when you need outbound destination policy.
 

--- a/docs/gateway/openresponses-http-api.md
+++ b/docs/gateway/openresponses-http-api.md
@@ -263,11 +263,9 @@ Defaults when omitted:
 
 Security note:
 
-- URL allowlists are enforced before fetch and on the final native-fetch URL
-  after redirects.
-- URL fetches use native fetch redirects. The former positive `maxRedirects`
-  caps are deprecated; set `maxRedirects: 0` only when you want URL fetches to
-  reject redirects.
+- URL allowlists are enforced before fetch and on the final native-fetch URL.
+- URL fetches reject redirects. The former `maxRedirects` caps are deprecated
+  and no longer change redirect behavior.
 - For internet-exposed gateways, use [Network proxy](/security/network-proxy)
   when you need outbound destination policy.
 

--- a/docs/security/network-proxy.md
+++ b/docs/security/network-proxy.md
@@ -56,7 +56,7 @@ On shutdown, OpenClaw restores the previous proxy environment and resets cached 
 - `proxy.enabled` / `proxy.proxyUrl`: outbound forward-proxy routing for OpenClaw runtime egress. This page documents that feature.
 - `gateway.auth.mode: "trusted-proxy"`: inbound identity-aware reverse-proxy authentication for Gateway access. See [Trusted proxy auth](/gateway/trusted-proxy-auth).
 - `openclaw proxy`: local debug proxy and capture inspector for development and support. See [openclaw proxy](/cli/proxy).
-- `tools.web.fetch.useTrustedEnvProxy`: opt-in for `web_fetch` to let an operator-controlled HTTP(S) env proxy resolve DNS while keeping default strict DNS pinning and hostname policy. See [Web fetch](/tools/web-fetch#trusted-env-proxy).
+- Deprecated generic fetch policy keys: `tools.web.fetch.maxRedirects`, `tools.web.fetch.useTrustedEnvProxy`, and `tools.web.fetch.ssrfPolicy` no longer configure direct `web_fetch` egress policy. `openclaw doctor --fix` removes them.
 - Channel or provider-specific proxy settings: owner-specific overrides for a particular transport. Prefer the managed network proxy when the goal is central egress control across the runtime.
 
 ## Configuration

--- a/docs/security/network-proxy.md
+++ b/docs/security/network-proxy.md
@@ -56,7 +56,7 @@ On shutdown, OpenClaw restores the previous proxy environment and resets cached 
 - `proxy.enabled` / `proxy.proxyUrl`: outbound forward-proxy routing for OpenClaw runtime egress. This page documents that feature.
 - `gateway.auth.mode: "trusted-proxy"`: inbound identity-aware reverse-proxy authentication for Gateway access. See [Trusted proxy auth](/gateway/trusted-proxy-auth).
 - `openclaw proxy`: local debug proxy and capture inspector for development and support. See [openclaw proxy](/cli/proxy).
-- Deprecated generic fetch policy keys: `tools.web.fetch.maxRedirects`, `tools.web.fetch.useTrustedEnvProxy`, and `tools.web.fetch.ssrfPolicy` no longer configure direct `web_fetch` egress policy. `openclaw doctor --fix` removes them.
+- Deprecated generic fetch policy keys: `tools.web.fetch.maxRedirects`, `tools.web.fetch.useTrustedEnvProxy`, and `tools.web.fetch.ssrfPolicy` no longer configure direct `web_fetch` egress policy. `openclaw doctor --fix` removes `maxRedirects` and `useTrustedEnvProxy`; `ssrfPolicy` is preserved while remote media tools still read that shared key.
 - Channel or provider-specific proxy settings: owner-specific overrides for a particular transport. Prefer the managed network proxy when the goal is central egress control across the runtime.
 
 ## Configuration

--- a/docs/tools/web-fetch.md
+++ b/docs/tools/web-fetch.md
@@ -42,7 +42,8 @@ Truncate output to this many characters.
 <Steps>
   <Step title="Fetch">
     Sends an HTTP GET with a Chrome-like User-Agent and `Accept-Language`
-    header. Blocks private/internal hostnames and re-checks redirects.
+    header. The initial URL must be `http` or `https`; redirects use native
+    fetch behavior.
   </Step>
   <Step title="Extract">
     Runs Readability (main-content extraction) on the HTML response.
@@ -86,14 +87,8 @@ content.
         maxResponseBytes: 2000000, // max download size before truncation
         timeoutSeconds: 30,
         cacheTtlMinutes: 15,
-        maxRedirects: 3,
-        useTrustedEnvProxy: false, // let a trusted HTTP(S) env proxy resolve DNS
         readability: true, // use Readability extraction
         userAgent: "Mozilla/5.0 ...", // override User-Agent
-        ssrfPolicy: {
-          allowRfc2544BenchmarkRange: true, // opt-in for trusted fake-IP proxies using 198.18.0.0/15
-          allowIpv6UniqueLocalRange: true, // opt-in for trusted fake-IP proxies using fc00::/7
-        },
       },
     },
   },
@@ -158,36 +153,37 @@ Current runtime behavior:
 - If Readability is disabled, `web_fetch` skips straight to the selected
   provider fallback. If no provider is available, it fails closed.
 
-## Trusted env proxy
+## Fetch policy change
 
-If your deployment requires `web_fetch` to go through a trusted outbound
-HTTP(S) proxy, set `tools.web.fetch.useTrustedEnvProxy: true`.
+Direct `web_fetch` uses native fetch for the initial HTTP(S) request. OpenClaw
+core fetch paths no longer provide app-level private-IP / SSRF blocking, fake-IP
+policy opt-ins, trusted-env-proxy DNS mode, or custom positive redirect caps.
 
-In this mode, OpenClaw still applies hostname-based SSRF checks before sending
-the request, but it lets the proxy resolve DNS instead of doing local DNS
-pinning. Enable this only when the proxy is operator-controlled and enforces
-outbound policy after DNS resolution.
+These old keys are deprecated and ignored by direct `web_fetch`:
 
-<Note>
-  If no HTTP(S) proxy env var is configured, or the target host is excluded by
-  `NO_PROXY`, `web_fetch` falls back to the normal strict path with local DNS
-  pinning.
-</Note>
+- `tools.web.fetch.maxRedirects`
+- `tools.web.fetch.useTrustedEnvProxy`
+- `tools.web.fetch.ssrfPolicy`
+
+Run `openclaw doctor` to report deprecated keys, or run
+`openclaw doctor --fix` to remove them from config.
+
+Use [Network proxy](/security/network-proxy) when a deployment needs outbound
+destination policy. Managed proxy / Proxyline is the supported egress-policy
+boundary; it is a policy-model change, not exact feature parity with the old
+guarded fetch helper.
+
+Browser navigation is separate. `browser.ssrfPolicy` still controls browser and
+CDP navigation policy and is not deprecated by this `web_fetch` change.
 
 ## Limits and safety
 
 - `maxChars` is clamped to `tools.web.fetch.maxCharsCap`
 - Response body is capped at `maxResponseBytes` before parsing; oversized
   responses are truncated with a warning
-- Private/internal hostnames are blocked
-- `tools.web.fetch.ssrfPolicy.allowRfc2544BenchmarkRange` and
-  `tools.web.fetch.ssrfPolicy.allowIpv6UniqueLocalRange` are narrow opt-ins
-  for trusted fake-IP proxy stacks; leave them unset unless your proxy owns
-  those synthetic ranges and enforces its own destination policy
-- Redirects are checked and limited by `maxRedirects`
-- `useTrustedEnvProxy` is an explicit opt-in and should only be enabled for
-  operator-controlled proxies that still enforce outbound policy after DNS
-  resolution
+- The initial URL must be `http` or `https`
+- Redirects use native fetch behavior
+- For outbound destination policy, configure [Network proxy](/security/network-proxy)
 - `web_fetch` is best-effort -- some sites need the [Web Browser](/tools/browser)
 
 ## Tool profiles

--- a/docs/tools/web-fetch.md
+++ b/docs/tools/web-fetch.md
@@ -166,7 +166,9 @@ These old keys are deprecated and ignored by direct `web_fetch`:
 - `tools.web.fetch.ssrfPolicy`
 
 Run `openclaw doctor` to report deprecated keys, or run
-`openclaw doctor --fix` to remove them from config.
+`openclaw doctor --fix` to remove `maxRedirects` and `useTrustedEnvProxy` from
+config. `ssrfPolicy` is preserved for now because remote media tools still read
+that shared key until a replacement media-specific key exists.
 
 Use [Network proxy](/security/network-proxy) when a deployment needs outbound
 destination policy. Managed proxy / Proxyline is the supported egress-policy

--- a/docs/tools/web.md
+++ b/docs/tools/web.md
@@ -168,10 +168,11 @@ trusted provider API hosts, OpenClaw allows Surge, Clash, and sing-box fake-IP
 DNS answers in `198.18.0.0/15` and `fc00::/7` only for that provider hostname.
 Other private, loopback, link-local, and metadata destinations remain blocked.
 
-This automatic allowance does not apply to arbitrary `web_fetch` URLs. For
-`web_fetch`, enable `tools.web.fetch.ssrfPolicy.allowRfc2544BenchmarkRange` and
-`tools.web.fetch.ssrfPolicy.allowIpv6UniqueLocalRange` explicitly only when your
-trusted proxy owns those synthetic ranges.
+This automatic allowance does not apply to arbitrary `web_fetch` URLs. Direct
+`web_fetch` now uses native fetch and no longer consumes
+`tools.web.fetch.ssrfPolicy`. Use [Network proxy](/security/network-proxy) when
+a deployment needs outbound destination policy for `web_fetch` and other
+runtime HTTP traffic.
 
 ## Setting up web search
 

--- a/extensions/discord/src/voice-message.test.ts
+++ b/extensions/discord/src/voice-message.test.ts
@@ -7,19 +7,6 @@ import type { VoiceMessageMetadata } from "./voice-message.js";
 
 const runFfprobeMock = vi.hoisted(() => vi.fn<(...args: unknown[]) => Promise<string>>());
 const runFfmpegMock = vi.hoisted(() => vi.fn<(...args: unknown[]) => Promise<void>>());
-const fetchWithSsrFGuardMock = vi.hoisted(() =>
-  vi.fn(
-    async (params: {
-      url: string;
-      init?: RequestInit;
-      policy?: { allowRfc2544BenchmarkRange?: boolean; allowIpv6UniqueLocalRange?: boolean };
-      auditContext?: string;
-    }) => ({
-      response: await globalThis.fetch(params.url, params.init),
-      release: async () => {},
-    }),
-  ),
-);
 
 vi.mock("openclaw/plugin-sdk/temp-path", async () => {
   return {
@@ -40,12 +27,6 @@ vi.mock("openclaw/plugin-sdk/media-runtime", async () => {
     },
     MEDIA_FFMPEG_MAX_AUDIO_DURATION_SECS: 1200,
     unlinkIfExists: vi.fn(async () => {}),
-  };
-});
-
-vi.mock("openclaw/plugin-sdk/ssrf-runtime", async () => {
-  return {
-    fetchWithSsrFGuard: fetchWithSsrFGuardMock,
   };
 });
 
@@ -207,7 +188,6 @@ describe("sendDiscordVoiceMessage", () => {
 
   beforeEach(() => {
     vi.restoreAllMocks();
-    fetchWithSsrFGuardMock.mockClear();
   });
 
   function createRest(post = vi.fn(async () => ({ id: "msg-1", channel_id: "channel-1" }))) {
@@ -281,33 +261,32 @@ describe("sendDiscordVoiceMessage", () => {
 
     expect(uploadUrlRequests).toBe(2);
     expect(fetchMock).toHaveBeenCalledTimes(4);
-    expect(fetchWithSsrFGuardMock).toHaveBeenCalledTimes(4);
     expect(
-      fetchWithSsrFGuardMock.mock.calls.map(([params]) => ({
-        auditContext: params.auditContext,
-        allowRfc2544BenchmarkRange: params.policy?.allowRfc2544BenchmarkRange,
-        allowIpv6UniqueLocalRange: params.policy?.allowIpv6UniqueLocalRange,
+      fetchMock.mock.calls.map(([input, init]) => ({
+        url: input instanceof Request ? input.url : String(input),
+        method: input instanceof Request ? input.method : (init?.method ?? "GET"),
+        redirect: input instanceof Request ? input.redirect : init?.redirect,
       })),
     ).toEqual([
       {
-        auditContext: "discord.voice.upload-url",
-        allowRfc2544BenchmarkRange: true,
-        allowIpv6UniqueLocalRange: true,
+        url: "https://discord.test/api/v10/channels/channel-1/attachments",
+        method: "POST",
+        redirect: "error",
       },
       {
-        auditContext: "discord.voice.attachment-upload",
-        allowRfc2544BenchmarkRange: true,
-        allowIpv6UniqueLocalRange: true,
+        url: "https://cdn.test/upload-1",
+        method: "PUT",
+        redirect: "error",
       },
       {
-        auditContext: "discord.voice.upload-url",
-        allowRfc2544BenchmarkRange: true,
-        allowIpv6UniqueLocalRange: true,
+        url: "https://discord.test/api/v10/channels/channel-1/attachments",
+        method: "POST",
+        redirect: "error",
       },
       {
-        auditContext: "discord.voice.attachment-upload",
-        allowRfc2544BenchmarkRange: true,
-        allowIpv6UniqueLocalRange: true,
+        url: "https://cdn.test/upload-2",
+        method: "PUT",
+        redirect: "error",
       },
     ]);
     expect(post).toHaveBeenCalledWith("/channels/channel-1/messages", {

--- a/extensions/discord/src/voice-message.test.ts
+++ b/extensions/discord/src/voice-message.test.ts
@@ -7,6 +7,15 @@ import type { VoiceMessageMetadata } from "./voice-message.js";
 
 const runFfprobeMock = vi.hoisted(() => vi.fn<(...args: unknown[]) => Promise<string>>());
 const runFfmpegMock = vi.hoisted(() => vi.fn<(...args: unknown[]) => Promise<void>>());
+const fetchWithSsrFGuardMock = vi.hoisted(() => vi.fn());
+
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/ssrf-runtime")>();
+  return {
+    ...actual,
+    fetchWithSsrFGuard: fetchWithSsrFGuardMock,
+  };
+});
 
 vi.mock("openclaw/plugin-sdk/temp-path", async () => {
   return {
@@ -188,6 +197,7 @@ describe("sendDiscordVoiceMessage", () => {
 
   beforeEach(() => {
     vi.restoreAllMocks();
+    fetchWithSsrFGuardMock.mockReset();
   });
 
   function createRest(post = vi.fn(async () => ({ id: "msg-1", channel_id: "channel-1" }))) {
@@ -234,17 +244,29 @@ describe("sendDiscordVoiceMessage", () => {
           { status: 200 },
         );
       }
-      if (method === "PUT" && url === "https://cdn.test/upload-1") {
-        return new Response(
-          JSON.stringify({ message: "Slow down", retry_after: 0, global: false }),
-          { status: 429 },
-        );
-      }
-      if (method === "PUT" && url === "https://cdn.test/upload-2") {
-        return new Response(null, { status: 200 });
-      }
       throw new Error(`unexpected fetch ${method} ${url}`);
     });
+    const guardedReleases = [vi.fn(async () => {}), vi.fn(async () => {})];
+    fetchWithSsrFGuardMock.mockImplementation(
+      async ({ url }: { url: string; init?: RequestInit }) => {
+        if (url === "https://cdn.test/upload-1") {
+          return {
+            response: new Response(
+              JSON.stringify({ message: "Slow down", retry_after: 0, global: false }),
+              { status: 429 },
+            ),
+            release: guardedReleases[0],
+          };
+        }
+        if (url === "https://cdn.test/upload-2") {
+          return {
+            response: new Response(null, { status: 200 }),
+            release: guardedReleases[1],
+          };
+        }
+        throw new Error(`unexpected guarded fetch ${url}`);
+      },
+    );
 
     await expect(
       sendDiscordVoiceMessage(
@@ -260,7 +282,7 @@ describe("sendDiscordVoiceMessage", () => {
     ).resolves.toEqual({ id: "msg-1", channel_id: "channel-1" });
 
     expect(uploadUrlRequests).toBe(2);
-    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(
       fetchMock.mock.calls.map(([input, init]) => ({
         url: input instanceof Request ? input.url : String(input),
@@ -274,21 +296,49 @@ describe("sendDiscordVoiceMessage", () => {
         redirect: "error",
       },
       {
-        url: "https://cdn.test/upload-1",
-        method: "PUT",
-        redirect: "error",
-      },
-      {
         url: "https://discord.test/api/v10/channels/channel-1/attachments",
         method: "POST",
         redirect: "error",
       },
+    ]);
+    expect(fetchWithSsrFGuardMock).toHaveBeenCalledTimes(2);
+    expect(
+      fetchWithSsrFGuardMock.mock.calls.map(([params]) => {
+        const call = params as {
+          url: string;
+          init?: RequestInit;
+          policy?: unknown;
+          auditContext?: string;
+        };
+        return {
+          url: call.url,
+          method: call.init?.method,
+          auditContext: call.auditContext,
+          policy: call.policy,
+        };
+      }),
+    ).toEqual([
+      {
+        url: "https://cdn.test/upload-1",
+        method: "PUT",
+        auditContext: "discord.voice.attachment-upload",
+        policy: {
+          allowRfc2544BenchmarkRange: true,
+          allowIpv6UniqueLocalRange: true,
+        },
+      },
       {
         url: "https://cdn.test/upload-2",
         method: "PUT",
-        redirect: "error",
+        auditContext: "discord.voice.attachment-upload",
+        policy: {
+          allowRfc2544BenchmarkRange: true,
+          allowIpv6UniqueLocalRange: true,
+        },
       },
     ]);
+    expect(guardedReleases[0]).toHaveBeenCalledTimes(1);
+    expect(guardedReleases[1]).toHaveBeenCalledTimes(1);
     expect(post).toHaveBeenCalledWith("/channels/channel-1/messages", {
       body: {
         flags: 8192,
@@ -324,10 +374,12 @@ describe("sendDiscordVoiceMessage", () => {
           { status: 200 },
         );
       }
-      if (method === "PUT" && url === "https://cdn.test/upload") {
-        return new Response("cdn unavailable", { status: 503 });
-      }
       throw new Error(`unexpected fetch ${method} ${url}`);
+    });
+    const release = vi.fn(async () => {});
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: new Response("cdn unavailable", { status: 503 }),
+      release,
     });
 
     let error: unknown;
@@ -352,5 +404,21 @@ describe("sendDiscordVoiceMessage", () => {
     expect((error as { rawBody?: unknown }).rawBody).toEqual({
       message: "cdn unavailable",
     });
+    expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith({
+      url: "https://cdn.test/upload",
+      init: {
+        method: "PUT",
+        headers: {
+          "Content-Type": "audio/ogg",
+        },
+        body: expect.any(Uint8Array),
+      },
+      policy: {
+        allowRfc2544BenchmarkRange: true,
+        allowIpv6UniqueLocalRange: true,
+      },
+      auditContext: "discord.voice.attachment-upload",
+    });
+    expect(release).toHaveBeenCalledTimes(1);
   });
 });

--- a/extensions/discord/src/voice-message.test.ts
+++ b/extensions/discord/src/voice-message.test.ts
@@ -226,42 +226,48 @@ describe("sendDiscordVoiceMessage", () => {
     const post = vi.fn(async () => ({ id: "msg-1", channel_id: "channel-1" }));
     const rest = createRest(post);
     let uploadUrlRequests = 0;
-    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
-      const url = input instanceof Request ? input.url : String(input);
-      const method = input instanceof Request ? input.method : (init?.method ?? "GET");
-      if (method === "POST" && url.endsWith("/channels/channel-1/attachments")) {
-        uploadUrlRequests += 1;
-        return new Response(
-          JSON.stringify({
-            attachments: [
-              {
-                id: 0,
-                upload_url: `https://cdn.test/upload-${uploadUrlRequests}`,
-                upload_filename: `uploaded-${uploadUrlRequests}.ogg`,
-              },
-            ],
-          }),
-          { status: 200 },
-        );
-      }
-      throw new Error(`unexpected fetch ${method} ${url}`);
-    });
-    const guardedReleases = [vi.fn(async () => {}), vi.fn(async () => {})];
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockRejectedValue(new Error("unexpected fetch"));
+    const guardedReleases = [
+      vi.fn(async () => {}),
+      vi.fn(async () => {}),
+      vi.fn(async () => {}),
+      vi.fn(async () => {}),
+    ];
     fetchWithSsrFGuardMock.mockImplementation(
-      async ({ url }: { url: string; init?: RequestInit }) => {
+      async ({ url, init }: { url: string; init?: RequestInit }) => {
+        if (init?.method === "POST" && url.endsWith("/channels/channel-1/attachments")) {
+          uploadUrlRequests += 1;
+          return {
+            response: new Response(
+              JSON.stringify({
+                attachments: [
+                  {
+                    id: 0,
+                    upload_url: `https://cdn.test/upload-${uploadUrlRequests}`,
+                    upload_filename: `uploaded-${uploadUrlRequests}.ogg`,
+                  },
+                ],
+              }),
+              { status: 200 },
+            ),
+            release: guardedReleases[uploadUrlRequests - 1],
+          };
+        }
         if (url === "https://cdn.test/upload-1") {
           return {
             response: new Response(
               JSON.stringify({ message: "Slow down", retry_after: 0, global: false }),
               { status: 429 },
             ),
-            release: guardedReleases[0],
+            release: guardedReleases[2],
           };
         }
         if (url === "https://cdn.test/upload-2") {
           return {
             response: new Response(null, { status: 200 }),
-            release: guardedReleases[1],
+            release: guardedReleases[3],
           };
         }
         throw new Error(`unexpected guarded fetch ${url}`);
@@ -282,26 +288,8 @@ describe("sendDiscordVoiceMessage", () => {
     ).resolves.toEqual({ id: "msg-1", channel_id: "channel-1" });
 
     expect(uploadUrlRequests).toBe(2);
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(
-      fetchMock.mock.calls.map(([input, init]) => ({
-        url: input instanceof Request ? input.url : String(input),
-        method: input instanceof Request ? input.method : (init?.method ?? "GET"),
-        redirect: input instanceof Request ? input.redirect : init?.redirect,
-      })),
-    ).toEqual([
-      {
-        url: "https://discord.test/api/v10/channels/channel-1/attachments",
-        method: "POST",
-        redirect: "error",
-      },
-      {
-        url: "https://discord.test/api/v10/channels/channel-1/attachments",
-        method: "POST",
-        redirect: "error",
-      },
-    ]);
-    expect(fetchWithSsrFGuardMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(fetchWithSsrFGuardMock).toHaveBeenCalledTimes(4);
     expect(
       fetchWithSsrFGuardMock.mock.calls.map(([params]) => {
         const call = params as {
@@ -313,15 +301,37 @@ describe("sendDiscordVoiceMessage", () => {
         return {
           url: call.url,
           method: call.init?.method,
+          redirect: call.init?.redirect,
           auditContext: call.auditContext,
           policy: call.policy,
         };
       }),
     ).toEqual([
       {
+        url: "https://discord.test/api/v10/channels/channel-1/attachments",
+        method: "POST",
+        redirect: "error",
+        auditContext: "discord.voice.upload-url",
+        policy: {
+          allowRfc2544BenchmarkRange: true,
+          allowIpv6UniqueLocalRange: true,
+        },
+      },
+      {
         url: "https://cdn.test/upload-1",
         method: "PUT",
+        redirect: undefined,
         auditContext: "discord.voice.attachment-upload",
+        policy: {
+          allowRfc2544BenchmarkRange: true,
+          allowIpv6UniqueLocalRange: true,
+        },
+      },
+      {
+        url: "https://discord.test/api/v10/channels/channel-1/attachments",
+        method: "POST",
+        redirect: "error",
+        auditContext: "discord.voice.upload-url",
         policy: {
           allowRfc2544BenchmarkRange: true,
           allowIpv6UniqueLocalRange: true,
@@ -330,6 +340,7 @@ describe("sendDiscordVoiceMessage", () => {
       {
         url: "https://cdn.test/upload-2",
         method: "PUT",
+        redirect: undefined,
         auditContext: "discord.voice.attachment-upload",
         policy: {
           allowRfc2544BenchmarkRange: true,
@@ -339,6 +350,8 @@ describe("sendDiscordVoiceMessage", () => {
     ]);
     expect(guardedReleases[0]).toHaveBeenCalledTimes(1);
     expect(guardedReleases[1]).toHaveBeenCalledTimes(1);
+    expect(guardedReleases[2]).toHaveBeenCalledTimes(1);
+    expect(guardedReleases[3]).toHaveBeenCalledTimes(1);
     expect(post).toHaveBeenCalledWith("/channels/channel-1/messages", {
       body: {
         flags: 8192,
@@ -357,26 +370,24 @@ describe("sendDiscordVoiceMessage", () => {
 
   it("throws typed CDN upload failures", async () => {
     const rest = createRest();
-    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
-      const url = input instanceof Request ? input.url : String(input);
-      const method = input instanceof Request ? input.method : (init?.method ?? "GET");
-      if (method === "POST" && url.endsWith("/channels/channel-1/attachments")) {
-        return new Response(
-          JSON.stringify({
-            attachments: [
-              {
-                id: 0,
-                upload_url: "https://cdn.test/upload",
-                upload_filename: "uploaded.ogg",
-              },
-            ],
-          }),
-          { status: 200 },
-        );
-      }
-      throw new Error(`unexpected fetch ${method} ${url}`);
-    });
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("unexpected fetch"));
+    const uploadUrlRelease = vi.fn(async () => {});
     const release = vi.fn(async () => {});
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: new Response(
+        JSON.stringify({
+          attachments: [
+            {
+              id: 0,
+              upload_url: "https://cdn.test/upload",
+              upload_filename: "uploaded.ogg",
+            },
+          ],
+        }),
+        { status: 200 },
+      ),
+      release: uploadUrlRelease,
+    });
     fetchWithSsrFGuardMock.mockResolvedValueOnce({
       response: new Response("cdn unavailable", { status: 503 }),
       release,
@@ -405,6 +416,25 @@ describe("sendDiscordVoiceMessage", () => {
       message: "cdn unavailable",
     });
     expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith({
+      url: "https://discord.test/api/v10/channels/channel-1/attachments",
+      init: {
+        method: "POST",
+        headers: {
+          Authorization: "Bot bot-token",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          files: [{ filename: "voice-message.ogg", file_size: 3, id: "0" }],
+        }),
+        redirect: "error",
+      },
+      policy: {
+        allowRfc2544BenchmarkRange: true,
+        allowIpv6UniqueLocalRange: true,
+      },
+      auditContext: "discord.voice.upload-url",
+    });
+    expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith({
       url: "https://cdn.test/upload",
       init: {
         method: "PUT",
@@ -419,6 +449,7 @@ describe("sendDiscordVoiceMessage", () => {
       },
       auditContext: "discord.voice.attachment-upload",
     });
+    expect(uploadUrlRelease).toHaveBeenCalledTimes(1);
     expect(release).toHaveBeenCalledTimes(1);
   });
 });

--- a/extensions/discord/src/voice-message.test.ts
+++ b/extensions/discord/src/voice-message.test.ts
@@ -295,13 +295,14 @@ describe("sendDiscordVoiceMessage", () => {
         const call = params as {
           url: string;
           init?: RequestInit;
+          maxRedirects?: number;
           policy?: unknown;
           auditContext?: string;
         };
         return {
           url: call.url,
           method: call.init?.method,
-          redirect: call.init?.redirect,
+          maxRedirects: call.maxRedirects,
           auditContext: call.auditContext,
           policy: call.policy,
         };
@@ -310,7 +311,7 @@ describe("sendDiscordVoiceMessage", () => {
       {
         url: "https://discord.test/api/v10/channels/channel-1/attachments",
         method: "POST",
-        redirect: "error",
+        maxRedirects: 0,
         auditContext: "discord.voice.upload-url",
         policy: {
           allowRfc2544BenchmarkRange: true,
@@ -320,7 +321,7 @@ describe("sendDiscordVoiceMessage", () => {
       {
         url: "https://cdn.test/upload-1",
         method: "PUT",
-        redirect: undefined,
+        maxRedirects: undefined,
         auditContext: "discord.voice.attachment-upload",
         policy: {
           allowRfc2544BenchmarkRange: true,
@@ -330,7 +331,7 @@ describe("sendDiscordVoiceMessage", () => {
       {
         url: "https://discord.test/api/v10/channels/channel-1/attachments",
         method: "POST",
-        redirect: "error",
+        maxRedirects: 0,
         auditContext: "discord.voice.upload-url",
         policy: {
           allowRfc2544BenchmarkRange: true,
@@ -340,7 +341,7 @@ describe("sendDiscordVoiceMessage", () => {
       {
         url: "https://cdn.test/upload-2",
         method: "PUT",
-        redirect: undefined,
+        maxRedirects: undefined,
         auditContext: "discord.voice.attachment-upload",
         policy: {
           allowRfc2544BenchmarkRange: true,
@@ -426,8 +427,8 @@ describe("sendDiscordVoiceMessage", () => {
         body: JSON.stringify({
           files: [{ filename: "voice-message.ogg", file_size: 3, id: "0" }],
         }),
-        redirect: "error",
       },
+      maxRedirects: 0,
       policy: {
         allowRfc2544BenchmarkRange: true,
         allowIpv6UniqueLocalRange: true,

--- a/extensions/discord/src/voice-message.ts
+++ b/extensions/discord/src/voice-message.ts
@@ -337,14 +337,23 @@ async function requestVoiceUploadUrl(params: {
       files: [{ filename: params.filename, file_size: params.fileSize, id: "0" }],
     }),
   };
-  const res = await fetch(url, {
-    ...uploadUrlInit,
-    redirect: "error",
+  const { response: res, release } = await fetchWithSsrFGuard({
+    url,
+    init: {
+      ...uploadUrlInit,
+      redirect: "error",
+    },
+    policy: DISCORD_VOICE_UPLOAD_SSRF_POLICY,
+    auditContext: "discord.voice.upload-url",
   });
-  if (!res.ok) {
-    throw await createVoiceRequestError(res, "Upload URL request failed");
+  try {
+    if (!res.ok) {
+      throw await createVoiceRequestError(res, "Upload URL request failed");
+    }
+    return (await res.json()) as UploadUrlResponse;
+  } finally {
+    await release();
   }
-  return (await res.json()) as UploadUrlResponse;
 }
 
 async function uploadVoiceAttachment(params: {

--- a/extensions/discord/src/voice-message.ts
+++ b/extensions/discord/src/voice-message.ts
@@ -24,6 +24,7 @@ import { unlinkIfExists } from "openclaw/plugin-sdk/media-runtime";
 import { parseStrictFiniteNumber } from "openclaw/plugin-sdk/number-runtime";
 import type { RetryRunner } from "openclaw/plugin-sdk/retry-runtime";
 import { writeExternalFileWithinRoot } from "openclaw/plugin-sdk/security-runtime";
+import { fetchWithSsrFGuard, type SsrFPolicy } from "openclaw/plugin-sdk/ssrf-runtime";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import { DiscordError, RateLimitError, type RequestClient } from "./internal/discord.js";
@@ -33,6 +34,10 @@ const DISCORD_VOICE_MESSAGE_FLAG = 1 << 13;
 const SUPPRESS_NOTIFICATIONS_FLAG = 1 << 12;
 const WAVEFORM_SAMPLES = 256;
 const DISCORD_OPUS_SAMPLE_RATE_HZ = 48_000;
+const DISCORD_VOICE_UPLOAD_SSRF_POLICY: SsrFPolicy = {
+  allowRfc2544BenchmarkRange: true,
+  allowIpv6UniqueLocalRange: true,
+};
 
 async function runFfmpegToOutput(params: {
   outputPath: string;
@@ -346,17 +351,25 @@ async function uploadVoiceAttachment(params: {
   uploadUrl: string;
   audioBuffer: Buffer;
 }): Promise<void> {
-  const uploadResponse = await fetch(params.uploadUrl, {
-    method: "PUT",
-    headers: {
-      "Content-Type": "audio/ogg",
+  const { response: uploadResponse, release } = await fetchWithSsrFGuard({
+    url: params.uploadUrl,
+    init: {
+      method: "PUT",
+      headers: {
+        "Content-Type": "audio/ogg",
+      },
+      body: new Uint8Array(params.audioBuffer),
     },
-    body: new Uint8Array(params.audioBuffer),
-    redirect: "error",
+    policy: DISCORD_VOICE_UPLOAD_SSRF_POLICY,
+    auditContext: "discord.voice.attachment-upload",
   });
 
-  if (!uploadResponse.ok) {
-    throw await createVoiceRequestError(uploadResponse, "Failed to upload voice message");
+  try {
+    if (!uploadResponse.ok) {
+      throw await createVoiceRequestError(uploadResponse, "Failed to upload voice message");
+    }
+  } finally {
+    await release();
   }
 }
 

--- a/extensions/discord/src/voice-message.ts
+++ b/extensions/discord/src/voice-message.ts
@@ -24,7 +24,6 @@ import { unlinkIfExists } from "openclaw/plugin-sdk/media-runtime";
 import { parseStrictFiniteNumber } from "openclaw/plugin-sdk/number-runtime";
 import type { RetryRunner } from "openclaw/plugin-sdk/retry-runtime";
 import { writeExternalFileWithinRoot } from "openclaw/plugin-sdk/security-runtime";
-import { fetchWithSsrFGuard, type SsrFPolicy } from "openclaw/plugin-sdk/ssrf-runtime";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import { DiscordError, RateLimitError, type RequestClient } from "./internal/discord.js";
@@ -34,10 +33,6 @@ const DISCORD_VOICE_MESSAGE_FLAG = 1 << 13;
 const SUPPRESS_NOTIFICATIONS_FLAG = 1 << 12;
 const WAVEFORM_SAMPLES = 256;
 const DISCORD_OPUS_SAMPLE_RATE_HZ = 48_000;
-const DISCORD_VOICE_UPLOAD_SSRF_POLICY: SsrFPolicy = {
-  allowRfc2544BenchmarkRange: true,
-  allowIpv6UniqueLocalRange: true,
-};
 
 async function runFfmpegToOutput(params: {
   outputPath: string;
@@ -337,45 +332,31 @@ async function requestVoiceUploadUrl(params: {
       files: [{ filename: params.filename, file_size: params.fileSize, id: "0" }],
     }),
   };
-  const { response: res, release } = await fetchWithSsrFGuard({
-    url,
-    init: uploadUrlInit,
-    policy: DISCORD_VOICE_UPLOAD_SSRF_POLICY,
-    auditContext: "discord.voice.upload-url",
+  const res = await fetch(url, {
+    ...uploadUrlInit,
+    redirect: "error",
   });
-  try {
-    if (!res.ok) {
-      throw await createVoiceRequestError(res, "Upload URL request failed");
-    }
-    return (await res.json()) as UploadUrlResponse;
-  } finally {
-    await release();
+  if (!res.ok) {
+    throw await createVoiceRequestError(res, "Upload URL request failed");
   }
+  return (await res.json()) as UploadUrlResponse;
 }
 
 async function uploadVoiceAttachment(params: {
   uploadUrl: string;
   audioBuffer: Buffer;
 }): Promise<void> {
-  const { response: uploadResponse, release } = await fetchWithSsrFGuard({
-    url: params.uploadUrl,
-    init: {
-      method: "PUT",
-      headers: {
-        "Content-Type": "audio/ogg",
-      },
-      body: new Uint8Array(params.audioBuffer),
+  const uploadResponse = await fetch(params.uploadUrl, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "audio/ogg",
     },
-    policy: DISCORD_VOICE_UPLOAD_SSRF_POLICY,
-    auditContext: "discord.voice.attachment-upload",
+    body: new Uint8Array(params.audioBuffer),
+    redirect: "error",
   });
 
-  try {
-    if (!uploadResponse.ok) {
-      throw await createVoiceRequestError(uploadResponse, "Failed to upload voice message");
-    }
-  } finally {
-    await release();
+  if (!uploadResponse.ok) {
+    throw await createVoiceRequestError(uploadResponse, "Failed to upload voice message");
   }
 }
 
@@ -402,7 +383,7 @@ export async function sendDiscordVoiceMessage(
 
   // Step 1: Request upload URL from Discord
   // RequestClient auto-converts "files" bodies to multipart/form-data, but Discord's
-  // /attachments endpoint expects JSON, so this path uses a guarded raw HTTP call.
+  // /attachments endpoint expects JSON, so this path uses a raw HTTP call.
   const botToken = token;
   if (!botToken) {
     throw new Error("Discord bot token is required for voice message upload");

--- a/extensions/discord/src/voice-message.ts
+++ b/extensions/discord/src/voice-message.ts
@@ -339,10 +339,8 @@ async function requestVoiceUploadUrl(params: {
   };
   const { response: res, release } = await fetchWithSsrFGuard({
     url,
-    init: {
-      ...uploadUrlInit,
-      redirect: "error",
-    },
+    init: uploadUrlInit,
+    maxRedirects: 0,
     policy: DISCORD_VOICE_UPLOAD_SSRF_POLICY,
     auditContext: "discord.voice.upload-url",
   });

--- a/extensions/qqbot/src/engine/api/media-chunked.test.ts
+++ b/extensions/qqbot/src/engine/api/media-chunked.test.ts
@@ -21,12 +21,6 @@ import type { UploadCacheAdapter } from "./media.js";
 import { UPLOAD_PREPARE_FALLBACK_CODE } from "./retry.js";
 import type { TokenManager } from "./token.js";
 
-const fetchWithSsrFGuardMock = vi.hoisted(() => vi.fn());
-
-vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
-  fetchWithSsrFGuard: fetchWithSsrFGuardMock,
-}));
-
 // ============ Test doubles ============
 
 /** Build a minimal ApiClient stub whose `request` is fully mockable. */
@@ -89,17 +83,15 @@ const FIXTURE_BUFFER = Buffer.from("0123456789abcdefghij"); // 20 bytes
 let originalFetch: typeof globalThis.fetch;
 
 function stubFetchOk(): ReturnType<typeof vi.fn> {
-  fetchWithSsrFGuardMock.mockImplementation(async () => ({
-    response: new Response("", {
+  return vi.spyOn(globalThis, "fetch").mockResolvedValue(
+    new Response("", {
       status: 200,
       headers: {
         ETag: '"etag-value"',
         "x-cos-request-id": "req-id",
       },
     }),
-    release: vi.fn(),
-  }));
-  return fetchWithSsrFGuardMock;
+  );
 }
 
 // ============ Tests ============
@@ -128,7 +120,6 @@ describe("media-chunked: ChunkedMediaApi.uploadChunked", () => {
 
   afterEach(() => {
     globalThis.fetch = originalFetch;
-    fetchWithSsrFGuardMock.mockReset();
     vi.restoreAllMocks();
   });
 
@@ -243,7 +234,7 @@ describe("media-chunked: ChunkedMediaApi.uploadChunked", () => {
 
     // 3 COS PUTs, one per part, each to the presigned URL.
     expect(fetchSpy).toHaveBeenCalledTimes(3);
-    const putUrls = fetchSpy.mock.calls.map((c) => (c[0] as { url: string }).url);
+    const putUrls = fetchSpy.mock.calls.map((c) => String(c[0]));
     expect(new Set(putUrls)).toEqual(
       new Set([
         "https://cos.example.com/part-1",
@@ -251,6 +242,9 @@ describe("media-chunked: ChunkedMediaApi.uploadChunked", () => {
         "https://cos.example.com/part-3",
       ]),
     );
+    for (const [, init] of fetchSpy.mock.calls) {
+      expect(init).toMatchObject({ method: "PUT", redirect: "error" });
+    }
 
     // FILE uploads carry filename metadata in upload_prepare, so the content-only
     // cache is bypassed to avoid reusing file_info with a stale name.

--- a/extensions/qqbot/src/engine/api/media-chunked.test.ts
+++ b/extensions/qqbot/src/engine/api/media-chunked.test.ts
@@ -4,6 +4,17 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const fetchWithSsrFGuardMock = vi.hoisted(() => vi.fn());
+
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/ssrf-runtime")>();
+  return {
+    ...actual,
+    fetchWithSsrFGuard: fetchWithSsrFGuardMock,
+  };
+});
+
 import { normalizeSource } from "../messaging/media-source.js";
 import {
   ApiError,
@@ -78,20 +89,27 @@ function makePrepareResponse(uploadId: string, parts: number): UploadPrepareResp
 /** Fixture: a 20-byte buffer that spans 3 parts at block_size=8. */
 const FIXTURE_BUFFER = Buffer.from("0123456789abcdefghij"); // 20 bytes
 
-// ============ fetch stub for COS PUT ============
+// ============ Guarded fetch stub for COS PUT ============
 
-let originalFetch: typeof globalThis.fetch;
+const guardedFetchReleases: Array<ReturnType<typeof vi.fn>> = [];
 
 function stubFetchOk(): ReturnType<typeof vi.fn> {
-  return vi.spyOn(globalThis, "fetch").mockResolvedValue(
-    new Response("", {
+  guardedFetchReleases.length = 0;
+  fetchWithSsrFGuardMock.mockImplementation(async () => ({
+    response: new Response("", {
       status: 200,
       headers: {
         ETag: '"etag-value"',
         "x-cos-request-id": "req-id",
       },
     }),
-  );
+    release: (() => {
+      const release = vi.fn(async () => {});
+      guardedFetchReleases.push(release);
+      return release;
+    })(),
+  }));
+  return fetchWithSsrFGuardMock;
 }
 
 // ============ Tests ============
@@ -115,11 +133,11 @@ describe("media-chunked: isChunkedUploadImplemented", () => {
 
 describe("media-chunked: ChunkedMediaApi.uploadChunked", () => {
   beforeEach(() => {
-    originalFetch = globalThis.fetch;
+    fetchWithSsrFGuardMock.mockReset();
   });
 
   afterEach(() => {
-    globalThis.fetch = originalFetch;
+    fetchWithSsrFGuardMock.mockReset();
     vi.restoreAllMocks();
   });
 
@@ -232,9 +250,15 @@ describe("media-chunked: ChunkedMediaApi.uploadChunked", () => {
     // One prepare + 3 part_finish + 1 complete = 5 client requests.
     expect(client.request).toHaveBeenCalledTimes(5);
 
-    // 3 COS PUTs, one per part, each to the presigned URL.
+    // 3 guarded COS PUTs, one per part, each to the presigned URL.
     expect(fetchSpy).toHaveBeenCalledTimes(3);
-    const putUrls = fetchSpy.mock.calls.map((c) => String(c[0]));
+    expect(guardedFetchReleases).toHaveLength(3);
+    for (const release of guardedFetchReleases) {
+      expect(release).toHaveBeenCalledTimes(1);
+    }
+    const putUrls = fetchSpy.mock.calls.map(([params]) => {
+      return (params as { url: string }).url;
+    });
     expect(new Set(putUrls)).toEqual(
       new Set([
         "https://cos.example.com/part-1",
@@ -242,8 +266,15 @@ describe("media-chunked: ChunkedMediaApi.uploadChunked", () => {
         "https://cos.example.com/part-3",
       ]),
     );
-    for (const [, init] of fetchSpy.mock.calls) {
-      expect(init).toMatchObject({ method: "PUT", redirect: "error" });
+    for (const [params] of fetchSpy.mock.calls) {
+      const guardedRequest = params as {
+        auditContext?: string;
+        init?: RequestInit;
+        signal?: AbortSignal;
+      };
+      expect(guardedRequest.auditContext).toBe("qqbot-media-part-upload");
+      expect(guardedRequest.init).toMatchObject({ method: "PUT" });
+      expect(guardedRequest.signal).toBeInstanceOf(AbortSignal);
     }
 
     // FILE uploads carry filename metadata in upload_prepare, so the content-only

--- a/extensions/qqbot/src/engine/api/media-chunked.ts
+++ b/extensions/qqbot/src/engine/api/media-chunked.ts
@@ -36,7 +36,6 @@
 
 import * as crypto from "node:crypto";
 import type { FileHandle } from "node:fs/promises";
-import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import type { MediaSource, OpenedLocalFile } from "../messaging/media-source.js";
 import { openLocalFile } from "../messaging/media-source.js";
 import {
@@ -566,38 +565,31 @@ async function putToPresignedUrl(
       ) as ArrayBuffer;
 
       const startTime = Date.now();
-      const { response, release } = await fetchWithSsrFGuard({
-        url: presignedUrl,
-        auditContext: "qqbot-media-part-upload",
-        init: {
-          method: "PUT",
-          body: new Blob([ab]),
-          headers: { "Content-Length": String(data.length) },
-        },
+      const response = await fetch(presignedUrl, {
+        method: "PUT",
+        body: new Blob([ab]),
+        headers: { "Content-Length": String(data.length) },
         signal: controller.signal,
+        redirect: "error",
       });
-      try {
-        const elapsed = Date.now() - startTime;
-        const requestId = response.headers.get("x-cos-request-id") ?? "-";
-        const etag = response.headers.get("ETag") ?? "-";
+      const elapsed = Date.now() - startTime;
+      const requestId = response.headers.get("x-cos-request-id") ?? "-";
+      const etag = response.headers.get("ETag") ?? "-";
 
-        if (!response.ok) {
-          const body = await response.text().catch(() => "");
-          logger?.error?.(
-            `${prefix} PUT part ${partIndex}/${totalParts}: HTTP ${response.status} ${response.statusText} (${elapsed}ms, requestId=${requestId}) body=${body.slice(0, 160)}`,
-          );
-          throw new Error(
-            `COS PUT failed: ${response.status} ${response.statusText} - ${body.slice(0, 120)}`,
-          );
-        }
-
-        logger?.debug?.(
-          `${prefix} PUT part ${partIndex}/${totalParts} OK (${elapsed}ms ETag=${etag} requestId=${requestId})`,
+      if (!response.ok) {
+        const body = await response.text().catch(() => "");
+        logger?.error?.(
+          `${prefix} PUT part ${partIndex}/${totalParts}: HTTP ${response.status} ${response.statusText} (${elapsed}ms, requestId=${requestId}) body=${body.slice(0, 160)}`,
         );
-        return;
-      } finally {
-        await release();
+        throw new Error(
+          `COS PUT failed: ${response.status} ${response.statusText} - ${body.slice(0, 120)}`,
+        );
       }
+
+      logger?.debug?.(
+        `${prefix} PUT part ${partIndex}/${totalParts} OK (${elapsed}ms ETag=${etag} requestId=${requestId})`,
+      );
+      return;
     } catch (err) {
       lastError = err instanceof Error ? err : new Error(String(err));
       if (lastError.name === "AbortError") {

--- a/extensions/qqbot/src/engine/api/media-chunked.ts
+++ b/extensions/qqbot/src/engine/api/media-chunked.ts
@@ -36,6 +36,7 @@
 
 import * as crypto from "node:crypto";
 import type { FileHandle } from "node:fs/promises";
+import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import type { MediaSource, OpenedLocalFile } from "../messaging/media-source.js";
 import { openLocalFile } from "../messaging/media-source.js";
 import {
@@ -565,31 +566,39 @@ async function putToPresignedUrl(
       ) as ArrayBuffer;
 
       const startTime = Date.now();
-      const response = await fetch(presignedUrl, {
-        method: "PUT",
-        body: new Blob([ab]),
-        headers: { "Content-Length": String(data.length) },
+      const { response, release } = await fetchWithSsrFGuard({
+        url: presignedUrl,
+        auditContext: "qqbot-media-part-upload",
+        init: {
+          method: "PUT",
+          body: new Blob([ab]),
+          headers: { "Content-Length": String(data.length) },
+        },
         signal: controller.signal,
-        redirect: "error",
       });
-      const elapsed = Date.now() - startTime;
-      const requestId = response.headers.get("x-cos-request-id") ?? "-";
-      const etag = response.headers.get("ETag") ?? "-";
 
-      if (!response.ok) {
-        const body = await response.text().catch(() => "");
-        logger?.error?.(
-          `${prefix} PUT part ${partIndex}/${totalParts}: HTTP ${response.status} ${response.statusText} (${elapsed}ms, requestId=${requestId}) body=${body.slice(0, 160)}`,
+      try {
+        const elapsed = Date.now() - startTime;
+        const requestId = response.headers.get("x-cos-request-id") ?? "-";
+        const etag = response.headers.get("ETag") ?? "-";
+
+        if (!response.ok) {
+          const body = await response.text().catch(() => "");
+          logger?.error?.(
+            `${prefix} PUT part ${partIndex}/${totalParts}: HTTP ${response.status} ${response.statusText} (${elapsed}ms, requestId=${requestId}) body=${body.slice(0, 160)}`,
+          );
+          throw new Error(
+            `COS PUT failed: ${response.status} ${response.statusText} - ${body.slice(0, 120)}`,
+          );
+        }
+
+        logger?.debug?.(
+          `${prefix} PUT part ${partIndex}/${totalParts} OK (${elapsed}ms ETag=${etag} requestId=${requestId})`,
         );
-        throw new Error(
-          `COS PUT failed: ${response.status} ${response.statusText} - ${body.slice(0, 120)}`,
-        );
+        return;
+      } finally {
+        await release();
       }
-
-      logger?.debug?.(
-        `${prefix} PUT part ${partIndex}/${totalParts} OK (${elapsed}ms ETag=${etag} requestId=${requestId})`,
-      );
-      return;
     } catch (err) {
       lastError = err instanceof Error ? err : new Error(String(err));
       if (lastError.name === "AbortError") {

--- a/extensions/qqbot/src/engine/api/media.test.ts
+++ b/extensions/qqbot/src/engine/api/media.test.ts
@@ -6,7 +6,6 @@ import { ApiClient } from "./api-client.js";
 import { MediaApi } from "./media.js";
 import { TokenManager } from "./token.js";
 
-const fetchWithSsrFGuardMock = vi.hoisted(() => vi.fn());
 const readResponseWithLimitMock = vi.hoisted(() => vi.fn());
 
 vi.mock("openclaw/plugin-sdk/response-limit-runtime", async (importOriginal) => {
@@ -15,14 +14,6 @@ vi.mock("openclaw/plugin-sdk/response-limit-runtime", async (importOriginal) => 
   return {
     ...actual,
     readResponseWithLimit: readResponseWithLimitMock,
-  };
-});
-
-vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/ssrf-runtime")>();
-  return {
-    ...actual,
-    fetchWithSsrFGuard: fetchWithSsrFGuardMock,
   };
 });
 
@@ -35,18 +26,13 @@ const UPLOAD_RESPONSE: UploadMediaResponse = {
 const MEDIA_BYTES = Buffer.from("downloaded-media");
 const MEDIA_BASE64 = MEDIA_BYTES.toString("base64");
 
-function mockGuardedResponse(
+function mockNativeResponse(
   body: BodyInit = MEDIA_BYTES,
   init?: ResponseInit,
-): {
-  release: ReturnType<typeof vi.fn>;
-} {
-  const release = vi.fn(async () => {});
-  fetchWithSsrFGuardMock.mockResolvedValueOnce({
-    response: new Response(body, init),
-    release,
-  });
-  return { release };
+): Response {
+  const response = new Response(body, init);
+  vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(response);
+  return response;
 }
 
 function mockApiClient(): ApiClient {
@@ -61,25 +47,24 @@ function mockTokenManager(): TokenManager {
   return tokenManager;
 }
 
-function expectGuardedDownload(url: string): void {
-  expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith({
+function expectNativeDownload(url: string): void {
+  expect(globalThis.fetch).toHaveBeenCalledWith(
     url,
-    maxRedirects: 0,
-    signal: expect.any(AbortSignal),
-  });
-  expect(fetchWithSsrFGuardMock).not.toHaveBeenCalledWith(
-    expect.objectContaining({ timeoutMs: expect.any(Number) }),
+    expect.objectContaining({
+      redirect: "follow",
+      signal: expect.any(AbortSignal),
+    }),
   );
-  const signal = fetchWithSsrFGuardMock.mock.calls.at(-1)?.[0]?.signal;
+  const signal = vi.mocked(globalThis.fetch).mock.calls.at(-1)?.[1]?.signal;
   expect(signal).toBeInstanceOf(AbortSignal);
 }
 
 describe("MediaApi.uploadMedia direct URL uploads", () => {
   beforeEach(() => {
-    fetchWithSsrFGuardMock.mockReset();
+    vi.restoreAllMocks();
     readResponseWithLimitMock.mockReset();
     readResponseWithLimitMock.mockResolvedValue(MEDIA_BYTES);
-    mockGuardedResponse();
+    mockNativeResponse();
   });
 
   it.each([
@@ -87,7 +72,7 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
     { fileType: MediaFileType.VIDEO, url: "http://cdn.example.com/assets/video.mp4" },
     { fileType: MediaFileType.FILE, url: "http://cdn.example.com/assets/report.pdf" },
   ])(
-    "downloads public HTTP(S) $fileType URLs through the pinned SSRF guard",
+    "downloads public HTTP(S) $fileType URLs with native fetch redirects",
     async ({ fileType, url }) => {
       const client = mockApiClient();
       const tokenManager = mockTokenManager();
@@ -102,7 +87,7 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
       );
 
       expect(result).toBe(UPLOAD_RESPONSE);
-      expectGuardedDownload(url);
+      expectNativeDownload(url);
       expect(readResponseWithLimitMock).toHaveBeenCalledWith(
         expect.any(Response),
         MAX_UPLOAD_SIZE,
@@ -126,9 +111,7 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
     },
   );
 
-  it("releases the pinned SSRF dispatcher after downloading media", async () => {
-    fetchWithSsrFGuardMock.mockReset();
-    const { release } = mockGuardedResponse();
+  it("uses native fetch redirect-follow behavior when downloading media", async () => {
     const client = mockApiClient();
     const tokenManager = mockTokenManager();
     const api = new MediaApi(client, tokenManager);
@@ -141,14 +124,14 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
       { url: "https://cdn.example.com/assets/photo.png" },
     );
 
-    expect(release).toHaveBeenCalledTimes(1);
+    expectNativeDownload("https://cdn.example.com/assets/photo.png");
   });
 
-  it("bounds stalled guarded fetch setup before reading URL bodies", async () => {
+  it("bounds stalled native fetch setup before reading URL bodies", async () => {
     vi.useFakeTimers();
     try {
-      fetchWithSsrFGuardMock.mockReset();
-      fetchWithSsrFGuardMock.mockImplementationOnce(() => new Promise(() => {}));
+      vi.restoreAllMocks();
+      vi.spyOn(globalThis, "fetch").mockImplementationOnce(() => new Promise(() => {}));
       const client = mockApiClient();
       const tokenManager = mockTokenManager();
       const api = new MediaApi(client, tokenManager);
@@ -177,8 +160,7 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
   it("rejects URL bodies that keep trickling under the idle timeout", async () => {
     vi.useFakeTimers();
     try {
-      fetchWithSsrFGuardMock.mockReset();
-      const { release } = mockGuardedResponse();
+      mockNativeResponse();
       readResponseWithLimitMock.mockReset();
       readResponseWithLimitMock.mockImplementationOnce(() => new Promise<Buffer>(() => {}));
       const client = mockApiClient();
@@ -203,7 +185,6 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
       );
       await vi.advanceTimersByTimeAsync(8 * 60_000);
       await rejection;
-      expect(release).toHaveBeenCalledTimes(1);
     } finally {
       vi.useRealTimers();
     }
@@ -285,7 +266,7 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
       ),
     ).rejects.toThrow("Direct-upload media URL must be a valid URL");
 
-    expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
+    expect(globalThis.fetch).not.toHaveBeenCalled();
     expect(tokenManager["getAccessToken"]).not.toHaveBeenCalled();
     expect(client["request"]).not.toHaveBeenCalled();
   });
@@ -305,15 +286,16 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
       ),
     ).rejects.toThrow("Direct-upload media URL must use HTTP or HTTPS");
 
-    expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
+    expect(globalThis.fetch).not.toHaveBeenCalled();
     expect(tokenManager["getAccessToken"]).not.toHaveBeenCalled();
     expect(client["request"]).not.toHaveBeenCalled();
   });
 
   it.each(["127.0.0.1", "169.254.169.254", "10.0.0.1", "192.168.1.1"])(
-    "does not upload direct URLs rejected by the SSRF guard: %s",
+    "does not upload direct URLs rejected by literal host validation: %s",
     async (host) => {
-      fetchWithSsrFGuardMock.mockReset();
+      vi.restoreAllMocks();
+      const fetchSpy = vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("unexpected"));
       const client = mockApiClient();
       const tokenManager = mockTokenManager();
       const api = new MediaApi(client, tokenManager);
@@ -328,17 +310,15 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
         ),
       ).rejects.toThrow("Blocked hostname");
 
-      expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
+      expect(fetchSpy).not.toHaveBeenCalled();
       expect(tokenManager["getAccessToken"]).not.toHaveBeenCalled();
       expect(client["request"]).not.toHaveBeenCalled();
     },
   );
 
-  it("does not forward URLs when the guarded download fails", async () => {
-    fetchWithSsrFGuardMock.mockReset();
-    fetchWithSsrFGuardMock.mockRejectedValueOnce(
-      new Error("Blocked: resolves to private/internal/special-use IP address"),
-    );
+  it("does not forward URLs when the native download fails", async () => {
+    vi.restoreAllMocks();
+    vi.spyOn(globalThis, "fetch").mockRejectedValueOnce(new Error("download failed"));
     const client = mockApiClient();
     const tokenManager = mockTokenManager();
     const api = new MediaApi(client, tokenManager);
@@ -351,14 +331,15 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
         { appId: "app-id", clientSecret: "client-secret" },
         { url: "https://attacker.example/latest/meta-data/" },
       ),
-    ).rejects.toThrow("resolves to private");
+    ).rejects.toThrow("download failed");
 
     expect(tokenManager["getAccessToken"]).not.toHaveBeenCalled();
     expect(client["request"]).not.toHaveBeenCalled();
   });
 
-  it("rejects literal RFC 2544 special-use URL hosts through the guarded download", async () => {
-    fetchWithSsrFGuardMock.mockReset();
+  it("rejects literal RFC 2544 special-use URL hosts before native download", async () => {
+    vi.restoreAllMocks();
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("unexpected"));
     const client = mockApiClient();
     const tokenManager = mockTokenManager();
     const api = new MediaApi(client, tokenManager);
@@ -373,12 +354,12 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
       ),
     ).rejects.toThrow("Blocked hostname");
 
-    expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
     expect(tokenManager["getAccessToken"]).not.toHaveBeenCalled();
     expect(client["request"]).not.toHaveBeenCalled();
   });
 
-  it("keeps public literal IP URLs on the default SSRF policy", async () => {
+  it("keeps public literal IP URLs on the native download path", async () => {
     const client = mockApiClient();
     const tokenManager = mockTokenManager();
     const api = new MediaApi(client, tokenManager);
@@ -391,7 +372,7 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
       { url: "http://93.184.216.34/assets/photo.png" },
     );
 
-    expectGuardedDownload("http://93.184.216.34/assets/photo.png");
+    expectNativeDownload("http://93.184.216.34/assets/photo.png");
   });
 
   it("does not pass URL or fake-IP DNS policy to the QQ upload body", async () => {
@@ -407,7 +388,7 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
       { url: "https://cdn.example.com/assets/photo.png" },
     );
 
-    expectGuardedDownload("https://cdn.example.com/assets/photo.png");
+    expectNativeDownload("https://cdn.example.com/assets/photo.png");
     expect(client["request"]).toHaveBeenCalledWith(
       "token-1",
       "POST",
@@ -426,9 +407,9 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
     );
   });
 
-  it("rejects HTTP errors from guarded direct-upload downloads before calling the QQ API", async () => {
-    fetchWithSsrFGuardMock.mockReset();
-    mockGuardedResponse("not found", { status: 404 });
+  it("rejects HTTP errors from native direct-upload downloads before calling the QQ API", async () => {
+    vi.restoreAllMocks();
+    mockNativeResponse("not found", { status: 404 });
     const client = mockApiClient();
     const tokenManager = mockTokenManager();
     const api = new MediaApi(client, tokenManager);

--- a/extensions/qqbot/src/engine/api/media.test.ts
+++ b/extensions/qqbot/src/engine/api/media.test.ts
@@ -3,8 +3,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { MediaFileType, type UploadMediaResponse } from "../types.js";
 import { MAX_UPLOAD_SIZE } from "../utils/file-utils.js";
 import { ApiClient } from "./api-client.js";
-import { MediaApi } from "./media.js";
+import { downloadDirectUploadUrl, MediaApi } from "./media.js";
 import { TokenManager } from "./token.js";
+
+type LookupFn = NonNullable<Parameters<typeof downloadDirectUploadUrl>[1]>["lookupFn"];
 
 const readResponseWithLimitMock = vi.hoisted(() => vi.fn());
 
@@ -334,6 +336,21 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
       expect(client["request"]).not.toHaveBeenCalled();
     },
   );
+
+  it("rejects direct URL hosts that resolve to private addresses before fetch", async () => {
+    vi.restoreAllMocks();
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("unexpected"));
+    const lookupFn: LookupFn = async () => ({
+      address: "127.0.0.1",
+      family: 4,
+    });
+
+    await expect(
+      downloadDirectUploadUrl("https://cdn.example.com/assets/photo.png", { lookupFn }),
+    ).rejects.toThrow("resolves to private/internal/special-use IP address");
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
 
   it("does not forward URLs when the native download fails", async () => {
     vi.restoreAllMocks();

--- a/extensions/qqbot/src/engine/api/media.test.ts
+++ b/extensions/qqbot/src/engine/api/media.test.ts
@@ -178,6 +178,30 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
     }
   });
 
+  it("bounds stalled direct-upload DNS setup before reading URL bodies", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.restoreAllMocks();
+      vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("unexpected"));
+      const lookupFn = (() => new Promise(() => {})) as unknown as LookupFn;
+
+      const downloadPromise = downloadDirectUploadUrl(
+        "https://slow-dns.example.com/assets/photo.png",
+        { lookupFn },
+      );
+      const rejection = expect(downloadPromise).rejects.toThrow(
+        "Direct-upload media URL fetch timed out",
+      );
+
+      await vi.advanceTimersByTimeAsync(30_000);
+      await rejection;
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+      expect(readResponseWithLimitMock).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("rejects URL bodies that keep trickling under the idle timeout", async () => {
     vi.useFakeTimers();
     try {
@@ -196,8 +220,8 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
         { url: "https://cdn.example.com/assets/slow.bin" },
       );
 
-      for (let i = 0; i < 5 && readResponseWithLimitMock.mock.calls.length === 0; i += 1) {
-        await Promise.resolve();
+      for (let i = 0; i < 20 && readResponseWithLimitMock.mock.calls.length === 0; i += 1) {
+        await vi.advanceTimersByTimeAsync(0);
       }
       expect(readResponseWithLimitMock).toHaveBeenCalledOnce();
 
@@ -340,10 +364,10 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
   it("rejects direct URL hosts that resolve to private addresses before fetch", async () => {
     vi.restoreAllMocks();
     const fetchMock = vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("unexpected"));
-    const lookupFn: LookupFn = async () => ({
+    const lookupFn = (async () => ({
       address: "127.0.0.1",
       family: 4,
-    });
+    })) as unknown as LookupFn;
 
     await expect(
       downloadDirectUploadUrl("https://cdn.example.com/assets/photo.png", { lookupFn }),

--- a/extensions/qqbot/src/engine/api/media.test.ts
+++ b/extensions/qqbot/src/engine/api/media.test.ts
@@ -1,5 +1,5 @@
 // Qqbot tests cover media plugin behavior.
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MediaFileType, type UploadMediaResponse } from "../types.js";
 import { MAX_UPLOAD_SIZE } from "../utils/file-utils.js";
 import { ApiClient } from "./api-client.js";
@@ -8,7 +8,16 @@ import { TokenManager } from "./token.js";
 
 type LookupFn = NonNullable<Parameters<typeof downloadDirectUploadUrl>[1]>["lookupFn"];
 
+const createHttp1EnvHttpProxyAgentMock = vi.hoisted(() => vi.fn());
 const readResponseWithLimitMock = vi.hoisted(() => vi.fn());
+
+vi.mock("openclaw/plugin-sdk/fetch-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/fetch-runtime")>();
+  return {
+    ...actual,
+    createHttp1EnvHttpProxyAgent: createHttp1EnvHttpProxyAgentMock,
+  };
+});
 
 vi.mock("openclaw/plugin-sdk/response-limit-runtime", async (importOriginal) => {
   const actual =
@@ -61,9 +70,14 @@ function expectNativeDownload(url: string): void {
 describe("MediaApi.uploadMedia direct URL uploads", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    createHttp1EnvHttpProxyAgentMock.mockReset();
     readResponseWithLimitMock.mockReset();
     readResponseWithLimitMock.mockResolvedValue(MEDIA_BYTES);
     mockNativeResponse();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   it.each([
@@ -374,6 +388,36 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
     ).rejects.toThrow("resolves to private/internal/special-use IP address");
 
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("uses managed env proxy dispatcher after DNS validation when proxy is active", async () => {
+    vi.restoreAllMocks();
+    vi.stubEnv("OPENCLAW_PROXY_ACTIVE", "1");
+    vi.stubEnv("HTTPS_PROXY", "http://127.0.0.1:8888");
+    const close = vi.fn(async () => undefined);
+    const dispatcher = { close };
+    createHttp1EnvHttpProxyAgentMock.mockReturnValueOnce(dispatcher);
+    const response = mockNativeResponse();
+    const lookupFn = vi.fn(async () => ({
+      address: "93.184.216.34",
+      family: 4,
+    })) as unknown as LookupFn;
+
+    const result = await downloadDirectUploadUrl("https://cdn.example.com/assets/photo.png", {
+      lookupFn,
+    });
+
+    expect(result).toStrictEqual(MEDIA_BYTES);
+    expect(lookupFn).toHaveBeenCalled();
+    expect(createHttp1EnvHttpProxyAgentMock).toHaveBeenCalledOnce();
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "https://cdn.example.com/assets/photo.png",
+      expect.objectContaining({ dispatcher }),
+    );
+    expect(readResponseWithLimitMock).toHaveBeenCalledWith(response, MAX_UPLOAD_SIZE, {
+      chunkTimeoutMs: 10_000,
+    });
+    expect(close).toHaveBeenCalledTimes(1);
   });
 
   it("does not forward URLs when the native download fails", async () => {

--- a/extensions/qqbot/src/engine/api/media.test.ts
+++ b/extensions/qqbot/src/engine/api/media.test.ts
@@ -26,10 +26,7 @@ const UPLOAD_RESPONSE: UploadMediaResponse = {
 const MEDIA_BYTES = Buffer.from("downloaded-media");
 const MEDIA_BASE64 = MEDIA_BYTES.toString("base64");
 
-function mockNativeResponse(
-  body: BodyInit = MEDIA_BYTES,
-  init?: ResponseInit,
-): Response {
+function mockNativeResponse(body: BodyInit = MEDIA_BYTES, init?: ResponseInit): Response {
   const response = new Response(body, init);
   vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(response);
   return response;
@@ -51,7 +48,7 @@ function expectNativeDownload(url: string): void {
   expect(globalThis.fetch).toHaveBeenCalledWith(
     url,
     expect.objectContaining({
-      redirect: "follow",
+      redirect: "error",
       signal: expect.any(AbortSignal),
     }),
   );
@@ -71,47 +68,42 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
     { fileType: MediaFileType.IMAGE, url: "https://cdn.example.com/assets/photo.png" },
     { fileType: MediaFileType.VIDEO, url: "http://cdn.example.com/assets/video.mp4" },
     { fileType: MediaFileType.FILE, url: "http://cdn.example.com/assets/report.pdf" },
-  ])(
-    "downloads public HTTP(S) $fileType URLs with native fetch redirects",
-    async ({ fileType, url }) => {
-      const client = mockApiClient();
-      const tokenManager = mockTokenManager();
-      const api = new MediaApi(client, tokenManager);
+  ])("downloads public HTTP(S) $fileType URLs with native fetch", async ({ fileType, url }) => {
+    const client = mockApiClient();
+    const tokenManager = mockTokenManager();
+    const api = new MediaApi(client, tokenManager);
 
-      const result = await api.uploadMedia(
-        "c2c",
-        "user-openid",
-        fileType,
-        { appId: "app-id", clientSecret: "client-secret" },
-        { url },
-      );
+    const result = await api.uploadMedia(
+      "c2c",
+      "user-openid",
+      fileType,
+      { appId: "app-id", clientSecret: "client-secret" },
+      { url },
+    );
 
-      expect(result).toBe(UPLOAD_RESPONSE);
-      expectNativeDownload(url);
-      expect(readResponseWithLimitMock).toHaveBeenCalledWith(
-        expect.any(Response),
-        MAX_UPLOAD_SIZE,
-        { chunkTimeoutMs: 10_000 },
-      );
-      expect(tokenManager["getAccessToken"]).toHaveBeenCalledWith("app-id", "client-secret");
-      expect(client["request"]).toHaveBeenCalledWith(
-        "token-1",
-        "POST",
-        expect.any(String),
-        {
-          file_type: fileType,
-          srv_send_msg: false,
-          file_data: MEDIA_BASE64,
-        },
-        {
-          redactBodyKeys: ["file_data"],
-          uploadRequest: true,
-        },
-      );
-    },
-  );
+    expect(result).toBe(UPLOAD_RESPONSE);
+    expectNativeDownload(url);
+    expect(readResponseWithLimitMock).toHaveBeenCalledWith(expect.any(Response), MAX_UPLOAD_SIZE, {
+      chunkTimeoutMs: 10_000,
+    });
+    expect(tokenManager["getAccessToken"]).toHaveBeenCalledWith("app-id", "client-secret");
+    expect(client["request"]).toHaveBeenCalledWith(
+      "token-1",
+      "POST",
+      expect.any(String),
+      {
+        file_type: fileType,
+        srv_send_msg: false,
+        file_data: MEDIA_BASE64,
+      },
+      {
+        redactBodyKeys: ["file_data"],
+        uploadRequest: true,
+      },
+    );
+  });
 
-  it("uses native fetch redirect-follow behavior when downloading media", async () => {
+  it("uses native fetch no-redirect behavior when downloading media", async () => {
     const client = mockApiClient();
     const tokenManager = mockTokenManager();
     const api = new MediaApi(client, tokenManager);
@@ -125,6 +117,33 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
     );
 
     expectNativeDownload("https://cdn.example.com/assets/photo.png");
+  });
+
+  it("rejects redirects before reading media URL bodies", async () => {
+    vi.restoreAllMocks();
+    const redirectResponse = new Response(null, {
+      status: 302,
+      headers: { Location: "http://127.0.0.1/private.png" },
+    });
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(redirectResponse);
+    const client = mockApiClient();
+    const tokenManager = mockTokenManager();
+    const api = new MediaApi(client, tokenManager);
+
+    await expect(
+      api.uploadMedia(
+        "c2c",
+        "user-openid",
+        MediaFileType.IMAGE,
+        { appId: "app-id", clientSecret: "client-secret" },
+        { url: "https://cdn.example.com/assets/photo.png" },
+      ),
+    ).rejects.toThrow("Direct-upload media URL returned HTTP 302");
+
+    expectNativeDownload("https://cdn.example.com/assets/photo.png");
+    expect(readResponseWithLimitMock).not.toHaveBeenCalled();
+    expect(tokenManager["getAccessToken"]).not.toHaveBeenCalled();
+    expect(client["request"]).not.toHaveBeenCalled();
   });
 
   it("bounds stalled native fetch setup before reading URL bodies", async () => {

--- a/extensions/qqbot/src/engine/api/media.ts
+++ b/extensions/qqbot/src/engine/api/media.ts
@@ -13,7 +13,7 @@
 
 import * as fs from "node:fs";
 import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
-import { fetchWithSsrFGuard, isBlockedHostnameOrIp } from "openclaw/plugin-sdk/ssrf-runtime";
+import { isBlockedHostnameOrIp } from "openclaw/plugin-sdk/ssrf-runtime";
 import {
   MediaFileType,
   type ChatScope,
@@ -68,31 +68,20 @@ function assertDirectUploadDownloadHostAllowed(hostname: string): void {
 async function fetchDirectUploadDownload(url: string) {
   const controller = new AbortController();
   const timeoutError = new Error("Direct-upload media URL fetch timed out");
-  let timedOut = false;
   let timeout: ReturnType<typeof setTimeout> | undefined;
   const timeoutPromise = new Promise<never>((_, reject) => {
     timeout = setTimeout(() => {
-      timedOut = true;
       controller.abort(timeoutError);
       reject(timeoutError);
     }, DIRECT_UPLOAD_DOWNLOAD_TIMEOUT_MS);
     unrefTimer(timeout);
   });
-  const guardedFetch = fetchWithSsrFGuard({
-    url,
-    maxRedirects: 0,
+  const downloadFetch = fetch(url, {
     signal: controller.signal,
+    redirect: "follow",
   });
-  void guardedFetch.then(
-    (result) => {
-      if (timedOut) {
-        void result.release().catch(() => undefined);
-      }
-    },
-    () => undefined,
-  );
   try {
-    return await Promise.race([guardedFetch, timeoutPromise]);
+    return await Promise.race([downloadFetch, timeoutPromise]);
   } finally {
     if (timeout) {
       clearTimeout(timeout);
@@ -158,15 +147,11 @@ export async function downloadDirectUploadUrl(
   }
 
   assertDirectUploadDownloadHostAllowed(parsed.hostname);
-  const { response, release } = await fetchDirectUploadDownload(parsed.toString());
-  try {
-    if (!response.ok) {
-      throw new Error(`Direct-upload media URL returned HTTP ${response.status}`);
-    }
-    return await readDirectUploadResponse(response, opts.maxBytes ?? MAX_UPLOAD_SIZE);
-  } finally {
-    await release?.();
+  const response = await fetchDirectUploadDownload(parsed.toString());
+  if (!response.ok) {
+    throw new Error(`Direct-upload media URL returned HTTP ${response.status}`);
   }
+  return await readDirectUploadResponse(response, opts.maxBytes ?? MAX_UPLOAD_SIZE);
 }
 
 /**

--- a/extensions/qqbot/src/engine/api/media.ts
+++ b/extensions/qqbot/src/engine/api/media.ts
@@ -13,7 +13,19 @@
 
 import * as fs from "node:fs";
 import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
-import { isBlockedHostnameOrIp } from "openclaw/plugin-sdk/ssrf-runtime";
+import {
+  fetchWithRuntimeDispatcherOrMockedGlobal,
+  isMockedFetch,
+  type DispatcherAwareRequestInit,
+} from "openclaw/plugin-sdk/runtime-fetch";
+import {
+  closeDispatcher,
+  createPinnedDispatcher,
+  isBlockedHostnameOrIp,
+  resolvePinnedHostnameWithPolicy,
+  type LookupFn,
+} from "openclaw/plugin-sdk/ssrf-runtime";
+import type { Dispatcher } from "undici";
 import {
   MediaFileType,
   type ChatScope,
@@ -65,10 +77,26 @@ function assertDirectUploadDownloadHostAllowed(hostname: string): void {
   }
 }
 
-async function fetchDirectUploadDownload(url: string) {
+async function createDirectUploadDispatcher(
+  url: URL,
+  lookupFn: LookupFn | undefined,
+): Promise<Dispatcher | null> {
+  if (lookupFn === undefined && isMockedFetch(globalThis.fetch)) {
+    return null;
+  }
+  const pinned = await resolvePinnedHostnameWithPolicy(url.hostname, { lookupFn });
+  return createPinnedDispatcher(pinned);
+}
+
+async function fetchDirectUploadDownload(
+  url: URL,
+  lookupFn: LookupFn | undefined,
+): Promise<{ response: Response; release: () => Promise<void> }> {
   const controller = new AbortController();
   const timeoutError = new Error("Direct-upload media URL fetch timed out");
   let timeout: ReturnType<typeof setTimeout> | undefined;
+  let dispatcher: Dispatcher | null = null;
+  dispatcher = await createDirectUploadDispatcher(url, lookupFn);
   const timeoutPromise = new Promise<never>((_, reject) => {
     timeout = setTimeout(() => {
       controller.abort(timeoutError);
@@ -76,16 +104,34 @@ async function fetchDirectUploadDownload(url: string) {
     }, DIRECT_UPLOAD_DOWNLOAD_TIMEOUT_MS);
     unrefTimer(timeout);
   });
-  const downloadFetch = fetch(url, {
+  const init: DispatcherAwareRequestInit = {
     signal: controller.signal,
     redirect: "error",
-  });
-  try {
-    return await Promise.race([downloadFetch, timeoutPromise]);
-  } finally {
+    ...(dispatcher ? { dispatcher } : {}),
+  };
+  const downloadFetch = fetchWithRuntimeDispatcherOrMockedGlobal(url.toString(), init);
+  let released = false;
+  const release = async () => {
+    if (released) {
+      return;
+    }
+    released = true;
     if (timeout) {
       clearTimeout(timeout);
+      timeout = undefined;
     }
+    await closeDispatcher(dispatcher);
+  };
+  try {
+    const response = await Promise.race([downloadFetch, timeoutPromise]);
+    if (timeout) {
+      clearTimeout(timeout);
+      timeout = undefined;
+    }
+    return { response, release };
+  } catch (err) {
+    await release();
+    throw err;
   }
 }
 
@@ -133,7 +179,7 @@ async function readDirectUploadResponse(response: Response, maxBytes: number): P
 
 export async function downloadDirectUploadUrl(
   url: string,
-  opts: { maxBytes?: number } = {},
+  opts: { maxBytes?: number; lookupFn?: LookupFn } = {},
 ): Promise<Buffer> {
   let parsed: URL;
   try {
@@ -147,11 +193,15 @@ export async function downloadDirectUploadUrl(
   }
 
   assertDirectUploadDownloadHostAllowed(parsed.hostname);
-  const response = await fetchDirectUploadDownload(parsed.toString());
-  if (!response.ok) {
-    throw new Error(`Direct-upload media URL returned HTTP ${response.status}`);
+  const { response, release } = await fetchDirectUploadDownload(parsed, opts.lookupFn);
+  try {
+    if (!response.ok) {
+      throw new Error(`Direct-upload media URL returned HTTP ${response.status}`);
+    }
+    return await readDirectUploadResponse(response, opts.maxBytes ?? MAX_UPLOAD_SIZE);
+  } finally {
+    await release();
   }
-  return await readDirectUploadResponse(response, opts.maxBytes ?? MAX_UPLOAD_SIZE);
 }
 
 /**

--- a/extensions/qqbot/src/engine/api/media.ts
+++ b/extensions/qqbot/src/engine/api/media.ts
@@ -96,20 +96,6 @@ async function fetchDirectUploadDownload(
   const timeoutError = new Error("Direct-upload media URL fetch timed out");
   let timeout: ReturnType<typeof setTimeout> | undefined;
   let dispatcher: Dispatcher | null = null;
-  dispatcher = await createDirectUploadDispatcher(url, lookupFn);
-  const timeoutPromise = new Promise<never>((_, reject) => {
-    timeout = setTimeout(() => {
-      controller.abort(timeoutError);
-      reject(timeoutError);
-    }, DIRECT_UPLOAD_DOWNLOAD_TIMEOUT_MS);
-    unrefTimer(timeout);
-  });
-  const init: DispatcherAwareRequestInit = {
-    signal: controller.signal,
-    redirect: "error",
-    ...(dispatcher ? { dispatcher } : {}),
-  };
-  const downloadFetch = fetchWithRuntimeDispatcherOrMockedGlobal(url.toString(), init);
   let released = false;
   const release = async () => {
     if (released) {
@@ -122,6 +108,27 @@ async function fetchDirectUploadDownload(
     }
     await closeDispatcher(dispatcher);
   };
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeout = setTimeout(() => {
+      controller.abort(timeoutError);
+      reject(timeoutError);
+    }, DIRECT_UPLOAD_DOWNLOAD_TIMEOUT_MS);
+    unrefTimer(timeout);
+  });
+  const downloadFetch = (async () => {
+    dispatcher = await createDirectUploadDispatcher(url, lookupFn);
+    if (controller.signal.aborted) {
+      await closeDispatcher(dispatcher);
+      dispatcher = null;
+      throw timeoutError;
+    }
+    const init: DispatcherAwareRequestInit = {
+      signal: controller.signal,
+      redirect: "error",
+      ...(dispatcher ? { dispatcher } : {}),
+    };
+    return await fetchWithRuntimeDispatcherOrMockedGlobal(url.toString(), init);
+  })();
   try {
     const response = await Promise.race([downloadFetch, timeoutPromise]);
     if (timeout) {

--- a/extensions/qqbot/src/engine/api/media.ts
+++ b/extensions/qqbot/src/engine/api/media.ts
@@ -12,6 +12,10 @@
  */
 
 import * as fs from "node:fs";
+import {
+  createHttp1EnvHttpProxyAgent,
+  shouldUseEnvHttpProxyForUrl,
+} from "openclaw/plugin-sdk/fetch-runtime";
 import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import {
   fetchWithRuntimeDispatcherOrMockedGlobal,
@@ -85,6 +89,9 @@ async function createDirectUploadDispatcher(
     return null;
   }
   const pinned = await resolvePinnedHostnameWithPolicy(url.hostname, { lookupFn });
+  if (process.env["OPENCLAW_PROXY_ACTIVE"] === "1" && shouldUseEnvHttpProxyForUrl(url.toString())) {
+    return createHttp1EnvHttpProxyAgent();
+  }
   return createPinnedDispatcher(pinned);
 }
 

--- a/extensions/qqbot/src/engine/api/media.ts
+++ b/extensions/qqbot/src/engine/api/media.ts
@@ -78,7 +78,7 @@ async function fetchDirectUploadDownload(url: string) {
   });
   const downloadFetch = fetch(url, {
     signal: controller.signal,
-    redirect: "follow",
+    redirect: "error",
   });
   try {
     return await Promise.race([downloadFetch, timeoutPromise]);

--- a/extensions/slack/src/send.ts
+++ b/extensions/slack/src/send.ts
@@ -8,7 +8,6 @@ import {
   type MessageReceiptSourceResult,
 } from "openclaw/plugin-sdk/channel-outbound";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { withTrustedEnvProxyGuardedFetchMode } from "openclaw/plugin-sdk/fetch-runtime";
 import { resolveMarkdownTableMode } from "openclaw/plugin-sdk/markdown-table-runtime";
 import { requireRuntimeConfig } from "openclaw/plugin-sdk/plugin-config-runtime";
 import {
@@ -19,7 +18,6 @@ import {
 } from "openclaw/plugin-sdk/reply-chunking";
 import { resolveTextChunksWithFallback } from "openclaw/plugin-sdk/reply-payload";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
-import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
@@ -38,10 +36,6 @@ import { parseSlackTarget } from "./targets.js";
 import { normalizeSlackThreadTsCandidate } from "./thread-ts.js";
 import { resolveSlackBotToken } from "./token.js";
 import { truncateSlackText } from "./truncate.js";
-const SLACK_UPLOAD_SSRF_POLICY = {
-  allowedHostnames: ["*.slack.com", "*.slack-edge.com", "*.slack-files.com"],
-  allowRfc2544BenchmarkRange: true,
-};
 const SLACK_DM_CHANNEL_CACHE_MAX = 1024;
 const SLACK_DNS_RETRY_CODES = new Set(["EAI_AGAIN", "ENOTFOUND", "UND_ERR_DNS_RESOLVE_FAILED"]);
 const SLACK_DNS_RETRY_ATTEMPTS = 2;
@@ -581,24 +575,14 @@ async function uploadSlackFile(params: {
 
   // Upload the file content to the presigned URL
   const uploadBody = new Uint8Array(buffer) as BodyInit;
-  const { response: uploadResp, release } = await fetchWithSsrFGuard(
-    withTrustedEnvProxyGuardedFetchMode({
-      url: uploadUrlResp.upload_url,
-      init: {
-        method: "POST",
-        ...(contentType ? { headers: { "Content-Type": contentType } } : {}),
-        body: uploadBody,
-      },
-      policy: SLACK_UPLOAD_SSRF_POLICY,
-      auditContext: "slack-upload-file",
-    }),
-  );
-  try {
-    if (!uploadResp.ok) {
-      throw new Error(`Failed to upload file: HTTP ${uploadResp.status}`);
-    }
-  } finally {
-    await release();
+  const uploadResp = await fetch(uploadUrlResp.upload_url, {
+    method: "POST",
+    ...(contentType ? { headers: { "Content-Type": contentType } } : {}),
+    body: uploadBody,
+    redirect: "error",
+  });
+  if (!uploadResp.ok) {
+    throw new Error(`Failed to upload file: HTTP ${uploadResp.status}`);
   }
 
   // Complete the upload and share to channel/thread

--- a/extensions/slack/src/send.ts
+++ b/extensions/slack/src/send.ts
@@ -8,10 +8,7 @@ import {
   type MessageReceiptSourceResult,
 } from "openclaw/plugin-sdk/channel-outbound";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import {
-  createHttp1EnvHttpProxyAgent,
-  shouldUseEnvHttpProxyForUrl,
-} from "openclaw/plugin-sdk/fetch-runtime";
+import { withTrustedEnvProxyGuardedFetchMode } from "openclaw/plugin-sdk/fetch-runtime";
 import { resolveMarkdownTableMode } from "openclaw/plugin-sdk/markdown-table-runtime";
 import { requireRuntimeConfig } from "openclaw/plugin-sdk/plugin-config-runtime";
 import {
@@ -22,11 +19,7 @@ import {
 } from "openclaw/plugin-sdk/reply-chunking";
 import { resolveTextChunksWithFallback } from "openclaw/plugin-sdk/reply-payload";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
-import {
-  fetchWithRuntimeDispatcherOrMockedGlobal,
-  type DispatcherAwareRequestInit,
-} from "openclaw/plugin-sdk/runtime-fetch";
-import { closeDispatcher } from "openclaw/plugin-sdk/ssrf-runtime";
+import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
@@ -46,6 +39,10 @@ import { normalizeSlackThreadTsCandidate } from "./thread-ts.js";
 import { resolveSlackBotToken } from "./token.js";
 import { truncateSlackText } from "./truncate.js";
 const SLACK_DM_CHANNEL_CACHE_MAX = 1024;
+const SLACK_UPLOAD_SSRF_POLICY = {
+  allowedHostnames: ["*.slack.com", "*.slack-edge.com", "*.slack-files.com"],
+  allowRfc2544BenchmarkRange: true,
+};
 const SLACK_DNS_RETRY_CODES = new Set(["EAI_AGAIN", "ENOTFOUND", "UND_ERR_DNS_RESOLVE_FAILED"]);
 const SLACK_DNS_RETRY_ATTEMPTS = 2;
 const SLACK_DNS_RETRY_BASE_DELAY_MS = 250;
@@ -549,20 +546,24 @@ async function uploadSlackFileContent(params: {
   body: BodyInit;
   contentType?: string;
 }): Promise<Response> {
-  const dispatcher = shouldUseEnvHttpProxyForUrl(params.uploadUrl)
-    ? createHttp1EnvHttpProxyAgent()
-    : null;
-  const init: DispatcherAwareRequestInit = {
-    method: "POST",
-    ...(params.contentType ? { headers: { "Content-Type": params.contentType } } : {}),
-    body: params.body,
-    redirect: "error",
-    ...(dispatcher ? { dispatcher } : {}),
-  };
+  const { response, release } = await fetchWithSsrFGuard(
+    withTrustedEnvProxyGuardedFetchMode({
+      url: params.uploadUrl,
+      maxRedirects: 0,
+      init: {
+        method: "POST",
+        ...(params.contentType ? { headers: { "Content-Type": params.contentType } } : {}),
+        body: params.body,
+        redirect: "error",
+      },
+      policy: SLACK_UPLOAD_SSRF_POLICY,
+      auditContext: "slack-upload-file",
+    }),
+  );
   try {
-    return await fetchWithRuntimeDispatcherOrMockedGlobal(params.uploadUrl, init);
+    return response;
   } finally {
-    await closeDispatcher(dispatcher);
+    await release();
   }
 }
 

--- a/extensions/slack/src/send.ts
+++ b/extensions/slack/src/send.ts
@@ -8,6 +8,10 @@ import {
   type MessageReceiptSourceResult,
 } from "openclaw/plugin-sdk/channel-outbound";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import {
+  createHttp1EnvHttpProxyAgent,
+  shouldUseEnvHttpProxyForUrl,
+} from "openclaw/plugin-sdk/fetch-runtime";
 import { resolveMarkdownTableMode } from "openclaw/plugin-sdk/markdown-table-runtime";
 import { requireRuntimeConfig } from "openclaw/plugin-sdk/plugin-config-runtime";
 import {
@@ -18,6 +22,11 @@ import {
 } from "openclaw/plugin-sdk/reply-chunking";
 import { resolveTextChunksWithFallback } from "openclaw/plugin-sdk/reply-payload";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
+import {
+  fetchWithRuntimeDispatcherOrMockedGlobal,
+  type DispatcherAwareRequestInit,
+} from "openclaw/plugin-sdk/runtime-fetch";
+import { closeDispatcher } from "openclaw/plugin-sdk/ssrf-runtime";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
@@ -535,6 +544,28 @@ export function clearSlackSendQueuesForTest(): void {
   slackSendQueues.clear();
 }
 
+async function uploadSlackFileContent(params: {
+  uploadUrl: string;
+  body: BodyInit;
+  contentType?: string;
+}): Promise<Response> {
+  const dispatcher = shouldUseEnvHttpProxyForUrl(params.uploadUrl)
+    ? createHttp1EnvHttpProxyAgent()
+    : null;
+  const init: DispatcherAwareRequestInit = {
+    method: "POST",
+    ...(params.contentType ? { headers: { "Content-Type": params.contentType } } : {}),
+    body: params.body,
+    redirect: "error",
+    ...(dispatcher ? { dispatcher } : {}),
+  };
+  try {
+    return await fetchWithRuntimeDispatcherOrMockedGlobal(params.uploadUrl, init);
+  } finally {
+    await closeDispatcher(dispatcher);
+  }
+}
+
 async function uploadSlackFile(params: {
   client: WebClient;
   channelId: string;
@@ -575,11 +606,10 @@ async function uploadSlackFile(params: {
 
   // Upload the file content to the presigned URL
   const uploadBody = new Uint8Array(buffer) as BodyInit;
-  const uploadResp = await fetch(uploadUrlResp.upload_url, {
-    method: "POST",
-    ...(contentType ? { headers: { "Content-Type": contentType } } : {}),
+  const uploadResp = await uploadSlackFileContent({
+    uploadUrl: uploadUrlResp.upload_url,
     body: uploadBody,
-    redirect: "error",
+    ...(contentType ? { contentType } : {}),
   });
   if (!uploadResp.ok) {
     throw new Error(`Failed to upload file: HTTP ${uploadResp.status}`);

--- a/extensions/slack/src/send.upload.test.ts
+++ b/extensions/slack/src/send.upload.test.ts
@@ -17,32 +17,6 @@ const loadOutboundMediaFromUrlMock = vi.hoisted(() =>
     fileName: "screenshot.png",
   })),
 );
-const fetchWithSsrFGuard = vi.fn(
-  async (params: { url: string; init?: RequestInit }) =>
-    ({
-      response: await fetch(params.url, params.init),
-      finalUrl: params.url,
-      release: async () => {},
-    }) as const,
-);
-
-vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
-  fetchWithSsrFGuard: (...args: unknown[]) =>
-    fetchWithSsrFGuard(...(args as [params: { url: string; init?: RequestInit }])),
-}));
-
-vi.mock("openclaw/plugin-sdk/fetch-runtime", async () => {
-  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/fetch-runtime")>(
-    "openclaw/plugin-sdk/fetch-runtime",
-  );
-  return {
-    ...actual,
-    withTrustedEnvProxyGuardedFetchMode: (params: Record<string, unknown>) => ({
-      ...params,
-      mode: "trusted_env_proxy",
-    }),
-  };
-});
 
 vi.mock("./runtime-api.js", async () => {
   const actual = await vi.importActual<typeof import("./runtime-api.js")>("./runtime-api.js");
@@ -165,7 +139,6 @@ describe("sendMessageSlack file upload with user IDs", () => {
     globalThis.fetch = vi.fn(
       async () => new Response("ok", { status: 200 }),
     ) as unknown as typeof fetch;
-    fetchWithSsrFGuard.mockClear();
     loadOutboundMediaFromUrlMock.mockClear();
     clearSlackDmChannelCache();
     clearSlackSendQueuesForTest();
@@ -379,11 +352,9 @@ describe("sendMessageSlack file upload with user IDs", () => {
     expect(fetchCalls).toHaveLength(1);
     const [fetchUrl, fetchInit] = fetchCalls[0] ?? [];
     expect(fetchUrl).toBe("https://uploads.slack.test/upload");
-    expectFields(requireRecord(fetchInit, "fetch init"), { method: "POST" });
-    expectOnlyCallFirstArg(fetchWithSsrFGuard, {
-      url: "https://uploads.slack.test/upload",
-      mode: "trusted_env_proxy",
-      auditContext: "slack-upload-file",
+    expectFields(requireRecord(fetchInit, "fetch init"), {
+      method: "POST",
+      redirect: "error",
     });
     expectCompletedUpload({
       client,

--- a/extensions/slack/src/send.upload.test.ts
+++ b/extensions/slack/src/send.upload.test.ts
@@ -137,7 +137,7 @@ function createUploadTestClient(): UploadTestClient {
     files: {
       getUploadURLExternal: vi.fn<(...args: unknown[]) => Promise<unknown>>(async () => ({
         ok: true,
-        upload_url: "https://uploads.slack.test/upload",
+        upload_url: "https://uploads.slack-files.com/upload",
         file_id: "F001",
       })),
       completeUploadExternal: vi.fn<(...args: unknown[]) => Promise<unknown>>(async () => ({
@@ -385,10 +385,10 @@ describe("sendMessageSlack file upload with user IDs", () => {
     const fetchCalls = (globalThis.fetch as unknown as MockCalls).mock.calls;
     expect(fetchCalls).toHaveLength(1);
     const [fetchUrl, fetchInit] = fetchCalls[0] ?? [];
-    expect(fetchUrl).toBe("https://uploads.slack.test/upload");
+    expect(fetchUrl).toBe("https://uploads.slack-files.com/upload");
     expectFields(requireRecord(fetchInit, "fetch init"), {
       method: "POST",
-      redirect: "error",
+      redirect: "manual",
     });
     expectCompletedUpload({
       client,
@@ -400,6 +400,27 @@ describe("sendMessageSlack file upload with user IDs", () => {
     });
     expect(hasSlackThreadParticipation("default", "C123CHAN", "171.222")).toBe(true);
     expect(result.receipt.threadId).toBe("171.222");
+  });
+
+  it("rejects non-Slack presigned upload URLs before posting bytes", async () => {
+    const client = createUploadTestClient();
+    client.files.getUploadURLExternal.mockResolvedValueOnce({
+      ok: true,
+      upload_url: "http://127.0.0.1/upload",
+      file_id: "F001",
+    });
+
+    await expect(
+      sendMessageSlack("channel:C123CHAN", "caption", {
+        token: "xoxb-test",
+        cfg: SLACK_TEST_CFG,
+        client,
+        mediaUrl: "/tmp/threaded.png",
+      }),
+    ).rejects.toThrow("Blocked hostname");
+
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(client.files.completeUploadExternal).not.toHaveBeenCalled();
   });
 
   it("uses the configured env proxy dispatcher for presigned upload bytes", async () => {

--- a/extensions/slack/src/send.upload.test.ts
+++ b/extensions/slack/src/send.upload.test.ts
@@ -32,6 +32,21 @@ vi.mock("./runtime-api.js", async () => {
 const { sendMessageSlack, clearSlackDmChannelCache, clearSlackSendQueuesForTest } =
   await import("./send.js");
 const SLACK_TEST_CFG = { channels: { slack: { botToken: "xoxb-test" } } };
+const PROXY_ENV_KEYS = [
+  "HTTPS_PROXY",
+  "HTTP_PROXY",
+  "https_proxy",
+  "http_proxy",
+  "NO_PROXY",
+  "no_proxy",
+] as const;
+const ORIGINAL_PROXY_ENV: Partial<Record<(typeof PROXY_ENV_KEYS)[number], string>> = {};
+for (const key of PROXY_ENV_KEYS) {
+  const value = process.env[key];
+  if (value !== undefined) {
+    ORIGINAL_PROXY_ENV[key] = value;
+  }
+}
 
 type UploadTestClient = WebClient & {
   conversations: { open: ReturnType<typeof vi.fn<(...args: unknown[]) => Promise<unknown>>> };
@@ -132,10 +147,28 @@ function createUploadTestClient(): UploadTestClient {
   } as unknown as UploadTestClient;
 }
 
+function clearProxyEnvForTest(): void {
+  for (const key of PROXY_ENV_KEYS) {
+    delete process.env[key];
+  }
+}
+
+function restoreProxyEnvForTest(): void {
+  for (const key of PROXY_ENV_KEYS) {
+    const original = ORIGINAL_PROXY_ENV[key];
+    if (original === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = original;
+    }
+  }
+}
+
 describe("sendMessageSlack file upload with user IDs", () => {
   const originalFetch = globalThis.fetch;
 
   beforeEach(() => {
+    clearProxyEnvForTest();
     globalThis.fetch = vi.fn(
       async () => new Response("ok", { status: 200 }),
     ) as unknown as typeof fetch;
@@ -147,6 +180,7 @@ describe("sendMessageSlack file upload with user IDs", () => {
 
   afterEach(() => {
     globalThis.fetch = originalFetch;
+    restoreProxyEnvForTest();
     vi.restoreAllMocks();
   });
 
@@ -366,6 +400,23 @@ describe("sendMessageSlack file upload with user IDs", () => {
     });
     expect(hasSlackThreadParticipation("default", "C123CHAN", "171.222")).toBe(true);
     expect(result.receipt.threadId).toBe("171.222");
+  });
+
+  it("uses the configured env proxy dispatcher for presigned upload bytes", async () => {
+    process.env.HTTPS_PROXY = "http://proxy.example.com:3128";
+    const client = createUploadTestClient();
+
+    await sendMessageSlack("channel:C123CHAN", "caption", {
+      token: "xoxb-test",
+      cfg: SLACK_TEST_CFG,
+      client,
+      mediaUrl: "/tmp/threaded.png",
+    });
+
+    const fetchCalls = (globalThis.fetch as unknown as MockCalls).mock.calls;
+    expect(fetchCalls).toHaveLength(1);
+    const [, fetchInit] = fetchCalls[0] ?? [];
+    expect(requireRecord(fetchInit, "fetch init").dispatcher).toBeDefined();
   });
 
   it("uses explicit upload filename and title overrides when provided", async () => {

--- a/src/agents/provider-request-config.test.ts
+++ b/src/agents/provider-request-config.test.ts
@@ -193,6 +193,7 @@ describe("provider request config", () => {
     expect(buildProviderRequestDispatcherPolicy(resolved)).toEqual({
       mode: "explicit-proxy",
       proxyUrl: "http://proxy.internal:8443",
+      allowPrivateProxy: true,
       proxyTls: {
         ca: "proxy-ca",
       },

--- a/src/agents/provider-request-config.ts
+++ b/src/agents/provider-request-config.ts
@@ -649,6 +649,7 @@ export function buildProviderRequestDispatcherPolicy(
   return {
     mode: "explicit-proxy",
     proxyUrl: request.proxy.proxyUrl,
+    allowPrivateProxy: true,
     ...(proxiedTls ? { proxyTls: proxiedTls } : {}),
   };
 }

--- a/src/agents/provider-transport-fetch.test.ts
+++ b/src/agents/provider-transport-fetch.test.ts
@@ -32,6 +32,7 @@ type DispatcherPolicyMockResult =
 
 const {
   buildProviderRequestDispatcherPolicyMock,
+  assertExplicitProxyAllowedWithPolicyMock,
   fetchWithSsrFGuardMock,
   captureHttpExchangeMock,
   closeDispatcherMock,
@@ -80,6 +81,7 @@ const {
     buildProviderRequestDispatcherPolicyMock: vi.fn<
       (_request?: unknown) => DispatcherPolicyMockResult
     >(() => undefined),
+    assertExplicitProxyAllowedWithPolicyMock: vi.fn(async () => undefined),
     fetchWithSsrFGuardMock: vi.fn(),
     captureHttpExchangeMock: vi.fn(),
     closeDispatcherMock: vi.fn(async (dispatcher: { close?: () => Promise<void> } | null) => {
@@ -168,6 +170,7 @@ vi.mock("../infra/net/ssrf.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../infra/net/ssrf.js")>();
   return {
     ...actual,
+    assertExplicitProxyAllowedWithPolicy: assertExplicitProxyAllowedWithPolicyMock,
     closeDispatcher: closeDispatcherMock,
     createPinnedDispatcher: createPinnedDispatcherMock,
     resolvePinnedHostnameWithPolicy: resolvePinnedHostnameWithPolicyMock,
@@ -248,6 +251,7 @@ describe("buildGuardedModelFetch", () => {
       release: vi.fn(async () => undefined),
     });
     ensureModelProviderLocalServiceMock.mockReset().mockResolvedValue(undefined);
+    assertExplicitProxyAllowedWithPolicyMock.mockReset().mockResolvedValue(undefined);
     buildProviderRequestDispatcherPolicyMock.mockClear().mockReturnValue(undefined);
     captureHttpExchangeMock.mockClear();
     createHttp1AgentMock.mockClear().mockReturnValue({ close: vi.fn(async () => undefined) });
@@ -916,6 +920,44 @@ describe("buildGuardedModelFetch", () => {
       },
       undefined,
     );
+  });
+
+  it("rejects private explicit provider proxy hosts before fetch", async () => {
+    buildProviderRequestDispatcherPolicyMock.mockReturnValueOnce({
+      mode: "explicit-proxy",
+      proxyUrl: "http://127.0.0.1:8888",
+    });
+    assertExplicitProxyAllowedWithPolicyMock.mockRejectedValueOnce(
+      new Error("Blocked hostname or private/internal/special-use IP address"),
+    );
+    const model = {
+      id: "gpt-5.4",
+      provider: "openai",
+      api: "openai-responses",
+      baseUrl: "https://api.openai.com/v1",
+    } as unknown as Model<"openai-responses">;
+
+    await expect(
+      buildGuardedModelFetch(model)("https://api.openai.com/v1/responses", {
+        method: "POST",
+      }),
+    ).rejects.toThrow("Blocked hostname or private/internal/special-use IP address");
+
+    expect(assertExplicitProxyAllowedWithPolicyMock).toHaveBeenCalledWith(
+      {
+        mode: "explicit-proxy",
+        proxyUrl: "http://127.0.0.1:8888",
+      },
+      {
+        policy: expect.objectContaining({
+          allowedOrigins: ["https://api.openai.com"],
+          hostnameAllowlist: ["api.openai.com"],
+        }),
+      },
+    );
+    expect(resolvePinnedHostnameWithPolicyMock).not.toHaveBeenCalled();
+    expect(createHttp1ProxyAgentMock).not.toHaveBeenCalled();
+    expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
   });
 
   it("rejects plain HTTP provider targets through explicit proxies", async () => {

--- a/src/agents/provider-transport-fetch.test.ts
+++ b/src/agents/provider-transport-fetch.test.ts
@@ -26,6 +26,7 @@ type DispatcherPolicyMockResult =
   | {
       mode: "explicit-proxy";
       proxyUrl: string;
+      allowPrivateProxy?: boolean;
       proxyTls?: Record<string, unknown>;
     }
   | undefined;
@@ -102,6 +103,7 @@ const {
         policy?: {
           mode?: "direct" | "env-proxy" | "explicit-proxy";
           proxyUrl?: string;
+          allowPrivateProxy?: boolean;
           connect?: Record<string, unknown>;
           proxyTls?: Record<string, unknown>;
         },
@@ -922,7 +924,53 @@ describe("buildGuardedModelFetch", () => {
     );
   });
 
-  it("rejects private explicit provider proxy hosts before fetch", async () => {
+  it("allows configured private explicit provider proxy hosts", async () => {
+    buildProviderRequestDispatcherPolicyMock.mockReturnValueOnce({
+      mode: "explicit-proxy",
+      proxyUrl: "http://127.0.0.1:8888",
+      allowPrivateProxy: true,
+    });
+    const model = {
+      id: "gpt-5.4",
+      provider: "openai",
+      api: "openai-responses",
+      baseUrl: "https://api.openai.com/v1",
+    } as unknown as Model<"openai-responses">;
+
+    await buildGuardedModelFetch(model)("https://api.openai.com/v1/responses", {
+      method: "POST",
+    });
+
+    expect(assertExplicitProxyAllowedWithPolicyMock).toHaveBeenCalledWith(
+      {
+        mode: "explicit-proxy",
+        proxyUrl: "http://127.0.0.1:8888",
+        allowPrivateProxy: true,
+      },
+      {
+        policy: expect.objectContaining({
+          allowedOrigins: ["https://api.openai.com"],
+          hostnameAllowlist: ["api.openai.com"],
+        }),
+      },
+    );
+    expect(resolvePinnedHostnameWithPolicyMock).toHaveBeenCalledWith("api.openai.com", {
+      policy: expect.objectContaining({
+        allowedOrigins: ["https://api.openai.com"],
+        hostnameAllowlist: ["api.openai.com"],
+      }),
+    });
+    expect(createHttp1ProxyAgentMock).toHaveBeenCalledWith(
+      {
+        uri: "http://127.0.0.1:8888",
+        requestTls: { lookup: expect.any(Function) },
+      },
+      undefined,
+    );
+    expect(fetchWithSsrFGuardMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects unmarked private explicit provider proxy hosts before fetch", async () => {
     buildProviderRequestDispatcherPolicyMock.mockReturnValueOnce({
       mode: "explicit-proxy",
       proxyUrl: "http://127.0.0.1:8888",
@@ -943,18 +991,6 @@ describe("buildGuardedModelFetch", () => {
       }),
     ).rejects.toThrow("Blocked hostname or private/internal/special-use IP address");
 
-    expect(assertExplicitProxyAllowedWithPolicyMock).toHaveBeenCalledWith(
-      {
-        mode: "explicit-proxy",
-        proxyUrl: "http://127.0.0.1:8888",
-      },
-      {
-        policy: expect.objectContaining({
-          allowedOrigins: ["https://api.openai.com"],
-          hostnameAllowlist: ["api.openai.com"],
-        }),
-      },
-    );
     expect(resolvePinnedHostnameWithPolicyMock).not.toHaveBeenCalled();
     expect(createHttp1ProxyAgentMock).not.toHaveBeenCalled();
     expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();

--- a/src/agents/provider-transport-fetch.test.ts
+++ b/src/agents/provider-transport-fetch.test.ts
@@ -46,6 +46,7 @@ const {
   resolvePinnedHostnameWithPolicyMock,
   resolveProviderRequestPolicyConfigMock,
   shouldUseEnvHttpProxyForUrlMock,
+  globalUndiciStreamTimeoutMsState,
   managedStreamCleanupRegistrations,
 } = vi.hoisted(() => {
   // Mock FinalizationRegistry so stream cleanup registrations are directly assertable.
@@ -148,6 +149,7 @@ const {
       }),
     ),
     shouldUseEnvHttpProxyForUrlMock: vi.fn(() => false),
+    globalUndiciStreamTimeoutMsState: { value: undefined as number | undefined },
     managedStreamCleanupRegistrations: managedStreamCleanupRegistrationsLocal,
   };
 });
@@ -178,6 +180,12 @@ vi.mock("../infra/net/ssrf.js", async (importOriginal) => {
     resolvePinnedHostnameWithPolicy: resolvePinnedHostnameWithPolicyMock,
   };
 });
+
+vi.mock("../infra/net/undici-global-dispatcher.js", () => ({
+  get globalUndiciStreamTimeoutMs() {
+    return globalUndiciStreamTimeoutMsState.value;
+  },
+}));
 
 vi.mock("../proxy-capture/runtime.js", () => ({
   captureHttpExchange: captureHttpExchangeMock,
@@ -275,6 +283,7 @@ describe("buildGuardedModelFetch", () => {
       .mockClear()
       .mockReturnValue({ allowPrivateNetwork: false, policy: { endpointClass: "local" } });
     shouldUseEnvHttpProxyForUrlMock.mockClear().mockReturnValue(false);
+    globalUndiciStreamTimeoutMsState.value = undefined;
     delete process.env.OPENCLAW_DEBUG_PROXY_ENABLED;
     delete process.env.OPENCLAW_DEBUG_PROXY_URL;
     delete process.env.OPENCLAW_SDK_RETRY_MAX_WAIT_SECONDS;
@@ -869,6 +878,26 @@ describe("buildGuardedModelFetch", () => {
     );
     expect((latestGuardedFetchParams().init as Record<string, unknown>).dispatcher).toBe(
       createHttp1AgentMock.mock.results[0]?.value,
+    );
+  });
+
+  it("uses the configured global stream timeout when provider timeout is omitted", async () => {
+    globalUndiciStreamTimeoutMsState.value = 1_900_000;
+    buildProviderRequestDispatcherPolicyMock.mockReturnValueOnce({ mode: "direct" });
+    const model = {
+      id: "gpt-5.4",
+      provider: "openai",
+      api: "openai-responses",
+      baseUrl: "https://api.openai.com/v1",
+    } as unknown as Model<"openai-responses">;
+
+    await buildGuardedModelFetch(model)("https://api.openai.com/v1/responses", {
+      method: "POST",
+    });
+
+    expect(createHttp1AgentMock).toHaveBeenCalledWith(
+      { connect: { lookup: expect.any(Function) } },
+      1_900_000,
     );
   });
 

--- a/src/agents/provider-transport-fetch.test.ts
+++ b/src/agents/provider-transport-fetch.test.ts
@@ -13,6 +13,23 @@ type ProviderRequestPolicyConfigMockResult = {
   };
 };
 
+type DispatcherPolicyMockResult =
+  | {
+      mode: "direct";
+      connect?: Record<string, unknown>;
+    }
+  | {
+      mode: "env-proxy";
+      connect?: Record<string, unknown>;
+      proxyTls?: Record<string, unknown>;
+    }
+  | {
+      mode: "explicit-proxy";
+      proxyUrl: string;
+      proxyTls?: Record<string, unknown>;
+    }
+  | undefined;
+
 const {
   buildProviderRequestDispatcherPolicyMock,
   fetchWithSsrFGuardMock,
@@ -61,16 +78,22 @@ const {
 
   return {
     buildProviderRequestDispatcherPolicyMock: vi.fn<
-      (_request?: unknown) => { mode: "direct" } | undefined
+      (_request?: unknown) => DispatcherPolicyMockResult
     >(() => undefined),
     fetchWithSsrFGuardMock: vi.fn(),
     captureHttpExchangeMock: vi.fn(),
     closeDispatcherMock: vi.fn(async (dispatcher: { close?: () => Promise<void> } | null) => {
       await dispatcher?.close?.();
     }),
-    createHttp1AgentMock: vi.fn(() => ({ close: vi.fn(async () => undefined) })),
-    createHttp1EnvHttpProxyAgentMock: vi.fn(() => ({ close: vi.fn(async () => undefined) })),
-    createHttp1ProxyAgentMock: vi.fn(() => ({ close: vi.fn(async () => undefined) })),
+    createHttp1AgentMock: vi.fn((_options?: unknown, _timeoutMs?: number) => ({
+      close: vi.fn(async () => undefined),
+    })),
+    createHttp1EnvHttpProxyAgentMock: vi.fn((_options?: unknown, _timeoutMs?: number) => ({
+      close: vi.fn(async () => undefined),
+    })),
+    createHttp1ProxyAgentMock: vi.fn((_options?: unknown, _timeoutMs?: number) => ({
+      close: vi.fn(async () => undefined),
+    })),
     createPinnedDispatcherMock: vi.fn(
       (
         pinned: { lookup: unknown },

--- a/src/agents/provider-transport-fetch.test.ts
+++ b/src/agents/provider-transport-fetch.test.ts
@@ -17,11 +17,14 @@ const {
   buildProviderRequestDispatcherPolicyMock,
   fetchWithSsrFGuardMock,
   captureHttpExchangeMock,
+  closeDispatcherMock,
   createHttp1AgentMock,
   createHttp1EnvHttpProxyAgentMock,
   createHttp1ProxyAgentMock,
+  createPinnedDispatcherMock,
   ensureModelProviderLocalServiceMock,
   mergeModelProviderRequestOverridesMock,
+  resolvePinnedHostnameWithPolicyMock,
   resolveProviderRequestPolicyConfigMock,
   shouldUseEnvHttpProxyForUrlMock,
   managedStreamCleanupRegistrations,
@@ -62,17 +65,59 @@ const {
     >(() => undefined),
     fetchWithSsrFGuardMock: vi.fn(),
     captureHttpExchangeMock: vi.fn(),
+    closeDispatcherMock: vi.fn(async (dispatcher: { close?: () => Promise<void> } | null) => {
+      await dispatcher?.close?.();
+    }),
     createHttp1AgentMock: vi.fn(() => ({ close: vi.fn(async () => undefined) })),
     createHttp1EnvHttpProxyAgentMock: vi.fn(() => ({ close: vi.fn(async () => undefined) })),
     createHttp1ProxyAgentMock: vi.fn(() => ({ close: vi.fn(async () => undefined) })),
+    createPinnedDispatcherMock: vi.fn(
+      (
+        pinned: { lookup: unknown },
+        policy?: {
+          mode?: "direct" | "env-proxy" | "explicit-proxy";
+          proxyUrl?: string;
+          connect?: Record<string, unknown>;
+          proxyTls?: Record<string, unknown>;
+        },
+        _ssrfPolicy?: unknown,
+        timeoutMs?: number,
+      ) => {
+        if (policy?.mode === "env-proxy") {
+          return createHttp1EnvHttpProxyAgentMock(
+            {
+              connect: { ...policy.connect, lookup: pinned.lookup },
+              ...(policy.proxyTls ? { proxyTls: policy.proxyTls } : {}),
+            },
+            timeoutMs,
+          );
+        }
+        if (policy?.mode === "explicit-proxy") {
+          return createHttp1ProxyAgentMock(
+            { uri: policy.proxyUrl, requestTls: { ...policy.proxyTls, lookup: pinned.lookup } },
+            timeoutMs,
+          );
+        }
+        return createHttp1AgentMock(
+          { connect: { ...policy?.connect, lookup: pinned.lookup } },
+          timeoutMs,
+        );
+      },
+    ),
     ensureModelProviderLocalServiceMock: vi.fn(),
     mergeModelProviderRequestOverridesMock: vi.fn((current, overrides) => ({
       ...current,
       ...overrides,
     })),
+    resolvePinnedHostnameWithPolicyMock: vi.fn(async (hostname: string) => ({
+      hostname,
+      addresses: ["93.184.216.34"],
+      lookup: vi.fn(),
+    })),
     resolveProviderRequestPolicyConfigMock: vi.fn<() => ProviderRequestPolicyConfigMockResult>(
       () => ({
         allowPrivateNetwork: false,
+        policy: { endpointClass: "local" },
       }),
     ),
     shouldUseEnvHttpProxyForUrlMock: vi.fn(() => false),
@@ -95,6 +140,16 @@ vi.mock("../infra/net/undici-runtime.js", () => ({
   createHttp1EnvHttpProxyAgent: createHttp1EnvHttpProxyAgentMock,
   createHttp1ProxyAgent: createHttp1ProxyAgentMock,
 }));
+
+vi.mock("../infra/net/ssrf.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../infra/net/ssrf.js")>();
+  return {
+    ...actual,
+    closeDispatcher: closeDispatcherMock,
+    createPinnedDispatcher: createPinnedDispatcherMock,
+    resolvePinnedHostnameWithPolicy: resolvePinnedHostnameWithPolicyMock,
+  };
+});
 
 vi.mock("../proxy-capture/runtime.js", () => ({
   captureHttpExchange: captureHttpExchangeMock,
@@ -177,10 +232,19 @@ describe("buildGuardedModelFetch", () => {
       .mockClear()
       .mockReturnValue({ close: vi.fn(async () => undefined) });
     createHttp1ProxyAgentMock.mockClear().mockReturnValue({ close: vi.fn(async () => undefined) });
+    closeDispatcherMock.mockClear();
+    createPinnedDispatcherMock.mockClear();
+    resolvePinnedHostnameWithPolicyMock
+      .mockClear()
+      .mockImplementation(async (hostname: string) => ({
+        hostname,
+        addresses: ["93.184.216.34"],
+        lookup: vi.fn(),
+      }));
     mergeModelProviderRequestOverridesMock.mockClear();
     resolveProviderRequestPolicyConfigMock
       .mockClear()
-      .mockReturnValue({ allowPrivateNetwork: false });
+      .mockReturnValue({ allowPrivateNetwork: false, policy: { endpointClass: "local" } });
     shouldUseEnvHttpProxyForUrlMock.mockClear().mockReturnValue(false);
     delete process.env.OPENCLAW_DEBUG_PROXY_ENABLED;
     delete process.env.OPENCLAW_DEBUG_PROXY_URL;
@@ -223,6 +287,52 @@ describe("buildGuardedModelFetch", () => {
       },
     });
     expect(capture.response).toBeInstanceOf(Response);
+  });
+
+  it("checks provider private-network policy before native fetch", async () => {
+    resolveProviderRequestPolicyConfigMock.mockReturnValueOnce({
+      allowPrivateNetwork: false,
+      privateNetworkExplicitlyDenied: true,
+      policy: { endpointClass: "local" },
+    });
+    resolvePinnedHostnameWithPolicyMock.mockRejectedValueOnce(
+      new Error("Blocked hostname or private/internal/special-use IP address"),
+    );
+    const model = {
+      id: "local-model",
+      provider: "custom-openai",
+      api: "openai-completions",
+      baseUrl: "http://127.0.0.1:18000/v1",
+    } as unknown as Model<"openai-completions">;
+
+    await expect(
+      buildGuardedModelFetch(model)("http://127.0.0.1:18000/v1/chat/completions", {
+        method: "POST",
+        body: '{"messages":[]}',
+      }),
+    ).rejects.toThrow("Blocked hostname or private/internal/special-use IP address");
+
+    expect(resolvePinnedHostnameWithPolicyMock).toHaveBeenCalledWith("127.0.0.1", {
+      policy: undefined,
+    });
+    expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects native redirect following for provider requests with bodies", async () => {
+    const model = {
+      id: "gpt-5.4",
+      provider: "openai",
+      api: "openai-responses",
+      baseUrl: "https://api.openai.com/v1",
+    } as unknown as Model<"openai-responses">;
+
+    await buildGuardedModelFetch(model)("https://api.openai.com/v1/responses", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: '{"input":"secret prompt"}',
+    });
+
+    expect((latestGuardedFetchParams().init as RequestInit | undefined)?.redirect).toBe("error");
   });
 
   it("rejects successful streamed OpenAI-compatible responses with HTML content", async () => {
@@ -714,7 +824,7 @@ describe("buildGuardedModelFetch", () => {
 
     expect(createHttp1EnvHttpProxyAgentMock).not.toHaveBeenCalled();
     expect(createHttp1AgentMock).toHaveBeenCalledWith(
-      { connect: { ca: "provider-ca" } },
+      { connect: { ca: "provider-ca", lookup: expect.any(Function) } },
       undefined,
     );
     expect((latestGuardedFetchParams().init as Record<string, unknown>).dispatcher).toBe(
@@ -740,7 +850,10 @@ describe("buildGuardedModelFetch", () => {
     });
 
     expect(createHttp1EnvHttpProxyAgentMock).toHaveBeenCalledWith(
-      { connect: { ca: "target-ca" }, proxyTls: { ca: "proxy-ca" } },
+      {
+        connect: { ca: "target-ca", lookup: expect.any(Function) },
+        proxyTls: { ca: "proxy-ca" },
+      },
       undefined,
     );
   });
@@ -763,7 +876,10 @@ describe("buildGuardedModelFetch", () => {
     });
 
     expect(createHttp1ProxyAgentMock).toHaveBeenCalledWith(
-      { uri: "https://proxy.example:8443", requestTls: { ca: "target-ca" } },
+      {
+        uri: "https://proxy.example:8443",
+        requestTls: { ca: "target-ca", lookup: expect.any(Function) },
+      },
       undefined,
     );
   });

--- a/src/agents/provider-transport-fetch.test.ts
+++ b/src/agents/provider-transport-fetch.test.ts
@@ -907,6 +907,30 @@ describe("buildGuardedModelFetch", () => {
     );
   });
 
+  it("rejects plain HTTP provider targets through explicit proxies", async () => {
+    buildProviderRequestDispatcherPolicyMock.mockReturnValueOnce({
+      mode: "explicit-proxy",
+      proxyUrl: "https://proxy.example:8443",
+    });
+    const model = {
+      id: "local-model",
+      provider: "local",
+      api: "openai-responses",
+      baseUrl: "http://model.example.test/v1",
+    } as unknown as Model<"openai-responses">;
+
+    await expect(
+      buildGuardedModelFetch(model)("http://model.example.test/v1/responses", {
+        method: "POST",
+      }),
+    ).rejects.toThrow(
+      "Explicit proxy SSRF pinning requires HTTPS targets; plain HTTP targets are not supported",
+    );
+
+    expect(createHttp1ProxyAgentMock).not.toHaveBeenCalled();
+    expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
+  });
+
   it("threads explicit transport timeouts into the provider fetch signal", async () => {
     const model = {
       id: "gpt-5.4",

--- a/src/agents/provider-transport-fetch.test.ts
+++ b/src/agents/provider-transport-fetch.test.ts
@@ -16,11 +16,14 @@ type ProviderRequestPolicyConfigMockResult = {
 const {
   buildProviderRequestDispatcherPolicyMock,
   fetchWithSsrFGuardMock,
+  captureHttpExchangeMock,
+  createHttp1AgentMock,
+  createHttp1EnvHttpProxyAgentMock,
+  createHttp1ProxyAgentMock,
   ensureModelProviderLocalServiceMock,
   mergeModelProviderRequestOverridesMock,
   resolveProviderRequestPolicyConfigMock,
   shouldUseEnvHttpProxyForUrlMock,
-  withTrustedEnvProxyGuardedFetchModeMock,
   managedStreamCleanupRegistrations,
 } = vi.hoisted(() => {
   // Mock FinalizationRegistry so stream cleanup registrations are directly assertable.
@@ -58,6 +61,10 @@ const {
       (_request?: unknown) => { mode: "direct" } | undefined
     >(() => undefined),
     fetchWithSsrFGuardMock: vi.fn(),
+    captureHttpExchangeMock: vi.fn(),
+    createHttp1AgentMock: vi.fn(() => ({ close: vi.fn(async () => undefined) })),
+    createHttp1EnvHttpProxyAgentMock: vi.fn(() => ({ close: vi.fn(async () => undefined) })),
+    createHttp1ProxyAgentMock: vi.fn(() => ({ close: vi.fn(async () => undefined) })),
     ensureModelProviderLocalServiceMock: vi.fn(),
     mergeModelProviderRequestOverridesMock: vi.fn((current, overrides) => ({
       ...current,
@@ -69,17 +76,28 @@ const {
       }),
     ),
     shouldUseEnvHttpProxyForUrlMock: vi.fn(() => false),
-    withTrustedEnvProxyGuardedFetchModeMock: vi.fn((params: Record<string, unknown>) => ({
-      ...params,
-      mode: "trusted_env_proxy",
-    })),
     managedStreamCleanupRegistrations: managedStreamCleanupRegistrationsLocal,
   };
 });
 
-vi.mock("../infra/net/fetch-guard.js", () => ({
-  fetchWithSsrFGuard: fetchWithSsrFGuardMock,
-  withTrustedEnvProxyGuardedFetchMode: withTrustedEnvProxyGuardedFetchModeMock,
+vi.mock("../infra/net/runtime-fetch.js", () => ({
+  fetchWithRuntimeDispatcherOrMockedGlobal: vi.fn(async (input, init) => {
+    const result = await fetchWithSsrFGuardMock({
+      url: input instanceof URL ? input.toString() : String(input),
+      init,
+    });
+    return result instanceof Response ? result : result.response;
+  }),
+}));
+
+vi.mock("../infra/net/undici-runtime.js", () => ({
+  createHttp1Agent: createHttp1AgentMock,
+  createHttp1EnvHttpProxyAgent: createHttp1EnvHttpProxyAgentMock,
+  createHttp1ProxyAgent: createHttp1ProxyAgentMock,
+}));
+
+vi.mock("../proxy-capture/runtime.js", () => ({
+  captureHttpExchange: captureHttpExchangeMock,
 }));
 
 vi.mock("../infra/net/proxy-env.js", () => ({
@@ -98,20 +116,11 @@ vi.mock("./provider-request-config.js", () => ({
 }));
 
 function latestGuardedFetchParams(): Record<string, unknown> {
-  // All transport calls should pass through the SSRF-guarded fetch seam.
+  // All transport calls should pass through the provider runtime fetch seam.
   const calls = fetchWithSsrFGuardMock.mock.calls;
   const params = calls[calls.length - 1]?.[0];
   if (!params || typeof params !== "object") {
     throw new Error("Expected guarded fetch call");
-  }
-  return params;
-}
-
-function latestTrustedEnvProxyParams(): Record<string, unknown> {
-  const calls = withTrustedEnvProxyGuardedFetchModeMock.mock.calls;
-  const params = calls[calls.length - 1]?.[0];
-  if (!params || typeof params !== "object") {
-    throw new Error("Expected trusted env proxy call");
   }
   return params;
 }
@@ -162,12 +171,17 @@ describe("buildGuardedModelFetch", () => {
     });
     ensureModelProviderLocalServiceMock.mockReset().mockResolvedValue(undefined);
     buildProviderRequestDispatcherPolicyMock.mockClear().mockReturnValue(undefined);
+    captureHttpExchangeMock.mockClear();
+    createHttp1AgentMock.mockClear().mockReturnValue({ close: vi.fn(async () => undefined) });
+    createHttp1EnvHttpProxyAgentMock
+      .mockClear()
+      .mockReturnValue({ close: vi.fn(async () => undefined) });
+    createHttp1ProxyAgentMock.mockClear().mockReturnValue({ close: vi.fn(async () => undefined) });
     mergeModelProviderRequestOverridesMock.mockClear();
     resolveProviderRequestPolicyConfigMock
       .mockClear()
       .mockReturnValue({ allowPrivateNetwork: false });
     shouldUseEnvHttpProxyForUrlMock.mockClear().mockReturnValue(false);
-    withTrustedEnvProxyGuardedFetchModeMock.mockClear();
     delete process.env.OPENCLAW_DEBUG_PROXY_ENABLED;
     delete process.env.OPENCLAW_DEBUG_PROXY_URL;
     delete process.env.OPENCLAW_SDK_RETRY_MAX_WAIT_SECONDS;
@@ -177,7 +191,7 @@ describe("buildGuardedModelFetch", () => {
     delete process.env.OPENCLAW_SDK_RETRY_MAX_WAIT_SECONDS;
   });
 
-  it("pushes provider capture metadata into the shared guarded fetch seam", async () => {
+  it("captures provider transport metadata at the native fetch seam", async () => {
     const model = {
       id: "gpt-5.4",
       provider: "openai",
@@ -194,17 +208,27 @@ describe("buildGuardedModelFetch", () => {
 
     const params = latestGuardedFetchParams();
     expect(params.url).toBe("https://api.openai.com/v1/responses");
-    expect(params.capture).toEqual({
+    const capture = captureHttpExchangeMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(capture).toMatchObject({
+      url: "https://api.openai.com/v1/responses",
+      method: "POST",
+      requestHeaders: { "content-type": "application/json" },
+      requestBody: '{"input":"hello"}',
+      transport: "http",
       meta: {
+        captureOrigin: "provider-transport",
         provider: "openai",
         api: "openai-responses",
         model: "gpt-5.4",
       },
     });
+    expect(capture.response).toBeInstanceOf(Response);
   });
 
   it("rejects successful streamed OpenAI-compatible responses with HTML content", async () => {
-    const release = vi.fn(async () => undefined);
+    const dispatcherClose = vi.fn(async () => undefined);
+    createHttp1AgentMock.mockReturnValueOnce({ close: dispatcherClose });
+    buildProviderRequestDispatcherPolicyMock.mockReturnValueOnce({ mode: "direct" });
     const model = {
       id: "private-model",
       provider: "custom-openai",
@@ -217,7 +241,6 @@ describe("buildGuardedModelFetch", () => {
         headers: { "content-type": "text/html; charset=utf-8" },
       }),
       finalUrl: "https://proxy.example.com/chat/completions",
-      release,
     });
 
     let error: unknown;
@@ -239,7 +262,7 @@ describe("buildGuardedModelFetch", () => {
     });
     expect(error).toBeInstanceOf(Error);
     expect((error as Error).message).toMatch(/baseUrl.*\/v1 path prefix/);
-    expect(release).toHaveBeenCalled();
+    expect(dispatcherClose).toHaveBeenCalled();
   });
 
   it("allows missing content-type when streamed OpenAI-compatible responses contain SSE", async () => {
@@ -372,7 +395,9 @@ describe("buildGuardedModelFetch", () => {
   });
 
   it("rejects missing content-type streamed OpenAI-compatible responses with HTML bodies", async () => {
-    const release = vi.fn(async () => undefined);
+    const dispatcherClose = vi.fn(async () => undefined);
+    createHttp1AgentMock.mockReturnValueOnce({ close: dispatcherClose });
+    buildProviderRequestDispatcherPolicyMock.mockReturnValueOnce({ mode: "direct" });
     const model = {
       id: "private-model",
       provider: "custom-openai",
@@ -382,7 +407,6 @@ describe("buildGuardedModelFetch", () => {
     fetchWithSsrFGuardMock.mockResolvedValue({
       response: new Response(responseStreamText("<html>not the API</html>")),
       finalUrl: "https://proxy.example.com/chat/completions",
-      release,
     });
 
     await expect(
@@ -397,7 +421,7 @@ describe("buildGuardedModelFetch", () => {
       code: "invalid_provider_content_type",
       errorType: "invalid_response",
     });
-    expect(release).toHaveBeenCalled();
+    expect(dispatcherClose).toHaveBeenCalled();
   });
 
   it("ensures configured local services before the model request", async () => {
@@ -421,8 +445,10 @@ describe("buildGuardedModelFetch", () => {
     await vi.waitFor(() => expect(release).toHaveBeenCalledTimes(1));
   });
 
-  it("releases guarded fetch slots when streamed bodies are abandoned", async () => {
-    const release = vi.fn(async () => undefined);
+  it("closes provider dispatchers when streamed bodies are abandoned", async () => {
+    const dispatcherClose = vi.fn(async () => undefined);
+    createHttp1AgentMock.mockReturnValueOnce({ close: dispatcherClose });
+    buildProviderRequestDispatcherPolicyMock.mockReturnValueOnce({ mode: "direct" });
     const encoder = new TextEncoder();
     fetchWithSsrFGuardMock.mockResolvedValue({
       response: new Response(
@@ -435,7 +461,6 @@ describe("buildGuardedModelFetch", () => {
         { status: 200 },
       ),
       finalUrl: "https://api.anthropic.com/v1/messages",
-      release,
     });
     const model = {
       id: "claude-sonnet-4-6",
@@ -458,7 +483,7 @@ describe("buildGuardedModelFetch", () => {
     expect(registration).toBeDefined();
     await registration?.held.finalize();
 
-    expect(release).toHaveBeenCalledTimes(1);
+    expect(dispatcherClose).toHaveBeenCalledTimes(1);
     expect(managedStreamCleanupRegistrations).toHaveLength(0);
   });
 
@@ -531,9 +556,7 @@ describe("buildGuardedModelFetch", () => {
         timeoutController.signal,
       );
       const params = latestGuardedFetchParams();
-      expect(params.timeoutMs).toBe(750);
-      expect(params.signal).toBeUndefined();
-      expect((params.init as RequestInit | undefined)?.signal).toBeUndefined();
+      expect((params.init as RequestInit | undefined)?.signal).toBeInstanceOf(AbortSignal);
     } finally {
       timeoutSpy.mockRestore();
     }
@@ -562,7 +585,9 @@ describe("buildGuardedModelFetch", () => {
         undefined,
         timeoutController.signal,
       );
-      expect(latestGuardedFetchParams().timeoutMs).toBe(MAX_TIMER_TIMEOUT_MS);
+      expect((latestGuardedFetchParams().init as RequestInit | undefined)?.signal).toBeInstanceOf(
+        AbortSignal,
+      );
     } finally {
       timeoutSpy.mockRestore();
     }
@@ -587,7 +612,7 @@ describe("buildGuardedModelFetch", () => {
 
       expect(timeoutSpy).not.toHaveBeenCalled();
       expect(ensureModelProviderLocalServiceMock).toHaveBeenCalledWith(model, undefined, undefined);
-      expect(latestGuardedFetchParams().timeoutMs).toBeUndefined();
+      expect((latestGuardedFetchParams().init as RequestInit | undefined)?.signal).toBeUndefined();
     } finally {
       timeoutSpy.mockRestore();
     }
@@ -622,15 +647,14 @@ describe("buildGuardedModelFetch", () => {
         combinedController.signal,
       );
       const params = latestGuardedFetchParams();
-      expect(params.signal).toBe(callerController.signal);
-      expect((params.init as RequestInit | undefined)?.signal).toBe(callerController.signal);
+      expect((params.init as RequestInit | undefined)?.signal).toBeInstanceOf(AbortSignal);
     } finally {
       timeoutSpy.mockRestore();
       anySpy.mockRestore();
     }
   });
 
-  it("releases local service leases when guarded fetch fails", async () => {
+  it("releases local service leases when provider fetch fails", async () => {
     const release = vi.fn();
     ensureModelProviderLocalServiceMock.mockResolvedValue({ release });
     fetchWithSsrFGuardMock.mockRejectedValue(new Error("network down"));
@@ -649,259 +673,7 @@ describe("buildGuardedModelFetch", () => {
     expect(release).toHaveBeenCalledTimes(1);
   });
 
-  it("scopes fake-IP DNS exemptions to the configured provider host", async () => {
-    const model = {
-      id: "gpt-5.4",
-      provider: "openai",
-      api: "openai-responses",
-      baseUrl: "https://api.openai.com/v1",
-    } as unknown as Model<"openai-responses">;
-
-    const fetcher = buildGuardedModelFetch(model);
-    await fetcher("https://api.openai.com/v1/responses", { method: "POST" });
-
-    const policy = latestGuardedFetchParams().policy as Record<string, unknown> | undefined;
-    expect(policy).toEqual({
-      allowRfc2544BenchmarkRange: true,
-      allowIpv6UniqueLocalRange: true,
-      hostnameAllowlist: ["api.openai.com"],
-    });
-    expect(policy?.allowedHostnames).toBeUndefined();
-    expect(policy?.allowPrivateNetwork).toBeUndefined();
-    expect(policy?.dangerouslyAllowPrivateNetwork).toBeUndefined();
-  });
-
-  it("does not apply fake-IP exemptions to non-provider hosts", async () => {
-    const model = {
-      id: "gpt-5.4",
-      provider: "openai",
-      api: "openai-responses",
-      baseUrl: "https://api.openai.com/v1",
-    } as unknown as Model<"openai-responses">;
-
-    const fetcher = buildGuardedModelFetch(model);
-    await fetcher("https://uploads.openai.com/v1/files", { method: "POST" });
-
-    const policy = latestGuardedFetchParams().policy;
-    expect(policy).toBeUndefined();
-  });
-
-  it("trusts exact configured custom provider hosts without broad private-network opt-in", async () => {
-    resolveProviderRequestPolicyConfigMock.mockReturnValueOnce({
-      allowPrivateNetwork: false,
-      policy: { endpointClass: "custom" },
-    });
-    const model = {
-      id: "qwen3:32b",
-      provider: "lmstudio",
-      api: "openai-completions",
-      baseUrl: "http://10.0.0.5:1234/v1",
-    } as unknown as Model<"openai-completions">;
-
-    const fetcher = buildGuardedModelFetch(model);
-    await fetcher("http://10.0.0.5:1234/v1/chat/completions", { method: "POST" });
-
-    const policy = fetchWithSsrFGuardMock.mock.calls[0]?.[0]?.policy;
-    expect(policy).toEqual({
-      allowedOrigins: ["http://10.0.0.5:1234"],
-    });
-    expect(policy?.allowPrivateNetwork).toBeUndefined();
-    expect(policy?.dangerouslyAllowPrivateNetwork).toBeUndefined();
-  });
-
-  it("trusts exact configured HTTPS custom provider origins", async () => {
-    resolveProviderRequestPolicyConfigMock.mockReturnValueOnce({
-      allowPrivateNetwork: false,
-      policy: { endpointClass: "custom" },
-    });
-    const model = {
-      id: "qwen3:32b",
-      provider: "custom-vllm",
-      api: "openai-completions",
-      baseUrl: "https://10.0.0.5:1234/v1",
-    } as unknown as Model<"openai-completions">;
-
-    const fetcher = buildGuardedModelFetch(model);
-    await fetcher("https://10.0.0.5:1234/v1/chat/completions", { method: "POST" });
-
-    const policy = fetchWithSsrFGuardMock.mock.calls[0]?.[0]?.policy;
-    expect(policy).toEqual({
-      allowedOrigins: ["https://10.0.0.5:1234"],
-    });
-  });
-
-  it("keeps explicit private-network denial ahead of configured custom origin trust", async () => {
-    resolveProviderRequestPolicyConfigMock.mockReturnValueOnce({
-      allowPrivateNetwork: false,
-      privateNetworkExplicitlyDenied: true,
-      policy: { endpointClass: "custom" },
-    });
-    const model = {
-      id: "qwen3:32b",
-      provider: "lmstudio",
-      api: "openai-completions",
-      baseUrl: "http://10.0.0.5:1234/v1",
-    } as unknown as Model<"openai-completions">;
-
-    const fetcher = buildGuardedModelFetch(model);
-    await fetcher("http://10.0.0.5:1234/v1/chat/completions", { method: "POST" });
-
-    const policy = fetchWithSsrFGuardMock.mock.calls[0]?.[0]?.policy;
-    expect(policy).toBeUndefined();
-  });
-
-  it("trusts exact configured local provider origins", async () => {
-    resolveProviderRequestPolicyConfigMock.mockReturnValueOnce({
-      allowPrivateNetwork: false,
-      policy: { endpointClass: "local" },
-    });
-    const model = {
-      id: "qwen3:32b",
-      provider: "lmstudio",
-      api: "openai-completions",
-      baseUrl: "http://127.0.0.1:1234/v1",
-    } as unknown as Model<"openai-completions">;
-
-    const fetcher = buildGuardedModelFetch(model);
-    await fetcher("http://127.0.0.1:1234/v1/chat/completions", { method: "POST" });
-
-    const policy = fetchWithSsrFGuardMock.mock.calls[0]?.[0]?.policy;
-    expect(policy).toEqual({
-      allowedOrigins: ["http://127.0.0.1:1234"],
-    });
-  });
-
-  it("does not trust a configured provider host on a different port", async () => {
-    resolveProviderRequestPolicyConfigMock.mockReturnValueOnce({
-      allowPrivateNetwork: false,
-      policy: { endpointClass: "custom" },
-    });
-    const model = {
-      id: "qwen3:32b",
-      provider: "lmstudio",
-      api: "openai-completions",
-      baseUrl: "http://10.0.0.5:1234/v1",
-    } as unknown as Model<"openai-completions">;
-
-    const fetcher = buildGuardedModelFetch(model);
-    await fetcher("http://10.0.0.5:4321/v1/chat/completions", { method: "POST" });
-
-    const policy = fetchWithSsrFGuardMock.mock.calls[0]?.[0]?.policy;
-    expect(policy).toBeUndefined();
-  });
-
-  it("does not add exact-origin trust for non-custom provider endpoints", async () => {
-    resolveProviderRequestPolicyConfigMock.mockReturnValueOnce({
-      allowPrivateNetwork: false,
-      policy: { endpointClass: "openai-public" },
-    });
-    const model = {
-      id: "qwen3:32b",
-      provider: "openai",
-      api: "openai-completions",
-      baseUrl: "http://10.0.0.5:1234/v1",
-    } as unknown as Model<"openai-completions">;
-
-    const fetcher = buildGuardedModelFetch(model);
-    await fetcher("http://10.0.0.5:1234/v1/chat/completions", { method: "POST" });
-
-    const policy = fetchWithSsrFGuardMock.mock.calls[0]?.[0]?.policy;
-    expect(policy).toBeUndefined();
-  });
-
-  it.each([
-    {
-      label: "link-local metadata IP",
-      baseUrl: "http://169.254.169.254/v1",
-      requestUrl: "http://169.254.169.254/v1/chat/completions",
-    },
-    {
-      label: "legacy link-local metadata IP",
-      baseUrl: "http://2852039166/v1",
-      requestUrl: "http://2852039166/v1/chat/completions",
-    },
-    {
-      label: "embedded IPv6 link-local metadata IP",
-      baseUrl: "http://[64:ff9b::a9fe:a9fe]/v1",
-      requestUrl: "http://[64:ff9b::a9fe:a9fe]/v1/chat/completions",
-    },
-    {
-      label: "non-link-local cloud metadata IP",
-      baseUrl: "http://100.100.100.200/v1",
-      requestUrl: "http://100.100.100.200/v1/chat/completions",
-    },
-    {
-      label: "IPv6 cloud metadata IP",
-      baseUrl: "http://[fd00:ec2::254]/v1",
-      requestUrl: "http://[fd00:ec2::254]/v1/chat/completions",
-    },
-    {
-      label: "embedded IPv6 cloud metadata IP",
-      baseUrl: "http://[64:ff9b::6464:64c8]/v1",
-      requestUrl: "http://[64:ff9b::6464:64c8]/v1/chat/completions",
-    },
-    {
-      label: "metadata hostname",
-      baseUrl: "http://metadata.google.internal/v1",
-      requestUrl: "http://metadata.google.internal/v1/chat/completions",
-    },
-    {
-      label: "metadata short hostname",
-      baseUrl: "http://metadata/v1",
-      requestUrl: "http://metadata/v1/chat/completions",
-    },
-    {
-      label: "metadata compound hostname",
-      baseUrl: "http://metadata-server.example/v1",
-      requestUrl: "http://metadata-server.example/v1/chat/completions",
-    },
-    {
-      label: "cloud instance-data hostname",
-      baseUrl: "http://instance-data.ec2.internal/v1",
-      requestUrl: "http://instance-data.ec2.internal/v1/chat/completions",
-    },
-  ])("does not add implicit exact-origin trust for $label", async (entry) => {
-    resolveProviderRequestPolicyConfigMock.mockReturnValueOnce({
-      allowPrivateNetwork: false,
-      policy: { endpointClass: "custom" },
-    });
-    const model = {
-      id: "qwen3:32b",
-      provider: "custom-metadata",
-      api: "openai-completions",
-      baseUrl: entry.baseUrl,
-    } as unknown as Model<"openai-completions">;
-
-    const fetcher = buildGuardedModelFetch(model);
-    await fetcher(entry.requestUrl, { method: "POST" });
-
-    const policy = fetchWithSsrFGuardMock.mock.calls[0]?.[0]?.policy;
-    expect(policy).toBeUndefined();
-  });
-
-  it("merges explicit private-network opt-in into the provider-host policies", async () => {
-    resolveProviderRequestPolicyConfigMock.mockReturnValueOnce({
-      allowPrivateNetwork: true,
-      policy: { endpointClass: "custom" },
-    });
-    const model = {
-      id: "qwen3:32b",
-      provider: "ollama",
-      api: "ollama",
-      baseUrl: "http://10.0.0.5:11434",
-    } as unknown as Model<"ollama">;
-
-    const fetcher = buildGuardedModelFetch(model);
-    await fetcher("http://10.0.0.5:11434/api/chat", { method: "POST" });
-
-    const policy = latestGuardedFetchParams().policy;
-    expect(policy).toEqual({
-      allowedOrigins: ["http://10.0.0.5:11434"],
-      allowPrivateNetwork: true,
-    });
-  });
-
-  it("uses trusted env-proxy mode for provider calls when no explicit dispatcher policy is configured", async () => {
+  it("uses an env proxy dispatcher for provider calls when no explicit dispatcher policy is configured", async () => {
     shouldUseEnvHttpProxyForUrlMock.mockReturnValueOnce(true);
     const model = {
       id: "gpt-5.4",
@@ -916,23 +688,20 @@ describe("buildGuardedModelFetch", () => {
     expect(shouldUseEnvHttpProxyForUrlMock).toHaveBeenCalledWith(
       "https://api.openai.com/v1/responses",
     );
-    const trustedParams = latestTrustedEnvProxyParams();
-    expect(trustedParams.url).toBe("https://api.openai.com/v1/responses");
-    expect(trustedParams.dispatcherPolicy).toBeUndefined();
-    expect(trustedParams.policy).toEqual({
-      allowRfc2544BenchmarkRange: true,
-      allowIpv6UniqueLocalRange: true,
-      hostnameAllowlist: ["api.openai.com"],
-    });
-
     const guardedParams = latestGuardedFetchParams();
     expect(guardedParams.url).toBe("https://api.openai.com/v1/responses");
-    expect(guardedParams.mode).toBe("trusted_env_proxy");
+    expect(createHttp1EnvHttpProxyAgentMock).toHaveBeenCalledWith(undefined, undefined);
+    expect((guardedParams.init as Record<string, unknown>).dispatcher).toBe(
+      createHttp1EnvHttpProxyAgentMock.mock.results[0]?.value,
+    );
   });
 
-  it("keeps explicit provider dispatcher policies in strict guarded-fetch mode", async () => {
+  it("uses direct dispatchers for explicit provider TLS policies", async () => {
     shouldUseEnvHttpProxyForUrlMock.mockReturnValueOnce(true);
-    buildProviderRequestDispatcherPolicyMock.mockReturnValueOnce({ mode: "direct" });
+    buildProviderRequestDispatcherPolicyMock.mockReturnValueOnce({
+      mode: "direct",
+      connect: { ca: "provider-ca" },
+    });
     const model = {
       id: "gpt-5.4",
       provider: "openai",
@@ -943,11 +712,63 @@ describe("buildGuardedModelFetch", () => {
     const fetcher = buildGuardedModelFetch(model);
     await fetcher("https://api.openai.com/v1/responses", { method: "POST" });
 
-    expect(withTrustedEnvProxyGuardedFetchModeMock).not.toHaveBeenCalled();
-    expect(latestGuardedFetchParams().dispatcherPolicy).toEqual({ mode: "direct" });
+    expect(createHttp1EnvHttpProxyAgentMock).not.toHaveBeenCalled();
+    expect(createHttp1AgentMock).toHaveBeenCalledWith(
+      { connect: { ca: "provider-ca" } },
+      undefined,
+    );
+    expect((latestGuardedFetchParams().init as Record<string, unknown>).dispatcher).toBe(
+      createHttp1AgentMock.mock.results[0]?.value,
+    );
   });
 
-  it("threads explicit transport timeouts into the shared guarded fetch seam", async () => {
+  it("uses configured env proxy dispatchers with target and proxy TLS options", async () => {
+    buildProviderRequestDispatcherPolicyMock.mockReturnValueOnce({
+      mode: "env-proxy",
+      connect: { ca: "target-ca" },
+      proxyTls: { ca: "proxy-ca" },
+    });
+    const model = {
+      id: "gpt-5.4",
+      provider: "openai",
+      api: "openai-responses",
+      baseUrl: "https://api.openai.com/v1",
+    } as unknown as Model<"openai-responses">;
+
+    await buildGuardedModelFetch(model)("https://api.openai.com/v1/responses", {
+      method: "POST",
+    });
+
+    expect(createHttp1EnvHttpProxyAgentMock).toHaveBeenCalledWith(
+      { connect: { ca: "target-ca" }, proxyTls: { ca: "proxy-ca" } },
+      undefined,
+    );
+  });
+
+  it("uses configured explicit proxy dispatchers with request TLS options", async () => {
+    buildProviderRequestDispatcherPolicyMock.mockReturnValueOnce({
+      mode: "explicit-proxy",
+      proxyUrl: "https://proxy.example:8443",
+      proxyTls: { ca: "target-ca" },
+    });
+    const model = {
+      id: "gpt-5.4",
+      provider: "openai",
+      api: "openai-responses",
+      baseUrl: "https://api.openai.com/v1",
+    } as unknown as Model<"openai-responses">;
+
+    await buildGuardedModelFetch(model)("https://api.openai.com/v1/responses", {
+      method: "POST",
+    });
+
+    expect(createHttp1ProxyAgentMock).toHaveBeenCalledWith(
+      { uri: "https://proxy.example:8443", requestTls: { ca: "target-ca" } },
+      undefined,
+    );
+  });
+
+  it("threads explicit transport timeouts into the provider fetch signal", async () => {
     const model = {
       id: "gpt-5.4",
       provider: "openai",
@@ -958,10 +779,12 @@ describe("buildGuardedModelFetch", () => {
     const fetcher = buildGuardedModelFetch(model, 123_456);
     await fetcher("https://api.openai.com/v1/responses", { method: "POST" });
 
-    expect(latestGuardedFetchParams().timeoutMs).toBe(123_456);
+    expect((latestGuardedFetchParams().init as RequestInit | undefined)?.signal).toBeInstanceOf(
+      AbortSignal,
+    );
   });
 
-  it("threads resolved provider timeout metadata into the shared guarded fetch seam", async () => {
+  it("threads resolved provider timeout metadata into the provider fetch signal", async () => {
     const model = {
       id: "qwen3:32b",
       provider: "ollama",
@@ -973,7 +796,9 @@ describe("buildGuardedModelFetch", () => {
     const fetcher = buildGuardedModelFetch(model);
     await fetcher("http://127.0.0.1:11434/api/chat", { method: "POST" });
 
-    expect(latestGuardedFetchParams().timeoutMs).toBe(300_000);
+    expect((latestGuardedFetchParams().init as RequestInit | undefined)?.signal).toBeInstanceOf(
+      AbortSignal,
+    );
   });
 
   it("does not force explicit debug proxy overrides onto plain HTTP model transports", async () => {
@@ -1302,7 +1127,6 @@ describe("buildGuardedModelFetch", () => {
 
   it("refreshes the guarded timeout while consuming streaming response chunks", async () => {
     const encoder = new TextEncoder();
-    const refreshTimeout = vi.fn();
     fetchWithSsrFGuardMock.mockResolvedValue({
       response: new Response(
         new ReadableStream({
@@ -1315,8 +1139,6 @@ describe("buildGuardedModelFetch", () => {
         { headers: { "content-type": "text/event-stream" } },
       ),
       finalUrl: "https://api.openai.com/v1/chat/completions",
-      release: vi.fn(async () => undefined),
-      refreshTimeout,
     });
     const model = {
       id: "gpt-5.4",
@@ -1335,7 +1157,6 @@ describe("buildGuardedModelFetch", () => {
     }
 
     expect(items).toEqual([{ ok: true }]);
-    expect(refreshTimeout).toHaveBeenCalledTimes(2);
   });
 
   describe("long retry-after handling", () => {

--- a/src/agents/provider-transport-fetch.test.ts
+++ b/src/agents/provider-transport-fetch.test.ts
@@ -341,7 +341,12 @@ describe("buildGuardedModelFetch", () => {
     expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
   });
 
-  it("rejects native redirect following for provider requests with bodies", async () => {
+  it("rejects native redirect following for provider requests", async () => {
+    fetchWithSsrFGuardMock.mockImplementation(async () => ({
+      response: new Response("ok", { status: 200 }),
+      finalUrl: "https://api.openai.com/v1/responses",
+      release: vi.fn(async () => undefined),
+    }));
     const model = {
       id: "gpt-5.4",
       provider: "openai",
@@ -353,6 +358,12 @@ describe("buildGuardedModelFetch", () => {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: '{"input":"secret prompt"}',
+    });
+
+    expect((latestGuardedFetchParams().init as RequestInit | undefined)?.redirect).toBe("error");
+
+    await buildGuardedModelFetch(model)("https://api.openai.com/v1/models", {
+      method: "GET",
     });
 
     expect((latestGuardedFetchParams().init as RequestInit | undefined)?.redirect).toBe("error");

--- a/src/agents/provider-transport-fetch.ts
+++ b/src/agents/provider-transport-fetch.ts
@@ -21,6 +21,7 @@ import {
   type DispatcherAwareRequestInit,
 } from "../infra/net/runtime-fetch.js";
 import {
+  assertExplicitProxyAllowedWithPolicy,
   assertHostnameAllowedWithPolicy,
   closeDispatcher,
   createPinnedDispatcher,
@@ -751,6 +752,7 @@ async function createProviderTransportDispatcher(params: {
     throw new Error("Invalid URL: must be http or https");
   }
   assertExplicitProxySupportsProviderTarget(parsedUrl, params.dispatcherPolicy);
+  await assertExplicitProxyAllowedWithPolicy(params.dispatcherPolicy, { policy: params.policy });
   const policyForUrl = resolveSsrFPolicyForUrl(parsedUrl, params.policy);
 
   if (params.useEnvProxy && !params.dispatcherPolicy) {

--- a/src/agents/provider-transport-fetch.ts
+++ b/src/agents/provider-transport-fetch.ts
@@ -33,6 +33,7 @@ import {
   type PinnedDispatcherPolicy,
   type SsrFPolicy,
 } from "../infra/net/ssrf.js";
+import { globalUndiciStreamTimeoutMs } from "../infra/net/undici-global-dispatcher.js";
 import { createHttp1EnvHttpProxyAgent } from "../infra/net/undici-runtime.js";
 import type { Model } from "../llm/types.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -729,6 +730,11 @@ type ProviderTransportFetchResult = {
   refreshTimeout?: () => void;
 };
 
+function resolveProviderDispatcherTimeoutMs(timeoutMs: number | undefined): number | undefined {
+  const resolved = timeoutMs ?? globalUndiciStreamTimeoutMs;
+  return resolved === undefined ? undefined : clampTimerTimeoutMs(resolved);
+}
+
 function assertExplicitProxySupportsProviderTarget(
   url: URL,
   dispatcherPolicy?: PinnedDispatcherPolicy,
@@ -754,16 +760,17 @@ async function createProviderTransportDispatcher(params: {
   assertExplicitProxySupportsProviderTarget(parsedUrl, params.dispatcherPolicy);
   await assertExplicitProxyAllowedWithPolicy(params.dispatcherPolicy, { policy: params.policy });
   const policyForUrl = resolveSsrFPolicyForUrl(parsedUrl, params.policy);
+  const dispatcherTimeoutMs = resolveProviderDispatcherTimeoutMs(params.timeoutMs);
 
   if (params.useEnvProxy && !params.dispatcherPolicy) {
     assertHostnameAllowedWithPolicy(parsedUrl.hostname, policyForUrl);
-    return createHttp1EnvHttpProxyAgent(undefined, params.timeoutMs);
+    return createHttp1EnvHttpProxyAgent(undefined, dispatcherTimeoutMs);
   }
 
   const pinned = await resolvePinnedHostnameWithPolicy(parsedUrl.hostname, {
     policy: policyForUrl,
   });
-  return createPinnedDispatcher(pinned, params.dispatcherPolicy, policyForUrl, params.timeoutMs);
+  return createPinnedDispatcher(pinned, params.dispatcherPolicy, policyForUrl, dispatcherTimeoutMs);
 }
 
 function captureProviderTransportExchange(params: {

--- a/src/agents/provider-transport-fetch.ts
+++ b/src/agents/provider-transport-fetch.ts
@@ -728,6 +728,17 @@ type ProviderTransportFetchResult = {
   refreshTimeout?: () => void;
 };
 
+function assertExplicitProxySupportsProviderTarget(
+  url: URL,
+  dispatcherPolicy?: PinnedDispatcherPolicy,
+): void {
+  if (dispatcherPolicy?.mode === "explicit-proxy" && url.protocol !== "https:") {
+    throw new Error(
+      "Explicit proxy SSRF pinning requires HTTPS targets; plain HTTP targets are not supported",
+    );
+  }
+}
+
 async function createProviderTransportDispatcher(params: {
   url: string;
   dispatcherPolicy: PinnedDispatcherPolicy | undefined;
@@ -739,6 +750,7 @@ async function createProviderTransportDispatcher(params: {
   if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {
     throw new Error("Invalid URL: must be http or https");
   }
+  assertExplicitProxySupportsProviderTarget(parsedUrl, params.dispatcherPolicy);
   const policyForUrl = resolveSsrFPolicyForUrl(parsedUrl, params.policy);
 
   if (params.useEnvProxy && !params.dispatcherPolicy) {

--- a/src/agents/provider-transport-fetch.ts
+++ b/src/agents/provider-transport-fetch.ts
@@ -1,8 +1,13 @@
 /**
  * Guarded provider fetch transport utilities.
  *
- * Applies request timeouts, proxy/TLS overrides, local-service leases, retry hints, and SSE normalization.
+ * Applies request timeouts, proxy/TLS overrides, SSRF policy, local-service leases, retry hints, and SSE normalization.
  */
+import {
+  isCloudMetadataIpAddress,
+  isLinkLocalIpAddress,
+  parseCanonicalIpAddress,
+} from "@openclaw/net-policy/ip";
 import {
   asFiniteNumberInRange,
   clampTimerTimeoutMs,
@@ -15,12 +20,19 @@ import {
   fetchWithRuntimeDispatcherOrMockedGlobal,
   type DispatcherAwareRequestInit,
 } from "../infra/net/runtime-fetch.js";
-import { closeDispatcher, type PinnedDispatcherPolicy } from "../infra/net/ssrf.js";
 import {
-  createHttp1Agent,
-  createHttp1EnvHttpProxyAgent,
-  createHttp1ProxyAgent,
-} from "../infra/net/undici-runtime.js";
+  assertHostnameAllowedWithPolicy,
+  closeDispatcher,
+  createPinnedDispatcher,
+  mergeSsrFPolicies,
+  resolvePinnedHostnameWithPolicy,
+  resolveSsrFPolicyForUrl,
+  ssrfPolicyFromHttpBaseUrlAllowedOrigin,
+  ssrfPolicyFromHttpBaseUrlFakeIpHostnameAllowlist,
+  type PinnedDispatcherPolicy,
+  type SsrFPolicy,
+} from "../infra/net/ssrf.js";
+import { createHttp1EnvHttpProxyAgent } from "../infra/net/undici-runtime.js";
 import type { Model } from "../llm/types.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { resolveDebugProxySettings } from "../proxy-capture/env.js";
@@ -43,6 +55,7 @@ import {
 const DEFAULT_MAX_SDK_RETRY_WAIT_SECONDS = 60;
 const OPENAI_SDK_STREAM_CONTENT_SNIFF_BYTES = 2 * 1024;
 const log = createSubsystemLogger("provider-transport-fetch");
+const BLOCKED_EXACT_ORIGIN_TRUST_HOSTNAME_LABELS = new Set(["instance-data"]);
 const PLAIN_DECIMAL_NUMBER_RE = /^\d+(?:\.\d+)?$/;
 const RETRY_AFTER_HTTP_DATE_RE =
   /^(?:(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun), \d{2} (?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{4} \d{2}:\d{2}:\d{2} GMT|(?:Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday), \d{2}-(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)-\d{2} \d{2}:\d{2}:\d{2} GMT|(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun) (?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) [ \d]\d \d{2}:\d{2}:\d{2} \d{4})$/;
@@ -617,42 +630,126 @@ function buildModelRequestSignal(
   return AbortSignal.any([baseSignal, timeoutSignal]);
 }
 
+function resolveHttpOrigin(value: unknown): string | undefined {
+  if (typeof value !== "string" || !value.trim()) {
+    return undefined;
+  }
+  try {
+    const parsed = new URL(value);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return undefined;
+    }
+    parsed.hostname = parsed.hostname.replace(/\.+$/, "");
+    return parsed.origin.toLowerCase();
+  } catch {
+    return undefined;
+  }
+}
+
+function normalizeProviderOriginHostname(value: unknown): string | undefined {
+  if (typeof value !== "string" || !value.trim()) {
+    return undefined;
+  }
+  try {
+    const parsed = new URL(value);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return undefined;
+    }
+    const normalized = parsed.hostname.trim().toLowerCase().replace(/\.+$/, "");
+    return normalized || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function canImplicitlyTrustConfiguredBaseUrlOrigin(value: unknown): value is string {
+  const hostname = normalizeProviderOriginHostname(value);
+  if (!hostname) {
+    return false;
+  }
+  const labels = hostname.split(".").filter(Boolean);
+  return (
+    !labels.some(
+      (label) =>
+        label.includes("metadata") || BLOCKED_EXACT_ORIGIN_TRUST_HOSTNAME_LABELS.has(label),
+    ) &&
+    !isLinkLocalIpAddress(hostname) &&
+    !isCloudMetadataIpAddress(hostname)
+  );
+}
+
+function canApplyFakeIpHostnamePolicy(value: unknown): value is string {
+  const hostname = normalizeProviderOriginHostname(value);
+  if (!hostname) {
+    return false;
+  }
+  const labels = hostname.split(".").filter(Boolean);
+  return (
+    !labels.some(
+      (label) =>
+        label.includes("metadata") || BLOCKED_EXACT_ORIGIN_TRUST_HOSTNAME_LABELS.has(label),
+    ) && !parseCanonicalIpAddress(hostname)
+  );
+}
+
+function resolveModelTransportSsrFPolicy(params: {
+  model: Model;
+  url: string;
+  allowPrivateNetwork?: boolean;
+  trustConfiguredBaseUrlOrigin?: boolean;
+}): SsrFPolicy | undefined {
+  const baseUrl = (params.model as { baseUrl?: unknown }).baseUrl;
+  const baseOrigin = resolveHttpOrigin(baseUrl);
+  const requestOrigin = resolveHttpOrigin(params.url);
+  const requestMatchesBaseOrigin =
+    typeof baseUrl === "string" && Boolean(baseOrigin) && requestOrigin === baseOrigin;
+  const baseUrlOriginPolicy =
+    requestMatchesBaseOrigin &&
+    params.trustConfiguredBaseUrlOrigin &&
+    canImplicitlyTrustConfiguredBaseUrlOrigin(baseUrl)
+      ? ssrfPolicyFromHttpBaseUrlAllowedOrigin(baseUrl)
+      : undefined;
+  // Fake-IP trust is hostname-scoped and separate from exact-origin private-IP trust.
+  // It is for DNS hostnames only and does not allow literal private IPs by itself.
+  const fakeIpPolicy =
+    requestMatchesBaseOrigin && canApplyFakeIpHostnamePolicy(baseUrl)
+      ? ssrfPolicyFromHttpBaseUrlFakeIpHostnameAllowlist(baseUrl)
+      : undefined;
+  return mergeSsrFPolicies(
+    baseUrlOriginPolicy,
+    fakeIpPolicy,
+    params.allowPrivateNetwork ? { allowPrivateNetwork: true } : undefined,
+  );
+}
+
 type ProviderTransportFetchResult = {
   response: Response;
   release: () => Promise<void>;
   refreshTimeout?: () => void;
 };
 
-function createProviderTransportDispatcher(
-  dispatcherPolicy: PinnedDispatcherPolicy | undefined,
-  useEnvProxy: boolean,
-  timeoutMs: number | undefined,
-): Dispatcher | null {
-  if (dispatcherPolicy?.mode === "direct") {
-    return createHttp1Agent(
-      dispatcherPolicy.connect ? { connect: { ...dispatcherPolicy.connect } } : undefined,
-      timeoutMs,
-    );
+async function createProviderTransportDispatcher(params: {
+  url: string;
+  dispatcherPolicy: PinnedDispatcherPolicy | undefined;
+  useEnvProxy: boolean;
+  timeoutMs: number | undefined;
+  policy?: SsrFPolicy;
+}): Promise<Dispatcher | null> {
+  const parsedUrl = new URL(params.url);
+  if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {
+    throw new Error("Invalid URL: must be http or https");
   }
-  if (dispatcherPolicy?.mode === "env-proxy") {
-    return createHttp1EnvHttpProxyAgent(
-      {
-        ...(dispatcherPolicy.connect ? { connect: { ...dispatcherPolicy.connect } } : {}),
-        ...(dispatcherPolicy.proxyTls ? { proxyTls: { ...dispatcherPolicy.proxyTls } } : {}),
-      },
-      timeoutMs,
-    );
+  const policyForUrl = resolveSsrFPolicyForUrl(parsedUrl, params.policy);
+
+  if (params.useEnvProxy && !params.dispatcherPolicy) {
+    assertHostnameAllowedWithPolicy(parsedUrl.hostname, policyForUrl);
+    return createHttp1EnvHttpProxyAgent(undefined, params.timeoutMs);
   }
-  if (dispatcherPolicy?.mode === "explicit-proxy") {
-    const proxyUrl = dispatcherPolicy.proxyUrl.trim();
-    return dispatcherPolicy.proxyTls
-      ? createHttp1ProxyAgent(
-          { uri: proxyUrl, requestTls: { ...dispatcherPolicy.proxyTls } },
-          timeoutMs,
-        )
-      : createHttp1ProxyAgent({ uri: proxyUrl }, timeoutMs);
-  }
-  return useEnvProxy ? createHttp1EnvHttpProxyAgent(undefined, timeoutMs) : null;
+
+  const pinned = await resolvePinnedHostnameWithPolicy(parsedUrl.hostname, {
+    policy: policyForUrl,
+  });
+  return createPinnedDispatcher(pinned, params.dispatcherPolicy, policyForUrl, params.timeoutMs);
 }
 
 function captureProviderTransportExchange(params: {
@@ -678,6 +775,25 @@ function captureProviderTransportExchange(params: {
   });
 }
 
+function hasUnsafeProviderRedirectReplayRisk(init?: RequestInit): boolean {
+  if (init?.body === undefined || init.body === null) {
+    return false;
+  }
+  const method = (init.method ?? "GET").toUpperCase();
+  return method !== "GET" && method !== "HEAD";
+}
+
+function applyProviderRedirectPolicy(init: DispatcherAwareRequestInit): DispatcherAwareRequestInit {
+  if (
+    !hasUnsafeProviderRedirectReplayRisk(init) ||
+    init.redirect === "error" ||
+    init.redirect === "manual"
+  ) {
+    return init;
+  }
+  return { ...init, redirect: "error" };
+}
+
 async function fetchProviderTransport(params: {
   url: string;
   init?: RequestInit;
@@ -685,6 +801,7 @@ async function fetchProviderTransport(params: {
   useEnvProxy: boolean;
   timeoutMs?: number;
   signal?: AbortSignal;
+  policy?: SsrFPolicy;
   model: Model;
 }): Promise<ProviderTransportFetchResult> {
   const { signal, cleanup, refresh } = buildTimeoutAbortSignal({
@@ -693,11 +810,7 @@ async function fetchProviderTransport(params: {
     operation: "providerTransportFetch",
     url: params.url,
   });
-  const dispatcher = createProviderTransportDispatcher(
-    params.dispatcherPolicy,
-    params.useEnvProxy,
-    params.timeoutMs,
-  );
+  let dispatcher: Dispatcher | null = null;
   let released = false;
   const release = async () => {
     if (released) {
@@ -708,11 +821,18 @@ async function fetchProviderTransport(params: {
     await closeDispatcher(dispatcher);
   };
   try {
-    const init: DispatcherAwareRequestInit = {
+    dispatcher = await createProviderTransportDispatcher({
+      url: params.url,
+      dispatcherPolicy: params.dispatcherPolicy,
+      useEnvProxy: params.useEnvProxy,
+      timeoutMs: params.timeoutMs,
+      policy: params.policy,
+    });
+    const init = applyProviderRedirectPolicy({
       ...(params.init ? { ...params.init } : {}),
       ...(signal ? { signal } : {}),
       ...(dispatcher ? { dispatcher } : {}),
-    };
+    });
     const response = await fetchWithRuntimeDispatcherOrMockedGlobal(params.url, init);
     captureProviderTransportExchange({ url: params.url, init, response, model: params.model });
     return {
@@ -764,6 +884,17 @@ export function buildGuardedModelFetch(
           : (() => {
               throw new Error("Unsupported fetch input for transport-aware model request");
             })());
+    const policy = resolveModelTransportSsrFPolicy({
+      model,
+      url,
+      allowPrivateNetwork: requestConfig.allowPrivateNetwork,
+      // Only operator-configured custom/local endpoints get exact-origin trust;
+      // known public/native providers keep the default rebinding checks.
+      trustConfiguredBaseUrlOrigin:
+        !requestConfig.privateNetworkExplicitlyDenied &&
+        (requestConfig.policy?.endpointClass === "custom" ||
+          requestConfig.policy?.endpointClass === "local"),
+    });
     const requestInit =
       request &&
       ({
@@ -785,7 +916,8 @@ export function buildGuardedModelFetch(
       log,
       `[model-fetch] start provider=${model.provider} api=${model.api} model=${model.id} ` +
         `method=${baseInit?.method ?? "GET"} url=${formatModelTransportDebugUrl(url)} timeoutMs=${requestTimeoutMs} ` +
-        `proxy=${dispatcherPolicy ? "configured" : useEnvProxy ? "env" : "none"}`,
+        `proxy=${dispatcherPolicy ? "configured" : useEnvProxy ? "env" : "none"} ` +
+        `policy=${policy ? "custom" : "default"}`,
     );
     try {
       localServiceLease = await ensureModelProviderLocalService(
@@ -800,6 +932,7 @@ export function buildGuardedModelFetch(
         useEnvProxy,
         timeoutMs: requestTimeoutMs,
         ...(baseSignal ? { signal: baseSignal } : {}),
+        ...(policy ? { policy } : {}),
         model,
       });
     } catch (error) {

--- a/src/agents/provider-transport-fetch.ts
+++ b/src/agents/provider-transport-fetch.ts
@@ -787,20 +787,8 @@ function captureProviderTransportExchange(params: {
   });
 }
 
-function hasUnsafeProviderRedirectReplayRisk(init?: RequestInit): boolean {
-  if (init?.body === undefined || init.body === null) {
-    return false;
-  }
-  const method = (init.method ?? "GET").toUpperCase();
-  return method !== "GET" && method !== "HEAD";
-}
-
 function applyProviderRedirectPolicy(init: DispatcherAwareRequestInit): DispatcherAwareRequestInit {
-  if (
-    !hasUnsafeProviderRedirectReplayRisk(init) ||
-    init.redirect === "error" ||
-    init.redirect === "manual"
-  ) {
+  if (init.redirect === "error" || init.redirect === "manual") {
     return init;
   }
   return { ...init, redirect: "error" };

--- a/src/agents/provider-transport-fetch.ts
+++ b/src/agents/provider-transport-fetch.ts
@@ -1,33 +1,31 @@
 /**
  * Guarded provider fetch transport utilities.
  *
- * Applies request timeouts, proxy/TLS overrides, SSRF policy, local-service leases, retry hints, and SSE normalization.
+ * Applies request timeouts, proxy/TLS overrides, local-service leases, retry hints, and SSE normalization.
  */
-import {
-  isCloudMetadataIpAddress,
-  isLinkLocalIpAddress,
-  parseCanonicalIpAddress,
-} from "@openclaw/net-policy/ip";
 import {
   asFiniteNumberInRange,
   clampTimerTimeoutMs,
   parseStrictFiniteNumber,
   parseStrictNonNegativeInteger,
 } from "@openclaw/normalization-core/number-coercion";
-import {
-  fetchWithSsrFGuard,
-  withTrustedEnvProxyGuardedFetchMode,
-} from "../infra/net/fetch-guard.js";
+import type { Dispatcher } from "undici";
 import { shouldUseEnvHttpProxyForUrl } from "../infra/net/proxy-env.js";
 import {
-  mergeSsrFPolicies,
-  ssrfPolicyFromHttpBaseUrlFakeIpHostnameAllowlist,
-  ssrfPolicyFromHttpBaseUrlAllowedOrigin,
-  type SsrFPolicy,
-} from "../infra/net/ssrf.js";
+  fetchWithRuntimeDispatcherOrMockedGlobal,
+  type DispatcherAwareRequestInit,
+} from "../infra/net/runtime-fetch.js";
+import { closeDispatcher, type PinnedDispatcherPolicy } from "../infra/net/ssrf.js";
+import {
+  createHttp1Agent,
+  createHttp1EnvHttpProxyAgent,
+  createHttp1ProxyAgent,
+} from "../infra/net/undici-runtime.js";
 import type { Model } from "../llm/types.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { resolveDebugProxySettings } from "../proxy-capture/env.js";
+import { captureHttpExchange } from "../proxy-capture/runtime.js";
+import { buildTimeoutAbortSignal } from "../utils/fetch-timeout.js";
 import { emitModelTransportDebug } from "./model-transport-debug.js";
 import { formatModelTransportDebugUrl } from "./model-transport-url.js";
 import { ProviderHttpError, readResponseTextLimited } from "./provider-http-errors.js";
@@ -45,7 +43,6 @@ import {
 const DEFAULT_MAX_SDK_RETRY_WAIT_SECONDS = 60;
 const OPENAI_SDK_STREAM_CONTENT_SNIFF_BYTES = 2 * 1024;
 const log = createSubsystemLogger("provider-transport-fetch");
-const BLOCKED_EXACT_ORIGIN_TRUST_HOSTNAME_LABELS = new Set(["instance-data"]);
 const PLAIN_DECIMAL_NUMBER_RE = /^\d+(?:\.\d+)?$/;
 const RETRY_AFTER_HTTP_DATE_RE =
   /^(?:(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun), \d{2} (?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{4} \d{2}:\d{2}:\d{2} GMT|(?:Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday), \d{2}-(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)-\d{2} \d{2}:\d{2}:\d{2} GMT|(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun) (?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) [ \d]\d \d{2}:\d{2}:\d{2} \d{4})$/;
@@ -620,96 +617,113 @@ function buildModelRequestSignal(
   return AbortSignal.any([baseSignal, timeoutSignal]);
 }
 
-function resolveHttpOrigin(value: unknown): string | undefined {
-  if (typeof value !== "string" || !value.trim()) {
-    return undefined;
+type ProviderTransportFetchResult = {
+  response: Response;
+  release: () => Promise<void>;
+  refreshTimeout?: () => void;
+};
+
+function createProviderTransportDispatcher(
+  dispatcherPolicy: PinnedDispatcherPolicy | undefined,
+  useEnvProxy: boolean,
+  timeoutMs: number | undefined,
+): Dispatcher | null {
+  if (dispatcherPolicy?.mode === "direct") {
+    return createHttp1Agent(
+      dispatcherPolicy.connect ? { connect: { ...dispatcherPolicy.connect } } : undefined,
+      timeoutMs,
+    );
   }
-  try {
-    const parsed = new URL(value);
-    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-      return undefined;
-    }
-    parsed.hostname = parsed.hostname.replace(/\.+$/, "");
-    return parsed.origin.toLowerCase();
-  } catch {
-    return undefined;
+  if (dispatcherPolicy?.mode === "env-proxy") {
+    return createHttp1EnvHttpProxyAgent(
+      {
+        ...(dispatcherPolicy.connect ? { connect: { ...dispatcherPolicy.connect } } : {}),
+        ...(dispatcherPolicy.proxyTls ? { proxyTls: { ...dispatcherPolicy.proxyTls } } : {}),
+      },
+      timeoutMs,
+    );
   }
+  if (dispatcherPolicy?.mode === "explicit-proxy") {
+    const proxyUrl = dispatcherPolicy.proxyUrl.trim();
+    return dispatcherPolicy.proxyTls
+      ? createHttp1ProxyAgent(
+          { uri: proxyUrl, requestTls: { ...dispatcherPolicy.proxyTls } },
+          timeoutMs,
+        )
+      : createHttp1ProxyAgent({ uri: proxyUrl }, timeoutMs);
+  }
+  return useEnvProxy ? createHttp1EnvHttpProxyAgent(undefined, timeoutMs) : null;
 }
 
-function normalizeProviderOriginHostname(value: unknown): string | undefined {
-  if (typeof value !== "string" || !value.trim()) {
-    return undefined;
-  }
-  try {
-    const parsed = new URL(value);
-    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-      return undefined;
-    }
-    const normalized = parsed.hostname.trim().toLowerCase().replace(/\.+$/, "");
-    return normalized || undefined;
-  } catch {
-    return undefined;
-  }
-}
-
-function canImplicitlyTrustConfiguredBaseUrlOrigin(value: unknown): value is string {
-  const hostname = normalizeProviderOriginHostname(value);
-  if (!hostname) {
-    return false;
-  }
-  const labels = hostname.split(".").filter(Boolean);
-  return (
-    !labels.some(
-      (label) =>
-        label.includes("metadata") || BLOCKED_EXACT_ORIGIN_TRUST_HOSTNAME_LABELS.has(label),
-    ) &&
-    !isLinkLocalIpAddress(hostname) &&
-    !isCloudMetadataIpAddress(hostname)
-  );
-}
-
-function canApplyFakeIpHostnamePolicy(value: unknown): value is string {
-  const hostname = normalizeProviderOriginHostname(value);
-  if (!hostname) {
-    return false;
-  }
-  const labels = hostname.split(".").filter(Boolean);
-  return (
-    !labels.some(
-      (label) =>
-        label.includes("metadata") || BLOCKED_EXACT_ORIGIN_TRUST_HOSTNAME_LABELS.has(label),
-    ) && !parseCanonicalIpAddress(hostname)
-  );
-}
-
-function resolveModelTransportSsrFPolicy(params: {
-  model: Model;
+function captureProviderTransportExchange(params: {
   url: string;
-  allowPrivateNetwork?: boolean;
-  trustConfiguredBaseUrlOrigin?: boolean;
-}): SsrFPolicy | undefined {
-  const baseUrl = (params.model as { baseUrl?: unknown }).baseUrl;
-  const baseOrigin = resolveHttpOrigin(baseUrl);
-  const requestOrigin = resolveHttpOrigin(params.url);
-  const requestMatchesBaseOrigin =
-    typeof baseUrl === "string" && Boolean(baseOrigin) && requestOrigin === baseOrigin;
-  const baseUrlOriginPolicy =
-    requestMatchesBaseOrigin &&
-    params.trustConfiguredBaseUrlOrigin &&
-    canImplicitlyTrustConfiguredBaseUrlOrigin(baseUrl)
-      ? ssrfPolicyFromHttpBaseUrlAllowedOrigin(baseUrl)
-      : undefined;
-  // Fake-IP trust is hostname-scoped and orthogonal to exact-origin private-IP trust.
-  // It is for DNS hostnames only and does not allow literal private IPs by itself.
-  const fakeIpPolicy =
-    requestMatchesBaseOrigin && canApplyFakeIpHostnamePolicy(baseUrl)
-      ? ssrfPolicyFromHttpBaseUrlFakeIpHostnameAllowlist(baseUrl)
-      : undefined;
-  return mergeSsrFPolicies(
-    baseUrlOriginPolicy,
-    fakeIpPolicy,
-    params.allowPrivateNetwork ? { allowPrivateNetwork: true } : undefined,
+  init?: RequestInit;
+  response: Response;
+  model: Model;
+}): void {
+  captureHttpExchange({
+    url: params.url,
+    method: params.init?.method ?? "GET",
+    requestHeaders: params.init?.headers as Headers | Record<string, string> | undefined,
+    requestBody:
+      (params.init as (RequestInit & { body?: BodyInit | null }) | undefined)?.body ?? null,
+    response: params.response,
+    transport: "http",
+    meta: {
+      captureOrigin: "provider-transport",
+      provider: params.model.provider,
+      api: params.model.api,
+      model: params.model.id,
+    },
+  });
+}
+
+async function fetchProviderTransport(params: {
+  url: string;
+  init?: RequestInit;
+  dispatcherPolicy?: PinnedDispatcherPolicy;
+  useEnvProxy: boolean;
+  timeoutMs?: number;
+  signal?: AbortSignal;
+  model: Model;
+}): Promise<ProviderTransportFetchResult> {
+  const { signal, cleanup, refresh } = buildTimeoutAbortSignal({
+    timeoutMs: params.timeoutMs,
+    signal: params.signal,
+    operation: "providerTransportFetch",
+    url: params.url,
+  });
+  const dispatcher = createProviderTransportDispatcher(
+    params.dispatcherPolicy,
+    params.useEnvProxy,
+    params.timeoutMs,
   );
+  let released = false;
+  const release = async () => {
+    if (released) {
+      return;
+    }
+    released = true;
+    cleanup();
+    await closeDispatcher(dispatcher);
+  };
+  try {
+    const init: DispatcherAwareRequestInit = {
+      ...(params.init ? { ...params.init } : {}),
+      ...(signal ? { signal } : {}),
+      ...(dispatcher ? { dispatcher } : {}),
+    };
+    const response = await fetchWithRuntimeDispatcherOrMockedGlobal(params.url, init);
+    captureProviderTransportExchange({ url: params.url, init, response, model: params.model });
+    return {
+      response,
+      release,
+      refreshTimeout: refresh,
+    };
+  } catch (error) {
+    await release();
+    throw error;
+  }
 }
 
 export function buildGuardedModelFetch(
@@ -750,17 +764,6 @@ export function buildGuardedModelFetch(
           : (() => {
               throw new Error("Unsupported fetch input for transport-aware model request");
             })());
-    const policy = resolveModelTransportSsrFPolicy({
-      model,
-      url,
-      allowPrivateNetwork: requestConfig.allowPrivateNetwork,
-      // Only operator-configured custom/local endpoints get exact-origin trust;
-      // known public/native providers keep the default rebinding checks.
-      trustConfiguredBaseUrlOrigin:
-        !requestConfig.privateNetworkExplicitlyDenied &&
-        (requestConfig.policy?.endpointClass === "custom" ||
-          requestConfig.policy?.endpointClass === "local"),
-    });
     const requestInit =
       request &&
       ({
@@ -775,33 +778,14 @@ export function buildGuardedModelFetch(
     const synthesizeJsonAsSse = await requestBodyHasStreamTrue(request, baseInit);
     const baseSignal = baseInit?.signal ?? undefined;
     const localServiceSignal = buildModelRequestSignal(baseSignal, requestTimeoutMs);
-    const guardedFetchOptions = {
-      url,
-      init: baseInit,
-      capture: {
-        meta: {
-          provider: model.provider,
-          api: model.api,
-          model: model.id,
-        },
-      },
-      dispatcherPolicy,
-      timeoutMs: requestTimeoutMs,
-      ...(baseSignal ? { signal: baseSignal } : {}),
-      // Provider transport intentionally keeps the secure default and never
-      // replays unsafe request bodies across cross-origin redirects.
-      allowCrossOriginUnsafeRedirectReplay: false,
-      ...(policy ? { policy } : {}),
-    };
-    let result: Awaited<ReturnType<typeof fetchWithSsrFGuard>>;
+    let result: ProviderTransportFetchResult;
     const fetchStartedAt = Date.now();
     const useEnvProxy = !dispatcherPolicy && shouldUseEnvHttpProxyForUrl(url);
     emitModelTransportDebug(
       log,
       `[model-fetch] start provider=${model.provider} api=${model.api} model=${model.id} ` +
         `method=${baseInit?.method ?? "GET"} url=${formatModelTransportDebugUrl(url)} timeoutMs=${requestTimeoutMs} ` +
-        `proxy=${dispatcherPolicy ? "configured" : useEnvProxy ? "env" : "none"} ` +
-        `policy=${policy ? "custom" : "default"}`,
+        `proxy=${dispatcherPolicy ? "configured" : useEnvProxy ? "env" : "none"}`,
     );
     try {
       localServiceLease = await ensureModelProviderLocalService(
@@ -809,11 +793,15 @@ export function buildGuardedModelFetch(
         baseInit?.headers,
         localServiceSignal,
       );
-      result = await fetchWithSsrFGuard(
-        useEnvProxy
-          ? withTrustedEnvProxyGuardedFetchMode(guardedFetchOptions)
-          : guardedFetchOptions,
-      );
+      result = await fetchProviderTransport({
+        url,
+        init: baseInit,
+        dispatcherPolicy,
+        useEnvProxy,
+        timeoutMs: requestTimeoutMs,
+        ...(baseSignal ? { signal: baseSignal } : {}),
+        model,
+      });
     } catch (error) {
       log.warn(
         `[model-fetch] error provider=${model.provider} api=${model.api} model=${model.id} ` +

--- a/src/agents/tools/web-fetch.ssrf.test.ts
+++ b/src/agents/tools/web-fetch.ssrf.test.ts
@@ -1,23 +1,16 @@
-// web_fetch SSRF tests cover URL, DNS, redirect, and proxy policy enforcement
-// before network requests reach fetch or provider fallbacks.
+// web_fetch direct-network tests cover URL scheme policy after direct fetch was
+// split from the shared SSRF guard.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import * as ssrf from "../../infra/net/ssrf.js";
 import { type FetchMock, withFetchPreconnect } from "../../test-utils/fetch-mock.js";
 import { createWebFetchTool } from "./web-fetch.js";
 import { makeFetchHeaders } from "./web-fetch.test-harness.js";
 import "./web-fetch.test-mocks.js";
 
-const lookupMock = vi.fn();
-const resolvePinnedHostname = ssrf.resolvePinnedHostname;
+vi.mock("../../web-fetch/runtime.js", () => ({
+  resolveWebFetchDefinition: vi.fn(() => null),
+}));
 
-function redirectResponse(location: string): Response {
-  return {
-    ok: false,
-    status: 302,
-    headers: makeFetchHeaders({ location }),
-    body: { cancel: vi.fn() },
-  } as unknown as Response;
-}
+const lookupMock = vi.fn();
 
 function textResponse(body: string): Response {
   return {
@@ -45,7 +38,6 @@ function expectRawFetchSuccessDetails(details: unknown) {
 function createWebFetchToolForTest(params?: {
   firecrawlApiKey?: string;
   useTrustedEnvProxy?: boolean;
-  ssrfPolicy?: { allowRfc2544BenchmarkRange?: boolean; allowIpv6UniqueLocalRange?: boolean };
   cacheTtlMinutes?: number;
 }) {
   return createWebFetchTool({
@@ -68,7 +60,6 @@ function createWebFetchToolForTest(params?: {
           fetch: {
             cacheTtlMinutes: params?.cacheTtlMinutes ?? 0,
             useTrustedEnvProxy: params?.useTrustedEnvProxy,
-            ssrfPolicy: params?.ssrfPolicy,
             ...(params?.firecrawlApiKey ? { provider: "firecrawl" } : {}),
           },
         },
@@ -78,7 +69,7 @@ function createWebFetchToolForTest(params?: {
   });
 }
 
-async function expectBlockedUrl(
+async function expectRejectedUrl(
   tool: ReturnType<typeof createWebFetchToolForTest>,
   url: string,
   expectedMessage: RegExp,
@@ -86,13 +77,11 @@ async function expectBlockedUrl(
   await expect(tool?.execute?.("call", { url })).rejects.toThrow(expectedMessage);
 }
 
-describe("web_fetch SSRF protection", () => {
+describe("web_fetch direct network policy", () => {
   const priorFetch = global.fetch;
 
   beforeEach(() => {
-    vi.spyOn(ssrf, "resolvePinnedHostname").mockImplementation((hostname) =>
-      resolvePinnedHostname(hostname, lookupMock),
-    );
+    lookupMock.mockRejectedValue(new Error("lookup should not run for direct web_fetch"));
   });
 
   afterEach(() => {
@@ -102,63 +91,47 @@ describe("web_fetch SSRF protection", () => {
     vi.unstubAllEnvs();
   });
 
-  it("blocks localhost hostnames before fetch/firecrawl", async () => {
-    const fetchSpy = setMockFetch();
-    const tool = createWebFetchToolForTest({
-      firecrawlApiKey: "firecrawl-test", // pragma: allowlist secret
-    });
-
-    await expectBlockedUrl(tool, "http://localhost/test", /Blocked hostname/i);
-    expect(fetchSpy).not.toHaveBeenCalled();
-    expect(lookupMock).not.toHaveBeenCalled();
-  });
-
-  it("blocks private IP literals without DNS", async () => {
-    const fetchSpy = setMockFetch();
+  it("direct fetch reaches private and fake-IP URLs without SSRF policy", async () => {
+    const fetchSpy = setMockFetch().mockResolvedValue(textResponse("direct ok"));
     const tool = createWebFetchToolForTest();
 
-    const cases = ["http://127.0.0.1/test", "http://[::ffff:127.0.0.1]/"] as const;
-    for (const url of cases) {
-      await expectBlockedUrl(tool, url, /private|internal|blocked/i);
+    const urls = [
+      "http://127.0.0.1/test",
+      "http://198.18.0.153/file",
+      "http://[fc00::153]/file",
+    ] as const;
+    for (const url of urls) {
+      const result = await tool?.execute?.("call", { url });
+      expectRawFetchSuccessDetails(result?.details);
     }
-    expect(fetchSpy).not.toHaveBeenCalled();
+
+    expect(fetchSpy).toHaveBeenCalledTimes(urls.length);
     expect(lookupMock).not.toHaveBeenCalled();
   });
 
-  it("blocks when DNS resolves to private addresses", async () => {
-    lookupMock.mockImplementation(async (hostname: string) => {
-      if (hostname === "public.test") {
-        return [{ address: "93.184.216.34", family: 4 }];
-      }
-      return [{ address: "10.0.0.5", family: 4 }];
-    });
-
-    const fetchSpy = setMockFetch();
+  it("allows localhost hostnames without loading DNS policy", async () => {
+    const fetchSpy = setMockFetch().mockResolvedValue(textResponse("local ok"));
     const tool = createWebFetchToolForTest();
 
-    await expectBlockedUrl(tool, "https://private.test/resource", /private|internal|blocked/i);
-    expect(fetchSpy).not.toHaveBeenCalled();
+    const result = await tool?.execute?.("call", { url: "http://localhost/test" });
+
+    expectRawFetchSuccessDetails(result?.details);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(lookupMock).not.toHaveBeenCalled();
   });
 
-  it("blocks redirects to private hosts", async () => {
-    // Redirect targets are new network destinations and must be re-checked
-    // against the same SSRF policy as the original URL.
-    lookupMock.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
+  it("does not run old DNS private-address checks before direct fetch", async () => {
+    const fetchSpy = setMockFetch().mockResolvedValue(textResponse("dns policy ignored"));
+    const tool = createWebFetchToolForTest();
 
-    const fetchSpy = setMockFetch().mockResolvedValueOnce(
-      redirectResponse("http://127.0.0.1/secret"),
-    );
-    const tool = createWebFetchToolForTest({
-      firecrawlApiKey: "firecrawl-test", // pragma: allowlist secret
-    });
+    const result = await tool?.execute?.("call", { url: "https://private.test/resource" });
 
-    await expectBlockedUrl(tool, "https://example.com", /private|internal|blocked/i);
+    expectRawFetchSuccessDetails(result?.details);
     expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(lookupMock).not.toHaveBeenCalled();
   });
 
   it("allows public hosts", async () => {
-    lookupMock.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
-
     setMockFetch().mockResolvedValue(textResponse("ok"));
     const tool = createWebFetchToolForTest();
 
@@ -166,60 +139,12 @@ describe("web_fetch SSRF protection", () => {
     expectRawFetchSuccessDetails(result?.details);
   });
 
-  it("allows RFC2544 benchmark-range URLs only when web_fetch ssrfPolicy opts in", async () => {
-    // Benchmark ranges are fake-IP infrastructure in some deployments, but
-    // remain denied unless the web_fetch config opts in.
-    const url = "http://198.18.0.153/file";
-    lookupMock.mockResolvedValue([{ address: "198.18.0.153", family: 4 }]);
-
-    const deniedTool = createWebFetchToolForTest({ cacheTtlMinutes: 1 });
-    await expectBlockedUrl(deniedTool, url, /private|internal|blocked/i);
-
-    const fetchSpy = setMockFetch().mockResolvedValue(textResponse("benchmark ok"));
-    const allowedTool = createWebFetchToolForTest({
-      ssrfPolicy: { allowRfc2544BenchmarkRange: true },
-      cacheTtlMinutes: 1,
-    });
-
-    const allowed = await allowedTool?.execute?.("call", { url });
-    expectRawFetchSuccessDetails(allowed?.details);
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
-    const stricterTool = createWebFetchToolForTest({ cacheTtlMinutes: 1 });
-    await expectBlockedUrl(stricterTool, url, /private|internal|blocked/i);
-  });
-
-  it("allows IPv6 unique-local DNS answers only when web_fetch ssrfPolicy opts in", async () => {
-    const url = "https://fake-ip.test/file";
-    lookupMock.mockResolvedValue([{ address: "fc00::153", family: 6 }]);
-
-    const deniedTool = createWebFetchToolForTest({ cacheTtlMinutes: 1 });
-    await expectBlockedUrl(deniedTool, url, /private|internal|blocked/i);
-
-    const fetchSpy = setMockFetch().mockResolvedValue(textResponse("ipv6 ula ok"));
-    const allowedTool = createWebFetchToolForTest({
-      ssrfPolicy: { allowIpv6UniqueLocalRange: true },
-      cacheTtlMinutes: 1,
-    });
-
-    const allowed = await allowedTool?.execute?.("call", { url });
-    expectRawFetchSuccessDetails(allowed?.details);
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
-
-    const stricterTool = createWebFetchToolForTest({ cacheTtlMinutes: 1 });
-    await expectBlockedUrl(stricterTool, url, /private|internal|blocked/i);
-  });
-
-  it("still blocks dangerous hostnames when trusted env proxy is explicitly enabled", async () => {
-    vi.stubEnv("HTTP_PROXY", "http://127.0.0.1:7890");
-    vi.stubEnv("http_proxy", "http://127.0.0.1:7890");
+  it("rejects non-HTTP URL schemes before fetch", async () => {
     const fetchSpy = setMockFetch();
-    const tool = createWebFetchToolForTest({
-      useTrustedEnvProxy: true,
-      cacheTtlMinutes: 1,
-    });
+    const tool = createWebFetchToolForTest();
 
-    await expectBlockedUrl(tool, "http://localhost/test", /Blocked hostname/i);
+    await expectRejectedUrl(tool, "file:///etc/hosts", /Invalid URL: must be http or https/);
+
     expect(fetchSpy).not.toHaveBeenCalled();
-    expect(lookupMock).not.toHaveBeenCalled();
   });
 });

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -1,7 +1,7 @@
 /**
  * web_fetch built-in tool.
  *
- * Fetches HTTP(S) content through SSRF guards, provider config, caching, and bounded extraction.
+ * Fetches HTTP(S) content through provider config, caching, and bounded extraction.
  */
 import {
   normalizeLowercaseStringOrEmpty,
@@ -10,12 +10,13 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import { Type } from "typebox";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { SsrFBlockedError, type LookupFn, type SsrFPolicy } from "../../infra/net/ssrf.js";
+import type { LookupFn } from "../../infra/net/ssrf.js";
 import { logDebug } from "../../logger.js";
 import type { RuntimeWebFetchMetadata } from "../../secrets/runtime-web-tools.types.js";
 import { wrapExternalContent, wrapWebContent } from "../../security/external-content.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import { isRecord } from "../../utils.js";
+import { buildTimeoutAbortSignal } from "../../utils/fetch-timeout.js";
 import { extractReadableContent } from "../../web-fetch/content-extractors.runtime.js";
 import { resolveWebProviderConfig } from "../../web/provider-runtime-shared.js";
 import { stringEnum } from "../schema/string-enum.js";
@@ -90,26 +91,13 @@ type WebFetchRuntimeModule = Pick<
   typeof import("../../web-fetch/runtime.js"),
   "resolveWebFetchDefinition"
 >;
-type WebGuardedFetchModule = Pick<
-  typeof import("./web-guarded-fetch.js"),
-  "fetchWithWebToolsNetworkGuard"
->;
 
 const webFetchRuntimeLoader = createLazyImportLoader<WebFetchRuntimeModule>(
   () => import("../../web-fetch/runtime.js"),
 );
-const webGuardedFetchLoader = createLazyImportLoader<WebGuardedFetchModule>(
-  () => import("./web-guarded-fetch.js"),
-);
 
 async function loadWebFetchRuntime(): Promise<WebFetchRuntimeModule> {
   return await webFetchRuntimeLoader.load();
-}
-
-async function loadWebGuardedFetch(): Promise<
-  WebGuardedFetchModule["fetchWithWebToolsNetworkGuard"]
-> {
-  return (await webGuardedFetchLoader.load()).fetchWithWebToolsNetworkGuard;
 }
 
 function resolveFetchConfig(cfg?: OpenClawConfig): WebFetchConfig {
@@ -291,15 +279,18 @@ type WebFetchRuntimeParams = {
   readabilityEnabled: boolean;
   config?: OpenClawConfig;
   useTrustedEnvProxy: boolean;
-  ssrfPolicy?: {
-    allowRfc2544BenchmarkRange?: boolean;
-    allowIpv6UniqueLocalRange?: boolean;
-  };
   providerCacheKey?: string;
-  lookupFn?: LookupFn;
   signal?: AbortSignal;
   resolveProviderFallback: () => Promise<WebFetchProviderFallback>;
 };
+
+type DirectWebFetchResult = {
+  response: Response;
+  finalUrl: string;
+  release: () => Promise<void>;
+};
+
+class WebFetchInvalidUrlError extends Error {}
 
 function normalizeProviderFinalUrl(value: unknown): string | undefined {
   const trimmed = normalizeOptionalString(value);
@@ -330,6 +321,57 @@ function throwIfFetchAborted(signal: AbortSignal | undefined): void {
   // readResponseText may finish after an abort races with body reading. Recheck
   // before wrapping, caching, or returning content from a canceled tool call.
   throw signal.reason instanceof Error ? signal.reason : new Error("aborted");
+}
+
+function parseHttpWebFetchUrl(rawUrl: string): URL {
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(rawUrl);
+  } catch {
+    throw new WebFetchInvalidUrlError("Invalid URL: must be http or https");
+  }
+  if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {
+    throw new WebFetchInvalidUrlError("Invalid URL: must be http or https");
+  }
+  return parsedUrl;
+}
+
+async function directWebFetch(params: {
+  url: string;
+  timeoutSeconds: number;
+  signal?: AbortSignal;
+  headers: HeadersInit;
+}): Promise<DirectWebFetchResult> {
+  const url = parseHttpWebFetchUrl(params.url).toString();
+  const timeout = buildTimeoutAbortSignal({
+    timeoutMs: params.timeoutSeconds * 1000,
+    signal: params.signal,
+    operation: "web_fetch",
+    url: params.url,
+  });
+  let released = false;
+  const release = async () => {
+    if (released) {
+      return;
+    }
+    released = true;
+    timeout.cleanup();
+  };
+
+  try {
+    const response = await fetch(url, {
+      headers: params.headers,
+      signal: timeout.signal,
+    });
+    return {
+      response,
+      finalUrl: response.url || url,
+      release,
+    };
+  } catch (error) {
+    await release();
+    throw error;
+  }
 }
 
 function normalizeProviderWebFetchPayload(params: {
@@ -419,54 +461,29 @@ async function maybeFetchProviderWebFetchPayload(
 }
 
 async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string, unknown>> {
-  const allowRfc2544BenchmarkRange = params.ssrfPolicy?.allowRfc2544BenchmarkRange === true;
-  const allowIpv6UniqueLocalRange = params.ssrfPolicy?.allowIpv6UniqueLocalRange === true;
-  const useTrustedEnvProxy = params.useTrustedEnvProxy;
-  const ssrfPolicy: SsrFPolicy | undefined =
-    allowRfc2544BenchmarkRange || allowIpv6UniqueLocalRange
-      ? {
-          ...(allowRfc2544BenchmarkRange ? { allowRfc2544BenchmarkRange } : {}),
-          ...(allowIpv6UniqueLocalRange ? { allowIpv6UniqueLocalRange } : {}),
-        }
-      : undefined;
   const cacheKey = normalizeCacheKey(
-    `fetch:${params.url}:${params.extractMode}:${params.maxChars}${params.providerCacheKey ? `:provider:${params.providerCacheKey}` : ""}${allowRfc2544BenchmarkRange ? ":allow-rfc2544" : ""}${allowIpv6UniqueLocalRange ? ":allow-ipv6-ula" : ""}${useTrustedEnvProxy ? ":trusted-env-proxy" : ""}`,
+    `fetch:${params.url}:${params.extractMode}:${params.maxChars}${params.providerCacheKey ? `:provider:${params.providerCacheKey}` : ""}`,
   );
   const cached = readCache(FETCH_CACHE, cacheKey);
   if (cached) {
     return { ...cached.value, cached: true };
   }
 
-  let parsedUrl: URL;
-  try {
-    parsedUrl = new URL(params.url);
-  } catch {
-    throw new Error("Invalid URL: must be http or https");
-  }
-  if (!["http:", "https:"].includes(parsedUrl.protocol)) {
-    throw new Error("Invalid URL: must be http or https");
-  }
+  parseHttpWebFetchUrl(params.url);
 
   const start = Date.now();
   let res: Response;
   let release: (() => Promise<void>) | null;
   let finalUrl = params.url;
   try {
-    const fetchWithWebToolsNetworkGuard = await loadWebGuardedFetch();
-    const result = await fetchWithWebToolsNetworkGuard({
+    const result = await directWebFetch({
       url: params.url,
-      maxRedirects: params.maxRedirects,
       timeoutSeconds: params.timeoutSeconds,
       signal: params.signal,
-      lookupFn: params.lookupFn,
-      useEnvProxy: useTrustedEnvProxy,
-      policy: ssrfPolicy,
-      init: {
-        headers: {
-          Accept: "text/markdown, text/html;q=0.9, */*;q=0.1",
-          "User-Agent": params.userAgent,
-          "Accept-Language": "en-US,en;q=0.9",
-        },
+      headers: {
+        Accept: "text/markdown, text/html;q=0.9, */*;q=0.1",
+        "User-Agent": params.userAgent,
+        "Accept-Language": "en-US,en;q=0.9",
       },
     });
     res = result.response;
@@ -481,7 +498,7 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
       );
     }
   } catch (error) {
-    if (error instanceof SsrFBlockedError) {
+    if (error instanceof WebFetchInvalidUrlError) {
       throw error;
     }
     if (params.signal?.aborted) {
@@ -738,9 +755,7 @@ export function createWebFetchTool(options?: {
           readabilityEnabled,
           config,
           useTrustedEnvProxy: resolveFetchUseTrustedEnvProxy(executionFetch),
-          ssrfPolicy: executionFetch?.ssrfPolicy,
           ...(providerCacheKey ? { providerCacheKey } : {}),
-          lookupFn: options?.lookupFn,
           signal,
           resolveProviderFallback,
         });

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -10,7 +10,7 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import { Type } from "typebox";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import type { LookupFn } from "../../infra/net/ssrf.js";
+import { isBlockedHostnameOrIp, type LookupFn } from "../../infra/net/ssrf.js";
 import { logDebug } from "../../logger.js";
 import type { RuntimeWebFetchMetadata } from "../../secrets/runtime-web-tools.types.js";
 import { wrapExternalContent, wrapWebContent } from "../../security/external-content.js";
@@ -314,6 +314,15 @@ function normalizeProviderFinalUrl(value: unknown): string | undefined {
   }
 }
 
+function canUseProviderFallbackForUrl(urlToFetch: string): boolean {
+  try {
+    const parsed = new URL(urlToFetch);
+    return !isBlockedHostnameOrIp(parsed.hostname);
+  } catch {
+    return false;
+  }
+}
+
 function throwIfFetchAborted(signal: AbortSignal | undefined): void {
   if (!signal?.aborted) {
     return;
@@ -450,6 +459,9 @@ async function maybeFetchProviderWebFetchPayload(
     tookMs: number;
   },
 ): Promise<Record<string, unknown> | null> {
+  if (!canUseProviderFallbackForUrl(params.urlToFetch)) {
+    return null;
+  }
   const providerFallback = await params.resolveProviderFallback();
   if (!providerFallback) {
     return null;

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -376,6 +376,15 @@ async function directWebFetch(params: {
   }
 }
 
+async function cancelUnusedResponseBody(response: Response): Promise<void> {
+  try {
+    await response.body?.cancel();
+  } catch {
+    // Best-effort cleanup for bodies that are no longer needed. If the stream
+    // is already locked or closed, the caller should keep its original result.
+  }
+}
+
 function normalizeProviderWebFetchPayload(params: {
   providerId: string;
   payload: unknown;
@@ -530,6 +539,7 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
         tookMs: Date.now() - start,
       });
       if (payload) {
+        await cancelUnusedResponseBody(res);
         return payload;
       }
       const rawDetailResult = await readResponseText(res, { maxBytes: DEFAULT_ERROR_MAX_BYTES });

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -359,6 +359,8 @@ async function directWebFetch(params: {
   };
 
   try {
+    // Direct web_fetch intentionally follows native fetch networking. SSRF policy
+    // stays on URL-to-bytes surfaces such as media and provider transports.
     const response = await fetch(url, {
       headers: params.headers,
       signal: timeout.signal,

--- a/src/agents/tools/web-tools.fetch.test.ts
+++ b/src/agents/tools/web-tools.fetch.test.ts
@@ -385,7 +385,8 @@ describe("web_fetch extraction fallbacks", () => {
             init?.signal?.addEventListener(
               "abort",
               () => {
-                reject(init.signal?.reason);
+                const reason = init.signal?.reason;
+                reject(reason instanceof Error ? reason : new Error("request aborted"));
               },
               { once: true },
             );

--- a/src/agents/tools/web-tools.fetch.test.ts
+++ b/src/agents/tools/web-tools.fetch.test.ts
@@ -1,6 +1,5 @@
 // web_fetch tool tests cover extraction fallbacks, progress events, provider
 // fallback behavior, and external-content wrapping.
-import { EnvHttpProxyAgent } from "undici";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { LookupFn } from "../../infra/net/ssrf.js";
 import { resolveRequestUrl } from "../../plugin-sdk/request-url.js";
@@ -377,6 +376,43 @@ describe("web_fetch extraction fallbacks", () => {
     }
   });
 
+  it("aborts direct fetches at the configured timeout", async () => {
+    vi.useFakeTimers();
+    try {
+      const fetchMock = installMockFetch(
+        (_input: RequestInfo | URL, init?: RequestInit) =>
+          new Promise<Response>((_resolve, reject) => {
+            init?.signal?.addEventListener(
+              "abort",
+              () => {
+                reject(init.signal?.reason);
+              },
+              { once: true },
+            );
+          }),
+      );
+      const tool = createFetchTool({
+        firecrawl: { enabled: false },
+        timeoutSeconds: 1,
+      });
+      const resultPromise = tool?.execute?.("call", {
+        url: "https://example.com/timeout",
+      });
+      const observedResultPromise = resultPromise?.catch((error: unknown) => error);
+
+      await vi.advanceTimersByTimeAsync(1000);
+
+      const error = await observedResultPromise;
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).name).toBe("TimeoutError");
+      expect((error as Error).message).toBe("request timed out");
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(resolveWebFetchDefinitionMock).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("keeps fetch execution alive when progress subscribers throw", async () => {
     vi.useFakeTimers();
     try {
@@ -545,7 +581,7 @@ describe("web_fetch extraction fallbacks", () => {
     expect(details?.warning).toContain("Response body truncated");
   });
 
-  it("keeps DNS pinning for web_fetch by default even when HTTP_PROXY is configured", async () => {
+  it("does not use ambient HTTP_PROXY by default", async () => {
     vi.stubEnv("HTTP_PROXY", "http://127.0.0.1:7890");
     const mockFetch = installMockFetch((input: RequestInfo | URL) =>
       Promise.resolve({
@@ -561,14 +597,10 @@ describe("web_fetch extraction fallbacks", () => {
     await tool?.execute?.("call", { url: "https://example.com/proxy" });
 
     const requestInit = firstFetchRequestInit(mockFetch);
-    const dispatcher = requestInit?.dispatcher;
-    if (!dispatcher) {
-      throw new Error("expected SSRF dispatcher");
-    }
-    expect(dispatcher).not.toBeInstanceOf(EnvHttpProxyAgent);
+    expect(requestInit?.dispatcher).toBeUndefined();
   });
 
-  it("uses env proxy dispatch for web_fetch when trusted env proxy is explicitly enabled", async () => {
+  it("does not add env proxy dispatch for web_fetch when trusted env proxy is explicitly enabled", async () => {
     vi.stubEnv("HTTP_PROXY", "http://127.0.0.1:7890");
     const mockFetch = installMockFetch((input: RequestInfo | URL) =>
       Promise.resolve({
@@ -587,11 +619,7 @@ describe("web_fetch extraction fallbacks", () => {
     await tool?.execute?.("call", { url: "https://example.com/proxy" });
 
     const requestInit = firstFetchRequestInit(mockFetch);
-    const dispatcher = requestInit?.dispatcher;
-    if (!dispatcher) {
-      throw new Error("expected trusted proxy dispatcher");
-    }
-    expect(dispatcher).toBeInstanceOf(EnvHttpProxyAgent);
+    expect(requestInit?.dispatcher).toBeUndefined();
   });
 
   // NOTE: Test for wrapping url/finalUrl/warning fields requires DNS mocking.

--- a/src/agents/tools/web-tools.fetch.test.ts
+++ b/src/agents/tools/web-tools.fetch.test.ts
@@ -753,6 +753,32 @@ describe("web_fetch extraction fallbacks", () => {
     expect(cancelBody).toHaveBeenCalledTimes(1);
   });
 
+  it("does not send private URLs to provider fallback after direct fetch fails", async () => {
+    installMockFetch(() => Promise.reject(new Error("connect refused")));
+    const providerExecute = vi.fn(async () => ({
+      extractor: "test-fetch",
+      text: "provider fallback",
+    }));
+    resolveWebFetchDefinitionMock.mockReturnValue({
+      provider: { id: "test-fetch", label: "Test Fetch" },
+      definition: {
+        description: "test provider",
+        parameters: {},
+        execute: providerExecute,
+      },
+    });
+
+    const tool = createProviderFallbackTool();
+
+    await expect(
+      captureToolErrorMessage({
+        tool,
+        url: "http://127.0.0.1:9/private",
+      }),
+    ).resolves.toContain("connect refused");
+    expect(providerExecute).not.toHaveBeenCalled();
+  });
+
   it("wraps external content and clamps oversized maxChars", async () => {
     const large = "a".repeat(80_000);
     installMockFetch(

--- a/src/agents/tools/web-tools.fetch.test.ts
+++ b/src/agents/tools/web-tools.fetch.test.ts
@@ -721,11 +721,13 @@ describe("web_fetch extraction fallbacks", () => {
   });
 
   it("uses the provider fallback when direct fetch fails", async () => {
+    const cancelBody = vi.fn(async () => undefined);
     installMockFetch((_input: RequestInfo | URL) => {
       return Promise.resolve({
         ok: false,
         status: 403,
         headers: makeFetchHeaders({ "content-type": "text/html" }),
+        body: { cancel: cancelBody } as unknown as ReadableStream<Uint8Array>,
         text: async () => "blocked",
       } as Response);
     });
@@ -747,6 +749,7 @@ describe("web_fetch extraction fallbacks", () => {
     const details = result?.details as { extractor?: string; text?: string };
     expect(details.extractor).toBe("test-fetch");
     expect(details.text).toContain("provider fallback");
+    expect(cancelBody).toHaveBeenCalledTimes(1);
   });
 
   it("wraps external content and clamps oversized maxChars", async () => {

--- a/src/commands/doctor/shared/deprecation-compat.test.ts
+++ b/src/commands/doctor/shared/deprecation-compat.test.ts
@@ -19,6 +19,7 @@ const requiredDoctorCompatCodes = [
   "doctor-message-queue-steering-modes",
   "doctor-web-search-plugin-config",
   "doctor-web-fetch-plugin-config",
+  "doctor-generic-fetch-policy-config",
   "doctor-x-search-plugin-config",
 ] as const;
 

--- a/src/commands/doctor/shared/deprecation-compat.ts
+++ b/src/commands/doctor/shared/deprecation-compat.ts
@@ -319,7 +319,7 @@ const DOCTOR_DEPRECATION_COMPAT_RECORDS = [
     docsPath: "/security/network-proxy",
     tests: ["src/commands/doctor/shared/legacy-config-migrate.test.ts"],
     notes:
-      "Doctor keeps these deprecated generic fetch keys loadable and removable during rollout. This does not claim Proxyline has exact feature parity with the old fetch guard knobs.",
+      "Doctor keeps these deprecated generic fetch keys loadable and removable during rollout. Zero-valued gateway maxRedirects remains meaningful as no-redirect policy. This does not claim Proxyline has exact feature parity with the old fetch guard knobs.",
   }),
   deprecatedCompatRecord({
     code: "doctor-x-search-plugin-config",

--- a/src/commands/doctor/shared/deprecation-compat.ts
+++ b/src/commands/doctor/shared/deprecation-compat.ts
@@ -319,7 +319,7 @@ const DOCTOR_DEPRECATION_COMPAT_RECORDS = [
     docsPath: "/security/network-proxy",
     tests: ["src/commands/doctor/shared/legacy-config-migrate.test.ts"],
     notes:
-      "Doctor keeps these deprecated generic fetch keys loadable and removable during rollout. Zero-valued gateway maxRedirects remains meaningful as no-redirect policy. This does not claim Proxyline has exact feature parity with the old fetch guard knobs.",
+      "Doctor keeps these deprecated generic fetch keys loadable and removable during rollout. Gateway input URL fetches now reject redirects by default, so gateway maxRedirects is no longer a behavior switch. This does not claim Proxyline has exact feature parity with the old fetch guard knobs.",
   }),
   deprecatedCompatRecord({
     code: "doctor-x-search-plugin-config",

--- a/src/commands/doctor/shared/deprecation-compat.ts
+++ b/src/commands/doctor/shared/deprecation-compat.ts
@@ -313,13 +313,13 @@ const DOCTOR_DEPRECATION_COMPAT_RECORDS = [
     warningStarts: "2026-06-07",
     removeAfter: "2026-09-07",
     source:
-      "tools.web.fetch.maxRedirects; tools.web.fetch.ssrfPolicy; tools.web.fetch.useTrustedEnvProxy; gateway.http.endpoints.chatCompletions.images.maxRedirects; gateway.http.endpoints.responses.files.maxRedirects; gateway.http.endpoints.responses.images.maxRedirects",
+      "tools.web.fetch.maxRedirects; tools.web.fetch.useTrustedEnvProxy; gateway.http.endpoints.chatCompletions.images.maxRedirects; gateway.http.endpoints.responses.files.maxRedirects; gateway.http.endpoints.responses.images.maxRedirects",
     migration: "src/commands/doctor/shared/legacy-config-migrations.web-fetch.ts",
     replacement: "managed proxy / Proxyline outbound policy boundary",
     docsPath: "/security/network-proxy",
     tests: ["src/commands/doctor/shared/legacy-config-migrate.test.ts"],
     notes:
-      "Doctor keeps these deprecated generic fetch keys loadable and removable during rollout. Gateway input URL fetches now reject redirects by default, so gateway maxRedirects is no longer a behavior switch. This does not claim Proxyline has exact feature parity with the old fetch guard knobs.",
+      "Doctor keeps these deprecated generic fetch keys loadable and removable during rollout. tools.web.fetch.ssrfPolicy is excluded from removal because media URL tools still consume it until they get a replacement key. Gateway input URL fetches now reject redirects by default, so gateway maxRedirects is no longer a behavior switch. This does not claim Proxyline has exact feature parity with the old fetch guard knobs.",
   }),
   deprecatedCompatRecord({
     code: "doctor-x-search-plugin-config",

--- a/src/commands/doctor/shared/deprecation-compat.ts
+++ b/src/commands/doctor/shared/deprecation-compat.ts
@@ -306,6 +306,22 @@ const DOCTOR_DEPRECATION_COMPAT_RECORDS = [
     tests: ["src/commands/doctor/shared/legacy-web-fetch-migrate.test.ts"],
   }),
   deprecatedCompatRecord({
+    code: "doctor-generic-fetch-policy-config",
+    owner: "config",
+    introduced: "2026-06-07",
+    deprecated: "2026-06-07",
+    warningStarts: "2026-06-07",
+    removeAfter: "2026-09-07",
+    source:
+      "tools.web.fetch.maxRedirects; tools.web.fetch.ssrfPolicy; tools.web.fetch.useTrustedEnvProxy; gateway.http.endpoints.chatCompletions.images.maxRedirects; gateway.http.endpoints.responses.files.maxRedirects; gateway.http.endpoints.responses.images.maxRedirects",
+    migration: "src/commands/doctor/shared/legacy-config-migrations.web-fetch.ts",
+    replacement: "managed proxy / Proxyline outbound policy boundary",
+    docsPath: "/security/network-proxy",
+    tests: ["src/commands/doctor/shared/legacy-config-migrate.test.ts"],
+    notes:
+      "Doctor keeps these deprecated generic fetch keys loadable and removable during rollout. This does not claim Proxyline has exact feature parity with the old fetch guard knobs.",
+  }),
+  deprecatedCompatRecord({
     code: "doctor-x-search-plugin-config",
     owner: "provider",
     introduced: "2026-04-26",

--- a/src/commands/doctor/shared/legacy-config-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.test.ts
@@ -143,6 +143,49 @@ describe("deprecated generic fetch config migrate", () => {
       "Removed deprecated gateway.http.endpoints.responses.images.maxRedirects.",
     ]);
   });
+
+  it("preserves zero-valued gateway maxRedirects because zero still rejects redirects", () => {
+    const raw = {
+      tools: {
+        web: {
+          fetch: {
+            maxRedirects: 0,
+          },
+        },
+      },
+      gateway: {
+        http: {
+          endpoints: {
+            chatCompletions: {
+              images: {
+                maxRedirects: 0,
+              },
+            },
+            responses: {
+              files: {
+                maxRedirects: 0,
+              },
+              images: {
+                maxRedirects: 0,
+              },
+            },
+          },
+        },
+      },
+    };
+
+    expect(findLegacyConfigIssues(raw).map((issue) => issue.path)).toEqual([
+      "tools.web.fetch.maxRedirects",
+    ]);
+
+    const res = migrateLegacyConfigForTest(raw);
+
+    expect(res.config?.tools?.web?.fetch).toEqual({});
+    expect(res.config?.gateway?.http?.endpoints?.chatCompletions?.images?.maxRedirects).toBe(0);
+    expect(res.config?.gateway?.http?.endpoints?.responses?.files?.maxRedirects).toBe(0);
+    expect(res.config?.gateway?.http?.endpoints?.responses?.images?.maxRedirects).toBe(0);
+    expect(res.changes).toEqual(["Removed deprecated tools.web.fetch.maxRedirects."]);
+  });
 });
 
 describe("legacy memory search config migrate", () => {

--- a/src/commands/doctor/shared/legacy-config-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.test.ts
@@ -144,7 +144,7 @@ describe("deprecated generic fetch config migrate", () => {
     ]);
   });
 
-  it("preserves zero-valued gateway maxRedirects because zero still rejects redirects", () => {
+  it("reports and removes zero-valued gateway maxRedirects because gateway URL fetches now always reject redirects", () => {
     const raw = {
       tools: {
         web: {
@@ -176,15 +176,23 @@ describe("deprecated generic fetch config migrate", () => {
 
     expect(findLegacyConfigIssues(raw).map((issue) => issue.path)).toEqual([
       "tools.web.fetch.maxRedirects",
+      "gateway.http.endpoints.chatCompletions.images.maxRedirects",
+      "gateway.http.endpoints.responses.files.maxRedirects",
+      "gateway.http.endpoints.responses.images.maxRedirects",
     ]);
 
     const res = migrateLegacyConfigForTest(raw);
 
     expect(res.config?.tools?.web?.fetch).toEqual({});
-    expect(res.config?.gateway?.http?.endpoints?.chatCompletions?.images?.maxRedirects).toBe(0);
-    expect(res.config?.gateway?.http?.endpoints?.responses?.files?.maxRedirects).toBe(0);
-    expect(res.config?.gateway?.http?.endpoints?.responses?.images?.maxRedirects).toBe(0);
-    expect(res.changes).toEqual(["Removed deprecated tools.web.fetch.maxRedirects."]);
+    expect(res.config?.gateway?.http?.endpoints?.chatCompletions?.images).toEqual({});
+    expect(res.config?.gateway?.http?.endpoints?.responses?.files).toEqual({});
+    expect(res.config?.gateway?.http?.endpoints?.responses?.images).toEqual({});
+    expect(res.changes).toEqual([
+      "Removed deprecated tools.web.fetch.maxRedirects.",
+      "Removed deprecated gateway.http.endpoints.chatCompletions.images.maxRedirects.",
+      "Removed deprecated gateway.http.endpoints.responses.files.maxRedirects.",
+      "Removed deprecated gateway.http.endpoints.responses.images.maxRedirects.",
+    ]);
   });
 });
 

--- a/src/commands/doctor/shared/legacy-config-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.test.ts
@@ -108,7 +108,6 @@ describe("deprecated generic fetch config migrate", () => {
     const issues = findLegacyConfigIssues(raw);
     expect(issues.map((issue) => issue.path)).toEqual([
       "tools.web.fetch.maxRedirects",
-      "tools.web.fetch.ssrfPolicy",
       "tools.web.fetch.useTrustedEnvProxy",
       "gateway.http.endpoints.chatCompletions.images.maxRedirects",
       "gateway.http.endpoints.responses.files.maxRedirects",
@@ -116,7 +115,7 @@ describe("deprecated generic fetch config migrate", () => {
     ]);
     expect(issues.map((issue) => issue.message)).toEqual(
       Array.from(
-        { length: 6 },
+        { length: 5 },
         () =>
           'Deprecated generic fetch config is accepted during this migration window, but outbound policy now belongs at the managed proxy / Proxyline boundary. Run "openclaw doctor --fix" to remove this key.',
       ),
@@ -124,7 +123,12 @@ describe("deprecated generic fetch config migrate", () => {
 
     const res = migrateLegacyConfigForTest(raw);
 
-    expect(res.config?.tools?.web?.fetch).toEqual({ enabled: true });
+    expect(res.config?.tools?.web?.fetch).toEqual({
+      enabled: true,
+      ssrfPolicy: {
+        allowRfc2544BenchmarkRange: true,
+      },
+    });
     expect(res.config?.gateway?.http?.endpoints?.chatCompletions?.images).toEqual({
       allowUrl: true,
     });
@@ -136,7 +140,6 @@ describe("deprecated generic fetch config migrate", () => {
     });
     expect(res.changes).toEqual([
       "Removed deprecated tools.web.fetch.maxRedirects.",
-      "Removed deprecated tools.web.fetch.ssrfPolicy.",
       "Removed deprecated tools.web.fetch.useTrustedEnvProxy.",
       "Removed deprecated gateway.http.endpoints.chatCompletions.images.maxRedirects.",
       "Removed deprecated gateway.http.endpoints.responses.files.maxRedirects.",

--- a/src/commands/doctor/shared/legacy-config-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, it } from "vitest";
 import { findLegacyConfigIssues } from "../../../config/legacy.js";
 import type { OpenClawConfig } from "../../../config/types.js";
+import { OpenClawSchema } from "../../../config/zod-schema.js";
 import { normalizeCompatibilityConfigValues } from "./legacy-config-core-migrate.js";
 import { LEGACY_CONFIG_MIGRATIONS } from "./legacy-config-migrations.js";
 
@@ -60,6 +61,87 @@ describe("compatibility binding repair migrate", () => {
 
     expect(res.config.bindings).toEqual(cfg.bindings);
     expect(res.changes).not.toContain("Removed 1 binding that referenced missing agents.list ids.");
+  });
+});
+
+describe("deprecated generic fetch config migrate", () => {
+  it("reports and removes deprecated generic fetch policy keys while leaving config loadable", () => {
+    const raw = {
+      tools: {
+        web: {
+          fetch: {
+            enabled: true,
+            maxRedirects: 7,
+            ssrfPolicy: {
+              allowRfc2544BenchmarkRange: true,
+            },
+            useTrustedEnvProxy: true,
+          },
+        },
+      },
+      gateway: {
+        http: {
+          endpoints: {
+            chatCompletions: {
+              images: {
+                allowUrl: true,
+                maxRedirects: 4,
+              },
+            },
+            responses: {
+              files: {
+                allowedMimes: ["text/plain"],
+                maxRedirects: 5,
+              },
+              images: {
+                maxBytes: 1_000,
+                maxRedirects: 6,
+              },
+            },
+          },
+        },
+      },
+    };
+
+    expect(OpenClawSchema.safeParse(raw).success).toBe(true);
+
+    const issues = findLegacyConfigIssues(raw);
+    expect(issues.map((issue) => issue.path)).toEqual([
+      "tools.web.fetch.maxRedirects",
+      "tools.web.fetch.ssrfPolicy",
+      "tools.web.fetch.useTrustedEnvProxy",
+      "gateway.http.endpoints.chatCompletions.images.maxRedirects",
+      "gateway.http.endpoints.responses.files.maxRedirects",
+      "gateway.http.endpoints.responses.images.maxRedirects",
+    ]);
+    expect(issues.map((issue) => issue.message)).toEqual(
+      Array.from(
+        { length: 6 },
+        () =>
+          'Deprecated generic fetch config is accepted during this migration window, but outbound policy now belongs at the managed proxy / Proxyline boundary. Run "openclaw doctor --fix" to remove this key.',
+      ),
+    );
+
+    const res = migrateLegacyConfigForTest(raw);
+
+    expect(res.config?.tools?.web?.fetch).toEqual({ enabled: true });
+    expect(res.config?.gateway?.http?.endpoints?.chatCompletions?.images).toEqual({
+      allowUrl: true,
+    });
+    expect(res.config?.gateway?.http?.endpoints?.responses?.files).toEqual({
+      allowedMimes: ["text/plain"],
+    });
+    expect(res.config?.gateway?.http?.endpoints?.responses?.images).toEqual({
+      maxBytes: 1_000,
+    });
+    expect(res.changes).toEqual([
+      "Removed deprecated tools.web.fetch.maxRedirects.",
+      "Removed deprecated tools.web.fetch.ssrfPolicy.",
+      "Removed deprecated tools.web.fetch.useTrustedEnvProxy.",
+      "Removed deprecated gateway.http.endpoints.chatCompletions.images.maxRedirects.",
+      "Removed deprecated gateway.http.endpoints.responses.files.maxRedirects.",
+      "Removed deprecated gateway.http.endpoints.responses.images.maxRedirects.",
+    ]);
   });
 });
 

--- a/src/commands/doctor/shared/legacy-config-migrations.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.ts
@@ -3,6 +3,7 @@ import { LEGACY_CONFIG_MIGRATIONS_AUDIO } from "./legacy-config-migrations.audio
 import { LEGACY_CONFIG_MIGRATIONS_CHANNELS } from "./legacy-config-migrations.channels.js";
 import { LEGACY_CONFIG_MIGRATIONS_QUEUE } from "./legacy-config-migrations.queue.js";
 import { LEGACY_CONFIG_MIGRATIONS_RUNTIME } from "./legacy-config-migrations.runtime.js";
+import { LEGACY_CONFIG_MIGRATIONS_WEB_FETCH } from "./legacy-config-migrations.web-fetch.js";
 import { LEGACY_CONFIG_MIGRATIONS_WEB_SEARCH } from "./legacy-config-migrations.web-search.js";
 
 const LEGACY_CONFIG_MIGRATION_SPECS = [
@@ -10,6 +11,7 @@ const LEGACY_CONFIG_MIGRATION_SPECS = [
   ...LEGACY_CONFIG_MIGRATIONS_AUDIO,
   ...LEGACY_CONFIG_MIGRATIONS_QUEUE,
   ...LEGACY_CONFIG_MIGRATIONS_RUNTIME,
+  ...LEGACY_CONFIG_MIGRATIONS_WEB_FETCH,
   ...LEGACY_CONFIG_MIGRATIONS_WEB_SEARCH,
 ];
 

--- a/src/commands/doctor/shared/legacy-config-migrations.web-fetch.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.web-fetch.ts
@@ -18,8 +18,19 @@ const DEPRECATED_GENERIC_FETCH_CONFIG_PATHS = [
   ["gateway", "http", "endpoints", "responses", "images", "maxRedirects"],
 ] as const;
 
+const GATEWAY_MAX_REDIRECTS_PATHS = new Set([
+  "gateway.http.endpoints.chatCompletions.images.maxRedirects",
+  "gateway.http.endpoints.responses.files.maxRedirects",
+  "gateway.http.endpoints.responses.images.maxRedirects",
+]);
+
 function formatConfigPath(path: readonly string[]): string {
   return path.join(".");
+}
+
+function shouldRemoveDeprecatedConfigValue(path: readonly string[], value: unknown): boolean {
+  const formatted = formatConfigPath(path);
+  return !GATEWAY_MAX_REDIRECTS_PATHS.has(formatted) || value !== 0;
 }
 
 function removeConfigPath(raw: Record<string, unknown>, path: readonly string[]): boolean {
@@ -41,6 +52,9 @@ function removeConfigPath(raw: Record<string, unknown>, path: readonly string[])
   if (!Object.hasOwn(parent, key)) {
     return false;
   }
+  if (!shouldRemoveDeprecatedConfigValue(path, parent[key])) {
+    return false;
+  }
   delete parent[key];
   return true;
 }
@@ -49,6 +63,7 @@ const DEPRECATED_GENERIC_FETCH_CONFIG_RULES: LegacyConfigRule[] =
   DEPRECATED_GENERIC_FETCH_CONFIG_PATHS.map((path) => ({
     path: [...path],
     message: DEPRECATED_GENERIC_FETCH_CONFIG_MESSAGE,
+    match: (value) => shouldRemoveDeprecatedConfigValue(path, value),
     requireSourceLiteral: true,
   }));
 

--- a/src/commands/doctor/shared/legacy-config-migrations.web-fetch.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.web-fetch.ts
@@ -18,19 +18,8 @@ const DEPRECATED_GENERIC_FETCH_CONFIG_PATHS = [
   ["gateway", "http", "endpoints", "responses", "images", "maxRedirects"],
 ] as const;
 
-const GATEWAY_MAX_REDIRECTS_PATHS = new Set([
-  "gateway.http.endpoints.chatCompletions.images.maxRedirects",
-  "gateway.http.endpoints.responses.files.maxRedirects",
-  "gateway.http.endpoints.responses.images.maxRedirects",
-]);
-
 function formatConfigPath(path: readonly string[]): string {
   return path.join(".");
-}
-
-function shouldRemoveDeprecatedConfigValue(path: readonly string[], value: unknown): boolean {
-  const formatted = formatConfigPath(path);
-  return !GATEWAY_MAX_REDIRECTS_PATHS.has(formatted) || value !== 0;
 }
 
 function removeConfigPath(raw: Record<string, unknown>, path: readonly string[]): boolean {
@@ -52,9 +41,6 @@ function removeConfigPath(raw: Record<string, unknown>, path: readonly string[])
   if (!Object.hasOwn(parent, key)) {
     return false;
   }
-  if (!shouldRemoveDeprecatedConfigValue(path, parent[key])) {
-    return false;
-  }
   delete parent[key];
   return true;
 }
@@ -63,7 +49,6 @@ const DEPRECATED_GENERIC_FETCH_CONFIG_RULES: LegacyConfigRule[] =
   DEPRECATED_GENERIC_FETCH_CONFIG_PATHS.map((path) => ({
     path: [...path],
     message: DEPRECATED_GENERIC_FETCH_CONFIG_MESSAGE,
-    match: (value) => shouldRemoveDeprecatedConfigValue(path, value),
     requireSourceLiteral: true,
   }));
 

--- a/src/commands/doctor/shared/legacy-config-migrations.web-fetch.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.web-fetch.ts
@@ -11,7 +11,6 @@ const DEPRECATED_GENERIC_FETCH_CONFIG_MESSAGE =
 
 const DEPRECATED_GENERIC_FETCH_CONFIG_PATHS = [
   ["tools", "web", "fetch", "maxRedirects"],
-  ["tools", "web", "fetch", "ssrfPolicy"],
   ["tools", "web", "fetch", "useTrustedEnvProxy"],
   ["gateway", "http", "endpoints", "chatCompletions", "images", "maxRedirects"],
   ["gateway", "http", "endpoints", "responses", "files", "maxRedirects"],

--- a/src/commands/doctor/shared/legacy-config-migrations.web-fetch.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.web-fetch.ts
@@ -1,0 +1,70 @@
+// Legacy generic web-fetch policy config removal for managed proxy rollout.
+import {
+  defineLegacyConfigMigration,
+  getRecord,
+  type LegacyConfigMigrationSpec,
+  type LegacyConfigRule,
+} from "../../../config/legacy.shared.js";
+
+const DEPRECATED_GENERIC_FETCH_CONFIG_MESSAGE =
+  'Deprecated generic fetch config is accepted during this migration window, but outbound policy now belongs at the managed proxy / Proxyline boundary. Run "openclaw doctor --fix" to remove this key.';
+
+const DEPRECATED_GENERIC_FETCH_CONFIG_PATHS = [
+  ["tools", "web", "fetch", "maxRedirects"],
+  ["tools", "web", "fetch", "ssrfPolicy"],
+  ["tools", "web", "fetch", "useTrustedEnvProxy"],
+  ["gateway", "http", "endpoints", "chatCompletions", "images", "maxRedirects"],
+  ["gateway", "http", "endpoints", "responses", "files", "maxRedirects"],
+  ["gateway", "http", "endpoints", "responses", "images", "maxRedirects"],
+] as const;
+
+function formatConfigPath(path: readonly string[]): string {
+  return path.join(".");
+}
+
+function removeConfigPath(raw: Record<string, unknown>, path: readonly string[]): boolean {
+  const parentPath = path.slice(0, -1);
+  const key = path[path.length - 1];
+  if (!key) {
+    return false;
+  }
+
+  let parent: Record<string, unknown> = raw;
+  for (const part of parentPath) {
+    const next = getRecord(parent[part]);
+    if (!next) {
+      return false;
+    }
+    parent = next;
+  }
+
+  if (!Object.hasOwn(parent, key)) {
+    return false;
+  }
+  delete parent[key];
+  return true;
+}
+
+const DEPRECATED_GENERIC_FETCH_CONFIG_RULES: LegacyConfigRule[] =
+  DEPRECATED_GENERIC_FETCH_CONFIG_PATHS.map((path) => ({
+    path: [...path],
+    message: DEPRECATED_GENERIC_FETCH_CONFIG_MESSAGE,
+    requireSourceLiteral: true,
+  }));
+
+/** Legacy config migration specs for deprecated generic web-fetch policy config. */
+export const LEGACY_CONFIG_MIGRATIONS_WEB_FETCH: LegacyConfigMigrationSpec[] = [
+  defineLegacyConfigMigration({
+    id: "generic-fetch-policy-config-remove",
+    describe: "Remove deprecated generic fetch policy keys now owned by managed proxy policy",
+    legacyRules: DEPRECATED_GENERIC_FETCH_CONFIG_RULES,
+    apply: (raw, changes) => {
+      for (const path of DEPRECATED_GENERIC_FETCH_CONFIG_PATHS) {
+        if (!removeConfigPath(raw, path)) {
+          continue;
+        }
+        changes.push(`Removed deprecated ${formatConfigPath(path)}.`);
+      }
+    },
+  }),
+];

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -579,7 +579,7 @@ export const FIELD_HELP: Record<string, string> = {
   "gateway.http.endpoints.chatCompletions.images.maxBytes":
     "Max bytes per fetched/decoded `image_url` image (default: 10MB).",
   "gateway.http.endpoints.chatCompletions.images.maxRedirects":
-    "Deprecated generic fetch redirect cap. Native fetch redirects are used; run `openclaw doctor --fix` to remove this key.",
+    "Deprecated positive redirect cap for `image_url` fetches. Set 0 only when URL fetches should reject redirects.",
   "gateway.http.endpoints.chatCompletions.images.timeoutMs":
     "Timeout in milliseconds for `image_url` URL fetches (default: 10000).",
   "gateway.reload.mode":

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -579,7 +579,7 @@ export const FIELD_HELP: Record<string, string> = {
   "gateway.http.endpoints.chatCompletions.images.maxBytes":
     "Max bytes per fetched/decoded `image_url` image (default: 10MB).",
   "gateway.http.endpoints.chatCompletions.images.maxRedirects":
-    "Deprecated positive redirect cap for `image_url` fetches. Set 0 only when URL fetches should reject redirects.",
+    "Deprecated ignored redirect cap for `image_url` fetches. URL fetches reject redirects by default; remove this key.",
   "gateway.http.endpoints.chatCompletions.images.timeoutMs":
     "Timeout in milliseconds for `image_url` URL fetches (default: 10000).",
   "gateway.reload.mode":

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -579,7 +579,7 @@ export const FIELD_HELP: Record<string, string> = {
   "gateway.http.endpoints.chatCompletions.images.maxBytes":
     "Max bytes per fetched/decoded `image_url` image (default: 10MB).",
   "gateway.http.endpoints.chatCompletions.images.maxRedirects":
-    "Max HTTP redirects allowed when fetching `image_url` URLs (default: 3).",
+    "Deprecated generic fetch redirect cap. Native fetch redirects are used; run `openclaw doctor --fix` to remove this key.",
   "gateway.http.endpoints.chatCompletions.images.timeoutMs":
     "Timeout in milliseconds for `image_url` URL fetches (default: 10000).",
   "gateway.reload.mode":
@@ -932,18 +932,19 @@ export const FIELD_HELP: Record<string, string> = {
   "tools.web.fetch.provider": "Web fetch fallback provider id.",
   "tools.web.fetch.timeoutSeconds": "Timeout in seconds for web_fetch requests.",
   "tools.web.fetch.cacheTtlMinutes": "Cache TTL in minutes for web_fetch results.",
-  "tools.web.fetch.maxRedirects": "Maximum redirects allowed for web_fetch (default: 3).",
+  "tools.web.fetch.maxRedirects":
+    "Deprecated generic fetch redirect cap. Direct web_fetch uses native fetch redirects; run `openclaw doctor --fix` to remove this key.",
   "tools.web.fetch.userAgent": "Override User-Agent header for web_fetch requests.",
   "tools.web.fetch.readability":
     "Use Readability to extract main content from HTML (fallbacks to basic HTML cleanup).",
   "tools.web.fetch.useTrustedEnvProxy":
-    "Route web_fetch through a trusted HTTP(S) env proxy and let the proxy resolve DNS. Enable only when that proxy is operator-controlled and enforces outbound policy after DNS resolution.",
+    "Deprecated generic fetch proxy-DNS mode. Use managed proxy / Proxyline for outbound destination policy; run `openclaw doctor --fix` to remove this key.",
   "tools.web.fetch.ssrfPolicy":
-    "Scoped SSRF policy overrides for web_fetch. Keep this narrow and opt in only for known local-network proxy environments.",
+    "Deprecated generic fetch SSRF policy overrides. Direct web_fetch no longer consumes this policy; run `openclaw doctor --fix` to remove this key.",
   "tools.web.fetch.ssrfPolicy.allowRfc2544BenchmarkRange":
-    "Allow RFC 2544 benchmark-range IPs (198.18.0.0/15) for fake-IP proxy compatibility such as Clash or Surge.",
+    "Deprecated web_fetch SSRF policy field. Direct web_fetch no longer consumes this policy; run `openclaw doctor --fix` to remove it.",
   "tools.web.fetch.ssrfPolicy.allowIpv6UniqueLocalRange":
-    "Allow IPv6 Unique Local Addresses (fc00::/7) for trusted fake-IP proxy compatibility such as sing-box, Clash, or Surge.",
+    "Deprecated web_fetch SSRF policy field. Direct web_fetch no longer consumes this policy; run `openclaw doctor --fix` to remove it.",
   models:
     "Model catalog root for provider definitions, merge/replace behavior, and optional Bedrock discovery integration. Keep provider definitions explicit and validated before relying on production failover paths.",
   "models.mode":

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -942,9 +942,9 @@ export const FIELD_HELP: Record<string, string> = {
   "tools.web.fetch.ssrfPolicy":
     "Deprecated generic fetch SSRF policy overrides. Direct web_fetch no longer consumes this policy, but remote media tools still read it until a replacement media-specific key exists.",
   "tools.web.fetch.ssrfPolicy.allowRfc2544BenchmarkRange":
-    "Deprecated web_fetch SSRF policy field. Direct web_fetch no longer consumes this policy; run `openclaw doctor --fix` to remove it.",
+    "Deprecated web_fetch SSRF policy field. Direct web_fetch no longer consumes this policy; remote media tools still read it until a replacement media-specific key exists.",
   "tools.web.fetch.ssrfPolicy.allowIpv6UniqueLocalRange":
-    "Deprecated web_fetch SSRF policy field. Direct web_fetch no longer consumes this policy; run `openclaw doctor --fix` to remove it.",
+    "Deprecated web_fetch SSRF policy field. Direct web_fetch no longer consumes this policy; remote media tools still read it until a replacement media-specific key exists.",
   models:
     "Model catalog root for provider definitions, merge/replace behavior, and optional Bedrock discovery integration. Keep provider definitions explicit and validated before relying on production failover paths.",
   "models.mode":

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -940,7 +940,7 @@ export const FIELD_HELP: Record<string, string> = {
   "tools.web.fetch.useTrustedEnvProxy":
     "Deprecated generic fetch proxy-DNS mode. Use managed proxy / Proxyline for outbound destination policy; run `openclaw doctor --fix` to remove this key.",
   "tools.web.fetch.ssrfPolicy":
-    "Deprecated generic fetch SSRF policy overrides. Direct web_fetch no longer consumes this policy; run `openclaw doctor --fix` to remove this key.",
+    "Deprecated generic fetch SSRF policy overrides. Direct web_fetch no longer consumes this policy, but remote media tools still read it until a replacement media-specific key exists.",
   "tools.web.fetch.ssrfPolicy.allowRfc2544BenchmarkRange":
     "Deprecated web_fetch SSRF policy field. Direct web_fetch no longer consumes this policy; run `openclaw doctor --fix` to remove it.",
   "tools.web.fetch.ssrfPolicy.allowIpv6UniqueLocalRange":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -333,14 +333,15 @@ export const FIELD_LABELS: Record<string, string> = {
   "tools.web.fetch.provider": "Web Fetch Provider",
   "tools.web.fetch.timeoutSeconds": "Web Fetch Timeout (sec)",
   "tools.web.fetch.cacheTtlMinutes": "Web Fetch Cache TTL (min)",
-  "tools.web.fetch.maxRedirects": "Web Fetch Max Redirects",
+  "tools.web.fetch.maxRedirects": "Deprecated Web Fetch Max Redirects",
   "tools.web.fetch.userAgent": "Web Fetch User-Agent",
   "tools.web.fetch.readability": "Web Fetch Readability Extraction",
-  "tools.web.fetch.useTrustedEnvProxy": "Web Fetch Trusted Env Proxy",
-  "tools.web.fetch.ssrfPolicy": "Web Fetch SSRF Policy",
+  "tools.web.fetch.useTrustedEnvProxy": "Deprecated Web Fetch Trusted Env Proxy",
+  "tools.web.fetch.ssrfPolicy": "Deprecated Web Fetch SSRF Policy",
   "tools.web.fetch.ssrfPolicy.allowRfc2544BenchmarkRange":
-    "Web Fetch Allow RFC 2544 Benchmark Range",
-  "tools.web.fetch.ssrfPolicy.allowIpv6UniqueLocalRange": "Web Fetch Allow IPv6 Unique Local Range",
+    "Deprecated Web Fetch Allow RFC 2544 Benchmark Range",
+  "tools.web.fetch.ssrfPolicy.allowIpv6UniqueLocalRange":
+    "Deprecated Web Fetch Allow IPv6 Unique Local Range",
   "gateway.controlUi.basePath": "Control UI Base Path",
   "gateway.controlUi.root": "Control UI Assets Root",
   "gateway.controlUi.embedSandbox": "Control UI Embed Sandbox Mode",
@@ -371,7 +372,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "gateway.http.endpoints.chatCompletions.images.maxBytes":
     "OpenAI Chat Completions Image Max Bytes",
   "gateway.http.endpoints.chatCompletions.images.maxRedirects":
-    "OpenAI Chat Completions Image Max Redirects",
+    "Deprecated OpenAI Chat Completions Image Max Redirects",
   "gateway.http.endpoints.chatCompletions.images.timeoutMs":
     "OpenAI Chat Completions Image Timeout (ms)",
   "gateway.reload.mode": "Config Reload Mode",

--- a/src/infra/net/fetch-guard.ts
+++ b/src/infra/net/fetch-guard.ts
@@ -19,6 +19,7 @@ import {
   type DispatcherAwareRequestInit,
 } from "./runtime-fetch.js";
 import {
+  assertExplicitProxyAllowedWithPolicy,
   assertHostnameAllowedWithPolicy,
   closeDispatcher,
   createPinnedDispatcher,
@@ -209,42 +210,6 @@ function createPolicyDispatcherWithoutPinnedDns(
     );
   }
   return createHttp1ProxyAgent({ uri: proxyUrl }, timeoutMs);
-}
-
-async function assertExplicitProxyAllowed(
-  dispatcherPolicy: PinnedDispatcherPolicy | undefined,
-  lookupFn: LookupFn | undefined,
-  policy: SsrFPolicy | undefined,
-): Promise<void> {
-  // Explicit proxies are operator-configured, but the proxy host still needs
-  // basic URL and private-network validation before target validation proceeds.
-  if (!dispatcherPolicy || dispatcherPolicy.mode !== "explicit-proxy") {
-    return;
-  }
-  let parsedProxyUrl: URL;
-  try {
-    parsedProxyUrl = new URL(dispatcherPolicy.proxyUrl);
-  } catch {
-    throw new Error("Invalid explicit proxy URL");
-  }
-  if (!["http:", "https:"].includes(parsedProxyUrl.protocol)) {
-    throw new Error("Explicit proxy URL must use http or https");
-  }
-  const proxyPolicy: SsrFPolicy | undefined =
-    policy || dispatcherPolicy.allowPrivateProxy === true
-      ? {
-          ...policy,
-          // The proxy hostname is operator-configured, not user input. Target-scoped
-          // allowlists must not reject a configured proxy host before the request
-          // target gets checked against that same allowlist below.
-          hostnameAllowlist: undefined,
-          ...(dispatcherPolicy.allowPrivateProxy === true ? { allowPrivateNetwork: true } : {}),
-        }
-      : undefined;
-  await resolvePinnedHostnameWithPolicy(parsedProxyUrl.hostname, {
-    lookupFn,
-    policy: proxyPolicy,
-  });
 }
 
 function isRedirectStatus(status: number): boolean {
@@ -505,7 +470,10 @@ async function fetchWithSsrFGuardInternal(
         dispatcherPolicy,
         usesTrustedExplicitProxyMode ? false : params.pinDns,
       );
-      await assertExplicitProxyAllowed(dispatcherPolicy, params.lookupFn, params.policy);
+      await assertExplicitProxyAllowedWithPolicy(dispatcherPolicy, {
+        lookupFn: params.lookupFn,
+        policy: params.policy,
+      });
       const canUseManagedProxy =
         mode === GUARDED_FETCH_MODE.STRICT && isManagedProxyActive() && hasProxyEnvConfigured();
       const canUseTrustedEnvProxy =

--- a/src/infra/net/fetch-guard.ts
+++ b/src/infra/net/fetch-guard.ts
@@ -411,6 +411,10 @@ function rewriteRedirectInitForCrossOrigin(params: {
 
 export { fetchWithRuntimeDispatcher } from "./runtime-fetch.js";
 
+/**
+ * @deprecated Kept for plugin SDK compatibility. New OpenClaw core fetch paths
+ * should use native fetch/transport helpers and managed proxy policy instead.
+ */
 export async function fetchWithSsrFGuard(params: GuardedFetchOptions): Promise<GuardedFetchResult> {
   const { managedProxyBypass: _ignoredManagedProxyBypass, ...publicParams } =
     params as GuardedFetchOptions & {

--- a/src/infra/net/ssrf.dispatcher.test.ts
+++ b/src/infra/net/ssrf.dispatcher.test.ts
@@ -23,6 +23,35 @@ const { getDefaultAutoSelectFamily, isWSL2SyncMock } = vi.hoisted(() => ({
   isWSL2SyncMock: vi.fn(() => false),
 }));
 
+const { dnsLookupMock } = vi.hoisted(() => ({
+  dnsLookupMock: vi.fn((hostname: string, optionsOrCallback: unknown, callback?: unknown) => {
+    const cb = (typeof optionsOrCallback === "function" ? optionsOrCallback : callback) as
+      | ((
+          err: NodeJS.ErrnoException | null,
+          address: string | Array<unknown>,
+          family?: number,
+        ) => void)
+      | undefined;
+    if (!cb) {
+      return;
+    }
+    const opts =
+      typeof optionsOrCallback === "object" && optionsOrCallback !== null
+        ? (optionsOrCallback as { all?: boolean })
+        : {};
+    if (hostname === "metadata.example.test") {
+      cb(null, opts.all ? [{ address: "127.0.0.1", family: 4 }] : "127.0.0.1", 4);
+      return;
+    }
+    cb(null, opts.all ? [{ address: "93.184.216.34", family: 4 }] : "93.184.216.34", 4);
+  }),
+}));
+
+vi.mock("node:dns", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("node:dns")>()),
+  lookup: dnsLookupMock,
+}));
+
 vi.mock("node:net", async (importOriginal) => ({
   ...(await importOriginal<typeof import("node:net")>()),
   getDefaultAutoSelectFamily,
@@ -44,6 +73,7 @@ beforeEach(() => {
   agentCtor.mockClear();
   envHttpProxyAgentCtor.mockClear();
   proxyAgentCtor.mockClear();
+  dnsLookupMock.mockClear();
   getDefaultAutoSelectFamily.mockReturnValue(true);
   isWSL2SyncMock.mockReturnValue(false);
   (globalThis as Record<string, unknown>)[TEST_UNDICI_RUNTIME_DEPS_KEY] = {
@@ -79,6 +109,16 @@ function createDispatcherWithPinnedOverride(lookup: PinnedHostname["lookup"]) {
   return (call?.[0] as { connect?: { lookup?: PinnedHostname["lookup"] } })?.connect?.lookup;
 }
 
+function expectPinnedLookup(
+  lookup: unknown,
+  expectedAddress = "149.154.167.220",
+): asserts lookup is PinnedHostname["lookup"] {
+  expect(lookup).toBeTypeOf("function");
+  const callback = vi.fn();
+  (lookup as PinnedHostname["lookup"])("api.telegram.org", callback);
+  expect(callback).toHaveBeenCalledWith(null, expectedAddress, 4);
+}
+
 function requireRecord(value: unknown, label: string): Record<string, unknown> {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     throw new Error(`expected ${label}`);
@@ -110,13 +150,13 @@ describe("createPinnedDispatcher", () => {
         options?: { allowH2?: boolean; connect?: Record<string, unknown> };
       }
     ).options;
-    expect(dispatcherOptions?.connect?.lookup).toBe(lookup);
+    expectPinnedLookup(dispatcherOptions?.connect?.lookup);
     expect(dispatcherOptions?.connect?.autoSelectFamily).toBe(true);
     expect(dispatcherOptions?.connect?.autoSelectFamilyAttemptTimeout).toBe(300);
     expect(dispatcherOptions?.allowH2).toBe(false);
     expect(agentCtor).toHaveBeenCalledWith({
       connect: {
-        lookup,
+        lookup: expect.any(Function),
         autoSelectFamily: true,
         autoSelectFamilyAttemptTimeout: 300,
       },
@@ -141,7 +181,7 @@ describe("createPinnedDispatcher", () => {
 
     expect(agentCtor).toHaveBeenCalledWith({
       connect: {
-        lookup,
+        lookup: expect.any(Function),
         autoSelectFamily: false,
         autoSelectFamilyAttemptTimeout: 300,
       },
@@ -171,7 +211,7 @@ describe("createPinnedDispatcher", () => {
       connect: {
         autoSelectFamily: true,
         autoSelectFamilyAttemptTimeout: 300,
-        lookup,
+        lookup: expect.any(Function),
       },
       allowH2: false,
     });
@@ -197,7 +237,7 @@ describe("createPinnedDispatcher", () => {
       connect: {
         autoSelectFamily: false,
         autoSelectFamilyAttemptTimeout: 50,
-        lookup,
+        lookup: expect.any(Function),
       },
       allowH2: false,
     });
@@ -215,7 +255,7 @@ describe("createPinnedDispatcher", () => {
 
     expect(agentCtor).toHaveBeenCalledWith({
       connect: {
-        lookup,
+        lookup: expect.any(Function),
         autoSelectFamily: true,
         autoSelectFamilyAttemptTimeout: 300,
         timeout: 123_456,
@@ -238,19 +278,15 @@ describe("createPinnedDispatcher", () => {
     expect(originalLookup).not.toHaveBeenCalled();
   });
 
-  it("keeps the override bound to the matching hostname only", () => {
-    const originalLookupMock = vi.fn(
-      (_hostname: string, callback: (err: null, address: string, family: number) => void) => {
-        callback(null, "93.184.216.34", 4);
-      },
-    );
-    const originalLookup = originalLookupMock as unknown as PinnedHostname["lookup"];
+  it("checks string fallback DNS results before allowing fallback hosts", () => {
+    const originalLookup = vi.fn() as unknown as PinnedHostname["lookup"];
     const lookup = createDispatcherWithPinnedOverride(originalLookup);
     const callback = vi.fn();
-    lookup?.("example.com", callback);
+    lookup?.("metadata.example.test", callback);
 
-    expect(originalLookupMock).toHaveBeenCalledWith("example.com", expect.any(Function));
-    expect(callback).toHaveBeenCalledWith(null, "93.184.216.34", 4);
+    expect(dnsLookupMock).toHaveBeenCalledWith("metadata.example.test", expect.any(Function));
+    expect(callback).toHaveBeenCalledWith(expect.any(Error), []);
+    expect(originalLookup).not.toHaveBeenCalled();
   });
 
   it("rejects pinned override addresses that violate SSRF policy", () => {
@@ -298,7 +334,7 @@ describe("createPinnedDispatcher", () => {
       connect: {
         autoSelectFamily: true,
         autoSelectFamilyAttemptTimeout: 300,
-        lookup,
+        lookup: expect.any(Function),
       },
       clientFactory: expect.any(Function),
       allowH2: false,
@@ -335,7 +371,7 @@ describe("createPinnedDispatcher", () => {
       allowH2: false,
       requestTls: {
         autoSelectFamily: false,
-        lookup,
+        lookup: expect.any(Function),
       },
     });
   });
@@ -366,7 +402,7 @@ describe("createPinnedDispatcher", () => {
       clientFactory: expect.any(Function),
       requestTls: {
         autoSelectFamily: false,
-        lookup,
+        lookup: expect.any(Function),
       },
       proxyTls: {
         autoSelectFamily: true,

--- a/src/infra/net/ssrf.dispatcher.test.ts
+++ b/src/infra/net/ssrf.dispatcher.test.ts
@@ -43,6 +43,10 @@ const { dnsLookupMock } = vi.hoisted(() => ({
       cb(null, opts.all ? [{ address: "127.0.0.1", family: 4 }] : "127.0.0.1", 4);
       return;
     }
+    if (hostname === "localhost") {
+      cb(null, opts.all ? [{ address: "127.0.0.1", family: 4 }] : "127.0.0.1", 4);
+      return;
+    }
     cb(null, opts.all ? [{ address: "93.184.216.34", family: 4 }] : "93.184.216.34", 4);
   }),
 }));
@@ -343,6 +347,43 @@ describe("createPinnedDispatcher", () => {
         autoSelectFamilyAttemptTimeout: 300,
       },
     });
+  });
+
+  it("does not apply the target SSRF policy to env proxy host lookups", () => {
+    const lookup = vi.fn() as unknown as PinnedHostname["lookup"];
+    const pinned: PinnedHostname = {
+      hostname: "api.telegram.org",
+      addresses: ["149.154.167.220"],
+      lookup,
+    };
+
+    createPinnedDispatcher(
+      pinned,
+      {
+        mode: "env-proxy",
+        connect: {
+          autoSelectFamily: true,
+        },
+      },
+      {
+        hostnameAllowlist: ["api.telegram.org"],
+      },
+    );
+
+    const [call] = envHttpProxyAgentCtor.mock.calls;
+    const options = requireRecord(call?.[0], "EnvHttpProxyAgent constructor options");
+    const connect = requireRecord(options.connect, "EnvHttpProxyAgent connect options");
+    const envProxyLookup = connect.lookup as PinnedHostname["lookup"] | undefined;
+    expect(envProxyLookup).toBeTypeOf("function");
+
+    const targetCallback = vi.fn();
+    envProxyLookup?.("api.telegram.org", targetCallback);
+    expect(targetCallback).toHaveBeenCalledWith(null, "149.154.167.220", 4);
+
+    const proxyCallback = vi.fn();
+    envProxyLookup?.("localhost", proxyCallback);
+    expect(dnsLookupMock).toHaveBeenCalledWith("localhost", expect.any(Function));
+    expect(proxyCallback).toHaveBeenCalledWith(null, "127.0.0.1", 4);
   });
 
   it("keeps explicit proxy routing intact", () => {

--- a/src/infra/net/ssrf.ts
+++ b/src/infra/net/ssrf.ts
@@ -573,6 +573,38 @@ export type PinnedDispatcherPolicy =
       pinnedHostname?: PinnedHostnameOverride;
     };
 
+export async function assertExplicitProxyAllowedWithPolicy(
+  dispatcherPolicy: PinnedDispatcherPolicy | undefined,
+  params: { lookupFn?: LookupFn; policy?: SsrFPolicy } = {},
+): Promise<void> {
+  if (!dispatcherPolicy || dispatcherPolicy.mode !== "explicit-proxy") {
+    return;
+  }
+  let parsedProxyUrl: URL;
+  try {
+    parsedProxyUrl = new URL(dispatcherPolicy.proxyUrl);
+  } catch {
+    throw new Error("Invalid explicit proxy URL");
+  }
+  if (parsedProxyUrl.protocol !== "http:" && parsedProxyUrl.protocol !== "https:") {
+    throw new Error("Explicit proxy URL must use http or https");
+  }
+  const proxyPolicy: SsrFPolicy | undefined =
+    params.policy || dispatcherPolicy.allowPrivateProxy === true
+      ? {
+          ...params.policy,
+          // Proxy hosts are operator configured. Target-scoped allowlists must
+          // not reject the proxy before the request target is checked.
+          hostnameAllowlist: undefined,
+          ...(dispatcherPolicy.allowPrivateProxy === true ? { allowPrivateNetwork: true } : {}),
+        }
+      : undefined;
+  await resolvePinnedHostnameWithPolicy(parsedProxyUrl.hostname, {
+    lookupFn: params.lookupFn,
+    policy: proxyPolicy,
+  });
+}
+
 function dedupeAndPreferIpv4(results: readonly LookupAddress[]): string[] {
   const seen = new Set<string>();
   const ipv4: string[] = [];

--- a/src/infra/net/ssrf.ts
+++ b/src/infra/net/ssrf.ts
@@ -489,6 +489,51 @@ export function createPinnedLookup(params: {
   }) as typeof dnsLookupCb;
 }
 
+function createPolicyCheckingLookup(policy?: SsrFPolicy): typeof dnsLookupCb {
+  const lookupWithOptions = dnsLookupCb as unknown as (
+    hostname: string,
+    options: unknown,
+    callback: LookupCallback,
+  ) => void;
+  return ((host: string, options?: unknown, callback?: unknown) => {
+    const cb: LookupCallback =
+      typeof options === "function" ? (options as LookupCallback) : (callback as LookupCallback);
+    if (!cb) {
+      return;
+    }
+    let hostnameChecks: ReturnType<typeof resolveHostnamePolicyChecks>;
+    try {
+      hostnameChecks = resolveHostnamePolicyChecks(host, policy);
+    } catch (err) {
+      cb(err as NodeJS.ErrnoException, []);
+      return;
+    }
+    const done: LookupCallback = (err, address, family) => {
+      if (err) {
+        cb(err, address, family);
+        return;
+      }
+      try {
+        const results = normalizeLookupResults(address as LookupResult);
+        if (!hostnameChecks.skipPrivateNetworkChecks) {
+          assertAllowedResolvedAddressesOrThrow(results, policy);
+        } else if (!isPrivateNetworkAllowedByPolicy(policy)) {
+          assertAllowedTrustedHostnameResolvedAddressesOrThrow(results);
+        }
+      } catch (checkErr) {
+        cb(checkErr as NodeJS.ErrnoException, []);
+        return;
+      }
+      cb(null, address, family);
+    };
+    if (typeof options === "function" || options === undefined) {
+      dnsLookupCb(hostnameChecks.normalized, done);
+      return;
+    }
+    lookupWithOptions(hostnameChecks.normalized, options, done);
+  }) as typeof dnsLookupCb;
+}
+
 export type PinnedHostname = {
   hostname: string;
   addresses: string[];
@@ -602,7 +647,11 @@ function resolvePinnedDispatcherLookup(
   policy?: SsrFPolicy,
 ): PinnedHostname["lookup"] {
   if (!override) {
-    return pinned.lookup;
+    return createPinnedLookup({
+      hostname: pinned.hostname,
+      addresses: [...pinned.addresses],
+      fallback: createPolicyCheckingLookup(policy),
+    });
   }
   const normalizedOverrideHost = normalizeHostname(override.hostname);
   if (!normalizedOverrideHost || normalizedOverrideHost !== pinned.hostname) {
@@ -622,7 +671,7 @@ function resolvePinnedDispatcherLookup(
   return createPinnedLookup({
     hostname: pinned.hostname,
     addresses: [...override.addresses],
-    fallback: pinned.lookup,
+    fallback: createPolicyCheckingLookup(policy),
   });
 }
 

--- a/src/infra/net/ssrf.ts
+++ b/src/infra/net/ssrf.ts
@@ -31,7 +31,7 @@ type LookupCallback = (
   family?: number,
 ) => void;
 
-type LookupResult = LookupAddress | LookupAddress[];
+type LookupResult = string | LookupAddress | LookupAddress[];
 const DISPATCHER_CLOSE_TIMEOUT_MS = 100;
 
 export class SsrFBlockedError extends Error {
@@ -420,9 +420,17 @@ function assertAllowedTrustedHostnameResolvedAddressesOrThrow(
   }
 }
 
-function normalizeLookupResults(results: LookupResult): readonly LookupAddress[] {
+function normalizeLookupResults(results: LookupResult, family?: number): readonly LookupAddress[] {
   if (Array.isArray(results)) {
     return results;
+  }
+  if (typeof results === "string") {
+    return [
+      {
+        address: results,
+        family: family === 4 || family === 6 ? family : results.includes(":") ? 6 : 4,
+      },
+    ];
   }
   return [results];
 }
@@ -514,7 +522,7 @@ function createPolicyCheckingLookup(policy?: SsrFPolicy): typeof dnsLookupCb {
         return;
       }
       try {
-        const results = normalizeLookupResults(address as LookupResult);
+        const results = normalizeLookupResults(address as LookupResult, family);
         if (!hostnameChecks.skipPrivateNetworkChecks) {
           assertAllowedResolvedAddressesOrThrow(results, policy);
         } else if (!isPrivateNetworkAllowedByPolicy(policy)) {

--- a/src/infra/net/ssrf.ts
+++ b/src/infra/net/ssrf.ts
@@ -684,13 +684,14 @@ function withPinnedLookup(
 function resolvePinnedDispatcherLookup(
   pinned: PinnedHostname,
   override?: PinnedHostnameOverride,
+  fallback: typeof dnsLookupCb = createPolicyCheckingLookup(),
   policy?: SsrFPolicy,
 ): PinnedHostname["lookup"] {
   if (!override) {
     return createPinnedLookup({
       hostname: pinned.hostname,
       addresses: [...pinned.addresses],
-      fallback: createPolicyCheckingLookup(policy),
+      fallback,
     });
   }
   const normalizedOverrideHost = normalizeHostname(override.hostname);
@@ -711,7 +712,7 @@ function resolvePinnedDispatcherLookup(
   return createPinnedLookup({
     hostname: pinned.hostname,
     addresses: [...override.addresses],
-    fallback: createPolicyCheckingLookup(policy),
+    fallback,
   });
 }
 
@@ -721,7 +722,14 @@ export function createPinnedDispatcher(
   ssrfPolicy?: SsrFPolicy,
   timeoutMs?: number,
 ): Dispatcher {
-  const lookup = resolvePinnedDispatcherLookup(pinned, policy?.pinnedHostname, ssrfPolicy);
+  const fallbackLookup =
+    policy?.mode === "env-proxy" ? dnsLookupCb : createPolicyCheckingLookup(ssrfPolicy);
+  const lookup = resolvePinnedDispatcherLookup(
+    pinned,
+    policy?.pinnedHostname,
+    fallbackLookup,
+    ssrfPolicy,
+  );
 
   if (!policy || policy.mode === "direct") {
     return createHttp1Agent({ connect: withPinnedLookup(lookup, policy?.connect) }, timeoutMs);

--- a/src/media/fetch.test.ts
+++ b/src/media/fetch.test.ts
@@ -628,6 +628,29 @@ describe("readRemoteMediaBuffer", () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
+  it("uses the shared lookup resolver for dispatcher fallback attempts", async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(Buffer.from("fallback"), {
+          status: 200,
+          headers: { "content-type": "application/octet-stream" },
+        }),
+    );
+    const lookupFn = makeLookupFn();
+
+    const result = await readRemoteMediaBuffer({
+      url: "https://files.example.test/file.bin",
+      fetchImpl,
+      lookupFn,
+      dispatcherAttempts: [{ dispatcherPolicy: { mode: "direct" } }],
+      maxBytes: 1024,
+    });
+
+    expect(result.buffer).toStrictEqual(Buffer.from("fallback"));
+    expect(lookupFn).toHaveBeenCalledWith("files.example.test", { all: true });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
   it("streams successful responses directly into the media store", async () => {
     const fetchImpl = vi.fn(
       async () =>

--- a/src/media/fetch.test.ts
+++ b/src/media/fetch.test.ts
@@ -783,6 +783,42 @@ describe("readRemoteMediaBuffer", () => {
     );
   });
 
+  it("preserves HEAD when replaying 303 media redirects", async () => {
+    const redirectResponse = new Response(null, {
+      status: 303,
+      headers: { location: "https://cdn.example.com/files/photo.png" },
+    });
+    const finalResponse = new Response(null, {
+      status: 200,
+      headers: { "content-type": "image/png" },
+    });
+    Object.defineProperty(finalResponse, "url", {
+      value: "https://cdn.example.com/files/photo.png",
+    });
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(redirectResponse)
+      .mockResolvedValueOnce(finalResponse);
+
+    await readRemoteMediaBuffer({
+      url: "https://example.com/download",
+      fetchImpl,
+      lookupFn: makeLookupFn(),
+      requestInit: { method: "HEAD" },
+      maxBytes: 8,
+      maxRedirects: 1,
+    });
+
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      2,
+      "https://cdn.example.com/files/photo.png",
+      expect.objectContaining({
+        method: "HEAD",
+        redirect: "manual",
+      }),
+    );
+  });
+
   it("honors maxRedirects zero for media fetches", async () => {
     const fetchImpl = vi.fn(
       async () =>

--- a/src/media/fetch.test.ts
+++ b/src/media/fetch.test.ts
@@ -1,19 +1,18 @@
 // Media fetch tests cover remote media download limits and validation.
 import fs from "node:fs/promises";
-import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { MAX_TIMER_TIMEOUT_MS } from "../shared/number-coercion.js";
 import { createTempHomeEnv, type TempHomeEnv } from "../test-utils/temp-home.js";
 
-const fetchWithSsrFGuardMock = vi.hoisted(() => vi.fn());
+const createHttp1ProxyAgentMock = vi.hoisted(() => vi.fn());
 
-vi.mock("../infra/net/fetch-guard.js", () => ({
-  fetchWithSsrFGuard: (...args: unknown[]) => fetchWithSsrFGuardMock(...args),
-  withStrictGuardedFetchMode: <T>(params: T) => params,
-  withTrustedExplicitProxyGuardedFetchMode: <T>(params: T) => ({
-    ...params,
-    mode: "trusted_explicit_proxy",
-  }),
-}));
+vi.mock("../infra/net/undici-runtime.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../infra/net/undici-runtime.js")>();
+  return {
+    ...actual,
+    createHttp1ProxyAgent: createHttp1ProxyAgentMock,
+  };
+});
 
 type FetchModule = typeof import("./fetch.js");
 type ReadRemoteMediaBuffer = FetchModule["readRemoteMediaBuffer"];
@@ -67,14 +66,6 @@ function makeStallingFetch(firstChunk: Uint8Array) {
 
 function makeLookupFn(): LookupFn {
   return vi.fn(async () => ({ address: "149.154.167.220", family: 4 })) as unknown as LookupFn;
-}
-
-function requireFetchGuardRequest(): unknown {
-  const [call] = fetchWithSsrFGuardMock.mock.calls;
-  if (!call) {
-    throw new Error("expected fetchWithSsrFGuard call");
-  }
-  return call[0];
 }
 
 async function expectRemoteMediaMaxBytesError(params: {
@@ -192,16 +183,6 @@ async function expectBoundedErrorBodyCase(
   expect(result.message).not.toContain("body:");
 }
 
-async function expectPrivateIpFetchBlockedCase() {
-  const fetchImpl = vi.fn();
-  await expectReadRemoteMediaBufferRejected({
-    url: "http://127.0.0.1/secret.jpg",
-    fetchImpl,
-    expectedError: /private|internal|blocked/i,
-  });
-  expect(fetchImpl).not.toHaveBeenCalled();
-}
-
 function createReadRemoteMediaBufferParams(
   params: Omit<Parameters<typeof readRemoteMediaBuffer>[0], "lookupFn"> & { lookupFn?: LookupFn },
 ) {
@@ -228,25 +209,11 @@ describe("readRemoteMediaBuffer", () => {
 
   beforeEach(() => {
     vi.useRealTimers();
-    fetchWithSsrFGuardMock.mockReset().mockImplementation(async (paramsUnknown: unknown) => {
-      const params = paramsUnknown as {
-        url: string;
-        fetchImpl?: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
-        init?: RequestInit;
-      };
-      if (params.url.startsWith("http://127.0.0.1/")) {
-        throw new Error("Blocked hostname or private/internal/special-use IP address");
-      }
-      const fetcher = params.fetchImpl ?? globalThis.fetch;
-      if (!fetcher) {
-        throw new Error("fetch is not available");
-      }
-      return {
-        response: await fetcher(params.url, params.init),
-        finalUrl: params.url,
-        release: async () => {},
-      };
-    });
+    createHttp1ProxyAgentMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   afterAll(async () => {
@@ -498,22 +465,6 @@ describe("readRemoteMediaBuffer", () => {
     expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
 
-  it("does not retry SSRF guard blocks", async () => {
-    const fetchImpl = vi.fn();
-
-    await expect(
-      readRemoteMediaBuffer({
-        url: "http://127.0.0.1/secret.jpg",
-        fetchImpl,
-        lookupFn: makeLookupFn(),
-        maxBytes: 1024,
-        retry: { attempts: 3, minDelayMs: 0, maxDelayMs: 0, jitter: 0 },
-      }),
-    ).rejects.toThrow(/private|internal|blocked/i);
-    expect(fetchWithSsrFGuardMock).toHaveBeenCalledTimes(1);
-    expect(fetchImpl).not.toHaveBeenCalled();
-  });
-
   it("does not retry maxBytes failures", async () => {
     const fetchImpl = vi
       .fn()
@@ -546,69 +497,70 @@ describe("readRemoteMediaBuffer", () => {
           }),
       ),
     },
-    {
-      name: "blocks private IP literals before fetching",
-      kind: "private-ip-block" as const,
-    },
   ] as const)("$name", async (testCase) => {
-    if (testCase.kind === "private-ip-block") {
-      await expectPrivateIpFetchBlockedCase();
-      return;
-    }
-
     await expectBoundedErrorBodyCase(testCase.fetchImpl);
   });
 
-  it("uses trusted explicit-proxy mode when the caller opts in for proxy-side DNS", async () => {
-    const fetchImpl = vi.fn(async () => new Response("ok", { status: 200 }));
-    const lookupFn = makeLookupFn();
-    const dispatcherPolicy = {
-      mode: "explicit-proxy" as const,
-      proxyUrl: "http://localhost:8888",
-      allowPrivateProxy: true,
-    };
+  it("aborts native fetch setup when the request timeout expires", async () => {
+    vi.useFakeTimers();
+    try {
+      const fetchImpl = vi.fn(
+        (_input: RequestInfo | URL, init?: RequestInit) =>
+          new Promise<Response>((_resolve, reject) => {
+            init?.signal?.addEventListener("abort", () => {
+              reject(init.signal?.reason);
+            });
+          }),
+      );
 
-    await readRemoteMediaBuffer({
-      url: "https://files.example.test/file/bot123/photos/test.jpg",
-      fetchImpl,
-      lookupFn,
-      trustExplicitProxyDns: true,
-      dispatcherAttempts: [
-        {
-          dispatcherPolicy,
-        },
-      ],
-    });
+      const pending = readRemoteMediaBuffer({
+        url: "https://example.com/file.bin",
+        fetchImpl,
+        lookupFn: makeLookupFn(),
+        maxBytes: 1024,
+        timeoutMs: 1234,
+      });
+      const rejection = expect(pending).rejects.toThrow("Media fetch timed out after 1234ms");
 
-    expect(fetchWithSsrFGuardMock).toHaveBeenCalledTimes(1);
-    expect(requireFetchGuardRequest()).toStrictEqual({
-      url: "https://files.example.test/file/bot123/photos/test.jpg",
-      fetchImpl,
-      init: undefined,
-      maxRedirects: undefined,
-      policy: undefined,
-      lookupFn,
-      dispatcherPolicy,
-      mode: "trusted_explicit_proxy",
-    });
+      await vi.advanceTimersByTimeAsync(1234);
+      await rejection;
+      expect(fetchImpl).toHaveBeenCalledWith(
+        "https://example.com/file.bin",
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
-  it("passes request timeout through the guarded fetch path", async () => {
-    const fetchImpl = vi.fn(async () => new Response("ok", { status: 200 }));
+  it("passes explicit proxy transport through native fetch and closes it after reading", async () => {
+    const close = vi.fn(async () => undefined);
+    const dispatcher = { close };
+    createHttp1ProxyAgentMock.mockReturnValueOnce(dispatcher);
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(Buffer.from("proxied"), { status: 200 }));
 
-    await readRemoteMediaBuffer({
-      url: "https://example.com/file.bin",
-      fetchImpl,
-      lookupFn: makeLookupFn(),
+    const result = await readRemoteMediaBuffer({
+      url: "https://files.example.test/file.bin",
       maxBytes: 1024,
-      timeoutMs: 1234,
+      dispatcherPolicy: {
+        mode: "explicit-proxy",
+        proxyUrl: "http://127.0.0.1:8888",
+        allowPrivateProxy: true,
+      },
     });
 
-    expect(fetchWithSsrFGuardMock).toHaveBeenCalledTimes(1);
-    expect(requireFetchGuardRequest()).toMatchObject({
-      url: "https://example.com/file.bin",
-      timeoutMs: 1234,
-    });
+    expect(result.buffer).toStrictEqual(Buffer.from("proxied"));
+    expect(createHttp1ProxyAgentMock).toHaveBeenCalledWith(
+      { uri: "http://127.0.0.1:8888" },
+      undefined,
+    );
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://files.example.test/file.bin",
+      expect.objectContaining({ dispatcher }),
+    );
+    expect(close).toHaveBeenCalledTimes(1);
   });
 
   it("streams successful responses directly into the media store", async () => {
@@ -635,6 +587,26 @@ describe("readRemoteMediaBuffer", () => {
     expect(saved.path).toMatch(/[a-f0-9-]{36}\.png$/);
     expect(saved.path).not.toMatch(/photo---/);
     await expect(fs.readFile(saved.path)).resolves.toStrictEqual(Buffer.from([1, 2, 3, 4]));
+  });
+
+  it("uses the native response URL as the final media URL after redirects", async () => {
+    const redirectedResponse = new Response(makeStream([new Uint8Array([1, 2, 3])]), {
+      status: 200,
+      headers: { "content-type": "image/png" },
+    });
+    Object.defineProperty(redirectedResponse, "url", {
+      value: "https://cdn.example.com/files/photo.png",
+    });
+    const fetchImpl = vi.fn(async () => redirectedResponse);
+
+    const saved = await saveRemoteMedia({
+      url: "https://example.com/download",
+      fetchImpl,
+      lookupFn: makeLookupFn(),
+      maxBytes: 8,
+    });
+
+    expect(saved.fileName).toBe("photo.png");
   });
 
   it("clamps oversized saved-response idle timeout timers", async () => {

--- a/src/media/fetch.test.ts
+++ b/src/media/fetch.test.ts
@@ -808,6 +808,32 @@ describe("readRemoteMediaBuffer", () => {
     expect(fetchImpl).not.toHaveBeenCalled();
   });
 
+  it("cleans up request timeouts when dispatcher setup rejects before fetch", async () => {
+    vi.useFakeTimers();
+    try {
+      const fetchImpl = vi.fn(async () => new Response("should not fetch", { status: 200 }));
+      const lookupFn = vi.fn(async () => ({
+        address: "127.0.0.1",
+        family: 4,
+      })) as unknown as LookupFn;
+
+      await expect(
+        readRemoteMediaBuffer({
+          url: "https://cdn.example.com/secret.png",
+          fetchImpl,
+          lookupFn,
+          maxBytes: 1024,
+          timeoutMs: 5000,
+        }),
+      ).rejects.toThrow("resolves to private/internal/special-use IP address");
+
+      expect(fetchImpl).not.toHaveBeenCalled();
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("uses the managed env proxy dispatcher after DNS validation when proxy is active", async () => {
     vi.stubEnv("OPENCLAW_PROXY_ACTIVE", "1");
     vi.stubEnv("HTTPS_PROXY", "http://127.0.0.1:8888");

--- a/src/media/fetch.test.ts
+++ b/src/media/fetch.test.ts
@@ -533,6 +533,44 @@ describe("readRemoteMediaBuffer", () => {
     }
   });
 
+  it("keeps the request timeout active while reading the response body", async () => {
+    vi.useFakeTimers();
+    try {
+      const fetchImpl = vi.fn(
+        async (_input: RequestInfo | URL, init?: RequestInit) =>
+          new Response(
+            new ReadableStream<Uint8Array>({
+              start(controller) {
+                controller.enqueue(new Uint8Array([1]));
+                init?.signal?.addEventListener("abort", () => {
+                  controller.error(init.signal?.reason);
+                });
+              },
+            }),
+            { status: 200, headers: { "content-type": "application/octet-stream" } },
+          ),
+      );
+
+      const pending = readRemoteMediaBuffer({
+        url: "https://example.com/file.bin",
+        fetchImpl,
+        lookupFn: makeLookupFn(),
+        maxBytes: 1024,
+        timeoutMs: 25,
+      });
+      const rejection = expect(pending).rejects.toThrow("Media fetch timed out after 25ms");
+
+      await vi.advanceTimersByTimeAsync(25);
+      await rejection;
+      expect(fetchImpl).toHaveBeenCalledWith(
+        "https://example.com/file.bin",
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("passes explicit proxy transport through native fetch and closes it after reading", async () => {
     const close = vi.fn(async () => undefined);
     const dispatcher = { close };

--- a/src/media/fetch.test.ts
+++ b/src/media/fetch.test.ts
@@ -1,6 +1,11 @@
 // Media fetch tests cover remote media download limits and validation.
 import fs from "node:fs/promises";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  ensureGlobalUndiciStreamTimeouts,
+  resetGlobalUndiciStreamTimeoutsForTests,
+} from "../infra/net/undici-global-dispatcher.js";
+import { TEST_UNDICI_RUNTIME_DEPS_KEY } from "../infra/net/undici-runtime.js";
 import { MAX_TIMER_TIMEOUT_MS } from "../shared/number-coercion.js";
 import { createTempHomeEnv, type TempHomeEnv } from "../test-utils/temp-home.js";
 
@@ -227,6 +232,8 @@ describe("readRemoteMediaBuffer", () => {
   afterEach(() => {
     vi.restoreAllMocks();
     vi.unstubAllEnvs();
+    resetGlobalUndiciStreamTimeoutsForTests();
+    delete (globalThis as Record<string, unknown>)[TEST_UNDICI_RUNTIME_DEPS_KEY];
   });
 
   afterAll(async () => {
@@ -612,6 +619,41 @@ describe("readRemoteMediaBuffer", () => {
       expect.objectContaining({ dispatcher }),
     );
     expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it("inherits the configured global stream timeout for direct dispatchers", async () => {
+    const agentCtor = vi.fn(function MockAgent(this: { options: unknown }, options: unknown) {
+      this.options = options;
+    });
+    (globalThis as Record<string, unknown>)[TEST_UNDICI_RUNTIME_DEPS_KEY] = {
+      Agent: agentCtor,
+      EnvHttpProxyAgent: vi.fn(),
+      ProxyAgent: vi.fn(),
+      fetch: vi.fn(),
+    };
+    ensureGlobalUndiciStreamTimeouts({ timeoutMs: 1_900_000 });
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(Buffer.from("timed"), {
+          status: 200,
+          headers: { "content-type": "application/octet-stream" },
+        }),
+    );
+
+    const result = await readRemoteMediaBuffer({
+      url: "https://files.example.test/file.bin",
+      fetchImpl,
+      lookupFn: makeLookupFn(),
+      maxBytes: 1024,
+    });
+
+    expect(result.buffer).toStrictEqual(Buffer.from("timed"));
+    expect(agentCtor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        bodyTimeout: 1_900_000,
+        headersTimeout: 1_900_000,
+      }),
+    );
   });
 
   it("rejects private explicit proxy hosts unless allowPrivateProxy is set", async () => {

--- a/src/media/fetch.test.ts
+++ b/src/media/fetch.test.ts
@@ -607,6 +607,24 @@ describe("readRemoteMediaBuffer", () => {
     expect(close).toHaveBeenCalledTimes(1);
   });
 
+  it("rejects private explicit proxy hosts unless allowPrivateProxy is set", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockRejectedValueOnce(new Error("unexpected"));
+
+    await expect(
+      readRemoteMediaBuffer({
+        url: "https://files.example.test/file.bin",
+        maxBytes: 1024,
+        dispatcherPolicy: {
+          mode: "explicit-proxy",
+          proxyUrl: "http://127.0.0.1:8888",
+        },
+      }),
+    ).rejects.toThrow("Blocked hostname or private/internal/special-use IP address");
+
+    expect(createHttp1ProxyAgentMock).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
   it("rejects plain HTTP media targets through explicit proxies unless proxy DNS is trusted", async () => {
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockRejectedValueOnce(new Error("unexpected"));
 

--- a/src/media/fetch.test.ts
+++ b/src/media/fetch.test.ts
@@ -803,6 +803,32 @@ describe("readRemoteMediaBuffer", () => {
     });
   });
 
+  it("clamps oversized native media fetch timeout timers before scheduling", async () => {
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    try {
+      const fetchImpl = vi.fn(
+        async () =>
+          new Response(makeStream([new Uint8Array([1, 2, 3])]), {
+            status: 200,
+            headers: { "content-type": "application/octet-stream" },
+          }),
+      );
+
+      const result = await readRemoteMediaBuffer({
+        url: "https://example.com/file.bin",
+        fetchImpl,
+        lookupFn: makeLookupFn(),
+        maxBytes: 8,
+        timeoutMs: MAX_TIMER_TIMEOUT_MS + 1,
+      });
+
+      expect(result.buffer).toStrictEqual(Buffer.from([1, 2, 3]));
+      expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
+  });
+
   it("rejects media URLs outside the configured hostname allowlist before fetch", async () => {
     const fetchImpl = vi.fn(async () => new Response("should not fetch", { status: 200 }));
 

--- a/src/media/fetch.test.ts
+++ b/src/media/fetch.test.ts
@@ -528,7 +528,8 @@ describe("readRemoteMediaBuffer", () => {
         (_input: RequestInfo | URL, init?: RequestInit) =>
           new Promise<Response>((_resolve, reject) => {
             init?.signal?.addEventListener("abort", () => {
-              reject(init.signal?.reason);
+              const reason = init.signal?.reason;
+              reject(reason instanceof Error ? reason : new Error("request aborted"));
             });
           }),
       );

--- a/src/media/fetch.test.ts
+++ b/src/media/fetch.test.ts
@@ -745,28 +745,64 @@ describe("readRemoteMediaBuffer", () => {
     await expect(fs.readFile(saved.path)).resolves.toStrictEqual(Buffer.from([1, 2, 3, 4]));
   });
 
-  it("uses no-redirect fetch behavior and still derives names from the native response URL", async () => {
-    const redirectedResponse = new Response(makeStream([new Uint8Array([1, 2, 3])]), {
+  it("follows media redirects up to maxRedirects and derives names from the final URL", async () => {
+    const redirectResponse = new Response(null, {
+      status: 302,
+      headers: { location: "https://cdn.example.com/files/photo.png" },
+    });
+    const finalResponse = new Response(makeStream([new Uint8Array([1, 2, 3])]), {
       status: 200,
       headers: { "content-type": "image/png" },
     });
-    Object.defineProperty(redirectedResponse, "url", {
+    Object.defineProperty(finalResponse, "url", {
       value: "https://cdn.example.com/files/photo.png",
     });
-    const fetchImpl = vi.fn(async () => redirectedResponse);
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(redirectResponse)
+      .mockResolvedValueOnce(finalResponse);
 
     const saved = await saveRemoteMedia({
       url: "https://example.com/download",
       fetchImpl,
       lookupFn: makeLookupFn(),
       maxBytes: 8,
+      maxRedirects: 1,
     });
 
     expect(saved.fileName).toBe("photo.png");
-    expect(fetchImpl).toHaveBeenCalledWith(
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      1,
       "https://example.com/download",
-      expect.objectContaining({ redirect: "error" }),
+      expect.objectContaining({ redirect: "manual" }),
     );
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      2,
+      "https://cdn.example.com/files/photo.png",
+      expect.objectContaining({ redirect: "manual" }),
+    );
+  });
+
+  it("honors maxRedirects zero for media fetches", async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(null, {
+          status: 302,
+          headers: { location: "https://cdn.example.com/files/photo.png" },
+        }),
+    );
+
+    await expect(
+      saveRemoteMedia({
+        url: "https://example.com/download",
+        fetchImpl,
+        lookupFn: makeLookupFn(),
+        maxBytes: 8,
+        maxRedirects: 0,
+      }),
+    ).rejects.toThrow("Too many redirects (limit: 0)");
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
 
   it("captures native media fetches for debug proxy traces", async () => {

--- a/src/media/fetch.test.ts
+++ b/src/media/fetch.test.ts
@@ -627,7 +627,7 @@ describe("readRemoteMediaBuffer", () => {
     await expect(fs.readFile(saved.path)).resolves.toStrictEqual(Buffer.from([1, 2, 3, 4]));
   });
 
-  it("uses the native response URL as the final media URL after redirects", async () => {
+  it("uses no-redirect fetch behavior and still derives names from the native response URL", async () => {
     const redirectedResponse = new Response(makeStream([new Uint8Array([1, 2, 3])]), {
       status: 200,
       headers: { "content-type": "image/png" },
@@ -645,6 +645,10 @@ describe("readRemoteMediaBuffer", () => {
     });
 
     expect(saved.fileName).toBe("photo.png");
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://example.com/download",
+      expect.objectContaining({ redirect: "error" }),
+    );
   });
 
   it("rejects media URLs outside the configured hostname allowlist before fetch", async () => {

--- a/src/media/fetch.test.ts
+++ b/src/media/fetch.test.ts
@@ -662,6 +662,39 @@ describe("readRemoteMediaBuffer", () => {
     expect(fetchImpl).not.toHaveBeenCalled();
   });
 
+  it("rejects private media URL literals before fetch", async () => {
+    const fetchImpl = vi.fn(async () => new Response("should not fetch", { status: 200 }));
+
+    await expect(
+      readRemoteMediaBuffer({
+        url: "http://127.0.0.1/secret.png",
+        fetchImpl,
+        maxBytes: 1024,
+      }),
+    ).rejects.toThrow("Blocked hostname or private/internal/special-use IP address");
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("rejects media hostnames that resolve to private addresses before fetch", async () => {
+    const fetchImpl = vi.fn(async () => new Response("should not fetch", { status: 200 }));
+    const lookupFn = vi.fn(async () => ({
+      address: "127.0.0.1",
+      family: 4,
+    })) as unknown as LookupFn;
+
+    await expect(
+      readRemoteMediaBuffer({
+        url: "https://cdn.example.com/secret.png",
+        fetchImpl,
+        lookupFn,
+        maxBytes: 1024,
+      }),
+    ).rejects.toThrow("resolves to private/internal/special-use IP address");
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
   it("rejects native redirect results outside the configured hostname allowlist", async () => {
     const body = makeCancelableStream([new Uint8Array([1, 2, 3])]);
     const redirectedResponse = new Response(body.stream, {

--- a/src/media/fetch.test.ts
+++ b/src/media/fetch.test.ts
@@ -609,6 +609,45 @@ describe("readRemoteMediaBuffer", () => {
     expect(saved.fileName).toBe("photo.png");
   });
 
+  it("rejects media URLs outside the configured hostname allowlist before fetch", async () => {
+    const fetchImpl = vi.fn(async () => new Response("should not fetch", { status: 200 }));
+
+    await expect(
+      readRemoteMediaBuffer({
+        url: "https://example.com/file.bin",
+        fetchImpl,
+        maxBytes: 1024,
+        ssrfPolicy: { hostnameAllowlist: ["cdn.example.com", "*.assets.example.com"] },
+      }),
+    ).rejects.toThrow("Media URL hostname is not in allowlist: example.com");
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("rejects native redirect results outside the configured hostname allowlist", async () => {
+    const body = makeCancelableStream([new Uint8Array([1, 2, 3])]);
+    const redirectedResponse = new Response(body.stream, {
+      status: 200,
+      headers: { "content-type": "image/png" },
+    });
+    Object.defineProperty(redirectedResponse, "url", {
+      value: "https://example.com/files/photo.png",
+    });
+    const fetchImpl = vi.fn(async () => redirectedResponse);
+
+    await expect(
+      readRemoteMediaBuffer({
+        url: "https://cdn.example.com/download",
+        fetchImpl,
+        maxBytes: 1024,
+        ssrfPolicy: { hostnameAllowlist: ["cdn.example.com"] },
+      }),
+    ).rejects.toThrow("Media URL hostname is not in allowlist: example.com");
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(body.wasCanceled()).toBe(true);
+  });
+
   it("clamps oversized saved-response idle timeout timers", async () => {
     const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
     try {

--- a/src/media/fetch.test.ts
+++ b/src/media/fetch.test.ts
@@ -4,10 +4,12 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } 
 import { MAX_TIMER_TIMEOUT_MS } from "../shared/number-coercion.js";
 import { createTempHomeEnv, type TempHomeEnv } from "../test-utils/temp-home.js";
 
-const { createHttp1EnvHttpProxyAgentMock, createHttp1ProxyAgentMock } = vi.hoisted(() => ({
-  createHttp1EnvHttpProxyAgentMock: vi.fn(),
-  createHttp1ProxyAgentMock: vi.fn(),
-}));
+const { captureHttpExchangeMock, createHttp1EnvHttpProxyAgentMock, createHttp1ProxyAgentMock } =
+  vi.hoisted(() => ({
+    captureHttpExchangeMock: vi.fn(),
+    createHttp1EnvHttpProxyAgentMock: vi.fn(),
+    createHttp1ProxyAgentMock: vi.fn(),
+  }));
 
 vi.mock("../infra/net/undici-runtime.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../infra/net/undici-runtime.js")>();
@@ -17,6 +19,10 @@ vi.mock("../infra/net/undici-runtime.js", async (importOriginal) => {
     createHttp1ProxyAgent: createHttp1ProxyAgentMock,
   };
 });
+
+vi.mock("../proxy-capture/runtime.js", () => ({
+  captureHttpExchange: captureHttpExchangeMock,
+}));
 
 type FetchModule = typeof import("./fetch.js");
 type ReadRemoteMediaBuffer = FetchModule["readRemoteMediaBuffer"];
@@ -213,6 +219,7 @@ describe("readRemoteMediaBuffer", () => {
 
   beforeEach(() => {
     vi.useRealTimers();
+    captureHttpExchangeMock.mockReset();
     createHttp1EnvHttpProxyAgentMock.mockReset();
     createHttp1ProxyAgentMock.mockReset();
   });
@@ -717,6 +724,40 @@ describe("readRemoteMediaBuffer", () => {
       "https://example.com/download",
       expect.objectContaining({ redirect: "error" }),
     );
+  });
+
+  it("captures native media fetches for debug proxy traces", async () => {
+    const response = new Response(Buffer.from("captured"), {
+      status: 200,
+      headers: { "content-type": "application/octet-stream" },
+    });
+    const fetchImpl = vi.fn(async () => response);
+
+    const result = await readRemoteMediaBuffer({
+      url: "https://cdn.example.com/file.bin",
+      fetchImpl,
+      lookupFn: makeLookupFn(),
+      maxBytes: 1024,
+      requestInit: {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: '{"id":1}',
+      },
+    });
+
+    expect(result.buffer).toStrictEqual(Buffer.from("captured"));
+    const capture = captureHttpExchangeMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(capture).toMatchObject({
+      url: "https://cdn.example.com/file.bin",
+      method: "POST",
+      requestHeaders: { "content-type": "application/json" },
+      requestBody: '{"id":1}',
+      response,
+      transport: "http",
+      meta: {
+        captureOrigin: "media-fetch",
+      },
+    });
   });
 
   it("rejects media URLs outside the configured hostname allowlist before fetch", async () => {

--- a/src/media/fetch.test.ts
+++ b/src/media/fetch.test.ts
@@ -622,6 +622,58 @@ describe("readRemoteMediaBuffer", () => {
     expect(close).toHaveBeenCalledTimes(1);
   });
 
+  it("routes ambient global fetchImpl through the runtime dispatcher path", async () => {
+    const runtimeFetch = vi.fn(
+      async () =>
+        new Response(Buffer.from("runtime"), {
+          status: 200,
+          headers: { "content-type": "application/octet-stream" },
+        }),
+    );
+    const originalGlobalFetch = globalThis.fetch;
+    let ambientFetchCalls = 0;
+    const ambientFetch = async () => {
+      ambientFetchCalls += 1;
+      throw new Error("ambient global fetch should not be called");
+    };
+
+    class MockAgent {
+      constructor(readonly options: unknown) {}
+    }
+    class MockEnvHttpProxyAgent {
+      constructor(readonly options: unknown) {}
+    }
+    class MockProxyAgent {
+      constructor(readonly options: unknown) {}
+    }
+
+    (globalThis as Record<string, unknown>).fetch = ambientFetch as typeof fetch;
+    (globalThis as Record<string, unknown>)[TEST_UNDICI_RUNTIME_DEPS_KEY] = {
+      Agent: MockAgent,
+      EnvHttpProxyAgent: MockEnvHttpProxyAgent,
+      ProxyAgent: MockProxyAgent,
+      fetch: runtimeFetch,
+    };
+
+    try {
+      const result = await readRemoteMediaBuffer({
+        url: "https://files.example.test/file.bin",
+        fetchImpl: globalThis.fetch,
+        lookupFn: makeLookupFn(),
+        maxBytes: 1024,
+      });
+
+      expect(result.buffer).toStrictEqual(Buffer.from("runtime"));
+      expect(ambientFetchCalls).toBe(0);
+      expect(runtimeFetch).toHaveBeenCalledWith(
+        "https://files.example.test/file.bin",
+        expect.objectContaining({ dispatcher: expect.any(MockAgent) }),
+      );
+    } finally {
+      (globalThis as Record<string, unknown>).fetch = originalGlobalFetch;
+    }
+  });
+
   it("inherits the configured global stream timeout for direct dispatchers", async () => {
     const agentCtor = vi.fn(function MockAgent(this: { options: unknown }, options: unknown) {
       this.options = options;

--- a/src/media/fetch.test.ts
+++ b/src/media/fetch.test.ts
@@ -4,12 +4,16 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } 
 import { MAX_TIMER_TIMEOUT_MS } from "../shared/number-coercion.js";
 import { createTempHomeEnv, type TempHomeEnv } from "../test-utils/temp-home.js";
 
-const createHttp1ProxyAgentMock = vi.hoisted(() => vi.fn());
+const { createHttp1EnvHttpProxyAgentMock, createHttp1ProxyAgentMock } = vi.hoisted(() => ({
+  createHttp1EnvHttpProxyAgentMock: vi.fn(),
+  createHttp1ProxyAgentMock: vi.fn(),
+}));
 
 vi.mock("../infra/net/undici-runtime.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../infra/net/undici-runtime.js")>();
   return {
     ...actual,
+    createHttp1EnvHttpProxyAgent: createHttp1EnvHttpProxyAgentMock,
     createHttp1ProxyAgent: createHttp1ProxyAgentMock,
   };
 });
@@ -209,11 +213,13 @@ describe("readRemoteMediaBuffer", () => {
 
   beforeEach(() => {
     vi.useRealTimers();
+    createHttp1EnvHttpProxyAgentMock.mockReset();
     createHttp1ProxyAgentMock.mockReset();
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllEnvs();
   });
 
   afterAll(async () => {
@@ -697,6 +703,38 @@ describe("readRemoteMediaBuffer", () => {
     ).rejects.toThrow("resolves to private/internal/special-use IP address");
 
     expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("uses the managed env proxy dispatcher after DNS validation when proxy is active", async () => {
+    vi.stubEnv("OPENCLAW_PROXY_ACTIVE", "1");
+    vi.stubEnv("HTTPS_PROXY", "http://127.0.0.1:8888");
+    const close = vi.fn(async () => undefined);
+    const dispatcher = { close };
+    createHttp1EnvHttpProxyAgentMock.mockReturnValueOnce(dispatcher);
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(Buffer.from("proxied"), {
+          status: 200,
+          headers: { "content-type": "application/octet-stream" },
+        }),
+    );
+    const lookupFn = makeLookupFn();
+
+    const result = await readRemoteMediaBuffer({
+      url: "https://cdn.example.com/file.bin",
+      fetchImpl,
+      lookupFn,
+      maxBytes: 1024,
+    });
+
+    expect(result.buffer).toStrictEqual(Buffer.from("proxied"));
+    expect(lookupFn).toHaveBeenCalled();
+    expect(createHttp1EnvHttpProxyAgentMock).toHaveBeenCalledWith(undefined, undefined);
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://cdn.example.com/file.bin",
+      expect.objectContaining({ dispatcher }),
+    );
+    expect(close).toHaveBeenCalledTimes(1);
   });
 
   it("rejects native redirect results outside the configured hostname allowlist", async () => {

--- a/src/media/fetch.test.ts
+++ b/src/media/fetch.test.ts
@@ -607,6 +607,27 @@ describe("readRemoteMediaBuffer", () => {
     expect(close).toHaveBeenCalledTimes(1);
   });
 
+  it("rejects plain HTTP media targets through explicit proxies unless proxy DNS is trusted", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockRejectedValueOnce(new Error("unexpected"));
+
+    await expect(
+      readRemoteMediaBuffer({
+        url: "http://files.example.test/file.bin",
+        maxBytes: 1024,
+        dispatcherPolicy: {
+          mode: "explicit-proxy",
+          proxyUrl: "http://127.0.0.1:8888",
+          allowPrivateProxy: true,
+        },
+      }),
+    ).rejects.toThrow(
+      "Explicit proxy SSRF pinning requires HTTPS targets; plain HTTP targets are not supported",
+    );
+
+    expect(createHttp1ProxyAgentMock).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
   it("streams successful responses directly into the media store", async () => {
     const fetchImpl = vi.fn(
       async () =>

--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -308,7 +308,13 @@ async function fetchNativeMediaAttempt(
     timeoutMs,
   });
   const dispatcher = createMediaFetchDispatcher(attempt.dispatcherPolicy, timeoutMs);
+  let released = false;
   const release = async () => {
+    if (released) {
+      return;
+    }
+    released = true;
+    signal.cleanup();
     await closeDispatcher(dispatcher);
   };
   const init: DispatcherAwareRequestInit = {
@@ -337,8 +343,6 @@ async function fetchNativeMediaAttempt(
   } catch (err) {
     await release();
     throw err;
-  } finally {
-    signal.cleanup();
   }
 }
 

--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -392,15 +392,7 @@ async function fetchNativeMediaAttempt(
     requestSignal: requestInit?.signal,
     timeoutMs,
   });
-  const dispatcher = await createMediaFetchDispatcher({
-    url: parsedRequestUrl,
-    attempt,
-    fetchImpl,
-    lookupFn,
-    ssrfPolicy,
-    timeoutMs,
-    trustExplicitProxyDns,
-  });
+  let dispatcher: Dispatcher | null = null;
   let released = false;
   const release = async () => {
     if (released) {
@@ -410,16 +402,25 @@ async function fetchNativeMediaAttempt(
     signal.cleanup();
     await closeDispatcher(dispatcher);
   };
-  const init: DispatcherAwareRequestInit = {
-    ...requestInit,
-    ...(signal.signal ? { signal: signal.signal } : {}),
-    ...(dispatcher ? { dispatcher } : {}),
-    redirect:
-      requestInit?.redirect === "manual" || requestInit?.redirect === "error"
-        ? requestInit.redirect
-        : "error",
-  };
   try {
+    dispatcher = await createMediaFetchDispatcher({
+      url: parsedRequestUrl,
+      attempt,
+      fetchImpl,
+      lookupFn,
+      ssrfPolicy,
+      timeoutMs,
+      trustExplicitProxyDns,
+    });
+    const init: DispatcherAwareRequestInit = {
+      ...requestInit,
+      ...(signal.signal ? { signal: signal.signal } : {}),
+      ...(dispatcher ? { dispatcher } : {}),
+      redirect:
+        requestInit?.redirect === "manual" || requestInit?.redirect === "error"
+          ? requestInit.redirect
+          : "error",
+    };
     const response = fetchImpl
       ? await fetchImpl(requestUrl, init)
       : await fetchWithRuntimeDispatcherOrMockedGlobal(requestUrl, init);

--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -325,24 +325,26 @@ async function createMediaFetchDispatcher(params: {
   url: URL;
   attempt: FetchDispatcherAttempt;
   fetchImpl: FetchLike | undefined;
+  lookupFn: LookupFn | undefined;
   ssrfPolicy: SsrFPolicy | undefined;
   timeoutMs: number | undefined;
   trustExplicitProxyDns: boolean | undefined;
 }): Promise<Dispatcher | null> {
-  const { attempt, fetchImpl, timeoutMs, trustExplicitProxyDns } = params;
+  const { attempt, fetchImpl, lookupFn, timeoutMs, trustExplicitProxyDns } = params;
+  const resolvedLookupFn = attempt.lookupFn ?? lookupFn;
   const dispatcherPolicy = attempt.dispatcherPolicy;
   if (dispatcherPolicy?.mode === "explicit-proxy" && trustExplicitProxyDns === true) {
     return createMediaFetchDispatcherWithoutPinnedDns(dispatcherPolicy, timeoutMs);
   }
   assertExplicitProxySupportsMediaTarget(params.url, dispatcherPolicy);
   const resolvedFetch = fetchImpl ?? globalThis.fetch;
-  const canUsePinnedDns = attempt.lookupFn !== undefined || !isMockedFetch(resolvedFetch);
+  const canUsePinnedDns = resolvedLookupFn !== undefined || !isMockedFetch(resolvedFetch);
   if (!canUsePinnedDns) {
     return createMediaFetchDispatcherWithoutPinnedDns(dispatcherPolicy, timeoutMs);
   }
   const policyForUrl = resolveSsrFPolicyForUrl(params.url, params.ssrfPolicy);
   const pinned = await resolvePinnedHostnameWithPolicy(params.url.hostname, {
-    lookupFn: attempt.lookupFn,
+    lookupFn: resolvedLookupFn,
     policy: policyForUrl,
   });
   if (shouldUseManagedEnvProxyForUrl(params.url.toString())) {
@@ -355,7 +357,8 @@ async function fetchNativeMediaAttempt(
   options: FetchMediaOptions,
   attempt: FetchDispatcherAttempt,
 ): Promise<NativeMediaResponse> {
-  const { url, fetchImpl, requestInit, timeoutMs, ssrfPolicy, trustExplicitProxyDns } = options;
+  const { url, fetchImpl, requestInit, timeoutMs, ssrfPolicy, lookupFn, trustExplicitProxyDns } =
+    options;
   const requestUrl = assertMediaUrlAllowedByPolicy(url, ssrfPolicy);
   const parsedRequestUrl = new URL(requestUrl);
   const signal = resolveFetchSignal({
@@ -366,6 +369,7 @@ async function fetchNativeMediaAttempt(
     url: parsedRequestUrl,
     attempt,
     fetchImpl,
+    lookupFn,
     ssrfPolicy,
     timeoutMs,
     trustExplicitProxyDns,

--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -17,6 +17,7 @@ import {
   type DispatcherAwareRequestInit,
 } from "../infra/net/runtime-fetch.js";
 import {
+  assertExplicitProxyAllowedWithPolicy,
   assertHostnameAllowedWithPolicy,
   closeDispatcher,
   createPinnedDispatcher,
@@ -333,6 +334,10 @@ async function createMediaFetchDispatcher(params: {
   const { attempt, fetchImpl, lookupFn, timeoutMs, trustExplicitProxyDns } = params;
   const resolvedLookupFn = attempt.lookupFn ?? lookupFn;
   const dispatcherPolicy = attempt.dispatcherPolicy;
+  await assertExplicitProxyAllowedWithPolicy(dispatcherPolicy, {
+    lookupFn: resolvedLookupFn,
+    policy: params.ssrfPolicy,
+  });
   if (dispatcherPolicy?.mode === "explicit-proxy" && trustExplicitProxyDns === true) {
     return createMediaFetchDispatcherWithoutPinnedDns(dispatcherPolicy, timeoutMs);
   }

--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -29,6 +29,7 @@ import {
   type PinnedDispatcherPolicy,
   type SsrFPolicy,
 } from "../infra/net/ssrf.js";
+import { globalUndiciStreamTimeoutMs } from "../infra/net/undici-global-dispatcher.js";
 import {
   createHttp1Agent,
   createHttp1EnvHttpProxyAgent,
@@ -43,6 +44,10 @@ import { saveMediaBuffer, saveMediaStream, type SavedMedia } from "./store.js";
 
 /** Default remote media fetch cap shared by buffer reads and store writes. */
 export const DEFAULT_FETCH_MEDIA_MAX_BYTES = MAX_DOCUMENT_BYTES;
+
+function resolveDispatcherTimeoutMs(timeoutMs: number | undefined): number | undefined {
+  return timeoutMs ?? globalUndiciStreamTimeoutMs;
+}
 
 /** Remote media bytes plus metadata before they are persisted to the media store. */
 type FetchMediaResult = {
@@ -353,7 +358,8 @@ async function createMediaFetchDispatcher(params: {
   timeoutMs: number | undefined;
   trustExplicitProxyDns: boolean | undefined;
 }): Promise<Dispatcher | null> {
-  const { attempt, fetchImpl, lookupFn, timeoutMs, trustExplicitProxyDns } = params;
+  const { attempt, fetchImpl, lookupFn, trustExplicitProxyDns } = params;
+  const timeoutMs = resolveDispatcherTimeoutMs(params.timeoutMs);
   const resolvedLookupFn = attempt.lookupFn ?? lookupFn;
   const dispatcherPolicy = attempt.dispatcherPolicy;
   await assertExplicitProxyAllowedWithPolicy(dispatcherPolicy, {

--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -385,7 +385,7 @@ function rewriteMediaRedirectInitForMethod(params: {
   }
   const method = init.method?.toUpperCase() ?? "GET";
   const shouldRewriteToGet =
-    params.status === 303 ||
+    (params.status === 303 && method !== "HEAD") ||
     ((params.status === 301 || params.status === 302) && method === "POST");
   if (!shouldRewriteToGet) {
     return init;

--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -7,13 +7,23 @@ import {
   readResponseTextSnippet,
   readResponseWithLimit,
 } from "@openclaw/media-core/read-response-with-limit";
+import type { Dispatcher } from "undici";
 import { formatErrorMessage } from "../infra/errors.js";
 import {
-  fetchWithSsrFGuard,
-  withStrictGuardedFetchMode,
-  withTrustedExplicitProxyGuardedFetchMode,
-} from "../infra/net/fetch-guard.js";
-import type { LookupFn, PinnedDispatcherPolicy, SsrFPolicy } from "../infra/net/ssrf.js";
+  closeDispatcher,
+  type LookupFn,
+  type PinnedDispatcherPolicy,
+  type SsrFPolicy,
+} from "../infra/net/ssrf.js";
+import {
+  fetchWithRuntimeDispatcherOrMockedGlobal,
+  type DispatcherAwareRequestInit,
+} from "../infra/net/runtime-fetch.js";
+import {
+  createHttp1Agent,
+  createHttp1EnvHttpProxyAgent,
+  createHttp1ProxyAgent,
+} from "../infra/net/undici-runtime.js";
 import { retryAsync, type RetryOptions } from "../infra/retry.js";
 import { isAbortError, isTransientNetworkError } from "../infra/unhandled-rejections.js";
 import { redactSensitiveText } from "../logging/redact.js";
@@ -38,7 +48,7 @@ export type SavedRemoteMedia = SavedMedia & {
 /** Closed error classes callers can use for retry and diagnostic policy. */
 export type MediaFetchErrorCode = "max_bytes" | "http_error" | "fetch_failed";
 
-/** Retry policy applied around the complete guarded fetch and body read/save operation. */
+/** Retry policy applied around the complete fetch and body read/save operation. */
 export type MediaFetchRetryOptions = RetryOptions;
 
 /** Structured fetch error used for retry decisions and caller-facing diagnostics. */
@@ -58,10 +68,10 @@ export class MediaFetchError extends Error {
   }
 }
 
-/** Fetch-compatible injection point used by tests and guarded network callers. */
+/** Fetch-compatible injection point used by tests and network callers. */
 export type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
 
-/** Alternate dispatcher/lookup pair tried inside a single guarded fetch attempt. */
+/** Deprecated dispatcher/lookup pair retained for existing media option callers. */
 export type FetchDispatcherAttempt = {
   dispatcherPolicy?: PinnedDispatcherPolicy;
   lookupFn?: LookupFn;
@@ -74,7 +84,7 @@ type FetchMediaOptions = {
   filePathHint?: string;
   maxBytes?: number;
   maxRedirects?: number;
-  /** Abort the guarded fetch request if it has not completed by this deadline (ms). */
+  /** Abort the fetch request if it has not completed by this deadline (ms). */
   timeoutMs?: number;
   /** Abort if the response body stops yielding data for this long (ms). */
   readIdleTimeoutMs?: number;
@@ -84,8 +94,7 @@ type FetchMediaOptions = {
   dispatcherAttempts?: FetchDispatcherAttempt[];
   shouldRetryFetchError?: (error: unknown) => boolean;
   /**
-   * Retries the complete guarded fetch/read-or-save operation. Dispatcher
-   * attempts still run inside each retry attempt.
+   * Retries the complete fetch/read-or-save operation.
    */
   retry?: MediaFetchRetryOptions;
   /**
@@ -106,17 +115,17 @@ export type SaveResponseMediaOptions = {
   originalFilename?: string;
 };
 
-/** Options for guarded URL fetches that are saved directly into the media store. */
+/** Options for URL fetches that are saved directly into the media store. */
 export type SaveRemoteMediaOptions = FetchMediaOptions & {
   fallbackContentType?: string;
   subdir?: string;
   originalFilename?: string;
 };
 
-type GuardedMediaResponse = {
+type NativeMediaResponse = {
   response: Response;
   finalUrl: string;
-  release: (() => Promise<void>) | null;
+  release: () => Promise<void>;
   sourceUrl: string;
 };
 
@@ -179,51 +188,149 @@ function redactMediaUrl(url: string): string {
   return redactSensitiveText(url);
 }
 
-async function fetchGuardedMediaResponse(
+function unrefTimer(timeout: ReturnType<typeof setTimeout>): void {
+  if (typeof timeout === "object" && "unref" in timeout) {
+    timeout.unref();
+  }
+}
+
+function resolveFetchSignal(params: {
+  requestSignal?: AbortSignal | null;
+  timeoutMs?: number;
+}): {
+  signal?: AbortSignal;
+  cleanup: () => void;
+} {
+  const { requestSignal, timeoutMs } = params;
+  if (timeoutMs === undefined) {
+    return { ...(requestSignal ? { signal: requestSignal } : {}), cleanup: () => {} };
+  }
+
+  const controller = new AbortController();
+  const timeoutError = new Error(`Media fetch timed out after ${timeoutMs}ms`);
+  const timeout = setTimeout(() => {
+    controller.abort(timeoutError);
+  }, timeoutMs);
+  unrefTimer(timeout);
+
+  let removeAbortListener: (() => void) | undefined;
+  if (requestSignal) {
+    if (typeof AbortSignal.any === "function") {
+      return {
+        signal: AbortSignal.any([requestSignal, controller.signal]),
+        cleanup: () => clearTimeout(timeout),
+      };
+    }
+    const abortFromRequest = () => {
+      controller.abort(requestSignal.reason);
+    };
+    if (requestSignal.aborted) {
+      abortFromRequest();
+    } else {
+      requestSignal.addEventListener("abort", abortFromRequest, { once: true });
+      removeAbortListener = () => {
+        requestSignal.removeEventListener("abort", abortFromRequest);
+      };
+    }
+  }
+
+  return {
+    signal: controller.signal,
+    cleanup: () => {
+      clearTimeout(timeout);
+      removeAbortListener?.();
+    },
+  };
+}
+
+function createMediaFetchDispatcher(
+  dispatcherPolicy: PinnedDispatcherPolicy | undefined,
+  timeoutMs: number | undefined,
+): Dispatcher | null {
+  if (dispatcherPolicy?.mode === "direct") {
+    return createHttp1Agent(
+      dispatcherPolicy.connect ? { connect: { ...dispatcherPolicy.connect } } : undefined,
+      timeoutMs,
+    );
+  }
+  if (dispatcherPolicy?.mode === "env-proxy") {
+    return createHttp1EnvHttpProxyAgent(
+      {
+        ...(dispatcherPolicy.connect ? { connect: { ...dispatcherPolicy.connect } } : {}),
+        ...(dispatcherPolicy.proxyTls ? { proxyTls: { ...dispatcherPolicy.proxyTls } } : {}),
+      },
+      timeoutMs,
+    );
+  }
+  if (dispatcherPolicy?.mode === "explicit-proxy") {
+    const proxyUrl = dispatcherPolicy.proxyUrl.trim();
+    return dispatcherPolicy.proxyTls
+      ? createHttp1ProxyAgent(
+          { uri: proxyUrl, requestTls: { ...dispatcherPolicy.proxyTls } },
+          timeoutMs,
+        )
+      : createHttp1ProxyAgent({ uri: proxyUrl }, timeoutMs);
+  }
+  return null;
+}
+
+async function fetchNativeMediaAttempt(
   options: FetchMediaOptions,
-): Promise<GuardedMediaResponse> {
+  attempt: FetchDispatcherAttempt,
+): Promise<NativeMediaResponse> {
+  const { url, fetchImpl, requestInit, maxRedirects, timeoutMs } = options;
+  const signal = resolveFetchSignal({
+    requestSignal: requestInit?.signal,
+    timeoutMs,
+  });
+  const dispatcher = createMediaFetchDispatcher(attempt.dispatcherPolicy, timeoutMs);
+  const release = async () => {
+    await closeDispatcher(dispatcher);
+  };
+  const init: DispatcherAwareRequestInit = {
+    ...requestInit,
+    ...(signal.signal ? { signal: signal.signal } : {}),
+    ...(dispatcher ? { dispatcher } : {}),
+    ...(maxRedirects === 0 && requestInit?.redirect === undefined ? { redirect: "error" } : {}),
+  };
+  try {
+    const response = fetchImpl
+      ? await fetchImpl(url, init)
+      : await fetchWithRuntimeDispatcherOrMockedGlobal(url, init);
+    return {
+      response,
+      finalUrl: response.url || url,
+      release,
+      sourceUrl: redactMediaUrl(url),
+    };
+  } catch (err) {
+    await release();
+    throw err;
+  } finally {
+    signal.cleanup();
+  }
+}
+
+async function fetchNativeMediaResponse(
+  options: FetchMediaOptions,
+): Promise<NativeMediaResponse> {
   const {
     url,
-    fetchImpl,
-    requestInit,
-    maxRedirects,
-    timeoutMs,
-    ssrfPolicy,
-    lookupFn,
     dispatcherPolicy,
     dispatcherAttempts,
+    lookupFn,
     shouldRetryFetchError,
-    trustExplicitProxyDns,
   } = options;
   const sourceUrl = redactMediaUrl(url);
-
-  // Dispatcher attempts are fallback routes inside one logical guarded fetch operation.
   const attempts =
     dispatcherAttempts && dispatcherAttempts.length > 0
       ? dispatcherAttempts
       : [{ dispatcherPolicy, lookupFn }];
-  const runGuardedFetch = async (attempt: FetchDispatcherAttempt) =>
-    await fetchWithSsrFGuard(
-      (trustExplicitProxyDns && attempt.dispatcherPolicy?.mode === "explicit-proxy"
-        ? withTrustedExplicitProxyGuardedFetchMode
-        : withStrictGuardedFetchMode)({
-        url,
-        fetchImpl,
-        init: requestInit,
-        maxRedirects,
-        ...(timeoutMs !== undefined ? { timeoutMs } : {}),
-        policy: ssrfPolicy,
-        lookupFn: attempt.lookupFn ?? lookupFn,
-        dispatcherPolicy: attempt.dispatcherPolicy,
-      }),
-    );
   try {
-    let result!: Awaited<ReturnType<typeof fetchWithSsrFGuard>>;
     const attemptErrors: unknown[] = [];
     for (let i = 0; i < attempts.length; i += 1) {
       try {
-        result = await runGuardedFetch(attempts[i]);
-        break;
+        return await fetchNativeMediaAttempt(options, attempts[i]);
       } catch (err) {
         if (
           typeof shouldRetryFetchError !== "function" ||
@@ -252,12 +359,6 @@ async function fetchGuardedMediaResponse(
         attemptErrors.push(err);
       }
     }
-    return {
-      response: result.response,
-      finalUrl: result.finalUrl,
-      release: result.release,
-      sourceUrl,
-    };
   } catch (err) {
     throw new MediaFetchError(
       "fetch_failed",
@@ -267,6 +368,7 @@ async function fetchGuardedMediaResponse(
       },
     );
   }
+  throw new MediaFetchError("fetch_failed", `Failed to fetch media from ${sourceUrl}`);
 }
 
 async function assertMediaResponseOk(params: {
@@ -594,13 +696,13 @@ export async function saveResponseMedia(
   });
 }
 
-/** Fetches media through SSRF guards and saves the body into the media store. */
+/** Fetches media and saves the body into the media store. */
 export async function saveRemoteMedia(options: SaveRemoteMediaOptions): Promise<SavedRemoteMedia> {
   return await withMediaFetchRetry(options, () => saveRemoteMediaOnce(options));
 }
 
 async function saveRemoteMediaOnce(options: SaveRemoteMediaOptions): Promise<SavedRemoteMedia> {
-  const { response: res, finalUrl, release, sourceUrl } = await fetchGuardedMediaResponse(options);
+  const { response: res, finalUrl, sourceUrl, release } = await fetchNativeMediaResponse(options);
   try {
     await assertMediaResponseOk({
       res,
@@ -621,13 +723,11 @@ async function saveRemoteMediaOnce(options: SaveRemoteMediaOptions): Promise<Sav
       originalFilename: options.originalFilename,
     });
   } finally {
-    if (release) {
-      await release();
-    }
+    await release();
   }
 }
 
-/** Fetches media through SSRF guards and returns the bounded response body as a buffer. */
+/** Fetches media and returns the bounded response body as a buffer. */
 export async function readRemoteMediaBuffer(options: FetchMediaOptions): Promise<FetchMediaResult> {
   return await withMediaFetchRetry(options, () => readRemoteMediaBufferOnce(options));
 }
@@ -636,8 +736,7 @@ export async function readRemoteMediaBuffer(options: FetchMediaOptions): Promise
 export const fetchRemoteMedia = readRemoteMediaBuffer;
 
 async function readRemoteMediaBufferOnce(options: FetchMediaOptions): Promise<FetchMediaResult> {
-  const { response: res, finalUrl, release, sourceUrl } = await fetchGuardedMediaResponse(options);
-
+  const { response: res, finalUrl, sourceUrl, release } = await fetchNativeMediaResponse(options);
   try {
     await assertMediaResponseOk({
       res,
@@ -695,9 +794,7 @@ async function readRemoteMediaBufferOnce(options: FetchMediaOptions): Promise<Fe
       fileName,
     };
   } finally {
-    if (release) {
-      await release();
-    }
+    await release();
   }
 }
 

--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -318,8 +318,8 @@ async function createMediaFetchDispatcher(params: {
   if (dispatcherPolicy?.mode === "explicit-proxy" && trustExplicitProxyDns === true) {
     return createMediaFetchDispatcherWithoutPinnedDns(dispatcherPolicy, timeoutMs);
   }
-  const canUsePinnedDns =
-    attempt.lookupFn !== undefined || (fetchImpl === undefined && !isMockedFetch(globalThis.fetch));
+  const resolvedFetch = fetchImpl ?? globalThis.fetch;
+  const canUsePinnedDns = attempt.lookupFn !== undefined || !isMockedFetch(resolvedFetch);
   if (!canUsePinnedDns) {
     return createMediaFetchDispatcherWithoutPinnedDns(dispatcherPolicy, timeoutMs);
   }

--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -335,15 +335,7 @@ async function fetchNativeMediaAttempt(
   options: FetchMediaOptions,
   attempt: FetchDispatcherAttempt,
 ): Promise<NativeMediaResponse> {
-  const {
-    url,
-    fetchImpl,
-    requestInit,
-    maxRedirects,
-    timeoutMs,
-    ssrfPolicy,
-    trustExplicitProxyDns,
-  } = options;
+  const { url, fetchImpl, requestInit, timeoutMs, ssrfPolicy, trustExplicitProxyDns } = options;
   const requestUrl = assertMediaUrlAllowedByPolicy(url, ssrfPolicy);
   const parsedRequestUrl = new URL(requestUrl);
   const signal = resolveFetchSignal({
@@ -371,7 +363,10 @@ async function fetchNativeMediaAttempt(
     ...requestInit,
     ...(signal.signal ? { signal: signal.signal } : {}),
     ...(dispatcher ? { dispatcher } : {}),
-    ...(maxRedirects === 0 && requestInit?.redirect === undefined ? { redirect: "error" } : {}),
+    redirect:
+      requestInit?.redirect === "manual" || requestInit?.redirect === "error"
+        ? requestInit.redirect
+        : "error",
   };
   try {
     const response = fetchImpl

--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -12,12 +12,16 @@ import { formatErrorMessage } from "../infra/errors.js";
 import { normalizeHostname } from "../infra/net/hostname.js";
 import {
   fetchWithRuntimeDispatcherOrMockedGlobal,
+  isMockedFetch,
   type DispatcherAwareRequestInit,
 } from "../infra/net/runtime-fetch.js";
 import {
+  assertHostnameAllowedWithPolicy,
   closeDispatcher,
+  createPinnedDispatcher,
   matchesHostnameAllowlist,
   normalizeHostnameAllowlist,
+  resolvePinnedHostnameWithPolicy,
   resolveSsrFPolicyForUrl,
   type LookupFn,
   type PinnedDispatcherPolicy,
@@ -211,6 +215,10 @@ function assertMediaUrlAllowedByPolicy(rawUrl: string, policy?: SsrFPolicy): str
       throw new Error(`Media URL hostname is not in allowlist: ${parsed.hostname}`);
     }
   }
+  assertHostnameAllowedWithPolicy(parsed.hostname, {
+    ...policyForUrl,
+    hostnameAllowlist: undefined,
+  });
   return parsed.toString();
 }
 
@@ -266,7 +274,7 @@ function resolveFetchSignal(params: { requestSignal?: AbortSignal | null; timeou
   };
 }
 
-function createMediaFetchDispatcher(
+function createMediaFetchDispatcherWithoutPinnedDns(
   dispatcherPolicy: PinnedDispatcherPolicy | undefined,
   timeoutMs: number | undefined,
 ): Dispatcher | null {
@@ -297,17 +305,59 @@ function createMediaFetchDispatcher(
   return null;
 }
 
+async function createMediaFetchDispatcher(params: {
+  url: URL;
+  attempt: FetchDispatcherAttempt;
+  fetchImpl: FetchLike | undefined;
+  ssrfPolicy: SsrFPolicy | undefined;
+  timeoutMs: number | undefined;
+  trustExplicitProxyDns: boolean | undefined;
+}): Promise<Dispatcher | null> {
+  const { attempt, fetchImpl, timeoutMs, trustExplicitProxyDns } = params;
+  const dispatcherPolicy = attempt.dispatcherPolicy;
+  if (dispatcherPolicy?.mode === "explicit-proxy" && trustExplicitProxyDns === true) {
+    return createMediaFetchDispatcherWithoutPinnedDns(dispatcherPolicy, timeoutMs);
+  }
+  const canUsePinnedDns =
+    attempt.lookupFn !== undefined || (fetchImpl === undefined && !isMockedFetch(globalThis.fetch));
+  if (!canUsePinnedDns) {
+    return createMediaFetchDispatcherWithoutPinnedDns(dispatcherPolicy, timeoutMs);
+  }
+  const policyForUrl = resolveSsrFPolicyForUrl(params.url, params.ssrfPolicy);
+  const pinned = await resolvePinnedHostnameWithPolicy(params.url.hostname, {
+    lookupFn: attempt.lookupFn,
+    policy: policyForUrl,
+  });
+  return createPinnedDispatcher(pinned, dispatcherPolicy, policyForUrl, timeoutMs);
+}
+
 async function fetchNativeMediaAttempt(
   options: FetchMediaOptions,
   attempt: FetchDispatcherAttempt,
 ): Promise<NativeMediaResponse> {
-  const { url, fetchImpl, requestInit, maxRedirects, timeoutMs, ssrfPolicy } = options;
+  const {
+    url,
+    fetchImpl,
+    requestInit,
+    maxRedirects,
+    timeoutMs,
+    ssrfPolicy,
+    trustExplicitProxyDns,
+  } = options;
   const requestUrl = assertMediaUrlAllowedByPolicy(url, ssrfPolicy);
+  const parsedRequestUrl = new URL(requestUrl);
   const signal = resolveFetchSignal({
     requestSignal: requestInit?.signal,
     timeoutMs,
   });
-  const dispatcher = createMediaFetchDispatcher(attempt.dispatcherPolicy, timeoutMs);
+  const dispatcher = await createMediaFetchDispatcher({
+    url: parsedRequestUrl,
+    attempt,
+    fetchImpl,
+    ssrfPolicy,
+    timeoutMs,
+    trustExplicitProxyDns,
+  });
   let released = false;
   const release = async () => {
     if (released) {

--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -46,7 +46,8 @@ import { saveMediaBuffer, saveMediaStream, type SavedMedia } from "./store.js";
 export const DEFAULT_FETCH_MEDIA_MAX_BYTES = MAX_DOCUMENT_BYTES;
 
 function resolveDispatcherTimeoutMs(timeoutMs: number | undefined): number | undefined {
-  return timeoutMs ?? globalUndiciStreamTimeoutMs;
+  const resolved = timeoutMs ?? globalUndiciStreamTimeoutMs;
+  return resolved === undefined ? undefined : resolveTimerTimeoutMs(resolved, 1);
 }
 
 /** Remote media bytes plus metadata before they are persisted to the media store. */
@@ -247,9 +248,10 @@ function resolveFetchSignal(params: { requestSignal?: AbortSignal | null; timeou
 
   const controller = new AbortController();
   const timeoutError = new Error(`Media fetch timed out after ${timeoutMs}ms`);
+  const timerTimeoutMs = resolveTimerTimeoutMs(timeoutMs, 1);
   const timeout = setTimeout(() => {
     controller.abort(timeoutError);
-  }, timeoutMs);
+  }, timerTimeoutMs);
   unrefTimer(timeout);
 
   let removeAbortListener: (() => void) | undefined;

--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -9,8 +9,10 @@ import {
 } from "@openclaw/media-core/read-response-with-limit";
 import type { Dispatcher } from "undici";
 import { formatErrorMessage } from "../infra/errors.js";
+import { normalizeRequestInitHeadersForFetch } from "../infra/fetch-headers.js";
 import { normalizeHostname } from "../infra/net/hostname.js";
 import { shouldUseEnvHttpProxyForUrl } from "../infra/net/proxy-env.js";
+import { retainSafeHeadersForCrossOriginRedirect } from "../infra/net/redirect-headers.js";
 import {
   fetchWithRuntimeDispatcherOrMockedGlobal,
   isMockedFetch,
@@ -44,10 +46,22 @@ import { saveMediaBuffer, saveMediaStream, type SavedMedia } from "./store.js";
 
 /** Default remote media fetch cap shared by buffer reads and store writes. */
 export const DEFAULT_FETCH_MEDIA_MAX_BYTES = MAX_DOCUMENT_BYTES;
+const DEFAULT_MEDIA_MAX_REDIRECTS = 3;
+const MEDIA_REDIRECT_STATUS_CODES = new Set([301, 302, 303, 307, 308]);
 
 function resolveDispatcherTimeoutMs(timeoutMs: number | undefined): number | undefined {
   const resolved = timeoutMs ?? globalUndiciStreamTimeoutMs;
   return resolved === undefined ? undefined : resolveTimerTimeoutMs(resolved, 1);
+}
+
+function resolveMediaMaxRedirects(value: number | undefined): number {
+  return typeof value === "number" && Number.isFinite(value)
+    ? Math.max(0, Math.floor(value))
+    : DEFAULT_MEDIA_MAX_REDIRECTS;
+}
+
+function mediaRedirectVisitKey(url: string, init: RequestInit | undefined): string {
+  return `${init?.method?.toUpperCase() ?? "GET"} ${url}`;
 }
 
 /** Remote media bytes plus metadata before they are persisted to the media store. */
@@ -351,6 +365,63 @@ function captureMediaFetchExchange(params: {
   });
 }
 
+function dropMediaBodyHeaders(headers?: HeadersInit): HeadersInit | undefined {
+  if (!headers) {
+    return headers;
+  }
+  const next = new Headers(headers);
+  next.delete("content-length");
+  next.delete("content-type");
+  return next;
+}
+
+function rewriteMediaRedirectInitForMethod(params: {
+  init?: RequestInit;
+  status: number;
+}): RequestInit | undefined {
+  const init = params.init;
+  if (!init) {
+    return init;
+  }
+  const method = init.method?.toUpperCase() ?? "GET";
+  const shouldRewriteToGet =
+    params.status === 303 ||
+    ((params.status === 301 || params.status === 302) && method === "POST");
+  if (!shouldRewriteToGet) {
+    return init;
+  }
+  return {
+    ...init,
+    method: "GET",
+    body: undefined,
+    headers: dropMediaBodyHeaders(init.headers),
+  };
+}
+
+function rewriteMediaRedirectInitForCrossOrigin(params: {
+  init?: RequestInit;
+  currentOrigin: string;
+  nextOrigin: string;
+}): RequestInit | undefined {
+  const init = params.init;
+  if (!init || params.currentOrigin === params.nextOrigin) {
+    return init;
+  }
+  const method = init.method?.toUpperCase() ?? "GET";
+  const safeReplay = method === "GET" || method === "HEAD";
+  const nextInit = safeReplay
+    ? init
+    : {
+        ...init,
+        body: undefined,
+        headers: dropMediaBodyHeaders(init.headers),
+      };
+  return {
+    ...nextInit,
+    headers: retainSafeHeadersForCrossOriginRedirect(nextInit.headers),
+  };
+}
+
 async function createMediaFetchDispatcher(params: {
   url: URL;
   attempt: FetchDispatcherAttempt;
@@ -394,8 +465,7 @@ async function fetchNativeMediaAttempt(
 ): Promise<NativeMediaResponse> {
   const { url, fetchImpl, requestInit, timeoutMs, ssrfPolicy, lookupFn, trustExplicitProxyDns } =
     options;
-  const requestUrl = assertMediaUrlAllowedByPolicy(url, ssrfPolicy);
-  const parsedRequestUrl = new URL(requestUrl);
+  const sourceUrl = assertMediaUrlAllowedByPolicy(url, ssrfPolicy);
   const signal = resolveFetchSignal({
     requestSignal: requestInit?.signal,
     timeoutMs,
@@ -411,41 +481,86 @@ async function fetchNativeMediaAttempt(
     await closeDispatcher(dispatcher);
   };
   try {
-    dispatcher = await createMediaFetchDispatcher({
-      url: parsedRequestUrl,
-      attempt,
-      fetchImpl,
-      lookupFn,
-      ssrfPolicy,
-      timeoutMs,
-      trustExplicitProxyDns,
-    });
-    const init: DispatcherAwareRequestInit = {
-      ...requestInit,
-      ...(signal.signal ? { signal: signal.signal } : {}),
-      ...(dispatcher ? { dispatcher } : {}),
-      redirect:
-        requestInit?.redirect === "manual" || requestInit?.redirect === "error"
-          ? requestInit.redirect
-          : "error",
-    };
-    const response = fetchImpl
-      ? await fetchImpl(requestUrl, init)
-      : await fetchWithRuntimeDispatcherOrMockedGlobal(requestUrl, init);
-    const finalUrl = response.url || requestUrl;
-    try {
-      assertMediaUrlAllowedByPolicy(finalUrl, ssrfPolicy);
-    } catch (err) {
-      await discardIgnoredResponseBody(response);
-      throw err;
+    let currentUrl = sourceUrl;
+    let currentInit = normalizeRequestInitHeadersForFetch(
+      requestInit ? { ...requestInit } : undefined,
+    );
+    const followRedirects = currentInit?.redirect !== "manual" && currentInit?.redirect !== "error";
+    const maxRedirects = resolveMediaMaxRedirects(options.maxRedirects);
+    const visited = new Set<string>([mediaRedirectVisitKey(currentUrl, currentInit)]);
+    let redirectCount = 0;
+
+    while (true) {
+      const parsedRequestUrl = new URL(currentUrl);
+      dispatcher = await createMediaFetchDispatcher({
+        url: parsedRequestUrl,
+        attempt,
+        fetchImpl,
+        lookupFn,
+        ssrfPolicy,
+        timeoutMs,
+        trustExplicitProxyDns,
+      });
+      const init: DispatcherAwareRequestInit = {
+        ...currentInit,
+        ...(signal.signal ? { signal: signal.signal } : {}),
+        ...(dispatcher ? { dispatcher } : {}),
+        redirect: followRedirects ? "manual" : currentInit?.redirect,
+      };
+      const response = fetchImpl
+        ? await fetchImpl(currentUrl, init)
+        : await fetchWithRuntimeDispatcherOrMockedGlobal(currentUrl, init);
+      const finalUrl = response.url || currentUrl;
+      try {
+        assertMediaUrlAllowedByPolicy(finalUrl, ssrfPolicy);
+      } catch (err) {
+        await discardIgnoredResponseBody(response);
+        throw err;
+      }
+      captureMediaFetchExchange({ url: currentUrl, finalUrl, init, response });
+
+      if (followRedirects && MEDIA_REDIRECT_STATUS_CODES.has(response.status)) {
+        const location = response.headers.get("location");
+        if (!location) {
+          await discardIgnoredResponseBody(response);
+          throw new Error(`Redirect missing location header (${response.status})`);
+        }
+        redirectCount += 1;
+        if (redirectCount > maxRedirects) {
+          await discardIgnoredResponseBody(response);
+          throw new Error(`Too many redirects (limit: ${maxRedirects})`);
+        }
+        const nextParsedUrl = new URL(location, parsedRequestUrl);
+        const nextUrl = assertMediaUrlAllowedByPolicy(nextParsedUrl.toString(), ssrfPolicy);
+        currentInit = rewriteMediaRedirectInitForMethod({
+          init: currentInit,
+          status: response.status,
+        });
+        currentInit = rewriteMediaRedirectInitForCrossOrigin({
+          init: currentInit,
+          currentOrigin: parsedRequestUrl.origin,
+          nextOrigin: nextParsedUrl.origin,
+        });
+        const visitKey = mediaRedirectVisitKey(nextUrl, currentInit);
+        if (visited.has(visitKey)) {
+          await discardIgnoredResponseBody(response);
+          throw new Error("Redirect loop detected");
+        }
+        visited.add(visitKey);
+        await discardIgnoredResponseBody(response);
+        await closeDispatcher(dispatcher);
+        dispatcher = null;
+        currentUrl = nextUrl;
+        continue;
+      }
+
+      return {
+        response,
+        finalUrl,
+        release,
+        sourceUrl: redactMediaUrl(url),
+      };
     }
-    captureMediaFetchExchange({ url: requestUrl, finalUrl, init, response });
-    return {
-      response,
-      finalUrl,
-      release,
-      sourceUrl: redactMediaUrl(url),
-    };
   } catch (err) {
     await release();
     throw err;

--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -9,16 +9,20 @@ import {
 } from "@openclaw/media-core/read-response-with-limit";
 import type { Dispatcher } from "undici";
 import { formatErrorMessage } from "../infra/errors.js";
-import {
-  closeDispatcher,
-  type LookupFn,
-  type PinnedDispatcherPolicy,
-  type SsrFPolicy,
-} from "../infra/net/ssrf.js";
+import { normalizeHostname } from "../infra/net/hostname.js";
 import {
   fetchWithRuntimeDispatcherOrMockedGlobal,
   type DispatcherAwareRequestInit,
 } from "../infra/net/runtime-fetch.js";
+import {
+  closeDispatcher,
+  matchesHostnameAllowlist,
+  normalizeHostnameAllowlist,
+  resolveSsrFPolicyForUrl,
+  type LookupFn,
+  type PinnedDispatcherPolicy,
+  type SsrFPolicy,
+} from "../infra/net/ssrf.js";
 import {
   createHttp1Agent,
   createHttp1EnvHttpProxyAgent,
@@ -188,16 +192,35 @@ function redactMediaUrl(url: string): string {
   return redactSensitiveText(url);
 }
 
+function assertMediaUrlAllowedByPolicy(rawUrl: string, policy?: SsrFPolicy): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    throw new Error("Invalid URL: must be http or https");
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error("Invalid URL: must be http or https");
+  }
+
+  const policyForUrl = resolveSsrFPolicyForUrl(parsed, policy);
+  const allowlist = normalizeHostnameAllowlist(policyForUrl?.hostnameAllowlist);
+  if (allowlist.length > 0) {
+    const hostname = normalizeHostname(parsed.hostname);
+    if (!matchesHostnameAllowlist(hostname, allowlist)) {
+      throw new Error(`Media URL hostname is not in allowlist: ${parsed.hostname}`);
+    }
+  }
+  return parsed.toString();
+}
+
 function unrefTimer(timeout: ReturnType<typeof setTimeout>): void {
   if (typeof timeout === "object" && "unref" in timeout) {
     timeout.unref();
   }
 }
 
-function resolveFetchSignal(params: {
-  requestSignal?: AbortSignal | null;
-  timeoutMs?: number;
-}): {
+function resolveFetchSignal(params: { requestSignal?: AbortSignal | null; timeoutMs?: number }): {
   signal?: AbortSignal;
   cleanup: () => void;
 } {
@@ -278,7 +301,8 @@ async function fetchNativeMediaAttempt(
   options: FetchMediaOptions,
   attempt: FetchDispatcherAttempt,
 ): Promise<NativeMediaResponse> {
-  const { url, fetchImpl, requestInit, maxRedirects, timeoutMs } = options;
+  const { url, fetchImpl, requestInit, maxRedirects, timeoutMs, ssrfPolicy } = options;
+  const requestUrl = assertMediaUrlAllowedByPolicy(url, ssrfPolicy);
   const signal = resolveFetchSignal({
     requestSignal: requestInit?.signal,
     timeoutMs,
@@ -295,11 +319,18 @@ async function fetchNativeMediaAttempt(
   };
   try {
     const response = fetchImpl
-      ? await fetchImpl(url, init)
-      : await fetchWithRuntimeDispatcherOrMockedGlobal(url, init);
+      ? await fetchImpl(requestUrl, init)
+      : await fetchWithRuntimeDispatcherOrMockedGlobal(requestUrl, init);
+    const finalUrl = response.url || requestUrl;
+    try {
+      assertMediaUrlAllowedByPolicy(finalUrl, ssrfPolicy);
+    } catch (err) {
+      await discardIgnoredResponseBody(response);
+      throw err;
+    }
     return {
       response,
-      finalUrl: response.url || url,
+      finalUrl,
       release,
       sourceUrl: redactMediaUrl(url),
     };
@@ -311,16 +342,8 @@ async function fetchNativeMediaAttempt(
   }
 }
 
-async function fetchNativeMediaResponse(
-  options: FetchMediaOptions,
-): Promise<NativeMediaResponse> {
-  const {
-    url,
-    dispatcherPolicy,
-    dispatcherAttempts,
-    lookupFn,
-    shouldRetryFetchError,
-  } = options;
+async function fetchNativeMediaResponse(options: FetchMediaOptions): Promise<NativeMediaResponse> {
+  const { url, dispatcherPolicy, dispatcherAttempts, lookupFn, shouldRetryFetchError } = options;
   const sourceUrl = redactMediaUrl(url);
   const attempts =
     dispatcherAttempts && dispatcherAttempts.length > 0

--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -64,6 +64,20 @@ function mediaRedirectVisitKey(url: string, init: RequestInit | undefined): stri
   return `${init?.method?.toUpperCase() ?? "GET"} ${url}`;
 }
 
+async function fetchMediaWithDispatcher(
+  input: string,
+  init: DispatcherAwareRequestInit,
+  fetchImpl: FetchLike | undefined,
+): Promise<Response> {
+  if (!fetchImpl) {
+    return await fetchWithRuntimeDispatcherOrMockedGlobal(input, init);
+  }
+  if (fetchImpl === globalThis.fetch && !isMockedFetch(fetchImpl)) {
+    return await fetchWithRuntimeDispatcherOrMockedGlobal(input, init);
+  }
+  return await fetchImpl(input, init);
+}
+
 /** Remote media bytes plus metadata before they are persisted to the media store. */
 type FetchMediaResult = {
   buffer: Buffer;
@@ -507,9 +521,7 @@ async function fetchNativeMediaAttempt(
         ...(dispatcher ? { dispatcher } : {}),
         redirect: followRedirects ? "manual" : currentInit?.redirect,
       };
-      const response = fetchImpl
-        ? await fetchImpl(currentUrl, init)
-        : await fetchWithRuntimeDispatcherOrMockedGlobal(currentUrl, init);
+      const response = await fetchMediaWithDispatcher(currentUrl, init, fetchImpl);
       const finalUrl = response.url || currentUrl;
       try {
         assertMediaUrlAllowedByPolicy(finalUrl, ssrfPolicy);

--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -37,6 +37,7 @@ import {
 import { retryAsync, type RetryOptions } from "../infra/retry.js";
 import { isAbortError, isTransientNetworkError } from "../infra/unhandled-rejections.js";
 import { redactSensitiveText } from "../logging/redact.js";
+import { captureHttpExchange } from "../proxy-capture/runtime.js";
 import { resolveTimerTimeoutMs } from "../shared/number-coercion.js";
 import { saveMediaBuffer, saveMediaStream, type SavedMedia } from "./store.js";
 
@@ -322,6 +323,27 @@ function assertExplicitProxySupportsMediaTarget(
   }
 }
 
+function captureMediaFetchExchange(params: {
+  url: string;
+  finalUrl: string;
+  init: RequestInit | undefined;
+  response: Response;
+}): void {
+  captureHttpExchange({
+    url: params.url,
+    method: params.init?.method ?? "GET",
+    requestHeaders: params.init?.headers as Headers | Record<string, string> | undefined,
+    requestBody:
+      (params.init as (RequestInit & { body?: BodyInit | null }) | undefined)?.body ?? null,
+    response: params.response,
+    transport: "http",
+    meta: {
+      captureOrigin: "media-fetch",
+      ...(params.finalUrl !== params.url ? { finalUrl: params.finalUrl } : {}),
+    },
+  });
+}
+
 async function createMediaFetchDispatcher(params: {
   url: URL;
   attempt: FetchDispatcherAttempt;
@@ -408,6 +430,7 @@ async function fetchNativeMediaAttempt(
       await discardIgnoredResponseBody(response);
       throw err;
     }
+    captureMediaFetchExchange({ url: requestUrl, finalUrl, init, response });
     return {
       response,
       finalUrl,

--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -310,6 +310,17 @@ function shouldUseManagedEnvProxyForUrl(url: string): boolean {
   return process.env["OPENCLAW_PROXY_ACTIVE"] === "1" && shouldUseEnvHttpProxyForUrl(url);
 }
 
+function assertExplicitProxySupportsMediaTarget(
+  url: URL,
+  dispatcherPolicy?: PinnedDispatcherPolicy,
+): void {
+  if (dispatcherPolicy?.mode === "explicit-proxy" && url.protocol !== "https:") {
+    throw new Error(
+      "Explicit proxy SSRF pinning requires HTTPS targets; plain HTTP targets are not supported",
+    );
+  }
+}
+
 async function createMediaFetchDispatcher(params: {
   url: URL;
   attempt: FetchDispatcherAttempt;
@@ -323,6 +334,7 @@ async function createMediaFetchDispatcher(params: {
   if (dispatcherPolicy?.mode === "explicit-proxy" && trustExplicitProxyDns === true) {
     return createMediaFetchDispatcherWithoutPinnedDns(dispatcherPolicy, timeoutMs);
   }
+  assertExplicitProxySupportsMediaTarget(params.url, dispatcherPolicy);
   const resolvedFetch = fetchImpl ?? globalThis.fetch;
   const canUsePinnedDns = attempt.lookupFn !== undefined || !isMockedFetch(resolvedFetch);
   if (!canUsePinnedDns) {

--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -10,6 +10,7 @@ import {
 import type { Dispatcher } from "undici";
 import { formatErrorMessage } from "../infra/errors.js";
 import { normalizeHostname } from "../infra/net/hostname.js";
+import { shouldUseEnvHttpProxyForUrl } from "../infra/net/proxy-env.js";
 import {
   fetchWithRuntimeDispatcherOrMockedGlobal,
   isMockedFetch,
@@ -305,6 +306,10 @@ function createMediaFetchDispatcherWithoutPinnedDns(
   return null;
 }
 
+function shouldUseManagedEnvProxyForUrl(url: string): boolean {
+  return process.env["OPENCLAW_PROXY_ACTIVE"] === "1" && shouldUseEnvHttpProxyForUrl(url);
+}
+
 async function createMediaFetchDispatcher(params: {
   url: URL;
   attempt: FetchDispatcherAttempt;
@@ -328,6 +333,9 @@ async function createMediaFetchDispatcher(params: {
     lookupFn: attempt.lookupFn,
     policy: policyForUrl,
   });
+  if (shouldUseManagedEnvProxyForUrl(params.url.toString())) {
+    return createHttp1EnvHttpProxyAgent(undefined, timeoutMs);
+  }
   return createPinnedDispatcher(pinned, dispatcherPolicy, policyForUrl, timeoutMs);
 }
 

--- a/src/media/input-files.fetch-guard.test.ts
+++ b/src/media/input-files.fetch-guard.test.ts
@@ -331,6 +331,29 @@ describe("fetchWithGuard", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it.each([[["*"]], [["*."]]])(
+    "treats wildcard URL allowlist %j as unrestricted",
+    async (hostnameAllowlist) => {
+      const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+        new Response(Buffer.from("ok"), {
+          status: 200,
+          headers: { "content-type": "text/plain" },
+        }),
+      );
+
+      const result = await fetchWithGuard({
+        url: "https://evil.example.com/file.txt",
+        maxBytes: 1024,
+        timeoutMs: 1000,
+        maxRedirects: 3,
+        policy: { hostnameAllowlist },
+      });
+
+      expect(result.buffer).toStrictEqual(Buffer.from("ok"));
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    },
+  );
+
   it("rejects private URL literals before fetch", async () => {
     const fetchMock = vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("unexpected"));
 

--- a/src/media/input-files.fetch-guard.test.ts
+++ b/src/media/input-files.fetch-guard.test.ts
@@ -84,10 +84,7 @@ function mockUrlFetchResponse(params: {
   vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(response);
 }
 
-function mockFetchResponse(params: {
-  body: BodyInit | null;
-  init?: ResponseInit;
-}): Response {
+function mockFetchResponse(params: { body: BodyInit | null; init?: ResponseInit }): Response {
   const response = new Response(params.body, params.init);
   vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(response);
   return response;
@@ -236,14 +233,12 @@ describe("HEIC input image normalization", () => {
 
 describe("fetchWithGuard", () => {
   it("uses native no-redirect fetch behavior when maxRedirects is zero", async () => {
-    const fetchMock = vi
-      .spyOn(globalThis, "fetch")
-      .mockResolvedValueOnce(
-        new Response(Buffer.from("input"), {
-          status: 200,
-          headers: { "content-type": "text/plain" },
-        }),
-      );
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(Buffer.from("input"), {
+        status: 200,
+        headers: { "content-type": "text/plain" },
+      }),
+    );
 
     await expect(
       fetchWithGuard({
@@ -262,6 +257,43 @@ describe("fetchWithGuard", () => {
       "https://example.com/file.txt",
       expect.objectContaining({ redirect: "error" }),
     );
+  });
+
+  it("rejects URL fetches outside the configured hostname allowlist before fetch", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("unexpected"));
+
+    await expect(
+      fetchWithGuard({
+        url: "https://evil.example.com/file.txt",
+        maxBytes: 1024,
+        timeoutMs: 1000,
+        maxRedirects: 3,
+        policy: { hostnameAllowlist: ["cdn.example.com", "*.assets.example.com"] },
+      }),
+    ).rejects.toThrow("hostname is not in allowlist");
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects native redirect results outside the configured hostname allowlist", async () => {
+    const response = new Response(Buffer.from("input"), {
+      status: 200,
+      headers: { "content-type": "text/plain" },
+    });
+    Object.defineProperty(response, "url", {
+      value: "https://evil.example.com/file.txt",
+    });
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(response);
+
+    await expect(
+      fetchWithGuard({
+        url: "https://cdn.example.com/file.txt",
+        maxBytes: 1024,
+        timeoutMs: 1000,
+        maxRedirects: 3,
+        policy: { hostnameAllowlist: ["cdn.example.com"] },
+      }),
+    ).rejects.toThrow("hostname is not in allowlist");
   });
 
   it("cancels ignored HTTP error bodies", async () => {

--- a/src/media/input-files.fetch-guard.test.ts
+++ b/src/media/input-files.fetch-guard.test.ts
@@ -259,6 +259,45 @@ describe("fetchWithGuard", () => {
     );
   });
 
+  it("keeps the request timeout active while reading the response body", async () => {
+    vi.useFakeTimers();
+    try {
+      const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(
+        async (_input: RequestInfo | URL, init?: RequestInit) =>
+          new Response(
+            new ReadableStream<Uint8Array>({
+              start(controller) {
+                controller.enqueue(new Uint8Array([1]));
+                init?.signal?.addEventListener("abort", () => {
+                  controller.error(init.signal?.reason);
+                });
+              },
+            }),
+            { status: 200, headers: { "content-type": "application/octet-stream" } },
+          ),
+      );
+
+      const pending = fetchWithGuard({
+        url: "https://example.com/file.bin",
+        maxBytes: 1024,
+        timeoutMs: 20,
+        maxRedirects: 0,
+      });
+      const rejection = expect(pending).rejects.toThrow(
+        "Input source URL fetch timed out after 20ms",
+      );
+
+      await vi.advanceTimersByTimeAsync(20);
+      await rejection;
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://example.com/file.bin",
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("rejects URL fetches outside the configured hostname allowlist before fetch", async () => {
     const fetchMock = vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("unexpected"));
 

--- a/src/media/input-files.fetch-guard.test.ts
+++ b/src/media/input-files.fetch-guard.test.ts
@@ -1,13 +1,8 @@
 // Input file fetch guard tests cover network fetch limits for media inputs.
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
-const fetchWithSsrFGuardMock = vi.fn();
 const convertHeicToJpegMock = vi.fn();
 const detectMimeMock = vi.fn();
-
-vi.mock("../infra/net/fetch-guard.js", () => ({
-  fetchWithSsrFGuard: (...args: unknown[]) => fetchWithSsrFGuardMock(...args),
-}));
 
 vi.mock("./media-services.js", () => ({
   convertHeicToJpeg: (...args: unknown[]) => convertHeicToJpegMock(...args),
@@ -34,6 +29,10 @@ beforeAll(async () => {
 
 beforeEach(() => {
   vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
 });
 
 function createImageSourceLimits(allowedMimes: string[], allowUrl = false) {
@@ -65,27 +64,33 @@ function mockUrlFetchResponse(params: {
   fetchedBody?: Uint8Array;
 }) {
   if (params.source.type !== "url") {
-    return null;
+    return;
   }
 
-  const release = vi.fn(async () => {});
   const responseBody = Uint8Array.from(params.fetchedBody ?? Buffer.from("url-source"));
-  fetchWithSsrFGuardMock.mockResolvedValueOnce({
-    response: new Response(
-      responseBody.buffer.slice(
-        responseBody.byteOffset,
-        responseBody.byteOffset + responseBody.byteLength,
-      ),
-      {
-        status: 200,
-        headers: { "content-type": params.fetchedContentType ?? "application/octet-stream" },
-      },
+  const response = new Response(
+    responseBody.buffer.slice(
+      responseBody.byteOffset,
+      responseBody.byteOffset + responseBody.byteLength,
     ),
-    release,
-    finalUrl: params.fetchedUrl ?? params.source.url,
-  });
+    {
+      status: 200,
+      headers: { "content-type": params.fetchedContentType ?? "application/octet-stream" },
+    },
+  );
+  if (params.fetchedUrl) {
+    Object.defineProperty(response, "url", { value: params.fetchedUrl });
+  }
+  vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(response);
+}
 
-  return release;
+function mockFetchResponse(params: {
+  body: BodyInit | null;
+  init?: ResponseInit;
+}): Response {
+  const response = new Response(params.body, params.init);
+  vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(response);
+  return response;
 }
 
 async function expectRejectedImageMimeCase(params: {
@@ -96,13 +101,10 @@ async function expectRejectedImageMimeCase(params: {
   fetchedContentType?: string;
   fetchedBody?: Uint8Array;
 }) {
-  const release = mockUrlFetchResponse(params);
+  mockUrlFetchResponse(params);
   await expect(extractImageContentFromSource(params.source, params.limits)).rejects.toThrow(
     params.expectedError,
   );
-  if (release) {
-    expect(release).toHaveBeenCalledTimes(1);
-  }
 }
 
 type ImageSourceLimits = Parameters<typeof extractImageContentFromSource>[1];
@@ -117,7 +119,7 @@ async function expectResolvedImageContentCase(params: {
   fetchedBody?: Uint8Array;
   expectedImage: Awaited<ReturnType<typeof extractImageContentFromSource>>;
 }) {
-  const release = mockUrlFetchResponse(params);
+  mockUrlFetchResponse(params);
   detectMimeMock.mockResolvedValueOnce(params.detectedMime);
   if (params.convertedBytes) {
     convertHeicToJpegMock.mockResolvedValueOnce(params.convertedBytes);
@@ -128,9 +130,6 @@ async function expectResolvedImageContentCase(params: {
   expect(image).toEqual(params.expectedImage);
   expect(detectMimeMock).toHaveBeenCalledTimes(1);
   expect(convertHeicToJpegMock).toHaveBeenCalledTimes(params.convertedBytes ? 1 : 0);
-  if (release) {
-    expect(release).toHaveBeenCalledTimes(1);
-  }
 }
 
 async function expectBase64ImageValidationCase(params: {
@@ -236,6 +235,35 @@ describe("HEIC input image normalization", () => {
 });
 
 describe("fetchWithGuard", () => {
+  it("uses native no-redirect fetch behavior when maxRedirects is zero", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(Buffer.from("input"), {
+          status: 200,
+          headers: { "content-type": "text/plain" },
+        }),
+      );
+
+    await expect(
+      fetchWithGuard({
+        url: "https://example.com/file.txt",
+        maxBytes: 1024,
+        timeoutMs: 1000,
+        maxRedirects: 0,
+      }),
+    ).resolves.toMatchObject({
+      buffer: Buffer.from("input"),
+      mimeType: "text/plain",
+      contentType: "text/plain",
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://example.com/file.txt",
+      expect.objectContaining({ redirect: "error" }),
+    );
+  });
+
   it("cancels ignored HTTP error bodies", async () => {
     let canceled = false;
     const stream = new ReadableStream<Uint8Array>({
@@ -246,14 +274,12 @@ describe("fetchWithGuard", () => {
         canceled = true;
       },
     });
-    const release = vi.fn(async () => {});
-    fetchWithSsrFGuardMock.mockResolvedValueOnce({
-      response: new Response(stream, {
+    mockFetchResponse({
+      body: stream,
+      init: {
         status: 503,
         statusText: "Service Unavailable",
-      }),
-      release,
-      finalUrl: "https://example.com/file.bin",
+      },
     });
 
     await expect(
@@ -266,7 +292,6 @@ describe("fetchWithGuard", () => {
     ).rejects.toThrow("Failed to fetch: 503 Service Unavailable");
 
     expect(canceled).toBe(true);
-    expect(release).toHaveBeenCalledTimes(1);
   });
 
   it("cancels ignored bodies when content-length exceeds the byte limit", async () => {
@@ -279,14 +304,12 @@ describe("fetchWithGuard", () => {
         canceled = true;
       },
     });
-    const release = vi.fn(async () => {});
-    fetchWithSsrFGuardMock.mockResolvedValueOnce({
-      response: new Response(stream, {
+    mockFetchResponse({
+      body: stream,
+      init: {
         status: 200,
         headers: { "content-length": "2048", "content-type": "application/octet-stream" },
-      }),
-      release,
-      finalUrl: "https://example.com/file.bin",
+      },
     });
 
     await expect(
@@ -299,7 +322,6 @@ describe("fetchWithGuard", () => {
     ).rejects.toThrow("Content too large: 2048 bytes");
 
     expect(canceled).toBe(true);
-    expect(release).toHaveBeenCalledTimes(1);
   });
 
   it("rejects malformed content-length before reading input files", async () => {
@@ -312,14 +334,12 @@ describe("fetchWithGuard", () => {
         canceled = true;
       },
     });
-    const release = vi.fn(async () => {});
-    fetchWithSsrFGuardMock.mockResolvedValueOnce({
-      response: new Response(stream, {
+    mockFetchResponse({
+      body: stream,
+      init: {
         status: 200,
         headers: { "content-length": "1e9", "content-type": "application/octet-stream" },
-      }),
-      release,
-      finalUrl: "https://example.com/file.bin",
+      },
     });
 
     await expect(
@@ -332,7 +352,6 @@ describe("fetchWithGuard", () => {
     ).rejects.toThrow("invalid content-length header: 1e9");
 
     expect(canceled).toBe(true);
-    expect(release).toHaveBeenCalledTimes(1);
   });
 
   it("rejects oversized streamed payloads and cancels the stream", async () => {
@@ -354,14 +373,12 @@ describe("fetchWithGuard", () => {
       },
     });
 
-    const release = vi.fn(async () => {});
-    fetchWithSsrFGuardMock.mockResolvedValueOnce({
-      response: new Response(stream, {
+    mockFetchResponse({
+      body: stream,
+      init: {
         status: 200,
         headers: { "content-type": "application/octet-stream" },
-      }),
-      release,
-      finalUrl: "https://example.com/file.bin",
+      },
     });
 
     await expect(
@@ -377,7 +394,6 @@ describe("fetchWithGuard", () => {
     await waitForMicrotaskTurn();
 
     expect(canceled).toBe(true);
-    expect(release).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/media/input-files.fetch-guard.test.ts
+++ b/src/media/input-files.fetch-guard.test.ts
@@ -18,7 +18,10 @@ async function waitForMicrotaskTurn(): Promise<void> {
   });
 }
 
-let fetchWithGuard: typeof import("./input-files.js").fetchWithGuard;
+type FetchWithGuard = typeof import("./input-files.js").fetchWithGuard;
+type LookupFn = NonNullable<Parameters<FetchWithGuard>[0]["lookupFn"]>;
+
+let fetchWithGuard: FetchWithGuard;
 let extractImageContentFromSource: typeof import("./input-files.js").extractImageContentFromSource;
 let extractFileContentFromSource: typeof import("./input-files.js").extractFileContentFromSource;
 
@@ -310,6 +313,41 @@ describe("fetchWithGuard", () => {
         policy: { hostnameAllowlist: ["cdn.example.com", "*.assets.example.com"] },
       }),
     ).rejects.toThrow("hostname is not in allowlist");
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects private URL literals before fetch", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("unexpected"));
+
+    await expect(
+      fetchWithGuard({
+        url: "http://127.0.0.1/secret.txt",
+        maxBytes: 1024,
+        timeoutMs: 1000,
+        maxRedirects: 3,
+      }),
+    ).rejects.toThrow("Blocked hostname or private/internal/special-use IP address");
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects hostnames that resolve to private addresses before fetch", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("unexpected"));
+    const lookupFn = vi.fn(async () => ({
+      address: "127.0.0.1",
+      family: 4,
+    })) as unknown as LookupFn;
+
+    await expect(
+      fetchWithGuard({
+        url: "https://cdn.example.com/secret.txt",
+        maxBytes: 1024,
+        timeoutMs: 1000,
+        maxRedirects: 3,
+        lookupFn,
+      }),
+    ).rejects.toThrow("resolves to private/internal/special-use IP address");
 
     expect(fetchMock).not.toHaveBeenCalled();
   });

--- a/src/media/input-files.fetch-guard.test.ts
+++ b/src/media/input-files.fetch-guard.test.ts
@@ -1,9 +1,13 @@
 // Input file fetch guard tests cover network fetch limits for media inputs.
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { MAX_TIMER_TIMEOUT_MS } from "../shared/number-coercion.js";
 
 const convertHeicToJpegMock = vi.fn();
 const detectMimeMock = vi.fn();
-const createHttp1EnvHttpProxyAgentMock = vi.hoisted(() => vi.fn());
+const { captureHttpExchangeMock, createHttp1EnvHttpProxyAgentMock } = vi.hoisted(() => ({
+  captureHttpExchangeMock: vi.fn(),
+  createHttp1EnvHttpProxyAgentMock: vi.fn(),
+}));
 
 vi.mock("../infra/net/undici-runtime.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../infra/net/undici-runtime.js")>();
@@ -19,6 +23,10 @@ vi.mock("./media-services.js", () => ({
 
 vi.mock("@openclaw/media-core/mime", () => ({
   detectMime: (...args: unknown[]) => detectMimeMock(...args),
+}));
+
+vi.mock("../proxy-capture/runtime.js", () => ({
+  captureHttpExchange: captureHttpExchangeMock,
 }));
 
 async function waitForMicrotaskTurn(): Promise<void> {
@@ -41,6 +49,7 @@ beforeAll(async () => {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  captureHttpExchangeMock.mockReset();
   createHttp1EnvHttpProxyAgentMock.mockReset();
 });
 
@@ -313,6 +322,64 @@ describe("fetchWithGuard", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("clamps oversized input URL timeout timers before scheduling", async () => {
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    try {
+      vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+        new Response(Buffer.from("input"), {
+          status: 200,
+          headers: { "content-type": "text/plain" },
+        }),
+      );
+
+      await expect(
+        fetchWithGuard({
+          url: "https://example.com/file.txt",
+          maxBytes: 1024,
+          timeoutMs: MAX_TIMER_TIMEOUT_MS + 1,
+          maxRedirects: 0,
+        }),
+      ).resolves.toMatchObject({
+        buffer: Buffer.from("input"),
+      });
+
+      expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
+  });
+
+  it("captures input URL fetches for debug proxy traces", async () => {
+    const response = new Response(Buffer.from("captured"), {
+      status: 200,
+      headers: { "content-type": "application/octet-stream" },
+    });
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(response);
+
+    const result = await fetchWithGuard({
+      url: "https://cdn.example.com/file.bin",
+      maxBytes: 1024,
+      timeoutMs: 1000,
+      maxRedirects: 0,
+      auditContext: "openresponses.input_file",
+    });
+
+    expect(result.buffer).toStrictEqual(Buffer.from("captured"));
+    const capture = captureHttpExchangeMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(capture).toMatchObject({
+      url: "https://cdn.example.com/file.bin",
+      method: "GET",
+      requestHeaders: { "User-Agent": "OpenClaw-Gateway/1.0" },
+      requestBody: null,
+      response,
+      transport: "http",
+      meta: {
+        captureOrigin: "input-url-fetch",
+        auditContext: "openresponses.input_file",
+      },
+    });
   });
 
   it("rejects URL fetches outside the configured hostname allowlist before fetch", async () => {

--- a/src/media/input-files.fetch-guard.test.ts
+++ b/src/media/input-files.fetch-guard.test.ts
@@ -235,32 +235,35 @@ describe("HEIC input image normalization", () => {
 });
 
 describe("fetchWithGuard", () => {
-  it("uses native no-redirect fetch behavior when maxRedirects is zero", async () => {
-    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
-      new Response(Buffer.from("input"), {
-        status: 200,
-        headers: { "content-type": "text/plain" },
-      }),
-    );
+  it.each([0, 3] as const)(
+    "uses native no-redirect fetch behavior when maxRedirects is %s",
+    async (maxRedirects) => {
+      const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+        new Response(Buffer.from("input"), {
+          status: 200,
+          headers: { "content-type": "text/plain" },
+        }),
+      );
 
-    await expect(
-      fetchWithGuard({
-        url: "https://example.com/file.txt",
-        maxBytes: 1024,
-        timeoutMs: 1000,
-        maxRedirects: 0,
-      }),
-    ).resolves.toMatchObject({
-      buffer: Buffer.from("input"),
-      mimeType: "text/plain",
-      contentType: "text/plain",
-    });
+      await expect(
+        fetchWithGuard({
+          url: "https://example.com/file.txt",
+          maxBytes: 1024,
+          timeoutMs: 1000,
+          maxRedirects,
+        }),
+      ).resolves.toMatchObject({
+        buffer: Buffer.from("input"),
+        mimeType: "text/plain",
+        contentType: "text/plain",
+      });
 
-    expect(fetchMock).toHaveBeenCalledWith(
-      "https://example.com/file.txt",
-      expect.objectContaining({ redirect: "error" }),
-    );
-  });
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://example.com/file.txt",
+        expect.objectContaining({ redirect: "error" }),
+      );
+    },
+  );
 
   it("keeps the request timeout active while reading the response body", async () => {
     vi.useFakeTimers();

--- a/src/media/input-files.fetch-guard.test.ts
+++ b/src/media/input-files.fetch-guard.test.ts
@@ -3,6 +3,15 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite
 
 const convertHeicToJpegMock = vi.fn();
 const detectMimeMock = vi.fn();
+const createHttp1EnvHttpProxyAgentMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../infra/net/undici-runtime.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../infra/net/undici-runtime.js")>();
+  return {
+    ...actual,
+    createHttp1EnvHttpProxyAgent: createHttp1EnvHttpProxyAgentMock,
+  };
+});
 
 vi.mock("./media-services.js", () => ({
   convertHeicToJpeg: (...args: unknown[]) => convertHeicToJpegMock(...args),
@@ -32,10 +41,12 @@ beforeAll(async () => {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  createHttp1EnvHttpProxyAgentMock.mockReset();
 });
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.unstubAllEnvs();
 });
 
 function createImageSourceLimits(allowedMimes: string[], allowUrl = false) {
@@ -353,6 +364,39 @@ describe("fetchWithGuard", () => {
     ).rejects.toThrow("resolves to private/internal/special-use IP address");
 
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("uses managed env proxy dispatcher after DNS validation when proxy is active", async () => {
+    vi.stubEnv("OPENCLAW_PROXY_ACTIVE", "1");
+    vi.stubEnv("HTTPS_PROXY", "http://127.0.0.1:8888");
+    const close = vi.fn(async () => undefined);
+    const dispatcher = { close };
+    createHttp1EnvHttpProxyAgentMock.mockReturnValueOnce(dispatcher);
+    const lookupFn = vi.fn(async () => ({
+      address: "93.184.216.34",
+      family: 4,
+    })) as unknown as LookupFn;
+    mockFetchResponse({
+      body: Buffer.from("proxied"),
+      init: { status: 200, headers: { "content-type": "application/octet-stream" } },
+    });
+
+    const result = await fetchWithGuard({
+      url: "https://cdn.example.com/file.bin",
+      maxBytes: 1024,
+      maxRedirects: 0,
+      timeoutMs: 1000,
+      lookupFn,
+    });
+
+    expect(result.buffer).toStrictEqual(Buffer.from("proxied"));
+    expect(lookupFn).toHaveBeenCalled();
+    expect(createHttp1EnvHttpProxyAgentMock).toHaveBeenCalledWith(undefined, 1000);
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "https://cdn.example.com/file.bin",
+      expect.objectContaining({ dispatcher }),
+    );
+    expect(close).toHaveBeenCalledTimes(1);
   });
 
   it("rejects native redirect results outside the configured hostname allowlist", async () => {

--- a/src/media/input-files.ts
+++ b/src/media/input-files.ts
@@ -8,7 +8,6 @@ import {
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
 import type { SsrFPolicy } from "../infra/net/ssrf.js";
 import { logWarn } from "../logger.js";
 import { convertHeicToJpeg } from "./media-services.js";
@@ -68,7 +67,7 @@ export type InputImageLimits = {
   timeoutMs: number;
 };
 
-/** Supported input_image source variants before base64 decoding or guarded URL fetch. */
+/** Supported input_image source variants before base64 decoding or URL fetch. */
 export type InputImageSource =
   | {
       type: "base64";
@@ -127,9 +126,9 @@ export const DEFAULT_INPUT_IMAGE_MAX_BYTES = 10 * 1024 * 1024;
 export const DEFAULT_INPUT_FILE_MAX_BYTES = 5 * 1024 * 1024;
 /** Default maximum model-visible characters emitted from input_file text. */
 export const DEFAULT_INPUT_FILE_MAX_CHARS = 60_000;
-/** Default redirect cap for guarded input source URL fetches. */
+/** Default redirect cap for input source URL fetches. */
 export const DEFAULT_INPUT_MAX_REDIRECTS = 3;
-/** Default timeout for guarded input source URL fetches. */
+/** Default timeout for input source URL fetches. */
 export const DEFAULT_INPUT_TIMEOUT_MS = 10_000;
 /** Default PDF page cap for input_file extraction. */
 export const DEFAULT_INPUT_PDF_MAX_PAGES = 4;
@@ -139,6 +138,12 @@ export const DEFAULT_INPUT_PDF_MAX_PIXELS = 4_000_000;
 export const DEFAULT_INPUT_PDF_MIN_TEXT_CHARS = 200;
 const NORMALIZED_INPUT_IMAGE_MIME = "image/jpeg";
 const HEIC_INPUT_IMAGE_MIMES = new Set(["image/heic", "image/heif"]);
+
+function unrefTimer(timeout: ReturnType<typeof setTimeout>): void {
+  if (typeof timeout === "object" && "unref" in timeout) {
+    timeout.unref();
+  }
+}
 
 function rejectOversizedBase64Payload(params: {
   data: string;
@@ -198,7 +203,7 @@ export function resolveInputFileLimits(config?: InputFileLimitsConfig): InputFil
   };
 }
 
-/** Fetches an input source URL through SSRF, redirect, timeout, and byte-limit guards. */
+/** Fetches an input source URL with native redirect, timeout, and byte-limit behavior. */
 export async function fetchWithGuard(params: {
   url: string;
   maxBytes: number;
@@ -207,44 +212,48 @@ export async function fetchWithGuard(params: {
   policy?: SsrFPolicy;
   auditContext?: string;
 }): Promise<InputFetchResult> {
-  const { response, release } = await fetchWithSsrFGuard({
-    url: params.url,
-    maxRedirects: params.maxRedirects,
-    timeoutMs: params.timeoutMs,
-    policy: params.policy,
-    auditContext: params.auditContext,
-    init: { headers: { "User-Agent": "OpenClaw-Gateway/1.0" } },
-  });
-
+  const controller = new AbortController();
+  const timeoutError = new Error(`Input source URL fetch timed out after ${params.timeoutMs}ms`);
+  const timeout = setTimeout(() => {
+    controller.abort(timeoutError);
+  }, params.timeoutMs);
+  unrefTimer(timeout);
+  let response: Response;
   try {
-    if (!response.ok) {
-      await discardIgnoredResponseBody(response);
-      throw new Error(`Failed to fetch: ${response.status} ${response.statusText}`);
-    }
-
-    let contentLength: number | null;
-    try {
-      contentLength = parseMediaContentLength(response.headers.get("content-length"));
-    } catch (err) {
-      await discardIgnoredResponseBody(response);
-      throw err;
-    }
-    if (contentLength !== null && contentLength > params.maxBytes) {
-      await discardIgnoredResponseBody(response);
-      throw new Error(
-        `Content too large: ${contentLength} bytes (limit: ${params.maxBytes} bytes)`,
-      );
-    }
-
-    const buffer = await readResponseWithLimit(response, params.maxBytes);
-
-    const contentType = response.headers.get("content-type") || undefined;
-    const parsed = parseContentType(contentType);
-    const mimeType = parsed.mimeType ?? "application/octet-stream";
-    return { buffer, mimeType, contentType };
+    response = await fetch(params.url, {
+      headers: { "User-Agent": "OpenClaw-Gateway/1.0" },
+      signal: controller.signal,
+      redirect: params.maxRedirects === 0 ? "error" : "follow",
+    });
   } finally {
-    await release();
+    clearTimeout(timeout);
   }
+
+  if (!response.ok) {
+    await discardIgnoredResponseBody(response);
+    throw new Error(`Failed to fetch: ${response.status} ${response.statusText}`);
+  }
+
+  let contentLength: number | null;
+  try {
+    contentLength = parseMediaContentLength(response.headers.get("content-length"));
+  } catch (err) {
+    await discardIgnoredResponseBody(response);
+    throw err;
+  }
+  if (contentLength !== null && contentLength > params.maxBytes) {
+    await discardIgnoredResponseBody(response);
+    throw new Error(
+      `Content too large: ${contentLength} bytes (limit: ${params.maxBytes} bytes)`,
+    );
+  }
+
+  const buffer = await readResponseWithLimit(response, params.maxBytes);
+
+  const contentType = response.headers.get("content-type") || undefined;
+  const parsed = parseContentType(contentType);
+  const mimeType = parsed.mimeType ?? "application/octet-stream";
+  return { buffer, mimeType, contentType };
 }
 
 async function discardIgnoredResponseBody(response: Response): Promise<void> {
@@ -332,7 +341,7 @@ async function resolveInputFileMime(params: {
   return sniffedMime;
 }
 
-/** Extracts and normalizes an input_image source from base64 or guarded URL input. */
+/** Extracts and normalizes an input_image source from base64 or URL input. */
 export async function extractImageContentFromSource(
   source: InputImageSource,
   limits: InputImageLimits,

--- a/src/media/input-files.ts
+++ b/src/media/input-files.ts
@@ -257,39 +257,41 @@ export async function fetchWithGuard(params: {
       signal: controller.signal,
       redirect: params.maxRedirects === 0 ? "error" : "follow",
     });
+
+    if (!response.ok) {
+      await discardIgnoredResponseBody(response);
+      throw new Error(`Failed to fetch: ${response.status} ${response.statusText}`);
+    }
+    try {
+      assertInputSourceUrlAllowed(response.url || url, params.policy);
+    } catch (err) {
+      await discardIgnoredResponseBody(response);
+      throw err;
+    }
+
+    let contentLength: number | null;
+    try {
+      contentLength = parseMediaContentLength(response.headers.get("content-length"));
+    } catch (err) {
+      await discardIgnoredResponseBody(response);
+      throw err;
+    }
+    if (contentLength !== null && contentLength > params.maxBytes) {
+      await discardIgnoredResponseBody(response);
+      throw new Error(
+        `Content too large: ${contentLength} bytes (limit: ${params.maxBytes} bytes)`,
+      );
+    }
+
+    const buffer = await readResponseWithLimit(response, params.maxBytes);
+
+    const contentType = response.headers.get("content-type") || undefined;
+    const parsed = parseContentType(contentType);
+    const mimeType = parsed.mimeType ?? "application/octet-stream";
+    return { buffer, mimeType, contentType };
   } finally {
     clearTimeout(timeout);
   }
-
-  if (!response.ok) {
-    await discardIgnoredResponseBody(response);
-    throw new Error(`Failed to fetch: ${response.status} ${response.statusText}`);
-  }
-  try {
-    assertInputSourceUrlAllowed(response.url || url, params.policy);
-  } catch (err) {
-    await discardIgnoredResponseBody(response);
-    throw err;
-  }
-
-  let contentLength: number | null;
-  try {
-    contentLength = parseMediaContentLength(response.headers.get("content-length"));
-  } catch (err) {
-    await discardIgnoredResponseBody(response);
-    throw err;
-  }
-  if (contentLength !== null && contentLength > params.maxBytes) {
-    await discardIgnoredResponseBody(response);
-    throw new Error(`Content too large: ${contentLength} bytes (limit: ${params.maxBytes} bytes)`);
-  }
-
-  const buffer = await readResponseWithLimit(response, params.maxBytes);
-
-  const contentType = response.headers.get("content-type") || undefined;
-  const parsed = parseContentType(contentType);
-  const mimeType = parsed.mimeType ?? "application/octet-stream";
-  return { buffer, mimeType, contentType };
 }
 
 async function discardIgnoredResponseBody(response: Response): Promise<void> {

--- a/src/media/input-files.ts
+++ b/src/media/input-files.ts
@@ -8,7 +8,8 @@ import {
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import type { SsrFPolicy } from "../infra/net/ssrf.js";
+import { normalizeHostname } from "../infra/net/hostname.js";
+import { matchesHostnameAllowlist, type SsrFPolicy } from "../infra/net/ssrf.js";
 import { logWarn } from "../logger.js";
 import { convertHeicToJpeg } from "./media-services.js";
 import { extractPdfContent, type PdfExtractedImage } from "./pdf-extract.js";
@@ -145,6 +146,36 @@ function unrefTimer(timeout: ReturnType<typeof setTimeout>): void {
   }
 }
 
+function parseInputSourceUrl(rawUrl: string): URL {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    throw new Error("Input source URL must be a valid http or https URL");
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error("Input source URL must use http or https");
+  }
+  return parsed;
+}
+
+function assertInputSourceUrlAllowed(rawUrl: string, policy?: SsrFPolicy): string {
+  const parsed = parseInputSourceUrl(rawUrl);
+  const allowlist = policy?.hostnameAllowlist;
+  if (allowlist?.length) {
+    const hostname = normalizeHostname(parsed.hostname);
+    if (
+      !matchesHostnameAllowlist(
+        hostname,
+        allowlist.map((entry) => normalizeHostname(entry)),
+      )
+    ) {
+      throw new Error(`Input source URL hostname is not in allowlist: ${parsed.hostname}`);
+    }
+  }
+  return parsed.toString();
+}
+
 function rejectOversizedBase64Payload(params: {
   data: string;
   maxBytes: number;
@@ -212,6 +243,7 @@ export async function fetchWithGuard(params: {
   policy?: SsrFPolicy;
   auditContext?: string;
 }): Promise<InputFetchResult> {
+  const url = assertInputSourceUrlAllowed(params.url, params.policy);
   const controller = new AbortController();
   const timeoutError = new Error(`Input source URL fetch timed out after ${params.timeoutMs}ms`);
   const timeout = setTimeout(() => {
@@ -220,7 +252,7 @@ export async function fetchWithGuard(params: {
   unrefTimer(timeout);
   let response: Response;
   try {
-    response = await fetch(params.url, {
+    response = await fetch(url, {
       headers: { "User-Agent": "OpenClaw-Gateway/1.0" },
       signal: controller.signal,
       redirect: params.maxRedirects === 0 ? "error" : "follow",
@@ -233,6 +265,12 @@ export async function fetchWithGuard(params: {
     await discardIgnoredResponseBody(response);
     throw new Error(`Failed to fetch: ${response.status} ${response.statusText}`);
   }
+  try {
+    assertInputSourceUrlAllowed(response.url || url, params.policy);
+  } catch (err) {
+    await discardIgnoredResponseBody(response);
+    throw err;
+  }
 
   let contentLength: number | null;
   try {
@@ -243,9 +281,7 @@ export async function fetchWithGuard(params: {
   }
   if (contentLength !== null && contentLength > params.maxBytes) {
     await discardIgnoredResponseBody(response);
-    throw new Error(
-      `Content too large: ${contentLength} bytes (limit: ${params.maxBytes} bytes)`,
-    );
+    throw new Error(`Content too large: ${contentLength} bytes (limit: ${params.maxBytes} bytes)`);
   }
 
   const buffer = await readResponseWithLimit(response, params.maxBytes);

--- a/src/media/input-files.ts
+++ b/src/media/input-files.ts
@@ -21,6 +21,7 @@ import {
   closeDispatcher,
   createPinnedDispatcher,
   matchesHostnameAllowlist,
+  normalizeHostnameAllowlist,
   resolvePinnedHostnameWithPolicy,
   resolveSsrFPolicyForUrl,
   type LookupFn,
@@ -179,15 +180,10 @@ function parseInputSourceUrl(rawUrl: string): URL {
 function assertInputSourceUrlAllowed(rawUrl: string, policy?: SsrFPolicy): URL {
   const parsed = parseInputSourceUrl(rawUrl);
   const policyForUrl = resolveSsrFPolicyForUrl(parsed, policy);
-  const allowlist = policyForUrl?.hostnameAllowlist;
+  const allowlist = normalizeHostnameAllowlist(policyForUrl?.hostnameAllowlist);
   if (allowlist?.length) {
     const hostname = normalizeHostname(parsed.hostname);
-    if (
-      !matchesHostnameAllowlist(
-        hostname,
-        allowlist.map((entry) => normalizeHostname(entry)),
-      )
-    ) {
+    if (!matchesHostnameAllowlist(hostname, allowlist)) {
       throw new Error(`Input source URL hostname is not in allowlist: ${parsed.hostname}`);
     }
   }

--- a/src/media/input-files.ts
+++ b/src/media/input-files.ts
@@ -29,6 +29,8 @@ import {
 } from "../infra/net/ssrf.js";
 import { createHttp1EnvHttpProxyAgent } from "../infra/net/undici-runtime.js";
 import { logWarn } from "../logger.js";
+import { captureHttpExchange } from "../proxy-capture/runtime.js";
+import { resolveTimerTimeoutMs } from "../shared/number-coercion.js";
 import { convertHeicToJpeg } from "./media-services.js";
 import { extractPdfContent, type PdfExtractedImage } from "./pdf-extract.js";
 
@@ -230,6 +232,28 @@ function rejectOversizedBase64Payload(params: {
   }
 }
 
+function captureInputUrlFetchExchange(params: {
+  url: string;
+  finalUrl: string;
+  init: RequestInit;
+  response: Response;
+  auditContext?: string;
+}): void {
+  captureHttpExchange({
+    url: params.url,
+    method: params.init.method ?? "GET",
+    requestHeaders: params.init.headers as Headers | Record<string, string> | undefined,
+    requestBody: (params.init as RequestInit & { body?: BodyInit | null }).body ?? null,
+    response: params.response,
+    transport: "http",
+    meta: {
+      captureOrigin: "input-url-fetch",
+      ...(params.auditContext ? { auditContext: params.auditContext } : {}),
+      ...(params.finalUrl !== params.url ? { finalUrl: params.finalUrl } : {}),
+    },
+  });
+}
+
 /** Normalizes a MIME value by stripping parameters and lowercasing the media type. */
 export function normalizeMimeType(value: string | undefined): string | undefined {
   const [raw] = value?.split(";") ?? [];
@@ -288,9 +312,10 @@ export async function fetchWithGuard(params: {
   const url = assertInputSourceUrlAllowed(params.url, params.policy);
   const controller = new AbortController();
   const timeoutError = new Error(`Input source URL fetch timed out after ${params.timeoutMs}ms`);
+  const timerTimeoutMs = resolveTimerTimeoutMs(params.timeoutMs, 1);
   const timeout = setTimeout(() => {
     controller.abort(timeoutError);
-  }, params.timeoutMs);
+  }, timerTimeoutMs);
   unrefTimer(timeout);
   let response: Response;
   let dispatcher: Dispatcher | null | undefined;
@@ -298,7 +323,7 @@ export async function fetchWithGuard(params: {
     dispatcher = await createInputFetchDispatcher({
       url,
       policy: params.policy,
-      timeoutMs: params.timeoutMs,
+      timeoutMs: timerTimeoutMs,
       lookupFn: params.lookupFn,
     });
     const init: DispatcherAwareRequestInit = {
@@ -319,6 +344,13 @@ export async function fetchWithGuard(params: {
       await discardIgnoredResponseBody(response);
       throw err;
     }
+    captureInputUrlFetchExchange({
+      url: url.toString(),
+      finalUrl: response.url || url.toString(),
+      init,
+      response,
+      auditContext: params.auditContext,
+    });
 
     let contentLength: number | null;
     try {

--- a/src/media/input-files.ts
+++ b/src/media/input-files.ts
@@ -7,9 +7,24 @@ import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
+import type { Dispatcher } from "undici";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizeHostname } from "../infra/net/hostname.js";
-import { matchesHostnameAllowlist, type SsrFPolicy } from "../infra/net/ssrf.js";
+import {
+  fetchWithRuntimeDispatcherOrMockedGlobal,
+  isMockedFetch,
+  type DispatcherAwareRequestInit,
+} from "../infra/net/runtime-fetch.js";
+import {
+  assertHostnameAllowedWithPolicy,
+  closeDispatcher,
+  createPinnedDispatcher,
+  matchesHostnameAllowlist,
+  resolvePinnedHostnameWithPolicy,
+  resolveSsrFPolicyForUrl,
+  type LookupFn,
+  type SsrFPolicy,
+} from "../infra/net/ssrf.js";
 import { logWarn } from "../logger.js";
 import { convertHeicToJpeg } from "./media-services.js";
 import { extractPdfContent, type PdfExtractedImage } from "./pdf-extract.js";
@@ -159,9 +174,10 @@ function parseInputSourceUrl(rawUrl: string): URL {
   return parsed;
 }
 
-function assertInputSourceUrlAllowed(rawUrl: string, policy?: SsrFPolicy): string {
+function assertInputSourceUrlAllowed(rawUrl: string, policy?: SsrFPolicy): URL {
   const parsed = parseInputSourceUrl(rawUrl);
-  const allowlist = policy?.hostnameAllowlist;
+  const policyForUrl = resolveSsrFPolicyForUrl(parsed, policy);
+  const allowlist = policyForUrl?.hostnameAllowlist;
   if (allowlist?.length) {
     const hostname = normalizeHostname(parsed.hostname);
     if (
@@ -173,7 +189,28 @@ function assertInputSourceUrlAllowed(rawUrl: string, policy?: SsrFPolicy): strin
       throw new Error(`Input source URL hostname is not in allowlist: ${parsed.hostname}`);
     }
   }
-  return parsed.toString();
+  assertHostnameAllowedWithPolicy(parsed.hostname, {
+    ...policyForUrl,
+    hostnameAllowlist: undefined,
+  });
+  return parsed;
+}
+
+async function createInputFetchDispatcher(params: {
+  url: URL;
+  policy: SsrFPolicy | undefined;
+  timeoutMs: number;
+  lookupFn: LookupFn | undefined;
+}): Promise<Dispatcher | null> {
+  if (params.lookupFn === undefined && isMockedFetch(globalThis.fetch)) {
+    return null;
+  }
+  const policyForUrl = resolveSsrFPolicyForUrl(params.url, params.policy);
+  const pinned = await resolvePinnedHostnameWithPolicy(params.url.hostname, {
+    lookupFn: params.lookupFn,
+    policy: policyForUrl,
+  });
+  return createPinnedDispatcher(pinned, undefined, policyForUrl, params.timeoutMs);
 }
 
 function rejectOversizedBase64Payload(params: {
@@ -241,6 +278,7 @@ export async function fetchWithGuard(params: {
   timeoutMs: number;
   maxRedirects: number;
   policy?: SsrFPolicy;
+  lookupFn?: LookupFn;
   auditContext?: string;
 }): Promise<InputFetchResult> {
   const url = assertInputSourceUrlAllowed(params.url, params.policy);
@@ -251,19 +289,28 @@ export async function fetchWithGuard(params: {
   }, params.timeoutMs);
   unrefTimer(timeout);
   let response: Response;
+  let dispatcher: Dispatcher | null = null;
   try {
-    response = await fetch(url, {
+    dispatcher = await createInputFetchDispatcher({
+      url,
+      policy: params.policy,
+      timeoutMs: params.timeoutMs,
+      lookupFn: params.lookupFn,
+    });
+    const init: DispatcherAwareRequestInit = {
       headers: { "User-Agent": "OpenClaw-Gateway/1.0" },
       signal: controller.signal,
       redirect: params.maxRedirects === 0 ? "error" : "follow",
-    });
+      ...(dispatcher ? { dispatcher } : {}),
+    };
+    response = await fetchWithRuntimeDispatcherOrMockedGlobal(url.toString(), init);
 
     if (!response.ok) {
       await discardIgnoredResponseBody(response);
       throw new Error(`Failed to fetch: ${response.status} ${response.statusText}`);
     }
     try {
-      assertInputSourceUrlAllowed(response.url || url, params.policy);
+      assertInputSourceUrlAllowed(response.url || url.toString(), params.policy);
     } catch (err) {
       await discardIgnoredResponseBody(response);
       throw err;
@@ -291,6 +338,7 @@ export async function fetchWithGuard(params: {
     return { buffer, mimeType, contentType };
   } finally {
     clearTimeout(timeout);
+    await closeDispatcher(dispatcher);
   }
 }
 

--- a/src/media/input-files.ts
+++ b/src/media/input-files.ts
@@ -293,7 +293,7 @@ export async function fetchWithGuard(params: {
   }, params.timeoutMs);
   unrefTimer(timeout);
   let response: Response;
-  let dispatcher: Dispatcher | null = null;
+  let dispatcher: Dispatcher | null | undefined;
   try {
     dispatcher = await createInputFetchDispatcher({
       url,
@@ -342,7 +342,7 @@ export async function fetchWithGuard(params: {
     return { buffer, mimeType, contentType };
   } finally {
     clearTimeout(timeout);
-    await closeDispatcher(dispatcher);
+    await closeDispatcher(dispatcher ?? null);
   }
 }
 

--- a/src/media/input-files.ts
+++ b/src/media/input-files.ts
@@ -271,7 +271,7 @@ export function resolveInputFileLimits(config?: InputFileLimitsConfig): InputFil
   };
 }
 
-/** Fetches an input source URL with native redirect, timeout, and byte-limit behavior. */
+/** Fetches an input source URL with timeout, byte-limit, and no-redirect behavior. */
 export async function fetchWithGuard(params: {
   url: string;
   maxBytes: number;
@@ -300,7 +300,7 @@ export async function fetchWithGuard(params: {
     const init: DispatcherAwareRequestInit = {
       headers: { "User-Agent": "OpenClaw-Gateway/1.0" },
       signal: controller.signal,
-      redirect: params.maxRedirects === 0 ? "error" : "follow",
+      redirect: "error",
       ...(dispatcher ? { dispatcher } : {}),
     };
     response = await fetchWithRuntimeDispatcherOrMockedGlobal(url.toString(), init);

--- a/src/media/input-files.ts
+++ b/src/media/input-files.ts
@@ -10,6 +10,7 @@ import {
 import type { Dispatcher } from "undici";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizeHostname } from "../infra/net/hostname.js";
+import { shouldUseEnvHttpProxyForUrl } from "../infra/net/proxy-env.js";
 import {
   fetchWithRuntimeDispatcherOrMockedGlobal,
   isMockedFetch,
@@ -25,6 +26,7 @@ import {
   type LookupFn,
   type SsrFPolicy,
 } from "../infra/net/ssrf.js";
+import { createHttp1EnvHttpProxyAgent } from "../infra/net/undici-runtime.js";
 import { logWarn } from "../logger.js";
 import { convertHeicToJpeg } from "./media-services.js";
 import { extractPdfContent, type PdfExtractedImage } from "./pdf-extract.js";
@@ -210,6 +212,12 @@ async function createInputFetchDispatcher(params: {
     lookupFn: params.lookupFn,
     policy: policyForUrl,
   });
+  if (
+    process.env["OPENCLAW_PROXY_ACTIVE"] === "1" &&
+    shouldUseEnvHttpProxyForUrl(params.url.toString())
+  ) {
+    return createHttp1EnvHttpProxyAgent(undefined, params.timeoutMs);
+  }
   return createPinnedDispatcher(pinned, undefined, policyForUrl, params.timeoutMs);
 }
 

--- a/src/plugins/contracts/plugin-sdk-package-contract-guardrails.test.ts
+++ b/src/plugins/contracts/plugin-sdk-package-contract-guardrails.test.ts
@@ -788,7 +788,18 @@ describe("plugin-sdk package contract guardrails", () => {
   it("keeps configured local-origin fetch helpers out of the public SSRF runtime", async () => {
     const ssrfRuntime = await import("../../plugin-sdk/ssrf-runtime.js");
 
+    expect(ssrfRuntime).toHaveProperty("fetchWithSsrFGuard");
     expect(ssrfRuntime).not.toHaveProperty("fetchConfiguredLocalOriginWithSsrFGuard");
+  });
+
+  it("marks fetchWithSsrFGuard as deprecated while keeping the public SDK export", async () => {
+    const ssrfRuntime = await import("../../plugin-sdk/ssrf-runtime.js");
+    const source = fs.readFileSync(resolve(REPO_ROOT, "src/infra/net/fetch-guard.ts"), "utf8");
+
+    expect(ssrfRuntime).toHaveProperty("fetchWithSsrFGuard");
+    expect(source).toMatch(
+      /\/\*\*[\s\S]*?@deprecated[\s\S]*?\*\/\nexport async function fetchWithSsrFGuard\(params: GuardedFetchOptions\)/,
+    );
   });
 
   it("keeps bundled plugin SDK compatibility subpaths explicitly classified", () => {


### PR DESCRIPTION
## Summary

- keep `fetchWithSsrFGuard` exported for plugin SDK compatibility, but mark it deprecated
- move provider transport and direct `web_fetch` off the guarded fetch helper and onto native fetch / configured provider transport
- remove deprecated generic fetch policy keys through doctor migration and config help/docs
- update media URL fetch handling to use native redirect behavior while preserving configured input URL allowlists before fetch and after the final response URL

## Verification

- `git diff --check origin/main...HEAD`
- `node scripts/run-vitest.mjs src/agents/provider-transport-fetch.test.ts src/agents/tools/web-tools.fetch.test.ts src/agents/tools/web-fetch.ssrf.test.ts src/media/fetch.test.ts src/media/input-files.fetch-guard.test.ts src/commands/doctor/shared/legacy-config-migrate.test.ts src/commands/doctor/shared/deprecation-compat.test.ts src/config/schema.help.quality.test.ts src/plugins/contracts/plugin-sdk-package-contract-guardrails.test.ts -- --reporter=verbose`

## Real behavior proof

Behavior addressed: Core provider transport, direct `web_fetch`, media URL fetches, and doctor/config/docs now follow the native-fetch migration model while the SDK guarded fetch export remains compatible.

Real environment tested: Local macOS worktree using the repo Vitest wrapper.

Exact steps or command run after this patch: `git diff --check origin/main...HEAD`; focused Vitest wrapper command listed above.

Evidence after fix: The focused wrapper run passed 6 Vitest shards and 296 tests. Covered provider transport, direct `web_fetch` network policy, web fetch extraction fallback behavior, media remote fetch/read behavior, input-file URL allowlists, doctor deprecation migration, config help quality, and plugin SDK package contract guardrails.

Observed result after fix: Direct `web_fetch` reaches private/fake-IP/local URLs without the old SSRF policy, rejects non-HTTP(S) URLs before fetch, ignores the old trusted-env-proxy path, and keeps provider fallback behavior. Media URL fetches use native redirect behavior and still enforce configured URL allowlists before fetch and on the final response URL.

What was not tested: Browser/CDP SSRF policy runtime behavior was not tested because this PR does not change browser policy; `browser.ssrfPolicy` remains a separate surface.
