### PR TITLE
fix(exec): clarify node approval recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Node exec approval recovery:** point unavailable `host=node` prompts to the Control UI approval inbox, describe `approvals get --node` as effective-policy inspection, and preserve resolved node IDs through deterministic reply rendering. (#91280, #53250) Thanks @deepujain.
 - **Codex runtime switching:** accept the bundled Codex runtime for both `codex/*` and `openai/*` model routes while keeping unsupported provider/runtime pairs rejected. (#103762)
 - **Agent abort cleanup:** serialize prompt lock reacquisition with terminal cleanup so canceled embedded runs do not self-contend on session locks for up to 60 seconds.
 - **Chutes OAuth deadlines:** bound token exchange, profile lookup, and refresh requests, and keep issued tokens when optional userinfo enrichment stalls. (#102026) Thanks @Alix-007.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Node exec approval recovery:** point unavailable `host=node` prompts to the Control UI approval inbox, describe `approvals get --node` as effective-policy inspection, and preserve resolved node IDs through deterministic reply rendering. (#91280, #53250) Thanks @deepujain.
 - **Codex runtime switching:** accept the bundled Codex runtime for both `codex/*` and `openai/*` model routes while keeping unsupported provider/runtime pairs rejected. (#103762)
 - **Agent abort cleanup:** serialize prompt lock reacquisition with terminal cleanup so canceled embedded runs do not self-contend on session locks for up to 60 seconds.
 - **Chutes OAuth deadlines:** bound token exchange, profile lookup, and refresh requests, and keep issued tokens when optional userinfo enrichment stalls. (#102026) Thanks @Alix-007.

--- a/src/agents/bash-tools.exec-host-shared.test.ts
+++ b/src/agents/bash-tools.exec-host-shared.test.ts
@@ -612,6 +612,37 @@ describe("buildExecApprovalPendingToolResult", () => {
     expect(text).not.toContain("Pending command:");
   });
 
+  it("preserves node metadata in unavailable recovery guidance", () => {
+    const result = buildExecApprovalPendingToolResult({
+      host: "node",
+      nodeId: "node-mac-1",
+      command: "uname -a",
+      cwd: "/tmp",
+      warningText: "",
+      approvalId: "approval-id",
+      approvalSlug: "approval-slug",
+      expiresAtMs: Date.now() + 60_000,
+      initiatingSurface: {
+        kind: "enabled",
+        channel: undefined,
+        channelLabel: "Web UI",
+      },
+      sentApproverDms: false,
+      unavailableReason: "no-approval-route",
+    });
+
+    expect(result.details).toMatchObject({
+      status: "approval-unavailable",
+      host: "node",
+      nodeId: "node-mac-1",
+    });
+    const text = result.content.find((part) => part.type === "text")?.text ?? "";
+    expect(text).toContain("Open the approval inbox with `openclaw dashboard --no-open`.");
+    expect(text).toContain(
+      "Inspect the node's effective exec policy with `openclaw approvals get --node node-mac-1`.",
+    );
+  });
+
   it("keeps the Telegram unavailable reply when Discord DM approvals are not fully configured", () => {
     const result = buildDisabledSurfaceApprovalResult({
       channel: "telegram",

--- a/src/agents/bash-tools.exec-host-shared.test.ts
+++ b/src/agents/bash-tools.exec-host-shared.test.ts
@@ -637,7 +637,9 @@ describe("buildExecApprovalPendingToolResult", () => {
       nodeId: "node-mac-1",
     });
     const text = result.content.find((part) => part.type === "text")?.text ?? "";
-    expect(text).toContain("Open the approval inbox with `openclaw dashboard --no-open`.");
+    expect(text).toContain(
+      "Print the Control UI URL with `openclaw dashboard --no-open`, open it in a browser, then use the approval inbox.",
+    );
     expect(text).toContain(
       "Inspect the node's effective exec policy with `openclaw approvals get --node node-mac-1`.",
     );

--- a/src/agents/bash-tools.exec-host-shared.ts
+++ b/src/agents/bash-tools.exec-host-shared.ts
@@ -523,6 +523,8 @@ export function buildExecApprovalPendingToolResult(params: {
                 channelLabel: params.initiatingSurface.channelLabel,
                 accountId: params.initiatingSurface.accountId,
                 sentApproverDms: params.sentApproverDms,
+                host: params.host,
+                nodeId: params.nodeId,
               }).text ?? "")
             : buildApprovalPendingMessage({
                 warningText: params.warningText,

--- a/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
@@ -2171,10 +2171,12 @@ describe("handleToolExecutionEnd exec approval prompts", () => {
         result: {
           details: {
             status: "approval-unavailable",
-            reason: "initiating-platform-disabled",
+            reason: "no-approval-route",
             channel: "discord",
             channelLabel: "Discord",
             accountId: "work",
+            host: "node",
+            nodeId: "node-mac-1",
           },
         },
       } as never,
@@ -2184,7 +2186,11 @@ describe("handleToolExecutionEnd exec approval prompts", () => {
       requireMockCallArg(onToolResult, 0, "tool result").text,
       "tool result text",
     );
-    expect(text).toContain("native chat exec approvals are not configured on Discord");
+    expect(text).toContain("no interactive approval client is currently available");
+    expect(text).toContain("Open the approval inbox with `openclaw dashboard --no-open`.");
+    expect(text).toContain(
+      "Inspect the node's effective exec policy with `openclaw approvals get --node node-mac-1`.",
+    );
     expect(text).not.toContain("/approve");
     expect(text).not.toContain("Pending command:");
     expect(text).not.toContain("Host:");

--- a/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
@@ -2187,7 +2187,9 @@ describe("handleToolExecutionEnd exec approval prompts", () => {
       "tool result text",
     );
     expect(text).toContain("no interactive approval client is currently available");
-    expect(text).toContain("Open the approval inbox with `openclaw dashboard --no-open`.");
+    expect(text).toContain(
+      "Print the Control UI URL with `openclaw dashboard --no-open`, open it in a browser, then use the approval inbox.",
+    );
     expect(text).toContain(
       "Inspect the node's effective exec policy with `openclaw approvals get --node node-mac-1`.",
     );

--- a/src/agents/embedded-agent-subscribe.handlers.tools.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.ts
@@ -758,6 +758,8 @@ function readExecApprovalUnavailableDetails(result: unknown): {
   channelLabel?: string;
   accountId?: string;
   sentApproverDms?: boolean;
+  host?: "gateway" | "node";
+  nodeId?: string;
 } | null {
   if (!result || typeof result !== "object") {
     return null;
@@ -786,6 +788,8 @@ function readExecApprovalUnavailableDetails(result: unknown): {
     channelLabel: readStringValue(details.channelLabel),
     accountId: readStringValue(details.accountId),
     sentApproverDms: details.sentApproverDms === true,
+    host: details.host === "gateway" || details.host === "node" ? details.host : undefined,
+    nodeId: readStringValue(details.nodeId),
   };
 }
 
@@ -855,6 +859,8 @@ async function emitToolResultOutput(params: {
           channelLabel: approvalUnavailable.channelLabel,
           accountId: approvalUnavailable.accountId,
           sentApproverDms: approvalUnavailable.sentApproverDms,
+          host: approvalUnavailable.host,
+          nodeId: approvalUnavailable.nodeId,
         }),
       );
       ctx.state.deterministicApprovalPromptSent = true;

--- a/src/infra/exec-approval-reply.test.ts
+++ b/src/infra/exec-approval-reply.test.ts
@@ -116,20 +116,21 @@ describe("exec approval reply helpers", () => {
     );
   });
 
-  it("distinguishes the node approval inbox from policy inspection", () => {
+  it("distinguishes node approval-inbox access from policy inspection", () => {
     const text = buildExecApprovalUnavailableReplyPayload({
       reason: "no-approval-route",
       host: "node",
       nodeId: "mac-1",
     }).text;
 
-    expect(text).toContain("Open the approval inbox with `openclaw dashboard --no-open`.");
+    expect(text).toContain(
+      "Print the Control UI URL with `openclaw dashboard --no-open`, open it in a browser, then use the approval inbox.",
+    );
     expect(text).toContain(
       "Inspect the node's effective exec policy with `openclaw approvals get --node mac-1`.",
     );
-    expect(text).not.toContain(
-      "approval inbox with `openclaw dashboard --no-open` or `openclaw approvals get",
-    );
+    expect(text).not.toContain("`openclaw dashboard --no-open` or `openclaw approvals get");
+    expect(text).not.toContain("Open the approval inbox with");
     expect(text).not.toContain("exec-approvals list");
   });
 

--- a/src/infra/exec-approval-reply.test.ts
+++ b/src/infra/exec-approval-reply.test.ts
@@ -116,6 +116,23 @@ describe("exec approval reply helpers", () => {
     );
   });
 
+  it("distinguishes the node approval inbox from policy inspection", () => {
+    const text = buildExecApprovalUnavailableReplyPayload({
+      reason: "no-approval-route",
+      host: "node",
+      nodeId: "mac-1",
+    }).text;
+
+    expect(text).toContain("Open the approval inbox with `openclaw dashboard --no-open`.");
+    expect(text).toContain(
+      "Inspect the node's effective exec policy with `openclaw approvals get --node mac-1`.",
+    );
+    expect(text).not.toContain(
+      "approval inbox with `openclaw dashboard --no-open` or `openclaw approvals get",
+    );
+    expect(text).not.toContain("exec-approvals list");
+  });
+
   it("explains how to enable Matrix native approvals when Matrix is the initiating platform", () => {
     const text = buildExecApprovalUnavailableReplyPayload({
       reason: "initiating-platform-disabled",

--- a/src/infra/exec-approval-reply.ts
+++ b/src/infra/exec-approval-reply.ts
@@ -70,6 +70,8 @@ export type ExecApprovalUnavailableReplyParams = {
   accountId?: string;
   reason: ExecApprovalUnavailableReason;
   sentApproverDms?: boolean;
+  host?: ExecHost;
+  nodeId?: string;
 };
 
 function resolveNativeExecApprovalClientList(params?: { excludeChannel?: string }): string {
@@ -80,13 +82,22 @@ function resolveNativeExecApprovalClientList(params?: { excludeChannel?: string 
   );
 }
 
-function buildGenericNativeExecApprovalFallbackText(params?: { excludeChannel?: string }): string {
+function buildGenericNativeExecApprovalFallbackText(params?: {
+  excludeChannel?: string;
+  host?: ExecHost;
+  nodeId?: string;
+}): string {
   const clients = resolveNativeExecApprovalClientList({
     excludeChannel: params?.excludeChannel,
   });
+  let manualRecovery = "Open the approval inbox with `openclaw dashboard --no-open`.";
+  if (params?.host === "node") {
+    const nodeId = normalizeOptionalString(params.nodeId) ?? "<id|name|ip>";
+    manualRecovery += ` Inspect the node's effective exec policy with \`openclaw approvals get --node ${nodeId}\`.`;
+  }
   return clients
-    ? `Approve it from the Web UI or terminal UI, or enable a native chat approval client such as ${clients}. If those accounts already know your owner ID via allowFrom or owner config, OpenClaw can often infer approvers automatically.`
-    : "Approve it from the Web UI or terminal UI.";
+    ? `Approve it from the Web UI or terminal UI, or enable a native chat approval client such as ${clients}. ${manualRecovery} If those accounts already know your owner ID via allowFrom or owner config, OpenClaw can often infer approvers automatically.`
+    : `Approve it from the Web UI or terminal UI. ${manualRecovery}`;
 }
 
 function resolveAllowedDecisions(params: {
@@ -442,7 +453,12 @@ export function buildExecApprovalUnavailableReplyPayload(
     if (setupText) {
       lines.push(setupText);
     } else {
-      lines.push(buildGenericNativeExecApprovalFallbackText());
+      lines.push(
+        buildGenericNativeExecApprovalFallbackText({
+          host: params.host,
+          nodeId: params.nodeId,
+        }),
+      );
     }
   } else if (params.reason === "initiating-platform-unsupported") {
     lines.push(
@@ -451,6 +467,8 @@ export function buildExecApprovalUnavailableReplyPayload(
     lines.push(
       buildGenericNativeExecApprovalFallbackText({
         excludeChannel: params.channel,
+        host: params.host,
+        nodeId: params.nodeId,
       }),
     );
   } else {
@@ -458,7 +476,10 @@ export function buildExecApprovalUnavailableReplyPayload(
       "Exec approval is required, but no interactive approval client is currently available.",
     );
     lines.push(
-      `${buildGenericNativeExecApprovalFallbackText()} Then retry the command. You can usually leave execApprovals.approvers unset when owner config already identifies the approvers.`,
+      `${buildGenericNativeExecApprovalFallbackText({
+        host: params.host,
+        nodeId: params.nodeId,
+      })} Then retry the command. You can usually leave execApprovals.approvers unset when owner config already identifies the approvers.`,
     );
   }
 

--- a/src/infra/exec-approval-reply.ts
+++ b/src/infra/exec-approval-reply.ts
@@ -90,7 +90,8 @@ function buildGenericNativeExecApprovalFallbackText(params?: {
   const clients = resolveNativeExecApprovalClientList({
     excludeChannel: params?.excludeChannel,
   });
-  let manualRecovery = "Open the approval inbox with `openclaw dashboard --no-open`.";
+  let manualRecovery =
+    "Print the Control UI URL with `openclaw dashboard --no-open`, open it in a browser, then use the approval inbox.";
   if (params?.host === "node") {
     const nodeId = normalizeOptionalString(params.nodeId) ?? "<id|name|ip>";
     manualRecovery += ` Inspect the node's effective exec policy with \`openclaw approvals get --node ${nodeId}\`.`;


### PR DESCRIPTION
Fixes #53250.

## What Problem This Solves

Fixes an issue where operators running an exec command on a node could receive only `exec denied: approval required (approval UI not available)` when no interactive approval route was available. The message did not tell them where to review the pending request or how to inspect the affected node's exec policy.

## Why This Change Was Made

The shared exec approval-unavailable renderer now owns node-aware recovery guidance, so both the initial tool result and deterministic rerender use the same message. It distinguishes the two supported surfaces:

- print the Control UI URL with `openclaw dashboard --no-open`, open it in a browser, then use the approval inbox
- inspect the node's effective exec policy with `openclaw approvals get --node <id|name|ip>` or the resolved node id when available

The CLI command is intentionally described as policy inspection. Pending approval list/resolve commands proposed in #83440 are not on current `main` and are not claimed here.

## User Impact

Operators who hit the current `host=node` approval-unavailable path get truthful Control UI access steps plus a separately labeled policy diagnostic. The change preserves fail-closed approval behavior and does not alter approval authority, decisions, or policy enforcement.

## Evidence

Validation on Blacksmith Testbox lease `tbx_01kx70bgej5kn6b8vsz00z2cp2`:

- 182 focused tests passed across `src/infra/exec-approval-reply.test.ts`, `src/agents/bash-tools.exec-host-shared.test.ts`, and `src/agents/embedded-agent-subscribe.handlers.tools.test.ts`.
- `corepack pnpm check:changed` passed the core, core-tests, and docs lanes, including typecheck, lint, guards, and zero runtime import cycles.
- Focused `oxfmt` and `git diff --check` passed.
- Fresh autoreview reported no accepted or actionable findings.

Focused tests prove that:

- `buildExecApprovalUnavailableReplyPayload({ reason: "no-approval-route", host: "node", nodeId: "mac-1" })` identifies `openclaw dashboard --no-open` as a Control UI URL printer, tells the operator to open that URL and use the approval inbox, and labels `openclaw approvals get --node mac-1` as effective-policy inspection.
- host and node metadata pass from the exec-host result through the deterministic tool-result rerender boundary.

Live clawmac approval-unavailable/recovery proof was not collected because that machine was reserved for an unrelated exact-head signed restart cycle during this repair. This patch changes only recovery copy and metadata propagation; the focused tests cover each runtime boundary it touches.

AI-assisted maintainer repair: Codex corrected the command contract, rebased the contributor branch, expanded focused coverage, and preserved Deepak Jain's commit credit and PR attribution. Release-note context remains in this body per the repository's normal-PR policy.
