### PR TITLE
feat(plugins): allow host config to admit non-bundled plugins for trusted tool policies

### DIFF
--- a/src/gateway/server-plugin-bootstrap.ts
+++ b/src/gateway/server-plugin-bootstrap.ts
@@ -42,6 +42,7 @@ type GatewayPluginBootstrapParams = {
   coreGatewayHandlers?: Record<string, GatewayRequestHandler>;
   coreGatewayMethodNames?: readonly string[];
   hostServices?: PluginRegistryParams["hostServices"];
+  trustedToolPolicyAllowlist?: PluginRegistryParams["trustedToolPolicyAllowlist"];
   baseMethods: string[];
   pluginIds?: string[];
   pluginLookUpTable?: PluginLookUpTable;
@@ -117,6 +118,9 @@ export function prepareGatewayPluginLoad(params: GatewayPluginBootstrapParams) {
     }),
     ...(params.hostServices !== undefined && {
       hostServices: params.hostServices,
+    }),
+    ...(params.trustedToolPolicyAllowlist !== undefined && {
+      trustedToolPolicyAllowlist: params.trustedToolPolicyAllowlist,
     }),
     baseMethods: params.baseMethods,
     pluginIds: params.pluginIds,

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -710,6 +710,7 @@ export function loadGatewayPlugins(params: {
   coreGatewayHandlers?: Record<string, GatewayRequestHandler>;
   coreGatewayMethodNames?: readonly string[];
   hostServices?: PluginRegistryParams["hostServices"];
+  trustedToolPolicyAllowlist?: PluginRegistryParams["trustedToolPolicyAllowlist"];
   baseMethods: string[];
   pluginIds?: string[];
   pluginLookUpTable?: PluginLookUpTable;
@@ -805,6 +806,9 @@ export function loadGatewayPlugins(params: {
     }),
     ...(params.hostServices !== undefined && {
       hostServices: params.hostServices,
+    }),
+    ...(params.trustedToolPolicyAllowlist !== undefined && {
+      trustedToolPolicyAllowlist: params.trustedToolPolicyAllowlist,
     }),
     runtimeOptions: {
       allowGatewaySubagentBinding: true,

--- a/src/gateway/server-startup-plugins.ts
+++ b/src/gateway/server-startup-plugins.ts
@@ -225,6 +225,7 @@ export async function loadGatewayStartupPluginRuntime(params: {
   baseMethods: string[];
   coreGatewayMethodNames?: readonly string[];
   hostServices?: PluginRegistryParams["hostServices"];
+  trustedToolPolicyAllowlist?: PluginRegistryParams["trustedToolPolicyAllowlist"];
   startupPluginIds: string[];
   pluginLookUpTable?: ReturnType<typeof loadPluginLookUpTable>;
   preferSetupRuntimeForChannelPlugins?: boolean;
@@ -243,6 +244,9 @@ export async function loadGatewayStartupPluginRuntime(params: {
     baseMethods: params.baseMethods,
     ...(params.hostServices !== undefined && {
       hostServices: params.hostServices,
+    }),
+    ...(params.trustedToolPolicyAllowlist !== undefined && {
+      trustedToolPolicyAllowlist: params.trustedToolPolicyAllowlist,
     }),
     pluginIds: params.startupPluginIds,
     pluginLookUpTable: params.pluginLookUpTable,

--- a/src/plugin-sdk/test-helpers/contracts-testkit.ts
+++ b/src/plugin-sdk/test-helpers/contracts-testkit.ts
@@ -20,7 +20,10 @@ export { registerProviders, requireProvider, uniqueSortedStrings };
 /** Creates a minimal plugin registry fixture with quiet logger defaults. */
 export function createPluginRegistryFixture(
   config = {} as OpenClawConfig,
-  params: { hostServices?: PluginRegistryParams["hostServices"] } = {},
+  params: {
+    hostServices?: PluginRegistryParams["hostServices"];
+    trustedToolPolicyAllowlist?: PluginRegistryParams["trustedToolPolicyAllowlist"];
+  } = {},
 ) {
   return {
     config,
@@ -33,6 +36,9 @@ export function createPluginRegistryFixture(
       },
       runtime: {} as PluginRuntime,
       ...(params.hostServices ? { hostServices: params.hostServices } : {}),
+      ...(params.trustedToolPolicyAllowlist
+        ? { trustedToolPolicyAllowlist: params.trustedToolPolicyAllowlist }
+        : {}),
     }),
   };
 }

--- a/src/plugins/contracts/host-hooks.contract.test.ts
+++ b/src/plugins/contracts/host-hooks.contract.test.ts
@@ -189,6 +189,65 @@ describe("host-hook fixture plugin contract", () => {
     expect(diagnostics[1]?.message).toContain("only bundled plugins can claim reserved command");
   });
 
+  it("admits an external plugin to trusted tool policies when allowlisted by host config", () => {
+    const { config, registry } = createPluginRegistryFixture(undefined, {
+      trustedToolPolicyAllowlist: ["host-trusted-policy"],
+    });
+    registerTestPlugin({
+      registry,
+      config,
+      record: createPluginRecord({
+        id: "host-trusted-policy",
+        name: "Host Trusted Policy",
+        origin: "workspace",
+      }),
+      register(api) {
+        api.registerTrustedToolPolicy({
+          id: "deny-rm-rf",
+          description: "Host-managed policy allowed via trustedToolPolicyAllowlist",
+          evaluate: () => undefined,
+        });
+      },
+    });
+
+    expect(registry.registry.trustedToolPolicies ?? []).toHaveLength(1);
+    expect(registry.registry.trustedToolPolicies?.[0]?.pluginId).toBe("host-trusted-policy");
+    const denyDiagnostics = diagnosticSummaries(registry.registry.diagnostics).filter(
+      (entry) => entry.message?.includes("only bundled plugins can register trusted tool"),
+    );
+    expect(denyDiagnostics).toHaveLength(0);
+  });
+
+  it("still rejects an external plugin whose id is not in the allowlist", () => {
+    const { config, registry } = createPluginRegistryFixture(undefined, {
+      trustedToolPolicyAllowlist: ["some-other-id"],
+    });
+    registerTestPlugin({
+      registry,
+      config,
+      record: createPluginRecord({
+        id: "external-policy",
+        name: "External Policy",
+        origin: "workspace",
+      }),
+      register(api) {
+        api.registerTrustedToolPolicy({
+          id: "deny",
+          description: "Should still be rejected; id not on allowlist",
+          evaluate: () => undefined,
+        });
+      },
+    });
+
+    expect(registry.registry.trustedToolPolicies ?? []).toHaveLength(0);
+    const denyDiagnostics = diagnosticSummaries(registry.registry.diagnostics).filter(
+      (entry) =>
+        entry.pluginId === "external-policy" &&
+        entry.message?.includes("only bundled plugins can register trusted tool"),
+    );
+    expect(denyDiagnostics).toHaveLength(1);
+  });
+
   it("allows the official npm Codex plugin to keep /codex command ownership", () => {
     const { config, registry } = createPluginRegistryFixture();
     const codexRoot = path.join("/tmp", ".openclaw", "npm", "node_modules", "@openclaw", "codex");

--- a/src/plugins/loader.runtime-registry.test.ts
+++ b/src/plugins/loader.runtime-registry.test.ts
@@ -367,6 +367,58 @@ describe("getCompatibleActivePluginRegistry", () => {
     expect(resolving).not.toBe(plain);
   });
 
+  it("separates trusted tool policy allowlist in the loader cache key", () => {
+    const baseOptions = {
+      config: {
+        plugins: {
+          allow: ["demo"],
+        },
+      },
+    };
+
+    const noAllowlist = testing.resolvePluginLoadCacheContext(baseOptions).cacheKey;
+    const withAllowlist = testing.resolvePluginLoadCacheContext({
+      ...baseOptions,
+      trustedToolPolicyAllowlist: ["host-trusted-policy"],
+    }).cacheKey;
+    const withDifferentAllowlist = testing.resolvePluginLoadCacheContext({
+      ...baseOptions,
+      trustedToolPolicyAllowlist: ["other-trusted-policy"],
+    }).cacheKey;
+
+    expect(withAllowlist).not.toBe(noAllowlist);
+    expect(withDifferentAllowlist).not.toBe(withAllowlist);
+  });
+
+  it("treats logically-equivalent trusted tool policy allowlists as the same cache key", () => {
+    const baseOptions = {
+      config: {
+        plugins: {
+          allow: ["demo"],
+        },
+      },
+    };
+
+    // Order, duplicates, and empty-string entries are normalized away so
+    // callers that build the list dynamically don't accidentally invalidate
+    // an otherwise-warm cache entry.
+    const canonical = testing.resolvePluginLoadCacheContext({
+      ...baseOptions,
+      trustedToolPolicyAllowlist: ["a", "b"],
+    }).cacheKey;
+    const reordered = testing.resolvePluginLoadCacheContext({
+      ...baseOptions,
+      trustedToolPolicyAllowlist: ["b", "a"],
+    }).cacheKey;
+    const duplicated = testing.resolvePluginLoadCacheContext({
+      ...baseOptions,
+      trustedToolPolicyAllowlist: ["a", "a", "b", ""],
+    }).cacheKey;
+
+    expect(reordered).toBe(canonical);
+    expect(duplicated).toBe(canonical);
+  });
+
   it("does not embed raw resolved plugin config env values in the loader cache key", () => {
     const { cacheKey } = testing.resolvePluginLoadCacheContext({
       config: {

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -193,6 +193,13 @@ export type PluginLoadOptions = {
   coreGatewayHandlers?: Record<string, GatewayRequestHandler>;
   coreGatewayMethodNames?: readonly string[];
   hostServices?: PluginRegistryParams["hostServices"];
+  /**
+   * Forwarded to {@link PluginRegistryParams.trustedToolPolicyAllowlist}. Plugin
+   * ids listed here may register trusted tool policies even when their
+   * `record.origin` is not `"bundled"`. The bundled-only default applies when
+   * this list is omitted.
+   */
+  trustedToolPolicyAllowlist?: readonly string[];
   runtimeOptions?: CreatePluginRuntimeOptions;
   startupTrace?: {
     detail: (name: string, metrics: ReadonlyArray<readonly [string, number | string]>) => void;
@@ -933,6 +940,7 @@ function buildCacheKey(params: {
   runtimeSubagentMode?: "default" | "explicit" | "gateway-bindable";
   pluginSdkResolution?: PluginSdkResolutionPreference;
   coreGatewayMethodNames?: string[];
+  trustedToolPolicyAllowlist?: readonly string[];
   activate?: boolean;
 }): string {
   const discoveryContext = resolvePluginDiscoveryContext({
@@ -981,6 +989,15 @@ function buildCacheKey(params: {
   const discoveryMode = params.toolDiscovery === true ? "tool-discovery" : "default-discovery";
   const runtimeSubagentMode = params.runtimeSubagentMode ?? "default";
   const gatewayMethodsKey = JSON.stringify(params.coreGatewayMethodNames ?? []);
+  // Allowlist participates in cache identity because it relaxes the
+  // bundled-only admission gate for `registerTrustedToolPolicy`. Two loads
+  // with the same plugin config but different allowlists must produce
+  // different registries; otherwise a registry cached with an allowlisted
+  // external policy could be reused for a later caller that omitted the
+  // allowlist (or vice versa), poisoning the trusted-policy authorization
+  // state. The list is normalized to a sorted, deduped form so logically
+  // equivalent inputs hash identically.
+  const trustedToolPolicyAllowlistKey = JSON.stringify(params.trustedToolPolicyAllowlist ?? []);
   const activationMode = params.activate === false ? "snapshot" : "active";
   return `${roots.workspace ?? ""}::${roots.global ?? ""}::${roots.stock ?? ""}::${JSON.stringify({
     bundledPackage,
@@ -990,7 +1007,24 @@ function buildCacheKey(params: {
     installs,
     loadPaths,
     activationMetadataKey: params.activationMetadataKey ?? "",
-  })}::${scopeKey}::${setupOnlyKey}::${setupOnlyModeKey}::${setupOnlyRequirementKey}::${startupChannelMode}::${bundledArtifactMode}::${rawConfigEnvMode}::${moduleLoadMode}::${discoveryMode}::${runtimeSubagentMode}::${params.pluginSdkResolution ?? "auto"}::${gatewayMethodsKey}::${activationMode}`;
+  })}::${scopeKey}::${setupOnlyKey}::${setupOnlyModeKey}::${setupOnlyRequirementKey}::${startupChannelMode}::${bundledArtifactMode}::${rawConfigEnvMode}::${moduleLoadMode}::${discoveryMode}::${runtimeSubagentMode}::${params.pluginSdkResolution ?? "auto"}::${gatewayMethodsKey}::${trustedToolPolicyAllowlistKey}::${activationMode}`;
+}
+
+/**
+ * Normalize a trusted-tool-policy allowlist for caching/comparison: dedupe,
+ * drop empty ids (the gate rejects empty ids anyway), and sort so that the
+ * order callers happen to pass doesn't influence cache identity. Returns
+ * `undefined` when the input is `undefined` or normalizes to empty so that
+ * call sites can treat "unset" and "set-to-empty" identically.
+ */
+function normalizeTrustedToolPolicyAllowlist(
+  allowlist: readonly string[] | undefined,
+): readonly string[] | undefined {
+  if (allowlist === undefined) {
+    return undefined;
+  }
+  const normalized = Array.from(new Set(allowlist.filter((id) => id.length > 0))).toSorted();
+  return normalized.length > 0 ? normalized : undefined;
 }
 
 function matchesScopedPluginRequest(params: {
@@ -1075,6 +1109,7 @@ function hasExplicitCompatibilityInputs(options: PluginLoadOptions): boolean {
     options.runtimeOptions !== undefined ||
     options.pluginSdkResolution !== undefined ||
     options.coreGatewayHandlers !== undefined ||
+    normalizeTrustedToolPolicyAllowlist(options.trustedToolPolicyAllowlist) !== undefined ||
     options.includeSetupOnlyChannelPlugins === true ||
     options.forceSetupOnlyChannelPlugins === true ||
     options.requireSetupEntryForSetupOnlyChannelPlugins === true ||
@@ -1300,6 +1335,9 @@ function resolvePluginLoadCacheContext(options: PluginLoadOptions = {}) {
   const preferBuiltPluginArtifacts = options.preferBuiltPluginArtifacts === true;
   const runtimeSubagentMode = resolveRuntimeSubagentMode(options.runtimeOptions);
   const coreGatewayMethodNames = resolveCoreGatewayMethodNames(options);
+  const normalizedTrustedToolPolicyAllowlist = normalizeTrustedToolPolicyAllowlist(
+    options.trustedToolPolicyAllowlist,
+  );
   const installRecords = {
     ...(options.installRecords ?? loadInstalledPluginIndexInstallRecordsSync({ env })),
     ...cfg.plugins?.installs,
@@ -1330,6 +1368,9 @@ function resolvePluginLoadCacheContext(options: PluginLoadOptions = {}) {
     runtimeSubagentMode,
     pluginSdkResolution: options.pluginSdkResolution,
     ...(coreGatewayMethodNames !== undefined && { coreGatewayMethodNames }),
+    ...(normalizedTrustedToolPolicyAllowlist !== undefined && {
+      trustedToolPolicyAllowlist: normalizedTrustedToolPolicyAllowlist,
+    }),
     activate: options.activate,
   });
   return {
@@ -1904,6 +1945,9 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       }),
       ...(options.hostServices !== undefined && {
         hostServices: options.hostServices,
+      }),
+      ...(options.trustedToolPolicyAllowlist !== undefined && {
+        trustedToolPolicyAllowlist: options.trustedToolPolicyAllowlist,
       }),
       activateGlobalSideEffects: shouldActivate,
     });
@@ -2844,6 +2888,9 @@ export async function loadOpenClawPluginCliRegistry(
     coreGatewayHandlers: options.coreGatewayHandlers as Record<string, GatewayRequestHandler>,
     ...(options.coreGatewayMethodNames !== undefined && {
       coreGatewayMethodNames: options.coreGatewayMethodNames,
+    }),
+    ...(options.trustedToolPolicyAllowlist !== undefined && {
+      trustedToolPolicyAllowlist: options.trustedToolPolicyAllowlist,
     }),
     activateGlobalSideEffects: false,
   });

--- a/src/plugins/registry-types.ts
+++ b/src/plugins/registry-types.ts
@@ -491,6 +491,20 @@ export type PluginRegistryParams = {
     cron?: import("../cron/service-contract.js").CronServiceContract;
   };
   activateGlobalSideEffects?: boolean;
+  /**
+   * Plugin ids that are explicitly trusted to register tool policies even when
+   * their {@link PluginRecord.origin} is not `"bundled"`.
+   *
+   * This allowlist is the host's way of saying "I have out-of-band trust in
+   * this plugin and accept responsibility for the policies it registers" -
+   * typically a host-managed policy plugin shipped alongside openclaw but
+   * installed via a non-bundled path (for example a sibling
+   * `plugins/` directory loaded at host startup).
+   *
+   * Match is exact on the plugin id at registration time. An empty / missing
+   * list preserves the historical bundled-only behaviour.
+   */
+  trustedToolPolicyAllowlist?: readonly string[];
 };
 
 export type PluginRegistrationMode = import("./types.js").PluginRegistrationMode;

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -2020,11 +2020,20 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
     });
   };
 
+  // O(1) membership test for the host-managed allowlist; computed once so the
+  // gate stays cheap on hot registration paths. Matches on `record.id` only;
+  // empty ids fall through to the bundled-only default by design.
+  const trustedToolPolicyAllowlist = new Set(
+    registryParams.trustedToolPolicyAllowlist ?? [],
+  );
+
   const registerTrustedToolPolicy = (
     record: PluginRecord,
     policy: PluginTrustedToolPolicyRegistration,
   ) => {
-    if (record.origin !== "bundled") {
+    const isAllowlistedExternal =
+      record.id.length > 0 && trustedToolPolicyAllowlist.has(record.id);
+    if (record.origin !== "bundled" && !isAllowlistedExternal) {
       pushDiagnostic({
         level: "error",
         pluginId: record.id,


### PR DESCRIPTION
# Summary
- Unblocks #91258: `registerTrustedToolPolicy` is currently hard-gated to `record.origin === "bundled"`, so hosts that ship a policy plugin via a non-bundled install path cannot register tool policies even when the host operator considers that plugin trustworthy.
- Adds an opt-in `trustedToolPolicyAllowlist?: readonly string[]` to `PluginRegistryParams`, forwarded through `PluginLoadOptions` and the three gateway-side `hostServices` re-declaration points (`server-plugin-bootstrap.ts`, `server-plugins.ts`, `server-startup-plugins.ts`). Plugin ids in the list may register trusted tool policies even when `record.origin !== "bundled"`.
- The bundled-only default applies whenever the list is missing or empty, so the change is fully backward-compatible and every existing assertion on the `"only bundled plugins can register trusted tool policies"` diagnostic remains valid.
- The allowlist participates in the loader cache identity (`buildCacheKey` + `hasExplicitCompatibilityInputs`) so two loads with the same plugin set but different allowlists produce different cached registries — no risk of a previously-admitted external policy being reused for a caller that omitted the allowlist. The list is normalized (deduped, empty ids dropped, sorted) so logically equivalent inputs hash identically and don't churn the cache.
- Intentionally out of scope (separate follow-up PRs): (1) host-config schema entry under `gateway.plugins.*` so the option is reachable from `openclaw.json` rather than only programmatic callers; (2) generalising the same gate to the sibling bundled-only registrations (`registerCodexAppServerExtensionFactory`, `registerAgentToolResultMiddleware`) via a shared helper; (3) info log line when an external plugin is admitted via the allowlist.
- Success looks like: the existing reject path is unchanged for all current callers; a host that explicitly opts in via `loadOpenClawPlugins({ trustedToolPolicyAllowlist: [...] })` (or the gateway equivalents) admits the listed external plugins to `registerTrustedToolPolicy`; cache identity correctly differentiates loads by allowlist.
- Reviewer focus: the gate change in `src/plugins/registry.ts`, the cache-key plumbing in `src/plugins/loader.ts` (`buildCacheKey`, `hasExplicitCompatibilityInputs`, `resolvePluginLoadCacheContext`, `normalizeTrustedToolPolicyAllowlist`), and whether the public-API shape (field name, placement next to `hostServices`, exact-id matching only) matches the direction maintainers want.

# Linked context

Closes #91258

Related: this PR implements the proposal discussed in #91258 directly.

Was this requested by a maintainer or owner? No — opened in coordination with the linked issue. Happy to take a different direction (different config shape, signed-manifest mechanism, decline in favour of bundling, etc.) if the maintainers prefer.

# Real behavior proof (required for external PRs)

- **Behavior or issue addressed:** `registerTrustedToolPolicy` rejects any plugin whose `record.origin !== "bundled"` with the diagnostic `"only bundled plugins can register trusted tool policies"`. This PR adds an opt-in host allowlist that admits listed plugin ids regardless of origin, while preserving the bundled-only default for all current callers.

- **Real environment tested:** Local macOS (Apple Silicon, Node 26.0.0) against the openclaw monorepo checkout at `main`-as-of-this-PR + this branch.

- **Exact steps or commands run after this patch:**
pnpm tsgo pnpm check:test-types pnpm exec vitest run src/plugins/contracts/host-hooks.contract.test.ts -t "trusted tool" pnpm exec vitest run src/plugins/loader.runtime-registry.test.ts -t "trusted tool policy allowlist"


- **Evidence after fix (terminal captures):**

Contract gate (3 tests cover: bundled-only default rejects, allowlisted external admitted, non-listed external still rejected with unchanged diagnostic):
✓ src/plugins/contracts/host-hooks.contract.test.ts ✓ rejects trusted tool policy registration from a non-bundled plugin ✓ admits an external plugin to trusted tool policies when allowlisted by host config ✓ still rejects an external plugin whose id is not in the allowlist
Test Files 1 passed (1) Tests 3 passed


Loader cache identity (2 tests cover: differentiation by allowlist, normalization-equivalence so callers don't churn the cache with reordered/duplicated/empty entries):
✓ src/plugins/loader.runtime-registry.test.ts ✓ separates trusted tool policy allowlist in the loader cache key ✓ treats logically-equivalent trusted tool policy allowlists as the same cache key
Test Files 1 passed (1) Tests 2 passed | 27 skipped (29)


`pnpm tsgo` and `pnpm check:test-types`: both exit 0 (no errors).

- **Observed result after fix:** All targeted tests pass. The reject diagnostic is unchanged in the negative path; the new positive path admits the listed plugin id and stores the policy in the registry as expected.

- **What was not tested:** End-to-end exercise of the new field via `loadOpenClawPlugins(...)` against a real non-bundled plugin checkout. The change is plumbed through the loader and gateway entry points, but I did not stand up a separate host that ships a non-bundled trusted-policy plugin. The contract tests in `host-hooks.contract.test.ts` exercise the registration path directly with the same `PluginRegistryParams` surface the loader forwards.

- **Proof limitations or environment constraints:** `pnpm check` is currently red on the `npm-shrinkwrap guard` on a clean `main` (independent of this change). Per CONTRIBUTING.md ("Do not submit test or CI-config fixes for failures already red on `main`"), I have not touched `npm-shrinkwrap.json` in this PR. The targeted gates above are the meaningful coverage for this change.

- **Before evidence (optional):** Pre-patch, the contract test `"rejects trusted tool policy registration from a non-bundled plugin"` was the only positive coverage; running the same test produces the rejection diagnostic regardless of any caller intent because there is no allowlist surface. Verifiable by running the test on `main`.

# Tests and validation

Commands run (all green):

- `pnpm tsgo`
- `pnpm check:test-types`
- `pnpm exec vitest run src/plugins/contracts/host-hooks.contract.test.ts -t "trusted tool"` — 3 passed
- `pnpm exec vitest run src/plugins/loader.runtime-registry.test.ts -t "trusted tool policy allowlist"` — 2 passed

Regression coverage added:

- `host-hooks.contract.test.ts`: 1 positive ("admits an external plugin to trusted tool policies when allowlisted by host config") + 1 targeted negative ("still rejects an external plugin whose id is not in the allowlist"). The original negative ("rejects trusted tool policy registration from a non-bundled plugin") is unchanged and continues to assert the existing diagnostic.
- `loader.runtime-registry.test.ts`: 1 cache-key differentiation test + 1 normalization-equivalence test (covers reordered/duplicated/empty-id inputs hashing to the same cache key).

What failed before this fix, if known: any caller passing `trustedToolPolicyAllowlist` got it silently ignored because the field did not exist on the API surface. The contract negative `"rejects trusted tool policy registration from a non-bundled plugin"` was effectively the only achievable state for non-bundled callers.

If no test was added, why not: N/A — new tests added at both the contract and loader-cache layers.

# Risk checklist

- **Did user-visible behavior change?** No. The bundled-only default is preserved; existing callers see identical behavior. The new field is opt-in.
- **Did config, environment, or migration behavior change?** No. This PR opens the door at the loader/gateway API level only — no host-config schema entry, no env var, no migration step. A follow-up PR will wire `gateway.plugins.*` config once the API surface settles.
- **Did security, auth, secrets, network, or tool execution behavior change?** Yes — this relaxes a trust gate.
- **Highest-risk area:** `registerTrustedToolPolicy` admits an additional class of plugins when the host opts in.
- **How is that risk mitigated:**
- Opt-in: default-deny preserved when the option is omitted or empty.
- Exact-id match only (no prefixes, no wildcards, no regex). Empty ids fall through to the bundled-only default.
- Diagnostic string in the reject path is unchanged, so existing assertions in `host-hooks.contract.test.ts`, `kitchen-sink-plugin-assertions.test.ts`, `scripts/e2e/lib/kitchen-sink-plugin/assertions.mjs`, and `qa/scenarios/plugins/kitchen-sink-live-openai.md` continue to act as regression coverage.
- Allowlist is included in loader cache identity (`buildCacheKey` + `hasExplicitCompatibilityInputs`), so cached registries cannot be reused across allowlist boundaries — no risk of cached state poisoning between callers with different allowlists.
- Allowlist is normalized before hashing/comparing (deduped, empty ids dropped, sorted), so logically equivalent inputs are treated identically and pathological ordering can't be used to influence cache identity.

# Current review state

- Next action: maintainer review.
- Waiting on: maintainer direction on (a) whether to add a corresponding host-config schema key in a follow-up PR, and (b) whether to generalise the same gate to the sibling bundled-only registrations (`registerCodexAppServerExtensionFactory`, `registerAgentToolResultMiddleware`).
- Bot/reviewer comments addressed: local Codex review flagged a P1 ("New allowlist changes security-sensitive registry contents but is not represented in the plugin loader cache identity"). Addressed by including the normalized allowlist in `buildCacheKey`, flagging it as an explicit compatibility input in `hasExplicitCompatibilityInputs`, threading it through `resolvePluginLoadCacheContext`, and adding the two regression tests above.