### PR TITLE
perf(memory): coalesce + cache session-file listings to cut NFS READDIR load

### DIFF
--- a/packages/memory-host-sdk/src/host/session-files.test.ts
+++ b/packages/memory-host-sdk/src/host/session-files.test.ts
@@ -154,6 +154,33 @@ describe("listSessionFilesForAgent listing cache", () => {
     expect(readdirSpy).toHaveBeenCalledTimes(2);
     expect(baseNames(afterInvalidate)).toEqual(["a.jsonl", "b.jsonl"]);
   });
+
+  it("does not cache a transient scan failure and retries on the next call", async () => {
+    writeSession("a.jsonl");
+    const transient = Object.assign(new Error("nfs blip"), { code: "EIO" });
+    const readdirSpy = vi.spyOn(fsPromises, "readdir").mockRejectedValueOnce(transient);
+
+    // A transient READDIR failure is surfaced to this caller as empty...
+    const failed = await listSessionFilesForAgent("main");
+    expect(failed).toEqual([]);
+    // ...but must not be cached: the next call within the TTL re-scans and
+    // recovers the real listing instead of serving the false-empty snapshot.
+    const recovered = await listSessionFilesForAgent("main");
+    expect(baseNames(recovered)).toEqual(["a.jsonl"]);
+    expect(readdirSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("caches an absent sessions dir as empty without re-scanning", async () => {
+    fsSync.rmSync(sessionsDir, { recursive: true, force: true });
+    const readdirSpy = vi.spyOn(fsPromises, "readdir");
+
+    const first = await listSessionFilesForAgent("main");
+    const second = await listSessionFilesForAgent("main");
+
+    expect(first).toEqual([]);
+    expect(second).toEqual([]);
+    expect(readdirSpy).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("sessionPathForFile", () => {

--- a/packages/memory-host-sdk/src/host/session-files.test.ts
+++ b/packages/memory-host-sdk/src/host/session-files.test.ts
@@ -128,6 +128,30 @@ describe("listSessionFilesForAgent listing cache", () => {
     expect(baseNames(secondCall)).toEqual(["a.jsonl"]);
   });
 
+  it("returns an isolated copy so caller mutation cannot corrupt the cache", async () => {
+    writeSession("a.jsonl");
+    const readdirSpy = vi.spyOn(fsPromises, "readdir");
+
+    // Concurrent burst exercises the in-flight originator + joiner return paths;
+    // a shared reference here would poison the snapshot for everyone.
+    const [a, b] = await Promise.all([
+      listSessionFilesForAgent("main"),
+      listSessionFilesForAgent("main"),
+    ]);
+    a.length = 0;
+    b.push("/phantom.jsonl");
+
+    // Sequential cache hit exercises the snapshot return path.
+    const cached = await listSessionFilesForAgent("main");
+    cached.length = 0;
+
+    const afterMutation = await listSessionFilesForAgent("main");
+
+    // One scan total; no caller's mutation leaked into the cached snapshot.
+    expect(readdirSpy).toHaveBeenCalledTimes(1);
+    expect(baseNames(afterMutation)).toEqual(["a.jsonl"]);
+  });
+
   it("refreshes the snapshot after the TTL elapses", async () => {
     vi.useFakeTimers({ toFake: ["Date"] });
     writeSession("a.jsonl");

--- a/packages/memory-host-sdk/src/host/session-files.test.ts
+++ b/packages/memory-host-sdk/src/host/session-files.test.ts
@@ -1,11 +1,14 @@
 // Memory Host SDK tests cover session files behavior.
 import fsSync from "node:fs";
+import fsPromises from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { emitSessionTranscriptUpdate } from "../../../../src/sessions/transcript-events.js";
 import {
   buildSessionEntry,
   listSessionFilesForAgent,
+  resetSessionFilesListingCache,
   sessionPathForFile,
   type SessionFileEntry,
 } from "./session-files.js";
@@ -71,6 +74,85 @@ describe("listSessionFilesForAgent", () => {
     expect(files.map((filePath) => path.basename(filePath)).toSorted()).toEqual(
       included.toSorted(),
     );
+  });
+});
+
+describe("listSessionFilesForAgent listing cache", () => {
+  let sessionsDir: string;
+
+  beforeEach(() => {
+    resetSessionFilesListingCache();
+    sessionsDir = path.join(tmpDir, "agents", "main", "sessions");
+    fsSync.mkdirSync(sessionsDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+    resetSessionFilesListingCache();
+  });
+
+  function writeSession(name: string): void {
+    fsSync.writeFileSync(path.join(sessionsDir, name), "");
+  }
+
+  function baseNames(files: string[]): string[] {
+    return files.map((filePath) => path.basename(filePath)).toSorted();
+  }
+
+  it("coalesces concurrent reads into a single READDIR", async () => {
+    writeSession("a.jsonl");
+    const readdirSpy = vi.spyOn(fsPromises, "readdir");
+
+    const [first, second] = await Promise.all([
+      listSessionFilesForAgent("main"),
+      listSessionFilesForAgent("main"),
+    ]);
+
+    expect(readdirSpy).toHaveBeenCalledTimes(1);
+    expect(first).toEqual(second);
+    expect(baseNames(first)).toEqual(["a.jsonl"]);
+  });
+
+  it("serves the cached snapshot within the TTL and skips repeat scans", async () => {
+    writeSession("a.jsonl");
+    const readdirSpy = vi.spyOn(fsPromises, "readdir");
+
+    const firstCall = await listSessionFilesForAgent("main");
+    // Mutate the dir without emitting a transcript event; the cache must hold.
+    writeSession("b.jsonl");
+    const secondCall = await listSessionFilesForAgent("main");
+
+    expect(readdirSpy).toHaveBeenCalledTimes(1);
+    expect(baseNames(firstCall)).toEqual(["a.jsonl"]);
+    expect(baseNames(secondCall)).toEqual(["a.jsonl"]);
+  });
+
+  it("refreshes the snapshot after the TTL elapses", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    writeSession("a.jsonl");
+    const readdirSpy = vi.spyOn(fsPromises, "readdir");
+
+    await listSessionFilesForAgent("main");
+    writeSession("b.jsonl");
+    vi.setSystemTime(Date.now() + 5_001);
+    const refreshed = await listSessionFilesForAgent("main");
+
+    expect(readdirSpy).toHaveBeenCalledTimes(2);
+    expect(baseNames(refreshed)).toEqual(["a.jsonl", "b.jsonl"]);
+  });
+
+  it("invalidates the snapshot when a transcript update lands for the agent", async () => {
+    writeSession("a.jsonl");
+    const readdirSpy = vi.spyOn(fsPromises, "readdir");
+
+    await listSessionFilesForAgent("main");
+    writeSession("b.jsonl");
+    emitSessionTranscriptUpdate({ sessionFile: path.join(sessionsDir, "b.jsonl") });
+    const afterInvalidate = await listSessionFilesForAgent("main");
+
+    expect(readdirSpy).toHaveBeenCalledTimes(2);
+    expect(baseNames(afterInvalidate)).toEqual(["a.jsonl", "b.jsonl"]);
   });
 });
 

--- a/packages/memory-host-sdk/src/host/session-files.test.ts
+++ b/packages/memory-host-sdk/src/host/session-files.test.ts
@@ -135,7 +135,7 @@ describe("listSessionFilesForAgent listing cache", () => {
 
     await listSessionFilesForAgent("main");
     writeSession("b.jsonl");
-    vi.setSystemTime(Date.now() + 5_001);
+    vi.setSystemTime(Date.now() + 1_001);
     const refreshed = await listSessionFilesForAgent("main");
 
     expect(readdirSpy).toHaveBeenCalledTimes(2);

--- a/packages/memory-host-sdk/src/host/session-files.ts
+++ b/packages/memory-host-sdk/src/host/session-files.ts
@@ -360,17 +360,54 @@ function pruneSessionFilesListing(): void {
   }
 }
 
-async function readSessionFilesForDir(dir: string): Promise<string[]> {
+// A successful scan (including a legitimately absent dir) yields a listing we
+// can cache; a transient failure must not be cached as an empty set, or one
+// NFS blip would hide real session files from sync/export for the whole TTL.
+type SessionFilesReadResult = { ok: true; files: string[] } | { ok: false };
+
+async function readSessionFilesForDir(dir: string): Promise<SessionFilesReadResult> {
   try {
     const entries = await fs.readdir(dir, { withFileTypes: true });
-    return entries
+    const files = entries
       .filter((entry) => entry.isFile())
       .map((entry) => entry.name)
       .filter((name) => isUsageCountedSessionTranscriptFileName(name))
       .map((name) => path.join(dir, name));
-  } catch {
+    return { ok: true, files };
+  } catch (err) {
+    // A missing sessions dir is the normal "no sessions yet" state and is safe
+    // to cache as empty (the first session write emits an invalidation event).
+    // Any other readdir failure (transient NFS EIO/ESTALE/EACCES/timeout) is
+    // returned to this caller as empty but deliberately not cached.
+    if ((err as NodeJS.ErrnoException)?.code === "ENOENT") {
+      return { ok: true, files: [] };
+    }
+    return { ok: false };
+  }
+}
+
+async function loadSessionFilesSnapshot(
+  dir: string,
+  entry: SessionFilesListingEntry,
+): Promise<string[]> {
+  const result = await readSessionFilesForDir(dir);
+  // Only act if this read is still the active entry; an invalidation or a newer
+  // read during the await must win.
+  const active = sessionFilesListingByDir.get(dir) === entry;
+  if (!result.ok) {
+    // Failed scan: never publish an empty snapshot. Drop the entry so the next
+    // caller retries instead of serving a false-empty listing for the TTL.
+    if (active) {
+      sessionFilesListingByDir.delete(dir);
+    }
     return [];
   }
+  if (active) {
+    entry.inFlight = undefined;
+    entry.value = result.files;
+    entry.expiresAt = Date.now() + SESSION_FILES_LISTING_TTL_MS;
+  }
+  return result.files;
 }
 
 export async function listSessionFilesForAgent(agentId: string): Promise<string[]> {
@@ -383,19 +420,14 @@ export async function listSessionFilesForAgent(agentId: string): Promise<string[
   if (existing?.value && Date.now() < existing.expiresAt) {
     return existing.value;
   }
-  const inFlight = readSessionFilesForDir(dir);
-  const entry: SessionFilesListingEntry = { inFlight, expiresAt: 0 };
+  const entry: SessionFilesListingEntry = { expiresAt: 0 };
   sessionFilesListingByDir.set(dir, entry);
   pruneSessionFilesListing();
-  const value = await inFlight;
-  // Only publish the snapshot if this read is still the active entry; an
-  // invalidation or newer read during the await must win.
-  if (sessionFilesListingByDir.get(dir) === entry) {
-    entry.inFlight = undefined;
-    entry.value = value;
-    entry.expiresAt = Date.now() + SESSION_FILES_LISTING_TTL_MS;
-  }
-  return value;
+  // Share one in-flight read across concurrent callers; the snapshot is only
+  // published on success (see loadSessionFilesSnapshot).
+  const inFlight = loadSessionFilesSnapshot(dir, entry);
+  entry.inFlight = inFlight;
+  return await inFlight;
 }
 
 /** Clears cached session-file listing snapshots. Used by tests to isolate runs. */

--- a/packages/memory-host-sdk/src/host/session-files.ts
+++ b/packages/memory-host-sdk/src/host/session-files.ts
@@ -313,8 +313,9 @@ function classifySessionTranscriptFromSessionStore(absPath: string): {
 // chat inject, command exec, and `.reset.`/`.deleted.` archive rotation) emits
 // `onSessionTranscriptUpdate`, which drops the affected directory's snapshot.
 // The TTL is only a backstop for writers that never reach our event bus, such
-// as another node sharing the NFS sessions dir or low-frequency archive prunes.
-const SESSION_FILES_LISTING_TTL_MS = 5_000;
+// as another node sharing the NFS sessions dir or low-frequency archive prunes;
+// 1s keeps that eventual-consistency window tight.
+const SESSION_FILES_LISTING_TTL_MS = 1_000;
 // Bound the snapshot map so a process that touches many agents cannot grow it
 // without limit; agents are few in practice, so eviction is rare.
 const SESSION_FILES_LISTING_MAX_DIRS = 64;
@@ -413,11 +414,14 @@ export async function listSessionFilesForAgent(agentId: string): Promise<string[
   ensureSessionFilesInvalidationSubscription();
   const dir = resolveSessionTranscriptsDirForAgent(agentId);
   const existing = sessionFilesListingByDir.get(dir);
+  // Return a copy: coalesced and cached callers share the stored snapshot, so
+  // handing out the array directly would let one caller's in-place mutation
+  // corrupt the cache and every other caller's view.
   if (existing?.inFlight) {
-    return await existing.inFlight;
+    return (await existing.inFlight).slice();
   }
   if (existing?.value && Date.now() < existing.expiresAt) {
-    return existing.value;
+    return existing.value.slice();
   }
   const entry: SessionFilesListingEntry = { expiresAt: 0 };
   sessionFilesListingByDir.set(dir, entry);
@@ -426,7 +430,7 @@ export async function listSessionFilesForAgent(agentId: string): Promise<string[
   // single read; the snapshot is only stored on success.
   const inFlight = loadSessionFilesSnapshot(dir, entry);
   entry.inFlight = inFlight;
-  return await inFlight;
+  return (await inFlight).slice();
 }
 
 /** Clears cached session-file listing snapshots. Used by tests to isolate runs. */

--- a/packages/memory-host-sdk/src/host/session-files.ts
+++ b/packages/memory-host-sdk/src/host/session-files.ts
@@ -16,6 +16,7 @@ import {
   isSessionArchiveArtifactName,
   isSilentReplyPayloadText,
   isUsageCountedSessionTranscriptFileName,
+  onSessionTranscriptUpdate,
   parseUsageCountedSessionIdFromFileName,
   resolveSessionTranscriptsDirForAgent,
   stripInboundMetadata,
@@ -300,8 +301,66 @@ function classifySessionTranscriptFromSessionStore(absPath: string): {
   };
 }
 
-export async function listSessionFilesForAgent(agentId: string): Promise<string[]> {
-  const dir = resolveSessionTranscriptsDirForAgent(agentId);
+// `listSessionFilesForAgent` performs a directory READDIR that is expensive on
+// networked filesystems (NFS): resolving each entry's type turns one logical
+// scan into roughly one attribute fetch per session file. Several subsystems
+// (startup catch-up, incremental sync, dreaming, qmd export) scan the same
+// agent sessions dir in close succession, so we coalesce concurrent reads and
+// serve a short-lived snapshot between scans.
+//
+// Correctness comes from event-driven invalidation, not from the TTL: every
+// in-process mutation to a session-owned path (append, compaction, rewrite,
+// chat inject, command exec, and `.reset.`/`.deleted.` archive rotation) emits
+// `onSessionTranscriptUpdate`, which drops the affected directory's snapshot.
+// The TTL is only a backstop for writers that never reach our event bus, such
+// as another node sharing the NFS sessions dir or low-frequency archive prunes.
+const SESSION_FILES_LISTING_TTL_MS = 5_000;
+// Bound the snapshot map so a process that touches many agents cannot grow it
+// without limit; agents are few in practice, so eviction is rare.
+const SESSION_FILES_LISTING_MAX_DIRS = 64;
+
+type SessionFilesListingEntry = {
+  // Shared in-flight read so concurrent callers issue a single READDIR.
+  inFlight?: Promise<string[]>;
+  // Last resolved listing, served until `expiresAt` or invalidation.
+  value?: string[];
+  expiresAt: number;
+};
+
+// Keyed by the resolved sessions directory rather than the agent id: the dir
+// folds in OPENCLAW_STATE_DIR so it stays correct across env changes, and it
+// matches `path.dirname(update.sessionFile)` for precise invalidation.
+const sessionFilesListingByDir = new Map<string, SessionFilesListingEntry>();
+let sessionFilesInvalidationSubscribed = false;
+
+function ensureSessionFilesInvalidationSubscription(): void {
+  if (sessionFilesInvalidationSubscribed) {
+    return;
+  }
+  sessionFilesInvalidationSubscribed = true;
+  // Single canonical invalidation channel. Archive rotation also emits here, so
+  // each rotation/mutation write path is covered without a separate hook.
+  onSessionTranscriptUpdate((update) => {
+    if (update.agentId) {
+      sessionFilesListingByDir.delete(resolveSessionTranscriptsDirForAgent(update.agentId));
+    }
+    if (update.sessionFile) {
+      sessionFilesListingByDir.delete(path.dirname(update.sessionFile));
+    }
+  });
+}
+
+function pruneSessionFilesListing(): void {
+  while (sessionFilesListingByDir.size > SESSION_FILES_LISTING_MAX_DIRS) {
+    const oldest = sessionFilesListingByDir.keys().next().value;
+    if (oldest === undefined) {
+      return;
+    }
+    sessionFilesListingByDir.delete(oldest);
+  }
+}
+
+async function readSessionFilesForDir(dir: string): Promise<string[]> {
   try {
     const entries = await fs.readdir(dir, { withFileTypes: true });
     return entries
@@ -312,6 +371,36 @@ export async function listSessionFilesForAgent(agentId: string): Promise<string[
   } catch {
     return [];
   }
+}
+
+export async function listSessionFilesForAgent(agentId: string): Promise<string[]> {
+  ensureSessionFilesInvalidationSubscription();
+  const dir = resolveSessionTranscriptsDirForAgent(agentId);
+  const existing = sessionFilesListingByDir.get(dir);
+  if (existing?.inFlight) {
+    return await existing.inFlight;
+  }
+  if (existing?.value && Date.now() < existing.expiresAt) {
+    return existing.value;
+  }
+  const inFlight = readSessionFilesForDir(dir);
+  const entry: SessionFilesListingEntry = { inFlight, expiresAt: 0 };
+  sessionFilesListingByDir.set(dir, entry);
+  pruneSessionFilesListing();
+  const value = await inFlight;
+  // Only publish the snapshot if this read is still the active entry; an
+  // invalidation or newer read during the await must win.
+  if (sessionFilesListingByDir.get(dir) === entry) {
+    entry.inFlight = undefined;
+    entry.value = value;
+    entry.expiresAt = Date.now() + SESSION_FILES_LISTING_TTL_MS;
+  }
+  return value;
+}
+
+/** Clears cached session-file listing snapshots. Used by tests to isolate runs. */
+export function resetSessionFilesListingCache(): void {
+  sessionFilesListingByDir.clear();
 }
 
 function extractAgentIdFromSessionPath(absPath: string): string | null {

--- a/packages/memory-host-sdk/src/host/session-files.ts
+++ b/packages/memory-host-sdk/src/host/session-files.ts
@@ -375,10 +375,9 @@ async function readSessionFilesForDir(dir: string): Promise<SessionFilesReadResu
       .map((name) => path.join(dir, name));
     return { ok: true, files };
   } catch (err) {
-    // A missing sessions dir is the normal "no sessions yet" state and is safe
-    // to cache as empty (the first session write emits an invalidation event).
-    // Any other readdir failure (transient NFS EIO/ESTALE/EACCES/timeout) is
-    // returned to this caller as empty but deliberately not cached.
+    // A missing sessions dir is the normal "no sessions yet" state, safe to
+    // cache as empty (the first session write emits an invalidation event).
+    // Any other failure is transient (EIO/ESTALE/timeout) and stays uncached.
     if ((err as NodeJS.ErrnoException)?.code === "ENOENT") {
       return { ok: true, files: [] };
     }
@@ -395,8 +394,8 @@ async function loadSessionFilesSnapshot(
   // read during the await must win.
   const active = sessionFilesListingByDir.get(dir) === entry;
   if (!result.ok) {
-    // Failed scan: never publish an empty snapshot. Drop the entry so the next
-    // caller retries instead of serving a false-empty listing for the TTL.
+    // Drop the entry so the next caller retries; never publish a false-empty
+    // snapshot from a transient failure.
     if (active) {
       sessionFilesListingByDir.delete(dir);
     }
@@ -423,8 +422,8 @@ export async function listSessionFilesForAgent(agentId: string): Promise<string[
   const entry: SessionFilesListingEntry = { expiresAt: 0 };
   sessionFilesListingByDir.set(dir, entry);
   pruneSessionFilesListing();
-  // Share one in-flight read across concurrent callers; the snapshot is only
-  // published on success (see loadSessionFilesSnapshot).
+  // Publish inFlight before this function awaits so concurrent callers join a
+  // single read; the snapshot is only stored on success.
   const inFlight = loadSessionFilesSnapshot(dir, entry);
   entry.inFlight = inFlight;
   return await inFlight;


### PR DESCRIPTION
## Summary

Repeated session-directory scans (`listSessionFilesForAgent`) issue a `fs.readdir(dir, { withFileTypes: true })` per call with **zero caching or coalescing** across call sites. On networked filesystems (NFS) this is expensive: resolving each entry's type turns one logical scan into roughly one attribute fetch per session file, and several subsystems (startup catch-up, incremental sync, dreaming, qmd export) scan the same agent sessions dir in close succession — producing redundant READDIR/GETATTR load.

This adds an in-flight dedupe + short-TTL snapshot cache around `listSessionFilesForAgent`:

- **Coalescing (the zero-staleness win)** — concurrent callers join a single in-flight `Promise`, so a burst of scans triggers one READDIR instead of N. Each caller still sees a result that reflects the directory at read time; there is no staleness window for the concurrent case.
- **Short-TTL snapshot** — a resolved listing is reused briefly between scans. The cache is keyed by the **resolved sessions directory** (folds in `OPENCLAW_STATE_DIR`, and lines up with `path.dirname(update.sessionFile)` for precise invalidation).
- **Per-caller copies** — every public return hands back a `.slice()` of the snapshot, so the cached array is never shared by reference. A caller mutating its result can't corrupt the cache or another caller's view; the coalescing/caching is invisible to callers.
- **Event-driven invalidation (the correctness path)** — a single lazy subscription to the canonical `onSessionTranscriptUpdate` event drops the affected directory's snapshot. Every in-process mutation to a session-owned path (append, compaction, rewrite, chat inject, command exec) emits this event, and archive rotation (`archiveFileOnDisk`) already emits through it too, so one canonical hook covers all in-process write paths without scattered per-path invalidation.
- **TTL as a backstop only** — `SESSION_FILES_LISTING_TTL_MS = 1_000` (1s) bounds staleness for writers that never reach our event bus (e.g. another node sharing the NFS sessions dir, or low-frequency archive prunes). Correctness for in-process writes comes from the event invalidation above, not the TTL; 1s keeps the eventual-consistency window for out-of-band writers tight.
- **Failed scans are never cached** — read results are a discriminated union (`{ ok: true; files } | { ok: false }`). A transient `fs.readdir` failure (NFS `EIO`/`ESTALE`/`EACCES`/timeout) is returned to the one caller as empty but **not published** into the snapshot, so the next call retries instead of serving a false-empty session set for the TTL window. A legitimately absent dir (`ENOENT`, the normal "no sessions yet" state) is still cached as empty, since the first session write emits an invalidation event.

The cache is bounded (64 dirs), module-lifecycle-owned, and race-safe: a completed read only publishes its snapshot if its entry is still the active one, so an invalidation or newer read during the await wins. A `resetSessionFilesListingCache()` helper exists for test isolation and is intentionally kept out of the package's public re-export surface.

`withFileTypes` removal (to cut the per-entry NFS `lstat` amplification) is deferred to a focused follow-up.

## Scope — what reads are covered

The cache wraps a single physical read: the `fs.readdir(dir, { withFileTypes: true })` inside `listSessionFilesForAgent`, where `dir` is the resolved per-agent sessions directory (`…/agents/<agentId>/sessions`). That `withFileTypes` scan is the expensive NFS operation — one logical scan fans out into roughly one attribute fetch per session file.

Four in-process memory-engine call sites repeatedly scan the same sessions dir in close succession (the "repeated scans" pattern from the analysis); all now route through the coalesce/cache layer:

| Caller | Path | What triggers it |
|---|---|---|
| `manager-sync-ops.ts:1188` | `markSessionStartupCatchupDirtyFiles()` | Startup catch-up — memory manager boot with the `sessions` source enabled. |
| `manager-sync-ops.ts:1629` | incremental/targeted reindex | Memory sync cycles — when no explicit `targetSessionFiles` are passed, it lists the whole dir to build the reindex plan. |
| `dreaming-phases.ts:850` | session-ingestion loop | Dreaming — iterates `agentIds`, listing each agent's sessions to batch messages by day. |
| `qmd-manager.ts:2383` | `exportSessions()` | qmd export — retention/export pass listing sessions to compute keep/track sets. |

These run on overlapping schedules and can fire concurrently, so they previously produced N independent READDIR storms over a single directory. With the cache:

- Concurrent calls → coalesced into **1** READDIR (in-flight join).
- Sequential calls within the TTL with no intervening write → served from snapshot, **0** READDIR.
- After any session write → the `onSessionTranscriptUpdate` event drops the snapshot, so the next call re-scans.

**Out of scope (intentional — focused change):** other sessions-dir reads that are one-shot / CLI / diagnostic rather than hot-loop, and are left for a follow-up: `dreaming-narrative.ts:901` (separate narrative readdir; the most natural follow-up candidate), `cli.runtime.ts:527` (`scanSessionFiles` CLI diagnostic), `session-cost-usage.ts:378` (cost/usage subsystem), `dreaming-repair.ts:78` (repair corpus pass). Unrelated scans of the parent `agents/` directory (`session-utils.ts`, `agent-list.ts`, gateway `doctor.ts`) use a different key and are untouched.

## Verification

### Committed regression tests

`node scripts/run-vitest.mjs packages/memory-host-sdk/src/host/session-files.test.ts` — **19/19** (12 pre-existing + 7 new). The cache tests count real scans by spying on `fsPromises.readdir`:

- **concurrent coalescing** — two un-awaited concurrent calls ⇒ `readdir` called **exactly once**.
- **cached-within-TTL** — a second call after writing a new file *without* emitting an event still returns the prior snapshot ⇒ **1** scan.
- **refresh-after-TTL** — with `vi.useFakeTimers({ toFake: ["Date"] })`, advancing `Date` past the 1s TTL forces a re-scan ⇒ **2** scans, fresh listing.
- **event invalidation** — `emitSessionTranscriptUpdate({ sessionFile })` drops the snapshot ⇒ next call re-scans, fresh listing.
- **failed-scan not cached** *(new, addresses review)* — `readdir` rejected once with `EIO` ⇒ first call returns `[]`, a second call within the TTL **re-scans** (2 scans) and recovers the real listing.
- **absent-dir cached** *(new)* — a missing sessions dir (`ENOENT`) is cached as empty ⇒ **1** scan across two calls.
- **isolated per-caller copies** *(new)* — across a concurrent burst (in-flight originator + joiner) and a sequential cache hit, callers mutate their returned arrays (`.length = 0`, `.push`); a later read still returns the correct listing ⇒ caller mutation can't corrupt the snapshot, all from **1** scan.

Other proof:

- Consumer suites green: `manager-sync-ops.startup-catchup`, `manager-targeted-sync`, `manager-session-sync-state`, `qmd-manager`, `manager.fts-only-reindex`, `manager-source-state`, `dreaming-phases`, `manager-sync-yield`, `session-files-yield`.
- Typecheck: `pnpm tsgo:core` and `pnpm tsgo:test:packages` exit 0. `node scripts/run-oxlint.mjs` clean; `oxfmt --check` clean.

### Concurrency chaos / fuzz hammering (dev-time stress; not committed)

A seeded invariant-based harness drove **randomized interleavings** of concurrent read bursts + real file create/delete + `onSessionTranscriptUpdate` events against the live cache, asserting:

- **coalescing by physical READDIR count** — a `fsPromises.readdir` spy confirms a synchronous burst of N concurrent reads issues **≤1** physical scan (a fresh read, or **0** when served from a live snapshot), never one per caller, and every caller observes the same content (compared by value, since each now receives its own array copy);
- **no phantom files** — every returned name is a real, valid session file that actually existed;
- **eventual consistency** — after a final invalidation, the listing equals on-disk ground truth exactly;
- **cache-bound correctness** — with agent count > the 64-dir bound, evicted entries re-read fresh (never stale/wrong).

Ran against the current design (1s TTL, per-caller copies, READDIR-count coalescing proof) at **20,000 iterations × burst 32 × 300 agents across 5 seeds** — all green. (Kept as a local stress tool rather than a committed suite to avoid a long-running test in CI; the committed unit tests above are the durable regression guard.)

### Mutation testing (dev-time; confirms the tests actually catch breakage)

Each cache invariant was corrupted one at a time in `session-files.ts`; the unit + chaos suites were re-run to confirm they **kill** the mutant, then the source was restored (verified clean via `git diff`):

| Mutant | Killed by | Result |
|---|---|---|
| re-cache failed scan (the bug this PR's fix removes) | unit | ✅ killed |
| drop event-driven invalidation | unit + chaos | ✅ killed |
| TTL constant → 0 (cache disabled) | unit | ✅ killed |
| disable TTL cache read (never serve snapshot) | unit | ✅ killed |
| no coalesce-join (no shared in-flight) | unit + chaos | ✅ killed |
| treat ENOENT as failure (stop caching empty dirs) | unit | ✅ killed |
| drop `.slice()` on in-flight originator return | unit | ✅ killed |
| drop `.slice()` on coalesced joiner return | unit | ✅ killed |
| drop `.slice()` on cached-snapshot return | unit | ✅ killed |
| drop race-guard on publish | — | ⚪ survives (expected) |
| max-dirs bound 64 → 100000 | — | ⚪ survives (perf-only) |

**9/9 correctness mutants killed, 0 unexpected survivors.** The surviving `drop-race-guard` is expected: reads *replace* the map entry rather than mutating it, so a stale completion writing into an orphaned entry is harmless — the guard is documented defensive intent, not load-bearing. `max-dirs` is a perf knob, not a correctness property.



