### PR TITLE
fix(xai): clarify x_search query guidance

### DIFF
--- a/extensions/xai/x-search-tool-shared.ts
+++ b/extensions/xai/x-search-tool-shared.ts
@@ -20,7 +20,10 @@ export function createXSearchToolDefinition(
     description:
       "Search X (formerly Twitter) using xAI, including targeted post or thread lookups. For per-post stats like reposts, replies, bookmarks, or views, prefer the exact post URL or status ID.",
     parameters: Type.Object({
-      query: Type.String({ description: "X search query string." }),
+      query: Type.String({
+        description:
+          "Natural-language instruction sent to the Grok X-search agent. Must be meaningful and non-empty.",
+      }),
       allowed_x_handles: Type.Optional(
         Type.Array(Type.String({ minLength: 1 }), {
           description: "Only include posts from these X handles.",

--- a/extensions/xai/x-search.test.ts
+++ b/extensions/xai/x-search.test.ts
@@ -73,6 +73,34 @@ afterEach(() => {
 });
 
 describe("xai x_search tool", () => {
+  it("describes query as the required instruction for the Grok X-search agent", () => {
+    const tool = createXSearchTool({
+      config: {
+        plugins: {
+          entries: {
+            xai: {
+              config: {
+                webSearch: {
+                  apiKey: "xai-plugin-key", // pragma: allowlist secret
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const parameters = tool?.parameters as
+      | { properties?: { query?: { description?: string } } }
+      | undefined;
+    const queryDescription = parameters?.properties?.query?.description;
+
+    expect(queryDescription).toContain("Natural-language instruction");
+    expect(queryDescription).toContain("Grok X-search agent");
+    expect(queryDescription).toContain("meaningful and non-empty");
+    expect(queryDescription).not.toContain("allowed_x_handles");
+  });
+
   it("enables x_search when runtime config carries the shared xAI key", () => {
     const tool = createXSearchTool({
       config: {},


### PR DESCRIPTION
## Summary

- Clarifies the `x_search.query` schema description so models treat it as the natural-language instruction sent to the Grok X-search agent.
- Keeps the fix narrowly scoped to model-facing tool guidance; no runtime request shape, config, auth, or xAI API behavior changes.
- Adds a regression assertion that the registered `query` field says the value must be meaningful and non-empty.

## Linked context

No public issue.

This comes from a real Telegram/Grok failure where `x_search` was called with an empty `query` plus an X handle filter. OpenClaw rejected that call locally with `query required`; later retries used filler queries and the assistant incorrectly told the user there were no recent posts from `@pmarca`.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: `x_search.query` was described only as an "X search query string." In practice, the value is the natural-language input sent to the Grok-backed X-search request, so it must still be meaningful even when structured filters are present. In production Telegram traces, the vague wording led Grok to send empty or filler `query` values and produce misleading user-visible answers. This PR clarifies that `query` is a meaningful, non-empty natural-language instruction sent to the Grok X-search agent.
- Real environment tested: Telegram channel on an OpenClaw gateway using the bundled xAI plugin with this patch applied, model `xai/grok-4.3`, OpenAI Responses runtime, `thinking=xhigh`.
- Exact steps or command run after this patch:
  1. Applied the narrowed `query` description to `extensions/xai/x-search-tool-shared.ts` in the gateway checkout.
  2. Restarted the OpenClaw gateway.
  3. Confirmed gateway startup showed `agent model: xai/grok-4.3 (thinking=xhigh, fast=off)` and the Telegram channel started.
  4. Sent Telegram prompts after restart: `what's new on x based on the people i follow`, `pmarca`, `pmarca`, and `latest x posts from pmarca`.
  5. Inspected `~/.openclaw/agents/main/sessions/*.trajectory.jsonl` for `x_search` tool calls and results.
- Evidence after fix (redacted runtime log excerpt and copied trajectory output):

```text
2026-06-07T11:26:13.594Z [gateway] agent model: xai/grok-4.3 (thinking=xhigh, fast=off)
2026-06-07T11:26:13.800Z [gateway] ready
2026-06-07T11:26:16.435Z [telegram] [default] starting provider

trajectory a1c927d0... run e5817aba... model xai/grok-4.3 thinkLevel=high
prompt: what's new on x based on the people i follow
TOOL_CALL x_search {"query":"what's new on X based on the people I follow","from_date":"2026-06-06","enable_image_understanding":false,"enable_video_understanding":false}
TOOL_RESULT x_search {"isError":false,"query":"what's new on X based on the people I follow","model":"grok-4-1-fast-non-reasoning","tookMs":2861,"citations":[]}
assistant: I can't pull your personal X feed or followed accounts...

same trajectory, follow-up prompt: pmarca
TOOL_CALL x_search {"query":"latest posts and activity from pmarca","allowed_x_handles":["pmarca"],"from_date":"2026-06-06","enable_image_understanding":false,"enable_video_understanding":false}
TOOL_RESULT x_search {"isError":false,"query":"latest posts and activity from pmarca","model":"grok-4-1-fast-non-reasoning","tookMs":9455,"allowedXHandles":["pmarca"],"fromDate":"2026-06-06","citations":["https://x.com/pmarca/status/2063403673980719562","https://x.com/pmarca/status/2063402375046660177","https://x.com/pmarca/status/2063397793260311023","https://x.com/pmarca/status/2063397702852104234","https://x.com/pmarca/status/2063374393330589877"]}

trajectory bc11d51d... run 0e26041e... follow-up prompt: pmarca
TOOL_CALL x_search {"query":"latest posts and recent activity from pmarca","allowed_x_handles":["pmarca"]}
TOOL_RESULT x_search {"isError":false,"query":"latest posts and recent activity from pmarca","model":"grok-4-1-fast-non-reasoning","tookMs":11794,"allowedXHandles":["pmarca"],"citations":["https://x.com/pmarca/status/2063403673980719562","https://x.com/pmarca/status/2063402375046660177","https://x.com/pmarca/status/2063397793260311023","https://x.com/pmarca/status/2063397702852104234","https://x.com/pmarca/status/2063374393330589877"]}

trajectory 4bf68ac8... run b3266823... prompt: latest x posts from pmarca
TOOL_CALL x_search {"query":"latest posts","allowed_x_handles":["pmarca"]}
TOOL_RESULT x_search {"isError":false,"query":"latest posts","model":"grok-4-1-fast-non-reasoning","tookMs":12225,"allowedXHandles":["pmarca"],"citations":["https://x.com/i/status/2039901953317343277","https://x.com/i/status/2063374393330589877","https://x.com/i/status/2063397793260311023","https://x.com/i/status/2063397702852104234","https://x.com/i/status/1505074073897897984"]}
```

- Observed result after fix: After the schema wording change, all tested Telegram turns used non-empty natural-language `query` values. Direct `pmarca` lookups returned successful xAI X-search results with citations instead of the previous local `query required` failure or misleading "no recent posts" response.
- What was not tested: This PR does not make OpenClaw able to read a user's private X account, home timeline, or following list. Requests such as "what's new on X based on the people I follow" still require the user to provide specific public handles, or a future feature that can access the user's X account with the right authorization.
- Proof limitations or environment constraints: Live proof exercised the Telegram channel and bundled xAI `x_search` tool with this patch applied. The proof does not cover private X account access, home timeline access, or following-list access.
- Before evidence (optional but encouraged):

```text
production Telegram trajectory before this fix, prompt: pmarca
TOOL_CALL x_search {"query":"","allowed_x_handles":["pmarca"],"from_date":"2026-05-20","enable_image_understanding":false}
TOOL_RESULT x_search {"status":"error","tool":"x_search","error":"query required"}

same production session retry behavior:
TOOL_CALL x_search {"query":"the","allowed_x_handles":["pmarca"],"from_date":"2026-05-20","enable_image_understanding":false,"enable_video_understanding":false}
TOOL_CALL x_search {"query":"AI","allowed_x_handles":["pmarca"],"enable_image_understanding":false,"enable_video_understanding":false}

another production trajectory before this fix:
TOOL_CALL x_search {"query":"*","allowed_x_handles":["pmarca"],"from_date":"2026-05-20","to_date":"2026-06-04","enable_image_understanding":false,"enable_video_understanding":false}
TOOL_CALL x_search {"query":"pmarca","allowed_x_handles":["pmarca"],"enable_image_understanding":false,"enable_video_understanding":false}
assistant: No recent posts from @pmarca in the current X search results. The tool returned mostly profile info.
```

## Tests and validation

- `pnpm exec oxfmt --check --threads=1 extensions/xai/x-search-tool-shared.ts extensions/xai/x-search.test.ts`
- `pnpm test extensions/xai/x-search.test.ts` - 15 tests passed
- `git diff --check`
- `pnpm changed:lanes --json` - only `extensions` and `extensionTests` lanes selected
- `codex review --base origin/main` - no introduced runtime, schema-projection, or lazy-registration correctness issue found

Regression coverage added: `extensions/xai/x-search.test.ts` now asserts the registered `x_search.query` description identifies the value as a natural-language instruction for the Grok X-search agent, says it must be meaningful and non-empty, and does not mention sibling filter fields such as `allowed_x_handles` inside the query field description.

## Risk checklist

Did user-visible behavior change? (`Yes/No`): Yes

Did config, environment, or migration behavior change? (`Yes/No`): No

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`): No

What is the highest-risk area?

The wording is model-facing, so the main risk is over-constraining model tool-use behavior.

How is that risk mitigated?

The wording is intentionally narrow: it only clarifies that `query` is a meaningful, non-empty natural-language instruction sent to Grok. It does not add a normalizer, change request construction, rename fields, alter filters, change auth, or add configuration.

## Current review state

What is the next action?

Run draft PR CI and review. Address any maintainer, CI, or automated review feedback.

What is still waiting on author, maintainer, CI, or external proof?

Waiting on PR CI and maintainer review.

Which bot or reviewer comments were addressed?

None yet; this is the initial draft PR.
