### PR TITLE
Allow Skill Workshop apply through trusted skill symlinks

### DIFF
--- a/docs/gateway/configuration-examples.md
+++ b/docs/gateway/configuration-examples.md
@@ -493,6 +493,8 @@ example `~/.agents/skills/manager -> ~/Projects/manager/skills`.
 - `extraDirs` scans the sibling repo as an explicit skill root.
 - `allowSymlinkTargets` lets symlinked skill folders resolve into that trusted
   real target root without allowing arbitrary symlink escapes.
+- To let Skill Workshop apply write through the same trusted symlink target,
+  set `skills.workshop.allowSymlinkTargetWrites: true`.
 
 ## Common patterns
 

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -200,6 +200,9 @@ See [MCP](/cli/mcp#openclaw-as-an-mcp-client-registry) and
       nodeManager: "npm", // npm | pnpm | yarn | bun
       allowUploadedArchives: false,
     },
+    workshop: {
+      allowSymlinkTargetWrites: false,
+    },
     entries: {
       "image-lab": {
         apiKey: { source: "env", provider: "default", id: "GEMINI_API_KEY" }, // or plaintext string
@@ -216,6 +219,8 @@ See [MCP](/cli/mcp#openclaw-as-an-mcp-client-registry) and
 - `load.extraDirs`: extra shared skill roots (lowest precedence).
 - `load.allowSymlinkTargets`: trusted real target roots that skill symlinks may
   resolve into when the link lives outside its configured source root.
+- `workshop.allowSymlinkTargetWrites`: allows Skill Workshop apply to write
+  through already-trusted symlink targets (default: false).
 - `install.preferBrew`: when true, prefer Homebrew installers when `brew` is
   available before falling back to other installer kinds.
 - `install.nodeManager`: node installer preference for `metadata.openclaw.install`

--- a/docs/gateway/troubleshooting.md
+++ b/docs/gateway/troubleshooting.md
@@ -154,6 +154,10 @@ Do not use broad targets such as `~`, `/`, or a whole synced project folder.
 Keep `allowSymlinkTargets` scoped to the real skill root that contains trusted
 `SKILL.md` directories.
 
+If Skill Workshop apply should also write through those trusted symlinked
+workspace skill paths, enable `skills.workshop.allowSymlinkTargetWrites`. Keep
+it disabled for read-only shared skill roots.
+
 Related:
 
 - [Skills config](/tools/skills-config#symlinked-sibling-repos)

--- a/docs/tools/skill-workshop.md
+++ b/docs/tools/skill-workshop.md
@@ -190,6 +190,7 @@ agent session or the CLI.
       autonomous: {
         enabled: false,
       },
+      allowSymlinkTargetWrites: false,
       approvalPolicy: "pending",
       maxPending: 50,
       maxSkillBytes: 40000,
@@ -200,6 +201,9 @@ agent session or the CLI.
 
 - `autonomous.enabled`: allows OpenClaw to create pending proposals from durable
   conversation signals after successful turns. Default: `false`.
+- `allowSymlinkTargetWrites`: allows apply to write through workspace skill
+  symlinks whose real target is listed in `skills.load.allowSymlinkTargets`.
+  Default: `false`.
 - `approvalPolicy: "pending"`: requires an approval prompt before
   agent-initiated `apply`, `reject`, or `quarantine`.
 - `approvalPolicy: "auto"`: skips that approval prompt. The agent must still
@@ -265,6 +269,7 @@ Default state directory: `~/.openclaw`.
 | `Skill proposal content is too large`          | Shorten the proposal body or raise `skills.workshop.maxSkillBytes`.                                                                                                                                         |
 | `Target skill changed after proposal creation` | Revise the proposal against the current target, or create a new proposal.                                                                                                                                   |
 | `Proposal scan failed`                         | Inspect scanner findings, then revise or quarantine the proposal.                                                                                                                                           |
+| `untrusted symlink target`                     | Configure `skills.load.allowSymlinkTargets` and enable `skills.workshop.allowSymlinkTargetWrites` only for intentional shared skill roots.                                                                  |
 | `Support file paths must be under one of...`   | Move support files under `assets/`, `examples/`, `references/`, `scripts/`, or `templates/`.                                                                                                                |
 | Proposal does not show in list                 | Check the selected `--agent` workspace and `OPENCLAW_STATE_DIR`.                                                                                                                                            |
 | Agent cannot call `skill_workshop`             | Check the active tool policy and run mode. `coding` includes the tool; restrictive `tools.allow` policies must list it explicitly, and sandboxed runs must use a normal host-side agent session or the CLI. |

--- a/docs/tools/skills-config.md
+++ b/docs/tools/skills-config.md
@@ -364,6 +364,8 @@ To allow an intentional symlink layout, declare the trusted target:
 With this config, `<workspace>/skills/manager -> ~/Projects/manager/skills` is
 accepted after realpath resolution. `extraDirs` scans the sibling repo directly;
 `allowSymlinkTargets` preserves the symlinked path for existing layouts.
+Skill Workshop apply uses the same trust list before publishing proposals
+through symlinked workspace skill paths.
 
 Managed `~/.openclaw/skills` and personal `~/.agents/skills` directories
 already accept skill-directory symlinks (per-skill `SKILL.md` containment still

--- a/docs/tools/skills-config.md
+++ b/docs/tools/skills-config.md
@@ -29,6 +29,7 @@ Most skills configuration lives under `skills` in
     },
     workshop: {
       autonomous: { enabled: false },
+      allowSymlinkTargetWrites: false,
       approvalPolicy: "pending",
       maxPending: 50,
       maxSkillBytes: 40000,
@@ -333,6 +334,13 @@ different visible skill set per agent.
   quarantine. `auto` allows those actions without approval.
 </ParamField>
 
+<ParamField path="skills.workshop.allowSymlinkTargetWrites" type="boolean" default="false">
+  Allow Skill Workshop apply to write through workspace skill symlinks whose
+  real target is already trusted by `skills.load.allowSymlinkTargets`. Keep this
+  disabled unless generated proposal applies should mutate that shared skill
+  root.
+</ParamField>
+
 <ParamField path="skills.workshop.maxPending" type="number" default="50">
   Maximum pending and quarantined proposals retained per workspace.
 </ParamField>
@@ -364,8 +372,23 @@ To allow an intentional symlink layout, declare the trusted target:
 With this config, `<workspace>/skills/manager -> ~/Projects/manager/skills` is
 accepted after realpath resolution. `extraDirs` scans the sibling repo directly;
 `allowSymlinkTargets` preserves the symlinked path for existing layouts.
-Skill Workshop apply uses the same trust list before publishing proposals
-through symlinked workspace skill paths.
+
+Skill Workshop apply does not write through those symlinks by default. To let
+Workshop apply mutate skills under already-trusted symlink targets, opt in
+separately:
+
+```json5
+{
+  skills: {
+    load: {
+      allowSymlinkTargets: ["~/Projects/manager/skills"],
+    },
+    workshop: {
+      allowSymlinkTargetWrites: true,
+    },
+  },
+}
+```
 
 Managed `~/.openclaw/skills` and personal `~/.agents/skills` directories
 already accept skill-directory symlinks (per-skill `SKILL.md` containment still

--- a/docs/tools/skills.md
+++ b/docs/tools/skills.md
@@ -204,6 +204,8 @@ publish and sync.
     Workspace, project-agent, and extra-dir skill discovery only accepts skill
     roots whose resolved realpath stays inside the configured root, unless
     `skills.load.allowSymlinkTargets` explicitly trusts a target root.
+    Skill Workshop writes through those trusted targets only when
+    `skills.workshop.allowSymlinkTargetWrites` is enabled.
     Managed `~/.openclaw/skills` and personal `~/.agents/skills` may contain
     symlinked skill folders, but every `SKILL.md` realpath must still stay
     inside its resolved skill directory.
@@ -533,6 +535,8 @@ aligned.
     Use `allowSymlinkTargets` for intentional symlinked layouts where a skill
     root symlink points outside the configured root, for example
     `<workspace>/skills/manager -> ~/Projects/manager/skills`.
+    Enable `skills.workshop.allowSymlinkTargetWrites` only when Skill Workshop
+    should also apply proposals through those trusted symlinked paths.
 
   </Accordion>
   <Accordion title="Remote macOS nodes (Linux gateway)">

--- a/src/agents/tools/skill-workshop-tool.ts
+++ b/src/agents/tools/skill-workshop-tool.ts
@@ -170,6 +170,7 @@ export function createSkillWorkshopTool(options: SkillWorkshopToolOptions): AnyA
       if (action === "apply") {
         const applied = await applySkillProposal({
           workspaceDir: options.workspaceDir,
+          config: options.config,
           proposalId: readLifecycleProposalIdParam(params),
           reason: readStringParam(params, "reason"),
         });

--- a/src/cli/skills-cli.ts
+++ b/src/cli/skills-cli.ts
@@ -734,8 +734,8 @@ export function registerSkillsCli(program: Command) {
     .action(
       async (proposalId: string, opts: { json?: boolean; agent?: string }, command: Command) => {
         try {
-          const { workspaceDir } = resolveSkillsWorkspaceForCommand(command.parent, opts);
-          const applied = await applySkillProposal({ workspaceDir, proposalId });
+          const { config, workspaceDir } = resolveSkillsWorkspaceForCommand(command.parent, opts);
+          const applied = await applySkillProposal({ workspaceDir, config, proposalId });
           if (opts.json) {
             defaultRuntime.writeJson(applied);
             return;

--- a/src/config/schema.help.quality.test.ts
+++ b/src/config/schema.help.quality.test.ts
@@ -579,6 +579,7 @@ const FINAL_BACKLOG_TARGET_KEYS = [
   "skills.load.extraDirs",
   "skills.load.watch",
   "skills.load.watchDebounceMs",
+  "skills.workshop.allowSymlinkTargetWrites",
   "ui.assistant.avatar",
   "ui.assistant.name",
   "ui.seamColor",

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -838,6 +838,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Enable filesystem watching for skill-definition changes so updates can be applied without full process restart. Keep enabled in development workflows and disable in immutable production images.",
   "skills.load.watchDebounceMs":
     "Debounce window in milliseconds for coalescing rapid skill file changes before reload logic runs. Increase to reduce reload churn on frequent writes, or lower for faster edit feedback.",
+  "skills.workshop.allowSymlinkTargetWrites":
+    "Allows Skill Workshop apply to write through symlinked workspace skill paths whose real target is already trusted by skills.load.allowSymlinkTargets. Keep disabled unless operators intentionally want generated proposal applies to mutate those shared skill roots.",
   approvals:
     "Approval routing controls for forwarding exec and plugin approval requests to chat destinations outside the originating session. Keep these disabled unless operators need explicit out-of-band approval visibility.",
   "approvals.exec":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -420,6 +420,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "skills.load.allowSymlinkTargets": "Allowed Skill Symlink Targets",
   "skills.load.watch": "Watch Skills",
   "skills.load.watchDebounceMs": "Skills Watch Debounce (ms)",
+  "skills.workshop.allowSymlinkTargetWrites": "Allow Skill Workshop Symlink Writes",
   "agents.defaults.skills": "Skills",
   "agents.defaults.subagents.delegationMode": "Sub-agent Delegation Mode",
   "agents.list[].subagents.delegationMode": "Sub-agent Delegation Mode",

--- a/src/config/types.skills.ts
+++ b/src/config/types.skills.ts
@@ -63,6 +63,8 @@ export type SkillsWorkshopConfig = {
     /** Allow agents to create pending proposals from durable conversation signals. */
     enabled?: boolean;
   };
+  /** Allow Skill Workshop apply to write through trusted skill symlink targets. */
+  allowSymlinkTargetWrites?: boolean;
   /** Whether proposal lifecycle actions need explicit approval. */
   approvalPolicy?: "pending" | "auto";
   /** Maximum pending/quarantined proposals retained per workspace. */

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -1270,6 +1270,7 @@ export const OpenClawSchema = z
               .strict()
               .optional(),
             approvalPolicy: z.union([z.literal("pending"), z.literal("auto")]).optional(),
+            allowSymlinkTargetWrites: z.boolean().optional(),
             maxPending: z.number().int().min(1).optional(),
             maxSkillBytes: z.number().int().min(1).optional(),
           })

--- a/src/gateway/server-methods/skills.ts
+++ b/src/gateway/server-methods/skills.ts
@@ -483,6 +483,7 @@ export const skillsHandlers: GatewayRequestHandlers = {
       run: (parsedParams, resolved) =>
         applySkillProposal({
           workspaceDir: resolved.workspaceDir,
+          config: resolved.cfg,
           proposalId: parsedParams.proposalId,
           reason: parsedParams.reason,
         }),

--- a/src/skills/loading/symlink-targets.ts
+++ b/src/skills/loading/symlink-targets.ts
@@ -1,0 +1,47 @@
+// Shared helpers for config-trusted skill symlink targets.
+import fs from "node:fs";
+import path from "node:path";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { isPathInside } from "../../infra/path-guards.js";
+import { resolveUserPath } from "../../utils.js";
+
+export function resolveAllowedSkillSymlinkTargetRealPaths(config?: OpenClawConfig): string[] {
+  const rawTargets = config?.skills?.load?.allowSymlinkTargets ?? [];
+  const targetPaths = rawTargets
+    .map((dir) => normalizeOptionalString(dir) ?? "")
+    .filter(Boolean)
+    .map((dir) => tryRealpath(resolveUserPath(dir)))
+    .filter((dir): dir is string => Boolean(dir));
+  return uniqueStrings(targetPaths);
+}
+
+export function findContainingAllowedSkillSymlinkTarget(
+  rootRealPaths: readonly string[],
+  candidateRealPath: string,
+): string | null {
+  const resolvedCandidate = path.resolve(candidateRealPath);
+  for (const rootRealPath of rootRealPaths) {
+    const resolvedRoot = path.resolve(rootRealPath);
+    if (isPathInside(resolvedRoot, resolvedCandidate)) {
+      return resolvedRoot;
+    }
+  }
+  return null;
+}
+
+export function isPathInsideAnyAllowedSkillSymlinkTarget(
+  rootRealPaths: readonly string[],
+  candidateRealPath: string,
+): boolean {
+  return findContainingAllowedSkillSymlinkTarget(rootRealPaths, candidateRealPath) !== null;
+}
+
+export function tryRealpath(filePath: string): string | null {
+  try {
+    return fs.realpathSync(filePath);
+  } catch {
+    return null;
+  }
+}

--- a/src/skills/loading/workspace.ts
+++ b/src/skills/loading/workspace.ts
@@ -34,6 +34,7 @@ import { loadSkillsFromDirSafe, readSkillFrontmatterSafe } from "./local-loader.
 import { resolvePluginSkillDirs } from "./plugin-skills.js";
 import { serializeByKey } from "./serialize.js";
 import { formatSkillsForPrompt, type Skill } from "./skill-contract.js";
+import { resolveAllowedSkillSymlinkTargetRealPaths, tryRealpath } from "./symlink-targets.js";
 
 const fsp = fs.promises;
 const skillsLogger = createSubsystemLogger("skills");
@@ -373,14 +374,6 @@ function hasLoadableSkillFrontmatter(
   const fallbackName = path.basename(skillDir).trim();
   const name = frontmatter?.name?.trim() || fallbackName;
   return Boolean(name) && Boolean(frontmatter?.description?.trim());
-}
-
-function tryRealpath(filePath: string): string | null {
-  try {
-    return fs.realpathSync(filePath);
-  } catch {
-    return null;
-  }
 }
 
 function isSymlinkPath(filePath: string): boolean {
@@ -735,16 +728,6 @@ function resolvePluginSkillRootRealPaths(pluginSkillDirs: readonly string[]): st
   );
 }
 
-function resolveAllowedSymlinkTargetRealPaths(config?: OpenClawConfig): string[] {
-  const rawTargets = config?.skills?.load?.allowSymlinkTargets ?? [];
-  const targetPaths = rawTargets
-    .map((dir) => normalizeOptionalString(dir) ?? "")
-    .filter(Boolean)
-    .map((dir) => tryRealpath(resolveUserPath(dir)))
-    .filter((dir): dir is string => Boolean(dir));
-  return uniqueStrings(targetPaths);
-}
-
 function loadGeneratedPluginSkillRecords(params: {
   pluginSkillsDir: string;
   pluginSkillDirs: readonly string[];
@@ -857,7 +840,7 @@ function loadSkillEntries(
   },
 ): SkillEntry[] {
   const limits = resolveSkillsLimits(opts?.config, opts?.agentId);
-  const allowedSymlinkTargetRealPaths = resolveAllowedSymlinkTargetRealPaths(opts?.config);
+  const allowedSymlinkTargetRealPaths = resolveAllowedSkillSymlinkTargetRealPaths(opts?.config);
 
   const loadSkills = (params: { dir: string; source: string }): LoadedSkillRecord[] => {
     const rootDir = path.resolve(params.dir);

--- a/src/skills/runtime/refresh.ts
+++ b/src/skills/runtime/refresh.ts
@@ -9,6 +9,10 @@ import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { CONFIG_DIR, resolveUserPath } from "../../utils.js";
 import { resolvePluginSkillDirs } from "../loading/plugin-skills.js";
 import {
+  resolveAllowedSkillSymlinkTargetRealPaths,
+  tryRealpath,
+} from "../loading/symlink-targets.js";
+import {
   bumpSkillsSnapshotVersion,
   clearSkillsSnapshotVersionForWorkspace,
   resetSkillsRefreshStateForTest,
@@ -111,7 +115,7 @@ function resolveWatchTargets(workspaceDir: string, config?: OpenClawConfig): Wat
     .filter(Boolean)
     .map((dir) => resolveUserPath(dir));
   const pluginSkillDirs = resolvePluginSkillDirs({ workspaceDir, config });
-  const allowedSymlinkTargetRealPaths = resolveAllowedSymlinkTargetRealPaths(config);
+  const allowedSymlinkTargetRealPaths = resolveAllowedSkillSymlinkTargetRealPaths(config);
   const signature = JSON.stringify({
     basePaths: baseRoots.map((root) => toWatchRoot(root.path)),
     extraDirs: extraDirs.map(toWatchRoot),
@@ -363,23 +367,6 @@ function watchDepthForPath(raw: string, depth: number): number {
     candidate = parent;
   }
   return depth + missingSegments;
-}
-
-function resolveAllowedSymlinkTargetRealPaths(config?: OpenClawConfig): string[] {
-  const rawTargets = config?.skills?.load?.allowSymlinkTargets ?? [];
-  return rawTargets
-    .map((dir) => normalizeOptionalString(dir) ?? "")
-    .filter(Boolean)
-    .map((dir) => tryRealpath(resolveUserPath(dir)))
-    .filter((dir): dir is string => Boolean(dir));
-}
-
-function tryRealpath(filePath: string): string | null {
-  try {
-    return fs.realpathSync(filePath);
-  } catch {
-    return null;
-  }
 }
 
 function isPathInside(parent: string, child: string): boolean {

--- a/src/skills/workshop/config.ts
+++ b/src/skills/workshop/config.ts
@@ -7,6 +7,7 @@ export type SkillWorkshopConfig = {
   autonomous: {
     enabled: boolean;
   };
+  allowSymlinkTargetWrites: boolean;
   approvalPolicy: "pending" | "auto";
   maxPending: number;
   maxSkillBytes: number;
@@ -16,6 +17,7 @@ const DEFAULT_CONFIG: SkillWorkshopConfig = {
   autonomous: {
     enabled: false,
   },
+  allowSymlinkTargetWrites: false,
   approvalPolicy: "pending",
   maxPending: 50,
   maxSkillBytes: 40_000,
@@ -42,6 +44,10 @@ export function resolveSkillWorkshopConfig(config?: OpenClawConfig): SkillWorksh
     autonomous: {
       enabled: readBoolean(autonomous.enabled, DEFAULT_CONFIG.autonomous.enabled),
     },
+    allowSymlinkTargetWrites: readBoolean(
+      raw.allowSymlinkTargetWrites,
+      DEFAULT_CONFIG.allowSymlinkTargetWrites,
+    ),
     approvalPolicy: readApprovalPolicy(raw.approvalPolicy, DEFAULT_CONFIG.approvalPolicy),
     maxPending: readInteger(raw.maxPending, DEFAULT_CONFIG.maxPending, 1, 200),
     maxSkillBytes: readInteger(raw.maxSkillBytes, DEFAULT_CONFIG.maxSkillBytes, 1024, 200_000),

--- a/src/skills/workshop/service.test.ts
+++ b/src/skills/workshop/service.test.ts
@@ -25,7 +25,11 @@ import {
   resolvePendingSkillProposal,
   reviseSkillProposal,
 } from "./service.js";
-import { readSkillProposalManifest, resolveProposalDraftPath } from "./store.js";
+import {
+  readSkillProposalManifest,
+  resolveProposalDraftPath,
+  updateSkillProposalRecord,
+} from "./store.js";
 
 const tempDirs = createTrackedTempDirs();
 let testState: OpenClawTestState;
@@ -214,6 +218,56 @@ describe("skill workshop proposals", () => {
       ).rejects.toThrow();
       await expect(
         fs.access(path.join(targetSkillsDir, "readonly-symlink-skill", "references", "details.md")),
+      ).rejects.toThrow();
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "validates support file targets against trusted symlink write roots",
+    async () => {
+      const workspaceDir = await makeWorkspace();
+      const targetSkillsDir = await tempDirs.make("openclaw-skill-workshop-support-trusted-");
+      const untrustedSkillsDir = await tempDirs.make("openclaw-skill-workshop-support-untrusted-");
+      await fs.symlink(targetSkillsDir, path.join(workspaceDir, "skills"), "dir");
+      await fs.symlink(untrustedSkillsDir, path.join(workspaceDir, "other-skills"), "dir");
+      const config = {
+        skills: {
+          load: { allowSymlinkTargets: [targetSkillsDir] },
+          workshop: { allowSymlinkTargetWrites: true },
+        },
+      };
+      const proposal = await proposeCreateSkill({
+        workspaceDir,
+        config,
+        name: "Support Escape",
+        description: "Must keep support writes in trusted roots",
+        content: "# Support Escape\n\nDo not write through the wrong skill dir.\n",
+        supportFiles: [
+          {
+            path: "references/details.md",
+            content: "This support file must not be written outside the trusted target.\n",
+          },
+        ],
+      });
+
+      await updateSkillProposalRecord({
+        record: {
+          ...proposal.record,
+          target: {
+            ...proposal.record.target,
+            skillDir: path.join(workspaceDir, "other-skills", "support-escape"),
+          },
+        },
+      });
+
+      await expect(
+        applySkillProposal({ workspaceDir, config, proposalId: proposal.record.id }),
+      ).rejects.toThrow("untrusted symlink target");
+      await expect(
+        fs.access(path.join(untrustedSkillsDir, "support-escape", "references", "details.md")),
+      ).rejects.toThrow();
+      await expect(
+        fs.access(path.join(targetSkillsDir, "support-escape", "SKILL.md")),
       ).rejects.toThrow();
     },
   );

--- a/src/skills/workshop/service.test.ts
+++ b/src/skills/workshop/service.test.ts
@@ -138,6 +138,75 @@ describe("skill workshop proposals", () => {
     expect((await inspectSkillProposal(proposal.record.id))?.record.status).toBe("applied");
   });
 
+  it.runIf(process.platform !== "win32")(
+    "applies updates through trusted workspace skills symlink targets",
+    async () => {
+      const workspaceDir = await makeWorkspace();
+      const targetSkillsDir = await tempDirs.make("openclaw-skill-workshop-target-skills-");
+      await fs.symlink(targetSkillsDir, path.join(workspaceDir, "skills"), "dir");
+      const skillDir = path.join(targetSkillsDir, "shared-skill");
+      await writeSkill({
+        dir: skillDir,
+        name: "shared-skill",
+        description: "Shared skill target",
+        body: "# Shared Skill\n\nOld body.\n",
+      });
+      const config = { skills: { load: { allowSymlinkTargets: [targetSkillsDir] } } };
+      const proposal = await proposeUpdateSkill({
+        workspaceDir,
+        config,
+        skillName: "shared-skill",
+        content: "# Shared Skill\n\nNew body.\n",
+      });
+
+      const applied = await applySkillProposal({
+        workspaceDir,
+        config,
+        proposalId: proposal.record.id,
+      });
+
+      expect(applied.targetSkillFile).toBe(
+        path.join(workspaceDir, "skills", "shared-skill", "SKILL.md"),
+      );
+      await expect(fs.readFile(path.join(skillDir, "SKILL.md"), "utf8")).resolves.toContain(
+        "New body.",
+      );
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "blocks untrusted workspace skills symlink targets before support files are written",
+    async () => {
+      const workspaceDir = await makeWorkspace();
+      const targetSkillsDir = await tempDirs.make("openclaw-skill-workshop-untrusted-skills-");
+      await fs.symlink(targetSkillsDir, path.join(workspaceDir, "skills"), "dir");
+      const proposal = await proposeCreateSkill({
+        workspaceDir,
+        name: "Untrusted Symlink Skill",
+        description: "Must not write through an untrusted symlink",
+        content: "# Untrusted\n\nDo not write.\n",
+        supportFiles: [
+          {
+            path: "references/details.md",
+            content: "This support file must not be written.\n",
+          },
+        ],
+      });
+
+      await expect(
+        applySkillProposal({ workspaceDir, proposalId: proposal.record.id }),
+      ).rejects.toThrow("untrusted symlink target");
+      await expect(
+        fs.access(path.join(targetSkillsDir, "untrusted-symlink-skill", "SKILL.md")),
+      ).rejects.toThrow();
+      await expect(
+        fs.access(
+          path.join(targetSkillsDir, "untrusted-symlink-skill", "references", "details.md"),
+        ),
+      ).rejects.toThrow();
+    },
+  );
+
   it("preserves non-proposal frontmatter when proposals become active skills", async () => {
     const workspaceDir = await makeWorkspace();
     const created = await proposeCreateSkill({

--- a/src/skills/workshop/service.test.ts
+++ b/src/skills/workshop/service.test.ts
@@ -139,7 +139,7 @@ describe("skill workshop proposals", () => {
   });
 
   it.runIf(process.platform !== "win32")(
-    "applies updates through trusted workspace skills symlink targets",
+    "applies updates through opted-in trusted workspace skills symlink targets",
     async () => {
       const workspaceDir = await makeWorkspace();
       const targetSkillsDir = await tempDirs.make("openclaw-skill-workshop-target-skills-");
@@ -151,12 +151,20 @@ describe("skill workshop proposals", () => {
         description: "Shared skill target",
         body: "# Shared Skill\n\nOld body.\n",
       });
-      const config = { skills: { load: { allowSymlinkTargets: [targetSkillsDir] } } };
+      await fs.mkdir(path.join(skillDir, "references"), { recursive: true });
+      await fs.writeFile(path.join(skillDir, "references", "shared.md"), "Old support.\n", "utf8");
+      const config = {
+        skills: {
+          load: { allowSymlinkTargets: [targetSkillsDir] },
+          workshop: { allowSymlinkTargetWrites: true },
+        },
+      };
       const proposal = await proposeUpdateSkill({
         workspaceDir,
         config,
         skillName: "shared-skill",
         content: "# Shared Skill\n\nNew body.\n",
+        supportFiles: [{ path: "references/shared.md", content: "New support.\n" }],
       });
 
       const applied = await applySkillProposal({
@@ -171,6 +179,42 @@ describe("skill workshop proposals", () => {
       await expect(fs.readFile(path.join(skillDir, "SKILL.md"), "utf8")).resolves.toContain(
         "New body.",
       );
+      await expect(
+        fs.readFile(path.join(skillDir, "references", "shared.md"), "utf8"),
+      ).resolves.toBe("New support.\n");
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "blocks trusted workspace skills symlink writes until workshop writes are enabled",
+    async () => {
+      const workspaceDir = await makeWorkspace();
+      const targetSkillsDir = await tempDirs.make("openclaw-skill-workshop-readonly-skills-");
+      await fs.symlink(targetSkillsDir, path.join(workspaceDir, "skills"), "dir");
+      const config = { skills: { load: { allowSymlinkTargets: [targetSkillsDir] } } };
+      const proposal = await proposeCreateSkill({
+        workspaceDir,
+        config,
+        name: "Readonly Symlink Skill",
+        description: "Must not write without explicit workshop opt-in",
+        content: "# Readonly\n\nDo not write.\n",
+        supportFiles: [
+          {
+            path: "references/details.md",
+            content: "This support file must not be written.\n",
+          },
+        ],
+      });
+
+      await expect(
+        applySkillProposal({ workspaceDir, config, proposalId: proposal.record.id }),
+      ).rejects.toThrow("allowSymlinkTargetWrites");
+      await expect(
+        fs.access(path.join(targetSkillsDir, "readonly-symlink-skill", "SKILL.md")),
+      ).rejects.toThrow();
+      await expect(
+        fs.access(path.join(targetSkillsDir, "readonly-symlink-skill", "references", "details.md")),
+      ).rejects.toThrow();
     },
   );
 

--- a/src/skills/workshop/service.ts
+++ b/src/skills/workshop/service.ts
@@ -664,10 +664,12 @@ async function publishProposalTarget(params: {
   try {
     for (const file of params.supportFiles) {
       await writeWorkspaceSupportFile({
+        workspaceDir: params.workspaceDir,
         skillDir: params.record.target.skillDir,
         relativePath: file.path,
         content: file.content,
         overwrite: params.record.kind === "update",
+        allowedSymlinkTargetRealPaths: params.allowedSymlinkTargetRealPaths,
       });
       writtenSupportPaths.push(file.path);
     }
@@ -680,33 +682,49 @@ async function publishProposalTarget(params: {
     });
   } catch (error) {
     if (params.record.kind === "create") {
-      await cleanupCreatedSupportFiles(params.record, writtenSupportPaths);
+      await cleanupCreatedSupportFiles({
+        workspaceDir: params.workspaceDir,
+        record: params.record,
+        writtenSupportPaths,
+        allowedSymlinkTargetRealPaths: params.allowedSymlinkTargetRealPaths,
+      });
     } else {
       await restoreUpdatedSupportFiles({
+        workspaceDir: params.workspaceDir,
         record: params.record,
         writtenSupportPaths,
         previousSupportFiles: params.previousSupportFiles,
+        allowedSymlinkTargetRealPaths: params.allowedSymlinkTargetRealPaths,
       });
     }
     throw error;
   }
 }
 
-async function cleanupCreatedSupportFiles(
-  record: SkillProposalRecord,
-  writtenSupportPaths: readonly string[],
-): Promise<void> {
+async function cleanupCreatedSupportFiles(params: {
+  workspaceDir: string;
+  record: SkillProposalRecord;
+  writtenSupportPaths: readonly string[];
+  allowedSymlinkTargetRealPaths: readonly string[];
+}): Promise<void> {
   await Promise.allSettled(
-    writtenSupportPaths.toReversed().map(async (relativePath) => {
-      await removeWorkspaceSupportFile({ skillDir: record.target.skillDir, relativePath });
+    params.writtenSupportPaths.toReversed().map(async (relativePath) => {
+      await removeWorkspaceSupportFile({
+        workspaceDir: params.workspaceDir,
+        skillDir: params.record.target.skillDir,
+        relativePath,
+        allowedSymlinkTargetRealPaths: params.allowedSymlinkTargetRealPaths,
+      });
     }),
   );
 }
 
 async function restoreUpdatedSupportFiles(params: {
+  workspaceDir: string;
   record: SkillProposalRecord;
   writtenSupportPaths: readonly string[];
   previousSupportFiles: NonNullable<SkillProposalRollback["supportFiles"]>;
+  allowedSymlinkTargetRealPaths: readonly string[];
 }): Promise<void> {
   const previousByPath = new Map(params.previousSupportFiles.map((file) => [file.path, file]));
   await Promise.allSettled(
@@ -717,13 +735,20 @@ async function restoreUpdatedSupportFiles(params: {
       }
       if (previous.existed) {
         await writeWorkspaceSupportFile({
+          workspaceDir: params.workspaceDir,
           skillDir: params.record.target.skillDir,
           relativePath,
           content: previous.previousContent ?? "",
           overwrite: true,
+          allowedSymlinkTargetRealPaths: params.allowedSymlinkTargetRealPaths,
         });
       } else {
-        await removeWorkspaceSupportFile({ skillDir: params.record.target.skillDir, relativePath });
+        await removeWorkspaceSupportFile({
+          workspaceDir: params.workspaceDir,
+          skillDir: params.record.target.skillDir,
+          relativePath,
+          allowedSymlinkTargetRealPaths: params.allowedSymlinkTargetRealPaths,
+        });
       }
     }),
   );

--- a/src/skills/workshop/service.ts
+++ b/src/skills/workshop/service.ts
@@ -532,7 +532,10 @@ export async function applySkillProposal(
 
     assertInsideWorkspace(input.workspaceDir, record.target.skillFile, "skill file");
     assertInsideWorkspace(input.workspaceDir, record.target.skillDir, "skill directory");
-    const allowedSymlinkTargetRealPaths = resolveAllowedSkillSymlinkTargetRealPaths(input.config);
+    const workshopConfig = resolveSkillWorkshopConfig(input.config);
+    const allowedSymlinkTargetRealPaths = workshopConfig.allowSymlinkTargetWrites
+      ? resolveAllowedSkillSymlinkTargetRealPaths(input.config)
+      : [];
     await assertWorkspaceSkillWriteTarget({
       workspaceDir: input.workspaceDir,
       filePath: record.target.skillFile,

--- a/src/skills/workshop/service.ts
+++ b/src/skills/workshop/service.ts
@@ -10,6 +10,7 @@ import {
   resolveSkillStatusEntry,
   type SkillStatusEntry,
 } from "../discovery/status.js";
+import { resolveAllowedSkillSymlinkTargetRealPaths } from "../loading/symlink-targets.js";
 import { bumpSkillsSnapshotVersion } from "../runtime/refresh-state.js";
 import { scanSkillContent, scanSource } from "../security/scanner.js";
 import { resolveSkillWorkshopConfig, type SkillWorkshopConfig } from "./config.js";
@@ -20,6 +21,7 @@ import {
 } from "./frontmatter.js";
 import {
   assertInsideWorkspace,
+  assertWorkspaceSkillWriteTarget,
   createSkillProposalId,
   createSkillProposalRollback,
   hashSkillProposalContent,
@@ -530,6 +532,12 @@ export async function applySkillProposal(
 
     assertInsideWorkspace(input.workspaceDir, record.target.skillFile, "skill file");
     assertInsideWorkspace(input.workspaceDir, record.target.skillDir, "skill directory");
+    const allowedSymlinkTargetRealPaths = resolveAllowedSkillSymlinkTargetRealPaths(input.config);
+    await assertWorkspaceSkillWriteTarget({
+      workspaceDir: input.workspaceDir,
+      filePath: record.target.skillFile,
+      allowedSymlinkTargetRealPaths,
+    });
     const targetState = await readApplyTargetState(record, supportFiles);
     const rollback = createSkillProposalRollback({
       proposalId: record.id,
@@ -554,6 +562,7 @@ export async function applySkillProposal(
       skillContent,
       supportFiles,
       previousSupportFiles: targetState.previousSupportFiles,
+      allowedSymlinkTargetRealPaths,
     });
     bumpSkillsSnapshotVersion({
       workspaceDir: input.workspaceDir,
@@ -646,6 +655,7 @@ async function publishProposalTarget(params: {
   skillContent: string;
   supportFiles: readonly PreparedSkillProposalSupportFile[];
   previousSupportFiles: NonNullable<SkillProposalRollback["supportFiles"]>;
+  allowedSymlinkTargetRealPaths: readonly string[];
 }): Promise<void> {
   const writtenSupportPaths: string[] = [];
   try {
@@ -663,6 +673,7 @@ async function publishProposalTarget(params: {
       filePath: params.record.target.skillFile,
       content: params.skillContent,
       overwrite: params.record.kind === "update",
+      allowedSymlinkTargetRealPaths: params.allowedSymlinkTargetRealPaths,
     });
   } catch (error) {
     if (params.record.kind === "create") {

--- a/src/skills/workshop/store.ts
+++ b/src/skills/workshop/store.ts
@@ -615,15 +615,24 @@ async function tryRealpath(filePath: string): Promise<string | null> {
 }
 
 export async function writeWorkspaceSupportFile(params: {
+  workspaceDir?: string;
   skillDir: string;
   relativePath: string;
   content: string;
   overwrite?: boolean;
+  allowedSymlinkTargetRealPaths?: readonly string[];
 }): Promise<void> {
   const relativePath = normalizeSkillProposalSupportPath(params.relativePath);
-  await fs.mkdir(params.skillDir, { recursive: true });
-  const skillRoot = await root(params.skillDir);
-  await skillRoot.write(relativePath, params.content, {
+  const filePath = path.join(params.skillDir, ...relativePath.split("/"));
+  const target = params.workspaceDir
+    ? await resolveWorkspaceSkillWriteTarget({
+        workspaceDir: params.workspaceDir,
+        filePath,
+        allowedSymlinkTargetRealPaths: params.allowedSymlinkTargetRealPaths,
+      })
+    : { rootDir: params.skillDir, relativePath };
+  const targetRoot = await root(target.rootDir);
+  await targetRoot.write(target.relativePath, params.content, {
     encoding: "utf8",
     mkdir: true,
     ...(params.overwrite === undefined ? {} : { overwrite: params.overwrite }),
@@ -631,12 +640,22 @@ export async function writeWorkspaceSupportFile(params: {
 }
 
 export async function removeWorkspaceSupportFile(params: {
+  workspaceDir?: string;
   skillDir: string;
   relativePath: string;
+  allowedSymlinkTargetRealPaths?: readonly string[];
 }): Promise<void> {
   const relativePath = normalizeSkillProposalSupportPath(params.relativePath);
-  const skillRoot = await root(params.skillDir);
-  await skillRoot.remove(relativePath).catch((error: unknown) => {
+  const filePath = path.join(params.skillDir, ...relativePath.split("/"));
+  const target = params.workspaceDir
+    ? await resolveWorkspaceSkillWriteTarget({
+        workspaceDir: params.workspaceDir,
+        filePath,
+        allowedSymlinkTargetRealPaths: params.allowedSymlinkTargetRealPaths,
+      })
+    : { rootDir: params.skillDir, relativePath };
+  const targetRoot = await root(target.rootDir);
+  await targetRoot.remove(target.relativePath).catch((error: unknown) => {
     if ((error as { code?: string })?.code !== "ENOENT") {
       throw error;
     }

--- a/src/skills/workshop/store.ts
+++ b/src/skills/workshop/store.ts
@@ -9,6 +9,7 @@ import { pathExists, root } from "../../infra/fs-safe.js";
 import { tryReadJson } from "../../infra/json-files.js";
 import { isPathInside } from "../../infra/path-safety.js";
 import { normalizeSkillIndexName } from "../discovery/skill-index.js";
+import { findContainingAllowedSkillSymlinkTarget } from "../loading/symlink-targets.js";
 import {
   SKILL_WORKSHOP_MANIFEST_SCHEMA,
   SKILL_WORKSHOP_ROLLBACK_SCHEMA,
@@ -514,18 +515,103 @@ export async function writeWorkspaceSkillFile(params: {
   filePath: string;
   content: string;
   overwrite?: boolean;
+  allowedSymlinkTargetRealPaths?: readonly string[];
 }): Promise<void> {
   assertInsideWorkspace(params.workspaceDir, params.filePath, "skill file");
-  const relativePath = path.relative(
-    path.resolve(params.workspaceDir),
-    path.resolve(params.filePath),
-  );
-  const workspaceRoot = await root(params.workspaceDir);
-  await workspaceRoot.write(relativePath, params.content, {
+  const target = await resolveWorkspaceSkillWriteTarget({
+    workspaceDir: params.workspaceDir,
+    filePath: params.filePath,
+    allowedSymlinkTargetRealPaths: params.allowedSymlinkTargetRealPaths,
+  });
+  const targetRoot = await root(target.rootDir);
+  await targetRoot.write(target.relativePath, params.content, {
     encoding: "utf8",
     mkdir: true,
     ...(params.overwrite === undefined ? {} : { overwrite: params.overwrite }),
   });
+}
+
+export async function assertWorkspaceSkillWriteTarget(params: {
+  workspaceDir: string;
+  filePath: string;
+  allowedSymlinkTargetRealPaths?: readonly string[];
+}): Promise<void> {
+  assertInsideWorkspace(params.workspaceDir, params.filePath, "skill file");
+  await resolveWorkspaceSkillWriteTarget(params);
+}
+
+type WorkspaceSkillWriteTarget = {
+  rootDir: string;
+  relativePath: string;
+};
+
+async function resolveWorkspaceSkillWriteTarget(params: {
+  workspaceDir: string;
+  filePath: string;
+  allowedSymlinkTargetRealPaths?: readonly string[];
+}): Promise<WorkspaceSkillWriteTarget> {
+  const workspaceDir = path.resolve(params.workspaceDir);
+  const filePath = path.resolve(params.filePath);
+  const relativePath = path.relative(workspaceDir, filePath);
+  const aliasTarget = await resolveWorkspaceAliasTarget({
+    workspaceDir,
+    filePath,
+  });
+  if (!aliasTarget) {
+    return { rootDir: workspaceDir, relativePath };
+  }
+  const allowedRoot = findContainingAllowedSkillSymlinkTarget(
+    params.allowedSymlinkTargetRealPaths ?? [],
+    aliasTarget.realTarget,
+  );
+  if (!allowedRoot) {
+    throw new Error(
+      `Skill file resolves through an untrusted symlink target: ${params.filePath}. Configure skills.load.allowSymlinkTargets for intentional skill symlinks.`,
+    );
+  }
+  return {
+    rootDir: allowedRoot,
+    relativePath: path.relative(allowedRoot, aliasTarget.realTarget),
+  };
+}
+
+async function resolveWorkspaceAliasTarget(params: {
+  workspaceDir: string;
+  filePath: string;
+}): Promise<{ realTarget: string } | null> {
+  const workspaceRealPath = (await tryRealpath(params.workspaceDir)) ?? params.workspaceDir;
+  const realTarget = await resolveRealPathThroughExistingAncestors(
+    params.workspaceDir,
+    params.filePath,
+  );
+  if (isPathInside(workspaceRealPath, realTarget)) {
+    return null;
+  }
+  return { realTarget };
+}
+
+async function resolveRealPathThroughExistingAncestors(
+  workspaceDir: string,
+  filePath: string,
+): Promise<string> {
+  const relativePath = path.relative(workspaceDir, filePath);
+  const segments = relativePath.split(path.sep).filter(Boolean);
+  let lexicalCursor = workspaceDir;
+  let realCursor = (await tryRealpath(workspaceDir)) ?? workspaceDir;
+  for (const segment of segments) {
+    lexicalCursor = path.join(lexicalCursor, segment);
+    const existingRealPath = await tryRealpath(lexicalCursor);
+    realCursor = existingRealPath ?? path.join(realCursor, segment);
+  }
+  return path.resolve(realCursor);
+}
+
+async function tryRealpath(filePath: string): Promise<string | null> {
+  try {
+    return await fs.realpath(filePath);
+  } catch {
+    return null;
+  }
 }
 
 export async function writeWorkspaceSupportFile(params: {

--- a/src/skills/workshop/store.ts
+++ b/src/skills/workshop/store.ts
@@ -566,7 +566,7 @@ async function resolveWorkspaceSkillWriteTarget(params: {
   );
   if (!allowedRoot) {
     throw new Error(
-      `Skill file resolves through an untrusted symlink target: ${params.filePath}. Configure skills.load.allowSymlinkTargets for intentional skill symlinks.`,
+      `Skill file resolves through an untrusted symlink target: ${params.filePath}. Configure skills.load.allowSymlinkTargets and enable skills.workshop.allowSymlinkTargetWrites for intentional Skill Workshop symlink writes.`,
     );
   }
   return {

--- a/src/skills/workshop/types.ts
+++ b/src/skills/workshop/types.ts
@@ -151,6 +151,7 @@ export type SkillProposalReviseInput = {
 
 export type SkillProposalActionInput = {
   workspaceDir: string;
+  config?: OpenClawConfig;
   proposalId: string;
   reason?: string;
 };


### PR DESCRIPTION
## Summary
- Keep trusted symlink target configuration in one place with `skills.load.allowSymlinkTargets`.
- Add `skills.workshop.allowSymlinkTargetWrites` as the separate default-false switch for Skill Workshop writes through those already trusted targets.
- Thread active config into CLI, gateway, and agent-tool apply paths.
- Validate both `SKILL.md` and proposal support-file writes/removes through the same symlink write-target resolver.
- Add regression coverage and docs for trusted, read-only trusted, untrusted, and support-file symlink behavior.

## Tests
- `node scripts/run-vitest.mjs src/skills/workshop/service.test.ts src/config/schema.help.quality.test.ts`
- `node_modules/.bin/oxfmt --check --threads=1 src/skills/workshop/store.ts src/skills/workshop/service.ts src/skills/workshop/service.test.ts`
- `node_modules/.bin/oxlint src/skills/workshop/store.ts src/skills/workshop/service.ts src/skills/workshop/service.test.ts`
- `git diff --check origin/main...HEAD`
- `$HOME/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` -> clean, no accepted/actionable findings
- Testbox-through-Crabbox current-head proof: provider `blacksmith-testbox`, id `tbx_01ktvesre39fhhqj4c3z42et6a`, Actions run `27351180098`, head `8cd27f37b12175e9103bf9bf73996244caabe6b1`

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Skill Workshop can load/propose against skills under trusted symlink targets from `skills.load.allowSymlinkTargets`, but apply-time writes through those targets remain blocked unless `skills.workshop.allowSymlinkTargetWrites` is explicitly `true`. Untrusted symlink targets and tampered support-file targets remain blocked before writing.
- Real environment tested: Linux Blacksmith Testbox through Crabbox, Node `24.13.0`, current PR head `8cd27f37b12175e9103bf9bf73996244caabe6b1`, isolated temporary `OPENCLAW_STATE_DIR` and `OPENCLAW_CONFIG_PATH` per scenario. Each scenario used real filesystem directory symlinks and the real `node scripts/run-node.mjs skills workshop ...` CLI entrypoint.
- Exact steps or command run after this patch:
  1. Ran focused regression tests remotely: `node scripts/run-vitest.mjs src/skills/workshop/service.test.ts src/config/schema.help.quality.test.ts`.
  2. Created an isolated workspace where `workspace/skills` pointed to an external target and no `skills.load.allowSymlinkTargets` was configured; proposed a create with `PROPOSAL.md` plus `references/details.md`; verified apply failed with `untrusted symlink target` and wrote neither file.
  3. Created an isolated workspace where `workspace/skills` pointed to a target listed in `skills.load.allowSymlinkTargets`, with no Workshop write switch; verified `propose-update shared-skill` succeeded, then apply failed with `allowSymlinkTargetWrites` and preserved old `SKILL.md` plus support content.
  4. Created the same trusted symlink setup with `skills.workshop.allowSymlinkTargetWrites: true`; verified apply succeeded and wrote both `SKILL.md` and `references/details.md` into the real trusted target.
  5. Created a trusted `workspace/skills` symlink and an untrusted sibling `workspace/other-skills` symlink; proposed a create with support files, tampered the persisted proposal record so `target.skillDir` pointed through the untrusted sibling while `target.skillFile` stayed under the trusted target, and verified apply failed with `untrusted symlink target` without writing support files or `SKILL.md`.
- Evidence after fix (terminal capture):
```text
CRABBOX_PHASE:tests
REMOTE_HEAD 8cd27f37b12175e9103bf9bf73996244caabe6b1
[test] passed 2 Vitest shards in 7.82s
src/skills/workshop/service.test.ts: 25 passed
src/config/schema.help.quality.test.ts: 23 passed

CRABBOX_PHASE:cli-proof
PROOF no_allowlist_blocked id=no-allowlist-skill-20260611-43d5b0340b
PROOF allowlist_loads_but_write_blocked id=shared-skill-20260611-429d46fa49
PROOF allowlist_write_enabled_applied id=shared-skill-20260611-c76a973654
PROOF tampered_support_target_blocked id=support-escape-20260611-b85d70d5b6
PROOF_COMPLETE current-head symlink workshop CLI proof passed

blacksmith run summary sync=delegated command=2m14.007s total=2m19.707s exit=0
{"provider":"blacksmith-testbox","leaseId":"tbx_01ktvesre39fhhqj4c3z42et6a","syncDelegated":true,"exitCode":0}
```
- Observed result after fix: The read trust list alone permits loading/proposal creation but not writes; enabling the Workshop switch permits writes only through already trusted targets; untrusted symlink targets and tampered support-file targets fail before any target file is created or modified.
- What was not tested: Live gateway delivery, Discord delivery, and a live model-driven agent-tool turn were not exercised in this proof run; the shared CLI/service write boundary and config schema/help paths were exercised directly, and PR CI is covering the broader repository gates for the pushed head.
- Proof limitations or environment constraints: The proof used isolated temporary OpenClaw state/config so it did not mutate operator or contributor workspaces.
