### PR TITLE
fix(gateway): mark active main sessions before restart shutdown aborts

### DIFF
--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -70,7 +70,9 @@ function runStatusFromWaitPayload(payload: unknown): RunResult["status"] {
   const statusAlreadyTimeoutAttributed = status === "timeout" || status === "timed_out";
   const hardTimeout =
     !pendingError &&
-    ((record.providerStarted === true && statusAlreadyTimeoutAttributed) ||
+    ((stopReason !== "restart" &&
+      record.providerStarted === true &&
+      statusAlreadyTimeoutAttributed) ||
       timeoutPhase === "preflight" ||
       timeoutPhase === "provider" ||
       timeoutPhase === "post_turn");
@@ -93,6 +95,7 @@ function runStatusFromWaitPayload(payload: unknown): RunResult["status"] {
     stopReason === "canceled" ||
     stopReason === "killed" ||
     stopReason === "auth-revoked" ||
+    stopReason === "restart" ||
     stopReason === "rpc" ||
     stopReason === "user" ||
     (record.aborted === true && stopReason === "stop")

--- a/packages/sdk/src/index.test.ts
+++ b/packages/sdk/src/index.test.ts
@@ -156,6 +156,23 @@ describe("OpenClaw SDK", () => {
     expect(result.error?.message).toBe("aborted by operator");
   });
 
+  it("maps restart wait snapshots to cancelled", async () => {
+    const transport = new FakeTransport({
+      "agent.wait": {
+        status: "timeout",
+        runId: "run_restart",
+        stopReason: "restart",
+        providerStarted: true,
+      },
+    });
+    const oc = new OpenClaw({ transport });
+
+    const result = await oc.runs.wait("run_restart");
+
+    expect(result.runId).toBe("run_restart");
+    expect(result.status).toBe("cancelled");
+  });
+
   it("maps provider-started rpc timeout wait snapshots to timed_out", async () => {
     const transport = new FakeTransport({
       "agent.wait": {
@@ -1209,9 +1226,57 @@ describe("OpenClaw SDK", () => {
     expect(cancelled.runId).toBe("run_1");
     expect(cancelled.data).toEqual({ phase: "end", aborted: true, stopReason: "rpc" });
 
-    const hardTimeout = normalizeGatewayEvent({
+    const restartCancelled = normalizeGatewayEvent({
       event: "agent",
       seq: 6,
+      payload: {
+        runId: "run_1",
+        stream: "lifecycle",
+        ts,
+        data: {
+          phase: "end",
+          aborted: true,
+          stopReason: "restart",
+          providerStarted: true,
+        },
+      },
+    });
+    expect(restartCancelled.type).toBe("run.cancelled");
+    expect(restartCancelled.runId).toBe("run_1");
+    expect(restartCancelled.data).toEqual({
+      phase: "end",
+      aborted: true,
+      stopReason: "restart",
+      providerStarted: true,
+    });
+
+    const restartErrorCancelled = normalizeGatewayEvent({
+      event: "agent",
+      seq: 7,
+      payload: {
+        runId: "run_1",
+        stream: "lifecycle",
+        ts,
+        data: {
+          phase: "error",
+          aborted: true,
+          stopReason: "restart",
+          error: "agent run aborted for restart",
+        },
+      },
+    });
+    expect(restartErrorCancelled.type).toBe("run.cancelled");
+    expect(restartErrorCancelled.runId).toBe("run_1");
+    expect(restartErrorCancelled.data).toEqual({
+      phase: "error",
+      aborted: true,
+      stopReason: "restart",
+      error: "agent run aborted for restart",
+    });
+
+    const hardTimeout = normalizeGatewayEvent({
+      event: "agent",
+      seq: 8,
       payload: {
         runId: "run_1",
         stream: "lifecycle",
@@ -1237,7 +1302,7 @@ describe("OpenClaw SDK", () => {
 
     const hardTimeoutError = normalizeGatewayEvent({
       event: "agent",
-      seq: 7,
+      seq: 9,
       payload: {
         runId: "run_1",
         stream: "lifecycle",
@@ -1261,7 +1326,7 @@ describe("OpenClaw SDK", () => {
 
     const providerStartedError = normalizeGatewayEvent({
       event: "agent",
-      seq: 8,
+      seq: 10,
       payload: {
         runId: "run_1",
         stream: "lifecycle",
@@ -1283,7 +1348,7 @@ describe("OpenClaw SDK", () => {
 
     const hardTimeoutEnd = normalizeGatewayEvent({
       event: "agent",
-      seq: 9,
+      seq: 11,
       payload: {
         runId: "run_1",
         stream: "lifecycle",
@@ -1305,7 +1370,7 @@ describe("OpenClaw SDK", () => {
 
     const providerStartedEnd = normalizeGatewayEvent({
       event: "agent",
-      seq: 10,
+      seq: 12,
       payload: {
         runId: "run_1",
         stream: "lifecycle",
@@ -1325,7 +1390,7 @@ describe("OpenClaw SDK", () => {
 
     const authRevoked = normalizeGatewayEvent({
       event: "agent",
-      seq: 10,
+      seq: 13,
       payload: {
         runId: "run_1",
         stream: "lifecycle",
@@ -1343,7 +1408,7 @@ describe("OpenClaw SDK", () => {
 
     const timedOut = normalizeGatewayEvent({
       event: "agent",
-      seq: 11,
+      seq: 14,
       payload: {
         runId: "run_1",
         stream: "lifecycle",

--- a/packages/sdk/src/normalize.ts
+++ b/packages/sdk/src/normalize.ts
@@ -28,15 +28,10 @@ function hasHardTimeoutMetadata(data: JsonObject, statusAlreadyTimeoutAttributed
   );
 }
 
-function normalizeLifecycleEndEventType(data: JsonObject): OpenClawEventType {
+function isLifecycleCancellation(data: JsonObject): boolean {
   const status = readLowerString(data.status);
   const stopReason = readLowerString(data.stopReason);
-  const statusAlreadyTimeoutAttributed =
-    status === "timeout" || status === "timed_out" || data.aborted === true;
-  if (hasHardTimeoutMetadata(data, statusAlreadyTimeoutAttributed)) {
-    return "run.timed_out";
-  }
-  if (
+  return (
     status === "aborted" ||
     status === "cancelled" ||
     status === "canceled" ||
@@ -46,10 +41,23 @@ function normalizeLifecycleEndEventType(data: JsonObject): OpenClawEventType {
     stopReason === "canceled" ||
     stopReason === "killed" ||
     stopReason === "auth-revoked" ||
+    stopReason === "restart" ||
     stopReason === "rpc" ||
     stopReason === "user" ||
     (data.aborted === true && stopReason === "stop")
-  ) {
+  );
+}
+
+function normalizeLifecycleEndEventType(data: JsonObject): OpenClawEventType {
+  const status = readLowerString(data.status);
+  const stopReason = readLowerString(data.stopReason);
+  const statusAlreadyTimeoutAttributed =
+    stopReason !== "restart" &&
+    (status === "timeout" || status === "timed_out" || data.aborted === true);
+  if (hasHardTimeoutMetadata(data, statusAlreadyTimeoutAttributed)) {
+    return "run.timed_out";
+  }
+  if (isLifecycleCancellation(data)) {
     return "run.cancelled";
   }
   if (
@@ -90,6 +98,9 @@ function normalizeAgentEventType(payload: JsonObject): OpenClawEventType {
     if (phase === "error") {
       if (hasHardTimeoutMetadata(data, false)) {
         return "run.timed_out";
+      }
+      if (isLifecycleCancellation(data)) {
+        return "run.cancelled";
       }
       return "run.failed";
     }

--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite
 import type { SessionEntry } from "../config/sessions.js";
 import { INTERNAL_RUNTIME_CONTEXT_BEGIN, INTERNAL_RUNTIME_CONTEXT_END } from "./internal-events.js";
 import { LiveSessionModelSwitchError } from "./live-model-switch-error.js";
+import { createAgentRunRestartAbortError } from "./run-termination.js";
 
 const state = vi.hoisted(() => ({
   defaultRuntimeConfig: {
@@ -21,6 +22,8 @@ const state = vi.hoisted(() => ({
   acpRunTurnMock: vi.fn((..._args: unknown[]): unknown => undefined),
   buildAcpResultMock: vi.fn(),
   createAcpVisibleTextAccumulatorMock: vi.fn(),
+  emitAcpLifecycleEndMock: vi.fn(),
+  emitAcpLifecycleErrorMock: vi.fn(),
   persistCliTurnTranscriptMock: vi.fn(),
   persistAcpTurnTranscriptMock: vi.fn(),
   runCliTurnCompactionLifecycleMock: vi.fn(),
@@ -75,8 +78,8 @@ vi.mock("./command/attempt-execution.runtime.js", () => ({
   buildAcpResult: (...args: unknown[]) => state.buildAcpResultMock(...args),
   createAcpVisibleTextAccumulator: () => state.createAcpVisibleTextAccumulatorMock(),
   emitAcpAssistantDelta: vi.fn(),
-  emitAcpLifecycleEnd: vi.fn(),
-  emitAcpLifecycleError: vi.fn(),
+  emitAcpLifecycleEnd: (...args: unknown[]) => state.emitAcpLifecycleEndMock(...args),
+  emitAcpLifecycleError: (...args: unknown[]) => state.emitAcpLifecycleErrorMock(...args),
   emitAcpLifecycleStart: vi.fn(),
   emitAcpRuntimeEvent: vi.fn(),
   persistCliTurnTranscript: (...args: unknown[]) => state.persistCliTurnTranscriptMock(...args),
@@ -1164,6 +1167,105 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
       expect.any(String),
       "post-restart-generation",
     );
+  });
+
+  it("preserves restart ownership when an aborted attempt resolves normally", async () => {
+    setupSingleAttemptFallback();
+    state.runAgentAttemptMock.mockResolvedValue({
+      payloads: [],
+      meta: {
+        durationMs: 100,
+        aborted: true,
+        stopReason: "end_turn",
+        agentMeta: { provider: "anthropic", model: "claude" },
+      },
+    });
+    const controller = new AbortController();
+    controller.abort(createAgentRunRestartAbortError());
+
+    await expect(
+      agentCommand({
+        message: "hello",
+        to: "+1234567890",
+        abortSignal: controller.signal,
+      }),
+    ).rejects.toThrow("agent run aborted for restart");
+
+    const lifecycleEvents = state.emitAgentEventMock.mock.calls
+      .map((call) => call[0] as { stream?: string; data?: Record<string, unknown> })
+      .filter((event) => event.stream === "lifecycle");
+    expect(lifecycleEvents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          data: expect.objectContaining({
+            phase: "error",
+            aborted: true,
+            stopReason: "restart",
+          }),
+        }),
+      ]),
+    );
+    expect(state.deliverAgentCommandResultMock).not.toHaveBeenCalled();
+  });
+
+  it("preserves restart ownership when an aborted ACP turn resolves normally", async () => {
+    state.acpResolveSessionMock.mockReturnValue({
+      kind: "ready",
+      meta: {
+        agent: "claude",
+        cwd: "/tmp/workspace",
+      },
+    });
+    const controller = new AbortController();
+    controller.abort(createAgentRunRestartAbortError());
+
+    await expect(
+      agentCommand({
+        message: "hello",
+        sessionKey: "agent:main:main",
+        abortSignal: controller.signal,
+      }),
+    ).rejects.toThrow("agent run aborted for restart");
+
+    expect(state.emitAcpLifecycleEndMock).not.toHaveBeenCalled();
+    expect(state.deliverAgentCommandResultMock).not.toHaveBeenCalled();
+  });
+
+  it("suppresses ACP delivery when restart begins during transcript persistence", async () => {
+    state.acpResolveSessionMock.mockReturnValue({
+      kind: "ready",
+      meta: {
+        agent: "claude",
+        cwd: "/tmp/workspace",
+      },
+    });
+    const controller = new AbortController();
+    state.persistAcpTurnTranscriptMock.mockImplementation(
+      async (params: { sessionEntry?: unknown }) => {
+        controller.abort(createAgentRunRestartAbortError());
+        return params.sessionEntry;
+      },
+    );
+
+    await expect(
+      agentCommand({
+        message: "hello",
+        sessionKey: "agent:main:main",
+        abortSignal: controller.signal,
+      }),
+    ).rejects.toThrow("agent run aborted for restart");
+
+    expect(state.emitAcpLifecycleEndMock).not.toHaveBeenCalled();
+    expect(state.emitAcpLifecycleErrorMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: "session-1",
+        sessionKey: "agent:main:main",
+        abortSignal: controller.signal,
+      }),
+    );
+    expect(state.persistAcpTurnTranscriptMock).toHaveBeenCalledTimes(1);
+    expect(state.buildAcpResultMock).not.toHaveBeenCalled();
+    expect(state.deliverAgentCommandResultMock).not.toHaveBeenCalled();
   });
 
   it("keeps the initial session touch for local runs", async () => {
@@ -2546,6 +2648,34 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
       return arg?.stream === "lifecycle" && arg?.data?.phase === "error";
     });
     expect(lifecycleErrorCalls.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("marks lifecycle errors aborted when cancellation reaches post-turn handling", async () => {
+    const abortController = new AbortController();
+    abortController.abort();
+    state.runWithModelFallbackMock.mockRejectedValueOnce(new Error("request aborted"));
+
+    await expect(
+      agentCommand({
+        message: "hello",
+        to: "+1234567890",
+        abortSignal: abortController.signal,
+      }),
+    ).rejects.toThrow("request aborted");
+
+    expect(
+      state.emitAgentEventMock.mock.calls.some(([event]) => {
+        const candidate = event as {
+          stream?: string;
+          data?: { phase?: string; aborted?: boolean };
+        };
+        return (
+          candidate.stream === "lifecycle" &&
+          candidate.data?.phase === "error" &&
+          candidate.data.aborted === true
+        );
+      }),
+    ).toBe(true);
   });
 
   it("propagates authProfileId from the switch error to the retried session entry", async () => {

--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -270,10 +270,14 @@ vi.mock("./internal-session-effects.js", () => ({
 }));
 
 vi.mock("../infra/agent-events.js", () => ({
+  assertAgentRunLifecycleGenerationCurrent: vi.fn(),
+  captureAgentRunLifecycleGeneration: () => "test-generation",
   clearAgentRunContext: (...args: unknown[]) => state.clearAgentRunContextMock(...args),
   emitAgentEvent: (...args: unknown[]) => state.emitAgentEventMock(...args),
+  getAgentEventLifecycleGeneration: () => "test-generation",
   onAgentEvent: vi.fn(),
   registerAgentRunContext: (...args: unknown[]) => state.registerAgentRunContextMock(...args),
+  withAgentRunLifecycleGeneration: (_generation: string, run: () => unknown) => run(),
 }));
 
 vi.mock("../infra/outbound/session-context.js", () => ({
@@ -1129,6 +1133,36 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     ).toBeLessThan(deliveryOrder);
     expect(deliveryOrder).toBeLessThan(
       state.emitAgentEventMock.mock.invocationCallOrder[lastEndIndex] ?? 0,
+    );
+  });
+
+  it("uses an embedded queue rebound generation for terminal lifecycle and cleanup", async () => {
+    setupSingleAttemptFallback();
+    state.runAgentAttemptMock.mockImplementation(async (attemptParams: unknown) => {
+      (
+        attemptParams as {
+          onLifecycleGenerationChanged?: (lifecycleGeneration: string) => void;
+        }
+      ).onLifecycleGenerationChanged?.("post-restart-generation");
+      return makeSuccessResult("openai", "gpt-5.4");
+    });
+
+    await runBasicAgentCommand();
+
+    const lifecycleEnd = state.emitAgentEventMock.mock.calls
+      .map(
+        (call) =>
+          call[0] as {
+            stream?: string;
+            data?: { phase?: string };
+            lifecycleGeneration?: string;
+          },
+      )
+      .find((event) => event.stream === "lifecycle" && event.data?.phase === "end");
+    expect(lifecycleEnd?.lifecycleGeneration).toBe("post-restart-generation");
+    expect(state.clearAgentRunContextMock).toHaveBeenCalledWith(
+      expect.any(String),
+      "post-restart-generation",
     );
   });
 

--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -39,6 +39,7 @@ const state = vi.hoisted(() => ({
   hasLegacyAutoFallbackWithoutOriginMock: vi.fn((_entry: unknown) => false),
   resolveAutoFallbackPrimaryProbeMock: vi.fn((_params: unknown) => undefined as unknown),
   resolveChannelModelOverrideMock: vi.fn((_params: unknown) => null as unknown),
+  assertLifecycleCurrentMock: vi.fn(),
   emitAgentEventMock: vi.fn(),
   registerAgentRunContextMock: vi.fn(),
   clearAgentRunContextMock: vi.fn(),
@@ -273,7 +274,8 @@ vi.mock("./internal-session-effects.js", () => ({
 }));
 
 vi.mock("../infra/agent-events.js", () => ({
-  assertAgentRunLifecycleGenerationCurrent: vi.fn(),
+  assertAgentRunLifecycleGenerationCurrent: (...args: unknown[]) =>
+    state.assertLifecycleCurrentMock(...args),
   captureAgentRunLifecycleGeneration: () => "test-generation",
   clearAgentRunContext: (...args: unknown[]) => state.clearAgentRunContextMock(...args),
   emitAgentEvent: (...args: unknown[]) => state.emitAgentEventMock(...args),
@@ -1268,6 +1270,29 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     expect(state.deliverAgentCommandResultMock).not.toHaveBeenCalled();
   });
 
+  it("threads lifecycle ownership into ACP delivery", async () => {
+    state.acpResolveSessionMock.mockReturnValue({
+      kind: "ready",
+      meta: {
+        agent: "claude",
+        cwd: "/tmp/workspace",
+      },
+    });
+
+    await agentCommand({
+      message: "hello",
+      sessionKey: "agent:main:main",
+    });
+
+    const deliveryParams = requireRecord(
+      mockCallArg(state.deliverAgentCommandResultMock),
+      "ACP delivery params",
+    );
+    expect(deliveryParams.assertDeliveryCurrent).toBeTypeOf("function");
+    (deliveryParams.assertDeliveryCurrent as () => void)();
+    expect(state.assertLifecycleCurrentMock).toHaveBeenLastCalledWith("test-generation");
+  });
+
   it("keeps the initial session touch for local runs", async () => {
     setupSingleAttemptFallback();
     state.runAgentAttemptMock.mockResolvedValue(makeSuccessResult("openai", "gpt-5.4"));
@@ -1281,6 +1306,22 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     });
     expect(touchWrites).toHaveLength(1);
     expect(state.updateSessionStoreAfterAgentRunMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("threads lifecycle ownership into normal delivery", async () => {
+    setupSingleAttemptFallback();
+    state.runAgentAttemptMock.mockResolvedValue(makeSuccessResult("openai", "gpt-5.4"));
+    setupSessionTouchStore();
+
+    await runBasicAgentCommand();
+
+    const deliveryParams = requireRecord(
+      mockCallArg(state.deliverAgentCommandResultMock),
+      "delivery params",
+    );
+    expect(deliveryParams.assertDeliveryCurrent).toBeTypeOf("function");
+    (deliveryParams.assertDeliveryCurrent as () => void)();
+    expect(state.assertLifecycleCurrentMock).toHaveBeenLastCalledWith("test-generation");
   });
 
   it("passes explicit timeout overrides into agent attempts", async () => {

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -125,6 +125,10 @@ import {
 } from "./model-visibility-policy.js";
 import { listOpenAIAuthProfileProvidersForAgentRuntime } from "./openai-routing.js";
 import { resolveProviderIdForAuth } from "./provider-auth-aliases.js";
+import {
+  isAgentRunRestartAbortReason,
+  resolveAgentRunAbortLifecycleFields,
+} from "./run-termination.js";
 import { normalizeSpawnedRunMetadata } from "./spawned-context.js";
 import { resolveAgentTimeoutMs } from "./timeout.js";
 import { ensureAgentWorkspace } from "./workspace.js";
@@ -227,6 +231,23 @@ function parseAgentCommandModelRef(
 
 type AttemptExecutionRuntime = typeof import("./command/attempt-execution.runtime.js");
 type AgentAttemptResult = Awaited<ReturnType<AttemptExecutionRuntime["runAgentAttempt"]>>;
+
+function applyAgentRunAbortMetadata<T extends { meta: object }>(
+  result: T,
+  signal: AbortSignal | undefined,
+): T {
+  const abortFields = resolveAgentRunAbortLifecycleFields(signal);
+  if (abortFields.aborted !== true) {
+    return result;
+  }
+  return {
+    ...result,
+    meta: {
+      ...result.meta,
+      ...abortFields,
+    },
+  };
+}
 type AcpManagerRuntime = typeof import("../acp/control-plane/manager.js");
 type AcpPolicyRuntime = typeof import("../acp/policy.js");
 type AcpRuntimeErrorsRuntime = typeof import("../acp/runtime/errors.js");
@@ -1003,6 +1024,9 @@ async function agentCommandInternal(
             });
           },
         });
+        if (isAgentRunRestartAbortReason(opts.abortSignal?.reason)) {
+          throw opts.abortSignal?.reason;
+        }
       } catch (error) {
         const { toAcpRuntimeError } = await loadAcpRuntimeErrorsRuntime();
         const acpError = toAcpRuntimeError({
@@ -1015,11 +1039,10 @@ async function agentCommandInternal(
           error: acpError,
           sessionKey,
           lifecycleGeneration,
+          abortSignal: opts.abortSignal,
         });
         throw acpError;
       }
-
-      attemptExecutionRuntime.emitAcpLifecycleEnd({ runId, lifecycleGeneration });
 
       const finalTextRaw = visibleTextAccumulator.finalizeRaw();
       const finalText = visibleTextAccumulator.finalize();
@@ -1076,13 +1099,32 @@ async function agentCommandInternal(
           `ACP transcript persistence failed for ${sessionKey}: ${formatErrorMessage(error)}`,
         );
       }
-
-      const result = attemptExecutionRuntime.buildAcpResult({
-        payloadText: finalText,
-        startedAt,
-        stopReason,
+      const restartAbortReason = opts.abortSignal?.reason;
+      if (isAgentRunRestartAbortReason(restartAbortReason)) {
+        attemptExecutionRuntime.emitAcpLifecycleError({
+          runId,
+          error: restartAbortReason,
+          sessionKey,
+          lifecycleGeneration,
+          abortSignal: opts.abortSignal,
+        });
+        throw restartAbortReason;
+      }
+      attemptExecutionRuntime.emitAcpLifecycleEnd({
+        runId,
+        lifecycleGeneration,
         abortSignal: opts.abortSignal,
       });
+
+      const result = applyAgentRunAbortMetadata(
+        attemptExecutionRuntime.buildAcpResult({
+          payloadText: finalText,
+          startedAt,
+          stopReason,
+          abortSignal: opts.abortSignal,
+        }),
+        opts.abortSignal,
+      );
       const payloads = result.payloads;
       const { deliverAgentCommandResult } = await loadDeliveryRuntime();
 
@@ -1630,6 +1672,7 @@ async function agentCommandInternal(
           endedAt: Date.now(),
           aborted: runResult.meta.aborted ?? false,
           stopReason: runResult.meta.stopReason,
+          ...resolveAgentRunAbortLifecycleFields(opts.abortSignal),
         },
       });
     };
@@ -1652,6 +1695,7 @@ async function agentCommandInternal(
           endedAt: Date.now(),
           aborted: runResult.meta.aborted ?? false,
           stopReason,
+          ...resolveAgentRunAbortLifecycleFields(opts.abortSignal),
         },
       });
     };
@@ -1669,6 +1713,7 @@ async function agentCommandInternal(
           startedAt,
           endedAt: Date.now(),
           error: error instanceof Error ? error.message : "Agent run failed",
+          ...resolveAgentRunAbortLifecycleFields(opts.abortSignal),
         },
       });
     };
@@ -1825,7 +1870,10 @@ async function agentCommandInternal(
             });
           },
         });
-        result = fallbackResult.result;
+        result = applyAgentRunAbortMetadata(fallbackResult.result, opts.abortSignal);
+        if (isAgentRunRestartAbortReason(opts.abortSignal?.reason)) {
+          throw opts.abortSignal?.reason;
+        }
         fallbackProvider = fallbackResult.provider;
         fallbackModel = fallbackResult.model;
         if (
@@ -1986,6 +2034,7 @@ async function agentCommandInternal(
               startedAt,
               endedAt: Date.now(),
               error: err instanceof Error ? err.message : "Agent run failed",
+              ...resolveAgentRunAbortLifecycleFields(opts.abortSignal),
             },
           });
         }

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -19,9 +19,12 @@ import type { SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { withLocalGatewayRequestScope } from "../gateway/local-request-context.js";
 import {
+  assertAgentRunLifecycleGenerationCurrent,
+  captureAgentRunLifecycleGeneration,
   clearAgentRunContext,
   emitAgentEvent,
   registerAgentRunContext,
+  withAgentRunLifecycleGeneration,
 } from "../infra/agent-events.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import {
@@ -841,6 +844,8 @@ async function agentCommandInternal(
     manifestMetadataSnapshot,
     modelManifestContext,
   } = prepared;
+  let lifecycleGeneration = opts.lifecycleGeneration ?? captureAgentRunLifecycleGeneration(runId);
+  assertAgentRunLifecycleGenerationCurrent(lifecycleGeneration);
   const effectiveCwd = cwd ? resolveUserPath(cwd) : workspaceDir;
   let sessionEntry = prepared.sessionEntry;
   let trackedRestartRecoveryDeliveryContext = false;
@@ -881,6 +886,7 @@ async function agentCommandInternal(
         opts,
         sessionEntry: entry,
       });
+      assertAgentRunLifecycleGenerationCurrent(lifecycleGeneration);
       const next: SessionEntry = {
         ...entry,
         sessionId,
@@ -908,18 +914,20 @@ async function agentCommandInternal(
     }
 
     if (!isRawModelRun && acpResolution?.kind === "ready" && sessionKey) {
+      assertAgentRunLifecycleGenerationCurrent(lifecycleGeneration);
       const attemptExecutionRuntime = await loadAttemptExecutionRuntime();
       const startedAt = Date.now();
       registerAgentRunContext(
         runId,
         suppressVisibleSessionEffects
-          ? { isControlUiVisible: false }
+          ? { isControlUiVisible: false, lifecycleGeneration }
           : {
               sessionKey,
               sessionId,
+              lifecycleGeneration,
             },
       );
-      attemptExecutionRuntime.emitAcpLifecycleStart({ runId, startedAt });
+      attemptExecutionRuntime.emitAcpLifecycleStart({ runId, startedAt, lifecycleGeneration });
 
       const visibleTextAccumulator = attemptExecutionRuntime.createAcpVisibleTextAccumulator();
       let stopReason: string | undefined;
@@ -945,6 +953,7 @@ async function agentCommandInternal(
         }
 
         const acpImageAttachments = resolveInlineAgentImageAttachments(opts.images);
+        assertAgentRunLifecycleGenerationCurrent(lifecycleGeneration);
         await acpManager.runTurn({
           cfg,
           sessionKey,
@@ -1005,11 +1014,12 @@ async function agentCommandInternal(
           runId,
           error: acpError,
           sessionKey,
+          lifecycleGeneration,
         });
         throw acpError;
       }
 
-      attemptExecutionRuntime.emitAcpLifecycleEnd({ runId });
+      attemptExecutionRuntime.emitAcpLifecycleEnd({ runId, lifecycleGeneration });
 
       const finalTextRaw = visibleTextAccumulator.finalizeRaw();
       const finalText = visibleTextAccumulator.finalize();
@@ -1092,9 +1102,11 @@ async function agentCommandInternal(
     const resolvedVerboseLevel =
       verboseOverride ?? persistedVerbose ?? (agentCfg?.verboseDefault as VerboseLevel | undefined);
 
+    assertAgentRunLifecycleGenerationCurrent(lifecycleGeneration);
     if (sessionKey || suppressVisibleSessionEffects) {
       registerAgentRunContext(runId, {
         ...(sessionKey && !suppressVisibleSessionEffects ? { sessionKey, sessionId } : {}),
+        lifecycleGeneration,
         verboseLevel: resolvedVerboseLevel,
         isControlUiVisible: !suppressVisibleSessionEffects,
       });
@@ -1610,6 +1622,7 @@ async function agentCommandInternal(
       attemptLifecycleState.lifecycleFinishing = true;
       emitAgentEvent({
         runId,
+        lifecycleGeneration,
         stream: "lifecycle",
         data: {
           phase: "finishing",
@@ -1631,6 +1644,7 @@ async function agentCommandInternal(
       }
       emitAgentEvent({
         runId,
+        lifecycleGeneration,
         stream: "lifecycle",
         data: {
           phase: "end",
@@ -1648,6 +1662,7 @@ async function agentCommandInternal(
       attemptLifecycleState.lifecycleEnded = true;
       emitAgentEvent({
         runId,
+        lifecycleGeneration,
         stream: "lifecycle",
         data: {
           phase: "error",
@@ -1781,6 +1796,7 @@ async function agentCommandInternal(
               timeoutMs,
               runTimeoutOverrideMs,
               runId,
+              lifecycleGeneration,
               opts,
               runContext,
               spawnedBy,
@@ -1801,6 +1817,9 @@ async function agentCommandInternal(
                 opts.suppressPromptPersistence === true ||
                 (isFallbackRetry && attemptLifecycleState.currentTurnUserMessagePersisted),
               onUserMessagePersisted: attemptLifecycleCallbacks.onUserMessagePersisted,
+              onLifecycleGenerationChanged: (nextLifecycleGeneration) => {
+                lifecycleGeneration = nextLifecycleGeneration;
+              },
               onAgentEvent: attemptLifecycleCallbacks.onAgentEvent,
               deferTerminalLifecycleEnd: true,
             });
@@ -1878,6 +1897,7 @@ async function agentCommandInternal(
             if (!attemptLifecycleState.lifecycleEnded) {
               emitAgentEvent({
                 runId,
+                lifecycleGeneration,
                 stream: "lifecycle",
                 data: {
                   phase: "error",
@@ -1908,6 +1928,7 @@ async function agentCommandInternal(
             if (!attemptLifecycleState.lifecycleEnded) {
               emitAgentEvent({
                 runId,
+                lifecycleGeneration,
                 stream: "lifecycle",
                 data: {
                   phase: "error",
@@ -1958,6 +1979,7 @@ async function agentCommandInternal(
         if (!attemptLifecycleState.lifecycleEnded) {
           emitAgentEvent({
             runId,
+            lifecycleGeneration,
             stream: "lifecycle",
             data: {
               phase: "error",
@@ -2216,7 +2238,7 @@ async function agentCommandInternal(
         );
       }
     }
-    clearAgentRunContext(runId);
+    clearAgentRunContext(runId, lifecycleGeneration);
   }
 }
 
@@ -2227,25 +2249,30 @@ export async function agentCommand(
   deps?: CliDeps,
 ) {
   const resolvedDeps = await resolveAgentCommandDeps(deps);
-  return await withLocalGatewayRequestScope(
-    {
-      deps: resolvedDeps,
-      getRuntimeConfig,
-    },
-    async () =>
-      await agentCommandInternal(
-        {
-          ...opts,
-          // agentCommand is the trusted-operator entrypoint used by CLI/local flows.
-          // Ingress callers must opt into owner identity explicitly via
-          // agentCommandFromIngress so network-facing paths cannot inherit this default by accident.
-          senderIsOwner: opts.senderIsOwner ?? true,
-          // Local/CLI callers are trusted by default for per-run model overrides.
-          allowModelOverride: opts.allowModelOverride ?? true,
-        },
-        runtime,
-        resolvedDeps,
-      ),
+  const lifecycleGeneration =
+    opts.lifecycleGeneration ?? captureAgentRunLifecycleGeneration(opts.runId ?? "");
+  return await withAgentRunLifecycleGeneration(lifecycleGeneration, () =>
+    withLocalGatewayRequestScope(
+      {
+        deps: resolvedDeps,
+        getRuntimeConfig,
+      },
+      async () =>
+        await agentCommandInternal(
+          {
+            ...opts,
+            lifecycleGeneration,
+            // agentCommand is the trusted-operator entrypoint used by CLI/local flows.
+            // Ingress callers must opt into owner identity explicitly via
+            // agentCommandFromIngress so network-facing paths cannot inherit this default by accident.
+            senderIsOwner: opts.senderIsOwner ?? true,
+            // Local/CLI callers are trusted by default for per-run model overrides.
+            allowModelOverride: opts.allowModelOverride ?? true,
+          },
+          runtime,
+          resolvedDeps,
+        ),
+    ),
   );
 }
 
@@ -2258,10 +2285,18 @@ export async function agentCommandFromIngress(
   if (typeof opts.allowModelOverride !== "boolean") {
     throw new Error("allowModelOverride must be explicitly set for ingress agent runs.");
   }
-  return await agentCommandInternal(
-    { ...opts, senderIsOwner: opts.senderIsOwner === true },
-    runtime,
-    deps,
+  const lifecycleGeneration =
+    opts.lifecycleGeneration ?? captureAgentRunLifecycleGeneration(opts.runId ?? "");
+  return await withAgentRunLifecycleGeneration(lifecycleGeneration, () =>
+    agentCommandInternal(
+      {
+        ...opts,
+        lifecycleGeneration,
+        senderIsOwner: opts.senderIsOwner === true,
+      },
+      runtime,
+      deps,
+    ),
   );
 }
 

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -1137,6 +1137,7 @@ async function agentCommandInternal(
         sessionEntry,
         result,
         payloads,
+        assertDeliveryCurrent: () => assertAgentRunLifecycleGenerationCurrent(lifecycleGeneration),
       });
     }
 
@@ -2215,6 +2216,7 @@ async function agentCommandInternal(
         sessionEntry,
         result,
         payloads,
+        assertDeliveryCurrent: () => assertAgentRunLifecycleGenerationCurrent(lifecycleGeneration),
       };
       const deliveryResult = await deliverAgentCommandResult(
         resolveFreshSessionEntryForDelivery

--- a/src/agents/agent-run-terminal-outcome.test.ts
+++ b/src/agents/agent-run-terminal-outcome.test.ts
@@ -60,6 +60,43 @@ describe("agent run terminal outcome", () => {
     ).toBe("cancelled");
   });
 
+  it("keeps restart cancellation sticky over late completion", () => {
+    const restartCancel = buildAgentRunTerminalOutcome({
+      status: "timeout",
+      stopReason: "restart",
+      timeoutPhase: "gateway_draining",
+      providerStarted: true,
+      endedAt: 100,
+    });
+    const lateCompletion = buildAgentRunTerminalOutcome({
+      status: "ok",
+      endedAt: 200,
+    });
+
+    expect(restartCancel).toMatchObject({
+      reason: "cancelled",
+      status: "timeout",
+      stopReason: "restart",
+    });
+    expect(mergeAgentRunTerminalOutcome(restartCancel, lateCompletion)).toBe(restartCancel);
+  });
+
+  it("keeps explicit provider timeout attribution ahead of restart cancellation", () => {
+    expect(
+      buildAgentRunTerminalOutcome({
+        status: "timeout",
+        stopReason: "restart",
+        timeoutPhase: "provider",
+        providerStarted: true,
+      }),
+    ).toMatchObject({
+      reason: "hard_timeout",
+      status: "timeout",
+      stopReason: "restart",
+      timeoutPhase: "provider",
+    });
+  });
+
   it("does not treat successful model stop metadata as cancellation", () => {
     expect(
       buildAgentRunTerminalOutcome({

--- a/src/agents/agent-run-terminal-outcome.ts
+++ b/src/agents/agent-run-terminal-outcome.ts
@@ -1,6 +1,10 @@
 /** Normalizes agent run wait/liveness/timeout metadata into sticky terminal outcomes. */
 import { formatBlockedLivenessError, isBlockedLivenessState } from "../shared/agent-liveness.js";
-import { AGENT_RUN_ABORTED_ERROR, isAbortedAgentStopReason } from "./run-termination.js";
+import {
+  AGENT_RUN_ABORTED_ERROR,
+  AGENT_RUN_RESTART_ABORT_STOP_REASON,
+  isAbortedAgentStopReason,
+} from "./run-termination.js";
 import {
   normalizeAgentRunTimeoutPhase,
   normalizeProviderStarted,
@@ -99,15 +103,17 @@ export function buildAgentRunTerminalOutcome(
   const timeoutPhase = normalizeAgentRunTimeoutPhase(input.timeoutPhase);
   const providerStarted = normalizeProviderStarted(input.providerStarted);
   const rawError = asNonEmptyString(input.error);
+  const restartCancelled = stopReason === AGENT_RUN_RESTART_ABORT_STOP_REASON;
   // Queue and gateway-draining timeouts are wait-layer uncertainty. Provider
   // errors need explicit timeout attribution; providerStarted only proves reach.
   const hardTimeout =
     isHardAgentRunTimeoutPhase(timeoutPhase) ||
-    (input.status === "timeout" && providerStarted === true);
-  const aborted = isAbortedAgentStopReason(stopReason);
+    (!restartCancelled && input.status === "timeout" && providerStarted === true);
+  const aborted = isAbortedAgentStopReason(stopReason) && !restartCancelled;
   // ACP/model `stop` can be a normal successful finish. Treat rpc/stop as
   // cancellation only for non-success terminal payloads from abort paths.
-  const cancelled = input.status !== "ok" && isCancellationStopReason(stopReason);
+  const cancelled =
+    restartCancelled || (input.status !== "ok" && isCancellationStopReason(stopReason));
   const blocked = isBlockedLivenessState(livenessState);
   const error = hardTimeout
     ? rawError

--- a/src/agents/auth-profile-runtime-contract.test.ts
+++ b/src/agents/auth-profile-runtime-contract.test.ts
@@ -15,12 +15,22 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { SessionEntry } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type * as ManifestRegistryModule from "../plugins/manifest-registry.js";
-import { runAgentAttempt } from "./command/attempt-execution.js";
+import { runAgentAttempt as runAgentAttemptImpl } from "./command/attempt-execution.js";
 import type { RunEmbeddedAgentParams } from "./embedded-agent-runner/run/params.js";
 import type { EmbeddedAgentRunResult } from "./embedded-agent.js";
 import { resolveProviderIdForAuth } from "./provider-auth-aliases.js";
 
 type LoadPluginManifestRegistry = typeof ManifestRegistryModule.loadPluginManifestRegistry;
+type RunAgentAttemptParams = Parameters<typeof runAgentAttemptImpl>[0];
+
+const runAgentAttempt = (
+  params: Omit<RunAgentAttemptParams, "lifecycleGeneration"> &
+    Partial<Pick<RunAgentAttemptParams, "lifecycleGeneration">>,
+) =>
+  runAgentAttemptImpl({
+    ...params,
+    lifecycleGeneration: params.lifecycleGeneration ?? "test-generation",
+  });
 
 const loadPluginManifestRegistry = vi.hoisted(() =>
   vi.fn<LoadPluginManifestRegistry>(() => ({

--- a/src/agents/cli-runner.before-agent-reply-cron.test.ts
+++ b/src/agents/cli-runner.before-agent-reply-cron.test.ts
@@ -116,6 +116,21 @@ afterEach(() => {
 });
 
 describe("runCliAgent cron before_agent_reply seam", () => {
+  it("rejects stale lifecycle ownership before CLI preparation", async () => {
+    await expect(
+      runCliAgent({
+        ...baseRunParams,
+        lifecycleGeneration: "stale-generation",
+      }),
+    ).rejects.toMatchObject({
+      name: "AbortError",
+      message: "Agent run belongs to a stale gateway lifecycle",
+    });
+
+    expect(prepareCliRunContextMock).not.toHaveBeenCalled();
+    expect(executePreparedCliRunMock).not.toHaveBeenCalled();
+  });
+
   it("lets before_agent_reply claim cron runs before the CLI subprocess is invoked", async () => {
     const logInfoSpy = vi.spyOn(cliBackendLog, "info").mockImplementation(() => undefined);
     hasHooksMock.mockImplementation((hookName) => hookName === "before_agent_reply");

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -4,6 +4,11 @@
 import { setReplyPayloadMetadata, type ReplyPayload } from "../auto-reply/reply-payload.js";
 import { SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import { appendExactAssistantMessageToSessionTranscript } from "../config/sessions/transcript.js";
+import {
+  assertAgentRunLifecycleGenerationCurrent,
+  captureAgentRunLifecycleGeneration,
+  withAgentRunLifecycleGeneration,
+} from "../infra/agent-events.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { buildAgentHookContextChannelFields } from "../plugins/hook-agent-context.js";
@@ -348,7 +353,19 @@ async function finalizeCliContextEngineTurn(params: {
 }
 
 /** Prepares and runs one CLI-backed agent turn. */
-export async function runCliAgent(params: RunCliAgentParams): Promise<EmbeddedAgentRunResult> {
+export function runCliAgent(paramsInput: RunCliAgentParams): Promise<EmbeddedAgentRunResult> {
+  const lifecycleGeneration =
+    paramsInput.lifecycleGeneration ?? captureAgentRunLifecycleGeneration(paramsInput.runId);
+  return withAgentRunLifecycleGeneration(lifecycleGeneration, () =>
+    runCliAgentInternal({
+      ...paramsInput,
+      lifecycleGeneration,
+    }),
+  );
+}
+
+async function runCliAgentInternal(params: RunCliAgentParams): Promise<EmbeddedAgentRunResult> {
+  assertAgentRunLifecycleGenerationCurrent(params.lifecycleGeneration!);
   // Cron gate must fire before prepareCliRunContext — that call allocates
   // backend resources released only by runPreparedCliAgent's try…finally.
   params.onExecutionStarted?.();

--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -4,7 +4,10 @@
  */
 import crypto from "node:crypto";
 import { shouldLogVerbose } from "../../globals.js";
-import { emitAgentEvent } from "../../infra/agent-events.js";
+import {
+  assertAgentRunLifecycleGenerationCurrent,
+  emitAgentEvent,
+} from "../../infra/agent-events.js";
 import { isTruthyEnvValue } from "../../infra/env.js";
 import {
   resolveEventSessionKeyForPolicy,
@@ -386,6 +389,9 @@ export async function executePreparedCliRun(
 
   try {
     return await enqueueCliRun(queueKey, async () => {
+      if (params.lifecycleGeneration) {
+        assertAgentRunLifecycleGenerationCurrent(params.lifecycleGeneration);
+      }
       const cliTurnStartedAt = Date.now();
       const restoreSkillEnv = params.skillsSnapshot
         ? applySkillEnvOverridesFromSnapshot({

--- a/src/agents/cli-runner/types.ts
+++ b/src/agents/cli-runner/types.ts
@@ -63,6 +63,8 @@ export type RunCliAgentParams = {
    */
   runTimeoutOverrideMs?: number;
   runId: string;
+  /** Immutable lifecycle ownership captured when this execution was admitted. */
+  lifecycleGeneration?: string;
   lane?: string;
   jobId?: string;
   extraSystemPrompt?: string;

--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -10,8 +10,21 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { saveAuthProfileStore } from "../auth-profiles/store.js";
 import type { EmbeddedAgentRunResult } from "../embedded-agent.js";
 import { FailoverError } from "../failover-error.js";
-import { persistCliTurnTranscript, runAgentAttempt } from "./attempt-execution.js";
+import {
+  persistCliTurnTranscript,
+  runAgentAttempt as runAgentAttemptImpl,
+} from "./attempt-execution.js";
 import { resolveClaudeCliProjectDirForWorkspace } from "./claude-cli-project-dir.js";
+
+type RunAgentAttemptParams = Parameters<typeof runAgentAttemptImpl>[0];
+const runAgentAttempt = (
+  params: Omit<RunAgentAttemptParams, "lifecycleGeneration"> &
+    Partial<Pick<RunAgentAttemptParams, "lifecycleGeneration">>,
+) =>
+  runAgentAttemptImpl({
+    ...params,
+    lifecycleGeneration: params.lifecycleGeneration ?? "test-generation",
+  });
 
 const runCliAgentMock = vi.hoisted(() => vi.fn());
 const runEmbeddedAgentMock = vi.hoisted(() => vi.fn());

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -43,6 +43,7 @@ import { resolveAvailableAgentHarnessPolicy } from "../harness/selection.js";
 import { resolveCliRuntimeExecutionProvider } from "../model-runtime-aliases.js";
 import { isCliProvider } from "../model-selection.js";
 import { resolveOpenAIRuntimeProvider } from "../openai-routing.js";
+import { resolveAgentRunAbortLifecycleFields } from "../run-termination.js";
 import { buildAgentRuntimeAuthPlan } from "../runtime-plan/auth.js";
 import type { AgentMessage } from "../runtime/index.js";
 import { acquireSessionWriteLock, resolveSessionWriteLockOptions } from "../session-write-lock.js";
@@ -780,12 +781,13 @@ export function buildAcpResult(params: {
     text: params.payloadText,
   });
   const payloads = normalizedFinalPayload ? [normalizedFinalPayload] : [];
+  const abortFields = resolveAgentRunAbortLifecycleFields(params.abortSignal);
   return {
     payloads,
     meta: {
       durationMs: Date.now() - params.startedAt,
-      aborted: params.abortSignal?.aborted === true,
-      stopReason: params.stopReason,
+      aborted: abortFields.aborted ?? false,
+      stopReason: abortFields.stopReason ?? params.stopReason,
     },
   };
 }
@@ -893,7 +895,11 @@ export function emitAcpRuntimeEvent(params: {
   });
 }
 
-export function emitAcpLifecycleEnd(params: { runId: string; lifecycleGeneration?: string }) {
+export function emitAcpLifecycleEnd(params: {
+  runId: string;
+  lifecycleGeneration?: string;
+  abortSignal?: AbortSignal;
+}) {
   emitAgentEvent({
     runId: params.runId,
     ...(params.lifecycleGeneration ? { lifecycleGeneration: params.lifecycleGeneration } : {}),
@@ -901,6 +907,7 @@ export function emitAcpLifecycleEnd(params: { runId: string; lifecycleGeneration
     data: {
       phase: "end",
       endedAt: Date.now(),
+      ...resolveAgentRunAbortLifecycleFields(params.abortSignal),
     },
   });
 }
@@ -910,6 +917,7 @@ export function emitAcpLifecycleError(params: {
   error: unknown;
   sessionKey?: string;
   lifecycleGeneration?: string;
+  abortSignal?: AbortSignal;
 }) {
   emitAgentEvent({
     runId: params.runId,
@@ -920,6 +928,7 @@ export function emitAcpLifecycleError(params: {
       phase: "error",
       error: formatAcpErrorChain(params.error),
       endedAt: Date.now(),
+      ...resolveAgentRunAbortLifecycleFields(params.abortSignal),
     },
   });
 }

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -446,6 +446,7 @@ export function runAgentAttempt(params: {
   timeoutMs: number;
   runTimeoutOverrideMs?: number;
   runId: string;
+  lifecycleGeneration: string;
   opts: AgentCommandOpts;
   runContext: ReturnType<typeof resolveAgentRunContext>;
   spawnedBy: string | undefined;
@@ -469,6 +470,7 @@ export function runAgentAttempt(params: {
   sessionHasHistory?: boolean;
   suppressPromptPersistenceOnRetry?: boolean;
   onUserMessagePersisted?: (message: Extract<AgentMessage, { role: "user" }>) => void;
+  onLifecycleGenerationChanged?: (lifecycleGeneration: string) => void;
 }) {
   const isRawModelRun = params.opts.modelRun === true || params.opts.promptMode === "none";
   const claudeCliFallbackPrelude =
@@ -617,6 +619,7 @@ export function runAgentAttempt(params: {
         timeoutMs: params.timeoutMs,
         runTimeoutOverrideMs: params.runTimeoutOverrideMs,
         runId: params.runId,
+        lifecycleGeneration: params.lifecycleGeneration,
         lane: params.opts.lane,
         extraSystemPrompt: params.opts.extraSystemPrompt,
         inputProvenance: params.opts.inputProvenance,
@@ -733,6 +736,7 @@ export function runAgentAttempt(params: {
     bashElevated: params.opts.bashElevated,
     timeoutMs: params.timeoutMs,
     runId: params.runId,
+    lifecycleGeneration: params.lifecycleGeneration,
     lane: params.opts.lane,
     abortSignal: params.opts.abortSignal,
     extraSystemPrompt: params.opts.extraSystemPrompt,
@@ -755,6 +759,12 @@ export function runAgentAttempt(params: {
     deferTerminalLifecycleEnd: params.deferTerminalLifecycleEnd,
     suppressNextUserMessagePersistence: params.suppressPromptPersistenceOnRetry === true,
     onUserMessagePersisted: params.onUserMessagePersisted,
+    onExecutionStarted: (info) => {
+      if (info?.lifecycleGeneration) {
+        params.onLifecycleGenerationChanged?.(info.lifecycleGeneration);
+      }
+    },
+    onSessionIdChanged: params.opts.onSessionIdChanged,
     bootstrapPromptWarningSignaturesSeen,
     bootstrapPromptWarningSignature,
   });
@@ -780,9 +790,14 @@ export function buildAcpResult(params: {
   };
 }
 
-export function emitAcpLifecycleStart(params: { runId: string; startedAt: number }) {
+export function emitAcpLifecycleStart(params: {
+  runId: string;
+  startedAt: number;
+  lifecycleGeneration?: string;
+}) {
   emitAgentEvent({
     runId: params.runId,
+    ...(params.lifecycleGeneration ? { lifecycleGeneration: params.lifecycleGeneration } : {}),
     stream: "lifecycle",
     data: {
       phase: "start",
@@ -878,9 +893,10 @@ export function emitAcpRuntimeEvent(params: {
   });
 }
 
-export function emitAcpLifecycleEnd(params: { runId: string }) {
+export function emitAcpLifecycleEnd(params: { runId: string; lifecycleGeneration?: string }) {
   emitAgentEvent({
     runId: params.runId,
+    ...(params.lifecycleGeneration ? { lifecycleGeneration: params.lifecycleGeneration } : {}),
     stream: "lifecycle",
     data: {
       phase: "end",
@@ -893,9 +909,11 @@ export function emitAcpLifecycleError(params: {
   runId: string;
   error: unknown;
   sessionKey?: string;
+  lifecycleGeneration?: string;
 }) {
   emitAgentEvent({
     runId: params.runId,
+    ...(params.lifecycleGeneration ? { lifecycleGeneration: params.lifecycleGeneration } : {}),
     stream: "lifecycle",
     ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
     data: {

--- a/src/agents/command/delivery.test.ts
+++ b/src/agents/command/delivery.test.ts
@@ -6,6 +6,7 @@ import type { CliDeps } from "../../cli/outbound-send-deps.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import { createOutboundTestPlugin, createTestRegistry } from "../../test-utils/channel-plugins.js";
+import { createAgentRunRestartAbortError } from "../run-termination.js";
 import { deliverAgentCommandResult, normalizeAgentCommandReplyPayloads } from "./delivery.js";
 import type { AgentCommandOpts } from "./types.js";
 
@@ -237,6 +238,130 @@ describe("normalizeAgentCommandReplyPayloads", () => {
 
     expect(normalized).toHaveLength(1);
     expectTextPayload(normalized[0], "Choose [[slack_buttons: Retry:retry]]");
+  });
+
+  it("rechecks delivery ownership after asynchronous payload preparation", async () => {
+    let deliveryCurrent = true;
+    createReplyMediaPathNormalizerMock.mockImplementationOnce(
+      (..._args: unknown[]) =>
+        async (payload: ReplyPayload): Promise<ReplyPayload> => {
+          deliveryCurrent = false;
+          return payload;
+        },
+    );
+
+    await expect(
+      deliverAgentCommandResult({
+        cfg: {
+          agents: {
+            list: [{ id: "tester", workspace: "/tmp/agent-workspace" }],
+          },
+        } as OpenClawConfig,
+        deps: {} as CliDeps,
+        runtime: { log: vi.fn(), error: vi.fn() } as never,
+        opts: {
+          message: "go",
+          deliver: true,
+          replyChannel: "slack",
+          replyTo: "#general",
+        } as AgentCommandOpts,
+        outboundSession: undefined,
+        sessionEntry: undefined,
+        payloads: [{ text: "result", mediaUrls: ["./out/photo.png"] }],
+        result: createResult(),
+        assertDeliveryCurrent: () => {
+          if (!deliveryCurrent) {
+            throw new Error("stale lifecycle");
+          }
+        },
+      }),
+    ).rejects.toThrow("stale lifecycle");
+    expect(deliverOutboundPayloadsMock).not.toHaveBeenCalled();
+  });
+
+  it("forwards the run abort signal into durable delivery", async () => {
+    const controller = new AbortController();
+    controller.abort(createAgentRunRestartAbortError());
+
+    await deliverMediaReplyForTest(undefined, {
+      abortSignal: controller.signal,
+    });
+
+    const deliverySignal = (
+      deliverOutboundPayloadsMock.mock.calls[0]?.[0] as { abortSignal?: AbortSignal } | undefined
+    )?.abortSignal;
+    expect(deliverySignal).toBeInstanceOf(AbortSignal);
+    expect(deliverySignal?.aborted).toBe(true);
+    expect(deliverySignal?.reason).toBe(controller.signal.reason);
+  });
+
+  it("does not cancel final delivery for an ordinary run timeout", async () => {
+    const controller = new AbortController();
+    const timeoutError = new Error("run timed out");
+    timeoutError.name = "TimeoutError";
+    controller.abort(timeoutError);
+
+    await deliverMediaReplyForTest(undefined, {
+      abortSignal: controller.signal,
+    });
+
+    const deliverySignal = (
+      deliverOutboundPayloadsMock.mock.calls[0]?.[0] as { abortSignal?: AbortSignal } | undefined
+    )?.abortSignal;
+    expect(deliverySignal).toBeInstanceOf(AbortSignal);
+    expect(deliverySignal?.aborted).toBe(false);
+  });
+
+  it("cancels durable delivery when restart arrives before the durable intent", async () => {
+    const controller = new AbortController();
+    let deliverySignal: AbortSignal | undefined;
+    deliverOutboundPayloadsMock.mockImplementationOnce(async (params: unknown) => {
+      deliverySignal = (params as { abortSignal?: AbortSignal }).abortSignal;
+      controller.abort(createAgentRunRestartAbortError());
+      expect(deliverySignal?.aborted).toBe(true);
+      throw deliverySignal?.reason;
+    });
+
+    await expect(
+      deliverMediaReplyForTest(undefined, {
+        abortSignal: controller.signal,
+      }),
+    ).rejects.toThrow("agent run aborted for restart");
+
+    expect(deliverySignal?.reason).toBe(controller.signal.reason);
+  });
+
+  it("finishes durable delivery when restart arrives after the durable intent", async () => {
+    const controller = new AbortController();
+    let deliverySignal: AbortSignal | undefined;
+    deliverOutboundPayloadsMock.mockImplementationOnce(async (params: unknown) => {
+      const request = params as {
+        abortSignal?: AbortSignal;
+        onDeliveryIntent?: (intent: {
+          id: string;
+          channel: string;
+          to: string;
+          queuePolicy: "required";
+        }) => void;
+      };
+      deliverySignal = request.abortSignal;
+      request.onDeliveryIntent?.({
+        id: "intent-after-restart",
+        channel: "discord",
+        to: "channel:123",
+        queuePolicy: "required",
+      });
+      controller.abort(createAgentRunRestartAbortError());
+      expect(deliverySignal?.aborted).toBe(false);
+      return [{ channel: "discord", messageId: "sent-after-restart" }];
+    });
+
+    const result = await deliverMediaReplyForTest(undefined, {
+      abortSignal: controller.signal,
+    });
+
+    expect(result.deliverySucceeded).toBe(true);
+    expect(deliverySignal?.aborted).toBe(false);
   });
 
   it("renders response prefix templates with the selected runtime model", () => {

--- a/src/agents/command/delivery.ts
+++ b/src/agents/command/delivery.ts
@@ -35,10 +35,35 @@ import { isInternalMessageChannel } from "../../utils/message-channel.js";
 import type { MessagingToolSend } from "../embedded-agent-messaging.types.js";
 import type { EmbeddedAgentRunMeta } from "../embedded-agent-runner/types.js";
 import { isNestedAgentLane } from "../lanes.js";
+import { isAgentRunRestartAbortReason } from "../run-termination.js";
 import type { AgentCommandOpts, AgentCommandResultMetaOverrides } from "./types.js";
 
 type RunResult = Awaited<ReturnType<(typeof import("../embedded-agent.js"))["runEmbeddedAgent"]>>;
 type DurableSendResult = Awaited<ReturnType<typeof sendDurableMessageBatch>>;
+
+function createRestartOnlyAbortSignal(source: AbortSignal | undefined): {
+  signal?: AbortSignal;
+  dispose: () => void;
+} {
+  if (!source) {
+    return { dispose: () => {} };
+  }
+  const controller = new AbortController();
+  const onAbort = () => {
+    if (isAgentRunRestartAbortReason(source.reason)) {
+      controller.abort(source.reason);
+    }
+  };
+  if (source.aborted) {
+    onAbort();
+  } else {
+    source.addEventListener("abort", onAbort, { once: true });
+  }
+  return {
+    signal: controller.signal,
+    dispose: () => source.removeEventListener("abort", onAbort),
+  };
+}
 
 /** Per-payload durable delivery status. */
 export type AgentCommandDeliveryPayloadStatus = "sent" | "suppressed" | "failed";
@@ -109,6 +134,7 @@ type DeliverAgentCommandResultParams = {
   sessionEntry: SessionEntry | undefined;
   result: RunResult;
   payloads: RunResult["payloads"];
+  assertDeliveryCurrent?: () => void;
 } & FreshSessionDeliveryRefreshParams;
 
 function normalizeDeliverySessionId(value: string | undefined): string | undefined {
@@ -426,6 +452,7 @@ export function normalizeAgentCommandReplyPayloads(params: {
 export async function deliverAgentCommandResult(
   params: DeliverAgentCommandResultParams,
 ): Promise<AgentCommandDeliveryResult> {
+  params.assertDeliveryCurrent?.();
   const { cfg, deps, runtime, opts, outboundSession, sessionEntry, payloads, result } = params;
   const effectiveSessionKey = outboundSession?.key ?? opts.sessionKey;
   const deliveryAgentId =
@@ -458,10 +485,12 @@ export async function deliverAgentCommandResult(
       turnSourceAccountId,
       turnSourceThreadId,
     });
+    params.assertDeliveryCurrent?.();
     let deliveryChannel = deliveryPlan.resolvedChannel;
     if (deliver && isInternalMessageChannel(deliveryChannel) && !explicitChannelHint) {
       try {
         const selection = await resolveMessageChannelSelection({ cfg });
+        params.assertDeliveryCurrent?.();
         deliveryChannel = selection.channel;
       } catch {
         // Keep the internal channel marker; error handling below reports the failure.
@@ -559,8 +588,10 @@ export async function deliverAgentCommandResult(
   };
 
   let deliveryRouting = await resolveDeliveryRouting(sessionEntry);
+  params.assertDeliveryCurrent?.();
   if (isRetryableFreshSessionRoutingFailure(deliveryRouting)) {
     const freshSessionEntry = await params.resolveFreshSessionEntryForDelivery?.();
+    params.assertDeliveryCurrent?.();
     const expectedFreshSessionId =
       params.expectedSessionIdForFreshDelivery ?? sessionEntry?.sessionId;
     if (
@@ -569,6 +600,7 @@ export async function deliverAgentCommandResult(
       isFreshDeliverySessionMatch(freshSessionEntry, expectedFreshSessionId)
     ) {
       const freshRouting = await resolveDeliveryRouting(freshSessionEntry);
+      params.assertDeliveryCurrent?.();
       if (!deliveryRoutingFailureReason(freshRouting)) {
         if (!opts.json) {
           runtime.log(
@@ -652,6 +684,7 @@ export async function deliverAgentCommandResult(
           accountId: resolvedAccountId,
         })
       : normalizedReplyPayloads;
+  params.assertDeliveryCurrent?.();
   const outboundPayloadPlan = createOutboundPayloadPlan(mediaNormalizedReplyPayloads);
   const normalizedPayloads = projectOutboundPayloadPlanForJson(outboundPayloadPlan);
   const resultMeta = mergeResultMetaOverrides(result.meta, opts.resultMetaOverrides);
@@ -710,21 +743,33 @@ export async function deliverAgentCommandResult(
   }
   if (deliver && deliveryChannel && !isInternalMessageChannel(deliveryChannel)) {
     if (deliveryTarget && !deliveryStatus) {
-      const send = await sendDurableMessageBatch({
-        cfg,
-        channel: deliveryChannel,
-        to: deliveryTarget,
-        accountId: resolvedAccountId,
-        payloads: deliveryPayloads,
-        session: outboundSession,
-        replyToId: resolvedReplyToId ?? null,
-        threadId: resolvedThreadTarget ?? null,
-        bestEffort: bestEffortDeliver,
-        durability: bestEffortDeliver ? "best_effort" : "required",
-        onError: logDeliveryError,
-        onPayload: logPayload,
-        deps: createOutboundSendDeps(deps),
-      });
+      params.assertDeliveryCurrent?.();
+      const restartAbort = createRestartOnlyAbortSignal(opts.abortSignal);
+      let send: DurableSendResult;
+      try {
+        send = await sendDurableMessageBatch({
+          cfg,
+          channel: deliveryChannel,
+          to: deliveryTarget,
+          accountId: resolvedAccountId,
+          payloads: deliveryPayloads,
+          session: outboundSession,
+          replyToId: resolvedReplyToId ?? null,
+          threadId: resolvedThreadTarget ?? null,
+          bestEffort: bestEffortDeliver,
+          durability: bestEffortDeliver ? "best_effort" : "required",
+          signal: restartAbort.signal,
+          onDeliveryIntent: restartAbort.dispose,
+          onError: logDeliveryError,
+          onPayload: logPayload,
+          deps: createOutboundSendDeps(deps),
+        });
+      } finally {
+        restartAbort.dispose();
+      }
+      if (restartAbort.signal?.aborted && send.status === "failed") {
+        throw restartAbort.signal.reason;
+      }
       deliveryStatus = deliveryStatusFromDurableSend(send);
       if (!bestEffortDeliver && (send.status === "failed" || send.status === "partial_failed")) {
         emitJsonEnvelope(deliveryStatus);

--- a/src/agents/command/types.ts
+++ b/src/agents/command/types.ts
@@ -108,6 +108,8 @@ export type AgentCommandOpts = {
   abortSignal?: AbortSignal;
   lane?: string;
   runId?: string;
+  /** Immutable gateway lifecycle ownership captured when this run was admitted. */
+  lifecycleGeneration?: string;
   extraSystemPrompt?: string;
   /** Bootstrap workspace context injection mode for this run. */
   bootstrapContextMode?: "full" | "lightweight";
@@ -141,6 +143,8 @@ export type AgentCommandOpts = {
   resultMetaOverrides?: AgentCommandResultMetaOverrides;
   /** Called when the actual run model is selected, including fallback retries. */
   onActiveModelSelected?: (ctx: { provider: string; model: string }) => void;
+  /** Called when compaction rotates the active run onto a successor session. */
+  onSessionIdChanged?: (sessionId: string) => void;
   /** Internal one-shot model probe mode: no tools, no workspace/chat prompt policy. */
   modelRun?: boolean;
   /** Internal prompt-mode override for trusted local/gateway callsites. */

--- a/src/agents/embedded-agent-runner/run-state.ts
+++ b/src/agents/embedded-agent-runner/run-state.ts
@@ -6,6 +6,7 @@ import {
   getActiveReplyRunCount,
   listActiveReplyRunSessionKeys,
   listActiveReplyRunSessionIds,
+  resolveActiveReplyRunSessionId,
 } from "../../auto-reply/reply/reply-run-registry.js";
 import { resolveGlobalSingleton } from "../../shared/global-singleton.js";
 
@@ -133,4 +134,16 @@ export function listActiveEmbeddedRunSessionIds(): string[] {
       ...listActiveReplyRunSessionIds(),
     ]),
   ].toSorted((a, b) => a.localeCompare(b));
+}
+
+/** Resolves the current session id for an active run after resets or compaction. */
+export function resolveActiveEmbeddedRunSessionId(sessionKey: string): string | undefined {
+  const normalizedSessionKey = sessionKey.trim();
+  if (!normalizedSessionKey) {
+    return undefined;
+  }
+  return (
+    resolveActiveReplyRunSessionId(normalizedSessionKey) ??
+    ACTIVE_EMBEDDED_RUN_SESSION_IDS_BY_KEY.get(normalizedSessionKey)
+  );
 }

--- a/src/agents/embedded-agent-runner/run-state.ts
+++ b/src/agents/embedded-agent-runner/run-state.ts
@@ -23,7 +23,7 @@ export type EmbeddedAgentQueueHandle = {
   isCompacting: () => boolean;
   supportsTranscriptCommitWait?: boolean;
   cancel?: (reason?: "user_abort" | "restart" | "superseded") => void;
-  abort: () => void;
+  abort: (reason?: "restart") => void;
   sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
 };
 

--- a/src/agents/embedded-agent-runner/run.overflow-compaction.test.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.test.ts
@@ -840,6 +840,7 @@ describe("runEmbeddedAgent overflow compaction trigger routing", () => {
     const runPromise = runEmbeddedAgent({
       ...overflowBaseRunParams,
       runId: "queued-across-restart",
+      trigger: "user",
       lifecycleGeneration: getAgentEventLifecycleGeneration(),
       onExecutionStarted,
       enqueue: async (task) => {
@@ -872,6 +873,40 @@ describe("runEmbeddedAgent overflow compaction trigger routing", () => {
       lifecycleGeneration: currentLifecycleGeneration,
     });
     resetAgentRunContextForTest();
+  });
+
+  it("rejects background work queued across lifecycle rotation", async () => {
+    resetAgentRunContextForTest();
+    let enqueueCount = 0;
+    let runQueuedTask: (() => void) | undefined;
+    const runPromise = runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      runId: "background-queued-across-restart",
+      trigger: "cron",
+      lifecycleGeneration: getAgentEventLifecycleGeneration(),
+      enqueue: async (task) => {
+        enqueueCount += 1;
+        if (enqueueCount === 1) {
+          return await task();
+        }
+        return await new Promise((resolve, reject) => {
+          runQueuedTask = () => {
+            void Promise.resolve().then(task).then(resolve, reject);
+          };
+        });
+      },
+    });
+    await vi.waitFor(() => expect(runQueuedTask).toBeTypeOf("function"));
+
+    rotateAgentEventLifecycleGeneration();
+    runQueuedTask?.();
+
+    await expect(runPromise).rejects.toMatchObject({
+      name: "AbortError",
+      message: "Agent run belongs to a stale gateway lifecycle",
+    });
+    expect(mockedRunEmbeddedAttempt).not.toHaveBeenCalled();
+    expect(getAgentRunContext("background-queued-across-restart")).toBeUndefined();
   });
 
   it("does not claim a rebound generation after queued work was aborted", async () => {

--- a/src/agents/embedded-agent-runner/run.overflow-compaction.test.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.test.ts
@@ -3,6 +3,15 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createReplyOperation } from "../../auto-reply/reply/reply-run-registry.js";
+import {
+  claimAgentRunContext,
+  getAgentEventLifecycleGeneration,
+  getAgentRunContext,
+  resetAgentRunContextForTest,
+  rotateAgentEventLifecycleGeneration,
+  withAgentRunLifecycleGeneration,
+} from "../../infra/agent-events.js";
 import type { AgentHarness } from "../harness/types.js";
 import type { AgentInternalEvent } from "../internal-events.js";
 import type { AgentRuntimePlan } from "../runtime-plan/types.js";
@@ -805,6 +814,121 @@ describe("runEmbeddedAgent overflow compaction trigger routing", () => {
     const attemptParams = mockCallArg(mockedRunEmbeddedAttempt) as EmbeddedRunAttemptParams;
     expect(attemptParams?.runtimePlan).toBe(runtimePlan);
     expect(attemptParams?.internalEvents).toBe(internalEvents);
+  });
+
+  it("keeps an explicitly captured lifecycle generation across the embedded attempt", async () => {
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
+    const lifecycleGeneration = getAgentEventLifecycleGeneration();
+
+    await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      runId: "run-before-restart",
+      lifecycleGeneration,
+    });
+
+    expectMockCallFields(mockedRunEmbeddedAttempt, {
+      lifecycleGeneration,
+    });
+  });
+
+  it("rebinds preserved queued work to the current lifecycle generation", async () => {
+    resetAgentRunContextForTest();
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
+    let enqueueCount = 0;
+    let runQueuedTask: (() => void) | undefined;
+    const onExecutionStarted = vi.fn();
+    const runPromise = runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      runId: "queued-across-restart",
+      lifecycleGeneration: getAgentEventLifecycleGeneration(),
+      onExecutionStarted,
+      enqueue: async (task) => {
+        enqueueCount += 1;
+        if (enqueueCount === 1) {
+          return await task();
+        }
+        return await new Promise((resolve, reject) => {
+          runQueuedTask = () => {
+            void Promise.resolve().then(task).then(resolve, reject);
+          };
+        });
+      },
+    });
+    await vi.waitFor(() => expect(runQueuedTask).toBeTypeOf("function"));
+
+    const currentLifecycleGeneration = rotateAgentEventLifecycleGeneration();
+    runQueuedTask?.();
+    await runPromise;
+
+    expectMockCallFields(mockedRunEmbeddedAttempt, {
+      lifecycleGeneration: currentLifecycleGeneration,
+    });
+    expect(getAgentRunContext("queued-across-restart")).toEqual(
+      expect.objectContaining({
+        lifecycleGeneration: currentLifecycleGeneration,
+      }),
+    );
+    expect(onExecutionStarted).toHaveBeenCalledWith({
+      lifecycleGeneration: currentLifecycleGeneration,
+    });
+    resetAgentRunContextForTest();
+  });
+
+  it("does not claim a rebound generation after queued work was aborted", async () => {
+    resetAgentRunContextForTest();
+    let enqueueCount = 0;
+    let runQueuedTask: (() => void) | undefined;
+    const abortController = new AbortController();
+    const onExecutionStarted = vi.fn();
+    const runPromise = runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      runId: "aborted-queued-across-restart",
+      lifecycleGeneration: getAgentEventLifecycleGeneration(),
+      abortSignal: abortController.signal,
+      onExecutionStarted,
+      enqueue: async (task) => {
+        enqueueCount += 1;
+        if (enqueueCount === 1) {
+          return await task();
+        }
+        return await new Promise((resolve, reject) => {
+          runQueuedTask = () => {
+            void Promise.resolve().then(task).then(resolve, reject);
+          };
+        });
+      },
+    });
+    await vi.waitFor(() => expect(runQueuedTask).toBeTypeOf("function"));
+
+    const runResult = runPromise.catch((error: unknown) => error);
+    rotateAgentEventLifecycleGeneration();
+    abortController.abort();
+    runQueuedTask?.();
+
+    await expect(runResult).resolves.toMatchObject({ name: "AbortError" });
+    expect(onExecutionStarted).not.toHaveBeenCalled();
+    expect(getAgentRunContext("aborted-queued-across-restart")).toBeUndefined();
+  });
+
+  it("rejects stale descendants admitted after lifecycle rotation", async () => {
+    resetAgentRunContextForTest();
+    const preRestartGeneration = getAgentEventLifecycleGeneration();
+    rotateAgentEventLifecycleGeneration();
+
+    const runPromise = withAgentRunLifecycleGeneration(preRestartGeneration, () =>
+      runEmbeddedAgent({
+        ...overflowBaseRunParams,
+        runId: "stale-descendant",
+        enqueue: async (task) => await task(),
+      }),
+    );
+
+    await expect(runPromise).rejects.toMatchObject({
+      name: "AbortError",
+      message: "Agent run belongs to a stale gateway lifecycle",
+    });
+    expect(mockedRunEmbeddedAttempt).not.toHaveBeenCalled();
+    expect(getAgentRunContext("stale-descendant")).toBeUndefined();
   });
 
   it("marks user-triggered session queue work as foreground", async () => {
@@ -2207,20 +2331,71 @@ describe("runEmbeddedAgent overflow compaction trigger routing", () => {
       }),
     );
 
-    await runEmbeddedAgent(overflowBaseRunParams);
+    const replyOperation = createReplyOperation({
+      sessionKey: "test-key",
+      sessionId: "test-session",
+      resetTriggered: false,
+    });
+    const onSessionIdChanged = vi.fn();
+    replyOperation.setPhase("running");
+    try {
+      await runEmbeddedAgent({
+        ...overflowBaseRunParams,
+        replyOperation,
+        onSessionIdChanged,
+      });
 
-    expectMockCallFields(
-      mockedRunEmbeddedAttempt,
-      {
+      expectMockCallFields(
+        mockedRunEmbeddedAttempt,
+        {
+          sessionId: "rotated-session",
+          sessionFile: "/tmp/rotated-session.json",
+        },
+        1,
+      );
+      expectMockCallFields(mockedRunContextEngineMaintenance, {
         sessionId: "rotated-session",
         sessionFile: "/tmp/rotated-session.json",
-      },
-      1,
-    );
-    expectMockCallFields(mockedRunContextEngineMaintenance, {
-      sessionId: "rotated-session",
-      sessionFile: "/tmp/rotated-session.json",
+      });
+      expect(replyOperation.sessionId).toBe("rotated-session");
+      expect(onSessionIdChanged).toHaveBeenCalledWith("rotated-session");
+    } finally {
+      replyOperation.complete();
+    }
+  });
+
+  it("does not let an old execution rotate a newer same-id run context", async () => {
+    resetAgentRunContextForTest();
+    const currentLifecycleGeneration = rotateAgentEventLifecycleGeneration();
+    claimAgentRunContext("shared-run", {
+      sessionKey: "new-session-key",
+      sessionId: "new-session",
+      lifecycleGeneration: currentLifecycleGeneration,
     });
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        promptError: null,
+        sessionIdUsed: "old-rotated-session",
+      }),
+    );
+
+    await expect(
+      runEmbeddedAgent({
+        ...overflowBaseRunParams,
+        runId: "shared-run",
+        lifecycleGeneration: "pre-restart",
+      }),
+    ).rejects.toMatchObject({ name: "AbortError" });
+
+    expect(mockedRunEmbeddedAttempt).not.toHaveBeenCalled();
+    expect(getAgentRunContext("shared-run")).toEqual(
+      expect.objectContaining({
+        sessionKey: "new-session-key",
+        sessionId: "new-session",
+        lifecycleGeneration: currentLifecycleGeneration,
+      }),
+    );
+    resetAgentRunContextForTest();
   });
 
   it("guards thrown engine-owned overflow compaction attempts", async () => {

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -578,9 +578,14 @@ async function runEmbeddedAgentInternal(
       const existingContext = getAgentRunContext(params.runId);
       if (lifecycleGeneration !== currentLifecycleGeneration) {
         const wasQueuedBeforeRotation = queuedLifecycleGeneration === lifecycleGeneration;
+        const canResumeAcrossRotation = sessionQueuePriority === "foreground";
         const newerSameIdExecutionOwnsContext =
           existingContext?.lifecycleGeneration === currentLifecycleGeneration;
-        if (!wasQueuedBeforeRotation || newerSameIdExecutionOwnsContext) {
+        if (
+          !wasQueuedBeforeRotation ||
+          !canResumeAcrossRotation ||
+          newerSameIdExecutionOwnsContext
+        ) {
           assertAgentRunLifecycleGenerationCurrent(lifecycleGeneration);
         }
         lifecycleGeneration = currentLifecycleGeneration;

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -14,7 +14,16 @@ import {
   resolveContextEngine,
   resolveContextEngineOwnerPluginId,
 } from "../../context-engine/registry.js";
-import { emitAgentPlanEvent, registerAgentRunContext } from "../../infra/agent-events.js";
+import {
+  assertAgentRunLifecycleGenerationCurrent,
+  captureAgentRunLifecycleGeneration,
+  claimAgentRunContext,
+  emitAgentPlanEvent,
+  getAgentEventLifecycleGeneration,
+  getAgentRunContext,
+  registerAgentRunContext,
+  withAgentRunLifecycleGeneration,
+} from "../../infra/agent-events.js";
 import { sleepWithAbort } from "../../infra/backoff.js";
 import { freezeDiagnosticTraceContext } from "../../infra/diagnostic-trace-context.js";
 import { formatErrorMessage } from "../../infra/errors.js";
@@ -497,10 +506,25 @@ function buildHandledReplyPayloads(reply?: ReplyPayload) {
   ];
 }
 
-export async function runEmbeddedAgent(
+export function runEmbeddedAgent(
+  paramsInput: RunEmbeddedAgentParams,
+): Promise<EmbeddedAgentRunResult> {
+  const lifecycleGeneration =
+    paramsInput.lifecycleGeneration ?? captureAgentRunLifecycleGeneration(paramsInput.runId);
+  return withAgentRunLifecycleGeneration(lifecycleGeneration, () =>
+    runEmbeddedAgentInternal({
+      ...paramsInput,
+      lifecycleGeneration,
+    }),
+  );
+}
+
+async function runEmbeddedAgentInternal(
   paramsInput: RunEmbeddedAgentParams,
 ): Promise<EmbeddedAgentRunResult> {
   let params = paramsInput;
+  let lifecycleGeneration = params.lifecycleGeneration!;
+  const queuedLifecycleGeneration = getAgentEventLifecycleGeneration();
   // Resolve sessionKey early so all downstream consumers (hooks, LCM, compaction)
   // receive a non-null key even when callers omit it. See #60552.
   const effectiveSessionKey = backfillSessionKey({
@@ -520,6 +544,21 @@ export async function runEmbeddedAgent(
   const noteLaneTaskProgress = () => {
     laneTaskProgressAtMs = Date.now();
   };
+  const throwIfAborted = () => {
+    if (!params.abortSignal?.aborted) {
+      return;
+    }
+    const reason = params.abortSignal.reason;
+    if (reason instanceof Error) {
+      throw reason;
+    }
+    const abortErr =
+      reason !== undefined
+        ? new Error("Operation aborted", { cause: reason })
+        : new Error("Operation aborted");
+    abortErr.name = "AbortError";
+    throw abortErr;
+  };
   const withLaneTimeout = (opts?: CommandQueueEnqueueOptions) =>
     withEmbeddedRunLaneTimeout(
       {
@@ -533,9 +572,31 @@ export async function runEmbeddedAgent(
       ...opts,
       priority: sessionQueuePriority,
     };
+    const taskWithCurrentLifecycle = () => {
+      throwIfAborted();
+      const currentLifecycleGeneration = getAgentEventLifecycleGeneration();
+      const existingContext = getAgentRunContext(params.runId);
+      if (lifecycleGeneration !== currentLifecycleGeneration) {
+        const wasQueuedBeforeRotation = queuedLifecycleGeneration === lifecycleGeneration;
+        const newerSameIdExecutionOwnsContext =
+          existingContext?.lifecycleGeneration === currentLifecycleGeneration;
+        if (!wasQueuedBeforeRotation || newerSameIdExecutionOwnsContext) {
+          assertAgentRunLifecycleGenerationCurrent(lifecycleGeneration);
+        }
+        lifecycleGeneration = currentLifecycleGeneration;
+        params = { ...params, lifecycleGeneration };
+      }
+      claimAgentRunContext(params.runId, {
+        ...existingContext,
+        sessionKey: params.sessionKey ?? existingContext?.sessionKey,
+        sessionId: params.sessionId ?? existingContext?.sessionId,
+        lifecycleGeneration,
+      });
+      return withAgentRunLifecycleGeneration(lifecycleGeneration, task);
+    };
     return params.enqueue
-      ? params.enqueue(task, withLaneTimeout(globalOpts))
-      : enqueueCommandInLane(globalLane, task, withLaneTimeout(globalOpts));
+      ? params.enqueue(taskWithCurrentLifecycle, withLaneTimeout(globalOpts))
+      : enqueueCommandInLane(globalLane, taskWithCurrentLifecycle, withLaneTimeout(globalOpts));
   };
   const enqueueSession = <T>(task: () => Promise<T>, opts?: CommandQueueEnqueueOptions) => {
     const sessionOpts: CommandQueueEnqueueOptions = { ...opts, priority: sessionQueuePriority };
@@ -552,22 +613,6 @@ export async function runEmbeddedAgent(
         : "plain"
       : "markdown");
   const isProbeSession = params.sessionId?.startsWith("probe-") ?? false;
-
-  const throwIfAborted = () => {
-    if (!params.abortSignal?.aborted) {
-      return;
-    }
-    const reason = params.abortSignal.reason;
-    if (reason instanceof Error) {
-      throw reason;
-    }
-    const abortErr =
-      reason !== undefined
-        ? new Error("Operation aborted", { cause: reason })
-        : new Error("Operation aborted");
-    abortErr.name = "AbortError";
-    throw abortErr;
-  };
 
   throwIfAborted();
 
@@ -610,7 +655,7 @@ export async function runEmbeddedAgent(
           log.trace(message);
         }
       };
-      params.onExecutionStarted?.();
+      params.onExecutionStarted?.({ lifecycleGeneration });
       notifyExecutionPhase("runner_entered");
       const workspaceResolution = resolveRunWorkspaceDir({
         workspaceDir: params.workspaceDir,
@@ -1282,6 +1327,20 @@ export async function runEmbeddedAgent(
       const rateLimitProfileRotationLimit = resolveRateLimitProfileRotationLimit(params.config);
       let activeSessionId = params.sessionId;
       let activeSessionFile = params.sessionFile;
+      const adoptActiveSessionId = (nextSessionId: string | undefined) => {
+        if (!nextSessionId || nextSessionId === activeSessionId) {
+          return;
+        }
+        activeSessionId = nextSessionId;
+        // Keep every active-run owner on the rotated identity. Restart recovery
+        // uses the reply registry while lifecycle persistence uses run context.
+        params.replyOperation?.updateSessionId(activeSessionId);
+        params.onSessionIdChanged?.(activeSessionId);
+        registerAgentRunContext(params.runId, {
+          sessionId: activeSessionId,
+          lifecycleGeneration,
+        });
+      };
       let suppressNextUserMessagePersistence = params.suppressNextUserMessagePersistence ?? false;
       // The embedded agent owns JSONL persistence; this marker lets the outer retry avoid
       // replaying the same inbound channel message after overflow compaction.
@@ -1428,13 +1487,7 @@ export async function runEmbeddedAgent(
         ) => {
           const nextSessionId = compactResult.result?.sessionId;
           const nextSessionFile = compactResult.result?.sessionFile;
-          if (nextSessionId && nextSessionId !== activeSessionId) {
-            activeSessionId = nextSessionId;
-            // Keep the run context's sessionId tracking the live session so
-            // lifecycle persistence isn't treated as stale after a legitimate
-            // mid-run compaction rotation (#88538).
-            registerAgentRunContext(params.runId, { sessionId: activeSessionId });
-          }
+          adoptActiveSessionId(nextSessionId);
           if (nextSessionFile && nextSessionFile !== activeSessionFile) {
             activeSessionFile = nextSessionFile;
           }
@@ -1719,6 +1772,7 @@ export async function runEmbeddedAgent(
             timeoutMs: params.timeoutMs,
             runTimeoutOverrideMs: params.runTimeoutOverrideMs,
             runId: params.runId,
+            lifecycleGeneration,
             abortSignal: attemptAbortController.signal,
             replyOperation: params.replyOperation,
             shouldEmitToolResult: params.shouldEmitToolResult,
@@ -1799,11 +1853,7 @@ export async function runEmbeddedAgent(
             attempt.setTerminalLifecycleMeta?.({ ...meta, aborted });
           };
           const timedOutDuringToolExecution = attempt.timedOutDuringToolExecution ?? false;
-          if (sessionIdUsed && sessionIdUsed !== activeSessionId) {
-            activeSessionId = sessionIdUsed;
-            // Track the live session for lifecycle persistence identity (#88538).
-            registerAgentRunContext(params.runId, { sessionId: activeSessionId });
-          }
+          adoptActiveSessionId(sessionIdUsed);
           if (sessionFileUsed && sessionFileUsed !== activeSessionFile) {
             activeSessionFile = sessionFileUsed;
           }

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -169,6 +169,11 @@ import { wrapStreamFnTextTransforms } from "../../plugin-text-transforms.js";
 import { resolveAgentPromptSurfaceForSessionKey } from "../../prompt-surface.js";
 import { describeProviderRequestRoutingSummary } from "../../provider-attribution.js";
 import { registerProviderStreamForModel } from "../../provider-stream.js";
+import {
+  AGENT_RUN_RESTART_ABORT_STOP_REASON,
+  createAgentRunRestartAbortError,
+  isAgentRunRestartAbortReason,
+} from "../../run-termination.js";
 import { collectRuntimeChannelCapabilities } from "../../runtime-capabilities.js";
 import {
   logAgentRuntimeToolDiagnostics,
@@ -3330,6 +3335,10 @@ export async function runEmbeddedAttempt(
           onAgentEvent: params.onAgentEvent,
           terminalLifecyclePhase: params.deferTerminalLifecycleEnd ? "finishing" : "end",
           isTerminalAborted: () => aborted,
+          resolveTerminalStopReason: () =>
+            isAgentRunRestartAbortReason(runAbortController.signal.reason)
+              ? AGENT_RUN_RESTART_ABORT_STOP_REASON
+              : undefined,
           onBeforeLifecycleTerminal: () => {
             if (
               requiresCompletionRequiredAsyncTaskWait({
@@ -3432,9 +3441,9 @@ export async function runEmbeddedAttempt(
         }
       };
 
-      const abortActiveRunExternally = () => {
+      const abortActiveRunExternally = (reason?: "user_abort" | "restart" | "superseded") => {
         externalAbort = true;
-        abortRun();
+        abortRun(false, reason === "restart" ? createAgentRunRestartAbortError() : undefined);
       };
       const queueHandle: EmbeddedAgentQueueHandle & {
         kind: "embedded";
@@ -3452,7 +3461,7 @@ export async function runEmbeddedAttempt(
         supportsTranscriptCommitWait: true,
         sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
         cancel: abortActiveRunExternally,
-        abort: abortActiveRunExternally,
+        abort: (reason) => abortActiveRunExternally(reason),
       };
       let lastAssistant: AssistantMessage | undefined;
       let currentAttemptAssistant: EmbeddedRunAttemptResult["currentAttemptAssistant"];

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -3304,6 +3304,7 @@ export async function runEmbeddedAttempt(
         buildEmbeddedSubscriptionParams({
           session: activeSession,
           runId: params.runId,
+          lifecycleGeneration: params.lifecycleGeneration,
           messageChannel: runtimeChannel,
           initialReplayState: params.initialReplayState,
           hookRunner: getGlobalHookRunner() ?? undefined,

--- a/src/agents/embedded-agent-runner/run/params.ts
+++ b/src/agents/embedded-agent-runner/run/params.ts
@@ -44,6 +44,8 @@ export type CurrentInboundPromptContext = {
 export type RunEmbeddedAgentParams = {
   sessionId: string;
   sessionKey?: string;
+  /** Immutable gateway lifecycle ownership captured when this execution was admitted. */
+  lifecycleGeneration?: string;
   /** Provider prompt-cache affinity key; distinct from transcript/session identity. */
   promptCacheKey?: string;
   /** Session-like key for sandbox and tool-policy resolution. Defaults to sessionKey. */
@@ -173,7 +175,7 @@ export type RunEmbeddedAgentParams = {
   runTimeoutOverrideMs?: number;
   runId: string;
   abortSignal?: AbortSignal;
-  onExecutionStarted?: () => void;
+  onExecutionStarted?: (info?: { lifecycleGeneration?: string }) => void;
   onExecutionPhase?: (info: {
     phase: EmbeddedAgentExecutionPhase;
     provider?: string;
@@ -191,6 +193,7 @@ export type RunEmbeddedAgentParams = {
     model?: string;
     backend?: string;
   }) => void;
+  onSessionIdChanged?: (sessionId: string) => void;
   replyOperation?: ReplyOperation;
   shouldEmitToolResult?: () => boolean;
   shouldEmitToolOutput?: () => boolean;

--- a/src/agents/embedded-agent-runner/runs.test.ts
+++ b/src/agents/embedded-agent-runner/runs.test.ts
@@ -120,6 +120,14 @@ describe("embedded-agent runner run registry", () => {
     expect(abortB).toHaveBeenCalledTimes(1);
   });
 
+  it("passes restart ownership to every aborted run", () => {
+    const abort = vi.fn();
+    setActiveEmbeddedRun("session-restart", createRunHandle({ abort }));
+
+    expect(abortEmbeddedAgentRun(undefined, { mode: "all", reason: "restart" })).toBe(true);
+    expect(abort).toHaveBeenCalledWith("restart");
+  });
+
   it("resolves active embedded runs by canonical session file", async () => {
     // Session-file lookup canonicalizes symlinks so heartbeat/diagnostic callers
     // can find the active handle from the file path they observe.

--- a/src/agents/embedded-agent-runner/runs.ts
+++ b/src/agents/embedded-agent-runner/runs.ts
@@ -10,7 +10,6 @@ import {
   isReplyRunAbortableForCompaction,
   isReplyRunStreamingForSessionId,
   queueReplyRunMessage,
-  resolveActiveReplyRunSessionId,
   waitForReplyRunEndBySessionId,
 } from "../../auto-reply/reply/reply-run-registry.js";
 import {
@@ -48,6 +47,7 @@ export {
   getActiveEmbeddedRunCount,
   listActiveEmbeddedRunSessionIds,
   listActiveEmbeddedRunSessionKeys,
+  resolveActiveEmbeddedRunSessionId,
   type ActiveEmbeddedRunSnapshot,
   type EmbeddedAgentQueueHandle,
   type EmbeddedAgentQueueMessageOptions,
@@ -554,17 +554,6 @@ export function resolveActiveEmbeddedRunHandleSessionIdBySessionFile(
   }
   return ACTIVE_EMBEDDED_RUN_SESSION_IDS_BY_FILE.get(
     resolveEmbeddedSessionFileKey(normalizedSessionFile),
-  );
-}
-
-export function resolveActiveEmbeddedRunSessionId(sessionKey: string): string | undefined {
-  const normalizedSessionKey = sessionKey.trim();
-  if (!normalizedSessionKey) {
-    return undefined;
-  }
-  return (
-    resolveActiveReplyRunSessionId(normalizedSessionKey) ??
-    ACTIVE_EMBEDDED_RUN_SESSION_IDS_BY_KEY.get(normalizedSessionKey)
   );
 }
 

--- a/src/agents/embedded-agent-runner/runs.ts
+++ b/src/agents/embedded-agent-runner/runs.ts
@@ -440,11 +440,11 @@ function prepareEmbeddedAgentQueueMessage(
 export function abortEmbeddedAgentRun(sessionId: string): boolean;
 export function abortEmbeddedAgentRun(
   sessionId: undefined,
-  opts: { mode: "all" | "compacting" },
+  opts: { mode: "all" | "compacting"; reason?: "restart" },
 ): boolean;
 export function abortEmbeddedAgentRun(
   sessionId?: string,
-  opts?: { mode?: "all" | "compacting" },
+  opts?: { mode?: "all" | "compacting"; reason?: "restart" },
 ): boolean {
   if (typeof sessionId === "string" && sessionId.length > 0) {
     const handle = ACTIVE_EMBEDDED_RUNS.get(sessionId);
@@ -457,7 +457,7 @@ export function abortEmbeddedAgentRun(
     }
     diag.debug(`aborting run: sessionId=${sessionId}`);
     try {
-      handle.abort();
+      handle.abort(opts?.reason);
     } catch (err) {
       diag.warn(`abort failed: sessionId=${sessionId} err=${String(err)}`);
       return false;
@@ -476,7 +476,7 @@ export function abortEmbeddedAgentRun(
       }
       diag.debug(params.formatDebugMessage(id));
       try {
-        handle.abort();
+        handle.abort(opts?.reason);
         aborted = true;
       } catch (err) {
         diag.warn(`abort failed: sessionId=${id} err=${String(err)}`);

--- a/src/agents/embedded-agent-subscribe.handlers.lifecycle.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.lifecycle.test.ts
@@ -20,6 +20,7 @@ function createContext(
     onBeforeLifecycleTerminal?: () => void | Promise<void>;
     onBlockReply?: ((payload: unknown) => void) | undefined;
     onBlockReplyFlush?: () => void | Promise<void>;
+    resolveTerminalStopReason?: () => string | undefined;
   },
 ): EmbeddedAgentSubscribeContext {
   // Lifecycle tests only need terminal state and delivery callbacks; omitted
@@ -34,6 +35,7 @@ function createContext(
       sessionKey: "agent:main:main",
       onAgentEvent: overrides?.onAgentEvent,
       onBeforeLifecycleTerminal: overrides?.onBeforeLifecycleTerminal,
+      resolveTerminalStopReason: overrides?.resolveTerminalStopReason,
       ...(onBlockReply ? { onBlockReply } : {}),
       onBlockReplyFlush: overrides?.onBlockReplyFlush,
     },
@@ -249,6 +251,38 @@ describe("handleAgentEnd", () => {
       data: {
         phase: "end",
         stopReason: "aborted",
+      },
+    });
+  });
+
+  it("overrides embedded abort terminals with the restart stop reason", async () => {
+    emitAgentEventMock.mockClear();
+    const onAgentEvent = vi.fn();
+    const ctx = createContext(undefined, {
+      onAgentEvent,
+      resolveTerminalStopReason: () => "restart",
+    });
+    ctx.state.terminalStopReason = "aborted";
+    ctx.state.terminalAborted = true;
+
+    await handleAgentEnd(ctx);
+
+    expect(emitAgentEventMock).toHaveBeenCalledWith({
+      runId: "run-1",
+      sessionKey: "agent:main:main",
+      stream: "lifecycle",
+      data: expect.objectContaining({
+        phase: "end",
+        stopReason: "restart",
+        aborted: true,
+      }),
+    });
+    expect(onAgentEvent).toHaveBeenCalledWith({
+      stream: "lifecycle",
+      data: {
+        phase: "end",
+        stopReason: "restart",
+        aborted: true,
       },
     });
   });

--- a/src/agents/embedded-agent-subscribe.handlers.lifecycle.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.lifecycle.test.ts
@@ -2,7 +2,7 @@
 // lifecycle events, and deferred reply cleanup.
 import { describe, expect, it, vi } from "vitest";
 import { createInlineCodeState } from "../../packages/markdown-core/src/code-spans.js";
-import { handleAgentEnd } from "./embedded-agent-subscribe.handlers.lifecycle.js";
+import { handleAgentEnd, handleAgentStart } from "./embedded-agent-subscribe.handlers.lifecycle.js";
 import type { EmbeddedAgentSubscribeContext } from "./embedded-agent-subscribe.handlers.types.js";
 
 const { emitAgentEventMock } = vi.hoisted(() => ({
@@ -96,6 +96,44 @@ function firstWarnMeta(ctx: EmbeddedAgentSubscribeContext): Record<string, unkno
 }
 
 describe("handleAgentEnd", () => {
+  it("keeps explicit session and agent identity on lifecycle start events", () => {
+    emitAgentEventMock.mockClear();
+    const ctx = createContext(undefined);
+    ctx.params.sessionId = "session-1";
+    ctx.params.agentId = "main";
+
+    handleAgentStart(ctx);
+
+    expect(emitAgentEventMock).toHaveBeenCalledWith({
+      runId: "run-1",
+      sessionKey: "agent:main:main",
+      sessionId: "session-1",
+      agentId: "main",
+      stream: "lifecycle",
+      data: expect.objectContaining({ phase: "start" }),
+    });
+  });
+
+  it("keeps the execution lifecycle generation on terminal events", async () => {
+    emitAgentEventMock.mockClear();
+    const ctx = createContext(undefined);
+    ctx.params.lifecycleGeneration = "pre-restart-generation";
+    ctx.params.sessionId = "session-1";
+    ctx.params.agentId = "main";
+
+    await handleAgentEnd(ctx);
+
+    expect(emitAgentEventMock).toHaveBeenCalledWith({
+      runId: "run-1",
+      sessionKey: "agent:main:main",
+      sessionId: "session-1",
+      agentId: "main",
+      lifecycleGeneration: "pre-restart-generation",
+      stream: "lifecycle",
+      data: expect.objectContaining({ phase: "end" }),
+    });
+  });
+
   it("suppresses raw assistant error messages in user-facing lifecycle events", async () => {
     // Canary text proves provider error strings are sanitized before lifecycle
     // events reach channel integrations.
@@ -199,6 +237,7 @@ describe("handleAgentEnd", () => {
 
     expect(emitAgentEventMock).toHaveBeenCalledWith({
       runId: "run-1",
+      sessionKey: "agent:main:main",
       stream: "lifecycle",
       data: expect.objectContaining({
         phase: "end",
@@ -225,6 +264,7 @@ describe("handleAgentEnd", () => {
 
     expect(emitAgentEventMock).toHaveBeenCalledWith({
       runId: "run-1",
+      sessionKey: "agent:main:main",
       stream: "lifecycle",
       data: expect.objectContaining({
         phase: "end",

--- a/src/agents/embedded-agent-subscribe.handlers.lifecycle.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.lifecycle.ts
@@ -137,6 +137,7 @@ export function handleAgentEnd(
 
   const emitLifecycleTerminal = () => {
     const terminalStopReason =
+      ctx.params.resolveTerminalStopReason?.() ??
       ctx.state.terminalStopReason ??
       (!isError && isAssistantMessage(lastAssistant) ? lastAssistant.stopReason : undefined);
     const terminalAborted =

--- a/src/agents/embedded-agent-subscribe.handlers.lifecycle.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.lifecycle.ts
@@ -35,6 +35,12 @@ export function handleAgentStart(ctx: EmbeddedAgentSubscribeContext) {
   ctx.log.debug(`embedded run agent start: runId=${ctx.params.runId}`);
   emitAgentEvent({
     runId: ctx.params.runId,
+    ...(ctx.params.sessionKey ? { sessionKey: ctx.params.sessionKey } : {}),
+    ...(ctx.params.sessionId ? { sessionId: ctx.params.sessionId } : {}),
+    ...(ctx.params.agentId ? { agentId: ctx.params.agentId } : {}),
+    ...(ctx.params.lifecycleGeneration
+      ? { lifecycleGeneration: ctx.params.lifecycleGeneration }
+      : {}),
     stream: "lifecycle",
     data: {
       phase: "start",
@@ -149,6 +155,12 @@ export function handleAgentEnd(
     if (isError) {
       emitAgentEvent({
         runId: ctx.params.runId,
+        ...(ctx.params.sessionKey ? { sessionKey: ctx.params.sessionKey } : {}),
+        ...(ctx.params.sessionId ? { sessionId: ctx.params.sessionId } : {}),
+        ...(ctx.params.agentId ? { agentId: ctx.params.agentId } : {}),
+        ...(ctx.params.lifecycleGeneration
+          ? { lifecycleGeneration: ctx.params.lifecycleGeneration }
+          : {}),
         stream: "lifecycle",
         data: {
           phase: "error",
@@ -174,6 +186,12 @@ export function handleAgentEnd(
     const successPhase = ctx.params.terminalLifecyclePhase ?? "end";
     emitAgentEvent({
       runId: ctx.params.runId,
+      ...(ctx.params.sessionKey ? { sessionKey: ctx.params.sessionKey } : {}),
+      ...(ctx.params.sessionId ? { sessionId: ctx.params.sessionId } : {}),
+      ...(ctx.params.agentId ? { agentId: ctx.params.agentId } : {}),
+      ...(ctx.params.lifecycleGeneration
+        ? { lifecycleGeneration: ctx.params.lifecycleGeneration }
+        : {}),
       stream: "lifecycle",
       data: {
         phase: successPhase,

--- a/src/agents/embedded-agent-subscribe.types.ts
+++ b/src/agents/embedded-agent-subscribe.types.ts
@@ -75,6 +75,8 @@ export type SubscribeEmbeddedAgentSessionParams = {
   terminalLifecyclePhase?: "end" | "finishing";
   /** Read immediately before terminal lifecycle emission. */
   isTerminalAborted?: () => boolean | undefined;
+  /** Override the terminal stop reason from the current abort owner. */
+  resolveTerminalStopReason?: () => string | undefined;
   /** Gate final block delivery/lifecycle after the natural answer is known. */
   onBeforeTerminalDelivery?: (event: {
     messages: AgentMessage[];

--- a/src/agents/embedded-agent-subscribe.types.ts
+++ b/src/agents/embedded-agent-subscribe.types.ts
@@ -29,6 +29,8 @@ export type {
 export type SubscribeEmbeddedAgentSessionParams = {
   session: AgentSession;
   runId: string;
+  /** Immutable gateway lifecycle ownership for this execution. */
+  lifecycleGeneration?: string;
   /** Originating message channel used for subsystem log attribution. */
   messageChannel?: string;
   initialReplayState?: EmbeddedRunReplayState;

--- a/src/agents/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-restart-recovery.test.ts
@@ -233,6 +233,183 @@ describe("main-session-restart-recovery", () => {
     ]);
   });
 
+  it("marks queued abort-registry runs before lifecycle start changes session status", async () => {
+    const sessionsDir = await makeSessionsDir();
+    await writeStore(sessionsDir, {
+      "agent:main:main": {
+        sessionId: "main-session",
+        updatedAt: Date.now() - 10_000,
+        status: "done",
+        startedAt: 1_000,
+        endedAt: 2_000,
+        runtimeMs: 1_000,
+      },
+    });
+
+    const result = await markRestartAbortedMainSessions({
+      stateDir: tmpDir,
+      sessionKeys: ["agent:main:main"],
+      sessionIds: ["main-session"],
+      activeRuns: [
+        {
+          runId: "queued-run",
+          lifecycleGeneration: "pre-restart",
+          sessionKey: "agent:main:main",
+          sessionId: "main-session",
+        },
+      ],
+    });
+
+    const store = loadSessionStore(path.join(sessionsDir, "sessions.json"));
+    expect(result).toEqual({ marked: 1, skipped: 0 });
+    expect(store["agent:main:main"]).toEqual(
+      expect.objectContaining({
+        status: "running",
+        abortedLastRun: true,
+        restartRecoveryRuns: [
+          {
+            runId: "queued-run",
+            lifecycleGeneration: "pre-restart",
+          },
+        ],
+      }),
+    );
+    expect(store["agent:main:main"]?.startedAt).toBeUndefined();
+    expect(store["agent:main:main"]?.endedAt).toBeUndefined();
+    expect(store["agent:main:main"]?.runtimeMs).toBeUndefined();
+  });
+
+  it("marks queued registered runs before lifecycle start without explicit candidates", async () => {
+    const sessionsDir = await makeSessionsDir();
+    await writeStore(sessionsDir, {
+      "agent:main:main": {
+        sessionId: "main-session",
+        updatedAt: Date.now() - 10_000,
+        status: "done",
+      },
+    });
+    registerAgentRunContext("queued-context-run", {
+      sessionKey: "agent:main:main",
+      sessionId: "main-session",
+    });
+
+    const result = await markRestartAbortedMainSessions({
+      stateDir: tmpDir,
+      sessionKeys: ["agent:main:main"],
+      sessionIds: ["main-session"],
+    });
+
+    const store = loadSessionStore(path.join(sessionsDir, "sessions.json"));
+    expect(result).toEqual({ marked: 1, skipped: 0 });
+    expect(store["agent:main:main"]).toEqual(
+      expect.objectContaining({
+        status: "running",
+        abortedLastRun: true,
+        restartRecoveryRuns: [
+          {
+            runId: "queued-context-run",
+            lifecycleGeneration: getAgentEventLifecycleGeneration(),
+          },
+        ],
+      }),
+    );
+  });
+
+  it("does not reopen a queued run that completed before store persistence", async () => {
+    const sessionsDir = await makeSessionsDir();
+    await writeStore(sessionsDir, {
+      "agent:main:main": {
+        sessionId: "main-session",
+        updatedAt: Date.now() - 10_000,
+        status: "done",
+      },
+    });
+
+    const result = await markRestartAbortedMainSessions({
+      stateDir: tmpDir,
+      sessionKeys: ["agent:main:main"],
+      sessionIds: ["main-session"],
+      activeRuns: [
+        {
+          runId: "completed-run",
+          lifecycleGeneration: "pre-restart",
+          sessionKey: "agent:main:main",
+          sessionId: "main-session",
+        },
+      ],
+      isActiveRun: () => false,
+    });
+
+    const store = loadSessionStore(path.join(sessionsDir, "sessions.json"));
+    expect(result).toEqual({ marked: 0, skipped: 0 });
+    expect(store["agent:main:main"]?.status).toBe("done");
+    expect(store["agent:main:main"]?.restartRecoveryRuns).toBeUndefined();
+  });
+
+  it("does not reopen a session completed after a failed terminal persistence candidate", async () => {
+    const sessionsDir = await makeSessionsDir();
+    await writeStore(sessionsDir, {
+      "agent:main:main": {
+        sessionId: "main-session",
+        updatedAt: 3_000,
+        status: "done",
+      },
+    });
+
+    const result = await markRestartAbortedMainSessions({
+      stateDir: tmpDir,
+      sessionKeys: ["agent:main:main"],
+      sessionIds: ["main-session"],
+      activeRuns: [
+        {
+          runId: "failed-persistence-run",
+          lifecycleGeneration: "pre-restart",
+          sessionKey: "agent:main:main",
+          sessionId: "main-session",
+          observedAt: 2_000,
+        },
+      ],
+      isActiveRun: () => true,
+    });
+
+    const store = loadSessionStore(path.join(sessionsDir, "sessions.json"));
+    expect(result).toEqual({ marked: 0, skipped: 0 });
+    expect(store["agent:main:main"]?.status).toBe("done");
+    expect(store["agent:main:main"]?.restartRecoveryRuns).toBeUndefined();
+  });
+
+  it("does not reopen a terminal row written at the observed event timestamp", async () => {
+    const sessionsDir = await makeSessionsDir();
+    await writeStore(sessionsDir, {
+      "agent:main:main": {
+        sessionId: "main-session",
+        updatedAt: 2_000,
+        status: "done",
+      },
+    });
+
+    const result = await markRestartAbortedMainSessions({
+      stateDir: tmpDir,
+      sessionKeys: ["agent:main:main"],
+      sessionIds: ["main-session"],
+      activeRuns: [
+        {
+          runId: "just-persisted-run",
+          lifecycleGeneration: "pre-restart",
+          sessionKey: "agent:main:main",
+          sessionId: "main-session",
+          observedAt: 2_000,
+        },
+      ],
+      isActiveRun: () => true,
+    });
+
+    const store = loadSessionStore(path.join(sessionsDir, "sessions.json"));
+    expect(result).toEqual({ marked: 0, skipped: 0 });
+    expect(store["agent:main:main"]?.status).toBe("done");
+    expect(store["agent:main:main"]?.restartRecoveryRuns).toBeUndefined();
+  });
+
   it("preserves current-generation markers across repeated restart marking", async () => {
     const sessionsDir = await makeSessionsDir();
     const lifecycleGeneration = getAgentEventLifecycleGeneration();

--- a/src/agents/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-restart-recovery.test.ts
@@ -10,6 +10,11 @@ import {
 } from "../config/sessions/test-helpers.js";
 import { callGateway } from "../gateway/call.js";
 import {
+  getAgentEventLifecycleGeneration,
+  registerAgentRunContext,
+  resetAgentRunContextForTest,
+} from "../infra/agent-events.js";
+import {
   INTERNAL_RUNTIME_CONTEXT_BEGIN,
   INTERNAL_RUNTIME_CONTEXT_END,
 } from "./internal-runtime-context.js";
@@ -30,6 +35,7 @@ let tmpDir: string;
 
 beforeEach(async () => {
   vi.clearAllMocks();
+  resetAgentRunContextForTest();
   tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-main-restart-recovery-"));
 });
 
@@ -123,6 +129,17 @@ describe("main-session-restart-recovery", () => {
       },
     });
 
+    registerAgentRunContext("restart-run", {
+      sessionKey: "agent:main:main",
+      sessionId: "main-session",
+    });
+    registerAgentRunContext("key-only-run", {
+      sessionKey: "agent:main:main",
+    });
+    registerAgentRunContext("stale-session-run", {
+      sessionKey: "agent:main:main",
+      sessionId: "stale-session",
+    });
     const result = await markRestartAbortedMainSessions({
       stateDir: tmpDir,
       sessionKeys: ["agent:main:main", "agent:main:completed", "agent:main:subagent:child"],
@@ -135,6 +152,11 @@ describe("main-session-restart-recovery", () => {
     expect(store["agent:main:subagent:child"]?.abortedLastRun).toBeUndefined();
     expect(store["cron:nightly"]?.abortedLastRun).toBeUndefined();
     expect(store["agent:main:other"]?.abortedLastRun).toBeUndefined();
+    const lifecycleGeneration = getAgentEventLifecycleGeneration();
+    expect(store["agent:main:main"]?.restartRecoveryRuns).toEqual([
+      { runId: "key-only-run", lifecycleGeneration },
+      { runId: "restart-run", lifecycleGeneration },
+    ]);
   });
 
   it("marks active sessions in a configured custom session store", async () => {
@@ -175,6 +197,123 @@ describe("main-session-restart-recovery", () => {
     });
 
     expect(recovery).toEqual({ recovered: 1, failed: 0, skipped: 0 });
+  });
+
+  it("persists abort-registry runs after their event context was cleared", async () => {
+    const sessionsDir = await makeSessionsDir();
+    await writeStore(sessionsDir, {
+      "agent:main:main": {
+        sessionId: "main-session",
+        updatedAt: Date.now() - 10_000,
+        status: "running",
+      },
+    });
+
+    const result = await markRestartAbortedMainSessions({
+      stateDir: tmpDir,
+      sessionKeys: ["agent:main:main"],
+      sessionIds: ["main-session"],
+      activeRuns: [
+        {
+          runId: "cleared-context-run",
+          lifecycleGeneration: "pre-restart",
+          sessionKey: "agent:main:main",
+          sessionId: "main-session",
+        },
+      ],
+    });
+
+    const store = loadSessionStore(path.join(sessionsDir, "sessions.json"));
+    expect(result).toEqual({ marked: 1, skipped: 0 });
+    expect(store["agent:main:main"]?.restartRecoveryRuns).toEqual([
+      {
+        runId: "cleared-context-run",
+        lifecycleGeneration: "pre-restart",
+      },
+    ]);
+  });
+
+  it("preserves current-generation markers across repeated restart marking", async () => {
+    const sessionsDir = await makeSessionsDir();
+    const lifecycleGeneration = getAgentEventLifecycleGeneration();
+    await writeStore(sessionsDir, {
+      "agent:main:main": {
+        sessionId: "main-session",
+        updatedAt: Date.now() - 10_000,
+        status: "running",
+        restartRecoveryRuns: [
+          {
+            runId: "first-restart-run",
+            lifecycleGeneration,
+          },
+        ],
+      },
+    });
+
+    await markRestartAbortedMainSessions({
+      stateDir: tmpDir,
+      sessionKeys: ["agent:main:main"],
+      sessionIds: ["main-session"],
+      activeRuns: [
+        {
+          runId: "second-restart-run",
+          lifecycleGeneration,
+          sessionKey: "agent:main:main",
+          sessionId: "main-session",
+        },
+      ],
+    });
+
+    const store = loadSessionStore(path.join(sessionsDir, "sessions.json"));
+    expect(store["agent:main:main"]?.restartRecoveryRuns).toEqual([
+      {
+        runId: "first-restart-run",
+        lifecycleGeneration,
+      },
+      {
+        runId: "second-restart-run",
+        lifecycleGeneration,
+      },
+    ]);
+  });
+
+  it("replaces an older marker when the same run id is active after another restart", async () => {
+    const sessionsDir = await makeSessionsDir();
+    await writeStore(sessionsDir, {
+      "agent:main:main": {
+        sessionId: "main-session",
+        updatedAt: Date.now() - 10_000,
+        status: "running",
+        restartRecoveryRuns: [
+          {
+            runId: "shared-run",
+            lifecycleGeneration: "first-generation",
+          },
+        ],
+      },
+    });
+
+    await markRestartAbortedMainSessions({
+      stateDir: tmpDir,
+      sessionKeys: ["agent:main:main"],
+      sessionIds: ["main-session"],
+      activeRuns: [
+        {
+          runId: "shared-run",
+          lifecycleGeneration: "second-generation",
+          sessionKey: "agent:main:main",
+          sessionId: "main-session",
+        },
+      ],
+    });
+
+    const store = loadSessionStore(path.join(sessionsDir, "sessions.json"));
+    expect(store["agent:main:main"]?.restartRecoveryRuns).toEqual([
+      {
+        runId: "shared-run",
+        lifecycleGeneration: "second-generation",
+      },
+    ]);
   });
 
   it("uses active session ids to avoid marking stale duplicate keys in another store", async () => {
@@ -829,12 +968,24 @@ describe("main-session-restart-recovery", () => {
         sessionId: "completed-session",
         updatedAt: cutoff - 10_000,
         status: "done",
+        restartRecoveryRuns: [
+          {
+            runId: "completed-prior-process-run",
+            lifecycleGeneration: "prior-process",
+          },
+        ],
       },
       "agent:main:already-marked": {
         sessionId: "already-marked-session",
         updatedAt: cutoff - 10_000,
         status: "running",
         abortedLastRun: true,
+        restartRecoveryRuns: [
+          {
+            runId: "marked-prior-process-run",
+            lifecycleGeneration: "prior-process",
+          },
+        ],
       },
     });
     await writeTranscript(sessionsDir, "main-session", [
@@ -863,6 +1014,8 @@ describe("main-session-restart-recovery", () => {
     expect(store["agent:main:cron:nightly"]?.abortedLastRun).toBeUndefined();
     expect(store["agent:main:completed"]?.abortedLastRun).toBeUndefined();
     expect(store["agent:main:already-marked"]?.abortedLastRun).toBe(true);
+    expect(store["agent:main:completed"]?.restartRecoveryRuns).toHaveLength(1);
+    expect(store["agent:main:already-marked"]?.restartRecoveryRuns).toHaveLength(1);
 
     const recovered = await recoverRestartAbortedMainSessions({ stateDir: tmpDir });
 

--- a/src/agents/main-session-restart-recovery.ts
+++ b/src/agents/main-session-restart-recovery.ts
@@ -134,8 +134,16 @@ export async function markRestartAbortedMainSessions(params: {
     RestartRecoveryRun & {
       sessionKey: string;
       sessionId: string;
+      observedAt?: number;
     }
   >;
+  isActiveRun?: (
+    run: RestartRecoveryRun & {
+      sessionKey: string;
+      sessionId: string;
+      observedAt?: number;
+    },
+  ) => boolean;
   reason?: string;
 }): Promise<{ marked: number; skipped: number }> {
   const sessionKeys = normalizeStringSet(params.sessionKeys);
@@ -147,6 +155,7 @@ export async function markRestartAbortedMainSessions(params: {
       lifecycleGeneration: run.lifecycleGeneration.trim(),
       sessionKey: run.sessionKey.trim(),
       sessionId: run.sessionId.trim(),
+      observedAt: normalizeFiniteTimestamp(run.observedAt),
     }))
     .filter((run) => run.runId && run.lifecycleGeneration && (run.sessionKey || run.sessionId));
   const currentLifecycleGeneration = getAgentEventLifecycleGeneration();
@@ -203,7 +212,27 @@ export async function markRestartAbortedMainSessions(params: {
       storePath,
       (store) => {
         for (const [sessionKey, entry] of Object.entries(store)) {
-          if (!entry || entry.status !== "running") {
+          if (!entry) {
+            continue;
+          }
+          const registeredActiveRuns = listAgentRunsForSession({
+            sessionKey,
+            sessionId: entry.sessionId,
+          });
+          const matchingActiveRuns = activeRuns.filter(
+            (run) =>
+              (run.sessionId ? run.sessionId === entry.sessionId : run.sessionKey === sessionKey) &&
+              (entry.status === "running" ||
+                run.observedAt === undefined ||
+                normalizeFiniteTimestamp(entry.updatedAt) === undefined ||
+                entry.updatedAt < run.observedAt) &&
+              params.isActiveRun?.(run) !== false,
+          );
+          if (
+            entry.status !== "running" &&
+            matchingActiveRuns.length === 0 &&
+            registeredActiveRuns.length === 0
+          ) {
             continue;
           }
           const matches =
@@ -217,7 +246,14 @@ export async function markRestartAbortedMainSessions(params: {
             result.skipped++;
             continue;
           }
+          const wasRunning = entry.status === "running";
+          entry.status = "running";
           entry.abortedLastRun = true;
+          if (!wasRunning) {
+            entry.startedAt = undefined;
+            entry.endedAt = undefined;
+            entry.runtimeMs = undefined;
+          }
           const recoveryRuns = new Map<string, RestartRecoveryRun>();
           for (const run of entry.restartRecoveryRuns ?? []) {
             if (run.lifecycleGeneration === currentLifecycleGeneration) {
@@ -232,22 +268,14 @@ export async function markRestartAbortedMainSessions(params: {
             }
             recoveryRuns.set(`${run.runId}\u0000${run.lifecycleGeneration}`, run);
           };
-          for (const run of listAgentRunsForSession({
-            sessionKey,
-            sessionId: entry.sessionId,
-          })) {
+          for (const run of registeredActiveRuns) {
             replaceActiveRunMarker(run);
           }
-          for (const run of activeRuns) {
-            const matchesEntry = run.sessionId
-              ? run.sessionId === entry.sessionId
-              : run.sessionKey === sessionKey;
-            if (matchesEntry) {
-              replaceActiveRunMarker({
-                runId: run.runId,
-                lifecycleGeneration: run.lifecycleGeneration,
-              });
-            }
+          for (const run of matchingActiveRuns) {
+            replaceActiveRunMarker({
+              runId: run.runId,
+              lifecycleGeneration: run.lifecycleGeneration,
+            });
           }
           entry.restartRecoveryRuns = [...recoveryRuns.values()].toSorted((a, b) =>
             a.runId === b.runId
@@ -259,7 +287,7 @@ export async function markRestartAbortedMainSessions(params: {
           result.marked++;
         }
       },
-      { skipMaintenance: true },
+      { skipMaintenance: true, requireWriteSuccess: true },
     );
   }
 

--- a/src/agents/main-session-restart-recovery.ts
+++ b/src/agents/main-session-restart-recovery.ts
@@ -9,6 +9,7 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import { sanitizePendingFinalDeliveryText } from "../auto-reply/reply/pending-final-delivery.js";
 import { resolveStateDir } from "../config/paths.js";
 import {
+  type RestartRecoveryRun,
   type SessionEntry,
   loadSessionStore,
   resolveAllAgentSessionStoreTargetsSync,
@@ -20,6 +21,10 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { callGateway } from "../gateway/call.js";
 import { readSessionMessagesAsync } from "../gateway/session-utils.fs.js";
 import { resolveGatewaySessionStoreTarget } from "../gateway/session-utils.js";
+import {
+  getAgentEventLifecycleGeneration,
+  listAgentRunsForSession,
+} from "../infra/agent-events.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { CommandLane } from "../process/lanes.js";
 import { isAcpSessionKey, isCronSessionKey, isSubagentSessionKey } from "../routing/session-key.js";
@@ -125,11 +130,26 @@ export async function markRestartAbortedMainSessions(params: {
   stateDir?: string;
   sessionKeys?: Iterable<string>;
   sessionIds?: Iterable<string>;
+  activeRuns?: Iterable<
+    RestartRecoveryRun & {
+      sessionKey: string;
+      sessionId: string;
+    }
+  >;
   reason?: string;
 }): Promise<{ marked: number; skipped: number }> {
   const sessionKeys = normalizeStringSet(params.sessionKeys);
   const sessionIds = normalizeStringSet(params.sessionIds);
   const preferSessionIdMatch = sessionIds.size > 0;
+  const activeRuns = [...(params.activeRuns ?? [])]
+    .map((run) => ({
+      runId: run.runId.trim(),
+      lifecycleGeneration: run.lifecycleGeneration.trim(),
+      sessionKey: run.sessionKey.trim(),
+      sessionId: run.sessionId.trim(),
+    }))
+    .filter((run) => run.runId && run.lifecycleGeneration && (run.sessionKey || run.sessionId));
+  const currentLifecycleGeneration = getAgentEventLifecycleGeneration();
   const result = { marked: 0, skipped: 0 };
   if (sessionKeys.size === 0 && sessionIds.size === 0) {
     return result;
@@ -198,6 +218,42 @@ export async function markRestartAbortedMainSessions(params: {
             continue;
           }
           entry.abortedLastRun = true;
+          const recoveryRuns = new Map<string, RestartRecoveryRun>();
+          for (const run of entry.restartRecoveryRuns ?? []) {
+            if (run.lifecycleGeneration === currentLifecycleGeneration) {
+              recoveryRuns.set(`${run.runId}\u0000${run.lifecycleGeneration}`, run);
+            }
+          }
+          const replaceActiveRunMarker = (run: RestartRecoveryRun) => {
+            for (const [key, existingRun] of recoveryRuns) {
+              if (existingRun.runId === run.runId) {
+                recoveryRuns.delete(key);
+              }
+            }
+            recoveryRuns.set(`${run.runId}\u0000${run.lifecycleGeneration}`, run);
+          };
+          for (const run of listAgentRunsForSession({
+            sessionKey,
+            sessionId: entry.sessionId,
+          })) {
+            replaceActiveRunMarker(run);
+          }
+          for (const run of activeRuns) {
+            const matchesEntry = run.sessionId
+              ? run.sessionId === entry.sessionId
+              : run.sessionKey === sessionKey;
+            if (matchesEntry) {
+              replaceActiveRunMarker({
+                runId: run.runId,
+                lifecycleGeneration: run.lifecycleGeneration,
+              });
+            }
+          }
+          entry.restartRecoveryRuns = [...recoveryRuns.values()].toSorted((a, b) =>
+            a.runId === b.runId
+              ? a.lifecycleGeneration.localeCompare(b.lifecycleGeneration)
+              : a.runId.localeCompare(b.runId),
+          );
           entry.updatedAt = Date.now();
           store[sessionKey] = entry;
           result.marked++;
@@ -242,7 +298,10 @@ export async function markStartupOrphanedMainSessionsForRecovery(params: {
       storePath,
       (store) => {
         for (const [sessionKey, entry] of Object.entries(store)) {
-          if (!entry || entry.status !== "running" || entry.abortedLastRun === true) {
+          if (!entry) {
+            continue;
+          }
+          if (entry.status !== "running" || entry.abortedLastRun === true) {
             continue;
           }
           if (shouldSkipMainRecovery(entry, sessionKey)) {

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -31,6 +31,7 @@ import {
   runWithImageModelFallback,
   runWithModelFallback as runWithModelFallbackBase,
 } from "./model-fallback.js";
+import { createAgentRunRestartAbortError } from "./run-termination.js";
 import { SessionWriteLockTimeoutError } from "./session-write-lock-error.js";
 import { makeModelFallbackCfg } from "./test-helpers/model-fallback-config-fixture.js";
 
@@ -2560,6 +2561,25 @@ describe("runWithModelFallback", () => {
     expect(run).toHaveBeenCalledTimes(1);
   });
 
+  it("does not fall back on restart aborts", async () => {
+    const cfg = makeCfg();
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce(createAgentRunRestartAbortError())
+      .mockResolvedValueOnce("fallback should not run");
+
+    await expect(
+      runWithModelFallback({
+        cfg,
+        provider: "openai",
+        model: "gpt-4.1-mini",
+        run,
+      }),
+    ).rejects.toThrow("agent run aborted for restart");
+
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
   it("does not fall back when the caller abort signal timed out", async () => {
     const cfg = makeCfg();
     const timeoutReason = new Error("chat run timed out");
@@ -2612,6 +2632,35 @@ describe("runWithModelFallback", () => {
         classifyResult,
       }),
     ).rejects.toThrow("This operation was aborted");
+
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(classifyResult).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fall back when a restart abort is classified from the result", async () => {
+    const cfg = makeProviderFallbackCfg("openai");
+    const controller = new AbortController();
+    controller.abort(createAgentRunRestartAbortError());
+    const run = vi
+      .fn()
+      .mockResolvedValueOnce({ payloads: [] })
+      .mockResolvedValueOnce({ payloads: [{ text: "fallback should not run" }] });
+    const classifyResult = vi.fn(() => ({
+      message: "empty response",
+      reason: "format" as const,
+      code: "empty_result",
+    }));
+
+    await expect(
+      runWithModelFallback({
+        cfg,
+        provider: "openai",
+        model: "m1",
+        abortSignal: controller.signal,
+        run,
+        classifyResult,
+      }),
+    ).rejects.toThrow("empty response");
 
     expect(run).toHaveBeenCalledTimes(1);
     expect(classifyResult).toHaveBeenCalledTimes(1);

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -75,6 +75,7 @@ import {
   resolveConfiguredModelRef,
   resolveModelRefFromString,
 } from "./model-selection-resolve.js";
+import { isAgentRunRestartAbortReason } from "./run-termination.js";
 import { resolveSessionSuspensionReason, suspendSession } from "./session-suspension.js";
 
 const log = createSubsystemLogger("model-fallback");
@@ -207,6 +208,9 @@ function isTerminalAbort(signal: AbortSignal | undefined): boolean {
   const reason = signal.reason;
   if (!(reason instanceof Error)) {
     return false;
+  }
+  if (isAgentRunRestartAbortReason(reason)) {
+    return true;
   }
   if (reason.name === "TimeoutError") {
     return true;

--- a/src/agents/run-termination.test.ts
+++ b/src/agents/run-termination.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import {
+  createAgentRunRestartAbortError,
+  isAbortedAgentStopReason,
+  resolveAgentRunAbortLifecycleFields,
+} from "./run-termination.js";
+
+describe("resolveAgentRunAbortLifecycleFields", () => {
+  it("classifies generic cancellation as aborted", () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    expect(resolveAgentRunAbortLifecycleFields(controller.signal)).toEqual({
+      aborted: true,
+      stopReason: "aborted",
+    });
+  });
+
+  it("preserves timeout attribution", () => {
+    const controller = new AbortController();
+    const timeout = new Error("timed out");
+    timeout.name = "TimeoutError";
+    controller.abort(timeout);
+
+    expect(resolveAgentRunAbortLifecycleFields(controller.signal)).toEqual({
+      aborted: true,
+      stopReason: "timeout",
+    });
+  });
+
+  it("classifies managed restart cancellation", () => {
+    const controller = new AbortController();
+    controller.abort(createAgentRunRestartAbortError());
+
+    expect(resolveAgentRunAbortLifecycleFields(controller.signal)).toEqual({
+      aborted: true,
+      stopReason: "restart",
+    });
+  });
+
+  it("treats restart as an aborted terminal reason", () => {
+    expect(isAbortedAgentStopReason("aborted")).toBe(true);
+    expect(isAbortedAgentStopReason("restart")).toBe(true);
+    expect(isAbortedAgentStopReason("timeout")).toBe(false);
+  });
+});

--- a/src/agents/run-termination.ts
+++ b/src/agents/run-termination.ts
@@ -8,10 +8,50 @@
 export const AGENT_RUN_ABORTED_STOP_REASON = "aborted" as const;
 /** Error text used for aborted agent runs. */
 export const AGENT_RUN_ABORTED_ERROR = "agent run aborted" as const;
+export const AGENT_RUN_RESTART_ABORT_STOP_REASON = "restart" as const;
+
+const AGENT_RUN_RESTART_ABORT_ERROR_CODE = "OPENCLAW_RESTART_ABORT";
+
+export function createAgentRunRestartAbortError(): Error {
+  const error = new Error("agent run aborted for restart") as Error & { code: string };
+  error.name = "AbortError";
+  error.code = AGENT_RUN_RESTART_ABORT_ERROR_CODE;
+  return error;
+}
+
+export function isAgentRunRestartAbortReason(value: unknown): boolean {
+  return (
+    value instanceof Error && "code" in value && value.code === AGENT_RUN_RESTART_ABORT_ERROR_CODE
+  );
+}
+
+export function resolveAgentRunAbortLifecycleFields(signal: AbortSignal | undefined): {
+  aborted?: true;
+  stopReason?:
+    | typeof AGENT_RUN_ABORTED_STOP_REASON
+    | typeof AGENT_RUN_RESTART_ABORT_STOP_REASON
+    | "timeout";
+} {
+  if (!signal?.aborted) {
+    return {};
+  }
+  const stopReason = isAgentRunRestartAbortReason(signal.reason)
+    ? AGENT_RUN_RESTART_ABORT_STOP_REASON
+    : signal.reason &&
+        typeof signal.reason === "object" &&
+        "name" in signal.reason &&
+        signal.reason.name === "TimeoutError"
+      ? "timeout"
+      : AGENT_RUN_ABORTED_STOP_REASON;
+  return {
+    aborted: true,
+    stopReason,
+  };
+}
 
 /** Returns whether a stop reason is the stable aborted-run reason. */
 export function isAbortedAgentStopReason(
   value: unknown,
-): value is typeof AGENT_RUN_ABORTED_STOP_REASON {
-  return value === AGENT_RUN_ABORTED_STOP_REASON;
+): value is typeof AGENT_RUN_ABORTED_STOP_REASON | typeof AGENT_RUN_RESTART_ABORT_STOP_REASON {
+  return value === AGENT_RUN_ABORTED_STOP_REASON || value === AGENT_RUN_RESTART_ABORT_STOP_REASON;
 }

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -2777,6 +2777,101 @@ describe("subagent registry seam flow", () => {
     expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
   });
 
+  it("announces restart lifecycle end events as killed subagent failures", async () => {
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        return { status: "pending" };
+      }
+      return {};
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-restart-end",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "restart task",
+      cleanup: "keep",
+      expectsCompletionMessage: true,
+    });
+
+    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
+      mocks.onAgentEvent.mock.calls.length - 1
+    ] as unknown as
+      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
+      | undefined;
+    const lifecycleHandler = lastOnAgentEventCall?.[0];
+    lifecycleHandler?.({
+      runId: "run-restart-end",
+      stream: "lifecycle",
+      data: {
+        phase: "end",
+        startedAt: 10,
+        endedAt: 20,
+        aborted: true,
+        stopReason: "restart",
+      },
+    });
+
+    await waitForFast(() => {
+      const run = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-restart-end");
+      expect(run?.endedReason).toBe("subagent-killed");
+      expect(run?.outcome?.status).toBe("error");
+      expect(run?.cleanupCompletedAt).toBeTypeOf("number");
+      expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("announces restart lifecycle error events as killed subagent failures", async () => {
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        return { status: "pending" };
+      }
+      return {};
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-restart-error",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "restart error task",
+      cleanup: "keep",
+      expectsCompletionMessage: true,
+    });
+
+    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
+      mocks.onAgentEvent.mock.calls.length - 1
+    ] as unknown as
+      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
+      | undefined;
+    const lifecycleHandler = lastOnAgentEventCall?.[0];
+    lifecycleHandler?.({
+      runId: "run-restart-error",
+      stream: "lifecycle",
+      data: {
+        phase: "error",
+        startedAt: 10,
+        endedAt: 20,
+        error: "ACP turn failed before completion",
+        aborted: true,
+        stopReason: "restart",
+      },
+    });
+
+    await waitForFast(() => {
+      const run = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-restart-error");
+      expect(run?.endedReason).toBe("subagent-killed");
+      expect(run?.outcome?.status).toBe("error");
+      expect(run?.cleanupCompletedAt).toBeTypeOf("number");
+      expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+    });
+  });
+
   it("resumes ended cleanup when lifecycle killed completion rejects before cleanup", async () => {
     mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
       if (request.method === "agent.wait") {

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -1146,6 +1146,15 @@ function ensureListener() {
         );
         return;
       }
+      if (phase === "error") {
+        schedulePendingLifecycleError({
+          runId: evt.runId,
+          endedAt,
+          startedAt,
+          error,
+        });
+        return;
+      }
       if (isBlockedLivenessState(livenessState)) {
         clearPendingLifecycleError(evt.runId);
         clearPendingLifecycleTimeout(evt.runId);

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -1097,15 +1097,6 @@ function ensureListener() {
       const livenessState =
         typeof evt.data?.livenessState === "string" ? evt.data.livenessState : undefined;
       const stopReason = typeof evt.data?.stopReason === "string" ? evt.data.stopReason : undefined;
-      if (phase === "error") {
-        schedulePendingLifecycleError({
-          runId: evt.runId,
-          endedAt,
-          startedAt,
-          error,
-        });
-        return;
-      }
       // sessions_yield ends the turn by aborting the run signal, so a yielded
       // terminal can also look aborted. An explicit yield is authoritative — pause,
       // don't kill — else the tracking task settles `cancelled` with a false notice (#92448).

--- a/src/auto-reply/reply/agent-runner-cli-dispatch.test.ts
+++ b/src/auto-reply/reply/agent-runner-cli-dispatch.test.ts
@@ -1,6 +1,7 @@
 // Tests CLI dispatch arguments and runtime selection for agent runner turns.
 import { describe, expect, it, vi } from "vitest";
 import type { EmbeddedAgentRunResult } from "../../agents/embedded-agent-runner/types.js";
+import { createAgentRunRestartAbortError } from "../../agents/run-termination.js";
 
 const cliDispatchMocks = vi.hoisted(() => ({
   emitAgentEvent: vi.fn(),
@@ -55,6 +56,50 @@ describe("runCliAgentWithLifecycle", () => {
     expect(
       lifecycleEvents.every((event) => event.lifecycleGeneration === "pre-restart-generation"),
     ).toBe(true);
+  });
+
+  it("preserves restart ownership when the CLI resolves after cancellation", async () => {
+    cliDispatchMocks.emitAgentEvent.mockClear();
+    const controller = new AbortController();
+    cliDispatchMocks.runCliAgent.mockImplementationOnce(async () => {
+      controller.abort(createAgentRunRestartAbortError());
+      return {
+        payloads: [{ text: "stale result" }],
+        meta: { durationMs: 1 },
+      } satisfies EmbeddedAgentRunResult;
+    });
+
+    await expect(
+      runCliAgentWithLifecycle({
+        runId: "run-restart",
+        provider: "claude-cli",
+        runParams: {
+          sessionId: "session-1",
+          sessionFile: "/tmp/session.jsonl",
+          workspaceDir: "/tmp/workspace",
+          prompt: "hello",
+          provider: "claude-cli",
+          model: "claude",
+          thinkLevel: "off",
+          timeoutMs: 1_000,
+          runId: "run-restart",
+          abortSignal: controller.signal,
+        },
+      }),
+    ).rejects.toThrow("agent run aborted for restart");
+
+    const terminal = cliDispatchMocks.emitAgentEvent.mock.calls
+      .map(([event]) => event as { stream?: string; data?: Record<string, unknown> })
+      .find((event) => event.stream === "lifecycle" && event.data?.phase === "error");
+    expect(terminal?.data).toMatchObject({
+      aborted: true,
+      stopReason: "restart",
+    });
+    expect(
+      cliDispatchMocks.emitAgentEvent.mock.calls.some(
+        ([event]) => (event as { stream?: string }).stream === "assistant",
+      ),
+    ).toBe(false);
   });
 });
 

--- a/src/auto-reply/reply/agent-runner-cli-dispatch.test.ts
+++ b/src/auto-reply/reply/agent-runner-cli-dispatch.test.ts
@@ -1,10 +1,62 @@
 // Tests CLI dispatch arguments and runtime selection for agent runner turns.
 import { describe, expect, it, vi } from "vitest";
 import type { EmbeddedAgentRunResult } from "../../agents/embedded-agent-runner/types.js";
+
+const cliDispatchMocks = vi.hoisted(() => ({
+  emitAgentEvent: vi.fn(),
+  runCliAgent: vi.fn(),
+}));
+
+vi.mock("../../agents/cli-runner.js", () => ({
+  runCliAgent: (...args: unknown[]) => cliDispatchMocks.runCliAgent(...args),
+}));
+
+vi.mock("../../infra/agent-events.js", () => ({
+  emitAgentEvent: (...args: unknown[]) => cliDispatchMocks.emitAgentEvent(...args),
+  onAgentEvent: vi.fn(() => () => undefined),
+  withAgentRunLifecycleGeneration: (_generation: string, run: () => unknown) => run(),
+}));
+
 import {
   createCliToolSummaryTracker,
   keepCliSessionBindingOnlyWhenReused,
+  runCliAgentWithLifecycle,
 } from "./agent-runner-cli-dispatch.js";
+
+describe("runCliAgentWithLifecycle", () => {
+  it("keeps the captured lifecycle generation on start and terminal events", async () => {
+    cliDispatchMocks.emitAgentEvent.mockClear();
+    cliDispatchMocks.runCliAgent.mockResolvedValueOnce({
+      payloads: [],
+      meta: { durationMs: 1 },
+    } satisfies EmbeddedAgentRunResult);
+
+    await runCliAgentWithLifecycle({
+      runId: "run-before-restart",
+      lifecycleGeneration: "pre-restart-generation",
+      provider: "claude-cli",
+      runParams: {
+        sessionId: "session-1",
+        sessionFile: "/tmp/session.jsonl",
+        workspaceDir: "/tmp/workspace",
+        prompt: "hello",
+        provider: "claude-cli",
+        model: "claude",
+        thinkLevel: "off",
+        timeoutMs: 1_000,
+        runId: "run-before-restart",
+      },
+    });
+
+    const lifecycleEvents = cliDispatchMocks.emitAgentEvent.mock.calls
+      .map(([event]) => event as { stream?: string; lifecycleGeneration?: string })
+      .filter((event) => event.stream === "lifecycle");
+    expect(lifecycleEvents).toHaveLength(2);
+    expect(
+      lifecycleEvents.every((event) => event.lifecycleGeneration === "pre-restart-generation"),
+    ).toBe(true);
+  });
+});
 
 describe("keepCliSessionBindingOnlyWhenReused", () => {
   it("keeps the first room-event CLI binding when no binding exists yet", () => {

--- a/src/auto-reply/reply/agent-runner-cli-dispatch.ts
+++ b/src/auto-reply/reply/agent-runner-cli-dispatch.ts
@@ -10,6 +10,10 @@ import { clearCliSession } from "../../agents/cli-session.js";
 import { extractToolResultText } from "../../agents/embedded-agent-subscribe.tools.js";
 import { inferToolMetaFromArgs } from "../../agents/embedded-agent-utils.js";
 import type { EmbeddedAgentRunResult } from "../../agents/embedded-agent.js";
+import {
+  isAgentRunRestartAbortReason,
+  resolveAgentRunAbortLifecycleFields,
+} from "../../agents/run-termination.js";
 import { updateSessionStore, type SessionEntry } from "../../config/sessions.js";
 import type { AgentEventPayload } from "../../infra/agent-events.js";
 import {
@@ -372,6 +376,10 @@ async function runCliAgentWithLifecycleInternal(
       ...params.runParams,
       emitCommentaryText: Boolean(params.onCommentaryText),
     });
+    const restartAbortReason = params.runParams.abortSignal?.reason;
+    if (isAgentRunRestartAbortReason(restartAbortReason)) {
+      throw restartAbortReason;
+    }
     const result = params.transformResult?.(rawResult) ?? rawResult;
     await stopAgentEventBridges(bridges);
 
@@ -395,6 +403,7 @@ async function runCliAgentWithLifecycleInternal(
           phase: "end",
           startedAt,
           endedAt: Date.now(),
+          ...resolveAgentRunAbortLifecycleFields(params.runParams.abortSignal),
         },
       });
       lifecycleTerminalEmitted = true;
@@ -415,6 +424,7 @@ async function runCliAgentWithLifecycleInternal(
           startedAt,
           endedAt: Date.now(),
           error: String(err),
+          ...resolveAgentRunAbortLifecycleFields(params.runParams.abortSignal),
         },
       });
       lifecycleTerminalEmitted = true;
@@ -436,6 +446,7 @@ async function runCliAgentWithLifecycleInternal(
           startedAt,
           endedAt: Date.now(),
           error: "CLI run completed without lifecycle terminal event",
+          ...resolveAgentRunAbortLifecycleFields(params.runParams.abortSignal),
         },
       });
     }

--- a/src/auto-reply/reply/agent-runner-cli-dispatch.ts
+++ b/src/auto-reply/reply/agent-runner-cli-dispatch.ts
@@ -12,7 +12,11 @@ import { inferToolMetaFromArgs } from "../../agents/embedded-agent-utils.js";
 import type { EmbeddedAgentRunResult } from "../../agents/embedded-agent.js";
 import { updateSessionStore, type SessionEntry } from "../../config/sessions.js";
 import type { AgentEventPayload } from "../../infra/agent-events.js";
-import { emitAgentEvent, onAgentEvent } from "../../infra/agent-events.js";
+import {
+  emitAgentEvent,
+  onAgentEvent,
+  withAgentRunLifecycleGeneration,
+} from "../../infra/agent-events.js";
 import { formatToolAggregate } from "../tool-meta.js";
 
 function isClaudeCliProvider(provider: string): boolean {
@@ -288,8 +292,9 @@ function createCommentaryEventBridge(params: {
   });
 }
 
-export async function runCliAgentWithLifecycle(params: {
+type RunCliAgentWithLifecycleParams = {
   runId: string;
+  lifecycleGeneration?: string;
   provider: string;
   runParams: RunCliAgentParams;
   startedAt?: number;
@@ -303,7 +308,22 @@ export async function runCliAgentWithLifecycle(params: {
   onCommentaryText?: (payload: { text: string; itemId?: string }) => Promise<void>;
   onErrorBeforeLifecycle?: (err: unknown) => Promise<void>;
   transformResult?: (result: EmbeddedAgentRunResult) => EmbeddedAgentRunResult;
-}): Promise<EmbeddedAgentRunResult> {
+};
+
+export function runCliAgentWithLifecycle(
+  params: RunCliAgentWithLifecycleParams,
+): Promise<EmbeddedAgentRunResult> {
+  if (!params.lifecycleGeneration) {
+    return runCliAgentWithLifecycleInternal(params);
+  }
+  return withAgentRunLifecycleGeneration(params.lifecycleGeneration, () =>
+    runCliAgentWithLifecycleInternal(params),
+  );
+}
+
+async function runCliAgentWithLifecycleInternal(
+  params: RunCliAgentWithLifecycleParams,
+): Promise<EmbeddedAgentRunResult> {
   const startedAt = params.startedAt ?? Date.now();
   const emitLifecycleStart = params.emitLifecycleStart ?? true;
   const emitLifecycleTerminal = params.emitLifecycleTerminal ?? true;
@@ -311,6 +331,9 @@ export async function runCliAgentWithLifecycle(params: {
   if (emitLifecycleStart) {
     emitAgentEvent({
       runId: params.runId,
+      ...(params.runParams.sessionKey ? { sessionKey: params.runParams.sessionKey } : {}),
+      ...(params.runParams.sessionId ? { sessionId: params.runParams.sessionId } : {}),
+      ...(params.lifecycleGeneration ? { lifecycleGeneration: params.lifecycleGeneration } : {}),
       stream: "lifecycle",
       data: {
         phase: "start",
@@ -364,6 +387,9 @@ export async function runCliAgentWithLifecycle(params: {
     if (emitLifecycleTerminal) {
       emitAgentEvent({
         runId: params.runId,
+        ...(params.runParams.sessionKey ? { sessionKey: params.runParams.sessionKey } : {}),
+        ...(params.runParams.sessionId ? { sessionId: params.runParams.sessionId } : {}),
+        ...(params.lifecycleGeneration ? { lifecycleGeneration: params.lifecycleGeneration } : {}),
         stream: "lifecycle",
         data: {
           phase: "end",
@@ -380,6 +406,9 @@ export async function runCliAgentWithLifecycle(params: {
     if (emitLifecycleTerminal) {
       emitAgentEvent({
         runId: params.runId,
+        ...(params.runParams.sessionKey ? { sessionKey: params.runParams.sessionKey } : {}),
+        ...(params.runParams.sessionId ? { sessionId: params.runParams.sessionId } : {}),
+        ...(params.lifecycleGeneration ? { lifecycleGeneration: params.lifecycleGeneration } : {}),
         stream: "lifecycle",
         data: {
           phase: "error",
@@ -398,6 +427,9 @@ export async function runCliAgentWithLifecycle(params: {
     if (emitLifecycleTerminal && !lifecycleTerminalEmitted) {
       emitAgentEvent({
         runId: params.runId,
+        ...(params.runParams.sessionKey ? { sessionKey: params.runParams.sessionKey } : {}),
+        ...(params.runParams.sessionId ? { sessionId: params.runParams.sessionId } : {}),
+        ...(params.lifecycleGeneration ? { lifecycleGeneration: params.lifecycleGeneration } : {}),
         stream: "lifecycle",
         data: {
           phase: "error",

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -42,6 +42,7 @@ const state = vi.hoisted(() => ({
   isContextOverflowErrorMock: vi.fn((_: string | undefined) => false),
   isLikelyContextOverflowErrorMock: vi.fn((_: string | undefined) => false),
   updateSessionStoreMock: vi.fn(),
+  resolveCurrentTurnImagesMock: vi.fn(),
 }));
 
 const GENERIC_RUN_FAILURE_TEXT =
@@ -148,6 +149,7 @@ vi.mock("../../infra/agent-events.js", async () => {
   );
   return {
     ...actual,
+    clearAgentRunContext: vi.fn(),
     emitAgentEvent: vi.fn(),
     registerAgentRunContext: vi.fn(),
   };
@@ -171,6 +173,10 @@ vi.mock("../heartbeat.js", () => ({
     didStrip: false,
     shouldSkip: false,
   }),
+}));
+
+vi.mock("./current-turn-images.js", () => ({
+  resolveCurrentTurnImages: (params: unknown) => state.resolveCurrentTurnImagesMock(params),
 }));
 
 vi.mock("./agent-runner-utils.js", () => ({
@@ -1155,6 +1161,13 @@ describe("runAgentTurnWithFallback", () => {
     state.isLikelyContextOverflowErrorMock.mockReset();
     state.isLikelyContextOverflowErrorMock.mockReturnValue(false);
     state.updateSessionStoreMock.mockReset();
+    state.resolveCurrentTurnImagesMock.mockReset();
+    state.resolveCurrentTurnImagesMock.mockImplementation(
+      async (params: { images?: unknown[]; imageOrder?: unknown[] }) => ({
+        images: params.images,
+        imageOrder: params.imageOrder,
+      }),
+    );
     state.runWithModelFallbackMock.mockImplementation(async (params: FallbackRunnerParams) => ({
       result: await params.run("anthropic", "claude"),
       provider: "anthropic",
@@ -1191,6 +1204,55 @@ describe("runAgentTurnWithFallback", () => {
     expect(fallbackCall.abortSignal).toBe(replyOperation.abortSignal);
     expect(fallbackCall.sessionId).toBe("session");
     expect(embeddedCall.abortSignal).toBe(replyOperation.abortSignal);
+  });
+
+  it("registers run ownership before asynchronous image preflight", async () => {
+    const agentEvents = await import("../../infra/agent-events.js");
+    const registerAgentRunContext = vi.mocked(agentEvents.registerAgentRunContext);
+    let resolveImages: (() => void) | undefined;
+    state.resolveCurrentTurnImagesMock.mockImplementationOnce(
+      () =>
+        new Promise<Record<string, never>>((resolve) => {
+          resolveImages = () => resolve({});
+        }),
+    );
+    state.runEmbeddedAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "ok" }],
+      meta: {},
+    });
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const runPromise = runAgentTurnWithFallback(createMinimalRunAgentTurnParams());
+
+    expect(registerAgentRunContext).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        sessionKey: "main",
+        sessionId: "session",
+      }),
+    );
+    expect(state.runWithModelFallbackMock).not.toHaveBeenCalled();
+
+    resolveImages?.();
+    await runPromise;
+  });
+
+  it("clears run ownership when image preflight fails", async () => {
+    const agentEvents = await import("../../infra/agent-events.js");
+    const clearAgentRunContext = vi.mocked(agentEvents.clearAgentRunContext);
+    state.resolveCurrentTurnImagesMock.mockRejectedValueOnce(new Error("invalid image metadata"));
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    await expect(
+      runAgentTurnWithFallback(
+        createMinimalRunAgentTurnParams({
+          opts: { runId: "preflight-failure" },
+        }),
+      ),
+    ).rejects.toThrow("invalid image metadata");
+
+    expect(clearAgentRunContext).toHaveBeenCalledWith("preflight-failure", expect.any(String));
+    expect(state.runWithModelFallbackMock).not.toHaveBeenCalled();
   });
 
   it("passes runtime toolsAllow to embedded agent runs", async () => {
@@ -5244,12 +5306,14 @@ describe("runAgentTurnWithFallback", () => {
   });
 
   it("surfaces gateway restart text when the reply operation was aborted for restart", async () => {
+    const agentEvents = await import("../../infra/agent-events.js");
+    const emitAgentEvent = vi.mocked(agentEvents.emitAgentEvent);
     const { replyOperation, failMock } = createMockReplyOperation();
     Object.defineProperty(replyOperation, "result", {
       value: { kind: "aborted", code: "aborted_for_restart" } as const,
       configurable: true,
     });
-    state.runWithModelFallbackMock.mockRejectedValueOnce(
+    state.runEmbeddedAgentMock.mockRejectedValueOnce(
       Object.assign(new Error("aborted"), { name: "AbortError" }),
     );
 
@@ -5285,6 +5349,70 @@ describe("runAgentTurnWithFallback", () => {
       );
     }
     expect(failMock).not.toHaveBeenCalled();
+    expect(
+      emitAgentEvent.mock.calls.some(
+        ([event]) =>
+          event.stream === "lifecycle" &&
+          event.data.phase === "end" &&
+          event.data.aborted === true &&
+          event.data.stopReason === "restart",
+      ),
+    ).toBe(true);
+  });
+
+  it("preserves restart ownership when an aborted embedded runner resolves normally", async () => {
+    const agentEvents = await import("../../infra/agent-events.js");
+    const emitAgentEvent = vi.mocked(agentEvents.emitAgentEvent);
+    const { replyOperation } = createMockReplyOperation();
+    Object.defineProperty(replyOperation, "result", {
+      value: { kind: "aborted", code: "aborted_for_restart" } as const,
+      configurable: true,
+    });
+    state.runEmbeddedAgentMock.mockResolvedValueOnce({
+      payloads: [],
+      meta: {},
+    });
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback({
+      commandBody: "hello",
+      followupRun: createFollowupRun(),
+      sessionCtx: {
+        Provider: "whatsapp",
+        MessageSid: "msg",
+      } as unknown as TemplateContext,
+      replyOperation,
+      opts: {},
+      typingSignals: createMockTypingSignaler(),
+      blockReplyPipeline: null,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      applyReplyToMode: (payload) => payload,
+      shouldEmitToolResult: () => true,
+      shouldEmitToolOutput: () => false,
+      pendingToolTasks: new Set(),
+      resetSessionAfterRoleOrderingConflict: async () => false,
+      isHeartbeat: false,
+      sessionKey: "main",
+      getActiveSessionEntry: () => undefined,
+      resolvedVerboseLevel: "off",
+    });
+
+    expect(result).toEqual({
+      kind: "final",
+      payload: expect.objectContaining({
+        text: "⚠️ Gateway is restarting. Please wait a few seconds and try again.",
+      }),
+    });
+    expect(
+      emitAgentEvent.mock.calls.some(
+        ([event]) =>
+          event.stream === "lifecycle" &&
+          event.data.phase === "end" &&
+          event.data.aborted === true &&
+          event.data.stopReason === "restart",
+      ),
+    ).toBe(true);
   });
 
   it("uses compact generic copy for raw external chat errors when verbose is off", async () => {

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -236,6 +236,8 @@ type FallbackRunnerParams = {
 };
 
 type EmbeddedAgentParams = {
+  lifecycleGeneration?: string;
+  onExecutionStarted?: (info?: { lifecycleGeneration?: string }) => void;
   onBlockReply?: (payload: { text?: string; mediaUrls?: string[] }) => Promise<void> | void;
   onToolResult?: (payload: { text?: string; mediaUrls?: string[] }) => Promise<void> | void;
   onItemEvent?: (payload: {
@@ -3948,6 +3950,64 @@ describe("runAgentTurnWithFallback", () => {
       replayInvalid: true,
     });
     expect(typeof lifecycleData.endedAt).toBe("number");
+  });
+
+  it("uses a rebound lifecycle generation for embedded terminal events", async () => {
+    const agentEvents = await import("../../infra/agent-events.js");
+    const emitAgentEvent = vi.mocked(agentEvents.emitAgentEvent);
+    state.runEmbeddedAgentMock.mockImplementationOnce(async (params: EmbeddedAgentParams) => {
+      params.onExecutionStarted?.({ lifecycleGeneration: "post-restart" });
+      await params.onAgentEvent?.({
+        stream: "lifecycle",
+        data: { phase: "start", startedAt: 1_000 },
+      });
+      throw new Error("rebound failure");
+    });
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback({
+      commandBody: "hello",
+      followupRun: createFollowupRun(),
+      sessionCtx: {
+        Provider: "whatsapp",
+        MessageSid: "msg",
+      } as unknown as TemplateContext,
+      opts: { runId: "run-rebound" } as GetReplyOptions,
+      typingSignals: createMockTypingSignaler(),
+      blockReplyPipeline: null,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      applyReplyToMode: (payload) => payload,
+      shouldEmitToolResult: () => true,
+      shouldEmitToolOutput: () => false,
+      pendingToolTasks: new Set(),
+      resetSessionAfterRoleOrderingConflict: async () => false,
+      isHeartbeat: false,
+      sessionKey: "main",
+      getActiveSessionEntry: () => undefined,
+      resolvedVerboseLevel: "off",
+    });
+
+    expect(result.kind).toBe("final");
+    const lifecycleEvents = emitAgentEvent.mock.calls
+      .map((call) => call[0])
+      .filter(
+        (event) =>
+          event.runId === "run-rebound" &&
+          event.stream === "lifecycle" &&
+          (event.data.phase === "error" || event.data.fallbackExhaustedFailure === true),
+      );
+    expect(lifecycleEvents.length).toBeGreaterThan(0);
+    expect(lifecycleEvents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          lifecycleGeneration: "post-restart",
+        }),
+      ]),
+    );
+    expect(lifecycleEvents.every((event) => event.lifecycleGeneration === "post-restart")).toBe(
+      true,
+    );
   });
 
   it("does not duplicate embedded lifecycle terminal events already reported by the runner", async () => {

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -63,7 +63,11 @@ import {
 import { resolveSilentReplyPolicy } from "../../config/silent-reply.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { logVerbose } from "../../globals.js";
-import { emitAgentEvent, registerAgentRunContext } from "../../infra/agent-events.js";
+import {
+  captureAgentRunLifecycleGeneration,
+  emitAgentEvent,
+  registerAgentRunContext,
+} from "../../infra/agent-events.js";
 import { isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { logSessionTurnCreated } from "../../logging/diagnostic.js";
@@ -1307,7 +1311,11 @@ function isReplyOperationRestartAbort(replyOperation?: ReplyOperation): boolean 
   );
 }
 
-function createEmbeddedLifecycleTerminalBackstop(params: { runId: string; sessionKey?: string }) {
+function createEmbeddedLifecycleTerminalBackstop(params: {
+  runId: string;
+  sessionKey?: string;
+  getLifecycleGeneration: () => string;
+}) {
   let terminalEmitted = false;
   let startedAt: number | undefined;
 
@@ -1358,6 +1366,7 @@ function createEmbeddedLifecycleTerminalBackstop(params: { runId: string; sessio
     }
     emitAgentEvent({
       runId: params.runId,
+      lifecycleGeneration: params.getLifecycleGeneration(),
       ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
       stream: "lifecycle",
       data,
@@ -1665,6 +1674,7 @@ export async function runAgentTurnWithFallback(params: {
       isControlUiVisible: shouldSurfaceToControlUi,
     });
   }
+  let lifecycleGeneration = captureAgentRunLifecycleGeneration(runId);
   let runResult: Awaited<ReturnType<typeof runEmbeddedAgent>>;
   let fallbackProvider = params.followupRun.run.provider;
   let fallbackModel = params.followupRun.run.model;
@@ -2117,6 +2127,7 @@ export async function runAgentTurnWithFallback(params: {
               const result = await agentTurnTiming.measure("cli_run", () =>
                 runCliAgentWithLifecycle({
                   runId,
+                  lifecycleGeneration,
                   provider: cliExecutionProvider,
                   onAgentRunStart: notifyAgentRunStart,
                   suppressAssistantBridge: params.followupRun.run.silentExpected,
@@ -2298,6 +2309,7 @@ export async function runAgentTurnWithFallback(params: {
               const lifecycleBackstop = createEmbeddedLifecycleTerminalBackstop({
                 runId,
                 sessionKey: params.sessionKey,
+                getLifecycleGeneration: () => lifecycleGeneration,
               });
               try {
                 // Profiler-only milestone: it exposes time spent before Codex
@@ -2311,6 +2323,7 @@ export async function runAgentTurnWithFallback(params: {
                 const result = await agentTurnTiming.measure("embedded_run", () =>
                   runEmbeddedAgent({
                     ...embeddedContext,
+                    lifecycleGeneration,
                     allowGatewaySubagentBinding: true,
                     trigger: params.isHeartbeat ? "heartbeat" : "user",
                     groupId: resolveGroupSessionKey(params.sessionCtx)?.id,
@@ -2367,6 +2380,11 @@ export async function runAgentTurnWithFallback(params: {
                     imageOrder: currentTurnImages.imageOrder,
                     abortSignal: runAbortSignal,
                     replyOperation: params.replyOperation,
+                    onExecutionStarted: (info) => {
+                      if (info?.lifecycleGeneration) {
+                        lifecycleGeneration = info.lifecycleGeneration;
+                      }
+                    },
                     blockReplyBreak: params.resolvedBlockStreamingBreak,
                     blockReplyChunking: params.blockReplyChunking,
                     onPartialReply: async (payload) => {
@@ -2957,6 +2975,7 @@ export async function runAgentTurnWithFallback(params: {
 
       emitAgentEvent({
         runId,
+        lifecycleGeneration,
         ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
         stream: "lifecycle",
         data: {

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -54,6 +54,12 @@ import {
   resolvePersistedOverrideModelRef,
 } from "../../agents/model-selection.js";
 import { resolveOpenAIRuntimeProvider } from "../../agents/openai-routing.js";
+import {
+  AGENT_RUN_RESTART_ABORT_STOP_REASON,
+  createAgentRunRestartAbortError,
+  isAgentRunRestartAbortReason,
+  resolveAgentRunAbortLifecycleFields,
+} from "../../agents/run-termination.js";
 import { buildAgentRuntimeOutcomePlan } from "../../agents/runtime-plan/build.js";
 import {
   resolveGroupSessionKey,
@@ -65,6 +71,7 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { logVerbose } from "../../globals.js";
 import {
   captureAgentRunLifecycleGeneration,
+  clearAgentRunContext,
   emitAgentEvent,
   registerAgentRunContext,
 } from "../../infra/agent-events.js";
@@ -1315,6 +1322,10 @@ function createEmbeddedLifecycleTerminalBackstop(params: {
   runId: string;
   sessionKey?: string;
   getLifecycleGeneration: () => string;
+  resolveAbortLifecycleFields: () => {
+    aborted?: true;
+    stopReason?: string;
+  };
 }) {
   let terminalEmitted = false;
   let startedAt: number | undefined;
@@ -1337,13 +1348,20 @@ function createEmbeddedLifecycleTerminalBackstop(params: {
       return;
     }
     terminalEmitted = true;
+    const abortLifecycleFields = params.resolveAbortLifecycleFields();
+    const restartAbort = abortLifecycleFields.stopReason === AGENT_RUN_RESTART_ABORT_STOP_REASON;
+    const terminalPhase = restartAbort ? "end" : phase;
     const data: Record<string, unknown> = {
-      phase,
+      phase: terminalPhase,
       endedAt: Date.now(),
       ...(startedAt !== undefined ? { startedAt } : {}),
     };
-    if (phase === "error") {
+    if (restartAbort) {
+      data.aborted = true;
+      data.stopReason = AGENT_RUN_RESTART_ABORT_STOP_REASON;
+    } else if (phase === "error") {
       data.error = formatErrorMessage(resultOrError);
+      Object.assign(data, abortLifecycleFields);
     } else {
       const meta =
         resultOrError && typeof resultOrError === "object" && "meta" in resultOrError
@@ -1362,6 +1380,12 @@ function createEmbeddedLifecycleTerminalBackstop(params: {
       }
       if (meta?.replayInvalid === true) {
         data.replayInvalid = true;
+      }
+      if (abortLifecycleFields.aborted === true) {
+        data.aborted = true;
+      }
+      if (abortLifecycleFields.stopReason && !readStringValue(data.stopReason)) {
+        data.stopReason = abortLifecycleFields.stopReason;
       }
     }
     emitAgentEvent({
@@ -1577,6 +1601,22 @@ export async function runAgentTurnWithFallback(params: {
   const agentTurnTiming = createAgentTurnTimingTracker({
     profilerEnabled: isReplyProfilerEnabled({ config: runtimeConfig }),
   });
+  const shouldSurfaceToControlUi = isInternalMessageChannel(
+    params.followupRun.run.messageProvider ??
+      params.sessionCtx.Surface ??
+      params.sessionCtx.Provider,
+  );
+  let lifecycleGeneration = captureAgentRunLifecycleGeneration(runId);
+  if (params.sessionKey) {
+    registerAgentRunContext(runId, {
+      sessionKey: params.sessionKey,
+      ...(params.followupRun.run.sessionId ? { sessionId: params.followupRun.run.sessionId } : {}),
+      lifecycleGeneration,
+      verboseLevel: params.resolvedVerboseLevel,
+      isHeartbeat: params.isHeartbeat,
+      isControlUiVisible: shouldSurfaceToControlUi,
+    });
+  }
   if (isDiagnosticsEnabled(runtimeConfig)) {
     logSessionTurnCreated({
       runId,
@@ -1590,32 +1630,40 @@ export async function runAgentTurnWithFallback(params: {
       trigger: params.isHeartbeat ? "heartbeat" : "user",
     });
   }
-  const replyMediaContext =
-    params.replyMediaContext ??
-    agentTurnTiming.measureSync("reply_media_context", () =>
-      createReplyMediaContext({
+  let replyMediaContext: ReplyMediaContext;
+  let currentTurnImages: Awaited<ReturnType<typeof resolveCurrentTurnImages>>;
+  try {
+    replyMediaContext =
+      params.replyMediaContext ??
+      agentTurnTiming.measureSync("reply_media_context", () =>
+        createReplyMediaContext({
+          cfg: runtimeConfig,
+          sessionKey: params.sessionKey,
+          workspaceDir: params.followupRun.run.workspaceDir,
+          messageProvider: params.followupRun.run.messageProvider,
+          accountId:
+            params.followupRun.originatingAccountId ?? params.followupRun.run.agentAccountId,
+          groupId: params.followupRun.run.groupId,
+          groupChannel: params.followupRun.run.groupChannel,
+          groupSpace: params.followupRun.run.groupSpace,
+          requesterSenderId: params.followupRun.run.senderId,
+          requesterSenderName: params.followupRun.run.senderName,
+          requesterSenderUsername: params.followupRun.run.senderUsername,
+          requesterSenderE164: params.followupRun.run.senderE164,
+        }),
+      );
+    currentTurnImages = await agentTurnTiming.measure("current_turn_images", () =>
+      resolveCurrentTurnImages({
+        ctx: params.sessionCtx,
         cfg: runtimeConfig,
-        sessionKey: params.sessionKey,
-        workspaceDir: params.followupRun.run.workspaceDir,
-        messageProvider: params.followupRun.run.messageProvider,
-        accountId: params.followupRun.originatingAccountId ?? params.followupRun.run.agentAccountId,
-        groupId: params.followupRun.run.groupId,
-        groupChannel: params.followupRun.run.groupChannel,
-        groupSpace: params.followupRun.run.groupSpace,
-        requesterSenderId: params.followupRun.run.senderId,
-        requesterSenderName: params.followupRun.run.senderName,
-        requesterSenderUsername: params.followupRun.run.senderUsername,
-        requesterSenderE164: params.followupRun.run.senderE164,
+        images: params.followupRun.images ?? params.opts?.images,
+        imageOrder: params.followupRun.imageOrder ?? params.opts?.imageOrder,
       }),
     );
-  const currentTurnImages = await agentTurnTiming.measure("current_turn_images", () =>
-    resolveCurrentTurnImages({
-      ctx: params.sessionCtx,
-      cfg: runtimeConfig,
-      images: params.followupRun.images ?? params.opts?.images,
-      imageOrder: params.followupRun.imageOrder ?? params.opts?.imageOrder,
-    }),
-  );
+  } catch (error) {
+    clearAgentRunContext(runId, lifecycleGeneration);
+    throw error;
+  }
   let didNotifyAgentRunStart = false;
   const notifyAgentRunStart = () => {
     if (didNotifyAgentRunStart) {
@@ -1660,21 +1708,6 @@ export async function runAgentTurnWithFallback(params: {
     }
     await deliverCompactionNoticePayload(noticePayload, "hook");
   };
-  const shouldSurfaceToControlUi = isInternalMessageChannel(
-    params.followupRun.run.messageProvider ??
-      params.sessionCtx.Surface ??
-      params.sessionCtx.Provider,
-  );
-  if (params.sessionKey) {
-    registerAgentRunContext(runId, {
-      sessionKey: params.sessionKey,
-      ...(params.followupRun.run.sessionId ? { sessionId: params.followupRun.run.sessionId } : {}),
-      verboseLevel: params.resolvedVerboseLevel,
-      isHeartbeat: params.isHeartbeat,
-      isControlUiVisible: shouldSurfaceToControlUi,
-    });
-  }
-  let lifecycleGeneration = captureAgentRunLifecycleGeneration(runId);
   let runResult: Awaited<ReturnType<typeof runEmbeddedAgent>>;
   let fallbackProvider = params.followupRun.run.provider;
   let fallbackModel = params.followupRun.run.model;
@@ -2310,6 +2343,15 @@ export async function runAgentTurnWithFallback(params: {
                 runId,
                 sessionKey: params.sessionKey,
                 getLifecycleGeneration: () => lifecycleGeneration,
+                resolveAbortLifecycleFields: () => ({
+                  ...resolveAgentRunAbortLifecycleFields(runAbortSignal),
+                  ...(isReplyOperationRestartAbort(params.replyOperation)
+                    ? {
+                        aborted: true as const,
+                        stopReason: AGENT_RUN_RESTART_ABORT_STOP_REASON,
+                      }
+                    : {}),
+                }),
               });
               try {
                 // Profiler-only milestone: it exposes time spent before Codex
@@ -2712,6 +2754,12 @@ export async function runAgentTurnWithFallback(params: {
         sessionKey: params.sessionKey,
         outcome: "completed",
       });
+      const restartAbortReason = runAbortSignal?.reason;
+      if (isReplyOperationRestartAbort(params.replyOperation)) {
+        throw isAgentRunRestartAbortReason(restartAbortReason)
+          ? restartAbortReason
+          : createAgentRunRestartAbortError();
+      }
       runResult = fallbackResult.result;
       fallbackProvider = fallbackResult.provider;
       fallbackModel = fallbackResult.model;
@@ -2972,6 +3020,21 @@ export async function runAgentTurnWithFallback(params: {
         isGenericRunnerFailure: externalRunFailureReply?.isGenericRunnerFailure ?? false,
         cfg: params.followupRun.run.config,
       });
+      const abortedSignal =
+        params.replyOperation?.abortSignal.aborted === true
+          ? params.replyOperation.abortSignal
+          : params.opts?.abortSignal?.aborted === true
+            ? params.opts.abortSignal
+            : undefined;
+      const abortLifecycleFields = {
+        ...resolveAgentRunAbortLifecycleFields(abortedSignal),
+        ...(isReplyOperationRestartAbort(params.replyOperation)
+          ? {
+              aborted: true as const,
+              stopReason: AGENT_RUN_RESTART_ABORT_STOP_REASON,
+            }
+          : {}),
+      };
 
       emitAgentEvent({
         runId,
@@ -2982,6 +3045,7 @@ export async function runAgentTurnWithFallback(params: {
           phase: "error",
           error: message,
           endedAt: Date.now(),
+          ...abortLifecycleFields,
           fallbackExhaustedFailure: true,
         },
       });

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -39,6 +39,7 @@ let setRuntimeConfigSnapshot: typeof import("../../config/config.js").setRuntime
 let createMockFollowupRun: typeof import("./test-helpers.js").createMockFollowupRun;
 let createMockTypingController: typeof import("./test-helpers.js").createMockTypingController;
 let createReplyOperationForTest: typeof import("./reply-run-registry.js").createReplyOperation;
+let abortActiveReplyRunsForTest: typeof import("./reply-run-registry.js").abortActiveReplyRuns;
 let replyRunTestingForTest: typeof import("./reply-run-registry.js").testing;
 let cliBackendsTestingForTest: typeof import("../../agents/cli-backends.js").testing;
 let setReplyPayloadMetadataForTest: typeof import("../reply-payload.js").setReplyPayloadMetadata;
@@ -463,8 +464,11 @@ async function loadFreshFollowupRunnerModuleForTest() {
   ({ clearFollowupQueue, enqueueFollowupRun } = await import("./queue.js"));
   sessionRunAccounting = await import("./session-run-accounting.js");
   ({ createMockFollowupRun, createMockTypingController } = await import("./test-helpers.js"));
-  ({ createReplyOperation: createReplyOperationForTest, testing: replyRunTestingForTest } =
-    await import("./reply-run-registry.js"));
+  ({
+    abortActiveReplyRuns: abortActiveReplyRunsForTest,
+    createReplyOperation: createReplyOperationForTest,
+    testing: replyRunTestingForTest,
+  } = await import("./reply-run-registry.js"));
   ({ setReplyPayloadMetadata: setReplyPayloadMetadataForTest } =
     await import("../reply-payload.js"));
 }
@@ -1597,6 +1601,86 @@ describe("createFollowupRunner runtime config", () => {
     const embeddedCall = requireLastMockCallArg(runEmbeddedAgentMock, "run embedded agent");
     expect(embeddedCall.suppressAssistantErrorPersistence).toBe(false);
     expect(lifecyclePhases).toEqual(["start", "start", "end"]);
+  });
+
+  it("suppresses deferred CLI success after restart cancellation", async () => {
+    const realAgentEvents = await vi.importActual<typeof import("../../infra/agent-events.js")>(
+      "../../infra/agent-events.js",
+    );
+    const lifecycleEvents: Array<Record<string, unknown>> = [];
+    const unsubscribe = realAgentEvents.onAgentEvent((evt) => {
+      if (evt.stream === "lifecycle") {
+        lifecycleEvents.push(evt.data);
+      }
+    });
+    const runtimeConfig: OpenClawConfig = {
+      agents: {
+        defaults: {
+          cliBackends: {
+            "claude-cli": { command: "claude" },
+          },
+          models: {
+            "anthropic/claude-opus-4-7": { agentRuntime: { id: "claude-cli" } },
+          },
+        },
+      },
+    };
+    let resolveCli: (() => void) | undefined;
+    runCliAgentMock.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveCli = () =>
+            resolve({
+              payloads: [{ text: "completed after restart" }],
+              meta: {
+                agentMeta: {
+                  provider: "claude-cli",
+                  model: "claude-opus-4-7",
+                },
+              },
+            });
+        }),
+    );
+    const runner = createFollowupRunner({
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      sessionKey: "main",
+      defaultModel: "anthropic/claude-opus-4-7",
+    });
+
+    try {
+      const pending = runner(
+        createQueuedRun({
+          originatingChannel: "telegram",
+          originatingTo: "chat-1",
+          run: {
+            config: runtimeConfig,
+            provider: "anthropic",
+            model: "claude-opus-4-7",
+            messageProvider: "telegram",
+          },
+        }),
+      );
+      await vi.waitFor(() => {
+        expect(runCliAgentMock).toHaveBeenCalledTimes(1);
+      });
+      expect(abortActiveReplyRunsForTest({ mode: "all" })).toBe(true);
+      resolveCli?.();
+      await pending;
+    } finally {
+      unsubscribe();
+    }
+
+    expect(lifecycleEvents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          phase: "error",
+          aborted: true,
+          stopReason: "restart",
+        }),
+      ]),
+    );
+    expect(routeReplyMock).not.toHaveBeenCalled();
   });
 
   it("uses the active runtime snapshot for queued embedded followup runs", async () => {

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -2992,6 +2992,82 @@ describe("createFollowupRunner compaction", () => {
     expect(realAgentEvents.getAgentRunContext(observedRunId ?? "")?.sessionId).toBe("new-session");
     realAgentEvents.resetAgentRunContextForTest();
   });
+
+  it("captures follow-up lifecycle ownership before asynchronous preflight", async () => {
+    const realAgentEvents = await vi.importActual<typeof import("../../infra/agent-events.js")>(
+      "../../infra/agent-events.js",
+    );
+    realAgentEvents.resetAgentRunContextForTest();
+    const initialGeneration = realAgentEvents.getAgentEventLifecycleGeneration();
+    let releasePreflight: (() => void) | undefined;
+    runPreflightCompactionIfNeededMock.mockImplementationOnce(
+      async (params: { sessionEntry?: SessionEntry }) => {
+        await new Promise<void>((resolve) => {
+          releasePreflight = resolve;
+        });
+        return params.sessionEntry;
+      },
+    );
+    let observedLifecycleGeneration: string | undefined;
+    runEmbeddedAgentMock.mockImplementationOnce(
+      async (params: { lifecycleGeneration?: string }) => {
+        observedLifecycleGeneration = params.lifecycleGeneration;
+        if (params.lifecycleGeneration !== realAgentEvents.getAgentEventLifecycleGeneration()) {
+          const error = new Error("Agent run belongs to a stale gateway lifecycle");
+          error.name = "AbortError";
+          throw error;
+        }
+        return {
+          payloads: [{ text: "final" }],
+          meta: { agentMeta: { usage: { input: 1, output: 1 } } },
+        };
+      },
+    );
+    const runner = createFollowupRunner({
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      sessionEntry: {
+        sessionId: "preflight-session",
+        updatedAt: Date.now(),
+      },
+      sessionKey: "main",
+      defaultModel: "anthropic/claude",
+    });
+
+    try {
+      const pending = runner(
+        createQueuedRun({
+          run: {
+            sessionId: "preflight-session",
+            sessionKey: "main",
+            provider: "anthropic",
+            model: "claude",
+          },
+        }),
+      );
+      await vi.waitFor(() => {
+        expect(runPreflightCompactionIfNeededMock).toHaveBeenCalledTimes(1);
+      });
+      const [registeredRun] = realAgentEvents.listAgentRunsForSession({
+        sessionKey: "main",
+        sessionId: "preflight-session",
+      });
+      expect(registeredRun).toEqual(
+        expect.objectContaining({
+          lifecycleGeneration: initialGeneration,
+        }),
+      );
+
+      realAgentEvents.rotateAgentEventLifecycleGeneration();
+      releasePreflight?.();
+      await pending;
+
+      expect(observedLifecycleGeneration).toBe(initialGeneration);
+      expect(realAgentEvents.getAgentRunContext(registeredRun?.runId ?? "")).toBeUndefined();
+    } finally {
+      realAgentEvents.resetAgentRunContextForTest();
+    }
+  });
 });
 
 describe("createFollowupRunner bootstrap warning dedupe", () => {

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -30,7 +30,9 @@ import type { TypingMode } from "../../config/types.js";
 import { logVerbose } from "../../globals.js";
 import {
   captureAgentRunLifecycleGeneration,
+  clearAgentRunContext,
   emitAgentEvent,
+  getAgentEventLifecycleGeneration,
   registerAgentRunContext,
 } from "../../infra/agent-events.js";
 import { formatErrorMessage } from "../../infra/errors.js";
@@ -644,6 +646,16 @@ export function createFollowupRunner(params: {
             );
           }
         : undefined;
+      let lifecycleGeneration = captureAgentRunLifecycleGeneration(runId);
+      if (run.sessionKey) {
+        registerAgentRunContext(runId, {
+          sessionKey: run.sessionKey,
+          ...(run.sessionId ? { sessionId: run.sessionId } : {}),
+          lifecycleGeneration,
+          verboseLevel: run.verboseLevel,
+          isControlUiVisible: shouldSurfaceToControlUi,
+        });
+      }
       try {
         activeSessionEntry = await runPreflightCompactionIfNeeded({
           cfg: runtimeConfig,
@@ -660,6 +672,7 @@ export function createFollowupRunner(params: {
           onCompactionNotice: notifyPreflightCompaction,
         });
       } catch (err) {
+        clearAgentRunContext(runId, lifecycleGeneration);
         const message = formatErrorMessage(err);
         replyOperation.fail("run_failed", err);
         const preflightCompactionFailureText = buildPreflightCompactionFailureText(message, {
@@ -687,11 +700,11 @@ export function createFollowupRunner(params: {
         registerAgentRunContext(runId, {
           sessionKey: run.sessionKey,
           ...(owningSessionId ? { sessionId: owningSessionId } : {}),
+          lifecycleGeneration,
           verboseLevel: run.verboseLevel,
           isControlUiVisible: shouldSurfaceToControlUi,
         });
       }
-      let lifecycleGeneration = captureAgentRunLifecycleGeneration(runId);
       let bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
         activeSessionEntry?.systemPromptReport,
       );
@@ -1182,6 +1195,9 @@ export function createFollowupRunner(params: {
             },
           });
           pendingDeferredCliTerminal = undefined;
+        }
+        if (lifecycleGeneration !== getAgentEventLifecycleGeneration()) {
+          clearAgentRunContext(runId, lifecycleGeneration);
         }
         await drainProgressDeliveries();
         defaultRuntime.error?.(`Followup agent failed before reply: ${message}`);

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -17,6 +17,10 @@ import { runWithModelFallback } from "../../agents/model-fallback.js";
 import { resolveCliRuntimeExecutionProvider } from "../../agents/model-runtime-aliases.js";
 import { isCliProvider } from "../../agents/model-selection-cli.js";
 import {
+  isAgentRunRestartAbortReason,
+  resolveAgentRunAbortLifecycleFields,
+} from "../../agents/run-termination.js";
+import {
   buildAgentRuntimeDeliveryPlan,
   buildAgentRuntimeOutcomePlan,
 } from "../../agents/runtime-plan/build.js";
@@ -1136,6 +1140,9 @@ export function createFollowupRunner(params: {
         runResult = fallbackResult.result;
         fallbackProvider = fallbackResult.provider;
         fallbackModel = fallbackResult.model;
+        if (isAgentRunRestartAbortReason(runAbortSignal.reason)) {
+          throw runAbortSignal.reason;
+        }
         if (
           pendingDeferredCliTerminal &&
           pendingDeferredCliTerminal.provider === fallbackProvider &&
@@ -1149,6 +1156,7 @@ export function createFollowupRunner(params: {
               phase: "end",
               startedAt: pendingDeferredCliTerminal.startedAt,
               endedAt: Date.now(),
+              ...resolveAgentRunAbortLifecycleFields(runAbortSignal),
             },
           });
         }
@@ -1170,6 +1178,7 @@ export function createFollowupRunner(params: {
               startedAt: pendingDeferredCliTerminal.startedAt,
               endedAt: Date.now(),
               error: message,
+              ...resolveAgentRunAbortLifecycleFields(runAbortSignal),
             },
           });
           pendingDeferredCliTerminal = undefined;

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -24,7 +24,11 @@ import { updateSessionStore, type SessionEntry } from "../../config/sessions.js"
 import { readSessionEntry } from "../../config/sessions/store-load.js";
 import type { TypingMode } from "../../config/types.js";
 import { logVerbose } from "../../globals.js";
-import { emitAgentEvent, registerAgentRunContext } from "../../infra/agent-events.js";
+import {
+  captureAgentRunLifecycleGeneration,
+  emitAgentEvent,
+  registerAgentRunContext,
+} from "../../infra/agent-events.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { defaultRuntime } from "../../runtime.js";
 import { shouldPreserveUserFacingSessionStateForInputProvenance } from "../../sessions/input-provenance.js";
@@ -683,6 +687,7 @@ export function createFollowupRunner(params: {
           isControlUiVisible: shouldSurfaceToControlUi,
         });
       }
+      let lifecycleGeneration = captureAgentRunLifecycleGeneration(runId);
       let bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
         activeSessionEntry?.systemPromptReport,
       );
@@ -879,6 +884,7 @@ export function createFollowupRunner(params: {
                 });
                 const result = await runCliAgentWithLifecycle({
                   runId,
+                  lifecycleGeneration,
                   provider: cliExecutionProvider,
                   startedAt: cliLifecycleStartedAt,
                   emitLifecycleTerminal: false,
@@ -1007,6 +1013,7 @@ export function createFollowupRunner(params: {
               const followupCurrentMessageId = resolveFollowupCurrentMessageId();
               const result = await runEmbeddedAgent({
                 allowGatewaySubagentBinding: true,
+                lifecycleGeneration,
                 replyOperation,
                 sessionId: run.sessionId,
                 sessionKey: run.sessionKey,
@@ -1071,6 +1078,11 @@ export function createFollowupRunner(params: {
                 runTimeoutOverrideMs: run.runTimeoutOverrideMs,
                 runId,
                 abortSignal: runAbortSignal,
+                onExecutionStarted: (info) => {
+                  if (info?.lifecycleGeneration) {
+                    lifecycleGeneration = info.lifecycleGeneration;
+                  }
+                },
                 images: queuedImages,
                 imageOrder: queuedImageOrder,
                 allowTransientCooldownProbe: runOptions?.allowTransientCooldownProbe,
@@ -1131,6 +1143,7 @@ export function createFollowupRunner(params: {
         ) {
           emitAgentEvent({
             runId,
+            lifecycleGeneration,
             stream: "lifecycle",
             data: {
               phase: "end",
@@ -1150,6 +1163,7 @@ export function createFollowupRunner(params: {
         if (pendingDeferredCliTerminal) {
           emitAgentEvent({
             runId,
+            lifecycleGeneration,
             stream: "lifecycle",
             data: {
               phase: "error",

--- a/src/auto-reply/reply/reply-run-registry.ts
+++ b/src/auto-reply/reply/reply-run-registry.ts
@@ -1,5 +1,6 @@
 // Tracks active reply runs so stop, queue, and status commands can coordinate.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { createAgentRunRestartAbortError } from "../../agents/run-termination.js";
 import {
   markDiagnosticEmbeddedRunEnded,
   markDiagnosticEmbeddedRunStarted,
@@ -398,7 +399,7 @@ export function createReplyOperation(params: {
     },
     abortForRestart() {
       const phaseBeforeAbort = phase;
-      abortWithReason("restart", new Error("Reply operation aborted for restart"), {
+      abortWithReason("restart", createAgentRunRestartAbortError(), {
         abortedCode: "aborted_for_restart",
       });
       if (phaseBeforeAbort === "queued") {

--- a/src/channels/message/send.ts
+++ b/src/channels/message/send.ts
@@ -136,6 +136,8 @@ function toDurablePayloadOutcomes(
 
 export type DurableMessageSendContextParams = DurableMessageBatchSendParams & {
   durability?: Exclude<MessageDurabilityPolicy, "disabled">;
+  /** Runs after the durable queue intent exists and before platform delivery starts. */
+  onDeliveryIntent?: (intent: DurableMessageSendIntent) => void;
   preview?: LiveMessageState<ReplyPayload>;
   onPreviewUpdate?: (
     rendered: RenderedMessageBatch<ReplyPayload>,
@@ -164,6 +166,7 @@ export async function withDurableMessageSendContext<T>(
     attempt,
     durability,
     onDeleteReceipt,
+    onDeliveryIntent,
     onEditReceipt,
     onCommitReceipt,
     onPreviewUpdate,
@@ -215,7 +218,9 @@ export async function withDurableMessageSendContext<T>(
           },
           onDeliveryIntent: (intent) => {
             deliveryIntent = intent;
-            ctx.intent = toDurableMessageIntent(intent, rendered);
+            const durableIntent = toDurableMessageIntent(intent, rendered);
+            ctx.intent = durableIntent;
+            onDeliveryIntent?.(durableIntent);
           },
         });
         const receipt = createMessageReceiptFromOutboundResults({

--- a/src/cli/gateway-cli/lifecycle.runtime.ts
+++ b/src/cli/gateway-cli/lifecycle.runtime.ts
@@ -25,6 +25,7 @@ export {
   scheduleGatewaySigusr1Restart,
 } from "../../infra/restart.js";
 export { writeGatewayRestartHandoffSync } from "../../infra/restart-handoff.js";
+export { rotateAgentEventLifecycleGeneration } from "../../infra/agent-events.js";
 export { markUpdateRestartSentinelFailure } from "../../infra/restart-sentinel.js";
 export { detectRespawnSupervisor } from "../../infra/supervisor-markers.js";
 export { writeDiagnosticStabilityBundleForFailureSync } from "../../logging/diagnostic-stability-bundle.js";

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -76,7 +76,7 @@ const markUpdateRestartSentinelFailure = vi.fn<(reason: string) => Promise<null>
   async (_reason: string) => null,
 );
 const abortEmbeddedAgentRun = vi.fn(
-  (_sessionId?: string, _opts?: { mode?: "all" | "compacting" }) => false,
+  (_sessionId?: string, _opts?: { mode?: "all" | "compacting"; reason?: "restart" }) => false,
 );
 const getActiveEmbeddedRunCount = vi.fn(() => 0);
 const listActiveEmbeddedRunSessionIds = vi.fn(() => [] as string[]);
@@ -168,8 +168,10 @@ vi.mock("../../tasks/task-registry.maintenance.js", () => ({
 }));
 
 vi.mock("../../agents/embedded-agent-runner/runs.js", () => ({
-  abortEmbeddedAgentRun: (sessionId?: string, opts?: { mode?: "all" | "compacting" }) =>
-    abortEmbeddedAgentRun(sessionId, opts),
+  abortEmbeddedAgentRun: (
+    sessionId?: string,
+    opts?: { mode?: "all" | "compacting"; reason?: "restart" },
+  ) => abortEmbeddedAgentRun(sessionId, opts),
   getActiveEmbeddedRunCount: () => getActiveEmbeddedRunCount(),
   listActiveEmbeddedRunSessionIds: () => listActiveEmbeddedRunSessionIds(),
   listActiveEmbeddedRunSessionKeys: () => listActiveEmbeddedRunSessionKeys(),
@@ -528,8 +530,14 @@ describe("runGatewayLoop", () => {
       });
 
       expect(waitForActiveEmbeddedRuns).toHaveBeenCalledWith(undefined);
-      expect(abortEmbeddedAgentRun).toHaveBeenCalledWith(undefined, { mode: "compacting" });
-      expect(abortEmbeddedAgentRun).not.toHaveBeenCalledWith(undefined, { mode: "all" });
+      expect(abortEmbeddedAgentRun).toHaveBeenCalledWith(undefined, {
+        mode: "compacting",
+        reason: "restart",
+      });
+      expect(abortEmbeddedAgentRun).not.toHaveBeenCalledWith(undefined, {
+        mode: "all",
+        reason: "restart",
+      });
       expectRestartCloseCall(close, 15_000);
       expect(start).toHaveBeenCalledTimes(2);
 
@@ -564,8 +572,14 @@ describe("runGatewayLoop", () => {
       });
 
       expect(waitForActiveEmbeddedRuns).toHaveBeenCalledWith(undefined);
-      expect(abortEmbeddedAgentRun).toHaveBeenCalledWith(undefined, { mode: "compacting" });
-      expect(abortEmbeddedAgentRun).not.toHaveBeenCalledWith(undefined, { mode: "all" });
+      expect(abortEmbeddedAgentRun).toHaveBeenCalledWith(undefined, {
+        mode: "compacting",
+        reason: "restart",
+      });
+      expect(abortEmbeddedAgentRun).not.toHaveBeenCalledWith(undefined, {
+        mode: "all",
+        reason: "restart",
+      });
       expectRestartCloseCall(close, 15_000);
       expect(start).toHaveBeenCalledTimes(2);
 
@@ -600,8 +614,14 @@ describe("runGatewayLoop", () => {
 
       expect(waitForActiveTasks).toHaveBeenCalledWith(90_000);
       expect(waitForActiveEmbeddedRuns).toHaveBeenCalledWith(90_000);
-      expect(abortEmbeddedAgentRun).toHaveBeenCalledWith(undefined, { mode: "compacting" });
-      expect(abortEmbeddedAgentRun).toHaveBeenCalledWith(undefined, { mode: "all" });
+      expect(abortEmbeddedAgentRun).toHaveBeenCalledWith(undefined, {
+        mode: "compacting",
+        reason: "restart",
+      });
+      expect(abortEmbeddedAgentRun).toHaveBeenCalledWith(undefined, {
+        mode: "all",
+        reason: "restart",
+      });
       expect(gatewayLog.warn).toHaveBeenCalledWith(ACTIVE_RUN_DRAIN_TIMEOUT_LOG);
       expect(gatewayLog.warn).toHaveBeenCalledWith(DRAIN_TIMEOUT_LOG);
       expect(markRestartAbortedMainSessions).toHaveBeenCalledWith({
@@ -653,8 +673,14 @@ describe("runGatewayLoop", () => {
 
       expect(waitForActiveTasks).not.toHaveBeenCalled();
       expect(waitForActiveEmbeddedRuns).not.toHaveBeenCalled();
-      expect(abortEmbeddedAgentRun).toHaveBeenCalledWith(undefined, { mode: "compacting" });
-      expect(abortEmbeddedAgentRun).toHaveBeenCalledWith(undefined, { mode: "all" });
+      expect(abortEmbeddedAgentRun).toHaveBeenCalledWith(undefined, {
+        mode: "compacting",
+        reason: "restart",
+      });
+      expect(abortEmbeddedAgentRun).toHaveBeenCalledWith(undefined, {
+        mode: "all",
+        reason: "restart",
+      });
       expect(markRestartAbortedMainSessions).toHaveBeenCalledWith({
         cfg: {
           gateway: {
@@ -665,7 +691,7 @@ describe("runGatewayLoop", () => {
         },
         sessionIds: new Set(["session-deferral-timeout"]),
         sessionKeys: new Set(["agent:main:deferral-timeout"]),
-        reason: "config reload forced restart",
+        reason: "gateway restart drain",
       });
       expect(markGatewaySigusr1RestartHandled).toHaveBeenCalledOnce();
       expectRestartCloseCall(close, 0);
@@ -712,7 +738,10 @@ describe("runGatewayLoop", () => {
 
       expect(waitForActiveTasks).not.toHaveBeenCalled();
       expect(waitForActiveEmbeddedRuns).not.toHaveBeenCalled();
-      expect(abortEmbeddedAgentRun).toHaveBeenCalledWith(undefined, { mode: "all" });
+      expect(abortEmbeddedAgentRun).toHaveBeenCalledWith(undefined, {
+        mode: "all",
+        reason: "restart",
+      });
       expect(markRestartAbortedMainSessions).toHaveBeenCalledWith({
         cfg: {
           gateway: {
@@ -723,7 +752,7 @@ describe("runGatewayLoop", () => {
         },
         sessionIds: new Set(["session-forced-task"]),
         sessionKeys: new Set(["agent:main:forced-task"]),
-        reason: "forced gateway restart",
+        reason: "gateway restart drain",
       });
       expect(gatewayLog.warn).toHaveBeenCalledWith(
         "restart blocked by active background task run(s): taskId=task-force runId=run-force status=running runtime=cron label=forced",
@@ -821,10 +850,16 @@ describe("runGatewayLoop", () => {
         setImmediate(resolve);
       });
 
-      expect(abortEmbeddedAgentRun).toHaveBeenCalledWith(undefined, { mode: "compacting" });
+      expect(abortEmbeddedAgentRun).toHaveBeenCalledWith(undefined, {
+        mode: "compacting",
+        reason: "restart",
+      });
       expect(waitForActiveTasks).toHaveBeenCalledWith(1_234);
       expect(waitForActiveEmbeddedRuns).toHaveBeenCalledWith(1_234);
-      expect(abortEmbeddedAgentRun).toHaveBeenCalledWith(undefined, { mode: "all" });
+      expect(abortEmbeddedAgentRun).toHaveBeenCalledWith(undefined, {
+        mode: "all",
+        reason: "restart",
+      });
       expect(markRestartAbortedMainSessions).toHaveBeenCalledWith({
         cfg: {
           gateway: {
@@ -835,7 +870,7 @@ describe("runGatewayLoop", () => {
         },
         sessionIds: new Set(["session-issue-82433"]),
         sessionKeys: new Set(["agent:main:issue-82433"]),
-        reason: "gateway restart drain timeout",
+        reason: "gateway restart drain",
       });
       expect(markGatewayDraining).toHaveBeenCalledTimes(1);
       expect(gatewayLog.warn).toHaveBeenCalledWith(DRAIN_TIMEOUT_LOG);
@@ -1334,7 +1369,7 @@ describe("runGatewayLoop", () => {
         },
         sessionIds: new Set(["session-file-intent"]),
         sessionKeys: new Set(["agent:main:file-intent"]),
-        reason: "file-intent restart",
+        reason: "gateway restart drain",
       });
       expect(start).toHaveBeenCalledTimes(2);
 

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -55,6 +55,7 @@ const markGatewayDraining = vi.fn();
 const waitForActiveTasks = vi.fn(async (_timeoutMs?: number) => ({ drained: true }));
 const resetAllLanes = vi.fn();
 const reloadTaskRegistryFromStore = vi.fn();
+const rotateAgentEventLifecycleGeneration = vi.fn();
 const clearRuntimeConfigSnapshot = vi.fn();
 const restartGatewayProcessWithFreshPid = vi.fn<
   (_opts?: { env?: NodeJS.ProcessEnv }) => {
@@ -152,6 +153,10 @@ vi.mock("../../process/command-queue.js", () => ({
 
 vi.mock("../../tasks/runtime-internal.js", () => ({
   reloadTaskRegistryFromStore: () => reloadTaskRegistryFromStore(),
+}));
+
+vi.mock("../../infra/agent-events.js", () => ({
+  rotateAgentEventLifecycleGeneration: () => rotateAgentEventLifecycleGeneration(),
 }));
 
 vi.mock("../../config/runtime-snapshot.js", () => ({
@@ -839,7 +844,11 @@ describe("runGatewayLoop", () => {
       expect(resetAllLanes).toHaveBeenCalledTimes(1);
       expect(clearRuntimeConfigSnapshot).toHaveBeenCalledTimes(1);
       expect(resetGatewayRestartStateForInProcessRestart).toHaveBeenCalledTimes(1);
+      expect(rotateAgentEventLifecycleGeneration).toHaveBeenCalledTimes(1);
       expect(reloadTaskRegistryFromStore).toHaveBeenCalledTimes(1);
+      expect(
+        rotateAgentEventLifecycleGeneration.mock.invocationCallOrder[0] ?? Infinity,
+      ).toBeLessThan(resetAllLanes.mock.invocationCallOrder[0] ?? Infinity);
 
       sigusr1();
 
@@ -853,6 +862,7 @@ describe("runGatewayLoop", () => {
       expect(resetAllLanes).toHaveBeenCalledTimes(2);
       expect(clearRuntimeConfigSnapshot).toHaveBeenCalledTimes(2);
       expect(resetGatewayRestartStateForInProcessRestart).toHaveBeenCalledTimes(2);
+      expect(rotateAgentEventLifecycleGeneration).toHaveBeenCalledTimes(2);
       expect(reloadTaskRegistryFromStore).toHaveBeenCalledTimes(2);
       expect(acquireGatewayLock).toHaveBeenCalledTimes(3);
 

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -547,7 +547,8 @@ export async function runGatewayLoop(params: {
               // Best-effort abort for compacting runs so long compaction operations
               // don't hold session write locks across restart boundaries.
               if (activeRuns > 0) {
-                abortEmbeddedAgentRun(undefined, { mode: "compacting" });
+                await markActiveMainSessionsForRestart("gateway restart drain");
+                abortEmbeddedAgentRun(undefined, { mode: "compacting", reason: "restart" });
               }
 
               if (activeTasks > 0 || activeRuns > 0) {
@@ -565,7 +566,7 @@ export async function runGatewayLoop(params: {
                   await markActiveMainSessionsForRestart(
                     restartIntent.reason ?? "forced gateway restart",
                   );
-                  abortEmbeddedAgentRun(undefined, { mode: "all" });
+                  abortEmbeddedAgentRun(undefined, { mode: "all", reason: "restart" });
                 } else {
                   const stillPendingDrainLogger = createStillPendingDrainLogger();
                   let abortedAfterRunTimeout = false;
@@ -584,7 +585,7 @@ export async function runGatewayLoop(params: {
                       gatewayLog.warn(
                         "active embedded run drain timeout reached; aborting active run(s) before restart",
                       );
-                      abortEmbeddedAgentRun(undefined, { mode: "all" });
+                      abortEmbeddedAgentRun(undefined, { mode: "all", reason: "restart" });
                       abortedAfterRunTimeout = true;
                     }
                     tasksDrain = await tasksDrainPromise;
@@ -600,7 +601,7 @@ export async function runGatewayLoop(params: {
                     // Final best-effort abort to avoid carrying active runs into the
                     // next lifecycle when drain time budget is exhausted.
                     if (!abortedAfterRunTimeout) {
-                      abortEmbeddedAgentRun(undefined, { mode: "all" });
+                      abortEmbeddedAgentRun(undefined, { mode: "all", reason: "restart" });
                     }
                   }
                 }

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -802,7 +802,10 @@ export async function runGatewayLoop(params: {
         reloadTaskRegistryFromStore,
         resetAllLanes,
         resetGatewayRestartStateForInProcessRestart,
+        rotateAgentEventLifecycleGeneration,
       } = await loadGatewayLifecycleRuntimeModule();
+      // Rotate ownership before reset pumps preserved queue entries.
+      rotateAgentEventLifecycleGeneration();
       resetAllLanes();
       clearRuntimeConfigSnapshot();
       resetGatewayRestartStateForInProcessRestart();

--- a/src/commands/agent.acp.test.ts
+++ b/src/commands/agent.acp.test.ts
@@ -17,17 +17,21 @@ const agentEventMocks = vi.hoisted(() => {
   type AgentEvent = { stream: string; data?: Record<string, unknown>; runId?: string };
   const handlers = new Set<(event: AgentEvent) => void>();
   return {
+    assertAgentRunLifecycleGenerationCurrent: vi.fn(),
+    captureAgentRunLifecycleGeneration: vi.fn(() => "test-generation"),
     clearAgentRunContext: vi.fn(),
     emitAgentEvent: vi.fn((event: AgentEvent) => {
       for (const handler of handlers) {
         handler(event);
       }
     }),
+    getAgentEventLifecycleGeneration: vi.fn(() => "test-generation"),
     onAgentEvent: vi.fn((handler: (event: AgentEvent) => void) => {
       handlers.add(handler);
       return () => handlers.delete(handler);
     }),
     registerAgentRunContext: vi.fn(),
+    withAgentRunLifecycleGeneration: vi.fn((_generation: string, run: () => unknown) => run()),
   };
 });
 

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -168,6 +168,8 @@ type SaveSessionStoreOptions = {
   maintenanceConfig?: ResolvedSessionMaintenanceConfig;
   /** Changed top-level entry when a hot path only updated one existing session. */
   singleEntryPersistence?: SingleEntryPersistencePatch;
+  /** Throw when best-effort store recovery cannot confirm the requested write. */
+  requireWriteSuccess?: boolean;
 };
 
 type UpdateSessionStoreOptions<T> = SaveSessionStoreOptions & {
@@ -717,6 +719,7 @@ async function saveSessionStoreUnlocked(
 
   // Windows: keep retry semantics because rename can fail while readers hold locks.
   if (process.platform === "win32") {
+    let finalError: unknown;
     for (let i = 0; i < 5; i++) {
       try {
         await writeSessionStoreAtomic({
@@ -730,8 +733,12 @@ async function saveSessionStoreUnlocked(
         });
         return;
       } catch (err) {
+        finalError = err;
         const code = getErrorCode(err);
         if (code === "ENOENT") {
+          if (opts?.requireWriteSuccess) {
+            throw err;
+          }
           return;
         }
         if (i < 4) {
@@ -744,6 +751,9 @@ async function saveSessionStoreUnlocked(
         // the next save will retry with fresh data. Log for diagnostics.
         log.warn(`atomic write failed after 5 attempts: ${storePath}`);
       }
+    }
+    if (opts?.requireWriteSuccess) {
+      throw finalError;
     }
     return;
   }
@@ -777,6 +787,9 @@ async function saveSessionStoreUnlocked(
       } catch (err2) {
         const code2 = getErrorCode(err2);
         if (code2 === "ENOENT") {
+          if (opts?.requireWriteSuccess) {
+            throw err2;
+          }
           return;
         }
         throw err2;
@@ -924,6 +937,7 @@ async function persistResolvedSessionEntry(params: {
   skipMaintenance?: boolean;
   takeCacheOwnership?: boolean;
   returnDetached?: boolean;
+  requireWriteSuccess?: boolean;
 }): Promise<SessionEntry> {
   const entryUnchanged =
     params.resolved.legacyKeys.length === 0 &&
@@ -942,6 +956,7 @@ async function persistResolvedSessionEntry(params: {
         ? { sessionKey: params.resolved.normalizedKey, entry: next }
         : undefined,
     takeCacheOwnership: params.takeCacheOwnership,
+    requireWriteSuccess: params.requireWriteSuccess,
   });
   return entryUnchanged || params.returnDetached ? cloneSessionEntry(next) : next;
 }
@@ -954,6 +969,7 @@ export async function updateSessionStoreEntry(params: {
   ) => Promise<Partial<SessionEntry> | null> | Partial<SessionEntry> | null;
   skipMaintenance?: boolean;
   takeCacheOwnership?: boolean;
+  requireWriteSuccess?: boolean;
 }): Promise<SessionEntry | null> {
   const { storePath, sessionKey, update } = params;
   return await runExclusiveSessionStoreWrite(storePath, async () => {
@@ -975,6 +991,7 @@ export async function updateSessionStoreEntry(params: {
       next,
       skipMaintenance: params.skipMaintenance,
       takeCacheOwnership: params.takeCacheOwnership ?? true,
+      requireWriteSuccess: params.requireWriteSuccess,
       returnDetached: params.takeCacheOwnership !== true,
     });
   });

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -201,6 +201,11 @@ export type SessionGoal = {
   budgetLimitedAt?: number;
 };
 
+export type RestartRecoveryRun = {
+  runId: string;
+  lifecycleGeneration: string;
+};
+
 export type SessionEntry = {
   /**
    * Last delivered heartbeat payload (used to suppress duplicate heartbeat notifications).
@@ -250,6 +255,8 @@ export type SessionEntry = {
   pluginOwnerId?: string;
   systemSent?: boolean;
   abortedLastRun?: boolean;
+  /** Interrupted run generations whose late lifecycle events must be ignored. */
+  restartRecoveryRuns?: RestartRecoveryRun[];
   /** Durable guard state for automatic subagent orphan recovery. */
   subagentRecovery?: SubagentRecoveryState;
   /** Quota cascade protection and state-aware failover status. */

--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -152,7 +152,7 @@ export function createCronPromptExecutor(params: {
   cronSession: MutableCronSession;
   abortSignal?: AbortSignal;
   abortReason: () => string;
-  onExecutionStarted?: () => void;
+  onExecutionStarted?: (info?: { lifecycleGeneration?: string }) => void;
   onExecutionPhase?: (
     info: Pick<CronAgentExecutionPhaseUpdate, "phase"> &
       Partial<Omit<CronAgentExecutionPhaseUpdate, "jobId" | "phase">>,
@@ -394,7 +394,7 @@ export async function executeCronRun(params: {
   abortSignal?: AbortSignal;
   abortReason: () => string;
   isAborted: () => boolean;
-  onExecutionStarted?: () => void;
+  onExecutionStarted?: (info?: { lifecycleGeneration?: string }) => void;
   onExecutionPhase?: (
     info: Pick<CronAgentExecutionPhaseUpdate, "phase"> &
       Partial<Omit<CronAgentExecutionPhaseUpdate, "jobId" | "phase">>,

--- a/src/cron/isolated-agent/run.message-tool-policy.test.ts
+++ b/src/cron/isolated-agent/run.message-tool-policy.test.ts
@@ -891,6 +891,68 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
     expect(getAgentRunContext("test-session-id")).toBeUndefined();
   });
 
+  it("keeps shared cron context until overlapping invocations finish", async () => {
+    mockRunCronFallbackPassthrough();
+    resolveCronSessionMock.mockImplementation(() => makeCronSession());
+    const { claimAgentRunContext, getAgentEventLifecycleGeneration, getAgentRunContext } =
+      await import("../../infra/agent-events.js");
+    let invocationCount = 0;
+    let releaseFirst = () => {};
+    let releaseSecond = () => {};
+    let markFirstStarted = () => {};
+    let markSecondStarted = () => {};
+    const firstStarted = new Promise<void>((resolve) => {
+      markFirstStarted = resolve;
+    });
+    const secondStarted = new Promise<void>((resolve) => {
+      markSecondStarted = resolve;
+    });
+    const firstBlocked = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const secondBlocked = new Promise<void>((resolve) => {
+      releaseSecond = resolve;
+    });
+    runEmbeddedAgentMock.mockImplementation(async () => {
+      claimAgentRunContext("test-session-id", {
+        sessionKey: "agent:default:cron:message-tool-policy",
+        sessionId: "test-session-id",
+        lifecycleGeneration: getAgentEventLifecycleGeneration(),
+      });
+      invocationCount += 1;
+      if (invocationCount === 1) {
+        markFirstStarted();
+        await firstBlocked;
+      } else {
+        markSecondStarted();
+        await secondBlocked;
+      }
+      return {
+        payloads: [{ text: "test output" }],
+        meta: { agentMeta: {} },
+      };
+    });
+    const currentSessionJob = makeMessageToolPolicyJob() as unknown as Record<string, unknown>;
+    currentSessionJob.sessionTarget = "current";
+    const runParams = {
+      ...makeParams(),
+      job: currentSessionJob as never,
+    };
+
+    const firstRun = runCronIsolatedAgentTurn(runParams);
+    await firstStarted;
+    const secondRun = runCronIsolatedAgentTurn(runParams);
+    await secondStarted;
+
+    releaseFirst();
+    await firstRun;
+    expect(getAgentRunContext("test-session-id")).toBeDefined();
+
+    releaseSecond();
+    await secondRun;
+    expect(getAgentRunContext("test-session-id")).toBeUndefined();
+  });
+
   it("releases a stale shared cron context replaced by this invocation", async () => {
     mockRunCronFallbackPassthrough();
     runEmbeddedAgentMock.mockRejectedValueOnce(new Error("runner failed"));

--- a/src/cron/isolated-agent/run.message-tool-policy.test.ts
+++ b/src/cron/isolated-agent/run.message-tool-policy.test.ts
@@ -781,6 +781,43 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
     expect(cronSession.store).toBeUndefined();
   });
 
+  it("does not let old cron cleanup clear a newer same-id run context", async () => {
+    mockRunCronFallbackPassthrough();
+    const {
+      claimAgentRunContext,
+      clearAgentRunContext,
+      getAgentRunContext,
+      rotateAgentEventLifecycleGeneration,
+    } = await import("../../infra/agent-events.js");
+    let newerLifecycleGeneration = "";
+    runEmbeddedAgentMock.mockImplementationOnce(
+      async (runParams: {
+        onExecutionStarted?: (info?: { lifecycleGeneration?: string }) => void;
+      }) => {
+        runParams.onExecutionStarted?.();
+        newerLifecycleGeneration = rotateAgentEventLifecycleGeneration();
+        claimAgentRunContext("test-session-id", {
+          sessionKey: "agent:default:cron:message-tool-policy",
+          sessionId: "test-session-id",
+          lifecycleGeneration: newerLifecycleGeneration,
+        });
+        return {
+          payloads: [{ text: "test output" }],
+          meta: { agentMeta: {} },
+        };
+      },
+    );
+
+    await runCronIsolatedAgentTurn(makeParams());
+
+    expect(getAgentRunContext("test-session-id")).toEqual(
+      expect.objectContaining({
+        lifecycleGeneration: newerLifecycleGeneration,
+      }),
+    );
+    clearAgentRunContext("test-session-id", newerLifecycleGeneration);
+  });
+
   it("keeps shared cron run context references active after completion", async () => {
     const cronSession = makeCronSession({
       store: { "agent:default:cron:message-tool-policy": { retained: true } },

--- a/src/cron/isolated-agent/run.message-tool-policy.test.ts
+++ b/src/cron/isolated-agent/run.message-tool-policy.test.ts
@@ -13,6 +13,7 @@ import {
   loadRunCronIsolatedAgentTurn,
   makeCronSession,
   mockRunCronFallbackPassthrough,
+  preflightCronModelProviderMock,
   resolveCronPayloadOutcomeMock,
   resolveCronSessionMock,
   resetRunCronIsolatedAgentTurnHarness,
@@ -816,6 +817,33 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
       }),
     );
     clearAgentRunContext("test-session-id", newerLifecycleGeneration);
+  });
+
+  it("rejects cron work when the gateway lifecycle rotates during preparation", async () => {
+    let releasePreflight: (() => void) | undefined;
+    const preflightStarted = new Promise<void>((resolveStarted) => {
+      preflightCronModelProviderMock.mockImplementationOnce(async () => {
+        resolveStarted();
+        await new Promise<void>((resolve) => {
+          releasePreflight = resolve;
+        });
+        return { status: "available" };
+      });
+    });
+    const { getAgentRunContext, rotateAgentEventLifecycleGeneration } =
+      await import("../../infra/agent-events.js");
+
+    const runPromise = runCronIsolatedAgentTurn(makeParams());
+    await preflightStarted;
+    rotateAgentEventLifecycleGeneration();
+    releasePreflight?.();
+
+    await expect(runPromise).resolves.toMatchObject({
+      status: "error",
+      error: expect.stringContaining("Agent run belongs to a stale gateway lifecycle"),
+    });
+    expect(runEmbeddedAgentMock).not.toHaveBeenCalled();
+    expect(getAgentRunContext("test-session-id")).toBeUndefined();
   });
 
   it("keeps shared cron run context references active after completion", async () => {

--- a/src/cron/isolated-agent/run.message-tool-policy.test.ts
+++ b/src/cron/isolated-agent/run.message-tool-policy.test.ts
@@ -872,6 +872,51 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
     clearAgentRunContext("test-session-id");
   });
 
+  it("releases a shared cron run context created by this invocation", async () => {
+    mockRunCronFallbackPassthrough();
+    runEmbeddedAgentMock.mockRejectedValueOnce(new Error("runner failed"));
+    const { getAgentRunContext } = await import("../../infra/agent-events.js");
+    const currentSessionJob = makeMessageToolPolicyJob() as unknown as Record<string, unknown>;
+    currentSessionJob.sessionTarget = "current";
+
+    await expect(
+      runCronIsolatedAgentTurn({
+        ...makeParams(),
+        job: currentSessionJob as never,
+      }),
+    ).resolves.toMatchObject({
+      status: "error",
+    });
+
+    expect(getAgentRunContext("test-session-id")).toBeUndefined();
+  });
+
+  it("releases a stale shared cron context replaced by this invocation", async () => {
+    mockRunCronFallbackPassthrough();
+    runEmbeddedAgentMock.mockRejectedValueOnce(new Error("runner failed"));
+    const {
+      claimAgentRunContext,
+      getAgentEventLifecycleGeneration,
+      getAgentRunContext,
+      rotateAgentEventLifecycleGeneration,
+    } = await import("../../infra/agent-events.js");
+    claimAgentRunContext("test-session-id", {
+      sessionKey: "agent:default:cron:message-tool-policy",
+      sessionId: "test-session-id",
+      lifecycleGeneration: getAgentEventLifecycleGeneration(),
+    });
+    rotateAgentEventLifecycleGeneration();
+    const currentSessionJob = makeMessageToolPolicyJob() as unknown as Record<string, unknown>;
+    currentSessionJob.sessionTarget = "current";
+
+    await runCronIsolatedAgentTurn({
+      ...makeParams(),
+      job: currentSessionJob as never,
+    });
+
+    expect(getAgentRunContext("test-session-id")).toBeUndefined();
+  });
+
   it("skips cron delivery when output is heartbeat-only", async () => {
     mockRunCronFallbackPassthrough();
     resolveCronDeliveryPlanMock.mockReturnValue(makeAnnounceDeliveryPlan());

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -18,9 +18,9 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
   assertAgentRunLifecycleGenerationCurrent,
   claimAgentRunContext,
-  clearAgentRunContext,
   getAgentEventLifecycleGeneration,
   getAgentRunContext,
+  releaseAgentRunContext,
 } from "../../infra/agent-events.js";
 import { isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
 import {
@@ -1234,12 +1234,9 @@ async function disposeCronRunContext(params: {
   sessionId: string;
   cronSession: MutableCronSession;
   ownsRunContext: boolean;
-  clearRunContext: boolean;
-  lifecycleGeneration: string;
+  runContextOwnerToken?: string;
 }): Promise<void> {
-  if (params.clearRunContext) {
-    clearAgentRunContext(params.sessionId, params.lifecycleGeneration);
-  }
+  releaseAgentRunContext(params.sessionId, params.runContextOwnerToken);
   if (params.ownsRunContext) {
     await retireSessionMcpRuntime({
       sessionId: params.sessionId,
@@ -1285,7 +1282,7 @@ export async function runCronIsolatedAgentTurn(params: {
   // Capture the stable run id before execution can rotate its persisted session.
   const initialSessionId = prepared.context.cronSession.sessionEntry.sessionId;
   const ownsRunContext = params.job.sessionTarget === "isolated";
-  let clearRunContext = ownsRunContext;
+  let runContextOwnerToken: string | undefined;
   let runLifecycleGeneration = admittedLifecycleGeneration;
   const notifyExecutionStarted = (info?: { lifecycleGeneration?: string }) => {
     if (info?.lifecycleGeneration) {
@@ -1334,19 +1331,21 @@ export async function runCronIsolatedAgentTurn(params: {
   try {
     assertAgentRunLifecycleGenerationCurrent(runLifecycleGeneration);
     const existingRunContext = getAgentRunContext(initialSessionId);
-    const replacesStaleRunContext =
-      existingRunContext?.lifecycleGeneration !== undefined &&
-      existingRunContext.lifecycleGeneration !== runLifecycleGeneration;
-    clearRunContext ||= existingRunContext === undefined || replacesStaleRunContext;
-    claimAgentRunContext(initialSessionId, {
-      ...existingRunContext,
-      sessionKey:
-        ownsRunContext || !existingRunContext?.sessionKey
-          ? prepared.context.runSessionKey
-          : existingRunContext.sessionKey,
-      sessionId: initialSessionId,
-      lifecycleGeneration: runLifecycleGeneration,
-    });
+    runContextOwnerToken = claimAgentRunContext(
+      initialSessionId,
+      {
+        sessionKey:
+          ownsRunContext || !existingRunContext?.sessionKey
+            ? prepared.context.runSessionKey
+            : existingRunContext.sessionKey,
+        sessionId: initialSessionId,
+        lifecycleGeneration: runLifecycleGeneration,
+      },
+      {
+        trackOwner: true,
+        ownsContext: ownsRunContext,
+      },
+    );
     const { executeCronRun } = await loadCronExecutorRuntime();
     const execution = await executeCronRun({
       cfg: params.cfg,
@@ -1438,8 +1437,7 @@ export async function runCronIsolatedAgentTurn(params: {
       sessionId: initialSessionId,
       cronSession: prepared.context.cronSession,
       ownsRunContext,
-      clearRunContext,
-      lifecycleGeneration: runLifecycleGeneration,
+      runContextOwnerToken,
     });
   }
 }

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -16,6 +16,7 @@ import { resolveAgentModelPrimaryValue } from "../../config/model-input.js";
 import type { AgentDefaultsConfig } from "../../config/types.agent-defaults.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
+  assertAgentRunLifecycleGenerationCurrent,
   claimAgentRunContext,
   clearAgentRunContext,
   getAgentEventLifecycleGeneration,
@@ -1264,6 +1265,7 @@ export async function runCronIsolatedAgentTurn(params: {
   agentId?: string;
   lane?: string;
 }): Promise<RunCronAgentTurnResult> {
+  const admittedLifecycleGeneration = getAgentEventLifecycleGeneration();
   const abortSignal = params.abortSignal ?? params.signal;
   const isAborted = () => abortSignal?.aborted === true;
   const abortReason = () => {
@@ -1280,17 +1282,7 @@ export async function runCronIsolatedAgentTurn(params: {
   // Capture the stable run id before execution can rotate its persisted session.
   const initialSessionId = prepared.context.cronSession.sessionEntry.sessionId;
   const ownsRunContext = params.job.sessionTarget === "isolated";
-  let runLifecycleGeneration = getAgentEventLifecycleGeneration();
-  const existingRunContext = getAgentRunContext(initialSessionId);
-  claimAgentRunContext(initialSessionId, {
-    ...existingRunContext,
-    sessionKey:
-      ownsRunContext || !existingRunContext?.sessionKey
-        ? prepared.context.runSessionKey
-        : existingRunContext.sessionKey,
-    sessionId: initialSessionId,
-    lifecycleGeneration: runLifecycleGeneration,
-  });
+  let runLifecycleGeneration = admittedLifecycleGeneration;
   const notifyExecutionStarted = (info?: { lifecycleGeneration?: string }) => {
     if (info?.lifecycleGeneration) {
       runLifecycleGeneration = info.lifecycleGeneration;
@@ -1336,6 +1328,17 @@ export async function runCronIsolatedAgentTurn(params: {
   let outcome: "completed" | "error" = "completed";
   let outcomeError: string | undefined;
   try {
+    assertAgentRunLifecycleGenerationCurrent(runLifecycleGeneration);
+    const existingRunContext = getAgentRunContext(initialSessionId);
+    claimAgentRunContext(initialSessionId, {
+      ...existingRunContext,
+      sessionKey:
+        ownsRunContext || !existingRunContext?.sessionKey
+          ? prepared.context.runSessionKey
+          : existingRunContext.sessionKey,
+      sessionId: initialSessionId,
+      lifecycleGeneration: runLifecycleGeneration,
+    });
     const { executeCronRun } = await loadCronExecutorRuntime();
     const execution = await executeCronRun({
       cfg: params.cfg,

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -15,7 +15,12 @@ import {
 import { resolveAgentModelPrimaryValue } from "../../config/model-input.js";
 import type { AgentDefaultsConfig } from "../../config/types.agent-defaults.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { clearAgentRunContext } from "../../infra/agent-events.js";
+import {
+  claimAgentRunContext,
+  clearAgentRunContext,
+  getAgentEventLifecycleGeneration,
+  getAgentRunContext,
+} from "../../infra/agent-events.js";
 import { isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
 import {
   createSourceDeliveryPlan,
@@ -1228,9 +1233,10 @@ async function disposeCronRunContext(params: {
   sessionId: string;
   cronSession: MutableCronSession;
   ownsRunContext: boolean;
+  lifecycleGeneration: string;
 }): Promise<void> {
   if (params.ownsRunContext) {
-    clearAgentRunContext(params.sessionId);
+    clearAgentRunContext(params.sessionId, params.lifecycleGeneration);
     await retireSessionMcpRuntime({
       sessionId: params.sessionId,
       reason: "isolated-cron-dispose",
@@ -1271,7 +1277,24 @@ export async function runCronIsolatedAgentTurn(params: {
   if (!prepared.ok) {
     return prepared.result;
   }
-  const notifyExecutionStarted = () =>
+  // Capture the stable run id before execution can rotate its persisted session.
+  const initialSessionId = prepared.context.cronSession.sessionEntry.sessionId;
+  const ownsRunContext = params.job.sessionTarget === "isolated";
+  let runLifecycleGeneration = getAgentEventLifecycleGeneration();
+  const existingRunContext = getAgentRunContext(initialSessionId);
+  claimAgentRunContext(initialSessionId, {
+    ...existingRunContext,
+    sessionKey:
+      ownsRunContext || !existingRunContext?.sessionKey
+        ? prepared.context.runSessionKey
+        : existingRunContext.sessionKey,
+    sessionId: initialSessionId,
+    lifecycleGeneration: runLifecycleGeneration,
+  });
+  const notifyExecutionStarted = (info?: { lifecycleGeneration?: string }) => {
+    if (info?.lifecycleGeneration) {
+      runLifecycleGeneration = info.lifecycleGeneration;
+    }
     params.onExecutionStarted?.({
       jobId: params.job.id,
       agentId: prepared.context.agentId,
@@ -1281,6 +1304,7 @@ export async function runCronIsolatedAgentTurn(params: {
       provider: prepared.context.liveSelection.provider,
       model: prepared.context.liveSelection.model,
     });
+  };
   const notifyExecutionPhase = (
     info: Pick<CronAgentExecutionPhaseUpdate, "phase"> &
       Partial<Omit<CronAgentExecutionPhaseUpdate, "jobId" | "phase">>,
@@ -1295,10 +1319,6 @@ export async function runCronIsolatedAgentTurn(params: {
       ...info,
     });
   };
-
-  // Capture the sessionId before the try block so the finally block clears
-  // the correct context even if adoptCronRunSessionMetadata() rotates it.
-  const initialSessionId = prepared.context.cronSession.sessionEntry.sessionId;
 
   const turnStartedAtMs = Date.now();
   const diagnosticsEnabled = isDiagnosticsEnabled(params.cfg);
@@ -1406,7 +1426,8 @@ export async function runCronIsolatedAgentTurn(params: {
     await disposeCronRunContext({
       sessionId: initialSessionId,
       cronSession: prepared.context.cronSession,
-      ownsRunContext: params.job.sessionTarget === "isolated",
+      ownsRunContext,
+      lifecycleGeneration: runLifecycleGeneration,
     });
   }
 }

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -1234,10 +1234,13 @@ async function disposeCronRunContext(params: {
   sessionId: string;
   cronSession: MutableCronSession;
   ownsRunContext: boolean;
+  clearRunContext: boolean;
   lifecycleGeneration: string;
 }): Promise<void> {
-  if (params.ownsRunContext) {
+  if (params.clearRunContext) {
     clearAgentRunContext(params.sessionId, params.lifecycleGeneration);
+  }
+  if (params.ownsRunContext) {
     await retireSessionMcpRuntime({
       sessionId: params.sessionId,
       reason: "isolated-cron-dispose",
@@ -1282,6 +1285,7 @@ export async function runCronIsolatedAgentTurn(params: {
   // Capture the stable run id before execution can rotate its persisted session.
   const initialSessionId = prepared.context.cronSession.sessionEntry.sessionId;
   const ownsRunContext = params.job.sessionTarget === "isolated";
+  let clearRunContext = ownsRunContext;
   let runLifecycleGeneration = admittedLifecycleGeneration;
   const notifyExecutionStarted = (info?: { lifecycleGeneration?: string }) => {
     if (info?.lifecycleGeneration) {
@@ -1330,6 +1334,10 @@ export async function runCronIsolatedAgentTurn(params: {
   try {
     assertAgentRunLifecycleGenerationCurrent(runLifecycleGeneration);
     const existingRunContext = getAgentRunContext(initialSessionId);
+    const replacesStaleRunContext =
+      existingRunContext?.lifecycleGeneration !== undefined &&
+      existingRunContext.lifecycleGeneration !== runLifecycleGeneration;
+    clearRunContext ||= existingRunContext === undefined || replacesStaleRunContext;
     claimAgentRunContext(initialSessionId, {
       ...existingRunContext,
       sessionKey:
@@ -1430,6 +1438,7 @@ export async function runCronIsolatedAgentTurn(params: {
       sessionId: initialSessionId,
       cronSession: prepared.context.cronSession,
       ownsRunContext,
+      clearRunContext,
       lifecycleGeneration: runLifecycleGeneration,
     });
   }

--- a/src/gateway/chat-abort.test.ts
+++ b/src/gateway/chat-abort.test.ts
@@ -1,6 +1,7 @@
 // Chat abort tests protect in-flight run tracking, stop-command parsing, provider
 // abort fanout, history snapshots, and cleanup of buffered streaming state.
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { isAgentRunRestartAbortReason } from "../agents/run-termination.js";
 import {
   abortChatRunById,
   abortChatRunsForProvider,
@@ -235,6 +236,69 @@ describe("registerChatAbortController", () => {
     });
     expect(chatAbortControllers.get("run-internal-agent")?.controlUiVisible).toBe(false);
   });
+
+  it("retains completed registrations until terminal persistence succeeds", async () => {
+    const chatAbortControllers = new Map<string, ChatAbortControllerEntry>();
+    const registration = registerChatAbortController({
+      chatAbortControllers,
+      runId: "run-persisting",
+      sessionId: "sess-1",
+      sessionKey: "main",
+      timeoutMs: 60_000,
+    });
+    let resolvePersistence: () => void = () => undefined;
+    const persistence = new Promise<void>((resolve) => {
+      resolvePersistence = resolve;
+    });
+    if (!registration.entry) {
+      throw new Error("expected registered entry");
+    }
+    registration.entry.projectSessionActive = false;
+    registration.entry.projectSessionTerminalPersistence = persistence;
+
+    registration.cleanup();
+
+    expect(chatAbortControllers.has("run-persisting")).toBe(true);
+    resolvePersistence();
+    await persistence;
+    await Promise.resolve();
+    expect(chatAbortControllers.has("run-persisting")).toBe(false);
+  });
+
+  it("retains registrations when terminal lifecycle was observed before caller cleanup", () => {
+    const chatAbortControllers = new Map<string, ChatAbortControllerEntry>();
+    const registration = registerChatAbortController({
+      chatAbortControllers,
+      runId: "run-awaiting-terminal",
+      sessionId: "sess-1",
+      sessionKey: "main",
+      timeoutMs: 60_000,
+    });
+
+    if (!registration.entry) {
+      throw new Error("expected registered entry");
+    }
+    registration.entry.projectSessionTerminalPending = true;
+    registration.cleanup();
+
+    expect(chatAbortControllers.has("run-awaiting-terminal")).toBe(true);
+    expect(registration.entry?.registrationCleanupRequested).toBe(true);
+  });
+
+  it("force-cleans registrations when dispatch fails before lifecycle starts", () => {
+    const chatAbortControllers = new Map<string, ChatAbortControllerEntry>();
+    const registration = registerChatAbortController({
+      chatAbortControllers,
+      runId: "run-before-dispatch",
+      sessionId: "sess-1",
+      sessionKey: "main",
+      timeoutMs: 60_000,
+    });
+
+    registration.cleanup({ force: true });
+
+    expect(chatAbortControllers.has("run-before-dispatch")).toBe(false);
+  });
 });
 
 describe("abortChatRunById", () => {
@@ -346,6 +410,18 @@ describe("abortChatRunById", () => {
     expect(entry.controller.signal.aborted).toBe(true);
     expect(entry.controller.signal.reason).toBeInstanceOf(Error);
     expect((entry.controller.signal.reason as Error).name).toBe("TimeoutError");
+  });
+
+  it("tags restart abort signals with a restart-specific reason", () => {
+    const runId = "run-restart";
+    const sessionKey = "main";
+    const entry = createActiveEntry(sessionKey);
+    const ops = createOps({ runId, entry });
+
+    const result = abortChatRunById(ops, { runId, sessionKey, stopReason: "restart" });
+
+    expect(result).toEqual({ aborted: true });
+    expect(isAgentRunRestartAbortReason(entry.controller.signal.reason)).toBe(true);
   });
 
   it("preserves partial message even when abort listeners clear buffers synchronously", () => {

--- a/src/gateway/chat-abort.ts
+++ b/src/gateway/chat-abort.ts
@@ -6,6 +6,7 @@ import {
   resolveExpiresAtMsFromDurationMs,
 } from "@openclaw/normalization-core/number-coercion";
 import { resolveDefaultAgentId } from "../agents/agent-scope-config.js";
+import { createAgentRunRestartAbortError } from "../agents/run-termination.js";
 import { isAbortRequestText } from "../auto-reply/reply/abort-primitives.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { emitAgentEvent, getAgentEventLifecycleGeneration } from "../infra/agent-events.js";
@@ -38,6 +39,16 @@ export type ChatAbortControllerEntry = {
    * idempotency guard until normal cleanup removes it.
    */
   projectSessionActive?: boolean;
+  /** True after the terminal session-store update has completed. */
+  projectSessionTerminalPersisted?: boolean;
+  /** A terminal lifecycle event was observed and is awaiting persistence. */
+  projectSessionTerminalPending?: boolean;
+  /** Store timestamp expected from the observed terminal lifecycle event. */
+  projectSessionTerminalObservedAt?: number;
+  /** In-flight terminal session-store update used by restart shutdown. */
+  projectSessionTerminalPersistence?: Promise<void>;
+  /** Caller completion requested cleanup before terminal lifecycle persistence settled. */
+  registrationCleanupRequested?: boolean;
   /**
    * Which RPC owns this registration. Absent (undefined) is treated as
    * `"chat-send"` so pre-existing callers that constructed entries without
@@ -47,11 +58,19 @@ export type ChatAbortControllerEntry = {
   kind?: "chat-send" | "agent";
 };
 
+export type RestartRecoveryCandidate = {
+  runId: string;
+  lifecycleGeneration: string;
+  sessionKey: string;
+  sessionId: string;
+  observedAt?: number;
+};
+
 type RegisteredChatAbortController = {
   controller: AbortController;
   registered: boolean;
   entry?: ChatAbortControllerEntry;
-  cleanup: () => void;
+  cleanup: (opts?: { force?: boolean }) => void;
 };
 
 export function isChatStopCommandText(text: string): boolean {
@@ -59,6 +78,9 @@ export function isChatStopCommandText(text: string): boolean {
 }
 
 function createChatAbortSignalReason(stopReason: string | undefined): Error | undefined {
+  if (stopReason === "restart") {
+    return createAgentRunRestartAbortError();
+  }
   if (stopReason !== "timeout") {
     return undefined;
   }
@@ -129,9 +151,34 @@ export function registerChatAbortController(params: {
   expiresAtMs?: number;
 }): RegisteredChatAbortController {
   const controller = new AbortController();
-  const cleanup = () => {
+  const cleanup = (opts?: { force?: boolean }) => {
     const entry = params.chatAbortControllers.get(params.runId);
     if (entry?.controller === controller) {
+      if (opts?.force === true) {
+        params.chatAbortControllers.delete(params.runId);
+        return;
+      }
+      entry.registrationCleanupRequested = true;
+      // Terminal event handling owns final removal once the event has been
+      // observed. Runs that never emitted a terminal event still clean up here.
+      if (entry.projectSessionTerminalPending === true) {
+        return;
+      }
+      const persistence = entry.projectSessionTerminalPersistence;
+      if (persistence) {
+        void persistence
+          .then(() => {
+            if (params.chatAbortControllers.get(params.runId)?.controller === controller) {
+              params.chatAbortControllers.delete(params.runId);
+            }
+          })
+          .catch(() => {
+            if (params.chatAbortControllers.get(params.runId)?.controller === controller) {
+              params.chatAbortControllers.delete(params.runId);
+            }
+          });
+        return;
+      }
       params.chatAbortControllers.delete(params.runId);
     }
   };

--- a/src/gateway/chat-abort.ts
+++ b/src/gateway/chat-abort.ts
@@ -8,7 +8,7 @@ import {
 import { resolveDefaultAgentId } from "../agents/agent-scope-config.js";
 import { isAbortRequestText } from "../auto-reply/reply/abort-primitives.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { emitAgentEvent } from "../infra/agent-events.js";
+import { emitAgentEvent, getAgentEventLifecycleGeneration } from "../infra/agent-events.js";
 import { jsonUtf8Bytes } from "../infra/json-utf8-bytes.js";
 import { projectLiveAssistantBufferedText } from "./live-chat-projector.js";
 
@@ -18,6 +18,7 @@ export type ChatAbortControllerEntry = {
   controller: AbortController;
   sessionId: string;
   sessionKey: string;
+  lifecycleGeneration?: string;
   agentId?: string;
   startedAtMs: number;
   expiresAtMs: number;
@@ -123,6 +124,7 @@ export function registerChatAbortController(params: {
   authProviderId?: string;
   controlUiVisible?: boolean;
   kind?: ChatAbortControllerEntry["kind"];
+  lifecycleGeneration?: string;
   now?: number;
   expiresAtMs?: number;
 }): RegisteredChatAbortController {
@@ -148,6 +150,7 @@ export function registerChatAbortController(params: {
     controller,
     sessionId: params.sessionId,
     sessionKey: params.sessionKey,
+    lifecycleGeneration: params.lifecycleGeneration ?? getAgentEventLifecycleGeneration(),
     agentId: normalizeActiveAgentId(params.agentId),
     startedAtMs: now,
     expiresAtMs:
@@ -438,6 +441,7 @@ export function abortChatRunById(
   }
   emitAgentEvent({
     runId,
+    ...(active.lifecycleGeneration ? { lifecycleGeneration: active.lifecycleGeneration } : {}),
     sessionKey,
     agentId: active.agentId,
     stream: "lifecycle",

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -83,6 +83,8 @@ describe("agent event handler", () => {
     lifecycleErrorRetryGraceMs?: number;
     isChatSendRunActive?: (runId: string) => boolean;
     clearTrackedActiveRun?: AgentEventHandlerOptions["clearTrackedActiveRun"];
+    markTrackedRunTerminalPersisted?: AgentEventHandlerOptions["markTrackedRunTerminalPersisted"];
+    trackTrackedRunTerminalPersistence?: AgentEventHandlerOptions["trackTrackedRunTerminalPersistence"];
     resolveActiveLifecycleGenerationForRun?: (runId: string) => string | undefined;
   }) {
     const nowSpy =
@@ -114,6 +116,8 @@ describe("agent event handler", () => {
       lifecycleErrorRetryGraceMs: params?.lifecycleErrorRetryGraceMs,
       isChatSendRunActive: params?.isChatSendRunActive,
       clearTrackedActiveRun: params?.clearTrackedActiveRun ?? clearTrackedActiveRun,
+      markTrackedRunTerminalPersisted: params?.markTrackedRunTerminalPersisted,
+      trackTrackedRunTerminalPersistence: params?.trackTrackedRunTerminalPersistence,
       resolveActiveLifecycleGenerationForRun: params?.resolveActiveLifecycleGenerationForRun,
     });
 
@@ -1927,7 +1931,17 @@ describe("agent event handler", () => {
     resetAgentRunContextForTest();
   });
 
-  it("broadcasts terminal session status to session subscribers on lifecycle end", () => {
+  it("broadcasts terminal session status to session subscribers on lifecycle end", async () => {
+    vi.mocked(loadGatewaySessionRow).mockReturnValue({
+      key: "session-finished",
+      kind: "direct",
+      updatedAt: 1_700,
+      status: "done",
+      startedAt: 900,
+      endedAt: 1_700,
+      runtimeMs: 800,
+      abortedLastRun: false,
+    });
     const { broadcastToConnIds, sessionEventSubscribers, handler } = createHarness({
       resolveSessionKeyForRun: () => "session-finished",
     });
@@ -1960,6 +1974,11 @@ describe("agent event handler", () => {
       },
     });
 
+    await vi.waitFor(() => {
+      expect(
+        broadcastToConnIds.mock.calls.filter(([event]) => event === "sessions.changed"),
+      ).toHaveLength(2);
+    });
     const sessionsChangedCalls = broadcastToConnIds.mock.calls.filter(
       ([event]) => event === "sessions.changed",
     );
@@ -1990,7 +2009,7 @@ describe("agent event handler", () => {
     resetAgentRunContextForTest();
   });
 
-  it("does not project stale pre-reset lifecycle events into session subscriber snapshots", () => {
+  it("does not project stale pre-reset lifecycle events into session subscriber snapshots", async () => {
     vi.mocked(loadGatewaySessionRow).mockReturnValue({
       key: "session-reset",
       kind: "direct",
@@ -2033,6 +2052,11 @@ describe("agent event handler", () => {
       },
     });
 
+    await vi.waitFor(() => {
+      expect(
+        broadcastToConnIds.mock.calls.filter(([event]) => event === "sessions.changed"),
+      ).toHaveLength(2);
+    });
     const sessionsChangedCalls = broadcastToConnIds.mock.calls.filter(
       ([event]) => event === "sessions.changed",
     );
@@ -2059,7 +2083,7 @@ describe("agent event handler", () => {
     resetAgentRunContextForTest();
   });
 
-  it("suppresses late pre-restart lifecycle events from live projections", () => {
+  it("suppresses late interrupted pre-restart lifecycle events from live projections", () => {
     vi.mocked(loadSessionEntry).mockReturnValue({
       cfg: {},
       storePath: "/tmp/sessions.json",
@@ -2107,6 +2131,8 @@ describe("agent event handler", () => {
       ts: 2_100,
       data: {
         phase: "end",
+        aborted: true,
+        stopReason: "restart",
         endedAt: 2_100,
       },
     });
@@ -2123,6 +2149,377 @@ describe("agent event handler", () => {
       clientRunId: "interrupted-run",
       sessionKey: "session-recovery",
     });
+  });
+
+  it("projects successful completion when a restart marker was persisted before abort", async () => {
+    vi.mocked(loadSessionEntry).mockReturnValue({
+      cfg: {},
+      storePath: "/tmp/sessions.json",
+      store: {},
+      entry: {
+        sessionId: "session-recovery",
+        updatedAt: 2_000,
+        status: "running",
+        abortedLastRun: true,
+        restartRecoveryRuns: [
+          {
+            runId: "completed-during-marker-write",
+            lifecycleGeneration: "pre-restart",
+          },
+        ],
+      },
+      canonicalKey: "session-recovery",
+      legacyKey: undefined,
+    });
+    const markTrackedRunTerminalPersisted = vi.fn();
+    const trackTrackedRunTerminalPersistence = vi.fn();
+    const {
+      broadcast,
+      broadcastToConnIds,
+      chatRunState,
+      clearAgentRunContext,
+      clearTrackedActiveRun,
+      handler,
+      sessionEventSubscribers,
+    } = createHarness({
+      resolveSessionKeyForRun: () => "session-recovery",
+      lifecycleErrorRetryGraceMs: 0,
+      markTrackedRunTerminalPersisted,
+      trackTrackedRunTerminalPersistence,
+    });
+    sessionEventSubscribers.subscribe("conn-session");
+    chatRunState.registry.add("completed-during-marker-write", {
+      sessionKey: "session-recovery",
+      clientRunId: "completed-during-marker-write",
+    });
+
+    handler({
+      runId: "completed-during-marker-write",
+      lifecycleGeneration: "pre-restart",
+      seq: 2,
+      stream: "lifecycle",
+      sessionKey: "session-recovery",
+      sessionId: "session-recovery",
+      ts: 2_100,
+      data: {
+        phase: "end",
+        endedAt: 2_100,
+      },
+    });
+
+    expect(chatBroadcastCalls(broadcast)).toHaveLength(1);
+    expect(persistGatewaySessionLifecycleEventMock).toHaveBeenCalledTimes(1);
+    expect(trackTrackedRunTerminalPersistence).toHaveBeenCalledWith({
+      runId: "completed-during-marker-write",
+      clientRunId: "completed-during-marker-write",
+      sessionKey: "session-recovery",
+      observedAt: 2_100,
+      persistence: expect.any(Promise),
+    });
+    await vi.waitFor(() => {
+      expect(markTrackedRunTerminalPersisted).toHaveBeenCalledWith({
+        runId: "completed-during-marker-write",
+        clientRunId: "completed-during-marker-write",
+        sessionKey: "session-recovery",
+      });
+      expect(
+        broadcastToConnIds.mock.calls.filter(([event]) => event === "sessions.changed"),
+      ).toHaveLength(1);
+    });
+    expect(chatRunState.registry.peek("completed-during-marker-write")).toBeUndefined();
+    expect(clearAgentRunContext).toHaveBeenCalledWith("completed-during-marker-write");
+    expect(clearTrackedActiveRun).toHaveBeenCalledWith({
+      runId: "completed-during-marker-write",
+      clientRunId: "completed-during-marker-write",
+      sessionKey: "session-recovery",
+    });
+  });
+
+  it("keeps live session status running while another recovery run remains", async () => {
+    const restartRecoveryRuns = [
+      {
+        runId: "completed-run",
+        lifecycleGeneration: "pre-restart",
+      },
+      {
+        runId: "interrupted-run",
+        lifecycleGeneration: "pre-restart",
+      },
+    ];
+    vi.mocked(loadSessionEntry).mockReturnValue({
+      cfg: {},
+      storePath: "/tmp/sessions.json",
+      store: {},
+      entry: {
+        sessionId: "session-recovery",
+        updatedAt: 2_000,
+        status: "running",
+        abortedLastRun: true,
+        restartRecoveryRuns,
+      },
+      canonicalKey: "session-recovery",
+      legacyKey: undefined,
+    });
+    vi.mocked(loadGatewaySessionRow).mockReturnValue({
+      key: "session-recovery",
+      kind: "direct",
+      sessionId: "session-recovery",
+      updatedAt: 2_000,
+      status: "running",
+      abortedLastRun: true,
+    });
+    const { broadcastToConnIds, handler, sessionEventSubscribers } = createHarness({
+      resolveSessionKeyForRun: () => "session-recovery",
+      lifecycleErrorRetryGraceMs: 0,
+    });
+    sessionEventSubscribers.subscribe("conn-session");
+
+    handler({
+      runId: "completed-run",
+      lifecycleGeneration: "pre-restart",
+      seq: 2,
+      stream: "lifecycle",
+      sessionKey: "session-recovery",
+      sessionId: "session-recovery",
+      ts: 2_100,
+      data: {
+        phase: "end",
+        endedAt: 2_100,
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(
+        broadcastToConnIds.mock.calls.filter(([event]) => event === "sessions.changed"),
+      ).toHaveLength(1);
+    });
+    const payload = requireRecord(
+      requireMockArg(broadcastToConnIds, 0, 1, "sessions changed payload"),
+      "sessions changed payload",
+    );
+    expectPayloadFields(payload, {
+      status: "running",
+      abortedLastRun: true,
+      endedAt: undefined,
+      runtimeMs: undefined,
+    });
+  });
+
+  it("broadcasts canonical state after concurrent recovery completions persist", async () => {
+    const restartRecoveryRuns = [
+      {
+        runId: "run-a",
+        lifecycleGeneration: "pre-restart-a",
+      },
+      {
+        runId: "run-b",
+        lifecycleGeneration: "pre-restart-b",
+      },
+    ];
+    vi.mocked(loadSessionEntry).mockReturnValue({
+      cfg: {},
+      storePath: "/tmp/sessions.json",
+      store: {},
+      entry: {
+        sessionId: "session-recovery",
+        updatedAt: 2_000,
+        status: "running",
+        abortedLastRun: true,
+        restartRecoveryRuns,
+      },
+      canonicalKey: "session-recovery",
+      legacyKey: undefined,
+    });
+    let currentRow = {
+      key: "session-recovery",
+      kind: "direct" as const,
+      sessionId: "session-recovery",
+      updatedAt: 2_000,
+      status: "running" as "done" | "running",
+      abortedLastRun: true,
+    };
+    vi.mocked(loadGatewaySessionRow).mockImplementation(() => currentRow);
+    let resolveRunA: (() => void) | undefined;
+    let resolveRunB: (() => void) | undefined;
+    persistGatewaySessionLifecycleEventMock.mockImplementation(
+      ({ event }: { event: { runId: string } }) =>
+        new Promise<void>((resolve) => {
+          if (event.runId === "run-a") {
+            resolveRunA = resolve;
+          } else {
+            resolveRunB = resolve;
+          }
+        }),
+    );
+    const { broadcastToConnIds, handler, sessionEventSubscribers } = createHarness({
+      resolveSessionKeyForRun: () => "session-recovery",
+      lifecycleErrorRetryGraceMs: 0,
+    });
+    sessionEventSubscribers.subscribe("conn-session");
+
+    for (const [runId, lifecycleGeneration, seq] of [
+      ["run-a", "pre-restart-a", 1],
+      ["run-b", "pre-restart-b", 2],
+    ] as const) {
+      handler({
+        runId,
+        lifecycleGeneration,
+        seq,
+        stream: "lifecycle",
+        sessionKey: "session-recovery",
+        sessionId: "session-recovery",
+        ts: 2_100 + seq,
+        data: {
+          phase: "end",
+          endedAt: 2_100 + seq,
+        },
+      });
+    }
+
+    currentRow = { ...currentRow, updatedAt: 2_101 };
+    resolveRunA?.();
+    await vi.waitFor(() => {
+      expect(
+        broadcastToConnIds.mock.calls.filter(([event]) => event === "sessions.changed"),
+      ).toHaveLength(1);
+    });
+    expectPayloadFields(requireMockArg(broadcastToConnIds, 0, 1, "run-a session snapshot"), {
+      status: "running",
+      abortedLastRun: true,
+    });
+
+    currentRow = {
+      ...currentRow,
+      updatedAt: 2_102,
+      status: "done",
+      abortedLastRun: false,
+    };
+    resolveRunB?.();
+    await vi.waitFor(() => {
+      expect(
+        broadcastToConnIds.mock.calls.filter(([event]) => event === "sessions.changed"),
+      ).toHaveLength(2);
+    });
+    expectPayloadFields(requireMockArg(broadcastToConnIds, 1, 1, "run-b session snapshot"), {
+      status: "done",
+      abortedLastRun: false,
+    });
+  });
+
+  it("reloads canonical state when a restart marker races terminal persistence", async () => {
+    vi.mocked(loadSessionEntry).mockReturnValue({
+      cfg: {},
+      storePath: "/tmp/sessions.json",
+      store: {},
+      entry: {
+        sessionId: "session-recovery",
+        updatedAt: 2_000,
+        status: "running",
+      },
+      canonicalKey: "session-recovery",
+      legacyKey: undefined,
+    });
+    let currentRow = {
+      key: "session-recovery",
+      kind: "direct" as const,
+      sessionId: "session-recovery",
+      updatedAt: 2_000,
+      status: "done" as "done" | "running",
+      abortedLastRun: false,
+    };
+    vi.mocked(loadGatewaySessionRow).mockImplementation(() => currentRow);
+    let resolvePersistence: (() => void) | undefined;
+    persistGatewaySessionLifecycleEventMock.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolvePersistence = resolve;
+        }),
+    );
+    const { broadcastToConnIds, handler, sessionEventSubscribers } = createHarness({
+      resolveSessionKeyForRun: () => "session-recovery",
+      lifecycleErrorRetryGraceMs: 0,
+    });
+    sessionEventSubscribers.subscribe("conn-session");
+
+    handler({
+      runId: "completed-run",
+      lifecycleGeneration: "pre-restart",
+      seq: 2,
+      stream: "lifecycle",
+      sessionKey: "session-recovery",
+      sessionId: "session-recovery",
+      ts: 2_100,
+      data: {
+        phase: "end",
+        endedAt: 2_100,
+      },
+    });
+
+    expect(
+      broadcastToConnIds.mock.calls.filter(([event]) => event === "sessions.changed"),
+    ).toHaveLength(0);
+    currentRow = {
+      ...currentRow,
+      updatedAt: 2_100,
+      status: "running",
+      abortedLastRun: true,
+    };
+    resolvePersistence?.();
+
+    await vi.waitFor(() => {
+      expect(
+        broadcastToConnIds.mock.calls.filter(([event]) => event === "sessions.changed"),
+      ).toHaveLength(1);
+    });
+    expectPayloadFields(requireMockArg(broadcastToConnIds, 0, 1, "canonical session snapshot"), {
+      status: "running",
+      abortedLastRun: true,
+    });
+  });
+
+  it("broadcasts a terminal fallback snapshot when persistence fails", async () => {
+    vi.mocked(loadGatewaySessionRow).mockReturnValue({
+      key: "session-failed-write",
+      kind: "direct",
+      sessionId: "session-failed-write",
+      updatedAt: 2_000,
+      status: "running",
+      startedAt: 1_000,
+      abortedLastRun: false,
+    });
+    persistGatewaySessionLifecycleEventMock.mockRejectedValueOnce(new Error("disk full"));
+    const markTrackedRunTerminalPersisted = vi.fn();
+    const { broadcastToConnIds, handler, sessionEventSubscribers } = createHarness({
+      resolveSessionKeyForRun: () => "session-failed-write",
+      lifecycleErrorRetryGraceMs: 0,
+      markTrackedRunTerminalPersisted,
+    });
+    sessionEventSubscribers.subscribe("conn-session");
+
+    handler({
+      runId: "run-failed-write",
+      seq: 2,
+      stream: "lifecycle",
+      sessionKey: "session-failed-write",
+      sessionId: "session-failed-write",
+      ts: 2_100,
+      data: {
+        phase: "end",
+        endedAt: 2_100,
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(
+        broadcastToConnIds.mock.calls.filter(([event]) => event === "sessions.changed"),
+      ).toHaveLength(1);
+    });
+    expectPayloadFields(requireMockArg(broadcastToConnIds, 0, 1, "fallback session snapshot"), {
+      status: "done",
+      updatedAt: 2_100,
+      abortedLastRun: false,
+    });
+    expect(markTrackedRunTerminalPersisted).not.toHaveBeenCalled();
   });
 
   it("does not clear a same-id retry when an old restart terminal arrives", () => {
@@ -2264,7 +2661,7 @@ describe("agent event handler", () => {
     expect(clearAgentRunContext).not.toHaveBeenCalled();
   });
 
-  it("clears tracked active runs before terminal sessions.changed broadcasts", () => {
+  it("clears tracked active runs before terminal sessions.changed broadcasts", async () => {
     vi.mocked(loadGatewaySessionRow).mockReturnValue({
       key: "session-finished",
       kind: "direct",
@@ -2301,6 +2698,11 @@ describe("agent event handler", () => {
       runId: "provider-run",
       clientRunId: "client-run",
       sessionKey: "session-finished",
+    });
+    await vi.waitFor(() => {
+      expect(
+        broadcastToConnIds.mock.calls.filter(([event]) => event === "sessions.changed"),
+      ).toHaveLength(1);
     });
     expect(requireMockArg(broadcastToConnIds, 0, 0, "sessions changed event")).toBe(
       "sessions.changed",
@@ -2374,7 +2776,7 @@ describe("agent event handler", () => {
     expect(chatBroadcastCalls(broadcast)).toHaveLength(0);
   });
 
-  it("keeps live session setting metadata at the top level for lifecycle updates", () => {
+  it("keeps live session setting metadata at the top level for lifecycle updates", async () => {
     vi.mocked(loadGatewaySessionRow).mockReturnValue({
       key: "session-finished",
       kind: "direct",
@@ -2422,6 +2824,11 @@ describe("agent event handler", () => {
       },
     });
 
+    await vi.waitFor(() => {
+      expect(
+        broadcastToConnIds.mock.calls.filter(([event]) => event === "sessions.changed"),
+      ).toHaveLength(1);
+    });
     expect(requireMockArg(broadcastToConnIds, 0, 0, "sessions changed event")).toBe(
       "sessions.changed",
     );
@@ -2452,7 +2859,7 @@ describe("agent event handler", () => {
     });
   });
 
-  it("omits goal state from unscoped global lifecycle snapshots", () => {
+  it("omits goal state from unscoped global lifecycle snapshots", async () => {
     vi.mocked(loadGatewaySessionRow).mockReturnValue({
       key: "global",
       kind: "global",
@@ -2485,6 +2892,11 @@ describe("agent event handler", () => {
       data: { phase: "end", endedAt: 1_700 },
     });
 
+    await vi.waitFor(() => {
+      expect(
+        broadcastToConnIds.mock.calls.filter(([event]) => event === "sessions.changed"),
+      ).toHaveLength(1);
+    });
     const payload = requireRecord(
       requireMockArg(broadcastToConnIds, 0, 1, "sessions changed payload"),
       "sessions changed payload",

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -83,6 +83,7 @@ describe("agent event handler", () => {
     lifecycleErrorRetryGraceMs?: number;
     isChatSendRunActive?: (runId: string) => boolean;
     clearTrackedActiveRun?: AgentEventHandlerOptions["clearTrackedActiveRun"];
+    resolveActiveLifecycleGenerationForRun?: (runId: string) => string | undefined;
   }) {
     const nowSpy =
       params?.now === undefined ? undefined : vi.spyOn(Date, "now").mockReturnValue(params.now);
@@ -113,6 +114,7 @@ describe("agent event handler", () => {
       lifecycleErrorRetryGraceMs: params?.lifecycleErrorRetryGraceMs,
       isChatSendRunActive: params?.isChatSendRunActive,
       clearTrackedActiveRun: params?.clearTrackedActiveRun ?? clearTrackedActiveRun,
+      resolveActiveLifecycleGenerationForRun: params?.resolveActiveLifecycleGenerationForRun,
     });
 
     return {
@@ -2055,6 +2057,211 @@ describe("agent event handler", () => {
       });
     }
     resetAgentRunContextForTest();
+  });
+
+  it("suppresses late pre-restart lifecycle events from live projections", () => {
+    vi.mocked(loadSessionEntry).mockReturnValue({
+      cfg: {},
+      storePath: "/tmp/sessions.json",
+      store: {},
+      entry: {
+        sessionId: "session-recovery",
+        updatedAt: 2_000,
+        status: "running",
+        abortedLastRun: true,
+        restartRecoveryRuns: [
+          {
+            runId: "interrupted-run",
+            lifecycleGeneration: "pre-restart",
+          },
+        ],
+      },
+      canonicalKey: "session-recovery",
+      legacyKey: undefined,
+    });
+    const {
+      broadcast,
+      broadcastToConnIds,
+      chatRunState,
+      clearAgentRunContext,
+      clearTrackedActiveRun,
+      handler,
+      sessionEventSubscribers,
+    } = createHarness({
+      resolveSessionKeyForRun: () => "session-recovery",
+      lifecycleErrorRetryGraceMs: 0,
+    });
+    sessionEventSubscribers.subscribe("conn-session");
+    chatRunState.registry.add("interrupted-run", {
+      sessionKey: "session-recovery",
+      clientRunId: "interrupted-run",
+    });
+
+    handler({
+      runId: "interrupted-run",
+      lifecycleGeneration: "pre-restart",
+      seq: 2,
+      stream: "lifecycle",
+      sessionKey: "session-recovery",
+      sessionId: "session-recovery",
+      ts: 2_100,
+      data: {
+        phase: "end",
+        endedAt: 2_100,
+      },
+    });
+
+    expect(chatBroadcastCalls(broadcast)).toHaveLength(0);
+    expect(
+      broadcastToConnIds.mock.calls.filter(([event]) => event === "sessions.changed"),
+    ).toHaveLength(0);
+    expect(persistGatewaySessionLifecycleEventMock).not.toHaveBeenCalled();
+    expect(chatRunState.registry.peek("interrupted-run")).toBeUndefined();
+    expect(clearAgentRunContext).toHaveBeenCalledWith("interrupted-run");
+    expect(clearTrackedActiveRun).toHaveBeenCalledWith({
+      runId: "interrupted-run",
+      clientRunId: "interrupted-run",
+      sessionKey: "session-recovery",
+    });
+  });
+
+  it("does not clear a same-id retry when an old restart terminal arrives", () => {
+    vi.mocked(loadSessionEntry).mockReturnValue({
+      cfg: {},
+      storePath: "/tmp/sessions.json",
+      store: {},
+      entry: {
+        sessionId: "session-recovery",
+        updatedAt: 2_000,
+        status: "running",
+        restartRecoveryRuns: [
+          {
+            runId: "shared-run",
+            lifecycleGeneration: "pre-restart",
+          },
+        ],
+      },
+      canonicalKey: "session-recovery",
+      legacyKey: undefined,
+    });
+    registerAgentRunContext("shared-run", {
+      sessionKey: "session-recovery",
+      sessionId: "session-recovery",
+      lifecycleGeneration: "pre-restart",
+    });
+    const { agentRunSeq, chatRunState, clearAgentRunContext, clearTrackedActiveRun, handler } =
+      createHarness({
+        resolveSessionKeyForRun: () => "session-recovery",
+        lifecycleErrorRetryGraceMs: 0,
+        resolveActiveLifecycleGenerationForRun: () => "post-restart",
+      });
+    agentRunSeq.set("shared-run", 4);
+    chatRunState.registry.add("shared-run", {
+      sessionKey: "session-recovery",
+      clientRunId: "shared-run",
+    });
+    chatRunState.buffers.set("shared-run", "new retry output");
+
+    handler({
+      runId: "shared-run",
+      lifecycleGeneration: "pre-restart",
+      seq: 3,
+      stream: "lifecycle",
+      sessionKey: "session-recovery",
+      sessionId: "session-recovery",
+      ts: 2_100,
+      data: {
+        phase: "end",
+        endedAt: 2_100,
+      },
+    });
+
+    expect(chatRunState.registry.peek("shared-run")).toBeDefined();
+    expect(chatRunState.buffers.get("shared-run")).toBe("new retry output");
+    expect(agentRunSeq.get("shared-run")).toBe(4);
+    expect(clearAgentRunContext).not.toHaveBeenCalled();
+    expect(clearTrackedActiveRun).not.toHaveBeenCalled();
+    expect(persistGatewaySessionLifecycleEventMock).not.toHaveBeenCalled();
+  });
+
+  it("cancels a deferred old-generation error before a same-id retry", () => {
+    vi.useFakeTimers();
+    let activeLifecycleGeneration = "pre-restart";
+    registerAgentRunContext("shared-run", {
+      sessionKey: "session-recovery",
+      sessionId: "session-recovery",
+      lifecycleGeneration: activeLifecycleGeneration,
+    });
+    const { chatRunState, clearAgentRunContext, handler } = createHarness({
+      resolveSessionKeyForRun: () => "session-recovery",
+      lifecycleErrorRetryGraceMs: 100,
+      resolveActiveLifecycleGenerationForRun: () => activeLifecycleGeneration,
+    });
+    chatRunState.registry.add("shared-run", {
+      sessionKey: "session-recovery",
+      clientRunId: "shared-run",
+    });
+
+    handler({
+      runId: "shared-run",
+      lifecycleGeneration: "pre-restart",
+      seq: 1,
+      stream: "lifecycle",
+      sessionKey: "session-recovery",
+      sessionId: "session-recovery",
+      ts: 2_000,
+      data: {
+        phase: "error",
+        error: "retryable provider failure",
+        endedAt: 2_000,
+      },
+    });
+    expect(vi.getTimerCount()).toBe(1);
+
+    vi.mocked(loadSessionEntry).mockReturnValue({
+      cfg: {},
+      storePath: "/tmp/sessions.json",
+      store: {},
+      entry: {
+        sessionId: "session-recovery",
+        updatedAt: 2_000,
+        status: "running",
+        restartRecoveryRuns: [
+          {
+            runId: "shared-run",
+            lifecycleGeneration: "pre-restart",
+          },
+        ],
+      },
+      canonicalKey: "session-recovery",
+      legacyKey: undefined,
+    });
+    resetAgentRunContextForTest();
+    activeLifecycleGeneration = "post-restart";
+    registerAgentRunContext("shared-run", {
+      sessionKey: "session-recovery",
+      sessionId: "session-recovery",
+      lifecycleGeneration: activeLifecycleGeneration,
+    });
+
+    handler({
+      runId: "shared-run",
+      lifecycleGeneration: "pre-restart",
+      seq: 2,
+      stream: "lifecycle",
+      sessionKey: "session-recovery",
+      sessionId: "session-recovery",
+      ts: 2_100,
+      data: {
+        phase: "end",
+        endedAt: 2_100,
+      },
+    });
+
+    expect(vi.getTimerCount()).toBe(0);
+    vi.advanceTimersByTime(100);
+    expect(chatRunState.registry.peek("shared-run")).toBeDefined();
+    expect(clearAgentRunContext).not.toHaveBeenCalled();
   });
 
   it("clears tracked active runs before terminal sessions.changed broadcasts", () => {

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -2213,6 +2213,7 @@ describe("agent event handler", () => {
       runId: "completed-during-marker-write",
       clientRunId: "completed-during-marker-write",
       sessionKey: "session-recovery",
+      sessionId: "session-recovery",
       observedAt: 2_100,
       persistence: expect.any(Promise),
     });

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -29,7 +29,7 @@ import type {
 import { loadGatewaySessionRow } from "./server-chat.load-gateway-session-row.runtime.js";
 import { persistGatewaySessionLifecycleEvent } from "./server-chat.persist-session-lifecycle.runtime.js";
 import {
-  deriveGatewaySessionLifecycleSnapshot,
+  deriveGatewaySessionLifecycleProjectionPatch,
   isRestartRecoveryLifecycleEvent,
   isStaleLifecycleEventForSession,
 } from "./session-lifecycle-state.js";
@@ -272,6 +272,18 @@ export type AgentEventHandlerOptions = {
     clientRunId: string;
     sessionKey: string;
   }) => void;
+  markTrackedRunTerminalPersisted?: (params: {
+    runId: string;
+    clientRunId: string;
+    sessionKey: string;
+  }) => void;
+  trackTrackedRunTerminalPersistence?: (params: {
+    runId: string;
+    clientRunId: string;
+    sessionKey: string;
+    observedAt: number;
+    persistence: Promise<void>;
+  }) => void;
   resolveActiveLifecycleGenerationForRun?: (runId: string) => string | undefined;
 };
 
@@ -294,11 +306,14 @@ export function createAgentEventHandler({
   lifecycleErrorRetryGraceMs = AGENT_LIFECYCLE_ERROR_RETRY_GRACE_MS,
   isChatSendRunActive = () => false,
   clearTrackedActiveRun,
+  markTrackedRunTerminalPersisted,
+  trackTrackedRunTerminalPersistence,
   resolveActiveLifecycleGenerationForRun = () => undefined,
 }: AgentEventHandlerOptions) {
   type TerminalLifecycleOptions = {
     skipChatErrorFinal?: boolean;
     suppressRestartRecoveryProjection?: boolean;
+    restartRecoveryState?: { suppress: boolean };
   };
   type PendingTerminalLifecycleError = {
     timer: NodeJS.Timeout;
@@ -339,19 +354,19 @@ export function createAgentEventHandler({
     pendingTerminalLifecycleErrors.delete(runId);
   };
 
-  const shouldSuppressRestartRecoveryLifecycle = (
+  const resolveRestartRecoveryLifecycleState = (
     sessionKey: string,
     agentId: string | undefined,
     event: AgentEventPayload,
-  ): boolean => {
+  ): { suppress: boolean } => {
     try {
       const { entry } = loadSessionEntry(sessionKey, {
         ...(agentId ? { agentId } : {}),
         clone: false,
       });
-      return isRestartRecoveryLifecycleEvent({ entry, event });
+      return { suppress: isRestartRecoveryLifecycleEvent({ entry, event }) };
     } catch {
-      return false;
+      return { suppress: false };
     }
   };
 
@@ -393,8 +408,8 @@ export function createAgentEventHandler({
         owningSessionId: evt.sessionId,
         currentSessionId: row?.sessionId,
       })
-        ? deriveGatewaySessionLifecycleSnapshot({
-            session: row
+        ? deriveGatewaySessionLifecycleProjectionPatch({
+            entry: row
               ? {
                   updatedAt: row.updatedAt ?? undefined,
                   status: row.status,
@@ -550,6 +565,15 @@ export function createAgentEventHandler({
     const deliverySessionKey = sessionKey
       ? resolveSessionDeliveryKey(sessionKey, sessionAgentId)
       : undefined;
+    const restartRecoveryState =
+      opts?.restartRecoveryState ??
+      (restartRecoverySessionKey
+        ? resolveRestartRecoveryLifecycleState(
+            restartRecoverySessionKey,
+            restartRecoveryAgentId,
+            evt,
+          )
+        : undefined);
     const suppressRestartRecoveryProjection =
       opts?.suppressRestartRecoveryProjection === true ||
       Boolean(
@@ -557,14 +581,7 @@ export function createAgentEventHandler({
         activeLifecycleGeneration &&
         evt.lifecycleGeneration !== activeLifecycleGeneration,
       ) ||
-      Boolean(
-        restartRecoverySessionKey &&
-        shouldSuppressRestartRecoveryLifecycle(
-          restartRecoverySessionKey,
-          restartRecoveryAgentId,
-          evt,
-        ),
-      );
+      restartRecoveryState?.suppress === true;
     const isSupersededRestartRecoveryEvent =
       suppressRestartRecoveryProjection &&
       Boolean(
@@ -643,13 +660,23 @@ export function createAgentEventHandler({
     if (sessionKey) {
       clearTrackedActiveRun?.({ runId: evt.runId, clientRunId, sessionKey });
       if (!suppressRestartRecoveryProjection) {
-        void persistGatewaySessionLifecycleEvent({
+        const persistence = persistGatewaySessionLifecycleEvent({
           sessionKey,
           agentId: sessionAgentId,
           event: evt,
-        }).catch(() => undefined);
-        const sessionEventConnIds = sessionEventSubscribers.getAll();
-        if (sessionEventConnIds.size > 0) {
+        });
+        trackTrackedRunTerminalPersistence?.({
+          runId: evt.runId,
+          clientRunId,
+          sessionKey,
+          observedAt: evt.ts,
+          persistence,
+        });
+        const broadcastSessionChange = (snapshotEvent?: AgentEventPayload) => {
+          const sessionEventConnIds = sessionEventSubscribers.getAll();
+          if (sessionEventConnIds.size === 0) {
+            return;
+          }
           broadcastToConnIds(
             "sessions.changed",
             {
@@ -659,12 +686,31 @@ export function createAgentEventHandler({
               runId: evt.runId,
               ...(eventRunId !== evt.runId ? { clientRunId: eventRunId } : {}),
               ts: evt.ts,
-              ...buildSessionEventSnapshot(sessionKey, evt, sessionAgentId),
+              ...buildSessionEventSnapshot(sessionKey, snapshotEvent, sessionAgentId),
             },
             sessionEventConnIds,
             { dropIfSlow: true },
           );
-        }
+        };
+        const markPersisted = () => {
+          markTrackedRunTerminalPersisted?.({
+            runId: evt.runId,
+            clientRunId,
+            sessionKey,
+          });
+        };
+        // Terminal writes serialize with restart markers. Reload only after the
+        // write so subscribers see the canonical post-race session state.
+        void persistence
+          .then(() => {
+            markPersisted();
+            broadcastSessionChange();
+          })
+          .catch(() => {
+            // Persistence recovery remains tracked by the controller entry, but
+            // subscribers still need a terminal projection instead of hanging.
+            broadcastSessionChange(evt);
+          });
       }
     }
   };
@@ -1101,6 +1147,9 @@ export function createAgentEventHandler({
     const eventForClients = chatLink ? { ...evt, runId: eventRunId } : evt;
     const isAborted =
       chatRunState.abortedRuns.has(clientRunId) || chatRunState.abortedRuns.has(evt.runId);
+    const restartRecoveryState = restartRecoverySessionKey
+      ? resolveRestartRecoveryLifecycleState(restartRecoverySessionKey, restartRecoveryAgentId, evt)
+      : undefined;
     const suppressRestartRecoveryLifecycle =
       lifecyclePhase !== null &&
       (Boolean(
@@ -1108,18 +1157,14 @@ export function createAgentEventHandler({
         activeLifecycleGeneration &&
         evt.lifecycleGeneration !== activeLifecycleGeneration,
       ) ||
-        Boolean(
-          restartRecoverySessionKey &&
-          shouldSuppressRestartRecoveryLifecycle(
-            restartRecoverySessionKey,
-            restartRecoveryAgentId,
-            evt,
-          ),
-        ));
+        restartRecoveryState?.suppress === true);
     if (suppressRestartRecoveryLifecycle) {
       clearPendingTerminalLifecycleError(evt.runId, evt.lifecycleGeneration);
       if (lifecyclePhase === "end" || lifecyclePhase === "error") {
-        finalizeLifecycleEvent(evt, { suppressRestartRecoveryProjection: true });
+        finalizeLifecycleEvent(evt, {
+          suppressRestartRecoveryProjection: true,
+          restartRecoveryState,
+        });
       }
       return;
     }
@@ -1353,15 +1398,15 @@ export function createAgentEventHandler({
       // the runId. Once the runner marks fallback as exhausted, clear chat state
       // immediately so webchat sessions do not stay in progress until the timer.
       if (isAborted || isFallbackExhaustedFailure || lifecycleErrorRetryGraceMs <= 0) {
-        finalizeLifecycleEvent(evt, { skipChatErrorFinal });
+        finalizeLifecycleEvent(evt, { skipChatErrorFinal, restartRecoveryState });
       } else {
-        scheduleTerminalLifecycleError(evt, { skipChatErrorFinal });
+        scheduleTerminalLifecycleError(evt, { skipChatErrorFinal, restartRecoveryState });
       }
       return;
     }
 
     if (lifecyclePhase === "end") {
-      finalizeLifecycleEvent(evt);
+      finalizeLifecycleEvent(evt, { restartRecoveryState });
       return;
     }
 

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -281,6 +281,7 @@ export type AgentEventHandlerOptions = {
     runId: string;
     clientRunId: string;
     sessionKey: string;
+    sessionId?: string;
     observedAt: number;
     persistence: Promise<void>;
   }) => void;
@@ -669,6 +670,7 @@ export function createAgentEventHandler({
           runId: evt.runId,
           clientRunId,
           sessionKey,
+          sessionId: evt.sessionId,
           observedAt: evt.ts,
           persistence,
         });

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -30,6 +30,7 @@ import { loadGatewaySessionRow } from "./server-chat.load-gateway-session-row.ru
 import { persistGatewaySessionLifecycleEvent } from "./server-chat.persist-session-lifecycle.runtime.js";
 import {
   deriveGatewaySessionLifecycleSnapshot,
+  isRestartRecoveryLifecycleEvent,
   isStaleLifecycleEventForSession,
 } from "./session-lifecycle-state.js";
 import { loadSessionEntry } from "./session-utils.js";
@@ -271,6 +272,7 @@ export type AgentEventHandlerOptions = {
     clientRunId: string;
     sessionKey: string;
   }) => void;
+  resolveActiveLifecycleGenerationForRun?: (runId: string) => string | undefined;
 };
 
 function roundedChatSendTimingMs(value: number): number {
@@ -292,8 +294,12 @@ export function createAgentEventHandler({
   lifecycleErrorRetryGraceMs = AGENT_LIFECYCLE_ERROR_RETRY_GRACE_MS,
   isChatSendRunActive = () => false,
   clearTrackedActiveRun,
+  resolveActiveLifecycleGenerationForRun = () => undefined,
 }: AgentEventHandlerOptions) {
-  type TerminalLifecycleOptions = { skipChatErrorFinal?: boolean };
+  type TerminalLifecycleOptions = {
+    skipChatErrorFinal?: boolean;
+    suppressRestartRecoveryProjection?: boolean;
+  };
   type PendingTerminalLifecycleError = {
     timer: NodeJS.Timeout;
     event: AgentEventPayload;
@@ -317,13 +323,36 @@ export function createAgentEventHandler({
     chatRunState.clearRun(clientRunId);
   };
 
-  const clearPendingTerminalLifecycleError = (runId: string) => {
+  const clearPendingTerminalLifecycleError = (runId: string, lifecycleGeneration?: string) => {
     const pending = pendingTerminalLifecycleErrors.get(runId);
     if (!pending) {
       return;
     }
+    if (
+      lifecycleGeneration &&
+      pending.event.lifecycleGeneration &&
+      lifecycleGeneration !== pending.event.lifecycleGeneration
+    ) {
+      return;
+    }
     clearTimeout(pending.timer);
     pendingTerminalLifecycleErrors.delete(runId);
+  };
+
+  const shouldSuppressRestartRecoveryLifecycle = (
+    sessionKey: string,
+    agentId: string | undefined,
+    event: AgentEventPayload,
+  ): boolean => {
+    try {
+      const { entry } = loadSessionEntry(sessionKey, {
+        ...(agentId ? { agentId } : {}),
+        clone: false,
+      });
+      return isRestartRecoveryLifecycleEvent({ entry, event });
+    } catch {
+      return false;
+    }
   };
 
   // Only subagent/acp keys can carry spawnedBy (mirrors supportsSpawnLineage in
@@ -500,15 +529,20 @@ export function createAgentEventHandler({
       return;
     }
 
-    clearPendingTerminalLifecycleError(evt.runId);
+    const currentRunContext = getAgentRunContext(evt.runId);
+    const activeLifecycleGeneration = resolveActiveLifecycleGenerationForRun(evt.runId);
+    const currentLifecycleGeneration =
+      activeLifecycleGeneration ?? currentRunContext?.lifecycleGeneration;
 
     const chatLink = chatRunState.registry.peek(evt.runId);
     const sessionAgentId = chatLink?.agentId ?? evt.agentId;
     const eventSessionKey =
       typeof evt.sessionKey === "string" && evt.sessionKey.trim() ? evt.sessionKey : undefined;
-    const isControlUiVisible = getAgentRunContext(evt.runId)?.isControlUiVisible ?? true;
+    const isControlUiVisible = currentRunContext?.isControlUiVisible ?? true;
     const sessionKey =
       chatLink?.sessionKey ?? eventSessionKey ?? resolveSessionKeyForRun(evt.runId);
+    const restartRecoverySessionKey = eventSessionKey ?? sessionKey;
+    const restartRecoveryAgentId = evt.agentId ?? sessionAgentId;
     const clientRunId = chatLink?.clientRunId ?? evt.runId;
     const eventRunId = chatLink?.clientRunId ?? evt.runId;
     const isAborted =
@@ -516,8 +550,34 @@ export function createAgentEventHandler({
     const deliverySessionKey = sessionKey
       ? resolveSessionDeliveryKey(sessionKey, sessionAgentId)
       : undefined;
+    const suppressRestartRecoveryProjection =
+      opts?.suppressRestartRecoveryProjection === true ||
+      Boolean(
+        evt.lifecycleGeneration &&
+        activeLifecycleGeneration &&
+        evt.lifecycleGeneration !== activeLifecycleGeneration,
+      ) ||
+      Boolean(
+        restartRecoverySessionKey &&
+        shouldSuppressRestartRecoveryLifecycle(
+          restartRecoverySessionKey,
+          restartRecoveryAgentId,
+          evt,
+        ),
+      );
+    const isSupersededRestartRecoveryEvent =
+      suppressRestartRecoveryProjection &&
+      Boolean(
+        evt.lifecycleGeneration &&
+        currentLifecycleGeneration &&
+        evt.lifecycleGeneration !== currentLifecycleGeneration,
+      );
+    if (isSupersededRestartRecoveryEvent) {
+      return;
+    }
 
     if (
+      !suppressRestartRecoveryProjection &&
       sessionKey &&
       (isControlUiVisible ||
         (deliverySessionKey ? sessionMessageSubscribers.get(deliverySessionKey).size > 0 : false))
@@ -573,33 +633,38 @@ export function createAgentEventHandler({
 
     toolEventRecipients.markFinal(evt.runId);
     clearBufferedChatState(clientRunId);
+    if (suppressRestartRecoveryProjection && chatLink) {
+      chatRunState.registry.remove(evt.runId, clientRunId, sessionKey);
+    }
     clearAgentRunContext(evt.runId);
     agentRunSeq.delete(evt.runId);
     agentRunSeq.delete(clientRunId);
 
     if (sessionKey) {
       clearTrackedActiveRun?.({ runId: evt.runId, clientRunId, sessionKey });
-      void persistGatewaySessionLifecycleEvent({
-        sessionKey,
-        agentId: sessionAgentId,
-        event: evt,
-      }).catch(() => undefined);
-      const sessionEventConnIds = sessionEventSubscribers.getAll();
-      if (sessionEventConnIds.size > 0) {
-        broadcastToConnIds(
-          "sessions.changed",
-          {
-            sessionKey,
-            ...(sessionAgentId ? { agentId: sessionAgentId } : {}),
-            phase: lifecyclePhase,
-            runId: evt.runId,
-            ...(eventRunId !== evt.runId ? { clientRunId: eventRunId } : {}),
-            ts: evt.ts,
-            ...buildSessionEventSnapshot(sessionKey, evt, sessionAgentId),
-          },
-          sessionEventConnIds,
-          { dropIfSlow: true },
-        );
+      if (!suppressRestartRecoveryProjection) {
+        void persistGatewaySessionLifecycleEvent({
+          sessionKey,
+          agentId: sessionAgentId,
+          event: evt,
+        }).catch(() => undefined);
+        const sessionEventConnIds = sessionEventSubscribers.getAll();
+        if (sessionEventConnIds.size > 0) {
+          broadcastToConnIds(
+            "sessions.changed",
+            {
+              sessionKey,
+              ...(sessionAgentId ? { agentId: sessionAgentId } : {}),
+              phase: lifecyclePhase,
+              runId: evt.runId,
+              ...(eventRunId !== evt.runId ? { clientRunId: eventRunId } : {}),
+              ts: evt.ts,
+              ...buildSessionEventSnapshot(sessionKey, evt, sessionAgentId),
+            },
+            sessionEventConnIds,
+            { dropIfSlow: true },
+          );
+        }
       }
     }
   };
@@ -1018,24 +1083,49 @@ export function createAgentEventHandler({
   return (evt: AgentEventPayload) => {
     const lifecyclePhase =
       evt.stream === "lifecycle" && typeof evt.data?.phase === "string" ? evt.data.phase : null;
-    if (lifecyclePhase !== null && lifecyclePhase !== "error") {
-      clearPendingTerminalLifecycleError(evt.runId);
-    }
 
     const chatLink = chatRunState.registry.peek(evt.runId);
     const sessionAgentId = chatLink?.agentId ?? evt.agentId;
     const eventSessionKey =
       typeof evt.sessionKey === "string" && evt.sessionKey.trim() ? evt.sessionKey : undefined;
     const runContext = getAgentRunContext(evt.runId);
+    const activeLifecycleGeneration = resolveActiveLifecycleGenerationForRun(evt.runId);
     const isControlUiVisible = runContext?.isControlUiVisible ?? true;
     const isHeartbeat = runContext?.isHeartbeat;
     const sessionKey =
       chatLink?.sessionKey ?? eventSessionKey ?? resolveSessionKeyForRun(evt.runId);
+    const restartRecoverySessionKey = eventSessionKey ?? sessionKey;
+    const restartRecoveryAgentId = evt.agentId ?? sessionAgentId;
     const clientRunId = chatLink?.clientRunId ?? evt.runId;
     const eventRunId = chatLink?.clientRunId ?? evt.runId;
     const eventForClients = chatLink ? { ...evt, runId: eventRunId } : evt;
     const isAborted =
       chatRunState.abortedRuns.has(clientRunId) || chatRunState.abortedRuns.has(evt.runId);
+    const suppressRestartRecoveryLifecycle =
+      lifecyclePhase !== null &&
+      (Boolean(
+        evt.lifecycleGeneration &&
+        activeLifecycleGeneration &&
+        evt.lifecycleGeneration !== activeLifecycleGeneration,
+      ) ||
+        Boolean(
+          restartRecoverySessionKey &&
+          shouldSuppressRestartRecoveryLifecycle(
+            restartRecoverySessionKey,
+            restartRecoveryAgentId,
+            evt,
+          ),
+        ));
+    if (suppressRestartRecoveryLifecycle) {
+      clearPendingTerminalLifecycleError(evt.runId, evt.lifecycleGeneration);
+      if (lifecyclePhase === "end" || lifecyclePhase === "error") {
+        finalizeLifecycleEvent(evt, { suppressRestartRecoveryProjection: true });
+      }
+      return;
+    }
+    if (lifecyclePhase !== null && lifecyclePhase !== "error") {
+      clearPendingTerminalLifecycleError(evt.runId);
+    }
     // Include sessionKey so Control UI can filter tool streams per session.
     const spawnedBy = sessionKey ? resolveSpawnedBy(sessionKey) : null;
     const agentPayload = sessionKey

--- a/src/gateway/server-close.test.ts
+++ b/src/gateway/server-close.test.ts
@@ -78,6 +78,9 @@ const {
 } = await import("./restart-trace.js");
 type GatewayCloseHandlerParams = Parameters<typeof createGatewayCloseHandler>[0];
 type GatewayCloseClient = GatewayCloseHandlerParams["clients"] extends Set<infer T> ? T : never;
+type MarkMainSessionsAbortedForRestart = NonNullable<
+  GatewayCloseHandlerParams["markMainSessionsAbortedForRestart"]
+>;
 type DrainActiveSessionsForShutdown = NonNullable<
   GatewayCloseHandlerParams["drainActiveSessionsForShutdown"]
 >;
@@ -708,7 +711,7 @@ describe("createGatewayCloseHandler", () => {
         },
       ],
     ]);
-    const markMainSessionsAbortedForRestart = vi.fn(async () => {
+    const markMainSessionsAbortedForRestart = vi.fn<MarkMainSessionsAbortedForRestart>(async () => {
       events.push("marker");
     });
     const removeChatRun = vi.fn(() => {

--- a/src/gateway/server-close.test.ts
+++ b/src/gateway/server-close.test.ts
@@ -2,6 +2,7 @@
  * Gateway server close lifecycle tests.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { isAgentRunRestartAbortReason } from "../agents/run-termination.js";
 import type { InternalHookEvent } from "../hooks/internal-hooks.js";
 
 type TriggerInternalHookMock = (event: InternalHookEvent) => Promise<void>;
@@ -121,6 +122,7 @@ function createGatewayCloseTestDeps(
     lifecycleUnsub: null,
     chatRunState: createTestChatRunState(),
     chatAbortControllers: new Map(),
+    restartRecoveryCandidates: new Map(),
     removeChatRun: vi.fn(),
     agentRunSeq: new Map(),
     nodeSendToSession: vi.fn(),
@@ -664,6 +666,7 @@ describe("createGatewayCloseHandler", () => {
 
     expect(result.warnings).toContain("restart-reply-drain");
     expect(controller.signal.aborted).toBe(true);
+    expect(isAgentRunRestartAbortReason(controller.signal.reason)).toBe(true);
     expect(chatAbortControllers.size).toBe(0);
     expect(
       mocks.logWarn.mock.calls.some(([message]) =>
@@ -676,6 +679,8 @@ describe("createGatewayCloseHandler", () => {
     const events: string[] = [];
     const controller = new AbortController();
     const agentController = new AbortController();
+    const completedController = new AbortController();
+    const hiddenController = new AbortController();
     const alreadyAbortedController = new AbortController();
     alreadyAbortedController.abort();
     const chatAbortControllers = new Map([
@@ -703,6 +708,20 @@ describe("createGatewayCloseHandler", () => {
         },
       ],
       [
+        "completed-run",
+        {
+          controller: completedController,
+          sessionId: "completed-session-id",
+          sessionKey: "agent:main:completed",
+          lifecycleGeneration: "generation-1",
+          projectSessionActive: false,
+          projectSessionTerminalPersisted: true,
+          registrationCleanupRequested: true,
+          startedAtMs: Date.now(),
+          expiresAtMs: Date.now() + 60_000,
+        },
+      ],
+      [
         "stale-run",
         {
           controller: alreadyAbortedController,
@@ -711,6 +730,19 @@ describe("createGatewayCloseHandler", () => {
           lifecycleGeneration: "generation-1",
           startedAtMs: Date.now(),
           expiresAtMs: Date.now() + 60_000,
+        },
+      ],
+      [
+        "hidden-run",
+        {
+          controller: hiddenController,
+          sessionId: "hidden-session-id",
+          sessionKey: "agent:main:hidden",
+          lifecycleGeneration: "generation-1",
+          controlUiVisible: false,
+          startedAtMs: Date.now(),
+          expiresAtMs: Date.now() + 60_000,
+          kind: "agent" as const,
         },
       ],
     ]);
@@ -761,16 +793,300 @@ describe("createGatewayCloseHandler", () => {
         lifecycleGeneration: "generation-1",
         sessionKey: "agent:main:main",
         sessionId: "current-session-id-1",
+        observedAt: expect.any(Number),
       },
       {
         runId: "agent-run-1",
         lifecycleGeneration: "generation-1",
         sessionKey: "agent:main:test:direct:source",
         sessionId: "session-id-2",
+        observedAt: expect.any(Number),
       },
     ]);
     expect(controller.signal.aborted).toBe(true);
     expect(agentController.signal.aborted).toBe(true);
+    expect(completedController.signal.aborted).toBe(true);
+    expect(hiddenController.signal.aborted).toBe(true);
+  });
+
+  it("keeps post-terminal caller work in restart drain and recovery", async () => {
+    const controller = new AbortController();
+    const markMainSessionsAbortedForRestart = vi.fn<MarkMainSessionsAbortedForRestart>();
+    const chatAbortControllers = new Map([
+      [
+        "post-terminal-run",
+        {
+          controller,
+          sessionId: "post-terminal-session-id",
+          sessionKey: "agent:main:post-terminal",
+          lifecycleGeneration: "generation-1",
+          projectSessionActive: false,
+          projectSessionTerminalPersisted: true,
+          startedAtMs: Date.now(),
+          expiresAtMs: Date.now() + 60_000,
+        },
+      ],
+    ]);
+    const close = createGatewayCloseHandler(
+      createGatewayCloseTestDeps({
+        chatAbortControllers,
+        markMainSessionsAbortedForRestart,
+      }),
+    );
+
+    const result = await close({
+      reason: "gateway restarting",
+      restartExpectedMs: 123,
+      drainTimeoutMs: 0,
+    });
+
+    expect(result.warnings).toContain("restart-reply-drain");
+    expect(markMainSessionsAbortedForRestart).toHaveBeenCalledWith(
+      expect.objectContaining({
+        activeRuns: [
+          {
+            runId: "post-terminal-run",
+            lifecycleGeneration: "generation-1",
+            sessionKey: "agent:main:post-terminal",
+            sessionId: "post-terminal-session-id",
+            observedAt: expect.any(Number),
+          },
+        ],
+      }),
+    );
+    expect(controller.signal.aborted).toBe(true);
+  });
+
+  it("marks and quietly cancels terminal runs before persistence settles", async () => {
+    const controller = new AbortController();
+    const broadcast = vi.fn();
+    const markMainSessionsAbortedForRestart = vi.fn<MarkMainSessionsAbortedForRestart>();
+    const nodeSendToSession = vi.fn();
+    const chatAbortControllers = new Map([
+      [
+        "completed-run",
+        {
+          controller,
+          sessionId: "completed-session-id",
+          sessionKey: "agent:main:completed",
+          lifecycleGeneration: "generation-1",
+          projectSessionActive: false,
+          projectSessionTerminalPersisted: false,
+          registrationCleanupRequested: true,
+          startedAtMs: Date.now(),
+          expiresAtMs: Date.now() + 60_000,
+        },
+      ],
+    ]);
+    const close = createGatewayCloseHandler(
+      createGatewayCloseTestDeps({
+        broadcast,
+        chatAbortControllers,
+        getPendingReplyCount: () => 1,
+        markMainSessionsAbortedForRestart,
+        nodeSendToSession,
+      }),
+    );
+
+    await close({
+      reason: "gateway restarting",
+      restartExpectedMs: 123,
+      drainTimeoutMs: 0,
+    });
+
+    expect(controller.signal.aborted).toBe(true);
+    expect(chatAbortControllers.size).toBe(0);
+    expect(markMainSessionsAbortedForRestart).toHaveBeenCalledWith(
+      expect.objectContaining({
+        activeRuns: [
+          {
+            runId: "completed-run",
+            lifecycleGeneration: "generation-1",
+            sessionKey: "agent:main:completed",
+            sessionId: "completed-session-id",
+            observedAt: expect.any(Number),
+          },
+        ],
+      }),
+    );
+    expect(broadcast.mock.calls.some(([event]) => event === "chat")).toBe(false);
+    expect(nodeSendToSession).not.toHaveBeenCalled();
+  });
+
+  it("awaits terminal persistence before deciding restart recovery", async () => {
+    const controller = new AbortController();
+    const markMainSessionsAbortedForRestart = vi.fn<MarkMainSessionsAbortedForRestart>();
+    const chatAbortControllers = new Map([
+      [
+        "completed-run",
+        {
+          controller,
+          sessionId: "completed-session-id",
+          sessionKey: "agent:main:completed",
+          lifecycleGeneration: "generation-1",
+          projectSessionActive: false,
+          projectSessionTerminalPersisted: false,
+          projectSessionTerminalPersistence: Promise.resolve(),
+          registrationCleanupRequested: true,
+          startedAtMs: Date.now(),
+          expiresAtMs: Date.now() + 60_000,
+        },
+      ],
+    ]);
+    const close = createGatewayCloseHandler(
+      createGatewayCloseTestDeps({
+        chatAbortControllers,
+        getPendingReplyCount: () => 1,
+        markMainSessionsAbortedForRestart,
+      }),
+    );
+
+    await close({
+      reason: "gateway restarting",
+      restartExpectedMs: 123,
+      drainTimeoutMs: 0,
+    });
+
+    expect(markMainSessionsAbortedForRestart).not.toHaveBeenCalled();
+    expect(controller.signal.aborted).toBe(true);
+    expect(chatAbortControllers.size).toBe(0);
+  });
+
+  it("bounds terminal persistence waiting and preserves recovery", async () => {
+    vi.useFakeTimers();
+    const controller = new AbortController();
+    const markMainSessionsAbortedForRestart = vi.fn<MarkMainSessionsAbortedForRestart>();
+    const getPendingReplyCount = vi.fn().mockReturnValueOnce(1).mockReturnValue(0);
+    const chatAbortControllers = new Map([
+      [
+        "persisting-run",
+        {
+          controller,
+          sessionId: "persisting-session-id",
+          sessionKey: "agent:main:persisting",
+          lifecycleGeneration: "generation-1",
+          projectSessionActive: false,
+          projectSessionTerminalPersisted: false,
+          projectSessionTerminalPersistence: new Promise<void>(() => {}),
+          registrationCleanupRequested: true,
+          startedAtMs: Date.now(),
+          expiresAtMs: Date.now() + 60_000,
+        },
+      ],
+    ]);
+    const close = createGatewayCloseHandler(
+      createGatewayCloseTestDeps({
+        chatAbortControllers,
+        getPendingReplyCount,
+        markMainSessionsAbortedForRestart,
+      }),
+    );
+
+    const closePromise = close({
+      reason: "gateway restarting",
+      restartExpectedMs: 123,
+      drainTimeoutMs: 0,
+    });
+    await vi.advanceTimersByTimeAsync(1_000);
+    await closePromise;
+
+    expect(markMainSessionsAbortedForRestart).toHaveBeenCalledTimes(1);
+    expect(controller.signal.aborted).toBe(true);
+  });
+
+  it("warns on slow restart marker persistence and waits before cleanup", async () => {
+    vi.useFakeTimers();
+    const controller = new AbortController();
+    const getPendingReplyCount = vi.fn().mockReturnValueOnce(1).mockReturnValue(0);
+    let finishMarker: (() => void) | undefined;
+    const markerPending = new Promise<void>((resolve) => {
+      finishMarker = resolve;
+    });
+    const chatAbortControllers = new Map([
+      [
+        "active-run",
+        {
+          controller,
+          sessionId: "active-session-id",
+          sessionKey: "agent:main:active",
+          lifecycleGeneration: "generation-1",
+          startedAtMs: Date.now(),
+          expiresAtMs: Date.now() + 60_000,
+        },
+      ],
+    ]);
+    const close = createGatewayCloseHandler(
+      createGatewayCloseTestDeps({
+        chatAbortControllers,
+        getPendingReplyCount,
+        markMainSessionsAbortedForRestart: () => markerPending,
+      }),
+    );
+
+    let closeSettled = false;
+    const closePromise = close({
+      reason: "gateway restarting",
+      restartExpectedMs: 123,
+      drainTimeoutMs: 0,
+    });
+    void closePromise.finally(() => {
+      closeSettled = true;
+    });
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(closeSettled).toBe(false);
+    expect(controller.signal.aborted).toBe(false);
+    finishMarker?.();
+    const result = await closePromise;
+
+    expect(result.warnings).toContain("restart-main-session-marker");
+    expect(controller.signal.aborted).toBe(true);
+  });
+
+  it("marks failed terminal persistence after the run guard is gone", async () => {
+    let activeDuringMark = false;
+    const markMainSessionsAbortedForRestart = vi.fn<MarkMainSessionsAbortedForRestart>(
+      async (params) => {
+        const run = params.activeRuns[0];
+        activeDuringMark = run ? params.isActiveRun(run) : false;
+      },
+    );
+    const restartRecoveryCandidates = new Map([
+      [
+        "failed-persistence-run",
+        {
+          runId: "failed-persistence-run",
+          lifecycleGeneration: "generation-1",
+          sessionKey: "agent:main:failed-persistence",
+          sessionId: "failed-persistence-session",
+        },
+      ],
+    ]);
+    const close = createGatewayCloseHandler(
+      createGatewayCloseTestDeps({
+        markMainSessionsAbortedForRestart,
+        restartRecoveryCandidates,
+        resolveActiveSessionIdForKey: () => "rotated-persistence-session",
+      }),
+    );
+
+    await close({
+      reason: "gateway restarting",
+      restartExpectedMs: 123,
+      drainTimeoutMs: 0,
+    });
+
+    const markerCall = firstMockCall(markMainSessionsAbortedForRestart);
+    expect(markerCall?.[0]?.activeRuns).toEqual([
+      {
+        runId: "failed-persistence-run",
+        lifecycleGeneration: "generation-1",
+        sessionKey: "agent:main:failed-persistence",
+        sessionId: "rotated-persistence-session",
+        observedAt: expect.any(Number),
+      },
+    ]);
+    expect(activeDuringMark).toBe(true);
+    expect(restartRecoveryCandidates.size).toBe(0);
   });
 
   it("continues restart shutdown when marking active main sessions fails", async () => {

--- a/src/gateway/server-close.test.ts
+++ b/src/gateway/server-close.test.ts
@@ -685,6 +685,7 @@ describe("createGatewayCloseHandler", () => {
           controller,
           sessionId: "session-id-1",
           sessionKey: "agent:main:main",
+          lifecycleGeneration: "generation-1",
           startedAtMs: Date.now(),
           expiresAtMs: Date.now() + 60_000,
         },
@@ -695,6 +696,7 @@ describe("createGatewayCloseHandler", () => {
           controller: agentController,
           sessionId: "session-id-2",
           sessionKey: "agent:main:test:direct:source",
+          lifecycleGeneration: "generation-1",
           startedAtMs: Date.now(),
           expiresAtMs: Date.now() + 60_000,
           kind: "agent" as const,
@@ -706,6 +708,7 @@ describe("createGatewayCloseHandler", () => {
           controller: alreadyAbortedController,
           sessionId: "stale-session-id",
           sessionKey: "agent:main:stale",
+          lifecycleGeneration: "generation-1",
           startedAtMs: Date.now(),
           expiresAtMs: Date.now() + 60_000,
         },
@@ -723,6 +726,15 @@ describe("createGatewayCloseHandler", () => {
         chatAbortControllers,
         markMainSessionsAbortedForRestart,
         removeChatRun,
+        resolveActiveSessionIdForKey: (sessionKey) => {
+          if (sessionKey === "agent:main:main") {
+            return "current-session-id-1";
+          }
+          if (sessionKey === "agent:main:test:direct:source") {
+            return "stale-agent-registry-id";
+          }
+          return undefined;
+        },
       }),
     );
 
@@ -740,9 +752,66 @@ describe("createGatewayCloseHandler", () => {
     expect(markerCall?.[0]?.sessionKeys).toStrictEqual(
       new Set(["agent:main:main", "agent:main:test:direct:source"]),
     );
-    expect(markerCall?.[0]?.sessionIds).toStrictEqual(new Set(["session-id-1", "session-id-2"]));
+    expect(markerCall?.[0]?.sessionIds).toStrictEqual(
+      new Set(["current-session-id-1", "session-id-2"]),
+    );
+    expect(markerCall?.[0]?.activeRuns).toEqual([
+      {
+        runId: "run-1",
+        lifecycleGeneration: "generation-1",
+        sessionKey: "agent:main:main",
+        sessionId: "current-session-id-1",
+      },
+      {
+        runId: "agent-run-1",
+        lifecycleGeneration: "generation-1",
+        sessionKey: "agent:main:test:direct:source",
+        sessionId: "session-id-2",
+      },
+    ]);
     expect(controller.signal.aborted).toBe(true);
     expect(agentController.signal.aborted).toBe(true);
+  });
+
+  it("continues restart shutdown when marking active main sessions fails", async () => {
+    const controller = new AbortController();
+    const chatAbortControllers = new Map([
+      [
+        "run-1",
+        {
+          controller,
+          sessionId: "session-id-1",
+          sessionKey: "agent:main:main",
+          startedAtMs: Date.now(),
+          expiresAtMs: Date.now() + 60_000,
+        },
+      ],
+    ]);
+    const close = createGatewayCloseHandler(
+      createGatewayCloseTestDeps({
+        chatAbortControllers,
+        markMainSessionsAbortedForRestart: vi.fn(async () => {
+          throw new Error("marker unavailable");
+        }),
+      }),
+    );
+
+    const result = await close({
+      reason: "gateway restarting",
+      restartExpectedMs: 123,
+      drainTimeoutMs: 0,
+    });
+
+    expect(result.warnings).toContain("restart-main-session-marker");
+    expect(controller.signal.aborted).toBe(true);
+    expect(chatAbortControllers.size).toBe(0);
+    expect(
+      mocks.logWarn.mock.calls.some(([message]) =>
+        String(message).includes(
+          "failed to mark active main session(s) for restart recovery: Error: marker unavailable",
+        ),
+      ),
+    ).toBe(true);
   });
 
   it("continues restart shutdown and records a warning when gateway pre-restart hook stalls", async () => {

--- a/src/gateway/server-close.test.ts
+++ b/src/gateway/server-close.test.ts
@@ -669,6 +669,79 @@ describe("createGatewayCloseHandler", () => {
     ).toBe(true);
   });
 
+  it("marks active main sessions for restart recovery before aborting restart-drained runs", async () => {
+    const events: string[] = [];
+    const controller = new AbortController();
+    const agentController = new AbortController();
+    const alreadyAbortedController = new AbortController();
+    alreadyAbortedController.abort();
+    const chatAbortControllers = new Map([
+      [
+        "run-1",
+        {
+          controller,
+          sessionId: "session-id-1",
+          sessionKey: "agent:main:main",
+          startedAtMs: Date.now(),
+          expiresAtMs: Date.now() + 60_000,
+        },
+      ],
+      [
+        "agent-run-1",
+        {
+          controller: agentController,
+          sessionId: "session-id-2",
+          sessionKey: "agent:main:test:direct:source",
+          startedAtMs: Date.now(),
+          expiresAtMs: Date.now() + 60_000,
+          kind: "agent" as const,
+        },
+      ],
+      [
+        "stale-run",
+        {
+          controller: alreadyAbortedController,
+          sessionId: "stale-session-id",
+          sessionKey: "agent:main:stale",
+          startedAtMs: Date.now(),
+          expiresAtMs: Date.now() + 60_000,
+        },
+      ],
+    ]);
+    const markMainSessionsAbortedForRestart = vi.fn(async () => {
+      events.push("marker");
+    });
+    const removeChatRun = vi.fn(() => {
+      events.push("abort");
+      return { sessionKey: "agent:main:main", clientRunId: "run-1" };
+    });
+    const close = createGatewayCloseHandler(
+      createGatewayCloseTestDeps({
+        chatAbortControllers,
+        markMainSessionsAbortedForRestart,
+        removeChatRun,
+      }),
+    );
+
+    const result = await close({
+      reason: "gateway restarting",
+      restartExpectedMs: 123,
+      drainTimeoutMs: 0,
+    });
+
+    expect(result.warnings).toContain("restart-reply-drain");
+    expect(markMainSessionsAbortedForRestart).toHaveBeenCalledTimes(1);
+    expect(events[0]).toBe("marker");
+    const markerCall = firstMockCall(markMainSessionsAbortedForRestart);
+    expect(markerCall?.[0]?.reason).toBe("gateway restart shutdown");
+    expect(markerCall?.[0]?.sessionKeys).toStrictEqual(
+      new Set(["agent:main:main", "agent:main:test:direct:source"]),
+    );
+    expect(markerCall?.[0]?.sessionIds).toStrictEqual(new Set(["session-id-1", "session-id-2"]));
+    expect(controller.signal.aborted).toBe(true);
+    expect(agentController.signal.aborted).toBe(true);
+  });
+
   it("continues restart shutdown and records a warning when gateway pre-restart hook stalls", async () => {
     vi.useFakeTimers();
     mocks.triggerInternalHook.mockImplementation((event: InternalHookEvent) => {

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -151,8 +151,15 @@ type RestartRunAbortParams = {
   markMainSessionsAbortedForRestart?: (params: {
     sessionKeys: Set<string>;
     sessionIds: Set<string>;
+    activeRuns: Array<{
+      runId: string;
+      lifecycleGeneration: string;
+      sessionKey: string;
+      sessionId: string;
+    }>;
     reason: string;
   }) => Promise<void> | void;
+  resolveActiveSessionIdForKey?: (sessionKey: string) => string | undefined;
 };
 
 /** Wait for pending replies and active runs to drain before restart shutdown. */
@@ -191,24 +198,47 @@ async function waitForRestartReplyDrain(params: {
 }
 
 function collectActiveRestartSessionRefs(
-  chatAbortControllers: Map<string, ChatAbortControllerEntry>,
-): { sessionKeys: Set<string>; sessionIds: Set<string> } {
+  params: Pick<RestartRunAbortParams, "chatAbortControllers" | "resolveActiveSessionIdForKey">,
+): {
+  sessionKeys: Set<string>;
+  sessionIds: Set<string>;
+  activeRuns: Array<{
+    runId: string;
+    lifecycleGeneration: string;
+    sessionKey: string;
+    sessionId: string;
+  }>;
+} {
   const sessionKeys = new Set<string>();
   const sessionIds = new Set<string>();
-  for (const entry of chatAbortControllers.values()) {
+  const activeRuns = [];
+  for (const [runId, entry] of params.chatAbortControllers) {
     if (entry.controller.signal.aborted) {
       continue;
     }
     const sessionKey = entry.sessionKey.trim();
-    const sessionId = entry.sessionId.trim();
     if (sessionKey) {
       sessionKeys.add(sessionKey);
     }
+    // Registration metadata can predate a reset or compaction session-id rotation.
+    const resolvedSessionId =
+      entry.kind === "agent" || !sessionKey
+        ? undefined
+        : params.resolveActiveSessionIdForKey?.(sessionKey);
+    const sessionId = resolvedSessionId || entry.sessionId.trim();
     if (sessionId) {
       sessionIds.add(sessionId);
     }
+    if (runId && entry.lifecycleGeneration && sessionKey && sessionId) {
+      activeRuns.push({
+        runId,
+        lifecycleGeneration: entry.lifecycleGeneration,
+        sessionKey,
+        sessionId,
+      });
+    }
   }
-  return { sessionKeys, sessionIds };
+  return { sessionKeys, sessionIds, activeRuns };
 }
 
 async function markActiveRunsForRestartRecovery(
@@ -220,7 +250,7 @@ async function markActiveRunsForRestartRecovery(
   if (!params.markMainSessionsAbortedForRestart) {
     return;
   }
-  const refs = collectActiveRestartSessionRefs(params.chatAbortControllers);
+  const refs = collectActiveRestartSessionRefs(params);
   if (refs.sessionKeys.size === 0 && refs.sessionIds.size === 0) {
     return;
   }
@@ -559,6 +589,7 @@ export function createGatewayCloseHandler(
                 broadcast: params.broadcast,
                 nodeSendToSession: params.nodeSendToSession,
                 markMainSessionsAbortedForRestart: params.markMainSessionsAbortedForRestart,
+                resolveActiveSessionIdForKey: params.resolveActiveSessionIdForKey,
                 timeoutMs: drainTimeoutMs,
                 warnings,
               }),

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -148,6 +148,11 @@ type RestartRunAbortParams = {
   agentRunSeq: Map<string, number>;
   broadcast: (event: string, payload: unknown, opts?: { dropIfSlow?: boolean }) => void;
   nodeSendToSession: (sessionKey: string, event: string, payload: unknown) => void;
+  markMainSessionsAbortedForRestart?: (params: {
+    sessionKeys: Set<string>;
+    sessionIds: Set<string>;
+    reason: string;
+  }) => Promise<void> | void;
 };
 
 /** Wait for pending replies and active runs to drain before restart shutdown. */
@@ -182,6 +187,51 @@ async function waitForRestartReplyDrain(params: {
     if (counts.pendingReplies <= 0 && counts.activeRuns <= 0) {
       return { drained: true, elapsedMs: Date.now() - startedAt, counts };
     }
+  }
+}
+
+function collectActiveRestartSessionRefs(
+  chatAbortControllers: Map<string, ChatAbortControllerEntry>,
+): { sessionKeys: Set<string>; sessionIds: Set<string> } {
+  const sessionKeys = new Set<string>();
+  const sessionIds = new Set<string>();
+  for (const entry of chatAbortControllers.values()) {
+    if (entry.controller.signal.aborted) {
+      continue;
+    }
+    const sessionKey = entry.sessionKey.trim();
+    const sessionId = entry.sessionId.trim();
+    if (sessionKey) {
+      sessionKeys.add(sessionKey);
+    }
+    if (sessionId) {
+      sessionIds.add(sessionId);
+    }
+  }
+  return { sessionKeys, sessionIds };
+}
+
+async function markActiveRunsForRestartRecovery(
+  params: RestartRunAbortParams & {
+    reason: string;
+    warnings: string[];
+  },
+): Promise<void> {
+  if (!params.markMainSessionsAbortedForRestart) {
+    return;
+  }
+  const refs = collectActiveRestartSessionRefs(params.chatAbortControllers);
+  if (refs.sessionKeys.size === 0 && refs.sessionIds.size === 0) {
+    return;
+  }
+  try {
+    await params.markMainSessionsAbortedForRestart({
+      ...refs,
+      reason: params.reason,
+    });
+  } catch (err) {
+    shutdownLog.warn(`failed to mark active main session(s) for restart recovery: ${String(err)}`);
+    recordShutdownWarning(params.warnings, "restart-main-session-marker");
   }
 }
 
@@ -243,6 +293,10 @@ async function drainRestartPendingRepliesForShutdown(
     return;
   }
 
+  await markActiveRunsForRestartRecovery({
+    ...params,
+    reason: "gateway restart shutdown",
+  });
   const abortedRuns = abortActiveRunsForRestart(params);
   if (abortedRuns <= 0) {
     return;
@@ -504,6 +558,7 @@ export function createGatewayCloseHandler(
                 agentRunSeq: params.agentRunSeq,
                 broadcast: params.broadcast,
                 nodeSendToSession: params.nodeSendToSession,
+                markMainSessionsAbortedForRestart: params.markMainSessionsAbortedForRestart,
                 timeoutMs: drainTimeoutMs,
                 warnings,
               }),

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -5,13 +5,18 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import type { WebSocketServer } from "ws";
 import { disposeAllSessionMcpRuntimes } from "../agents/agent-bundle-mcp-tools.js";
 import { disposeRegisteredAgentHarnesses } from "../agents/harness/registry.js";
+import { createAgentRunRestartAbortError } from "../agents/run-termination.js";
 import { type ChannelId, listChannelPlugins } from "../channels/plugins/index.js";
 import { createInternalHookEvent, triggerInternalHook } from "../hooks/internal-hooks.js";
 import type { HeartbeatRunner } from "../infra/heartbeat-runner.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { closePluginStateSqliteStore } from "../plugin-state/plugin-state-store.js";
 import type { PluginServicesHandle } from "../plugins/services.js";
-import { abortTrackedChatRunById, type ChatAbortControllerEntry } from "./chat-abort.js";
+import {
+  abortTrackedChatRunById,
+  type ChatAbortControllerEntry,
+  type RestartRecoveryCandidate,
+} from "./chat-abort.js";
 import {
   collectGatewayProcessMemoryUsageMb,
   measureGatewayRestartTrace,
@@ -33,6 +38,8 @@ const LSP_RUNTIME_CLOSE_GRACE_MS = 5_000;
 const RESTART_REPLY_DRAIN_POLL_MS = 100;
 const RESTART_REPLY_POST_ABORT_DRAIN_TIMEOUT_MS = 1_000;
 const RESTART_REPLY_POST_ABORT_DRAIN_POLL_MS = 50;
+const RESTART_TERMINAL_PERSISTENCE_WAIT_TIMEOUT_MS = 1_000;
+const RESTART_MARKER_SLOW_WARNING_MS = 1_000;
 
 export type ShutdownResult = {
   durationMs: number;
@@ -107,11 +114,34 @@ function getRestartReplyDrainCounts(params: {
   };
 }
 
-/** List active runs participating in restart drain. */
+/** List unaborted runs still owned by the restart lifecycle. */
+function listUnabortedRestartRuns(
+  chatAbortControllers: Map<string, ChatAbortControllerEntry>,
+): Array<[string, ChatAbortControllerEntry]> {
+  return Array.from(chatAbortControllers.entries()).filter(
+    ([, entry]) => !entry.controller.signal.aborted,
+  );
+}
+
+/** List runtime-active runs participating in restart drain. */
 function listRestartDrainRuns(
   chatAbortControllers: Map<string, ChatAbortControllerEntry>,
 ): Array<[string, ChatAbortControllerEntry]> {
-  return Array.from(chatAbortControllers.entries());
+  return listUnabortedRestartRuns(chatAbortControllers).filter(
+    ([, entry]) => entry.registrationCleanupRequested !== true,
+  );
+}
+
+/** List active runs whose session lifecycle still needs restart recovery. */
+function listRestartRecoveryRuns(
+  chatAbortControllers: Map<string, ChatAbortControllerEntry>,
+): Array<[string, ChatAbortControllerEntry]> {
+  return listUnabortedRestartRuns(chatAbortControllers).filter(
+    ([, entry]) =>
+      entry.controlUiVisible !== false &&
+      (entry.registrationCleanupRequested !== true ||
+        entry.projectSessionTerminalPersisted !== true),
+  );
 }
 
 /** Format drain counts for shutdown logs. */
@@ -139,6 +169,7 @@ async function sleepForRestartReplyDrain(delayMs: number): Promise<void> {
 
 type RestartRunAbortParams = {
   chatAbortControllers: Map<string, ChatAbortControllerEntry>;
+  restartRecoveryCandidates?: Map<string, RestartRecoveryCandidate>;
   chatRunState: ChatRunState;
   removeChatRun: (
     sessionId: string,
@@ -156,8 +187,16 @@ type RestartRunAbortParams = {
       lifecycleGeneration: string;
       sessionKey: string;
       sessionId: string;
+      observedAt?: number;
     }>;
     reason: string;
+    isActiveRun: (run: {
+      runId: string;
+      lifecycleGeneration: string;
+      sessionKey: string;
+      sessionId: string;
+      observedAt?: number;
+    }) => boolean;
   }) => Promise<void> | void;
   resolveActiveSessionIdForKey?: (sessionKey: string) => string | undefined;
 };
@@ -198,7 +237,10 @@ async function waitForRestartReplyDrain(params: {
 }
 
 function collectActiveRestartSessionRefs(
-  params: Pick<RestartRunAbortParams, "chatAbortControllers" | "resolveActiveSessionIdForKey">,
+  params: Pick<
+    RestartRunAbortParams,
+    "chatAbortControllers" | "resolveActiveSessionIdForKey" | "restartRecoveryCandidates"
+  >,
 ): {
   sessionKeys: Set<string>;
   sessionIds: Set<string>;
@@ -207,15 +249,22 @@ function collectActiveRestartSessionRefs(
     lifecycleGeneration: string;
     sessionKey: string;
     sessionId: string;
+    observedAt?: number;
   }>;
 } {
   const sessionKeys = new Set<string>();
   const sessionIds = new Set<string>();
-  const activeRuns = [];
-  for (const [runId, entry] of params.chatAbortControllers) {
-    if (entry.controller.signal.aborted) {
-      continue;
-    }
+  const activeRuns = new Map<string, RestartRecoveryCandidate>();
+  const observedAt = Date.now();
+  const addRun = (run: RestartRecoveryCandidate) => {
+    sessionKeys.add(run.sessionKey);
+    sessionIds.add(run.sessionId);
+    activeRuns.set(`${run.runId}\u0000${run.lifecycleGeneration}`, {
+      ...run,
+      observedAt: run.observedAt ?? observedAt,
+    });
+  };
+  for (const [runId, entry] of listRestartRecoveryRuns(params.chatAbortControllers)) {
     const sessionKey = entry.sessionKey.trim();
     if (sessionKey) {
       sessionKeys.add(sessionKey);
@@ -230,15 +279,60 @@ function collectActiveRestartSessionRefs(
       sessionIds.add(sessionId);
     }
     if (runId && entry.lifecycleGeneration && sessionKey && sessionId) {
-      activeRuns.push({
+      addRun({
         runId,
         lifecycleGeneration: entry.lifecycleGeneration,
         sessionKey,
         sessionId,
+        observedAt: entry.projectSessionTerminalObservedAt,
       });
     }
   }
-  return { sessionKeys, sessionIds, activeRuns };
+  for (const candidate of params.restartRecoveryCandidates?.values() ?? []) {
+    const resolvedSessionId = params.resolveActiveSessionIdForKey?.(candidate.sessionKey);
+    addRun({
+      ...candidate,
+      sessionId: resolvedSessionId || candidate.sessionId,
+    });
+  }
+  return { sessionKeys, sessionIds, activeRuns: [...activeRuns.values()] };
+}
+
+async function settleTerminalSessionPersistenceForRestart(
+  chatAbortControllers: Map<string, ChatAbortControllerEntry>,
+): Promise<void> {
+  const pending = listUnabortedRestartRuns(chatAbortControllers).flatMap(([, entry]) => {
+    const persistence = entry.projectSessionTerminalPersistence;
+    if (entry.projectSessionActive !== false || !persistence) {
+      return [];
+    }
+    return [{ entry, persistence }];
+  });
+  if (pending.length === 0) {
+    return;
+  }
+  const timeout = createTimeoutRace(RESTART_TERMINAL_PERSISTENCE_WAIT_TIMEOUT_MS, () => null);
+  const results = await Promise.race([
+    Promise.allSettled(pending.map(({ persistence }) => persistence)),
+    timeout.promise,
+  ]);
+  timeout.clear();
+  if (!results) {
+    shutdownLog.warn(
+      `terminal session persistence did not settle within ${RESTART_TERMINAL_PERSISTENCE_WAIT_TIMEOUT_MS}ms; preserving restart recovery`,
+    );
+    return;
+  }
+  for (const [index, result] of results.entries()) {
+    const tracked = pending[index];
+    if (!tracked || tracked.entry.projectSessionTerminalPersistence !== tracked.persistence) {
+      continue;
+    }
+    tracked.entry.projectSessionTerminalPersistence = undefined;
+    if (result.status === "fulfilled") {
+      tracked.entry.projectSessionTerminalPersisted = true;
+    }
+  }
 }
 
 async function markActiveRunsForRestartRecovery(
@@ -250,15 +344,54 @@ async function markActiveRunsForRestartRecovery(
   if (!params.markMainSessionsAbortedForRestart) {
     return;
   }
+  await settleTerminalSessionPersistenceForRestart(params.chatAbortControllers);
   const refs = collectActiveRestartSessionRefs(params);
   if (refs.sessionKeys.size === 0 && refs.sessionIds.size === 0) {
     return;
   }
   try {
-    await params.markMainSessionsAbortedForRestart({
-      ...refs,
-      reason: params.reason,
-    });
+    const markerTimeout = createTimeoutRace(
+      RESTART_MARKER_SLOW_WARNING_MS,
+      () => "timeout" as const,
+    );
+    const markerOutcome = Promise.resolve(
+      params.markMainSessionsAbortedForRestart({
+        ...refs,
+        reason: params.reason,
+        isActiveRun: (run) => {
+          const entry = params.chatAbortControllers.get(run.runId);
+          const candidate = params.restartRecoveryCandidates?.get(run.runId);
+          return (
+            (entry &&
+              !entry.controller.signal.aborted &&
+              (entry.registrationCleanupRequested !== true ||
+                entry.projectSessionTerminalPersisted !== true) &&
+              entry.lifecycleGeneration === run.lifecycleGeneration) ||
+            candidate?.lifecycleGeneration === run.lifecycleGeneration
+          );
+        },
+      }),
+    ).then(
+      () => ({ status: "completed" as const }),
+      (error: unknown) => ({ status: "failed" as const, error }),
+    );
+    const firstOutcome = await Promise.race([markerOutcome, markerTimeout.promise]);
+    markerTimeout.clear();
+    if (firstOutcome === "timeout") {
+      shutdownLog.warn(
+        `restart session marker did not settle within ${RESTART_MARKER_SLOW_WARNING_MS}ms; waiting before shutdown`,
+      );
+      recordShutdownWarning(params.warnings, "restart-main-session-marker");
+      const delayedOutcome = await markerOutcome;
+      if (delayedOutcome.status === "failed") {
+        throw delayedOutcome.error;
+      }
+    } else if (firstOutcome.status === "failed") {
+      throw firstOutcome.error;
+    }
+    for (const run of refs.activeRuns) {
+      params.restartRecoveryCandidates?.delete(run.runId);
+    }
   } catch (err) {
     shutdownLog.warn(`failed to mark active main session(s) for restart recovery: ${String(err)}`);
     recordShutdownWarning(params.warnings, "restart-main-session-marker");
@@ -268,7 +401,21 @@ async function markActiveRunsForRestartRecovery(
 /** Abort active chat runs that did not drain before restart shutdown. */
 function abortActiveRunsForRestart(params: RestartRunAbortParams): number {
   let aborted = 0;
-  for (const [runId, entry] of listRestartDrainRuns(params.chatAbortControllers)) {
+  for (const [runId, entry] of listUnabortedRestartRuns(params.chatAbortControllers)) {
+    if (entry.projectSessionActive === false) {
+      entry.abortStopReason = "restart";
+      entry.controller.abort(createAgentRunRestartAbortError());
+      params.chatAbortControllers.delete(runId);
+      params.chatRunState.abortedRuns.set(runId, Date.now());
+      params.chatRunState.clearRun(runId);
+      const removed = params.removeChatRun(runId, runId, entry.sessionKey);
+      params.agentRunSeq.delete(runId);
+      if (removed?.clientRunId) {
+        params.agentRunSeq.delete(removed.clientRunId);
+      }
+      aborted += 1;
+      continue;
+    }
     const result = abortTrackedChatRunById(
       { ...params, chatRunBuffers: params.chatRunState.buffers },
       {
@@ -294,6 +441,11 @@ async function drainRestartPendingRepliesForShutdown(
 ): Promise<void> {
   const initialCounts = getRestartReplyDrainCounts(params);
   if (initialCounts.pendingReplies <= 0 && initialCounts.activeRuns <= 0) {
+    await markActiveRunsForRestartRecovery({
+      ...params,
+      reason: "gateway restart shutdown",
+    });
+    abortActiveRunsForRestart(params);
     return;
   }
 
@@ -310,6 +462,11 @@ async function drainRestartPendingRepliesForShutdown(
     timeoutMs,
   });
   if (drainResult.drained) {
+    await markActiveRunsForRestartRecovery({
+      ...params,
+      reason: "gateway restart shutdown",
+    });
+    abortActiveRunsForRestart(params);
     shutdownLog.info(`restart reply drain completed after ${drainResult.elapsedMs}ms`);
     return;
   }
@@ -319,7 +476,11 @@ async function drainRestartPendingRepliesForShutdown(
   );
   recordShutdownWarning(params.warnings, "restart-reply-drain");
 
-  if (drainResult.counts.activeRuns <= 0) {
+  if (
+    drainResult.counts.activeRuns <= 0 &&
+    (params.restartRecoveryCandidates?.size ?? 0) === 0 &&
+    listRestartRecoveryRuns(params.chatAbortControllers).length === 0
+  ) {
     return;
   }
 
@@ -583,6 +744,7 @@ export function createGatewayCloseHandler(
               drainRestartPendingRepliesForShutdown({
                 getPendingReplyCount: params.getPendingReplyCount!,
                 chatAbortControllers: params.chatAbortControllers,
+                restartRecoveryCandidates: params.restartRecoveryCandidates,
                 chatRunState: params.chatRunState,
                 removeChatRun: params.removeChatRun,
                 agentRunSeq: params.agentRunSeq,

--- a/src/gateway/server-maintenance.test.ts
+++ b/src/gateway/server-maintenance.test.ts
@@ -426,6 +426,55 @@ describe("startGatewayMaintenanceTimers", () => {
     stopMaintenanceTimers(timers);
   });
 
+  it("converts expired stalled terminal persistence into a recovery candidate", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-22T00:00:00Z"));
+    const { startGatewayMaintenanceTimers } = await import("./server-maintenance.js");
+    const deps = createMaintenanceTimerDeps();
+    const runId = "run-terminal-persistence";
+    const terminalRun = createActiveRun("main");
+    terminalRun.expiresAtMs = Date.now() - 1;
+    terminalRun.projectSessionActive = false;
+    terminalRun.lifecycleGeneration = "generation-1";
+    terminalRun.projectSessionTerminalObservedAt = Date.now() - 500;
+    terminalRun.projectSessionTerminalPersistence = new Promise<void>(() => {});
+    deps.chatAbortControllers.set(runId, terminalRun);
+
+    const timers = startGatewayMaintenanceTimers(deps);
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(terminalRun.controller.signal.aborted).toBe(false);
+    expect(deps.chatAbortControllers.has(runId)).toBe(false);
+    expect(deps.restartRecoveryCandidates.get(runId)).toEqual({
+      runId,
+      lifecycleGeneration: "generation-1",
+      sessionKey: "main",
+      sessionId: "sess-1",
+      observedAt: Date.now() - 60_500,
+    });
+    stopMaintenanceTimers(timers);
+  });
+
+  it("reaps expired inactive registrations without emitting a timeout abort", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-22T00:00:00Z"));
+    const { startGatewayMaintenanceTimers } = await import("./server-maintenance.js");
+    const deps = createMaintenanceTimerDeps();
+    const runId = "run-terminal-persisted";
+    const terminalRun = createActiveRun("main");
+    terminalRun.expiresAtMs = Date.now() - 1;
+    terminalRun.projectSessionActive = false;
+    terminalRun.projectSessionTerminalPersisted = true;
+    deps.chatAbortControllers.set(runId, terminalRun);
+
+    const timers = startGatewayMaintenanceTimers(deps);
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(terminalRun.controller.signal.aborted).toBe(false);
+    expect(deps.chatAbortControllers.has(runId)).toBe(false);
+    stopMaintenanceTimers(timers);
+  });
+
   it("keeps active exec approval dedupe aliases past the normal ttl", async () => {
     const { startGatewayMaintenanceTimers, deps, now } = await createTimedMaintenanceScenario();
     const runId = "exec-approval-followup:req-active:nonce:retry-1";

--- a/src/gateway/server-maintenance.ts
+++ b/src/gateway/server-maintenance.ts
@@ -4,7 +4,11 @@ import { isFutureDateTimestampMs } from "@openclaw/normalization-core/number-coe
 import type { HealthSummary } from "../commands/health.js";
 import { sweepStaleRunContexts } from "../infra/agent-events.js";
 import { cleanOldMedia } from "../media/store.js";
-import { abortTrackedChatRunById, type ChatAbortControllerEntry } from "./chat-abort.js";
+import {
+  abortTrackedChatRunById,
+  type ChatAbortControllerEntry,
+  type RestartRecoveryCandidate,
+} from "./chat-abort.js";
 import { pruneStaleControlPlaneBuckets } from "./control-plane-rate-limit.js";
 import type { ChatRunState } from "./server-chat-state.js";
 import type { ChatRunEntry } from "./server-chat.js";
@@ -37,6 +41,7 @@ export function startGatewayMaintenanceTimers(params: {
   logHealth: { error: (msg: string) => void };
   dedupe: Map<string, DedupeEntry>;
   chatAbortControllers: Map<string, ChatAbortControllerEntry>;
+  restartRecoveryCandidates: Map<string, RestartRecoveryCandidate>;
   chatRunState: Pick<
     ChatRunState,
     | "abortedRuns"
@@ -188,7 +193,30 @@ export function startGatewayMaintenanceTimers(params: {
     };
 
     for (const [runId, entry] of params.chatAbortControllers) {
+      if (entry.projectSessionTerminalPending === true) {
+        continue;
+      }
       if (isFutureDateTimestampMs(entry.expiresAtMs, { nowMs: now })) {
+        continue;
+      }
+      if (entry.projectSessionTerminalPersistence) {
+        const lifecycleGeneration = entry.lifecycleGeneration?.trim();
+        const sessionKey = entry.sessionKey.trim();
+        const sessionId = entry.sessionId.trim();
+        if (entry.controlUiVisible !== false && lifecycleGeneration && sessionKey && sessionId) {
+          params.restartRecoveryCandidates.set(runId, {
+            runId,
+            lifecycleGeneration,
+            sessionKey,
+            sessionId,
+            observedAt: entry.projectSessionTerminalObservedAt,
+          });
+        }
+        params.chatAbortControllers.delete(runId);
+        continue;
+      }
+      if (entry.projectSessionActive === false) {
+        params.chatAbortControllers.delete(runId);
         continue;
       }
       abortTrackedChatRunById(params, {

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -7,6 +7,7 @@ import {
   registerExecApprovalFollowupRuntimeHandoff,
   resetExecApprovalFollowupRuntimeHandoffsForTests,
 } from "../../agents/bash-tools.exec-approval-followup-state.js";
+import { createAgentRunRestartAbortError } from "../../agents/run-termination.js";
 import {
   getSubagentRunByChildSessionKey,
   resetSubagentRegistryForTests,
@@ -3465,6 +3466,43 @@ describe("gateway agent handler", () => {
     });
   });
 
+  it("preserves restart ownership for aborted async gateway agent rejections", async () => {
+    await withTempDir({ prefix: "openclaw-gateway-agent-task-restart-abort-" }, async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskRegistryForTests();
+      primeMainAgentRun();
+      const abortError = createAgentRunRestartAbortError();
+      const wrappedError = new Error("ACP turn failed before completion", {
+        cause: abortError,
+      });
+      wrappedError.name = "AcpRuntimeError";
+      const context = makeContext();
+      const runId = "task-registry-agent-run-restart-abort";
+      mocks.agentCommand.mockImplementationOnce(() => {
+        context.chatAbortControllers.get(runId)?.controller.abort(abortError);
+        return Promise.reject(wrappedError);
+      });
+
+      await invokeAgent(
+        {
+          message: "background cli task",
+          sessionKey: "agent:main:main",
+          idempotencyKey: runId,
+        },
+        { context, reqId: runId },
+      );
+
+      await waitForAssertion(() => {
+        expectRecordFields(context.dedupe.get(`agent:${runId}`)?.payload, {
+          runId,
+          status: "timeout",
+          summary: "aborted",
+          stopReason: "restart",
+        });
+      });
+    });
+  });
+
   it("classifies timeout async gateway agent rejections as timed out", async () => {
     await withTempDir({ prefix: "openclaw-gateway-agent-task-timeout-error-" }, async (root) => {
       process.env.OPENCLAW_STATE_DIR = root;
@@ -6844,6 +6882,48 @@ describe("gateway agent handler chat.abort integration", () => {
       { context, reqId: runId },
     );
 
+    await waitForAssertion(() => {
+      expect(context.chatAbortControllers.has(runId)).toBe(false);
+    });
+  });
+
+  it("retains agent RPC registration until terminal persistence settles", async () => {
+    prime();
+    let resolveAgent: (value: {
+      payloads: Array<{ text: string }>;
+      meta: { durationMs: number };
+    }) => void = () => undefined;
+    const agentResult = new Promise<{
+      payloads: Array<{ text: string }>;
+      meta: { durationMs: number };
+    }>((resolve) => {
+      resolveAgent = resolve;
+    });
+    mocks.agentCommand.mockReturnValueOnce(agentResult);
+
+    const context = makeContext();
+    const runId = "idem-abort-cleanup-persisting";
+    await invokeAgent(
+      {
+        message: "hi",
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        idempotencyKey: runId,
+      },
+      { context, reqId: runId },
+    );
+
+    const entry = requireValue(context.chatAbortControllers.get(runId), "chat abort entry missing");
+    let resolvePersistence: () => void = () => undefined;
+    entry.projectSessionTerminalPersistence = new Promise<void>((resolve) => {
+      resolvePersistence = resolve;
+    });
+    resolveAgent({ payloads: [{ text: "ok" }], meta: { durationMs: 1 } });
+
+    await waitForAssertion(() => {
+      expect(context.chatAbortControllers.has(runId)).toBe(true);
+    });
+    resolvePersistence();
     await waitForAssertion(() => {
       expect(context.chatAbortControllers.has(runId)).toBe(false);
     });

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -6420,7 +6420,7 @@ describe("gateway agent handler chat.abort integration", () => {
     expectRecordFields(context.dedupe.get(`agent:${runId}`)?.payload, {
       runId,
       status: "timeout",
-      stopReason: "gateway_restart",
+      stopReason: "restart",
       timeoutPhase: "queue",
       providerStarted: false,
     });

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -37,6 +37,7 @@ const mocks = vi.hoisted(() => ({
   loadGatewaySessionRow: vi.fn(),
   updateSessionStore: vi.fn(),
   agentCommand: vi.fn(),
+  clearAgentRunContext: vi.fn(),
   registerAgentRunContext: vi.fn(),
   emitAgentEvent: vi.fn(),
   performGatewaySessionReset: vi.fn(),
@@ -56,6 +57,7 @@ const mocks = vi.hoisted(() => ({
       lastInteractionAt: entry?.lastInteractionAt,
     }),
   ),
+  lifecycleGeneration: "test-generation",
 }));
 
 vi.mock("../session-utils.js", async () => {
@@ -137,7 +139,10 @@ vi.mock("../../agents/agent-scope.js", () => ({
 }));
 
 vi.mock("../../infra/agent-events.js", () => ({
+  claimAgentRunContext: mocks.registerAgentRunContext,
+  clearAgentRunContext: mocks.clearAgentRunContext,
   emitAgentEvent: mocks.emitAgentEvent,
+  getAgentEventLifecycleGeneration: () => mocks.lifecycleGeneration,
   registerAgentRunContext: mocks.registerAgentRunContext,
   onAgentEvent: vi.fn(),
 }));
@@ -537,6 +542,7 @@ describe("gateway agent handler", () => {
           lastInteractionAt: entry?.lastInteractionAt,
         }),
       );
+    mocks.lifecycleGeneration = "test-generation";
     dateOnlyFakeClockActive = false;
     vi.useRealTimers();
     resetExecApprovalFollowupRuntimeHandoffsForTests();
@@ -2178,6 +2184,7 @@ describe("gateway agent handler", () => {
     expect(context.addChatRun).not.toHaveBeenCalled();
     expect(mocks.registerAgentRunContext).toHaveBeenCalledWith("test-backend-internal-effects", {
       isControlUiVisible: false,
+      lifecycleGeneration: "test-generation",
     });
   });
 
@@ -4329,6 +4336,39 @@ describe("gateway agent handler", () => {
     expect(registerToolEventRecipient).toHaveBeenCalledWith("run-existing", "conn-1");
   });
 
+  it("updates tracked agent session identity after compaction rotation", async () => {
+    primeMainAgentRun();
+    const context = makeContext();
+    let trackedSessionId: string | undefined;
+    mocks.agentCommand.mockImplementation(async (call: AgentCommandCall) => {
+      const onSessionIdChanged = call.onSessionIdChanged;
+      if (typeof onSessionIdChanged !== "function") {
+        throw new Error("expected session id change callback");
+      }
+      onSessionIdChanged("rotated-session-id");
+      trackedSessionId = context.chatAbortControllers.get("agent-session-rotation")?.sessionId;
+      return {
+        payloads: [{ text: "ok" }],
+        meta: { durationMs: 100 },
+      };
+    });
+
+    await invokeAgent(
+      {
+        message: "rotate session",
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        idempotencyKey: "agent-session-rotation",
+      },
+      {
+        reqId: "agent-session-rotation",
+        context,
+      },
+    );
+
+    expect(trackedSessionId).toBe("rotated-session-id");
+  });
+
   it("honors selected-global agent id when the request uses the main alias", async () => {
     mocks.listAgentIds.mockReturnValue(["main", "work"]);
     mocks.loadConfigReturn = {
@@ -5391,6 +5431,7 @@ describe("gateway agent handler chat.abort integration", () => {
     mocks.loadVoiceWakeRoutingConfig.mockReset();
     mocks.resolveVoiceWakeRouteByTrigger.mockReset();
     mocks.resolveSendPolicy.mockReset().mockReturnValue("allow");
+    mocks.lifecycleGeneration = "test-generation";
     dateOnlyFakeClockActive = false;
     vi.useRealTimers();
     resetExecApprovalFollowupRuntimeHandoffsForTests();
@@ -6290,6 +6331,63 @@ describe("gateway agent handler chat.abort integration", () => {
     });
   });
 
+  it("does not register or dispatch agent work prepared across a gateway restart", async () => {
+    mocks.registerAgentRunContext.mockClear();
+    let releaseRouting: (() => void) | undefined;
+    mocks.loadVoiceWakeRoutingConfig.mockImplementation(
+      async () =>
+        await new Promise((resolve) => {
+          releaseRouting = () =>
+            resolve({
+              version: 1,
+              defaultTarget: { mode: "current" },
+              routes: [],
+              updatedAtMs: 0,
+            });
+        }),
+    );
+    mocks.resolveVoiceWakeRouteByTrigger.mockReturnValue({ sessionKey: "agent:main:voice" });
+    mocks.loadSessionEntry.mockImplementation((sessionKey: string) => ({
+      cfg: {},
+      storePath: "/tmp/sessions.json",
+      entry: {
+        sessionId: sessionKey === "agent:main:voice" ? "voice-session-id" : "main-session-id",
+        updatedAt: Date.now(),
+      },
+      canonicalKey: sessionKey === "agent:main:voice" ? "agent:main:voice" : "agent:main:main",
+    }));
+    mocks.updateSessionStore.mockResolvedValue(undefined);
+
+    const context = makeContext();
+    const respond = vi.fn();
+    const runId = "idem-restart-during-voice-route";
+    const pending = invokeAgent(
+      {
+        message: "wake up",
+        sessionKey: "agent:main:main",
+        voiceWakeTrigger: "robot wake",
+        idempotencyKey: runId,
+      },
+      { context, respond, reqId: runId, flushDispatch: false },
+    );
+    await waitForAssertion(() => expect(releaseRouting).toBeTypeOf("function"));
+
+    mocks.lifecycleGeneration = "post-restart-generation";
+    releaseRouting?.();
+    await pending;
+
+    expect(context.chatAbortControllers.has(runId)).toBe(false);
+    expect(mocks.registerAgentRunContext).not.toHaveBeenCalled();
+    expect(mocks.agentCommand).not.toHaveBeenCalled();
+    expectRecordFields(context.dedupe.get(`agent:${runId}`)?.payload, {
+      runId,
+      status: "timeout",
+      stopReason: "gateway_restart",
+      timeoutPhase: "queue",
+      providerStarted: false,
+    });
+  });
+
   it("rejects unauthorized chat.abort during pre-accept setup", async () => {
     prime();
     let releaseSessionWrite: (() => void) | undefined;
@@ -6832,6 +6930,7 @@ describe("gateway agent handler chat.abort integration", () => {
     };
     context.chatAbortControllers.set(runId, preExisting);
     context.dedupe.delete(`agent:${runId}`);
+    mocks.registerAgentRunContext.mockClear();
     const respond = vi.fn();
 
     await invokeAgent(
@@ -6846,6 +6945,8 @@ describe("gateway agent handler chat.abort integration", () => {
 
     expect(context.chatAbortControllers.get(runId)).toBe(preExisting);
     expect(context.dedupe.has(`agent:${runId}`)).toBe(false);
+    expect(context.addChatRun).not.toHaveBeenCalled();
+    expect(mocks.registerAgentRunContext).not.toHaveBeenCalled();
     expect(mocks.agentCommand).not.toHaveBeenCalled();
     expect(respond).toHaveBeenCalledWith(true, { runId, status: "in_flight" }, undefined, {
       cached: true,

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -6931,6 +6931,7 @@ describe("gateway agent handler chat.abort integration", () => {
 
   it("removes the chatAbortControllers entry after the run errors", async () => {
     prime();
+    mocks.clearAgentRunContext.mockClear();
     mocks.agentCommand.mockRejectedValueOnce(new Error("boom"));
 
     const context = makeContext();
@@ -6947,6 +6948,7 @@ describe("gateway agent handler chat.abort integration", () => {
 
     await waitForAssertion(() => {
       expect(context.chatAbortControllers.has(runId)).toBe(false);
+      expect(mocks.clearAgentRunContext).toHaveBeenCalledWith(runId, "test-generation");
     });
   });
 

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -140,6 +140,14 @@ vi.mock("../../agents/agent-scope.js", () => ({
 }));
 
 vi.mock("../../infra/agent-events.js", () => ({
+  assertAgentRunLifecycleGenerationCurrent: (lifecycleGeneration: string) => {
+    if (lifecycleGeneration === mocks.lifecycleGeneration) {
+      return;
+    }
+    const error = new Error("Agent run belongs to a stale gateway lifecycle");
+    error.name = "AbortError";
+    throw error;
+  },
   claimAgentRunContext: mocks.registerAgentRunContext,
   clearAgentRunContext: mocks.clearAgentRunContext,
   emitAgentEvent: mocks.emitAgentEvent,
@@ -6417,12 +6425,277 @@ describe("gateway agent handler chat.abort integration", () => {
     expect(context.chatAbortControllers.has(runId)).toBe(false);
     expect(mocks.registerAgentRunContext).not.toHaveBeenCalled();
     expect(mocks.agentCommand).not.toHaveBeenCalled();
+    expect(mocks.updateSessionStore).not.toHaveBeenCalled();
     expectRecordFields(context.dedupe.get(`agent:${runId}`)?.payload, {
       runId,
+      sessionKey: "agent:main:voice",
       status: "timeout",
       stopReason: "restart",
       timeoutPhase: "queue",
       providerStarted: false,
+    });
+  });
+
+  it("does not mutate a session after losing lifecycle ownership while waiting for its store", async () => {
+    prime();
+    let releaseSessionWrite: (() => void) | undefined;
+    let updaterCompleted = false;
+    mocks.updateSessionStore.mockImplementation(async (_path, updater) => {
+      await new Promise<void>((resolve) => {
+        releaseSessionWrite = resolve;
+      });
+      const store = {
+        "agent:main:main": buildExistingMainStoreEntry(),
+      };
+      const result = await updater(store);
+      updaterCompleted = true;
+      return result;
+    });
+
+    const context = makeContext();
+    const respond = vi.fn();
+    const runId = "idem-restart-during-session-write";
+    const pending = invokeAgent(
+      {
+        message: "hi",
+        sessionKey: "agent:main:main",
+        idempotencyKey: runId,
+      },
+      { context, respond, reqId: runId, flushDispatch: false },
+    );
+    await waitForAssertion(() => expect(releaseSessionWrite).toBeTypeOf("function"));
+
+    mocks.lifecycleGeneration = "post-restart-generation";
+    releaseSessionWrite?.();
+    await pending;
+
+    expect(updaterCompleted).toBe(false);
+    expect(mocks.agentCommand).not.toHaveBeenCalled();
+    expectRecordFields(context.dedupe.get(`agent:${runId}`)?.payload, {
+      runId,
+      sessionKey: "agent:main:main",
+      status: "timeout",
+      stopReason: "restart",
+    });
+  });
+
+  it("does not acknowledge a bare reset that loses lifecycle ownership", async () => {
+    prime();
+    let releaseReset: (() => void) | undefined;
+    mocks.performGatewaySessionReset.mockImplementation(
+      async (opts: { assertCurrent?: () => void }) => {
+        await new Promise<void>((resolve) => {
+          releaseReset = resolve;
+        });
+        opts.assertCurrent?.();
+        return {
+          ok: true,
+          key: "agent:main:main",
+          entry: { sessionId: "reset-session-id" },
+        };
+      },
+    );
+
+    const context = makeContext();
+    const respond = vi.fn();
+    const runId = "idem-restart-during-bare-reset";
+    const pending = invokeAgent(
+      {
+        message: "/reset",
+        sessionKey: "agent:main:main",
+        idempotencyKey: runId,
+      },
+      {
+        context,
+        respond,
+        reqId: runId,
+        client: { connect: { scopes: ["operator.admin"] } } as AgentHandlerArgs["client"],
+      },
+    );
+    await waitForAssertion(() => expect(releaseReset).toBeTypeOf("function"));
+
+    mocks.lifecycleGeneration = "post-restart-generation";
+    releaseReset?.();
+    await pending;
+
+    expect(mocks.agentCommand).not.toHaveBeenCalled();
+    expectRecordFields(context.dedupe.get(`agent:${runId}`)?.payload, {
+      runId,
+      sessionKey: "agent:main:main",
+      status: "timeout",
+      stopReason: "restart",
+    });
+    expect(
+      respond.mock.calls.some(
+        (call: unknown[]) => (call[1] as { result?: unknown } | undefined)?.result !== undefined,
+      ),
+    ).toBe(false);
+  });
+
+  it("acknowledges a committed reset when restart prevents its follow-up", async () => {
+    prime();
+    mocks.performGatewaySessionReset.mockImplementation(
+      async (opts: { onCommitted?: (commit: { key: string; sessionId: string }) => void }) => {
+        opts.onCommitted?.({
+          key: "agent:main:main",
+          sessionId: "reset-session-id",
+        });
+        mocks.lifecycleGeneration = "post-restart-generation";
+        return {
+          ok: true,
+          key: "agent:main:main",
+          entry: { sessionId: "reset-session-id" },
+        };
+      },
+    );
+
+    const context = makeContext();
+    const respond = await invokeAgent(
+      {
+        message: "/reset check status",
+        sessionKey: "agent:main:main",
+        idempotencyKey: "idem-restart-after-reset-commit",
+      },
+      {
+        context,
+        reqId: "restart-after-reset-commit",
+        client: { connect: { scopes: ["operator.admin"] } } as AgentHandlerArgs["client"],
+      },
+    );
+
+    expect(mocks.agentCommand).not.toHaveBeenCalled();
+    expect(mockCallArg(respond)).toBe(true);
+    const result = expectRecordFields(mockCallArg(respond, 0, 1), {
+      status: "ok",
+      summary: "completed",
+    }).result as { payloads?: Array<{ text?: string }> };
+    expect(result.payloads?.[0]?.text).toContain("Session reset.");
+    expect(result.payloads?.[0]?.text).toContain("send the follow-up message again");
+    expectRecordFields(context.dedupe.get("agent:idem-restart-after-reset-commit")?.payload, {
+      status: "ok",
+      summary: "completed",
+    });
+  });
+
+  it("acknowledges a committed bare reset after lifecycle rotation", async () => {
+    prime();
+    mocks.performGatewaySessionReset.mockImplementation(
+      async (opts: { onCommitted?: (commit: { key: string; sessionId: string }) => void }) => {
+        opts.onCommitted?.({
+          key: "agent:main:main",
+          sessionId: "reset-session-id",
+        });
+        mocks.lifecycleGeneration = "post-restart-generation";
+        return {
+          ok: true,
+          key: "agent:main:main",
+          entry: { sessionId: "reset-session-id" },
+        };
+      },
+    );
+
+    const context = makeContext();
+    const respond = await invokeAgent(
+      {
+        message: "/reset",
+        sessionKey: "agent:main:main",
+        idempotencyKey: "idem-restart-after-bare-reset",
+      },
+      {
+        context,
+        reqId: "restart-after-bare-reset",
+        client: { connect: { scopes: ["operator.admin"] } } as AgentHandlerArgs["client"],
+      },
+    );
+
+    expect(mocks.agentCommand).not.toHaveBeenCalled();
+    expect(mockCallArg(respond)).toBe(true);
+    const result = expectRecordFields(mockCallArg(respond, 0, 1), {
+      status: "ok",
+      summary: "completed",
+    }).result as { payloads?: Array<{ text?: string }> };
+    expect(result.payloads?.[0]?.text).toBe("✅ Session reset.");
+    expectRecordFields(context.dedupe.get("agent:idem-restart-after-bare-reset")?.payload, {
+      status: "ok",
+      summary: "completed",
+    });
+  });
+
+  it("acknowledges a committed reset when post-commit work fails after rotation", async () => {
+    prime();
+    mocks.performGatewaySessionReset.mockImplementation(
+      async (opts: { onCommitted?: (commit: { key: string; sessionId: string }) => void }) => {
+        opts.onCommitted?.({
+          key: "agent:main:main",
+          sessionId: "reset-session-id",
+        });
+        mocks.lifecycleGeneration = "post-restart-generation";
+        throw new Error("post-commit cleanup failed");
+      },
+    );
+
+    const context = makeContext();
+    const respond = await invokeAgent(
+      {
+        message: "/reset",
+        sessionKey: "agent:main:main",
+        idempotencyKey: "idem-post-commit-reset-failure",
+      },
+      {
+        context,
+        reqId: "post-commit-reset-failure",
+        client: { connect: { scopes: ["operator.admin"] } } as AgentHandlerArgs["client"],
+      },
+    );
+
+    expect(mockCallArg(respond)).toBe(true);
+    const result = expectRecordFields(mockCallArg(respond, 0, 1), {
+      status: "ok",
+      summary: "completed",
+    }).result as { payloads?: Array<{ text?: string }> };
+    expect(result.payloads?.[0]?.text).toBe("✅ Session reset.");
+    expectRecordFields(context.dedupe.get("agent:idem-post-commit-reset-failure")?.payload, {
+      status: "ok",
+      summary: "completed",
+    });
+  });
+
+  it("acknowledges a committed reset when restart wins during later session persistence", async () => {
+    prime();
+    mockSessionResetSuccess({ reason: "reset" });
+    mocks.updateSessionStore.mockImplementation(async (_path, updater) => {
+      const store = {
+        "agent:main:main": buildExistingMainStoreEntry(),
+      };
+      const result = await updater(store);
+      mocks.lifecycleGeneration = "post-restart-generation";
+      return result;
+    });
+
+    const context = makeContext();
+    const respond = await invokeAgent(
+      {
+        message: "/reset check status",
+        sessionKey: "agent:main:main",
+        idempotencyKey: "idem-restart-after-reset-later",
+      },
+      {
+        context,
+        reqId: "restart-after-reset-later",
+        client: { connect: { scopes: ["operator.admin"] } } as AgentHandlerArgs["client"],
+      },
+    );
+
+    expect(mocks.agentCommand).not.toHaveBeenCalled();
+    expect(mockCallArg(respond)).toBe(true);
+    const result = expectRecordFields(mockCallArg(respond, 0, 1), {
+      status: "ok",
+      summary: "completed",
+    }).result as { payloads?: Array<{ text?: string }> };
+    expect(result.payloads?.[0]?.text).toContain("send the follow-up message again");
+    expectRecordFields(context.dedupe.get("agent:idem-restart-after-reset-later")?.payload, {
+      status: "ok",
+      summary: "completed",
     });
   });
 

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -76,6 +76,7 @@ import { resolveMaintenanceConfigFromInput } from "../../config/sessions/store-m
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
   claimAgentRunContext,
+  clearAgentRunContext,
   getAgentEventLifecycleGeneration,
 } from "../../infra/agent-events.js";
 import { formatUncaughtError, readErrorName } from "../../infra/errors.js";
@@ -1007,6 +1008,7 @@ function dispatchAgentRunFromGateway(params: {
       });
     })
     .finally(() => {
+      clearAgentRunContext(params.runId, params.ingressOpts.lifecycleGeneration);
       params.cleanupAbortController();
     });
 }

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -70,7 +70,10 @@ import {
 } from "../../config/sessions.js";
 import { resolveMaintenanceConfigFromInput } from "../../config/sessions/store-maintenance.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { registerAgentRunContext } from "../../infra/agent-events.js";
+import {
+  claimAgentRunContext,
+  getAgentEventLifecycleGeneration,
+} from "../../infra/agent-events.js";
 import { formatUncaughtError, readErrorName } from "../../infra/errors.js";
 import {
   resolveAgentDeliveryPlanWithSessionRoute,
@@ -1122,6 +1125,7 @@ export const agentHandlers: GatewayRequestHandlers = {
     const cfg = context.getRuntimeConfig();
     const idem = request.idempotencyKey;
     const runId = idem;
+    const lifecycleGeneration = getAgentEventLifecycleGeneration();
     const execApprovalFollowupApprovalId = parseExecApprovalFollowupApprovalId(idem);
     if (execApprovalFollowupApprovalId && !canUseInternalRuntimeHandoff) {
       respond(
@@ -1565,6 +1569,7 @@ export const agentHandlers: GatewayRequestHandlers = {
       let resolvedSessionAgentId: string | undefined;
       let isNewSession = false;
       let skipAgentInitialSessionTouch = false;
+      let pendingChatRun: { sessionKey: string; agentId?: string } | undefined;
 
       const resetCommandMatch = message.match(RESET_COMMAND_RE);
       if (resetCommandMatch && requestedSessionKey) {
@@ -2144,21 +2149,14 @@ export const agentHandlers: GatewayRequestHandlers = {
         ) {
           const selectedGlobalAgentId =
             canonicalSessionKey === "global" ? sessionAgentId : undefined;
-          context.addChatRun(idem, {
+          pendingChatRun = {
             sessionKey: canonicalSessionKey,
             ...(selectedGlobalAgentId ? { agentId: selectedGlobalAgentId } : {}),
-            clientRunId: idem,
-          });
+          };
           if (requestedBestEffortDeliver === undefined) {
             bestEffortDeliver = true;
           }
         }
-        registerAgentRunContext(
-          idem,
-          suppressVisibleSessionEffects
-            ? { isControlUiVisible: false }
-            : { sessionKey: canonicalSessionKey },
-        );
       }
 
       const activeSessionAgentId =
@@ -2337,6 +2335,31 @@ export const agentHandlers: GatewayRequestHandlers = {
         });
         return;
       }
+      if (lifecycleGeneration !== getAgentEventLifecycleGeneration()) {
+        const stopReason = "gateway_restart";
+        agentRunAccepted = true;
+        setAbortedAgentDedupeEntries({
+          dedupe: context.dedupe,
+          keys: agentDedupeKeys,
+          agentId: resolvedSessionKey === "global" ? activeSessionAgentId : undefined,
+          runId,
+          stopReason,
+        });
+        respond(
+          true,
+          {
+            runId,
+            status: "timeout" as const,
+            summary: "aborted",
+            stopReason,
+            timeoutPhase: "queue" as const,
+            providerStarted: false,
+          },
+          undefined,
+          { runId },
+        );
+        return;
+      }
 
       // Register before the accepted ack so an immediate chat.abort/sessions.abort
       // cannot race the active-run entry. Agent RPC runs use the agent timeout;
@@ -2367,6 +2390,7 @@ export const agentHandlers: GatewayRequestHandlers = {
         authProviderId: activeAuthProvider,
         controlUiVisible: !suppressVisibleSessionEffects,
         kind: "agent",
+        lifecycleGeneration,
       });
       const existingRunAbort = context.chatAbortControllers.get(runId);
       if (!activeRunAbort.registered && existingRunAbort) {
@@ -2376,6 +2400,22 @@ export const agentHandlers: GatewayRequestHandlers = {
           runId,
         });
         return;
+      }
+      if (activeRunAbort.registered) {
+        if (pendingChatRun) {
+          context.addChatRun(runId, {
+            ...pendingChatRun,
+            clientRunId: runId,
+          });
+        }
+        if (resolvedSessionKey) {
+          claimAgentRunContext(
+            runId,
+            suppressVisibleSessionEffects
+              ? { isControlUiVisible: false, lifecycleGeneration }
+              : { sessionKey: resolvedSessionKey, lifecycleGeneration },
+          );
+        }
       }
 
       const resolvedThreadId = explicitThreadId ?? deliveryPlan.resolvedThreadId;
@@ -2589,6 +2629,7 @@ export const agentHandlers: GatewayRequestHandlers = {
                 }),
               cleanupBundleMcpOnRunEnd: request.cleanupBundleMcpOnRunEnd,
               abortSignal: activeRunAbort.controller.signal,
+              lifecycleGeneration,
               onActiveModelSelected: ({ provider }) => {
                 updateChatRunProvider(context.chatAbortControllers, {
                   runId,
@@ -2597,6 +2638,11 @@ export const agentHandlers: GatewayRequestHandlers = {
                     config: cfgForAgent ?? cfg,
                   }),
                 });
+              },
+              onSessionIdChanged: (sessionId) => {
+                if (activeRunAbort.entry) {
+                  activeRunAbort.entry.sessionId = sessionId;
+                }
               },
               // Internal-only: allow workspace override for spawned subagent runs.
               workspaceDir: resolveIngressWorkspaceOverrideForSpawnedRun({

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -75,6 +75,7 @@ import {
 import { resolveMaintenanceConfigFromInput } from "../../config/sessions/store-maintenance.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
+  assertAgentRunLifecycleGenerationCurrent,
   claimAgentRunContext,
   clearAgentRunContext,
   getAgentEventLifecycleGeneration,
@@ -260,6 +261,8 @@ async function runSessionResetFromAgent(params: {
   key: string;
   agentId?: string;
   reason: "new" | "reset";
+  assertCurrent?: () => void;
+  onCommitted?: (commit: { key: string; sessionId: string }) => void;
 }): Promise<
   | { ok: true; key: string; sessionId?: string }
   | { ok: false; error: ReturnType<typeof errorShape> }
@@ -269,6 +272,8 @@ async function runSessionResetFromAgent(params: {
     ...(params.agentId ? { agentId: params.agentId } : {}),
     reason: params.reason,
     commandSource: "gateway:agent",
+    assertCurrent: params.assertCurrent,
+    onCommitted: params.onCommitted,
   });
   if (!result.ok) {
     return result;
@@ -284,9 +289,13 @@ function sessionResetAckText(reason: "new" | "reset"): string {
   return reason === "new" ? "✅ New session started." : "✅ Session reset.";
 }
 
-function buildBareSessionResetResult(params: { reason: "new" | "reset"; sessionId?: string }) {
+function buildBareSessionResetResult(params: {
+  reason: "new" | "reset";
+  sessionId?: string;
+  ackText?: string;
+}) {
   return {
-    payloads: [{ text: sessionResetAckText(params.reason) }],
+    payloads: [{ text: params.ackText ?? sessionResetAckText(params.reason) }],
     meta: {
       durationMs: 0,
       ...(params.sessionId
@@ -336,18 +345,22 @@ async function deliverBareSessionResetResult(params: {
   deliveryTargetMode?: AgentCommandOpts["deliveryTargetMode"];
   originMessageChannel?: string;
   runId: string;
+  assertCurrent?: () => void;
+  ackText?: string;
 }) {
   const { deliverAgentCommandResult } = await import("../../agents/command/delivery.runtime.js");
+  params.assertCurrent?.();
   const result = buildBareSessionResetResult({
     reason: params.reason,
     sessionId: params.sessionId,
+    ackText: params.ackText,
   });
   return await deliverAgentCommandResult({
     cfg: params.cfg,
     deps: params.context.deps,
     runtime: defaultRuntime,
     opts: {
-      message: sessionResetAckText(params.reason),
+      message: params.ackText ?? sessionResetAckText(params.reason),
       ...(params.agentId ? { agentId: params.agentId } : {}),
       ...(params.sessionId ? { sessionId: params.sessionId } : {}),
       sessionKey: params.sessionKey,
@@ -375,6 +388,7 @@ async function deliverBareSessionResetResult(params: {
     sessionEntry: params.sessionEntry,
     result: result as never,
     payloads: result.payloads as never,
+    assertDeliveryCurrent: params.assertCurrent,
   });
 }
 
@@ -389,11 +403,15 @@ async function resolveBareSessionResetResult(params: {
   request: Parameters<GatewayRequestHandlers["agent"]>[0]["params"];
   originMessageChannel?: string;
   runId: string;
+  assertCurrent?: () => void;
+  ackText?: string;
 }) {
+  params.assertCurrent?.();
   if (params.request.deliver !== true) {
     return buildBareSessionResetResult({
       reason: params.reason,
       sessionId: params.sessionId,
+      ackText: params.ackText,
     });
   }
   const sendPolicy = resolveSendPolicy({
@@ -426,6 +444,7 @@ async function resolveBareSessionResetResult(params: {
     turnSourceAccountId: normalizeOptionalString(params.request.accountId),
     turnSourceThreadId: normalizeOptionalString(params.request.threadId),
   });
+  params.assertCurrent?.();
   const mainSessionKey = resolveAgentMainSessionKey({
     cfg: params.cfg,
     agentId: params.agentId ?? resolveAgentIdFromSessionKey(params.sessionKey),
@@ -450,6 +469,8 @@ async function resolveBareSessionResetResult(params: {
     deliveryTargetMode: deliveryPlan.deliveryTargetMode,
     originMessageChannel: params.originMessageChannel ?? deliveryPlan.resolvedChannel,
     runId: params.runId,
+    assertCurrent: params.assertCurrent,
+    ackText: params.ackText,
   });
 }
 
@@ -815,6 +836,7 @@ function setAbortedAgentDedupeEntries(params: {
   dedupe: GatewayRequestContext["dedupe"];
   keys: readonly string[];
   agentId?: string;
+  sessionKey?: string;
   runId: string;
   stopReason: string;
 }) {
@@ -827,6 +849,7 @@ function setAbortedAgentDedupeEntries(params: {
       payload: {
         runId: params.runId,
         ...(params.agentId ? { agentId: params.agentId } : {}),
+        ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
         status: "timeout" as const,
         summary: "aborted",
         stopReason: params.stopReason,
@@ -1210,6 +1233,15 @@ export const agentHandlers: GatewayRequestHandlers = {
     }
     let agentDedupeReserved = false;
     let agentRunAccepted = false;
+    let committedResetCompletion:
+      | {
+          reason: "new" | "reset";
+          sessionId?: string;
+          sessionKey: string;
+          agentId?: string;
+          followUpPending: boolean;
+        }
+      | undefined;
     const ownerConnId = typeof client?.connId === "string" ? client.connId : undefined;
     const ownerDeviceId =
       typeof client?.connect?.device?.id === "string" ? client.connect.device.id : undefined;
@@ -1269,6 +1301,70 @@ export const agentHandlers: GatewayRequestHandlers = {
         keys: agentDedupeKeys,
       });
       agentDedupeReserved = false;
+    };
+    const abortForLifecycleRotation = (target?: {
+      sessionKey?: string;
+      agentId?: string;
+    }): boolean => {
+      if (lifecycleGeneration === getAgentEventLifecycleGeneration()) {
+        return false;
+      }
+      if (committedResetCompletion) {
+        const completion = committedResetCompletion;
+        const responsePayload = buildBareSessionResetResponse({
+          runId,
+          result: buildBareSessionResetResult({
+            reason: completion.reason,
+            sessionId: completion.sessionId,
+            ackText: completion.followUpPending
+              ? `${sessionResetAckText(completion.reason)} Gateway restarted before the follow-up ran; send the follow-up message again.`
+              : undefined,
+          }),
+        });
+        agentRunAccepted = true;
+        setGatewayDedupeEntries({
+          dedupe: context.dedupe,
+          keys: agentDedupeKeys,
+          entry: {
+            ts: Date.now(),
+            ok: true,
+            payload: responsePayload,
+          },
+        });
+        respond(true, responsePayload, undefined, { runId });
+        emitSessionsChanged(context, {
+          sessionKey: completion.sessionKey,
+          ...(completion.sessionKey === "global" && completion.agentId
+            ? { agentId: completion.agentId }
+            : {}),
+          reason: completion.reason,
+        });
+        return true;
+      }
+      const stopReason = AGENT_RUN_RESTART_ABORT_STOP_REASON;
+      agentRunAccepted = true;
+      setAbortedAgentDedupeEntries({
+        dedupe: context.dedupe,
+        keys: agentDedupeKeys,
+        agentId: target?.agentId,
+        sessionKey: target?.sessionKey,
+        runId,
+        stopReason,
+      });
+      respond(
+        true,
+        {
+          runId,
+          status: "timeout" as const,
+          summary: "aborted",
+          stopReason,
+          timeoutPhase: "queue" as const,
+          providerStarted: false,
+        },
+        undefined,
+        { runId },
+      );
+      return true;
     };
     const normalizedAttachments = normalizeRpcAttachmentsToChatAttachments(request.attachments);
     const requestedBestEffortDeliver =
@@ -1583,6 +1679,9 @@ export const agentHandlers: GatewayRequestHandlers = {
 
       const resetCommandMatch = message.match(RESET_COMMAND_RE);
       if (resetCommandMatch && requestedSessionKey) {
+        if (abortForLifecycleRotation({ sessionKey: requestedSessionKey, agentId })) {
+          return;
+        }
         const postResetMessage = normalizeOptionalString(resetCommandMatch[2]) ?? "";
         if (!clientHasAdminScope(client)) {
           respond(
@@ -1594,18 +1693,46 @@ export const agentHandlers: GatewayRequestHandlers = {
         }
         const resetReason =
           normalizeOptionalLowercaseString(resetCommandMatch[1]) === "new" ? "new" : "reset";
-        const resetResult = await runSessionResetFromAgent({
-          key: requestedSessionKey,
-          ...(requestedSessionKey === "global" && agentId ? { agentId } : {}),
-          reason: resetReason,
-        });
+        let resetResult: Awaited<ReturnType<typeof runSessionResetFromAgent>>;
+        try {
+          resetResult = await runSessionResetFromAgent({
+            key: requestedSessionKey,
+            ...(requestedSessionKey === "global" && agentId ? { agentId } : {}),
+            reason: resetReason,
+            assertCurrent: () => assertAgentRunLifecycleGenerationCurrent(lifecycleGeneration),
+            onCommitted: (commit) => {
+              committedResetCompletion = {
+                reason: resetReason,
+                sessionId: commit.sessionId,
+                sessionKey: commit.key,
+                agentId,
+                followUpPending: Boolean(postResetMessage),
+              };
+            },
+          });
+        } catch (err) {
+          if (abortForLifecycleRotation({ sessionKey: requestedSessionKey, agentId })) {
+            return;
+          }
+          throw err;
+        }
         if (!resetResult.ok) {
           respond(false, undefined, resetResult.error);
           return;
         }
         requestedSessionKey = resetResult.key;
         resolvedSessionId = resetResult.sessionId ?? resolvedSessionId;
+        committedResetCompletion = {
+          reason: resetReason,
+          sessionId: resetResult.sessionId,
+          sessionKey: resetResult.key,
+          agentId,
+          followUpPending: Boolean(postResetMessage),
+        };
         if (postResetMessage) {
+          if (abortForLifecycleRotation({ sessionKey: resetResult.key, agentId })) {
+            return;
+          }
           message = postResetMessage;
         } else {
           let resetAckResult: Awaited<ReturnType<typeof resolveBareSessionResetResult>>;
@@ -1628,8 +1755,12 @@ export const agentHandlers: GatewayRequestHandlers = {
               sessionEntry: deliverySession?.entry,
               request,
               runId,
+              assertCurrent: () => assertAgentRunLifecycleGenerationCurrent(lifecycleGeneration),
             });
           } catch (err) {
+            if (abortForLifecycleRotation({ sessionKey: resetResult.key, agentId })) {
+              return;
+            }
             respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, formatForLog(err)));
             return;
           }
@@ -2018,6 +2149,9 @@ export const agentHandlers: GatewayRequestHandlers = {
               }).sessionStartedAt
             : undefined;
         if (storePath && !suppressVisibleSessionEffects) {
+          if (abortForLifecycleRotation({ sessionKey: canonicalSessionKey, agentId })) {
+            return;
+          }
           const requestedStoreKey = requestedSessionKey;
           let deniedBySendPolicy = false;
           let singleEntryPersistence:
@@ -2026,68 +2160,82 @@ export const agentHandlers: GatewayRequestHandlers = {
                 entry: SessionEntry;
               }
             | undefined;
-          const persisted = await updateSessionStore(
-            storePath,
-            (store) => {
-              const storeKeysBeforeMigration = new Set(Object.keys(store));
-              const preMigrationTarget = resolveGatewaySessionStoreTarget({
-                cfg: cfgLocal,
-                key: requestedStoreKey,
-                store,
-                ...(sessionAgentId ? { agentId: sessionAgentId } : {}),
-              });
-              const hadLegacyStoreKey = preMigrationTarget.storeKeys.some(
-                (storeKey) =>
-                  storeKey !== preMigrationTarget.canonicalKey && Object.hasOwn(store, storeKey),
-              );
-              const { target, primaryKey } = migrateAndPruneGatewaySessionStoreKey({
-                cfg: cfgLocal,
-                key: requestedStoreKey,
-                store,
-              });
-              const prunedStoreKey = [...storeKeysBeforeMigration].some(
-                (storeKey) => !Object.hasOwn(store, storeKey),
-              );
-              const freshEntry = store[primaryKey];
-              patchBuild = buildSessionPatch(freshEntry);
-              const effectivePatch =
-                recoveredSessionStartedAt !== undefined &&
-                freshEntry?.sessionStartedAt === undefined &&
-                freshEntry?.sessionId === entry?.sessionId
-                  ? { ...patchBuild.patch, sessionStartedAt: recoveredSessionStartedAt }
-                  : patchBuild.patch;
-              const merged = mergeSessionEntry(freshEntry, effectivePatch);
-              const sendPolicy =
-                request.deliver === true
-                  ? resolveSendPolicy({
-                      cfg: cfgLocal,
-                      entry: merged,
-                      sessionKey: canonicalKey,
-                      channel: merged?.channel,
-                      chatType: merged?.chatType,
-                    })
-                  : "allow";
-              if (sendPolicy === "deny") {
-                deniedBySendPolicy = true;
+          let persisted: SessionEntry | undefined;
+          try {
+            persisted = await updateSessionStore(
+              storePath,
+              (store) => {
+                // The writer lock may outlive this request's lifecycle. Check at
+                // transaction admission; once admitted, let the atomic write finish.
+                assertAgentRunLifecycleGenerationCurrent(lifecycleGeneration);
+                const storeKeysBeforeMigration = new Set(Object.keys(store));
+                const preMigrationTarget = resolveGatewaySessionStoreTarget({
+                  cfg: cfgLocal,
+                  key: requestedStoreKey,
+                  store,
+                  ...(sessionAgentId ? { agentId: sessionAgentId } : {}),
+                });
+                const hadLegacyStoreKey = preMigrationTarget.storeKeys.some(
+                  (storeKey) =>
+                    storeKey !== preMigrationTarget.canonicalKey && Object.hasOwn(store, storeKey),
+                );
+                const { target, primaryKey } = migrateAndPruneGatewaySessionStoreKey({
+                  cfg: cfgLocal,
+                  key: requestedStoreKey,
+                  store,
+                });
+                const prunedStoreKey = [...storeKeysBeforeMigration].some(
+                  (storeKey) => !Object.hasOwn(store, storeKey),
+                );
+                const freshEntry = store[primaryKey];
+                patchBuild = buildSessionPatch(freshEntry);
+                const effectivePatch =
+                  recoveredSessionStartedAt !== undefined &&
+                  freshEntry?.sessionStartedAt === undefined &&
+                  freshEntry?.sessionId === entry?.sessionId
+                    ? { ...patchBuild.patch, sessionStartedAt: recoveredSessionStartedAt }
+                    : patchBuild.patch;
+                const merged = mergeSessionEntry(freshEntry, effectivePatch);
+                const sendPolicy =
+                  request.deliver === true
+                    ? resolveSendPolicy({
+                        cfg: cfgLocal,
+                        entry: merged,
+                        sessionKey: canonicalKey,
+                        channel: merged?.channel,
+                        chatType: merged?.chatType,
+                      })
+                    : "allow";
+                if (sendPolicy === "deny") {
+                  deniedBySendPolicy = true;
+                  return merged;
+                }
+                store[primaryKey] = merged;
+                const canonicalKeyChanged = target.canonicalKey !== preMigrationTarget.canonicalKey;
+                singleEntryPersistence =
+                  freshEntry && !hadLegacyStoreKey && !canonicalKeyChanged && !prunedStoreKey
+                    ? {
+                        sessionKey: primaryKey,
+                        entry: merged,
+                      }
+                    : undefined;
                 return merged;
-              }
-              store[primaryKey] = merged;
-              const canonicalKeyChanged = target.canonicalKey !== preMigrationTarget.canonicalKey;
-              singleEntryPersistence =
-                freshEntry && !hadLegacyStoreKey && !canonicalKeyChanged && !prunedStoreKey
-                  ? {
-                      sessionKey: primaryKey,
-                      entry: merged,
-                    }
-                  : undefined;
-              return merged;
-            },
-            {
-              takeCacheOwnership: true,
-              maintenanceConfig: sessionMaintenanceConfig,
-              resolveSingleEntryPersistence: () => singleEntryPersistence,
-            },
-          );
+              },
+              {
+                takeCacheOwnership: true,
+                maintenanceConfig: sessionMaintenanceConfig,
+                resolveSingleEntryPersistence: () => singleEntryPersistence,
+              },
+            );
+          } catch (err) {
+            if (abortForLifecycleRotation({ sessionKey: canonicalSessionKey, agentId })) {
+              return;
+            }
+            throw err;
+          }
+          if (abortForLifecycleRotation({ sessionKey: canonicalSessionKey, agentId })) {
+            return;
+          }
           if (persisted) {
             sessionEntry = persisted;
             resolvedSessionId = sessionEntry.sessionId;
@@ -2345,29 +2493,12 @@ export const agentHandlers: GatewayRequestHandlers = {
         });
         return;
       }
-      if (lifecycleGeneration !== getAgentEventLifecycleGeneration()) {
-        const stopReason = AGENT_RUN_RESTART_ABORT_STOP_REASON;
-        agentRunAccepted = true;
-        setAbortedAgentDedupeEntries({
-          dedupe: context.dedupe,
-          keys: agentDedupeKeys,
+      if (
+        abortForLifecycleRotation({
+          sessionKey: resolvedSessionKey,
           agentId: resolvedSessionKey === "global" ? activeSessionAgentId : undefined,
-          runId,
-          stopReason,
-        });
-        respond(
-          true,
-          {
-            runId,
-            status: "timeout" as const,
-            summary: "aborted",
-            stopReason,
-            timeoutPhase: "queue" as const,
-            providerStarted: false,
-          },
-          undefined,
-          { runId },
-        );
+        })
+      ) {
         return;
       }
 

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -41,6 +41,7 @@ import {
 import { AGENT_INTERNAL_EVENT_TYPE_TASK_COMPLETION } from "../../agents/internal-event-contract.js";
 import type { AgentInternalEvent } from "../../agents/internal-events.js";
 import { resolveProviderIdForAuth } from "../../agents/provider-auth-aliases.js";
+import { isAgentRunRestartAbortReason } from "../../agents/run-termination.js";
 import {
   normalizeAgentRunTimeoutPhase,
   normalizeProviderStarted,
@@ -851,6 +852,9 @@ function isGatewayAgentAbortRejection(error: unknown, signal: AbortSignal): bool
   if (!signal.aborted) {
     return false;
   }
+  if (isAgentRunRestartAbortReason(signal.reason)) {
+    return true;
+  }
   if (readErrorName(signal.reason) === "TimeoutError") {
     return true;
   }
@@ -860,7 +864,10 @@ function isGatewayAgentAbortRejection(error: unknown, signal: AbortSignal): bool
   return isAbortError(error) || readErrorName(error) === "TimeoutError";
 }
 
-function resolveGatewayAgentAbortStopReason(signal: AbortSignal): "rpc" | "timeout" {
+function resolveGatewayAgentAbortStopReason(signal: AbortSignal): "restart" | "rpc" | "timeout" {
+  if (isAgentRunRestartAbortReason(signal.reason)) {
+    return "restart";
+  }
   return readErrorName(signal.reason) === "TimeoutError" ? "timeout" : "rpc";
 }
 
@@ -887,6 +894,7 @@ function dispatchAgentRunFromGateway(params: {
    * touching a same-runId entry owned by a concurrent chat.send.
    */
   abortController: AbortController;
+  cleanupAbortController: () => void;
   respond: GatewayRequestHandlerOptions["respond"];
   context: GatewayRequestHandlerOptions["context"];
   taskTrackingMode: Exclude<GatewayAgentTaskTrackingMode, "plugin_subagent">;
@@ -996,10 +1004,7 @@ function dispatchAgentRunFromGateway(params: {
       });
     })
     .finally(() => {
-      const entry = params.context.chatAbortControllers.get(params.runId);
-      if (entry?.controller === params.abortController) {
-        params.context.chatAbortControllers.delete(params.runId);
-      }
+      params.cleanupAbortController();
     });
 }
 
@@ -2658,6 +2663,7 @@ export const agentHandlers: GatewayRequestHandlers = {
             runId,
             dedupeKeys: agentDedupeKeys,
             abortController: activeRunAbort.controller,
+            cleanupAbortController: activeRunAbort.cleanup,
             respond,
             context,
             taskTrackingMode: dispatchTaskTrackingMode,
@@ -2686,7 +2692,7 @@ export const agentHandlers: GatewayRequestHandlers = {
           });
         } finally {
           if (!dispatched) {
-            activeRunAbort.cleanup();
+            activeRunAbort.cleanup({ force: true });
           }
         }
       })();

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -41,7 +41,10 @@ import {
 import { AGENT_INTERNAL_EVENT_TYPE_TASK_COMPLETION } from "../../agents/internal-event-contract.js";
 import type { AgentInternalEvent } from "../../agents/internal-events.js";
 import { resolveProviderIdForAuth } from "../../agents/provider-auth-aliases.js";
-import { isAgentRunRestartAbortReason } from "../../agents/run-termination.js";
+import {
+  AGENT_RUN_RESTART_ABORT_STOP_REASON,
+  isAgentRunRestartAbortReason,
+} from "../../agents/run-termination.js";
 import {
   normalizeAgentRunTimeoutPhase,
   normalizeProviderStarted,
@@ -2341,7 +2344,7 @@ export const agentHandlers: GatewayRequestHandlers = {
         return;
       }
       if (lifecycleGeneration !== getAgentEventLifecycleGeneration()) {
-        const stopReason = "gateway_restart";
+        const stopReason = AGENT_RUN_RESTART_ABORT_STOP_REASON;
         agentRunAccepted = true;
         setAbortedAgentDedupeEntries({
           dedupe: context.dedupe,

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -17,6 +17,7 @@ import { setReplyPayloadMetadata } from "../../auto-reply/reply-payload.js";
 import type { MsgContext } from "../../auto-reply/templating.js";
 import { appendSessionTranscriptMessage } from "../../config/sessions/transcript-append.js";
 import { resolveMirroredTranscriptText } from "../../config/sessions/transcript-mirror.js";
+import { getAgentRunContext } from "../../infra/agent-events.js";
 import { withEnvAsync } from "../../test-utils/env.js";
 import { readSessionTranscriptIndex } from "../session-transcript-index.fs.js";
 import type { GatewayRequestContext } from "./types.js";
@@ -4646,6 +4647,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     expect(response?.[1]).toBeUndefined();
     expect(response?.[2]?.code).toBe(ErrorCodes.INVALID_REQUEST);
     expect(response?.[2]?.message).toContain("attachment broken.png: invalid base64 content");
+    expect(getAgentRunContext("idem-chat-send-attachment-parse-stack")).toBeUndefined();
     const parseLogCall = (context.logGateway.error as unknown as ReturnType<typeof vi.fn>).mock
       .calls[0] as [string, Record<string, string>] | undefined;
     expect(parseLogCall?.[0]).toBe("chat.send attachment parse/stage failed");

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -3351,7 +3351,7 @@ export const chatHandlers: GatewayRequestHandlers = {
           performance.now() - prepareAttachmentsStartedAtMs,
         );
       } catch (err) {
-        activeRunAbort.cleanup();
+        activeRunAbort.cleanup({ force: true });
         clearAgentRunContext(clientRunId, lifecycleGeneration);
         clearActiveChatSendDedupeRun(context.dedupe, activeChatSendDedupeKey, clientRunId);
         logAttachmentFailure(context.logGateway, "chat.send attachment parse/stage failed", err);
@@ -4527,7 +4527,7 @@ export const chatHandlers: GatewayRequestHandlers = {
           context.removeChatRun(clientRunId, clientRunId, sessionKey);
         });
     } catch (err) {
-      activeRunAbort.cleanup();
+      activeRunAbort.cleanup({ force: true });
       clearAgentRunContext(clientRunId, lifecycleGeneration);
       clearActiveChatSendDedupeRun(context.dedupe, activeChatSendDedupeKey, clientRunId);
       context.removeChatRun(clientRunId, clientRunId, sessionKey);

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -59,6 +59,11 @@ import { resolveMirroredTranscriptText } from "../../config/sessions/transcript-
 import { CURRENT_SESSION_VERSION } from "../../config/sessions/version.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
+  claimAgentRunContext,
+  clearAgentRunContext,
+  getAgentEventLifecycleGeneration,
+} from "../../infra/agent-events.js";
+import {
   emitDiagnosticsTimelineEvent,
   measureDiagnosticsTimelineSpan,
   measureDiagnosticsTimelineSpanSync,
@@ -3240,6 +3245,7 @@ export const chatHandlers: GatewayRequestHandlers = {
         return;
       }
     }
+    const lifecycleGeneration = getAgentEventLifecycleGeneration();
     const activeRunAbort = registerChatAbortController({
       chatAbortControllers: context.chatAbortControllers,
       runId: clientRunId,
@@ -3253,6 +3259,7 @@ export const chatHandlers: GatewayRequestHandlers = {
       providerId: resolvedSessionModel.provider,
       authProviderId: resolvedSessionAuthProvider,
       kind: "chat-send",
+      lifecycleGeneration,
     });
     if (!activeRunAbort.registered) {
       respond(true, { runId: clientRunId, status: "in_flight" as const }, undefined, {
@@ -3261,6 +3268,11 @@ export const chatHandlers: GatewayRequestHandlers = {
       });
       return;
     }
+    claimAgentRunContext(clientRunId, {
+      sessionKey,
+      sessionId: backingSessionId ?? clientRunId,
+      lifecycleGeneration,
+    });
     if (activeChatSendDedupeKey) {
       context.dedupe.set(activeChatSendDedupeKey, {
         ts: now,
@@ -3340,6 +3352,7 @@ export const chatHandlers: GatewayRequestHandlers = {
         );
       } catch (err) {
         activeRunAbort.cleanup();
+        clearAgentRunContext(clientRunId, lifecycleGeneration);
         clearActiveChatSendDedupeRun(context.dedupe, activeChatSendDedupeKey, clientRunId);
         logAttachmentFailure(context.logGateway, "chat.send attachment parse/stage failed", err);
         respond(
@@ -4509,11 +4522,13 @@ export const chatHandlers: GatewayRequestHandlers = {
         })
         .finally(() => {
           activeRunAbort.cleanup();
+          clearAgentRunContext(clientRunId, lifecycleGeneration);
           clearActiveChatSendDedupeRun(context.dedupe, activeChatSendDedupeKey, clientRunId);
           context.removeChatRun(clientRunId, clientRunId, sessionKey);
         });
     } catch (err) {
       activeRunAbort.cleanup();
+      clearAgentRunContext(clientRunId, lifecycleGeneration);
       clearActiveChatSendDedupeRun(context.dedupe, activeChatSendDedupeKey, clientRunId);
       context.removeChatRun(clientRunId, clientRunId, sessionKey);
       const error = errorShape(ErrorCodes.UNAVAILABLE, String(err));

--- a/src/gateway/server-runtime-subscriptions.ts
+++ b/src/gateway/server-runtime-subscriptions.ts
@@ -84,7 +84,13 @@ export function startGatewayEventSubscriptions(params: {
             }
           }
         },
-        trackTrackedRunTerminalPersistence: ({ runId, clientRunId, observedAt, persistence }) => {
+        trackTrackedRunTerminalPersistence: ({
+          runId,
+          clientRunId,
+          sessionId: terminalSessionId,
+          observedAt,
+          persistence,
+        }) => {
           const candidateRunIds = runId === clientRunId ? [runId] : [runId, clientRunId];
           for (const candidateRunId of candidateRunIds) {
             const entry = params.chatAbortControllers.get(candidateRunId);
@@ -102,7 +108,7 @@ export function startGatewayEventSubscriptions(params: {
               }
               const lifecycleGeneration = entry.lifecycleGeneration?.trim();
               const sessionKey = entry.sessionKey.trim();
-              const sessionId = entry.sessionId.trim();
+              const sessionId = terminalSessionId?.trim() || entry.sessionId.trim();
               if (
                 entry.controlUiVisible !== false &&
                 lifecycleGeneration &&

--- a/src/gateway/server-runtime-subscriptions.ts
+++ b/src/gateway/server-runtime-subscriptions.ts
@@ -3,7 +3,7 @@ import { clearAgentRunContext, onAgentEvent } from "../infra/agent-events.js";
 import { onHeartbeatEvent } from "../infra/heartbeat-events.js";
 import { onSessionLifecycleEvent } from "../sessions/session-lifecycle-events.js";
 import { onSessionTranscriptUpdate } from "../sessions/transcript-events.js";
-import type { ChatAbortControllerEntry } from "./chat-abort.js";
+import type { ChatAbortControllerEntry, RestartRecoveryCandidate } from "./chat-abort.js";
 import type {
   ChatRunState,
   SessionEventSubscriberRegistry,
@@ -27,6 +27,7 @@ export function startGatewayEventSubscriptions(params: {
   sessionEventSubscribers: SessionEventSubscriberRegistry;
   sessionMessageSubscribers: SessionMessageSubscriberRegistry;
   chatAbortControllers: Map<string, ChatAbortControllerEntry>;
+  restartRecoveryCandidates: Map<string, RestartRecoveryCandidate>;
 }) {
   let agentEventHandlerPromise: Promise<
     ReturnType<typeof import("./server-chat.js").createAgentEventHandler>
@@ -56,6 +57,68 @@ export function startGatewayEventSubscriptions(params: {
             // state holds the canonical key; the run ids are the scoped match.
             if (entry) {
               entry.projectSessionActive = false;
+              entry.projectSessionTerminalPending = false;
+              entry.projectSessionTerminalPersisted = false;
+              queueMicrotask(() => {
+                const current = params.chatAbortControllers.get(candidateRunId);
+                if (
+                  current === entry &&
+                  entry.registrationCleanupRequested === true &&
+                  !entry.projectSessionTerminalPersistence
+                ) {
+                  params.chatAbortControllers.delete(candidateRunId);
+                }
+              });
+            }
+          }
+        },
+        markTrackedRunTerminalPersisted: ({ runId, clientRunId }) => {
+          const candidateRunIds = runId === clientRunId ? [runId] : [runId, clientRunId];
+          for (const candidateRunId of candidateRunIds) {
+            params.restartRecoveryCandidates.delete(candidateRunId);
+            const entry = params.chatAbortControllers.get(candidateRunId);
+            if (entry) {
+              entry.projectSessionTerminalPending = false;
+              entry.projectSessionTerminalPersisted = true;
+              entry.projectSessionTerminalPersistence = undefined;
+            }
+          }
+        },
+        trackTrackedRunTerminalPersistence: ({ runId, clientRunId, observedAt, persistence }) => {
+          const candidateRunIds = runId === clientRunId ? [runId] : [runId, clientRunId];
+          for (const candidateRunId of candidateRunIds) {
+            const entry = params.chatAbortControllers.get(candidateRunId);
+            if (entry) {
+              entry.projectSessionTerminalPending = false;
+              entry.projectSessionTerminalPersistence = persistence;
+              if (entry.registrationCleanupRequested === true) {
+                void persistence
+                  .catch(() => undefined)
+                  .then(() => {
+                    if (params.chatAbortControllers.get(candidateRunId) === entry) {
+                      params.chatAbortControllers.delete(candidateRunId);
+                    }
+                  });
+              }
+              const lifecycleGeneration = entry.lifecycleGeneration?.trim();
+              const sessionKey = entry.sessionKey.trim();
+              const sessionId = entry.sessionId.trim();
+              if (
+                entry.controlUiVisible !== false &&
+                lifecycleGeneration &&
+                sessionKey &&
+                sessionId
+              ) {
+                void persistence.catch(() => {
+                  params.restartRecoveryCandidates.set(candidateRunId, {
+                    runId: candidateRunId,
+                    lifecycleGeneration,
+                    sessionKey,
+                    sessionId,
+                    observedAt,
+                  });
+                });
+              }
             }
           }
         },
@@ -107,6 +170,48 @@ export function startGatewayEventSubscriptions(params: {
   };
 
   const agentUnsub = onAgentEvent((evt) => {
+    const lifecyclePhase =
+      evt.stream === "lifecycle" && typeof evt.data?.phase === "string"
+        ? evt.data.phase
+        : undefined;
+    if (lifecyclePhase === "end" || lifecyclePhase === "error") {
+      const chatLink = params.chatRunState.registry.peek(evt.runId);
+      const clientRunId = chatLink?.clientRunId ?? evt.runId;
+      const candidateRunIds = evt.runId === clientRunId ? [evt.runId] : [evt.runId, clientRunId];
+      for (const candidateRunId of candidateRunIds) {
+        const entry = params.chatAbortControllers.get(candidateRunId);
+        const eventLifecycleGeneration = evt.lifecycleGeneration?.trim();
+        if (
+          entry &&
+          (!eventLifecycleGeneration ||
+            !entry.lifecycleGeneration ||
+            entry.lifecycleGeneration === eventLifecycleGeneration)
+        ) {
+          entry.projectSessionTerminalPending = true;
+          entry.projectSessionTerminalObservedAt =
+            typeof evt.data.endedAt === "number" && Number.isFinite(evt.data.endedAt)
+              ? evt.data.endedAt
+              : evt.ts;
+        }
+      }
+    } else if (lifecyclePhase === "start") {
+      const chatLink = params.chatRunState.registry.peek(evt.runId);
+      const clientRunId = chatLink?.clientRunId ?? evt.runId;
+      const candidateRunIds = evt.runId === clientRunId ? [evt.runId] : [evt.runId, clientRunId];
+      const eventLifecycleGeneration = evt.lifecycleGeneration?.trim();
+      for (const candidateRunId of candidateRunIds) {
+        const entry = params.chatAbortControllers.get(candidateRunId);
+        if (
+          entry &&
+          (!eventLifecycleGeneration ||
+            !entry.lifecycleGeneration ||
+            entry.lifecycleGeneration === eventLifecycleGeneration)
+        ) {
+          entry.projectSessionTerminalPending = false;
+          entry.projectSessionTerminalObservedAt = undefined;
+        }
+      }
+    }
     void getAgentEventHandler().then((handler) => handler(evt));
   });
 

--- a/src/gateway/server-runtime-subscriptions.ts
+++ b/src/gateway/server-runtime-subscriptions.ts
@@ -63,6 +63,8 @@ export function startGatewayEventSubscriptions(params: {
           const entry = params.chatAbortControllers.get(runId);
           return entry !== undefined && entry.kind !== "agent";
         },
+        resolveActiveLifecycleGenerationForRun: (runId) =>
+          params.chatAbortControllers.get(runId)?.lifecycleGeneration,
       }),
     );
     return agentEventHandlerPromise;

--- a/src/gateway/server-startup-early.ts
+++ b/src/gateway/server-startup-early.ts
@@ -95,6 +95,7 @@ export async function startGatewayEarlyRuntime(params: {
   logHealth: GatewayMaintenanceParams["logHealth"];
   dedupe: GatewayMaintenanceParams["dedupe"];
   chatAbortControllers: GatewayMaintenanceParams["chatAbortControllers"];
+  restartRecoveryCandidates: GatewayMaintenanceParams["restartRecoveryCandidates"];
   chatRunState: GatewayMaintenanceParams["chatRunState"];
   chatRunBuffers: GatewayMaintenanceParams["chatRunBuffers"];
   chatDeltaSentAt: GatewayMaintenanceParams["chatDeltaSentAt"];
@@ -178,6 +179,7 @@ export async function startGatewayEarlyRuntime(params: {
         logHealth: params.logHealth,
         dedupe: params.dedupe,
         chatAbortControllers: params.chatAbortControllers,
+        restartRecoveryCandidates: params.restartRecoveryCandidates,
         chatRunState: params.chatRunState,
         chatRunBuffers: params.chatRunBuffers,
         chatDeltaSentAt: params.chatDeltaSentAt,

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -59,6 +59,7 @@ import {
 } from "../secrets/runtime-state.js";
 import { createAuthRateLimiter, type AuthRateLimiter } from "./auth-rate-limit.js";
 import { resolveGatewayAuth } from "./auth.js";
+import type { RestartRecoveryCandidate } from "./chat-abort.js";
 import { ADMIN_SCOPE } from "./method-scopes.js";
 import {
   STARTUP_UNAVAILABLE_GATEWAY_METHODS,
@@ -928,6 +929,7 @@ export async function startGatewayServer(
       getReadiness,
     }),
   );
+  const restartRecoveryCandidates = new Map<string, RestartRecoveryCandidate>();
   const { createGatewayNodeSessionRuntime } = await import("./server-node-session-runtime.js");
   const {
     nodeRegistry,
@@ -1049,6 +1051,7 @@ export async function startGatewayServer(
       lifecycleUnsub: runtimeState.lifecycleUnsub,
       chatRunState,
       chatAbortControllers,
+      restartRecoveryCandidates,
       removeChatRun,
       agentRunSeq,
       nodeSendToSession,
@@ -1058,6 +1061,7 @@ export async function startGatewayServer(
         sessionIds,
         activeRuns,
         reason,
+        isActiveRun,
       }) => {
         if (sessionKeys.size === 0 && sessionIds.size === 0) {
           return;
@@ -1069,6 +1073,7 @@ export async function startGatewayServer(
           sessionKeys,
           sessionIds,
           activeRuns,
+          isActiveRun,
           reason,
         });
       },
@@ -1118,6 +1123,7 @@ export async function startGatewayServer(
           logHealth,
           dedupe,
           chatAbortControllers,
+          restartRecoveryCandidates,
           chatRunState,
           chatRunBuffers,
           chatDeltaSentAt,
@@ -1160,6 +1166,7 @@ export async function startGatewayServer(
         sessionEventSubscribers,
         sessionMessageSubscribers,
         chatAbortControllers,
+        restartRecoveryCandidates,
       }),
     );
     Object.assign(runtimeState, runtimeSubscriptions);

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -1049,6 +1049,19 @@ export async function startGatewayServer(
       removeChatRun,
       agentRunSeq,
       nodeSendToSession,
+      markMainSessionsAbortedForRestart: async ({ sessionKeys, sessionIds, reason }) => {
+        if (sessionKeys.size === 0 && sessionIds.size === 0) {
+          return;
+        }
+        const { markRestartAbortedMainSessions } =
+          await import("../agents/main-session-restart-recovery.js");
+        await markRestartAbortedMainSessions({
+          cfg: getRuntimeConfig(),
+          sessionKeys,
+          sessionIds,
+          reason,
+        });
+      },
       getPendingReplyCount: getTotalPendingReplies,
       clients,
       configReloader: runtimeState.configReloader,

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -2,7 +2,10 @@
 // and WebSocket surfaces, config reload hooks, and graceful restart/shutdown.
 import { monitorEventLoopDelay, performance } from "node:perf_hooks";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
-import { getActiveEmbeddedRunCount } from "../agents/embedded-agent-runner/run-state.js";
+import {
+  getActiveEmbeddedRunCount,
+  resolveActiveEmbeddedRunSessionId,
+} from "../agents/embedded-agent-runner/run-state.js";
 import { getTotalPendingReplies } from "../auto-reply/reply/dispatcher-registry.js";
 import {
   getLoadedChannelPluginEntryById,
@@ -1049,7 +1052,13 @@ export async function startGatewayServer(
       removeChatRun,
       agentRunSeq,
       nodeSendToSession,
-      markMainSessionsAbortedForRestart: async ({ sessionKeys, sessionIds, reason }) => {
+      resolveActiveSessionIdForKey: resolveActiveEmbeddedRunSessionId,
+      markMainSessionsAbortedForRestart: async ({
+        sessionKeys,
+        sessionIds,
+        activeRuns,
+        reason,
+      }) => {
         if (sessionKeys.size === 0 && sessionIds.size === 0) {
           return;
         }
@@ -1059,6 +1068,7 @@ export async function startGatewayServer(
           cfg: getRuntimeConfig(),
           sessionKeys,
           sessionIds,
+          activeRuns,
           reason,
         });
       },

--- a/src/gateway/server.sessions.reset-cleanup.test.ts
+++ b/src/gateway/server.sessions.reset-cleanup.test.ts
@@ -264,6 +264,97 @@ test("sessions.reset closes ACP runtime handles for ACP sessions", async () => {
   expectResetAcpState(readAcpSessionMeta({ sessionKey: "agent:main:main" }));
 });
 
+test("sessions.reset finishes after lifecycle rotation during destructive cleanup", async () => {
+  const { dir } = await createSessionStoreDir();
+  await writeSingleLineSession(dir, "sess-main", "hello");
+  const prepareFreshSession = installAcpRuntimeBackendWithFreshSession();
+  await writeSessionStore({
+    entries: {
+      main: sessionStoreEntry("sess-main"),
+    },
+  });
+  writeAcpSessionMetaForMigration({
+    sessionKey: "agent:main:main",
+    sessionId: "sess-main",
+    meta: resolvedAcpMeta({
+      recordId: "agent:main:main",
+      backendSessionId: "backend-session-1",
+      runtimeOptions: {
+        runtimeMode: "auto",
+        timeoutSeconds: 30,
+      },
+    }),
+  });
+  let lifecycleCurrent = true;
+  acpManagerMocks.closeSession.mockImplementationOnce(async () => {
+    lifecycleCurrent = false;
+  });
+  const { performGatewaySessionReset } = await import("./session-reset-service.js");
+
+  const reset = await performGatewaySessionReset({
+    key: "main",
+    reason: "new",
+    commandSource: "gateway:agent",
+    assertCurrent: () => {
+      if (!lifecycleCurrent) {
+        throw new Error("stale lifecycle");
+      }
+    },
+  });
+
+  expect(reset.ok).toBe(true);
+  expectResetAcpState(readAcpSessionMeta({ sessionKey: "agent:main:main" }));
+  expect(prepareFreshSession).not.toHaveBeenCalled();
+});
+
+test("sessions.reset preserves a newer session after lifecycle rotation", async () => {
+  const { dir, storePath } = await createSessionStoreDir();
+  await writeSingleLineSession(dir, "sess-main", "hello");
+  installAcpRuntimeBackendWithFreshSession();
+  await writeSessionStore({
+    entries: {
+      main: sessionStoreEntry("sess-main"),
+    },
+  });
+  writeAcpSessionMetaForMigration({
+    sessionKey: "agent:main:main",
+    sessionId: "sess-main",
+    meta: resolvedAcpMeta({
+      recordId: "agent:main:main",
+      backendSessionId: "backend-session-1",
+    }),
+  });
+  let lifecycleCurrent = true;
+  acpManagerMocks.closeSession.mockImplementationOnce(async () => {
+    lifecycleCurrent = false;
+    await writeSessionStore({
+      entries: {
+        main: sessionStoreEntry("new-owner-session"),
+      },
+    });
+  });
+  const { performGatewaySessionReset } = await import("./session-reset-service.js");
+
+  await expect(
+    performGatewaySessionReset({
+      key: "main",
+      reason: "new",
+      commandSource: "gateway:agent",
+      assertCurrent: () => {
+        if (!lifecycleCurrent) {
+          throw new Error("stale lifecycle");
+        }
+      },
+    }),
+  ).rejects.toThrow("stale lifecycle");
+
+  const store = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
+    string,
+    { sessionId?: string }
+  >;
+  expect(store["agent:main:main"]?.sessionId).toBe("new-owner-session");
+});
+
 test("sessions.reset closes child ACP runtime handles spawned from the parent", async () => {
   const { dir } = await createSessionStoreDir();
   await writeSingleLineSession(dir, "sess-main", "hello");

--- a/src/gateway/server.sessions.reset-hooks.test.ts
+++ b/src/gateway/server.sessions.reset-hooks.test.ts
@@ -217,6 +217,8 @@ async function performSessionReset(params: {
   agentId?: string;
   reason: "new" | "reset";
   commandSource: string;
+  assertCurrent?: () => void;
+  onCommitted?: (commit: { key: string; sessionId: string }) => void;
 }) {
   const { performGatewaySessionReset } = await import("./session-reset-service.js");
   return performGatewaySessionReset(params);
@@ -346,6 +348,33 @@ test("sessions.reset emits internal command hook with reason", async () => {
   expect(event.sessionKey).toBe("agent:main:main");
   expect(event.context?.commandSource).toBe("gateway:sessions.reset");
   expect(event.context?.previousSessionEntry?.sessionId).toBe("sess-main");
+});
+
+test("sessions.reset does not begin cleanup after losing lifecycle ownership", async () => {
+  const { dir } = await createSessionStoreDir();
+  await writeSingleLineSession(dir, "sess-main", "hello");
+  await writeMainSessionEntry("sess-main");
+  let ownershipChecks = 0;
+
+  await expect(
+    performSessionReset({
+      key: "main",
+      reason: "new",
+      commandSource: "gateway:agent",
+      assertCurrent: () => {
+        ownershipChecks += 1;
+        if (ownershipChecks >= 2) {
+          const error = new Error("stale lifecycle");
+          error.name = "AbortError";
+          throw error;
+        }
+      },
+    }),
+  ).rejects.toThrow("stale lifecycle");
+
+  expect(ownershipChecks).toBe(2);
+  const store = await loadGatewaySessionStoreForKey("main");
+  expect(store["agent:main:main"]?.sessionId).toBe("sess-main");
 });
 
 test("sessions.reset emits before_reset hook with transcript context", async () => {

--- a/src/gateway/session-lifecycle-state.test.ts
+++ b/src/gateway/session-lifecycle-state.test.ts
@@ -159,7 +159,7 @@ describe("session lifecycle state", () => {
         stopReason: "restart",
         endedAt: 1_800,
       },
-      expected: terminalPatch(1_050, 1_800, "timeout", false),
+      expected: terminalPatch(1_050, 1_800, "killed", true),
     });
   });
 
@@ -171,12 +171,9 @@ describe("session lifecycle state", () => {
         stopReason: "restart",
       },
       {
-        phase: "end",
-        aborted: true,
-        stopReason: "aborted",
-      },
-      {
         phase: "error",
+        aborted: true,
+        stopReason: "restart",
         error: "request aborted",
       },
     ] as const) {
@@ -197,6 +194,132 @@ describe("session lifecycle state", () => {
         expected: {},
       });
     }
+  });
+
+  it.each([
+    {
+      name: "user cancellation",
+      data: {
+        phase: "end",
+        aborted: true,
+        stopReason: "aborted",
+        endedAt: 1_800,
+      } as const,
+      expected: {
+        ...terminalPatch(1_050, 1_800, "killed", true),
+        restartRecoveryRuns: undefined,
+      },
+    },
+    {
+      name: "provider timeout",
+      data: {
+        phase: "end",
+        aborted: true,
+        stopReason: "timeout",
+        endedAt: 1_800,
+      } as const,
+      expected: {
+        ...terminalPatch(1_050, 1_800, "timeout", false),
+        restartRecoveryRuns: undefined,
+      },
+    },
+  ])("persists $name terminal state despite a restart marker", ({ data, expected }) => {
+    expectPersistedLifecyclePatch({
+      entry: {
+        status: "running",
+        abortedLastRun: true,
+        restartRecoveryRuns: [
+          {
+            runId: "restart-run",
+            lifecycleGeneration: "pre-restart",
+          },
+        ],
+      },
+      runId: "restart-run",
+      lifecycleGeneration: "pre-restart",
+      data,
+      expected,
+    });
+  });
+
+  it("preserves restart recovery state through a delayed lifecycle start", () => {
+    expectPersistedLifecyclePatch({
+      entry: {
+        status: "running",
+        abortedLastRun: true,
+        restartRecoveryRuns: [
+          {
+            runId: "restart-run",
+            lifecycleGeneration: "pre-restart",
+          },
+        ],
+      },
+      runId: "restart-run",
+      lifecycleGeneration: "pre-restart",
+      data: {
+        phase: "start",
+        startedAt: 1_500,
+      },
+      expected: {},
+    });
+  });
+
+  it("persists successful marked-run completion and removes its recovery marker", () => {
+    expectPersistedLifecyclePatch({
+      entry: {
+        status: "running",
+        abortedLastRun: true,
+        restartRecoveryRuns: [
+          {
+            runId: "restart-run",
+            lifecycleGeneration: "pre-restart",
+          },
+        ],
+      },
+      runId: "restart-run",
+      lifecycleGeneration: "pre-restart",
+      data: {
+        phase: "end",
+        endedAt: 1_800,
+      },
+      expected: {
+        ...terminalPatch(1_050, 1_800, "done", false),
+        restartRecoveryRuns: undefined,
+      },
+    });
+  });
+
+  it("keeps session recovery active while another marked run remains", () => {
+    expectPersistedLifecyclePatch({
+      entry: {
+        status: "running",
+        abortedLastRun: true,
+        restartRecoveryRuns: [
+          {
+            runId: "completed-run",
+            lifecycleGeneration: "pre-restart",
+          },
+          {
+            runId: "interrupted-run",
+            lifecycleGeneration: "pre-restart",
+          },
+        ],
+      },
+      runId: "completed-run",
+      lifecycleGeneration: "pre-restart",
+      data: {
+        phase: "end",
+        endedAt: 1_800,
+      },
+      expected: {
+        restartRecoveryRuns: [
+          {
+            runId: "interrupted-run",
+            lifecycleGeneration: "pre-restart",
+          },
+        ],
+      },
+    });
   });
 
   it("persists lifecycle events from a recovery run with a different run id", () => {

--- a/src/gateway/session-lifecycle-state.test.ts
+++ b/src/gateway/session-lifecycle-state.test.ts
@@ -39,6 +39,8 @@ function terminalPatch(
 function expectPersistedLifecyclePatch(options: {
   entry?: Partial<PersistedLifecycleInput["entry"]>;
   data: PersistedLifecycleData;
+  runId?: string;
+  lifecycleGeneration?: string;
   expected: ReturnType<typeof derivePersistedSessionLifecyclePatch>;
 }): void {
   expect(
@@ -50,6 +52,8 @@ function expectPersistedLifecyclePatch(options: {
       },
       event: {
         ts: 2_000,
+        runId: options.runId,
+        lifecycleGeneration: options.lifecycleGeneration,
         data: options.data,
       },
     }),
@@ -140,6 +144,80 @@ describe("session lifecycle state", () => {
         stopReason: "aborted",
       },
       expected: terminalPatch(1_100, 1_800, "killed", true),
+    });
+  });
+
+  it("persists restart terminal lifecycle when no recovery marker exists", () => {
+    expectPersistedLifecyclePatch({
+      entry: {
+        status: "running",
+        abortedLastRun: false,
+      },
+      data: {
+        phase: "end",
+        aborted: true,
+        stopReason: "restart",
+        endedAt: 1_800,
+      },
+      expected: terminalPatch(1_050, 1_800, "timeout", false),
+    });
+  });
+
+  it("preserves restart recovery state through late interrupted-run lifecycle events", () => {
+    for (const data of [
+      {
+        phase: "end",
+        aborted: true,
+        stopReason: "restart",
+      },
+      {
+        phase: "end",
+        aborted: true,
+        stopReason: "aborted",
+      },
+      {
+        phase: "error",
+        error: "request aborted",
+      },
+    ] as const) {
+      expectPersistedLifecyclePatch({
+        entry: {
+          status: "running",
+          abortedLastRun: true,
+          restartRecoveryRuns: [
+            {
+              runId: "restart-run",
+              lifecycleGeneration: "pre-restart",
+            },
+          ],
+        },
+        runId: "restart-run",
+        lifecycleGeneration: "pre-restart",
+        data,
+        expected: {},
+      });
+    }
+  });
+
+  it("persists lifecycle events from a recovery run with a different run id", () => {
+    expectPersistedLifecyclePatch({
+      entry: {
+        status: "running",
+        abortedLastRun: true,
+        restartRecoveryRuns: [
+          {
+            runId: "shared-idempotency-key",
+            lifecycleGeneration: "pre-restart",
+          },
+        ],
+      },
+      runId: "shared-idempotency-key",
+      lifecycleGeneration: "post-restart",
+      data: {
+        phase: "end",
+        endedAt: 1_800,
+      },
+      expected: terminalPatch(1_050, 1_800, "done", false),
     });
   });
 

--- a/src/gateway/session-lifecycle-state.ts
+++ b/src/gateway/session-lifecycle-state.ts
@@ -12,6 +12,8 @@ import type { GatewaySessionRow, SessionRunStatus } from "./session-utils.types.
 type LifecyclePhase = "start" | "end" | "error";
 
 type LifecycleEventLike = Pick<AgentEventPayload, "ts" | "sessionId"> & {
+  runId?: string;
+  lifecycleGeneration?: string;
   data?: {
     phase?: unknown;
     startedAt?: unknown;
@@ -32,7 +34,13 @@ type LifecycleSessionShape = Pick<
 
 type PersistedLifecycleSessionShape = Pick<
   SessionEntry,
-  "updatedAt" | "status" | "startedAt" | "endedAt" | "runtimeMs" | "abortedLastRun"
+  | "updatedAt"
+  | "status"
+  | "startedAt"
+  | "endedAt"
+  | "runtimeMs"
+  | "abortedLastRun"
+  | "restartRecoveryRuns"
 >;
 
 type GatewaySessionLifecycleSnapshot = Partial<LifecycleSessionShape>;
@@ -166,6 +174,9 @@ export function derivePersistedSessionLifecyclePatch(params: {
   entry?: Partial<PersistedLifecycleSessionShape> | null;
   event: LifecycleEventLike;
 }): Partial<PersistedLifecycleSessionShape> {
+  if (isRestartRecoveryLifecycleEvent(params)) {
+    return {};
+  }
   const snapshot = deriveGatewaySessionLifecycleSnapshot({
     session: params.entry ?? undefined,
     event: params.event,
@@ -174,6 +185,21 @@ export function derivePersistedSessionLifecyclePatch(params: {
     ...snapshot,
     updatedAt: typeof snapshot.updatedAt === "number" ? snapshot.updatedAt : undefined,
   };
+}
+
+export function isRestartRecoveryLifecycleEvent(params: {
+  entry?: Pick<SessionEntry, "restartRecoveryRuns"> | null;
+  event: Pick<LifecycleEventLike, "runId" | "lifecycleGeneration">;
+}): boolean {
+  const runId = params.event.runId?.trim();
+  const lifecycleGeneration = params.event.lifecycleGeneration?.trim();
+  return Boolean(
+    runId &&
+    lifecycleGeneration &&
+    params.entry?.restartRecoveryRuns?.some(
+      (run) => run.runId === runId && run.lifecycleGeneration === lifecycleGeneration,
+    ),
+  );
 }
 
 /**
@@ -227,10 +253,11 @@ export async function persistGatewaySessionLifecycleEvent(params: {
       if (isStaleLifecycleEventForSession({ owningSessionId, currentSessionId: entry.sessionId })) {
         return null;
       }
-      return derivePersistedSessionLifecyclePatch({
+      const patch = derivePersistedSessionLifecyclePatch({
         entry,
         event: params.event,
       });
+      return Object.keys(patch).length > 0 ? patch : null;
     },
   });
 }

--- a/src/gateway/session-lifecycle-state.ts
+++ b/src/gateway/session-lifecycle-state.ts
@@ -49,7 +49,7 @@ function isFiniteTimestamp(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value) && value > 0;
 }
 
-function resolveLifecyclePhase(event: LifecycleEventLike): LifecyclePhase | null {
+function resolveLifecyclePhase(event: Pick<LifecycleEventLike, "data">): LifecyclePhase | null {
   const phase = typeof event.data?.phase === "string" ? event.data.phase : "";
   return phase === "start" || phase === "end" || phase === "error" ? phase : null;
 }
@@ -181,24 +181,59 @@ export function derivePersistedSessionLifecyclePatch(params: {
     session: params.entry ?? undefined,
     event: params.event,
   });
-  return {
+  const patch: Partial<PersistedLifecycleSessionShape> = {
     ...snapshot,
     updatedAt: typeof snapshot.updatedAt === "number" ? snapshot.updatedAt : undefined,
   };
+  const runId = params.event.runId?.trim();
+  const lifecycleGeneration = params.event.lifecycleGeneration?.trim();
+  const restartRecoveryRuns = params.entry?.restartRecoveryRuns;
+  if (
+    resolveLifecyclePhase(params.event) !== "start" &&
+    runId &&
+    lifecycleGeneration &&
+    restartRecoveryRuns?.some(
+      (run) => run.runId === runId && run.lifecycleGeneration === lifecycleGeneration,
+    )
+  ) {
+    const remainingRuns = restartRecoveryRuns.filter(
+      (run) => run.runId !== runId || run.lifecycleGeneration !== lifecycleGeneration,
+    );
+    if (remainingRuns.length > 0) {
+      return { restartRecoveryRuns: remainingRuns };
+    }
+    patch.restartRecoveryRuns = undefined;
+  }
+  return patch;
+}
+
+export function deriveGatewaySessionLifecycleProjectionPatch(params: {
+  entry?: Partial<PersistedLifecycleSessionShape> | null;
+  event: LifecycleEventLike;
+}): GatewaySessionLifecycleSnapshot {
+  const { restartRecoveryRuns: _restartRecoveryRuns, ...patch } =
+    derivePersistedSessionLifecyclePatch(params);
+  return patch;
 }
 
 export function isRestartRecoveryLifecycleEvent(params: {
   entry?: Pick<SessionEntry, "restartRecoveryRuns"> | null;
-  event: Pick<LifecycleEventLike, "runId" | "lifecycleGeneration">;
+  event: Pick<LifecycleEventLike, "runId" | "lifecycleGeneration" | "data">;
 }): boolean {
   const runId = params.event.runId?.trim();
   const lifecycleGeneration = params.event.lifecycleGeneration?.trim();
-  return Boolean(
+  const phase = resolveLifecyclePhase(params.event);
+  const interrupted = params.event.data?.stopReason === "restart";
+  const matchesRecoveryRun = Boolean(
     runId &&
     lifecycleGeneration &&
     params.entry?.restartRecoveryRuns?.some(
       (run) => run.runId === runId && run.lifecycleGeneration === lifecycleGeneration,
     ),
+  );
+  return (
+    matchesRecoveryRun &&
+    (phase === "start" || ((phase === "end" || phase === "error") && interrupted))
   );
 }
 
@@ -246,6 +281,7 @@ export async function persistGatewaySessionLifecycleEvent(params: {
     sessionKey: sessionEntry.canonicalKey,
     skipMaintenance: true,
     takeCacheOwnership: true,
+    requireWriteSuccess: true,
     update: async (entry) => {
       // Reject a pre-reset run's lifecycle event: sessions.reset rotates the row
       // to a new sessionId under the same sessionKey, so an old in-flight run's

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -377,8 +377,10 @@ async function ensureSessionRuntimeCleanup(params: {
   key: string;
   target: ReturnType<typeof resolveGatewaySessionStoreTarget>;
   sessionId?: string;
+  assertCurrent?: () => void;
 }) {
   const closeTrackedBrowserTabs = async () => {
+    params.assertCurrent?.();
     const closeKeys = new Set<string>([
       params.key,
       params.target.canonicalKey,
@@ -390,8 +392,10 @@ async function ensureSessionRuntimeCleanup(params: {
       sessionKeys: [...closeKeys],
       onWarn: (message) => logVerbose(message),
     });
+    params.assertCurrent?.();
   };
 
+  params.assertCurrent?.();
   const queueKeys = new Set<string>(params.target.storeKeys);
   queueKeys.add(params.target.canonicalKey);
   if (params.sessionId) {
@@ -400,14 +404,18 @@ async function ensureSessionRuntimeCleanup(params: {
   clearSessionResetRuntimeState([...queueKeys]);
   stopSubagentsForRequester({ cfg: params.cfg, requesterSessionKey: params.target.canonicalKey });
   if (!params.sessionId) {
+    params.assertCurrent?.();
     clearBootstrapSnapshot(params.target.canonicalKey);
     await closeTrackedBrowserTabs();
     return undefined;
   }
+  params.assertCurrent?.();
   abortEmbeddedAgentRun(params.sessionId);
   const ended = await waitForEmbeddedAgentRunEnd(params.sessionId, 15_000);
+  params.assertCurrent?.();
   clearBootstrapSnapshot(params.target.canonicalKey);
   if (ended) {
+    params.assertCurrent?.();
     await retireSessionMcpRuntime({
       sessionId: params.sessionId,
       reason: "gateway-session-cleanup",
@@ -417,6 +425,7 @@ async function ensureSessionRuntimeCleanup(params: {
         );
       },
     });
+    params.assertCurrent?.();
     await closeTrackedBrowserTabs();
     return undefined;
   }
@@ -450,7 +459,15 @@ async function closeAcpRuntimeForSession(params: {
   fallbackSessionKeys?: Array<string | undefined>;
   reason: "session-reset" | "session-delete";
   onResetMeta?: (params: { sessionKey: string; meta: SessionAcpMeta }) => void;
+  deferResetState?: boolean;
+  onDeferredResetState?: (params: { sessionKey: string; meta: SessionAcpMeta }) => void;
+  assertCurrent?: () => void;
+  shouldCleanup?: () => boolean;
 }) {
+  if (params.shouldCleanup && !params.shouldCleanup()) {
+    return undefined;
+  }
+  params.assertCurrent?.();
   const sessionKeys = Array.from(
     new Set(
       [params.sessionKey, ...(params.fallbackSessionKeys ?? [])]
@@ -471,6 +488,10 @@ async function closeAcpRuntimeForSession(params: {
     return undefined;
   }
   const acpManager = getAcpSessionManager();
+  if (params.shouldCleanup && !params.shouldCleanup()) {
+    return undefined;
+  }
+  params.assertCurrent?.();
   const cancelOutcome = await runAcpCleanupStep({
     op: async () => {
       await acpManager.cancelSession({
@@ -480,6 +501,10 @@ async function closeAcpRuntimeForSession(params: {
       });
     },
   });
+  if (params.shouldCleanup && !params.shouldCleanup()) {
+    return undefined;
+  }
+  params.assertCurrent?.();
   if (cancelOutcome.status === "timeout") {
     return errorShape(
       ErrorCodes.UNAVAILABLE,
@@ -492,6 +517,10 @@ async function closeAcpRuntimeForSession(params: {
     );
   }
 
+  if (params.shouldCleanup && !params.shouldCleanup()) {
+    return undefined;
+  }
+  params.assertCurrent?.();
   const closeOutcome = await runAcpCleanupStep({
     op: async () => {
       await acpManager.closeSession({
@@ -504,6 +533,10 @@ async function closeAcpRuntimeForSession(params: {
       });
     },
   });
+  if (params.shouldCleanup && !params.shouldCleanup()) {
+    return undefined;
+  }
+  params.assertCurrent?.();
   if (closeOutcome.status === "timeout") {
     return errorShape(
       ErrorCodes.UNAVAILABLE,
@@ -516,10 +549,17 @@ async function closeAcpRuntimeForSession(params: {
     );
   }
   if (params.reason === "session-delete") {
+    params.assertCurrent?.();
     await upsertAcpSessionMeta({
       cfg: params.cfg,
       sessionKey: acpSessionKey,
       mutate: () => null,
+    });
+    params.assertCurrent?.();
+  } else if (params.deferResetState) {
+    params.onDeferredResetState?.({
+      sessionKey: acpSessionKey,
+      meta: acpMeta,
     });
   } else {
     const resetMeta = await ensureFreshAcpResetState({
@@ -527,6 +567,8 @@ async function closeAcpRuntimeForSession(params: {
       sessionKey: acpSessionKey,
       reason: params.reason,
       acpMeta,
+      assertCurrent: params.assertCurrent,
+      shouldApply: params.shouldCleanup,
     });
     if (resetMeta) {
       params.onResetMeta?.({ sessionKey: acpSessionKey, meta: resetMeta });
@@ -563,6 +605,8 @@ async function ensureFreshAcpResetState(params: {
   sessionKey: string;
   reason: "session-reset" | "session-delete";
   acpMeta: SessionAcpMeta;
+  assertCurrent?: () => void;
+  shouldApply?: () => boolean;
 }): Promise<SessionAcpMeta | undefined> {
   if (params.reason !== "session-reset") {
     return undefined;
@@ -580,11 +624,20 @@ async function ensureFreshAcpResetState(params: {
   }
 
   const backendId = (latestMeta.backend || params.cfg.acp?.backend || "").trim() || undefined;
+  if (params.shouldApply && !params.shouldApply()) {
+    return undefined;
+  }
   try {
+    params.assertCurrent?.();
     await getAcpRuntimeBackend(backendId)?.runtime.prepareFreshSession?.({
       sessionKey: params.sessionKey,
     });
+    if (params.shouldApply && !params.shouldApply()) {
+      return undefined;
+    }
+    params.assertCurrent?.();
   } catch (error) {
+    params.assertCurrent?.();
     logVerbose(
       `sessions.${params.reason}: ACP prepareFreshSession failed for ${params.sessionKey}: ${String(error)}`,
     );
@@ -592,14 +645,22 @@ async function ensureFreshAcpResetState(params: {
 
   const now = Date.now();
   let resetMeta: SessionAcpMeta | undefined;
+  if (params.shouldApply && !params.shouldApply()) {
+    return undefined;
+  }
+  params.assertCurrent?.();
   await upsertAcpSessionMeta({
     cfg: params.cfg,
     sessionKey: params.sessionKey,
     mutate: (current) => {
+      if (params.shouldApply && !params.shouldApply()) {
+        return current;
+      }
       resetMeta = buildPendingAcpMeta(current ?? latestMeta, now);
       return resetMeta;
     },
   });
+  params.assertCurrent?.();
   return resetMeta;
 }
 
@@ -607,6 +668,8 @@ async function closeChildAcpRuntimesForParent(params: {
   cfg: OpenClawConfig;
   parentKey: string;
   reason: "session-reset" | "session-delete";
+  assertCurrent?: () => void;
+  shouldCleanup?: () => boolean;
 }): Promise<void> {
   // Enumerate across every agent session store, not just the parent's: ACP
   // spawns create child keys under the target agent (`agent:<targetAgentId>:acp:…`)
@@ -616,6 +679,10 @@ async function closeChildAcpRuntimesForParent(params: {
   // session list uses).
   let children: Array<{ sessionKey: string }>;
   try {
+    if (params.shouldCleanup && !params.shouldCleanup()) {
+      return;
+    }
+    params.assertCurrent?.();
     children = findDirectChildSessionsForParent({
       cfg: params.cfg,
       parentKey: params.parentKey,
@@ -636,12 +703,18 @@ async function closeChildAcpRuntimesForParent(params: {
   // cleanup timeout window rather than scaling with the number of stuck
   // children; per-child failures are logged best-effort and never propagated,
   // so a stuck child cannot block or fail the parent mutation.
+  if (params.shouldCleanup && !params.shouldCleanup()) {
+    return;
+  }
+  params.assertCurrent?.();
   await Promise.allSettled(
     children.map(({ sessionKey }) =>
       closeAcpRuntimeForSession({
         cfg: params.cfg,
         sessionKey,
         reason: params.reason,
+        assertCurrent: params.assertCurrent,
+        shouldCleanup: params.shouldCleanup,
       }).then((childError) => {
         if (childError) {
           logVerbose(`sessions.${params.reason}: child ACP cleanup incomplete for ${sessionKey}`);
@@ -649,6 +722,10 @@ async function closeChildAcpRuntimesForParent(params: {
       }),
     ),
   );
+  if (params.shouldCleanup && !params.shouldCleanup()) {
+    return;
+  }
+  params.assertCurrent?.();
 }
 
 export async function cleanupSessionBeforeMutation(params: {
@@ -660,12 +737,14 @@ export async function cleanupSessionBeforeMutation(params: {
   canonicalKey?: string;
   reason: "session-reset" | "session-delete";
   onAcpResetMeta?: (params: { sessionKey: string; meta: SessionAcpMeta }) => void;
+  assertCurrent?: () => void;
 }) {
   const cleanupError = await ensureSessionRuntimeCleanup({
     cfg: params.cfg,
     key: params.key,
     target: params.target,
     sessionId: params.entry?.sessionId,
+    assertCurrent: params.assertCurrent,
   });
   if (cleanupError) {
     return cleanupError;
@@ -675,7 +754,12 @@ export async function cleanupSessionBeforeMutation(params: {
     registry: getActivePluginRegistry(),
     reason: params.reason === "session-reset" ? "reset" : "delete",
     sessionKey: params.target.canonicalKey ?? params.key,
+    shouldCleanup: () => {
+      params.assertCurrent?.();
+      return true;
+    },
   });
+  params.assertCurrent?.();
   for (const failure of pluginCleanup.failures) {
     logVerbose(
       `plugin host cleanup failed for ${failure.pluginId}/${failure.hookId}: ${String(failure.error)}`,
@@ -688,12 +772,16 @@ export async function cleanupSessionBeforeMutation(params: {
     fallbackSessionKeys: [params.canonicalKey, params.legacyKey, params.key],
     reason: params.reason,
     onResetMeta: params.onAcpResetMeta,
+    assertCurrent: params.assertCurrent,
   });
+  params.assertCurrent?.();
   await closeChildAcpRuntimesForParent({
     cfg: params.cfg,
     parentKey: params.target.canonicalKey ?? params.canonicalKey ?? params.key,
     reason: params.reason,
+    assertCurrent: params.assertCurrent,
   });
+  params.assertCurrent?.();
   return parentAcpError;
 }
 
@@ -753,6 +841,8 @@ export async function performGatewaySessionReset(params: {
   agentId?: string;
   reason: "new" | "reset";
   commandSource: string;
+  assertCurrent?: () => void;
+  onCommitted?: (commit: { key: string; sessionId: string }) => void;
 }): Promise<
   | { ok: true; key: string; entry: SessionEntry; agentId: string; storePath: string }
   | { ok: false; error: ReturnType<typeof errorShape> }
@@ -802,7 +892,16 @@ export async function performGatewaySessionReset(params: {
   const hadExistingEntry = Boolean(entry);
   const agentId = normalizeAgentId(target.agentId ?? resolveDefaultAgentId(cfg));
   const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
-  let pendingAcpResetMeta: { sessionKey: string; meta: SessionAcpMeta } | undefined;
+  const resetPluginRegistry = getActivePluginRegistry();
+  const isResetLifecycleCurrent = () => {
+    try {
+      params.assertCurrent?.();
+      return true;
+    } catch {
+      return false;
+    }
+  };
+  let deferredAcpResetState: { sessionKey: string; meta: SessionAcpMeta } | undefined;
   const hookEvent = createInternalHookEvent(
     "command",
     params.reason,
@@ -815,22 +914,52 @@ export async function performGatewaySessionReset(params: {
       workspaceDir,
     },
   );
+  params.assertCurrent?.();
   await triggerInternalHook(hookEvent);
-  const mutationCleanupError = await cleanupSessionBeforeMutation({
+  params.assertCurrent?.();
+  // Cleanup below is destructive. Once it starts, finish rotating the same
+  // session even if gateway ownership changes; otherwise runtime state can be
+  // reset while the persisted session still points at the old conversation.
+  const runtimeCleanupError = await ensureSessionRuntimeCleanup({
     cfg,
     key: params.key,
     target,
-    entry,
-    legacyKey,
-    canonicalKey,
+    sessionId: entry?.sessionId,
+  });
+  if (runtimeCleanupError) {
+    return { ok: false, error: runtimeCleanupError };
+  }
+  const parentSessionKey = target.canonicalKey ?? canonicalKey ?? params.key;
+  const parentAcpError = await closeAcpRuntimeForSession({
+    cfg,
+    sessionKey: parentSessionKey,
+    fallbackSessionKeys: [canonicalKey, legacyKey, params.key],
     reason: "session-reset",
-    onAcpResetMeta: (meta) => {
-      pendingAcpResetMeta = meta;
+    deferResetState: true,
+    onDeferredResetState: (state) => {
+      deferredAcpResetState = state;
     },
   });
-  if (mutationCleanupError) {
-    return { ok: false, error: mutationCleanupError };
+  if (parentAcpError) {
+    return { ok: false, error: parentAcpError };
   }
+  const pluginCleanup = await runPluginHostCleanup({
+    cfg,
+    registry: resetPluginRegistry,
+    reason: "reset",
+    sessionKey: target.canonicalKey ?? params.key,
+    skipPersistentSessionState: true,
+  });
+  for (const failure of pluginCleanup.failures) {
+    logVerbose(
+      `plugin host cleanup failed for ${failure.pluginId}/${failure.hookId}: ${String(failure.error)}`,
+    );
+  }
+  await closeChildAcpRuntimesForParent({
+    cfg,
+    parentKey: target.canonicalKey ?? canonicalKey ?? params.key,
+    reason: "session-reset",
+  });
 
   let oldSessionId: string | undefined;
   let oldSessionFile: string | undefined;
@@ -843,6 +972,11 @@ export async function performGatewaySessionReset(params: {
       ...(requestedAgentId ? { agentId: requestedAgentId } : {}),
     });
     const currentEntry = store[primaryKey];
+    if (!isResetLifecycleCurrent() && currentEntry?.sessionId !== entry?.sessionId) {
+      // A newer owner already replaced or removed the session while cleanup
+      // targeted the old id. Preserve that newer state instead of resetting it.
+      params.assertCurrent?.();
+    }
     resetSourceEntry = currentEntry ? { ...currentEntry } : undefined;
     const parsed = parseAgentSessionKey(primaryKey);
     const sessionAgentId = normalizeAgentId(
@@ -951,12 +1085,40 @@ export async function performGatewaySessionReset(params: {
     store[primaryKey] = nextEntry;
     return nextEntry;
   });
-  if (pendingAcpResetMeta) {
-    writeAcpSessionMetaForMigration({
-      sessionKey: pendingAcpResetMeta.sessionKey,
-      sessionId: next.sessionId,
-      meta: pendingAcpResetMeta.meta,
-    });
+  let committedAcpResetState: { sessionKey: string; meta: SessionAcpMeta } | undefined;
+  if (deferredAcpResetState) {
+    const identity = deferredAcpResetState.meta.identity;
+    if (identity?.state === "resolved" && (identity.acpxSessionId || identity.agentSessionId)) {
+      committedAcpResetState = {
+        sessionKey: deferredAcpResetState.sessionKey,
+        meta: buildPendingAcpMeta(deferredAcpResetState.meta, Date.now()),
+      };
+      // The JSON session rotation and SQLite metadata cannot share a transaction.
+      // Bind captured ACP state before acknowledging the committed reset so the
+      // new session never observes an unreadable old-session row.
+      writeAcpSessionMetaForMigration({
+        sessionKey: committedAcpResetState.sessionKey,
+        sessionId: next.sessionId,
+        meta: committedAcpResetState.meta,
+      });
+    }
+  }
+  params.onCommitted?.({
+    key: target.canonicalKey,
+    sessionId: next.sessionId,
+  });
+  if (committedAcpResetState && isResetLifecycleCurrent()) {
+    try {
+      await getAcpRuntimeBackend(
+        (committedAcpResetState.meta.backend || cfg.acp?.backend || "").trim() || undefined,
+      )?.runtime.prepareFreshSession?.({
+        sessionKey: committedAcpResetState.sessionKey,
+      });
+    } catch (error) {
+      logVerbose(
+        `sessions.session-reset: ACP prepareFreshSession failed for ${committedAcpResetState.sessionKey}: ${String(error)}`,
+      );
+    }
   }
   await emitGatewayBeforeResetPluginHook({
     cfg,

--- a/src/gateway/test-helpers.maintenance-state.ts
+++ b/src/gateway/test-helpers.maintenance-state.ts
@@ -20,6 +20,7 @@ export function createGatewayMaintenanceStateForTest(params?: {
     logHealth: { error: () => {} },
     dedupe: new Map(),
     chatAbortControllers: new Map(),
+    restartRecoveryCandidates: new Map(),
     chatRunState,
     chatRunBuffers: chatRunState.buffers,
     chatDeltaSentAt: chatRunState.deltaSentAt,

--- a/src/infra/agent-events.test.ts
+++ b/src/infra/agent-events.test.ts
@@ -11,6 +11,7 @@ import {
   listAgentRunsForSession,
   onAgentEvent,
   registerAgentRunContext,
+  releaseAgentRunContext,
   resetAgentEventsForTest,
   resetAgentRunContextForTest,
   rotateAgentEventLifecycleGeneration,
@@ -89,6 +90,81 @@ describe("agent-events sequencing", () => {
     stop();
 
     expect(seen).toEqual([1, 2]);
+  });
+
+  test("keeps a tracked context until every overlapping owner exits", () => {
+    const lifecycleGeneration = getAgentEventLifecycleGeneration();
+    const firstOwner = claimAgentRunContext(
+      "shared-run",
+      { sessionKey: "main", lifecycleGeneration },
+      { trackOwner: true },
+    );
+    const secondOwner = claimAgentRunContext(
+      "shared-run",
+      { sessionKey: "main", lifecycleGeneration },
+      { trackOwner: true },
+    );
+
+    clearAgentRunContext("shared-run", lifecycleGeneration);
+    releaseAgentRunContext("shared-run", firstOwner);
+    expect(getAgentRunContext("shared-run")).toBeDefined();
+
+    releaseAgentRunContext("shared-run", secondOwner);
+    expect(getAgentRunContext("shared-run")).toBeUndefined();
+  });
+
+  test("clears tracked context after an inner same-generation reclaim", () => {
+    const lifecycleGeneration = getAgentEventLifecycleGeneration();
+    const ownerToken = claimAgentRunContext(
+      "shared-run",
+      { sessionKey: "main", lifecycleGeneration },
+      { trackOwner: true },
+    );
+
+    claimAgentRunContext("shared-run", {
+      sessionKey: "main",
+      lifecycleGeneration,
+      verboseLevel: "off",
+    });
+    releaseAgentRunContext("shared-run", ownerToken);
+
+    expect(getAgentRunContext("shared-run")).toBeUndefined();
+  });
+
+  test("honors a matching clear deferred behind a tracked owner", () => {
+    const lifecycleGeneration = getAgentEventLifecycleGeneration();
+    registerAgentRunContext("shared-run", {
+      sessionKey: "main",
+      lifecycleGeneration,
+    });
+    const ownerToken = claimAgentRunContext(
+      "shared-run",
+      { sessionKey: "main", lifecycleGeneration },
+      { trackOwner: true },
+    );
+
+    clearAgentRunContext("shared-run", lifecycleGeneration);
+    releaseAgentRunContext("shared-run", ownerToken);
+
+    expect(getAgentRunContext("shared-run")).toBeUndefined();
+  });
+
+  test("full event reset clears tracked ownership", () => {
+    const lifecycleGeneration = getAgentEventLifecycleGeneration();
+    claimAgentRunContext(
+      "shared-run",
+      { sessionKey: "main", lifecycleGeneration },
+      { trackOwner: true },
+    );
+
+    resetAgentEventsForTest();
+    registerAgentRunContext("shared-run", {
+      sessionKey: "main",
+      lifecycleGeneration,
+    });
+    clearAgentRunContext("shared-run", lifecycleGeneration);
+
+    expect(getAgentRunContext("shared-run")).toBeUndefined();
   });
 
   test("drops stale explicit-generation events before shared listeners", () => {

--- a/src/infra/agent-events.test.ts
+++ b/src/infra/agent-events.test.ts
@@ -1,14 +1,20 @@
 // Covers agent event sequencing and run context cleanup.
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import {
+  type AgentEventPayload,
+  captureAgentRunLifecycleGeneration,
+  claimAgentRunContext,
   clearAgentRunContext,
   emitAgentEvent,
+  getAgentEventLifecycleGeneration,
   getAgentRunContext,
   onAgentEvent,
   registerAgentRunContext,
   resetAgentEventsForTest,
   resetAgentRunContextForTest,
+  rotateAgentEventLifecycleGeneration,
   sweepStaleRunContexts,
+  withAgentRunLifecycleGeneration,
 } from "./agent-events.js";
 
 type AgentEventsModule = typeof import("./agent-events.js");
@@ -31,6 +37,156 @@ describe("agent-events sequencing", () => {
     expect(getAgentRunContext("run-1")).toBeUndefined();
   });
 
+  test("does not let an old execution clear a newer same-id context", () => {
+    registerAgentRunContext("shared-run", {
+      sessionKey: "main",
+      lifecycleGeneration: "post-restart",
+    });
+
+    clearAgentRunContext("shared-run", "pre-restart");
+    expect(getAgentRunContext("shared-run")?.lifecycleGeneration).toBe("post-restart");
+
+    clearAgentRunContext("shared-run", "post-restart");
+    expect(getAgentRunContext("shared-run")).toBeUndefined();
+  });
+
+  test("clears sequence state when guarded cleanup finds no run context", () => {
+    const seen: number[] = [];
+    const stop = onAgentEvent((event) => {
+      if (event.runId === "contextless-run") {
+        seen.push(event.seq);
+      }
+    });
+
+    emitAgentEvent({ runId: "contextless-run", stream: "assistant", data: { text: "first" } });
+    clearAgentRunContext("contextless-run", getAgentEventLifecycleGeneration());
+    emitAgentEvent({ runId: "contextless-run", stream: "assistant", data: { text: "second" } });
+    stop();
+
+    expect(seen).toEqual([1, 1]);
+  });
+
+  test("preserves sequence state when same-generation ownership is reclaimed", () => {
+    const lifecycleGeneration = getAgentEventLifecycleGeneration();
+    claimAgentRunContext("retry-run", {
+      sessionKey: "main",
+      lifecycleGeneration,
+    });
+    const seen: number[] = [];
+    const stop = onAgentEvent((event) => {
+      if (event.runId === "retry-run") {
+        seen.push(event.seq);
+      }
+    });
+
+    emitAgentEvent({ runId: "retry-run", stream: "assistant", data: { text: "first" } });
+    claimAgentRunContext("retry-run", {
+      sessionKey: "main",
+      lifecycleGeneration,
+    });
+    emitAgentEvent({ runId: "retry-run", stream: "assistant", data: { text: "second" } });
+    stop();
+
+    expect(seen).toEqual([1, 2]);
+  });
+
+  test("drops stale explicit-generation events before shared listeners", () => {
+    const activeGeneration = getAgentEventLifecycleGeneration();
+    registerAgentRunContext("shared-run", {
+      sessionKey: "main",
+      lifecycleGeneration: activeGeneration,
+    });
+    const seen: AgentEventPayload[] = [];
+    const stop = onAgentEvent((event) => seen.push(event));
+
+    emitAgentEvent({
+      runId: "shared-run",
+      lifecycleGeneration: "pre-restart",
+      stream: "lifecycle",
+      data: { phase: "end" },
+    });
+    emitAgentEvent({
+      runId: "shared-run",
+      lifecycleGeneration: activeGeneration,
+      stream: "lifecycle",
+      data: { phase: "start" },
+    });
+    stop();
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0]?.seq).toBe(1);
+    expect(seen[0]?.data.phase).toBe("start");
+  });
+
+  test("drops stale inherited-generation events from every stream", () => {
+    const preRestartGeneration = getAgentEventLifecycleGeneration();
+    claimAgentRunContext("shared-run", {
+      sessionKey: "main",
+      lifecycleGeneration: preRestartGeneration,
+    });
+    const seen: AgentEventPayload[] = [];
+    const stop = onAgentEvent((event) => seen.push(event));
+
+    rotateAgentEventLifecycleGeneration();
+    const postRestartGeneration = getAgentEventLifecycleGeneration();
+    withAgentRunLifecycleGeneration(preRestartGeneration, () => {
+      emitAgentEvent({
+        runId: "shared-run",
+        stream: "assistant",
+        data: { text: "stale" },
+      });
+    });
+    claimAgentRunContext("shared-run", {
+      sessionKey: "main",
+      lifecycleGeneration: postRestartGeneration,
+    });
+    withAgentRunLifecycleGeneration(postRestartGeneration, () => {
+      emitAgentEvent({
+        runId: "shared-run",
+        stream: "tool",
+        data: { name: "current" },
+      });
+    });
+    stop();
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0]?.seq).toBe(1);
+    expect(seen[0]?.stream).toBe("tool");
+  });
+
+  test("captures inherited lifecycle ownership for descendant runs", () => {
+    const preRestartGeneration = getAgentEventLifecycleGeneration();
+    rotateAgentEventLifecycleGeneration();
+
+    const captured = withAgentRunLifecycleGeneration(preRestartGeneration, () =>
+      captureAgentRunLifecycleGeneration("descendant-run"),
+    );
+
+    expect(captured).toBe(preRestartGeneration);
+  });
+
+  test("drops stale-generation terminal lifecycle after rotation", () => {
+    const preRestartGeneration = getAgentEventLifecycleGeneration();
+    claimAgentRunContext("interrupted-run", {
+      sessionKey: "main",
+      lifecycleGeneration: preRestartGeneration,
+    });
+    rotateAgentEventLifecycleGeneration();
+    const seen: AgentEventPayload[] = [];
+    const stop = onAgentEvent((event) => seen.push(event));
+
+    withAgentRunLifecycleGeneration(preRestartGeneration, () => {
+      emitAgentEvent({
+        runId: "interrupted-run",
+        stream: "lifecycle",
+        data: { phase: "end" },
+      });
+    });
+    stop();
+
+    expect(seen).toHaveLength(0);
+  });
+
   test("stamps the owning sessionId onto lifecycle events for reset-stale guarding (#88538)", () => {
     registerAgentRunContext("run-1", { sessionKey: "main", sessionId: "old-session-id" });
     const seen: Array<{ stream: string; sessionId?: string }> = [];
@@ -48,6 +204,66 @@ describe("agent-events sequencing", () => {
     expect(seen.find((evt) => evt.stream === "lifecycle")?.sessionId).toBe("old-session-id");
     // Only lifecycle events carry the sessionId; other streams stay unstamped.
     expect(seen.find((evt) => evt.stream === "item")?.sessionId).toBeUndefined();
+  });
+
+  test("rejects old runs after restart and stamps the new generation", () => {
+    const oldGeneration = getAgentEventLifecycleGeneration();
+    registerAgentRunContext("old-run", { sessionKey: "main" });
+    const newGeneration = rotateAgentEventLifecycleGeneration();
+    registerAgentRunContext("new-run", { sessionKey: "main" });
+    const seen = new Map<string, { generation?: string; keys: string[] }>();
+    const stop = onAgentEvent((evt) => {
+      if (evt.stream === "lifecycle") {
+        seen.set(evt.runId, {
+          generation: evt.lifecycleGeneration,
+          keys: Object.keys(evt),
+        });
+      }
+    });
+
+    emitAgentEvent({ runId: "old-run", stream: "lifecycle", data: { phase: "end" } });
+    emitAgentEvent({ runId: "new-run", stream: "lifecycle", data: { phase: "start" } });
+    stop();
+
+    expect(newGeneration).not.toBe(oldGeneration);
+    expect(seen.has("old-run")).toBe(false);
+    expect(seen.get("new-run")?.generation).toBe(newGeneration);
+    expect(seen.get("new-run")?.keys).not.toContain("lifecycleGeneration");
+  });
+
+  test("lets a newly admitted retry claim an explicit lifecycle generation", () => {
+    registerAgentRunContext("shared-run-id", { sessionKey: "main" });
+    const oldGeneration = getAgentRunContext("shared-run-id")?.lifecycleGeneration;
+    const newGeneration = rotateAgentEventLifecycleGeneration();
+
+    claimAgentRunContext("shared-run-id", {
+      sessionKey: "main",
+      lifecycleGeneration: newGeneration,
+    });
+
+    expect(newGeneration).not.toBe(oldGeneration);
+    expect(getAgentRunContext("shared-run-id")?.lifecycleGeneration).toBe(newGeneration);
+  });
+
+  test("does not let an older execution reclaim a newly admitted run id", () => {
+    claimAgentRunContext("shared-run-id", {
+      sessionKey: "new-session",
+      lifecycleGeneration: "post-restart",
+    });
+
+    registerAgentRunContext("shared-run-id", {
+      sessionKey: "old-session",
+      lifecycleGeneration: "pre-restart",
+      isControlUiVisible: false,
+    });
+
+    expect(getAgentRunContext("shared-run-id")).toEqual(
+      expect.objectContaining({
+        sessionKey: "new-session",
+        lifecycleGeneration: "post-restart",
+      }),
+    );
+    expect(getAgentRunContext("shared-run-id")?.isControlUiVisible).toBeUndefined();
   });
 
   test("refreshes the stamped sessionId when run context is re-registered (#88538)", () => {

--- a/src/infra/agent-events.test.ts
+++ b/src/infra/agent-events.test.ts
@@ -8,6 +8,7 @@ import {
   emitAgentEvent,
   getAgentEventLifecycleGeneration,
   getAgentRunContext,
+  listAgentRunsForSession,
   onAgentEvent,
   registerAgentRunContext,
   resetAgentEventsForTest,
@@ -163,6 +164,26 @@ describe("agent-events sequencing", () => {
     );
 
     expect(captured).toBe(preRestartGeneration);
+  });
+
+  test("lists only runs owned by the current lifecycle", () => {
+    const preRestartGeneration = getAgentEventLifecycleGeneration();
+    claimAgentRunContext("stale-run", {
+      sessionKey: "main",
+      lifecycleGeneration: preRestartGeneration,
+    });
+    const currentLifecycleGeneration = rotateAgentEventLifecycleGeneration();
+    claimAgentRunContext("current-run", {
+      sessionKey: "main",
+      lifecycleGeneration: currentLifecycleGeneration,
+    });
+
+    expect(listAgentRunsForSession({ sessionKey: "main" })).toEqual([
+      {
+        runId: "current-run",
+        lifecycleGeneration: currentLifecycleGeneration,
+      },
+    ]);
   });
 
   test("drops stale-generation terminal lifecycle after rotation", () => {

--- a/src/infra/agent-events.ts
+++ b/src/infra/agent-events.ts
@@ -154,6 +154,15 @@ type AgentEventState = {
   seqByRun: Map<string, number>;
   listeners: Set<(evt: AgentEventPayload) => void>;
   runContextById: Map<string, AgentRunContext>;
+  runContextOwnersById?: Map<
+    string,
+    {
+      lifecycleGeneration: string;
+      ownerTokens: Set<string>;
+      preserveAfterRelease: boolean;
+      clearRequested: boolean;
+    }
+  >;
   lifecycleGeneration: string;
 };
 
@@ -260,20 +269,53 @@ export function registerAgentRunContext(runId: string, context: AgentRunContext)
   }
 }
 
+function getAgentRunContextOwners(state = getAgentEventState()) {
+  state.runContextOwnersById ??= new Map();
+  return state.runContextOwnersById;
+}
+
 /** Claims a run id for a newly admitted execution, replacing stale ownership. */
-export function claimAgentRunContext(runId: string, context: AgentRunContext) {
+export function claimAgentRunContext(
+  runId: string,
+  context: AgentRunContext,
+  options: { trackOwner?: boolean; ownsContext?: boolean } = {},
+): string | undefined {
   if (!runId) {
-    return;
+    return undefined;
   }
   const state = getAgentEventState();
   const lifecycleGeneration = context.lifecycleGeneration ?? state.lifecycleGeneration;
   const existing = state.runContextById.get(runId);
+  const ownersById = getAgentRunContextOwners(state);
+  const existingOwners = ownersById.get(runId);
+  let ownerToken: string | undefined;
+  if (options.trackOwner) {
+    ownerToken = randomUUID();
+    if (existingOwners?.lifecycleGeneration === lifecycleGeneration) {
+      existingOwners.ownerTokens.add(ownerToken);
+      if (options.ownsContext) {
+        existingOwners.preserveAfterRelease = false;
+      }
+    } else {
+      ownersById.set(runId, {
+        lifecycleGeneration,
+        ownerTokens: new Set([ownerToken]),
+        preserveAfterRelease:
+          options.ownsContext !== true && existing?.lifecycleGeneration === lifecycleGeneration,
+        clearRequested: false,
+      });
+    }
+  } else if (existingOwners?.lifecycleGeneration !== lifecycleGeneration) {
+    // Same-generation untracked claims refresh metadata inside the tracked
+    // execution. A new lifecycle replaces that ownership outright.
+    ownersById.delete(runId);
+  }
   if (existing?.lifecycleGeneration === lifecycleGeneration) {
     registerAgentRunContext(runId, {
       ...context,
       lifecycleGeneration,
     });
-    return;
+    return ownerToken;
   }
   state.runContextById.set(runId, {
     ...context,
@@ -281,6 +323,7 @@ export function claimAgentRunContext(runId: string, context: AgentRunContext) {
     registeredAt: context.registeredAt ?? Date.now(),
   });
   state.seqByRun.delete(runId);
+  return ownerToken;
 }
 
 /** Returns the currently registered context for a run, if it has not been cleared or swept. */
@@ -317,8 +360,35 @@ export function clearAgentRunContext(runId: string, lifecycleGeneration?: string
   if (lifecycleGeneration && existing && existing.lifecycleGeneration !== lifecycleGeneration) {
     return;
   }
+  const owners = getAgentRunContextOwners(state).get(runId);
+  if (owners?.ownerTokens.size) {
+    if (!lifecycleGeneration || owners.lifecycleGeneration === lifecycleGeneration) {
+      owners.clearRequested = true;
+    }
+    return;
+  }
   state.runContextById.delete(runId);
   state.seqByRun.delete(runId);
+}
+
+/** Releases one tracked owner and clears its context after the final owner exits. */
+export function releaseAgentRunContext(runId: string, ownerToken: string | undefined) {
+  if (!runId || !ownerToken) {
+    return;
+  }
+  const state = getAgentEventState();
+  const ownersById = getAgentRunContextOwners(state);
+  const owners = ownersById.get(runId);
+  if (!owners?.ownerTokens.delete(ownerToken)) {
+    return;
+  }
+  if (owners.ownerTokens.size > 0) {
+    return;
+  }
+  ownersById.delete(runId);
+  if (owners.clearRequested || !owners.preserveAfterRelease) {
+    clearAgentRunContext(runId, owners.lifecycleGeneration);
+  }
 }
 
 /**
@@ -337,6 +407,7 @@ export function sweepStaleRunContexts(maxAgeMs = 30 * 60 * 1000): number {
     if (age > maxAgeMs) {
       state.runContextById.delete(runId);
       state.seqByRun.delete(runId);
+      getAgentRunContextOwners(state).delete(runId);
       swept++;
     }
   }
@@ -345,8 +416,10 @@ export function sweepStaleRunContexts(maxAgeMs = 30 * 60 * 1000): number {
 
 /** Clears run context state without removing event listeners; test-only helper. */
 export function resetAgentRunContextForTest() {
-  getAgentEventState().runContextById.clear();
-  getAgentEventState().seqByRun.clear();
+  const state = getAgentEventState();
+  state.runContextById.clear();
+  state.seqByRun.clear();
+  getAgentRunContextOwners(state).clear();
 }
 
 /** Emits an agent event after assigning per-run sequence, timestamp, and context metadata. */
@@ -490,4 +563,5 @@ export function resetAgentEventsForTest() {
   state.seqByRun.clear();
   state.listeners.clear();
   state.runContextById.clear();
+  getAgentRunContextOwners(state).clear();
 }

--- a/src/infra/agent-events.ts
+++ b/src/infra/agent-events.ts
@@ -293,12 +293,13 @@ export function listAgentRunsForSession(params: {
   sessionKey: string;
   sessionId?: string;
 }): Array<{ runId: string; lifecycleGeneration: string }> {
+  const currentLifecycleGeneration = getAgentEventState().lifecycleGeneration;
   const runs: Array<{ runId: string; lifecycleGeneration: string }> = [];
   for (const [runId, context] of getAgentEventState().runContextById) {
     const matches = context.sessionId
       ? context.sessionId === params.sessionId
       : context.sessionKey === params.sessionKey;
-    if (matches && context.lifecycleGeneration) {
+    if (matches && context.lifecycleGeneration === currentLifecycleGeneration) {
       runs.push({ runId, lifecycleGeneration: context.lifecycleGeneration });
     }
   }

--- a/src/infra/agent-events.ts
+++ b/src/infra/agent-events.ts
@@ -1,4 +1,6 @@
 // Stores and broadcasts agent lifecycle and streaming events.
+import { AsyncLocalStorage } from "node:async_hooks";
+import { randomUUID } from "node:crypto";
 import type { VerboseLevel } from "../auto-reply/thinking.js";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 import { notifyListeners, registerListener } from "../shared/listeners.js";
@@ -119,6 +121,8 @@ export type AgentEventPayload = {
   stream: AgentEventStream;
   ts: number;
   data: Record<string, unknown>;
+  /** Internal, non-enumerable gateway lifecycle generation that owns this run. */
+  lifecycleGeneration?: string;
   sessionKey?: string;
   /**
    * sessionId the run was bound to when it started. Lifecycle persistence uses
@@ -134,6 +138,8 @@ export type AgentRunContext = {
   sessionKey?: string;
   /** Owning run's sessionId; stamped onto lifecycle events (see AgentEventPayload.sessionId). */
   sessionId?: string;
+  /** Gateway lifecycle generation captured when the run was registered. */
+  lifecycleGeneration?: string;
   verboseLevel?: VerboseLevel;
   isHeartbeat?: boolean;
   /** Whether control UI clients should receive chat/agent updates for this run. */
@@ -148,16 +154,65 @@ type AgentEventState = {
   seqByRun: Map<string, number>;
   listeners: Set<(evt: AgentEventPayload) => void>;
   runContextById: Map<string, AgentRunContext>;
+  lifecycleGeneration: string;
 };
 
 const AGENT_EVENT_STATE_KEY = Symbol.for("openclaw.agentEvents.state");
+const AGENT_EVENT_EXECUTION_CONTEXT_KEY = Symbol.for("openclaw.agentEvents.executionContext");
+
+type AgentEventExecutionContext = {
+  lifecycleGeneration: string;
+};
 
 function getAgentEventState(): AgentEventState {
   return resolveGlobalSingleton<AgentEventState>(AGENT_EVENT_STATE_KEY, () => ({
     seqByRun: new Map<string, number>(),
     listeners: new Set<(evt: AgentEventPayload) => void>(),
     runContextById: new Map<string, AgentRunContext>(),
+    lifecycleGeneration: randomUUID(),
   }));
+}
+
+function getAgentEventExecutionContext() {
+  return resolveGlobalSingleton<AsyncLocalStorage<AgentEventExecutionContext>>(
+    AGENT_EVENT_EXECUTION_CONTEXT_KEY,
+    () => new AsyncLocalStorage<AgentEventExecutionContext>(),
+  );
+}
+
+/** Runs one execution with immutable ownership inherited by every emitted stream event. */
+export function withAgentRunLifecycleGeneration<T>(lifecycleGeneration: string, run: () => T): T {
+  return getAgentEventExecutionContext().run({ lifecycleGeneration }, run);
+}
+
+export function getAgentEventLifecycleGeneration(): string {
+  return getAgentEventState().lifecycleGeneration;
+}
+
+/** Rejects work that no longer belongs to the active gateway lifecycle. */
+export function assertAgentRunLifecycleGenerationCurrent(lifecycleGeneration: string): void {
+  if (lifecycleGeneration === getAgentEventState().lifecycleGeneration) {
+    return;
+  }
+  const error = new Error("Agent run belongs to a stale gateway lifecycle");
+  error.name = "AbortError";
+  throw error;
+}
+
+/** Captures immutable lifecycle ownership for one admitted execution. */
+export function captureAgentRunLifecycleGeneration(runId: string): string {
+  return (
+    getAgentEventExecutionContext().getStore()?.lifecycleGeneration ??
+    getAgentEventState().runContextById.get(runId)?.lifecycleGeneration ??
+    getAgentEventState().lifecycleGeneration
+  );
+}
+
+/** Starts a new ownership generation before an in-process gateway restart. */
+export function rotateAgentEventLifecycleGeneration(): string {
+  const state = getAgentEventState();
+  state.lifecycleGeneration = randomUUID();
+  return state.lifecycleGeneration;
 }
 
 /** Registers or merges per-run context used by later agent event emissions. */
@@ -170,8 +225,16 @@ export function registerAgentRunContext(runId: string, context: AgentRunContext)
   if (!existing) {
     state.runContextById.set(runId, {
       ...context,
+      lifecycleGeneration: context.lifecycleGeneration ?? state.lifecycleGeneration,
       registeredAt: context.registeredAt ?? Date.now(),
     });
+    return;
+  }
+  if (
+    context.lifecycleGeneration &&
+    existing.lifecycleGeneration &&
+    context.lifecycleGeneration !== existing.lifecycleGeneration
+  ) {
     return;
   }
   if (context.sessionKey && existing.sessionKey !== context.sessionKey) {
@@ -197,14 +260,62 @@ export function registerAgentRunContext(runId: string, context: AgentRunContext)
   }
 }
 
+/** Claims a run id for a newly admitted execution, replacing stale ownership. */
+export function claimAgentRunContext(runId: string, context: AgentRunContext) {
+  if (!runId) {
+    return;
+  }
+  const state = getAgentEventState();
+  const lifecycleGeneration = context.lifecycleGeneration ?? state.lifecycleGeneration;
+  const existing = state.runContextById.get(runId);
+  if (existing?.lifecycleGeneration === lifecycleGeneration) {
+    registerAgentRunContext(runId, {
+      ...context,
+      lifecycleGeneration,
+    });
+    return;
+  }
+  state.runContextById.set(runId, {
+    ...context,
+    lifecycleGeneration,
+    registeredAt: context.registeredAt ?? Date.now(),
+  });
+  state.seqByRun.delete(runId);
+}
+
 /** Returns the currently registered context for a run, if it has not been cleared or swept. */
 export function getAgentRunContext(runId: string) {
   return getAgentEventState().runContextById.get(runId);
 }
 
+/** Lists active runs bound to one current session identity. */
+export function listAgentRunsForSession(params: {
+  sessionKey: string;
+  sessionId?: string;
+}): Array<{ runId: string; lifecycleGeneration: string }> {
+  const runs: Array<{ runId: string; lifecycleGeneration: string }> = [];
+  for (const [runId, context] of getAgentEventState().runContextById) {
+    const matches = context.sessionId
+      ? context.sessionId === params.sessionId
+      : context.sessionKey === params.sessionKey;
+    if (matches && context.lifecycleGeneration) {
+      runs.push({ runId, lifecycleGeneration: context.lifecycleGeneration });
+    }
+  }
+  return runs.toSorted((a, b) =>
+    a.runId === b.runId
+      ? a.lifecycleGeneration.localeCompare(b.lifecycleGeneration)
+      : a.runId.localeCompare(b.runId),
+  );
+}
+
 /** Clears context and sequence state for a run that has ended or been discarded. */
-export function clearAgentRunContext(runId: string) {
+export function clearAgentRunContext(runId: string, lifecycleGeneration?: string) {
   const state = getAgentEventState();
+  const existing = state.runContextById.get(runId);
+  if (lifecycleGeneration && existing && existing.lifecycleGeneration !== lifecycleGeneration) {
+    return;
+  }
   state.runContextById.delete(runId);
   state.seqByRun.delete(runId);
 }
@@ -240,9 +351,22 @@ export function resetAgentRunContextForTest() {
 /** Emits an agent event after assigning per-run sequence, timestamp, and context metadata. */
 export function emitAgentEvent(event: Omit<AgentEventPayload, "seq" | "ts">) {
   const state = getAgentEventState();
+  const context = state.runContextById.get(event.runId);
+  const executionLifecycleGeneration =
+    event.lifecycleGeneration ?? getAgentEventExecutionContext().getStore()?.lifecycleGeneration;
+  const ownedLifecycleGeneration = executionLifecycleGeneration ?? context?.lifecycleGeneration;
+  if (
+    executionLifecycleGeneration &&
+    context?.lifecycleGeneration &&
+    executionLifecycleGeneration !== context.lifecycleGeneration
+  ) {
+    return;
+  }
+  if (ownedLifecycleGeneration && ownedLifecycleGeneration !== state.lifecycleGeneration) {
+    return;
+  }
   const nextSeq = (state.seqByRun.get(event.runId) ?? 0) + 1;
   state.seqByRun.set(event.runId, nextSeq);
-  const context = state.runContextById.get(event.runId);
   if (context) {
     context.lastActiveAt = Date.now();
   }
@@ -261,6 +385,10 @@ export function emitAgentEvent(event: Omit<AgentEventPayload, "seq" | "ts">) {
   // emit time, since the run context can be cleared before the terminal persists.
   const sessionId =
     event.stream === "lifecycle" ? (event.sessionId ?? context?.sessionId) : event.sessionId;
+  const lifecycleGeneration =
+    event.stream === "lifecycle"
+      ? (ownedLifecycleGeneration ?? state.lifecycleGeneration)
+      : ownedLifecycleGeneration;
   const enriched: AgentEventPayload = {
     ...event,
     sessionKey,
@@ -268,6 +396,14 @@ export function emitAgentEvent(event: Omit<AgentEventPayload, "seq" | "ts">) {
     seq: nextSeq,
     ts: Date.now(),
   };
+  if (lifecycleGeneration) {
+    // Persistence needs restart ownership, but agent events are also spread into
+    // public payloads. Keep the internal generation readable without serializing it.
+    Object.defineProperty(enriched, "lifecycleGeneration", {
+      value: lifecycleGeneration,
+      enumerable: false,
+    });
+  }
   notifyListeners(state.listeners, enriched);
 }
 

--- a/src/plugins/host-hook-cleanup.session-store.test.ts
+++ b/src/plugins/host-hook-cleanup.session-store.test.ts
@@ -2,7 +2,11 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { clearSessionStoreCacheForTest, saveSessionStore } from "../config/sessions/store.js";
+import {
+  clearSessionStoreCacheForTest,
+  loadSessionStore,
+  saveSessionStore,
+} from "../config/sessions/store.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import * as jsonFiles from "../infra/json-files.js";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
@@ -55,5 +59,46 @@ describe("plugin host cleanup session stores", () => {
 
     expect(result).toEqual({ cleanupCount: 0, failures: [] });
     expect(writeSpy).not.toHaveBeenCalled();
+  });
+
+  it("can defer persistent session-state cleanup to an atomic owner", async () => {
+    stateDir = await fs.mkdtemp(
+      path.join(resolvePreferredOpenClawTmpDir(), "openclaw-host-cleanup-deferred-"),
+    );
+    previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+    const storePath = path.join(stateDir, "sessions.json");
+    await saveSessionStore(
+      storePath,
+      {
+        "agent:main:main": {
+          sessionId: "session-id",
+          updatedAt: Date.now(),
+          pluginExtensions: {
+            test: {
+              state: { active: true },
+            },
+          },
+        } satisfies SessionEntry,
+      },
+      { skipMaintenance: true },
+    );
+
+    const result = await runPluginHostCleanup({
+      cfg: { session: { store: storePath } },
+      registry: createEmptyPluginRegistry(),
+      reason: "reset",
+      sessionKey: "agent:main:main",
+      skipPersistentSessionState: true,
+    });
+
+    expect(result).toEqual({ cleanupCount: 0, failures: [] });
+    expect(
+      loadSessionStore(storePath, { skipCache: true })["agent:main:main"]?.pluginExtensions,
+    ).toEqual({
+      test: {
+        state: { active: true },
+      },
+    });
   });
 });

--- a/src/plugins/host-hook-cleanup.ts
+++ b/src/plugins/host-hook-cleanup.ts
@@ -246,6 +246,7 @@ async function clearPluginOwnedSessionStores(params: {
   sessionEntrySlotKeys?: ReadonlySet<string>;
   storePaths?: readonly string[];
   resolveStorePaths?: ResolveCleanupSessionStorePaths;
+  shouldCleanup?: () => boolean;
 }): Promise<number> {
   if (!params.pluginId && !params.sessionKey) {
     return 0;
@@ -253,9 +254,15 @@ async function clearPluginOwnedSessionStores(params: {
   const storePaths = resolveCleanupSessionStorePaths(params);
   let cleared = 0;
   for (const storePath of storePaths) {
+    if (params.shouldCleanup && !params.shouldCleanup()) {
+      break;
+    }
     cleared += await updateSessionStore(
       storePath,
       (store) => {
+        if (params.shouldCleanup && !params.shouldCleanup()) {
+          return 0;
+        }
         let clearedInStore = 0;
         const now = Date.now();
         for (const [entryKey, entry] of Object.entries(store)) {
@@ -287,6 +294,7 @@ async function clearPromotedSessionEntrySlotStores(params: {
   sessionEntrySlotKeys: ReadonlySet<string>;
   storePaths?: readonly string[];
   resolveStorePaths?: ResolveCleanupSessionStorePaths;
+  shouldCleanup?: () => boolean;
 }): Promise<number> {
   if ((!params.pluginId && !params.sessionKey) || params.sessionEntrySlotKeys.size === 0) {
     return 0;
@@ -294,9 +302,15 @@ async function clearPromotedSessionEntrySlotStores(params: {
   const storePaths = resolveCleanupSessionStorePaths(params);
   let cleared = 0;
   for (const storePath of storePaths) {
+    if (params.shouldCleanup && !params.shouldCleanup()) {
+      break;
+    }
     cleared += await updateSessionStore(
       storePath,
       (store) => {
+        if (params.shouldCleanup && !params.shouldCleanup()) {
+          return 0;
+        }
         let clearedInStore = 0;
         const now = Date.now();
         for (const [entryKey, entry] of Object.entries(store)) {
@@ -360,6 +374,7 @@ export async function runPluginHostCleanup(params: {
   preserveSchedulerOwnerRegistry?: PluginRegistry | null;
   sessionStorePaths?: readonly string[];
   resolveSessionStorePaths?: ResolveCleanupSessionStorePaths;
+  skipPersistentSessionState?: boolean;
 }): Promise<PluginHostCleanupResult> {
   const failures: PluginHostCleanupFailure[] = [];
   const shouldCleanup = params.shouldCleanup ?? (() => true);
@@ -374,7 +389,7 @@ export async function runPluginHostCleanup(params: {
   const restartPromotedSessionEntrySlotKeys =
     params.restartPromotedSessionEntrySlotKeys ?? sessionEntrySlotKeys;
   let persistentCleanupCount = 0;
-  if (shouldCleanup()) {
+  if (!params.skipPersistentSessionState && shouldCleanup()) {
     try {
       persistentCleanupCount =
         params.reason === "restart"
@@ -385,6 +400,7 @@ export async function runPluginHostCleanup(params: {
               sessionEntrySlotKeys: restartPromotedSessionEntrySlotKeys,
               storePaths: params.sessionStorePaths,
               resolveStorePaths: params.resolveSessionStorePaths,
+              shouldCleanup,
             })
           : await clearPluginOwnedSessionStores({
               cfg: params.cfg ?? getRuntimeConfig(),
@@ -393,6 +409,7 @@ export async function runPluginHostCleanup(params: {
               sessionEntrySlotKeys,
               storePaths: params.sessionStorePaths,
               resolveStorePaths: params.resolveSessionStorePaths,
+              shouldCleanup,
             });
     } catch (error) {
       failures.push({

--- a/src/plugins/session-entry-slot-keys.ts
+++ b/src/plugins/session-entry-slot-keys.ts
@@ -29,6 +29,7 @@ const SESSION_ENTRY_RESERVED_SLOT_KEY_LIST = [
   "pluginOwnerId",
   "systemSent",
   "abortedLastRun",
+  "restartRecoveryRuns",
   "goal",
   "sessionStartedAt",
   "lastInteractionAt",


### PR DESCRIPTION
## Summary

Fixes #91355.

Managed Gateway restart shutdown already drains pending replies and active chat runs before process exit. When that drain times out, the close path aborts active runs with `stopReason: "restart"`, but it did not mark the affected main sessions for restart recovery first. This PR adds a narrow bridge so active main-session refs are persisted through the existing restart-recovery marker before restart abort cleanup clears active run state.

## Source-proven bug this PR fixes

A Windows-side OpenClaw `2026.6.5-beta.2` direct-chat setup/diagnostic turn reached a Gateway restart while the same main turn was still in flight. The first rollout stopped after the restart with no final conclusion and no visible restart-recovery feedback. A second rollout was needed to get the diagnostic result.

The source-level gap is in `src/gateway/server-close.ts`: restart close drain can time out, call `abortActiveRunsForRestart(...)`, and clear active chat-run state without first persisting `abortedLastRun` for the active main session. Other restart paths already use `markRestartAbortedMainSessions(...)`; this close path did not have that bridge.

## What changed

- Collect active restart-drained chat run session keys/session ids immediately before restart abort cleanup.
- Call a best-effort `markMainSessionsAbortedForRestart` hook before aborting active runs.
- Wire the Gateway server close handler to the existing `markRestartAbortedMainSessions(...)` helper with the current runtime config.
- Preserve normal shutdown behavior: the marker only runs on restart shutdown when active runs remain after drain timeout.
- Preserve existing marker policy: subagent/cron/ACP filtering remains inside `markRestartAbortedMainSessions(...)`.

## Scope / non-goals

- No full graceful Gateway restart recovery implementation.
- No shell-command interception or special-casing of `openclaw gateway restart` inside tools.
- No broad CLI restart semantic change.
- No normal SIGTERM/SIGINT shutdown behavior change.
- No message-tool final-selection change; #91330 / #91333 cover that separate bug.

## Related context

- #91355 is the focused issue for this PR.
- #82772 is the adjacent prior fix that marks interrupted sessions before other forced restart paths; this PR extends that idea to restart close drain aborts.

## Real behavior proof

- **Behavior or issue addressed**: Restart close drain timeout could abort active main-session chat runs without durable restart-recovery state, so the next Gateway startup could have no marker to resume or emit restart-recovery feedback for the interrupted turn.

- **Real environment tested**: Local OpenClaw source checkout on macOS/Darwin, branch `agent/xiaozhua/managed-restart-main-session-marker`, commit `79df9459560daff5439fafd0f669291819153ab5`. The observed user-visible incident came from a Windows-side OpenClaw `2026.6.5-beta.2` direct chat and is summarized in #91355 with sensitive values redacted.

- **Exact steps or command run after this patch**:

  ```bash
  node --import tsx /tmp/restart-close-marker-probe.ts
  node scripts/run-vitest.mjs src/gateway/server-close.test.ts
  pnpm exec oxlint src/gateway/server-close.ts src/gateway/server.impl.ts src/gateway/server-close.test.ts
  git diff --check
  pnpm check:no-runtime-action-load-config
  pnpm check:runtime-sidecar-loaders
  pnpm check:import-cycles
  ```

- **Evidence after fix**: Console output from `node --import tsx /tmp/restart-close-marker-probe.ts`. The after-patch source-level probe directly imports the real Gateway close handler, creates an active main-session chat run, forces restart close drain timeout with `drainTimeoutMs: 0`, and records marker/abort order:

  ```json
  {
    "events": [
      "marker",
      "abort"
    ],
    "markerBeforeAbort": true,
    "markerPayload": {
      "reason": "gateway restart shutdown",
      "sessionKeys": [
        "agent:main:main"
      ],
      "sessionIds": [
        "session-id-1"
      ]
    },
    "aborted": true,
    "remainingActiveRuns": 0,
    "warnings": [
      "restart-reply-drain"
    ]
  }
  ```

  The new focused regression covers the same path and also verifies already-aborted stale entries are not included in the marker input.

  Focused test output:

  ```text
  ✓ gateway-server ../../src/gateway/server-close.test.ts (33 tests)
  ✓ gateway-methods ../../src/gateway/server-close.test.ts (33 tests)
  Test Files 2 passed (2)
  Tests 66 passed (66)
  ```

  Additional local checks:

  ```text
  Found 0 warnings and 0 errors.
  git diff --check: no output
  runtime-sidecar-loaders: local runtime sidecar loaders look OK.
  Import cycle check: 0 runtime value cycle(s).
  ```

- **Observed result after fix**: Restart close drain aborts still happen when the drain budget is exhausted, but active main-session refs are marked for restart recovery before the abort clears active run state. Normal shutdowns still do not invoke the marker.

- **What was not tested**: I did not intentionally restart a patched production Gateway during an active live chat turn. `pnpm check:changed` could not run locally because the crabbox/blacksmith wrapper failed its local binary sanity check before running project checks. `pnpm check:test-types` reached the core test tsgo phase and was killed by the local process timeout/SIGKILL without type-error output.

## Tests

- `node --import tsx /tmp/restart-close-marker-probe.ts`
- `node scripts/run-vitest.mjs src/gateway/server-close.test.ts`
- `pnpm exec oxlint src/gateway/server-close.ts src/gateway/server.impl.ts src/gateway/server-close.test.ts`
- `git diff --check`
- `pnpm check:no-runtime-action-load-config`
- `pnpm check:runtime-sidecar-loaders`
- `pnpm check:import-cycles`

## Local gates attempted but unavailable

- `pnpm check:changed` — blocked before project checks by local crabbox/blacksmith sanity failure.
- `pnpm check:test-types` — reached `pnpm tsgo:core:test` and was killed by local timeout/SIGKILL without type-error output.
