### PR TITLE
fix(config): allow per-agent typingMode and typingIntervalSeconds (fixes #62725)

### DIFF
--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -316,6 +316,10 @@ export const FIELD_HELP: Record<string, string> = {
     "When true, defer heartbeat turns on this agent's extra busy lanes: its own session-keyed subagent or nested command work. Cron lanes always defer heartbeat turns.",
   "agents.list[].heartbeat.skipWhenBusy":
     "Per-agent override that defers heartbeat turns on that agent's extra busy lanes: its own session-keyed subagent or nested command work. Cron lanes always defer heartbeat turns.",
+  "agents.list[].typingMode":
+    "Optional per-agent typing mode (never|message|turn). Overrides agents.defaults.typingMode for this agent.",
+  "agents.list[].typingIntervalSeconds":
+    "Optional per-agent typing interval in seconds. Overrides agents.defaults.typingIntervalSeconds for this agent.",
   browser:
     "Browser runtime controls for local or remote CDP attachment, profile routing, and screenshot/snapshot behavior. Keep defaults unless your automation workflow requires custom browser transport settings.",
   "browser.enabled":

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -21,6 +21,7 @@ import {
   ToolsLinksSchema,
   ToolsMediaSchema,
   TtsConfigSchema,
+  TypingModeSchema,
 } from "./zod-schema.core.js";
 import { sensitive } from "./zod-schema.sensitive.js";
 
@@ -1070,6 +1071,8 @@ export const AgentEntrySchema = z
     memorySearch: MemorySearchSchema,
     humanDelay: HumanDelaySchema.optional(),
     tts: TtsConfigSchema,
+    typingMode: TypingModeSchema.optional(),
+    typingIntervalSeconds: z.number().int().positive().optional(),
     skillsLimits: AgentSkillsLimitsSchema,
     contextLimits: AgentContextLimitsSchema,
     contextTokens: z.number().int().positive().optional(),


### PR DESCRIPTION
## Problem

Currently `typingMode` and `typingIntervalSeconds` are only recognized at the global `agents.defaults` level and session level. Setting them on an individual `agents.list[]` entry fails with `'Unrecognized key: "typingMode"'`.

The runtime already reads these values from the per-agent config (e.g., `heartbeat-runner.ts`, `get-reply-run.ts`), but the Zod schema and field help were missing them.

## Fix

- Add `typingMode` and `typingIntervalSeconds` to `AgentEntrySchema`
- Add corresponding field help text for `agents.list[].typingMode` and `agents.list[].typingIntervalSeconds`

## Changes
- `src/config/zod-schema.agent-runtime.ts`: +3 lines (add `typingMode` and `typingIntervalSeconds` to schema)
- `src/config/schema.help.ts`: +4 lines (add field help text)

## Verification
- `tsc --noEmit` passes
- No runtime behavior change; existing code already reads per-agent `typingMode` and `typingIntervalSeconds`

Fixes #62725