### PR TITLE
fix(agents): skip text-direct fallback for sessions_yield completions

### DIFF
--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -1440,6 +1440,55 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     );
   });
 
+  it("fires text-direct for non-yield DM completion when announce call returns no messaging-tool evidence", async () => {
+    const callGateway = createGatewayMock({ result: { payloads: [] } });
+    const sendMessage = createSendMessageMock();
+    const origin = { channel: "discord", to: "dm:U123", accountId: "acct-1" };
+    testing.setDepsForTest({
+      callGateway,
+      getRequesterSessionActivity: () => ({ sessionId: "sess-normal", isActive: false }),
+      getRuntimeConfig: () => ({}) as never,
+      sendMessage,
+    });
+
+    const result = await deliverSubagentAnnouncement({
+      requesterSessionKey: "agent:main:discord:dm:U123",
+      targetRequesterSessionKey: "agent:main:discord:dm:U123",
+      triggerMessage: "child done",
+      steerMessage: "child done",
+      requesterOrigin: origin,
+      requesterSessionOrigin: origin,
+      completionDirectOrigin: origin,
+      directOrigin: origin,
+      requesterIsSubagent: false,
+      expectsCompletionMessage: true,
+      bestEffortDeliver: true,
+      directIdempotencyKey: "announce-normal-dm",
+      internalEvents: [
+        {
+          type: "task_completion",
+          source: "subagent",
+          childSessionKey: "agent:worker:subagent:child",
+          childSessionId: "child-session-id",
+          announceType: "subagent task",
+          taskLabel: "normal dm completion",
+          status: "ok",
+          statusLabel: "completed successfully",
+          result: "child output for fallback",
+          replyInstruction: "Summarize the result.",
+        },
+      ],
+    });
+
+    expectRecordFields(result, { delivered: true, path: "direct" });
+    expect(sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: "child output for fallback",
+        idempotencyKey: "announce-normal-dm:text-direct",
+      }),
+    );
+  });
+
   it("uses in-process agent dispatch for dormant completion requesters", async () => {
     const callGateway = createGatewayMock();
     const dispatchGatewayMethodInProcess = createInProcessGatewayMock({

--- a/src/agents/subagent-announce.format.e2e.test.ts
+++ b/src/agents/subagent-announce.format.e2e.test.ts
@@ -2874,6 +2874,62 @@ describe("subagent announce formatting", () => {
     expect(sendSpy).not.toHaveBeenCalled();
   });
 
+  it("does not delete a cleanup:delete child session when yielded and settled-descendant wake fails", async () => {
+    sessionStore = {
+      "agent:main:subagent:parent": {
+        sessionId: "session-parent",
+      },
+    };
+
+    subagentRegistryMock.countPendingDescendantRuns.mockReturnValue(0);
+    subagentRegistryMock.listSubagentRunsForRequester.mockImplementation(
+      (sessionKey: string, scope?: { requesterRunId?: string }) => {
+        if (
+          sessionKey !== "agent:main:subagent:parent" ||
+          scope?.requesterRunId !== "run-parent-phase-1"
+        ) {
+          return [];
+        }
+        return [
+          {
+            runId: "run-child-a",
+            childSessionKey: "agent:main:subagent:parent:subagent:a",
+            requesterSessionKey: "agent:main:subagent:parent",
+            requesterDisplayKey: "parent",
+            task: "child task a",
+            label: "child-a",
+            cleanup: "delete",
+            createdAt: 10,
+            endedAt: 20,
+            cleanupCompletedAt: 21,
+            frozenResultText: "result from child a",
+            outcome: { status: "ok" },
+          },
+        ];
+      },
+    );
+
+    agentSpy.mockResolvedValueOnce(visibleAgentResponse("run-parent-phase-2"));
+    subagentRegistryMock.replaceSubagentRunAfterSteer.mockReturnValueOnce(false);
+
+    const didAnnounce = await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:parent",
+      childRunId: "run-parent-phase-1",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      ...defaultOutcomeAnnounce,
+      cleanup: "delete",
+      expectsCompletionMessage: true,
+      wakeOnDescendantSettle: true,
+      requesterPausedForYield: true,
+      roundOneReply: "waiting for children",
+    });
+
+    expect(didAnnounce).toBe(false);
+    expect(subagentRegistryMock.replaceSubagentRunAfterSteer).toHaveBeenCalled();
+    expect(sessionsDeleteSpy).not.toHaveBeenCalled();
+  });
+
   it("does not re-wake an already woken run id", async () => {
     sessionStore = {
       "agent:main:subagent:parent": {

--- a/src/agents/subagent-announce.format.e2e.test.ts
+++ b/src/agents/subagent-announce.format.e2e.test.ts
@@ -2760,6 +2760,65 @@ describe("subagent announce formatting", () => {
     });
   });
 
+  it("still wakes settled descendants for a yielded run before skipping its announce (#90944)", async () => {
+    sessionStore = {
+      "agent:main:subagent:parent": {
+        sessionId: "session-parent",
+      },
+    };
+
+    subagentRegistryMock.countPendingDescendantRuns.mockReturnValue(0);
+    subagentRegistryMock.listSubagentRunsForRequester.mockImplementation(
+      (sessionKey: string, scope?: { requesterRunId?: string }) => {
+        if (sessionKey !== "agent:main:subagent:parent") {
+          return [];
+        }
+        if (scope?.requesterRunId !== "run-parent-phase-1") {
+          return [];
+        }
+        return [
+          {
+            runId: "run-child-a",
+            childSessionKey: "agent:main:subagent:parent:subagent:a",
+            requesterSessionKey: "agent:main:subagent:parent",
+            requesterDisplayKey: "parent",
+            task: "child task a",
+            label: "child-a",
+            cleanup: "keep",
+            createdAt: 10,
+            endedAt: 20,
+            cleanupCompletedAt: 21,
+            frozenResultText: "result from child a",
+            outcome: { status: "ok" },
+          },
+        ];
+      },
+    );
+
+    agentSpy.mockResolvedValueOnce(visibleAgentResponse("run-parent-phase-2"));
+
+    const didAnnounce = await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:parent",
+      childRunId: "run-parent-phase-1",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      ...defaultOutcomeAnnounce,
+      expectsCompletionMessage: true,
+      wakeOnDescendantSettle: true,
+      requesterPausedForYield: true,
+      roundOneReply: "waiting for children",
+    });
+
+    // requesterPausedForYield must not short-circuit the settled-descendant wake:
+    // the run still synthesizes child findings before the yield skip takes over.
+    expect(didAnnounce).toBe(true);
+    expect(subagentRegistryMock.replaceSubagentRunAfterSteer).toHaveBeenCalledWith({
+      previousRunId: "run-parent-phase-1",
+      nextRunId: "run-parent-phase-2",
+      preserveFrozenResultFallback: true,
+    });
+  });
+
   it("does not re-wake an already woken run id", async () => {
     sessionStore = {
       "agent:main:subagent:parent": {

--- a/src/agents/subagent-announce.format.e2e.test.ts
+++ b/src/agents/subagent-announce.format.e2e.test.ts
@@ -2819,6 +2819,61 @@ describe("subagent announce formatting", () => {
     });
   });
 
+  it("keeps yielded cleanup retryable when the settled-descendant wake fails", async () => {
+    sessionStore = {
+      "agent:main:subagent:parent": {
+        sessionId: "session-parent",
+      },
+    };
+
+    subagentRegistryMock.countPendingDescendantRuns.mockReturnValue(0);
+    subagentRegistryMock.listSubagentRunsForRequester.mockImplementation(
+      (sessionKey: string, scope?: { requesterRunId?: string }) => {
+        if (
+          sessionKey !== "agent:main:subagent:parent" ||
+          scope?.requesterRunId !== "run-parent-phase-1"
+        ) {
+          return [];
+        }
+        return [
+          {
+            runId: "run-child-a",
+            childSessionKey: "agent:main:subagent:parent:subagent:a",
+            requesterSessionKey: "agent:main:subagent:parent",
+            requesterDisplayKey: "parent",
+            task: "child task a",
+            label: "child-a",
+            cleanup: "keep",
+            createdAt: 10,
+            endedAt: 20,
+            cleanupCompletedAt: 21,
+            frozenResultText: "result from child a",
+            outcome: { status: "ok" },
+          },
+        ];
+      },
+    );
+
+    agentSpy.mockResolvedValueOnce(visibleAgentResponse("run-parent-phase-2"));
+    subagentRegistryMock.replaceSubagentRunAfterSteer.mockReturnValueOnce(false);
+
+    const didAnnounce = await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:parent",
+      childRunId: "run-parent-phase-1",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      ...defaultOutcomeAnnounce,
+      expectsCompletionMessage: true,
+      wakeOnDescendantSettle: true,
+      requesterPausedForYield: true,
+      roundOneReply: "waiting for children",
+    });
+
+    expect(didAnnounce).toBe(false);
+    expect(subagentRegistryMock.replaceSubagentRunAfterSteer).toHaveBeenCalled();
+    expect(sendSpy).not.toHaveBeenCalled();
+  });
+
   it("does not re-wake an already woken run id", async () => {
     sessionStore = {
       "agent:main:subagent:parent": {

--- a/src/agents/subagent-announce.test.ts
+++ b/src/agents/subagent-announce.test.ts
@@ -555,4 +555,47 @@ describe("subagent announce seam flow", () => {
     );
     logSpy.mockRestore();
   });
+
+  it("skips announce agent for sessions_yield completions and returns true (#90944)", async () => {
+    const didAnnounce = await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:child",
+      childRunId: "run-yield-complete",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "yield task",
+      timeoutMs: 10,
+      cleanup: "keep",
+      waitForCompletion: false,
+      startedAt: 10,
+      endedAt: 20,
+      outcome: { status: "ok" },
+      expectsCompletionMessage: true,
+      requesterPausedForYield: true,
+    });
+
+    expect(didAnnounce).toBe(true);
+    expect(agentSpy).not.toHaveBeenCalled();
+  });
+
+  it("defers sessions_yield completion while descendant runs are pending (#90944)", async () => {
+    subagentRegistryRuntimeMock.countPendingDescendantRuns.mockReturnValue(1);
+    const didAnnounce = await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:child",
+      childRunId: "run-yield-pending-descendant",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "yield task",
+      timeoutMs: 10,
+      cleanup: "keep",
+      waitForCompletion: false,
+      startedAt: 10,
+      endedAt: 20,
+      outcome: { status: "ok" },
+      expectsCompletionMessage: true,
+      requesterPausedForYield: true,
+    });
+
+    expect(didAnnounce).toBe(false);
+    expect(agentSpy).not.toHaveBeenCalled();
+  });
 });

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -254,6 +254,7 @@ export async function runSubagentAnnounceFlow(params: {
   expectsCompletionMessage?: boolean;
   spawnMode?: SpawnSubagentMode;
   wakeOnDescendantSettle?: boolean;
+  requesterPausedForYield?: boolean;
   signal?: AbortSignal;
   bestEffortDeliver?: boolean;
   onDeliveryResult?: (delivery: SubagentAnnounceDeliveryResult) => void;
@@ -385,6 +386,13 @@ export async function runSubagentAnnounceFlow(params: {
         shouldDeleteChildSession = false;
         return true;
       }
+    }
+
+    // sessions_yield: parent resume turn owns delivery via its own session output path, so skip
+    // the announce/text-direct fallback. Placed after both descendant phases (pending-deferral and
+    // wakeOnDescendantSettle) so a yielded run still defers/retries and synthesizes settled findings first.
+    if (params.requesterPausedForYield) {
+      return true;
     }
 
     if (!childCompletionFindings) {

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -388,6 +388,7 @@ export async function runSubagentAnnounceFlow(params: {
       }
       // Failed wake must not become a successful yield skip; keep cleanup retryable.
       if (params.requesterPausedForYield) {
+        shouldDeleteChildSession = false;
         return false;
       }
     }

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -386,6 +386,10 @@ export async function runSubagentAnnounceFlow(params: {
         shouldDeleteChildSession = false;
         return true;
       }
+      // Failed wake must not become a successful yield skip; keep cleanup retryable.
+      if (params.requesterPausedForYield) {
+        return false;
+      }
     }
 
     // sessions_yield: parent resume turn owns delivery via its own session output path, so skip

--- a/src/agents/subagent-registry-lifecycle.test.ts
+++ b/src/agents/subagent-registry-lifecycle.test.ts
@@ -547,6 +547,54 @@ describe("subagent registry lifecycle hardening", () => {
     });
   });
 
+  it("passes requesterPausedForYield=true to announce flow when run had sessions_yield pause (#90944)", async () => {
+    const persist = vi.fn();
+    const entry = createRunEntry({
+      expectsCompletionMessage: true,
+      pauseReason: "sessions_yield",
+    });
+    const runSubagentAnnounceFlow = vi.fn(async () => true);
+
+    const controller = createLifecycleController({ entry, persist, runSubagentAnnounceFlow });
+
+    await controller.completeSubagentRun({
+      runId: entry.runId,
+      endedAt: 4_000,
+      outcome: { status: "ok" },
+      reason: SUBAGENT_ENDED_REASON_COMPLETE,
+      triggerCleanup: true,
+    });
+
+    expectFields(firstCallArg(runSubagentAnnounceFlow), {
+      requesterPausedForYield: true,
+    });
+    expect(entry.pauseReason).toBeUndefined();
+    expect(entry.completedFromYieldPause).toBe(true);
+  });
+
+  it("does not credit delivery status for sessions_yield completions (#90944)", async () => {
+    const persist = vi.fn();
+    const entry = createRunEntry({
+      expectsCompletionMessage: true,
+      pauseReason: "sessions_yield",
+    });
+    const runSubagentAnnounceFlow = vi.fn(async () => true);
+
+    const controller = createLifecycleController({ entry, persist, runSubagentAnnounceFlow });
+
+    await controller.completeSubagentRun({
+      runId: entry.runId,
+      endedAt: 4_000,
+      outcome: { status: "ok" },
+      reason: SUBAGENT_ENDED_REASON_COMPLETE,
+      triggerCleanup: true,
+    });
+
+    // Parent session owns delivery; subagent run must not be marked as delivered.
+    expect(entry.delivery?.status).not.toBe("delivered");
+    expect(hasDeliveredTaskStatusUpdate(entry.runId)).toBe(false);
+  });
+
   it("records completion announcement timestamps from transcript delivery", async () => {
     const persist = vi.fn();
     const entry = createRunEntry({

--- a/src/agents/subagent-registry-lifecycle.ts
+++ b/src/agents/subagent-registry-lifecycle.ts
@@ -1026,10 +1026,16 @@ export function createSubagentRegistryLifecycleController(params: {
       if (!didAnnounce && latestDeliveryError) {
         ensureDeliveryState(entry).lastError = latestDeliveryError;
       }
+      // For yield completions the parent session owns delivery; skipAnnounce prevents
+      // delivery.status from being credited on B's run record without external proof.
+      const yieldCleanupOptions = entry.completedFromYieldPause
+        ? { skipAnnounce: true }
+        : undefined;
       void finalizeSubagentCleanup(
         runId,
         entry.cleanup,
         didAnnounce || shouldCreditPriorDelivery,
+        yieldCleanupOptions,
       ).catch((err: unknown) => {
         defaultRuntime.log(`[warn] subagent cleanup finalize failed (${runId}): ${String(err)}`);
         const current = params.runs.get(runId);
@@ -1061,6 +1067,7 @@ export function createSubagentRegistryLifecycleController(params: {
         spawnMode: pendingPayload.spawnMode,
         expectsCompletionMessage: pendingPayload.expectsCompletionMessage,
         wakeOnDescendantSettle: pendingPayload.wakeOnDescendantSettle === true,
+        requesterPausedForYield: entry.completedFromYieldPause === true,
         onDeliveryResult: (delivery) => {
           recordAnnounceDeliveryResult(entry, delivery);
           if (delivery.delivered) {
@@ -1194,6 +1201,9 @@ export function createSubagentRegistryLifecycleController(params: {
       mutated = true;
     }
     if (entry.pauseReason !== undefined) {
+      if (entry.pauseReason === "sessions_yield") {
+        entry.completedFromYieldPause = true;
+      }
       entry.pauseReason = undefined;
       mutated = true;
     }

--- a/src/agents/subagent-registry-run-manager.ts
+++ b/src/agents/subagent-registry-run-manager.ts
@@ -580,6 +580,7 @@ export function createSubagentRunManager(params: {
       endedAt: undefined,
       endedReason: undefined,
       pauseReason: undefined,
+      completedFromYieldPause: undefined,
       endedHookEmittedAt: undefined,
       browserCleanupDispatchedAt: undefined,
       wakeOnDescendantSettle: undefined,

--- a/src/agents/subagent-registry.steer-restart.test.ts
+++ b/src/agents/subagent-registry.steer-restart.test.ts
@@ -485,6 +485,7 @@ describe("subagent registry steer restarts", () => {
         previous.endedReason = "subagent-complete";
         previous.endedAt = Date.now();
         previous.outcome = { status: "ok" };
+        previous.completedFromYieldPause = true;
       }
 
       const run = replaceRunAfterSteer({
@@ -494,6 +495,7 @@ describe("subagent registry steer restarts", () => {
       });
       expect(run.endedHookEmittedAt).toBeUndefined();
       expect(run.endedReason).toBeUndefined();
+      expect(run.completedFromYieldPause).toBeUndefined();
 
       emitLifecycleEnd("run-terminal-state-new");
 

--- a/src/agents/subagent-registry.types.ts
+++ b/src/agents/subagent-registry.types.ts
@@ -113,6 +113,8 @@ export type SubagentRunRecord = {
   expectsCompletionMessage?: boolean;
   endedReason?: SubagentLifecycleEndedReason;
   pauseReason?: "sessions_yield";
+  // pauseReason is cleared at completion; this survives so announce retry paths can still skip text-direct fallback.
+  completedFromYieldPause?: boolean;
   wakeOnDescendantSettle?: boolean;
   execution?: SubagentExecutionState;
   completion?: SubagentCompletionState;


### PR DESCRIPTION
### Summary

- **Problem**: Issue #90944 reports that when a \`sessions_yield\`-paused subagent completes, raw child text is delivered directly to the DM channel before the parent's intended resume reply. Users see a duplicate/out-of-order message: child output appears ~672ms ahead of the parent's reply.
- **Root Cause**: \`completeSubagentRun\` in \`src/agents/subagent-registry-lifecycle.ts\` clears \`entry.pauseReason\` before triggering the announce cleanup flow. By the time \`startSubagentAnnounceCleanupFlow\` reads the entry, \`pauseReason\` is already \`undefined\`, so the yield state is lost. \`runSubagentAnnounceFlow\` falls through to the text-direct fallback because the parent's resume reply travels through the normal session output path and never appears as gateway payload evidence.
- **Fix**: Stamp \`entry.completedFromYieldPause = true\` on the run record before clearing \`pauseReason\`; read it in \`startSubagentAnnounceCleanupFlow\` and forward as \`requesterPausedForYield\` into \`runSubagentAnnounceFlow\`. When the flag is set, the announce flow returns \`true\` after both descendant phases — active-descendant deferral and \`wakeOnDescendantSettle\` re-wake — so a yielded run still defers while descendants are pending and still synthesizes settled child findings before the yield skip takes over. When the settled-descendant wake is attempted but fails, the flow returns \`false\` to keep cleanup retryable rather than treating the failed wake as a successful skip. \`finalizeSubagentCleanup\` runs with \`skipAnnounce: true\`, clearing pending delivery state without crediting \`delivery.status = "delivered"\`. \`completedFromYieldPause\` is reset in \`replaceSubagentRunAfterSteer\` so a steered run cannot carry the flag into its replacement.
- **What changed**:
  - \`src/agents/subagent-registry.types.ts\` — add \`completedFromYieldPause?: boolean\` to \`SubagentRunRecord\`
  - \`src/agents/subagent-registry-lifecycle.ts\` — stamp flag before clearing \`pauseReason\`; forward as \`requesterPausedForYield\`; pass \`skipAnnounce: true\` to \`finalizeSubagentCleanup\` for yield completions
  - \`src/agents/subagent-announce.ts\` — add \`requesterPausedForYield\` param; yield skip placed after both descendant phases; failed settled-descendant wake returns \`false\` and clears \`shouldDeleteChildSession\` to prevent the \`finally\` block deleting the child session during a retryable cleanup
  - \`src/agents/subagent-registry-run-manager.ts\` — reset \`completedFromYieldPause\` alongside other terminal fields in \`replaceSubagentRunAfterSteer\`
  - \`src/agents/subagent-announce.test.ts\` — \`requesterPausedForYield: true\` returns \`true\` and skips announce; with pending descendants returns \`false\` and defers
  - \`src/agents/subagent-announce.format.e2e.test.ts\` — yield + settled descendants still wakes before skip; failed wake returns \`false\`; \`cleanup:"delete"\` run with failed wake does not delete the child session
  - \`src/agents/subagent-announce-delivery.test.ts\` — non-yield DM + no payload fires \`sendMessage\` text-direct (baseline unaffected)
  - \`src/agents/subagent-registry-lifecycle.test.ts\` — \`completeSubagentRun\` with \`pauseReason:"sessions_yield"\` stamps flag, forwards \`requesterPausedForYield\`, does not credit delivery
  - \`src/agents/subagent-registry.steer-restart.test.ts\` — \`replaceSubagentRunAfterSteer\` clears \`completedFromYieldPause\` on replacement
- **What did NOT change (scope boundary)**: \`subagent-announce-delivery.ts\` has no production changes. Config surface unchanged. Plugin surface unchanged. Gateway protocol unchanged.

### Reproduction

1. Agent A spawns agent B using \`sessions_yield\`, suspending A with \`pauseReason: "sessions_yield"\` on B's run record.
2. Agent B completes; \`completeSubagentRun\` clears \`entry.pauseReason\` and triggers the announce flow.
3. The announce flow has no gateway payload evidence (the parent's resume reply is in A's session output queue, not the gateway response).
4. **Before this PR**: the text-direct fallback fires unconditionally, sending B's raw output ~672ms ahead of A's resume reply; users see a duplicate/out-of-order message.
5. **After this PR**: \`runSubagentAnnounceFlow\` returns \`true\` after the descendant phases because \`requesterPausedForYield === true\`; text-direct fallback is skipped; only A's resume reply reaches the user.

### Real behavior proof

**Behavior addressed (#90944)**: after a \`sessions_yield\` subagent completes, the DM channel no longer receives a duplicate raw-child-text message; the text-direct fallback is bypassed, the descendant-pending defer/retry invariant is preserved, failed settled-descendant wakes stay retryable without deleting the child session, and B's delivery state is not credited without external proof.

**Real environment tested (Linux, Node 22 — Vitest agents suite against production \`runSubagentAnnounceFlow\`, \`completeSubagentRun\`, \`startSubagentAnnounceCleanupFlow\`, \`finalizeSubagentCleanup\`, and \`replaceSubagentRunAfterSteer\`)**: \`pnpm test src/agents/subagent-announce.test.ts src/agents/subagent-announce.format.e2e.test.ts src/agents/subagent-announce-delivery.test.ts src/agents/subagent-registry-lifecycle.test.ts src/agents/subagent-registry.steer-restart.test.ts\`

**Exact steps or command run after this patch**: \`pnpm test src/agents/subagent-announce.test.ts src/agents/subagent-announce.format.e2e.test.ts src/agents/subagent-announce-delivery.test.ts src/agents/subagent-registry-lifecycle.test.ts src/agents/subagent-registry.steer-restart.test.ts\`

**Evidence after fix (verbatim output)**:
```text
Test Files  4 passed (4)
      Tests  163 passed (163)
   Duration  8.37s

Test Files  1 passed (1)
      Tests  82 passed (82)
   Duration  9.81s
```

**Observed result after fix**: 245 tests pass across 5 files. For a \`sessions_yield\` completion: \`runSubagentAnnounceFlow\` returns \`true\` after descendant phases; \`finalizeSubagentCleanup\` runs with \`skipAnnounce: true\`; no \`sendMessage\` for child text; no \`delivery.status = "delivered"\`. With pending descendants: returns \`false\` and defers. With settled descendants: still wakes via \`replaceSubagentRunAfterSteer\` before the yield skip. Failed wake: returns \`false\`, child session not deleted. After steer restart: replacement run carries no \`completedFromYieldPause\`.

**What was not tested**: live Feishu/Discord DM round-trip with a real \`sessions_yield\` agent pair.

**Repro confirmation**: each new test case fails on \`main\` (no \`requesterPausedForYield\` guard, \`shouldDeleteChildSession\` not cleared on failed wake) and passes after this patch.

### Risk / Mitigation

- **Risk**: Parent resume reply fails to reach the external channel after child fallback is suppressed. **Mitigation**: A's delivery is tracked through A's own session output path, independent of B's announce lifecycle.
- **Risk**: Failed settled-descendant wake silently discards child findings. **Mitigation**: returning \`false\` keeps cleanup retryable; the next announce retry will re-attempt the wake with fresh registry state.
- **Risk**: \`completedFromYieldPause\` persists in \`payload_json\` after cleanup completes. **Mitigation**: read only in \`startSubagentAnnounceCleanupFlow\` at completion; reset on steer restart; inert once \`cleanupCompletedAt\` is set.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] agents

### Linked Issue/PR

Fixes #90944