### PR TITLE
fix: strip Google provider prefix from Gemini paths

### DIFF
--- a/extensions/google/model-id.ts
+++ b/extensions/google/model-id.ts
@@ -2,9 +2,13 @@
 const ANTIGRAVITY_BARE_PRO_IDS = new Set(["gemini-3-pro", "gemini-3.1-pro", "gemini-3-1-pro"]);
 const GOOGLE_PROVIDER_PREFIX = "google/";
 
+export function stripGoogleProviderPrefix(id: string): string {
+  return id.startsWith(GOOGLE_PROVIDER_PREFIX) ? id.slice(GOOGLE_PROVIDER_PREFIX.length) : id;
+}
+
 export function normalizeGoogleModelId(id: string): string {
   if (id.startsWith(GOOGLE_PROVIDER_PREFIX)) {
-    const modelId = id.slice(GOOGLE_PROVIDER_PREFIX.length);
+    const modelId = stripGoogleProviderPrefix(id);
     const normalizedModelId = normalizeGoogleModelId(modelId);
     return normalizedModelId === modelId ? id : `${GOOGLE_PROVIDER_PREFIX}${normalizedModelId}`;
   }

--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -447,6 +447,31 @@ describe("google transport stream", () => {
     expect(result.content[2]).toHaveProperty("thoughtSignature", "Y2FsbF9zaWdfMQ==");
   });
 
+  it("strips redundant google provider prefixes from Gemini API model paths", async () => {
+    guardedFetchMock.mockResolvedValueOnce(buildSseResponse([]));
+
+    const model = buildGeminiModel({
+      id: "google/gemini-3-flash-preview",
+      name: "Gemini 3 Flash Preview",
+    });
+    const streamFn = createGoogleGenerativeAiTransportStreamFn();
+    const stream = await Promise.resolve(
+      streamFn(
+        model,
+        {
+          messages: [{ role: "user", content: "hello", timestamp: 0 }],
+        } as Parameters<typeof streamFn>[1],
+        { apiKey: "gemini-api-key" } as Parameters<typeof streamFn>[2],
+      ),
+    );
+    await stream.result();
+
+    const guardedCall = requireMockCall(guardedFetchMock, 0, "guarded fetch");
+    expect(guardedCall[0]).toBe(
+      "https://generativelanguage.googleapis.com/v1beta/models/gemini-3-flash-preview:streamGenerateContent?alt=sse",
+    );
+  });
+
   it("merges tool-call thought signatures from sibling SSE parts", async () => {
     guardedFetchMock.mockResolvedValueOnce(
       buildSseResponse([

--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -28,6 +28,7 @@ import {
   normalizeOptionalString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { parseGeminiAuth } from "./gemini-auth.js";
+import { stripGoogleProviderPrefix } from "./model-id.js";
 import { normalizeGoogleApiBaseUrl } from "./provider-policy.js";
 import {
   isGoogleGemini25ThinkingBudgetModel,
@@ -323,7 +324,7 @@ function resolveGoogleModelPath(modelId: string): string {
   if (modelId.startsWith("models/") || modelId.startsWith("tunedModels/")) {
     return modelId;
   }
-  return `models/${modelId}`;
+  return `models/${stripGoogleProviderPrefix(modelId)}`;
 }
 
 function buildGoogleGenerativeAiRequestUrl(model: GoogleTransportModel): string {
@@ -356,7 +357,10 @@ function resolveGoogleVertexLocation(options: GoogleTransportOptions | undefined
   return location;
 }
 
-export function resolveGoogleVertexBaseOrigin(model: GoogleTransportModel, location: string): string {
+export function resolveGoogleVertexBaseOrigin(
+  model: GoogleTransportModel,
+  location: string,
+): string {
   const configured = normalizeOptionalString(model.baseUrl);
   if (configured && !configured.includes("{location}")) {
     try {

--- a/extensions/qa-lab/src/live-transports/whatsapp/cli.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/whatsapp/cli.runtime.test.ts
@@ -25,7 +25,7 @@ vi.mock("./whatsapp-live.runtime.js", () => ({
 }));
 
 const tempDirs: string[] = [];
-let originalExitCode: string | number | undefined;
+let originalExitCode: typeof process.exitCode;
 
 afterEach(async () => {
   process.exitCode = originalExitCode;


### PR DESCRIPTION
## Summary

Fixes #71932.

Native Google Gemini transport now strips a redundant same-provider `google/` prefix before constructing Gemini API REST paths. This keeps configured model matching/provider-scoped IDs intact while sending `models/gemini-3-flash-preview` to Google instead of the invalid `models/google/gemini-3-flash-preview` path.

## Verification

- Live Gemini API proof with `GEMINI_API_KEY` from 1Password: `models/google/gemini-3-flash-preview:generateContent` returned 404; `models/gemini-3-flash-preview:generateContent` returned 200.
- Google Gemini API docs define `generateContent` and `streamGenerateContent` endpoints as `https://generativelanguage.googleapis.com/v1beta/{model=models/*}:...` with model format `models/{model}`.
- `node scripts/run-vitest.mjs extensions/google/transport-stream.test.ts`
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/model.test.ts`
- `node scripts/run-vitest.mjs src/agents/openclaw-tools.subagents.sessions-spawn.model.test.ts`
- `pnpm exec oxfmt --check --threads=1 extensions/google/model-id.ts extensions/google/transport-stream.ts extensions/google/transport-stream.test.ts`
- `git diff --check`
- `pnpm tsgo:extensions`
- `pnpm lint:extensions`
- `pnpm check:test-types`
- Autoreview: clean, no accepted/actionable findings.
