### PR TITLE
fix(codex): deliver assistant reply when orphan tool.call lacks result

### DIFF
--- a/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
@@ -623,6 +623,31 @@ describe("buildEmbeddedRunPayloads", () => {
     expect(payloads[1]?.text).toContain("Exec");
   });
 
+  it("shows bash warnings for degraded orphan native command errors when assistant reply omits missing proof", () => {
+    const payloads = buildPayloads({
+      assistantTexts: ["The requested publish command was denied before execution."],
+      lastAssistant: { stopReason: "end_turn" } as unknown as AssistantMessage,
+      lastToolError: {
+        toolName: "bash",
+        meta: "node scripts/report.js --publish (workspace)",
+        error:
+          "OpenClaw recorded a native Codex tool.call without a matching tool.result before the turn completed. toolCallId=cmd-denied; toolName=bash",
+        mutatingAction: true,
+        actionFingerprint: JSON.stringify({
+          type: "commandExecution",
+          command: "node scripts/report.js --publish",
+          cwd: "/workspace",
+        }),
+      },
+    });
+
+    expect(payloads).toHaveLength(2);
+    expect(payloads[0]?.text).toBe("The requested publish command was denied before execution.");
+    expect(payloads[1]?.isError).toBe(true);
+    expect(payloads[1]?.text).toContain("node scripts/report.js --publish (workspace)");
+    expect(payloads[1]?.text).not.toContain("without a matching tool.result");
+  });
+
   it("shows exec tool errors when assistant output claims success", () => {
     const payloads = buildPayloads({
       assistantTexts: ["The script is ready to use and saved in your workspace."],


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- Fixes a 2026.6.1 regression where embedded Codex turns with a completed final `agentMessage` but an orphan native `tool.call` were marked `promptError`, suppressing channel delivery of the composed assistant reply.

Why does this matter now?

- Closes #91067 (P1, `impact:message-loss`): users saw **no answer and no error** after long native tool runs.

What is the intended outcome?

- Keep synthesizing failed `tool.result` records for transcript/trajectory consistency, but treat **completed turns with deliverable assistant text** as degraded-success instead of prompt-failed.
- Expose `lastToolError` on the degraded path so downstream payload/session layers can still observe the orphan-tool condition without blocking delivery.

What is intentionally out of scope?

- No change to channel-specific delivery, Codex projector policy for failed/interrupted turns without deliverable text, or broader ACPX packaging.

What does success look like?

- `buildResult()` / `runCodexAppServerAttempt()` return `promptError: null` while preserving synthetic error `toolResult` rows, final assistant text in `messagesSnapshot`, and a non-empty `lastToolError` degraded signal.

What should reviewers focus on?

- `extensions/codex/src/app-server/event-projector.ts` — `synthesize` vs `recordPromptError` split and degraded `lastToolError`
- Regression tests in `event-projector.test.ts` and `run-attempt.test.ts`

## Linked context

Which issue does this close?

Closes #91067

Which issues, PRs, or discussions are related?

Related #86808 (orphan `tool.call` synthesis), prior fail-closed projector behavior

Was this requested by a maintainer or owner?

- ClawSweeper labels: `clawsweeper:queueable-fix`, `clawsweeper:fix-shape-clear`, `clawsweeper:source-repro`

## Real behavior proof (required for external PRs)

- **Behavior or issue addressed:** Completed Codex turn + final assistant text + orphan `tool.call` no longer sets `promptError`; reply is deliverable; `lastToolError` records the synthetic orphan-tool failure.
- **Real environment tested:** Local checkout on branch `fix/issue-91067-orphan-tool-deliver-reply` (Windows, Node v25, no live Discord/Codex gateway).
- **Exact steps or command run after this patch:**
  - `node scripts/run-vitest.mjs extensions/codex/src/app-server/event-projector.test.ts -t "delivers completed assistant text when a native tool call finishes without a matching result"`
  - `node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.test.ts -t "delivers completed assistant text when an orphan native tool call lacks a matching result"`
  - `node scripts/run-vitest.mjs extensions/codex/src/app-server/event-projector.test.ts -t "records promptError when a completed turn has only whitespace assistant text"`
  - `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run.codex-app-server-recovery.test.ts`
  - `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/payloads.errors.test.ts`
- **Evidence after fix:**

```json
{
  "promptError": null,
  "promptErrorSource": null,
  "lastToolError": {
    "toolName": "bash",
    "error": "OpenClaw recorded a native Codex tool.call without a matching tool.result before the turn completed. toolCallId=cmd-denied; toolName=bash",
    "mutatingAction": true,
    "actionFingerprint": "{\"type\":\"commandExecution\",\"command\":\"node scripts/report.js --publish\",\"cwd\":\"/workspace\"}"
  },
  "assistantTexts": [
    "The requested publish command was denied before execution."
  ],
  "messagesSnapshotRoles": ["user", "assistant", "toolResult", "assistant"],
  "syntheticToolResult": {
    "toolCallId": "cmd-denied",
    "isError": true,
    "contains": "without a matching tool.result"
  },
  "runAttemptIntegration": {
    "promptError": null,
    "lastToolError": {
      "toolName": "bash",
      "mutatingAction": true,
      "actionFingerprint": "{\"type\":\"commandExecution\",\"command\":\"pnpm test extensions/codex\",\"cwd\":\"/workspace\"}"
    },
    "assistantTexts": [
      "Recovered with final answer after orphan tool call."
    ],
    "toolCallId": "cmd-orphan"
  },
  "whitespaceBoundary": {
    "promptError": "contains without a matching tool.result",
    "lastToolError": null
  }
}
```

- **Observed result after fix:** Projector and run-attempt paths emit final assistant text; synthetic failed `tool.result` remains in snapshot for reconciliation; degraded `lastToolError` surfaces orphan-tool state without failing the turn.
- **What was not tested:** Live Discord/Codex end-to-end turn with real native tool latency; Crabbox `check:changed` (local Testbox unavailable).
- **Proof limitations or environment constraints:** Source-level + harness integration proof only; no live gateway session. Harness L2 evidence is included; live proof is left to maintainer discretion per ClawSweeper policy.
- **Before evidence (optional but encouraged):** Before: `buildResult().promptError` contained `without a matching tool.result` even when `assistantTexts` had final answer; run-attempt suppressed terminal assistant emission.

## Tests and validation

Which commands did you run?

- `node scripts/run-vitest.mjs extensions/codex/src/app-server/event-projector.test.ts` → projector suite
- `node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.test.ts -t "delivers completed assistant text when an orphan native tool call lacks a matching result"` → passed
- `node scripts/run-vitest.mjs extensions/codex/src/app-server/event-projector.test.ts extensions/codex/src/app-server/run-attempt.test.ts -t "delivers completed assistant text when"` → 2 passed
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run.codex-app-server-recovery.test.ts` → ClawSweeper acceptance
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/payloads.errors.test.ts` → ClawSweeper acceptance
- `pnpm format:check extensions/codex/src/app-server/event-projector.ts extensions/codex/src/app-server/event-projector.test.ts extensions/codex/src/app-server/run-attempt.test.ts` → passed
- Rebased onto latest `openclaw/main` (`66b91d78`) — branch now 1 commit ahead of main (payload warning regression only; core projector fix already on main via cherry-picks)
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/payloads.errors.test.ts -t "shows bash warnings for degraded orphan"` → passed
- `pnpm check:test-types` → passed; `pnpm format:check` → passed; `pnpm check:changed` → skipped locally (Testbox/crabbox unavailable)

What regression coverage was added or updated?

- `event-projector.test.ts`: completed turn + orphan tool + assistant text → `promptError` null, `lastToolError` set, synthetic `toolResult` + final assistant preserved
- `event-projector.test.ts`: completed turn + orphan tool + whitespace-only assistant → `promptError` still set, `lastToolError` undefined
- `run-attempt.test.ts`: harness integration from `item/started` through `turn/completed` → deliverable assistant text without `promptError`, with `lastToolError`
- `payloads.errors.test.ts`: degraded orphan `bash` + `mutatingAction: true` still surfaces channel warning when assistant reply omits missing proof

What failed before this fix, if known?

- Projector set `synthesizedMissingToolResultError` whenever `assistantTexts.length > 0`, blocking terminal assistant delivery (#91067).

If no test was added, why not?

- N/A — projector + run-attempt regression tests added.

## Risk checklist

Did user-visible behavior change? (`Yes`)

Did config, environment, or migration behavior change? (`No`)

Did security, auth, secrets, network, or tool execution behavior change? (`No`)

What is the highest-risk area?

- Completed Codex turns with orphan tools now deliver assistant text instead of failing closed.

How is that risk mitigated?

- Synthetic failed `tool.result` records still written; `lastToolError` exposes degraded orphan-tool state; failed/interrupted turns and completed turns **without** deliverable assistant text keep `recordPromptError` behavior unchanged.

## Current review state

What is the next action?

- Await ClawSweeper re-review after branch refresh + mutating-metadata alignment with main + payload warning regression.

What is still waiting on author, maintainer, CI, or external proof?

- GitHub CI on refreshed branch (1-file diff vs `66b91d78`).
- Harness L2 evidence provided; live embedded Codex gateway proof still optional per maintainer policy.

Which bot or reviewer comments were addressed?

- [P1] Preserve mutating orphan-command warnings: main now records degraded `lastToolError` with `mutatingAction: true` + `actionFingerprint` via `toolTrajectoryItemsById`; added `payloads.errors.test.ts` regression proving channel warnings still surface.
- [P1] Branch dirty against base: rebased onto current `openclaw/main` (`66b91d78`); PR diff is now a single focused test commit.
