### PR TITLE
fix(memory-core): write ## Deep Sleep summary to DREAMS.md

### DIFF
--- a/extensions/memory-core/src/dreaming-markdown.test.ts
+++ b/extensions/memory-core/src/dreaming-markdown.test.ts
@@ -11,15 +11,6 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-async function expectPathMissing(targetPath: string): Promise<void> {
-  const error = await fs.access(targetPath).then(
-    () => undefined,
-    (accessError: unknown) => accessError,
-  );
-  expect(error).toBeInstanceOf(Error);
-  expect((error as NodeJS.ErrnoException).code).toBe("ENOENT");
-}
-
 function requireInlinePath(result: { inlinePath?: string }): string {
   if (!result.inlinePath) {
     throw new Error("Expected inline dreaming markdown path");
@@ -138,7 +129,7 @@ describe("dreaming markdown storage", () => {
     await expect(fs.readFile(lowercasePath, "utf-8")).resolves.toBe("# Scratch\n\n");
   });
 
-  it("still writes deep reports to the per-phase report directory", async () => {
+  it("writes deep sleep summary to DREAMS.md and optionally to separate report", async () => {
     const workspaceDir = await createTempWorkspace("openclaw-dreaming-markdown-");
 
     const reportPath = await writeDeepDreamingReport({
@@ -146,20 +137,205 @@ describe("dreaming markdown storage", () => {
       bodyLines: ["- Promoted: durable preference"],
       storage: {
         mode: "separate",
+        separateReports: true,
+      },
+      nowMs: Date.parse("2026-04-05T10:00:00Z"),
+      timezone: "UTC",
+    });
+
+    // Separate report is written when separateReports is true.
+    const requiredReportPath = requireReportPath(reportPath);
+    expect(requiredReportPath).toBe(
+      path.join(workspaceDir, "memory", "dreaming", "deep", "2026-04-05.md"),
+    );
+    const reportContent = await fs.readFile(requiredReportPath, "utf-8");
+    expect(reportContent).toContain("# Deep Sleep");
+    expect(reportContent).toContain("- Promoted: durable preference");
+
+    // DREAMS.md is always written with the ## Deep Sleep section.
+    const dreamsContent = await fs.readFile(
+      path.join(workspaceDir, "DREAMS.md"), "utf-8",
+    );
+    expect(dreamsContent).toContain("## Deep Sleep");
+    expect(dreamsContent).toContain("- Promoted: durable preference");
+  });
+
+  it("writes ## Deep Sleep to DREAMS.md even when separateReports is false", async () => {
+    const workspaceDir = await createTempWorkspace("openclaw-dreaming-markdown-");
+
+    const reportPath = await writeDeepDreamingReport({
+      workspaceDir,
+      bodyLines: ["- Promoted: durable preference"],
+      storage: {
+        mode: "inline",
         separateReports: false,
       },
       nowMs: Date.parse("2026-04-05T10:00:00Z"),
       timezone: "UTC",
     });
 
-    const requiredReportPath = requireReportPath(reportPath);
-    expect(requiredReportPath).toBe(
-      path.join(workspaceDir, "memory", "dreaming", "deep", "2026-04-05.md"),
-    );
-    const content = await fs.readFile(requiredReportPath, "utf-8");
-    expect(content).toContain("# Deep Sleep");
-    expect(content).toContain("- Promoted: durable preference");
+    // No separate report path is returned when separateReports is false.
+    expect(reportPath).toBeUndefined();
 
-    await expectPathMissing(path.join(workspaceDir, "DREAMS.md"));
+    // DREAMS.md is always written with the ## Deep Sleep section.
+    const dreamsContent = await fs.readFile(
+      path.join(workspaceDir, "DREAMS.md"), "utf-8",
+    );
+    expect(dreamsContent).toContain("## Deep Sleep");
+    expect(dreamsContent).toContain("- Promoted: durable preference");
+  });
+
+  it("replaces an existing ## Deep Sleep section in DREAMS.md", async () => {
+    const workspaceDir = await createTempWorkspace("openclaw-dreaming-markdown-");
+
+    // Pre-populate DREAMS.md with an existing ## Deep Sleep section
+    // flanked by other sections.
+    const dreamsPath = path.join(workspaceDir, "DREAMS.md");
+    await fs.mkdir(workspaceDir, { recursive: true });
+    await fs.writeFile(
+      dreamsPath,
+      [
+        "## Other Section",
+        "",
+        "- Other item",
+        "",
+        "## Deep Sleep",
+        "- Old stale item",
+        "",
+        "## Another Section",
+        "- Another item",
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    await writeDeepDreamingReport({
+      workspaceDir,
+      bodyLines: ["- New durable preference"],
+      storage: {
+        mode: "inline",
+        separateReports: false,
+      },
+      nowMs: Date.parse("2026-04-05T10:00:00Z"),
+      timezone: "UTC",
+    });
+
+    const content = await fs.readFile(dreamsPath, "utf-8");
+    // The new content replaces the old ## Deep Sleep section.
+    expect(content).toContain("- New durable preference");
+    expect(content).not.toContain("- Old stale item");
+    // Other sections are preserved intact.
+    expect(content).toContain("## Other Section");
+    expect(content).toContain("## Another Section");
+    // Only one ## Deep Sleep heading remains.
+    const deepMatches = content.match(/## Deep Sleep/g);
+    expect(deepMatches?.length).toBe(1);
+  });
+
+  it("updates lowercase dreams.md when it already exists", async () => {
+    const workspaceDir = await createTempWorkspace("openclaw-dreaming-markdown-");
+
+    // Pre-populate lowercase dreams.md — the Dreams resolver prefers
+    // the existing file over creating a new DREAMS.md.
+    const dreamsPath = path.join(workspaceDir, "dreams.md");
+    await fs.mkdir(workspaceDir, { recursive: true });
+    await fs.writeFile(dreamsPath, "# Dream Diary\n\n- Old diary entry\n", "utf-8");
+
+    await writeDeepDreamingReport({
+      workspaceDir,
+      bodyLines: ["- Promoted: from lowercase"],
+      storage: {
+        mode: "inline",
+        separateReports: false,
+      },
+      nowMs: Date.parse("2026-04-05T10:00:00Z"),
+      timezone: "UTC",
+    });
+
+    // The lowercase file was updated, not a new uppercase file created.
+    const content = await fs.readFile(dreamsPath, "utf-8");
+    expect(content).toContain("## Deep Sleep");
+    expect(content).toContain("- Promoted: from lowercase");
+    // Original content is preserved.
+    expect(content).toContain("- Old diary entry");
+
+    // No uppercase DREAMS.md was created.
+    await expect(
+      fs.access(path.join(workspaceDir, "DREAMS.md")),
+    ).rejects.toThrow(/ENOENT/);
+  });
+
+  it("preserves dream diary entries alongside the ## Deep Sleep section", async () => {
+    const workspaceDir = await createTempWorkspace("openclaw-dreaming-markdown-");
+
+    // Pre-populate DREAMS.md with diary markers and entries, plus
+    // an existing ## Deep Sleep section.
+    const dreamsPath = path.join(workspaceDir, "DREAMS.md");
+    await fs.mkdir(workspaceDir, { recursive: true });
+    const original = [
+      "# Dream Diary",
+      "",
+      "<!-- openclaw:dreaming:diary:start -->",
+      "",
+      "---",
+      "",
+      "*June 5, 2026 at 10:00 AM EDT*",
+      "",
+      "A quiet morning of reflection on memory patterns.",
+      "",
+      "<!-- openclaw:dreaming:diary:end -->",
+      "",
+      "## Deep Sleep",
+      "- Previous: ranked 3, promoted 1",
+      "",
+    ].join("\n");
+    await fs.writeFile(dreamsPath, original, "utf-8");
+
+    await writeDeepDreamingReport({
+      workspaceDir,
+      bodyLines: ["- Ranked 5, promoted 2"],
+      storage: {
+        mode: "inline",
+        separateReports: false,
+      },
+      nowMs: Date.parse("2026-04-05T10:00:00Z"),
+      timezone: "UTC",
+    });
+
+    const content = await fs.readFile(dreamsPath, "utf-8");
+    // Deep Sleep section was updated.
+    expect(content).toContain("- Ranked 5, promoted 2");
+    // Diary markers and entries are preserved intact.
+    expect(content).toContain("<!-- openclaw:dreaming:diary:start -->");
+    expect(content).toContain("<!-- openclaw:dreaming:diary:end -->");
+    expect(content).toContain("*June 5, 2026 at 10:00 AM EDT*");
+    expect(content).toContain("A quiet morning of reflection on memory patterns.");
+    // Only one ## Deep Sleep heading.
+    const deepMatches = content.match(/## Deep Sleep/g);
+    expect(deepMatches?.length).toBe(1);
+  });
+
+  it("rejects a symlinked DREAMS.md when writing deep sleep summary", async () => {
+    const workspaceDir = await createTempWorkspace("openclaw-dreaming-markdown-");
+
+    // Create a real target file and symlink DREAMS.md to it.
+    const targetPath = path.join(workspaceDir, "real-dreams.md");
+    await fs.mkdir(workspaceDir, { recursive: true });
+    await fs.writeFile(targetPath, "# Real dreams\n", "utf-8");
+    const dreamsPath = path.join(workspaceDir, "DREAMS.md");
+    await fs.symlink("real-dreams.md", dreamsPath);
+
+    await expect(
+      writeDeepDreamingReport({
+        workspaceDir,
+        bodyLines: ["- Should be rejected"],
+        storage: {
+          mode: "inline",
+          separateReports: false,
+        },
+        nowMs: Date.parse("2026-04-05T10:00:00Z"),
+        timezone: "UTC",
+      }),
+    ).rejects.toThrow(/symlink/i);
   });
 });

--- a/extensions/memory-core/src/dreaming-markdown.ts
+++ b/extensions/memory-core/src/dreaming-markdown.ts
@@ -11,6 +11,7 @@ import {
   replaceManagedMarkdownBlock,
   withTrailingNewline,
 } from "openclaw/plugin-sdk/memory-host-markdown";
+import { updateDreamsFile } from "./dreaming-narrative.js";
 import { resolveMemoryCoreNowMs, resolveMemoryCoreTimestamp } from "./time.js";
 
 const DAILY_PHASE_HEADINGS: Record<Exclude<MemoryDreamingPhaseName, "deep">, string> = {
@@ -130,21 +131,68 @@ export async function writeDeepDreamingReport(params: {
   timezone?: string;
   storage: MemoryDreamingStorageConfig;
 }): Promise<string | undefined> {
-  if (!shouldWriteSeparate(params.storage)) {
-    return undefined;
-  }
   const nowMs = resolveMemoryCoreNowMs(params.nowMs);
-  const reportPath = resolveSeparateReportPath(params.workspaceDir, "deep", nowMs, params.timezone);
-  await fs.mkdir(path.dirname(reportPath), { recursive: true });
   const body = params.bodyLines.length > 0 ? params.bodyLines.join("\n") : "- No durable changes.";
-  await fs.writeFile(reportPath, `# Deep Sleep\n\n${body}\n`, "utf-8");
+  const deepSection = `## Deep Sleep\n\n${body}\n`;
+
+  // Route the ## Deep Sleep section through the shared Dreams file
+  // infrastructure so the summary benefits from the existing resolver
+  // (lowercase dreams.md → DREAMS.md), file lock, atomic write, and
+  // symlink / non-file guard.  The section sits outside the diary
+  // markers so it stays separate from narrative diary entries.
+  await updateDreamsFile({
+    workspaceDir: params.workspaceDir,
+    updater: (existing) => {
+      // Allow ## Deep Sleep to appear anywhere, including at file start.
+      const deepHeading = "## Deep Sleep\n";
+      const deepMarker = "\n" + deepHeading;
+      let deepIndex = existing.indexOf(deepMarker);
+      if (deepIndex < 0 && existing.startsWith(deepHeading)) {
+        deepIndex = 0;
+      }
+      let updated: string;
+      if (deepIndex >= 0) {
+        // Replace the existing ## Deep Sleep section.
+        const markerLen = deepIndex === 0 ? deepHeading.length : deepMarker.length;
+        const before = existing.slice(0, deepIndex);
+        const afterMarker = existing.slice(deepIndex + markerLen);
+        const nextHeader = afterMarker.search(/\n## /);
+        const after =
+          nextHeader >= 0 ? afterMarker.slice(nextHeader) : "";
+        updated = before + deepSection + after;
+      } else {
+        // Append the ## Deep Sleep section at the end.
+        updated = existing.endsWith("\n") ? existing + deepSection : existing + "\n" + deepSection;
+      }
+      return { content: updated, result: undefined };
+    },
+  });
+
+  // Optionally write the separate deep report file when storage mode
+  // requests it (mirrors the inline DREAMS.md section above).
+  if (shouldWriteSeparate(params.storage)) {
+    const reportPath = resolveSeparateReportPath(
+      params.workspaceDir, "deep", nowMs, params.timezone,
+    );
+    await fs.mkdir(path.dirname(reportPath), { recursive: true });
+    await fs.writeFile(reportPath, `# Deep Sleep\n\n${body}\n`, "utf-8");
+    await appendMemoryHostEvent(params.workspaceDir, {
+      type: "memory.dream.completed",
+      timestamp: resolveMemoryCoreTimestamp(nowMs),
+      phase: "deep",
+      reportPath,
+      lineCount: params.bodyLines.length,
+      storageMode: params.storage.mode,
+    });
+    return reportPath;
+  }
+
   await appendMemoryHostEvent(params.workspaceDir, {
     type: "memory.dream.completed",
     timestamp: resolveMemoryCoreTimestamp(nowMs),
     phase: "deep",
-    reportPath,
     lineCount: params.bodyLines.length,
     storageMode: params.storage.mode,
   });
-  return reportPath;
+  return undefined;
 }

--- a/extensions/memory-core/src/dreaming-narrative.ts
+++ b/extensions/memory-core/src/dreaming-narrative.ts
@@ -530,7 +530,7 @@ async function writeDreamsFileAtomic(dreamsPath: string, content: string): Promi
   });
 }
 
-async function updateDreamsFile<T>(params: {
+export async function updateDreamsFile<T>(params: {
   workspaceDir: string;
   updater: (
     existing: string,


### PR DESCRIPTION
## Summary

- Problem: The Deep Sleep phase writes per-phase report files (`memory/dreaming/deep/YYYY-MM-DD.md`) but never writes the documented `## Deep Sleep` summary section to `DREAMS.md`. Per docs: "Deep phase writes a `## Deep Sleep` summary into `DREAMS.md` and optionally writes `memory/dreaming/deep/YYYY-MM-DD.md`."
- What changed: `writeDeepDreamingReport` now routes the `## Deep Sleep` summary through the existing shared Dreams file infrastructure (`updateDreamsFile`) which provides the lowercase dreams.md/DREAMS.md resolver, file-level lock, atomic write, and symlink/non-file guard. The summary section is written outside the diary markers so narrative diary entries are preserved. When an existing `## Deep Sleep` section is present it is replaced in-place; otherwise it is appended. The separate per-phase report file is still conditionally written when storage mode requests it.
- Tests added: separateReports:true, separateReports:false, section replacement (non-destructive), lowercase dreams.md compatibility, diary entry preservation, symlink rejection.

## Change Type

- [x] Bug fix

## Linked Issues

- Closes #91051

## Real behavior proof

**Behavior addressed:** Deep Sleep phase never writes `## Deep Sleep` to DREAMS.md (#91051).

**Real environment tested:** Node v22.22.0, Linux x86_64, pnpm v11.2.2.

**Exact steps or command run after this patch:**

OPENCLAW_VITEST_MAX_WORKERS=4 pnpm test -- extensions/memory-core/src/dreaming-markdown.test.ts extensions/memory-core/src/dreaming-phases.test.ts

**Evidence after fix (terminal capture):**

Raw console output captured from a real terminal run on the patched branch:

$ OPENCLAW_VITEST_MAX_WORKERS=4 pnpm test -- extensions/memory-core/src/dreaming-markdown.test.ts extensions/memory-core/src/dreaming-phases.test.ts

 Test Files  2 passed (2)
      Tests  55 passed (55)
   Start at  14:37:17
   Duration  19.31s (transform 24.90s, setup 2.02s, import 30.50s, tests 2.89s, environment 0ms)

exit code: 0

**Observed result after fix:** `writeDeepDreamingReport` now writes the `## Deep Sleep` section to the Dreams file through the shared `updateDreamsFile` infrastructure. The summary is protected by the same resolver, lock, atomic write, and symlink guard used by narrative diary entries. Lowercase `dreams.md` workspaces are updated in-place. Dream diary markers and entries are preserved alongside the deep summary.

**What was not tested:** Live cron-triggered deep dreaming sweep.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>