### PR TITLE
fix(logging): improve memory pressure log readability

### DIFF
--- a/src/logging/diagnostic-memory.test.ts
+++ b/src/logging/diagnostic-memory.test.ts
@@ -347,15 +347,22 @@ describe("diagnostic memory", () => {
       stop();
     }
 
+    const criticalRecord = records.find((r) =>
+      r.message?.includes("memory pressure: level=critical reason=rss_threshold"),
+    );
+    expect(criticalRecord).toEqual(
+      expect.objectContaining({
+        level: "WARN",
+        message: expect.stringContaining("rss=3.9 KiB"),
+        attributes: expect.objectContaining({
+          subsystem: "gateway/diagnostics/memory",
+        }),
+      }),
+    );
+    expect(criticalRecord?.message).toContain("heap=2.9 KiB");
+    expect(criticalRecord?.message).toContain("threshold=2.9 KiB");
     expect(records).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({
-          level: "WARN",
-          message: expect.stringContaining("memory pressure: level=critical reason=rss_threshold"),
-          attributes: expect.objectContaining({
-            subsystem: "gateway/diagnostics/memory",
-          }),
-        }),
         expect.objectContaining({
           level: "WARN",
           message:
@@ -366,6 +373,44 @@ describe("diagnostic memory", () => {
         }),
       ]),
     );
+  });
+
+  it("logs warning pressure at WARN level with readable format", async () => {
+    setLoggerOverride({ level: "info", consoleLevel: "silent" });
+    const records: Array<Extract<DiagnosticEventPayload, { type: "log.record" }>> = [];
+    const stop = onInternalDiagnosticEvent((event) => {
+      if (event.type === "log.record") {
+        records.push(event);
+      }
+    });
+    try {
+      emitDiagnosticMemorySample({
+        now: Date.parse("2026-04-22T12:00:00.000Z"),
+        memoryUsage: memoryUsage({ rss: 2000, heapUsed: 500 }),
+        thresholds: {
+          rssWarningBytes: 1000,
+          rssCriticalBytes: 4000,
+          pressureRepeatMs: 60_000,
+        },
+      });
+      await flushDiagnosticEvents();
+    } finally {
+      stop();
+    }
+
+    const warningRecord = records.find((r) =>
+      r.message?.includes("memory pressure: level=warning reason=rss_threshold"),
+    );
+    expect(warningRecord).toEqual(
+      expect.objectContaining({
+        level: "WARN",
+        message: expect.stringContaining("rss=2.0 KiB"),
+        attributes: expect.objectContaining({
+          subsystem: "gateway/diagnostics/memory",
+        }),
+      }),
+    );
+    expect(warningRecord?.message).toContain("(200%)");
   });
 
   it("writes a stability bundle when critical pressure is emitted", () => {

--- a/src/logging/diagnostic-memory.ts
+++ b/src/logging/diagnostic-memory.ts
@@ -164,11 +164,37 @@ function formatOptionalPressureMetric(label: string, value: number | undefined):
   return typeof value === "number" && Number.isFinite(value) ? ` ${label}=${value}` : "";
 }
 
+function formatBytes(value: number | undefined): string {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return "n/a";
+  }
+  const units = ["B", "KiB", "MiB", "GiB"];
+  let amount = Math.max(0, value);
+  let unitIndex = 0;
+  while (amount >= 1024 && unitIndex < units.length - 1) {
+    amount /= 1024;
+    unitIndex += 1;
+  }
+  const digits = unitIndex === 0 || amount >= 100 ? 0 : 1;
+  return `${amount.toFixed(digits)} ${units[unitIndex]}`;
+}
+
 function logMemoryPressure(params: {
   pressure: Omit<DiagnosticMemoryPressureEvent, "seq" | "ts" | "type">;
   writeCriticalBundle: boolean;
 }): void {
   const { pressure } = params;
+  const thresholdPercent =
+    typeof pressure.thresholdBytes === "number" && Number.isFinite(pressure.thresholdBytes)
+      ? Math.round((pressure.memory.rssBytes / pressure.thresholdBytes) * 100)
+      : undefined;
+  const readableSuffix =
+    ` rss=${formatBytes(pressure.memory.rssBytes)}` +
+    ` heap=${formatBytes(pressure.memory.heapUsedBytes)}` +
+    (typeof pressure.thresholdBytes === "number"
+      ? ` threshold=${formatBytes(pressure.thresholdBytes)}`
+      : "") +
+    (typeof thresholdPercent === "number" ? ` (${thresholdPercent}%)` : "");
   const message =
     `memory pressure: level=${pressure.level} reason=${pressure.reason}` +
     ` rssBytes=${pressure.memory.rssBytes}` +
@@ -176,14 +202,11 @@ function logMemoryPressure(params: {
     formatOptionalPressureMetric("thresholdBytes", pressure.thresholdBytes) +
     formatOptionalPressureMetric("rssGrowthBytes", pressure.rssGrowthBytes) +
     formatOptionalPressureMetric("windowMs", pressure.windowMs) +
+    readableSuffix +
     (pressure.level === "critical"
       ? ` memoryPressureSnapshot=${params.writeCriticalBundle ? "enabled" : "disabled"}`
       : "");
-  if (pressure.level === "critical") {
-    log.warn(message);
-  } else {
-    log.info(message);
-  }
+  log.warn(message);
 }
 
 export function emitDiagnosticMemorySample(options?: {


### PR DESCRIPTION
Fixes #90783

## Summary

The `gateway/diagnostics/memory` subsystem emits memory pressure warnings that are currently non-actionable:
- Warning level uses `log.info` instead of `log.warn` (log level disagrees with message content)
- Raw byte values without units are hard to read (`rssBytes=2012905472`)
- No percentage indicator for threshold comparison

This PR addresses these issues while preserving backward compatibility for log parsers.

## Changes

1. **Log level fix**: Changed from `log.info` to `log.warn` for warning-level pressure, matching critical pressure behavior
2. **Human-readable format**: Added `formatBytes()` helper with IEC units (KiB/MiB/GiB)
3. **Threshold percentage**: Added percentage indicator for quick assessment
4. **Backward compatible**: Original `*Bytes` fields preserved, new readable fields appended

## Before

```
memory pressure: level=warning reason=rss_threshold rssBytes=2012905472 heapUsedBytes=1307038712 thresholdBytes=1610612736
```

## After

```
memory pressure: level=warning reason=rss_threshold rssBytes=2012905472 heapUsedBytes=1307038712 thresholdBytes=1610612736 rss=1.9 GiB heap=1.2 GiB threshold=1.5 GiB (125%)
```

## Test Plan

- Unit tests: `npm test src/logging/diagnostic-memory.test.ts` (11 tests pass)
- Added new test case verifying warning-level log uses WARN and contains readable format
- Verified backward compatibility: original byte fields still present in output