### PR TITLE
fix(cron): replace excessive as unknown as type assertions with direct annotations in store loading

### DIFF
--- a/src/cron/service/store.ts
+++ b/src/cron/service/store.ts
@@ -104,11 +104,11 @@ export async function ensureLoaded(
     previousJobsById.set(job.id, job);
   }
   const loaded = await loadCronJobsStoreWithConfigJobs(state.deps.storePath);
-  const loadedJobs = (loaded.store.jobs ?? []) as unknown as CronJob[];
+  const loadedJobs: CronJob[] = loaded.store.jobs ?? [];
   const jobs: CronJob[] = [];
   const quarantinedConfigJobs: QuarantinedCronConfigJob[] = [...loaded.invalidConfigRows];
   for (const [index, job] of loadedJobs.entries()) {
-    const decodedRaw = job as unknown as Record<string, unknown>;
+    const decodedRaw: Record<string, unknown> = job;
     const rawConfigJob = loaded.configJobs[index] ?? structuredClone(decodedRaw);
     const raw = decodedRaw;
     const sourceIndex = loaded.configJobIndexes[index] ?? index;
@@ -129,11 +129,9 @@ export async function ensureLoaded(
         "cron: job has invalid persisted sessionTarget; run openclaw doctor --fix to repair",
       );
     }
-    const hydrated =
-      normalized && typeof normalized === "object" ? (normalized as unknown as CronJob) : job;
-    const invalidReason = getInvalidPersistedCronJobReason(
-      hydrated as unknown as Record<string, unknown>,
-    );
+    const hydrated: CronJob =
+      normalized && typeof normalized === "object" ? (normalized as CronJob) : job;
+    const invalidReason = getInvalidPersistedCronJobReason(hydrated);
     if (invalidReason) {
       const quarantineEntry: QuarantinedCronConfigJob = {
         sourceIndex,


### PR DESCRIPTION
## Summary

- Replaces excessive `as unknown as` type assertions in `src/cron/service/store.ts` with direct type annotations
- `CronStoreFile.jobs` is already typed as `CronJob[]`, so the intermediate cast through `unknown` is unnecessary
- `CronJob` extends `CronJobBase` which is an object type, so it satisfies `Record<string, unknown>` without an intermediate cast
- No behavioral changes — purely removing unsafe type assertions while preserving all validation logic

## Linked context

Closes #91314

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Removed 4 `as unknown as` type assertions in cron service store loading that bypass TypeScript type checking
- Real environment tested: Local OpenClaw instance (Linux x86_64, Node v24.16.0), with running cron subsystem
- Exact steps or command run after this patch:
  ```bash
  # 1. TypeScript compilation — zero errors
  npx tsc --noEmit --project tsconfig.json

  # 2. Full cron test suite — 100 test files, 995 tests, all passed
  node scripts/run-vitest.mjs run --config test/vitest/vitest.cron.config.ts
  # Test Files  100 passed (100)
  #       Tests  995 passed (995)

  # 3. Running OpenClaw cron store loads and operates normally
  openclaw cron status
  # {
  #   "enabled": true,
  #   "storePath": "/root/.openclaw/cron/jobs.json",
  #   "jobs": 1,
  #   "nextWakeAtMs": ...
  # }
  ```
- Evidence after fix:
  ```
  ✓ cron src/cron/service/store.test.ts (10 tests) 198ms
  Test Files  100 passed (100)
       Tests  995 passed (995)
  ```
- Observed result after fix: All 995 cron tests pass, cron store loads successfully on the running instance
- What was not tested: Runtime type-coercion edge cases on malformed persisted data (existing quarantine/validation logic handles that layer)
- Proof limitations or environment constraints: This is a type-safety refactor with zero behavioral impact; real-environment proof confirms the cron service starts and stores are loaded correctly

## Tests and validation

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.cron.config.ts` — 100 test files, 995 tests (all passing)
- `node scripts/run-vitest.mjs run src/cron/service/store.test.ts` — 10 tests (all passing)

## Risk checklist

Did user-visible behavior change? `No`

Did config, environment, or migration behavior change? `No`

Did security, auth, secrets, network, or tool execution behavior change? `No`

What is the highest-risk area? None — this is a pure type annotation change with zero runtime impact.

How is that risk mitigated? All existing cron tests pass identically. The removed casts are unnecessary because `CronStoreFile.jobs` is already typed as `CronJob[]` and `CronJob` already satisfies `Record<string, unknown>`.

## Current review state

What is the next action? Ready for maintainer review.

What is still waiting on author, maintainer, CI, or external proof? Updated real behavior proof with running OpenClaw instance output. Requesting re-review.