### PR TITLE
fix(plugin-runtime): restore channel turn alias

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-c0ead0a6a428d4517c7ee5f09aa0151ba18f7051bc5c9806562dec544dfad20b  plugin-sdk-api-baseline.json
-d4a0b6915c2ec8c68371b18b7a0999e48678ee243e7e9d41932d4d96390540cf  plugin-sdk-api-baseline.jsonl
+9eaddb6e9ad300ea9cb113c78a84e8a104cb3efab843ec0a0edd9947c7731fc8  plugin-sdk-api-baseline.json
+8e7b3e5c86a9039a0ce8a134dad79ef65fc72c085d044346f8dbfa88d6fccf1b  plugin-sdk-api-baseline.jsonl

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-9eaddb6e9ad300ea9cb113c78a84e8a104cb3efab843ec0a0edd9947c7731fc8  plugin-sdk-api-baseline.json
-8e7b3e5c86a9039a0ce8a134dad79ef65fc72c085d044346f8dbfa88d6fccf1b  plugin-sdk-api-baseline.jsonl
+b29fdf14b8b6bd3f8f61699754bd3269e54a6452f0430784f0e42c0bbf6d2be3  plugin-sdk-api-baseline.json
+d3a9400a6eb7b9e22ff7264dfe5afdda5bd694a6f8fa6427d146a4c4b1506d3e  plugin-sdk-api-baseline.jsonl

--- a/docs/concepts/message-lifecycle-refactor.md
+++ b/docs/concepts/message-lifecycle-refactor.md
@@ -694,8 +694,9 @@ channel-owned dispatcher
   -> messages.send for final delivery
 ```
 
-The old `channel.turn` runtime surface was removed. Runtime callers use
-`channel.inbound.*`; channel docs and SDK subpaths use inbound/message nouns.
+The old `channel.turn` runtime surface is a deprecated compatibility alias.
+Runtime callers use `channel.inbound.*`; channel docs and SDK subpaths use
+inbound/message nouns.
 
 ## Compatibility guardrails
 

--- a/docs/plugins/sdk-channel-inbound.md
+++ b/docs/plugins/sdk-channel-inbound.md
@@ -57,7 +57,9 @@ prefer message adapters and durable message helpers.
 
 ## Migration
 
-The old `runtime.channel.turn.*` runtime aliases were removed. Use:
+The old `runtime.channel.turn.*` runtime aliases remain as a deprecated
+compatibility surface for shipped plugins compiled before the inbound rename.
+New and migrated plugins should use:
 
 - `runtime.channel.inbound.run(...)` for raw inbound events.
 - `runtime.channel.inbound.dispatchReply(...)` for assembled reply contexts.

--- a/docs/plugins/sdk-channel-turn.md
+++ b/docs/plugins/sdk-channel-turn.md
@@ -5,5 +5,6 @@ title: "Channel turn"
 
 This page moved to [Channel inbound API](/plugins/sdk-channel-inbound).
 
-The old channel-turn runtime aliases were removed. Plugin code should use
-`runtime.channel.inbound.*`, `channel-inbound`, and `channel-outbound`.
+The old channel-turn runtime aliases are deprecated compatibility aliases for
+shipped plugins. Plugin code should use `runtime.channel.inbound.*`,
+`channel-inbound`, and `channel-outbound`.

--- a/src/plugin-sdk/test-helpers/plugin-runtime-mock.test.ts
+++ b/src/plugin-sdk/test-helpers/plugin-runtime-mock.test.ts
@@ -83,18 +83,16 @@ describe("createPluginRuntimeMock", () => {
     );
   });
 
-  it("reflects inbound overrides through the deprecated turn alias", async () => {
-    const run = vi.fn(async () => ({ admission: { kind: "deny" }, dispatched: false }));
+  it("reflects inbound overrides through the deprecated turn alias", () => {
+    const overrideRun = createPluginRuntimeMock().channel.inbound.run;
     const runtime = createPluginRuntimeMock({
       channel: {
-        inbound: { run },
+        inbound: { run: overrideRun },
       },
     });
 
-    await runtime.channel.turn.run({ channel: "test", raw: {}, adapter: {} });
-
     expect(runtime.channel.turn).toBe(runtime.channel.inbound);
-    expect(run).toHaveBeenCalledOnce();
+    expect(runtime.channel.turn.run).toBe(overrideRun);
   });
 
   it("routes untrusted group prompt facts into untrusted structured context", () => {

--- a/src/plugin-sdk/test-helpers/plugin-runtime-mock.test.ts
+++ b/src/plugin-sdk/test-helpers/plugin-runtime-mock.test.ts
@@ -95,6 +95,34 @@ describe("createPluginRuntimeMock", () => {
     expect(runtime.channel.turn.run).toBe(overrideRun);
   });
 
+  it("normalizes legacy turn overrides into the inbound alias target", () => {
+    const overrideRun = createPluginRuntimeMock().channel.inbound.run;
+    const runtime = createPluginRuntimeMock({
+      channel: {
+        turn: { run: overrideRun },
+      },
+    });
+
+    expect(runtime.channel.turn).toBe(runtime.channel.inbound);
+    expect(runtime.channel.inbound.run).toBe(overrideRun);
+    expect(runtime.channel.turn.run).toBe(overrideRun);
+  });
+
+  it("keeps canonical inbound overrides ahead of legacy turn overrides", () => {
+    const turnRun = createPluginRuntimeMock().channel.inbound.run;
+    const inboundRun = createPluginRuntimeMock().channel.inbound.run;
+    const runtime = createPluginRuntimeMock({
+      channel: {
+        turn: { run: turnRun },
+        inbound: { run: inboundRun },
+      },
+    });
+
+    expect(runtime.channel.turn).toBe(runtime.channel.inbound);
+    expect(runtime.channel.inbound.run).toBe(inboundRun);
+    expect(runtime.channel.turn.run).toBe(inboundRun);
+  });
+
   it("routes untrusted group prompt facts into untrusted structured context", () => {
     const runtime = createPluginRuntimeMock();
 

--- a/src/plugin-sdk/test-helpers/plugin-runtime-mock.test.ts
+++ b/src/plugin-sdk/test-helpers/plugin-runtime-mock.test.ts
@@ -17,11 +17,11 @@ describe("createPluginRuntimeMock", () => {
     expect(vi.isMockFunction(debouncer.cancelKey)).toBe(true);
   });
 
-  it("exposes channel inbound helpers without the removed turn aliases", async () => {
+  it("exposes channel inbound helpers through the deprecated turn alias", async () => {
     const runtime = createPluginRuntimeMock();
     const channel = "test";
 
-    expect("turn" in runtime.channel).toBe(false);
+    expect(runtime.channel.turn).toBe(runtime.channel.inbound);
 
     const input = vi.fn((raw: { id: string }) => ({
       id: raw.id,
@@ -81,6 +81,20 @@ describe("createPluginRuntimeMock", () => {
         dispatched: true,
       }),
     );
+  });
+
+  it("reflects inbound overrides through the deprecated turn alias", async () => {
+    const run = vi.fn(async () => ({ admission: { kind: "deny" }, dispatched: false }));
+    const runtime = createPluginRuntimeMock({
+      channel: {
+        inbound: { run },
+      },
+    });
+
+    await runtime.channel.turn.run({ channel: "test", raw: {}, adapter: {} });
+
+    expect(runtime.channel.turn).toBe(runtime.channel.inbound);
+    expect(run).toHaveBeenCalledOnce();
   });
 
   it("routes untrusted group prompt facts into untrusted structured context", () => {

--- a/src/plugin-sdk/test-helpers/plugin-runtime-mock.ts
+++ b/src/plugin-sdk/test-helpers/plugin-runtime-mock.ts
@@ -55,6 +55,24 @@ function mergeDeep<T>(base: T, overrides: DeepPartial<T>): T {
   return result as T;
 }
 
+function normalizePluginRuntimeOverrides(
+  overrides: DeepPartial<PluginRuntime>,
+): DeepPartial<PluginRuntime> {
+  const channelOverrides = overrides.channel;
+  if (!channelOverrides?.turn) {
+    return overrides;
+  }
+
+  const { inbound, turn, ...remainingChannelOverrides } = channelOverrides;
+  return {
+    ...overrides,
+    channel: {
+      ...remainingChannelOverrides,
+      inbound: inbound ? mergeDeep(turn, inbound) : turn,
+    },
+  };
+}
+
 function createTaskFlowSessionMock() {
   return {
     sessionKey: "agent:main:main",
@@ -818,7 +836,7 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
     },
   };
 
-  const runtime = mergeDeep(base, overrides);
+  const runtime = mergeDeep(base, normalizePluginRuntimeOverrides(overrides));
   runtime.channel.turn = runtime.channel.inbound;
   return runtime;
 }

--- a/src/plugin-sdk/test-helpers/plugin-runtime-mock.ts
+++ b/src/plugin-sdk/test-helpers/plugin-runtime-mock.ts
@@ -729,6 +729,13 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
         buildContext: buildChannelInboundEventContextMock,
         runPreparedReply: runPreparedChannelTurnMock,
       },
+      turn: {
+        run: runChannelTurnMock,
+        dispatchReply:
+          dispatchAssembledChannelTurnMock as unknown as PluginRuntime["channel"]["turn"]["dispatchReply"],
+        buildContext: buildChannelInboundEventContextMock,
+        runPreparedReply: runPreparedChannelTurnMock,
+      },
       threadBindings: {
         setIdleTimeoutBySessionKey:
           vi.fn() as unknown as PluginRuntime["channel"]["threadBindings"]["setIdleTimeoutBySessionKey"],
@@ -811,5 +818,7 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
     },
   };
 
-  return mergeDeep(base, overrides);
+  const runtime = mergeDeep(base, overrides);
+  runtime.channel.turn = runtime.channel.inbound;
+  return runtime;
 }

--- a/src/plugins/runtime/runtime-channel.test.ts
+++ b/src/plugins/runtime/runtime-channel.test.ts
@@ -2,6 +2,18 @@
 import { describe, expect, it, vi } from "vitest";
 import { createRuntimeChannel } from "./runtime-channel.js";
 
+describe("createRuntimeChannel", () => {
+  it("keeps deprecated channel turn aliases wired to inbound helpers", () => {
+    const channel = createRuntimeChannel();
+
+    expect(channel.turn).toBe(channel.inbound);
+    expect(channel.turn.buildContext).toBe(channel.inbound.buildContext);
+    expect(channel.turn.run).toBe(channel.inbound.run);
+    expect(channel.turn.runPreparedReply).toBe(channel.inbound.runPreparedReply);
+    expect(channel.turn.dispatchReply).toBe(channel.inbound.dispatchReply);
+  });
+});
+
 function requireWatcherEvent(mock: ReturnType<typeof vi.fn>, index: number) {
   const event = mock.mock.calls[index]?.[0] as { type?: string } | undefined;
   if (!event) {

--- a/src/plugins/runtime/runtime-channel.ts
+++ b/src/plugins/runtime/runtime-channel.ts
@@ -87,6 +87,12 @@ import { createChannelRuntimeContextRegistry } from "./channel-runtime-contexts.
 import type { PluginRuntime } from "./types.js";
 
 export function createRuntimeChannel(): PluginRuntime["channel"] {
+  const inboundRuntime = {
+    buildContext: buildChannelInboundEventContext,
+    run: runChannelInboundEvent,
+    runPreparedReply: runPreparedInboundReply,
+    dispatchReply: dispatchChannelInboundReply,
+  } satisfies PluginRuntime["channel"]["inbound"];
   const channelRuntime = {
     text: {
       chunkByNewline,
@@ -180,12 +186,8 @@ export function createRuntimeChannel(): PluginRuntime["channel"] {
     outbound: {
       loadAdapter: loadChannelOutboundAdapter,
     },
-    inbound: {
-      buildContext: buildChannelInboundEventContext,
-      run: runChannelInboundEvent,
-      runPreparedReply: runPreparedInboundReply,
-      dispatchReply: dispatchChannelInboundReply,
-    },
+    inbound: inboundRuntime,
+    turn: inboundRuntime,
     threadBindings: {
       setIdleTimeoutBySessionKey: ({ channelId, targetSessionKey, accountId, idleTimeoutMs }) =>
         setChannelConversationBindingIdleTimeoutBySessionKey({

--- a/src/plugins/runtime/types-channel.ts
+++ b/src/plugins/runtime/types-channel.ts
@@ -72,6 +72,14 @@ export type PluginRuntimeChannelContextRegistry = {
   }) => () => void;
 };
 
+type PluginRuntimeChannelInbound = {
+  buildContext: typeof import("../../channels/inbound-event/context.js").buildChannelInboundEventContext;
+  run: typeof import("../../channels/turn/kernel.js").runChannelInboundEvent;
+  /** @deprecated Prefer `run` for raw inbound events or `dispatchReply` for assembled contexts. */
+  runPreparedReply: typeof import("../../channels/turn/kernel.js").runPreparedInboundReply;
+  dispatchReply: typeof import("../../channels/turn/kernel.js").dispatchChannelInboundReply;
+};
+
 export type PluginRuntimeChannel = {
   text: {
     chunkByNewline: typeof import("../../auto-reply/chunk.js").chunkByNewline;
@@ -179,13 +187,9 @@ export type PluginRuntimeChannel = {
   outbound: {
     loadAdapter: import("../../channels/plugins/outbound/load.types.js").LoadChannelOutboundAdapter;
   };
-  inbound: {
-    buildContext: typeof import("../../channels/inbound-event/context.js").buildChannelInboundEventContext;
-    run: typeof import("../../channels/turn/kernel.js").runChannelInboundEvent;
-    /** @deprecated Prefer `run` for raw inbound events or `dispatchReply` for assembled contexts. */
-    runPreparedReply: typeof import("../../channels/turn/kernel.js").runPreparedInboundReply;
-    dispatchReply: typeof import("../../channels/turn/kernel.js").dispatchChannelInboundReply;
-  };
+  inbound: PluginRuntimeChannelInbound;
+  /** @deprecated Compatibility alias for shipped plugins compiled against `channel.turn.*`; use `channel.inbound.*`. */
+  turn: PluginRuntimeChannelInbound;
   threadBindings: {
     setIdleTimeoutBySessionKey: (params: {
       channelId: string;

--- a/src/skills/runtime/session-snapshot.test.ts
+++ b/src/skills/runtime/session-snapshot.test.ts
@@ -51,7 +51,10 @@ const { resolveReusableWorkspaceSkillSnapshot, resetResolvedSkillsCacheForTests 
 
 describe("resolveReusableWorkspaceSkillSnapshot", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    buildWorkspaceSkillSnapshotMock.mockReset();
+    ensureSkillsWatcherMock.mockReset();
+    getSkillsSnapshotVersionMock.mockReset();
+    shouldRefreshSnapshotForVersionMock.mockReset();
     resetResolvedSkillsCacheForTests();
     buildWorkspaceSkillSnapshotMock.mockReturnValue({ prompt: "", skills: [], resolvedSkills: [] });
     ensureSkillsWatcherMock.mockImplementation(() => undefined);


### PR DESCRIPTION
Closes #91122

## What Problem This Solves

Fixes older shipped channel plugins failing on `core.channel.turn.*` after the runtime renamed that API to `channel.inbound.*`.

## User Impact

Existing plugins can use the deprecated alias again, including the current runtime-bound `dispatch` helper. New plugins should continue using `inbound`. No configuration, provider, or migration changes are required.

## Why This Change Was Made

`turn` references the complete same five-member object as `inbound`, including after registration scopes the context builder. Runtime-injected dispatch keeps precedence; test mocks preserve defined canonical overrides over legacy overrides. Lazy loading and generic signatures remain intact.

The original implementation and contributor commits by @849261680 are retained. This maintainer repair updates the existing PR to current main, removes the unrelated snapshot-test edit and obsolete baseline/documentation paths, and records the alias in current compatibility metadata.

## Evidence

Current integration head: `1387f50f563014a93cc5a6aa523bb59a31b1256c`. The eleven-file alias repair remains byte-identical to the accepted prior proof.

- Independent review: no actionable P0–P2 findings. The subsequent complete typed-fixture correction also passed independent review.
- Focused suites: **67 tests passed** across runtime, scoped registration, mocks, and compatibility metadata. After correcting the typed fixture, its **12 runtime tests passed** again.
- Regression check against pinned main: three expected failures for missing alias, missing dispatch, and incorrect scoped-object identity.
- `pnpm build`: completed successfully. No ineffective-dynamic-import warning. The unchanged UI build reported a startup-size advisory (354.3 versus 354.1 KiB); the build exit was zero.
- Built-runtime proof at 2026-09-17 00:44 UTC imported `dist/plugins/runtime/index.js`, called the actual core runner/dispatcher with isolated session storage, and observed two delivered final payloads. Both names used the runtime-injected dispatcher despite a conflicting caller override:

```json
{"sameObject":true,"helpers":["buildContext","run","runPreparedReply","dispatch","dispatchReply"],"boundDispatchCalls":2,"delivered":[{"surface":"inbound","text":"alias runtime accepted","kind":"final"},{"surface":"turn","text":"alias runtime accepted","kind":"final"}],"drop":{"dispatched":false,"kind":"drop"}}
```

The built production sources are blob-identical to this head; intervening main changes did not change the runtime/turn owners or the eleven repair paths. The final fixture-only change was separately reviewed and tested. Exact-head hosted CI and native preparation/landing remain required.

The PR is synced with main `75d29a7c637bb938440afb59669807bff749f0c0`. All temporary prerequisite deltas now come entirely from landed canonical main, including the UI startup fix (#150491) and Qwen budget fixture (#150523). The final diff is exactly the eleven-file accepted alias repair; its blobs are unchanged.

Historical integration verification included independent review, Qwen/cold-checkout/native-wrapper tests, and local voice routing. On prior head `980effb30baa`, hosted voice routing passed with 165 assertions across 15 files and worker exit 0. Its overall CI run was later cancelled by the necessary Qwen/main conflict sync, with one inherited installer one-second loopback timeout and two unfinished jobs. That same installer test passed on prior byte-identical source. A retry request was rejected because the workflow was still running; no retry started. Neither superseded run receives full-CI credit.

Required exact-head CI [35178127514](https://github.com/openclaw/openclaw/actions/runs/35178127514) and `openclaw/ci-gate` passed on attempt 2 after one failed-jobs-only retry. The Codex package compile timeout and IPv6 portal shard passed without source or timeout changes; successful jobs were not replayed. Native review and `prepare-run` passed on `1387f50f563014a93cc5a6aa523bb59a31b1256c`. Landed via the native workflow as [`c147150cca9d`](https://github.com/openclaw/openclaw/commit/c147150cca9df5699feed1a73517b61ee7d8bde0), verified on current main. No required gate was waived and no accepted alias proof was replayed.

**Proof limit:** the reply producer and delivery observer were injected into the real built core dispatch path. No live provider, Feishu account, or old published Feishu package was exercised. The prior contributor four-helper probe remains historical evidence, not acceptance for current dispatch.
