### PR TITLE
fix #78571: [Bug]: Telegram Connection Bot

### DIFF
--- a/src/agents/cli-output.test.ts
+++ b/src/agents/cli-output.test.ts
@@ -401,6 +401,44 @@ describe("parseCliJsonl", () => {
     });
   });
 
+  it("uses Claude assistant text when the terminal stream-json result is empty", () => {
+    const result = parseCliJsonl(
+      [
+        JSON.stringify({ type: "system", subtype: "init", session_id: "session-telegram" }),
+        JSON.stringify({
+          type: "assistant",
+          message: {
+            content: [{ type: "text", text: "Telegram visible reply." }],
+          },
+        }),
+        JSON.stringify({
+          type: "result",
+          session_id: "session-telegram",
+          result: "   ",
+          usage: { input_tokens: 10, output_tokens: 3 },
+        }),
+      ].join("\n"),
+      {
+        command: "claude",
+        output: "jsonl",
+        sessionIdFields: ["session_id"],
+      },
+      "claude-cli",
+    );
+
+    expect(result).toEqual({
+      text: "Telegram visible reply.",
+      sessionId: "session-telegram",
+      usage: {
+        input: 10,
+        output: 3,
+        cacheRead: undefined,
+        cacheWrite: undefined,
+        total: undefined,
+      },
+    });
+  });
+
   it("unwraps nested Claude agent result JSON from stream-json output", () => {
     const result = parseCliJsonl(
       [
@@ -564,6 +602,49 @@ describe("createCliJsonlStreamingParser", () => {
       cacheRead: 125,
       cacheWrite: undefined,
       total: undefined,
+    });
+  });
+
+  it("keeps Claude assistant text in streaming output when the terminal result is empty", () => {
+    const parser = createCliJsonlStreamingParser({
+      backend: {
+        command: "claude",
+        output: "jsonl",
+        sessionIdFields: ["session_id"],
+      },
+      providerId: "claude-cli",
+      onAssistantDelta: () => {},
+    });
+
+    parser.push(
+      [
+        JSON.stringify({ type: "system", subtype: "init", session_id: "session-telegram" }),
+        JSON.stringify({
+          type: "assistant",
+          message: {
+            content: [{ type: "text", text: "Telegram visible reply." }],
+          },
+        }),
+        JSON.stringify({
+          type: "result",
+          session_id: "session-telegram",
+          result: "   ",
+          usage: { input_tokens: 10, output_tokens: 3 },
+        }),
+      ].join("\n") + "\n",
+    );
+    parser.finish();
+
+    expect(parser.getOutput()).toEqual({
+      text: "Telegram visible reply.",
+      sessionId: "session-telegram",
+      usage: {
+        input: 10,
+        output: 3,
+        cacheRead: undefined,
+        cacheWrite: undefined,
+        total: undefined,
+      },
     });
   });
 

--- a/src/agents/cli-output.ts
+++ b/src/agents/cli-output.ts
@@ -361,12 +361,28 @@ export function parseCliJson(
   return { text, sessionId, usage };
 }
 
+function collectClaudeCliAssistantText(params: {
+  backend: CliBackendConfig;
+  providerId: string;
+  parsed: Record<string, unknown>;
+}): string {
+  if (!usesClaudeStreamJsonDialect(params) || params.parsed.type !== "assistant") {
+    return "";
+  }
+  return collectCliText(params.parsed.message).trim();
+}
+
+function resolveBufferedCliText(texts: readonly string[], assistantText = ""): string {
+  return texts.join("\n").trim() || assistantText.trim();
+}
+
 function parseClaudeCliJsonlResult(params: {
   backend: CliBackendConfig;
   providerId: string;
   parsed: Record<string, unknown>;
   sessionId?: string;
   usage?: CliUsage;
+  fallbackText?: string;
 }): CliOutput | null {
   if (!usesClaudeStreamJsonDialect(params)) {
     return null;
@@ -379,6 +395,10 @@ function parseClaudeCliJsonlResult(params: {
     const resultText = unwrapNestedCliResultText(params.parsed.result).trim();
     if (resultText) {
       return { text: resultText, sessionId: params.sessionId, usage: params.usage };
+    }
+    const fallbackText = params.fallbackText?.trim();
+    if (fallbackText) {
+      return { text: fallbackText, sessionId: params.sessionId, usage: params.usage };
     }
     // Claude may finish with an empty result after tool-only work. Keep the
     // resolved session handle and usage instead of dropping them.
@@ -663,10 +683,20 @@ export function createCliJsonlStreamingParser(params: {
       parsed,
       sessionId,
       usage,
+      fallbackText: resolveBufferedCliText(texts, assistantText),
     });
     if (result) {
       output = result;
       return;
+    }
+
+    const assistantMessageText = collectClaudeCliAssistantText({
+      backend: params.backend,
+      providerId: params.providerId,
+      parsed,
+    });
+    if (assistantMessageText) {
+      texts.push(assistantMessageText);
     }
 
     const item = isRecord(parsed.item) ? parsed.item : null;
@@ -746,7 +776,7 @@ export function createCliJsonlStreamingParser(params: {
       if (output) {
         return output;
       }
-      const text = texts.join("\n").trim();
+      const text = resolveBufferedCliText(texts, assistantText);
       return text ? { text, sessionId, usage } : null;
     },
   };
@@ -784,9 +814,15 @@ export function parseCliJsonl(
         parsed,
         sessionId,
         usage,
+        fallbackText: resolveBufferedCliText(texts),
       });
       if (claudeResult) {
         return claudeResult;
+      }
+
+      const assistantMessageText = collectClaudeCliAssistantText({ backend, providerId, parsed });
+      if (assistantMessageText) {
+        texts.push(assistantMessageText);
       }
 
       const item = isRecord(parsed.item) ? parsed.item : null;
@@ -798,7 +834,7 @@ export function parseCliJsonl(
       }
     }
   }
-  const text = texts.join("\n").trim();
+  const text = resolveBufferedCliText(texts);
   if (!text) {
     return null;
   }

--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -11,48 +11,11 @@ import {
   decodeWindowsOutputBuffer,
   resolveWindowsConsoleEncoding,
 } from "../infra/windows-encoding.js";
-import { getWindowsInstallRoots } from "../infra/windows-install-roots.js";
 import { logDebug, logError } from "../logger.js";
 import { resolveCommandStdio } from "./spawn-utils.js";
-import { resolveWindowsCommandShim } from "./windows-command.js";
+import { buildWindowsBatchInvocation, resolveWindowsCommandShim } from "./windows-command.js";
 
 const execFileAsync = promisify(execFile);
-
-const WINDOWS_UNSAFE_CMD_CHARS_RE = /[&|<>^%\r\n]/;
-
-function isWindowsBatchCommand(resolvedCommand: string): boolean {
-  if (process.platform !== "win32") {
-    return false;
-  }
-  const ext = normalizeLowercaseStringOrEmpty(path.extname(resolvedCommand));
-  return ext === ".cmd" || ext === ".bat";
-}
-
-function escapeForCmdExe(arg: string): string {
-  // Reject cmd metacharacters to avoid injection when we must pass a single command line.
-  if (WINDOWS_UNSAFE_CMD_CHARS_RE.test(arg)) {
-    throw new Error(
-      `Unsafe Windows cmd.exe argument detected: ${JSON.stringify(arg)}. ` +
-        "Pass an explicit shell-wrapper argv at the call site instead.",
-    );
-  }
-  // Quote when needed; double inner quotes for cmd parsing.
-  if (!arg.includes(" ") && !arg.includes('"')) {
-    return arg;
-  }
-  return `"${arg.replace(/"/g, '""')}"`;
-}
-
-function buildCmdExeCommandLine(resolvedCommand: string, args: string[]): string {
-  return [escapeForCmdExe(resolvedCommand), ...args.map(escapeForCmdExe)].join(" ");
-}
-
-function resolveTrustedWindowsCmdExe(): string {
-  if (process.platform !== "win32") {
-    return "cmd.exe";
-  }
-  return path.win32.join(getWindowsInstallRoots().systemRoot, "System32", "cmd.exe");
-}
 
 function assignChildEnvValue(params: {
   env: NodeJS.ProcessEnv;
@@ -148,17 +111,19 @@ function resolveChildProcessInvocation(params: {
       : params.argv;
   const resolvedCommand =
     finalArgv !== params.argv ? (finalArgv[0] ?? "") : resolveCommand(params.argv[0] ?? "");
-  const useCmdWrapper = isWindowsBatchCommand(resolvedCommand);
+  const batchInvocation = buildWindowsBatchInvocation({
+    command: resolvedCommand,
+    args: finalArgv.slice(1),
+  });
 
   return {
-    command: useCmdWrapper ? resolveTrustedWindowsCmdExe() : resolvedCommand,
-    args: useCmdWrapper
-      ? ["/d", "/s", "/c", buildCmdExeCommandLine(resolvedCommand, finalArgv.slice(1))]
-      : finalArgv.slice(1),
+    command: batchInvocation?.command ?? resolvedCommand,
+    args: batchInvocation?.args ?? finalArgv.slice(1),
     usesWindowsExitCodeShim:
-      process.platform === "win32" && (useCmdWrapper || finalArgv !== params.argv),
+      process.platform === "win32" && (batchInvocation !== null || finalArgv !== params.argv),
     windowsHide: true,
-    windowsVerbatimArguments: useCmdWrapper ? true : params.windowsVerbatimArguments,
+    windowsVerbatimArguments:
+      batchInvocation?.windowsVerbatimArguments ?? params.windowsVerbatimArguments,
   };
 }
 

--- a/src/process/supervisor/adapters/child.test.ts
+++ b/src/process/supervisor/adapters/child.test.ts
@@ -83,6 +83,7 @@ type SpawnWithFallbackParams = {
     detached?: boolean;
     env?: NodeJS.ProcessEnv | Record<string, string>;
     stdio?: string[];
+    windowsVerbatimArguments?: boolean;
   };
   fallbacks?: Array<{ options?: { detached?: boolean } }>;
 };
@@ -365,6 +366,26 @@ describe("createChildAdapter", () => {
     await vi.advanceTimersByTimeAsync(300);
 
     expect(settled).toHaveBeenCalledWith({ code: 0, signal: null });
+  });
+
+  it("wraps Windows Claude CLI child runs through cmd.exe instead of spawning .cmd directly", async () => {
+    setPlatform("win32");
+
+    await createAdapterHarness({
+      pid: 3131,
+      argv: ["claude", "--print", "hello world"],
+    });
+
+    const spawnArgs = firstSpawnWithFallbackParams();
+    expect(spawnArgs.argv).toEqual([
+      "C:\\Windows\\System32\\cmd.exe",
+      "/d",
+      "/s",
+      "/c",
+      'claude.cmd --print "hello world"',
+    ]);
+    expect(spawnArgs.options?.detached).toBe(false);
+    expect(spawnArgs.options?.windowsVerbatimArguments).toBe(true);
   });
 
   it("disables detached mode in service-managed runtime", async () => {

--- a/src/process/supervisor/adapters/child.ts
+++ b/src/process/supervisor/adapters/child.ts
@@ -4,7 +4,7 @@ import { createWindowsOutputDecoder } from "../../../infra/windows-encoding.js";
 import { signalProcessTree } from "../../kill-tree.js";
 import { prepareOomScoreAdjustedSpawn } from "../../linux-oom-score.js";
 import { spawnWithFallback } from "../../spawn-utils.js";
-import { resolveWindowsCommandShim } from "../../windows-command.js";
+import { buildWindowsBatchInvocation, resolveWindowsCommandShim } from "../../windows-command.js";
 import type { ManagedRunStdin, SpawnProcessAdapter } from "../types.js";
 import { toStringEnv } from "./env.js";
 
@@ -14,7 +14,7 @@ const WINDOWS_CLOSE_STATE_SETTLE_TIMEOUT_MS = 250;
 function resolveCommand(command: string): string {
   return resolveWindowsCommandShim({
     command,
-    cmdCommands: ["npm", "pnpm", "yarn", "npx"],
+    cmdCommands: ["claude", "npm", "pnpm", "yarn", "npx"],
   });
 }
 
@@ -38,6 +38,12 @@ export async function createChildAdapter(params: {
   const preparedSpawn = prepareOomScoreAdjustedSpawn(resolvedArgv[0] ?? "", resolvedArgv.slice(1), {
     env: baseEnv,
   });
+  const batchInvocation = buildWindowsBatchInvocation({
+    command: preparedSpawn.command,
+    args: preparedSpawn.args,
+  });
+  const spawnCommand = batchInvocation?.command ?? preparedSpawn.command;
+  const spawnArgs = batchInvocation?.args ?? preparedSpawn.args;
 
   const stdinMode = params.stdinMode ?? (params.input !== undefined ? "pipe-closed" : "inherit");
 
@@ -52,7 +58,8 @@ export async function createChildAdapter(params: {
     stdio: ["pipe", "pipe", "pipe"],
     detached: useDetached,
     windowsHide: true,
-    windowsVerbatimArguments: params.windowsVerbatimArguments,
+    windowsVerbatimArguments:
+      batchInvocation?.windowsVerbatimArguments ?? params.windowsVerbatimArguments,
   };
   if (stdinMode === "inherit") {
     options.stdio = ["inherit", "pipe", "pipe"];
@@ -61,7 +68,7 @@ export async function createChildAdapter(params: {
   }
 
   const spawned = await spawnWithFallback({
-    argv: [preparedSpawn.command, ...preparedSpawn.args],
+    argv: [spawnCommand, ...spawnArgs],
     options,
     fallbacks: useDetached
       ? [

--- a/src/process/windows-command.test.ts
+++ b/src/process/windows-command.test.ts
@@ -1,6 +1,6 @@
 // Windows command tests cover command quoting and shell resolution on Windows.
 import { describe, expect, it } from "vitest";
-import { resolveWindowsCommandShim } from "./windows-command.js";
+import { buildWindowsBatchInvocation, resolveWindowsCommandShim } from "./windows-command.js";
 
 describe("resolveWindowsCommandShim", () => {
   it("leaves commands unchanged outside Windows", () => {
@@ -41,5 +41,52 @@ describe("resolveWindowsCommandShim", () => {
         platform: "win32",
       }),
     ).toBe("npm.cmd");
+  });
+
+  it("appends .cmd for Claude CLI on Windows when configured by the caller", () => {
+    expect(
+      resolveWindowsCommandShim({
+        command: "claude",
+        cmdCommands: ["claude", "npm", "npx"],
+        platform: "win32",
+      }),
+    ).toBe("claude.cmd");
+  });
+});
+
+describe("buildWindowsBatchInvocation", () => {
+  it("wraps Windows batch commands with a trusted cmd.exe invocation", () => {
+    expect(
+      buildWindowsBatchInvocation({
+        command: "claude.cmd",
+        args: ["--print", "hello world"],
+        env: { SystemRoot: "C:\\TestWindows" },
+        platform: "win32",
+      }),
+    ).toEqual({
+      command: "C:\\TestWindows\\System32\\cmd.exe",
+      args: ["/d", "/s", "/c", 'claude.cmd --print "hello world"'],
+      windowsVerbatimArguments: true,
+    });
+  });
+
+  it("does not wrap batch commands outside Windows", () => {
+    expect(
+      buildWindowsBatchInvocation({
+        command: "claude.cmd",
+        args: ["--print", "hello"],
+        platform: "linux",
+      }),
+    ).toBeNull();
+  });
+
+  it("rejects Windows cmd.exe metacharacters instead of enabling shell injection", () => {
+    expect(() =>
+      buildWindowsBatchInvocation({
+        command: "claude.cmd",
+        args: ["hello & calc.exe"],
+        platform: "win32",
+      }),
+    ).toThrow(/Unsafe Windows cmd\.exe argument/);
   });
 });

--- a/src/process/windows-command.ts
+++ b/src/process/windows-command.ts
@@ -2,9 +2,18 @@
 import path from "node:path";
 import process from "node:process";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import { getWindowsInstallRoots } from "../infra/windows-install-roots.js";
+
+const WINDOWS_UNSAFE_CMD_CHARS_RE = /[&|<>^%\r\n]/;
+
+export type WindowsBatchInvocation = {
+  args: string[];
+  command: string;
+  windowsVerbatimArguments: true;
+};
 
 /**
- * Resolve package-manager commands that Windows exposes through .cmd shims.
+ * Resolve commands that Windows exposes through .cmd shims.
  * Explicit extensions are preserved so callers can pass already-resolved tools.
  */
 export function resolveWindowsCommandShim(params: {
@@ -23,4 +32,60 @@ export function resolveWindowsCommandShim(params: {
     return `${params.command}.cmd`;
   }
   return params.command;
+}
+
+export function isWindowsBatchCommand(params: {
+  command: string;
+  platform?: NodeJS.Platform;
+}): boolean {
+  if ((params.platform ?? process.platform) !== "win32") {
+    return false;
+  }
+  const ext = normalizeLowercaseStringOrEmpty(path.extname(params.command));
+  return ext === ".cmd" || ext === ".bat";
+}
+
+function escapeForCmdExe(arg: string): string {
+  if (WINDOWS_UNSAFE_CMD_CHARS_RE.test(arg)) {
+    throw new Error(
+      `Unsafe Windows cmd.exe argument detected: ${JSON.stringify(arg)}. ` +
+        "Pass an explicit shell-wrapper argv at the call site instead.",
+    );
+  }
+  if (!arg.includes(" ") && !arg.includes('"')) {
+    return arg;
+  }
+  return `"${arg.replace(/"/g, '""')}"`;
+}
+
+function buildCmdExeCommandLine(command: string, args: readonly string[]): string {
+  return [escapeForCmdExe(command), ...args.map(escapeForCmdExe)].join(" ");
+}
+
+export function resolveTrustedWindowsCmdExe(
+  params: {
+    env?: Record<string, string | undefined>;
+    platform?: NodeJS.Platform;
+  } = {},
+): string {
+  if ((params.platform ?? process.platform) !== "win32") {
+    return "cmd.exe";
+  }
+  return path.win32.join(getWindowsInstallRoots(params.env).systemRoot, "System32", "cmd.exe");
+}
+
+export function buildWindowsBatchInvocation(params: {
+  args: readonly string[];
+  command: string;
+  env?: Record<string, string | undefined>;
+  platform?: NodeJS.Platform;
+}): WindowsBatchInvocation | null {
+  if (!isWindowsBatchCommand({ command: params.command, platform: params.platform })) {
+    return null;
+  }
+  return {
+    command: resolveTrustedWindowsCmdExe({ env: params.env, platform: params.platform }),
+    args: ["/d", "/s", "/c", buildCmdExeCommandLine(params.command, params.args)],
+    windowsVerbatimArguments: true,
+  };
 }


### PR DESCRIPTION
Fixes #78571

## Summary

- Preserve visible Claude stream-json assistant text when the terminal `result` event is blank, so a successful Claude CLI turn still produces a final reply for Telegram dispatch.
- Route Windows `.cmd`/`.bat` shims through a trusted `cmd.exe /d /s /c` argv wrapper instead of spawning batch files directly, covering the supervisor child path used by live Claude CLI sessions.
- Keep the existing tool-only blank result metadata behavior and reject unsafe Windows cmd metacharacters rather than enabling `shell: true`.

## Root Cause

- **Root cause:** The Telegram + Claude CLI path had two source-level parser/resolver failures in the reported Windows chain. The supervisor child adapter did not resolve bare `claude` to the Windows `.cmd` shim, and patched Node versions reject direct `.cmd` / `.bat` spawning with `spawn EINVAL`. Separately, Claude stream-json output can include visible `assistant.message.content` text followed by a blank terminal `result`; OpenClaw used that blank terminal result as the normalized final text and discarded the earlier visible assistant text.
- **Why this is root-cause fix:** The patch changes the canonical CLI output parser that feeds live-session final results before Telegram dispatch, and the shared Windows command invocation helper used before process spawn. It does not add a Telegram fallback, a silent-reply workaround, or a downstream string special case; it fixes the parser/resolver invariants that caused the no-visible-reply behavior.
- **Fix classification:** Root-cause bug fix for Claude CLI stream-json output normalization and Windows command invocation.
- **Maintainer-ready confidence:** High for the local production code paths covered here: parser normalization, streaming parser output, Windows shim resolution, trusted batch wrapper construction, and unsafe cmd metacharacter rejection all have focused regressions and a production-code proof. Live Windows/Telegram/OAuth execution is not claimed from this Linux environment.
- **Patch quality notes:** Patch quality warnings were reviewed. The added default returns are guard exits for non-Claude/non-Windows records, not broad fallback behavior that masks errors. Public contract risk is bounded because no config schema, Telegram API, Claude CLI protocol, or provider setting changes; the command helper centralizes the existing Windows batch contract and preserves `shell: false`.

## What changed

- `src/agents/cli-output.ts` now buffers Claude stream-json assistant text and uses it only when the terminal `result` event is empty or whitespace.
- Non-empty terminal `result` text still wins, and blank tool-only terminal results still preserve session/usage metadata with `text: ""`.
- `src/process/windows-command.ts` now owns shared Windows batch invocation handling, including trusted `cmd.exe` resolution and metacharacter rejection.
- `src/process/exec.ts` reuses the shared batch invocation helper instead of keeping a duplicate wrapper.
- `src/process/supervisor/adapters/child.ts` resolves bare `claude` to `claude.cmd` on Windows and wraps batch shims before `spawnWithFallback`.

## Scope boundary

- **Why it matters / User impact:** A Windows Telegram bot using Claude CLI can complete a Claude turn but still send no visible Telegram reply. Preserving the assistant text and avoiding direct `.cmd` spawn failures keeps the configured bot path from silently ending without a response.
- **What did NOT change:** This does not change Telegram plugin routing, OAuth login, provider selection, live gateway config, Claude model selection, user config schema, message queue semantics, or the `shell: false` security boundary. It only changes the Claude CLI parser and Windows process invocation boundary implicated by #78571.
- **Architecture / source-of-truth check:** The source-of-truth boundaries are `src/agents/cli-output.ts` for CLI backend output normalization and `src/process/windows-command.ts` for Windows command shim resolution/wrapping. No schema/default/migration changes are needed. Related public-contract scan found no related open PRs in `/media/vdc/code/ai/aispace/openclaw-issue-78571-evidence/public-contract-related-prs.json`.

## Real behavior proof

- **Behavior or issue addressed:** A Claude CLI stream-json turn can contain a visible assistant message followed by a blank terminal `result`. Before this patch, the parser normalized that turn to `text: ""`, matching the report's `rawLines=12` plus `queuedFinal:false` / `sentFallback:false` symptom. The patch preserves the assistant text for final dispatch while retaining blank-result metadata for tool-only turns. The Windows process side also resolves bare `claude` to the `.cmd` shim and routes it through the validated `cmd.exe` wrapper instead of direct `.cmd` spawning.
- **Real environment tested:** Local Linux OpenClaw worktree at commit `6290a419090f9563ee5779ebd55bfc541030eb1d`, using production TypeScript modules through `node --import tsx`. The Windows command behavior was verified through the production Windows command helper with `platform: "win32"` and a deterministic Windows root fixture.
- **Exact steps or command run after this patch:**

```bash
source /media/vdc/code/ai/aispace/openclaw-issue-78571-evidence/context.env
cd "$TASK_WORKTREE"
node --import tsx /media/vdc/code/ai/aispace/openclaw-issue-78571-evidence/local-telegram-claude-cli-proof.mjs
```

- **Evidence after fix:**

```json
{
  "issue": 78571,
  "checks": {
    "completeParserKeepsAssistantTextBeforeBlankResult": true,
    "streamingParserKeepsAssistantTextBeforeBlankResult": true,
    "blankToolOnlyResultStillKeepsMetadata": true,
    "nonEmptyTerminalResultStillWins": true,
    "bareClaudeResolvesToWindowsCmdShim": true,
    "windowsCmdShimUsesTrustedCmdWrapper": true,
    "unsafeCmdMetacharactersRejected": true
  },
  "outputs": {
    "complete": {
      "text": "Telegram visible reply.",
      "sessionId": "session-telegram",
      "usage": {
        "input": 10,
        "output": 3
      }
    },
    "streaming": {
      "text": "Telegram visible reply.",
      "sessionId": "session-telegram",
      "usage": {
        "input": 10,
        "output": 3
      }
    },
    "emptyToolOnly": {
      "text": "",
      "sessionId": "session-empty",
      "usage": {
        "input": 18
      }
    },
    "nonEmptyTerminalResult": {
      "text": "final result wins",
      "sessionId": "session-final"
    },
    "resolvedClaude": "claude.cmd",
    "batchInvocation": {
      "command": "C:\\TestWindows\\System32\\cmd.exe",
      "args": [
        "/d",
        "/s",
        "/c",
        "claude.cmd --print \"hello world\""
      ],
      "windowsVerbatimArguments": true
    }
  }
}
```

- **Observed result after fix:** Both complete and streaming parser paths return `text: "Telegram visible reply."` for the issue-shaped Claude stream-json fixture with a blank terminal result. A blank tool-only result still returns metadata with empty text, non-empty terminal result text still takes precedence, bare `claude` resolves to `claude.cmd` on Windows, and unsafe cmd metacharacters are rejected before wrapper construction.
- **What was not tested:** Live Windows 11 Scheduled Task startup, live Telegram network delivery, and a live Claude OAuth session were not run in this Linux environment. The proof covers the local production code paths that normalize Claude CLI output and construct the Windows batch invocation used before process spawn.

## Regression Test Plan

- **Target test file:** `src/agents/cli-output.test.ts`, `src/process/windows-command.test.ts`, `src/process/supervisor/adapters/child.test.ts`, and `src/gateway/test-helpers.agent-results.test.ts`.
- **Scenario locked in:** The regression fixtures cover a Claude assistant text record followed by a blank terminal result for both complete JSONL parsing and the streaming parser, a blank tool-only terminal result that must keep metadata with empty text, a non-empty terminal result that must still win, and a Windows `claude` child spawn that must become `cmd.exe /d /s /c claude.cmd ...` instead of direct `.cmd` spawn.
- **Why this is the smallest reliable guardrail:** These tests lock the two failing invariants at their source boundaries: parser output before message dispatch and command invocation before process spawn. They avoid requiring live Telegram or a Windows Scheduled Task while still exercising the production modules that failed in #78571.

```bash
node scripts/run-vitest.mjs run src/agents/cli-output.test.ts src/process/windows-command.test.ts src/process/supervisor/adapters/child.test.ts src/gateway/test-helpers.agent-results.test.ts
pnpm tsgo:test
pnpm lint
pnpm exec oxfmt --check --threads=1 src/agents/cli-output.ts src/agents/cli-output.test.ts src/process/windows-command.ts src/process/windows-command.test.ts src/process/exec.ts src/process/supervisor/adapters/child.ts src/process/supervisor/adapters/child.test.ts
git diff --check
```

Observed validation results:

```text
related tests: PASS (3 Vitest shards, 7 test files, 62 tests)
typecheck: PASS
lint: PASS
scoped format check for all changed files: PASS
git diff --check: PASS
```

Note: full `pnpm format:check` currently reports unrelated formatting issues outside this patch, so the submitted evidence uses scoped format verification for every changed file plus `git diff --check`.

## Merge risk

- **Risk labels considered:** `merge-risk: message-delivery`, `merge-risk: availability`, `merge-risk: security-boundary`, `merge-risk: compatibility`.
- **Risk explanation:** The message-delivery behavior changes only for Claude stream-json turns where a visible assistant message is followed by an empty terminal result; those now surface the assistant text instead of empty text. The availability/compatibility side changes Windows `.cmd` shim invocation before spawn but keeps `shell: false` and rejects cmd metacharacters before constructing the command line.
- **Why acceptable:** The parser fallback is limited to blank Claude terminal results and keeps non-empty terminal results plus tool-only blank-result metadata unchanged. The Windows wrapper centralizes behavior already used by the exec path, avoids Node's direct batch-spawn failure mode, and preserves the command-injection boundary.
