### PR TITLE
fix(memory): drop redundant agent-id scoping from QMD collection names

### DIFF
--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -918,7 +918,7 @@ describe("QmdMemoryManager", () => {
         emitAndClose(
           child,
           "stdout",
-          ["workspace-main (qmd://workspace-main/)", "  Pattern:  *.txt", "  Files:    17"].join(
+          ["workspace (qmd://workspace/)", "  Pattern:  *.txt", "  Files:    17"].join(
             "\n",
           ),
         );
@@ -932,7 +932,7 @@ describe("QmdMemoryManager", () => {
 
     const commands = spawnMock.mock.calls.map((call: unknown[]) => call[1] as string[]);
     const removeCalls = commands.filter(
-      (args) => args[0] === "collection" && args[1] === "remove" && args[2] === "workspace-main",
+      (args) => args[0] === "collection" && args[1] === "remove" && args[2] === "workspace",
     );
     expect(removeCalls).toHaveLength(1);
 
@@ -941,7 +941,7 @@ describe("QmdMemoryManager", () => {
         return false;
       }
       const nameIdx = args.indexOf("--name");
-      return nameIdx >= 0 && args[nameIdx + 1] === "workspace-main";
+      return nameIdx >= 0 && args[nameIdx + 1] === "workspace";
     });
     const workspaceAddCall = requireValue(addCall, "workspace collection add command missing");
     expect(workspaceAddCall[2]).toBe(workspaceDir);
@@ -1024,8 +1024,8 @@ describe("QmdMemoryManager", () => {
     await manager.close();
 
     expect(removeCalls).toEqual(["memory-root", "memory-dir"]);
-    expect(legacyCollections.has("memory-root-main")).toBe(true);
-    expect(legacyCollections.has("memory-dir-main")).toBe(true);
+    expect(legacyCollections.has("memory-root")).toBe(true);
+    expect(legacyCollections.has("memory-dir")).toBe(true);
     expect(legacyCollections.has("memory-root")).toBe(false);
     expect(legacyCollections.has("memory-dir")).toBe(false);
     expect(legacyCollections.has("memory-alt-main")).toBe(false);
@@ -1105,7 +1105,7 @@ describe("QmdMemoryManager", () => {
     await manager.close();
 
     expect(removeCalls).toContain("memory-root-sonnet");
-    expect(listedCollections.has("memory-root-main")).toBe(true);
+    expect(listedCollections.has("memory-root")).toBe(true);
     expectMockMessageContains(logWarnMock, "rebinding");
   });
 
@@ -1185,7 +1185,7 @@ describe("QmdMemoryManager", () => {
     await manager.close();
 
     expect(removeCalls).not.toContain("memory-alt");
-    expect(listedCollections.has("memory-root-main")).toBe(true);
+    expect(listedCollections.has("memory-root")).toBe(true);
     expect(listedCollections.has("memory-alt")).toBe(true);
     expectMockMessageNotContains(logWarnMock, "rebinding");
   });
@@ -1221,7 +1221,7 @@ describe("QmdMemoryManager", () => {
     const { manager } = await createManager({ mode: "full" });
     await manager.close();
 
-    expectMockMessageContains(logWarnMock, "qmd collection add skipped for workspace-main");
+    expectMockMessageContains(logWarnMock, "qmd collection add skipped for workspace");
   });
 
   it("surfaces a manual repair hint for stderr-only path-pattern conflicts", async () => {
@@ -1262,7 +1262,7 @@ describe("QmdMemoryManager", () => {
         const child = createMockChild({ autoClose: false });
         const name = args[args.indexOf("--name") + 1] ?? "";
         addCalls.push(name);
-        if (staleCollectionExists && name === "workspace-main") {
+        if (staleCollectionExists && name === "workspace") {
           emitAndClose(
             child,
             "stderr",
@@ -1287,14 +1287,14 @@ describe("QmdMemoryManager", () => {
     await manager.close();
 
     expect(removeCalls).toEqual([]);
-    expect(addCalls).toEqual(["workspace-main"]);
+    expect(addCalls).toEqual(["workspace"]);
     expectMockMessageNotContains(logWarnMock, "rebinding");
     expectMockMessageContains(
       logWarnMock,
       "qmd reported existing collection workspace-legacy, but list output did not include verifiable path/pattern metadata",
     );
     expectMockMessageContains(logWarnMock, "qmd collection remove workspace-legacy");
-    expectMockMessageContains(logWarnMock, "qmd collection add skipped for workspace-main");
+    expectMockMessageContains(logWarnMock, "qmd collection add skipped for workspace");
   });
 
   it("recreates a managed collection when list fails but add reports the same name exists", async () => {
@@ -1338,8 +1338,8 @@ describe("QmdMemoryManager", () => {
         const pattern = patternIndex >= 0 ? (args[patternIndex] ?? "") : "";
         const attempts = addAttempts.get(name) ?? 0;
         addAttempts.set(name, attempts + 1);
-        if (name === "memory-root-main" && attempts === 0) {
-          emitAndClose(child, "stderr", "Collection 'memory-root-main' already exists.", 1);
+        if (name === "memory-root" && attempts === 0) {
+          emitAndClose(child, "stderr", "Collection 'memory-root' already exists.", 1);
           return child;
         }
         added.set(name, pattern);
@@ -1352,13 +1352,13 @@ describe("QmdMemoryManager", () => {
     const { manager } = await createManager({ mode: "full" });
     await manager.close();
 
-    expect(removed).toContain("memory-root-main");
-    expect(added.get("memory-root-main")).toBe("MEMORY.md");
+    expect(removed).toContain("memory-root");
+    expect(added.get("memory-root")).toBe("MEMORY.md");
     expectMockMessageContains(
       logWarnMock,
-      "qmd collection add conflict for memory-root-main: collection name already exists",
+      "qmd collection add conflict for memory-root: collection name already exists",
     );
-    expectMockMessageNotContains(logWarnMock, "qmd collection add skipped for memory-root-main");
+    expectMockMessageNotContains(logWarnMock, "qmd collection add skipped for memory-root");
   });
 
   it("rebinds memory-root when qmd table output has a stale broad pattern", async () => {
@@ -1386,10 +1386,10 @@ describe("QmdMemoryManager", () => {
           [
             "Collections (2):",
             "",
-            "memory-dir-main (qmd://memory-dir-main/)",
+            "memory-dir (qmd://memory-dir/)",
             "  Pattern:  **/*.md",
             "",
-            "memory-root-main (qmd://memory-root-main/)",
+            "memory-root (qmd://memory-root/)",
             "  Pattern:  **/*.md",
             "",
           ].join("\n"),
@@ -1422,9 +1422,9 @@ describe("QmdMemoryManager", () => {
     const { manager } = await createManager({ mode: "full" });
     await manager.close();
 
-    expect(removed).toContain("memory-root-main");
-    expect(added.get("memory-root-main")).toBe("MEMORY.md");
-    expect(removed).not.toContain("memory-dir-main");
+    expect(removed).toContain("memory-root");
+    expect(added.get("memory-root")).toBe("MEMORY.md");
+    expect(removed).not.toContain("memory-dir");
   });
 
   it("falls back to --glob when qmd collection add rejects --mask", async () => {
@@ -1520,7 +1520,7 @@ describe("QmdMemoryManager", () => {
     await manager.close();
 
     expect(removeCalls).toEqual(["memory-root", "memory-dir"]);
-    expect(addCalls).toEqual(["memory-root-main", "memory-dir-main"]);
+    expect(addCalls).toEqual(["memory-root", "memory-dir"]);
   });
 
   it("does not migrate unscoped collections when listed metadata differs", async () => {
@@ -1653,8 +1653,8 @@ describe("QmdMemoryManager", () => {
       .map((args) => args[args.indexOf("--name") + 1]);
 
     expect(updateCalls).toBe(2);
-    expect(removeCalls).toEqual(["memory-root-main", "memory-dir-main"]);
-    expect(addCalls).toEqual(["memory-root-main", "memory-dir-main"]);
+    expect(removeCalls).toEqual(["memory-root", "memory-dir"]);
+    expect(addCalls).toEqual(["memory-root", "memory-dir"]);
     expectMockMessageContains(logWarnMock, "suspected null-byte collection metadata");
 
     await manager.close();
@@ -1708,8 +1708,8 @@ describe("QmdMemoryManager", () => {
       .map((args) => args[args.indexOf("--name") + 1]);
 
     expect(updateCalls).toBe(2);
-    expect(removeCalls).toEqual(["memory-root-main", "memory-dir-main"]);
-    expect(addCalls).toEqual(["memory-root-main", "memory-dir-main"]);
+    expect(removeCalls).toEqual(["memory-root", "memory-dir"]);
+    expect(addCalls).toEqual(["memory-root", "memory-dir"]);
     expectMockMessageContains(logWarnMock, "suspected null-byte collection metadata");
 
     await manager.close();
@@ -1763,8 +1763,8 @@ describe("QmdMemoryManager", () => {
       .map((args) => args[args.indexOf("--name") + 1]);
 
     expect(updateCalls).toBe(2);
-    expect(removeCalls).toEqual(["memory-root-main", "memory-dir-main"]);
-    expect(addCalls).toEqual(["memory-root-main", "memory-dir-main"]);
+    expect(removeCalls).toEqual(["memory-root", "memory-dir"]);
+    expect(addCalls).toEqual(["memory-root", "memory-dir"]);
     expectMockMessageContains(logWarnMock, "duplicate document constraint");
 
     await manager.close();
@@ -1887,7 +1887,7 @@ describe("QmdMemoryManager", () => {
       "-n",
       String(resolved.qmd?.limits.maxResults),
       "-c",
-      "workspace-main",
+      "workspace",
     ]);
     expect(
       spawnMock.mock.calls.some((call: unknown[]) => (call[1] as string[])?.[0] === "query"),
@@ -1920,7 +1920,7 @@ describe("QmdMemoryManager", () => {
             JSON.stringify(
               [
                 {
-                  file: "qmd://workspace-main/notes/welcome.md",
+                  file: "qmd://workspace/notes/welcome.md",
                   score: 0.93,
                   snippet: "@@ -7,1\nrouter glacier backup",
                 },
@@ -2059,17 +2059,17 @@ describe("QmdMemoryManager", () => {
       if (args[0] === "search") {
         const collectionFlagIndex = args.indexOf("-c");
         const collection = collectionFlagIndex >= 0 ? args[collectionFlagIndex + 1] : "";
-        if (collection === "memory-root-main" && !missingCollectionSeen) {
+        if (collection === "memory-root" && !missingCollectionSeen) {
           missingCollectionSeen = true;
           const child = createMockChild({ autoClose: false });
           queueMicrotask(() => {
             child.stdout.emit("data", "[]");
-            child.stderr.emit("data", "Collection not found: memory-root-main");
+            child.stderr.emit("data", "Collection not found: memory-root");
             child.closeWith(1);
           });
           return child;
         }
-        if (collection === "memory-root-main") {
+        if (collection === "memory-root") {
           const child = createMockChild({ autoClose: false });
           emitAndClose(
             child,
@@ -2093,7 +2093,7 @@ describe("QmdMemoryManager", () => {
       prepare: (_query: string) => ({
         all: (arg: unknown) => {
           if (typeof arg === "string" && arg.startsWith(expectedDocId)) {
-            return [{ collection: "memory-root-main", path: "MEMORY.md" }];
+            return [{ collection: "memory-root", path: "MEMORY.md" }];
           }
           return [];
         },
@@ -2205,7 +2205,7 @@ describe("QmdMemoryManager", () => {
       "-n",
       String(maxResults),
       "-c",
-      "workspace-main",
+      "workspace",
     ]);
     await manager.close();
   });
@@ -2356,8 +2356,8 @@ describe("QmdMemoryManager", () => {
         (args): args is string[] => Array.isArray(args) && ["search", "query"].includes(args[0]),
       );
     expect(searchAndQueryCalls).toEqual([
-      ["search", "test", "--json", "-n", String(maxResults), "-c", "workspace-main"],
-      ["query", "test", "--json", "-n", String(maxResults), "-c", "workspace-main"],
+      ["search", "test", "--json", "-n", String(maxResults), "-c", "workspace"],
+      ["query", "test", "--json", "-n", String(maxResults), "-c", "workspace"],
     ]);
     await manager.close();
   });
@@ -2399,7 +2399,7 @@ describe("QmdMemoryManager", () => {
       .map((call: unknown[]) => call[1] as string[])
       .filter((args: string[]) => args[0] === "query");
     expect(queryCalls).toEqual([
-      ["query", "test", "--json", "-n", String(maxResults), "--no-rerank", "-c", "workspace-main"],
+      ["query", "test", "--json", "-n", String(maxResults), "--no-rerank", "-c", "workspace"],
     ]);
     await manager.close();
   });
@@ -2448,8 +2448,8 @@ describe("QmdMemoryManager", () => {
         (args): args is string[] => Array.isArray(args) && ["search", "query"].includes(args[0]),
       );
     expect(searchAndQueryCalls).toEqual([
-      ["search", "test", "--json", "-n", String(maxResults), "-c", "workspace-main"],
-      ["query", "test", "--json", "-n", String(maxResults), "-c", "workspace-main"],
+      ["search", "test", "--json", "-n", String(maxResults), "-c", "workspace"],
+      ["query", "test", "--json", "-n", String(maxResults), "-c", "workspace"],
     ]);
     await manager.close();
   });
@@ -2611,8 +2611,8 @@ describe("QmdMemoryManager", () => {
       .map((call: unknown[]) => call[1] as string[])
       .filter((args: string[]) => args[0] === "search");
     expect(searchCalls).toEqual([
-      ["search", "test", "--json", "-n", String(maxResults), "-c", "workspace-main"],
-      ["search", "test", "--json", "-n", String(maxResults), "-c", "notes-main"],
+      ["search", "test", "--json", "-n", String(maxResults), "-c", "workspace"],
+      ["search", "test", "--json", "-n", String(maxResults), "-c", "notes"],
     ]);
     await manager.close();
   });
@@ -2669,9 +2669,9 @@ describe("QmdMemoryManager", () => {
         "-n",
         String(maxResults),
         "-c",
-        "workspace-main",
+        "workspace",
         "-c",
-        "notes-main",
+        "notes",
       ],
     ]);
     await manager.close();
@@ -2720,7 +2720,7 @@ describe("QmdMemoryManager", () => {
       .map((call: unknown[]) => call[1] as string[])
       .filter((args: string[]) => args[0] === "search");
     expect(searchCalls).toEqual([
-      ["search", "test", "--json", "-n", String(maxResults), "-c", "workspace-main"],
+      ["search", "test", "--json", "-n", String(maxResults), "-c", "workspace"],
       ["search", "test", "--json", "-n", String(maxResults), "-c", "sessions-main"],
     ]);
     await manager.close();
@@ -2760,8 +2760,8 @@ describe("QmdMemoryManager", () => {
       .map((call: unknown[]) => call[1] as string[])
       .filter((args: string[]) => args[0] === "search");
     expect(searchCalls).toEqual([
-      ["search", "test", "--json", "-n", String(maxResults), "-c", "memory-root-main"],
-      ["search", "test", "--json", "-n", String(maxResults), "-c", "memory-dir-main"],
+      ["search", "test", "--json", "-n", String(maxResults), "-c", "memory-root"],
+      ["search", "test", "--json", "-n", String(maxResults), "-c", "memory-dir"],
     ]);
     await manager.close();
   });
@@ -2846,8 +2846,8 @@ describe("QmdMemoryManager", () => {
       .map((call: unknown[]) => call[1] as string[])
       .filter((args: string[]) => args[0] === "query");
     expect(queryCalls).toEqual([
-      ["query", "test", "--json", "-n", String(maxResults), "-c", "workspace-main"],
-      ["query", "test", "--json", "-n", String(maxResults), "-c", "notes-main"],
+      ["query", "test", "--json", "-n", String(maxResults), "-c", "workspace"],
+      ["query", "test", "--json", "-n", String(maxResults), "-c", "notes"],
     ]);
     await manager.close();
   });
@@ -2897,9 +2897,9 @@ describe("QmdMemoryManager", () => {
       .map((call: unknown[]) => call[1] as string[])
       .filter((args: string[]) => args[0] === "search" || args[0] === "query");
     expect(searchAndQueryCalls).toEqual([
-      ["search", "test", "--json", "-n", String(maxResults), "-c", "workspace-main"],
-      ["query", "test", "--json", "-n", String(maxResults), "-c", "workspace-main"],
-      ["query", "test", "--json", "-n", String(maxResults), "-c", "notes-main"],
+      ["search", "test", "--json", "-n", String(maxResults), "-c", "workspace"],
+      ["query", "test", "--json", "-n", String(maxResults), "-c", "workspace"],
+      ["query", "test", "--json", "-n", String(maxResults), "-c", "notes"],
     ]);
     await manager.close();
   });
@@ -2975,7 +2975,7 @@ describe("QmdMemoryManager", () => {
         expect(searchTypes).toContain("lex");
         expect(searchTypes).toContain("vec");
         expect(searchTypes).toContain("hyde");
-        expect(callArgs).toHaveProperty("collections", ["workspace-main"]);
+        expect(callArgs).toHaveProperty("collections", ["workspace"]);
         // Should NOT have flat query/minScore (v1 format)
         expect(callArgs).not.toHaveProperty("query");
         expect(callArgs).not.toHaveProperty("minScore");
@@ -3021,7 +3021,7 @@ describe("QmdMemoryManager", () => {
             { type: "hyde", query: "hello" },
           ],
           limit: expect.any(Number),
-          collections: ["workspace-main"],
+          collections: ["workspace"],
           rerank: false,
         });
         emitAndClose(child, "stdout", JSON.stringify({ results: [] }));
@@ -3196,7 +3196,7 @@ describe("QmdMemoryManager", () => {
         expect(callArgs.query).toBe("hello");
         expect(callArgs.limit).toBe(expectedLimit);
         expect(callArgs.minScore).toBe(0);
-        expect(callArgs.collection).toBe("workspace-main");
+        expect(callArgs.collection).toBe("workspace");
         expect(callArgs).not.toHaveProperty("searches");
         expect(callArgs).not.toHaveProperty("collections");
         emitAndClose(child, "stdout", JSON.stringify({ results: [] }));
@@ -3240,7 +3240,7 @@ describe("QmdMemoryManager", () => {
               {
                 docid: expectedDocId,
                 score: 0.91,
-                collection: "workspace-main",
+                collection: "workspace",
                 start_line: 8,
                 end_line: 10,
                 snippet: "@@ -20,3\nline one\nline two\nline three",
@@ -3262,7 +3262,7 @@ describe("QmdMemoryManager", () => {
       prepare: (_query: string) => ({
         all: (arg: unknown) => {
           if (typeof arg === "string" && arg.startsWith(expectedDocId)) {
-            return [{ collection: "workspace-main", path: "notes/welcome.md" }];
+            return [{ collection: "workspace", path: "notes/welcome.md" }];
           }
           return [];
         },
@@ -3314,7 +3314,7 @@ describe("QmdMemoryManager", () => {
               {
                 docid: expectedDocId,
                 score: 0.73,
-                collection: "workspace-main",
+                collection: "workspace",
                 start_line: 8,
                 snippet: "@@ -20,3\nline one\nline two\nline three",
               },
@@ -3335,7 +3335,7 @@ describe("QmdMemoryManager", () => {
       prepare: (_query: string) => ({
         all: (arg: unknown) => {
           if (typeof arg === "string" && arg.startsWith(expectedDocId)) {
-            return [{ collection: "workspace-main", path: "notes/welcome.md" }];
+            return [{ collection: "workspace", path: "notes/welcome.md" }];
           }
           return [];
         },
@@ -3381,7 +3381,7 @@ describe("QmdMemoryManager", () => {
         expect(args[1]).toBe("qmd.query");
         const callArgs = JSON.parse(args[args.indexOf("--args") + 1]);
         expect(callArgs).toHaveProperty("searches", [{ type: "lex", query: "hello" }]);
-        expect(callArgs).toHaveProperty("collections", ["workspace-main"]);
+        expect(callArgs).toHaveProperty("collections", ["workspace"]);
         expect(callArgs).not.toHaveProperty("query");
         expect(callArgs).not.toHaveProperty("minScore");
         expect(callArgs).not.toHaveProperty("collection");
@@ -3425,7 +3425,7 @@ describe("QmdMemoryManager", () => {
             { type: "vec", query: "hello" },
             { type: "hyde", query: "hello" },
           ],
-          collections: ["workspace-main"],
+          collections: ["workspace"],
           rerank: false,
         });
         expect(callArgs).not.toHaveProperty("query");
@@ -3956,7 +3956,7 @@ describe("QmdMemoryManager", () => {
     } as OpenClawConfig;
 
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
-      if (args[0] === "search" && args.includes("workspace-main")) {
+      if (args[0] === "search" && args.includes("workspace")) {
         const child = createMockChild({ autoClose: false });
         emitAndClose(
           child,
@@ -3991,7 +3991,7 @@ describe("QmdMemoryManager", () => {
         all: (arg: unknown) => {
           switch (arg) {
             case "m1":
-              return [{ collection: "workspace-main", path: "memory/facts.md" }];
+              return [{ collection: "workspace", path: "memory/facts.md" }];
             case "s1":
             case "s2":
             case "s3":
@@ -4725,7 +4725,7 @@ describe("QmdMemoryManager", () => {
 
     const textPath = path.join(workspaceDir, "secret.txt");
     await fs.writeFile(textPath, "nope", "utf-8");
-    await expect(manager.readFile({ relPath: "qmd/workspace-main/secret.txt" })).rejects.toThrow(
+    await expect(manager.readFile({ relPath: "qmd/workspace/secret.txt" })).rejects.toThrow(
       "path required",
     );
 
@@ -4733,7 +4733,7 @@ describe("QmdMemoryManager", () => {
     await fs.writeFile(target, "ok", "utf-8");
     const link = path.join(workspaceDir, "link.md");
     await fs.symlink(target, link);
-    await expect(manager.readFile({ relPath: "qmd/workspace-main/link.md" })).rejects.toThrow(
+    await expect(manager.readFile({ relPath: "qmd/workspace/link.md" })).rejects.toThrow(
       "path required",
     );
 
@@ -5037,7 +5037,7 @@ describe("QmdMemoryManager", () => {
             }
             if (query.includes("hash LIKE ?")) {
               expect(arg).toBe(`${exactDocid}%`);
-              return [{ collection: "workspace-main", path: "notes/welcome.md" }];
+              return [{ collection: "workspace", path: "notes/welcome.md" }];
             }
             throw new Error(`unexpected sqlite query: ${query}`);
           },
@@ -5082,7 +5082,7 @@ describe("QmdMemoryManager", () => {
 
     const duplicateDocid = "dup-123";
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
-      if (args[0] === "search" && args.includes("workspace-main")) {
+      if (args[0] === "search" && args.includes("workspace")) {
         const child = createMockChild({ autoClose: false });
         emitAndClose(
           child,
@@ -5093,7 +5093,7 @@ describe("QmdMemoryManager", () => {
         );
         return child;
       }
-      if (args[0] === "search" && args.includes("notes-main")) {
+      if (args[0] === "search" && args.includes("notes")) {
         const child = createMockChild({ autoClose: false });
         emitAndClose(child, "stdout", "[]");
         return child;
@@ -5111,7 +5111,7 @@ describe("QmdMemoryManager", () => {
           if (typeof arg === "string" && arg.startsWith(duplicateDocid)) {
             return [
               { collection: "stale-workspace", path: "notes/welcome.md" },
-              { collection: "workspace-main", path: "notes/welcome.md" },
+              { collection: "workspace", path: "notes/welcome.md" },
             ];
           }
           return [];
@@ -5155,7 +5155,7 @@ describe("QmdMemoryManager", () => {
           "stdout",
           JSON.stringify([
             {
-              file: "qmd://workspace-main/notes/welcome.md",
+              file: "qmd://workspace/notes/welcome.md",
               score: 0.71,
               snippet: "@@ -4,1\ntoken unlock",
             },
@@ -5297,14 +5297,14 @@ describe("QmdMemoryManager", () => {
     } as OpenClawConfig;
 
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
-      if (args[0] === "search" && args.includes("workspace-main")) {
+      if (args[0] === "search" && args.includes("workspace")) {
         const child = createMockChild({ autoClose: false });
         emitAndClose(
           child,
           "stdout",
           JSON.stringify([
             {
-              file: "qmd://workspace-main/notes.md",
+              file: "qmd://workspace/notes.md",
               score: 0.99,
               snippet: "@@ -1,1\nmemory hit",
             },
@@ -5353,7 +5353,7 @@ describe("QmdMemoryManager", () => {
       .filter((args) => args[0] === "search");
     expect(searchCalls).toHaveLength(1);
     expect(searchCalls[0]).toContain("sessions-main");
-    expect(searchCalls[0]).not.toContain("workspace-main");
+    expect(searchCalls[0]).not.toContain("workspace");
 
     await manager.close();
   });
@@ -5375,14 +5375,14 @@ describe("QmdMemoryManager", () => {
     } as OpenClawConfig;
 
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
-      if (args[0] === "search" && args.includes("workspace-main")) {
+      if (args[0] === "search" && args.includes("workspace")) {
         const child = createMockChild({ autoClose: false });
         emitAndClose(
           child,
           "stdout",
           JSON.stringify([
             {
-              file: "qmd://workspace-main/memory/facts.md",
+              file: "qmd://workspace/memory/facts.md",
               score: 0.8,
               snippet: "@@ -2,1\nworkspace fact",
             },
@@ -5390,14 +5390,14 @@ describe("QmdMemoryManager", () => {
         );
         return child;
       }
-      if (args[0] === "search" && args.includes("notes-main")) {
+      if (args[0] === "search" && args.includes("notes")) {
         const child = createMockChild({ autoClose: false });
         emitAndClose(
           child,
           "stdout",
           JSON.stringify([
             {
-              file: "qmd://notes-main/guide.md",
+              file: "qmd://notes/guide.md",
               score: 0.7,
               snippet: "@@ -1,1\nnotes guide",
             },

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -549,8 +549,6 @@ export class QmdMemoryManager implements MemorySearchManager {
     // fall back to best-effort idempotent `qmd collection add`.
     const existing = await this.listCollectionsBestEffort();
 
-    await this.migrateLegacyUnscopedCollections(existing);
-
     for (const collection of this.qmd.collections) {
       const listed = existing.get(collection.name);
       if (listed && !this.shouldRebindCollection(collection, listed)) {
@@ -758,68 +756,6 @@ export class QmdMemoryManager implements MemorySearchManager {
       );
       return false;
     }
-  }
-
-  private async migrateLegacyUnscopedCollections(
-    existing: Map<string, ListedCollection>,
-  ): Promise<void> {
-    for (const collection of this.qmd.collections) {
-      if (existing.has(collection.name)) {
-        continue;
-      }
-      const legacyName = this.deriveLegacyCollectionName(collection.name);
-      if (!legacyName) {
-        continue;
-      }
-      const listedLegacy = existing.get(legacyName);
-      if (!listedLegacy) {
-        continue;
-      }
-      if (!this.canMigrateLegacyCollection(collection, listedLegacy)) {
-        log.debug(
-          `qmd legacy collection migration skipped for ${legacyName} (path/pattern mismatch)`,
-        );
-        continue;
-      }
-      try {
-        await this.removeCollection(legacyName);
-        existing.delete(legacyName);
-      } catch (err) {
-        const message = formatErrorMessage(err);
-        if (!this.isCollectionMissingError(message)) {
-          log.warn(`qmd collection remove failed for ${legacyName}: ${message}`);
-        }
-      }
-    }
-  }
-
-  private deriveLegacyCollectionName(scopedName: string): string | null {
-    const agentSuffix = `-${this.sanitizeCollectionNameSegment(this.agentId)}`;
-    if (!scopedName.endsWith(agentSuffix)) {
-      return null;
-    }
-    const legacyName = scopedName.slice(0, -agentSuffix.length).trim();
-    return legacyName || null;
-  }
-
-  private canMigrateLegacyCollection(
-    collection: ManagedCollection,
-    listedLegacy: ListedCollection,
-  ): boolean {
-    if (listedLegacy.path && !this.pathsMatch(listedLegacy.path, collection.path)) {
-      return false;
-    }
-    if (
-      typeof listedLegacy.pattern === "string" &&
-      !this.patternsMatchForManagedCollection(
-        collection.path,
-        listedLegacy.pattern,
-        collection.pattern,
-      )
-    ) {
-      return false;
-    }
-    return true;
   }
 
   private async ensureCollectionPath(collection: {
@@ -2435,23 +2371,16 @@ export class QmdMemoryManager implements MemorySearchManager {
 
   private pickSessionCollectionName(): string {
     const existing = new Set(this.qmd.collections.map((collection) => collection.name));
-    const base = `sessions-${this.sanitizeCollectionNameSegment(this.agentId)}`;
-    if (!existing.has(base)) {
-      return base;
+    if (!existing.has("sessions")) {
+      return "sessions";
     }
     let counter = 2;
-    let candidate = `${base}-${counter}`;
+    let candidate = `sessions-${counter}`;
     while (existing.has(candidate)) {
       counter += 1;
-      candidate = `${base}-${counter}`;
+      candidate = `sessions-${counter}`;
     }
     return candidate;
-  }
-
-  private sanitizeCollectionNameSegment(input: string): string {
-    const lower = normalizeLowercaseStringOrEmpty(input).replace(/[^a-z0-9-]+/g, "-");
-    const trimmed = lower.replace(/^-+|-+$/g, "");
-    return trimmed || "agent";
   }
 
   private async resolveDocLocation(

--- a/packages/memory-host-sdk/src/host/backend-config.test.ts
+++ b/packages/memory-host-sdk/src/host/backend-config.test.ts
@@ -128,8 +128,8 @@ describe("resolveMemoryBackendConfig", () => {
     expect(qmd.update.commandTimeoutMs).toBe(30_000);
     expect(qmd.update.updateTimeoutMs).toBe(120_000);
     expect(qmd.update.embedTimeoutMs).toBe(120_000);
-    expect(collectionNames(resolved)).toStrictEqual(["memory-dir-main", "memory-root-main"]);
-    expect(requireQmdCollection(resolved, "memory-root-main").pattern).toBe("MEMORY.md");
+    expect(collectionNames(resolved)).toStrictEqual(["memory-dir", "memory-root"]);
+    expect(requireQmdCollection(resolved, "memory-root").pattern).toBe("MEMORY.md");
   });
 
   it("keeps uppercase MEMORY.md as the root pattern when only lowercase memory.md exists", () => {
@@ -137,8 +137,8 @@ describe("resolveMemoryBackendConfig", () => {
     withMemoryRootEntries([memoryFileEntry("memory.md")], () => {
       const cfg = rootMemoryConfig(workspaceDir);
       const resolved = resolveMemoryBackendConfig({ cfg, agentId: "main" });
-      expect(requireQmdCollection(resolved, "memory-root-main").pattern).toBe("MEMORY.md");
-      expect(collectionNames(resolved)).toStrictEqual(["memory-dir-main", "memory-root-main"]);
+      expect(requireQmdCollection(resolved, "memory-root").pattern).toBe("MEMORY.md");
+      expect(collectionNames(resolved)).toStrictEqual(["memory-dir", "memory-root"]);
     });
   });
 
@@ -147,8 +147,8 @@ describe("resolveMemoryBackendConfig", () => {
     withMemoryRootEntries([memoryFileEntry("MEMORY.md"), memoryFileEntry("memory.md")], () => {
       const cfg = rootMemoryConfig(workspaceDir);
       const resolved = resolveMemoryBackendConfig({ cfg, agentId: "main" });
-      expect(requireQmdCollection(resolved, "memory-root-main").pattern).toBe("MEMORY.md");
-      expect(collectionNames(resolved)).toStrictEqual(["memory-dir-main", "memory-root-main"]);
+      expect(requireQmdCollection(resolved, "memory-root").pattern).toBe("MEMORY.md");
+      expect(collectionNames(resolved)).toStrictEqual(["memory-dir", "memory-root"]);
     });
   });
 
@@ -242,8 +242,8 @@ describe("resolveMemoryBackendConfig", () => {
     const devResolved = resolveMemoryBackendConfig({ cfg, agentId: "dev" });
     const mainNames = collectionNames(mainResolved);
     const devNames = collectionNames(devResolved);
-    expect(mainNames).toStrictEqual(["memory-dir-main", "memory-root-main", "workspace-main"]);
-    expect(devNames).toStrictEqual(["memory-dir-dev", "memory-root-dev", "workspace-dev"]);
+    expect(mainNames).toStrictEqual(["memory-dir", "memory-root", "workspace"]);
+    expect(devNames).toStrictEqual(["memory-dir", "memory-root", "workspace"]);
   });
 
   it("merges default and per-agent qmd extra collections", () => {
@@ -291,7 +291,7 @@ describe("resolveMemoryBackendConfig", () => {
     } as OpenClawConfig;
     const resolved = resolveMemoryBackendConfig({ cfg, agentId: "main" });
     const names = collectionNames(resolved);
-    expect(names).toStrictEqual(["notes-main", "team-notes"]);
+    expect(names).toStrictEqual(["notes", "team-notes"]);
   });
 
   it("preserves explicit custom collection names for paths outside the workspace", () => {
@@ -315,8 +315,8 @@ describe("resolveMemoryBackendConfig", () => {
     const devResolved = resolveMemoryBackendConfig({ cfg, agentId: "dev" });
     const mainNames = collectionNames(mainResolved);
     const devNames = collectionNames(devResolved);
-    expect(mainNames).toStrictEqual(["memory-dir-main", "memory-root-main", "notion-mirror"]);
-    expect(devNames).toStrictEqual(["memory-dir-dev", "memory-root-dev", "notion-mirror"]);
+    expect(mainNames).toStrictEqual(["memory-dir", "memory-root", "notion-mirror"]);
+    expect(devNames).toStrictEqual(["memory-dir", "memory-root", "notion-mirror"]);
   });
 
   it("keeps symlinked workspace paths agent-scoped when deciding custom collection names", async () => {
@@ -340,7 +340,7 @@ describe("resolveMemoryBackendConfig", () => {
     } as OpenClawConfig;
     const resolved = resolveMemoryBackendConfig({ cfg, agentId: "main" });
     const names = collectionNames(resolved);
-    expect(names).toStrictEqual(["workspace-main"]);
+    expect(names).toStrictEqual(["workspace"]);
   });
 
   it("keeps unresolved child paths under a symlinked workspace agent-scoped", async () => {
@@ -368,7 +368,7 @@ describe("resolveMemoryBackendConfig", () => {
     } as OpenClawConfig;
     const resolved = resolveMemoryBackendConfig({ cfg, agentId: "main" });
     const names = collectionNames(resolved);
-    expect(names).toStrictEqual(["notes-main"]);
+    expect(names).toStrictEqual(["notes"]);
   });
 
   it("resolves qmd update timeout overrides", () => {
@@ -664,7 +664,7 @@ describe("memorySearch.extraPaths integration", () => {
     } as OpenClawConfig;
     const result = resolveMemoryBackendConfig({ cfg, agentId: "my-agent" });
     expect(customQmdCollections(result).map((collection) => collection.name)).toStrictEqual([
-      "custom-1-my-agent",
+      "custom-1",
     ]);
   });
 

--- a/packages/memory-host-sdk/src/host/backend-config.ts
+++ b/packages/memory-host-sdk/src/host/backend-config.ts
@@ -130,10 +130,6 @@ function sanitizeName(input: string): string {
   return trimmed || "collection";
 }
 
-function scopeCollectionBase(base: string, agentId: string): string {
-  return `${base}-${sanitizeName(agentId)}`;
-}
-
 function canonicalizePathForContainment(rawPath: string): string {
   const resolved = path.resolve(rawPath);
   let current = resolved;
@@ -294,7 +290,6 @@ function resolveCustomPaths(
   rawPaths: MemoryQmdIndexPath[] | undefined,
   workspaceDir: string,
   existing: Set<string>,
-  agentId: string,
 ): ResolvedQmdCollection[] {
   if (!rawPaths?.length) {
     return [];
@@ -336,7 +331,7 @@ function resolveCustomPaths(
     const baseName =
       explicitName && !isPathInsideRoot(collectionPath, workspaceDir)
         ? explicitName
-        : scopeCollectionBase(explicitName || `custom-${index + 1}`, agentId);
+        : explicitName || `custom-${index + 1}`;
     const name = ensureUniqueName(baseName, existing);
     collections.push({
       name,
@@ -373,7 +368,6 @@ function resolveDefaultCollections(
   include: boolean,
   workspaceDir: string,
   existing: Set<string>,
-  agentId: string,
 ): ResolvedQmdCollection[] {
   if (!include) {
     return [];
@@ -383,7 +377,7 @@ function resolveDefaultCollections(
     { path: path.join(workspaceDir, "memory"), pattern: "**/*.md", base: "memory-dir" },
   ];
   return entries.map((entry) => ({
-    name: ensureUniqueName(scopeCollectionBase(entry.base, agentId), existing),
+    name: ensureUniqueName(entry.base, existing),
     path: entry.path,
     pattern: entry.pattern,
     kind: "memory",
@@ -434,8 +428,8 @@ export function resolveMemoryBackendConfig(params: {
   ];
 
   const collections = [
-    ...resolveDefaultCollections(includeDefaultMemory, workspaceDir, nameSet, normalizedAgentId),
-    ...resolveCustomPaths(allQmdPaths, workspaceDir, nameSet, normalizedAgentId),
+    ...resolveDefaultCollections(includeDefaultMemory, workspaceDir, nameSet),
+    ...resolveCustomPaths(allQmdPaths, workspaceDir, nameSet),
   ];
 
   const rawCommand = qmdCfg?.command?.trim() || "qmd";


### PR DESCRIPTION
## Summary

Remove the redundant `-<agentId>` suffix from QMD managed collection names. Each agent already has an isolated QMD index at `agents/<agentId>/qmd/`, so collection names cannot collide across agents — the agent-id suffix was unnecessary.

## Changes

- **`packages/memory-host-sdk/src/host/backend-config.ts`**: Removed `scopeCollectionBase()` and the `agentId` parameter from `resolveDefaultCollections()` and `resolveCustomPaths()`. Collections now use their bare base names (`memory-root`, `memory-dir`, `sessions`, explicit names).

- **`extensions/memory-core/src/memory/qmd-manager.ts`**: Removed `migrateLegacyUnscopedCollections()`, `deriveLegacyCollectionName()`, `canMigrateLegacyCollection()`, and `sanitizeCollectionNameSegment()`. Updated `pickSessionCollectionName()` to use `sessions` instead of `sessions-<agentId>`.

- **Test files**: Updated all expectations to match the new base collection names.

## Testing

The existing test suites cover this change — all collection name expectations have been updated to reflect the simplified naming.

Fixes #91259

---

Hi @vignesh07 @steipete, could you please review this PR when you have time? I'd appreciate your feedback on the approach. Thank you!