### PR TITLE
fix(sessions): append new entry when file exists in persist() no-assistant guard (fixes #89206)

### DIFF
--- a/src/agents/sessions/session-manager.test.ts
+++ b/src/agents/sessions/session-manager.test.ts
@@ -77,6 +77,74 @@ describe("SessionManager.open", () => {
     }
   });
 
+  it("does not duplicate header or user turn when resuming a header+user-only file", async () => {
+    // Case 2 from issue #89206: normal resume of a session whose last turn is
+    // a user message with no assistant reply yet. The first follow-up turn
+    // should append without duplicating the header or the existing user turn.
+    const dir = await makeTempDir();
+    const sessionFile = path.join(dir, "session.jsonl");
+
+    // Simulate a previous session: header + one user message on disk, no assistant.
+    const header = {
+      type: "session",
+      version: 3,
+      id: "existing-session",
+      timestamp: "2026-06-01T00:00:00.000Z",
+      cwd: "/srv/openclaw/main",
+    };
+    const user1 = {
+      type: "message",
+      id: "user-1",
+      parentId: null,
+      timestamp: "2026-06-01T00:00:01.000Z",
+      message: { role: "user", content: "first question" },
+    };
+    const initialTranscript = [JSON.stringify(header), JSON.stringify(user1)].join("\n") + "\n";
+    await fs.writeFile(sessionFile, initialTranscript, "utf8");
+
+    // Open the existing session and resume — add a follow-up turn.
+    const sessionManager = SessionManager.open(sessionFile, dir, "/tmp/task-repo");
+    sessionManager.appendMessage({
+      role: "user",
+      content: "follow-up question",
+      timestamp: Date.now(),
+    });
+    sessionManager.appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "follow-up answer" }],
+      api: "messages",
+      provider: "anthropic",
+      model: "sonnet-4.6",
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: "stop",
+      timestamp: Date.now(),
+    });
+
+    const entries = (await fs.readFile(sessionFile, "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as { type: string; id?: string });
+
+    // Should have exactly: header + user1 + user2 + assistant = 4 entries
+    expect(entries).toHaveLength(4);
+    expect(entries.map((e) => e.type)).toEqual(["session", "message", "message", "message"]);
+    // Verify the original user message is preserved (not duplicated).
+    const userEntries = entries.filter(
+      (e) =>
+        e.type === "message" && (e as { message?: { role?: string } }).message?.role === "user",
+    );
+    expect(userEntries).toHaveLength(2);
+    // No duplicate session headers.
+    expect(entries.filter((e) => e.type === "session")).toHaveLength(1);
+  });
+
   it("does not duplicate the header after recovering a header-only corrupt file", async () => {
     const dir = await makeTempDir();
     const sessionFile = path.join(dir, "session.jsonl");

--- a/src/agents/sessions/session-manager.ts
+++ b/src/agents/sessions/session-manager.ts
@@ -902,8 +902,18 @@ export class SessionManager {
       (e) => e.type === "message" && e.message.role === "assistant",
     );
     if (!hasAssistant) {
-      // Mark as not flushed so when assistant arrives, all entries get written
-      this.flushed = false;
+      // Defer the first full write until an assistant entry arrives so the
+      // session header is always the first line on disk (newSession contract).
+      // When the file already exists (resume / corrupt-header recovery), the
+      // header is already on disk, so append the new entry immediately to keep
+      // the flushed invariant and avoid the duplicate-header rewrite in the
+      // next assistant-triggered persist.
+      if (existsSync(this.sessionFile)) {
+        appendJsonlEntrySync(this.sessionFile, entry);
+        this.flushed = true;
+      } else {
+        this.flushed = false;
+      }
       return;
     }
 


### PR DESCRIPTION
## Summary

Fix the session persist path so resuming a `header + user-only` file no longer triggers a full in-memory buffer rewrite on the next assistant entry. The change is a narrow guard in `persist()` that appends the new entry immediately when the file already exists, keeping the `flushed` invariant true.

**Scope**: 1 source file (`session-manager.ts`), 1 test file
**Changes**: `src/agents/sessions/session-manager.ts` (+10/-2), `session-manager.test.ts` (+73)

## Root Cause

`persist()` has a `no-assistant` guard that sets `flushed = false` for all call paths, deferring the first disk write until an assistant entry arrives. Prior commit 2c48dd2277 swapped `appendJsonlEntriesSync` for `writeJsonlEntriesSync` in the `!flushed` branch to avoid appending a duplicate header, but the root cause — the unnecessary reset of the flushed invariant — remained.

When `setSessionFile` loads an existing file (resume / corrupt-header recovery), the file already contains a session header on disk. Resetting `flushed = false` on the next user-only turn means the assistant-triggered `persist()` will rewrite the entire in-memory buffer (header included) over the existing file. The overwrite is safe with `writeFileSync` today but is fragile: if the write strategy changes back to append for performance, the duplicate-header bug returns.

The fix checks `existsSync(this.sessionFile)`: when the file already exists, the header is already on disk so we can safely `appendJsonlEntrySync` the new entry immediately and keep `flushed = true`. Only when the file does not exist (newSession path) do we defer to the assistant arrival so the header is written first.

### Violated invariant

`flushed` tracks whether the on-disk session file matches `fileEntries`. The `no-assistant` guard breaks this invariant when the file already exists on disk by marking it out of sync even though the only change is a new entry that could have been appended.

### Code path

`setSessionFile()` (resume/recovery) → `flushed = true` →
`appendMessage(user)` → `appendEntry()` → `persist()` →
`!hasAssistant` → `flushed = false` (BUG: file already on disk) →
`appendMessage(assistant)` → `!flushed` → `writeJsonlEntriesSync(fullBuffer)`

## Verification

```
pnpm build  # passed
pnpm test src/agents/sessions/session-manager.test.ts  # 3 tests passed
pnpm test src/agents/sessions/session-manager.test.ts src/agents/sessions/auth-storage.test.ts src/agents/sessions/sdk.test.ts  # 11 tests passed (3 files)
```

## Real Behavior Proof

**Behavior or issue addressed**: Session persist was rewriting the full in-memory buffer on the next assistant entry after a resume/recovery path, risking duplicate headers if the write strategy changed. Now new entries are appended immediately when the file already exists, preserving the flushed invariant.

**Real environment tested**: Ubuntu 24.04, Node v22.22.0, OpenClaw main @ fc6400ede3

**Exact steps or command run after this patch**:
1. `pnpm build` — project compiles cleanly
2. `pnpm test src/agents/sessions/session-manager.test.ts` — 3 tests pass including the new `"does not duplicate header or user turn when resuming a header+user-only file"` regression test
3. `pnpm test src/agents/sessions/session-manager.test.ts src/agents/sessions/auth-storage.test.ts src/agents/sessions/sdk.test.ts` — 11 tests pass across 3 session test files

**Evidence after fix**:
- Test file: [src/agents/sessions/session-manager.test.ts](https://github.com/openclaw/openclaw/blob/fix/issue-89206-persist-flush-resume/src/agents/sessions/session-manager.test.ts) — new test at L80–L146 covers Case 2 (resume header+user-only file)
- Source fix: [src/agents/sessions/session-manager.ts](https://github.com/openclaw/openclaw/blob/fix/issue-89206-persist-flush-resume/src/agents/sessions/session-manager.ts) — `persist()` L904–L916
- Regression test output:
```
Test Files  3 passed (3)
     Tests  11 passed (11)
```

**Observed result after fix**: All 3 session-manager tests pass, including the new regression test for Case 2. The `persist()` method now correctly appends new entries when the file already exists and keeps `flushed = true`, eliminating the need for a full buffer rewrite that could duplicate entries.

**What was not tested**: Long-running session with many user-then-assistant cycles across multiple resume/restart boundaries; concurrent write scenarios (single-process assumption unchanged).

## Review Findings Addressed

N/A — this is a new PR targeting an open issue with no prior review findings.

## Regression Test Plan

- `pnpm test src/agents/sessions/session-manager.test.ts` — session-manager unit tests (3 tests)
- `pnpm test src/agents/sessions/` — full session test suite
- Manual smoke: `openclaw --continue` after a user-only turn in a previous session

## Merge Risk

🔹 **Low**. The change is a narrow guard (8 lines of logic) in a single function. The `existsSync` check is deterministic; the `appendJsonlEntrySync` path mirrors the existing `else` branch at L914. No new dependencies, no API changes, no behavioral changes for callers.
