### PR TITLE
feat(ios): clarify talk realtime fallback

### DIFF
--- a/apps/ios/Sources/Design/SettingsProTab.swift
+++ b/apps/ios/Sources/Design/SettingsProTab.swift
@@ -57,6 +57,7 @@ struct SettingsProTab: View {
     @State var notificationActionText = "Request Access"
     @State var diagnosticsLastRunText = "Not run"
     @State var diagnosticsIssueCount: Int?
+    @State var showTalkIssueDetails = false
 
     var body: some View {
         NavigationStack {
@@ -127,6 +128,11 @@ struct SettingsProTab: View {
                     onPrimaryAction: {
                         Task { await self.handleGatewayProblemPrimaryAction(gatewayProblem) }
                     })
+            }
+        }
+        .sheet(isPresented: self.$showTalkIssueDetails) {
+            if let issue = self.appModel.talkMode.gatewayTalkCurrentFallbackIssue {
+                TalkRuntimeIssueDetailsSheet(issue: issue)
             }
         }
         .sheet(isPresented: self.$showQRScanner) {

--- a/apps/ios/Sources/Design/SettingsProTabActions.swift
+++ b/apps/ios/Sources/Design/SettingsProTabActions.swift
@@ -610,6 +610,21 @@ extension SettingsProTab {
         return self.appModel.talkMode.gatewayTalkApiKeyConfigured ? "Configured" : "Not configured"
     }
 
+    var gatewayTalkActiveVoiceDetail: String {
+        let title = self.appModel.talkMode.gatewayTalkActiveModeTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+        let subtitle = (self.appModel.talkMode.gatewayTalkActiveModeSubtitle ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        if title.isEmpty { return "Not active" }
+        if subtitle.isEmpty { return title }
+        return "\(title) • \(subtitle)"
+    }
+
+    var gatewayTalkLastIssueDetail: String? {
+        let detail = (self.appModel.talkMode.gatewayTalkLastIssueText ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return detail.isEmpty ? nil : detail
+    }
+
     func gatewayDetailLines(_ gateway: GatewayDiscoveryModel.DiscoveredGateway) -> [String] {
         var lines: [String] = []
         if let lanHost = gateway.lanHost { lines.append("LAN: \(lanHost)") }

--- a/apps/ios/Sources/Design/SettingsProTabSections.swift
+++ b/apps/ios/Sources/Design/SettingsProTabSections.swift
@@ -792,26 +792,44 @@ extension SettingsProTab {
     }
 
     var talkVoiceSettingsCard: some View {
-        ProCard(radius: SettingsLayout.cardRadius) {
-            VStack(alignment: .leading, spacing: 12) {
-                Picker("Provider", selection: self.talkProviderSelectionBinding) {
-                    ForEach(TalkModeProviderSelection.allCases) { option in
-                        Text(option.label).tag(option.rawValue)
-                    }
-                }
-                if self.shouldShowRealtimeVoicePicker {
-                    Picker("Realtime Voice", selection: self.talkRealtimeVoiceSelectionBinding) {
-                        Text("Gateway Default").tag("")
-                        ForEach(TalkModeRealtimeVoiceSelection.voices, id: \.self) { voice in
-                            Text(TalkModeRealtimeVoiceSelection.label(for: voice)).tag(voice)
+        VStack(alignment: .leading, spacing: 10) {
+            if self.gatewayConnected,
+               let issue = self.appModel.talkMode.gatewayTalkCurrentFallbackIssue
+            {
+                TalkRuntimeIssueBanner(
+                    issue: issue,
+                    onOpenSettings: nil,
+                    onShowDetails: {
+                        self.showTalkIssueDetails = true
+                    })
+            }
+            ProCard(radius: SettingsLayout.cardRadius) {
+                VStack(alignment: .leading, spacing: 12) {
+                    Picker("Provider", selection: self.talkProviderSelectionBinding) {
+                        ForEach(TalkModeProviderSelection.allCases) { option in
+                            Text(option.label).tag(option.rawValue)
                         }
                     }
+                    if self.shouldShowRealtimeVoicePicker {
+                        Picker("Realtime Voice", selection: self.talkRealtimeVoiceSelectionBinding) {
+                            Text("Gateway Default").tag("")
+                            ForEach(TalkModeRealtimeVoiceSelection.voices, id: \.self) { voice in
+                                Text(TalkModeRealtimeVoiceSelection.label(for: voice)).tag(voice)
+                            }
+                        }
+                    }
+                    self.detailRow("Voice Mode", value: self.appModel.talkMode.gatewayTalkVoiceModeTitle)
+                    Divider()
+                    self.detailRow("Active Voice", value: self.gatewayTalkActiveVoiceDetail)
+                    if let issue = self.gatewayTalkLastIssueDetail {
+                        Divider()
+                        self.detailRow("Last Voice Issue", value: issue)
+                    }
+                    Divider()
+                    self.detailRow("Transport", value: self.appModel.talkMode.gatewayTalkTransportLabel)
+                    Divider()
+                    self.detailRow("API Key", value: self.talkApiKeyStatus)
                 }
-                self.detailRow("Voice Mode", value: self.appModel.talkMode.gatewayTalkVoiceModeTitle)
-                Divider()
-                self.detailRow("Transport", value: self.appModel.talkMode.gatewayTalkTransportLabel)
-                Divider()
-                self.detailRow("API Key", value: self.talkApiKeyStatus)
             }
         }
         .padding(.horizontal, OpenClawProMetric.pagePadding)

--- a/apps/ios/Sources/Design/TalkProTab.swift
+++ b/apps/ios/Sources/Design/TalkProTab.swift
@@ -8,6 +8,7 @@ struct TalkProTab: View {
         TalkDefaults.speakerphoneEnabledByDefault
     @AppStorage("talk.background.enabled") private var talkBackgroundEnabled: Bool = false
     @State private var showPermissionPrompt = false
+    @State private var showTalkIssueDetails = false
     var openSettings: () -> Void
 
     private var state: TalkProState {
@@ -30,6 +31,15 @@ struct TalkProTab: View {
                 ScrollView {
                     VStack(alignment: .leading, spacing: 10) {
                         self.header
+                        if let fallbackIssue = self.fallbackIssue {
+                            TalkRuntimeIssueBanner(
+                                issue: fallbackIssue,
+                                onOpenSettings: self.openSettings,
+                                onShowDetails: {
+                                    self.showTalkIssueDetails = true
+                                })
+                                .padding(.horizontal, OpenClawProMetric.pagePadding)
+                        }
                         self.voiceHeroCard
                         self.conversationCard
                         self.voiceModeCard
@@ -61,6 +71,14 @@ struct TalkProTab: View {
             }
             .presentationDetents([.medium, .large])
             .openClawSheetChrome()
+        }
+        .sheet(isPresented: self.$showTalkIssueDetails) {
+            if let fallbackIssue = self.fallbackIssue {
+                TalkRuntimeIssueDetailsSheet(
+                    issue: fallbackIssue,
+                    onOpenSettings: self.openSettings)
+                    .openClawSheetChrome()
+            }
         }
         .onAppear { self.alignPersistedTalkState() }
     }
@@ -173,9 +191,21 @@ struct TalkProTab: View {
                     .padding(.horizontal, 12)
                     .padding(.top, 11)
                     .padding(.bottom, 3)
-                self.infoRow(icon: "waveform", title: "Mode", value: self.appModel.talkMode.gatewayTalkVoiceModeTitle)
+                self.infoRow(
+                    icon: "waveform",
+                    title: "Configured",
+                    value: self.appModel.talkMode.gatewayTalkVoiceModeTitle)
+                Divider().padding(.leading, 54)
+                self.infoRow(
+                    icon: "waveform",
+                    title: "Active now",
+                    value: self.activeModeText)
                 Divider().padding(.leading, 54)
                 self.infoRow(icon: "antenna.radiowaves.left.and.right", title: "Transport", value: self.transportText)
+                if let issueText = self.talkIssueText {
+                    Divider().padding(.leading, 54)
+                    self.infoRow(icon: "exclamationmark.triangle.fill", title: "Last issue", value: issueText)
+                }
                 Divider().padding(.leading, 54)
                 self.infoRow(icon: "key.fill", title: "Permission", value: self.permissionText)
                 Divider().padding(.leading, 54)
@@ -287,6 +317,11 @@ struct TalkProTab: View {
             GatewayStatusBuilder.build(appModel: self.appModel) == .connected
     }
 
+    private var fallbackIssue: TalkRuntimeIssue? {
+        guard self.gatewayConnected else { return nil }
+        return self.appModel.talkMode.gatewayTalkCurrentFallbackIssue
+    }
+
     private var headerSubtitle: String {
         let mode = self.appModel.talkMode.gatewayTalkVoiceModeTitle.trimmingCharacters(in: .whitespacesAndNewlines)
         let agent = self.appModel.chatAgentName.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -315,6 +350,21 @@ struct TalkProTab: View {
         if provider.isEmpty || provider == "Not loaded" { return transport.isEmpty ? "Not loaded" : transport }
         if transport.isEmpty || transport == "Not loaded" { return provider }
         return "\(provider) • \(transport)"
+    }
+
+    private var activeModeText: String {
+        let title = self.appModel.talkMode.gatewayTalkActiveModeTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+        let subtitle = (self.appModel.talkMode.gatewayTalkActiveModeSubtitle ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        if title.isEmpty { return "Not active" }
+        if subtitle.isEmpty { return title }
+        return "\(title) • \(subtitle)"
+    }
+
+    private var talkIssueText: String? {
+        let text = (self.appModel.talkMode.gatewayTalkLastIssueText ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return text.isEmpty ? nil : text
     }
 
     private var permissionText: String {

--- a/apps/ios/Sources/Design/TalkRuntimeIssueBanner.swift
+++ b/apps/ios/Sources/Design/TalkRuntimeIssueBanner.swift
@@ -1,0 +1,158 @@
+import SwiftUI
+import UIKit
+
+struct TalkRuntimeIssueBanner: View {
+    @Environment(\.colorScheme) private var colorScheme
+
+    let issue: TalkRuntimeIssue
+    var onOpenSettings: (() -> Void)?
+    var onShowDetails: (() -> Void)?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .top, spacing: 10) {
+                Image(systemName: self.iconName)
+                    .font(.headline.weight(.semibold))
+                    .foregroundStyle(self.tint)
+                    .frame(width: 20)
+                    .padding(.top, 2)
+
+                VStack(alignment: .leading, spacing: 5) {
+                    HStack(alignment: .firstTextBaseline, spacing: 8) {
+                        Text(self.issue.fallbackBannerTitle)
+                            .font(.subheadline.weight(.semibold))
+                            .multilineTextAlignment(.leading)
+                        Spacer(minLength: 0)
+                        Text(self.issue.fallbackBannerOwnerLabel)
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                    }
+
+                    Text(self.issue.fallbackBannerMessage)
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    Text(self.issue.displayMessage)
+                        .font(.caption.weight(.medium))
+                        .foregroundStyle(self.tint)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+
+            HStack(spacing: 10) {
+                if let onOpenSettings {
+                    Button("Open Settings", action: onOpenSettings)
+                        .buttonStyle(.borderedProminent)
+                        .controlSize(.small)
+                }
+                if let onShowDetails {
+                    Button("Details", action: onShowDetails)
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(13)
+        .background {
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(.ultraThickMaterial)
+                .overlay {
+                    RoundedRectangle(cornerRadius: 16, style: .continuous)
+                        .strokeBorder(Color.primary.opacity(self.colorScheme == .dark ? 0.12 : 0.07), lineWidth: 1)
+                }
+                .shadow(color: .black.opacity(self.colorScheme == .dark ? 0.16 : 0.07), radius: 16, y: 7)
+        }
+    }
+
+    private var iconName: String {
+        switch self.issue.code {
+        case .credentialInvalid, .credentialMissing, .gatewayConfigInvalid:
+            "key.slash.fill"
+        case .networkError:
+            "wifi.exclamationmark"
+        case .modelUnavailable, .providerUnavailable:
+            "waveform.badge.exclamationmark"
+        case .providerClosedBeforeReady, .unknown:
+            "exclamationmark.triangle.fill"
+        }
+    }
+
+    private var tint: Color {
+        switch self.issue.code {
+        case .networkError, .providerClosedBeforeReady:
+            .yellow
+        case .providerUnavailable:
+            .orange
+        default:
+            .red
+        }
+    }
+}
+
+struct TalkRuntimeIssueDetailsSheet: View {
+    @Environment(\.dismiss) private var dismiss
+
+    let issue: TalkRuntimeIssue
+    var onOpenSettings: (() -> Void)?
+
+    @State private var copyFeedback: String?
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Section {
+                    VStack(alignment: .leading, spacing: 10) {
+                        Text(self.issue.fallbackBannerTitle)
+                            .font(.title3.weight(.semibold))
+                        Text(self.issue.fallbackBannerMessage)
+                            .font(.body)
+                            .foregroundStyle(.secondary)
+                        Text(self.issue.displayMessage)
+                            .font(.footnote.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.vertical, 4)
+                }
+
+                Section("Technical details") {
+                    Text(verbatim: self.issue.technicalDetails)
+                        .font(.system(.footnote, design: .monospaced))
+                        .foregroundStyle(.secondary)
+                        .textSelection(.enabled)
+                    Button("Copy diagnostics") {
+                        UIPasteboard.general.string = self.issue.technicalDetails
+                        self.copyFeedback = "Copied diagnostics"
+                    }
+                }
+
+                if let copyFeedback {
+                    Section {
+                        Text(copyFeedback)
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+            .navigationTitle("Talk fallback")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    if let onOpenSettings {
+                        Button("Open Settings") {
+                            self.dismiss()
+                            onOpenSettings()
+                        }
+                    }
+                }
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Done") {
+                        self.dismiss()
+                    }
+                }
+            }
+        }
+    }
+}

--- a/apps/ios/Sources/Design/TalkRuntimeIssueBanner.swift
+++ b/apps/ios/Sources/Design/TalkRuntimeIssueBanner.swift
@@ -67,27 +67,11 @@ struct TalkRuntimeIssueBanner: View {
     }
 
     private var iconName: String {
-        switch self.issue.code {
-        case .credentialInvalid, .credentialMissing, .gatewayConfigInvalid:
-            "key.slash.fill"
-        case .networkError:
-            "wifi.exclamationmark"
-        case .modelUnavailable, .providerUnavailable:
-            "waveform.badge.exclamationmark"
-        case .providerClosedBeforeReady, .unknown:
-            "exclamationmark.triangle.fill"
-        }
+        "exclamationmark.triangle.fill"
     }
 
     private var tint: Color {
-        switch self.issue.code {
-        case .networkError, .providerClosedBeforeReady:
-            .yellow
-        case .providerUnavailable:
-            .orange
-        default:
-            .red
-        }
+        .orange
     }
 }
 

--- a/apps/ios/Sources/Voice/RealtimeTalkRelaySession.swift
+++ b/apps/ios/Sources/Voice/RealtimeTalkRelaySession.swift
@@ -103,6 +103,12 @@ final class RealtimeTalkRelaySession {
         let failed: Bool
     }
 
+    private enum StartupWaitResult {
+        case ready
+        case failed(TalkRuntimeIssue)
+        case cancelled
+    }
+
     private nonisolated static let expectedInputEncoding = "pcm16"
     private nonisolated static let expectedOutputEncoding = "pcm16"
     private nonisolated static let defaultSampleRateHz = 24000
@@ -110,16 +116,23 @@ final class RealtimeTalkRelaySession {
     private nonisolated static let bargeInRmsThreshold: Float = 0.08
     private nonisolated static let bargeInCooldownMs: Double = 900
     private nonisolated static let minOutputBeforeBargeInMs: Double = 250
+    private nonisolated static let startupReadyTimeoutSeconds = 12
 
     private let gateway: GatewayNodeSession
     private let options: Options
     private let pcmPlayer: PCMStreamingAudioPlaying
     private let logger = Logger(subsystem: "ai.openclaw", category: "RealtimeTalkRelay")
     private let onStatus: (String) -> Void
+    private let onIssue: (TalkRuntimeIssue) -> Void
     private let onSpeakingChanged: (Bool) -> Void
 
     private let audioEngine = AVAudioEngine()
     private var relaySessionId: String?
+    private var hasReceivedReady = false
+    private var hasReceivedFailure = false
+    private var startupIssue: TalkRuntimeIssue?
+    private var startupWaiter: CheckedContinuation<StartupWaitResult, Never>?
+    private var pendingPreRelayEvents: [EventFrame] = []
     private var inputSampleRateHz = Double(RealtimeTalkRelaySession.defaultSampleRateHz)
     private var outputSampleRateHz = Double(RealtimeTalkRelaySession.defaultSampleRateHz)
     private var eventTask: Task<Void, Never>?
@@ -151,34 +164,53 @@ final class RealtimeTalkRelaySession {
         options: Options,
         pcmPlayer: PCMStreamingAudioPlaying,
         onStatus: @escaping (String) -> Void,
+        onIssue: @escaping (TalkRuntimeIssue) -> Void = { _ in },
         onSpeakingChanged: @escaping (Bool) -> Void)
     {
         self.gateway = gateway
         self.options = options
         self.pcmPlayer = pcmPlayer
         self.onStatus = onStatus
+        self.onIssue = onIssue
         self.onSpeakingChanged = onSpeakingChanged
     }
 
     func start() async throws {
         self.isClosed = false
+        self.hasReceivedReady = false
+        self.hasReceivedFailure = false
+        self.startupIssue = nil
+        self.startupWaiter = nil
+        self.pendingPreRelayEvents.removeAll()
         self.onStatus("Connecting realtime…")
-        let result = try await self.createRelaySession()
-        guard let relaySessionId = result.relaysessionid?.trimmingCharacters(in: .whitespacesAndNewlines),
-              !relaySessionId.isEmpty
-        else {
-            throw NSError(domain: "RealtimeTalkRelay", code: 1, userInfo: [
-                NSLocalizedDescriptionKey: "Gateway did not return a realtime relay session",
-            ])
-        }
-        self.relaySessionId = relaySessionId
+        let eventStream = await self.gateway.subscribeServerEvents(bufferingNewest: 200)
+        self.startEventPump(stream: eventStream)
         do {
+            let result = try await self.createRelaySession()
+            guard let relaySessionId = result.relaysessionid?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !relaySessionId.isEmpty
+            else {
+                throw NSError(domain: "RealtimeTalkRelay", code: 1, userInfo: [
+                    NSLocalizedDescriptionKey: "Gateway did not return a realtime relay session",
+                ])
+            }
+            self.relaySessionId = relaySessionId
             self.audioSender = RealtimeAudioSender(gateway: self.gateway, relaySessionId: relaySessionId)
-            let eventStream = await self.gateway.subscribeServerEvents(bufferingNewest: 200)
-            self.startEventPump(stream: eventStream)
             self.configureAudioContract(result.audio)
             try self.startMicrophonePump()
-            self.onStatus("Listening (Realtime)")
+            self.onStatus("Waiting for realtime…")
+            await self.drainPendingPreRelayEvents()
+            switch await self.waitForStartupResult(timeoutSeconds: Self.startupReadyTimeoutSeconds) {
+            case .ready:
+                return
+            case let .failed(issue):
+                self.close(sendClose: true)
+                throw NSError(domain: "RealtimeTalkRelay", code: 6, userInfo: [
+                    NSLocalizedDescriptionKey: issue.displayMessage,
+                ])
+            case .cancelled:
+                return
+            }
         } catch {
             let createdRelaySessionId = self.relaySessionId
             self.close(sendClose: false)
@@ -196,6 +228,7 @@ final class RealtimeTalkRelaySession {
     private func close(sendClose: Bool) {
         guard !self.isClosed else { return }
         self.isClosed = true
+        self.finishStartupWait(.cancelled)
         self.stopMicrophonePump()
         self.eventTask?.cancel()
         self.eventTask = nil
@@ -299,14 +332,21 @@ final class RealtimeTalkRelaySession {
         guard event.event == "talk.event",
               let payload = event.payload?.dictionaryValue
         else { return }
-        if let relaySessionId,
-           payload["relaySessionId"]?.stringValue != relaySessionId
-        {
+        guard let relaySessionId else {
+            self.pendingPreRelayEvents.append(event)
+            if self.pendingPreRelayEvents.count > 200 {
+                self.pendingPreRelayEvents.removeFirst(self.pendingPreRelayEvents.count - 200)
+            }
+            return
+        }
+        if payload["relaySessionId"]?.stringValue != relaySessionId {
             return
         }
         guard let type = payload["type"]?.stringValue else { return }
         switch type {
         case "ready":
+            self.hasReceivedReady = true
+            self.finishStartupWait(.ready)
             self.onStatus("Listening (Realtime)")
         case "audio":
             guard let base64 = payload["audioBase64"]?.stringValue,
@@ -331,15 +371,116 @@ final class RealtimeTalkRelaySession {
             await self.handleToolCall(payload)
         case "error":
             let message = payload["message"]?.stringValue ?? "Realtime failed"
+            let issue = Self.issue(
+                payload: payload,
+                fallbackMessage: message,
+                fallbackProvider: self.options.provider,
+                fallbackModel: self.options.model)
             GatewayDiagnostics.log("talk realtime: error=\(Self.safeLogMessage(message))")
+            self.hasReceivedFailure = true
+            self.startupIssue = issue
+            self.onIssue(issue)
+            self.finishStartupWait(.failed(issue))
             self.onStatus(message)
         case "close":
             GatewayDiagnostics.log("talk realtime: close")
-            self.onStatus("Ready")
+            if self.hasReceivedReady {
+                self.onStatus("Ready")
+            } else if !self.hasReceivedFailure {
+                let issue = TalkRuntimeIssue(
+                    code: .providerClosedBeforeReady,
+                    message: "Realtime closed before it became ready.",
+                    provider: self.options.provider,
+                    model: self.options.model,
+                    transport: "gateway-relay",
+                    phase: "connect")
+                self.onIssue(issue)
+                self.startupIssue = issue
+                self.finishStartupWait(.failed(issue))
+                self.onStatus("Realtime failed before connecting")
+            }
             self.close(sendClose: false)
         default:
             return
         }
+    }
+
+    private func waitForStartupResult(timeoutSeconds: Int) async -> StartupWaitResult {
+        if self.isClosed { return .cancelled }
+        if self.hasReceivedReady { return .ready }
+        if let startupIssue { return .failed(startupIssue) }
+        return await withCheckedContinuation { continuation in
+            if self.isClosed {
+                continuation.resume(returning: .cancelled)
+                return
+            }
+            self.startupWaiter = continuation
+            Task { [weak self] in
+                try? await Task.sleep(nanoseconds: UInt64(max(0, timeoutSeconds)) * 1_000_000_000)
+                await self?.timeoutStartupWaiterIfNeeded()
+            }
+        }
+    }
+
+    private func drainPendingPreRelayEvents() async {
+        let pendingEvents = self.pendingPreRelayEvents
+        self.pendingPreRelayEvents.removeAll()
+        for event in pendingEvents {
+            await self.handleGatewayEvent(event)
+        }
+    }
+
+    private func finishStartupWait(_ result: StartupWaitResult) {
+        guard let waiter = self.startupWaiter else { return }
+        self.startupWaiter = nil
+        waiter.resume(returning: result)
+    }
+
+    private func timeoutStartupWaiterIfNeeded() {
+        guard !self.isClosed, self.startupWaiter != nil, !self.hasReceivedReady, self.startupIssue == nil else {
+            return
+        }
+        let issue = TalkRuntimeIssue(
+            code: .providerUnavailable,
+            message: "Realtime did not become ready in time.",
+            provider: self.options.provider,
+            model: self.options.model,
+            transport: "gateway-relay",
+            phase: "connect")
+        self.hasReceivedFailure = true
+        self.startupIssue = issue
+        self.onIssue(issue)
+        self.onStatus(issue.displayMessage)
+        self.finishStartupWait(.failed(issue))
+    }
+
+    private static func issue(
+        payload: [String: AnyCodable],
+        fallbackMessage: String,
+        fallbackProvider: String?,
+        fallbackModel: String?) -> TalkRuntimeIssue
+    {
+        let code = payload["code"]?.stringValue
+            .flatMap { TalkRuntimeIssue.Code(rawValue: $0.trimmingCharacters(in: .whitespacesAndNewlines)) }
+        let provider = payload["provider"]?.stringValue ?? fallbackProvider
+        let model = payload["model"]?.stringValue ?? fallbackModel
+        let transport = payload["transport"]?.stringValue ?? "gateway-relay"
+        let phase = payload["phase"]?.stringValue
+        if let code {
+            return TalkRuntimeIssue(
+                code: code,
+                message: fallbackMessage,
+                provider: provider,
+                model: model,
+                transport: transport,
+                phase: phase)
+        }
+        return TalkRuntimeIssue.classify(
+            message: fallbackMessage,
+            provider: provider,
+            model: model,
+            transport: transport,
+            phase: phase)
     }
 
     private func recordOutputAudioChunk(byteCount: Int) {
@@ -804,6 +945,25 @@ final class RealtimeTalkRelaySession {
 }
 
 extension RealtimeTalkRelaySession {
+    func _test_setRelaySessionId(_ relaySessionId: String) {
+        self.relaySessionId = relaySessionId
+    }
+
+    func _test_handleGatewayEvent(_ event: EventFrame) async {
+        await self.handleGatewayEvent(event)
+    }
+
+    func _test_waitForStartupCancelled(timeoutSeconds: Int) async -> Bool {
+        if case .cancelled = await self.waitForStartupResult(timeoutSeconds: timeoutSeconds) {
+            return true
+        }
+        return false
+    }
+
+    func _test_startupReadyTimeoutSeconds() -> Int {
+        Self.startupReadyTimeoutSeconds
+    }
+
     func _test_markOutputAudioStarted(nowMs: Double) {
         self.markOutputAudioStarted(byteCount: 4800, nowMs: nowMs)
     }

--- a/apps/ios/Sources/Voice/RealtimeTalkRelaySession.swift
+++ b/apps/ios/Sources/Voice/RealtimeTalkRelaySession.swift
@@ -388,7 +388,7 @@ final class RealtimeTalkRelaySession {
                 self.onStatus("Ready")
             } else if !self.hasReceivedFailure {
                 let issue = TalkRuntimeIssue(
-                    code: .providerClosedBeforeReady,
+                    code: .realtimeUnavailable,
                     message: "Realtime closed before it became ready.",
                     provider: self.options.provider,
                     model: self.options.model,
@@ -441,7 +441,7 @@ final class RealtimeTalkRelaySession {
             return
         }
         let issue = TalkRuntimeIssue(
-            code: .providerUnavailable,
+            code: .realtimeUnavailable,
             message: "Realtime did not become ready in time.",
             provider: self.options.provider,
             model: self.options.model,
@@ -460,22 +460,11 @@ final class RealtimeTalkRelaySession {
         fallbackProvider: String?,
         fallbackModel: String?) -> TalkRuntimeIssue
     {
-        let code = payload["code"]?.stringValue
-            .flatMap { TalkRuntimeIssue.Code(rawValue: $0.trimmingCharacters(in: .whitespacesAndNewlines)) }
         let provider = payload["provider"]?.stringValue ?? fallbackProvider
         let model = payload["model"]?.stringValue ?? fallbackModel
         let transport = payload["transport"]?.stringValue ?? "gateway-relay"
         let phase = payload["phase"]?.stringValue
-        if let code {
-            return TalkRuntimeIssue(
-                code: code,
-                message: fallbackMessage,
-                provider: provider,
-                model: model,
-                transport: transport,
-                phase: phase)
-        }
-        return TalkRuntimeIssue.classify(
+        return TalkRuntimeIssue.realtimeUnavailable(
             message: fallbackMessage,
             provider: provider,
             model: model,

--- a/apps/ios/Sources/Voice/TalkModeGatewayConfig.swift
+++ b/apps/ios/Sources/Voice/TalkModeGatewayConfig.swift
@@ -9,14 +9,7 @@ enum TalkModeExecutionMode {
 
 struct TalkRuntimeIssue: Equatable {
     enum Code: String {
-        case credentialInvalid = "credential_invalid"
-        case credentialMissing = "credential_missing"
-        case providerUnavailable = "provider_unavailable"
-        case modelUnavailable = "model_unavailable"
-        case gatewayConfigInvalid = "gateway_config_invalid"
-        case networkError = "network_error"
-        case providerClosedBeforeReady = "provider_closed_before_ready"
-        case unknown
+        case realtimeUnavailable = "realtime_unavailable"
     }
 
     let code: Code
@@ -47,24 +40,7 @@ struct TalkRuntimeIssue: Equatable {
 
     var displayMessage: String {
         if !self.message.isEmpty { return self.message }
-        switch self.code {
-        case .credentialInvalid:
-            return "Realtime credentials were rejected."
-        case .credentialMissing:
-            return "Realtime credentials are missing."
-        case .providerUnavailable:
-            return "The realtime provider is unavailable."
-        case .modelUnavailable:
-            return "The realtime model is unavailable."
-        case .gatewayConfigInvalid:
-            return "Gateway realtime configuration is invalid."
-        case .networkError:
-            return "Realtime network connection failed."
-        case .providerClosedBeforeReady:
-            return "Realtime closed before it became ready."
-        case .unknown:
-            return "Realtime voice failed."
-        }
+        return "Realtime voice did not start."
     }
 
     var fallbackStatusText: String {
@@ -76,18 +52,11 @@ struct TalkRuntimeIssue: Equatable {
     }
 
     var fallbackBannerOwnerLabel: String {
-        switch self.code {
-        case .credentialInvalid, .credentialMissing, .providerUnavailable, .modelUnavailable, .gatewayConfigInvalid:
-            "Fix on gateway"
-        case .networkError:
-            "Check network"
-        case .providerClosedBeforeReady, .unknown:
-            "Needs attention"
-        }
+        "Fallback active"
     }
 
     var fallbackBannerMessage: String {
-        "Realtime voice is unavailable. Talk is still running with iOS speech recognition and TTS."
+        "Realtime voice did not start. Talk is running with iOS speech recognition and TTS."
     }
 
     var technicalDetails: String {
@@ -111,34 +80,15 @@ struct TalkRuntimeIssue: Equatable {
         return parts.joined(separator: " • ")
     }
 
-    static func classify(
+    static func realtimeUnavailable(
         message: String,
         provider: String? = nil,
         model: String? = nil,
         transport: String? = nil,
         phase: String? = nil) -> TalkRuntimeIssue
     {
-        let normalized = message.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        let code: Code = if normalized.contains("api key") || normalized.contains("unauthorized") || normalized
-            .contains("401")
-        {
-            normalized.contains("missing") ? .credentialMissing : .credentialInvalid
-        } else if normalized.contains("credential") || normalized.contains("auth") {
-            normalized.contains("missing") ? .credentialMissing : .credentialInvalid
-        } else if normalized.contains("model") && (
-            normalized.contains("not found") || normalized.contains("unsupported") || normalized.contains(
-                "unavailable"))
-        {
-            .modelUnavailable
-        } else if normalized.contains("network") || normalized.contains("socket") || normalized.contains("connection") {
-            .networkError
-        } else if normalized.contains("provider") || normalized.contains("unavailable") {
-            .providerUnavailable
-        } else {
-            .unknown
-        }
-        return TalkRuntimeIssue(
-            code: code,
+        TalkRuntimeIssue(
+            code: .realtimeUnavailable,
             message: message,
             provider: provider,
             model: model,

--- a/apps/ios/Sources/Voice/TalkModeGatewayConfig.swift
+++ b/apps/ios/Sources/Voice/TalkModeGatewayConfig.swift
@@ -7,6 +7,146 @@ enum TalkModeExecutionMode {
     case realtimeRelay
 }
 
+struct TalkRuntimeIssue: Equatable {
+    enum Code: String {
+        case credentialInvalid = "credential_invalid"
+        case credentialMissing = "credential_missing"
+        case providerUnavailable = "provider_unavailable"
+        case modelUnavailable = "model_unavailable"
+        case gatewayConfigInvalid = "gateway_config_invalid"
+        case networkError = "network_error"
+        case providerClosedBeforeReady = "provider_closed_before_ready"
+        case unknown
+    }
+
+    let code: Code
+    let message: String
+    let provider: String?
+    let model: String?
+    let transport: String?
+    let phase: String?
+    let occurredAt: Date
+
+    init(
+        code: Code,
+        message: String,
+        provider: String? = nil,
+        model: String? = nil,
+        transport: String? = nil,
+        phase: String? = nil,
+        occurredAt: Date = Date())
+    {
+        self.code = code
+        self.message = message.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.provider = provider?.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.model = model?.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.transport = transport?.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.phase = phase?.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.occurredAt = occurredAt
+    }
+
+    var displayMessage: String {
+        if !self.message.isEmpty { return self.message }
+        switch self.code {
+        case .credentialInvalid:
+            return "Realtime credentials were rejected."
+        case .credentialMissing:
+            return "Realtime credentials are missing."
+        case .providerUnavailable:
+            return "The realtime provider is unavailable."
+        case .modelUnavailable:
+            return "The realtime model is unavailable."
+        case .gatewayConfigInvalid:
+            return "Gateway realtime configuration is invalid."
+        case .networkError:
+            return "Realtime network connection failed."
+        case .providerClosedBeforeReady:
+            return "Realtime closed before it became ready."
+        case .unknown:
+            return "Realtime voice failed."
+        }
+    }
+
+    var fallbackStatusText: String {
+        "Listening (iOS Speech fallback)"
+    }
+
+    var fallbackBannerTitle: String {
+        "Using iOS Speech fallback"
+    }
+
+    var fallbackBannerOwnerLabel: String {
+        switch self.code {
+        case .credentialInvalid, .credentialMissing, .providerUnavailable, .modelUnavailable, .gatewayConfigInvalid:
+            "Fix on gateway"
+        case .networkError:
+            "Check network"
+        case .providerClosedBeforeReady, .unknown:
+            "Needs attention"
+        }
+    }
+
+    var fallbackBannerMessage: String {
+        "Realtime voice is unavailable. Talk is still running with iOS speech recognition and TTS."
+    }
+
+    var technicalDetails: String {
+        var lines = [
+            "code: \(self.code.rawValue)",
+            "message: \(self.displayMessage)",
+        ]
+        if let provider, !provider.isEmpty { lines.append("provider: \(provider)") }
+        if let model, !model.isEmpty { lines.append("model: \(model)") }
+        if let transport, !transport.isEmpty { lines.append("transport: \(transport)") }
+        if let phase, !phase.isEmpty { lines.append("phase: \(phase)") }
+        return lines.joined(separator: "\n")
+    }
+
+    var diagnosticSummary: String {
+        var parts = [self.displayMessage]
+        if let provider, !provider.isEmpty { parts.append("provider: \(provider)") }
+        if let model, !model.isEmpty { parts.append("model: \(model)") }
+        if let transport, !transport.isEmpty { parts.append("transport: \(transport)") }
+        if let phase, !phase.isEmpty { parts.append("phase: \(phase)") }
+        return parts.joined(separator: " • ")
+    }
+
+    static func classify(
+        message: String,
+        provider: String? = nil,
+        model: String? = nil,
+        transport: String? = nil,
+        phase: String? = nil) -> TalkRuntimeIssue
+    {
+        let normalized = message.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let code: Code = if normalized.contains("api key") || normalized.contains("unauthorized") || normalized
+            .contains("401")
+        {
+            normalized.contains("missing") ? .credentialMissing : .credentialInvalid
+        } else if normalized.contains("credential") || normalized.contains("auth") {
+            normalized.contains("missing") ? .credentialMissing : .credentialInvalid
+        } else if normalized.contains("model") && (
+            normalized.contains("not found") || normalized.contains("unsupported") || normalized.contains(
+                "unavailable"))
+        {
+            .modelUnavailable
+        } else if normalized.contains("network") || normalized.contains("socket") || normalized.contains("connection") {
+            .networkError
+        } else if normalized.contains("provider") || normalized.contains("unavailable") {
+            .providerUnavailable
+        } else {
+            .unknown
+        }
+        return TalkRuntimeIssue(
+            code: code,
+            message: message,
+            provider: provider,
+            model: model,
+            transport: transport,
+            phase: phase)
+    }
+}
+
 struct TalkVoiceModeDescriptor: Equatable {
     let title: String
     let subtitle: String?

--- a/apps/ios/Sources/Voice/TalkModeManager.swift
+++ b/apps/ios/Sources/Voice/TalkModeManager.swift
@@ -60,6 +60,10 @@ final class TalkModeManager: NSObject {
     var gatewayTalkVoiceModeTitle: String = "Not loaded"
     var gatewayTalkVoiceModeSubtitle: String?
     var gatewayTalkVoiceModeAccessibilityValue: String = "Not loaded"
+    var gatewayTalkActiveModeTitle: String = "Not active"
+    var gatewayTalkActiveModeSubtitle: String?
+    var gatewayTalkLastIssueText: String?
+    var gatewayTalkCurrentFallbackIssue: TalkRuntimeIssue?
     var gatewayTalkPermissionState: TalkGatewayPermissionState = .unknown
 
     var isGatewayConnected: Bool {
@@ -75,6 +79,12 @@ final class TalkModeManager: NSObject {
         case idle
         case continuous
         case pushToTalk
+    }
+
+    private enum RealtimeStartResult {
+        case started
+        case unavailable(TalkRuntimeIssue)
+        case ignored
     }
 
     private var isStarting = false
@@ -129,6 +139,8 @@ final class TalkModeManager: NSObject {
         voiceId: nil,
         transport: nil,
         isRealtime: false)
+    private var pendingRealtimeIssue: TalkRuntimeIssue?
+    private var realtimeRelayStartIssue: TalkRuntimeIssue?
     private var apiKey: String?
     private var voiceAliases: [String: String] = [:]
     private var interruptOnSpeech: Bool = true
@@ -192,6 +204,8 @@ final class TalkModeManager: NSObject {
             }
         } else {
             self.stopRealtimeSession()
+            self.gatewayTalkActiveModeTitle = "Not active"
+            self.gatewayTalkActiveModeSubtitle = nil
             if self.isEnabled, !self.isSpeaking {
                 self.statusText = "Offline"
             }
@@ -299,11 +313,15 @@ final class TalkModeManager: NSObject {
             return
         }
         if self.realtimeWebRTCEnabled {
-            let started = self.executionMode == .realtimeRelay
+            let realtimeStart = self.executionMode == .realtimeRelay
                 ? await self.startRealtimeRelayIfAvailable()
                 : await self.startRealtimeIfAvailable()
-            if started {
+            switch realtimeStart {
+            case .started, .ignored:
                 return
+            case let .unavailable(issue):
+                self.pendingRealtimeIssue = issue
+                self.gatewayTalkLastIssueText = issue.diagnosticSummary
             }
         }
 
@@ -324,7 +342,11 @@ final class TalkModeManager: NSObject {
             self.captureMode = .continuous
             try self.startRecognition()
             self.isListening = true
-            self.statusText = "Listening"
+            if let issue = self.pendingRealtimeIssue {
+                self.markNativeFallbackActive(after: issue)
+            } else {
+                self.markNativeTalkActive()
+            }
             self.startSilenceMonitor()
             await self.subscribeChatIfNeeded(sessionKey: self.mainSessionKey)
             self.logger.info("listening")
@@ -379,6 +401,11 @@ final class TalkModeManager: NSObject {
         self.isPushToTalkActive = false
         self.captureMode = .idle
         self.statusText = "Off"
+        self.pendingRealtimeIssue = nil
+        self.gatewayTalkCurrentFallbackIssue = nil
+        self.gatewayTalkActiveModeTitle = "Not active"
+        self.gatewayTalkActiveModeSubtitle = nil
+        self.gatewayTalkLastIssueText = nil
         self.lastTranscript = ""
         self.lastHeard = nil
         self.silenceTask?.cancel()
@@ -425,6 +452,8 @@ final class TalkModeManager: NSObject {
         self.isPushToTalkActive = false
         self.captureMode = .idle
         self.statusText = "Paused"
+        self.gatewayTalkActiveModeTitle = "Paused"
+        self.gatewayTalkActiveModeSubtitle = nil
         self.lastTranscript = ""
         self.lastHeard = nil
         self.silenceTask?.cancel()
@@ -1047,8 +1076,10 @@ final class TalkModeManager: NSObject {
         }
     }
 
-    private func startRealtimeIfAvailable() async -> Bool {
-        guard let gateway else { return false }
+    private func startRealtimeIfAvailable() async -> RealtimeStartResult {
+        guard let gateway else {
+            return .unavailable(self.realtimeIssue(message: "Gateway not connected", phase: "start"))
+        }
         let startedAt = Self.nowSeconds()
         if self.prefetchedRealtimeSession == nil, let prefetchTask = self.realtimePrefetchTask {
             GatewayDiagnostics.log("talk.timeline realtime awaiting in-flight prefetch")
@@ -1069,49 +1100,53 @@ final class TalkModeManager: NSObject {
                 prefetchedSession: prefetchedSession)
             guard self.realtimeSession === session, self.isEnabled else {
                 session.stop()
-                return true
+                return .ignored
             }
             self.isListening = true
             self.captureMode = .continuous
-            self.statusText = "Listening"
+            self.markRealtimeActive()
             GatewayDiagnostics.log(
                 "talk.timeline realtime start ready elapsedMs=\(Self.elapsedMs(since: startedAt))")
             GatewayDiagnostics.log("talk realtime: started direct OpenAI WebRTC session")
-            return true
+            return .started
         } catch {
             guard self.realtimeSession === session, self.isEnabled else {
                 session.stop()
-                return true
+                return .ignored
             }
             self.stopRealtimeSession()
+            let issue = self.realtimeIssue(from: error, phase: "start")
             GatewayDiagnostics
                 .log("talk realtime: unavailable; falling back to speech pipeline error=\(error.localizedDescription)")
             GatewayDiagnostics.log(
                 "talk.timeline realtime start failed elapsedMs=\(Self.elapsedMs(since: startedAt)) "
                     + "error=\(error.localizedDescription)")
-            return false
+            return .unavailable(issue)
         }
     }
 
-    private func startRealtimeRelayIfAvailable() async -> Bool {
-        guard let gateway else { return false }
+    private func startRealtimeRelayIfAvailable() async -> RealtimeStartResult {
+        guard let gateway else {
+            return .unavailable(self.realtimeIssue(message: "Gateway not connected", phase: "start"))
+        }
         guard self.foregroundAudioCaptureAllowed else {
             self.statusText = "Paused"
             GatewayDiagnostics.log("talk realtime ignored: app backgrounded")
-            return true
+            return .ignored
         }
         if self.realtimeRelaySession != nil {
             self.captureMode = .continuous
             self.isListening = true
             GatewayDiagnostics.log("talk realtime ignored: already active")
-            return true
+            return .started
         }
         guard !self.realtimeRelayStartInFlight else {
             GatewayDiagnostics.log("talk realtime ignored: already starting")
-            return true
+            return .ignored
         }
         self.realtimeRelayStartInFlight = true
         defer { self.realtimeRelayStartInFlight = false }
+        self.prepareRealtimeRelayStart()
         GatewayDiagnostics.log("talk.timeline realtime relay start attempt sessionKey=\(self.mainSessionKey)")
         let startedAt = Self.nowSeconds()
         let relaySession = RealtimeTalkRelaySession(
@@ -1124,13 +1159,15 @@ final class TalkModeManager: NSObject {
             pcmPlayer: self.pcmPlayer,
             onStatus: { [weak self] status in
                 guard let self else { return }
-                self.statusText = status
-                self.isListening = status.localizedCaseInsensitiveContains("listening")
-                if status.localizedCaseInsensitiveContains("thinking") {
-                    self.isListening = false
-                    self.isSpeaking = false
-                    self.isUserSpeechDetected = false
-                }
+                self.handleRealtimeRelayStatus(status)
+            },
+            onIssue: { [weak self] issue in
+                guard let self else { return }
+                self.realtimeRelayStartIssue = issue
+                self.pendingRealtimeIssue = issue
+                self.gatewayTalkLastIssueText = issue.diagnosticSummary
+                self.gatewayTalkActiveModeTitle = "Realtime unavailable"
+                self.gatewayTalkActiveModeSubtitle = issue.displayMessage
             },
             onSpeakingChanged: { [weak self] speaking in
                 guard let self else { return }
@@ -1145,23 +1182,35 @@ final class TalkModeManager: NSObject {
             try await relaySession.start()
             guard self.realtimeRelaySession === relaySession, self.isEnabled else {
                 relaySession.stop()
-                return true
+                return .ignored
+            }
+            if let issue = self.realtimeRelayStartIssue {
+                self.realtimeRelaySession = nil
+                relaySession.stop()
+                GatewayDiagnostics.log(
+                    "talk.timeline realtime relay start unavailable elapsedMs=\(Self.elapsedMs(since: startedAt)) "
+                        + "issue=\(issue.code.rawValue)")
+                return .unavailable(issue)
             }
             self.isListening = true
             self.captureMode = .continuous
+            self.realtimeRelayStartIssue = nil
             GatewayDiagnostics.log(
                 "talk.timeline realtime relay start ready elapsedMs=\(Self.elapsedMs(since: startedAt))")
-            return true
+            return .started
         } catch {
             guard self.realtimeRelaySession === relaySession, self.isEnabled else {
                 relaySession.stop()
-                return true
+                return .ignored
             }
             self.realtimeRelaySession = nil
+            let issue = self.realtimeRelayStartIssue
+                ?? self.realtimeIssue(from: error, phase: "start")
+            self.realtimeRelayStartIssue = nil
             GatewayDiagnostics.log(
                 "talk.timeline realtime relay start failed elapsedMs=\(Self.elapsedMs(since: startedAt)) "
                     + "error=\(error.localizedDescription)")
-            return false
+            return .unavailable(issue)
         }
     }
 
@@ -2363,6 +2412,114 @@ extension TalkModeManager {
         self.gatewayTalkVoiceModeAccessibilityValue = descriptor.accessibilityValue
     }
 
+    private func markRealtimeActive() {
+        self.pendingRealtimeIssue = nil
+        self.gatewayTalkCurrentFallbackIssue = nil
+        self.gatewayTalkLastIssueText = nil
+        self.gatewayTalkActiveModeTitle = self.configuredVoiceModeDescriptor.title
+        self.gatewayTalkActiveModeSubtitle = self.configuredVoiceModeDescriptor.subtitle
+        self.statusText = "Listening (Realtime)"
+    }
+
+    private func handleRealtimeRelayStatus(_ status: String) {
+        if status == "Listening (Realtime)" {
+            self.markRealtimeActive()
+        } else {
+            self.statusText = status
+            if status == "Ready" {
+                self.realtimeRelaySession = nil
+                self.gatewayTalkActiveModeTitle = "Not active"
+                self.gatewayTalkActiveModeSubtitle = nil
+                self.isListening = false
+                self.isSpeaking = false
+                self.isUserSpeechDetected = false
+            }
+        }
+        self.isListening = status.localizedCaseInsensitiveContains("listening")
+        if status.localizedCaseInsensitiveContains("thinking") {
+            self.isListening = false
+            self.isSpeaking = false
+            self.isUserSpeechDetected = false
+        }
+    }
+
+    private func prepareRealtimeRelayStart() {
+        self.realtimeRelayStartIssue = nil
+        self.pendingRealtimeIssue = nil
+        self.gatewayTalkCurrentFallbackIssue = nil
+    }
+
+    private func markNativeTalkActive() {
+        self.pendingRealtimeIssue = nil
+        self.gatewayTalkCurrentFallbackIssue = nil
+        self.gatewayTalkActiveModeTitle = "iOS Speech + TTS"
+        self.gatewayTalkActiveModeSubtitle = nil
+        self.statusText = "Listening"
+    }
+
+    private func markNativeFallbackActive(after issue: TalkRuntimeIssue) {
+        self.gatewayTalkActiveModeTitle = "iOS Speech fallback"
+        self.gatewayTalkActiveModeSubtitle = issue.displayMessage
+        self.gatewayTalkCurrentFallbackIssue = issue
+        self.gatewayTalkLastIssueText = issue.diagnosticSummary
+        self.statusText = issue.fallbackStatusText
+    }
+
+    private func realtimeIssue(message: String, phase: String) -> TalkRuntimeIssue {
+        TalkRuntimeIssue.classify(
+            message: message,
+            provider: self.realtimeProvider,
+            model: self.realtimeModelId,
+            transport: self.executionMode == .realtimeRelay ? "gateway-relay" : "webrtc",
+            phase: phase)
+    }
+
+    private func realtimeIssue(from error: Error, phase: String) -> TalkRuntimeIssue {
+        if let gatewayError = error as? GatewayResponseError,
+           let issue = Self.talkRuntimeIssue(
+               from: gatewayError,
+               fallbackProvider: self.realtimeProvider,
+               fallbackModel: self.realtimeModelId,
+               fallbackTransport: self.executionMode == .realtimeRelay ? "gateway-relay" : "webrtc",
+               fallbackPhase: phase)
+        {
+            return issue
+        }
+        return self.realtimeIssue(message: error.localizedDescription, phase: phase)
+    }
+
+    private static func talkRuntimeIssue(
+        from gatewayError: GatewayResponseError,
+        fallbackProvider: String?,
+        fallbackModel: String?,
+        fallbackTransport: String?,
+        fallbackPhase: String) -> TalkRuntimeIssue?
+    {
+        guard let rawIssue = gatewayError.details["talkIssue"]?.dictionaryValue else { return nil }
+        let rawCode = rawIssue["code"]?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let code = rawCode.flatMap(TalkRuntimeIssue.Code.init(rawValue:))
+        let message = rawIssue["message"]?.stringValue ?? gatewayError.message
+        let provider = rawIssue["provider"]?.stringValue ?? fallbackProvider
+        let model = rawIssue["model"]?.stringValue ?? fallbackModel
+        let transport = rawIssue["transport"]?.stringValue ?? fallbackTransport
+        let phase = rawIssue["phase"]?.stringValue ?? fallbackPhase
+        guard let code else {
+            return TalkRuntimeIssue.classify(
+                message: message,
+                provider: provider,
+                model: model,
+                transport: transport,
+                phase: phase)
+        }
+        return TalkRuntimeIssue(
+            code: code,
+            message: message,
+            provider: provider,
+            model: model,
+            transport: transport,
+            phase: phase)
+    }
+
     private func restoreConfiguredVoiceModeDescriptor() {
         self.applyVoiceModeDescriptor(self.configuredVoiceModeDescriptor)
     }
@@ -2836,7 +2993,11 @@ extension TalkModeManager: TalkRealtimeWebRTCSessionDelegate {
     func realtimeSession(_ session: TalkRealtimeWebRTCSession, didChangeStatus status: String) {
         guard session === self.realtimeSession else { return }
         GatewayDiagnostics.log("talk.timeline realtime status=\(status)")
-        self.statusText = status
+        if status == "Listening" {
+            self.markRealtimeActive()
+        } else {
+            self.statusText = status
+        }
         self.isListening = status == "Listening"
         self.isSpeaking = status == "Speaking"
         if status == "Thinking" {
@@ -2877,6 +3038,8 @@ extension TalkModeManager: TalkRealtimeWebRTCSessionDelegate {
         self.isListening = false
         self.isSpeaking = false
         self.isUserSpeechDetected = false
+        self.gatewayTalkActiveModeTitle = "Not active"
+        self.gatewayTalkActiveModeSubtitle = nil
         if self.isEnabled {
             self.statusText = self.gatewayConnected ? "Ready" : "Offline"
         }
@@ -2907,6 +3070,49 @@ extension TalkModeManager {
 
     func _test_gatewayTalkUsesRealtimeRelay() -> Bool {
         self.gatewayTalkUsesRealtimeRelay
+    }
+
+    func _test_markNativeFallbackActive(after issue: TalkRuntimeIssue) {
+        self.markNativeFallbackActive(after: issue)
+    }
+
+    func _test_recordRealtimeIssue(_ issue: TalkRuntimeIssue) {
+        self.pendingRealtimeIssue = issue
+        self.gatewayTalkLastIssueText = issue.diagnosticSummary
+        self.gatewayTalkActiveModeTitle = "Realtime unavailable"
+        self.gatewayTalkActiveModeSubtitle = issue.displayMessage
+    }
+
+    func _test_handleRealtimeRelayStatus(_ status: String) {
+        self.handleRealtimeRelayStatus(status)
+    }
+
+    func _test_prepareRealtimeRelayStart() {
+        self.prepareRealtimeRelayStart()
+    }
+
+    func _test_realtimeIssue(from error: Error, phase: String) -> TalkRuntimeIssue {
+        self.realtimeIssue(from: error, phase: phase)
+    }
+
+    func _test_hasPendingRealtimeIssue() -> Bool {
+        self.pendingRealtimeIssue != nil
+    }
+
+    func _test_gatewayTalkActiveModeTitle() -> String {
+        self.gatewayTalkActiveModeTitle
+    }
+
+    func _test_gatewayTalkActiveModeSubtitle() -> String? {
+        self.gatewayTalkActiveModeSubtitle
+    }
+
+    func _test_gatewayTalkLastIssueText() -> String? {
+        self.gatewayTalkLastIssueText
+    }
+
+    func _test_gatewayTalkCurrentFallbackIssue() -> TalkRuntimeIssue? {
+        self.gatewayTalkCurrentFallbackIssue
     }
 
     func _test_seedTranscript(_ transcript: String) {

--- a/apps/ios/Sources/Voice/TalkModeManager.swift
+++ b/apps/ios/Sources/Voice/TalkModeManager.swift
@@ -2466,7 +2466,7 @@ extension TalkModeManager {
     }
 
     private func realtimeIssue(message: String, phase: String) -> TalkRuntimeIssue {
-        TalkRuntimeIssue.classify(
+        TalkRuntimeIssue.realtimeUnavailable(
             message: message,
             provider: self.realtimeProvider,
             model: self.realtimeModelId,
@@ -2496,23 +2496,12 @@ extension TalkModeManager {
         fallbackPhase: String) -> TalkRuntimeIssue?
     {
         guard let rawIssue = gatewayError.details["talkIssue"]?.dictionaryValue else { return nil }
-        let rawCode = rawIssue["code"]?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines)
-        let code = rawCode.flatMap(TalkRuntimeIssue.Code.init(rawValue:))
         let message = rawIssue["message"]?.stringValue ?? gatewayError.message
         let provider = rawIssue["provider"]?.stringValue ?? fallbackProvider
         let model = rawIssue["model"]?.stringValue ?? fallbackModel
         let transport = rawIssue["transport"]?.stringValue ?? fallbackTransport
         let phase = rawIssue["phase"]?.stringValue ?? fallbackPhase
-        guard let code else {
-            return TalkRuntimeIssue.classify(
-                message: message,
-                provider: provider,
-                model: model,
-                transport: transport,
-                phase: phase)
-        }
-        return TalkRuntimeIssue(
-            code: code,
+        return TalkRuntimeIssue.realtimeUnavailable(
             message: message,
             provider: provider,
             model: model,

--- a/apps/ios/SwiftSources.input.xcfilelist
+++ b/apps/ios/SwiftSources.input.xcfilelist
@@ -21,6 +21,7 @@ Sources/Design/SettingsProTab.swift
 Sources/Design/SettingsProTabSupport.swift
 Sources/Design/SettingsProTabSections.swift
 Sources/Design/SettingsProTabActions.swift
+Sources/Design/TalkRuntimeIssueBanner.swift
 Sources/Design/CommandCenterSupport.swift
 Sources/Design/AgentProTab+Overview.swift
 Sources/Design/AgentProTab+Destinations.swift

--- a/apps/ios/Tests/RealtimeTalkRelaySessionTests.swift
+++ b/apps/ios/Tests/RealtimeTalkRelaySessionTests.swift
@@ -58,7 +58,7 @@ private final class UnusedPCMStreamingAudioPlayer: PCMStreamingAudioPlaying {
                 "relaySessionId": "relay-1",
                 "type": "error",
                 "message": "OpenAI API key rejected with 401",
-                "code": "credential_invalid",
+                "code": "realtime_unavailable",
                 "provider": "openai",
                 "model": "gpt-realtime-2",
                 "transport": "gateway-relay",
@@ -77,7 +77,7 @@ private final class UnusedPCMStreamingAudioPlayer: PCMStreamingAudioPlaying {
             seq: nil,
             stateversion: nil))
 
-        #expect(issues.map(\.code) == [.credentialInvalid])
+        #expect(issues.map(\.code) == [.realtimeUnavailable])
         #expect(statuses == ["OpenAI API key rejected with 401"])
     }
 

--- a/apps/ios/Tests/RealtimeTalkRelaySessionTests.swift
+++ b/apps/ios/Tests/RealtimeTalkRelaySessionTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import OpenClawKit
+import OpenClawProtocol
 import Testing
 @testable import OpenClaw
 
@@ -36,5 +37,71 @@ private final class UnusedPCMStreamingAudioPlayer: PCMStreamingAudioPlaying {
 
         session._test_markOutputAudioStarted(nowMs: 500)
         #expect(session._test_outputStartedAtMs() == 500)
+    }
+
+    @Test func closeAfterClassifiedErrorDoesNotReplaceIssue() async {
+        var issues: [TalkRuntimeIssue] = []
+        var statuses: [String] = []
+        let session = RealtimeTalkRelaySession(
+            gateway: GatewayNodeSession(),
+            options: .init(sessionKey: "main", provider: "openai", model: "gpt-realtime-2", voice: nil),
+            pcmPlayer: UnusedPCMStreamingAudioPlayer(),
+            onStatus: { statuses.append($0) },
+            onIssue: { issues.append($0) },
+            onSpeakingChanged: { _ in })
+        session._test_setRelaySessionId("relay-1")
+
+        await session._test_handleGatewayEvent(EventFrame(
+            type: "event",
+            event: "talk.event",
+            payload: AnyCodable([
+                "relaySessionId": "relay-1",
+                "type": "error",
+                "message": "OpenAI API key rejected with 401",
+                "code": "credential_invalid",
+                "provider": "openai",
+                "model": "gpt-realtime-2",
+                "transport": "gateway-relay",
+                "phase": "connect",
+            ]),
+            seq: nil,
+            stateversion: nil))
+        await session._test_handleGatewayEvent(EventFrame(
+            type: "event",
+            event: "talk.event",
+            payload: AnyCodable([
+                "relaySessionId": "relay-1",
+                "type": "close",
+                "reason": "error",
+            ]),
+            seq: nil,
+            stateversion: nil))
+
+        #expect(issues.map(\.code) == [.credentialInvalid])
+        #expect(statuses == ["OpenAI API key rejected with 401"])
+    }
+
+    @Test func closedRelayDoesNotWaitForStartupReady() async {
+        let session = RealtimeTalkRelaySession(
+            gateway: GatewayNodeSession(),
+            options: .init(sessionKey: "main", provider: "openai", model: "gpt-realtime-2", voice: nil),
+            pcmPlayer: UnusedPCMStreamingAudioPlayer(),
+            onStatus: { _ in },
+            onSpeakingChanged: { _ in })
+
+        session.stop()
+
+        #expect(await session._test_waitForStartupCancelled(timeoutSeconds: 1))
+    }
+
+    @Test func startupReadyWaitCoversGatewayConnectBudget() {
+        let session = RealtimeTalkRelaySession(
+            gateway: GatewayNodeSession(),
+            options: .init(sessionKey: "main", provider: "openai", model: "gpt-realtime-2", voice: nil),
+            pcmPlayer: UnusedPCMStreamingAudioPlayer(),
+            onStatus: { _ in },
+            onSpeakingChanged: { _ in })
+
+        #expect(session._test_startupReadyTimeoutSeconds() >= 12)
     }
 }

--- a/apps/ios/Tests/TalkModeConfigParsingTests.swift
+++ b/apps/ios/Tests/TalkModeConfigParsingTests.swift
@@ -184,28 +184,31 @@ import Testing
         #expect(manager._test_gatewayTalkUsesRealtimeRelay())
     }
 
-    @Test func classifiesRealtimeAuthFailureForDisplay() {
-        let issue = TalkRuntimeIssue.classify(
+    @Test func buildsGenericRealtimeFallbackIssueForDisplay() {
+        let issue = TalkRuntimeIssue.realtimeUnavailable(
             message: "OpenAI API key rejected with 401",
             provider: "openai",
             model: "gpt-realtime-2",
             transport: "gateway-relay",
             phase: "start")
 
-        #expect(issue.code == .credentialInvalid)
+        #expect(issue.code == .realtimeUnavailable)
         #expect(issue.displayMessage == "OpenAI API key rejected with 401")
         #expect(issue.diagnosticSummary.contains("provider: openai"))
         #expect(issue.diagnosticSummary.contains("model: gpt-realtime-2"))
         #expect(issue.fallbackStatusText == "Listening (iOS Speech fallback)")
         #expect(issue.fallbackBannerTitle == "Using iOS Speech fallback")
-        #expect(issue.fallbackBannerOwnerLabel == "Fix on gateway")
-        #expect(issue.technicalDetails.contains("code: credential_invalid"))
+        #expect(issue.fallbackBannerOwnerLabel == "Fallback active")
+        #expect(issue
+            .fallbackBannerMessage ==
+            "Realtime voice did not start. Talk is running with iOS speech recognition and TTS.")
+        #expect(issue.technicalDetails.contains("code: realtime_unavailable"))
     }
 
     @Test func nativeFallbackKeepsRealtimeIssueVisible() {
         let manager = TalkModeManager(allowSimulatorCapture: true)
         let issue = TalkRuntimeIssue(
-            code: .providerClosedBeforeReady,
+            code: .realtimeUnavailable,
             message: "Realtime closed before it became ready.",
             provider: "openai",
             model: "gpt-realtime-2",
@@ -229,7 +232,7 @@ import Testing
             message: "Error: OpenAI API key rejected with 401",
             details: [
                 "talkIssue": AnyCodable([
-                    "code": "credential_invalid",
+                    "code": "realtime_unavailable",
                     "message": "OpenAI API key rejected with 401",
                     "provider": "openai",
                     "model": "gpt-realtime-2",
@@ -240,7 +243,7 @@ import Testing
 
         let issue = manager._test_realtimeIssue(from: error, phase: "start")
 
-        #expect(issue.code == .credentialInvalid)
+        #expect(issue.code == .realtimeUnavailable)
         #expect(issue.displayMessage == "OpenAI API key rejected with 401")
         #expect(issue.provider == "openai")
         #expect(issue.model == "gpt-realtime-2")
@@ -251,7 +254,7 @@ import Testing
     @Test func relayStartupIssueSurvivesUntilReadyStatus() {
         let manager = TalkModeManager(allowSimulatorCapture: true)
         let issue = TalkRuntimeIssue(
-            code: .credentialInvalid,
+            code: .realtimeUnavailable,
             message: "OpenAI API key rejected with 401",
             provider: "openai",
             model: "gpt-realtime-2",
@@ -288,7 +291,7 @@ import Testing
     @Test func relayRetryClearsStaleFallbackTriggerButKeepsLastIssueVisible() {
         let manager = TalkModeManager(allowSimulatorCapture: true)
         let issue = TalkRuntimeIssue(
-            code: .providerClosedBeforeReady,
+            code: .realtimeUnavailable,
             message: "Realtime closed before it became ready.",
             provider: "openai",
             model: "gpt-realtime-2",

--- a/apps/ios/Tests/TalkModeConfigParsingTests.swift
+++ b/apps/ios/Tests/TalkModeConfigParsingTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import OpenClawKit
 import Testing
 @testable import OpenClaw
 
@@ -181,6 +182,129 @@ import Testing
         #expect(manager._test_realtimeProvider() == "openai")
         #expect(manager._test_realtimeModelId() == "gpt-realtime-2")
         #expect(manager._test_gatewayTalkUsesRealtimeRelay())
+    }
+
+    @Test func classifiesRealtimeAuthFailureForDisplay() {
+        let issue = TalkRuntimeIssue.classify(
+            message: "OpenAI API key rejected with 401",
+            provider: "openai",
+            model: "gpt-realtime-2",
+            transport: "gateway-relay",
+            phase: "start")
+
+        #expect(issue.code == .credentialInvalid)
+        #expect(issue.displayMessage == "OpenAI API key rejected with 401")
+        #expect(issue.diagnosticSummary.contains("provider: openai"))
+        #expect(issue.diagnosticSummary.contains("model: gpt-realtime-2"))
+        #expect(issue.fallbackStatusText == "Listening (iOS Speech fallback)")
+        #expect(issue.fallbackBannerTitle == "Using iOS Speech fallback")
+        #expect(issue.fallbackBannerOwnerLabel == "Fix on gateway")
+        #expect(issue.technicalDetails.contains("code: credential_invalid"))
+    }
+
+    @Test func nativeFallbackKeepsRealtimeIssueVisible() {
+        let manager = TalkModeManager(allowSimulatorCapture: true)
+        let issue = TalkRuntimeIssue(
+            code: .providerClosedBeforeReady,
+            message: "Realtime closed before it became ready.",
+            provider: "openai",
+            model: "gpt-realtime-2",
+            transport: "gateway-relay",
+            phase: "connect")
+
+        manager._test_markNativeFallbackActive(after: issue)
+
+        #expect(manager.statusText == "Listening (iOS Speech fallback)")
+        #expect(manager._test_gatewayTalkActiveModeTitle() == "iOS Speech fallback")
+        #expect(manager._test_gatewayTalkActiveModeSubtitle() == "Realtime closed before it became ready.")
+        #expect(manager._test_gatewayTalkLastIssueText()?.contains("phase: connect") == true)
+        #expect(manager._test_gatewayTalkCurrentFallbackIssue() == issue)
+    }
+
+    @Test func gatewayTalkIssueDetailsDriveRealtimeFailureDisplay() {
+        let manager = TalkModeManager(allowSimulatorCapture: true)
+        let error = GatewayResponseError(
+            method: "talk.session.create",
+            code: "UNAVAILABLE",
+            message: "Error: OpenAI API key rejected with 401",
+            details: [
+                "talkIssue": AnyCodable([
+                    "code": "credential_invalid",
+                    "message": "OpenAI API key rejected with 401",
+                    "provider": "openai",
+                    "model": "gpt-realtime-2",
+                    "transport": "gateway-relay",
+                    "phase": "request",
+                ]),
+            ])
+
+        let issue = manager._test_realtimeIssue(from: error, phase: "start")
+
+        #expect(issue.code == .credentialInvalid)
+        #expect(issue.displayMessage == "OpenAI API key rejected with 401")
+        #expect(issue.provider == "openai")
+        #expect(issue.model == "gpt-realtime-2")
+        #expect(issue.transport == "gateway-relay")
+        #expect(issue.phase == "request")
+    }
+
+    @Test func relayStartupIssueSurvivesUntilReadyStatus() {
+        let manager = TalkModeManager(allowSimulatorCapture: true)
+        let issue = TalkRuntimeIssue(
+            code: .credentialInvalid,
+            message: "OpenAI API key rejected with 401",
+            provider: "openai",
+            model: "gpt-realtime-2",
+            transport: "gateway-relay",
+            phase: "connect")
+
+        manager._test_recordRealtimeIssue(issue)
+        manager._test_handleRealtimeRelayStatus("Connecting realtime…")
+
+        #expect(manager._test_gatewayTalkActiveModeTitle() == "Realtime unavailable")
+        #expect(manager._test_gatewayTalkLastIssueText()?.contains("OpenAI API key rejected") == true)
+
+        manager._test_handleRealtimeRelayStatus("Listening (Realtime)")
+
+        #expect(manager.statusText == "Listening (Realtime)")
+        #expect(manager._test_gatewayTalkLastIssueText() == nil)
+        #expect(manager._test_gatewayTalkCurrentFallbackIssue() == nil)
+    }
+
+    @Test func relayCloseClearsActiveRealtimeMode() {
+        let manager = TalkModeManager(allowSimulatorCapture: true)
+
+        manager._test_handleRealtimeRelayStatus("Listening (Realtime)")
+        #expect(manager.statusText == "Listening (Realtime)")
+        #expect(manager._test_gatewayTalkActiveModeTitle() != "Not active")
+
+        manager._test_handleRealtimeRelayStatus("Ready")
+
+        #expect(manager.statusText == "Ready")
+        #expect(manager._test_gatewayTalkActiveModeTitle() == "Not active")
+        #expect(manager._test_gatewayTalkActiveModeSubtitle() == nil)
+    }
+
+    @Test func relayRetryClearsStaleFallbackTriggerButKeepsLastIssueVisible() {
+        let manager = TalkModeManager(allowSimulatorCapture: true)
+        let issue = TalkRuntimeIssue(
+            code: .providerClosedBeforeReady,
+            message: "Realtime closed before it became ready.",
+            provider: "openai",
+            model: "gpt-realtime-2",
+            transport: "gateway-relay",
+            phase: "connect")
+
+        manager._test_recordRealtimeIssue(issue)
+        manager._test_markNativeFallbackActive(after: issue)
+        #expect(manager._test_hasPendingRealtimeIssue())
+        #expect(manager._test_gatewayTalkCurrentFallbackIssue() == issue)
+
+        manager._test_prepareRealtimeRelayStart()
+
+        #expect(!manager._test_hasPendingRealtimeIssue())
+        #expect(manager._test_gatewayTalkCurrentFallbackIssue() == nil)
+        #expect(manager._test_gatewayTalkLastIssueText()?.contains("Realtime closed before") == true)
     }
 
     @Test func mapsWebRTCRealtimeTransportToGatewayRelayOnIOS() {

--- a/src/gateway/server-methods/talk-session.ts
+++ b/src/gateway/server-methods/talk-session.ts
@@ -144,7 +144,51 @@ function respondInvalidRequest(respond: RespondFn, message: string) {
 }
 
 function respondUnavailable(respond: RespondFn, err: unknown) {
-  respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, formatForLog(err)));
+  const message = formatForLog(err);
+  respond(
+    false,
+    undefined,
+    errorShape(ErrorCodes.UNAVAILABLE, message, {
+      details: {
+        talkIssue: {
+          code: classifyTalkUnavailableIssue(message),
+          message,
+          phase: "request",
+        },
+      },
+    }),
+  );
+}
+
+function classifyTalkUnavailableIssue(message: string): string {
+  const lower = message.toLowerCase();
+  if (
+    lower.includes("api key") ||
+    lower.includes("unauthorized") ||
+    lower.includes("401") ||
+    lower.includes("credential") ||
+    lower.includes("auth")
+  ) {
+    return lower.includes("missing") ? "credential_missing" : "credential_invalid";
+  }
+  if (
+    lower.includes("model") &&
+    (lower.includes("not found") || lower.includes("unsupported") || lower.includes("unavailable"))
+  ) {
+    return "model_unavailable";
+  }
+  if (
+    lower.includes("network") ||
+    lower.includes("socket") ||
+    lower.includes("connection") ||
+    lower.includes("closed")
+  ) {
+    return "network_error";
+  }
+  if (lower.includes("provider") || lower.includes("unavailable")) {
+    return "provider_unavailable";
+  }
+  return "unknown";
 }
 
 function respondOk(respond: RespondFn, payload: unknown = { ok: true }) {

--- a/src/gateway/server-methods/talk-session.ts
+++ b/src/gateway/server-methods/talk-session.ts
@@ -151,44 +151,13 @@ function respondUnavailable(respond: RespondFn, err: unknown) {
     errorShape(ErrorCodes.UNAVAILABLE, message, {
       details: {
         talkIssue: {
-          code: classifyTalkUnavailableIssue(message),
+          code: "realtime_unavailable",
           message,
           phase: "request",
         },
       },
     }),
   );
-}
-
-function classifyTalkUnavailableIssue(message: string): string {
-  const lower = message.toLowerCase();
-  if (
-    lower.includes("api key") ||
-    lower.includes("unauthorized") ||
-    lower.includes("401") ||
-    lower.includes("credential") ||
-    lower.includes("auth")
-  ) {
-    return lower.includes("missing") ? "credential_missing" : "credential_invalid";
-  }
-  if (
-    lower.includes("model") &&
-    (lower.includes("not found") || lower.includes("unsupported") || lower.includes("unavailable"))
-  ) {
-    return "model_unavailable";
-  }
-  if (
-    lower.includes("network") ||
-    lower.includes("socket") ||
-    lower.includes("connection") ||
-    lower.includes("closed")
-  ) {
-    return "network_error";
-  }
-  if (lower.includes("provider") || lower.includes("unavailable")) {
-    return "provider_unavailable";
-  }
-  return "unknown";
 }
 
 function respondOk(respond: RespondFn, payload: unknown = { ok: true }) {

--- a/src/gateway/server-methods/talk.test.ts
+++ b/src/gateway/server-methods/talk.test.ts
@@ -788,7 +788,7 @@ describe("talk.session unified handlers", () => {
       message: "Error: OpenAI API key rejected with 401",
     });
     expectRecordFields((error.details as Record<string, unknown>).talkIssue, {
-      code: "credential_invalid",
+      code: "realtime_unavailable",
       message: "Error: OpenAI API key rejected with 401",
       phase: "request",
     });

--- a/src/gateway/server-methods/talk.test.ts
+++ b/src/gateway/server-methods/talk.test.ts
@@ -742,6 +742,58 @@ describe("talk.session unified handlers", () => {
     expect(closeRespond).toHaveBeenCalledWith(true, { ok: true }, undefined);
   });
 
+  it("returns classified talk issue details when realtime relay creation fails", async () => {
+    const provider = {
+      id: "openai",
+      label: "OpenAI Realtime",
+      isConfigured: () => true,
+      createBridge: vi.fn(),
+    };
+    mocks.resolveConfiguredRealtimeVoiceProvider.mockReturnValue({
+      provider,
+      providerConfig: { apiKey: "bad-key" },
+    });
+    mocks.createTalkRealtimeRelaySession.mockImplementation(() => {
+      throw new Error("OpenAI API key rejected with 401");
+    });
+
+    const respond = vi.fn();
+    await talkHandlers["talk.session.create"]({
+      req: { type: "req", id: "1", method: "talk.session.create" },
+      params: {
+        mode: "realtime",
+        transport: "gateway-relay",
+        brain: "agent-consult",
+        provider: "openai",
+        model: "gpt-realtime-2",
+      },
+      client: { connId: "conn-1" } as never,
+      isWebchatConnect: () => false,
+      respond: respond as never,
+      context: {
+        getRuntimeConfig: () =>
+          ({
+            talk: {
+              realtime: {
+                provider: "openai",
+                providers: { openai: { apiKey: "bad-key" } },
+              },
+            },
+          }) as OpenClawConfig,
+      } as never,
+    });
+
+    const error = expectRespondError(respond, {
+      code: ErrorCodes.UNAVAILABLE,
+      message: "Error: OpenAI API key rejected with 401",
+    });
+    expectRecordFields((error.details as Record<string, unknown>).talkIssue, {
+      code: "credential_invalid",
+      message: "Error: OpenAI API key rejected with 401",
+      phase: "request",
+    });
+  });
+
   it("creates transcription gateway-relay sessions through the unified API", async () => {
     const provider = {
       id: "openai",

--- a/src/gateway/talk-realtime-relay.test.ts
+++ b/src/gateway/talk-realtime-relay.test.ts
@@ -235,10 +235,20 @@ describe("talk realtime gateway relay", () => {
         return bridge;
       },
     };
-    const events: Array<{ event: string; payload: unknown; connIds: string[] }> = [];
+    const events: Array<{
+      event: string;
+      payload: unknown;
+      connIds: string[];
+      opts?: { dropIfSlow?: boolean };
+    }> = [];
     const context = {
-      broadcastToConnIds: (event: string, payload: unknown, connIds: ReadonlySet<string>) => {
-        events.push({ event, payload, connIds: [...connIds] });
+      broadcastToConnIds: (
+        event: string,
+        payload: unknown,
+        connIds: ReadonlySet<string>,
+        opts?: { dropIfSlow?: boolean },
+      ) => {
+        events.push({ event, payload, connIds: [...connIds], opts });
       },
     } as never;
 
@@ -290,6 +300,7 @@ describe("talk realtime gateway relay", () => {
     });
     const readyEvent = events.find((entry) => entry.payload === readyPayload);
     expectRecordFields(readyEvent, { event: "talk.event", connIds: ["conn-1"] });
+    expectRecordFields(readyEvent?.opts, { dropIfSlow: false });
 
     const audioPayload = findEventPayload(events, (payload) => payload.type === "audio");
     expectRecordFields(audioPayload, {
@@ -298,6 +309,8 @@ describe("talk realtime gateway relay", () => {
       audioBase64: Buffer.from("audio-out").toString("base64"),
     });
     expectRecordFields(audioPayload.talkEvent, { type: "output.audio.delta" });
+    const audioEvent = events.find((entry) => entry.payload === audioPayload);
+    expectRecordFields(audioEvent?.opts, { dropIfSlow: true });
 
     const userTranscript = findEventPayload(
       events,
@@ -477,6 +490,180 @@ describe("talk realtime gateway relay", () => {
       reason: "completed",
     });
     expectRecordFields(closePayload.talkEvent, { type: "session.closed", final: true });
+  });
+
+  it("emits classified issue details when relay connect fails", async () => {
+    const provider: RealtimeVoiceProviderPlugin = {
+      id: "openai",
+      label: "OpenAI Realtime",
+      isConfigured: () => true,
+      createBridge: () => ({
+        connect: vi.fn(async () => {
+          throw new Error("OpenAI API key rejected with 401");
+        }),
+        sendAudio: vi.fn(),
+        setMediaTimestamp: vi.fn(),
+        handleBargeIn: vi.fn(),
+        submitToolResult: vi.fn(),
+        acknowledgeMark: vi.fn(),
+        close: vi.fn(),
+        isConnected: vi.fn(() => false),
+      }),
+    };
+    const events: Array<{ event: string; payload: unknown; connIds: string[] }> = [];
+    const context = {
+      broadcastToConnIds: (event: string, payload: unknown, connIds: ReadonlySet<string>) => {
+        events.push({ event, payload, connIds: [...connIds] });
+      },
+    } as never;
+
+    const session = createTalkRealtimeRelaySession({
+      context,
+      connId: "conn-1",
+      provider,
+      providerConfig: {},
+      instructions: "brief",
+      tools: [],
+      model: "gpt-realtime-2",
+    });
+    await Promise.resolve();
+
+    const errorPayload = findEventPayload(events, (payload) => payload.type === "error");
+    expectRecordFields(errorPayload, {
+      relaySessionId: session.relaySessionId,
+      type: "error",
+      message: "OpenAI API key rejected with 401",
+      code: "credential_invalid",
+      provider: "openai",
+      model: "gpt-realtime-2",
+      transport: "gateway-relay",
+      phase: "connect",
+    });
+    expectRecordFields(errorPayload.talkEvent, {
+      type: "session.error",
+      final: true,
+    });
+    expectRecordFields((errorPayload.talkEvent as Record<string, unknown>).payload, {
+      code: "credential_invalid",
+      provider: "openai",
+      model: "gpt-realtime-2",
+      transport: "gateway-relay",
+      phase: "connect",
+    });
+  });
+
+  it("emits an issue when the provider closes before ready", () => {
+    let bridgeRequest: RealtimeVoiceBridgeCreateRequest | undefined;
+    const provider: RealtimeVoiceProviderPlugin = {
+      id: "openai",
+      label: "OpenAI Realtime",
+      isConfigured: () => true,
+      createBridge: (req) => {
+        bridgeRequest = req;
+        return {
+          connect: vi.fn(async () => undefined),
+          sendAudio: vi.fn(),
+          setMediaTimestamp: vi.fn(),
+          handleBargeIn: vi.fn(),
+          submitToolResult: vi.fn(),
+          acknowledgeMark: vi.fn(),
+          close: vi.fn(),
+          isConnected: vi.fn(() => true),
+        };
+      },
+    };
+    const events: Array<{ event: string; payload: unknown; connIds: string[] }> = [];
+    const context = {
+      broadcastToConnIds: (event: string, payload: unknown, connIds: ReadonlySet<string>) => {
+        events.push({ event, payload, connIds: [...connIds] });
+      },
+    } as never;
+    const session = createTalkRealtimeRelaySession({
+      context,
+      connId: "conn-1",
+      provider,
+      providerConfig: {},
+      instructions: "brief",
+      tools: [],
+      model: "gpt-realtime-2",
+    });
+
+    bridgeRequest?.onClose?.("error");
+
+    const errorPayload = findEventPayload(events, (payload) => payload.type === "error");
+    expectRecordFields(errorPayload, {
+      relaySessionId: session.relaySessionId,
+      type: "error",
+      code: "provider_closed_before_ready",
+      provider: "openai",
+      model: "gpt-realtime-2",
+      transport: "gateway-relay",
+      phase: "connect",
+    });
+    const closePayload = findEventPayload(events, (payload) => payload.type === "close");
+    expectRecordFields(closePayload, {
+      relaySessionId: session.relaySessionId,
+      type: "close",
+      reason: "error",
+    });
+  });
+
+  it("does not replace provider errors with pre-ready close issues", () => {
+    let bridgeRequest: RealtimeVoiceBridgeCreateRequest | undefined;
+    const provider: RealtimeVoiceProviderPlugin = {
+      id: "openai",
+      label: "OpenAI Realtime",
+      isConfigured: () => true,
+      createBridge: (req) => {
+        bridgeRequest = req;
+        return {
+          connect: vi.fn(async () => undefined),
+          sendAudio: vi.fn(),
+          setMediaTimestamp: vi.fn(),
+          handleBargeIn: vi.fn(),
+          submitToolResult: vi.fn(),
+          acknowledgeMark: vi.fn(),
+          close: vi.fn(),
+          isConnected: vi.fn(() => true),
+        };
+      },
+    };
+    const events: Array<{ event: string; payload: unknown; connIds: string[] }> = [];
+    const context = {
+      broadcastToConnIds: (event: string, payload: unknown, connIds: ReadonlySet<string>) => {
+        events.push({ event, payload, connIds: [...connIds] });
+      },
+    } as never;
+    createTalkRealtimeRelaySession({
+      context,
+      connId: "conn-1",
+      provider,
+      providerConfig: {},
+      instructions: "brief",
+      tools: [],
+      model: "gpt-realtime-2",
+    });
+
+    bridgeRequest?.onError?.(new Error("OpenAI API key rejected with 401"));
+    bridgeRequest?.onClose?.("error");
+
+    const errorPayloads = events
+      .map((entry) => entry.payload)
+      .filter(
+        (payload): payload is Record<string, unknown> =>
+          typeof payload === "object" &&
+          payload !== null &&
+          (payload as Record<string, unknown>).type === "error",
+      );
+    expect(errorPayloads).toHaveLength(1);
+    expectRecordFields(errorPayloads[0], {
+      type: "error",
+      code: "credential_invalid",
+      provider: "openai",
+      model: "gpt-realtime-2",
+      transport: "gateway-relay",
+      phase: "connect",
+    });
   });
 
   it("does not route assistant echo transcripts back into the realtime model", async () => {

--- a/src/gateway/talk-realtime-relay.test.ts
+++ b/src/gateway/talk-realtime-relay.test.ts
@@ -492,7 +492,7 @@ describe("talk realtime gateway relay", () => {
     expectRecordFields(closePayload.talkEvent, { type: "session.closed", final: true });
   });
 
-  it("emits classified issue details when relay connect fails", async () => {
+  it("emits generic issue details when relay connect fails", async () => {
     const provider: RealtimeVoiceProviderPlugin = {
       id: "openai",
       label: "OpenAI Realtime",
@@ -533,7 +533,7 @@ describe("talk realtime gateway relay", () => {
       relaySessionId: session.relaySessionId,
       type: "error",
       message: "OpenAI API key rejected with 401",
-      code: "credential_invalid",
+      code: "realtime_unavailable",
       provider: "openai",
       model: "gpt-realtime-2",
       transport: "gateway-relay",
@@ -544,7 +544,7 @@ describe("talk realtime gateway relay", () => {
       final: true,
     });
     expectRecordFields((errorPayload.talkEvent as Record<string, unknown>).payload, {
-      code: "credential_invalid",
+      code: "realtime_unavailable",
       provider: "openai",
       model: "gpt-realtime-2",
       transport: "gateway-relay",
@@ -594,7 +594,7 @@ describe("talk realtime gateway relay", () => {
     expectRecordFields(errorPayload, {
       relaySessionId: session.relaySessionId,
       type: "error",
-      code: "provider_closed_before_ready",
+      code: "realtime_unavailable",
       provider: "openai",
       model: "gpt-realtime-2",
       transport: "gateway-relay",
@@ -658,7 +658,7 @@ describe("talk realtime gateway relay", () => {
     expect(errorPayloads).toHaveLength(1);
     expectRecordFields(errorPayloads[0], {
       type: "error",
-      code: "credential_invalid",
+      code: "realtime_unavailable",
       provider: "openai",
       model: "gpt-realtime-2",
       transport: "gateway-relay",

--- a/src/gateway/talk-realtime-relay.ts
+++ b/src/gateway/talk-realtime-relay.ts
@@ -90,7 +90,16 @@ type TalkRealtimeRelayEventPayload =
     }
   | { relaySessionId: string; type: "toolResult"; callId: string }
   | { relaySessionId: string; type: "toolProgress"; result: RealtimeVoiceAgentControlResult }
-  | { relaySessionId: string; type: "error"; message: string }
+  | {
+      relaySessionId: string;
+      type: "error";
+      message: string;
+      code?: TalkRealtimeRelayIssueCode;
+      provider?: string;
+      model?: string;
+      transport?: "gateway-relay";
+      phase?: string;
+    }
   | { relaySessionId: string; type: "close"; reason: "completed" | "error" };
 
 type TalkRealtimeRelayEvent = TalkRealtimeRelayEventPayload & { talkEvent?: TalkEvent };
@@ -109,6 +118,25 @@ type RelaySession = {
   completedAgentToolCalls: Set<string>;
   forcedConsults: RealtimeVoiceForcedConsultCoordinator;
   transcript: RealtimeVoiceTranscriptEntry[];
+};
+
+type TalkRealtimeRelayIssueCode =
+  | "credential_invalid"
+  | "credential_missing"
+  | "provider_unavailable"
+  | "model_unavailable"
+  | "gateway_config_invalid"
+  | "network_error"
+  | "provider_closed_before_ready"
+  | "unknown";
+
+type TalkRealtimeRelayIssue = {
+  code: TalkRealtimeRelayIssueCode;
+  message: string;
+  provider: string;
+  model?: string;
+  transport: "gateway-relay";
+  phase: string;
 };
 
 type CreateTalkRealtimeRelaySessionParams = {
@@ -139,6 +167,62 @@ const relaySessions = new Map<string, RelaySession>();
 
 function formatError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+function classifyRealtimeRelayIssue(params: {
+  error: unknown;
+  provider: string;
+  model?: string;
+  phase: string;
+}): TalkRealtimeRelayIssue {
+  const message = formatError(params.error);
+  const lower = message.toLowerCase();
+  const code: TalkRealtimeRelayIssueCode =
+    lower.includes("api key") ||
+    lower.includes("unauthorized") ||
+    lower.includes("401") ||
+    lower.includes("credential") ||
+    lower.includes("auth")
+      ? lower.includes("missing")
+        ? "credential_missing"
+        : "credential_invalid"
+      : lower.includes("model") &&
+          (lower.includes("not found") ||
+            lower.includes("unsupported") ||
+            lower.includes("unavailable"))
+        ? "model_unavailable"
+        : lower.includes("network") ||
+            lower.includes("socket") ||
+            lower.includes("connection") ||
+            lower.includes("closed")
+          ? "network_error"
+          : lower.includes("provider") || lower.includes("unavailable")
+            ? "provider_unavailable"
+            : "unknown";
+  return {
+    code,
+    message,
+    provider: params.provider,
+    ...(params.model ? { model: params.model } : {}),
+    transport: "gateway-relay",
+    phase: params.phase,
+  };
+}
+
+function relayIssuePayload(
+  relaySessionId: string,
+  issue: TalkRealtimeRelayIssue,
+): Extract<TalkRealtimeRelayEventPayload, { type: "error" }> {
+  return {
+    relaySessionId,
+    type: "error",
+    message: issue.message,
+    code: issue.code,
+    provider: issue.provider,
+    ...(issue.model ? { model: issue.model } : {}),
+    transport: issue.transport,
+    phase: issue.phase,
+  };
 }
 
 function isWorkingToolResult(result: unknown): boolean {
@@ -193,8 +277,20 @@ function broadcastToOwner(
   context: GatewayRequestContext,
   connId: string,
   event: TalkRealtimeRelayEvent,
+  options: { dropIfSlow?: boolean } = { dropIfSlow: true },
 ): void {
-  context.broadcastToConnIds(RELAY_EVENT, event, new Set([connId]), { dropIfSlow: true });
+  context.broadcastToConnIds(RELAY_EVENT, event, new Set([connId]), options);
+}
+
+function relayEventDeliveryOptions(event: TalkRealtimeRelayEventPayload): { dropIfSlow?: boolean } {
+  switch (event.type) {
+    case "ready":
+    case "error":
+    case "close":
+      return { dropIfSlow: false };
+    default:
+      return { dropIfSlow: true };
+  }
 }
 
 function abortRelayAgentRuns(session: RelaySession, reason: string): void {
@@ -353,12 +449,19 @@ export function createTalkRealtimeRelaySession(
     { onEvent: recordTalkObservabilityEvent },
   );
   const emit = (event: TalkRealtimeRelayEventPayload, talkEvent?: TalkEventInput) =>
-    broadcastToOwner(params.context, params.connId, {
-      ...event,
-      ...(talkEvent ? { talkEvent: talk.emit(talkEvent) } : {}),
-    });
+    broadcastToOwner(
+      params.context,
+      params.connId,
+      {
+        ...event,
+        ...(talkEvent ? { talkEvent: talk.emit(talkEvent) } : {}),
+      },
+      relayEventDeliveryOptions(event),
+    );
   let currentOutputItemId: string | undefined;
   let currentOutputResponseId: string | undefined;
+  let ready = false;
+  let failureEmitted = false;
   const relayRef: { current?: RelaySession } = {};
   const bridge = createRealtimeVoiceBridgeSession({
     provider: params.provider,
@@ -547,13 +650,24 @@ export function createTalkRealtimeRelaySession(
         },
       );
     },
-    onReady: () =>
-      emit({ relaySessionId, type: "ready" }, { type: "session.ready", payload: null }),
-    onError: (error) =>
-      emit(
-        { relaySessionId, type: "error", message: error.message },
-        { type: "session.error", payload: { message: error.message }, final: true },
-      ),
+    onReady: () => {
+      ready = true;
+      emit({ relaySessionId, type: "ready" }, { type: "session.ready", payload: null });
+    },
+    onError: (error) => {
+      const issue = classifyRealtimeRelayIssue({
+        error,
+        provider: params.provider.id,
+        model: params.model,
+        phase: ready ? "stream" : "connect",
+      });
+      failureEmitted = true;
+      emit(relayIssuePayload(relaySessionId, issue), {
+        type: "session.error",
+        payload: issue,
+        final: true,
+      });
+    },
     onClose: (reason) => {
       const active = relaySessions.get(relaySessionId);
       if (!active) {
@@ -564,6 +678,21 @@ export function createTalkRealtimeRelaySession(
       forgetUnifiedTalkSession(relaySessionId);
       clearTimeout(active.cleanupTimer);
       abortRelayAgentRuns(active, "relay-closed");
+      if (!ready && !failureEmitted) {
+        const issue: TalkRealtimeRelayIssue = {
+          code: "provider_closed_before_ready",
+          message: "Realtime provider closed before the session became ready.",
+          provider: params.provider.id,
+          ...(params.model ? { model: params.model } : {}),
+          transport: "gateway-relay",
+          phase: "connect",
+        };
+        emit(relayIssuePayload(relaySessionId, issue), {
+          type: "session.error",
+          payload: issue,
+          final: true,
+        });
+      }
       emit(
         { relaySessionId, type: "close", reason },
         { type: "session.closed", payload: { reason }, final: true },
@@ -594,7 +723,18 @@ export function createTalkRealtimeRelaySession(
   relay.cleanupTimer.unref?.();
   relaySessions.set(relaySessionId, relay);
   bridge.connect().catch((error: unknown) => {
-    emit({ relaySessionId, type: "error", message: formatError(error) });
+    const issue = classifyRealtimeRelayIssue({
+      error,
+      provider: params.provider.id,
+      model: params.model,
+      phase: "connect",
+    });
+    failureEmitted = true;
+    emit(relayIssuePayload(relaySessionId, issue), {
+      type: "session.error",
+      payload: issue,
+      final: true,
+    });
     const active = relaySessions.get(relaySessionId);
     if (active) {
       closeRelaySession(active, "error");

--- a/src/gateway/talk-realtime-relay.ts
+++ b/src/gateway/talk-realtime-relay.ts
@@ -94,7 +94,7 @@ type TalkRealtimeRelayEventPayload =
       relaySessionId: string;
       type: "error";
       message: string;
-      code?: TalkRealtimeRelayIssueCode;
+      code?: "realtime_unavailable";
       provider?: string;
       model?: string;
       transport?: "gateway-relay";
@@ -120,18 +120,8 @@ type RelaySession = {
   transcript: RealtimeVoiceTranscriptEntry[];
 };
 
-type TalkRealtimeRelayIssueCode =
-  | "credential_invalid"
-  | "credential_missing"
-  | "provider_unavailable"
-  | "model_unavailable"
-  | "gateway_config_invalid"
-  | "network_error"
-  | "provider_closed_before_ready"
-  | "unknown";
-
 type TalkRealtimeRelayIssue = {
-  code: TalkRealtimeRelayIssueCode;
+  code: "realtime_unavailable";
   message: string;
   provider: string;
   model?: string;
@@ -169,39 +159,15 @@ function formatError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
-function classifyRealtimeRelayIssue(params: {
-  error: unknown;
+function realtimeRelayIssue(params: {
+  message: string;
   provider: string;
   model?: string;
   phase: string;
 }): TalkRealtimeRelayIssue {
-  const message = formatError(params.error);
-  const lower = message.toLowerCase();
-  const code: TalkRealtimeRelayIssueCode =
-    lower.includes("api key") ||
-    lower.includes("unauthorized") ||
-    lower.includes("401") ||
-    lower.includes("credential") ||
-    lower.includes("auth")
-      ? lower.includes("missing")
-        ? "credential_missing"
-        : "credential_invalid"
-      : lower.includes("model") &&
-          (lower.includes("not found") ||
-            lower.includes("unsupported") ||
-            lower.includes("unavailable"))
-        ? "model_unavailable"
-        : lower.includes("network") ||
-            lower.includes("socket") ||
-            lower.includes("connection") ||
-            lower.includes("closed")
-          ? "network_error"
-          : lower.includes("provider") || lower.includes("unavailable")
-            ? "provider_unavailable"
-            : "unknown";
   return {
-    code,
-    message,
+    code: "realtime_unavailable",
+    message: params.message,
     provider: params.provider,
     ...(params.model ? { model: params.model } : {}),
     transport: "gateway-relay",
@@ -655,8 +621,8 @@ export function createTalkRealtimeRelaySession(
       emit({ relaySessionId, type: "ready" }, { type: "session.ready", payload: null });
     },
     onError: (error) => {
-      const issue = classifyRealtimeRelayIssue({
-        error,
+      const issue = realtimeRelayIssue({
+        message: formatError(error),
         provider: params.provider.id,
         model: params.model,
         phase: ready ? "stream" : "connect",
@@ -679,14 +645,12 @@ export function createTalkRealtimeRelaySession(
       clearTimeout(active.cleanupTimer);
       abortRelayAgentRuns(active, "relay-closed");
       if (!ready && !failureEmitted) {
-        const issue: TalkRealtimeRelayIssue = {
-          code: "provider_closed_before_ready",
+        const issue = realtimeRelayIssue({
           message: "Realtime provider closed before the session became ready.",
           provider: params.provider.id,
-          ...(params.model ? { model: params.model } : {}),
-          transport: "gateway-relay",
+          model: params.model,
           phase: "connect",
-        };
+        });
         emit(relayIssuePayload(relaySessionId, issue), {
           type: "session.error",
           payload: issue,
@@ -723,8 +687,8 @@ export function createTalkRealtimeRelaySession(
   relay.cleanupTimer.unref?.();
   relaySessions.set(relaySessionId, relay);
   bridge.connect().catch((error: unknown) => {
-    const issue = classifyRealtimeRelayIssue({
-      error,
+    const issue = realtimeRelayIssue({
+      message: formatError(error),
       provider: params.provider.id,
       model: params.model,
       phase: "connect",


### PR DESCRIPTION
## Summary

- Clarifies the iOS Talk experience when gateway realtime mode fails and the app falls back to native iOS speech recognition/TTS.
- Adds a single generic gateway/runtime issue for realtime startup failures, preserving the safe provider message and diagnostics without classifying root cause in the app.
- Shows configured vs active talk mode in iOS, plus a small fallback banner with details and diagnostics when realtime fails over while the gateway is still connected.
- Keeps lifecycle events from being dropped in the gateway relay so iOS can reliably distinguish realtime ready/error/close outcomes.
- Out of scope: changing provider credentials, adding new talk modes, or changing the normal successful realtime audio path beyond startup readiness tracking.

## Linked context

Requested by maintainer in this thread after testing the confusing fallback cases on iOS.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: iOS now makes realtime talk fallback visible instead of silently switching to native iOS speech/TTS when configured gateway realtime fails.
- Real environment tested: Local iOS build installed and launched on Nimrod's iPhone; temporary gateway failure was tested against the running gateway during development and then the original gateway config was restored.
- Exact steps or command run after this patch:
  - `pnpm test src/gateway/talk-realtime-relay.test.ts src/gateway/server-methods/talk.test.ts`
  - `xcodebuild -project apps/ios/OpenClaw.xcodeproj -scheme OpenClaw -destination "platform=iOS Simulator,name=iPhone 17" -configuration Debug -derivedDataPath apps/ios/build/simulator -only-testing:OpenClawTests/RealtimeTalkRelaySessionTests -only-testing:OpenClawTests/TalkModeManagerTests test`
  - `swiftformat --lint --config config/swiftformat apps/ios/Sources/Voice/RealtimeTalkRelaySession.swift apps/ios/Tests/RealtimeTalkRelaySessionTests.swift`
  - `swiftlint` on touched iOS source files via script input files
  - `git diff --check`
  - `codex review --uncommitted` before commit
  - `.agents/skills/autoreview/scripts/autoreview --mode local` after simplifying fallback issues
  - `xcodebuild -project apps/ios/OpenClaw.xcodeproj -scheme OpenClaw -destination "id=00008140-000848A92EE3001C" -configuration Debug -derivedDataPath apps/ios/build/phone build`
  - `xcrun devicectl device install app --device 6A19D82B-4EA6-5D67-B3A7-0AB3B71B550C apps/ios/build/phone/Build/Products/Debug-iphoneos/OpenClaw.app`
  - `xcrun devicectl device process launch --device 6A19D82B-4EA6-5D67-B3A7-0AB3B71B550C ai.openclaw.ios.test.guti-gzs353x62e`
- Evidence after fix: The failure banner was manually verified on the physical phone during temporary gateway failover testing; the signed app then built, installed, and launched successfully on the same phone after the branch was pushed.
- Observed result after fix: The app displays the native speech fallback state and a visible runtime issue banner instead of silently hiding gateway realtime failure.
- What was not tested: Full end-to-end successful provider audio on every realtime provider/model combination.
- Proof limitations or environment constraints: The first phone launch attempt was denied because the device was locked; after unlocking, launch succeeded.
- Before evidence: Previously, failed gateway realtime startup could immediately fall back to native speech/TTS without clear in-app indication.

## Tests and validation

- Gateway regression tests passed: 136 tests.
- iOS selected simulator tests passed: 25 tests across `RealtimeTalkRelaySessionTests` and `TalkModeManagerTests`.
- SwiftFormat lint: clean.
- SwiftLint on touched iOS files: 0 violations.
- `git diff --check`: clean.
- Codex/autoreview: no actionable correctness issues after accepted fixes were applied and after the generic fallback simplification.
- Physical-device iOS Debug build, install, and launch succeeded.

Regression coverage added/updated:
- Gateway relay tests now cover generic talk issue events and non-droppable lifecycle events.
- iOS relay tests now cover startup cancellation and startup timeout budget behavior.
- iOS config parsing tests cover generic talk issue parsing and fallback banner state.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

Yes, only in error reporting for talk provider/auth failures. No secrets are surfaced; diagnostics use a generic issue code plus safe issue metadata.

What is the highest-risk area?

Realtime relay startup sequencing and generic failure propagation between gateway events and iOS fallback.

How is that risk mitigated?

The iOS relay now subscribes before session creation, waits for provider ready before reporting realtime startup success, preserves the first realtime issue, and the gateway keeps lifecycle events non-droppable. Focused gateway and iOS tests cover these cases.

## Current review state

What is the next action?

Maintainer review and GitHub checks.

What is still waiting on author, maintainer, CI, or external proof?

Waiting on PR CI and maintainer review. No known author-side loose ends.

Which bot or reviewer comments were addressed?

Local Codex review findings were addressed before this PR: startup cancellation hang, droppable lifecycle events, and startup wait budget shorter than gateway provider connect budget. Maintainer feedback to remove semantic failure classification was addressed by collapsing fallback reporting to one generic `realtime_unavailable` issue.

<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Redacted codex session transcript</summary>

````text
source: [LOCAL_SESSION]
redaction: local paths, emails, phone-shaped strings, token-shaped strings, auth headers, auth query params
omitted: raw tool outputs, system/developer prompts, local paths, secrets, browser/session/auth details
stats: {"agent":"codex","entries":27,"user":13,"assistant":13,"toolCalls":580,"toolOutputsDropped":579,"web":0,"redactions":10,"omittedUnsafe":0,"rawEntries":423}

[user]
I want to improve the iOS talk experience -
Today when several talk options are configured on the gateway - if one of them fails the experience is not clear in the iOS app. For example if I configured gpt realtime 2.0 in gateway relay mode but it failed and the iOS falls back into regular speech recognition and tts - it's not clear. Also if the API key fails in the gateway and the realtime mode closes the socket immediately there's no indication on the app. Please help spec and plan improvements to this

[assistant]
I’ll ground the plan in the current iOS/gateway talk flow first, then turn it into a concrete product/technical spec with implementation phases and verification points.

The broad search is too noisy, but it confirms there is already a `src/talk` event/diagnostics layer and mobile voice E2E scaffolding. I’m narrowing to iOS app files and gateway protocol/talk event contracts now.

[instructions recap omitted; policy/config text, not task dialogue]

The current protocol already has `talk.session.create` and `TalkEvent` schemas, and iOS advertises `talk` plus speech-recognition permission state. The likely gap is not capability discovery, but explicit session outcome reporting and a UI state machine that can distinguish “realtime active”, “trying realtime”, “fell back to local STT/TTS”, and “failed before fallback.”

A concrete thing from the server path: realtime relay creation is all-or-error during `talk.session.create`; if provider resolution or bridge creation throws, the gateway returns `UNAVAILABLE`. After creation, later provider/socket failure is only represented through session events, so the iOS side needs to surface those instead of silently choosing another path.

The iOS relay session currently sets status to `Connecting realtime…`, then `Listening (Realtime)` only after create, event subscription, audio contract, and mic pump succeed. The unclear path likely happens one level up in `TalkModeManager`, where realtime start failure falls through to native speech without preserving a visible degraded reason.

I have enough context to draft this without changing files. I’m going to frame it around one canonical “Talk runtime state” instead of more status strings, because the current state is spread across `statusText`, configured mode labels, and relay session callbacks.

I’d spec this as a **Talk runtime transparency** improvement: the app should always show the configured voice path, the active voice path, and any degradation reason.

Current behavior from the code: realtime start can fail and return `false`, then `TalkModeManager` starts the native speech path and overwrites status with plain `Listening` at `apps/ios/Sources/Voice/TalkModeManager.swift:301` and `apps/ios/Sources/Voice/TalkModeManager.swift:320`. Relay errors also flow through a plain string callback, while relay close becomes `Ready` at `apps/ios/Sources/Voice/RealtimeTalkRelaySession.swift:332`.

**Spec**
- Add an explicit iOS `TalkRuntimeState`, separate from `statusText`:
  - `off`
  - `starting(requestedMode)`
  - `active(mode, provider, model, transport)`
  - `degraded(requestedMode, activeMode, reason, retryAvailable)`
  - `failed(requestedMode, reason, recoveryAction)`
- Derive `statusText` from that state instead of using ad hoc strings.
- When realtime fails and native STT/TTS starts, show:
  - Runtime: `Listening (iOS Speech fallback)`
  - Banner/chip: `GPT Realtime 2.0 unavailable. Using iOS speech.`
  - Detail: `Gateway realtime failed: invalid API key` or classified reason.
- When gateway relay closes before ready, do not show `Ready`; show:
  - `Realtime failed before connecting`
  - If fallback is allowed and speech permissions are available, transition to degraded fallback.
  - If fallback is unavailable, keep a visible failed state with `Retry` and `Open Settings`.
- Keep “configured mode” and “active mode” separate in UI. Example:
  - Configured: `GPT Realtime 2.0 • Gateway Relay`
  - Active now: `iOS Speech + system TTS fallback`
- Add a small `Last realtime issue` row in Talk settings/debug, with timestamp, provider, model, transport, and reason. No secrets.

**Gateway/API Plan**
1. Use the existing `TalkEvent` contract for structured failure events. It already supports `session.error`, `session.closed`, and `health.changed` in `src/talk/talk-events.ts`, and the protocol schema accepts provider/mode/transport context at `packages/gateway-protocol/src/schema/channels.ts:148`.
2. Make realtime relay emit a structured `session.error` before closing when provider auth, model, websocket, or startup fails.
3. Classify gateway/provider failures into stable codes:
   - `credential_invalid`
   - `credential_missing`
   - `provider_unavailable`
   - `model_unavailable`
   - `gateway_config_invalid`
   - `network_error`
   - `provider_closed_before_ready`
   - `unknown`
4. Include safe metadata only: `provider`, `model`, `transport`, `phase`, `message`, `code`.
5. For `talk.session.create`, return the same classified error details when creation fails around provider resolution / bridge creation at `src/gateway/server-methods/talk-session.ts:294`.

**iOS Implementation Plan**
1. Add `TalkRuntimeState` and `TalkRuntimeIssue` in the voice module.
2. Change `startRealtimeIfAvailable()` and `startRealtimeRelayIfAvailable()` to return a structured result instead of `Bool`, for example:
   - `.started`
   - `.unavailable(issue)`
   - `.ignored`
3. When fallback starts, preserve the realtime issue and set degraded state instead of overwriting status with plain `Listening`.
4. Replace `RealtimeTalkRelaySession`’s `onStatus(String)` with a structured callback:
   - `.ready`
   - `.transcript(role, final)`
   - `.outputStarted`
   - `.error(issue)`
   - `.closed(reason, wasReady)`
5. Update TalkPro UI and compact chat orb to render active/degraded/failed state clearly.
6. Add retry behavior:
   - `Retry Realtime` attempts only the configured realtime path.
   - Toggle off/on clears the issue.
   - Successful realtime start clears degraded state.

**Acceptance Criteria**
- Bad gateway OpenAI API key: app shows realtime failure reason, then either degraded iOS speech fallback or failed state.
- Gateway relay socket closes immediately: app does not show `Ready`; it shows `Realtime failed before connecting`.
- Realtime configured but native fallback active: Talk UI clearly says fallback is active.
- Successful realtime session shows `Listening (Realtime)` and active provider/model.
- No secrets are rendered or logged.

**Verification**
- Swift tests: `TalkModeManager` fallback state, relay close-before-ready, relay error event.
- Gateway tests: `talk.session.create` auth/provider failure classification, relay emits `session.error` before close.
- Manual E2E: configured `gpt-realtime-2` with invalid key, confirm visible degraded/failed state on iOS.

[user]
implement this in a new branch

[assistant]
I’ll create a feature branch first, then make the iOS state changes and the gateway/protocol failure classification changes together so the app can consume structured failure data when it exists.

Using `openclaw-testing` for the validation path; this is a normal checkout, so I’ll keep proof targeted to the touched Swift and gateway protocol/tests unless the diff expands.

Branch `improve-ios-talk-runtime-transparency` is active. I’m reading the generated protocol structs and existing iOS tests now so the patch fits the current decoding patterns instead of adding a parallel protocol layer.

I found the key iOS issue: realtime start failure only logs and returns `false`, so the fallback path replaces it with `Listening`. I’m going to add a small issue/result model and keep the previous config labels intact while exposing the active degraded runtime.

Implementation plan:
- Add a typed iOS `TalkRuntimeState`/`TalkRuntimeIssue` and expose active/degraded labels to the Talk UI.
- Change realtime start helpers to return `started` or `unavailable(issue)` so native fallback keeps the realtime failure visible.
- Make relay error/close callbacks structured, especially close-before-ready.
- Add gateway relay failure metadata to `talk.event` error payloads and request errors where practical.
- Add targeted Swift and TypeScript tests around state formatting and relay error classification.

I’m starting with the iOS model because that fixes the confusing fallback UX even before every gateway error has perfect metadata. The gateway patch will enrich the reason text where available.

I’m editing the existing Swift voice files rather than adding a new file, so the Xcode project does not need source-list churn. The visible UI will get “Configured mode” and “Active now” rows plus a last issue detail.

Next I’m wiring the manager: realtime start failures will become a `TalkRuntimeIssue`, and the native path will render as an explicit iOS Speech fallback instead of plain listening.

I’m changing only the decision boundary around realtime startup: if realtime fails, the fallback can still start, but it carries the realtime failure forward into UI state and diagnostics.

Now I’m updating the two realtime start helpers and adding a few small helpers for active/degraded labels. This is intentionally local to Talk mode state, not a new config surface.

The helper methods are going in the existing descriptor section, where configured voice labels are already normalized. That keeps the active/degraded labels using the same provider/model naming rules.

I’m adding the UI rows now: configured mode remains visible, active mode is separate, and a last-issue row appears only when there is an actual degraded/failure reason.

I’m avoiding new icons where possible to reduce SF Symbol compatibility risk across iOS targets; the functional change is the active/degraded text, not icon art.

I’m also adding the same active/runtime visibility in Settings, since that’s where someone debugging an API-key or gateway relay issue will naturally check.

The settings rows need compact computed strings, so I’m placing those next to the existing Talk settings helper properties rather than threading more view state.

I’m adding those Settings helper properties in `SettingsProTabActions.swift`, which already owns the Talk config display helpers.

The new Settings values will collapse empty subtitles, so normal users see one extra useful row and only see “Last Voice Issue” after a real degradation.

I’m adding reset behavior now: toggling Talk off clears the degraded issue, while a fallback issue remains visible while Talk stays enabled.

I’m checking the WebRTC delegate path too, so direct realtime and relay realtime report active mode consistently.

The WebRTC delegate currently only mirrors raw provider status. I’m making the “Listening” realtime status use the same active-mode helper so direct WebRTC doesn’t look like native speech.

When realtime ends normally, I’m clearing the active mode back to “Not active” so Settings doesn’t imply an ended session is still live.

I’m adding test-only hooks for the new state formatting rather than trying to drive AVAudio/Speech permissions in unit tests. That keeps tests deterministic.

The tests will pin two user-visible behaviors: auth-style errors classify as credential issues, and fallback state renders as iOS Speech fallback with a retained issue summary.

I’m enriching the gateway relay events now. The existing relay already emits `session.error`; I’m adding stable error codes and making the connect-time rejection include the Talk event payload instead of only a raw message.

The gateway side now has a relay issue classifier. I’m wiring it into provider error, close-before-ready, and bridge connect failure paths so iOS can show a stable reason.

I’m checking the request error helper before changing it; if the gateway already preserves `ErrorShape.details`, I’ll add classified details only at this Talk creation boundary.

`talk-session.ts` has its own response helper, so I’m patching that local helper rather than widening generic gateway error behavior.

For request-time failures, I’m adding structured `details.talkIssue` to the `UNAVAILABLE` response. Existing clients still get the same top-level message; newer iOS can classify from the message even if it cannot read details yet.

I’m looking for the existing Talk gateway tests before adding new ones, so the added assertions land in the current suite instead of a new standalone harness.

I’m continuing from the implementation branch and checking the gateway test surface before running focused proof. The remaining risk is making sure the new failure metadata is covered by tests and does not break existing relay behavior.

The iOS side now keeps both the configured mode and the actual active mode, so fallback is visible instead of silently looking like the selected realtime option is running. I’m adding/adjusting gateway tests now so auth and early-close failures carry structured issue codes to the app.

The existing relay tests already exercise provider close paths, so I can extend that coverage rather than create a separate harness. I’m also going to cover the `talk.session.create` failure response because that is the request-time path the iOS app sees before a relay is established.

I found one cleanup issue in my own gateway change: request-time errors were annotated, but provider/model context is only available inside the realtime create branch. I’m going to keep the public detail shape narrow while adding the missing focused tests.

I’m editing the tests and keeping the new behavior scoped to the existing Talk relay/session modules. No commits or pushes will happen unless you explicitly ask.

Relay error coverage is in place for both connect failures and pre-ready closes. Next I’m adding the request-time `talk.session.create` coverage so iOS can surface a failed API key even when the socket never gets a usable relay session.

The UI diff is intentionally simple: the Talk screen now shows “Configured” separately from “Active now”, and Settings mirrors the active voice plus the last failure detail. I’m checking the supporting JSON model and build syntax next because these Swift paths are sensitive to small type issues.

`git diff --check` is clean. I’m running focused gateway tests first, then I’ll run the iOS test target for the Talk config/relay changes if the simulator setup cooperates.

The first gateway test command failed because `--runInBand` is a Jest flag and Vitest rejects it here. I’m rerunning the same focused test set with the repo wrapper’s supported flags only.

The focused gateway tests exposed a real parser error in `talk-realtime-relay.ts`, so I’m fixing that before continuing. The failure is in the edited callback object around the new `onError` block.

That parser issue was just a stray comma after an `emit(...)` call. I’ve corrected it and am rerunning the focused gateway tests.

The rerun shows the existing gateway error formatter includes the `Error:` prefix. I’m updating the new assertion to match that contract rather than changing the formatter behavior.

The new gateway assertions now follow the existing formatted error contract. I’m rerunning the focused gateway tests again.

Gateway proof is green now: 132 focused tests passed. I’m checking the iOS project schemes so I can run the narrow Swift test target for the Talk changes.

The project has an `OpenClaw` scheme with `OpenClawTests`. I’m checking available simulators so the narrow Talk test run uses an installed destination.

I found available iOS simulators and am running only the Talk-related XCTest/Swift Testing suites on `iPhone 16e` for iOS 18.6.

The iOS build did not reach tests because the project’s SwiftFormat lint caught two edited files. I’m applying the formatter to just those Swift files, then I’ll rerun the same narrow iOS tests.

The lint errors are all formatter style issues in my edits. I’m running SwiftFormat on only `TalkModeGatewayConfig.swift` and `TalkModeManager.swift`.

SwiftFormat updated only the two files it flagged. I’m quickly reviewing the changed hunks, then I’ll rerun the same iOS test command.

The formatter changes are clean and `git diff --check` still passes. I’m rerunning the same iOS Talk test command now.

The formatter issue is fixed, but the iOS app target currently fails earlier on unrelated missing `AppleReviewDemo*` symbols before the Talk tests can run. I’m checking whether there is a narrower logic-test target or build flag that avoids that app-target failure without touching unrelated code.

The app-target iOS test is still blocked by existing unrelated `AppleReviewDemoMode` / `AppleReviewDemoChatTransport` build errors. A logic-test scheme runs but does not include these app Talk tests, so I’m treating app-target proof as blocked and will keep the successful gateway proof plus SwiftFormat lint proof for the touched iOS files.

The touched Swift files pass the project SwiftFormat lint now. I’m doing a final status/numstat pass so the handoff includes exact scope and remaining proof gap.

The implementation is complete enough for handoff, but repo policy requires a fresh autoreview before closeout for code changes. I’m running that review pass now and will address any concrete findings it produces.

Using the repo-local `$autoreview` workflow now: `.agents/skills/autoreview/scripts/autoreview --mode local`. This may take a while; I’ll keep the review output actionable rather than dumping noise.

The autoreview helper is still running. I’m letting it continue; no findings have returned yet.

Autoreview is healthy and reporting heartbeat at 60 seconds. I’m continuing to wait for the structured result.

Autoreview found a real bug: after a classified relay `error`, iOS would process the following `close` and overwrite the specific issue with a generic “closed before ready.” I’m fixing that by tracking whether an error was already received and preserving the original issue on close.

I’m adding a narrow regression test around the exact event sequence from the review finding: classified `error`, then `close` before ready. The expected behavior is that the credential issue remains the only reported issue.

The runtime fix is in: a close event no longer replaces a classified error if one already arrived. I’m exposing a test-only event hook and adding the regression assertion.

The regression test now exercises the reviewed failure sequence. I’m formatting the touched Swift files and then rerunning the relevant focused proof.

SwiftFormat made no further changes. Since the app target is already blocked by unrelated missing Apple Review demo symbols, I’m rerunning lint for touched Swift files and the gateway tests; then I’ll rerun autoreview as required after the fix.

Focused gateway tests and SwiftFormat lint are green after the autoreview fix. I’m rerunning autoreview now to confirm there are no remaining accepted/actionable findings.

The second autoreview pass is running. I’m waiting for the structured result.

Autoreview heartbeat is healthy at 60 seconds; still waiting.

The second review found the same class on the gateway side: `onError` followed by provider `onClose` could emit two error events. I’m adding a server-side `failureEmitted` guard and a test that only the actionable provider error is sent.

The gateway now tracks whether it already emitted a provider failure. I’m adding the regression test for `onError` followed by `onClose` so this doesn’t regress.

The gateway-side regression test is in. I’m rerunning the focused gateway suite and diff checks before a third autoreview pass.

Gateway tests are green again, now 136 tests with the added regression coverage. I’m rerunning autoreview once more and will stop when it returns clean.

Third autoreview pass is running. I’m waiting for the structured result.

Autoreview heartbeat is healthy at 60 seconds; continuing to wait.

The review is still running without a new finding payload. I’m giving it more time under the helper’s expected window.

Autoreview is still healthy at 120 seconds. I’m continuing to wait for completion.

Autoreview is clean now. I’m collecting final status and scope so the closeout is precise.

Implemented on new branch `improve-ios-talk-runtime-transparency`. No commit or push was made.

What changed:
- Gateway relay now emits structured Talk issue details for realtime failures: credential/model/provider/network/pre-ready close codes in `src/gateway/talk-realtime-relay.ts`.
- `talk.session.create` failures now include `details.talkIssue` so iOS can surface request-time failures like bad API keys in `src/gateway/server-methods/talk-session.ts`.
- iOS now separates configured voice mode from active runtime mode and shows fallback clearly in `apps/ios/Sources/Design/TalkProTab.swift` and settings.
- iOS preserves the actionable realtime failure when falling back to native speech/TTS, including the error-after-close sequencing fixes in `apps/ios/Sources/Voice/RealtimeTalkRelaySession.swift`.
- Added regression coverage in gateway tests and iOS Talk tests.

Verification:
- Passed: `pnpm test src/gateway/talk-realtime-relay.test.ts src/gateway/server-methods/talk.test.ts` (`136` tests).
- Passed: `swiftformat --lint` on touched iOS files.
- Passed: `git diff --check`.
- Passed: `.agents/skills/autoreview/scripts/autoreview --mode local` clean.

iOS app-target test note:
- `xcodebuild test ... OpenClawTests/TalkModeManagerTests ...` is currently blocked before Talk tests run by unrelated existing missing symbols: `AppleReviewDemoMode` and `AppleReviewDemoChatTransport`.

[user]
$codex-review

[assistant]
Using `$codex-review` as requested. Since this is still uncommitted local work, I’m running the bundled helper in local mode and disabling its broad auto-check so the review target stays on the dirty patch we already tested.

The helper exists but is not executable in this install. I’m checking the script wrapper and then I’ll run it through its interpreter rather than changing permissions unless needed.

The helper is a Bash script without the executable bit, so I’m invoking it with `bash` directly.

Codex review is still inspecting the patch. It has read the changed iOS and gateway paths and is continuing.

Codex review is still running and has not returned findings yet. I’m continuing to let it complete.

I’m continuing from the codex-review run that was already in progress. I’ll wait for its verdict, then only change code if it raises a finding that holds up against the current implementation.

The review is doing a fairly broad read, including gateway session handling and iOS runtime state. It has already run the focused gateway tests successfully from inside the review process; I’m waiting for the final findings block.

No final verdict yet. I’m keeping the review process alive rather than starting another overlapping check, since this helper shells out to Codex and can take a while on a multi-surface diff.

Still running without new stdout. If it returns actionable findings, I’ll verify them against the code before patching; otherwise I’ll close out with the clean review result and the proof that did run.

The review has been quiet for a few polling intervals, which usually means the nested reviewer is still reasoning rather than blocked on a prompt. I’m giving it more time before considering it hung.

It remains active but silent. I’m going to poll with a longer wait once; if there’s still no output, I’ll inspect whether the nested process is genuinely still doing work or stuck.

The long poll produced no new output, so I’m checking the process tree now. That will tell me whether the nested review is still consuming work or has stalled behind a child process.

There are two active `codex-review` helper trees from this checkout, likely from the interrupted/resumed turn plus the current rerun. I’m checking their activity before deciding whether to wait or rely on a fresh single run.

The active review process is still consuming CPU, so it is not hung. I’ll let that complete rather than starting a third reviewer.

Codex Review raised one actionable finding: a fast relay error during startup can be recorded and then immediately cleared by `markRealtimeActive()` before the gateway ever sends `ready`. I’m fixing that by treating relay `ready` as the only signal that makes realtime active, and by returning the captured startup issue to the fallback path.

I’m making a narrow fix in `TalkModeManager`: relay startup will no longer mark realtime active after local setup. It will only become active when the relay emits `ready`, and if an issue arrived during startup it returns `.unavailable(issue)` so the existing fallback state path can keep the reason visible.

To keep the regression covered without standing up a fake gateway socket, I’m extracting the relay status handling into a small private method and exposing it only through the existing DEBUG test surface. That lets the test prove a relay issue survives until the actual `ready` status arrives.

I’m adding the minimal test hook now, scoped to DEBUG alongside the other TalkModeManager test-only methods.

The test will cover the exact state transition behind the finding: a captured startup issue is visible while relay status is still connecting, and only a real `Listening (Realtime)` ready status clears it.

The code change is in place. I’m running formatting and the focused gateway test lane again, then I’ll rerun Codex Review because the accepted finding changed code.

Focused checks passed after the fix. I’m checking for leftover nested review processes before the required rerun, because the interrupted review left more than one helper process in the tree earlier.

No active review processes remain. I’m rerunning the helper cleanly now with auto tests disabled, since the focused proof already ran and the helper’s default full check would be too broad for this dirty iOS/gateway patch.

The rerun is active and reading the updated diff. I’ll wait for its final findings before making any more changes.

The rerun is looking at the relay start path now. One thing I’m watching closely is that `RealtimeTalkRelaySession.start()` currently emits a local “Listening (Realtime)” after microphone setup; if the reviewer flags that as still pre-ready, I’ll adjust that status source rather than broadening the state machine.

The reviewer has inspected the shared gateway request error path and the full relay lifecycle. I’m still waiting for the verdict; no change will be made until it returns.

The review is still active. It is checking two likely edge paths: request-time gateway error details and relay cleanup after a pre-ready failure. I’ll keep the rerun single-threaded and wait for the final output.

The rerun found a real stale-state bug: after a healthy relay closes, the new “Active now” field can keep showing realtime. I’m fixing that and also tightening the related readiness signal so only the gateway `ready` event marks relay realtime as active.

Now I’m clearing both the visible active state and the closed relay object when the relay reports `Ready` after a close, so the next start cannot mistake a closed relay for an active one.

I’m extending the iOS state test to cover the close path Codex flagged: active realtime after `Listening (Realtime)`, then inactive after `Ready`.

The accepted finding is patched. I’m rerunning the same focused checks, then I’ll rerun Codex Review again as required.

The focused checks are green again. I’m starting the final Codex Review rerun; if this one exits cleanly, I’ll stop there per the skill contract.

The final rerun is still active. It has reviewed the updated close-state handling and relay readiness path; I’m waiting for the final clean-or-findings line.

The latest finding is also valid: I reused `pendingRealtimeIssue` both as “last fallback reason” and “this relay attempt failed,” so a retry could inherit an old failure. I’m separating the per-attempt relay issue from the displayed last issue, while preserving the UI detail from the earlier fallback.

The first patch context was stale because the descriptor initializer had a different local shape. I’ve read the current lines and am applying the same fix against the actual file.

I’m adding a tiny helper for the retry preparation so the behavior is explicit and testable: clear the retry-only issue, clear the fallback trigger, but keep the displayed last issue text.

I’m wiring the helper into the DEBUG test surface and adding a regression for stale fallback issues blocking retry.

The regression keeps the visible “last issue” text intact but proves the retry trigger is no longer stale.

The stale retry issue is patched. I’m rerunning formatting, diff check, and the focused gateway tests before another review pass.

Focused checks are green after the retry fix. I’m rerunning Codex Review again; this has to end clean before I hand off.

The review is running through the updated retry path. It has not returned findings yet; I’m waiting for the final helper result.

The reviewer is right: returning `.started` before the provider `ready` event still bypasses fallback for async bridge failures. I’m changing relay startup to wait for `ready`, a classified pre-ready error/close, or a bounded startup timeout before `startRealtimeRelayIfAvailable()` reports success.

Continuing from the review loop. I’m going to finish the last accepted finding first: the relay startup path now waits for gateway readiness, but the manager still needs to preserve the structured issue captured during that wait.

The branch is already in place with only the intended files modified. I found the exact manager catch path that can still throw away the startup issue; I’m patching that narrowly now.

There are no scoped iOS instructions under `apps/ios`. I’m also checking the gateway scoped guides before final review because this change touches `src/gateway` and a server-method subdirectory.

The gateway guide doesn’t add any extra constraints for this patch beyond using the focused gateway tests, which are already the right proof path. I’m applying the manager fix now.

The structured relay issue is now preserved through the thrown startup path, so native fallback should receive the real reason instead of a generic start error. I’m running the focused formatting and test proof next.

Focused gateway tests and Swift formatting are green. I’m doing a whitespace diff check, then I’ll rerun the local Codex review pass to verify the accepted finding is actually closed.

The diff check passed. I’m using the `codex-review` skill now and disabling its broad auto-test hook so it reviews the actual dirty branch without kicking off a repo-wide check.

The review is still running. One thing visible in the streamed diff is a duplicate `code` field in a gateway payload helper; I’ll wait for the review to finish, then fix that along with any accepted findings it reports.

The review is digging through the gateway event subscription path now. So far it verified the duplicate `code` field is not present in the actual file, only an artifact of the earlier streamed diff, so there’s nothing to patch there.

The reviewer is now checking lifecycle interactions around start/stop and subscriptions. I’m letting it finish so we have a complete accepted/rejected finding list instead of pre-empting with partial output.

The nested review reran the focused gateway tests itself as part of its verification path; they passed again. It has started the final review command and is still active.

No new output yet; the final nested review process is still running.

The review found a real race: the readiness wait subscribes after `talk.session.create`, while gateway events are not replayed. I’m fixing it by registering the event stream before creating the relay session, then starting the pump only after the returned relay id is known so buffered events are filtered correctly.

The subscription now exists before the gateway can emit `ready`/`error`, while the event pump still starts after `relaySessionId` is set. I’m rerunning the focused proof and then the review.

Formatting, focused gateway tests, and diff whitespace are green after the race fix. I’m rerunning Codex review now; if it comes back clean I’ll stop there per the review skill contract.

The review is running again and has the race fix in its diff. I’m waiting for the final accepted/rejected finding list.

The review is still inspecting lifecycle and gateway request details. No accepted finding has been emitted yet in this pass.

The review is still active. It is spending time validating the Swift gateway error propagation and event stream behavior; I’ll keep polling until it exits.

Still running. The current pass has not produced a new accepted finding in the visible output; it is validating against provider `onReady` contracts and stop/reset behavior.

The helper has reached its final nested `codex review --uncommitted` call again. I’m waiting for that to finish; no code edits while it’s still running.

No new output yet; final nested review is still running.

Still waiting on the nested review process.

The review process is taking longer than the previous pass, but it is still alive and producing no findings yet.

Still running. I’m not starting any parallel commands against the worktree while the review owns it.

No output yet from the nested review. I’m giving it more time rather than interrupting, since the review skill asks for the clean helper result.

The second review found another real lifecycle bug: an intentional stop while startup is waiting can leave the timeout armed and later report a fake realtime failure. I’m fixing the close path to complete the startup wait as cancelled, so stop/pause cannot mutate the UI afterward.

The close path now resumes any pending startup wait as `cancelled`, and the timeout explicitly no-ops once closed. I’m rerunning the focused proof before another review pass.

Focused proof is green after the cancellation fix. I’m rerunning Codex review again and will continue only if it reports another accepted finding.

The latest review pass is running and currently reading the diff and tests. I’m waiting for the final result.

The review is validating the gateway protocol schema around the new structured issue details. Still no final accepted finding in this pass yet.

The review is now down in the Talk event controller and relay emission helper. Still waiting for completion.

The review has again reached its nested `codex review --uncommitted` verification step. Waiting for the result.

No output yet from the final nested review.

Still waiting on the nested review.

The nested review emitted a very large search result while checking `session.error` consumers; it is still running.

No new output; still waiting for the review closeout.

The review process is still active with no new output.

The next finding is also valid: subscribing before create fixed the event race but left no owner to cancel the stream if `talk.session.create` itself fails. I’m changing that shape so the event pump owns the stream immediately, buffers pre-id events locally, and then replays them after the relay id is known. That keeps the race fix without leaking subscriptions.

I’m moving `createRelaySession()` inside the cleanup `do/catch` and starting the pump immediately after subscription. Pre-id events get buffered instead of processed, then drained once `relaySessionId` exists and the local audio path is ready.

The event subscription now has an owning task even if create fails, and early events are bounded to the same 200-event window as the stream. I’m rerunning formatting, focused gateway tests, and diff checks.

Focused checks are green after the subscription ownership fix. I’m rerunning Codex review again.

The review is running with the revised event-pump ownership model. It is still reading the core start paths and has not emitted a finding yet.

The review has started checking the new pre-relay event buffering against the tests. I’m waiting for the final verdict.

The nested reviewer tried a Vitest `--runInBand` flag, which this repo’s Vitest rejects; it then started the correct focused `pnpm test` command. I’m waiting for the review result rather than treating that internal attempt as our verification.

The review caught that the Swift relay event test no longer reaches the event branch because pre-id events are now buffered. I’m adding a narrow test hook to seed the relay id and updating that test.

The test now seeds `relaySessionId` before dispatching synthetic relay events, so it exercises the classified-error path instead of the pre-id buffer. I’m rerunning the focused checks.

Checks are green after the test fix. I’m rerunning Codex review; this is the closeout gate now.

I’m continuing from the review pass after the latest relay test hook fix. I’ll rerun the Codex review helper now and only close out once any accepted findings are handled.

The review is still running. It has already dug into the relay startup path, so I’m waiting for the actual findings rather than reacting to partial output.

The nested reviewer is checking the current uncommitted diff directly now. I’m watching specifically for findings it accepts so I can verify them against the code before editing.

Still waiting on the review command. No final finding output yet.

The review is still active and quiet, which usually means the reviewer is in the final diff pass. I’ll let it finish rather than interrupt and lose the result.

The helper has been running for a few minutes with no new output. I’m keeping the session open until it exits so we have a valid clean-or-findings result.

Codex review completed clean with no accepted/actionable findings. I’m doing one final status check so the closeout accurately reflects the branch and dirty files.

Implemented on branch `improve-ios-talk-runtime-transparency`. Changes are uncommitted and not pushed.

What changed:
- iOS Talk now distinguishes configured mode vs active mode in `apps/ios/Sources/Design/TalkProTab.swift` and Settings.
- Realtime gateway relay failures now surface structured issue text instead of silently falling back.
- iOS fallback now shows `iOS Speech fallback` plus the last realtime/gateway issue.
- Gateway realtime relay now emits classified failures like invalid credentials, missing credentials, unavailable model/provider, network errors, and provider closed before ready.
- Relay startup now waits for provider readiness before marking realtime active, so immediate socket/API-key failures fall back clearly.

Review/proof:
- `CODEX_REVIEW_AUTO_TESTS=0 bash [HOME_PATH] --mode local`
  - Result: clean, no accepted/actionable findings.
  - Final findings accepted: none.
  - Final findings rejected: none.
- `pnpm test src/gateway/talk-realtime-relay.test.ts src/gateway/server-methods/talk.test.ts`
- `swiftformat --lint --config config/swiftformat ...`
- `git diff --check`

One proof gap: direct `xcodebuild` iOS app-target tests are still blocked by unrelated existing symbols `AppleReviewDemoMode` / `AppleReviewDemoChatTransport`. The focused gateway tests and Swift formatting checks passed.

[user]
run on my phone
how would I test this?

[assistant]
I’ll try to install/run the iOS app on the connected device first, then I’ll give you a concrete manual test script for the new Talk failure states.

I found the paired physical device: `Nimrod’s iPhone` (`iPhone 16 Pro`). I’m going to build the Debug app for that device and install/launch it with `devicectl`; the repo’s `ios:run` script is simulator-oriented, so I’ll use the physical-device path directly.

Signing and version config are prepared. Next I’m regenerating the Xcode project, then I’ll build against the phone’s device id.

The project regenerated cleanly. I’m starting the device build now; if it hits the known unrelated Apple review demo compile issue, I’ll report that clearly instead of masking it.

The device build is still running and compiling dependencies/extensions for `iphoneos`. I’ll poll until it either produces the app bundle or fails with actionable diagnostics.

The physical-device build succeeded. I’m installing the generated `OpenClaw.app` onto the paired iPhone and launching it.

The app installed successfully, but iOS refused the launch because the phone is locked. Please unlock `Nimrod’s iPhone` and leave it on the home screen; I’ll retry the launch.

It’s still locked from `devicectl`’s perspective. The build is installed, so once the phone is unlocked I can launch it remotely, or you can tap the OpenClaw icon directly.

The device is connected now; I’m retrying launch once more.

The phone disconnected during the launch request. I’ll check whether it came back before I stop; the app is already installed even if remote launch is flaky.

The phone is back to paired/available, not actively connected. I’m going to stop retrying remote launch for now because the install succeeded; you can open the newly installed local build from the phone.

I’m checking the worktree once after the phone build because Xcode generation/build scripts can touch generated files; I want the handoff to be precise.

Built and installed the Debug app on `Nimrod’s iPhone`.

Bundle installed: `ai.openclaw.ios.test.guti-gzs353x62e`

Remote launch did not complete because the phone was locked first, then the device disconnected during the retry. The app is installed, so open it from the phone. If you unlock it and want me to retry remote launch, I can.

How to test this:

1. Start with a valid realtime gateway config.
   - Pair/connect the iPhone to the gateway.
   - Open Talk.
   - Expected: the card shows `Configured` as the selected gateway voice mode.
   - Start Talk.
   - Expected: `Active now` becomes the realtime mode, status is `Listening (Realtime)`, and `Last issue` is empty.

2. Test bad API key / immediate realtime failure.
   - Put an invalid or missing OpenAI API key in the gateway realtime config.
   - Restart/reload the gateway if needed.
   - Reconnect the iPhone, open Talk, start Talk.
   - Expected: app falls back to native iOS Speech/TTS.
   - Expected UI:
     - `Configured`: OpenAI realtime/gateway relay
     - `Active now`: `iOS Speech fallback`
     - `Last issue`: credential/missing-key style diagnostic
     - status: `Listening (iOS Speech fallback)`

3. Test bad realtime model.
   - Configure a bogus realtime model.
   - Start Talk.
   - Expected: fallback to `iOS Speech fallback`, with `Last issue` showing model/provider failure detail.

4. Test recovery.
   - Restore a valid API key/model.
   - Restart/reload gateway, reconnect app, start Talk again.
   - Expected: realtime becomes active; stale fallback issue should not block retry, and successful realtime clears `Last issue`.

You can also verify the same fields in Settings under the Talk/Gateway voice section: `Active Voice` and `Last Voice Issue`.

[user]
can we make the fallback clearer with a small banner like we have when the gateway connection is not working? spec and plan

[assistant]
I’ll look at the existing gateway connection problem banner/component first so the plan fits the current iOS design instead of inventing a parallel warning style.

Yes. I’d make the fallback state a first-class scoped warning, not just a row in the Voice mode card.

**Spec**
Add a Talk-only banner shown when configured realtime/gateway relay is unavailable and the app is currently using native iOS Speech/TTS fallback.

Placement:
- In `TalkProTab`, directly under the Talk header and above the hero card.
- In Settings, keep the current `Last Voice Issue` row, but optionally add the same compact banner at the top of the Talk/Gateway voice section if fallback is active.

Copy:
- Title: `Using iOS Speech fallback`
- Message: `Realtime voice is unavailable. Talk is still running with iOS speech recognition and TTS.`
- Detail text from `TalkRuntimeIssue.displayMessage`, for example:
  - `OpenAI API key is invalid or missing.`
  - `Realtime closed before it became ready.`
  - `Configured realtime model is unavailable.`
- Owner label: `Fix on gateway` for credential/model/provider/config issues, `Check network` for network/socket issues.

Actions:
- Primary: `Open Settings`
  - Opens Voice & Talk settings / gateway voice config surface.
- Secondary: `Details`
  - Shows diagnostic summary: provider, model, transport, phase, issue code, message.
- Optional later: `Retry realtime`
  - Only when Talk is still enabled and gateway is connected. Internally restart the Talk runtime, but not needed for v1.

Behavior:
- Banner appears when `gatewayTalkActiveModeTitle == "iOS Speech fallback"` or a stronger explicit `gatewayTalkFallbackIssue` exists.
- Banner clears when realtime successfully becomes active.
- Banner clears when Talk is stopped.
- Banner does not appear for normal native iOS Speech + TTS mode when that was the configured mode.
- Banner should not replace the existing gateway connection banner; if gateway is offline, the gateway banner remains the primary problem.

**Implementation Plan**
1. Add a dedicated `TalkRuntimeIssueBanner` SwiftUI component, modeled visually after `GatewayProblemBanner` in `apps/ios/Sources/Gateway/GatewayProblemView.swift`, but smaller and scoped to Talk.

2. Extend `TalkRuntimeIssue` with UI metadata:
   - `bannerTitle`
   - `ownerLabel`
   - `tint`
   - maybe `technicalDetails`
   Keep classification in `apps/ios/Sources/Voice/TalkModeGatewayConfig.swift`.

3. Expose a structured current fallback issue from `TalkModeManager`, not only `gatewayTalkLastIssueText`.
   - Current text is fine for rows, but the banner/details sheet should avoid reparsing strings.
   - Example: `gatewayTalkCurrentFallbackIssue: TalkRuntimeIssue?`.

4. Render the banner in `TalkProTab`.
   - Place between `header` and `voiceHeroCard`.
   - Use `Open Settings` for the primary action.
   - Add a local `@State showTalkIssueDetails`.

5. Add `TalkRuntimeIssueDetailsSheet`.
   - Keep it simpler than gateway connection details.
   - Include issue message, configured provider/model, transport, phase, and code.
   - Add copyable diagnostic text if useful.

6. Tests:
   - Swift unit test that fallback issue produces banner-visible state.
   - Swift unit test that successful realtime clears the fallback issue.
   - Existing gateway tests remain unchanged.
   - Manual phone test: bad API key should show banner plus active fallback; valid API key should remove banner.

[user]
let's do that

[assistant]
I’ll implement this as a Talk-scoped banner and details sheet, reusing the existing gateway problem visual language but keeping the state owned by `TalkModeManager`. After edits I’ll run Swift formatting/lint and a device build if feasible.

I found the existing gateway banner and the current Talk UI. I’ll add a small reusable Talk issue banner component under `apps/ios/Sources/Gateway` or `Design`, then wire it to a structured fallback issue on the manager instead of only the diagnostic string.

I’m going to keep the structured issue as optional manager state named `gatewayTalkCurrentFallbackIssue`. That makes the banner only appear for real fallback, while `gatewayTalkLastIssueText` can stay as historical/diagnostic text in the rows.

Next I’m wiring that issue state into the manager so the UI can tell “fallback active now” apart from “there was an earlier realtime issue.”

I’m adding the banner/details views now. They reuse the same material, border, icon, and small action-button pattern as the gateway banner, but with Talk-specific copy and diagnostics.

I’m placing the banner above the Talk hero and hiding it when the gateway itself is offline, so the global gateway problem banner remains the top-level failure indicator.

I’m also adding the same compact banner to the Settings Talk voice card, since that’s where someone will naturally go after tapping “Open Settings.”

I’m adding a second details sheet state in Settings and using the same Talk fallback details sheet there.

The Settings view already has multiple sheets for gateway details and QR scanning, so I’m following that pattern rather than introducing a generic sheet router for this small addition.

To avoid nesting a card-like banner inside the Settings card, I’m making it a sibling immediately above the Talk voice settings card.

I’ll gate the Settings banner on the same gateway-connected check used by Settings status, so an offline gateway still points users to the connection problem first.

I’m extending the focused Talk tests to lock the banner state: fallback sets a structured current issue, realtime success clears it, and retry preparation clears stale fallback state.

The implementation and tests are in place. I’m formatting the touched Swift files before running focused checks.

Formatting passed. I’m regenerating the iOS project so the new Swift file is included, then I’ll run the same physical-device Debug build path.

The Xcode project regenerated cleanly. I’m running a device build now to catch SwiftUI or symbol issues in the new banner.

The updated app builds successfully for the physical iPhone. I’m installing this new build onto the phone now.

The new build is installed. I’m going to try the focused Talk unit tests on the device; if the phone is locked or test launching is denied, I’ll report that as a device-state blocker rather than treating it as a code failure.

The device build passed and install passed. The focused test build exposed an existing test compile issue in `RealtimeTalkRelaySessionTests`: it references `EventFrame` without importing the module that defines it. I’ll fix that now because it blocks the Talk test target.

That test compile blocker was just a missing `OpenClawProtocol` import. I’ve added it and will rerun formatting plus the focused Talk test command.

The focused Talk manager tests now pass on the iPhone

...[transcript truncated to 50000 chars]
````

</details>
<!-- agent-transcript:end -->

