### PR TITLE
fix(gateway): skip deleted-agent guard for ACP harness session keys

### DIFF
--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -828,6 +828,24 @@ describe("gateway session utils", () => {
     expect(resolveDeletedAgentIdFromSessionKey(cfg, "agent:main:discord:direct:u1")).toBe("main");
   });
 
+  test("resolveDeletedAgentIdFromSessionKey ignores ACP harness session keys", () => {
+    const cfg = {
+      agents: { list: [{ id: "main", default: true }] },
+    } as OpenClawConfig;
+    expect(
+      resolveDeletedAgentIdFromSessionKey(
+        cfg,
+        "agent:claude:acp:11111111-1111-4111-8111-111111111111",
+      ),
+    ).toBeNull();
+    expect(
+      resolveDeletedAgentIdFromSessionKey(
+        cfg,
+        "agent:cursor:acp:22222222-2222-4222-8222-222222222222",
+      ),
+    ).toBeNull();
+  });
+
   test("resolveSessionStoreKey canonicalizes bare keys to default agent", () => {
     const cfg = {
       session: { mainKey: "main" },

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -846,6 +846,22 @@ describe("gateway session utils", () => {
     ).toBeNull();
   });
 
+  test("resolveDeletedAgentIdFromSessionKey rejects deleted configured ACP binding owners", () => {
+    const cfg = {
+      agents: { list: [{ id: "main", default: true }] },
+    } as OpenClawConfig;
+
+    expect(
+      resolveDeletedAgentIdFromSessionKey(
+        cfg,
+        "agent:deleted-agent:acp:binding:discord:default:feedface",
+      ),
+    ).toBe("deleted-agent");
+    expect(
+      resolveDeletedAgentIdFromSessionKey(cfg, "agent:main:acp:binding:discord:default:feedface"),
+    ).toBeNull();
+  });
+
   test("resolveSessionStoreKey canonicalizes bare keys to default agent", () => {
     const cfg = {
       session: { mainKey: "main" },

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -76,7 +76,7 @@ import {
   normalizeMainKey,
   parseAgentSessionKey,
 } from "../routing/session-key.js";
-import { isCronRunSessionKey } from "../sessions/session-key-utils.js";
+import { isAcpSessionKey, isCronRunSessionKey } from "../sessions/session-key-utils.js";
 import {
   AVATAR_MAX_BYTES,
   isAvatarDataUrl,
@@ -916,12 +916,16 @@ function resolveTranscriptUsageFallback(params: {
 /**
  * Returns the owning agent id if the session key belongs to an agent that is no
  * longer present in config (deleted). Returns null for non-agent legacy/global
- * keys, or when the owning agent still exists (#65524).
+ * keys, ACP harness session keys, or when the owning agent still exists (#65524).
  */
 export function resolveDeletedAgentIdFromSessionKey(
   cfg: OpenClawConfig,
   sessionKey: string,
 ): string | null {
+  // ACP keys use agent:<harnessId>:acp:<uuid>; harness ids are not agents.list entries.
+  if (isAcpSessionKey(sessionKey)) {
+    return null;
+  }
   const parsed = parseAgentSessionKey(sessionKey);
   if (!parsed) {
     return null;

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -922,12 +922,13 @@ export function resolveDeletedAgentIdFromSessionKey(
   cfg: OpenClawConfig,
   sessionKey: string,
 ): string | null {
-  // ACP keys use agent:<harnessId>:acp:<uuid>; harness ids are not agents.list entries.
-  if (isAcpSessionKey(sessionKey)) {
-    return null;
-  }
   const parsed = parseAgentSessionKey(sessionKey);
   if (!parsed) {
+    return null;
+  }
+  // Free ACP spawn keys use agent:<harnessId>:acp:<uuid>, but configured ACP
+  // bindings use agent:<agentId>:acp:binding:* where agentId remains the owner.
+  if (isAcpSessionKey(sessionKey) && !parsed.rest.startsWith("acp:binding:")) {
     return null;
   }
   const agentId = normalizeAgentId(parsed.agentId);

--- a/src/gateway/sessions-resolve-store.test.ts
+++ b/src/gateway/sessions-resolve-store.test.ts
@@ -248,6 +248,51 @@ describe("resolveSessionKeyFromResolveParams store canonicalization", () => {
     });
   });
 
+  it("rejects configured ACP binding sessions when their owning agent is deleted", async () => {
+    await withStateDirEnv("openclaw-sessions-resolve-acp-binding-deleted-", async () => {
+      const cfg: OpenClawConfig = {
+        agents: { list: [{ id: "main", default: true }] },
+      };
+      const acpBindingKey = "agent:deleted-agent:acp:binding:discord:default:feedface";
+      const deletedStorePath = resolveStorePath(cfg.session?.store, { agentId: "deleted-agent" });
+      await saveSessionStore(deletedStorePath, {
+        [acpBindingKey]: {
+          sessionId: "sess-acp-binding-deleted",
+          label: "deleted-binding",
+          updatedAt: freshUpdatedAt(),
+        },
+      });
+      const expected = {
+        ok: false,
+        error: {
+          code: ErrorCodes.INVALID_REQUEST,
+          message: 'Agent "deleted-agent" no longer exists in configuration',
+        },
+      };
+
+      await expect(
+        resolveSessionKeyFromResolveParams({
+          cfg,
+          p: { key: acpBindingKey },
+        }),
+      ).resolves.toEqual(expected);
+
+      await expect(
+        resolveSessionKeyFromResolveParams({
+          cfg,
+          p: { sessionId: "sess-acp-binding-deleted" },
+        }),
+      ).resolves.toEqual(expected);
+
+      await expect(
+        resolveSessionKeyFromResolveParams({
+          cfg,
+          p: { label: "deleted-binding" },
+        }),
+      ).resolves.toEqual(expected);
+    });
+  });
+
   it("rejects an explicit listed deleted main key instead of remapping to the live default main", async () => {
     await withStateDirEnv("openclaw-sessions-resolve-key-deleted-main-", async () => {
       const cfg: OpenClawConfig = {

--- a/src/gateway/sessions-resolve-store.test.ts
+++ b/src/gateway/sessions-resolve-store.test.ts
@@ -210,6 +210,44 @@ describe("resolveSessionKeyFromResolveParams store canonicalization", () => {
     });
   });
 
+  it("resolves ACP harness session keys from real stores when harness id is not in agents.list", async () => {
+    await withStateDirEnv("openclaw-sessions-resolve-acp-harness-", async () => {
+      const cfg: OpenClawConfig = {
+        agents: { list: [{ id: "main", default: true }] },
+      };
+      const acpKey = "agent:claude:acp:11111111-1111-4111-8111-111111111111";
+      const claudeStorePath = resolveStorePath(cfg.session?.store, { agentId: "claude" });
+      await saveSessionStore(claudeStorePath, {
+        [acpKey]: {
+          sessionId: "sess-acp-harness",
+          label: "claude-delegate",
+          updatedAt: freshUpdatedAt(),
+        },
+      });
+
+      await expect(
+        resolveSessionKeyFromResolveParams({
+          cfg,
+          p: { key: acpKey },
+        }),
+      ).resolves.toEqual({ ok: true, key: acpKey });
+
+      await expect(
+        resolveSessionKeyFromResolveParams({
+          cfg,
+          p: { sessionId: "sess-acp-harness" },
+        }),
+      ).resolves.toEqual({ ok: true, key: acpKey });
+
+      await expect(
+        resolveSessionKeyFromResolveParams({
+          cfg,
+          p: { label: "claude-delegate" },
+        }),
+      ).resolves.toEqual({ ok: true, key: acpKey });
+    });
+  });
+
   it("rejects an explicit listed deleted main key instead of remapping to the live default main", async () => {
     await withStateDirEnv("openclaw-sessions-resolve-key-deleted-main-", async () => {
       const cfg: OpenClawConfig = {

--- a/src/gateway/sessions-resolve.test.ts
+++ b/src/gateway/sessions-resolve.test.ts
@@ -177,6 +177,29 @@ describe("resolveSessionKeyFromResolveParams", () => {
     });
   });
 
+  it("resolves ACP harness session keys even when harness id is not in agents.list", async () => {
+    const acpKey = "agent:claude:acp:11111111-1111-4111-8111-111111111111";
+    hoisted.resolveGatewaySessionStoreTargetMock.mockReturnValue({
+      canonicalKey: acpKey,
+      storeKeys: [acpKey],
+      storePath,
+    });
+    hoisted.loadSessionStoreMock.mockReturnValue({
+      [acpKey]: { sessionId: "sess-acp", updatedAt: 1, label: "claude-delegate-test" },
+    });
+    hoisted.listAgentIdsMock.mockReturnValue(["main"]);
+
+    await expect(
+      resolveSessionKeyFromResolveParams({
+        cfg: {},
+        p: { key: acpKey },
+      }),
+    ).resolves.toEqual({
+      ok: true,
+      key: acpKey,
+    });
+  });
+
   it("rejects non-alias agent:main sessions when main is no longer configured", async () => {
     const staleMainKey = "agent:main:guildchat:direct:u1";
     hoisted.resolveGatewaySessionStoreTargetMock.mockReturnValue({


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- The deleted-agent guard added in #65524 treats ACP harness session keys like normal agent session keys.
- ACP keys use `agent:<harnessId>:acp:<uuid>` (for example `agent:claude:acp:...`), but `<harnessId>` is **not** an `agents.list` entry.
- That causes `sessions.resolve`, `sessions_send`, and other deleted-agent-guarded paths to reject valid ACP workers with `Agent "claude" no longer exists in configuration`.

Why does this matter now?

- ACP persistent/background workers are increasingly used from hub surfaces; a false deleted-agent rejection breaks follow-up routing by key or label.
- The guard is correct for real orphaned agent sessions, but it must not classify harness ids as deleted agents.

What is the intended outcome?

- `resolveDeletedAgentIdFromSessionKey` returns `null` for ACP harness session keys, so existing ACP sessions keep working while true deleted-agent protection remains for normal agent keys.
- The exemption lives in the shared helper so **all** deleted-agent guard callers benefit consistently (`sessions.resolve` key/sessionId/label paths, direct `sessions.send` / `chat.send` guards).

What is intentionally out of scope?

- No change to deleted-agent cleanup when an agent is actually removed from config.
- No ACP spawn/delegate lifecycle, label routing, protocol schema, config, or migration changes.
- No per-caller bypasses in `sessions.resolve`, `sessions.send`, or `chat.send`; no `parseAgentSessionKey` special-casing; no ACP metadata hydration gate.

What does success look like?

- `sessions.resolve({ key: "agent:claude:acp:<uuid>" })` succeeds when the session exists, even if `claude` is not in `agents.list`.
- Real deleted-agent sessions such as `agent:deleted-agent:main` are still rejected.

What should reviewers focus on?

- The early `isAcpSessionKey(sessionKey)` bypass in `resolveDeletedAgentIdFromSessionKey` (`src/gateway/session-utils.ts`) — shared owner boundary, not a single-entry workaround.
- That normal deleted-agent behavior for non-ACP keys is unchanged.
- Why alternatives were rejected: resolver-only bypass (too narrow), `parseAgentSessionKey` ACP special-case (too wide), metadata-hydration gate (heavier than needed for guard-layer false positives).

## Linked context

Which issue does this close?

Closes #

Which issues, PRs, or discussions are related?

- Related #65524 — deleted-agent guard / orphaned session rejection. This PR narrows that guard so ACP harness keys are not misclassified as deleted agents.

Was this requested by a maintainer or owner?

Local dogfood while testing ACP worker follow-up after the deleted-agent guard landed on `main`.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: valid ACP harness session keys are no longer rejected by the deleted-agent guard when the harness id (for example `claude`, `codex`) is absent from `agents.list`.
- Real environment tested: local OpenClaw install on macOS; gateway on `ws://127.0.0.1:18789`; config at `~/.openclaw/openclaw.json` with `agents.list` ids `main` and `cursor` only (no `claude`).
- Exact steps or command run after this patch:

```bash
pnpm openclaw config get agents.list --json | rg '"id"'
pnpm openclaw gateway call sessions.resolve \
  --params '{"key":"agent:claude:acp:48a22c29-5e40-474d-85a5-46234fd7d1ce"}' \
  --json
```

- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

Copied live terminal output from the local gateway RPC:

```text
$ pnpm openclaw gateway call sessions.resolve --params '{"key":"agent:claude:acp:48a22c29-5e40-474d-85a5-46234fd7d1ce"}' --json
{
  "ok": true,
  "key": "agent:claude:acp:48a22c29-5e40-474d-85a5-46234fd7d1ce"
}
```

- Observed result after fix: live `sessions.resolve` accepts the existing ACP harness session key even though `claude` is not configured in `agents.list`; no deleted-agent error is returned for this key.
- What was not tested:
  - Full `OPENCLAW_LIVE_ACP_BIND` suite.
  - Broad CI / Crabbox / cross-channel proof.
- Proof limitations or environment constraints: live proof uses an existing local ACP session store entry under `~/.openclaw/agents/claude/sessions/sessions.json`.
- Before evidence (optional but encouraged): prior dogfood observed ACP follow-up/resolution failing with deleted-agent errors when harness ids were not present in `agents.list`.

## Tests and validation

Which commands did you run?

```bash
pnpm test src/gateway/sessions-resolve-store.test.ts -t "resolves ACP harness session keys from real stores"
pnpm test src/gateway/sessions-resolve-store.test.ts
pnpm test src/gateway/session-utils.test.ts -t "resolveDeletedAgentIdFromSessionKey ignores ACP harness session keys"
pnpm test src/gateway/sessions-resolve.test.ts -t "resolves ACP harness session keys even when harness id is not in agents.list"
pnpm test src/gateway/sessions-resolve.test.ts -t "rejects sessions belonging to a deleted agent"
pnpm openclaw gateway call sessions.resolve --params '{"key":"agent:claude:acp:48a22c29-5e40-474d-85a5-46234fd7d1ce"}' --json
```

What regression coverage was added or updated?

- `src/gateway/session-utils.test.ts` — ACP harness keys bypass deleted-agent detection.
- `src/gateway/sessions-resolve.test.ts` — key-based `sessions.resolve` succeeds for ACP harness keys when harness id is not in `agents.list`.
- `src/gateway/sessions-resolve-store.test.ts` — **real store integration** for ACP key/sessionId/label resolve without mocking the deleted-agent guard.

What failed before this fix, if known?

- ACP session keys such as `agent:claude:acp:<uuid>` could be treated as belonging to deleted agent `claude`, causing resolver/send paths to fail even though the ACP session store entry existed.

If no test was added, why not?

N/A — regression tests were added for helper, resolver path, and store integration.

## Risk checklist

Did user-visible behavior change? (`Yes`)

Yes. ACP sessions that were incorrectly blocked by the deleted-agent guard can be resolved/sent again.

Did config, environment, or migration behavior change? (`No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`No`)

No new surfaces. This removes a false positive from an existing guard; true deleted-agent rejection for normal agent session keys remains.

What is the highest-risk area?

Accidentally exempting too many session-key shapes from deleted-agent checks.

How is that risk mitigated?

- Exemption is limited to `isAcpSessionKey(sessionKey)` only — an existing session-key class; the guard should not reinterpret `agent:<harnessId>:acp:*`'s second segment as an `agents.list` owner.
- Existing deleted-agent tests for real orphaned agent keys remain in place and still pass.
- New tests assert ACP harness keys are ignored while deleted-agent keys are still rejected.
- Fix is centralized in the shared helper used by resolver and direct send guards, avoiding drift across entry points.

## Current review state

What is the next action?

Refresh PR #91219 with store integration test + updated Real behavior proof.

What is still waiting on author, maintainer, CI, or external proof?

- CI on updated head after store test commit.
- Maintainer review.

Which bot or reviewer comments were addressed?

- Autoreview / code-read pass: **no blocking findings**.
- Verdict: **best minimal fix** — shared `resolveDeletedAgentIdFromSessionKey` bypass for ACP keys is the correct owner boundary; covers `sessions.resolve` (key/sessionId/label) via `validateSessionAgentExists` and direct `sessions.send` / `chat.send` guards.
- Evidence reviewed: `session-utils.ts`, `sessions-resolve.ts`, `server-methods/sessions.ts`, `server-methods/chat.ts`, `session-key-utils.ts`, adjacent tests.
