### PR TITLE
fix(codex): quarantine unreadable dynamic tool schemas

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-16202a4c1ba8816643ad4cc81536c6ff9bfea38b01826d090c2195230dc85ab3  plugin-sdk-api-baseline.json
-a674e0fc5998b343fd1235438794c9c342fcd6e538157650109d2d30c184b7bc  plugin-sdk-api-baseline.jsonl
+8be695e0892078773d78dae5f4c5a20ee57f30c5df227be6a89cc316fc4b4e10  plugin-sdk-api-baseline.json
+45944cb6fa30a094c4f104d19eec7afc5822be05c88bbd2aa4a8b93a7cba9de8  plugin-sdk-api-baseline.jsonl

--- a/extensions/codex/src/app-server/dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.test.ts
@@ -372,6 +372,35 @@ describe("createCodexDynamicToolBridge", () => {
     expect(badExecute).not.toHaveBeenCalled();
   });
 
+  it("quarantines unreadable dynamic tool schemas before bridge construction", () => {
+    const badExecute = vi.fn();
+    const badTool = createTool({
+      name: "dofbot_move_angles",
+      execute: badExecute,
+    });
+    Object.defineProperty(badTool, "parameters", {
+      enumerable: true,
+      get() {
+        throw new Error("dofbot schema getter exploded");
+      },
+    });
+
+    const bridge = createCodexDynamicToolBridge({
+      tools: [badTool, createTool({ name: "message" })],
+      signal: new AbortController().signal,
+    });
+
+    expect(bridge.availableSpecs.map((tool) => tool.name)).toEqual(["message"]);
+    expect(bridge.specs.map((tool) => tool.name)).toEqual(["message"]);
+    expect(bridge.telemetry.quarantinedTools).toEqual([
+      {
+        tool: "dofbot_move_angles",
+        violations: ["dofbot_move_angles.inputSchema is unreadable"],
+      },
+    ]);
+    expect(badExecute).not.toHaveBeenCalled();
+  });
+
   it("can expose all dynamic tools directly for compatibility", () => {
     const bridge = createCodexDynamicToolBridge({
       tools: [createTool({ name: "web_search" }), createTool({ name: "message" })],

--- a/extensions/codex/src/app-server/dynamic-tools.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.ts
@@ -15,7 +15,7 @@ import {
   isMessagingTool,
   isMessagingToolSendAction,
   normalizeHeartbeatToolResponse,
-  projectRuntimeToolInputSchema,
+  projectRuntimeCompatibleToolInputSchemas,
   runAgentHarnessAfterToolCallHook,
   setBeforeToolCallDiagnosticsEnabled,
   type AnyAgentTool,
@@ -322,17 +322,19 @@ function projectCodexDynamicTools(tools: readonly AnyAgentTool[]): {
   tools: ProjectedCodexDynamicTool[];
   quarantinedTools: CodexDynamicToolSchemaQuarantine[];
 } {
-  const projectedTools: ProjectedCodexDynamicTool[] = [];
-  const quarantinedTools: CodexDynamicToolSchemaQuarantine[] = [];
-  for (const tool of tools) {
-    const projection = projectRuntimeToolInputSchema(tool.parameters, `${tool.name}.inputSchema`);
-    if (projection.violations.length > 0) {
-      quarantinedTools.push({ tool: tool.name, violations: projection.violations });
-      continue;
-    }
-    projectedTools.push({ tool, inputSchema: projection.schema as JsonValue });
-  }
-  return { tools: projectedTools, quarantinedTools };
+  const projection = projectRuntimeCompatibleToolInputSchemas(tools, {
+    schemaLabel: "inputSchema",
+  });
+  return {
+    tools: projection.tools.map(({ tool, schema }) => ({
+      tool,
+      inputSchema: schema as JsonValue,
+    })),
+    quarantinedTools: projection.diagnostics.map((diagnostic) => ({
+      tool: diagnostic.toolName,
+      violations: diagnostic.violations,
+    })),
+  };
 }
 
 function warnQuarantinedDynamicTools(tools: readonly CodexDynamicToolSchemaQuarantine[]): void {

--- a/src/agents/tool-schema-projection.test.ts
+++ b/src/agents/tool-schema-projection.test.ts
@@ -5,6 +5,7 @@ import {
   filterProviderNormalizableTools,
   filterRuntimeCompatibleTools,
   inspectRuntimeToolInputSchemas,
+  projectRuntimeCompatibleToolInputSchemas,
   projectRuntimeToolInputSchema,
 } from "./tool-schema-projection.js";
 import type { AnyAgentTool } from "./tools/common.js";
@@ -161,6 +162,43 @@ describe("runtime tool input schema projection", () => {
           toolName: "fuzzplugin_unreadable",
           toolIndex: 0,
           violations: ["fuzzplugin_unreadable.parameters is unreadable"],
+        },
+      ],
+    });
+  });
+
+  it("projects compatible schemas while quarantining unreadable runtime fields", () => {
+    const unreadable = {
+      name: "fuzzplugin_unreadable",
+      parameters: { type: "object", properties: {} },
+    };
+    Object.defineProperty(unreadable, "parameters", {
+      enumerable: true,
+      get() {
+        throw new Error("fuzzplugin parameters getter exploded");
+      },
+    });
+    const healthy = {
+      name: "healthy",
+      parameters: { type: "object", properties: { query: { type: "string" } } },
+    };
+
+    expect(
+      projectRuntimeCompatibleToolInputSchemas([unreadable, healthy], {
+        schemaLabel: "inputSchema",
+      }),
+    ).toEqual({
+      tools: [
+        {
+          tool: healthy,
+          schema: { type: "object", properties: { query: { type: "string" } } },
+        },
+      ],
+      diagnostics: [
+        {
+          toolName: "fuzzplugin_unreadable",
+          toolIndex: 0,
+          violations: ["fuzzplugin_unreadable.inputSchema is unreadable"],
         },
       ],
     });

--- a/src/agents/tool-schema-projection.ts
+++ b/src/agents/tool-schema-projection.ts
@@ -20,6 +20,14 @@ export type RuntimeToolInputSchemaProjection = {
   readonly violations: readonly string[];
 };
 
+/** Runtime tool paired with its projected JSON-safe schema. */
+export type RuntimeToolInputSchemaProjectedTool<
+  TTool extends Pick<AnyAgentTool, "name" | "parameters">,
+> = {
+  readonly tool: TTool;
+  readonly schema: RuntimeToolInputSchemaJson;
+};
+
 /** Diagnostic for one incompatible runtime tool schema. */
 export type RuntimeToolSchemaDiagnostic = {
   readonly toolName: string;
@@ -30,6 +38,14 @@ export type RuntimeToolSchemaDiagnostic = {
 /** Runtime tool list split into compatible tools and schema diagnostics. */
 export type RuntimeToolSchemaInspection<TTool extends Pick<AnyAgentTool, "name" | "parameters">> = {
   readonly tools: readonly TTool[];
+  readonly diagnostics: readonly RuntimeToolSchemaDiagnostic[];
+};
+
+/** Runtime tool list split into projected compatible tools and schema diagnostics. */
+export type RuntimeToolInputSchemaProjectionInspection<
+  TTool extends Pick<AnyAgentTool, "name" | "parameters">,
+> = {
+  readonly tools: readonly RuntimeToolInputSchemaProjectedTool<TTool>[];
   readonly diagnostics: readonly RuntimeToolSchemaDiagnostic[];
 };
 
@@ -45,6 +61,10 @@ type RuntimeToolEntryRead<TTool extends Pick<AnyAgentTool, "name" | "parameters"
     };
 
 type ToolSchemaInspectionMode = "runtime" | "provider-normalizable";
+
+type RuntimeToolProjectionOptions = {
+  schemaLabel?: string;
+};
 
 function unreadableRuntimeToolEntry(
   toolIndex: number,
@@ -250,6 +270,50 @@ function inspectToolSchema(
   return violations.length > 0 ? { toolName, toolIndex, violations } : undefined;
 }
 
+function projectToolSchema<TTool extends Pick<AnyAgentTool, "name" | "parameters">>(
+  tool: TTool,
+  toolIndex: number,
+  options: RuntimeToolProjectionOptions,
+):
+  | { ok: true; tool: TTool; schema: RuntimeToolInputSchemaJson }
+  | { ok: false; diagnostic: RuntimeToolSchemaDiagnostic } {
+  const schemaLabel = options.schemaLabel ?? "parameters";
+  const nameRead = readToolProjectionField(tool, "name");
+  const toolName =
+    nameRead.readable && typeof nameRead.value === "string" && nameRead.value
+      ? nameRead.value
+      : `tool[${toolIndex}]`;
+  const descriptorViolations = nameRead.readable ? [] : [`${toolName}.name is unreadable`];
+  const parametersRead = readToolProjectionField(tool, "parameters");
+  if (!parametersRead.readable) {
+    return {
+      ok: false,
+      diagnostic: {
+        toolName,
+        toolIndex,
+        violations: [...descriptorViolations, `${toolName}.${schemaLabel} is unreadable`],
+      },
+    };
+  }
+
+  const projection = projectRuntimeToolInputSchema(
+    parametersRead.value,
+    `${toolName}.${schemaLabel}`,
+  );
+  const violations = [...descriptorViolations, ...projection.violations];
+  if (violations.length > 0) {
+    return {
+      ok: false,
+      diagnostic: {
+        toolName,
+        toolIndex,
+        violations,
+      },
+    };
+  }
+  return { ok: true, tool, schema: projection.schema };
+}
+
 function inspectToolEntries<TTool extends Pick<AnyAgentTool, "name" | "parameters">>(
   entries: readonly RuntimeToolEntryRead<TTool>[],
   mode: ToolSchemaInspectionMode,
@@ -283,6 +347,30 @@ export function filterRuntimeCompatibleTools<
   TTool extends Pick<AnyAgentTool, "name" | "parameters">,
 >(tools: readonly TTool[]): RuntimeToolSchemaInspection<TTool> {
   return inspectToolEntries(readRuntimeToolEntries(tools), "runtime");
+}
+
+/** Projects and filters tools to schemas accepted by runtime dynamic tool surfaces. */
+export function projectRuntimeCompatibleToolInputSchemas<
+  TTool extends Pick<AnyAgentTool, "name" | "parameters">,
+>(
+  tools: readonly TTool[],
+  options: RuntimeToolProjectionOptions = {},
+): RuntimeToolInputSchemaProjectionInspection<TTool> {
+  const diagnostics: RuntimeToolSchemaDiagnostic[] = [];
+  const projectedTools: RuntimeToolInputSchemaProjectedTool<TTool>[] = [];
+  for (const entry of readRuntimeToolEntries(tools)) {
+    if (!entry.ok) {
+      diagnostics.push(entry.diagnostic);
+      continue;
+    }
+    const projection = projectToolSchema(entry.tool, entry.toolIndex, options);
+    if (projection.ok) {
+      projectedTools.push({ tool: projection.tool, schema: projection.schema });
+      continue;
+    }
+    diagnostics.push(projection.diagnostic);
+  }
+  return { tools: projectedTools, diagnostics };
 }
 
 /** Filters tools to those that providers can normalize before dispatch. */

--- a/src/agents/tools-effective-inventory-build.ts
+++ b/src/agents/tools-effective-inventory-build.ts
@@ -105,12 +105,17 @@ function buildUnsupportedToolSchemaNotices(params: {
   diagnostics: readonly RuntimeToolSchemaDiagnostic[];
   tools: readonly AnyAgentTool[];
   rawToolsByName: ReadonlyMap<string, AnyAgentTool>;
+  fallbackToolsByIndex?: readonly AnyAgentTool[];
 }): EffectiveToolInventoryNotice[] {
   return params.diagnostics.map((diagnostic) =>
     buildUnsupportedToolSchemaNotice({
       diagnostic,
       tool: readMatchingTool(params.tools, diagnostic),
-      fallbackTool: params.rawToolsByName.get(diagnostic.toolName),
+      fallbackTool:
+        params.rawToolsByName.get(diagnostic.toolName) ??
+        (params.fallbackToolsByIndex
+          ? readToolByIndex(params.fallbackToolsByIndex, diagnostic.toolIndex)
+          : undefined),
     }),
   );
 }
@@ -122,6 +127,17 @@ function readMatchingTool(
   try {
     const tool = tools[diagnostic.toolIndex];
     return tool?.name === diagnostic.toolName ? tool : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function readToolByIndex(
+  tools: readonly AnyAgentTool[],
+  toolIndex: number,
+): AnyAgentTool | undefined {
+  try {
+    return tools[toolIndex];
   } catch {
     return undefined;
   }
@@ -223,9 +239,10 @@ export function buildRuntimeCompatibleToolInventory(params: {
 } {
   const rawToolsByName = buildReadableRawToolsByName(params.tools);
   const preNormalizationProjection = filterProviderNormalizableTools(params.tools);
-  const preNormalizationDiagnostics: RuntimeToolSchemaDiagnostic[] = [
+  const sourceProjectionDiagnostics: RuntimeToolSchemaDiagnostic[] = [
     ...preNormalizationProjection.diagnostics,
   ];
+  const normalizationDiagnostics: RuntimeToolSchemaDiagnostic[] = [];
   const normalizedTools = normalizeAgentRuntimeTools({
     // Schema normalization can replace tool definitions, so hand the runtime
     // policy a mutable copy while keeping this inventory API readonly.
@@ -237,17 +254,30 @@ export function buildRuntimeCompatibleToolInventory(params: {
     modelApi: params.modelApi ?? undefined,
     model: params.runtimeModel,
     onPreNormalizationSchemaDiagnostics: (diagnostics) =>
-      preNormalizationDiagnostics.push(...diagnostics),
+      normalizationDiagnostics.push(...diagnostics),
   });
   const projection = filterRuntimeCompatibleTools(normalizedTools);
-  const diagnostics = [...preNormalizationDiagnostics, ...projection.diagnostics];
   return {
     entries: buildEffectiveToolInventoryEntries(projection.tools, rawToolsByName),
-    notices: buildUnsupportedToolSchemaNotices({
-      diagnostics,
-      tools: normalizedTools,
-      rawToolsByName,
-    }),
+    notices: [
+      ...buildUnsupportedToolSchemaNotices({
+        diagnostics: sourceProjectionDiagnostics,
+        tools: params.tools,
+        rawToolsByName,
+        fallbackToolsByIndex: params.tools,
+      }),
+      ...buildUnsupportedToolSchemaNotices({
+        diagnostics: normalizationDiagnostics,
+        tools: preNormalizationProjection.tools,
+        rawToolsByName,
+        fallbackToolsByIndex: preNormalizationProjection.tools,
+      }),
+      ...buildUnsupportedToolSchemaNotices({
+        diagnostics: projection.diagnostics,
+        tools: normalizedTools,
+        rawToolsByName,
+      }),
+    ],
   };
 }
 

--- a/src/agents/tools-effective-inventory.test.ts
+++ b/src/agents/tools-effective-inventory.test.ts
@@ -30,6 +30,7 @@ const effectiveInventoryState = vi.hoisted(() => ({
     mockTool({ name: "docs_lookup", label: "Docs Lookup", description: "Search docs" }),
   ] as AnyAgentTool[],
   pluginMeta: {} as Record<string, { pluginId: string } | undefined>,
+  pluginMetaByTool: new WeakMap<object, { pluginId: string }>(),
   channelMeta: {} as Record<string, { channelId: string } | undefined>,
   effectivePolicy: {} as { profile?: string; providerProfile?: string },
   normalizeToolsMock: vi.fn((options: { tools: AnyAgentTool[] }) => options.tools),
@@ -61,7 +62,9 @@ vi.mock("./agent-tools.js", () => ({
 }));
 
 vi.mock("../plugins/tools.js", () => ({
-  getPluginToolMeta: (tool: { name: string }) => effectiveInventoryState.pluginMeta[tool.name],
+  getPluginToolMeta: (tool: { name: string }) =>
+    effectiveInventoryState.pluginMetaByTool.get(tool) ??
+    effectiveInventoryState.pluginMeta[tool.name],
   buildPluginToolMetadataKey: (pluginId: string, toolName: string) =>
     JSON.stringify([pluginId, toolName]),
 }));
@@ -115,6 +118,7 @@ async function loadHarness(options?: {
   tools?: AnyAgentTool[];
   createToolsMock?: typeof effectiveInventoryState.createToolsMock;
   pluginMeta?: Record<string, { pluginId: string } | undefined>;
+  pluginMetaByTool?: WeakMap<object, { pluginId: string }>;
   channelMeta?: Record<string, { channelId: string } | undefined>;
   effectivePolicy?: { profile?: string; providerProfile?: string };
   normalizeToolsMock?: typeof effectiveInventoryState.normalizeToolsMock;
@@ -124,6 +128,7 @@ async function loadHarness(options?: {
     mockTool({ name: "docs_lookup", label: "Docs Lookup", description: "Search docs" }),
   ];
   effectiveInventoryState.pluginMeta = options?.pluginMeta ?? {};
+  effectiveInventoryState.pluginMetaByTool = options?.pluginMetaByTool ?? new WeakMap();
   effectiveInventoryState.channelMeta = options?.channelMeta ?? {};
   effectiveInventoryState.effectivePolicy = options?.effectivePolicy ?? {};
   effectiveInventoryState.normalizeToolsMock =
@@ -151,6 +156,7 @@ describe("resolveEffectiveToolInventory", () => {
       mockTool({ name: "docs_lookup", label: "Docs Lookup", description: "Search docs" }),
     ];
     effectiveInventoryState.pluginMeta = {};
+    effectiveInventoryState.pluginMetaByTool = new WeakMap();
     effectiveInventoryState.channelMeta = {};
     effectiveInventoryState.effectivePolicy = {};
     effectiveInventoryState.normalizeToolsMock = vi.fn((options) => options.tools);
@@ -376,6 +382,43 @@ describe("resolveEffectiveToolInventory", () => {
         severity: "warning",
         message:
           'Tool "fuzzplugin_move_angles" from plugin "fuzzplugin" has an unsupported runtime input schema (fuzzplugin_move_angles.parameters.type must be "object") and was quarantined before model projection. Fix or disable the owner, or remove the tool from active allowlists.',
+      },
+    ]);
+  });
+
+  it("preserves plugin ownership for unreadable pre-normalization tool names", async () => {
+    const unreadable = mockTool({
+      name: "fuzzplugin_move_angles",
+      label: "Fuzzplugin Move Angles",
+      description: "Move fixture joints",
+    });
+    Object.defineProperty(unreadable, "name", {
+      enumerable: true,
+      get() {
+        throw new Error("fuzzplugin name getter exploded");
+      },
+    });
+    const pluginMetaByTool = new WeakMap<object, { pluginId: string }>([
+      [unreadable, { pluginId: "fuzzplugin" }],
+    ]);
+    const { resolveEffectiveToolInventory: resolveEffectiveToolInventoryLocal14 } =
+      await loadHarness({
+        tools: [
+          unreadable,
+          mockTool({ name: "exec", label: "Exec", description: "Run shell commands" }),
+        ],
+        pluginMetaByTool,
+      });
+
+    const result = resolveEffectiveToolInventoryLocal14({ cfg: {} });
+
+    expect(result.groups.flatMap((group) => group.tools.map((tool) => tool.id))).toEqual(["exec"]);
+    expect(result.notices).toEqual([
+      {
+        id: "unsupported-tool-schema:tool[0]",
+        severity: "warning",
+        message:
+          'Tool "tool[0]" from plugin "fuzzplugin" has an unsupported runtime input schema (tool[0].name is unreadable) and was quarantined before model projection. Fix or disable the owner, or remove the tool from active allowlists.',
       },
     ]);
   });

--- a/src/commands/doctor/shared/active-tool-schema-warnings.test.ts
+++ b/src/commands/doctor/shared/active-tool-schema-warnings.test.ts
@@ -6,6 +6,7 @@ import type { AnyAgentTool } from "../../../agents/tools/common.js";
 const toolState = vi.hoisted(() => ({
   tools: [] as AnyAgentTool[],
   pluginIds: {} as Record<string, string | undefined>,
+  pluginIdsByTool: new WeakMap<object, string>(),
   throwError: null as Error | null,
   runtimeModel: null as {
     id: string;
@@ -19,7 +20,12 @@ const toolState = vi.hoisted(() => ({
   resolveModel: vi.fn(),
   createTools: vi.fn<typeof createOpenClawCodingTools>(),
   normalizeTools: vi.fn(
-    (options: { tools: AnyAgentTool[]; modelApi?: string; model?: unknown }) => options.tools,
+    (options: {
+      tools: AnyAgentTool[];
+      modelApi?: string;
+      model?: unknown;
+      onPreNormalizationSchemaDiagnostics?: (diagnostics: unknown[], tools: AnyAgentTool[]) => void;
+    }) => options.tools,
   ),
 }));
 
@@ -39,7 +45,8 @@ vi.mock("../../../agents/agent-tools.js", () => ({
 
 vi.mock("../../../plugins/tools.js", () => ({
   getPluginToolMeta: (toolLocal: { name: string }) => {
-    const pluginId = toolState.pluginIds[toolLocal.name];
+    const pluginId =
+      toolState.pluginIdsByTool.get(toolLocal) ?? toolState.pluginIds[toolLocal.name];
     return pluginId ? { pluginId, optional: false } : undefined;
   },
 }));
@@ -66,6 +73,7 @@ describe("active tool schema doctor warnings", () => {
   beforeEach(() => {
     toolState.tools = [];
     toolState.pluginIds = {};
+    toolState.pluginIdsByTool = new WeakMap();
     toolState.throwError = null;
     toolState.runtimeModel = null;
     toolState.resolveModelError = null;
@@ -133,6 +141,50 @@ describe("active tool schema doctor warnings", () => {
       }),
     ).toEqual([
       '- agents.main: active tool "tool[0]" has unsupported runtime input schema (tool[0] is unreadable). OpenClaw will quarantine this tool at runtime; fix or disable the plugin, or remove the tool from active allowlists.',
+    ]);
+  });
+
+  it("preserves plugin ownership for pre-normalization tools with unreadable names", () => {
+    const unreadable = tool("fuzzplugin_move_angles", {
+      type: "object",
+      properties: {},
+    });
+    Object.defineProperty(unreadable, "name", {
+      enumerable: true,
+      get() {
+        throw new Error("fuzzplugin name getter exploded");
+      },
+    });
+    const healthy = tool("message", { type: "object", properties: {} });
+    toolState.tools = [unreadable, healthy];
+    toolState.pluginIdsByTool.set(unreadable, "fuzzplugin");
+    toolState.normalizeTools.mockImplementation((options) => {
+      options.onPreNormalizationSchemaDiagnostics?.(
+        [
+          {
+            toolName: "tool[0]",
+            toolIndex: 0,
+            violations: ["tool[0].name is unreadable"],
+          },
+        ],
+        options.tools,
+      );
+      return [healthy];
+    });
+
+    expect(
+      collectActiveToolSchemaProjectionWarnings({
+        cfg: {
+          plugins: {
+            entries: {
+              fuzzplugin: { enabled: true },
+            },
+          },
+        },
+        env: { HOME: "/tmp/openclaw-test" },
+      }),
+    ).toEqual([
+      '- agents.main: active tool "tool[0]" from plugin "fuzzplugin" has unsupported runtime input schema (tool[0].name is unreadable). OpenClaw will quarantine this tool at runtime; fix or disable the plugin, or remove the tool from active allowlists.',
     ]);
   });
 

--- a/src/commands/doctor/shared/active-tool-schema-warnings.ts
+++ b/src/commands/doctor/shared/active-tool-schema-warnings.ts
@@ -115,6 +115,17 @@ function readPluginId(tool: AnyAgentTool | undefined): string | undefined {
   }
 }
 
+function resolveDiagnosticPluginId(params: {
+  tools: readonly AnyAgentTool[];
+  rawToolsByName: ReadonlyMap<string, AnyAgentTool>;
+  diagnostic: RuntimeToolSchemaDiagnostic;
+}): string | undefined {
+  return (
+    readPluginId(readToolByIndex(params.tools, params.diagnostic.toolIndex)) ??
+    readPluginId(params.rawToolsByName.get(params.diagnostic.toolName))
+  );
+}
+
 /** Collect per-agent warnings for active plugin tools rejected by runtime schema projection. */
 export function collectActiveToolSchemaProjectionWarnings(params: {
   cfg: OpenClawConfig;
@@ -172,7 +183,10 @@ export function collectActiveToolSchemaProjectionWarnings(params: {
     }
 
     const rawToolsByName = buildReadableToolsByName(tools);
-    const preNormalizationDiagnostics: RuntimeToolSchemaDiagnostic[] = [];
+    const preNormalizationDiagnostics: {
+      diagnostic: RuntimeToolSchemaDiagnostic;
+      sourceTools: readonly AnyAgentTool[];
+    }[] = [];
     let normalizedTools: typeof tools;
     try {
       normalizedTools = normalizeAgentRuntimeTools({
@@ -184,8 +198,11 @@ export function collectActiveToolSchemaProjectionWarnings(params: {
         modelId: modelRef.model,
         modelApi: runtimeModelContext.modelApi,
         model: runtimeModelContext.model,
-        onPreNormalizationSchemaDiagnostics: (diagnostics) =>
-          preNormalizationDiagnostics.push(...diagnostics),
+        onPreNormalizationSchemaDiagnostics: (diagnostics, sourceTools) => {
+          for (const diagnostic of diagnostics) {
+            preNormalizationDiagnostics.push({ diagnostic, sourceTools });
+          }
+        },
       });
     } catch (error) {
       warnings.push(
@@ -195,9 +212,12 @@ export function collectActiveToolSchemaProjectionWarnings(params: {
       );
       continue;
     }
-    for (const diagnostic of preNormalizationDiagnostics) {
-      const rawTool = rawToolsByName.get(diagnostic.toolName);
-      const pluginId = readPluginId(rawTool);
+    for (const { diagnostic, sourceTools } of preNormalizationDiagnostics) {
+      const pluginId = resolveDiagnosticPluginId({
+        tools: sourceTools,
+        rawToolsByName,
+        diagnostic,
+      });
       warnings.push(
         formatDiagnostic({
           agentId,
@@ -208,9 +228,11 @@ export function collectActiveToolSchemaProjectionWarnings(params: {
     }
     const projection = filterRuntimeCompatibleTools(normalizedTools);
     for (const diagnostic of projection.diagnostics) {
-      const tool = readToolByIndex(normalizedTools, diagnostic.toolIndex);
-      const rawTool = rawToolsByName.get(diagnostic.toolName);
-      const pluginId = readPluginId(tool) ?? readPluginId(rawTool);
+      const pluginId = resolveDiagnosticPluginId({
+        tools: normalizedTools,
+        rawToolsByName,
+        diagnostic,
+      });
       warnings.push(
         formatDiagnostic({
           agentId,

--- a/src/plugin-sdk/agent-harness-runtime.ts
+++ b/src/plugin-sdk/agent-harness-runtime.ts
@@ -178,8 +178,11 @@ export {
 export {
   filterProviderNormalizableTools,
   inspectRuntimeToolInputSchemas,
+  projectRuntimeCompatibleToolInputSchemas,
   projectRuntimeToolInputSchema,
   type RuntimeToolInputSchemaJson,
+  type RuntimeToolInputSchemaProjectedTool,
+  type RuntimeToolInputSchemaProjectionInspection,
   type RuntimeToolInputSchemaProjection,
   type RuntimeToolSchemaDiagnostic,
 } from "../agents/tool-schema-projection.js";


### PR DESCRIPTION
Summary
- Quarantines Codex dynamic tools whose input schemas cannot be safely normalized before they reach the Codex app-server bridge.
- Preserves plugin/owner attribution for tool-schema quarantine diagnostics so `openclaw doctor` can point at the owning source instead of losing context.
- Cherry-picked from the superseded large split stack in https://github.com/openclaw/openclaw/pull/90411: `6d7a1b8d0ec7` and `27ef8763e733`.

Codex contract checked
- `openai-codex` Python protocol types expose dynamic tool `inputSchema` as unconstrained schema data (`sdk/python/src/openai_codex/generated/v2_all.py:807`).
- Codex Rust protocol stores dynamic tool schemas as JSON values (`codex-rs/protocol/src/dynamic_tools.rs:8`).
- Codex app-server validates dynamic tool schemas before conversion and rejects unsupported schemas with a tool-specific error (`codex-rs/app-server/src/request_processors/thread_processor.rs:316`).
- Codex has coverage for rejecting unsupported dynamic tool schemas (`codex-rs/app-server/src/request_processors/thread_processor_tests.rs:91`).

Verification
- `node scripts/run-vitest.mjs run extensions/codex/src/app-server/dynamic-tools.test.ts src/agents/tool-schema-projection.test.ts src/agents/tools-effective-inventory.test.ts src/commands/doctor/shared/active-tool-schema-warnings.test.ts --reporter=dot`
- `node --max-old-space-size=8192 --import tsx scripts/generate-plugin-sdk-api-baseline.ts --check`
- `./node_modules/.bin/oxfmt --check docs/.generated/plugin-sdk-api-baseline.sha256 extensions/codex/src/app-server/dynamic-tools.test.ts extensions/codex/src/app-server/dynamic-tools.ts src/agents/tool-schema-projection.test.ts src/agents/tool-schema-projection.ts src/agents/tools-effective-inventory-build.ts src/agents/tools-effective-inventory.test.ts src/commands/doctor/shared/active-tool-schema-warnings.test.ts src/commands/doctor/shared/active-tool-schema-warnings.ts src/plugin-sdk/agent-harness-runtime.ts`
- `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/agents/tool-schema-projection.test.ts src/agents/tool-schema-projection.ts src/agents/tools-effective-inventory-build.ts src/agents/tools-effective-inventory.test.ts src/commands/doctor/shared/active-tool-schema-warnings.test.ts src/commands/doctor/shared/active-tool-schema-warnings.ts src/plugin-sdk/agent-harness-runtime.ts`
- `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-bundled-extension-oxlint.mjs extensions/codex/src/app-server/dynamic-tools.test.ts extensions/codex/src/app-server/dynamic-tools.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

Behavior addressed
- Dynamic Codex tools with unreadable or unsupported schema shapes are skipped/quarantined by OpenClaw instead of being allowed to crash or fail later in the Codex app-server path.

Real environment tested
- macOS linked OpenClaw worktree with shared install and focused Vitest/lint/format checks.

Exact steps or command run after this patch
- Ran the focused commands listed in Verification after cherry-picking and resolving the SDK baseline conflict.

Evidence after fix
- 77 focused tests passed across Codex app-server dynamic tools, agent schema projection, effective inventory, and doctor warning ownership.
- SDK API baseline check passed.
- Focused format, core oxlint, bundled extension oxlint, and autoreview passed.

Observed result after fix
- Invalid dynamic tool schemas are quarantined with retained owner/source context, and the Codex bridge keeps building valid dynamic tools.

What was not tested
- Broad `pnpm check:changed` was not run locally because this is a linked/sparse worktree; PR CI should cover the wider gate.
