### PR TITLE
fix(context): report compactable transcript counts

### DIFF
--- a/docs/concepts/context.md
+++ b/docs/concepts/context.md
@@ -21,7 +21,7 @@ Context is _not the same thing_ as "memory": memory can be stored on disk and re
 
 - `/status` → quick "how full is my window?" view + session settings.
 - `/context list` → what's injected + rough sizes (per file + totals).
-- `/context detail` → deeper breakdown: per-file, per-tool schema sizes, per-skill entry sizes, and system prompt size.
+- `/context detail` → deeper breakdown: per-file, per-tool schema sizes, per-skill entry sizes, system prompt size, and compactable transcript message counts.
 - `/context map` → WinDirStat-style treemap image of the current session's tracked context contributors.
 - `/usage tokens` → append per-reply usage footer to normal replies.
 - `/compact` → summarize older history into a compact entry to free window space.
@@ -179,7 +179,7 @@ pluggable interface, lifecycle hooks, and configuration.
 - `System prompt (run)` = captured from the last embedded (tool-capable) run and persisted in the session store.
 - `System prompt (estimate)` = computed on the fly when no run report exists (or when running via a CLI backend that doesn't generate the report).
 
-Either way, it reports sizes and top contributors; it does **not** dump the full system prompt or tool schemas.
+Either way, it reports sizes and top contributors; it does **not** dump the full system prompt or tool schemas. In detailed mode, it also compares the session transcript with the same real-conversation message predicate used by compaction, so high prompt/cache usage is easier to distinguish from compactable conversation history.
 
 ## Related
 

--- a/src/auto-reply/reply/commands-context-report.test.ts
+++ b/src/auto-reply/reply/commands-context-report.test.ts
@@ -1,5 +1,7 @@
 /** Tests context report command output and generated report files. */
-import { readFile, unlink } from "node:fs/promises";
+import { mkdtemp, readFile, rm, unlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import type { SessionEntry } from "../../config/sessions.js";
 import { buildContextReply } from "./commands-context-report.js";
@@ -15,6 +17,9 @@ function makeParams(
     totalTokensFresh?: boolean;
     cfg?: Record<string, unknown>;
     sessionKey?: string;
+    sessionId?: string;
+    sessionFile?: string;
+    storePath?: string;
     agentId?: string;
     currentTurn?: NonNullable<SessionEntry["systemPromptReport"]>["currentTurn"];
   },
@@ -28,12 +33,15 @@ function makeParams(
     sessionKey: options?.sessionKey ?? "agent:default:main",
     workspaceDir: "/tmp/workspace",
     contextTokens: options?.contextTokens ?? null,
+    storePath: options?.storePath,
     provider: "openai",
     model: "gpt-5",
     elevated: { allowed: false },
     resolvedThinkLevel: "off",
     resolvedReasoningLevel: "off",
     sessionEntry: {
+      ...(options?.sessionId ? { sessionId: options.sessionId } : {}),
+      ...(options?.sessionFile ? { sessionFile: options.sessionFile } : {}),
       totalTokens: options?.totalTokens ?? 123,
       totalTokensFresh: options?.totalTokensFresh ?? true,
       inputTokens: 100,
@@ -79,6 +87,27 @@ function makeParams(
     commandArgs: [],
     resolvedElevatedLevel: "off",
   } as unknown as HandleCommandsParams;
+}
+
+async function withTranscript(
+  messages: unknown[],
+  run: (sessionFile: string, dir: string) => Promise<void>,
+): Promise<void> {
+  const dir = await mkdtemp(join(tmpdir(), "openclaw-context-report-"));
+  try {
+    const sessionFile = join(dir, "session.jsonl");
+    const lines = messages.map((message, index) =>
+      JSON.stringify({
+        id: `record-${index + 1}`,
+        timestamp: new Date(index + 1).toISOString(),
+        message,
+      }),
+    );
+    await writeFile(sessionFile, `${lines.join("\n")}\n`, "utf8");
+    await run(sessionFile, dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
 }
 
 describe("buildContextReply", () => {
@@ -143,7 +172,81 @@ describe("buildContextReply", () => {
     expect(result.text).toContain("Tracked prompt estimate: 1,020 chars (~255 tok)");
     expect(result.text).toContain("Actual context usage (cached): 900 tok");
     expect(result.text).toContain("Untracked provider/runtime overhead: ~645 tok");
+    expect(result.text).toContain(
+      "Compactable transcript: unavailable (no active transcript session)",
+    );
     expect(result.text).toContain("Session tokens (cached): 900 total / ctx=8,192");
+  });
+
+  it("reports compactable real conversation messages from the active transcript", async () => {
+    await withTranscript(
+      [
+        { role: "user", content: "Please inspect the repo", timestamp: 1 },
+        {
+          role: "assistant",
+          content: [{ type: "toolCall", toolName: "read", toolCallId: "call-1", args: {} }],
+          timestamp: 2,
+        },
+        {
+          role: "toolResult",
+          content: [{ type: "text", text: "package.json" }],
+          timestamp: 3,
+          toolCallId: "call-1",
+          toolName: "read",
+        },
+      ],
+      async (sessionFile) => {
+        const result = await buildContextReply(
+          makeParams("/context detail", false, {
+            contextTokens: 8_192,
+            totalTokens: 900,
+            sessionId: "session",
+            sessionFile,
+          }),
+        );
+
+        expect(result.text).toContain(
+          "Compactable transcript: 2 real conversation message(s) / 3 transcript message(s)",
+        );
+        expect(result.text).not.toContain("Compaction note:");
+      },
+    );
+  });
+
+  it("explains when cached prompt usage has no compactable conversation messages", async () => {
+    await withTranscript(
+      [
+        {
+          role: "assistant",
+          content: [{ type: "toolCall", toolName: "read", toolCallId: "call-1", args: {} }],
+          timestamp: 1,
+        },
+        {
+          role: "toolResult",
+          content: [{ type: "text", text: "package.json" }],
+          timestamp: 2,
+          toolCallId: "call-1",
+          toolName: "read",
+        },
+      ],
+      async (sessionFile) => {
+        const result = await buildContextReply(
+          makeParams("/context detail", false, {
+            contextTokens: 8_192,
+            totalTokens: 900,
+            sessionId: "session",
+            sessionFile,
+          }),
+        );
+
+        expect(result.text).toContain(
+          "Compactable transcript: 0 real conversation message(s) / 2 transcript message(s)",
+        );
+        expect(result.text).toContain(
+          "Compaction note: prompt/cache usage may be high even when there are no compactable conversation messages.",
+        );
+      },
+    );
   });
 
   it("shows estimate-only detail output when cached context usage is unavailable", async () => {

--- a/src/auto-reply/reply/commands-context-report.ts
+++ b/src/auto-reply/reply/commands-context-report.ts
@@ -2,15 +2,19 @@
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { resolveSessionAgentIds } from "../../agents/agent-scope.js";
 import { analyzeBootstrapBudget } from "../../agents/bootstrap-budget.js";
+import { isRealConversationMessage } from "../../agents/compaction-real-conversation.js";
 import {
   resolveBootstrapMaxChars,
   resolveBootstrapTotalMaxChars,
 } from "../../agents/embedded-agent-helpers/bootstrap.js";
+import type { AgentMessage } from "../../agents/runtime/index.js";
 import { buildSystemPromptReport } from "../../agents/system-prompt-report.js";
 import {
   resolveFreshSessionTotalTokens,
+  type SessionEntry,
   type SessionSystemPromptReport,
 } from "../../config/sessions/types.js";
+import { readSessionMessages } from "../../gateway/session-utils.fs.js";
 import { estimateTokensFromChars } from "../../utils/cjk-chars.js";
 import type { ReplyPayload } from "../types.js";
 import type { HandleCommandsParams } from "./commands-types.js";
@@ -57,6 +61,47 @@ function resolveContextReportAgentId(params: HandleCommandsParams): string {
     config: params.cfg,
     agentId: params.agentId,
   }).sessionAgentId;
+}
+
+type TranscriptCompactabilityReport =
+  | {
+      available: true;
+      totalMessages: number;
+      realConversationMessages: number;
+    }
+  | {
+      available: false;
+      reason: string;
+    };
+
+function resolveTranscriptCompactabilityReport(
+  params: HandleCommandsParams,
+  targetSessionEntry: SessionEntry | undefined,
+): TranscriptCompactabilityReport {
+  const sessionId = targetSessionEntry?.sessionId?.trim();
+  if (!sessionId) {
+    return { available: false, reason: "no active transcript session" };
+  }
+
+  const messages = readSessionMessages(
+    sessionId,
+    params.storePath,
+    targetSessionEntry?.sessionFile,
+  ) as AgentMessage[];
+  if (!messages.length) {
+    return { available: false, reason: "no transcript messages found" };
+  }
+
+  const realConversationMessages = messages.reduce(
+    (count, message, index) =>
+      count + (isRealConversationMessage(message, messages, index) ? 1 : 0),
+    0,
+  );
+  return {
+    available: true,
+    totalMessages: messages.length,
+    realConversationMessages,
+  };
 }
 
 async function resolveContextReport(
@@ -303,6 +348,20 @@ export async function buildContextReply(params: HandleCommandsParams): Promise<R
         : overheadTokens > 0
           ? `Untracked provider/runtime overhead: ~${formatInt(overheadTokens)} tok`
           : "Untracked provider/runtime overhead: not observed in cached usage";
+    const transcriptCompactability = resolveTranscriptCompactabilityReport(
+      params,
+      targetSessionEntry,
+    );
+    const transcriptCompactabilityLines = transcriptCompactability.available
+      ? [
+          `Compactable transcript: ${formatInt(transcriptCompactability.realConversationMessages)} real conversation message(s) / ${formatInt(transcriptCompactability.totalMessages)} transcript message(s)`,
+          ...(transcriptCompactability.realConversationMessages === 0
+            ? [
+                "Compaction note: prompt/cache usage may be high even when there are no compactable conversation messages.",
+              ]
+            : []),
+        ]
+      : [`Compactable transcript: unavailable (${transcriptCompactability.reason})`];
 
     return {
       text: [
@@ -326,6 +385,7 @@ export async function buildContextReply(params: HandleCommandsParams): Promise<R
         trackedPromptLine,
         actualContextLine,
         ...(overheadLine ? [overheadLine] : []),
+        ...transcriptCompactabilityLines,
         "",
         totalsLine,
         "",


### PR DESCRIPTION
## Summary

- Adds a `/context detail` diagnostic line that reports compactable transcript state as real conversation messages vs total transcript messages.
- Reuses the existing compaction real-conversation predicate, so the context report explains the same eligibility rule that `/compact` uses.
- Shows a short note when prompt/cache usage may be high but the active transcript has zero compactable conversation messages.
- Updates the context docs to mention the new detailed transcript compactability count.
- Intentionally out of scope: changing compaction eligibility, transcript rotation, or the normal `/status` card layout.

## Linked context

Closes #91150

Related #83526, #73056

Was this requested by a maintainer or owner?

No direct maintainer request. The issue is labeled `clawsweeper:queueable-fix` and the review comment recommends a narrow diagnostics repair.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: `/context detail` now distinguishes prompt/cache usage from compactable transcript content by reporting the real-conversation message count used by compaction.
- Real environment tested: local OpenClaw checkout on this branch; the `/context detail` command code path was run directly with a JSONL session transcript on disk.
- Exact steps or command run after this patch: `node --import tsx --input-type=module` executed `buildContextReply()` for `/context detail` against a local transcript containing two internal/tool-only records.
- Evidence after fix: copied console output from the local OpenClaw command run:

```text
OpenClaw /context detail local smoke output:
Actual context usage (cached): 900 tok
Compactable transcript: 0 real conversation message(s) / 2 transcript message(s)
Compaction note: prompt/cache usage may be high even when there are no compactable conversation messages.
Session tokens (cached): 900 total / ctx=8,192
```

- Observed result after fix: the detailed context report now shows that cached prompt usage can be 900 tokens while the active transcript has zero compactable real-conversation messages.
- What was not tested: a live Telegram/Codex provider session.
- Proof limitations or environment constraints: this local proof covers the command output and transcript reader path; a maintainer or operator with a long-running provider session can add channel-specific evidence if desired.
- Before evidence: prior `/context detail` output showed tracked/cached/session token buckets but did not read the active transcript or expose compaction eligibility counts.

## Tests and validation

- `node scripts/run-vitest.mjs src/auto-reply/reply/commands-context-report.test.ts src/auto-reply/reply/commands-status.test.ts src/agents/embedded-agent-runner/compact.hooks.test.ts`
- `npm run format:check`
- `git diff --check`

Regression coverage added:

- `/context detail` with a transcript containing real conversation messages reports the compactable count.
- `/context detail` with only internal/tool-only transcript content reports zero real conversation messages and explains the prompt/cache mismatch.

`npm run check:changed` was attempted, but the command hung in the Blacksmith Testbox setup while `pnpm install` retried registry tarball downloads with error code 23. I stopped that hung validation after the targeted tests and format checks had passed.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. `/context detail` prints one additional transcript compactability bucket and a note when the count is zero.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

The new detail view reads the active transcript to count messages.

How is that risk mitigated?

The read is limited to explicit `/context detail`/`deep` output, uses the existing transcript reader, and does not affect the normal status path or compaction predicate.

## Current review state

What is the next action?

Ready for maintainer review and CI.

What is still waiting on author, maintainer, CI, or external proof?

CI and any maintainer preference on the exact wording. The local output proof is included above; a live long-running provider session could provide extra channel-specific confirmation.

Which bot or reviewer comments were addressed?

Addresses the ClawSweeper issue review recommendation to add compactable transcript eligibility and real-conversation message count diagnostics without changing compaction behavior.
