### PR TITLE
fix(media-understanding): skip image understanding when primary model supports vision, regardless of imageModel config (fixes #91084)

### DIFF
--- a/src/media-understanding/runner.ts
+++ b/src/media-understanding/runner.ts
@@ -714,20 +714,6 @@ function resolveImageModelFromAgentDefaults(params: {
   return entries;
 }
 
-function hasExplicitImageUnderstandingConfig(params: {
-  cfg: OpenClawConfig;
-  config?: MediaUnderstandingConfig;
-  agentId?: string;
-}): boolean {
-  return (
-    (params.config?.models?.length ?? 0) > 0 ||
-    resolveImageModelFromAgentDefaults({
-      cfg: params.cfg,
-      agentId: params.agentId,
-    }).length > 0
-  );
-}
-
 async function resolveAutoEntries(params: {
   cfg: OpenClawConfig;
   agentId?: string;
@@ -1036,16 +1022,16 @@ export async function runCapability(params: {
 
   // Skip image understanding when the primary model supports vision natively.
   // The image will be injected directly into the model context instead.
+  // Per docs, agents.defaults.imageModel is only used when the primary model
+  // can't accept images. However, explicit tools.media.image.models still
+  // forces image understanding as an intentional user override.
   const activeProvider = params.activeModel?.provider?.trim();
+  const hasExplicitMediaModels = (config?.models?.length ?? 0) > 0;
   if (
     capability === "image" &&
     activeProvider &&
     !isMinimaxVlmProvider(activeProvider) &&
-    !hasExplicitImageUnderstandingConfig({
-      cfg,
-      config,
-      agentId: params.agentId,
-    })
+    !hasExplicitMediaModels
   ) {
     const { findModelInCatalog, loadModelCatalog, modelSupportsVision } =
       await loadModelCatalogApi();

--- a/src/media-understanding/runner.vision-skip.test.ts
+++ b/src/media-understanding/runner.vision-skip.test.ts
@@ -199,6 +199,8 @@ describe("runCapability image skip", () => {
           config: {
             models: [{ provider: "openrouter", model: "google/gemini-2.5-flash" }],
           },
+          // Explicit config.models overrides native vision skip — image understanding
+          // still runs even when the active model is vision-capable.
           activeModel: { provider: "openai", model: "gpt-4.1" },
         });
 
@@ -214,7 +216,55 @@ describe("runCapability image skip", () => {
     );
   });
 
-  it("lets per-request image prompts override entry prompts", async () => {
+  it("skips image understanding for vision-capable model even when agents.defaults.imageModel is configured", async () => {
+    await withMediaFixture(
+      {
+        filePrefix: "openclaw-image-defaults-imagemodel",
+        extension: "png",
+        mediaType: "image/png",
+        fileContents: Buffer.from("image"),
+      },
+      async ({ ctx, media, cache }) => {
+        const cfg = {
+          agents: {
+            defaults: {
+              imageModel: {
+                primary: "google/gemini-2.5-flash",
+              },
+            },
+          },
+        } as unknown as OpenClawConfig;
+
+        const result = await runCapability({
+          capability: "image",
+          cfg,
+          ctx,
+          attachments: cache,
+          media,
+          agentDir: "/tmp",
+          providerRegistry: new Map([
+            [
+              "openrouter",
+              {
+                id: "openrouter",
+                capabilities: ["image"],
+                describeImage: async (req) => ({ text: "should not run", model: req.model }),
+              },
+            ],
+          ]),
+          // gpt-4.1 is in the mock catalog with input: ["text", "image"],
+          // so the native vision skip should apply even though imageModel is configured.
+          activeModel: { provider: "openai", model: "gpt-4.1" },
+        });
+
+        // agents.defaults.imageModel should NOT block native vision skip;
+        // per docs it is only used when the primary model can't accept images.
+        expect(result.decision.outcome).toBe("skipped");
+      },
+    );
+  });
+
+  it("lets per-request image prompts override entry prompts for non-vision model", async () => {
     await withMediaFixture(
       {
         filePrefix: "openclaw-image-request-prompt",
@@ -256,7 +306,8 @@ describe("runCapability image skip", () => {
               },
             ],
           },
-          activeModel: { provider: "openai", model: "gpt-4.1" },
+          // Not in the mock vision catalog — image understanding runs
+          activeModel: { provider: "openai", model: "gpt-3.5-turbo" },
         });
 
         expect(result.decision.outcome).toBe("success");
@@ -285,7 +336,7 @@ describe("runCapability image skip", () => {
     });
   });
 
-  it("runs providerless configured imageModel fallbacks on the unique configured provider", async () => {
+  it("runs providerless configured imageModel fallbacks for non-vision active model", async () => {
     await withMediaFixture(
       {
         filePrefix: "openclaw-image-providerless-fallbacks",
@@ -343,7 +394,8 @@ describe("runCapability image skip", () => {
               } satisfies MediaUnderstandingProvider,
             ],
           ]),
-          activeModel: { provider: "openai", model: "gpt-4.1" },
+          // Not in the mock vision catalog — image understanding runs
+          activeModel: { provider: "openai", model: "gpt-3.5-turbo" },
         });
 
         expect(result.decision.outcome).toBe("success");


### PR DESCRIPTION
## Summary

Fix the vision-skip guard in `runCapability` so `agents.defaults.imageModel` no longer bypasses native vision skip, while preserving explicit `tools.media.image.models` as an intentional user override.

**Changes**: 2 files, +31 −19 lines

## Root Cause

The vision-skip guard checked `!hasExplicitImageUnderstandingConfig(...)` before allowing native vision skip. That function returned `true` whenever `agents.defaults.imageModel` was configured, even when the primary model natively supported vision. This contradicted `docs/concepts/models.md`, which states `agents.defaults.imageModel` is "used only when the primary model can't accept images."

However, `hasExplicitImageUnderstandingConfig` also returned `true` when `tools.media.image.models` was configured — and that path should be preserved as an intentional user override.

**Invariant violated**: when the primary model supports vision, `agents.defaults.imageModel` should not force image understanding, but `tools.media.image.models` should.

**Code path**: `runCapability` → vision-skip guard → `!hasExplicitImageUnderstandingConfig(...)` → both `config.models` and `resolveImageModelFromAgentDefaults` blocked the skip.

**Sibling audit**: no other module contains a similar vision-skip decision.

**Why this fix**: instead of removing the entire guard, the fix narrows it to only check `(config?.models?.length ?? 0) > 0` — preserving explicit media model overrides while removing `agents.defaults.imageModel` from the skip blocker. Dead `hasExplicitImageUnderstandingConfig` is removed since its only remaining caller was the guard.

## Verification

```
pnpm test src/media-understanding/runner.vision-skip.test.ts  # 16 passed (+1 new)
pnpm test src/media-understanding/runner.entries.guards.test.ts  # 3 passed
```

## Real behavior proof

**Behavior or issue addressed**: Narrowed the vision-skip guard to only check `config?.models?.length` (explicit `tools.media.image.models`) instead of the removed `hasExplicitImageUnderstandingConfig` function which also checked `agents.defaults.imageModel`. `agents.defaults.imageModel` no longer blocks native vision skip, matching docs, while `tools.media.image.models` still forces image understanding as an intentional override.

**Real environment tested**: Ubuntu 20.04 x86_64, Linux 4.19.112, Node v22.22.0, pnpm 11.2.2, OpenClaw 2026.6.2 @ 08ae0e6d29

**Exact steps or command run after this patch**:

```
pnpm build && pnpm exec oxlint src/media-understanding/runner.ts && pnpm test src/media-understanding/runner.vision-skip.test.ts src/media-understanding/runner.entries.guards.test.ts && pnpm openclaw --version
```

**Evidence after fix**:

Build and version check:

```
$ pnpm openclaw --version
OpenClaw 2026.6.2 (46af0a7)
```

Vision-skip regression suite — 16/16 pass including the new test for `agents.defaults.imageModel` + vision-capable primary model:

```
$ pnpm test src/media-understanding/runner.vision-skip.test.ts
 RUN  v4.1.7 /home/0668001395/openclawProject1
 Test Files  1 passed (1)
      Tests  16 passed (16)
```

Entry guard regression suite — 3/3 pass:

```
$ pnpm test src/media-understanding/runner.entries.guards.test.ts
 RUN  v4.1.7 /home/0668001395/openclawProject1
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

Source-level change — the narrowed guard at `src/media-understanding/runner.ts:1023–1032`:

```diff
+  const hasExplicitMediaModels = (config?.models?.length ?? 0) > 0;
   if (
     capability === "image" &&
     activeProvider &&
     !isMinimaxVlmProvider(activeProvider) &&
-    !hasExplicitImageUnderstandingConfig({
-      cfg,
-      config,
-      agentId: params.agentId,
-    })
+    !hasExplicitMediaModels
   )
```

New test "skips image understanding for vision-capable model even when agents.defaults.imageModel is configured" verifies the exact reported bug scenario. Restored test "uses explicit media image models instead of native vision skip" protects the explicit `config.models` override path.

```json
{
  "behaviorAddressed": "agents.defaults.imageModel no longer blocks native vision skip when the primary model supports vision, while explicit tools.media.image.models still forces image understanding as an intentional override",
  "assertions": [
    { "path": "src/media-understanding/runner.vision-skip.test.ts", "behavior": "16 tests: explicit models override skip (restored), imageModel defaults don't block skip (new), text-only fallback coverage (existing)" },
    { "path": "src/media-understanding/runner.entries.guards.test.ts", "behavior": "entry resolution guards unchanged (3 tests)" }
  ],
  "observedResult": "pnpm build exited 0, oxlint 0 warnings, pnpm test 19/19 passed, pnpm openclaw --version produces 2026.6.2",
  "testSummary": "2 test files, 19 tests passed (16 vision-skip + 3 entries-guards)"
}
```

**Observed result after fix**: `pnpm build` exits 0, `pnpm exec oxlint` reports 0 warnings, 19/19 tests pass, `pnpm openclaw --version` shows 2026.6.2.

**What was not tested**: End-to-end gateway behavior with real MiniMax provider (requires API key); real Feishu/Discord channel image delivery with `agents.defaults.imageModel` configured.

## Review Findings Addressed

- [P1] **Preserve explicit image model configs before skipping** — addressed: the guard now only checks `config?.models?.length`, not `agents.defaults.imageModel`. Explicit `tools.media.image.models` still forces image understanding.
- [P1] **Add regression coverage for `agents.defaults.imageModel` configured with a vision-capable active primary model** — addressed: new test "skips image understanding for vision-capable model even when agents.defaults.imageModel is configured"
- [P1] **Add redacted real behavior proof** — addressed: terminal output above from `pnpm openclaw --version` and `pnpm test`

## Regression Test Plan

```
pnpm test src/media-understanding/runner.vision-skip.test.ts      # primary coverage (16 tests)
pnpm test src/media-understanding/runner.entries.guards.test.ts   # entry guards (3 tests)
pnpm test src/media-understanding/runner.auto-audio.test.ts       # auto audio
pnpm test src/media-understanding/defaults.test.ts                # defaults
```

## Merge Risk

Low. The change narrows the vision-skip guard to only check `config?.models?.length` instead of the broader `hasExplicitImageUnderstandingConfig`. Explicit `tools.media.image.models` overrides are preserved and tested. The `agents.defaults.imageModel` fallback path in `resolveAutoEntries` (line ~741) is untouched — it still resolves image models when the primary model is not vision-capable. MiniMax VLM special-casing (`isMinimaxVlmProvider`) is preserved.
