### PR TITLE
Fix loopback no-auth gateway startup warning

### DIFF
--- a/src/cli/gateway-cli/run.option-collisions.test.ts
+++ b/src/cli/gateway-cli/run.option-collisions.test.ts
@@ -266,6 +266,12 @@ describe("gateway run option collisions", () => {
     };
   }
 
+  function hasNoAuthStartupWarning() {
+    return gatewayLogMessages.includes(
+      "Gateway auth mode=none explicitly configured; all gateway connections are unauthenticated.",
+    );
+  }
+
   function expectAuthOverrideMode(mode: string) {
     expect(gatewayStartOptions().auth?.mode).toBe(mode);
   }
@@ -392,6 +398,67 @@ describe("gateway run option collisions", () => {
     expect(options.bind).toBe("auto");
   });
 
+  it("suppresses the no-auth startup warning for strictly local loopback gateway binds", async () => {
+    configState.snapshot = {
+      exists: true,
+      valid: true,
+      config: {
+        gateway: {
+          bind: "loopback",
+          auth: { mode: "none" },
+        },
+      },
+    };
+
+    await withEnvAsync(withoutGatewayAuthEnv, async () => {
+      await runGatewayCli(["gateway", "run", "--allow-unconfigured"]);
+    });
+
+    expect(gatewayStartOptions().bind).toBe("loopback");
+    expect(hasNoAuthStartupWarning()).toBe(false);
+  });
+
+  it("keeps the no-auth startup warning when a loopback bind is exposed through Tailscale", async () => {
+    configState.snapshot = {
+      exists: true,
+      valid: true,
+      config: {
+        gateway: {
+          bind: "loopback",
+          auth: { mode: "none" },
+        },
+      },
+    };
+
+    await withEnvAsync(withoutGatewayAuthEnv, async () => {
+      await runGatewayCli(["gateway", "run", "--tailscale", "serve", "--allow-unconfigured"]);
+    });
+
+    expect(gatewayStartOptions().bind).toBe("loopback");
+    expect(hasNoAuthStartupWarning()).toBe(true);
+  });
+
+  it("keeps the no-auth startup warning when a loopback bind has configured proxy exposure", async () => {
+    configState.snapshot = {
+      exists: true,
+      valid: true,
+      config: {
+        gateway: {
+          bind: "loopback",
+          trustedProxies: ["10.0.0.2"],
+          auth: { mode: "none" },
+        },
+      },
+    };
+
+    await withEnvAsync(withoutGatewayAuthEnv, async () => {
+      await runGatewayCli(["gateway", "run", "--allow-unconfigured"]);
+    });
+
+    expect(gatewayStartOptions().bind).toBe("loopback");
+    expect(hasNoAuthStartupWarning()).toBe(true);
+  });
+
   it("blocks container auto startup without explicit gateway auth", async () => {
     netState.autoBindHost = "0.0.0.0";
     netState.container = true;
@@ -407,12 +474,23 @@ describe("gateway run option collisions", () => {
   });
 
   it("blocks non-loopback startup without explicit gateway auth", async () => {
+    configState.snapshot = {
+      exists: true,
+      valid: true,
+      config: {
+        gateway: {
+          auth: { mode: "none" },
+        },
+      },
+    };
+
     await withEnvAsync(withoutGatewayAuthEnv, async () => {
       await expect(
         runGatewayCli(["gateway", "run", "--bind", "lan", "--allow-unconfigured"]),
       ).rejects.toThrow("__exit__:78");
     });
 
+    expect(hasNoAuthStartupWarning()).toBe(true);
     expect(runtimeErrors.join("\n")).toContain("Refusing to bind gateway to lan without auth.");
     expect(startGatewayServer).not.toHaveBeenCalled();
   });

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -234,6 +234,25 @@ function shouldBlockGatewayBindWithoutExplicitAuth(params: {
   );
 }
 
+function shouldLogUnauthenticatedGatewayWarning(params: {
+  bindHost: string;
+  cfg: OpenClawConfig;
+  resolvedAuthMode: GatewayAuthMode;
+  tailscaleMode: GatewayTailscaleMode;
+}): boolean {
+  if (params.resolvedAuthMode !== "none") {
+    return false;
+  }
+  if (!isLoopbackHost(params.bindHost) || params.tailscaleMode !== "off") {
+    return true;
+  }
+  return (
+    (params.cfg.gateway?.trustedProxies?.length ?? 0) > 0 ||
+    (params.cfg.gateway?.controlUi?.allowedOrigins?.length ?? 0) > 0 ||
+    params.cfg.gateway?.auth?.trustedProxy !== undefined
+  );
+}
+
 async function maybeLogPendingControlUiBuild(cfg: OpenClawConfig): Promise<void> {
   if (cfg.gateway?.controlUi?.enabled === false) {
     return;
@@ -772,12 +791,19 @@ export async function runGatewayCommand(opts: GatewayRunOpts) {
     defaultRuntime.exit(EXIT_CONFIG_ERROR);
     return;
   }
-  if (resolvedAuthMode === "none") {
+  const healthHost = await resolveGatewayBindHost(bind, cfg.gateway?.customBindHost);
+  if (
+    shouldLogUnauthenticatedGatewayWarning({
+      bindHost: healthHost,
+      cfg,
+      resolvedAuthMode,
+      tailscaleMode: effectiveTailscaleMode,
+    })
+  ) {
     gatewayLog.warn(
       "Gateway auth mode=none explicitly configured; all gateway connections are unauthenticated.",
     );
   }
-  const healthHost = await resolveGatewayBindHost(bind, cfg.gateway?.customBindHost);
   if (
     shouldBlockGatewayBindWithoutExplicitAuth({
       bindHost: healthHost,


### PR DESCRIPTION
## Summary

- Quiet the Gateway `auth mode=none` startup warning when startup can resolve a strictly local loopback-only no-auth bind.
- Keep the warning for non-loopback binds, Tailscale exposure, and loopback no-auth configs that declare proxy/browser exposure signals.
- Cover local suppression plus exposed warning paths in the existing gateway run CLI tests.

Fixes #91151.

## Verification

- `pnpm install --frozen-lockfile`
- `node scripts/run-vitest.mjs src/cli/gateway-cli/run.option-collisions.test.ts`
- `pnpm exec oxfmt --check src/cli/gateway-cli/run.ts src/cli/gateway-cli/run.option-collisions.test.ts`
- `node scripts/run-oxlint.mjs src/cli/gateway-cli/run.ts src/cli/gateway-cli/run.option-collisions.test.ts`
- `pnpm changed:lanes --json`
- `codex review --base origin/main` (rerun after addressing the first review finding; final review reported no actionable regression)
- Real CLI proof with temporary `OPENCLAW_CONFIG_PATH` / `OPENCLAW_STATE_DIR`:
  - loopback + `gateway.auth.mode="none"`: gateway reached `ready`; output did not contain `auth mode=none explicitly configured`
  - `--bind lan` + `gateway.auth.mode="none"`: exited 78; output contained the no-auth warning and `Refusing to bind gateway to lan without auth.`

`pnpm check:changed` was attempted but could not run here because the local Crabbox/Testbox binary failed its basic sanity check before executing the remote check lane.

## Real behavior proof

Behavior addressed: Gateway startup no longer prints the unauthenticated-connection warning for a strictly local loopback-only `gateway.auth.mode="none"` deployment, while exposed no-auth startup paths still warn.

Real environment tested: macOS local checkout, Node v26.0.0, pnpm 11.2.2, temporary config and state directories via `OPENCLAW_CONFIG_PATH` and `OPENCLAW_STATE_DIR`.

Exact steps or command run after this patch: Started `pnpm openclaw gateway run --port 19572` with a temp config containing `gateway.mode="local"`, `gateway.bind="loopback"`, and `gateway.auth.mode="none"`; then started `pnpm openclaw gateway run --bind lan --port 19574` with a temp config containing `gateway.mode="local"` and `gateway.auth.mode="none"`.

Evidence after fix: The loopback run logged `loading configuration`, `resolving authentication`, `starting...`, and `ready`, with no `auth mode=none explicitly configured` line. The LAN run logged `auth mode=none explicitly configured; all gateway connections are unauthenticated.` and `Refusing to bind gateway to lan without auth.` before exiting 78.

Observed result after fix: The noisy default warning is absent for the local loopback no-auth case, but remains visible for a non-loopback no-auth startup that OpenClaw refuses.

What was not tested: Full `pnpm check` / `pnpm test` were not run; `pnpm check:changed` was blocked by the local Crabbox/Testbox sanity check before starting the remote job.

## AI-assisted

This PR was prepared with Codex. I reviewed the code path, ran the proof above, addressed Codex review feedback, and understand the change.
