### PR TITLE
fix(agents): resolve model aliases in compaction model override (fixes #90340)

### DIFF
--- a/src/agents/embedded-agent-runner/compaction-runtime-context.test.ts
+++ b/src/agents/embedded-agent-runner/compaction-runtime-context.test.ts
@@ -397,4 +397,85 @@ describe("buildEmbeddedCompactionRuntimeContext", () => {
     });
     expect(result.provider).toBe("anthropic");
   });
+
+  it("resolves compaction.model alias to canonical provider/model (#90340)", () => {
+    const result = resolveEmbeddedCompactionTarget({
+      config: {
+        agents: {
+          defaults: {
+            models: {
+              "openai/gpt-5.4-mini": { alias: "gpt54mini" },
+            },
+            compaction: { model: "gpt54mini" },
+          },
+        },
+      } as unknown as OpenClawConfig,
+      provider: "openai",
+      modelId: "gpt-5.5",
+      authProfileId: "openai:p1",
+      defaultProvider: "openai",
+      defaultModel: "gpt-5.5",
+    });
+    expect(result.provider).toBe("openai");
+    expect(result.model).toBe("gpt-5.4-mini");
+    // Auth profile preserved because provider didn't change
+    expect(result.authProfileId).toBe("openai:p1");
+  });
+
+  it("preserves bare model-id when it collides with a configured alias key (#90340)", () => {
+    // When the bare compaction.model value is already a configured model id
+    // for the current provider, shipped literal behavior takes precedence over
+    // alias resolution to avoid a silent model/provider switch on upgrade.
+    const result = resolveEmbeddedCompactionTarget({
+      config: {
+        models: {
+          providers: {
+            openai: { models: [{ id: "gpt-5.4" }, { id: "gpt-5.4-special" }] },
+          },
+        },
+        agents: {
+          defaults: {
+            models: {
+              "openai/gpt-5.4-special": { alias: "gpt-5.4" },
+            },
+            compaction: { model: "gpt-5.4" },
+          },
+        },
+      } as unknown as OpenClawConfig,
+      provider: "openai",
+      modelId: "gpt-5.5",
+      authProfileId: "openai:p1",
+      defaultProvider: "openai",
+      defaultModel: "gpt-5.5",
+    });
+    // Bare model-id "gpt-5.4" is a configured model for openai, so it
+    // should NOT be resolved through the alias that shares the same key.
+    expect(result.provider).toBe("openai");
+    expect(result.model).toBe("gpt-5.4");
+    expect(result.authProfileId).toBe("openai:p1");
+  });
+
+  it("resolves cross-provider compaction.model alias (#90340)", () => {
+    const result = resolveEmbeddedCompactionTarget({
+      config: {
+        agents: {
+          defaults: {
+            models: {
+              "anthropic/claude-opus-4-6": { alias: "opus46" },
+            },
+            compaction: { model: "opus46" },
+          },
+        },
+      } as unknown as OpenClawConfig,
+      provider: "openai",
+      modelId: "gpt-5.5",
+      authProfileId: "openai:p1",
+      defaultProvider: "openai",
+      defaultModel: "gpt-5.5",
+    });
+    expect(result.provider).toBe("anthropic");
+    expect(result.model).toBe("claude-opus-4-6");
+    // Auth profile dropped because provider changed
+    expect(result.authProfileId).toBeUndefined();
+  });
 });

--- a/src/agents/embedded-agent-runner/compaction-runtime-context.ts
+++ b/src/agents/embedded-agent-runner/compaction-runtime-context.ts
@@ -123,20 +123,46 @@ export function resolveEmbeddedCompactionTarget(params: {
   // Resolve alias-only compaction model overrides through the model alias index.
   // Without this, an alias like "gpt54mini" is passed to resolveModelAsync as-is,
   // resulting in "Unknown model: openai/gpt54mini" (#90340).
+  //
+  // Safety: preserve bare model-id precedence. A bare override that is already a
+  // configured model id for the current provider must keep shipped literal behavior
+  // even when it collides with a configured alias key. Only non-colliding bare
+  // values (true aliases) are resolved through the alias index.
   const defaultProvider = params.defaultProvider ?? provider;
+  const aliasIndex = defaultProvider
+    ? buildModelAliasIndex({
+        cfg: params.config as OpenClawConfig,
+        defaultProvider,
+      })
+    : null;
   const resolvedAlias = defaultProvider
     ? resolveModelRefFromString({
         cfg: params.config,
         raw: override,
         defaultProvider,
-        aliasIndex: buildModelAliasIndex({
-          cfg: params.config as OpenClawConfig,
-          defaultProvider,
-        }),
+        aliasIndex: aliasIndex ?? undefined,
       })
     : null;
   const authProfileId = params.authProfileId ?? undefined;
-  if (resolvedAlias) {
+  const hasAliasMatch = Boolean(resolvedAlias?.alias);
+  if (hasAliasMatch && resolvedAlias && aliasIndex) {
+    // The override matched a configured alias. Check whether the bare value also
+    // collides with a known model id for the current provider — if it does, the
+    // shipped bare-model-id behavior takes precedence to avoid a silent switch.
+    const isKnownModelId = isBareModelConfiguredForProvider({
+      config: params.config,
+      provider: provider ?? "",
+      modelId: override,
+    });
+    if (isKnownModelId) {
+      // Bare model-id takes precedence over the alias to preserve existing behavior.
+      return {
+        provider,
+        ...resolveTargetProviders(provider, authProfileId),
+        model: override,
+        authProfileId,
+      };
+    }
     const aliasProvider = resolvedAlias.ref.provider;
     const aliasModel = resolvedAlias.ref.model;
     const aliasAuthProfileId =
@@ -170,6 +196,26 @@ function shouldUseCodexRuntimeProviderForCompaction(params: {
     return false;
   }
   return true;
+}
+
+/**
+ * Check whether a bare model id is already configured for the given provider.
+ * When true, the bare model-id takes precedence over any alias that shares the
+ * same key, preserving upgrade-safe shipped-config behavior (#90340).
+ */
+function isBareModelConfiguredForProvider(params: {
+  config?: OpenClawConfig;
+  provider: string;
+  modelId: string;
+}): boolean {
+  const providerEntry = params.config?.models?.providers?.[params.provider];
+  if (!providerEntry?.models?.length) {
+    return false;
+  }
+  const normalized = params.modelId.toLowerCase();
+  return providerEntry.models.some(
+    (m) => typeof m.id === "string" && m.id.toLowerCase() === normalized,
+  );
 }
 
 export function buildEmbeddedCompactionRuntimeContext(params: {

--- a/src/agents/embedded-agent-runner/compaction-runtime-context.ts
+++ b/src/agents/embedded-agent-runner/compaction-runtime-context.ts
@@ -11,6 +11,7 @@ import {
   type ActiveProcessSessionReference,
 } from "../bash-process-references.js";
 import type { ExecElevatedDefaults } from "../bash-tools.js";
+import { buildModelAliasIndex, resolveModelRefFromString } from "../model-selection-shared.js";
 import {
   openAIProviderUsesCodexRuntimeByDefault,
   resolveSelectedOpenAIRuntimeProvider,
@@ -119,7 +120,36 @@ export function resolveEmbeddedCompactionTarget(params: {
       authProfileId,
     };
   }
+  // Resolve alias-only compaction model overrides through the model alias index.
+  // Without this, an alias like "gpt54mini" is passed to resolveModelAsync as-is,
+  // resulting in "Unknown model: openai/gpt54mini" (#90340).
+  const defaultProvider = params.defaultProvider ?? provider;
+  const resolvedAlias = defaultProvider
+    ? resolveModelRefFromString({
+        cfg: params.config,
+        raw: override,
+        defaultProvider,
+        aliasIndex: buildModelAliasIndex({
+          cfg: params.config as OpenClawConfig,
+          defaultProvider,
+        }),
+      })
+    : null;
   const authProfileId = params.authProfileId ?? undefined;
+  if (resolvedAlias) {
+    const aliasProvider = resolvedAlias.ref.provider;
+    const aliasModel = resolvedAlias.ref.model;
+    const aliasAuthProfileId =
+      aliasProvider !== (params.provider ?? "")?.trim()
+        ? undefined
+        : (params.authProfileId ?? undefined);
+    return {
+      provider: aliasProvider,
+      ...resolveTargetProviders(aliasProvider, aliasAuthProfileId),
+      model: aliasModel,
+      authProfileId: aliasAuthProfileId,
+    };
+  }
   return {
     provider,
     ...resolveTargetProviders(provider, authProfileId),


### PR DESCRIPTION
## Summary

Auto-compaction does not resolve configured model aliases before dispatch. When `agents.defaults.compaction.model` is set to an alias like `gpt54mini`, the alias is passed to `resolveModelAsync` as the literal model id, resulting in `Unknown model: openai/gpt54mini`.

**Fix**: Resolve alias-only compaction model overrides through the model alias index (`buildModelAliasIndex` + `resolveModelRefFromString`) before dispatch, with **bare model-id precedence**: if the bare override value is already a configured model id for the current provider, shipped literal behavior takes precedence over any alias that shares the same key.

**Changes**: 2 files, +132/-5 — `src/agents/embedded-agent-runner/compaction-runtime-context.ts` (+51/-5), test file (+81)

## Root Cause

In `resolveEmbeddedCompactionTarget()`, when the compaction model override (`agents.defaults.compaction.model`) doesn't contain a `/` (i.e., it's a plain alias like `gpt54mini` rather than a fully-qualified `openai/gpt-5.4-mini`), the value was used as-is without alias resolution.

The normal model selection path resolves aliases through `resolveModelRefFromString()` + `buildModelAliasIndex()` (from `model-selection-shared.ts`), which is used by `heartbeat-runner.ts`, `tts-core.ts`, `fallbacks-shared.ts`, and other call sites. The compaction path was missing this resolution step.

**Sibling audit**: All other model ref resolution call sites correctly use `resolveModelRefFromString`. The compaction target resolver was the only call site operating on model aliases without going through the alias index.

**Compatibility safeguard**: Before applying alias resolution, the fix checks whether the bare override value is already a configured model id for the current provider (`isBareModelConfiguredForProvider`). If it is, the shipped bare model-id behavior is preserved to avoid silent model/provider switches on upgrade.

**Scope**:
- In scope: Compaction model alias resolution, bare model-id precedence
- Out of scope: Other model resolution paths (already correct), compaction provider routing, fallback model resolution

## Verification

```shell
$ pnpm build && pnpm check
✓ built in 1.82s
[check] all checks passed

$ pnpm test src/agents/embedded-agent-runner/compaction-runtime-context.test.ts src/agents/model-selection.test.ts src/agents/embedded-agent-runner/compact.hooks.test.ts
Test Files  3 passed (3)
     Tests  206 passed (206)
```

## Real Behavior Proof

**Behavior or issue addressed**: Compaction model alias (e.g. `gpt54mini` → `openai/gpt-5.4-mini`) is now resolved through the model alias index before dispatch, with bare model-id taking precedence over colliding alias keys to preserve upgrade compatibility.

**Real environment tested**: Ubuntu 24.04, Node.js v22.22.0, OpenClaw main @ 66b91d78fe, pnpm 11.2.2

**Exact steps or command run after this patch**:
```shell
cd ~/openclawProject1
pnpm build
pnpm test src/agents/embedded-agent-runner/compaction-runtime-context.test.ts src/agents/model-selection.test.ts src/agents/embedded-agent-runner/compact.hooks.test.ts
```

**Evidence after fix**:
- Source-level: `resolveModelRefFromString` is called with the alias index built from config. When `gpt54mini` matches the alias `openai/gpt-5.4-mini` and does NOT collide with a configured model id, the resolved ref is used. When a bare value collides with a known model id, the shipped literal behavior is preserved.
- New regression tests (3 tests added to `compaction-runtime-context.test.ts`):
  - Alias resolution to canonical provider/model
  - Bare model-id precedence over colliding alias key
  - Cross-provider alias resolution (with auth profile drop)
- Terminal output:
```
✓ built in 1.82s
[check] all checks passed (1 non-blocking: npm shrinkwrap stale)
Test Files  3 passed (3)
     Tests  206 passed (206)
```

**Observed result after fix**: All 206 tests pass (203 existing + 3 new regression tests). `resolveEmbeddedCompactionTarget` resolves true aliases while preserving bare model-id behavior when the model is already configured for the current provider.

**What was not tested**: End-to-end auto-compaction with a real gateway session using an aliased compaction model. The alias resolution path is covered by existing `model-selection.test.ts` tests; the compaction target resolution including collision handling is covered by `compaction-runtime-context.test.ts` tests.

## Review Findings Addressed

- **[P1] Preserve ambiguous bare compaction overrides**: Added `isBareModelConfiguredForProvider` check. When the bare override collides with both a known model id and an alias key, the shipped bare model-id takes precedence. Regression tests added for collision case.
- **[P1] Regression tests**: Added 3 regression tests covering alias resolution, bare model-id precedence, and cross-provider alias resolution.

## Regression Test Plan

- `src/agents/embedded-agent-runner/compaction-runtime-context.test.ts` (21 tests) — covers compaction target resolution including model-only overrides, provider/model overrides, auth profile handling, runtime routing, alias resolution, and collision precedence
- `src/agents/model-selection.test.ts` — covers alias index building and model ref resolution
- `src/agents/embedded-agent-runner/compact.hooks.test.ts` — covers compaction lifecycle hooks

## Merge Risk

**Low**. The change is guarded:
1. If the alias index is empty or the override doesn't match any alias → falls through to existing behavior
2. If the override matches an alias but collides with a known model id → bare model-id takes precedence
3. All 206 existing + new tests pass without modification to existing test expectations
