### PR TITLE
fix(test): type overflow resolver mock

### DIFF
--- a/src/agents/embedded-agent-runner/run.overflow-compaction.harness.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.harness.ts
@@ -50,6 +50,20 @@ type MockCompactionResult =
       result?: undefined;
     };
 
+type MockResolvedModel = {
+  model: {
+    id: string;
+    provider: string;
+    contextWindow: number;
+    api: string;
+    reasoning?: boolean;
+  };
+  error: null;
+  authStorage: Record<string, unknown>;
+  modelRegistry: Record<string, unknown>;
+};
+type MockResolveModelAsync = (..._args: unknown[]) => Promise<MockResolvedModel>;
+
 export const mockedGlobalHookRunner = {
   hasHooks: vi.fn((_hookName: string) => false),
   runBeforeAgentReply: vi.fn(
@@ -102,7 +116,7 @@ export const mockedResolveContextEngineOwnerPluginId = vi.fn(() => undefined);
 export const mockedBuildAgentRuntimePlan = vi.fn(() => ({}));
 export const mockedRunPostCompactionSideEffects = vi.fn(async () => {});
 export const mockedEnsureRuntimePluginsLoaded = vi.fn<(params?: unknown) => void>();
-export const mockedResolveModelAsync = vi.fn(async () => ({
+export const mockedResolveModelAsync = vi.fn<MockResolveModelAsync>(async () => ({
   model: {
     id: "test-model",
     provider: "anthropic",


### PR DESCRIPTION
## Summary

- Fixes the current `check-test-types` failure on `main` by typing the shared overflow compaction `mockedResolveModelAsync` test double with the partial resolved-model shape the harness actually uses.
- Keeps the harness permissive for existing partial `authStorage` and `modelRegistry` test doubles while allowing model overrides to include `reasoning`.

## Verification

- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo`
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run.overflow-compaction.loop.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

## Notes

The CI failure is unrelated to PRs #90780 and #90782. Both were failing the same `check-test-types` error from `src/agents/embedded-agent-runner/run.overflow-compaction.loop.test.ts`; current `origin/main` still had the stale mock type at the time this branch was created.
