### PR TITLE
fix(cron): preserve isolated agent turn payload message

### DIFF
--- a/src/cron/isolated-agent/run.payload-fallbacks.test.ts
+++ b/src/cron/isolated-agent/run.payload-fallbacks.test.ts
@@ -41,6 +41,7 @@ describe("runCronIsolatedAgentTurn — payload.fallbacks", () => {
 
   it("uses the persisted agentTurn payload message when the dispatch message is malformed", async () => {
     mockRunCronFallbackPassthrough();
+    const dispatchMessage = "SERIALIZATION_PROBE should not be wrapped";
 
     const result = await runCronIsolatedAgentTurn(
       makeIsolatedAgentTurnParams({
@@ -51,7 +52,7 @@ describe("runCronIsolatedAgentTurn — payload.fallbacks", () => {
               "SERIALIZATION_PROBE: reply exactly with the marker token you received and nothing else.",
           },
         }),
-        message: { message: "SERIALIZATION_PROBE should not be wrapped" } as unknown as string,
+        message: { message: dispatchMessage } as unknown as string,
       }),
     );
 
@@ -59,6 +60,7 @@ describe("runCronIsolatedAgentTurn — payload.fallbacks", () => {
     expect(runEmbeddedAgentMock).toHaveBeenCalledOnce();
     const request = runEmbeddedAgentMock.mock.calls[0]?.[0] as { prompt?: unknown } | undefined;
     expect(request?.prompt).toContain("SERIALIZATION_PROBE: reply exactly");
+    expect(request?.prompt).not.toContain(dispatchMessage);
     expect(request?.prompt).not.toContain("[object Object]");
   });
 

--- a/src/cron/isolated-agent/run.payload-fallbacks.test.ts
+++ b/src/cron/isolated-agent/run.payload-fallbacks.test.ts
@@ -39,6 +39,29 @@ function requireModelFallbackRequest(): {
 describe("runCronIsolatedAgentTurn — payload.fallbacks", () => {
   setupRunCronIsolatedAgentTurnSuite({ fast: true });
 
+  it("uses the persisted agentTurn payload message when the dispatch message is malformed", async () => {
+    mockRunCronFallbackPassthrough();
+
+    const result = await runCronIsolatedAgentTurn(
+      makeIsolatedAgentTurnParams({
+        job: makeIsolatedAgentTurnJob({
+          payload: {
+            kind: "agentTurn",
+            message:
+              "SERIALIZATION_PROBE: reply exactly with the marker token you received and nothing else.",
+          },
+        }),
+        message: { message: "SERIALIZATION_PROBE should not be wrapped" } as unknown as string,
+      }),
+    );
+
+    expect(result.status).toBe("ok");
+    expect(runEmbeddedAgentMock).toHaveBeenCalledOnce();
+    const request = runEmbeddedAgentMock.mock.calls[0]?.[0] as { prompt?: unknown } | undefined;
+    expect(request?.prompt).toContain("SERIALIZATION_PROBE: reply exactly");
+    expect(request?.prompt).not.toContain("[object Object]");
+  });
+
   it.each([
     {
       name: "passes payload.fallbacks as fallbacksOverride when defined",

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -456,6 +456,13 @@ type RunCronAgentTurnParams = {
   lane?: string;
 };
 
+function resolveCronAgentTurnMessage(input: RunCronAgentTurnParams): string {
+  if (input.job.payload.kind === "agentTurn") {
+    return input.job.payload.message;
+  }
+  return input.message;
+}
+
 type WithRunSession = (
   result: Omit<RunCronAgentTurnResult, "sessionId" | "sessionKey">,
 ) => RunCronAgentTurnResult;
@@ -765,7 +772,8 @@ async function prepareCronRunContext(params: {
     });
 
   const { formattedTime, timeLine } = resolveCronStyleNow(input.cfg, now);
-  const base = `[cron:${input.job.id} ${input.job.name}] ${input.message}`.trim();
+  const message = resolveCronAgentTurnMessage(input);
+  const base = `[cron:${input.job.id} ${input.job.name}] ${message}`.trim();
   const isExternalHook =
     hookExternalContentSource !== undefined || isExternalHookSession(baseSessionKey);
   const allowUnsafeExternalContent =
@@ -776,7 +784,7 @@ async function prepareCronRunContext(params: {
 
   if (isExternalHook) {
     const { detectSuspiciousPatterns } = await loadCronExternalContentRuntime();
-    const suspiciousPatterns = detectSuspiciousPatterns(input.message);
+    const suspiciousPatterns = detectSuspiciousPatterns(message);
     if (suspiciousPatterns.length > 0) {
       logWarn(
         `[security] Suspicious patterns detected in external hook content ` +
@@ -789,7 +797,7 @@ async function prepareCronRunContext(params: {
     const { buildSafeExternalPrompt } = await loadCronExternalContentRuntime();
     const hookType = mapHookExternalContentSource(hookExternalContentSource ?? "webhook");
     const safeContent = buildSafeExternalPrompt({
-      content: input.message,
+      content: message,
       source: hookType,
       jobName: input.job.name,
       jobId: input.job.id,

--- a/src/cron/service/ops.regression.test.ts
+++ b/src/cron/service/ops.regression.test.ts
@@ -264,6 +264,41 @@ describe("cron service ops regressions", () => {
     expect((staleExecuted?.state.nextRunAtMs ?? 0) > nowMs).toBe(true);
   });
 
+  it("passes the rehydrated agentTurn payload message to isolated manual runs", async () => {
+    const store = opsRegressionFixtures.makeStorePath();
+    const nowMs = Date.now();
+    const marker =
+      "SERIALIZATION_PROBE: reply exactly with the marker token you received and nothing else.";
+    const job = createIsolatedRegressionJob({
+      id: "manual-payload-message",
+      name: "manual payload message",
+      scheduledAt: nowMs,
+      schedule: { kind: "at", at: new Date(nowMs + 3_600_000).toISOString() },
+      payload: { kind: "agentTurn", message: marker },
+      state: { nextRunAtMs: nowMs + 3_600_000 },
+    });
+    await saveCronStore(store.storePath, { version: 1, jobs: [job] });
+
+    const runIsolatedAgentJob = vi.fn().mockResolvedValue({ status: "ok", summary: "ok" });
+    const state = createCronServiceState({
+      cronEnabled: false,
+      storePath: store.storePath,
+      log: noopLogger,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob,
+    });
+
+    const runResult = await run(state, job.id, "force");
+
+    expect(runResult).toEqual({ ok: true, ran: true });
+    expect(runIsolatedAgentJob).toHaveBeenCalledOnce();
+    const [params] = requireMockCall(runIsolatedAgentJob, 0, "runIsolatedAgentJob") as [
+      { message?: unknown }?,
+    ];
+    expect(params?.message).toBe(marker);
+  });
+
   it("applies timeoutSeconds to manual cron.run isolated executions", async () => {
     vi.useFakeTimers();
     try {


### PR DESCRIPTION
## Summary
- Keep isolated cron agent prompts sourced from the canonical `agentTurn` payload message instead of the duplicated dispatch `message` field.
- Cover the regression where a malformed dispatch message would otherwise stringify to `[object Object]` before reaching the isolated agent prompt.
- Add service coverage proving SQLite-rehydrated `agentTurn` jobs pass the configured payload message into isolated manual runs.

Fixes #91228

## Verification
- `node scripts/run-vitest.mjs src/cron/isolated-agent/run.payload-fallbacks.test.ts`
- `node scripts/run-vitest.mjs src/cron/store.test.ts src/cron/service/ops.regression.test.ts src/cron/isolated-agent/run*.test.ts`
- `node_modules/.bin/oxfmt --check src/cron/isolated-agent/run.ts src/cron/isolated-agent/run.payload-fallbacks.test.ts src/cron/service/ops.regression.test.ts`
- `git diff --check -- src/cron/isolated-agent/run.ts src/cron/isolated-agent/run.payload-fallbacks.test.ts src/cron/service/ops.regression.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode commit --commit HEAD` -> clean, no accepted/actionable findings

## Real behavior proof
Behavior addressed: Isolated `agentTurn` cron runs now build the prompt from the persisted `job.payload.message` string, so a malformed duplicated dispatch message cannot become `[object Object]` in the LLM prompt.
Real environment tested: Local macOS checkout at `a4464dacc4` using a temporary `OPENCLAW_STATE_DIR`, the real OpenClaw SQLite cron store, and the real cron service `cron.run` boundary.
Exact steps or command run after this patch: `OPENCLAW_STATE_DIR=/tmp/openclaw-91228-proof.<redacted>/state node_modules/.bin/tsx <temporary proof script>`
Evidence after fix: Terminal output from the real OpenClaw cron store/service path:
```json
{
  "openclawHead": "a4464dacc4",
  "stateDir": "/tmp/openclaw-91228-proof.<redacted>/state",
  "persistedPayloadType": "string",
  "persistedPayloadMessage": "SERIALIZATION_PROBE: reply exactly with the marker token you received and nothing else.",
  "runResult": {
    "ok": true,
    "ran": true
  },
  "observedDispatchType": "string",
  "observedDispatchMessage": "SERIALIZATION_PROBE: reply exactly with the marker token you received and nothing else.",
  "containsObjectObject": false
}
```
Observed result after fix: A real SQLite-backed cron job persisted `payload.message` as a string, `cron.run` returned `{ ok: true, ran: true }`, and the isolated runner dispatch boundary observed the exact `SERIALIZATION_PROBE` string with `containsObjectObject: false`.
What was not tested: I did not run a live provider-backed cron job against Anthropic/Claude; this patch is covered at the scheduler, SQLite rehydration, and isolated runner prompt-construction boundaries.
