### PR TITLE
fix(cron): honor configured delivery.channel instead of misrouting (#46899)

### DIFF
--- a/src/cron/delivery-field-schemas.ts
+++ b/src/cron/delivery-field-schemas.ts
@@ -1,4 +1,5 @@
 /** Parses user-provided cron delivery fields into narrow runtime values. */
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import { z, type ZodType } from "zod";
 
@@ -16,6 +17,19 @@ const DeliveryModeFieldSchema = z
 export const LowercaseNonEmptyStringFieldSchema = z.preprocess(
   trimLowercaseStringPreprocess,
   z.string().min(1),
+);
+
+// Persisted/legacy cron jobs may carry `delivery.channel` as a `{ id }` channel
+// reference instead of a bare id. Recover the id so the explicit channel survives
+// normalization; otherwise it is dropped and routing degrades to implicit "last",
+// misrouting delivery to another configured channel (e.g. Feishu instead of Telegram).
+const channelReferenceToId = (value: unknown): unknown =>
+  isRecord(value) && typeof value.id === "string" ? value.id : value;
+
+/** Accepts a channel id string or a `{ id }` channel reference from persisted cron jobs. */
+export const DeliveryChannelFieldSchema = z.preprocess(
+  channelReferenceToId,
+  LowercaseNonEmptyStringFieldSchema,
 );
 
 /** Accepts non-empty string fields after trimming delivery input without changing case. */
@@ -45,7 +59,7 @@ type ParsedDeliveryInput = {
 export function parseDeliveryInput(input: Record<string, unknown>): ParsedDeliveryInput {
   return {
     mode: parseOptionalField(DeliveryModeFieldSchema, input.mode),
-    channel: parseOptionalField(LowercaseNonEmptyStringFieldSchema, input.channel),
+    channel: parseOptionalField(DeliveryChannelFieldSchema, input.channel),
     to: parseOptionalField(TrimmedNonEmptyStringFieldSchema, input.to),
     threadId: parseOptionalField(DeliveryThreadIdFieldSchema, input.threadId),
     accountId: parseOptionalField(TrimmedNonEmptyStringFieldSchema, input.accountId),

--- a/src/cron/normalize.test.ts
+++ b/src/cron/normalize.test.ts
@@ -4,8 +4,10 @@ import {
   validateCronAddParams,
   validateCronUpdateParams,
 } from "../../packages/gateway-protocol/src/index.js";
+import { resolveCronDeliveryPlan } from "./delivery-plan.js";
 import { normalizeCronJobCreate, normalizeCronJobPatch } from "./normalize.js";
 import { DEFAULT_TOP_OF_HOUR_STAGGER_MS } from "./stagger.js";
+import type { CronJob } from "./types.js";
 
 function expectNormalizedAtSchedule(scheduleInput: Record<string, unknown>) {
   const normalized = normalizeCronJobCreate({
@@ -140,6 +142,24 @@ describe("normalizeCronJobCreate", () => {
 
     const delivery = normalized.delivery as Record<string, unknown>;
     expectAnnounceDeliveryTarget(delivery, { channel: "telegram", to: "7200373102" });
+  });
+
+  it("recovers an object-shaped delivery.channel so cron honors the explicit channel (#46899)", () => {
+    const normalized = normalizeIsolatedAgentTurnCreateJob({
+      name: "object channel ref",
+      delivery: {
+        mode: "announce",
+        channel: { id: "telegram" },
+        to: "7200373102",
+      },
+    });
+
+    const delivery = normalized.delivery as Record<string, unknown>;
+    // A persisted `{ id }` channel reference must normalize to the canonical id.
+    // Dropping it degrades routing to implicit "last", which misroutes delivery to
+    // another configured channel (the #46899 Telegram-configured/Feishu-used regression).
+    expectAnnounceDeliveryTarget(delivery, { channel: "telegram", to: "7200373102" });
+    expect(resolveCronDeliveryPlan(normalized as unknown as CronJob).channel).toBe("telegram");
   });
 
   it("coerces ISO schedule.at to normalized ISO (UTC)", () => {


### PR DESCRIPTION
## Summary

A cron job configured with an explicit `delivery.channel` (e.g. Telegram) could be silently misrouted to a different enabled channel (e.g. Feishu) using a stale/leftover recipient id, failing with `Invalid ids: [-1002381931352]`. This makes the configured `delivery.channel` authoritative again by preserving it through cron delivery normalization, so an explicit channel can no longer be overridden by implicit session routing.

## Root cause

`delivery.channel` is canonically a string channel id (`CronMessageChannel`). Cron delivery normalization parses delivery fields in `parseDeliveryInput` (`src/cron/delivery-field-schemas.ts`), where `channel` was validated with the string-only `LowercaseNonEmptyStringFieldSchema`.

When a persisted/legacy cron job carries `delivery.channel` as a channel-reference object (`{ id: "telegram" }`) instead of a bare string, the schema rejects it and `coerceDelivery` (`src/cron/normalize.ts`) deletes the `channel` field. The job is then persisted/hydrated with no channel, so at run time `resolveCronDeliveryPlan` (`src/cron/delivery-plan.ts`) degrades to implicit `"last"` routing. With multiple channels enabled, `"last"` resolves to the session's last channel/recipient — e.g. Feishu with a stale leftover id `-1002381931352` — instead of delivering via Telegram.

## The fix

Recover the canonical channel id from a `{ id }` channel reference during delivery normalization so the explicit channel survives instead of being dropped:

- `src/cron/delivery-field-schemas.ts`: add `DeliveryChannelFieldSchema`, which preprocesses a `{ id: string }` reference into its id before applying the existing lowercase/non-empty string validation, and use it for `channel` in `parseDeliveryInput`.

This keeps the runtime canonical (channel stays a string), normalizes the legacy/alternate shape at the ingress layer (consistent with the architecture rule that legacy shapes normalize before runtime), and preserves the legitimate "no channel configured → `last`" fallback: omitted/empty/`null` channels are untouched, and genuinely unrecoverable shapes (no string `id`) still drop as before.

## Verification

- Focused unit test (single worker, low CPU):
  `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/cron/normalize.test.ts` → **49 passed**.
  New regression test `recovers an object-shaped delivery.channel so cron honors the explicit channel (#46899)` **fails before** the fix (`expected undefined to be 'telegram'`) and **passes after**. It asserts both that normalization preserves `channel: "telegram"` and that `resolveCronDeliveryPlan(...).channel === "telegram"` (never the `"last"` fallback that misroutes to Feishu).
- Earlier combined run of the sibling cron suites also passed: `src/cron/normalize.test.ts src/cron/delivery.test.ts src/cron/delivery-plan.test.ts` → **69 passed**.
- Intentionally skipped to limit local CPU/heat: `tsgo` typecheck, `pnpm build`, and the full suite/broad lint. The change is small and confined to cron delivery normalization (only `parseDeliveryInput`'s channel field consumes the new schema).
- **OpenClaw was NOT run locally** (no gateway/CLI/`openclaw`). Verification is static review plus focused unit tests only; live cron delivery (Telegram/Feishu) was not exercised.

Fixes #46899
