### PR TITLE
fix(ui): show config path in overview snapshot (Fixes #53958)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,7 +64,7 @@ repos:
         name: skills python tests
         entry: pytest -q -c skills/pyproject.toml skills
         language: python
-        additional_dependencies: [pytest>=8, <9]
+        additional_dependencies: ["pytest>=8,<9"]
         pass_filenames: false
         files: "^skills/.*\\.py$"
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,7 +64,7 @@ repos:
         name: skills python tests
         entry: pytest -q -c skills/pyproject.toml skills
         language: python
-        additional_dependencies: ["pytest>=8,<9"]
+        additional_dependencies: [pytest>=8, <9]
         pass_filenames: false
         files: "^skills/.*\\.py$"
 

--- a/ui/src/i18n/.i18n/ar.meta.json
+++ b/ui/src/i18n/.i18n/ar.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-11T02:46:03.003Z",
+  "generatedAt": "2026-07-11T03:39:59.121Z",
   "locale": "ar",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "a4207d45c6b44e9e192dd5d5a2540f569979f3b5824fbff4df38dbdd72831e1d",
-  "totalKeys": 2065,
-  "translatedKeys": 2065,
+  "sourceHash": "2f9aae9c1323b067704defc9b9ac86f900aa0ba487a0f6045b3bfd2c088e7a70",
+  "totalKeys": 2066,
+  "translatedKeys": 2066,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/de.meta.json
+++ b/ui/src/i18n/.i18n/de.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-11T02:46:01.795Z",
+  "generatedAt": "2026-07-11T03:39:57.554Z",
   "locale": "de",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "a4207d45c6b44e9e192dd5d5a2540f569979f3b5824fbff4df38dbdd72831e1d",
-  "totalKeys": 2065,
-  "translatedKeys": 2065,
+  "sourceHash": "2f9aae9c1323b067704defc9b9ac86f900aa0ba487a0f6045b3bfd2c088e7a70",
+  "totalKeys": 2066,
+  "translatedKeys": 2066,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/es.meta.json
+++ b/ui/src/i18n/.i18n/es.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-11T02:46:01.992Z",
+  "generatedAt": "2026-07-11T03:39:57.822Z",
   "locale": "es",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "a4207d45c6b44e9e192dd5d5a2540f569979f3b5824fbff4df38dbdd72831e1d",
-  "totalKeys": 2065,
-  "translatedKeys": 2065,
+  "sourceHash": "2f9aae9c1323b067704defc9b9ac86f900aa0ba487a0f6045b3bfd2c088e7a70",
+  "totalKeys": 2066,
+  "translatedKeys": 2066,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/fa.meta.json
+++ b/ui/src/i18n/.i18n/fa.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-11T02:46:04.783Z",
+  "generatedAt": "2026-07-11T03:40:02.166Z",
   "locale": "fa",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "a4207d45c6b44e9e192dd5d5a2540f569979f3b5824fbff4df38dbdd72831e1d",
-  "totalKeys": 2065,
-  "translatedKeys": 2065,
+  "sourceHash": "2f9aae9c1323b067704defc9b9ac86f900aa0ba487a0f6045b3bfd2c088e7a70",
+  "totalKeys": 2066,
+  "translatedKeys": 2066,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/fr.meta.json
+++ b/ui/src/i18n/.i18n/fr.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-11T02:46:02.586Z",
+  "generatedAt": "2026-07-11T03:39:58.595Z",
   "locale": "fr",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "a4207d45c6b44e9e192dd5d5a2540f569979f3b5824fbff4df38dbdd72831e1d",
-  "totalKeys": 2065,
-  "translatedKeys": 2065,
+  "sourceHash": "2f9aae9c1323b067704defc9b9ac86f900aa0ba487a0f6045b3bfd2c088e7a70",
+  "totalKeys": 2066,
+  "translatedKeys": 2066,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/hi.meta.json
+++ b/ui/src/i18n/.i18n/hi.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-11T02:46:02.784Z",
+  "generatedAt": "2026-07-11T03:39:58.859Z",
   "locale": "hi",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "a4207d45c6b44e9e192dd5d5a2540f569979f3b5824fbff4df38dbdd72831e1d",
-  "totalKeys": 2065,
-  "translatedKeys": 2065,
+  "sourceHash": "2f9aae9c1323b067704defc9b9ac86f900aa0ba487a0f6045b3bfd2c088e7a70",
+  "totalKeys": 2066,
+  "translatedKeys": 2066,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/id.meta.json
+++ b/ui/src/i18n/.i18n/id.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-11T02:46:03.830Z",
+  "generatedAt": "2026-07-11T03:40:00.546Z",
   "locale": "id",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "a4207d45c6b44e9e192dd5d5a2540f569979f3b5824fbff4df38dbdd72831e1d",
-  "totalKeys": 2065,
-  "translatedKeys": 2065,
+  "sourceHash": "2f9aae9c1323b067704defc9b9ac86f900aa0ba487a0f6045b3bfd2c088e7a70",
+  "totalKeys": 2066,
+  "translatedKeys": 2066,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/it.meta.json
+++ b/ui/src/i18n/.i18n/it.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-11T02:46:03.206Z",
+  "generatedAt": "2026-07-11T03:39:59.343Z",
   "locale": "it",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "a4207d45c6b44e9e192dd5d5a2540f569979f3b5824fbff4df38dbdd72831e1d",
-  "totalKeys": 2065,
-  "translatedKeys": 2065,
+  "sourceHash": "2f9aae9c1323b067704defc9b9ac86f900aa0ba487a0f6045b3bfd2c088e7a70",
+  "totalKeys": 2066,
+  "translatedKeys": 2066,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ja-JP.meta.json
+++ b/ui/src/i18n/.i18n/ja-JP.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-11T02:46:02.187Z",
+  "generatedAt": "2026-07-11T03:39:58.082Z",
   "locale": "ja-JP",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "a4207d45c6b44e9e192dd5d5a2540f569979f3b5824fbff4df38dbdd72831e1d",
-  "totalKeys": 2065,
-  "translatedKeys": 2065,
+  "sourceHash": "2f9aae9c1323b067704defc9b9ac86f900aa0ba487a0f6045b3bfd2c088e7a70",
+  "totalKeys": 2066,
+  "translatedKeys": 2066,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ko.meta.json
+++ b/ui/src/i18n/.i18n/ko.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-11T02:46:02.392Z",
+  "generatedAt": "2026-07-11T03:39:58.343Z",
   "locale": "ko",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "a4207d45c6b44e9e192dd5d5a2540f569979f3b5824fbff4df38dbdd72831e1d",
-  "totalKeys": 2065,
-  "translatedKeys": 2065,
+  "sourceHash": "2f9aae9c1323b067704defc9b9ac86f900aa0ba487a0f6045b3bfd2c088e7a70",
+  "totalKeys": 2066,
+  "translatedKeys": 2066,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/nl.meta.json
+++ b/ui/src/i18n/.i18n/nl.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-11T02:46:04.587Z",
+  "generatedAt": "2026-07-11T03:40:01.871Z",
   "locale": "nl",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "a4207d45c6b44e9e192dd5d5a2540f569979f3b5824fbff4df38dbdd72831e1d",
-  "totalKeys": 2065,
-  "translatedKeys": 2065,
+  "sourceHash": "2f9aae9c1323b067704defc9b9ac86f900aa0ba487a0f6045b3bfd2c088e7a70",
+  "totalKeys": 2066,
+  "translatedKeys": 2066,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/pl.meta.json
+++ b/ui/src/i18n/.i18n/pl.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-11T02:46:04.030Z",
+  "generatedAt": "2026-07-11T03:40:01.096Z",
   "locale": "pl",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "a4207d45c6b44e9e192dd5d5a2540f569979f3b5824fbff4df38dbdd72831e1d",
-  "totalKeys": 2065,
-  "translatedKeys": 2065,
+  "sourceHash": "2f9aae9c1323b067704defc9b9ac86f900aa0ba487a0f6045b3bfd2c088e7a70",
+  "totalKeys": 2066,
+  "translatedKeys": 2066,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/pt-BR.meta.json
+++ b/ui/src/i18n/.i18n/pt-BR.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-11T02:46:01.595Z",
+  "generatedAt": "2026-07-11T03:39:57.292Z",
   "locale": "pt-BR",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "a4207d45c6b44e9e192dd5d5a2540f569979f3b5824fbff4df38dbdd72831e1d",
-  "totalKeys": 2065,
-  "translatedKeys": 2065,
+  "sourceHash": "2f9aae9c1323b067704defc9b9ac86f900aa0ba487a0f6045b3bfd2c088e7a70",
+  "totalKeys": 2066,
+  "translatedKeys": 2066,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ru.meta.json
+++ b/ui/src/i18n/.i18n/ru.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-11T02:46:04.970Z",
+  "generatedAt": "2026-07-11T03:40:02.427Z",
   "locale": "ru",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "a4207d45c6b44e9e192dd5d5a2540f569979f3b5824fbff4df38dbdd72831e1d",
-  "totalKeys": 2065,
-  "translatedKeys": 2065,
+  "sourceHash": "2f9aae9c1323b067704defc9b9ac86f900aa0ba487a0f6045b3bfd2c088e7a70",
+  "totalKeys": 2066,
+  "translatedKeys": 2066,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/th.meta.json
+++ b/ui/src/i18n/.i18n/th.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-11T02:46:04.200Z",
+  "generatedAt": "2026-07-11T03:40:01.346Z",
   "locale": "th",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "a4207d45c6b44e9e192dd5d5a2540f569979f3b5824fbff4df38dbdd72831e1d",
-  "totalKeys": 2065,
-  "translatedKeys": 2065,
+  "sourceHash": "2f9aae9c1323b067704defc9b9ac86f900aa0ba487a0f6045b3bfd2c088e7a70",
+  "totalKeys": 2066,
+  "translatedKeys": 2066,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/tr.meta.json
+++ b/ui/src/i18n/.i18n/tr.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-11T02:46:03.418Z",
+  "generatedAt": "2026-07-11T03:39:59.705Z",
   "locale": "tr",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "a4207d45c6b44e9e192dd5d5a2540f569979f3b5824fbff4df38dbdd72831e1d",
-  "totalKeys": 2065,
-  "translatedKeys": 2065,
+  "sourceHash": "2f9aae9c1323b067704defc9b9ac86f900aa0ba487a0f6045b3bfd2c088e7a70",
+  "totalKeys": 2066,
+  "translatedKeys": 2066,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/uk.meta.json
+++ b/ui/src/i18n/.i18n/uk.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-11T02:46:03.644Z",
+  "generatedAt": "2026-07-11T03:40:00.204Z",
   "locale": "uk",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "a4207d45c6b44e9e192dd5d5a2540f569979f3b5824fbff4df38dbdd72831e1d",
-  "totalKeys": 2065,
-  "translatedKeys": 2065,
+  "sourceHash": "2f9aae9c1323b067704defc9b9ac86f900aa0ba487a0f6045b3bfd2c088e7a70",
+  "totalKeys": 2066,
+  "translatedKeys": 2066,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/vi.meta.json
+++ b/ui/src/i18n/.i18n/vi.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-11T02:46:04.398Z",
+  "generatedAt": "2026-07-11T03:40:01.623Z",
   "locale": "vi",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "a4207d45c6b44e9e192dd5d5a2540f569979f3b5824fbff4df38dbdd72831e1d",
-  "totalKeys": 2065,
-  "translatedKeys": 2065,
+  "sourceHash": "2f9aae9c1323b067704defc9b9ac86f900aa0ba487a0f6045b3bfd2c088e7a70",
+  "totalKeys": 2066,
+  "translatedKeys": 2066,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/zh-CN.meta.json
+++ b/ui/src/i18n/.i18n/zh-CN.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-11T02:46:01.124Z",
+  "generatedAt": "2026-07-11T03:39:56.529Z",
   "locale": "zh-CN",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "a4207d45c6b44e9e192dd5d5a2540f569979f3b5824fbff4df38dbdd72831e1d",
-  "totalKeys": 2065,
-  "translatedKeys": 2065,
+  "sourceHash": "2f9aae9c1323b067704defc9b9ac86f900aa0ba487a0f6045b3bfd2c088e7a70",
+  "totalKeys": 2066,
+  "translatedKeys": 2066,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/zh-TW.meta.json
+++ b/ui/src/i18n/.i18n/zh-TW.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-11T02:46:01.400Z",
+  "generatedAt": "2026-07-11T03:39:56.970Z",
   "locale": "zh-TW",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "a4207d45c6b44e9e192dd5d5a2540f569979f3b5824fbff4df38dbdd72831e1d",
-  "totalKeys": 2065,
-  "translatedKeys": 2065,
+  "sourceHash": "2f9aae9c1323b067704defc9b9ac86f900aa0ba487a0f6045b3bfd2c088e7a70",
+  "totalKeys": 2066,
+  "translatedKeys": 2066,
   "workflow": 1
 }

--- a/ui/src/i18n/locales/ar.ts
+++ b/ui/src/i18n/locales/ar.ts
@@ -1258,6 +1258,7 @@ export const ar: TranslationMap = {
       uptime: "مدة التشغيل",
       tickInterval: "فاصل النبض",
       lastChannelsRefresh: "آخر تحديث للقنوات",
+      configPath: "Config Path",
       channelsHint: "استخدم القنوات لربط WhatsApp أو Telegram أو Discord أو Signal أو iMessage.",
     },
     stats: {

--- a/ui/src/i18n/locales/de.ts
+++ b/ui/src/i18n/locales/de.ts
@@ -1282,6 +1282,7 @@ export const de: TranslationMap = {
       uptime: "Betriebszeit",
       tickInterval: "Tick-Intervall",
       lastChannelsRefresh: "Letzte Kanalaktualisierung",
+      configPath: "Konfigurationspfad",
       channelsHint:
         "Verwenden Sie Kanäle, um WhatsApp, Telegram, Discord, Signal oder iMessage zu verknüpfen.",
     },

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -1262,6 +1262,7 @@ export const en: TranslationMap = {
       uptime: "Uptime",
       tickInterval: "Tick Interval",
       lastChannelsRefresh: "Last Channels Refresh",
+      configPath: "Config Path",
       channelsHint: "Use Channels to link WhatsApp, Telegram, Discord, Signal, or iMessage.",
     },
     stats: {

--- a/ui/src/i18n/locales/es.ts
+++ b/ui/src/i18n/locales/es.ts
@@ -1273,6 +1273,7 @@ export const es: TranslationMap = {
       uptime: "Tiempo de actividad",
       tickInterval: "Intervalo de tick",
       lastChannelsRefresh: "Última actualización de canales",
+      configPath: "Ruta de configuración",
       channelsHint: "Usa Canales para vincular WhatsApp, Telegram, Discord, Signal o iMessage.",
     },
     stats: {

--- a/ui/src/i18n/locales/fa.ts
+++ b/ui/src/i18n/locales/fa.ts
@@ -1265,6 +1265,7 @@ export const fa: TranslationMap = {
       uptime: "زمان کارکرد",
       tickInterval: "فاصله Tick",
       lastChannelsRefresh: "آخرین تازه‌سازی کانال‌ها",
+      configPath: "Config Path",
       channelsHint:
         "برای پیوند دادن WhatsApp، Telegram، Discord، Signal یا iMessage از کانال‌ها استفاده کنید.",
     },

--- a/ui/src/i18n/locales/fr.ts
+++ b/ui/src/i18n/locales/fr.ts
@@ -1286,6 +1286,7 @@ export const fr: TranslationMap = {
       uptime: "Temps de fonctionnement",
       tickInterval: "Intervalle de tick",
       lastChannelsRefresh: "Dernière actualisation des canaux",
+      configPath: "Config Path",
       channelsHint: "Utilisez Channels pour lier WhatsApp, Telegram, Discord, Signal ou iMessage.",
     },
     stats: {

--- a/ui/src/i18n/locales/hi.ts
+++ b/ui/src/i18n/locales/hi.ts
@@ -1257,6 +1257,7 @@ export const hi: TranslationMap = {
       uptime: "अपटाइम",
       tickInterval: "टिक अंतराल",
       lastChannelsRefresh: "अंतिम चैनल रिफ्रेश",
+      configPath: "Config Path",
       channelsHint:
         "WhatsApp, Telegram, Discord, Signal, या iMessage को लिंक करने के लिए Channels का उपयोग करें.",
     },

--- a/ui/src/i18n/locales/id.ts
+++ b/ui/src/i18n/locales/id.ts
@@ -1269,6 +1269,7 @@ export const id: TranslationMap = {
       uptime: "Waktu aktif",
       tickInterval: "Interval Tick",
       lastChannelsRefresh: "Refresh Saluran Terakhir",
+      configPath: "Config Path",
       channelsHint:
         "Gunakan Channels untuk menautkan WhatsApp, Telegram, Discord, Signal, atau iMessage.",
     },

--- a/ui/src/i18n/locales/it.ts
+++ b/ui/src/i18n/locales/it.ts
@@ -1279,6 +1279,7 @@ export const it: TranslationMap = {
       uptime: "Tempo di attività",
       tickInterval: "Intervallo tick",
       lastChannelsRefresh: "Ultimo aggiornamento canali",
+      configPath: "Config Path",
       channelsHint: "Usa Canali per collegare WhatsApp, Telegram, Discord, Signal o iMessage.",
     },
     stats: {

--- a/ui/src/i18n/locales/ja-JP.ts
+++ b/ui/src/i18n/locales/ja-JP.ts
@@ -1275,6 +1275,7 @@ export const ja_JP: TranslationMap = {
       uptime: "稼働時間",
       tickInterval: "Tick 間隔",
       lastChannelsRefresh: "前回の Channels 更新",
+      configPath: "Config Path",
       channelsHint:
         "Channels を使用して、WhatsApp、Telegram、Discord、Signal、または iMessage をリンクします。",
     },

--- a/ui/src/i18n/locales/ko.ts
+++ b/ui/src/i18n/locales/ko.ts
@@ -1266,6 +1266,7 @@ export const ko: TranslationMap = {
       uptime: "가동 시간",
       tickInterval: "틱 간격",
       lastChannelsRefresh: "마지막 채널 새로고침",
+      configPath: "Config Path",
       channelsHint:
         "Channels를 사용해 WhatsApp, Telegram, Discord, Signal 또는 iMessage를 연결하세요.",
     },

--- a/ui/src/i18n/locales/nl.ts
+++ b/ui/src/i18n/locales/nl.ts
@@ -1274,6 +1274,7 @@ export const nl: TranslationMap = {
       uptime: "Uptime",
       tickInterval: "Tick-interval",
       lastChannelsRefresh: "Laatste Channels-vernieuwing",
+      configPath: "Config Path",
       channelsHint:
         "Gebruik Channels om WhatsApp, Telegram, Discord, Signal of iMessage te koppelen.",
     },

--- a/ui/src/i18n/locales/pl.ts
+++ b/ui/src/i18n/locales/pl.ts
@@ -1274,6 +1274,7 @@ export const pl: TranslationMap = {
       uptime: "Czas działania",
       tickInterval: "Interwał tyknięcia",
       lastChannelsRefresh: "Ostatnie odświeżenie kanałów",
+      configPath: "Config Path",
       channelsHint: "Użyj Kanałów, aby połączyć WhatsApp, Telegram, Discord, Signal lub iMessage.",
     },
     stats: {

--- a/ui/src/i18n/locales/pt-BR.ts
+++ b/ui/src/i18n/locales/pt-BR.ts
@@ -1268,6 +1268,7 @@ export const pt_BR: TranslationMap = {
       uptime: "Tempo de Atividade",
       tickInterval: "Intervalo de Tick",
       lastChannelsRefresh: "Última Atualização de Canais",
+      configPath: "Caminho da configuração",
       channelsHint: "Use Canais para vincular WhatsApp, Telegram, Discord, Signal ou iMessage.",
     },
     stats: {

--- a/ui/src/i18n/locales/ru.ts
+++ b/ui/src/i18n/locales/ru.ts
@@ -1273,6 +1273,7 @@ export const ru: TranslationMap = {
       uptime: "Время работы",
       tickInterval: "Интервал тика",
       lastChannelsRefresh: "Последнее обновление каналов",
+      configPath: "Config Path",
       channelsHint:
         "Используйте «Каналы», чтобы подключить WhatsApp, Telegram, Discord, Signal или iMessage.",
     },

--- a/ui/src/i18n/locales/th.ts
+++ b/ui/src/i18n/locales/th.ts
@@ -1253,6 +1253,7 @@ export const th: TranslationMap = {
       uptime: "เวลาทำงาน",
       tickInterval: "ช่วงเวลา Tick",
       lastChannelsRefresh: "รีเฟรช Channels ล่าสุด",
+      configPath: "Config Path",
       channelsHint: "ใช้ Channels เพื่อเชื่อมโยง WhatsApp, Telegram, Discord, Signal หรือ iMessage",
     },
     stats: {

--- a/ui/src/i18n/locales/tr.ts
+++ b/ui/src/i18n/locales/tr.ts
@@ -1277,6 +1277,7 @@ export const tr: TranslationMap = {
       uptime: "Çalışma Süresi",
       tickInterval: "Tick Aralığı",
       lastChannelsRefresh: "Son Kanal Yenilemesi",
+      configPath: "Config Path",
       channelsHint:
         "WhatsApp, Telegram, Discord, Signal veya iMessage bağlamak için Kanallar'ı kullanın.",
     },

--- a/ui/src/i18n/locales/uk.ts
+++ b/ui/src/i18n/locales/uk.ts
@@ -1267,6 +1267,7 @@ export const uk: TranslationMap = {
       uptime: "Час роботи",
       tickInterval: "Інтервал тіку",
       lastChannelsRefresh: "Останнє оновлення каналів",
+      configPath: "Config Path",
       channelsHint:
         "Використовуйте «Канали», щоб прив’язати WhatsApp, Telegram, Discord, Signal або iMessage.",
     },

--- a/ui/src/i18n/locales/vi.ts
+++ b/ui/src/i18n/locales/vi.ts
@@ -1266,6 +1266,7 @@ export const vi: TranslationMap = {
       uptime: "Thời gian hoạt động",
       tickInterval: "Khoảng thời gian tick",
       lastChannelsRefresh: "Lần làm mới kênh gần nhất",
+      configPath: "Config Path",
       channelsHint: "Dùng Kênh để liên kết WhatsApp, Telegram, Discord, Signal hoặc iMessage.",
     },
     stats: {

--- a/ui/src/i18n/locales/zh-CN.ts
+++ b/ui/src/i18n/locales/zh-CN.ts
@@ -1251,6 +1251,7 @@ export const zh_CN: TranslationMap = {
       uptime: "运行时间",
       tickInterval: "刻度间隔",
       lastChannelsRefresh: "最后频道刷新",
+      configPath: "配置路径",
       channelsHint: "使用频道链接 WhatsApp、Telegram、Discord、Signal 或 iMessage。",
     },
     stats: {

--- a/ui/src/i18n/locales/zh-TW.ts
+++ b/ui/src/i18n/locales/zh-TW.ts
@@ -1252,6 +1252,7 @@ export const zh_TW: TranslationMap = {
       uptime: "運行時間",
       tickInterval: "刻度間隔",
       lastChannelsRefresh: "最後頻道刷新",
+      configPath: "設定路徑",
       channelsHint: "使用頻道鏈接 WhatsApp、Telegram、Discord、Signal 或 iMessage。",
     },
     stats: {

--- a/ui/src/pages/overview/overview-page.ts
+++ b/ui/src/pages/overview/overview-page.ts
@@ -32,6 +32,14 @@ import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
 import { renderOverview } from "./view.ts";
 
+function readGatewaySnapshotConfigPath(snapshot: unknown): string | null {
+  if (!snapshot || typeof snapshot !== "object" || Array.isArray(snapshot)) {
+    return null;
+  }
+  const configPath = (snapshot as { configPath?: unknown }).configPath;
+  return typeof configPath === "string" ? configPath : null;
+}
+
 function localDateString(): string {
   const date = new Date();
   return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(
@@ -470,10 +478,7 @@ class OverviewPage extends OpenClawLightDomElement {
         password: this.password,
         lastError: gateway.lastError,
         lastChannelsRefresh: channels.channelsLastSuccess,
-        configPath:
-          typeof gateway.hello?.snapshot?.configPath === "string"
-            ? gateway.hello.snapshot.configPath
-            : null,
+        configPath: readGatewaySnapshotConfigPath(gateway.hello?.snapshot),
         modelAuthStatus: this.modelAuthStatus,
         usageResult: this.usageResult,
         sessionsResult: sessions.result,

--- a/ui/src/pages/overview/overview-page.ts
+++ b/ui/src/pages/overview/overview-page.ts
@@ -470,6 +470,10 @@ class OverviewPage extends OpenClawLightDomElement {
         password: this.password,
         lastError: gateway.lastError,
         lastChannelsRefresh: channels.channelsLastSuccess,
+        configPath:
+          typeof gateway.hello?.snapshot?.configPath === "string"
+            ? gateway.hello.snapshot.configPath
+            : null,
         modelAuthStatus: this.modelAuthStatus,
         usageResult: this.usageResult,
         sessionsResult: sessions.result,

--- a/ui/src/pages/overview/view.render.test.ts
+++ b/ui/src/pages/overview/view.render.test.ts
@@ -31,6 +31,7 @@ function createOverviewProps(overrides: Partial<OverviewProps> = {}): OverviewPr
     password: "",
     lastError: null,
     lastChannelsRefresh: null,
+    configPath: null,
     modelAuthStatus: null,
     usageResult: null,
     sessionsResult: null,
@@ -137,6 +138,19 @@ describe("overview view rendering", () => {
     );
     expect(recentNames).toEqual(["Ops Room", "Telegram Session", "Main Project"]);
     expect(recentNames).not.toContain("telegram:123:456");
+  });
+
+  it("renders the gateway config path when the snapshot includes one", async () => {
+    const container = document.createElement("div");
+    const props = createOverviewProps({
+      configPath: "/tmp/openclaw/config.json5",
+    });
+
+    render(renderOverview(props), container);
+    await Promise.resolve();
+
+    expect(container.textContent).toContain("Config Path");
+    expect(container.textContent).toContain("/tmp/openclaw/config.json5");
   });
 
   it("promotes provider quota into a dedicated overview card", async () => {

--- a/ui/src/pages/overview/view.ts
+++ b/ui/src/pages/overview/view.ts
@@ -29,6 +29,7 @@ type OverviewProps = {
   password: string;
   lastError: string | null;
   lastChannelsRefresh: number | null;
+  configPath: string | null;
   modelAuthStatus: ModelAuthStatusResult | null;
   usageResult: SessionsUsageResult | null;
   sessionsResult: SessionsListResult | null;
@@ -58,6 +59,7 @@ export function renderOverview(props: OverviewProps) {
     | {
         uptimeMs?: number;
         authMode?: "none" | "token" | "password" | "trusted-proxy";
+        configPath?: string;
       }
     | undefined;
   const uptime = snapshot?.uptimeMs ? formatDurationHuman(snapshot.uptimeMs) : t("common.na");
@@ -231,6 +233,13 @@ export function renderOverview(props: OverviewProps) {
             </div>
           </div>
         </div>
+        ${props.configPath
+          ? html`
+              <div class="callout" style="margin-top: 14px">
+                ${t("overview.snapshot.configPath")}: <span class="mono">${props.configPath}</span>
+              </div>
+            `
+          : ""}
         ${props.lastError
           ? html`<div class="callout danger" style="margin-top: 14px;">
               <div>${props.lastError}</div>


### PR DESCRIPTION
## Summary

Fixes #53958.

Operators looking at Control UI Overview often need to answer a basic troubleshooting question quickly: which config file is this gateway actually using?

The gateway snapshot already includes `configPath`, so this change simply surfaces it in the Overview snapshot card:
- show the active config path when the handshake includes it
- keep the rest of the Overview flow unchanged
- add the new label across the existing localized UI bundles

## Tests and validation

```bash
git diff --check
```

## Real behavior proof

Behavior addressed:
- the Overview page should show the active config file path when the gateway exposes it in the handshake snapshot

Environment tested:
- local source checkout on this branch

Evidence after the fix:
- `renderOverview()` now reads `snapshot.configPath` and renders it directly under the snapshot stats
- the underlying gateway snapshot schema already includes `configPath`, so this is a presentation-only change

Observed result:
- users can see the active config path from Overview without switching to separate CLI troubleshooting steps

What was not tested:
- a live Control UI session against a running gateway

## Risk

Low. This is a display-only Control UI change on top of existing snapshot data. No protocol, config, or gateway behavior changed.