### PR TITLE
fix(agents): strip reasoning_content placeholder signatures from Anthropic replay history

### DIFF
--- a/src/agents/embedded-agent-runner.sanitize-session-history.test.ts
+++ b/src/agents/embedded-agent-runner.sanitize-session-history.test.ts
@@ -2348,6 +2348,35 @@ describe("sanitizeSessionHistory", () => {
     expect((textBlocks[0] as { text?: string }).text).toBe("result");
   });
 
+  it("strips reasoning_content placeholder signatures from prior assistant turns for native Anthropic replay", async () => {
+    setNonGoogleModelApi();
+
+    const messages = castAgentMessages([
+      makeUserMessage("first"),
+      makeAssistantMessage([
+        {
+          type: "thinking",
+          thinking: "xai private reasoning",
+          thinkingSignature: "reasoning_content",
+        },
+        { type: "text", text: "xai answer" },
+      ]),
+      makeUserMessage("second"),
+    ]);
+
+    const result = await sanitizeAnthropicHistory({
+      messages,
+      preserveLatestAssistantThinking: false,
+    });
+
+    const assistant = getAssistantMessage(result);
+    const thinkingBlocks = assistant.content.filter(
+      (b: { type: string }) => b.type === "thinking" || b.type === "redacted_thinking",
+    );
+    expect(thinkingBlocks).toHaveLength(0);
+    expect(assistant.content).toEqual([{ type: "text", text: "xai answer" }]);
+  });
+
   it("preserves unsigned thinking blocks for kimi coding with anthropic-messages transport", async () => {
     setNonGoogleModelApi();
 

--- a/src/agents/embedded-agent-runner/thinking.ts
+++ b/src/agents/embedded-agent-runner/thinking.ts
@@ -228,7 +228,12 @@ function hasReplayableThinkingSignature(block: AssistantContentBlock): boolean {
       ? [record.data, record.signature, record.thinkingSignature, record.thought_signature]
       : [record.signature, record.thinkingSignature, record.thought_signature];
   return candidates.some((signature) => {
-    return typeof signature === "string" && signature.trim().length > 0;
+    // "reasoning_content" is an OpenAI-compat placeholder, not a valid Anthropic signature.
+    return (
+      typeof signature === "string" &&
+      signature.trim().length > 0 &&
+      signature !== "reasoning_content"
+    );
   });
 }
 


### PR DESCRIPTION
### Summary

- **Problem**: When a session switches from an OpenAI-compatible provider (xAI, DeepSeek, etc.) to a native Anthropic model and is reloaded from JSONL, prior assistant turns may carry thinking blocks with `thinkingSignature: "reasoning_content"` — an OpenAI-compat wire sentinel set by `anthropic-transport-stream.ts` when capturing reasoning from non-Anthropic providers. `hasReplayableThinkingSignature` treated any non-blank string as a valid Anthropic signature, so `stripInvalidThinkingSignatures` preserved those blocks and forwarded them to Anthropic with `signature: "reasoning_content"`, causing API rejection and bricking the session.
- **Root Cause**: `hasReplayableThinkingSignature` in `src/agents/embedded-agent-runner/thinking.ts` checks only `typeof signature === "string" && signature.trim().length > 0`. The `"reasoning_content"` sentinel is a well-known non-Anthropic placeholder — it is not a real cryptographic signature — but it passes this check unchanged.
- **Fix**: Exclude `"reasoning_content"` from the valid-signature predicate. The change is contained to `hasReplayableThinkingSignature`, which is called only from `stripInvalidThinkingSignatures`. That path runs only when `signedThinkingProvider || policy.preserveSignatures` is true (Anthropic, Bedrock, Vertex); providers that natively consume `reasoning_content` (Kimi, MiMo) do not reach this path.
- **What changed**:
  - `src/agents/embedded-agent-runner/thinking.ts` — exclude `"reasoning_content"` from `hasReplayableThinkingSignature`.
  - `src/agents/embedded-agent-runner.sanitize-session-history.test.ts` — add regression test: prior assistant turns with `thinkingSignature: "reasoning_content"` are stripped during `sanitizeSessionHistory` for a native Anthropic target.
- **What did NOT change (scope boundary)**:
  - Config surface unchanged (no schema, defaults, doctor migrations, or `docs/reference/config`).
  - Plugin surface unchanged (no plugin SDK, manifest, `extensions/*` api/runtime-api, registry/loader).
  - The `stripInvalidThinkingSignatures` call sites, the compaction-stale strip path, and the recovery retry path are unchanged.
  - OpenAI-compatible providers that preserve `reasoning_content` for replay (Kimi, MiMo) are unaffected — their sanitize path does not invoke `stripInvalidThinkingSignatures`.

### Reproduction

1. Start a session with an xAI model (e.g. `grok-4`) — it produces thinking blocks with `thinkingSignature: "reasoning_content"`.
2. Switch the active model to a native Anthropic model and continue the conversation.
3. OpenClaw restarts (or JSONL history is replayed from disk).
4. **Before this PR:** Anthropic API returns a signature validation error; the session is bricked for the remainder of the JSONL-loaded history.
5. **After this PR:** `"reasoning_content"` thinking blocks from prior provider turns are stripped during `sanitizeSessionHistory`; Anthropic replay succeeds.

### Real behavior proof

**Behavior addressed (#91205)**: after a provider switch (xAI → Anthropic) and JSONL reload, sessions carrying prior `reasoning_content` thinking blocks are no longer bricked; `stripInvalidThinkingSignatures` now treats `"reasoning_content"` as an invalid signature and strips those blocks before the Anthropic request is assembled.

**Real environment tested (Linux, Node 22 — Vitest against the production `sanitizeSessionHistory` pipeline with `provider: "anthropic"` and prior assistant turns carrying `thinkingSignature: "reasoning_content"`)**: the new test directly exercises the JSONL-reload path via `sanitizeSessionHistory`.

**Exact steps or command run after this patch**: `pnpm test src/agents/embedded-agent-runner.sanitize-session-history.test.ts`; `pnpm test src/agents/embedded-agent-runner/thinking.test.ts`; `node scripts/run-oxlint.mjs` and `pnpm format:check` on changed files.

**Evidence after fix**:

```
sanitize-session-history.test.ts  Tests  72 passed (72)
thinking.test.ts                  Tests  42 passed (42)
```

New test `strips reasoning_content placeholder signatures from prior assistant turns for native Anthropic replay` fails on the pre-patch tree (thinking block survives) and passes with the fix (thinking block stripped, text block preserved).

**Observed result after fix**: thinking blocks with `thinkingSignature: "reasoning_content"` in prior assistant turns are stripped; text content is preserved; the Anthropic request assembles without a signature validation error.

**What was not tested**: live xAI → Anthropic session reload with a real gateway; Bedrock and Vertex Anthropic endpoints (same `signedThinkingProvider` path — fix applies identically).

**Repro confirmation**: the new test fails on the pre-patch predicate (`signature.trim().length > 0` only) and passes after adding `signature !== "reasoning_content"`, confirming the test covers the production change.

### Risk / Mitigation

- **Risk**: a valid Anthropic thinking signature that happens to equal the string `"reasoning_content"`. **Mitigation**: Anthropic signatures are opaque cryptographic blobs; `"reasoning_content"` is a human-readable sentinel written only by the OpenAI-compat reasoning capture path and never by any Anthropic or Bedrock endpoint. There is no realistic collision.
- **Risk**: Kimi or MiMo `reasoning_content` blocks being stripped in their native replay path. **Mitigation**: those providers use `openai-completions` transport and have `policy.preserveSignatures: false`; `stripInvalidThinkingSignatures` is not in their path — confirmed by passing existing tests at lines 1363–1401 of the test file.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Agent / runtime
- [x] Tests

### Linked Issue/PR

Fixes #91205