### PR TITLE
docs(ios): clarify official app availability (Fixes #90835)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -106,7 +106,7 @@ repos:
         name: skills python tests
         entry: pytest -q skills
         language: python
-        additional_dependencies: [pytest>=8, <9]
+        additional_dependencies: ["pytest>=8,<9"]
         pass_filenames: false
         files: "^skills/.*\\.py$"
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -106,7 +106,7 @@ repos:
         name: skills python tests
         entry: pytest -q skills
         language: python
-        additional_dependencies: ["pytest>=8,<9"]
+        additional_dependencies: [pytest>=8, <9]
         pass_filenames: false
         files: "^skills/.*\\.py$"
 

--- a/docs/platforms/ios.md
+++ b/docs/platforms/ios.md
@@ -11,6 +11,13 @@ title: "iOS App"
 
 Availability: internal preview. The iOS app is not publicly distributed yet.
 
+There is currently no official public App Store listing for the OpenClaw iOS app.
+
+If you were looking for the app in the App Store:
+- the official iOS app is still internal-preview only
+- public App Store clones or similarly named apps are not the official OpenClaw app
+- access currently comes from the OpenClaw team (for example via internal preview / TestFlight-style distribution), not from a public store search
+
 ## What it does
 
 - Connects to a Gateway over WebSocket (LAN or tailnet).

--- a/docs/platforms/ios.md
+++ b/docs/platforms/ios.md
@@ -14,6 +14,7 @@ Availability: internal preview. The iOS app is not publicly distributed yet.
 There is currently no official public App Store listing for the OpenClaw iOS app.
 
 If you were looking for the app in the App Store:
+
 - the official iOS app is still internal-preview only
 - public App Store clones or similarly named apps are not the official OpenClaw app
 - access currently comes from the OpenClaw team (for example via internal preview / TestFlight-style distribution), not from a public store search


### PR DESCRIPTION
## Summary

Fixes #90835.

The iOS platform page already says the app is an internal preview, but it does not answer the practical question users are asking: whether there is an official public App Store listing and how they are supposed to get the app.

This docs-only change makes that explicit near the top of the page:
- there is no official public App Store listing yet
- similarly named App Store entries are not the official OpenClaw app
- access currently comes through the OpenClaw team / preview distribution, not a public search

## Tests and validation

```bash
git diff --check
```

## Real behavior proof

Behavior addressed:
- readers landing on `/platforms/ios` should immediately understand that there is no official public App Store listing yet

Environment tested:
- local docs source checkout on this branch

Evidence after the fix:
- the top of `docs/platforms/ios.md` now explicitly answers the App Store availability question instead of only implying it through the “internal preview” note

Observed result:
- the page now tells readers what is official, what is not, and how access currently works before they continue into setup steps

What was not tested:
- rendered docs-site preview in a running local docs server

## Risk

Low. This is a docs-only clarification with no runtime, config, or API changes.