### PR TITLE
fix(google-vertex): retry transient pre-stream failures and stale ADC

### DIFF
--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -913,6 +913,94 @@ describe("google transport stream", () => {
     expect(new Headers(guardedInit.headers).has("x-goog-api-key")).toBe(false);
   });
 
+  it("retries retryable Google Vertex pre-stream HTTP failures before parsing SSE", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-google-vertex-stream-retry-"));
+    vi.stubEnv("GOOGLE_APPLICATION_CREDENTIALS", "");
+    vi.stubEnv("HOME", path.join(tempDir, "home"));
+    vi.stubEnv("APPDATA", "");
+    vi.stubEnv("GOOGLE_CLOUD_PROJECT", "vertex-project");
+    vi.stubEnv("GOOGLE_CLOUD_LOCATION", "us-central1");
+    vi.stubEnv("OPENCLAW_GOOGLE_VERTEX_STREAM_RETRY_BASE_DELAY_MS", "0");
+    vi.stubEnv("OPENCLAW_GOOGLE_VERTEX_STREAM_RETRY_MAX_DELAY_MS", "0");
+    googleAuthGetAccessTokenMock.mockResolvedValueOnce("ya29.retry-token");
+    guardedFetchMock
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: { message: "temporarily unavailable" } }), {
+          status: 503,
+          headers: { "content-type": "application/json", "retry-after": "0" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ error: { message: "quota exceeded", status: "RESOURCE_EXHAUSTED" } }),
+          { status: 429, headers: { "content-type": "application/json" } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        buildSseResponse([
+          {
+            candidates: [{ content: { parts: [{ text: "recovered" }] }, finishReason: "STOP" }],
+          },
+        ]),
+      );
+
+    const streamFn = createGoogleVertexTransportStreamFn();
+    const stream = await Promise.resolve(
+      streamFn(
+        buildGoogleVertexModel(),
+        {
+          messages: [{ role: "user", content: "hello", timestamp: 0 }],
+        } as Parameters<typeof streamFn>[1],
+        {
+          apiKey: "gcp-vertex-credentials",
+        } as Parameters<typeof streamFn>[2],
+      ),
+    );
+    const result = await stream.result();
+
+    expect(guardedFetchMock).toHaveBeenCalledTimes(3);
+    expect(result.stopReason).toBe("stop");
+    expect(result.content).toEqual([{ type: "text", text: "recovered" }]);
+  });
+
+  it("does not retry Google Vertex stream errors after an SSE chunk arrives", async () => {
+    const tempDir = await mkdtemp(
+      path.join(os.tmpdir(), "openclaw-google-vertex-partial-stream-error-"),
+    );
+    vi.stubEnv("GOOGLE_APPLICATION_CREDENTIALS", "");
+    vi.stubEnv("HOME", path.join(tempDir, "home"));
+    vi.stubEnv("APPDATA", "");
+    vi.stubEnv("GOOGLE_CLOUD_PROJECT", "vertex-project");
+    vi.stubEnv("GOOGLE_CLOUD_LOCATION", "us-central1");
+    vi.stubEnv("OPENCLAW_GOOGLE_VERTEX_STREAM_RETRY_BASE_DELAY_MS", "0");
+    vi.stubEnv("OPENCLAW_GOOGLE_VERTEX_STREAM_RETRY_MAX_DELAY_MS", "0");
+    googleAuthGetAccessTokenMock.mockResolvedValueOnce("ya29.partial-token");
+    guardedFetchMock.mockResolvedValueOnce(
+      buildRawSseResponse(
+        'data: {"candidates":[{"content":{"parts":[{"text":"partial"}]}}]}\n\ndata: {bad json\n\n',
+      ),
+    );
+
+    const streamFn = createGoogleVertexTransportStreamFn();
+    const stream = await Promise.resolve(
+      streamFn(
+        buildGoogleVertexModel(),
+        {
+          messages: [{ role: "user", content: "hello", timestamp: 0 }],
+        } as Parameters<typeof streamFn>[1],
+        {
+          apiKey: "gcp-vertex-credentials",
+        } as Parameters<typeof streamFn>[2],
+      ),
+    );
+    const result = await stream.result();
+
+    expect(guardedFetchMock).toHaveBeenCalledTimes(1);
+    expect(result.stopReason).toBe("error");
+    expect(result.errorMessage).toBe("Google SSE stream returned malformed JSON");
+    expect(result.content).toEqual([{ type: "text", text: "partial" }]);
+  });
+
   it("refreshes authorized_user ADC before Google Vertex requests", async () => {
     const tempDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-google-vertex-adc-"));
     const credentialsPath = path.join(tempDir, "application_default_credentials.json");
@@ -1081,6 +1169,85 @@ describe("google transport stream", () => {
     });
 
     expect(tokenFetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("clears cached Vertex ADC tokens and retries once after unauthenticated responses", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-google-vertex-adc-401-"));
+    const credentialsPath = path.join(tempDir, "application_default_credentials.json");
+    await writeFile(
+      credentialsPath,
+      JSON.stringify({
+        type: "authorized_user",
+        client_id: "client-id",
+        client_secret: "client-secret",
+        refresh_token: "refresh-token",
+      }),
+      "utf8",
+    );
+    vi.stubEnv("GOOGLE_APPLICATION_CREDENTIALS", credentialsPath);
+    vi.stubEnv("GOOGLE_CLOUD_PROJECT", "vertex-project");
+    vi.stubEnv("GOOGLE_CLOUD_LOCATION", "global");
+    const tokenFetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ access_token: "ya29.stale-token", expires_in: 3600 }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ access_token: "ya29.fresh-token", expires_in: 3600 }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+    guardedFetchMock
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            error: {
+              message: "Request had invalid authentication credentials.",
+              status: "UNAUTHENTICATED",
+            },
+          }),
+          { status: 401, headers: { "content-type": "application/json" } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        buildSseResponse([
+          {
+            candidates: [{ content: { parts: [{ text: "ok" }] }, finishReason: "STOP" }],
+          },
+        ]),
+      );
+
+    const streamFn = createGoogleVertexTransportStreamFn();
+    const stream = await Promise.resolve(
+      streamFn(
+        buildGoogleVertexModel(),
+        {
+          messages: [{ role: "user", content: "hello", timestamp: 0 }],
+        } as Parameters<typeof streamFn>[1],
+        {
+          apiKey: "gcp-vertex-credentials",
+          fetch: tokenFetchMock,
+        } as Parameters<typeof streamFn>[2],
+      ),
+    );
+    const result = await stream.result();
+
+    expect(tokenFetchMock).toHaveBeenCalledTimes(2);
+    expect(guardedFetchMock).toHaveBeenCalledTimes(2);
+    expectHeaders(
+      requireRequestInit(requireMockCall(guardedFetchMock, 0, "guarded fetch"), "guarded fetch"),
+      { Authorization: "Bearer ya29.stale-token" },
+    );
+    expectHeaders(
+      requireRequestInit(requireMockCall(guardedFetchMock, 1, "guarded fetch"), "guarded fetch"),
+      { Authorization: "Bearer ya29.fresh-token" },
+    );
+    expect(result.stopReason).toBe("stop");
+    expect(result.content).toEqual([{ type: "text", text: "ok" }]);
   });
 
   it("refreshes authorized_user ADC from the Windows APPDATA fallback for Google Vertex requests", async () => {

--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -23,6 +23,7 @@ import {
   transformTransportMessages,
   type WritableTransportStream,
 } from "openclaw/plugin-sdk/provider-transport-runtime";
+import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
@@ -40,6 +41,7 @@ import {
   type GoogleThinkingLevel,
 } from "./thinking-api.js";
 import {
+  clearGoogleVertexAdcTokenCache,
   isGoogleVertexCredentialsMarker,
   resolveGoogleVertexAuthorizedUserHeaders,
 } from "./vertex-adc.js";
@@ -83,6 +85,15 @@ type GoogleGenerateContentRequest = {
 
 const GOOGLE_GEMINI3_FIRST_RESPONSE_RETRY_DEFAULT_MS = 45_000;
 const GOOGLE_GEMINI3_FIRST_RESPONSE_RETRY_ENV = "OPENCLAW_GOOGLE_GEMINI_FIRST_RESPONSE_RETRY_MS";
+const GOOGLE_VERTEX_STREAM_MAX_RETRIES_DEFAULT = 2;
+const GOOGLE_VERTEX_STREAM_RETRY_BASE_DELAY_DEFAULT_MS = 250;
+const GOOGLE_VERTEX_STREAM_RETRY_MAX_DELAY_DEFAULT_MS = 2_000;
+const GOOGLE_VERTEX_STREAM_MAX_RETRIES_ENV = "OPENCLAW_GOOGLE_VERTEX_STREAM_MAX_RETRIES";
+const GOOGLE_VERTEX_STREAM_RETRY_BASE_DELAY_ENV =
+  "OPENCLAW_GOOGLE_VERTEX_STREAM_RETRY_BASE_DELAY_MS";
+const GOOGLE_VERTEX_STREAM_RETRY_MAX_DELAY_ENV = "OPENCLAW_GOOGLE_VERTEX_STREAM_RETRY_MAX_DELAY_MS";
+
+const vertexTransportLog = createSubsystemLogger("google-vertex/transport");
 
 type GoogleTransportContentBlock =
   | { type: "text"; text: string; textSignature?: string }
@@ -830,6 +841,114 @@ export function resolveGoogleGemini3FirstResponseRetryMs(env = process.env): num
   return parseStrictNonNegativeInteger(raw) ?? GOOGLE_GEMINI3_FIRST_RESPONSE_RETRY_DEFAULT_MS;
 }
 
+function resolveGoogleVertexStreamRetryInteger(params: {
+  env: NodeJS.ProcessEnv;
+  name: string;
+  defaultValue: number;
+}): number {
+  const raw = params.env[params.name];
+  if (raw === undefined || raw.trim() === "") {
+    return params.defaultValue;
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return params.defaultValue;
+  }
+  return Math.floor(parsed);
+}
+
+function resolveGoogleVertexStreamRetryConfig(env = process.env): {
+  maxRetries: number;
+  baseDelayMs: number;
+  maxDelayMs: number;
+} {
+  const maxRetries = resolveGoogleVertexStreamRetryInteger({
+    env,
+    name: GOOGLE_VERTEX_STREAM_MAX_RETRIES_ENV,
+    defaultValue: GOOGLE_VERTEX_STREAM_MAX_RETRIES_DEFAULT,
+  });
+  const baseDelayMs = resolveGoogleVertexStreamRetryInteger({
+    env,
+    name: GOOGLE_VERTEX_STREAM_RETRY_BASE_DELAY_ENV,
+    defaultValue: GOOGLE_VERTEX_STREAM_RETRY_BASE_DELAY_DEFAULT_MS,
+  });
+  const rawMaxDelayMs = resolveGoogleVertexStreamRetryInteger({
+    env,
+    name: GOOGLE_VERTEX_STREAM_RETRY_MAX_DELAY_ENV,
+    defaultValue: GOOGLE_VERTEX_STREAM_RETRY_MAX_DELAY_DEFAULT_MS,
+  });
+  return {
+    maxRetries,
+    baseDelayMs,
+    maxDelayMs: Math.max(baseDelayMs, rawMaxDelayMs),
+  };
+}
+
+function parseGoogleVertexRetryAfterMs(value: string | null): number | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  if (/^\d+$/.test(trimmed)) {
+    return Number.parseInt(trimmed, 10) * 1_000;
+  }
+  const timestampMs = Date.parse(trimmed);
+  if (!Number.isFinite(timestampMs)) {
+    return undefined;
+  }
+  return Math.max(0, timestampMs - Date.now());
+}
+
+function resolveGoogleVertexStreamRetryDelayMs(params: {
+  response: Response;
+  retryIndex: number;
+  baseDelayMs: number;
+  maxDelayMs: number;
+}): number {
+  const retryAfterMs = parseGoogleVertexRetryAfterMs(params.response.headers.get("retry-after"));
+  if (retryAfterMs !== undefined) {
+    return retryAfterMs;
+  }
+  const exponentialDelayMs = params.baseDelayMs * 2 ** Math.max(params.retryIndex - 1, 0);
+  const jitterMs = exponentialDelayMs * 0.25 * Math.random();
+  return Math.min(params.maxDelayMs, Math.round(exponentialDelayMs + jitterMs));
+}
+
+function isRetryableGoogleVertexPreStreamResponse(response: Response): boolean {
+  return response.status === 429 || response.status === 503;
+}
+
+async function sleepGoogleVertexStreamRetry(ms: number, signal?: AbortSignal): Promise<void> {
+  if (ms <= 0) {
+    return;
+  }
+  await new Promise<void>((resolve, reject) => {
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    const abort = () => {
+      if (timeout) {
+        clearTimeout(timeout);
+        timeout = undefined;
+      }
+      signal?.removeEventListener("abort", abort);
+      reject(new Error("aborted", { cause: signal?.reason }));
+    };
+    if (signal?.aborted) {
+      abort();
+      return;
+    }
+    signal?.addEventListener("abort", abort, { once: true });
+    timeout = setTimeout(() => {
+      timeout = undefined;
+      signal?.removeEventListener("abort", abort);
+      resolve();
+    }, ms);
+    timeout.unref?.();
+  });
+}
+
 function shouldRetryGoogleGemini3FirstResponse(params: {
   kind: CanonicalGoogleTransportApi;
   model: GoogleTransportModel;
@@ -1004,6 +1123,67 @@ async function openGoogleSseAttempt(params: {
   }
 }
 
+async function fetchGooglePreStreamResponse(params: {
+  kind: CanonicalGoogleTransportApi;
+  guardedFetch: ReturnType<typeof buildGuardedModelFetch>;
+  url: string;
+  headers: Record<string, string>;
+  request: GoogleGenerateContentRequest;
+  signal?: AbortSignal;
+  errorPrefix: string;
+}): Promise<Response> {
+  const retryConfig =
+    params.kind === "google-vertex" ? resolveGoogleVertexStreamRetryConfig() : undefined;
+  const maxRetries = retryConfig?.maxRetries ?? 0;
+  let retryIndex = 0;
+
+  for (;;) {
+    const response = await params.guardedFetch(params.url, {
+      method: "POST",
+      headers: params.headers,
+      body: JSON.stringify(params.request),
+      signal: params.signal,
+    });
+    if (response.ok) {
+      return response;
+    }
+    if (
+      params.kind !== "google-vertex" ||
+      retryIndex >= maxRetries ||
+      !isRetryableGoogleVertexPreStreamResponse(response) ||
+      params.signal?.aborted
+    ) {
+      if (params.kind === "google-vertex" && isRetryableGoogleVertexPreStreamResponse(response)) {
+        vertexTransportLog.debug("vertex pre-stream retry exhausted; giving up", {
+          status: response.status,
+          attempts: retryIndex,
+          aborted: Boolean(params.signal?.aborted),
+        });
+      }
+      throw await createProviderHttpError(response, params.errorPrefix);
+    }
+
+    retryIndex += 1;
+    const retryAfterHonored =
+      parseGoogleVertexRetryAfterMs(response.headers.get("retry-after")) !== undefined;
+    const delayMs = resolveGoogleVertexStreamRetryDelayMs({
+      response,
+      retryIndex,
+      baseDelayMs: retryConfig?.baseDelayMs ?? GOOGLE_VERTEX_STREAM_RETRY_BASE_DELAY_DEFAULT_MS,
+      maxDelayMs: retryConfig?.maxDelayMs ?? GOOGLE_VERTEX_STREAM_RETRY_MAX_DELAY_DEFAULT_MS,
+    });
+    vertexTransportLog.debug("retrying vertex pre-stream request", {
+      status: response.status,
+      attempt: retryIndex,
+      maxRetries,
+      delayMs,
+      retryAfterHonored,
+    });
+    await response.body?.cancel().catch(() => undefined);
+    await sleepGoogleVertexStreamRetry(delayMs, params.signal);
+  }
+}
+
 async function openGoogleSseChunks(params: {
   kind: CanonicalGoogleTransportApi;
   model: GoogleTransportModel;
@@ -1018,15 +1198,15 @@ async function openGoogleSseChunks(params: {
       ? "Google Vertex AI API error"
       : "Google Generative AI API error";
   if (!shouldRetryGoogleGemini3FirstResponse({ kind: params.kind, model: params.model })) {
-    const response = await params.guardedFetch(params.url, {
-      method: "POST",
+    const response = await fetchGooglePreStreamResponse({
+      kind: params.kind,
+      guardedFetch: params.guardedFetch,
+      url: params.url,
       headers: params.headers,
-      body: JSON.stringify(params.request),
+      request: params.request,
       signal: params.options?.signal,
+      errorPrefix,
     });
-    if (!response.ok) {
-      throw await createProviderHttpError(response, errorPrefix);
-    }
     return {
       type: "ready",
       chunks: parseGoogleSseChunks(response, params.options?.signal),
@@ -1042,15 +1222,15 @@ async function openGoogleSseChunks(params: {
         })
       : undefined;
   if (!retryRequest) {
-    const response = await params.guardedFetch(params.url, {
-      method: "POST",
+    const response = await fetchGooglePreStreamResponse({
+      kind: params.kind,
+      guardedFetch: params.guardedFetch,
+      url: params.url,
       headers: params.headers,
-      body: JSON.stringify(params.request),
+      request: params.request,
       signal: params.options?.signal,
+      errorPrefix,
     });
-    if (!response.ok) {
-      throw await createProviderHttpError(response, errorPrefix);
-    }
     return {
       type: "ready",
       chunks: parseGoogleSseChunks(response, params.options?.signal),
@@ -1100,6 +1280,39 @@ async function buildGoogleTransportHeaders(params: {
         params.fetchImpl,
       )
     : buildGoogleHeaders(params.model, params.apiKey, params.optionHeaders);
+}
+
+function isGoogleVertexUnauthenticatedError(error: unknown): boolean {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+  const record = error as {
+    status?: unknown;
+    statusCode?: unknown;
+    code?: unknown;
+    errorCode?: unknown;
+    message?: unknown;
+  };
+  const status = typeof record.status === "number" ? record.status : record.statusCode;
+  if (status !== 401) {
+    return false;
+  }
+  const code = normalizeLowercaseStringOrEmpty(
+    typeof record.errorCode === "string"
+      ? record.errorCode
+      : typeof record.code === "string"
+        ? record.code
+        : undefined,
+  );
+  const message = normalizeLowercaseStringOrEmpty(
+    typeof record.message === "string" ? record.message : undefined,
+  );
+  return (
+    code.includes("unauthenticated") ||
+    message.includes("unauthenticated") ||
+    message.includes("invalid authentication credentials") ||
+    message.includes("invalid auth credentials")
+  );
 }
 
 async function* parseGoogleSseChunks(
@@ -1232,22 +1445,53 @@ function createGoogleTransportStreamFn(kind: CanonicalGoogleTransportApi): Strea
           params = nextParams as GoogleGenerateContentRequest;
         }
         const requestUrl = buildGoogleTransportRequestUrl(kind, model, options);
-        const requestHeaders = await buildGoogleTransportHeaders({
+        let requestHeaders = await buildGoogleTransportHeaders({
           kind,
           model,
           apiKey,
           optionHeaders: options?.headers,
           fetchImpl: (options as { fetch?: typeof fetch } | undefined)?.fetch,
         });
-        const sse = await openGoogleSseChunks({
-          kind,
-          model,
-          options,
-          guardedFetch,
-          url: requestUrl,
-          headers: requestHeaders,
-          request: params,
-        });
+        let sse: Extract<GoogleSseAttempt, { type: "ready" }>;
+        try {
+          sse = await openGoogleSseChunks({
+            kind,
+            model,
+            options,
+            guardedFetch,
+            url: requestUrl,
+            headers: requestHeaders,
+            request: params,
+          });
+        } catch (error) {
+          if (
+            kind !== "google-vertex" ||
+            !isGoogleVertexCredentialsMarker(apiKey) ||
+            !isGoogleVertexUnauthenticatedError(error)
+          ) {
+            throw error;
+          }
+          vertexTransportLog.debug(
+            "vertex 401 UNAUTHENTICATED; clearing ADC token cache and retrying once",
+          );
+          clearGoogleVertexAdcTokenCache();
+          requestHeaders = await buildGoogleTransportHeaders({
+            kind,
+            model,
+            apiKey,
+            optionHeaders: options?.headers,
+            fetchImpl: (options as { fetch?: typeof fetch } | undefined)?.fetch,
+          });
+          sse = await openGoogleSseChunks({
+            kind,
+            model,
+            options,
+            guardedFetch,
+            url: requestUrl,
+            headers: requestHeaders,
+            request: params,
+          });
+        }
         stream.push({ type: "start", partial: output as never });
         let currentBlockIndex = -1;
         const chunks =

--- a/extensions/google/vertex-adc.ts
+++ b/extensions/google/vertex-adc.ts
@@ -89,10 +89,14 @@ function resolveGoogleAuthLibraryTokenExpiresAtMs(nowRaw = Date.now()): number |
     : resolveExpiresAtMsFromDurationMs(GOOGLE_VERTEX_AUTHLIB_TOKEN_CACHE_MS, { nowMs });
 }
 
-export function resetGoogleVertexAuthorizedUserTokenCacheForTest(): void {
+export function clearGoogleVertexAdcTokenCache(): void {
   cachedGoogleVertexAuthorizedUserToken = undefined;
   cachedGoogleAuthClient = undefined;
   cachedGoogleVertexAdcToken = undefined;
+}
+
+export function resetGoogleVertexAuthorizedUserTokenCacheForTest(): void {
+  clearGoogleVertexAdcTokenCache();
 }
 
 export function isGoogleVertexCredentialsMarker(


### PR DESCRIPTION
## Summary

Vertex streaming requests currently fail the entire turn on two transient,
recoverable conditions:

1. **Pre-stream `429` / `503`** from the Vertex endpoint (rate limiting /
   backend unavailability), surfaced as a hard error before any SSE chunk is
   read.
2. **`401 UNAUTHENTICATED`** caused by a *stale cached ADC token* — the cache
   can outlive the upstream credential, which currently forces a restart to
   recover.

This PR adds narrowly-scoped, Vertex-only recovery for both:

- **Bounded retry for pre-stream `429`/`503`**: exponential backoff with jitter,
  honoring `Retry-After` (delta-seconds or HTTP-date) when present. Retries only
  happen **before** the first SSE chunk is parsed — once streaming has started we
  never retry, so a partially-streamed turn is never replayed.
- **Single `401` ADC retry**: on a Vertex `401 UNAUTHENTICATED` while using ADC,
  clear the cached token, re-resolve request headers, and retry exactly once.

Non-Vertex Google (Generative Language API / API-key) behavior is unchanged.

## Why

Vertex deployments periodically see `429`/`503` and post-rotation `401`s. Today
each one aborts a turn that would have succeeded on an immediate retry — the
single largest source of avoidable turn failures we observe against Vertex.

## Configuration (all optional, Vertex-only)

| Env var | Default | Meaning |
| --- | --- | --- |
| `OPENCLAW_GOOGLE_VERTEX_STREAM_MAX_RETRIES` | `2` | Max pre-stream retries for 429/503 |
| `OPENCLAW_GOOGLE_VERTEX_STREAM_RETRY_BASE_DELAY_MS` | `250` | Backoff base |
| `OPENCLAW_GOOGLE_VERTEX_STREAM_RETRY_MAX_DELAY_MS` | `2000` | Backoff ceiling |

Defaults give ~2 quick retries; `MAX_RETRIES=0` fully disables the new
pre-stream retry path.

## Implementation notes

- New `fetchGooglePreStreamResponse()` wraps the pre-stream POST and is the only
  place the retry loop lives; both the non-Gemini-3 and Gemini-3 first-response
  paths route through it, so retry semantics are identical.
- `Retry-After` parsing supports both integer seconds and HTTP-date.
- The retry sleep is abort-aware (honors `options.signal`).
- A `clearGoogleVertexAdcTokenCache()` is exported from `vertex-adc.ts` for the
  401 path; the existing test-only `resetGoogleVertexAuthorizedUserTokenCacheForTest()`
  is kept as a thin alias for back-compat.
- Diagnostics go through `createSubsystemLogger("google-vertex/transport")`
  (`.debug`, gated by `OPENCLAW_LOG_LEVEL`) — no new stdout/stderr noise.

## Relationship to #61443

#61443 ("configurable retry for LLM provider API calls") adds a **generic**
provider-retry framework at the agent/provider layer (`src/infra/retry.ts`,
`src/agents/provider-retry.ts`) and wires it into `openai-transport-stream.ts`.
This change is **complementary**, not a duplicate:

- It does not reach the Google extension's own SSE transport
  (`extensions/google/transport-stream.ts`), where the Vertex pre-stream request
  is issued and parsed.
- The **401 stale-ADC recovery** here is auth-cache-specific: it must clear the
  cached token and re-resolve headers before retrying. A generic status-based
  retry would replay the *same* stale token and fail again.

If preferred, the 429/503 portion can later be expressed in terms of #61443's
framework once it lands; the 401-ADC portion stays Vertex-specific regardless.

## Test plan

`extensions/google/transport-stream.test.ts` — **66/66 pass on latest `main`**.
New cases:

- retries pre-stream `503`→`429`→success and returns the recovered stream;
- does **not** retry once an SSE chunk has arrived (malformed-JSON mid-stream
  still surfaces, partial content preserved);
- on `401 UNAUTHENTICATED`, clears the ADC cache, re-fetches the token, and
  retries once with the fresh `Authorization` header.

```
pnpm exec vitest run extensions/google/transport-stream.test.ts
# Test Files 1 passed (1) / Tests 66 passed (66)
```

Additionally validated against live `gemini-3.1-pro-preview` Vertex traffic in a
production deployment: real `streamGenerateContent` requests flow through the new
pre-stream wrapper and complete normally, confirming the path is non-breaking on
real traffic.
