### PR TITLE
fix(openai-completions): add Xiaomi to detectCompat requiresReasoningContentOnAssistantMessages

### DIFF
--- a/src/llm/providers/openai-completions.ts
+++ b/src/llm/providers/openai-completions.ts
@@ -1274,6 +1274,10 @@ function detectCompat(model: Model<"openai-completions">): ResolvedOpenAIComplet
 
   const isGrok = provider === "xai" || baseUrl.includes("api.x.ai");
   const isDeepSeek = provider === "deepseek" || baseUrl.includes("deepseek.com");
+  const isXiaomi =
+    provider === "xiaomi" ||
+    provider === "xiaomi-token-plan" ||
+    baseUrl.includes("api.ai.xiaomi.com");
   const cacheControlFormat =
     provider === "openrouter" && model.id.startsWith("anthropic/") ? "anthropic" : undefined;
 
@@ -1287,7 +1291,7 @@ function detectCompat(model: Model<"openai-completions">): ResolvedOpenAIComplet
     requiresToolResultName: false,
     requiresAssistantAfterToolResult: false,
     requiresThinkingAsText: false,
-    requiresReasoningContentOnAssistantMessages: isDeepSeek,
+    requiresReasoningContentOnAssistantMessages: isDeepSeek || isXiaomi,
     thinkingFormat: isDeepSeek
       ? "deepseek"
       : isZai


### PR DESCRIPTION
## Summary

Align `detectCompat` in `openai-completions.ts` with the agent-layer compat in `openai-completions-compat.ts` — add Xiaomi endpoint detection for `requiresReasoningContentOnAssistantMessages`.

**Before:** Only DeepSeek gets the compat flag at the provider layer.
**After:** Xiaomi (`xiaomi`, `xiaomi-token-plan`, `api.ai.xiaomi.com`) also gets it, matching the agent-layer behavior.

## Linked context

Closes #91106

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: `detectCompat` in `openai-completions.ts` missed Xiaomi for `requiresReasoningContentOnAssistantMessages` — agent-layer compat did cover it. Multi-turn Xiaomi sessions through provider layer would fail API validation.
- Real environment tested: macOS, Node v22.22.3, OpenClaw source checkout at upstream/main (589ea28da)
- Exact steps or command run after this patch:

```bash
# 1. Node.js proof: verify isXiaomi detection for all provider/URL variants
node /tmp/proof-91106.mjs

# 2. Unit tests
node scripts/run-vitest.mjs run src/llm/providers/openai-completions.test.ts
node scripts/run-vitest.mjs run src/agents/openai-completions-compat.test.ts
```

- Evidence after fix (copied live output):

```
============================================================
Proof: Xiaomi requiresReasoningContentOnAssistantMessages detection
PR: https://github.com/openclaw/openclaw/pull/91109
Issue: https://github.com/openclaw/openclaw/issues/91106
============================================================

✅ PASS | Xiaomi provider (explicit)
       provider=xiaomi → isXiaomi=true, requiresReasoningContent=true
✅ PASS | Xiaomi Token Plan provider
       provider=xiaomi-token-plan → isXiaomi=true, requiresReasoningContent=true
✅ PASS | Xiaomi URL (provider-agnostic)
       baseUrl=api.ai.xiaomi.com → isXiaomi=true, requiresReasoningContent=true
✅ PASS | DeepSeek (existing behavior preserved)
       requiresReasoningContent=true (unchanged)
✅ PASS | OpenAI (no false positives)
       requiresReasoningContent=false (correct)
✅ PASS | Unknown custom endpoint (no false positives)
       requiresReasoningContent=false (correct)

Unit tests: 39 passed (22 completions + 17 compat)
------------------------------------------------------------
Before fix: Xiaomi endpoints → requiresReasoningContent = false (API rejects multi-turn)
After  fix: Xiaomi endpoints → requiresReasoningContent = true  (matches agent-layer)
🎉 All proof checks passed!
```

- Observed result after fix: `detectCompat` returns `requiresReasoningContentOnAssistantMessages: true` for all three Xiaomi detection paths (xiaomi provider, xiaomi-token-plan provider, api.ai.xiaomi.com URL), while DeepSeek behavior is unchanged and non-Xiaomi endpoints are not affected.
- What was not tested: Live Xiaomi AI Studio API multi-turn session (no Xiaomi API key available). Source-level detection proof covers all three code paths.
- Proof limitations or environment constraints: The fix is a pure detection-flag addition mirroring existing logic in `openai-completions-compat.ts:75-77`. The detection logic is deterministic — given the same provider/URL inputs, the output is guaranteed.

## Tests and validation

**Which commands did you run?**
```bash
node scripts/run-vitest.mjs run src/llm/providers/openai-completions.test.ts
# 22 passed

node scripts/run-vitest.mjs run src/agents/openai-completions-compat.test.ts
# 17 passed
```

**What regression coverage was added or updated?** Existing tests cover the detectCompat path. The fix mirrors the agent-layer compat logic already tested in `openai-completions-compat.test.ts`.

## Risk checklist

**Did user-visible behavior change?** Yes — Xiaomi multi-turn sessions via provider layer now include `reasoning_content` on replayed messages
**Did config, environment, or migration behavior change?** No
**Did security, auth, secrets, network, or tool execution behavior change?** No
**What is the highest-risk area?** Adding Xiaomi detection could false-positive. Mitigation: URL pattern is specific to `api.ai.xiaomi.com`, provider names are exact matches.
**How is that risk mitigated?** Consistent with agent-layer detection (same pattern in `openai-completions-compat.ts:75-77`).

## Current review state

**What is the next action?** CI verification + maintainer review.
**What is still waiting on author, maintainer, CI, or external proof?** None.
**Which bot or reviewer comments were addressed?** N/A

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Code <noreply@anthropic.com>
