### PR TITLE
fix: preserve Foundry Responses reasoning replay ids

### DIFF
--- a/extensions/microsoft-foundry/index.test.ts
+++ b/extensions/microsoft-foundry/index.test.ts
@@ -1,4 +1,5 @@
 // Microsoft Foundry tests cover index plugin behavior.
+import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -779,6 +780,60 @@ describe("microsoft-foundry plugin", () => {
     const provider = result.configPatch?.models?.providers?.["microsoft-foundry"];
     expect(provider?.models[0]?.compat?.supportsStore).toBe(false);
     expect(provider?.models[0]?.compat?.maxTokensField).toBe("max_completion_tokens");
+  });
+
+  it("keeps replay item ids for Foundry encrypted reasoning continuations", async () => {
+    const provider = registerProvider();
+    let capturedReplayIds: boolean | undefined;
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      capturedReplayIds = (options as { replayResponsesItemIds?: boolean } | undefined)
+        ?.replayResponsesItemIds;
+      return {} as never;
+    };
+
+    const wrappedStreamFn = provider.wrapStreamFn?.({
+      streamFn: baseStreamFn,
+      modelId: "gpt-5.4",
+      model: buildFoundryModel({
+        reasoning: true,
+        compat: { supportsStore: false },
+      }),
+      extraParams: {},
+      config: {},
+      agentDir: defaultFoundryAgentDir,
+    } as never);
+
+    expect(wrappedStreamFn).toBeTypeOf("function");
+    await wrappedStreamFn?.(
+      buildFoundryModel({
+        reasoning: true,
+        compat: { supportsStore: false },
+      }) as never,
+      { systemPrompt: "system", messages: [] } as never,
+      {},
+    );
+
+    expect(capturedReplayIds).toBe(true);
+  });
+
+  it("leaves Foundry chat completions streams unwrapped by Responses defaults", () => {
+    const provider = registerProvider();
+    const baseStreamFn: StreamFn = () => ({}) as never;
+
+    expect(
+      provider.wrapStreamFn?.({
+        streamFn: baseStreamFn,
+        modelId: "gpt-4o-mini",
+        model: buildFoundryModel({
+          id: "gpt-4o-mini",
+          name: "gpt-4o-mini",
+          api: "openai-completions",
+        }),
+        extraParams: {},
+        config: {},
+        agentDir: defaultFoundryAgentDir,
+      } as never),
+    ).toBe(baseStreamFn);
   });
 
   it("marks Foundry chat models as not supporting reasoning_effort", () => {

--- a/extensions/microsoft-foundry/provider.ts
+++ b/extensions/microsoft-foundry/provider.ts
@@ -4,6 +4,7 @@ import type {
   ModelProviderConfig,
   ProviderPlugin,
 } from "openclaw/plugin-sdk/provider-model-shared";
+import { OPENAI_RESPONSES_STREAM_HOOKS } from "openclaw/plugin-sdk/provider-stream-family";
 import { apiKeyAuthMethod, entraIdAuthMethod } from "./auth.js";
 import { prepareFoundryRuntimeAuth } from "./runtime.js";
 import {
@@ -17,6 +18,40 @@ import {
   resolveFoundryModelCapabilities,
   resolveFoundryTargetProfileId,
 } from "./shared.js";
+
+type FoundryProviderHooks = Pick<ProviderPlugin, "wrapStreamFn">;
+
+const wrapOpenAIResponsesStreamFn = OPENAI_RESPONSES_STREAM_HOOKS.wrapStreamFn;
+
+const wrapMicrosoftFoundryStreamFn: NonNullable<FoundryProviderHooks["wrapStreamFn"]> = (ctx) => {
+  if (ctx.model?.api !== "openai-responses") {
+    return ctx.streamFn ?? null;
+  }
+
+  const baseStreamFn = ctx.streamFn;
+  if (!baseStreamFn) {
+    return wrapOpenAIResponsesStreamFn?.(ctx) ?? null;
+  }
+
+  const streamFnWithResponsesReplayIds: NonNullable<typeof ctx.streamFn> = (
+    model,
+    context,
+    options,
+  ) =>
+    baseStreamFn(model, context, {
+      ...options,
+      // Foundry validates encrypted reasoning replay against the original item id,
+      // even though its Responses endpoint does not support persisted `store`.
+      replayResponsesItemIds: true,
+    } as typeof options & { replayResponsesItemIds: true });
+
+  return (
+    wrapOpenAIResponsesStreamFn?.({
+      ...ctx,
+      streamFn: streamFnWithResponsesReplayIds,
+    }) ?? streamFnWithResponsesReplayIds
+  );
+};
 
 export function buildMicrosoftFoundryProvider(): ProviderPlugin {
   return {
@@ -174,6 +209,7 @@ export function buildMicrosoftFoundryProvider(): ProviderPlugin {
         ...(compat ? { compat } : {}),
       };
     },
+    wrapStreamFn: wrapMicrosoftFoundryStreamFn,
     prepareRuntimeAuth: prepareFoundryRuntimeAuth,
   };
 }

--- a/src/llm/providers/openai-responses-shared.test.ts
+++ b/src/llm/providers/openai-responses-shared.test.ts
@@ -354,6 +354,53 @@ describe("convertResponsesMessages", () => {
     });
     expect(functionCall).not.toHaveProperty("id");
   });
+
+  it("keeps encrypted reasoning replay item ids when requested", () => {
+    const input = convertResponsesMessages(
+      nativeOpenAIModel,
+      {
+        systemPrompt: "system",
+        messages: [
+          {
+            role: "assistant",
+            api: nativeOpenAIModel.api,
+            provider: nativeOpenAIModel.provider,
+            model: nativeOpenAIModel.id,
+            usage: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 0,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+            },
+            stopReason: "stop",
+            timestamp: 1,
+            content: [
+              {
+                type: "thinking",
+                thinking: "Need continuity.",
+                thinkingSignature: JSON.stringify({
+                  type: "reasoning",
+                  id: "rs_foundry_prior",
+                  encrypted_content: "ciphertext",
+                }),
+              },
+            ],
+          },
+        ],
+      } satisfies Context,
+      allowedToolCallProviders,
+      { includeSystemPrompt: false, replayResponsesItemIds: true },
+    ) as unknown as Array<Record<string, unknown>>;
+
+    expect(input.find((item) => item.type === "reasoning")).toMatchObject({
+      type: "reasoning",
+      id: "rs_foundry_prior",
+      encrypted_content: "ciphertext",
+      summary: [],
+    });
+  });
 });
 
 describe("processResponsesStream", () => {


### PR DESCRIPTION
## Summary
- fixes microsoft-foundry Responses continuations by preserving replay item ids for encrypted reasoning items
- keeps the existing OpenAI Responses wrapper stack for Foundry Responses models while leaving Foundry chat-completions streams untouched
- adds regression coverage for the Foundry hook and the Responses serializer id-preserving option

Fixes #91033.

## Verification
- `node scripts/run-vitest.mjs extensions/microsoft-foundry/index.test.ts src/llm/providers/openai-responses-shared.test.ts`
- `pnpm lint:extensions`
- `pnpm lint:core`
- `pnpm check:test-types`
- `pnpm tsgo:extensions`
- `pnpm exec oxfmt --check --threads=1 extensions/microsoft-foundry/provider.ts extensions/microsoft-foundry/index.test.ts src/llm/providers/openai-responses-shared.test.ts`
- `git diff --check`
- `/Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode local` -> clean, no accepted/actionable findings

## Live API Proof
Molty 1Password metadata search found no available microsoft-foundry / Foundry / Azure OpenAI credential item, so I could not run a live Foundry request. The fix follows the issue's direct API proof: Foundry accepts encrypted reasoning replay when the original reasoning item id is present and rejects the same replay when the encrypted content is sent without that id.
