### PR TITLE
fix(queue): preserve queued platform message ids in collect drains (Fixes #36212)

### DIFF
--- a/src/auto-reply/reply/queue.collect.test.ts
+++ b/src/auto-reply/reply/queue.collect.test.ts
@@ -97,6 +97,50 @@ describe("followup queue collect routing", () => {
     expect(calls[0]?.originatingTo).toBe("channel:A");
   });
 
+  it("preserves the latest queued message id on collected followups", async () => {
+    const key = `test-collect-message-id-${Date.now()}`;
+    const calls: FollowupRun[] = [];
+    const done = createDeferred<void>();
+    const runFollowup = async (run: FollowupRun) => {
+      calls.push(run);
+      done.resolve();
+    };
+    const settings: QueueSettings = {
+      mode: "collect",
+      debounceMs: 0,
+      cap: 50,
+      dropPolicy: "summarize",
+    };
+
+    enqueueFollowupRun(
+      key,
+      createRun({
+        prompt: "first",
+        messageId: "platform-msg-1",
+        originatingChannel: "feishu",
+        originatingTo: "chat:123",
+      }),
+      settings,
+    );
+    enqueueFollowupRun(
+      key,
+      createRun({
+        prompt: "second",
+        messageId: "platform-msg-2",
+        originatingChannel: "feishu",
+        originatingTo: "chat:123",
+      }),
+      settings,
+    );
+
+    scheduleFollowupDrain(key, runFollowup);
+    await done.promise;
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.prompt).toContain("[Queued messages while agent was busy]");
+    expect(calls[0]?.messageId).toBe("platform-msg-2");
+  });
+
   it("collects compatible items after one cross-channel drain", async () => {
     const key = `test-collect-after-cross-${Date.now()}`;
     const calls: FollowupRun[] = [];

--- a/src/auto-reply/reply/queue/drain.ts
+++ b/src/auto-reply/reply/queue/drain.ts
@@ -54,6 +54,8 @@ type OriginRoutingMetadata = Pick<
   "originatingChannel" | "originatingTo" | "originatingAccountId" | "originatingThreadId"
 >;
 
+type OriginMessageMetadata = Pick<FollowupRun, "messageId" | "originatingReplyToId">;
+
 function resolveOriginRoutingMetadata(items: FollowupRun[]): OriginRoutingMetadata {
   const metadata: OriginRoutingMetadata = {};
   for (const item of items) {
@@ -80,6 +82,23 @@ function resolveOriginRoutingMetadata(items: FollowupRun[]): OriginRoutingMetada
       metadata.originatingAccountId &&
       metadata.originatingThreadId != null
     ) {
+      break;
+    }
+  }
+  return metadata;
+}
+
+function resolveOriginMessageMetadata(items: FollowupRun[]): OriginMessageMetadata {
+  const metadata: OriginMessageMetadata = {};
+  for (let index = items.length - 1; index >= 0; index -= 1) {
+    const item = items[index];
+    if (!metadata.messageId && item.messageId) {
+      metadata.messageId = item.messageId;
+    }
+    if (!metadata.originatingReplyToId && item.originatingReplyToId) {
+      metadata.originatingReplyToId = item.originatingReplyToId;
+    }
+    if (metadata.messageId && metadata.originatingReplyToId) {
       break;
     }
   }
@@ -474,6 +493,7 @@ export function scheduleFollowupDrain(
             }
 
             const routing = resolveOriginRoutingMetadata(groupItems);
+            const messageMetadata = resolveOriginMessageMetadata(groupItems);
             const prompt = buildCollectPrompt({
               title: "[Queued messages while agent was busy]",
               items: groupItems,
@@ -486,6 +506,7 @@ export function scheduleFollowupDrain(
                 run,
                 enqueuedAt: Date.now(),
                 ...routing,
+                ...messageMetadata,
                 ...collectRuntimeMetadata(groupItems),
                 ...collectQueuedImages(groupItems),
               });
@@ -525,10 +546,12 @@ export function scheduleFollowupDrain(
                     prompt: summaryPrompt,
                     run,
                     enqueuedAt: Date.now(),
+                    messageId: item.messageId,
                     originatingChannel: item.originatingChannel,
                     originatingTo: item.originatingTo,
                     originatingAccountId: item.originatingAccountId,
                     originatingThreadId: item.originatingThreadId,
+                    originatingReplyToId: item.originatingReplyToId,
                     ...collectSummaryRuntimeMetadata([item]),
                     ...collectQueuedImages([item]),
                   });


### PR DESCRIPTION
## Summary

Fixes #36212.

Collected queued followups were dropping the original platform `message_id` when the drain synthesized a combined `[Queued messages while agent was busy]` turn. The queue already stores each inbound platform message id, but the collect and overflow-summary drain paths were rebuilding a new followup run without carrying that metadata forward.

This change keeps the latest queued item's `messageId` (and reply-target id when present) on the synthesized followup run so downstream message tooling can still target the real platform message instead of a synthetic placeholder id.

Non-goals:
- no queue-mode behavior changes
- no changes to dedupe keys or routing selection
- no provider-specific reply policy changes

## Tests and validation

```bash
node scripts/run-vitest.mjs src/auto-reply/reply/queue.collect.test.ts
node scripts/run-vitest.mjs src/auto-reply/reply/followup-runner.test.ts --testNamePattern "restart sentinel routed followups use reply target ids for CLI current message context"
git diff --check
```

## Real behavior proof

Behavior addressed:
- collect-mode queued followups should preserve the latest queued platform `message_id` when they collapse multiple queued inbound messages into a single deferred turn

Environment tested:
- local source checkout on current `main`-based branch

Evidence after the fix:
- added a focused regression in `src/auto-reply/reply/queue.collect.test.ts` that enqueues two Feishu-style queued messages with distinct `messageId` values and verifies the drained collected followup keeps `platform-msg-2`
- the existing followup-runner routing test for reply-target/current-message-id behavior remains green

Observed result:
- the collect drain now forwards the latest queued message id instead of dropping back to a synthetic followup-only id

What was not tested:
- a live Feishu `im.message.reply` call against a real channel account

Proof limitations:
- I attempted a standalone ad-hoc local queue-drain probe, but the fresh worktree did not have the hydrated dependency layout needed for that direct runtime script, so the meaningful proof here is the focused regression test over the real queue drain code path

## Risk

Low. This only changes metadata preservation on synthesized queued followup runs. It does not alter queue admission, batching rules, or provider routing. The main behavior change is that downstream tooling sees the real latest queued platform message id where previously it saw no preserved queued message id.
