### PR TITLE
fix(mattermost): merge progress preview lines by identity

### DIFF
--- a/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
@@ -371,6 +371,7 @@ describe("mattermost inbound user posts", () => {
     mockState.createMattermostClient.mockReturnValue({});
     mockState.createMattermostDraftStream.mockReturnValue({
       update: vi.fn(),
+      flush: vi.fn(async () => {}),
       stop: vi.fn(async () => {}),
     });
     mockState.fetchMattermostMe.mockResolvedValue({
@@ -442,6 +443,98 @@ describe("mattermost inbound user posts", () => {
     expect(ctx?.MessageSid).toBe("post-1");
     expect(ctx?.OriginatingChannel).toBe("mattermost");
     expect(ctx?.Provider).toBe("mattermost");
+  });
+
+  it("merges Mattermost progress preview updates by line identity", async () => {
+    const socket = new FakeWebSocket();
+    const abortController = new AbortController();
+    mockState.abortController = abortController;
+    const draftStream = {
+      update: vi.fn(),
+      flush: vi.fn(async () => {}),
+      stop: vi.fn(async () => {}),
+    };
+    mockState.createMattermostDraftStream.mockReturnValue(draftStream);
+    const progressConfig: OpenClawConfig = {
+      channels: {
+        mattermost: {
+          enabled: true,
+          baseUrl: "https://mattermost.example.com",
+          botToken: "bot-token",
+          chatmode: "onmessage",
+          dmPolicy: "open",
+          groupPolicy: "open",
+          streaming: {
+            mode: "progress",
+            progress: {
+              label: false,
+              toolProgress: true,
+            },
+          },
+        },
+      },
+    };
+    mockState.runtimeCore = createRuntimeCore(progressConfig);
+    mockState.dispatchReplyFromConfig.mockImplementation(async (params) => {
+      await params.replyOptions?.onToolStart?.({
+        itemId: "tool-read",
+        name: "read",
+        phase: "start",
+      });
+      await params.replyOptions?.onToolStart?.({
+        itemId: "tool-exec",
+        name: "exec",
+        phase: "start",
+      });
+      await params.replyOptions?.onItemEvent?.({
+        itemId: "tool-read",
+        kind: "tool",
+        name: "read",
+        status: "completed",
+        progressText: "done",
+      });
+      abortController.abort();
+    });
+
+    const monitor = monitorMattermostProvider({
+      config: progressConfig,
+      runtime: testRuntime(),
+      abortSignal: abortController.signal,
+      webSocketFactory: () => socket,
+    });
+
+    await vi.waitFor(() => {
+      expect(socket.openListenerCount).toBeGreaterThan(0);
+    });
+    socket.emitOpen();
+
+    await socket.emitMessage({
+      event: "posted",
+      data: {
+        channel_id: "chan-1",
+        channel_name: "town-square",
+        channel_display_name: "Town Square",
+        sender_name: "alice",
+        post: JSON.stringify({
+          id: "post-progress",
+          channel_id: "chan-1",
+          user_id: "user-1",
+          message: "run this",
+          create_at: 1_714_000_000_000,
+        }),
+      },
+      broadcast: {
+        channel_id: "chan-1",
+        user_id: "user-1",
+      },
+    });
+    socket.emitClose(1000);
+    await monitor;
+
+    const updates = draftStream.update.mock.calls.map((call) => String(call[0]));
+    expect(updates.at(-1)).toContain("Read");
+    expect(updates.at(-1)).toContain("Exec");
+    expect(updates.at(-1)).toContain("done");
   });
 
   it("does not drop inline command-looking group text from non-command-authorized senders", async () => {

--- a/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
@@ -477,19 +477,19 @@ describe("mattermost inbound user posts", () => {
     mockState.runtimeCore = createRuntimeCore(progressConfig);
     mockState.dispatchReplyFromConfig.mockImplementation(async (params) => {
       await params.replyOptions?.onToolStart?.({
-        itemId: "tool-read",
+        toolCallId: "read-1",
         name: "read",
         phase: "start",
       });
       params.replyOptions?.onAssistantMessageStart?.();
       params.replyOptions?.onReasoningEnd?.();
       await params.replyOptions?.onToolStart?.({
-        itemId: "tool-exec",
+        toolCallId: "exec-1",
         name: "exec",
         phase: "start",
       });
       await params.replyOptions?.onItemEvent?.({
-        itemId: "tool-read",
+        itemId: "tool:read-1",
         kind: "tool",
         name: "read",
         status: "completed",
@@ -499,7 +499,7 @@ describe("mattermost inbound user posts", () => {
       await params.replyOptions?.onReasoningEnd?.();
       await params.replyOptions?.onReasoningStream?.({ text: "Checking" });
       await params.replyOptions?.onItemEvent?.({
-        itemId: "tool-read",
+        itemId: "tool:read-1",
         kind: "tool",
         name: "read",
         status: "completed",

--- a/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
@@ -495,6 +495,14 @@ describe("mattermost inbound user posts", () => {
         status: "completed",
         progressText: "done",
       });
+      await params.replyOptions?.onReasoningStream?.({ text: "Thinking" });
+      await params.replyOptions?.onItemEvent?.({
+        itemId: "tool-read",
+        kind: "tool",
+        name: "read",
+        status: "completed",
+        progressText: "done",
+      });
       abortController.abort();
     });
 

--- a/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
@@ -481,6 +481,8 @@ describe("mattermost inbound user posts", () => {
         name: "read",
         phase: "start",
       });
+      params.replyOptions?.onAssistantMessageStart?.();
+      params.replyOptions?.onReasoningEnd?.();
       await params.replyOptions?.onToolStart?.({
         itemId: "tool-exec",
         name: "exec",

--- a/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
@@ -496,6 +496,8 @@ describe("mattermost inbound user posts", () => {
         progressText: "done",
       });
       await params.replyOptions?.onReasoningStream?.({ text: "Thinking" });
+      await params.replyOptions?.onReasoningEnd?.();
+      await params.replyOptions?.onReasoningStream?.({ text: "Checking" });
       await params.replyOptions?.onItemEvent?.({
         itemId: "tool-read",
         kind: "tool",
@@ -545,6 +547,8 @@ describe("mattermost inbound user posts", () => {
     expect(updates.at(-1)).toContain("Read");
     expect(updates.at(-1)).toContain("Exec");
     expect(updates.at(-1)).toContain("done");
+    expect(updates.at(-1)).toContain("Checking");
+    expect(updates.at(-1)).not.toContain("ThinkingChecking");
   });
 
   it("does not drop inline command-looking group text from non-command-authorized senders", async () => {

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -4,7 +4,8 @@ import {
   deliverWithFinalizableLivePreviewAdapter,
 } from "openclaw/plugin-sdk/channel-outbound";
 import {
-  formatChannelProgressDraftLineForEntry,
+  buildChannelProgressDraftLineForEntry,
+  createChannelProgressDraftCompositor,
   resolveChannelStreamingPreviewToolProgress,
 } from "openclaw/plugin-sdk/channel-outbound";
 import { isLoopbackHost } from "openclaw/plugin-sdk/gateway-runtime";
@@ -38,7 +39,7 @@ import {
   type MattermostPost,
   type MattermostUser,
 } from "./client.js";
-import { buildMattermostToolStatusText, createMattermostDraftStream } from "./draft-stream.js";
+import { createMattermostDraftStream } from "./draft-stream.js";
 import {
   computeInteractionCallbackUrl,
   createMattermostInteractionHandler,
@@ -1682,6 +1683,18 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
             })
           : createDisabledMattermostDraftStream();
         let lastPartialText = "";
+        const progressDraft = createChannelProgressDraftCompositor({
+          entry: account.config,
+          mode: account.streamingMode,
+          active: draftPreviewEnabled,
+          seed: `${account.accountId}:${channelId}`,
+          update: async (previewText, options) => {
+            draftStream.update(previewText);
+            if (options?.flush) {
+              await draftStream.flush();
+            }
+          },
+        });
         const previewState: MattermostDraftPreviewState = {
           finalizedViaPreviewPost: false,
         };
@@ -1746,6 +1759,9 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
             humanDelay: core.channel.reply.resolveHumanDelayConfig(cfg, route.agentId),
             typingCallbacks,
             deliver: async (payloadEntry: ReplyPayload, info) => {
+              if (info.kind === "final") {
+                progressDraft.markFinalReplyStarted();
+              }
               await deliverMattermostReplyWithDraftPreview({
                 payload: payloadEntry,
                 info,
@@ -1785,6 +1801,9 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                   }
                 },
               });
+              if (info.kind === "final") {
+                progressDraft.markFinalReplyDelivered();
+              }
             },
             onError: (err, info) => {
               runtime.error?.(`mattermost ${info.kind} reply failed: ${String(err)}`);
@@ -1893,9 +1912,11 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                           },
                           onAssistantMessageStart: () => {
                             lastPartialText = "";
+                            progressDraft.reset();
                           },
                           onReasoningEnd: () => {
                             lastPartialText = "";
+                            progressDraft.reset();
                           },
                           onReasoningStream: async () => {
                             if (!lastPartialText) {
@@ -1906,20 +1927,30 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                             if (!draftToolProgressEnabled) {
                               return;
                             }
-                            draftStream.update(
-                              buildMattermostToolStatusText({
-                                ...payloadValue,
-                                config: account.config,
-                              }),
+                            await progressDraft.pushToolProgress(
+                              buildChannelProgressDraftLineForEntry(
+                                account.config,
+                                {
+                                  event: "tool",
+                                  itemId: payloadValue.itemId,
+                                  toolCallId: payloadValue.toolCallId,
+                                  name: payloadValue.name,
+                                  phase: payloadValue.phase,
+                                  args: payloadValue.args,
+                                },
+                                payloadValue.detailMode
+                                  ? { detailMode: payloadValue.detailMode }
+                                  : undefined,
+                              ),
+                              { startImmediately: true },
                             );
                           },
                           onItemEvent: async (payloadLocal) => {
                             if (!draftToolProgressEnabled) {
                               return;
                             }
-                            const progressText = formatChannelProgressDraftLineForEntry(
-                              account.config,
-                              {
+                            await progressDraft.pushToolProgress(
+                              buildChannelProgressDraftLineForEntry(account.config, {
                                 event: "item",
                                 itemId: payloadLocal.itemId,
                                 itemKind: payloadLocal.kind,
@@ -1930,11 +1961,9 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                                 summary: payloadLocal.summary,
                                 progressText: payloadLocal.progressText,
                                 meta: payloadLocal.meta,
-                              },
+                              }),
+                              { startImmediately: true },
                             );
-                            if (progressText) {
-                              draftStream.update(progressText);
-                            }
                           },
                         },
                       }),

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1922,7 +1922,14 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                               progressDraft.reset();
                             }
                           },
-                          onReasoningStream: async () => {
+                          onReasoningStream: async (payloadResult) => {
+                            if (account.streamingMode === "progress") {
+                              await progressDraft.pushReasoningProgress(
+                                payloadResult.text || "Thinking…",
+                                { snapshot: payloadResult.isReasoningSnapshot === true },
+                              );
+                              return;
+                            }
                             if (!lastPartialText) {
                               draftStream.update("Thinking…");
                             }

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1912,12 +1912,14 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                           },
                           onAssistantMessageStart: () => {
                             lastPartialText = "";
+                            progressDraft.resetReasoningProgress();
                             if (account.streamingMode !== "progress") {
                               progressDraft.reset();
                             }
                           },
                           onReasoningEnd: () => {
                             lastPartialText = "";
+                            progressDraft.resetReasoningProgress();
                             if (account.streamingMode !== "progress") {
                               progressDraft.reset();
                             }

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1912,11 +1912,15 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                           },
                           onAssistantMessageStart: () => {
                             lastPartialText = "";
-                            progressDraft.reset();
+                            if (account.streamingMode !== "progress") {
+                              progressDraft.reset();
+                            }
                           },
                           onReasoningEnd: () => {
                             lastPartialText = "";
-                            progressDraft.reset();
+                            if (account.streamingMode !== "progress") {
+                              progressDraft.reset();
+                            }
                           },
                           onReasoningStream: async () => {
                             if (!lastPartialText) {

--- a/src/channels/progress-draft-compositor.test.ts
+++ b/src/channels/progress-draft-compositor.test.ts
@@ -72,6 +72,24 @@ describe("createChannelProgressDraftCompositor", () => {
     expect(update).toHaveBeenLastCalledWith("Shelling\n\n🛠️ Exec\n• _Reading files_", undefined);
   });
 
+  it("resets reasoning deltas without clearing tool progress", async () => {
+    const update = vi.fn();
+    const progress = createChannelProgressDraftCompositor({
+      entry: { streaming: { mode: "progress", progress: { label: "Shelling" } } },
+      mode: "progress",
+      active: true,
+      seed: "test",
+      update,
+    });
+
+    await progress.pushToolProgress("🛠️ Exec", { startImmediately: true });
+    await progress.pushReasoningProgress("Checking files");
+    progress.resetReasoningProgress();
+    await progress.pushReasoningProgress("Now testing");
+
+    expect(update).toHaveBeenLastCalledWith("Shelling\n\n🛠️ Exec\n• _Now testing_", undefined);
+  });
+
   it("preserves tagged reasoning content without leaking tags", async () => {
     const update = vi.fn();
     const progress = createChannelProgressDraftCompositor({

--- a/src/channels/progress-draft-compositor.ts
+++ b/src/channels/progress-draft-compositor.ts
@@ -200,6 +200,9 @@ export function createChannelProgressDraftCompositor(params: {
     reset() {
       clearProgressState(false);
     },
+    resetReasoningProgress() {
+      reasoningRawText = "";
+    },
     suppress() {
       clearProgressState(true);
     },

--- a/src/channels/progress-draft-lines.test.ts
+++ b/src/channels/progress-draft-lines.test.ts
@@ -23,6 +23,17 @@ describe("progress draft lines", () => {
     expect(itemLine?.id).toBe(toolLine?.id);
   });
 
+  it("treats tool call ids as opaque when building item identities", () => {
+    const line = buildChannelProgressDraftLine({
+      event: "tool",
+      toolCallId: "tool:read-1",
+      name: "read",
+      phase: "start",
+    });
+
+    expect(line?.id).toBe("tool:tool:read-1");
+  });
+
   it("removes keyed progress lines in place", () => {
     const line = buildChannelProgressDraftLine({
       event: "item",

--- a/src/channels/progress-draft-lines.test.ts
+++ b/src/channels/progress-draft-lines.test.ts
@@ -4,6 +4,25 @@ import { removeChannelProgressDraftLine } from "./progress-draft-lines.js";
 import { buildChannelProgressDraftLine } from "./streaming.js";
 
 describe("progress draft lines", () => {
+  it("uses the item lifecycle identity for raw tool call ids", () => {
+    const toolLine = buildChannelProgressDraftLine({
+      event: "tool",
+      toolCallId: "read-1",
+      name: "read",
+      phase: "start",
+    });
+    const itemLine = buildChannelProgressDraftLine({
+      event: "item",
+      itemId: "tool:read-1",
+      itemKind: "tool",
+      name: "read",
+      status: "completed",
+    });
+
+    expect(toolLine?.id).toBe("tool:read-1");
+    expect(itemLine?.id).toBe(toolLine?.id);
+  });
+
   it("removes keyed progress lines in place", () => {
     const line = buildChannelProgressDraftLine({
       event: "item",

--- a/src/channels/streaming.ts
+++ b/src/channels/streaming.ts
@@ -450,13 +450,7 @@ export function buildChannelProgressDraftLine(
 ): ChannelProgressDraftLine | undefined {
   switch (input.event) {
     case "tool": {
-      const itemId =
-        input.itemId ??
-        (input.toolCallId
-          ? input.toolCallId.startsWith("tool:")
-            ? input.toolCallId
-            : `tool:${input.toolCallId}`
-          : undefined);
+      const itemId = input.itemId ?? (input.toolCallId ? `tool:${input.toolCallId}` : undefined);
       return buildNamedProgressLine(
         input.event,
         input.name,

--- a/src/channels/streaming.ts
+++ b/src/channels/streaming.ts
@@ -450,6 +450,13 @@ export function buildChannelProgressDraftLine(
 ): ChannelProgressDraftLine | undefined {
   switch (input.event) {
     case "tool": {
+      const itemId =
+        input.itemId ??
+        (input.toolCallId
+          ? input.toolCallId.startsWith("tool:")
+            ? input.toolCallId
+            : `tool:${input.toolCallId}`
+          : undefined);
       return buildNamedProgressLine(
         input.event,
         input.name,
@@ -460,7 +467,7 @@ export function buildChannelProgressDraftLine(
           input.phase && !input.name ? input.phase : undefined,
         ],
         options,
-        { id: input.itemId ?? input.toolCallId },
+        { id: itemId },
       );
     }
     case "item": {


### PR DESCRIPTION
## Summary
- reuse the shared channel progress draft compositor for Mattermost progress previews
- build structured progress lines for tool and item callbacks so updates merge by itemId/toolCallId
- add a Mattermost inbound regression test that keeps unrelated progress lines visible when one line updates

Fixes #89761

## Real behavior proof

- **Behavior or issue addressed:** Mattermost progress preview overwrote the whole draft per frame instead of merging by line identity (#89761). After this patch each tool/item progress line updates in place by itemId/toolCallId while unrelated lines stay visible.
- **Real environment tested:** OpenClaw built from source at release `v2026.6.5-beta.5` with only this PR's `extensions/mattermost/src/mattermost/monitor.ts` change applied on top (the sole diff vs the tag). Self-hosted Mattermost, `channels.mattermost.streaming.mode=progress`, `streaming.preview.toolProgress=true`, model `openai/gpt-5.5`.
- **Exact steps or command run after this patch:** Built the image (`docker build --build-arg OPENCLAW_EXTENSIONS=mattermost,codex,openai`), ran the gateway against the real Mattermost, then mentioned the bot with a 4-step task so the agent emits several tool/item progress frames: `@openclaw run, step by step: 1) ls -la 2) python3 -c "print(2+2)" 3) date 4) uname -a`.
- **Evidence after fix:** The single live "Molting" draft post (edited in place) accumulates multiple distinct progress lines as the agent runs:

  ![progress lines start to accumulate](https://github.com/iloveleon19/openclaw/releases/download/pr91331-proof/pr91331-proof-1.png)

  ![multiple tool and item lines coexisting in one draft](https://github.com/iloveleon19/openclaw/releases/download/pr91331-proof/pr91331-proof-2.png)

  ![final state with the uname output in its own fenced block](https://github.com/iloveleon19/openclaw/releases/download/pr91331-proof/pr91331-proof-3.png)

- **Observed result after fix:** Each `🛠️` tool line (`list files`, `run python3 inline script`, `date`, …) and each `•` item line (`第 1 步完成…`, `第 2 步完成…`, …) stays visible and updates by its own identity within the one preview post; the `uname -a` output renders in its own fenced block. No whole-draft overwrite. Before this patch the draft showed only the latest single frame during streaming.
- **What was not tested:** None

## Tests
- node scripts/run-vitest.mjs extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts extensions/mattermost/src/mattermost/draft-stream.test.ts src/plugin-sdk/channel-streaming.test.ts
- node scripts/run-vitest.mjs extensions/mattermost/src/mattermost/monitor.test.ts extensions/mattermost/src/mattermost/draft-stream.test.ts src/plugin-sdk/channel-streaming.test.ts
- corepack pnpm tsgo:extensions:test
- corepack pnpm format:check extensions/mattermost/src/mattermost/monitor.ts extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
- git diff --check
