### PR TITLE
fix(cron): remove unnecessary as unknown as cast in store loading

### DIFF
--- a/src/cron/service/store.ts
+++ b/src/cron/service/store.ts
@@ -104,7 +104,7 @@ export async function ensureLoaded(
     previousJobsById.set(job.id, job);
   }
   const loaded = await loadCronJobsStoreWithConfigJobs(state.deps.storePath);
-  const loadedJobs = (loaded.store.jobs ?? []) as unknown as CronJob[];
+  const loadedJobs: CronJob[] = loaded.store.jobs ?? [];
   const jobs: CronJob[] = [];
   const quarantinedConfigJobs: QuarantinedCronConfigJob[] = [...loaded.invalidConfigRows];
   for (const [index, job] of loadedJobs.entries()) {


### PR DESCRIPTION
## Summary\n\nRemoves a redundant double type assertion () in  during cron store loading.\n\n## What changed\n\n**File:** \n\nThe loaded store's  field is already typed as  in  (defined in ):\n\n\n\nThe  double cast was unnecessary because the store file type already guarantees . The  fallback remains unchanged.\n\n## Why this matters\n\n- **Type safety:** Direct type annotation makes the intent clearer\n- **Code clarity:** Removes a pattern the project AGENTS.md advises against for unnecessary assertions\n- **No behavioral changes:** This is a pure refactor — the runtime behavior is identical\n\n## Testing\n\nAll existing cron store tests pass:\n\n\n\n## Related issue\n\nFixes #91314