### PR TITLE
fix(memory): do not prune session index from a failed directory scan

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-e9fb501204b6c4c0e08c09174311f85ae8a129bf35e18edea0fa217ee4203ad8  plugin-sdk-api-baseline.json
-50db19cf60c5465b22d342ccdabe465ae08d0c475e6403b86360f775bfc3513a  plugin-sdk-api-baseline.jsonl
+81c4c2c686e22a47d807c40df926ec9b9fbac27a1646d414cd869da79419b488  plugin-sdk-api-baseline.json
+11a5a81566c6647541dff98961bc6cba568060ff61a87efb7f2e9b3f74aab0f1  plugin-sdk-api-baseline.jsonl

--- a/extensions/memory-core/src/cli.runtime.ts
+++ b/extensions/memory-core/src/cli.runtime.ts
@@ -532,7 +532,7 @@ async function checkReadableFile(pathname: string): Promise<{ exists: boolean; i
   }
 }
 
-async function scanSessionFiles(agentId: string): Promise<SourceScan> {
+async function diagnoseSessionFiles(agentId: string): Promise<SourceScan> {
   const issues: string[] = [];
   const sessionsDir = resolveSessionTranscriptsDirForAgent(agentId);
   try {
@@ -554,7 +554,7 @@ async function scanSessionFiles(agentId: string): Promise<SourceScan> {
   }
 }
 
-async function scanMemoryFiles(
+async function diagnoseMemoryFiles(
   workspaceDir: string,
   extraPaths: string[] = [],
 ): Promise<SourceScan> {
@@ -680,10 +680,10 @@ async function scanMemorySources(params: {
   const extraPaths = params.extraPaths ?? [];
   for (const source of params.sources) {
     if (source === "memory") {
-      scans.push(await scanMemoryFiles(params.workspaceDir, extraPaths));
+      scans.push(await diagnoseMemoryFiles(params.workspaceDir, extraPaths));
     }
     if (source === "sessions") {
-      scans.push(await scanSessionFiles(params.agentId));
+      scans.push(await diagnoseSessionFiles(params.agentId));
     }
   }
   const issues = scans.flatMap((scan) => scan.issues);

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -1335,12 +1335,13 @@ describe("memory index", () => {
       try {
         const fields = nextManager as unknown as {
           dirty: boolean;
-          syncSessionFiles: (params: unknown) => Promise<void>;
+          syncSessionFiles: (params: unknown) => Promise<unknown>;
         };
         const syncSessionFiles = fields.syncSessionFiles.bind(nextManager);
         fields.syncSessionFiles = async (params) => {
           fields.dirty = true;
-          await syncSessionFiles(params);
+          // Forward the sync plan: runSync reads scanOk from the return value.
+          return await syncSessionFiles(params);
         };
 
         await nextManager.sync({ reason: "test", force: true });

--- a/extensions/memory-core/src/memory/manager-session-sync-state.test.ts
+++ b/extensions/memory-core/src/memory/manager-session-sync-state.test.ts
@@ -17,6 +17,7 @@ describe("memory session sync state", () => {
         { path: "sessions/b.jsonl", hash: "hash-b" },
       ],
       sessionPathForFile: (file) => `sessions/${file.split("/").at(-1)}`,
+      scanOk: true,
     });
 
     expect(plan.indexAll).toBe(true);
@@ -31,6 +32,46 @@ describe("memory session sync state", () => {
         ["sessions/b.jsonl", "hash-b"],
       ]),
     );
+    // A full enumeration that read the directory may prune stale rows.
+    expect(plan.pruneStaleRows).toBe(true);
+  });
+
+  it("skips pruning when the full directory scan failed", () => {
+    const plan = resolveMemorySessionSyncPlan({
+      needsFullReindex: false,
+      // A failed scan surfaces an empty listing even though the index still
+      // holds rows; pruning here would wipe the whole session index.
+      files: [],
+      targetSessionFiles: null,
+      sessionsDirtyFiles: new Set(),
+      existingRows: [
+        { path: "sessions/a.jsonl", hash: "hash-a" },
+        { path: "sessions/b.jsonl", hash: "hash-b" },
+      ],
+      sessionPathForFile: (file) => `sessions/${file.split("/").at(-1)}`,
+      scanOk: false,
+    });
+
+    expect(plan.activePaths).toEqual(new Set());
+    expect(plan.pruneStaleRows).toBe(false);
+  });
+
+  it("still prunes when an authoritatively empty directory leaves orphaned rows", () => {
+    const plan = resolveMemorySessionSyncPlan({
+      needsFullReindex: false,
+      // The directory was read successfully and genuinely has no session files
+      // (e.g. disk-budget removed the last archive); orphaned rows should be
+      // pruned rather than lingering in search.
+      files: [],
+      targetSessionFiles: null,
+      sessionsDirtyFiles: new Set(),
+      existingRows: [{ path: "sessions/a.jsonl", hash: "hash-a" }],
+      sessionPathForFile: (file) => `sessions/${file.split("/").at(-1)}`,
+      scanOk: true,
+    });
+
+    expect(plan.activePaths).toEqual(new Set());
+    expect(plan.pruneStaleRows).toBe(true);
   });
 
   it("treats targeted session syncs as refresh-only and skips unrelated pruning", () => {
@@ -44,12 +85,15 @@ describe("memory session sync state", () => {
         { path: "sessions/targeted-second.jsonl", hash: "hash-second" },
       ],
       sessionPathForFile: (file) => `sessions/${file.split("/").at(-1)}`,
+      scanOk: true,
     });
 
     expect(plan.indexAll).toBe(true);
     expect(plan.activePaths).toBeNull();
     expect(plan.existingRows).toBeNull();
     expect(plan.existingHashes).toBeNull();
+    // Targeted syncs never hold a full enumeration, so they must not prune.
+    expect(plan.pruneStaleRows).toBe(false);
   });
 
   it("keeps dirty-only incremental mode when no targeted sync is requested", () => {
@@ -60,6 +104,7 @@ describe("memory session sync state", () => {
       sessionsDirtyFiles: new Set(["/tmp/incremental.jsonl"]),
       existingRows: [],
       sessionPathForFile: (file) => `sessions/${file.split("/").at(-1)}`,
+      scanOk: true,
     });
 
     expect(plan.indexAll).toBe(false);

--- a/extensions/memory-core/src/memory/manager-session-sync-state.ts
+++ b/extensions/memory-core/src/memory/manager-session-sync-state.ts
@@ -40,11 +40,25 @@ export function resolveMemorySessionSyncPlan(params: {
   sessionsDirtyFiles: Set<string>;
   existingRows?: MemorySourceFileStateRow[] | null;
   sessionPathForFile: (file: string) => string;
+  // Whether the enumeration that produced `files` was authoritative (the
+  // sessions dir was read or does not exist). Required so a new caller cannot
+  // silently default a failed scan to authoritative: an empty `files` array
+  // from a failed scan must not drive the destructive stale-row prune. See
+  // `pruneStaleRows`. Targeted syncs pass true (no scan involved).
+  scanOk: boolean;
 }): {
   activePaths: Set<string> | null;
   existingRows: MemorySourceFileStateRow[] | null;
   existingHashes: Map<string, string> | null;
   indexAll: boolean;
+  // True only when the stale-row prune is safe to run: a full enumeration
+  // (activePaths !== null) that authoritatively read the directory. When the
+  // scan failed, `files` is empty for reasons unrelated to the on-disk state,
+  // so pruning every row not in the (empty) listing would wipe the session
+  // index on a single transient NFS error. An authoritatively empty directory
+  // still prunes, so legitimately removed sessions (e.g. disk-budget removing
+  // the last archive) do not leave orphaned rows.
+  pruneStaleRows: boolean;
 } {
   const activePaths = params.targetSessionFiles
     ? null
@@ -58,5 +72,6 @@ export function resolveMemorySessionSyncPlan(params: {
       params.needsFullReindex ||
       Boolean(params.targetSessionFiles) ||
       params.sessionsDirtyFiles.size === 0,
+    pruneStaleRows: activePaths !== null && params.scanOk,
   };
 }

--- a/extensions/memory-core/src/memory/manager-sync-ops.prune-guard.test.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.prune-guard.test.ts
@@ -1,0 +1,230 @@
+// Memory Core tests cover stale-row prune safety in manager sync ops: a full
+// enumeration only prunes indexed rows when it actually read the source roots,
+// so a transient scan failure cannot wipe the session or memory-file index.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { DatabaseSync } from "node:sqlite";
+import {
+  resolveSessionTranscriptsDirForAgent,
+  type OpenClawConfig,
+  type ResolvedMemorySearchConfig,
+} from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { MemoryIndexProviderIdentity } from "./manager-reindex-state.js";
+import { MemoryManagerSyncOps } from "./manager-sync-ops.js";
+
+type SourceStateRow = { path: string; hash: string; mtime: number; size: number };
+type SourceSyncPlanResult = { scanOk: boolean };
+
+class PruneGuardHarness extends MemoryManagerSyncOps {
+  protected readonly cfg = {} as OpenClawConfig;
+  protected readonly agentId = "main";
+  protected readonly settings = {
+    sync: {
+      sessions: {
+        deltaBytes: 100_000,
+        deltaMessages: 50,
+        postCompactionForce: true,
+      },
+    },
+  } as ResolvedMemorySearchConfig;
+  protected readonly batch = {
+    enabled: false,
+    wait: false,
+    concurrency: 1,
+    pollIntervalMs: 0,
+    timeoutMs: 0,
+  };
+  protected readonly vector = { enabled: false, available: false };
+  protected readonly cache = { enabled: false };
+  protected providerUnavailableReason?: string;
+  protected providerLifecycle = { mode: "active" as const, providerId: "test" };
+  protected db: DatabaseSync;
+
+  readonly deletedRows: Array<{ path: string; source: string }> = [];
+
+  constructor(
+    sourceRows: SourceStateRow[],
+    protected readonly workspaceDir = "/tmp/openclaw-test-workspace",
+  ) {
+    super();
+    this.sources.add("sessions");
+    this.sources.add("memory");
+    this.db = {
+      prepare: (sql: string) => ({
+        all: () => sourceRows,
+        get: () => undefined,
+        run: (...args: unknown[]) => {
+          if (sql.startsWith("DELETE FROM memory_index_sources")) {
+            this.deletedRows.push({ path: String(args[0]), source: String(args[1]) });
+          }
+          return undefined;
+        },
+      }),
+    } as unknown as DatabaseSync;
+  }
+
+  async runFullSessionSync(): Promise<SourceSyncPlanResult> {
+    return await (
+      this as unknown as {
+        syncSessionFiles: (p: unknown) => Promise<SourceSyncPlanResult>;
+      }
+    ).syncSessionFiles({ needsFullReindex: true });
+  }
+
+  async runFullMemorySync(): Promise<SourceSyncPlanResult> {
+    return await (
+      this as unknown as {
+        syncMemoryFiles: (p: unknown) => Promise<SourceSyncPlanResult>;
+      }
+    ).syncMemoryFiles({ needsFullReindex: true });
+  }
+
+  deletedPathsFor(source: string): string[] {
+    return this.deletedRows.filter((row) => row.source === source).map((row) => row.path);
+  }
+
+  protected computeProviderKey(): string {
+    return "test";
+  }
+
+  protected resolveProviderIndexIdentities(): MemoryIndexProviderIdentity[] {
+    return [];
+  }
+
+  protected async sync(): Promise<void> {}
+
+  protected async withTimeout<T>(promise: Promise<T>): Promise<T> {
+    return await promise;
+  }
+
+  protected getIndexConcurrency(): number {
+    return 1;
+  }
+
+  protected pruneEmbeddingCacheIfNeeded(): void {}
+
+  protected resetProviderInitializationForRetry(): void {}
+
+  protected assertRequiredProviderAvailable(): void {}
+
+  protected async indexFile(): Promise<void> {}
+}
+
+describe("session prune safety", () => {
+  let stateDir = "";
+
+  beforeEach(async () => {
+    stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-session-prune-"));
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+    await fs.rm(stateDir, { recursive: true, force: true });
+  });
+
+  it("does not prune indexed session rows when the directory scan fails", async () => {
+    // The index holds a session row; a transient readdir failure surfaces an
+    // empty listing. Without the guard the empty listing would prune the row.
+    await fs.mkdir(resolveSessionTranscriptsDirForAgent("main"), { recursive: true });
+    const harness = new PruneGuardHarness([
+      { path: "sessions/main/thread.jsonl", hash: "hash-a", mtime: 1, size: 1 },
+    ]);
+    vi.spyOn(fs, "readdir").mockRejectedValueOnce(
+      Object.assign(new Error("nfs blip"), { code: "EIO" }),
+    );
+
+    const plan = await harness.runFullSessionSync();
+
+    expect(plan.scanOk).toBe(false);
+    expect(harness.deletedPathsFor("sessions")).toEqual([]);
+  });
+
+  it("prunes orphaned session rows when the directory is authoritatively empty", async () => {
+    // The directory is read successfully and genuinely holds no session files
+    // (e.g. disk-budget removed the last archive). The orphaned row must be
+    // pruned rather than lingering in search.
+    await fs.mkdir(resolveSessionTranscriptsDirForAgent("main"), { recursive: true });
+    const harness = new PruneGuardHarness([
+      { path: "sessions/main/gone.jsonl", hash: "hash-gone", mtime: 1, size: 1 },
+    ]);
+
+    const plan = await harness.runFullSessionSync();
+
+    expect(plan.scanOk).toBe(true);
+    expect(harness.deletedPathsFor("sessions")).toEqual(["sessions/main/gone.jsonl"]);
+  });
+
+  it("prunes orphaned session rows when the sessions directory is absent", async () => {
+    // The dir only exists once a transcript is written, so ENOENT under an
+    // existing agent dir is an authoritative empty enumeration (fresh agent,
+    // or the dir was removed wholesale) and orphaned rows must still be
+    // pruned.
+    await fs.mkdir(path.join(stateDir, "agents", "main"), { recursive: true });
+    const harness = new PruneGuardHarness([
+      { path: "sessions/main/gone.jsonl", hash: "hash-gone", mtime: 1, size: 1 },
+    ]);
+
+    const plan = await harness.runFullSessionSync();
+
+    expect(plan.scanOk).toBe(true);
+    expect(harness.deletedPathsFor("sessions")).toEqual(["sessions/main/gone.jsonl"]);
+  });
+});
+
+describe("memory-file prune safety", () => {
+  let stateDir = "";
+
+  beforeEach(async () => {
+    stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-memory-prune-"));
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+    await fs.rm(stateDir, { recursive: true, force: true });
+  });
+
+  it("does not prune indexed memory rows when the enumeration fails", async () => {
+    const workspaceDir = path.join(stateDir, "workspace");
+    const memoryDir = path.join(workspaceDir, "memory");
+    await fs.mkdir(memoryDir, { recursive: true });
+    const harness = new PruneGuardHarness(
+      [{ path: "memory/notes.md", hash: "hash-notes", mtime: 1, size: 1 }],
+      workspaceDir,
+    );
+    const realLstat = fs.lstat;
+    vi.spyOn(fs, "lstat").mockImplementation(async (...args: Parameters<typeof realLstat>) => {
+      const [target] = args;
+      if (typeof target === "string" && path.resolve(target) === memoryDir) {
+        throw Object.assign(new Error("nfs blip"), { code: "EIO" });
+      }
+      return await realLstat(...args);
+    });
+
+    const plan = await harness.runFullMemorySync();
+
+    expect(plan.scanOk).toBe(false);
+    expect(harness.deletedPathsFor("memory")).toEqual([]);
+  });
+
+  it("prunes orphaned memory rows when the workspace holds no memory files", async () => {
+    // The workspace exists but has no root memory file and no memory dir; the
+    // enumeration is authoritative, so the orphaned row must be pruned.
+    const workspaceDir = path.join(stateDir, "workspace-empty");
+    await fs.mkdir(workspaceDir, { recursive: true });
+    const harness = new PruneGuardHarness(
+      [{ path: "memory/gone.md", hash: "hash-gone", mtime: 1, size: 1 }],
+      workspaceDir,
+    );
+
+    const plan = await harness.runFullMemorySync();
+
+    expect(plan.scanOk).toBe(true);
+    expect(harness.deletedPathsFor("memory")).toEqual(["memory/gone.md"]);
+  });
+});

--- a/extensions/memory-core/src/memory/manager-sync-ops.targeted-delta.test.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.targeted-delta.test.ts
@@ -1,0 +1,216 @@
+// Memory Core tests cover session delta sync targeting: event-driven delta
+// syncs pass the dirty set as explicit targets (skipping the sessions-dir
+// enumeration), and fall back to a full enumeration at most once per
+// reconcile window so out-of-band deletions still get pruned.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { DatabaseSync } from "node:sqlite";
+import {
+  resolveSessionTranscriptsDirForAgent,
+  type OpenClawConfig,
+  type ResolvedMemorySearchConfig,
+} from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { MemoryIndexProviderIdentity } from "./manager-reindex-state.js";
+import { MemoryManagerSyncOps } from "./manager-sync-ops.js";
+
+type RecordedSync = { reason?: string; force?: boolean; sessionFiles?: string[] };
+
+class TargetedDeltaHarness extends MemoryManagerSyncOps {
+  protected readonly cfg = {} as OpenClawConfig;
+  protected readonly agentId = "main";
+  protected readonly settings = {
+    sync: {
+      sessions: {
+        deltaBytes: 100_000,
+        deltaMessages: 50,
+        postCompactionForce: true,
+      },
+    },
+  } as ResolvedMemorySearchConfig;
+  protected readonly batch = {
+    enabled: false,
+    wait: false,
+    concurrency: 1,
+    pollIntervalMs: 0,
+    timeoutMs: 0,
+  };
+  protected readonly vector = { enabled: false, available: false };
+  protected readonly cache = { enabled: false };
+  protected providerUnavailableReason?: string;
+  protected providerLifecycle = { mode: "active" as const, providerId: "test" };
+  protected db: DatabaseSync;
+
+  readonly syncCalls: RecordedSync[] = [];
+
+  constructor(protected readonly workspaceDir = "/tmp/openclaw-test-workspace") {
+    super();
+    this.sources.add("sessions");
+    this.db = {
+      prepare: () => ({ all: () => [], get: () => undefined, run: () => undefined }),
+    } as unknown as DatabaseSync;
+  }
+
+  async runDeltaBatch(pendingFiles: string[]): Promise<void> {
+    for (const file of pendingFiles) {
+      this.sessionPendingFiles.add(file);
+    }
+    await (
+      this as unknown as { processSessionDeltaBatch: () => Promise<void> }
+    ).processSessionDeltaBatch();
+  }
+
+  addDirtyFile(sessionFile: string): void {
+    this.sessionsDirtyFiles.add(sessionFile);
+  }
+
+  setLastReconcileAt(ms: number): void {
+    (this as unknown as { lastSessionPruneReconcileAt: number }).lastSessionPruneReconcileAt = ms;
+  }
+
+  lastReconcileAt(): number {
+    return (this as unknown as { lastSessionPruneReconcileAt: number }).lastSessionPruneReconcileAt;
+  }
+
+  async runFullSessionSync(): Promise<void> {
+    await (
+      this as unknown as { syncSessionFiles: (p: unknown) => Promise<unknown> }
+    ).syncSessionFiles({ needsFullReindex: true });
+  }
+
+  protected computeProviderKey(): string {
+    return "test";
+  }
+
+  protected resolveProviderIndexIdentities(): MemoryIndexProviderIdentity[] {
+    return [];
+  }
+
+  protected async sync(params?: RecordedSync): Promise<void> {
+    this.syncCalls.push(params ?? {});
+  }
+
+  protected async withTimeout<T>(promise: Promise<T>): Promise<T> {
+    return await promise;
+  }
+
+  protected getIndexConcurrency(): number {
+    return 1;
+  }
+
+  protected pruneEmbeddingCacheIfNeeded(): void {}
+
+  protected resetProviderInitializationForRetry(): void {}
+
+  protected assertRequiredProviderAvailable(): void {}
+
+  protected async indexFile(): Promise<void> {}
+}
+
+function liveSessionFile(name: string): string {
+  return path.join(resolveSessionTranscriptsDirForAgent("main"), `${name}.jsonl`);
+}
+
+async function writeLargeLiveSession(name: string): Promise<string> {
+  const file = liveSessionFile(name);
+  await fs.mkdir(path.dirname(file), { recursive: true });
+  await fs.writeFile(file, "x".repeat(100_000), "utf8");
+  return file;
+}
+
+function archiveSessionFile(name: string): string {
+  return path.join(
+    resolveSessionTranscriptsDirForAgent("main"),
+    `${name}.jsonl.reset.2026-01-01T00-00-00.000Z`,
+  );
+}
+
+describe("session delta sync targeting", () => {
+  let stateDir = "";
+
+  beforeEach(async () => {
+    stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-targeted-delta-"));
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+    await fs.rm(stateDir, { recursive: true, force: true });
+  });
+
+  it("passes the dirty set as sync targets inside the reconcile window", async () => {
+    const harness = new TargetedDeltaHarness();
+    harness.setLastReconcileAt(Date.now());
+    const live = await writeLargeLiveSession("thread-a");
+
+    await harness.runDeltaBatch([live]);
+
+    expect(harness.syncCalls).toEqual([{ reason: "session-delta", sessionFiles: [live] }]);
+  });
+
+  it("includes leftover dirty files from earlier syncs in the targets", async () => {
+    const harness = new TargetedDeltaHarness();
+    harness.setLastReconcileAt(Date.now());
+    const leftover = liveSessionFile("thread-leftover");
+    const fresh = await writeLargeLiveSession("thread-fresh");
+    harness.addDirtyFile(leftover);
+
+    await harness.runDeltaBatch([fresh]);
+
+    expect(harness.syncCalls).toHaveLength(1);
+    expect(harness.syncCalls[0]?.reason).toBe("session-delta");
+    expect(new Set(harness.syncCalls[0]?.sessionFiles)).toEqual(new Set([leftover, fresh]));
+  });
+
+  it("forces leftover archive dirty files through a full enumeration", async () => {
+    const harness = new TargetedDeltaHarness();
+    harness.setLastReconcileAt(Date.now());
+    harness.addDirtyFile(archiveSessionFile("thread-leftover"));
+
+    await harness.runDeltaBatch([await writeLargeLiveSession("thread-fresh")]);
+
+    expect(harness.syncCalls).toEqual([{ reason: "session-delta" }]);
+  });
+
+  it("forces archive events through a full enumeration inside the reconcile window", async () => {
+    const harness = new TargetedDeltaHarness();
+    harness.setLastReconcileAt(Date.now());
+
+    await harness.runDeltaBatch([archiveSessionFile("thread-archive")]);
+
+    expect(harness.syncCalls).toEqual([{ reason: "session-delta" }]);
+  });
+
+  it("falls back to a full enumeration once the reconcile window elapses", async () => {
+    // lastSessionPruneReconcileAt starts at 0, so the first active delta sync
+    // reconciles with a full enumeration unless a prior prune already ran.
+    const harness = new TargetedDeltaHarness();
+
+    await harness.runDeltaBatch([await writeLargeLiveSession("thread-b")]);
+
+    expect(harness.syncCalls).toEqual([{ reason: "session-delta" }]);
+  });
+
+  it("advances the reconcile timestamp after an authoritative prune", async () => {
+    await fs.mkdir(resolveSessionTranscriptsDirForAgent("main"), { recursive: true });
+    const harness = new TargetedDeltaHarness();
+
+    await harness.runFullSessionSync();
+
+    expect(harness.lastReconcileAt()).toBeGreaterThan(0);
+  });
+
+  it("does not advance the reconcile timestamp when the scan fails", async () => {
+    await fs.mkdir(resolveSessionTranscriptsDirForAgent("main"), { recursive: true });
+    const harness = new TargetedDeltaHarness();
+    vi.spyOn(fs, "readdir").mockRejectedValueOnce(
+      Object.assign(new Error("nfs blip"), { code: "EIO" }),
+    );
+
+    await harness.runFullSessionSync();
+
+    expect(harness.lastReconcileAt()).toBe(0);
+  });
+});

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -24,6 +24,7 @@ import {
   listSessionTranscriptCorpusEntriesForAgent,
   parseCanonicalSessionSyncTargetFromPath,
   resolveSessionFileForSyncTarget,
+  scanSessionFilesForAgent,
   sessionPathForFile,
   type SessionTranscriptCorpusEntry,
 } from "openclaw/plugin-sdk/memory-core-host-engine-qmd";
@@ -31,7 +32,6 @@ import {
   buildFileEntry,
   ensureMemoryIndexSchema,
   isFileMissingError,
-  listMemoryFiles,
   loadSqliteVecExtension,
   MEMORY_EMBEDDING_CACHE_TABLE,
   MEMORY_INDEX_FTS_TABLE,
@@ -39,6 +39,7 @@ import {
   normalizeExtraMemoryPaths,
   retryTransientMemoryRead,
   runWithConcurrency,
+  scanMemoryFiles,
   type MemorySource,
   type MemorySessionSyncTarget,
   type MemorySyncParams,
@@ -137,6 +138,10 @@ export type MemoryIndexWorkItem = {
 type MemorySourceSyncPlan = {
   indexItems: MemoryIndexWorkItem[];
   finalize: () => Promise<void> | void;
+  // False when the source enumeration failed (non-authoritative listing).
+  // runSync then keeps the source's dirty state so the next eligible sync
+  // retries, instead of reporting a clean sync that indexed nothing.
+  scanOk: boolean;
 };
 
 type MemorySessionDeltaState = { lastSize: number; pendingBytes: number; pendingMessages: number };
@@ -156,6 +161,11 @@ const LEGACY_VECTOR_TABLE = "chunks_vec";
 const FTS_TABLE = MEMORY_INDEX_FTS_TABLE;
 const EMBEDDING_CACHE_TABLE = MEMORY_EMBEDDING_CACHE_TABLE;
 const SESSION_DIRTY_DEBOUNCE_MS = 5000;
+// Targeted delta syncs skip the sessions-dir enumeration entirely, so rows for
+// files deleted out-of-band (another process/node on shared storage) are only
+// pruned by full enumerations. Force one full-enumeration delta sync at most
+// this often to bound how long such stale rows can linger in search.
+const SESSION_PRUNE_RECONCILE_INTERVAL_MS = 15 * 60 * 1000;
 const SESSION_DELTA_READ_CHUNK_BYTES = 64 * 1024;
 const SESSION_SYNC_YIELD_EVERY = 10;
 const SOURCE_WIDE_SESSION_INDEX_FLUSH_FILES = 128;
@@ -344,6 +354,10 @@ export abstract class MemoryManagerSyncOps {
   protected sessionsFullRetryDirty = false;
   private readonly memoryWatchPressureWarning: MemoryWatchPressureWarningState = { shown: false };
   protected sessionsDirtyFiles = new Set<string>();
+  // Epoch ms of the last completed session stale-row prune (authoritative full
+  // enumeration). Starts at 0 so the first active delta sync reconciles unless
+  // the startup catch-up sync already did.
+  private lastSessionPruneReconcileAt = 0;
   protected sessionPendingFiles = new Set<string>();
   protected sessionPendingTargets = new Map<string, MemorySessionSyncTarget>();
   protected sessionDeltas = new Map<string, MemorySessionDeltaState>();
@@ -375,7 +389,20 @@ export abstract class MemoryManagerSyncOps {
   }
 
   private emptySourceSyncPlan(): MemorySourceSyncPlan {
-    return { indexItems: [], finalize: () => {} };
+    return { indexItems: [], finalize: () => {}, scanOk: true };
+  }
+
+  // A full reindex builds a fresh index from the enumeration alone, so a
+  // failed scan would persist an empty index over existing rows. Abort: the
+  // safe path restores the original DB on throw, and the unsafe path skips
+  // writeMeta so the next sync retries the full rebuild.
+  private assertReindexScanOk(source: MemorySource, scanOk: boolean): void {
+    if (scanOk) {
+      return;
+    }
+    throw new Error(
+      `Memory reindex aborted: ${source} enumeration failed; keeping the existing index.`,
+    );
   }
 
   private snapshotReindexRetryState(): MemoryReindexRetryState {
@@ -496,7 +523,7 @@ export abstract class MemoryManagerSyncOps {
     needsFullSessionReindex?: boolean;
     targetSessionFiles?: string[];
     progress?: MemorySyncProgressState;
-  }): Promise<void> {
+  }): Promise<{ memoryScanOk: boolean; sessionsScanOk: boolean }> {
     const memoryPlan = params.shouldSyncMemory
       ? await this.syncMemoryFiles({
           needsFullReindex: params.needsFullReindex,
@@ -505,7 +532,7 @@ export abstract class MemoryManagerSyncOps {
         })
       : this.emptySourceSyncPlan();
     if (params.shouldSyncSessions) {
-      await this.syncSessionFiles({
+      const sessionPlan = await this.syncSessionFiles({
         needsFullReindex: params.needsFullSessionReindex ?? params.needsFullReindex,
         targetSessionFiles: params.targetSessionFiles,
         progress: params.progress,
@@ -513,9 +540,10 @@ export abstract class MemoryManagerSyncOps {
         prefixIndexItems: memoryPlan.indexItems,
       });
       await memoryPlan.finalize();
-      return;
+      return { memoryScanOk: memoryPlan.scanOk, sessionsScanOk: sessionPlan.scanOk };
     }
     await this.executeSourceSyncPlans([memoryPlan], params.progress);
+    return { memoryScanOk: memoryPlan.scanOk, sessionsScanOk: true };
   }
 
   protected hasIndexedChunks(): boolean {
@@ -1581,6 +1609,7 @@ export abstract class MemoryManagerSyncOps {
     this.sessionPendingTargets.clear();
     pending.push(...Array.from(await this.resolveSessionFilesForSyncTargets(pendingTargets)));
     let shouldSync = false;
+    let needsFullSessionEnumeration = false;
     for (const sessionFile of pending) {
       // Usage-counted session archives (`.jsonl.reset.<iso>` and
       // `.jsonl.deleted.<iso>`) are one-shot mutation events: the file is
@@ -1597,6 +1626,7 @@ export abstract class MemoryManagerSyncOps {
       ) {
         this.sessionsDirtyFiles.add(sessionFile);
         this.sessionsDirty = true;
+        needsFullSessionEnumeration = true;
         shouldSync = true;
         continue;
       }
@@ -1624,7 +1654,26 @@ export abstract class MemoryManagerSyncOps {
       shouldSync = true;
     }
     if (shouldSync) {
-      void this.sync({ reason: "session-delta" }).catch((err: unknown) => {
+      // The dirty set already names every live transcript this sync must index,
+      // so pass it through and skip the sessions-dir enumeration (expensive on
+      // networked filesystems). Archive/reset events force a full enumeration
+      // because their old live transcript row must be pruned authoritatively.
+      const dirtySessionFiles = Array.from(this.sessionsDirtyFiles);
+      const dirtySetNeedsFullEnumeration = dirtySessionFiles.some((file) => {
+        const baseName = path.basename(file);
+        return (
+          isSessionArchiveArtifactName(baseName) &&
+          isUsageCountedSessionTranscriptFileName(baseName)
+        );
+      });
+      const reconcileDue =
+        needsFullSessionEnumeration ||
+        dirtySetNeedsFullEnumeration ||
+        Date.now() - this.lastSessionPruneReconcileAt >= SESSION_PRUNE_RECONCILE_INTERVAL_MS;
+      const syncParams = reconcileDue
+        ? { reason: "session-delta" }
+        : { reason: "session-delta", sessionFiles: dirtySessionFiles };
+      void this.sync(syncParams).catch((err: unknown) => {
         log.warn(`memory sync failed (session-delta): ${String(err)}`);
       });
     }
@@ -1983,11 +2032,15 @@ export abstract class MemoryManagerSyncOps {
         ? this.db.prepare(`DELETE FROM ${FTS_TABLE} WHERE path = ? AND source = ?`)
         : null;
 
-    const files = await listMemoryFiles(
+    // Track whether the enumeration actually read every root, so a transient
+    // failure cannot surface an empty/partial listing that the stale-row prune
+    // below would treat as mass deletion.
+    const scan = await scanMemoryFiles(
       this.workspaceDir,
       this.settings.extraPaths,
       this.settings.multimodal,
     );
+    const files = scan.files;
     const fileEntries = (
       await runWithConcurrency(
         files.map(
@@ -2020,6 +2073,15 @@ export abstract class MemoryManagerSyncOps {
     }
 
     const deleteStaleRows = async () => {
+      if (!scan.ok) {
+        // A failed enumeration is non-authoritative: pruning against it would
+        // delete index rows for files that still exist on disk. Keep the rows
+        // until the next successful scan reconciles.
+        log.warn(
+          `memory sync: skipping memory-file prune after a failed enumeration; retaining ${existingRows.length} indexed rows until the next successful scan`,
+        );
+        return;
+      }
       for (const stale of existingRows) {
         if (activePaths.has(stale.path)) {
           continue;
@@ -2058,7 +2120,7 @@ export abstract class MemoryManagerSyncOps {
         (entry): MemoryIndexWorkItem => ({ entry, source: "memory" }),
       );
       if (params.deferIndex) {
-        return { indexItems, finalize: deleteStaleRows };
+        return { indexItems, finalize: deleteStaleRows, scanOk: scan.ok };
       }
       await this.indexQueuedFiles(indexItems, params.progress);
     } else {
@@ -2086,7 +2148,7 @@ export abstract class MemoryManagerSyncOps {
     }
 
     await deleteStaleRows();
-    return this.emptySourceSyncPlan();
+    return { ...this.emptySourceSyncPlan(), scanOk: scan.ok };
   }
 
   private async syncSessionFiles(params: {
@@ -2120,6 +2182,13 @@ export abstract class MemoryManagerSyncOps {
     const corpusEntryByPath = new Map<string, SessionTranscriptCorpusEntry>(
       corpusEntries.map((entry) => [entry.sessionFile, entry]),
     );
+    // Indexing stays corpus-driven (active sessions + archive artifacts +
+    // dreaming/cron classification). Full enumerations additionally scan the
+    // sessions dir so a transient NFS failure cannot masquerade as an empty dir
+    // and drive the destructive stale-row prune below; only `scan.ok` gates it.
+    const scan = targetSessionFiles
+      ? { ok: true, files: Array.from(targetSessionFiles) }
+      : await scanSessionFilesForAgent(this.agentId);
     const files = targetSessionFiles
       ? Array.from(targetSessionFiles)
       : corpusEntries.map((entry) => entry.sessionFile);
@@ -2135,8 +2204,9 @@ export abstract class MemoryManagerSyncOps {
             source: "sessions",
           }).rows,
       sessionPathForFile,
+      scanOk: scan.ok,
     });
-    const { activePaths, existingRows, existingHashes, indexAll } = sessionPlan;
+    const { activePaths, existingRows, existingHashes, indexAll, pruneStaleRows } = sessionPlan;
     log.debug("memory sync: indexing session files", {
       files: files.length,
       indexAll,
@@ -2156,7 +2226,21 @@ export abstract class MemoryManagerSyncOps {
 
     const yieldAfterSessionFile = createSessionSyncYield(files.length);
     const deleteStaleRows = async () => {
-      if (activePaths === null) {
+      if (!pruneStaleRows || activePaths === null) {
+        // Skip the stale-row prune unless we hold an authoritative full
+        // enumeration. Targeted syncs (activePaths === null) only refresh the
+        // requested transcripts. A failed directory scan also lands here: it
+        // surfaces an empty listing for reasons unrelated to on-disk state
+        // (e.g. transient NFS EIO/ESTALE), so pruning would wipe the entire
+        // session index on one blip. Leave the index intact and let the next
+        // successful enumeration reconcile.
+        if (activePaths !== null && !scan.ok) {
+          log.warn(
+            `memory sync: skipping session prune after a failed directory scan; retaining ${
+              (existingRows ?? []).length
+            } indexed session rows until the next successful enumeration`,
+          );
+        }
         return;
       }
 
@@ -2183,6 +2267,9 @@ export abstract class MemoryManagerSyncOps {
           await yieldAfterStaleSessionRow();
         }
       }
+      // A completed authoritative prune is the reconciliation point targeted
+      // delta syncs rely on; record it so they keep skipping enumerations.
+      this.lastSessionPruneReconcileAt = Date.now();
     };
 
     if (params.deferIndex) {
@@ -2280,7 +2367,7 @@ export abstract class MemoryManagerSyncOps {
 
       await flushPendingIndexItems();
       await deleteStaleRows();
-      return this.emptySourceSyncPlan();
+      return { ...this.emptySourceSyncPlan(), scanOk: scan.ok };
     }
     if ((params.prefixIndexItems?.length ?? 0) > 0) {
       throw new Error("Memory session sync prefix requires deferred source-wide indexing.");
@@ -2351,7 +2438,7 @@ export abstract class MemoryManagerSyncOps {
     await runWithConcurrency(tasks, this.getIndexConcurrency());
 
     await deleteStaleRows();
-    return this.emptySourceSyncPlan();
+    return { ...this.emptySourceSyncPlan(), scanOk: scan.ok };
   }
 
   private createSyncProgress(
@@ -2531,8 +2618,11 @@ export abstract class MemoryManagerSyncOps {
         ((!hasTargetSessionFiles && params?.force) || needsFullReindex || this.dirty);
       const shouldSyncSessions = this.shouldSyncSessions(params, needsFullReindex);
 
+      // A sync whose enumeration failed indexed nothing for that source; keep
+      // its dirty state so the next eligible sync retries instead of treating
+      // the source as clean until something marks it dirty again.
       if (this.shouldDeferSourceWideBatch()) {
-        await this.executeSourceWideSync({
+        const outcome = await this.executeSourceWideSync({
           shouldSyncMemory,
           shouldSyncSessions,
           needsFullReindex,
@@ -2540,27 +2630,36 @@ export abstract class MemoryManagerSyncOps {
           targetSessionFiles: targetSessionFiles ? Array.from(targetSessionFiles) : undefined,
           progress: progress ?? undefined,
         });
-        if (shouldSyncMemory) {
+        if (shouldSyncMemory && outcome.memoryScanOk) {
           this.clearMemoryRetryState();
         }
         if (shouldSyncSessions) {
-          this.clearSessionRetryState();
+          if (outcome.sessionsScanOk) {
+            this.clearSessionRetryState();
+          }
         } else {
           this.refreshSessionDirtyFlag();
         }
       } else {
         if (shouldSyncMemory) {
-          await this.syncMemoryFiles({ needsFullReindex, progress: progress ?? undefined });
-          this.clearMemoryRetryState();
+          const memoryPlan = await this.syncMemoryFiles({
+            needsFullReindex,
+            progress: progress ?? undefined,
+          });
+          if (memoryPlan.scanOk) {
+            this.clearMemoryRetryState();
+          }
         }
 
         if (shouldSyncSessions) {
-          await this.syncSessionFiles({
+          const sessionPlan = await this.syncSessionFiles({
             needsFullReindex: needsFullSessionReindex,
             targetSessionFiles: targetSessionFiles ? Array.from(targetSessionFiles) : undefined,
             progress: progress ?? undefined,
           });
-          this.clearSessionRetryState();
+          if (sessionPlan.scanOk) {
+            this.clearSessionRetryState();
+          }
         } else {
           this.refreshSessionDirtyFlag();
         }
@@ -2723,12 +2822,16 @@ export abstract class MemoryManagerSyncOps {
       const shouldSyncSessions = shouldRetrySessionsOnFailure;
 
       if (this.shouldDeferSourceWideBatch()) {
-        await this.executeSourceWideSync({
+        const outcome = await this.executeSourceWideSync({
           shouldSyncMemory,
           shouldSyncSessions,
           needsFullReindex: true,
           progress: params.progress,
         });
+        // A failed enumeration must abort the reindex before the empty rebuild
+        // publishes, or the swap wipes the live index exactly like an unguarded prune.
+        this.assertReindexScanOk("memory", outcome.memoryScanOk);
+        this.assertReindexScanOk("sessions", outcome.sessionsScanOk);
         if (shouldSyncMemory) {
           this.clearMemoryRetryState();
         }
@@ -2739,12 +2842,20 @@ export abstract class MemoryManagerSyncOps {
         }
       } else {
         if (shouldSyncMemory) {
-          await this.syncMemoryFiles({ needsFullReindex: true, progress: params.progress });
+          const memoryPlan = await this.syncMemoryFiles({
+            needsFullReindex: true,
+            progress: params.progress,
+          });
+          this.assertReindexScanOk("memory", memoryPlan.scanOk);
           this.clearMemoryRetryState();
         }
 
         if (shouldSyncSessions) {
-          await this.syncSessionFiles({ needsFullReindex: true, progress: params.progress });
+          const sessionPlan = await this.syncSessionFiles({
+            needsFullReindex: true,
+            progress: params.progress,
+          });
+          this.assertReindexScanOk("sessions", sessionPlan.scanOk);
           this.clearSessionRetryState();
         } else {
           this.refreshSessionDirtyFlag();

--- a/extensions/memory-core/src/memory/manager-sync-yield.test.ts
+++ b/extensions/memory-core/src/memory/manager-sync-yield.test.ts
@@ -44,6 +44,7 @@ vi.mock("openclaw/plugin-sdk/memory-core-host-engine-qmd", () => {
       sessionFile: `/tmp/${target.sessionId}.jsonl`,
       sessionId: target.sessionId,
     }),
+    scanSessionFilesForAgent: vi.fn(async () => ({ ok: true, files: [] })),
     sessionPathForFile: (filePath: string) => `sessions/${basename(filePath)}`,
   };
 });

--- a/extensions/memory-core/src/memory/manager.reindex-recovery.test.ts
+++ b/extensions/memory-core/src/memory/manager.reindex-recovery.test.ts
@@ -110,7 +110,7 @@ describe("memory manager reindex recovery", () => {
       pendingBytes: 100,
       pendingMessages: 2,
     };
-    const emptySyncPlan = { indexItems: [], finalize: () => undefined };
+    const emptySyncPlan = { indexItems: [], finalize: () => undefined, scanOk: true };
 
     harness.dirty = true;
     harness.sessionsDirty = true;
@@ -149,7 +149,7 @@ describe("memory manager reindex recovery", () => {
       }),
     );
     const harness = memoryManager as unknown as ReindexHarness;
-    const emptySyncPlan = { indexItems: [], finalize: () => undefined };
+    const emptySyncPlan = { indexItems: [], finalize: () => undefined, scanOk: true };
 
     harness.syncMemoryFiles = async () => emptySyncPlan;
     harness.syncSessionFiles = async () => emptySyncPlan;
@@ -223,7 +223,7 @@ describe("memory manager reindex recovery", () => {
     await memoryManager.sync({ reason: "test", force: true });
 
     const harness = memoryManager as unknown as ReindexHarness;
-    const emptySyncPlan = { indexItems: [], finalize: () => undefined };
+    const emptySyncPlan = { indexItems: [], finalize: () => undefined, scanOk: true };
     const sessionSyncCalls: SyncSessionParams[] = [];
 
     harness.sessionsDirty = true;
@@ -323,7 +323,7 @@ describe("memory manager reindex recovery", () => {
     await memoryManager.sync({ reason: "test", force: true });
 
     const harness = memoryManager as unknown as ReindexHarness;
-    const emptySyncPlan = { indexItems: [], finalize: () => undefined };
+    const emptySyncPlan = { indexItems: [], finalize: () => undefined, scanOk: true };
     const memorySyncCalls: Array<{ needsFullReindex: boolean }> = [];
 
     harness.dirty = true;

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -5602,6 +5602,53 @@ describe("QmdMemoryManager", () => {
     }
   });
 
+  it("does not mark qmd clean when session export enumeration fails", async () => {
+    const sessionsDir = path.join(stateDir, "agents", agentId, "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    await fs.writeFile(
+      path.join(sessionsDir, "session-1.jsonl"),
+      '{"type":"message","message":{"role":"user","content":"hello"}}\n',
+      "utf-8",
+    );
+
+    const currentMemory = cfg.memory;
+    cfg = {
+      ...cfg,
+      memory: {
+        ...currentMemory,
+        qmd: {
+          ...currentMemory?.qmd,
+          sessions: { enabled: true },
+        },
+      },
+    } as OpenClawConfig;
+
+    const { manager } = await createManager();
+    const updateCallsBefore = spawnMock.mock.calls.filter(
+      (call: unknown[]) => (call[1] as string[])[0] === "update",
+    ).length;
+    const realReaddir = fs.readdir;
+    vi.spyOn(fs, "readdir").mockImplementation(async (...args: Parameters<typeof realReaddir>) => {
+      const [target] = args;
+      if (typeof target === "string" && path.resolve(target) === sessionsDir) {
+        throw Object.assign(new Error("nfs blip"), { code: "EIO" });
+      }
+      return await realReaddir(...args);
+    });
+
+    try {
+      await expect(manager.sync({ reason: "manual", force: true })).rejects.toThrow(
+        "QMD session export aborted: session enumeration failed",
+      );
+      const updateCallsAfter = spawnMock.mock.calls.filter(
+        (call: unknown[]) => (call[1] as string[])[0] === "update",
+      ).length;
+      expect(updateCallsAfter).toBe(updateCallsBefore);
+    } finally {
+      await manager.close();
+    }
+  });
+
   it("fails closed when sqlite index is busy during doc lookup or search", async () => {
     const cases = [
       {

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -30,6 +30,7 @@ import {
   resolveSessionIdentityForTranscriptFile,
   resolveCliSpawnInvocation,
   runCliCommand,
+  scanSessionFilesForAgent,
   type QmdQueryResult,
   type SessionFileEntry,
   type SessionTranscriptCorpusEntry,
@@ -2597,6 +2598,9 @@ export class QmdMemoryManager implements MemorySearchManager {
     await fs.mkdir(exportDir, { recursive: true });
     const exportRoot = await root(exportDir);
     const corpusEntries = await listSessionTranscriptCorpusEntriesForAgent(this.agentId);
+    // Corpus drives the export; the raw scan only supplies the ok-flag that
+    // gates the reconcile-delete below (a failed listing must not wipe exports).
+    const scan = await scanSessionFilesForAgent(this.agentId);
     const keep = new Set<string>();
     const tracked = new Set<string>();
     const artifactMappings: QmdSessionArtifactMapping[] = [];
@@ -2639,6 +2643,12 @@ export class QmdMemoryManager implements MemorySearchManager {
         target,
       });
       keep.add(target);
+    }
+    if (!scan.ok) {
+      // A failed listing is non-authoritative: reconciling against it would
+      // delete the whole exported corpus and force a full re-export on the
+      // next pass. Abort so runUpdate keeps dirty state and retries later.
+      throw new Error("QMD session export aborted: session enumeration failed");
     }
     const exported = await exportRoot.list(".").catch(() => []);
     for (const name of exported) {

--- a/package.json
+++ b/package.json
@@ -1964,7 +1964,7 @@
     "@mistralai/mistralai": "2.2.5",
     "@modelcontextprotocol/sdk": "1.29.0",
     "@mozilla/readability": "0.6.0",
-    "@openclaw/fs-safe": "0.3.0",
+    "@openclaw/fs-safe": "0.4.0",
     "@openclaw/proxyline": "0.3.3",
     "chalk": "5.6.2",
     "chokidar": "5.0.0",

--- a/packages/memory-host-sdk/src/engine-qmd.ts
+++ b/packages/memory-host-sdk/src/engine-qmd.ts
@@ -11,11 +11,13 @@ export {
   parseCanonicalSessionSyncTargetFromPath,
   resolveSessionIdentityForTranscriptFile,
   resolveSessionFileForSyncTarget,
+  scanSessionFilesForAgent,
   sessionPathForFile,
   type BuildSessionEntryOptions,
   type ResolvedMemorySessionSyncTarget,
   type ResolvedSessionTranscriptIdentity,
   type SessionFileEntry,
+  type SessionFilesScanResult,
   type SessionTranscriptClassification,
   type SessionTranscriptCorpusEntry,
 } from "./host/session-files.js";

--- a/packages/memory-host-sdk/src/engine-storage.ts
+++ b/packages/memory-host-sdk/src/engine-storage.ts
@@ -12,8 +12,10 @@ export {
   parseEmbedding,
   remapChunkLines,
   runWithConcurrency,
+  scanMemoryFiles,
   type MemoryChunk,
   type MemoryFileEntry,
+  type MemoryFilesScanResult,
 } from "./host/internal.js";
 export { readMemoryFile } from "./host/read-file.js";
 export { isTransientMemoryReadError, retryTransientMemoryRead } from "./host/read-retry.js";

--- a/packages/memory-host-sdk/src/host/internal.test.ts
+++ b/packages/memory-host-sdk/src/host/internal.test.ts
@@ -13,6 +13,7 @@ import {
   listMemoryFiles,
   normalizeExtraMemoryPaths,
   remapChunkLines,
+  scanMemoryFiles,
 } from "./internal.js";
 import {
   DEFAULT_MEMORY_MULTIMODAL_MAX_FILE_BYTES,
@@ -137,6 +138,96 @@ describe("memory host SDK package internals", () => {
       path.join("extra", "diagram.png"),
       path.join("extra", "note.md"),
     ]);
+  });
+
+  it("treats missing memory roots as an authoritative empty scan", async () => {
+    const tmpDir = getTmpDir();
+
+    const scan = await scanMemoryFiles(tmpDir, [path.join(tmpDir, "missing-extra")]);
+
+    // No memory dir, no root memory file, missing extra path: nothing exists,
+    // so destructive callers may safely prune orphaned rows.
+    expect(scan).toEqual({ ok: true, files: [] });
+  });
+
+  it("flags the scan when the workspace root cannot be read", async () => {
+    const tmpDir = getTmpDir();
+    const realReaddir = fs.readdir;
+    vi.spyOn(fs, "readdir").mockImplementation(async (...args: Parameters<typeof realReaddir>) => {
+      const [target] = args;
+      if (typeof target === "string" && path.resolve(target) === tmpDir) {
+        throw Object.assign(new Error("nfs blip"), { code: "EIO" });
+      }
+      return await realReaddir(...args);
+    });
+
+    const scan = await scanMemoryFiles(tmpDir);
+
+    // The root MEMORY.md lookup is part of the authoritative listing; a root
+    // read failure must not look like the file was deleted.
+    expect(scan).toEqual({ ok: false, files: [] });
+  });
+
+  it("flags the scan when the memory dir cannot be read", async () => {
+    const tmpDir = getTmpDir();
+    const memoryDir = path.join(tmpDir, "memory");
+    fsSync.mkdirSync(memoryDir, { recursive: true });
+    fsSync.writeFileSync(path.join(memoryDir, "note.md"), "# Note");
+    const realLstat = fs.lstat;
+    vi.spyOn(fs, "lstat").mockImplementation(async (...args: Parameters<typeof realLstat>) => {
+      const [target] = args;
+      if (typeof target === "string" && path.resolve(target) === memoryDir) {
+        throw Object.assign(new Error("nfs blip"), { code: "EIO" });
+      }
+      return await realLstat(...args);
+    });
+
+    const scan = await scanMemoryFiles(tmpDir);
+
+    // The listing is incomplete, not empty: destructive callers must not prune.
+    expect(scan.ok).toBe(false);
+    expect(scan.files).toEqual([]);
+  });
+
+  it("flags the scan when the memory dir readdir fails after a successful lstat", async () => {
+    // fs-safe walkDirectory swallows readdir errors and returns an empty walk,
+    // so the scan must probe the root read itself or a permission/NFS blip on
+    // readdir would masquerade as an authoritatively empty dir.
+    const tmpDir = getTmpDir();
+    const memoryDir = path.join(tmpDir, "memory");
+    fsSync.mkdirSync(memoryDir, { recursive: true });
+    fsSync.writeFileSync(path.join(memoryDir, "note.md"), "# Note");
+    const realReaddir = fs.readdir;
+    vi.spyOn(fs, "readdir").mockImplementation(async (...args: Parameters<typeof realReaddir>) => {
+      const [target] = args;
+      if (typeof target === "string" && path.resolve(target) === memoryDir) {
+        throw Object.assign(new Error("nfs blip"), { code: "EIO" });
+      }
+      return await realReaddir(...args);
+    });
+
+    const scan = await scanMemoryFiles(tmpDir);
+
+    expect(scan.ok).toBe(false);
+    expect(scan.files).toEqual([]);
+  });
+
+  it("flags the scan when an extra path cannot be read", async () => {
+    const tmpDir = getTmpDir();
+    const extraDir = path.join(tmpDir, "extra");
+    fsSync.mkdirSync(extraDir, { recursive: true });
+    const realLstat = fs.lstat;
+    vi.spyOn(fs, "lstat").mockImplementation(async (...args: Parameters<typeof realLstat>) => {
+      const [target] = args;
+      if (typeof target === "string" && path.resolve(target) === extraDir) {
+        throw Object.assign(new Error("nfs blip"), { code: "EACCES" });
+      }
+      return await realLstat(...args);
+    });
+
+    const scan = await scanMemoryFiles(tmpDir, [extraDir]);
+
+    expect(scan.ok).toBe(false);
   });
 
   it("allows top-level dreams path casing variants", () => {

--- a/packages/memory-host-sdk/src/host/internal.test.ts
+++ b/packages/memory-host-sdk/src/host/internal.test.ts
@@ -190,9 +190,9 @@ describe("memory host SDK package internals", () => {
   });
 
   it("flags the scan when the memory dir readdir fails after a successful lstat", async () => {
-    // fs-safe walkDirectory swallows readdir errors and returns an empty walk,
-    // so the scan must probe the root read itself or a permission/NFS blip on
-    // readdir would masquerade as an authoritatively empty dir.
+    // fs-safe 0.4.0 surfaces a failed readdir via walkDirectory's failedDirs;
+    // the scan must flag it so a permission/NFS blip on readdir does not
+    // masquerade as an authoritatively empty dir.
     const tmpDir = getTmpDir();
     const memoryDir = path.join(tmpDir, "memory");
     fsSync.mkdirSync(memoryDir, { recursive: true });

--- a/packages/memory-host-sdk/src/host/internal.ts
+++ b/packages/memory-host-sdk/src/host/internal.ts
@@ -127,12 +127,15 @@ function shouldDescendMemoryEntry(
   return entry.kind === "directory" && entry.name !== ".openclaw-repair";
 }
 
+// Returns false when fs-safe reported a failed readdir (root or any subtree)
+// in `failedDirs`: the listing is then incomplete and destructive callers must
+// not treat unseen files as deleted.
 async function collectMemoryFilesFromDir(
   dir: string,
   files: string[],
   multimodal?: MemoryMultimodalSettings,
   shouldSkipPath?: (absPath: string) => boolean,
-): Promise<void> {
+): Promise<boolean> {
   const scan = await walkDirectory(dir, {
     symlinks: "skip",
     descend: (entry) => shouldDescendMemoryEntry(entry, shouldSkipPath),
@@ -142,14 +145,14 @@ async function collectMemoryFilesFromDir(
       isAllowedMemoryFilePath(entry.path, multimodal),
   });
   files.push(...scan.entries.map((entry) => entry.path));
+  return scan.failedDirs.length === 0;
 }
 
 // Result of enumerating memory files. `ok` is false when a listing root (the
-// workspace memory dir, an extra path, or the root memory file stat) failed
-// for a non-missing reason; destructive callers (stale-row pruning) must then
-// skip rather than treat unseen files as deleted. Failures in subtrees below
-// the probed roots stay invisible (fs-safe walkDirectory swallows them); the
-// flag guards the whole-index wipe hazard, not per-file drift.
+// workspace memory dir, an extra path, or the root memory file stat) failed for
+// a non-missing reason, or when fs-safe walkDirectory reported a failed readdir
+// at any depth (failedDirs). Destructive callers (stale-row pruning) must then
+// skip rather than treat unseen files as deleted.
 export type MemoryFilesScanResult = { ok: boolean; files: string[] };
 
 export async function scanMemoryFiles(
@@ -196,11 +199,15 @@ export async function scanMemoryFiles(
   try {
     const dirStat = await fs.lstat(memoryDir);
     if (!dirStat.isSymbolicLink() && dirStat.isDirectory()) {
-      // fs-safe walkDirectory swallows readdir errors, even at the root, so
-      // probe the root read explicitly: a transient failure must flag the
-      // scan instead of reading as an empty dir and triggering mass pruning.
-      await fs.readdir(memoryDir);
-      await collectMemoryFilesFromDir(memoryDir, result, multimodal, shouldSkipWorkspaceMemoryPath);
+      const scanOk = await collectMemoryFilesFromDir(
+        memoryDir,
+        result,
+        multimodal,
+        shouldSkipWorkspaceMemoryPath,
+      );
+      if (!scanOk) {
+        ok = false;
+      }
     }
   } catch (err) {
     if (!isFileMissingError(err)) {
@@ -220,15 +227,15 @@ export async function scanMemoryFiles(
           continue;
         }
         if (stat.isDirectory()) {
-          // Same root-read probe as the memory dir: walkDirectory cannot
-          // report a failed readdir.
-          await fs.readdir(inputPath);
-          await collectMemoryFilesFromDir(
+          const scanOk = await collectMemoryFilesFromDir(
             inputPath,
             result,
             multimodal,
             shouldSkipWorkspaceMemoryPath,
           );
+          if (!scanOk) {
+            ok = false;
+          }
           continue;
         }
         if (stat.isFile() && isAllowedMemoryFilePath(inputPath, multimodal)) {

--- a/packages/memory-host-sdk/src/host/internal.ts
+++ b/packages/memory-host-sdk/src/host/internal.ts
@@ -26,10 +26,7 @@ import {
   estimateStringChars,
   runTasksWithConcurrency,
 } from "./openclaw-runtime-io.js";
-import {
-  resolveCanonicalRootMemoryFile,
-  shouldSkipRootMemoryAuxiliaryPath,
-} from "./openclaw-runtime-memory.js";
+import { shouldSkipRootMemoryAuxiliaryPath } from "./openclaw-runtime-memory.js";
 import { retryTransientMemoryRead } from "./read-retry.js";
 import { normalizeStringEntries, uniqueStrings } from "./string-utils.js";
 
@@ -147,12 +144,21 @@ async function collectMemoryFilesFromDir(
   files.push(...scan.entries.map((entry) => entry.path));
 }
 
-export async function listMemoryFiles(
+// Result of enumerating memory files. `ok` is false when a listing root (the
+// workspace memory dir, an extra path, or the root memory file stat) failed
+// for a non-missing reason; destructive callers (stale-row pruning) must then
+// skip rather than treat unseen files as deleted. Failures in subtrees below
+// the probed roots stay invisible (fs-safe walkDirectory swallows them); the
+// flag guards the whole-index wipe hazard, not per-file drift.
+export type MemoryFilesScanResult = { ok: boolean; files: string[] };
+
+export async function scanMemoryFiles(
   workspaceDir: string,
   extraPaths?: string[],
   multimodal?: MemoryMultimodalSettings,
-): Promise<string[]> {
+): Promise<MemoryFilesScanResult> {
   const result: string[] = [];
+  let ok = true;
   const memoryDir = path.join(workspaceDir, "memory");
 
   const shouldSkipWorkspaceMemoryPath = (absPath: string): boolean =>
@@ -168,19 +174,39 @@ export async function listMemoryFiles(
         return;
       }
       result.push(absPath);
-    } catch {}
+    } catch {
+      ok = false;
+    }
   };
 
-  const memoryFile = await resolveCanonicalRootMemoryFile(workspaceDir);
-  if (memoryFile) {
-    await addMarkdownFile(memoryFile);
+  try {
+    const entries = await fs.readdir(workspaceDir, { withFileTypes: true });
+    const memoryEntry = entries.find(
+      (entry) =>
+        entry.name === CANONICAL_ROOT_MEMORY_FILENAME && entry.isFile() && !entry.isSymbolicLink(),
+    );
+    if (memoryEntry) {
+      await addMarkdownFile(path.join(workspaceDir, memoryEntry.name));
+    }
+  } catch (err) {
+    if (!isFileMissingError(err)) {
+      ok = false;
+    }
   }
   try {
     const dirStat = await fs.lstat(memoryDir);
     if (!dirStat.isSymbolicLink() && dirStat.isDirectory()) {
+      // fs-safe walkDirectory swallows readdir errors, even at the root, so
+      // probe the root read explicitly: a transient failure must flag the
+      // scan instead of reading as an empty dir and triggering mass pruning.
+      await fs.readdir(memoryDir);
       await collectMemoryFilesFromDir(memoryDir, result, multimodal, shouldSkipWorkspaceMemoryPath);
     }
-  } catch {}
+  } catch (err) {
+    if (!isFileMissingError(err)) {
+      ok = false;
+    }
+  }
 
   const normalizedExtraPaths = normalizeExtraMemoryPaths(workspaceDir, extraPaths);
   if (normalizedExtraPaths.length > 0) {
@@ -194,6 +220,9 @@ export async function listMemoryFiles(
           continue;
         }
         if (stat.isDirectory()) {
+          // Same root-read probe as the memory dir: walkDirectory cannot
+          // report a failed readdir.
+          await fs.readdir(inputPath);
           await collectMemoryFilesFromDir(
             inputPath,
             result,
@@ -205,11 +234,15 @@ export async function listMemoryFiles(
         if (stat.isFile() && isAllowedMemoryFilePath(inputPath, multimodal)) {
           result.push(inputPath);
         }
-      } catch {}
+      } catch (err) {
+        if (!isFileMissingError(err)) {
+          ok = false;
+        }
+      }
     }
   }
   if (result.length <= 1) {
-    return result;
+    return { ok, files: result };
   }
   const seen = new Set<string>();
   const deduped: string[] = [];
@@ -224,7 +257,15 @@ export async function listMemoryFiles(
     seen.add(key);
     deduped.push(entry);
   }
-  return deduped;
+  return { ok, files: deduped };
+}
+
+export async function listMemoryFiles(
+  workspaceDir: string,
+  extraPaths?: string[],
+  multimodal?: MemoryMultimodalSettings,
+): Promise<string[]> {
+  return (await scanMemoryFiles(workspaceDir, extraPaths, multimodal)).files;
 }
 
 export async function buildFileEntry(

--- a/packages/memory-host-sdk/src/host/session-files.test.ts
+++ b/packages/memory-host-sdk/src/host/session-files.test.ts
@@ -1,8 +1,9 @@
 // Memory Host SDK tests cover session files behavior.
 import fsSync from "node:fs";
+import fsPromises from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { clearConfigCache, clearRuntimeConfigSnapshot } from "./openclaw-runtime-session.js";
 import {
   buildSessionEntry,
@@ -12,6 +13,7 @@ import {
   parseCanonicalSessionSyncTargetFromPath,
   resolveSessionIdentityForTranscriptFile,
   resolveSessionFileForSyncTarget,
+  scanSessionFilesForAgent,
   sessionPathForFile,
   type SessionFileEntry,
 } from "./session-files.js";
@@ -97,6 +99,66 @@ describe("listSessionFilesForAgent", () => {
     expect(files.map((filePath) => path.basename(filePath)).toSorted()).toEqual(
       included.toSorted(),
     );
+  });
+});
+
+describe("scanSessionFilesForAgent", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("reports ok with the listing for a populated directory", async () => {
+    const sessionsDir = path.join(tmpDir, "agents", "main", "sessions");
+    fsSync.mkdirSync(sessionsDir, { recursive: true });
+    fsSync.writeFileSync(path.join(sessionsDir, "a.jsonl"), "");
+
+    const scan = await scanSessionFilesForAgent("main");
+
+    expect(scan.ok).toBe(true);
+    expect(scan.files.map((filePath) => path.basename(filePath))).toEqual(["a.jsonl"]);
+  });
+
+  it("reports ok with an empty listing when the directory exists but holds no sessions", async () => {
+    fsSync.mkdirSync(path.join(tmpDir, "agents", "main", "sessions"), { recursive: true });
+
+    const scan = await scanSessionFilesForAgent("main");
+
+    // An authoritatively empty directory is still a successful scan, so callers
+    // may safely prune orphaned index rows.
+    expect(scan).toEqual({ ok: true, files: [] });
+  });
+
+  it("reports not-ok with an empty listing when the scan fails", async () => {
+    const sessionsDir = path.join(tmpDir, "agents", "main", "sessions");
+    fsSync.mkdirSync(sessionsDir, { recursive: true });
+    fsSync.writeFileSync(path.join(sessionsDir, "a.jsonl"), "");
+    const transient = Object.assign(new Error("nfs blip"), { code: "EIO" });
+    vi.spyOn(fsPromises, "readdir").mockRejectedValueOnce(transient);
+
+    const scan = await scanSessionFilesForAgent("main");
+
+    // A failed scan must not be mistaken for an empty directory: ok=false lets
+    // destructive callers skip pruning rather than wiping the index.
+    expect(scan).toEqual({ ok: false, files: [] });
+  });
+
+  it("treats an absent sessions directory as authoritatively empty when the agent dir exists", async () => {
+    fsSync.mkdirSync(path.join(tmpDir, "agents", "main"), { recursive: true });
+
+    const scan = await scanSessionFilesForAgent("main");
+
+    // The sessions dir only exists once a transcript is written, so ENOENT with
+    // a present agent dir genuinely means "no sessions" (fresh agent) and must
+    // not block orphan pruning or warn on every full sync.
+    expect(scan).toEqual({ ok: true, files: [] });
+  });
+
+  it("treats an absent agent/session tree as authoritatively empty", async () => {
+    const scan = await scanSessionFilesForAgent("main");
+
+    // Fresh agents have no agent/session dirs until state is first written, so a
+    // missing tree is still an authoritative empty session listing.
+    expect(scan).toEqual({ ok: true, files: [] });
   });
 });
 

--- a/packages/memory-host-sdk/src/host/session-files.ts
+++ b/packages/memory-host-sdk/src/host/session-files.ts
@@ -1,8 +1,9 @@
 // Memory Host SDK module implements session files behavior.
 import fsSync from "node:fs";
+import fs from "node:fs/promises";
 import path from "node:path";
 import { normalizeAgentId } from "./config-utils.js";
-import { readRegularFile, statRegularFile } from "./fs-utils.js";
+import { isFileMissingError, readRegularFile, statRegularFile } from "./fs-utils.js";
 import { hashText } from "./hash.js";
 import { createSubsystemLogger, redactSensitiveText } from "./openclaw-runtime-io.js";
 import {
@@ -377,6 +378,40 @@ function classifySessionTranscriptFromSessionStore(absPath: string): {
   };
 }
 
+// Result of scanning an agent's sessions directory. `ok` distinguishes an
+// authoritative enumeration (the directory was read, or it does not exist —
+// agent/session dirs are only created when state is written) from a failed scan
+// (e.g. a transient NFS EIO/ESTALE or a permission error). Callers that prune
+// indexed state from this listing must only treat `ok: true` as authoritative:
+// a failed scan surfaces an empty `files` array but must not be read as "no
+// sessions exist", or one blip would wipe the session index.
+export type SessionFilesScanResult = { ok: boolean; files: string[] };
+
+export async function scanSessionFilesForAgent(agentId: string): Promise<SessionFilesScanResult> {
+  const dir = resolveSessionTranscriptsDirForAgent(agentId);
+  try {
+    const entries = await fs.readdir(dir, { withFileTypes: true });
+    const files = entries
+      .filter((entry) => entry.isFile())
+      .map((entry) => entry.name)
+      .filter((name) => isUsageCountedSessionTranscriptFileName(name))
+      .map((name) => path.join(dir, name));
+    return { ok: true, files };
+  } catch (err) {
+    // A missing sessions path is authoritative: fresh agents have no agent or
+    // sessions dir until state is first written, so ENOENT means no transcripts.
+    if (isFileMissingError(err)) {
+      return { ok: true, files: [] };
+    }
+    // Anything else (transient NFS error, permission) is non-authoritative
+    // for destructive callers; surface empty but flag not-ok.
+    return { ok: false, files: [] };
+  }
+}
+
+// Corpus-backed listing stays the canonical enumerator (active sessions +
+// archive artifacts + dreaming/cron classification). `scanSessionFilesForAgent`
+// above only feeds the destructive-prune ok-gate, not this list.
 export async function listSessionFilesForAgent(agentId: string): Promise<string[]> {
   return (await listSessionTranscriptCorpusEntriesForAgent(agentId)).map(
     (entry) => entry.sessionFile,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,8 +83,8 @@ importers:
         specifier: 0.6.0
         version: 0.6.0
       '@openclaw/fs-safe':
-        specifier: 0.3.0
-        version: 0.3.0
+        specifier: 0.4.0
+        version: 0.4.0
       '@openclaw/proxyline':
         specifier: 0.3.3
         version: 0.3.3(undici@8.5.0)
@@ -2368,16 +2368,8 @@ packages:
     resolution: {integrity: sha512-fT1qHVGAag4IEkrupZ6lRRbNCs1vS9P01KB/sG8zKgvUztbYtFBtQpjSITNwooDZ83tpsPzP0mRNs1/KVszCRA==}
     engines: {node: '>= 20.12.0'}
 
-  '@clack/core@1.4.1':
-    resolution: {integrity: sha512-FILJa1gGKEFTGZAJE9RpVhrjKz3c3h4ar60dSv6cGuDqufQ84YEIS3GAGvZiN+H6yaLbbvTFNejjCC4tXpZEuw==}
-    engines: {node: '>= 20.12.0'}
-
   '@clack/prompts@1.4.0':
     resolution: {integrity: sha512-S0My7XPGIgpRWMDG8uRqalbgT+a6FmCUdOW+HaIOVVpUPHOb7RrpvjTjiODadKp06fsrVDJZlIzc6yCTp4AnxA==}
-    engines: {node: '>= 20.12.0'}
-
-  '@clack/prompts@1.5.1':
-    resolution: {integrity: sha512-zccHj2z2oCCO4yrDiRSlFOxWerGqRiysP7a5jPK6uoI9URKAquwY42Dd/iUP8JWHxEzdRe4TlbvZCo8z1/mhrw==}
     engines: {node: '>= 20.12.0'}
 
   '@clawdbot/lobster@2026.5.22':
@@ -3190,6 +3182,10 @@ packages:
   '@openclaw/fs-safe@0.3.0':
     resolution: {integrity: sha512-uIBE441CIt1kIURoP9qRGKZ8LkGyfD9ZzeESjwAd29ZPWtghws/5GR3Pjb67jKdcJHP1I6roNXcvnhzAU7lHlA==}
     engines: {node: '>=20.11'}
+
+  '@openclaw/fs-safe@0.4.0':
+    resolution: {integrity: sha512-UxHKy+W2Wc5y7ARLdSZuIzutNCuhFpZpKlpX4iodycBadYLR30c6yuv9AhTpJ+Sq0x1NoXsZJcfwRncfQNT48Q==}
+    engines: {node: '>=22'}
 
   '@openclaw/proxyline@0.3.3':
     resolution: {integrity: sha512-sftHnW69NHQqLjCxBTvQ8f/eQl+peZ5pHCBQtuTWBbeuYRHZ0/GXVTmw/O/YKsShMbqPWhJB0UYtPPdvCUSS8w==}
@@ -4547,40 +4543,47 @@ packages:
     resolution: {integrity: sha512-9/tnj1fXeXIONgr+5FGwr3bkqd4jaORdr3X9/k++rzHW+UIzvgIeXrJKv43403gtuKp0BoxdzsFxe2qsAQhhkw==}
     cpu: [arm64]
     os: [darwin]
+    deprecated: This package has been replaced by @agentclientprotocol/codex-acp. Please migrate to continue receiving updates.
     hasBin: true
 
   '@zed-industries/codex-acp-darwin-x64@0.15.0':
     resolution: {integrity: sha512-2cmflnVYM5yzvNu4ldff6OsfLzQThFToPszCT3t7jytWuG28V+W1cUEGsvFJGNkGC1Wo29Z4w5LZ3wyfOkvPxg==}
     cpu: [x64]
     os: [darwin]
+    deprecated: This package has been replaced by @agentclientprotocol/codex-acp. Please migrate to continue receiving updates.
     hasBin: true
 
   '@zed-industries/codex-acp-linux-arm64@0.15.0':
     resolution: {integrity: sha512-ioCXCiZMd4v7Eqyed9Iz4xcPKsZbSH157wOitsWQKxUiX43c1Ti5fykZcrh9cNSLOgiGmI3V2nbYp0aTf66grQ==}
     cpu: [arm64]
     os: [linux]
+    deprecated: This package has been replaced by @agentclientprotocol/codex-acp. Please migrate to continue receiving updates.
     hasBin: true
 
   '@zed-industries/codex-acp-linux-x64@0.15.0':
     resolution: {integrity: sha512-WtqI8KGX9z7XvdkazumYraoDwpip5lFBRtFXoIwYCSBoDZdOqQsfNQndIfTDttfQ1BdZYKczDnrfbRaiIFU9UA==}
     cpu: [x64]
     os: [linux]
+    deprecated: This package has been replaced by @agentclientprotocol/codex-acp. Please migrate to continue receiving updates.
     hasBin: true
 
   '@zed-industries/codex-acp-win32-arm64@0.15.0':
     resolution: {integrity: sha512-L+OFIPOzAuxsImlq8E227MZxgujMLMEJSqiR9QjZq8fiIFCKh/HnxmvyXvjWaHbJdb1pZ09WKe3MNwV9ln/+GQ==}
     cpu: [arm64]
     os: [win32]
+    deprecated: This package has been replaced by @agentclientprotocol/codex-acp. Please migrate to continue receiving updates.
     hasBin: true
 
   '@zed-industries/codex-acp-win32-x64@0.15.0':
     resolution: {integrity: sha512-LDnADpCg1Rzbkyxs4hMaOvRwNa68KLp8CoNVom8ZE/sChSvcDrj/RCoMsZWrARJGWs7EQ9zYeLoeVk5VcVQoPQ==}
     cpu: [x64]
     os: [win32]
+    deprecated: This package has been replaced by @agentclientprotocol/codex-acp. Please migrate to continue receiving updates.
     hasBin: true
 
   '@zed-industries/codex-acp@0.15.0':
     resolution: {integrity: sha512-eAv7sGBeiYrYkOulF729nrM51szS7WIhBtugRj5wWq6csRKZUhAZfoUZlF8xUWdHPtOIzd/eT6MNG6gMHu6z0w==}
+    deprecated: This package has been replaced by @agentclientprotocol/codex-acp. Please migrate to continue receiving updates.
     hasBin: true
 
   abort-controller@3.0.0:
@@ -7530,6 +7533,10 @@ packages:
     resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
+  undici@8.3.0:
+    resolution: {integrity: sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q==}
+    engines: {node: '>=22.19.0'}
+
   undici@8.5.0:
     resolution: {integrity: sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==}
     engines: {node: '>=22.19.0'}
@@ -8518,21 +8525,9 @@ snapshots:
       fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
 
-  '@clack/core@1.4.1':
-    dependencies:
-      fast-wrap-ansi: 0.2.2
-      sisteransi: 1.0.5
-
   '@clack/prompts@1.4.0':
     dependencies:
       '@clack/core': 1.3.1
-      fast-string-width: 3.0.2
-      fast-wrap-ansi: 0.2.2
-      sisteransi: 1.0.5
-
-  '@clack/prompts@1.5.1':
-    dependencies:
-      '@clack/core': 1.4.1
       fast-string-width: 3.0.2
       fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
@@ -9280,6 +9275,15 @@ snapshots:
     optionalDependencies:
       jszip: 3.10.1
       tar: 7.5.16
+
+  '@openclaw/fs-safe@0.4.0':
+    optionalDependencies:
+      jszip: 3.10.1
+      tar: 7.5.16
+
+  '@openclaw/proxyline@0.3.3(undici@8.3.0)':
+    dependencies:
+      undici: 8.3.0
 
   '@openclaw/proxyline@0.3.3(undici@8.5.0)':
     dependencies:
@@ -12961,7 +12965,7 @@ snapshots:
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
       '@mozilla/readability': 0.6.0
       '@openclaw/fs-safe': 0.3.0
-      '@openclaw/proxyline': 0.3.3(undici@8.5.0)
+      '@openclaw/proxyline': 0.3.3(undici@8.3.0)
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
       chokidar: 5.0.0
@@ -12999,7 +13003,7 @@ snapshots:
       tslog: 4.10.2
       typebox: 1.1.39
       typescript: 6.0.3
-      undici: 8.5.0
+      undici: 8.3.0
       web-push: 3.6.7
       web-tree-sitter: 0.26.9
       ws: 8.21.0
@@ -14136,6 +14140,8 @@ snapshots:
   undici-types@7.24.6: {}
 
   undici@7.28.0: {}
+
+  undici@8.3.0: {}
 
   undici@8.5.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,7 +8,6 @@ minimumReleaseAge: 2880
 
 minimumReleaseAgeExclude:
   - "@openclaw/crabline@0.1.0"
-  - "@openclaw/fs-safe@0.3.0"
   - "@openclaw/proxyline@0.3.3"
   - "acpx"
   - "tokenjuice"

--- a/src/plugin-sdk/memory-core-host-engine-storage.ts
+++ b/src/plugin-sdk/memory-core-host-engine-storage.ts
@@ -34,6 +34,7 @@ export {
   requireNodeSqlite,
   resolveMemoryBackendConfig,
   runWithConcurrency,
+  scanMemoryFiles,
   statRegularFile,
 } from "../../packages/memory-host-sdk/src/engine-storage.js";
 
@@ -66,6 +67,7 @@ export type MemoryEmbeddingProbeResult = {
 export type {
   MemoryChunk,
   MemoryFileEntry,
+  MemoryFilesScanResult,
   MemoryProviderStatus,
   MemoryReadResult,
   MemorySearchManager,


### PR DESCRIPTION
## Summary

A full memory sync treats source enumerations as the source of truth for **destructive** maintenance: stale-row pruning of the session and memory-file indexes (`files` + `chunks` + vectors + FTS), full reindex rebuilds, and exported-session reconciliation. These enumerations swallowed filesystem errors and returned an empty listing, so a single transient scan failure (NFS `EIO`/`ESTALE`, permission blip) was indistinguishable from an empty directory and wiped the corresponding index — followed by an expensive full re-read/re-embed after the next successful scan. The failed-scan prune test in this PR fails without the guard (the indexed row gets deleted), confirming the hazard is live.

### Sessions

- `packages/memory-host-sdk`: add `scanSessionFilesForAgent(agentId): { ok, files }`. `ok: true` means the directory was actually read or authoritatively does not exist (see below); `ok: false` means the scan failed. `listSessionFilesForAgent` delegates to it and is unchanged for its non-destructive callers.
- `resolveMemorySessionSyncPlan` takes a required `scanOk` and returns `pruneStaleRows`, true only for a full enumeration that authoritatively read the directory.
- `syncSessionFiles` gates the stale-row prune on `pruneStaleRows`. A failed scan skips the prune (with a warning) and leaves the index intact for the next successful enumeration.
- A missing sessions dir is authoritative-empty only when the parent agent dir exists: fresh agents (the dir appears on first transcript write) prune orphans without log noise, while an unreachable state tree (e.g. unmounted volume) counts as a failed scan.
- `MemorySourceSyncPlan` carries `scanOk`; `runSync` no longer clears `dirty`/`sessionsDirty`/`sessionsDirtyFiles` after a failed scan, so the next eligible sync retries instead of reporting a clean sync that indexed nothing.
- The memory-file sibling gets the same guard: new `scanMemoryFiles(): { ok, files }` (exported via `engine-storage` and the plugin SDK barrel) with explicit root `readdir` probes — fs-safe `walkDirectory` swallows readdir errors even at the walk root, so an lstat-only check would still report `ok` on the exact failure class this PR targets. `syncMemoryFiles` skips its stale-row prune on a failed enumeration.
- Full reindexes abort (`assertReindexScanOk`) instead of swapping in an empty index built from a failed scan; the safe path restores the original DB on throw, the unsafe path skips `writeMeta` so the next sync retries the rebuild.
- `exportSessions` skips its reconcile-delete pass on a failed listing so one blip cannot delete the exported session-markdown corpus.
- Renamed the local CLI diagnostics in `cli.runtime.ts` (`scanMemoryFiles` → `diagnoseMemoryFiles`, `scanSessionFiles` → `diagnoseSessionFiles`) to avoid colliding with the new SDK export surfaced through the same barrel.

### Why skip on *failed*, not on *empty*

Deletions/resets archive to usage-counted `.deleted.`/`.reset.` artifacts that still appear in the listing, and `disk-budget` can physically remove the last archive — so an **authoritatively empty** directory with a non-empty index is legitimately reachable. In that case we must still prune, or deleted-session content would linger in search forever. Skipping only on a *failed* scan prevents the wipe without introducing persistent orphan rows.

### Known residual gaps (follow-ups)

- Subtree readdir failures below the probed roots remain invisible (`@openclaw/fs-safe` `walkDirectory` reports no errors); blast radius is the affected subtree, not the whole index. A clean fix needs an additive fs-safe API (e.g. `WalkDirectoryResult.failedDirCount`), which would also remove the root `readdir` probes.
- `resolveCanonicalRootMemoryFile` swallows workspace-root readdir errors; bounded to the single root memory file.

## Verification

Rebased on `origin/main` (`e3a6da0f51`). The rebase dropped the previously included `manager-sync-ops.startup-catchup.test.ts` assertion fix — it landed on `main` independently and the commit was skipped as already applied.

- `pnpm test extensions/memory-core` — **905/905 passing** (66 files), including the new `manager-sync-ops.prune-guard.test.ts`, `manager-sync-ops.targeted-delta.test.ts`, `manager-session-sync-state.test.ts` matrix, and `main`'s atomic-reindex suites added since the original base.
- `pnpm test packages/memory-host-sdk/src/host/session-files.test.ts packages/memory-host-sdk/src/host/internal.test.ts` — **31/31 passing** (scan ok / authoritatively-empty / absent-dir-with-parent / unreachable-tree / failed readdir-after-lstat / failed extra path; `listSessionFilesForAgent` and `listMemoryFiles` unchanged on failure).
- `pnpm tsgo:core`, `pnpm tsgo:extensions`, `pnpm tsgo:test:packages`, `pnpm tsgo:test:extensions` — clean.
- Reindex abort re-verified against `main`'s new swap machinery (`865fdab075`, "preserve live SQLite index during swaps"): `runMemoryAtomicReindex` publishes via `swapMemoryIndexFiles` only after `build()` resolves; `assertReindexScanOk` throws inside `build()` before any dirty-flag clearing, so the temp DB is closed and removed, the original DB handle and FTS/vector state are restored, and dirty state is retained for retry.
- Hazard proof: running this PR's failed-scan prune test without the guard deletes the indexed session row (`expected ['sessions/main/thread.jsonl'] to deeply equal []`).

## Notes

- #91081 (session-listing cache perf PR, still open) is complementary: it reduces READDIR load further; this PR makes the destructive consumers stop trusting failed listings. Integration note for whichever lands second: the listing cache must carry the `{ ok, files }` scan result and must never serve a failed scan as authoritative, or it reintroduces the wipe hazard this PR closes.
