### PR TITLE
fix(agents): snapshot session tool definitions

### DIFF
--- a/src/agents/agent-tool-definition-adapter.test.ts
+++ b/src/agents/agent-tool-definition-adapter.test.ts
@@ -48,6 +48,96 @@ async function executeTool(tool: AgentTool, callId: string) {
 }
 
 describe("agent tool definition adapter", () => {
+  it("skips unreadable tool parameters while preserving healthy siblings", () => {
+    const badTool = {
+      name: "bad_schema",
+      label: "Bad Schema",
+      description: "throws while reading parameters",
+      execute: async () => ({
+        content: [{ type: "text" as const, text: "bad" }],
+      }),
+    } as AgentTool;
+    Object.defineProperty(badTool, "parameters", {
+      get: () => {
+        throw new Error("revoked schema");
+      },
+    });
+    const healthyTool = {
+      name: "healthy_schema",
+      label: "Healthy Schema",
+      description: "survives a bad sibling",
+      parameters: { type: "object", properties: { query: { type: "string" } } },
+      execute: async () => ({
+        content: [{ type: "text" as const, text: "ok" }],
+      }),
+    } satisfies AgentTool;
+
+    const defs = toToolDefinitions([badTool, healthyTool]);
+
+    expect(defs.map((def) => def.name)).toEqual(["healthy_schema"]);
+  });
+
+  it("skips unreadable tool names before normalizing session definitions", () => {
+    const badTool = {
+      label: "Bad Name",
+      description: "throws while reading name",
+      parameters: { type: "object", properties: {} },
+      execute: async () => ({
+        content: [{ type: "text" as const, text: "bad" }],
+      }),
+    } as AgentTool;
+    Object.defineProperty(badTool, "name", {
+      get: () => {
+        throw new Error("revoked name");
+      },
+    });
+    const healthyTool = {
+      name: "healthy_name",
+      label: "Healthy Name",
+      description: "survives a bad sibling",
+      parameters: { type: "object", properties: {} },
+      execute: async () => ({
+        content: [{ type: "text" as const, text: "ok" }],
+      }),
+    } satisfies AgentTool;
+
+    const defs = toToolDefinitions([badTool, healthyTool]);
+
+    expect(defs.map((def) => def.name)).toEqual(["healthy_name"]);
+  });
+
+  it("snapshots tool definition schemas before exposing session definitions", () => {
+    const parameters = {
+      type: "object",
+      properties: {
+        query: { type: "string" },
+      },
+    };
+    const tool = {
+      name: "search",
+      label: "Search",
+      description: "searches",
+      parameters,
+      execute: async () => ({
+        content: [{ type: "text" as const, text: "ok" }],
+      }),
+    } satisfies AgentTool;
+
+    const [definition] = toToolDefinitions([tool]);
+    if (!definition) {
+      throw new Error("missing tool definition");
+    }
+    parameters.properties.query.type = "number";
+
+    expect(definition.parameters).toEqual({
+      type: "object",
+      properties: {
+        query: { type: "string" },
+      },
+    });
+    expect(definition.parameters).not.toBe(parameters);
+  });
+
   it("wraps tool errors into a tool result", async () => {
     const result = await executeThrowingTool("boom", "call1");
 

--- a/src/agents/agent-tool-definition-adapter.ts
+++ b/src/agents/agent-tool-definition-adapter.ts
@@ -58,6 +58,30 @@ const TOOL_ERROR_PARAM_PREVIEW_MAX_CHARS = 600;
 const TOOL_ERROR_EXEC_COMMAND_HASH_CHARS = 16;
 const SENSITIVE_EXEC_ENV_VALUE = "[omitted exec env value]";
 const EXEC_COMMAND_PARAM_KEYS = new Set(["command", "cmd"]);
+const TOOL_DEFINITION_SCHEMA_MAX_DEPTH = 24;
+const TOOL_DEFINITION_SCHEMA_MAX_NODES = 1_000;
+
+class InvalidToolDefinitionSchemaError extends Error {
+  constructor() {
+    super("parameters schema is not JSON-document-compatible");
+    this.name = "InvalidToolDefinitionSchemaError";
+  }
+}
+
+type ToolDefinitionSchemaCloneState = {
+  seen: WeakSet<object>;
+  nodes: number;
+};
+
+type ToolDefinitionSnapshot = {
+  sourceTool: AnyAgentTool;
+  name: string;
+  normalizedName: string;
+  label: string;
+  description: string;
+  parameters: ToolDefinition["parameters"];
+  beforeHookWrapped: boolean;
+};
 
 export type ClientToolCallRecorder =
   | ((toolName: string, params: Record<string, unknown>) => void)
@@ -359,15 +383,21 @@ export function toToolDefinitions(
   tools: AnyAgentTool[],
   hookContext?: HookContext,
 ): ToolDefinition[] {
-  return tools.map((tool) => {
-    const name = tool.name || "tool";
-    const normalizedName = normalizeToolName(name);
-    const beforeHookWrapped = isToolWrappedWithBeforeToolCallHook(tool);
+  return snapshotAgentToolDefinitions(tools).map((toolSnapshot) => {
+    const {
+      sourceTool: tool,
+      name,
+      normalizedName,
+      label,
+      description,
+      parameters,
+      beforeHookWrapped,
+    } = toolSnapshot;
     return {
       name,
-      label: tool.label ?? name,
-      description: tool.description ?? "",
-      parameters: tool.parameters,
+      label,
+      description,
+      parameters,
       execute: async (...args: ToolExecuteArgs): Promise<AgentToolResult<unknown>> => {
         const { toolCallId, params, onUpdate, signal } = splitToolExecuteArgs(args);
         let executeParams = params;
@@ -452,6 +482,121 @@ export function toToolDefinitions(
       },
     } satisfies ToolDefinition;
   });
+}
+
+function snapshotAgentToolDefinitions(tools: readonly AnyAgentTool[]): ToolDefinitionSnapshot[] {
+  const snapshots: ToolDefinitionSnapshot[] = [];
+  for (const tool of tools) {
+    const snapshot = snapshotAgentToolDefinition(tool);
+    if (snapshot) {
+      snapshots.push(snapshot);
+    }
+  }
+  return snapshots;
+}
+
+function snapshotAgentToolDefinition(tool: AnyAgentTool): ToolDefinitionSnapshot | undefined {
+  let name = "tool";
+  try {
+    const rawName = tool.name;
+    if (typeof rawName === "string" && rawName.length > 0) {
+      name = rawName;
+    } else if (rawName != null && rawName !== "") {
+      throw new Error(`tool name must be a string`);
+    }
+    const rawLabel = tool.label;
+    const rawDescription = tool.description;
+    const label = typeof rawLabel === "string" && rawLabel.length > 0 ? rawLabel : name;
+    const description = typeof rawDescription === "string" ? rawDescription : "";
+    const parameters = snapshotToolDefinitionSchema(tool.parameters);
+    return {
+      sourceTool: tool,
+      name,
+      normalizedName: normalizeToolName(name),
+      label,
+      description,
+      parameters,
+      beforeHookWrapped: isToolWrappedWithBeforeToolCallHook(tool),
+    };
+  } catch (err) {
+    logError(
+      `[tools] skipped invalid tool definition "${name}": ${describeToolDefinitionError(err)}`,
+    );
+    return undefined;
+  }
+}
+
+function describeToolDefinitionError(err: unknown): string {
+  if (err instanceof Error && err.message) {
+    return err.message;
+  }
+  return String(err);
+}
+
+function snapshotToolDefinitionSchema(value: unknown): ToolDefinition["parameters"] {
+  if (value === undefined) {
+    return undefined as unknown as ToolDefinition["parameters"];
+  }
+  return cloneToolDefinitionSchemaValue(
+    value,
+    {
+      seen: new WeakSet<object>(),
+      nodes: 0,
+    },
+    0,
+  ) as ToolDefinition["parameters"];
+}
+
+function cloneToolDefinitionSchemaValue(
+  value: unknown,
+  state: ToolDefinitionSchemaCloneState,
+  depth: number,
+): unknown {
+  if (value === null || typeof value === "string" || typeof value === "boolean") {
+    return value;
+  }
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) {
+      throw new InvalidToolDefinitionSchemaError();
+    }
+    return value;
+  }
+  if (typeof value !== "object") {
+    throw new InvalidToolDefinitionSchemaError();
+  }
+  if (depth > TOOL_DEFINITION_SCHEMA_MAX_DEPTH || state.seen.has(value)) {
+    throw new InvalidToolDefinitionSchemaError();
+  }
+  state.nodes += 1;
+  if (state.nodes > TOOL_DEFINITION_SCHEMA_MAX_NODES) {
+    throw new InvalidToolDefinitionSchemaError();
+  }
+  state.seen.add(value);
+  try {
+    if (Array.isArray(value)) {
+      return value.map((entry) => cloneToolDefinitionSchemaValue(entry, state, depth + 1));
+    }
+    if (!isPlainObject(value)) {
+      throw new InvalidToolDefinitionSchemaError();
+    }
+    const cloned: Record<string, unknown> = {};
+    for (const key of Object.keys(value)) {
+      const clonedValue = cloneToolDefinitionSchemaValue(Reflect.get(value, key), state, depth + 1);
+      if (key === "__proto__") {
+        Object.defineProperty(cloned, key, {
+          value: clonedValue,
+          enumerable: true,
+          configurable: true,
+          writable: true,
+        });
+      } else {
+        cloned[key] = clonedValue;
+      }
+    }
+    return cloned;
+  } finally {
+    state.seen.delete(value);
+  }
 }
 
 /**

--- a/src/agents/sessions/agent-session.ts
+++ b/src/agents/sessions/agent-session.ts
@@ -93,7 +93,10 @@ import { type BuildSystemPromptOptions, buildSystemPrompt } from "./system-promp
 import type { BashOperations } from "./tools/bash-operations.js";
 import { createLocalBashOperations } from "./tools/bash.js";
 import { createAllToolDefinitions } from "./tools/index.js";
-import { createToolDefinitionFromAgentTool } from "./tools/tool-definition-wrapper.js";
+import {
+  createToolDefinitionsFromAgentTools,
+  snapshotSessionToolDefinitions,
+} from "./tools/tool-definition-wrapper.js";
 
 function unwrapCoreResult<T>(result: { ok: true; value: T } | { ok: false; error: Error }): T {
   if (result.ok) {
@@ -383,7 +386,7 @@ export class AgentSession {
     this.settingsManager = config.settingsManager;
     this.scopedModelEntries = config.scopedModels ?? [];
     this.sessionResourceLoader = config.resourceLoader;
-    this.customTools = config.customTools ?? [];
+    this.customTools = snapshotSessionToolDefinitions(config.customTools ?? []);
     this.cwd = config.cwd;
     this.sessionModelRegistry = config.modelRegistry;
     this.extensionRunnerRef = config.extensionRunnerRef;
@@ -2485,12 +2488,7 @@ export class AgentSession {
     const shellCommandPrefix = this.settingsManager.getShellCommandPrefix();
     const shellPath = this.settingsManager.getShellPath();
     const baseToolDefinitions = this.baseToolsOverride
-      ? Object.fromEntries(
-          Object.entries(this.baseToolsOverride).map(([name, tool]) => [
-            name,
-            createToolDefinitionFromAgentTool(tool),
-          ]),
-        )
+      ? createToolDefinitionsFromAgentTools(this.baseToolsOverride)
       : createAllToolDefinitions(this.cwd, {
           read: { autoResizeImages },
           bash: { commandPrefix: shellCommandPrefix, shellPath },
@@ -2521,7 +2519,7 @@ export class AgentSession {
     this.applyExtensionBindings(this.currentExtensionRunner);
 
     const defaultActiveToolNames = this.baseToolsOverride
-      ? Object.keys(this.baseToolsOverride)
+      ? Array.from(this.baseToolDefinitions.keys())
       : ["read", "bash", "edit", "write"];
     const baseActiveToolNames = options.activeToolNames ?? defaultActiveToolNames;
     this.refreshToolRegistry({

--- a/src/agents/sessions/extensions/loader.test.ts
+++ b/src/agents/sessions/extensions/loader.test.ts
@@ -47,4 +47,43 @@ export default async function(api) {
     expect(result.extensions).toHaveLength(1);
     expect(result.extensions[0]?.commands.has("sdk-subpath-probe")).toBe(true);
   });
+
+  it("skips invalid registered tool schemas without failing extension load", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "openclaw-extension-tool-schema-"));
+    tempDirs.push(dir);
+    const extensionPath = join(dir, "extension.ts");
+    await writeFile(
+      extensionPath,
+      `
+export default async function(api) {
+  api.registerTool({
+    name: "bad_lookup",
+    label: "Bad Lookup",
+    description: "bad",
+    get parameters() {
+      throw new Error("revoked schema");
+    },
+    async execute() {
+      return { content: [{ type: "text", text: "bad" }], details: {} };
+    },
+  });
+  api.registerTool({
+    name: "healthy_lookup",
+    label: "Healthy Lookup",
+    description: "healthy",
+    parameters: { type: "object", properties: {} },
+    async execute() {
+      return { content: [{ type: "text", text: "ok" }], details: {} };
+    },
+  });
+}
+`,
+    );
+
+    const result = await loadExtensions([extensionPath], dir);
+
+    expect(result.errors).toEqual([]);
+    expect(result.extensions).toHaveLength(1);
+    expect(Array.from(result.extensions[0]?.tools.keys() ?? [])).toEqual(["healthy_lookup"]);
+  });
 });

--- a/src/agents/sessions/extensions/loader.ts
+++ b/src/agents/sessions/extensions/loader.ts
@@ -29,6 +29,7 @@ import type { ExecOptions } from "../exec.js";
 import { execCommand } from "../exec.js";
 import * as bundledAgentSessions from "../extension-sdk.js";
 import { createSyntheticSourceInfo } from "../source-info.js";
+import { snapshotSessionToolDefinition } from "../tools/tool-definition-wrapper.js";
 import type {
   Extension,
   ExtensionAPI,
@@ -226,8 +227,12 @@ function createExtensionAPI(
 
     registerTool(tool: ToolDefinition): void {
       runtime.assertActive();
-      extension.tools.set(tool.name, {
-        definition: tool,
+      const definition = snapshotSessionToolDefinition(tool);
+      if (!definition) {
+        return;
+      }
+      extension.tools.set(definition.name, {
+        definition,
         sourceInfo: extension.sourceInfo,
       });
       runtime.refreshTools();

--- a/src/agents/sessions/sdk.test.ts
+++ b/src/agents/sessions/sdk.test.ts
@@ -121,6 +121,46 @@ describe("createAgentSession tool defaults", () => {
     expect(session.getActiveToolNames()).toEqual(["custom_lookup"]);
   });
 
+  it("skips unreadable custom tool schemas while preserving healthy custom tools", async () => {
+    const badTool = {
+      name: "bad_lookup",
+      label: "Bad Lookup",
+      description: "Bad custom lookup.",
+      execute: async () => ({
+        content: [{ type: "text" as const, text: "bad" }],
+        details: {},
+      }),
+    } as ToolDefinition;
+    Object.defineProperty(badTool, "parameters", {
+      get: () => {
+        throw new Error("revoked schema");
+      },
+    });
+    const healthyTool: ToolDefinition = {
+      name: "custom_lookup",
+      label: "Custom Lookup",
+      description: "Looks up a test value.",
+      parameters: Type.Object({}),
+      execute: async () => ({
+        content: [{ type: "text", text: "ok" }],
+        details: {},
+      }),
+    };
+
+    const { session } = await createAgentSession({
+      model: testModel,
+      noTools: "builtin",
+      customTools: [badTool, healthyTool],
+      resourceLoader: createEmptyResourceLoader(),
+      sessionManager: SessionManager.inMemory(),
+      settingsManager: SettingsManager.inMemory(),
+      modelRegistry: ModelRegistry.inMemory(AuthStorage.inMemory()),
+    });
+
+    expect(session.getActiveToolNames()).toEqual(["custom_lookup"]);
+    expect(session.getAllTools().map((tool) => tool.name)).toEqual(["custom_lookup"]);
+  });
+
   it("preserves an exact base system prompt when active tools change", async () => {
     const customTool: ToolDefinition = {
       name: "custom_lookup",

--- a/src/agents/sessions/sdk.ts
+++ b/src/agents/sessions/sdk.ts
@@ -40,6 +40,7 @@ import {
   type ToolName,
   withFileMutationQueue,
 } from "./tools/index.js";
+import { snapshotSessionToolDefinitions } from "./tools/tool-definition-wrapper.js";
 
 export interface CreateAgentSessionOptions {
   /** Working directory for project-local discovery. Default: process.cwd() */
@@ -288,7 +289,8 @@ export async function createAgentSession(
   }
 
   const defaultActiveToolNames: ToolName[] = ["read", "bash", "edit", "write"];
-  const customToolNames = options.customTools?.map((tool) => tool.name) ?? [];
+  const customTools = snapshotSessionToolDefinitions(options.customTools ?? []);
+  const customToolNames = customTools.map((tool) => tool.name);
   const allowedToolNames = options.tools ?? (options.noTools === "all" ? [] : undefined);
   const disableBuiltInTools = !options.tools && options.noTools === "builtin";
   const initialActiveToolNames: string[] = options.tools
@@ -431,7 +433,7 @@ export async function createAgentSession(
     cwd,
     scopedModels: options.scopedModels,
     resourceLoader,
-    customTools: options.customTools,
+    customTools,
     modelRegistry,
     initialActiveToolNames,
     allowedToolNames,

--- a/src/agents/sessions/tools/tool-definition-wrapper.test.ts
+++ b/src/agents/sessions/tools/tool-definition-wrapper.test.ts
@@ -1,0 +1,125 @@
+import { Type } from "typebox";
+import { describe, expect, it } from "vitest";
+import type { AgentTool } from "../../runtime/index.js";
+import type { ToolDefinition } from "../extensions/types.js";
+import {
+  createToolDefinitionsFromAgentTools,
+  snapshotSessionToolDefinitions,
+  wrapToolDefinitions,
+} from "./tool-definition-wrapper.js";
+
+function createUnreadableParametersDefinition(name: string): ToolDefinition {
+  const definition = {
+    name,
+    label: name,
+    description: "bad schema",
+    execute: async () => ({
+      content: [{ type: "text" as const, text: "bad" }],
+    }),
+  } as ToolDefinition;
+  Object.defineProperty(definition, "parameters", {
+    get: () => {
+      throw new Error("revoked schema");
+    },
+  });
+  return definition;
+}
+
+describe("session tool definition wrapper", () => {
+  it("skips unreadable ToolDefinition schemas while preserving healthy siblings", () => {
+    const healthy = {
+      name: "healthy_lookup",
+      label: "Healthy Lookup",
+      description: "survives bad siblings",
+      parameters: Type.Object({ query: Type.String() }),
+      execute: async () => ({
+        content: [{ type: "text" as const, text: "ok" }],
+      }),
+    } satisfies ToolDefinition;
+
+    const tools = wrapToolDefinitions([
+      createUnreadableParametersDefinition("bad_lookup"),
+      healthy,
+    ]);
+
+    expect(tools.map((tool) => tool.name)).toEqual(["healthy_lookup"]);
+  });
+
+  it("snapshots schemas without stripping TypeBox metadata", () => {
+    const parameters = Type.Object({ query: Type.String() });
+    const [snapshot] = snapshotSessionToolDefinitions([
+      {
+        name: "search",
+        label: "Search",
+        description: "searches",
+        parameters,
+        execute: async () => ({
+          content: [{ type: "text" as const, text: "ok" }],
+        }),
+      },
+    ]);
+    if (!snapshot) {
+      throw new Error("missing snapshot");
+    }
+    (parameters.properties.query as Record<string, unknown>).type = "number";
+
+    expect(snapshot.parameters).not.toBe(parameters);
+    expect(snapshot.parameters).toMatchObject({
+      type: "object",
+      properties: { query: { type: "string" } },
+    });
+    expect(Object.getOwnPropertyDescriptor(snapshot.parameters, "~kind")).toMatchObject({
+      value: "Object",
+      enumerable: false,
+    });
+  });
+
+  it("keeps tools that intentionally omit a parameter schema", () => {
+    const [tool] = wrapToolDefinitions([
+      {
+        name: "no_args",
+        label: "No Args",
+        description: "accepts no arguments",
+        parameters: undefined as never,
+        execute: async () => ({
+          content: [{ type: "text" as const, text: "ok" }],
+        }),
+      },
+    ]);
+
+    expect(tool?.name).toBe("no_args");
+    expect(tool?.parameters).toBeUndefined();
+  });
+
+  it("skips unreadable AgentTool schemas while preserving healthy base overrides", () => {
+    const badTool = {
+      name: "bad_override",
+      label: "Bad Override",
+      description: "bad schema",
+      execute: async () => ({
+        content: [{ type: "text" as const, text: "bad" }],
+      }),
+    } as AgentTool;
+    Object.defineProperty(badTool, "parameters", {
+      get: () => {
+        throw new Error("revoked schema");
+      },
+    });
+    const healthyTool = {
+      name: "healthy_override",
+      label: "Healthy Override",
+      description: "survives bad overrides",
+      parameters: Type.Object({ query: Type.String() }),
+      execute: async () => ({
+        content: [{ type: "text" as const, text: "ok" }],
+      }),
+    } satisfies AgentTool;
+
+    const definitions = createToolDefinitionsFromAgentTools({
+      bad_override: badTool,
+      healthy_override: healthyTool,
+    });
+
+    expect(Object.keys(definitions)).toEqual(["healthy_override"]);
+  });
+});

--- a/src/agents/sessions/tools/tool-definition-wrapper.ts
+++ b/src/agents/sessions/tools/tool-definition-wrapper.ts
@@ -4,16 +4,212 @@
  * Bridges extension-style ToolDefinition objects and core runtime AgentTool objects.
  */
 import type { TSchema } from "typebox";
+import { logError } from "../../../logger.js";
+import { isPlainObject } from "../../../utils.js";
 import type { AgentTool } from "../../runtime/index.js";
 import type { ExtensionContext, ToolDefinition } from "../extensions/types.js";
 
-/** Wrap a ToolDefinition into an AgentTool for the core runtime. */
-export function wrapToolDefinition<
+const SESSION_TOOL_SCHEMA_MAX_DEPTH = 24;
+const SESSION_TOOL_SCHEMA_MAX_NODES = 1_000;
+
+class InvalidSessionToolSchemaError extends Error {
+  constructor() {
+    super("parameters schema is not JSON-document-compatible");
+    this.name = "InvalidSessionToolSchemaError";
+  }
+}
+
+type SessionToolSchemaCloneState = {
+  seen: WeakSet<object>;
+  nodes: number;
+};
+
+function describeSessionToolSnapshotError(err: unknown): string {
+  if (err instanceof Error && err.message) {
+    return err.message;
+  }
+  return String(err);
+}
+
+function readStringField(value: unknown, fieldName: string, fallback?: string): string {
+  if (typeof value === "string" && value.length > 0) {
+    return value;
+  }
+  if (value == null || value === "") {
+    if (fallback !== undefined) {
+      return fallback;
+    }
+    throw new Error(`${fieldName} is required`);
+  }
+  throw new Error(`${fieldName} must be a string`);
+}
+
+function cloneSessionToolSchema<TParams extends TSchema>(schema: TParams): TParams {
+  if (schema === undefined) {
+    return undefined as unknown as TParams;
+  }
+  return cloneSessionToolSchemaValue(
+    schema,
+    {
+      seen: new WeakSet<object>(),
+      nodes: 0,
+    },
+    0,
+  ) as TParams;
+}
+
+function cloneSessionToolSchemaValue(
+  value: unknown,
+  state: SessionToolSchemaCloneState,
+  depth: number,
+): unknown {
+  if (value === null || typeof value === "string" || typeof value === "boolean") {
+    return value;
+  }
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) {
+      throw new InvalidSessionToolSchemaError();
+    }
+    return value;
+  }
+  if (typeof value !== "object") {
+    throw new InvalidSessionToolSchemaError();
+  }
+  if (depth > SESSION_TOOL_SCHEMA_MAX_DEPTH || state.seen.has(value)) {
+    throw new InvalidSessionToolSchemaError();
+  }
+  state.nodes += 1;
+  if (state.nodes > SESSION_TOOL_SCHEMA_MAX_NODES) {
+    throw new InvalidSessionToolSchemaError();
+  }
+  state.seen.add(value);
+  try {
+    if (Array.isArray(value)) {
+      return value.map((entry) => cloneSessionToolSchemaValue(entry, state, depth + 1));
+    }
+    if (!isPlainObject(value)) {
+      throw new InvalidSessionToolSchemaError();
+    }
+    const cloned: Record<string, unknown> = {};
+    for (const key of Object.getOwnPropertyNames(value)) {
+      const descriptor = Object.getOwnPropertyDescriptor(value, key);
+      if (!descriptor) {
+        continue;
+      }
+      const rawValue = "value" in descriptor ? descriptor.value : Reflect.get(value, key);
+      const clonedValue = cloneSessionToolSchemaValue(rawValue, state, depth + 1);
+      Object.defineProperty(cloned, key, {
+        value: clonedValue,
+        enumerable: descriptor.enumerable,
+        configurable: true,
+        writable: true,
+      });
+    }
+    return cloned;
+  } finally {
+    state.seen.delete(value);
+  }
+}
+
+/** Snapshot a session ToolDefinition before it crosses runtime boundaries. */
+export function snapshotSessionToolDefinition<
   TParams extends TSchema = TSchema,
   TDetails = unknown,
   TState = unknown,
 >(
   definition: ToolDefinition<TParams, TDetails, TState>,
+): ToolDefinition<TParams, TDetails, TState> | undefined {
+  let name = "tool";
+  try {
+    name = readStringField(definition.name, "tool name");
+    const label = readStringField(definition.label, "tool label", name);
+    const description = typeof definition.description === "string" ? definition.description : "";
+    const parameters = cloneSessionToolSchema(definition.parameters);
+    const executeValue = Reflect.get(definition, "execute");
+    if (typeof executeValue !== "function") {
+      throw new Error("tool execute must be a function");
+    }
+    const execute = executeValue.bind(definition);
+    const promptSnippet =
+      typeof definition.promptSnippet === "string" ? definition.promptSnippet : undefined;
+    const promptGuidelines = Array.isArray(definition.promptGuidelines)
+      ? definition.promptGuidelines.filter((entry): entry is string => typeof entry === "string")
+      : undefined;
+    const renderShell =
+      definition.renderShell === "default" || definition.renderShell === "self"
+        ? definition.renderShell
+        : undefined;
+    const prepareArgumentsValue = Reflect.get(definition, "prepareArguments");
+    const prepareArguments =
+      typeof prepareArgumentsValue === "function"
+        ? (prepareArgumentsValue.bind(definition) as ToolDefinition<
+            TParams,
+            TDetails,
+            TState
+          >["prepareArguments"])
+        : undefined;
+    const executionMode =
+      definition.executionMode === "parallel" || definition.executionMode === "sequential"
+        ? definition.executionMode
+        : undefined;
+    const renderCallValue = Reflect.get(definition, "renderCall");
+    const renderCall =
+      typeof renderCallValue === "function"
+        ? (renderCallValue.bind(definition) as ToolDefinition<
+            TParams,
+            TDetails,
+            TState
+          >["renderCall"])
+        : undefined;
+    const renderResultValue = Reflect.get(definition, "renderResult");
+    const renderResult =
+      typeof renderResultValue === "function"
+        ? (renderResultValue.bind(definition) as ToolDefinition<
+            TParams,
+            TDetails,
+            TState
+          >["renderResult"])
+        : undefined;
+
+    return {
+      name,
+      label,
+      description,
+      ...(promptSnippet !== undefined ? { promptSnippet } : {}),
+      ...(promptGuidelines && promptGuidelines.length > 0 ? { promptGuidelines } : {}),
+      parameters,
+      ...(renderShell ? { renderShell } : {}),
+      ...(prepareArguments ? { prepareArguments } : {}),
+      ...(executionMode ? { executionMode } : {}),
+      execute: (toolCallId, params, signal, onUpdate, ctx) =>
+        execute(toolCallId, params, signal, onUpdate, ctx),
+      ...(renderCall ? { renderCall } : {}),
+      ...(renderResult ? { renderResult } : {}),
+    } satisfies ToolDefinition<TParams, TDetails, TState>;
+  } catch (err) {
+    logError(
+      `[tools] skipped invalid session tool definition "${name}": ${describeSessionToolSnapshotError(err)}`,
+    );
+    return undefined;
+  }
+}
+
+/** Snapshot a batch of session ToolDefinitions, dropping only malformed tools. */
+export function snapshotSessionToolDefinitions(
+  definitions: readonly ToolDefinition[],
+): ToolDefinition[] {
+  const snapshots: ToolDefinition[] = [];
+  for (const definition of definitions) {
+    const snapshot = snapshotSessionToolDefinition(definition);
+    if (snapshot) {
+      snapshots.push(snapshot);
+    }
+  }
+  return snapshots;
+}
+
+function wrapSessionToolDefinitionSnapshot<TParams extends TSchema = TSchema, TDetails = unknown>(
+  definition: ToolDefinition<TParams, TDetails>,
   ctxFactory?: () => ExtensionContext,
 ): AgentTool<TParams, TDetails> {
   return {
@@ -28,12 +224,67 @@ export function wrapToolDefinition<
   };
 }
 
+/** Wrap a ToolDefinition into an AgentTool for the core runtime. */
+export function wrapToolDefinition<
+  TParams extends TSchema = TSchema,
+  TDetails = unknown,
+  TState = unknown,
+>(
+  definition: ToolDefinition<TParams, TDetails, TState>,
+  ctxFactory?: () => ExtensionContext,
+): AgentTool<TParams, TDetails> {
+  const snapshot = snapshotSessionToolDefinition(definition);
+  if (!snapshot) {
+    throw new Error("invalid session tool definition");
+  }
+  return wrapSessionToolDefinitionSnapshot(snapshot, ctxFactory);
+}
+
 /** Wrap multiple ToolDefinitions into AgentTools for the core runtime. */
 export function wrapToolDefinitions(
   definitions: ToolDefinition[],
   ctxFactory?: () => ExtensionContext,
 ): AgentTool[] {
-  return definitions.map((definition) => wrapToolDefinition(definition, ctxFactory));
+  return snapshotSessionToolDefinitions(definitions).map((definition) =>
+    wrapSessionToolDefinitionSnapshot(definition, ctxFactory),
+  );
+}
+
+function snapshotAgentToolAsDefinition(tool: AgentTool): ToolDefinition | undefined {
+  let name = "tool";
+  try {
+    name = readStringField(tool.name, "tool name");
+    const label = readStringField(tool.label, "tool label", name);
+    const description = typeof tool.description === "string" ? tool.description : "";
+    const parameters = cloneSessionToolSchema(tool.parameters);
+    const executeValue = Reflect.get(tool, "execute");
+    if (typeof executeValue !== "function") {
+      throw new Error("tool execute must be a function");
+    }
+    const execute = executeValue.bind(tool);
+    const prepareArgumentsValue = Reflect.get(tool, "prepareArguments");
+    const prepareArguments =
+      typeof prepareArgumentsValue === "function"
+        ? (prepareArgumentsValue.bind(tool) as AgentTool["prepareArguments"])
+        : undefined;
+    return {
+      name,
+      label,
+      description,
+      parameters,
+      ...(prepareArguments ? { prepareArguments } : {}),
+      ...(tool.executionMode === "parallel" || tool.executionMode === "sequential"
+        ? { executionMode: tool.executionMode }
+        : {}),
+      execute: async (toolCallId, params, signal, onUpdate) =>
+        execute(toolCallId, params, signal, onUpdate),
+    } satisfies ToolDefinition;
+  } catch (err) {
+    logError(
+      `[tools] skipped invalid agent tool definition "${name}": ${describeSessionToolSnapshotError(err)}`,
+    );
+    return undefined;
+  }
 }
 
 /**
@@ -43,14 +294,23 @@ export function wrapToolDefinitions(
  * provides plain AgentTool overrides that do not include prompt metadata or renderers.
  */
 export function createToolDefinitionFromAgentTool(tool: AgentTool): ToolDefinition {
-  return {
-    name: tool.name,
-    label: tool.label,
-    description: tool.description,
-    parameters: tool.parameters,
-    prepareArguments: tool.prepareArguments,
-    executionMode: tool.executionMode,
-    execute: async (toolCallId, params, signal, onUpdate) =>
-      tool.execute(toolCallId, params, signal, onUpdate),
-  };
+  const snapshot = snapshotAgentToolAsDefinition(tool);
+  if (!snapshot) {
+    throw new Error("invalid agent tool definition");
+  }
+  return snapshot;
+}
+
+/** Convert a base-tool override record while quarantining malformed entries. */
+export function createToolDefinitionsFromAgentTools(
+  tools: Record<string, AgentTool>,
+): Record<string, ToolDefinition> {
+  const definitions: Record<string, ToolDefinition> = {};
+  for (const tool of Object.values(tools)) {
+    const definition = snapshotAgentToolAsDefinition(tool);
+    if (definition) {
+      definitions[definition.name] = definition;
+    }
+  }
+  return definitions;
 }


### PR DESCRIPTION
Summary
- Snapshots session tool definitions and registered extension tool definitions before agent runtime paths normalize or execute them.
- Quarantines unreadable schema/name values while preserving healthy sibling tools and existing execution/error behavior.
- Cherry-picked from the superseded large split stack in https://github.com/openclaw/openclaw/pull/90411: `b4cc7c792c9` and `8c92f6bc055`.

Verification
- `node scripts/run-vitest.mjs run src/agents/agent-tool-definition-adapter.test.ts src/agents/sessions/extensions/loader.test.ts src/agents/sessions/sdk.test.ts src/agents/sessions/tools/tool-definition-wrapper.test.ts --reporter=dot`
- `./node_modules/.bin/oxfmt --check src/agents/agent-tool-definition-adapter.test.ts src/agents/agent-tool-definition-adapter.ts src/agents/sessions/agent-session.ts src/agents/sessions/extensions/loader.test.ts src/agents/sessions/extensions/loader.ts src/agents/sessions/sdk.test.ts src/agents/sessions/sdk.ts src/agents/sessions/tools/tool-definition-wrapper.test.ts src/agents/sessions/tools/tool-definition-wrapper.ts`
- `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/agents/agent-tool-definition-adapter.test.ts src/agents/agent-tool-definition-adapter.ts src/agents/sessions/agent-session.ts src/agents/sessions/extensions/loader.test.ts src/agents/sessions/extensions/loader.ts src/agents/sessions/sdk.test.ts src/agents/sessions/sdk.ts src/agents/sessions/tools/tool-definition-wrapper.test.ts src/agents/sessions/tools/tool-definition-wrapper.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

Behavior addressed
- Session and extension-registered tool definitions are copied at the boundary so later schema/name getter failures or mutations cannot break unrelated healthy tools.

Real environment tested
- macOS linked OpenClaw worktree with shared install and focused Vitest/lint/format checks.

Exact steps or command run after this patch
- Ran the focused commands listed in Verification after cherry-picking the agent/session snapshot commits.

Evidence after fix
- 34 focused tests passed across agent tool definition adaptation, session SDK custom tools, extension loader registration, and session tool wrapping.
- Focused format, core oxlint, whitespace check, and autoreview passed.

Observed result after fix
- Bad session/extension tool schema or name access is quarantined locally, while healthy tools remain registered and callable.

What was not tested
- Broad `pnpm check:changed` was not run locally because this is a linked/sparse worktree and disk is currently tight; PR CI should cover the wider gate.
