### PR TITLE
fix(control-ui): make Control UI bootstrap config endpoint base-path-relative (#66946)

### DIFF
--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -74,7 +74,7 @@ The same browser-local pattern applies to the assistant avatar override. Uploade
 
 ## Runtime config endpoint
 
-The Control UI fetches its runtime settings from `/__openclaw/control-ui-config.json`. That endpoint is gated by the same gateway auth as the rest of the HTTP surface: unauthenticated browsers cannot fetch it, and a successful fetch requires either an already valid gateway token/password, Tailscale Serve identity, or a trusted-proxy identity.
+The Control UI fetches its runtime settings from `/control-ui-config.json`, resolved relative to the gateway's Control UI base path (for example `/__openclaw__/control-ui-config.json` when the UI is served under `/__openclaw__/`). That endpoint is gated by the same gateway auth as the rest of the HTTP surface: unauthenticated browsers cannot fetch it, and a successful fetch requires either an already valid gateway token/password, Tailscale Serve identity, or a trusted-proxy identity.
 
 ## Language support
 

--- a/src/gateway/control-ui-contract.ts
+++ b/src/gateway/control-ui-contract.ts
@@ -1,7 +1,7 @@
 // Control UI bootstrap contract served by the gateway and consumed by the
 // browser app before it knows runtime branding, media roots, or embed policy.
 /** HTTP path for the Control UI bootstrap config payload. */
-export const CONTROL_UI_BOOTSTRAP_CONFIG_PATH = "/__openclaw/control-ui-config.json";
+export const CONTROL_UI_BOOTSTRAP_CONFIG_PATH = "/control-ui-config.json";
 
 /** Sandbox policy for assistant-provided embed surfaces inside Control UI. */
 export type ControlUiEmbedSandboxMode = "strict" | "scripts" | "trusted";

--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -895,6 +895,48 @@ describe("handleControlUiHttpRequest", () => {
     });
   });
 
+  it("serves bootstrap config at the base-path-relative endpoint when mounted under /__openclaw__ (#66946)", async () => {
+    await withControlUiRoot({
+      fn: async (tmp) => {
+        const { res, end } = makeMockHttpResponse();
+        const handled = await handleControlUiHttpRequest(
+          {
+            url: "/__openclaw__/control-ui-config.json",
+            method: "GET",
+          } as IncomingMessage,
+          res,
+          {
+            basePath: "/__openclaw__",
+            root: { kind: "resolved", path: tmp },
+            config: {
+              agents: { defaults: { workspace: tmp } },
+              ui: { assistant: { name: "Ops", avatar: "ops.png" } },
+            },
+          },
+        );
+        expect(handled).toBe(true);
+        expect(res.statusCode).not.toBe(404);
+        const parsed = parseBootstrapPayload(end);
+        expect(parsed.basePath).toBe("/__openclaw__");
+        expect(parsed.assistantAgentId).toBe("main");
+      },
+    });
+  });
+
+  it("does not serve bootstrap config from the doubled /__openclaw__/__openclaw path (#66946)", async () => {
+    await withControlUiRoot({
+      fn: async (tmp) => {
+        const { res, end, handled } = await runControlUiRequest({
+          url: "/__openclaw__/__openclaw/control-ui-config.json",
+          method: "GET",
+          rootPath: tmp,
+          basePath: "/__openclaw__",
+        });
+        expectNotFoundResponse({ handled, res, end });
+      },
+    });
+  });
+
   it("serves local avatar bytes through hardened avatar handler", async () => {
     const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-avatar-http-"));
     try {

--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -972,6 +972,41 @@ describe("handleControlUiHttpRequest", () => {
     });
   });
 
+  // Compatibility regression: current main and v2026.6.1 serve and document the
+  // single-underscore `/__openclaw/control-ui-config.json` endpoint under an empty
+  // base path. #66946 makes the config path base-path-relative; this case proves
+  // the old documented endpoint still returns config (no upgrade 404 break).
+  // Without the LEGACY_BOOTSTRAP_CONFIG_PATH alias this request 404s, so it is not
+  // vacuous.
+  it("still serves bootstrap config at the legacy /__openclaw/control-ui-config.json with no configured basePath (#66946)", async () => {
+    await withControlUiRoot({
+      fn: async (tmp) => {
+        const { res, end } = makeMockHttpResponse();
+        const handled = await handleControlUiHttpRequest(
+          {
+            url: "/__openclaw/control-ui-config.json",
+            method: "GET",
+          } as IncomingMessage,
+          res,
+          {
+            // No basePath: matches the legacy default deployment that documented
+            // and served the single-underscore endpoint.
+            root: { kind: "resolved", path: tmp },
+            config: {
+              agents: { defaults: { workspace: tmp } },
+              ui: { assistant: { name: "Ops", avatar: "ops.png" } },
+            },
+          },
+        );
+        expect(handled).toBe(true);
+        expect(res.statusCode).not.toBe(404);
+        const parsed = parseBootstrapPayload(end);
+        expect(parsed.basePath).toBe("");
+        expect(parsed.assistantAgentId).toBe("main");
+      },
+    });
+  });
+
   it("does not serve bootstrap config from the doubled /__openclaw__/__openclaw path (#66946)", async () => {
     await withControlUiRoot({
       fn: async (tmp) => {

--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -895,7 +895,7 @@ describe("handleControlUiHttpRequest", () => {
     });
   });
 
-  it("serves bootstrap config at the base-path-relative endpoint when mounted under /__openclaw__ (#66946)", async () => {
+  it("serves bootstrap config under the configured /__openclaw__ basePath (#66946)", async () => {
     await withControlUiRoot({
       fn: async (tmp) => {
         const { res, end } = makeMockHttpResponse();
@@ -923,6 +923,55 @@ describe("handleControlUiHttpRequest", () => {
     });
   });
 
+  // Real reported scenario: the gateway has NO configured `gateway.controlUi.basePath`,
+  // so the SPA is served at the default `/__openclaw__/` namespace. The browser opens
+  // the default entry, `inferBasePathFromPathname("/__openclaw__/")` yields `/__openclaw__`,
+  // and the loader fetches `/__openclaw__/control-ui-config.json`. Before this fix the
+  // gateway only matched the bare `/control-ui-config.json` for an empty base path, so the
+  // default-entry request 404ed (issue #66946). This case fails without the namespace alias.
+  it("serves bootstrap config at the default /__openclaw__ entry with no configured basePath (#66946)", async () => {
+    await withControlUiRoot({
+      fn: async (tmp) => {
+        const { res, end } = makeMockHttpResponse();
+        const handled = await handleControlUiHttpRequest(
+          {
+            url: "/__openclaw__/control-ui-config.json",
+            method: "GET",
+          } as IncomingMessage,
+          res,
+          {
+            // No basePath: simulates the default deployment from the issue report.
+            root: { kind: "resolved", path: tmp },
+            config: {
+              agents: { defaults: { workspace: tmp } },
+              ui: { assistant: { name: "Ops", avatar: "ops.png" } },
+            },
+          },
+        );
+        expect(handled).toBe(true);
+        expect(res.statusCode).not.toBe(404);
+        const parsed = parseBootstrapPayload(end);
+        // Configured base path is empty, so the payload reports "" (the loader keeps
+        // its own inferred base path; it does not read this field back for the fetch).
+        expect(parsed.basePath).toBe("");
+        expect(parsed.assistantAgentId).toBe("main");
+      },
+    });
+  });
+
+  it("still serves bootstrap config at the bare /control-ui-config.json for compatibility (#66946)", async () => {
+    await withControlUiRoot({
+      fn: async (tmp) => {
+        const { res, handled, end } = await runBootstrapConfigRequest({ rootPath: tmp });
+        expect(handled).toBe(true);
+        expect(res.statusCode).not.toBe(404);
+        const parsed = parseBootstrapPayload(end);
+        expect(parsed.basePath).toBe("");
+        expect(parsed.assistantAgentId).toBe("main");
+      },
+    });
+  });
+
   it("does not serve bootstrap config from the doubled /__openclaw__/__openclaw path (#66946)", async () => {
     await withControlUiRoot({
       fn: async (tmp) => {
@@ -930,7 +979,6 @@ describe("handleControlUiHttpRequest", () => {
           url: "/__openclaw__/__openclaw/control-ui-config.json",
           method: "GET",
           rootPath: tmp,
-          basePath: "/__openclaw__",
         });
         expectNotFoundResponse({ handled, res, end });
       },

--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -1007,6 +1007,44 @@ describe("handleControlUiHttpRequest", () => {
     });
   });
 
+  // Compatibility regression for configured-base-path deployments: when a
+  // `gateway.controlUi.basePath` is set (e.g. `/openclaw`), current main and
+  // v2026.6.1 serve the bootstrap config at `${basePath}/__openclaw/control-ui-config.json`
+  // (single underscore). #66946 moves the canonical path to
+  // `${basePath}/control-ui-config.json`; this case proves the old configured-base-path
+  // endpoint still returns config so older bundles and proxies that still request it
+  // do not 404 after upgrade. Without the configured-base-path legacy alias this
+  // request 404s, so the assertion is not vacuous.
+  it("still serves bootstrap config at the legacy ${basePath}/__openclaw/control-ui-config.json under a configured basePath (#66946)", async () => {
+    await withControlUiRoot({
+      fn: async (tmp) => {
+        const { res, end } = makeMockHttpResponse();
+        const handled = await handleControlUiHttpRequest(
+          {
+            url: "/openclaw/__openclaw/control-ui-config.json",
+            method: "GET",
+          } as IncomingMessage,
+          res,
+          {
+            basePath: "/openclaw",
+            root: { kind: "resolved", path: tmp },
+            config: {
+              agents: { defaults: { workspace: tmp } },
+              ui: { assistant: { name: "Ops", avatar: "ops.png" } },
+            },
+          },
+        );
+        expect(handled).toBe(true);
+        expect(res.statusCode).not.toBe(404);
+        const parsed = parseBootstrapPayload(end);
+        // The configured base path is reported back so the loader resolves
+        // base-path-relative URLs against it.
+        expect(parsed.basePath).toBe("/openclaw");
+        expect(parsed.assistantAgentId).toBe("main");
+      },
+    });
+  });
+
   it("does not serve bootstrap config from the doubled /__openclaw__/__openclaw path (#66946)", async () => {
     await withControlUiRoot({
       fn: async (tmp) => {

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -846,6 +846,21 @@ const CONTROL_UI_DEFAULT_NAMESPACE_BOOTSTRAP_CONFIG_PATH = `${CONTROL_UI_NAMESPA
   "",
 )}${CONTROL_UI_BOOTSTRAP_CONFIG_PATH}`;
 
+// Single-underscore `/__openclaw` prefix used by the pre-base-path-relative
+// bootstrap endpoint. Before #66946 made the config path base-path-relative,
+// `CONTROL_UI_BOOTSTRAP_CONFIG_PATH` was hard-coded to
+// `/__openclaw/control-ui-config.json`, so current main and the v2026.6.1
+// release serve and document that exact path under an empty base path.
+const LEGACY_CONTROL_UI_NAMESPACE_PREFIX = "/__openclaw";
+
+// The old documented no-base-path bootstrap endpoint
+// (`/__openclaw/control-ui-config.json`, single underscore). It is derived from
+// the legacy `/__openclaw` namespace joined with the canonical config constant
+// so it tracks any rename of the config filename. Kept as an empty-base-path
+// compatibility alias so older bundles and clients that fetch the previously
+// documented endpoint keep receiving config after upgrading instead of 404ing.
+const LEGACY_BOOTSTRAP_CONFIG_PATH = `${LEGACY_CONTROL_UI_NAMESPACE_PREFIX}${CONTROL_UI_BOOTSTRAP_CONFIG_PATH}`;
+
 /**
  * Whether `pathname` should be served the Control UI bootstrap config payload.
  *
@@ -853,8 +868,10 @@ const CONTROL_UI_DEFAULT_NAMESPACE_BOOTSTRAP_CONFIG_PATH = `${CONTROL_UI_NAMESPA
  * bootstrap constant (or the bare constant when no base path is configured).
  * When no base path is configured we additionally accept the default-namespace
  * alias `/__openclaw__/control-ui-config.json`, which is what the default
- * `/__openclaw__/` entry requests after inferring its base path from the URL.
- * The bare endpoint is preserved for compatibility; no path is removed.
+ * `/__openclaw__/` entry requests after inferring its base path from the URL,
+ * and the legacy single-underscore `/__openclaw/control-ui-config.json`, which
+ * current main and v2026.6.1 serve and document under an empty base path. The
+ * bare and legacy endpoints are preserved for compatibility; no path is removed.
  */
 function matchesControlUiBootstrapConfigPath(pathname: string, basePath: string): boolean {
   if (basePath) {
@@ -862,7 +879,8 @@ function matchesControlUiBootstrapConfigPath(pathname: string, basePath: string)
   }
   return (
     pathname === CONTROL_UI_BOOTSTRAP_CONFIG_PATH ||
-    pathname === CONTROL_UI_DEFAULT_NAMESPACE_BOOTSTRAP_CONFIG_PATH
+    pathname === CONTROL_UI_DEFAULT_NAMESPACE_BOOTSTRAP_CONFIG_PATH ||
+    pathname === LEGACY_BOOTSTRAP_CONFIG_PATH
   );
 }
 

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -866,22 +866,31 @@ const LEGACY_BOOTSTRAP_CONFIG_PATH = `${LEGACY_CONTROL_UI_NAMESPACE_PREFIX}${CON
  *
  * The canonical endpoint is the configured base path joined with the shared
  * bootstrap constant (or the bare constant when no base path is configured).
- * When no base path is configured we additionally accept the default-namespace
- * alias `/__openclaw__/control-ui-config.json`, which is what the default
- * `/__openclaw__/` entry requests after inferring its base path from the URL,
- * and the legacy single-underscore `/__openclaw/control-ui-config.json`, which
- * current main and v2026.6.1 serve and document under an empty base path. The
- * bare and legacy endpoints are preserved for compatibility; no path is removed.
+ * For every base path (configured or empty) we additionally accept the legacy
+ * single-underscore suffix `${basePath}/__openclaw/control-ui-config.json` that
+ * current main and v2026.6.1 serve and document, so older bundles and clients
+ * that still request the pre-#66946 endpoint keep receiving config after an
+ * upgrade instead of 404ing. When no base path is configured we further accept
+ * the default-namespace alias `/__openclaw__/control-ui-config.json`, which is
+ * what the default `/__openclaw__/` entry requests after inferring its base path
+ * from the URL. All compatibility endpoints are preserved; no path is removed.
  */
 function matchesControlUiBootstrapConfigPath(pathname: string, basePath: string): boolean {
-  if (basePath) {
-    return pathname === `${basePath}${CONTROL_UI_BOOTSTRAP_CONFIG_PATH}`;
+  // Canonical and legacy suffixes apply under both an empty and a configured
+  // base path. `LEGACY_BOOTSTRAP_CONFIG_PATH` already starts with the legacy
+  // `/__openclaw` namespace, so joining it with the base path yields
+  // `${basePath}/__openclaw/control-ui-config.json` (or the bare legacy path
+  // when no base path is configured).
+  if (
+    pathname === `${basePath}${CONTROL_UI_BOOTSTRAP_CONFIG_PATH}` ||
+    pathname === `${basePath}${LEGACY_BOOTSTRAP_CONFIG_PATH}`
+  ) {
+    return true;
   }
-  return (
-    pathname === CONTROL_UI_BOOTSTRAP_CONFIG_PATH ||
-    pathname === CONTROL_UI_DEFAULT_NAMESPACE_BOOTSTRAP_CONFIG_PATH ||
-    pathname === LEGACY_BOOTSTRAP_CONFIG_PATH
-  );
+  // The default `/__openclaw__/` namespace alias only applies when no base path
+  // is configured; with a configured base path the canonical endpoint already
+  // lives under that base path and this inferred alias does not apply.
+  return basePath === "" && pathname === CONTROL_UI_DEFAULT_NAMESPACE_BOOTSTRAP_CONFIG_PATH;
 }
 
 export async function handleControlUiHttpRequest(

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -835,6 +835,37 @@ function isSafeRelativePath(relPath: string) {
   return true;
 }
 
+// Path served by the gateway under the default Control UI namespace when no
+// `gateway.controlUi.basePath` is configured. The SPA is mounted at
+// `/__openclaw__/`, so a browser that opens the default entry infers
+// `/__openclaw__` as its base path (see `inferBasePathFromPathname`) and fetches
+// `/__openclaw__/control-ui-config.json`. Accept that namespaced alias so the
+// default entry resolves its bootstrap config instead of 404ing.
+const CONTROL_UI_DEFAULT_NAMESPACE_BOOTSTRAP_CONFIG_PATH = `${CONTROL_UI_NAMESPACE_PREFIX.replace(
+  /\/$/,
+  "",
+)}${CONTROL_UI_BOOTSTRAP_CONFIG_PATH}`;
+
+/**
+ * Whether `pathname` should be served the Control UI bootstrap config payload.
+ *
+ * The canonical endpoint is the configured base path joined with the shared
+ * bootstrap constant (or the bare constant when no base path is configured).
+ * When no base path is configured we additionally accept the default-namespace
+ * alias `/__openclaw__/control-ui-config.json`, which is what the default
+ * `/__openclaw__/` entry requests after inferring its base path from the URL.
+ * The bare endpoint is preserved for compatibility; no path is removed.
+ */
+function matchesControlUiBootstrapConfigPath(pathname: string, basePath: string): boolean {
+  if (basePath) {
+    return pathname === `${basePath}${CONTROL_UI_BOOTSTRAP_CONFIG_PATH}`;
+  }
+  return (
+    pathname === CONTROL_UI_BOOTSTRAP_CONFIG_PATH ||
+    pathname === CONTROL_UI_DEFAULT_NAMESPACE_BOOTSTRAP_CONFIG_PATH
+  );
+}
+
 export async function handleControlUiHttpRequest(
   req: IncomingMessage,
   res: ServerResponse,
@@ -871,10 +902,7 @@ export async function handleControlUiHttpRequest(
 
   applyControlUiSecurityHeaders(res);
 
-  const bootstrapConfigPath = basePath
-    ? `${basePath}${CONTROL_UI_BOOTSTRAP_CONFIG_PATH}`
-    : CONTROL_UI_BOOTSTRAP_CONFIG_PATH;
-  if (pathname === bootstrapConfigPath) {
+  if (matchesControlUiBootstrapConfigPath(pathname, basePath)) {
     if (
       !(await authorizeControlUiReadRequest(req, res, {
         auth: opts?.auth,

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -273,7 +273,7 @@ export default function controlUiViteConfig(): UserConfig {
       {
         name: "control-ui-dev-stubs",
         configureServer(server) {
-          server.middlewares.use("/__openclaw/control-ui-config.json", (_req, res) => {
+          server.middlewares.use("/control-ui-config.json", (_req, res) => {
             res.setHeader("Content-Type", "application/json");
             res.end(
               JSON.stringify({

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -228,6 +228,7 @@ function controlUiServiceWorkerBuildIdPlugin(buildId: string): Plugin {
 export default function controlUiViteConfig(): UserConfig {
   const envBase = process.env.OPENCLAW_CONTROL_UI_BASE_PATH?.trim();
   const base = envBase ? normalizeBase(envBase) : "./";
+  const bootstrapConfigPath = base === "./" ? "/control-ui-config.json" : `${base}control-ui-config.json`;
   const controlUiBuildId = resolveControlUiBuildId();
   return {
     base,
@@ -273,7 +274,7 @@ export default function controlUiViteConfig(): UserConfig {
       {
         name: "control-ui-dev-stubs",
         configureServer(server) {
-          server.middlewares.use(`${base}control-ui-config.json`, (_req, res) => {
+          server.middlewares.use(bootstrapConfigPath, (_req, res) => {
             res.setHeader("Content-Type", "application/json");
             res.end(
               JSON.stringify({

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -273,7 +273,7 @@ export default function controlUiViteConfig(): UserConfig {
       {
         name: "control-ui-dev-stubs",
         configureServer(server) {
-          server.middlewares.use("/control-ui-config.json", (_req, res) => {
+          server.middlewares.use(`${base}control-ui-config.json`, (_req, res) => {
             res.setHeader("Content-Type", "application/json");
             res.end(
               JSON.stringify({


### PR DESCRIPTION
## Summary

Opening the Control UI at the default entry `http://localhost:18789/__openclaw__/` returned `404` for the runtime config request, so the chat UI never finished bootstrapping. The browser issued `GET /__openclaw__/__openclaw/control-ui-config.json` — the `__openclaw` segment was duplicated — and that URL was never a served endpoint, so it 404'd.

Closes #66946.

## Root cause (full chain, default entry)

The reporter runs the default deployment: **no `gateway.controlUi.basePath` is configured**, so the Control UI SPA is mounted under the default namespace `/__openclaw__/`. Two things then interact:

1. **Constant carried its own prefix.** `CONTROL_UI_BOOTSTRAP_CONFIG_PATH` was `"/__openclaw/control-ui-config.json"` (single trailing underscore — it does not even match the `/__openclaw__` mount). Both sides compose the endpoint as `${basePath}${CONST}`: the gateway in `handleControlUiHttpRequest` (`src/gateway/control-ui.ts`) and the browser loader in `loadControlUiBootstrapConfig` (`ui/src/ui/controllers/control-ui-bootstrap.ts`).
2. **Browser infers a base path from the URL.** A browser served at `/__openclaw__/` has no injected base path, so it falls back to `inferBasePathFromPathname("/__openclaw__/")` (`ui/src/ui/navigation.ts`), which returns `/__openclaw__` (a non-tab segment). It then fetches `"/__openclaw__"` + `"/__openclaw/control-ui-config.json"` = `/__openclaw__/__openclaw/control-ui-config.json` — exactly the doubled 404 URL in the report.

Meanwhile the **gateway's configured base path is empty**, so on `main` it only ever served the bootstrap config at the bare `/control-ui-config.json` (after a relative constant) — never at `/__openclaw__/control-ui-config.json`. So even after making the constant base-path-relative, the **default-entry request still 404'd**: the browser asks for `/__openclaw__/control-ui-config.json`, but an empty-base-path gateway did not serve that path. The earlier revision of this PR fixed the constant but only tested the *configured* `basePath: "/__openclaw__"` case, which bypassed the real default-entry scenario. This revision completes the fix.

## Fix

All parts are **purely additive — no route or endpoint is removed**:

1. **Constant is base-path-relative** (`src/gateway/control-ui-contract.ts`): `"/control-ui-config.json"`. Composition then yields the correct URL on both sides under a *configured* base path, and the bare path with none.
2. **Gateway accepts the default-namespace alias** (`src/gateway/control-ui.ts`): when the configured base path is empty, `handleControlUiHttpRequest` matches the bootstrap config at **both** the bare `/control-ui-config.json` (unchanged, compatibility) **and** the default-namespace alias `/__openclaw__/control-ui-config.json` — the path the default `/__openclaw__/` entry actually requests. The alias is derived from the existing `CONTROL_UI_NAMESPACE_PREFIX` mount constant, so it stays in sync with the SPA mount.
3. **Gateway preserves the legacy documented endpoint under every base path** (`src/gateway/control-ui.ts`): current `main` and `v2026.6.1` serve and document the single-underscore `/__openclaw/control-ui-config.json` suffix (that literal **was** `CONTROL_UI_BOOTSTRAP_CONFIG_PATH` before this PR made the path base-path-relative). To avoid an upgrade `404` for older bundles / clients hitting the documented endpoint, the matcher now accepts the legacy suffix under **both** an empty base path (`/__openclaw/control-ui-config.json`) **and** a configured base path (`${basePath}/__openclaw/control-ui-config.json`), derived from the existing `LEGACY_BOOTSTRAP_CONFIG_PATH` constant (the legacy `/__openclaw` namespace joined with the canonical config constant, so it tracks any filename rename). The matcher checks the canonical and legacy suffixes uniformly as `${basePath}${CONST}` for both cases; the default-namespace alias stays empty-base-path-only.

Files:

- `src/gateway/control-ui-contract.ts` — base-path-relative constant.
- `src/gateway/control-ui.ts` — `matchesControlUiBootstrapConfigPath()` accepting, under every base path, the canonical suffix and the legacy `/__openclaw/control-ui-config.json` suffix; plus, for empty base paths only, the inferred default-namespace alias `/__openclaw__/control-ui-config.json`.
- `ui/vite.config.ts` — align the Vite dev-server stub mount to the same path.
- `docs/web/control-ui.md` — document the base-path-relative endpoint.
- `src/gateway/control-ui.http.test.ts` — coverage for the real default-entry scenario (empty base path + `/__openclaw__/...`), the configured-base-path canonical case, the bare-path compatibility case, the **empty-base-path** legacy `/__openclaw/control-ui-config.json` endpoint, the **configured-base-path** legacy `${basePath}/__openclaw/control-ui-config.json` endpoint, and the doubled-path 404.

No `CHANGELOG.md` change.

## Compatibility (responding to the `merge-risk: 🚨 compatibility` flag — full matrix)

No documented endpoint is deleted or redirected; the change only *adds* accepted paths. The complete matrix the matcher now covers (canonical = post-#66946 path, legacy = the exact pre-#66946 documented path):

| base path | canonical (new) | default-namespace inferred alias | legacy (pre-#66946 documented) |
|---|---|---|---|
| **empty** | `/control-ui-config.json` ✅ | `/__openclaw__/control-ui-config.json` ✅ | `/__openclaw/control-ui-config.json` ✅ |
| **configured `/x`** | `/x/control-ui-config.json` ✅ | n/a (the inferred default entry only applies when no base path is configured; with a base path the canonical path already lives under it) | `/x/__openclaw/control-ui-config.json` ✅ |

- **Both legacy documented endpoints are preserved.** Under an empty base path the single-underscore `/__openclaw/control-ui-config.json` keeps returning config; under a configured base path `${basePath}/__openclaw/control-ui-config.json` keeps returning config. **There is no upgrade `404` break** for any base-path configuration, older bundle, or client that fetches the previously documented endpoint directly.
- The doubled path `/__openclaw__/__openclaw/control-ui-config.json` correctly stays `404` (it was always a 404 and has no consumer) under both an empty and a configured base path; the legacy alias does not match it.

## Proof — real gateway HTTP behavior, before vs after (curl)

Mounted the **real production `handleControlUiHttpRequest`** over a real `http.createServer` (the same opts wiring as `src/gateway/server-http.ts`) and `curl`'d each path over a real socket. The empty-base-path scenario (canonical / default-namespace / legacy, before vs after) was verified in the prior revision and is unchanged. This revision adds the **configured-base-path** scenario (`basePath: "/x"`).

**Before** (pre-fix matcher — legacy suffix accepted only under an empty base path) — the configured-base-path legacy endpoint 404s, which is the regression the P1 flag is about:

```
$ curl -s -o /dev/null -w 'HTTP %{http_code}\n' http://127.0.0.1:34331/x/__openclaw/control-ui-config.json
HTTP 404
```

**After** (this PR) — under a configured base path `/x`, both the canonical and the legacy endpoints return `200` + the bootstrap config JSON, and the doubled path still `404`s:

```
# (1) canonical, configured base path
$ curl -s -w '\nHTTP %{http_code}\n' http://127.0.0.1:35241/x/control-ui-config.json
{"basePath":"/x","assistantName":"Ops","assistantAvatar":"/x/avatar/main",...,"assistantAgentId":"main",...}
HTTP 200

# (2) legacy documented endpoint under configured base path — before: 404, after: 200
$ curl -s -w '\nHTTP %{http_code}\n' http://127.0.0.1:35241/x/__openclaw/control-ui-config.json
{"basePath":"/x","assistantName":"Ops","assistantAvatar":"/x/avatar/main",...,"assistantAgentId":"main",...}
HTTP 200

# doubled path correctly stays 404 under a configured base path (no consumer); legacy alias does not match it
$ curl -s -o /dev/null -w 'HTTP %{http_code}\n' http://127.0.0.1:35241/x/__openclaw__/__openclaw/control-ui-config.json
HTTP 404
```

(Empty-base-path proof from the prior revision — bare `/control-ui-config.json`, default-namespace `/__openclaw__/control-ui-config.json`, and legacy `/__openclaw/control-ui-config.json` all `200`; doubled path `404` — is unchanged.)

### Regression tests (each fails without its fix)

`src/gateway/control-ui.http.test.ts` covers the **default-entry** path, the **empty-base-path legacy** endpoint, and now the **configured-base-path legacy** endpoint. With the corresponding alias disabled, each case fails with `404`, proving they pin the actual behavior rather than passing vacuously:

```
× serves bootstrap config at the default /__openclaw__ entry with no configured basePath (#66946)
  AssertionError: expected 404 not to be 404
× still serves bootstrap config at the legacy /__openclaw/control-ui-config.json with no configured basePath (#66946)
  AssertionError: expected 404 not to be 404
× still serves bootstrap config at the legacy ${basePath}/__openclaw/control-ui-config.json under a configured basePath (#66946)
  AssertionError: expected 404 not to be 404
```

With the fix, the ClawSweeper-named command is green:

```
$ node scripts/run-vitest.mjs src/gateway/control-ui.http.test.ts \
    ui/src/ui/controllers/control-ui-bootstrap.test.ts ui/src/ui/navigation.test.ts
Test Files  4 passed (4)   Tests  224 passed (224)   # gateway shards
Test Files  2 passed (2)   Tests   36 passed  (36)   # ui shards
```

`git diff --check` is clean.

**Proof**: real gateway HTTP run (real `http.createServer` + `curl`) for the configured base path `/x` — the legacy single-underscore suffix before (404) vs after (200 + JSON body with `basePath:"/x"`), the canonical configured endpoint at 200, the doubled path still 404 — plus regression tests that fail without each alias. The empty-base-path proof (three accepted endpoints + doubled-path 404) is unchanged from the prior revision.


## Real behavior proof

- **Behavior or issue addressed**: Opening the Control UI at the default `/__openclaw__/` entry must load `control-ui-config.json` without duplicating the `__openclaw` namespace, and existing legacy bootstrap config endpoints must keep working.
- **Real environment tested**: Real OpenClaw gateway HTTP handler mounted on a real `http.createServer`, tested over `127.0.0.1` sockets with `curl`; configured-base-path scenario used `basePath: "/x"`.
- **Exact steps or command run after this patch**: Started the real production `handleControlUiHttpRequest` server with Control UI options, then ran `curl -s -w '\nHTTP %{http_code}\n'` against `/x/control-ui-config.json`, `/x/__openclaw/control-ui-config.json`, and `/x/__openclaw__/__openclaw/control-ui-config.json`.
- **Evidence after fix**: Terminal output from the live HTTP run:

```text
$ curl -s -w '\nHTTP %{http_code}\n' http://127.0.0.1:35241/x/control-ui-config.json
{"basePath":"/x","assistantName":"Ops","assistantAvatar":"/x/avatar/main",...,"assistantAgentId":"main",...}
HTTP 200

$ curl -s -w '\nHTTP %{http_code}\n' http://127.0.0.1:35241/x/__openclaw/control-ui-config.json
{"basePath":"/x","assistantName":"Ops","assistantAvatar":"/x/avatar/main",...,"assistantAgentId":"main",...}
HTTP 200

$ curl -s -o /dev/null -w 'HTTP %{http_code}\n' http://127.0.0.1:35241/x/__openclaw__/__openclaw/control-ui-config.json
HTTP 404
```

- **Observed result after fix**: The canonical configured endpoint and the legacy configured endpoint both returned `HTTP 200` with bootstrap config JSON containing `"basePath":"/x"`; the invalid doubled path still returned `HTTP 404`.
- **What was not tested**: No browser screenshot was captured; the proof exercises the real gateway HTTP behavior directly over a socket.
