### PR TITLE
fix #91224: Bug: internal inter-session confirmation acks leak to external channels

### DIFF
--- a/src/agents/command/delivery.test.ts
+++ b/src/agents/command/delivery.test.ts
@@ -408,6 +408,70 @@ describe("normalizeAgentCommandReplyPayloads", () => {
     });
   });
 
+  it("uses provenance source channel when suppressing subagent announce acks with external delivery hints", async () => {
+    const delivered = await deliverAgentCommandResult({
+      cfg: {
+        agents: {
+          list: [{ id: "tester", workspace: "/tmp/agent-workspace" }],
+        },
+      } as OpenClawConfig,
+      deps: {} as CliDeps,
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      opts: {
+        message: "subagent ack",
+        deliver: true,
+        bestEffortDeliver: true,
+        channel: "slack",
+        accountId: "workspace-1",
+        to: "U123",
+        sessionKey: "agent:tester:main",
+        inputProvenance: {
+          kind: "inter_session",
+          sourceChannel: "webchat",
+          sourceTool: "subagent_announce",
+        },
+      } as AgentCommandOpts,
+      outboundSession: {
+        key: "agent:tester:main",
+        agentId: "tester",
+      } as never,
+      sessionEntry: {
+        sessionId: "session-1",
+        updatedAt: 1,
+        deliveryContext: {
+          channel: "slack",
+          to: "U123",
+          accountId: "workspace-1",
+        },
+      },
+      payloads: [{ text: "Confirmation received; the parent message was delivered." }],
+      result: {
+        ...createResult(),
+        didSendViaMessagingTool: true,
+        messagingToolSentTargets: [
+          {
+            tool: "message",
+            provider: "slack",
+            to: "U123",
+            text: "The subagent completion already reached the user.",
+          },
+        ],
+      } as RunResult,
+    });
+
+    expect(deliverOutboundPayloadsMock).not.toHaveBeenCalled();
+    expect(delivered.deliverySucceeded).toBe(true);
+    expect(delivered.didSendViaMessagingTool).toBe(true);
+    expectDeliveryStatusFields(delivered, {
+      requested: true,
+      attempted: false,
+      status: "suppressed",
+      succeeded: true,
+      reason: "inter_session_control_reply",
+      resultCount: 0,
+    });
+  });
+
   it("keeps delivering genuine internal inter-session completions without messaging-tool evidence", async () => {
     deliverOutboundPayloadsMock.mockResolvedValue([{ channel: "slack", messageId: "msg-1" }]);
 

--- a/src/agents/command/delivery.test.ts
+++ b/src/agents/command/delivery.test.ts
@@ -346,6 +346,123 @@ describe("normalizeAgentCommandReplyPayloads", () => {
     });
   });
 
+  it("suppresses internal inter-session messaging-tool acknowledgements before external delivery", async () => {
+    const delivered = await deliverAgentCommandResult({
+      cfg: {
+        agents: {
+          list: [{ id: "tester", workspace: "/tmp/agent-workspace" }],
+        },
+      } as OpenClawConfig,
+      deps: {} as CliDeps,
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      opts: {
+        message: "internal ack",
+        deliver: true,
+        bestEffortDeliver: true,
+        messageChannel: "webchat",
+        sessionKey: "agent:tester:main",
+        inputProvenance: {
+          kind: "inter_session",
+          sourceChannel: "webchat",
+          sourceTool: "sessions_send",
+        },
+      } as AgentCommandOpts,
+      outboundSession: {
+        key: "agent:tester:main",
+        agentId: "tester",
+      } as never,
+      sessionEntry: {
+        sessionId: "session-1",
+        updatedAt: 1,
+        deliveryContext: {
+          channel: "slack",
+          to: "U123",
+          accountId: "workspace-1",
+        },
+      },
+      payloads: [{ text: "I've received the confirmation that the message was routed." }],
+      result: {
+        ...createResult(),
+        didSendViaMessagingTool: true,
+        messagingToolSentTargets: [
+          {
+            tool: "message",
+            provider: "slack",
+            to: "U123",
+            text: "The actual user-facing reply.",
+          },
+        ],
+      } as RunResult,
+    });
+
+    expect(deliverOutboundPayloadsMock).not.toHaveBeenCalled();
+    expect(delivered.deliverySucceeded).toBe(true);
+    expect(delivered.didSendViaMessagingTool).toBe(true);
+    expectDeliveryStatusFields(delivered, {
+      requested: true,
+      attempted: false,
+      status: "suppressed",
+      succeeded: true,
+      reason: "inter_session_control_reply",
+      resultCount: 0,
+    });
+  });
+
+  it("keeps delivering genuine internal inter-session completions without messaging-tool evidence", async () => {
+    deliverOutboundPayloadsMock.mockResolvedValue([{ channel: "slack", messageId: "msg-1" }]);
+
+    const delivered = await deliverAgentCommandResult({
+      cfg: {
+        agents: {
+          list: [{ id: "tester", workspace: "/tmp/agent-workspace" }],
+        },
+      } as OpenClawConfig,
+      deps: {} as CliDeps,
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      opts: {
+        message: "internal completion",
+        deliver: true,
+        bestEffortDeliver: true,
+        messageChannel: "webchat",
+        sessionKey: "agent:tester:main",
+        inputProvenance: {
+          kind: "inter_session",
+          sourceChannel: "webchat",
+          sourceTool: "sessions_send",
+        },
+      } as AgentCommandOpts,
+      outboundSession: {
+        key: "agent:tester:main",
+        agentId: "tester",
+      } as never,
+      sessionEntry: {
+        sessionId: "session-1",
+        updatedAt: 1,
+        deliveryContext: {
+          channel: "slack",
+          to: "U123",
+          accountId: "workspace-1",
+        },
+      },
+      payloads: [{ text: "The requested summary is ready." }],
+      result: createResult(),
+    });
+
+    expect(deliverOutboundPayloadsMock).toHaveBeenCalledTimes(1);
+    const deliverArgs = latestOutboundDeliveryArgs();
+    expect(deliverArgs.channel).toBe("slack");
+    expect(deliverArgs.to).toBe("U123");
+    expectTextPayload(deliverArgs.payloads[0], "The requested summary is ready.");
+    expect(delivered.deliverySucceeded).toBe(true);
+    expectDeliveryStatusFields(delivered, {
+      requested: true,
+      attempted: true,
+      status: "sent",
+      succeeded: true,
+      resultCount: 1,
+    });
+  });
+
   it("refreshes stale implicit session routing before final delivery", async () => {
     deliverOutboundPayloadsMock.mockResolvedValue([{ channel: "slack", messageId: "msg-1" }]);
     const runtime = { log: vi.fn(), error: vi.fn() };

--- a/src/agents/command/delivery.ts
+++ b/src/agents/command/delivery.ts
@@ -33,6 +33,7 @@ import type { OutboundSessionContext } from "../../infra/outbound/session-contex
 import { type RuntimeEnv, writeRuntimeJson } from "../../runtime.js";
 import { isInternalMessageChannel } from "../../utils/message-channel.js";
 import type { MessagingToolSend } from "../embedded-agent-messaging.types.js";
+import { hasMessagingToolDeliveryEvidence } from "../embedded-agent-runner/delivery-evidence.js";
 import type { EmbeddedAgentRunMeta } from "../embedded-agent-runner/types.js";
 import { isNestedAgentLane } from "../lanes.js";
 import type { AgentCommandOpts, AgentCommandResultMetaOverrides } from "./types.js";
@@ -188,15 +189,6 @@ function hasNonEmptyStringArray(value: unknown): value is string[] {
 
 function hasNonEmptyArray<T>(value: T[] | undefined): value is T[] {
   return Array.isArray(value) && value.length > 0;
-}
-
-function hasMessagingToolDeliveryEvidence(result: RunResult): boolean {
-  return (
-    result.didSendViaMessagingTool === true ||
-    hasNonEmptyStringArray(result.messagingToolSentTexts) ||
-    hasNonEmptyStringArray(result.messagingToolSentMediaUrls) ||
-    hasNonEmptyArray(result.messagingToolSentTargets)
-  );
 }
 
 function isInternalInterSessionControlReplySource(opts: AgentCommandOpts): boolean {

--- a/src/agents/command/delivery.ts
+++ b/src/agents/command/delivery.ts
@@ -87,6 +87,10 @@ export type AgentCommandDeliveryResult = {
 };
 
 const NESTED_LOG_PREFIX = "[agent:nested]";
+const INTER_SESSION_CONTROL_REPLY_SOURCE_TOOLS: ReadonlySet<string> = new Set([
+  "sessions_send",
+  "subagent_announce",
+]);
 
 type FreshSessionEntryForDeliveryResolver = () => Promise<SessionEntry | undefined>;
 
@@ -184,6 +188,76 @@ function hasNonEmptyStringArray(value: unknown): value is string[] {
 
 function hasNonEmptyArray<T>(value: T[] | undefined): value is T[] {
   return Array.isArray(value) && value.length > 0;
+}
+
+function hasMessagingToolDeliveryEvidence(result: RunResult): boolean {
+  return (
+    result.didSendViaMessagingTool === true ||
+    hasNonEmptyStringArray(result.messagingToolSentTexts) ||
+    hasNonEmptyStringArray(result.messagingToolSentMediaUrls) ||
+    hasNonEmptyArray(result.messagingToolSentTargets)
+  );
+}
+
+function isInternalInterSessionControlReplySource(opts: AgentCommandOpts): boolean {
+  const provenance = opts.inputProvenance;
+  if (provenance?.kind !== "inter_session") {
+    return false;
+  }
+  const sourceTool = provenance.sourceTool?.trim().toLowerCase();
+  if (!sourceTool || !INTER_SESSION_CONTROL_REPLY_SOURCE_TOOLS.has(sourceTool)) {
+    return false;
+  }
+  const sourceChannel =
+    opts.runContext?.messageChannel ??
+    opts.messageChannel ??
+    opts.channel ??
+    provenance.sourceChannel;
+  return isInternalMessageChannel(sourceChannel);
+}
+
+function isSingleTextOnlyPayload(payloads: readonly NormalizedOutboundPayload[]): boolean {
+  if (payloads.length !== 1) {
+    return false;
+  }
+  const payload = payloads[0];
+  return Boolean(
+    payload?.text.trim() &&
+    payload.mediaUrls.length === 0 &&
+    payload.audioAsVoice !== true &&
+    !payload.presentation &&
+    !payload.delivery &&
+    !payload.interactive &&
+    !payload.channelData &&
+    !payload.hookContent,
+  );
+}
+
+function shouldSuppressInterSessionControlReply(params: {
+  opts: AgentCommandOpts;
+  result: RunResult;
+  deliveryChannel: string;
+  deliveryTarget?: string | null;
+  deliveryPayloads: readonly NormalizedOutboundPayload[];
+}): boolean {
+  return (
+    !isInternalMessageChannel(params.deliveryChannel) &&
+    Boolean(params.deliveryTarget) &&
+    isInternalInterSessionControlReplySource(params.opts) &&
+    hasMessagingToolDeliveryEvidence(params.result) &&
+    isSingleTextOnlyPayload(params.deliveryPayloads)
+  );
+}
+
+function interSessionControlReplyStatus(): AgentCommandDeliveryStatus {
+  return {
+    requested: true,
+    attempted: false,
+    status: "suppressed",
+    succeeded: true,
+    reason: "inter_session_control_reply",
+    resultCount: 0,
+  };
 }
 
 function buildDeliveryResult(params: {
@@ -707,6 +781,26 @@ export async function deliverAgentCommandResult(
     }
     emitJsonEnvelope();
     return buildDeliveryResult({ payloads: normalizedPayloads, meta: resultMeta, result });
+  }
+  if (
+    !deliveryStatus &&
+    shouldSuppressInterSessionControlReply({
+      opts,
+      result,
+      deliveryChannel,
+      deliveryTarget,
+      deliveryPayloads,
+    })
+  ) {
+    deliveryStatus = interSessionControlReplyStatus();
+    emitJsonEnvelope(deliveryStatus);
+    return buildDeliveryResult({
+      payloads: normalizedPayloads,
+      meta: resultMeta,
+      result,
+      deliverySucceeded: true,
+      deliveryStatus,
+    });
   }
   if (deliver && deliveryChannel && !isInternalMessageChannel(deliveryChannel)) {
     if (deliveryTarget && !deliveryStatus) {

--- a/src/agents/command/delivery.ts
+++ b/src/agents/command/delivery.ts
@@ -209,10 +209,7 @@ function isInternalInterSessionControlReplySource(opts: AgentCommandOpts): boole
     return false;
   }
   const sourceChannel =
-    opts.runContext?.messageChannel ??
-    opts.messageChannel ??
-    opts.channel ??
-    provenance.sourceChannel;
+    opts.runContext?.messageChannel ?? opts.messageChannel ?? provenance.sourceChannel;
   return isInternalMessageChannel(sourceChannel);
 }
 


### PR DESCRIPTION
## Summary

- Problem: Internal inter-session confirmation acknowledgements from `sessions_send` or `subagent_announce` could inherit the parent session's persisted external route and leak to a Slack DM after the actual user-facing reply had already been delivered.
- Solution: Suppress only structurally identified internal control replies at the final delivery boundary when messaging-tool delivery evidence already exists, and classify the internal source from run/message/provenance source metadata rather than external delivery hints.
- What changed: `deliverAgentCommandResult` now checks inter-session provenance, source tool, internal source channel, external resolved target, messaging-tool evidence, and single text-only payload shape before returning a suppressed delivery status.
- What did NOT change: Genuine inter-session completions without messaging-tool evidence still deliver to external routes; rich/media/non-text payloads are unchanged; channel provider APIs, schemas, configs, defaults, and migrations are out of scope and unchanged.
- Why it matters / User impact: Users no longer see internal routing confirmations in external channels while legitimate agent completions continue to reach the conversation that established the route.
- Fixes #91224

## Real behavior proof

- **Behavior or issue addressed:** Internal inter-session confirmation acknowledgements from `sessions_send` and `subagent_announce` no longer leak to the parent session's persisted external Slack route after the actual user-facing reply has already been delivered through the messaging tool; genuine inter-session completions still deliver externally.
- **Real environment tested:** Local Linux OpenClaw worktree for PR #91234 after this patch, using the production `deliverAgentCommandResult` and durable channel delivery path with a local Slack outbound adapter registered through the active channel registry.
- **Exact steps or command run after this patch:** Ran the local production delivery proof with `node --import tsx`; full command:
```bash
set -a; . "/media/vdc/code/ai/aispace/openclaw-issue-91224-evidence/context.env"; set +a; cd "$TASK_WORKTREE" && node --import tsx "$EVIDENCE_DIR/local-inter-session-ack-proof.mjs" > "$EVIDENCE_DIR/local-inter-session-ack-delivery-proof.clean.log"
```
- **Evidence after fix:** The command wrote `/media/vdc/code/ai/aispace/openclaw-issue-91224-evidence/local-inter-session-ack-delivery-proof.clean.log` with these key results:
```text
productionPath:
- deliverAgentCommandResult resolved the parent session's persisted Slack delivery route
- sendDurableMessageBatch used the active channel registry and local Slack outbound adapter
- internal inter-session provenance came from the production AgentCommandOpts/InputProvenance surface
- subagent_announce proof used an explicit external opts.channel delivery hint while provenance.sourceChannel stayed internal

leakCandidateWithoutControlEvidence:
  sourceTool: sessions_send
  deliveryStatus.status: sent
  sendCount: 1

suppressedSessionsSendAck:
  sourceTool: sessions_send
  deliveryStatus.status: suppressed
  deliveryStatus.reason: inter_session_control_reply
  didSendViaMessagingTool: true
  sendCount: 0

suppressedSubagentAnnounceAck:
  name: suppressed-subagent-announce-ack-with-external-delivery-hint
  sourceTool: subagent_announce
  deliveryStatus.status: suppressed
  deliveryStatus.reason: inter_session_control_reply
  didSendViaMessagingTool: true
  sendCount: 0

genuineCompletionStillDelivered:
  sourceTool: sessions_send
  deliveryStatus.status: sent
  sendCount: 1

checks:
  leakCandidateWithoutControlEvidenceSent: true
  sessionsSendAckSuppressed: true
  subagentAnnounceAckSuppressed: true
  genuineCompletionStillDelivered: true
  noRuntimeErrors: true
```
- **Observed result after fix:** Both internal control-reply cases returned `deliveryStatus.status: suppressed` with `reason: inter_session_control_reply` and made zero outbound Slack sends, including the `subagent_announce` case with explicit external `opts.channel: slack`. The genuine completion case still sent one message to the persisted Slack route. The same acknowledgement text without messaging-tool delivery evidence still sent normally, proving the suppression is metadata-driven rather than text-matched.
- **What was not tested:** Live Slack network/API delivery was not exercised because the bug is in OpenClaw's local delivery routing boundary before provider I/O; the proof uses a local Slack adapter to capture whether the production delivery path attempts an external send. Full live agent/subagent orchestration was not run, but the affected delivery boundary and related inter-session paths are covered by the local proof and validation below.

## Review findings addressed

- **RF-001:** Fixed. `isInternalInterSessionControlReplySource` now derives the source channel from `opts.runContext?.messageChannel`, `opts.messageChannel`, or `inputProvenance.sourceChannel`; it no longer treats `opts.channel` as the source channel. Added focused coverage for `subagent_announce` where `opts.channel` is the explicit external Slack delivery hint while `inputProvenance.sourceChannel` remains internal.
- **RF-002:** Fixed. The suppression predicate now reuses the canonical `hasMessagingToolDeliveryEvidence` helper from `src/agents/embedded-agent-runner/delivery-evidence.ts`; the local duplicate helper in `delivery.ts` was removed so the final-delivery suppression follows the shared outbound evidence contract.

## Regression Test Plan

- **Target test file:** `src/agents/command/delivery.test.ts`, with related coverage run through `src/agents/subagent-announce-delivery.test.ts` and `src/agents/tools/sessions-send-tool.a2a.test.ts`.
- **Scenario locked in:** An internal `webchat` inter-session result with `sourceTool: sessions_send`, persisted Slack delivery context, messaging-tool sent-target evidence, and a single text-only acknowledgement payload is suppressed before external delivery; `subagent_announce` is also suppressed when `opts.channel` is an explicit external delivery hint but provenance keeps the source channel internal; the same inter-session route without messaging-tool evidence still sends a genuine completion.
- **Why this is the smallest reliable guardrail:** The regression sits at `deliverAgentCommandResult`, the shared outbound boundary that actually decides whether the inherited external route is used, so it protects both affected tool paths without adding broader integration surface.

## Merge risk

- **Risk labels considered:** message-delivery.
- **Risk explanation:** This changes message-delivery behavior only for internal inter-session control replies that have already produced messaging-tool delivery evidence and are about to send a single text-only final acknowledgement to an external route.
- **Why acceptable:** The predicate is narrow, the source-of-truth decision is made before provider I/O at the production delivery boundary, and local proof plus regression coverage show the leak is suppressed while genuine completions continue to send.

## Root Cause

- **Root cause:** The delivery boundary reused the parent session's persisted external route for an internal inter-session run but lacked a structural invariant to distinguish a control acknowledgement from a real completion once the agent runner returned final text.
- **Why this is root-cause fix:** The fix adds that missing invariant at the source-of-truth delivery decision point: only internal inter-session results from `sessions_send` or `subagent_announce` with existing messaging-tool delivery evidence and a single text-only payload are suppressed before external provider delivery. The source-channel side of the invariant now comes from run/message/provenance source metadata, not from `opts.channel`, because `opts.channel` can be an external delivery hint in the subagent path. This prevents the incorrect send instead of filtering English acknowledgement text downstream.
- **Fix classification:** Root cause fix.
- **Maintainer-ready confidence:** High.
- **Patch quality notes:** Patch-quality warnings around default `return false` guard branches are intentional predicate boundaries, not fallback masking. Each guard rejects a condition where suppression would be unsafe, such as non-inter-session provenance, unsupported source tools, non-internal source channels, missing delivery target, or payload shapes that may represent real user content.
- **Architecture / source-of-truth check:** Source-of-truth is `deliverAgentCommandResult`, the delivery resolver that owns whether normalized agent command payloads are sent to an external channel. This does not change public API/config/schema/protocol/defaults/migrations; it only tightens the canonical session state and message-delivery decision before downstream provider adapters are invoked.

## Validation

```text
node scripts/run-vitest.mjs run src/agents/command/delivery.test.ts
Test Files  1 passed (1)
Tests  23 passed (23)

node scripts/run-vitest.mjs run src/agents/command/delivery.test.ts src/agents/subagent-announce-delivery.test.ts src/agents/tools/sessions-send-tool.a2a.test.ts
Test Files  3 passed (3)
Tests  137 passed (137)

node --import tsx "$EVIDENCE_DIR/local-inter-session-ack-proof.mjs"
checks.sessionsSendAckSuppressed: true
checks.subagentAnnounceAckSuppressed: true
checks.genuineCompletionStillDelivered: true
checks.noRuntimeErrors: true

pnpm tsgo:test
passed

pnpm lint
passed

pnpm format:check
All matched files use the correct format.

git diff --check
passed
```
