### PR TITLE
fix(tui): persist canonical provider in session modelProvider

### DIFF
--- a/src/agents/command/session-store.test.ts
+++ b/src/agents/command/session-store.test.ts
@@ -25,6 +25,18 @@ vi.mock("../model-selection.js", () => ({
   normalizeProviderId: (provider: string) => provider.trim().toLowerCase(),
 }));
 
+vi.mock("../cli-backends.js", () => ({
+  resolveCliRuntimeCanonicalProvider: (params: { runtime?: string; config?: OpenClawConfig }) => {
+    const backends = params.config?.agents?.defaults?.cliBackends ?? {};
+    const entry = backends[params.runtime ?? ""];
+    if (typeof entry === "object" && entry !== null && "provider" in entry) {
+      const provider = (entry as { provider?: unknown }).provider;
+      return typeof provider === "string" ? provider : undefined;
+    }
+    return undefined;
+  },
+}));
+
 type MockCost = {
   input?: number;
   output?: number;
@@ -275,6 +287,49 @@ describe("updateSessionStoreAfterAgentRun", () => {
 
       expect(sessionStore[sessionKey]?.agentHarnessId).toBe("codex");
       expect(loadSessionStore(storePath)[sessionKey]?.agentHarnessId).toBe("codex");
+    });
+  });
+
+  it("canonicalizes CLI runtime-id provider before persisting modelProvider", async () => {
+    await withTempSessionStore(async ({ storePath }) => {
+      const cfg = {
+        agents: {
+          defaults: {
+            cliBackends: {
+              "claude-cli": { provider: "anthropic" },
+            },
+          },
+        },
+      } as unknown as OpenClawConfig;
+      const sessionKey = "agent:main:explicit:test-canonical-provider";
+      const sessionId = "test-canonical-provider-session";
+      const sessionStore: Record<string, SessionEntry> = {
+        [sessionKey]: { sessionId, updatedAt: 1 },
+      };
+      await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2));
+
+      await updateSessionStoreAfterAgentRun({
+        cfg,
+        sessionId,
+        sessionKey,
+        storePath,
+        sessionStore,
+        defaultProvider: "anthropic",
+        defaultModel: "claude-sonnet-4-6",
+        result: {
+          meta: {
+            durationMs: 1,
+            agentMeta: {
+              sessionId,
+              provider: "claude-cli",
+              model: "claude-sonnet-4-6",
+            },
+          },
+        },
+      });
+
+      expect(sessionStore[sessionKey]?.modelProvider).toBe("anthropic");
+      expect(sessionStore[sessionKey]?.model).toBe("claude-sonnet-4-6");
     });
   });
 

--- a/src/agents/command/session-store.ts
+++ b/src/agents/command/session-store.ts
@@ -17,6 +17,7 @@ import { resolveMaintenanceConfigFromInput } from "../../config/sessions/store-m
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
+import { resolveCliRuntimeCanonicalProvider } from "../cli-backends.js";
 import { clearCliSession, setCliSessionBinding, setCliSessionId } from "../cli-session.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../defaults.js";
 import { isCliProvider } from "../model-selection.js";
@@ -180,8 +181,19 @@ export async function updateSessionStoreAfterAgentRun(params: {
     // When there is no prior runtime model, do nothing: a heartbeat turn
     // should not establish initial model state on an empty session.
   } else {
+    // Map CLI runtime ids (e.g. "claude-cli", "google-antigravity-cli") back to
+    // their canonical provider (e.g. "anthropic", "google") before persisting,
+    // so display surfaces and downstream consumers see "anthropic/<model>"
+    // instead of leaking the runtime id. Falls back to the raw value when no
+    // canonical mapping is available.
+    const canonicalProviderForPersistence =
+      resolveCliRuntimeCanonicalProvider({
+        runtime: providerUsed,
+        config: cfg,
+        includeSetupRegistry: true,
+      }) ?? providerUsed;
     setSessionRuntimeModel(next, {
-      provider: providerUsed,
+      provider: canonicalProviderForPersistence,
       model: modelUsed,
     });
   }


### PR DESCRIPTION
## Summary

After a CLI-routed agent run (any model with `agentRuntime.id` pinned to a CLI backend such as `claude-cli` or `google-antigravity-cli`), the TUI footer renders `claude-cli/claude-sonnet-4-6` instead of `anthropic/claude-sonnet-4-6` — leaking the implementation-routing id into the user-facing status line.

Root cause: `setSessionRuntimeModel(next, { provider: providerUsed, ... })` in `src/agents/command/session-store.ts` was called with the runtime id as `provider`, persisting it as `sessionInfo.modelProvider`. The footer renderer (`src/tui/tui.ts:~1183`) just reads that value.

Fix: canonicalize at the single setter call site using the existing `resolveCliRuntimeCanonicalProvider` helper (`src/agents/cli-backends.ts:245-271`). Only the persisted display value changes; the raw `providerUsed` continues to drive runtime-dependent logic (`isCliProvider`, CLI session bookkeeping).

## Scope

- `src/agents/command/session-store.ts` — call canonicalization helper before `setSessionRuntimeModel` in the non-preserve branch.
- `src/agents/command/session-store.test.ts` — vi.mock `../cli-backends.js` with the lookup convention used for `isCliProvider`; add failing-first test.

## Deliberately Out Of Scope

- The `preserveRuntimeModel` branch (lines 160-179) re-uses an already-persisted `entry.modelProvider`. After this fix that value is canonical for any new run; legacy stored sessions remain unchanged. No migration is shipped — stale entries naturally update on the next non-preserve run.
- Other consumers of `sessionInfo.modelProvider` (e.g. UI controls) are unaffected because the field's contract becomes *more* aligned with what they already render.

## Real behavior proof

**Behavior or issue addressed:** TUI footer shows runtime id (`claude-cli/...`) instead of canonical provider (`anthropic/...`) when a model is routed through a CLI backend.

**Real environment tested:** macOS, source repo `/Users/rob/Development/openclaw`, branch `feature/canonical-modelprovider`. User config has `anthropic/claude-*` pinned to `agentRuntime.id = "claude-cli"`.

**Exact steps or command run after this patch:**

```
pnpm exec vitest run src/agents/command/session-store.test.ts
pnpm tsgo:core
```

**Evidence after fix:** Terminal output, real run:

```
Test Files  2 passed (2)
      Tests  74 passed (74)
```

`pnpm tsgo:core` exit=0.

The new test `canonicalizes CLI runtime-id provider before persisting modelProvider` was first written failing (`Expected: "anthropic" Received: "claude-cli"`) and then made green with the helper-based fix — confirming both the root cause and the resolution.

**Observed result after fix:** `sessionInfo.modelProvider` now persists the canonical provider id. With the same TUI footer renderer (`${modelProvider}/${model}`), the status line will display `anthropic/claude-sonnet-4-6` instead of `claude-cli/claude-sonnet-4-6`.

**What was not tested:**

- Live TUI footer render against this source build (requires installing the source dist; deferred to user smoke after merge or via `pnpm gateway:dev`).
- Migration of pre-existing session-store entries that carry the old runtime-id format (none performed; legacy values heal on next run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)