### PR TITLE
fix(agents): rename timezone-only prompt section (Fixes #63181)

### DIFF
--- a/docs/concepts/system-prompt.md
+++ b/docs/concepts/system-prompt.md
@@ -41,7 +41,7 @@ The prompt is compact, with fixed sections:
 - **Documentation**: local docs/source path and when to read them.
 - **Workspace Files (injected)**: notes that bootstrap files are included below.
 - **Sandbox** (when enabled): sandboxed runtime, sandbox paths, elevated-exec availability.
-- **Current Date & Time**: time zone only (cache-stable; the live clock comes from `session_status`).
+- **Time Zone**: time zone only (cache-stable; the live clock comes from `session_status`).
 - **Assistant Output Directives**: compact attachment, voice-note, and reply-tag syntax.
 - **Collapsible Details** (when supported): teaches the model to keep optional depth in `<details>` disclosures while leaving the primary answer and required actions visible.
 - **Heartbeats**: heartbeat prompt and ack behavior, when heartbeats are enabled for the default agent.
@@ -72,7 +72,7 @@ On channels with native approval cards/buttons, the prompt tells the agent to re
 OpenClaw renders smaller system prompts for sub-agents. The runtime sets a `promptMode` per run (not user-facing config):
 
 - `full` (default): all sections above.
-- `minimal`: used for sub-agents; omits the memory prompt section (bundled as **Memory Recall**), **OpenClaw Self-Update**, **Model Aliases**, **User Identity**, **Assistant Output Directives**, **Messaging**, **Collapsible Details**, **Silent Replies**, and **Heartbeats**. Tooling, **Safety**, **Skills** (when supplied), Workspace, Sandbox, Current Date & Time (when known), Runtime, and injected context stay available.
+- `minimal`: used for sub-agents; omits the memory prompt section (bundled as **Memory Recall**), **OpenClaw Self-Update**, **Model Aliases**, **User Identity**, **Assistant Output Directives**, **Messaging**, **Collapsible Details**, **Silent Replies**, and **Heartbeats**. Tooling, **Safety**, **Skills** (when supplied), Workspace, Sandbox, Time Zone (when known), Runtime, and injected context stay available.
 - `none`: returns only the base identity line.
 
 Under `promptMode=minimal`, extra injected prompts are labeled **Subagent Context** instead of **Group Chat Context**.
@@ -132,7 +132,9 @@ To inspect how much each injected file contributes (raw vs injected, truncation,
 
 ## Time handling
 
-The **Current Date & Time** section appears only when the user timezone is known, and only includes the **time zone** (no dynamic clock or time format) to keep the prompt cache-stable.
+The system prompt includes a dedicated **Time Zone** section when the
+user timezone is known. To keep the prompt cache-stable, it now only includes
+the **time zone** (no dynamic clock or time format).
 
 Use `session_status` when the agent needs the current time; its status card includes a timestamp line. The same tool can optionally set a per-session model override (`model=default` clears it).
 

--- a/docs/concepts/timezone.md
+++ b/docs/concepts/timezone.md
@@ -14,7 +14,7 @@ OpenClaw standardizes timestamps so the model sees a **single reference time** i
 | ----------------- | ---------------------------------------------------------------------------------------------------------- | ------------------------------------- | ------------------------------------------------------ |
 | Message envelopes | Wraps inbound channel messages: `[Signal +1555 Sun 2026-01-18 00:19:42 PST] hello`                         | Host-local                            | `agents.defaults.envelopeTimezone`                     |
 | Tool payloads     | Channel `readMessages`-style tools return raw provider time plus normalized `timestampMs` / `timestampUtc` | UTC fields always present             | Not configurable; preserves provider-native timestamps |
-| System prompt     | A small `Current Date & Time` block with the **time zone only** (no clock value, for cache stability)      | Host timezone if `userTimezone` unset | `agents.defaults.userTimezone`                         |
+| System prompt     | A small `Time Zone` block with the **time zone only** (no clock value, for cache stability)              | Host timezone if `userTimezone` unset | `agents.defaults.userTimezone`                          |
 
 The system prompt deliberately omits the live clock to keep prompt caching stable across turns. When the agent needs the current time, it calls `session_status`.
 

--- a/docs/concepts/timezone.md
+++ b/docs/concepts/timezone.md
@@ -10,11 +10,11 @@ OpenClaw standardizes timestamps so the model sees a **single reference time** i
 
 ## Three timezone surfaces
 
-| Surface           | What it shows                                                                                              | Default                               | Configured via                                         |
-| ----------------- | ---------------------------------------------------------------------------------------------------------- | ------------------------------------- | ------------------------------------------------------ |
-| Message envelopes | Wraps inbound channel messages: `[Signal +1555 Sun 2026-01-18 00:19:42 PST] hello`                         | Host-local                            | `agents.defaults.envelopeTimezone`                     |
-| Tool payloads     | Channel `readMessages`-style tools return raw provider time plus normalized `timestampMs` / `timestampUtc` | UTC fields always present             | Not configurable; preserves provider-native timestamps |
-| System prompt     | A small `Time Zone` block with the **time zone only** (no clock value, for cache stability)              | Host timezone if `userTimezone` unset | `agents.defaults.userTimezone`                          |
+| Surface           | What it shows                                                                                           | Default                               | Configured via                                          |
+| ----------------- | ------------------------------------------------------------------------------------------------------- | ------------------------------------- | ------------------------------------------------------- |
+| Message envelopes | Wraps inbound channel messages: `[Signal +1555 Sun 2026-01-18 00:19:42 PST] hello`                      | Host-local                            | `agents.defaults.envelopeTimezone`                      |
+| Tool payloads     | Channel `readMessages`-style tools return raw provider time + normalized `timestampMs` / `timestampUtc` | UTC fields always present             | Not configurable — preserves provider-native timestamps |
+| System prompt     | A small `Time Zone` block with the **time zone only** (no clock value, for cache stability)             | Host timezone if `userTimezone` unset | `agents.defaults.userTimezone`                          |
 
 The system prompt deliberately omits the live clock to keep prompt caching stable across turns. When the agent needs the current time, it calls `session_status`.
 

--- a/docs/date-time.md
+++ b/docs/date-time.md
@@ -96,7 +96,7 @@ System: [2026-01-12 12:19:17 PST] Model switched.
 ```
 
 - `userTimezone` sets the **user-local timezone** for prompt context (and for `envelopeTimezone: "user"`).
-- `timeFormat` controls **12h/24h display** in prompt-facing times. `auto` follows OS preferences.
+- `timeFormat` controls **12h/24h display** in rendered time strings. `auto` follows OS prefs.
 
 ## Time format detection (auto)
 

--- a/docs/date-time.md
+++ b/docs/date-time.md
@@ -59,10 +59,11 @@ Override under `agents.defaults`:
 [WhatsApp +1555 +30s Sun 2026-01-18T05:19:00Z] follow-up
 ```
 
-## System prompt: current date and time
+## System prompt: time zone
 
-The system prompt includes a **Current Date & Time** section with the **time zone only**
-(no clock or time format) so prompt caching stays stable:
+If the user timezone is known, the system prompt includes a dedicated
+**Time Zone** section with the **time zone only** (no clock/time format)
+to keep prompt caching stable:
 
 ```
 Time zone: America/Chicago

--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -1282,6 +1282,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
 - Headings:
   - H1: openclaw agent
   - H2: agent exec
+  - H3: Code Mode model matrix
   - H3: agent exec options
   - H2: Options
   - H2: Examples

--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -3207,7 +3207,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
 - Headings:
   - H2: Message envelopes (local by default)
   - H3: Examples
-  - H2: System prompt: current date and time
+  - H2: System prompt: time zone
   - H2: System event lines (local by default)
   - H3: Configure user timezone + format
   - H2: Time format detection (auto)

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -747,7 +747,7 @@ describe("buildAgentSystemPrompt", () => {
 
     for (const testCase of cases) {
       const prompt = buildAgentSystemPrompt(testCase.params);
-      expect(prompt, testCase.name).toContain("## Current Date & Time");
+      expect(prompt, testCase.name).toContain("## Time Zone");
       expect(prompt, testCase.name).toContain("Time zone: America/Chicago");
     }
   });

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -434,7 +434,7 @@ function buildTimeSection(params: { userTimezone?: string }) {
   if (!params.userTimezone) {
     return [];
   }
-  return ["## Current Date & Time", `Time zone: ${params.userTimezone}`, ""];
+  return ["## Time Zone", `Time zone: ${params.userTimezone}`, ""];
 }
 
 function buildAssistantOutputDirectivesSection(params: {


### PR DESCRIPTION
## Summary

Fixes #63181.

Rename the timezone-only system prompt section from `Current Date & Time` to `Time Zone`.

This keeps the prompt wording aligned with current behavior: the section only injects the configured timezone to preserve cache stability, and agents should still use `session_status` when they need the live date/time.

Scope stays narrow:

- rename the emitted system prompt heading
- update the adjacent prompt test
- update the directly related docs that describe this section

Non-goals:

- no change to timestamp injection behavior
- no change to `session_status`
- no reintroduction of dynamic date/time into the system prompt

## Evidence

- Problem statement: current `main` emits a timezone-only prompt section under the misleading `Current Date & Time` heading, even though the section intentionally avoids live date/time injection for cache stability.
- Focused validation: `node scripts/run-vitest.mjs src/agents/system-prompt.test.ts` passes and exercises the production prompt builder that renders this section.
- Docs validation: `node scripts/generate-docs-map.mjs --check` passes, and the touched docs files pass `oxfmt --check` with the shared OpenClaw formatter binary.
- Proof limit: `node scripts/format-docs.mjs --check` still reports pre-existing formatting issues in unrelated docs files outside this PR's diff.

## Tests and validation

- `node scripts/run-vitest.mjs src/agents/system-prompt.test.ts`
- `git diff --check`

## Real behavior proof

Behavior addressed:

- the live system prompt should no longer present a timezone-only section under the misleading `Current Date & Time` heading

Local proof attempted:

- direct prompt-builder invocation from this clean worktree via `tsx` to print the rendered section

Observed result:

- the focused system prompt test passed after the heading rename
- a standalone `tsx` eval path in this worktree failed before prompt rendering because local workspace package resolution for `@openclaw/fs-safe/config` is not available in this environment

What was not tested:

- a fully booted runtime render of the prompt in a running OpenClaw session

Why this is still meaningful:

- the changed runtime surface is a single string emitted by `buildTimeSection()` in `src/agents/system-prompt.ts`
- the adjacent test exercises the production prompt builder directly and verifies the rendered heading and timezone line together

## Risk

Low risk.

This is a wording-only fix to better match the existing cache-stable timezone behavior. It does not change prompt timing semantics, model routing, tool access, or any runtime date/time source.
