### PR TITLE
feat(diagnostics-otel): capture tool input/output content via trusted channel

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-1cd5bcc75461c64d39a00918a50d033e66ae7ec199d8029f7cccaaa2eeb16f22  plugin-sdk-api-baseline.json
-a5d3b43c3710c4238958b1b3163e652ac34bdc7b82215c6294ce61b72188d75e  plugin-sdk-api-baseline.jsonl
+ae06e87a060aaa9618e2b245553d90402c0fbbe1ebc864928dc7f771cede7c6d  plugin-sdk-api-baseline.json
+8ae4665726d0a8e2e80587ab0b98afce6718861a996daef2fac207066c29dd4f  plugin-sdk-api-baseline.jsonl

--- a/docs/gateway/opentelemetry.md
+++ b/docs/gateway/opentelemetry.md
@@ -161,6 +161,13 @@ When any subkey is enabled, model and tool spans get bounded, redacted
 `captureContent: true` only for broad diagnostics captures where OTLP log
 message bodies are also approved for export.
 
+`toolInputs`/`toolOutputs` content is captured for the built-in agent runtime's
+tool executions (`openclaw.content.tool_input` on completed/error spans,
+`openclaw.content.tool_output` on completed spans). External harness tool calls
+(Codex, Claude CLI) emit `tool.execution.*` spans without content payloads.
+Captured content travels on a trusted, listener-only channel and is never placed
+on the public diagnostic event bus.
+
 ## Sampling and flushing
 
 - **Traces:** `diagnostics.otel.sampleRate` (root-span only, `0.0` drops all,

--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -408,6 +408,22 @@ function emitTrustedModelCallCompletedWithContent(
   );
 }
 
+function emitTrustedToolExecutionCompletedWithContent(
+  event: Omit<
+    Extract<Parameters<typeof emitDiagnosticEvent>[0], { type: "tool.execution.completed" }>,
+    "type"
+  >,
+  toolContent: NonNullable<DiagnosticEventPrivateData["toolContent"]>,
+) {
+  emitTrustedDiagnosticEventWithPrivateData(
+    {
+      type: "tool.execution.completed",
+      ...event,
+    },
+    { toolContent },
+  );
+}
+
 afterAll(() => {
   vi.doUnmock("@opentelemetry/api");
   vi.doUnmock("@opentelemetry/sdk-node");
@@ -3991,15 +4007,18 @@ describe("diagnostics-otel service", () => {
         systemPrompt: "private system prompt",
       },
     );
-    emitDiagnosticEvent({
-      type: "tool.execution.completed",
-      runId: "run-1",
-      toolName: "read",
-      toolCallId: "tool-1",
-      durationMs: 20,
-      toolInput: "private tool input",
-      toolOutput: "private tool output",
-    } as Parameters<typeof emitDiagnosticEvent>[0]);
+    emitTrustedToolExecutionCompletedWithContent(
+      {
+        runId: "run-1",
+        toolName: "read",
+        toolCallId: "tool-1",
+        durationMs: 20,
+      },
+      {
+        toolInput: "private tool input",
+        toolOutput: "private tool output",
+      },
+    );
     await flushDiagnosticEvents();
 
     const modelOptions = startedSpanOptions("openclaw.model.call");
@@ -4052,15 +4071,18 @@ describe("diagnostics-otel service", () => {
         systemPrompt: "system prompt",
       },
     );
-    emitDiagnosticEvent({
-      type: "tool.execution.completed",
-      runId: "run-1",
-      toolName: "read",
-      toolCallId: "tool-1",
-      durationMs: 20,
-      toolInput: "tool input",
-      toolOutput: `${"x".repeat(4077)} Bearer ${"a".repeat(80)}`, // pragma: allowlist secret
-    } as Parameters<typeof emitDiagnosticEvent>[0]);
+    emitTrustedToolExecutionCompletedWithContent(
+      {
+        runId: "run-1",
+        toolName: "read",
+        toolCallId: "tool-1",
+        durationMs: 20,
+      },
+      {
+        toolInput: "tool input",
+        toolOutput: `${"x".repeat(4077)} Bearer ${"a".repeat(80)}`, // pragma: allowlist secret
+      },
+    );
     await flushDiagnosticEvents();
 
     const modelCall = telemetryState.tracer.startSpan.mock.calls.find(

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -109,6 +109,11 @@ type OtelModelCallContent = {
   toolDefinitions?: unknown;
 };
 
+type OtelToolCallContent = {
+  toolInput?: unknown;
+  toolOutput?: unknown;
+};
+
 type MessageDeliveryDiagnosticEvent = Extract<
   DiagnosticEventPayload,
   {
@@ -910,14 +915,14 @@ function assignOtelModelContentAttributes(
 
 function assignOtelToolContentAttributes(
   attributes: Record<string, string | number | boolean>,
-  event: Record<string, unknown>,
+  content: OtelToolCallContent | undefined,
   policy: OtelContentCapturePolicy,
 ): void {
   if (policy.toolInputs) {
-    assignOtelContentAttribute(attributes, "openclaw.content.tool_input", event.toolInput);
+    assignOtelContentAttribute(attributes, "openclaw.content.tool_input", content?.toolInput);
   }
   if (policy.toolOutputs) {
-    assignOtelContentAttribute(attributes, "openclaw.content.tool_output", event.toolOutput);
+    assignOtelContentAttribute(attributes, "openclaw.content.tool_output", content?.toolOutput);
   }
 }
 
@@ -3045,6 +3050,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
       const recordToolExecutionCompleted = (
         evt: Extract<DiagnosticEventPayload, { type: "tool.execution.completed" }>,
         metadata: DiagnosticEventMetadata,
+        toolContent?: OtelToolCallContent,
       ) => {
         const attrs = toolExecutionBaseAttrs(evt);
         toolExecutionDurationHistogram.record(evt.durationMs, attrs);
@@ -3055,11 +3061,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
           ...toolExecutionBaseAttrs(evt),
         };
         addRunAttrs(spanAttrs, evt);
-        assignOtelToolContentAttributes(
-          spanAttrs,
-          evt as unknown as Record<string, unknown>,
-          contentCapturePolicy,
-        );
+        assignOtelToolContentAttributes(spanAttrs, toolContent, contentCapturePolicy);
         const span =
           takeTrackedTrustedSpan(evt, metadata) ??
           spanWithDuration("openclaw.tool.execution", spanAttrs, evt.durationMs, {
@@ -3073,6 +3075,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
       const recordToolExecutionError = (
         evt: Extract<DiagnosticEventPayload, { type: "tool.execution.error" }>,
         metadata: DiagnosticEventMetadata,
+        toolContent?: OtelToolCallContent,
       ) => {
         const attrs = {
           ...toolExecutionBaseAttrs(evt),
@@ -3090,11 +3093,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         if (evt.errorCode) {
           spanAttrs["openclaw.errorCode"] = lowCardinalityAttr(evt.errorCode, "other");
         }
-        assignOtelToolContentAttributes(
-          spanAttrs,
-          evt as unknown as Record<string, unknown>,
-          contentCapturePolicy,
-        );
+        assignOtelToolContentAttributes(spanAttrs, toolContent, contentCapturePolicy);
         const span =
           takeTrackedTrustedSpan(evt, metadata) ??
           spanWithDuration("openclaw.tool.execution", spanAttrs, evt.durationMs, {
@@ -3425,10 +3424,10 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
               recordToolExecutionStarted(evt, metadata);
               return;
             case "tool.execution.completed":
-              recordToolExecutionCompleted(evt, metadata);
+              recordToolExecutionCompleted(evt, metadata, privateData.toolContent);
               return;
             case "tool.execution.error":
-              recordToolExecutionError(evt, metadata);
+              recordToolExecutionError(evt, metadata, privateData.toolContent);
               return;
             case "tool.execution.blocked":
               recordToolExecutionBlocked(evt, metadata);

--- a/src/agents/agent-tools.before-tool-call.e2e.test.ts
+++ b/src/agents/agent-tools.before-tool-call.e2e.test.ts
@@ -9,8 +9,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   onInternalDiagnosticEvent,
   onDiagnosticEvent,
+  onTrustedInternalDiagnosticEvent,
   resetDiagnosticEventsForTest,
   type DiagnosticEventPayload,
+  type DiagnosticEventPrivateData,
   type DiagnosticToolLoopEvent,
 } from "../infra/diagnostic-events.js";
 import { MAX_PLUGIN_APPROVAL_TIMEOUT_MS } from "../infra/plugin-approvals.js";
@@ -1759,5 +1761,144 @@ describe("before_tool_call requireApproval handling", () => {
     });
 
     expect(onResolution).toHaveBeenCalledWith("cancelled");
+  });
+});
+
+describe("before_tool_call tool content private-data capture", () => {
+  type TrustedToolEvent = {
+    event: DiagnosticEventPayload;
+    privateData: DiagnosticEventPrivateData;
+  };
+
+  beforeEach(() => {
+    resetDiagnosticSessionStateForTest();
+    resetDiagnosticEventsForTest();
+  });
+
+  async function withTrustedToolEvents(
+    run: (emitted: TrustedToolEvent[], flush: () => Promise<void>) => Promise<void>,
+  ) {
+    const emitted: TrustedToolEvent[] = [];
+    const stop = onTrustedInternalDiagnosticEvent((event, _metadata, privateData) => {
+      if (event.type.startsWith("tool.execution.")) {
+        emitted.push({ event, privateData });
+      }
+    });
+    const flush = () =>
+      new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+    try {
+      await run(emitted, flush);
+    } finally {
+      stop();
+    }
+  }
+
+  function configWithToolContent(
+    fields: { toolInputs?: boolean; toolOutputs?: boolean } = {
+      toolInputs: true,
+      toolOutputs: true,
+    },
+  ) {
+    return {
+      diagnostics: {
+        enabled: true,
+        otel: {
+          enabled: true,
+          traces: true,
+          captureContent: { enabled: true, ...fields },
+        },
+      },
+    } as unknown as import("../config/types.openclaw.js").OpenClawConfig;
+  }
+
+  it("attaches tool input/output to private data when opted in", async () => {
+    const execute = vi.fn().mockResolvedValue({ content: [{ type: "text", text: "file body" }] });
+    const tool = wrapToolWithBeforeToolCallHook({ name: "read", execute } as any, {
+      agentId: "main",
+      sessionKey: "session-key",
+      runId: "run-1",
+      loopDetection: { enabled: false },
+      config: configWithToolContent(),
+    });
+
+    await withTrustedToolEvents(async (emitted, flush) => {
+      await tool.execute("call-1", { path: "/etc/secret" }, undefined, undefined);
+      await flush();
+
+      const completed = emitted.find((e) => e.event.type === "tool.execution.completed");
+      expect(completed?.privateData.toolContent?.toolInput).toEqual({ path: "/etc/secret" });
+      expect(completed?.privateData.toolContent?.toolOutput).toEqual({
+        content: [{ type: "text", text: "file body" }],
+      });
+      // Public event payload must never carry raw params/results.
+      expect(JSON.stringify(completed?.event)).not.toContain("/etc/secret");
+      expect(JSON.stringify(completed?.event)).not.toContain("file body");
+    });
+  });
+
+  it("omits tool content from private data when capture is not configured", async () => {
+    const execute = vi.fn().mockResolvedValue({ content: [{ type: "text", text: "ok" }] });
+    const tool = wrapToolWithBeforeToolCallHook({ name: "read", execute } as any, {
+      agentId: "main",
+      sessionKey: "session-key",
+      runId: "run-1",
+      loopDetection: { enabled: false },
+    });
+
+    await withTrustedToolEvents(async (emitted, flush) => {
+      await tool.execute("call-1", { path: "/etc/secret" }, undefined, undefined);
+      await flush();
+
+      const completed = emitted.find((e) => e.event.type === "tool.execution.completed");
+      expect(completed).toBeDefined();
+      expect(completed?.privateData.toolContent).toBeUndefined();
+    });
+  });
+
+  it("captures only opted-in fields and clones away from live params", async () => {
+    const liveParams = { path: "/etc/secret" };
+    const execute = vi.fn().mockResolvedValue({ content: [{ type: "text", text: "out" }] });
+    const tool = wrapToolWithBeforeToolCallHook({ name: "read", execute } as any, {
+      agentId: "main",
+      sessionKey: "session-key",
+      runId: "run-1",
+      loopDetection: { enabled: false },
+      config: configWithToolContent({ toolInputs: true, toolOutputs: false }),
+    });
+
+    await withTrustedToolEvents(async (emitted, flush) => {
+      await tool.execute("call-1", liveParams, undefined, undefined);
+      await flush();
+
+      const completed = emitted.find((e) => e.event.type === "tool.execution.completed");
+      expect(completed?.privateData.toolContent?.toolInput).toEqual({ path: "/etc/secret" });
+      expect(completed?.privateData.toolContent?.toolOutput).toBeUndefined();
+      // Captured snapshot is a clone, not the live params object.
+      expect(completed?.privateData.toolContent?.toolInput).not.toBe(liveParams);
+    });
+  });
+
+  it("attaches tool input but not output on execution errors", async () => {
+    const execute = vi.fn().mockRejectedValue(new Error("boom"));
+    const tool = wrapToolWithBeforeToolCallHook({ name: "read", execute } as any, {
+      agentId: "main",
+      sessionKey: "session-key",
+      runId: "run-1",
+      loopDetection: { enabled: false },
+      config: configWithToolContent(),
+    });
+
+    await withTrustedToolEvents(async (emitted, flush) => {
+      await expect(
+        tool.execute("call-1", { path: "/etc/secret" }, undefined, undefined),
+      ).rejects.toThrow("boom");
+      await flush();
+
+      const errored = emitted.find((e) => e.event.type === "tool.execution.error");
+      expect(errored?.privateData.toolContent?.toolInput).toEqual({ path: "/etc/secret" });
+      expect(errored?.privateData.toolContent?.toolOutput).toBeUndefined();
+    });
   });
 });

--- a/src/agents/agent-tools.before-tool-call.ts
+++ b/src/agents/agent-tools.before-tool-call.ts
@@ -14,9 +14,16 @@ import {
 } from "../infra/diagnostic-error-metadata.js";
 import {
   emitTrustedDiagnosticEvent,
+  emitTrustedDiagnosticEventWithPrivateData,
+  type DiagnosticEventPrivateData,
   type DiagnosticToolParamsSummary,
   type DiagnosticToolSource,
 } from "../infra/diagnostic-events.js";
+import {
+  cloneDiagnosticContentValue,
+  resolveDiagnosticModelContentCapturePolicy,
+  type DiagnosticModelContentCapturePolicy,
+} from "../infra/diagnostic-llm-content.js";
 import {
   createChildDiagnosticTraceContext,
   freezeDiagnosticTraceContext,
@@ -700,6 +707,26 @@ export function buildBlockedToolResult(params: {
   };
 }
 
+// Build the private (trusted-listener-only) tool content payload for a tool
+// execution diagnostic event. Raw args/results never ride the public event bus;
+// consumers (e.g. diagnostics-otel) bound and redact before export.
+function buildToolContentPrivateData(
+  policy: DiagnosticModelContentCapturePolicy,
+  args: { input: unknown; output?: unknown; includeOutput: boolean },
+): DiagnosticEventPrivateData | undefined {
+  if (!policy.toolInputs && !policy.toolOutputs) {
+    return undefined;
+  }
+  const toolContent: { toolInput?: unknown; toolOutput?: unknown } = {};
+  if (policy.toolInputs) {
+    toolContent.toolInput = cloneDiagnosticContentValue(args.input);
+  }
+  if (args.includeOutput && policy.toolOutputs) {
+    toolContent.toolOutput = cloneDiagnosticContentValue(args.output);
+  }
+  return Object.keys(toolContent).length > 0 ? { toolContent } : undefined;
+}
+
 function summarizeToolParams(params: unknown): DiagnosticToolParamsSummary {
   if (params === null) {
     return { kind: "null" };
@@ -1117,6 +1144,9 @@ export function wrapToolWithBeforeToolCallHook(
     ...(options.approvalMode ? { approvalMode: options.approvalMode } : {}),
     emitDiagnostics: options.emitDiagnostics !== false,
   };
+  // Resolved once per wrap from the same opt-in config gate the model-content
+  // path uses; controls whether tool input/output rides the trusted private channel.
+  const toolContentPolicy = resolveDiagnosticModelContentCapturePolicy(ctx?.config);
   const wrappedTool: AnyAgentTool = {
     ...tool,
     execute: async (toolCallId, params, signal, onUpdate) => {
@@ -1235,24 +1265,37 @@ export function wrapToolWithBeforeToolCallHook(
               toolCallId,
             });
           }
-          emitTrustedDiagnosticEvent({
-            type: "tool.execution.completed",
-            ...eventBase,
-            durationMs,
-          });
+          emitTrustedDiagnosticEventWithPrivateData(
+            {
+              type: "tool.execution.completed",
+              ...eventBase,
+              durationMs,
+            },
+            buildToolContentPrivateData(toolContentPolicy, {
+              input: executeParams,
+              output: result,
+              includeOutput: true,
+            }),
+          );
         }
         return result;
       } catch (err) {
         const cause = unwrapErrorCause(err);
         const errorCode = diagnosticHttpStatusCode(cause);
         if (hookOptions.emitDiagnostics) {
-          emitTrustedDiagnosticEvent({
-            type: "tool.execution.error",
-            ...eventBase,
-            durationMs: Date.now() - startedAt,
-            errorCategory: diagnosticErrorCategory(cause),
-            ...(errorCode ? { errorCode } : {}),
-          });
+          emitTrustedDiagnosticEventWithPrivateData(
+            {
+              type: "tool.execution.error",
+              ...eventBase,
+              durationMs: Date.now() - startedAt,
+              errorCategory: diagnosticErrorCategory(cause),
+              ...(errorCode ? { errorCode } : {}),
+            },
+            buildToolContentPrivateData(toolContentPolicy, {
+              input: executeParams,
+              includeOutput: false,
+            }),
+          );
         }
         await recordLoopOutcome({
           ctx,

--- a/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.ts
@@ -15,7 +15,10 @@ import {
   type DiagnosticMemoryUsage,
   emitTrustedDiagnosticEventWithPrivateData,
 } from "../../../infra/diagnostic-events.js";
-import type { DiagnosticModelContentCapturePolicy } from "../../../infra/diagnostic-llm-content.js";
+import {
+  cloneDiagnosticContentValue,
+  type DiagnosticModelContentCapturePolicy,
+} from "../../../infra/diagnostic-llm-content.js";
 import {
   createChildDiagnosticTraceContext,
   freezeDiagnosticTraceContext,
@@ -146,19 +149,6 @@ function responseStreamChunkByteLength(chunk: unknown): number | undefined {
     return responseStreamChunkByteLengthUnchecked(chunk);
   } catch {
     return undefined;
-  }
-}
-
-function cloneDiagnosticContentValue(value: unknown): unknown {
-  try {
-    return structuredClone(value);
-  } catch {
-    try {
-      const serialized = JSON.stringify(value);
-      return serialized === undefined ? null : (JSON.parse(serialized) as unknown);
-    } catch {
-      return String(value);
-    }
   }
 }
 

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -714,8 +714,14 @@ export type DiagnosticModelCallContent = Readonly<{
   toolDefinitions?: unknown;
 }>;
 
+export type DiagnosticToolCallContent = Readonly<{
+  toolInput?: unknown;
+  toolOutput?: unknown;
+}>;
+
 export type DiagnosticEventPrivateData = Readonly<{
   modelContent?: DiagnosticModelCallContent;
+  toolContent?: DiagnosticToolCallContent;
 }>;
 
 type DiagnosticEventListener = (

--- a/src/infra/diagnostic-llm-content.test.ts
+++ b/src/infra/diagnostic-llm-content.test.ts
@@ -109,4 +109,47 @@ describe("resolveDiagnosticModelContentCapturePolicy", () => {
       anyModelContent: true,
     });
   });
+
+  it("resolves tool content flags independently from model-visible content", () => {
+    const base = (captureContent: Record<string, unknown>) =>
+      resolveDiagnosticModelContentCapturePolicy({
+        diagnostics: {
+          enabled: true,
+          otel: { enabled: true, captureContent: { enabled: true, ...captureContent } },
+        },
+      });
+
+    // Tool input only: tool content on, model content off.
+    expect(base({ toolInputs: true })).toMatchObject({
+      toolInputs: true,
+      toolOutputs: false,
+      anyModelContent: false,
+    });
+
+    // Tool output only.
+    expect(base({ toolOutputs: true })).toMatchObject({
+      toolInputs: false,
+      toolOutputs: true,
+    });
+
+    // Model content only: tool flags stay off.
+    expect(base({ inputMessages: true })).toMatchObject({
+      toolInputs: false,
+      toolOutputs: false,
+      anyModelContent: true,
+    });
+
+    // captureContent: true enables both families.
+    expect(
+      resolveDiagnosticModelContentCapturePolicy({
+        diagnostics: { enabled: true, otel: { enabled: true, captureContent: true } },
+      }),
+    ).toMatchObject({ anyModelContent: true, toolInputs: true, toolOutputs: true });
+
+    // Disabled config: no tool content.
+    expect(resolveDiagnosticModelContentCapturePolicy({})).toMatchObject({
+      toolInputs: false,
+      toolOutputs: false,
+    });
+  });
 });

--- a/src/infra/diagnostic-llm-content.ts
+++ b/src/infra/diagnostic-llm-content.ts
@@ -30,6 +30,21 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
+// Clone captured content so private diagnostic payloads never alias live runtime
+// objects (tool params/results, model messages) that callers keep mutating.
+export function cloneDiagnosticContentValue(value: unknown): unknown {
+  try {
+    return structuredClone(value);
+  } catch {
+    try {
+      const serialized = JSON.stringify(value);
+      return serialized === undefined ? null : (JSON.parse(serialized) as unknown);
+    } catch {
+      return String(value);
+    }
+  }
+}
+
 function withDerivedFields(
   policy: Omit<DiagnosticModelContentCapturePolicy, "anyModelContent">,
 ): DiagnosticModelContentCapturePolicy {


### PR DESCRIPTION
## Summary

`diagnostics.otel.captureContent.toolInputs` / `toolOutputs` were documented and
config-wired but never produced any span content — the OTel exporter had a
consumer for tool content, but nothing on the runtime side emitted it.

This wires the missing producer, mirroring the model-content path (#86191):

- **Producer** (`agent-tools.before-tool-call.ts`): on tool completion/error,
  emit cloned tool args/results over the **trusted private-data diagnostic
  channel**, gated behind the existing `captureContent` opt-in. Raw tool content
  never rides the public diagnostic event bus.
- **Consumer** (`diagnostics-otel/service.ts`): reads `privateData.toolContent`
  and bounds/redacts/truncates (128KB) before setting `openclaw.content.tool_input`
  and `openclaw.content.tool_output` span attributes.

Scope is the core embedded-runner tool path (the canonical producer). The Codex
harness (async-batched diagnostics) and the Claude CLI session remain follow-ups,
noted in `docs/gateway/opentelemetry.md` and tracked by #77391.

## Verification

- Tests: `diagnostic-llm-content` (4), `attempt.model-diagnostic-events` (13),
  `agent-tools.before-tool-call.e2e` (54, incl. 4 new producer cases),
  `diagnostics-otel/service` (87) — all pass via `node scripts/run-vitest.mjs`.
- Types: `tsgo:core`, `tsgo:extensions`, `tsgo:test:src`, `tsgo:test:extensions`.
- SDK contract: `plugin-sdk:api:check` passes (baseline regenerated for source
  line shifts; no public declaration shape change).
- `oxfmt --check` + `oxlint` clean; Codex autoreview clean (no findings).

Refs #77391
