### PR TITLE
Create cron-main-channel-targeting.md

### DIFF
--- a/proposals/cron-main-channel-targeting.md
+++ b/proposals/cron-main-channel-targeting.md
@@ -1,0 +1,11 @@
+Subject: Cron job session routing — channel delivery ambiguity with multi-channel agents
+When a cron job runs in sessionTarget: isolated mode, the resulting message is sent to a Slack channel but the message is never injected back into an active agent session. This means users cannot reply to the cron output and have the agent treat it as a continuation of that conversation — the reply simply goes unhandled or falls into a different session context.
+isolated mode does support a to: field in the cron delivery config, which guarantees the output is routed to the correct channel. This makes channel delivery predictable.
+Switching to sessionTarget: main resolves the reply continuity issue, but introduces a different problem: main mode does not support a to: field. For agents bound to multiple Slack channels, there is no mechanism to guarantee the cron output is delivered to the intended channel. The delivery channel appears to depend on whichever channel last had activity in the main session, making it non-deterministic.
+This creates a forced tradeoff with no clean solution:
+• isolated → guaranteed channel delivery, but no reply continuity
+• main → reply continuity, but no channel targeting (to: not supported)
+Questions:
+1. Is there a plan to support to: (or equivalent channel pinning) in sessionTarget: main cron jobs?
+2. Alternatively, is there a way in isolated mode to inject the cron message into a session so that subsequent user replies are handled in context?
+3. Is this a known limitation, or is there a recommended workaround for multi-channel agents that need both delivery guarantees and reply continuity?


### PR DESCRIPTION
Summary
What problem does this PR solve?
Cron jobs using sessionTarget: main have no way to specify a target delivery channel. For agents bound to multiple Slack channels, the output channel is non-deterministic — it depends on which channel last had activity in the main session. This makes reliable, channel-specific cron delivery impossible without switching to isolated mode.
Why does this matter now?
Multi-channel agents are a common pattern (e.g. a single agent serving several account channels). Without channel targeting in main mode, operators must choose between reply continuity (main) and delivery guarantees (isolated) — there is no option that provides both.
What is the intended outcome?
Support a to: field (or equivalent channel-targeting parameter) in sessionTarget: main cron job configuration, so the output is always delivered to the specified channel regardless of session history.
What is intentionally out of scope?
Changes to isolated mode behavior; changes to how replies are routed after delivery.
What does success look like?
A cron job configured with sessionTarget: main and a to: <channel> field consistently delivers its output to the specified channel, even when the agent is active in other channels.
What should reviewers focus on?
Whether the proposed to: parameter is the right API surface, or whether an alternative (e.g. delivery.channel unified across both session targets) is preferred.
───
Linked context
Which issue does this close?
Closes # (open a matching issue first if one doesn't exist, then link it here)
Which issues, PRs, or discussions are related?
Related # (link any Discord discussion or forum thread)
Was this requested by a maintainer or owner?
No — this is a community-raised limitation discovered in production use of multi-channel agents.
───
Real behavior proof (required for external PRs)
• Behavior or issue addressed: Cron job with sessionTarget: main delivering to the wrong Slack channel when agent is active in multiple channels
• Real environment tested: Self-hosted OpenClaw on AWS EC2, multiple Slack channels bound to a single agent
• Exact steps or command run after this patch: N/A — this is a feature proposal PR, no implementation patch included
• Evidence after fix: N/A
• Observed result after fix: N/A
• What was not tested: Full implementation — this PR proposes the feature; implementation and testing would follow maintainer feedback
• Proof limitations or environment constraints: This is a design/feature proposal. Real behavior proof will be added once an implementation approach is agreed upon.
───
Tests and validation
Which commands did you run? N/A — proposal only
What regression coverage was added or updated? None at this stage
What failed before this fix, if known? Cron output delivered to wrong channel in multi-channel agent setup
If no test was added, why not? No implementation yet — this PR is to propose and discuss the feature before writing code
───
Risk checklist
Did user-visible behavior change? No (proposal only)
Did config, environment, or migration behavior change? No
Did security, auth, secrets, network, or tool execution behavior change? No
What is the highest-risk area? Session routing logic for main mode cron jobs
How is that risk mitigated? To be determined by maintainers during design review
───
Current review state
What is the next action? Maintainer feedback on whether to: in main mode is the right approach, or if an alternative API is preferred
What is still waiting on? Maintainer input before any implementation begins
Which bot or reviewer comments were addressed? None yet — initial submission