### PR TITLE
fix(memory-core): exclude archive transcripts from dreaming session corpus collection

### DIFF
--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -1861,6 +1861,143 @@ describe("memory-core dreaming phases", () => {
     expect(newOccurrences).toBe(1);
   });
 
+  it("excludes archive (.deleted/.reset) transcripts from session corpus collection", async () => {
+    const workspaceDir = await createDreamingWorkspace();
+    vi.stubEnv("OPENCLAW_TEST_FAST", "1");
+    vi.stubEnv("OPENCLAW_STATE_DIR", path.join(workspaceDir, ".state"));
+    const sessionsDir = resolveSessionTranscriptsDirForAgent("main");
+    await fs.mkdir(sessionsDir, { recursive: true });
+
+    // Primary transcript with real user content
+    await fs.writeFile(
+      path.join(sessionsDir, "dreaming-main.jsonl"),
+      [
+        JSON.stringify({
+          type: "message",
+          message: {
+            role: "user",
+            timestamp: "2026-04-16T18:01:00.000Z",
+            content: [{ type: "text", text: "Document the memory-core plugin setup." }],
+          },
+        }),
+        JSON.stringify({
+          type: "message",
+          message: {
+            role: "assistant",
+            timestamp: "2026-04-16T18:02:00.000Z",
+            content: [{ type: "text", text: "I documented the memory-core plugin setup." }],
+          },
+        }),
+      ].join("\n") + "\n",
+      "utf-8",
+    );
+
+    // Deleted archive — should be excluded from corpus
+    await fs.writeFile(
+      path.join(sessionsDir, "dreaming-main.jsonl.deleted.2026-04-15T18-00-00.000Z"),
+      [
+        JSON.stringify({
+          type: "message",
+          message: {
+            role: "user",
+            timestamp: "2026-04-15T18:01:00.000Z",
+            content: [{ type: "text", text: "Archive message that must not appear." }],
+          },
+        }),
+        JSON.stringify({
+          type: "message",
+          message: {
+            role: "assistant",
+            timestamp: "2026-04-15T18:02:00.000Z",
+            content: [{ type: "text", text: "I replied to the archived session." }],
+          },
+        }),
+      ].join("\n") + "\n",
+      "utf-8",
+    );
+
+    // Reset archive — should also be excluded
+    await fs.writeFile(
+      path.join(sessionsDir, "dreaming-main.jsonl.reset.2026-04-14T18-00-00.000Z"),
+      [
+        JSON.stringify({
+          type: "message",
+          message: {
+            role: "user",
+            timestamp: "2026-04-14T18:01:00.000Z",
+            content: [{ type: "text", text: "Reset-archive content that must be excluded." }],
+          },
+        }),
+      ].join("\n") + "\n",
+      "utf-8",
+    );
+
+    const now = new Date("2026-04-16T19:00:00.000Z");
+    await fs.utimes(path.join(sessionsDir, "dreaming-main.jsonl"), now, now);
+    await fs.utimes(
+      path.join(sessionsDir, "dreaming-main.jsonl.deleted.2026-04-15T18-00-00.000Z"),
+      now,
+      now,
+    );
+    await fs.utimes(
+      path.join(sessionsDir, "dreaming-main.jsonl.reset.2026-04-14T18-00-00.000Z"),
+      now,
+      now,
+    );
+
+    const { beforeAgentReply } = createHarness(
+      {
+        agents: {
+          defaults: { workspace: workspaceDir },
+          list: [{ id: "main", workspace: workspaceDir }],
+        },
+        plugins: {
+          entries: {
+            "memory-core": {
+              config: {
+                dreaming: {
+                  enabled: true,
+                  phases: {
+                    light: {
+                      enabled: true,
+                      limit: 20,
+                      lookbackDays: 7,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      workspaceDir,
+    );
+
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+    try {
+      await beforeAgentReply(
+        { cleanedBody: "__openclaw_memory_core_light_sleep__" },
+        { trigger: "heartbeat", workspaceDir },
+      );
+    } finally {
+      vi.useRealTimers();
+      vi.unstubAllEnvs();
+    }
+
+    const corpus = await fs.readFile(
+      path.join(workspaceDir, "memory", ".dreams", "session-corpus", "2026-04-16.txt"),
+      "utf-8",
+    );
+    // Primary transcript content should be present
+    expect(corpus).toContain("User: Document the memory-core plugin setup.");
+    expect(corpus).toContain("Assistant: I documented the memory-core plugin setup.");
+    // Archive content must not appear
+    expect(corpus).not.toContain("Archive message that must not appear.");
+    expect(corpus).not.toContain("I replied to the archived session.");
+    expect(corpus).not.toContain("Reset-archive content that must be excluded.");
+  });
+
   it("buckets session snippets by per-message day rather than file mtime", async () => {
     const workspaceDir = await createDreamingWorkspace();
     vi.stubEnv("OPENCLAW_TEST_FAST", "1");

--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -1900,7 +1900,7 @@ describe("memory-core dreaming phases", () => {
           type: "message",
           message: {
             role: "user",
-            timestamp: "2026-04-15T18:01:00.000Z",
+            timestamp: "2026-04-16T18:03:00.000Z",
             content: [{ type: "text", text: "Archive message that must not appear." }],
           },
         }),
@@ -1908,7 +1908,7 @@ describe("memory-core dreaming phases", () => {
           type: "message",
           message: {
             role: "assistant",
-            timestamp: "2026-04-15T18:02:00.000Z",
+            timestamp: "2026-04-16T18:04:00.000Z",
             content: [{ type: "text", text: "I replied to the archived session." }],
           },
         }),
@@ -1924,7 +1924,7 @@ describe("memory-core dreaming phases", () => {
           type: "message",
           message: {
             role: "user",
-            timestamp: "2026-04-14T18:01:00.000Z",
+            timestamp: "2026-04-16T18:05:00.000Z",
             content: [{ type: "text", text: "Reset-archive content that must be excluded." }],
           },
         }),

--- a/extensions/memory-core/src/dreaming-phases.ts
+++ b/extensions/memory-core/src/dreaming-phases.ts
@@ -5,6 +5,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import {
   buildSessionEntry,
+  isSessionArchiveArtifactName,
   listSessionFilesForAgent,
   loadSessionTranscriptClassificationForAgent,
   normalizeSessionTranscriptPathForComparison,
@@ -857,6 +858,9 @@ async function collectSessionIngestionBatches(params: {
           };
     for (const absolutePath of files) {
       if (isCheckpointSessionTranscriptPath(absolutePath)) {
+        continue;
+      }
+      if (isSessionArchiveArtifactName(path.basename(absolutePath))) {
         continue;
       }
       const normalizedPath = normalizeSessionTranscriptPathForComparison(absolutePath);


### PR DESCRIPTION
## Summary

- **Problem**: Dreaming session corpus ingestion used `listSessionFilesForAgent` which returns usage-counted files including `.deleted` and `.reset` archive transcripts. This caused archive transcripts to be re-ingested as duplicates alongside the current primary transcript, polluting the dreaming corpus with up to 91% automation noise on cron-heavy deployments.
- **Fix**: Skip archive artifacts in the dreaming session corpus collection loop via `isSessionArchiveArtifactName`, mirroring the existing checkpoint skip pattern. No change to `listSessionFilesForAgent` or any shared helper — memory_search archive indexing is unaffected.
- **Scope**: Only the dreaming corpus collection path in `collectSessionIngestionBatches`. Light/REM phase logic, narrative writer, and all other dreaming paths are unchanged.

## Linked context

Related #90313

## Real behavior proof

**Behavior addressed:** Archived transcripts (`.deleted.*`, `.reset.*`) no longer pollute dreaming session corpus during light dreaming ingestion.

**Real environment tested:** Node v22 on Linux (WSL2), branch `fix/issue-90313-dreaming-corpus-archive-filter`, head `29b6db19b7a`.

**Exact steps or command run after this patch:**

```bash
OPENCLAW_VITEST_CONFIG=test/vitest/vitest.extension-memory.config.ts \
  node scripts/run-vitest.mjs extensions/memory-core/src/dreaming-phases.test.ts
```

This runs the regression `excludes archive (.deleted/.reset) transcripts from session corpus collection`, which exercises the patched production path end-to-end:

`beforeAgentReply` → `runPhaseIfTriggered` (light) → `runLightDreaming` → `ingestSessionTranscriptSignals` → `collectSessionIngestionBatches` (archive skip at `dreaming-phases.ts:863-865`).

**Evidence after fix:**

```text
 RUN  v4.1.7 /home/princeht/fire_project/openclaw

 Test Files  1 passed (1)
      Tests  45 passed (45)
   Duration  8.51s
[test] passed 1 Vitest shard in 14.28s
```

Session corpus written by the light dreaming sweep (`memory/.dreams/session-corpus/2026-04-16.txt`) contains primary transcript lines and excludes archive-only content:

```text
User: Document the memory-core plugin setup.
Assistant: I documented the memory-core plugin setup.
```

Archive-only strings verified absent from corpus:

```text
Archive message that must not appear.
I replied to the archived session.
Reset-archive content that must be excluded.
```

**Observed result after fix:** After a patched light dreaming sweep over primary + `.deleted` + `.reset` transcripts, only the primary transcript content is ingested into the session corpus; archive transcript bodies are filtered out before `appendSessionCorpusLines`.

**What was not tested:** Live gateway heartbeat on a production OpenClaw deployment with real cron subagent spawns.

## Tests and validation

- Regression test added: `excludes archive (.deleted/.reset) transcripts from session corpus collection` — creates primary + `.deleted` + `.reset` transcripts, runs light dreaming, asserts archive content absent from corpus while primary content remains
- Existing test `drops archive, cron, and heartbeat chatter from fresh session corpus output` continues to pass

## Risk checklist

- User-visible behavior changed: Yes — dreaming corpus will no longer contain content from archive transcripts; dream quality should improve on cron-heavy deployments
- Config, environment, or migration change: No
- Security, auth, secrets, network, or tool execution change: No
- Highest-risk area: Low — the change is purely subtractive (removes files from ingestion, never adds)
- No data is deleted; archive files remain on disk and remain indexed by memory_search

## Current review state

Next action: `@clawsweeper re-review` on head `29b6db19b7a`.
Waiting on: proof label refresh after re-review.
Bot comments addressed: PR body now documents patched light-dreaming corpus collection proof (not just the filename predicate).

Related #90313
