### PR TITLE
fix(tavily): keep web_search contract executable

### DIFF
--- a/extensions/tavily/src/tavily-search-provider.ts
+++ b/extensions/tavily/src/tavily-search-provider.ts
@@ -1,7 +1,11 @@
 // Tavily provider module implements model/runtime integration.
 import { readPositiveIntegerParam } from "openclaw/plugin-sdk/param-readers";
 import type { WebSearchProviderPlugin } from "openclaw/plugin-sdk/provider-web-search-contract";
-import { buildTavilyWebSearchProviderBase } from "../web-search-shared.js";
+import {
+  buildTavilyWebSearchProviderBase,
+  TAVILY_GENERIC_SEARCH_DESCRIPTION,
+  TAVILY_GENERIC_SEARCH_SCHEMA,
+} from "../web-search-shared.js";
 
 type TavilyClientModule = typeof import("./tavily-client.js");
 
@@ -12,27 +16,12 @@ function loadTavilyClientModule(): Promise<TavilyClientModule> {
   return tavilyClientModulePromise;
 }
 
-const GenericTavilySearchSchema = {
-  type: "object",
-  properties: {
-    query: { type: "string", description: "Search query string." },
-    count: {
-      type: "integer",
-      description: "Number of results to return (1-20).",
-      minimum: 1,
-      maximum: 20,
-    },
-  },
-  additionalProperties: false,
-} satisfies Record<string, unknown>;
-
 export function createTavilyWebSearchProvider(): WebSearchProviderPlugin {
   return {
     ...buildTavilyWebSearchProviderBase(),
     createTool: (ctx) => ({
-      description:
-        "Search the web using Tavily. Returns structured results with snippets. Use tavily_search for Tavily-specific options like search depth, topic filtering, or AI answers.",
-      parameters: GenericTavilySearchSchema,
+      description: TAVILY_GENERIC_SEARCH_DESCRIPTION,
+      parameters: TAVILY_GENERIC_SEARCH_SCHEMA,
       execute: async (args) => {
         const { runTavilySearch } = await loadTavilyClientModule();
         return await runTavilySearch({

--- a/extensions/tavily/src/tavily-tools.test.ts
+++ b/extensions/tavily/src/tavily-tools.test.ts
@@ -47,6 +47,7 @@ function fakeApi(): OpenClawPluginApi {
 
 describe("tavily tools", () => {
   let createTavilyWebSearchProvider: typeof import("./tavily-search-provider.js").createTavilyWebSearchProvider;
+  let createTavilyContractWebSearchProvider: typeof import("../web-search-contract-api.js").createTavilyWebSearchProvider;
   let createTavilySearchTool: typeof import("./tavily-search-tool.js").createTavilySearchTool;
   let createTavilyExtractTool: typeof import("./tavily-extract-tool.js").createTavilyExtractTool;
   let tavilyClientTesting: typeof import("./tavily-client.js").testing;
@@ -54,6 +55,8 @@ describe("tavily tools", () => {
 
   beforeAll(async () => {
     ({ createTavilyWebSearchProvider } = await import("./tavily-search-provider.js"));
+    ({ createTavilyWebSearchProvider: createTavilyContractWebSearchProvider } =
+      await import("../web-search-contract-api.js"));
     ({ createTavilySearchTool } = await import("./tavily-search-tool.js"));
     ({ createTavilyExtractTool } = await import("./tavily-extract-tool.js"));
     ({ testing: tavilyClientTesting } =
@@ -107,6 +110,32 @@ describe("tavily tools", () => {
       cfg: { test: true },
       query: "weather sf",
       maxResults: 7,
+    });
+  });
+
+  it("keeps the contract web search provider executable", async () => {
+    const provider = createTavilyContractWebSearchProvider();
+    const tool = provider.createTool({
+      config: { test: "contract" },
+    } as never);
+    if (!tool) {
+      throw new Error("Expected contract provider tool definition");
+    }
+
+    const result = await tool.execute({
+      query: "runtime registration",
+      count: 3,
+    });
+
+    expect(runTavilySearch).toHaveBeenCalledWith({
+      cfg: { test: "contract" },
+      query: "runtime registration",
+      maxResults: 3,
+    });
+    expect(result).toEqual({
+      cfg: { test: "contract" },
+      query: "runtime registration",
+      maxResults: 3,
     });
   });
 

--- a/extensions/tavily/web-search-contract-api.ts
+++ b/extensions/tavily/web-search-contract-api.ts
@@ -1,10 +1,2 @@
 // Tavily API module exposes the plugin public contract.
-import type { WebSearchProviderPlugin } from "openclaw/plugin-sdk/provider-web-search-contract";
-import { buildTavilyWebSearchProviderBase } from "./web-search-shared.js";
-
-export function createTavilyWebSearchProvider(): WebSearchProviderPlugin {
-  return {
-    ...buildTavilyWebSearchProviderBase(),
-    createTool: () => null,
-  };
-}
+export { createTavilyWebSearchProvider } from "./src/tavily-search-provider.js";

--- a/extensions/tavily/web-search-contract-api.ts
+++ b/extensions/tavily/web-search-contract-api.ts
@@ -1,2 +1,35 @@
 // Tavily API module exposes the plugin public contract.
-export { createTavilyWebSearchProvider } from "./src/tavily-search-provider.js";
+import type { WebSearchProviderPlugin } from "openclaw/plugin-sdk/provider-web-search-config-contract";
+import {
+  buildTavilyWebSearchProviderBase,
+  TAVILY_GENERIC_SEARCH_DESCRIPTION,
+  TAVILY_GENERIC_SEARCH_SCHEMA,
+} from "./web-search-shared.js";
+
+type TavilySearchProviderModule = typeof import("./src/tavily-search-provider.js");
+
+let tavilySearchProviderModulePromise: Promise<TavilySearchProviderModule> | undefined;
+
+function loadTavilySearchProviderModule(): Promise<TavilySearchProviderModule> {
+  tavilySearchProviderModulePromise ??= import("./src/tavily-search-provider.js");
+  return tavilySearchProviderModulePromise;
+}
+
+export function createTavilyWebSearchProvider(): WebSearchProviderPlugin {
+  return {
+    ...buildTavilyWebSearchProviderBase(),
+    createTool: (ctx) => ({
+      description: TAVILY_GENERIC_SEARCH_DESCRIPTION,
+      parameters: TAVILY_GENERIC_SEARCH_SCHEMA,
+      execute: async (args) => {
+        const { createTavilyWebSearchProvider: createRuntimeProvider } =
+          await loadTavilySearchProviderModule();
+        const tool = createRuntimeProvider().createTool(ctx);
+        if (!tool) {
+          throw new Error("Tavily web_search provider did not create a runtime tool.");
+        }
+        return await tool.execute(args);
+      },
+    }),
+  };
+}

--- a/extensions/tavily/web-search-shared.ts
+++ b/extensions/tavily/web-search-shared.ts
@@ -6,6 +6,23 @@ import {
 
 export const TAVILY_CREDENTIAL_PATH = "plugins.entries.tavily.config.webSearch.apiKey";
 
+export const TAVILY_GENERIC_SEARCH_DESCRIPTION =
+  "Search the web using Tavily. Returns structured results with snippets. Use tavily_search for Tavily-specific options like search depth, topic filtering, or AI answers.";
+
+export const TAVILY_GENERIC_SEARCH_SCHEMA = {
+  type: "object",
+  properties: {
+    query: { type: "string", description: "Search query string." },
+    count: {
+      type: "integer",
+      description: "Number of results to return (1-20).",
+      minimum: 1,
+      maximum: 20,
+    },
+  },
+  additionalProperties: false,
+} satisfies Record<string, unknown>;
+
 export function buildTavilyWebSearchProviderBase(): Omit<WebSearchProviderPlugin, "createTool"> {
   return {
     id: "tavily",


### PR DESCRIPTION
Fixes #91096.

## Summary

- Route Tavily's `web-search-contract-api` through the executable Tavily web search provider instead of returning a metadata-only provider.
- Add a regression test proving the contract path can build and execute the generic `web_search` tool definition.

## Why

The Tavily manifest advertises `contracts.webSearchProviders: ["tavily"]`, and the plugin entrypoint registers a working provider. Some bundled web-search resolution paths can load `web-search-contract-api.js` directly, though. Tavily's contract facade previously returned `createTool: () => null`, so an explicit `tools.web.search.provider: tavily` configuration could resolve a provider descriptor but still have no executable provider available.

## Verification

- `pnpm install` after the first test run found missing local dependencies.
- `node scripts/run-vitest.mjs extensions/tavily/src/tavily-tools.test.ts`
- `node scripts/run-vitest.mjs src/plugins/web-provider-public-artifacts.explicit-fast-path.test.ts`
- `pnpm exec oxfmt --write extensions/tavily/web-search-contract-api.ts extensions/tavily/src/tavily-tools.test.ts`
- Runtime probe below.

## Real behavior proof

Behavior addressed: Tavily's bundled web-search contract facade now creates an executable `web_search` provider instead of a metadata-only provider.
Real environment tested: Local OpenClaw checkout on macOS, branch `fix/tavily-web-search-registration`.
Exact steps or command run after this patch: `pnpm exec tsx -e 'import { runWebSearch } from "./src/web-search/runtime.ts"; async function main() { try { await runWebSearch({ config: { plugins: { entries: { tavily: { enabled: true } } }, tools: { web: { search: { enabled: true, provider: "tavily" } } } }, preferInputConfig: true, preferRuntimeProviders: false, args: { query: "OpenClaw Tavily registration", count: 1 } }); console.log("unexpected success"); process.exit(1); } catch (error) { const message = error instanceof Error ? error.message : String(error); console.log(JSON.stringify({ providerReached: message.startsWith("web_search (tavily) needs a Tavily API key"), message }, null, 2)); if (!message.startsWith("web_search (tavily) needs a Tavily API key")) { process.exit(1); } } } main();'`
Evidence after fix: The runtime probe loaded OpenClaw's `runWebSearch` with `tools.web.search.provider: "tavily"` and no Tavily API key. It reached Tavily's provider-specific missing-key message instead of `web_search is disabled or no provider is available.` Terminal output:

```json
{
  "providerReached": true,
  "message": "web_search (tavily) needs a Tavily API key. Set TAVILY_API_KEY in the Gateway environment, or configure plugins.entries.tavily.config.webSearch.apiKey."
}
```

Observed result after fix: The command exited 0 with `providerReached: true`, proving the managed `web_search` path found Tavily's executable provider and dispatched into it.
What was not tested: A live Tavily API call was not run because this registration bug can be proven without a real API key.
