### PR TITLE
Fix CLI silent reply fallback policy

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -1865,6 +1865,49 @@ describe("runAgentTurnWithFallback", () => {
     });
   });
 
+  it("passes silent empty-reply policy to CLI backends for message-tool-only turns", async () => {
+    state.isCliProviderMock.mockReturnValue(true);
+    state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({
+      result: await params.run("claude-cli", "claude-sonnet-4-6"),
+      provider: "claude-cli",
+      model: "claude-sonnet-4-6",
+      attempts: [],
+    }));
+    state.runCliAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: SILENT_REPLY_TOKEN }],
+      meta: { executionTrace: { fallbackUsed: false } },
+    });
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const followupRun = createFollowupRun();
+    followupRun.run.provider = "claude-cli";
+    followupRun.run.model = "claude-sonnet-4-6";
+    followupRun.run.sourceReplyDeliveryMode = "message_tool_only";
+    followupRun.run.allowEmptyAssistantReplyAsSilent = true;
+    followupRun.originatingChannel = "telegram";
+
+    const result = await runAgentTurnWithFallback(
+      createMinimalRunAgentTurnParams({
+        followupRun,
+        sessionCtx: {
+          Provider: "telegram",
+          MessageSid: "msg",
+          ChatType: "group",
+        } as unknown as TemplateContext,
+      }),
+    );
+
+    expect(result.kind).toBe("success");
+    expectMockCallArgFields(state.runCliAgentMock, 0, "CLI run params", {
+      provider: "claude-cli",
+      model: "claude-sonnet-4-6",
+      sourceReplyDeliveryMode: "message_tool_only",
+      allowEmptyAssistantReplyAsSilent: true,
+      messageChannel: "telegram",
+      messageProvider: "telegram",
+    });
+  });
+
   it("passes prepared CLI user turns to the runtime persistence boundary", async () => {
     state.isCliProviderMock.mockReturnValue(true);
     state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -2187,6 +2187,8 @@ export async function runAgentTurnWithFallback(params: {
                     extraSystemPrompt: params.followupRun.run.extraSystemPrompt,
                     sourceReplyDeliveryMode: params.followupRun.run.sourceReplyDeliveryMode,
                     silentReplyPromptMode: params.followupRun.run.silentReplyPromptMode,
+                    allowEmptyAssistantReplyAsSilent:
+                      params.followupRun.run.allowEmptyAssistantReplyAsSilent,
                     extraSystemPromptStatic: params.followupRun.run.extraSystemPromptStatic,
                     ownerNumbers: params.followupRun.run.ownerNumbers,
                     cliSessionId: cliSessionBinding?.sessionId,

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -1119,6 +1119,7 @@ describe("createFollowupRunner runtime config", () => {
           model: "claude-opus-4-7",
           suppressNextUserMessagePersistence: true,
           sourceReplyDeliveryMode: "message_tool_only",
+          allowEmptyAssistantReplyAsSilent: true,
         },
       }),
     );
@@ -1129,6 +1130,8 @@ describe("createFollowupRunner runtime config", () => {
     expect(call.currentInboundEventKind).toBe("room_event");
     expect(call.currentInboundAudio).toBe(true);
     expect(call.suppressNextUserMessagePersistence).toBe(true);
+    expect(call.sourceReplyDeliveryMode).toBe("message_tool_only");
+    expect(call.allowEmptyAssistantReplyAsSilent).toBe(true);
     expect(call.cliSessionId).toBe("cli-session-1");
     expect(call.cliSessionBinding).toEqual({ sessionId: "cli-session-1" });
   });

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -825,6 +825,7 @@ export function createFollowupRunner(params: {
                     extraSystemPrompt: run.extraSystemPrompt,
                     sourceReplyDeliveryMode: run.sourceReplyDeliveryMode,
                     silentReplyPromptMode: run.silentReplyPromptMode,
+                    allowEmptyAssistantReplyAsSilent: run.allowEmptyAssistantReplyAsSilent,
                     extraSystemPromptStatic: run.extraSystemPromptStatic,
                     ownerNumbers: run.ownerNumbers,
                     cliSessionId: cliSessionBinding?.sessionId,


### PR DESCRIPTION
## Summary
- pass the existing `allowEmptyAssistantReplyAsSilent` policy through both direct and queued CLI runner paths in fallback/followup orchestration
- add regression tests proving Telegram/message-tool-only Claude CLI turns receive the silent-empty policy instead of falling into `empty_response` fallback handling

Fixes #91302.

## Real behavior proof
- **Behavior or issue addressed**: Claude CLI/message-tool-only turns can validly complete by sending through the message tool and then returning empty assistant text. `get-reply-run` already marks those turns with `allowEmptyAssistantReplyAsSilent`, and the CLI runner already honors that flag, but CLI orchestration handoffs were dropping the flag. This PR forwards the policy through the direct fallback CLI path and the queued followup CLI path so those paths produce the silent reply token instead of triggering the `empty_response` fallback and a duplicate user-visible reply.
- **Real environment tested**: Local OpenClaw PR checkout `/Users/andy/openclaw-91302` on branch `codex/91302-cli-tool-empty-success`, head `2f3762d22986a2867031b4a016adffeafb4e1168`, Node/Vitest through the repository scripts.
- **Exact steps or command run after this patch**:
```sh
git rev-parse HEAD
rg -n "allowEmptyAssistantReplyAsSilent" src/auto-reply/reply/agent-runner-execution.ts src/auto-reply/reply/agent-runner-execution.test.ts src/auto-reply/reply/followup-runner.ts src/auto-reply/reply/followup-runner.test.ts
node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-execution.test.ts --testNamePattern 'passes silent empty-reply policy to CLI backends for message-tool-only turns'
node scripts/run-vitest.mjs src/auto-reply/reply/followup-runner.test.ts --testNamePattern 'reuses CLI session bindings for queued room-event followups'
node scripts/run-vitest.mjs src/auto-reply/reply/followup-runner.test.ts
node scripts/run-vitest.mjs src/agents/cli-runner.reliability.test.ts src/agents/cli-runner.spawn.test.ts src/auto-reply/reply/agent-runner-execution.test.ts
node scripts/run-vitest.mjs src/auto-reply/reply/get-reply-run.media-only.test.ts src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
```
- **Evidence after fix**:
```text
$ git rev-parse HEAD
2f3762d22986a2867031b4a016adffeafb4e1168

$ rg -n "allowEmptyAssistantReplyAsSilent" src/auto-reply/reply/agent-runner-execution.ts src/auto-reply/reply/agent-runner-execution.test.ts src/auto-reply/reply/followup-runner.ts src/auto-reply/reply/followup-runner.test.ts
src/auto-reply/reply/followup-runner.ts:828:                    allowEmptyAssistantReplyAsSilent: run.allowEmptyAssistantReplyAsSilent,
src/auto-reply/reply/followup-runner.ts:929:                allowEmptyAssistantReplyAsSilent: run.allowEmptyAssistantReplyAsSilent,
src/auto-reply/reply/agent-runner-execution.ts:2190:                    allowEmptyAssistantReplyAsSilent:
src/auto-reply/reply/agent-runner-execution.ts:2191:                      params.followupRun.run.allowEmptyAssistantReplyAsSilent,
src/auto-reply/reply/followup-runner.test.ts:1122:          allowEmptyAssistantReplyAsSilent: true,
src/auto-reply/reply/followup-runner.test.ts:1134:    expect(call.allowEmptyAssistantReplyAsSilent).toBe(true);
src/auto-reply/reply/agent-runner-execution.test.ts:1886:    followupRun.run.allowEmptyAssistantReplyAsSilent = true;
src/auto-reply/reply/agent-runner-execution.test.ts:1905:      allowEmptyAssistantReplyAsSilent: true,

$ node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-execution.test.ts --testNamePattern 'passes silent empty-reply policy to CLI backends for message-tool-only turns'
[test] passed 1 Vitest shard in 2.74s

$ node scripts/run-vitest.mjs src/auto-reply/reply/followup-runner.test.ts --testNamePattern 'reuses CLI session bindings for queued room-event followups'
Test Files  1 passed (1)
Tests  1 passed | 66 skipped (67)

$ node scripts/run-vitest.mjs src/auto-reply/reply/followup-runner.test.ts
[test] passed 1 Vitest shard in 6.50s

$ node scripts/run-vitest.mjs src/agents/cli-runner.reliability.test.ts src/agents/cli-runner.spawn.test.ts src/auto-reply/reply/agent-runner-execution.test.ts
[test] passed 2 Vitest shards in 51.79s

$ node scripts/run-vitest.mjs src/auto-reply/reply/get-reply-run.media-only.test.ts src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
[test] passed 2 Vitest shards in 21.19s
```
- **Observed result after fix**: The direct-path regression creates a Telegram group/message-tool-only `claude-cli` follow-up run and observes the direct CLI backend params include `allowEmptyAssistantReplyAsSilent: true`, `sourceReplyDeliveryMode: "message_tool_only"`, and Telegram channel/provider context. The queued-path regression creates a queued room-event CLI followup and observes the queued CLI backend params also include `allowEmptyAssistantReplyAsSilent: true` with `sourceReplyDeliveryMode: "message_tool_only"`. The existing CLI reliability coverage proves the CLI runner returns the silent reply token instead of `empty_response` when that flag is present.
- **What was not tested**: A live Telegram plus Claude CLI provider run was not performed in this local checkout; this source-repro issue was validated with PR-head source inspection and after-fix OpenClaw runner tests for every reachable CLI policy handoff ClawSweeper identified.

## Tests
- `node scripts/run-vitest.mjs src/auto-reply/reply/followup-runner.test.ts --testNamePattern 'reuses CLI session bindings for queued room-event followups'`
- `node scripts/run-vitest.mjs src/auto-reply/reply/followup-runner.test.ts`
- `node scripts/run-vitest.mjs src/agents/cli-runner.reliability.test.ts src/agents/cli-runner.spawn.test.ts src/auto-reply/reply/agent-runner-execution.test.ts`
- `node scripts/run-vitest.mjs src/auto-reply/reply/get-reply-run.media-only.test.ts src/agents/embedded-agent-runner/run.incomplete-turn.test.ts`
- `pnpm exec oxfmt --check src/auto-reply/reply/followup-runner.ts src/auto-reply/reply/followup-runner.test.ts src/auto-reply/reply/agent-runner-execution.ts src/auto-reply/reply/agent-runner-execution.test.ts`
- `node scripts/run-oxlint.mjs src/auto-reply/reply/followup-runner.ts src/auto-reply/reply/followup-runner.test.ts src/auto-reply/reply/agent-runner-execution.ts src/auto-reply/reply/agent-runner-execution.test.ts`
- `git diff --check`
- `pnpm tsgo:core`
- `pnpm tsgo:core:test`

@clawsweeper re-review
