### PR TITLE
fix: prevent A2A target from reverse-calling sessions_send to requester (#39476)

### DIFF
--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -496,6 +496,13 @@ export function createOpenClawCodingTools(options?: {
   /** Visible source replies must be sent through the message tool when set to message_tool_only. */
   sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
   inboundEventKind?: InboundEventKind;
+  /**
+   * True when this run is processing a sessions_send agent-to-agent message. The
+   * target's reply already returns through the sessions_send tool result, so the
+   * routed turn omits sessions_send to stop the target reverse-calling the
+   * requester and duplicating content (issue #39476).
+   */
+  interAgentSendTurn?: boolean;
   /** If true, omit the message tool from the tool list. */
   disableMessageTool?: boolean;
   /** Keep the message tool available even when the selected profile omits it. */
@@ -1024,6 +1031,7 @@ export function createOpenClawCodingTools(options?: {
           requireExplicitMessageTarget: options?.requireExplicitMessageTarget,
           sourceReplyDeliveryMode: options?.sourceReplyDeliveryMode,
           inboundEventKind: options?.inboundEventKind,
+          interAgentSendTurn: options?.interAgentSendTurn,
           disableMessageTool: options?.disableMessageTool,
           enableHeartbeatTool,
           disablePluginTools: !includePluginTools,

--- a/src/agents/embedded-agent-runner/run/attempt.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.test.ts
@@ -126,6 +126,33 @@ describe("buildEmbeddedAttemptToolRunContext", () => {
     expect(context.memoryFlushWritePath).toBe("memory/log.md");
     expect(context.runtimeToolAllowlist).toEqual(["memory_search", "memory_get"]);
   });
+
+  it("flags sessions_send A2A turns so tool construction can drop sessions_send", () => {
+    const context = buildEmbeddedAttemptToolRunContext({
+      trigger: "manual",
+      inputProvenance: {
+        kind: "inter_session",
+        sourceSessionKey: "agent:requester:discord:source",
+        sourceTool: "sessions_send",
+      },
+    });
+    expect(context.interAgentSendTurn).toBe(true);
+  });
+
+  it("does not flag normal user turns or non-send inter-session handoffs", () => {
+    expect(
+      buildEmbeddedAttemptToolRunContext({
+        trigger: "manual",
+        inputProvenance: { kind: "external_user", sourceChannel: "discord" },
+      }).interAgentSendTurn,
+    ).toBeUndefined();
+    expect(
+      buildEmbeddedAttemptToolRunContext({
+        trigger: "manual",
+        inputProvenance: { kind: "inter_session", sourceTool: "subagent_announce" },
+      }).interAgentSendTurn,
+    ).toBeUndefined();
+  });
 });
 
 describe("resolvePromptBuildHookResult", () => {

--- a/src/agents/embedded-agent-runner/run/attempt.tool-run-context.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.tool-run-context.ts
@@ -5,6 +5,10 @@ import {
   freezeDiagnosticTraceContext,
   type DiagnosticTraceContext,
 } from "../../../infra/diagnostic-trace-context.js";
+import {
+  type InputProvenance,
+  isAgentToAgentSendInputProvenance,
+} from "../../../sessions/input-provenance.js";
 import type { EmbeddedRunTrigger } from "./params.js";
 
 /**
@@ -15,12 +19,14 @@ export function buildEmbeddedAttemptToolRunContext(params: {
   jobId?: string;
   memoryFlushWritePath?: string;
   toolsAllow?: string[];
+  inputProvenance?: InputProvenance;
   trace?: DiagnosticTraceContext;
 }): {
   trigger?: EmbeddedRunTrigger;
   jobId?: string;
   memoryFlushWritePath?: string;
   runtimeToolAllowlist?: string[];
+  interAgentSendTurn?: boolean;
   trace?: DiagnosticTraceContext;
 } {
   return {
@@ -28,6 +34,12 @@ export function buildEmbeddedAttemptToolRunContext(params: {
     jobId: params.jobId,
     memoryFlushWritePath: params.memoryFlushWritePath,
     ...(params.toolsAllow ? { runtimeToolAllowlist: params.toolsAllow } : {}),
+    // A sessions_send A2A turn already returns its reply through the tool result.
+    // Flag it so tool construction drops sessions_send and the target cannot
+    // reverse-call the requester (issue #39476).
+    ...(isAgentToAgentSendInputProvenance(params.inputProvenance)
+      ? { interAgentSendTurn: true }
+      : {}),
     // Freeze trace metadata at the attempt boundary so later mutable diagnostic updates do not
     // rewrite the facts attached to tool calls already in flight.
     ...(params.trace ? { trace: freezeDiagnosticTraceContext(params.trace) } : {}),

--- a/src/agents/openclaw-tools.inter-agent-send.test.ts
+++ b/src/agents/openclaw-tools.inter-agent-send.test.ts
@@ -1,0 +1,37 @@
+// Verifies createOpenClawTools drops sessions_send on a sessions_send A2A turn so
+// the target cannot reverse-call the requester and duplicate content (issue #39476).
+import { beforeEach, describe, expect, it } from "vitest";
+import { setActivePluginRegistry } from "../plugins/runtime.js";
+import { createSessionConversationTestRegistry } from "../test-utils/session-conversation-registry.js";
+import { createOpenClawTools } from "./openclaw-tools.js";
+
+const BASE_OPTIONS = {
+  agentSessionKey: "agent:main:discord:channel:target-room",
+  agentChannel: "discord",
+  // Keep construction to shipped core tools so the assertion stays focused.
+  disableMessageTool: true,
+  disablePluginTools: true,
+} as const;
+
+function toolNames(options: Parameters<typeof createOpenClawTools>[0]): string[] {
+  return createOpenClawTools(options).map((tool) => tool.name);
+}
+
+describe("createOpenClawTools sessions_send A2A gate", () => {
+  beforeEach(() => {
+    setActivePluginRegistry(createSessionConversationTestRegistry());
+  });
+
+  it("exposes sessions_send on a normal turn", () => {
+    expect(toolNames(BASE_OPTIONS)).toContain("sessions_send");
+  });
+
+  it("omits sessions_send when the turn is itself a sessions_send A2A turn", () => {
+    const names = toolNames({ ...BASE_OPTIONS, interAgentSendTurn: true });
+    expect(names).not.toContain("sessions_send");
+    // Only the reverse-call vector is removed; other session tools remain so the
+    // target can still read context during the routed turn.
+    expect(names).toContain("sessions_list");
+    expect(names).toContain("sessions_history");
+  });
+});

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -142,6 +142,13 @@ export function createOpenClawTools(
     /** Visible source replies must be sent through the message tool when set to message_tool_only. */
     sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
     inboundEventKind?: InboundEventKind;
+    /**
+     * True when this turn is processing a sessions_send agent-to-agent message.
+     * The reply already returns through the sessions_send tool result, so the
+     * tool is omitted here to stop the target reverse-calling the requester and
+     * posting duplicate content (issue #39476).
+     */
+    interAgentSendTurn?: boolean;
     /** If true, omit the message tool from the tool list. */
     disableMessageTool?: boolean;
     /** If true, include the heartbeat response tool for structured heartbeat outcomes. */
@@ -491,7 +498,10 @@ export function createOpenClawTools(
       config: resolvedConfig,
       callGateway: effectiveCallGateway,
     }),
-    ...(embedded
+    // A sessions_send A2A turn returns the target's reply via the tool result, so
+    // the routed turn must not re-expose sessions_send: otherwise the target can
+    // reverse-call the requester and duplicate the content (issue #39476).
+    ...(embedded || options?.interAgentSendTurn
       ? []
       : [
           createSessionsSendTool({

--- a/src/sessions/input-provenance.test.ts
+++ b/src/sessions/input-provenance.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   annotateInterSessionPromptText,
   isAgentMediatedCompletionSourceTool,
+  isAgentToAgentSendInputProvenance,
   shouldPreserveUserFacingSessionStateForInputProvenance,
   stripInterSessionPromptPrefixForDisplay,
 } from "./input-provenance.js";
@@ -95,6 +96,32 @@ describe("isAgentMediatedCompletionSourceTool", () => {
       expect(isAgentMediatedCompletionSourceTool(sourceTool)).toBe(false);
     },
   );
+});
+
+describe("isAgentToAgentSendInputProvenance", () => {
+  it("identifies an inter-session sessions_send turn", () => {
+    expect(
+      isAgentToAgentSendInputProvenance({
+        kind: "inter_session",
+        sourceSessionKey: "agent:other:discord:source",
+        sourceTool: "sessions_send",
+      }),
+    ).toBe(true);
+  });
+
+  it.each(["subagent_announce", "agent_harness_task", "image_generate"])(
+    "does not flag inter-session %s turns",
+    (sourceTool) => {
+      expect(isAgentToAgentSendInputProvenance({ kind: "inter_session", sourceTool })).toBe(false);
+    },
+  );
+
+  it("does not flag external-user sessions_send provenance or missing provenance", () => {
+    expect(
+      isAgentToAgentSendInputProvenance({ kind: "external_user", sourceTool: "sessions_send" }),
+    ).toBe(false);
+    expect(isAgentToAgentSendInputProvenance(undefined)).toBe(false);
+  });
 });
 
 describe("shouldPreserveUserFacingSessionStateForInputProvenance", () => {

--- a/src/sessions/input-provenance.ts
+++ b/src/sessions/input-provenance.ts
@@ -103,6 +103,18 @@ export function shouldPreserveUserFacingSessionStateForInputProvenance(value: un
   return sourceTool ? USER_FACING_SESSION_STATE_PRESERVING_SOURCE_TOOLS.has(sourceTool) : false;
 }
 
+// True when this turn is processing a sessions_send agent-to-agent message. The
+// target's reply already flows back through the sessions_send tool result, so the
+// routed turn must not expose sessions_send again: otherwise the target can
+// reverse-call the requester and post the same content twice (issue #39476).
+export function isAgentToAgentSendInputProvenance(value: unknown): boolean {
+  const provenance = normalizeInputProvenance(value);
+  if (provenance?.kind !== "inter_session") {
+    return false;
+  }
+  return provenance.sourceTool === "sessions_send";
+}
+
 export function hasInterSessionUserProvenance(
   message: { role?: unknown; provenance?: unknown } | undefined,
 ): boolean {


### PR DESCRIPTION
## Summary

A2A `sessions_send` could post duplicate messages in the requester's channel. When Agent A calls `sessions_send(agentId: "agentB", ...)`, Agent B's reply already flows back to A through the `sessions_send` tool result (and the announce flow). But because the A2A-routed turn still exposed the `sessions_send` tool to Agent B, B could *reverse-call* `sessions_send` back to A during the same turn, so A received the same content twice.

This change removes `sessions_send` from any turn that is itself processing an inter-agent `sessions_send` message, so the target can no longer reverse-call the requester. Result delivery is unchanged (it still happens via the tool return value / announce flow).

Fixes #39476

## Root cause

The initial send (`src/agents/tools/sessions-send-tool.ts`) and the A2A flow (`runSessionsSendA2AFlow` in `src/agents/tools/sessions-send-tool.a2a.ts`) route the requester's message into the target session as an inter-session turn (`inputProvenance.kind = "inter_session"`, `sourceTool = "sessions_send"`) and expose the requester's session via `buildAgentToAgentMessageContext`. The target's per-turn tool list (built in `createOpenClawTools`) still included `sessions_send`, so the target model could call it back at the requester and duplicate the reply that the tool already returns.

## The fix (Option A: code-level tool guard)

Drop `sessions_send` from the target's tool set for the A2A-routed turn:

- `src/sessions/input-provenance.ts`: add `isAgentToAgentSendInputProvenance()`, true when `kind === "inter_session"` and `sourceTool === "sessions_send"`.
- `src/agents/embedded-agent-runner/run/attempt.tool-run-context.ts`: derive `interAgentSendTurn` from the run's `inputProvenance` and forward it into tool construction.
- `src/agents/agent-tools.ts` and `src/agents/openclaw-tools.ts`: thread `interAgentSendTurn` through and skip creating `sessions_send` when it is set.

This covers all A2A target turns (initial send, ping-pong, announce) because they all carry the same provenance, and it is per-turn: a normal (non-A2A) turn restores `sessions_send`. Other session tools (`sessions_list`, `sessions_history`) stay available during the routed turn. `subagent_announce` and other inter-session handoffs use a different `sourceTool` and are unaffected.

Note: this guards the OpenClaw agent loop's `sessions_send` tool. Native-harness (e.g. Codex MCP-bridged) tool exposure is a separate surface and is not changed here.

## Verification

Focused colocated unit tests, run single-worker to keep local CPU low:

- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/agents/openclaw-tools.inter-agent-send.test.ts` -> 2 passed (proves `sessions_send` is present on a normal turn and absent on an A2A turn, while `sessions_list`/`sessions_history` remain).
- `node scripts/run-vitest.mjs src/sessions/input-provenance.test.ts` -> passed (new `isAgentToAgentSendInputProvenance` cases).
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt.test.ts -t "buildEmbeddedAttemptToolRunContext"` -> passed (provenance -> `interAgentSendTurn` derivation).

Intentionally NOT run in this environment to limit local CPU/heat: `tsgo`/typecheck, `pnpm build`, and the full test suite. OpenClaw was NOT run locally (no gateway/CLI); a live multi-agent A2A round-trip was not exercised.
