### PR TITLE
fix(channels): keep contributed message-tool schema properties optional

### DIFF
--- a/src/channels/plugins/message-action-discovery.ts
+++ b/src/channels/plugins/message-action-discovery.ts
@@ -5,7 +5,7 @@
  */
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
-import type { TSchema } from "typebox";
+import { Type, type TSchema } from "typebox";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { defaultRuntime } from "../../runtime.js";
@@ -361,9 +361,14 @@ function mergeToolSchemaProperties(
     return;
   }
   for (const [name, schema] of Object.entries(source)) {
-    if (!(name in target)) {
-      target[name] = schema;
+    if (name in target) {
+      continue;
     }
+    // Message-tool params dispatch on `action`; no contributed property may be
+    // object-level required. Type.Object treats schemas missing typebox's
+    // non-enumerable `~optional` marker (plain JSON or cloned/serialized plugin
+    // schemas) as required, which fails validation for every message call.
+    target[name] = Type.IsOptional(schema) ? schema : Type.Optional(schema);
   }
 }
 

--- a/src/channels/plugins/message-actions.test.ts
+++ b/src/channels/plugins/message-actions.test.ts
@@ -194,6 +194,48 @@ describe("message action capability checks", () => {
     ).toHaveProperty("components");
   });
 
+  it("keeps contributed schema properties optional so only action stays required", () => {
+    const contributingPlugin: ChannelPlugin = {
+      ...createChannelTestPluginBase({
+        id: "demo-contrib",
+        label: "Demo Contrib",
+        capabilities: { chatTypes: ["direct", "group"] },
+        config: {
+          listAccountIds: () => ["default"],
+        },
+      }),
+      actions: {
+        describeMessageTool: () => ({
+          actions: ["send"],
+          schema: {
+            properties: {
+              // Non-optional TypeBox schema: plugin forgot Type.Optional.
+              components: Type.Array(Type.String()),
+              // Cloning strips typebox's non-enumerable `~optional` marker;
+              // mirrors serialized/external plugin contributions.
+              chatRef: structuredClone(Type.Optional(Type.String())),
+              media: Type.Optional(Type.String()),
+            },
+          },
+        }),
+      },
+    };
+    setActivePluginRegistry(
+      createTestRegistry([
+        { pluginId: "demo-contrib", source: "test", plugin: contributingPlugin },
+      ]),
+    );
+
+    const properties = resolveChannelMessageToolSchemaProperties({
+      cfg: {} as OpenClawConfig,
+      channel: "demo-contrib",
+    });
+    // Regression: required leakage made every message tool call fail validation
+    // with "must have required properties chatRef, media, ...".
+    const toolSchema = Type.Object({ action: Type.String(), ...properties });
+    expect(toolSchema.required).toEqual(["action"]);
+  });
+
   it("filters only actions that depend on current-channel-only schema", () => {
     const scopedSchemaPlugin: ChannelPlugin = {
       ...createChannelTestPluginBase({


### PR DESCRIPTION
## Summary

- Channel-plugin `describeMessageTool` schema contributions are merged into the `message` tool's `Type.Object`. typebox 1.1.39 marks optionality with a **non-enumerable** `~optional` property, so any contribution that is plain JSON, or a TypeBox schema that crossed a clone/serialization boundary (spread, `structuredClone`, JSON round-trip), silently loses the marker and `Type.Object` promotes it to **required**.
- Contributions are spread last in `buildMessageToolSchemaProps`, so they can also shadow core optional props (`message`, `media`, `caption`, ...) and drag those into `required` too. Result: every `message(action="send", ...)` call fails validation with `must have required properties ...` across all channels. Symptoms vary by which channels are configured, which made the bug look non-deterministic.
- Fix at the contribution-merge boundary (`mergeToolSchemaProperties` in `src/channels/plugins/message-action-discovery.ts`): wrap any non-optional contributed property with `Type.Optional`. The message tool dispatches on `action`; `action` is the only required property by contract.
- This is the same failure class as the earlier `buttons`/`components` bugs (#54385/#56496/#57108, PR #54418). #54418 fixed one contributor; this fixes the seam so no contributor can regress it again.
- Out of scope: schema normalization/flattening in `agent-tools-parameter-schema.ts` (verified not the cause) and any per-plugin schema changes.
- Reviewer focus: the one-line invariant in `mergeToolSchemaProperties` and whether forcing optionality at this seam is the right ownership boundary (vs. per-plugin fixes).

## Linked context

Closes #67852

Related #56496, #57108, #54385, #54800 (prior instances of the same required-leak class; #54418 fixed the `buttons` contributor, this fixes the merge seam)

Was this requested by a maintainer or owner? No — bug encountered in production on v2026.6.1.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: `message` tool failed schema validation on every call (`must have required properties media, caption, asVoice, chatRef, ...`) on OpenClaw 2026.6.1 across SimpleX, Signal, Discord, and Telegram.
- Real environment tested: patched v2026.6.1 (`2e08f0f` + this commit cherry-picked), Node v22.22.3, macOS, channels: SimpleX, Signal.
- Exact steps or command run after this patch: rebuilt dist, restarted gateway, had the agent call `message(action="send", target=..., message=...)` on each channel.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): see screenshot below
- Observed result after fix: `message(action="send")` validates and delivers on all configured channels.
- What was not tested: non-send actions on every channel (react/poll/etc. providers other than Signal and SimpleX.
- Proof limitations or environment constraints: none significant — tested on a production-mirroring install.
- Before evidence (optional but encouraged): `Validation failed for tool "message": ... must have required properties media, caption, asVoice, messageId, ...`

BEFORE
<img width="960" height="502" alt="Screenshot 2026-06-07 at 3 42 57 AM" src="https://github.com/user-attachments/assets/9bbc7d99-cc31-4c11-a469-1781064008d7" />

AFTER
<img width="1077" height="861" alt="Screenshot 2026-06-07 at 2 21 39 AM" src="https://github.com/user-attachments/assets/4b2f3dea-75cf-478e-9307-93d780a4fd42" />

## Tests and validation

Which commands did you run?

- `pnpm test src/channels/plugins/message-actions.test.ts` — 11/11 passed
- `pnpm test src/agents/tools/message-tool.test.ts` — 98/98 passed
- oxlint + oxfmt clean on touched files
- Same two suites pass with this commit cherry-picked onto `v2026.6.1` (11/11, 94/94)

What regression coverage was added or updated?

`src/channels/plugins/message-actions.test.ts`: a plugin contributing (a) a non-optional TypeBox schema and (b) a `structuredClone`-stripped optional schema; asserts the assembled tool schema's `required` is exactly `["action"]`.

What failed before this fix, if known?

The new test fails on `main` with `required: ["action", "components", "chatRef"]`. At runtime, every `message` tool call failed validation when any configured channel contributed a marker-less schema property.

If no test was added, why not?

n/a — test added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes — `message` tool calls validate again; contributed params are now uniformly optional.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

A plugin that intended a contributed property to be object-level required would lose that.

How is that risk mitigated?

No in-tree contributor does this, and a cross-action required param cannot work on a multi-action tool — that is the bug class itself (see #56496).

## Current review state

What is the next action?

Maintainer review.

What is still waiting on author, maintainer, CI, or external proof?

Nothing waiting on author; after-fix screenshots attached above.

Which bot or reviewer comments were addressed?

None yet.
