### PR TITLE
fix(state): avoid sqlite wal on nfs state volumes

### DIFF
--- a/extensions/memory-core/src/memory/manager-db.ts
+++ b/extensions/memory-core/src/memory/manager-db.ts
@@ -40,7 +40,10 @@ export function openMemoryDatabaseAtPath(
     }
   }
   const db = new DatabaseSync(dbPath, { allowExtension });
-  configureMemorySqliteWalMaintenance(db);
+  configureMemorySqliteWalMaintenance(db, { databasePath: dbPath });
+  // busy_timeout is per-connection and resets to 0 on restart.
+  // Set it on every open so concurrent processes retry instead of
+  // failing immediately with SQLITE_BUSY.
   db.exec("PRAGMA busy_timeout = 5000");
   return db;
 }

--- a/extensions/memory-core/src/memory/manager-db.ts
+++ b/extensions/memory-core/src/memory/manager-db.ts
@@ -28,10 +28,7 @@ export function openMemoryDatabaseAtPath(
       probe.close();
     } catch (err) {
       const msg = (err as Error).message ?? "";
-      if (
-        msg.includes("unable to open database file") ||
-        msg.includes("SQLITE_CANTOPEN")
-      ) {
+      if (msg.includes("unable to open database file") || msg.includes("SQLITE_CANTOPEN")) {
         throw new Error(
           `Memory database not found at ${dbPath}; refusing to auto-create an empty database during an index swap window.`,
           { cause: err },

--- a/src/infra/sqlite-wal.test.ts
+++ b/src/infra/sqlite-wal.test.ts
@@ -1,4 +1,8 @@
 // Covers SQLite WAL maintenance configuration.
+import childProcess from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { MAX_TIMER_TIMEOUT_MS } from "../shared/number-coercion.js";
@@ -13,8 +17,21 @@ function createMockDb(): DatabaseSync {
   } as unknown as DatabaseSync;
 }
 
+function statfsFixture(type: number): ReturnType<typeof fs.statfsSync> {
+  return {
+    type,
+    bsize: 1024,
+    blocks: 1,
+    bfree: 1,
+    bavail: 1,
+    files: 0,
+    ffree: 0,
+  };
+}
+
 describe("sqlite WAL maintenance", () => {
   afterEach(() => {
+    vi.restoreAllMocks();
     vi.useRealTimers();
   });
 
@@ -28,6 +45,71 @@ describe("sqlite WAL maintenance", () => {
       2,
       `PRAGMA wal_autocheckpoint = ${DEFAULT_SQLITE_WAL_AUTOCHECKPOINT_PAGES};`,
     );
+  });
+
+  it("uses rollback journaling for databases on NFS-backed volumes", () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sqlite-nfs-"));
+    try {
+      const db = createMockDb();
+      const statfs = vi.spyOn(fs, "statfsSync").mockReturnValue(statfsFixture(0x6969));
+
+      const maintenance = configureSqliteWalMaintenance(db, {
+        checkpointIntervalMs: 0,
+        databasePath: path.join(tempDir, "missing", "openclaw.sqlite"),
+      });
+
+      expect(statfs).toHaveBeenCalledWith(tempDir);
+      expect(db["exec"]).toHaveBeenCalledTimes(1);
+      expect(db["exec"]).toHaveBeenCalledWith("PRAGMA journal_mode = DELETE;");
+      expect(maintenance.checkpoint()).toBe(true);
+      expect(maintenance.close()).toBe(true);
+      expect(db["exec"]).toHaveBeenCalledTimes(1);
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("uses mountinfo filesystem names when statfs magic is not enough", () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sqlite-nfs-"));
+    try {
+      const db = createMockDb();
+      vi.spyOn(fs, "statfsSync").mockReturnValue(statfsFixture(0));
+      vi.spyOn(fs, "readFileSync").mockReturnValue(
+        `42 12 0:41 / ${tempDir} rw,relatime - nfs4 server:/share rw\n`,
+      );
+
+      configureSqliteWalMaintenance(db, {
+        checkpointIntervalMs: 0,
+        databasePath: path.join(tempDir, "openclaw.sqlite"),
+      });
+
+      expect(db["exec"]).toHaveBeenCalledWith("PRAGMA journal_mode = DELETE;");
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("uses mount command filesystem names on platforms without proc mountinfo", () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sqlite-nfs-"));
+    try {
+      const db = createMockDb();
+      vi.spyOn(fs, "statfsSync").mockReturnValue(statfsFixture(0));
+      vi.spyOn(fs, "readFileSync").mockImplementation(() => {
+        throw new Error("no proc mountinfo");
+      });
+      vi.spyOn(childProcess, "execFileSync").mockReturnValue(
+        Buffer.from(`server:/share on ${tempDir} (nfs, nodev, nosuid)\n`),
+      );
+
+      configureSqliteWalMaintenance(db, {
+        checkpointIntervalMs: 0,
+        databasePath: path.join(tempDir, "openclaw.sqlite"),
+      });
+
+      expect(db["exec"]).toHaveBeenCalledWith("PRAGMA journal_mode = DELETE;");
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 
   it("runs periodic TRUNCATE checkpoints and stops them on close", () => {

--- a/src/infra/sqlite-wal.test.ts
+++ b/src/infra/sqlite-wal.test.ts
@@ -14,6 +14,9 @@ import {
 function createMockDb(): DatabaseSync {
   return {
     exec: vi.fn(),
+    prepare: vi.fn(() => ({
+      get: vi.fn(() => ({ journal_mode: "delete" })),
+    })),
   } as unknown as DatabaseSync;
 }
 
@@ -59,11 +62,32 @@ describe("sqlite WAL maintenance", () => {
       });
 
       expect(statfs).toHaveBeenCalledWith(tempDir);
-      expect(db["exec"]).toHaveBeenCalledTimes(1);
-      expect(db["exec"]).toHaveBeenCalledWith("PRAGMA journal_mode = DELETE;");
+      expect(db["prepare"]).toHaveBeenCalledWith("PRAGMA journal_mode = DELETE;");
+      expect(db["exec"]).not.toHaveBeenCalled();
       expect(maintenance.checkpoint()).toBe(true);
       expect(maintenance.close()).toBe(true);
-      expect(db["exec"]).toHaveBeenCalledTimes(1);
+      expect(db["exec"]).not.toHaveBeenCalled();
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("refuses NFS-backed databases when SQLite keeps WAL active", () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sqlite-nfs-"));
+    try {
+      const db = createMockDb();
+      vi.mocked(db["prepare"]).mockReturnValue({
+        get: vi.fn(() => ({ journal_mode: "wal" })),
+      } as unknown as ReturnType<DatabaseSync["prepare"]>);
+      vi.spyOn(fs, "statfsSync").mockReturnValue(statfsFixture(0x6969));
+
+      expect(() =>
+        configureSqliteWalMaintenance(db, {
+          checkpointIntervalMs: 0,
+          databaseLabel: "test-db",
+          databasePath: path.join(tempDir, "openclaw.sqlite"),
+        }),
+      ).toThrow(/test-db .*journal_mode=wal/);
     } finally {
       fs.rmSync(tempDir, { recursive: true, force: true });
     }
@@ -83,7 +107,7 @@ describe("sqlite WAL maintenance", () => {
         databasePath: path.join(tempDir, "openclaw.sqlite"),
       });
 
-      expect(db["exec"]).toHaveBeenCalledWith("PRAGMA journal_mode = DELETE;");
+      expect(db["prepare"]).toHaveBeenCalledWith("PRAGMA journal_mode = DELETE;");
     } finally {
       fs.rmSync(tempDir, { recursive: true, force: true });
     }
@@ -106,7 +130,30 @@ describe("sqlite WAL maintenance", () => {
         databasePath: path.join(tempDir, "openclaw.sqlite"),
       });
 
-      expect(db["exec"]).toHaveBeenCalledWith("PRAGMA journal_mode = DELETE;");
+      expect(db["prepare"]).toHaveBeenCalledWith("PRAGMA journal_mode = DELETE;");
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("parses Linux mount command filesystem names when proc mountinfo is unavailable", () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sqlite-nfs-"));
+    try {
+      const db = createMockDb();
+      vi.spyOn(fs, "statfsSync").mockReturnValue(statfsFixture(0));
+      vi.spyOn(fs, "readFileSync").mockImplementation(() => {
+        throw new Error("no proc mountinfo");
+      });
+      vi.spyOn(childProcess, "execFileSync").mockReturnValue(
+        Buffer.from(`server:/share on ${tempDir} type nfs4 (rw,relatime)\n`),
+      );
+
+      configureSqliteWalMaintenance(db, {
+        checkpointIntervalMs: 0,
+        databasePath: path.join(tempDir, "openclaw.sqlite"),
+      });
+
+      expect(db["prepare"]).toHaveBeenCalledWith("PRAGMA journal_mode = DELETE;");
     } finally {
       fs.rmSync(tempDir, { recursive: true, force: true });
     }

--- a/src/infra/sqlite-wal.ts
+++ b/src/infra/sqlite-wal.ts
@@ -1,4 +1,7 @@
 // Configures SQLite WAL and related pragmas for local stores.
+import childProcess from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
 import { MAX_TIMER_TIMEOUT_MS } from "../shared/number-coercion.js";
 
@@ -6,6 +9,8 @@ import { MAX_TIMER_TIMEOUT_MS } from "../shared/number-coercion.js";
 // checkpoints so state databases do not accumulate unbounded WAL files.
 export const DEFAULT_SQLITE_WAL_AUTOCHECKPOINT_PAGES = 1000;
 export const DEFAULT_SQLITE_WAL_TRUNCATE_INTERVAL_MS = 30 * 60 * 1000;
+const LINUX_NFS_SUPER_MAGIC = 0x6969;
+const PROC_MOUNTINFO_PATH = "/proc/self/mountinfo";
 
 type IntervalHandle = ReturnType<typeof setInterval> & {
   unref?: () => void;
@@ -35,6 +40,112 @@ function normalizeNonNegativeInteger(value: number, label: string): number {
   return value;
 }
 
+function findExistingVolumePath(targetPath: string): string | null {
+  let current = path.resolve(targetPath);
+  while (true) {
+    try {
+      const stats = fs.statSync(current);
+      return stats.isDirectory() ? current : path.dirname(current);
+    } catch {
+      const parent = path.dirname(current);
+      if (parent === current) {
+        return null;
+      }
+      current = parent;
+    }
+  }
+}
+
+function decodeMountPath(value: string): string {
+  return value.replace(/\\([0-7]{3})/g, (_match, octal: string) =>
+    String.fromCharCode(Number.parseInt(octal, 8)),
+  );
+}
+
+function parseProcMountInfoEntries(
+  contents: string,
+): Array<{ mountPoint: string; fsType: string }> {
+  const entries: Array<{ mountPoint: string; fsType: string }> = [];
+  for (const line of contents.split("\n")) {
+    const separator = line.indexOf(" - ");
+    if (separator === -1) {
+      continue;
+    }
+    const fields = line.slice(0, separator).split(" ");
+    const suffixFields = line.slice(separator + 3).split(" ");
+    const mountPoint = fields[4];
+    const fsType = suffixFields[0];
+    if (mountPoint && fsType) {
+      entries.push({ mountPoint: decodeMountPath(mountPoint), fsType });
+    }
+  }
+  return entries;
+}
+
+function parseMountCommandEntries(contents: string): Array<{ mountPoint: string; fsType: string }> {
+  const entries: Array<{ mountPoint: string; fsType: string }> = [];
+  for (const line of contents.split("\n")) {
+    const match = /^.* on (.+) \(([^,\s)]+)/.exec(line);
+    if (match) {
+      entries.push({ mountPoint: match[1], fsType: match[2] });
+    }
+  }
+  return entries;
+}
+
+function readMountEntries(): Array<{ mountPoint: string; fsType: string }> {
+  try {
+    return parseProcMountInfoEntries(fs.readFileSync(PROC_MOUNTINFO_PATH, "utf8"));
+  } catch {
+    // macOS/BSD expose filesystem type names in `mount` output instead of
+    // Linux superblock magic, so keep this fallback for non-Linux NFS mounts.
+  }
+  try {
+    return parseMountCommandEntries(String(childProcess.execFileSync("mount", [])));
+  } catch {
+    return [];
+  }
+}
+
+function isPathWithinMount(targetPath: string, mountPoint: string): boolean {
+  const resolvedTarget = path.resolve(targetPath);
+  const resolvedMountPoint = path.resolve(mountPoint);
+  return (
+    resolvedTarget === resolvedMountPoint ||
+    resolvedMountPoint === path.parse(resolvedMountPoint).root ||
+    resolvedTarget.startsWith(`${resolvedMountPoint}${path.sep}`)
+  );
+}
+
+function isNfsMountType(fsType: string): boolean {
+  return fsType.toLowerCase().startsWith("nfs");
+}
+
+function isNfsMountEntryPath(targetPath: string): boolean {
+  const mountEntry = readMountEntries()
+    .filter((entry) => isPathWithinMount(targetPath, entry.mountPoint))
+    .toSorted((a, b) => b.mountPoint.length - a.mountPoint.length)[0];
+  return mountEntry ? isNfsMountType(mountEntry.fsType) : false;
+}
+
+function isNfsBackedPath(targetPath: string): boolean {
+  if (typeof fs.statfsSync !== "function") {
+    return isNfsMountEntryPath(targetPath);
+  }
+  const checkedPath = findExistingVolumePath(targetPath);
+  if (!checkedPath) {
+    return false;
+  }
+  try {
+    if (fs.statfsSync(checkedPath).type === LINUX_NFS_SUPER_MAGIC) {
+      return true;
+    }
+  } catch {
+    return isNfsMountEntryPath(checkedPath);
+  }
+  return isNfsMountEntryPath(checkedPath);
+}
+
 /** Configure WAL pragmas and return a handle for checkpoint/close maintenance. */
 export function configureSqliteWalMaintenance(
   db: DatabaseSync,
@@ -50,6 +161,13 @@ export function configureSqliteWalMaintenance(
   );
   const timerIntervalMs = Math.min(checkpointIntervalMs, MAX_TIMER_TIMEOUT_MS);
   const checkpointMode = options.checkpointMode ?? "TRUNCATE";
+  if (options.databasePath && isNfsBackedPath(options.databasePath)) {
+    db.exec("PRAGMA journal_mode = DELETE;");
+    return {
+      checkpoint: () => true,
+      close: () => true,
+    };
+  }
   db.exec("PRAGMA journal_mode = WAL;");
   db.exec(`PRAGMA wal_autocheckpoint = ${autoCheckpointPages};`);
 

--- a/src/infra/sqlite-wal.ts
+++ b/src/infra/sqlite-wal.ts
@@ -85,9 +85,14 @@ function parseProcMountInfoEntries(
 function parseMountCommandEntries(contents: string): Array<{ mountPoint: string; fsType: string }> {
   const entries: Array<{ mountPoint: string; fsType: string }> = [];
   for (const line of contents.split("\n")) {
-    const match = /^.* on (.+) \(([^,\s)]+)/.exec(line);
-    if (match) {
-      entries.push({ mountPoint: match[1], fsType: match[2] });
+    const linuxMatch = /^.* on (.+) type ([^,\s)]+) \(/.exec(line);
+    if (linuxMatch) {
+      entries.push({ mountPoint: linuxMatch[1], fsType: linuxMatch[2] });
+      continue;
+    }
+    const bsdMatch = /^.* on (.+) \(([^,\s)]+)/.exec(line);
+    if (bsdMatch) {
+      entries.push({ mountPoint: bsdMatch[1], fsType: bsdMatch[2] });
     }
   }
   return entries;
@@ -146,6 +151,28 @@ function isNfsBackedPath(targetPath: string): boolean {
   return isNfsMountEntryPath(checkedPath);
 }
 
+function readJournalModeResult(row: unknown): string | null {
+  if (!row || typeof row !== "object") {
+    return null;
+  }
+  const record = row as Record<string, unknown>;
+  const value = record.journal_mode ?? Object.values(record)[0];
+  return typeof value === "string" ? value.toLowerCase() : null;
+}
+
+function requireRollbackJournalMode(db: DatabaseSync, options: SqliteWalMaintenanceOptions): void {
+  const row = db.prepare("PRAGMA journal_mode = DELETE;").get();
+  const journalMode = readJournalModeResult(row);
+  if (journalMode !== "delete") {
+    const label = options.databaseLabel ?? "sqlite database";
+    const location = options.databasePath ? ` at ${options.databasePath}` : "";
+    const actual = journalMode ?? "unknown";
+    throw new Error(
+      `${label}${location} is on an NFS-backed volume but SQLite kept journal_mode=${actual}; refusing to continue with WAL on NFS.`,
+    );
+  }
+}
+
 /** Configure WAL pragmas and return a handle for checkpoint/close maintenance. */
 export function configureSqliteWalMaintenance(
   db: DatabaseSync,
@@ -162,7 +189,7 @@ export function configureSqliteWalMaintenance(
   const timerIntervalMs = Math.min(checkpointIntervalMs, MAX_TIMER_TIMEOUT_MS);
   const checkpointMode = options.checkpointMode ?? "TRUNCATE";
   if (options.databasePath && isNfsBackedPath(options.databasePath)) {
-    db.exec("PRAGMA journal_mode = DELETE;");
+    requireRollbackJournalMode(db, options);
     return {
       checkpoint: () => true,
       close: () => true,

--- a/src/proxy-capture/store.sqlite.test.ts
+++ b/src/proxy-capture/store.sqlite.test.ts
@@ -1,8 +1,8 @@
 // Proxy capture SQLite store tests cover persisted capture reads and writes.
-import { mkdtempSync, rmSync } from "node:fs";
+import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   acquireDebugProxyCaptureStore,
   closeDebugProxyCaptureStore,
@@ -15,23 +15,24 @@ const cleanupDirs: string[] = [];
 
 afterEach(() => {
   closeDebugProxyCaptureStore();
+  vi.restoreAllMocks();
   while (cleanupDirs.length > 0) {
     const dir = cleanupDirs.pop();
     if (dir) {
-      rmSync(dir, { recursive: true, force: true });
+      fs.rmSync(dir, { recursive: true, force: true });
     }
   }
 });
 
 function makeStore() {
-  const root = mkdtempSync(path.join(os.tmpdir(), "openclaw-proxy-capture-"));
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-proxy-capture-"));
   cleanupDirs.push(root);
   return new DebugProxyCaptureStore(path.join(root, "capture.sqlite"), path.join(root, "blobs"));
 }
 
 describe("DebugProxyCaptureStore", () => {
   it("keeps the cached store open until the last lease releases", () => {
-    const root = mkdtempSync(path.join(os.tmpdir(), "openclaw-proxy-capture-lease-"));
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-proxy-capture-lease-"));
     cleanupDirs.push(root);
     const dbPath = path.join(root, "capture.sqlite");
     const blobDir = path.join(root, "blobs");
@@ -49,6 +50,32 @@ describe("DebugProxyCaptureStore", () => {
     const reopened = getDebugProxyCaptureStore(dbPath, blobDir);
     expect(Object.is(reopened, first.store)).toBe(false);
     expect(reopened.isClosed).toBe(false);
+  });
+
+  it("uses rollback journaling for captures on NFS-backed volumes", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-proxy-capture-nfs-"));
+    cleanupDirs.push(root);
+    vi.spyOn(fs, "statfsSync").mockReturnValue({
+      type: 0x6969,
+      bsize: 1024,
+      blocks: 1,
+      bfree: 1,
+      bavail: 1,
+      files: 0,
+      ffree: 0,
+    });
+
+    const store = new DebugProxyCaptureStore(
+      path.join(root, "capture.sqlite"),
+      path.join(root, "blobs"),
+    );
+    try {
+      expect(store.db.prepare("PRAGMA journal_mode").get()).toMatchObject({
+        journal_mode: "delete",
+      });
+    } finally {
+      store.close();
+    }
   });
 
   it("ignores duplicate close calls", () => {

--- a/src/proxy-capture/store.sqlite.ts
+++ b/src/proxy-capture/store.sqlite.ts
@@ -33,7 +33,10 @@ function openDatabase(dbPath: string): OpenedDatabase {
   ensureParentDir(dbPath);
   const { DatabaseSync } = requireNodeSqlite();
   const db = new DatabaseSync(dbPath);
-  const walMaintenance = configureSqliteWalMaintenance(db);
+  const walMaintenance = configureSqliteWalMaintenance(db, {
+    databaseLabel: "debug-proxy-capture",
+    databasePath: dbPath,
+  });
   db.exec("PRAGMA busy_timeout = 5000");
   db.exec(`
     CREATE TABLE IF NOT EXISTS capture_sessions (

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -2,7 +2,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { readCronRunLogEntriesSync } from "../cron/run-log.js";
 import {
   executeSqliteQuerySync,
@@ -29,8 +29,21 @@ function createTempStateDir(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-state-db-"));
 }
 
+function statfsFixture(type: number): ReturnType<typeof fs.statfsSync> {
+  return {
+    type,
+    bsize: 1024,
+    blocks: 1,
+    bfree: 1,
+    bavail: 1,
+    files: 0,
+    ffree: 0,
+  };
+}
+
 afterEach(() => {
   closeOpenClawStateDatabaseForTest();
+  vi.restoreAllMocks();
 });
 
 describe("openclaw state database", () => {
@@ -314,6 +327,21 @@ describe("openclaw state database", () => {
       | { journal_mode?: string }
       | undefined;
     expect(journalMode?.journal_mode?.toLowerCase()).toBe("wal");
+  });
+
+  it("uses rollback journaling for shared state databases on NFS-backed volumes", () => {
+    const stateDir = createTempStateDir();
+    const statfs = vi.spyOn(fs, "statfsSync").mockReturnValue(statfsFixture(0x6969));
+
+    const database = openOpenClawStateDatabase({
+      env: { OPENCLAW_STATE_DIR: stateDir },
+    });
+
+    const journalMode = database.db.prepare("PRAGMA journal_mode").get() as
+      | { journal_mode?: string }
+      | undefined;
+    expect(journalMode?.journal_mode?.toLowerCase()).toBe("delete");
+    expect(statfs).toHaveBeenCalledWith(path.join(stateDir, "state"));
   });
 
   it("records durable schema metadata", () => {


### PR DESCRIPTION
## Summary

- Detect SQLite database paths on NFS-backed volumes and use rollback journaling instead of WAL.
- Keep existing WAL behavior unchanged for local filesystems; detection uses Linux `statfs` magic first, then mount metadata (`/proc/self/mountinfo` or `mount` output) for platform-specific filesystem type names.
- Pass the memory-core database path into the shared SQLite journal helper and add regression coverage for the helper plus shared state opener.

Fixes #90491

## Real behavior proof

- **Behavior addressed:** OpenClaw no longer forces SQLite WAL for state databases whose backing volume is reported as NFS, avoiding the WAL-on-NFS path that can corrupt persisted state during Azure Container Apps revision replacement.
- **Real environment tested:** GitHub Actions Ubuntu `24.04` runner with a real localhost NFS export mounted at `/mnt/openclaw-nfs-proof`, Node `v24.16.0`, pnpm `11.2.2`, and the production `openOpenClawStateDatabase()` opener from this branch. The proof run is https://github.com/849261680/openclaw/actions/runs/27105565187.
- **Exact steps or command run after this patch:**
  - In the proof workflow, install `nfs-kernel-server` and `nfs-common`, export `/tmp/openclaw-nfs-export`, mount it as `127.0.0.1:/tmp/openclaw-nfs-export` at `/mnt/openclaw-nfs-proof`, and verify the mount with `mount`, `findmnt`, and `stat -f`.
  - Run `openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: "/mnt/openclaw-nfs-proof/openclaw-state" } })` through `node --import tsx --input-type=module` twice: first open and restart-open.
  - In each process, read `PRAGMA journal_mode`, write to a proof table, list the state DB directory, close the production opener, and fail if any `*-wal` or `*-shm` sidecar exists.
  - Local supporting checks: `node scripts/run-vitest.mjs src/infra/sqlite-wal.test.ts src/state/openclaw-state-db.test.ts`; `node scripts/run-vitest.mjs extensions/memory-core/src/memory/manager.readonly-recovery.test.ts`; targeted oxfmt/oxlint; `corepack pnpm tsgo:core`; `corepack pnpm tsgo:extensions`; `.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main`.
- **Evidence after fix:** Real NFS mount proof output from https://github.com/849261680/openclaw/actions/runs/27105565187:

  ```text
  Operating System: Ubuntu
  Image: ubuntu-24.04
  127.0.0.1:/tmp/openclaw-nfs-export on /mnt/openclaw-nfs-proof type nfs (rw,relatime,vers=3,...)
  TARGET                  FSTYPE SOURCE                             OPTIONS
  /mnt/openclaw-nfs-proof nfs    127.0.0.1:/tmp/openclaw-nfs-export rw,relatime,vers=3,...
  statfs-type-name=nfs statfs-type-hex=6969
  ```

  First production opener on that NFS-mounted state directory:

  ```json
  {
    "label": "first-open",
    "stateDir": "/mnt/openclaw-nfs-proof/openclaw-state",
    "databasePath": "/mnt/openclaw-nfs-proof/openclaw-state/state/openclaw.sqlite",
    "journalMode": "delete",
    "proofRows": 1,
    "hasWalSidecar": false,
    "files": [
      "openclaw.sqlite"
    ]
  }
  ```

  Restart-open production opener on the same NFS-mounted state directory:

  ```json
  {
    "label": "restart-open",
    "stateDir": "/mnt/openclaw-nfs-proof/openclaw-state",
    "databasePath": "/mnt/openclaw-nfs-proof/openclaw-state/state/openclaw.sqlite",
    "journalMode": "delete",
    "proofRows": 2,
    "hasWalSidecar": false,
    "files": [
      "openclaw.sqlite"
    ]
  }
  ```

  Proof run final line:

  ```text
  OpenClaw #90491 NFS proof passed
  ```

  Focused local Vitest output after the final patch:

  ```text
   Test Files  1 passed (1)
        Tests  14 passed (14)

   Test Files  1 passed (1)
        Tests  7 passed (7)
  [test] passed 2 Vitest shards in 22.61s
  ```

  Memory-core supporting test output:

  ```text
   Test Files  1 passed (1)
        Tests  9 passed (9)
  [test] passed 1 Vitest shard in 22.35s
  ```

  Autoreview output after the mount metadata fallback was added:

  ```text
  autoreview clean: no accepted/actionable findings reported
  overall: patch is correct (0.78)
  ```
- **Observed result after fix:** On a real Linux NFS mount, the production shared state opener selected `journal_mode=delete`, wrote state successfully across a restart-open, and created no `-wal` or `-shm` sidecar files. The default local shared state database still uses WAL in the local smoke, and tests cover Linux statfs, Linux mountinfo, and macOS/BSD-style mount output detection. The memory-core database path now reaches the same shared helper instead of opening without path context.
- **What was not tested:** Did not run Azure Container Apps itself or a real overlapping ACA revision replacement. The required real Linux NFS storage behavior was tested on a GitHub-hosted Ubuntu runner with a real NFS mount.

## Verification

- GitHub Actions real NFS proof: https://github.com/849261680/openclaw/actions/runs/27105565187
- `node scripts/run-vitest.mjs src/infra/sqlite-wal.test.ts src/state/openclaw-state-db.test.ts`
- `node scripts/run-vitest.mjs extensions/memory-core/src/memory/manager.readonly-recovery.test.ts`
- `node --import tsx --input-type=module` shared-state opener smoke on local disk and simulated Linux NFS statfs
- `corepack pnpm format:check -- src/infra/sqlite-wal.ts src/infra/sqlite-wal.test.ts src/state/openclaw-state-db.test.ts extensions/memory-core/src/memory/manager-db.ts`
- `git diff --check`
- `OPENCLAW_OXLINT_SKIP_LOCK=1 OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/infra/sqlite-wal.ts src/infra/sqlite-wal.test.ts src/state/openclaw-state-db.test.ts`
- `OPENCLAW_OXLINT_SKIP_LOCK=1 OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/memory-core/src/memory/manager-db.ts`
- `corepack pnpm tsgo:core`
- `corepack pnpm tsgo:extensions`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main`
