### PR TITLE
fix(agents): suppress private finals after message tool source replies

### DIFF
--- a/src/agents/embedded-agent-runner/run/payloads.test.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.test.ts
@@ -225,6 +225,27 @@ describe("buildEmbeddedRunPayloads tool-error warnings", () => {
     expectSinglePayloadText(payloads, "The schema export is fixed.");
   });
 
+  it("suppresses private finals after delivered current-source message-tool replies", () => {
+    const payloads = buildPayloads({
+      assistantTexts: ["I already sent the answer through the message tool."],
+      didSendViaMessagingTool: true,
+      messagingToolSourceReplyPayloads: [
+        {
+          text: "The requested status check completed successfully.",
+        },
+      ],
+      sourceReplyDeliveryMode: "automatic",
+      sessionKey: "agent:main:test:direct:source",
+      agentId: "main",
+      runId: "run-current-source-reply",
+    });
+
+    // Automatic-mode message-tool sends have already been delivered by the
+    // message tool path; the final payload builder should only suppress the
+    // follow-up private bookkeeping text, not resend the source reply.
+    expect(payloads).toEqual([]);
+  });
+
   it("turns internal message-tool source replies into suppression-safe final payloads", () => {
     // message_tool_only source replies are already delivered internally but
     // still need mirror metadata so transcript/persistence can record them.

--- a/src/agents/embedded-agent-runner/run/payloads.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.ts
@@ -262,10 +262,25 @@ export function buildEmbeddedRunPayloads(params: {
     };
   }> = [];
 
+  const deliveredSourceReplyPayloads = params.messagingToolSourceReplyPayloads ?? [];
+  const sourceReplyPayloadHasContent = (payload: MessagingToolSourceReplyPayload): boolean => {
+    const text = normalizeOptionalString(payload.text) ?? "";
+    const media = Array.from(
+      new Set([...(payload.mediaUrl ? [payload.mediaUrl] : []), ...(payload.mediaUrls ?? [])]),
+    ).filter((value) => value.trim().length > 0);
+    return Boolean(
+      text ||
+      media.length > 0 ||
+      payload.presentation ||
+      payload.interactive ||
+      payload.channelData,
+    );
+  };
+  const hasDeliveredSourceReplyPayload = deliveredSourceReplyPayloads.some(
+    sourceReplyPayloadHasContent,
+  );
   const sourceReplyPayloads =
-    params.sourceReplyDeliveryMode === "message_tool_only"
-      ? (params.messagingToolSourceReplyPayloads ?? [])
-      : [];
+    params.sourceReplyDeliveryMode === "message_tool_only" ? deliveredSourceReplyPayloads : [];
   const sourceReplyStartIndex = replyItems.length;
   sourceReplyPayloads.forEach((payload, index) => {
     const text = normalizeOptionalString(payload.text) ?? "";
@@ -302,7 +317,9 @@ export function buildEmbeddedRunPayloads(params: {
 
   const useMarkdown = params.toolResultFormat === "markdown";
   const suppressAssistantArtifacts =
-    params.didSendDeterministicApprovalPrompt === true || hasSourceReplyPayload;
+    params.didSendDeterministicApprovalPrompt === true ||
+    hasSourceReplyPayload ||
+    hasDeliveredSourceReplyPayload;
   const nonEmptyAssistantTexts = params.assistantTexts.filter((text) => text.trim().length > 0);
   const currentAssistant = params.currentAssistant ?? undefined;
   const assistantForPayload =

--- a/src/infra/outbound/message-action-runner.core-send.test.ts
+++ b/src/infra/outbound/message-action-runner.core-send.test.ts
@@ -37,12 +37,14 @@ const slackConfig = {
   },
 } as OpenClawConfig;
 
-function registerSlackTextPlugin() {
-  const sendText = vi.fn().mockResolvedValue({
+function registerSlackTextPlugin(
+  result: Record<string, unknown> = {
     channel: "slack",
     messageId: "m1",
     chatId: "C123",
-  });
+  },
+) {
+  const sendText = vi.fn().mockResolvedValue(result);
   setActivePluginRegistry(
     createTestRegistry([
       {
@@ -235,6 +237,122 @@ describe("runMessageAction core send routing", () => {
     expect(result.to).toBe("telegram:-1001234567890:topic:42");
     expect(payload.to).toBe("telegram:-1001234567890:topic:42");
     expect(payload.dryRun).toBe(true);
+  });
+
+  it("marks successful current-session sends as delivered source replies", async () => {
+    const sendText = registerSlackTextPlugin();
+
+    const result = await runMessageAction({
+      cfg: slackConfig,
+      action: "send",
+      params: {
+        message: "visible source reply",
+      },
+      toolContext: {
+        currentChannelProvider: "slack",
+        currentChannelId: "channel:C123",
+      },
+      sessionKey: "agent:main:slack:channel:c123",
+      dryRun: false,
+    });
+
+    expect(result.kind).toBe("send");
+    expect(sendText).toHaveBeenCalledOnce();
+    expect(result.payload).toMatchObject({
+      deliveryStatus: "sent",
+      sourceReplySink: "internal-ui",
+      sourceReply: {
+        text: "visible source reply",
+      },
+      message: "visible source reply",
+    });
+  });
+
+  it("does not mark sends to another session as current-source replies", async () => {
+    const sendText = registerSlackTextPlugin();
+
+    const result = await runMessageAction({
+      cfg: slackConfig,
+      action: "send",
+      params: {
+        target: "channel:C999",
+        message: "send elsewhere",
+      },
+      toolContext: {
+        currentChannelProvider: "slack",
+        currentChannelId: "channel:C123",
+      },
+      sessionKey: "agent:main:slack:channel:c123",
+      dryRun: false,
+    });
+
+    expect(result.kind).toBe("send");
+    expect(sendText).toHaveBeenCalledOnce();
+    expect(result.payload).not.toMatchObject({
+      sourceReplySink: "internal-ui",
+    });
+  });
+
+  it("does not mark ambiguous current-session sends as delivered source replies", async () => {
+    const sendText = registerSlackTextPlugin({
+      channel: "slack",
+      chatId: "C123",
+    });
+
+    const result = await runMessageAction({
+      cfg: slackConfig,
+      action: "send",
+      params: {
+        message: "final should remain eligible when delivery is ambiguous",
+      },
+      toolContext: {
+        currentChannelProvider: "slack",
+        currentChannelId: "channel:C123",
+      },
+      sessionKey: "agent:main:slack:channel:c123",
+      dryRun: false,
+    });
+
+    expect(result.kind).toBe("send");
+    expect(sendText).toHaveBeenCalledOnce();
+    expect(result.payload).not.toMatchObject({
+      deliveryStatus: "sent",
+      sourceReplySink: "internal-ui",
+    });
+  });
+
+  it("does not mark failed current-session sends as delivered source replies", async () => {
+    const sendText = registerSlackTextPlugin({
+      channel: "slack",
+      chatId: "C123",
+      deliveryStatus: "failed",
+      error: "send failed",
+    });
+
+    const result = await runMessageAction({
+      cfg: slackConfig,
+      action: "send",
+      params: {
+        message: "final should remain eligible after failed delivery",
+      },
+      toolContext: {
+        currentChannelProvider: "slack",
+        currentChannelId: "channel:C123",
+      },
+      sessionKey: "agent:main:slack:channel:c123",
+      dryRun: false,
+    });
+
+    expect(result.kind).toBe("send");
+    expect(sendText).toHaveBeenCalledOnce();
+    expect(result.payload).toMatchObject({
+      result: {
+        deliveryStatus: "failed",
+      },
+    });
+    expect(result.payload).not.toMatchObject({
+      sourceReplySink: "internal-ui",
+    });
   });
 
   it("uses best-effort delivery for implicit message-tool-only source replies", async () => {

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -87,7 +87,11 @@ import {
   shouldApplyCrossContextMarker,
 } from "./outbound-policy.js";
 import { executePollAction, executeSendAction } from "./outbound-send-service.js";
-import { ensureOutboundSessionEntry, resolveOutboundSessionRoute } from "./outbound-session.js";
+import {
+  ensureOutboundSessionEntry,
+  resolveOutboundSessionRoute,
+  type OutboundSessionRoute,
+} from "./outbound-session.js";
 import { normalizeTargetForProvider } from "./target-normalization.js";
 import { resolveChannelTarget, type ResolvedMessagingTarget } from "./target-resolver.js";
 import { extractToolPayload } from "./tool-payload.js";
@@ -1073,6 +1077,116 @@ async function buildSendPayloadParts(params: {
   };
 }
 
+function isCurrentSourceOutboundRoute(params: {
+  input: RunMessageActionParams;
+  actionParams: Record<string, unknown>;
+  outboundRoute: OutboundSessionRoute | null;
+  dryRun: boolean;
+}): boolean {
+  if (params.dryRun) {
+    return false;
+  }
+  const currentSessionKey = normalizeOptionalLowercaseString(params.input.sessionKey);
+  const outboundSessionKey = normalizeOptionalLowercaseString(params.outboundRoute?.sessionKey);
+  if (currentSessionKey && outboundSessionKey && currentSessionKey === outboundSessionKey) {
+    return true;
+  }
+  return (
+    !hasExplicitNonCurrentChannelParam(params.input, params.actionParams) &&
+    isCurrentSourceTargetParam(params.input, params.actionParams)
+  );
+}
+
+function collectDeliveryEvidencePayloads(
+  payloadRecord: Record<string, unknown>,
+): Record<string, unknown>[] {
+  const nested = payloadRecord.result;
+  if (nested && typeof nested === "object" && !Array.isArray(nested)) {
+    return [payloadRecord, nested as Record<string, unknown>];
+  }
+  return [payloadRecord];
+}
+
+function payloadHasPositiveDeliveryEvidence(payloadRecord: Record<string, unknown>): boolean {
+  let hasDeliveredStatus = false;
+  let hasMessageId = false;
+  for (const candidate of collectDeliveryEvidencePayloads(payloadRecord)) {
+    const deliveryStatus = normalizeOptionalString(candidate.deliveryStatus)?.toLowerCase();
+    const status = normalizeOptionalString(candidate.status)?.toLowerCase();
+    if (
+      deliveryStatus === "failed" ||
+      deliveryStatus === "error" ||
+      deliveryStatus === "undelivered" ||
+      status === "failed" ||
+      status === "error" ||
+      status === "undelivered" ||
+      candidate.ok === false
+    ) {
+      return false;
+    }
+    hasDeliveredStatus ||= deliveryStatus === "sent" || deliveryStatus === "delivered";
+    hasDeliveredStatus ||= status === "sent" || status === "delivered";
+    hasMessageId ||= Boolean(
+      normalizeOptionalString(candidate.messageId) ?? normalizeOptionalString(candidate.message_id),
+    );
+  }
+  return hasDeliveredStatus || hasMessageId;
+}
+
+function annotatePayloadForCurrentSourceReply(params: {
+  payload: unknown;
+  sendPayload: SendPayloadParts;
+  input: RunMessageActionParams;
+  actionParams: Record<string, unknown>;
+  outboundRoute: OutboundSessionRoute | null;
+  dryRun: boolean;
+}): unknown {
+  if (!isCurrentSourceOutboundRoute(params)) {
+    return params.payload;
+  }
+  const payloadRecord: Record<string, unknown> =
+    params.payload && typeof params.payload === "object" && !Array.isArray(params.payload)
+      ? { ...(params.payload as Record<string, unknown>) }
+      : { result: params.payload };
+  if (!payloadHasPositiveDeliveryEvidence(payloadRecord)) {
+    return params.payload;
+  }
+  return {
+    ...payloadRecord,
+    deliveryStatus: "sent",
+    sourceReplySink: "internal-ui" as const,
+    ...(params.input.sourceReplyDeliveryMode
+      ? { sourceReplyDeliveryMode: params.input.sourceReplyDeliveryMode }
+      : {}),
+    sourceReply: params.sendPayload.payload,
+    ...(params.sendPayload.message ? { message: params.sendPayload.message } : {}),
+    ...(params.sendPayload.mediaUrl ? { mediaUrl: params.sendPayload.mediaUrl } : {}),
+    ...(params.sendPayload.mediaUrls?.length ? { mediaUrls: params.sendPayload.mediaUrls } : {}),
+  };
+}
+
+function annotateToolResultForCurrentSourceReply(
+  toolResult: AgentToolResult<unknown> | undefined,
+  params: {
+    sendPayload: SendPayloadParts;
+    input: RunMessageActionParams;
+    actionParams: Record<string, unknown>;
+    outboundRoute: OutboundSessionRoute | null;
+    dryRun: boolean;
+  },
+): AgentToolResult<unknown> | undefined {
+  if (!toolResult || !isCurrentSourceOutboundRoute(params)) {
+    return toolResult;
+  }
+  return {
+    ...toolResult,
+    details: annotatePayloadForCurrentSourceReply({
+      payload: toolResult.details,
+      ...params,
+    }),
+  };
+}
+
 async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActionRunResult> {
   const {
     cfg,
@@ -1171,7 +1285,27 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
     }),
   });
   if (gatewayPluginAction) {
-    return gatewayPluginAction;
+    if (gatewayPluginAction.kind !== "send") {
+      return gatewayPluginAction;
+    }
+    return {
+      ...gatewayPluginAction,
+      payload: annotatePayloadForCurrentSourceReply({
+        payload: gatewayPluginAction.payload,
+        sendPayload,
+        input,
+        actionParams: params,
+        outboundRoute,
+        dryRun,
+      }),
+      toolResult: annotateToolResultForCurrentSourceReply(gatewayPluginAction.toolResult, {
+        sendPayload,
+        input,
+        actionParams: params,
+        outboundRoute,
+        dryRun,
+      }),
+    };
   }
 
   const send = await executeSendAction({
@@ -1230,8 +1364,21 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
     action,
     to,
     handledBy: send.handledBy,
-    payload: send.payload,
-    toolResult: send.toolResult,
+    payload: annotatePayloadForCurrentSourceReply({
+      payload: send.payload,
+      sendPayload,
+      input,
+      actionParams: params,
+      outboundRoute,
+      dryRun,
+    }),
+    toolResult: annotateToolResultForCurrentSourceReply(send.toolResult, {
+      sendPayload,
+      input,
+      actionParams: params,
+      outboundRoute,
+      dryRun,
+    }),
     sendResult: send.sendResult,
     dryRun,
   };


### PR DESCRIPTION
## Summary

Fixes #91330.

Current-session `message(action="send")` replies can already deliver the useful answer to the source chat, but the runner did not mark those sends as delivered source replies. If the model then ended with private bookkeeping text, that bookkeeping final could become the channel-visible final answer.

This PR marks successful current-source message sends as delivered source replies and suppresses later private assistant artifacts. It does not resend the message-tool reply in automatic delivery mode.

## Source-proven bug this PR fixes

A Windows/OpenClaw node running `2026.6.5-beta.2` reproduced this during a Telegram direct-chat QQBot setup diagnosis:

- The useful diagnosis was sent with the `message` tool back to the same Telegram source conversation.
- The tool result only carried a normal successful send result (`ok: true`, `messageId: ...`), so the embedded runner did not record it as a source reply.
- The model then ended with private bookkeeping text equivalent to: `I replied via Telegram and recorded the setup state in memory.`
- That private bookkeeping text became the apparent final response, making the turn look like it had no useful conclusion even though the useful message-tool reply had already been delivered.

The QQBot-specific diagnosis was incidental; this PR only fixes the current-session message-tool/final-selection boundary.

## What changed

- Annotate successful current-source `send` results only when the send result has positive delivery evidence (`messageId`/`message_id`, explicit `sent`/`delivered` status, and no failed/error status), with:
  - `deliveryStatus: "sent"`
  - `sourceReplySink: "internal-ui"`
  - `sourceReply`
- Keep explicit sends to another target/session unannotated.
- Keep failed or ambiguous current-source sends unannotated so the later assistant final remains eligible instead of being suppressed.
- In payload building:
  - `message_tool_only` keeps the existing mirror payload behavior.
  - `automatic` uses delivered source-reply evidence to suppress later private finals without resending the source reply.

## Related context

- #91330 is the first-hand incident for this PR.
- #90610 is adjacent final-answer candidate visibility work, but it does not cover a useful current-session message-tool reply followed by a private bookkeeping final.
- #88992 and #90095 are related `message_tool_only` delivery fixes. This PR covers the normal automatic direct-session path instead.

This PR intentionally does not fix gateway restart/session continuation. The earlier interrupted rollout in the incident is a separate problem and is not required for this patch.

## Real behavior proof

- **Behavior or issue addressed**: A current-session message-tool reply can deliver the useful response, but a later private bookkeeping final can replace/obscure it as the visible final answer because the successful send was not recorded as a delivered source reply.

- **Real environment tested**: Local OpenClaw source checkout on macOS/Darwin, branch `agent/xiaozhua/restart-message-final-incident`. The user-visible incident came from a Windows/OpenClaw `2026.6.5-beta.2` Telegram direct session and is documented in #91330 with sensitive values redacted.

- **Exact steps or command run after this patch**: Ran an after-patch source-level behavior probe with `pnpm exec tsx /tmp/message-tool-source-reply-probe.ts`, plus focused regression tests:

  ```bash
  pnpm exec tsx /tmp/message-tool-source-reply-probe.ts
  node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/payloads.test.ts
  node scripts/run-vitest.mjs src/infra/outbound/message-action-runner.core-send.test.ts
  pnpm exec oxlint src/infra/outbound/message-action-runner.ts src/infra/outbound/message-action-runner.core-send.test.ts src/agents/embedded-agent-runner/run/payloads.ts src/agents/embedded-agent-runner/run/payloads.test.ts
  git diff --check
  ```

- **Evidence after fix**: Console output from the after-patch source-level probe for the real incident shape (`automatic` delivery, delivered current-session message-tool source reply, followed by private bookkeeping final):

  ```json
  {
    "scenario": "automatic current-session message-tool source reply followed by private bookkeeping final",
    "payloadCount": 0,
    "payloads": []
  }
  ```

  Focused test output also covered the regression path:

  ```text
  ✓ src/agents/embedded-agent-runner/run/payloads.test.ts (35 tests)
  ✓ src/infra/outbound/message-action-runner.core-send.test.ts (13 tests)
  Found 0 warnings and 0 errors.
  ```

- **Observed result after fix**: Automatic-mode delivered source replies suppress later private bookkeeping finals (`payloadCount: 0`) and do not emit a duplicate final payload for the already-delivered message-tool reply. Existing `message_tool_only` mirror behavior remains covered. Explicit sends to another session remain unmarked as source replies, and failed/ambiguous current-source sends remain unmarked so a later final is not hidden when delivery was not proven.

- **What was not tested**: A full live Telegram replay against a patched production Gateway was not run. Gateway restart/session continuation is not fixed or tested by this PR.

## Tests

- `pnpm exec tsx /tmp/message-tool-source-reply-probe.ts`
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/payloads.test.ts`
- `node scripts/run-vitest.mjs src/infra/outbound/message-action-runner.core-send.test.ts`
- `pnpm exec oxlint src/infra/outbound/message-action-runner.ts src/infra/outbound/message-action-runner.core-send.test.ts src/agents/embedded-agent-runner/run/payloads.ts src/agents/embedded-agent-runner/run/payloads.test.ts`
- `git diff --check`
- `pnpm build:plugin-sdk:dts`
