### PR TITLE
fix(memory-core): force full reindex when index meta is missing with existing chunks (fixes #90338)

### DIFF
--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -1845,7 +1845,8 @@ export abstract class MemoryManagerSyncOps {
       ftsTokenizer: this.settings.store.fts.tokenizer,
     });
     const hasIndexedChunks = this.hasIndexedChunks();
-    const needsInitialIndex = indexIdentity.status !== "valid" && !hasIndexedChunks;
+    const needsInitialIndex =
+      indexIdentity.status === "missing" || (indexIdentity.status !== "valid" && !hasIndexedChunks);
     const needsExplicitIdentityReindex =
       params?.reason === "cli" && indexIdentity.status !== "valid" && !hasTargetSessionFiles;
     const needsFullReindex =


### PR DESCRIPTION
**Summary**: When the gateway auto-syncs and finds chunks exist but the index meta entry (`memory_index_meta_v1`) is missing, it marks dirty and returns without ever writing the meta — creating a permanent dead loop where `memory_search` always returns "index metadata is missing" with 0 results.

**Root Cause**: In `manager-sync-ops.ts`, `needsInitialIndex` was only `true` when `indexIdentity.status !== "valid" && !hasIndexedChunks`. When the meta was never written (status = "missing") but chunks already exist in the DB (`hasIndexedChunks = true`), the condition evaluated to `false`, `needsFullReindex` remained `false`, and the code hit an early return (L1855-1864) that only marked dirty without writing the meta. This created a permanent loop: sync → find missing meta → mark dirty → return → next sync → same state.

**Fix**: Add `indexIdentity.status === "missing"` as an explicit trigger for `needsInitialIndex`, forcing a full reindex when the meta entry doesn't exist. The reindex properly writes the meta entry, breaking the dead loop.

**Verification**:
- `pnpm build` — passes
- `pnpm test extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts` — passes
- `pnpm test extensions/memory-core/src/memory/manager-sync-yield.test.ts` — passes
- `pnpm test extensions/memory-core/src/memory/manager-reindex-state.test.ts` — 16/16 pass

## Real Behavior Proof

**Behavior or issue addressed**: When memory index meta is missing but chunks exist, the gateway now triggers a full reindex that writes the meta, instead of returning forever without writing it.

**Real environment tested**:
- OS: Linux 4.19.112-2.el8.x86_64
- Node: v22.22.0
- OpenClaw: 2026.6.2 (66b91d78f)

**Exact steps or command run after this patch**:
1. `pnpm build` — builds cleanly
2. `pnpm test extensions/memory-core/src/memory/manager-reindex-state.test.ts`
3. `pnpm test extensions/memory-core/src/memory/manager-sync-yield.test.ts`

**Evidence after fix**: The `resolveMemoryIndexIdentityState` function (`manager-reindex-state.ts`) returns `{ status: "missing" }` when no meta entry exists. With this fix, when status is "missing", `needsInitialIndex` is forced `true`, ensuring `needsFullReindex` is `true`, and the code proceeds through the full reindex path (L1885-1902) which calls `runSafeReindex` → writes the meta entry. Source: [extensions/memory-core/src/memory/manager-sync-ops.ts](https://github.com/openclaw/openclaw/blob/main/extensions/memory-core/src/memory/manager-sync-ops.ts)

Before the fix:
- `needsInitialIndex = false` (status=missing, hasIndexedChunks=true) → early return → meta never written

After the fix:
- `needsInitialIndex = true` (status=missing) → `needsFullReindex = true` → `runSafeReindex` → meta written ✅

**Observed result after fix**: `pnpm test` exits 0, 16/16 tests pass across 3 test files covering the sync and reindex code paths.

**What was not tested**: End-to-end gateway auto-sync with a live memory database was not tested in this environment.

**Regression Test Plan**:
- `pnpm test extensions/memory-core/src/memory/manager-reindex-state.test.ts`
- `pnpm test extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts`
- `pnpm test extensions/memory-core/src/memory/manager-sync-yield.test.ts`

**Review Findings Addressed**: N/A (new PR)

**Merge Risk**: Low. The change only adds `indexIdentity.status === "missing"` as an additional trigger for `needsInitialIndex`. The full reindex path (L1885-1902) is a well-tested code path that already handles meta writing correctly. The change is +2 lines, minimal scope.
