### PR TITLE
fix(cron): allow clearing payload.model via update (fixes #91298)

### DIFF
--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -180,6 +180,8 @@ Model-selection precedence for isolated jobs is:
 3. User-selected stored cron session model override
 4. Agent/default model selection
 
+To remove a stored `model` override from an existing job, send a cron update with `payload.model` set to `null` (an empty string works too). The job then falls back to the remaining selection steps. Omitting `model` from an update preserves the current override.
+
 Fast mode follows the resolved live selection too. If the selected model config has `params.fastMode`, isolated cron uses that by default. A stored session `fastMode` override still wins over config in either direction.
 
 If an isolated run hits a live model-switch handoff, cron retries with the switched provider/model and persists that live selection for the active run before retrying. When the switch also carries a new auth profile, cron persists that auth profile override for the active run too. Retries are bounded: after the initial attempt plus 2 switch retries, cron aborts instead of looping forever.

--- a/packages/gateway-protocol/src/schema/cron.ts
+++ b/packages/gateway-protocol/src/schema/cron.ts
@@ -10,12 +10,16 @@ import { NonEmptyString } from "./primitives.js";
  */
 
 /** Builds create/patch payload variants while preserving per-call field optionality. */
-function cronAgentTurnPayloadSchema(params: { message: TSchema; toolsAllow: TSchema }) {
+function cronAgentTurnPayloadSchema(params: {
+  message: TSchema;
+  toolsAllow: TSchema;
+  model: TSchema;
+}) {
   return Type.Object(
     {
       kind: Type.Literal("agentTurn"),
       message: params.message,
-      model: Type.Optional(Type.String()),
+      model: Type.Optional(params.model),
       fallbacks: Type.Optional(Type.Array(Type.String())),
       thinking: Type.Optional(Type.String()),
       timeoutSeconds: Type.Optional(Type.Number({ minimum: 0 })),
@@ -228,6 +232,7 @@ export const CronPayloadSchema = Type.Union([
   cronAgentTurnPayloadSchema({
     message: NonEmptyString,
     toolsAllow: Type.Array(Type.String()),
+    model: Type.String(),
   }),
   cronCommandPayloadSchema({
     argv: Type.Array(NonEmptyString, { minItems: 1 }),
@@ -246,6 +251,7 @@ export const CronPayloadPatchSchema = Type.Union([
   cronAgentTurnPayloadSchema({
     message: Type.Optional(NonEmptyString),
     toolsAllow: Type.Union([Type.Array(Type.String()), Type.Null()]),
+    model: Type.Union([Type.String(), Type.Null()]),
   }),
   cronCommandPayloadSchema({
     argv: Type.Optional(Type.Array(NonEmptyString, { minItems: 1 })),

--- a/src/cron/normalize.test.ts
+++ b/src/cron/normalize.test.ts
@@ -832,6 +832,32 @@ describe("normalizeCronJobPatch", () => {
     expect(validateCronUpdateParams({ id: "job-1", patch: normalized })).toBe(true);
   });
 
+  it("preserves null model so patches can clear the model override", () => {
+    const normalized = normalizeCronJobPatch({
+      payload: {
+        kind: "agentTurn",
+        model: null,
+      },
+    }) as unknown as Record<string, unknown>;
+
+    const payload = normalized.payload as Record<string, unknown>;
+    expect(payload.kind).toBe("agentTurn");
+    expect(payload.model).toBeNull();
+    expect(validateCronUpdateParams({ id: "job-1", patch: normalized })).toBe(true);
+  });
+
+  it("treats an empty-string model patch as a clear signal", () => {
+    const normalized = normalizeCronJobPatch({
+      payload: {
+        kind: "agentTurn",
+        model: "   ",
+      },
+    }) as unknown as Record<string, unknown>;
+
+    const payload = normalized.payload as Record<string, unknown>;
+    expect(payload.model).toBeNull();
+  });
+
   it("preserves null sessionKey patches and trims string values", () => {
     const trimmed = normalizeCronJobPatch({
       sessionKey: "  agent:main:telegram:group:-100123  ",

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -170,11 +170,17 @@ function coercePayload(payload: UnknownRecord) {
     }
   }
   if ("model" in next) {
-    const model = parseOptionalField(TrimmedNonEmptyStringFieldSchema, next.model);
-    if (model !== undefined) {
-      next.model = model;
+    if (next.model === null || (typeof next.model === "string" && next.model.trim().length === 0)) {
+      // Patch clear: null or empty string drops the override so the job inherits
+      // the agent/global default model. Mirrors toolsAllow null handling.
+      next.model = null;
     } else {
-      delete next.model;
+      const model = parseOptionalField(TrimmedNonEmptyStringFieldSchema, next.model);
+      if (model !== undefined) {
+        next.model = model;
+      } else {
+        delete next.model;
+      }
     }
   }
   if ("thinking" in next) {

--- a/src/cron/service.jobs.test.ts
+++ b/src/cron/service.jobs.test.ts
@@ -294,6 +294,52 @@ describe("applyJobPatch", () => {
     }
   });
 
+  it("clears agentTurn payload.model when patched with null", () => {
+    const job = createIsolatedAgentTurnJob("job-clear-model", {
+      mode: "announce",
+      channel: "telegram",
+    });
+    job.payload = { kind: "agentTurn", message: "do it", model: "openrouter/some/model" };
+
+    applyJobPatch(job, { payload: { kind: "agentTurn", model: null } });
+
+    expect(job.payload.kind).toBe("agentTurn");
+    if (job.payload.kind === "agentTurn") {
+      expect(job.payload.model).toBeUndefined();
+    }
+  });
+
+  it("preserves agentTurn payload.model when the patch omits it", () => {
+    const job = createIsolatedAgentTurnJob("job-keep-model", {
+      mode: "announce",
+      channel: "telegram",
+    });
+    job.payload = { kind: "agentTurn", message: "do it", model: "openrouter/some/model" };
+
+    applyJobPatch(job, { payload: { kind: "agentTurn", thinking: "high" } });
+
+    expect(job.payload.kind).toBe("agentTurn");
+    if (job.payload.kind === "agentTurn") {
+      expect(job.payload.model).toBe("openrouter/some/model");
+      expect(job.payload.thinking).toBe("high");
+    }
+  });
+
+  it("updates agentTurn payload.model when patched with a string", () => {
+    const job = createIsolatedAgentTurnJob("job-update-model", {
+      mode: "announce",
+      channel: "telegram",
+    });
+    job.payload = { kind: "agentTurn", message: "do it", model: "old/model" };
+
+    applyJobPatch(job, { payload: { kind: "agentTurn", model: "new/model" } });
+
+    expect(job.payload.kind).toBe("agentTurn");
+    if (job.payload.kind === "agentTurn") {
+      expect(job.payload.model).toBe("new/model");
+    }
+  });
+
   it("persists agentTurn payload.fallbacks updates when editing existing jobs", () => {
     const job = createIsolatedAgentTurnJob("job-fallbacks", {
       mode: "announce",

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -923,6 +923,9 @@ function mergeCronPayload(existing: CronPayload, patch: CronPayloadPatch): CronP
   }
   if (typeof patch.model === "string") {
     next.model = patch.model;
+  } else if (patch.model === null) {
+    // Explicit clear: drop the override so the job inherits the agent/global default.
+    delete next.model;
   }
   if (Array.isArray(patch.fallbacks)) {
     next.fallbacks = patch.fallbacks;
@@ -978,7 +981,8 @@ function buildPayloadFromPatch(patch: CronPayloadPatch): CronPayload {
   return {
     kind: "agentTurn",
     message: patch.message,
-    model: patch.model,
+    // A cleared (null) model becomes "unset" on a full payload rebuild.
+    model: typeof patch.model === "string" ? patch.model : undefined,
     fallbacks: patch.fallbacks,
     toolsAllow: Array.isArray(patch.toolsAllow) ? patch.toolsAllow : undefined,
     thinking: patch.thinking,

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -256,8 +256,11 @@ type CronAgentTurnPayload = {
 
 type CronAgentTurnPayloadPatch = {
   kind: "agentTurn";
-} & Partial<Omit<CronAgentTurnPayloadFields, "toolsAllow">> & {
+} & Partial<Omit<CronAgentTurnPayloadFields, "toolsAllow" | "model">> & {
     toolsAllow?: string[] | null;
+    // `null` (or an empty string) clears the override so the job inherits the
+    // agent/global default model. Omitting `model` preserves the current value.
+    model?: string | null;
   };
 
 type CronCommandPayloadFields = {


### PR DESCRIPTION
## Summary

- **Problem:** The cron `update` API can't clear an `agentTurn` job's `payload.model`. `model: null` and `model: ""` are silently dropped, and omitting `model` merge-preserves the old value — so a hardcoded model stays pinned even after the agent's default model changes.
- **Why it matters:** Rotating your active model profile leaves existing cron jobs running on the old model. The only workarounds are bad: re-pin a current model (still hardcoded), or delete + recreate the job (loses `lastRunAtMs`, `consecutiveErrors`, `createdAtMs`, etc.).
- **What changed:** `payload.model: null` (or `""`) now clears the override so the job inherits the agent/global default. This gives `model` the **exact same nullable-clear treatment `toolsAllow` already has**, across the four layers that each dropped the clear signal: protocol schema (`packages/gateway-protocol/src/schema/cron.ts`) → patch type (`src/cron/types.ts`) → normalization (`src/cron/normalize.ts`) → merge (`src/cron/service/jobs.ts`).
- **What did NOT change (scope boundary):** Omitting `model` still preserves it (merge semantics unchanged). Create still rejects `null` (string-only schema). `payload.fallbacks` is untouched — it already supports `[]` to clear and is out of scope here.

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway / orchestration (cron)
- [x] API / contracts

## Linked Issue

- Closes #91298

## User-visible / Behavior Changes

`cron update` with `patch.payload.model = null` (or an empty string) now clears the model override and the job falls back to the agent/global default. Omitting `model` from an update preserves the current value. Documented in `docs/automation/cron-jobs.md`.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Steps

1. Create an isolated `agentTurn` cron job with `payload.model` set to a specific model.
2. `cron update` the job with `patch: { payload: { kind: "agentTurn", model: null } }`.

### Expected

- `payload.model` is removed; the job inherits the agent/global default model.

### Actual (before this PR)

- `model: null` is dropped during normalization and the merge only applies string models, so the old model stays pinned.

## Evidence

- [x] **Failing test before + passing after.** Reverting the merge null-clear turns the new `clears agentTurn payload.model when patched with null` test red (`AssertionError: expected 'openrouter/some/model' to be undefined`); restoring it makes it green.
- 5 new regression tests across `src/cron/normalize.test.ts` (preserve `null`, treat `""` as clear) and `src/cron/service.jobs.test.ts` (clear via `null`, preserve on omit, update via string).
- Full local run (Node 22): **372 tests pass** — `src/cron/{normalize,service.jobs,cron-protocol-conformance}.test.ts`, `src/agents/tools/cron-tool.test.ts`, `src/gateway/server.cron.test.ts`, and `packages/gateway-protocol/src/cron-validators.test.ts`. `tsgo` typecheck: 0 errors. oxlint + oxfmt clean on all touched files.

## Human Verification

- Verified scenarios: model cleared via `null`; cleared via `""`; preserved when the patch omits it; updated when a string is provided; the protocol patch schema accepts `model: null` (via `validateCronUpdateParams`).
- Edge cases checked: kind-switch payload rebuild coerces a cleared `null` model to "unset".
- Not verified: a live end-to-end gateway round-trip (verified at unit/source level only).

## Compatibility / Migration

- Backward compatible? Yes — additive, and consistent with the existing `toolsAllow` clear semantics. `model: null` was previously rejected/ignored; valid existing patches behave identically.
- Config/env changes? No
- Migration needed? No

## AI assistance

AI-assisted (Claude Code). Fully tested locally (unit + source-level, 372 tests + typecheck/lint/format). Author understands the change. Local `codex review` was unavailable in this environment; the GitHub Codex review on this PR covers that pass.

## Risks and Mitigations

- Risk: a caller relying on the old behavior where `model: null` was a silent no-op.
  - Mitigation: that path returned an unchanged job (clearing was impossible), so no caller could depend on a "cleared" outcome; passing `null` now does the documented, expected thing, identical to how `toolsAllow: null` already behaves.

## Real behavior proof

Behavior addressed: cron `update` with `patch.payload.model = null` (or empty string) now clears the model override so the job inherits the agent/global default; omitting `model` preserves it.
Real environment tested: Local unit + source verification on Node 22.22.1 (macOS). No live gateway/channel run.
Exact steps or command run after this patch: `node node_modules/vitest/vitest.mjs run src/cron/normalize.test.ts src/cron/service.jobs.test.ts src/cron/cron-protocol-conformance.test.ts src/agents/tools/cron-tool.test.ts src/gateway/server.cron.test.ts packages/gateway-protocol/src/cron-validators.test.ts` plus `pnpm tsgo`, oxlint, oxfmt.
Evidence after fix: 372 tests pass incl. new clear-via-null / clear-via-empty-string / preserve-on-omit / update-via-string tests; reverting the merge null-clear turns the clear test red (`expected 'openrouter/some/model' to be undefined`).
Observed result after fix: `payload.model` removed; job falls back to agent/global default; protocol patch schema accepts `model: null`.
What was not tested: a live end-to-end gateway cron update round-trip (verified at unit/source level only).
