### PR TITLE
fix(telegram): route outbound sends through configured default account (#61012)

### DIFF
--- a/extensions/telegram/src/accounts.test.ts
+++ b/extensions/telegram/src/accounts.test.ts
@@ -173,6 +173,50 @@ describe("resolveTelegramAccount", () => {
     expect(accounts[0]?.token).toBe("tok-default");
     expect(accounts[0]?.tokenSource).toBe("config");
   });
+
+  it("routes omitted-account sends through the configured defaultAccount (#61012)", () => {
+    const account = resolveAccountWithEnv(
+      { TELEGRAM_BOT_TOKEN: "" },
+      {
+        channels: {
+          telegram: {
+            // Top-level token gives the implicit "default" account a credential,
+            // which previously shadowed the configured defaultAccount on send.
+            botToken: "tok-default-bot",
+            defaultAccount: "secondary",
+            accounts: {
+              primary: { botToken: "tok-primary-bot" },
+              secondary: { botToken: "tok-secondary-bot" },
+            },
+          },
+        },
+      },
+    );
+    expect(account.accountId).toBe("secondary");
+    expect(account.token).toBe("tok-secondary-bot");
+    expect(account.tokenSource).toBe("config");
+  });
+
+  it("routes explicit-account sends through the requested account (#61012)", () => {
+    const account = resolveAccountWithEnv(
+      { TELEGRAM_BOT_TOKEN: "" },
+      {
+        channels: {
+          telegram: {
+            botToken: "tok-default-bot",
+            defaultAccount: "secondary",
+            accounts: {
+              primary: { botToken: "tok-primary-bot" },
+              secondary: { botToken: "tok-secondary-bot" },
+            },
+          },
+        },
+      },
+      "primary",
+    );
+    expect(account.accountId).toBe("primary");
+    expect(account.token).toBe("tok-primary-bot");
+  });
 });
 
 describe("resolveDefaultTelegramAccountId", () => {

--- a/extensions/telegram/src/accounts.ts
+++ b/extensions/telegram/src/accounts.ts
@@ -168,11 +168,13 @@ export function resolveTelegramAccount(params: {
     } satisfies ResolvedTelegramAccount;
   };
 
-  // If accountId is omitted, prefer a configured account token over failing on
-  // the implicit "default" account. This keeps env-based setups working while
-  // making config-only tokens work for things like heartbeats.
+  // No accountId means "configured default": resolve it up front
+  // (channels.telegram.defaultAccount / default-agent binding) so multi-bot
+  // outbound sends honor it instead of the implicit env/top-level "default" bot.
+  // Matches the nextcloud-talk resolver. (#61012)
+  const resolvedAccountId = params.accountId ?? resolveDefaultTelegramAccountId(params.cfg);
   return resolveAccountWithDefaultFallback({
-    accountId: params.accountId,
+    accountId: resolvedAccountId,
     normalizeAccountId,
     resolvePrimary: resolve,
     hasCredential: (account) => account.tokenSource !== "none",


### PR DESCRIPTION
## Summary

With multiple Telegram bot accounts configured, outbound sends via `openclaw message send --channel telegram` (and proactive/subagent sends) ignored the configured default account and always routed through the implicit env/top-level `"default"` bot. This makes the outbound account resolver honor the configured default when no account is specified, so:

1. `message send --channel telegram` with **no** `--account` uses the configured default bot.
2. `--account <id>` routes to that bot.
3. Subagent/proactive sends (which omit `--account`) use the correct bot identity.

## Root cause

`extensions/telegram/src/accounts.ts` → `resolveTelegramAccount()` passed the raw (possibly `undefined`) `accountId` straight into the shared `resolveAccountWithDefaultFallback()` helper:

```ts
return resolveAccountWithDefaultFallback({
  accountId: params.accountId, // undefined when no --account
  ...
});
```

When `accountId` is omitted, the helper normalizes `undefined` → the literal `"default"` account id and resolves that **first**. If the implicit `"default"` account has any credential — e.g. a top-level `channels.telegram.botToken` or `TELEGRAM_BOT_TOKEN` left over from a single-bot setup — the helper returns it immediately and never consults `resolveDefaultTelegramAccountId()`. So `channels.telegram.defaultAccount` (and the default-agent binding) was silently ignored and every send went out under the `"default"` bot. The helper's `resolveDefaultAccountId` fallback only fires when the `"default"` account has *no* credential — precisely the case where the bug doesn't bite.

The outbound path confirms this is the deciding point: the durable send adapter (`outbound-adapter.ts`) calls `sendMessageTelegram(to, text, { cfg, accountId })` with **no** explicit token, so `resolveTelegramAccount()` alone decides the bot/token.

The sibling channel `extensions/nextcloud-talk/src/accounts.ts` already does this correctly — it pre-resolves `params.accountId ?? resolveDefaultNextcloudTalkAccountId(cfg)` before calling the same helper.

## The fix

Mirror the nextcloud-talk resolver: resolve the configured default account id up front when none is provided, then pass that into the helper.

```ts
const resolvedAccountId = params.accountId ?? resolveDefaultTelegramAccountId(params.cfg);
return resolveAccountWithDefaultFallback({
  accountId: resolvedAccountId,
  ...
});
```

`resolveDefaultTelegramAccountId()` already encapsulates the correct precedence (default-agent binding → `channels.telegram.defaultAccount` → first listed / implicit `"default"`), so single-bot, env-only, explicit `--account`, and inbound routing are unchanged; only the previously-broken multi-bot default selection changes.

Scope note: `inspectTelegramAccount()` uses the same helper for capability/status discovery (not send routing). Its omitted-`accountId` callers either branch to the all-accounts union (`channel-actions.ts`) or are diagnostic, so they don't affect which bot sends; left out of this bug-scoped change.

## Verification

Done in an isolated linked worktree on `fix/issue-61012-telegram-default-account` (based on latest `upstream/main`). **OpenClaw was not run locally** — no gateway/CLI/`pnpm dev`/`openclaw …`. Verified by code review + focused Vitest unit tests only.

Added a focused colocated test in `extensions/telegram/src/accounts.test.ts` covering default-account selection (no flag) and explicit-account selection, and confirmed it fails before the fix and passes after:

- **Before** (fix one-liner reverted): `routes omitted-account sends through the configured defaultAccount (#61012)` fails — `AssertionError: expected 'default' to be 'secondary'` (1 failed | 35 passed).
- **After**: `node scripts/run-vitest.mjs extensions/telegram/src/accounts.test.ts` → **36 passed**.
- **Regression** (send/account/outbound path): `node scripts/run-vitest.mjs` over `send.test.ts action-runtime.test.ts outbound-adapter.test.ts bot-message-dispatch.test.ts channel.gateway.test.ts channel.message-adapter.test.ts send.proxy.test.ts` → **345 passed (7 files)**.

Not tested: live multi-bot Telegram delivery (no real bots/tokens exercised). No tokens or secrets are included in the code, tests, or this PR.

Fixes #61012
