### PR TITLE
fix(reply): pass silent-empty policy to CLI fallback runs

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -1865,6 +1865,38 @@ describe("runAgentTurnWithFallback", () => {
     });
   });
 
+  it("forwards silent-empty reply allowance to CLI backends for message-tool-only turns", async () => {
+    state.isCliProviderMock.mockReturnValue(true);
+    state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({
+      result: await params.run("claude-cli", "sonnet-4.6"),
+      provider: "claude-cli",
+      model: "sonnet-4.6",
+      attempts: [],
+    }));
+    state.runCliAgentMock.mockResolvedValueOnce({
+      payloads: [],
+      meta: {},
+    });
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const followupRun = createFollowupRun();
+    followupRun.run.provider = "claude-cli";
+    followupRun.run.model = "sonnet-4.6";
+    followupRun.run.sourceReplyDeliveryMode = "message_tool_only";
+    followupRun.run.allowEmptyAssistantReplyAsSilent = true;
+    followupRun.originatingChannel = "telegram";
+
+    const result = await runAgentTurnWithFallback(createMinimalRunAgentTurnParams({ followupRun }));
+
+    expect(result.kind).toBe("success");
+    expectMockCallArgFields(state.runCliAgentMock, 0, "CLI run params", {
+      sourceReplyDeliveryMode: "message_tool_only",
+      allowEmptyAssistantReplyAsSilent: true,
+      messageChannel: "telegram",
+      messageProvider: "telegram",
+    });
+  });
+
   it("passes prepared CLI user turns to the runtime persistence boundary", async () => {
     state.isCliProviderMock.mockReturnValue(true);
     state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -2186,6 +2186,8 @@ export async function runAgentTurnWithFallback(params: {
                     lane: runLane,
                     extraSystemPrompt: params.followupRun.run.extraSystemPrompt,
                     sourceReplyDeliveryMode: params.followupRun.run.sourceReplyDeliveryMode,
+                    allowEmptyAssistantReplyAsSilent:
+                      params.followupRun.run.allowEmptyAssistantReplyAsSilent,
                     silentReplyPromptMode: params.followupRun.run.silentReplyPromptMode,
                     extraSystemPromptStatic: params.followupRun.run.extraSystemPromptStatic,
                     ownerNumbers: params.followupRun.run.ownerNumbers,


### PR DESCRIPTION
## Summary

- Fixes #91302 by forwarding the existing `allowEmptyAssistantReplyAsSilent` policy into CLI fallback runs.
- Keeps `empty_response` fallback behavior unchanged unless the current reply run already allowed an empty assistant reply as silent.
- Does not add parser-level empty-success behavior, does not disable fallback broadly, and does not special-case Telegram.

## Relationship to nearby PRs

This is intentionally narrower than parser/CLI-layer empty-result fixes such as #89029 and #90450. Those PRs add new CLI output signals for Claude empty results or tool-only turns. This PR only fixes the existing policy propagation gap: `get-reply-run` already computes `allowEmptyAssistantReplyAsSilent`, and embedded runs already receive it, but the CLI fallback path dropped it from `runParams`.

## Verification

- Watched the new regression fail before the fix: `allowEmptyAssistantReplyAsSilent` was `undefined` in the CLI run params.
- `node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-execution.test.ts`
- `node scripts/run-vitest.mjs src/agents/cli-runner.reliability.test.ts src/agents/cli-runner.spawn.test.ts src/auto-reply/reply/get-reply-run.media-only.test.ts src/agents/embedded-agent-runner/run.incomplete-turn.test.ts src/auto-reply/reply/agent-runner-execution.test.ts`
- `git diff --check HEAD^ HEAD`
- `./node_modules/.bin/oxfmt --check src/auto-reply/reply/agent-runner-execution.ts src/auto-reply/reply/agent-runner-execution.test.ts`
- `node scripts/run-oxlint.mjs src/auto-reply/reply/agent-runner-execution.ts src/auto-reply/reply/agent-runner-execution.test.ts`

## Real behavior proof

- Behavior addressed: CLI-backed message-tool-only turns can now honor the already-computed silent-empty policy instead of converting a clean empty final assistant text into an `empty_response` failover that may rerun the turn on a fallback model.
- Real environment tested: local OpenClaw checkout on macOS, branch `fix/91302-cli-empty-tool-turn`, running the real `runAgentTurnWithFallback` boundary with the repository's Vitest harness and local toolchain.
- Exact steps or command run after this patch: the verification commands listed above.
- Evidence after fix: terminal output copied from the local checkout after applying this patch:

```text
$ node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-execution.test.ts
[test] starting test/vitest/vitest.auto-reply.config.ts

 RUN  v4.1.7 /Users/xiayu/.config/superpowers/worktrees/openclaw/fix-91302-cli-empty-tool-turn

 Test Files  1 passed (1)
      Tests  184 passed (184)
   Start at  12:54:30
   Duration  3.89s (transform 1.41s, setup 146ms, import 2.52s, tests 1.11s, environment 0ms)

[test] passed 1 Vitest shard in 7.77s

$ node scripts/run-vitest.mjs src/agents/cli-runner.reliability.test.ts src/agents/cli-runner.spawn.test.ts src/auto-reply/reply/get-reply-run.media-only.test.ts src/agents/embedded-agent-runner/run.incomplete-turn.test.ts src/auto-reply/reply/agent-runner-execution.test.ts
[test] starting test/vitest/vitest.auto-reply.config.ts

 RUN  v4.1.7 /Users/xiayu/.config/superpowers/worktrees/openclaw/fix-91302-cli-empty-tool-turn

 Test Files  2 passed (2)
      Tests  264 passed (264)
   Start at  12:54:49
   Duration  7.75s (transform 2.67s, setup 160ms, import 1.32s, tests 6.15s, environment 0ms)

[test] starting test/vitest/vitest.agents.config.ts

 RUN  v4.1.7 /Users/xiayu/.config/superpowers/worktrees/openclaw/fix-91302-cli-empty-tool-turn

[vitest] still running with no output for 30000ms (test/vitest/vitest.agents.config.ts).

 Test Files  3 passed (3)
      Tests  209 passed (209)
   Start at  12:54:59
   Duration  33.88s (transform 2.67s, setup 129ms, import 26.19s, tests 7.46s, environment 0ms)

[test] passed 2 Vitest shards in 48.76s

$ ./node_modules/.bin/oxfmt --check src/auto-reply/reply/agent-runner-execution.ts src/auto-reply/reply/agent-runner-execution.test.ts
Checking formatting...

All matched files use the correct format.
Finished in 58ms on 2 files using 11 threads.

$ node scripts/run-oxlint.mjs src/auto-reply/reply/agent-runner-execution.ts src/auto-reply/reply/agent-runner-execution.test.ts
[qa-channel boundary dts] fresh; skipping
[discord boundary dts] fresh; skipping
[slack boundary dts] fresh; skipping
```

- Observed result after fix: `runAgentTurnWithFallback` now passes `allowEmptyAssistantReplyAsSilent: true` to `runCliAgent` when a message-tool-only followup run carries that existing policy; the related CLI empty-response and embedded incomplete-turn regression files still pass.
- What was not tested: live Telegram + Claude CLI E2E.
