### PR TITLE
fix(ci): repair main lint and import graph checks

### DIFF
--- a/extensions/device-pair/notify.ts
+++ b/extensions/device-pair/notify.ts
@@ -108,7 +108,7 @@ async function readNotifyState(api: OpenClawPluginApi): Promise<NotifyStateFile>
 
   const subscribers = subscriberEntries
     .map((entry) => entry.value)
-    .sort((a, b) => a.addedAtMs - b.addedAtMs);
+    .toSorted((a, b) => a.addedAtMs - b.addedAtMs);
   const notifiedRequestIds: Record<string, number> = {};
   for (const entry of seenRequestEntries) {
     const requestId = normalizeOptionalString(entry.value.requestId);

--- a/extensions/memory-core/doctor-contract-api.test.ts
+++ b/extensions/memory-core/doctor-contract-api.test.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
   createPluginStateKeyedStoreForTests,
   resetPluginStateStoreForTests,
@@ -53,11 +54,11 @@ describe("memory-core doctor dreaming migration", () => {
   }
 
   function migrationParams(
-    config: unknown = {
+    config: OpenClawConfig = {
       agents: {
         list: [{ id: "main", workspace: workspaceDir }],
       },
-    },
+    } as OpenClawConfig,
   ) {
     return {
       config,
@@ -242,7 +243,7 @@ describe("memory-core doctor dreaming migration", () => {
       }),
       "utf8",
     );
-    const config = { agents: { list: [{ id: "main", default: true }] } };
+    const config = { agents: { list: [{ id: "main", default: true }] } } as OpenClawConfig;
 
     const preview = await stateMigrations[0].detectLegacyState(migrationParams(config));
     expect(preview?.preview).toEqual([expect.stringContaining("Memory Core short-term recall")]);

--- a/extensions/memory-core/doctor-contract-api.ts
+++ b/extensions/memory-core/doctor-contract-api.ts
@@ -51,7 +51,7 @@ async function fileExists(filePath: string): Promise<boolean> {
   }
 }
 
-async function readJsonFile(filePath: string): Promise<unknown | null> {
+async function readJsonFile(filePath: string): Promise<unknown> {
   return JSON.parse(await fs.readFile(filePath, "utf8")) as unknown;
 }
 

--- a/extensions/memory-core/src/dreaming-state.ts
+++ b/extensions/memory-core/src/dreaming-state.ts
@@ -80,31 +80,32 @@ export function memoryCoreStateReference(namespace: string, workspaceDir: string
   return `plugin-state:${MEMORY_CORE_PLUGIN_ID}/${namespace}/${memoryCoreWorkspaceStateKey(workspaceDir)}`;
 }
 
-function openWorkspaceStore<T>(namespace: string): PluginStateKeyedStore<WorkspaceValue<T>> {
-  return openMemoryCoreStateStore<WorkspaceValue<T>>({
+function openWorkspaceStore(namespace: string): PluginStateKeyedStore<WorkspaceValue<unknown>> {
+  return openMemoryCoreStateStore<WorkspaceValue<unknown>>({
     namespace,
     maxEntries: DREAMING_WORKSPACE_STATE_MAX_ENTRIES,
   });
 }
 
+// oxlint-disable-next-line typescript/no-unnecessary-type-parameters -- Callers bind plugin-state JSON values by namespace.
 export async function readMemoryCoreWorkspaceEntries<T>(params: {
   namespace: string;
   workspaceDir: string;
 }): Promise<Array<{ key: string; value: T }>> {
   const workspaceKey = memoryCoreWorkspaceStateKey(params.workspaceDir);
   const prefix = `${workspaceKey}:`;
-  const entries = await openWorkspaceStore<T>(params.namespace).entries();
+  const entries = await openWorkspaceStore(params.namespace).entries();
   return entries
     .filter((entry) => entry.key.startsWith(prefix) && entry.value.workspaceKey === workspaceKey)
-    .map((entry) => ({ key: entry.value.key, value: entry.value.value }));
+    .map((entry) => ({ key: entry.value.key, value: entry.value.value as T }));
 }
 
-export async function writeMemoryCoreWorkspaceEntries<T>(params: {
+export async function writeMemoryCoreWorkspaceEntries(params: {
   namespace: string;
   workspaceDir: string;
-  entries: Array<{ key: string; value: T }>;
+  entries: Array<{ key: string; value: unknown }>;
 }): Promise<void> {
-  const store = openWorkspaceStore<T>(params.namespace);
+  const store = openWorkspaceStore(params.namespace);
   const workspaceKey = memoryCoreWorkspaceStateKey(params.workspaceDir);
   const prefix = `${workspaceKey}:`;
   const replacementKeys = new Set<string>();
@@ -126,14 +127,14 @@ export async function writeMemoryCoreWorkspaceEntries<T>(params: {
   }
 }
 
-export async function writeMemoryCoreWorkspaceEntry<T>(params: {
+export async function writeMemoryCoreWorkspaceEntry(params: {
   namespace: string;
   workspaceDir: string;
   key: string;
-  value: T;
+  value: unknown;
 }): Promise<void> {
   const workspaceKey = memoryCoreWorkspaceStateKey(params.workspaceDir);
-  await openWorkspaceStore<T>(params.namespace).register(
+  await openWorkspaceStore(params.namespace).register(
     memoryCoreWorkspaceEntryKey(params.workspaceDir, params.key),
     {
       version: 1,

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -2499,7 +2499,6 @@ export async function auditShortTermPromotionArtifacts(params: {
   const storePath = resolveStorePath(workspaceDir);
   const lockPath = resolveLockPath(workspaceDir);
   const issues: ShortTermAuditIssue[] = [];
-  let exists = false;
   let entryCount = 0;
   let promotedCount = 0;
   let spacedEntryCount = 0;
@@ -2513,7 +2512,7 @@ export async function auditShortTermPromotionArtifacts(params: {
     namespace: SHORT_TERM_RECALL_NAMESPACE,
     workspaceDir,
   });
-  exists = rawEntries.length > 0;
+  const exists = rawEntries.length > 0;
   if (exists) {
     const parsed = {
       version: 1,
@@ -2788,9 +2787,7 @@ export const testing = {
       writeMemoryCoreWorkspaceEntries({
         namespace: SHORT_TERM_RECALL_NAMESPACE,
         workspaceDir,
-        entries: entries
-          ? Object.entries(entries).map(([key, value]) => ({ key, value: value as unknown }))
-          : [],
+        entries: entries ? Object.entries(entries).map(([key, value]) => ({ key, value })) : [],
       }),
       writeMemoryCoreWorkspaceEntry({
         namespace: SHORT_TERM_META_NAMESPACE,
@@ -2812,9 +2809,7 @@ export const testing = {
       writeMemoryCoreWorkspaceEntries({
         namespace: SHORT_TERM_PHASE_SIGNAL_NAMESPACE,
         workspaceDir,
-        entries: entries
-          ? Object.entries(entries).map(([key, value]) => ({ key, value: value as unknown }))
-          : [],
+        entries: entries ? Object.entries(entries).map(([key, value]) => ({ key, value })) : [],
       }),
       writeMemoryCoreWorkspaceEntry({
         namespace: SHORT_TERM_META_NAMESPACE,

--- a/scripts/e2e/kitchen-sink-rpc-walk.mjs
+++ b/scripts/e2e/kitchen-sink-rpc-walk.mjs
@@ -283,9 +283,12 @@ export function runCommand(command, args, options = {}) {
             });
           }
         })
-        .catch((error) => {
-          lastResourceSampleError = error;
-        })
+        .catch(
+          /** @param {unknown} error */
+          (error) => {
+            lastResourceSampleError = error;
+          },
+        )
         .finally(() => {
           resourceSampleInFlight = null;
         });

--- a/scripts/lib/kova-report-gate.mjs
+++ b/scripts/lib/kova-report-gate.mjs
@@ -6,8 +6,7 @@ function numericCount(value) {
   if (typeof value !== "number") {
     return undefined;
   }
-  const count = Number(value);
-  return Number.isFinite(count) ? count : undefined;
+  return Number.isFinite(value) ? value : undefined;
 }
 
 const rssMetricIds = ["peakRssMb", "resourcePeakGatewayRssMb"];

--- a/scripts/openclaw-cross-os-release-checks.ts
+++ b/scripts/openclaw-cross-os-release-checks.ts
@@ -3965,19 +3965,24 @@ export async function startStaticFileServer(params) {
     close: () => {
       closePromise ??= new Promise((resolvePromise, rejectPromise) => {
         closeStaticFileServerConnections(server, sockets);
-        server.close(async (error) => {
-          const closeLogError = await finishStaticFileServerLog(logStream, logStreamError).catch(
-            (logError) => logError,
+        server.close((error) => {
+          void finishStaticFileServerLog(logStream, logStreamError).then(
+            () => {
+              if (error) {
+                rejectPromise(error);
+                return;
+              }
+              resolvePromise();
+            },
+            (logError: unknown) => {
+              rejectPromise(
+                error ??
+                  (logError instanceof Error
+                    ? logError
+                    : new Error(`Static file server log close failed: ${formatError(logError)}`)),
+              );
+            },
           );
-          if (error) {
-            rejectPromise(error);
-            return;
-          }
-          if (closeLogError) {
-            rejectPromise(closeLogError);
-            return;
-          }
-          resolvePromise();
         });
         closeStaticFileServerConnections(server, sockets);
       });

--- a/scripts/test-group-report.mjs
+++ b/scripts/test-group-report.mjs
@@ -465,7 +465,7 @@ function isFiniteNumber(value) {
 }
 
 function validateCounter(counter, reportPath, fieldName, index = null) {
-  const label = index === null ? fieldName : `${fieldName}[${index}]`;
+  const label = index === null ? fieldName : `${fieldName}[${String(index)}]`;
   if (!counter || typeof counter !== "object" || Array.isArray(counter)) {
     throw new Error(
       `[test-group-report] invalid grouped report ${reportPath}: ${label} must be an object`,

--- a/scripts/test-live-media.ts
+++ b/scripts/test-live-media.ts
@@ -353,7 +353,9 @@ export async function buildRunPlan(
       (
         await Promise.all(
           options.suites.flatMap((suiteId) =>
-            MEDIA_SUITES[suiteId].providers.map((provider) => getProviderEnvVarsImpl(provider)),
+            MEDIA_SUITES[suiteId].providers.map((provider) =>
+              Promise.resolve(getProviderEnvVarsImpl(provider)),
+            ),
           ),
         )
       ).flat(),

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -20,6 +20,7 @@ import { isAcpEnabledByPolicy, resolveAcpAgentPolicyError } from "../acp/policy.
 import { readAcpSessionMeta } from "../acp/runtime/session-meta.js";
 import { DEFAULT_HEARTBEAT_EVERY } from "../auto-reply/heartbeat.js";
 import { formatThinkingLevels } from "../auto-reply/thinking.js";
+import { formatConversationTarget } from "../channels/conversation-delivery-target.js";
 import {
   resolveChannelDefaultBindingPlacement,
   resolveInboundConversationResolution,
@@ -65,11 +66,7 @@ import {
 } from "../routing/session-key.js";
 import { createRunningTaskRun } from "../tasks/detached-task-runtime.js";
 import { listTasksForOwnerKey } from "../tasks/runtime-internal.js";
-import {
-  deliveryContextFromSession,
-  formatConversationTarget,
-  normalizeDeliveryContext,
-} from "../utils/delivery-context.js";
+import { deliveryContextFromSession, normalizeDeliveryContext } from "../utils/delivery-context.js";
 import {
   type AcpSpawnParentRelayHandle,
   resolveAcpSpawnStreamLogPath,

--- a/src/agents/agent-auth-credentials.ts
+++ b/src/agents/agent-auth-credentials.ts
@@ -3,7 +3,7 @@ import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { asDateTimestampMs } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { coerceSecretRef } from "../config/types.secrets.js";
-import type { AuthProfileCredential, AuthProfileStore } from "./auth-profiles.js";
+import type { AuthProfileCredential, AuthProfileStore } from "./auth-profiles/types.js";
 
 // Converts auth-profile credentials into the compact credential map consumed by
 // agent runtimes. Secret refs can be represented by markers without reading

--- a/src/auto-reply/reply/reply-dispatcher.runtime-types.ts
+++ b/src/auto-reply/reply/reply-dispatcher.runtime-types.ts
@@ -1,4 +1,0 @@
-// Runtime-only type alias for reply dispatcher creation.
-/** Type of the lazy reply dispatcher factory used by runtime dispatch paths. */
-export type CreateReplyDispatcherWithTyping =
-  typeof import("./reply-dispatcher.js").createReplyDispatcherWithTyping;

--- a/src/channels/conversation-delivery-target.ts
+++ b/src/channels/conversation-delivery-target.ts
@@ -1,0 +1,78 @@
+// Conversation delivery target helpers resolve channel-owned route metadata.
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { normalizeMessageChannel } from "../utils/message-channel.js";
+import { getChannelPlugin, normalizeChannelId } from "./plugins/index.js";
+
+type ConversationTargetParams = {
+  channel?: string;
+  conversationId?: string | number;
+  parentConversationId?: string | number;
+};
+
+function normalizeConversationId(value: string | number | undefined): string | undefined {
+  return typeof value === "number" && Number.isFinite(value)
+    ? String(Math.trunc(value))
+    : typeof value === "string"
+      ? normalizeOptionalString(value)
+      : undefined;
+}
+
+function normalizeConversationTargetParams(params: ConversationTargetParams): {
+  channel?: string;
+  conversationId?: string;
+  parentConversationId?: string;
+} {
+  const channel =
+    typeof params.channel === "string"
+      ? (normalizeMessageChannel(params.channel) ?? params.channel.trim())
+      : undefined;
+  const conversationId = normalizeConversationId(params.conversationId);
+  const parentConversationId = normalizeConversationId(params.parentConversationId);
+  return { channel, conversationId, parentConversationId };
+}
+
+/** Formats a conversation id into a deliverable target, using plugin hooks before generic fallback. */
+export function formatConversationTarget(params: ConversationTargetParams): string | undefined {
+  const { channel, conversationId, parentConversationId } =
+    normalizeConversationTargetParams(params);
+  if (!channel || !conversationId) {
+    return undefined;
+  }
+  const pluginTarget = normalizeChannelId(channel)
+    ? getChannelPlugin(normalizeChannelId(channel)!)?.messaging?.resolveDeliveryTarget?.({
+        conversationId,
+        parentConversationId,
+      })
+    : null;
+  if (pluginTarget?.to?.trim()) {
+    return pluginTarget.to.trim();
+  }
+  return `channel:${conversationId}`;
+}
+
+/** Resolves a channel conversation into target/thread fields for delivery routing. */
+export function resolveConversationDeliveryTarget(params: {
+  channel?: string;
+  conversationId?: string | number;
+  parentConversationId?: string | number;
+}): { to?: string; threadId?: string } {
+  const { channel, conversationId, parentConversationId } =
+    normalizeConversationTargetParams(params);
+  const pluginTarget =
+    channel && conversationId
+      ? getChannelPlugin(
+          normalizeChannelId(channel) ?? channel,
+        )?.messaging?.resolveDeliveryTarget?.({
+          conversationId,
+          parentConversationId,
+        })
+      : null;
+  if (pluginTarget) {
+    return {
+      ...(pluginTarget.to?.trim() ? { to: pluginTarget.to.trim() } : {}),
+      ...(pluginTarget.threadId?.trim() ? { threadId: pluginTarget.threadId.trim() } : {}),
+    };
+  }
+  const to = formatConversationTarget(params);
+  return { to };
+}

--- a/src/channels/route-projection.ts
+++ b/src/channels/route-projection.ts
@@ -17,9 +17,9 @@ import {
   deliveryContextFromSession,
   normalizeDeliveryContext,
   normalizeSessionDeliveryFields,
-  resolveConversationDeliveryTarget,
   type DeliveryContext,
 } from "../utils/delivery-context.js";
+import { resolveConversationDeliveryTarget } from "./conversation-delivery-target.js";
 
 /** Channel route normalized enough to address an outbound delivery target. */
 export type RoutableChannelRouteRef = ChannelRouteRef & {

--- a/src/plugin-sdk/channel-entry-contract.ts
+++ b/src/plugin-sdk/channel-entry-contract.ts
@@ -21,7 +21,6 @@ import {
   type PluginModuleLoaderFactory,
   type PluginModuleLoaderCache,
 } from "../plugins/plugin-module-loader-cache.js";
-import type { PluginRuntime } from "../plugins/runtime/types.js";
 import { buildPluginLoaderAliasMap, resolveLoaderPackageRoot } from "../plugins/sdk-alias.js";
 import type {
   AnyAgentTool,
@@ -30,6 +29,8 @@ import type {
   PluginCommandContext,
 } from "../plugins/types.js";
 import { toSafeImportPath } from "../shared/import-specifier.js";
+
+type BundledChannelRuntime = OpenClawPluginApi["runtime"];
 
 export type {
   AnyAgentTool,
@@ -126,7 +127,7 @@ export type BundledChannelEntryContract<TPlugin = ChannelPlugin> = {
   loadChannelAccountInspector?: (
     options?: BundledEntryModuleLoadOptions,
   ) => NonNullable<ChannelPlugin["config"]["inspectAccount"]>;
-  setChannelRuntime?: (runtime: PluginRuntime) => void;
+  setChannelRuntime?: (runtime: BundledChannelRuntime) => void;
 };
 
 /** Runtime contract returned by a bundled channel's setup-only entrypoint definition. */
@@ -142,7 +143,7 @@ export type BundledChannelSetupEntryContract<TPlugin = ChannelPlugin> = {
   loadLegacySessionSurface?: (
     options?: BundledEntryModuleLoadOptions,
   ) => BundledChannelLegacySessionSurface;
-  setChannelRuntime?: (runtime: PluginRuntime) => void;
+  setChannelRuntime?: (runtime: BundledChannelRuntime) => void;
   registerSetupRuntime?: (api: OpenClawPluginApi) => void;
   features?: BundledChannelSetupEntryFeatures;
 };
@@ -537,8 +538,8 @@ export function defineBundledChannelEntry<TPlugin = ChannelPlugin>({
         )
     : undefined;
   const setChannelRuntime = runtime
-    ? (pluginRuntime: PluginRuntime) => {
-        const setter = loadBundledEntryExportSync<(runtime: PluginRuntime) => void>(
+    ? (pluginRuntime: BundledChannelRuntime) => {
+        const setter = loadBundledEntryExportSync<(runtime: BundledChannelRuntime) => void>(
           importMetaUrl,
           runtime,
         );
@@ -604,8 +605,8 @@ export function defineBundledChannelSetupEntry<TPlugin = ChannelPlugin>({
   // When runtime wiring is needed, expose only the setter so the loader can hand
   // the setup surface the active runtime without importing the full channel entry.
   const setChannelRuntime = runtime
-    ? (pluginRuntime: PluginRuntime) => {
-        const setter = loadBundledEntryExportSync<(runtime: PluginRuntime) => void>(
+    ? (pluginRuntime: BundledChannelRuntime) => {
+        const setter = loadBundledEntryExportSync<(runtime: BundledChannelRuntime) => void>(
           importMetaUrl,
           runtime,
         );

--- a/src/plugins/runtime/types-channel.ts
+++ b/src/plugins/runtime/types-channel.ts
@@ -5,12 +5,14 @@
  * inside the owning plugin package instead of hanging off core runtime slots
  * keyed by plugin id.
  */
-import type { DispatchReplyWithBufferedBlockDispatcher } from "../../auto-reply/reply/provider-dispatcher.types.js";
-import type { CreateReplyDispatcherWithTyping } from "../../auto-reply/reply/reply-dispatcher.runtime-types.js";
 import type {
   ReadChannelAllowFromStoreForAccount,
   UpsertChannelPairingRequestForAccount,
 } from "../../pairing/pairing-store.types.js";
+type DispatchReplyWithBufferedBlockDispatcher =
+  typeof import("../../auto-reply/reply/provider-dispatcher.js").dispatchReplyWithBufferedBlockDispatcher;
+type CreateReplyDispatcherWithTyping =
+  typeof import("../../auto-reply/reply/reply-dispatcher.js").createReplyDispatcherWithTyping;
 type ShouldHandleTextCommands =
   import("../../auto-reply/commands-registry.runtime-types.js").ShouldHandleTextCommands;
 type IsControlCommandMessage =

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -6,6 +6,7 @@ import type {
   UnifiedModelCatalogKind,
 } from "@openclaw/model-catalog-core/model-catalog-types";
 import type { Command } from "commander";
+import type { AgentMessage, StreamFn } from "../../packages/agent-core/src/types.js";
 import type {
   ApiKeyCredential,
   AuthProfileCredential,
@@ -15,8 +16,6 @@ import type {
 import type { FailoverReason } from "../agents/embedded-agent-helpers/types.js";
 import type { AgentHarness } from "../agents/harness/types.js";
 import type { ModelCatalogEntry } from "../agents/model-catalog.types.js";
-import type { AgentMessage } from "../agents/runtime/index.js";
-import type { StreamFn } from "../agents/runtime/index.js";
 import type { ProviderSystemPromptContribution } from "../agents/system-prompt-contribution.js";
 import type { PromptMode } from "../agents/system-prompt.types.js";
 import type { AnyAgentTool } from "../agents/tools/common.js";

--- a/src/security/dm-policy-shared.ts
+++ b/src/security/dm-policy-shared.ts
@@ -1,15 +1,11 @@
 // Shares direct-message policy normalization for channel audits.
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
-import { resolveGroupAllowFromSources } from "../channels/allow-from.js";
+import { mergeDmAllowFromSources, resolveGroupAllowFromSources } from "../channels/allow-from.js";
 import { resolveControlCommandGate } from "../channels/command-gating.js";
-import { resolveDmAllowAuditState } from "../channels/message-access/dm-allow-state.js";
-import {
-  readChannelIngressStoreAllowFromForDmPolicy,
-  resolveChannelIngressEffectiveAllowFromLists,
-} from "../channels/message-access/runtime.js";
-import type { ChannelId } from "../channels/plugins/types.public.js";
 import type { GroupPolicy } from "../config/types.base.js";
 import { evaluateMatchedGroupAccessForPolicy } from "../plugin-sdk/group-access.js";
+
+type ChannelId = string;
 
 /**
  * Derive a stable main-DM owner from a single-entry allowlist.
@@ -48,7 +44,24 @@ export function resolveEffectiveAllowFromLists(params: {
   effectiveAllowFrom: string[];
   effectiveGroupAllowFrom: string[];
 } {
-  return resolveChannelIngressEffectiveAllowFromLists(params);
+  const allowFrom = Array.isArray(params.allowFrom) ? params.allowFrom : undefined;
+  const groupAllowFrom = Array.isArray(params.groupAllowFrom) ? params.groupAllowFrom : undefined;
+  const storeAllowFrom = Array.isArray(params.storeAllowFrom) ? params.storeAllowFrom : undefined;
+  const effectiveAllowFrom = normalizeStringEntries(
+    mergeDmAllowFromSources({
+      allowFrom,
+      storeAllowFrom,
+      dmPolicy: params.dmPolicy ?? undefined,
+    }),
+  );
+  const effectiveGroupAllowFrom = normalizeStringEntries(
+    resolveGroupAllowFromSources({
+      allowFrom,
+      groupAllowFrom,
+      fallbackToAllowFrom: params.groupAllowFromFallbackToAllowFrom ?? undefined,
+    }),
+  );
+  return { effectiveAllowFrom, effectiveGroupAllowFrom };
 }
 
 /** Admission decision returned by legacy DM/group access helpers. */
@@ -152,6 +165,8 @@ export async function readStoreAllowFromForDmPolicy(params: {
   shouldRead?: boolean | null;
   readStore?: (provider: ChannelId, accountId: string) => Promise<string[]>;
 }): Promise<string[]> {
+  const { readChannelIngressStoreAllowFromForDmPolicy } =
+    await import("../channels/message-access/runtime.js");
   return await readChannelIngressStoreAllowFromForDmPolicy(params);
 }
 
@@ -353,5 +368,6 @@ export async function resolveDmAllowState(params: {
   allowCount: number;
   isMultiUserDm: boolean;
 }> {
+  const { resolveDmAllowAuditState } = await import("../channels/message-access/dm-allow-state.js");
   return await resolveDmAllowAuditState(params);
 }

--- a/src/skills/workshop/policy.ts
+++ b/src/skills/workshop/policy.ts
@@ -1,7 +1,7 @@
 // Workshop policy helpers validate generated skill drafts against workspace policy.
 import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import type { PluginHookBeforeToolCallResult } from "../../plugins/types.js";
+import type { PluginHookBeforeToolCallResult } from "../../plugins/hook-types.js";
 import { resolveSkillWorkshopConfig } from "./config.js";
 
 const SKILL_WORKSHOP_LIFECYCLE_ACTIONS = new Set(["apply", "reject", "quarantine"]);

--- a/src/skills/workshop/policy.ts
+++ b/src/skills/workshop/policy.ts
@@ -8,13 +8,17 @@ const SKILL_WORKSHOP_LIFECYCLE_ACTIONS = new Set(["apply", "reject", "quarantine
 
 type SkillWorkshopLifecycleAction = "apply" | "reject" | "quarantine";
 
+function isSkillWorkshopLifecycleAction(action: string): action is SkillWorkshopLifecycleAction {
+  return SKILL_WORKSHOP_LIFECYCLE_ACTIONS.has(action);
+}
+
 // Only lifecycle actions mutate proposals and therefore require approval checks.
 function readLifecycleAction(params: unknown): SkillWorkshopLifecycleAction | undefined {
   const action = asNullableRecord(params)?.action;
-  if (typeof action !== "string" || !SKILL_WORKSHOP_LIFECYCLE_ACTIONS.has(action)) {
+  if (typeof action !== "string" || !isSkillWorkshopLifecycleAction(action)) {
     return undefined;
   }
-  return action as SkillWorkshopLifecycleAction;
+  return action;
 }
 
 function lifecycleApprovalText(action: SkillWorkshopLifecycleAction): {

--- a/src/utils/delivery-context.test.ts
+++ b/src/utils/delivery-context.test.ts
@@ -1,15 +1,17 @@
 // Delivery context tests cover context normalization for channel delivery.
 import { beforeEach, describe, expect, it } from "vitest";
+import {
+  formatConversationTarget,
+  resolveConversationDeliveryTarget,
+} from "../channels/conversation-delivery-target.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
 import { createChannelTestPluginBase, createTestRegistry } from "../test-utils/channel-plugins.js";
 import {
-  formatConversationTarget,
   deliveryContextKey,
   deliveryContextFromSession,
   mergeDeliveryContext,
   normalizeDeliveryContext,
   normalizeSessionDeliveryFields,
-  resolveConversationDeliveryTarget,
 } from "./delivery-context.js";
 
 describe("delivery context helpers", () => {

--- a/src/utils/delivery-context.ts
+++ b/src/utils/delivery-context.ts
@@ -1,7 +1,4 @@
 // Delivery context helpers normalize target and route metadata for delivery.
-import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import { getChannelPlugin, normalizeChannelId } from "../channels/plugins/index.js";
-import { normalizeMessageChannel } from "./message-channel.js";
 export {
   channelRouteFromDeliveryContext,
   deliveryContextFromChannelRoute,
@@ -12,77 +9,3 @@ export {
   normalizeSessionDeliveryFields,
 } from "./delivery-context.shared.js";
 export type { DeliveryContext, DeliveryContextSessionSource } from "./delivery-context.types.js";
-
-type ConversationTargetParams = {
-  channel?: string;
-  conversationId?: string | number;
-  parentConversationId?: string | number;
-};
-
-function normalizeConversationId(value: string | number | undefined): string | undefined {
-  return typeof value === "number" && Number.isFinite(value)
-    ? String(Math.trunc(value))
-    : typeof value === "string"
-      ? normalizeOptionalString(value)
-      : undefined;
-}
-
-function normalizeConversationTargetParams(params: ConversationTargetParams): {
-  channel?: string;
-  conversationId?: string;
-  parentConversationId?: string;
-} {
-  const channel =
-    typeof params.channel === "string"
-      ? (normalizeMessageChannel(params.channel) ?? params.channel.trim())
-      : undefined;
-  const conversationId = normalizeConversationId(params.conversationId);
-  const parentConversationId = normalizeConversationId(params.parentConversationId);
-  return { channel, conversationId, parentConversationId };
-}
-
-/** Formats a conversation id into a deliverable target, using plugin hooks before generic fallback. */
-export function formatConversationTarget(params: ConversationTargetParams): string | undefined {
-  const { channel, conversationId, parentConversationId } =
-    normalizeConversationTargetParams(params);
-  if (!channel || !conversationId) {
-    return undefined;
-  }
-  const pluginTarget = normalizeChannelId(channel)
-    ? getChannelPlugin(normalizeChannelId(channel)!)?.messaging?.resolveDeliveryTarget?.({
-        conversationId,
-        parentConversationId,
-      })
-    : null;
-  if (pluginTarget?.to?.trim()) {
-    return pluginTarget.to.trim();
-  }
-  return `channel:${conversationId}`;
-}
-
-/** Resolves a channel conversation into target/thread fields for delivery routing. */
-export function resolveConversationDeliveryTarget(params: {
-  channel?: string;
-  conversationId?: string | number;
-  parentConversationId?: string | number;
-}): { to?: string; threadId?: string } {
-  const { channel, conversationId, parentConversationId } =
-    normalizeConversationTargetParams(params);
-  const pluginTarget =
-    channel && conversationId
-      ? getChannelPlugin(
-          normalizeChannelId(channel) ?? channel,
-        )?.messaging?.resolveDeliveryTarget?.({
-          conversationId,
-          parentConversationId,
-        })
-      : null;
-  if (pluginTarget) {
-    return {
-      ...(pluginTarget.to?.trim() ? { to: pluginTarget.to.trim() } : {}),
-      ...(pluginTarget.threadId?.trim() ? { threadId: pluginTarget.threadId.trim() } : {}),
-    };
-  }
-  const to = formatConversationTarget(params);
-  return { to };
-}

--- a/test/scripts/lint-suppressions.test.ts
+++ b/test/scripts/lint-suppressions.test.ts
@@ -192,6 +192,7 @@ describe("production lint suppressions", () => {
         "extensions/discord/src/test-support/provider.test-support.ts|typescript/no-unnecessary-type-parameters|1",
         "extensions/feishu/src/bitable.ts|typescript/no-unnecessary-type-parameters|1",
         "extensions/matrix/src/onboarding.test-harness.ts|typescript/no-unnecessary-type-parameters|1",
+        "extensions/memory-core/src/dreaming-state.ts|typescript/no-unnecessary-type-parameters|1",
         "extensions/slack/src/monitor/provider-support.ts|typescript/no-unnecessary-type-parameters|1",
         "src/channels/plugins/channel-runtime-surface.types.ts|typescript/no-unnecessary-type-parameters|1",
         "src/channels/plugins/contracts/test-helpers.ts|typescript/no-unnecessary-type-parameters|1",


### PR DESCRIPTION
## Summary

Fixes unrelated `main` CI failures observed on CI run https://github.com/openclaw/openclaw/actions/runs/27079803851 at `b804d20da79397bb1b405ec83be0935618a9d58b`.

- repairs current oxlint failures in memory-core, device-pair, and script files
- updates memory-core doctor test helpers to pass the current `OpenClawConfig` contract
- breaks the remaining madge import cycle by keeping channel-aware delivery target resolution in `src/channels/**`, removing broad plugin/runtime type imports from hot/shared boundaries, and lazily loading deprecated DM policy runtime wrappers
- preserves the gateway-watch built-artifact invariant that failed on `main`

## Verification

- `node scripts/run-oxlint-shards.mjs --threads=8`
- `node scripts/run-vitest.mjs test/scripts/lint-suppressions.test.ts`
- `node scripts/run-vitest.mjs extensions/memory-core/doctor-contract-api.test.ts src/utils/delivery-context.test.ts src/plugin-sdk/channel-entry-contract.test.ts src/plugin-sdk/core.test.ts`
- `pnpm check:test-types`
- `node --import tsx scripts/check-import-cycles.ts && node --import tsx scripts/check-madge-import-cycles.ts`
- `pnpm build`
- `node scripts/check-gateway-watch-regression.mjs --skip-build --ready-timeout-ms 5000`
- `git diff --check`

Gateway-watch after fix:

```json
{
  "watchTriggeredBuild": false,
  "readyBeforeWindow": true,
  "cpuMs": 20,
  "distRuntimeFileGrowth": 0,
  "distRuntimeByteGrowth": 0,
  "distRuntimeAddedPaths": 0
}
```
