### PR TITLE
fix(sandbox): repair fs bridge stat for Codex exec-server native writes

### DIFF
--- a/src/agents/sandbox/fs-bridge-path-safety.ts
+++ b/src/agents/sandbox/fs-bridge-path-safety.ts
@@ -192,6 +192,24 @@ export class SandboxFsPathGuard {
     });
   }
 
+  /**
+   * Anchors a stat of an allowed mount root onto the root itself. Parent
+   * anchoring cannot work there: the parent lives outside every mount, so
+   * stat of the OpenClaw-owned bind target (for example the workspace root)
+   * would be rejected as a mount escape. Read-only stat only; mutations of
+   * mount roots stay invalid.
+   */
+  resolveMountRootStatEntry(target: SandboxResolvedFsPath): AnchoredSandboxEntry | null {
+    const normalized = normalizeContainerPath(target.containerPath);
+    const mount = this.mountsByContainer.find(
+      (candidate) => normalizeContainerPath(candidate.containerRoot) === normalized,
+    );
+    if (!mount) {
+      return null;
+    }
+    return { canonicalParentPath: normalized, basename: "." };
+  }
+
   async resolveAnchoredSandboxEntry(
     target: SandboxResolvedFsPath,
     action: string,

--- a/src/agents/sandbox/fs-bridge-shell-command-plans.ts
+++ b/src/agents/sandbox/fs-bridge-shell-command-plans.ts
@@ -15,14 +15,26 @@ export type SandboxFsCommandPlan = {
   allowFailure?: boolean;
 };
 
+/**
+ * Exit code reserved for a stat whose parent directory does not exist. Shell
+ * `cd` failure text differs across dash/bash/busybox, so callers match this
+ * code instead of stderr to report not-found rather than a bridge error.
+ */
+export const SANDBOX_STAT_PARENT_NOT_FOUND_EXIT_CODE = 44;
+
 /** Builds a stat command that anchors the path at its canonical parent before reading metadata. */
 export function buildStatPlan(
   target: SandboxResolvedFsPath,
   anchoredTarget: AnchoredSandboxEntry,
+  // Stat accepts files and directories; the boundary open defaults to files
+  // only, so directory targets must declare themselves to pass the check.
+  allowedType?: "file" | "directory",
 ): SandboxFsCommandPlan {
   return {
-    checks: [{ target, options: { action: "stat files" } }],
-    script: 'set -eu\ncd -- "$1"\nstat -c "%F|%s|%y" -- "$2"',
+    checks: [
+      { target, options: { action: "stat files", ...(allowedType ? { allowedType } : {}) } },
+    ],
+    script: `set -eu\nif ! cd -- "$1" 2>/dev/null; then exit ${SANDBOX_STAT_PARENT_NOT_FOUND_EXIT_CODE}; fi\nstat -c "%F|%s|%y" -- "$2"`,
     args: [anchoredTarget.canonicalParentPath, anchoredTarget.basename],
     allowFailure: true,
   };

--- a/src/agents/sandbox/fs-bridge.boundary.test.ts
+++ b/src/agents/sandbox/fs-bridge.boundary.test.ts
@@ -3,12 +3,17 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { SANDBOX_STAT_PARENT_NOT_FOUND_EXIT_CODE } from "./fs-bridge-shell-command-plans.js";
 import {
   createHostEscapeFixture,
   createSandbox,
   createSandboxFsBridge,
+  dockerExecResult,
   expectMkdirpAllowsExistingDirectory,
   findCallByDockerArg,
+  findCallByScriptFragment,
+  getDockerArg,
+  getDockerScript,
   installFsBridgeTestHarness,
   mockedExecDockerRaw,
   withTempDir,
@@ -117,5 +122,69 @@ describe("sandbox fs bridge boundary validation", () => {
     const bridge = createSandboxFsBridge({ sandbox: createSandbox() });
     await expect(bridge.readFile({ filePath: "a.txt" })).rejects.toThrow(/ENOENT|no such file/i);
     expect(mockedExecDockerRaw).not.toHaveBeenCalled();
+  });
+
+  // Stat must work for every existing in-mount path shape the Codex sandbox
+  // exec-server probes: the mount root itself, directories, and paths whose
+  // parents do not exist yet. Regressions here break native apply_patch
+  // writes, which pre-check the target's parent directory through stat.
+  it("stats the workspace mount root instead of escaping to its parent", async () => {
+    await withTempDir("openclaw-fs-bridge-root-stat-", async (stateDir) => {
+      const workspaceDir = path.join(stateDir, "workspace");
+      await fs.mkdir(workspaceDir, { recursive: true });
+      const bridge = createSandboxFsBridge({
+        sandbox: createSandbox({ workspaceDir, agentWorkspaceDir: workspaceDir }),
+      });
+
+      await expect(bridge.stat({ filePath: "/workspace" })).resolves.not.toBeNull();
+
+      const statCall = findCallByScriptFragment('stat -c "%F|%s|%y"');
+      if (!statCall) {
+        throw new Error("expected docker stat call");
+      }
+      // Anchored at the mount root itself; its parent lives outside the mounts.
+      expect(getDockerArg(statCall[0], 1)).toBe("/workspace");
+      expect(getDockerArg(statCall[0], 2)).toBe(".");
+    });
+  });
+
+  it("stats an existing directory target", async () => {
+    await withTempDir("openclaw-fs-bridge-dir-stat-", async (stateDir) => {
+      const workspaceDir = path.join(stateDir, "workspace");
+      await fs.mkdir(path.join(workspaceDir, "subdir"), { recursive: true });
+      const bridge = createSandboxFsBridge({
+        sandbox: createSandbox({ workspaceDir, agentWorkspaceDir: workspaceDir }),
+      });
+
+      await expect(bridge.stat({ filePath: "subdir" })).resolves.not.toBeNull();
+    });
+  });
+
+  it("returns null instead of throwing when intermediate directories are missing", async () => {
+    await withTempDir("openclaw-fs-bridge-missing-parent-stat-", async (stateDir) => {
+      const workspaceDir = path.join(stateDir, "workspace");
+      await fs.mkdir(workspaceDir, { recursive: true });
+      const bridge = createSandboxFsBridge({
+        sandbox: createSandbox({ workspaceDir, agentWorkspaceDir: workspaceDir }),
+      });
+      mockedExecDockerRaw.mockImplementation(async (args) => {
+        const script = getDockerScript(args);
+        if (script.includes('readlink -f -- "$cursor"')) {
+          return dockerExecResult(`${getDockerArg(args, 1)}\n`);
+        }
+        if (script.includes('stat -c "%F|%s|%y"')) {
+          return {
+            stdout: Buffer.alloc(0),
+            stderr: Buffer.alloc(0),
+            code: SANDBOX_STAT_PARENT_NOT_FOUND_EXIT_CODE,
+          };
+        }
+        return dockerExecResult("");
+      });
+
+      // A missing-parent stat is a not-found result, not a bridge failure;
+      // writers rely on the not-found signal to create parent directories.
+      await expect(bridge.stat({ filePath: "ghost/sub/file.txt" })).resolves.toBeNull();
+    });
   });
 });

--- a/src/agents/sandbox/fs-bridge.ts
+++ b/src/agents/sandbox/fs-bridge.ts
@@ -17,7 +17,11 @@ import {
   buildPinnedWritePlan,
 } from "./fs-bridge-mutation-helper.js";
 import { SandboxFsPathGuard } from "./fs-bridge-path-safety.js";
-import { buildStatPlan, type SandboxFsCommandPlan } from "./fs-bridge-shell-command-plans.js";
+import {
+  buildStatPlan,
+  SANDBOX_STAT_PARENT_NOT_FOUND_EXIT_CODE,
+  type SandboxFsCommandPlan,
+} from "./fs-bridge-shell-command-plans.js";
 import { parseSandboxStatMtimeMs, parseSandboxStatSize } from "./fs-bridge-stat-parse.js";
 import type { SandboxFsBridge, SandboxFsStat, SandboxResolvedPath } from "./fs-bridge.types.js";
 import {
@@ -201,14 +205,20 @@ class SandboxFsBridgeImpl implements SandboxFsBridge {
     signal?: AbortSignal;
   }): Promise<SandboxFsStat | null> {
     const target = this.resolveResolvedPath(params);
-    const anchoredTarget = await this.pathGuard.resolveAnchoredSandboxEntry(target, "stat files");
+    const anchoredTarget =
+      this.pathGuard.resolveMountRootStatEntry(target) ??
+      (await this.pathGuard.resolveAnchoredSandboxEntry(target, "stat files"));
+    const hostStat = fs.statSync(target.hostPath, { throwIfNoEntry: false });
     const result = await this.runPlannedCommand(
-      buildStatPlan(target, anchoredTarget),
+      buildStatPlan(target, anchoredTarget, hostStat?.isDirectory() ? "directory" : undefined),
       params.signal,
     );
     if (result.code !== 0) {
       const stderr = result.stderr.toString("utf8");
-      if (stderr.includes("No such file or directory")) {
+      if (
+        result.code === SANDBOX_STAT_PARENT_NOT_FOUND_EXIT_CODE ||
+        stderr.includes("No such file or directory")
+      ) {
         return null;
       }
       const message = stderr.trim() || `stat failed with code ${result.code}`;


### PR DESCRIPTION
## Summary

Native Codex `apply_patch` failed for **every** write inside an OpenClaw Docker sandbox with `appServer.experimental.sandboxExecServer=true` (`Failed to write file ...`), while shell writes in the same sandboxed session succeeded.

Live diagnosis against a real Docker sandbox showed the root cause is not Codex-side sandbox nesting. Codex `fs/writeFile` first stats the target's parent directory through the OpenClaw sandbox exec-server, and the sandbox fs bridge could not answer that stat for any relevant path shape. Three defects in `src/agents/sandbox/fs-bridge*`:

1. **Stat of the mount root itself was rejected.** `resolveAnchoredSandboxEntry` anchors stats on the target's parent; the workspace root's parent lives outside every mount, so `stat /workspace` failed with `Sandbox path escapes allowed mounts`. Every write to a workspace-root file pre-checks `dirname` = mount root and died.
2. **Stat of a path with missing intermediate directories threw instead of reporting not-found.** The stat shell plan ran `cd -- <parent>` under `set -eu`; with a missing parent, dash reports `cd: can't cd to ...` (which does not match the `No such file or directory` string check), so the bridge threw a generic error. The exec-server then returned `-32603` instead of `-32004 NOT_FOUND`, so Codex never received the not-found signal that triggers its recursive `create_directory` + retry. Every write into a new subdirectory died — this is exactly the original incident shape (`Failed to write file /workspace/raw/2026-06-06/index.md`).
3. **Stat of any existing directory failed boundary checks.** The pinned boundary open (`openRootFile` → `openPinnedFileSync`) defaults to `allowedType: "file"` and rejects directory targets, so even writes whose parent directory already existed died.

Fix, mirroring existing seams:

- anchor mount-root stats on the root itself (read-only stat only; mutations of mount roots stay invalid via the unchanged pinned-entry paths);
- reserve a dedicated exit code (`SANDBOX_STAT_PARENT_NOT_FOUND_EXIT_CODE`) for the missing-parent `cd` failure and map it to a `null` stat, so shell error-text differences (dash/bash/busybox) cannot turn not-found into a bridge error;
- pass `allowedType: "directory"` to the boundary open when the host path is a directory, matching the existing `mkdirp` pattern.

Sibling surface checked: `src/agents/sandbox/remote-fs-bridge.ts` (SSH backend) is unaffected — it pre-checks existence (`remotePathExists` → `null`), stats the canonical target directly without parent anchoring, and has no file-only boundary open.

## Why this PR no longer touches the Codex thread sandbox mode

Earlier revisions of this PR started the Codex app-server thread with `danger-full-access` for sandbox exec-server turns, on the theory that Codex's inner filesystem sandbox (`workspace-write`) was rejecting the writes. Live end-to-end testing falsified that theory:

- A real Codex turn from the earlier PR build (thread `danger-full-access`, turn `externalSandbox`, per the Codex session rollout `turn_context`) still failed with the identical `Failed to write file` error, on both `@openai/codex` 0.135.0 and 0.139.0.
- Codex applies the **per-turn** sandbox policy, which OpenClaw already sends as `externalSandbox` on current `main` for sandboxed turns. With that policy the inner filesystem sandbox is not engaged: observed exec-server `fs/*` RPCs carry `"sandbox": null`, and codex-rs treats `ExternalSandbox` as non-restricted (rust-v0.135.0 `codex-rs/core/src/exec.rs:975`, `codex-rs/core/src/exec_policy.rs:717,736`; `TurnContext` derives enforcement from the per-turn `permission_profile`, `codex-rs/core/src/session/turn_context.rs:101-119`). The thread-level sandbox mode is only a default for turns that do not carry an explicit policy.
- A control run with the thread-sandbox override disabled and only the fs bridge fix applied succeeded end-to-end.

So the override neither fixed the incident nor participates in enforcement on this path, and it was the only security-boundary relaxation in this PR. It is dropped; the Codex thread sandbox behavior is unchanged from `main`.

## Real behavior proof (required for external PRs)

- Behavior addressed: Native Codex `apply_patch` fails to write any file (workspace-root or nested) inside an OpenClaw Docker sandbox when the sandbox exec-server owns native tool execution, while shell writes succeed.
- Real environment tested: Local Linux host, isolated `OPENCLAW_STATE_DIR`, real Docker sandbox (`openclaw-sandbox:bookworm-slim`, `workspaceAccess=rw`), real OpenAI auth profile, `appServer.experimental.sandboxExecServer=true`, Codex harness model `openai/gpt-5.5`, real `@openai/codex` 0.135.0 binary (same version as the original incident) plus a 0.139.0 control. Live LLM turns through `openclaw agent --local` from this branch.
- Exact steps or command run after this patch: `OPENCLAW_STATE_DIR=<isolated> node scripts/run-node.mjs agent --agent <sandboxed-agent> --local --message "Use your native apply_patch tool to create TWO files: first root-proof3.md in the workspace root ... then nested path raw/2026-06-12/nested-proof3.md ... Only apply_patch, no shell."`
- Evidence after fix:

```text
Success. Updated the following files:
A root-proof3.md
A raw/2026-06-12/nested-proof3.md
```

  Both files exist on the host workspace mount with the exact requested contents. Exec-server traffic shows the healthy protocol flow: probe stats now return clean not-found, the first nested write returns `parent directory not found` (`-32004`), Codex issues recursive `fs/createDirectory`, and the retried write succeeds.

- Observed result after fix: Native `apply_patch` writes succeed for workspace-root files and nested new-directory files inside the Docker sandbox, with the Codex thread sandbox left at its current `main` behavior.
- What was not tested: SSH-backend sandboxes live (code-inspected only, see sibling note); a deployed long-running gateway (the live runs used embedded `--local` turns, which share the same sandbox fs bridge and exec-server code paths).

Before evidence: the same live setup running the prior approach reproduced the incident on every write:

```text
[fs/writeFile {"path":"/workspace/proof.md"}] error=Sandbox path escapes allowed mounts; cannot stat files: /
[fs/writeFile {"path":"/workspace/raw/2026-06-12/index.md"}] error=stat failed for /workspace/raw/2026-06-12: openclaw-sandbox-fs: 2: cd: can't cd to /workspace/raw
patch_apply_end success=false stderr="Failed to write file /workspace/proof.md"
```

## Tests and validation

- `node scripts/run-vitest.mjs run src/agents/sandbox/fs-bridge.boundary.test.ts src/agents/sandbox/fs-bridge.shell.test.ts src/agents/sandbox/fs-bridge.anchored-ops.test.ts src/agents/sandbox/fs-bridge-mutation-helper.test.ts` → 43 passed (3 new regression tests: mount-root stat anchoring, existing-directory stat, missing-parent stat → null).
- `pnpm tsgo` clean, `oxlint`/`oxfmt` clean on touched files.

## Risk checklist

Did user-visible behavior change? `Yes` — native Codex file writes inside sandbox exec-server turns now work.

Did config, environment, or migration behavior change? `No`.

Did security, auth, secrets, network, or tool execution behavior change? `No relaxation` — the previously proposed Codex thread sandbox change is dropped. The fs bridge keeps all mount, symlink, hardlink, and writability checks; the fix only makes read-only stat answer correctly for in-mount paths (mount root, directories, missing children).

Highest-risk area: the stat boundary-open change. Mitigation: mutations still go through the unchanged pinned-entry guards; the mount-root anchor is stat-only; new regression tests pin all three behaviors; symlink/hardlink escape tests still pass.
