### PR TITLE
fix(codex): mark incomplete turns unsafe to blindly retry

### DIFF
--- a/extensions/codex/src/conversation-turn-collector.test.ts
+++ b/extensions/codex/src/conversation-turn-collector.test.ts
@@ -1,7 +1,10 @@
 // Codex tests cover conversation turn collector plugin behavior.
 import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createCodexConversationTurnCollector } from "./conversation-turn-collector.js";
+import {
+  CODEX_TURN_INCOMPLETE_RETRY_WARNING,
+  createCodexConversationTurnCollector,
+} from "./conversation-turn-collector.js";
 
 describe("codex conversation turn collector", () => {
   afterEach(() => {
@@ -188,7 +191,7 @@ describe("codex conversation turn collector", () => {
     try {
       const collector = createCodexConversationTurnCollector("thread-1");
       const completion = collector.wait({ timeoutMs: 100 });
-      const assertion = expect(completion).rejects.toThrow("codex app-server bound turn timed out");
+      const assertion = expect(completion).rejects.toThrow(CODEX_TURN_INCOMPLETE_RETRY_WARNING);
       await vi.advanceTimersByTimeAsync(100);
       await assertion;
     } finally {

--- a/extensions/codex/src/conversation-turn-collector.ts
+++ b/extensions/codex/src/conversation-turn-collector.ts
@@ -12,6 +12,8 @@ import {
 } from "./app-server/protocol.js";
 
 const MAX_PENDING_NOTIFICATIONS_PER_TURN = 100;
+export const CODEX_TURN_INCOMPLETE_RETRY_WARNING =
+  "Codex stopped before confirming the turn was complete. Some work may already have been performed; verify the current state before retrying.";
 
 export function createCodexConversationTurnCollector(threadId: string) {
   let turnId: string | undefined;
@@ -142,7 +144,7 @@ export function createCodexConversationTurnCollector(threadId: string) {
         timeout = setTimeout(
           () => {
             completed = true;
-            reject(new Error("codex app-server bound turn timed out"));
+            reject(new Error(CODEX_TURN_INCOMPLETE_RETRY_WARNING));
             clearWaitState();
           },
           resolveTimerTimeoutMs(params.timeoutMs, 100, 100),


### PR DESCRIPTION
## Summary
- replace the Codex bound-turn timeout error with an explicit incomplete-turn warning
- tell callers that partial work may already have happened and state must be verified before retrying
- update the collector timeout test to assert the stable warning constant

## Why
Linda reported the runtime message: "Codex stopped before confirming the turn was complete. Some work may already have been performed; verify the current state before retrying."

The old collector error said only "codex app-server bound turn timed out", which is both less actionable and more likely to be treated as a generic retryable timeout. The new message makes blind retry unsafe by construction.

## Real behavior proof

- Behavior or issue addressed: A Codex app-server bound turn that stops before completion should surface an incomplete-turn warning that tells the caller partial work may already exist and current state must be verified before retrying.
- Real environment tested: Clean local checkout of this PR branch at `/home/chrisb/openclaw-codex-turn-error-handling`, branch `fix/codex-turn-incomplete-error-handling`, Node v22.22.1. This was checked on a real OpenClaw development workstation.
- Exact steps or command run after this patch: Ran `rg -n "CODEX_TURN_INCOMPLETE_RETRY_WARNING|bound turn timed out|stopped before confirming" extensions/codex/src/conversation-turn-collector.ts extensions/codex/src/conversation-turn-collector.test.ts` after applying the patch.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```console
$ rg -n "CODEX_TURN_INCOMPLETE_RETRY_WARNING|bound turn timed out|stopped before confirming" extensions/codex/src/conversation-turn-collector.ts extensions/codex/src/conversation-turn-collector.test.ts
extensions/codex/src/conversation-turn-collector.test.ts:5:  CODEX_TURN_INCOMPLETE_RETRY_WARNING,
extensions/codex/src/conversation-turn-collector.test.ts:194:      const assertion = expect(completion).rejects.toThrow(CODEX_TURN_INCOMPLETE_RETRY_WARNING);
extensions/codex/src/conversation-turn-collector.ts:15:export const CODEX_TURN_INCOMPLETE_RETRY_WARNING =
extensions/codex/src/conversation-turn-collector.ts:16:  "Codex stopped before confirming the turn was complete. Some work may already have been performed; verify the current state before retrying.";
extensions/codex/src/conversation-turn-collector.ts:147:            reject(new Error(CODEX_TURN_INCOMPLETE_RETRY_WARNING));
```

- Observed result after fix: The collector timeout path now rejects with `CODEX_TURN_INCOMPLETE_RETRY_WARNING`, and the timeout test asserts that same stable warning. The old generic `codex app-server bound turn timed out` wording no longer appears in the collector/test paths checked above.
- What was not tested: Targeted Vitest was blocked locally because this shell has no `pnpm` installed, and `corepack pnpm vitest run extensions/codex/src/conversation-turn-collector.test.ts` fails before test startup with `ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING` from Corepack under Node v22.22.1.
- Proof limitations or environment constraints: I could verify the patched timeout message in source and test expectations from a real checkout, but could not execute the targeted Vitest lane locally due the Corepack failure above.
- Before evidence (optional but encouraged): Before this patch, the timeout path rejected with `new Error("codex app-server bound turn timed out")`.

## Verification
- `git diff --check`

## Not Run
- Targeted Vitest: local shell has no `pnpm` installed; `corepack pnpm vitest run extensions/codex/src/conversation-turn-collector.test.ts` fails before test startup with `ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING` from Corepack under Node v22.22.1.
