### PR TITLE
fix: report Codex ChatGPT status auth

### DIFF
--- a/src/agents/cli-credentials.test.ts
+++ b/src/agents/cli-credentials.test.ts
@@ -448,6 +448,57 @@ describe("cli credentials", () => {
     });
   });
 
+  it("does not read stale Codex tokens when auth.json resolves to API-key mode", () => {
+    const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-codex-api-key-mode-"));
+    process.env.CODEX_HOME = tempHome;
+    const expSeconds = Math.floor(Date.parse("2026-03-24T12:34:56Z") / 1000);
+    execSyncMock.mockImplementation(() => {
+      throw new Error("not found");
+    });
+
+    const authPath = path.join(tempHome, "auth.json");
+    fs.mkdirSync(tempHome, { recursive: true, mode: 0o700 });
+    fs.writeFileSync(
+      authPath,
+      JSON.stringify({
+        auth_mode: "apikey",
+        OPENAI_API_KEY: "sk-codex-api-key",
+        tokens: {
+          access_token: createJwtWithExp(expSeconds),
+          refresh_token: "stale-file-refresh",
+        },
+      }),
+      "utf8",
+    );
+
+    expect(readCodexCliCredentials({ platform: "linux", execSync: execSyncMock })).toBeNull();
+  });
+
+  it("treats an empty Codex auth.json API-key field as API-key mode", () => {
+    const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-codex-empty-api-key-mode-"));
+    process.env.CODEX_HOME = tempHome;
+    const expSeconds = Math.floor(Date.parse("2026-03-24T12:34:56Z") / 1000);
+    execSyncMock.mockImplementation(() => {
+      throw new Error("not found");
+    });
+
+    const authPath = path.join(tempHome, "auth.json");
+    fs.mkdirSync(tempHome, { recursive: true, mode: 0o700 });
+    fs.writeFileSync(
+      authPath,
+      JSON.stringify({
+        OPENAI_API_KEY: "",
+        tokens: {
+          access_token: createJwtWithExp(expSeconds),
+          refresh_token: "stale-file-refresh",
+        },
+      }),
+      "utf8",
+    );
+
+    expect(readCodexCliCredentials({ platform: "linux", execSync: execSyncMock })).toBeNull();
+  });
+
   it("rejects Codex auth.json fallback expiry when stat and process clock are invalid", () => {
     const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-codex-invalid-clock-"));
     process.env.CODEX_HOME = tempHome;

--- a/src/agents/cli-credentials.ts
+++ b/src/agents/cli-credentials.ts
@@ -154,6 +154,14 @@ function resolveCodexHomePath(codexHome?: string) {
   }
 }
 
+function codexAuthJsonUsesChatGptTokens(data: Record<string, unknown>): boolean {
+  const authMode = typeof data.auth_mode === "string" ? data.auth_mode.toLowerCase() : undefined;
+  if (authMode) {
+    return authMode === "chatgpt" || authMode === "chatgptauthtokens";
+  }
+  return typeof data.OPENAI_API_KEY !== "string";
+}
+
 function resolveMiniMaxCliCredentialsPath(homeDir?: string) {
   const baseDir = homeDir ?? resolveUserPath("~");
   return path.join(baseDir, MINIMAX_CLI_CREDENTIALS_RELATIVE_PATH);
@@ -649,6 +657,9 @@ export function readCodexCliCredentials(options?: {
   }
 
   const data = raw as Record<string, unknown>;
+  if (!codexAuthJsonUsesChatGptTokens(data)) {
+    return null;
+  }
   const tokens = data.tokens as Record<string, unknown> | undefined;
   if (!tokens || typeof tokens !== "object") {
     return null;

--- a/src/agents/model-auth-label.test.ts
+++ b/src/agents/model-auth-label.test.ts
@@ -192,6 +192,39 @@ describe("resolveModelAuthLabel", () => {
     });
   });
 
+  it("uses Codex CLI auth for Codex-backed OpenAI before env fallback", () => {
+    mocks.ensureAuthProfileStore.mockReturnValue({
+      version: 1,
+      profiles: {},
+    } as never);
+    mocks.resolveAuthProfileOrder.mockReturnValue([]);
+    mocks.readCodexCliCredentialsCached.mockReturnValue({
+      type: "oauth",
+      provider: "openai",
+      access: "token",
+      refresh: "refresh",
+      expires: Date.now() + 60_000,
+    });
+    mocks.resolveEnvApiKey.mockReturnValue({
+      apiKey: "env-key-placeholder",
+      source: "env: OPENAI_API_KEY",
+    });
+
+    const label = resolveModelAuthLabel({
+      provider: "openai",
+      cfg: {},
+      codexCliCredentialsHome: "/tmp/openclaw-agent/codex-home",
+    });
+
+    expect(label).toBe("oauth (codex-cli)");
+    expect(mocks.readCodexCliCredentialsCached).toHaveBeenCalledWith({
+      codexHome: "/tmp/openclaw-agent/codex-home",
+      ttlMs: 5_000,
+      allowKeychainPrompt: false,
+    });
+    expect(mocks.resolveEnvApiKey).not.toHaveBeenCalled();
+  });
+
   it("shows claude cli auth for claude-cli provider without auth profiles", () => {
     mocks.ensureAuthProfileStore.mockReturnValue({
       version: 1,

--- a/src/agents/model-auth-label.ts
+++ b/src/agents/model-auth-label.ts
@@ -33,6 +33,7 @@ export function resolveModelAuthLabel(params: {
   sessionEntry?: Partial<Pick<SessionEntry, "authProfileOverride">>;
   agentDir?: string;
   workspaceDir?: string;
+  codexCliCredentialsHome?: string;
   includeExternalProfiles?: boolean;
   acceptedProviderIds?: readonly string[];
 }): string | undefined {
@@ -116,6 +117,18 @@ export function resolveModelAuthLabel(params: {
     // Preserve the fact that config pointed at a profile while avoiding a
     // misleading auth mode for an incompatible provider/profile pairing.
     return "unknown";
+  }
+
+  if (
+    params.codexCliCredentialsHome &&
+    (providerKey === "openai" || providerKey === "codex") &&
+    readCodexCliCredentialsCached({
+      codexHome: params.codexCliCredentialsHome,
+      ttlMs: 5_000,
+      allowKeychainPrompt: false,
+    })
+  ) {
+    return "oauth (codex-cli)";
   }
 
   const envKey = resolveEnvApiKey(providerKey, process.env, {

--- a/src/auto-reply/reply/commands-status.test.ts
+++ b/src/auto-reply/reply/commands-status.test.ts
@@ -791,6 +791,69 @@ describe("buildStatusReply subagent summary", () => {
     );
   });
 
+  it("uses the Codex app-server account before OpenAI env labels on Codex harness status", async () => {
+    registerStatusCodexHarness();
+
+    await withTempHome(
+      async (dir) => {
+        const agentDir = path.join(dir, ".openclaw", "agents", "main", "agent");
+        const codexHome = path.join(agentDir, "codex-home");
+        fs.mkdirSync(codexHome, { recursive: true });
+        fs.writeFileSync(
+          path.join(codexHome, "auth.json"),
+          JSON.stringify({
+            auth_mode: "chatgpt",
+            tokens: {
+              access_token: "codex-access-token",
+              refresh_token: "codex-refresh-token",
+            },
+          }),
+          "utf-8",
+        );
+
+        const text = await buildStatusText({
+          cfg: {
+            ...baseCfg,
+            agents: {
+              defaults: {
+                agentRuntime: { id: "codex" },
+              },
+            },
+          },
+          sessionEntry: {
+            sessionId: "sess-status-codex-home-oauth",
+            updatedAt: 0,
+          },
+          sessionKey: "agent:main:main",
+          parentSessionKey: "agent:main:main",
+          sessionScope: "per-sender",
+          statusChannel: "mobilechat",
+          provider: "openai",
+          model: "gpt-5.5",
+          contextTokens: 32_000,
+          resolvedFastMode: false,
+          resolvedVerboseLevel: "off",
+          resolvedReasoningLevel: "off",
+          resolveDefaultThinkingLevel: async () => undefined,
+          isGroup: false,
+          defaultGroupActivation: () => "mention",
+        });
+
+        const normalized = normalizeTestText(text);
+        expect(normalized).toContain("Model: openai/gpt-5.5");
+        expect(normalized).toContain("Runtime: OpenAI Codex");
+        expect(normalized).toContain("oauth (codex-cli)");
+        expect(normalized).not.toContain("api-key (env: OPENAI_API_KEY)");
+      },
+      {
+        env: {
+          OPENAI_API_KEY: "status-env-key-placeholder",
+          OPENAI_OAUTH_TOKEN: undefined,
+        },
+      },
+    );
+  });
+
   it("uses Codex usage for bare codex models running on the Codex harness", async () => {
     registerStatusCodexHarness();
 

--- a/src/status/status-text.ts
+++ b/src/status/status-text.ts
@@ -1,5 +1,6 @@
 // Status text helpers render runtime status summaries for CLI output.
 import os from "node:os";
+import path from "node:path";
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import {
   resolveAgentConfig,
@@ -57,6 +58,7 @@ const USAGE_OAUTH_ONLY_PROVIDERS = new Set([
   "google-gemini-cli",
   "openai",
 ]);
+const CODEX_APP_SERVER_HOME_DIRNAME = "codex-home";
 
 let statusMessageRuntimePromise: Promise<typeof import("../auto-reply/status.runtime.js")> | null =
   null;
@@ -249,6 +251,15 @@ function resolveStatusRuntimeProvider(params: {
   return params.provider;
 }
 
+function resolveStatusCodexCliCredentialsHome(params: {
+  agentDir: string;
+  effectiveHarness?: string;
+}): string | undefined {
+  return normalizeOptionalLowercaseString(params.effectiveHarness) === "codex"
+    ? path.join(params.agentDir, CODEX_APP_SERVER_HOME_DIRNAME)
+    : undefined;
+}
+
 function formatAgentTaskCountsLine(agentId: string): string | undefined {
   const snapshot = buildTaskStatusSnapshot(listTasksForAgentIdForStatus(agentId));
   if (snapshot.totalCount === 0) {
@@ -313,6 +324,10 @@ export async function buildStatusText(params: BuildStatusTextParams): Promise<st
       sessionKey,
       sessionEntry,
     }));
+  const codexCliCredentialsHome = resolveStatusCodexCliCredentialsHome({
+    agentDir: statusAgentDir,
+    effectiveHarness,
+  });
   const selectedStatusProvider = resolveStatusRuntimeProvider({
     provider,
     effectiveHarness,
@@ -341,6 +356,7 @@ export async function buildStatusText(params: BuildStatusTextParams): Promise<st
         sessionEntry,
         agentDir: statusAgentDir,
         workspaceDir: statusWorkspaceDir,
+        codexCliCredentialsHome,
         includeExternalProfiles: false,
       });
   const activeModelAuth = Object.hasOwn(params, "activeModelAuthOverride")
@@ -353,6 +369,7 @@ export async function buildStatusText(params: BuildStatusTextParams): Promise<st
           sessionEntry,
           agentDir: statusAgentDir,
           workspaceDir: statusWorkspaceDir,
+          codexCliCredentialsHome,
           includeExternalProfiles: false,
         })
       : selectedModelAuth;


### PR DESCRIPTION
## Summary

- Teach `/status` auth labels for OpenAI models running on the Codex harness to check the agent-owned Codex app-server `codex-home` before ambient OpenAI env keys.
- Align OpenClaw's Codex `auth.json` OAuth reader with Codex auth-mode resolution so API-key-mode files do not reuse stale ChatGPT tokens.
- Add regression coverage for the status label path and Codex auth.json API-key precedence.

Fixes #91099.

## Real behavior proof

- Behavior addressed: `/status` no longer reports `api-key (env: OPENAI_API_KEY)` for `openai/*` on the Codex harness when the agent's Codex app-server home has ChatGPT token auth.
- Real environment tested: Local macOS OpenClaw source checkout on Node 24, using a temporary OpenClaw state directory, a temporary agent `codex-home/auth.json` with ChatGPT token auth, and an ambient `OPENAI_API_KEY` set in the process environment.
- Exact steps or command run after this patch: `node --import tsx /tmp/openclaw-91099-real-proof.ts`. The script rendered the OpenClaw status text through the runtime status path against the temporary state/auth setup.
- Evidence after fix: terminal output from the runtime proof script:

```text
OpenClaw 2026.6.2 (bb6163d)
Uptime: gateway 52s · system 2d 6h
Model: openai/gpt-5.5 · oauth (codex-cli)
Context: 0/32k (0%) · Compactions: 0
Session: agent:main:main • updated 20612d ago
Execution: direct · Runtime: OpenAI Codex · Think: off · Fast: off · Text: low · elevated
Queue: steer (depth 0)
--- proof checks ---
contains oauth codex label: true
contains ambient env api-key label: false
```

- Observed result after fix: the runtime-rendered status output showed `oauth (codex-cli)` for the Codex-harness OpenAI model and did not show the ambient `api-key (env: OPENAI_API_KEY)` label.
- What was not tested: no live Gateway or Telegram reproduction was run.

## Tests and validation

- `node scripts/run-vitest.mjs src/agents/cli-credentials.test.ts src/agents/model-auth-label.test.ts src/auto-reply/reply/commands-status.test.ts`
- `pnpm exec oxfmt --check src/agents/cli-credentials.ts src/agents/cli-credentials.test.ts src/agents/model-auth-label.ts src/status/status-text.ts src/agents/model-auth-label.test.ts src/auto-reply/reply/commands-status.test.ts`
- `pnpm exec oxlint src/agents/cli-credentials.ts src/agents/cli-credentials.test.ts src/agents/model-auth-label.ts src/status/status-text.ts src/agents/model-auth-label.test.ts src/auto-reply/reply/commands-status.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

Targeted tests passed, formatting/diff checks passed, direct oxlint on changed files passed, and autoreview reported no accepted/actionable findings.

## Dependency contract checked

- Codex `login status` prints ChatGPT for `AuthMode::Chatgpt` / `ChatgptAuthTokens`: `../codex/codex-rs/cli/src/login.rs`.
- Codex `AuthDotJson::resolved_mode` uses explicit `auth_mode` first, otherwise treats any `OPENAI_API_KEY` field as API-key mode before defaulting to ChatGPT tokens: `../codex/codex-rs/login/src/auth/manager.rs`.

