### PR TITLE
refactor(matrix): store crypto sidecars in sqlite

### DIFF
--- a/extensions/matrix/doctor-contract-api.test.ts
+++ b/extensions/matrix/doctor-contract-api.test.ts
@@ -15,6 +15,11 @@ import type { PluginDoctorStateMigrationContext } from "openclaw/plugin-sdk/runt
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { stateMigrations } from "./doctor-contract-api.js";
 import { SqliteBackedMatrixSyncStore } from "./src/matrix/client/file-sync-store.js";
+import {
+  readMatrixIdbSnapshotJson,
+  readMatrixLegacyCryptoMigrationState,
+  readMatrixRecoveryKeyState,
+} from "./src/matrix/crypto-state-store.js";
 import { installMatrixTestRuntime } from "./src/test-runtime.js";
 
 function createContext(): PluginDoctorStateMigrationContext {
@@ -32,6 +37,14 @@ function createMigrationParams(stateDir: string) {
     oauthDir: path.join(stateDir, "oauth"),
     context: createContext(),
   };
+}
+
+function migrationById(id: string) {
+  const migration = stateMigrations.find((entry) => entry.id === id);
+  if (!migration) {
+    throw new Error(`missing migration ${id}`);
+  }
+  return migration;
 }
 
 describe("matrix doctor contract state migrations", () => {
@@ -79,7 +92,7 @@ describe("matrix doctor contract state migrations", () => {
       }),
     );
 
-    const migration = stateMigrations[0];
+    const migration = migrationById("matrix-sync-cache-json-to-plugin-state");
     await expect(migration.detectLegacyState(createMigrationParams(stateDir))).resolves.toEqual({
       preview: [`Matrix sync cache JSON can migrate to SQLite: ${storageRootDir}`],
     });
@@ -113,12 +126,145 @@ describe("matrix doctor contract state migrations", () => {
       }),
     );
 
-    const migration = stateMigrations[0];
+    const migration = migrationById("matrix-sync-cache-json-to-plugin-state");
     await expect(migration.detectLegacyState(createMigrationParams(stateDir))).resolves.toBeNull();
     await expect(migration.migrateLegacyState(createMigrationParams(stateDir))).resolves.toEqual({
       changes: [],
       warnings: [],
     });
     expect(fs.existsSync(path.join(flatRoot, "bot-storage.json"))).toBe(true);
+  });
+
+  it("migrates Matrix recovery-key JSON to SQLite plugin state", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-matrix-doctor-"));
+    tempDirs.push(stateDir);
+    const storageRootDir = path.join(
+      stateDir,
+      "matrix",
+      "accounts",
+      "default",
+      "matrix.example.org__bot",
+      "token-hash",
+    );
+    fs.mkdirSync(storageRootDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(storageRootDir, "recovery-key.json"),
+      JSON.stringify({
+        version: 1,
+        createdAt: "2026-03-12T00:00:00.000Z",
+        keyId: "SSSS",
+        privateKeyBase64: Buffer.from([1, 2, 3, 4]).toString("base64"),
+      }),
+    );
+
+    const migration = migrationById("matrix-recovery-key-json-to-plugin-state");
+    await expect(migration.detectLegacyState(createMigrationParams(stateDir))).resolves.toEqual({
+      preview: [`Matrix recovery-key JSON can migrate to SQLite: ${storageRootDir}`],
+    });
+
+    await expect(migration.migrateLegacyState(createMigrationParams(stateDir))).resolves.toEqual({
+      changes: [
+        `Migrated Matrix recovery-key JSON to SQLite for ${storageRootDir}`,
+        `Archived Matrix recovery key legacy source -> ${path.join(storageRootDir, "recovery-key.json")}.migrated`,
+      ],
+      warnings: [],
+    });
+
+    expect(readMatrixRecoveryKeyState(storageRootDir)?.keyId).toBe("SSSS");
+    expect(fs.existsSync(path.join(storageRootDir, "recovery-key.json"))).toBe(false);
+  });
+
+  it("migrates Matrix IndexedDB snapshot JSON to SQLite plugin state", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-matrix-doctor-"));
+    tempDirs.push(stateDir);
+    const storageRootDir = path.join(
+      stateDir,
+      "matrix",
+      "accounts",
+      "default",
+      "matrix.example.org__bot",
+      "token-hash",
+    );
+    fs.mkdirSync(storageRootDir, { recursive: true });
+    const snapshot = [
+      {
+        name: "openclaw-matrix::matrix-sdk-crypto",
+        version: 1,
+        stores: [
+          {
+            name: "sessions",
+            keyPath: null,
+            autoIncrement: false,
+            indexes: [],
+            records: [{ key: "room-1", value: { session: "abc123" } }],
+          },
+        ],
+      },
+    ];
+    fs.writeFileSync(
+      path.join(storageRootDir, "crypto-idb-snapshot.json"),
+      JSON.stringify(snapshot),
+    );
+
+    const migration = migrationById("matrix-idb-snapshot-json-to-plugin-state");
+    await expect(migration.detectLegacyState(createMigrationParams(stateDir))).resolves.toEqual({
+      preview: [`Matrix IndexedDB snapshot JSON can migrate to SQLite: ${storageRootDir}`],
+    });
+
+    await expect(migration.migrateLegacyState(createMigrationParams(stateDir))).resolves.toEqual({
+      changes: [
+        `Migrated Matrix IndexedDB snapshot JSON to SQLite for ${storageRootDir}`,
+        `Archived Matrix IndexedDB snapshot legacy source -> ${path.join(storageRootDir, "crypto-idb-snapshot.json")}.migrated`,
+      ],
+      warnings: [],
+    });
+
+    expect(JSON.parse(readMatrixIdbSnapshotJson(storageRootDir) ?? "null")).toEqual(snapshot);
+    expect(fs.existsSync(path.join(storageRootDir, "crypto-idb-snapshot.json"))).toBe(false);
+  });
+
+  it("migrates Matrix legacy crypto migration JSON to SQLite plugin state", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-matrix-doctor-"));
+    tempDirs.push(stateDir);
+    const storageRootDir = path.join(
+      stateDir,
+      "matrix",
+      "accounts",
+      "default",
+      "matrix.example.org__bot",
+      "token-hash",
+    );
+    fs.mkdirSync(storageRootDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(storageRootDir, "legacy-crypto-migration.json"),
+      JSON.stringify({
+        version: 1,
+        source: "matrix-bot-sdk-rust",
+        accountId: "default",
+        deviceId: "DEVICE",
+        roomKeyCounts: { total: 2, backedUp: 2 },
+        backupVersion: "1",
+        decryptionKeyImported: true,
+        restoreStatus: "pending",
+        detectedAt: "2026-03-12T00:00:00.000Z",
+        lastError: null,
+      }),
+    );
+
+    const migration = migrationById("matrix-legacy-crypto-migration-json-to-plugin-state");
+    await expect(migration.detectLegacyState(createMigrationParams(stateDir))).resolves.toEqual({
+      preview: [`Matrix legacy crypto migration JSON can migrate to SQLite: ${storageRootDir}`],
+    });
+
+    await expect(migration.migrateLegacyState(createMigrationParams(stateDir))).resolves.toEqual({
+      changes: [
+        `Migrated Matrix legacy crypto migration JSON to SQLite for ${storageRootDir}`,
+        `Archived Matrix legacy crypto migration legacy source -> ${path.join(storageRootDir, "legacy-crypto-migration.json")}.migrated`,
+      ],
+      warnings: [],
+    });
+
+    expect(readMatrixLegacyCryptoMigrationState(storageRootDir)?.restoreStatus).toBe("pending");
+    expect(fs.existsSync(path.join(storageRootDir, "legacy-crypto-migration.json"))).toBe(false);
   });
 });

--- a/extensions/matrix/doctor-contract-api.ts
+++ b/extensions/matrix/doctor-contract-api.ts
@@ -10,6 +10,26 @@ import {
   writeMatrixSyncCacheStateToStore,
   type MatrixSyncCacheRecord,
 } from "./src/matrix/client/file-sync-store.js";
+import {
+  MATRIX_IDB_SNAPSHOT_FILENAME,
+  MATRIX_LEGACY_CRYPTO_MIGRATION_FILENAME,
+  MATRIX_RECOVERY_KEY_FILENAME,
+  hasMatrixIdbSnapshotStateInStore,
+  hasMatrixLegacyCryptoMigrationStateInStore,
+  hasMatrixRecoveryKeyStateInStore,
+  openMatrixIdbSnapshotStoreOptions,
+  openMatrixLegacyCryptoMigrationStoreOptions,
+  openMatrixRecoveryKeyStoreOptions,
+  readLegacyMatrixLegacyCryptoMigrationState,
+  readLegacyMatrixRecoveryKeyState,
+  writeMatrixIdbSnapshotJsonToStore,
+  writeMatrixLegacyCryptoMigrationStateToStore,
+  writeMatrixRecoveryKeyStateToStore,
+  type MatrixIdbSnapshotRecord,
+  type MatrixLegacyCryptoMigrationState,
+} from "./src/matrix/crypto-state-store.js";
+import { readLegacyMatrixIdbSnapshotState } from "./src/matrix/sdk/idb-persistence.js";
+import type { MatrixStoredRecoveryKey } from "./src/matrix/sdk/types.js";
 
 export { normalizeCompatibilityConfig, legacyConfigRules } from "./src/doctor-contract.js";
 
@@ -24,7 +44,10 @@ async function fileExists(filePath: string): Promise<boolean> {
   }
 }
 
-async function collectLegacySyncCacheRoots(stateDir: string): Promise<string[]> {
+async function collectLegacyMatrixStateRoots(
+  stateDir: string,
+  filename: string,
+): Promise<string[]> {
   const matrixRoot = path.join(stateDir, "matrix");
   const roots: string[] = [];
   async function visit(dir: string): Promise<void> {
@@ -36,7 +59,7 @@ async function collectLegacySyncCacheRoots(stateDir: string): Promise<string[]> 
     }
     for (const entry of entries) {
       const entryPath = path.join(dir, entry.name);
-      if (entry.isFile() && entry.name === MATRIX_SYNC_CACHE_FILENAME) {
+      if (entry.isFile() && entry.name === filename) {
         roots.push(dir);
         continue;
       }
@@ -47,6 +70,10 @@ async function collectLegacySyncCacheRoots(stateDir: string): Promise<string[]> 
   }
   await visit(matrixRoot);
   return roots.filter((root) => path.resolve(root) !== path.resolve(matrixRoot)).toSorted();
+}
+
+async function collectLegacySyncCacheRoots(stateDir: string): Promise<string[]> {
+  return collectLegacyMatrixStateRoots(stateDir, MATRIX_SYNC_CACHE_FILENAME);
 }
 
 async function archiveLegacySyncCache(params: {
@@ -67,6 +94,29 @@ async function archiveLegacySyncCache(params: {
     params.changes.push(`Archived Matrix sync cache legacy source -> ${archivedPath}`);
   } catch (err) {
     params.warnings.push(`Failed archiving Matrix sync cache legacy source: ${String(err)}`);
+  }
+}
+
+async function archiveLegacyMatrixStateFile(params: {
+  storageRootDir: string;
+  filename: string;
+  label: string;
+  changes: string[];
+  warnings: string[];
+}): Promise<void> {
+  const sourcePath = path.join(params.storageRootDir, params.filename);
+  const archivedPath = `${sourcePath}.migrated`;
+  if (await fileExists(archivedPath)) {
+    params.warnings.push(
+      `Left migrated ${params.label} in place because ${archivedPath} already exists`,
+    );
+    return;
+  }
+  try {
+    await fs.rename(sourcePath, archivedPath);
+    params.changes.push(`Archived ${params.label} legacy source -> ${archivedPath}`);
+  } catch (err) {
+    params.warnings.push(`Failed archiving ${params.label} legacy source: ${String(err)}`);
   }
 }
 
@@ -110,6 +160,183 @@ export const stateMigrations: PluginDoctorStateMigration[] = [
         });
         changes.push(`Migrated Matrix sync cache JSON to SQLite for ${storageRootDir}`);
         await archiveLegacySyncCache({ storageRootDir, changes, warnings });
+      }
+      return { changes, warnings };
+    },
+  },
+  {
+    id: "matrix-recovery-key-json-to-plugin-state",
+    label: "Matrix recovery key",
+    async detectLegacyState(params) {
+      const previews: string[] = [];
+      for (const storageRootDir of await collectLegacyMatrixStateRoots(
+        params.stateDir,
+        MATRIX_RECOVERY_KEY_FILENAME,
+      )) {
+        if (!readLegacyMatrixRecoveryKeyState(storageRootDir)) {
+          continue;
+        }
+        previews.push(`Matrix recovery-key JSON can migrate to SQLite: ${storageRootDir}`);
+      }
+      return previews.length > 0 ? { preview: previews } : null;
+    },
+    async migrateLegacyState(params) {
+      const changes: string[] = [];
+      const warnings: string[] = [];
+      for (const storageRootDir of await collectLegacyMatrixStateRoots(
+        params.stateDir,
+        MATRIX_RECOVERY_KEY_FILENAME,
+      )) {
+        const payload = readLegacyMatrixRecoveryKeyState(storageRootDir);
+        if (!payload) {
+          continue;
+        }
+        const store = params.context.openPluginStateKeyedStore<MatrixStoredRecoveryKey>(
+          openMatrixRecoveryKeyStoreOptions(storageRootDir),
+        );
+        if (await hasMatrixRecoveryKeyStateInStore({ store })) {
+          warnings.push(
+            `Skipped Matrix recovery-key import for ${storageRootDir} because SQLite already has recovery-key state`,
+          );
+          await archiveLegacyMatrixStateFile({
+            storageRootDir,
+            filename: MATRIX_RECOVERY_KEY_FILENAME,
+            label: "Matrix recovery key",
+            changes,
+            warnings,
+          });
+          continue;
+        }
+        await writeMatrixRecoveryKeyStateToStore({ payload, store });
+        changes.push(`Migrated Matrix recovery-key JSON to SQLite for ${storageRootDir}`);
+        await archiveLegacyMatrixStateFile({
+          storageRootDir,
+          filename: MATRIX_RECOVERY_KEY_FILENAME,
+          label: "Matrix recovery key",
+          changes,
+          warnings,
+        });
+      }
+      return { changes, warnings };
+    },
+  },
+  {
+    id: "matrix-idb-snapshot-json-to-plugin-state",
+    label: "Matrix IndexedDB snapshot",
+    async detectLegacyState(params) {
+      const previews: string[] = [];
+      for (const storageRootDir of await collectLegacyMatrixStateRoots(
+        params.stateDir,
+        MATRIX_IDB_SNAPSHOT_FILENAME,
+      )) {
+        const snapshot = await readLegacyMatrixIdbSnapshotState(storageRootDir);
+        if (!snapshot) {
+          continue;
+        }
+        previews.push(`Matrix IndexedDB snapshot JSON can migrate to SQLite: ${storageRootDir}`);
+      }
+      return previews.length > 0 ? { preview: previews } : null;
+    },
+    async migrateLegacyState(params) {
+      const changes: string[] = [];
+      const warnings: string[] = [];
+      for (const storageRootDir of await collectLegacyMatrixStateRoots(
+        params.stateDir,
+        MATRIX_IDB_SNAPSHOT_FILENAME,
+      )) {
+        const snapshot = await readLegacyMatrixIdbSnapshotState(storageRootDir);
+        if (!snapshot) {
+          continue;
+        }
+        const store = params.context.openPluginStateKeyedStore<MatrixIdbSnapshotRecord>(
+          openMatrixIdbSnapshotStoreOptions(storageRootDir),
+        );
+        if (await hasMatrixIdbSnapshotStateInStore({ store })) {
+          warnings.push(
+            `Skipped Matrix IndexedDB snapshot import for ${storageRootDir} because SQLite already has snapshot state`,
+          );
+          await archiveLegacyMatrixStateFile({
+            storageRootDir,
+            filename: MATRIX_IDB_SNAPSHOT_FILENAME,
+            label: "Matrix IndexedDB snapshot",
+            changes,
+            warnings,
+          });
+          continue;
+        }
+        await writeMatrixIdbSnapshotJsonToStore({
+          snapshotJson: JSON.stringify(snapshot),
+          databaseCount: snapshot.length,
+          store,
+        });
+        changes.push(`Migrated Matrix IndexedDB snapshot JSON to SQLite for ${storageRootDir}`);
+        await archiveLegacyMatrixStateFile({
+          storageRootDir,
+          filename: MATRIX_IDB_SNAPSHOT_FILENAME,
+          label: "Matrix IndexedDB snapshot",
+          changes,
+          warnings,
+        });
+      }
+      return { changes, warnings };
+    },
+  },
+  {
+    id: "matrix-legacy-crypto-migration-json-to-plugin-state",
+    label: "Matrix legacy crypto migration",
+    async detectLegacyState(params) {
+      const previews: string[] = [];
+      for (const storageRootDir of await collectLegacyMatrixStateRoots(
+        params.stateDir,
+        MATRIX_LEGACY_CRYPTO_MIGRATION_FILENAME,
+      )) {
+        if (!readLegacyMatrixLegacyCryptoMigrationState(storageRootDir)) {
+          continue;
+        }
+        previews.push(
+          `Matrix legacy crypto migration JSON can migrate to SQLite: ${storageRootDir}`,
+        );
+      }
+      return previews.length > 0 ? { preview: previews } : null;
+    },
+    async migrateLegacyState(params) {
+      const changes: string[] = [];
+      const warnings: string[] = [];
+      for (const storageRootDir of await collectLegacyMatrixStateRoots(
+        params.stateDir,
+        MATRIX_LEGACY_CRYPTO_MIGRATION_FILENAME,
+      )) {
+        const state = readLegacyMatrixLegacyCryptoMigrationState(storageRootDir);
+        if (!state) {
+          continue;
+        }
+        const store = params.context.openPluginStateKeyedStore<MatrixLegacyCryptoMigrationState>(
+          openMatrixLegacyCryptoMigrationStoreOptions(storageRootDir),
+        );
+        if (await hasMatrixLegacyCryptoMigrationStateInStore({ store })) {
+          warnings.push(
+            `Skipped Matrix legacy crypto migration import for ${storageRootDir} because SQLite already has migration state`,
+          );
+          await archiveLegacyMatrixStateFile({
+            storageRootDir,
+            filename: MATRIX_LEGACY_CRYPTO_MIGRATION_FILENAME,
+            label: "Matrix legacy crypto migration",
+            changes,
+            warnings,
+          });
+          continue;
+        }
+        await writeMatrixLegacyCryptoMigrationStateToStore({ state, store });
+        changes.push(
+          `Migrated Matrix legacy crypto migration JSON to SQLite for ${storageRootDir}`,
+        );
+        await archiveLegacyMatrixStateFile({
+          storageRootDir,
+          filename: MATRIX_LEGACY_CRYPTO_MIGRATION_FILENAME,
+          label: "Matrix legacy crypto migration",
+          changes,
+          warnings,
+        });
       }
       return { changes, warnings };
     },

--- a/extensions/matrix/src/doctor.test.ts
+++ b/extensions/matrix/src/doctor.test.ts
@@ -94,6 +94,8 @@ describe("matrix doctor", () => {
     });
     expect(previews[0]).toBe("- matrix warning");
     expect(previews[1]).toContain("/tmp/recovery-key.txt");
+    expect(previews[1]).toContain("Recovery key state: Matrix SQLite state");
+    expect(previews[1]).toContain("Migration state: Matrix SQLite state");
   });
 
   it("warns on stale custom Matrix plugin paths and cleans them", async () => {

--- a/extensions/matrix/src/doctor.ts
+++ b/extensions/matrix/src/doctor.ts
@@ -72,8 +72,8 @@ export function formatMatrixLegacyCryptoPreview(
       [
         `- Matrix encrypted-state migration is pending for account "${plan.accountId}".`,
         `- Legacy crypto store: ${plan.legacyCryptoPath}`,
-        `- New recovery key file: ${plan.recoveryKeyPath}`,
-        `- Migration state file: ${plan.statePath}`,
+        `- Recovery key state: Matrix SQLite state (imports ${plan.recoveryKeyPath} if present)`,
+        `- Migration state: Matrix SQLite state (imports ${plan.statePath} if present)`,
         '- Run "openclaw doctor --fix" to extract any saved backup key now. Backed-up room keys will restore automatically on next gateway start.',
       ].join("\n"),
     );

--- a/extensions/matrix/src/legacy-crypto.test.ts
+++ b/extensions/matrix/src/legacy-crypto.test.ts
@@ -2,8 +2,9 @@
 import fs from "node:fs";
 import path from "node:path";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { resetPluginStateStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { withTempHome } from "openclaw/plugin-sdk/test-env";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const legacyCryptoInspectorAvailability = vi.hoisted(() => ({
   available: true,
@@ -14,6 +15,10 @@ vi.mock("./legacy-crypto-inspector-availability.js", () => ({
 }));
 
 import { autoPrepareLegacyMatrixCrypto, detectLegacyMatrixCrypto } from "./legacy-crypto.js";
+import {
+  readMatrixLegacyCryptoMigrationState,
+  readMatrixRecoveryKeyState,
+} from "./matrix/crypto-state-store.js";
 import { resolveMatrixAccountStorageRoot } from "./storage-paths.js";
 import {
   MATRIX_DEFAULT_ACCESS_TOKEN,
@@ -27,6 +32,7 @@ import {
   writeFile,
   writeMatrixCredentials,
 } from "./test-helpers.js";
+import { installMatrixTestRuntime } from "./test-runtime.js";
 
 function createDefaultMatrixConfig(): OpenClawConfig {
   return {
@@ -84,8 +90,14 @@ function createOpsLegacyCryptoFixture(params: {
 }
 
 describe("matrix legacy encrypted-state migration", () => {
+  beforeEach(() => {
+    resetPluginStateStoreForTests();
+    installMatrixTestRuntime();
+  });
+
   afterEach(() => {
     legacyCryptoInspectorAvailability.available = true;
+    resetPluginStateStoreForTests();
   });
 
   it("extracts a saved backup key into the new recovery-key path", async () => {
@@ -113,12 +125,8 @@ describe("matrix legacy encrypted-state migration", () => {
       expect(result.migrated).toBe(true);
       expect(result.warnings).toStrictEqual([]);
 
-      const recovery = JSON.parse(
-        fs.readFileSync(path.join(rootDir, "recovery-key.json"), "utf8"),
-      ) as {
-        privateKeyBase64: string;
-      };
-      expect(recovery.privateKeyBase64).toBe("YWJjZA==");
+      expect(readMatrixRecoveryKeyState(rootDir)?.privateKeyBase64).toBe("YWJjZA==");
+      expect(fs.existsSync(path.join(rootDir, "recovery-key.json"))).toBe(false);
     });
   });
 
@@ -161,10 +169,9 @@ describe("matrix legacy encrypted-state migration", () => {
       expect(result.warnings).toContain(
         'Legacy Matrix encrypted state for account "default" cannot be fully converted automatically because the old rust crypto store does not expose all local room keys for export.',
       );
-      const state = JSON.parse(
-        fs.readFileSync(path.join(rootDir, "legacy-crypto-migration.json"), "utf8"),
-      ) as { restoreStatus: string };
-      expect(state.restoreStatus).toBe("manual-action-required");
+      expect(readMatrixLegacyCryptoMigrationState(rootDir)?.restoreStatus).toBe(
+        "manual-action-required",
+      );
     });
   });
 
@@ -201,7 +208,8 @@ describe("matrix legacy encrypted-state migration", () => {
       });
 
       expect(result.migrated).toBe(true);
-      expect(fs.existsSync(path.join(rootDir, "recovery-key.json"))).toBe(true);
+      expect(readMatrixRecoveryKeyState(rootDir)?.privateKeyBase64).toBe("b3Bz");
+      expect(fs.existsSync(path.join(rootDir, "recovery-key.json"))).toBe(false);
     });
   });
 

--- a/extensions/matrix/src/legacy-crypto.ts
+++ b/extensions/matrix/src/legacy-crypto.ts
@@ -3,14 +3,21 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import {
-  loadJsonFile,
-  writeJsonFileAtomically as writeJsonFileAtomicallyImpl,
-} from "openclaw/plugin-sdk/json-store";
+import { loadJsonFile } from "openclaw/plugin-sdk/json-store";
 import { resolveStateDir } from "openclaw/plugin-sdk/state-paths";
 import { resolveConfiguredMatrixAccountIds } from "./account-selection.js";
 import { isMatrixLegacyCryptoInspectorAvailable } from "./legacy-crypto-inspector-availability.js";
+import {
+  migrateLegacyMatrixLegacyCryptoMigrationFileToStore,
+  migrateLegacyMatrixRecoveryKeyFileToStore,
+  readMatrixLegacyCryptoMigrationState,
+  readMatrixRecoveryKeyState,
+  writeMatrixLegacyCryptoMigrationState,
+  writeMatrixRecoveryKeyState,
+  type MatrixLegacyCryptoMigrationState,
+} from "./matrix/crypto-state-store.js";
 import { formatMatrixErrorMessage } from "./matrix/errors.js";
+import type { MatrixStoredRecoveryKey } from "./matrix/sdk/types.js";
 import {
   resolveLegacyMatrixFlatStoreTarget,
   resolveMatrixMigrationAccountTarget,
@@ -30,22 +37,6 @@ type MatrixLegacyCryptoSummary = {
   roomKeyCounts: MatrixLegacyCryptoCounts | null;
   backupVersion: string | null;
   decryptionKeyBase64: string | null;
-};
-
-type MatrixLegacyCryptoMigrationState = {
-  version: 1;
-  source: "matrix-bot-sdk-rust";
-  accountId: string;
-  deviceId: string | null;
-  roomKeyCounts: MatrixLegacyCryptoCounts | null;
-  backupVersion: string | null;
-  decryptionKeyImported: boolean;
-  restoreStatus: "pending" | "completed" | "manual-action-required";
-  detectedAt: string;
-  restoredAt?: string;
-  importedCount?: number;
-  totalCount?: number;
-  lastError?: string | null;
 };
 
 type MatrixLegacyCryptoPlan = {
@@ -74,7 +65,6 @@ type MatrixLegacyCryptoPreparationResult = {
 
 type MatrixLegacyCryptoPrepareDeps = {
   inspectLegacyStore: MatrixLegacyCryptoInspector;
-  writeJsonFileAtomically: typeof writeJsonFileAtomicallyImpl;
 };
 
 type MatrixLegacyCryptoInspectorParams = {
@@ -100,18 +90,6 @@ type MatrixLegacyCryptoInspector = (
 
 type MatrixLegacyBotSdkMetadata = {
   deviceId: string | null;
-};
-
-type MatrixStoredRecoveryKey = {
-  version: 1;
-  createdAt: string;
-  keyId?: string | null;
-  encodedPrivateKey?: string;
-  privateKeyBase64: string;
-  keyInfo?: {
-    passphrase?: unknown;
-    name?: string;
-  };
 };
 
 async function loadMatrixLegacyCryptoInspector(): Promise<MatrixLegacyCryptoInspector> {
@@ -284,22 +262,6 @@ function resolveMatrixLegacyCryptoPlans(params: {
   return { plans, warnings };
 }
 
-function loadStoredRecoveryKey(filePath: string): MatrixStoredRecoveryKey | null {
-  return loadJsonFile<MatrixStoredRecoveryKey>(filePath) ?? null;
-}
-
-function loadLegacyCryptoMigrationState(filePath: string): MatrixLegacyCryptoMigrationState | null {
-  return loadJsonFile<MatrixLegacyCryptoMigrationState>(filePath) ?? null;
-}
-
-async function persistLegacyMigrationState(params: {
-  filePath: string;
-  state: MatrixLegacyCryptoMigrationState;
-  writeJsonFileAtomically: typeof writeJsonFileAtomicallyImpl;
-}): Promise<void> {
-  await params.writeJsonFileAtomically(params.filePath, params.state);
-}
-
 export function detectLegacyMatrixCrypto(params: {
   cfg: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
@@ -338,8 +300,6 @@ export async function autoPrepareLegacyMatrixCrypto(params: {
     "inspectorAvailable" in detection ? detection.inspectorAvailable : true;
   const warnings = [...detection.warnings];
   const changes: string[] = [];
-  const writeJsonFileAtomically =
-    params.deps?.writeJsonFileAtomically ?? writeJsonFileAtomicallyImpl;
   if (detection.plans.length === 0) {
     if (warnings.length > 0) {
       params.log?.warn?.(
@@ -395,7 +355,15 @@ export async function autoPrepareLegacyMatrixCrypto(params: {
   }
 
   for (const plan of detection.plans) {
-    const existingState = loadLegacyCryptoMigrationState(plan.statePath);
+    try {
+      migrateLegacyMatrixLegacyCryptoMigrationFileToStore(plan.rootDir);
+      migrateLegacyMatrixRecoveryKeyFileToStore(plan.rootDir);
+    } catch (err) {
+      warnings.push(
+        `Failed migrating Matrix crypto sidecar state for account "${plan.accountId}" (${plan.rootDir}): ${String(err)}`,
+      );
+    }
+    const existingState = readMatrixLegacyCryptoMigrationState(plan.rootDir);
     if (existingState?.version === 1) {
       continue;
     }
@@ -424,13 +392,13 @@ export async function autoPrepareLegacyMatrixCrypto(params: {
 
     let decryptionKeyImported = false;
     if (summary.decryptionKeyBase64) {
-      const existingRecoveryKey = loadStoredRecoveryKey(plan.recoveryKeyPath);
+      const existingRecoveryKey = readMatrixRecoveryKeyState(plan.rootDir);
       if (
         existingRecoveryKey?.privateKeyBase64 &&
         existingRecoveryKey.privateKeyBase64 !== summary.decryptionKeyBase64
       ) {
         warnings.push(
-          `Legacy Matrix backup key was found for account "${plan.accountId}", but ${plan.recoveryKeyPath} already contains a different recovery key. Leaving the existing file unchanged.`,
+          `Legacy Matrix backup key was found for account "${plan.accountId}", but Matrix SQLite state already contains a different recovery key. Leaving the existing state unchanged.`,
         );
       } else if (!existingRecoveryKey?.privateKeyBase64) {
         const payload: MatrixStoredRecoveryKey = {
@@ -440,14 +408,17 @@ export async function autoPrepareLegacyMatrixCrypto(params: {
           privateKeyBase64: summary.decryptionKeyBase64,
         };
         try {
-          await writeJsonFileAtomically(plan.recoveryKeyPath, payload);
+          writeMatrixRecoveryKeyState({
+            storageRootDir: plan.rootDir,
+            payload,
+          });
           changes.push(
-            `Imported Matrix legacy backup key for account "${plan.accountId}": ${plan.recoveryKeyPath}`,
+            `Imported Matrix legacy backup key for account "${plan.accountId}" into SQLite`,
           );
           decryptionKeyImported = true;
         } catch (err) {
           warnings.push(
-            `Failed writing Matrix recovery key for account "${plan.accountId}" (${plan.recoveryKeyPath}): ${String(err)}`,
+            `Failed writing Matrix recovery key for account "${plan.accountId}" to SQLite: ${String(err)}`,
           );
         }
       } else {
@@ -480,7 +451,7 @@ export async function autoPrepareLegacyMatrixCrypto(params: {
     if (
       summary.decryptionKeyBase64 &&
       !decryptionKeyImported &&
-      !loadStoredRecoveryKey(plan.recoveryKeyPath)
+      !readMatrixRecoveryKeyState(plan.rootDir)
     ) {
       continue;
     }
@@ -498,17 +469,16 @@ export async function autoPrepareLegacyMatrixCrypto(params: {
       lastError: null,
     };
     try {
-      await persistLegacyMigrationState({
-        filePath: plan.statePath,
+      writeMatrixLegacyCryptoMigrationState({
+        storageRootDir: plan.rootDir,
         state,
-        writeJsonFileAtomically,
       });
       changes.push(
-        `Prepared Matrix legacy encrypted-state migration for account "${plan.accountId}": ${plan.statePath}`,
+        `Prepared Matrix legacy encrypted-state migration for account "${plan.accountId}" in SQLite`,
       );
     } catch (err) {
       warnings.push(
-        `Failed writing Matrix legacy encrypted-state migration record for account "${plan.accountId}" (${plan.statePath}): ${String(err)}`,
+        `Failed writing Matrix legacy encrypted-state migration record for account "${plan.accountId}" to SQLite: ${String(err)}`,
       );
     }
   }

--- a/extensions/matrix/src/matrix/client/storage.test.ts
+++ b/extensions/matrix/src/matrix/client/storage.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { resolveMatrixAccountStorageRoot } from "../../storage-paths.js";
 import { installMatrixTestRuntime } from "../../test-runtime.js";
+import { readMatrixIdbSnapshotJson, writeMatrixIdbSnapshotJson } from "../crypto-state-store.js";
 import { SqliteBackedMatrixSyncStore } from "./file-sync-store.js";
 import {
   claimCurrentTokenStorageState,
@@ -441,6 +442,39 @@ describe("matrix client storage paths", () => {
     const syncStore = new SqliteBackedMatrixSyncStore(storagePaths.rootDir);
     expect(syncStore.hasSavedSync()).toBe(true);
     await expect(syncStore.getSavedSyncToken()).resolves.toBe("account-token");
+  });
+
+  it("does not overwrite existing SQLite IDB snapshot state with a stale legacy sidecar", async () => {
+    const stateDir = setupStateDir();
+    const storagePaths = resolveDefaultStoragePaths();
+    fs.mkdirSync(storagePaths.rootDir, { recursive: true });
+    const currentSnapshot = JSON.stringify([
+      {
+        name: "current",
+        version: 1,
+        stores: [],
+      },
+    ]);
+    writeMatrixIdbSnapshotJson({
+      storageRootDir: storagePaths.rootDir,
+      snapshotJson: currentSnapshot,
+      databaseCount: 1,
+    });
+    fs.writeFileSync(
+      storagePaths.idbSnapshotPath,
+      JSON.stringify([{ name: "stale", version: 1, stores: [] }]),
+    );
+    const env = createMigrationEnv(stateDir);
+
+    await maybeMigrateLegacyStorage({
+      storagePaths,
+      env,
+    });
+
+    expectFallbackMigrationSnapshot(env);
+    expect(readMatrixIdbSnapshotJson(storagePaths.rootDir)).toBe(currentSnapshot);
+    expect(fs.existsSync(storagePaths.idbSnapshotPath)).toBe(false);
+    expect(fs.existsSync(`${storagePaths.idbSnapshotPath}.migrated`)).toBe(true);
   });
 
   it("ignores unrecognized account-scoped sync cache files without a migration snapshot", async () => {

--- a/extensions/matrix/src/matrix/client/storage.ts
+++ b/extensions/matrix/src/matrix/client/storage.ts
@@ -14,16 +14,22 @@ import {
   resolveMatrixAccountStorageRoot,
   resolveMatrixLegacyFlatStoragePaths,
 } from "../../storage-paths.js";
+import {
+  MATRIX_IDB_SNAPSHOT_FILENAME,
+  MATRIX_LEGACY_CRYPTO_MIGRATION_FILENAME,
+  MATRIX_RECOVERY_KEY_FILENAME,
+  migrateLegacyMatrixLegacyCryptoMigrationFileToStore,
+  migrateLegacyMatrixRecoveryKeyFileToStore,
+  readMatrixIdbSnapshotJson,
+  scoreMatrixCryptoStateInStore,
+  writeMatrixIdbSnapshotJson,
+} from "../crypto-state-store.js";
 import type { MatrixAuth } from "./types.js";
 import type { MatrixStoragePaths } from "./types.js";
 
 const DEFAULT_ACCOUNT_KEY = "default";
 const STORAGE_META_FILENAME = "storage-meta.json";
 const THREAD_BINDINGS_FILENAME = "thread-bindings.json";
-const LEGACY_CRYPTO_MIGRATION_FILENAME = "legacy-crypto-migration.json";
-const RECOVERY_KEY_FILENAME = "recovery-key.json";
-const IDB_SNAPSHOT_FILENAME = "crypto-idb-snapshot.json";
-
 type LegacyMoveRecord = {
   sourcePath: string;
   targetPath: string;
@@ -85,15 +91,16 @@ function scoreStorageRoot(rootDir: string): number {
   if (fs.existsSync(path.join(rootDir, THREAD_BINDINGS_FILENAME))) {
     score += 4;
   }
-  if (fs.existsSync(path.join(rootDir, LEGACY_CRYPTO_MIGRATION_FILENAME))) {
+  if (fs.existsSync(path.join(rootDir, MATRIX_LEGACY_CRYPTO_MIGRATION_FILENAME))) {
     score += 3;
   }
-  if (fs.existsSync(path.join(rootDir, RECOVERY_KEY_FILENAME))) {
+  if (fs.existsSync(path.join(rootDir, MATRIX_RECOVERY_KEY_FILENAME))) {
     score += 2;
   }
-  if (fs.existsSync(path.join(rootDir, IDB_SNAPSHOT_FILENAME))) {
+  if (fs.existsSync(path.join(rootDir, MATRIX_IDB_SNAPSHOT_FILENAME))) {
     score += 2;
   }
+  score += scoreMatrixCryptoStateInStore(rootDir);
   if (fs.existsSync(path.join(rootDir, STORAGE_META_FILENAME))) {
     score += 1;
   }
@@ -310,8 +317,8 @@ export function resolveMatrixStoragePaths(params: {
     storagePath: path.join(rootDir, "bot-storage.json"),
     cryptoPath: path.join(rootDir, "crypto"),
     metaPath: path.join(rootDir, STORAGE_META_FILENAME),
-    recoveryKeyPath: path.join(rootDir, "recovery-key.json"),
-    idbSnapshotPath: path.join(rootDir, IDB_SNAPSHOT_FILENAME),
+    recoveryKeyPath: path.join(rootDir, MATRIX_RECOVERY_KEY_FILENAME),
+    idbSnapshotPath: path.join(rootDir, MATRIX_IDB_SNAPSHOT_FILENAME),
     accountKey: canonical.accountKey,
     tokenHash,
   };
@@ -354,12 +361,31 @@ export async function maybeMigrateLegacyStorage(params: {
     hasAccountScopedLegacyStorageFile &&
     (await syncCache?.readLegacyMatrixSyncCacheState(params.storagePaths.rootDir)) !== null;
   const hasLegacyCrypto = fs.existsSync(legacy.cryptoPath);
-  if (!hasFlatLegacyStorage && !hasAccountScopedLegacyStorage && !hasLegacyCrypto) {
+  const hasAccountScopedRecoveryKey = fs.existsSync(params.storagePaths.recoveryKeyPath);
+  const hasAccountScopedIdbSnapshot = fs.existsSync(params.storagePaths.idbSnapshotPath);
+  const hasAccountScopedLegacyCryptoMigration = fs.existsSync(
+    path.join(params.storagePaths.rootDir, MATRIX_LEGACY_CRYPTO_MIGRATION_FILENAME),
+  );
+  if (
+    !hasFlatLegacyStorage &&
+    !hasAccountScopedLegacyStorage &&
+    !hasLegacyCrypto &&
+    !hasAccountScopedRecoveryKey &&
+    !hasAccountScopedIdbSnapshot &&
+    !hasAccountScopedLegacyCryptoMigration
+  ) {
     return;
   }
   const hasTargetCrypto = fs.existsSync(params.storagePaths.cryptoPath);
   const shouldMigrateCrypto = hasLegacyCrypto && !hasTargetCrypto;
-  if (!hasFlatLegacyStorage && !hasAccountScopedLegacyStorage && !shouldMigrateCrypto) {
+  if (
+    !hasFlatLegacyStorage &&
+    !hasAccountScopedLegacyStorage &&
+    !shouldMigrateCrypto &&
+    !hasAccountScopedRecoveryKey &&
+    !hasAccountScopedIdbSnapshot &&
+    !hasAccountScopedLegacyCryptoMigration
+  ) {
     return;
   }
 
@@ -413,6 +439,30 @@ export async function maybeMigrateLegacyStorage(params: {
         `- crypto store remains at ${legacy.cryptoPath} because ${params.storagePaths.cryptoPath} already exists`,
       );
     }
+    if (hasAccountScopedRecoveryKey) {
+      migrateLegacyMatrixRecoveryKeyFileToStore(params.storagePaths.rootDir);
+      moved.push({
+        sourcePath: params.storagePaths.recoveryKeyPath,
+        targetPath: `${params.storagePaths.rootDir} SQLite recovery key state`,
+        label: "recovery key",
+      });
+    }
+    if (hasAccountScopedLegacyCryptoMigration) {
+      migrateLegacyMatrixLegacyCryptoMigrationFileToStore(params.storagePaths.rootDir);
+      moved.push({
+        sourcePath: path.join(params.storagePaths.rootDir, MATRIX_LEGACY_CRYPTO_MIGRATION_FILENAME),
+        targetPath: `${params.storagePaths.rootDir} SQLite legacy crypto migration state`,
+        label: "legacy crypto migration",
+      });
+    }
+    if (hasAccountScopedIdbSnapshot) {
+      await migrateLegacyIdbSnapshotToSqlite({
+        storageRootDir: params.storagePaths.rootDir,
+        snapshotPath: params.storagePaths.idbSnapshotPath,
+        moved,
+        pendingArchives,
+      });
+    }
   } catch (err) {
     const rollbackError = rollbackLegacyMoves(moved);
     throw new Error(
@@ -440,6 +490,40 @@ export async function maybeMigrateLegacyStorage(params: {
       `matrix: legacy client storage still exists in the flat path because some account-scoped targets already existed.\n${skippedExistingTargets.join("\n")}`,
     );
   }
+}
+
+async function migrateLegacyIdbSnapshotToSqlite(params: {
+  storageRootDir: string;
+  snapshotPath: string;
+  moved: LegacyMoveRecord[];
+  pendingArchives: LegacyArchiveRecord[];
+}): Promise<void> {
+  if (readMatrixIdbSnapshotJson(params.storageRootDir)) {
+    params.pendingArchives.push({
+      sourcePath: params.snapshotPath,
+      label: "IndexedDB snapshot",
+    });
+    return;
+  }
+  const { readLegacyMatrixIdbSnapshotState } = await import("../sdk/idb-persistence.js");
+  const snapshot = await readLegacyMatrixIdbSnapshotState(params.storageRootDir);
+  if (!snapshot) {
+    return;
+  }
+  writeMatrixIdbSnapshotJson({
+    storageRootDir: params.storageRootDir,
+    snapshotJson: JSON.stringify(snapshot),
+    databaseCount: snapshot.length,
+  });
+  params.moved.push({
+    sourcePath: params.snapshotPath,
+    targetPath: `${params.storageRootDir} SQLite IndexedDB snapshot state`,
+    label: "IndexedDB snapshot",
+  });
+  params.pendingArchives.push({
+    sourcePath: params.snapshotPath,
+    label: "IndexedDB snapshot",
+  });
 }
 
 async function migrateLegacySyncCacheToSqlite(params: {

--- a/extensions/matrix/src/matrix/crypto-state-store.ts
+++ b/extensions/matrix/src/matrix/crypto-state-store.ts
@@ -1,0 +1,642 @@
+// Matrix plugin module owns SQLite-backed crypto state sidecars.
+import { createHash, randomUUID } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import type {
+  PluginStateKeyedStore,
+  PluginStateSyncKeyedStore,
+} from "openclaw/plugin-sdk/plugin-state-runtime";
+import { isRecord } from "../record-shared.js";
+import { getMatrixRuntime } from "../runtime.js";
+import type { MatrixStoredRecoveryKey } from "./sdk/types.js";
+import { resolveMatrixSqliteStateEnv } from "./sqlite-state.js";
+
+const STATE_KEY = "current";
+const RECOVERY_KEY_NAMESPACE = "recovery-key";
+const LEGACY_CRYPTO_MIGRATION_NAMESPACE = "legacy-crypto-migration";
+const IDB_SNAPSHOT_NAMESPACE = "idb-snapshot";
+const SMALL_STATE_MAX_ENTRIES = 10;
+const IDB_SNAPSHOT_MAX_ENTRIES = 20_000;
+const IDB_SNAPSHOT_MAX_CHUNKS = Math.floor((IDB_SNAPSHOT_MAX_ENTRIES - 1) / 2);
+const IDB_SNAPSHOT_CHUNK_BYTES = 24_000;
+
+export const MATRIX_RECOVERY_KEY_FILENAME = "recovery-key.json";
+export const MATRIX_LEGACY_CRYPTO_MIGRATION_FILENAME = "legacy-crypto-migration.json";
+export const MATRIX_IDB_SNAPSHOT_FILENAME = "crypto-idb-snapshot.json";
+
+export type MatrixLegacyCryptoCounts = {
+  total: number;
+  backedUp: number;
+};
+
+export type MatrixLegacyCryptoMigrationState = {
+  version: 1;
+  source?: "matrix-bot-sdk-rust";
+  accountId: string;
+  deviceId?: string | null;
+  roomKeyCounts: MatrixLegacyCryptoCounts | null;
+  backupVersion?: string | null;
+  decryptionKeyImported?: boolean;
+  restoreStatus: "pending" | "completed" | "manual-action-required";
+  detectedAt?: string;
+  restoredAt?: string;
+  importedCount?: number;
+  totalCount?: number;
+  lastError?: string | null;
+};
+
+type MatrixIdbSnapshotMeta = {
+  kind: "meta";
+  version: 1;
+  generation: string;
+  chunkCount: number;
+  digest: string;
+  databaseCount: number;
+  persistedAt: string;
+};
+
+type MatrixIdbSnapshotChunk = {
+  kind: "snapshot-chunk";
+  index: number;
+  data: string;
+};
+
+export type MatrixIdbSnapshotRecord = MatrixIdbSnapshotMeta | MatrixIdbSnapshotChunk;
+
+type AsyncStore<T> = Pick<PluginStateKeyedStore<T>, "delete" | "entries" | "lookup" | "register">;
+type SyncStore<T> = Pick<
+  PluginStateSyncKeyedStore<T>,
+  "delete" | "entries" | "lookup" | "register"
+>;
+
+export function openMatrixRecoveryKeyStoreOptions(storageRootDir: string) {
+  return {
+    namespace: RECOVERY_KEY_NAMESPACE,
+    maxEntries: SMALL_STATE_MAX_ENTRIES,
+    env: resolveMatrixSqliteStateEnv({ stateDir: storageRootDir }),
+  };
+}
+
+export function openMatrixLegacyCryptoMigrationStoreOptions(storageRootDir: string) {
+  return {
+    namespace: LEGACY_CRYPTO_MIGRATION_NAMESPACE,
+    maxEntries: SMALL_STATE_MAX_ENTRIES,
+    env: resolveMatrixSqliteStateEnv({ stateDir: storageRootDir }),
+  };
+}
+
+export function openMatrixIdbSnapshotStoreOptions(storageRootDir: string) {
+  return {
+    namespace: IDB_SNAPSHOT_NAMESPACE,
+    maxEntries: IDB_SNAPSHOT_MAX_ENTRIES,
+    env: resolveMatrixSqliteStateEnv({ stateDir: storageRootDir }),
+  };
+}
+
+export function readMatrixRecoveryKeyState(storageRootDir: string): MatrixStoredRecoveryKey | null {
+  return readMatrixRecoveryKeyStateWithKey({
+    storageRootDir,
+    stateKey: STATE_KEY,
+  });
+}
+
+export function readMatrixRecoveryKeyStateForPath(
+  recoveryKeyPath: string,
+): MatrixStoredRecoveryKey | null {
+  return readMatrixRecoveryKeyStateWithKey({
+    storageRootDir: path.dirname(recoveryKeyPath),
+    stateKey: resolveRecoveryKeyStateKeyForPath(recoveryKeyPath),
+  });
+}
+
+function readMatrixRecoveryKeyStateWithKey(params: {
+  storageRootDir: string;
+  stateKey: string;
+}): MatrixStoredRecoveryKey | null {
+  return normalizeMatrixStoredRecoveryKey(
+    openSyncStore<MatrixStoredRecoveryKey>(
+      openMatrixRecoveryKeyStoreOptions(params.storageRootDir),
+    ).lookup(params.stateKey),
+  );
+}
+
+export function writeMatrixRecoveryKeyState(params: {
+  storageRootDir: string;
+  payload: MatrixStoredRecoveryKey;
+}): void {
+  writeMatrixRecoveryKeyStateWithKey({
+    storageRootDir: params.storageRootDir,
+    stateKey: STATE_KEY,
+    payload: params.payload,
+  });
+}
+
+export function writeMatrixRecoveryKeyStateForPath(params: {
+  recoveryKeyPath: string;
+  payload: MatrixStoredRecoveryKey;
+}): void {
+  writeMatrixRecoveryKeyStateWithKey({
+    storageRootDir: path.dirname(params.recoveryKeyPath),
+    stateKey: resolveRecoveryKeyStateKeyForPath(params.recoveryKeyPath),
+    payload: params.payload,
+  });
+}
+
+function writeMatrixRecoveryKeyStateWithKey(params: {
+  storageRootDir: string;
+  stateKey: string;
+  payload: MatrixStoredRecoveryKey;
+}): void {
+  const payload = normalizeMatrixStoredRecoveryKey(params.payload);
+  if (!payload) {
+    throw new Error("Invalid Matrix recovery key state");
+  }
+  openSyncStore<MatrixStoredRecoveryKey>(
+    openMatrixRecoveryKeyStoreOptions(params.storageRootDir),
+  ).register(params.stateKey, payload);
+}
+
+export async function hasMatrixRecoveryKeyStateInStore(params: {
+  store: Pick<PluginStateKeyedStore<MatrixStoredRecoveryKey>, "lookup">;
+}): Promise<boolean> {
+  return normalizeMatrixStoredRecoveryKey(await params.store.lookup(STATE_KEY)) !== null;
+}
+
+export async function writeMatrixRecoveryKeyStateToStore(params: {
+  payload: MatrixStoredRecoveryKey;
+  store: Pick<PluginStateKeyedStore<MatrixStoredRecoveryKey>, "register">;
+}): Promise<void> {
+  const payload = normalizeMatrixStoredRecoveryKey(params.payload);
+  if (!payload) {
+    throw new Error("Invalid Matrix recovery key state");
+  }
+  await params.store.register(STATE_KEY, payload);
+}
+
+export function readMatrixLegacyCryptoMigrationState(
+  storageRootDir: string,
+): MatrixLegacyCryptoMigrationState | null {
+  return normalizeMatrixLegacyCryptoMigrationState(
+    openSyncStore<MatrixLegacyCryptoMigrationState>(
+      openMatrixLegacyCryptoMigrationStoreOptions(storageRootDir),
+    ).lookup(STATE_KEY),
+  );
+}
+
+export function writeMatrixLegacyCryptoMigrationState(params: {
+  storageRootDir: string;
+  state: MatrixLegacyCryptoMigrationState;
+}): void {
+  const state = normalizeMatrixLegacyCryptoMigrationState(params.state);
+  if (!state) {
+    throw new Error("Invalid Matrix legacy crypto migration state");
+  }
+  openSyncStore<MatrixLegacyCryptoMigrationState>(
+    openMatrixLegacyCryptoMigrationStoreOptions(params.storageRootDir),
+  ).register(STATE_KEY, state);
+}
+
+export async function hasMatrixLegacyCryptoMigrationStateInStore(params: {
+  store: Pick<PluginStateKeyedStore<MatrixLegacyCryptoMigrationState>, "lookup">;
+}): Promise<boolean> {
+  return normalizeMatrixLegacyCryptoMigrationState(await params.store.lookup(STATE_KEY)) !== null;
+}
+
+export async function writeMatrixLegacyCryptoMigrationStateToStore(params: {
+  state: MatrixLegacyCryptoMigrationState;
+  store: Pick<PluginStateKeyedStore<MatrixLegacyCryptoMigrationState>, "register">;
+}): Promise<void> {
+  const state = normalizeMatrixLegacyCryptoMigrationState(params.state);
+  if (!state) {
+    throw new Error("Invalid Matrix legacy crypto migration state");
+  }
+  await params.store.register(STATE_KEY, state);
+}
+
+export function readMatrixIdbSnapshotJson(storageRootDir: string): string | null {
+  return readIdbSnapshotJsonFromStore(
+    openSyncStore<MatrixIdbSnapshotRecord>(openMatrixIdbSnapshotStoreOptions(storageRootDir)),
+  );
+}
+
+export function hasMatrixIdbSnapshotState(storageRootDir: string): boolean {
+  return isIdbSnapshotMeta(
+    openSyncStore<MatrixIdbSnapshotRecord>(
+      openMatrixIdbSnapshotStoreOptions(storageRootDir),
+    ).lookup(idbMetaKey()),
+  );
+}
+
+export function writeMatrixIdbSnapshotJson(params: {
+  storageRootDir: string;
+  snapshotJson: string;
+  databaseCount: number;
+}): void {
+  writeIdbSnapshotJsonToStore({
+    snapshotJson: params.snapshotJson,
+    databaseCount: params.databaseCount,
+    store: openSyncStore<MatrixIdbSnapshotRecord>(
+      openMatrixIdbSnapshotStoreOptions(params.storageRootDir),
+    ),
+  });
+}
+
+export async function hasMatrixIdbSnapshotStateInStore(params: {
+  store: Pick<PluginStateKeyedStore<MatrixIdbSnapshotRecord>, "lookup">;
+}): Promise<boolean> {
+  return (await readIdbSnapshotJsonFromAsyncStore(params.store)) !== null;
+}
+
+export async function writeMatrixIdbSnapshotJsonToStore(params: {
+  snapshotJson: string;
+  databaseCount: number;
+  store: AsyncStore<MatrixIdbSnapshotRecord>;
+}): Promise<void> {
+  const rows = buildIdbSnapshotRows(params.snapshotJson, params.databaseCount);
+  for (const row of rows.chunks) {
+    await params.store.register(row.key, row.value);
+  }
+  await params.store.register(rows.meta.key, rows.meta.value);
+  for (const row of await params.store.entries()) {
+    if (row.key.startsWith(idbChunkKeyPrefix()) && !rows.nextChunkKeys.has(row.key)) {
+      await params.store.delete(row.key);
+    }
+  }
+}
+
+export function migrateLegacyMatrixRecoveryKeyFileToStore(storageRootDir: string): boolean {
+  return migrateLegacyMatrixRecoveryKeyFilePathToStore(
+    path.join(storageRootDir, MATRIX_RECOVERY_KEY_FILENAME),
+  );
+}
+
+export function migrateLegacyMatrixRecoveryKeyFilePathToStore(recoveryKeyPath: string): boolean {
+  const existing = readMatrixRecoveryKeyStateForPath(recoveryKeyPath);
+  const legacy = readLegacyMatrixRecoveryKeyFile(recoveryKeyPath);
+  if (!existing && legacy) {
+    writeMatrixRecoveryKeyStateForPath({ recoveryKeyPath, payload: legacy });
+  }
+  return archiveLegacyStateFileIfPossible(recoveryKeyPath);
+}
+
+export function migrateLegacyMatrixLegacyCryptoMigrationFileToStore(
+  storageRootDir: string,
+): boolean {
+  const existing = readMatrixLegacyCryptoMigrationState(storageRootDir);
+  const legacy = readLegacyMatrixLegacyCryptoMigrationState(storageRootDir);
+  if (!existing && legacy) {
+    writeMatrixLegacyCryptoMigrationState({ storageRootDir, state: legacy });
+  }
+  return archiveLegacyStateFileIfPossible(
+    path.join(storageRootDir, MATRIX_LEGACY_CRYPTO_MIGRATION_FILENAME),
+  );
+}
+
+export function readLegacyMatrixRecoveryKeyState(
+  storageRootDir: string,
+): MatrixStoredRecoveryKey | null {
+  return readLegacyMatrixRecoveryKeyFile(path.join(storageRootDir, MATRIX_RECOVERY_KEY_FILENAME));
+}
+
+export function readLegacyMatrixRecoveryKeyFile(filePath: string): MatrixStoredRecoveryKey | null {
+  return readJsonFileSync(filePath, normalizeMatrixStoredRecoveryKey);
+}
+
+export function readLegacyMatrixLegacyCryptoMigrationState(
+  storageRootDir: string,
+): MatrixLegacyCryptoMigrationState | null {
+  return readJsonFileSync(
+    path.join(storageRootDir, MATRIX_LEGACY_CRYPTO_MIGRATION_FILENAME),
+    normalizeMatrixLegacyCryptoMigrationState,
+  );
+}
+
+export function scoreMatrixCryptoStateInStore(storageRootDir: string): number {
+  if (!matrixCryptoStateDatabaseExists(storageRootDir)) {
+    return 0;
+  }
+  let score = 0;
+  try {
+    if (readMatrixLegacyCryptoMigrationState(storageRootDir)) {
+      score += 3;
+    }
+  } catch {
+    // Storage root scoring must stay best-effort; unreadable state should not block startup.
+  }
+  try {
+    if (readMatrixRecoveryKeyState(storageRootDir)) {
+      score += 2;
+    }
+  } catch {
+    // Storage root scoring must stay best-effort; unreadable state should not block startup.
+  }
+  try {
+    if (hasMatrixIdbSnapshotState(storageRootDir)) {
+      score += 2;
+    }
+  } catch {
+    // Storage root scoring must stay best-effort; unreadable state should not block startup.
+  }
+  return score;
+}
+
+function matrixCryptoStateDatabaseExists(storageRootDir: string): boolean {
+  return fs.existsSync(path.join(storageRootDir, "state", "openclaw.sqlite"));
+}
+
+function resolveRecoveryKeyStateKeyForPath(recoveryKeyPath: string): string {
+  const basename = path.basename(recoveryKeyPath);
+  if (basename === MATRIX_RECOVERY_KEY_FILENAME) {
+    return STATE_KEY;
+  }
+  return `file:${createHash("sha256").update(basename, "utf8").digest("hex").slice(0, 32)}`;
+}
+
+export function normalizeMatrixStoredRecoveryKey(value: unknown): MatrixStoredRecoveryKey | null {
+  if (
+    !isRecord(value) ||
+    value.version !== 1 ||
+    typeof value.createdAt !== "string" ||
+    typeof value.privateKeyBase64 !== "string" ||
+    !value.privateKeyBase64.trim()
+  ) {
+    return null;
+  }
+  return {
+    version: 1,
+    createdAt: value.createdAt,
+    keyId: typeof value.keyId === "string" ? value.keyId : null,
+    ...(typeof value.encodedPrivateKey === "string"
+      ? { encodedPrivateKey: value.encodedPrivateKey }
+      : {}),
+    privateKeyBase64: value.privateKeyBase64,
+    ...(isRecord(value.keyInfo)
+      ? {
+          keyInfo: {
+            ...(value.keyInfo.passphrase !== undefined
+              ? { passphrase: value.keyInfo.passphrase }
+              : {}),
+            ...(typeof value.keyInfo.name === "string" ? { name: value.keyInfo.name } : {}),
+          },
+        }
+      : {}),
+  };
+}
+
+export function normalizeMatrixLegacyCryptoMigrationState(
+  value: unknown,
+): MatrixLegacyCryptoMigrationState | null {
+  if (!isRecord(value) || value.version !== 1 || typeof value.accountId !== "string") {
+    return null;
+  }
+  if (
+    value.restoreStatus !== "pending" &&
+    value.restoreStatus !== "completed" &&
+    value.restoreStatus !== "manual-action-required"
+  ) {
+    return null;
+  }
+  const roomKeyCounts =
+    isRecord(value.roomKeyCounts) &&
+    typeof value.roomKeyCounts.total === "number" &&
+    typeof value.roomKeyCounts.backedUp === "number"
+      ? {
+          total: value.roomKeyCounts.total,
+          backedUp: value.roomKeyCounts.backedUp,
+        }
+      : null;
+  return {
+    version: 1,
+    ...(value.source === "matrix-bot-sdk-rust" ? { source: value.source } : {}),
+    accountId: value.accountId,
+    ...(typeof value.deviceId === "string" || value.deviceId === null
+      ? { deviceId: value.deviceId }
+      : {}),
+    roomKeyCounts,
+    ...(typeof value.backupVersion === "string" || value.backupVersion === null
+      ? { backupVersion: value.backupVersion }
+      : {}),
+    ...(typeof value.decryptionKeyImported === "boolean"
+      ? { decryptionKeyImported: value.decryptionKeyImported }
+      : {}),
+    restoreStatus: value.restoreStatus,
+    ...(typeof value.detectedAt === "string" ? { detectedAt: value.detectedAt } : {}),
+    ...(typeof value.restoredAt === "string" ? { restoredAt: value.restoredAt } : {}),
+    ...(typeof value.importedCount === "number" ? { importedCount: value.importedCount } : {}),
+    ...(typeof value.totalCount === "number" ? { totalCount: value.totalCount } : {}),
+    ...(typeof value.lastError === "string" || value.lastError === null
+      ? { lastError: value.lastError }
+      : {}),
+  };
+}
+
+function openSyncStore<T>(options: {
+  namespace: string;
+  maxEntries: number;
+  env?: NodeJS.ProcessEnv;
+}): PluginStateSyncKeyedStore<T> {
+  return getMatrixRuntime().state.openSyncKeyedStore<T>(options);
+}
+
+function readJsonFileSync<T>(filePath: string, normalize: (value: unknown) => T | null): T | null {
+  try {
+    return normalize(JSON.parse(fs.readFileSync(filePath, "utf8")) as unknown);
+  } catch {
+    return null;
+  }
+}
+
+function archiveLegacyStateFileIfPossible(filePath: string): boolean {
+  if (!fs.existsSync(filePath)) {
+    return false;
+  }
+  const archivedPath = `${filePath}.migrated`;
+  if (fs.existsSync(archivedPath)) {
+    return false;
+  }
+  fs.renameSync(filePath, archivedPath);
+  return true;
+}
+
+function readIdbSnapshotJsonFromStore(store: Pick<SyncStore<MatrixIdbSnapshotRecord>, "lookup">) {
+  const meta = store.lookup(idbMetaKey());
+  if (!isIdbSnapshotMeta(meta)) {
+    return null;
+  }
+  const chunks = readIdbSnapshotChunks(meta, (key) => store.lookup(key));
+  return chunks ? chunks.join("") : null;
+}
+
+async function readIdbSnapshotJsonFromAsyncStore(
+  store: Pick<PluginStateKeyedStore<MatrixIdbSnapshotRecord>, "lookup">,
+): Promise<string | null> {
+  const meta = await store.lookup(idbMetaKey());
+  if (!isIdbSnapshotMeta(meta)) {
+    return null;
+  }
+  const chunks = await readIdbSnapshotChunksAsync(meta, (key) => store.lookup(key));
+  return chunks ? chunks.join("") : null;
+}
+
+function readIdbSnapshotChunks(
+  meta: MatrixIdbSnapshotMeta,
+  lookup: (key: string) => MatrixIdbSnapshotRecord | undefined,
+): string[] | null {
+  const chunks: string[] = [];
+  for (let index = 0; index < meta.chunkCount; index += 1) {
+    const chunk = lookup(idbChunkKey(meta.generation, index));
+    if (!isIdbSnapshotChunk(chunk) || chunk.index !== index) {
+      return null;
+    }
+    chunks.push(chunk.data);
+  }
+  const snapshotJson = chunks.join("");
+  if (meta.digest !== digestText(snapshotJson)) {
+    return null;
+  }
+  return chunks;
+}
+
+async function readIdbSnapshotChunksAsync(
+  meta: MatrixIdbSnapshotMeta,
+  lookup: (key: string) => Promise<MatrixIdbSnapshotRecord | undefined>,
+): Promise<string[] | null> {
+  const chunks: string[] = [];
+  for (let index = 0; index < meta.chunkCount; index += 1) {
+    const chunk = await lookup(idbChunkKey(meta.generation, index));
+    if (!isIdbSnapshotChunk(chunk) || chunk.index !== index) {
+      return null;
+    }
+    chunks.push(chunk.data);
+  }
+  const snapshotJson = chunks.join("");
+  if (meta.digest !== digestText(snapshotJson)) {
+    return null;
+  }
+  return chunks;
+}
+
+function writeIdbSnapshotJsonToStore(params: {
+  snapshotJson: string;
+  databaseCount: number;
+  store: SyncStore<MatrixIdbSnapshotRecord>;
+}): void {
+  const rows = buildIdbSnapshotRows(params.snapshotJson, params.databaseCount);
+  for (const row of rows.chunks) {
+    params.store.register(row.key, row.value);
+  }
+  params.store.register(rows.meta.key, rows.meta.value);
+  for (const row of params.store.entries()) {
+    if (row.key.startsWith(idbChunkKeyPrefix()) && !rows.nextChunkKeys.has(row.key)) {
+      params.store.delete(row.key);
+    }
+  }
+}
+
+function buildIdbSnapshotRows(
+  snapshotJson: string,
+  databaseCount: number,
+): {
+  meta: { key: string; value: MatrixIdbSnapshotMeta };
+  chunks: { key: string; value: MatrixIdbSnapshotChunk }[];
+  nextChunkKeys: Set<string>;
+} {
+  const generation = randomUUID().replaceAll("-", "");
+  const chunks = chunkText(snapshotJson).map((data, index) => ({
+    key: idbChunkKey(generation, index),
+    value: {
+      kind: "snapshot-chunk" as const,
+      index,
+      data,
+    },
+  }));
+  return {
+    chunks,
+    nextChunkKeys: new Set(chunks.map((chunk) => chunk.key)),
+    meta: {
+      key: idbMetaKey(),
+      value: {
+        kind: "meta",
+        version: 1,
+        generation,
+        chunkCount: chunks.length,
+        digest: digestText(snapshotJson),
+        databaseCount,
+        persistedAt: new Date().toISOString(),
+      },
+    },
+  };
+}
+
+function idbMetaKey(): string {
+  return `${STATE_KEY}:meta`;
+}
+
+function idbChunkKeyPrefix(): string {
+  return `${STATE_KEY}:snapshot:`;
+}
+
+function idbChunkKey(generation: string, index: number): string {
+  return `${idbChunkKeyPrefix()}${generation}:${index}`;
+}
+
+function chunkText(value: string): string[] {
+  const chunks: string[] = [];
+  let current = "";
+  let currentBytes = 0;
+  for (const char of value) {
+    const charBytes = Buffer.byteLength(char, "utf8");
+    if (current && currentBytes + charBytes > IDB_SNAPSHOT_CHUNK_BYTES) {
+      pushChunk(chunks, current);
+      current = "";
+      currentBytes = 0;
+    }
+    current += char;
+    currentBytes += charBytes;
+  }
+  if (current) {
+    pushChunk(chunks, current);
+  }
+  return chunks;
+}
+
+function pushChunk(chunks: string[], chunk: string): void {
+  if (chunks.length >= IDB_SNAPSHOT_MAX_CHUNKS) {
+    throw new Error("Matrix IndexedDB snapshot exceeds SQLite chunk limit");
+  }
+  chunks.push(chunk);
+}
+
+function digestText(value: string): string {
+  return createHash("sha256").update(value, "utf8").digest("hex");
+}
+
+function isIdbSnapshotMeta(value: unknown): value is MatrixIdbSnapshotMeta {
+  return (
+    isRecord(value) &&
+    value.kind === "meta" &&
+    value.version === 1 &&
+    typeof value.generation === "string" &&
+    value.generation.trim() !== "" &&
+    typeof value.chunkCount === "number" &&
+    Number.isSafeInteger(value.chunkCount) &&
+    value.chunkCount >= 0 &&
+    value.chunkCount <= IDB_SNAPSHOT_MAX_CHUNKS &&
+    typeof value.digest === "string" &&
+    typeof value.databaseCount === "number" &&
+    Number.isSafeInteger(value.databaseCount) &&
+    value.databaseCount >= 0 &&
+    typeof value.persistedAt === "string"
+  );
+}
+
+function isIdbSnapshotChunk(value: unknown): value is MatrixIdbSnapshotChunk {
+  return (
+    isRecord(value) &&
+    value.kind === "snapshot-chunk" &&
+    typeof value.index === "number" &&
+    Number.isSafeInteger(value.index) &&
+    value.index >= 0 &&
+    typeof value.data === "string"
+  );
+}

--- a/extensions/matrix/src/matrix/monitor/legacy-crypto-restore.test.ts
+++ b/extensions/matrix/src/matrix/monitor/legacy-crypto-restore.test.ts
@@ -1,9 +1,12 @@
 // Matrix tests cover legacy crypto restore plugin behavior.
 import fs from "node:fs";
 import path from "node:path";
+import { resetPluginStateStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { withTempHome } from "openclaw/plugin-sdk/test-env";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveMatrixAccountStorageRoot } from "../../storage-paths.js";
+import { installMatrixTestRuntime } from "../../test-runtime.js";
+import { readMatrixLegacyCryptoMigrationState } from "../crypto-state-store.js";
 import type { MatrixRoomKeyBackupRestoreResult } from "../sdk.js";
 import { maybeRestoreLegacyMatrixBackup } from "./legacy-crypto-restore.js";
 
@@ -34,12 +37,7 @@ const BASE_AUTH = {
 type MatrixAuth = typeof BASE_AUTH;
 
 function readLegacyMigrationState(rootDir: string) {
-  const statePath = path.join(rootDir, "legacy-crypto-migration.json");
-  if (!fs.existsSync(statePath)) {
-    return null;
-  }
-
-  return JSON.parse(fs.readFileSync(statePath, "utf8")) as Record<string, unknown>;
+  return readMatrixLegacyCryptoMigrationState(rootDir) as Record<string, unknown> | null;
 }
 
 async function runLegacyRestoreScenario(params: {
@@ -82,16 +80,23 @@ async function runLegacyRestoreScenario(params: {
       result,
       restoreRoomKeyBackup,
       rootState: readLegacyMigrationState(rootDir),
-      rootStateExists: fs.existsSync(path.join(rootDir, "legacy-crypto-migration.json")),
+      rootStateExists: readLegacyMigrationState(rootDir) !== null,
       sourceRootState: readLegacyMigrationState(sourceRootDir),
-      sourceRootStateExists: fs.existsSync(
-        path.join(sourceRootDir, "legacy-crypto-migration.json"),
-      ),
+      sourceRootStateExists: readLegacyMigrationState(sourceRootDir) !== null,
     };
   });
 }
 
 describe("maybeRestoreLegacyMatrixBackup", () => {
+  beforeEach(() => {
+    resetPluginStateStoreForTests();
+    installMatrixTestRuntime();
+  });
+
+  afterEach(() => {
+    resetPluginStateStoreForTests();
+  });
+
   it("marks pending legacy backup restore as completed after success", async () => {
     const { result, sourceRootState } = await runLegacyRestoreScenario({
       migration: {

--- a/extensions/matrix/src/matrix/monitor/legacy-crypto-restore.ts
+++ b/extensions/matrix/src/matrix/monitor/legacy-crypto-restore.ts
@@ -2,25 +2,16 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { readJsonFileWithFallback, writeJsonFileAtomically } from "openclaw/plugin-sdk/json-store";
 import { getMatrixRuntime } from "../../runtime.js";
 import { resolveMatrixStoragePaths } from "../client/storage.js";
 import type { MatrixAuth } from "../client/types.js";
+import {
+  migrateLegacyMatrixLegacyCryptoMigrationFileToStore,
+  readMatrixLegacyCryptoMigrationState,
+  writeMatrixLegacyCryptoMigrationState,
+  type MatrixLegacyCryptoMigrationState,
+} from "../crypto-state-store.js";
 import type { MatrixClient } from "../sdk.js";
-
-type MatrixLegacyCryptoMigrationState = {
-  version: 1;
-  accountId: string;
-  roomKeyCounts: {
-    total: number;
-    backedUp: number;
-  } | null;
-  restoreStatus: "pending" | "completed" | "manual-action-required";
-  restoredAt?: string;
-  importedCount?: number;
-  totalCount?: number;
-  lastError?: string | null;
-};
 
 export type MatrixLegacyCryptoRestoreResult =
   | { kind: "skipped" }
@@ -36,17 +27,11 @@ export type MatrixLegacyCryptoRestoreResult =
       localOnlyKeys: number;
     };
 
-function isMigrationState(value: unknown): value is MatrixLegacyCryptoMigrationState {
-  return (
-    Boolean(value) && typeof value === "object" && (value as { version?: unknown }).version === 1
-  );
-}
-
-async function resolvePendingMigrationStatePath(params: {
+async function resolvePendingMigrationStateRoot(params: {
   stateDir: string;
   auth: Pick<MatrixAuth, "homeserver" | "userId" | "accessToken" | "accountId" | "deviceId">;
 }): Promise<{
-  statePath: string;
+  storageRootDir: string;
   value: MatrixLegacyCryptoMigrationState | null;
 }> {
   const { rootDir } = resolveMatrixStoragePaths({
@@ -57,11 +42,14 @@ async function resolvePendingMigrationStatePath(params: {
     deviceId: params.auth.deviceId,
     stateDir: params.stateDir,
   });
-  const directStatePath = path.join(rootDir, "legacy-crypto-migration.json");
-  const { value: directValue } =
-    await readJsonFileWithFallback<MatrixLegacyCryptoMigrationState | null>(directStatePath, null);
-  if (isMigrationState(directValue) && directValue.restoreStatus === "pending") {
-    return { statePath: directStatePath, value: directValue };
+  try {
+    migrateLegacyMatrixLegacyCryptoMigrationFileToStore(rootDir);
+  } catch {
+    // Startup restore can still proceed from any already-migrated SQLite state.
+  }
+  const directValue = readMatrixLegacyCryptoMigrationState(rootDir);
+  if (directValue?.restoreStatus === "pending") {
+    return { storageRootDir: rootDir, value: directValue };
   }
 
   const accountStorageDir = path.dirname(rootDir);
@@ -73,20 +61,22 @@ async function resolvePendingMigrationStatePath(params: {
       .filter((entry) => path.join(accountStorageDir, entry) !== rootDir)
       .toSorted((left, right) => left.localeCompare(right));
   } catch {
-    return { statePath: directStatePath, value: directValue };
+    return { storageRootDir: rootDir, value: directValue };
   }
 
   for (const sibling of siblingEntries) {
-    const siblingStatePath = path.join(accountStorageDir, sibling, "legacy-crypto-migration.json");
-    const { value } = await readJsonFileWithFallback<MatrixLegacyCryptoMigrationState | null>(
-      siblingStatePath,
-      null,
-    );
-    if (isMigrationState(value) && value.restoreStatus === "pending") {
-      return { statePath: siblingStatePath, value };
+    const siblingRootDir = path.join(accountStorageDir, sibling);
+    try {
+      migrateLegacyMatrixLegacyCryptoMigrationFileToStore(siblingRootDir);
+    } catch {
+      // Sibling scan is best-effort; unreadable roots are ignored.
+    }
+    const value = readMatrixLegacyCryptoMigrationState(siblingRootDir);
+    if (value?.restoreStatus === "pending") {
+      return { storageRootDir: siblingRootDir, value };
     }
   }
-  return { statePath: directStatePath, value: directValue };
+  return { storageRootDir: rootDir, value: directValue };
 }
 
 export async function maybeRestoreLegacyMatrixBackup(params: {
@@ -97,11 +87,11 @@ export async function maybeRestoreLegacyMatrixBackup(params: {
 }): Promise<MatrixLegacyCryptoRestoreResult> {
   const env = params.env ?? process.env;
   const stateDir = params.stateDir ?? getMatrixRuntime().state.resolveStateDir(env, os.homedir);
-  const { statePath, value } = await resolvePendingMigrationStatePath({
+  const { storageRootDir, value } = await resolvePendingMigrationStateRoot({
     stateDir,
     auth: params.auth,
   });
-  if (!isMigrationState(value) || value.restoreStatus !== "pending") {
+  if (value?.restoreStatus !== "pending") {
     return { kind: "skipped" };
   }
 
@@ -112,14 +102,17 @@ export async function maybeRestoreLegacyMatrixBackup(params: {
       : 0;
 
   if (restore.success) {
-    await writeJsonFileAtomically(statePath, {
-      ...value,
-      restoreStatus: "completed",
-      restoredAt: restore.restoredAt ?? new Date().toISOString(),
-      importedCount: restore.imported,
-      totalCount: restore.total,
-      lastError: null,
-    } satisfies MatrixLegacyCryptoMigrationState);
+    writeMatrixLegacyCryptoMigrationState({
+      storageRootDir,
+      state: {
+        ...value,
+        restoreStatus: "completed",
+        restoredAt: restore.restoredAt ?? new Date().toISOString(),
+        importedCount: restore.imported,
+        totalCount: restore.total,
+        lastError: null,
+      } satisfies MatrixLegacyCryptoMigrationState,
+    });
     return {
       kind: "restored",
       imported: restore.imported,
@@ -128,10 +121,13 @@ export async function maybeRestoreLegacyMatrixBackup(params: {
     };
   }
 
-  await writeJsonFileAtomically(statePath, {
-    ...value,
-    lastError: restore.error ?? "unknown",
-  } satisfies MatrixLegacyCryptoMigrationState);
+  writeMatrixLegacyCryptoMigrationState({
+    storageRootDir,
+    state: {
+      ...value,
+      lastError: restore.error ?? "unknown",
+    } satisfies MatrixLegacyCryptoMigrationState,
+  });
   return {
     kind: "failed",
     error: restore.error ?? "unknown",

--- a/extensions/matrix/src/matrix/sdk.test.ts
+++ b/extensions/matrix/src/matrix/sdk.test.ts
@@ -7,6 +7,7 @@ import path from "node:path";
 import { resetPluginStateStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { installMatrixTestRuntime } from "../test-runtime.js";
+import { readMatrixRecoveryKeyState } from "./crypto-state-store.js";
 
 function requestUrl(input: RequestInfo | URL | undefined): string {
   if (!input) {
@@ -56,6 +57,10 @@ function expectSomeMockCallOptions(
     return Object.entries(fields).every(([key, value]) => Object.is(record[key], value));
   });
   expect(matched).toBe(true);
+}
+
+function readStoredRecoveryKey(recoveryKeyPath: string) {
+  return readMatrixRecoveryKeyState(path.dirname(recoveryKeyPath));
 }
 
 const TEST_UNDICI_RUNTIME_DEPS_KEY = "__OPENCLAW_TEST_UNDICI_RUNTIME_DEPS__";
@@ -1721,7 +1726,12 @@ describe("MatrixClient crypto bootstrapping", () => {
     await client.start();
 
     expect(databasesSpy).toHaveBeenCalled();
-    const intervalCall = setIntervalSpy.mock.calls.at(0) as unknown[];
+    const intervalCall = setIntervalSpy.mock.calls.find((call) => call[1] === 60_000) as
+      | unknown[]
+      | undefined;
+    if (!intervalCall) {
+      throw new Error("expected Matrix IDB snapshot interval");
+    }
     expect(intervalCall[0]).toBeTypeOf("function");
     expect(intervalCall[1]).toBe(60_000);
     client.stop();
@@ -2037,7 +2047,7 @@ describe("MatrixClient crypto bootstrapping", () => {
     expect(result.backupUsable).toBe(true);
     expect(result.deviceOwnerVerified).toBe(true);
     expect(result.recoveryKeyStored).toBe(true);
-    expect(fs.existsSync(recoveryKeyPath)).toBe(true);
+    expect(readStoredRecoveryKey(recoveryKeyPath)?.encodedPrivateKey).toBe(encoded);
   });
 
   it("fails recovery-key verification when the device lacks full cross-signing identity trust", async () => {
@@ -2133,7 +2143,7 @@ describe("MatrixClient crypto bootstrapping", () => {
     expect(result.deviceOwnerVerified).toBe(false);
     expect(result.verified).toBe(false);
     expect(result.recoveryKeyStored).toBe(true);
-    expect(fs.existsSync(recoveryKeyPath)).toBe(true);
+    expect(readStoredRecoveryKey(recoveryKeyPath)?.encodedPrivateKey).toBe(encoded);
   });
 
   it("does not persist a staged recovery key when backup usability came from existing material", async () => {
@@ -2202,10 +2212,8 @@ describe("MatrixClient crypto bootstrapping", () => {
     expect(result.success).toBe(false);
     expect(result.recoveryKeyAccepted).toBe(false);
     expect(result.backupUsable).toBe(true);
-    const persisted = JSON.parse(fs.readFileSync(recoveryKeyPath, "utf8")) as {
-      encodedPrivateKey?: string;
-    };
-    expect(persisted.encodedPrivateKey).toBe(previousEncoded);
+    const persisted = readStoredRecoveryKey(recoveryKeyPath);
+    expect(persisted?.encodedPrivateKey).toBe(previousEncoded);
   });
 
   it("does not persist a staged recovery key that secret storage did not validate", async () => {
@@ -2274,10 +2282,8 @@ describe("MatrixClient crypto bootstrapping", () => {
     expect(result.success).toBe(false);
     expect(result.recoveryKeyAccepted).toBe(false);
     expect(result.backupUsable).toBe(true);
-    const persisted = JSON.parse(fs.readFileSync(recoveryKeyPath, "utf8")) as {
-      encodedPrivateKey?: string;
-    };
-    expect(persisted.encodedPrivateKey).toBe(previousEncoded);
+    const persisted = readStoredRecoveryKey(recoveryKeyPath);
+    expect(persisted?.encodedPrivateKey).toBe(previousEncoded);
   });
 
   it("returns recovery-key diagnostics without bootstrapping when backup is already usable", async () => {
@@ -2456,10 +2462,8 @@ describe("MatrixClient crypto bootstrapping", () => {
 
     expect(result.success).toBe(false);
     expect(result.error).toContain("full Matrix identity trust");
-    const persisted = JSON.parse(fs.readFileSync(recoveryKeyPath, "utf8")) as {
-      encodedPrivateKey?: string;
-    };
-    expect(persisted.encodedPrivateKey).toBe(previousEncoded);
+    const persisted = readStoredRecoveryKey(recoveryKeyPath);
+    expect(persisted?.encodedPrivateKey).toBe(previousEncoded);
   });
 
   it("reports detailed room-key backup health", async () => {

--- a/extensions/matrix/src/matrix/sdk/idb-persistence.lock-order.test.ts
+++ b/extensions/matrix/src/matrix/sdk/idb-persistence.lock-order.test.ts
@@ -3,7 +3,9 @@ import "fake-indexeddb/auto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { resetPluginStateStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { installMatrixTestRuntime } from "../../test-runtime.js";
 import {
   computeMinimumRetryWindowMs,
   MATRIX_IDB_PERSIST_INTERVAL_MS,
@@ -41,6 +43,8 @@ describe("Matrix IndexedDB persistence lock ordering", () => {
   let tmpDir: string;
 
   beforeEach(async () => {
+    resetPluginStateStoreForTests();
+    installMatrixTestRuntime();
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "matrix-idb-lock-order-"));
     withFileLockMock.mockReset();
     withFileLockMock.mockImplementation(
@@ -51,10 +55,11 @@ describe("Matrix IndexedDB persistence lock ordering", () => {
 
   afterEach(async () => {
     await clearAllIndexedDbState({ databasePrefix: DATABASE_PREFIX });
+    resetPluginStateStoreForTests();
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it("captures the snapshot after the file lock is acquired", async () => {
+  it("captures the current snapshot into SQLite state", async () => {
     const snapshotPath = path.join(tmpDir, "crypto-idb-snapshot.json");
     await seedDatabase({
       name: cryptoDatabaseName,
@@ -62,45 +67,26 @@ describe("Matrix IndexedDB persistence lock ordering", () => {
       records: [{ key: "room-1", value: { session: "old-session" } }],
     });
 
-    withFileLockMock.mockImplementationOnce(async (_filePath, _options, fn) => {
-      await seedDatabase({
-        name: cryptoDatabaseName,
-        storeName: "sessions",
-        records: [{ key: "room-1", value: { session: "new-session" } }],
-      });
-      return await fn();
-    });
-
     await persistIdbToDisk({ snapshotPath, databasePrefix: DATABASE_PREFIX });
+    await clearAllIndexedDbState({ databasePrefix: DATABASE_PREFIX });
 
-    const data = JSON.parse(fs.readFileSync(snapshotPath, "utf8")) as Array<{
-      stores: Array<{
-        name: string;
-        records: Array<{ key: IDBValidKey; value: { session: string } }>;
-      }>;
-    }>;
-    const sessionsStore = data[0]?.stores.find((store) => store.name === "sessions");
-    expect(sessionsStore?.records).toEqual([{ key: "room-1", value: { session: "new-session" } }]);
+    await expect(restoreIdbFromDisk(snapshotPath)).resolves.toBe(true);
+    const dbs = await indexedDB.databases();
+    expect(dbs.map((entry) => entry.name)).toContain(cryptoDatabaseName);
   });
 
-  it("waits at least one persist interval before timing out on snapshot lock contention", async () => {
+  it("uses the long snapshot lock options when importing a legacy file", async () => {
     const snapshotPath = path.join(tmpDir, "crypto-idb-snapshot.json");
     const capturedOptions: CapturedLockOptions[] = [];
 
     withFileLockMock.mockImplementationOnce(async (_filePath, options) => {
       capturedOptions.push(options as CapturedLockOptions);
-      return 0;
-    });
-    await persistIdbToDisk({ snapshotPath, databasePrefix: DATABASE_PREFIX });
-
-    fs.writeFileSync(snapshotPath, "[]", "utf8");
-    withFileLockMock.mockImplementationOnce(async (_filePath, options) => {
-      capturedOptions.push(options as CapturedLockOptions);
       return false;
     });
+    fs.writeFileSync(snapshotPath, "[]", "utf8");
     await restoreIdbFromDisk(snapshotPath);
 
-    expect(capturedOptions).toHaveLength(2);
+    expect(capturedOptions).toHaveLength(1);
     for (const options of capturedOptions) {
       expect(computeMinimumRetryWindowMs(options.retries)).toBeGreaterThanOrEqual(
         MATRIX_IDB_PERSIST_INTERVAL_MS,

--- a/extensions/matrix/src/matrix/sdk/idb-persistence.test.ts
+++ b/extensions/matrix/src/matrix/sdk/idb-persistence.test.ts
@@ -3,11 +3,11 @@ import "fake-indexeddb/auto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import {
-  drainFileLockStateForTest,
-  resetFileLockStateForTest,
-} from "openclaw/plugin-sdk/file-lock";
+import { resetFileLockStateForTest } from "openclaw/plugin-sdk/file-lock";
+import { resetPluginStateStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getMatrixRuntime } from "../../runtime.js";
+import { installMatrixTestRuntime } from "../../test-runtime.js";
 import { persistIdbToDisk, restoreIdbFromDisk } from "./idb-persistence.js";
 import {
   clearAllIndexedDbState,
@@ -20,7 +20,6 @@ const DATABASE_PREFIX = "openclaw-matrix-persistence-test";
 const OTHER_DATABASE_PREFIX = "openclaw-matrix-persistence-other-test";
 const cryptoDatabaseName = `${DATABASE_PREFIX}::matrix-sdk-crypto`;
 const otherCryptoDatabaseName = `${OTHER_DATABASE_PREFIX}::matrix-sdk-crypto`;
-const EXPECTS_POSIX_PRIVATE_FILE_MODE = process.platform !== "win32";
 
 async function clearTestIndexedDbState(): Promise<void> {
   await clearAllIndexedDbState({ databasePrefix: DATABASE_PREFIX });
@@ -32,6 +31,8 @@ describe("Matrix IndexedDB persistence", () => {
   let warnSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(async () => {
+    resetPluginStateStoreForTests();
+    installMatrixTestRuntime();
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "matrix-idb-persist-"));
     warnSpy = vi.spyOn(LogService, "warn").mockImplementation(() => {});
     await clearTestIndexedDbState();
@@ -41,6 +42,7 @@ describe("Matrix IndexedDB persistence", () => {
     warnSpy.mockRestore();
     await clearTestIndexedDbState();
     resetFileLockStateForTest();
+    resetPluginStateStoreForTests();
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
@@ -61,12 +63,7 @@ describe("Matrix IndexedDB persistence", () => {
       snapshotPath,
       databasePrefix: DATABASE_PREFIX,
     });
-    expect(fs.existsSync(snapshotPath)).toBe(true);
-
-    const mode = fs.statSync(snapshotPath).mode & 0o777;
-    if (EXPECTS_POSIX_PRIVATE_FILE_MODE) {
-      expect(mode).toBe(0o600);
-    }
+    expect(fs.existsSync(snapshotPath)).toBe(false);
 
     await clearTestIndexedDbState();
 
@@ -81,6 +78,80 @@ describe("Matrix IndexedDB persistence", () => {
 
     const dbs = await indexedDB.databases();
     expect(dbs.map((entry) => entry.name)).not.toContain(otherCryptoDatabaseName);
+  });
+
+  it("imports and archives a legacy JSON snapshot during restore", async () => {
+    const snapshotPath = path.join(tmpDir, "crypto-idb-snapshot.json");
+    fs.writeFileSync(
+      snapshotPath,
+      JSON.stringify([
+        {
+          name: cryptoDatabaseName,
+          version: 1,
+          stores: [
+            {
+              name: "sessions",
+              keyPath: null,
+              autoIncrement: false,
+              indexes: [],
+              records: [{ key: "room-1", value: { session: "legacy" } }],
+            },
+          ],
+        },
+      ]),
+      "utf8",
+    );
+
+    const restored = await restoreIdbFromDisk(snapshotPath);
+    expect(restored).toBe(true);
+    expect(fs.existsSync(snapshotPath)).toBe(false);
+    expect(fs.existsSync(`${snapshotPath}.migrated`)).toBe(true);
+
+    await clearTestIndexedDbState();
+    await expect(restoreIdbFromDisk(snapshotPath)).resolves.toBe(true);
+    await expect(
+      readDatabaseRecords({
+        name: cryptoDatabaseName,
+        storeName: "sessions",
+      }),
+    ).resolves.toEqual([{ key: "room-1", value: { session: "legacy" } }]);
+  });
+
+  it("restores a valid legacy JSON snapshot when SQLite import fails", async () => {
+    const snapshotPath = path.join(tmpDir, "crypto-idb-snapshot.json");
+    fs.writeFileSync(
+      snapshotPath,
+      JSON.stringify([
+        {
+          name: cryptoDatabaseName,
+          version: 1,
+          stores: [
+            {
+              name: "sessions",
+              keyPath: null,
+              autoIncrement: false,
+              indexes: [],
+              records: [{ key: "room-1", value: { session: "legacy" } }],
+            },
+          ],
+        },
+      ]),
+      "utf8",
+    );
+    vi.spyOn(getMatrixRuntime().state, "openSyncKeyedStore").mockImplementation(() => {
+      throw new Error("sqlite unavailable");
+    });
+
+    const restored = await restoreIdbFromDisk(snapshotPath);
+
+    expect(restored).toBe(true);
+    expect(fs.existsSync(snapshotPath)).toBe(true);
+    await expect(
+      readDatabaseRecords({
+        name: cryptoDatabaseName,
+        storeName: "sessions",
+      }),
+    ).resolves.toEqual([{ key: "room-1", value: { session: "legacy" } }]);
   });
 
   it("returns false and logs a warning for malformed snapshots", async () => {
@@ -114,7 +185,7 @@ describe("Matrix IndexedDB persistence", () => {
     expect(warnSpy).not.toHaveBeenCalled();
   });
 
-  it("serializes concurrent persist operations via file lock", async () => {
+  it("handles concurrent persist operations in SQLite state", async () => {
     const snapshotPath = path.join(tmpDir, "concurrent-persist.json");
     await seedDatabase({
       name: cryptoDatabaseName,
@@ -127,44 +198,29 @@ describe("Matrix IndexedDB persistence", () => {
       persistIdbToDisk({ snapshotPath, databasePrefix: DATABASE_PREFIX }),
     ]);
 
-    expect(fs.existsSync(snapshotPath)).toBe(true);
-
-    const data = JSON.parse(fs.readFileSync(snapshotPath, "utf8"));
-    expect(Array.isArray(data)).toBe(true);
-    expect(data.length).toBe(1);
-  });
-
-  it("releases lock after persist completes", async () => {
-    const snapshotPath = path.join(tmpDir, "lock-release.json");
-    await seedDatabase({
-      name: cryptoDatabaseName,
-      storeName: "sessions",
-      records: [{ key: "room-1", value: { session: "abc123" } }],
-    });
-
-    await persistIdbToDisk({ snapshotPath, databasePrefix: DATABASE_PREFIX });
-
-    const lockPath = `${snapshotPath}.lock`;
-    expect(fs.existsSync(lockPath)).toBe(false);
-    await drainFileLockStateForTest();
-  });
-
-  it("releases lock after restore completes", async () => {
-    const snapshotPath = path.join(tmpDir, "lock-release-restore.json");
-    await seedDatabase({
-      name: cryptoDatabaseName,
-      storeName: "sessions",
-      records: [{ key: "room-1", value: { session: "abc123" } }],
-    });
-
-    await persistIdbToDisk({ snapshotPath, databasePrefix: DATABASE_PREFIX });
+    expect(fs.existsSync(snapshotPath)).toBe(false);
     await clearTestIndexedDbState();
-    await drainFileLockStateForTest();
+    await expect(restoreIdbFromDisk(snapshotPath)).resolves.toBe(true);
+    await expect(
+      readDatabaseRecords({
+        name: cryptoDatabaseName,
+        storeName: "sessions",
+      }),
+    ).resolves.toEqual([{ key: "room-1", value: { session: "abc123" } }]);
+  });
 
-    await restoreIdbFromDisk(snapshotPath);
+  it("archives an existing legacy snapshot file after persist", async () => {
+    const snapshotPath = path.join(tmpDir, "persist-archives-legacy.json");
+    fs.writeFileSync(snapshotPath, "[]", "utf8");
+    await seedDatabase({
+      name: cryptoDatabaseName,
+      storeName: "sessions",
+      records: [{ key: "room-1", value: { session: "abc123" } }],
+    });
 
-    const lockPath = `${snapshotPath}.lock`;
-    expect(fs.existsSync(lockPath)).toBe(false);
-    await drainFileLockStateForTest();
+    await persistIdbToDisk({ snapshotPath, databasePrefix: DATABASE_PREFIX });
+
+    expect(fs.existsSync(snapshotPath)).toBe(false);
+    expect(fs.existsSync(`${snapshotPath}.migrated`)).toBe(true);
   });
 });

--- a/extensions/matrix/src/matrix/sdk/idb-persistence.ts
+++ b/extensions/matrix/src/matrix/sdk/idb-persistence.ts
@@ -3,6 +3,11 @@ import fs from "node:fs";
 import path from "node:path";
 import { indexedDB as fakeIndexedDB } from "fake-indexeddb";
 import { withFileLock } from "openclaw/plugin-sdk/file-lock";
+import {
+  MATRIX_IDB_SNAPSHOT_FILENAME,
+  readMatrixIdbSnapshotJson,
+  writeMatrixIdbSnapshotJson,
+} from "../crypto-state-store.js";
 import { MATRIX_IDB_SNAPSHOT_LOCK_OPTIONS } from "./idb-persistence-lock.js";
 import { LogService } from "./logger.js";
 
@@ -226,23 +231,63 @@ function resolveDefaultIdbSnapshotPath(): string {
 export async function restoreIdbFromDisk(snapshotPath?: string): Promise<boolean> {
   const candidatePaths = snapshotPath ? [snapshotPath] : [resolveDefaultIdbSnapshotPath()];
   for (const resolvedPath of candidatePaths) {
-    if (!fs.existsSync(resolvedPath)) {
-      continue;
-    }
+    const storageRootDir = path.dirname(resolvedPath);
     try {
       const restored = await withFileLock(
         resolvedPath,
         MATRIX_IDB_SNAPSHOT_LOCK_OPTIONS,
         async () => {
+          try {
+            const storedSnapshotJson = readMatrixIdbSnapshotJson(storageRootDir);
+            if (storedSnapshotJson) {
+              const snapshot = parseSnapshotPayload(storedSnapshotJson);
+              if (snapshot) {
+                await restoreIndexedDatabases(snapshot);
+                LogService.info(
+                  "IdbPersistence",
+                  `Restored ${snapshot.length} IndexedDB database(s) from Matrix SQLite state`,
+                );
+                return true;
+              }
+            }
+          } catch (err) {
+            LogService.warn(
+              "IdbPersistence",
+              "Failed to restore IndexedDB snapshot from SQLite:",
+              err,
+            );
+          }
+
+          if (!fs.existsSync(resolvedPath)) {
+            return false;
+          }
           const data = fs.readFileSync(resolvedPath, "utf8");
           const snapshot = parseSnapshotPayload(data);
           if (!snapshot) {
             return false;
           }
+          let migratedToSqlite = false;
+          try {
+            writeMatrixIdbSnapshotJson({
+              storageRootDir,
+              snapshotJson: data,
+              databaseCount: snapshot.length,
+            });
+            archiveLegacyIdbSnapshotFile(resolvedPath);
+            migratedToSqlite = true;
+          } catch (err) {
+            LogService.warn(
+              "IdbPersistence",
+              `Failed to migrate IndexedDB snapshot to SQLite from ${resolvedPath}:`,
+              err,
+            );
+          }
           await restoreIndexedDatabases(snapshot);
           LogService.info(
             "IdbPersistence",
-            `Restored ${snapshot.length} IndexedDB database(s) from ${resolvedPath}`,
+            migratedToSqlite
+              ? `Migrated and restored ${snapshot.length} IndexedDB database(s) from ${resolvedPath}`
+              : `Restored ${snapshot.length} IndexedDB database(s) from legacy snapshot ${resolvedPath}`,
           );
           return true;
         },
@@ -277,8 +322,12 @@ export async function persistIdbToDisk(params?: {
         if (snapshot.length === 0) {
           return 0;
         }
-        fs.writeFileSync(snapshotPath, JSON.stringify(snapshot));
-        fs.chmodSync(snapshotPath, 0o600);
+        writeMatrixIdbSnapshotJson({
+          storageRootDir: path.dirname(snapshotPath),
+          snapshotJson: JSON.stringify(snapshot),
+          databaseCount: snapshot.length,
+        });
+        archiveLegacyIdbSnapshotFile(snapshotPath);
         return snapshot.length;
       },
     );
@@ -287,11 +336,39 @@ export async function persistIdbToDisk(params?: {
     }
     LogService.debug(
       "IdbPersistence",
-      `Persisted ${persistedCount} IndexedDB database(s) to ${snapshotPath}`,
+      `Persisted ${persistedCount} IndexedDB database(s) to Matrix SQLite state`,
     );
   } catch (err) {
     LogService.warn("IdbPersistence", "Failed to persist IndexedDB snapshot:", err);
   }
+}
+
+export async function readLegacyMatrixIdbSnapshotState(
+  storageRootDir: string,
+): Promise<IdbDatabaseSnapshot[] | null> {
+  const snapshotPath = path.join(storageRootDir, MATRIX_IDB_SNAPSHOT_FILENAME);
+  if (!fs.existsSync(snapshotPath)) {
+    return null;
+  }
+  try {
+    return await withFileLock(snapshotPath, MATRIX_IDB_SNAPSHOT_LOCK_OPTIONS, async () => {
+      const snapshot = parseSnapshotPayload(fs.readFileSync(snapshotPath, "utf8"));
+      return snapshot;
+    });
+  } catch {
+    return null;
+  }
+}
+
+function archiveLegacyIdbSnapshotFile(snapshotPath: string): void {
+  if (!fs.existsSync(snapshotPath)) {
+    return;
+  }
+  const archivedPath = `${snapshotPath}.migrated`;
+  if (fs.existsSync(archivedPath)) {
+    return;
+  }
+  fs.renameSync(snapshotPath, archivedPath);
 }
 
 function toLintErrorObject(value: unknown, fallbackMessage: string): Error {

--- a/extensions/matrix/src/matrix/sdk/recovery-key-store.test.ts
+++ b/extensions/matrix/src/matrix/sdk/recovery-key-store.test.ts
@@ -3,7 +3,14 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { encodeRecoveryKey } from "matrix-js-sdk/lib/crypto-api/recovery-key.js";
+import { resetPluginStateStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getMatrixRuntime } from "../../runtime.js";
+import { installMatrixTestRuntime } from "../../test-runtime.js";
+import {
+  readMatrixRecoveryKeyState,
+  readMatrixRecoveryKeyStateForPath,
+} from "../crypto-state-store.js";
 import { MatrixRecoveryKeyStore } from "./recovery-key-store.js";
 import type { MatrixCryptoBootstrapApi, MatrixSecretStorageStatus } from "./types.js";
 
@@ -11,8 +18,6 @@ function createTempRecoveryKeyPath(): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "matrix-recovery-key-store-"));
   return path.join(dir, "recovery-key.json");
 }
-
-const EXPECTS_POSIX_PRIVATE_FILE_MODE = process.platform !== "win32";
 
 function createGeneratedRecoveryKey(params: {
   keyId: string;
@@ -83,6 +88,14 @@ function expectRecoveryKeySummary(
   }
 }
 
+function readStoredRecoveryKey(recoveryKeyPath: string) {
+  const state = readMatrixRecoveryKeyState(path.dirname(recoveryKeyPath));
+  if (!state) {
+    throw new Error("expected stored recovery key state");
+  }
+  return state;
+}
+
 async function runSecretStorageBootstrapScenario(params: {
   generated: ReturnType<typeof createGeneratedRecoveryKey>;
   status: MatrixSecretStorageStatus;
@@ -114,6 +127,8 @@ async function runSecretStorageBootstrapScenario(params: {
 describe("MatrixRecoveryKeyStore", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    resetPluginStateStoreForTests();
+    installMatrixTestRuntime();
   });
 
   it("loads a stored recovery key for requested secret-storage keys", async () => {
@@ -130,6 +145,8 @@ describe("MatrixRecoveryKeyStore", () => {
     );
 
     const store = new MatrixRecoveryKeyStore(recoveryKeyPath);
+    expect(fs.existsSync(recoveryKeyPath)).toBe(false);
+    expect(fs.existsSync(`${recoveryKeyPath}.migrated`)).toBe(true);
     const callbacks = store.buildCryptoCallbacks();
     const resolved = await callbacks.getSecretStorageKey?.(
       { keys: { SSSS: { name: "test" } } },
@@ -140,7 +157,64 @@ describe("MatrixRecoveryKeyStore", () => {
     expect(Array.from(resolved?.[1] ?? [])).toEqual([1, 2, 3, 4]);
   });
 
-  it("persists cached secret-storage keys with secure file permissions", () => {
+  it("keeps a readable legacy recovery key usable when SQLite migration fails", async () => {
+    const recoveryKeyPath = createTempRecoveryKeyPath();
+    fs.writeFileSync(
+      recoveryKeyPath,
+      JSON.stringify({
+        version: 1,
+        createdAt: new Date().toISOString(),
+        keyId: "SSSS",
+        privateKeyBase64: Buffer.from([1, 2, 3, 4]).toString("base64"),
+      }),
+      "utf8",
+    );
+    vi.spyOn(getMatrixRuntime().state, "openSyncKeyedStore").mockImplementation(() => {
+      throw new Error("sqlite unavailable");
+    });
+
+    const store = new MatrixRecoveryKeyStore(recoveryKeyPath);
+    const callbacks = store.buildCryptoCallbacks();
+    const resolved = await callbacks.getSecretStorageKey?.(
+      { keys: { SSSS: { name: "test" } } },
+      "m.cross_signing.master",
+    );
+
+    expect(resolved?.[0]).toBe("SSSS");
+    expect(Array.from(resolved?.[1] ?? [])).toEqual([1, 2, 3, 4]);
+    expect(fs.existsSync(recoveryKeyPath)).toBe(true);
+  });
+
+  it("migrates a custom legacy recovery key filename without colliding with the default key", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "matrix-recovery-key-store-"));
+    const recoveryKeyPath = path.join(dir, "recovery.key");
+    fs.writeFileSync(
+      recoveryKeyPath,
+      JSON.stringify({
+        version: 1,
+        createdAt: new Date().toISOString(),
+        keyId: "CUSTOM",
+        privateKeyBase64: Buffer.from([4, 3, 2, 1]).toString("base64"),
+      }),
+      "utf8",
+    );
+
+    const store = new MatrixRecoveryKeyStore(recoveryKeyPath);
+    const callbacks = store.buildCryptoCallbacks();
+    const resolved = await callbacks.getSecretStorageKey?.(
+      { keys: { CUSTOM: { name: "custom" } } },
+      "m.cross_signing.master",
+    );
+
+    expect(resolved?.[0]).toBe("CUSTOM");
+    expect(Array.from(resolved?.[1] ?? [])).toEqual([4, 3, 2, 1]);
+    expect(readMatrixRecoveryKeyState(dir)).toBeNull();
+    expect(readMatrixRecoveryKeyStateForPath(recoveryKeyPath)?.keyId).toBe("CUSTOM");
+    expect(fs.existsSync(recoveryKeyPath)).toBe(false);
+    expect(fs.existsSync(`${recoveryKeyPath}.migrated`)).toBe(true);
+  });
+
+  it("persists cached secret-storage keys in SQLite state", () => {
     const recoveryKeyPath = createTempRecoveryKeyPath();
     const store = new MatrixRecoveryKeyStore(recoveryKeyPath);
     const callbacks = store.buildCryptoCallbacks();
@@ -153,17 +227,10 @@ describe("MatrixRecoveryKeyStore", () => {
       new Uint8Array([9, 8, 7]),
     );
 
-    const saved = JSON.parse(fs.readFileSync(recoveryKeyPath, "utf8")) as {
-      keyId?: string;
-      privateKeyBase64?: string;
-    };
+    expect(fs.existsSync(recoveryKeyPath)).toBe(false);
+    const saved = readStoredRecoveryKey(recoveryKeyPath);
     expect(saved.keyId).toBe("KEY123");
     expect(saved.privateKeyBase64).toBe(Buffer.from([9, 8, 7]).toString("base64"));
-
-    const mode = fs.statSync(recoveryKeyPath).mode & 0o777;
-    if (EXPECTS_POSIX_PRIVATE_FILE_MODE) {
-      expect(mode).toBe(0o600);
-    }
   });
 
   it("creates and persists a recovery key when secret storage is missing", async () => {
@@ -312,10 +379,7 @@ describe("MatrixRecoveryKeyStore", () => {
 
     expect(summary.keyId).toBe("SSSSKEY");
     expect(summary.encodedPrivateKey).toBe(encoded);
-    const persisted = JSON.parse(fs.readFileSync(recoveryKeyPath, "utf8")) as {
-      privateKeyBase64?: string;
-      keyId?: string;
-    };
+    const persisted = readStoredRecoveryKey(recoveryKeyPath);
     expect(persisted.keyId).toBe("SSSSKEY");
     expect(
       Buffer.from(persisted.privateKeyBase64 ?? "", "base64").equals(
@@ -348,10 +412,7 @@ describe("MatrixRecoveryKeyStore", () => {
 
     store.commitStagedRecoveryKey({ keyId: "SSSSKEY" });
 
-    const persisted = JSON.parse(fs.readFileSync(recoveryKeyPath, "utf8")) as {
-      keyId?: string;
-      encodedPrivateKey?: string;
-    };
+    const persisted = readStoredRecoveryKey(recoveryKeyPath);
     expect(persisted.keyId).toBe("SSSSKEY");
     expect(persisted.encodedPrivateKey).toBe(encoded);
   });
@@ -397,10 +458,7 @@ describe("MatrixRecoveryKeyStore", () => {
 
     await store.bootstrapSecretStorageWithRecoveryKey(crypto);
 
-    const persisted = JSON.parse(fs.readFileSync(recoveryKeyPath, "utf8")) as {
-      keyId?: string;
-      encodedPrivateKey?: string;
-    };
+    const persisted = readStoredRecoveryKey(recoveryKeyPath);
     expect(persisted.keyId).toBe("OLD");
     expect(persisted.encodedPrivateKey).toBe(storedEncoded);
   });
@@ -448,10 +506,7 @@ describe("MatrixRecoveryKeyStore", () => {
       forceNewSecretStorage: true,
     });
 
-    const persisted = JSON.parse(fs.readFileSync(recoveryKeyPath, "utf8")) as {
-      keyId?: string;
-      encodedPrivateKey?: string;
-    };
+    const persisted = readStoredRecoveryKey(recoveryKeyPath);
     expect(createRecoveryKeyFromPassphrase).toHaveBeenCalledTimes(1);
     expect(persisted.keyId).toBe("NEW");
     expect(persisted.encodedPrivateKey).toBe(freshEncoded);

--- a/extensions/matrix/src/matrix/sdk/recovery-key-store.ts
+++ b/extensions/matrix/src/matrix/sdk/recovery-key-store.ts
@@ -1,6 +1,12 @@
+import path from "node:path";
 // Matrix plugin module implements recovery key store behavior.
 import { decodeRecoveryKey } from "matrix-js-sdk/lib/crypto-api/recovery-key.js";
-import { loadJsonFile, saveJsonFile } from "openclaw/plugin-sdk/json-store";
+import {
+  migrateLegacyMatrixRecoveryKeyFilePathToStore,
+  readLegacyMatrixRecoveryKeyFile,
+  readMatrixRecoveryKeyStateForPath,
+  writeMatrixRecoveryKeyStateForPath,
+} from "../crypto-state-store.js";
 import { formatMatrixErrorMessage, formatMatrixErrorReason } from "../errors.js";
 import { LogService } from "./logger.js";
 import type {
@@ -36,8 +42,22 @@ export class MatrixRecoveryKeyStore {
   private stagedRecoveryKey: MatrixStoredRecoveryKey | null = null;
   private stagedRecoveryKeyUsed = false;
   private readonly stagedCacheKeyIds = new Set<string>();
+  private readonly storageRootDir?: string;
+  private readonly recoveryKeyPath?: string;
+  private legacyRecoveryKeyPathOnMigrationFailure?: string;
 
-  constructor(private readonly recoveryKeyPath?: string) {}
+  constructor(recoveryKeyPath?: string) {
+    this.recoveryKeyPath = recoveryKeyPath;
+    this.storageRootDir = recoveryKeyPath ? path.dirname(recoveryKeyPath) : undefined;
+    if (this.recoveryKeyPath) {
+      try {
+        migrateLegacyMatrixRecoveryKeyFilePathToStore(this.recoveryKeyPath);
+      } catch (err) {
+        this.legacyRecoveryKeyPathOnMigrationFailure = this.recoveryKeyPath;
+        LogService.warn("MatrixClientLite", "Failed to migrate Matrix recovery key state:", err);
+      }
+    }
+  }
 
   buildCryptoCallbacks(): MatrixCryptoCallbacks {
     return {
@@ -338,10 +358,10 @@ export class MatrixRecoveryKeyStore {
       });
     }
 
-    if (generatedRecoveryKey && this.recoveryKeyPath) {
+    if (generatedRecoveryKey && this.storageRootDir) {
       LogService.warn(
         "MatrixClientLite",
-        `Generated Matrix recovery key and saved it to ${this.recoveryKeyPath}. Keep this file secure.`,
+        "Generated Matrix recovery key and saved it to Matrix SQLite state. Keep the displayed recovery key secure.",
       );
     }
   }
@@ -399,33 +419,18 @@ export class MatrixRecoveryKeyStore {
       return null;
     }
     try {
-      const parsed = loadJsonFile<Partial<MatrixStoredRecoveryKey>>(this.recoveryKeyPath);
-      if (
-        parsed?.version !== 1 ||
-        typeof parsed.createdAt !== "string" ||
-        typeof parsed.privateKeyBase64 !== "string" || // pragma: allowlist secret
-        !parsed.privateKeyBase64.trim()
-      ) {
-        return null;
+      const stored = readMatrixRecoveryKeyStateForPath(this.recoveryKeyPath);
+      if (stored) {
+        return stored;
       }
-      return {
-        version: 1,
-        createdAt: parsed.createdAt,
-        keyId: typeof parsed.keyId === "string" ? parsed.keyId : null,
-        encodedPrivateKey:
-          typeof parsed.encodedPrivateKey === "string" ? parsed.encodedPrivateKey : undefined,
-        privateKeyBase64: parsed.privateKeyBase64,
-        keyInfo:
-          parsed.keyInfo && typeof parsed.keyInfo === "object"
-            ? {
-                passphrase: parsed.keyInfo.passphrase,
-                name: typeof parsed.keyInfo.name === "string" ? parsed.keyInfo.name : undefined,
-              }
-            : undefined,
-      };
     } catch {
-      return null;
+      // If the SQLite migration failed during construction, keep the readable
+      // legacy file usable for this run and leave it unarchived for retry.
     }
+    if (this.legacyRecoveryKeyPathOnMigrationFailure) {
+      return readLegacyMatrixRecoveryKeyFile(this.legacyRecoveryKeyPathOnMigrationFailure);
+    }
+    return null;
   }
 
   private saveRecoveryKeyToDisk(params: MatrixGeneratedSecretStorageKey): void {
@@ -446,7 +451,10 @@ export class MatrixRecoveryKeyStore {
             }
           : undefined,
       };
-      saveJsonFile(this.recoveryKeyPath, payload);
+      writeMatrixRecoveryKeyStateForPath({
+        recoveryKeyPath: this.recoveryKeyPath,
+        payload,
+      });
     } catch (err) {
       LogService.warn("MatrixClientLite", "Failed to persist recovery key:", err);
     }


### PR DESCRIPTION
## Summary

- Move Matrix recovery-key, IndexedDB snapshot, and legacy crypto migration sidecars into Matrix plugin-state SQLite.
- Add doctor migrations that import/archive the old JSON sidecars.
- Keep legacy JSON usable only during failed migration paths so upgrade recovery does not silently drop readable crypto material.
- Update startup migration, root scoring, restore locking, and doctor preview wording for the SQLite store.

## Verification

- `git diff --check`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/matrix/doctor-contract-api.ts extensions/matrix/doctor-contract-api.test.ts extensions/matrix/src/doctor.ts extensions/matrix/src/doctor.test.ts extensions/matrix/src/legacy-crypto.ts extensions/matrix/src/legacy-crypto.test.ts extensions/matrix/src/matrix/client/storage.ts extensions/matrix/src/matrix/client/storage.test.ts extensions/matrix/src/matrix/crypto-state-store.ts extensions/matrix/src/matrix/monitor/legacy-crypto-restore.ts extensions/matrix/src/matrix/monitor/legacy-crypto-restore.test.ts extensions/matrix/src/matrix/sdk/idb-persistence.ts extensions/matrix/src/matrix/sdk/idb-persistence.test.ts extensions/matrix/src/matrix/sdk/idb-persistence.lock-order.test.ts extensions/matrix/src/matrix/sdk/recovery-key-store.ts extensions/matrix/src/matrix/sdk/recovery-key-store.test.ts extensions/matrix/src/matrix/sdk.test.ts`
- `pnpm tsgo:extensions`
- `node scripts/run-vitest.mjs extensions/matrix/doctor-contract-api.test.ts extensions/matrix/src/doctor.test.ts extensions/matrix/src/matrix/sdk/idb-persistence.test.ts extensions/matrix/src/matrix/sdk/idb-persistence.lock-order.test.ts extensions/matrix/src/matrix/sdk/recovery-key-store.test.ts extensions/matrix/src/legacy-crypto.test.ts extensions/matrix/src/matrix/monitor/legacy-crypto-restore.test.ts extensions/matrix/src/matrix/client/storage.test.ts extensions/matrix/src/matrix/sdk.test.ts extensions/matrix/src/matrix/client/create-client.test.ts extensions/matrix/src/startup-maintenance.test.ts extensions/matrix/src/matrix/client/file-sync-store.test.ts extensions/qa-matrix/src/runners/contract/scenarios.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local` clean, no accepted/actionable findings

## Known proof gap

- `pnpm check:changed` did not run because the local Crabbox binary is 0.15.0 and Testbox delegation requires Crabbox >= 0.22.0.
