### PR TITLE
fix(windows): hide startup fallback launcher with VBS

### DIFF
--- a/docs/gateway/index.md
+++ b/docs/gateway/index.md
@@ -278,8 +278,10 @@ openclaw gateway stop
 
 Native Windows managed startup uses a Scheduled Task named `OpenClaw Gateway`
 (or `OpenClaw Gateway (<profile>)` for named profiles). If Scheduled Task
-creation is denied, OpenClaw falls back to a per-user Startup-folder launcher
-that points at `gateway.cmd` inside the state directory.
+creation is denied, OpenClaw falls back to a per-user Startup-folder launcher.
+Current installs write a hidden `gateway.vbs` launcher that starts the state-dir
+task script without flashing a console window, and older `gateway.cmd` entries
+remain supported for cleanup and status detection.
 
   </Tab>
 

--- a/docs/install/uninstall.md
+++ b/docs/install/uninstall.md
@@ -114,10 +114,12 @@ The task script lives under your state dir.
 
 ```powershell
 schtasks /Delete /F /TN "OpenClaw Gateway"
+Remove-Item -Force "$env:USERPROFILE\.openclaw\gateway.vbs"
 Remove-Item -Force "$env:USERPROFILE\.openclaw\gateway.cmd"
 ```
 
-If you used a profile, delete the matching task name and `~\.openclaw-<profile>\gateway.cmd`.
+If you used a profile, delete the matching task name and `~\.openclaw-<profile>\gateway.vbs`.
+Older installs may still leave `~\.openclaw-<profile>\gateway.cmd`, so remove that too if present.
 
 ## Normal install vs source checkout
 

--- a/src/daemon/schtasks.startup-fallback.test.ts
+++ b/src/daemon/schtasks.startup-fallback.test.ts
@@ -73,7 +73,7 @@ const {
   uninstallScheduledTask,
 } = await import("./schtasks.js");
 
-function resolveStartupEntryPath(env: Record<string, string>, extension = "vbs") {
+function resolveStartupEntryPath(env: Record<string, string>, extension = "cmd") {
   const taskName = env.OPENCLAW_WINDOWS_TASK_NAME ?? "OpenClaw Gateway";
   return path.join(
     env.APPDATA,
@@ -86,10 +86,14 @@ function resolveStartupEntryPath(env: Record<string, string>, extension = "vbs")
   );
 }
 
-async function writeStartupFallbackEntry(env: Record<string, string>) {
-  const startupEntryPath = resolveStartupEntryPath(env);
+async function writeStartupFallbackEntry(env: Record<string, string>, extension = "cmd") {
+  const startupEntryPath = resolveStartupEntryPath(env, extension);
   await fs.mkdir(path.dirname(startupEntryPath), { recursive: true });
-  await fs.writeFile(startupEntryPath, 'CreateObject("WScript.Shell")\r\n', "utf8");
+  if (extension === "vbs") {
+    await fs.writeFile(startupEntryPath, 'CreateObject("WScript.Shell")\r\n', "utf8");
+  } else {
+    await fs.writeFile(startupEntryPath, "@echo off\r\n", "utf8");
+  }
   return startupEntryPath;
 }
 
@@ -629,7 +633,7 @@ describe("Windows startup fallback", () => {
   it("treats an installed Startup-folder launcher as loaded", async () => {
     await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
       addStartupFallbackMissingResponses();
-      await writeStartupFallbackEntry(env);
+      await writeStartupFallbackEntry(env, "vbs");
 
       await expect(isScheduledTaskInstalled({ env })).resolves.toBe(true);
     });
@@ -672,7 +676,7 @@ describe("Windows startup fallback", () => {
   it("reports runtime from the gateway listener when using the Startup fallback", async () => {
     await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
       addStartupFallbackMissingResponses();
-      await writeStartupFallbackEntry(env);
+      await writeStartupFallbackEntry(env, "vbs");
       inspectPortUsage.mockResolvedValue({
         port: 18789,
         status: "busy",
@@ -690,7 +694,7 @@ describe("Windows startup fallback", () => {
     await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
       const nodeEnv = makeNodeServiceEnv(env);
       addStartupFallbackMissingResponses();
-      await writeStartupFallbackEntry(nodeEnv);
+      await writeStartupFallbackEntry(nodeEnv, "vbs");
       inspectPortUsage.mockResolvedValue({
         port: 18789,
         status: "busy",
@@ -709,7 +713,7 @@ describe("Windows startup fallback", () => {
     await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
       const nodeEnv = makeNodeServiceEnv(env);
       addStartupFallbackMissingResponses();
-      await writeStartupFallbackEntry(nodeEnv);
+      await writeStartupFallbackEntry(nodeEnv, "vbs");
       inspectPortUsage.mockResolvedValue({
         port: 18789,
         status: "busy",
@@ -728,7 +732,7 @@ describe("Windows startup fallback", () => {
     await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
       const nodeEnv = makeNodeServiceEnv(env);
       addStartupFallbackMissingResponses();
-      await writeStartupFallbackEntry(nodeEnv);
+      await writeStartupFallbackEntry(nodeEnv, "vbs");
       await writeNodeScript(nodeEnv);
       mockWindowsNodeHostProcess();
 
@@ -747,7 +751,7 @@ describe("Windows startup fallback", () => {
         { code: 0, stdout: "", stderr: "" },
         { code: 0, stdout: "", stderr: "" },
       );
-      await writeStartupFallbackEntry(nodeEnv);
+      await writeStartupFallbackEntry(nodeEnv, "vbs");
       await writeNodeScript(nodeEnv);
       mockWindowsNodeHostProcess();
 
@@ -783,7 +787,7 @@ describe("Windows startup fallback", () => {
         { code: 1, stdout: "", stderr: "not found" },
       ]);
       await writeGatewayScript(env);
-      await writeStartupFallbackEntry(env);
+      await writeStartupFallbackEntry(env, "vbs");
       inspectPortUsage.mockResolvedValue({
         port: 18789,
         status: "busy",

--- a/src/daemon/schtasks.startup-fallback.test.ts
+++ b/src/daemon/schtasks.startup-fallback.test.ts
@@ -73,7 +73,7 @@ const {
   uninstallScheduledTask,
 } = await import("./schtasks.js");
 
-function resolveStartupEntryPath(env: Record<string, string>, extension = "cmd") {
+function resolveStartupEntryPath(env: Record<string, string>, extension = "vbs") {
   const taskName = env.OPENCLAW_WINDOWS_TASK_NAME ?? "OpenClaw Gateway";
   return path.join(
     env.APPDATA,
@@ -89,7 +89,7 @@ function resolveStartupEntryPath(env: Record<string, string>, extension = "cmd")
 async function writeStartupFallbackEntry(env: Record<string, string>) {
   const startupEntryPath = resolveStartupEntryPath(env);
   await fs.mkdir(path.dirname(startupEntryPath), { recursive: true });
-  await fs.writeFile(startupEntryPath, "@echo off\r\n", "utf8");
+  await fs.writeFile(startupEntryPath, 'CreateObject("WScript.Shell")\r\n', "utf8");
   return startupEntryPath;
 }
 
@@ -292,15 +292,16 @@ describe("Windows startup fallback", () => {
       const startupEntryPath = resolveStartupEntryPath(env);
       const startupScript = await fs.readFile(startupEntryPath, "utf8");
       expect(result.scriptPath).toBe(resolveTaskScriptPath(env));
-      expect(startupScript).toContain('start "" /min cmd.exe /d /c');
+      expect(startupScript).toContain("WScript.Shell");
       expect(startupScript).toContain("gateway.cmd");
+      expect(startupScript).toContain(`Run """${result.scriptPath}""", 0, False`);
       expectStartupFallbackSpawn();
       expect(childUnref).toHaveBeenCalled();
       expect(printed).toContain("Installed Windows login item");
     });
   });
 
-  it("uses a hidden Startup-folder launcher when requested", async () => {
+  it("still uses a hidden Startup-folder launcher when requested", async () => {
     await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
       addStartupFallbackMissingResponses([
         { code: 5, stdout: "", stderr: "ERROR: Access is denied." },
@@ -311,7 +312,7 @@ describe("Windows startup fallback", () => {
         OPENCLAW_WINDOWS_TASK_HIDDEN_LAUNCHER: "1",
       });
 
-      const startupEntryPath = resolveStartupEntryPath(env, "vbs");
+      const startupEntryPath = resolveStartupEntryPath(env);
       const startupScript = await fs.readFile(startupEntryPath, "utf8");
       expect(result.scriptPath).toBe(resolveTaskScriptPath(env));
       expect(startupScript).toContain("WScript.Shell");

--- a/src/daemon/schtasks.startup-fallback.test.ts
+++ b/src/daemon/schtasks.startup-fallback.test.ts
@@ -73,7 +73,7 @@ const {
   uninstallScheduledTask,
 } = await import("./schtasks.js");
 
-function resolveStartupEntryPath(env: Record<string, string>, extension = "cmd") {
+function resolveStartupEntryPath(env: Record<string, string>, extension = "vbs") {
   const taskName = env.OPENCLAW_WINDOWS_TASK_NAME ?? "OpenClaw Gateway";
   return path.join(
     env.APPDATA,

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -86,7 +86,11 @@ function sanitizeWindowsFilename(value: string): string {
 
 function resolveStartupEntryPath(env: GatewayServiceEnv, extension?: "cmd" | "vbs"): string {
   const taskName = resolveTaskName(env);
-  const entryExtension = extension ?? (shouldUseHiddenWindowsTaskLauncher(env) ? "vbs" : "cmd");
+  // The Startup-folder fallback should launch silently by default on Windows.
+  // A `.vbs` entry using `WScript.Shell.Run(..., 0, False)` suppresses the
+  // transient cmd.exe frame before it reaches the compositor, unlike
+  // `start /min cmd.exe`, which still flashes briefly at logon (#70788).
+  const entryExtension = extension ?? "vbs";
   return path.join(
     resolveWindowsStartupDir(env),
     `${sanitizeWindowsFilename(taskName)}.${entryExtension}`,
@@ -410,21 +414,6 @@ function buildTaskScript({
   }
   const command = programArguments.map(quoteCmdScriptArg).join(" ");
   lines.push(command);
-  return `${lines.join("\r\n")}\r\n`;
-}
-
-function renderStartupLaunchCommand(scriptPath: string): string {
-  return `start "" /min cmd.exe /d /c ${quoteCmdScriptArg(scriptPath)}`;
-}
-
-function buildStartupLauncherScript(params: { description?: string; scriptPath: string }): string {
-  const lines = ["@echo off"];
-  const trimmedDescription = params.description?.trim();
-  if (trimmedDescription) {
-    assertNoCmdLineBreak(trimmedDescription, "Startup launcher description");
-    lines.push(`rem ${trimmedDescription}`);
-  }
-  lines.push(renderStartupLaunchCommand(params.scriptPath));
   return `${lines.join("\r\n")}\r\n`;
 }
 
@@ -1193,15 +1182,10 @@ async function activateScheduledTask(params: {
     if (shouldFallbackToStartupEntry({ code: create.code, detail })) {
       const startupEntryPath = resolveStartupEntryPath(params.env);
       await fs.mkdir(path.dirname(startupEntryPath), { recursive: true });
-      const launcher = shouldUseHiddenWindowsTaskLauncher(params.env)
-        ? buildHiddenLauncherScript({
-            description: taskDescription,
-            scriptPath: params.scriptPath,
-          })
-        : buildStartupLauncherScript({
-            description: taskDescription,
-            scriptPath: params.scriptPath,
-          });
+      const launcher = buildHiddenLauncherScript({
+        description: taskDescription,
+        scriptPath: params.scriptPath,
+      });
       await fs.writeFile(startupEntryPath, launcher, "utf8");
       await launchFallbackTaskScript(params.env);
       writeFormattedLines(


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- Windows Startup-folder fallback installs currently launch the gateway through a visible `cmd.exe` hop.
- Even with `start /min`, Windows still flashes the terminal frame briefly at logon before minimizing it.
- This PR switches the Startup-folder fallback to a hidden `.vbs` launcher by default so the gateway starts without the visible console flash.

Why does this matter now?

- Fixes #70788, where the per-user Startup fallback produced a distracting terminal flash on every Windows login.

What is the intended outcome?

- When Task Scheduler is unavailable and OpenClaw falls back to the Startup folder, the installed login item launches silently with no visible `cmd.exe` frame.

What is intentionally out of scope?

- No change to the main Task Scheduler install/update path.
- No change to the gateway command script itself (`gateway.cmd`).
- No change to runtime/service detection beyond continuing to recognize and clean up both `.vbs` and legacy `.cmd` Startup entries.

What does success look like?

- Startup fallback writes a hidden `.vbs` launcher by default.
- Existing stop/restart/uninstall flows still work with the new default and with legacy `.cmd` fallback entries.

What should reviewers focus on?

- `resolveStartupEntryPath()` now defaults the Startup-folder fallback to `.vbs`.
- `activateScheduledTask()` now always writes the hidden launcher for the Startup fallback path.
- The focused fallback tests still cover install, stop/restart, and legacy cleanup behavior.

## Linked context

Which issue does this close?

Closes #70788

Which issues, PRs, or discussions are related?

Related #57682 for the same visible-console root cause on a different Windows launch path.

Was this requested by a maintainer or owner?

No maintainer request found; the issue is labeled `clawsweeper:queueable-fix`, `clawsweeper:fix-shape-clear`, and `clawsweeper:source-repro`.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Windows Startup-folder fallback no longer generates a visible `cmd.exe` launch hop by default.
- Real environment tested: local source checkout on macOS/Linux using the production Windows fallback installer path under mocked `schtasks` denial and Windows env in the daemon Vitest suites.
- Exact steps or command run after this patch:
  - `node scripts/run-vitest.mjs src/daemon/schtasks.startup-fallback.test.ts src/daemon/schtasks.install.test.ts src/daemon/schtasks.test.ts src/daemon/schtasks.stop.test.ts`
- Evidence after fix:

  ```text
  Startup fallback install now writes the Startup entry as .vbs by default.
  The generated launcher contains:
  CreateObject("WScript.Shell").Run """<gateway.cmd>""", 0, False
  ```

- Observed result after fix: the fallback install tests now assert that the installed Startup entry is the hidden VBS launcher by default, while stop/restart/runtime tests continue to pass against the same fallback lifecycle.
- What was not tested: a live native Windows login session proving compositor-level `no visible flash` behavior. This environment does not provide an interactive Windows desktop.
- Proof limitations or environment constraints: the proof is limited to the production fallback-generation path and lifecycle tests, not a live Windows desktop login.

## Tests and validation

Which commands did you run?

```bash
node scripts/run-vitest.mjs src/daemon/schtasks.startup-fallback.test.ts src/daemon/schtasks.install.test.ts src/daemon/schtasks.test.ts src/daemon/schtasks.stop.test.ts
git diff --check
```

What regression coverage was added or updated?

- Updated Startup fallback tests to assert the default installed login item is now `.vbs`.
- Existing lifecycle tests continue to cover fallback install, restart, stop, and uninstall/cleanup.

What failed before this fix, if known?

- The Startup-folder fallback used `start "" /min cmd.exe /d /c ...`, which still flashes a visible console frame before minimizing.

If no test was added, why not?

- Existing focused tests were updated for the new default behavior instead of adding a separate redundant case.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

- Windows fallback lifecycle compatibility for installs that already have legacy `.cmd` Startup entries.

How is that risk mitigated?

- Uninstall and install-state checks already consider both `.vbs` and legacy `.cmd` paths, and the focused fallback lifecycle tests remain green after the default switch.

## Current review state

What is the next action?

- ClawSweeper review and maintainer review.

What is still waiting on author, maintainer, CI, or external proof?

- CI and maintainer review.
- Live native Windows desktop proof is still unavailable in this environment.

Which bot or reviewer comments were addressed?

- No PR-thread comments yet; this is the initial implementation for #70788.
