### PR TITLE
fix(memory-core): skip session archive artifacts during dreaming corpus collection (fixes #90313)

### DIFF
--- a/extensions/memory-core/src/dreaming-phases.ts
+++ b/extensions/memory-core/src/dreaming-phases.ts
@@ -5,6 +5,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import {
   buildSessionEntry,
+  isSessionArchiveArtifactName,
   listSessionFilesForAgent,
   loadSessionTranscriptClassificationForAgent,
   normalizeSessionTranscriptPathForComparison,
@@ -857,6 +858,13 @@ async function collectSessionIngestionBatches(params: {
           };
     for (const absolutePath of files) {
       if (isCheckpointSessionTranscriptPath(absolutePath)) {
+        continue;
+      }
+      // Defect 1 (#90313): listSessionFilesForAgent uses isUsageCountedSessionTranscriptFileName,
+      // which includes archived (`.deleted.*` / `.reset.*`) transcript copies. For dreaming
+      // corpus ingestion those archives should be skipped — the primary transcript already
+      // covers the same conversation and re-ingesting the archive double-counts it.
+      if (isSessionArchiveArtifactName(path.basename(absolutePath))) {
         continue;
       }
       const normalizedPath = normalizeSessionTranscriptPathForComparison(absolutePath);


### PR DESCRIPTION
## Summary

Fix Defect 1 of #90313: dreaming session-corpus ingestion no longer re-ingests archived (`.deleted.*` / `.reset.*`) transcript copies. When a session is rotated or deleted, `listSessionFilesForAgent` previously included archive variants — causing the same conversation to be double-counted in the dreaming corpus and drowning out real user content.

**Changes**: 1 file, +8 lines
- `extensions/memory-core/src/dreaming-phases.ts` — skip session archive artifacts during dreaming corpus file collection

Addresses Defect 1 of #90313 (Defect 2 — cron parentage classification — remains tracked in the issue)

## Root Cause

**Invariant violated**: Dreaming corpus ingestion should only include primary session transcripts. Each conversation should contribute to the corpus once. Archive variants (`.jsonl.deleted.*`, `.jsonl.reset.*`) are rotated copies of the same conversation — re-ingesting them double-counts the content.

**Code path**: `dreaming-phases.ts:collectSessionIngestionBatches` → `listSessionFilesForAgent(agentId)` (`session-files.ts:303`) → filters files with `isUsageCountedSessionTranscriptFileName(name)` (`session-files.ts:310`). That predicate is correct for usage/billing telemetry (you always want to count messages even after rotation), but is wrong for dreaming corpus ingestion. The fix adds an archive artifact check in the dreaming-phases file collection loop, using the already-available `isSessionArchiveArtifactName` helper (exported from `engine-qmd`).

**Sibling Surface Audit**:
- `memory/manager-sync-ops.ts:1188` — also calls `listSessionFilesForAgent`, but for **memory_search indexing** where archive content MUST remain searchable. Not modified.
- `memory/qmd-manager.ts:2383` — same, for memory_search. Not modified.
- `session-files.ts:shouldSkipTranscriptFileForDreaming` — already skips non-usage-counted archives but deliberately keeps usage-counted ones for memory_search. The `buildSessionEntry` caller already classifies archives correctly; the leak is in `listSessionFilesForAgent` itself.

**Scope**:
- **In scope**: Skip session archive artifact files during dreaming corpus file collection (Defect 1)
- **Out of scope**: Defect 2 (cron classification parentage following) — requires deeper session-store schema changes and is tracked separately in #90313

**Why this is a root-cause fix**: The fix targets the exact predicate mismatch — `isUsageCountedSessionTranscriptFileName` includes archives, the dreaming corpus should only use primary transcripts. Adding the archive filter at the file collection point prevents the double-counting at its source.

## Verification

```bash
pnpm build && pnpm test extensions/memory-core/src/dreaming-phases.test.ts packages/memory-host-sdk/src/host/session-files.test.ts
```

- `pnpm build`: ✅ passed
- `extensions/memory-core/src/dreaming-phases.test.ts`: ✅ 45 tests passed
- `packages/memory-host-sdk/src/host/session-files.test.ts`: ✅ 12 tests passed
- Total: **2 files, 57 tests passed**
- `pnpm exec oxlint` on changed file: ✅ clean

## Real Behavior Proof

**Behavior or issue addressed**: Dreaming session-corpus file collection in `collectSessionIngestionBatches` now skips session archive artifacts (`.jsonl.deleted.*` / `.jsonl.reset.*`) during agent file listing. Previously, `listSessionFilesForAgent` returned both primary and archived transcripts because `isUsageCountedSessionTranscriptFileName` includes archive variants (intentionally — they are needed for usage/billing and memory_search). The dreaming corpus ingestion loop now adds an `isSessionArchiveArtifactName` guard alongside the existing `isCheckpointSessionTranscriptPath` guard, so only primary session transcripts feed the corpus.

**Real environment tested**: Linux x86_64, Node v22.22.0, pnpm 10.25.0, OpenClaw main @ `2a21de63223963d4a36792a75d69df958bc4e2a5`

**Exact steps or command run after this patch**:
```bash
pnpm build
pnpm test extensions/memory-core/src/dreaming-phases.test.ts packages/memory-host-sdk/src/host/session-files.test.ts
pnpm exec oxlint extensions/memory-core/src/dreaming-phases.ts
```

**Evidence after fix**:
1. **57 tests pass** across 2 test files (CI-level `pnpm test`)
2. **dreaming-phases.test.ts**: 45 tests pass — includes existing corpus ingestion tests that continue to work correctly with the new archive filter
3. **session-files.test.ts**: 12 tests pass — session file listing and archive classification unchanged; the fix is at the calling site, not in the shared utility
4. **Source evidence**: `isSessionArchiveArtifactName` is the same predicate used by `shouldSkipTranscriptFileForDreaming` in `session-files.ts:82` and `buildSessionEntry` in `session-files.ts:288` — the fix follows the same pattern
5. **oxlint**: clean on changed file

```json
{
  "behaviorAddressed": "Dreaming corpus file collection skips session archive artifacts, preventing double-counting of rotated/reset session transcripts",
  "assertions": [
    { "path": "extensions/memory-core/src/dreaming-phases.test.ts", "behavior": "45 tests verify dreaming phase behaviors including session file collection, corpus ingestion, and file filtering" },
    { "path": "packages/memory-host-sdk/src/host/session-files.test.ts", "behavior": "12 tests verify session file listing, archive classification, and usage-counted file name predicates" }
  ],
  "observedResult": "pnpm test exited 0 for both test files (57 tests total)",
  "testSummary": "2 test files, 57 tests passed"
}
```

**Observed result after fix**: `collectSessionIngestionBatches` now skips files matching `isSessionArchiveArtifactName` (`.jsonl.deleted.*`, `.jsonl.reset.*`) alongside existing checkpoint transcript checks. Primary transcripts continue to be collected normally. The `listSessionFilesForAgent` function and its `isUsageCountedSessionTranscriptFileName` predicate are unchanged — the archive filter is applied only at the dreaming corpus ingestion call site.

**What was not tested**: End-to-end verification with a real workspace that has a large number of archived/reset session transcripts (requires a production-like session store with many rotations). The archive file filtering logic follows the same predicate patterns already tested in `session-files.test.ts`, and the existing dreaming-phases tests confirm the ingestion pipeline continues to work correctly.

## Review Findings Addressed

No automated review findings yet — this is the initial PR.

## Regression Test Plan

```bash
pnpm test extensions/memory-core/src/dreaming-phases.test.ts
pnpm test packages/memory-host-sdk/src/host/session-files.test.ts
```

To verify in a live environment with actual session archives:
```bash
# Before fix: count archived files in dreaming corpus
grep -cE "\.jsonl\.(deleted|reset)" memory/.dreams/session-corpus/*.txt

# After fix: archived files should no longer appear in corpus
grep -cE "\.jsonl\.(deleted|reset)" memory/.dreams/session-corpus/*.txt
```

## Merge Risk

**Risk**: Low. The change is purely additive — a single `continue` guard alongside an existing checkpoint filter of the same shape. `isSessionArchiveArtifactName` is already well-tested (used in `session-files.ts:shouldSkipTranscriptFileForDreaming` and `buildSessionEntry`). The `listSessionFilesForAgent` shared utility is unchanged, so memory_search indexing and usage/billing telemetry continue to include archive content as intended. No API surface or configuration changes.
