### PR TITLE
feat(tui,gateway): show CLI-routing label in /model picker

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -4692,6 +4692,7 @@ public struct ModelChoice: Codable, Sendable {
     public let available: Bool?
     public let contextwindow: Int?
     public let reasoning: Bool?
+    public let runtimelabel: String?
 
     public init(
         id: String,
@@ -4700,7 +4701,8 @@ public struct ModelChoice: Codable, Sendable {
         alias: String?,
         available: Bool? = nil,
         contextwindow: Int?,
-        reasoning: Bool?)
+        reasoning: Bool?,
+        runtimelabel: String?)
     {
         self.id = id
         self.name = name
@@ -4709,6 +4711,7 @@ public struct ModelChoice: Codable, Sendable {
         self.available = available
         self.contextwindow = contextwindow
         self.reasoning = reasoning
+        self.runtimelabel = runtimelabel
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -4719,6 +4722,7 @@ public struct ModelChoice: Codable, Sendable {
         case available
         case contextwindow = "contextWindow"
         case reasoning
+        case runtimelabel = "runtimeLabel"
     }
 }
 

--- a/packages/gateway-protocol/src/schema/agents-models-skills.ts
+++ b/packages/gateway-protocol/src/schema/agents-models-skills.ts
@@ -21,6 +21,7 @@ export const ModelChoiceSchema = Type.Object(
     available: Type.Optional(Type.Boolean()),
     contextWindow: Type.Optional(Type.Integer({ minimum: 1 })),
     reasoning: Type.Optional(Type.Boolean()),
+    runtimeLabel: Type.Optional(NonEmptyString),
   },
   { additionalProperties: false },
 );

--- a/src/agents/model-selection-cli.ts
+++ b/src/agents/model-selection-cli.ts
@@ -22,3 +22,22 @@ export function isCliProvider(provider: string, cfg?: OpenClawConfig): boolean {
   }
   return false;
 }
+
+/**
+ * Resolve the user-facing integration label for a model entry. Returns "CLI"
+ * when the model is pinned to a CLI backend via `agentRuntime.id` in user
+ * config, otherwise undefined. Intended for picker/status display only —
+ * never used as a routing key.
+ */
+export function resolveModelRuntimeLabel(
+  provider: string,
+  modelId: string,
+  cfg?: OpenClawConfig,
+): string | undefined {
+  const modelKey = `${provider}/${modelId}`;
+  const runtimeId = cfg?.agents?.defaults?.models?.[modelKey]?.agentRuntime?.id;
+  if (runtimeId && isCliProvider(runtimeId, cfg)) {
+    return "CLI";
+  }
+  return undefined;
+}

--- a/src/gateway/server-methods/models-list-result.ts
+++ b/src/gateway/server-methods/models-list-result.ts
@@ -25,13 +25,14 @@ import {
   resolveVisibleModelCatalog,
 } from "../../agents/model-catalog-visibility.js";
 import type { ModelCatalogEntry } from "../../agents/model-catalog.types.js";
+import { resolveModelRuntimeLabel } from "../../agents/model-selection-cli.js";
 import { resolveDefaultAgentWorkspaceDir } from "../../agents/workspace.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { isSecretRef } from "../../config/types.secrets.js";
 import type { GatewayRequestContext } from "./types.js";
 
 type ModelsListView = ModelCatalogBrowseView;
-type ModelsListEntry = ModelCatalogEntry & { available?: boolean };
+type ModelsListEntry = ModelCatalogEntry & { available?: boolean; runtimeLabel?: string };
 type ModelsListAvailability = boolean | undefined;
 type ModelsListProviderAuthChecker = (
   provider: string,
@@ -223,21 +224,25 @@ async function buildPublicModelsListEntry(params: {
   providerAuthChecker?: ModelsListProviderAuthChecker;
 }): Promise<ModelsListEntry> {
   const publicEntry = omitRuntimeModelParams(params.entry);
+  const runtimeLabel = resolveModelRuntimeLabel(params.entry.provider, params.entry.id, params.cfg);
+  const withRuntimeLabel: ModelsListEntry = runtimeLabel
+    ? { ...publicEntry, runtimeLabel }
+    : publicEntry;
   if (modelCatalogEntryHasUnknownSecretRefAvailability(params.cfg, params.entry)) {
     return {
-      ...publicEntry,
+      ...withRuntimeLabel,
       available: false,
     };
   }
   if (!params.providerAuthChecker) {
-    return publicEntry;
+    return withRuntimeLabel;
   }
   const available = await resolveModelsListEntryAvailability(
     params.providerAuthChecker,
     params.entry,
   );
   return {
-    ...publicEntry,
+    ...withRuntimeLabel,
     available: available ?? false,
   };
 }

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -5,6 +5,7 @@ import { agentCommandFromIngress } from "../agents/agent-command.js";
 import { resolveDefaultAgentId, resolveSessionAgentId } from "../agents/agent-scope.js";
 import { ensureContextWindowCacheLoaded } from "../agents/context.js";
 import { DEFAULT_PROVIDER } from "../agents/defaults.js";
+import { resolveModelRuntimeLabel } from "../agents/model-selection-cli.js";
 import {
   buildAllowedModelSet,
   buildConfiguredModelCatalog,
@@ -577,6 +578,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
       provider: entry.provider,
       contextWindow: entry.contextWindow,
       reasoning: entry.reasoning,
+      runtimeLabel: resolveModelRuntimeLabel(entry.provider, entry.id, cfg),
     }));
   }
 

--- a/src/tui/tui-backend.ts
+++ b/src/tui/tui-backend.ts
@@ -111,6 +111,12 @@ export type TuiModelChoice = {
   provider: string;
   contextWindow?: number;
   reasoning?: boolean;
+  /**
+   * Optional integration-route label shown as the picker description (e.g.
+   * "CLI" for models routed through a local CLI backend). When set, takes
+   * precedence over the human-readable model name.
+   */
+  runtimeLabel?: string;
 };
 
 /** Result shape returned by session mutation commands. */

--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -1149,6 +1149,29 @@ describe("tui command handlers", () => {
     expect(closeOverlay).toHaveBeenCalledTimes(1);
   });
 
+  it("uses runtimeLabel as model selector description when provided", async () => {
+    const listModels = vi.fn().mockResolvedValue([
+      {
+        provider: "anthropic",
+        id: "claude-sonnet-4-6",
+        name: "Claude Sonnet 4.6",
+        runtimeLabel: "CLI",
+      },
+      {
+        provider: "openrouter",
+        id: "openrouter/auto",
+        name: "OpenRouter Auto",
+      },
+    ]);
+    const { handleCommand, openOverlay } = createHarness({ listModels });
+
+    await handleCommand("/model");
+
+    const selector = firstMockArg(openOverlay, "openOverlay") as SelectableOverlay;
+    expect(selector?.items?.[0]?.description).toBe("CLI");
+    expect(selector?.items?.[1]?.description).toBe("OpenRouter Auto");
+  });
+
   it("renders model listing feedback before the backend list resolves", async () => {
     let resolveModels: (
       value: Array<{ provider: string; id: string; name?: string }>,

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -175,10 +175,12 @@ export function createCommandHandlers(context: CommandHandlerContext) {
       }
       const items = models.map((model) => {
         const ref = modelKey(model.provider, model.id);
+        const description =
+          model.runtimeLabel ?? (model.name && model.name !== model.id ? model.name : "");
         return {
           value: ref,
           label: ref,
-          description: model.name && model.name !== model.id ? model.name : "",
+          description,
         };
       });
       const selector = createSearchableSelectList(items, 9);


### PR DESCRIPTION
## Summary

The `/model` picker today shows the human-readable model name as the description line (e.g. `anthropic/claude-opus-4-6  Claude Opus 4.6`). When a model is pinned to a CLI backend via user-config `agents.defaults.models[...].agentRuntime.id` (e.g. `claude-cli`, `google-antigravity-cli`), the user has no immediate visual cue that the model will be routed through a local CLI rather than the direct API.

This PR adds an optional `runtimeLabel` field to `TuiModelChoice` and the gateway `ModelChoiceSchema`, and shows it in the picker as `"CLI"` whenever the user has pinned a CLI runtime. The runtime label takes precedence over the model name; falls back to the existing display name otherwise.

## Scope

Display-only — never used as a routing key. Symmetrical between both list-models sources:

- `src/agents/model-selection-cli.ts` — new helper `resolveModelRuntimeLabel(provider, modelId, cfg)` next to the existing `isCliProvider`.
- `src/tui/embedded-backend.ts` — `listModels()` populates `runtimeLabel` for embedded mode.
- `src/gateway/server-methods/models-list-result.ts` — `buildPublicModelsListEntry` populates `runtimeLabel` for the gateway RPC.
- `packages/gateway-protocol/src/schema/agents-models-skills.ts` — `ModelChoiceSchema` gains `runtimeLabel: Type.Optional(NonEmptyString)`.
- `src/tui/tui-backend.ts` — `TuiModelChoice` gains `runtimeLabel?: string`.
- `src/tui/tui-command-handlers.ts` — picker description prefers `runtimeLabel` over `name`.

## Deliberately Out Of Scope

- 3-way classification (`CLI`/`OAuth`/`API`). MVP only emits `"CLI"`. OAuth-vs-API requires inspecting per-agent auth-profiles and is left to a follow-up PR.
- Statusline format (`runtime-id/model-id` → `provider/model-id`). Separate root cause — `sessionInfo.modelProvider` carries the runtime id; needs deeper investigation.

## Real behavior proof

**Behavior or issue addressed:** Picker did not show whether a model is routed through a CLI backend; the description line repeated the human-readable name.

**Real environment tested:** macOS, source repo `/Users/rob/Development/openclaw`, branch `feature/display-runtime-labels`. User config `~/.openclaw/openclaw.json` has `anthropic/claude-*` pinned to `agentRuntime.id = "claude-cli"` and `google/gemini-*` pinned to `agentRuntime.id = "google-antigravity-cli"`.

**Exact steps or command run after this patch:**

```
pnpm exec vitest run \
  src/tui/embedded-backend.test.ts \
  src/tui/tui-command-handlers.test.ts \
  src/agents/model-selection-cli.test.ts \
  src/gateway/server.models-voicewake-misc.test.ts
pnpm tsgo:core
pnpm tsgo:extensions
```

**Evidence after fix:** Terminal output, real run, no mocks beyond the new unit-test fixture:

```
Test Files  4 passed (4)
      Tests  114 passed (114)
```

`pnpm tsgo:core` exit=0, `pnpm tsgo:extensions` exit=0.

**Observed result after fix:** Picker description column now shows `"CLI"` for any model whose user-config `agentRuntime.id` resolves to a CLI backend via `isCliProvider(...)`. Models without a pinned CLI runtime continue to show the human-readable name as before.

**What was not tested:**

- Live `/model` picker in a running TUI session against this source build (deferred to user smoke after merge or via `pnpm gateway:dev`).
- 3-way OAuth/API classification (out of scope, see above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)