### PR TITLE
fix(test): add missing reasoning field to overflow compaction harness mock defaults

### DIFF
--- a/src/agents/embedded-agent-runner/run.overflow-compaction.harness.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.harness.ts
@@ -126,6 +126,7 @@ export const mockedResolveModelAsync = vi.fn(
       provider: "anthropic",
       contextWindow: 200000,
       api: "messages",
+      reasoning: false,
     },
     error: null,
     authStorage: {
@@ -332,6 +333,7 @@ export function resetRunOverflowCompactionHarnessMocks(): void {
       provider: "anthropic",
       contextWindow: 200000,
       api: "messages",
+      reasoning: false,
     },
     error: null,
     authStorage: {


### PR DESCRIPTION
## Summary

Fix tsgo type error in `run.overflow-compaction.loop.test.ts` by adding the missing `reasoning` field to `mockedResolveModelAsync` default return values in the harness file.

**Changes**: 1 file, +2 lines

## Root Cause

The `Model` interface (`packages/llm-core/src/types.ts:580`) includes `reasoning: boolean`. The overflow compaction harness defines `mockedResolveModelAsync` with `vi.fn()`, and TypeScript infers the return type from the default mock value. Since the default model object was missing `reasoning`, the inferred type did not include it — causing TS2353 when individual tests pass `reasoning: true`.

- **Invariant violated**: mock defaults should be assignable to the real return type (`Model`), which requires `reasoning: boolean`
- **Code path**: `vi.fn()` type inference → default return value → `model` object without `reasoning` → incompatible with `Model` interface
- **Sibling audit**: the `Model` interface in `packages/llm-core/src/types.ts` already has `reasoning: boolean` at line 580; no other changes needed — this is purely a mock fixture gap

## Verification

```
pnpm test src/agents/embedded-agent-runner/run.overflow-compaction.loop.test.ts
// 25 passed

npx tsc --noEmit -p test/tsconfig/tsconfig.core.test.json
// 0 overflow-compaction errors
```

## Real behavior proof

**Behavior or issue addressed**: The `mockedResolveModelAsync` default return values in the overflow compaction harness were missing the `reasoning` field required by the `Model` interface, causing tsgo (TypeScript type checking) to fail with TS2353 when individual tests pass `reasoning: true`. Adding `reasoning: false` to the mock defaults fixes the type inference.

**Real environment tested**: Ubuntu 20.04 x86_64, Linux 4.19.112, Node v22.22.0, pnpm 11.2.2, OpenClaw 2026.6.2 @ 08ae0e6d29

**Exact steps or command run after this patch**:

```
pnpm build && npx tsc --noEmit -p test/tsconfig/tsconfig.core.test.json && pnpm test src/agents/embedded-agent-runner/run.overflow-compaction.loop.test.ts && pnpm openclaw --version
```

**Evidence after fix**:

tsgo type check passes clean (0 overflow-compaction errors):

```
$ npx tsc --noEmit -p test/tsconfig/tsconfig.core.test.json
# exit 0, no errors
```

Overflow compaction regression suite — all 25 tests pass:

```
$ pnpm test src/agents/embedded-agent-runner/run.overflow-compaction.loop.test.ts
 RUN  v4.1.7 /home/0668001395/openclawProject1
 Test Files  1 passed (1)
      Tests  25 passed (25)
```

Build and CLI verify the environment:

```
$ pnpm openclaw --version
OpenClaw 2026.6.2 (08ae0e6)
```

Source-level change — `run.overflow-compaction.harness.ts` lines 105-111 and 310-316, `reasoning: false` added to model defaults:

```diff
   model: {
     id: "test-model",
     provider: "anthropic",
     contextWindow: 200000,
     api: "messages",
+    reasoning: false,
   },
```

```json
{
  "behaviorAddressed": "Mock default return values in overflow compaction harness now include reasoning: false, matching the Model interface requirement (reasoning: boolean) and fixing tsgo type inference",
  "assertions": [
    { "path": "src/agents/embedded-agent-runner/run.overflow-compaction.loop.test.ts", "behavior": "all 25 overflow compaction loop tests pass, including the test that passes reasoning: true" }
  ],
  "observedResult": "npx tsc --noEmit exit 0, pnpm build exit 0, pnpm test 25/25 passed",
  "testSummary": "1 test file, 25 tests passed"
}
```

**Observed result after fix**: `npx tsc --noEmit` exits 0 (no type errors), `pnpm build` succeeds, 25/25 overflow compaction tests pass.

**What was not tested**: Full CI pipeline (`tsgo:core:test && tsgo:extensions:test`) on macOS; the tsgo check was run locally only. No impact on runtime behavior — this is a pure type-level mock fixture fix.

## Review Findings Addressed

- Self-review: confirmed `Model` interface at `packages/llm-core/src/types.ts:580` has `reasoning: boolean` — the mock should match
- Sibling audit: no other mock fixtures in the harness define model objects without `reasoning`

## Regression Test Plan

```
pnpm test src/agents/embedded-agent-runner/run.overflow-compaction.loop.test.ts
npx tsc --noEmit -p test/tsconfig/tsconfig.core.test.json
```

## Merge Risk

Minimal. The change adds `reasoning: false` to mock default values only — no runtime code paths are affected. The `Model` interface already requires `reasoning: boolean`; this just makes the mocks honest about the interface contract. 1 file, 2 lines.
