### PR TITLE
fix(ui): preserve /reset soft args in Control UI dispatch

### DIFF
--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -1380,7 +1380,24 @@ describe("handleSendChat", () => {
     expect(host.chatMessage).toBe("");
   });
 
-  it("preserves /reset soft args and skips confirmation dialog", async () => {
+  it.each([
+    {
+      input: "/reset soft please reload system prompt",
+      expected: "/reset soft please reload system prompt",
+    },
+    {
+      input: "/reset\tsoft please reload system prompt",
+      expected: "/reset soft please reload system prompt",
+    },
+    {
+      input: "/reset\nsoft please reload system prompt",
+      expected: "/reset soft please reload system prompt",
+    },
+    {
+      input: "/reset: soft please reload system prompt",
+      expected: "/reset soft please reload system prompt",
+    },
+  ])("preserves $input args and skips confirmation dialog", async ({ input, expected }) => {
     const confirm = vi.fn(() => false);
     vi.stubGlobal("confirm", confirm);
     const request = vi.fn(async (method: string) => {
@@ -1391,7 +1408,7 @@ describe("handleSendChat", () => {
     });
     const host = makeHost({
       client: { request } as unknown as ChatHost["client"],
-      chatMessage: "/reset soft please reload system prompt",
+      chatMessage: input,
       sessionKey: "agent:main",
     });
 
@@ -1404,8 +1421,35 @@ describe("handleSendChat", () => {
       "chat send payload",
     );
     expect(payload.sessionKey).toBe("agent:main");
-    expect(payload.message).toBe("/reset soft please reload system prompt");
+    expect(payload.message).toBe(expected);
     expect(host.chatMessage).toBe("");
+  });
+
+  it.each([
+    "/reset softish please archive",
+    "/reset\tsoftish please archive",
+    "/reset\nsoftish please archive",
+    "/reset: softish please archive",
+  ])("keeps %s on the hard-reset confirmation path", async (message) => {
+    const confirm = vi.fn(() => false);
+    vi.stubGlobal("confirm", confirm);
+    const request = vi.fn(async (method: string) => {
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const host = makeHost({
+      client: { request } as unknown as ChatHost["client"],
+      chatMessage: "keep this draft",
+      sessionKey: "agent:main",
+    });
+
+    await handleSendChat(host, message, {
+      confirmReset: true,
+      restoreDraft: true,
+    });
+
+    expect(confirm).toHaveBeenCalledTimes(1);
+    expect(request).not.toHaveBeenCalled();
+    expect(host.chatMessage).toBe("keep this draft");
   });
 
   it("records visible send timing phases for a normal chat send", async () => {

--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -1380,6 +1380,34 @@ describe("handleSendChat", () => {
     expect(host.chatMessage).toBe("");
   });
 
+  it("preserves /reset soft args and skips confirmation dialog", async () => {
+    const confirm = vi.fn(() => false);
+    vi.stubGlobal("confirm", confirm);
+    const request = vi.fn(async (method: string) => {
+      if (method === "chat.send") {
+        return { status: "started" };
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const host = makeHost({
+      client: { request } as unknown as ChatHost["client"],
+      chatMessage: "/reset soft please reload system prompt",
+      sessionKey: "agent:main",
+    });
+
+    await handleSendChat(host);
+
+    expect(confirm).not.toHaveBeenCalled();
+    const payload = findRequestPayload(
+      request as unknown as MockCallSource,
+      "chat.send",
+      "chat send payload",
+    );
+    expect(payload.sessionKey).toBe("agent:main");
+    expect(payload.message).toBe("/reset soft please reload system prompt");
+    expect(host.chatMessage).toBe("");
+  });
+
   it("records visible send timing phases for a normal chat send", async () => {
     const request = vi.fn(async (method: string) => {
       if (method === "chat.send") {

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -245,18 +245,17 @@ export function isChatStopCommand(text: string) {
 }
 
 function isChatResetCommand(text: string) {
-  const trimmed = text.trim();
-  if (!trimmed) {
+  const parsed = parseSlashCommand(text);
+  if (!parsed || (parsed.command.key !== "new" && parsed.command.key !== "reset")) {
     return false;
   }
-  const normalized = normalizeLowercaseStringOrEmpty(trimmed);
-  if (normalized === "/new" || normalized === "/reset") {
+  if (parsed.command.key === "new") {
     return true;
   }
-  if (normalized.match(/^\/reset soft(?:\s|$)/)) {
+  if (/^soft(?:\s|$)/.test(normalizeLowercaseStringOrEmpty(parsed.args))) {
     return false;
   }
-  return normalized.startsWith("/new ") || normalized.startsWith("/reset ");
+  return true;
 }
 
 function confirmChatResetCommand(text: string) {

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -253,6 +253,9 @@ function isChatResetCommand(text: string) {
   if (normalized === "/new" || normalized === "/reset") {
     return true;
   }
+  if (normalized.startsWith("/reset soft")) {
+    return false;
+  }
   return normalized.startsWith("/new ") || normalized.startsWith("/reset ");
 }
 
@@ -1888,7 +1891,7 @@ async function dispatchSlashCommand(
       await host.onSlashAction("new-session");
       return;
     case "reset":
-      await sendChatMessageNow(host, "/reset", {
+      await sendChatMessageNow(host, args ? `/reset ${args}` : "/reset", {
         refreshSessions: true,
         previousDraft: sendOpts?.previousDraft,
         restoreDraft: sendOpts?.restoreDraft,

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -253,7 +253,7 @@ function isChatResetCommand(text: string) {
   if (normalized === "/new" || normalized === "/reset") {
     return true;
   }
-  if (normalized.startsWith("/reset soft")) {
+  if (normalized.match(/^\/reset soft(?:\s|$)/)) {
     return false;
   }
   return normalized.startsWith("/new ") || normalized.startsWith("/reset ");


### PR DESCRIPTION
## Summary
- Fix \`case \"reset\":\` in \`dispatchSlashCommand\` to forward \`args\` instead of hardcoding \`/reset\`, so \`/reset soft [message]\` is preserved.
- Fix \`isChatResetCommand\` to exclude \`/reset soft\` from the hard-reset confirmation dialog, matching the silent in-place behavior of other channels.
- Tighten soft-reset detection to match Gateway's token boundary (\`soft\` followed by whitespace or end-of-input), preventing misclassification of tails like \`/reset softish\`.
- Add regression test verifying \`/reset soft please reload system prompt\` skips confirmation and sends the full message.

## Test plan
- [x] \`node scripts/run-vitest.mjs run ui/src/ui/app-chat.test.ts\` passes (85/85)
- [x] \`pnpm tsgo:core\` type-checks cleanly
- [x] \`pnpm tsgo:test:ui\` type-checks cleanly
- [x] \`pnpm format\` produces no changes

## Real behavior proof (required for external PRs)
Behavior addressed: Control UI truncated \`/reset soft\` to \`/reset\`, silently archiving the transcript instead of performing a soft reset.
Real environment tested: Linux Node 24, local Gateway + Control UI (http://127.0.0.1:18789)
Exact steps or command run after this patch:
1. \`pnpm build\` — builds Control UI and Gateway from patched source
2. \`pnpm openclaw gateway start\` — starts live Gateway on port 18789
3. Open Control UI in browser (http://127.0.0.1:18789), authenticate with gateway token
4. Type \`/reset soft please reload system prompt\` in chat input and press Enter
5. Observe behavior: no hard-reset confirmation dialog; message sent in full

Evidence after fix:
- **Confirm dialog**: Hooked \`window.confirm\` before send; confirmed \`dialogShown: false\`, meaning no confirmation dialog was triggered for \`/reset soft ...\`
- **Message content**: The full text \`/reset soft please reload system prompt\` appears in the chat transcript bubble, proving args were preserved (not truncated to \`/reset\`)
- **Gateway processing**: After sending, Gateway shows \"In progress\" status, confirming the full message was dispatched and is being processed
- **Token boundary**: Verified \`isChatResetCommand(\"/reset softish\")\` returns \`true\` (would trigger confirmation path), while \`isChatResetCommand(\"/reset soft please\")\` returns \`false\` (skips confirmation)
- **Unit tests**: All 85 app-chat tests pass

Screenshots:

**Before send** — Control UI with \`/reset soft please reload system prompt\` typed in composer:
![before-send](https://github.com/zhouhe-xydt/openclaw/releases/download/pr-91353-proof-1780909005/proof-1-before-send.png)

**After send** — Chat history showing the full message sent without confirmation dialog. Gateway processes it (status \"In progress\"):
![after-send](https://github.com/zhouhe-xydt/openclaw/releases/download/pr-91353-proof-1780909005/proof-2-after-send.png)

Observed result after fix: \`/reset soft\` no longer triggers the hard-reset confirmation dialog and the full message including args is dispatched to the Gateway. Token boundary fix ensures \`/reset softish\` is still treated as a destructive hard reset.
What was not tested: Full \`pnpm check:changed\` (requires remote Crabbox/Testbox); CI run.

Fixes #91316

Maintainer follow-up proof after branch rebase and fixup:
- AWS Crabbox `run_fbaf31b3fff8` on Linux Node 24.16.0: content sanity plus `node scripts/run-vitest.mjs ui/src/ui/app-chat.test.ts --maxWorkers=1 -t "reset soft|reset softish|typed /reset command dispatch"` passed.
- AWS Crabbox `run_eb3af5b92e42`: remote `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed` passed.
- Autoreview final pass: no accepted/actionable findings.
