### PR TITLE
fix: minSecurity order inverted — full should be least restrictive

### DIFF
--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -1528,7 +1528,7 @@ export function persistAllowAlwaysPatterns(params: {
 }
 
 export function minSecurity(a: ExecSecurity, b: ExecSecurity): ExecSecurity {
-  const order: Record<ExecSecurity, number> = { deny: 0, allowlist: 1, full: 2 };
+  const order: Record<ExecSecurity, number> = { full: 0, allowlist: 1, deny: 2 };
   return order[a] <= order[b] ? a : b;
 }
 


### PR DESCRIPTION
`minSecurity` was treating `"full"` as rank 2 (most restrictive) and `"deny"` as rank 0 (least restrictive), which is backwards.

When `resolveExecHostApprovalContext` computes:

```ts
const hostSecurity = minSecurity(params.security, approvals.agent.security);
```

a session-level `security="full"` override was being clamped to the agent's `"allowlist"` because `order["full"]` (2) > `order["allowlist"]` (1), so `minSecurity` would always return the more restrictive value.

Note that `execSecurityFloorRank` in the same file already uses the *correct* order (`full=0, allowlist=1, deny=2`). This aligns `minSecurity` with that.

**Impact:** Users with `exec.security="full"` in session overrides or `exec-approvals.json` would still get `allowlist` enforcement unless the agent config was also `"full"` — making per-session security overrides effectively broken.

**Fixes:** #58691, #59079
**Closes:** #91283