### PR TITLE
fix(memory): rebind qmd collections when a collection root changes

### DIFF
--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -5848,6 +5848,170 @@ describe("QmdMemoryManager", () => {
       }
     });
   });
+
+  it("rebinds a managed collection when its root path changed (show reveals old path)", async () => {
+    // Regression: listCollectionsBestEffort gets only the name from `collection list`
+    // (no path). The fix enriches path via `collection show`; without it shouldRebindCollection
+    // hits the `!listed.path` branch and skips the rebind, leaving the old path pinned.
+    const oldWorkspaceDir = path.join(tmpRoot, "old-workspace");
+    const newWorkspaceDir = workspaceDir; // the manager is configured for this new path
+
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [{ path: newWorkspaceDir, pattern: "**/*.md", name: "workspace" }],
+        },
+      },
+    } as OpenClawConfig;
+
+    const collectionName = `workspace-${agentId}`;
+
+    spawnMock.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === "collection" && args[1] === "list") {
+        // Real qmd: names only, no path/pattern in list output.
+        const child = createMockChild({ autoClose: false });
+        emitAndClose(child, "stdout", JSON.stringify([collectionName]));
+        return child;
+      }
+      if (args[0] === "collection" && args[1] === "show" && args[2] === collectionName) {
+        // Real qmd `collection show` output — exposes the stale (old) path.
+        const child = createMockChild({ autoClose: false });
+        emitAndClose(
+          child,
+          "stdout",
+          [
+            `Collection: ${collectionName}`,
+            `  Path:     ${oldWorkspaceDir}`,
+            `  Pattern:  **/*.md`,
+            `  Include:  yes (default)`,
+          ].join("\n"),
+        );
+        return child;
+      }
+      return createMockChild();
+    });
+
+    const { manager } = await createManager({ mode: "full" });
+    await manager.close();
+
+    const commands = spawnMock.mock.calls.map((call: unknown[]) => call[1] as string[]);
+
+    const removeCall = commands.find(
+      (args) => args[0] === "collection" && args[1] === "remove" && args[2] === collectionName,
+    );
+    expect(removeCall).toBeDefined(); // rebind must remove the stale collection
+
+    const addCall = commands.find((args) => {
+      if (args[0] !== "collection" || args[1] !== "add") {
+        return false;
+      }
+      const nameIdx = args.indexOf("--name");
+      return nameIdx >= 0 && args[nameIdx + 1] === collectionName;
+    });
+    expect(addCall).toBeDefined();
+    // The new add must target the NEW workspace path, not the old one.
+    expect(addCall?.[2]).toBe(newWorkspaceDir);
+  });
+
+  it("rebinds a stale in-container collection root to the host workspace (sandbox-mode transition)", async () => {
+    // Sandbox coverage: an agent that previously ran with its workspace bind-mounted under
+    // /home/node/.openclaw/... stored that in-container path as the collection root. Resolved
+    // with host paths, `collection show` reveals the stale container path; the rebind is
+    // path-namespace-agnostic and re-binds to the current host root.
+    const containerRoot = "/home/node/.openclaw/teams/x/workspace";
+    const newWorkspaceDir = workspaceDir; // host path the manager is configured for
+
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [{ path: newWorkspaceDir, pattern: "**/*.md", name: "workspace" }],
+        },
+      },
+    } as OpenClawConfig;
+
+    const collectionName = `workspace-${agentId}`;
+
+    spawnMock.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === "collection" && args[1] === "list") {
+        const child = createMockChild({ autoClose: false });
+        emitAndClose(child, "stdout", JSON.stringify([collectionName]));
+        return child;
+      }
+      if (args[0] === "collection" && args[1] === "show" && args[2] === collectionName) {
+        const child = createMockChild({ autoClose: false });
+        emitAndClose(
+          child,
+          "stdout",
+          [
+            `Collection: ${collectionName}`,
+            `  Path:     ${containerRoot}`,
+            `  Pattern:  **/*.md`,
+            `  Include:  yes (default)`,
+          ].join("\n"),
+        );
+        return child;
+      }
+      return createMockChild();
+    });
+
+    const { manager } = await createManager({ mode: "full" });
+    await manager.close();
+
+    const commands = spawnMock.mock.calls.map((call: unknown[]) => call[1] as string[]);
+    const removeCall = commands.find(
+      (args) => args[0] === "collection" && args[1] === "remove" && args[2] === collectionName,
+    );
+    expect(removeCall).toBeDefined();
+    const addCall = commands.find((args) => {
+      if (args[0] !== "collection" || args[1] !== "add") {
+        return false;
+      }
+      const nameIdx = args.indexOf("--name");
+      return nameIdx >= 0 && args[nameIdx + 1] === collectionName;
+    });
+    expect(addCall).toBeDefined();
+    // Re-added at the host workspace root, not the stale container path.
+    expect(addCall?.[2]).toBe(newWorkspaceDir);
+  });
+
+  it("parseShownCollection extracts path and pattern from qmd collection show output", async () => {
+    // Unit test for the private parser — accessed via type cast to avoid exporting internals.
+    const { manager } = await createManager({ mode: "status" });
+    type WithParser = {
+      parseShownCollection: (output: string) => { path?: string; pattern?: string };
+    };
+    const parser = (manager as unknown as WithParser).parseShownCollection.bind(manager);
+
+    const sampleOutput = [
+      "Collection: memory-dir-tony",
+      "  Path:     /home/node/.openclaw/teams/front-door/workspace-tony/memory",
+      "  Pattern:  **/*.md",
+      "  Include:  yes (default)",
+    ].join("\n");
+
+    const result = parser(sampleOutput);
+    expect(result.path).toBe("/home/node/.openclaw/teams/front-door/workspace-tony/memory");
+    expect(result.pattern).toBe("**/*.md");
+
+    // Tolerant of missing fields.
+    expect(parser("")).toEqual({});
+    expect(parser("Collection: no-path-here\n  Include:  yes")).toEqual({});
+
+    // Path-only (no pattern line).
+    const pathOnly = parser("Collection: x\n  Path:  /some/path\n");
+    expect(pathOnly.path).toBe("/some/path");
+    expect(pathOnly.pattern).toBeUndefined();
+
+    await manager.close();
+  });
 });
 
 function createDeferred<T>() {

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -657,6 +657,36 @@ export class QmdMemoryManager implements MemorySearchManager {
     } catch {
       // ignore; older qmd versions might not support list --json.
     }
+
+    // `qmd collection list` never emits the filesystem path, so `shouldRebindCollection`
+    // cannot detect a workspace move. Enrich the path for managed collections only
+    // (bounded subprocess count) via `qmd collection show`, which does expose it.
+    for (const collection of this.qmd.collections) {
+      const entry = existing.get(collection.name);
+      if (!entry || entry.path) {
+        // Not listed, or path already present (future-proof qmd version or text parser).
+        continue;
+      }
+      try {
+        const showResult = await this.runQmd(["collection", "show", collection.name], {
+          timeoutMs: this.qmd.update.commandTimeoutMs,
+        });
+        const shown = this.parseShownCollection(showResult.stdout);
+        if (shown.path) {
+          entry.path = shown.path;
+        }
+        // Only backfill pattern when the list parse left it absent; never overwrite a
+        // pattern already extracted from `collection list` output (e.g. a changed pattern
+        // detected via qmd text output would be lost if we clobber it here).
+        if (shown.pattern && !entry.pattern) {
+          entry.pattern = shown.pattern;
+        }
+      } catch {
+        // If show fails (old qmd, timeout, missing collection), leave path undefined.
+        // shouldRebindCollection preserves the safe defensive behavior in that case.
+      }
+    }
+
     return existing;
   }
 
@@ -979,6 +1009,28 @@ export class QmdMemoryManager implements MemorySearchManager {
       }
     }
     return listed;
+  }
+
+  // Parses the output of `qmd collection show <name>`, which emits:
+  //   Collection: <name>
+  //     Path:     <absolute-path>
+  //     Pattern:  <glob>
+  //     Include:  yes (default)
+  // This is the only qmd command that reliably surfaces the filesystem path.
+  private parseShownCollection(output: string): { path?: string; pattern?: string } {
+    const result: { path?: string; pattern?: string } = {};
+    for (const rawLine of output.split(/\r?\n/)) {
+      const pathMatch = /^\s*Path\s*:\s*(.+?)\s*$/.exec(rawLine);
+      if (pathMatch) {
+        result.path = pathMatch[1].trim();
+        continue;
+      }
+      const patternMatch = /^\s*Pattern\s*:\s*(.+?)\s*$/.exec(rawLine);
+      if (patternMatch) {
+        result.pattern = patternMatch[1].trim();
+      }
+    }
+    return result;
   }
 
   private shouldRebindCollection(collection: ManagedCollection, listed: ListedCollection): boolean {


### PR DESCRIPTION
## Summary

- **Problem:** `MemoryQmdManager.ensureCollections()` is meant to rebind a managed qmd collection (remove + re-add) when its filesystem root changes — e.g. when an agent's `workspace` is repointed. It never fires, so collections stay pinned to the stale root and recall keeps resolving the old location after a workspace move.
- **Root cause:** `shouldRebindCollection()` compares `listed.path` to the desired path, but `listed.path` is **always `undefined`** — `listCollectionsBestEffort()` reads `qmd collection list`, whose output carries no filesystem path (only name / pattern / counts). With `listed.path` undefined, `shouldRebindCollection` takes its defensive "incomplete metadata" branch and skips the rebind.
- **Outcome:** enrich the listed collections with their `path` via `qmd collection show <name>` (which **does** expose `Path:`) for managed collections only, so a changed root is detected and the rebind fires.
- **Out of scope:** the agent-scoped collection naming convention (`scopeCollectionBase`), tracked separately; and any change to `@tobilu/qmd` itself (it already exposes the path via `collection show`).
- **Reviewer focus:** the enrichment is bounded to **managed** collections and fails safe per-collection — a failed `show` leaves `path` undefined, degrading to the exact prior (defensive, no-rebind) behavior rather than throwing.

## Linked context

Closes #91251

Related: none.

Requested by a maintainer or owner? No — community contribution.

## Real behavior proof (required for external PRs)

Behavior addressed: qmd memory collections rebinding when a managed collection's filesystem root changes (an agent `workspace` repoint).

Real environment tested: a live, self-hosted OpenClaw gateway (macOS), memory backend `qmd` (`@tobilu/qmd` 2.5.2), running this build; plus a standalone `qmd` repro on the same version.

Exact steps or command run after this patch:
```
# (A) Standalone, generic root-cause repro — shows `list` lacks the path that `show` exposes:
qmd collection add /tmp/ws/workspace-A/memory --name memory-dir
qmd collection list      # name/pattern/counts only — NO path
qmd collection show memory-dir   # exposes "Path: ..."

# (B) End-to-end on the live gateway — repoint an agent workspace and reindex:
openclaw config set agents.list[N].workspace "<NEW_WS>"   # same content as <OLD_WS>
openclaw config validate && openclaw gateway restart
openclaw memory index --force --agent <agent>
sqlite3 <agent-qmd-index>.sqlite "select name,path from store_collections where name like 'memory%';"
```

Evidence after fix:
```
# (A) standalone qmd 2.5.2 (generic /tmp paths, unredacted):
$ qmd collection list
memory-dir (qmd://memory-dir/)
  Pattern:  **/*.md
  Files:    1            # <- no Path field
$ qmd collection show memory-dir
Collection: memory-dir
  Path:     /tmp/ws/workspace-A/memory     # <- path IS available here

# (B) live gateway, after the fix (paths/agent redacted):
$ sqlite3 <agent-qmd-index>.sqlite "select name,path from store_collections where name like 'memory%';"
memory-root-<agent>  <NEW_WS>
memory-dir-<agent>   <NEW_WS>/memory       # both rebound from <OLD_WS> to <NEW_WS>
$ openclaw memory search "<query>" --agent <agent>
0.770  library/promoted/index.md:4-7       # resolved from <NEW_WS>
```

Observed result after fix: the managed memory collections rebound from `<OLD_WS>` to `<NEW_WS>`; recall resolves `<NEW_WS>`.

What was not tested: a live sandbox/container-mode (`sandbox.mode != "off"`) run end-to-end — the in-container `/home/node/...` namespace is covered by unit tests (parser + a container→host rebind transition test) but not exercised against a running container in this change.

Proof limitations or environment constraints: live evidence is redacted terminal output from a private fleet (paths, agent, team identifiers removed); the standalone qmd repro (A) is unredacted and reproducible by any maintainer on `@tobilu/qmd` 2.5.2.

Before evidence: same steps WITHOUT this patch → `store_collections` stayed at `<OLD_WS>` (0 of the managed memory collections rebound); recall kept resolving `<OLD_WS>`.

## Tests and validation

Commands run (clean checkout off `openclaw/openclaw` `main`):
- `pnpm test extensions/memory-core/src/memory/qmd-manager.test.ts` → **123 passed**
- `pnpm test extensions/memory-core/src/memory` → **432 passed (40 files)**
- `pnpm check:test-types` (tsgo) → **clean, 0 errors**
- `oxfmt` applied to the touched files.

Regression coverage added:
- `rebinds a managed collection when its root path changed (show reveals old path)` — mocks `collection list` (name only) + `collection show` (stale path); asserts `collection remove` + `collection add` at the new path fire. Fails on baseline (no remove/add, because `listed.path` was undefined).
- `rebinds a stale in-container collection root to the host workspace (sandbox-mode transition)` — same, with an in-container `/home/node/...` stale root, asserting it rebinds to the host root (path-namespace-agnostic).
- a unit test for the `qmd collection show` output parser (`parseShownCollection`).

Multi-agent note: rebind is safe across agents by construction — each agent has its **own** isolated qmd index (`agents/<agentId>/qmd/...`), so there is no shared collection namespace to contend on.

## Risk checklist

User-visible behavior change? Yes — managed collections now rebind when their root changes (previously they silently did not). This is the intended fix.

Did config, environment, or migration behavior change? No.

Did security, auth, secrets, network, or tool execution behavior change? No.

Highest-risk area: (1) one extra `qmd collection show` call per managed collection on each `ensureCollections()`; (2) toggling `sandbox.mode` switches the path namespace (host `/Volumes/...` vs in-container `/home/node/...`), which is now correctly detected as a root change and triggers a one-time rebind/reindex on the next run.

How is that risk mitigated: (1) the enrichment is bounded to managed collections and each `show` is `try/catch`-guarded — a failure leaves `path` undefined and falls back to the prior defensive no-rebind path; (2) the mode-toggle rebind is a single self-correcting reindex per switch, and `sandbox.mode` is a per-agent setting that is not toggled per-run.

## Current review state

Next action: maintainer review.

What is still waiting: CI + review.

Which bot or reviewer comments were addressed: none (initial submission).
