### PR TITLE
fix(tts): strip reasoning tags from summarized text before speech

### DIFF
--- a/src/tts/tts-core.test.ts
+++ b/src/tts/tts-core.test.ts
@@ -107,4 +107,77 @@ describe("TTS core", () => {
       setTimeoutSpy.mockRestore();
     }
   });
+
+  it("strips reasoning tags from TTS summary text", async () => {
+    const model = {
+      id: "test-model",
+      name: "Test Model",
+      api: "test-api",
+      provider: "test-provider",
+      baseUrl: "https://example.test",
+      reasoning: true,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 4096,
+      maxTokens: 1024,
+    } satisfies Model;
+    const config = {
+      auto: "off",
+      mode: "final",
+      provider: "test-provider",
+      providerSource: "config",
+      personas: {},
+      summaryModel: "test-provider/test-model",
+      modelOverrides: modelOverridePolicy,
+      providerConfigs: {},
+      maxTextLength: 10_000,
+      timeoutMs: 10_000,
+    } satisfies ResolvedTtsConfig;
+    const auth = {
+      apiKey: "key",
+      source: "test",
+      mode: "api-key",
+    } satisfies ResolvedProviderAuth;
+    const authStorage = AuthStorage.inMemory();
+    const modelRegistry = ModelRegistry.inMemory(authStorage);
+    // Simulate a reasoning model that wraps its summary in <think> tags
+    const assistant = {
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: "<think>Let me summarize this text for the user.</think> The weather is sunny today.",
+        },
+      ],
+      api: model.api,
+      provider: model.provider,
+      model: model.id,
+      stopReason: "stop",
+      usage,
+      timestamp: Date.now(),
+    } satisfies AssistantMessage;
+
+    const result = await summarizeText(
+      {
+        text: "What's the weather today? It looks like it's going to be sunny.",
+        targetLength: 120,
+        cfg: {},
+        config,
+        timeoutMs: 10_000,
+      },
+      {
+        completeSimple: vi.fn(async () => assistant),
+        getApiKeyForModel: vi.fn(async () => auth),
+        prepareModelForSimpleCompletion: vi.fn(() => model),
+        requireApiKey: vi.fn(() => "key"),
+        resolveModelAsync: vi.fn(async () => ({
+          model,
+          authStorage,
+          modelRegistry,
+        })),
+      },
+    );
+
+    expect(result.summary).toBe("The weather is sunny today.");
+  });
 });

--- a/src/tts/tts-core.ts
+++ b/src/tts/tts-core.ts
@@ -13,6 +13,7 @@ import type { OpenClawConfig } from "../config/types.js";
 import { completeSimple } from "../llm/stream.js";
 import type { TextContent } from "../llm/types.js";
 import { resolveTimerTimeoutMs } from "../shared/number-coercion.js";
+import { stripReasoningTagsFromText } from "../shared/text/reasoning-tags.js";
 import type { ResolvedTtsConfig } from "./tts-types.js";
 export {
   normalizeApplyTextNormalization,
@@ -136,12 +137,14 @@ export async function summarizeText(
           signal: controller.signal,
         },
       );
-      const summary = res.content
-        .filter(isTextContentBlock)
-        .map((block) => block.text.trim())
-        .filter(Boolean)
-        .join(" ")
-        .trim();
+      const summary = stripReasoningTagsFromText(
+        res.content
+          .filter(isTextContentBlock)
+          .map((block) => block.text.trim())
+          .filter(Boolean)
+          .join(" ")
+          .trim(),
+      );
 
       if (!summary) {
         throw new Error("No summary returned");


### PR DESCRIPTION
## Summary

- When a reasoning model (e.g., MiniMax with `reasoning: true`) is used as the TTS summary model, its output can include `<think>` / `<thinking>` / `<thought>` tags wrapping chain-of-thought content.
- These tags were passed through to the speech synthesis engine, producing unintelligible audio instead of a clean summary.
- This fix strips reasoning tags from the assembled summary text in `summarizeText` before returning it, reusing the existing `stripReasoningTagsFromText` helper that already handles nested tags, code regions, and orphan close boundaries.

## Verification

- `node scripts/run-vitest.mjs run src/tts/tts-core.test.ts` → 2 passed (including new regression test)
- Production `summarizeText` verified via `node --import tsx` with real mocks (see Real behavior proof below)

## Change Type

- [x] Bug fix / [ ] Feature / [ ] Refactor / [ ] Docs / [ ] Security / [ ] Chore

## Scope

- [ ] Gateway / [ ] Skills / [ ] Auth / [ ] Memory / [ ] Integrations / [ ] API / [x] UI/UX / [ ] CI

## Real behavior proof

**Behavior addressed:** When a reasoning model is used for TTS summarization, the model output includes `<think>` / `<thinking>` / `<thought>` tags that wrap chain-of-thought content. These tags reach the speech synthesis engine, producing garbled audio instead of a clean summary.

**Environment tested:** Node 24.x on Linux, `node --import tsx` calling the actual patched `summarizeText` production function from the fix branch with mocked dependencies that simulate a reasoning model.

**Steps run after the patch:** Called `summarizeText` from source via `node --import tsx` with:
1. A mock `completeSimple` that returns a reasoning-model-style response containing `<think>...</think>` followed by clean summary text
2. A mock `completeSimple` that returns plain summary text without thinking tags (passthrough control)

**Evidence after fix:**

```text
=== Real behavior proof: summarizeText with reasoning model ===

Test 1: Reasoning model with <think> tags
  Input chars: 740
  Summary: Today will be sunny with a high of 75 degrees Fahrenheit and light winds from the southwest.
  Contains <think>: false
  Expected: "Today will be sunny with a high of 75 degrees Fahrenheit and light winds from the southwest."
  Match: true

Test 2: Clean model without think tags (passthrough)
  Summary: The weather is clear and warm.
  Contains <think>: false
  Match: true

All tests passed: summarizeText correctly strips reasoning tags before returning summary.
```

**Observed result after the fix:** The patched `summarizeText` function correctly strips `<think>` tags from reasoning model output before returning the summary, while clean text without thinking tags passes through unmodified. The function produces output suitable for TTS audio synthesis.

**Not tested:** Live TTS audio flow with a real Microsoft/MiniMax TTS provider and an actual reasoning summary model generating spoken audio output.

Closes #90364
