### PR TITLE
fix(session): add fallback lock file cleanup on session write-lock release

### DIFF
--- a/src/agents/session-write-lock.ts
+++ b/src/agents/session-write-lock.ts
@@ -991,12 +991,14 @@ export async function acquireSessionWriteLock(params: {
       const release = async () => {
         await innerRelease();
         // Fallback cleanup: if sidecar-lock's removeLockIfUnchanged failed
-        // due to snapshot mismatch, force-remove the lock file if we still
-        // own it (pid matches current process).
+        // due to snapshot mismatch, force-remove the lock file if no
+        // reentrant holder remains and the file still matches our pid.
         try {
-          const payload = await readLockPayload(lockPath);
-          if (payload?.pid === process.pid) {
-            await fs.rm(lockPath, { force: true });
+          if (!sessionLockHeldByThisProcess(normalizedSessionFile)) {
+            const payload = await readLockPayload(lockPath);
+            if (payload?.pid === process.pid) {
+              await fs.rm(lockPath, { force: true });
+            }
           }
         } catch {
           // Best-effort fallback on filesystem errors.

--- a/src/agents/session-write-lock.ts
+++ b/src/agents/session-write-lock.ts
@@ -987,7 +987,22 @@ export async function acquireSessionWriteLock(params: {
           );
         },
       });
-      return { release: lock.release };
+      const innerRelease = lock.release;
+      const release = async () => {
+        await innerRelease();
+        // Fallback cleanup: if sidecar-lock's removeLockIfUnchanged failed
+        // due to snapshot mismatch, force-remove the lock file if we still
+        // own it (pid matches current process).
+        try {
+          const payload = await readLockPayload(lockPath);
+          if (payload?.pid === process.pid) {
+            await fs.rm(lockPath, { force: true });
+          }
+        } catch {
+          // Best-effort fallback on filesystem errors.
+        }
+      };
+      return { release };
     } catch (err) {
       if (!isFileLockError(err, "file_lock_timeout") && !isFileLockError(err, "file_lock_stale")) {
         throw err;


### PR DESCRIPTION
## Problem

When `sidecar-lock`'s `removeLockIfUnchanged` fails because the lock file snapshot doesn't match (content/inode changed between acquisition and release), the session write-lock file persists on disk permanently. This blocks all subsequent messages to that session with `SessionWriteLockTimeoutError` until the gateway is restarted.

Observed in production (OpenClaw 2026.6.1):
```
04:35:55 chat.abort ✓ 87ms
04:35:55 embedded abort settle timed out (timeoutMs=2000)
04:35:55 lock file created: pid=<gateway> maxHoldMs=1020000
04:37:14 SessionWriteLockTimeoutError ageMs=79210  (×2 lanes)
04:38:25 SessionWriteLockTimeoutError ageMs=149601 (×2 lanes)
```

See https://github.com/openclaw/openclaw/issues/91327 for full root cause analysis.

## Fix

Add a **fallback cleanup** in `acquireSessionWriteLock` in `session-write-lock.ts`: after the inner sidecar-lock `release()` completes, check if the `.lock` file still exists on disk and no reentrant holder remains. If both conditions hold and the file's `pid` field matches the current process, force-remove it.

```typescript
const innerRelease = lock.release;
const release = async () => {
    await innerRelease();
    // Fallback cleanup: if sidecar-lock's removeLockIfUnchanged failed
    // due to snapshot mismatch, force-remove the lock file if no
    // reentrant holder remains and the file still matches our pid.
    try {
        if (!sessionLockHeldByThisProcess(normalizedSessionFile)) {
            const payload = await readLockPayload(lockPath);
            if (payload?.pid === process.pid) {
                await fs.rm(lockPath, { force: true });
            }
        }
    } catch {
        // Best-effort fallback on filesystem errors.
    }
};
return { release };
```

## Why this is safe

1. **Reentrancy guard**: `sessionLockHeldByThisProcess()` prevents removing the lock file while other reentrant holders still expect it to exist.
2. **pid check**: Only force-removes if the lock file's pid matches `process.pid`. If another process replaced the lock file, it won't match → we don't touch it.  
3. **Best-effort**: Falls back silently on filesystem errors.
4. **Non-breaking**: The inner `release()` still runs as before. This is purely additive cleanup.

## Files changed

- `src/agents/session-write-lock.ts`: +18 lines, 1 changed

## Real behavior proof

**Setup:**
- OS: Oracle Linux 9.7 (aarch64)
- Node.js: v22.22.3
- Fork rebased onto `openclaw/main` tip — previously was 4,466 commits behind, now cleanly atop current upstream

**Verified before push:**

1. **Rebase integrity:** clean rebase, zero conflicts
2. **Diff confirms only intended change:**
```
$ git diff upstream/main --stat
 src/agents/session-write-lock.ts | 19 ++++++++++++++++++-
 1 file changed, 18 insertions(+), 1 deletion(-)
```

3. **Reentrancy fix (v2):** First iteration broke `expectLockRemovedOnlyAfterFinalRelease` — the fallback removed the lock file during the first release in a reentrant pair. Added `sessionLockHeldByThisProcess()` guard so the fallback only triggers when all holders have released.

4. **Scope check** — `readLockPayload`, `lockPath`, `fs`, `process.pid`, `normalizedSessionFile`, and `sessionLockHeldByThisProcess` are all in scope at the fix site.

**CI:** Full test suite running.

**Not tested (requires production environment):**
- Reproduction of the exact sidecar-lock snapshot mismatch race condition
- Multi-process lock contention with the fallback path triggered
- Long-running gateway with stale lock accumulation