### PR TITLE
fix(cli): add __testing.resetBannerEmittedForTests for test isolation

### DIFF
--- a/src/cli/banner.test.ts
+++ b/src/cli/banner.test.ts
@@ -132,4 +132,41 @@ describe("emitCliBanner", () => {
     expect(writeSpy).toHaveBeenCalledWith("\n🦞 OpenClaw 2026.3.7 (abc1234)\n\n");
     expect(hasEmittedCliBanner()).toBe(true);
   });
+
+  it("resets bannerEmitted flag via __testing helper", async () => {
+    const { emitCliBanner, hasEmittedCliBanner, __testing } =
+      await importFreshBannerModule();
+    setStdoutIsTty(false);
+    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    // First emission — banner is emitted and flag is set
+    emitCliBanner("2026.3.7", {
+      argv: ["node", "openclaw"],
+      commit: "abc1234",
+      env: { LANG: "en_US.UTF-8" },
+      isTty: true,
+      mode: "off",
+      platform: "darwin",
+      richTty: false,
+    });
+    expect(hasEmittedCliBanner()).toBe(true);
+    expect(writeSpy).toHaveBeenCalledTimes(1);
+
+    // Reset — flag is cleared
+    __testing.resetBannerEmittedForTests();
+    expect(hasEmittedCliBanner()).toBe(false);
+
+    // Second emission after reset — banner is emitted again
+    emitCliBanner("2026.3.7", {
+      argv: ["node", "openclaw"],
+      commit: "abc1234",
+      env: { LANG: "en_US.UTF-8" },
+      isTty: true,
+      mode: "off",
+      platform: "darwin",
+      richTty: false,
+    });
+    expect(hasEmittedCliBanner()).toBe(true);
+    expect(writeSpy).toHaveBeenCalledTimes(2);
+  });
 });

--- a/src/cli/banner.ts
+++ b/src/cli/banner.ts
@@ -198,3 +198,11 @@ export function emitCliBanner(version: string, options: BannerOptions = {}) {
 export function hasEmittedCliBanner(): boolean {
   return bannerEmitted;
 }
+
+function resetBannerEmittedForTests(): void {
+  bannerEmitted = false;
+}
+
+export const __testing = {
+  resetBannerEmittedForTests,
+};


### PR DESCRIPTION
## Summary

Add `__testing.resetBannerEmittedForTests()` to `src/cli/banner.ts`, following the established pattern in `channel-options.ts`. The module-level `bannerEmitted` flag previously had no reset path, causing test ordering dependencies.

## Linked context

Closes #83903

## Real behavior proof (required for external PRs)

- **Behavior or issue addressed:** `bannerEmitted` flag had no test reset path — two successive tests calling `emitCliBanner` would see the second silently skipped.
- **Real environment tested:** macOS, Node v22.22.3, latest upstream/main (66b91d78f)
- **Exact steps or command run after this patch:**
```bash
node scripts/run-vitest.mjs run src/cli/banner.test.ts
```
- **Evidence after fix (copied live output):**
```
Tests  7 passed (1 test file)
```
- **Observed result after fix:** After calling `resetBannerEmittedForTests()`, `hasEmittedCliBanner()` returns `false` and `emitCliBanner()` can emit a second banner.
- **What was not tested:** N/A — the fix is solely for test isolation; no production behavior changes.
- **Proof limitations or environment constraints:** None.

## Tests and validation

```bash
node scripts/run-vitest.mjs run src/cli/banner.test.ts
# 7 passed (1 test file)
```

New test: `resetBannerEmittedForTests` — verifies emit → reset → emit cycle.

## Risk checklist

**Did user-visible behavior change?** No
**Did config, environment, or migration behavior change?** No
**Did security, auth, secrets, network, or tool execution behavior change?** No
**What is the highest-risk area?** None — the `__testing` export is only accessed in test code.
**How is that risk mitigated?** Follows existing `channel-options.ts` pattern. No production callers.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Code <noreply@anthropic.com>