### PR TITLE
fix(compaction): lower default timeout from 900s to 180s, preserve explicit config

### DIFF
--- a/docs/gateway/config-agents.md
+++ b/docs/gateway/config-agents.md
@@ -661,7 +661,7 @@ Periodic heartbeat runs.
 
 - `mode`: `default` or `safeguard` (chunked summarization for long histories). See [Compaction](/concepts/compaction).
 - `provider`: id of a registered compaction provider plugin. When set, the provider's `summarize()` is called instead of built-in LLM summarization. Falls back to built-in on failure. Setting a provider forces `mode: "safeguard"`. See [Compaction](/concepts/compaction).
-- `timeoutSeconds`: maximum seconds allowed for a single compaction operation before OpenClaw aborts it. Default: `180`. Values above `600` are capped at runtime to prevent long session write-lock holds.
+- `timeoutSeconds`: maximum seconds allowed for a single compaction operation before OpenClaw aborts it. Default: `180`.
 - `keepRecentTokens`: agent cut-point budget for keeping the most recent transcript tail verbatim. Manual `/compact` honors this when explicitly set; otherwise manual compaction is a hard checkpoint.
 - `identifierPolicy`: `strict` (default), `off`, or `custom`. `strict` prepends built-in opaque identifier retention guidance during compaction summarization.
 - `identifierInstructions`: optional custom identifier-preservation text used when `identifierPolicy=custom`.

--- a/docs/gateway/config-agents.md
+++ b/docs/gateway/config-agents.md
@@ -634,7 +634,7 @@ Periodic heartbeat runs.
       compaction: {
         mode: "safeguard", // default | safeguard
         provider: "my-provider", // id of a registered compaction provider plugin (optional)
-        timeoutSeconds: 900,
+        timeoutSeconds: 180,
         reserveTokensFloor: 24000,
         keepRecentTokens: 50000,
         identifierPolicy: "strict", // strict | off | custom

--- a/docs/gateway/config-agents.md
+++ b/docs/gateway/config-agents.md
@@ -661,7 +661,7 @@ Periodic heartbeat runs.
 
 - `mode`: `default` or `safeguard` (chunked summarization for long histories). See [Compaction](/concepts/compaction).
 - `provider`: id of a registered compaction provider plugin. When set, the provider's `summarize()` is called instead of built-in LLM summarization. Falls back to built-in on failure. Setting a provider forces `mode: "safeguard"`. See [Compaction](/concepts/compaction).
-- `timeoutSeconds`: maximum seconds allowed for a single compaction operation before OpenClaw aborts it. Default: `900`.
+- `timeoutSeconds`: maximum seconds allowed for a single compaction operation before OpenClaw aborts it. Default: `180`. Values above `600` are capped at runtime to prevent long session write-lock holds.
 - `keepRecentTokens`: agent cut-point budget for keeping the most recent transcript tail verbatim. Manual `/compact` honors this when explicitly set; otherwise manual compaction is a hard checkpoint.
 - `identifierPolicy`: `strict` (default), `off`, or `custom`. `strict` prepends built-in opaque identifier retention guidance during compaction summarization.
 - `identifierInstructions`: optional custom identifier-preservation text used when `identifierPolicy=custom`.

--- a/src/agents/embedded-agent-runner.compaction-safety-timeout.test.ts
+++ b/src/agents/embedded-agent-runner.compaction-safety-timeout.test.ts
@@ -127,9 +127,17 @@ describe("resolveCompactionTimeoutMs", () => {
   it("converts timeoutSeconds to milliseconds", () => {
     expect(
       resolveCompactionTimeoutMs({
+        agents: { defaults: { compaction: { timeoutSeconds: 120 } } },
+      }),
+    ).toBe(120_000);
+  });
+
+  it("caps configured timeoutSeconds at 600", () => {
+    expect(
+      resolveCompactionTimeoutMs({
         agents: { defaults: { compaction: { timeoutSeconds: 1800 } } },
       }),
-    ).toBe(1_800_000);
+    ).toBe(600_000);
   });
 
   it("floors fractional seconds", () => {

--- a/src/agents/embedded-agent-runner.compaction-safety-timeout.test.ts
+++ b/src/agents/embedded-agent-runner.compaction-safety-timeout.test.ts
@@ -132,12 +132,12 @@ describe("resolveCompactionTimeoutMs", () => {
     ).toBe(120_000);
   });
 
-  it("caps configured timeoutSeconds at 600", () => {
+  it("preserves explicit timeoutSeconds above 600", () => {
     expect(
       resolveCompactionTimeoutMs({
         agents: { defaults: { compaction: { timeoutSeconds: 1800 } } },
       }),
-    ).toBe(600_000);
+    ).toBe(1_800_000);
   });
 
   it("floors fractional seconds", () => {

--- a/src/agents/embedded-agent-runner/compaction-safety-timeout.ts
+++ b/src/agents/embedded-agent-runner/compaction-safety-timeout.ts
@@ -6,7 +6,8 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { CompactResult, ContextEngine } from "../../context-engine/types.js";
 import { withTimeout } from "../../node-host/with-timeout.js";
 
-export const EMBEDDED_COMPACTION_TIMEOUT_MS = 900_000;
+export const EMBEDDED_COMPACTION_TIMEOUT_MS = 180_000;
+const MAX_COMPACTION_TIMEOUT_SECONDS = 600;
 
 function createAbortError(signal: AbortSignal): Error {
   const reason = "reason" in signal ? signal.reason : undefined;
@@ -57,10 +58,14 @@ function composeAbortSignals(...signals: Array<AbortSignal | undefined>): {
 }
 
 export function resolveCompactionTimeoutMs(cfg?: OpenClawConfig): number {
+  const rawSeconds = cfg?.agents?.defaults?.compaction?.timeoutSeconds;
+  const clampedSeconds =
+    typeof rawSeconds === "number" && Number.isFinite(rawSeconds) && rawSeconds > 0
+      ? Math.min(rawSeconds, MAX_COMPACTION_TIMEOUT_SECONDS)
+      : rawSeconds;
   return (
-    finiteSecondsToTimerSafeMilliseconds(cfg?.agents?.defaults?.compaction?.timeoutSeconds, {
-      floorSeconds: true,
-    }) ?? EMBEDDED_COMPACTION_TIMEOUT_MS
+    finiteSecondsToTimerSafeMilliseconds(clampedSeconds, { floorSeconds: true }) ??
+    EMBEDDED_COMPACTION_TIMEOUT_MS
   );
 }
 

--- a/src/agents/embedded-agent-runner/compaction-safety-timeout.ts
+++ b/src/agents/embedded-agent-runner/compaction-safety-timeout.ts
@@ -7,7 +7,6 @@ import type { CompactResult, ContextEngine } from "../../context-engine/types.js
 import { withTimeout } from "../../node-host/with-timeout.js";
 
 export const EMBEDDED_COMPACTION_TIMEOUT_MS = 180_000;
-const MAX_COMPACTION_TIMEOUT_SECONDS = 600;
 
 function createAbortError(signal: AbortSignal): Error {
   const reason = "reason" in signal ? signal.reason : undefined;
@@ -58,14 +57,10 @@ function composeAbortSignals(...signals: Array<AbortSignal | undefined>): {
 }
 
 export function resolveCompactionTimeoutMs(cfg?: OpenClawConfig): number {
-  const rawSeconds = cfg?.agents?.defaults?.compaction?.timeoutSeconds;
-  const clampedSeconds =
-    typeof rawSeconds === "number" && Number.isFinite(rawSeconds) && rawSeconds > 0
-      ? Math.min(rawSeconds, MAX_COMPACTION_TIMEOUT_SECONDS)
-      : rawSeconds;
   return (
-    finiteSecondsToTimerSafeMilliseconds(clampedSeconds, { floorSeconds: true }) ??
-    EMBEDDED_COMPACTION_TIMEOUT_MS
+    finiteSecondsToTimerSafeMilliseconds(cfg?.agents?.defaults?.compaction?.timeoutSeconds, {
+      floorSeconds: true,
+    }) ?? EMBEDDED_COMPACTION_TIMEOUT_MS
   );
 }
 

--- a/src/agents/embedded-agent-runner/run/attempt.run-decisions.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.run-decisions.ts
@@ -20,7 +20,7 @@ export function resolveEmbeddedAttemptSessionWriteLockOptions(params: {
   env?: NodeJS.ProcessEnv;
 }): { timeoutMs: number; staleMs: number; maxHoldMs: number } {
   // Bound embedded-attempt lock holds to the compaction window, not the full run timeout.
-  // With defaults this permits roughly 900s compaction time plus the shared 120s
+  // With defaults this permits roughly 180s compaction time plus the shared 120s
   // timeout grace before the watchdog releases a stuck live-process lock.
   return resolveSessionWriteLockOptions(params.config, {
     env: params.env,

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1494,7 +1494,7 @@ export const FIELD_HELP: Record<string, string> = {
   "agents.defaults.compaction.postCompactionSections":
     'Opt-in AGENTS.md H2/H3 section names re-injected after compaction so the agent reruns critical startup guidance. Leave unset or set [] to disable reinjection. Explicitly set ["Session Startup", "Red Lines"] to enable the legacy default pair with fallback to older "Every Session"/"Safety" headings. Enabling this can duplicate project context already present in the compaction summary.',
   "agents.defaults.compaction.timeoutSeconds":
-    "Maximum time in seconds allowed for a single compaction operation before it is aborted (default: 180, max: 600). Increase this for very large sessions that need more time to summarize, or decrease it to fail faster on unresponsive models.",
+    "Maximum time in seconds allowed for a single compaction operation before it is aborted (default: 180). Increase this for very large sessions that need more time to summarize, or decrease it to fail faster on unresponsive models.",
   "agents.defaults.compaction.model":
     "Optional provider/model override used only for compaction summarization. Set this when you want compaction to run on a different model than the session default, and leave it unset to keep using the primary agent model.",
   "agents.defaults.compaction.truncateAfterCompaction":

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1494,7 +1494,7 @@ export const FIELD_HELP: Record<string, string> = {
   "agents.defaults.compaction.postCompactionSections":
     'Opt-in AGENTS.md H2/H3 section names re-injected after compaction so the agent reruns critical startup guidance. Leave unset or set [] to disable reinjection. Explicitly set ["Session Startup", "Red Lines"] to enable the legacy default pair with fallback to older "Every Session"/"Safety" headings. Enabling this can duplicate project context already present in the compaction summary.',
   "agents.defaults.compaction.timeoutSeconds":
-    "Maximum time in seconds allowed for a single compaction operation before it is aborted (default: 900). Increase this for very large sessions that need more time to summarize, or decrease it to fail faster on unresponsive models.",
+    "Maximum time in seconds allowed for a single compaction operation before it is aborted (default: 180, max: 600). Increase this for very large sessions that need more time to summarize, or decrease it to fail faster on unresponsive models.",
   "agents.defaults.compaction.model":
     "Optional provider/model override used only for compaction summarization. Set this when you want compaction to run on a different model than the session default, and leave it unset to keep using the primary agent model.",
   "agents.defaults.compaction.truncateAfterCompaction":

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -541,7 +541,7 @@ export type AgentCompactionConfig = {
    * When set, compaction uses this model instead of the agent's primary model.
    * Falls back to the primary model when unset. */
   model?: string;
-  /** Maximum time in seconds for a single compaction operation (default: 180, capped at 600 at runtime). */
+  /** Maximum time in seconds for a single compaction operation (default: 180). */
   timeoutSeconds?: number;
   /**
    * Id of a registered compaction provider plugin.

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -541,7 +541,7 @@ export type AgentCompactionConfig = {
    * When set, compaction uses this model instead of the agent's primary model.
    * Falls back to the primary model when unset. */
   model?: string;
-  /** Maximum time in seconds for a single compaction operation (default: 900). */
+  /** Maximum time in seconds for a single compaction operation (default: 180, capped at 600 at runtime). */
   timeoutSeconds?: number;
   /**
    * Id of a registered compaction provider plugin.

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -185,7 +185,7 @@ export const AgentDefaultsSchema = z
         postIndexSync: z.enum(["off", "async", "await"]).optional(),
         postCompactionSections: z.array(z.string()).optional(),
         model: z.string().optional(),
-        timeoutSeconds: z.number().int().positive().optional(),
+        timeoutSeconds: z.number().int().positive().max(600).optional(),
         memoryFlush: z
           .object({
             enabled: z.boolean().optional(),

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -185,7 +185,7 @@ export const AgentDefaultsSchema = z
         postIndexSync: z.enum(["off", "async", "await"]).optional(),
         postCompactionSections: z.array(z.string()).optional(),
         model: z.string().optional(),
-        timeoutSeconds: z.number().int().positive().max(600).optional(),
+        timeoutSeconds: z.number().int().positive().optional(),
         memoryFlush: z
           .object({
             enabled: z.boolean().optional(),


### PR DESCRIPTION
## Summary

Fixes #91358: large-session compaction no longer holds the session write lock for up to 17 minutes by default.

- Lowers the default compaction safety timeout from 900s (15 min) to 180s (3 min).
- Preserves explicit `agents.defaults.compaction.timeoutSeconds` config values as-is; no runtime clamping is applied.
- Updates help text and public docs to reflect the new default.

With the previous default, `resolveSessionLockMaxHoldFromTimeout` produced a lock max-hold of 1,020,000ms (17 min), which guaranteed that any client with the default 60s acquire timeout would fail repeatedly while a large-session compaction ran. With the new default, max-hold becomes 300,000ms (5 min).

## Changes

- `src/agents/embedded-agent-runner/compaction-safety-timeout.ts`
  - `EMBEDDED_COMPACTION_TIMEOUT_MS`: `900_000` → `180_000`.
  - `resolveCompactionTimeoutMs` preserves finite positive configured values exactly; non-finite / non-positive values fall back to the default. No runtime cap is enforced.

- `src/agents/embedded-agent-runner/run/attempt.run-decisions.ts`
  - Comment updated to reflect 180s default instead of 900s.

- `src/config/schema.help.ts`
  - Updates help text: `(default: 900)` → `(default: 180)`.

- `docs/gateway/config-agents.md`
  - Updates compaction `timeoutSeconds` docs: default `180`. Removes the "Values above 600 are capped at runtime" sentence.

- `src/agents/embedded-agent-runner.compaction-safety-timeout.test.ts`
  - Adjusts conversion test to use `1800` (preserved as `1_800_000ms`).
  - Removes the regression test asserting values above 600 are clamped (that behavior was removed).

## Verification

```bash
pnpm test src/agents/embedded-agent-runner.compaction-safety-timeout.test.ts
# 22 passed

pnpm test src/agents/session-write-lock.test.ts
# 53 passed

npx oxlint --import-plugin --config .oxlintrc.json   src/agents/embedded-agent-runner/compaction-safety-timeout.ts   src/agents/embedded-agent-runner.compaction-safety-timeout.test.ts   src/config/schema.help.ts   docs/gateway/config-agents.md
# clean
```

## Real behavior proof

**Behavior addressed:** The default embedded compaction safety timeout was 900s, which combined with the 120s session write-lock grace produced a ~17-minute lock max-hold. Large-session compactions blocked all other clients with default 60s acquire timeouts for an unbounded duration.

**Real environment tested:** Local OpenClaw source checkout at commit `90d47ddfe0` on Node v22.22.0, running the actual runtime resolver (not a unit-test wrapper).

**Exact steps or command run after this patch:**

```bash
pnpm exec tsx scripts/repro/91361-compaction-timeout-proof.mjs
```

Script content: `scripts/repro/91361-compaction-timeout-proof.mjs`

**Evidence after fix:**

```
=== PR #91361 Compaction timeout proof ===

Default timeout (no config): 180000 ms
Expected: 180000 ms (180 seconds)

Configured 120s -> 120000 ms (expected: 120000 ms)
Configured 600s -> 600000 ms (expected: 600000 ms)
Configured 1800s -> 1800000 ms (expected: 1800000 ms, preserved)

PASS: timeout default lowered and explicit config preserved.
```

**Observed result after fix:**
- Unconfigured installs now resolve to `180_000ms` (3 min) instead of `900_000ms` (15 min).
- `timeoutSeconds: 120` is preserved as `120_000ms`.
- `timeoutSeconds: 1800` is preserved as `1_800_000ms` (30 min); no runtime clamp is applied.
- Combined with the existing `120_000ms` lock grace, the session write-lock max-hold drops from ~17 min to ~5 min by default.

**What was not tested:** A live 10–16MB session compaction run end-to-end; this proof exercises the exact runtime resolver that determines the compaction timeout used during real session compactions.

## Upgrade tradeoff

Unconfigured installs upgrading from a shipped release with the 900s default will see compaction abort after 180s instead of 900s. Agents with sessions whose compaction legitimately needs more than 3 minutes should set an explicit `agents.defaults.compaction.timeoutSeconds` value in `openclaw.json` to opt into a longer budget.

Closes #91358