### PR TITLE
fix(pre-commit): quote Python dependency range

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,7 +64,7 @@ repos:
         name: skills python tests
         entry: pytest -q -c skills/pyproject.toml skills
         language: python
-        additional_dependencies: [pytest>=8, <9]
+        additional_dependencies: ["pytest>=8,<9"]
         pass_filenames: false
         files: "^skills/.*\\.py$"
 


### PR DESCRIPTION
## What Problem This Solves

The local `skills-python-tests` hook listed the pytest lower and upper bounds as separate YAML flow-sequence values. `prek` treated the second value as another dependency, while `pre-commit` rejected the bare `<9` requirement, so neither frontend could create the hook environment reliably.

## Why This Change Was Made

Quote the complete PEP 508 range as one dependency string: `pytest>=8,<9`. This keeps the intended pytest compatibility window without adding another hook path or changing the test command.

## User Impact

Contributors can run the skills Python hook with either supported pre-commit frontend without dependency parsing failures.

## Evidence

- `uvx --from prek==0.3.9 prek run skills-python-tests --all-files`
- `uvx --from pre-commit==4.2.0 pre-commit run skills-python-tests --all-files`
- `git diff --check origin/main...HEAD`

Both live hook runs passed after creating an isolated environment from the quoted range.
