### PR TITLE
fix(exec): handle background exec completion without poll race

### DIFF
--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -34,7 +34,7 @@ export {
   normalizeExecSecurity,
   normalizeExecTarget,
 } from "../infra/exec-approvals.js";
-import { logWarn } from "../logger.js";
+import { logInfo, logWarn } from "../logger.js";
 import type { ManagedRun } from "../process/supervisor/index.js";
 import { getProcessSupervisor } from "../process/supervisor/index.js";
 import type { RunExit, TerminationReason } from "../process/supervisor/types.js";
@@ -346,11 +346,21 @@ export function applyShellPath(env: Record<string, string>, shellPath?: string |
 }
 
 function maybeNotifyOnExit(session: ProcessSession, status: "completed" | "failed") {
-  if (!session.backgrounded || !session.notifyOnExit || session.exitNotified) {
+  if (!session.backgrounded) {
+    logInfo(`[bg-exec] maybeNotifyOnExit skip: not backgrounded (id=${session.id})`);
+    return;
+  }
+  if (!session.notifyOnExit) {
+    logInfo(`[bg-exec] maybeNotifyOnExit skip: notifyOnExit disabled (id=${session.id})`);
+    return;
+  }
+  if (session.exitNotified) {
+    logInfo(`[bg-exec] maybeNotifyOnExit skip: already notified (id=${session.id})`);
     return;
   }
   const sessionKey = session.sessionKey?.trim();
   if (!sessionKey) {
+    logInfo(`[bg-exec] maybeNotifyOnExit skip: no sessionKey (id=${session.id})`);
     return;
   }
   session.exitNotified = true;
@@ -361,14 +371,19 @@ function maybeNotifyOnExit(session: ProcessSession, status: "completed" | "faile
     tail(session.tail || session.aggregated || "", DEFAULT_NOTIFY_TAIL_CHARS),
   );
   if (status === "failed" && session.exitReason === "manual-cancel" && !output) {
+    logInfo(`[bg-exec] maybeNotifyOnExit skip: manual-cancel no output (id=${session.id})`);
     return;
   }
   if (status === "completed" && !output && session.notifyOnExitEmptySuccess !== true) {
+    logInfo(
+      `[bg-exec] maybeNotifyOnExit skip: completed no output and notifyOnExitEmptySuccess not set (id=${session.id})`,
+    );
     return;
   }
   const summary = output
     ? `Exec ${status} (${session.id.slice(0, 8)}, ${exitLabel}) :: ${output}`
     : `Exec ${status} (${session.id.slice(0, 8)}, ${exitLabel})`;
+  logInfo(`[bg-exec] maybeNotifyOnExit enqueue: "${summary}" key=${sessionKey}`);
   const eventRouting = session.eventRouting ?? {
     mainKey: session.mainKey,
     sessionScope: session.sessionScope,
@@ -380,6 +395,7 @@ function maybeNotifyOnExit(session: ProcessSession, status: "completed" | "faile
   // Subagent sessions receive exec results via process poll and announce flow;
   // the heartbeat would fall back to the main session and cause spurious wakes.
   if (!isSubagentSessionKey(sessionKey)) {
+    logInfo(`[bg-exec] maybeNotifyOnExit requestHeartbeat key=${sessionKey}`);
     requestHeartbeat(
       scopedHeartbeatWakeOptionsForPolicy(
         sessionKey,
@@ -392,6 +408,8 @@ function maybeNotifyOnExit(session: ProcessSession, status: "completed" | "faile
         eventRouting,
       ),
     );
+  } else {
+    logInfo(`[bg-exec] maybeNotifyOnExit skip heartbeat: subagent session key=${sessionKey}`);
   }
 }
 

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -1908,15 +1908,24 @@ export function createExecTool(
       }
 
       return new Promise<AgentToolResult<ExecToolDetails>>((resolve, reject) => {
-        const resolveRunning = () => {
+        const resolveRunning = (backgrounded?: boolean) => {
           cleanupToolRunListeners();
+          const warning = getWarningText();
+          // Only promise auto-notification when notifyOnExit is enabled.
+          // When disabled, the agent needs to poll for results manually.
+          const canNotify = backgrounded && notifyOnExit;
+          const text = canNotify
+            ? `${warning}Command running in background (session ${run.session.id}, pid ${
+                run.session.pid ?? "n/a"
+              }). The system will automatically notify you when it completes. Continue with other work.`
+            : `${warning}Command still running (session ${run.session.id}, pid ${
+                run.session.pid ?? "n/a"
+              }). Use process (list/poll/log/write/send-keys/submit/paste/kill/clear/remove) for follow-up.`;
           resolve({
             content: [
               {
                 type: "text",
-                text: `${getWarningText()}Command still running (session ${run.session.id}, pid ${
-                  run.session.pid ?? "n/a"
-                }). Use process (list/poll/log/write/send-keys/submit/paste/kill/clear/remove) for follow-up.`,
+                text,
               },
             ],
             details: {
@@ -1936,7 +1945,7 @@ export function createExecTool(
           }
           yielded = true;
           markBackgrounded(run.session);
-          resolveRunning();
+          resolveRunning(true);
         };
 
         if (allowBackground && yieldWindow !== null) {
@@ -1949,7 +1958,7 @@ export function createExecTool(
               }
               yielded = true;
               markBackgrounded(run.session);
-              resolveRunning();
+              resolveRunning(true);
             }, yieldWindow);
           }
         }

--- a/src/infra/heartbeat-events-filter.test.ts
+++ b/src/infra/heartbeat-events-filter.test.ts
@@ -1,6 +1,14 @@
 // Covers heartbeat event prompt filtering.
 import { describe, expect, it } from "vitest";
 import {
+  addSession,
+  createSessionSlug,
+  markBackgrounded,
+  markExited,
+  resetProcessRegistryForTests,
+} from "../agents/bash-process-registry.js";
+import type { ProcessSession } from "../agents/bash-process-registry.js";
+import {
   buildCronEventPrompt,
   buildExecEventPrompt,
   isCronSystemEvent,
@@ -126,6 +134,94 @@ describe("heartbeat event prompts", () => {
     expect(prompt).toContain("heartbeat_respond");
     expect(prompt).toContain("notify=false");
     expect(prompt).not.toContain("HEARTBEAT_OK");
+  });
+
+  it("uses task-continuation prompt for gateway-format backgrounded exec completions", async () => {
+    const sessionId = createSessionSlug();
+    const session: ProcessSession = {
+      id: sessionId,
+      command: "test",
+      startedAt: Date.now(),
+      maxOutputChars: 10_000,
+      totalOutputChars: 0,
+      pendingStdout: [],
+      pendingStderr: [],
+      pendingStdoutChars: 0,
+      pendingStderrChars: 0,
+      aggregated: "",
+      tail: "",
+      exited: false,
+      truncated: false,
+      backgrounded: false,
+      cursorKeyMode: "unknown",
+    };
+
+    addSession(session);
+    markBackgrounded(session);
+    markExited(session, 0, null, "completed");
+
+    try {
+      const events = [`Exec finished (node=abc id=${sessionId}, code 0)\nSome output`];
+      const prompt = buildExecEventPrompt(events);
+
+      expect(prompt).toContain("background command you started earlier has completed");
+      expect(prompt).toContain("Continue with your original task");
+      expect(prompt).toContain("process(action=poll, sessionId=<id>)");
+      expect(prompt).toContain("Some output");
+      expect(prompt).not.toContain("HEARTBEAT_OK");
+      expect(prompt).not.toContain("relay the command output to the user");
+    } finally {
+      resetProcessRegistryForTests();
+    }
+  });
+
+  it("uses task-continuation prompt for local-format backgrounded exec completions", async () => {
+    const sessionId = createSessionSlug();
+    const session: ProcessSession = {
+      id: sessionId,
+      command: "test",
+      startedAt: Date.now(),
+      maxOutputChars: 10_000,
+      totalOutputChars: 0,
+      pendingStdout: [],
+      pendingStderr: [],
+      pendingStdoutChars: 0,
+      pendingStderrChars: 0,
+      aggregated: "",
+      tail: "",
+      exited: false,
+      truncated: false,
+      backgrounded: false,
+      cursorKeyMode: "unknown",
+    };
+
+    addSession(session);
+    markBackgrounded(session);
+    markExited(session, 0, null, "completed");
+
+    try {
+      // Local format uses session.id.slice(0, 8) as prefix
+      const prefix = sessionId.slice(0, 8);
+      const events = [`Exec completed (${prefix}, code 0) :: Some output`];
+      const prompt = buildExecEventPrompt(events);
+
+      expect(prompt).toContain("background command you started earlier has completed");
+      expect(prompt).toContain("Continue with your original task");
+      expect(prompt).toContain("Some output");
+      expect(prompt).not.toContain("HEARTBEAT_OK");
+      expect(prompt).not.toContain("relay the command output to the user");
+    } finally {
+      resetProcessRegistryForTests();
+    }
+  });
+
+  it("falls back to existing exec prompt for foreground exec completions", () => {
+    // No matching session in finishedSessions → not detected as backgrounded
+    const events = ["Exec finished (node=abc id=no-such-session, code 1)\nSome output"];
+    const prompt = buildExecEventPrompt(events);
+
+    expect(prompt).toContain("Please relay the command output to the user");
+    expect(prompt).not.toContain("background command you started earlier has completed");
   });
 });
 

--- a/src/infra/heartbeat-events-filter.ts
+++ b/src/infra/heartbeat-events-filter.ts
@@ -1,5 +1,6 @@
 // Filters heartbeat event text before it is added to prompts.
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import { getFinishedSession, listFinishedSessions } from "../agents/bash-process-registry.js";
 import { HEARTBEAT_RESPONSE_TOOL_INSTRUCTIONS } from "../auto-reply/heartbeat.js";
 import { HEARTBEAT_TOKEN } from "../auto-reply/tokens.js";
 
@@ -138,6 +139,13 @@ export function buildExecEventPrompt(
       "Reply HEARTBEAT_OK only. Do not mention, summarize, or reuse output from any earlier run."
     );
   }
+  // Background/yielded exec completions: agent hasn't seen the result yet,
+  // so tell it to check the output and continue the original task.
+  // This is orthogonal to deliverToUser — always prompt for task continuation.
+  if (eventText && pendingEvents.some(isBackgroundExecEvent)) {
+    return buildBackgroundExecPromptText(eventText);
+  }
+
   if (!deliverToUser) {
     if (useHeartbeatResponseTool) {
       return (
@@ -197,6 +205,38 @@ function isHeartbeatNoiseEvent(evt: string): boolean {
     isHeartbeatAckEvent(lower) ||
     lower.includes("heartbeat poll") ||
     lower.includes("heartbeat wake")
+  );
+}
+
+/** Detect if an exec completion event corresponds to a backgrounded/yielded session. */
+function isBackgroundExecEvent(evt: string): boolean {
+  // Gateway format: Exec finished (node=abc id=<fullSessionId>, code 0)
+  const gatewayMatch = /id=([a-zA-Z0-9_-]+)/.exec(evt);
+  if (gatewayMatch) {
+    const session = getFinishedSession(gatewayMatch[1]);
+    if (session) {
+      return true;
+    }
+  }
+  // Local structured format: Exec completed (<idPrefix>, code 0) :: output
+  // The prefix is session.id.slice(0, 8). Match by prefix since the full
+  // ID is not included in the event text.
+  const structured = parseStructuredExecCompletionEvent(evt);
+  if (structured && structured.id) {
+    return listFinishedSessions().some((s) => s.id.startsWith(structured.id));
+  }
+  return false;
+}
+
+/** Prompt text for background exec completions: examine result and continue task. */
+function buildBackgroundExecPromptText(eventText: string): string {
+  return (
+    "A background command you started earlier has completed. The completion details are:\n\n" +
+    eventText +
+    "\n\n" +
+    "Examine the result. If the command failed, diagnose and fix the issue.\n" +
+    "Continue with your original task. Use process(action=poll, sessionId=<id>)\n" +
+    "to retrieve the full output if needed."
   );
 }
 

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -1185,6 +1185,12 @@ function resolveHeartbeatRunPrompt(params: {
         .map((event) => event.text)
     : [];
   const hasExecCompletion = execEvents.length > 0;
+  if (hasExecCompletion) {
+    log.info(`[bg-exec] heartbeat found ${execEvents.length} exec event(s)`, {
+      events: execEvents,
+      canRelayToUser: params.canRelayToUser,
+    });
+  }
   const hasRelayableExecCompletion =
     params.canRelayToUser && execEvents.some((event) => isRelayableExecCompletionEvent(event));
   const hasCronEvents = cronEvents.length > 0;
@@ -1317,23 +1323,28 @@ export async function runHeartbeatOnce(opts: {
     mergeRequestedHeartbeat: opts.source === "cron",
   });
   if (!areHeartbeatsEnabled()) {
+    log.info(`[bg-exec] runHeartbeatOnce skip: heartbeats disabled (agent=${agentId})`);
     return { status: "skipped", reason: "disabled" };
   }
   if (!isHeartbeatEnabledForAgent(cfg, agentId)) {
+    log.info(`[bg-exec] runHeartbeatOnce skip: not enabled for agent (agent=${agentId})`);
     return { status: "skipped", reason: "disabled" };
   }
   if (!resolveHeartbeatIntervalMs(cfg, undefined, heartbeat)) {
+    log.info(`[bg-exec] runHeartbeatOnce skip: no interval (agent=${agentId})`);
     return { status: "skipped", reason: "disabled" };
   }
 
   const startedAt = opts.deps?.nowMs?.() ?? Date.now();
   if (!isWithinActiveHours(cfg, heartbeat, startedAt)) {
+    log.info(`[bg-exec] runHeartbeatOnce skip: quiet-hours (agent=${agentId})`);
     return { status: "skipped", reason: "quiet-hours" };
   }
 
   const getSize = opts.deps?.getQueueSize ?? getQueueSize;
   const getSnapshots = opts.deps?.getCommandLaneSnapshots ?? getCommandLaneSnapshots;
   if (getSize(CommandLane.Main) > 0) {
+    log.info(`[bg-exec] runHeartbeatOnce skip: main lane busy (agent=${agentId})`);
     return { status: "skipped", reason: HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT };
   }
 
@@ -1362,6 +1373,7 @@ export async function runHeartbeatOnce(opts: {
   // the same agent is already replying; immediate/manual wakes keep their
   // existing semantics for explicit user/system actions.
   if (shouldHonorActiveReplyRuns && hasActiveReplyRunForAgent(agentId, listActiveReplyRuns)) {
+    log.info(`[bg-exec] runHeartbeatOnce skip: active reply run (agent=${agentId})`);
     emitHeartbeatEvent({
       status: "skipped",
       reason: HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT,


### PR DESCRIPTION
## Summary

- Problem: when an exec yields/backgrounds (via `background: true`, `yieldMs`, or default 10s auto-yield), the tool result says "Use process poll" instead of telling the agent to wait for auto-notification. And when the background exec completes, the heartbeat-injected prompt says "HEARTBEAT_OK only, do not reuse command output" (no delivery channel) or "relay to user" (with a channel), instead of telling the agent to check the result and continue the original task.
- Why it matters: the agent either abandons the task (HEARTBEAT_OK path) or gets confused by "relay to user" when it should continue working. The polling guidance also creates a race with the auto-notification path.
- What changed: (1) background exec tool result now says "running in background, will notify" instead of "Use process poll". (2) `buildExecEventPrompt` detects backgrounded execs via `bash-process-registry.finishedSessions` and uses a task-continuation prompt instead of HEARTBEAT_OK / relay-to-user.
- What did NOT change (scope boundary): no changes to the gateway event pipeline, heartbeat wake mechanism, or process tool internals. The existing `deliverToUser` branches for foreground exec completions are preserved exactly.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `buildExecEventPrompt` was written for the periodic heartbeat poll scenario, where exec completions are stale events the agent has already processed via tool result. For background/yielded execs, the agent has NOT seen the result yet, but the same HEARTBEAT_OK/relay-to-user prompt was used. Additionally, `resolveRunning()` in the exec tool always recommended polling regardless of whether the exec was backgrounded.
- Missing detection / guardrail: no distinction between "stale foreground exec completion" and "first-time background exec completion" in the prompt builder.
- Contributing context (if known): `heartbeat.target` defaults to `"none"`, so exec-event wakes without explicit heartbeat config always hit the `!deliverToUser` (HEARTBEAT_OK) branch.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/infra/heartbeat-events-filter.test.ts`
- Scenario the test should lock in: backgrounded exec sessions produce a task-continuation prompt; non-backgrounded sessions still use the existing prompt.
- Why this is the smallest reliable guardrail: the fix is entirely within `buildExecEventPrompt` prompt text selection, so prompt assertions at the unit level are the direct seam.
- Existing test that already covers this (if any): existing tests cover foreground exec prompt paths (relay, HEARTBEAT_OK, missing output).
- If no new test is added, why not: N/A — two new tests added.

## User-visible / Behavior Changes

Agents should now:
- See "running in background, will notify" instead of "Use process poll" when exec yields/backgrounds,
- See "examine the result, continue your original task" instead of "HEARTBEAT_OK only, do not reuse" or "relay to user" when a background exec completes.

## Diagram (if applicable)

```text
Before:
[agent calls exec(cmd, {background: true})] → ["Use process poll"] → [agent polls] → [heartbeat injects "HEARTBEAT_OK only, do not reuse"] → [agent replies NO_REPLY, task lost]

After:
[agent calls exec(cmd, {background: true})] → ["running in background, will notify"] → [agent continues other work] → [heartbeat injects "examine result, continue task"] → [agent uses process poll, continues original task]
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Start a background exec or let a foreground exec auto-yield after 10s.
2. Observe the tool result text.
3. When the exec completes, observe the heartbeat-injected prompt.

### Expected

- The tool result says "running in background, will notify".
- The completion prompt says "examine the result, continue your original task".

### Actual

- With this patch, both show the corrected text.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: `pnpm test src/infra/heartbeat-events-filter.test.ts` — 51 passed (49 existing + 2 new). New test validates background exec detection via ProcessSession in finishedSessions.
- Edge cases checked: foreground exec completions (no matching finishedSession) still use existing prompt. Empty events still use HEARTBEAT_OK fallback.
- What you did **not** verify: full E2E with real exec processes.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: if the session ID format in `exec.finished` events changes, the regex in `isBackgroundExecEvent` might not match, causing background execs to fall back to the old HEARTBEAT_OK prompt.
  - Mitigation: the fallback behavior is the same as before this patch; no regression.
- Risk: the `getFinishedSession` import from `bash-process-registry` creates a new dependency in `heartbeat-events-filter.ts`.
  - Mitigation: this is a read-only lookup, no mutation. The module is already used downstream in agent tool execution.
