### PR TITLE
refactor(cron): reduce excessive as unknown as type assertions in store loading

### DIFF
--- a/src/cron/service/store.ts
+++ b/src/cron/service/store.ts
@@ -104,11 +104,11 @@ export async function ensureLoaded(
     previousJobsById.set(job.id, job);
   }
   const loaded = await loadCronJobsStoreWithConfigJobs(state.deps.storePath);
-  const loadedJobs = (loaded.store.jobs ?? []) as unknown as CronJob[];
+  const loadedJobs = loaded.store.jobs ?? [];
   const jobs: CronJob[] = [];
   const quarantinedConfigJobs: QuarantinedCronConfigJob[] = [...loaded.invalidConfigRows];
   for (const [index, job] of loadedJobs.entries()) {
-    const decodedRaw = job as unknown as Record<string, unknown>;
+    const decodedRaw = job as Record<string, unknown>;
     const rawConfigJob = loaded.configJobs[index] ?? structuredClone(decodedRaw);
     const raw = decodedRaw;
     const sourceIndex = loaded.configJobIndexes[index] ?? index;
@@ -129,11 +129,8 @@ export async function ensureLoaded(
         "cron: job has invalid persisted sessionTarget; run openclaw doctor --fix to repair",
       );
     }
-    const hydrated =
-      normalized && typeof normalized === "object" ? (normalized as unknown as CronJob) : job;
-    const invalidReason = getInvalidPersistedCronJobReason(
-      hydrated as unknown as Record<string, unknown>,
-    );
+    const hydrated = normalized && typeof normalized === "object" ? (normalized as CronJob) : job;
+    const invalidReason = getInvalidPersistedCronJobReason(hydrated as Record<string, unknown>);
     if (invalidReason) {
       const quarantineEntry: QuarantinedCronConfigJob = {
         sourceIndex,


### PR DESCRIPTION
## Summary
- Replace unnecessary `as unknown as CronJob[]` with direct assignment since `loaded.store.jobs` is already typed as `CronJob[]`.
- Remove intermediate `as unknown` from `job as unknown as Record<string, unknown>`; direct cast to `Record<string, unknown>` is sufficient.
- Remove `as unknown` from `normalized as unknown as CronJob` and `hydrated as unknown as Record<string, unknown>`.

## Test plan
- [x] `pnpm test src/cron/service/store.test.ts` passes
- [x] `pnpm tsgo:core` type-checks cleanly
- [x] `pnpm format` produces no changes

## Verification
Behavior addressed: Excessive `as unknown as` type assertions in `src/cron/service/store.ts` bypass TypeScript's type safety and reduce readability.
Real environment tested: Linux, Node v22.22.0
Exact steps or command run after this patch:
- `pnpm test src/cron/service/store.test.ts src/cron/service/store.load-missing-session-target.test.ts src/cron/service/ops.test.ts`
- `pnpm tsgo:core`
- `pnpm format`
Evidence after fix: All 23 cron store tests pass; core type-check exits cleanly with no errors.
Observed result after fix: No behavioral changes; only type annotation improvements. Existing validation via `normalizeCronJobInput()` and `getInvalidPersistedCronJobReason()` remains intact.
What was not tested: Full `pnpm check:changed` (requires remote Crabbox/Testbox); `pnpm lint` fails on pre-existing Discord `libopus-wasm` dependency issue unrelated to this change.

Fixes #91314