### PR TITLE
fix(agents): expose sessions_spawn in embedded mode when allowAgents is configured

### DIFF
--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -391,7 +391,10 @@ export function createOpenClawTools(
     !embedded ||
     options?.sourceReplyDeliveryMode === "message_tool_only" ||
     messageExplicitlyAllowed;
-  const includeSubagentSpawnTool = !embedded || options?.allowGatewaySubagentBinding === true;
+  const includeSubagentSpawnTool =
+    !embedded ||
+    options?.allowGatewaySubagentBinding === true ||
+    (resolvedConfig?.agents?.defaults?.subagents?.allowAgents?.length ?? 0) > 0;
   const effectiveCallGateway = embedded
     ? createEmbeddedCallGateway()
     : openClawToolsDeps.callGateway;


### PR DESCRIPTION
## Summary

- In embedded mode (TUI, `--local`), the `sessions_spawn` tool was unconditionally excluded unless `allowGatewaySubagentBinding` was explicitly set.
- This made `agents.defaults.subagents.allowAgents` silently ineffective for TUI users — the tool was always missing even when valid target agents were configured.
- Fix: allow `sessions_spawn` to be exposed in embedded mode when `allowAgents` lists at least one target agent, matching the documented intent of the config field.

## Verification

- `node scripts/run-vitest.mjs run src/agents/openclaw-tools.update-plan.test.ts` → 20 passed
- Production function verified via `node --import tsx` (see Real behavior proof below)

## Change Type

- [x] Bug fix / [ ] Feature / [ ] Refactor / [ ] Docs / [ ] Security / [ ] Chore

## Scope

- [ ] Gateway / [ ] Skills / [ ] Auth / [ ] Memory / [ ] Integrations / [ ] API / [x] UI/UX / [ ] CI

## Real behavior proof

**Behavior addressed:** `sessions_spawn` tool missing from TUI/embedded agent tool list even when `agents.defaults.subagents.allowAgents` is populated.

**Environment tested:** Node 24.x on Linux, `node --import tsx` production function call.

**Steps run after the patch:** Called `createOpenClawTools` from the patched source with a config that has `allowAgents: ['code-reader', 'test-agent']` but no `allowGatewaySubagentBinding`.

**Evidence after fix:**

```text
SUCCESS: sessions_spawn tool IS included when allowAgents is configured.
Tool name: sessions_spawn
```

**Observed result:** The `sessions_spawn` tool is correctly included in the tool inventory when `allowAgents` is configured, even in embedded mode.

**Not tested:** Live TUI session with actual sub-agent spawning through the tool. Config with empty `allowAgents` array (tool should still be excluded in that case).

Closes #91095