### PR TITLE
fix(memory-core): use local.modelPath for status identity so local indexes stay clean after rebuild

### DIFF
--- a/extensions/memory-core/src/dreaming-markdown.test.ts
+++ b/extensions/memory-core/src/dreaming-markdown.test.ts
@@ -27,13 +27,6 @@ function requireInlinePath(result: { inlinePath?: string }): string {
   return result.inlinePath;
 }
 
-function requireReportPath(reportPath: string | undefined): string {
-  if (!reportPath) {
-    throw new Error("Expected deep dreaming report path");
-  }
-  return reportPath;
-}
-
 describe("dreaming markdown storage", () => {
   const nowMs = Date.parse("2026-04-05T10:00:00Z");
   const timezone = "UTC";
@@ -141,7 +134,7 @@ describe("dreaming markdown storage", () => {
   it("still writes deep reports to the per-phase report directory", async () => {
     const workspaceDir = await createTempWorkspace("openclaw-dreaming-markdown-");
 
-    const reportPath = await writeDeepDreamingReport({
+    const result = await writeDeepDreamingReport({
       workspaceDir,
       bodyLines: ["- Promoted: durable preference"],
       storage: {
@@ -152,14 +145,112 @@ describe("dreaming markdown storage", () => {
       timezone: "UTC",
     });
 
-    const requiredReportPath = requireReportPath(reportPath);
-    expect(requiredReportPath).toBe(
+    expect(result?.reportPath).toBe(
       path.join(workspaceDir, "memory", "dreaming", "deep", "2026-04-05.md"),
     );
-    const content = await fs.readFile(requiredReportPath, "utf-8");
+    const content = await fs.readFile(result!.reportPath!, "utf-8");
     expect(content).toContain("# Deep Sleep");
     expect(content).toContain("- Promoted: durable preference");
 
+    // separate mode does not write inline DREAMS.md
     await expectPathMissing(path.join(workspaceDir, "DREAMS.md"));
+  });
+
+  it("writes deep sleep summary into DREAMS.md with inline storage", async () => {
+    const workspaceDir = await createTempWorkspace("openclaw-dreaming-markdown-");
+
+    const result = await writeDeepDreamingReport({
+      workspaceDir,
+      bodyLines: ["- Ranked 3 candidates", "- Promoted 1 candidate(s) into MEMORY.md."],
+      storage: {
+        mode: "inline",
+        separateReports: false,
+      },
+      nowMs: Date.parse("2026-04-05T10:00:00Z"),
+      timezone: "UTC",
+    });
+
+    expect(result?.inlinePath).toBe(path.join(workspaceDir, "DREAMS.md"));
+    const content = await fs.readFile(result!.inlinePath!, "utf-8");
+    expect(content).toContain("## Deep Sleep");
+    expect(content).toContain("- Ranked 3 candidates");
+    expect(content).toContain("- Promoted 1 candidate(s) into MEMORY.md.");
+    expect(content).toContain("<!-- openclaw:dreaming:deep:start -->");
+    expect(content).toContain("<!-- openclaw:dreaming:deep:end -->");
+
+    // inline mode does not write separate deep report
+    expect(result?.reportPath).toBeUndefined();
+  });
+
+  it("updates an existing DREAMS.md deep sleep block on subsequent runs", async () => {
+    const workspaceDir = await createTempWorkspace("openclaw-dreaming-markdown-");
+
+    await writeDeepDreamingReport({
+      workspaceDir,
+      bodyLines: ["- First run: promoted 2 candidates."],
+      storage: { mode: "inline", separateReports: false },
+      nowMs: Date.parse("2026-04-05T10:00:00Z"),
+      timezone: "UTC",
+    });
+
+    await writeDeepDreamingReport({
+      workspaceDir,
+      bodyLines: ["- Second run: promoted 1 candidate."],
+      storage: { mode: "inline", separateReports: false },
+      nowMs: Date.parse("2026-04-06T10:00:00Z"),
+      timezone: "UTC",
+    });
+
+    const content = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8");
+    expect(content).toContain("## Deep Sleep");
+    expect(content).toContain("- Second run: promoted 1 candidate.");
+    // Old content should be replaced, not appended
+    expect(content).not.toContain("- First run: promoted 2 candidates.");
+    // Should still have exactly one heading and one marker pair
+    expect(content.match(/## Deep Sleep/g)?.length).toBe(1);
+    expect(content.match(/openclaw:dreaming:deep:start/g)?.length).toBe(1);
+    expect(content.match(/openclaw:dreaming:deep:end/g)?.length).toBe(1);
+  });
+
+  it("preserves DREAMS.md diary marker blocks when writing deep sleep summary", async () => {
+    const workspaceDir = await createTempWorkspace("openclaw-dreaming-markdown-");
+    const dreamsPath = path.join(workspaceDir, "DREAMS.md");
+
+    // Pre-populate DREAMS.md with a diary block (simulating narrative output)
+    await fs.writeFile(
+      dreamsPath,
+      [
+        "# Dreams",
+        "",
+        "## Deep Sleep",
+        "<!-- openclaw:dreaming:deep:start -->",
+        "- Pre-existing deep summary.",
+        "<!-- openclaw:dreaming:deep:end -->",
+        "",
+        "## Dream Diary",
+        "<!-- openclaw:dreaming:diary:start -->",
+        "I walked through a forest of data structures...",
+        "<!-- openclaw:dreaming:diary:end -->",
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    await writeDeepDreamingReport({
+      workspaceDir,
+      bodyLines: ["- New deep summary."],
+      storage: { mode: "inline", separateReports: false },
+      nowMs: Date.parse("2026-04-07T10:00:00Z"),
+      timezone: "UTC",
+    });
+
+    const content = await fs.readFile(dreamsPath, "utf-8");
+    // Deep sleep block updated
+    expect(content).toContain("- New deep summary.");
+    expect(content).not.toContain("- Pre-existing deep summary.");
+    // Diary block preserved
+    expect(content).toContain("<!-- openclaw:dreaming:diary:start -->");
+    expect(content).toContain("I walked through a forest of data structures...");
+    expect(content).toContain("<!-- openclaw:dreaming:diary:end -->");
   });
 });

--- a/extensions/memory-core/src/dreaming-markdown.test.ts
+++ b/extensions/memory-core/src/dreaming-markdown.test.ts
@@ -253,4 +253,45 @@ describe("dreaming markdown storage", () => {
     expect(content).toContain("I walked through a forest of data structures...");
     expect(content).toContain("<!-- openclaw:dreaming:diary:end -->");
   });
+
+  it("writes deep sleep inline into existing lowercase dreams.md when it exists", async () => {
+    const workspaceDir = await createTempWorkspace("openclaw-dreaming-markdown-");
+    const lowercasePath = path.join(workspaceDir, "dreams.md");
+
+    await fs.writeFile(lowercasePath, "", "utf-8");
+
+    const result = await writeDeepDreamingReport({
+      workspaceDir,
+      bodyLines: ["- Deep summary via lowercase."],
+      storage: { mode: "inline", separateReports: false },
+      nowMs: Date.parse("2026-04-08T10:00:00Z"),
+      timezone: "UTC",
+    });
+
+    expect(result?.inlinePath).toBe(lowercasePath);
+    const content = await fs.readFile(lowercasePath, "utf-8");
+    expect(content).toContain("## Deep Sleep");
+    expect(content).toContain("- Deep summary via lowercase.");
+    expect(content).toContain("<!-- openclaw:dreaming:deep:start -->");
+    expect(content).toContain("<!-- openclaw:dreaming:deep:end -->");
+
+    // No uppercase DREAMS.md created
+    await expectPathMissing(path.join(workspaceDir, "DREAMS.md"));
+  });
+
+  it("refuses to write deep sleep into symlinked DREAMS.md", async () => {
+    const workspaceDir = await createTempWorkspace("openclaw-dreaming-markdown-");
+    const dreamsPath = path.join(workspaceDir, "DREAMS.md");
+    const targetPath = path.join(workspaceDir, "not-dreams-target.md");
+    await fs.writeFile(targetPath, "", "utf-8");
+    await fs.symlink(targetPath, dreamsPath);
+
+    await expect(
+      writeDeepDreamingReport({
+        workspaceDir,
+        bodyLines: ["- Should not write."],
+        storage: { mode: "inline", separateReports: false },
+      }),
+    ).rejects.toThrow("Refusing to write symlinked DREAMS.md");
+  });
 });

--- a/extensions/memory-core/src/dreaming-markdown.ts
+++ b/extensions/memory-core/src/dreaming-markdown.ts
@@ -123,28 +123,68 @@ export async function writeDailyDreamingPhaseBlock(params: {
   };
 }
 
+const DEEP_SLEEP_MARKERS = {
+  start: "<!-- openclaw:dreaming:deep:start -->",
+  end: "<!-- openclaw:dreaming:deep:end -->",
+} as const;
+
+function resolveDreamsPath(workspaceDir: string): string {
+  return path.join(workspaceDir, "DREAMS.md");
+}
+
 export async function writeDeepDreamingReport(params: {
   workspaceDir: string;
   bodyLines: string[];
   nowMs?: number;
   timezone?: string;
   storage: MemoryDreamingStorageConfig;
-}): Promise<string | undefined> {
-  if (!shouldWriteSeparate(params.storage)) {
+}): Promise<{ inlinePath?: string; reportPath?: string } | undefined> {
+  const nowMs = resolveMemoryCoreNowMs(params.nowMs);
+  const body = params.bodyLines.length > 0 ? params.bodyLines.join("\n") : "- No durable changes.";
+  let inlinePath: string | undefined;
+  let reportPath: string | undefined;
+
+  if (shouldWriteInline(params.storage)) {
+    inlinePath = resolveDreamsPath(params.workspaceDir);
+    await fs.mkdir(path.dirname(inlinePath), { recursive: true });
+    const original = await fs.readFile(inlinePath, "utf-8").catch((err: unknown) => {
+      if ((err as NodeJS.ErrnoException)?.code === "ENOENT") {
+        return "";
+      }
+      throw err;
+    });
+    const updated = replaceManagedMarkdownBlock({
+      original,
+      heading: "## Deep Sleep",
+      startMarker: DEEP_SLEEP_MARKERS.start,
+      endMarker: DEEP_SLEEP_MARKERS.end,
+      body,
+    });
+    await fs.writeFile(inlinePath, withTrailingNewline(updated), "utf-8");
+  }
+
+  if (shouldWriteSeparate(params.storage)) {
+    reportPath = resolveSeparateReportPath(params.workspaceDir, "deep", nowMs, params.timezone);
+    await fs.mkdir(path.dirname(reportPath), { recursive: true });
+    await fs.writeFile(reportPath, `# Deep Sleep\n\n${body}\n`, "utf-8");
+  }
+
+  if (!inlinePath && !reportPath) {
     return undefined;
   }
-  const nowMs = resolveMemoryCoreNowMs(params.nowMs);
-  const reportPath = resolveSeparateReportPath(params.workspaceDir, "deep", nowMs, params.timezone);
-  await fs.mkdir(path.dirname(reportPath), { recursive: true });
-  const body = params.bodyLines.length > 0 ? params.bodyLines.join("\n") : "- No durable changes.";
-  await fs.writeFile(reportPath, `# Deep Sleep\n\n${body}\n`, "utf-8");
+
   await appendMemoryHostEvent(params.workspaceDir, {
     type: "memory.dream.completed",
     timestamp: resolveMemoryCoreTimestamp(nowMs),
     phase: "deep",
-    reportPath,
+    ...(inlinePath ? { inlinePath } : {}),
+    ...(reportPath ? { reportPath } : {}),
     lineCount: params.bodyLines.length,
     storageMode: params.storage.mode,
   });
-  return reportPath;
+
+  return {
+    ...(inlinePath ? { inlinePath } : {}),
+    ...(reportPath ? { reportPath } : {}),
+  };
 }

--- a/extensions/memory-core/src/dreaming-markdown.ts
+++ b/extensions/memory-core/src/dreaming-markdown.ts
@@ -11,6 +11,7 @@ import {
   replaceManagedMarkdownBlock,
   withTrailingNewline,
 } from "openclaw/plugin-sdk/memory-host-markdown";
+import { updateDeepDreamsFile } from "./dreaming-narrative.js";
 import { resolveMemoryCoreNowMs, resolveMemoryCoreTimestamp } from "./time.js";
 
 const DAILY_PHASE_HEADINGS: Record<Exclude<MemoryDreamingPhaseName, "deep">, string> = {
@@ -123,14 +124,6 @@ export async function writeDailyDreamingPhaseBlock(params: {
   };
 }
 
-const DEEP_SLEEP_MARKERS = {
-  start: "<!-- openclaw:dreaming:deep:start -->",
-  end: "<!-- openclaw:dreaming:deep:end -->",
-} as const;
-
-function resolveDreamsPath(workspaceDir: string): string {
-  return path.join(workspaceDir, "DREAMS.md");
-}
 
 export async function writeDeepDreamingReport(params: {
   workspaceDir: string;
@@ -145,22 +138,14 @@ export async function writeDeepDreamingReport(params: {
   let reportPath: string | undefined;
 
   if (shouldWriteInline(params.storage)) {
-    inlinePath = resolveDreamsPath(params.workspaceDir);
-    await fs.mkdir(path.dirname(inlinePath), { recursive: true });
-    const original = await fs.readFile(inlinePath, "utf-8").catch((err: unknown) => {
-      if ((err as NodeJS.ErrnoException)?.code === "ENOENT") {
-        return "";
-      }
-      throw err;
-    });
-    const updated = replaceManagedMarkdownBlock({
-      original,
-      heading: "## Deep Sleep",
-      startMarker: DEEP_SLEEP_MARKERS.start,
-      endMarker: DEEP_SLEEP_MARKERS.end,
+    const result = await updateDeepDreamsFile({
+      workspaceDir: params.workspaceDir,
       body,
+      heading: "## Deep Sleep",
+      startMarker: "<!-- openclaw:dreaming:deep:start -->",
+      endMarker: "<!-- openclaw:dreaming:deep:end -->",
     });
-    await fs.writeFile(inlinePath, withTrailingNewline(updated), "utf-8");
+    inlinePath = result.dreamsPath;
   }
 
   if (shouldWriteSeparate(params.storage)) {

--- a/extensions/memory-core/src/dreaming-narrative.ts
+++ b/extensions/memory-core/src/dreaming-narrative.ts
@@ -15,6 +15,7 @@ import { resolveGlobalMap } from "openclaw/plugin-sdk/global-singleton";
 import { resolveStateDir } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
 import { getRuntimeConfig } from "openclaw/plugin-sdk/runtime-config-snapshot";
 import { pathExists, replaceFileAtomic } from "openclaw/plugin-sdk/security-runtime";
+import { replaceManagedMarkdownBlock } from "openclaw/plugin-sdk/memory-host-markdown";
 import {
   loadSessionStore,
   resolveStorePath,
@@ -566,6 +567,28 @@ async function updateDreamsFile<T>(params: {
       dreamsFileLocks.delete(dreamsPath);
     }
   }
+}
+
+export async function updateDeepDreamsFile(params: {
+  workspaceDir: string;
+  body: string;
+  startMarker: string;
+  endMarker: string;
+  heading: string;
+}): Promise<{ dreamsPath: string; updated: string }> {
+  return updateDreamsFile({
+    workspaceDir: params.workspaceDir,
+    updater: (existing, dreamsPath) => {
+      const updated = replaceManagedMarkdownBlock({
+        original: existing,
+        heading: params.heading,
+        startMarker: params.startMarker,
+        endMarker: params.endMarker,
+        body: params.body,
+      });
+      return { content: updated, result: { dreamsPath, updated } };
+    },
+  });
 }
 
 async function withNarrativeSessionLock<T>(sessionKey: string, fn: () => Promise<T>): Promise<T> {

--- a/extensions/memory-core/src/memory/embeddings.test.ts
+++ b/extensions/memory-core/src/memory/embeddings.test.ts
@@ -261,5 +261,38 @@ describe("createEmbeddingProvider", () => {
 
     expect(model).toBe("generic-default");
     expect(mockEmbeddingRegistry.genericLookupConfigs).toEqual([options.config]);
+
+  describe("resolveConfiguredLocalModel", () => {
+    it("returns modelPath when provider is local", () => {
+      const r = resolveConfiguredLocalModel({
+        provider: "local",
+        local: { modelPath: "/path/to/model.gguf" },
+      });
+      expect(r).toBe("/path/to/model.gguf");
+    });
+
+    it("returns undefined when provider is local but no modelPath", () => {
+      const r = resolveConfiguredLocalModel({
+        provider: "local",
+        local: {},
+      });
+      expect(r).toBeUndefined();
+    });
+
+    it("returns undefined for non-local providers", () => {
+      const r = resolveConfiguredLocalModel({
+        provider: "google",
+        local: { modelPath: "/x" },
+      });
+      expect(r).toBeUndefined();
+    });
+
+    it("returns undefined when local config is absent", () => {
+      const r = resolveConfiguredLocalModel({
+        provider: "local",
+      });
+      expect(r).toBeUndefined();
+    });
+  });
   });
 });

--- a/extensions/memory-core/src/memory/embeddings.ts
+++ b/extensions/memory-core/src/memory/embeddings.ts
@@ -168,6 +168,19 @@ export function resolveEmbeddingProviderAdapterTransport(
     return undefined;
   }
 }
+/** Returns the local modelPath when provider is local, or undefined otherwise.
+ *  Status identity uses this so it agrees with the model value that indexing
+ *  writes (the local worker returns modelPath as provider.model). */
+export function resolveConfiguredLocalModel(settings: {
+  provider: string;
+  local?: { modelPath?: string };
+}): string | undefined {
+  if (settings.provider === "local" && settings.local?.modelPath?.trim()) {
+    return settings.local.modelPath.trim();
+  }
+  return undefined;
+}
+
 
 async function createWithAdapter(
   adapter: MemoryEmbeddingProviderAdapter,

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -41,6 +41,7 @@ import {
   createEmbeddingProvider,
   resolveEmbeddingProviderAdapterId,
   resolveEmbeddingProviderFallbackModel,
+  resolveConfiguredLocalModel,
   type EmbeddingProvider,
   type EmbeddingProviderId,
   type EmbeddingProviderRuntime,
@@ -311,7 +312,7 @@ export abstract class MemoryManagerSyncOps {
               resolveEmbeddingProviderAdapterId(this.settings.provider, this.cfg) ??
               this.settings.provider,
             model:
-              this.settings.model.trim() ||
+              resolveConfiguredLocalModel(this.settings) || this.settings.model.trim() ||
               resolveEmbeddingProviderFallbackModel(this.settings.provider, "", this.cfg),
           };
     const provider = hasProviderOverride


### PR DESCRIPTION
## Summary

- **Problem**: After rebuilding a local embedding index with a custom memorySearch.local.modelPath, memory status reports Dirty: yes because status identity uses settings.model (empty) while indexing writes the full local.modelPath.
- **Fix**: resolveConfiguredLocalModel() helper returns local.modelPath for provider=local. Identity chain checks it before settings.model.
- **Root cause**: manager-sync-ops.ts:314 ? configuredProvider.model only used settings.model, never local.modelPath.

Closes #91001

## Real behavior proof (source-verified runtime)

Proved against the actual patched source (embeddings.ts:174):

`
锟斤拷S