### PR TITLE
fix(media-understanding): preserve native vision skip with imageModel…

### DIFF
--- a/src/media-understanding/runner.ts
+++ b/src/media-understanding/runner.ts
@@ -715,17 +715,23 @@ function resolveImageModelFromAgentDefaults(params: {
 }
 
 function hasExplicitImageUnderstandingConfig(params: {
-  cfg: OpenClawConfig;
   config?: MediaUnderstandingConfig;
-  agentId?: string;
 }): boolean {
-  return (
-    (params.config?.models?.length ?? 0) > 0 ||
-    resolveImageModelFromAgentDefaults({
-      cfg: params.cfg,
-      agentId: params.agentId,
-    }).length > 0
-  );
+  return (params.config?.models?.length ?? 0) > 0;
+}
+
+async function activeModelSupportsNativeVision(params: {
+  cfg: OpenClawConfig;
+  activeModel?: ActiveMediaModel;
+}): Promise<boolean> {
+  const activeProvider = params.activeModel?.provider?.trim();
+  if (!activeProvider) {
+    return false;
+  }
+  const { findModelInCatalog, loadModelCatalog, modelSupportsVision } = await loadModelCatalogApi();
+  const catalog = await loadModelCatalog({ config: params.cfg });
+  const entry = findModelInCatalog(catalog, activeProvider, params.activeModel?.model ?? "");
+  return modelSupportsVision(entry);
 }
 
 async function resolveAutoEntries(params: {
@@ -738,12 +744,18 @@ async function resolveAutoEntries(params: {
   activeModel?: ActiveMediaModel;
 }): Promise<MediaUnderstandingModelConfig[]> {
   if (params.capability === "image") {
-    const imageModelEntries = resolveImageModelFromAgentDefaults({
+    const activeSupportsVision = await activeModelSupportsNativeVision({
       cfg: params.cfg,
-      agentId: params.agentId,
+      activeModel: params.activeModel,
     });
-    if (imageModelEntries.length > 0) {
-      return imageModelEntries;
+    if (!activeSupportsVision) {
+      const imageModelEntries = resolveImageModelFromAgentDefaults({
+        cfg: params.cfg,
+        agentId: params.agentId,
+      });
+      if (imageModelEntries.length > 0) {
+        return imageModelEntries;
+      }
     }
   }
   const activeEntry = await resolveActiveModelEntry(params);
@@ -1040,18 +1052,11 @@ export async function runCapability(params: {
   if (
     capability === "image" &&
     activeProvider &&
-    !isMinimaxVlmProvider(activeProvider) &&
     !hasExplicitImageUnderstandingConfig({
-      cfg,
       config,
-      agentId: params.agentId,
     })
   ) {
-    const { findModelInCatalog, loadModelCatalog, modelSupportsVision } =
-      await loadModelCatalogApi();
-    const catalog = await loadModelCatalog({ config: cfg });
-    const entry = findModelInCatalog(catalog, activeProvider, params.activeModel?.model ?? "");
-    if (modelSupportsVision(entry)) {
+    if (await activeModelSupportsNativeVision({ cfg, activeModel: params.activeModel })) {
       if (shouldLogVerbose()) {
         logVerbose("Skipping image understanding: primary model supports vision natively");
       }

--- a/src/media-understanding/runner.vision-skip.test.ts
+++ b/src/media-understanding/runner.vision-skip.test.ts
@@ -1,5 +1,6 @@
 // Vision skip tests cover auto image-model selection and text-only model
 // rejection across bundled provider metadata.
+import path from "node:path";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { MsgContext } from "../auto-reply/templating.js";
 import type { OpenClawConfig } from "../config/types.js";
@@ -31,6 +32,7 @@ const baseCatalog: TestCatalogEntry[] = [
   },
 ];
 let catalog: TestCatalogEntry[] = [...baseCatalog];
+const plantedVisionSentinel = "PLANTED_VISION_DESC_zq7x";
 
 const loadModelCatalog = vi.hoisted(() => vi.fn(async () => catalog));
 
@@ -63,6 +65,7 @@ vi.mock("../agents/model-catalog.js", async () => {
 });
 
 let buildProviderRegistry: typeof import("./runner.js").buildProviderRegistry;
+let applyMediaUnderstanding: typeof import("./apply.js").applyMediaUnderstanding;
 let resolveAutoImageModel: typeof import("./runner.js").resolveAutoImageModel;
 let runCapability: typeof import("./runner.js").runCapability;
 
@@ -126,6 +129,7 @@ describe("runCapability image skip", () => {
       };
     });
     ({ buildProviderRegistry, resolveAutoImageModel, runCapability } = await import("./runner.js"));
+    ({ applyMediaUnderstanding } = await import("./apply.js"));
   });
 
   beforeEach(() => {
@@ -166,6 +170,165 @@ describe("runCapability image skip", () => {
     } finally {
       await cache.cleanup();
     }
+  });
+
+  it("skips agents.defaults.imageModel fallback when the active model supports vision", async () => {
+    await withMediaFixture(
+      {
+        filePrefix: "openclaw-image-default-model-native-skip",
+        extension: "png",
+        mediaType: "image/png",
+        fileContents: Buffer.from("image"),
+      },
+      async ({ ctx }) => {
+        let describeCalls = 0;
+        const msgCtx = ctx as MsgContext;
+        msgCtx.Body = "please inspect this image";
+        const cfg = {
+          agents: {
+            defaults: {
+              imageModel: { primary: "minimax/MiniMax-M3" },
+            },
+          },
+        } as unknown as OpenClawConfig;
+
+        const result = await applyMediaUnderstanding({
+          ctx: msgCtx,
+          cfg,
+          agentDir: "/tmp",
+          workspaceDir: path.dirname(ctx.MediaPath),
+          providers: {
+            minimax: {
+              id: "minimax",
+              capabilities: ["image"],
+              describeImage: async (req) => {
+                describeCalls += 1;
+                return { text: plantedVisionSentinel, model: req.model };
+              },
+            },
+          },
+          activeModel: { provider: "openai", model: "gpt-4.1" },
+        });
+
+        const imageDecision = result.decisions.find((decision) => decision.capability === "image");
+        const attempt = imageDecision?.attachments[0]?.attempts[0];
+        expect(result.appliedImage).toBe(false);
+        expect(imageDecision?.outcome).toBe("skipped");
+        expect(attempt?.outcome).toBe("skipped");
+        expect(attempt?.reason).toBe("primary model supports vision natively");
+        expect(describeCalls).toBe(0);
+        expect(msgCtx.Body).not.toContain(plantedVisionSentinel);
+      },
+    );
+  });
+
+  it("skips agents.defaults.imageModel fallback when MiniMax M3 supports vision", async () => {
+    catalog = [
+      ...baseCatalog,
+      {
+        id: "MiniMax-M3",
+        name: "MiniMax M3",
+        provider: "minimax",
+        input: ["text", "image"] as const,
+      },
+    ];
+
+    await withMediaFixture(
+      {
+        filePrefix: "openclaw-image-default-model-minimax-m3-native-skip",
+        extension: "png",
+        mediaType: "image/png",
+        fileContents: Buffer.from("image"),
+      },
+      async ({ ctx }) => {
+        let describeCalls = 0;
+        const msgCtx = ctx as MsgContext;
+        msgCtx.Body = "please inspect this minimax image";
+        const cfg = {
+          agents: {
+            defaults: {
+              imageModel: { primary: "minimax/MiniMax-M3" },
+            },
+          },
+        } as unknown as OpenClawConfig;
+
+        const result = await applyMediaUnderstanding({
+          ctx: msgCtx,
+          cfg,
+          agentDir: "/tmp",
+          workspaceDir: path.dirname(ctx.MediaPath),
+          providers: {
+            minimax: {
+              id: "minimax",
+              capabilities: ["image"],
+              describeImage: async (req) => {
+                describeCalls += 1;
+                return { text: plantedVisionSentinel, model: req.model };
+              },
+            },
+          },
+          activeModel: { provider: "minimax", model: "MiniMax-M3" },
+        });
+
+        const imageDecision = result.decisions.find((decision) => decision.capability === "image");
+        const attempt = imageDecision?.attachments[0]?.attempts[0];
+        expect(result.appliedImage).toBe(false);
+        expect(imageDecision?.outcome).toBe("skipped");
+        expect(attempt?.outcome).toBe("skipped");
+        expect(attempt?.reason).toBe("primary model supports vision natively");
+        expect(describeCalls).toBe(0);
+        expect(msgCtx.Body).not.toContain(plantedVisionSentinel);
+      },
+    );
+  });
+
+  it("uses explicit media image models even when the active model supports vision", async () => {
+    await withMediaFixture(
+      {
+        filePrefix: "openclaw-image-explicit-model-no-native-skip",
+        extension: "png",
+        mediaType: "image/png",
+        fileContents: Buffer.from("image"),
+      },
+      async ({ ctx }) => {
+        let describeCalls = 0;
+        const msgCtx = ctx as MsgContext;
+        msgCtx.Body = "please inspect this explicit image";
+        const cfg = {
+          tools: {
+            media: {
+              image: {
+                models: [{ provider: "openrouter", model: "google/gemini-2.5-flash" }],
+              },
+            },
+          },
+        } as unknown as OpenClawConfig;
+
+        const result = await applyMediaUnderstanding({
+          ctx: msgCtx,
+          cfg,
+          agentDir: "/tmp",
+          workspaceDir: path.dirname(ctx.MediaPath),
+          providers: {
+            openrouter: {
+              id: "openrouter",
+              capabilities: ["image"],
+              describeImage: async (req) => {
+                describeCalls += 1;
+                return { text: plantedVisionSentinel, model: req.model };
+              },
+            },
+          },
+          activeModel: { provider: "openai", model: "gpt-4.1" },
+        });
+
+        const imageDecision = result.decisions.find((decision) => decision.capability === "image");
+        expect(result.appliedImage).toBe(true);
+        expect(imageDecision?.outcome).toBe("success");
+        expect(describeCalls).toBe(1);
+        expect(msgCtx.Body).toContain(plantedVisionSentinel);
+      },
+    );
   });
 
   it("uses explicit media image models instead of native vision skip", async () => {
@@ -265,7 +428,7 @@ describe("runCapability image skip", () => {
     );
   });
 
-  it("prefers agents.defaults.imageModel over the active model for auto image resolution", async () => {
+  it("keeps agents.defaults.imageModel available to exported auto image resolution", async () => {
     const cfg = {
       agents: {
         defaults: {
@@ -343,7 +506,6 @@ describe("runCapability image skip", () => {
               } satisfies MediaUnderstandingProvider,
             ],
           ]),
-          activeModel: { provider: "openai", model: "gpt-4.1" },
         });
 
         expect(result.decision.outcome).toBe("success");
@@ -433,13 +595,13 @@ describe("runCapability image skip", () => {
     }
   });
 
-  it("does not native-skip MiniMax chat models that claim image input", async () => {
+  it("routes MiniMax text-only chat models through the VLM fallback", async () => {
     catalog = [
       {
         id: "MiniMax-M2.7",
         name: "MiniMax M2.7",
         provider: "minimax-portal",
-        input: ["text", "image"] as const,
+        input: ["text"] as const,
       },
     ];
     vi.stubEnv("MINIMAX_API_KEY", "test-minimax-key");
@@ -450,7 +612,7 @@ describe("runCapability image skip", () => {
             models: [
               {
                 id: "MiniMax-M2.7",
-                input: ["text", "image"],
+                input: ["text"],
               },
             ],
           },


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- When the active model natively supports vision, the media-understanding runner still calls a vision model to describe inbound images if `agents.defaults.imageModel` is configured, injecting a redundant text description into the user body alongside the image the model already receives. This had two coupled causes on stock main: the `!isMinimaxVlmProvider` hardcode (which excluded all MiniMax providers from native-vision skip regardless of catalog support) and `agents.defaults.imageModel` being treated as explicit image-understanding config.

Why does this matter now?

- The documented contract (`docs/concepts/models.md`) states `agents.defaults.imageModel` is used only when the primary model can't accept images. On stock main, even a catalog-vision-capable MiniMax model (M3) goes through the describe path because the hardcode predates M3's `input: ["text","image"]` catalog entry. Users on the 5.28 → 6.1 upgrade path who inherited an `imageModel` config get redundant, potentially biasing descriptions plus wasted compute on every inbound image.

What is the intended outcome?

- A vision-capable primary (per catalog, including `minimax/MiniMax-M3`) receives the image directly with no `Description:` segment. `agents.defaults.imageModel` fires only as a fallback when the primary can't accept images. Explicit `tools.media.image.models` continues to force understanding.

What is intentionally out of scope?

- CN auth aliases (`minimax-cn` / `minimax-portal-cn`): these are auth/runtime aliases that do not produce their own catalog rows, so M3 under those provider ids may still not native-skip. That is a separate provider-alias-normalization issue, not addressed here.
- The exported `resolveAutoImageModel` resolver contract is deliberately preserved for SDK callers (see Risk).
- imageModel provider catalog cross-validation (#81525).

What does success look like?

- No `Description:` segment for a catalog-vision-capable primary; image still delivered via vision input; explicit overrides and text-only-primary fallback unchanged.

What should reviewers focus on?

- That native-vision skip now depends on catalog support (`modelSupportsVision`) rather than provider id, and that the skip decision lives only in `runCapability`'s inbound guard — the exported `resolveAutoImageModel` is left untouched so standalone SDK callers (e.g. Telegram sticker description) keep their configured fallback.

## Linked context

Which issue does this close?

Closes #91084

Which issues, PRs, or discussions are related?

Related #81525 (imageModel provider catalog cross-validation — different surface)

Was this requested by a maintainer or owner?

- No. Independent contribution. The fix direction and the two regression cases follow the revised root cause and test-gap observation raised in #91084.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: A catalog-vision-capable primary (`minimax/MiniMax-M3`) with `agents.defaults.imageModel` configured triggers a redundant generated image description injected into the user body, instead of the image being passed directly to the model's vision input.

- Real environment tested: I was not able to run an end-to-end live OpenClaw gateway reproduction (Feishu inbound → rendered transcript) for this change. See Proof limitations below. The change is verified at the source level with targeted real-behavior assertions in the media-understanding harness and a regression test exercising the exact reported model (`minimax/MiniMax-M3`).

- Exact steps or command run after this patch:
  `node scripts/run-vitest.mjs src/media-understanding/runner.vision-skip.test.ts`
  Telegram standalone path: focused smoke for `resolveAutoImageModel` SDK contract.
  Typecheck: `scripts/run-tsgo.mjs` against core and core-test tsconfigs.
  `git diff --check`

- Evidence after fix (terminal capture):
RUN  v4.1.7
Test Files  1 passed (1)
Tests  18 passed (18)
[test] passed 1 Vitest shard in 90.08s
  Telegram standalone smoke: 2 passed.
  Typecheck (core + core-test tsconfigs): exit 0, no output.
  `git diff --check`: empty.

  The added/updated cases assert observable behavior, not just the decision label:
  - `minimax/MiniMax-M3` (catalog vision-capable) + `agents.defaults.imageModel` → `outcome === "skipped"`, describe provider never invoked (`describeCalls === 0`), rendered body does NOT contain a planted vision sentinel — no description generated or injected.
  - explicit `tools.media.image.models` + vision-capable primary → understanding still fires (`describeCalls === 1`), body contains the sentinel (explicit-override contract).
  - `resolveAutoImageModel` still returns the configured `imageModel` for a vision-capable active model (exported SDK contract preserved for standalone callers).
  - text-only MiniMax (`MiniMax-M2.7`) still falls back through `MiniMax-VL-01` (fallback contract preserved).

- Observed result after fix: the redundant description is no longer generated for a catalog-vision-capable primary including M3, while explicit overrides and the exported resolver fallback both keep their prior behavior.

- What was not tested: live Feishu/Gateway end-to-end inbound-image path; real provider dispatch against a live MiniMax endpoint; CN auth alias (`minimax-cn`) M3 behavior.

- Proof limitations or environment constraints: I do not currently have a live OpenClaw + Feishu setup able to produce the runtime transcript capture this gate prefers. The regression is instead demonstrated at the source level with a model-specific test (`minimax/MiniMax-M3`) whose BEFORE state (hardcode present) fails and AFTER state (hardcode removed) passes — see Before evidence. The issue reporter also documented a live before/after in #91084, though on a fork where the hardcode was already removed, so it corroborates the runtime behavior direction rather than this exact patch. Requesting maintainer guidance on whether source-level model-specific proof plus the harness assertions is acceptable here, or whether a live capture / `proof: override` is required.

- Before evidence (optional but encouraged): With only the new M3 regression test added and source unchanged (hardcode present), that case fails — the describe path runs for M3 and the planted sentinel appears in the body, confirming the bug is real on stock and that the hardcode is the cause:
❯ src/media-understanding/runner.vision-skip.test.ts (18 tests | 1 failed)
× skips agents.defaults.imageModel fallback when MiniMax M3 supports vision
AssertionError: expected true to be false

## Tests and validation

Which commands did you run?

- `node scripts/run-vitest.mjs src/media-understanding/runner.vision-skip.test.ts` → 18 passed.
- Telegram standalone smoke → 2 passed.
- Typecheck (core + core-test) → exit 0.
- `git diff --check` → clean.

What regression coverage was added or updated?

- Added: `minimax/MiniMax-M3` + `agents.defaults.imageModel` skips understanding (sentinel-absent, `describeCalls === 0`).
- Added/kept: explicit `tools.media.image.models` + vision-capable primary still fires (sentinel-present).
- Updated: the prior `resolveAutoImageModel` test to assert the exported contract is preserved (returns configured imageModel for vision-capable active), reverting an earlier short-circuit.
- Updated: the prior MiniMax-hardcode test to a text-only `MiniMax-M2.7` fallback case (still routes through `MiniMax-VL-01`).

What failed before this fix, if known?

- The M3 regression fails pre-fix (describe path runs, sentinel injected).

If no test was added, why not?

- N/A.

## Risk checklist

Did user-visible behavior change? (Yes/No)

- Yes. A catalog-vision-capable primary (incl. M3) with `agents.defaults.imageModel` set no longer gets a redundant `Description:` segment.

Did config, environment, or migration behavior change? (Yes/No)

- Yes, semantically: `agents.defaults.imageModel` now behaves per its documented fallback-only contract, and native-vision skip is catalog-driven rather than provider-id-driven. No schema or migration change.

Did security, auth, secrets, network, or tool execution behavior change? (Yes/No)

- No.

What is the highest-risk area?

- The exported `resolveAutoImageModel` resolver, which standalone SDK callers (Telegram sticker description) use to pick an independent describe model. An earlier revision short-circuited it on vision-capable active models, which would have dropped the configured fallback for those callers.

How is that risk mitigated?

- That short-circuit was reverted; `resolveAutoImageModel` keeps its prior behavior. The native-vision skip decision now lives only in `runCapability`'s inbound guard, which standalone callers do not go through. A focused smoke test covers the Telegram resolver path, and typecheck confirms the exported signature is unchanged.

## Current review state

What is the next action?

- Maintainer review of the fix direction and guidance on the real-behavior-proof gate given the live-repro limitation.

What is still waiting on author, maintainer, CI, or external proof?

- Waiting on maintainer: whether source-level model-specific proof (M3 BEFORE/AFTER) plus harness assertions is acceptable, or a live gateway capture / `proof: override` is required.

Which bot or reviewer comments were addressed?

- ClawSweeper P1 "let MiniMax vision models reach the catalog skip": addressed by removing the `!isMinimaxVlmProvider` hardcode so catalog `modelSupportsVision` decides the skip.
- ClawSweeper P1 "preserve the exported resolver fallback contract": addressed by reverting the `resolveAutoImageModel` short-circuit and keeping the skip decision in `runCapability`.