### PR TITLE
refactor(memory-wiki): store import runs in sqlite

### DIFF
--- a/extensions/memory-wiki/doctor-contract-api.test.ts
+++ b/extensions/memory-wiki/doctor-contract-api.test.ts
@@ -10,6 +10,11 @@ import {
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { stateMigrations } from "./doctor-contract-api.js";
 import {
+  createMemoryWikiImportRunStateStore,
+  readMemoryWikiImportRunRecord,
+  resolveMemoryWikiImportRunRecordPath,
+} from "./src/import-runs-state.js";
+import {
   createMemoryWikiSourceSyncStateStore,
   readMemoryWikiSourceSyncState,
   resolveMemoryWikiSourceSyncStatePath,
@@ -110,6 +115,78 @@ describe("memory-wiki doctor source sync migration", () => {
     });
     await expect(fs.stat(legacyPath)).rejects.toMatchObject({ code: "ENOENT" });
     await expect(fs.stat(`${legacyPath}.migrated`)).resolves.toBeDefined();
+  });
+
+  it("detects and migrates legacy import-run records into plugin state", async () => {
+    const stateDir = await makeTempDir();
+    const vaultRoot = path.join(stateDir, "vault");
+    const legacyPath = resolveMemoryWikiImportRunRecordPath(vaultRoot, "chatgpt-alpha");
+    const snapshotPath = path.join(
+      vaultRoot,
+      ".openclaw-wiki",
+      "import-runs",
+      "chatgpt-alpha",
+      "snapshots",
+      "alpha.md",
+    );
+    await fs.mkdir(path.dirname(legacyPath), { recursive: true });
+    await fs.mkdir(path.dirname(snapshotPath), { recursive: true });
+    await fs.writeFile(snapshotPath, "previous page\n", "utf8");
+    await fs.writeFile(
+      legacyPath,
+      `${JSON.stringify({
+        version: 1,
+        runId: "chatgpt-alpha",
+        importType: "chatgpt",
+        exportPath: "/tmp/chatgpt",
+        sourcePath: "/tmp/chatgpt/conversations.json",
+        appliedAt: "2026-04-10T10:00:00.000Z",
+        conversationCount: 2,
+        createdCount: 1,
+        updatedCount: 1,
+        skippedCount: 0,
+        createdPaths: ["sources/new.md"],
+        updatedPaths: [{ path: "sources/existing.md", snapshotPath: "snapshots/alpha.md" }],
+      })}\n`,
+    );
+    const params = migrationParams({ stateDir, vaultRoot });
+    const migration = stateMigrations.find(
+      (entry) => entry.id === "memory-wiki-import-runs-json-to-plugin-state",
+    );
+    if (!migration) {
+      throw new Error("Expected import-run migration");
+    }
+
+    await expect(migration.detectLegacyState(params)).resolves.toEqual({
+      preview: [expect.stringContaining("Memory Wiki import runs:")],
+    });
+    await expect(migration.migrateLegacyState(params)).resolves.toEqual({
+      changes: [
+        "Migrated Memory Wiki import runs -> plugin state (1 imported, 0 existing)",
+        expect.stringContaining("Archived Memory Wiki import-run legacy record ->"),
+      ],
+      warnings: [],
+    });
+    const store = createMemoryWikiImportRunStateStore(params.context.openPluginStateKeyedStore);
+    await expect(readMemoryWikiImportRunRecord(vaultRoot, "chatgpt-alpha", store)).resolves.toEqual(
+      {
+        version: 1,
+        runId: "chatgpt-alpha",
+        importType: "chatgpt",
+        exportPath: "/tmp/chatgpt",
+        sourcePath: "/tmp/chatgpt/conversations.json",
+        appliedAt: "2026-04-10T10:00:00.000Z",
+        conversationCount: 2,
+        createdCount: 1,
+        updatedCount: 1,
+        skippedCount: 0,
+        createdPaths: ["sources/new.md"],
+        updatedPaths: [{ path: "sources/existing.md", snapshotPath: "snapshots/alpha.md" }],
+      },
+    );
+    await expect(fs.stat(legacyPath)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(fs.stat(`${legacyPath}.migrated`)).resolves.toBeDefined();
+    await expect(fs.readFile(snapshotPath, "utf8")).resolves.toBe("previous page\n");
   });
 
   it("merges legacy entries with existing plugin state before archiving", async () => {

--- a/extensions/memory-wiki/doctor-contract-api.ts
+++ b/extensions/memory-wiki/doctor-contract-api.ts
@@ -1,9 +1,20 @@
 // Memory Wiki doctor contract migrates shipped source-sync state.
 import fs from "node:fs/promises";
+import path from "node:path";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/plugin-entry";
 import type { PluginDoctorStateMigration } from "openclaw/plugin-sdk/runtime-doctor";
 import { resolveMemoryWikiConfig, type MemoryWikiPluginConfig } from "./src/config.js";
 export { legacyConfigRules, normalizeCompatibilityConfig } from "./src/config-compat.js";
+import {
+  countMemoryWikiImportRunStateRows,
+  createMemoryWikiImportRunStateStore,
+  listMemoryWikiImportRunRecords,
+  MEMORY_WIKI_IMPORT_RUN_STATE_MAX_ENTRIES,
+  MEMORY_WIKI_IMPORT_RUN_STATE_NAMESPACE,
+  readLegacyMemoryWikiImportRunRecords,
+  resolveMemoryWikiImportRunsDir,
+  writeMemoryWikiImportRunRecord,
+} from "./src/import-runs-state.js";
 import {
   createMemoryWikiSourceSyncStateStore,
   MEMORY_WIKI_SOURCE_SYNC_STATE_MAX_ENTRIES,
@@ -52,22 +63,59 @@ async function fileExists(filePath: string): Promise<boolean> {
 
 async function archiveLegacySource(params: {
   filePath: string;
+  label: string;
   changes: string[];
   warnings: string[];
 }): Promise<void> {
   const archivedPath = `${params.filePath}.migrated`;
   if (await fileExists(archivedPath)) {
     params.warnings.push(
-      `Left migrated Memory Wiki source-sync source in place because ${archivedPath} already exists`,
+      `Left migrated ${params.label} in place because ${archivedPath} already exists`,
     );
     return;
   }
   try {
     await fs.rename(params.filePath, archivedPath);
-    params.changes.push(`Archived Memory Wiki source-sync legacy source -> ${archivedPath}`);
+    params.changes.push(`Archived ${params.label} -> ${archivedPath}`);
   } catch (err) {
-    params.warnings.push(`Failed archiving Memory Wiki source-sync legacy source: ${String(err)}`);
+    params.warnings.push(`Failed archiving ${params.label}: ${String(err)}`);
   }
+}
+
+async function archiveLegacyImportRunRecords(params: {
+  vaultRoot: string;
+  changes: string[];
+  warnings: string[];
+}): Promise<void> {
+  const importRunsDir = resolveMemoryWikiImportRunsDir(params.vaultRoot);
+  const entries = await fs
+    .readdir(importRunsDir, { withFileTypes: true })
+    .catch((error: unknown) => {
+      if (isRecord(error) && error.code === "ENOENT") {
+        return [];
+      }
+      throw error;
+    });
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith(".json")) {
+      continue;
+    }
+    await archiveLegacySource({
+      filePath: path.join(importRunsDir, entry.name),
+      label: "Memory Wiki import-run legacy record",
+      changes: params.changes,
+      warnings: params.warnings,
+    });
+  }
+}
+
+function countImportRunStateRows(
+  records: Array<{ createdPaths: string[]; updatedPaths: unknown[] }>,
+): number {
+  return records.reduce(
+    (total, record) => total + 1 + record.createdPaths.length + record.updatedPaths.length,
+    0,
+  );
 }
 
 export const stateMigrations: PluginDoctorStateMigration[] = [
@@ -131,7 +179,68 @@ export const stateMigrations: PluginDoctorStateMigration[] = [
         changes.push(
           `Migrated Memory Wiki source sync -> plugin state (${importedCount} imported, ${existingCount} existing)`,
         );
-        await archiveLegacySource({ filePath, changes, warnings });
+        await archiveLegacySource({
+          filePath,
+          label: "Memory Wiki source-sync legacy source",
+          changes,
+          warnings,
+        });
+      }
+      return { changes, warnings };
+    },
+  },
+  {
+    id: "memory-wiki-import-runs-json-to-plugin-state",
+    label: "Memory Wiki import run records",
+    async detectLegacyState(params) {
+      const previews: string[] = [];
+      for (const vaultRoot of resolveConfiguredVaultRoots({
+        config: params.config,
+        env: params.env,
+      })) {
+        const records = await readLegacyMemoryWikiImportRunRecords(vaultRoot);
+        if (records.length === 0) {
+          continue;
+        }
+        previews.push(
+          `- Memory Wiki import runs: ${resolveMemoryWikiImportRunsDir(vaultRoot)}/*.json -> plugin state (${MEMORY_WIKI_IMPORT_RUN_STATE_NAMESPACE}, ${records.length} records)`,
+        );
+      }
+      return previews.length > 0 ? { preview: previews } : null;
+    },
+    async migrateLegacyState(params) {
+      const changes: string[] = [];
+      const warnings: string[] = [];
+      const store = createMemoryWikiImportRunStateStore(params.context.openPluginStateKeyedStore);
+      for (const vaultRoot of resolveConfiguredVaultRoots({
+        config: params.config,
+        env: params.env,
+      })) {
+        const records = await readLegacyMemoryWikiImportRunRecords(vaultRoot);
+        if (records.length === 0) {
+          continue;
+        }
+        const existingRecords = await listMemoryWikiImportRunRecords(vaultRoot, store);
+        const existingRunIds = new Set(existingRecords.map((record) => record.runId));
+        const importedRecords = records.filter((record) => !existingRunIds.has(record.runId));
+        const nextRowCount =
+          (await countMemoryWikiImportRunStateRows(store)) +
+          countImportRunStateRows(importedRecords);
+        if (nextRowCount > MEMORY_WIKI_IMPORT_RUN_STATE_MAX_ENTRIES) {
+          warnings.push(
+            `Skipped Memory Wiki import-run import for ${vaultRoot}: ${nextRowCount} state rows exceeds ${MEMORY_WIKI_IMPORT_RUN_STATE_MAX_ENTRIES}`,
+          );
+          continue;
+        }
+        let importedCount = 0;
+        for (const record of importedRecords) {
+          await writeMemoryWikiImportRunRecord(vaultRoot, record, store);
+          importedCount += 1;
+        }
+        changes.push(
+          `Migrated Memory Wiki import runs -> plugin state (${importedCount} imported, ${existingRunIds.size} existing)`,
+        );
+        await archiveLegacyImportRunRecords({ vaultRoot, changes, warnings });
       }
       return { changes, warnings };
     },

--- a/extensions/memory-wiki/index.ts
+++ b/extensions/memory-wiki/index.ts
@@ -4,6 +4,10 @@ import { registerWikiCli } from "./src/cli.js";
 import { memoryWikiConfigSchema, resolveMemoryWikiConfig } from "./src/config.js";
 import { createWikiCorpusSupplement } from "./src/corpus-supplement.js";
 import { registerMemoryWikiGatewayMethods } from "./src/gateway.js";
+import {
+  configureMemoryWikiImportRunStateStore,
+  createMemoryWikiImportRunStateStore,
+} from "./src/import-runs-state.js";
 import { createWikiPromptSectionBuilder } from "./src/prompt-section.js";
 import {
   configureMemoryWikiSourceSyncStateStore,
@@ -26,6 +30,9 @@ export default definePluginEntry({
     const config = resolveMemoryWikiConfig(api.pluginConfig);
     configureMemoryWikiSourceSyncStateStore(
       createMemoryWikiSourceSyncStateStore(api.runtime.state.openKeyedStore),
+    );
+    configureMemoryWikiImportRunStateStore(
+      createMemoryWikiImportRunStateStore(api.runtime.state.openKeyedStore),
     );
 
     api.registerMemoryPromptSupplement(createWikiPromptSectionBuilder(config));

--- a/extensions/memory-wiki/src/chatgpt-import.ts
+++ b/extensions/memory-wiki/src/chatgpt-import.ts
@@ -2,7 +2,6 @@
 import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { writeJsonFileAtomically } from "openclaw/plugin-sdk/json-store";
 import {
   replaceManagedMarkdownBlock,
   withTrailingNewline,
@@ -11,6 +10,14 @@ import { timestampMsToIsoString } from "openclaw/plugin-sdk/number-runtime";
 import { uniqueStrings } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { compileMemoryWikiVault } from "./compile.js";
 import type { ResolvedMemoryWikiConfig } from "./config.js";
+import {
+  countMemoryWikiImportRunStateRows,
+  MEMORY_WIKI_IMPORT_RUN_STATE_MAX_ENTRIES,
+  readMemoryWikiImportRunRecord,
+  resolveMemoryWikiImportRunsDir,
+  type ChatGptImportRunRecord,
+  writeMemoryWikiImportRunRecord,
+} from "./import-runs-state.js";
 import { appendMemoryWikiLog } from "./log.js";
 import {
   parseWikiMarkdown,
@@ -93,27 +100,6 @@ type ChatGptImportAction = {
   userMessageCount: number;
   assistantMessageCount: number;
   preferenceSignals: string[];
-};
-
-type ChatGptImportRunEntry = {
-  path: string;
-  snapshotPath?: string;
-};
-
-type ChatGptImportRunRecord = {
-  version: 1;
-  runId: string;
-  importType: "chatgpt";
-  exportPath: string;
-  sourcePath: string;
-  appliedAt: string;
-  conversationCount: number;
-  createdCount: number;
-  updatedCount: number;
-  skippedCount: number;
-  createdPaths: string[];
-  updatedPaths: ChatGptImportRunEntry[];
-  rolledBackAt?: string;
 };
 
 export type ChatGptImportResult = {
@@ -654,14 +640,6 @@ function buildRunId(exportPath: string, nowIso: string): string {
   return `chatgpt-${createHash("sha1").update(seed).digest("hex").slice(0, 12)}`;
 }
 
-function resolveImportRunsDir(vaultRoot: string): string {
-  return path.join(vaultRoot, ".openclaw-wiki", "import-runs");
-}
-
-function resolveImportRunPath(vaultRoot: string, runId: string): string {
-  return path.join(resolveImportRunsDir(vaultRoot), `${runId}.json`);
-}
-
 function normalizeConversationActions(
   records: ChatGptConversationRecord[],
   operations: Map<string, ChatGptImportOperation>,
@@ -683,35 +661,35 @@ async function writeImportRunRecord(
   vaultRoot: string,
   record: ChatGptImportRunRecord,
 ): Promise<void> {
-  const recordPath = resolveImportRunPath(vaultRoot, record.runId);
-  await writeJsonFileAtomically(recordPath, record);
+  await writeMemoryWikiImportRunRecord(vaultRoot, record);
 }
 
 async function readImportRunRecord(
   vaultRoot: string,
   runId: string,
 ): Promise<ChatGptImportRunRecord> {
-  const recordPath = resolveImportRunPath(vaultRoot, runId);
-  const raw = await fs.readFile(recordPath, "utf8");
-  return JSON.parse(raw) as ChatGptImportRunRecord;
+  const record = await readMemoryWikiImportRunRecord(vaultRoot, runId);
+  if (!record) {
+    throw new Error(`Memory Wiki import run not found: ${runId}`);
+  }
+  return record;
 }
 
 async function writeTrackedImportPage(params: {
   vaultRoot: string;
   runDir: string;
   relativePath: string;
-  content: string;
+  existing: string;
+  rendered: string;
   record: ChatGptImportRunRecord;
 }): Promise<ChatGptImportOperation> {
   const absolutePath = path.join(params.vaultRoot, params.relativePath);
-  const existing = await fs.readFile(absolutePath, "utf8").catch(() => "");
-  const rendered = preserveExistingPageBlocks(params.content, existing);
-  if (existing === rendered) {
+  if (params.existing === params.rendered) {
     return "skip";
   }
   await fs.mkdir(path.dirname(absolutePath), { recursive: true });
-  if (!existing) {
-    await fs.writeFile(absolutePath, rendered, "utf8");
+  if (!params.existing) {
+    await fs.writeFile(absolutePath, params.rendered, "utf8");
     params.record.createdPaths.push(params.relativePath);
     return "create";
   }
@@ -719,8 +697,8 @@ async function writeTrackedImportPage(params: {
   const snapshotRelativePath = path.join("snapshots", `${snapshotHash}.md`).replace(/\\/g, "/");
   const snapshotAbsolutePath = path.join(params.runDir, snapshotRelativePath);
   await fs.mkdir(path.dirname(snapshotAbsolutePath), { recursive: true });
-  await fs.writeFile(snapshotAbsolutePath, existing, "utf8");
-  await fs.writeFile(absolutePath, rendered, "utf8");
+  await fs.writeFile(snapshotAbsolutePath, params.existing, "utf8");
+  await fs.writeFile(absolutePath, params.rendered, "utf8");
   params.record.updatedPaths.push({
     path: params.relativePath,
     snapshotPath: snapshotRelativePath,
@@ -749,28 +727,12 @@ export async function importChatGptConversations(params: {
   let skippedCount = 0;
   let runId: string | undefined;
   const nowIso = resolveMemoryWikiTimestamp(params.nowMs);
-
-  let importRunRecord: ChatGptImportRunRecord | undefined;
-  let importRunDir = "";
-
-  if (!params.dryRun) {
-    runId = buildRunId(exportPath, nowIso);
-    importRunDir = path.join(resolveImportRunsDir(params.config.vault.path), runId);
-    importRunRecord = {
-      version: 1,
-      runId,
-      importType: "chatgpt",
-      exportPath,
-      sourcePath: conversationsPath,
-      appliedAt: nowIso,
-      conversationCount: records.length,
-      createdCount: 0,
-      updatedCount: 0,
-      skippedCount: 0,
-      createdPaths: [],
-      updatedPaths: [],
-    };
-  }
+  const importPlans: Array<{
+    relativePath: string;
+    existing: string;
+    rendered: string;
+    operation: ChatGptImportOperation;
+  }> = [];
 
   for (const record of records) {
     const rendered = renderConversationPage(record);
@@ -787,12 +749,54 @@ export async function importChatGptConversations(params: {
     } else {
       skippedCount += 1;
     }
-    if (!params.dryRun && importRunRecord) {
+    importPlans.push({
+      relativePath: record.pagePath,
+      existing,
+      rendered: stabilized,
+      operation,
+    });
+  }
+
+  let importRunRecord: ChatGptImportRunRecord | undefined;
+  const changedCount = createdCount + updatedCount;
+
+  if (!params.dryRun && changedCount > 0) {
+    const requiredStateRows = 1 + changedCount;
+    const existingStateRows = await countMemoryWikiImportRunStateRows();
+    const projectedStateRows = existingStateRows + requiredStateRows;
+    if (projectedStateRows > MEMORY_WIKI_IMPORT_RUN_STATE_MAX_ENTRIES) {
+      throw new Error(
+        `Memory Wiki ChatGPT import exceeds SQLite import-run entry limit (${projectedStateRows}/${MEMORY_WIKI_IMPORT_RUN_STATE_MAX_ENTRIES})`,
+      );
+    }
+
+    runId = buildRunId(exportPath, nowIso);
+    const importRunDir = path.join(resolveMemoryWikiImportRunsDir(params.config.vault.path), runId);
+    importRunRecord = {
+      version: 1,
+      runId,
+      importType: "chatgpt",
+      exportPath,
+      sourcePath: conversationsPath,
+      appliedAt: nowIso,
+      conversationCount: records.length,
+      createdCount,
+      updatedCount,
+      skippedCount,
+      createdPaths: [],
+      updatedPaths: [],
+    };
+
+    for (const plan of importPlans) {
+      if (plan.operation === "skip") {
+        continue;
+      }
       await writeTrackedImportPage({
         vaultRoot: params.config.vault.path,
         runDir: importRunDir,
-        relativePath: record.pagePath,
-        content: rendered,
+        relativePath: plan.relativePath,
+        existing: plan.existing,
+        rendered: plan.rendered,
         record: importRunRecord,
       });
     }
@@ -800,9 +804,6 @@ export async function importChatGptConversations(params: {
 
   let indexUpdatedFiles: string[] = [];
   if (!params.dryRun && importRunRecord) {
-    importRunRecord.createdCount = createdCount;
-    importRunRecord.updatedCount = updatedCount;
-    importRunRecord.skippedCount = skippedCount;
     if (importRunRecord.createdPaths.length > 0 || importRunRecord.updatedPaths.length > 0) {
       const compile = await compileMemoryWikiVault(params.config);
       indexUpdatedFiles = compile.updatedFiles;
@@ -868,7 +869,7 @@ export async function rollbackChatGptImportRun(params: {
     removedCount += 1;
   }
   let restoredCount = 0;
-  const runDir = path.join(resolveImportRunsDir(params.config.vault.path), record.runId);
+  const runDir = path.join(resolveMemoryWikiImportRunsDir(params.config.vault.path), record.runId);
   for (const entry of record.updatedPaths) {
     if (!entry.snapshotPath) {
       continue;

--- a/extensions/memory-wiki/src/cli.test.ts
+++ b/extensions/memory-wiki/src/cli.test.ts
@@ -13,6 +13,7 @@ import {
   runWikiStatus,
 } from "./cli.js";
 import type { MemoryWikiPluginConfig } from "./config.js";
+import { resolveMemoryWikiImportRunRecordPath } from "./import-runs-state.js";
 import { parseWikiMarkdown, renderWikiMarkdown } from "./markdown.js";
 import type { MemoryWikiDoctorReport, MemoryWikiStatus } from "./status.js";
 import { createMemoryWikiTestHarness } from "./test-helpers.js";
@@ -572,6 +573,9 @@ cli note
     });
     expect(applied.runId).toMatch(/^chatgpt-[a-f0-9]{12}$/u);
     expect(applied.createdCount).toBe(1);
+    await expect(
+      fs.stat(resolveMemoryWikiImportRunRecordPath(rootDir, applied.runId ?? "")),
+    ).rejects.toMatchObject({ code: "ENOENT" });
     const sourceFiles = (await fs.readdir(path.join(rootDir, "sources"))).filter(
       (entry) => entry !== "index.md",
     );

--- a/extensions/memory-wiki/src/import-runs-state.ts
+++ b/extensions/memory-wiki/src/import-runs-state.ts
@@ -1,0 +1,487 @@
+// Memory Wiki plugin module implements import run state behavior.
+import { createHash } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import type {
+  OpenKeyedStoreOptions,
+  PluginStateKeyedStore,
+} from "openclaw/plugin-sdk/plugin-state-runtime";
+
+export type ChatGptImportRunEntry = {
+  path: string;
+  snapshotPath?: string;
+};
+
+export type ChatGptImportRunRecord = {
+  version: 1;
+  runId: string;
+  importType: "chatgpt";
+  exportPath: string;
+  sourcePath: string;
+  appliedAt: string;
+  conversationCount: number;
+  createdCount: number;
+  updatedCount: number;
+  skippedCount: number;
+  createdPaths: string[];
+  updatedPaths: ChatGptImportRunEntry[];
+  rolledBackAt?: string;
+};
+
+type MemoryWikiImportRunStateStore = {
+  read: (vaultRoot: string, runId: string) => Promise<ChatGptImportRunRecord | null>;
+  write: (vaultRoot: string, record: ChatGptImportRunRecord) => Promise<void>;
+  list: (vaultRoot: string) => Promise<ChatGptImportRunRecord[]>;
+  rowCount: () => Promise<number>;
+};
+
+type MemoryWikiImportRunMetaStateRecord = Omit<
+  ChatGptImportRunRecord,
+  "createdPaths" | "updatedPaths"
+> & {
+  kind: "meta";
+  vaultRootKey: string;
+};
+
+type MemoryWikiImportRunPathStateRecord = {
+  kind: "created-path" | "updated-path";
+  vaultRootKey: string;
+  runId: string;
+  index: number;
+  path: string;
+  snapshotPath?: string;
+};
+
+type MemoryWikiImportRunStateRecord =
+  | MemoryWikiImportRunMetaStateRecord
+  | MemoryWikiImportRunPathStateRecord;
+
+export const MEMORY_WIKI_IMPORT_RUN_STATE_NAMESPACE = "import-runs";
+export const MEMORY_WIKI_IMPORT_RUN_STATE_MAX_ENTRIES = 20_000;
+
+let configuredImportRunStore: MemoryWikiImportRunStateStore | undefined;
+const memoryImportRunsByVault = new Map<string, Map<string, ChatGptImportRunRecord>>();
+
+export function resolveMemoryWikiImportRunsDir(vaultRoot: string): string {
+  return path.join(vaultRoot, ".openclaw-wiki", "import-runs");
+}
+
+export function resolveMemoryWikiImportRunRecordPath(vaultRoot: string, runId: string): string {
+  return path.join(resolveMemoryWikiImportRunsDir(vaultRoot), `${runId}.json`);
+}
+
+function resolveVaultRootKey(vaultRoot: string): string {
+  return createHash("sha256").update(path.resolve(vaultRoot), "utf8").digest("hex").slice(0, 32);
+}
+
+function resolveStateEntryKey(vaultRootKey: string, runId: string): string {
+  return createHash("sha256").update(`${vaultRootKey}\0meta\0${runId}`, "utf8").digest("hex");
+}
+
+function resolvePathStateEntryKey(params: {
+  vaultRootKey: string;
+  runId: string;
+  kind: MemoryWikiImportRunPathStateRecord["kind"];
+  index: number;
+  path: string;
+}): string {
+  return createHash("sha256")
+    .update(
+      `${params.vaultRootKey}\0${params.runId}\0${params.kind}\0${params.index}\0${params.path}`,
+      "utf8",
+    )
+    .digest("hex");
+}
+
+function cloneImportRunRecord(record: ChatGptImportRunRecord): ChatGptImportRunRecord {
+  return {
+    ...record,
+    createdPaths: [...record.createdPaths],
+    updatedPaths: record.updatedPaths.map((entry) => ({ ...entry })),
+  };
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+function asStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter(
+    (entry): entry is string => typeof entry === "string" && entry.trim().length > 0,
+  );
+}
+
+function asNonNegativeInteger(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
+}
+
+export function normalizeMemoryWikiImportRunRecord(raw: unknown): ChatGptImportRunRecord | null {
+  const record = asRecord(raw);
+  if (!record) {
+    return null;
+  }
+  const runId = typeof record.runId === "string" ? record.runId.trim() : "";
+  const exportPath = typeof record.exportPath === "string" ? record.exportPath.trim() : "";
+  const sourcePath = typeof record.sourcePath === "string" ? record.sourcePath.trim() : "";
+  const appliedAt = typeof record.appliedAt === "string" ? record.appliedAt.trim() : "";
+  if (
+    record.version !== 1 ||
+    record.importType !== "chatgpt" ||
+    !runId ||
+    !exportPath ||
+    !sourcePath ||
+    !appliedAt
+  ) {
+    return null;
+  }
+  const updatedPaths = Array.isArray(record.updatedPaths)
+    ? record.updatedPaths
+        .map((entry) => asRecord(entry))
+        .filter((entry): entry is Record<string, unknown> => entry !== null)
+        .flatMap((entry): ChatGptImportRunEntry[] => {
+          const entryPath = typeof entry.path === "string" ? entry.path.trim() : "";
+          if (!entryPath) {
+            return [];
+          }
+          const snapshotPath =
+            typeof entry.snapshotPath === "string" && entry.snapshotPath.trim()
+              ? entry.snapshotPath.trim()
+              : undefined;
+          return [{ path: entryPath, ...(snapshotPath ? { snapshotPath } : {}) }];
+        })
+    : [];
+  const rolledBackAt =
+    typeof record.rolledBackAt === "string" && record.rolledBackAt.trim()
+      ? record.rolledBackAt.trim()
+      : undefined;
+  return {
+    version: 1,
+    runId,
+    importType: "chatgpt",
+    exportPath,
+    sourcePath,
+    appliedAt,
+    conversationCount: asNonNegativeInteger(record.conversationCount),
+    createdCount: asNonNegativeInteger(record.createdCount),
+    updatedCount: asNonNegativeInteger(record.updatedCount),
+    skippedCount: asNonNegativeInteger(record.skippedCount),
+    createdPaths: asStringArray(record.createdPaths),
+    updatedPaths,
+    ...(rolledBackAt ? { rolledBackAt } : {}),
+  };
+}
+
+function normalizeMetaRecord(raw: unknown): MemoryWikiImportRunMetaStateRecord | null {
+  const record = asRecord(raw);
+  if (!record || record.kind !== "meta") {
+    return null;
+  }
+  const normalized = normalizeMemoryWikiImportRunRecord({
+    ...record,
+    createdPaths: [],
+    updatedPaths: [],
+  });
+  const vaultRootKey = typeof record.vaultRootKey === "string" ? record.vaultRootKey : "";
+  return normalized && vaultRootKey
+    ? {
+        ...normalized,
+        kind: "meta",
+        vaultRootKey,
+      }
+    : null;
+}
+
+function normalizePathRecord(raw: unknown): MemoryWikiImportRunPathStateRecord | null {
+  const record = asRecord(raw);
+  if (
+    !record ||
+    (record.kind !== "created-path" && record.kind !== "updated-path") ||
+    typeof record.vaultRootKey !== "string" ||
+    typeof record.runId !== "string" ||
+    typeof record.path !== "string" ||
+    typeof record.index !== "number" ||
+    !Number.isFinite(record.index)
+  ) {
+    return null;
+  }
+  const snapshotPath =
+    typeof record.snapshotPath === "string" && record.snapshotPath.trim()
+      ? record.snapshotPath.trim()
+      : undefined;
+  return {
+    kind: record.kind,
+    vaultRootKey: record.vaultRootKey,
+    runId: record.runId,
+    index: Math.max(0, Math.floor(record.index)),
+    path: record.path,
+    ...(snapshotPath ? { snapshotPath } : {}),
+  };
+}
+
+function composeImportRunRecord(
+  meta: MemoryWikiImportRunMetaStateRecord,
+  pathRows: MemoryWikiImportRunPathStateRecord[],
+): ChatGptImportRunRecord {
+  const createdPaths = pathRows
+    .filter((row) => row.kind === "created-path")
+    .toSorted((left, right) => left.index - right.index)
+    .map((row) => row.path);
+  const updatedPaths = pathRows
+    .filter((row) => row.kind === "updated-path")
+    .toSorted((left, right) => left.index - right.index)
+    .map((row) => {
+      const entry: ChatGptImportRunEntry = { path: row.path };
+      if (row.snapshotPath) {
+        entry.snapshotPath = row.snapshotPath;
+      }
+      return entry;
+    });
+  return {
+    version: 1,
+    runId: meta.runId,
+    importType: "chatgpt",
+    exportPath: meta.exportPath,
+    sourcePath: meta.sourcePath,
+    appliedAt: meta.appliedAt,
+    conversationCount: meta.conversationCount,
+    createdCount: meta.createdCount,
+    updatedCount: meta.updatedCount,
+    skippedCount: meta.skippedCount,
+    createdPaths,
+    updatedPaths,
+    ...(meta.rolledBackAt ? { rolledBackAt: meta.rolledBackAt } : {}),
+  };
+}
+
+function toMetaRecord(
+  vaultRootKey: string,
+  record: ChatGptImportRunRecord,
+): MemoryWikiImportRunMetaStateRecord {
+  return {
+    version: 1,
+    kind: "meta",
+    vaultRootKey,
+    runId: record.runId,
+    importType: "chatgpt",
+    exportPath: record.exportPath,
+    sourcePath: record.sourcePath,
+    appliedAt: record.appliedAt,
+    conversationCount: record.conversationCount,
+    createdCount: record.createdCount,
+    updatedCount: record.updatedCount,
+    skippedCount: record.skippedCount,
+    ...(record.rolledBackAt ? { rolledBackAt: record.rolledBackAt } : {}),
+  };
+}
+
+function toPathRecords(
+  vaultRootKey: string,
+  record: ChatGptImportRunRecord,
+): MemoryWikiImportRunPathStateRecord[] {
+  return [
+    ...record.createdPaths.map(
+      (entryPath, index): MemoryWikiImportRunPathStateRecord => ({
+        kind: "created-path",
+        vaultRootKey,
+        runId: record.runId,
+        index,
+        path: entryPath,
+      }),
+    ),
+    ...record.updatedPaths.map(
+      (entry, index): MemoryWikiImportRunPathStateRecord => ({
+        kind: "updated-path",
+        vaultRootKey,
+        runId: record.runId,
+        index,
+        path: entry.path,
+        ...(entry.snapshotPath ? { snapshotPath: entry.snapshotPath } : {}),
+      }),
+    ),
+  ];
+}
+
+function createMemoryFallbackImportRunStore(): MemoryWikiImportRunStateStore {
+  return {
+    async read(vaultRoot, runId) {
+      const vaultRootKey = resolveVaultRootKey(vaultRoot);
+      const record = memoryImportRunsByVault.get(vaultRootKey)?.get(runId);
+      return record ? cloneImportRunRecord(record) : null;
+    },
+    async write(vaultRoot, record) {
+      const vaultRootKey = resolveVaultRootKey(vaultRoot);
+      const records = memoryImportRunsByVault.get(vaultRootKey) ?? new Map();
+      records.set(record.runId, cloneImportRunRecord(record));
+      memoryImportRunsByVault.set(vaultRootKey, records);
+    },
+    async list(vaultRoot) {
+      const vaultRootKey = resolveVaultRootKey(vaultRoot);
+      return [...(memoryImportRunsByVault.get(vaultRootKey)?.values() ?? [])].map(
+        cloneImportRunRecord,
+      );
+    },
+    async rowCount() {
+      let count = 0;
+      for (const records of memoryImportRunsByVault.values()) {
+        for (const record of records.values()) {
+          count += 1 + record.createdPaths.length + record.updatedPaths.length;
+        }
+      }
+      return count;
+    },
+  };
+}
+
+export function createMemoryWikiImportRunStateStore(
+  openKeyedStore: <T>(options: OpenKeyedStoreOptions) => PluginStateKeyedStore<T>,
+): MemoryWikiImportRunStateStore {
+  const openStore = () =>
+    openKeyedStore<MemoryWikiImportRunStateRecord>({
+      namespace: MEMORY_WIKI_IMPORT_RUN_STATE_NAMESPACE,
+      maxEntries: MEMORY_WIKI_IMPORT_RUN_STATE_MAX_ENTRIES,
+    });
+
+  return {
+    async read(vaultRoot, runId) {
+      const vaultRootKey = resolveVaultRootKey(vaultRoot);
+      const row = await openStore().lookup(resolveStateEntryKey(vaultRootKey, runId));
+      const meta = normalizeMetaRecord(row);
+      if (!meta || meta.vaultRootKey !== vaultRootKey) {
+        return null;
+      }
+      const pathRows = (await openStore().entries())
+        .map((entry) => normalizePathRecord(entry.value))
+        .filter(
+          (entry): entry is MemoryWikiImportRunPathStateRecord =>
+            entry !== null && entry.vaultRootKey === vaultRootKey && entry.runId === runId,
+        );
+      return composeImportRunRecord(meta, pathRows);
+    },
+    async write(vaultRoot, record) {
+      const vaultRootKey = resolveVaultRootKey(vaultRoot);
+      const store = openStore();
+      await store.register(
+        resolveStateEntryKey(vaultRootKey, record.runId),
+        toMetaRecord(vaultRootKey, record),
+      );
+      const nextPathKeys = new Set<string>();
+      for (const pathRecord of toPathRecords(vaultRootKey, record)) {
+        const key = resolvePathStateEntryKey({
+          vaultRootKey,
+          runId: record.runId,
+          kind: pathRecord.kind,
+          index: pathRecord.index,
+          path: pathRecord.path,
+        });
+        nextPathKeys.add(key);
+        await store.register(key, pathRecord);
+      }
+      for (const row of await store.entries()) {
+        const pathRecord = normalizePathRecord(row.value);
+        if (
+          pathRecord?.vaultRootKey === vaultRootKey &&
+          pathRecord.runId === record.runId &&
+          !nextPathKeys.has(row.key)
+        ) {
+          await store.delete(row.key);
+        }
+      }
+    },
+    async list(vaultRoot) {
+      const vaultRootKey = resolveVaultRootKey(vaultRoot);
+      const metaRows = new Map<string, MemoryWikiImportRunMetaStateRecord>();
+      const pathRows: MemoryWikiImportRunPathStateRecord[] = [];
+      for (const row of await openStore().entries()) {
+        const meta = normalizeMetaRecord(row.value);
+        if (meta?.vaultRootKey === vaultRootKey) {
+          metaRows.set(meta.runId, meta);
+          continue;
+        }
+        const pathRecord = normalizePathRecord(row.value);
+        if (pathRecord?.vaultRootKey === vaultRootKey) {
+          pathRows.push(pathRecord);
+        }
+      }
+      return [...metaRows.values()].map((meta) =>
+        composeImportRunRecord(
+          meta,
+          pathRows.filter((row) => row.runId === meta.runId),
+        ),
+      );
+    },
+    async rowCount() {
+      return (await openStore().entries()).length;
+    },
+  };
+}
+
+export function configureMemoryWikiImportRunStateStore(
+  store: MemoryWikiImportRunStateStore | undefined,
+): void {
+  configuredImportRunStore = store;
+}
+
+function resolveImportRunStore(
+  store?: MemoryWikiImportRunStateStore,
+): MemoryWikiImportRunStateStore {
+  return store ?? configuredImportRunStore ?? createMemoryFallbackImportRunStore();
+}
+
+export async function readMemoryWikiImportRunRecord(
+  vaultRoot: string,
+  runId: string,
+  store?: MemoryWikiImportRunStateStore,
+): Promise<ChatGptImportRunRecord | null> {
+  return await resolveImportRunStore(store).read(vaultRoot, runId);
+}
+
+export async function writeMemoryWikiImportRunRecord(
+  vaultRoot: string,
+  record: ChatGptImportRunRecord,
+  store?: MemoryWikiImportRunStateStore,
+): Promise<void> {
+  await resolveImportRunStore(store).write(vaultRoot, record);
+}
+
+export async function listMemoryWikiImportRunRecords(
+  vaultRoot: string,
+  store?: MemoryWikiImportRunStateStore,
+): Promise<ChatGptImportRunRecord[]> {
+  return await resolveImportRunStore(store).list(vaultRoot);
+}
+
+export async function countMemoryWikiImportRunStateRows(
+  store?: MemoryWikiImportRunStateStore,
+): Promise<number> {
+  return await resolveImportRunStore(store).rowCount();
+}
+
+export async function readLegacyMemoryWikiImportRunRecords(
+  vaultRoot: string,
+): Promise<ChatGptImportRunRecord[]> {
+  const importRunsDir = resolveMemoryWikiImportRunsDir(vaultRoot);
+  const entries = await fs
+    .readdir(importRunsDir, { withFileTypes: true })
+    .catch((error: unknown) => {
+      const code = asRecord(error)?.code;
+      if (code === "ENOENT") {
+        return [];
+      }
+      throw error;
+    });
+  const records = await Promise.all(
+    entries
+      .filter((entry) => entry.isFile() && entry.name.endsWith(".json"))
+      .map(async (entry) => {
+        const raw = await fs.readFile(path.join(importRunsDir, entry.name), "utf8");
+        return normalizeMemoryWikiImportRunRecord(JSON.parse(raw) as unknown);
+      }),
+  );
+  return records.filter((entry): entry is ChatGptImportRunRecord => entry !== null);
+}

--- a/extensions/memory-wiki/src/import-runs.test.ts
+++ b/extensions/memory-wiki/src/import-runs.test.ts
@@ -1,0 +1,80 @@
+// Memory Wiki tests cover import run listing behavior.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { resolveMemoryWikiConfig } from "./config.js";
+import { writeMemoryWikiImportRunRecord } from "./import-runs-state.js";
+import { listMemoryWikiImportRuns } from "./import-runs.js";
+
+const tempDirs: string[] = [];
+
+async function makeTempVault(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "memory-wiki-import-runs-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+describe("memory-wiki import runs", () => {
+  afterEach(async () => {
+    await Promise.all(
+      tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })),
+    );
+  });
+
+  it("lists import runs from plugin state", async () => {
+    const vaultRoot = await makeTempVault();
+    const config = resolveMemoryWikiConfig({ vault: { path: vaultRoot } });
+    await writeMemoryWikiImportRunRecord(vaultRoot, {
+      version: 1,
+      runId: "chatgpt-old",
+      importType: "chatgpt",
+      exportPath: "/tmp/old",
+      sourcePath: "/tmp/old/conversations.json",
+      appliedAt: "2026-04-09T10:00:00.000Z",
+      conversationCount: 1,
+      createdCount: 1,
+      updatedCount: 0,
+      skippedCount: 0,
+      createdPaths: ["sources/old.md"],
+      updatedPaths: [],
+      rolledBackAt: "2026-04-09T11:00:00.000Z",
+    });
+    await writeMemoryWikiImportRunRecord(vaultRoot, {
+      version: 1,
+      runId: "chatgpt-new",
+      importType: "chatgpt",
+      exportPath: "/tmp/new",
+      sourcePath: "/tmp/new/conversations.json",
+      appliedAt: "2026-04-10T10:00:00.000Z",
+      conversationCount: 2,
+      createdCount: 1,
+      updatedCount: 1,
+      skippedCount: 0,
+      createdPaths: ["sources/new.md"],
+      updatedPaths: [{ path: "sources/current.md", snapshotPath: "snapshots/current.md" }],
+    });
+
+    await expect(listMemoryWikiImportRuns(config, { limit: 1 })).resolves.toEqual({
+      runs: [
+        {
+          runId: "chatgpt-new",
+          importType: "chatgpt",
+          appliedAt: "2026-04-10T10:00:00.000Z",
+          exportPath: "/tmp/new",
+          sourcePath: "/tmp/new/conversations.json",
+          conversationCount: 2,
+          createdCount: 1,
+          updatedCount: 1,
+          skippedCount: 0,
+          status: "applied",
+          pagePaths: ["sources/new.md", "sources/current.md"],
+          samplePaths: ["sources/new.md", "sources/current.md"],
+        },
+      ],
+      totalRuns: 2,
+      activeRuns: 1,
+      rolledBackRuns: 1,
+    });
+  });
+});

--- a/extensions/memory-wiki/src/import-runs.ts
+++ b/extensions/memory-wiki/src/import-runs.ts
@@ -1,8 +1,7 @@
 // Memory Wiki plugin module implements import runs behavior.
-import fs from "node:fs/promises";
-import path from "node:path";
 import { uniqueStrings } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { ResolvedMemoryWikiConfig } from "./config.js";
+import { listMemoryWikiImportRunRecords } from "./import-runs-state.js";
 
 type MemoryWikiImportRunSummary = {
   runId: string;
@@ -103,35 +102,13 @@ function normalizeImportRunSummary(raw: unknown): MemoryWikiImportRunSummary | n
   };
 }
 
-function resolveImportRunsDir(vaultRoot: string): string {
-  return path.join(vaultRoot, ".openclaw-wiki", "import-runs");
-}
-
 export async function listMemoryWikiImportRuns(
   config: ResolvedMemoryWikiConfig,
   options?: { limit?: number },
 ): Promise<MemoryWikiImportRunsStatus> {
   const limit = Math.max(1, Math.floor(options?.limit ?? 10));
-  const importRunsDir = resolveImportRunsDir(config.vault.path);
-  const entries = await fs
-    .readdir(importRunsDir, { withFileTypes: true })
-    .catch((error: unknown) => {
-      const code = asRecord(error)?.code;
-      if (code === "ENOENT") {
-        return [];
-      }
-      throw error;
-    });
-  const runs = (
-    await Promise.all(
-      entries
-        .filter((entry) => entry.isFile() && entry.name.endsWith(".json"))
-        .map(async (entry) => {
-          const raw = await fs.readFile(path.join(importRunsDir, entry.name), "utf8");
-          return normalizeImportRunSummary(JSON.parse(raw) as unknown);
-        }),
-    )
-  )
+  const runs = (await listMemoryWikiImportRunRecords(config.vault.path))
+    .map((record) => normalizeImportRunSummary(record))
     .filter((entry): entry is MemoryWikiImportRunSummary => entry !== null)
     .toSorted((left, right) => right.appliedAt.localeCompare(left.appliedAt));
 


### PR DESCRIPTION
## Summary

- Move Memory Wiki ChatGPT import-run metadata from `.openclaw-wiki/import-runs/*.json` into SQLite plugin state.
- Keep rollback snapshot markdown files under `.openclaw-wiki/import-runs/<runId>/snapshots/` as explicit vault artifacts.
- Add doctor migration for legacy import-run JSON records, archiving migrated JSON files while preserving snapshot directories.
- Split run metadata and page paths into bounded plugin-state rows, with pre-mutation capacity checks for live imports.

## Verification

- `git diff --check`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/memory-wiki/src/import-runs-state.ts extensions/memory-wiki/src/chatgpt-import.ts extensions/memory-wiki/src/import-runs.ts extensions/memory-wiki/index.ts extensions/memory-wiki/doctor-contract-api.ts extensions/memory-wiki/doctor-contract-api.test.ts extensions/memory-wiki/src/cli.test.ts extensions/memory-wiki/src/import-runs.test.ts`
- `pnpm tsgo:extensions`
- `node scripts/run-vitest.mjs extensions/memory-wiki/doctor-contract-api.test.ts extensions/memory-wiki/src/cli.test.ts extensions/memory-wiki/src/import-runs.test.ts extensions/memory-wiki/src/gateway.test.ts extensions/memory-wiki/index.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local` => clean, no accepted/actionable findings.
