### PR TITLE
fix: align Xiaomi completions replay compat

### DIFF
--- a/scripts/e2e/lib/fixtures/workspace.mjs
+++ b/scripts/e2e/lib/fixtures/workspace.mjs
@@ -53,24 +53,24 @@ function writeAgentsDeleteConfig() {
 }
 
 function assertAgentsDeleteResult([outputPath]) {
-  outputPath = requireArg(outputPath, "outputPath");
-  const outputStat = fs.statSync(outputPath);
+  const resolvedOutputPath = requireArg(outputPath, "outputPath");
+  const outputStat = fs.statSync(resolvedOutputPath);
   if (outputStat.isFile() && outputStat.size > AGENTS_DELETE_OUTPUT_MAX_BYTES) {
     throw new Error(
       `agents delete --json output exceeded ${AGENTS_DELETE_OUTPUT_MAX_BYTES} bytes:\nstdout tail=${readTextFileTail(
-        outputPath,
+        resolvedOutputPath,
         ERROR_DETAIL_TAIL_BYTES,
       )}`,
     );
   }
   let parsed;
   try {
-    parsed = readJson(outputPath);
+    parsed = readJson(resolvedOutputPath);
   } catch (error) {
     console.error("agents delete --json did not emit valid JSON:");
-    console.error(readTextFileTail(outputPath, ERROR_DETAIL_TAIL_BYTES).trim());
+    console.error(readTextFileTail(resolvedOutputPath, ERROR_DETAIL_TAIL_BYTES).trim());
     const message = error instanceof Error ? error.message.split("\n").at(0) : String(error);
-    throw new Error(`agents delete --json parse failed: ${message}`);
+    throw new Error(`agents delete --json parse failed: ${message}`, { cause: error });
   }
   for (const [actual, expected, label] of [
     [parsed.agentId, "ops", "agentId"],

--- a/src/llm/providers/openai-completions.test.ts
+++ b/src/llm/providers/openai-completions.test.ts
@@ -295,6 +295,70 @@ describe("OpenAI-compatible completions params", () => {
       ],
     });
   });
+
+  it("adds reasoning_content replay fields for Xiaomi MiMo assistant tool history", async () => {
+    let capturedMessages: unknown;
+    const stream = streamOpenAICompletions(
+      {
+        ...createModel(32_000),
+        id: "mimo-v2.5-pro",
+        name: "MiMo V2.5 Pro",
+        provider: "xiaomi",
+        baseUrl: "https://api.xiaomimimo.com/v1",
+        reasoning: true,
+      },
+      {
+        messages: [
+          {
+            role: "user",
+            content: "search first",
+            timestamp: 1,
+          },
+          {
+            role: "assistant",
+            content: [
+              {
+                type: "toolCall",
+                id: "call_search",
+                name: "search",
+                arguments: { query: "MiMo docs" },
+              },
+            ],
+            timestamp: 2,
+          },
+          {
+            role: "toolResult",
+            toolCallId: "call_search",
+            toolName: "search",
+            content: [{ type: "text", text: "ok" }],
+            isError: false,
+            timestamp: 3,
+          },
+          {
+            role: "user",
+            content: "continue",
+            timestamp: 4,
+          },
+        ],
+      },
+      {
+        apiKey: "sk-test",
+        onPayload(payload) {
+          capturedMessages = (payload as { messages?: unknown }).messages;
+          throw new Error("stop before network");
+        },
+      },
+    );
+
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("error");
+    const messages = capturedMessages as Array<Record<string, unknown>>;
+    expect(messages.find((message) => message.role === "assistant")).toMatchObject({
+      role: "assistant",
+      reasoning_content: "",
+    });
+  });
 });
 
 describe("openai-completions stop-reason tool-call guard", () => {

--- a/src/llm/providers/openai-completions.test.ts
+++ b/src/llm/providers/openai-completions.test.ts
@@ -316,6 +316,18 @@ describe("OpenAI-compatible completions params", () => {
           },
           {
             role: "assistant",
+            api: "openai-completions",
+            provider: "xiaomi",
+            model: "mimo-v2.5-pro",
+            usage: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 0,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+            },
+            stopReason: "toolUse",
             content: [
               {
                 type: "toolCall",

--- a/src/llm/providers/openai-completions.ts
+++ b/src/llm/providers/openai-completions.ts
@@ -1274,6 +1274,7 @@ function detectCompat(model: Model<"openai-completions">): ResolvedOpenAIComplet
 
   const isGrok = provider === "xai" || baseUrl.includes("api.x.ai");
   const isDeepSeek = provider === "deepseek" || baseUrl.includes("deepseek.com");
+  const isXiaomi = provider === "xiaomi" || baseUrl.includes("xiaomimimo.com");
   const cacheControlFormat =
     provider === "openrouter" && model.id.startsWith("anthropic/") ? "anthropic" : undefined;
 
@@ -1287,16 +1288,18 @@ function detectCompat(model: Model<"openai-completions">): ResolvedOpenAIComplet
     requiresToolResultName: false,
     requiresAssistantAfterToolResult: false,
     requiresThinkingAsText: false,
-    requiresReasoningContentOnAssistantMessages: isDeepSeek,
+    requiresReasoningContentOnAssistantMessages: isDeepSeek || isXiaomi,
     thinkingFormat: isDeepSeek
       ? "deepseek"
-      : isZai
-        ? "zai"
-        : isTogether
-          ? "together"
-          : provider === "openrouter" || baseUrl.includes("openrouter.ai")
-            ? "openrouter"
-            : "openai",
+      : isXiaomi
+        ? "deepseek"
+        : isZai
+          ? "zai"
+          : isTogether
+            ? "together"
+            : provider === "openrouter" || baseUrl.includes("openrouter.ai")
+              ? "openrouter"
+              : "openai",
     openRouterRouting: {},
     vercelGatewayRouting: {},
     zaiToolStream: false,


### PR DESCRIPTION
## Summary
- align provider-layer OpenAI Completions compat detection with the existing agent transport Xiaomi/MiMo defaults
- treat documented `xiaomimimo.com` MiMo endpoints like DeepSeek-style reasoning endpoints for assistant replay
- add a direct provider payload regression proving Xiaomi assistant tool history gets `reasoning_content: ""`

Fixes #91106.

## Verification
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/llm/providers/openai-completions.test.ts src/agents/openai-completions-compat.test.ts` -> 40 tests passed
- `pnpm exec oxfmt --check --threads=1 src/llm/providers/openai-completions.ts src/llm/providers/openai-completions.test.ts`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/llm/providers/openai-completions.ts src/llm/providers/openai-completions.test.ts`
- `pnpm tsgo:core`
- `git diff --check`
- `pnpm changed:lanes --json` -> core + coreTests only
- `/Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode local` -> clean, no accepted/actionable findings

## API proof
- Official Xiaomi MiMo docs say multi-turn agent/tool-call history must pass back `reasoning_content`, otherwise the API returns 400: https://platform.xiaomimimo.com/docs/en-US/usage-guide/passing-back-reasoning_content
- Official OpenAI-compatible request docs list `https://api.xiaomimimo.com/v1/chat/completions` as the Xiaomi endpoint: https://platform.xiaomimimo.com/docs/en-US/api/chat/openai-api?target=request-body

## Not tested
- No live Xiaomi request was run. I checked 1Password via targeted metadata-only queries, but this `op` build has no search flag and I did not broadly enumerate vault contents. The after-fix regression captures the exact outbound provider payload before network dispatch.
