### PR TITLE
fix(openrouter): reconcile streamed generation cost

### DIFF
--- a/extensions/openrouter/index.test.ts
+++ b/extensions/openrouter/index.test.ts
@@ -1,4 +1,5 @@
 // Openrouter tests cover index plugin behavior.
+import { createAssistantMessageEventStream } from "openclaw/plugin-sdk/llm";
 import {
   registerProviderPlugin,
   registerSingleProviderPlugin,
@@ -14,6 +15,64 @@ import {
   isOpenRouterProxyReasoningUnsupportedModel,
 } from "./provider-catalog.js";
 import { resolveThinkingProfile } from "./provider-policy-api.js";
+
+function createOpenRouterDoneStream(params: { responseId: string; totalCost: number }) {
+  const stream = createAssistantMessageEventStream();
+  queueMicrotask(() => {
+    stream.push({
+      type: "done",
+      reason: "stop",
+      message: {
+        role: "assistant",
+        api: "openai-completions",
+        provider: "openrouter",
+        model: "openrouter/auto",
+        content: [{ type: "text", text: "ok" }],
+        responseId: params.responseId,
+        stopReason: "stop",
+        timestamp: Date.now(),
+        usage: {
+          input: 1,
+          output: 1,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 2,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: params.totalCost },
+        },
+      } as never,
+    });
+  });
+  return stream;
+}
+
+function createOpenRouterAbortedStream() {
+  const stream = createAssistantMessageEventStream();
+  queueMicrotask(() => {
+    stream.push({
+      type: "error",
+      reason: "aborted",
+      error: {
+        role: "assistant",
+        api: "openai-completions",
+        provider: "openrouter",
+        model: "openrouter/auto",
+        content: [],
+        responseId: "gen-aborted",
+        stopReason: "aborted",
+        timestamp: Date.now(),
+        usage: {
+          input: 1,
+          output: 1,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 2,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0.001 },
+        },
+      } as never,
+    });
+  });
+  return stream;
+}
 
 describe("openrouter provider hooks", () => {
   it("registers OpenRouter speech alongside model, media, and catalog providers", async () => {
@@ -300,6 +359,121 @@ describe("openrouter provider hooks", () => {
     expect(capturedPayload?.provider).toEqual({
       order: ["moonshot"],
     });
+  });
+
+  it("reconciles OpenRouter streamed usage with generation metadata cost", async () => {
+    const provider = await registerSingleProviderPlugin(openrouterPlugin);
+    const fetchMock = vi.fn(async (url: string) => {
+      expect(url).toBe("https://openrouter.ai/api/v1/generation?id=gen-cost-1");
+      return new Response(JSON.stringify({ data: { total_cost: 0.0042 } }), {
+        headers: { "Content-Type": "application/json" },
+        status: 200,
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const baseStreamFn = vi.fn(() =>
+      createOpenRouterDoneStream({ responseId: "gen-cost-1", totalCost: 0.001 }),
+    );
+
+    try {
+      const wrapped = provider.wrapStreamFn?.({
+        provider: "openrouter",
+        modelId: "openrouter/auto",
+        streamFn: baseStreamFn,
+      } as never);
+      if (!wrapped) {
+        throw new Error("expected OpenRouter wrapper");
+      }
+      const stream = await wrapped(
+        {
+          provider: "openrouter",
+          api: "openai-completions",
+          id: "openrouter/auto",
+          baseUrl: "https://openrouter.ai/api/v1",
+          compat: {},
+        } as never,
+        { messages: [] } as never,
+        { apiKey: "or-test-key" } as never,
+      );
+      const message = await stream.result();
+
+      expect(fetchMock).toHaveBeenCalledOnce();
+      expect(message.usage.cost.total).toBe(0.0042);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("does not fetch generation metadata for custom OpenRouter-compatible routes", async () => {
+    const provider = await registerSingleProviderPlugin(openrouterPlugin);
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const baseStreamFn = vi.fn(() =>
+      createOpenRouterDoneStream({ responseId: "gen-custom-route", totalCost: 0.001 }),
+    );
+
+    try {
+      const wrapped = provider.wrapStreamFn?.({
+        provider: "openrouter",
+        modelId: "openrouter/auto",
+        streamFn: baseStreamFn,
+      } as never);
+      if (!wrapped) {
+        throw new Error("expected OpenRouter wrapper");
+      }
+      const stream = await wrapped(
+        {
+          provider: "openrouter",
+          api: "openai-completions",
+          id: "openrouter/auto",
+          baseUrl: "https://proxy.example.test/api/v1",
+          compat: {},
+        } as never,
+        { messages: [] } as never,
+        { apiKey: "or-test-key" } as never,
+      );
+      const message = await stream.result();
+
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(message.usage.cost.total).toBe(0.001);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("does not fetch generation metadata for aborted stream errors", async () => {
+    const provider = await registerSingleProviderPlugin(openrouterPlugin);
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const baseStreamFn = vi.fn(() => createOpenRouterAbortedStream());
+
+    try {
+      const wrapped = provider.wrapStreamFn?.({
+        provider: "openrouter",
+        modelId: "openrouter/auto",
+        streamFn: baseStreamFn,
+      } as never);
+      if (!wrapped) {
+        throw new Error("expected OpenRouter wrapper");
+      }
+      const stream = await wrapped(
+        {
+          provider: "openrouter",
+          api: "openai-completions",
+          id: "openrouter/auto",
+          baseUrl: "https://openrouter.ai/api/v1",
+          compat: {},
+        } as never,
+        { messages: [] } as never,
+        { apiKey: "or-test-key" } as never,
+      );
+      const message = await stream.result();
+
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(message.stopReason).toBe("aborted");
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 
   it("merges resolved OpenRouter model params into transport params", async () => {

--- a/extensions/openrouter/stream.ts
+++ b/extensions/openrouter/stream.ts
@@ -1,6 +1,15 @@
 // Openrouter plugin module implements stream behavior.
 import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
+import {
+  createAssistantMessageEventStream,
+  type AssistantMessage,
+  type AssistantMessageEvent,
+} from "openclaw/plugin-sdk/llm";
 import type { ProviderWrapStreamFnContext } from "openclaw/plugin-sdk/plugin-entry";
+import {
+  assertOkOrThrowHttpError,
+  fetchWithTimeoutGuarded,
+} from "openclaw/plugin-sdk/provider-http";
 import { OPENROUTER_THINKING_STREAM_HOOKS } from "openclaw/plugin-sdk/provider-stream-family";
 import {
   createDeepSeekV4OpenAICompatibleThinkingWrapper,
@@ -17,6 +26,13 @@ import {
 } from "./provider-catalog.js";
 
 const log = createSubsystemLogger("openrouter-stream");
+const OPENROUTER_GENERATION_LOOKUP_TIMEOUT_MS = 2_000;
+
+type OpenRouterGenerationResponse = {
+  data?: {
+    total_cost?: unknown;
+  };
+};
 
 function readString(value: unknown): string | undefined {
   return typeof value === "string" ? value.trim() : undefined;
@@ -60,6 +76,128 @@ function shouldPatchDeepSeekV4OpenRouterPayload(model: Parameters<StreamFn>[0]):
 function shouldPatchOpenRouterRoutingPayload(model: Parameters<StreamFn>[0]): boolean {
   const api = readString(model.api);
   return (api === undefined || api === "openai-completions") && isVerifiedOpenRouterRoute(model);
+}
+
+function resolveOpenRouterGenerationUrl(
+  model: Parameters<StreamFn>[0],
+  responseId: string,
+): string {
+  const baseUrl = readString(model.baseUrl) || OPENROUTER_BASE_URL;
+  const url = new URL("generation", `${baseUrl.replace(/\/$/, "")}/`);
+  url.searchParams.set("id", responseId);
+  return url.href;
+}
+
+function readOpenRouterTotalCost(payload: OpenRouterGenerationResponse): number | undefined {
+  const totalCost = payload.data?.total_cost;
+  if (typeof totalCost !== "number" || !Number.isFinite(totalCost) || totalCost < 0) {
+    return undefined;
+  }
+  return totalCost;
+}
+
+function isDoneEvent(
+  event: AssistantMessageEvent,
+): event is Extract<AssistantMessageEvent, { type: "done" }> {
+  return event.type === "done";
+}
+
+async function fetchOpenRouterGenerationTotalCost(params: {
+  apiKey: string;
+  model: Parameters<StreamFn>[0];
+  responseId: string;
+}): Promise<number | undefined> {
+  const url = resolveOpenRouterGenerationUrl(params.model, params.responseId);
+  const { response, release } = await fetchWithTimeoutGuarded(
+    url,
+    {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${params.apiKey}`,
+        "HTTP-Referer": "https://openclaw.ai",
+        "X-OpenRouter-Title": "OpenClaw",
+      },
+    },
+    OPENROUTER_GENERATION_LOOKUP_TIMEOUT_MS,
+    fetch,
+    { auditContext: "openrouter-generation-cost" },
+  );
+  try {
+    await assertOkOrThrowHttpError(response, "OpenRouter generation metadata request failed");
+    return readOpenRouterTotalCost((await response.json()) as OpenRouterGenerationResponse);
+  } finally {
+    await release();
+  }
+}
+
+async function applyOpenRouterBilledCost(params: {
+  apiKey: string | undefined;
+  message: AssistantMessage;
+  model: Parameters<StreamFn>[0];
+}): Promise<void> {
+  const apiKey = readString(params.apiKey);
+  const responseId = readString((params.message as { responseId?: unknown }).responseId);
+  if (!apiKey || !responseId || !params.message.usage?.cost) {
+    return;
+  }
+  try {
+    const totalCost = await fetchOpenRouterGenerationTotalCost({
+      apiKey,
+      model: params.model,
+      responseId,
+    });
+    if (totalCost !== undefined) {
+      params.message.usage.cost.total = totalCost;
+    }
+  } catch (error) {
+    log.debug?.(
+      `kept streamed OpenRouter cost estimate because generation metadata lookup failed: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+function createOpenRouterBilledCostWrapper(
+  baseStreamFn: StreamFn | undefined,
+): StreamFn | undefined {
+  if (!baseStreamFn) {
+    return baseStreamFn;
+  }
+  return async (model, context, options) => {
+    const source = await baseStreamFn(model, context, options);
+    if (!isVerifiedOpenRouterRoute(model)) {
+      return source;
+    }
+    const output = createAssistantMessageEventStream();
+    const stream = output as unknown as { push(event: unknown): void; end(): void };
+    void (async () => {
+      try {
+        for await (const event of source as AsyncIterable<AssistantMessageEvent>) {
+          if (isDoneEvent(event)) {
+            await applyOpenRouterBilledCost({
+              apiKey: options?.apiKey,
+              message: event.message,
+              model,
+            });
+          }
+          stream.push(event);
+        }
+      } catch (error) {
+        stream.push({
+          type: "error",
+          reason: "error",
+          error: {
+            role: "assistant",
+            content: [],
+            stopReason: "error",
+            errorMessage: error instanceof Error ? error.message : String(error),
+          },
+        });
+      } finally {
+        stream.end();
+      }
+    })();
+    return output as ReturnType<StreamFn>;
+  };
 }
 
 function assistantMessageHasOpenAIToolCalls(message: Record<string, unknown>): boolean {
@@ -230,8 +368,10 @@ export function wrapOpenRouterProviderStream(
     : ctx.streamFn;
   const wrapStreamFn = OPENROUTER_THINKING_STREAM_HOOKS.wrapStreamFn ?? undefined;
   if (!wrapStreamFn) {
-    return createOpenRouterAnthropicPrefillWrapper(
-      createOpenRouterDeepSeekV4ThinkingWrapper(routedStreamFn, ctx.thinkingLevel),
+    return createOpenRouterBilledCostWrapper(
+      createOpenRouterAnthropicPrefillWrapper(
+        createOpenRouterDeepSeekV4ThinkingWrapper(routedStreamFn, ctx.thinkingLevel),
+      ),
     );
   }
   const wrappedStreamFn =
@@ -242,7 +382,9 @@ export function wrapOpenRouterProviderStream(
         ? undefined
         : ctx.thinkingLevel,
     }) ?? undefined;
-  return createOpenRouterAnthropicPrefillWrapper(
-    createOpenRouterDeepSeekV4ThinkingWrapper(wrappedStreamFn, ctx.thinkingLevel),
+  return createOpenRouterBilledCostWrapper(
+    createOpenRouterAnthropicPrefillWrapper(
+      createOpenRouterDeepSeekV4ThinkingWrapper(wrappedStreamFn, ctx.thinkingLevel),
+    ),
   );
 }


### PR DESCRIPTION
## Summary

- Reconciles completed OpenRouter streaming chat usage with the authoritative generation metadata `total_cost` before the final assistant message is emitted.
- Keeps the streamed estimate when metadata lookup fails or returns malformed cost, and skips custom OpenRouter-compatible proxy routes.
- Avoids generation lookup for aborted/error terminal events so cancellation stays responsive.

Fixes #68066.

## Verification

- Official OpenRouter docs checked: `/api/v1/generation?id=...` returns request/usage metadata including `total_cost`: https://openrouter.ai/docs/api/api-reference/generations/get-generation
- Live OpenRouter API proof with stored `OPENROUTER_API_KEY`: streamed `google/gemini-2.5-flash` chat completion returned HTTP 200, `gen-...` response id, `finish=stop`, streamed cost `0.0000049`; delayed generation lookup returned HTTP 200 with matching id, `streamed=true`, `cancelled=false`, `total_cost=0.0000049`.
- `node scripts/run-vitest.mjs extensions/openrouter/index.test.ts extensions/openrouter/provider-runtime.contract.test.ts`
- `node scripts/run-vitest.mjs extensions/openrouter`
- `pnpm exec oxfmt --check extensions/openrouter/stream.ts extensions/openrouter/index.test.ts`
- `git diff --check`
- Autoreview clean after accepted abort-fix finding; key-layering false positive verified against `src/agents/embedded-agent-runner/stream-resolution.ts` and existing `stream-resolution.test.ts` resolved-key coverage.

## Not Tested

- Did not rerun the expensive long-context tiered-pricing repro from #68066; live proof covered the real response-id to generation-metadata contract and the patch covers the persisted final message path.
