### PR TITLE
fix(codex): extend skill_workshop dynamic-tool timeout above approval ceiling

### DIFF
--- a/extensions/codex/src/app-server/dynamic-tool-execution.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-execution.test.ts
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   CODEX_DYNAMIC_IMAGE_TOOL_TIMEOUT_MS,
   CODEX_DYNAMIC_MESSAGE_TOOL_TIMEOUT_MS,
+  CODEX_DYNAMIC_SKILL_WORKSHOP_TOOL_TIMEOUT_MS,
   CODEX_DYNAMIC_TOOL_MAX_TIMEOUT_MS,
   CODEX_DYNAMIC_TOOL_TIMEOUT_MS,
   handleDynamicToolCallWithTimeout,
@@ -121,6 +122,24 @@ describe("dynamic tool execution helpers", () => {
         config: undefined,
       }),
     ).toBe(CODEX_DYNAMIC_MESSAGE_TOOL_TIMEOUT_MS);
+  });
+
+  it("uses an extended deadline for all skill_workshop calls regardless of action", () => {
+    for (const action of ["apply", "reject", "quarantine", "list", "inspect"]) {
+      expect(
+        resolveDynamicToolCallTimeoutMs({
+          call: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            callId: `call-skill-workshop-${action}`,
+            namespace: null,
+            tool: "skill_workshop",
+            arguments: { action, proposal_id: "weather-20260530-a1b2c3d4e5" },
+          },
+          config: undefined,
+        }),
+      ).toBe(CODEX_DYNAMIC_SKILL_WORKSHOP_TOOL_TIMEOUT_MS);
+    }
   });
 
   it("uses media image config and caps excessive dynamic tool timeouts", () => {

--- a/extensions/codex/src/app-server/dynamic-tool-execution.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-execution.ts
@@ -28,6 +28,8 @@ const CODEX_DYNAMIC_IMAGE_GENERATION_TOOL_TIMEOUT_MS = 120_000;
 export const CODEX_DYNAMIC_IMAGE_TOOL_TIMEOUT_MS = 60_000;
 /** Timeout for message-delivery dynamic tool calls. */
 export const CODEX_DYNAMIC_MESSAGE_TOOL_TIMEOUT_MS = 120_000;
+// any skill_workshop action may become a lifecycle call after before_tool_call hooks; approval waits up to 130s.
+export const CODEX_DYNAMIC_SKILL_WORKSHOP_TOOL_TIMEOUT_MS = 150_000;
 const LOG_FIELD_MAX_LENGTH = 160;
 
 type DynamicToolTimeoutDetails = {
@@ -412,6 +414,10 @@ function readConfiguredDynamicToolTimeoutMs(
 
   if (toolName === "message") {
     return CODEX_DYNAMIC_MESSAGE_TOOL_TIMEOUT_MS;
+  }
+
+  if (toolName === "skill_workshop") {
+    return CODEX_DYNAMIC_SKILL_WORKSHOP_TOOL_TIMEOUT_MS;
   }
 
   return undefined;

--- a/extensions/codex/src/app-server/side-question.test.ts
+++ b/extensions/codex/src/app-server/side-question.test.ts
@@ -1213,6 +1213,22 @@ describe("runCodexAppServerSideQuestion", () => {
     expect(timeoutMs).toBe(90_000);
   });
 
+  it("uses extended 150s for all side-thread skill_workshop calls regardless of action", () => {
+    for (const action of ["apply", "reject", "quarantine", "list", "inspect"]) {
+      const timeoutMs = testing.resolveSideDynamicToolCallTimeoutMs({
+        call: {
+          threadId: "side-thread",
+          turnId: "turn-1",
+          callId: `tool-skill-workshop-${action}`,
+          tool: "skill_workshop",
+          arguments: { action, proposal_id: "weather-20260530-a1b2c3d4e5" },
+        },
+        config: {} as never,
+      });
+      expect(timeoutMs).toBe(150_000);
+    }
+  });
+
   it("cleans up notification handlers when side tool setup fails", async () => {
     const client = createFakeClient();
     createOpenClawCodingToolsMock.mockImplementation(() => {

--- a/extensions/codex/src/app-server/side-question.ts
+++ b/extensions/codex/src/app-server/side-question.ts
@@ -83,6 +83,8 @@ const CODEX_SIDE_DYNAMIC_TOOL_TIMEOUT_MS = 90_000;
 const CODEX_SIDE_DYNAMIC_TOOL_MAX_TIMEOUT_MS = 600_000;
 const CODEX_SIDE_DYNAMIC_IMAGE_GENERATION_TOOL_TIMEOUT_MS = 120_000;
 const CODEX_SIDE_DYNAMIC_IMAGE_TOOL_TIMEOUT_MS = 60_000;
+// any skill_workshop action may become a lifecycle call after before_tool_call hooks; approval waits up to 130s.
+const CODEX_SIDE_DYNAMIC_SKILL_WORKSHOP_TOOL_TIMEOUT_MS = 150_000;
 const SIDE_QUESTION_COMPLETION_TIMEOUT_MS = 600_000;
 const CODEX_SIDE_NATIVE_HOOK_RELAY_MIN_TTL_MS = 30 * 60_000;
 const CODEX_SIDE_NATIVE_HOOK_RELAY_TTL_GRACE_MS = 5 * 60_000;
@@ -706,6 +708,9 @@ function resolveSideDynamicToolCallTimeoutMs(params: {
     (params.call.tool === "image"
       ? (readSideTimeoutSecondsAsMs(params.config?.tools?.media?.image?.timeoutSeconds) ??
         CODEX_SIDE_DYNAMIC_IMAGE_TOOL_TIMEOUT_MS)
+      : undefined) ??
+    (params.call.tool === "skill_workshop"
+      ? CODEX_SIDE_DYNAMIC_SKILL_WORKSHOP_TOOL_TIMEOUT_MS
       : undefined);
   return clampSideDynamicToolTimeoutMs(configured ?? CODEX_SIDE_DYNAMIC_TOOL_TIMEOUT_MS);
 }


### PR DESCRIPTION
### Summary

- **Problem**: `skill_workshop` lifecycle tool calls (apply/reject/quarantine) invoked from a Codex agent session fail with "OpenClaw dynamic tool call timed out after 90000ms while running tool skill_workshop" before the operator approval prompt can resolve. The proposal is left pending and unmodified. The same failure occurs on the `/btw` side thread.
- **Root Cause**: The Codex dynamic-tool bridge wraps every tool call with a per-tool watchdog (`CODEX_DYNAMIC_TOOL_TIMEOUT_MS = 90_000`). Skill Workshop lifecycle calls return a `requireApproval` payload that waits up to `DEFAULT_PLUGIN_APPROVAL_TIMEOUT_MS = 120_000` plus 10s gateway grace (130s total). The watchdog fires at 90s, before the approval can complete. Additionally, `before_tool_call` hooks can escalate a non-lifecycle action (e.g. `inspect → apply`) at runtime, after the timeout has already been resolved from the original arguments — so an action-gated 90s timeout would still fire on the hook-adjusted path.
- **Fix**: Return `CODEX_DYNAMIC_SKILL_WORKSHOP_TOOL_TIMEOUT_MS = 150_000` for all `skill_workshop` calls in both `readConfiguredDynamicToolTimeoutMs` (main thread) and `resolveSideDynamicToolCallTimeoutMs` (side thread). The 150s deadline exceeds the 130s approval ceiling; the unconditional match is correct because the timeout is resolved before hooks run and any action can be escalated to a lifecycle call at runtime. Non-lifecycle calls (list, inspect) complete in milliseconds so the wider window has no practical effect.
- **What changed**:
  - `extensions/codex/src/app-server/dynamic-tool-execution.ts` — exported `CODEX_DYNAMIC_SKILL_WORKSHOP_TOOL_TIMEOUT_MS = 150_000`; added unconditional `skill_workshop` branch in `readConfiguredDynamicToolTimeoutMs`.
  - `extensions/codex/src/app-server/side-question.ts` — added `CODEX_SIDE_DYNAMIC_SKILL_WORKSHOP_TOOL_TIMEOUT_MS = 150_000`; added unconditional `skill_workshop` arm in `resolveSideDynamicToolCallTimeoutMs`.
  - `extensions/codex/src/app-server/dynamic-tool-execution.test.ts` — extended deadline test covers all five action types; fake-timer before/after proof unchanged.
  - `extensions/codex/src/app-server/side-question.test.ts` — new test: all five action types return 150s on the side-thread path.
- **What did NOT change (scope boundary)**:
  - Skill Workshop approval policy (`src/skills/workshop/policy.ts`) unchanged; the 120s approval window is preserved for all callers.
  - Config surface unchanged (no schema, defaults, doctor migrations, or `docs/reference/config`).
  - Plugin surface unchanged (no plugin SDK, manifest, `extensions/api.ts`, registry/loader).
  - Gateway protocol unchanged.

### Reproduction

1. Configure Skill Workshop with default `approvalPolicy: pending`.
2. Start a Codex agent session and prompt it to apply a pending skill proposal.
3. The agent invokes `skill_workshop(action="apply", proposal_id="...")`.
4. **Before this PR**: the Codex dynamic-tool watchdog fires at 90s with "OpenClaw dynamic tool call timed out after 90000ms while running tool skill_workshop"; the approval prompt is never shown; the proposal stays pending.
5. **After this PR**: the 150s Codex deadline lets the approval flow reach its natural 120s expiry; if the operator does not respond the approval times out with a clean denial; if the operator responds the apply proceeds normally.

### Real behavior proof

**Behavior addressed (#91266)**: `skill_workshop` calls from a Codex agent session or `/btw` side thread no longer surface a generic 90s dynamic-tool timeout. All `skill_workshop` actions receive the 150s window regardless of action name, because `before_tool_call` hooks can escalate any action to a lifecycle call after the timeout is resolved.

**Real environment tested (Linux, Node 22 — Vitest with fake timers against `handleDynamicToolCallWithTimeout`, `resolveDynamicToolCallTimeoutMs`, and `resolveSideDynamicToolCallTimeoutMs`)**: unit tests verify the resolver returns 150s for apply/reject/quarantine/list/inspect on both paths; fake-timer tests confirm the 90s watchdog fires on a never-resolving call (before) and a 120s approval completes within the 150s deadline (after).

**Exact steps or command run after this patch**: `node scripts/run-vitest.mjs extensions/codex/src/app-server/dynamic-tool-execution.test.ts extensions/codex/src/app-server/side-question.test.ts`

**Evidence after fix**:

```text
 Test Files  2 passed (2)
      Tests  40 passed (40)
```

**Observed result after fix**: resolver returns 150s for all skill_workshop action types on both the main-thread and `/btw` side-thread paths; the before test confirms the 90s watchdog fires while approval is pending; the after test confirms a full 120s approval completes successfully within the 150s window.

**What was not tested**: live Gateway + Codex agent session with an active operator approval prompt in the UI.

**Repro confirmation**: the before test fails if `timeoutMs` is raised to 150_000 (approval would complete); the after test fails if `timeoutMs` is lowered to 90_000 (watchdog fires at 90s before the 120s approval).

### Risk / Mitigation

- **Risk**: All `skill_workshop` calls receive the 150s deadline, including non-lifecycle calls. **Mitigation**: non-lifecycle calls (list, inspect) complete in milliseconds; the wider window has no observable runtime effect. The unconditional match is required because `before_tool_call` hooks can escalate any action to a lifecycle call after the timeout has already been resolved.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Agent runtime
- [x] Codex extension

### Linked Issue/PR

Fixes #91266