### PR TITLE
fix(codex): preserve native subagent completion results

### DIFF
--- a/extensions/codex/src/app-server/native-subagent-monitor.test.ts
+++ b/extensions/codex/src/app-server/native-subagent-monitor.test.ts
@@ -265,6 +265,158 @@ describe("CodexNativeSubagentMonitor", () => {
     );
   });
 
+  it("reconciles transcript final text before delivering empty Codex completion notifications", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-subagent-"));
+    const codexHome = path.join(tempDir, "codex-home");
+    const transcriptDir = path.join(codexHome, "sessions", "2026", "06", "07");
+    await fs.mkdir(transcriptDir, { recursive: true });
+    await fs.writeFile(
+      path.join(transcriptDir, "rollout-2026-06-07T08-21-40-child-thread.jsonl"),
+      [
+        JSON.stringify({
+          type: "session_meta",
+          payload: {
+            source: {
+              subagent: {
+                thread_spawn: {
+                  parent_thread_id: "parent-thread",
+                  depth: 1,
+                },
+              },
+            },
+          },
+        }),
+        JSON.stringify({
+          timestamp: "2026-06-07T08:22:40.000Z",
+          type: "event_msg",
+          payload: {
+            type: "task_complete",
+            last_agent_message: "child transcript final result",
+            completed_at: 1780816960,
+          },
+        }),
+        "",
+      ].join("\n"),
+    );
+    const client = createClient();
+    const runtime = createRuntime();
+    const monitor = new CodexNativeSubagentMonitor(client, runtime, {
+      codexHome,
+      transcriptPollDelaysMs: [60_000],
+    });
+    monitor.registerParent({
+      parentThreadId: "parent-thread",
+      requesterSessionKey: "agent:main:discord:channel:C123",
+      taskRuntimeScope: createTaskScope(),
+      agentId: "main",
+    });
+
+    await notifyChildStarted(client);
+    await client.notify(
+      nativeCompletionNotification({
+        agentPath: "child-thread",
+        statusLabel: "completed",
+        result: null,
+      }),
+    );
+
+    expect(runtime.finalizeTaskRunByRunId).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: "codex-thread:child-thread",
+        status: "succeeded",
+        terminalSummary: "child transcript final result",
+      }),
+    );
+    expect(runtime.deliverAgentHarnessTaskCompletion).toHaveBeenCalledTimes(1);
+    expect(runtime.deliverAgentHarnessTaskCompletion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        childSessionKey: "codex-thread:child-thread",
+        childSessionId: "child-thread",
+        status: "succeeded",
+        statusLabel: "task_complete",
+        result: "child transcript final result",
+      }),
+    );
+
+    client.close();
+  });
+
+  it("delivers a typed no-final reason when no transcript source is configured", async () => {
+    const client = createClient();
+    const runtime = createRuntime();
+    const monitor = new CodexNativeSubagentMonitor(client, runtime);
+    monitor.registerParent({
+      parentThreadId: "parent-thread",
+      requesterSessionKey: "agent:main:discord:channel:C123",
+      taskRuntimeScope: createTaskScope(),
+      agentId: "main",
+    });
+
+    await notifyChildStarted(client);
+    await client.notify(
+      nativeCompletionNotification({
+        agentPath: "child-thread",
+        statusLabel: "completed",
+        result: null,
+      }),
+    );
+
+    expect(runtime.deliverAgentHarnessTaskCompletion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        childSessionId: "child-thread",
+        status: "succeeded",
+        statusLabel: "completed_without_final_message",
+        result: "Codex native subagent completed without a final assistant message.",
+      }),
+    );
+  });
+
+  it("falls back to typed no-final delivery when transcript reconciliation is unavailable", async () => {
+    vi.useFakeTimers();
+    try {
+      const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-subagent-"));
+      const codexHome = path.join(tempDir, "codex-home");
+      const client = createClient();
+      const runtime = createRuntime();
+      const monitor = new CodexNativeSubagentMonitor(client, runtime, {
+        codexHome,
+        transcriptPollDelaysMs: [10],
+      });
+      monitor.registerParent({
+        parentThreadId: "parent-thread",
+        requesterSessionKey: "agent:main:discord:channel:C123",
+        taskRuntimeScope: createTaskScope(),
+        agentId: "main",
+      });
+
+      await notifyChildStarted(client);
+      await client.notify(
+        nativeCompletionNotification({
+          agentPath: "child-thread",
+          statusLabel: "completed",
+          result: null,
+        }),
+      );
+
+      expect(runtime.deliverAgentHarnessTaskCompletion).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(20);
+
+      expect(runtime.deliverAgentHarnessTaskCompletion).toHaveBeenCalledWith(
+        expect.objectContaining({
+          childSessionId: "child-thread",
+          status: "succeeded",
+          statusLabel: "completed_without_final_message",
+          result: "Codex native subagent completed without a final assistant message.",
+        }),
+      );
+
+      client.close();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("delivers failed parent wakeups from Codex errored subagent notifications", async () => {
     const client = createClient();
     const runtime = createRuntime();

--- a/extensions/codex/src/app-server/native-subagent-monitor.ts
+++ b/extensions/codex/src/app-server/native-subagent-monitor.ts
@@ -60,6 +60,7 @@ type ChildState = {
   completionDeliveryAttempt: number;
   completionDeliveryTimer?: ReturnType<typeof setTimeout>;
   deliveringCompletionKey?: string;
+  noFinalCompletionFallbackTimer?: ReturnType<typeof setTimeout>;
 };
 
 type TranscriptCompletion = CodexNativeSubagentCompletion & {
@@ -302,6 +303,15 @@ export class CodexNativeSubagentMonitor {
         continue;
       }
       const completion = toThreadCompletion(nativeCompletion, childState.childThreadId);
+      if (shouldWaitForTranscriptCompletion(completion, this.codexHome)) {
+        const eventAt = Date.now();
+        const reconciled = await this.reconcileChildTranscript(childState.childThreadId);
+        if (!reconciled) {
+          this.scheduleTranscriptPoll(childState);
+          this.scheduleNoFinalCompletionFallback(state, childState, completion, eventAt);
+        }
+        continue;
+      }
       await this.processCompletion(state, completion);
     }
   }
@@ -350,6 +360,10 @@ export class CodexNativeSubagentMonitor {
       if (childState.transcriptPollTimer) {
         clearTimeout(childState.transcriptPollTimer);
         childState.transcriptPollTimer = undefined;
+      }
+      if (childState.noFinalCompletionFallbackTimer) {
+        clearTimeout(childState.noFinalCompletionFallbackTimer);
+        childState.noFinalCompletionFallbackTimer = undefined;
       }
     }
     if (!state.requesterSessionKey) {
@@ -578,6 +592,35 @@ export class CodexNativeSubagentMonitor {
     unrefTimer(childState.transcriptPollTimer);
   }
 
+  private scheduleNoFinalCompletionFallback(
+    state: ParentState,
+    childState: ChildState,
+    completion: CodexNativeSubagentCompletion,
+    eventAt: number,
+  ): void {
+    if (childState.transcriptTerminal || childState.noFinalCompletionFallbackTimer) {
+      return;
+    }
+    const delayMs = noFinalCompletionFallbackDelayMs(this.transcriptPollDelaysMs);
+    childState.noFinalCompletionFallbackTimer = setTimeout(() => {
+      childState.noFinalCompletionFallbackTimer = undefined;
+      void this.reconcileChildTranscript(childState.childThreadId)
+        .catch((error: unknown) => {
+          embeddedAgentLog.warn("Failed to reconcile Codex native subagent transcript", {
+            childThreadId: childState.childThreadId,
+            error: formatErrorMessage(error),
+          });
+          return false;
+        })
+        .then((reconciled) => {
+          if (!reconciled && !childState.transcriptTerminal) {
+            void this.processCompletion(state, completion, eventAt);
+          }
+        });
+    }, delayMs);
+    unrefTimer(childState.noFinalCompletionFallbackTimer);
+  }
+
   private clearTimers(): void {
     if (this.taskRowReconcileTimer) {
       clearInterval(this.taskRowReconcileTimer);
@@ -591,6 +634,10 @@ export class CodexNativeSubagentMonitor {
       if (childState.completionDeliveryTimer) {
         clearTimeout(childState.completionDeliveryTimer);
         childState.completionDeliveryTimer = undefined;
+      }
+      if (childState.noFinalCompletionFallbackTimer) {
+        clearTimeout(childState.noFinalCompletionFallbackTimer);
+        childState.noFinalCompletionFallbackTimer = undefined;
       }
     }
   }
@@ -830,6 +877,23 @@ function toThreadCompletion(
   };
 }
 
+function shouldWaitForTranscriptCompletion(
+  completion: CodexNativeSubagentCompletion,
+  codexHome: string | undefined,
+): boolean {
+  return Boolean(
+    codexHome &&
+    completion.status === "succeeded" &&
+    completion.statusLabel === "completed_without_final_message",
+  );
+}
+
+function noFinalCompletionFallbackDelayMs(delays: readonly number[]): number {
+  const first = delays[0] ?? 0;
+  const second = delays[1] ?? 0;
+  return Math.max(1, first + second);
+}
+
 function readSpawnParentThreadId(thread: JsonObject | undefined): string | undefined {
   const source = isJsonObject(thread?.source) ? thread.source : undefined;
   const subAgent = isJsonObject(source?.subAgent) ? source.subAgent : undefined;
@@ -999,15 +1063,14 @@ async function readTranscriptCompletion(
     }
     const payloadType = readString(payload, "type");
     if (payloadType === "task_complete") {
+      const result =
+        readString(payload, "last_agent_message")?.trim() || readString(payload, "message")?.trim();
       completion = {
         childThreadId,
         parentThreadId,
         status: "succeeded",
-        statusLabel: "task_complete",
-        result:
-          readString(payload, "last_agent_message")?.trim() ||
-          readString(payload, "message")?.trim() ||
-          "(no output)",
+        statusLabel: result ? "task_complete" : "completed_without_final_message",
+        result: result ?? "Codex native subagent completed without a final assistant message.",
         completedAt: secondsToMillis(readNumber(payload, "completed_at")) ?? readTimestamp(entry),
       };
     } else if (payloadType === "task_failed") {

--- a/extensions/codex/src/app-server/native-subagent-monitor.ts
+++ b/extensions/codex/src/app-server/native-subagent-monitor.ts
@@ -304,6 +304,8 @@ export class CodexNativeSubagentMonitor {
       }
       const completion = toThreadCompletion(nativeCompletion, childState.childThreadId);
       if (shouldWaitForTranscriptCompletion(completion, this.codexHome)) {
+        // Codex can notify `completed: null` before the child transcript exposes
+        // its final assistant message; poll briefly before delivering the no-final fallback.
         const eventAt = Date.now();
         const reconciled = await this.reconcileChildTranscript(childState.childThreadId);
         if (!reconciled) {

--- a/extensions/codex/src/app-server/native-subagent-notification.test.ts
+++ b/extensions/codex/src/app-server/native-subagent-notification.test.ts
@@ -52,6 +52,30 @@ describe("Codex native subagent notifications", () => {
     ]);
   });
 
+  it("preserves Codex completed-without-final as a typed reason", () => {
+    expect(
+      extractCodexNativeSubagentCompletionsFromText(
+        '<subagent_notification>{"agent_path":"null-child","status":{"completed":null}}' +
+          "</subagent_notification>\n" +
+          '<subagent_notification>{"agent_path":"empty-child","status":{"completed":"  "}}' +
+          "</subagent_notification>",
+      ),
+    ).toEqual([
+      {
+        agentPath: "null-child",
+        status: "succeeded",
+        statusLabel: "completed_without_final_message",
+        result: "Codex native subagent completed without a final assistant message.",
+      },
+      {
+        agentPath: "empty-child",
+        status: "succeeded",
+        statusLabel: "completed_without_final_message",
+        result: "Codex native subagent completed without a final assistant message.",
+      },
+    ]);
+  });
+
   it("normalizes failed and cancelled status keys", () => {
     expect(
       extractCodexNativeSubagentCompletionsFromText(

--- a/extensions/codex/src/app-server/native-subagent-notification.ts
+++ b/extensions/codex/src/app-server/native-subagent-notification.ts
@@ -116,10 +116,13 @@ function readCompletionStatus(status: JsonObject):
     if (!mappedStatus) {
       continue;
     }
+    const result = stringifyResult(value, mappedStatus);
+    const noFinalAssistantMessage =
+      mappedStatus === "succeeded" && result.kind === "no_final_assistant_message";
     return {
       status: mappedStatus,
-      label: rawKey,
-      result: stringifyResult(value),
+      label: noFinalAssistantMessage ? "completed_without_final_message" : rawKey,
+      result: result.text,
     };
   }
   return undefined;
@@ -149,18 +152,42 @@ function mapCompletionStatus(value: string): CodexNativeSubagentCompletionStatus
   return undefined;
 }
 
-function stringifyResult(value: JsonValue | undefined): string {
+function stringifyResult(
+  value: JsonValue | undefined,
+  status: CodexNativeSubagentCompletionStatus,
+): {
+  text: string;
+  kind?: "no_final_assistant_message";
+} {
   if (typeof value === "string") {
-    return value.trim() || "(no output)";
+    const text = value.trim();
+    if (text) {
+      return { text };
+    }
+    return status === "succeeded"
+      ? completedWithoutFinalAssistantMessage()
+      : { text: "(no output)" };
   }
   if (value === null || value === undefined) {
-    return "(no output)";
+    return status === "succeeded"
+      ? completedWithoutFinalAssistantMessage()
+      : { text: "(no output)" };
   }
   try {
-    return JSON.stringify(value);
+    return { text: JSON.stringify(value) };
   } catch {
-    return "(unserializable output)";
+    return { text: "(unserializable output)" };
   }
+}
+
+function completedWithoutFinalAssistantMessage(): {
+  text: string;
+  kind: "no_final_assistant_message";
+} {
+  return {
+    text: "Codex native subagent completed without a final assistant message.",
+    kind: "no_final_assistant_message",
+  };
 }
 
 function readTrustedInterAgentCommunicationContent(item: JsonObject): string | undefined {


### PR DESCRIPTION
## Summary

Fixes #91120.
Refs #78656.

Codex native subagent notifications can report `status: { completed: null }` when the child completed without a final assistant message. OpenClaw was collapsing that state to `(no output)` and, when a notification arrived before transcript reconciliation, marking the child terminal before the transcript path could recover `last_agent_message`.

This PR keeps the change inside the Codex plugin surface:

- classifies `completed:null` and blank completed strings as `completed_without_final_message` instead of `(no output)`;
- lets transcript reconciliation win before delivering an empty successful native completion when `codexHome` is configured;
- adds a bounded fallback so missing/unreadable transcripts still deliver the typed no-final reason instead of leaving the parent stuck;
- keeps failed/cancelled null statuses on the existing `(no output)` behavior.

Dependency contract checked directly in sibling `../codex`:

- `../codex/codex-rs/protocol/src/protocol.rs:1574` defines `AgentStatus::Completed(Option<String>)`.
- `../codex/codex-rs/core/src/context/subagent_notification.rs:33` serializes subagent notifications with `agent_path` and `status`.
- `../codex/codex-rs/core/src/tools/handlers/multi_agents/wait.rs:178` builds `wait_agent` results from final `AgentStatus` entries.

## Real behavior proof

- **Behavior addressed:** Codex native subagent completion notification and `wait_agent`/transcript result can disagree when an early `completed:null` notification is delivered as `(no output)` before a later transcript final is available.
- **Real environment tested:** macOS local OpenClaw source checkout in the dedicated worktree `openclaw-91120`, with repo dependencies installed and OpenClaw Codex plugin modules executed through Node/tsx.
- **Exact steps or command run after this patch:**
  - `node --import tsx --input-type=module` terminal run importing `extensions/codex/src/app-server/native-subagent-notification.ts` and parsing real Codex native `<subagent_notification>` payloads.
  - `node --import tsx --input-type=module` terminal run importing `extensions/codex/src/app-server/native-subagent-monitor.ts`, creating a local Codex transcript under a temp `codexHome`, sending a real `rawResponseItem/completed` notification with `completed:null`, and printing the monitor delivery payload.
  - Supplemental checks: `node scripts/run-vitest.mjs extensions/codex/src/app-server/native-subagent-notification.test.ts extensions/codex/src/app-server/native-subagent-monitor.test.ts`; targeted `oxfmt`; targeted `oxlint`; `pnpm tsgo:test:extensions`; `.agents/skills/autoreview/scripts/autoreview --mode local`.
- **Evidence after fix:** Terminal capture from the parser run:

```text
OpenClaw Codex native subagent notification live output
[
  {
    "agentPath": "child-null",
    "status": "succeeded",
    "statusLabel": "completed_without_final_message",
    "result": "Codex native subagent completed without a final assistant message."
  },
  {
    "agentPath": "child-final",
    "status": "succeeded",
    "statusLabel": "completed",
    "result": "final research note"
  }
]
observed_null_status_label=completed_without_final_message
observed_null_result=Codex native subagent completed without a final assistant message.
observed_final_result=final research note
```

Terminal capture from the monitor/transcript run:

```text
OpenClaw Codex native subagent monitor live output
{
  "deliveredResult": "transcript final beats early null notification",
  "deliveredStatusLabel": "task_complete",
  "deliveredStatus": "succeeded"
}
```

Supplemental verification output:

```text
Vitest: Test Files 2 passed (2) / Tests 29 passed (29)
oxfmt targeted check: All matched files use the correct format.
targeted oxlint wrapper exited 0.
tsgo:test:extensions exited 0 after waiting on the local heavy-check lock.
autoreview rerun: autoreview clean: no accepted/actionable findings reported.
```

- **Observed result after fix:** `completed:null` is no longer surfaced as `(no output)`; it becomes `statusLabel: "completed_without_final_message"`. When a transcript final exists, the parent delivery uses the transcript `task_complete` result (`transcript final beats early null notification`) instead of the early empty notification. If transcript reconciliation is unavailable, bounded fallback delivers the typed no-final reason rather than leaving the parent without a completion wakeup.
- **What was not tested:** Live Telegram/Codex roundtrip with real native subagents was not run. Remote Crabbox/Testbox `check:changed` could not be started because this environment has no usable `crabbox` or `blacksmith` binary; `node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox ... pnpm check:changed` failed at wrapper sanity check before provisioning.
