### PR TITLE
fix(ui): show prompt progress while sending

### DIFF
--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -1268,12 +1268,13 @@ describe("chat loading skeleton", () => {
   });
 
   it("keeps terminal status for the submitted run while its acknowledgement is pending", () => {
+    const occurredAt = Date.now();
     const container = renderChatView({
       runStatus: {
         phase: "done",
         runId: "run-main",
         sessionKey: "main",
-        occurredAt: 1_000,
+        occurredAt,
       },
       queue: [
         {

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -1184,6 +1184,15 @@ describe("chat loading skeleton", () => {
     expect(container.querySelectorAll(".chat-reading-indicator")).toHaveLength(1);
   });
 
+  it("shows prompt-bar progress while a submitted prompt is awaiting acknowledgement", () => {
+    const container = renderChatView({ sending: true });
+
+    const status = container.querySelector(".agent-chat__run-status--in-progress");
+    expect(status).toBeInstanceOf(HTMLElement);
+    expect(status?.textContent).toContain("In progress");
+    expect(status?.closest(".agent-chat__toolbar-left")).not.toBeNull();
+  });
+
   it("lets terminal run status win over stale abortable session UI", () => {
     const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1_000);
     try {

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -1184,13 +1184,80 @@ describe("chat loading skeleton", () => {
     expect(container.querySelectorAll(".chat-reading-indicator")).toHaveLength(1);
   });
 
-  it("shows prompt-bar progress while a submitted prompt is awaiting acknowledgement", () => {
-    const container = renderChatView({ sending: true });
+  it("shows prompt-bar progress while the current session send is awaiting acknowledgement", () => {
+    const container = renderChatView({
+      sending: true,
+      queue: [
+        {
+          id: "send-main",
+          text: "hello",
+          createdAt: 1,
+          sendRunId: "run-main",
+          sendState: "sending",
+          sessionKey: "main",
+        },
+      ],
+    });
 
     const status = container.querySelector(".agent-chat__run-status--in-progress");
     expect(status).toBeInstanceOf(HTMLElement);
     expect(status?.textContent).toContain("In progress");
     expect(status?.closest(".agent-chat__toolbar-left")).not.toBeNull();
+  });
+
+  it("does not show prompt-bar progress for another session send", () => {
+    const container = renderChatView({
+      sessionKey: "session-b",
+      sending: true,
+      queue: [
+        {
+          id: "send-a",
+          text: "hello from A",
+          createdAt: 1,
+          sendRunId: "run-a",
+          sendState: "sending",
+          sessionKey: "session-a",
+        },
+      ],
+    });
+
+    expect(container.querySelector(".agent-chat__run-status--in-progress")).toBeNull();
+  });
+
+  it("shows prompt-bar progress while the current session send waits for model switching", () => {
+    const container = renderChatView({
+      queue: [
+        {
+          id: "send-main",
+          text: "hello",
+          createdAt: 1,
+          sendRunId: "run-main",
+          sendState: "waiting-model",
+          sessionKey: "main",
+        },
+      ],
+    });
+
+    const status = container.querySelector(".agent-chat__run-status--in-progress");
+    expect(status).toBeInstanceOf(HTMLElement);
+    expect(status?.textContent).toContain("In progress");
+  });
+
+  it("does not show prompt-bar progress for reconnect-waiting sends", () => {
+    const container = renderChatView({
+      queue: [
+        {
+          id: "send-main",
+          text: "hello",
+          createdAt: 1,
+          sendRunId: "run-main",
+          sendState: "waiting-reconnect",
+          sessionKey: "main",
+        },
+      ],
+    });
+
+    expect(container.querySelector(".agent-chat__run-status--in-progress")).toBeNull();
   });
 
   it("lets terminal run status win over stale abortable session UI", () => {

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -1243,6 +1243,30 @@ describe("chat loading skeleton", () => {
     expect(status?.textContent).toContain("In progress");
   });
 
+  it("shows newer model-switch progress over the previous run's terminal status", () => {
+    const container = renderChatView({
+      runStatus: {
+        phase: "done",
+        runId: "run-previous",
+        sessionKey: "main",
+        occurredAt: 1_000,
+      },
+      queue: [
+        {
+          id: "send-main",
+          text: "hello",
+          createdAt: 1_001,
+          sendRunId: "run-main",
+          sendState: "waiting-model",
+          sessionKey: "main",
+        },
+      ],
+    });
+
+    expect(container.querySelector(".agent-chat__run-status--in-progress")).not.toBeNull();
+    expect(container.querySelector(".agent-chat__run-status--done")).toBeNull();
+  });
+
   it("does not show prompt-bar progress for reconnect-waiting sends", () => {
     const container = renderChatView({
       queue: [

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -1243,7 +1243,7 @@ describe("chat loading skeleton", () => {
     expect(status?.textContent).toContain("In progress");
   });
 
-  it("shows newer model-switch progress over the previous run's terminal status", () => {
+  it("shows active model-switch progress over the previous run's terminal status", () => {
     const container = renderChatView({
       runStatus: {
         phase: "done",
@@ -1255,7 +1255,7 @@ describe("chat loading skeleton", () => {
         {
           id: "send-main",
           text: "hello",
-          createdAt: 1_001,
+          createdAt: 999,
           sendRunId: "run-main",
           sendState: "waiting-model",
           sessionKey: "main",

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -1267,6 +1267,30 @@ describe("chat loading skeleton", () => {
     expect(container.querySelector(".agent-chat__run-status--done")).toBeNull();
   });
 
+  it("keeps terminal status for the submitted run while its acknowledgement is pending", () => {
+    const container = renderChatView({
+      runStatus: {
+        phase: "done",
+        runId: "run-main",
+        sessionKey: "main",
+        occurredAt: 1_000,
+      },
+      queue: [
+        {
+          id: "send-main",
+          text: "hello",
+          createdAt: 999,
+          sendRunId: "run-main",
+          sendState: "sending",
+          sessionKey: "main",
+        },
+      ],
+    });
+
+    expect(container.querySelector(".agent-chat__run-status--done")).not.toBeNull();
+    expect(container.querySelector(".agent-chat__run-status--in-progress")).toBeNull();
+  });
+
   it("does not show prompt-bar progress for reconnect-waiting sends", () => {
     const container = renderChatView({
       queue: [

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -1569,8 +1569,13 @@ export function renderChat(props: ChatProps) {
   const canCompose = props.connected;
   const isBusy = props.sending || props.stream !== null;
   const canAbort = Boolean(props.canAbort && props.onAbort);
-  const showAbortableUi = canAbort && !hasTerminalRunStatus(props.runStatus);
-  const composerRunStatus = showAbortableUi ? { phase: "in-progress" as const } : props.runStatus;
+  const hasTerminalStatus = hasTerminalRunStatus(props.runStatus);
+  const showAbortableUi = canAbort && !hasTerminalStatus;
+  const showSubmittedProgressUi = props.sending && !hasTerminalStatus;
+  const composerRunStatus =
+    showAbortableUi || showSubmittedProgressUi
+      ? { phase: "in-progress" as const }
+      : props.runStatus;
   const compactBusy =
     props.compactionStatus?.phase === "active" || props.compactionStatus?.phase === "retrying";
   const activeSession = props.sessions?.sessions?.find((row) => row.key === props.sessionKey);

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -86,6 +86,14 @@ function hasTerminalRunStatus(status: ChatRunUiStatus | null | undefined): boole
   return status?.phase === "done" || status?.phase === "interrupted";
 }
 
+function isCurrentSessionSubmittedProgress(item: ChatQueueItem, sessionKey: string): boolean {
+  return (
+    item.sessionKey === sessionKey &&
+    !item.pendingRunId &&
+    (item.sendState === "sending" || item.sendState === "waiting-model")
+  );
+}
+
 export type ChatProps = {
   sessionKey: string;
   onSessionKeyChange: (next: string) => void;
@@ -1571,7 +1579,9 @@ export function renderChat(props: ChatProps) {
   const canAbort = Boolean(props.canAbort && props.onAbort);
   const hasTerminalStatus = hasTerminalRunStatus(props.runStatus);
   const showAbortableUi = canAbort && !hasTerminalStatus;
-  const showSubmittedProgressUi = props.sending && !hasTerminalStatus;
+  const showSubmittedProgressUi =
+    props.queue.some((item) => isCurrentSessionSubmittedProgress(item, props.sessionKey)) &&
+    !hasTerminalStatus;
   const composerRunStatus =
     showAbortableUi || showSubmittedProgressUi
       ? { phase: "in-progress" as const }

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -94,6 +94,13 @@ function isCurrentSessionSubmittedProgress(item: ChatQueueItem, sessionKey: stri
   );
 }
 
+function isNewerThanTerminalStatus(
+  item: ChatQueueItem,
+  status: ChatRunUiStatus | null | undefined,
+): boolean {
+  return !hasTerminalRunStatus(status) || item.createdAt > status.occurredAt;
+}
+
 export type ChatProps = {
   sessionKey: string;
   onSessionKeyChange: (next: string) => void;
@@ -1579,9 +1586,11 @@ export function renderChat(props: ChatProps) {
   const canAbort = Boolean(props.canAbort && props.onAbort);
   const hasTerminalStatus = hasTerminalRunStatus(props.runStatus);
   const showAbortableUi = canAbort && !hasTerminalStatus;
-  const showSubmittedProgressUi =
-    props.queue.some((item) => isCurrentSessionSubmittedProgress(item, props.sessionKey)) &&
-    !hasTerminalStatus;
+  const showSubmittedProgressUi = props.queue.some(
+    (item) =>
+      isCurrentSessionSubmittedProgress(item, props.sessionKey) &&
+      isNewerThanTerminalStatus(item, props.runStatus),
+  );
   const composerRunStatus =
     showAbortableUi || showSubmittedProgressUi
       ? { phase: "in-progress" as const }

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -86,11 +86,16 @@ function hasTerminalRunStatus(status: ChatRunUiStatus | null | undefined): boole
   return status?.phase === "done" || status?.phase === "interrupted";
 }
 
-function isCurrentSessionSubmittedProgress(item: ChatQueueItem, sessionKey: string): boolean {
+function isCurrentSessionSubmittedProgress(
+  item: ChatQueueItem,
+  sessionKey: string,
+  status: ChatRunUiStatus | null | undefined,
+): boolean {
   return (
     item.sessionKey === sessionKey &&
     !item.pendingRunId &&
-    (item.sendState === "sending" || item.sendState === "waiting-model")
+    (item.sendState === "sending" || item.sendState === "waiting-model") &&
+    (!hasTerminalRunStatus(status) || item.sendRunId !== status.runId)
   );
 }
 
@@ -1580,7 +1585,7 @@ export function renderChat(props: ChatProps) {
   const hasTerminalStatus = hasTerminalRunStatus(props.runStatus);
   const showAbortableUi = canAbort && !hasTerminalStatus;
   const showSubmittedProgressUi = props.queue.some((item) =>
-    isCurrentSessionSubmittedProgress(item, props.sessionKey),
+    isCurrentSessionSubmittedProgress(item, props.sessionKey, props.runStatus),
   );
   const composerRunStatus =
     showAbortableUi || showSubmittedProgressUi

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -94,13 +94,6 @@ function isCurrentSessionSubmittedProgress(item: ChatQueueItem, sessionKey: stri
   );
 }
 
-function isNewerThanTerminalStatus(
-  item: ChatQueueItem,
-  status: ChatRunUiStatus | null | undefined,
-): boolean {
-  return !hasTerminalRunStatus(status) || item.createdAt > status.occurredAt;
-}
-
 export type ChatProps = {
   sessionKey: string;
   onSessionKeyChange: (next: string) => void;
@@ -1586,10 +1579,8 @@ export function renderChat(props: ChatProps) {
   const canAbort = Boolean(props.canAbort && props.onAbort);
   const hasTerminalStatus = hasTerminalRunStatus(props.runStatus);
   const showAbortableUi = canAbort && !hasTerminalStatus;
-  const showSubmittedProgressUi = props.queue.some(
-    (item) =>
-      isCurrentSessionSubmittedProgress(item, props.sessionKey) &&
-      isNewerThanTerminalStatus(item, props.runStatus),
+  const showSubmittedProgressUi = props.queue.some((item) =>
+    isCurrentSessionSubmittedProgress(item, props.sessionKey),
   );
   const composerRunStatus =
     showAbortableUi || showSubmittedProgressUi


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- The prompt-bar progress indicator now follows the visible session's queued send lifecycle instead of the host-global sending flag.
- A send in another session no longer makes the current session composer show `In progress`.
- Current-session sends that are waiting for a model switch now show `In progress`, while reconnect-waiting sends remain excluded.

Why does this matter now?

- The original issue is about immediate user feedback after submitting a prompt, but using a global send flag can show that feedback in the wrong session.
- Model switching is still a submitted-prompt wait state, so leaving it blank makes the composer look idle while the user is waiting for OpenClaw to continue.

What is the intended outcome?

- The composer shows `In progress` only for the current session's submitted prompt while it is `sending` or `waiting-model` and has not yet become a run.
- Abortability remains driven by the existing abort state, so this does not make reconnect-waiting sends look model-active.

What is intentionally out of scope?

- No changes to send queue ownership, session switching, reconnect retry behavior, abort handling, or model-switch scheduling.

What does success look like?

- Current-session `sending` and `waiting-model` queue items surface prompt-bar progress.
- Other-session sends and current-session `waiting-reconnect` queue items do not surface prompt-bar progress.

What should reviewers focus on?

- Whether `props.queue` is the right current-session source of truth for this composer indicator.
- Whether the state boundary intentionally includes `sending` / `waiting-model` and excludes `waiting-reconnect` / already-admitted runs.

Architecture / source-of-truth check

- `props.sending` is still used for host busy/compose state, but not as the prompt-bar progress source because it is host-global.
- The prompt-bar progress predicate now reads the visible `props.queue`, matches `item.sessionKey` to `props.sessionKey`, and ignores items that already have a `pendingRunId`.

Patch quality notes

- The production change is limited to the composer status predicate in `ui/src/ui/views/chat.ts`.
- Regression coverage is limited to the reviewer-reported session/state boundaries in `ui/src/ui/views/chat.test.ts`.

## Linked context

Which issue does this close?

Closes #91199

Which issues, PRs, or discussions are related?

Related #91215

Was this requested by a maintainer or owner?

- This update addresses reviewer feedback on #91215 about session scoping and the `waiting-model` / `waiting-reconnect` state boundary.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Prompt-bar progress for a submitted prompt is now scoped to the current visible session and to the submitted-prompt lifecycle states that should look active.
- Real environment tested: Local Control UI opened in Chromium through the repository's Playwright/Vite browser harness with a Gateway protocol harness; no external model provider call was needed for this UI-state proof.
- Exact steps or command run after this patch:
  - Opened `/chat` in Chromium from the local Control UI dev server.
  - Submitted a prompt in Session A while the `chat.send` response was held, then switched to Session B before the response was released.
  - Started a model override save, submitted a prompt while that save was still pending, and observed the model-wait queue state before any `chat.send` request was sent.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Runtime log excerpt from the Chromium Control UI run:

  ```text
  Control UI browser proof opened local Control UI /chat page
  cross-session proof: deferred chat.send requests=1; Session A toolbar status=["\n      \n    \n      \n      \n      \n      \n      \n      \n      \n      \n    \n  In progress\n    "]; Session B toolbar status=[]
  waiting-model proof: chat.send before model save=0; toolbar status=["\n      \n    \n      \n      \n      \n      \n      \n      \n      \n      \n    \n  In progress\n    "]; queue label="Waiting for model"
  Control UI browser proof completed: prompt-bar progress is session-scoped and includes waiting-model.
  ```
- Observed result after fix: While Session A's send was still in flight, Session A showed `In progress` and Session B did not; while a model override save was pending, the prompt stayed queued as `Waiting for model`, no `chat.send` had been sent yet, and the prompt bar showed `In progress`.
- What was not tested: I did not run an external model/provider completion because the changed behavior is the browser composer state before or around the send request.
- Proof limitations or environment constraints: The browser proof uses the repository's local Gateway protocol harness to control pre-ACK and model-save timing deterministically; it does not prove provider/network behavior.
- Before evidence (optional but encouraged): The same focused boundary coverage failed before this patch for the reviewer-reported cases: another session's send still showed `In progress`, and a current-session `waiting-model` send did not show `In progress`.

## Tests and validation

Which commands did you run?

- Browser proof: local Control UI in Chromium with controlled `chat.send` and model-save timing.
- `node scripts/run-vitest.mjs run ui/src/ui/views/chat.test.ts -t "prompt-bar progress"`
- `node scripts/run-vitest.mjs run ui/src/ui/views/chat.test.ts`
- `./node_modules/.bin/oxlint ui/src/ui/views/chat.ts ui/src/ui/views/chat.test.ts`

What regression coverage was added or updated?

- Updated prompt-progress coverage to require current-session `sending` to show `In progress`.
- Added a wrong-session `sending` regression so the host-global flag cannot leak progress into another composer.
- Added a current-session `waiting-model` regression so model-switch waits keep visible progress.
- Added a `waiting-reconnect` regression so offline/reconnect waits do not look like active model progress.

What failed before this fix, if known?

- The new boundary test failed before the production change for the wrong-session leak and missing `waiting-model` progress.

If no test was added, why not?

- Tests were added for the reviewer-reported state and session boundaries.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

- The prompt bar could show progress for the wrong queued item if the session/state predicate is too broad.

How is that risk mitigated?

- The predicate requires the queued item to match the visible session, have no admitted `pendingRunId`, and be in `sending` or `waiting-model`; tests lock the wrong-session and reconnect-wait exclusions.

## Current review state

What is the next action?

- Ready for review after this update is pushed.

What is still waiting on author, maintainer, CI, or external proof?

- CI and maintainer review after push.

Which bot or reviewer comments were addressed?

- Addressed the #91215 feedback that `props.sending` is host-global and that `waiting-model` should show progress while `waiting-reconnect` should not.
