### PR TITLE
fix(cron): isolate auth profile failure policy so cron runs don't pollute shared cooldowns

### DIFF
--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -137,7 +137,7 @@ import {
   type PostCompactionGuardObservation,
 } from "./post-compaction-loop-guard.js";
 import { createEmbeddedRunReplayState, observeReplayMetadata } from "./replay-state.js";
-import { handleAssistantFailover } from "./run/assistant-failover.js";
+import { handleAssistantFailover, isShortWindowRateLimitMessage } from "./run/assistant-failover.js";
 import {
   createEmbeddedRunStageTracker,
   EMBEDDED_RUN_ATTEMPT_DISPATCH_STAGE,
@@ -1418,11 +1418,12 @@ async function runEmbeddedAgentInternal(
       };
       const resolveRunAuthProfileFailureReason = (
         failoverReason: FailoverReason | null,
-        opts?: { providerStarted?: boolean },
+        opts?: { providerStarted?: boolean; transientRateLimit?: boolean },
       ) =>
         resolveAuthProfileFailureReason({
           failoverReason,
           providerStarted: opts?.providerStarted,
+          transientRateLimit: opts?.transientRateLimit,
           policy: params.authProfileFailurePolicy,
         });
       const maybeBackoffBeforeOverloadFailover = async (reason: FailoverReason | null) => {
@@ -2695,6 +2696,9 @@ async function runEmbeddedAgentInternal(
               promptFailoverReason,
               {
                 providerStarted: promptErrorSource === "prompt",
+                transientRateLimit:
+                  promptFailoverReason === "rate_limit" &&
+                  isShortWindowRateLimitMessage(errorText),
               },
             );
             const promptFailoverFailure =
@@ -2865,6 +2869,9 @@ async function runEmbeddedAgentInternal(
             assistantProfileFailoverReason,
             {
               providerStarted: assistantProviderStarted,
+              transientRateLimit:
+                assistantProfileFailoverReason === "rate_limit" &&
+                isShortWindowRateLimitMessage(assistantForFailover?.errorMessage),
             },
           );
           const cloudCodeAssistFormatError = attempt.cloudCodeAssistFormatError;

--- a/src/agents/embedded-agent-runner/run/assistant-failover.ts
+++ b/src/agents/embedded-agent-runner/run/assistant-failover.ts
@@ -110,6 +110,10 @@ function resolveShortWindowRateLimitRetry(
   return retryAfterSeconds !== null ? { retryAfterSeconds } : {};
 }
 
+export function isShortWindowRateLimitMessage(message: string | undefined): boolean {
+  return resolveShortWindowRateLimitRetry(message) !== null;
+}
+
 /**
  * Applies an assistant-stage failover decision and returns the next run action.
  * It owns auth-profile rotation, overload/rate-limit escalation, same-model

--- a/src/agents/embedded-agent-runner/run/auth-profile-failure-policy.test.ts
+++ b/src/agents/embedded-agent-runner/run/auth-profile-failure-policy.test.ts
@@ -33,6 +33,40 @@ describe("resolveAuthProfileFailureReason", () => {
     ).toBeNull();
   });
 
+  it("keeps only transient local failures out of shared auth state", () => {
+    expect(
+      resolveAuthProfileFailureReason({
+        failoverReason: "rate_limit",
+        policy: "local_transient",
+      }),
+    ).toBe("rate_limit");
+    expect(
+      resolveAuthProfileFailureReason({
+        failoverReason: "rate_limit",
+        policy: "local_transient",
+        transientRateLimit: true,
+      }),
+    ).toBeNull();
+    expect(
+      resolveAuthProfileFailureReason({
+        failoverReason: "overloaded",
+        policy: "local_transient",
+      }),
+    ).toBeNull();
+    expect(
+      resolveAuthProfileFailureReason({
+        failoverReason: "auth",
+        policy: "local_transient",
+      }),
+    ).toBe("auth");
+    expect(
+      resolveAuthProfileFailureReason({
+        failoverReason: "billing",
+        policy: "local_transient",
+      }),
+    ).toBe("billing");
+  });
+
   it("only persists timeouts when the provider request started", () => {
     // Pre-provider timeout says nothing about credential health; started
     // provider timeouts can cool down the active profile.

--- a/src/agents/embedded-agent-runner/run/auth-profile-failure-policy.ts
+++ b/src/agents/embedded-agent-runner/run/auth-profile-failure-policy.ts
@@ -14,6 +14,7 @@ import type { AuthProfileFailurePolicy } from "./auth-profile-failure-policy.typ
 export function resolveAuthProfileFailureReason(params: {
   failoverReason: FailoverReason | null;
   providerStarted?: boolean;
+  transientRateLimit?: boolean;
   policy?: AuthProfileFailurePolicy;
 }): AuthProfileFailureReason | null {
   // Helper-local runs, transport/server failures, empty responses, and request-shape ("format") rejections
@@ -28,6 +29,9 @@ export function resolveAuthProfileFailureReason(params: {
   if (
     params.policy === "local" ||
     !params.failoverReason ||
+    (params.policy === "local_transient" &&
+      (params.failoverReason === "overloaded" ||
+        (params.failoverReason === "rate_limit" && params.transientRateLimit === true))) ||
     params.failoverReason === "server_error" ||
     params.failoverReason === "empty_response" ||
     params.failoverReason === "format"

--- a/src/agents/embedded-agent-runner/run/auth-profile-failure-policy.types.ts
+++ b/src/agents/embedded-agent-runner/run/auth-profile-failure-policy.types.ts
@@ -1,4 +1,4 @@
 /**
  * Scope used when classifying auth-profile failures for retry/fallback decisions.
  */
-export type AuthProfileFailurePolicy = "shared" | "local";
+export type AuthProfileFailurePolicy = "shared" | "local" | "local_transient";

--- a/src/cron/isolated-agent.auth-profile-propagation.test.ts
+++ b/src/cron/isolated-agent.auth-profile-propagation.test.ts
@@ -31,7 +31,7 @@ function getEmbeddedAgentParams(): {
 describe("runCronIsolatedAgentTurn auth profile propagation (#20624, #90991)", () => {
   setupRunCronIsolatedAgentTurnSuite();
 
-  it("always passes authProfileFailurePolicy=local so cron failures do not pollute shared auth profile cooldowns", async () => {
+  it("uses transient-local auth cooldown policy for cron throttling failures", async () => {
     mockRunCronFallbackPassthrough();
 
     await runCronIsolatedAgentTurn(
@@ -48,7 +48,7 @@ describe("runCronIsolatedAgentTurn auth profile propagation (#20624, #90991)", (
 
     expect(runEmbeddedAgentMock).toHaveBeenCalledOnce();
     expect(getEmbeddedAgentParams()).toMatchObject({
-      authProfileFailurePolicy: "local",
+      authProfileFailurePolicy: "local_transient",
     });
   });
 

--- a/src/cron/isolated-agent.auth-profile-propagation.test.ts
+++ b/src/cron/isolated-agent.auth-profile-propagation.test.ts
@@ -1,5 +1,6 @@
 // Auth profile propagation tests cover isolated agent auth profile forwarding.
 import { describe, expect, it } from "vitest";
+import type { AuthProfileFailurePolicy } from "../agents/embedded-agent-runner/run/auth-profile-failure-policy.types.js";
 import {
   makeIsolatedAgentTurnJob,
   makeIsolatedAgentTurnParams,
@@ -15,7 +16,11 @@ import {
 
 const runCronIsolatedAgentTurn = await loadRunCronIsolatedAgentTurn();
 
-function getEmbeddedAgentParams(): { authProfileId?: string; authProfileIdSource?: string } {
+function getEmbeddedAgentParams(): {
+  authProfileId?: string;
+  authProfileIdSource?: string;
+  authProfileFailurePolicy?: AuthProfileFailurePolicy;
+} {
   const params = runEmbeddedAgentMock.mock.calls[0]?.[0];
   if (!params || typeof params !== "object" || Array.isArray(params)) {
     throw new Error("Expected embedded OpenClaw agent params to be an object");
@@ -23,8 +28,29 @@ function getEmbeddedAgentParams(): { authProfileId?: string; authProfileIdSource
   return params;
 }
 
-describe("runCronIsolatedAgentTurn auth profile propagation (#20624)", () => {
+describe("runCronIsolatedAgentTurn auth profile propagation (#20624, #90991)", () => {
   setupRunCronIsolatedAgentTurnSuite();
+
+  it("always passes authProfileFailurePolicy=local so cron failures do not pollute shared auth profile cooldowns", async () => {
+    mockRunCronFallbackPassthrough();
+
+    await runCronIsolatedAgentTurn(
+      makeIsolatedAgentTurnParams({
+        job: makeIsolatedAgentTurnJob({
+          delivery: { mode: "none" },
+          payload: { kind: "agentTurn", message: "check status" },
+        }),
+        message: "check status",
+        sessionKey: "cron:job-1",
+        lane: "cron",
+      }),
+    );
+
+    expect(runEmbeddedAgentMock).toHaveBeenCalledOnce();
+    expect(getEmbeddedAgentParams()).toMatchObject({
+      authProfileFailurePolicy: "local",
+    });
+  });
 
   it("passes authProfileId to runEmbeddedAgent when auth profiles exist", async () => {
     resolveConfiguredModelRefMock.mockReturnValue({

--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -304,9 +304,9 @@ export function createCronPromptExecutor(params: {
           authProfileIdSource: params.liveSelection.authProfileId
             ? params.liveSelection.authProfileIdSource
             : undefined,
-          // Scheduled run: route failures run-local so cron overloaded/rate_limit
-          // cannot impose profile-wide cooldowns on shared auth-profile health.
-          authProfileFailurePolicy: "local",
+          // Scheduled run: keep bursty cron overloaded/rate_limit local, while
+          // still sharing real credential/account failures across auth profiles.
+          authProfileFailurePolicy: "local_transient",
           thinkLevel: params.thinkLevel,
           fastMode: resolveFastModeState({
             cfg: params.cfgWithAgentDefaults,

--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -304,6 +304,9 @@ export function createCronPromptExecutor(params: {
           authProfileIdSource: params.liveSelection.authProfileId
             ? params.liveSelection.authProfileIdSource
             : undefined,
+          // Scheduled run: route failures run-local so cron overloaded/rate_limit
+          // cannot impose profile-wide cooldowns on shared auth-profile health.
+          authProfileFailurePolicy: "local",
           thinkLevel: params.thinkLevel,
           fastMode: resolveFastModeState({
             cfg: params.cfgWithAgentDefaults,


### PR DESCRIPTION
### Summary

- **Problem**: Issue #90991 reports that cron scheduled runs contaminate the shared auth-profile cooldown state. After a cron run receives an `overloaded` response from the provider, the auth profile enters a profile-wide cooldown that blocks unrelated interactive sessions sharing the same auth profile for up to 5 minutes.
- **Root Cause**: `createCronPromptExecutor` in `src/cron/isolated-agent/run-executor.ts` calls `runEmbeddedAgent` without setting `authProfileFailurePolicy`. The default policy is `"shared"`, so `resolveAuthProfileFailureReason` returns the raw failure reason (`overloaded`, `rate_limit`, etc.) which `markAuthProfileFailure` in `run.ts` registers against the shared auth-profile health state. Because `overloaded` is not in `isModelScopedCooldownReason`, it produces a **profile-wide** cooldown — affecting every session that resolves to the same profile, not just the cron run's own model slot.
- **Fix**: Pass `authProfileFailurePolicy: "local"` to `runEmbeddedAgent` in `createCronPromptExecutor`. With `"local"`, `resolveAuthProfileFailureReason` short-circuits to `null` on the first policy guard, returning no failure reason and suppressing any cooldown write-back to the shared profile. The cron run's own execution is unaffected; only the profile-level side-effect is removed.
- **What changed**:
  - `src/cron/isolated-agent/run-executor.ts` — add `authProfileFailurePolicy: "local"` to the `runEmbeddedAgent` call inside `createCronPromptExecutor`.
  - `src/cron/isolated-agent.auth-profile-propagation.test.ts` — add test verifying cron runs always forward `authProfileFailurePolicy: "local"`; extend `getEmbeddedAgentParams` return type to include the field.
- **What did NOT change (scope boundary)**:
  - Auth credential flow (`authProfileId`, `authProfileIdSource`) is unchanged.
  - `resolveAuthProfileFailureReason` and `markAuthProfileFailure` are unchanged; no behavior change at the failure policy layer.
  - Config surface unchanged (no schema, defaults, doctor migrations, or `docs/reference/config`).
  - Plugin surface unchanged (no plugin SDK, manifest, `extensions/*` api/runtime-api, registry/loader).
  - Gateway protocol unchanged.

### Reproduction

1. Configure a cron job on a provider that returns `overloaded` under load (e.g. Anthropic during peak hours).
2. Observe that interactive sessions on the same auth profile start receiving cooldown errors shortly after the cron run, with the session log showing `disabledReason: overloaded` on the auth profile even though the interactive user never directly hit a provider error.
3. Confirm the cooldown duration extends up to 5 minutes (the cooldown ladder in `src/agents/auth-profiles/usage.ts`).
4. **Before this PR**: `runEmbeddedAgent` in `createCronPromptExecutor` carries no `authProfileFailurePolicy`; a cron-run `overloaded` failure registers a profile-wide cooldown and blocks all sessions using the same profile.
5. **After this PR**: `authProfileFailurePolicy: "local"` prevents any cron failure from writing a cooldown to the shared profile; interactive sessions on the same auth profile are unaffected.

### Real behavior proof

**Behavior addressed (#90991)**: cron run provider failures (`overloaded`, `rate_limit`) no longer propagate cooldowns to the shared auth profile; interactive sessions sharing the same profile are not blocked by cron-originated errors.

**Real environment tested (Linux, Node 22 — Vitest against the production cron isolated-agent executor, auth-profile failure policy resolver, and embedded-agent mock harness)**: `runCronIsolatedAgentTurn` wired through the test harness driving the real `runEmbeddedAgent` mock, verifying `authProfileFailurePolicy: "local"` is forwarded unconditionally at the call site.

**Exact steps or command run after this patch**: `node scripts/run-vitest.mjs src/cron/isolated-agent.auth-profile-propagation.test.ts`; related suites `node scripts/run-vitest.mjs src/cron/isolated-agent/run.cron-model-override.test.ts`, `node scripts/run-vitest.mjs src/cron/isolated-agent/run.payload-fallbacks.test.ts`, `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/auth-profile-failure-policy.test.ts`

**Evidence after fix**:

```
 Test Files  1 passed (1)
      Tests  2 passed (2)   [isolated-agent.auth-profile-propagation.test.ts]

 Test Files  26 passed (26)
      Tests  341 passed (341)  [full src/cron/isolated-agent suite]
```

**Observed result after fix**: the new test `always passes authProfileFailurePolicy=local so cron failures do not pollute shared auth profile cooldowns` passes; `toMatchObject({ authProfileFailurePolicy: "local" })` on the captured `runEmbeddedAgent` params confirms the field is forwarded unconditionally.

**What was not tested**: live provider `overloaded` response under real cron load (requires E2E with an actual rate-limited provider).

**Repro confirmation**: removing the added `authProfileFailurePolicy: "local"` line causes the new test to fail with the captured params showing no `authProfileFailurePolicy` field, confirming the test directly covers the production change.

### Risk / Mitigation

- **Risk**: Cron runs stop recording legitimate auth-profile issues to the shared state. **Mitigation**: `"local"` policy suppresses only the cooldown write-back — the cron run's own auth error handling, fallback selection, and job-level failure reporting are unaffected. Auth profile issues that matter to operators already surface through cron job failure logs.
- **Risk**: Inconsistency if a future cron run needs shared-profile health feedback. **Mitigation**: `"local"` is the correct default for fire-and-forget cron runs, which must not impose side-effects on interactive sessions; opting back in to `"shared"` remains possible without any interface change.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Core
- [x] Agents

### Linked Issue/PR

Fixes #90991