### PR TITLE
fix: restrict session history to owning agent

### DIFF
--- a/src/agents/openclaw-tools.sessions-visibility.test.ts
+++ b/src/agents/openclaw-tools.sessions-visibility.test.ts
@@ -17,9 +17,9 @@ vi.mock("../config/config.js", async () => {
     resolveGatewayPort: () => 18789,
   };
 });
-function getSessionsHistoryTool(options?: { sandboxed?: boolean }) {
+function getSessionsHistoryTool(options?: { agentSessionKey?: string; sandboxed?: boolean }) {
   return createSessionsHistoryTool({
-    agentSessionKey: "main",
+    agentSessionKey: options?.agentSessionKey ?? "main",
     sandboxed: options?.sandboxed,
     config: mockConfig as never,
     callGateway: (opts: unknown) => callGatewayMock(opts),
@@ -110,5 +110,138 @@ describe("sessions tools visibility", () => {
       sessionKey: "agent:other:main",
     });
     expect((denied.details as { status?: string }).status).toBe("forbidden");
+  });
+
+  it("denies cmo reading rodrigo sessions_history even with all visibility and a2a enabled", async () => {
+    mockConfig = {
+      session: { mainKey: "main", scope: "per-sender" },
+      tools: { sessions: { visibility: "all" }, agentToAgent: { enabled: true, allow: ["*"] } },
+    };
+    mockGatewayWithHistory((req) => {
+      if (req.method === "sessions.resolve") {
+        const key = typeof req.params?.key === "string" ? req.params.key : "";
+        return { key };
+      }
+      return undefined;
+    });
+
+    const tool = getSessionsHistoryTool({ agentSessionKey: "agent:cmo:main" });
+    const denied = await tool.execute("call-cmo-rodrigo", {
+      sessionKey: "agent:rodrigo:main",
+    });
+
+    expect((denied.details as { status?: string }).status).toBe("forbidden");
+    expect((denied.details as { error?: string }).error).toContain(
+      "Only James/main OOA may read other agents' histories",
+    );
+    expect(
+      callGatewayMock.mock.calls.some(
+        (call) => (call[0] as { method?: string }).method === "chat.history",
+      ),
+    ).toBe(false);
+  });
+
+  it("denies rodrigo reading cmo sessions_history even with all visibility and a2a enabled", async () => {
+    mockConfig = {
+      session: { mainKey: "main", scope: "per-sender" },
+      tools: { sessions: { visibility: "all" }, agentToAgent: { enabled: true, allow: ["*"] } },
+    };
+    mockGatewayWithHistory((req) => {
+      if (req.method === "sessions.resolve") {
+        const key = typeof req.params?.key === "string" ? req.params.key : "";
+        return { key };
+      }
+      return undefined;
+    });
+
+    const tool = getSessionsHistoryTool({ agentSessionKey: "agent:rodrigo:main" });
+    const denied = await tool.execute("call-rodrigo-cmo", {
+      sessionKey: "agent:cmo:main",
+    });
+
+    expect((denied.details as { status?: string }).status).toBe("forbidden");
+    expect(
+      callGatewayMock.mock.calls.some(
+        (call) => (call[0] as { method?: string }).method === "chat.history",
+      ),
+    ).toBe(false);
+  });
+
+  it("allows same-agent sessions_history for the caller's own agent", async () => {
+    mockConfig = {
+      session: { mainKey: "main", scope: "per-sender" },
+      tools: { sessions: { visibility: "all" }, agentToAgent: { enabled: true, allow: ["*"] } },
+    };
+    mockGatewayWithHistory((req) => {
+      if (req.method === "sessions.resolve") {
+        const key = typeof req.params?.key === "string" ? req.params.key : "";
+        return { key };
+      }
+      return undefined;
+    });
+
+    const tool = getSessionsHistoryTool({ agentSessionKey: "agent:cmo:main" });
+    const allowed = await tool.execute("call-cmo-own", {
+      sessionKey: "agent:cmo:telegram:direct:428565749",
+    });
+
+    expect((allowed.details as { sessionKey?: string }).sessionKey).toBe(
+      "agent:cmo:telegram:direct:428565749",
+    );
+    expect(
+      callGatewayMock.mock.calls.some(
+        (call) => (call[0] as { method?: string }).method === "chat.history",
+      ),
+    ).toBe(true);
+  });
+
+  it("allows James/main OOA to read another agent sessions_history", async () => {
+    mockConfig = {
+      session: { mainKey: "main", scope: "per-sender" },
+      tools: { sessions: { visibility: "all" }, agentToAgent: { enabled: true, allow: ["*"] } },
+    };
+    mockGatewayWithHistory((req) => {
+      if (req.method === "sessions.resolve") {
+        const key = typeof req.params?.key === "string" ? req.params.key : "";
+        return { key };
+      }
+      return undefined;
+    });
+
+    const tool = getSessionsHistoryTool({ agentSessionKey: "agent:main:main" });
+    const allowed = await tool.execute("call-main-cmo", {
+      sessionKey: "agent:cmo:main",
+    });
+
+    expect((allowed.details as { sessionKey?: string }).sessionKey).toBe("agent:cmo:main");
+  });
+
+  it("denies elevated non-OOA sessions_history after resolving another agent sessionId", async () => {
+    mockConfig = {
+      session: { mainKey: "main", scope: "per-sender" },
+      tools: { sessions: { visibility: "all" }, agentToAgent: { enabled: true, allow: ["*"] } },
+      agents: { defaults: { sandbox: { sessionToolsVisibility: "all" } } },
+    };
+    mockGatewayWithHistory((req) => {
+      if (req.method === "sessions.resolve" && req.params?.sessionId === "sess-rodrigo") {
+        return { key: "agent:rodrigo:main" };
+      }
+      return undefined;
+    });
+
+    const tool = getSessionsHistoryTool({
+      agentSessionKey: "agent:cmo:main",
+      sandboxed: false,
+    });
+    const denied = await tool.execute("call-cmo-rodrigo-session-id", {
+      sessionKey: "sess-rodrigo",
+    });
+
+    expect((denied.details as { status?: string }).status).toBe("forbidden");
+    expect(
+      callGatewayMock.mock.calls.some(
+        (call) => (call[0] as { method?: string }).method === "chat.history",
+      ),
+    ).toBe(false);
   });
 });

--- a/src/agents/tools/sessions-history-tool.ts
+++ b/src/agents/tools/sessions-history-tool.ts
@@ -5,6 +5,7 @@ import { callGateway } from "../../gateway/call.js";
 import { capArrayByJsonBytes } from "../../gateway/session-utils.fs.js";
 import { jsonUtf8Bytes } from "../../infra/json-utf8-bytes.js";
 import { redactToolPayloadText } from "../../logging/redact.js";
+import { DEFAULT_AGENT_ID, resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import { readStringValue } from "../../shared/string-coerce.js";
 import { truncateUtf16Safe } from "../../utils.js";
 import {
@@ -177,6 +178,23 @@ function enforceSessionsHistoryHardCap(params: {
   return { items: placeholder, bytes: jsonUtf8Bytes(placeholder), hardCapped: true };
 }
 
+function enforceSessionHistoryAgentBoundary(params: {
+  requesterSessionKey: string;
+  targetSessionKey: string;
+}): { allowed: true } | { allowed: false; status: "forbidden"; error: string } {
+  const requesterAgentId = resolveAgentIdFromSessionKey(params.requesterSessionKey);
+  const targetAgentId = resolveAgentIdFromSessionKey(params.targetSessionKey);
+  if (requesterAgentId === targetAgentId || requesterAgentId === DEFAULT_AGENT_ID) {
+    return { allowed: true };
+  }
+  return {
+    allowed: false,
+    status: "forbidden",
+    error:
+      "Session history is restricted to the caller's own agent. Only James/main OOA may read other agents' histories.",
+  };
+}
+
 export function createSessionsHistoryTool(opts?: {
   agentSessionKey?: string;
   sandboxed?: boolean;
@@ -227,6 +245,17 @@ export function createSessionsHistoryTool(opts?: {
       // From here on, use the canonical key (sessionId inputs already resolved).
       const resolvedKey = visibleSession.key;
       const displayKey = visibleSession.displayKey;
+
+      const agentBoundary = enforceSessionHistoryAgentBoundary({
+        requesterSessionKey: effectiveRequesterKey,
+        targetSessionKey: resolvedKey,
+      });
+      if (!agentBoundary.allowed) {
+        return jsonResult({
+          status: agentBoundary.status,
+          error: agentBoundary.error,
+        });
+      }
 
       const a2aPolicy = createAgentToAgentPolicy(cfg);
       const visibility = resolveEffectiveSessionToolsVisibility({


### PR DESCRIPTION
## Summary
- Restrict sessions_history so non-OOA agents can only read histories for their own agentId.
- Keep James/main OOA as the only cross-agent exception.
- Add regression coverage for cross-agent denial, same-agent access, James access, and foreign sessionId denial before chat.history.

## Verification
- node scripts/run-vitest.mjs run --config test/vitest/vitest.unit.config.ts src/agents/openclaw-tools.sessions-visibility.test.ts: OK
- node scripts/run-vitest.mjs run --config test/vitest/vitest.unit.config.ts src/agents/openclaw-tools.sessions.test.ts: OK
- pnpm exec oxfmt --check src/agents/tools/sessions-history-tool.ts src/agents/openclaw-tools.sessions-visibility.test.ts: OK
- git diff --check: OK
- pnpm exec oxlint src/agents/tools/sessions-history-tool.ts src/agents/openclaw-tools.sessions-visibility.test.ts: OK
- pnpm tsgo:core:test: OK
- pnpm build: not counted as OK because it was manually interrupted after assets, tsdown, bootstrap import guard and runtime-postbuild; pnpm build:plugin-sdk:dts was run separately and passed

## Guardrails
- No production/runtime install, no Gateway restart, no deploy, no workflow rerun, no merge.