### PR TITLE
fix(doctor): report official managed plugin version drift

### DIFF
--- a/src/commands/doctor-workspace-status.test.ts
+++ b/src/commands/doctor-workspace-status.test.ts
@@ -281,6 +281,24 @@ describe("noteWorkspaceStatus", () => {
     }
   });
 
+  it("does not crash when plugin install-record loading fails", async () => {
+    mocks.loadInstalledPluginIndexInstallRecords.mockRejectedValueOnce(new Error("EBUSY"));
+    const noteSpy = await runNoteWorkspaceStatusForTest(
+      createPluginLoadResult({
+        plugins: [createPluginRecord({ id: "test-plugin", name: "Test" })],
+      }),
+    );
+    try {
+      // Doctor should complete without throwing — drift is best-effort.
+      const driftCalls = noteSpy.mock.calls.filter(([, title]) =>
+        String(title).includes("Plugin version drift"),
+      );
+      expect(driftCalls).toHaveLength(0);
+    } finally {
+      noteSpy.mockRestore();
+    }
+  });
+
   it("adds TaskFlow recovery hints for broken blocked flows", async () => {
     const noteSpy = await runNoteWorkspaceStatusForTest(createPluginLoadResult(), [], {
       flows: [

--- a/src/commands/doctor-workspace-status.test.ts
+++ b/src/commands/doctor-workspace-status.test.ts
@@ -17,7 +17,22 @@ const mocks = vi.hoisted(() => ({
   listTaskFlowRecords: vi.fn<() => unknown[]>(() => []),
   listTasksForFlowId: vi.fn<(flowId: string) => unknown[]>((_flowId: string) => []),
   loadInstalledPluginIndexInstallRecords: vi.fn(async () => ({})),
-  detectPluginVersionDrift: vi.fn(() => ({ gatewayVersion: "9.9.9-test", drifts: [] })),
+  detectPluginVersionDrift: vi.fn(
+    () =>
+      ({
+        gatewayVersion: "9.9.9-test",
+        drifts: [],
+      }) as {
+        gatewayVersion: string;
+        drifts: Array<{
+          pluginId: string;
+          installedVersion: string;
+          gatewayVersion: string;
+          source: string;
+          packageName?: string;
+        }>;
+      },
+  ),
 }));
 
 vi.mock("../agents/agent-scope.js", () => ({
@@ -49,12 +64,11 @@ vi.mock("../version.js", () => ({
 }));
 
 vi.mock("../plugins/installed-plugin-index-record-reader.js", () => ({
-  loadInstalledPluginIndexInstallRecords: (...args: unknown[]) =>
-    mocks.loadInstalledPluginIndexInstallRecords(...args),
+  loadInstalledPluginIndexInstallRecords: mocks.loadInstalledPluginIndexInstallRecords,
 }));
 
 vi.mock("../plugins/plugin-version-drift.js", () => ({
-  detectPluginVersionDrift: (...args: unknown[]) => mocks.detectPluginVersionDrift(...args),
+  detectPluginVersionDrift: mocks.detectPluginVersionDrift,
 }));
 
 async function runNoteWorkspaceStatusForTest(
@@ -231,8 +245,14 @@ describe("noteWorkspaceStatus", () => {
           pluginId: "codex",
           installedVersion: "2026.5.30-beta.1",
           gatewayVersion: "2026.6.2",
-          source: "npm",
+          source: "npm" as const,
           packageName: "@openclaw/codex",
+        } as {
+          pluginId: string;
+          installedVersion: string;
+          gatewayVersion: string;
+          source: string;
+          packageName?: string;
         },
       ],
     });

--- a/src/commands/doctor-workspace-status.test.ts
+++ b/src/commands/doctor-workspace-status.test.ts
@@ -16,6 +16,8 @@ const mocks = vi.hoisted(() => ({
   buildPluginCompatibilityWarnings: vi.fn(),
   listTaskFlowRecords: vi.fn<() => unknown[]>(() => []),
   listTasksForFlowId: vi.fn<(flowId: string) => unknown[]>((_flowId: string) => []),
+  loadInstalledPluginIndexInstallRecords: vi.fn(async () => ({})),
+  detectPluginVersionDrift: vi.fn(() => ({ gatewayVersion: "9.9.9-test", drifts: [] })),
 }));
 
 vi.mock("../agents/agent-scope.js", () => ({
@@ -42,6 +44,19 @@ vi.mock("../tasks/runtime-internal.js", () => ({
   listTasksForFlowId: (flowId: string) => mocks.listTasksForFlowId(flowId),
 }));
 
+vi.mock("../version.js", () => ({
+  VERSION: "9.9.9-test",
+}));
+
+vi.mock("../plugins/installed-plugin-index-record-reader.js", () => ({
+  loadInstalledPluginIndexInstallRecords: (...args: unknown[]) =>
+    mocks.loadInstalledPluginIndexInstallRecords(...args),
+}));
+
+vi.mock("../plugins/plugin-version-drift.js", () => ({
+  detectPluginVersionDrift: (...args: unknown[]) => mocks.detectPluginVersionDrift(...args),
+}));
+
 async function runNoteWorkspaceStatusForTest(
   loadResult: ReturnType<typeof createPluginLoadResult>,
   compatibilityWarnings: string[] = [],
@@ -66,7 +81,7 @@ async function runNoteWorkspaceStatusForTest(
   );
 
   const noteSpy = vi.spyOn(noteModule, "note").mockImplementation(() => {});
-  noteWorkspaceStatus({});
+  await noteWorkspaceStatus({});
   return noteSpy;
 }
 
@@ -203,6 +218,44 @@ describe("noteWorkspaceStatus", () => {
       expect(compatibilityCalls).toHaveLength(1);
       const [[body]] = compatibilityCalls;
       expect(body).toContain("legacy-plugin still uses legacy before_agent_start");
+    } finally {
+      noteSpy.mockRestore();
+    }
+  });
+
+  it("reports plugin version drift when official plugins are stale", async () => {
+    mocks.detectPluginVersionDrift.mockReturnValueOnce({
+      gatewayVersion: "2026.6.2",
+      drifts: [
+        {
+          pluginId: "codex",
+          installedVersion: "2026.5.30-beta.1",
+          gatewayVersion: "2026.6.2",
+          source: "npm",
+          packageName: "@openclaw/codex",
+        },
+      ],
+    });
+    const noteSpy = await runNoteWorkspaceStatusForTest(
+      createPluginLoadResult({
+        plugins: [
+          createPluginRecord({
+            id: "codex",
+            name: "Codex",
+          }),
+        ],
+      }),
+    );
+    try {
+      const driftCalls = noteSpy.mock.calls.filter(([, title]) =>
+        String(title).includes("Plugin version drift"),
+      );
+      expect(driftCalls).toHaveLength(1);
+      const [[body]] = driftCalls;
+      expect(body).toContain("codex");
+      expect(body).toContain("2026.5.30-beta.1");
+      expect(body).toContain("2026.6.2");
+      expect(body).toContain("openclaw plugins update");
     } finally {
       noteSpy.mockRestore();
     }

--- a/src/commands/doctor-workspace-status.ts
+++ b/src/commands/doctor-workspace-status.ts
@@ -3,6 +3,8 @@ import { note } from "../../packages/terminal-core/src/note.js";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { loadInstalledPluginIndexInstallRecords } from "../plugins/installed-plugin-index-record-reader.js";
+import { detectPluginVersionDrift } from "../plugins/plugin-version-drift.js";
 import {
   buildPluginCompatibilityWarnings,
   buildPluginRegistrySnapshotReport,
@@ -10,6 +12,7 @@ import {
 import { buildWorkspaceSkillStatus } from "../skills/discovery/status.js";
 import { listTasksForFlowId } from "../tasks/runtime-internal.js";
 import { listTaskFlowRecords } from "../tasks/task-flow-runtime-internal.js";
+import { VERSION } from "../version.js";
 import { detectLegacyWorkspaceDirs, formatLegacyWorkspaceWarning } from "./doctor-workspace.js";
 
 function noteFlowRecoveryHints() {
@@ -54,7 +57,7 @@ function noteFlowRecoveryHints() {
 }
 
 /** Emits workspace, skills, plugin, and TaskFlow recovery status notes for doctor. */
-export function noteWorkspaceStatus(cfg: OpenClawConfig) {
+export async function noteWorkspaceStatus(cfg: OpenClawConfig) {
   const workspaceDir = resolveAgentWorkspaceDir(cfg, resolveDefaultAgentId(cfg));
   const legacyWorkspace = detectLegacyWorkspaceDirs({ workspaceDir });
   if (legacyWorkspace.legacyDirs.length > 0) {
@@ -115,6 +118,28 @@ export function noteWorkspaceStatus(cfg: OpenClawConfig) {
   if (compatibilityWarnings.length > 0) {
     note(compatibilityWarnings.map((line) => `- ${line}`).join("\n"), "Plugin compatibility");
   }
+  // Check official managed plugin version drift against the running gateway.
+  const installRecords = await loadInstalledPluginIndexInstallRecords({
+    env: process.env,
+  });
+  const driftReport = detectPluginVersionDrift({
+    gatewayVersion: VERSION,
+    installRecords,
+    config: cfg,
+  });
+  if (driftReport.drifts.length > 0) {
+    const driftLines = driftReport.drifts.map(
+      (d) => `- ${d.pluginId}: ${d.installedVersion} -> expected ${d.gatewayVersion}`,
+    );
+    driftLines.push(
+      `Fix: ${formatCliCommand("openclaw plugins update <plugin-id>")} for each drifted plugin, then ${formatCliCommand("openclaw gateway restart")}.`,
+    );
+    note(
+      driftLines.join("\n"),
+      `Plugin version drift: ${driftReport.drifts.length} active official plugin${driftReport.drifts.length !== 1 ? "s" : ""} not on gateway ${driftReport.gatewayVersion}`,
+    );
+  }
+
   if (pluginRegistry.diagnostics.length > 0) {
     const lines = pluginRegistry.diagnostics.map((diag) => {
       const prefix = diag.level.toUpperCase();

--- a/src/commands/doctor-workspace-status.ts
+++ b/src/commands/doctor-workspace-status.ts
@@ -56,8 +56,17 @@ function noteFlowRecoveryHints() {
   );
 }
 
+type NoteWorkspaceStatusOptions = {
+  /** Env for resolving plugin install record paths (defaults to process.env). */
+  env?: Record<string, string | undefined>;
+  /** Running gateway version from a health probe, if available. Falls back to VERSION. */
+  gatewayVersion?: string;
+};
+
 /** Emits workspace, skills, plugin, and TaskFlow recovery status notes for doctor. */
-export async function noteWorkspaceStatus(cfg: OpenClawConfig) {
+export async function noteWorkspaceStatus(cfg: OpenClawConfig, opts?: NoteWorkspaceStatusOptions) {
+  const env = opts?.env ?? (process.env as Record<string, string | undefined>);
+  const driftGatewayVersion = opts?.gatewayVersion ?? VERSION;
   const workspaceDir = resolveAgentWorkspaceDir(cfg, resolveDefaultAgentId(cfg));
   const legacyWorkspace = detectLegacyWorkspaceDirs({ workspaceDir });
   if (legacyWorkspace.legacyDirs.length > 0) {
@@ -120,12 +129,14 @@ export async function noteWorkspaceStatus(cfg: OpenClawConfig) {
   }
   // Check official managed plugin version drift against the running gateway.
   // Best-effort: don't let a plugin-index read failure block the rest of doctor.
+  // Uses the same env/version inputs as gateway status --deep: env for resolving
+  // managed install paths, and probed gateway version falling back to CLI VERSION.
   try {
     const installRecords = await loadInstalledPluginIndexInstallRecords({
-      env: process.env,
+      env: env as NodeJS.ProcessEnv,
     });
     const driftReport = detectPluginVersionDrift({
-      gatewayVersion: VERSION,
+      gatewayVersion: driftGatewayVersion,
       installRecords,
       config: cfg,
     });

--- a/src/commands/doctor-workspace-status.ts
+++ b/src/commands/doctor-workspace-status.ts
@@ -119,25 +119,31 @@ export async function noteWorkspaceStatus(cfg: OpenClawConfig) {
     note(compatibilityWarnings.map((line) => `- ${line}`).join("\n"), "Plugin compatibility");
   }
   // Check official managed plugin version drift against the running gateway.
-  const installRecords = await loadInstalledPluginIndexInstallRecords({
-    env: process.env,
-  });
-  const driftReport = detectPluginVersionDrift({
-    gatewayVersion: VERSION,
-    installRecords,
-    config: cfg,
-  });
-  if (driftReport.drifts.length > 0) {
-    const driftLines = driftReport.drifts.map(
-      (d) => `- ${d.pluginId}: ${d.installedVersion} -> expected ${d.gatewayVersion}`,
-    );
-    driftLines.push(
-      `Fix: ${formatCliCommand("openclaw plugins update <plugin-id>")} for each drifted plugin, then ${formatCliCommand("openclaw gateway restart")}.`,
-    );
-    note(
-      driftLines.join("\n"),
-      `Plugin version drift: ${driftReport.drifts.length} active official plugin${driftReport.drifts.length !== 1 ? "s" : ""} not on gateway ${driftReport.gatewayVersion}`,
-    );
+  // Best-effort: don't let a plugin-index read failure block the rest of doctor.
+  try {
+    const installRecords = await loadInstalledPluginIndexInstallRecords({
+      env: process.env,
+    });
+    const driftReport = detectPluginVersionDrift({
+      gatewayVersion: VERSION,
+      installRecords,
+      config: cfg,
+    });
+    if (driftReport.drifts.length > 0) {
+      const driftLines = driftReport.drifts.map(
+        (d) => `- ${d.pluginId}: ${d.installedVersion} -> expected ${d.gatewayVersion}`,
+      );
+      driftLines.push(
+        `Fix: ${formatCliCommand("openclaw plugins update <plugin-id>")} for each drifted plugin, then ${formatCliCommand("openclaw gateway restart")}.`,
+      );
+      note(
+        driftLines.join("\n"),
+        `Plugin version drift: ${driftReport.drifts.length} active official plugin${driftReport.drifts.length !== 1 ? "s" : ""} not on gateway ${driftReport.gatewayVersion}`,
+      );
+    }
+  } catch {
+    // Plugin install-record loading can fail for transient filesystem or
+    // permission reasons; doctor diagnostic is advisory only.
   }
 
   if (pluginRegistry.diagnostics.length > 0) {

--- a/src/commands/doctor-workspace-status.ts
+++ b/src/commands/doctor-workspace-status.ts
@@ -129,8 +129,11 @@ export async function noteWorkspaceStatus(cfg: OpenClawConfig, opts?: NoteWorksp
   }
   // Check official managed plugin version drift against the running gateway.
   // Best-effort: don't let a plugin-index read failure block the rest of doctor.
-  // Uses the same env/version inputs as gateway status --deep: env for resolving
-  // managed install paths, and probed gateway version falling back to CLI VERSION.
+  // Uses the same env/version inputs and local-only guard as gateway status --deep.
+  // Remote gateways skip this check (their managed plugins live on another host).
+  if (cfg.gateway?.mode === "remote") {
+    return { workspaceDir };
+  }
   try {
     const installRecords = await loadInstalledPluginIndexInstallRecords({
       env: env as NodeJS.ProcessEnv,

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -728,9 +728,11 @@ async function runSystemdLingerHealth(ctx: DoctorHealthFlowContext): Promise<voi
 
 async function runWorkspaceStatusHealth(ctx: DoctorHealthFlowContext): Promise<void> {
   const { noteWorkspaceStatus } = await import("../commands/doctor-workspace-status.js");
+  // Match gateway status semantics: prefer the probed runtimeVersion
+  // over the invoking CLI VERSION when a gateway probe is available.
   await noteWorkspaceStatus(ctx.cfg, {
     env: ctx.env ?? process.env,
-    gatewayVersion: undefined, // probe context not available in doctor flow; falls back to VERSION
+    gatewayVersion: ctx.gatewayStatus?.runtimeVersion ?? undefined,
   });
 }
 

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -730,7 +730,7 @@ async function runWorkspaceStatusHealth(ctx: DoctorHealthFlowContext): Promise<v
   const { noteWorkspaceStatus } = await import("../commands/doctor-workspace-status.js");
   await noteWorkspaceStatus(ctx.cfg, {
     env: ctx.env ?? process.env,
-    gatewayVersion: ctx.gatewayStatus?.gateway?.version ?? undefined,
+    gatewayVersion: undefined, // probe context not available in doctor flow; falls back to VERSION
   });
 }
 

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -728,7 +728,7 @@ async function runSystemdLingerHealth(ctx: DoctorHealthFlowContext): Promise<voi
 
 async function runWorkspaceStatusHealth(ctx: DoctorHealthFlowContext): Promise<void> {
   const { noteWorkspaceStatus } = await import("../commands/doctor-workspace-status.js");
-  noteWorkspaceStatus(ctx.cfg);
+  await noteWorkspaceStatus(ctx.cfg);
 }
 
 async function runSkillsHealth(ctx: DoctorHealthFlowContext): Promise<void> {

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -728,7 +728,10 @@ async function runSystemdLingerHealth(ctx: DoctorHealthFlowContext): Promise<voi
 
 async function runWorkspaceStatusHealth(ctx: DoctorHealthFlowContext): Promise<void> {
   const { noteWorkspaceStatus } = await import("../commands/doctor-workspace-status.js");
-  await noteWorkspaceStatus(ctx.cfg);
+  await noteWorkspaceStatus(ctx.cfg, {
+    env: ctx.env ?? process.env,
+    gatewayVersion: ctx.gatewayStatus?.gateway?.version ?? undefined,
+  });
 }
 
 async function runSkillsHealth(ctx: DoctorHealthFlowContext): Promise<void> {


### PR DESCRIPTION
Closing in favor of #90927 which reuses the existing daemon status pipeline — architecturally the better approach. Thanks for the review!