### PR TITLE
fix(windows): remove findstr from scheduled-task restart probe (Fixes #84600)

### DIFF
--- a/src/infra/windows-task-restart.test.ts
+++ b/src/infra/windows-task-restart.test.ts
@@ -127,8 +127,9 @@ describe("relaunchGatewayScheduledTask", () => {
       'openclaw restart attempt source=windows-task-handoff target="OpenClaw Gateway (work)"',
     );
     expect(script).toContain(
-      `powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command "(Get-ScheduledTask -TaskName 'OpenClaw Gateway (work)' -ErrorAction SilentlyContinue).State" 2>nul | findstr /I /C:"Running" >nul 2>&1`,
+      `powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command "$task = Get-ScheduledTask -TaskName 'OpenClaw Gateway (work)' -ErrorAction SilentlyContinue; if ($null -ne $task -and $task.State -eq \\"Running\\") { exit 0 }; exit 1" >nul 2>&1`,
     );
+    expect(script).not.toContain("findstr");
     expect(script).toContain('schtasks /Run /TN "OpenClaw Gateway (work)" >>');
     expect(script.indexOf("powershell.exe -NoProfile")).toBeLessThan(
       script.indexOf('schtasks /Run /TN "OpenClaw Gateway (work)"'),
@@ -165,8 +166,9 @@ describe("relaunchGatewayScheduledTask", () => {
     const scriptPath = [...createdScriptPaths][0];
     const script = fs.readFileSync(scriptPath, "utf8");
     expect(script).toContain(
-      "-Command \"(Get-ScheduledTask -TaskName 'OpenClaw Gateway (Bob''s work)' -ErrorAction SilentlyContinue).State\"",
+      `-Command "$task = Get-ScheduledTask -TaskName 'OpenClaw Gateway (Bob''s work)' -ErrorAction SilentlyContinue; if ($null -ne $task -and $task.State -eq \\"Running\\") { exit 0 }; exit 1"`,
     );
+    expect(script).not.toContain("findstr");
   });
 
   it("returns failed when the helper cannot be spawned", () => {

--- a/src/infra/windows-task-restart.ts
+++ b/src/infra/windows-task-restart.ts
@@ -34,9 +34,11 @@ function buildScheduledTaskRestartScript(params: {
 }): string {
   const { quotedLogPath, setupLines, taskName, taskScriptPath } = params;
   const quotedTaskName = quoteCmdScriptArg(taskName);
-  const queryTaskStateCommand = `(Get-ScheduledTask -TaskName ${quotePowerShellSingleQuotedLiteral(
-    taskName,
-  )} -ErrorAction SilentlyContinue).State`;
+  const queryTaskStateCommand = [
+    `$task = Get-ScheduledTask -TaskName ${quotePowerShellSingleQuotedLiteral(taskName)} -ErrorAction SilentlyContinue`,
+    'if ($null -ne $task -and $task.State -eq "Running") { exit 0 }',
+    "exit 1",
+  ].join("; ");
   const quotedQueryTaskStateCommand = quoteCmdScriptArg(queryTaskStateCommand);
   const lines = [
     "@echo off",
@@ -50,7 +52,7 @@ function buildScheduledTaskRestartScript(params: {
     `timeout /t ${TASK_RESTART_RETRY_DELAY_SEC} /nobreak >nul`,
     "set /a attempts+=1",
     // Avoid racing with another restart path that already started the scheduled task.
-    `powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command ${quotedQueryTaskStateCommand} 2>nul | findstr /I /C:"Running" >nul 2>&1`,
+    `powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command ${quotedQueryTaskStateCommand} >nul 2>&1`,
     "if not errorlevel 1 goto cleanup",
     `schtasks /Run /TN ${quotedTaskName} >> ${quotedLogPath} 2>&1`,
     "if not errorlevel 1 goto cleanup",


### PR DESCRIPTION
## Summary

Fixes #84600.

The Windows scheduled-task restart helper still probed task state with a PowerShell command piped into `findstr /I /C:"Running"`. That leaves a visible `cmd.exe -> findstr.exe` child process shape on some Windows hosts, which matches the black heartbeat/restart window reported in the issue.

This change keeps the same retry semantics but replaces the `findstr` pipeline with a pure PowerShell exit-code check:
- exit `0` when the scheduled task is already running
- exit `1` otherwise

Non-goals:
- no scheduled-task retry timing changes
- no service install/startup behavior changes
- no fallback-launcher changes

## Tests and validation

```bash
node scripts/run-vitest.mjs src/infra/windows-task-restart.test.ts
git diff --check
```

## Real behavior proof

Behavior addressed:
- the generated Windows scheduled-task restart helper should not shell task-state detection through `findstr`

Environment tested:
- local source checkout on current `main`-based branch

Evidence after the fix:
- `src/infra/windows-task-restart.test.ts` now verifies the generated helper script uses a PowerShell-only task-state probe and explicitly does not contain `findstr`
- the quoting case with an apostrophe in the task name stays covered

Observed result:
- the helper script now probes `Get-ScheduledTask(...).State` directly and redirects PowerShell output, removing the `findstr` subprocess from the helper path

What was not tested:
- a live Windows scheduled-task restart on a real host

Proof limitations:
- I do not have a live Windows Task Scheduler environment in this workspace, so the meaningful proof here is the generated-script regression test over the exact helper content

## Risk

Low. This keeps the existing retry loop and scheduled-task commands intact. The only behavior change is how the helper decides whether the task is already running before attempting `/Run`.