### PR TITLE
fix #91216: [Bug]: gateway opens an empty memory database when main.sqlite is absent during the index swap, leaving memory_search paused with "index metadata is missing" until restart

### DIFF
--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -869,7 +869,7 @@ describe("memory index", () => {
       minScore: 0,
       hybrid: { enabled: true, vectorWeight: 0, textWeight: 1 },
     });
-    let staleBackupPath = "";
+    const staleBackupPath = `${dbPath}.backup-stale-handle`;
     const residentManager = await getFreshManager(cfg);
     try {
       await residentManager.sync({ reason: "test", force: true });
@@ -883,7 +883,6 @@ describe("memory index", () => {
         reason: "index metadata is missing",
       });
 
-      staleBackupPath = `${dbPath}.backup-stale-handle`;
       await moveSqliteFilesForTest(dbPath, staleBackupPath);
       const liveManager = await getFreshManager(cfg, "cli");
       try {

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -821,6 +821,27 @@ describe("memory index", () => {
     }
   });
 
+  it("keeps metadata after a same-identity safe reindex", async () => {
+    vi.stubEnv("OPENCLAW_TEST_MEMORY_UNSAFE_REINDEX", "0");
+    const dbPath = path.join(workspaceDir, "index-safe-reindex-same-identity.sqlite");
+    const cfg = createCfg({
+      storePath: dbPath,
+      provider: "none",
+      model: "",
+    });
+    const manager = await getFreshManager(cfg);
+    try {
+      await manager.sync({ reason: "test", force: true });
+      expect(manager.status().custom?.indexIdentity).toEqual({ status: "valid" });
+
+      await manager.sync({ reason: "test", force: true });
+
+      expect(manager.status().custom?.indexIdentity).toEqual({ status: "valid" });
+    } finally {
+      await manager.close?.();
+    }
+  });
+
   it("rebuilds missing metadata with existing chunks on gateway sync", async () => {
     const dbPath = path.join(workspaceDir, "index-missing-meta-cutover.sqlite");
     const cfg = createCfg({

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -399,6 +399,24 @@ describe("memory index", () => {
     }
   }
 
+  async function moveSqliteFilesForTest(sourceBase: string, targetBase: string): Promise<void> {
+    for (const suffix of ["", "-wal", "-shm"]) {
+      try {
+        await fs.rename(`${sourceBase}${suffix}`, `${targetBase}${suffix}`);
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+          throw err;
+        }
+      }
+    }
+  }
+
+  async function removeSqliteFilesForTest(basePath: string): Promise<void> {
+    for (const suffix of ["", "-wal", "-shm"]) {
+      await fs.rm(`${basePath}${suffix}`, { force: true });
+    }
+  }
+
   it("does not prepare vector deletes after unsafe reset drops a missing vector table", async () => {
     const cfg = createCfg({
       storePath: path.join(workspaceDir, "index-vector-missing-table.sqlite"),
@@ -839,6 +857,51 @@ describe("memory index", () => {
       expect(manager.status().custom?.indexIdentity).toEqual({ status: "valid" });
     } finally {
       await manager.close?.();
+    }
+  });
+
+  it("reopens a stale missing-metadata handle when the live index is healthy", async () => {
+    const dbPath = path.join(workspaceDir, "index-stale-missing-meta-handle.sqlite");
+    const cfg = createCfg({
+      storePath: dbPath,
+      provider: "none",
+      model: "",
+      minScore: 0,
+      hybrid: { enabled: true, vectorWeight: 0, textWeight: 1 },
+    });
+    let staleBackupPath = "";
+    const residentManager = await getFreshManager(cfg);
+    try {
+      await residentManager.sync({ reason: "test", force: true });
+      (
+        residentManager as unknown as {
+          db: { exec: (sql: string) => void };
+        }
+      ).db.exec(`DELETE FROM meta WHERE key = 'memory_index_meta_v1'`);
+      expect(residentManager.status().custom?.indexIdentity).toEqual({
+        status: "missing",
+        reason: "index metadata is missing",
+      });
+
+      staleBackupPath = `${dbPath}.backup-stale-handle`;
+      await moveSqliteFilesForTest(dbPath, staleBackupPath);
+      const liveManager = await getFreshManager(cfg, "cli");
+      try {
+        await liveManager.sync({ reason: "test", force: true });
+        expect(liveManager.status().custom?.indexIdentity).toEqual({ status: "valid" });
+      } finally {
+        await liveManager.close?.();
+      }
+
+      const results = await residentManager.search("alpha", { minScore: 0 });
+
+      expect(results.some((result) => result.path.endsWith("memory/2026-01-12.md"))).toBe(true);
+      expect(residentManager.status().custom?.indexIdentity).toEqual({ status: "valid" });
+    } finally {
+      await residentManager.close?.();
+      if (staleBackupPath) {
+        await removeSqliteFilesForTest(staleBackupPath);
+      }
     }
   });
 

--- a/extensions/memory-core/src/memory/manager-atomic-reindex.ts
+++ b/extensions/memory-core/src/memory/manager-atomic-reindex.ts
@@ -83,6 +83,16 @@ export async function moveMemoryIndexFiles(
   }
 }
 
+async function moveMemoryIndexSidecarFiles(
+  sourceBase: string,
+  targetBase: string,
+  options: ResolvedMemoryIndexFileOptions,
+): Promise<void> {
+  for (const suffix of ["-wal", "-shm"]) {
+    await renameWithRetry(`${sourceBase}${suffix}`, `${targetBase}${suffix}`, options);
+  }
+}
+
 async function rmWithRetry(path: string, options: ResolvedMemoryIndexFileOptions): Promise<void> {
   for (let attempt = 1; attempt <= options.maxRemoveAttempts; attempt++) {
     try {
@@ -112,13 +122,23 @@ export async function removeMemoryIndexFiles(
   }
 }
 
-async function swapMemoryIndexFiles(targetPath: string, tempPath: string): Promise<void> {
+async function swapMemoryIndexFiles(
+  targetPath: string,
+  tempPath: string,
+  options: MemoryIndexFileOptions = {},
+): Promise<void> {
+  const resolvedOptions = resolveMemoryIndexFileOptions(options);
   const backupPath = `${targetPath}.backup-${randomUUID()}`;
-  await moveMemoryIndexFiles(targetPath, backupPath);
+  await moveMemoryIndexSidecarFiles(targetPath, backupPath, resolvedOptions);
+  let basePublished = false;
   try {
-    await moveMemoryIndexFiles(tempPath, targetPath);
+    await renameWithRetry(tempPath, targetPath, resolvedOptions);
+    basePublished = true;
+    await moveMemoryIndexSidecarFiles(tempPath, targetPath, resolvedOptions);
   } catch (err) {
-    await moveMemoryIndexFiles(backupPath, targetPath);
+    if (!basePublished) {
+      await moveMemoryIndexSidecarFiles(backupPath, targetPath, resolvedOptions);
+    }
     throw err;
   }
   await removeMemoryIndexFiles(backupPath);
@@ -133,7 +153,7 @@ export async function runMemoryAtomicReindex<T>(params: {
 }): Promise<T> {
   try {
     const result = await params.build();
-    await swapMemoryIndexFiles(params.targetPath, params.tempPath);
+    await swapMemoryIndexFiles(params.targetPath, params.tempPath, params.fileOptions);
     return result;
   } catch (err) {
     try {

--- a/extensions/memory-core/src/memory/manager-db.ts
+++ b/extensions/memory-core/src/memory/manager-db.ts
@@ -21,6 +21,16 @@ export function openMemoryDatabaseAtPath(dbPath: string, allowExtension: boolean
   return db;
 }
 
+export function openMemoryDatabaseReadonlyAtPath(
+  dbPath: string,
+  allowExtension: boolean,
+): DatabaseSync {
+  const { DatabaseSync } = requireNodeSqlite();
+  const db = new DatabaseSync(dbPath, { allowExtension, readOnly: true });
+  db.exec("PRAGMA busy_timeout = 5000");
+  return db;
+}
+
 export function closeMemoryDatabase(db: DatabaseSync): void {
   closeMemorySqliteWalMaintenance(db);
   db.close();

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -2304,6 +2304,7 @@ export abstract class MemoryManagerSyncOps {
       } else {
         this.db = originalDb;
       }
+      this.lastMetaSerialized = null;
       this.fts.available = originalState.ftsAvailable;
       this.fts.loadError = originalState.ftsError;
       this.vector.available = originalDbClosed ? null : originalState.vectorAvailable;
@@ -2413,6 +2414,7 @@ export abstract class MemoryManagerSyncOps {
       });
 
       this.db = openMemoryDatabaseAtPath(dbPath, this.settings.store.vector.enabled);
+      this.lastMetaSerialized = null;
       this.resetVectorState();
       this.ensureSchema();
       this.vector.dims = nextMeta?.vectorDims;

--- a/extensions/memory-core/src/memory/manager.atomic-reindex.test.ts
+++ b/extensions/memory-core/src/memory/manager.atomic-reindex.test.ts
@@ -77,6 +77,53 @@ describe("memory manager atomic reindex", () => {
     await expectPathMissing(tempIndexPath);
   });
 
+  it("keeps the existing base index reachable until the temp base is published", async () => {
+    writeChunkMarker(indexPath, "before");
+    writeChunkMarker(tempIndexPath, "after");
+
+    const actualFs = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+    let targetExistedBeforeTempPublish: boolean | undefined;
+    const mockedFs = {
+      ...actualFs,
+      rename: async (
+        source: Parameters<typeof fs.rename>[0],
+        target: Parameters<typeof fs.rename>[1],
+      ) => {
+        if (String(source) === tempIndexPath && String(target) === indexPath) {
+          try {
+            await actualFs.access(indexPath);
+            targetExistedBeforeTempPublish = true;
+          } catch (err) {
+            if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+              throw err;
+            }
+            targetExistedBeforeTempPublish = false;
+          }
+        }
+        await actualFs.rename(source, target);
+      },
+    };
+
+    vi.resetModules();
+    vi.doMock("node:fs/promises", () => ({ ...mockedFs, default: mockedFs }));
+    try {
+      const { runMemoryAtomicReindex: runMemoryAtomicReindexWithMockedFs } =
+        await import("./manager-atomic-reindex.js");
+      await runMemoryAtomicReindexWithMockedFs({
+        targetPath: indexPath,
+        tempPath: tempIndexPath,
+        build: async () => undefined,
+      });
+    } finally {
+      vi.doUnmock("node:fs/promises");
+      vi.resetModules();
+    }
+
+    expect(targetExistedBeforeTempPublish).toBe(true);
+    expect(readChunkMarker(indexPath)).toBe("after");
+    await expectPathMissing(tempIndexPath);
+  });
+
   it("retries transient rename failures during index swaps", async () => {
     const rename = vi
       .fn()

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -8,6 +8,7 @@ import {
   resolveAgentDir,
   resolveAgentWorkspaceDir,
   resolveMemorySearchConfig,
+  resolveUserPath,
   type OpenClawConfig,
   type ResolvedMemorySearchConfig,
 } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
@@ -41,7 +42,7 @@ import {
   getOrCreateManagedCacheEntry,
   resolveSingletonManagedCache,
 } from "./manager-cache.js";
-import { closeMemoryDatabase } from "./manager-db.js";
+import { closeMemoryDatabase, openMemoryDatabaseReadonlyAtPath } from "./manager-db.js";
 import { MemoryManagerEmbeddingOps } from "./manager-embedding-ops.js";
 import { isLocalEmbeddingWorkerFailure } from "./manager-local-worker-errors.js";
 import {
@@ -51,7 +52,7 @@ import {
   resolveMemoryProviderState,
   type MemoryProviderLifecycleState,
 } from "./manager-provider-state.js";
-import type { MemoryIndexIdentityState } from "./manager-reindex-state.js";
+import type { MemoryIndexIdentityState, MemoryIndexMeta } from "./manager-reindex-state.js";
 import { resolveMemorySearchPreflight } from "./manager-search-preflight.js";
 import { searchKeyword, searchVector } from "./manager-search.js";
 import {
@@ -69,6 +70,7 @@ const SNIPPET_MAX_CHARS = 700;
 const VECTOR_TABLE = "chunks_vec";
 const FTS_TABLE = "chunks_fts";
 const EMBEDDING_CACHE_TABLE = "embedding_cache";
+const MEMORY_INDEX_META_KEY = "memory_index_meta_v1";
 const MEMORY_INDEX_MANAGER_CACHE_KEY = Symbol.for("openclaw.memoryIndexManagerCache");
 export const EMBEDDING_PROBE_CACHE_TTL_MS = 30_000;
 const log = createSubsystemLogger("memory");
@@ -562,6 +564,70 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     }
   }
 
+  private readLiveIndexMetaSnapshot(): {
+    meta: MemoryIndexMeta | null;
+    hasIndexedChunks: boolean;
+  } | null {
+    let liveDb: DatabaseSync;
+    try {
+      liveDb = openMemoryDatabaseReadonlyAtPath(
+        resolveUserPath(this.settings.store.path),
+        this.settings.store.vector.enabled,
+      );
+    } catch (err) {
+      log.debug(`memory index live metadata probe skipped: ${formatErrorMessage(err)}`);
+      return null;
+    }
+    try {
+      const row = liveDb
+        .prepare(`SELECT value FROM meta WHERE key = ?`)
+        .get(MEMORY_INDEX_META_KEY) as { value: string } | undefined;
+      const chunkRow = liveDb.prepare(`SELECT 1 as found FROM chunks LIMIT 1`).get() as
+        | { found?: number }
+        | undefined;
+      if (!row?.value) {
+        return { meta: null, hasIndexedChunks: chunkRow?.found === 1 };
+      }
+      try {
+        return {
+          meta: JSON.parse(row.value) as MemoryIndexMeta,
+          hasIndexedChunks: chunkRow?.found === 1,
+        };
+      } catch {
+        return { meta: null, hasIndexedChunks: chunkRow?.found === 1 };
+      }
+    } catch (err) {
+      log.debug(`memory index live metadata probe failed: ${formatErrorMessage(err)}`);
+      return null;
+    } finally {
+      closeMemoryDatabase(liveDb);
+    }
+  }
+
+  private reopenStaleMissingIndexHandle(params?: { providerKeyKnown?: boolean }): boolean {
+    const live = this.readLiveIndexMetaSnapshot();
+    if (!live?.meta) {
+      return false;
+    }
+    const liveState = this.resolveCurrentIndexIdentityState({
+      meta: live.meta,
+      providerKeyKnown: params?.providerKeyKnown,
+      hasIndexedChunks: live.hasIndexedChunks,
+    });
+    if (liveState.status !== "valid") {
+      return false;
+    }
+    const nextDb = this.openDatabase();
+    try {
+      closeMemoryDatabase(this.db);
+    } catch {}
+    this.db = nextDb;
+    this.resetVectorState();
+    this.ensureSchema();
+    this.vector.dims = live.meta.vectorDims;
+    return true;
+  }
+
   private refreshIndexIdentityDirty(params?: { providerKeyKnown?: boolean }) {
     const provider =
       this.settings.provider === "none"
@@ -571,10 +637,15 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
             ? { id: this.provider.id, model: this.provider.model }
             : null
           : undefined;
-    const state = this.resolveCurrentIndexIdentityState({
-      ...(provider !== undefined ? { provider } : {}),
-      providerKeyKnown: params?.providerKeyKnown,
-    });
+    const resolveState = () =>
+      this.resolveCurrentIndexIdentityState({
+        ...(provider !== undefined ? { provider } : {}),
+        providerKeyKnown: params?.providerKeyKnown,
+      });
+    let state = resolveState();
+    if (state.status === "missing" && this.reopenStaleMissingIndexHandle(params)) {
+      state = resolveState();
+    }
     this.indexIdentityState = state;
     this.indexIdentityDirty =
       state.status === "mismatched" ||


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- Fixes #91216, where `memory_search` could be left paused with `index metadata is missing` after a memory index rebuild/swap.
- The existing PR already keeps the live `main.sqlite` base reachable during atomic reindex publication and preserves metadata when safe reindex swaps DB handles.
- This update closes the remaining resident-gateway case: if a running manager is still holding a stale SQLite handle whose metadata is missing, it can reopen the healthy live index instead of staying paused until restart.

Why does this matter now?

- The reported failure is a gateway/runtime failure mode, not only a file-swap race: a long-running gateway can keep an old SQLite handle after another process rebuilds the live index.
- Without this recovery, the live `main.sqlite` can be healthy while the resident gateway still reports `index metadata is missing` from its stale handle.

What is the intended outcome?

- `main.sqlite` remains reachable during atomic reindex publication.
- Replacement safe-reindex databases retain valid `memory_index_meta_v1` metadata.
- A running gateway that sees missing metadata on its held DB handle probes the live DB read-only, validates the live metadata against the current identity, reopens the live DB, and serves `memory_search` without restart.

What is intentionally out of scope?

- No memory schema migration.
- No provider-selection, embedding, ranking, gateway API, auth, watcher, or tool contract changes.
- No recovery for mismatched index identity; provider/model/settings mismatches still keep memory search paused so stale rows are not served under the wrong configuration.

What does success look like?

- Concurrent/rebuilt memory indexes do not create an empty `main.sqlite`.
- Same-identity safe reindex keeps the metadata row in the replacement DB.
- A resident gateway with a stale missing-metadata handle can recover from the healthy live DB and return memory search results.
- Runtime output and HTTP responses do not contain `index metadata is missing` after recovery.

What should reviewers focus on?

- Fix classification: minimal canonical root-cause fix for the memory index DB-handle lifecycle boundary.
- Root cause: the root cause is a DB-handle lifecycle invariant break. The PR previously fixed file publication and temp-DB metadata-cache state, but a running gateway could still hold a stale/missing SQLite handle while the source-of-truth live path had already been rebuilt correctly.
- Why this is root-cause fix: the fix restores the lifecycle invariant at the source boundary where identity is evaluated. A missing held handle now validates the live DB metadata through the existing identity validator before the manager swaps handles, instead of treating the stale handle as authoritative forever.
- Recovery boundary: recovery only runs when the held handle resolves to `missing`; it opens the live DB read-only so a missing path is not auto-created, then reuses the existing identity validator and only swaps handles when the live metadata is `valid`.
- Safety invariant: `mismatched` metadata is not recovered, so provider/model/settings drift still fails closed instead of serving stale chunks.
- Patch boundary: the implementation adds a read-only live metadata probe plus a stale-missing-handle reopen path; it does not change schema, metadata format, provider identity, ranking, gateway routing, auth, or file-swap ordering.
- Architecture / source-of-truth check: the source of truth remains `resolveCurrentIndexIdentityState` and the existing metadata identity contract. This patch does not add a parallel validator, migration, provider-routing override, or partial schema fallback.
- Patch quality notes: the new broad catches are guardrails around read-only live probing and old-handle cleanup. Probe failures return no recovery and leave the existing paused/dirty path intact; cleanup failure is ignored only after a valid replacement handle has opened. The test `unknown as` access is limited to inducing the private SQLite state needed to reproduce the stale resident-handle bug, and the test `ENOENT` catch only ignores optional SQLite sidecar files.
- What did NOT change: schema, metadata format, provider selection, vector behavior, ranking, gateway API, auth, watcher behavior, and atomic file-swap ordering are unchanged; only stale missing-handle recovery was added.
- Related open PR / competition scan: this is an update to the existing PR #91227 for #91216; it is not a replacement or competing PR.

## Linked context

Closes #91216

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: a running gateway should recover when its resident memory index handle has missing metadata but the live `main.sqlite` has been rebuilt with valid metadata.
- Real environment tested: real OpenClaw gateway HTTP process, real `node:sqlite`, real filesystem renames, FTS-only memory index (`provider=none`, `model=fts-only`), and external HTTP `/tools/invoke` calls to `memory_search`.
- Exact steps or command run after this patch:
  1. Created an isolated memory corpus and preindexed it into `main.sqlite`.
  2. Started the gateway with token auth on loopback.
  3. Sent an external HTTP `memory_search` request to force the resident gateway manager to open the index handle.
  4. Deleted `memory_index_meta_v1` from that DB and moved the SQLite base/WAL/SHM files aside, leaving the running gateway with a stale missing-metadata handle.
  5. Rebuilt a healthy live `main.sqlite` through the normal memory index CLI path.
  6. Sent another external HTTP `memory_search` request through the still-running gateway.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Validation `live-gateway-stale-handle-memory-search` (pass, exit_code=0, 115499ms):

  ```text
  (node:795313) ExperimentalWarning: SQLite is an experimental feature and might change at any time
  (Use `node --trace-warnings ...` to show where the warning was created)
  [stale-handle-proof] gateway_ready=true
  [stale-handle-proof] resident_handle_opened=true initial_results=1
  [stale-handle-proof] resident_handle_forced_missing_metadata=true
  [stale-handle-proof] stale_sqlite_inode_moved_away=true
  [stale-handle-proof] live_index_rebuilt=true sqlite_meta_present=true chunks=129 provider=none model=fts-only
  [stale-handle-proof] memory_search_after_stale_handle ok=true results=1 duration_ms=491
  [stale-handle-proof] index_metadata_missing_response_hits=0
  [stale-handle-proof] index_metadata_missing_log_hits=0
  [stale-handle-proof] PASS running gateway reopened a stale missing-metadata memory index handle and served external memory_search from the healthy live index
  ```

- Observed result after fix: the same gateway process recovered from the stale missing-metadata handle, reopened the healthy live index, and returned a memory result; neither the HTTP response nor gateway log contained `index metadata is missing` after recovery.
- What was not tested: semantic vector-provider rebuilds and multi-agent gateway traffic were not live-tested here; this proof targets the FTS-only gateway path reported in #91216. The identity validation path is shared, and the regression suite covers the metadata/swap invariants.
- Proof limitations or environment constraints: this is local Linux runtime proof, not a deployed production environment. The SQLite warning above is Node's standard experimental `node:sqlite` warning.
- Before evidence: the new stale-handle regression test failed before this production fix because the resident manager continued reading the stale missing-metadata handle and returned no memory result.

## Tests and validation

Which commands did you run?

```text
pnpm lint --threads=8
pnpm run lint:extensions:bundled
node scripts/run-vitest.mjs extensions/memory-core/src/memory/index.test.ts extensions/memory-core/src/memory/manager.atomic-reindex.test.ts
```

Result:

```text
$ node scripts/run-oxlint-shards.mjs --threads=8
[oxlint:core] finished
[oxlint:extensions] finished
[oxlint:scripts] finished

$ node scripts/run-bundled-extension-oxlint.mjs
[plugin-sdk boundary dts] fresh; skipping
[plugin-sdk package boundary dts] fresh; skipping
[qa-channel boundary dts] fresh; skipping
[discord boundary dts] fresh; skipping
[slack boundary dts] fresh; skipping
[whatsapp boundary dts] fresh; skipping
[plugin-sdk boundary root shims] fresh; skipping

[test] starting test/vitest/vitest.extension-memory.config.ts

 RUN  v4.1.7 [local path redacted]

 Test Files  2 passed (2)
      Tests  63 passed (63)
   Start at  09:50:18
   Duration  85.62s (transform 16.70s, setup 1.09s, import 22.66s, tests 61.02s, environment 0ms)

[test] passed 1 Vitest shard in 125.31s
```

What regression coverage was added or updated?

- Added `reopens a stale missing-metadata handle when the live index is healthy`, which simulates a resident manager holding a missing-metadata SQLite handle while a fresh CLI manager rebuilds the live DB. The resident search must return the expected memory result and transition back to `valid`.
- Existing coverage still verifies that same-identity safe reindex keeps metadata and that atomic reindex keeps the prior base index reachable until the replacement base is published.

What failed before this fix, if known?

- The new stale-handle regression failed before the production fix: resident search did not find `memory/2026-01-12.md` after the live DB was rebuilt.
- The previously added safe-reindex regression failed before the metadata-cache fix with `index metadata is missing` after same-identity safe reindex.

If no test was added, why not?

- Regression coverage was added, and a current-head local gateway proof was run.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Memory search can recover automatically from a stale missing-metadata DB handle when the live index is valid, instead of requiring a gateway restart or another repair path.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

The highest-risk area is reopening the memory manager's SQLite handle without accidentally serving a stale or mismatched index.

How is that risk mitigated?

The recovery path only runs for `missing` identity, probes the live DB read-only to avoid creating an empty DB, validates the live metadata with the same identity rules used elsewhere, and only swaps handles when the live state is `valid`. Mismatched identity remains fail-closed.

## Current review state

What is the next action?

Ready for maintainer review after the PR update and remote checks settle.

What is still waiting on author, maintainer, CI, or external proof?

Remote checks need to run on the updated commit after submit. No known local author blocker remains.

Which bot or reviewer comments were addressed?

- RF-001: current local validation is bound to commit `a9b8bb4f7a`; remote checks still need to run after the branch update.
- RF-002: addressed with a current-head live gateway proof for the stale missing-metadata handle recovery path plus 63 passing memory-core regression tests.
- RF-003: bounded as a remote-check item after push; semantic vector-provider rebuilds and multi-agent live traffic remain outside the local live proof, while identity validation and DB-handle swap safety are covered by shared regression paths.
