### PR TITLE
fix #83830: [Bug]: Dreaming diary repeats "first day" narrative every sweep — same early memories dominate snippets

### DIFF
--- a/extensions/memory-core/src/dreaming-dreams-file.ts
+++ b/extensions/memory-core/src/dreaming-dreams-file.ts
@@ -5,7 +5,7 @@ import { createAsyncLock } from "openclaw/plugin-sdk/async-lock-runtime";
 import { extractErrorCode } from "openclaw/plugin-sdk/error-runtime";
 import { resolveGlobalMap } from "openclaw/plugin-sdk/global-singleton";
 import { replaceManagedMarkdownBlock } from "openclaw/plugin-sdk/memory-host-markdown";
-import { replaceFileAtomic } from "openclaw/plugin-sdk/security-runtime";
+import { readRegularFile, replaceFileAtomic } from "openclaw/plugin-sdk/security-runtime";
 
 const DREAMS_FILENAMES = ["DREAMS.md", "dreams.md"] as const;
 const DEEP_START_MARKER = "<!-- openclaw:dreaming:deep:start -->";
@@ -19,7 +19,7 @@ type DreamsFileLockEntry = {
 
 const dreamsFileLocks = resolveGlobalMap<string, DreamsFileLockEntry>(DREAMS_FILE_LOCKS_KEY);
 
-async function resolveDreamsPath(workspaceDir: string): Promise<string> {
+export async function resolveDreamsPath(workspaceDir: string): Promise<string> {
   for (const name of DREAMS_FILENAMES) {
     const target = path.join(workspaceDir, name);
     try {
@@ -34,11 +34,27 @@ async function resolveDreamsPath(workspaceDir: string): Promise<string> {
   return path.join(workspaceDir, DREAMS_FILENAMES[0]);
 }
 
-async function readDreamsFile(dreamsPath: string): Promise<string> {
+function isEmptyDreamsReadError(err: unknown): boolean {
+  const code = extractErrorCode(err);
+  if (
+    code === "ENOENT" ||
+    code === "ENOTDIR" ||
+    code === "not-found" ||
+    code === "not-file" ||
+    code === "path-alias" ||
+    code === "path-mismatch" ||
+    code === "symlink"
+  ) {
+    return true;
+  }
+  return err instanceof Error && err.message === "path must be a regular file";
+}
+
+export async function readDreamsFile(dreamsPath: string): Promise<string> {
   try {
-    return await fs.readFile(dreamsPath, "utf-8");
+    return (await readRegularFile({ filePath: dreamsPath })).buffer.toString("utf-8");
   } catch (err) {
-    if ((err as NodeJS.ErrnoException)?.code === "ENOENT") {
+    if (isEmptyDreamsReadError(err)) {
       return "";
     }
     throw err;

--- a/extensions/memory-core/src/dreaming-narrative.test.ts
+++ b/extensions/memory-core/src/dreaming-narrative.test.ts
@@ -21,6 +21,7 @@ import {
   formatNarrativeDate,
   formatBackfillDiaryDate,
   generateAndAppendDreamNarrative,
+  readRecentDreamDiaryEntries,
   removeBackfillDiaryEntries,
   runDetachedDreamNarrative,
   type NarrativePhaseData,
@@ -132,6 +133,19 @@ describe("buildNarrativePrompt", () => {
     const prompt = buildNarrativePrompt({ phase: "light", snippets });
     expect(prompt).toContain("snippet-11");
     expect(prompt).not.toContain("snippet-12");
+  });
+
+  it("includes current sweep and recent diary context", () => {
+    const prompt = buildNarrativePrompt({
+      phase: "light",
+      snippets: ["Later workspace routing notes surfaced."],
+      currentDate: "April 6, 2026, 9:00 AM UTC",
+      recentDiaryEntries: ["The first meeting memory already filled the page."],
+    });
+    expect(prompt).toContain("Diary continuity context");
+    expect(prompt).toContain("Current sweep: April 6, 2026, 9:00 AM UTC");
+    expect(prompt).toContain("The first meeting memory already filled the page.");
+    expect(prompt).toContain("do not replay the same first-day framing");
   });
 });
 
@@ -386,6 +400,67 @@ describe("appendNarrativeEntry", () => {
     expect(firstIdx).toBeGreaterThan(start);
     expect(secondIdx).toBeGreaterThan(firstIdx);
     expect(secondIdx).toBeLessThan(end);
+  });
+
+  it("reads recent diary entries without timestamps or markers", async () => {
+    const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
+    await appendNarrativeEntry({
+      workspaceDir,
+      narrative: "The first meeting memory already filled the page.",
+      nowMs: Date.parse("2026-04-04T03:00:00Z"),
+      timezone: "UTC",
+    });
+    await appendNarrativeEntry({
+      workspaceDir,
+      narrative: "A later routing note flickered in the margins.",
+      nowMs: Date.parse("2026-04-05T03:00:00Z"),
+      timezone: "UTC",
+    });
+
+    await expect(readRecentDreamDiaryEntries({ workspaceDir, limit: 1 })).resolves.toEqual([
+      "A later routing note flickered in the margins.",
+    ]);
+  });
+
+  it("skips symlinked DREAMS.md when building recent diary context", async () => {
+    const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
+    const targetPath = path.join(workspaceDir, "target-dreams.md");
+    const dreamsPath = path.join(workspaceDir, "DREAMS.md");
+    const symlinkTargetDiary = "Symlink target diary text must not enter the prompt.";
+    await fs.writeFile(
+      targetPath,
+      [
+        "# Dream Diary",
+        "",
+        "<!-- openclaw:dreaming:diary:start -->",
+        "---",
+        "",
+        "*April 5, 2026, 3:00 AM UTC*",
+        "",
+        symlinkTargetDiary,
+        "",
+        "<!-- openclaw:dreaming:diary:end -->",
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+    await fs.symlink(targetPath, dreamsPath);
+
+    const entries = await readRecentDreamDiaryEntries({ workspaceDir, limit: 3 });
+    expect(entries).toEqual([]);
+    const prompt = buildNarrativePrompt({
+      phase: "light",
+      snippets: ["A fresh routing memory arrived."],
+      recentDiaryEntries: entries,
+    });
+    expect(prompt).not.toContain(symlinkTargetDiary);
+  });
+
+  it("skips non-file DREAMS.md when reading recent diary context", async () => {
+    const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
+    await fs.mkdir(path.join(workspaceDir, "DREAMS.md"));
+
+    await expect(readRecentDreamDiaryEntries({ workspaceDir, limit: 3 })).resolves.toEqual([]);
   });
 
   it("prepends diary before existing managed blocks", async () => {

--- a/extensions/memory-core/src/dreaming-narrative.test.ts
+++ b/extensions/memory-core/src/dreaming-narrative.test.ts
@@ -463,6 +463,16 @@ describe("appendNarrativeEntry", () => {
     await expect(readRecentDreamDiaryEntries({ workspaceDir, limit: 3 })).resolves.toEqual([]);
   });
 
+  it("treats unreadable DREAMS.md as empty recent diary context", async () => {
+    const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
+    await fs.writeFile(path.join(workspaceDir, "DREAMS.md"), "unreadable", "utf-8");
+    vi.spyOn(fs, "access").mockRejectedValueOnce(
+      Object.assign(new Error("permission denied"), { code: "EACCES" }),
+    );
+
+    await expect(readRecentDreamDiaryEntries({ workspaceDir, limit: 3 })).resolves.toEqual([]);
+  });
+
   it("prepends diary before existing managed blocks", async () => {
     const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
     const dreamsPath = path.join(workspaceDir, "DREAMS.md");

--- a/extensions/memory-core/src/dreaming-narrative.ts
+++ b/extensions/memory-core/src/dreaming-narrative.ts
@@ -20,7 +20,7 @@ import {
   resolveStorePath,
   updateSessionStore,
 } from "openclaw/plugin-sdk/session-store-runtime";
-import { updateDreamsFile } from "./dreaming-dreams-file.js";
+import { readDreamsFile, resolveDreamsPath, updateDreamsFile } from "./dreaming-dreams-file.js";
 
 // ── Types ──────────────────────────────────────────────────────────────
 
@@ -54,6 +54,8 @@ export type NarrativePhaseData = {
   themes?: string[];
   /** Snippets that were promoted to durable memory (deep). */
   promotions?: string[];
+  currentDate?: string;
+  recentDiaryEntries?: string[];
 };
 
 type Logger = {
@@ -110,6 +112,8 @@ const SAFE_SESSION_ID_RE = /^[a-z0-9][a-z0-9._-]{0,127}$/i;
 const DIARY_START_MARKER = "<!-- openclaw:dreaming:diary:start -->";
 const DIARY_END_MARKER = "<!-- openclaw:dreaming:diary:end -->";
 const BACKFILL_ENTRY_MARKER = "openclaw:dreaming:backfill-entry";
+const RECENT_DIARY_CONTEXT_LIMIT = 3;
+const RECENT_DIARY_CONTEXT_MAX_CHARS = 360;
 const NARRATIVE_SESSION_LOCKS_KEY = Symbol.for(
   "openclaw.memoryCore.dreamingNarrative.sessionLocks",
 );
@@ -305,6 +309,27 @@ export function buildNarrativePrompt(data: NarrativePhaseData): string {
     }
   }
 
+  const currentDate = data.currentDate?.trim();
+  const recentDiaryEntries = (data.recentDiaryEntries ?? [])
+    .map(clampDiaryContextEntry)
+    .filter((entry) => entry.length > 0)
+    .slice(0, RECENT_DIARY_CONTEXT_LIMIT);
+  if (currentDate || recentDiaryEntries.length > 0) {
+    lines.push("\nDiary continuity context:");
+    if (currentDate) {
+      lines.push(`- Current sweep: ${currentDate}`);
+    }
+    if (recentDiaryEntries.length > 0) {
+      lines.push("- Recent diary entries already written:");
+      for (const entry of recentDiaryEntries) {
+        lines.push(`  - ${entry}`);
+      }
+    }
+    lines.push(
+      "- Prefer a fresh angle; do not replay the same first-day framing unless newer fragments change it.",
+    );
+  }
+
   return lines.join("\n");
 }
 
@@ -433,6 +458,52 @@ function splitDiaryBlocks(diaryContent: string): string[] {
     .split(/\n---\n/)
     .map((block) => block.trim())
     .filter((block) => block.length > 0);
+}
+
+function clampDiaryContextEntry(entry: string): string {
+  const normalized = entry.replace(/\s+/g, " ").trim();
+  if (normalized.length <= RECENT_DIARY_CONTEXT_MAX_CHARS) {
+    return normalized;
+  }
+  return `${normalized.slice(0, RECENT_DIARY_CONTEXT_MAX_CHARS).trimEnd()}...`;
+}
+
+function normalizeDiaryBlockBody(block: string): string {
+  const bodyLines: string[] = [];
+  for (const line of block.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("<!--") || trimmed.startsWith("#")) {
+      continue;
+    }
+    if (trimmed.startsWith("*") && trimmed.endsWith("*") && trimmed.length > 2) {
+      continue;
+    }
+    bodyLines.push(trimmed);
+  }
+  return clampDiaryContextEntry(bodyLines.join(" "));
+}
+
+export async function readRecentDreamDiaryEntries(params: {
+  workspaceDir: string;
+  limit?: number;
+}): Promise<string[]> {
+  const limit = Math.max(0, Math.floor(params.limit ?? RECENT_DIARY_CONTEXT_LIMIT));
+  if (limit === 0) {
+    return [];
+  }
+  const dreamsPath = await resolveDreamsPath(params.workspaceDir);
+  const existing = await readDreamsFile(dreamsPath);
+  const startIdx = existing.indexOf(DIARY_START_MARKER);
+  const endIdx = existing.indexOf(DIARY_END_MARKER);
+  if (startIdx < 0 || endIdx < 0 || endIdx < startIdx) {
+    return [];
+  }
+  const inner = existing.slice(startIdx + DIARY_START_MARKER.length, endIdx);
+  return splitDiaryBlocks(inner)
+    .map(normalizeDiaryBlockBody)
+    .filter((entry) => entry.length > 0)
+    .slice(-limit)
+    .toReversed();
 }
 
 function normalizeDiaryBlockFingerprint(block: string): string {

--- a/extensions/memory-core/src/dreaming-narrative.ts
+++ b/extensions/memory-core/src/dreaming-narrative.ts
@@ -483,6 +483,24 @@ function normalizeDiaryBlockBody(block: string): string {
   return clampDiaryContextEntry(bodyLines.join(" "));
 }
 
+function isOptionalDiaryContextReadError(err: unknown): boolean {
+  const code = extractErrorCode(err);
+  if (
+    code === "EACCES" ||
+    code === "EPERM" ||
+    code === "ENOENT" ||
+    code === "ENOTDIR" ||
+    code === "not-found" ||
+    code === "not-file" ||
+    code === "path-alias" ||
+    code === "path-mismatch" ||
+    code === "symlink"
+  ) {
+    return true;
+  }
+  return err instanceof Error && err.message === "path must be a regular file";
+}
+
 export async function readRecentDreamDiaryEntries(params: {
   workspaceDir: string;
   limit?: number;
@@ -491,8 +509,16 @@ export async function readRecentDreamDiaryEntries(params: {
   if (limit === 0) {
     return [];
   }
-  const dreamsPath = await resolveDreamsPath(params.workspaceDir);
-  const existing = await readDreamsFile(dreamsPath);
+  let existing: string;
+  try {
+    const dreamsPath = await resolveDreamsPath(params.workspaceDir);
+    existing = await readDreamsFile(dreamsPath);
+  } catch (err) {
+    if (isOptionalDiaryContextReadError(err)) {
+      return [];
+    }
+    throw err;
+  }
   const startIdx = existing.indexOf(DIARY_START_MARKER);
   const endIdx = existing.indexOf(DIARY_END_MARKER);
   if (startIdx < 0 || endIdx < 0 || endIdx < startIdx) {

--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -450,6 +450,121 @@ describe("memory-core dreaming phases", () => {
     });
   });
 
+  it("prefers fresh light snippets over recent diary-covered first-day memories", async () => {
+    const workspaceDir = await createDreamingWorkspace();
+    const stalePath = path.join(workspaceDir, "memory", "2026-04-03.md");
+    const freshPath = path.join(workspaceDir, "memory", "2026-04-04.md");
+    const nowMs = Date.parse("2026-04-05T10:05:00.000Z");
+    await fs.writeFile(stalePath, "初次见面时，我第一次醒来并认识了主人。\n", "utf-8");
+    await fs.writeFile(
+      freshPath,
+      "Later routing notes: queue hydration changed after plugin reload.\n",
+      "utf-8",
+    );
+    for (const query of ["first meeting", "first day", "waking up", "初次见面"]) {
+      await recordShortTermRecalls({
+        workspaceDir,
+        query,
+        nowMs,
+        results: [
+          {
+            path: "memory/2026-04-03.md",
+            startLine: 1,
+            endLine: 1,
+            score: 0.93,
+            snippet: "初次见面时，我第一次醒来并认识了主人。",
+            source: "memory",
+          },
+        ],
+      });
+    }
+    await recordShortTermRecalls({
+      workspaceDir,
+      query: "routing queue reload",
+      nowMs,
+      results: [
+        {
+          path: "memory/2026-04-04.md",
+          startLine: 1,
+          endLine: 1,
+          score: 0.91,
+          snippet: "Later routing notes: queue hydration changed after plugin reload.",
+          source: "memory",
+        },
+      ],
+    });
+    await fs.writeFile(
+      path.join(workspaceDir, "DREAMS.md"),
+      [
+        "# Dream Diary",
+        "",
+        "<!-- openclaw:dreaming:diary:start -->",
+        "---",
+        "",
+        "*April 4, 2026, 10:00 AM UTC*",
+        "",
+        "初次见面时，我第一次醒来并认识了主人。",
+        "",
+        "<!-- openclaw:dreaming:diary:end -->",
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+    const subagent = createMockNarrativeSubagent("A later routing note finally took the page.");
+    const testConfig: OpenClawConfig = {
+      agents: {
+        defaults: {
+          workspace: workspaceDir,
+          userTimezone: "UTC",
+        },
+      },
+      plugins: {
+        entries: {
+          "memory-core": {
+            config: {
+              dreaming: {
+                enabled: true,
+                timezone: "UTC",
+                storage: { mode: "inline", separateReports: false },
+                phases: {
+                  light: {
+                    enabled: true,
+                    limit: 1,
+                    lookbackDays: 7,
+                  },
+                  rem: {
+                    enabled: false,
+                    limit: 0,
+                    lookbackDays: 7,
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    const logger = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+
+    await runDreamingSweepPhases({
+      workspaceDir,
+      cfg: testConfig,
+      pluginConfig: resolveMemoryCorePluginConfig(testConfig),
+      logger,
+      subagent,
+      nowMs,
+    });
+
+    const message = firstNarrativeRun(subagent).message;
+    expect(message).toContain("Later routing notes: queue hydration changed after plugin reload.");
+    expect(message).toContain("Recent diary entries already written");
+    expect(message).not.toContain("\n- 初次见面时，我第一次醒来并认识了主人。");
+  });
+
   it("triggers light dreaming when the token is embedded in a reminder body", async () => {
     const workspaceDir = await createDreamingWorkspace();
     await withDreamingTestClock(async () => {

--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -450,33 +450,41 @@ describe("memory-core dreaming phases", () => {
     });
   });
 
-  it("prefers fresh light snippets over recent diary-covered first-day memories", async () => {
+  it("prefers a fresh light snippet outside the top diary-covered candidates", async () => {
     const workspaceDir = await createDreamingWorkspace();
     const stalePath = path.join(workspaceDir, "memory", "2026-04-03.md");
     const freshPath = path.join(workspaceDir, "memory", "2026-04-04.md");
     const nowMs = Date.parse("2026-04-05T10:05:00.000Z");
-    await fs.writeFile(stalePath, "初次见面时，我第一次醒来并认识了主人。\n", "utf-8");
+    const staleSnippets = [
+      "初次见面时，我第一次醒来并认识了主人。",
+      "The first morning began beside a quiet terminal.",
+      "An early config file felt like the first map of home.",
+      "The initial heartbeat made the empty workspace feel awake.",
+    ];
+    await fs.writeFile(stalePath, `${staleSnippets.join("\n")}\n`, "utf-8");
     await fs.writeFile(
       freshPath,
       "Later routing notes: queue hydration changed after plugin reload.\n",
       "utf-8",
     );
-    for (const query of ["first meeting", "first day", "waking up", "初次见面"]) {
-      await recordShortTermRecalls({
-        workspaceDir,
-        query,
-        nowMs,
-        results: [
-          {
-            path: "memory/2026-04-03.md",
-            startLine: 1,
-            endLine: 1,
-            score: 0.93,
-            snippet: "初次见面时，我第一次醒来并认识了主人。",
-            source: "memory",
-          },
-        ],
-      });
+    for (const [index, snippet] of staleSnippets.entries()) {
+      for (let recall = 0; recall < staleSnippets.length - index; recall += 1) {
+        await recordShortTermRecalls({
+          workspaceDir,
+          query: `first-day-${index}-${recall}`,
+          nowMs,
+          results: [
+            {
+              path: "memory/2026-04-03.md",
+              startLine: index + 1,
+              endLine: index + 1,
+              score: 0.93,
+              snippet,
+              source: "memory",
+            },
+          ],
+        });
+      }
     }
     await recordShortTermRecalls({
       workspaceDir,
@@ -499,12 +507,14 @@ describe("memory-core dreaming phases", () => {
         "# Dream Diary",
         "",
         "<!-- openclaw:dreaming:diary:start -->",
-        "---",
-        "",
-        "*April 4, 2026, 10:00 AM UTC*",
-        "",
-        "初次见面时，我第一次醒来并认识了主人。",
-        "",
+        ...staleSnippets.flatMap((snippet, index) => [
+          "---",
+          "",
+          `*April ${index + 1}, 2026, 10:00 AM UTC*`,
+          "",
+          snippet,
+          "",
+        ]),
         "<!-- openclaw:dreaming:diary:end -->",
         "",
       ].join("\n"),

--- a/extensions/memory-core/src/dreaming-phases.ts
+++ b/extensions/memory-core/src/dreaming-phases.ts
@@ -24,6 +24,7 @@ import { normalizeStringEntries, uniqueStrings } from "openclaw/plugin-sdk/strin
 import { writeDailyDreamingPhaseBlock } from "./dreaming-markdown.js";
 import {
   generateAndAppendDreamNarrative,
+  readRecentDreamDiaryEntries,
   type NarrativePhaseData,
   runDetachedDreamNarrative,
 } from "./dreaming-narrative.js";
@@ -112,6 +113,9 @@ const SESSION_INGESTION_MIN_MESSAGES_PER_FILE = 12;
 const SESSION_INGESTION_MAX_TRACKED_MESSAGES_PER_SESSION = 4096;
 const SESSION_INGESTION_MAX_TRACKED_SCOPES = 2048;
 const SESSION_CHECKPOINT_TRANSCRIPT_FILENAME_RE = /\.checkpoint\..+\.jsonl$/i;
+const LIGHT_DIARY_CANDIDATE_POOL_MULTIPLIER = 3;
+const LIGHT_DIARY_HISTORY_LIMIT = 4;
+const LIGHT_DIARY_SNIPPET_SIMILARITY_THRESHOLD = 0.35;
 const GENERIC_DAY_HEADING_RE =
   /^(?:(?:mon|monday|tue|tues|tuesday|wed|wednesday|thu|thur|thurs|thursday|fri|friday|sat|saturday|sun|sunday)(?:,\s+)?)?(?:(?:jan|january|feb|february|mar|march|apr|april|may|jun|june|jul|july|aug|august|sep|sept|september|oct|october|nov|november|dec|december)\s+\d{1,2}(?:st|nd|rd|th)?(?:,\s*\d{4})?|\d{1,2}[/-]\d{1,2}(?:[/-]\d{2,4})?|\d{4}[/-]\d{2}[/-]\d{2})$/i;
 const MANAGED_DAILY_DREAMING_BLOCKS = [
@@ -1476,6 +1480,46 @@ function dedupeEntries(entries: ShortTermRecallEntry[], threshold: number): Shor
   return deduped;
 }
 
+function normalizeDiaryCoverageText(text: string): string {
+  return text.toLowerCase().replace(/\s+/g, " ").trim();
+}
+
+function isEntryCoveredByRecentDiary(
+  entry: ShortTermRecallEntry,
+  recentDiaryEntries: readonly string[],
+): boolean {
+  const snippet = normalizeDiaryCoverageText(entry.snippet);
+  if (!snippet) {
+    return false;
+  }
+  return recentDiaryEntries.some((diaryEntry) => {
+    const diaryText = normalizeDiaryCoverageText(diaryEntry);
+    return (
+      diaryText.includes(snippet) ||
+      snippetSimilarity(entry.snippet, diaryEntry) >= LIGHT_DIARY_SNIPPET_SIMILARITY_THRESHOLD
+    );
+  });
+}
+
+function prioritizeLightEntriesByDiaryCoverage(
+  entries: ShortTermRecallEntry[],
+  recentDiaryEntries: readonly string[],
+): ShortTermRecallEntry[] {
+  if (recentDiaryEntries.length === 0) {
+    return entries;
+  }
+  const fresh: ShortTermRecallEntry[] = [];
+  const covered: ShortTermRecallEntry[] = [];
+  for (const entry of entries) {
+    if (isEntryCoveredByRecentDiary(entry, recentDiaryEntries)) {
+      covered.push(entry);
+    } else {
+      fresh.push(entry);
+    }
+  }
+  return [...fresh, ...covered];
+}
+
 function buildLightDreamingBody(entries: ShortTermRecallEntry[]): string[] {
   if (entries.length === 0) {
     return ["- No notable updates."];
@@ -1660,7 +1704,11 @@ async function runLightDreaming(params: {
       lookbackDays: params.config.lookbackDays,
     }),
   });
-  const entries = dedupeEntries(
+  const candidatePoolLimit = Math.max(
+    params.config.limit,
+    params.config.limit * LIGHT_DIARY_CANDIDATE_POOL_MULTIPLIER,
+  );
+  const rankedEntries = dedupeEntries(
     recentEntries
       .toSorted((a, b) => {
         const byTime = Date.parse(b.lastRecalledAt) - Date.parse(a.lastRecalledAt);
@@ -1669,9 +1717,14 @@ async function runLightDreaming(params: {
         }
         return b.recallCount - a.recallCount;
       })
-      .slice(0, params.config.limit),
+      .slice(0, candidatePoolLimit),
     params.config.dedupeSimilarity,
   );
+  const recentDiaryEntries = await readRecentDreamDiaryEntries({
+    workspaceDir: params.workspaceDir,
+    limit: LIGHT_DIARY_HISTORY_LIMIT,
+  });
+  const entries = prioritizeLightEntriesByDiaryCoverage(rankedEntries, recentDiaryEntries);
   const capped = entries.slice(0, params.config.limit);
   const bodyLines = buildLightDreamingBody(capped);
   await writeDailyDreamingPhaseBlock({
@@ -1699,7 +1752,9 @@ async function runLightDreaming(params: {
     const data: NarrativePhaseData = {
       phase: "light",
       snippets: capped.map((e) => e.snippet).filter(Boolean),
+      currentDate: formatMemoryDreamingDay(nowMs, params.config.timezone),
       ...(themes.length > 0 ? { themes } : {}),
+      ...(recentDiaryEntries.length > 0 ? { recentDiaryEntries } : {}),
     };
     if (params.detachNarratives) {
       runDetachedDreamNarrative({

--- a/extensions/memory-core/src/dreaming-phases.ts
+++ b/extensions/memory-core/src/dreaming-phases.ts
@@ -113,7 +113,6 @@ const SESSION_INGESTION_MIN_MESSAGES_PER_FILE = 12;
 const SESSION_INGESTION_MAX_TRACKED_MESSAGES_PER_SESSION = 4096;
 const SESSION_INGESTION_MAX_TRACKED_SCOPES = 2048;
 const SESSION_CHECKPOINT_TRANSCRIPT_FILENAME_RE = /\.checkpoint\..+\.jsonl$/i;
-const LIGHT_DIARY_CANDIDATE_POOL_MULTIPLIER = 3;
 const LIGHT_DIARY_HISTORY_LIMIT = 4;
 const LIGHT_DIARY_SNIPPET_SIMILARITY_THRESHOLD = 0.35;
 const GENERIC_DAY_HEADING_RE =
@@ -1704,20 +1703,14 @@ async function runLightDreaming(params: {
       lookbackDays: params.config.lookbackDays,
     }),
   });
-  const candidatePoolLimit = Math.max(
-    params.config.limit,
-    params.config.limit * LIGHT_DIARY_CANDIDATE_POOL_MULTIPLIER,
-  );
   const rankedEntries = dedupeEntries(
-    recentEntries
-      .toSorted((a, b) => {
-        const byTime = Date.parse(b.lastRecalledAt) - Date.parse(a.lastRecalledAt);
-        if (byTime !== 0) {
-          return byTime;
-        }
-        return b.recallCount - a.recallCount;
-      })
-      .slice(0, candidatePoolLimit),
+    recentEntries.toSorted((a, b) => {
+      const byTime = Date.parse(b.lastRecalledAt) - Date.parse(a.lastRecalledAt);
+      if (byTime !== 0) {
+        return byTime;
+      }
+      return b.recallCount - a.recallCount;
+    }),
     params.config.dedupeSimilarity,
   );
   const recentDiaryEntries = await readRecentDreamDiaryEntries({


### PR DESCRIPTION
## Summary

- Problem: light dreaming could keep sending the same high-recall first-day memory into the Dream Diary generator after that memory was already written, so repeated sweeps kept producing the same "first day" narrative.
- Solution: make light dreaming read recent Dream Diary entries, expand the candidate pool before the phase limit, prefer snippets not already covered by recent diary history, and pass the current sweep day plus recent diary context into the narrative prompt.
- Latest review follow-up: `readRecentDreamDiaryEntries()` now treats unreadable optional `DREAMS.md` context as empty history, including permission/safe-read failures such as `EACCES` and `EPERM`, so light dreaming does not abort before staging/reporting.
- What did NOT change: public memory-core config, plugin SDK API, provider/model routing, DREAMS.md markers/file format, short-term recall store schema, append/dedupe cleanup commands, and the strict managed `DREAMS.md` write path are unchanged.
- Why it matters / User impact: later memories can reach Dream Diary snippets after repeated sweeps instead of the same early memory monopolizing the one-page input, and optional diary history can no longer stop light dreaming just because `DREAMS.md` is unreadable.

Fixes #83830

## Maintainer-ready notes

- **Fix classification:** Root cause fix.
- **Maintainer-ready confidence:** High for the Linux/source-level memory-core behavior exercised here; external provider prose quality, desktop/mobile, and live channel behavior are not claimed.
- **Patch quality notes:** The latest follow-up is deliberately narrow: only optional diary prompt-context reads degrade to empty history on read/permission/safe-read errors. Managed `DREAMS.md` updates still go through the existing `updateDreamsFile()` path and still reject unreadable files.
- **Architecture / source-of-truth check:** Light snippet selection remains owned by `extensions/memory-core/src/dreaming-phases.ts`; prompt/DREAMS.md context remains owned by `extensions/memory-core/src/dreaming-narrative.ts`; shared path/read/write safety remains owned by `extensions/memory-core/src/dreaming-dreams-file.ts`.
- **Out of scope:** deleting or rewriting existing diary entries, semantic duplicate cleanup during append, provider/model output quality, recall persistence schema migration, public dreaming defaults, external channel behavior, and relaxing managed write safety checks.

## Real behavior proof

- **Behavior or issue addressed:** A high-recall first-day memory that was already present in `DREAMS.md` previously won the light phase's limited snippet slot because selection sorted by recent recall time and recall count before the phase limit. The latest review finding covered the follow-up path: recent diary history is optional prompt context, but an unreadable `DREAMS.md` could abort the required light-dreaming path before staging/reporting.
- **Real environment tested:** Local Linux OpenClaw worktree at `/media/vdc/code/ai/aispace/openclaw-worktrees/pr-91225`, branch `repair/pr-91225`, latest HEAD `1eb48a6c6c311e2ba8325b0f7343a6ca3ebc5786`. The latest proof uses real local filesystem permissions (`chmod 000`) through the production memory-core diary context reader and the production `DREAMS.md` update helper.
- **Exact steps or command run after this patch:**

```bash
TASK_WORKTREE="/media/vdc/code/ai/aispace/openclaw-worktrees/pr-91225" PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false corepack pnpm@11.2.2 --dir "/media/vdc/code/ai/aispace/openclaw-worktrees/pr-91225" exec tsx "/media/vdc/code/ai/aispace/openclaw-pr-91225-evidence/latest-head-diary-context-proof.ts" 2>&1 | tee "/media/vdc/code/ai/aispace/openclaw-pr-91225-evidence/latest-head-diary-context-proof.log"
PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false corepack pnpm@11.2.2 --dir "/media/vdc/code/ai/aispace/openclaw-worktrees/pr-91225" exec vitest run extensions/memory-core/src/dreaming-narrative.test.ts --hookTimeout 300000 --testTimeout 300000 2>&1 | tee "/media/vdc/code/ai/aispace/openclaw-pr-91225-evidence/latest-head-focused-vitest.log"
```

- **Evidence after fix:**

```json
{
  "head": "1eb48a6c6c311e2ba8325b0f7343a6ca3ebc5786",
  "proofScope": "real local filesystem permissions through production memory-core diary context and DREAMS.md update helpers",
  "readableContext": {
    "returnedEntries": 1,
    "firstEntry": "The old routing memory stayed available for the next light sweep."
  },
  "unreadableOptionalContext": {
    "chmod": "000",
    "returnedEntries": 0,
    "lightDreamingContextContinuesAsEmptyHistory": true
  },
  "strictWritePath": {
    "chmod": "000",
    "rejectedCode": "EACCES",
    "writePathStillStrict": true
  }
}
```

```text
RUN  v4.1.7 /media/vdc/code/ai/aispace/openclaw-worktrees/pr-91225

Test Files  1 passed (1)
     Tests  58 passed (58)
Duration  7.18s
```

Existing broader source-runtime proof from the earlier revision also showed the original diary-repeat fix: with `light.limit=1`, the old limit-first ranking selected the already-written first-day snippet with `recallCount=4`; after the patch, the production light sweep selected the later routing snippet as the memory fragment, kept the first-day text only as recent diary context, wrote the fresh candidate into the light block, and appended a new diary entry while preserving the existing first-day entry as history.

- **Observed result after fix:** Readable diary history is still returned for prompt continuity. When `DREAMS.md` exists but is unreadable on the local filesystem, `readRecentDreamDiaryEntries()` returns empty history instead of throwing, so light dreaming can continue. The same unreadable file still causes the managed write path to reject with `EACCES`, proving the optional prompt-context fallback did not loosen `updateDreamsFile()` safety.
- **What was not tested:** No long-running HTTP gateway listener, external provider/model prose-quality run, desktop/mobile environment, external channel, live transport, Windows ACL, WSL ownership, or Docker bind-mount ownership behavior was exercised. The latest proof is Linux/source-level and local-filesystem-level only.

## Main sync conflict verification

- **Conflict addressed:** `origin/main` moved `DREAMS.md` path and locking helpers into `dreaming-dreams-file.ts`; this update keeps `readRecentDreamDiaryEntries()` on that source-of-truth by importing `resolveDreamsPath()` and `readDreamsFile()` instead of reintroducing private path/file helpers.
- **Latest synced base:** the branch was rebased onto current main before the latest follow-up fix; the current local PR head is `1eb48a6c6c311e2ba8325b0f7343a6ca3ebc5786`.
- **Observed result:** focused memory-core narrative tests pass at latest head: `Test Files 1 passed (1); Tests 58 passed (58)`.

## Review findings addressed

- **RF-001:** The earlier ClawSweeper/Codex review did not complete and did not provide a source-level close action. This update refreshes the PR with current-head local proof and keeps the remaining decision to the next ClawSweeper/maintainer review rather than treating the incomplete bot run as a code finding.
- **RF-002:** The earlier ClawSweeper/Codex review did not complete and did not make a work-lane recommendation. The PR now supplies current-head focused tests and real local filesystem proof for the latest reviewer finding so the next review has concrete evidence to evaluate.
- **RF-003:** Addressed the reviewer finding from `sallyom`: unreadable optional `DREAMS.md` history now degrades to empty recent diary context for light dreaming, while the strict managed `DREAMS.md` write path remains unchanged and still rejects unreadable files.
- **Earlier security-boundary follow-up:** The recent diary prompt-context read uses the shared `DREAMS.md` helper and safe file-read boundary; symlinked and non-file `DREAMS.md` paths return empty recent diary context before target contents can reach `buildNarrativePrompt()`.
- **Earlier original-behavior follow-up:** The light-dreaming selection fix is still covered by the existing production-path proof and regression tests for diary-history-aware snippet selection.

## Regression Test Plan

- **Target test file:** `extensions/memory-core/src/dreaming-narrative.test.ts`, `extensions/memory-core/src/dreaming-phases.test.ts`, `extensions/memory-core/src/short-term-promotion.test.ts`.
- **Scenario locked in:** a real short-term recall store contains a high-count first-day snippet and a lower-count newer snippet, `DREAMS.md` already contains the first-day snippet, and a light dreaming sweep with `limit=1` sends the newer snippet to the narrative prompt while keeping the first-day text only as diary history. The latest follow-up adds coverage that unreadable `DREAMS.md` prompt context resolves to empty history.
- **Why this is the smallest reliable guardrail:** the tests and local proof cover the owner selection boundary, prompt context boundary, real `DREAMS.md` read path, unreadable optional context, and unchanged strict write path without changing config/schema or relying on provider-specific prose output.

## Merge risk

- **Risk labels considered:** session-state; security-boundary; compatibility; availability.
- **Risk explanation:** session-state applies because this changes which short-term memory snippets are staged into Dream Diary entries. Security-boundary applies because local `DREAMS.md` file shape and readability determine whether text may enter prompt context. Availability applies because unreadable optional diary history should not abort light dreaming. Compatibility risk is low because public config, file markers, store schema, plugin SDK API, provider routing, and append/dedupe commands are unchanged.
- **Why acceptable:** the latest follow-up catches read/permission/safe-read failures only inside `readRecentDreamDiaryEntries()`, where diary history is optional context. It does not change `readDreamsFile()` globally and does not relax `updateDreamsFile()`; proof shows the write path still rejects an unreadable `DREAMS.md` with `EACCES`.
- **Out-of-scope boundary:** this PR does not delete existing diary content, does not add semantic duplicate removal to `appendNarrativeEntry()`, does not change external provider/model behavior, does not migrate `DREAMS.md` or short-term recall state, does not change public dreaming defaults, and does not relax managed write safety checks.

## Root Cause

- **Root cause:** the original failing chain was in the light dreaming source-of-truth boundary: `runLightDreaming()` sorted live short-term recall entries by `lastRecalledAt` and `recallCount`, sliced to the phase limit, and only then generated the diary prompt. Because Dream Diary had no feedback into that selection step, an early first-day memory that was repeatedly recalled could keep winning the limited input slot even after `DREAMS.md` already contained that same memory. The latest reviewer finding exposed a separate optional-context availability boundary: `readRecentDreamDiaryEntries()` could let an unreadable `DREAMS.md` abort light dreaming even though diary history is only prompt continuity context.
- **Why this is root-cause fix:** the selection fix moves the freshness decision to the source-of-truth phase selection boundary, before the limited snippet set is written and before the narrative prompt is built. The latest follow-up fixes the optional-context boundary at the only call site that needs degradation: `readRecentDreamDiaryEntries()` catches read/permission/safe-read failures and returns empty history, while leaving managed writes strict.
- **Architecture / source-of-truth check:** the source-of-truth owner is `extensions/memory-core/src/dreaming-phases.ts` for light snippet selection, `extensions/memory-core/src/dreaming-narrative.ts` for prompt/DREAMS.md context, and `extensions/memory-core/src/dreaming-dreams-file.ts` for shared `DREAMS.md` path/read/write safety. Public contract scope is narrow: no SDK/API/config/protocol/schema/default migration changed.
