### PR TITLE
fix(cli): quiet local no-auth gateway warning

### DIFF
--- a/src/cli/gateway-cli/run.option-collisions.test.ts
+++ b/src/cli/gateway-cli/run.option-collisions.test.ts
@@ -266,6 +266,12 @@ describe("gateway run option collisions", () => {
     };
   }
 
+  function hasNoAuthStartupWarning() {
+    return gatewayLogMessages.includes(
+      "Gateway auth mode=none explicitly configured; all gateway connections are unauthenticated.",
+    );
+  }
+
   function expectAuthOverrideMode(mode: string) {
     expect(gatewayStartOptions().auth?.mode).toBe(mode);
   }
@@ -392,6 +398,85 @@ describe("gateway run option collisions", () => {
     expect(options.bind).toBe("auto");
   });
 
+  it.each([
+    {
+      name: "strictly local loopback gateway binds",
+      config: { gateway: { bind: "loopback", auth: { mode: "none" } } },
+      argv: ["gateway", "run", "--allow-unconfigured"],
+      expectedWarning: false,
+    },
+    {
+      name: "Tailscale exposure",
+      config: { gateway: { bind: "loopback", auth: { mode: "none" } } },
+      argv: ["gateway", "run", "--tailscale", "serve", "--allow-unconfigured"],
+      expectedWarning: true,
+    },
+    {
+      name: "configured proxy exposure",
+      config: {
+        gateway: {
+          bind: "loopback",
+          trustedProxies: ["10.0.0.2"],
+          auth: { mode: "none" },
+        },
+      },
+      argv: ["gateway", "run", "--allow-unconfigured"],
+      expectedWarning: true,
+    },
+    {
+      name: "configured Control UI origins",
+      config: {
+        gateway: {
+          bind: "loopback",
+          controlUi: { allowedOrigins: ["https://control.example.com"] },
+          auth: { mode: "none" },
+        },
+      },
+      argv: ["gateway", "run", "--allow-unconfigured"],
+      expectedWarning: true,
+    },
+    {
+      name: "Host-header origin fallback",
+      config: {
+        gateway: {
+          bind: "loopback",
+          controlUi: { dangerouslyAllowHostHeaderOriginFallback: true },
+          auth: { mode: "none" },
+        },
+      },
+      argv: ["gateway", "run", "--allow-unconfigured"],
+      expectedWarning: true,
+    },
+    {
+      name: "trusted-proxy auth config",
+      config: {
+        gateway: {
+          bind: "loopback",
+          auth: {
+            mode: "none",
+            trustedProxy: { userHeader: "x-forwarded-user" },
+          },
+        },
+      },
+      argv: ["gateway", "run", "--allow-unconfigured"],
+      expectedWarning: true,
+    },
+  ])("handles the no-auth startup warning for $name", async ({ config, argv, expectedWarning }) => {
+    configState.cfg = config;
+    configState.snapshot = {
+      exists: true,
+      valid: true,
+      config,
+    };
+
+    await withEnvAsync(withoutGatewayAuthEnv, async () => {
+      await runGatewayCli(argv);
+    });
+
+    expect(gatewayStartOptions().bind).toBe("loopback");
+    expect(hasNoAuthStartupWarning()).toBe(expectedWarning);
+  });
+
   it("blocks container auto startup without explicit gateway auth", async () => {
     netState.autoBindHost = "0.0.0.0";
     netState.container = true;
@@ -407,12 +492,20 @@ describe("gateway run option collisions", () => {
   });
 
   it("blocks non-loopback startup without explicit gateway auth", async () => {
+    configState.cfg = { gateway: { auth: { mode: "none" } } };
+    configState.snapshot = {
+      exists: true,
+      valid: true,
+      config: configState.cfg,
+    };
+
     await withEnvAsync(withoutGatewayAuthEnv, async () => {
       await expect(
         runGatewayCli(["gateway", "run", "--bind", "lan", "--allow-unconfigured"]),
       ).rejects.toThrow("__exit__:78");
     });
 
+    expect(hasNoAuthStartupWarning()).toBe(true);
     expect(runtimeErrors.join("\n")).toContain("Refusing to bind gateway to lan without auth.");
     expect(startGatewayServer).not.toHaveBeenCalled();
   });

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -762,12 +762,20 @@ export async function runGatewayCommand(opts: GatewayRunOpts) {
     defaultRuntime.exit(EXIT_CONFIG_ERROR);
     return;
   }
-  if (resolvedAuthMode === "none") {
+  const healthHost = await resolveGatewayBindHost(bind, cfg.gateway?.customBindHost);
+  const gatewayHasConfiguredExposure =
+    effectiveTailscaleMode !== "off" ||
+    (cfg.gateway?.trustedProxies?.length ?? 0) > 0 ||
+    (cfg.gateway?.controlUi?.allowedOrigins?.length ?? 0) > 0 ||
+    cfg.gateway?.controlUi?.dangerouslyAllowHostHeaderOriginFallback === true ||
+    cfg.gateway?.auth?.trustedProxy !== undefined;
+  const shouldWarnForNoAuth =
+    resolvedAuthMode === "none" && (!isLoopbackHost(healthHost) || gatewayHasConfiguredExposure);
+  if (shouldWarnForNoAuth) {
     gatewayLog.warn(
       "Gateway auth mode=none explicitly configured; all gateway connections are unauthenticated.",
     );
   }
-  const healthHost = await resolveGatewayBindHost(bind, cfg.gateway?.customBindHost);
   if (
     shouldBlockGatewayBindWithoutExplicitAuth({
       bindHost: healthHost,


### PR DESCRIPTION
## Summary

- Quiet the Gateway `auth mode=none` startup warning only for strictly local loopback no-auth startup.
- Keep the warning for non-loopback binds and loopback configs with exposure signals: Tailscale, `gateway.trustedProxies`, `gateway.controlUi.allowedOrigins`, `gateway.controlUi.dangerouslyAllowHostHeaderOriginFallback`, or `gateway.auth.trustedProxy`.
- Add focused gateway CLI regression coverage for the suppression case, the exposed loopback cases, and the existing LAN fail-closed path.
- Out of scope: adding a new config option or changing security audit findings.
- Review focus: whether the startup warning predicate matches the existing audit/docs exposure model without hiding no-auth risk.

## Linked context

Closes #91151

Related #91197. This PR keeps the same no-new-config direction but also covers the Host-header fallback exposure gap called out in that PR's ClawSweeper review.

Was this requested by a maintainer or owner? No.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Gateway startup no longer prints the unauthenticated warning for a strictly local loopback-only `gateway.auth.mode="none"` deployment, while exposed no-auth paths still warn.
- Real environment tested: macOS local checkout, Node v24.15.0, pnpm 11.2.2, temporary `OPENCLAW_CONFIG_PATH` and `OPENCLAW_STATE_DIR` directories.
- Exact steps or command run after this patch: Started `pnpm openclaw gateway run` with temporary configs for three cases: loopback no-auth on port 19591, loopback no-auth plus `gateway.controlUi.dangerouslyAllowHostHeaderOriginFallback=true` on port 19592, and `--bind lan` no-auth on port 19593.
- Evidence after fix:

```text
loopback config: gateway.bind="loopback", gateway.auth.mode="none"
[gateway] loading configuration...
[gateway] resolving authentication...
[gateway] starting...
(no "auth mode=none explicitly configured" warning appeared before startup reached starting)

Host-header fallback config: gateway.bind="loopback", gateway.auth.mode="none", gateway.controlUi.dangerouslyAllowHostHeaderOriginFallback=true
[gateway] loading configuration...
[gateway] resolving authentication...
[gateway] auth mode=none explicitly configured; all gateway connections are unauthenticated.
[gateway] starting...

LAN config: gateway.auth.mode="none" plus --bind lan
[gateway] loading configuration...
[gateway] resolving authentication...
[gateway] auth mode=none explicitly configured; all gateway connections are unauthenticated.
Refusing to bind gateway to lan without auth.
[ELIFECYCLE] Command failed with exit code 78.
```

- Observed result after fix: The noisy warning is absent for the strictly local loopback no-auth case, remains visible for the Host-header fallback exposure case, and remains visible before the existing LAN no-auth startup refusal.
- What was not tested: Full `pnpm check` / full test suite.
- Proof limitations or environment constraints: The two long-running loopback startup probes were stopped after log observation; they reached `starting...` but were not waited to a `ready` banner because this checkout was rebuilding local dist/assets and did not emit `ready` within the local 30-second observation window.
- Before evidence (optional but encouraged): Current `main` logs the no-auth warning unconditionally whenever `resolvedAuthMode === "none"` before resolving exposure-specific policy.

## Tests and validation

- `pnpm install`
- `node scripts/run-vitest.mjs src/cli/gateway-cli/run.option-collisions.test.ts`
- `pnpm exec oxfmt --check src/cli/gateway-cli/run.ts src/cli/gateway-cli/run.option-collisions.test.ts`
- `node scripts/run-oxlint.mjs src/cli/gateway-cli/run.ts src/cli/gateway-cli/run.option-collisions.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

Regression coverage added: table-driven CLI tests cover strictly local loopback suppression, Tailscale exposure, configured proxy exposure, configured Control UI origins, Host-header fallback, trusted-proxy auth config, and the existing non-loopback no-auth block.

What failed before this fix: A loopback-only config with `gateway.auth.mode="none"` emitted the unauthenticated startup warning even though the runtime was not exposed beyond local loopback.

## Risk checklist

Did user-visible behavior change? Yes.

Did config, environment, or migration behavior change? No.

Did security, auth, secrets, network, or tool execution behavior change? Yes, security-facing startup logging changes.

Highest-risk area: hiding an unauthenticated gateway warning for a configuration that is still meaningfully exposed.

Mitigation: the warning is suppressed only when the resolved bind host is loopback and no existing exposure signals are configured; the tests include the Host-header fallback case and other exposed loopback cases.

## Current review state

Next action: waiting for CI, ClawSweeper, and maintainer review.

Still waiting on author, maintainer, CI, or external proof: no author action known at PR creation time; broad `pnpm check` was not run locally.

Which bot or reviewer comments were addressed: this PR incorporates the Host-header fallback warning predicate/test gap identified by ClawSweeper on related PR #91197.
