### PR TITLE
Project channel activity into gateway health snapshots

### DIFF
--- a/src/commands/health.test.ts
+++ b/src/commands/health.test.ts
@@ -1,6 +1,7 @@
 // Health command tests cover gateway health probes, JSON output, and status formatting.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { stripAnsi } from "../../packages/terminal-core/src/ansi.js";
+import { recordChannelActivity, resetChannelActivityForTest } from "../infra/channel-activity.js";
 import {
   buildCredentialsRequiredHealthDiagnostic,
   GATEWAY_HEALTH_CREDENTIALS_REQUIRED_MESSAGE,
@@ -12,6 +13,7 @@ import {
   formatContextEngineHealthLine,
   formatHealthChannelLines,
   formatModelPricingHealthLine,
+  getHealthSnapshot,
   healthCommand,
 } from "./health.js";
 
@@ -80,6 +82,9 @@ const buildGatewayProbeConnectionDetailsMock = vi.fn(() => ({
 }));
 const formatGatewayTransportErrorJsonMock = vi.fn();
 const probeGatewayStatusMock = vi.fn();
+const healthConfigMock = vi.fn(() => ({}));
+const loadSessionStoreMock = vi.fn(() => ({}));
+const listReadOnlyChannelPluginsForConfigMock = vi.fn(() => []);
 vi.mock("../gateway/call.js", () => ({
   callGateway: (...args: unknown[]) => callGatewayMock(...args),
   buildGatewayConnectionDetails: (...args: [unknown, ...unknown[]]) =>
@@ -96,9 +101,26 @@ vi.mock("../cli/daemon-cli/probe.js", () => ({
   probeGatewayStatus: (...args: unknown[]) => probeGatewayStatusMock(...args),
 }));
 
-vi.mock("../channels/plugins/read-only.js", () => ({
-  listReadOnlyChannelPluginsForConfig: () => [],
+vi.mock("../config/config.js", () => ({
+  getRuntimeConfig: () => healthConfigMock(),
+  readBestEffortConfig: () => healthConfigMock(),
 }));
+
+vi.mock("../config/sessions/store.js", () => ({
+  loadSessionStore: () => loadSessionStoreMock(),
+}));
+
+vi.mock("../channels/plugins/read-only.js", () => ({
+  listReadOnlyChannelPluginsForConfig: (...args: unknown[]) =>
+    listReadOnlyChannelPluginsForConfigMock(...args),
+}));
+
+beforeEach(() => {
+  healthConfigMock.mockReturnValue({});
+  loadSessionStoreMock.mockReturnValue({});
+  listReadOnlyChannelPluginsForConfigMock.mockReturnValue([]);
+  resetChannelActivityForTest();
+});
 
 function requireFirstRuntimeLog(): string {
   const [call] = runtime.log.mock.calls;
@@ -123,6 +145,64 @@ function requireFirstGatewayRequest(): Record<string, unknown> {
   }
   return request as Record<string, unknown>;
 }
+
+describe("getHealthSnapshot", () => {
+  it("projects recorded channel activity onto fresh health snapshots", async () => {
+    healthConfigMock.mockReturnValue({
+      agents: { list: [{ id: "main" }] },
+      channels: { discord: {} },
+    });
+    listReadOnlyChannelPluginsForConfigMock.mockReturnValue([
+      {
+        id: "discord",
+        meta: { label: "Discord" },
+        config: {
+          listAccountIds: () => ["default"],
+          resolveAccount: () => ({ configured: true, enabled: true }),
+          inspectAccount: () => ({ configured: true, enabled: true }),
+          isEnabled: () => true,
+          isConfigured: () => true,
+        },
+      },
+    ]);
+    recordChannelActivity({
+      channel: "discord",
+      accountId: "default",
+      direction: "inbound",
+      at: 111,
+    });
+    recordChannelActivity({
+      channel: "discord",
+      accountId: "default",
+      direction: "outbound",
+      at: 222,
+    });
+
+    const summary = await getHealthSnapshot({
+      probe: false,
+      runtimeSnapshot: {
+        channels: {},
+        channelAccounts: {
+          discord: {
+            default: {
+              accountId: "default",
+              configured: true,
+              running: true,
+              connected: true,
+              lastInboundAt: 500,
+            },
+          },
+        },
+      },
+    });
+
+    const discord = summary.channels.discord;
+    expect(discord?.lastInboundAt).toBe(500);
+    expect(discord?.lastOutboundAt).toBe(222);
+    expect(discord?.accounts?.default?.lastInboundAt).toBe(500);
+    expect(discord?.accounts?.default?.lastOutboundAt).toBe(222);
+  });
+});
 
 describe("healthCommand", () => {
   beforeEach(() => {

--- a/src/commands/health.test.ts
+++ b/src/commands/health.test.ts
@@ -111,7 +111,7 @@ vi.mock("../config/sessions/store.js", () => ({
 }));
 
 vi.mock("../channels/plugins/read-only.js", () => ({
-  listReadOnlyChannelPluginsForConfig: (...args: unknown[]) =>
+  listReadOnlyChannelPluginsForConfig: (...args: Parameters<typeof import("../channels/plugins/read-only.js").listReadOnlyChannelPluginsForConfig>) =>
     listReadOnlyChannelPluginsForConfigMock(...args),
 }));
 
@@ -163,7 +163,7 @@ describe("getHealthSnapshot", () => {
           isEnabled: () => true,
           isConfigured: () => true,
         },
-      },
+      } as never,
     ]);
     recordChannelActivity({
       channel: "discord",

--- a/src/commands/health.test.ts
+++ b/src/commands/health.test.ts
@@ -111,8 +111,8 @@ vi.mock("../config/sessions/store.js", () => ({
 }));
 
 vi.mock("../channels/plugins/read-only.js", () => ({
-  listReadOnlyChannelPluginsForConfig: (...args: Parameters<typeof import("../channels/plugins/read-only.js").listReadOnlyChannelPluginsForConfig>) =>
-    listReadOnlyChannelPluginsForConfigMock(...args),
+  listReadOnlyChannelPluginsForConfig: (...args: [unknown, ...unknown[]]) =>
+    Reflect.apply(listReadOnlyChannelPluginsForConfigMock, undefined, args),
 }));
 
 beforeEach(() => {

--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -200,7 +200,6 @@ function mergeRecordedActivityTimestamp(params: {
   const existing = params.account[params.key];
   if (existing == null) {
     params.account[params.key] = params.recorded;
-    return;
   }
 }
 

--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -13,7 +13,7 @@ import { resolveChannelDefaultAccountId } from "../channels/plugins/helpers.js";
 import { listReadOnlyChannelPluginsForConfig } from "../channels/plugins/read-only.js";
 import { buildChannelAccountSnapshotFromAccount } from "../channels/plugins/status.js";
 import type { ChannelPlugin } from "../channels/plugins/types.plugin.js";
-import type { ChannelAccountSnapshot } from "../channels/plugins/types.public.js";
+import type { ChannelAccountSnapshot, ChannelId } from "../channels/plugins/types.public.js";
 import { probeGatewayStatus } from "../cli/daemon-cli/probe.js";
 import { withProgress } from "../cli/progress.js";
 import { resolveStorePath } from "../config/sessions/paths.js";
@@ -38,6 +38,7 @@ import { info } from "../globals.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { resolveHeartbeatSummaryForAgent } from "../infra/heartbeat-summary.js";
+import { getChannelActivity } from "../infra/channel-activity.js";
 import { getActivePluginRegistry } from "../plugins/runtime.js";
 import { buildChannelAccountBindings, resolvePreferredAccountId } from "../routing/bindings.js";
 import { normalizeAgentId } from "../routing/session-key.js";
@@ -186,6 +187,42 @@ function buildContextEngineHealthSummary(): ContextEngineHealthSummary | undefin
     quarantined.push(summary);
   }
   return quarantined.length > 0 ? { quarantined } : undefined;
+}
+
+function mergeRecordedActivityTimestamp(params: {
+  account: Record<string, unknown>;
+  key: "lastInboundAt" | "lastOutboundAt";
+  recorded: number | null;
+}) {
+  if (typeof params.recorded !== "number" || !Number.isFinite(params.recorded)) {
+    return;
+  }
+  const existing = params.account[params.key];
+  if (existing == null) {
+    params.account[params.key] = params.recorded;
+    return;
+  }
+}
+
+function projectRecordedChannelActivity(params: {
+  channelId: ChannelId;
+  account: ChannelAccountHealthSummary | ChannelAccountSnapshot;
+}) {
+  const activity = getChannelActivity({
+    channel: params.channelId,
+    accountId: params.account.accountId,
+  });
+  const account = params.account as Record<string, unknown>;
+  mergeRecordedActivityTimestamp({
+    account,
+    key: "lastInboundAt",
+    recorded: activity.inboundAt,
+  });
+  mergeRecordedActivityTimestamp({
+    account,
+    key: "lastOutboundAt",
+    recorded: activity.outboundAt,
+  });
 }
 
 /** Formats context engine quarantine state for text health output. */
@@ -544,6 +581,10 @@ export async function getHealthSnapshot(params?: {
       if (lastProbeAt) {
         snapshot.lastProbeAt = lastProbeAt;
       }
+      projectRecordedChannelActivity({
+        channelId: plugin.id,
+        account: snapshot,
+      });
       const health = evaluateChannelHealth(snapshot, {
         channelId: plugin.id,
         now: Date.now(),
@@ -589,6 +630,10 @@ export async function getHealthSnapshot(params?: {
         record.lastProbeAt = lastProbeAt;
       }
       record.accountId = accountId;
+      projectRecordedChannelActivity({
+        channelId: plugin.id,
+        account: record,
+      });
       accountSummaries[accountId] = record;
     }
 

--- a/src/gateway/server-methods/health.ts
+++ b/src/gateway/server-methods/health.ts
@@ -1,10 +1,11 @@
 // Health gateway methods return cached or refreshed status summaries while
 // detecting stale channel runtime state against live gateway snapshots.
 import { ErrorCodes, errorShape } from "../../../packages/gateway-protocol/src/index.js";
-import type { ChannelAccountSnapshot } from "../../channels/plugins/types.public.js";
+import type { ChannelAccountSnapshot, ChannelId } from "../../channels/plugins/types.public.js";
 import type { ChannelHealthSummary, HealthSummary } from "../../commands/health.types.js";
 import { getStatusSummary } from "../../commands/status.js";
 import { listContextEngineQuarantines } from "../../context-engine/registry.js";
+import { getChannelActivity } from "../../infra/channel-activity.js";
 import { getGatewayModelPricingHealth } from "../model-pricing-cache-state.js";
 import type { ChannelRuntimeSnapshot } from "../server-channel-runtime.types.js";
 import { HEALTH_REFRESH_INTERVAL_MS } from "../server-constants.js";
@@ -87,6 +88,80 @@ function cachedHealthDiffersFromRuntime(
   return false;
 }
 
+function mergeCachedActivityTimestamp(params: {
+  account: Record<string, unknown>;
+  key: "lastInboundAt" | "lastOutboundAt";
+  recorded: number | null;
+}) {
+  if (typeof params.recorded !== "number" || !Number.isFinite(params.recorded)) {
+    return;
+  }
+  const existing = params.account[params.key];
+  if (existing == null) {
+    params.account[params.key] = params.recorded;
+    return;
+  }
+  if (typeof existing === "number") {
+    params.account[params.key] = Math.max(existing, params.recorded);
+  }
+}
+
+function mergeCachedAccountActivity(params: {
+  channelId: ChannelId;
+  account: ChannelHealthSummary;
+}): ChannelHealthSummary {
+  const account = { ...params.account };
+  const activity = getChannelActivity({
+    channel: params.channelId,
+    accountId: account.accountId,
+  });
+  mergeCachedActivityTimestamp({
+    account,
+    key: "lastInboundAt",
+    recorded: activity.inboundAt,
+  });
+  mergeCachedActivityTimestamp({
+    account,
+    key: "lastOutboundAt",
+    recorded: activity.outboundAt,
+  });
+  return account;
+}
+
+function mergeCachedChannelActivity(params: {
+  channelId: ChannelId;
+  channel: ChannelHealthSummary;
+}): ChannelHealthSummary {
+  const accounts = params.channel.accounts
+    ? Object.fromEntries(
+        Object.entries(params.channel.accounts).map(([accountId, account]) => [
+          accountId,
+          mergeCachedAccountActivity({
+            channelId: params.channelId,
+            account,
+          }),
+        ]),
+      )
+    : undefined;
+  const channel = mergeCachedAccountActivity({
+    channelId: params.channelId,
+    account: params.channel,
+  });
+  return {
+    ...channel,
+    ...(accounts ? { accounts } : {}),
+  };
+}
+
+function mergeCachedHealthChannelActivity(channels: HealthSummary["channels"]) {
+  return Object.fromEntries(
+    Object.entries(channels).map(([channelId, channel]) => [
+      channelId,
+      mergeCachedChannelActivity({ channelId: channelId as ChannelId, channel }),
+    ]),
+  );
+}
+
 /** Merges cheap live runtime facts into a cached health summary before responding. */
 function mergeCachedHealthRuntimeState(params: {
   cached: HealthSummary;
@@ -108,6 +183,7 @@ function mergeCachedHealthRuntimeState(params: {
   }
   return {
     ...cached,
+    channels: mergeCachedHealthChannelActivity(cached.channels),
     ...(params.eventLoop ? { eventLoop: params.eventLoop } : {}),
     ...(quarantinedContextEngines.length > 0
       ? { contextEngines: { quarantined: quarantinedContextEngines } }

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -19,6 +19,7 @@ import {
   resolveContextEngine,
 } from "../../context-engine/registry.js";
 import { emitAgentEvent } from "../../infra/agent-events.js";
+import { recordChannelActivity, resetChannelActivityForTest } from "../../infra/channel-activity.js";
 import { formatZonedTimestamp } from "../../infra/format-time/format-datetime.js";
 import {
   buildSystemRunApprovalBinding,
@@ -3590,6 +3591,7 @@ describe("gateway healthHandlers.health cache freshness", () => {
 
   beforeEach(() => {
     pricingState.clearGatewayModelPricingCacheState();
+    resetChannelActivityForTest();
     registerLegacyContextEngine();
     clearContextEnginesForOwner(contextEngineTestOwner);
     clearContextEngineRuntimeQuarantine();
@@ -3597,6 +3599,7 @@ describe("gateway healthHandlers.health cache freshness", () => {
 
   afterEach(() => {
     pricingState.clearGatewayModelPricingCacheState();
+    resetChannelActivityForTest();
     clearContextEnginesForOwner(contextEngineTestOwner);
     clearContextEngineRuntimeQuarantine();
   });
@@ -3877,6 +3880,72 @@ describe("gateway healthHandlers.health cache freshness", () => {
     } finally {
       consoleError.mockRestore();
     }
+  });
+
+  it("merges recorded channel activity into cached health responses without backdating", async () => {
+    const cached = {
+      ok: true,
+      ts: Date.now(),
+      durationMs: 1,
+      channels: {
+        discord: {
+          accountId: "default",
+          configured: true,
+          lastInboundAt: 500,
+          lastOutboundAt: 100,
+          accounts: {
+            default: {
+              accountId: "default",
+              configured: true,
+              lastInboundAt: 500,
+              lastOutboundAt: 100,
+            },
+          },
+        },
+      },
+      channelOrder: ["discord"],
+      channelLabels: { discord: "Discord" },
+      heartbeatSeconds: 0,
+      defaultAgentId: "main",
+      agents: [],
+      sessions: { path: "/tmp/sessions.json", count: 0, recent: [] },
+    };
+    recordChannelActivity({
+      channel: "discord",
+      accountId: "default",
+      direction: "inbound",
+      at: 250,
+    });
+    recordChannelActivity({
+      channel: "discord",
+      accountId: "default",
+      direction: "outbound",
+      at: 900,
+    });
+    const respond = vi.fn();
+    const refreshHealthSnapshot = vi.fn().mockResolvedValue(cached);
+
+    await healthHandlers.health({
+      req: {} as never,
+      params: {} as never,
+      respond: respond as never,
+      context: {
+        getHealthCache: () => cached,
+        refreshHealthSnapshot,
+        getRuntimeSnapshot: () => ({ channels: {}, channelAccounts: {} }),
+        logHealth: { error: vi.fn() },
+      } as never,
+      client: { connect: { role: "operator", scopes: ["operator.read"] } } as never,
+      isWebchatConnect: () => false,
+    });
+
+    const payload = mockCallArg(respond, 0, 1) as typeof cached;
+    expect(payload.channels.discord.lastInboundAt).toBe(500);
+    expect(payload.channels.discord.lastOutboundAt).toBe(900);
+    expect(payload.channels.discord.accounts.default.lastInboundAt).toBe(500);
+    expect(payload.channels.discord.accounts.default.lastOutboundAt).toBe(900);
+    expect(cached.channels.discord.lastOutboundAt).toBe(100);
+    expect(mockCallArg(respond, 0, 3)).toEqual({ cached: true });
   });
 
   it("refreshes cached health when a runtime account is missing from the cached account summary", async () => {


### PR DESCRIPTION
Fixes openclaw/openclaw#90985.

## Summary

Project recorded channel activity timestamps into gateway health snapshots so the health/status surface reflects known inbound and outbound activity.

- **Fresh snapshots** fill `lastInboundAt` and `lastOutboundAt` from the channel activity tracker when plugin/runtime snapshots do not already provide them. An existing runtime-sourced timestamp is never overwritten.
- **Cached health responses** merge recorded channel activity before returning. Newer cached timestamps are preserved — no backdating.
- The original cached object is never mutated; the merge works on a clone.

This does not send messages, probe channels, or change runtime channel behavior. It only updates the health/status surface.

## Changed files

| File | What changed |
|---|---|
| `src/commands/health.ts` | `projectRecordedChannelActivity` helper, called in `getHealthSnapshot` |
| `src/gateway/server-methods/health.ts` | `mergeCachedAccountActivity` / `mergeCachedChannelActivity` helpers, called in `mergeCachedHealthRuntimeState` |
| `src/commands/health.test.ts` | New `getHealthSnapshot` describe block |
| `src/gateway/server-methods/server-methods.test.ts` | New cached health activity merge test |

## Real behavior proof

**Behavior or issue addressed:** `getHealthSnapshot` and the cached health merge path did not project recorded channel activity timestamps into health responses, while the sibling `getStatusSummary` in `src/commands/status.js` already did. This meant `lastInboundAt` and `lastOutboundAt` were missing from gateway health output even when the channel activity tracker had recorded values.

**Real environment tested:** Windows 11, Node 24.15.0, openclaw repository at commit `a4f8de6945` on branch `fix/gateway-health-channel-activity`. I do not have a live OpenClaw gateway running locally. The behavior gap was confirmed by source inspection.

**Exact steps or command run after fix:**

```
node scripts/run-vitest.mjs run src/commands/health.test.ts src/gateway/server-methods/server-methods.test.ts --maxWorkers 1 --testTimeout 15000 --reporter=verbose
```

**Evidence after fix:**

```
✓ getHealthSnapshot › projects recorded channel activity onto fresh health snapshots  20ms
✓ gateway healthHandlers.health cache freshness › merges recorded channel activity into cached health responses without backdating  1ms

Test Files  2 passed (2)
Tests       140 passed (140)
```

The tests exercise the real `recordChannelActivity` / `getChannelActivity` logic directly — those helpers are not mocked. The assertions verify concrete timestamp values flowing through the patched code paths.

**Observed result after fix:** Fresh health snapshots correctly fill missing `lastOutboundAt` from the activity tracker while preserving an existing runtime `lastInboundAt: 500`. Cached health merge correctly picks the newer of recorded vs cached outbound timestamp (`900 > 100`) and does not backdate a newer cached inbound (`500 > 250`). The original cached object is confirmed unmutated after merge.

A maintainer with a running gateway can verify live with:

```
pnpm openclaw health --json
```

Look for `lastInboundAt` and `lastOutboundAt` populated in channel entries after any channel activity is recorded.

**What was not tested:** Live gateway JSON output — no running OpenClaw instance available locally. Discord plugin accounting, provider/auth paths, fallback behavior, Windows portability fixes (kept on a separate branch).

## Out of scope

- Discord plugin accounting changes
- Runtime patch files
- Provider / auth changes
- Fallback behavior
- Semantic memory changes
- Gateway service / always-on changes
- Windows portability fixes (separate branch)

## AI-assisted

Built with OpenAI Codex. I reviewed and understand the changes. The fix mirrors the existing pattern in `src/commands/status.js` which already projects channel activity onto the channels status surface.