### PR TITLE
fix(models): keep bundled provider catalog when configured base URL is blank (#91270)

### DIFF
--- a/src/agents/models-config.applies-config-env-vars.test.ts
+++ b/src/agents/models-config.applies-config-env-vars.test.ts
@@ -157,6 +157,37 @@ beforeAll(async () => {
 });
 
 describe("models-config", () => {
+  it("keeps the implicit provider catalog when explicit baseUrl is blank", async () => {
+    let observedConfig: OpenClawConfig | undefined;
+    const providers = await resolveProvidersForModelsJsonWithDeps(
+      {
+        cfg: {
+          models: {
+            providers: {
+              openai: {
+                baseUrl: "   ",
+                apiKey: "OPENAI_API_KEY",
+              },
+            },
+          },
+        },
+        agentDir: "/tmp/openclaw-models-config-env-vars-test",
+        env: {},
+      },
+      {
+        resolveImplicitProviders: async ({ config }) => {
+          observedConfig = config;
+          return { openai: createImplicitOpenAiProvider() };
+        },
+      },
+    );
+
+    expect(observedConfig?.models?.providers?.openai?.baseUrl).toBeUndefined();
+    expect(providers.openai?.baseUrl).toBe("https://api.openai.com/v1");
+    expect(providers.openai?.apiKey).toBe("OPENAI_API_KEY");
+    expect(providers.openai?.models?.[0]?.id).toBe("gpt-5.5");
+  });
+
   it("threads plugin metadata snapshots into implicit provider discovery", async () => {
     const pluginMetadataSnapshot = {
       index: { plugins: [{ pluginId: "zai", enabled: true }] },

--- a/src/agents/models-config.plan.ts
+++ b/src/agents/models-config.plan.ts
@@ -107,8 +107,11 @@ export async function resolveProvidersForModelsJsonWithDeps(
     resolveImplicitProviders?: ResolveImplicitProvidersForModelsJson;
   },
 ): Promise<Record<string, ProviderConfig>> {
-  const { cfg, agentDir, env } = params;
-  const explicitProviders = cfg.models?.providers ?? {};
+  const { agentDir, env } = params;
+  const explicitProviders = stripBlankProviderBaseUrls(params.cfg.models?.providers ?? {});
+  const cfg = params.cfg.models?.providers
+    ? { ...params.cfg, models: { ...params.cfg.models, providers: explicitProviders } }
+    : params.cfg;
   const resolveImplicitProvidersImpl = deps?.resolveImplicitProviders ?? resolveImplicitProviders;
   const implicitProviders = await resolveImplicitProvidersImpl({
     agentDir,
@@ -131,6 +134,23 @@ export async function resolveProvidersForModelsJsonWithDeps(
     implicit: implicitProviders,
     explicit: explicitProviders,
   });
+}
+
+function stripBlankProviderBaseUrls(
+  providers: Record<string, ProviderConfig>,
+): Record<string, ProviderConfig> {
+  let mutated = false;
+  const next: Record<string, ProviderConfig> = {};
+  for (const [key, provider] of Object.entries(providers)) {
+    if (typeof provider?.baseUrl === "string" && provider.baseUrl.trim() === "") {
+      const { baseUrl: _blank, ...rest } = provider;
+      next[key] = rest as ProviderConfig;
+      mutated = true;
+      continue;
+    }
+    next[key] = provider;
+  }
+  return mutated ? next : providers;
 }
 
 function resolveProvidersForMode(params: {


### PR DESCRIPTION
## Summary

Fixes #91270. On the embedded runtime, Google Gemini models stop resolving with `model_not_found`:

```
Unknown model: google/gemini-2.5-flash. Found agents.defaults.models["google/gemini-2.5-flash"],
but no matching models.providers["google"].models[] entry.
```

even though the bundled Google catalog and forward-compat resolver know `gemini-2.5-flash` and `gemini-flash-latest`. The reporter hit this with `models.mode: "merge"` and a config edited by a plugin; their workaround was to add explicit `models.providers.google.models[]` rows.

## Root cause

When a `models.providers.<id>` entry exists with a blank `baseUrl: ""` (as written by a plugin or a partial hand edit), that empty string flows into models.json planning:

- It is spread into the provider-discovery config (`buildPluginCatalogConfig`) and the catalog merge, where it overrides the bundled transport base URL, so the discovered Google catalog ends up with `baseUrl: ""`.
- `isWritableProviderConfig` then treats the provider as non-writable (`baseUrl?.trim() && apiKey` is false), so `filterWritableProviders` drops the whole Google provider from the generated registry, including its bundled catalog and forward-compat templates.
- With no Google rows in the registry, the direct lookup (`gemini-2.5-flash`) and the forward-compat clone (`gemini-flash-latest`, which clones a `gemini-2.5-flash` template) both fail, so resolution falls through to the `model_not_found` registration hint.

A blank `baseUrl` should mean "use the provider default", not "erase the bundled catalog".

## Fix

`resolveProvidersForModelsJsonWithDeps` strips blank provider `baseUrl` values from the explicit config before they reach discovery and the merge, so the bundled catalog base URL survives and the provider stays writable. The change is provider-agnostic.

## Real behavior proof

Behavior addressed: Embedded runtime fails to resolve `google/gemini-2.5-flash` / `google/gemini-flash-latest` with `model_not_found` when a `models.providers.google` entry exists with a blank `baseUrl` and no/partial `models[]` (merge mode, plugin-edited config).

Real environment tested: Local checkout at `origin/main` 5c5391836b1, Node 22.19, `GEMINI_API_KEY` set; drove the production `ensureOpenClawModelsJson` then `resolveModelAsync("google", id, ...)` decision path for the reporter-shaped config across three variants (C1 no explicit google provider; C2 explicit google with model rows; C3 explicit google `{ api, baseUrl: "" }` with no model rows).

Exact steps or command run after this patch: generated models.json then resolved `google/gemini-2.5-flash` and `google/gemini-flash-latest` for each of C1, C2, C3 through the real resolver decision path.

Evidence after fix: copied live terminal output from the real resolver decision path.

Before the fix (C3 = blank-baseUrl plugin-written google entry):
```
[C3 explicit google EMPTY models] google/gemini-2.5-flash    => ERR: Unknown model: google/gemini-2.5-flash. Found agents.defaults.models["google/gemini-2.5-flash"], but no matching models.providers["google"].models[] entry.
[C3 explicit google EMPTY models] google/gemini-flash-latest => ERR: Unknown model: google/gemini-flash-latest. Found agents.defaults.models["google/gemini-flash-latest"], but no matching models.providers["google"].models[] entry.
```

After the fix:
```
[C1 NO explicit google]          google/gemini-2.5-flash    => OK api=google-generative-ai
[C1 NO explicit google]          google/gemini-flash-latest => OK api=google-generative-ai
[C2 explicit google WITH models] google/gemini-2.5-flash    => OK api=google-generative-ai
[C2 explicit google WITH models] google/gemini-flash-latest => OK api=google-generative-ai
[C3 explicit google EMPTY models] google/gemini-2.5-flash    => OK api=google-generative-ai
[C3 explicit google EMPTY models] google/gemini-flash-latest => OK api=google-generative-ai
```

Observed result after fix: all three configs resolve both Gemini ids on the embedded runtime; C1 and C2 were already resolving and stayed green (no regression).

What was not tested: a live request against the Google Gemini API (resolution only, no network call); non-Google providers were not exercised live, though the fix is provider-agnostic.

## Verification

Local (Node 22.19.0): `pnpm tsgo:core` exit 0; `oxfmt --check src/agents/models-config.plan.ts` clean; type-aware oxlint on the changed file clean.

## Related (not duplicates)

- #85042 (blank/missing google config misroutes the Gemini key to OpenAI) and #89192 (incomplete `model_not_found` remediation message) are adjacent issues in the same provider-config cluster. Keeping the bundled catalog when `baseUrl` is blank helps that cluster but does not fully cover their separate asks.
