### PR TITLE
fix(memory): align local modelPath index identity on status

### DIFF
--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -74,6 +74,7 @@ vi.mock("./embeddings.js", () => {
       provider?: string;
       model?: string;
       outputDimensionality?: number;
+      local?: { modelPath?: string };
     }) => {
       providerCalls.push({
         provider: options.provider,
@@ -86,6 +87,24 @@ vi.mock("./embeddings.js", () => {
           provider: null,
           requestedProvider: options.provider ?? "auto",
           providerUnavailableReason: "No API key found for provider",
+        };
+      }
+      if (options.provider === "local") {
+        const modelPath = options.local?.modelPath?.trim() || DEFAULT_LOCAL_MODEL;
+        return {
+          requestedProvider: "local",
+          provider: {
+            id: "local",
+            model: modelPath,
+            close: async () => {
+              providerCloseCalls += 1;
+            },
+            embedQuery: async (text: string) => embedText(text),
+            embedBatch: async (texts: string[]) => {
+              embedBatchCalls += 1;
+              return texts.map(embedText);
+            },
+          },
         };
       }
       const providerId =
@@ -278,6 +297,7 @@ describe("memory index", () => {
     provider?: string;
     fallback?: "none" | "gemini" | "fallback-provider";
     providerAliases?: NonNullable<NonNullable<TestCfg["models"]>["providers"]>;
+    local?: { modelPath?: string; contextSize?: number };
     model?: string;
     outputDimensionality?: number;
     multimodal?: {
@@ -298,7 +318,8 @@ describe("memory index", () => {
           memorySearch: {
             ...(params.provider !== undefined ? { provider: params.provider } : {}),
             model: params.model ?? "mock-embed",
-            fallback: params.fallback,
+            fallback: params.fallback ?? (params.provider === "local" ? "none" : undefined),
+            local: params.local,
             outputDimensionality: params.outputDimensionality,
             store: { path: params.storePath, vector: { enabled: params.vectorEnabled ?? false } },
             // Perf: keep test indexes to a single chunk to reduce sqlite work.
@@ -456,6 +477,30 @@ describe("memory index", () => {
       });
     } finally {
       await nextManager.close?.();
+    }
+  });
+
+  it("keeps status clean when local provider uses custom modelPath", async () => {
+    const customModelPath = "/home/node/.node-llama-cpp/models/embeddinggemma-300M-Q8_0.gguf";
+    const dbPath = path.join(workspaceDir, "index-local-modelpath-status.sqlite");
+    const cfg = createCfg({
+      storePath: dbPath,
+      provider: "local",
+      local: { modelPath: customModelPath },
+      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
+    });
+    const indexManager = await getFreshManager(cfg);
+    await indexManager.sync({ reason: "test", force: true });
+    await indexManager.close?.();
+
+    const statusManager = await getFreshManager(cfg, "status");
+    try {
+      const status = statusManager.status();
+
+      expect(status.dirty).toBe(false);
+      expect(status.custom?.indexIdentity).toEqual({ status: "valid" });
+    } finally {
+      await statusManager.close?.();
     }
   });
 

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -504,6 +504,43 @@ describe("memory index", () => {
     }
   });
 
+  it("keeps status clean when local provider alias resolves to indexed modelPath", async () => {
+    const customModelPath = "/models/custom-embed.gguf";
+    const dbPath = path.join(workspaceDir, "index-local-alias-modelpath-status.sqlite");
+    const indexCfg = createCfg({
+      storePath: dbPath,
+      provider: "local",
+      local: { modelPath: customModelPath },
+      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
+    });
+    const indexManager = await getFreshManager(indexCfg);
+    await indexManager.sync({ reason: "test", force: true });
+    await indexManager.close?.();
+
+    const statusCfg = createCfg({
+      storePath: dbPath,
+      provider: "local-home",
+      fallback: "none",
+      providerAliases: {
+        "local-home": {
+          api: "local",
+          models: [],
+        },
+      },
+      local: { modelPath: customModelPath },
+      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
+    });
+    const statusManager = await getFreshManager(statusCfg, "status");
+    try {
+      const status = statusManager.status();
+
+      expect(status.dirty).toBe(false);
+      expect(status.custom?.indexIdentity).toEqual({ status: "valid" });
+    } finally {
+      await statusManager.close?.();
+    }
+  });
+
   it("keeps status clean when configured provider alias resolves to indexed adapter", async () => {
     const dbPath = path.join(workspaceDir, "index-provider-alias-status.sqlite");
     const oldCfg = createCfg({

--- a/extensions/memory-core/src/memory/manager-provider-state.ts
+++ b/extensions/memory-core/src/memory/manager-provider-state.ts
@@ -4,11 +4,13 @@ import type {
   ResolvedMemorySearchConfig,
 } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
 import {
+  resolveEmbeddingProviderAdapterId,
   resolveEmbeddingProviderFallbackModel,
   type EmbeddingProvider,
   type EmbeddingProviderResult,
   type EmbeddingProviderRuntime,
 } from "./embeddings.js";
+import { DEFAULT_LOCAL_MODEL } from "./provider-adapters.js";
 
 type MemoryResolvedProviderState = {
   provider: EmbeddingProvider | null;
@@ -104,6 +106,26 @@ export function resolveFallbackCurrentProviderId(params: {
     return params.lifecycle.providerId;
   }
   return null;
+}
+
+export function resolveConfiguredEmbeddingProviderModelIdentity(params: {
+  cfg: OpenClawConfig;
+  settings: ResolvedMemorySearchConfig;
+}): string {
+  if (params.settings.provider === "none") {
+    return "";
+  }
+  const adapterId =
+    resolveEmbeddingProviderAdapterId(params.settings.provider, params.cfg) ??
+    params.settings.provider;
+  if (params.settings.provider === "local" || adapterId === "local") {
+    const modelPath = params.settings.local?.modelPath?.trim();
+    return modelPath || DEFAULT_LOCAL_MODEL;
+  }
+  return (
+    params.settings.model.trim() ||
+    resolveEmbeddingProviderFallbackModel(params.settings.provider, "", params.cfg)
+  );
 }
 
 export function resolveMemoryPrimaryProviderRequest(params: {

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -40,7 +40,6 @@ import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coer
 import {
   createEmbeddingProvider,
   resolveEmbeddingProviderAdapterId,
-  resolveEmbeddingProviderFallbackModel,
   type EmbeddingProvider,
   type EmbeddingProviderId,
   type EmbeddingProviderRuntime,
@@ -50,6 +49,7 @@ import { closeMemoryDatabase, openMemoryDatabaseAtPath } from "./manager-db.js";
 import { isMemoryEmbeddingOperationError } from "./manager-embedding-errors.js";
 import {
   applyMemoryFallbackProviderState,
+  resolveConfiguredEmbeddingProviderModelIdentity,
   resolveMemoryFallbackProviderRequest,
   resolveFallbackCurrentProviderId,
   type MemoryProviderLifecycleState,
@@ -310,9 +310,10 @@ export abstract class MemoryManagerSyncOps {
             id:
               resolveEmbeddingProviderAdapterId(this.settings.provider, this.cfg) ??
               this.settings.provider,
-            model:
-              this.settings.model.trim() ||
-              resolveEmbeddingProviderFallbackModel(this.settings.provider, "", this.cfg),
+            model: resolveConfiguredEmbeddingProviderModelIdentity({
+              cfg: this.cfg,
+              settings: this.settings,
+            }),
           };
     const provider = hasProviderOverride
       ? params.provider!


### PR DESCRIPTION
## Summary

- Fixes memory status reporting `Dirty: yes` after a successful local embedding reindex when `memorySearch.local.modelPath` is configured.
- Aligns status-only index identity resolution with the model identity that local indexing persists (`local.modelPath` or the builtin default), instead of comparing against `settings.model`.
- Adds regression coverage for custom `local.modelPath` status checks without requiring a real GGUF model.

Why does this matter now?

Local memory search users rebuild indexes and still see a stale dirty flag, which pauses vector search until another rebuild.

What is the intended outcome?

`openclaw memory index --force` followed by `openclaw memory status` reports `Dirty: no` when the configured local model path matches the indexed metadata.

What is intentionally out of scope?

- No changes to local embedding worker loading or GGUF runtime behavior
- No new config keys or migration paths

What does success look like?

Status-only managers agree with indexed `memory_index_meta_v1.model` for `provider: local` with custom `local.modelPath`.

What should reviewers focus on?

`resolveConfiguredEmbeddingProviderModelIdentity` parity with `createLocalEmbeddingProvider` model identity, and the new status regression in `index.test.ts`.

## Linked context

Which issue does this close?

Closes #91001

Which issues, PRs, or discussions are related?

Related ClawSweeper review on #91001 (source-level repro, queueable-fix).

Was this requested by a maintainer or owner?

No — community bug report with ClawSweeper queueable-fix label.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Local provider index rebuilt with custom `modelPath` still reported `Dirty: yes` / identity mismatch.
- Real environment tested: Vitest integration fixture with mocked local embedding provider and sqlite memory index (no live GGUF).
- Exact steps or command run after this patch:
  - `node scripts/run-vitest.mjs extensions/memory-core/src/memory/index.test.ts -t "local provider uses custom modelPath"`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```json
{
  "regression": "keeps status clean (4 cases)",
  "local_modelPath": { "dirty": false, "indexIdentity": { "status": "valid" } },
  "local_alias_modelPath": {
    "provider": "local-home",
    "adapterApi": "local",
    "dirty": false,
    "indexIdentity": { "status": "valid" }
  }
}
```

- Observed result after fix: Status-only managers agree with indexed metadata for direct `local` and aliased `local-home` providers when `local.modelPath` matches.
- What was not tested: Live `openclaw memory index --force` + `openclaw memory status` with a real GGUF file and `node-llama-cpp` worker.
- Proof limitations or environment constraints: Author environment has no local GGUF model. Maintainer can validate with:

```bash
# config: memorySearch.provider=local, memorySearch.local.modelPath=<path-to>.gguf
openclaw memory index --force --agent main
openclaw memory status --agent main
# expect: Dirty: no
```
- Before evidence (optional but encouraged): Prior behavior (main): status-only identity expected `settings.model` (often empty/`local`) while indexed metadata stored the full `modelPath`, yielding `Dirty: yes` and mismatched identity reason.

## Tests and validation

Which commands did you run?

- `node scripts/run-vitest.mjs extensions/memory-core/src/memory/index.test.ts` → 39 passed (rebased on main)
- `node scripts/run-vitest.mjs extensions/memory-core/src/memory/index.test.ts -t "keeps status clean"` → 4 passed (local modelPath, local alias, adapter default #90413, ollama alias)
- `node scripts/run-vitest.mjs extensions/memory-core/src/memory/manager-reindex-state.test.ts` → 9 passed
- `pnpm check:test-types` → passed
- `pnpm oxfmt --check extensions/memory-core/src/memory/manager-provider-state.ts extensions/memory-core/src/memory/manager-sync-ops.ts extensions/memory-core/src/memory/index.test.ts` → passed
- `pnpm check:changed` → skipped locally (Blacksmith Testbox/crabbox unavailable in this environment)

What regression coverage was added or updated?

- `index.test.ts`: local `modelPath` status clean after reindex
- `index.test.ts`: local provider **alias** (`local-home` → `api: local`) status clean with same `modelPath`
- Existing: adapter default model (#90413), provider alias (ollama)

What failed before this fix, if known?

Status-only path compared indexed `modelPath` against `settings.model`, leaving `indexIdentityDirty` true after rebuild.

If no test was added, why not?

N/A — regression test added.

## Risk checklist

Did user-visible behavior change? (`Yes`)

Yes — `memory status` dirty flag becomes accurate for local `modelPath` configs.

Did config, environment, or migration behavior change? (`No`)

No config schema or migration changes.

Did security, auth, secrets, network, or tool execution behavior change? (`No`)

No.

What is the highest-risk area?

Memory index identity comparison for non-local provider aliases that resolve to the local adapter.

How is that risk mitigated?

Direct `provider === "local"` fast path plus adapter-id fallback; existing alias and reindex-state tests unchanged and passing.

## Current review state

What is the next action?

Await maintainer merge or maintainer-run live GGUF proof. Code + CI + alias coverage complete on author side.

What is still waiting on author, maintainer, CI, or external proof?

- **CI**: re-run expected after push
- **ClawSweeper**: proof still mock-only (L2); needs redacted CLI/GGUF output or maintainer-recorded equivalent

Which bot or reviewer comments were addressed?

- **[P1] local-provider-alias coverage** — added regression: index with `provider: local`, status with `provider: local-home` (`api: local`) + same `modelPath` → `dirty: false`.
- **[P1] default-model fallback** — fixed (prior push).
- **Proof gap** — PR body now includes maintainer repro commands; author cannot run GGUF locally.
