### PR TITLE
ci: check bundled channel config metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1222,6 +1222,9 @@ jobs:
           - check_name: check-shrinkwrap
             task: shrinkwrap
             runner: blacksmith-4vcpu-ubuntu-2404
+          - check_name: check-bundled-channel-config-metadata
+            task: bundled-channel-config-metadata
+            runner: blacksmith-4vcpu-ubuntu-2404
           - check_name: check-prod-types
             task: prod-types
             runner: blacksmith-4vcpu-ubuntu-2404
@@ -1307,6 +1310,9 @@ jobs:
               ;;
             shrinkwrap)
               pnpm deps:shrinkwrap:check
+              ;;
+            bundled-channel-config-metadata)
+              pnpm check:bundled-channel-config-metadata
               ;;
             prod-types)
               pnpm tsgo:prod


### PR DESCRIPTION
Fixes #80536

## What Problem This Solves

`src/config/bundled-channel-config-metadata.generated.ts` is checked in and used by runtime channel config validation. The repository already has `pnpm check:bundled-channel-config-metadata`, but the main CI `check-shard` job did not run it. A PR could therefore change an extension `config-schema.ts`, forget to refresh bundled metadata, and only discover the stale generated file when the gateway rejected the new field at runtime.

## Fix

Add a `check-bundled-channel-config-metadata` entry to the existing `check-shard` matrix and dispatch that task to the existing `pnpm check:bundled-channel-config-metadata` script.

## Real Behavior Proof

### behavior

Before this patch, the normal CI check shard did not run the existing bundled channel config metadata staleness checker. After this patch, the workflow contains both the `check-bundled-channel-config-metadata` matrix entry and the matching dispatch to `pnpm check:bundled-channel-config-metadata`.

### environment

Local OpenClaw checkout on macOS, branch head `dab9eb9509c61a0d1e1d2bdb8ff1ba357e6023e2`, based on `origin/main` at `a7d5d929891136f792832f0c9a159828fe9906c5`.

### steps

Ran a direct workflow-content assertion, then ran the existing metadata checker and whitespace check from the repository root:

```console
$ node -e "const fs=require('fs'); const ci=fs.readFileSync('.github/workflows/ci.yml','utf8'); const hasMatrix=ci.includes('check-bundled-channel-config-metadata') && ci.includes('task: bundled-channel-config-metadata'); const hasCase=ci.includes('bundled-channel-config-metadata)') && ci.includes('pnpm check:bundled-channel-config-metadata'); if (!hasMatrix || !hasCase) { console.error('missing bundled channel config metadata check shard'); process.exit(1); } console.log('bundled channel config metadata check shard present');"
$ pnpm check:bundled-channel-config-metadata
$ git diff --check
```

### evidence

After-patch command output:

```console
$ node -e "const fs=require('fs'); const ci=fs.readFileSync('.github/workflows/ci.yml','utf8'); const hasMatrix=ci.includes('check-bundled-channel-config-metadata') && ci.includes('task: bundled-channel-config-metadata'); const hasCase=ci.includes('bundled-channel-config-metadata)') && ci.includes('pnpm check:bundled-channel-config-metadata'); if (!hasMatrix || !hasCase) { console.error('missing bundled channel config metadata check shard'); process.exit(1); } console.log('bundled channel config metadata check shard present');"
bundled channel config metadata check shard present

$ pnpm check:bundled-channel-config-metadata
$ node --import tsx scripts/generate-bundled-channel-config-metadata.ts --check

$ git diff --check
```

Before the patch, the same workflow-content assertion failed on latest `main` with this output:

```console
missing bundled channel config metadata check shard
```

### observedResult

The workflow now includes the bundled channel config metadata check shard, and the existing generated metadata checker exits 0 on the current generated file.

### notTested

No additional gaps.

## Duplicate Audit

Immediately before pushing, I reran five live open-PR searches:

- `Fixes #80536`: no open PRs
- `#80536`: no open PRs
- `bundled-channel-config-metadata.generated`: no open PRs
- `config-schema codegen validator`: only unrelated #74974
- `must NOT have additional properties channel`: unrelated config/channel PRs #63474, #63380, #63924, #87759, #89850

## Scope Notes

This does not change the generator or regenerate metadata during build. It only makes the existing read-only stale-output guard part of the normal check shard so missing generated metadata is caught in CI instead of at gateway startup.
