### PR TITLE
fix(telegram): improve section spacing in replies

### DIFF
--- a/extensions/telegram/src/format.test.ts
+++ b/extensions/telegram/src/format.test.ts
@@ -31,11 +31,57 @@ describe("markdownToTelegramHtml", () => {
       ["renders paragraphs with blank lines", "first\n\nsecond", "first\n\nsecond"],
       ["renders lists without block HTML", "- one\n- two", "• one\n• two"],
       ["renders ordered lists with numbering", "2. two\n3. three", "2. two\n3. three"],
-      ["flattens headings", "# Title", "Title"],
+      ["renders headings as bold Telegram sections", "# Title", "<b>Title</b>"],
     ] as const;
     for (const [name, input, expected] of cases) {
       expect(markdownToTelegramHtml(input), name).toBe(expected);
     }
+  });
+
+  it("adds breathing room around Telegram section headings", () => {
+    const input = [
+      "Construct validity: moderate",
+      "SPS is plausible but may not be an adequate dose.",
+      "",
+      "Less certain for:",
+      "- Early intervention",
+      "- Younger people newly presenting",
+    ].join("\n");
+
+    expect(markdownToTelegramHtml(input, { wrapFileRefs: false })).toBe(
+      [
+        "<b>Construct validity: moderate</b>",
+        "",
+        "SPS is plausible but may not be an adequate dose.",
+        "",
+        "<b>Less certain for:</b>",
+        "",
+        "• Early intervention",
+        "• Younger people newly presenting",
+      ].join("\n"),
+    );
+  });
+
+  it("spaces styled heading lines before body text", () => {
+    const input = ["**Policy significance: high**", "The effect is small."].join("\n");
+
+    expect(markdownToTelegramHtml(input, { wrapFileRefs: false })).toBe(
+      ["<b>Policy significance: high</b>", "", "The effect is small."].join("\n"),
+    );
+  });
+
+  it("does not treat list items with bold lead-ins as section headings", () => {
+    const input = [
+      "1. **Direct clinical contact:** AP roles and supervised client-facing work.",
+      "2. **Research:** trials and implementation work.",
+    ].join("\n");
+
+    expect(markdownToTelegramHtml(input, { wrapFileRefs: false })).toBe(
+      [
+        "1. <b>Direct clinical contact:</b> AP roles and supervised client-facing work.",
+        "2. <b>Research:</b> trials and implementation work.",
+      ].join("\n"),
+    );
   });
 
   it("preserves supported Telegram HTML in stream markdown rendering", () => {
@@ -190,6 +236,14 @@ describe("markdownToTelegramHtml", () => {
     const res = markdownToTelegramHtml(input, { wrapFileRefs: false });
 
     expect(res).toBe("<pre><code>  • literal bullet\n3. literal number\n</code></pre>");
+  });
+
+  it("does not promote Telegram section headings inside fenced code", () => {
+    const input = ["```", "Clinical significance: weak", "body", "```"].join("\n");
+
+    const res = markdownToTelegramHtml(input, { wrapFileRefs: false });
+
+    expect(res).toBe("<pre><code>Clinical significance: weak\nbody\n</code></pre>");
   });
 
   it("does not insert Telegram list boundary spacing inside indented code", () => {

--- a/extensions/telegram/src/format.ts
+++ b/extensions/telegram/src/format.ts
@@ -96,12 +96,59 @@ function isTelegramBulletLine(line: string): boolean {
   return /^[ \t]*(?:[•*+-])[ \t]+\S/.test(line);
 }
 
+function isTelegramListLine(line: string): boolean {
+  return /^[ \t]*(?:[•*+-]|\d+[.)])[ \t]+\S/.test(line);
+}
+
 function isTelegramListBoundaryLine(line: string): boolean {
   return /^[ \t]*(?:\d+\.|#{1,6})[ \t]+\S/.test(line);
 }
 
 function isMarkdownIndentedCodeLine(line: string): boolean {
   return /^(?: {4}|\t)/.test(line);
+}
+
+function isMarkdownHeadingLine(line: string): boolean {
+  return /^[ \t]{0,3}#{1,6}[ \t]+\S/.test(line);
+}
+
+function isMarkdownStyledSectionHeadingLine(line: string): boolean {
+  const trimmed = line.trim();
+  return (
+    /^(?:\*\*[^*\n]{1,160}\*\*|__[^_\n]{1,160}__)\s*$/.test(trimmed) ||
+    /^(?:\*[^*\n]{1,160}\*|_[^_\n]{1,160}_)\s*$/.test(trimmed)
+  );
+}
+
+function isPlainTelegramSectionHeadingLine(line: string): boolean {
+  if (leadingWhitespaceLength(line) > 0) {
+    return false;
+  }
+  const trimmed = line.trim();
+  if (
+    trimmed.length < 4 ||
+    trimmed.length > 120 ||
+    trimmed.startsWith("<") ||
+    trimmed.startsWith(">") ||
+    trimmed.startsWith("#") ||
+    isTelegramListLine(line) ||
+    /[.!?]$/.test(trimmed)
+  ) {
+    return false;
+  }
+  const colonIndex = trimmed.indexOf(":");
+  if (colonIndex <= 0 || colonIndex > 80) {
+    return false;
+  }
+  return /^[A-Z0-9]/.test(trimmed);
+}
+
+function isTelegramSectionHeadingLine(line: string): boolean {
+  return (
+    isMarkdownHeadingLine(line) ||
+    isMarkdownStyledSectionHeadingLine(line) ||
+    isPlainTelegramSectionHeadingLine(line)
+  );
 }
 
 function shouldPreserveTelegramListBoundarySpacing(previous: string, next: string): boolean {
@@ -136,14 +183,62 @@ function preserveTelegramListBoundarySpacing(markdown: string): string {
   return out.join("\n");
 }
 
+function stylePlainTelegramSectionHeading(line: string): string {
+  return isPlainTelegramSectionHeadingLine(line) ? `**${line.trim()}**` : line;
+}
+
+function improveTelegramSectionSpacing(markdown: string): string {
+  const lines = markdown.split("\n");
+  const out: string[] = [];
+  let inFence = false;
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index] ?? "";
+    const normalizedLine = line.replace(/\r$/, "");
+    const isFenceLine = /^[ \t]*(?:```|~~~)/.test(normalizedLine);
+
+    if (inFence) {
+      out.push(line);
+      if (isFenceLine) {
+        inFence = false;
+      }
+      continue;
+    }
+
+    if (isFenceLine) {
+      out.push(line);
+      inFence = true;
+      continue;
+    }
+
+    const headingLine = isTelegramSectionHeadingLine(normalizedLine);
+    if (headingLine && out.length > 0 && out[out.length - 1]?.trim()) {
+      out.push("");
+    }
+
+    out.push(stylePlainTelegramSectionHeading(line));
+
+    const nextLine = lines[index + 1];
+    if (headingLine && nextLine !== undefined && nextLine.trim()) {
+      out.push("");
+    }
+  }
+
+  return out.join("\n");
+}
+
+function prepareTelegramMarkdown(markdown: string): string {
+  return improveTelegramSectionSpacing(preserveTelegramListBoundarySpacing(markdown));
+}
+
 export function markdownToTelegramHtml(
   markdown: string,
   options: { tableMode?: MarkdownTableMode; wrapFileRefs?: boolean } = {},
 ): string {
-  const ir = markdownToIR(preserveTelegramListBoundarySpacing(markdown ?? ""), {
+  const ir = markdownToIR(prepareTelegramMarkdown(markdown ?? ""), {
     linkify: true,
     enableSpoilers: true,
-    headingStyle: "none",
+    headingStyle: "bold",
     blockquotePrefix: "",
     tableMode: options.tableMode,
   });
@@ -780,10 +875,10 @@ export function markdownToTelegramChunks(
   limit: number,
   options: { tableMode?: MarkdownTableMode } = {},
 ): TelegramFormattedChunk[] {
-  const ir = markdownToIR(preserveTelegramListBoundarySpacing(markdown ?? ""), {
+  const ir = markdownToIR(prepareTelegramMarkdown(markdown ?? ""), {
     linkify: true,
     enableSpoilers: true,
-    headingStyle: "none",
+    headingStyle: "bold",
     blockquotePrefix: "",
     tableMode: options.tableMode,
   });


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- Telegram final replies can feel cramped when model output uses Markdown headings or short section-label paragraphs, because Telegram Bot API HTML has no real heading/list block layout.
- This teaches the Telegram formatter to add section rhythm before converting Markdown to Telegram-safe HTML.

Why does this matter now?

- Long assistant replies on Telegram are easier to scan when section labels get bold emphasis and whitespace instead of rendering as dense paragraphs.

What is the intended outcome?

- Markdown headings render as bold Telegram sections.
- Short section-label lines such as `Clinical significance: weak` are promoted to bold headings with blank-line spacing.
- Lists and fenced/indented code keep their existing behavior.

What is intentionally out of scope?

- No Bot API send behavior changes beyond formatted text content.
- No config/env changes.
- No live Telegram delivery test in this PR pass.

What does success look like?

- Telegram-rendered text is more scannable without introducing unsupported Telegram HTML tags.
- Existing Telegram formatter wrapping/chunking tests continue to pass.

What should reviewers focus on?

- Whether the plain-section-heading heuristic is conservative enough.
- Whether this belongs in Telegram formatting rather than prompt policy.

## Linked context

Which issue does this close?

Closes: none

Which issues, PRs, or discussions are related?

Related: none

Was this requested by a maintainer or owner?

- Requested during local operator review of OpenClaw versus Hermes Telegram formatting.

## Real behavior proof (required for external PRs)

- Behavior addressed: Dense Telegram replies from Markdown headings and short section labels now render with bold section labels and blank-line spacing in Telegram HTML.
- Real environment tested: Local OpenClaw source checkout on branch `codex/telegram-format-spacing`, invoking the actual Telegram formatter implementation from `extensions/telegram/src/format.ts` through Node and `tsx`.
- Exact steps or command run after this patch:

  ```bash
  node --import tsx --input-type=module <<'NODE'
  import { markdownToTelegramHtml, markdownToTelegramChunks } from "./extensions/telegram/src/format.ts";
  // Rendered a Telegram-shaped reply containing plain section labels, bullets, and a numbered item.
  NODE
  ```

- Evidence after fix: Console output from the formatter render command, followed by one live Telegram Bot API send using the live OpenClaw default bot/target:

  ```text
  OPENCLAW_TELEGRAM_RENDER_PROOF
  Source branch: codex/telegram-format-spacing
  Formatter: extensions/telegram/src/format.ts markdownToTelegramHtml

  Rendered Telegram HTML:
  <b>Construct validity: moderate</b>

  SPS is plausible but may not be an adequate dose of psychological treatment for personality disorder. It may test a diluted package rather than a true active dose of DBT/MBT-informed therapy.

  <b>External validity: good for NHS secondary/primary mental health settings</b>

  Especially for adults with longstanding service contact and probable personality disorder.

  <b>Less certain for:</b>

  • Early intervention
  • Younger people newly presenting
  • Highly specialised services with expert SPS practitioners

  1. <b>Direct clinical contact:</b> AP roles, support worker, HCA, IAPT/mental health service roles, charity helplines, supervised client-facing work.

  Escaped rendered HTML:
  "<b>Construct validity: moderate</b>\n\nSPS is plausible but may not be an adequate dose of psychological treatment for personality disorder. It may test a diluted package rather than a true active dose of DBT/MBT-informed therapy.\n\n<b>External validity: good for NHS secondary/primary mental health settings</b>\n\nEspecially for adults with longstanding service contact and probable personality disorder.\n\n<b>Less certain for:</b>\n\n• Early intervention\n• Younger people newly presenting\n• Highly specialised services with expert SPS practitioners\n\n1. <b>Direct clinical contact:</b> AP roles, support worker, HCA, IAPT/mental health service roles, charity helplines, supervised client-facing work."

  Chunk count: 1
  ```

  Live Telegram send receipt, token and chat id redacted:

  ```text
  OPENCLAW_PR_91146_LIVE_FORMAT_PROOF 2026-06-07T11:02:32.539Z
  Telegram Bot API sendMessage accepted parse_mode=HTML payload.
  Live bot/target: OpenClaw default Telegram account and default target from live config.
  Chat id: ******9866
  Message id: 23385
  Silent: true
  ```

- Observed result after fix: The render output shows each section label as Telegram-supported `<b>...</b>` text followed by a blank line before the body, bullet items remain bullets under the spaced section, and the numbered bold lead-in remains an inline list item instead of becoming its own section. A live Telegram Bot API `sendMessage` call accepted that HTML payload with `parse_mode=HTML` and returned message id `23385`.
- What was not tested: Native Telegram Desktop visual capture, Mantis Crabbox evidence, and deployment of this PR branch into the live OpenClaw runtime. The live send used the patched formatter output as explicit Telegram HTML through the live bot.
- Before evidence (optional but encouraged): Prior formatter behavior flattened Markdown headings to plain text and did not add formatter-level emphasis or blank-line spacing for short section-label paragraphs.

## Tests and validation

Which commands did you run?

- `PNPM_CONFIG_MODULES_DIR=/Users/paulcouach/Projects/Homelab/homelab-clean/openclaw/node_modules node scripts/run-vitest.mjs extensions/telegram/src/format.test.ts`
- `PNPM_CONFIG_MODULES_DIR=/Users/paulcouach/Projects/Homelab/homelab-clean/openclaw/node_modules node scripts/run-vitest.mjs extensions/telegram/src/format.wrap-md.test.ts extensions/telegram/src/telegram-outbound.test.ts`
- `/Users/paulcouach/Projects/Homelab/homelab-clean/openclaw/node_modules/.bin/oxfmt --check --threads=1 extensions/telegram/src/format.ts extensions/telegram/src/format.test.ts`
- `git diff --check`

What regression coverage was added or updated?

- Updated heading behavior from flattened text to bold Telegram sections.
- Added coverage for plain section-label spacing, styled section-label spacing, list item non-promotion, and fenced-code non-promotion.

What failed before this fix, if known?

- Markdown headings flattened to plain text in Telegram formatting.
- Section-label paragraphs had no formatter-level whitespace/emphasis treatment.

If no test was added, why not?

- Tests were added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

- The section-label heuristic could bold/space a short colon-ending line that the author intended as plain text.

How is that risk mitigated?

- The heuristic skips indented lines, list items, raw HTML-ish lines, Markdown headings already handled by the parser, long lines, sentence-ending punctuation, and fenced code.
- Tests cover list items and fenced code.

## Current review state

What is the next action?

- Maintainer review of the formatter heuristic and embedded local Telegram HTML render proof.

What is still waiting on author, maintainer, CI, or external proof?

- Upstream CI/review after moving out of draft.
- Native Telegram Desktop or Mantis proof remains available as a maintainer-triggered follow-up if reviewers want a full visual screenshot/GIF.

Which bot or reviewer comments were addressed?

- Real behavior proof gate was addressed by embedding actual formatter render console output in the PR body.

