### PR TITLE
feat(voice-call): Microsoft Teams provider (msteams) — inbound voice + video vision

### DIFF
--- a/docs/plugins/voice-call.md
+++ b/docs/plugins/voice-call.md
@@ -659,12 +659,12 @@ auto-ending the call:
 
 The `msteams` provider connects OpenClaw to **Microsoft Teams 1:1 voice
 calls**. Unlike the carrier providers, Teams calls do **not** arrive on the
-webhook/media-stream plane: an **external Windows worker** (not part of this
-repo) owns the Microsoft Graph Calling notification endpoint and the
-`Microsoft.Skype.Bots.Media` audio socket — those SDKs are Windows-only — and
-relays PCM audio to OpenClaw over a **per-call WebSocket**, authenticated with
-HMAC-SHA256 and bound to loopback by default. The provider is **inbound-first**
-(it does not place outbound PSTN calls).
+webhook/media-stream plane: a **Windows-side bridge worker** owns the Microsoft
+Graph Calling notification endpoint and the `Microsoft.Skype.Bots.Media` audio
+socket — those SDKs are Windows-only — and relays PCM audio to OpenClaw over a
+**per-call WebSocket**, authenticated with HMAC-SHA256 and bound to loopback by
+default. The provider is **inbound-first** (it does not place outbound PSTN
+calls).
 
 ```json5
 {

--- a/docs/plugins/voice-call.md
+++ b/docs/plugins/voice-call.md
@@ -669,10 +669,11 @@ calls).
 ```json5
 {
   provider: "msteams",
-  // Inbound default is a safe "allowlist" (never "open"): with an empty
-  // allowFrom no caller is accepted until you opt callers in, or set
-  // inboundPolicy: "open" explicitly to accept any authenticated Teams caller.
-  inboundPolicy: "open",
+  // Inbound default is a safe "allowlist" (never "open"). List the caller's AAD
+  // object id in allowFrom; an empty allowFrom accepts no one. Set
+  // inboundPolicy: "open" only to accept any authenticated Teams caller.
+  inboundPolicy: "allowlist",
+  allowFrom: ["00000000-0000-0000-0000-000000000000"], // caller AAD object ids
   responseModel: "openai/gpt-5.4", // agent model for the streaming path
 
   msteams: {

--- a/docs/plugins/voice-call.md
+++ b/docs/plugins/voice-call.md
@@ -1,5 +1,5 @@
 ---
-summary: "Place outbound and accept inbound voice calls via Twilio, Telnyx, or Plivo, with optional realtime voice and streaming transcription"
+summary: "Place outbound and accept inbound voice calls via Twilio, Telnyx, Plivo, or Microsoft Teams, with optional realtime voice and streaming transcription"
 read_when:
   - You want to place an outbound voice call from OpenClaw
   - You are configuring or developing the voice-call plugin
@@ -14,7 +14,9 @@ transcription, and inbound calls with allowlist policies.
 
 **Current providers:** `twilio` (Programmable Voice + Media Streams),
 `telnyx` (Call Control v2), `plivo` (Voice API + XML transfer + GetInput
-speech), `mock` (dev/no network).
+speech), `msteams` (Microsoft Teams voice over an external bridge —
+inbound-first; see [Microsoft Teams voice](#microsoft-teams-voice-msteams)),
+`mock` (dev/no network).
 
 <Note>
 The Voice Call plugin runs **inside the Gateway process**. If you use a
@@ -652,6 +654,58 @@ auto-ending the call:
 
 - If the stream reconnects during that window, auto-end is canceled.
 - If no stream re-registers after the grace period, the call is ended to prevent stuck active calls.
+
+## Microsoft Teams voice (msteams)
+
+The `msteams` provider connects OpenClaw to **Microsoft Teams 1:1 voice
+calls**. Unlike the carrier providers, Teams calls do **not** arrive on the
+webhook/media-stream plane: an **external Windows worker** (not part of this
+repo) owns the Microsoft Graph Calling notification endpoint and the
+`Microsoft.Skype.Bots.Media` audio socket — those SDKs are Windows-only — and
+relays PCM audio to OpenClaw over a **per-call WebSocket**, authenticated with
+HMAC-SHA256 and bound to loopback by default. The provider is **inbound-first**
+(it does not place outbound PSTN calls).
+
+```json5
+{
+  provider: "msteams",
+  // Inbound default is a safe "allowlist" (never "open"): with an empty
+  // allowFrom no caller is accepted until you opt callers in, or set
+  // inboundPolicy: "open" explicitly to accept any authenticated Teams caller.
+  inboundPolicy: "open",
+  responseModel: "openai/gpt-5.4", // agent model for the streaming path
+
+  msteams: {
+    port: 8443,
+    bindAddress: "127.0.0.1", // loopback by default; set a trusted-network IP only if the worker is remote
+    path: "/voice/msteams/stream",
+    sharedSecret: "${MSTEAMS_WS_SECRET}", // SecretRef-compatible; must match the worker
+    requireRecordingStatus: true, // gate transcripts on active Teams recording status
+  },
+
+  // Pick one mode:
+  streaming: { enabled: true, provider: "elevenlabs" }, // agent does work (STT -> agent -> TTS)
+  // realtime: { enabled: true, provider: "openai" },   // speech-to-speech, lowest latency
+}
+```
+
+Key points:
+
+- **Modes:** enable `streaming` (transcription → the OpenClaw agent → TTS, for
+  doing work) **or** `realtime` (speech-to-speech for low-latency
+  conversation). At least one is required.
+- **Allowlist:** because Teams callers have no phone number, `allowFrom`
+  entries accept the caller's **AAD object id** (a GUID) as well as E.164
+  numbers — list the caller's `aadId` for `inboundPolicy: "allowlist"`.
+- **Recording gate:** with `requireRecordingStatus: true` (default), no
+  media-derived transcript is processed until the worker reports active Teams
+  recording status (a Microsoft Media Access API obligation).
+- **Security:** the WebSocket listener binds to loopback by default, verifies
+  HMAC-SHA256 over the handshake, caps payloads, and the shared secret is
+  SecretRef-backed.
+
+See the [voice-call extension README](https://github.com/openclaw/openclaw/blob/main/extensions/voice-call/README.md)
+for the full WebSocket bridge protocol and worker setup.
 
 ## Stale call reaper
 

--- a/docs/reference/secretref-credential-surface.md
+++ b/docs/reference/secretref-credential-surface.md
@@ -52,6 +52,7 @@ Scope intent:
 - `plugins.entries.minimax.config.webSearch.apiKey`
 - `plugins.entries.tavily.config.webSearch.apiKey`
 - `plugins.entries.parallel.config.webSearch.apiKey`
+- `plugins.entries.voice-call.config.msteams.sharedSecret`
 - `plugins.entries.voice-call.config.realtime.providers.*.apiKey`
 - `plugins.entries.voice-call.config.streaming.providers.*.apiKey`
 - `plugins.entries.voice-call.config.tts.providers.*.apiKey`

--- a/docs/reference/secretref-user-supplied-credentials-matrix.json
+++ b/docs/reference/secretref-user-supplied-credentials-matrix.json
@@ -611,6 +611,13 @@
       "optIn": true
     },
     {
+      "id": "plugins.entries.voice-call.config.msteams.sharedSecret",
+      "configFile": "openclaw.json",
+      "path": "plugins.entries.voice-call.config.msteams.sharedSecret",
+      "secretShape": "secret_input",
+      "optIn": true
+    },
+    {
       "id": "plugins.entries.voice-call.config.realtime.providers.*.apiKey",
       "configFile": "openclaw.json",
       "path": "plugins.entries.voice-call.config.realtime.providers.*.apiKey",

--- a/extensions/voice-call/README.md
+++ b/extensions/voice-call/README.md
@@ -107,6 +107,8 @@ Two modes:
 
 At least one of `streaming.enabled` / `realtime.enabled` must be set (validated), and `msteams.port` + `msteams.sharedSecret` are required.
 
+For `inboundPolicy: "allowlist"`, Teams callers have no phone number, so `allowFrom` entries are matched against the caller's **AAD object id** (a GUID) — list the caller's `aadId` (carrier providers still use E.164 numbers; either form is accepted).
+
 ```json5
 {
   provider: "msteams",

--- a/extensions/voice-call/README.md
+++ b/extensions/voice-call/README.md
@@ -112,7 +112,8 @@ When `inboundPolicy` is unset, msteams defaults to a **safe `"allowlist"`** (nev
 ```json5
 {
   provider: "msteams",
-  inboundPolicy: "open", // accept any authenticated Teams caller; or "allowlist" + allowFrom (the safe default)
+  inboundPolicy: "allowlist", // safe default; accept only listed callers
+  allowFrom: ["00000000-0000-0000-0000-000000000000"], // caller AAD object ids (use "open" to accept any authenticated Teams caller)
   responseModel: "microsoft-foundry/gpt-5.4", // agent model for the streaming path
 
   msteams: {

--- a/extensions/voice-call/README.md
+++ b/extensions/voice-call/README.md
@@ -7,6 +7,7 @@ Providers:
 - **Twilio** (Programmable Voice + Media Streams)
 - **Telnyx** (Call Control v2)
 - **Plivo** (Voice API + XML transfer + GetInput speech)
+- **Microsoft Teams** (`msteams`) — bridges Teams calls via an external Windows worker over an HMAC-authenticated WebSocket (inbound-only). See [Microsoft Teams provider](#microsoft-teams-provider-msteams).
 - **Mock** (dev/no network)
 
 Docs: `https://docs.openclaw.ai/plugins/voice-call`
@@ -35,7 +36,7 @@ Put under `plugins.entries.voice-call.config`:
 
 ```json5
 {
-  provider: "twilio", // or "telnyx" | "plivo" | "mock"
+  provider: "twilio", // or "telnyx" | "plivo" | "msteams" | "mock"
   fromNumber: "+15550001234",
   toNumber: "+15550005678",
   sessionScope: "per-phone", // or "per-call"
@@ -94,6 +95,78 @@ Put under `plugins.entries.voice-call.config`:
   },
 }
 ```
+
+## Microsoft Teams provider (`msteams`)
+
+Teams calls do not arrive on the webhook/media-stream plane. An **external Windows worker** (not part of this repo) owns the Graph Calling notification endpoint and the `Microsoft.Skype.Bots.Media` AudioSocket; when a call is answered it opens a **per-call WebSocket** to OpenClaw and relays PCM 16 kHz audio in both directions. The provider is **inbound-only** (`initiateCall` throws).
+
+Two modes:
+
+- **Agent (streaming):** caller audio -> realtime transcription (STT) -> the OpenClaw agent (`responseModel`, with tools) -> TTS. Use this to have the agent _do work_. Requires `streaming.enabled: true`.
+- **Realtime (speech-to-speech):** caller audio is bridged directly to a realtime voice provider (e.g. OpenAI Realtime). Lowest latency, conversational. Requires `realtime.enabled: true` + a realtime voice provider. The model handles small talk itself and **delegates real work to the OpenClaw agent**: `openclaw_agent_consult` for quick in-line answers, and (under `realtime.toolPolicy: "owner"`) `openclaw_agent_task` to run a long job in the background and deliver the result to the caller's Teams chat — see [Realtime delegation](#realtime-delegation-consult--background-tasks).
+
+At least one of `streaming.enabled` / `realtime.enabled` must be set (validated), and `msteams.port` + `msteams.sharedSecret` are required.
+
+```json5
+{
+  provider: "msteams",
+  inboundPolicy: "open", // defaulted to "open" for msteams (Teams is inbound-first)
+  responseModel: "microsoft-foundry/gpt-5.4", // agent model for the streaming path
+
+  msteams: {
+    port: 8443,
+    bindAddress: "127.0.0.1", // loopback by default; set a trusted-network IP only if the worker is remote
+    path: "/voice/msteams/stream",
+    sharedSecret: "${MSTEAMS_WS_SECRET}", // SecretRef-compatible; must match the worker
+    requireRecordingStatus: true, // see "Recording status" below
+  },
+
+  // Agent (streaming) mode:
+  streaming: {
+    enabled: true,
+    provider: "elevenlabs",
+    providers: {
+      elevenlabs: {
+        modelId: "scribe_v2_realtime",
+        audioFormat: "pcm_16000",
+        sampleRate: 16000,
+        commitStrategy: "vad",
+      },
+    },
+  },
+  tts: { provider: "elevenlabs", providers: { elevenlabs: { voiceId: "..." } } },
+
+  // OR realtime mode (instead of streaming):
+  // realtime: { enabled: true, provider: "openai" },
+}
+```
+
+**Security / transport**
+
+- Every WS upgrade is authenticated with **HMAC-SHA256** over `timestamp.callId` (headers `x-openclawteamsbridge-timestamp` / `x-openclawteamsbridge-signature`), compared in constant time, with a replay window.
+- The server **binds loopback (`127.0.0.1`) by default** - set `bindAddress` to a specific trusted-network address only when the worker connects from another host.
+- Connection guardrails: total + per-IP connection caps, a pre-start idle timeout, and a 64 KB inbound frame cap.
+- `sharedSecret` is SecretRef-compatible (`${ENV}` / secret refs) and never logged.
+
+**Recording status (Microsoft Media Access API)**
+
+Microsoft requires that media or media-derived data not be persisted before the bot has called Graph `updateRecordingStatus`. The worker reports this over the bridge (`recordingStatus` on `session.start`, and the `recording.status` message when it changes). With `requireRecordingStatus: true` (default):
+
+- the **streaming** path **drops transcripts until recording status is active**;
+- the **realtime** path **refuses `openclaw_agent_consult` and `openclaw_agent_task` until recording status is active** (the live small-talk conversation continues, but the agent will not process/persist or deliver call audio yet).
+
+VAD is handled by the STT provider (`commitStrategy: "vad"`) on the streaming path and by the realtime model on the realtime path; barge-in is supported on both.
+
+**Realtime delegation (consult + background tasks)**
+
+In realtime mode the speech-to-speech model is given two tools so it can do real work instead of only chatting:
+
+- `openclaw_agent_consult` — runs the OpenClaw agent (with the tools allowed by `realtime.toolPolicy`) and returns a short, speakable result in-line. A "working on it" filler covers longer runs. Use for quick questions/lookups/actions answered on the call.
+- `openclaw_agent_task` — available only under `realtime.toolPolicy: "owner"` (the agent's `message` tool, used for delivery, requires owner). The model acks immediately ("I'll message you on Microsoft Teams"), the call is free to continue or hang up, and the OpenClaw agent runs the job in the background, then delivers the final result to the caller's Teams chat via the `message` tool (`channel: "msteams"`, `target: "user:<aadId>"`). Use for multi-step or long-running work.
+
+Both tools are gated by recording status (see above) and respect `inboundPolicy` / `allowFrom`. Tuning: `realtime.consultThinkingLevel`, `realtime.consultFastMode`, `realtime.fastContext`, and `realtime.suppressInputDuringPlayback` (self-echo guard, off by default — Teams sends remote-participant audio, so gating would also defeat barge-in).
+
+**WebSocket protocol** (worker -> OpenClaw): `session.start` (`callId`, `threadId`, `caller.{aadId,displayName,tenantId}`, `recordingStatus?`), `recording.status` (`status`), `audio.frame` (`seq`, `timestampMs`, `payloadBase64` = PCM 16 kHz 16-bit mono), `session.end` (`reason`), `ping` (`ts`). OpenClaw -> worker: `audio.frame` (TTS / realtime audio) and `assistant.cancel` (barge-in).
 
 Notes:
 

--- a/extensions/voice-call/README.md
+++ b/extensions/voice-call/README.md
@@ -107,12 +107,12 @@ Two modes:
 
 At least one of `streaming.enabled` / `realtime.enabled` must be set (validated), and `msteams.port` + `msteams.sharedSecret` are required.
 
-For `inboundPolicy: "allowlist"`, Teams callers have no phone number, so `allowFrom` entries are matched against the caller's **AAD object id** (a GUID) — list the caller's `aadId` (carrier providers still use E.164 numbers; either form is accepted).
+When `inboundPolicy` is unset, msteams defaults to a **safe `"allowlist"`** (never `"open"`): with an empty `allowFrom` no caller is accepted until you opt callers in or set `inboundPolicy: "open"` explicitly. For `inboundPolicy: "allowlist"`, Teams callers have no phone number, so `allowFrom` entries are matched against the caller's **AAD object id** (a GUID) — list the caller's `aadId` (carrier providers still use E.164 numbers; either form is accepted).
 
 ```json5
 {
   provider: "msteams",
-  inboundPolicy: "open", // defaulted to "open" for msteams (Teams is inbound-first)
+  inboundPolicy: "open", // accept any authenticated Teams caller; or "allowlist" + allowFrom (the safe default)
   responseModel: "microsoft-foundry/gpt-5.4", // agent model for the streaming path
 
   msteams: {

--- a/extensions/voice-call/openclaw.plugin.json
+++ b/extensions/voice-call/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "voice-call",
   "name": "Voice Call",
-  "description": "OpenClaw voice-call plugin for Twilio, Telnyx, and Plivo phone calls.",
+  "description": "OpenClaw voice-call plugin for Twilio, Telnyx, and Plivo phone calls, and Microsoft Teams voice.",
   "commandAliases": [{ "name": "voicecall" }],
   "activation": {
     "onStartup": true,

--- a/extensions/voice-call/openclaw.plugin.json
+++ b/extensions/voice-call/openclaw.plugin.json
@@ -259,7 +259,7 @@
       },
       "provider": {
         "type": "string",
-        "enum": ["telnyx", "twilio", "plivo", "mock"]
+        "enum": ["telnyx", "twilio", "plivo", "mock", "msteams"]
       },
       "telnyx": {
         "type": "object",
@@ -297,6 +297,29 @@
           },
           "authToken": {
             "type": "string"
+          }
+        }
+      },
+      "msteams": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "port": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 65535
+          },
+          "bindAddress": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          },
+          "sharedSecret": {
+            "type": ["string", "object"]
+          },
+          "requireRecordingStatus": {
+            "type": "boolean"
           }
         }
       },
@@ -904,6 +927,7 @@
     "secretInputs": {
       "paths": [
         { "path": "twilio.authToken", "expected": "string" },
+        { "path": "msteams.sharedSecret", "expected": "string" },
         { "path": "realtime.providers.*.apiKey", "expected": "string" },
         { "path": "streaming.providers.*.apiKey", "expected": "string" },
         { "path": "tts.providers.*.apiKey", "expected": "string" }

--- a/extensions/voice-call/openclaw.plugin.json
+++ b/extensions/voice-call/openclaw.plugin.json
@@ -553,6 +553,9 @@
           "consultFastMode": {
             "type": "boolean"
           },
+          "suppressInputDuringPlayback": {
+            "type": "boolean"
+          },
           "tools": {
             "type": "array",
             "items": {

--- a/extensions/voice-call/openclaw.plugin.json
+++ b/extensions/voice-call/openclaw.plugin.json
@@ -339,7 +339,7 @@
         "type": "array",
         "items": {
           "type": "string",
-          "pattern": "^\\+[1-9]\\d{1,14}$"
+          "pattern": "^(\\+[1-9]\\d{1,14}|[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$"
         }
       },
       "inboundGreeting": {

--- a/extensions/voice-call/src/allowlist.test.ts
+++ b/extensions/voice-call/src/allowlist.test.ts
@@ -1,6 +1,6 @@
 // Voice Call tests cover allowlist plugin behavior.
 import { describe, expect, it } from "vitest";
-import { isAllowlistedCaller, normalizePhoneNumber } from "./allowlist.js";
+import { isAllowlistedCaller, isInboundCallAllowed, normalizePhoneNumber } from "./allowlist.js";
 
 describe("voice-call allowlist", () => {
   it("normalizes phone numbers by stripping non-digits", () => {
@@ -15,5 +15,20 @@ describe("voice-call allowlist", () => {
     expect(isAllowlistedCaller("02079460958", ["+1 (415) 555-0123", " 020-7946-0958 "])).toBe(true);
     expect(isAllowlistedCaller("", ["+1 (415) 555-0123"])).toBe(false);
     expect(isAllowlistedCaller("14155550123", ["", "abc"])).toBe(false);
+  });
+
+  it("matches a caller by exact id (e.g. a Teams AAD object id), case-insensitively", () => {
+    const aad = "9A783A59-BF32-4D17-8B42-459E8383E8BB";
+    expect(isAllowlistedCaller(aad.toLowerCase(), [aad])).toBe(true);
+    expect(isAllowlistedCaller(aad, [aad.toLowerCase()])).toBe(true);
+    expect(isAllowlistedCaller("00000000-0000-0000-0000-000000000000", [aad])).toBe(false);
+  });
+
+  it("isInboundCallAllowed admits an AAD caller under the allowlist policy", () => {
+    const aad = "9a783a59-bf32-4d17-8b42-459e8383e8bb";
+    expect(isInboundCallAllowed("allowlist", [aad], aad)).toBe(true);
+    expect(isInboundCallAllowed("allowlist", [aad], "other-aad-id")).toBe(false);
+    expect(isInboundCallAllowed("open", undefined, aad)).toBe(true);
+    expect(isInboundCallAllowed("disabled", [aad], aad)).toBe(false);
   });
 });

--- a/extensions/voice-call/src/allowlist.ts
+++ b/extensions/voice-call/src/allowlist.ts
@@ -21,3 +21,28 @@ export function isAllowlistedCaller(
     return normalizedAllow !== "" && normalizedAllow === normalizedFrom;
   });
 }
+
+/**
+ * Inbound-policy decision. Mirrors the switch in `manager/events.ts`
+ * `shouldAcceptInbound` so paths that do not route through the CallManager
+ * (e.g. the msteams realtime bridge) accept/reject callers identically.
+ * `from` is the caller id — a phone number, or a Teams `aadId` for msteams
+ * (which will not match a phone allowlist).
+ */
+export function isInboundCallAllowed(
+  inboundPolicy: "disabled" | "allowlist" | "pairing" | "open" | undefined,
+  allowFrom: string[] | undefined,
+  from: string | undefined,
+): boolean {
+  switch (inboundPolicy) {
+    case "open":
+      return true;
+    case "allowlist":
+    case "pairing":
+      return isAllowlistedCaller(normalizePhoneNumber(from), allowFrom);
+    default:
+      // "disabled" or unset → reject (config validation already blocks
+      // realtime + "disabled"; this is defensive).
+      return false;
+  }
+}

--- a/extensions/voice-call/src/allowlist.ts
+++ b/extensions/voice-call/src/allowlist.ts
@@ -8,17 +8,35 @@ export function normalizePhoneNumber(input?: string): string {
   return input.replace(/\D/g, "");
 }
 
-/** Return true when the normalized caller exactly matches an allowlist entry. */
+/**
+ * Return true when the caller matches an allowlist entry — by phone number
+ * (digits only) OR by exact caller id, case-insensitive. The id match lets
+ * providers whose caller id is not a phone number (e.g. the Microsoft Teams
+ * `aadId`, an AAD object id) use the allowlist without being phone-normalized.
+ * `from` may be a raw caller id or an already-normalized phone string.
+ */
 export function isAllowlistedCaller(
-  normalizedFrom: string,
+  from: string | undefined,
   allowFrom: string[] | undefined,
 ): boolean {
-  if (!normalizedFrom) {
+  const raw = from?.trim();
+  if (!raw) {
     return false;
   }
-  return (allowFrom ?? []).some((num) => {
-    const normalizedAllow = normalizePhoneNumber(num);
-    return normalizedAllow !== "" && normalizedAllow === normalizedFrom;
+  const idFrom = raw.toLowerCase();
+  const normalizedFrom = normalizePhoneNumber(raw);
+  return (allowFrom ?? []).some((entry) => {
+    const trimmed = entry.trim();
+    if (!trimmed) {
+      return false;
+    }
+    // Exact caller-id match (e.g. a Teams AAD object id), case-insensitive.
+    if (trimmed.toLowerCase() === idFrom) {
+      return true;
+    }
+    // Phone-number match (digits only).
+    const normalizedAllow = normalizePhoneNumber(trimmed);
+    return normalizedAllow !== "" && normalizedFrom !== "" && normalizedAllow === normalizedFrom;
   });
 }
 
@@ -26,8 +44,8 @@ export function isAllowlistedCaller(
  * Inbound-policy decision. Mirrors the switch in `manager/events.ts`
  * `shouldAcceptInbound` so paths that do not route through the CallManager
  * (e.g. the msteams realtime bridge) accept/reject callers identically.
- * `from` is the caller id — a phone number, or a Teams `aadId` for msteams
- * (which will not match a phone allowlist).
+ * `from` is the caller id — a phone number, or a Teams `aadId` for msteams.
+ * `isAllowlistedCaller` matches either form (phone digits or exact id).
  */
 export function isInboundCallAllowed(
   inboundPolicy: "disabled" | "allowlist" | "pairing" | "open" | undefined,
@@ -39,7 +57,7 @@ export function isInboundCallAllowed(
       return true;
     case "allowlist":
     case "pairing":
-      return isAllowlistedCaller(normalizePhoneNumber(from), allowFrom);
+      return isAllowlistedCaller(from, allowFrom);
     default:
       // "disabled" or unset → reject (config validation already blocks
       // realtime + "disabled"; this is defensive).

--- a/extensions/voice-call/src/config.test.ts
+++ b/extensions/voice-call/src/config.test.ts
@@ -56,6 +56,23 @@ describe("VoiceCallConfigSchema allowFrom", () => {
   });
 });
 
+describe("msteams inbound default", () => {
+  it("defaults msteams inboundPolicy to a safe allowlist (never open)", () => {
+    const config = resolveVoiceCallConfig({ enabled: true, provider: "msteams" });
+
+    expect(config.inboundPolicy).toBe("allowlist");
+  });
+
+  it("honors an explicit msteams inboundPolicy", () => {
+    const open = resolveVoiceCallConfig({
+      enabled: true,
+      provider: "msteams",
+      inboundPolicy: "open",
+    });
+    expect(open.inboundPolicy).toBe("open");
+  });
+});
+
 describe("validateProviderConfig", () => {
   const originalEnv = { ...process.env };
   const clearProviderEnv = () => {

--- a/extensions/voice-call/src/config.test.ts
+++ b/extensions/voice-call/src/config.test.ts
@@ -260,7 +260,7 @@ describe("validateProviderConfig", () => {
       const result = validateProviderConfig(config);
 
       expect(result.errors).not.toContain(
-        'plugins.entries.voice-call.config.provider must be "twilio" or "telnyx" when realtime.enabled is true',
+        'plugins.entries.voice-call.config.provider must be "twilio", "telnyx", or "msteams" when realtime.enabled is true',
       );
     });
 
@@ -273,7 +273,7 @@ describe("validateProviderConfig", () => {
 
       expect(result.valid).toBe(false);
       expect(result.errors).toContain(
-        'plugins.entries.voice-call.config.provider must be "twilio" or "telnyx" when realtime.enabled is true',
+        'plugins.entries.voice-call.config.provider must be "twilio", "telnyx", or "msteams" when realtime.enabled is true',
       );
     });
   });

--- a/extensions/voice-call/src/config.test.ts
+++ b/extensions/voice-call/src/config.test.ts
@@ -30,6 +30,32 @@ function requireElevenLabsTtsConfig(config: Pick<VoiceCallConfig, "tts">) {
   return { tts, elevenlabs };
 }
 
+describe("VoiceCallConfigSchema allowFrom", () => {
+  const aad = "9a783a59-bf32-4d17-8b42-459e8383e8bb";
+
+  it("accepts E.164 phone numbers and Teams AAD object ids (either case)", () => {
+    const config = VoiceCallConfigSchema.parse({
+      enabled: true,
+      provider: "msteams",
+      inboundPolicy: "allowlist",
+      allowFrom: ["+15550001234", aad, aad.toUpperCase()],
+    });
+
+    expect(config.allowFrom).toEqual(["+15550001234", aad, aad.toUpperCase()]);
+  });
+
+  it("rejects allowFrom entries that are neither E.164 nor a GUID", () => {
+    expect(() =>
+      VoiceCallConfigSchema.parse({
+        enabled: true,
+        provider: "msteams",
+        inboundPolicy: "allowlist",
+        allowFrom: ["not-a-number"],
+      }),
+    ).toThrow();
+  });
+});
+
 describe("validateProviderConfig", () => {
   const originalEnv = { ...process.env };
   const clearProviderEnv = () => {

--- a/extensions/voice-call/src/config.ts
+++ b/extensions/voice-call/src/config.ts
@@ -347,6 +347,12 @@ const VoiceCallRealtimeConfigSchema = z
     consultThinkingLevel: VoiceCallRealtimeConsultThinkingLevelSchema.optional(),
     /** Optional fast mode override for the regular agent behind realtime consults. */
     consultFastMode: z.boolean().optional(),
+    /**
+     * Suppress caller-leg input while assistant audio is playing (self-echo guard).
+     * Off by default: the msteams bridge delivers remote-participant audio (not our
+     * own playback), and gating input would also defeat the model's barge-in.
+     */
+    suppressInputDuringPlayback: z.boolean().optional(),
     /** Tool definitions exposed to the realtime provider. */
     tools: z.array(RealtimeToolSchema).default([]),
     /** Low-latency memory/session context for the consult tool. */

--- a/extensions/voice-call/src/config.ts
+++ b/extensions/voice-call/src/config.ts
@@ -23,6 +23,22 @@ const E164Schema = z
   .string()
   .regex(/^\+[1-9]\d{1,14}$/, "Expected E.164 format, e.g. +15550001234");
 
+/**
+ * Microsoft Teams caller id: an AAD object id (a GUID). Teams calls carry no
+ * E.164 number — the caller is identified by `aadId` — so allowlist entries
+ * accept this form too, letting the msteams provider use
+ * `inboundPolicy: "allowlist"`. Runtime matching is in `isAllowlistedCaller`.
+ */
+const AadObjectIdSchema = z
+  .string()
+  .regex(
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+    "Expected an AAD object id (GUID), e.g. 00000000-0000-0000-0000-000000000000",
+  );
+
+/** An inbound allowlist entry: an E.164 phone number or a Teams AAD object id. */
+const AllowFromEntrySchema = z.union([E164Schema, AadObjectIdSchema]);
+
 // -----------------------------------------------------------------------------
 // Inbound Policy
 // -----------------------------------------------------------------------------
@@ -457,8 +473,8 @@ export const VoiceCallConfigSchema = z
     /** Inbound call policy */
     inboundPolicy: InboundPolicySchema.default("disabled"),
 
-    /** Allowlist of phone numbers for inbound calls (E.164) */
-    allowFrom: z.array(E164Schema).default([]),
+    /** Allowlist for inbound calls: E.164 phone numbers or Teams AAD object ids. */
+    allowFrom: z.array(AllowFromEntrySchema).default([]),
 
     /** Greeting message for inbound calls */
     inboundGreeting: z.string().optional(),

--- a/extensions/voice-call/src/config.ts
+++ b/extensions/voice-call/src/config.ts
@@ -854,11 +854,13 @@ export function resolveVoiceCallConfig(config: VoiceCallConfigInput): VoiceCallC
     resolved.webhookSecurity.trustForwardingHeaders ?? false;
   resolved.webhookSecurity.trustedProxyIPs = resolved.webhookSecurity.trustedProxyIPs ?? [];
 
-  // Microsoft Teams is inbound-first: calls and meeting joins are delivered to the
-  // bot, so requiring the operator to also flip inboundPolicy is redundant. Default
-  // it to "open" for msteams unless an explicit policy was configured.
+  // Microsoft Teams is inbound-first, but defaulting inbound to "open" would
+  // accept every authenticated Teams caller out of the box. Use a safe
+  // allowlist-oriented default instead: with an empty allowFrom no caller is
+  // accepted until the operator opts callers in (the allowlist accepts AAD
+  // object ids) or explicitly sets inboundPolicy: "open". No unsafe default.
   if (resolved.provider === "msteams" && config.inboundPolicy === undefined) {
-    resolved.inboundPolicy = "open";
+    resolved.inboundPolicy = "allowlist";
   }
 
   return normalizeVoiceCallConfig(resolved);

--- a/extensions/voice-call/src/config.ts
+++ b/extensions/voice-call/src/config.ts
@@ -63,6 +63,32 @@ const TwilioConfigSchema = z
   })
   .strict();
 
+const MsteamsConfigSchema = z
+  .object({
+    /** TCP port the Teams bridge WebSocket server listens on. */
+    port: z.number().int().min(1).max(65535).optional(),
+    /**
+     * Address the Teams bridge WebSocket server binds to. Defaults to the
+     * loopback interface (127.0.0.1) so the bridge is never exposed on all
+     * interfaces. Set to a specific trusted-network address only when the
+     * Windows worker connects from another host (e.g. a private/VPN IP).
+     */
+    bindAddress: z.string().min(1).optional(),
+    /** URL path prefix for the WebSocket upgrade (per-call path = {path}/{callId}). */
+    path: z.string().min(1).default("/voice/msteams/stream"),
+    /** Shared secret used to verify HMAC-SHA256 on the WS handshake (SecretRef-compatible). */
+    sharedSecret: SecretInputSchema.optional(),
+    /**
+     * Require the worker to report active Teams recording status before any
+     * media-derived transcript is persisted or processed (Microsoft Media
+     * Access API obligation). Default true; set false only if recording/
+     * compliance is enforced out-of-band.
+     */
+    requireRecordingStatus: z.boolean().default(true),
+  })
+  .strict();
+export type MsteamsConfig = z.infer<typeof MsteamsConfigSchema>;
+
 const PlivoConfigSchema = z
   .object({
     /** Plivo Auth ID (starts with MA/SA) */
@@ -401,8 +427,8 @@ export const VoiceCallConfigSchema = z
     /** Enable voice call functionality */
     enabled: z.boolean().default(false),
 
-    /** Active provider (telnyx, twilio, plivo, or mock) */
-    provider: z.enum(["telnyx", "twilio", "plivo", "mock"]).optional(),
+    /** Active provider (telnyx, twilio, plivo, mock, or msteams) */
+    provider: z.enum(["telnyx", "twilio", "plivo", "mock", "msteams"]).optional(),
 
     /** Telnyx-specific configuration */
     telnyx: TelnyxConfigSchema.optional(),
@@ -412,6 +438,9 @@ export const VoiceCallConfigSchema = z
 
     /** Plivo-specific configuration */
     plivo: PlivoConfigSchema.optional(),
+
+    /** Microsoft Teams provider — bridges Teams call audio via an external Windows worker */
+    msteams: MsteamsConfigSchema.optional(),
 
     /** Phone number to call from (E.164) */
     fromNumber: E164Schema.optional(),
@@ -647,6 +676,18 @@ export function resolveTwilioAuthToken(
   });
 }
 
+const MSTEAMS_SHARED_SECRET_PATH = "plugins.entries.voice-call.config.msteams.sharedSecret";
+
+/** Resolve the msteams HMAC shared secret from its SecretRef-compatible config value. */
+export function resolveMsteamsSharedSecret(
+  config: Pick<VoiceCallConfig, "msteams">,
+): string | undefined {
+  return normalizeResolvedSecretInputString({
+    value: config.msteams?.sharedSecret,
+    path: MSTEAMS_SHARED_SECRET_PATH,
+  });
+}
+
 export function normalizeVoiceCallConfig(config: VoiceCallConfigInput): VoiceCallConfig {
   const defaults = cloneDefaultVoiceCallConfig();
   const serve = { ...defaults.serve, ...config.serve };
@@ -679,6 +720,16 @@ export function normalizeVoiceCallConfig(config: VoiceCallConfigInput): VoiceCal
     serve,
     tailscale: { ...defaults.tailscale, ...config.tailscale },
     tunnel: { ...defaults.tunnel, ...config.tunnel },
+    // msteams.path and requireRecordingStatus carry schema defaults, so apply
+    // them explicitly here — the `...config` spread above only sees the optional
+    // input shape.
+    msteams: config.msteams
+      ? {
+          ...config.msteams,
+          path: config.msteams.path ?? "/voice/msteams/stream",
+          requireRecordingStatus: config.msteams.requireRecordingStatus ?? true,
+        }
+      : config.msteams,
     webhookSecurity: {
       ...defaults.webhookSecurity,
       ...config.webhookSecurity,
@@ -781,6 +832,13 @@ export function resolveVoiceCallConfig(config: VoiceCallConfigInput): VoiceCallC
     resolved.webhookSecurity.trustForwardingHeaders ?? false;
   resolved.webhookSecurity.trustedProxyIPs = resolved.webhookSecurity.trustedProxyIPs ?? [];
 
+  // Microsoft Teams is inbound-first: calls and meeting joins are delivered to the
+  // bot, so requiring the operator to also flip inboundPolicy is redundant. Default
+  // it to "open" for msteams unless an explicit policy was configured.
+  if (resolved.provider === "msteams" && config.inboundPolicy === undefined) {
+    resolved.inboundPolicy = "open";
+  }
+
   return normalizeVoiceCallConfig(resolved);
 }
 
@@ -801,7 +859,9 @@ export function validateProviderConfig(config: VoiceCallConfig): {
     errors.push("plugins.entries.voice-call.config.provider is required");
   }
 
-  if (!config.fromNumber && config.provider !== "mock") {
+  // msteams and mock are inbound-first providers that never place outbound PSTN
+  // calls, so a fromNumber is meaningless for them.
+  if (!config.fromNumber && config.provider !== "mock" && config.provider !== "msteams") {
     errors.push(
       config.provider === "twilio"
         ? "plugins.entries.voice-call.config.fromNumber is required (or set TWILIO_FROM_NUMBER env)"
@@ -853,6 +913,26 @@ export function validateProviderConfig(config: VoiceCallConfig): {
     }
   }
 
+  if (config.provider === "msteams") {
+    // The Teams bridge cannot accept calls without a listening port and an HMAC
+    // shared secret, so require them up front rather than starting a runtime that
+    // silently never binds. (path has a schema default.)
+    if (!config.msteams?.port) {
+      errors.push("plugins.entries.voice-call.config.msteams.port is required");
+    }
+    if (!hasConfiguredSecretInput(config.msteams?.sharedSecret)) {
+      errors.push("plugins.entries.voice-call.config.msteams.sharedSecret is required");
+    }
+    // msteams is driven entirely by a realtime path: either streaming
+    // transcription or realtime voice-to-voice. Refuse to bind a listener that
+    // would accept calls it can neither transcribe nor answer.
+    if (!config.streaming?.enabled && !config.realtime?.enabled) {
+      errors.push(
+        'plugins.entries.voice-call.config.streaming.enabled (or realtime.enabled) must be true for provider "msteams"',
+      );
+    }
+  }
+
   if (config.realtime.enabled && config.inboundPolicy === "disabled") {
     errors.push(
       'plugins.entries.voice-call.config.inboundPolicy must not be "disabled" when realtime.enabled is true',
@@ -869,10 +949,11 @@ export function validateProviderConfig(config: VoiceCallConfig): {
     config.realtime.enabled &&
     config.provider &&
     config.provider !== "twilio" &&
-    config.provider !== "telnyx"
+    config.provider !== "telnyx" &&
+    config.provider !== "msteams"
   ) {
     errors.push(
-      'plugins.entries.voice-call.config.provider must be "twilio" or "telnyx" when realtime.enabled is true',
+      'plugins.entries.voice-call.config.provider must be "twilio", "telnyx", or "msteams" when realtime.enabled is true',
     );
   }
 

--- a/extensions/voice-call/src/manager/events.ts
+++ b/extensions/voice-call/src/manager/events.ts
@@ -1,7 +1,7 @@
 // Voice Call plugin module implements events behavior.
 import crypto from "node:crypto";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
-import { isAllowlistedCaller, normalizePhoneNumber } from "../allowlist.js";
+import { isAllowlistedCaller } from "../allowlist.js";
 import { resolveVoiceCallEffectiveConfig, resolveVoiceCallSessionKey } from "../config.js";
 import type { CallRecord, NormalizedEvent } from "../types.js";
 import type { CallManagerContext } from "./context.js";
@@ -41,12 +41,13 @@ function shouldAcceptInbound(config: EventContext["config"], from: string | unde
 
     case "allowlist":
     case "pairing": {
-      const normalized = normalizePhoneNumber(from);
-      if (!normalized) {
+      if (!from) {
         console.log("[voice-call] Inbound call rejected: missing caller ID");
         return false;
       }
-      const allowed = isAllowlistedCaller(normalized, allowFrom);
+      // Pass the raw caller id so AAD callers (msteams) match by exact id, not
+      // phone digits.
+      const allowed = isAllowlistedCaller(from, allowFrom);
       const status = allowed ? "accepted" : "rejected";
       console.log(
         `[voice-call] Inbound call ${status}: ${from} ${allowed ? "is in" : "not in"} allowlist`,

--- a/extensions/voice-call/src/msteams-media-stream.test.ts
+++ b/extensions/voice-call/src/msteams-media-stream.test.ts
@@ -316,7 +316,9 @@ describe("MsteamsMediaStream", () => {
 
     await waitFor(() => ends.length > 0);
     // The server closes the socket after session.end; let the close event run.
-    await new Promise<void>((resolve) => setTimeout(resolve, 100));
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 100);
+    });
     expect(ends).toEqual([{ callId, reason: "call-ended" }]);
   });
 
@@ -332,7 +334,9 @@ describe("MsteamsMediaStream", () => {
     });
     ws.close(); // close before any session.start
 
-    await new Promise<void>((resolve) => setTimeout(resolve, 100));
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 100);
+    });
     expect(ends).toHaveLength(0);
   });
 

--- a/extensions/voice-call/src/msteams-media-stream.test.ts
+++ b/extensions/voice-call/src/msteams-media-stream.test.ts
@@ -269,6 +269,73 @@ describe("MsteamsMediaStream", () => {
     expect(endInfo?.reason).toBe("call-ended");
   });
 
+  it("fires onSessionEnd when a started session's socket closes abruptly", async () => {
+    const port = randomPort();
+    const ends: Array<{ callId: string; reason: string }> = [];
+    let started = false;
+    server = await startServer({
+      port,
+      onSessionStart: () => {
+        started = true;
+      },
+      onSessionEnd: (info) => ends.push(info),
+    });
+
+    const callId = "call-drop";
+    const ws = openAuthed(port, callId);
+    await new Promise<void>((resolve, reject) => {
+      ws.once("open", () => resolve());
+      ws.once("error", reject);
+    });
+    ws.send(
+      JSON.stringify({ type: "session.start", callId, threadId: "t", caller: { aadId: "a" } }),
+    );
+    await waitFor(() => started);
+
+    ws.close(); // abrupt close — no session.end frame
+
+    await waitFor(() => ends.length > 0);
+    expect(ends).toEqual([{ callId, reason: "socket-closed" }]);
+  });
+
+  it("does not double-fire onSessionEnd when the socket closes after session.end", async () => {
+    const port = randomPort();
+    const ends: Array<{ callId: string; reason: string }> = [];
+    server = await startServer({ port, onSessionEnd: (info) => ends.push(info) });
+
+    const callId = "call-end-once";
+    const ws = openAuthed(port, callId);
+    await new Promise<void>((resolve, reject) => {
+      ws.once("open", () => resolve());
+      ws.once("error", reject);
+    });
+    ws.send(
+      JSON.stringify({ type: "session.start", callId, threadId: "t", caller: { aadId: "a" } }),
+    );
+    ws.send(JSON.stringify({ type: "session.end", reason: "call-ended" }));
+
+    await waitFor(() => ends.length > 0);
+    // The server closes the socket after session.end; let the close event run.
+    await new Promise<void>((resolve) => setTimeout(resolve, 100));
+    expect(ends).toEqual([{ callId, reason: "call-ended" }]);
+  });
+
+  it("does not fire onSessionEnd when the socket closes before session.start", async () => {
+    const port = randomPort();
+    const ends: Array<{ callId: string; reason: string }> = [];
+    server = await startServer({ port, onSessionEnd: (info) => ends.push(info) });
+
+    const ws = openAuthed(port, "call-prestart");
+    await new Promise<void>((resolve, reject) => {
+      ws.once("open", () => resolve());
+      ws.once("error", reject);
+    });
+    ws.close(); // close before any session.start
+
+    await new Promise<void>((resolve) => setTimeout(resolve, 100));
+    expect(ends).toHaveLength(0);
+  });
+
   it("drops the connection when an inbound frame exceeds the payload cap", async () => {
     const port = randomPort();
     let frames = 0;

--- a/extensions/voice-call/src/msteams-media-stream.test.ts
+++ b/extensions/voice-call/src/msteams-media-stream.test.ts
@@ -1,0 +1,451 @@
+import crypto from "node:crypto";
+import { afterEach, describe, expect, it } from "vitest";
+import { WebSocket } from "ws";
+import { MsteamsMediaStream, type MsteamsSession } from "./msteams-media-stream.js";
+
+const SECRET = "test-shared-secret";
+const PATH = "/voice/msteams/stream";
+
+function signHmac(secret: string, ts: number, callId: string): string {
+  return crypto.createHmac("sha256", secret).update(`${ts}.${callId}`).digest("hex");
+}
+
+/** Pick a port unlikely to collide. Range 31000-39999. */
+function randomPort(): number {
+  return 31000 + Math.floor(Math.random() * 9000);
+}
+
+async function startServer(opts: {
+  port: number;
+  maxConnections?: number;
+  maxConnectionsPerIp?: number;
+  preStartTimeoutMs?: number;
+  onSessionStart?: (s: MsteamsSession) => void;
+  onSessionEnd?: (info: { callId: string; reason: string }) => void;
+  onAudioFrame?: (info: {
+    callId: string;
+    seq: number;
+    timestampMs: number;
+    payload: Buffer;
+  }) => void;
+  onRecordingStatus?: (info: { callId: string; status: string }) => void;
+}): Promise<MsteamsMediaStream> {
+  const server = new MsteamsMediaStream({
+    port: opts.port,
+    path: PATH,
+    sharedSecret: SECRET,
+    maxConnections: opts.maxConnections,
+    maxConnectionsPerIp: opts.maxConnectionsPerIp,
+    preStartTimeoutMs: opts.preStartTimeoutMs,
+    onSessionStart: opts.onSessionStart,
+    onSessionEnd: opts.onSessionEnd,
+    onAudioFrame: opts.onAudioFrame,
+    onRecordingStatus: opts.onRecordingStatus,
+  });
+  await server.start();
+  return server;
+}
+
+/** Open an authenticated WS connection for a callId. */
+function openAuthed(port: number, callId: string): WebSocket {
+  const ts = Date.now();
+  return new WebSocket(`ws://127.0.0.1:${port}${PATH}/${callId}`, {
+    headers: {
+      "x-openclawteamsbridge-timestamp": String(ts),
+      "x-openclawteamsbridge-signature": signHmac(SECRET, ts, callId),
+    },
+  });
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 1000): Promise<void> {
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error("waitFor timed out");
+    }
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 10);
+    });
+  }
+}
+
+describe("MsteamsMediaStream", () => {
+  let server: MsteamsMediaStream | undefined;
+
+  afterEach(async () => {
+    if (server) {
+      await server.stop();
+      server = undefined;
+    }
+  });
+
+  it("accepts a connection with valid HMAC + parses session.start", async () => {
+    const port = randomPort();
+    let receivedSession: MsteamsSession | undefined;
+    server = await startServer({
+      port,
+      onSessionStart: (s) => {
+        receivedSession = s;
+      },
+    });
+
+    const callId = "call-abc";
+    const ts = Date.now();
+    const sig = signHmac(SECRET, ts, callId);
+
+    const ws = new WebSocket(`ws://127.0.0.1:${port}${PATH}/${callId}`, {
+      headers: {
+        "x-openclawteamsbridge-timestamp": String(ts),
+        "x-openclawteamsbridge-signature": sig,
+      },
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      ws.once("open", () => resolve());
+      ws.once("error", reject);
+    });
+
+    ws.send(
+      JSON.stringify({
+        type: "session.start",
+        callId,
+        threadId: "thread-xyz",
+        caller: { aadId: "aad-1", displayName: "Alice", tenantId: "tenant-1" },
+      }),
+    );
+
+    await waitFor(() => receivedSession !== undefined);
+
+    expect(receivedSession?.callId).toBe(callId);
+    expect(receivedSession?.threadId).toBe("thread-xyz");
+    expect(receivedSession?.caller.displayName).toBe("Alice");
+    expect(receivedSession?.caller.aadId).toBe("aad-1");
+    expect(server.sessionCount).toBe(1);
+
+    ws.close();
+  });
+
+  it("rejects upgrade with a bad HMAC signature", async () => {
+    const port = randomPort();
+    server = await startServer({ port });
+
+    const callId = "call-bad-sig";
+    const ws = new WebSocket(`ws://127.0.0.1:${port}${PATH}/${callId}`, {
+      headers: {
+        "x-openclawteamsbridge-timestamp": String(Date.now()),
+        "x-openclawteamsbridge-signature": "deadbeef",
+      },
+    });
+
+    const outcome = await new Promise<"unexpected-response" | "error" | "open">((resolve) => {
+      ws.once("unexpected-response", (_req, res) => {
+        expect(res.statusCode).toBe(401);
+        resolve("unexpected-response");
+      });
+      ws.once("error", () => resolve("error"));
+      ws.once("open", () => resolve("open"));
+    });
+
+    expect(outcome).not.toBe("open");
+    expect(server.sessionCount).toBe(0);
+  });
+
+  it("rejects upgrade when timestamp is far outside the HMAC window", async () => {
+    const port = randomPort();
+    server = await startServer({ port });
+
+    const callId = "call-stale-ts";
+    const staleTs = Date.now() - 5 * 60_000; // 5 minutes old
+    const sig = signHmac(SECRET, staleTs, callId);
+
+    const ws = new WebSocket(`ws://127.0.0.1:${port}${PATH}/${callId}`, {
+      headers: {
+        "x-openclawteamsbridge-timestamp": String(staleTs),
+        "x-openclawteamsbridge-signature": sig,
+      },
+    });
+
+    const outcome = await new Promise<"unexpected-response" | "error" | "open">((resolve) => {
+      ws.once("unexpected-response", () => resolve("unexpected-response"));
+      ws.once("error", () => resolve("error"));
+      ws.once("open", () => resolve("open"));
+    });
+
+    expect(outcome).not.toBe("open");
+  });
+
+  it("rejects upgrade missing the callId in the path", async () => {
+    const port = randomPort();
+    server = await startServer({ port });
+
+    const ts = Date.now();
+    const sig = signHmac(SECRET, ts, "");
+    const ws = new WebSocket(`ws://127.0.0.1:${port}${PATH}`, {
+      headers: {
+        "x-openclawteamsbridge-timestamp": String(ts),
+        "x-openclawteamsbridge-signature": sig,
+      },
+    });
+
+    const outcome = await new Promise<"unexpected-response" | "error" | "open">((resolve) => {
+      ws.once("unexpected-response", () => resolve("unexpected-response"));
+      ws.once("error", () => resolve("error"));
+      ws.once("open", () => resolve("open"));
+    });
+
+    expect(outcome).not.toBe("open");
+  });
+
+  it("decodes audio.frame and emits via onAudioFrame", async () => {
+    const port = randomPort();
+    const received: Array<{ callId: string; seq: number; payload: Buffer }> = [];
+    server = await startServer({
+      port,
+      onAudioFrame: (info) => {
+        received.push({ callId: info.callId, seq: info.seq, payload: info.payload });
+      },
+    });
+
+    const callId = "call-audio";
+    const ts = Date.now();
+    const sig = signHmac(SECRET, ts, callId);
+    const ws = new WebSocket(`ws://127.0.0.1:${port}${PATH}/${callId}`, {
+      headers: {
+        "x-openclawteamsbridge-timestamp": String(ts),
+        "x-openclawteamsbridge-signature": sig,
+      },
+    });
+    await new Promise<void>((resolve, reject) => {
+      ws.once("open", () => resolve());
+      ws.once("error", reject);
+    });
+
+    const rawAudio = Buffer.from([0x01, 0x02, 0x03, 0x04]);
+    ws.send(
+      JSON.stringify({
+        type: "audio.frame",
+        seq: 42,
+        timestampMs: Date.now(),
+        payloadBase64: rawAudio.toString("base64"),
+      }),
+    );
+
+    await waitFor(() => received.length > 0);
+    expect(received[0]?.callId).toBe(callId);
+    expect(received[0]?.seq).toBe(42);
+    expect(received[0]?.payload.equals(rawAudio)).toBe(true);
+
+    ws.close();
+  });
+
+  it("session.end triggers onSessionEnd and closes the socket", async () => {
+    const port = randomPort();
+    let endInfo: { callId: string; reason: string } | undefined;
+    server = await startServer({
+      port,
+      onSessionEnd: (info) => {
+        endInfo = info;
+      },
+    });
+
+    const callId = "call-end";
+    const ts = Date.now();
+    const sig = signHmac(SECRET, ts, callId);
+    const ws = new WebSocket(`ws://127.0.0.1:${port}${PATH}/${callId}`, {
+      headers: {
+        "x-openclawteamsbridge-timestamp": String(ts),
+        "x-openclawteamsbridge-signature": sig,
+      },
+    });
+    await new Promise<void>((resolve, reject) => {
+      ws.once("open", () => resolve());
+      ws.once("error", reject);
+    });
+
+    ws.send(JSON.stringify({ type: "session.end", reason: "call-ended" }));
+
+    await waitFor(() => endInfo !== undefined);
+    expect(endInfo?.callId).toBe(callId);
+    expect(endInfo?.reason).toBe("call-ended");
+  });
+
+  it("drops the connection when an inbound frame exceeds the payload cap", async () => {
+    const port = randomPort();
+    let frames = 0;
+    server = await startServer({
+      port,
+      onAudioFrame: () => {
+        frames += 1;
+      },
+    });
+
+    const callId = "call-oversize";
+    const ts = Date.now();
+    const sig = signHmac(SECRET, ts, callId);
+    const ws = new WebSocket(`ws://127.0.0.1:${port}${PATH}/${callId}`, {
+      headers: {
+        "x-openclawteamsbridge-timestamp": String(ts),
+        "x-openclawteamsbridge-signature": sig,
+      },
+    });
+    await new Promise<void>((resolve, reject) => {
+      ws.once("open", () => resolve());
+      ws.once("error", reject);
+    });
+
+    // ~70 KB base64 payload — over the 64 KB inbound cap. ws closes oversized
+    // frames with code 1009 (message too big) before they reach JSON parsing.
+    const closeCode = await new Promise<number>((resolve) => {
+      ws.once("close", (code) => resolve(code));
+      ws.send(
+        JSON.stringify({
+          type: "audio.frame",
+          seq: 0,
+          timestampMs: Date.now(),
+          payloadBase64: "A".repeat(70 * 1024),
+        }),
+      );
+    });
+
+    expect(closeCode).toBe(1009);
+    expect(frames).toBe(0);
+  });
+
+  it("rejects connections beyond maxConnections", async () => {
+    const port = randomPort();
+    server = await startServer({ port, maxConnections: 1 });
+
+    const ws1 = openAuthed(port, "call-cap-1");
+    await new Promise<void>((resolve, reject) => {
+      ws1.once("open", () => resolve());
+      ws1.once("error", reject);
+    });
+    expect(server.sessionCount).toBe(1);
+
+    const ws2 = openAuthed(port, "call-cap-2");
+    const outcome = await new Promise<"unexpected-response" | "error" | "open">((resolve) => {
+      ws2.once("unexpected-response", (_req, res) => {
+        expect(res.statusCode).toBe(503);
+        resolve("unexpected-response");
+      });
+      ws2.once("error", () => resolve("error"));
+      ws2.once("open", () => resolve("open"));
+    });
+    expect(outcome).not.toBe("open");
+    expect(server.sessionCount).toBe(1);
+    ws1.close();
+  });
+
+  it("rejects connections beyond maxConnectionsPerIp", async () => {
+    const port = randomPort();
+    server = await startServer({ port, maxConnectionsPerIp: 1 });
+
+    const ws1 = openAuthed(port, "call-ip-1");
+    await new Promise<void>((resolve, reject) => {
+      ws1.once("open", () => resolve());
+      ws1.once("error", reject);
+    });
+
+    const ws2 = openAuthed(port, "call-ip-2");
+    const outcome = await new Promise<"unexpected-response" | "error" | "open">((resolve) => {
+      ws2.once("unexpected-response", (_req, res) => {
+        expect(res.statusCode).toBe(503);
+        resolve("unexpected-response");
+      });
+      ws2.once("error", () => resolve("error"));
+      ws2.once("open", () => resolve("open"));
+    });
+    expect(outcome).not.toBe("open");
+    ws1.close();
+  });
+
+  it("rejects session.start whose callId does not match the authenticated path", async () => {
+    const port = randomPort();
+    let started = false;
+    server = await startServer({
+      port,
+      onSessionStart: () => {
+        started = true;
+      },
+    });
+
+    const ws = openAuthed(port, "call-auth");
+    await new Promise<void>((resolve, reject) => {
+      ws.once("open", () => resolve());
+      ws.once("error", reject);
+    });
+
+    const closeCode = await new Promise<number>((resolve) => {
+      ws.once("close", (code) => resolve(code));
+      ws.send(
+        JSON.stringify({
+          type: "session.start",
+          callId: "call-spoofed",
+          threadId: "thread-1",
+          caller: { aadId: "aad-1" },
+        }),
+      );
+    });
+
+    expect(started).toBe(false);
+    expect(closeCode).toBeGreaterThan(0);
+    expect(server.sessionCount).toBe(0);
+  });
+
+  it("closes a connection that never sends session.start", async () => {
+    const port = randomPort();
+    server = await startServer({ port, preStartTimeoutMs: 120 });
+
+    const ws = openAuthed(port, "call-idle");
+    await new Promise<void>((resolve, reject) => {
+      ws.once("open", () => resolve());
+      ws.once("error", reject);
+    });
+    expect(server.sessionCount).toBe(1);
+
+    await new Promise<void>((resolve) => {
+      ws.once("close", () => resolve());
+    });
+    expect(server.sessionCount).toBe(0);
+  });
+
+  it("surfaces recording status from session.start and recording.status messages", async () => {
+    const port = randomPort();
+    let startStatus: string | undefined;
+    const statuses: string[] = [];
+    server = await startServer({
+      port,
+      onSessionStart: (s) => {
+        startStatus = s.recordingStatus;
+      },
+      onRecordingStatus: (info) => {
+        statuses.push(info.status);
+      },
+    });
+
+    const callId = "call-rec";
+    const ws = openAuthed(port, callId);
+    await new Promise<void>((resolve, reject) => {
+      ws.once("open", () => resolve());
+      ws.once("error", reject);
+    });
+
+    ws.send(
+      JSON.stringify({
+        type: "session.start",
+        callId,
+        threadId: "thread-rec",
+        caller: { aadId: "aad-1" },
+        recordingStatus: "inactive",
+      }),
+    );
+    await waitFor(() => startStatus !== undefined);
+    expect(startStatus).toBe("inactive");
+
+    ws.send(JSON.stringify({ type: "recording.status", status: "active" }));
+    await waitFor(() => statuses.length > 0);
+    expect(statuses).toEqual(["active"]);
+
+    ws.close();
+  });
+});

--- a/extensions/voice-call/src/msteams-media-stream.test.ts
+++ b/extensions/voice-call/src/msteams-media-stream.test.ts
@@ -29,6 +29,15 @@ async function startServer(opts: {
     payload: Buffer;
   }) => void;
   onRecordingStatus?: (info: { callId: string; status: string }) => void;
+  onVideoFrame?: (info: {
+    callId: string;
+    source: "camera" | "screenshare";
+    ts: number;
+    width: number;
+    height: number;
+    mime: string;
+    dataBase64: string;
+  }) => void;
 }): Promise<MsteamsMediaStream> {
   const server = new MsteamsMediaStream({
     port: opts.port,
@@ -41,6 +50,7 @@ async function startServer(opts: {
     onSessionEnd: opts.onSessionEnd,
     onAudioFrame: opts.onAudioFrame,
     onRecordingStatus: opts.onRecordingStatus,
+    onVideoFrame: opts.onVideoFrame,
   });
   await server.start();
   return server;
@@ -364,8 +374,8 @@ describe("MsteamsMediaStream", () => {
       ws.once("error", reject);
     });
 
-    // ~70 KB base64 payload — over the 64 KB inbound cap. ws closes oversized
-    // frames with code 1009 (message too big) before they reach JSON parsing.
+    // ~3 MB base64 payload — over the 2 MB inbound cap (sized for video.frame). ws closes
+    // oversized frames with code 1009 (message too big) before they reach JSON parsing.
     const closeCode = await new Promise<number>((resolve) => {
       ws.once("close", (code) => resolve(code));
       ws.send(
@@ -373,13 +383,46 @@ describe("MsteamsMediaStream", () => {
           type: "audio.frame",
           seq: 0,
           timestampMs: Date.now(),
-          payloadBase64: "A".repeat(70 * 1024),
+          payloadBase64: "A".repeat(3 * 1024 * 1024),
         }),
       );
     });
 
     expect(closeCode).toBe(1009);
     expect(frames).toBe(0);
+  });
+
+  it("parses video.frame and emits via onVideoFrame", async () => {
+    const port = randomPort();
+    const received: Array<{ source: string; width: number; height: number; dataBase64: string }> =
+      [];
+    server = await startServer({ port, onVideoFrame: (info) => received.push(info) });
+
+    const callId = "call-video";
+    const ws = openAuthed(port, callId);
+    await new Promise<void>((resolve, reject) => {
+      ws.once("open", () => resolve());
+      ws.once("error", reject);
+    });
+    ws.send(
+      JSON.stringify({
+        type: "video.frame",
+        source: "screenshare",
+        ts: 1719,
+        width: 1280,
+        height: 720,
+        mime: "image/jpeg",
+        dataBase64: "AQID",
+      }),
+    );
+
+    await waitFor(() => received.length > 0);
+    expect(received[0]).toMatchObject({
+      source: "screenshare",
+      width: 1280,
+      height: 720,
+      dataBase64: "AQID",
+    });
   });
 
   it("rejects connections beyond maxConnections", async () => {

--- a/extensions/voice-call/src/msteams-media-stream.ts
+++ b/extensions/voice-call/src/msteams-media-stream.ts
@@ -64,11 +64,27 @@ const PingSchema = z.object({
   ts: z.number().int().nonnegative(),
 });
 
+/**
+ * A sampled inbound video frame (caller camera or screen-share) the worker forwards so the agent
+ * can "see" what the caller shows it. Sparse (a frame every few seconds), JPEG, already downscaled
+ * worker-side. Much larger than audio — see the inbound payload cap.
+ */
+const VideoFrameSchema = z.object({
+  type: z.literal("video.frame"),
+  source: z.enum(["camera", "screenshare"]),
+  ts: z.number().int().nonnegative(),
+  width: z.number().int().positive(),
+  height: z.number().int().positive(),
+  mime: z.string().min(1),
+  dataBase64: z.string().min(1),
+});
+
 const InboundMessageSchema = z.discriminatedUnion("type", [
   SessionStartSchema,
   SessionEndSchema,
   RecordingStatusMessageSchema,
   AudioFrameSchema,
+  VideoFrameSchema,
   PingSchema,
 ]);
 
@@ -130,6 +146,16 @@ export interface MsteamsMediaStreamConfig {
     timestampMs: number;
     payload: Buffer;
   }) => void;
+  /** A sampled inbound video frame (caller camera or screen-share) for the agent to "see". */
+  onVideoFrame?: (info: {
+    callId: string;
+    source: "camera" | "screenshare";
+    ts: number;
+    width: number;
+    height: number;
+    mime: string;
+    dataBase64: string;
+  }) => void;
 }
 
 const DEFAULT_HMAC_WINDOW_MS = 60_000;
@@ -143,12 +169,13 @@ const DEFAULT_HMAC_WINDOW_MS = 60_000;
 const DEFAULT_BIND_ADDRESS = "127.0.0.1";
 
 /**
- * Hard cap on a single inbound WebSocket frame. Legitimate messages are small
- * JSON envelopes — control messages plus one base64-encoded PCM audio frame,
- * well under 1 KB. Bounding the payload rejects oversized frames before they
- * reach JSON parsing, mitigating memory-exhaustion from unauthenticated peers.
+ * Hard cap on a single inbound WebSocket frame. Control + audio messages are tiny
+ * (<1 KB), but a `video.frame` carries a base64 JPEG (the worker downscales and caps
+ * the JPEG at ~1 MB, so base64 ≈ 1.4 MB). The cap is sized to admit one such frame
+ * and still bound memory: the sender is the HMAC-authenticated worker, not an
+ * arbitrary peer, so the looser bound only loosens the trusted path.
  */
-const MAX_INBOUND_PAYLOAD_BYTES = 64 * 1024;
+const MAX_INBOUND_PAYLOAD_BYTES = 2 * 1024 * 1024;
 
 /**
  * Connection guardrails, mirroring the Twilio media-stream path so a valid
@@ -455,6 +482,18 @@ export class MsteamsMediaStream {
           seq: parsed.seq,
           timestampMs: parsed.timestampMs,
           payload: Buffer.from(parsed.payloadBase64, "base64"),
+        });
+        break;
+      }
+      case "video.frame": {
+        this.config.onVideoFrame?.({
+          callId,
+          source: parsed.source,
+          ts: parsed.ts,
+          width: parsed.width,
+          height: parsed.height,
+          mime: parsed.mime,
+          dataBase64: parsed.dataBase64,
         });
         break;
       }

--- a/extensions/voice-call/src/msteams-media-stream.ts
+++ b/extensions/voice-call/src/msteams-media-stream.ts
@@ -163,6 +163,8 @@ const DEFAULT_PRE_START_TIMEOUT_MS = 10_000;
 interface ConnectionMeta {
   ip: string;
   started: boolean;
+  /** Set once onSessionEnd has fired, so socket close does not double-deliver it. */
+  ended: boolean;
   preStartTimer: ReturnType<typeof setTimeout>;
 }
 
@@ -351,11 +353,21 @@ export class MsteamsMediaStream {
     if (typeof preStartTimer.unref === "function") {
       preStartTimer.unref();
     }
-    this.connectionMeta.set(callId, { ip, started: false, preStartTimer });
+    this.connectionMeta.set(callId, { ip, started: false, ended: false, preStartTimer });
     this.config.logger?.info(`MsteamsMediaStream: connection open ${callId}`);
 
     ws.on("message", (data) => this.handleMessage(callId, data));
     ws.on("close", () => {
+      // An abrupt socket close (worker crash, network loss, hangup without a
+      // session.end frame) must still tear down provider + manager state for a
+      // session that already started — otherwise the call record leaks until the
+      // stale-call reaper. The `ended` guard avoids double-delivery when the
+      // close follows an explicit session.end.
+      const meta = this.connectionMeta.get(callId);
+      if (meta?.started && !meta.ended) {
+        meta.ended = true;
+        this.config.onSessionEnd?.({ callId, reason: "socket-closed" });
+      }
       this.cleanupConnection(callId);
       this.config.logger?.info(`MsteamsMediaStream: connection closed ${callId}`);
     });
@@ -429,6 +441,10 @@ export class MsteamsMediaStream {
         break;
       }
       case "session.end": {
+        const meta = this.connectionMeta.get(callId);
+        if (meta) {
+          meta.ended = true;
+        }
         this.config.onSessionEnd?.({ callId, reason: parsed.reason });
         this.closeSession(callId, parsed.reason);
         break;

--- a/extensions/voice-call/src/msteams-media-stream.ts
+++ b/extensions/voice-call/src/msteams-media-stream.ts
@@ -1,0 +1,501 @@
+/**
+ * MsteamsMediaStream
+ *
+ * WebSocket server that accepts connections from an external Windows-side Teams
+ * bridge worker and relays Microsoft Teams call audio in both directions. One
+ * connection per Teams call, keyed by callId in the URL path.
+ *
+ * Responsibilities:
+ * - HTTP upgrade with HMAC-SHA256 verification of timestamp + callId, plus a
+ *   replay window on the timestamp.
+ * - Session lifecycle messages (session.start / session.end) parsed and emitted
+ *   via callbacks for the host to wire into voice-call's session machinery.
+ * - Inbound audio frames surfaced via `onAudioFrame` for the host to forward to
+ *   the realtime-transcription provider.
+ * - Outbound `send` and `close` exposed on the SessionStart callback so the host
+ *   can push synthesized TTS audio and control messages back to the worker.
+ */
+
+import crypto from "node:crypto";
+import http from "node:http";
+import type { Duplex } from "node:stream";
+import { safeEqualSecret } from "openclaw/plugin-sdk/security-runtime";
+import { type RawData, WebSocket, WebSocketServer } from "ws";
+import { z } from "zod";
+
+const RecordingStatusSchema = z.enum(["active", "inactive", "unknown"]);
+
+const SessionStartSchema = z.object({
+  type: z.literal("session.start"),
+  callId: z.string().min(1),
+  threadId: z.string().min(1),
+  caller: z.object({
+    aadId: z.string().nullable().optional(),
+    displayName: z.string().nullable().optional(),
+    tenantId: z.string().nullable().optional(),
+  }),
+  /**
+   * Microsoft Teams recording status at answer time. The worker must call Graph
+   * `updateRecordingStatus` before media-derived data may be persisted; it
+   * reports the resulting state here (and via `recording.status` if it changes).
+   */
+  recordingStatus: RecordingStatusSchema.optional(),
+});
+
+const SessionEndSchema = z.object({
+  type: z.literal("session.end"),
+  reason: z.string(),
+});
+
+const RecordingStatusMessageSchema = z.object({
+  type: z.literal("recording.status"),
+  status: RecordingStatusSchema,
+});
+
+const AudioFrameSchema = z.object({
+  type: z.literal("audio.frame"),
+  seq: z.number().int().nonnegative(),
+  timestampMs: z.number().int().nonnegative(),
+  payloadBase64: z.string(),
+});
+
+const PingSchema = z.object({
+  type: z.literal("ping"),
+  ts: z.number().int().nonnegative(),
+});
+
+const InboundMessageSchema = z.discriminatedUnion("type", [
+  SessionStartSchema,
+  SessionEndSchema,
+  RecordingStatusMessageSchema,
+  AudioFrameSchema,
+  PingSchema,
+]);
+
+export type MsteamsRecordingStatus = z.infer<typeof RecordingStatusSchema>;
+
+type InboundMessage = z.infer<typeof InboundMessageSchema>;
+
+export interface MsteamsLogger {
+  info(message: string): void;
+  warn(message: string): void;
+  error(message: string): void;
+  debug?(message: string): void;
+}
+
+export interface MsteamsSession {
+  callId: string;
+  threadId: string;
+  caller: {
+    aadId?: string | null;
+    displayName?: string | null;
+    tenantId?: string | null;
+  };
+  /** Teams recording status reported at answer time (if the worker set it). */
+  recordingStatus?: MsteamsRecordingStatus;
+  /** Push a JSON-serializable message back to the worker. No-op if the socket has closed. */
+  send: (message: unknown) => void;
+  /** Close the WebSocket gracefully with the given reason text. */
+  close: (reason: string) => void;
+}
+
+export interface MsteamsMediaStreamConfig {
+  port: number;
+  /**
+   * Interface address to bind the WebSocket server to. Defaults to the loopback
+   * interface (127.0.0.1) so the bridge is not exposed on all interfaces.
+   */
+  bindAddress?: string;
+  path: string;
+  sharedSecret: string;
+  /**
+   * Reject upgrades whose timestamp is more than this many ms off from the
+   * server clock. Mitigates replay. Default 60_000 (60 seconds).
+   */
+  hmacWindowMs?: number;
+  /** Hard cap on total concurrent connections (pending + active). Default 64. */
+  maxConnections?: number;
+  /** Hard cap on concurrent connections per source IP. Default 8. */
+  maxConnectionsPerIp?: number;
+  /** Close a connection that has not sent session.start within this many ms. Default 10_000. */
+  preStartTimeoutMs?: number;
+  logger?: MsteamsLogger;
+  onSessionStart?: (session: MsteamsSession) => void;
+  /** Teams recording status changed mid-call (worker called Graph updateRecordingStatus). */
+  onRecordingStatus?: (info: { callId: string; status: MsteamsRecordingStatus }) => void;
+  onSessionEnd?: (info: { callId: string; reason: string }) => void;
+  onAudioFrame?: (info: {
+    callId: string;
+    seq: number;
+    timestampMs: number;
+    payload: Buffer;
+  }) => void;
+}
+
+const DEFAULT_HMAC_WINDOW_MS = 60_000;
+
+/**
+ * Bind to loopback by default. The Teams bridge worker typically runs on the
+ * same host (or reaches OpenClaw over a private/VPN interface the operator names
+ * explicitly via `bindAddress`); binding all interfaces would expose the audio
+ * transport to untrusted networks.
+ */
+const DEFAULT_BIND_ADDRESS = "127.0.0.1";
+
+/**
+ * Hard cap on a single inbound WebSocket frame. Legitimate messages are small
+ * JSON envelopes — control messages plus one base64-encoded PCM audio frame,
+ * well under 1 KB. Bounding the payload rejects oversized frames before they
+ * reach JSON parsing, mitigating memory-exhaustion from unauthenticated peers.
+ */
+const MAX_INBOUND_PAYLOAD_BYTES = 64 * 1024;
+
+/**
+ * Connection guardrails, mirroring the Twilio media-stream path so a valid
+ * shared secret (or a leaked/misbehaving worker) cannot open call sockets
+ * unbounded and exhaust file descriptors or memory.
+ */
+const DEFAULT_MAX_CONNECTIONS = 64;
+const DEFAULT_MAX_CONNECTIONS_PER_IP = 8;
+const DEFAULT_PRE_START_TIMEOUT_MS = 10_000;
+
+/** Per-connection bookkeeping for caps + pre-start idle reaping. */
+interface ConnectionMeta {
+  ip: string;
+  started: boolean;
+  preStartTimer: ReturnType<typeof setTimeout>;
+}
+
+export class MsteamsMediaStream {
+  private readonly config: MsteamsMediaStreamConfig;
+  private readonly hmacWindowMs: number;
+  private readonly maxConnections: number;
+  private readonly maxConnectionsPerIp: number;
+  private readonly preStartTimeoutMs: number;
+  private readonly sessions = new Map<string, WebSocket>();
+  private readonly connectionMeta = new Map<string, ConnectionMeta>();
+  private readonly connectionsByIp = new Map<string, number>();
+  private server?: http.Server;
+  private wss?: WebSocketServer;
+
+  constructor(config: MsteamsMediaStreamConfig) {
+    this.config = config;
+    this.hmacWindowMs = config.hmacWindowMs ?? DEFAULT_HMAC_WINDOW_MS;
+    this.maxConnections = config.maxConnections ?? DEFAULT_MAX_CONNECTIONS;
+    this.maxConnectionsPerIp = config.maxConnectionsPerIp ?? DEFAULT_MAX_CONNECTIONS_PER_IP;
+    this.preStartTimeoutMs = config.preStartTimeoutMs ?? DEFAULT_PRE_START_TIMEOUT_MS;
+  }
+
+  async start(): Promise<void> {
+    if (this.server) {
+      throw new Error("MsteamsMediaStream is already started");
+    }
+
+    const server = http.createServer();
+    const wss = new WebSocketServer({ noServer: true, maxPayload: MAX_INBOUND_PAYLOAD_BYTES });
+
+    server.on("upgrade", (request, socket, head) => {
+      this.handleUpgrade(request, socket, head, wss);
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      const onError = (err: Error) => {
+        server.off("listening", onListening);
+        reject(err);
+      };
+      const onListening = () => {
+        server.off("error", onError);
+        resolve();
+      };
+      server.once("error", onError);
+      server.once("listening", onListening);
+      server.listen(this.config.port, this.config.bindAddress ?? DEFAULT_BIND_ADDRESS);
+    });
+
+    this.server = server;
+    this.wss = wss;
+    this.config.logger?.info(
+      `MsteamsMediaStream listening host=${this.config.bindAddress ?? DEFAULT_BIND_ADDRESS} port=${this.config.port} path=${this.config.path}`,
+    );
+  }
+
+  async stop(): Promise<void> {
+    if (!this.server) {
+      return;
+    }
+
+    for (const ws of this.sessions.values()) {
+      try {
+        ws.close(1001, "shutdown");
+      } catch {
+        // best-effort close
+      }
+    }
+    for (const meta of this.connectionMeta.values()) {
+      clearTimeout(meta.preStartTimer);
+    }
+    this.connectionMeta.clear();
+    this.connectionsByIp.clear();
+    this.sessions.clear();
+
+    this.wss?.close();
+    await new Promise<void>((resolve) => {
+      // server is non-null because we early-returned above; cast is for ts narrowing
+      const s = this.server as http.Server;
+      s.close(() => resolve());
+    });
+
+    this.server = undefined;
+    this.wss = undefined;
+    this.config.logger?.info("MsteamsMediaStream stopped");
+  }
+
+  /** Number of currently open sessions. Exposed for tests + telemetry. */
+  get sessionCount(): number {
+    return this.sessions.size;
+  }
+
+  private handleUpgrade(
+    request: http.IncomingMessage,
+    socket: Duplex,
+    head: Buffer,
+    wss: WebSocketServer,
+  ): void {
+    const url = new URL(request.url ?? "", "http://localhost");
+
+    if (!url.pathname.startsWith(this.config.path)) {
+      this.rejectUpgrade(socket, 404, "Not Found");
+      return;
+    }
+
+    const callId = url.pathname.slice(this.config.path.length).replace(/^\//, "");
+    if (!callId) {
+      this.rejectUpgrade(socket, 400, "Bad Request (missing callId)");
+      return;
+    }
+
+    const timestamp = request.headers["x-openclawteamsbridge-timestamp"];
+    const signature = request.headers["x-openclawteamsbridge-signature"];
+    if (typeof timestamp !== "string" || typeof signature !== "string") {
+      this.config.logger?.warn(
+        `MsteamsMediaStream: rejecting upgrade for ${callId} — missing HMAC headers`,
+      );
+      this.rejectUpgrade(socket, 401, "Unauthorized");
+      return;
+    }
+
+    const ts = Number(timestamp);
+    if (!Number.isFinite(ts) || Math.abs(Date.now() - ts) > this.hmacWindowMs) {
+      this.config.logger?.warn(
+        `MsteamsMediaStream: rejecting upgrade for ${callId} — timestamp out of window`,
+      );
+      this.rejectUpgrade(socket, 401, "Unauthorized");
+      return;
+    }
+
+    const expected = crypto
+      .createHmac("sha256", this.config.sharedSecret)
+      .update(`${ts}.${callId}`)
+      .digest("hex");
+    if (!safeEqualSecret(signature, expected)) {
+      this.config.logger?.warn(
+        `MsteamsMediaStream: rejecting upgrade for ${callId} — bad signature`,
+      );
+      this.rejectUpgrade(socket, 401, "Unauthorized");
+      return;
+    }
+
+    const ip = normalizeIp(request.socket.remoteAddress);
+    // Bound total + per-IP concurrent sockets before accepting the upgrade.
+    if (this.sessions.size >= this.maxConnections) {
+      this.config.logger?.warn(
+        `MsteamsMediaStream: rejecting ${callId} — max connections (${this.maxConnections}) reached`,
+      );
+      this.rejectUpgrade(socket, 503, "Too Many Connections");
+      return;
+    }
+    if ((this.connectionsByIp.get(ip) ?? 0) >= this.maxConnectionsPerIp) {
+      this.config.logger?.warn(
+        `MsteamsMediaStream: rejecting ${callId} — per-IP cap (${this.maxConnectionsPerIp}) reached for ${ip}`,
+      );
+      this.rejectUpgrade(socket, 503, "Too Many Connections");
+      return;
+    }
+
+    wss.handleUpgrade(request, socket, head, (ws) => {
+      this.attachSession(callId, ws, ip);
+    });
+  }
+
+  private attachSession(callId: string, ws: WebSocket, ip: string): void {
+    if (this.sessions.has(callId)) {
+      // Same callId already connected — close the new one to avoid clobbering.
+      try {
+        ws.close(1008, "duplicate-callId");
+      } catch {
+        // ignore
+      }
+      this.config.logger?.warn(`MsteamsMediaStream: rejected duplicate connection for ${callId}`);
+      return;
+    }
+
+    this.sessions.set(callId, ws);
+    this.connectionsByIp.set(ip, (this.connectionsByIp.get(ip) ?? 0) + 1);
+    // Reap sockets that authenticate but never send session.start (idle hold).
+    const preStartTimer = setTimeout(() => {
+      this.config.logger?.warn(
+        `MsteamsMediaStream: closing ${callId} — no session.start within ${this.preStartTimeoutMs}ms`,
+      );
+      this.closeSession(callId, "pre-start-timeout");
+    }, this.preStartTimeoutMs);
+    if (typeof preStartTimer.unref === "function") {
+      preStartTimer.unref();
+    }
+    this.connectionMeta.set(callId, { ip, started: false, preStartTimer });
+    this.config.logger?.info(`MsteamsMediaStream: connection open ${callId}`);
+
+    ws.on("message", (data) => this.handleMessage(callId, data));
+    ws.on("close", () => {
+      this.cleanupConnection(callId);
+      this.config.logger?.info(`MsteamsMediaStream: connection closed ${callId}`);
+    });
+    ws.on("error", (err) => {
+      const message = err instanceof Error ? err.message : String(err);
+      this.config.logger?.warn(`MsteamsMediaStream: ws error ${callId} — ${message}`);
+    });
+  }
+
+  /** Release per-connection tracking (timer, per-IP count, session entry). */
+  private cleanupConnection(callId: string): void {
+    const meta = this.connectionMeta.get(callId);
+    if (meta) {
+      clearTimeout(meta.preStartTimer);
+      const remaining = (this.connectionsByIp.get(meta.ip) ?? 1) - 1;
+      if (remaining > 0) {
+        this.connectionsByIp.set(meta.ip, remaining);
+      } else {
+        this.connectionsByIp.delete(meta.ip);
+      }
+      this.connectionMeta.delete(callId);
+    }
+    this.sessions.delete(callId);
+  }
+
+  private handleMessage(callId: string, data: RawData): void {
+    const text = rawDataToString(data);
+    if (text === null) {
+      return;
+    }
+
+    let parsed: InboundMessage;
+    try {
+      parsed = InboundMessageSchema.parse(JSON.parse(text));
+    } catch (err) {
+      this.config.logger?.warn(
+        `MsteamsMediaStream: invalid message from ${callId}: ${(err as Error).message}`,
+      );
+      return;
+    }
+
+    switch (parsed.type) {
+      case "session.start": {
+        // The callId is authenticated via HMAC in the URL path; a session.start
+        // body claiming a different callId must be rejected, otherwise the call
+        // record and the send/close closures would key off different ids.
+        if (parsed.callId !== callId) {
+          this.config.logger?.warn(
+            `MsteamsMediaStream: session.start callId mismatch (authenticated=${callId} payload=${parsed.callId}); closing`,
+          );
+          this.closeSession(callId, "callid-mismatch");
+          return;
+        }
+        const meta = this.connectionMeta.get(callId);
+        if (meta) {
+          meta.started = true;
+          clearTimeout(meta.preStartTimer);
+        }
+        this.config.onSessionStart?.({
+          callId,
+          threadId: parsed.threadId,
+          caller: parsed.caller,
+          recordingStatus: parsed.recordingStatus,
+          send: (message) => this.sendTo(callId, message),
+          close: (reason) => this.closeSession(callId, reason),
+        });
+        break;
+      }
+      case "recording.status": {
+        this.config.onRecordingStatus?.({ callId, status: parsed.status });
+        break;
+      }
+      case "session.end": {
+        this.config.onSessionEnd?.({ callId, reason: parsed.reason });
+        this.closeSession(callId, parsed.reason);
+        break;
+      }
+      case "audio.frame": {
+        this.config.onAudioFrame?.({
+          callId,
+          seq: parsed.seq,
+          timestampMs: parsed.timestampMs,
+          payload: Buffer.from(parsed.payloadBase64, "base64"),
+        });
+        break;
+      }
+      case "ping": {
+        this.sendTo(callId, { type: "pong", ts: parsed.ts });
+        break;
+      }
+    }
+  }
+
+  private sendTo(callId: string, message: unknown): void {
+    const ws = this.sessions.get(callId);
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify(message));
+    }
+  }
+
+  private closeSession(callId: string, reason: string): void {
+    const ws = this.sessions.get(callId);
+    if (!ws) {
+      return;
+    }
+    try {
+      ws.close(1000, reason);
+    } catch {
+      // ignore
+    }
+    this.cleanupConnection(callId);
+  }
+
+  private rejectUpgrade(socket: Duplex, code: number, reason: string): void {
+    socket.write(`HTTP/1.1 ${code} ${reason}\r\nConnection: close\r\n\r\n`);
+    socket.destroy();
+  }
+}
+
+function normalizeIp(raw: string | undefined): string {
+  if (!raw) {
+    return "unknown";
+  }
+  // Collapse IPv4-mapped IPv6 (::ffff:1.2.3.4 -> 1.2.3.4) for stable per-IP keys.
+  return raw.startsWith("::ffff:") ? raw.slice("::ffff:".length) : raw;
+}
+
+function rawDataToString(data: RawData): string | null {
+  if (typeof data === "string") {
+    return data;
+  }
+  if (Buffer.isBuffer(data)) {
+    return data.toString("utf8");
+  }
+  if (Array.isArray(data)) {
+    return Buffer.concat(data).toString("utf8");
+  }
+  // ArrayBuffer fallback
+  if (data instanceof ArrayBuffer) {
+    return Buffer.from(data).toString("utf8");
+  }
+  return null;
+}

--- a/extensions/voice-call/src/msteams-realtime.test.ts
+++ b/extensions/voice-call/src/msteams-realtime.test.ts
@@ -220,6 +220,38 @@ describe("createMsteamsRealtimeCall", () => {
     );
   });
 
+  it("refuses a background task (no ack) when the caller has no AAD delivery target", () => {
+    const ctx = createMockSession();
+    ctx.session.caller.aadId = null; // anonymous caller — no Teams chat to deliver to
+    const mock = createMockProvider();
+    createMsteamsRealtimeCall({
+      session: ctx.session,
+      deps: {
+        provider: mock.provider,
+        providerConfig: {},
+        tools: [CONSULT_TOOL],
+        toolPolicy: "owner",
+        agentRuntime: {} as unknown as CoreAgentDeps,
+        voiceConfig: {} as unknown as VoiceCallConfig,
+        cfg: {} as unknown as OpenClawConfig,
+      },
+    });
+
+    mock.getRequest().onToolCall?.({
+      itemId: "item-3",
+      callId: "task-call-2",
+      name: "openclaw_agent_task",
+      args: { task: "do a big multi-step thing" },
+    });
+
+    const texts = mock.submitToolResult.mock.calls
+      .filter((args) => args[0] === "task-call-2")
+      .map((args) => (args[1] as { text: string }).text);
+    // Refused with the no-target message, and never acked a delivery it can't make.
+    expect(texts.some((t) => t.includes("don't have a Teams chat"))).toBe(true);
+    expect(texts.some((t) => t.includes("I'll message you"))).toBe(false);
+  });
+
   it("refuses a consult tool call until Teams recording status is active (Media Access API)", () => {
     const ctx = createMockSession("inactive");
     const mock = createMockProvider();

--- a/extensions/voice-call/src/msteams-realtime.test.ts
+++ b/extensions/voice-call/src/msteams-realtime.test.ts
@@ -323,6 +323,63 @@ describe("createMsteamsRealtimeCall", () => {
     expect(arg.images?.[0]).toMatchObject({ type: "image", data: "AQID", mimeType: "image/jpeg" });
   });
 
+  it("look_at_screen caches the answer for an unchanged frame and re-runs when it changes", async () => {
+    consultSpy.mockClear();
+    consultSpy.mockResolvedValue({ text: "A stack trace." });
+    const ctx = createMockSession();
+    const mock = createMockProvider();
+    let frameData = "AQID";
+    createMsteamsRealtimeCall({
+      session: ctx.session,
+      deps: {
+        provider: mock.provider,
+        providerConfig: {},
+        tools: [CONSULT_TOOL],
+        toolPolicy: "owner",
+        agentRuntime: { resolveThinkingDefault: () => "high" } as unknown as CoreAgentDeps,
+        voiceConfig: { realtime: {}, agentId: "main" } as unknown as VoiceCallConfig,
+        cfg: {} as unknown as OpenClawConfig,
+        getLatestFrame: () => ({
+          dataBase64: frameData,
+          mime: "image/jpeg",
+          width: 100,
+          height: 100,
+        }),
+      },
+    });
+    const req = mock.getRequest();
+
+    req.onToolCall?.({
+      itemId: "i1",
+      callId: "c1",
+      name: "look_at_screen",
+      args: { question: "x" },
+    });
+    await vi.waitFor(() => expect(consultSpy).toHaveBeenCalledTimes(1));
+
+    // Same frame again → cache hit, no second vision run.
+    req.onToolCall?.({
+      itemId: "i2",
+      callId: "c2",
+      name: "look_at_screen",
+      args: { question: "x2" },
+    });
+    await new Promise<void>((r) => {
+      setTimeout(r, 30);
+    });
+    expect(consultSpy).toHaveBeenCalledTimes(1);
+
+    // Frame changed → re-runs.
+    frameData = "BAUG";
+    req.onToolCall?.({
+      itemId: "i3",
+      callId: "c3",
+      name: "look_at_screen",
+      args: { question: "now?" },
+    });
+    await vi.waitFor(() => expect(consultSpy).toHaveBeenCalledTimes(2));
+  });
+
   it("refuses a consult tool call until Teams recording status is active (Media Access API)", () => {
     const ctx = createMockSession("inactive");
     const mock = createMockProvider();

--- a/extensions/voice-call/src/msteams-realtime.test.ts
+++ b/extensions/voice-call/src/msteams-realtime.test.ts
@@ -252,6 +252,77 @@ describe("createMsteamsRealtimeCall", () => {
     expect(texts.some((t) => t.includes("I'll message you"))).toBe(false);
   });
 
+  it("exposes look_at_screen and answers with a no-frame message when nothing is shared", () => {
+    const ctx = createMockSession();
+    const mock = createMockProvider();
+    createMsteamsRealtimeCall({
+      session: ctx.session,
+      deps: {
+        provider: mock.provider,
+        providerConfig: {},
+        tools: [CONSULT_TOOL],
+        toolPolicy: "owner",
+        agentRuntime: { resolveThinkingDefault: () => "high" } as unknown as CoreAgentDeps,
+        voiceConfig: { realtime: {}, agentId: "main" } as unknown as VoiceCallConfig,
+        cfg: {} as unknown as OpenClawConfig,
+        getLatestFrame: () => undefined, // nothing shared yet
+      },
+    });
+
+    const req = mock.getRequest();
+    expect((req.tools ?? []).map((t) => t.name)).toContain("look_at_screen");
+
+    req.onToolCall?.({
+      itemId: "i-look-0",
+      callId: "look-0",
+      name: "look_at_screen",
+      args: { question: "what's on my screen?" },
+    });
+
+    const texts = mock.submitToolResult.mock.calls
+      .filter((args) => args[0] === "look-0")
+      .map((args) => (args[1] as { text: string }).text);
+    expect(texts.some((t) => t.includes("can't see anything yet"))).toBe(true);
+  });
+
+  it("look_at_screen runs the agent with the latest frame as an image", async () => {
+    consultSpy.mockClear();
+    consultSpy.mockResolvedValueOnce({ text: "Your screen shows a stack trace on line 42." });
+    const ctx = createMockSession();
+    const mock = createMockProvider();
+    createMsteamsRealtimeCall({
+      session: ctx.session,
+      deps: {
+        provider: mock.provider,
+        providerConfig: {},
+        tools: [CONSULT_TOOL],
+        toolPolicy: "owner",
+        agentRuntime: { resolveThinkingDefault: () => "high" } as unknown as CoreAgentDeps,
+        voiceConfig: { realtime: {}, agentId: "main" } as unknown as VoiceCallConfig,
+        cfg: {} as unknown as OpenClawConfig,
+        getLatestFrame: () => ({
+          dataBase64: "AQID",
+          mime: "image/jpeg",
+          width: 1280,
+          height: 720,
+        }),
+      },
+    });
+
+    mock.getRequest().onToolCall?.({
+      itemId: "i-look-1",
+      callId: "look-1",
+      name: "look_at_screen",
+      args: { question: "read the error on my screen" },
+    });
+
+    await vi.waitFor(() => expect(consultSpy).toHaveBeenCalled());
+    const arg = consultSpy.mock.calls.at(-1)?.[0] as {
+      images?: Array<{ type: string; data: string; mimeType: string }>;
+    };
+    expect(arg.images?.[0]).toMatchObject({ type: "image", data: "AQID", mimeType: "image/jpeg" });
+  });
+
   it("refuses a consult tool call until Teams recording status is active (Media Access API)", () => {
     const ctx = createMockSession("inactive");
     const mock = createMockProvider();

--- a/extensions/voice-call/src/msteams-realtime.test.ts
+++ b/extensions/voice-call/src/msteams-realtime.test.ts
@@ -1,0 +1,380 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import {
+  REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME,
+  type RealtimeVoiceBridge,
+  type RealtimeVoiceBridgeCreateRequest,
+  type RealtimeVoiceProviderPlugin,
+  type RealtimeVoiceTool,
+} from "openclaw/plugin-sdk/realtime-voice";
+import { describe, expect, it, vi } from "vitest";
+import type { VoiceCallConfig } from "./config.js";
+import type { CoreAgentDeps } from "./core-bridge.js";
+import type { MsteamsSession } from "./msteams-media-stream.js";
+import { createMsteamsRealtimeCall, type MsteamsRealtimeDeps } from "./msteams-realtime.js";
+
+// Capture the transcript handed to the consult agent, while keeping the rest of
+// the realtime-voice SDK (createRealtimeVoiceBridgeSession, etc.) real.
+const consultSpy = vi.hoisted(() =>
+  vi.fn(async (_opts?: { transcript?: unknown }) => ({ text: "ok" })),
+);
+vi.mock("openclaw/plugin-sdk/realtime-voice", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/realtime-voice")>();
+  return { ...actual, consultRealtimeVoiceAgent: consultSpy };
+});
+vi.mock("./realtime-fast-context.js", () => ({
+  resolveRealtimeFastContextConsult: vi.fn(async () => ({ handled: false })),
+}));
+vi.mock("./response-model.js", () => ({
+  resolveVoiceResponseModel: vi.fn(() => ({ provider: "openai", model: "gpt-x" })),
+}));
+
+function createMockSession(recordingStatus: MsteamsSession["recordingStatus"] = "active"): {
+  session: MsteamsSession;
+  sent: unknown[];
+  closedReason: string | null;
+} {
+  const sent: unknown[] = [];
+  let closedReason: string | null = null;
+  const session: MsteamsSession = {
+    callId: "call-1",
+    threadId: "thread-1",
+    caller: { aadId: "aad-1", displayName: "Caller", tenantId: "tenant-1" },
+    recordingStatus,
+    send: (message) => sent.push(message),
+    close: (reason) => {
+      closedReason = reason;
+    },
+  };
+  return {
+    session,
+    sent,
+    get closedReason() {
+      return closedReason;
+    },
+  } as { session: MsteamsSession; sent: unknown[]; closedReason: string | null };
+}
+
+/** Mock realtime provider that captures the bridge create request so tests can drive callbacks. */
+function createMockProvider(): {
+  provider: RealtimeVoiceProviderPlugin;
+  getRequest: () => RealtimeVoiceBridgeCreateRequest;
+  submitToolResult: ReturnType<typeof vi.fn>;
+  sendAudio: ReturnType<typeof vi.fn>;
+} {
+  let request: RealtimeVoiceBridgeCreateRequest | undefined;
+  const submitToolResult = vi.fn();
+  const sendAudio = vi.fn();
+
+  const bridge: RealtimeVoiceBridge = {
+    supportsToolResultContinuation: true,
+    connect: async () => {},
+    sendAudio,
+    setMediaTimestamp: () => {},
+    submitToolResult,
+    acknowledgeMark: () => {},
+    close: () => {},
+    isConnected: () => true,
+  };
+
+  const provider = {
+    id: "openai",
+    label: "Mock Realtime",
+    isConfigured: () => true,
+    createBridge: (req: RealtimeVoiceBridgeCreateRequest) => {
+      request = req;
+      return bridge;
+    },
+  } as unknown as RealtimeVoiceProviderPlugin;
+
+  return {
+    provider,
+    getRequest: () => {
+      if (!request) {
+        throw new Error("createBridge was not called");
+      }
+      return request;
+    },
+    submitToolResult,
+    sendAudio,
+  };
+}
+
+const CONSULT_TOOL: RealtimeVoiceTool = {
+  type: "function",
+  name: REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME,
+  description: "consult",
+  parameters: { type: "object", properties: {} },
+};
+
+describe("createMsteamsRealtimeCall", () => {
+  it("forwards configured tools to the realtime bridge", () => {
+    const { session } = createMockSession();
+    const mock = createMockProvider();
+    const deps: MsteamsRealtimeDeps = {
+      provider: mock.provider,
+      providerConfig: {},
+      tools: [CONSULT_TOOL],
+    };
+
+    createMsteamsRealtimeCall({ session, deps });
+
+    expect(mock.getRequest().tools).toEqual([CONSULT_TOOL]);
+  });
+
+  it("plays model audio back to the caller as audio.frame and flushes on barge-in", () => {
+    const ctx = createMockSession();
+    const mock = createMockProvider();
+    createMsteamsRealtimeCall({
+      session: ctx.session,
+      deps: { provider: mock.provider, providerConfig: {} },
+    });
+
+    const req = mock.getRequest();
+    // Model emits 24 kHz PCM; bridge should resample + forward as audio.frame.
+    req.onAudio(Buffer.alloc(960));
+    const frame = ctx.sent.find(
+      (m): m is { type: string; payloadBase64: string } =>
+        typeof m === "object" && m !== null && (m as { type?: string }).type === "audio.frame",
+    );
+    expect(frame).toBeDefined();
+    expect(typeof frame?.payloadBase64).toBe("string");
+
+    // Barge-in -> assistant.cancel so the worker flushes its playback queue.
+    req.onClearAudio();
+    const cancel = ctx.sent.find(
+      (m) =>
+        typeof m === "object" && m !== null && (m as { type?: string }).type === "assistant.cancel",
+    );
+    expect(cancel).toBeDefined();
+  });
+
+  it("forwards caller audio into the bridge", () => {
+    const ctx = createMockSession();
+    const mock = createMockProvider();
+    const call = createMsteamsRealtimeCall({
+      session: ctx.session,
+      deps: { provider: mock.provider, providerConfig: {} },
+    });
+
+    call.pushAudio(Buffer.alloc(640)); // one 20 ms 16 kHz frame
+    expect(mock.sendAudio).toHaveBeenCalledTimes(1);
+    const forwarded = mock.sendAudio.mock.calls[0]?.[0] as Buffer;
+    expect(forwarded.length).toBeGreaterThan(0);
+  });
+
+  it("answers a consult tool call with an unavailable result when no agent runtime is wired", () => {
+    const ctx = createMockSession();
+    const mock = createMockProvider();
+    createMsteamsRealtimeCall({
+      session: ctx.session,
+      deps: { provider: mock.provider, providerConfig: {}, tools: [CONSULT_TOOL] },
+    });
+
+    mock.getRequest().onToolCall?.({
+      itemId: "item-1",
+      callId: "tool-call-1",
+      name: REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME,
+      args: { question: "do a thing" },
+    });
+
+    expect(mock.submitToolResult).toHaveBeenCalledWith(
+      "tool-call-1",
+      expect.objectContaining({ text: expect.any(String) }),
+      undefined,
+    );
+  });
+
+  it("exposes the async task tool under owner policy and acks a task call immediately", () => {
+    const ctx = createMockSession();
+    const mock = createMockProvider();
+    createMsteamsRealtimeCall({
+      session: ctx.session,
+      deps: {
+        provider: mock.provider,
+        providerConfig: {},
+        tools: [CONSULT_TOOL],
+        toolPolicy: "owner",
+        // Minimal fakes: enough to enable async + reach the (caught) background run.
+        agentRuntime: {} as unknown as CoreAgentDeps,
+        voiceConfig: {} as unknown as VoiceCallConfig,
+        cfg: {} as unknown as OpenClawConfig,
+      },
+    });
+
+    const req = mock.getRequest();
+    const toolNames = (req.tools ?? []).map((t) => t.name);
+    expect(toolNames).toContain("openclaw_agent_task");
+
+    req.onToolCall?.({
+      itemId: "item-2",
+      callId: "task-call-1",
+      name: "openclaw_agent_task",
+      args: { task: "do a big multi-step thing" },
+    });
+
+    // The model is acknowledged synchronously; the agent runs in the background.
+    expect(mock.submitToolResult).toHaveBeenCalledWith(
+      "task-call-1",
+      expect.objectContaining({ text: expect.any(String) }),
+      undefined,
+    );
+  });
+
+  it("refuses a consult tool call until Teams recording status is active (Media Access API)", () => {
+    const ctx = createMockSession("inactive");
+    const mock = createMockProvider();
+    const call = createMsteamsRealtimeCall({
+      session: ctx.session,
+      deps: {
+        provider: mock.provider,
+        providerConfig: {},
+        tools: [CONSULT_TOOL],
+        // Wire an agent so refusal is the recording gate, not "agent unavailable".
+        agentRuntime: {} as unknown as CoreAgentDeps,
+        voiceConfig: { realtime: {} } as unknown as VoiceCallConfig,
+        cfg: {} as unknown as OpenClawConfig,
+      },
+    });
+
+    const req = mock.getRequest();
+    req.onToolCall?.({
+      itemId: "item-3",
+      callId: "tool-call-blocked",
+      name: REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME,
+      args: { question: "do real work" },
+    });
+
+    const refused = mock.submitToolResult.mock.calls.some(
+      (args) =>
+        args[0] === "tool-call-blocked" &&
+        typeof (args[1] as { text?: string })?.text === "string" &&
+        (args[1] as { text: string }).text.includes("recording isn't active"),
+    );
+    expect(refused).toBe(true);
+
+    // Once the worker reports recording active, the gate opens for the next call.
+    mock.submitToolResult.mockClear();
+    call.setRecordingActive(true);
+    req.onToolCall?.({
+      itemId: "item-4",
+      callId: "tool-call-allowed",
+      name: REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME,
+      args: { question: "do real work" },
+    });
+    const refusedAgain = mock.submitToolResult.mock.calls.some(
+      (args) =>
+        args[0] === "tool-call-allowed" &&
+        typeof (args[1] as { text?: string })?.text === "string" &&
+        (args[1] as { text: string }).text.includes("recording isn't active"),
+    );
+    expect(refusedAgain).toBe(false);
+  });
+
+  it("refuses a background task (no ack) until recording status is active", () => {
+    const ctx = createMockSession("inactive");
+    const mock = createMockProvider();
+    createMsteamsRealtimeCall({
+      session: ctx.session,
+      deps: {
+        provider: mock.provider,
+        providerConfig: {},
+        tools: [CONSULT_TOOL],
+        toolPolicy: "owner",
+        agentRuntime: {} as unknown as CoreAgentDeps,
+        voiceConfig: {} as unknown as VoiceCallConfig,
+        cfg: {} as unknown as OpenClawConfig,
+      },
+    });
+
+    mock.getRequest().onToolCall?.({
+      itemId: "item-5",
+      callId: "task-blocked",
+      name: "openclaw_agent_task",
+      args: { task: "a long job" },
+    });
+
+    // Refused with the recording message — NOT the "I'll message you" ack.
+    const taskRefused = mock.submitToolResult.mock.calls.some(
+      (args) =>
+        args[0] === "task-blocked" &&
+        typeof (args[1] as { text?: string })?.text === "string" &&
+        (args[1] as { text: string }).text.includes("recording isn't active"),
+    );
+    expect(taskRefused).toBe(true);
+    const acked = mock.submitToolResult.mock.calls.some(
+      (args) =>
+        typeof (args[1] as { text?: string })?.text === "string" &&
+        (args[1] as { text: string }).text.includes("message you on Microsoft Teams"),
+    );
+    expect(acked).toBe(false);
+  });
+
+  it("can opt out of the recording gate via requireRecordingStatus: false", () => {
+    const ctx = createMockSession("inactive");
+    const mock = createMockProvider();
+    createMsteamsRealtimeCall({
+      session: ctx.session,
+      deps: {
+        provider: mock.provider,
+        providerConfig: {},
+        tools: [CONSULT_TOOL],
+        requireRecordingStatus: false,
+      },
+    });
+
+    mock.getRequest().onToolCall?.({
+      itemId: "item-6",
+      callId: "tool-call-optout",
+      name: REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME,
+      args: { question: "do a thing" },
+    });
+
+    // Gate disabled: reaches the agent path, which reports unavailable (no runtime),
+    // not the recording refusal.
+    const refused = mock.submitToolResult.mock.calls.some(
+      (args) =>
+        typeof (args[1] as { text?: string })?.text === "string" &&
+        (args[1] as { text: string }).text.includes("recording isn't active"),
+    );
+    expect(refused).toBe(false);
+  });
+
+  it("drops pre-recording transcripts from the consult context (Media Access API)", async () => {
+    consultSpy.mockClear();
+    const ctx = createMockSession("inactive");
+    const mock = createMockProvider();
+    const call = createMsteamsRealtimeCall({
+      session: ctx.session,
+      deps: {
+        provider: mock.provider,
+        providerConfig: {},
+        tools: [CONSULT_TOOL],
+        agentRuntime: { resolveThinkingDefault: () => undefined } as unknown as CoreAgentDeps,
+        voiceConfig: {
+          agentId: "main",
+          realtime: { toolPolicy: "owner" },
+        } as unknown as VoiceCallConfig,
+        cfg: {} as unknown as OpenClawConfig,
+      },
+    });
+    const req = mock.getRequest();
+
+    // Final transcript BEFORE recording is active — must not be retained.
+    req.onTranscript?.("user", "pre recording secret", true);
+    // Recording goes active; subsequent transcript is retained.
+    call.setRecordingActive(true);
+    req.onTranscript?.("user", "after recording question", true);
+
+    req.onToolCall?.({
+      itemId: "item-7",
+      callId: "tool-call-ctx",
+      name: REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME,
+      args: { question: "what did I say" },
+    });
+
+    await vi.waitFor(() => expect(consultSpy).toHaveBeenCalled());
+    const passedTranscript = JSON.stringify(consultSpy.mock.calls.at(-1)?.[0]?.transcript ?? []);
+    expect(passedTranscript).not.toContain("pre recording secret");
+    expect(passedTranscript).toContain("after recording question");
+  });
+});

--- a/extensions/voice-call/src/msteams-realtime.ts
+++ b/extensions/voice-call/src/msteams-realtime.ts
@@ -116,7 +116,7 @@ const MSTEAMS_LOOK_TOOL: RealtimeVoiceTool = {
 
 /** Returned when the caller asks the agent to look but no video frame has arrived yet. */
 const MSTEAMS_LOOK_NO_FRAME = {
-  text: "I can't see anything yet — make sure your camera or screen-share is on, then ask again.",
+  text: "I can't see anything yet — make sure your camera or screen-share is on. It can take a few seconds after you start sharing; then ask again.",
 };
 
 /** Spoken acknowledgement returned to the model when a background task is accepted. */

--- a/extensions/voice-call/src/msteams-realtime.ts
+++ b/extensions/voice-call/src/msteams-realtime.ts
@@ -1,0 +1,498 @@
+/**
+ * Microsoft Teams realtime voice bridge.
+ *
+ * When `realtime.enabled` is set for the msteams provider, a Teams call is wired
+ * directly to a speech-to-speech realtime model (e.g. OpenAI / Azure OpenAI
+ * Realtime) instead of the STT -> agent -> TTS pipeline. This is the low-latency
+ * path: the model listens, thinks, and speaks in one streaming session.
+ *
+ * Audio crosses the existing msteams WebSocket as PCM 16 kHz, 16-bit mono. The
+ * realtime model speaks PCM 16-bit mono at 24 kHz, so we resample on both legs:
+ *   caller  16 kHz -> 24 kHz -> model
+ *   model   24 kHz -> 16 kHz -> caller
+ * The Windows worker reframes the downlink PCM into 20 ms / 640-byte frames, so
+ * we can forward arbitrary-length chunks as a single `audio.frame`.
+ *
+ * The model owns conversation/VAD/turn-taking and answers small talk directly.
+ * For anything that needs work (lookups, actions, tools) it calls
+ * `openclaw_agent_consult`, which runs the full OpenClaw agent and returns a
+ * speakable result; a short "working on it" filler covers longer agent runs.
+ */
+
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import {
+  buildRealtimeVoiceAgentConsultWorkingResponse,
+  consultRealtimeVoiceAgent,
+  createRealtimeVoiceBridgeSession,
+  REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME,
+  REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ,
+  resamplePcm,
+  resolveRealtimeVoiceAgentConsultToolsAllow,
+  type RealtimeVoiceAgentConsultToolPolicy,
+  type RealtimeVoiceAgentConsultTranscriptEntry,
+  type RealtimeVoiceBridgeSession,
+  type RealtimeVoiceProviderConfig,
+  type RealtimeVoiceProviderPlugin,
+  type RealtimeVoiceTool,
+  type RealtimeVoiceToolCallEvent,
+} from "openclaw/plugin-sdk/realtime-voice";
+import type { VoiceCallConfig } from "./config.js";
+import type { CoreAgentDeps } from "./core-bridge.js";
+import type { MsteamsLogger, MsteamsSession } from "./msteams-media-stream.js";
+import { resolveRealtimeFastContextConsult } from "./realtime-fast-context.js";
+import { resolveVoiceResponseModel } from "./response-model.js";
+
+/** Teams bridge wire format. */
+const MSTEAMS_SAMPLE_RATE_HZ = 16_000;
+/** OpenAI/Azure realtime PCM format. */
+const REALTIME_SAMPLE_RATE_HZ = 24_000;
+/** Cap the consult transcript context so it cannot grow without bound on long calls. */
+const MAX_TRANSCRIPT_ENTRIES = 40;
+
+const MSTEAMS_REALTIME_CONSULT_SYSTEM_PROMPT = [
+  "You are the configured OpenClaw agent receiving delegated requests from a live Microsoft Teams voice call.",
+  "Act on behalf of the caller using the normal available tools when the caller asks you to do work.",
+  "Prioritize completing the caller's request and returning a fast, speakable result over exhaustive investigation.",
+  "Do not print secret values or dump environment variables; only check whether required configuration is present.",
+  "Be accurate, brief, and speakable.",
+].join(" ");
+
+/** Tool the realtime model calls to hand a long-running task to the background agent. */
+const MSTEAMS_AGENT_TASK_TOOL_NAME = "openclaw_agent_task";
+const MSTEAMS_AGENT_TASK_TOOL: RealtimeVoiceTool = {
+  type: "function",
+  name: MSTEAMS_AGENT_TASK_TOOL_NAME,
+  description:
+    "Hand a long-running task to the OpenClaw agent to complete in the background. " +
+    "Use this for work that may take more than a few seconds (multi-step actions, lengthy research). " +
+    "After calling it, tell the caller you are on it and will message them on Microsoft Teams when it is done. " +
+    "Do NOT use this for quick questions or lookups — use openclaw_agent_consult and answer in-line for those.",
+  parameters: {
+    type: "object",
+    properties: {
+      task: {
+        type: "string",
+        description:
+          "The task to perform, described in full so the background agent can complete it unattended.",
+      },
+    },
+    required: ["task"],
+  },
+};
+
+/** Spoken acknowledgement returned to the model when a background task is accepted. */
+const MSTEAMS_ASYNC_TASK_ACK = {
+  text: "Got it — I'm on it and I'll message you on Microsoft Teams when it's done.",
+};
+
+/**
+ * Returned to the model when the agent is asked to act but recording is not yet
+ * active. The agent must not process/persist call audio before Graph
+ * `updateRecordingStatus` (Media Access API), so consult + task are refused.
+ */
+const MSTEAMS_RECORDING_BLOCKED = {
+  text: "I can't act on that yet — call recording isn't active. Please make sure recording is on and ask again.",
+};
+
+function readArgString(args: unknown, key: string): string | undefined {
+  if (args && typeof args === "object" && !Array.isArray(args)) {
+    const value = (args as Record<string, unknown>)[key];
+    if (typeof value === "string" && value.trim()) {
+      return value.trim();
+    }
+  }
+  return undefined;
+}
+
+export interface MsteamsRealtimeDeps {
+  provider: RealtimeVoiceProviderPlugin;
+  providerConfig: RealtimeVoiceProviderConfig;
+  cfg?: OpenClawConfig;
+  /** System instructions for the realtime model. */
+  instructions?: string;
+  /** Instruction used to open the call (model speaks first). Empty/undefined = silent join. */
+  greetingInstructions?: string;
+  /** Realtime tools exposed to the model (e.g. openclaw_agent_consult). */
+  tools?: RealtimeVoiceTool[];
+  /** Inbound-call policy applied before bridging (mirrors the streaming path). */
+  inboundPolicy?: "disabled" | "allowlist" | "pairing" | "open";
+  /** Allowlist of caller ids honored when inboundPolicy is "allowlist"/"pairing". */
+  allowFrom?: string[];
+  /**
+   * Require active Teams recording status before the agent may process or persist
+   * call audio (the consult tool and the background task). Default true. Mirrors
+   * the streaming path's `msteams.requireRecordingStatus` (Media Access API).
+   */
+  requireRecordingStatus?: boolean;
+
+  // --- openclaw_agent_consult wiring (the agent actually does the work) ---
+  /** Host agent runtime used to run the OpenClaw agent behind the consult tool. */
+  agentRuntime?: CoreAgentDeps;
+  /** Full voice config (for agentId, realtime.{toolPolicy,fastContext,consult*}, responseTimeoutMs). */
+  voiceConfig?: VoiceCallConfig;
+  /** Consult tool policy; controls which agent tools the consult run may use. */
+  toolPolicy?: RealtimeVoiceAgentConsultToolPolicy;
+
+  /**
+   * Suppress caller-leg input while assistant audio is playing (self-echo guard).
+   * OFF by default: Teams delivers remote-participant audio (not our own playback),
+   * and gating input would also defeat the model's barge-in detection.
+   */
+  suppressInputDuringPlayback?: boolean;
+
+  logger?: MsteamsLogger;
+}
+
+/** A single Teams call bridged to the realtime model. */
+export interface MsteamsRealtimeCall {
+  /** Forward one inbound PCM 16 kHz frame from the caller into the model. */
+  pushAudio(pcm16k: Buffer): void;
+  /** Update Teams recording status (gates the consult tool + background task). */
+  setRecordingActive(active: boolean): void;
+  /** Tear down the realtime session. */
+  close(): void;
+}
+
+/**
+ * Create and connect a realtime bridge for one Teams call. Inbound caller audio
+ * is fed via {@link MsteamsRealtimeCall.pushAudio}; model audio is sent back over
+ * the provided {@link MsteamsSession} as `audio.frame` messages, and barge-in is
+ * surfaced as `assistant.cancel` so the worker flushes its playback queue.
+ */
+export function createMsteamsRealtimeCall(params: {
+  session: MsteamsSession;
+  deps: MsteamsRealtimeDeps;
+}): MsteamsRealtimeCall {
+  const { session, deps } = params;
+  const { logger } = deps;
+  const callId = session.callId;
+
+  let outboundSeq = 0;
+  let outboundTimestampMs = 0;
+  let turnId = 0;
+  let closed = false;
+  /** Last time we sent assistant audio to the caller (self-echo gate). */
+  let lastOutputAt = 0;
+  /**
+   * Teams recording status. Gates the consult tool + background task so the agent
+   * never processes or persists call audio before Graph `updateRecordingStatus`
+   * is active (Media Access API). Seeded from `session.start`, updated by
+   * `recording.status` via {@link MsteamsRealtimeCall.setRecordingActive}.
+   */
+  let recordingActive = session.recordingStatus === "active";
+  /** Whether the recording-status gate is enforced (default true). */
+  const requireRecordingStatus = deps.requireRecordingStatus !== false;
+  /** True when the agent must NOT process/persist call audio yet. */
+  const recordingGateBlocks = (): boolean => requireRecordingStatus && !recordingActive;
+
+  /** Rolling consult context built from the model's final transcripts. */
+  const transcript: RealtimeVoiceAgentConsultTranscriptEntry[] = [];
+
+  function recordTranscript(role: "user" | "assistant", text: string): void {
+    // Media Access API: never retain media-derived transcript text before Teams
+    // recording status is active. Otherwise pre-recording turns would sit in the
+    // buffer and be sent to the agent once consult/task run after recording flips
+    // active. Dropping here keeps the consult context recording-active-only.
+    if (recordingGateBlocks()) {
+      return;
+    }
+    const trimmed = text.trim();
+    if (!trimmed) {
+      return;
+    }
+    // Coalesce consecutive fragments from the same speaker so one spoken turn is
+    // a single context entry (avoids feeding the agent half-sentences).
+    const last = transcript.at(-1);
+    if (last && last.role === role) {
+      last.text = `${last.text} ${trimmed}`.trim();
+    } else {
+      transcript.push({ role, text: trimmed });
+    }
+    if (transcript.length > MAX_TRANSCRIPT_ENTRIES) {
+      transcript.splice(0, transcript.length - MAX_TRANSCRIPT_ENTRIES);
+    }
+  }
+
+  const consultToolPolicy: RealtimeVoiceAgentConsultToolPolicy =
+    deps.toolPolicy ?? deps.voiceConfig?.realtime.toolPolicy ?? "none";
+  // Async background tasks deliver their result via the agent's `message` tool,
+  // which is only available under the "owner" tool policy.
+  const asyncTasksEnabled =
+    Boolean(deps.agentRuntime && deps.voiceConfig && deps.cfg) && consultToolPolicy === "owner";
+  const bridgeTools = asyncTasksEnabled
+    ? [...(deps.tools ?? []), MSTEAMS_AGENT_TASK_TOOL]
+    : deps.tools;
+
+  const realtime = createRealtimeVoiceBridgeSession({
+    provider: deps.provider,
+    cfg: deps.cfg,
+    providerConfig: deps.providerConfig,
+    audioFormat: REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ,
+    instructions: deps.instructions,
+    initialGreetingInstructions: deps.greetingInstructions,
+    triggerGreetingOnReady: Boolean(deps.greetingInstructions),
+    autoRespondToAudio: true,
+    interruptResponseOnInputAudio: true,
+    tools: bridgeTools,
+    audioSink: {
+      isOpen: () => !closed,
+      sendAudio: (pcm24k: Buffer) => {
+        if (closed || pcm24k.length === 0) {
+          return;
+        }
+        lastOutputAt = Date.now();
+        const pcm16k = resamplePcm(pcm24k, REALTIME_SAMPLE_RATE_HZ, MSTEAMS_SAMPLE_RATE_HZ);
+        session.send({
+          type: "audio.frame",
+          seq: outboundSeq,
+          timestampMs: outboundTimestampMs,
+          payloadBase64: pcm16k.toString("base64"),
+        });
+        outboundSeq += 1;
+        // 16-bit mono: 2 bytes/sample.
+        outboundTimestampMs += Math.round((pcm16k.length / 2 / MSTEAMS_SAMPLE_RATE_HZ) * 1000);
+      },
+      clearAudio: () => {
+        // Barge-in: the model truncated its turn — tell the worker to flush the
+        // audio it has already queued for playback so the caller isn't talked over.
+        turnId += 1;
+        session.send({ type: "assistant.cancel", turnId });
+      },
+    },
+    onTranscript: (role, text, isFinal) => {
+      if (isFinal) {
+        recordTranscript(role, text);
+      }
+    },
+    onToolCall: (event, rtSession) => {
+      if (event.name === MSTEAMS_AGENT_TASK_TOOL_NAME) {
+        handleAsyncTask(event, rtSession);
+        return;
+      }
+      void handleToolCall(event, rtSession);
+    },
+    onError: (error) => {
+      logger?.warn(`MsteamsRealtime: bridge error — ${error.message}`);
+    },
+    onClose: () => {
+      closed = true;
+    },
+  });
+
+  /** Run the OpenClaw agent for an openclaw_agent_consult call and speak the result. */
+  async function handleToolCall(
+    event: RealtimeVoiceToolCallEvent,
+    rtSession: RealtimeVoiceBridgeSession,
+  ): Promise<void> {
+    if (event.name !== REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME) {
+      return;
+    }
+    // Media Access API: refuse to run the agent on call audio until recording is active.
+    if (recordingGateBlocks()) {
+      logger?.debug?.(`MsteamsRealtime: consult refused for ${callId} — recording not active`);
+      rtSession.submitToolResult(event.callId, MSTEAMS_RECORDING_BLOCKED);
+      return;
+    }
+    const { agentRuntime, voiceConfig, cfg } = deps;
+    if (!agentRuntime || !voiceConfig || !cfg) {
+      rtSession.submitToolResult(event.callId, {
+        text: "The assistant agent is not available right now.",
+      });
+      return;
+    }
+
+    const agentId = voiceConfig.agentId ?? "main";
+    const sessionKey = `agent:${agentId}:subagent:msteams:${callId}`;
+    const toolPolicy = deps.toolPolicy ?? voiceConfig.realtime.toolPolicy;
+
+    try {
+      // Fast path: answer from memory/session context without a full agent run.
+      const fastContext = await resolveRealtimeFastContextConsult({
+        cfg,
+        agentId,
+        sessionKey,
+        config: voiceConfig.realtime.fastContext,
+        args: event.args,
+        logger: { debug: (message) => logger?.debug?.(message) },
+      });
+      if (fastContext.handled) {
+        rtSession.submitToolResult(event.callId, fastContext.result);
+        return;
+      }
+
+      // Slower path: a full agent run. Emit a "working on it" filler first (if the
+      // provider supports tool-result continuation) so the caller is not left in
+      // silence while the agent works.
+      if (rtSession.bridge?.supportsToolResultContinuation) {
+        rtSession.submitToolResult(
+          event.callId,
+          buildRealtimeVoiceAgentConsultWorkingResponse("caller"),
+          { willContinue: true },
+        );
+      }
+
+      const { provider: agentProvider, model } = resolveVoiceResponseModel({
+        voiceConfig,
+        agentRuntime,
+      });
+      const thinkLevel =
+        voiceConfig.realtime.consultThinkingLevel ??
+        agentRuntime.resolveThinkingDefault({ cfg, provider: agentProvider, model });
+
+      const result = await consultRealtimeVoiceAgent({
+        cfg,
+        agentRuntime,
+        logger: { warn: (message) => logger?.warn(message) },
+        agentId,
+        sessionKey,
+        messageProvider: "voice",
+        lane: "voice",
+        runIdPrefix: `voice-realtime-consult:${callId}`,
+        args: event.args,
+        transcript: [...transcript],
+        surface: "a live Microsoft Teams call",
+        userLabel: "Caller",
+        assistantLabel: "Agent",
+        questionSourceLabel: "caller",
+        provider: agentProvider,
+        model,
+        thinkLevel,
+        fastMode: voiceConfig.realtime.consultFastMode,
+        timeoutMs: voiceConfig.responseTimeoutMs,
+        toolsAllow: resolveRealtimeVoiceAgentConsultToolsAllow(toolPolicy),
+        extraSystemPrompt: MSTEAMS_REALTIME_CONSULT_SYSTEM_PROMPT,
+      });
+      rtSession.submitToolResult(event.callId, result);
+    } catch (err) {
+      logger?.warn(
+        `MsteamsRealtime: consult failed for ${callId} — ${err instanceof Error ? err.message : String(err)}`,
+      );
+      rtSession.submitToolResult(event.callId, {
+        text: "Sorry, I ran into a problem while working on that.",
+      });
+    }
+  }
+
+  /**
+   * A long task: acknowledge on the call immediately, then run the OpenClaw agent
+   * in the background. The call can end while it works; the agent delivers the
+   * result to the caller's Teams chat via the `message` tool when done.
+   */
+  function handleAsyncTask(
+    event: RealtimeVoiceToolCallEvent,
+    rtSession: RealtimeVoiceBridgeSession,
+  ): void {
+    // Media Access API: a background task processes + persists call audio and
+    // delivers it to Teams chat, so it must not start before recording is active.
+    if (recordingGateBlocks()) {
+      logger?.debug?.(`MsteamsRealtime: task refused for ${callId} — recording not active`);
+      rtSession.submitToolResult(event.callId, MSTEAMS_RECORDING_BLOCKED);
+      return;
+    }
+    const task = readArgString(event.args, "task") ?? readArgString(event.args, "question");
+    // Ack immediately so the model speaks the "I'll message you" line and the
+    // call is free to continue or hang up.
+    rtSession.submitToolResult(event.callId, MSTEAMS_ASYNC_TASK_ACK);
+    if (!task) {
+      return;
+    }
+    // Detached: not awaited and not cancelled on call teardown.
+    void runAsyncTask(task);
+  }
+
+  async function runAsyncTask(task: string): Promise<void> {
+    const { agentRuntime, voiceConfig, cfg } = deps;
+    if (!agentRuntime || !voiceConfig || !cfg) {
+      return;
+    }
+    const aadId = session.caller.aadId ?? undefined;
+    const deliveryTarget = aadId ? `user:${aadId}` : undefined;
+    const agentId = voiceConfig.agentId ?? "main";
+    const sessionKey = `agent:${agentId}:subagent:msteams:${callId}`;
+
+    const deliveryInstruction = deliveryTarget
+      ? `This task was delegated from a live Microsoft Teams voice call and now runs in the background; the caller is no longer waiting on the line. Complete the task, then deliver the final result to the caller by calling the message tool exactly once with action "send", channel "msteams", target "${deliveryTarget}". Keep the delivered message concise.`
+      : "This task was delegated from a Microsoft Teams voice call and runs in the background; deliver the final result to the caller when complete.";
+
+    try {
+      const { provider: agentProvider, model } = resolveVoiceResponseModel({
+        voiceConfig,
+        agentRuntime,
+      });
+      const thinkLevel =
+        voiceConfig.realtime.consultThinkingLevel ??
+        agentRuntime.resolveThinkingDefault({ cfg, provider: agentProvider, model });
+
+      await consultRealtimeVoiceAgent({
+        cfg,
+        agentRuntime,
+        logger: { warn: (message) => logger?.warn(message) },
+        agentId,
+        sessionKey,
+        messageProvider: "voice",
+        lane: "voice",
+        runIdPrefix: `voice-realtime-task:${callId}`,
+        args: { question: task },
+        transcript: [...transcript],
+        surface: "a Microsoft Teams voice call (background task)",
+        userLabel: "Caller",
+        assistantLabel: "Agent",
+        questionSourceLabel: "caller",
+        provider: agentProvider,
+        model,
+        thinkLevel,
+        fastMode: false,
+        toolsAllow: resolveRealtimeVoiceAgentConsultToolsAllow(consultToolPolicy),
+        extraSystemPrompt: `${MSTEAMS_REALTIME_CONSULT_SYSTEM_PROMPT} ${deliveryInstruction}`,
+      });
+      logger?.debug?.(`MsteamsRealtime: background task complete for ${callId}`);
+    } catch (err) {
+      logger?.warn(
+        `MsteamsRealtime: background task failed for ${callId} — ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  void realtime.connect().catch((err: unknown) => {
+    logger?.error(
+      `MsteamsRealtime: connect failed — ${err instanceof Error ? err.message : String(err)}`,
+    );
+    // The model never came up; close the Teams session so the worker hangs up
+    // cleanly instead of leaving the caller in silence.
+    closed = true;
+    try {
+      session.close("realtime-unavailable");
+    } catch {
+      // best-effort teardown
+    }
+  });
+
+  return {
+    pushAudio: (pcm16k: Buffer) => {
+      if (closed || pcm16k.length === 0) {
+        return;
+      }
+      // Optional self-echo guard: drop caller-leg audio that arrives within a short
+      // window of our own playback. OFF by default (would also suppress barge-in).
+      if (deps.suppressInputDuringPlayback && Date.now() - lastOutputAt < 200) {
+        return;
+      }
+      const pcm24k = resamplePcm(pcm16k, MSTEAMS_SAMPLE_RATE_HZ, REALTIME_SAMPLE_RATE_HZ);
+      realtime.sendAudio(pcm24k);
+    },
+    setRecordingActive: (active: boolean) => {
+      recordingActive = active;
+    },
+    close: () => {
+      if (closed) {
+        return;
+      }
+      closed = true;
+      try {
+        realtime.close();
+      } catch {
+        // best-effort teardown
+      }
+    },
+  };
+}

--- a/extensions/voice-call/src/msteams-realtime.ts
+++ b/extensions/voice-call/src/msteams-realtime.ts
@@ -245,6 +245,14 @@ export function createMsteamsRealtimeCall(params: {
   /** Rolling consult context built from the model's final transcripts. */
   const transcript: RealtimeVoiceAgentConsultTranscriptEntry[] = [];
 
+  /**
+   * Vision rate-limit: cache the last look_at_screen answer keyed by the exact frame bytes, so
+   * repeated "what's on my screen?" on an unchanged frame returns instantly without re-running the
+   * (expensive) vision agent. A new frame (changed screen) misses the cache and re-runs.
+   */
+  let lastLookData: string | undefined;
+  let lastLookText: string | undefined;
+
   function recordTranscript(role: "user" | "assistant", text: string): void {
     // Media Access API: never retain media-derived transcript text before Teams
     // recording status is active. Otherwise pre-recording turns would sit in the
@@ -467,6 +475,13 @@ export function createMsteamsRealtimeCall(params: {
       return;
     }
 
+    // Rate-limit: the same frame was already described → return the cached answer without a re-run.
+    if (lastLookData === frame.dataBase64 && lastLookText) {
+      logger?.debug?.(`MsteamsRealtime: look cache hit for ${callId} (unchanged frame)`);
+      rtSession.submitToolResult(event.callId, { text: lastLookText });
+      return;
+    }
+
     const agentId = voiceConfig.agentId ?? "main";
     const sessionKey = `agent:${agentId}:subagent:msteams:${callId}`;
     const toolPolicy = deps.toolPolicy ?? voiceConfig.realtime.toolPolicy;
@@ -513,6 +528,8 @@ export function createMsteamsRealtimeCall(params: {
         toolsAllow: resolveRealtimeVoiceAgentConsultToolsAllow(toolPolicy),
         extraSystemPrompt: MSTEAMS_REALTIME_LOOK_SYSTEM_PROMPT,
       });
+      lastLookData = frame.dataBase64;
+      lastLookText = result.text;
       rtSession.submitToolResult(event.callId, result);
     } catch (err) {
       logger?.warn(

--- a/extensions/voice-call/src/msteams-realtime.ts
+++ b/extensions/voice-call/src/msteams-realtime.ts
@@ -86,6 +86,16 @@ const MSTEAMS_ASYNC_TASK_ACK = {
 };
 
 /**
+ * Returned to the model when a background task is requested but the caller has no
+ * AAD object id — there is no Teams chat to deliver the result to, so the task is
+ * refused rather than acknowledging a delivery that cannot happen. The model
+ * should offer to answer on the call instead.
+ */
+const MSTEAMS_ASYNC_TASK_NO_TARGET = {
+  text: "I can't run that in the background — I don't have a Teams chat to send the result to. I can work on it right now on the call instead.",
+};
+
+/**
  * Returned to the model when the agent is asked to act but recording is not yet
  * active. The agent must not process/persist call audio before Graph
  * `updateRecordingStatus` (Media Access API), so consult + task are refused.
@@ -387,6 +397,15 @@ export function createMsteamsRealtimeCall(params: {
     if (recordingGateBlocks()) {
       logger?.debug?.(`MsteamsRealtime: task refused for ${callId} — recording not active`);
       rtSession.submitToolResult(event.callId, MSTEAMS_RECORDING_BLOCKED);
+      return;
+    }
+    // A background task's only delivery channel is the caller's Teams chat
+    // (message tool -> user:<aadId>). Without an aadId there is nowhere to
+    // deliver, so refuse the task instead of acking a delivery we can't fulfill
+    // and silently dropping the result.
+    if (!session.caller.aadId) {
+      logger?.warn(`MsteamsRealtime: task refused for ${callId} — no caller.aadId delivery target`);
+      rtSession.submitToolResult(event.callId, MSTEAMS_ASYNC_TASK_NO_TARGET);
       return;
     }
     const task = readArgString(event.args, "task") ?? readArgString(event.args, "question");

--- a/extensions/voice-call/src/msteams-realtime.ts
+++ b/extensions/voice-call/src/msteams-realtime.ts
@@ -57,6 +57,13 @@ const MSTEAMS_REALTIME_CONSULT_SYSTEM_PROMPT = [
   "Be accurate, brief, and speakable.",
 ].join(" ");
 
+const MSTEAMS_REALTIME_LOOK_SYSTEM_PROMPT = [
+  "You are the configured OpenClaw agent looking at a still frame captured from a live Microsoft Teams call —",
+  "the caller's shared screen or camera. Answer the caller's question about what is visible.",
+  "Read on-screen text verbatim when asked. Be concise and speakable (1-2 sentences);",
+  "if the image is unclear or the thing asked about is not visible, say so briefly.",
+].join(" ");
+
 /** Tool the realtime model calls to hand a long-running task to the background agent. */
 const MSTEAMS_AGENT_TASK_TOOL_NAME = "openclaw_agent_task";
 const MSTEAMS_AGENT_TASK_TOOL: RealtimeVoiceTool = {
@@ -78,6 +85,38 @@ const MSTEAMS_AGENT_TASK_TOOL: RealtimeVoiceTool = {
     },
     required: ["task"],
   },
+};
+
+/** Tool the realtime model calls to "see" what the caller is showing (camera / screen-share). */
+const MSTEAMS_LOOK_TOOL_NAME = "look_at_screen";
+const MSTEAMS_LOOK_TOOL: RealtimeVoiceTool = {
+  type: "function",
+  name: MSTEAMS_LOOK_TOOL_NAME,
+  description:
+    "Look at what the caller is currently showing on the Teams call — their shared screen or " +
+    "camera — and answer a question about it. Use this whenever the caller refers to something " +
+    'visual ("what\'s on my screen?", "read this error", "what am I holding?"). ' +
+    "Defaults to the screen-share when present, otherwise the camera.",
+  parameters: {
+    type: "object",
+    properties: {
+      question: {
+        type: "string",
+        description: "What the caller wants to know about what they are showing.",
+      },
+      source: {
+        type: "string",
+        enum: ["screenshare", "camera"],
+        description: "Which video to look at; defaults to screen-share, then camera.",
+      },
+    },
+    required: ["question"],
+  },
+};
+
+/** Returned when the caller asks the agent to look but no video frame has arrived yet. */
+const MSTEAMS_LOOK_NO_FRAME = {
+  text: "I can't see anything yet — make sure your camera or screen-share is on, then ask again.",
 };
 
 /** Spoken acknowledgement returned to the model when a background task is accepted. */
@@ -142,6 +181,14 @@ export interface MsteamsRealtimeDeps {
   voiceConfig?: VoiceCallConfig;
   /** Consult tool policy; controls which agent tools the consult run may use. */
   toolPolicy?: RealtimeVoiceAgentConsultToolPolicy;
+  /**
+   * Latest sampled inbound video frame (camera / screen-share) for the `look_at_screen` tool, so
+   * the agent can describe what the caller is showing. Provided by the provider; undefined disables
+   * the tool. Structural type avoids a circular import with the provider.
+   */
+  getLatestFrame?: (
+    source?: "camera" | "screenshare",
+  ) => { dataBase64: string; mime: string; width: number; height: number } | undefined;
 
   /**
    * Suppress caller-leg input while assistant audio is playing (self-echo guard).
@@ -229,9 +276,15 @@ export function createMsteamsRealtimeCall(params: {
   // which is only available under the "owner" tool policy.
   const asyncTasksEnabled =
     Boolean(deps.agentRuntime && deps.voiceConfig && deps.cfg) && consultToolPolicy === "owner";
-  const bridgeTools = asyncTasksEnabled
-    ? [...(deps.tools ?? []), MSTEAMS_AGENT_TASK_TOOL]
-    : deps.tools;
+  // Vision: expose look_at_screen when the agent runtime + a frame source are available.
+  const visionEnabled = Boolean(
+    deps.agentRuntime && deps.voiceConfig && deps.cfg && deps.getLatestFrame,
+  );
+  const bridgeTools = [
+    ...(deps.tools ?? []),
+    ...(asyncTasksEnabled ? [MSTEAMS_AGENT_TASK_TOOL] : []),
+    ...(visionEnabled ? [MSTEAMS_LOOK_TOOL] : []),
+  ];
 
   const realtime = createRealtimeVoiceBridgeSession({
     provider: deps.provider,
@@ -277,6 +330,10 @@ export function createMsteamsRealtimeCall(params: {
     onToolCall: (event, rtSession) => {
       if (event.name === MSTEAMS_AGENT_TASK_TOOL_NAME) {
         handleAsyncTask(event, rtSession);
+        return;
+      }
+      if (event.name === MSTEAMS_LOOK_TOOL_NAME) {
+        void handleLook(event, rtSession);
         return;
       }
       void handleToolCall(event, rtSession);
@@ -380,6 +437,88 @@ export function createMsteamsRealtimeCall(params: {
       rtSession.submitToolResult(event.callId, {
         text: "Sorry, I ran into a problem while working on that.",
       });
+    }
+  }
+
+  /** Run a vision-capable agent over the latest inbound video frame and speak the answer. */
+  async function handleLook(
+    event: RealtimeVoiceToolCallEvent,
+    rtSession: RealtimeVoiceBridgeSession,
+  ): Promise<void> {
+    // Media Access API: do not process call video before recording is active.
+    if (recordingGateBlocks()) {
+      logger?.debug?.(`MsteamsRealtime: look refused for ${callId} — recording not active`);
+      rtSession.submitToolResult(event.callId, MSTEAMS_RECORDING_BLOCKED);
+      return;
+    }
+    const { agentRuntime, voiceConfig, cfg } = deps;
+    if (!agentRuntime || !voiceConfig || !cfg || !deps.getLatestFrame) {
+      rtSession.submitToolResult(event.callId, {
+        text: "The assistant can't look at video right now.",
+      });
+      return;
+    }
+
+    const sourceArg = readArgString(event.args, "source");
+    const source = sourceArg === "camera" || sourceArg === "screenshare" ? sourceArg : undefined;
+    const frame = deps.getLatestFrame(source);
+    if (!frame) {
+      rtSession.submitToolResult(event.callId, MSTEAMS_LOOK_NO_FRAME);
+      return;
+    }
+
+    const agentId = voiceConfig.agentId ?? "main";
+    const sessionKey = `agent:${agentId}:subagent:msteams:${callId}`;
+    const toolPolicy = deps.toolPolicy ?? voiceConfig.realtime.toolPolicy;
+
+    try {
+      // Speak a short filler while the vision run completes (if the provider supports it).
+      if (rtSession.bridge?.supportsToolResultContinuation) {
+        rtSession.submitToolResult(
+          event.callId,
+          buildRealtimeVoiceAgentConsultWorkingResponse("caller"),
+          { willContinue: true },
+        );
+      }
+
+      const { provider: agentProvider, model } = resolveVoiceResponseModel({
+        voiceConfig,
+        agentRuntime,
+      });
+      const thinkLevel =
+        voiceConfig.realtime.consultThinkingLevel ??
+        agentRuntime.resolveThinkingDefault({ cfg, provider: agentProvider, model });
+
+      const result = await consultRealtimeVoiceAgent({
+        cfg,
+        agentRuntime,
+        logger: { warn: (message) => logger?.warn(message) },
+        agentId,
+        sessionKey,
+        messageProvider: "voice",
+        lane: "voice",
+        runIdPrefix: `voice-realtime-look:${callId}`,
+        args: event.args,
+        images: [{ type: "image", data: frame.dataBase64, mimeType: frame.mime }],
+        transcript: [...transcript],
+        surface: "a live Microsoft Teams call (the caller is sharing video)",
+        userLabel: "Caller",
+        assistantLabel: "Agent",
+        questionSourceLabel: "caller",
+        provider: agentProvider,
+        model,
+        thinkLevel,
+        fastMode: voiceConfig.realtime.consultFastMode,
+        timeoutMs: voiceConfig.responseTimeoutMs,
+        toolsAllow: resolveRealtimeVoiceAgentConsultToolsAllow(toolPolicy),
+        extraSystemPrompt: MSTEAMS_REALTIME_LOOK_SYSTEM_PROMPT,
+      });
+      rtSession.submitToolResult(event.callId, result);
+    } catch (err) {
+      logger?.warn(
+        `MsteamsRealtime: look failed for ${callId} — ${err instanceof Error ? err.message : String(err)}`,
+      );
+      rtSession.submitToolResult(event.callId, { text: "Sorry, I had trouble seeing that." });
     }
   }
 

--- a/extensions/voice-call/src/msteams-tts.ts
+++ b/extensions/voice-call/src/msteams-tts.ts
@@ -1,0 +1,80 @@
+/**
+ * Microsoft Teams TTS adapter.
+ *
+ * The Teams bridge consumes raw PCM 16 kHz, 16-bit mono LE audio, whereas the
+ * shared telephony TTS path (`telephony-tts.ts`) emits 8 kHz mu-law for Twilio
+ * Media Streams. To keep upstream files untouched, the msteams-specific
+ * behavior — synthesize raw PCM, then resample to 16 kHz — lives here. It
+ * reuses the upstream host TTS runtime (`TelephonyTtsRuntime.textToSpeechTelephony`)
+ * and the SDK resampler instead of duplicating synthesis logic.
+ */
+
+import { resamplePcm } from "openclaw/plugin-sdk/realtime-voice";
+import type { VoiceCallTtsConfig } from "./config.js";
+import type { CoreConfig } from "./core-bridge.js";
+import { deepMergeDefined } from "./deep-merge.js";
+import type { TelephonyTtsRuntime } from "./telephony-tts.js";
+
+/** Teams wire format: PCM 16 kHz, 16-bit mono, little-endian. */
+export const MSTEAMS_TTS_SAMPLE_RATE_HZ = 16_000;
+
+export interface MsteamsTtsProvider {
+  /**
+   * Synthesize `text` and return PCM 16 kHz, 16-bit mono LE audio, resampled
+   * from the TTS provider's native rate (e.g. 22050 Hz) when needed.
+   */
+  synthesizePcm16k(text: string): Promise<Buffer>;
+}
+
+export function createMsteamsTtsProvider(params: {
+  coreConfig: CoreConfig;
+  ttsOverride?: VoiceCallTtsConfig;
+  runtime: TelephonyTtsRuntime;
+  logger?: {
+    warn?: (message: string) => void;
+  };
+}): MsteamsTtsProvider {
+  const { coreConfig, ttsOverride, runtime, logger } = params;
+  const mergedConfig = applyTtsOverride(coreConfig, ttsOverride);
+
+  return {
+    synthesizePcm16k: async (text: string) => {
+      const result = await runtime.textToSpeechTelephony({ text, cfg: mergedConfig });
+
+      if (!result.success || !result.audioBuffer || !result.sampleRate) {
+        throw new Error(result.error ?? "msteams TTS synthesis failed");
+      }
+
+      if (result.fallbackFrom && result.provider && result.fallbackFrom !== result.provider) {
+        const attemptedChain =
+          result.attemptedProviders && result.attemptedProviders.length > 0
+            ? result.attemptedProviders.join(" -> ")
+            : `${result.fallbackFrom} -> ${result.provider}`;
+        logger?.warn?.(
+          `[voice-call] msteams TTS fallback used from=${result.fallbackFrom} to=${result.provider} attempts=${attemptedChain}`,
+        );
+      }
+
+      if (result.sampleRate === MSTEAMS_TTS_SAMPLE_RATE_HZ) {
+        return result.audioBuffer;
+      }
+      return resamplePcm(result.audioBuffer, result.sampleRate, MSTEAMS_TTS_SAMPLE_RATE_HZ);
+    },
+  };
+}
+
+/** Layer the voice-call `tts` override on top of the core `messages.tts` config. */
+function applyTtsOverride(coreConfig: CoreConfig, override?: VoiceCallTtsConfig): CoreConfig {
+  if (!override) {
+    return coreConfig;
+  }
+  const base = coreConfig.messages?.tts;
+  const merged = base ? (deepMergeDefined(base, override) as VoiceCallTtsConfig) : override;
+  return {
+    ...coreConfig,
+    messages: {
+      ...coreConfig.messages,
+      tts: merged,
+    },
+  };
+}

--- a/extensions/voice-call/src/msteams.runtime.test.ts
+++ b/extensions/voice-call/src/msteams.runtime.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { vi } from "vitest";
+
+// Force the realtime-transcription resolver to find nothing so the streaming
+// path cannot resolve an STT provider.
+vi.mock("./realtime-transcription.runtime.js", () => ({
+  getRealtimeTranscriptionProvider: () => undefined,
+  listRealtimeTranscriptionProviders: () => [],
+}));
+
+import type { VoiceCallConfig } from "./config.js";
+import type { CoreAgentDeps, CoreConfig } from "./core-bridge.js";
+import type { CallManager } from "./manager.js";
+import { wireMsteamsRuntime } from "./msteams.runtime.js";
+import { MsteamsProvider } from "./providers/msteams.js";
+
+describe("wireMsteamsRuntime (fail-fast)", () => {
+  it("throws when streaming is enabled but no usable STT provider resolves", async () => {
+    const provider = new MsteamsProvider({});
+    const config = {
+      streaming: { enabled: true, provider: "nonexistent", providers: {} },
+    } as unknown as VoiceCallConfig;
+
+    await expect(
+      wireMsteamsRuntime({
+        config,
+        coreConfig: {} as unknown as CoreConfig,
+        fullConfig: {} as unknown as Parameters<typeof wireMsteamsRuntime>[0]["fullConfig"],
+        agentRuntime: {} as unknown as CoreAgentDeps,
+        manager: {} as unknown as CallManager,
+        provider,
+        logger: { info: () => {}, warn: () => {}, error: () => {} },
+      }),
+    ).rejects.toThrow(/no usable realtime transcription provider/);
+
+    await provider.stop();
+  });
+});

--- a/extensions/voice-call/src/msteams.runtime.ts
+++ b/extensions/voice-call/src/msteams.runtime.ts
@@ -1,0 +1,94 @@
+/**
+ * Microsoft Teams runtime wiring.
+ *
+ * Keeps all msteams-specific bootstrap out of the upstream `runtime.ts`: it
+ * resolves the realtime-transcription provider (the same way the webhook
+ * streaming init does), builds the msteams PCM TTS adapter, and injects the
+ * CallManager + response runtime into the `MsteamsProvider`.
+ */
+
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { resolveConfiguredCapabilityProvider } from "openclaw/plugin-sdk/provider-selection-runtime";
+import type { VoiceCallConfig } from "./config.js";
+import type { CoreAgentDeps, CoreConfig } from "./core-bridge.js";
+import type { CallManager } from "./manager.js";
+import { createMsteamsTtsProvider } from "./msteams-tts.js";
+import type { VoiceCallProvider } from "./providers/base.js";
+import type { MsteamsProvider } from "./providers/msteams.js";
+import {
+  getRealtimeTranscriptionProvider,
+  listRealtimeTranscriptionProviders,
+} from "./realtime-transcription.runtime.js";
+import type { TelephonyTtsRuntime } from "./telephony-tts.js";
+
+type Logger = {
+  info: (message: string) => void;
+  warn: (message: string) => void;
+  error: (message: string) => void;
+  debug?: (message: string) => void;
+};
+
+export async function wireMsteamsRuntime(params: {
+  config: VoiceCallConfig;
+  coreConfig: CoreConfig;
+  fullConfig: OpenClawConfig;
+  agentRuntime: CoreAgentDeps;
+  ttsRuntime?: TelephonyTtsRuntime;
+  manager: CallManager;
+  provider: VoiceCallProvider;
+  logger: Logger;
+}): Promise<void> {
+  const { config, coreConfig, fullConfig, agentRuntime, ttsRuntime, manager, provider, logger } =
+    params;
+  const msteamsProvider = provider as MsteamsProvider;
+  const streaming = config.streaming;
+
+  msteamsProvider.setCallManager(manager);
+  msteamsProvider.setResponseRuntime({ coreConfig, agentRuntime, voiceConfig: config });
+
+  const resolution = resolveConfiguredCapabilityProvider({
+    configuredProviderId: streaming.provider,
+    providerConfigs: streaming.providers,
+    cfg: fullConfig,
+    cfgForResolve: fullConfig,
+    getConfiguredProvider: (providerId) => getRealtimeTranscriptionProvider(providerId, fullConfig),
+    listProviders: () => listRealtimeTranscriptionProviders(fullConfig),
+    resolveProviderConfig: ({ provider: p, cfg: c, rawConfig }) =>
+      p.resolveConfig?.({ cfg: c, rawConfig }) ?? rawConfig,
+    isProviderConfigured: ({ provider: p, cfg: c, providerConfig }) =>
+      p.isConfigured({ cfg: c, providerConfig }),
+  });
+  if (resolution.ok) {
+    msteamsProvider.setTranscriptionProvider(
+      resolution.provider,
+      resolution.providerConfig,
+      fullConfig,
+    );
+    logger.info(`[voice-call] msteams realtime transcription provider: ${resolution.provider.id}`);
+  } else {
+    // Fail closed: binding the Teams listener without a usable STT provider would
+    // accept calls it can never transcribe (caller in silence). Abort runtime init
+    // before the listener binds rather than logging and continuing.
+    throw new Error(
+      `[voice-call] msteams streaming is enabled but no usable realtime transcription provider resolved (${resolution.code}); refusing to start the Teams listener`,
+    );
+  }
+
+  if (ttsRuntime?.textToSpeechTelephony) {
+    try {
+      const ttsProvider = createMsteamsTtsProvider({
+        coreConfig,
+        ttsOverride: config.tts,
+        runtime: ttsRuntime,
+        logger,
+      });
+      msteamsProvider.setTtsProvider(ttsProvider);
+      logger.info("[voice-call] msteams TTS provider configured");
+    } catch (err) {
+      logger.warn(`[voice-call] Failed to initialize msteams TTS: ${formatErrorMessage(err)}`);
+    }
+  } else {
+    logger.warn("[voice-call] Telephony TTS unavailable; msteams streaming TTS disabled");
+  }
+}

--- a/extensions/voice-call/src/providers/msteams.test.ts
+++ b/extensions/voice-call/src/providers/msteams.test.ts
@@ -292,6 +292,30 @@ describe("MsteamsProvider (audio loop wiring)", () => {
     ws.close();
   });
 
+  it("keys the call on a per-call-unique caller id when the Teams aadId is absent", async () => {
+    const { port, manager } = await setup();
+    const callId = "teams-no-aad";
+    const { ws } = await connect(port, callId);
+
+    ws.send(
+      JSON.stringify({
+        type: "session.start",
+        callId,
+        threadId: "thread-no-aad",
+        caller: { displayName: "Anon" }, // no aadId
+        recordingStatus: "active",
+      }),
+    );
+
+    await waitFor(() => manager.getCallByProviderCallId(callId) !== undefined);
+    const record = manager.getCallByProviderCallId(callId);
+    // Not the shared literal "teams" (which would collide every anonymous
+    // caller into one session); a per-call value preserves caller separation.
+    expect(record?.from).toBe(`teams:${callId}`);
+
+    ws.close();
+  });
+
   it("generates a reply on final transcript by composing generateVoiceResponse + manager.speak", async () => {
     generateVoiceResponseMock.mockResolvedValue({ text: "Sure, happy to help." });
     const { port, captured, manager } = await setup();

--- a/extensions/voice-call/src/providers/msteams.test.ts
+++ b/extensions/voice-call/src/providers/msteams.test.ts
@@ -1,0 +1,509 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type {
+  RealtimeTranscriptionSession,
+  RealtimeTranscriptionSessionCreateRequest,
+} from "openclaw/plugin-sdk/realtime-transcription";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { WebSocket } from "ws";
+import type { VoiceCallConfig } from "../config.js";
+import { CallManager } from "../manager.js";
+import { installVoiceCallStateRuntimeForTests } from "../manager.test-harness.js";
+import type { MsteamsTtsProvider } from "../msteams-tts.js";
+import { createVoiceCallBaseConfig } from "../test-fixtures.js";
+import type { HangupCallInput, InitiateCallInput, PlayTtsInput, WebhookContext } from "../types.js";
+import { MsteamsProvider } from "./msteams.js";
+
+const generateVoiceResponseMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../response-generator.js", () => ({
+  generateVoiceResponse: generateVoiceResponseMock,
+}));
+
+const STUB_WEBHOOK_CTX: WebhookContext = {
+  rawBody: "",
+  headers: {},
+  url: "/",
+} as unknown as WebhookContext;
+
+const STUB_HANGUP_INPUT: HangupCallInput = {} as unknown as HangupCallInput;
+const STUB_PLAY_TTS_INPUT: PlayTtsInput = {} as unknown as PlayTtsInput;
+const STUB_INITIATE_INPUT: InitiateCallInput = {} as unknown as InitiateCallInput;
+
+const SECRET = "test-shared-secret";
+const STREAM_PATH = "/voice/msteams/stream";
+
+function signHmac(ts: number, callId: string): string {
+  return crypto.createHmac("sha256", SECRET).update(`${ts}.${callId}`).digest("hex");
+}
+
+function randomPort(): number {
+  return 31000 + Math.floor(Math.random() * 9000);
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 2000): Promise<void> {
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error("waitFor timed out");
+    }
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 10);
+    });
+  }
+}
+
+describe("MsteamsProvider (stub surface)", () => {
+  it("identifies as the msteams provider", () => {
+    const p = new MsteamsProvider({});
+    expect(p.name).toBe("msteams");
+  });
+
+  it("verifyWebhook accepts unconditionally — Teams does not use the webhook plane", () => {
+    const p = new MsteamsProvider({});
+    expect(p.verifyWebhook(STUB_WEBHOOK_CTX)).toEqual({ ok: true });
+  });
+
+  it("parseWebhookEvent returns no events", () => {
+    const p = new MsteamsProvider({});
+    const result = p.parseWebhookEvent(STUB_WEBHOOK_CTX);
+    expect(result.events).toEqual([]);
+    expect(result.statusCode).toBe(204);
+  });
+
+  it("initiateCall throws — outbound dialing is not supported (inbound-only)", async () => {
+    const p = new MsteamsProvider({});
+    await expect(p.initiateCall(STUB_INITIATE_INPUT)).rejects.toThrow(/inbound-only/);
+  });
+
+  it("hangupCall is a no-op when no session exists", async () => {
+    const p = new MsteamsProvider({});
+    await expect(p.hangupCall(STUB_HANGUP_INPUT)).resolves.toBeUndefined();
+  });
+
+  it("playTts throws when there is no active session for the call", async () => {
+    const p = new MsteamsProvider({});
+    await expect(p.playTts(STUB_PLAY_TTS_INPUT)).rejects.toThrow(/no active session/);
+  });
+
+  it("getCallStatus reports terminal when no session is active (drives restart reaping)", async () => {
+    const p = new MsteamsProvider({});
+    const status = await p.getCallStatus({ providerCallId: "anything" });
+    expect(status.status).toBe("completed");
+    expect(status.isTerminal).toBe(true);
+  });
+});
+
+/** Capture the callbacks the provider passes into the realtime transcription session. */
+interface CapturedStt {
+  callbacks: RealtimeTranscriptionSessionCreateRequest;
+  session: RealtimeTranscriptionSession & {
+    connect: ReturnType<typeof vi.fn>;
+    sendAudio: ReturnType<typeof vi.fn>;
+    close: ReturnType<typeof vi.fn>;
+  };
+}
+
+/** Mutable knobs the tests flip before driving the provider. */
+interface SttControl {
+  /** When true, the next created STT session's connect() rejects. */
+  failConnect: boolean;
+}
+
+function createMockTranscriptionProvider(captured: { current?: CapturedStt }, control: SttControl) {
+  return {
+    id: "mock-stt",
+    label: "Mock STT",
+    isConfigured: () => true,
+    createSession: (req: RealtimeTranscriptionSessionCreateRequest) => {
+      let connected = false;
+      const shouldFail = control.failConnect;
+      const session = {
+        connect: vi.fn(async () => {
+          if (shouldFail) {
+            throw new Error("stt down");
+          }
+          connected = true;
+        }),
+        sendAudio: vi.fn(),
+        close: vi.fn(),
+        isConnected: () => connected,
+      };
+      captured.current = { callbacks: req, session };
+      return session as unknown as RealtimeTranscriptionSession;
+    },
+  };
+}
+
+function createMockTtsProvider(): MsteamsTtsProvider {
+  return {
+    // One 20 ms PCM 16 kHz frame (640 bytes), already resampled by msteams-tts.
+    synthesizePcm16k: vi.fn(async () => Buffer.alloc(640, 1)),
+  };
+}
+
+describe("MsteamsProvider (audio loop wiring)", () => {
+  let provider: MsteamsProvider | undefined;
+  let storeDir: string | undefined;
+
+  afterEach(async () => {
+    await provider?.stop();
+    provider = undefined;
+    generateVoiceResponseMock.mockReset();
+    if (storeDir) {
+      // Best-effort: the sync sqlite store may still hold the file open on
+      // Windows (EBUSY). Leaving the temp dir behind is harmless.
+      try {
+        fs.rmSync(storeDir, { recursive: true, force: true });
+      } catch {
+        // ignore
+      }
+      storeDir = undefined;
+    }
+  });
+
+  async function setup(): Promise<{
+    port: number;
+    captured: { current?: CapturedStt };
+    manager: CallManager;
+    tts: MsteamsTtsProvider;
+    sttControl: SttControl;
+  }> {
+    installVoiceCallStateRuntimeForTests();
+    const port = randomPort();
+    const config: VoiceCallConfig = {
+      ...createVoiceCallBaseConfig(),
+      inboundPolicy: "open",
+      fromNumber: "+10000000000",
+    };
+    storeDir = fs.mkdtempSync(path.join(os.tmpdir(), "msteams-test-"));
+    const manager = new CallManager(config, storeDir);
+
+    const captured: { current?: CapturedStt } = {};
+    const sttControl: SttControl = { failConnect: false };
+    const transcriptionProvider = createMockTranscriptionProvider(captured, sttControl);
+    const tts = createMockTtsProvider();
+
+    provider = new MsteamsProvider({ port, path: STREAM_PATH, sharedSecret: SECRET });
+    await provider.start();
+    await manager.initialize(provider, "http://localhost/voice/webhook");
+    provider.setCallManager(manager);
+    provider.setTranscriptionProvider(
+      transcriptionProvider as unknown as Parameters<
+        MsteamsProvider["setTranscriptionProvider"]
+      >[0],
+      {},
+      undefined,
+    );
+    provider.setTtsProvider(tts);
+    provider.setResponseRuntime({
+      coreConfig: {},
+      agentRuntime: {} as unknown as Parameters<
+        MsteamsProvider["setResponseRuntime"]
+      >[0]["agentRuntime"],
+      voiceConfig: config,
+    });
+    // Give the WS server a moment to bind.
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 50);
+    });
+    return { port, captured, manager, tts, sttControl };
+  }
+
+  function connect(port: number, callId: string): Promise<{ ws: WebSocket; inbound: unknown[] }> {
+    const ts = Date.now();
+    const ws = new WebSocket(`ws://127.0.0.1:${port}${STREAM_PATH}/${callId}`, {
+      headers: {
+        "x-openclawteamsbridge-timestamp": String(ts),
+        "x-openclawteamsbridge-signature": signHmac(ts, callId),
+      },
+    });
+    const inbound: unknown[] = [];
+    ws.on("message", (data: Buffer) => {
+      try {
+        inbound.push(JSON.parse(data.toString("utf8")));
+      } catch {
+        // ignore non-JSON
+      }
+    });
+    return new Promise((resolve, reject) => {
+      ws.once("open", () => {
+        resolve({ ws, inbound });
+      });
+      ws.once("error", reject);
+    });
+  }
+
+  function framesOf(inbound: unknown[]): Array<{ type: string; payloadBase64?: string }> {
+    return inbound.filter(
+      (m): m is { type: string; payloadBase64?: string } =>
+        Boolean(m) && typeof m === "object" && (m as { type?: unknown }).type === "audio.frame",
+    );
+  }
+
+  it("registers the call, streams the greeting back, and forwards caller audio to STT", async () => {
+    const { port, captured, manager } = await setup();
+    const callId = "teams-call-1";
+    const { ws, inbound } = await connect(port, callId);
+
+    ws.send(
+      JSON.stringify({
+        type: "session.start",
+        callId,
+        threadId: "thread-1",
+        caller: { aadId: "aad-123", displayName: "Alice", tenantId: "tenant-1" },
+        // Recording active so caller audio may be forwarded to STT (Media Access API).
+        recordingStatus: "active",
+      }),
+    );
+
+    // Call registered with the manager (inbound) and STT session connected.
+    await waitFor(() => manager.getCallByProviderCallId(callId) !== undefined);
+    await waitFor(() => captured.current?.session.connect.mock.calls.length === 1);
+
+    const record = manager.getCallByProviderCallId(callId);
+    expect(record?.direction).toBe("inbound");
+    expect(record?.from).toBe("aad-123");
+    expect(record?.to).toBe("+10000000000");
+
+    // Greeting is synthesized and streamed back as audio.frame messages.
+    await waitFor(() => framesOf(inbound).length > 0);
+    const greetingFrame = framesOf(inbound)[0];
+    expect(greetingFrame.type).toBe("audio.frame");
+    expect(typeof greetingFrame.payloadBase64).toBe("string");
+    expect(Buffer.from(greetingFrame.payloadBase64 ?? "", "base64").length).toBe(640);
+
+    // Inbound caller audio is forwarded to the STT session.
+    const callerPcm = Buffer.alloc(640, 7);
+    ws.send(
+      JSON.stringify({
+        type: "audio.frame",
+        seq: 0,
+        timestampMs: 0,
+        payloadBase64: callerPcm.toString("base64"),
+      }),
+    );
+    await waitFor(() => (captured.current?.session.sendAudio.mock.calls.length ?? 0) > 0);
+    const forwarded = captured.current?.session.sendAudio.mock.calls[0]?.[0] as Buffer;
+    expect(forwarded.equals(callerPcm)).toBe(true);
+
+    ws.close();
+  });
+
+  it("generates a reply on final transcript by composing generateVoiceResponse + manager.speak", async () => {
+    generateVoiceResponseMock.mockResolvedValue({ text: "Sure, happy to help." });
+    const { port, captured, manager } = await setup();
+    const speakSpy = vi.spyOn(manager, "speak");
+    const callId = "teams-call-2";
+    const { ws } = await connect(port, callId);
+
+    ws.send(
+      JSON.stringify({
+        type: "session.start",
+        callId,
+        threadId: "thread-2",
+        caller: { aadId: "aad-9", displayName: "Bob", tenantId: "tenant-9" },
+        recordingStatus: "active",
+      }),
+    );
+    await waitFor(() => captured.current !== undefined);
+    const record = manager.getCallByProviderCallId(callId);
+    const internalCallId = record?.callId;
+    expect(internalCallId).toBeDefined();
+
+    // Simulate the STT provider emitting a final transcript.
+    captured.current?.callbacks.onTranscript?.("what's the weather");
+
+    await waitFor(() => generateVoiceResponseMock.mock.calls.length > 0);
+    const responseArgs = generateVoiceResponseMock.mock.calls[0][0] as {
+      userMessage: string;
+      callId: string;
+    };
+    expect(responseArgs.userMessage).toBe("what's the weather");
+    expect(responseArgs.callId).toBe(internalCallId);
+
+    await waitFor(() =>
+      speakSpy.mock.calls.some(
+        (call) => call[0] === internalCallId && call[1] === "Sure, happy to help.",
+      ),
+    );
+
+    ws.close();
+  });
+
+  it("drops transcripts until Teams recording status is active (Media Access API)", async () => {
+    generateVoiceResponseMock.mockResolvedValue({ text: "should not be reached" });
+    const { port, captured } = await setup();
+    const callId = "teams-call-rec";
+    const { ws } = await connect(port, callId);
+
+    // session.start WITHOUT recordingStatus -> recording is not active.
+    ws.send(
+      JSON.stringify({
+        type: "session.start",
+        callId,
+        threadId: "thread-rec",
+        caller: { aadId: "aad-rec" },
+      }),
+    );
+    await waitFor(() => captured.current !== undefined);
+
+    // A transcript before recording is active must not reach the agent.
+    captured.current?.callbacks.onTranscript?.("do something");
+    await new Promise<void>((r) => {
+      setTimeout(r, 50);
+    });
+    expect(generateVoiceResponseMock).not.toHaveBeenCalled();
+
+    // Worker reports recording active -> subsequent transcripts are processed.
+    ws.send(JSON.stringify({ type: "recording.status", status: "active" }));
+    await new Promise<void>((r) => {
+      setTimeout(r, 20);
+    });
+    captured.current?.callbacks.onTranscript?.("now do it");
+    await waitFor(() => generateVoiceResponseMock.mock.calls.length > 0);
+    expect(
+      (generateVoiceResponseMock.mock.calls[0][0] as { userMessage: string }).userMessage,
+    ).toBe("now do it");
+
+    ws.close();
+  });
+
+  it("does not forward caller audio to STT until recording status is active (Media Access API)", async () => {
+    const { port, captured } = await setup();
+    const callId = "teams-call-audio-gate";
+    const { ws } = await connect(port, callId);
+
+    // session.start WITHOUT recordingStatus -> recording is not active.
+    ws.send(
+      JSON.stringify({
+        type: "session.start",
+        callId,
+        threadId: "thread-audio-gate",
+        caller: { aadId: "aad-gate" },
+      }),
+    );
+    await waitFor(() => captured.current?.session.connect.mock.calls.length === 1);
+
+    // Caller audio before recording is active must NOT reach the STT provider.
+    const preRecordingPcm = Buffer.alloc(640, 3);
+    ws.send(
+      JSON.stringify({
+        type: "audio.frame",
+        seq: 0,
+        timestampMs: 0,
+        payloadBase64: preRecordingPcm.toString("base64"),
+      }),
+    );
+    await new Promise<void>((r) => {
+      setTimeout(r, 50);
+    });
+    expect(captured.current?.session.sendAudio).not.toHaveBeenCalled();
+
+    // Worker reports recording active -> subsequent caller audio is forwarded.
+    ws.send(JSON.stringify({ type: "recording.status", status: "active" }));
+    await new Promise<void>((r) => {
+      setTimeout(r, 20);
+    });
+    const recordedPcm = Buffer.alloc(640, 9);
+    ws.send(
+      JSON.stringify({
+        type: "audio.frame",
+        seq: 1,
+        timestampMs: 20,
+        payloadBase64: recordedPcm.toString("base64"),
+      }),
+    );
+    await waitFor(() => (captured.current?.session.sendAudio.mock.calls.length ?? 0) > 0);
+    const forwarded = captured.current?.session.sendAudio.mock.calls[0]?.[0] as Buffer;
+    expect(forwarded.equals(recordedPcm)).toBe(true);
+
+    ws.close();
+  });
+
+  it("tears down the Teams session when the STT session fails to connect", async () => {
+    const { port, captured, manager, sttControl } = await setup();
+    // Force the STT session created on session.start to reject its connect().
+    sttControl.failConnect = true;
+    const callId = "teams-call-stt-fail";
+    const { ws } = await connect(port, callId);
+
+    ws.send(
+      JSON.stringify({
+        type: "session.start",
+        callId,
+        threadId: "thread-stt-fail",
+        caller: { aadId: "aad-fail" },
+        recordingStatus: "active",
+      }),
+    );
+
+    // connect() rejects -> the provider tears the call down (no silent live call).
+    await waitFor(() => captured.current?.session.connect.mock.calls.length === 1);
+    await waitFor(() => captured.current?.session.close.mock.calls.length === 1);
+    await waitFor(() => manager.getCallByProviderCallId(callId) === undefined);
+  });
+
+  it("sends assistant.cancel on barge-in (STT speech start)", async () => {
+    const { port, captured } = await setup();
+    const callId = "teams-call-3";
+    const { ws, inbound } = await connect(port, callId);
+
+    ws.send(
+      JSON.stringify({
+        type: "session.start",
+        callId,
+        threadId: "thread-3",
+        caller: { aadId: "aad-3", displayName: "Cara", tenantId: "tenant-3" },
+      }),
+    );
+    await waitFor(() => captured.current !== undefined);
+
+    captured.current?.callbacks.onSpeechStart?.();
+
+    await waitFor(() =>
+      inbound.some(
+        (m) =>
+          Boolean(m) &&
+          typeof m === "object" &&
+          (m as { type?: unknown }).type === "assistant.cancel",
+      ),
+    );
+    const cancel = inbound.find(
+      (m): m is { type: string; turnId: number } =>
+        Boolean(m) &&
+        typeof m === "object" &&
+        (m as { type?: unknown }).type === "assistant.cancel",
+    );
+    expect(typeof cancel?.turnId).toBe("number");
+
+    ws.close();
+  });
+
+  it("ends the call and closes the STT session on session.end", async () => {
+    const { port, captured, manager } = await setup();
+    const callId = "teams-call-4";
+    const { ws } = await connect(port, callId);
+
+    ws.send(
+      JSON.stringify({
+        type: "session.start",
+        callId,
+        threadId: "thread-4",
+        caller: { aadId: "aad-4", displayName: "Dan", tenantId: "tenant-4" },
+      }),
+    );
+    await waitFor(() => captured.current !== undefined);
+    const internalCallId = manager.getCallByProviderCallId(callId)?.callId;
+
+    ws.send(JSON.stringify({ type: "session.end", reason: "caller-hangup" }));
+
+    await waitFor(() => (captured.current?.session.close.mock.calls.length ?? 0) > 0);
+    await waitFor(() => {
+      const ended = internalCallId ? manager.getCall(internalCallId) : undefined;
+      return ended === undefined || ended.endReason !== undefined;
+    });
+  });
+});

--- a/extensions/voice-call/src/providers/msteams.test.ts
+++ b/extensions/voice-call/src/providers/msteams.test.ts
@@ -455,6 +455,50 @@ describe("MsteamsProvider (audio loop wiring)", () => {
     ws.close();
   });
 
+  it("attaches the latest shared video frame to the streaming agent turn (inbound vision)", async () => {
+    generateVoiceResponseMock.mockResolvedValue({ text: "I see a stack trace." });
+    const { port, captured } = await setup();
+    const callId = "teams-call-svid";
+    const { ws } = await connect(port, callId);
+
+    // Recording active so the frame buffers and the transcript is processed.
+    ws.send(
+      JSON.stringify({
+        type: "session.start",
+        callId,
+        threadId: "t",
+        caller: { aadId: "a" },
+        recordingStatus: "active",
+      }),
+    );
+    await waitFor(() => captured.current !== undefined);
+
+    ws.send(
+      JSON.stringify({
+        type: "video.frame",
+        source: "screenshare",
+        ts: 1,
+        width: 800,
+        height: 600,
+        mime: "image/jpeg",
+        dataBase64: "AQID",
+      }),
+    );
+    await new Promise<void>((r) => {
+      setTimeout(r, 30);
+    });
+
+    // A transcript drives a turn; the latest frame should ride along as an image.
+    captured.current?.callbacks.onTranscript?.("what's on my screen?");
+    await waitFor(() => generateVoiceResponseMock.mock.calls.length > 0);
+    const arg = generateVoiceResponseMock.mock.calls.at(-1)?.[0] as {
+      images?: Array<{ type: string; data: string; mimeType: string }>;
+    };
+    expect(arg.images?.[0]).toMatchObject({ type: "image", data: "AQID", mimeType: "image/jpeg" });
+
+    ws.close();
+  });
+
   it("does not forward caller audio to STT until recording status is active (Media Access API)", async () => {
     const { port, captured } = await setup();
     const callId = "teams-call-audio-gate";

--- a/extensions/voice-call/src/providers/msteams.test.ts
+++ b/extensions/voice-call/src/providers/msteams.test.ts
@@ -210,7 +210,7 @@ describe("MsteamsProvider (audio loop wiring)", () => {
     await new Promise<void>((resolve) => {
       setTimeout(resolve, 50);
     });
-    return { port, captured, manager, tts, sttControl, provider: provider! };
+    return { port, captured, manager, tts, sttControl, provider };
   }
 
   function connect(port: number, callId: string): Promise<{ ws: WebSocket; inbound: unknown[] }> {
@@ -397,7 +397,7 @@ describe("MsteamsProvider (audio loop wiring)", () => {
   });
 
   it("drops inbound video frames until Teams recording status is active (Media Access API)", async () => {
-    const { port, captured, provider } = await setup();
+    const { port, captured, provider: videoProvider } = await setup();
     const callId = "teams-call-vid";
     const { ws } = await connect(port, callId);
 
@@ -427,7 +427,7 @@ describe("MsteamsProvider (audio loop wiring)", () => {
     await new Promise<void>((r) => {
       setTimeout(r, 50);
     });
-    expect(provider.getLatestVideoFrame(callId)).toBeUndefined();
+    expect(videoProvider.getLatestVideoFrame(callId)).toBeUndefined();
 
     // Worker reports recording active -> subsequent frames are buffered.
     ws.send(JSON.stringify({ type: "recording.status", status: "active" }));
@@ -445,8 +445,8 @@ describe("MsteamsProvider (audio loop wiring)", () => {
         dataBase64: "BAUG",
       }),
     );
-    await waitFor(() => provider.getLatestVideoFrame(callId) !== undefined);
-    expect(provider.getLatestVideoFrame(callId)).toMatchObject({
+    await waitFor(() => videoProvider.getLatestVideoFrame(callId) !== undefined);
+    expect(videoProvider.getLatestVideoFrame(callId)).toMatchObject({
       dataBase64: "BAUG",
       width: 640,
       height: 360,

--- a/extensions/voice-call/src/providers/msteams.test.ts
+++ b/extensions/voice-call/src/providers/msteams.test.ts
@@ -170,6 +170,7 @@ describe("MsteamsProvider (audio loop wiring)", () => {
     manager: CallManager;
     tts: MsteamsTtsProvider;
     sttControl: SttControl;
+    provider: MsteamsProvider;
   }> {
     installVoiceCallStateRuntimeForTests();
     const port = randomPort();
@@ -209,7 +210,7 @@ describe("MsteamsProvider (audio loop wiring)", () => {
     await new Promise<void>((resolve) => {
       setTimeout(resolve, 50);
     });
-    return { port, captured, manager, tts, sttControl };
+    return { port, captured, manager, tts, sttControl, provider: provider! };
   }
 
   function connect(port: number, callId: string): Promise<{ ws: WebSocket; inbound: unknown[] }> {
@@ -391,6 +392,65 @@ describe("MsteamsProvider (audio loop wiring)", () => {
     expect(
       (generateVoiceResponseMock.mock.calls[0][0] as { userMessage: string }).userMessage,
     ).toBe("now do it");
+
+    ws.close();
+  });
+
+  it("drops inbound video frames until Teams recording status is active (Media Access API)", async () => {
+    const { port, captured, provider } = await setup();
+    const callId = "teams-call-vid";
+    const { ws } = await connect(port, callId);
+
+    // session.start WITHOUT recordingStatus -> recording not active.
+    ws.send(
+      JSON.stringify({
+        type: "session.start",
+        callId,
+        threadId: "thread-vid",
+        caller: { aadId: "aad-vid" },
+      }),
+    );
+    await waitFor(() => captured.current !== undefined);
+
+    // A video frame before recording is active must be dropped (not buffered).
+    ws.send(
+      JSON.stringify({
+        type: "video.frame",
+        source: "screenshare",
+        ts: 1,
+        width: 1280,
+        height: 720,
+        mime: "image/jpeg",
+        dataBase64: "AQID",
+      }),
+    );
+    await new Promise<void>((r) => {
+      setTimeout(r, 50);
+    });
+    expect(provider.getLatestVideoFrame(callId)).toBeUndefined();
+
+    // Worker reports recording active -> subsequent frames are buffered.
+    ws.send(JSON.stringify({ type: "recording.status", status: "active" }));
+    await new Promise<void>((r) => {
+      setTimeout(r, 20);
+    });
+    ws.send(
+      JSON.stringify({
+        type: "video.frame",
+        source: "screenshare",
+        ts: 2,
+        width: 640,
+        height: 360,
+        mime: "image/jpeg",
+        dataBase64: "BAUG",
+      }),
+    );
+    await waitFor(() => provider.getLatestVideoFrame(callId) !== undefined);
+    expect(provider.getLatestVideoFrame(callId)).toMatchObject({
+      dataBase64: "BAUG",
+      width: 640,
+      height: 360,
+    });
 
     ws.close();
   });

--- a/extensions/voice-call/src/providers/msteams.ts
+++ b/extensions/voice-call/src/providers/msteams.ts
@@ -1,0 +1,691 @@
+import { setTimeout as sleep } from "node:timers/promises";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import type {
+  RealtimeTranscriptionProviderConfig,
+  RealtimeTranscriptionProviderPlugin,
+  RealtimeTranscriptionSession,
+} from "openclaw/plugin-sdk/realtime-transcription";
+import { isInboundCallAllowed } from "../allowlist.js";
+import { resolveVoiceCallEffectiveConfig, type VoiceCallConfig } from "../config.js";
+import type { CoreAgentDeps, CoreConfig } from "../core-bridge.js";
+import type { CallManager } from "../manager.js";
+import {
+  MsteamsMediaStream,
+  type MsteamsLogger,
+  type MsteamsRecordingStatus,
+  type MsteamsSession,
+} from "../msteams-media-stream.js";
+import {
+  createMsteamsRealtimeCall,
+  type MsteamsRealtimeCall,
+  type MsteamsRealtimeDeps,
+} from "../msteams-realtime.js";
+import type { MsteamsTtsProvider } from "../msteams-tts.js";
+import { generateVoiceResponse } from "../response-generator.js";
+import { chunkAudio } from "../telephony-audio.js";
+import type {
+  EndReason,
+  GetCallStatusInput,
+  GetCallStatusResult,
+  HangupCallInput,
+  InitiateCallInput,
+  InitiateCallResult,
+  NormalizedEvent,
+  PlayTtsInput,
+  ProviderWebhookParseResult,
+  StartListeningInput,
+  StopListeningInput,
+  WebhookContext,
+  WebhookParseOptions,
+  WebhookVerificationResult,
+} from "../types.js";
+import type { VoiceCallProvider } from "./base.js";
+
+export interface MsteamsProviderOptions {
+  port?: number;
+  bindAddress?: string;
+  path?: string;
+  sharedSecret?: string;
+  logger?: MsteamsLogger;
+}
+
+/** Resolved realtime-transcription provider plus the config needed per session. */
+interface MsteamsTranscriptionDeps {
+  provider: RealtimeTranscriptionProviderPlugin;
+  providerConfig: RealtimeTranscriptionProviderConfig;
+  cfg?: OpenClawConfig;
+}
+
+/** Host dependencies needed to generate agent responses for a turn. */
+interface MsteamsResponseRuntime {
+  coreConfig: CoreConfig;
+  agentRuntime: CoreAgentDeps;
+  voiceConfig: VoiceCallConfig;
+}
+
+/** Per-call bridge state, keyed by the Teams callId (== providerCallId). */
+interface MsteamsCallState {
+  providerCallId: string;
+  /** Internal CallManager call id (UUID) for this Teams call. */
+  internalCallId: string;
+  session: MsteamsSession;
+  sttSession: RealtimeTranscriptionSession;
+  /** Aborts the in-flight TTS playback (barge-in / hangup). */
+  ttsAbort: AbortController | null;
+  /** Monotonic outbound audio.frame sequence number for this call. */
+  outboundSeq: number;
+  /** Monotonic outbound presentation timestamp (ms) for this call. */
+  outboundTimestampMs: number;
+  /** Current assistant turn id (used for assistant.cancel on barge-in). */
+  turnId: number;
+  /** Teams recording status — transcripts are only persisted while this is true. */
+  recordingActive: boolean;
+  /** Caller audio captured before the STT session finished connecting. */
+  pendingAudio: Buffer[];
+}
+
+/** PCM 16 kHz, 16-bit mono — the wire format both directions of the Teams bridge. */
+const MSTEAMS_SAMPLE_RATE_HZ = 16_000;
+const FRAME_DURATION_MS = 20;
+const BYTES_PER_SAMPLE = 2;
+/** 16000 Hz * 0.02 s * 2 bytes = 640 bytes per 20 ms mono frame. */
+const FRAME_BYTES = (MSTEAMS_SAMPLE_RATE_HZ / 1000) * FRAME_DURATION_MS * BYTES_PER_SAMPLE;
+
+/** Cap the pre-connect audio buffer at ~5 s of 20 ms frames to bound memory. */
+const MAX_PRECONNECT_FRAMES = 250;
+
+/**
+ * Microsoft Teams voice-call provider.
+ *
+ * Unlike Twilio/Telnyx/Plivo, Teams calls do not arrive on the voice-call
+ * webhook plane. An external Windows-side bridge worker owns the Graph calling
+ * notification endpoint and opens a per-call WebSocket to OpenClaw when a call
+ * is answered. The real transport lives in `MsteamsMediaStream`; this provider
+ * wires that transport into the existing voice-call machinery (CallManager,
+ * realtime transcription, response generation, telephony TTS), mirroring the
+ * streaming Twilio provider but speaking PCM 16 kHz instead of mu-law 8 kHz.
+ */
+export class MsteamsProvider implements VoiceCallProvider {
+  readonly name = "msteams" as const;
+
+  private readonly logger?: MsteamsLogger;
+
+  // Bound only when port + path + sharedSecret are all provided. Without it
+  // the provider is still usable for typecheck / runtime construction, but the
+  // WebSocket server never listens — useful for unit tests and disabled-mode.
+  private readonly mediaStream?: MsteamsMediaStream;
+
+  private manager: CallManager | null = null;
+  private transcription: MsteamsTranscriptionDeps | null = null;
+  private ttsProvider: MsteamsTtsProvider | null = null;
+  private responseRuntime: MsteamsResponseRuntime | null = null;
+
+  // When set, calls are bridged to a realtime speech-to-speech model instead of
+  // the STT -> agent -> TTS pipeline (the low-latency path).
+  private realtimeDeps: MsteamsRealtimeDeps | null = null;
+
+  private readonly calls = new Map<string, MsteamsCallState>();
+  private readonly realtimeCalls = new Map<string, MsteamsRealtimeCall>();
+
+  constructor(options: MsteamsProviderOptions) {
+    const { port, bindAddress, path, sharedSecret, logger } = options;
+    this.logger = logger;
+    if (port !== undefined && path && sharedSecret) {
+      this.mediaStream = new MsteamsMediaStream({
+        port,
+        bindAddress,
+        path,
+        sharedSecret,
+        logger,
+        onSessionStart: (session) => this.handleSessionStart(session),
+        onSessionEnd: (info) => this.handleSessionEnd(info),
+        onAudioFrame: (frame) => this.handleAudioFrame(frame),
+        onRecordingStatus: (info) => this.handleRecordingStatus(info),
+      });
+    } else {
+      logger?.warn(
+        "MsteamsProvider: msteams.port / msteams.path / msteams.sharedSecret not all set; WebSocket server not started",
+      );
+    }
+  }
+
+  /**
+   * Bind the Teams bridge WebSocket server. Called from the voice-call runtime's
+   * startup path and awaited, so a failed bind aborts runtime initialization
+   * (and is cleaned up) instead of being swallowed. No-op when the provider was
+   * constructed without a complete config (e.g. unit tests).
+   */
+  async start(): Promise<void> {
+    if (!this.mediaStream) {
+      this.logger?.warn(
+        "MsteamsProvider: start() called without a complete config; WebSocket server not started",
+      );
+      return;
+    }
+    await this.mediaStream.start();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Dependency injection (called by the runtime, mirroring Twilio's setters).
+  // ---------------------------------------------------------------------------
+
+  setCallManager(manager: CallManager): void {
+    this.manager = manager;
+  }
+
+  setTranscriptionProvider(
+    provider: RealtimeTranscriptionProviderPlugin,
+    providerConfig: RealtimeTranscriptionProviderConfig,
+    cfg?: OpenClawConfig,
+  ): void {
+    this.transcription = { provider, providerConfig, cfg };
+  }
+
+  setTtsProvider(provider: MsteamsTtsProvider): void {
+    this.ttsProvider = provider;
+  }
+
+  setResponseRuntime(runtime: MsteamsResponseRuntime): void {
+    this.responseRuntime = runtime;
+  }
+
+  /**
+   * Enable realtime (speech-to-speech) mode. When set, each Teams call is bridged
+   * directly to the realtime model rather than the STT -> agent -> TTS pipeline.
+   */
+  setRealtimeRuntime(deps: MsteamsRealtimeDeps): void {
+    this.realtimeDeps = deps;
+  }
+
+  /**
+   * Stop the underlying WebSocket server. Called from the voice-call runtime's
+   * teardown path. No-op if the provider was constructed without a full config.
+   */
+  async stop(): Promise<void> {
+    for (const providerCallId of Array.from(this.calls.keys())) {
+      this.teardownCall(providerCallId, { closeSession: true, reason: "shutdown" });
+    }
+    for (const [providerCallId, realtimeCall] of Array.from(this.realtimeCalls.entries())) {
+      this.realtimeCalls.delete(providerCallId);
+      realtimeCall.close();
+    }
+    await this.mediaStream?.stop();
+  }
+
+  // ---------------------------------------------------------------------------
+  // WebSocket lifecycle wiring.
+  // ---------------------------------------------------------------------------
+
+  private handleSessionStart(session: MsteamsSession): void {
+    const providerCallId = session.callId;
+
+    // Realtime mode: bridge the call straight to the speech-to-speech model.
+    // It does not route through CallManager, so the inbound-call policy is
+    // enforced here (mirroring the manager check the streaming path relies on).
+    if (this.realtimeDeps) {
+      if (this.realtimeCalls.has(providerCallId)) {
+        this.logger?.warn(
+          `MsteamsProvider: duplicate realtime session.start for ${providerCallId}`,
+        );
+        return;
+      }
+      const from = session.caller.aadId ?? "teams";
+      if (
+        !isInboundCallAllowed(this.realtimeDeps.inboundPolicy, this.realtimeDeps.allowFrom, from)
+      ) {
+        this.logger?.warn(
+          `MsteamsProvider: realtime call ${providerCallId} rejected by inbound policy (from=${from})`,
+        );
+        session.close("rejected");
+        return;
+      }
+      const realtimeCall = createMsteamsRealtimeCall({ session, deps: this.realtimeDeps });
+      this.realtimeCalls.set(providerCallId, realtimeCall);
+      this.logger?.info(
+        `MsteamsProvider: realtime session.start callId=${providerCallId} threadId=${session.threadId} caller.aadId=${session.caller.aadId ?? "teams"}`,
+      );
+      return;
+    }
+
+    if (!this.manager || !this.transcription) {
+      this.logger?.error(
+        `MsteamsProvider: session.start for ${providerCallId} before dependencies were wired; closing`,
+      );
+      session.close("not-ready");
+      return;
+    }
+    if (this.calls.has(providerCallId)) {
+      this.logger?.warn(`MsteamsProvider: duplicate session.start for ${providerCallId}`);
+      return;
+    }
+
+    const from = session.caller.aadId ?? "teams";
+    const to = this.responseRuntime?.voiceConfig.fromNumber ?? "msteams";
+
+    // Register the call with the manager. `call.initiated` creates the record
+    // (subject to inbound policy); `call.answered` starts timers and triggers
+    // the configured initial greeting via provider.playTts.
+    this.manager.processEvent(
+      this.buildEvent(providerCallId, { type: "call.initiated", from, to }),
+    );
+    const record = this.manager.getCallByProviderCallId(providerCallId);
+    if (!record) {
+      this.logger?.warn(
+        `MsteamsProvider: call ${providerCallId} was not registered (rejected by inbound policy?); closing`,
+      );
+      session.close("rejected");
+      return;
+    }
+
+    const sttSession = this.transcription.provider.createSession({
+      cfg: this.transcription.cfg,
+      providerConfig: this.transcription.providerConfig,
+      onPartial: (partial) => {
+        this.logger?.debug?.(`MsteamsProvider: partial ${providerCallId} chars=${partial.length}`);
+      },
+      onTranscript: (transcript) => this.handleTranscript(providerCallId, transcript),
+      onSpeechStart: () => this.handleSpeechStart(providerCallId),
+      onError: (error) => {
+        this.logger?.warn(`MsteamsProvider: STT error ${providerCallId} — ${error.message}`);
+      },
+    });
+
+    const state: MsteamsCallState = {
+      providerCallId,
+      internalCallId: record.callId,
+      session,
+      sttSession,
+      ttsAbort: null,
+      outboundSeq: 0,
+      outboundTimestampMs: 0,
+      turnId: 0,
+      recordingActive: session.recordingStatus === "active",
+      pendingAudio: [],
+    };
+    // Register state BEFORE `call.answered` so the greeting's playTts can find it.
+    this.calls.set(providerCallId, state);
+
+    void sttSession
+      .connect()
+      .then(() => this.flushPendingAudio(providerCallId))
+      .catch((err: unknown) => {
+        this.logger?.error(
+          `MsteamsProvider: STT connect failed for ${providerCallId} — ${describeError(err)}`,
+        );
+        // No transcription path means the caller would sit in silence; tear the
+        // call down (hang up the worker session) instead of leaving it open.
+        this.failCall(providerCallId, "stt-connect-failed");
+      });
+
+    this.manager.processEvent(this.buildEvent(providerCallId, { type: "call.answered", from, to }));
+    this.logger?.info(
+      `MsteamsProvider: session.start callId=${providerCallId} threadId=${session.threadId} caller.aadId=${from}`,
+    );
+  }
+
+  private handleAudioFrame(frame: { callId: string; payload: Buffer }): void {
+    const realtimeCall = this.realtimeCalls.get(frame.callId);
+    if (realtimeCall) {
+      realtimeCall.pushAudio(frame.payload);
+      return;
+    }
+    const state = this.calls.get(frame.callId);
+    if (!state) {
+      return;
+    }
+    // Microsoft Media Access API: caller audio is media-derived data and must not
+    // be uploaded to the (external) STT provider before Teams recording status is
+    // active. Drop pre-recording frames rather than buffering them across the
+    // recording boundary, so STT never processes audio captured before recording.
+    if (this.requireRecordingStatus() && !state.recordingActive) {
+      return;
+    }
+    // PCM 16 kHz passes straight through (provider configured for pcm_16000).
+    if (state.sttSession.isConnected()) {
+      state.sttSession.sendAudio(frame.payload);
+      return;
+    }
+    // Recording is active but the STT socket is still connecting: buffer a bounded
+    // amount of opening audio so the caller's first words are not lost; flushed on
+    // connect. Only recording-active frames ever reach this buffer.
+    if (state.pendingAudio.length < MAX_PRECONNECT_FRAMES) {
+      state.pendingAudio.push(frame.payload);
+    }
+  }
+
+  /** Whether the Teams recording-status gate is enforced (default true). */
+  private requireRecordingStatus(): boolean {
+    return this.responseRuntime?.voiceConfig.msteams?.requireRecordingStatus ?? true;
+  }
+
+  /** Flush any caller audio captured while the STT session was still connecting. */
+  private flushPendingAudio(providerCallId: string): void {
+    const state = this.calls.get(providerCallId);
+    if (!state || !state.sttSession.isConnected()) {
+      return;
+    }
+    // Never flush buffered audio to STT while the recording gate is closed.
+    if (this.requireRecordingStatus() && !state.recordingActive) {
+      return;
+    }
+    const buffered = state.pendingAudio;
+    state.pendingAudio = [];
+    for (const frame of buffered) {
+      state.sttSession.sendAudio(frame);
+    }
+  }
+
+  /** Track Teams recording status so transcript persistence can be gated on it. */
+  private handleRecordingStatus(info: { callId: string; status: MsteamsRecordingStatus }): void {
+    const active = info.status === "active";
+    const state = this.calls.get(info.callId);
+    if (state) {
+      state.recordingActive = active;
+      this.logger?.info(`MsteamsProvider: recording.status ${info.callId} = ${info.status}`);
+    }
+    // Realtime calls live in a separate map; keep their recording gate in sync so
+    // the consult tool + background task respect the Media Access API too.
+    const realtimeCall = this.realtimeCalls.get(info.callId);
+    if (realtimeCall) {
+      realtimeCall.setRecordingActive(active);
+      this.logger?.info(
+        `MsteamsProvider: recording.status ${info.callId} = ${info.status} (realtime)`,
+      );
+    }
+  }
+
+  private handleTranscript(providerCallId: string, transcript: string): void {
+    const trimmed = transcript.trim();
+    if (!trimmed) {
+      return;
+    }
+    const state = this.calls.get(providerCallId);
+    if (!state || !this.manager) {
+      return;
+    }
+    // Microsoft Media Access API: media-derived data must not be persisted or
+    // processed before the worker has set Teams recording status. Drop
+    // transcripts until recording is confirmed active (operator can opt out via
+    // msteams.requireRecordingStatus=false).
+    if (this.requireRecordingStatus() && !state.recordingActive) {
+      this.logger?.warn(
+        `MsteamsProvider: dropping transcript for ${providerCallId} — Teams recording status not active`,
+      );
+      return;
+    }
+    this.manager.processEvent({
+      id: `msteams-speech-${providerCallId}-${Date.now()}`,
+      type: "call.speech",
+      callId: state.internalCallId,
+      providerCallId,
+      timestamp: Date.now(),
+      transcript: trimmed,
+      isFinal: true,
+    });
+    void this.respond(state, trimmed).catch((err: unknown) => {
+      this.logger?.warn(
+        `MsteamsProvider: failed to respond on ${providerCallId} — ${describeError(err)}`,
+      );
+    });
+  }
+
+  /**
+   * Generate an agent reply by composing the existing exported helpers
+   * (`generateVoiceResponse` + `manager.speak`), rather than duplicating the
+   * webhook's `handleInboundResponse`.
+   */
+  private async respond(state: MsteamsCallState, userMessage: string): Promise<void> {
+    if (!this.manager || !this.responseRuntime) {
+      return;
+    }
+    const call = this.manager.getCall(state.internalCallId);
+    if (!call) {
+      return;
+    }
+    const { coreConfig, agentRuntime, voiceConfig } = this.responseRuntime;
+    const numberRouteKey =
+      typeof call.metadata?.numberRouteKey === "string" ? call.metadata.numberRouteKey : call.to;
+    const effectiveConfig = resolveVoiceCallEffectiveConfig(voiceConfig, numberRouteKey).config;
+
+    const result = await generateVoiceResponse({
+      voiceConfig: effectiveConfig,
+      coreConfig,
+      agentRuntime,
+      callId: state.internalCallId,
+      sessionKey: call.sessionKey,
+      from: call.from,
+      transcript: call.transcript,
+      userMessage,
+    });
+
+    if (result.error) {
+      this.logger?.warn(`MsteamsProvider: response generation error: ${result.error}`);
+      return;
+    }
+    if (result.text) {
+      await this.manager.speak(state.internalCallId, result.text);
+    }
+  }
+
+  /** Barge-in: stop in-flight playback and tell the worker to flush its buffer. */
+  private handleSpeechStart(providerCallId: string): void {
+    const state = this.calls.get(providerCallId);
+    if (!state) {
+      return;
+    }
+    state.ttsAbort?.abort();
+    state.ttsAbort = null;
+    state.session.send({ type: "assistant.cancel", turnId: state.turnId });
+  }
+
+  private handleSessionEnd(info: { callId: string; reason: string }): void {
+    const realtimeCall = this.realtimeCalls.get(info.callId);
+    if (realtimeCall) {
+      this.realtimeCalls.delete(info.callId);
+      realtimeCall.close();
+      return;
+    }
+    const state = this.teardownCall(info.callId, { closeSession: false });
+    if (!state || !this.manager) {
+      return;
+    }
+    this.manager.processEvent({
+      id: `msteams-ended-${info.callId}-${Date.now()}`,
+      type: "call.ended",
+      callId: state.internalCallId,
+      providerCallId: info.callId,
+      timestamp: Date.now(),
+      reason: mapEndReason(info.reason),
+    });
+  }
+
+  /** Abort playback, close the STT session, and drop per-call state. */
+  private teardownCall(
+    providerCallId: string,
+    options: { closeSession: boolean; reason?: string },
+  ): MsteamsCallState | undefined {
+    const state = this.calls.get(providerCallId);
+    if (!state) {
+      return undefined;
+    }
+    this.calls.delete(providerCallId);
+    state.ttsAbort?.abort();
+    state.ttsAbort = null;
+    try {
+      state.sttSession.close();
+    } catch (err) {
+      this.logger?.warn(
+        `MsteamsProvider: error closing STT for ${providerCallId} — ${describeError(err)}`,
+      );
+    }
+    if (options.closeSession) {
+      state.session.close(options.reason ?? "completed");
+    }
+    return state;
+  }
+
+  /**
+   * Tear down a call that cannot proceed (e.g. STT failed to connect): close the
+   * worker session and notify the CallManager so the call does not linger as
+   * active with no media path.
+   */
+  private failCall(providerCallId: string, reason: string): void {
+    const state = this.teardownCall(providerCallId, { closeSession: true, reason });
+    if (!state || !this.manager) {
+      return;
+    }
+    this.manager.processEvent({
+      id: `msteams-failed-${providerCallId}-${Date.now()}`,
+      type: "call.ended",
+      callId: state.internalCallId,
+      providerCallId,
+      timestamp: Date.now(),
+      reason: mapEndReason(reason),
+    });
+  }
+
+  private buildEvent(
+    providerCallId: string,
+    fields: { type: "call.initiated" | "call.answered"; from: string; to: string },
+  ): NormalizedEvent {
+    return {
+      id: `msteams-${fields.type}-${providerCallId}-${Date.now()}`,
+      type: fields.type,
+      callId: providerCallId,
+      providerCallId,
+      timestamp: Date.now(),
+      direction: "inbound",
+      from: fields.from,
+      to: fields.to,
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // VoiceCallProvider surface.
+  // ---------------------------------------------------------------------------
+
+  verifyWebhook(_ctx: WebhookContext): WebhookVerificationResult {
+    // Teams does not use the voice-call webhook plane — accept by default so
+    // the manager does not reject incoming traffic. Real auth lives on the
+    // WebSocket upgrade (see `MsteamsMediaStream`).
+    return { ok: true };
+  }
+
+  parseWebhookEvent(
+    _ctx: WebhookContext,
+    _options?: WebhookParseOptions,
+  ): ProviderWebhookParseResult {
+    // No webhook events to parse — the WS provides the lifecycle.
+    return { events: [], statusCode: 204 };
+  }
+
+  async initiateCall(_input: InitiateCallInput): Promise<InitiateCallResult> {
+    // Outbound calls (OpenClaw asking the worker to dial into a meeting) are not
+    // supported — the msteams provider is inbound-only.
+    throw new Error("MsteamsProvider.initiateCall is not supported (inbound-only)");
+  }
+
+  async hangupCall(input: HangupCallInput): Promise<void> {
+    // Manager-initiated hangup: stop playback, send AssistantCancel-equivalent
+    // close, and tear down. The manager finalizes the call record itself.
+    this.teardownCall(input.providerCallId, { closeSession: true, reason: input.reason });
+  }
+
+  async playTts(input: PlayTtsInput): Promise<void> {
+    const state = this.calls.get(input.providerCallId);
+    if (!state) {
+      throw new Error(`MsteamsProvider.playTts: no active session for ${input.providerCallId}`);
+    }
+    if (!this.ttsProvider) {
+      throw new Error("MsteamsProvider.playTts: TTS provider not configured");
+    }
+
+    // Supersede any in-flight playback for this call (e.g. rapid responses).
+    state.ttsAbort?.abort();
+    const abort = new AbortController();
+    state.ttsAbort = abort;
+    state.turnId += 1;
+
+    // msteams-tts.ts synthesizes and resamples to PCM 16 kHz mono.
+    const pcm16k = await this.ttsProvider.synthesizePcm16k(input.text);
+    if (abort.signal.aborted) {
+      return;
+    }
+    if (pcm16k.length === 0) {
+      throw new Error("MsteamsProvider.playTts: TTS produced no audio");
+    }
+
+    await this.streamPcmFrames(state, pcm16k, abort.signal);
+
+    if (state.ttsAbort === abort) {
+      state.ttsAbort = null;
+    }
+  }
+
+  /**
+   * Chunk PCM into 20 ms / 640-byte frames and send them to the worker with
+   * drift-corrected pacing, mirroring Twilio's `playTtsViaStream`. Uses an
+   * absolute clock so cumulative scheduling jitter does not accumulate.
+   */
+  private async streamPcmFrames(
+    state: MsteamsCallState,
+    pcm: Buffer,
+    signal: AbortSignal,
+  ): Promise<void> {
+    let nextFrameDueAt = Date.now() + FRAME_DURATION_MS;
+    for (const frame of chunkAudio(pcm, FRAME_BYTES)) {
+      if (signal.aborted) {
+        return;
+      }
+      state.session.send({
+        type: "audio.frame",
+        seq: state.outboundSeq,
+        timestampMs: state.outboundTimestampMs,
+        payloadBase64: frame.toString("base64"),
+      });
+      state.outboundSeq += 1;
+      state.outboundTimestampMs += FRAME_DURATION_MS;
+
+      const waitMs = nextFrameDueAt - Date.now();
+      if (waitMs > 0) {
+        await sleep(waitMs);
+      }
+      nextFrameDueAt += FRAME_DURATION_MS;
+    }
+  }
+
+  async startListening(_input: StartListeningInput): Promise<void> {
+    // No-op: caller audio is already streaming over the WS into the STT session
+    // for the lifetime of the call.
+  }
+
+  async stopListening(_input: StopListeningInput): Promise<void> {
+    // No-op: the WS keeps streaming; there is no per-turn listen gate.
+  }
+
+  async getCallStatus(input: GetCallStatusInput): Promise<GetCallStatusResult> {
+    // Status is driven by the WS lifecycle, not by webhook polling. Report
+    // active while a session exists; otherwise treat as terminal so the
+    // manager can reap stale persisted entries on restart.
+    if (this.calls.has(input.providerCallId)) {
+      return { status: "in-progress", isTerminal: false };
+    }
+    return { status: "completed", isTerminal: true };
+  }
+}
+
+function mapEndReason(reason: string): EndReason {
+  const normalized = reason.toLowerCase();
+  if (normalized.includes("timeout")) {
+    return "timeout";
+  }
+  if (normalized.includes("error") || normalized.includes("fail")) {
+    return "error";
+  }
+  // Worker-driven session.end is a caller hangup in the common case.
+  return "hangup-user";
+}
+
+function describeError(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/extensions/voice-call/src/providers/msteams.ts
+++ b/extensions/voice-call/src/providers/msteams.ts
@@ -535,6 +535,15 @@ export class MsteamsProvider implements VoiceCallProvider {
       typeof call.metadata?.numberRouteKey === "string" ? call.metadata.numberRouteKey : call.to;
     const effectiveConfig = resolveVoiceCallEffectiveConfig(voiceConfig, numberRouteKey).config;
 
+    // Inbound vision (streaming path): when the caller is sharing video, attach the latest frame
+    // so the agent can answer visual questions in the same turn (the realtime path uses the
+    // look_at_screen tool; the streaming agent runs per-turn, so we attach the frame directly).
+    // getLatestVideoFrame only returns recording-gated frames, so this is off until recording is active.
+    const frame = this.getLatestVideoFrame(state.providerCallId);
+    const images = frame
+      ? [{ type: "image" as const, data: frame.dataBase64, mimeType: frame.mime }]
+      : undefined;
+
     const result = await generateVoiceResponse({
       voiceConfig: effectiveConfig,
       coreConfig,
@@ -544,6 +553,7 @@ export class MsteamsProvider implements VoiceCallProvider {
       from: call.from,
       transcript: call.transcript,
       userMessage,
+      images,
     });
 
     if (result.error) {

--- a/extensions/voice-call/src/providers/msteams.ts
+++ b/extensions/voice-call/src/providers/msteams.ts
@@ -84,6 +84,18 @@ interface MsteamsCallState {
   pendingAudio: Buffer[];
 }
 
+/** A sampled inbound video frame the agent can "look" at (camera or screen-share). */
+export interface MsteamsVideoFrame {
+  /** Base64-encoded image (JPEG) ready to attach to a vision model. */
+  dataBase64: string;
+  /** MIME type, e.g. "image/jpeg". */
+  mime: string;
+  width: number;
+  height: number;
+  /** Worker capture timestamp (epoch ms). */
+  ts: number;
+}
+
 /** PCM 16 kHz, 16-bit mono — the wire format both directions of the Teams bridge. */
 const MSTEAMS_SAMPLE_RATE_HZ = 16_000;
 const FRAME_DURATION_MS = 20;
@@ -127,6 +139,18 @@ export class MsteamsProvider implements VoiceCallProvider {
   private readonly calls = new Map<string, MsteamsCallState>();
   private readonly realtimeCalls = new Map<string, MsteamsRealtimeCall>();
 
+  /**
+   * Latest sampled inbound video frame per call+source, so the agent can "look" at what the caller
+   * is showing (camera / screen-share). Recording-gated and path-agnostic (works for both the
+   * streaming and realtime paths). Only the most recent frame per source is kept.
+   */
+  private readonly latestVideoFrames = new Map<
+    string,
+    { camera?: MsteamsVideoFrame; screenshare?: MsteamsVideoFrame }
+  >();
+  /** Recording-active state per call (both paths), used to gate inbound video like audio. */
+  private readonly recordingActiveByCall = new Map<string, boolean>();
+
   constructor(options: MsteamsProviderOptions) {
     const { port, bindAddress, path, sharedSecret, logger } = options;
     this.logger = logger;
@@ -140,6 +164,7 @@ export class MsteamsProvider implements VoiceCallProvider {
         onSessionStart: (session) => this.handleSessionStart(session),
         onSessionEnd: (info) => this.handleSessionEnd(info),
         onAudioFrame: (frame) => this.handleAudioFrame(frame),
+        onVideoFrame: (frame) => this.handleVideoFrame(frame),
         onRecordingStatus: (info) => this.handleRecordingStatus(info),
       });
     } else {
@@ -224,6 +249,8 @@ export class MsteamsProvider implements VoiceCallProvider {
     // anonymous callers never collide into one session (cross-caller memory
     // bleed) or match an allowlist as a generic caller.
     const from = session.caller.aadId ?? `teams:${providerCallId}`;
+    // Seed the recording gate for inbound video from the session's initial status.
+    this.recordingActiveByCall.set(providerCallId, session.recordingStatus === "active");
 
     // Realtime mode: bridge the call straight to the speech-to-speech model.
     // It does not route through CallManager, so the inbound-call policy is
@@ -357,6 +384,55 @@ export class MsteamsProvider implements VoiceCallProvider {
     }
   }
 
+  /**
+   * Buffer the latest inbound video frame per source so the agent can "look" at it on demand.
+   * Recording-gated (Media Access API): video is media-derived data and must not be processed
+   * before Teams recording is active. Only the most recent frame per source is retained.
+   */
+  private handleVideoFrame(info: {
+    callId: string;
+    source: "camera" | "screenshare";
+    width: number;
+    height: number;
+    mime: string;
+    dataBase64: string;
+    ts: number;
+  }): void {
+    if (this.requireRecordingStatus() && !this.recordingActiveByCall.get(info.callId)) {
+      return;
+    }
+    const frames = this.latestVideoFrames.get(info.callId) ?? {};
+    frames[info.source] = {
+      dataBase64: info.dataBase64,
+      mime: info.mime,
+      width: info.width,
+      height: info.height,
+      ts: info.ts,
+    };
+    this.latestVideoFrames.set(info.callId, frames);
+    this.logger?.debug?.(
+      `MsteamsProvider: video.frame ${info.callId} ${info.source} ${info.width}x${info.height}`,
+    );
+  }
+
+  /**
+   * The latest inbound video frame for a call. With no `source`, prefers screen-share over camera
+   * (the share is usually what the caller is asking about). Undefined if none captured yet.
+   */
+  getLatestVideoFrame(
+    providerCallId: string,
+    source?: "camera" | "screenshare",
+  ): MsteamsVideoFrame | undefined {
+    const frames = this.latestVideoFrames.get(providerCallId);
+    if (!frames) {
+      return undefined;
+    }
+    if (source) {
+      return frames[source];
+    }
+    return frames.screenshare ?? frames.camera;
+  }
+
   /** Whether the Teams recording-status gate is enforced (default true). */
   private requireRecordingStatus(): boolean {
     return this.responseRuntime?.voiceConfig.msteams?.requireRecordingStatus ?? true;
@@ -382,6 +458,7 @@ export class MsteamsProvider implements VoiceCallProvider {
   /** Track Teams recording status so transcript persistence can be gated on it. */
   private handleRecordingStatus(info: { callId: string; status: MsteamsRecordingStatus }): void {
     const active = info.status === "active";
+    this.recordingActiveByCall.set(info.callId, active);
     const state = this.calls.get(info.callId);
     if (state) {
       state.recordingActive = active;
@@ -483,6 +560,8 @@ export class MsteamsProvider implements VoiceCallProvider {
   }
 
   private handleSessionEnd(info: { callId: string; reason: string }): void {
+    this.latestVideoFrames.delete(info.callId);
+    this.recordingActiveByCall.delete(info.callId);
     const realtimeCall = this.realtimeCalls.get(info.callId);
     if (realtimeCall) {
       this.realtimeCalls.delete(info.callId);

--- a/extensions/voice-call/src/providers/msteams.ts
+++ b/extensions/voice-call/src/providers/msteams.ts
@@ -271,7 +271,14 @@ export class MsteamsProvider implements VoiceCallProvider {
         session.close("rejected");
         return;
       }
-      const realtimeCall = createMsteamsRealtimeCall({ session, deps: this.realtimeDeps });
+      const realtimeCall = createMsteamsRealtimeCall({
+        session,
+        deps: {
+          ...this.realtimeDeps,
+          // Per-call accessor for the look_at_screen vision tool (inbound video only).
+          getLatestFrame: (source) => this.getLatestVideoFrame(providerCallId, source),
+        },
+      });
       this.realtimeCalls.set(providerCallId, realtimeCall);
       this.logger?.info(
         `MsteamsProvider: realtime session.start callId=${providerCallId} threadId=${session.threadId} caller.aadId=${session.caller.aadId ?? "teams"}`,

--- a/extensions/voice-call/src/providers/msteams.ts
+++ b/extensions/voice-call/src/providers/msteams.ts
@@ -218,6 +218,12 @@ export class MsteamsProvider implements VoiceCallProvider {
 
   private handleSessionStart(session: MsteamsSession): void {
     const providerCallId = session.callId;
+    // Caller identity drives both the inbound-policy check and the session key
+    // (per-phone memory). Prefer the Teams AAD object id; when it is absent fall
+    // back to a per-call-unique value rather than a shared literal so distinct
+    // anonymous callers never collide into one session (cross-caller memory
+    // bleed) or match an allowlist as a generic caller.
+    const from = session.caller.aadId ?? `teams:${providerCallId}`;
 
     // Realtime mode: bridge the call straight to the speech-to-speech model.
     // It does not route through CallManager, so the inbound-call policy is
@@ -229,7 +235,6 @@ export class MsteamsProvider implements VoiceCallProvider {
         );
         return;
       }
-      const from = session.caller.aadId ?? "teams";
       if (
         !isInboundCallAllowed(this.realtimeDeps.inboundPolicy, this.realtimeDeps.allowFrom, from)
       ) {
@@ -259,7 +264,6 @@ export class MsteamsProvider implements VoiceCallProvider {
       return;
     }
 
-    const from = session.caller.aadId ?? "teams";
     const to = this.responseRuntime?.voiceConfig.fromNumber ?? "msteams";
 
     // Register the call with the manager. `call.initiated` creates the record

--- a/extensions/voice-call/src/providers/msteams.ts
+++ b/extensions/voice-call/src/providers/msteams.ts
@@ -82,6 +82,8 @@ interface MsteamsCallState {
   recordingActive: boolean;
   /** Caller audio captured before the STT session finished connecting. */
   pendingAudio: Buffer[];
+  /** Last video frame (bytes) already attached to a streaming turn, to skip re-sending it unchanged. */
+  lastVisionFrame?: string;
 }
 
 /** A sampled inbound video frame the agent can "look" at (camera or screen-share). */
@@ -539,10 +541,14 @@ export class MsteamsProvider implements VoiceCallProvider {
     // so the agent can answer visual questions in the same turn (the realtime path uses the
     // look_at_screen tool; the streaming agent runs per-turn, so we attach the frame directly).
     // getLatestVideoFrame only returns recording-gated frames, so this is off until recording is active.
+    // Rate-limit: only attach the frame when it changed since the last turn — a static screen isn't
+    // re-sent every turn (the agent retains it in context), bounding image cost.
     const frame = this.getLatestVideoFrame(state.providerCallId);
-    const images = frame
-      ? [{ type: "image" as const, data: frame.dataBase64, mimeType: frame.mime }]
-      : undefined;
+    let images: Array<{ type: "image"; data: string; mimeType: string }> | undefined;
+    if (frame && frame.dataBase64 !== state.lastVisionFrame) {
+      images = [{ type: "image", data: frame.dataBase64, mimeType: frame.mime }];
+      state.lastVisionFrame = frame.dataBase64;
+    }
 
     const result = await generateVoiceResponse({
       voiceConfig: effectiveConfig,

--- a/extensions/voice-call/src/response-generator.ts
+++ b/extensions/voice-call/src/response-generator.ts
@@ -31,6 +31,11 @@ export type VoiceResponseParams = {
   transcript: Array<{ speaker: "user" | "bot"; text: string }>;
   /** Latest user message */
   userMessage: string;
+  /**
+   * Optional images for a vision-capable turn (e.g. the caller's latest shared video frame), so
+   * the streaming agent can answer "what's on my screen?"-style questions. Forwarded to the agent run.
+   */
+  images?: Array<{ type: "image"; data: string; mimeType: string }>;
 };
 
 export type VoiceResponseResult = {
@@ -222,6 +227,7 @@ export async function generateVoiceResponse(
     userMessage,
     coreConfig,
     agentRuntime,
+    images,
   } = params;
 
   if (!coreConfig) {
@@ -331,6 +337,7 @@ export async function generateVoiceResponse(
       workspaceDir,
       config: cfg,
       prompt: userMessage,
+      images,
       provider,
       model,
       thinkLevel,

--- a/extensions/voice-call/src/runtime.ts
+++ b/extensions/voice-call/src/runtime.ts
@@ -571,6 +571,8 @@ export async function createVoiceCallRuntime(params: {
             config.realtime.tools,
           ),
           toolPolicy: config.realtime.toolPolicy,
+          // Self-echo guard (off by default); configurable via realtime config.
+          suppressInputDuringPlayback: config.realtime.suppressInputDuringPlayback,
           agentRuntime,
           voiceConfig: config,
           logger: log,

--- a/extensions/voice-call/src/runtime.ts
+++ b/extensions/voice-call/src/runtime.ts
@@ -14,13 +14,16 @@ import type { VoiceCallConfig } from "./config.js";
 import {
   resolveVoiceCallEffectiveConfig,
   resolveVoiceCallSessionKey,
+  resolveMsteamsSharedSecret,
   resolveTwilioAuthToken,
   resolveVoiceCallConfig,
   validateProviderConfig,
 } from "./config.js";
 import type { CoreAgentDeps, CoreConfig } from "./core-bridge.js";
 import { CallManager } from "./manager.js";
+import { wireMsteamsRuntime } from "./msteams.runtime.js";
 import type { VoiceCallProvider } from "./providers/base.js";
+import type { MsteamsProvider } from "./providers/msteams.js";
 import type { TwilioProvider } from "./providers/twilio.js";
 import { buildRealtimeVoiceInstructions } from "./realtime-agent-context.js";
 import { resolveRealtimeFastContextConsult } from "./realtime-fast-context.js";
@@ -60,6 +63,7 @@ type TelnyxProviderModule = typeof import("./providers/telnyx.js");
 type TwilioProviderModule = typeof import("./providers/twilio.js");
 type PlivoProviderModule = typeof import("./providers/plivo.js");
 type MockProviderModule = typeof import("./providers/mock.js");
+type MsteamsProviderModule = typeof import("./providers/msteams.js");
 type RealtimeVoiceRuntimeModule = typeof import("./realtime-voice.runtime.js");
 type RealtimeHandlerModule = typeof import("./webhook/realtime-handler.js");
 
@@ -76,6 +80,7 @@ let telnyxProviderPromise: Promise<TelnyxProviderModule> | undefined;
 let twilioProviderPromise: Promise<TwilioProviderModule> | undefined;
 let plivoProviderPromise: Promise<PlivoProviderModule> | undefined;
 let mockProviderPromise: Promise<MockProviderModule> | undefined;
+let msteamsProviderPromise: Promise<MsteamsProviderModule> | undefined;
 let realtimeVoiceRuntimePromise: Promise<RealtimeVoiceRuntimeModule> | undefined;
 let realtimeHandlerPromise: Promise<RealtimeHandlerModule> | undefined;
 
@@ -97,6 +102,11 @@ function loadPlivoProvider(): Promise<PlivoProviderModule> {
 function loadMockProvider(): Promise<MockProviderModule> {
   mockProviderPromise ??= import("./providers/mock.js");
   return mockProviderPromise;
+}
+
+function loadMsteamsProvider(): Promise<MsteamsProviderModule> {
+  msteamsProviderPromise ??= import("./providers/msteams.js");
+  return msteamsProviderPromise;
 }
 
 function loadRealtimeVoiceRuntime(): Promise<RealtimeVoiceRuntimeModule> {
@@ -152,9 +162,11 @@ function createRuntimeResourceLifecycle(params: {
   webhookServer: VoiceCallWebhookServer;
 }): {
   setTunnelResult: (result: TunnelResult | null) => void;
+  setProviderStop: (stop: (() => Promise<void>) | null) => void;
   stop: (opts?: { suppressErrors?: boolean }) => Promise<void>;
 } {
   let tunnelResult: TunnelResult | null = null;
+  let providerStop: (() => Promise<void>) | null = null;
   let stopped = false;
 
   const runStep = async (step: () => Promise<void>, suppressErrors: boolean) => {
@@ -169,12 +181,22 @@ function createRuntimeResourceLifecycle(params: {
     setTunnelResult: (result) => {
       tunnelResult = result;
     },
+    setProviderStop: (stop) => {
+      providerStop = stop;
+    },
     stop: async (opts) => {
       if (stopped) {
         return;
       }
       stopped = true;
       const suppressErrors = opts?.suppressErrors ?? false;
+      // Stop the provider first so any network listener it owns (e.g. the Teams
+      // bridge WebSocket server) releases its port before the rest of teardown.
+      await runStep(async () => {
+        if (providerStop) {
+          await providerStop();
+        }
+      }, suppressErrors);
       await runStep(async () => {
         if (tunnelResult) {
           await tunnelResult.stop();
@@ -190,7 +212,7 @@ function createRuntimeResourceLifecycle(params: {
   };
 }
 
-async function resolveProvider(config: VoiceCallConfig): Promise<VoiceCallProvider> {
+async function resolveProvider(config: VoiceCallConfig, log: Logger): Promise<VoiceCallProvider> {
   const allowNgrokFreeTierLoopbackBypass =
     config.tunnel?.provider === "ngrok" &&
     isLoopbackHost(config.serve?.bind ?? "") &&
@@ -244,6 +266,16 @@ async function resolveProvider(config: VoiceCallConfig): Promise<VoiceCallProvid
     case "mock": {
       const { MockProvider } = await loadMockProvider();
       return new MockProvider();
+    }
+    case "msteams": {
+      const { MsteamsProvider } = await loadMsteamsProvider();
+      return new MsteamsProvider({
+        port: config.msteams?.port,
+        bindAddress: config.msteams?.bindAddress,
+        path: config.msteams?.path,
+        sharedSecret: resolveMsteamsSharedSecret(config),
+        logger: log,
+      });
     }
     default:
       throw new Error(`Unsupported voice-call provider: ${String(config.provider)}`);
@@ -305,7 +337,7 @@ export async function createVoiceCallRuntime(params: {
     throw new Error(`Invalid voice-call config: ${validation.errors.join("; ")}`);
   }
 
-  const provider = await resolveProvider(config);
+  const provider = await resolveProvider(config, log);
   if (stateRuntime) {
     setVoiceCallStateRuntime({ state: stateRuntime });
   }
@@ -507,6 +539,72 @@ export async function createVoiceCallRuntime(params: {
         twilioProvider.setMediaStreamHandler(mediaHandler);
         log.info("[voice-call] Media stream handler wired to provider");
       }
+    }
+
+    if (provider.name === "msteams") {
+      const msteamsProvider = provider as MsteamsProvider;
+      let handlerWired = false;
+      if (config.realtime.enabled && realtimeProvider) {
+        // Low-latency speech-to-speech: bridge the Teams call straight to the
+        // realtime model (no STT/agent/TTS pipeline).
+        const realtimeInstructions = await buildRealtimeVoiceInstructions({
+          baseInstructions: config.realtime.instructions,
+          config,
+          coreConfig,
+          agentRuntime,
+        });
+        msteamsProvider.setRealtimeRuntime({
+          provider: realtimeProvider.provider,
+          providerConfig: realtimeProvider.providerConfig,
+          cfg,
+          instructions: realtimeInstructions,
+          greetingInstructions: config.inboundGreeting,
+          inboundPolicy: config.inboundPolicy,
+          allowFrom: config.allowFrom,
+          // Gate the consult tool + background task on Teams recording status
+          // (Media Access API), mirroring the streaming path. Default true.
+          requireRecordingStatus: config.msteams?.requireRecordingStatus,
+          // Let the realtime model delegate real work to the OpenClaw agent via
+          // openclaw_agent_consult (the agent runs tools and returns a result).
+          tools: resolveRealtimeVoiceAgentConsultTools(
+            config.realtime.toolPolicy,
+            config.realtime.tools,
+          ),
+          toolPolicy: config.realtime.toolPolicy,
+          agentRuntime,
+          voiceConfig: config,
+          logger: log,
+        });
+        log.info("[voice-call] msteams realtime voice mode enabled");
+        handlerWired = true;
+      } else if (config.streaming?.enabled) {
+        await wireMsteamsRuntime({
+          config,
+          coreConfig,
+          fullConfig: cfg,
+          agentRuntime,
+          ttsRuntime,
+          manager,
+          provider,
+          logger: log,
+        });
+        handlerWired = true;
+      }
+      // Fail fast instead of binding a listener that would accept Teams calls it
+      // cannot handle (e.g. realtime requested but no realtime provider resolved,
+      // and streaming disabled).
+      if (!handlerWired) {
+        throw new Error(
+          config.realtime.enabled
+            ? "[voice-call] msteams: realtime.enabled is set but no realtime voice provider resolved, and streaming is disabled"
+            : "[voice-call] msteams: neither realtime nor streaming is enabled",
+        );
+      }
+      // Bind the Teams bridge WebSocket server as part of runtime startup so a
+      // failed bind aborts initialization (the catch below cleans up); register
+      // its stop so teardown releases the port instead of leaving it occupied.
+      await msteamsProvider.start();
+      lifecycle.setProviderStop(() => msteamsProvider.stop());
     }
 
     if (realtimeProvider) {

--- a/extensions/voice-call/src/types.ts
+++ b/extensions/voice-call/src/types.ts
@@ -6,7 +6,7 @@ import type { CallMode } from "./config.js";
 // Provider Identifiers
 // -----------------------------------------------------------------------------
 
-const ProviderNameSchema = z.enum(["telnyx", "twilio", "plivo", "mock"]);
+const ProviderNameSchema = z.enum(["telnyx", "twilio", "plivo", "mock", "msteams"]);
 export type ProviderName = z.infer<typeof ProviderNameSchema>;
 
 // -----------------------------------------------------------------------------

--- a/extensions/voice-call/src/webhook-exposure.test.ts
+++ b/extensions/voice-call/src/webhook-exposure.test.ts
@@ -1,6 +1,11 @@
 // Voice Call tests cover webhook exposure plugin behavior.
 import { describe, expect, it } from "vitest";
-import { isLocalOnlyWebhookHost, isProviderUnreachableWebhookUrl } from "./webhook-exposure.js";
+import {
+  isLocalOnlyWebhookHost,
+  isProviderUnreachableWebhookUrl,
+  providerRequiresPublicWebhook,
+  resolveWebhookExposureStatus,
+} from "./webhook-exposure.js";
 
 describe("webhook exposure host classification", () => {
   it.each([
@@ -31,4 +36,44 @@ describe("webhook exposure host classification", () => {
       expect(isLocalOnlyWebhookHost(host)).toBe(true);
     },
   );
+});
+
+describe("providerRequiresPublicWebhook", () => {
+  it("requires public webhooks only for carrier webhook-plane providers", () => {
+    expect(providerRequiresPublicWebhook("twilio")).toBe(true);
+    expect(providerRequiresPublicWebhook("telnyx")).toBe(true);
+    expect(providerRequiresPublicWebhook("plivo")).toBe(true);
+    expect(providerRequiresPublicWebhook("msteams")).toBe(false);
+    expect(providerRequiresPublicWebhook("mock")).toBe(false);
+  });
+});
+
+describe("resolveWebhookExposureStatus", () => {
+  it("does not flag msteams for webhook exposure (uses the bridge listener)", () => {
+    // Regression: a valid msteams config has no publicUrl/tunnel/tailscale, but
+    // Teams receives calls over its own bridge WebSocket — setup/status must not
+    // report it as needing public webhook exposure.
+    const status = resolveWebhookExposureStatus({ provider: "msteams" });
+    expect(status.ok).toBe(true);
+    expect(status.configured).toBe(true);
+    expect(status.message).toMatch(/bridge WebSocket listener/i);
+  });
+
+  it("exempts the mock provider", () => {
+    expect(resolveWebhookExposureStatus({ provider: "mock" }).ok).toBe(true);
+  });
+
+  it("still flags a webhook-plane provider with no exposure configured", () => {
+    const status = resolveWebhookExposureStatus({ provider: "twilio" });
+    expect(status.ok).toBe(false);
+    expect(status.configured).toBe(false);
+  });
+
+  it("accepts a reachable public URL for a webhook-plane provider", () => {
+    const status = resolveWebhookExposureStatus({
+      provider: "twilio",
+      publicUrl: "https://voice.example.com/voice/webhook",
+    });
+    expect(status.ok).toBe(true);
+  });
 });

--- a/extensions/voice-call/src/webhook-exposure.ts
+++ b/extensions/voice-call/src/webhook-exposure.ts
@@ -54,6 +54,18 @@ export function resolveWebhookExposureStatus(
     };
   }
 
+  // Microsoft Teams receives calls over its own authenticated bridge WebSocket
+  // listener (msteams.port/path), not the public provider-webhook plane, so it
+  // never needs publicUrl / tunnel / tailscale exposure.
+  if (config.provider === "msteams") {
+    return {
+      ok: true,
+      configured: true,
+      message:
+        "Microsoft Teams uses the bridge WebSocket listener; no public webhook exposure needed",
+    };
+  }
+
   if (config.publicUrl) {
     if (isProviderUnreachableWebhookUrl(config.publicUrl)) {
       return {

--- a/src/secrets/runtime-config-collectors-plugins.bundled.test.ts
+++ b/src/secrets/runtime-config-collectors-plugins.bundled.test.ts
@@ -20,6 +20,7 @@ describe("collectPluginConfigAssignments bundled plugin manifests", () => {
       })?.manifest.configContracts?.secretInputs?.paths,
     ).toEqual([
       { path: "twilio.authToken", expected: "string" },
+      { path: "msteams.sharedSecret", expected: "string" },
       { path: "realtime.providers.*.apiKey", expected: "string" },
       { path: "streaming.providers.*.apiKey", expected: "string" },
       { path: "tts.providers.*.apiKey", expected: "string" },
@@ -74,6 +75,7 @@ describe("collectPluginConfigAssignments bundled plugin manifests", () => {
       }).get("voice-call")?.configContracts.secretInputs?.paths,
     ).toEqual([
       { path: "twilio.authToken", expected: "string" },
+      { path: "msteams.sharedSecret", expected: "string" },
       { path: "realtime.providers.*.apiKey", expected: "string" },
       { path: "streaming.providers.*.apiKey", expected: "string" },
       { path: "tts.providers.*.apiKey", expected: "string" },

--- a/src/talk/agent-consult-runtime.ts
+++ b/src/talk/agent-consult-runtime.ts
@@ -224,6 +224,8 @@ export async function consultRealtimeVoiceAgent(params: {
   lane: string;
   runIdPrefix: string;
   args: unknown;
+  /** Optional images (e.g. a sampled call video frame) for a vision-capable agent run. */
+  images?: RunEmbeddedAgentParams["images"];
   transcript: RealtimeVoiceAgentConsultTranscriptEntry[];
   surface: string;
   userLabel: string;
@@ -302,6 +304,7 @@ export async function consultRealtimeVoiceAgent(params: {
       assistantLabel: params.assistantLabel,
       questionSourceLabel: params.questionSourceLabel,
     }),
+    images: params.images,
     provider: params.provider,
     model: params.model,
     thinkLevel: params.thinkLevel ?? "high",


### PR DESCRIPTION
## Summary

Adds a **Microsoft Teams (`msteams`) provider** to the `voice-call` extension: an inbound voice assistant for 1:1 Teams calls, plus optional **inbound video vision** so the agent can see the caller's camera or screen-share and answer questions about it.

Both existing voice-call interaction modes are supported:
- **Streaming** (STT → agent → TTS)
- **Realtime** (speech-to-speech)

## What's in this PR

**Voice (the `msteams` provider):**
- New `msteams` provider that exposes an HMAC-authenticated WebSocket endpoint for per-call audio.
- Caller **allowlist**, safe-by-default (never open; matches Teams AAD object ids / UPNs).
- Streaming + realtime paths; background-task delegation that messages the caller back on Microsoft Teams when long-running work finishes.
- Config schema, plugin-manifest entry, and docs.

**Video / vision (new here):**
- Inbound `video.frame` ingestion on the same authenticated endpoint; the provider buffers the latest frame per source (camera / screen-share).
- **`look_at_screen`** tool (realtime) + automatic frame attachment (streaming): the agent runs a vision-capable model over the latest frame and answers in line.
- **Rate-limited** (skips re-running on an unchanged frame) and **recording-gated** (no frame is processed before recording is active).

## Relationship to #89724

#89724 proposes the **voice-only** `msteams` provider. **This PR is a standalone superset** — the same voice provider **plus** inbound video/vision. If maintainers prefer to land voice first, #89724 is the voice-only subset; otherwise this PR delivers both together. They overlap — pick one.

## Safety & compliance

- **Recording gate:** no audio-derived data and no video frame is processed/persisted before the call's recording status is active.
- **Allowlist:** inbound is rejected unless the caller matches the configured allowlist; default posture is closed.
- HMAC-signed upgrade; shared secret supplied via secretref.

## Real behavior proof

- **Behavior or issue addressed:** Inbound Microsoft Teams voice + video — the agent can answer questions about the caller's shared screen via `look_at_screen`, and hand a long-running ask off as a background task that replies on Microsoft Teams.
- **Real environment tested:** A live 1:1 Microsoft Teams call against a running OpenClaw gateway (realtime speech path + a vision-capable model). A real call, not a mock.
- **Exact steps or command run after this patch:**
  1. `pnpm openclaw gateway run --force` to start the gateway with the `msteams` provider and realtime enabled.
  2. Placed a 1:1 Microsoft Teams call to the assistant and shared a screen.
  3. Asked aloud: *"what's on my screen?"*
  4. Then asked: *"what's the current Dubai time — check it in the background and message me."* and ended the call.
- **Evidence after fix (copied live output / redacted runtime log):**
  ```text
  look_at_screen — spoken answer to the caller:
    "A Chrome window open to the LibreChat docs Quick Start page; center cards
     Docker, npm, Railway; left nav Quick Start, Deploy, Configuration,
     Services, Infrastructure."

  background task — Microsoft Teams chat message received after the call:
    1) "checking the current time in Dubai, I'll send you the result shortly"
    2) "the current time in Dubai is 11:12 AM, Sunday 7 June 2026 (GST)"
  ```
- **Observed result after fix:** The agent described the live shared screen accurately and in line, and the background task delivered the Dubai time as a Microsoft Teams chat message after the call ended. Both matched expectations.
- **What was not tested:** Multi-party (group-call) per-participant camera selection.
- **Proof limitations or environment constraints:** Evidence is copied live output and redacted to avoid publishing the shared-screen image, call identifiers, and account details.

## Tests and validation

- Unit coverage across provider, media-stream, realtime, config, allowlist, and webhook-exposure (supplemental to the live proof above).

## Config (example)

```jsonc
"voice-call": {
  "config": {
    "msteams": {
      "port": 8443,
      "path": "/voice/msteams/stream",
      "sharedSecret": "<secretref>",
      "requireRecordingStatus": true
    },
    "realtime": { "enabled": true }
  }
}
```

## Out-of-scope follow-ups

- Inbound **camera is 1:1**; screen-share (VBSS) is source-addressed and works in meetings. Per-participant camera selection in group calls is out of scope here.
