### PR TITLE
fix(anthropic): drop reasoning_content replay signatures

### DIFF
--- a/src/llm/providers/anthropic.test.ts
+++ b/src/llm/providers/anthropic.test.ts
@@ -81,7 +81,7 @@ describe("Anthropic provider", () => {
     expect(config.defaultHeaders?.["cf-aig-authorization"]).toBe("Bearer gateway-token");
   });
 
-  it("preserves provider-signed Anthropic thinking text on replay", async () => {
+  it("preserves provider-signed Anthropic thinking and drops reasoning_content placeholders", async () => {
     const highSurrogate = String.fromCharCode(0xd83d);
     const signedThinking = `keep${highSurrogate}signed`;
     let capturedPayload: unknown;
@@ -161,11 +161,6 @@ describe("Anthropic provider", () => {
         type: "thinking",
         thinking: signedThinking,
         signature: "sig_1",
-      },
-      {
-        type: "thinking",
-        thinking: "sanitizesynthetic",
-        signature: "reasoning_content",
       },
     ]);
   });

--- a/src/llm/providers/anthropic.test.ts
+++ b/src/llm/providers/anthropic.test.ts
@@ -156,6 +156,7 @@ describe("Anthropic provider", () => {
 
     const payload = capturedPayload as { messages: Array<{ role: string; content: unknown[] }> };
     const assistantMessage = payload.messages.find((message) => message.role === "assistant");
+    expect(JSON.stringify(assistantMessage?.content)).not.toContain("reasoning_content");
     expect(assistantMessage?.content).toEqual([
       {
         type: "thinking",

--- a/src/llm/providers/anthropic.ts
+++ b/src/llm/providers/anthropic.ts
@@ -1132,13 +1132,14 @@ function convertMessages(
               text: sanitizeSurrogates(block.thinking),
             });
           } else {
-            const thinking =
-              block.thinkingSignature === "reasoning_content"
-                ? sanitizeSurrogates(block.thinking)
-                : block.thinking;
+            // OpenAI-compatible reasoning markers are field names, not native
+            // Anthropic replay signatures; sending them bricks persisted replays.
+            if (block.thinkingSignature === "reasoning_content") {
+              continue;
+            }
             blocks.push({
               type: "thinking",
-              thinking,
+              thinking: block.thinking,
               signature: block.thinkingSignature,
             });
           }


### PR DESCRIPTION
## Summary

- Drop persisted OpenAI-compatible `reasoning_content` thinking placeholders before constructing native Anthropic `thinking` replay blocks.
- Preserve real provider-signed Anthropic thinking blocks unchanged.
- Update the Anthropic provider replay test so a mixed persisted assistant turn no longer sends `signature: "reasoning_content"` to Anthropic.

Fixes #91205

## Verification

- `node scripts/run-vitest.mjs src/llm/providers/anthropic.test.ts` — 1 file passed, 8 tests passed.
- `pnpm format:check src/llm/providers/anthropic.ts src/llm/providers/anthropic.test.ts` — passed.
- `node scripts/run-oxlint.mjs src/llm/providers/anthropic.ts src/llm/providers/anthropic.test.ts` — passed.
- `.agents/skills/autoreview/scripts/autoreview --mode local` — clean, no accepted/actionable findings.

Dependency contract checked: `@anthropic-ai/sdk@0.100.1` declares native `ThinkingBlockParam` as `{ type: "thinking", thinking: string, signature: string }`; `reasoning_content` is an OpenAI-compatible field marker, not a native Anthropic replay signature.

## Real behavior proof

Behavior addressed: A persisted assistant turn containing `thinkingSignature: "reasoning_content"` no longer produces an Anthropic HTTP request body with `signature: "reasoning_content"`, preventing native Anthropic from rejecting future replay requests with invalid thinking signatures.
Real environment tested: Local OpenClaw source checkout using the production `streamAnthropic` provider and the real HTTP request path against a temporary local SSE endpoint that captured the outbound `/v1/messages` request body.
Exact steps or command run after this patch: `node --import tsx` script that started a temporary `127.0.0.1` Anthropic-compatible SSE server, invoked `streamAnthropic` with a persisted assistant message containing both `thinkingSignature: "sig_valid"` and `thinkingSignature: "reasoning_content"`, then printed the captured request payload summary.
Evidence after fix: Captured request output:

```json
{
  "method": "POST",
  "url": "/v1/messages",
  "assistantContent": [
    {
      "type": "thinking",
      "thinking": "valid signed reasoning",
      "signature": "sig_valid"
    },
    {
      "type": "text",
      "text": "visible answer"
    }
  ],
  "thinkingSignatures": ["sig_valid"],
  "sentReasoningContentSignature": false
}
```

Observed result after fix: The actual outbound Anthropic request preserved the real signed thinking block, kept visible assistant text, and did not send any `signature: "reasoning_content"` block.
What was not tested: A paid live Anthropic API call with production credentials; the local proof uses the real OpenClaw provider and HTTP request path but terminates at a local SSE endpoint to avoid secrets and external billing.
