### PR TITLE
fix(memory): rebind qmd collections after workspace moves

### DIFF
--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -899,6 +899,66 @@ describe("QmdMemoryManager", () => {
     expect(addCalls).toHaveLength(0);
   });
 
+  it("rebinds collection when qmd collection show reveals a stale path", async () => {
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+          sessions: { enabled: true },
+        },
+      },
+    } as OpenClawConfig;
+
+    const sessionCollectionName = `sessions-${agentId}`;
+    const wrongSessionsPath = path.join(stateDir, "agents", "other-agent", "qmd", "sessions");
+    spawnMock.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === "collection" && args[1] === "list") {
+        const child = createMockChild({ autoClose: false });
+        emitAndClose(child, "stdout", JSON.stringify([sessionCollectionName]));
+        return child;
+      }
+      if (args[0] === "collection" && args[1] === "show" && args[2] === sessionCollectionName) {
+        const child = createMockChild({ autoClose: false });
+        emitAndClose(
+          child,
+          "stdout",
+          [
+            `Collection: ${sessionCollectionName}`,
+            `Path: ${wrongSessionsPath}`,
+            "Pattern: **/*.md",
+          ].join("\n"),
+        );
+        return child;
+      }
+      return createMockChild();
+    });
+
+    const { manager } = await createManager({ mode: "full" });
+    await manager.close();
+
+    const commands = spawnMock.mock.calls.map((call: unknown[]) => call[1] as string[]);
+    const removeSessions = commands.find(
+      (args) =>
+        args[0] === "collection" && args[1] === "remove" && args[2] === sessionCollectionName,
+    );
+    requireValue(removeSessions, "sessions collection remove command missing");
+
+    const addSessions = commands.find((args) => {
+      if (args[0] !== "collection" || args[1] !== "add") {
+        return false;
+      }
+      const nameIdx = args.indexOf("--name");
+      return nameIdx >= 0 && args[nameIdx + 1] === sessionCollectionName;
+    });
+    expect(requireValue(addSessions, "sessions collection add command missing")[2]).toBe(
+      path.join(stateDir, "agents", agentId, "qmd", "sessions"),
+    );
+  });
+
   it("rebinds collection when qmd text output exposes a changed pattern without a path", async () => {
     cfg = {
       ...cfg,

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -654,10 +654,40 @@ export class QmdMemoryManager implements MemorySearchManager {
       for (const [name, details] of parsed) {
         existing.set(name, details);
       }
+      await this.enrichListedCollectionsBestEffort(existing);
     } catch {
       // ignore; older qmd versions might not support list --json.
     }
     return existing;
+  }
+
+  private async enrichListedCollectionsBestEffort(
+    existing: Map<string, ListedCollection>,
+  ): Promise<void> {
+    for (const [name, details] of existing) {
+      if (details.path && typeof details.pattern === "string") {
+        continue;
+      }
+      const described = await this.describeCollectionBestEffort(name);
+      if (!described) {
+        continue;
+      }
+      existing.set(name, {
+        path: described.path ?? details.path,
+        pattern: described.pattern ?? details.pattern,
+      });
+    }
+  }
+
+  private async describeCollectionBestEffort(name: string): Promise<ListedCollection | null> {
+    try {
+      const result = await this.runQmd(["collection", "show", name], {
+        timeoutMs: this.qmd.update.commandTimeoutMs,
+      });
+      return this.parseCollectionDetails(result.stdout);
+    } catch {
+      return null;
+    }
   }
 
   private findCollectionByPathPattern(
@@ -979,6 +1009,43 @@ export class QmdMemoryManager implements MemorySearchManager {
       }
     }
     return listed;
+  }
+
+  private parseCollectionDetails(output: string): ListedCollection | null {
+    const trimmed = output.trim();
+    if (!trimmed) {
+      return null;
+    }
+    try {
+      const parsed = JSON.parse(trimmed) as unknown;
+      if (parsed && typeof parsed === "object") {
+        const path = (parsed as { path?: unknown }).path;
+        const pattern = (parsed as { pattern?: unknown; mask?: unknown }).pattern;
+        const mask = (parsed as { mask?: unknown }).mask;
+        return {
+          path: typeof path === "string" ? path : undefined,
+          pattern:
+            typeof pattern === "string" ? pattern : typeof mask === "string" ? mask : undefined,
+        };
+      }
+    } catch {
+      // fall through to text parsing
+    }
+
+    const details: ListedCollection = {};
+    for (const rawLine of output.split(/\r?\n/)) {
+      const line = rawLine.trimEnd();
+      const pathLine = /^\s*path\s*:\s*(.+?)\s*$/i.exec(line);
+      if (pathLine) {
+        details.path = pathLine[1].trim();
+        continue;
+      }
+      const patternLine = /^\s*(?:pattern|mask)\s*:\s*(.+?)\s*$/i.exec(line);
+      if (patternLine) {
+        details.pattern = patternLine[1].trim();
+      }
+    }
+    return details.path || details.pattern ? details : null;
   }
 
   private shouldRebindCollection(collection: ManagedCollection, listed: ListedCollection): boolean {


### PR DESCRIPTION
## Summary

Teach the qmd memory manager to enrich `collection list` results with `collection show` metadata before deciding whether a managed collection needs to be rebound. That lets workspace path moves trigger the intended remove+add flow instead of staying pinned to the stale root when `list --json` omits filesystem paths.

## Changes

- hydrate missing collection `path` / `pattern` fields via `qmd collection show <name>`
- reuse the enriched metadata in the existing rebind decision path
- add a regression test covering list-name-only output plus stale-path recovery via `collection show`

## Testing

- `pnpm test extensions/memory-core/src/memory/qmd-manager.test.ts`

Fixes openclaw/openclaw#91251