### PR TITLE
fix(feishu): clear client cache when SDK is replaced via setFeishuClientRuntimeForTest

### DIFF
--- a/extensions/feishu/src/client.test.ts
+++ b/extensions/feishu/src/client.test.ts
@@ -386,6 +386,31 @@ describe("createFeishuClient HTTP timeout", () => {
       timeout: 45_000,
     });
   });
+
+  it("evicts client cache when SDK is replaced via setFeishuClientRuntimeForTest (#83911)", () => {
+    const ctorCountA = clientCtorMock.mock.calls.length;
+
+    // First client gets cached
+    createFeishuClient({ appId: "app_7", appSecret: "secret_7", accountId: "cache-clear-test" }); // pragma: allowlist secret
+    expect(clientCtorMock.mock.calls.length).toBe(ctorCountA + 1);
+
+    // SDK swap via setFeishuClientRuntimeForTest should clear the cache
+    setFeishuClientRuntimeForTest({
+      sdk: {
+        AppType: { SelfBuild: "self" } as never,
+        Client: clientCtorMock as never,
+        Domain: { Feishu: "https://open.feishu.cn", Lark: "https://open.larksuite.com" } as never,
+        LoggerLevel: { info: "info" } as never,
+        WSClient: vi.fn() as never,
+        EventDispatcher: vi.fn() as never,
+        defaultHttpInstance: mockBaseHttpInstance as never,
+      },
+    });
+
+    // Same credentials — would hit cache before the fix; now evicted
+    createFeishuClient({ appId: "app_7", appSecret: "secret_7", accountId: "cache-clear-test" }); // pragma: allowlist secret
+    expect(clientCtorMock.mock.calls.length).toBe(ctorCountA + 2);
+  });
 });
 
 describe("createFeishuWSClient proxy handling", () => {

--- a/extensions/feishu/src/client.ts
+++ b/extensions/feishu/src/client.ts
@@ -260,4 +260,5 @@ export function setFeishuClientRuntimeForTest(overrides?: {
   feishuClientSdk = overrides?.sdk
     ? { ...defaultFeishuClientSdk, ...overrides.sdk }
     : defaultFeishuClientSdk;
+  clearClientCache();
 }


### PR DESCRIPTION
## Summary

When `setFeishuClientRuntimeForTest` swaps the SDK, cached clients built with the old SDK were not evicted. Subsequent `createFeishuClient` calls would return stale clients, making mock assertions unreliable. Add a `clearClientCache()` call to ensure the cache is cleared on SDK swap.

## Linked context

Closes #83911

## Real behavior proof (required for external PRs)

- **Behavior or issue addressed:** `setFeishuClientRuntimeForTest` swapped the SDK but left stale clients in `clientCache`.
- **Real environment tested:** macOS, Node v22.22.3, latest upstream/main
- **Exact steps or command run after this patch:**

```bash
# 1. Unit tests with new regression test
node scripts/run-vitest.mjs run extensions/feishu/src/client.test.ts --reporter=verbose

# 2. Verify the code change
grep -A2 "clearClientCache" extensions/feishu/src/client.ts
```

- **Evidence after fix (copied live output):**

**Unit test output (17/17 passing):**
```
 ✓ createFeishuClient HTTP timeout > passes a custom httpInstance with default timeout to Lark.Client
 ✓ createFeishuClient HTTP timeout > ... (9 more)
 ✓ createFeishuClient HTTP timeout > recreates cached client when configured timeout changes
 ✓ createFeishuClient HTTP timeout > evicts client cache when SDK is replaced via setFeishuClientRuntimeForTest (#83911)
 ✓ createFeishuWSClient proxy handling > ... (6 more)

 Test Files  1 passed (1)
      Tests  17 passed (17)
```

**Source code change:**
```ts
export function setFeishuClientRuntimeForTest(overrides?: {
  sdk?: Partial<FeishuClientSdk>;
}): void {
  feishuClientSdk = overrides?.sdk
    ? { ...defaultFeishuClientSdk, ...overrides.sdk }
    : defaultFeishuClientSdk;
  clearClientCache();  // ← Added: evicts stale clients built with old SDK
}
```

- **Observed result after fix:** The new test `"evicts client cache when SDK is replaced via setFeishuClientRuntimeForTest"` creates a client, swaps the SDK, creates the same client again, and verifies the constructor was called twice (not cached). Before the fix, the second createFeishuClient call would return the stale cached client.
- **What was not tested:** Production behavior — this function is test-only.
- **Proof limitations or environment constraints:** None — the function is only used in test code.

## Tests and validation

**Which commands did you run?**
```bash
node scripts/run-vitest.mjs run extensions/feishu/src/client.test.ts --reporter=verbose
# 17 passed (1 test file)
```

**What regression coverage was added or updated?**
Added `"evicts client cache when SDK is replaced via setFeishuClientRuntimeForTest"` — creates a client, swaps SDK, recreates same client, and asserts the constructor was called twice (proving the cache was cleared).

## Risk checklist

**Did user-visible behavior change?** No — this function is test-only.
**Did config, environment, or migration behavior change?** No
**Did security, auth, secrets, network, or tool execution behavior change?** No
**What is the highest-risk area?** None — `clearClientCache()` is idempotent and already used in the test suite.
**How is that risk mitigated?** 17 existing + new tests pass.

## Current review state

**What is the next action?** Maintainer review.
**What is still waiting on author, maintainer, CI, or external proof?** None.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Code <noreply@anthropic.com>
