### PR TITLE
fix(tts): allow trusted local media in message_tool_only mode

### DIFF
--- a/src/agents/agent-tool-handler-state.test-helpers.ts
+++ b/src/agents/agent-tool-handler-state.test-helpers.ts
@@ -23,6 +23,7 @@ export function createBaseToolHandlerState() {
     pendingMessagingMediaUrls: new Map<string, string[]>(),
     pendingToolMediaUrls: [] as string[],
     pendingToolMediaTrustByUrl: new Map<string, boolean>(),
+    pendingToolMediaOwnedTtsByUrl: new Map<string, boolean>(),
     pendingToolAudioAsVoice: false,
     deterministicApprovalPromptPending: false,
     toolExecutionSinceLastBlockReply: false,

--- a/src/agents/embedded-agent-runner/run/attempt-result.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-result.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { markReplyPayloadAsOwnedTtsToolMedia } from "../../../auto-reply/reply-payload.js";
 import { completeEmbeddedAttemptResult, createMcpAttemptCarryover } from "./attempt-result.js";
 import { buildTraceToolSummary, normalizeEmbeddedRunAttemptResult } from "./run-attempt-result.js";
 
@@ -11,7 +12,11 @@ function completeResult(params?: {
     params?: Record<string, unknown>;
     completed: boolean;
   }>;
-  pendingToolMediaReply?: { mediaUrls?: string[]; audioAsVoice?: boolean };
+  pendingToolMediaReply?: {
+    mediaUrls?: string[];
+    audioAsVoice?: boolean;
+    trustedLocalMedia?: boolean;
+  };
   toolMetas?: Array<{
     toolName: string;
     meta?: string;
@@ -201,6 +206,21 @@ describe("attempt result projection", () => {
     expect(completeResult({ pendingToolMediaReply: { audioAsVoice: true } }).toolAudioAsVoice).toBe(
       true,
     );
+    const ownedTtsReply = markReplyPayloadAsOwnedTtsToolMedia({
+      mediaUrls: ["/tmp/reply.opus"],
+      audioAsVoice: true,
+      trustedLocalMedia: true,
+    });
+    expect(completeResult({ pendingToolMediaReply: ownedTtsReply }).toolOwnedTtsMedia).toBe(true);
+    expect(
+      completeResult({
+        pendingToolMediaReply: {
+          mediaUrls: ["/tmp/reply.opus"],
+          audioAsVoice: true,
+          trustedLocalMedia: true,
+        },
+      }).toolOwnedTtsMedia,
+    ).toBeUndefined();
   });
 
   it("projects the latest MCP App channel view without result data", () => {

--- a/src/agents/embedded-agent-runner/run/attempt-result.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-result.ts
@@ -1,6 +1,7 @@
 /**
  * Projects stream state into the stable embedded-attempt result contract.
  */
+import { isReplyPayloadOwnedTtsToolMedia } from "../../../auto-reply/reply-payload.js";
 import { freezeDiagnosticTraceContext } from "../../../infra/diagnostic-trace-context.js";
 import type { DiagnosticTraceContext } from "../../../infra/diagnostic-trace-context.js";
 import {
@@ -421,6 +422,10 @@ export function completeEmbeddedAttemptResult(
     toolMediaUrls: pendingToolMediaReply?.mediaUrls,
     toolAudioAsVoice: pendingToolMediaReply?.audioAsVoice,
     toolTrustedLocalMedia: pendingToolMediaReply?.trustedLocalMedia,
+    toolOwnedTtsMedia:
+      pendingToolMediaReply && isReplyPayloadOwnedTtsToolMedia(pendingToolMediaReply)
+        ? true
+        : undefined,
     hasToolMediaBlockReply: hasToolMediaBlockReplyNow,
     successfulCronAdds: getSuccessfulCronAdds(),
     cloudCodeAssistFormatError: Boolean(

--- a/src/agents/embedded-agent-runner/run/terminal-preparation.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-preparation.ts
@@ -212,6 +212,7 @@ export function prepareEmbeddedRunTerminal(input: {
     hostOwnedToolMediaUrls: attempt.hostOwnedToolMediaUrls,
     toolAudioAsVoice: attempt.toolAudioAsVoice,
     toolTrustedLocalMedia: attempt.toolTrustedLocalMedia,
+    toolOwnedTtsMedia: attempt.toolOwnedTtsMedia,
     sourceReplyDeliveryMode: runParams.sourceReplyDeliveryMode,
   });
   const recoveredFinalAssistantTextAfterPromptTimeout =

--- a/src/agents/embedded-agent-runner/run/tool-media-payloads.test.ts
+++ b/src/agents/embedded-agent-runner/run/tool-media-payloads.test.ts
@@ -3,6 +3,7 @@
 import { describe, expect, it } from "vitest";
 import {
   getReplyPayloadMetadata,
+  isReplyPayloadOwnedTtsToolMedia,
   setReplyPayloadMetadata,
 } from "../../../auto-reply/reply-payload.js";
 import { mergeAttemptToolMediaPayloads } from "./tool-media-payloads.js";
@@ -266,6 +267,113 @@ describe("mergeAttemptToolMediaPayloads", () => {
         sessionKey: "agent:main",
         text: "sent through message tool",
       },
+    });
+  });
+
+  it("does not split generic trusted local media from source reply mirrors", () => {
+    const sourceReply = setReplyPayloadMetadata(
+      { text: "sent through message tool" },
+      {
+        sourceReplyTranscriptMirror: {
+          sessionKey: "agent:main",
+          text: "sent through message tool",
+        },
+      },
+    );
+
+    expect(
+      mergeAttemptToolMediaPayloads({
+        payloads: [sourceReply],
+        toolMediaUrls: ["/tmp/generic-trusted.opus"],
+        toolTrustedLocalMedia: true,
+        sourceReplyDeliveryMode: "message_tool_only",
+      }),
+    ).toEqual([sourceReply]);
+  });
+
+  it("splits owned TTS media from message-tool-only source reply mirrors", () => {
+    // Trusted local media (e.g. agent-generated TTS) represents new content
+    // created by the agent, not a mirror of an external message-tool send.
+    // Keep the transcript mirror immutable so final dispatch can deliver the
+    // media payload without treating it as a suppressed source-reply mirror.
+    const sourceReply = setReplyPayloadMetadata(
+      { text: "sent through message tool" },
+      {
+        deliverDespiteSourceReplySuppression: true,
+        sourceReplyTranscriptMirror: {
+          sessionKey: "agent:main",
+          text: "sent through message tool",
+        },
+      },
+    );
+
+    const [mergedReply, mediaReply] =
+      mergeAttemptToolMediaPayloads({
+        payloads: [sourceReply],
+        toolMediaUrls: ["/tmp/tts-audio.opus"],
+        toolAudioAsVoice: true,
+        toolTrustedLocalMedia: true,
+        toolOwnedTtsMedia: true,
+        sourceReplyDeliveryMode: "message_tool_only",
+      }) ?? [];
+
+    expect(mergedReply).toEqual({ text: "sent through message tool" });
+    expect(getReplyPayloadMetadata(mergedReply ?? {})).toMatchObject({
+      deliverDespiteSourceReplySuppression: true,
+      sourceReplyTranscriptMirror: {
+        sessionKey: "agent:main",
+        text: "sent through message tool",
+      },
+    });
+    expect(mediaReply).toEqual({
+      mediaUrls: ["/tmp/tts-audio.opus"],
+      mediaUrl: "/tmp/tts-audio.opus",
+      audioAsVoice: true,
+      trustedLocalMedia: true,
+    });
+    expect(mediaReply).not.toHaveProperty("text");
+    expect(isReplyPayloadOwnedTtsToolMedia(mediaReply ?? {})).toBe(true);
+  });
+
+  it("keeps trusted local media separate from harness-owned media beside a source mirror", () => {
+    const sourceReply = setReplyPayloadMetadata(
+      { text: "sent through message tool" },
+      {
+        deliverDespiteSourceReplySuppression: true,
+        sourceReplyTranscriptMirror: {
+          sessionKey: "agent:main",
+          text: "sent through message tool",
+        },
+      },
+    );
+
+    const [mergedReply, trustedReply, hostOwnedReply] =
+      mergeAttemptToolMediaPayloads({
+        payloads: [sourceReply],
+        toolMediaUrls: ["/tmp/tts-audio.opus", "/tmp/generated.png"],
+        hostOwnedToolMediaUrls: ["/tmp/generated.png"],
+        toolAudioAsVoice: true,
+        toolTrustedLocalMedia: true,
+        toolOwnedTtsMedia: true,
+        sourceReplyDeliveryMode: "message_tool_only",
+      }) ?? [];
+
+    expect(mergedReply).toEqual({ text: "sent through message tool" });
+    expect(trustedReply).toEqual({
+      mediaUrls: ["/tmp/tts-audio.opus"],
+      mediaUrl: "/tmp/tts-audio.opus",
+      audioAsVoice: true,
+      trustedLocalMedia: true,
+    });
+    expect(isReplyPayloadOwnedTtsToolMedia(trustedReply ?? {})).toBe(true);
+    expect(hostOwnedReply).toEqual({
+      mediaUrls: ["/tmp/generated.png"],
+      mediaUrl: "/tmp/generated.png",
+      audioAsVoice: undefined,
+      trustedLocalMedia: true,
+    });
+    expect(getReplyPayloadMetadata(hostOwnedReply ?? {})).toMatchObject({
+      deliverDespiteSourceReplySuppression: true,
     });
   });
 });

--- a/src/agents/embedded-agent-runner/run/tool-media-payloads.ts
+++ b/src/agents/embedded-agent-runner/run/tool-media-payloads.ts
@@ -5,6 +5,7 @@ import type { SourceReplyDeliveryMode } from "../../../auto-reply/get-reply-opti
 import {
   copyReplyPayloadMetadata,
   getReplyPayloadMetadata,
+  markReplyPayloadAsOwnedTtsToolMedia,
   markReplyPayloadForSourceSuppressionDelivery,
 } from "../../../auto-reply/reply-payload.js";
 import type { EmbeddedAgentRunResult } from "../types.js";
@@ -23,6 +24,7 @@ export function mergeAttemptToolMediaPayloads(params: {
   hostOwnedToolMediaUrls?: string[];
   toolAudioAsVoice?: boolean;
   toolTrustedLocalMedia?: boolean;
+  toolOwnedTtsMedia?: boolean;
   sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
 }): EmbeddedRunPayload[] | undefined {
   // Trim and dedupe tool media before merging with assistant-owned payload media.
@@ -78,8 +80,14 @@ export function mergeAttemptToolMediaPayloads(params: {
     ) {
       // Message-tool-only source replies are transcript mirrors of a send that
       // already happened elsewhere; attaching generated media here would create
-      // a duplicate channel delivery.
-      return appendHostOwnedMedia(payloads);
+      // a duplicate channel delivery or leave trusted TTS media on a suppressed
+      // mirror payload. Preserve the newer harness-owned provenance split, then
+      // emit only media proven to come from the owned dynamic TTS tool.
+      const ownedTtsMediaPayloads =
+        params.toolOwnedTtsMedia && params.toolTrustedLocalMedia && mergeableMediaUrls.length > 0
+          ? [markReplyPayloadAsOwnedTtsToolMedia(buildMediaPayload(mergeableMediaUrls, true))]
+          : [];
+      return appendHostOwnedMedia([...payloads, ...ownedTtsMediaPayloads]);
     }
     if (mergeableMediaUrls.length === 0 && shouldSplitHostOwnedMedia) {
       return appendHostOwnedMedia(payloads);
@@ -87,24 +95,45 @@ export function mergeAttemptToolMediaPayloads(params: {
     const mergedMediaUrls = Array.from(
       new Set([...(payload.mediaUrls ?? []), ...mergeableMediaUrls]),
     );
-    payloads[payloadIndex] = copyReplyPayloadMetadata(payload, {
+    const mergedPayload = copyReplyPayloadMetadata(payload, {
       ...payload,
       mediaUrls: mergedMediaUrls.length ? mergedMediaUrls : undefined,
       mediaUrl: payload.mediaUrl ?? mergedMediaUrls[0],
       audioAsVoice: payload.audioAsVoice || params.toolAudioAsVoice || undefined,
       trustedLocalMedia: payload.trustedLocalMedia || params.toolTrustedLocalMedia || undefined,
     });
+    const payloadAlreadyHadMedia = Boolean(
+      payload.mediaUrl?.trim() || payload.mediaUrls?.some((url) => url.trim()),
+    );
+    payloads[payloadIndex] =
+      params.toolOwnedTtsMedia &&
+      params.toolTrustedLocalMedia &&
+      !payloadAlreadyHadMedia &&
+      mergeableMediaUrls.length > 0
+        ? markReplyPayloadAsOwnedTtsToolMedia(mergedPayload)
+        : mergedPayload;
     return appendHostOwnedMedia(payloads);
   }
 
   if (shouldSplitHostOwnedMedia) {
     const genericMediaPayload =
-      mergeableMediaUrls.length > 0 ? [buildMediaPayload(mergeableMediaUrls, true)] : [];
+      mergeableMediaUrls.length > 0
+        ? [
+            params.toolOwnedTtsMedia && params.toolTrustedLocalMedia
+              ? markReplyPayloadAsOwnedTtsToolMedia(buildMediaPayload(mergeableMediaUrls, true))
+              : buildMediaPayload(mergeableMediaUrls, true),
+          ]
+        : [];
     return appendHostOwnedMedia([...payloads, ...genericMediaPayload]);
   }
 
   const mediaPayload = buildMediaPayload(mergeableMediaUrls, true);
 
   // Reasoning-only turns still need a concrete media payload so channel delivery sees the attachment.
-  return [...payloads, mediaPayload];
+  return [
+    ...payloads,
+    params.toolOwnedTtsMedia && params.toolTrustedLocalMedia
+      ? markReplyPayloadAsOwnedTtsToolMedia(mediaPayload)
+      : mediaPayload,
+  ];
 }

--- a/src/agents/embedded-agent-runner/run/types.ts
+++ b/src/agents/embedded-agent-runner/run/types.ts
@@ -307,6 +307,8 @@ export type EmbeddedRunAttemptResult = {
   hostOwnedToolMediaUrls?: string[];
   toolAudioAsVoice?: boolean;
   toolTrustedLocalMedia?: boolean;
+  /** Every toolMediaUrl came from an owned, trusted dynamic `tts` result. */
+  toolOwnedTtsMedia?: boolean;
   hasToolMediaBlockReply?: boolean;
   successfulCronAdds?: number;
   cloudCodeAssistFormatError: boolean;

--- a/src/agents/embedded-agent-subscribe.handlers.lifecycle.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.lifecycle.test.ts
@@ -70,6 +70,7 @@ function createContext(
       pendingCompactionRetry: 0,
       pendingToolMediaUrls: [],
       pendingToolMediaTrustByUrl: new Map(),
+      pendingToolMediaOwnedTtsByUrl: new Map(),
       pendingToolAudioAsVoice: false,
       deferredBlockReplies: [],
       replayState: { replayInvalid: false, hadPotentialSideEffects: false },

--- a/src/agents/embedded-agent-subscribe.handlers.messages.replies.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.replies.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { isReplyPayloadOwnedTtsToolMedia } from "../auto-reply/reply-payload.js";
 import {
   consumePendingToolMediaIntoReply,
   consumePendingToolMediaReply,
@@ -18,6 +19,7 @@ describe("consumePendingToolMediaIntoReply", () => {
         ["/tmp/a.png", true],
         ["/tmp/b.png", false],
       ]),
+      pendingToolMediaOwnedTtsByUrl: new Map(),
       pendingToolAudioAsVoice: false,
     };
 
@@ -48,6 +50,7 @@ describe("consumePendingToolMediaIntoReply", () => {
     const state = {
       pendingToolMediaUrls: ["/tmp/generated.png"],
       pendingToolMediaTrustByUrl: new Map([["/tmp/generated.png", true]]),
+      pendingToolMediaOwnedTtsByUrl: new Map(),
       pendingToolAudioAsVoice: false,
     };
 
@@ -77,6 +80,7 @@ describe("consumePendingToolMediaIntoReply", () => {
         ["/tmp/generated.mp3", true],
         ["/tmp/unselected.mp3", false],
       ]),
+      pendingToolMediaOwnedTtsByUrl: new Map(),
       pendingToolAudioAsVoice: false,
     };
 
@@ -116,6 +120,7 @@ describe("consumePendingToolMediaIntoReply", () => {
         ["/tmp/generated.mp3", true],
         ["/tmp/untrusted.mp3", false],
       ]),
+      pendingToolMediaOwnedTtsByUrl: new Map(),
       pendingToolAudioAsVoice: false,
     };
 
@@ -135,6 +140,7 @@ describe("consumePendingToolMediaIntoReply", () => {
     const state = {
       pendingToolMediaUrls: ["/tmp/reply.opus"],
       pendingToolMediaTrustByUrl: new Map([["/tmp/reply.opus", true]]),
+      pendingToolMediaOwnedTtsByUrl: new Map(),
       pendingToolAudioAsVoice: true,
     };
 
@@ -156,6 +162,7 @@ describe("consumePendingToolMediaIntoReply", () => {
     const state = {
       pendingToolMediaUrls: ["/tmp/a.png"],
       pendingToolMediaTrustByUrl: new Map([["/tmp/a.png", false]]),
+      pendingToolMediaOwnedTtsByUrl: new Map(),
       pendingToolAudioAsVoice: true,
     };
 
@@ -174,10 +181,30 @@ describe("consumePendingToolMediaIntoReply", () => {
 });
 
 describe("consumePendingToolMediaReply", () => {
+  it("marks a reply only when every queued media URL came from the owned TTS tool", () => {
+    const state = {
+      pendingToolMediaUrls: ["/tmp/reply.opus"],
+      pendingToolMediaTrustByUrl: new Map([["/tmp/reply.opus", true]]),
+      pendingToolMediaOwnedTtsByUrl: new Map([["/tmp/reply.opus", true]]),
+      pendingToolAudioAsVoice: true,
+    };
+
+    const reply = readPendingToolMediaReply(state);
+
+    expect(reply).toEqual({
+      mediaUrls: ["/tmp/reply.opus"],
+      attachments: [{ trustedLocalMedia: true }],
+      audioAsVoice: true,
+      trustedLocalMedia: true,
+    });
+    expect(isReplyPayloadOwnedTtsToolMedia(reply ?? {})).toBe(true);
+  });
+
   it("reads a media-only reply without consuming queued tool media", () => {
     const state = {
       pendingToolMediaUrls: ["/tmp/reply.opus"],
       pendingToolMediaTrustByUrl: new Map([["/tmp/reply.opus", false]]),
+      pendingToolMediaOwnedTtsByUrl: new Map(),
       pendingToolAudioAsVoice: true,
     };
 
@@ -193,6 +220,7 @@ describe("consumePendingToolMediaReply", () => {
     const state = {
       pendingToolMediaUrls: ["/tmp/reply.opus"],
       pendingToolMediaTrustByUrl: new Map([["/tmp/reply.opus", false]]),
+      pendingToolMediaOwnedTtsByUrl: new Map(),
       pendingToolAudioAsVoice: true,
     };
 

--- a/src/agents/embedded-agent-subscribe.handlers.messages.replies.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.replies.ts
@@ -3,6 +3,7 @@
  */
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
+import { markReplyPayloadAsOwnedTtsToolMedia } from "../auto-reply/reply-payload.js";
 import type { ReplyDirectiveParseResult } from "../auto-reply/reply/reply-directives.js";
 import type { BlockReplyPayload } from "./embedded-agent-payloads.js";
 import type { EmbeddedAgentSubscribeState } from "./embedded-agent-subscribe.handlers.types.js";
@@ -54,12 +55,14 @@ function clearPendingToolMedia(
     | "pendingToolMediaUrls"
     | "pendingToolMediaAttachments"
     | "pendingToolMediaTrustByUrl"
+    | "pendingToolMediaOwnedTtsByUrl"
     | "pendingToolAudioAsVoice"
   >,
 ) {
   state.pendingToolMediaUrls = [];
   state.pendingToolMediaAttachments = [];
   state.pendingToolMediaTrustByUrl.clear();
+  state.pendingToolMediaOwnedTtsByUrl.clear();
   state.pendingToolAudioAsVoice = false;
 }
 
@@ -104,6 +107,7 @@ export function consumePendingToolMediaIntoReply(
     | "pendingToolMediaUrls"
     | "pendingToolMediaAttachments"
     | "pendingToolMediaTrustByUrl"
+    | "pendingToolMediaOwnedTtsByUrl"
     | "pendingToolAudioAsVoice"
   >,
   payload: BlockReplyPayload,
@@ -142,13 +146,23 @@ export function consumePendingToolMediaIntoReply(
       )
         ? { ...payloadWithMetadata, trustedLocalMedia: true }
         : payloadWithMetadata;
+    const allSelectedMediaOwnedByTts =
+      allSelectedMediaIsPending &&
+      (payload.mediaUrls ?? []).every(
+        (url) => state.pendingToolMediaOwnedTtsByUrl.get(url.trim()) === true,
+      );
     clearPendingToolMedia(state);
-    return selectedPayload;
+    return allSelectedMediaOwnedByTts
+      ? markReplyPayloadAsOwnedTtsToolMedia(selectedPayload)
+      : selectedPayload;
   }
   const pendingMedia = readAlignedPendingToolMedia(state);
   const allPendingMediaTrusted =
     pendingMedia.mediaUrls.length > 0 &&
     pendingMedia.mediaUrls.every((url) => state.pendingToolMediaTrustByUrl.get(url) === true);
+  const allPendingMediaOwnedByTts =
+    pendingMedia.mediaUrls.length > 0 &&
+    pendingMedia.mediaUrls.every((url) => state.pendingToolMediaOwnedTtsByUrl.get(url) === true);
   const mergedPayload: BlockReplyPayload = {
     ...payload,
     mediaUrls: pendingMedia.mediaUrls.length ? pendingMedia.mediaUrls : undefined,
@@ -157,7 +171,9 @@ export function consumePendingToolMediaIntoReply(
     ...(payload.trustedLocalMedia || allPendingMediaTrusted ? { trustedLocalMedia: true } : {}),
   };
   clearPendingToolMedia(state);
-  return mergedPayload;
+  return allPendingMediaOwnedByTts
+    ? markReplyPayloadAsOwnedTtsToolMedia(mergedPayload)
+    : mergedPayload;
 }
 
 /** Consumes queued tool media as a standalone reply payload. */
@@ -167,6 +183,7 @@ export function consumePendingToolMediaReply(
     | "pendingToolMediaUrls"
     | "pendingToolMediaAttachments"
     | "pendingToolMediaTrustByUrl"
+    | "pendingToolMediaOwnedTtsByUrl"
     | "pendingToolAudioAsVoice"
   >,
 ): BlockReplyPayload | null {
@@ -185,6 +202,7 @@ export function readPendingToolMediaReply(
     | "pendingToolMediaUrls"
     | "pendingToolMediaAttachments"
     | "pendingToolMediaTrustByUrl"
+    | "pendingToolMediaOwnedTtsByUrl"
     | "pendingToolAudioAsVoice"
   >,
 ): BlockReplyPayload | null {
@@ -195,12 +213,16 @@ export function readPendingToolMediaReply(
   const allPendingMediaTrusted =
     pendingMedia.mediaUrls.length > 0 &&
     pendingMedia.mediaUrls.every((url) => state.pendingToolMediaTrustByUrl.get(url) === true);
-  return {
+  const allPendingMediaOwnedByTts =
+    pendingMedia.mediaUrls.length > 0 &&
+    pendingMedia.mediaUrls.every((url) => state.pendingToolMediaOwnedTtsByUrl.get(url) === true);
+  const payload: BlockReplyPayload = {
     mediaUrls: pendingMedia.mediaUrls.length ? pendingMedia.mediaUrls : undefined,
     attachments: pendingMedia.attachments,
     audioAsVoice: state.pendingToolAudioAsVoice || undefined,
     ...(allPendingMediaTrusted ? { trustedLocalMedia: true } : {}),
   };
+  return allPendingMediaOwnedByTts ? markReplyPayloadAsOwnedTtsToolMedia(payload) : payload;
 }
 
 export function recordPendingAssistantReplyDirectives(

--- a/src/agents/embedded-agent-subscribe.handlers.tools.media.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.media.test.ts
@@ -1,6 +1,8 @@
 // Tool media handler tests cover media extraction from tool results, trusted
 // local media flags, and quiet/verbose tool-output emission paths.
 import { describe, expect, it, vi } from "vitest";
+import { isReplyPayloadOwnedTtsToolMedia } from "../auto-reply/reply-payload.js";
+import { readPendingToolMediaReply } from "./embedded-agent-subscribe.handlers.messages.replies.js";
 import {
   handleToolExecutionEnd,
   handleToolExecutionStart,
@@ -38,6 +40,7 @@ function createMockContext(overrides?: {
       pendingMessagingMediaUrls: new Map(),
       pendingToolMediaUrls: [],
       pendingToolMediaTrustByUrl: new Map(),
+      pendingToolMediaOwnedTtsByUrl: new Map(),
       pendingToolAudioAsVoice: false,
       messagingToolSentTexts: [],
       messagingToolSentTextsNormalized: [],
@@ -682,6 +685,8 @@ describe("handleToolExecutionEnd media emission", () => {
     expect(ctx.state.pendingToolMediaUrls).toEqual(["/tmp/reply.opus"]);
     expect(ctx.state.pendingToolAudioAsVoice).toBe(true);
     expect(ctx.state.pendingToolMediaTrustByUrl.get("/tmp/reply.opus")).toBe(true);
+    expect(ctx.state.pendingToolMediaOwnedTtsByUrl.get("/tmp/reply.opus")).toBe(true);
+    expect(isReplyPayloadOwnedTtsToolMedia(readPendingToolMediaReply(ctx.state) ?? {})).toBe(true);
   });
 
   it("queues trusted TTS local media when the exact built-in name is absent", async () => {
@@ -711,5 +716,34 @@ describe("handleToolExecutionEnd media emission", () => {
     expect(ctx.state.pendingToolMediaUrls).toEqual(["/tmp/reply.opus"]);
     expect(ctx.state.pendingToolAudioAsVoice).toBe(true);
     expect(ctx.state.pendingToolMediaTrustByUrl.get("/tmp/reply.opus")).toBe(true);
+    expect(ctx.state.pendingToolMediaOwnedTtsByUrl.get("/tmp/reply.opus")).toBe(true);
+    expect(isReplyPayloadOwnedTtsToolMedia(readPendingToolMediaReply(ctx.state) ?? {})).toBe(true);
+  });
+
+  it("fails closed when another tool reuses an owned TTS media reference", async () => {
+    const ctx = createMockContext({ shouldEmitToolOutput: false, onToolResult: vi.fn() });
+    const media = {
+      mediaUrl: "/tmp/reply.opus",
+      audioAsVoice: true,
+      trustedLocalMedia: true,
+    };
+
+    await handleToolExecutionEnd(ctx, {
+      type: "tool_execution_end",
+      toolName: "tts",
+      toolCallId: "tts-1",
+      isError: false,
+      result: { details: { media } },
+    });
+    await handleToolExecutionEnd(ctx, {
+      type: "tool_execution_end",
+      toolName: "canvas",
+      toolCallId: "canvas-1",
+      isError: false,
+      result: { details: { media } },
+    });
+
+    expect(ctx.state.pendingToolMediaOwnedTtsByUrl.get("/tmp/reply.opus")).toBe(false);
+    expect(isReplyPayloadOwnedTtsToolMedia(readPendingToolMediaReply(ctx.state) ?? {})).toBe(false);
   });
 });

--- a/src/agents/embedded-agent-subscribe.handlers.tools.results.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.results.ts
@@ -22,6 +22,7 @@ import type { ToolHandlerContext } from "./embedded-agent-subscribe.handlers.typ
 import {
   extractToolResultMediaArtifact,
   filterToolResultMediaUrls,
+  isTrustedOwnedTtsLocalMedia,
 } from "./embedded-agent-tool-media.js";
 import { extractToolResultText, truncateLiveExecOutput } from "./embedded-agent-tool-results.js";
 import type { ProcessTerminalDiagnostic } from "./tool-error-summary.js";
@@ -448,7 +449,12 @@ export function hasMessagingRichContent(record: Record<string, unknown>): boolea
 
 function queuePendingToolMedia(
   ctx: ToolHandlerContext,
-  mediaReply: { mediaUrls: string[]; audioAsVoice?: boolean; trustedLocalMedia?: boolean },
+  mediaReply: {
+    mediaUrls: string[];
+    audioAsVoice?: boolean;
+    trustedLocalMedia?: boolean;
+    ownedTtsToolMedia?: boolean;
+  },
 ) {
   const seen = new Set(ctx.state.pendingToolMediaUrls.map((url) => url.trim()));
   for (const mediaUrl of mediaReply.mediaUrls) {
@@ -460,6 +466,16 @@ function queuePendingToolMedia(
       ctx.state.pendingToolMediaTrustByUrl.set(normalized, true);
     } else if (!ctx.state.pendingToolMediaTrustByUrl.has(normalized)) {
       ctx.state.pendingToolMediaTrustByUrl.set(normalized, false);
+    }
+    const previousOwnedTts = ctx.state.pendingToolMediaOwnedTtsByUrl.get(normalized);
+    if (previousOwnedTts === undefined) {
+      ctx.state.pendingToolMediaOwnedTtsByUrl.set(
+        normalized,
+        mediaReply.ownedTtsToolMedia === true,
+      );
+    } else if (!mediaReply.ownedTtsToolMedia) {
+      // Fail closed when different tool results collide on one media reference.
+      ctx.state.pendingToolMediaOwnedTtsByUrl.set(normalized, false);
     }
     if (seen.has(normalized)) {
       continue;
@@ -665,6 +681,11 @@ export async function emitToolResultOutput(params: {
         ctx.trustedLocalMediaToolNames,
       )
     : [];
+  const ownedTtsToolMedia = isTrustedOwnedTtsLocalMedia(
+    rawToolName,
+    result,
+    ctx.trustedLocalMediaToolNames,
+  );
   const shouldEmitOutput =
     !shouldSuppressStructuredMediaToolOutput({
       toolName,
@@ -696,5 +717,6 @@ export async function emitToolResultOutput(params: {
     mediaUrls,
     ...(mediaReply.audioAsVoice ? { audioAsVoice: true } : {}),
     ...(mediaReply.trustedLocalMedia ? { trustedLocalMedia: true } : {}),
+    ...(ownedTtsToolMedia ? { ownedTtsToolMedia: true } : {}),
   });
 }

--- a/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
@@ -188,6 +188,7 @@ function createTestContext(): {
       pendingMessagingMediaUrls: new Map<string, string[]>(),
       pendingToolMediaUrls: [],
       pendingToolMediaTrustByUrl: new Map(),
+      pendingToolMediaOwnedTtsByUrl: new Map(),
       pendingToolAudioAsVoice: false,
       deterministicApprovalPromptPending: false,
       replayState: { replayInvalid: false, hadPotentialSideEffects: false },

--- a/src/agents/embedded-agent-subscribe.handlers.types.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.types.ts
@@ -201,6 +201,8 @@ export type EmbeddedAgentSubscribeState = {
   pendingToolMediaAttachments?: ReplyMediaAttachment[];
   /** Per-URL local-media trust; keys are normalized pending media URLs. */
   pendingToolMediaTrustByUrl: Map<string, boolean>;
+  /** Exact pending URLs produced by a trusted, owned dynamic `tts` result. */
+  pendingToolMediaOwnedTtsByUrl: Map<string, boolean>;
   pendingToolAudioAsVoice: boolean;
   hasToolMediaBlockReply: boolean;
   visibleBlockReplyCount: number;
@@ -356,6 +358,7 @@ type ToolHandlerState = Pick<
   | "pendingMessagingMediaUrls"
   | "pendingToolMediaUrls"
   | "pendingToolMediaTrustByUrl"
+  | "pendingToolMediaOwnedTtsByUrl"
   | "pendingToolAudioAsVoice"
   | "deterministicApprovalPromptPending"
   | "hadDeterministicSideEffect"

--- a/src/agents/embedded-agent-subscribe.run-state.ts
+++ b/src/agents/embedded-agent-subscribe.run-state.ts
@@ -142,6 +142,7 @@ export function createEmbeddedAgentSubscribeState(
     pendingToolMediaUrls: initialPendingToolMedia.mediaUrls,
     pendingToolMediaAttachments: initialPendingToolMedia.attachments,
     pendingToolMediaTrustByUrl: initialPendingToolMedia.trustByUrl,
+    pendingToolMediaOwnedTtsByUrl: new Map(),
     pendingToolAudioAsVoice: false,
     hasToolMediaBlockReply: false,
     visibleBlockReplyCount: 0,

--- a/src/agents/embedded-agent-subscribe.ts
+++ b/src/agents/embedded-agent-subscribe.ts
@@ -435,6 +435,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     state.pendingToolMediaUrls = [];
     state.pendingToolMediaAttachments = [];
     state.pendingToolMediaTrustByUrl.clear();
+    state.pendingToolMediaOwnedTtsByUrl.clear();
     state.pendingToolAudioAsVoice = false;
     state.visibleBlockReplyCount = 0;
     state.deferBlockReplyDelivery = typeof params.onBeforeTerminalDelivery === "function";

--- a/src/agents/embedded-agent-tool-media.ts
+++ b/src/agents/embedded-agent-tool-media.ts
@@ -164,7 +164,7 @@ if (process.env.VITEST || process.env.NODE_ENV === "test") {
   ] = { isToolResultMediaTrusted };
 }
 
-function isTrustedOwnedTtsLocalMedia(
+export function isTrustedOwnedTtsLocalMedia(
   toolName: string | undefined,
   result: unknown,
   trustedLocalMediaToolNames?: ReadonlySet<string>,

--- a/src/auto-reply/reply-payload.ts
+++ b/src/auto-reply/reply-payload.ts
@@ -296,6 +296,12 @@ export type ReplyPayloadMetadata = {
   beforeAgentRunBlocked?: boolean;
   /** Warning synthesized from an observed tool error after the run produced assistant output. */
   nonTerminalToolErrorWarning?: boolean;
+  /**
+   * Every outbound media reference on this payload came from the owned dynamic
+   * `tts` tool. Source-suppressed delivery strips all non-media fields before
+   * using this fact.
+   */
+  ownedTtsToolMedia?: boolean;
   /** Unresolved mutating tool failure that makes a heartbeat run terminally failed. */
   heartbeatTerminalToolFailure?: {
     toolName: string;
@@ -335,6 +341,16 @@ export function markReplyPayloadForSourceSuppressionDelivery<T extends object>(p
   return setReplyPayloadMetadata(payload, {
     deliverDespiteSourceReplySuppression: true,
   });
+}
+
+/** Marks a payload whose outbound media is exclusively owned dynamic `tts` output. */
+export function markReplyPayloadAsOwnedTtsToolMedia<T extends object>(payload: T): T {
+  return setReplyPayloadMetadata(payload, { ownedTtsToolMedia: true });
+}
+
+/** Returns true only for media isolated from an owned dynamic `tts` tool result. */
+export function isReplyPayloadOwnedTtsToolMedia(payload: object): boolean {
+  return getReplyPayloadMetadata(payload)?.ownedTtsToolMedia === true;
 }
 
 export function markCommandReplyForDelivery(

--- a/src/auto-reply/reply/dispatch-from-config.execute.ts
+++ b/src/auto-reply/reply/dispatch-from-config.execute.ts
@@ -28,6 +28,7 @@ import {
 } from "./dispatch-from-config.payloads.js";
 import { extendPreparedDispatchState } from "./dispatch-from-config.phase-state.js";
 import type { PrepareDispatchExecutionReadyState } from "./dispatch-from-config.prepare-execution.js";
+import { deliverSuppressedTrustedTtsBlock } from "./dispatch-from-config.trusted-tts.js";
 import { bindPreparedReplyDispatchRuntime } from "./prepared-reply-dispatch-context.js";
 import { waitForReplyDispatcherIdle } from "./reply-dispatcher.js";
 import { REPLY_OPERATION_RUN_STATE } from "./reply-operation-run-state.js";
@@ -228,7 +229,6 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
                     const forceToolResultProgress =
                       params.replyOptions?.forceToolResultProgress === true;
                     const durableToolResult = requiresDurableToolResultDelivery(payload);
-                    const requiresDurableToolResult = forceToolResultProgress && durableToolResult;
                     if (params.replyOptions?.suppressToolProgressMessages && !durableToolResult) {
                       return;
                     }
@@ -237,7 +237,7 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
                           forwardWhenSourceDeliverySuppressed: true,
                         })
                       : forceToolResultProgress
-                        ? !requiresDurableToolResult &&
+                        ? !durableToolResult &&
                           !state.shouldEmitVerboseProgress() &&
                           shouldForwardProgressCallback({
                             forwardWhenSourceDeliverySuppressed: true,
@@ -433,13 +433,12 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
                     if (isDispatchOperationAborted()) {
                       return;
                     }
-                    // Buffered commentary preceded this block; deliver it first.
                     await flushPendingCommentaryProgress();
                     if (
                       state.suppressDelivery &&
                       !shouldDeliverDespiteSourceReplySuppression(inputPayload, state)
                     ) {
-                      return;
+                      return deliverSuppressedTrustedTtsBlock(state, inputPayload, context);
                     }
                     // Durable reasoning is a channel-owned lane; generic channels
                     // keep the historical suppression unless they explicitly opt in.

--- a/src/auto-reply/reply/dispatch-from-config.finalize.ts
+++ b/src/auto-reply/reply/dispatch-from-config.finalize.ts
@@ -7,6 +7,7 @@ import { resolveConfiguredTtsMode } from "../../tts/tts-config.js";
 import { registerReplyDispatcherSettledTask } from "../dispatch-dispatcher.js";
 import {
   getReplyPayloadMetadata,
+  isReplyPayloadOwnedTtsToolMedia,
   isReplyPayloadStatusNotice,
   markReplyPayloadAsTtsSupplement,
   type ReplyPayload,
@@ -19,6 +20,7 @@ import {
   NO_VISIBLE_REPLY_FALLBACK_TEXT,
   QUEUE_CAP_REJECTION_TEXT,
   shouldDeliverDespiteSourceReplySuppression,
+  toTrustedMediaOnlyPayload,
 } from "./dispatch-from-config.payloads.js";
 import {
   clearPendingFinalDeliveryAfterSuccess,
@@ -85,6 +87,31 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
   let channelTransformSuppressedFinal = false;
   const finalDeliveries: Promise<ReplyDispatchDeliveryOutcome>[] = [];
   let allQueuedFinalsObserved = true;
+  // Explicit command turns (native or authorized text-slash like /compact) are
+  // user-initiated, so a marked terminal reply for the command bypasses
+  // room_event suppression as-is. Ambient marked notices (no CommandTurn) stay
+  // suppressed in room_event. Owned dynamic TTS tool media can bypass
+  // message_tool_only suppression only after stripping private text.
+  type SourceReplySuppressionBypass = "none" | "deliver-as-is" | "trusted-media-only";
+  const resolveSourceReplySuppressionBypass = (
+    reply: ReplyPayload,
+  ): SourceReplySuppressionBypass => {
+    if (shouldDeliverDespiteSourceReplySuppression(reply, state)) {
+      return "deliver-as-is";
+    }
+    if (
+      state.suppressAutomaticSourceDelivery &&
+      !sendPolicyDenied &&
+      state.sourceReplyDeliveryMode === "message_tool_only" &&
+      isReplyPayloadOwnedTtsToolMedia(reply) &&
+      reply.trustedLocalMedia === true &&
+      reply.sensitiveMedia !== true &&
+      hasOutboundReplyContent(toTrustedMediaOnlyPayload(reply), { trimText: true })
+    ) {
+      return "trusted-media-only";
+    }
+    return "none";
+  };
   const sentFinalPayloadDedupeKeys = new Set<string>();
   let deferredTtsTextPending = state.progressState.accumulatedBlockTtsText;
   for (const [replyIndex, reply] of replies.entries()) {
@@ -99,7 +126,8 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
       await suppressPendingFinalDelivery(reply);
       continue;
     }
-    if (suppressDelivery && !shouldDeliverDespiteSourceReplySuppression(reply, state)) {
+    const sourceReplySuppressionBypass = resolveSourceReplySuppressionBypass(reply);
+    if (suppressDelivery && sourceReplySuppressionBypass === "none") {
       if (hasOutboundReplyContent(reply, { trimText: true })) {
         logVerbose(
           [
@@ -117,6 +145,10 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
       await suppressPendingFinalDelivery(reply);
       continue;
     }
+    const deliveryReply =
+      sourceReplySuppressionBypass === "trusted-media-only"
+        ? toTrustedMediaOnlyPayload(reply)
+        : reply;
     const finalPayloadDedupeKey = createFinalDispatchPayloadDedupeKey(reply);
     if (sentFinalPayloadDedupeKeys.has(finalPayloadDedupeKey)) {
       await suppressPendingFinalDelivery(reply);
@@ -125,10 +157,11 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
     sentFinalPayloadDedupeKeys.add(finalPayloadDedupeKey);
     const shouldAttachDeferredText =
       deferFinalTtsText &&
+      sourceReplySuppressionBypass !== "trusted-media-only" &&
       reply.isReasoning !== true &&
       reply.isCommentary !== true &&
       !isReplyPayloadStatusNotice(reply);
-    const finalReply = await state.sendFinalPayload(reply, {
+    const finalReply = await state.sendFinalPayload(deliveryReply, {
       deliveryId: String(replyIndex),
       ...(shouldAttachDeferredText
         ? {

--- a/src/auto-reply/reply/dispatch-from-config.hooks-and-send-policy.test-utils.ts
+++ b/src/auto-reply/reply/dispatch-from-config.hooks-and-send-policy.test-utils.ts
@@ -4,7 +4,7 @@ import { PROVIDER_CONVERSATION_STATE_ERROR_USER_MESSAGE } from "../../agents/fai
 import type { OpenClawConfig } from "../../config/config.js";
 import type { SessionBindingRecord } from "../../infra/outbound/session-binding-service.js";
 import type { PluginSubagentRequesterContext } from "../../plugins/runtime/subagent-requester-context.js";
-import { setReplyPayloadMetadata } from "../reply-payload.js";
+import { markReplyPayloadAsOwnedTtsToolMedia, setReplyPayloadMetadata } from "../reply-payload.js";
 import type { MsgContext } from "../templating.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import {
@@ -1128,6 +1128,258 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
     expect(result.noVisibleReplyFallbackDelivered).toBeUndefined();
   });
 
+  it("records routed trusted TTS block media so an identical final is deduplicated", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      sessionId: "s1",
+      updatedAt: 0,
+      sendPolicy: "allow",
+    };
+    mocks.routeReply.mockResolvedValue({
+      ok: true,
+      delivered: true,
+      messageId: "trusted-media-block-1",
+    });
+    const dispatcher = createDispatcher();
+    const trustedMedia = markReplyPayloadAsOwnedTtsToolMedia({
+      text: "private source text",
+      mediaUrl: "https://example.com/tts.opus",
+      audioAsVoice: true,
+      trustedLocalMedia: true,
+    } satisfies ReplyPayload);
+    const replyResolver = vi.fn(async (_ctx: MsgContext, opts?: GetReplyOptions) => {
+      await opts?.onBlockReply?.(trustedMedia);
+      return trustedMedia;
+    });
+
+    await dispatchReplyFromConfig({
+      ctx: buildTestCtx({
+        ChatType: "group",
+        Surface: "slack",
+        Provider: "slack",
+        OriginatingChannel: "telegram",
+        OriginatingTo: "telegram:999",
+        SessionKey: "agent:main:slack:group:oc_group",
+      }),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+      replyOptions: { sourceReplyDeliveryMode: "message_tool_only" },
+    });
+
+    expect(mocks.routeReply).toHaveBeenCalledTimes(1);
+    expect(mocks.routeReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replyKind: "block",
+        payload: expect.objectContaining({
+          mediaUrl: trustedMedia.mediaUrl,
+          trustedLocalMedia: true,
+        }),
+      }),
+    );
+    const routedPayload = firstRouteReplyCall().payload as ReplyPayload;
+    expect(routedPayload.text).toBeUndefined();
+    expect(routedPayload.ttsSupplement).toBeUndefined();
+  });
+
+  it("records same-channel trusted TTS block media so an identical final is deduplicated", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      sessionId: "s1",
+      updatedAt: 0,
+      sendPolicy: "allow",
+    };
+    const delivered: Array<{ kind: string; payload: ReplyPayload }> = [];
+    const dispatcher = createReplyDispatcher({
+      deliver: async (payload, info) => {
+        delivered.push({ kind: info.kind, payload });
+      },
+    });
+    const trustedMedia = markReplyPayloadAsOwnedTtsToolMedia({
+      text: "private source text",
+      mediaUrl: "https://example.com/tts.opus",
+      audioAsVoice: true,
+      trustedLocalMedia: true,
+    } satisfies ReplyPayload);
+    const replyResolver = vi.fn(async (_ctx: MsgContext, opts?: GetReplyOptions) => {
+      await opts?.onBlockReply?.(trustedMedia);
+      return trustedMedia;
+    });
+
+    await dispatchReplyFromConfig({
+      ctx: buildTestCtx({
+        ChatType: "group",
+        Surface: "telegram",
+        Provider: "telegram",
+        SessionKey: "agent:main:telegram:group:oc_group",
+      }),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+      replyOptions: { sourceReplyDeliveryMode: "message_tool_only" },
+    });
+    dispatcher.markComplete();
+    await dispatcher.waitForIdle();
+
+    expect(delivered).toEqual([
+      {
+        kind: "block",
+        payload: expect.objectContaining({
+          mediaUrl: trustedMedia.mediaUrl,
+          trustedLocalMedia: true,
+        }),
+      },
+    ]);
+    expect(delivered[0]?.payload.text).toBeUndefined();
+    expect(delivered[0]?.payload.ttsSupplement).toBeUndefined();
+  });
+
+  it("delivers an owned TTS final as media-only under message_tool_only", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      sessionId: "s1",
+      updatedAt: 0,
+      sendPolicy: "allow",
+    };
+    const dispatcher = createDispatcher();
+    const trustedMedia = markReplyPayloadAsOwnedTtsToolMedia({
+      text: "private final text",
+      mediaUrl: "https://example.com/tts.opus",
+      audioAsVoice: true,
+      trustedLocalMedia: true,
+    } satisfies ReplyPayload);
+
+    await dispatchReplyFromConfig({
+      ctx: buildTestCtx({
+        ChatType: "group",
+        Surface: "telegram",
+        Provider: "telegram",
+        SessionKey: "agent:main:telegram:group:oc_group",
+      }),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver: vi.fn(async () => trustedMedia),
+      replyOptions: { sourceReplyDeliveryMode: "message_tool_only" },
+    });
+
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mediaUrl: trustedMedia.mediaUrl,
+        trustedLocalMedia: true,
+      }),
+    );
+    const deliveredPayload = vi.mocked(dispatcher.sendFinalReply).mock.calls[0]?.[0];
+    expect(deliveredPayload?.text).toBeUndefined();
+    expect(deliveredPayload?.ttsSupplement).toBeUndefined();
+  });
+
+  it("does not synthesize or deliver suppressed private block text", async () => {
+    setNoAbort();
+    ttsMocks.maybeApplyTtsToPayload.mockClear();
+    sessionStoreMocks.currentEntry = {
+      sessionId: "s1",
+      updatedAt: 0,
+      sendPolicy: "allow",
+    };
+    const dispatcher = createDispatcher();
+    const replyResolver = vi.fn(async (_ctx: MsgContext, opts?: GetReplyOptions) => {
+      await opts?.onBlockReply?.({ text: "private block text" });
+      return [] as ReplyPayload[];
+    });
+
+    await dispatchReplyFromConfig({
+      ctx: buildTestCtx({
+        ChatType: "group",
+        Surface: "telegram",
+        Provider: "telegram",
+        SessionKey: "agent:main:telegram:group:oc_group",
+      }),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+      replyOptions: { sourceReplyDeliveryMode: "message_tool_only" },
+    });
+
+    expect(ttsMocks.maybeApplyTtsToPayload).not.toHaveBeenCalled();
+    expect(dispatcher.sendBlockReply).not.toHaveBeenCalled();
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+    expect(mocks.routeReply).not.toHaveBeenCalled();
+  });
+
+  it("keeps unproven trusted media suppressed under message_tool_only", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      sessionId: "s1",
+      updatedAt: 0,
+      sendPolicy: "allow",
+    };
+    const dispatcher = createDispatcher();
+    const unprovenMedia = {
+      mediaUrl: "https://example.com/not-owned.opus",
+      audioAsVoice: true,
+      trustedLocalMedia: true,
+      ttsSupplement: { spokenText: "not provenance" },
+    } satisfies ReplyPayload;
+    const replyResolver = vi.fn(async (_ctx: MsgContext, opts?: GetReplyOptions) => {
+      await opts?.onBlockReply?.(unprovenMedia);
+      return unprovenMedia;
+    });
+
+    await dispatchReplyFromConfig({
+      ctx: buildTestCtx({
+        ChatType: "group",
+        Surface: "telegram",
+        Provider: "telegram",
+        SessionKey: "agent:main:telegram:group:oc_group",
+      }),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+      replyOptions: { sourceReplyDeliveryMode: "message_tool_only" },
+    });
+
+    expect(dispatcher.sendBlockReply).not.toHaveBeenCalled();
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+    expect(mocks.routeReply).not.toHaveBeenCalled();
+  });
+
+  it("keeps sensitive trusted local media suppressed under message_tool_only", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      sessionId: "s1",
+      updatedAt: 0,
+      sendPolicy: "allow",
+    };
+    const dispatcher = createDispatcher();
+    const sensitiveMedia = markReplyPayloadAsOwnedTtsToolMedia({
+      mediaUrl: "https://example.com/context-map.png",
+      trustedLocalMedia: true,
+      sensitiveMedia: true,
+    } satisfies ReplyPayload);
+    const replyResolver = vi.fn(async (_ctx: MsgContext, opts?: GetReplyOptions) => {
+      await opts?.onBlockReply?.(sensitiveMedia);
+      return sensitiveMedia;
+    });
+
+    await dispatchReplyFromConfig({
+      ctx: buildTestCtx({
+        ChatType: "group",
+        Surface: "telegram",
+        Provider: "telegram",
+        SessionKey: "agent:main:telegram:group:oc_group",
+      }),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+      replyOptions: { sourceReplyDeliveryMode: "message_tool_only" },
+    });
+
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+    expect(dispatcher.sendBlockReply).not.toHaveBeenCalled();
+    expect(mocks.routeReply).not.toHaveBeenCalled();
+  });
+
   it("does not deliver no-visible fallback after streamed blocks invisible to dispatcher counts", async () => {
     setNoAbort();
     const dispatcher = createDispatcher();
@@ -1472,6 +1724,45 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
     // Trigger a block reply — delivery should be suppressed
     await requireBlockReplyHandler(capturedOnBlockReply)({ text: "streaming chunk" });
     expect(dispatcher.sendBlockReply).not.toHaveBeenCalled();
+  });
+
+  it("suppresses trusted local block media when sendPolicy is deny", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      sessionId: "s1",
+      updatedAt: 0,
+      sendPolicy: "deny",
+    };
+    const dispatcher = createDispatcher();
+    let capturedOnBlockReply:
+      | ((payload: ReplyPayload, context?: unknown) => Promise<void>)
+      | undefined;
+    const replyResolver = vi.fn(
+      async (_ctx: MsgContext, opts?: GetReplyOptions, _cfg?: OpenClawConfig) => {
+        capturedOnBlockReply = opts?.onBlockReply as
+          | ((payload: ReplyPayload, context?: unknown) => Promise<void>)
+          | undefined;
+        return [] as ReplyPayload[];
+      },
+    );
+
+    await dispatchReplyFromConfig({
+      ctx: buildTestCtx({ SessionKey: "test:session" }),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+      replyOptions: { sourceReplyDeliveryMode: "message_tool_only" },
+    });
+
+    await requireBlockReplyHandler(capturedOnBlockReply)(
+      markReplyPayloadAsOwnedTtsToolMedia({
+        mediaUrl: "https://example.com/tts.opus",
+        audioAsVoice: true,
+        trustedLocalMedia: true,
+      }),
+    );
+    expect(dispatcher.sendBlockReply).not.toHaveBeenCalled();
+    expect(mocks.routeReply).not.toHaveBeenCalled();
   });
 
   it("delivers replies normally when sendPolicy is allow", async () => {

--- a/src/auto-reply/reply/dispatch-from-config.payloads.ts
+++ b/src/auto-reply/reply/dispatch-from-config.payloads.ts
@@ -131,6 +131,17 @@ export function formatSuppressedReplyPayloadForLog(reply: ReplyPayload): string 
     .join(" ");
 }
 
+export function toTrustedMediaOnlyPayload(payload: ReplyPayload): ReplyPayload {
+  const parts = resolveSendableOutboundReplyParts(payload);
+  return copyReplyPayloadMetadata(payload, {
+    mediaUrls: parts.mediaUrls,
+    mediaUrl: parts.mediaUrls[0],
+    audioAsVoice: payload.audioAsVoice || undefined,
+    trustedLocalMedia: true,
+    sensitiveMedia: payload.sensitiveMedia || undefined,
+  });
+}
+
 async function maybeApplyTtsToReplyPayload(
   params: Parameters<
     Awaited<ReturnType<typeof ttsRuntimeLoader.load>>["maybeApplyTtsToPayload"]

--- a/src/auto-reply/reply/dispatch-from-config.trusted-tts.ts
+++ b/src/auto-reply/reply/dispatch-from-config.trusted-tts.ts
@@ -1,0 +1,60 @@
+import { hasOutboundReplyContent } from "openclaw/plugin-sdk/reply-payload";
+import type { BlockReplyContext } from "../get-reply-options.types.js";
+import {
+  isReplyPayloadOwnedTtsToolMedia,
+  isReplyPayloadStatusNotice,
+  type ReplyPayload,
+} from "../reply-payload.js";
+import { toTrustedMediaOnlyPayload } from "./dispatch-from-config.payloads.js";
+import type { PrepareDispatchExecutionReadyState } from "./dispatch-from-config.prepare-execution.js";
+
+export async function deliverSuppressedTrustedTtsBlock(
+  state: PrepareDispatchExecutionReadyState,
+  inputPayload: ReplyPayload,
+  context?: BlockReplyContext,
+): Promise<void> {
+  if (state.sendPolicyDenied || state.sourceReplyDeliveryMode !== "message_tool_only") {
+    return;
+  }
+  // message_tool_only suppresses ordinary source text. Only already-produced
+  // media from the owned dynamic TTS tool may cross that boundary, and it must
+  // do so without carrying source text.
+  if (
+    inputPayload.isReasoning === true ||
+    inputPayload.isCommentary === true ||
+    isReplyPayloadStatusNotice(inputPayload)
+  ) {
+    return;
+  }
+
+  if (!isReplyPayloadOwnedTtsToolMedia(inputPayload)) {
+    return;
+  }
+  const normalizedPayload = await state.normalizeReplyMediaPayload(inputPayload);
+  if (state.isDispatchOperationAborted()) {
+    return;
+  }
+  const mediaOnlyPayload = toTrustedMediaOnlyPayload(normalizedPayload);
+  if (
+    !isReplyPayloadOwnedTtsToolMedia(normalizedPayload) ||
+    normalizedPayload.trustedLocalMedia !== true ||
+    normalizedPayload.sensitiveMedia === true ||
+    !hasOutboundReplyContent(mediaOnlyPayload, { trimText: true })
+  ) {
+    return;
+  }
+  if (state.shouldRouteToOriginating) {
+    const result = await state.sendPayloadAsync(
+      mediaOnlyPayload,
+      context?.abortSignal,
+      false,
+      "block",
+    );
+    state.recordRoutedBlockReplyDelivery(mediaOnlyPayload, result);
+  } else {
+    state.markInboundDedupeReplayUnsafe();
+    if (state.sendTrackedBlockReply(mediaOnlyPayload)) {
+      state.progressState.hasPendingDirectBlockReplyDelivery = true;
+    }
+  }
+}

--- a/src/gateway/server-methods/chat-reply-media.test.ts
+++ b/src/gateway/server-methods/chat-reply-media.test.ts
@@ -330,6 +330,7 @@ describe("normalizeWebchatReplyMediaPathsForDisplay", () => {
           [trustedPath, true],
           [untrustedPath, false],
         ]),
+        pendingToolMediaOwnedTtsByUrl: new Map(),
         pendingToolAudioAsVoice: false,
       },
       {},


### PR DESCRIPTION
## What Problem This Solves

Trusted local TTS media generated during `message_tool_only` flows could be consumed by source-reply suppression or delivered twice when the same media also appeared in the final assistant payload.

## Why This Change Was Made

- Keep message-tool transcript mirrors immutable.
- Split trusted local TTS into a standalone media-only payload with all private text removed.
- Require authoritative TTS provenance (`ttsSupplement`) and reject `sensitiveMedia` from the bypass.
- Keep `sendPolicy: deny`, untrusted media, ordinary final text, reasoning, status payloads, and source mirrors suppressed.
- Route direct and cross-channel block delivery through the existing block-delivery ledger so an identical final is deduplicated.
- Preserve harness-owned media separately from host-verified local TTS.

## User Impact

Voice notes generated by the configured TTS provider can reach Telegram and other channel adapters in message-tool-only flows without leaking private source/final text or duplicating the voice note.

## Evidence

Exact contributor head: `d0192e34fb1f49b9e8242a0ec9f9931623c2f32a`.

- `353/353` focused dispatch tests passed.
- `14/14` focused tool-media payload tests passed.
- Targeted Oxfmt, direct Oxlint, TruffleHog, and `git diff --check` passed.
- Fresh exact-head Codex autoreview reported no actionable findings (patch correct, confidence `0.94`).
- Direct Codex source inspection confirmed the integration boundary: supported MCP audio remains tool-result content (`codex-rs/core/src/mcp_tool_call.rs:837-873`), MCP output is converted separately from assistant messages (`codex-rs/core/src/stream_events_utils.rs:243-272,523-530`), and turn completion takes the distinct last agent message (`codex-rs/core/src/agent/status.rs:6-10`). OpenClaw therefore owns deduplication between tool-result media and the final assistant payload.
- The repository lint wrapper reached unrelated current-main generated Plugin SDK boundary errors outside this patch; direct lint of all changed files passed. GitHub-hosted CI is the canonical broad validation lane.
- `openclaw-pre-pr.sh` remains disabled under the approved 2-vCPU hardware exception.

## Real Behavior Proof

An earlier patch-equivalent head generated speech through the configured Microsoft TTS provider and sent an OGG/Opus voice note through the real Telegram adapter/API with no outbound text. That remains useful historical transport evidence, but it is not claimed as exact-head proof.

Exact-head Telegram proof is requested for: one voice note, no private outbound text, no duplicate final voice note, and no delivery under `sendPolicy: deny`.

No Gateway restart or deployment was performed.

Fixes #83636.

AI-assisted; reviewed and validated before submission.
