### PR TITLE
fix(outbound): preserve retries for budget-deferred deliveries

### DIFF
--- a/src/infra/outbound/delivery-queue-recovery.ts
+++ b/src/infra/outbound/delivery-queue-recovery.ts
@@ -326,17 +326,6 @@ async function moveEntryToFailedWithLogging(
   }
 }
 
-async function deferRemainingEntriesForBudget(
-  entries: readonly QueuedDelivery[],
-  stateDir: string | undefined,
-): Promise<void> {
-  // Increment retryCount so entries that are repeatedly deferred by the
-  // recovery budget eventually hit MAX_RETRIES and get pruned.
-  await Promise.allSettled(
-    entries.map((entry) => failDelivery(entry.id, "recovery time budget exceeded", stateDir)),
-  );
-}
-
 /** Compute the backoff delay in ms for a given retry count. */
 export function computeBackoffMs(retryCount: number): number {
   if (retryCount <= 0) {
@@ -624,12 +613,12 @@ export async function recoverPendingDeliveries(opts: {
   const deadline = resolveRecoveryDeadlineMs(opts.maxRecoveryMs);
   const summary = createEmptyRecoverySummary();
 
-  for (let i = 0; i < pending.length; i++) {
-    const entry = pending[i];
+  for (const entry of pending) {
     const now = Date.now();
     if (now >= deadline) {
       opts.log.warn(`Recovery time budget exceeded — remaining entries deferred to next startup`);
-      await deferRemainingEntriesForBudget(pending.slice(i), opts.stateDir);
+      // Budget deferral is not a delivery attempt. Keep entries pending without
+      // consuming retry budget; attempted failures still flow through failDelivery.
       break;
     }
 

--- a/src/infra/outbound/delivery-queue.recovery.test.ts
+++ b/src/infra/outbound/delivery-queue.recovery.test.ts
@@ -638,8 +638,7 @@ describe("delivery-queue recovery", () => {
 
     const remaining = await loadPendingDeliveries(tmpDir());
     expect(remaining).toHaveLength(3);
-    const entriesWithUnexpectedRetryCount = remaining.filter((entry) => entry.retryCount !== 0);
-    expect(entriesWithUnexpectedRetryCount).toStrictEqual([]);
+    expect(remaining.map((entry) => entry.retryCount)).toStrictEqual([0, 0, 0]);
     expectMockMessageContaining(log.warn, "deferred to next startup");
   });
 

--- a/src/infra/outbound/delivery-queue.recovery.test.ts
+++ b/src/infra/outbound/delivery-queue.recovery.test.ts
@@ -615,7 +615,7 @@ describe("delivery-queue recovery", () => {
     });
   });
 
-  it("respects maxRecoveryMs time budget and bumps deferred retries", async () => {
+  it("respects maxRecoveryMs time budget without bumping deferred retries", async () => {
     await enqueueCrashRecoveryEntries();
     await enqueueDelivery(
       { channel: "demo-channel-c", to: "#c", payloads: [{ text: "c" }] },
@@ -638,7 +638,7 @@ describe("delivery-queue recovery", () => {
 
     const remaining = await loadPendingDeliveries(tmpDir());
     expect(remaining).toHaveLength(3);
-    const entriesWithUnexpectedRetryCount = remaining.filter((entry) => entry.retryCount !== 1);
+    const entriesWithUnexpectedRetryCount = remaining.filter((entry) => entry.retryCount !== 0);
     expect(entriesWithUnexpectedRetryCount).toStrictEqual([]);
     expectMockMessageContaining(log.warn, "deferred to next startup");
   });


### PR DESCRIPTION
## Summary

- Keep recovery-budget-deferred outbound deliveries pending without calling `failDelivery`.
- Preserve retry accounting for real attempted delivery failures; only the unattempted budget-deferral path changes.
- Update the recovery regression so `maxRecoveryMs` exhaustion does not consume retry budget.

Addresses the budget-deferral retry-accounting part of #91212. The broader Feishu transport-readiness restart behavior remains intentionally open for maintainer follow-up.

## Verification

- `node scripts/run-vitest.mjs src/infra/outbound/delivery-queue.recovery.test.ts` — 1 file passed, 22 tests passed.
- `pnpm format:check src/infra/outbound/delivery-queue-recovery.ts src/infra/outbound/delivery-queue.recovery.test.ts` — passed.
- `node scripts/run-oxlint.mjs src/infra/outbound/delivery-queue-recovery.ts src/infra/outbound/delivery-queue.recovery.test.ts` — passed.
- `.agents/skills/autoreview/scripts/autoreview --mode local` — clean, no accepted/actionable findings.

Scope note: this intentionally fixes only the source-proven retry-accounting bug for unattempted budget deferrals. It does not add a fixed startup sleep, reset retry counts across restarts, or change Feishu transport-readiness policy.

## Real behavior proof

Behavior addressed: pending outbound deliveries that are deferred because the startup recovery wall-clock budget is exhausted no longer have `retryCount` or `lastAttemptAt` changed when no delivery attempt ran.
Real environment tested: Local OpenClaw source checkout using the production delivery queue APIs with a temporary state directory and real queue persistence.
Exact steps or command run after this patch: `node --import tsx` script that enqueued two Feishu outbound deliveries, called `recoverPendingDeliveries({ maxRecoveryMs: 0 })`, and printed the pending queue state before and after recovery.
Evidence after fix: Captured terminal output:

```json
{
  "result": {
    "recovered": 0,
    "failed": 0,
    "skippedMaxRetries": 0,
    "deferredBackoff": 0
  },
  "before": [
    {
      "id": "f8481ba9-9b34-4ee6-94ec-84f2dc2d791a",
      "retryCount": 0,
      "lastAttemptAt": null
    },
    {
      "id": "1f442292-c726-4591-8387-540b440e863e",
      "retryCount": 0,
      "lastAttemptAt": null
    }
  ],
  "after": [
    {
      "id": "f8481ba9-9b34-4ee6-94ec-84f2dc2d791a",
      "retryCount": 0,
      "lastAttemptAt": null
    },
    {
      "id": "1f442292-c726-4591-8387-540b440e863e",
      "retryCount": 0,
      "lastAttemptAt": null
    }
  ],
  "deliverCallCount": 0,
  "warning": "Recovery time budget exceeded — remaining entries deferred to next startup"
}
```

Observed result after fix: no delivery function was called, both queued entries remained pending, and their retry metadata stayed unchanged.
What was not tested: a live Feishu WebSocket restart scenario; this PR avoids transport readiness policy and fixes the generic queue retry-accounting path that is source-reproducible.

