### PR TITLE
fix(plugins): stabilize plugin tool schemas

### DIFF
--- a/src/mcp/plugin-tools-handlers.test.ts
+++ b/src/mcp/plugin-tools-handlers.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AnyAgentTool } from "../agents/tools/common.js";
+import { createPluginToolsMcpHandlers } from "./plugin-tools-handlers.js";
+
+function createToolWithUnreadableField(field: "name" | "parameters") {
+  const tool = {
+    name: "poisoned_tool",
+    description: "Poisoned tool",
+    parameters: { type: "object", properties: {} },
+    execute: vi.fn(),
+  };
+  Object.defineProperty(tool, field, {
+    enumerable: true,
+    get() {
+      throw new Error(`${field} revoked`);
+    },
+  });
+  return tool as never;
+}
+
+function createToolWithPoisonedExecuteBind() {
+  const execute = vi.fn().mockResolvedValue({ content: "Poisoned execute still callable." });
+  Object.defineProperty(execute, "bind", {
+    get() {
+      throw new Error("bind revoked");
+    },
+  });
+  return {
+    name: "poisoned_bind",
+    description: "Poisoned bind",
+    parameters: { type: "object", properties: {} },
+    execute,
+  } as unknown as AnyAgentTool;
+}
+
+describe("createPluginToolsMcpHandlers", () => {
+  it("isolates unreadable plugin tool metadata on the MCP bridge", async () => {
+    const execute = vi.fn().mockResolvedValue({ content: "Stored." });
+    const healthyTool = {
+      name: "memory_recall",
+      description: "Recall stored memory",
+      parameters: {
+        type: "object",
+        properties: {
+          query: { type: "string" },
+        },
+      },
+      execute,
+    } as unknown as AnyAgentTool;
+
+    const handlers = createPluginToolsMcpHandlers([
+      createToolWithUnreadableField("parameters"),
+      healthyTool,
+    ]);
+
+    await expect(handlers.listTools()).resolves.toEqual({
+      tools: [
+        {
+          name: "memory_recall",
+          description: "Recall stored memory",
+          inputSchema: {
+            type: "object",
+            properties: {
+              query: { type: "string" },
+            },
+          },
+        },
+      ],
+    });
+
+    const result = await handlers.callTool({
+      name: "memory_recall",
+      arguments: { query: "remember this" },
+    });
+    expect(execute).toHaveBeenCalledOnce();
+    expect(result.content).toEqual([{ type: "text", text: "Stored." }]);
+  });
+
+  it("does not read plugin execute bind while snapshotting MCP tools", async () => {
+    const handlers = createPluginToolsMcpHandlers([createToolWithPoisonedExecuteBind()]);
+
+    await expect(handlers.listTools()).resolves.toEqual({
+      tools: [
+        {
+          name: "poisoned_bind",
+          description: "Poisoned bind",
+          inputSchema: { type: "object", properties: {} },
+        },
+      ],
+    });
+    await expect(
+      handlers.callTool({
+        name: "poisoned_bind",
+        arguments: {},
+      }),
+    ).resolves.toEqual({
+      content: [{ type: "text", text: "Poisoned execute still callable." }],
+    });
+  });
+});

--- a/src/mcp/plugin-tools-handlers.ts
+++ b/src/mcp/plugin-tools-handlers.ts
@@ -4,8 +4,10 @@ import {
   rewrapToolWithBeforeToolCallHook,
   wrapToolWithBeforeToolCallHook,
 } from "../agents/agent-tools.before-tool-call.js";
+import { copyChannelAgentToolMeta } from "../agents/channel-tools.js";
 import type { AnyAgentTool } from "../agents/tools/common.js";
 import { formatErrorMessage } from "../infra/errors.js";
+import { copyPluginToolMeta } from "../plugins/tool-metadata.js";
 import { coerceChatContentText } from "../shared/chat-content.js";
 
 type CallPluginToolParams = {
@@ -21,14 +23,132 @@ function resolveJsonSchemaForTool(tool: AnyAgentTool): Record<string, unknown> {
   return { type: "object", properties: {} };
 }
 
-export function createPluginToolsMcpHandlers(tools: AnyAgentTool[]) {
-  const wrappedTools = tools.map((tool) => {
+function snapshotMcpPluginTool(tool: AnyAgentTool): AnyAgentTool | undefined {
+  let name: unknown;
+  let description: unknown;
+  let parameters: unknown;
+  let execute: unknown;
+  try {
+    name = tool.name;
+    description = tool.description;
+    parameters = tool.parameters;
+    execute = tool.execute;
+  } catch {
+    return undefined;
+  }
+  if (typeof name !== "string" || !name.trim() || typeof execute !== "function") {
+    return undefined;
+  }
+
+  let prototype: object | null;
+  try {
+    prototype = Reflect.getPrototypeOf(tool);
+  } catch {
+    return undefined;
+  }
+  const descriptors = copyReadableMcpPluginToolDescriptors(tool);
+  if (!descriptors) {
+    return undefined;
+  }
+  descriptors.name = {
+    configurable: true,
+    enumerable: true,
+    value: name.trim(),
+    writable: true,
+  };
+  descriptors.description = {
+    configurable: true,
+    enumerable: true,
+    value: typeof description === "string" ? description : "",
+    writable: true,
+  };
+  descriptors.parameters = {
+    configurable: true,
+    enumerable: true,
+    value: parameters,
+    writable: true,
+  };
+  descriptors.execute = {
+    configurable: true,
+    enumerable: true,
+    value: (...args: Parameters<AnyAgentTool["execute"]>) =>
+      Reflect.apply(execute, tool, args) as ReturnType<AnyAgentTool["execute"]>,
+    writable: true,
+  };
+
+  const snapshot = Object.create(prototype) as AnyAgentTool;
+  Object.defineProperties(snapshot, descriptors);
+  copyPluginToolMeta(tool, snapshot);
+  copyChannelAgentToolMeta(tool as never, snapshot as never);
+  return snapshot;
+}
+
+function copyReadableMcpPluginToolDescriptors(
+  tool: AnyAgentTool,
+): PropertyDescriptorMap | undefined {
+  let keys: PropertyKey[];
+  try {
+    keys = Reflect.ownKeys(tool);
+  } catch {
+    return undefined;
+  }
+
+  const descriptors: PropertyDescriptorMap = {};
+  for (const key of keys) {
+    if (key === "name" || key === "description" || key === "parameters" || key === "execute") {
+      continue;
+    }
+    let descriptor: PropertyDescriptor | undefined;
+    try {
+      descriptor = Reflect.getOwnPropertyDescriptor(tool, key);
+    } catch {
+      return undefined;
+    }
+    if (!descriptor) {
+      continue;
+    }
+    if ("value" in descriptor) {
+      descriptors[key] = {
+        configurable: true,
+        enumerable: descriptor.enumerable,
+        value: descriptor.value,
+        writable: true,
+      };
+      continue;
+    }
+    try {
+      descriptors[key] = {
+        configurable: true,
+        enumerable: descriptor.enumerable,
+        value: Reflect.get(tool, key, tool),
+        writable: true,
+      };
+    } catch {
+      continue;
+    }
+  }
+  return descriptors;
+}
+
+function wrapPluginToolForMcp(tool: AnyAgentTool): AnyAgentTool | undefined {
+  try {
     if (isToolWrappedWithBeforeToolCallHook(tool)) {
       return rewrapToolWithBeforeToolCallHook(tool, undefined, { approvalMode: "report" });
     }
-    // The ACPX MCP bridge should enforce the same pre-execution hook boundary
-    // as the agent and HTTP tool execution paths.
-    return wrapToolWithBeforeToolCallHook(tool, undefined, { approvalMode: "report" });
+  } catch {
+    return undefined;
+  }
+  const snapshot = snapshotMcpPluginTool(tool);
+  if (!snapshot) {
+    return undefined;
+  }
+  return wrapToolWithBeforeToolCallHook(snapshot, undefined, { approvalMode: "report" });
+}
+
+export function createPluginToolsMcpHandlers(tools: AnyAgentTool[]) {
+  const wrappedTools = tools.flatMap((tool) => {
+    const wrapped = wrapPluginToolForMcp(tool);
+    return wrapped ? [wrapped] : [];
   });
   const toolMap = new Map<string, AnyAgentTool>();
   for (const tool of wrappedTools) {

--- a/src/plugin-sdk/provider-tools.test.ts
+++ b/src/plugin-sdk/provider-tools.test.ts
@@ -12,6 +12,26 @@ import {
 } from "./provider-tools.js";
 
 describe("buildProviderToolCompatFamilyHooks", () => {
+  function createToolWithUnreadableField(field: "name" | "parameters") {
+    const tool = {
+      name: "revoked_tool",
+      description: "",
+      parameters: {
+        type: "object",
+        properties: {
+          mode: { anyOf: [{ type: "string" }, { type: "number" }] },
+        },
+      },
+    };
+    Object.defineProperty(tool, field, {
+      enumerable: true,
+      get() {
+        throw new Error(`${field} revoked`);
+      },
+    });
+    return tool as never;
+  }
+
   function normalizeOpenAIParameters(parameters: unknown): unknown {
     const hooks = buildProviderToolCompatFamilyHooks("openai");
     const tools = [{ name: "demo", description: "", parameters }] as never;
@@ -143,6 +163,108 @@ describe("buildProviderToolCompatFamilyHooks", () => {
         tools: normalized,
       }),
     ).toStrictEqual([]);
+  });
+
+  it("isolates unreadable provider tool schemas during normalize hooks", () => {
+    const hooks = buildProviderToolCompatFamilyHooks("deepseek");
+    const healthyTool = {
+      name: "healthy_tool",
+      description: "",
+      displaySummary: "healthy summary",
+      parameters: {
+        type: "object",
+        properties: {
+          mode: { anyOf: [{ type: "string" }, { type: "number" }] },
+        },
+      },
+      async execute() {
+        return "ok";
+      },
+    };
+
+    const normalized = hooks.normalizeToolSchemas({
+      provider: "deepseek",
+      modelId: "deepseek-v4-pro",
+      modelApi: "openai-completions",
+      model: {
+        provider: "deepseek",
+        api: "openai-completions",
+        id: "deepseek-v4-pro",
+      } as never,
+      tools: [createToolWithUnreadableField("parameters"), healthyTool] as never,
+    });
+
+    expect(normalized.map((tool) => tool.name)).toEqual(["healthy_tool"]);
+    expect(normalized[0]?.parameters).toEqual({
+      type: "object",
+      properties: {
+        mode: { type: "string" },
+      },
+    });
+    expect(Object.keys(normalized[0] as object)).toEqual([
+      "description",
+      "displaySummary",
+      "execute",
+      "name",
+      "parameters",
+    ]);
+    expect({ ...normalized[0] }).toMatchObject({
+      name: "healthy_tool",
+      description: "",
+      displaySummary: "healthy summary",
+      parameters: {
+        type: "object",
+        properties: {
+          mode: { type: "string" },
+        },
+      },
+    });
+    expect(typeof normalized[0]?.execute).toBe("function");
+  });
+
+  it("reports unreadable provider tool schema metadata during inspect hooks", () => {
+    const hooks = buildProviderToolCompatFamilyHooks("gemini");
+
+    const diagnostics = hooks.inspectToolSchemas({
+      provider: "google",
+      modelId: "gemini-3-pro",
+      modelApi: "google",
+      model: {
+        provider: "google",
+        api: "google",
+        id: "gemini-3-pro",
+      } as never,
+      tools: [
+        createToolWithUnreadableField("name"),
+        createToolWithUnreadableField("parameters"),
+        {
+          name: "healthy_tool",
+          description: "",
+          parameters: {
+            type: "object",
+            properties: { count: { type: "integer", minimum: 1 } },
+          },
+        },
+      ] as never,
+    });
+
+    expect(diagnostics).toEqual([
+      {
+        toolName: "tool[0]",
+        toolIndex: 0,
+        violations: ["tool.name is unreadable"],
+      },
+      {
+        toolName: "revoked_tool",
+        toolIndex: 1,
+        violations: ["revoked_tool.parameters is unreadable"],
+      },
+      {
+        toolName: "healthy_tool",
+        toolIndex: 2,
+        violations: ["healthy_tool.parameters.properties.count.minimum"],
+      },
+    ]);
   });
 
   it("preserves string-const unions as a flat enum for the deepseek family", () => {

--- a/src/plugin-sdk/provider-tools.ts
+++ b/src/plugin-sdk/provider-tools.ts
@@ -13,6 +13,142 @@ import type {
 
 export { cleanSchemaForGemini, GEMINI_UNSUPPORTED_SCHEMA_KEYWORDS, stripUnsupportedSchemaKeywords };
 
+type ReadProviderToolSnapshot =
+  | { tool: AnyAgentTool; name: string; parameters: unknown; diagnostic?: undefined }
+  | {
+      diagnostic: ProviderToolSchemaDiagnostic;
+      tool?: undefined;
+      name?: undefined;
+      parameters?: undefined;
+    };
+
+function readProviderToolSnapshot(tool: AnyAgentTool, toolIndex: number): ReadProviderToolSnapshot {
+  let name: string;
+  try {
+    name =
+      typeof tool.name === "string" && tool.name.trim() ? tool.name.trim() : `tool[${toolIndex}]`;
+  } catch {
+    return {
+      diagnostic: {
+        toolName: `tool[${toolIndex}]`,
+        toolIndex,
+        violations: ["tool.name is unreadable"],
+      },
+    };
+  }
+
+  let parameters: unknown;
+  try {
+    parameters = tool.parameters;
+  } catch {
+    return {
+      diagnostic: {
+        toolName: name,
+        toolIndex,
+        violations: [`${name}.parameters is unreadable`],
+      },
+    };
+  }
+
+  return { tool, name, parameters };
+}
+
+function withProviderToolParameters(
+  snapshot: Extract<ReadProviderToolSnapshot, { tool: AnyAgentTool }>,
+  parameters: TSchema,
+): AnyAgentTool | undefined {
+  let prototype: object | null;
+  try {
+    prototype = Reflect.getPrototypeOf(snapshot.tool);
+  } catch {
+    return undefined;
+  }
+
+  const descriptors = copyReadableProviderToolDescriptors(snapshot.tool);
+  if (!descriptors) {
+    return undefined;
+  }
+  descriptors.name = {
+    configurable: true,
+    enumerable: true,
+    value: snapshot.name,
+    writable: true,
+  };
+  descriptors.parameters = {
+    configurable: true,
+    enumerable: true,
+    value: parameters,
+    writable: true,
+  };
+
+  const stable = Object.create(prototype) as AnyAgentTool;
+  Object.defineProperties(stable, descriptors);
+  return new Proxy(stable, {
+    get(target, prop, receiver) {
+      if (Reflect.has(target, prop)) {
+        return Reflect.get(target, prop, receiver);
+      }
+      const value = Reflect.get(snapshot.tool, prop, snapshot.tool);
+      return typeof value === "function"
+        ? (...args: unknown[]) => Reflect.apply(value, snapshot.tool, args)
+        : value;
+    },
+  });
+}
+
+function copyReadableProviderToolDescriptors(
+  tool: AnyAgentTool,
+): PropertyDescriptorMap | undefined {
+  let keys: PropertyKey[];
+  try {
+    keys = Reflect.ownKeys(tool);
+  } catch {
+    return undefined;
+  }
+
+  const descriptors: PropertyDescriptorMap = {};
+  for (const key of keys) {
+    if (key === "name" || key === "parameters") {
+      continue;
+    }
+    let descriptor: PropertyDescriptor | undefined;
+    try {
+      descriptor = Reflect.getOwnPropertyDescriptor(tool, key);
+    } catch {
+      return undefined;
+    }
+    if (!descriptor) {
+      continue;
+    }
+    descriptors[key] =
+      "value" in descriptor
+        ? {
+            configurable: true,
+            enumerable: descriptor.enumerable,
+            value: descriptor.value,
+            writable: true,
+          }
+        : {
+            configurable: true,
+            enumerable: descriptor.enumerable,
+            get: descriptor.get ? () => Reflect.get(tool, key, tool) : undefined,
+            set: descriptor.set ? (value) => Reflect.set(tool, key, value, tool) : undefined,
+          };
+  }
+  return descriptors;
+}
+
+function pushToolWithProviderParameters(
+  tools: AnyAgentTool[],
+  snapshot: Extract<ReadProviderToolSnapshot, { tool: AnyAgentTool }>,
+  parameters: TSchema,
+): void {
+  const tool = withProviderToolParameters(snapshot, parameters);
+  if (tool) {
+    tools.push(tool);
+  }
+}
+
 /**
  * Finds unsupported JSON-schema keywords and reports their nested schema paths.
  */
@@ -68,15 +204,19 @@ export function normalizeGeminiToolSchemas(
   /** Provider tool-schema normalization context containing the active tool list. */
   ctx: ProviderNormalizeToolSchemasContext,
 ): AnyAgentTool[] {
-  return ctx.tools.map((tool) => {
-    if (!tool.parameters || typeof tool.parameters !== "object") {
-      return tool;
+  const tools: AnyAgentTool[] = [];
+  for (const [toolIndex, tool] of ctx.tools.entries()) {
+    const snapshot = readProviderToolSnapshot(tool, toolIndex);
+    if (snapshot.diagnostic) {
+      continue;
     }
-    return {
-      ...tool,
-      parameters: cleanSchemaForGemini(tool.parameters),
-    };
-  });
+    if (!snapshot.parameters || typeof snapshot.parameters !== "object") {
+      tools.push(tool);
+      continue;
+    }
+    pushToolWithProviderParameters(tools, snapshot, cleanSchemaForGemini(snapshot.parameters));
+  }
+  return tools;
 }
 
 /**
@@ -87,15 +227,19 @@ export function inspectGeminiToolSchemas(
   ctx: ProviderNormalizeToolSchemasContext,
 ): ProviderToolSchemaDiagnostic[] {
   return ctx.tools.flatMap((tool, toolIndex) => {
+    const snapshot = readProviderToolSnapshot(tool, toolIndex);
+    if (snapshot.diagnostic) {
+      return [snapshot.diagnostic];
+    }
     const violations = findUnsupportedSchemaKeywords(
-      tool.parameters,
-      `${tool.name}.parameters`,
+      snapshot.parameters,
+      `${snapshot.name}.parameters`,
       GEMINI_UNSUPPORTED_SCHEMA_KEYWORDS,
     );
     if (violations.length === 0) {
       return [];
     }
-    return [{ toolName: tool.name, toolIndex, violations }];
+    return [{ toolName: snapshot.name, toolIndex, violations }];
   });
 }
 
@@ -109,21 +253,27 @@ export function normalizeOpenAIToolSchemas(
   if (!shouldApplyOpenAIToolCompat(ctx)) {
     return ctx.tools;
   }
-  return ctx.tools.map((tool) => {
-    if (tool.parameters == null) {
-      return {
-        ...tool,
-        parameters: normalizeOpenAIStrictCompatSchema({}),
-      };
+  const tools: AnyAgentTool[] = [];
+  for (const [toolIndex, tool] of ctx.tools.entries()) {
+    const snapshot = readProviderToolSnapshot(tool, toolIndex);
+    if (snapshot.diagnostic) {
+      continue;
     }
-    if (typeof tool.parameters !== "object") {
-      return tool;
+    if (snapshot.parameters == null) {
+      pushToolWithProviderParameters(tools, snapshot, normalizeOpenAIStrictCompatSchema({}));
+      continue;
     }
-    return {
-      ...tool,
-      parameters: normalizeOpenAIStrictCompatSchema(tool.parameters),
-    };
-  });
+    if (typeof snapshot.parameters !== "object") {
+      tools.push(tool);
+      continue;
+    }
+    pushToolWithProviderParameters(
+      tools,
+      snapshot,
+      normalizeOpenAIStrictCompatSchema(snapshot.parameters),
+    );
+  }
+  return tools;
 }
 
 function normalizeOpenAIStrictCompatSchema(schema: unknown): TSchema {
@@ -504,18 +654,24 @@ export function normalizeDeepSeekToolSchemas(
   /** Provider tool-schema normalization context containing the active tool list. */
   ctx: ProviderNormalizeToolSchemasContext,
 ): AnyAgentTool[] {
-  return ctx.tools.map((tool) => {
-    if (!tool.parameters || typeof tool.parameters !== "object") {
-      return tool;
+  const tools: AnyAgentTool[] = [];
+  for (const [toolIndex, tool] of ctx.tools.entries()) {
+    const snapshot = readProviderToolSnapshot(tool, toolIndex);
+    if (snapshot.diagnostic) {
+      continue;
     }
-    const parameters = normalizeDeepSeekSchema(tool.parameters);
-    return parameters === tool.parameters
-      ? tool
-      : {
-          ...tool,
-          parameters: parameters as TSchema,
-        };
-  });
+    if (!snapshot.parameters || typeof snapshot.parameters !== "object") {
+      tools.push(tool);
+      continue;
+    }
+    const parameters = normalizeDeepSeekSchema(snapshot.parameters);
+    if (parameters === snapshot.parameters) {
+      tools.push(tool);
+      continue;
+    }
+    pushToolWithProviderParameters(tools, snapshot, parameters as TSchema);
+  }
+  return tools;
 }
 
 /**
@@ -526,15 +682,19 @@ export function inspectDeepSeekToolSchemas(
   ctx: ProviderNormalizeToolSchemasContext,
 ): ProviderToolSchemaDiagnostic[] {
   return ctx.tools.flatMap((tool, toolIndex) => {
+    const snapshot = readProviderToolSnapshot(tool, toolIndex);
+    if (snapshot.diagnostic) {
+      return [snapshot.diagnostic];
+    }
     const violations = findUnsupportedSchemaKeywords(
-      tool.parameters,
-      `${tool.name}.parameters`,
+      snapshot.parameters,
+      `${snapshot.name}.parameters`,
       DEEPSEEK_UNSUPPORTED_SCHEMA_KEYWORDS,
     );
     if (violations.length === 0) {
       return [];
     }
-    return [{ toolName: tool.name, toolIndex, violations }];
+    return [{ toolName: snapshot.name, toolIndex, violations }];
   });
 }
 

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -3813,6 +3813,55 @@ module.exports = { id: "throws-after-import", register() {} };`,
     ).toBe(true);
   });
 
+  it("isolates unreadable implicit plugin tool registration names", () => {
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "poisoned-tool-owner",
+      filename: "poisoned-tool-owner.cjs",
+      body: `module.exports = {
+        id: "poisoned-tool-owner",
+        register(api) {
+          api.registerTool({
+            get name() {
+              throw new Error("tool name revoked");
+            },
+            description: "Poisoned tool",
+            parameters: {},
+            execute: async () => ({ content: [{ type: "text", text: "bad" }] }),
+          });
+          api.registerTool({
+            name: "healthy_tool",
+            description: "Healthy tool",
+            parameters: {},
+            execute: async () => ({ content: [{ type: "text", text: "ok" }] }),
+          });
+        },
+      };`,
+    });
+    updatePluginManifest(plugin, { contracts: { tools: ["poisoned_tool", "healthy_tool"] } });
+
+    const registry = loadOpenClawPlugins({
+      activate: false,
+      cache: false,
+      workspaceDir: plugin.dir,
+      config: {
+        plugins: {
+          load: { paths: [plugin.file] },
+          allow: ["poisoned-tool-owner"],
+        },
+      },
+    });
+
+    expect(registry.tools.flatMap((entry) => entry.names)).toEqual(["healthy_tool"]);
+    expect(
+      registry.diagnostics.some(
+        (entry) =>
+          entry.pluginId === "poisoned-tool-owner" &&
+          entry.message === "plugin tool registration missing readable name",
+      ),
+    ).toBe(true);
+  });
+
   it("caches non-activating snapshots without restoring global side effects", () => {
     useNoBundledPlugins();
     clearPluginCommands();

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -209,6 +209,14 @@ const GATEWAY_METHOD_DISPATCH_CONTRACT = "authenticated-request";
 const LEGACY_DEACTIVATE_HOOK_ALIAS_COMPAT = getPluginCompatRecord("legacy-deactivate-hook-alias");
 const LEGACY_SUBAGENT_SPAWNING_HOOK_COMPAT = getPluginCompatRecord("legacy-subagent-spawning-hook");
 
+function readRegisteredToolName(tool: AnyAgentTool): string | undefined {
+  try {
+    return typeof tool.name === "string" && tool.name.trim() ? tool.name.trim() : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 function formatLegacyDeactivateHookAliasDiagnostic(): string {
   const removeAfter =
     LEGACY_DEACTIVATE_HOOK_ALIAS_COMPAT.removeAfter ?? "a future breaking release";
@@ -617,8 +625,18 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
     const factory: OpenClawPluginToolFactory =
       typeof tool === "function" ? tool : (_ctx: OpenClawPluginToolContext) => tool;
 
-    if (typeof tool !== "function") {
-      names.push(tool.name);
+    if (typeof tool !== "function" && names.length === 0) {
+      const toolName = readRegisteredToolName(tool);
+      if (!toolName) {
+        pushDiagnostic({
+          level: "error",
+          pluginId: record.id,
+          source: record.source,
+          message: "plugin tool registration missing readable name",
+        });
+        return;
+      }
+      names.push(toolName);
     }
 
     const normalized = normalizePluginToolNames(names);

--- a/src/plugins/tool-metadata.ts
+++ b/src/plugins/tool-metadata.ts
@@ -1,0 +1,37 @@
+import type { AnyAgentTool } from "../agents/tools/common.js";
+
+/** MCP bridge metadata attached to plugin tools surfaced through agent tool lists. */
+export type PluginToolMcpMeta = {
+  serverName: string;
+  safeServerName: string;
+  toolName: string;
+  operation: "tool" | "resources_list" | "resources_read" | "prompts_list" | "prompts_get";
+};
+
+/** Runtime metadata used to trace an agent tool back to its owning plugin registration. */
+export type PluginToolMeta = {
+  pluginId: string;
+  optional: boolean;
+  trustedLocalMedia?: boolean;
+  mcp?: PluginToolMcpMeta;
+};
+
+const pluginToolMeta = new WeakMap<AnyAgentTool, PluginToolMeta>();
+
+/** Attaches plugin ownership metadata to a concrete agent tool instance. */
+export function setPluginToolMeta(tool: AnyAgentTool, meta: PluginToolMeta): void {
+  pluginToolMeta.set(tool, meta);
+}
+
+/** Reads plugin ownership metadata for a concrete agent tool instance. */
+export function getPluginToolMeta(tool: AnyAgentTool): PluginToolMeta | undefined {
+  return pluginToolMeta.get(tool);
+}
+
+/** Copies plugin ownership metadata when wrappers replace a tool object. */
+export function copyPluginToolMeta(source: AnyAgentTool, target: AnyAgentTool): void {
+  const meta = pluginToolMeta.get(source);
+  if (meta) {
+    pluginToolMeta.set(target, meta);
+  }
+}

--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -670,6 +670,7 @@ describe("resolvePluginTools optional tools", () => {
 
     class AccessorTool {
       #name = "class_tool";
+      #description = "class backed tool";
       #parameters = { type: "object", properties: {} };
 
       get name() {
@@ -677,7 +678,7 @@ describe("resolvePluginTools optional tools", () => {
       }
 
       get description() {
-        return "class backed tool";
+        return this.#description;
       }
 
       get parameters() {
@@ -713,6 +714,7 @@ describe("resolvePluginTools optional tools", () => {
 
     const [tool] = resolvePluginTools(createResolveToolsParams({ context }));
     expect(tool?.name).toBe("class_tool");
+    expect(tool?.description).toBe("class backed tool");
     expect(Object.getPrototypeOf(tool)).toBe(AccessorTool.prototype);
     await tool?.execute("call-class", tool.prepareArguments?.({}) ?? {}, undefined);
 
@@ -1939,6 +1941,113 @@ describe("resolvePluginTools optional tools", () => {
     );
   });
 
+  it("stabilizes plugin tool schema metadata after validation", () => {
+    let schemaReads = 0;
+    const schema = { type: "object", properties: {} };
+    setRegistry([
+      {
+        pluginId: "schema-bug",
+        optional: false,
+        source: "/tmp/schema-bug.js",
+        names: ["volatile_tool", "valid_tool"],
+        factory: () => [
+          {
+            name: "volatile_tool",
+            description: "volatile tool",
+            get parameters() {
+              schemaReads += 1;
+              if (schemaReads > 1) {
+                throw new Error("schema getter should not be reread");
+              }
+              return schema;
+            },
+            async execute() {
+              return { content: [{ type: "text", text: "volatile-ok" }] };
+            },
+          },
+          makeTool("valid_tool"),
+        ],
+      },
+    ]);
+
+    const tools = resolvePluginTools(createResolveToolsParams());
+
+    expectResolvedToolNames(tools, ["volatile_tool", "valid_tool"]);
+    expect(tools[0]?.parameters).toBe(schema);
+    expect(schemaReads).toBe(1);
+  });
+
+  it("stabilizes non-configurable plugin tool schema properties", () => {
+    const schema = { type: "object", properties: {} };
+    setRegistry([
+      {
+        pluginId: "schema-bug",
+        optional: false,
+        source: "/tmp/schema-bug.js",
+        names: ["sealed_tool"],
+        factory: () => {
+          const tool = {
+            description: "sealed tool",
+            async execute() {
+              return { content: [{ type: "text", text: "sealed-ok" }] };
+            },
+          };
+          Object.defineProperties(tool, {
+            name: { enumerable: true, value: "sealed_tool" },
+            parameters: { enumerable: true, value: schema },
+          });
+          return tool;
+        },
+      },
+    ]);
+
+    const tools = resolvePluginTools(createResolveToolsParams());
+
+    expectResolvedToolNames(tools, ["sealed_tool"]);
+    expect(Object.getOwnPropertyDescriptor(tools[0], "parameters")?.value).toBe(schema);
+    expect({ ...tools[0] }.parameters).toBe(schema);
+  });
+
+  it("isolates plugin tools with throwing descriptor traps", () => {
+    setRegistry([
+      {
+        pluginId: "schema-bug",
+        optional: false,
+        source: "/tmp/schema-bug.js",
+        names: ["descriptor_trap_tool", "valid_tool"],
+        factory: () => {
+          let descriptorTrapsArmed = false;
+          const trappedTool = new Proxy(makeTool("descriptor_trap_tool"), {
+            get(target, prop, receiver) {
+              const value = Reflect.get(target, prop, receiver);
+              if (prop === "parameters") {
+                descriptorTrapsArmed = true;
+              }
+              return value;
+            },
+            getOwnPropertyDescriptor(target, prop) {
+              if (descriptorTrapsArmed) {
+                throw new Error("descriptor trap should not abort tool resolution");
+              }
+              return Reflect.getOwnPropertyDescriptor(target, prop);
+            },
+            ownKeys(target) {
+              if (descriptorTrapsArmed) {
+                throw new Error("ownKeys trap should not abort tool resolution");
+              }
+              return Reflect.ownKeys(target);
+            },
+          });
+          return [trappedTool, makeTool("valid_tool")];
+        },
+      },
+    ]);
+
+    const tools = resolvePluginTools(createResolveToolsParams());
+
+    expectResolvedToolNames(tools, ["valid_tool"]);
+  });
+
   it("warns with plugin factory timing details when a factory is slow", () => {
     vi.useFakeTimers({ now: 0 });
     const warnSpy = installConsoleMethodSpy("warn");
@@ -2060,6 +2169,46 @@ describe("resolvePluginTools optional tools", () => {
       content: [{ type: "text", text: "same" }],
     });
     expect(factory).toHaveBeenCalledTimes(2);
+  });
+
+  it("executes cached plugin tools without rereading runtime schemas", async () => {
+    let schemaReads = 0;
+    const schema = { type: "object", properties: {} };
+    const factory = vi.fn(() => ({
+      name: "cached_volatile_tool",
+      description: "cached volatile tool",
+      get parameters() {
+        schemaReads += 1;
+        if (schemaReads > 1) {
+          throw new Error("cached runtime should reuse the descriptor schema");
+        }
+        return schema;
+      },
+      async execute() {
+        return { content: [{ type: "text", text: "cached-volatile-ok" }] };
+      },
+    }));
+    setRegistry([
+      {
+        pluginId: "cache-test",
+        optional: false,
+        source: "/tmp/cache-test.js",
+        names: ["cached_volatile_tool"],
+        factory,
+      },
+    ]);
+
+    const first = resolvePluginTools(createResolveToolsParams());
+    const second = resolvePluginTools(createResolveToolsParams());
+
+    expectResolvedToolNames(first, ["cached_volatile_tool"]);
+    expectResolvedToolNames(second, ["cached_volatile_tool"]);
+    expect(factory).toHaveBeenCalledTimes(1);
+    await expect(second[0]?.execute("call", {}, undefined)).resolves.toEqual({
+      content: [{ type: "text", text: "cached-volatile-ok" }],
+    });
+    expect(factory).toHaveBeenCalledTimes(2);
+    expect(schemaReads).toBe(1);
   });
 
   it("executes cached healthy tools when a runtime sibling is malformed", async () => {

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -71,6 +71,11 @@ type PluginToolFactoryTiming = {
 };
 
 type PluginToolFactoryResult = AnyAgentTool | AnyAgentTool[] | null | undefined;
+type PluginToolSchemaSnapshot = {
+  name: string;
+  parameters: Record<string, unknown>;
+  execute: AnyAgentTool["execute"];
+};
 
 const log = createSubsystemLogger("plugins/tools");
 const PLUGIN_TOOL_FACTORY_WARN_TOTAL_MS = 5_000;
@@ -322,7 +327,11 @@ function readPluginToolName(tool: unknown): string {
     return "";
   }
   // Optional-tool allowlists need a best-effort name before full shape validation.
-  return typeof tool.name === "string" ? tool.name.trim() : "";
+  try {
+    return typeof tool.name === "string" ? tool.name.trim() : "";
+  } catch {
+    return "";
+  }
 }
 
 function toElapsedMs(value: number): number {
@@ -450,21 +459,120 @@ function shouldWarnPluginToolFactoryTimings(params: {
   );
 }
 
-function describeMalformedPluginTool(tool: unknown): string | undefined {
+function readPluginToolSchemaSnapshot(
+  tool: unknown,
+):
+  | { snapshot: PluginToolSchemaSnapshot; malformedReason?: undefined }
+  | { snapshot?: undefined; malformedReason: string } {
   if (!isRecord(tool)) {
-    return "tool must be an object";
+    return { malformedReason: "tool must be an object" };
   }
   const name = readPluginToolName(tool);
   if (!name) {
-    return "missing non-empty name";
+    return { malformedReason: "missing non-empty name" };
   }
-  if (typeof tool.execute !== "function") {
-    return `${name} missing execute function`;
+  let execute: unknown;
+  try {
+    execute = tool.execute;
+  } catch {
+    return { malformedReason: `${name} missing execute function` };
   }
-  if (!isRecord(tool.parameters)) {
-    return `${name} missing parameters object`;
+  if (typeof execute !== "function") {
+    return { malformedReason: `${name} missing execute function` };
   }
-  return undefined;
+  let parameters: unknown;
+  try {
+    parameters = tool.parameters;
+  } catch {
+    return { malformedReason: `${name} missing parameters object` };
+  }
+  if (!isRecord(parameters)) {
+    return { malformedReason: `${name} missing parameters object` };
+  }
+  return { snapshot: { name, parameters, execute: execute as AnyAgentTool["execute"] } };
+}
+
+function stabilizePluginToolSchema(
+  tool: AnyAgentTool,
+  snapshot: PluginToolSchemaSnapshot,
+): AnyAgentTool {
+  const prototype = (() => {
+    try {
+      return Object.getPrototypeOf(tool);
+    } catch {
+      throw new Error("tool metadata descriptors are unreadable");
+    }
+  })();
+  const isEnumerable = (prop: PropertyKey, fallback: boolean) => {
+    try {
+      return Reflect.getOwnPropertyDescriptor(tool, prop)?.enumerable ?? fallback;
+    } catch {
+      throw new Error("tool metadata descriptors are unreadable");
+    }
+  };
+  let prepareArguments: unknown;
+  try {
+    prepareArguments = (tool as { prepareArguments?: unknown }).prepareArguments;
+  } catch {
+    prepareArguments = undefined;
+  }
+  const stable = Object.create(prototype) as AnyAgentTool;
+  const stableDescriptors: PropertyDescriptorMap = {
+    name: {
+      configurable: true,
+      enumerable: isEnumerable("name", true),
+      value: snapshot.name,
+      writable: true,
+    },
+    parameters: {
+      configurable: true,
+      enumerable: isEnumerable("parameters", true),
+      value: snapshot.parameters,
+      writable: true,
+    },
+    execute: {
+      configurable: true,
+      enumerable: isEnumerable("execute", true),
+      value: (toolCallId: string, params: unknown, signal?: AbortSignal, onUpdate?: unknown) =>
+        Reflect.apply(snapshot.execute, tool, [toolCallId, params, signal, onUpdate]) as ReturnType<
+          AnyAgentTool["execute"]
+        >,
+      writable: true,
+    },
+  };
+  if (typeof prepareArguments === "function") {
+    stableDescriptors.prepareArguments = {
+      configurable: true,
+      enumerable: isEnumerable("prepareArguments", false),
+      value: (...args: unknown[]) => Reflect.apply(prepareArguments, tool, args),
+      writable: true,
+    };
+  }
+  for (const prop of [
+    "description",
+    "label",
+    "displaySummary",
+    "executionMode",
+    "prepareBeforeToolCallParams",
+    "finalizeBeforeToolCallParams",
+  ]) {
+    stableDescriptors[prop] = {
+      configurable: true,
+      enumerable: isEnumerable(prop, prop === "description"),
+      get() {
+        return Reflect.get(tool, prop, tool);
+      },
+    };
+  }
+  Object.defineProperties(stable, stableDescriptors);
+  return new Proxy(stable, {
+    get(target, prop, receiver) {
+      if (Reflect.has(target, prop)) {
+        return Reflect.get(target, prop, receiver);
+      }
+      return Reflect.get(tool, prop, tool);
+    },
+  });
 }
 
 function pluginToolNamesMatchAllowlist(params: {
@@ -696,13 +804,29 @@ function createCachedDescriptorPluginTool(params: {
         const resolved = resolvePluginToolFactory(candidate, params.ctx);
         const listRaw: unknown[] = Array.isArray(resolved) ? resolved : resolved ? [resolved] : [];
         for (const toolRaw of listRaw) {
-          const malformedReason = describeMalformedPluginTool(toolRaw);
-          if (malformedReason) {
+          if (!isRecord(toolRaw)) {
             continue;
           }
-          const runtimeTool = toolRaw as AnyAgentTool;
-          if (normalizeToolName(readPluginToolName(runtimeTool)) === requestedToolName) {
-            return runtimeTool;
+          const runtimeToolName = readPluginToolName(toolRaw);
+          if (normalizeToolName(runtimeToolName) !== requestedToolName) {
+            continue;
+          }
+          let execute: unknown;
+          try {
+            execute = toolRaw.execute;
+          } catch {
+            continue;
+          }
+          if (typeof execute === "function") {
+            try {
+              return stabilizePluginToolSchema(toolRaw as AnyAgentTool, {
+                name: runtimeToolName,
+                parameters: descriptor.inputSchema as Record<string, unknown>,
+                execute: execute as AnyAgentTool["execute"],
+              });
+            } catch {
+              continue;
+            }
           }
         }
         return undefined;
@@ -1277,9 +1401,10 @@ export function resolvePluginTools(params: {
     for (const toolRaw of list) {
       // Plugin factories run at request time and can return arbitrary values; isolate
       // malformed tools here so one bad plugin tool cannot poison every provider.
-      const malformedReason = describeMalformedPluginTool(toolRaw);
-      if (malformedReason) {
-        const message = `plugin tool is malformed (${entry.pluginId}): ${malformedReason}`;
+      const schemaSnapshot = readPluginToolSchemaSnapshot(toolRaw);
+      const toolSchema = schemaSnapshot.snapshot;
+      if (!toolSchema) {
+        const message = `plugin tool is malformed (${entry.pluginId}): ${schemaSnapshot.malformedReason}`;
         context.logger.error(message);
         registry.diagnostics.push({
           level: "error",
@@ -1289,11 +1414,25 @@ export function resolvePluginTools(params: {
         });
         continue;
       }
-      const tool = toolRaw as AnyAgentTool;
+      const toolName = toolSchema.name;
+      let tool: AnyAgentTool;
+      try {
+        tool = stabilizePluginToolSchema(toolRaw as AnyAgentTool, toolSchema);
+      } catch {
+        const message = `plugin tool is malformed (${entry.pluginId}): ${toolName} unreadable metadata descriptors`;
+        context.logger.error(message);
+        registry.diagnostics.push({
+          level: "error",
+          pluginId: entry.pluginId,
+          source: entry.source,
+          message,
+        });
+        continue;
+      }
       const undeclared = entry.declaredNames
         ? findUndeclaredPluginToolNames({
             declaredNames: entry.declaredNames,
-            toolNames: [tool.name],
+            toolNames: [toolName],
           })
         : [];
       if (undeclared.length > 0) {
@@ -1307,9 +1446,9 @@ export function resolvePluginTools(params: {
         });
         continue;
       }
-      const normalizedToolName = normalizeToolName(tool.name);
+      const normalizedToolName = normalizeToolName(toolName);
       if (normalizedNameSet.has(normalizedToolName) || existingNormalized.has(normalizedToolName)) {
-        const message = `plugin tool name conflict (${entry.pluginId}): ${tool.name}`;
+        const message = `plugin tool name conflict (${entry.pluginId}): ${toolName}`;
         if (!params.suppressNameConflicts) {
           context.logger.error(message);
           registry.diagnostics.push({
@@ -1322,19 +1461,19 @@ export function resolvePluginTools(params: {
         continue;
       }
       normalizedNameSet.add(normalizedToolName);
-      existing.add(tool.name);
+      existing.add(toolName);
       existingNormalized.add(normalizedToolName);
       const optional = isPluginToolOptional({
         entry,
         manifestPlugin,
-        toolName: tool.name,
+        toolName,
       });
       pluginToolMeta.set(tool, {
         pluginId: entry.pluginId,
         optional,
         trustedLocalMedia: isTrustedManifestLocalMediaTool({
           manifestPlugin,
-          toolName: tool.name,
+          toolName,
         }),
       });
       if (manifestPlugin) {

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -35,28 +35,20 @@ import {
   type PluginToolDescriptorConfigCacheKeyMemo,
   writeCachedPluginToolDescriptors,
 } from "./tool-descriptor-cache.js";
+import { copyPluginToolMeta, setPluginToolMeta } from "./tool-metadata.js";
 import type { OpenClawPluginToolContext } from "./types.js";
 
 export {
   resetPluginToolDescriptorCache,
   resetPluginToolDescriptorCache as resetPluginToolFactoryCache,
 } from "./tool-descriptor-cache.js";
-
-/** MCP bridge metadata attached to plugin tools surfaced through agent tool lists. */
-export type PluginToolMcpMeta = {
-  serverName: string;
-  safeServerName: string;
-  toolName: string;
-  operation: "tool" | "resources_list" | "resources_read" | "prompts_list" | "prompts_get";
-};
-
-/** Runtime metadata used to trace an agent tool back to its owning plugin registration. */
-export type PluginToolMeta = {
-  pluginId: string;
-  optional: boolean;
-  trustedLocalMedia?: boolean;
-  mcp?: PluginToolMcpMeta;
-};
+export {
+  copyPluginToolMeta,
+  getPluginToolMeta,
+  setPluginToolMeta,
+  type PluginToolMcpMeta,
+  type PluginToolMeta,
+} from "./tool-metadata.js";
 
 type PluginToolFactoryTimingResult = "array" | "error" | "null" | "single";
 
@@ -82,26 +74,7 @@ const PLUGIN_TOOL_FACTORY_WARN_TOTAL_MS = 5_000;
 const PLUGIN_TOOL_FACTORY_WARN_FACTORY_MS = 1_000;
 const PLUGIN_TOOL_FACTORY_SUMMARY_LIMIT = 20;
 
-const pluginToolMeta = new WeakMap<AnyAgentTool, PluginToolMeta>();
 const scopedPluginTools = new WeakMap<AnyAgentTool, Map<string, AnyAgentTool>>();
-
-/** Attaches plugin ownership metadata to a concrete agent tool instance. */
-export function setPluginToolMeta(tool: AnyAgentTool, meta: PluginToolMeta): void {
-  pluginToolMeta.set(tool, meta);
-}
-
-/** Reads plugin ownership metadata for a concrete agent tool instance. */
-export function getPluginToolMeta(tool: AnyAgentTool): PluginToolMeta | undefined {
-  return pluginToolMeta.get(tool);
-}
-
-/** Copies plugin ownership metadata when wrappers replace a tool object. */
-export function copyPluginToolMeta(source: AnyAgentTool, target: AnyAgentTool): void {
-  const meta = pluginToolMeta.get(source);
-  if (meta) {
-    pluginToolMeta.set(target, meta);
-  }
-}
 
 function pluginToolScopeKey(entry: PluginToolRegistration): string {
   return JSON.stringify([entry.pluginId, entry.source]);
@@ -1468,7 +1441,7 @@ export function resolvePluginTools(params: {
         manifestPlugin,
         toolName,
       });
-      pluginToolMeta.set(tool, {
+      setPluginToolMeta(tool, {
         pluginId: entry.pluginId,
         optional,
         trustedLocalMedia: isTrustedManifestLocalMediaTool({


### PR DESCRIPTION
Summary
- Snapshots plugin tool schemas and tool metadata before plugin-owned values can mutate or throw during later registry/MCP use.
- Guards implicit registration names and provider SDK schema helpers so plugin tooling keeps clear ownership and stable diagnostics.
- Cherry-picked from the superseded large split stack in https://github.com/openclaw/openclaw/pull/90411: `2a872029f02f`, `068518b4f117`, `8858b44278b5`, and `03f859237a88`.

Verification
- `node scripts/run-vitest.mjs run src/plugins/tools.optional.test.ts src/plugins/loader.test.ts src/plugin-sdk/provider-tools.test.ts src/mcp/plugin-tools-handlers.test.ts --reporter=dot`
- `./node_modules/.bin/oxfmt --check src/mcp/plugin-tools-handlers.test.ts src/mcp/plugin-tools-handlers.ts src/plugin-sdk/provider-tools.test.ts src/plugin-sdk/provider-tools.ts src/plugins/loader.test.ts src/plugins/registry.ts src/plugins/tool-metadata.ts src/plugins/tools.optional.test.ts src/plugins/tools.ts`
- `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/mcp/plugin-tools-handlers.test.ts src/mcp/plugin-tools-handlers.ts src/plugin-sdk/provider-tools.test.ts src/plugin-sdk/provider-tools.ts src/plugins/loader.test.ts src/plugins/registry.ts src/plugins/tool-metadata.ts src/plugins/tools.optional.test.ts src/plugins/tools.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

Behavior addressed
- Plugin tool registration, provider SDK helper output, and MCP plugin-tool bridge metadata now preserve stable schema/name snapshots instead of re-reading mutable or hostile plugin values later.

Real environment tested
- macOS linked OpenClaw worktree with shared install and focused Vitest/lint/format checks.

Exact steps or command run after this patch
- Ran the focused commands listed in Verification after cherry-picking the plugin/schema commits.

Evidence after fix
- 238 focused tests passed across plugin registration, provider SDK tool helpers, bundled plugin behavior, and MCP plugin tool handlers.
- Focused format, core oxlint, whitespace check, and autoreview passed.

Observed result after fix
- Plugin tool schemas and metadata are copied at the boundary, preserving ownership while preventing later getter/mutation traps from changing behavior.

What was not tested
- Broad `pnpm check:changed` was not run locally because this is a linked/sparse worktree and disk is currently tight; PR CI should cover the wider gate.
