### PR TITLE
fix(cron): allow update patches to clear payload.model back to inherit

### DIFF
--- a/packages/gateway-protocol/src/schema/cron.ts
+++ b/packages/gateway-protocol/src/schema/cron.ts
@@ -10,12 +10,16 @@ import { NonEmptyString } from "./primitives.js";
  */
 
 /** Builds create/patch payload variants while preserving per-call field optionality. */
-function cronAgentTurnPayloadSchema(params: { message: TSchema; toolsAllow: TSchema }) {
+function cronAgentTurnPayloadSchema(params: {
+  message: TSchema;
+  model: TSchema;
+  toolsAllow: TSchema;
+}) {
   return Type.Object(
     {
       kind: Type.Literal("agentTurn"),
       message: params.message,
-      model: Type.Optional(Type.String()),
+      model: params.model,
       fallbacks: Type.Optional(Type.Array(Type.String())),
       thinking: Type.Optional(Type.String()),
       timeoutSeconds: Type.Optional(Type.Number({ minimum: 0 })),
@@ -227,6 +231,7 @@ export const CronPayloadSchema = Type.Union([
   ),
   cronAgentTurnPayloadSchema({
     message: NonEmptyString,
+    model: Type.Optional(Type.String()),
     toolsAllow: Type.Array(Type.String()),
   }),
   cronCommandPayloadSchema({
@@ -245,6 +250,7 @@ export const CronPayloadPatchSchema = Type.Union([
   ),
   cronAgentTurnPayloadSchema({
     message: Type.Optional(NonEmptyString),
+    model: Type.Optional(Type.Union([Type.String(), Type.Null()])),
     toolsAllow: Type.Union([Type.Array(Type.String()), Type.Null()]),
   }),
   cronCommandPayloadSchema({

--- a/src/cron/normalize.test.ts
+++ b/src/cron/normalize.test.ts
@@ -832,6 +832,46 @@ describe("normalizeCronJobPatch", () => {
     expect(validateCronUpdateParams({ id: "job-1", patch: normalized })).toBe(true);
   });
 
+  it("preserves null model so patches can clear the model override", () => {
+    const normalized = normalizeCronJobPatch({
+      payload: {
+        kind: "agentTurn",
+        model: null,
+      },
+    }) as unknown as Record<string, unknown>;
+
+    const payload = normalized.payload as Record<string, unknown>;
+    expect(payload.kind).toBe("agentTurn");
+    expect(payload.model).toBeNull();
+    expect(validateCronUpdateParams({ id: "job-1", patch: normalized })).toBe(true);
+  });
+
+  it("treats empty-string model as an explicit clear", () => {
+    const normalized = normalizeCronJobPatch({
+      payload: {
+        kind: "agentTurn",
+        model: "",
+      },
+    }) as unknown as Record<string, unknown>;
+
+    const payload = normalized.payload as Record<string, unknown>;
+    expect(payload.model).toBeNull();
+    expect(validateCronUpdateParams({ id: "job-1", patch: normalized })).toBe(true);
+  });
+
+  it("preserves a non-empty model override and trims surrounding whitespace", () => {
+    const normalized = normalizeCronJobPatch({
+      payload: {
+        kind: "agentTurn",
+        model: "  anthropic/claude-sonnet-4-5  ",
+      },
+    }) as unknown as Record<string, unknown>;
+
+    const payload = normalized.payload as Record<string, unknown>;
+    expect(payload.model).toBe("anthropic/claude-sonnet-4-5");
+    expect(validateCronUpdateParams({ id: "job-1", patch: normalized })).toBe(true);
+  });
+
   it("preserves null sessionKey patches and trims string values", () => {
     const trimmed = normalizeCronJobPatch({
       sessionKey: "  agent:main:telegram:group:-100123  ",

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -170,11 +170,17 @@ function coercePayload(payload: UnknownRecord) {
     }
   }
   if ("model" in next) {
-    const model = parseOptionalField(TrimmedNonEmptyStringFieldSchema, next.model);
-    if (model !== undefined) {
-      next.model = model;
+    if (next.model === null || next.model === "") {
+      // Explicit clear: preserve null so cron.update can reset model to inherit
+      // the agent default, mirroring the toolsAllow clear-on-null contract.
+      next.model = null;
     } else {
-      delete next.model;
+      const model = parseOptionalField(TrimmedNonEmptyStringFieldSchema, next.model);
+      if (model !== undefined) {
+        next.model = model;
+      } else {
+        delete next.model;
+      }
     }
   }
   if ("thinking" in next) {

--- a/src/cron/service/jobs.apply-patch.test.ts
+++ b/src/cron/service/jobs.apply-patch.test.ts
@@ -22,6 +22,46 @@ function makeJob(overrides: Partial<CronJob> = {}): CronJob {
   };
 }
 
+describe("applyJobPatch payload model clear", () => {
+  it("clears a stale model override when patched with null", () => {
+    const job = makeJob({
+      payload: { kind: "agentTurn", message: "hello", model: "openai/gpt-5.4-mini" },
+    });
+    const patch = {
+      payload: { kind: "agentTurn", model: null },
+    } as Parameters<typeof applyJobPatch>[1];
+    applyJobPatch(job, patch);
+    expect(job.payload).toEqual({ kind: "agentTurn", message: "hello" });
+    expect("model" in job.payload).toBe(false);
+  });
+
+  it("preserves an existing model when the patch omits model", () => {
+    const job = makeJob({
+      payload: { kind: "agentTurn", message: "hello", model: "openai/gpt-5.4-mini" },
+    });
+    const patch = {
+      payload: { kind: "agentTurn", message: "updated" },
+    } as Parameters<typeof applyJobPatch>[1];
+    applyJobPatch(job, patch);
+    expect(job.payload).toEqual({
+      kind: "agentTurn",
+      message: "updated",
+      model: "openai/gpt-5.4-mini",
+    });
+  });
+
+  it("replaces the model override when patched with a new value", () => {
+    const job = makeJob({
+      payload: { kind: "agentTurn", message: "hello", model: "openai/gpt-5.4-mini" },
+    });
+    const patch = {
+      payload: { kind: "agentTurn", model: "anthropic/claude-sonnet-4-5" },
+    } as Parameters<typeof applyJobPatch>[1];
+    applyJobPatch(job, patch);
+    expect((job.payload as { model?: string }).model).toBe("anthropic/claude-sonnet-4-5");
+  });
+});
+
 describe("applyJobPatch delivery merge", () => {
   it("threads explicit delivery threadId patches into delivery", () => {
     const job = makeJob();

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -923,6 +923,8 @@ function mergeCronPayload(existing: CronPayload, patch: CronPayloadPatch): CronP
   }
   if (typeof patch.model === "string") {
     next.model = patch.model;
+  } else if (patch.model === null) {
+    delete next.model;
   }
   if (Array.isArray(patch.fallbacks)) {
     next.fallbacks = patch.fallbacks;
@@ -978,7 +980,7 @@ function buildPayloadFromPatch(patch: CronPayloadPatch): CronPayload {
   return {
     kind: "agentTurn",
     message: patch.message,
-    model: patch.model,
+    model: typeof patch.model === "string" ? patch.model : undefined,
     fallbacks: patch.fallbacks,
     toolsAllow: Array.isArray(patch.toolsAllow) ? patch.toolsAllow : undefined,
     thinking: patch.thinking,

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -256,7 +256,8 @@ type CronAgentTurnPayload = {
 
 type CronAgentTurnPayloadPatch = {
   kind: "agentTurn";
-} & Partial<Omit<CronAgentTurnPayloadFields, "toolsAllow">> & {
+} & Partial<Omit<CronAgentTurnPayloadFields, "toolsAllow" | "model">> & {
+    model?: string | null;
     toolsAllow?: string[] | null;
   };
 


### PR DESCRIPTION
## Summary

Fixes #91298. The cron `update` action cannot clear `payload.model` back to "inherit the agent default". Three patch shapes all silently no-op: `{model: null}`, `{model: ""}`, and omitting `model` while patching other fields. By contrast, `toolsAllow` already clears correctly via `null` — so this is a field-level asymmetry, not a design choice.

## Root cause

`toolsAllow` carries a complete clear-on-null contract across all four layers; `model` was missing it at every one:

| Layer | `toolsAllow` (clearable) | `model` (was missing) |
| --- | --- | --- |
| gateway-protocol patch schema | `Union([Array, Null])` | `Optional(String)` — no null |
| `CronAgentTurnPayloadPatch` type | `string[] \| null` | `string` — no null |
| `normalize` | `{ allowNull: true }` | dropped null/empty via `delete` |
| `mergeCronPayload` | `else if (=== null) delete` | only matched `typeof === "string"` |

Because `normalize` deleted the field on null/empty, the clear signal never reached the gateway; and even if it had, the merge step ignored it. The stale override then survived in storage (which already uses field-absence to mean "inherit").

## Fix

Mirror the existing `toolsAllow` clear semantics for `model`, layer by layer — no new behavior, just parity:

- **gateway-protocol schema**: parameterize `model` so the patch variant accepts `string | null` while create stays non-null.
- **type**: `model?: string | null` in the patch type.
- **normalize**: preserve explicit `null`/`""` as a null clear signal instead of dropping it.
- **merge**: `delete next.model` on a null patch; the kind-switch rebuild path coerces null → undefined (matching `toolsAllow`).

Storage and read-back need no change — a cleared (absent) `model` already inherits the agent default.

## Tests

- normalize: null clear, empty-string clear, non-empty preservation + trim.
- merge (`applyJobPatch`): clear-on-null, preserve-on-omit, replace-on-new-value.

## Scope note

`fallbacks` has a similar gap (its `[]` clears, but `null` does not). I scoped this PR to `model` as reported. Happy to extend the same parity to `fallbacks`/`thinking` if maintainers prefer a single sweep.
