### PR TITLE
fix: migrate legacy agent registry schema via doctor

### DIFF
--- a/src/commands/doctor-state-migrations.test.ts
+++ b/src/commands/doctor-state-migrations.test.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import type { DatabaseSync } from "node:sqlite";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import type { SessionEntry } from "../config/sessions/types.js";
@@ -257,6 +258,51 @@ afterEach(async () => {
 function writeJson5(filePath: string, value: unknown) {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
   fs.writeFileSync(filePath, JSON.stringify(value, null, 2), "utf-8");
+}
+
+function readPrimaryKeyColumns(db: DatabaseSync, tableName: string): string[] {
+  const rows = db.prepare(`PRAGMA table_info(${tableName})`).all() as Array<{
+    name?: unknown;
+    pk?: unknown;
+  }>;
+  return rows
+    .filter((row) => Number(row.pk ?? 0) > 0 && typeof row.name === "string")
+    .toSorted((left, right) => Number(left.pk ?? 0) - Number(right.pk ?? 0))
+    .map((row) => row.name as string);
+}
+
+function createLegacyAgentDatabaseRegistry(stateDir: string): string {
+  const stateDatabasePath = path.join(stateDir, "state", "openclaw.sqlite");
+  fs.mkdirSync(path.dirname(stateDatabasePath), { recursive: true });
+  const { DatabaseSync } = requireNodeSqlite();
+  const db = new DatabaseSync(stateDatabasePath);
+  try {
+    db.exec(`
+      CREATE TABLE agent_databases (
+        agent_id TEXT NOT NULL PRIMARY KEY,
+        path TEXT NOT NULL,
+        schema_version INTEGER NOT NULL,
+        last_seen_at INTEGER NOT NULL,
+        size_bytes INTEGER
+      );
+      INSERT INTO agent_databases (
+        agent_id,
+        path,
+        schema_version,
+        last_seen_at,
+        size_bytes
+      ) VALUES (
+        'worker-1',
+        '/legacy/worker-1/openclaw-agent.sqlite',
+        1,
+        10,
+        20
+      );
+    `);
+  } finally {
+    db.close();
+  }
+  return stateDatabasePath;
 }
 
 function writeLegacySessionsFixture(params: {
@@ -635,6 +681,82 @@ describe("doctor legacy state migrations", () => {
     expect(store["agent:main:slack:channel:c123"]?.sessionId).toBe("c");
     expect(store["agent:main:unknown:group:abc"]?.sessionId).toBe("d");
     expect(store["agent:main:subagent:xyz"]?.sessionId).toBe("e");
+  });
+
+  it("migrates the legacy shared state agent registry primary key", async () => {
+    const root = await makeTempRoot();
+    const stateDir = path.join(root, ".openclaw");
+    const stateDatabasePath = createLegacyAgentDatabaseRegistry(stateDir);
+    const detected = await detectLegacyStateMigrations({
+      cfg: {},
+      env: {} as NodeJS.ProcessEnv,
+      homedir: () => root,
+    });
+
+    expect(detected.preview).toContain(
+      "- Shared SQLite schema: agent database registry primary key → agent_id,path",
+    );
+
+    const result = await runLegacyStateMigrations({ detected });
+    expect(result.warnings).toStrictEqual([]);
+    expect(result.changes).toStrictEqual([
+      "Migrated shared state agent database registry primary key → agent_id,path",
+    ]);
+
+    const { DatabaseSync } = requireNodeSqlite();
+    const db = new DatabaseSync(stateDatabasePath);
+    try {
+      expect(readPrimaryKeyColumns(db, "agent_databases")).toEqual(["agent_id", "path"]);
+      expect(() =>
+        db.exec(`
+          INSERT INTO agent_databases (
+            agent_id,
+            path,
+            schema_version,
+            last_seen_at,
+            size_bytes
+          ) VALUES (
+            'worker-1',
+            '/relocated/worker-1/openclaw-agent.sqlite',
+            1,
+            20,
+            30
+          )
+          ON CONFLICT(agent_id, path) DO UPDATE SET
+            last_seen_at = excluded.last_seen_at,
+            size_bytes = excluded.size_bytes;
+        `),
+      ).not.toThrow();
+    } finally {
+      db.close();
+    }
+  });
+
+  it("does not repair newer shared state schemas", async () => {
+    const root = await makeTempRoot();
+    const stateDir = path.join(root, ".openclaw");
+    const stateDatabasePath = createLegacyAgentDatabaseRegistry(stateDir);
+    const { DatabaseSync } = requireNodeSqlite();
+    const seededDb = new DatabaseSync(stateDatabasePath);
+    seededDb.exec("PRAGMA user_version = 2;");
+    seededDb.close();
+
+    const detected = await detectLegacyStateMigrations({
+      cfg: {},
+      env: {} as NodeJS.ProcessEnv,
+      homedir: () => root,
+    });
+    const result = await runLegacyStateMigrations({ detected });
+    expect(result.changes).toStrictEqual([]);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain("uses newer schema version 2");
+
+    const db = new DatabaseSync(stateDatabasePath);
+    try {
+      expect(readPrimaryKeyColumns(db, "agent_databases")).toEqual(["agent_id"]);
+    } finally {
+      db.close();
+    }
   });
 
   it("migrates legacy ACP metadata from sessions.json into shared SQLite", async () => {

--- a/src/commands/doctor.e2e-harness.ts
+++ b/src/commands/doctor.e2e-harness.ts
@@ -227,6 +227,10 @@ function createLegacyStateMigrationDetectionResult(params?: {
       sourcePath: "/tmp/state/plugins/installs.json",
       hasLegacy: false,
     },
+    stateSchema: {
+      hasLegacy: false,
+      preview: [],
+    },
     taskStateSidecars: {
       taskRunsPath: "/tmp/state/tasks/runs.sqlite",
       flowRunsPath: "/tmp/state/flows/registry.sqlite",

--- a/src/infra/state-migrations.ts
+++ b/src/infra/state-migrations.ts
@@ -56,7 +56,11 @@ import {
 } from "../routing/session-key.js";
 import { normalizeSessionKeyPreservingOpaquePeerIds } from "../sessions/session-key-utils.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
-import { runOpenClawStateWriteTransaction } from "../state/openclaw-state-db.js";
+import {
+  detectOpenClawStateDatabaseSchemaMigrations,
+  repairOpenClawStateDatabaseSchema,
+  runOpenClawStateWriteTransaction,
+} from "../state/openclaw-state-db.js";
 import { expandHomePrefix } from "./home-dir.js";
 import {
   executeSqliteQuerySync,
@@ -109,6 +113,10 @@ export type LegacyStateDetection = {
   pluginInstallIndex: {
     sourcePath: string;
     hasLegacy: boolean;
+  };
+  stateSchema: {
+    hasLegacy: boolean;
+    preview: string[];
   };
   taskStateSidecars: {
     taskRunsPath: string;
@@ -2627,6 +2635,9 @@ export async function detectLegacyStateMigrations(params: {
   const hasPluginStateSidecar = fileExists(pluginStateSidecarPath);
   const pluginInstallIndexPath = resolveLegacyInstalledPluginIndexStorePath({ stateDir });
   const hasPluginInstallIndex = fileExists(pluginInstallIndexPath);
+  const stateSchemaMigrations = detectOpenClawStateDatabaseSchemaMigrations({
+    env: { ...env, OPENCLAW_STATE_DIR: stateDir },
+  });
   const taskRunsSidecarPath = resolveLegacyTaskRunsSidecarPath(stateDir);
   const flowRunsSidecarPath = resolveLegacyFlowRunsSidecarPath(stateDir);
   const hasTaskStateSidecars = fileExists(taskRunsSidecarPath) || fileExists(flowRunsSidecarPath);
@@ -2645,12 +2656,15 @@ export async function detectLegacyStateMigrations(params: {
     stateDir,
     oauthDir,
   });
-  const pluginPlans = await collectPluginDoctorStateMigrationPlans({
-    cfg: params.cfg,
-    env,
-    stateDir,
-    oauthDir,
-  });
+  const pluginPlans =
+    stateSchemaMigrations.length > 0
+      ? []
+      : await collectPluginDoctorStateMigrationPlans({
+          cfg: params.cfg,
+          env,
+          stateDir,
+          oauthDir,
+        });
 
   const preview: string[] = [];
   if (hasLegacySessions) {
@@ -2667,6 +2681,12 @@ export async function detectLegacyStateMigrations(params: {
   }
   if (hasPluginInstallIndex) {
     preview.push(`- Plugin install index: ${pluginInstallIndexPath} → shared SQLite state`);
+  }
+  if (stateSchemaMigrations.length > 0) {
+    preview.push("- Shared SQLite schema: agent database registry primary key → agent_id,path");
+    preview.push(
+      "- Rerun doctor after shared SQLite schema repair to detect plugin state migrations",
+    );
   }
   if (fileExists(taskRunsSidecarPath)) {
     preview.push(`- Task registry sidecar: ${taskRunsSidecarPath} → shared SQLite state`);
@@ -2718,6 +2738,10 @@ export async function detectLegacyStateMigrations(params: {
     pluginInstallIndex: {
       sourcePath: pluginInstallIndexPath,
       hasLegacy: hasPluginInstallIndex,
+    },
+    stateSchema: {
+      hasLegacy: stateSchemaMigrations.length > 0,
+      preview: stateSchemaMigrations.map((migration) => migration.path),
     },
     taskStateSidecars: {
       taskRunsPath: taskRunsSidecarPath,
@@ -2969,6 +2993,15 @@ async function runPluginDoctorStateMigrationPlans(params: {
   return { changes, warnings };
 }
 
+function migrateLegacyStateSchema(detected: LegacyStateDetection): {
+  changes: string[];
+  warnings: string[];
+} {
+  return repairOpenClawStateDatabaseSchema({
+    env: { ...process.env, OPENCLAW_STATE_DIR: detected.stateDir },
+  });
+}
+
 export async function runLegacyStateMigrations(params: {
   detected: LegacyStateDetection;
   config?: OpenClawConfig;
@@ -2977,6 +3010,10 @@ export async function runLegacyStateMigrations(params: {
 }): Promise<{ changes: string[]; warnings: string[] }> {
   const now = params.now ?? (() => Date.now());
   const detected = params.detected;
+  const stateSchema = migrateLegacyStateSchema(detected);
+  if (detected.stateSchema.hasLegacy && stateSchema.warnings.length > 0) {
+    return stateSchema;
+  }
   const pluginStateSidecar = await migrateLegacyPluginStateSidecar({
     stateDir: detected.stateDir,
   });
@@ -2992,10 +3029,12 @@ export async function runLegacyStateMigrations(params: {
   const preSessionChannelPlans = await runLegacyMigrationPlans(
     detected.channelPlans.plans.filter((plan) => plan.kind === "plugin-state-import"),
   );
-  const pluginPlans = await runPluginDoctorStateMigrationPlans({
-    detected,
-    config: params.config ?? ({} as OpenClawConfig),
-  });
+  const pluginPlans = detected.stateSchema.hasLegacy
+    ? { changes: [], warnings: [] }
+    : await runPluginDoctorStateMigrationPlans({
+        detected,
+        config: params.config ?? ({} as OpenClawConfig),
+      });
   const sessions = await migrateLegacySessions(detected, now, {
     recoverCorruptTargetStore: params.recoverCorruptTargetStore,
   });
@@ -3010,6 +3049,7 @@ export async function runLegacyStateMigrations(params: {
   );
   return {
     changes: [
+      ...stateSchema.changes,
       ...pluginStateSidecar.changes,
       ...pluginInstallIndex.changes,
       ...taskStateSidecars.changes,
@@ -3022,6 +3062,7 @@ export async function runLegacyStateMigrations(params: {
       ...channelPlans.changes,
     ],
     warnings: [
+      ...stateSchema.warnings,
       ...pluginStateSidecar.warnings,
       ...pluginInstallIndex.warnings,
       ...taskStateSidecars.warnings,
@@ -3306,6 +3347,10 @@ export async function autoMigrateLegacyState(params: {
     homedir: params.homedir,
     log: params.log,
   });
+  const stateDir = resolveStateDir(env, params.homedir ?? os.homedir);
+  const stateSchema = repairOpenClawStateDatabaseSchema({
+    env: { ...env, OPENCLAW_STATE_DIR: stateDir },
+  });
 
   // Canonicalize orphaned session keys regardless of whether legacy migration
   // is needed — the orphan-key bug (#29683) affects all installs with
@@ -3362,6 +3407,7 @@ export async function autoMigrateLegacyState(params: {
     });
     const changes = [
       ...stateDirResult.changes,
+      ...stateSchema.changes,
       ...orphanKeys.changes,
       ...acpSessionMetadata.changes,
       ...pluginStateSidecar.changes,
@@ -3373,6 +3419,7 @@ export async function autoMigrateLegacyState(params: {
     ];
     const warnings = [
       ...stateDirResult.warnings,
+      ...stateSchema.warnings,
       ...orphanKeys.warnings,
       ...acpSessionMetadata.warnings,
       ...pluginStateSidecar.warnings,
@@ -3386,6 +3433,7 @@ export async function autoMigrateLegacyState(params: {
     return {
       migrated:
         stateDirResult.migrated ||
+        stateSchema.changes.length > 0 ||
         orphanKeys.changes.length > 0 ||
         acpSessionMetadata.changes.length > 0 ||
         pluginStateSidecar.changes.length > 0 ||
@@ -3406,16 +3454,19 @@ export async function autoMigrateLegacyState(params: {
     !detected.pluginPlans?.hasLegacy &&
     !detected.pluginStateSidecar.hasLegacy &&
     !detected.pluginInstallIndex.hasLegacy &&
+    !detected.stateSchema.hasLegacy &&
     !detected.taskStateSidecars.hasLegacy &&
     !detected.deliveryQueues.hasLegacy
   ) {
     const changes = [
       ...stateDirResult.changes,
+      ...stateSchema.changes,
       ...orphanKeys.changes,
       ...acpSessionMetadata.changes,
     ];
     const warnings = [
       ...stateDirResult.warnings,
+      ...stateSchema.warnings,
       ...orphanKeys.warnings,
       ...acpSessionMetadata.warnings,
     ];
@@ -3423,6 +3474,7 @@ export async function autoMigrateLegacyState(params: {
     return {
       migrated:
         stateDirResult.migrated ||
+        stateSchema.changes.length > 0 ||
         orphanKeys.changes.length > 0 ||
         acpSessionMetadata.changes.length > 0,
       skipped: false,
@@ -3465,6 +3517,7 @@ export async function autoMigrateLegacyState(params: {
   );
   const changes = [
     ...stateDirResult.changes,
+    ...stateSchema.changes,
     ...orphanKeys.changes,
     ...acpSessionMetadata.changes,
     ...pluginStateSidecar.changes,
@@ -3480,6 +3533,7 @@ export async function autoMigrateLegacyState(params: {
   ];
   const warnings = [
     ...stateDirResult.warnings,
+    ...stateSchema.warnings,
     ...orphanKeys.warnings,
     ...acpSessionMetadata.warnings,
     ...pluginStateSidecar.warnings,

--- a/src/state/openclaw-agent-db.test.ts
+++ b/src/state/openclaw-agent-db.test.ts
@@ -115,6 +115,45 @@ describe("openclaw agent database", () => {
     ).toEqual([defaultDatabase.path, relocated.path].toSorted());
   });
 
+  it("rejects the legacy agent registry primary key with a doctor repair hint", () => {
+    const stateDir = createTempStateDir();
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const stateDatabasePath = path.join(stateDir, "state", "openclaw.sqlite");
+    fs.mkdirSync(path.dirname(stateDatabasePath), { recursive: true });
+    const { DatabaseSync } = requireNodeSqlite();
+    const legacyDb = new DatabaseSync(stateDatabasePath);
+    legacyDb.exec(`
+      CREATE TABLE agent_databases (
+        agent_id TEXT NOT NULL PRIMARY KEY,
+        path TEXT NOT NULL,
+        schema_version INTEGER NOT NULL,
+        last_seen_at INTEGER NOT NULL,
+        size_bytes INTEGER
+      );
+      INSERT INTO agent_databases (
+        agent_id,
+        path,
+        schema_version,
+        last_seen_at,
+        size_bytes
+      ) VALUES (
+        'worker-1',
+        '/legacy/worker-1/openclaw-agent.sqlite',
+        1,
+        10,
+        20
+      );
+    `);
+    legacyDb.close();
+
+    expect(() =>
+      openOpenClawAgentDatabase({
+        agentId: "worker-1",
+        env,
+      }),
+    ).toThrow(/run openclaw doctor --fix/);
+  });
+
   it("rejects sharing one explicit database path across agent ids", () => {
     const stateDir = createTempStateDir();
     const env = { OPENCLAW_STATE_DIR: stateDir };
@@ -174,11 +213,13 @@ describe("openclaw agent database", () => {
 
   it("does not chmod shared parent directories for explicit database paths", () => {
     const parentDir = createTempStateDir();
+    const env = { OPENCLAW_STATE_DIR: parentDir };
     fs.chmodSync(parentDir, 0o755);
     const databasePath = path.join(parentDir, "worker-1.sqlite");
 
     openOpenClawAgentDatabase({
       agentId: "worker-1",
+      env,
       path: databasePath,
     });
 

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -50,6 +50,11 @@ export type OpenClawMigrationRunStatus = "completed" | "warning" | "failed";
 /** Status stored for a state backup run. */
 export type OpenClawBackupRunStatus = "completed" | "failed";
 
+export type OpenClawStateDatabaseSchemaMigration = {
+  kind: "agent-databases-composite-primary-key";
+  path: string;
+};
+
 /** Input for recording one state migration run summary. */
 export type RecordOpenClawStateMigrationRunOptions = OpenClawStateDatabaseOptions & {
   id?: string;
@@ -132,6 +137,17 @@ function tableHasColumn(db: DatabaseSync, tableName: string, columnName: string)
   return rows.some((row) => row.name === columnName);
 }
 
+function tablePrimaryKeyColumns(db: DatabaseSync, tableName: string): string[] {
+  const rows = db.prepare(`PRAGMA table_info(${tableName})`).all() as Array<{
+    name?: unknown;
+    pk?: unknown;
+  }>;
+  return rows
+    .filter((row) => Number(row.pk ?? 0) > 0 && typeof row.name === "string")
+    .toSorted((left, right) => Number(left.pk ?? 0) - Number(right.pk ?? 0))
+    .map((row) => row.name as string);
+}
+
 function tableExists(db: DatabaseSync, tableName: string): boolean {
   const row = db
     .prepare("SELECT 1 AS ok FROM sqlite_master WHERE type = 'table' AND name = ?")
@@ -146,6 +162,121 @@ function ensureColumn(db: DatabaseSync, tableName: string, columnSql: string): v
   }
   // State migrations are additive here; destructive or shape-changing repairs belong in doctor.
   db.exec(`ALTER TABLE ${tableName} ADD COLUMN ${columnSql};`);
+}
+
+function hasCanonicalAgentDatabasesPrimaryKey(db: DatabaseSync): boolean {
+  if (!tableExists(db, "agent_databases")) {
+    return true;
+  }
+  const primaryKey = tablePrimaryKeyColumns(db, "agent_databases");
+  return primaryKey.length === 2 && primaryKey[0] === "agent_id" && primaryKey[1] === "path";
+}
+
+function canRepairAgentDatabasesPrimaryKey(db: DatabaseSync): boolean {
+  if (!tableExists(db, "agent_databases")) {
+    return false;
+  }
+  const requiredColumns = ["agent_id", "path", "schema_version", "last_seen_at", "size_bytes"];
+  return requiredColumns.every((column) => tableHasColumn(db, "agent_databases", column));
+}
+
+function repairAgentDatabasesCompositePrimaryKey(db: DatabaseSync): boolean {
+  if (hasCanonicalAgentDatabasesPrimaryKey(db) || !canRepairAgentDatabasesPrimaryKey(db)) {
+    return false;
+  }
+  // Released DBs may have PRIMARY KEY(agent_id); current registration upserts by
+  // (agent_id,path) so explicit relocated agent DBs do not overwrite each other.
+  db.exec(`
+    DROP TABLE IF EXISTS agent_databases_migration_new;
+    CREATE TABLE agent_databases_migration_new (
+      agent_id TEXT NOT NULL,
+      path TEXT NOT NULL,
+      schema_version INTEGER NOT NULL,
+      last_seen_at INTEGER NOT NULL,
+      size_bytes INTEGER,
+      PRIMARY KEY (agent_id, path)
+    );
+    INSERT OR REPLACE INTO agent_databases_migration_new (
+      agent_id,
+      path,
+      schema_version,
+      last_seen_at,
+      size_bytes
+    )
+    SELECT
+      agent_id,
+      path,
+      schema_version,
+      last_seen_at,
+      size_bytes
+    FROM agent_databases
+    WHERE agent_id IS NOT NULL AND path IS NOT NULL;
+    DROP TABLE agent_databases;
+    ALTER TABLE agent_databases_migration_new RENAME TO agent_databases;
+  `);
+  return true;
+}
+
+function assertCanonicalStateSchemaShape(db: DatabaseSync, pathname: string): void {
+  if (hasCanonicalAgentDatabasesPrimaryKey(db)) {
+    return;
+  }
+  throw new Error(
+    `OpenClaw state database ${pathname} has a legacy agent database registry schema; run openclaw doctor --fix to migrate it.`,
+  );
+}
+
+export function detectOpenClawStateDatabaseSchemaMigrations(
+  options: OpenClawStateDatabaseOptions = {},
+): OpenClawStateDatabaseSchemaMigration[] {
+  const pathname = resolveDatabasePath(options);
+  if (!existsSync(pathname)) {
+    return [];
+  }
+  const sqlite = requireNodeSqlite();
+  const db = new sqlite.DatabaseSync(pathname, { readOnly: true });
+  try {
+    return hasCanonicalAgentDatabasesPrimaryKey(db)
+      ? []
+      : [{ kind: "agent-databases-composite-primary-key", path: pathname }];
+  } finally {
+    db.close();
+  }
+}
+
+export function repairOpenClawStateDatabaseSchema(options: OpenClawStateDatabaseOptions = {}): {
+  changes: string[];
+  warnings: string[];
+} {
+  const env = options.env ?? process.env;
+  const pathname = resolveDatabasePath(options);
+  if (!existsSync(pathname)) {
+    return { changes: [], warnings: [] };
+  }
+  ensureOpenClawStatePermissions(pathname, env);
+  const sqlite = requireNodeSqlite();
+  const db = new sqlite.DatabaseSync(pathname);
+  db.exec(`PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS};`);
+  try {
+    assertSupportedSchemaVersion(db, pathname);
+    const repaired = runSqliteImmediateTransactionSync(db, () =>
+      repairAgentDatabasesCompositePrimaryKey(db),
+    );
+    return repaired
+      ? {
+          changes: [`Migrated shared state agent database registry primary key → agent_id,path`],
+          warnings: [],
+        }
+      : { changes: [], warnings: [] };
+  } catch (err) {
+    return {
+      changes: [],
+      warnings: [`Failed migrating shared state database schema at ${pathname}: ${String(err)}`],
+    };
+  } finally {
+    db.close();
+    ensureOpenClawStatePermissions(pathname, env);
+  }
 }
 
 function backfillCronRunLogEntryJson(db: DatabaseSync): void {
@@ -657,6 +788,7 @@ function ensureAdditiveStateColumns(db: DatabaseSync): void {
 function ensureSchema(db: DatabaseSync, pathname: string): void {
   assertSupportedSchemaVersion(db, pathname);
   ensureAdditiveStateColumns(db);
+  assertCanonicalStateSchemaShape(db, pathname);
   db.exec(OPENCLAW_STATE_SCHEMA_SQL);
   ensureAdditiveStateColumns(db);
   db.exec(`PRAGMA user_version = ${OPENCLAW_STATE_SCHEMA_VERSION};`);


### PR DESCRIPTION
## Summary
- move the legacy `agent_databases` primary-key repair into `openclaw doctor --fix`
- keep steady-state runtime strict: legacy shared state DBs now fail with a doctor repair hint
- defer plugin doctor migrations until after the shared schema repair so old DBs do not trip plugin-owned writes

## Release note context
Fixes upgrades from legacy shared SQLite state where the agent database registry was keyed only by `agent_id`, causing runtime upserts on `(agent_id, path)` to fail with SQLite `ON CONFLICT` errors. `openclaw doctor --fix` now migrates that shipped DB shape to the current composite key.

## Verification
- `pnpm test src/state/openclaw-agent-db.test.ts src/commands/doctor-state-migrations.test.ts src/commands/doctor.runs-legacy-state-migrations-yes-mode-without.e2e.test.ts -- --reporter=verbose`
- `git diff --check`
- `/Users/steipete/Projects/agent-skills/skills/autoreview/scripts/autoreview --mode local` -> clean, no accepted/actionable findings
