### PR TITLE
fix: stabilize claude-cli extraSystemPromptHash across group turns (#69118)

### DIFF
--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -2431,6 +2431,71 @@ describe("runPreparedReply media-only handling", () => {
     expect(call?.followupRun.run.extraSystemPromptStatic).toBe("group:discord:channel:#ops");
   });
 
+  it("keeps the CLI session-reuse static prompt stable across group turns despite first-turn groupIntro", async () => {
+    const { buildGroupIntro } = await import("./groups.js");
+    // groupIntro is injected only on the first turn; groupChatContext is persistent.
+    vi.mocked(buildGroupChatContext).mockReturnValue("GROUP-CHAT-CONTEXT");
+    vi.mocked(buildGroupIntro).mockReturnValue("GROUP-INTRO");
+    const groupCtx = {
+      Body: "hello team",
+      RawBody: "hello team",
+      CommandBody: "hello team",
+      Provider: "discord",
+      ChatType: "group" as const,
+      SessionKey: "agent:main:discord:guild-1:channel-1",
+    };
+    const groupSessionCtx = {
+      Body: "hello team",
+      BodyStripped: "hello team",
+      Provider: "discord",
+      ChatType: "group" as const,
+    };
+    try {
+      // Turn 1: first turn in the session injects the behavioral group intro.
+      await runPreparedReply(
+        baseParams({
+          isNewSession: true,
+          systemSent: false,
+          ctx: groupCtx,
+          sessionCtx: groupSessionCtx,
+        }),
+      );
+      const firstTurn = requireRunReplyAgentCall(0);
+      // Turn 2: established session no longer re-injects the intro.
+      await runPreparedReply(
+        baseParams({
+          isNewSession: false,
+          systemSent: true,
+          ctx: groupCtx,
+          sessionCtx: groupSessionCtx,
+          sessionEntry: {
+            sessionId: "session-1",
+            updatedAt: 1,
+            systemSent: true,
+            chatType: "group",
+            channel: "discord",
+          } as SessionEntry,
+        }),
+      );
+      const secondTurn = requireRunReplyAgentCall(1);
+
+      // The live prompt still gets the intro on the first turn only.
+      expect(firstTurn.followupRun.run.extraSystemPrompt).toContain("GROUP-INTRO");
+      expect(secondTurn.followupRun.run.extraSystemPrompt).not.toContain("GROUP-INTRO");
+
+      // The session-reuse hash input excludes the volatile intro and stays identical across
+      // turns, so claude-cli reuses the session instead of resetting it every group turn (#69118).
+      expect(firstTurn.followupRun.run.extraSystemPromptStatic).not.toContain("GROUP-INTRO");
+      expect(firstTurn.followupRun.run.extraSystemPromptStatic).toContain("GROUP-CHAT-CONTEXT");
+      expect(secondTurn.followupRun.run.extraSystemPromptStatic).toBe(
+        firstTurn.followupRun.run.extraSystemPromptStatic,
+      );
+    } finally {
+      vi.mocked(buildGroupChatContext).mockReturnValue("");
+      vi.mocked(buildGroupIntro).mockReturnValue("");
+    }
+  });
+
   it.each([
     ["/new", "new"],
     ["/reset", "reset"],

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -626,11 +626,12 @@ export async function runPreparedReply(
       fullAccessBlockedReason: fullAccessState.blockedReason,
     }),
   ].filter(Boolean);
-  // Static parts only (no per-message inbound metadata) for CLI session reuse hashing.
+  // Static parts for CLI session-reuse hashing. Excludes per-message inbound metadata and the
+  // first-turn-only groupIntro (still injected into the live prompt above): hashing groupIntro
+  // would drift the fingerprint between turn 1 and later turns, resetting the session (#69118).
   const extraSystemPromptStaticParts = [
     directChatContext,
     groupChatContext,
-    groupIntro,
     groupSystemPrompt,
     buildExecOverridePromptHint({
       execOverrides,


### PR DESCRIPTION
## Summary

On the `claude-cli` backend, agent sessions reset on **every turn transition** in
group-style channels (Discord channels, Telegram groups, etc.). Turn 2 is generated
against a fresh `claude -p` with no memory of turn 1, so the agent appears to have
"amnesia within seconds." This is independent of gateway restarts and is the companion
to #64386 (which covered `mcpConfigHash` drift on restart).

## Root cause

`claude-cli` session reuse is gated by a fingerprint (`extraSystemPromptHash`) computed
in `src/agents/cli-runner/prepare.ts` over the *static* extra system prompt
(`extraSystemPromptStatic`). When the stored hash differs from the freshly computed one,
`resolveCliSessionReuse()` (`src/agents/cli-session.ts`) returns
`invalidatedReason: "system-prompt"`, logged as:

```
cli session reset: provider=claude-cli reason=system-prompt
```

In `src/auto-reply/reply/get-reply-run.ts` `runPreparedReply()`, the hash input
`extraSystemPromptStaticParts` included `groupIntro`. But `groupIntro` is intentionally
**first-turn-only**:

```ts
const shouldInjectGroupIntro = Boolean(
  isGroupChat && (isFirstTurnInSession || sessionEntry?.groupActivationNeedsSystemIntro),
);
```

So the intro is present in the hash input on turn 1 and absent on turn 2 → the fingerprint
drifts between turns → `claude-cli` resets the session on every group turn.

## The fix

Exclude the volatile, first-turn-only `groupIntro` from `extraSystemPromptStaticParts`
(the session-reuse hash input), while still injecting `groupIntro` into the live prompt
(`extraSystemPromptParts`) when appropriate. The static fingerprint is now identical across
turn 1 (intro present in the prompt) and turn 2 (intro absent), so the session is reused and
memory is preserved — consistent with how #64386 stabilized `mcpConfigHash`.

- `src/auto-reply/reply/get-reply-run.ts`: drop `groupIntro` from `extraSystemPromptStaticParts`;
  the live `extraSystemPromptParts` still includes it. Added an inline comment documenting the invariant.

This also removes spurious resets on legitimate re-intros (`groupActivationNeedsSystemIntro`):
the re-intro text is still injected into the prompt but no longer forces a session reset.

## Verification

Work was done in an isolated linked git worktree on `fix/issue-69118-cli-groupintro-hash`
(based on latest `upstream/main`).

Added a focused colocated regression test in
`src/auto-reply/reply/get-reply-run.media-only.test.ts` that drives `runPreparedReply` for a
first turn (groupIntro injected) and a later turn (groupIntro absent), asserting that:
- the live prompt contains the intro on turn 1 only, and
- `extraSystemPromptStatic` is identical across turns and never contains the intro.

Command (run from inside the worktree):

```
node scripts/run-vitest.mjs src/auto-reply/reply/get-reply-run.media-only.test.ts
```

Results:
- With the fix: `Test Files 1 passed (1)` / `Tests 81 passed (81)`, including the new test.
- With the one-line fix reverted (groupIntro re-added to the static parts), the new test fails with
  `expected 'GROUP-CHAT-CONTEXT\n\nGROUP-INTRO' not to contain 'GROUP-INTRO'`, confirming it is a
  true regression test.

Honest scope of testing:
- Unit tests pass locally (Vitest).
- I did **not** run OpenClaw locally (no gateway/CLI/`pnpm dev`/`openclaw`); the live `claude-cli`
  group-channel path was not exercised end-to-end.
- No version bumps and no `CHANGELOG.md` edits.

Fixes #69118
