### PR TITLE
fix(cli): bound native hook relay process lifetime (#90993)

### DIFF
--- a/src/cli/hooks-cli.ts
+++ b/src/cli/hooks-cli.ts
@@ -26,6 +26,7 @@ import { shortenHomePath } from "../utils.js";
 import { setSafeTimeout } from "../utils/timer-delay.js";
 import { formatCliCommand } from "./command-format.js";
 import {
+  exitNativeHookRelayProcess,
   resolveNativeHookRelayProcessDeadlineMs,
   runNativeHookRelayCli,
   type NativeHookRelayCliOptions,
@@ -553,14 +554,16 @@ export function registerHooksCli(program: Command): void {
           // runNativeHookRelayCli reports invalid --timeout and returns a nonzero code.
         }
         const deadlineTimer = setSafeTimeout(() => {
-          restoreTerminalState("native hook relay deadline", { resumeStdinIfPaused: false });
-          process.exit(124);
+          void (async () => {
+            restoreTerminalState("native hook relay deadline", { resumeStdinIfPaused: false });
+            await exitNativeHookRelayProcess(124);
+          })();
         }, resolveNativeHookRelayProcessDeadlineMs(timeoutMs));
         deadlineTimer.unref?.();
         try {
           const exitCode = await runNativeHookRelayCli(opts);
           restoreTerminalState("runtime exit", { resumeStdinIfPaused: false });
-          process.exit(exitCode);
+          await exitNativeHookRelayProcess(exitCode);
         } finally {
           clearTimeout(deadlineTimer);
         }

--- a/src/cli/hooks-cli.ts
+++ b/src/cli/hooks-cli.ts
@@ -5,6 +5,7 @@ import {
   decorativePrefix,
 } from "../../packages/terminal-core/src/decorative-emoji.js";
 import { formatDocsLink } from "../../packages/terminal-core/src/links.js";
+import { restoreTerminalState } from "../../packages/terminal-core/src/restore.js";
 import { getTerminalTableWidth, renderTable } from "../../packages/terminal-core/src/table.js";
 import { theme } from "../../packages/terminal-core/src/theme.js";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
@@ -22,8 +23,14 @@ import { formatErrorMessage } from "../infra/errors.js";
 import { buildPluginDiagnosticsReport } from "../plugins/status.js";
 import { defaultRuntime } from "../runtime.js";
 import { shortenHomePath } from "../utils.js";
+import { setSafeTimeout } from "../utils/timer-delay.js";
 import { formatCliCommand } from "./command-format.js";
-import { runNativeHookRelayCli, type NativeHookRelayCliOptions } from "./native-hook-relay-cli.js";
+import {
+  resolveNativeHookRelayProcessDeadlineMs,
+  runNativeHookRelayCli,
+  type NativeHookRelayCliOptions,
+} from "./native-hook-relay-cli.js";
+import { parseTimeoutMsWithFallback } from "./parse-timeout.js";
 import { runPluginInstallCommand } from "./plugins-install-command.js";
 import { runPluginUpdateCommand } from "./plugins-update-command.js";
 
@@ -539,7 +546,24 @@ export function registerHooksCli(program: Command): void {
     .option("--timeout <ms>", "Gateway timeout in ms", "5000")
     .action(async (opts: NativeHookRelayCliOptions) =>
       runHooksCliAction(async () => {
-        process.exitCode = await runNativeHookRelayCli(opts);
+        let timeoutMs = 5_000;
+        try {
+          timeoutMs = parseTimeoutMsWithFallback(opts.timeout, 5_000);
+        } catch {
+          // runNativeHookRelayCli reports invalid --timeout and returns a nonzero code.
+        }
+        const deadlineTimer = setSafeTimeout(() => {
+          restoreTerminalState("native hook relay deadline", { resumeStdinIfPaused: false });
+          process.exit(124);
+        }, resolveNativeHookRelayProcessDeadlineMs(timeoutMs));
+        deadlineTimer.unref?.();
+        try {
+          const exitCode = await runNativeHookRelayCli(opts);
+          restoreTerminalState("runtime exit", { resumeStdinIfPaused: false });
+          process.exit(exitCode);
+        } finally {
+          clearTimeout(deadlineTimer);
+        }
       }),
     );
 

--- a/src/cli/native-hook-relay-cli.test.ts
+++ b/src/cli/native-hook-relay-cli.test.ts
@@ -1,12 +1,55 @@
 // Native hook relay CLI tests cover relay command registration and runtime delegation.
-import { describe, expect, it, vi } from "vitest";
+import { Readable } from "node:stream";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   createReadableTextStream,
   createWritableTextBuffer,
+  resolveNativeHookRelayProcessDeadlineMs,
   runNativeHookRelayCli,
 } from "./native-hook-relay-cli.js";
 
+afterEach(() => {
+  vi.useRealTimers();
+});
+
 describe("native hook relay CLI", () => {
+  it("derives a hard process deadline from --timeout", () => {
+    expect(resolveNativeHookRelayProcessDeadlineMs(5_000)).toBe(12_000);
+  });
+
+  it("times out when stdin never reaches EOF", async () => {
+    vi.useFakeTimers();
+    const callGateway = vi.fn();
+    const stderr = createWritableTextBuffer();
+    const stdin = new Readable({
+      read() {
+        // Simulate a harness that leaves the stdin pipe open indefinitely.
+      },
+    });
+
+    const runPromise = runNativeHookRelayCli(
+      {
+        provider: "codex",
+        relayId: "relay-1",
+        generation: "generation-1",
+        event: "pre_tool_use",
+        timeout: "1000",
+      },
+      {
+        stdin,
+        stderr,
+        callGateway: callGateway as never,
+      },
+    );
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    const exitCode = await runPromise;
+
+    expect(exitCode).toBe(1);
+    expect(stderr.text()).toContain("native hook stdin read timed out after 1000ms");
+    expect(callGateway).not.toHaveBeenCalled();
+  });
+
   it("reads Codex hook JSON from stdin and forwards it to the gateway relay", async () => {
     const callGateway = vi.fn(async () => ({ stdout: "", stderr: "", exitCode: 0 }));
     const stdout = createWritableTextBuffer();

--- a/src/cli/native-hook-relay-cli.test.ts
+++ b/src/cli/native-hook-relay-cli.test.ts
@@ -504,7 +504,7 @@ describe("native hook relay CLI", () => {
     });
     const exit = vi.fn((_code: number) => {
       events.push("exit");
-    }) as (code: number) => never;
+    });
 
     const exitCode = await runNativeHookRelayCli(
       { provider: "codex", relayId: "relay-1", event: "pre_tool_use" },

--- a/src/cli/native-hook-relay-cli.test.ts
+++ b/src/cli/native-hook-relay-cli.test.ts
@@ -1,9 +1,11 @@
 // Native hook relay CLI tests cover relay command registration and runtime delegation.
-import { Readable } from "node:stream";
+import { Readable, Writable } from "node:stream";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   createReadableTextStream,
   createWritableTextBuffer,
+  exitNativeHookRelayProcess,
+  flushNativeHookRelayProcessStreams,
   resolveNativeHookRelayProcessDeadlineMs,
   runNativeHookRelayCli,
 } from "./native-hook-relay-cli.js";
@@ -458,5 +460,73 @@ describe("native hook relay CLI", () => {
     expect(exitCode).toBe(0);
     expect(stdout.text()).toBe("");
     expect(stderr.text()).toContain("native hook relay unavailable");
+  });
+
+  it("flushes relay process streams after pending writes complete", async () => {
+    const events: string[] = [];
+    const stdout = new Writable({
+      write(chunk, _encoding, callback) {
+        setTimeout(() => {
+          events.push(chunk.length === 0 ? "flush" : "payload");
+          callback();
+        }, 20);
+      },
+    });
+    const stderr = createWritableTextBuffer();
+
+    stdout.write("payload");
+    const flushPromise = flushNativeHookRelayProcessStreams(stdout, stderr);
+    expect(events).toEqual([]);
+    await flushPromise;
+    expect(events).toEqual(["payload", "flush"]);
+  });
+
+  it("exits only after async stdout deny JSON has been written", async () => {
+    const events: string[] = [];
+    const chunks: Buffer[] = [];
+    const stdout = new Writable({
+      write(chunk, _encoding, callback) {
+        setTimeout(() => {
+          const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk));
+          if (buffer.byteLength > 0) {
+            chunks.push(buffer);
+            events.push("payload");
+          } else {
+            events.push("flush");
+          }
+          callback();
+        }, 20);
+      },
+    });
+    const stderr = createWritableTextBuffer();
+    const callGateway = vi.fn(async () => {
+      throw new Error("generation must be non-empty string");
+    });
+    const exit = vi.fn((_code: number) => {
+      events.push("exit");
+    }) as (code: number) => never;
+
+    const exitCode = await runNativeHookRelayCli(
+      { provider: "codex", relayId: "relay-1", event: "pre_tool_use" },
+      {
+        stdin: createReadableTextStream("{}"),
+        stdout,
+        stderr,
+        callGateway: callGateway as never,
+      },
+    );
+
+    expect(exitCode).toBe(0);
+    await exitNativeHookRelayProcess(exitCode, { stdout, stderr, exit });
+
+    expect(events).toEqual(["payload", "flush", "exit"]);
+    expect(JSON.parse(Buffer.concat(chunks).toString("utf8"))).toEqual({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: "Native hook relay unavailable",
+      },
+    });
+    expect(exit).toHaveBeenCalledWith(0);
   });
 });

--- a/src/cli/native-hook-relay-cli.ts
+++ b/src/cli/native-hook-relay-cli.ts
@@ -125,7 +125,7 @@ export async function runNativeHookRelayCli(
 export type NativeHookRelayProcessExitDeps = {
   stdout?: NodeJS.WritableStream;
   stderr?: NodeJS.WritableStream;
-  exit?: (code: number) => never;
+  exit?: (code: number) => void;
 };
 
 /** Drain relay stdout/stderr so Codex receives complete hook decision JSON before exit. */

--- a/src/cli/native-hook-relay-cli.ts
+++ b/src/cli/native-hook-relay-cli.ts
@@ -55,7 +55,7 @@ export async function runNativeHookRelayCli(
   try {
     timeoutMs = parseTimeoutMsWithFallback(opts.timeout, 5_000);
   } catch (error) {
-    writeText(stderr, formatRelayCliError("invalid native hook timeout", error));
+    await writeTextAsync(stderr, formatRelayCliError("invalid native hook timeout", error));
     return 1;
   }
 
@@ -64,7 +64,7 @@ export async function runNativeHookRelayCli(
     const rawInput = await readStreamText(stdin, MAX_NATIVE_HOOK_STDIN_BYTES, timeoutMs);
     rawPayload = rawInput.trim() ? JSON.parse(rawInput) : null;
   } catch (error) {
-    writeText(stderr, formatRelayCliError("failed to read native hook input", error));
+    await writeTextAsync(stderr, formatRelayCliError("failed to read native hook input", error));
     return 1;
   }
 
@@ -78,20 +78,20 @@ export async function runNativeHookRelayCli(
       registrationTimeoutMs: 100,
       timeoutMs,
     });
-    writeText(stdout, response.stdout);
-    writeText(stderr, response.stderr);
+    await writeTextAsync(stdout, response.stdout);
+    await writeTextAsync(stderr, response.stderr);
     return response.exitCode;
   } catch (error) {
     if (isNativeHookRelayBridgeStaleRegistrationError(error)) {
-      writeText(stderr, formatRelayCliError("native hook relay unavailable", error));
+      await writeTextAsync(stderr, formatRelayCliError("native hook relay unavailable", error));
       const response = renderNativeHookRelayUnavailableResponse({
         provider,
         event,
         preToolUseUnavailable: opts.preToolUseUnavailable,
         message: "Native hook relay unavailable",
       });
-      writeText(stdout, response.stdout);
-      writeText(stderr, response.stderr);
+      await writeTextAsync(stdout, response.stdout);
+      await writeTextAsync(stderr, response.stderr);
       return response.exitCode;
     }
     // Fall through to the gateway path for embedded/local gateway cases and
@@ -105,21 +105,47 @@ export async function runNativeHookRelayCli(
       timeoutMs,
       scopes: [ADMIN_SCOPE],
     });
-    writeText(stdout, response.stdout);
-    writeText(stderr, response.stderr);
+    await writeTextAsync(stdout, response.stdout);
+    await writeTextAsync(stderr, response.stderr);
     return response.exitCode;
   } catch (error) {
-    writeText(stderr, formatRelayCliError("native hook relay unavailable", error));
+    await writeTextAsync(stderr, formatRelayCliError("native hook relay unavailable", error));
     const response = renderNativeHookRelayUnavailableResponse({
       provider,
       event,
       preToolUseUnavailable: opts.preToolUseUnavailable,
       message: "Native hook relay unavailable",
     });
-    writeText(stdout, response.stdout);
-    writeText(stderr, response.stderr);
+    await writeTextAsync(stdout, response.stdout);
+    await writeTextAsync(stderr, response.stderr);
     return response.exitCode;
   }
+}
+
+export type NativeHookRelayProcessExitDeps = {
+  stdout?: NodeJS.WritableStream;
+  stderr?: NodeJS.WritableStream;
+  exit?: (code: number) => never;
+};
+
+/** Drain relay stdout/stderr so Codex receives complete hook decision JSON before exit. */
+export async function flushNativeHookRelayProcessStreams(
+  stdout: NodeJS.WritableStream = process.stdout,
+  stderr: NodeJS.WritableStream = process.stderr,
+): Promise<void> {
+  await Promise.all([flushWritableStream(stdout), flushWritableStream(stderr)]);
+}
+
+/** Flush relay output streams, then force-exit the relay CLI process. */
+export async function exitNativeHookRelayProcess(
+  exitCode: number,
+  deps: NativeHookRelayProcessExitDeps = {},
+): Promise<never> {
+  const stdout = deps.stdout ?? process.stdout;
+  const stderr = deps.stderr ?? process.stderr;
+  const exit = deps.exit ?? process.exit;
+  await flushNativeHookRelayProcessStreams(stdout, stderr);
+  exit(exitCode);
 }
 
 function readRequiredOption(value: string | undefined, name: string): string {
@@ -174,10 +200,53 @@ function destroyReadableStream(stream: NodeJS.ReadableStream): void {
   }
 }
 
-function writeText(stream: NodeJS.WritableStream, value: string | undefined): void {
-  if (value) {
-    stream.write(value);
+async function writeTextAsync(
+  stream: NodeJS.WritableStream,
+  value: string | undefined,
+): Promise<void> {
+  if (!value) {
+    return;
   }
+  await writeChunkAsync(stream, value);
+}
+
+function writeChunkAsync(stream: NodeJS.WritableStream, chunk: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if ((stream as NodeJS.WriteStream).destroyed || stream.writable === false) {
+      resolve();
+      return;
+    }
+    try {
+      const onDone = (err?: Error | null) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+        resolve();
+      };
+      const canContinue = stream.write(chunk, onDone);
+      if (!canContinue) {
+        stream.once("drain", () => {
+          // The write callback still signals completion for this chunk.
+        });
+      }
+    } catch (err) {
+      reject(err);
+    }
+  });
+}
+
+async function flushWritableStream(stream: NodeJS.WritableStream): Promise<void> {
+  if ((stream as NodeJS.WriteStream).destroyed || stream.writable === false) {
+    return;
+  }
+  await new Promise<void>((resolve) => {
+    try {
+      stream.write("", () => resolve());
+    } catch {
+      resolve();
+    }
+  });
 }
 
 function formatRelayCliError(prefix: string, error: unknown): string {

--- a/src/cli/native-hook-relay-cli.ts
+++ b/src/cli/native-hook-relay-cli.ts
@@ -140,11 +140,11 @@ export async function flushNativeHookRelayProcessStreams(
 export async function exitNativeHookRelayProcess(
   exitCode: number,
   deps: NativeHookRelayProcessExitDeps = {},
-): Promise<never> {
+): Promise<void> {
   const stdout = deps.stdout ?? process.stdout;
   const stderr = deps.stderr ?? process.stderr;
-  const exit = deps.exit ?? process.exit;
   await flushNativeHookRelayProcessStreams(stdout, stderr);
+  const exit = deps.exit ?? ((code: number): never => process.exit(code));
   exit(exitCode);
 }
 
@@ -212,7 +212,7 @@ async function writeTextAsync(
 
 function writeChunkAsync(stream: NodeJS.WritableStream, chunk: string): Promise<void> {
   return new Promise((resolve, reject) => {
-    if ((stream as NodeJS.WriteStream).destroyed || stream.writable === false) {
+    if ((stream as NodeJS.WriteStream).destroyed || !stream.writable) {
       resolve();
       return;
     }
@@ -231,13 +231,13 @@ function writeChunkAsync(stream: NodeJS.WritableStream, chunk: string): Promise<
         });
       }
     } catch (err) {
-      reject(err);
+      reject(err instanceof Error ? err : new Error(String(err)));
     }
   });
 }
 
 async function flushWritableStream(stream: NodeJS.WritableStream): Promise<void> {
-  if ((stream as NodeJS.WriteStream).destroyed || stream.writable === false) {
+  if ((stream as NodeJS.WriteStream).destroyed || !stream.writable) {
     return;
   }
   await new Promise<void>((resolve) => {

--- a/src/cli/native-hook-relay-cli.ts
+++ b/src/cli/native-hook-relay-cli.ts
@@ -8,9 +8,16 @@ import {
 } from "../agents/harness/native-hook-relay.js";
 import { callGateway } from "../gateway/call.js";
 import { ADMIN_SCOPE } from "../gateway/method-scopes.js";
+import { resolveSafeTimeoutDelayMs } from "../utils/timer-delay.js";
 import { parseTimeoutMsWithFallback } from "./parse-timeout.js";
 
 const MAX_NATIVE_HOOK_STDIN_BYTES = 1024 * 1024;
+const NATIVE_HOOK_RELAY_PROCESS_DEADLINE_GRACE_MS = 2_000;
+
+/** Upper bound for total relay CLI process lifetime derived from --timeout. */
+export function resolveNativeHookRelayProcessDeadlineMs(timeoutMs: number): number {
+  return resolveSafeTimeoutDelayMs(timeoutMs * 2 + NATIVE_HOOK_RELAY_PROCESS_DEADLINE_GRACE_MS);
+}
 
 /** User-facing flags for the native hook relay command. */
 export type NativeHookRelayCliOptions = {
@@ -54,7 +61,7 @@ export async function runNativeHookRelayCli(
 
   let rawPayload: unknown;
   try {
-    const rawInput = await readStreamText(stdin, MAX_NATIVE_HOOK_STDIN_BYTES);
+    const rawInput = await readStreamText(stdin, MAX_NATIVE_HOOK_STDIN_BYTES, timeoutMs);
     rawPayload = rawInput.trim() ? JSON.parse(rawInput) : null;
   } catch (error) {
     writeText(stderr, formatRelayCliError("failed to read native hook input", error));
@@ -122,18 +129,49 @@ function readRequiredOption(value: string | undefined, name: string): string {
   throw new Error(`Missing required option --${name}`);
 }
 
-async function readStreamText(stream: NodeJS.ReadableStream, maxBytes: number): Promise<string> {
-  const chunks: Buffer[] = [];
-  let total = 0;
-  for await (const chunk of stream) {
-    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
-    total += buffer.byteLength;
-    if (total > maxBytes) {
-      throw new Error(`native hook input exceeds ${maxBytes} bytes`);
+async function readStreamText(
+  stream: NodeJS.ReadableStream,
+  maxBytes: number,
+  timeoutMs: number,
+): Promise<string> {
+  const safeTimeoutMs = resolveSafeTimeoutDelayMs(timeoutMs);
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const readTask = (async () => {
+    const chunks: Buffer[] = [];
+    let total = 0;
+    for await (const chunk of stream) {
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      total += buffer.byteLength;
+      if (total > maxBytes) {
+        throw new Error(`native hook input exceeds ${maxBytes} bytes`);
+      }
+      chunks.push(buffer);
     }
-    chunks.push(buffer);
+    return Buffer.concat(chunks, total).toString("utf8");
+  })();
+
+  try {
+    return await Promise.race([
+      readTask,
+      new Promise<string>((_resolve, reject) => {
+        timer = setTimeout(() => {
+          destroyReadableStream(stream);
+          reject(new Error(`native hook stdin read timed out after ${safeTimeoutMs}ms`));
+        }, safeTimeoutMs);
+        timer.unref?.();
+      }),
+    ]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
   }
-  return Buffer.concat(chunks, total).toString("utf8");
+}
+
+function destroyReadableStream(stream: NodeJS.ReadableStream): void {
+  if (typeof (stream as NodeJS.ReadStream).destroy === "function") {
+    (stream as NodeJS.ReadStream).destroy();
+  }
 }
 
 function writeText(stream: NodeJS.WritableStream, value: string | undefined): void {


### PR DESCRIPTION
## Summary

Fixes #90993 by bounding native hook relay CLI (`openclaw-hooks`) process lifetime so leaked subprocesses cannot accumulate when harnesses leave stdin open or gateway handles remain referenced.

## Root cause

Three stacked issues in the relay CLI path:

1. **Unbounded stdin read** — `readStreamText()` blocked forever on open stdin before `--timeout` applied.
2. **No hard exit** — relay action set `process.exitCode` only; Node stayed alive while stdin/WebSocket handles remained open.
3. **Narrow timeout scope** — `--timeout` bounded only bridge/gateway RPC, not stdin or overall process lifetime.

## Changes

- `src/cli/native-hook-relay-cli.ts`: time-bound stdin read; await stdout/stderr writes; flush streams before forced exit; export deadline + exit helpers.
- `src/cli/hooks-cli.ts`: hard process deadline (`exit 124` on overrun); `exitNativeHookRelayProcess()` after relay work so Codex receives complete deny JSON.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Native hook relay CLI (`openclaw-hooks`) subprocesses leaked when stdin stayed open past `--timeout`; processes accumulated until host OOM (#90993).
- Real environment tested: Local Linux checkout, branch `fix/native-hook-relay-process-exit`, Node 22+, `pnpm build` completed on fix branch; before repro on `main`.
- Exact steps or command run after this patch:

```bash
pnpm build
for i in $(seq 1 10); do
  tail -f /dev/null | node scripts/run-node.mjs hooks relay \
    --provider codex --relay-id "mre-after-$i" --generation "mre-gen-$i" \
    --event pre_tool_use --timeout 5000 &
  sleep 2
done
sleep 12
ps -eo pid,comm,rss | grep openclaw-hooks || echo "(no openclaw-hooks — expected)"
```

- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

**Before fix (main):** 10 `openclaw-hooks` processes, ~250–450 MB RSS each (~2.5 GB total), alive past `--timeout 5000`.

![before-fix](https://github.com/user-attachments/assets/0494e803-205c-44cb-8dd6-b8d493f12877)

**After fix (this branch):** 0 `openclaw-hooks` after deadline; terminal shows `(no openclaw-hooks — expected)`.

![after-fix](https://github.com/user-attachments/assets/613b4bf5-69a8-45b1-87c5-15564892b1c5)

```text
$ ps -eo pid,comm,rss | grep openclaw-hooks || echo "(no openclaw-hooks — expected)"
(no openclaw-hooks — expected)
```

- Observed result after fix: Open-stdin relay exits within stdin timeout and hard process deadline; no lingering `openclaw-hooks` subprocesses after `sleep 12`.
- What was not tested: Multi-hour gateway + heartbeat + Codex production soak; full Codex harness with live gateway registration.
- Proof limitations or environment constraints: Reproduced via open-stdin MRE (`tail -f /dev/null` pipe), not full production Codex heartbeat loop.

## Tests and validation

```bash
node scripts/run-vitest.mjs src/cli/native-hook-relay-cli.test.ts
pnpm check
pnpm check:test-types
pnpm build
```

- 19/19 tests in `native-hook-relay-cli.test.ts` (stdin timeout, flush-before-exit, async stdout deny JSON)
- `pnpm check` and `pnpm check:test-types` pass locally

## Release note (for maintainers; no CHANGELOG edit per CONTRIBUTING)

CLI: bound native hook relay stdin read, flush hook output before exit, and force process exit so `openclaw-hooks` subprocesses cannot leak after hook events. (#90993)

## Sign-off

- Models used: AI-assisted
- Submitter effort: implemented fix + tests + local MRE verification