### PR TITLE
fix(google): strip provider prefix from Vertex model path

### DIFF
--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -913,6 +913,46 @@ describe("google transport stream", () => {
     expect(new Headers(guardedInit.headers).has("x-goog-api-key")).toBe(false);
   });
 
+  it("strips redundant google provider prefixes from Google Vertex model paths", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-google-vertex-prefix-"));
+    vi.stubEnv("HOME", path.join(tempDir, "home"));
+    vi.stubEnv("APPDATA", "");
+    vi.stubEnv("GOOGLE_CLOUD_PROJECT", "vertex-project");
+    vi.stubEnv("GOOGLE_CLOUD_LOCATION", "us-central1");
+    googleAuthGetAccessTokenMock.mockResolvedValueOnce("ya29.transport-token");
+    const tokenFetchMock = vi.fn();
+    guardedFetchMock.mockResolvedValueOnce(
+      buildSseResponse([
+        {
+          candidates: [{ content: { parts: [{ text: "ok" }] }, finishReason: "STOP" }],
+        },
+      ]),
+    );
+
+    const streamFn = createGoogleVertexTransportStreamFn();
+    const stream = await Promise.resolve(
+      streamFn(
+        buildGoogleVertexModel({ id: "google/gemini-3.1-pro-preview" }),
+        {
+          messages: [{ role: "user", content: "hello", timestamp: 0 }],
+        } as Parameters<typeof streamFn>[1],
+        {
+          apiKey: "gcp-vertex-credentials",
+          fetch: tokenFetchMock,
+        } as Parameters<typeof streamFn>[2],
+      ),
+    );
+    await stream.result();
+
+    // The provider prefix must be stripped from the Vertex model path, matching
+    // resolveGoogleModelPath; otherwise the id becomes models/google%2F... (404).
+    const guardedCall = requireMockCall(guardedFetchMock, 0, "guarded fetch");
+    expect(guardedCall[0]).toContain(
+      "/publishers/google/models/gemini-3.1-pro-preview:streamGenerateContent",
+    );
+    expect(guardedCall[0]).not.toContain("google%2F");
+  });
+
   it("refreshes authorized_user ADC before Google Vertex requests", async () => {
     const tempDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-google-vertex-adc-"));
     const credentialsPath = path.join(tempDir, "application_default_credentials.json");

--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -391,7 +391,9 @@ function buildGoogleVertexRequestUrl(
 ): string {
   const project = encodeURIComponent(resolveGoogleVertexProject(options));
   const location = encodeURIComponent(resolveGoogleVertexLocation(options));
-  const modelId = encodeURIComponent(model.id);
+  // Mirror resolveGoogleModelPath: strip the google/ provider prefix so a
+  // provider-qualified id does not become an invalid models/google%2F... path.
+  const modelId = encodeURIComponent(stripGoogleProviderPrefix(model.id));
   const origin = resolveGoogleVertexBaseOrigin(model, decodeURIComponent(location));
   return `${origin}/${GOOGLE_VERTEX_DEFAULT_API_VERSION}/projects/${project}/locations/${location}/publishers/google/models/${modelId}:streamGenerateContent?alt=sse`;
 }


### PR DESCRIPTION
## Summary

`buildGoogleVertexRequestUrl` (`extensions/google/transport-stream.ts`) embeds `model.id` into the Vertex request URL with only URL-encoding. A provider-qualified id such as `google/gemini-2.5-flash` therefore produces an invalid path segment:

`.../publishers/google/models/google%2Fgemini-2.5-flash:generateContent` → Vertex rejects it.

The sibling Generative-AI path, `resolveGoogleModelPath`, already strips this prefix via `stripGoogleProviderPrefix`. This mirrors that on the Vertex path (one line; the helper is already imported). Companion to #91125, which added the same strip to the Generative-AI path.

## Verification

- Regression test mirroring the existing Vertex stream test: `node scripts/run-vitest.mjs extensions/google/transport-stream.test.ts` → 64 passed.
- `oxfmt --check` / `oxlint` clean on the changed files.
- **Live Google Vertex run — see Real behavior proof below.**

## Real behavior proof

Behavior addressed: A provider-qualified Google Vertex model id (`google/gemini-2.5-flash`) built an invalid `publishers/google/models/google%2F...` request path that Vertex rejects; the prefix is now stripped so the request reaches the endpoint.

Real environment tested: Live Google Vertex AI (`us-central1`, ADC auth via `gcloud auth application-default login`; project id redacted as `<PROJECT>`). Tested both a direct REST call and OpenClaw's real `createGoogleVertexTransportStreamFn`.

Exact steps or command run after this patch:

1. Direct Vertex REST call to each path:
```
# Provider-qualified id in the path (what current main builds):
POST https://us-central1-aiplatform.googleapis.com/v1/projects/<PROJECT>/locations/us-central1/publishers/google/models/google%2Fgemini-2.5-flash:generateContent
  -> HTTP 400  { "error": { "message": "Invalid Endpoint name: projects/<PROJECT>/locations/us-central1/publishers/google/models/google%2Fgemini-2.5-flash." } }

# Prefix stripped (what this PR builds):
POST https://us-central1-aiplatform.googleapis.com/v1/projects/<PROJECT>/locations/us-central1/publishers/google/models/gemini-2.5-flash:generateContent
  -> HTTP 200  candidates[0].content.parts[0].text = "ok"
```

2. Ran the real OpenClaw transport (`createGoogleVertexTransportStreamFn`) against live Vertex with model id `google/gemini-2.5-flash`, before vs after this patch:
```
BEFORE (current main, no strip):  stream result text = ""    (request rejected -- invalid endpoint)
AFTER  (this patch):              stream result text = "ok"  (live generation)
```

Evidence after fix: the running OpenClaw Vertex transport returns a live generation ("ok") for a provider-qualified `google/`-prefixed model; the same id on current main returns empty because Vertex 400s the `google%2F` path (explicit `Invalid Endpoint name` error shown above).

Observed result after fix: the Vertex request path no longer contains `google%2F` and reaches the expected Vertex endpoint with HTTP 200; behavior now matches the Generative-AI path.

What was not tested: only a short non-streaming-shaped reply was exercised; no multi-turn or tool-call flow (out of scope for a URL-path fix).
