### PR TITLE
fix(docs): lint workspace templates

### DIFF
--- a/config/markdownlint-cli2.jsonc
+++ b/config/markdownlint-cli2.jsonc
@@ -1,6 +1,17 @@
 {
-  "globs": ["docs/**/*.md", "docs/**/*.mdx", "README.md"],
-  "ignores": ["docs/zh-CN/**", "docs/.i18n/**", "docs/reference/templates/**", "**/.local/**"],
+  "globs": [
+    "docs/**/*.md",
+    "docs/**/*.mdx",
+    "src/agents/templates/HEARTBEAT.md",
+    "README.md",
+  ],
+  "ignores": [
+    "docs/zh-CN/**",
+    "docs/.i18n/**",
+    "**/.local/**",
+    "docs/CLAUDE.md",
+    "docs/reference/templates/CLAUDE.md",
+  ],
   "config": {
     "default": true,
 

--- a/docs/reference/templates/AGENTS.md
+++ b/docs/reference/templates/AGENTS.md
@@ -48,7 +48,7 @@ Capture what matters. Decisions, context, things to remember. Skip the secrets u
 - This is your curated memory — the distilled essence, not raw logs
 - Over time, review your daily files and update MEMORY.md with what's worth keeping
 
-### 📝 Write It Down - No "Mental Notes"!
+### 📝 Write It Down - No "Mental Notes"
 
 - **Memory is limited** — if you want to remember something, WRITE IT TO A FILE
 - "Mental notes" don't survive session restarts. Files do.
@@ -84,7 +84,7 @@ Capture what matters. Decisions, context, things to remember. Skip the secrets u
 
 You have access to your human's stuff. That doesn't mean you _share_ their stuff. In groups, you're a participant — not their voice, not their proxy. Think before you speak.
 
-### 💬 Know When to Speak!
+### 💬 Know When to Speak
 
 In group chats where you receive every message, be **smart about when to contribute**:
 
@@ -110,7 +110,7 @@ In group chats where you receive every message, be **smart about when to contrib
 
 Participate, don't dominate.
 
-### 😊 React Like a Human!
+### 😊 React Like a Human
 
 On platforms that support reactions (Discord, Slack), use emoji reactions naturally:
 
@@ -139,7 +139,7 @@ Skills provide your tools. When you need one, check its `SKILL.md`. Keep local n
 - **Discord links:** Wrap multiple links in `<>` to suppress embeds: `<https://example.com>`
 - **WhatsApp:** No headers — use **bold** or CAPS for emphasis
 
-## 💓 Heartbeats - Be Proactive!
+## 💓 Heartbeats - Be Proactive
 
 When you receive a heartbeat poll (message matches the configured heartbeat prompt), don't just reply `HEARTBEAT_OK` every time. Use heartbeats productively!
 

--- a/docs/reference/templates/HEARTBEAT.md
+++ b/docs/reference/templates/HEARTBEAT.md
@@ -12,9 +12,9 @@ read_when:
 The default runtime template is:
 
 ```markdown
-# Keep this file empty (or with only comments) to skip heartbeat API calls.
+# Keep this file empty (or with only comments) to skip heartbeat API calls
 
-# Add tasks below when you want the agent to check something periodically.
+# Add tasks below when you want the agent to check something periodically
 ```
 
 Add short tasks below the comments only when you want the agent to check something periodically. Keep heartbeat instructions small because they are read during recurring wakes.

--- a/scripts/format-docs.mjs
+++ b/scripts/format-docs.mjs
@@ -13,13 +13,28 @@ const OXFMT_BIN = path.join(ROOT, "node_modules", "oxfmt", "bin", "oxfmt");
 const OXFMT_CONFIG = path.join(ROOT, ".oxfmtrc.jsonc");
 
 function docsFiles() {
-  const output = execFileSync("git", ["ls-files", "docs/**/*.md", "docs/**/*.mdx", "README.md"], {
-    cwd: ROOT,
-    encoding: "utf8",
-  });
+  const output = execFileSync(
+    "git",
+    ["ls-files", "-s", "docs/**/*.md", "docs/**/*.mdx", "README.md"],
+    {
+      cwd: ROOT,
+      encoding: "utf8",
+    },
+  );
+
   return output
     .split("\n")
     .filter(Boolean)
+    .map((line) => {
+      const tabIndex = line.indexOf("\t");
+      const metadata = line.slice(0, tabIndex);
+      const relativePath = line.slice(tabIndex + 1);
+      const mode = metadata.split(" ")[0];
+
+      return { mode, relativePath };
+    })
+    .filter(({ mode }) => mode !== "120000")
+    .map(({ relativePath }) => relativePath)
     .filter((relativePath) => fs.existsSync(path.join(ROOT, relativePath)));
 }
 

--- a/src/agents/templates/HEARTBEAT.md
+++ b/src/agents/templates/HEARTBEAT.md
@@ -1,5 +1,5 @@
 <!-- Heartbeat template; comments-only content prevents scheduled heartbeat API calls. -->
 
-# Keep this file empty (or with only comments) to skip heartbeat API calls.
+# Keep this file empty (or with only comments) to skip heartbeat API calls
 
-# Add tasks below when you want the agent to check something periodically.
+# Add tasks below when you want the agent to check something periodically

--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -671,10 +671,10 @@ describe("ensureAgentWorkspace", () => {
     const heartbeat = await fs.readFile(path.join(tempDir, DEFAULT_HEARTBEAT_FILENAME), "utf-8");
     expect(heartbeat).not.toContain("```");
     expect(heartbeat).toContain(
-      "# Keep this file empty (or with only comments) to skip heartbeat API calls.",
+      "# Keep this file empty (or with only comments) to skip heartbeat API calls",
     );
     expect(heartbeat).toContain(
-      "# Add tasks below when you want the agent to check something periodically.",
+      "# Add tasks below when you want the agent to check something periodically",
     );
   });
 });

--- a/src/commands/doctor-heartbeat-template-repair.test.ts
+++ b/src/commands/doctor-heartbeat-template-repair.test.ts
@@ -211,9 +211,9 @@ Add short tasks below the comments only when you want the agent to check somethi
       `${[
         "<!-- Heartbeat template; comments-only content prevents scheduled heartbeat API calls. -->",
         "",
-        "# Keep this file empty (or with only comments) to skip heartbeat API calls.",
+        "# Keep this file empty (or with only comments) to skip heartbeat API calls",
         "",
-        "# Add tasks below when you want the agent to check something periodically.",
+        "# Add tasks below when you want the agent to check something periodically",
       ].join("\n")}\n`,
     );
     expect(mocks.note).toHaveBeenCalledWith(

--- a/src/commands/doctor-heartbeat-template-repair.test.ts
+++ b/src/commands/doctor-heartbeat-template-repair.test.ts
@@ -75,9 +75,9 @@ Keep this file empty unless you want a tiny checklist. Keep it small.
     const analysis = analyzeHeartbeatTemplateForRepair(`# HEARTBEAT.md Template
 
 \`\`\`markdown
-# Keep this file empty (or with only comments) to skip heartbeat API calls.
+# Keep this file empty (or with only comments) to skip heartbeat API calls
 
-# Add tasks below when you want the agent to check something periodically.
+# Add tasks below when you want the agent to check something periodically
 \`\`\`
 `);
 
@@ -86,9 +86,9 @@ Keep this file empty unless you want a tiny checklist. Keep it small.
 
   it("recognizes the fenced docs-backed template as repairable", () => {
     const analysis = analyzeHeartbeatTemplateForRepair(`\`\`\`markdown
-# Keep this file empty (or with only comments) to skip heartbeat API calls.
+# Keep this file empty (or with only comments) to skip heartbeat API calls
 
-# Add tasks below when you want the agent to check something periodically.
+# Add tasks below when you want the agent to check something periodically
 \`\`\`
 `);
 
@@ -118,9 +118,9 @@ Keep this file empty unless you want a tiny checklist. Keep it small.
 The default runtime template is:
 
 \`\`\`markdown
-# Keep this file empty (or with only comments) to skip heartbeat API calls.
+# Keep this file empty (or with only comments) to skip heartbeat API calls
 
-# Add tasks below when you want the agent to check something periodically.
+# Add tasks below when you want the agent to check something periodically
 \`\`\`
 
 Add short tasks below the comments only when you want the agent to check something periodically. Keep heartbeat instructions small because they are read during recurring wakes.

--- a/src/commands/doctor-heartbeat-template-repair.ts
+++ b/src/commands/doctor-heartbeat-template-repair.ts
@@ -30,6 +30,18 @@ const LEGACY_HEARTBEAT_FENCED_TEMPLATE = [
   "```",
 ] as const;
 
+const CURRENT_HEARTBEAT_FENCED_TEMPLATE = [
+  "```markdown",
+  "# Keep this file empty (or with only comments) to skip heartbeat API calls",
+  "# Add tasks below when you want the agent to check something periodically",
+  "```",
+] as const;
+
+const CURRENT_HEARTBEAT_HEADING_FENCED_TEMPLATE = [
+  "# HEARTBEAT.md Template",
+  ...CURRENT_HEARTBEAT_FENCED_TEMPLATE,
+] as const;
+
 const LEGACY_HEARTBEAT_FENCED_RELATED_TEMPLATE = [
   "```markdown",
   "# Keep this file empty (or with only comments) to skip heartbeat API calls.",
@@ -44,8 +56,8 @@ const DOCS_HEARTBEAT_TEMPLATE_PAGE_AS_TEMPLATE = [
   "`HEARTBEAT.md` lives in the agent workspace. Keep the file empty, or with only Markdown comments and headings, when you want OpenClaw to skip heartbeat model calls.",
   "The default runtime template is:",
   "```markdown",
-  "# Keep this file empty (or with only comments) to skip heartbeat API calls.",
-  "# Add tasks below when you want the agent to check something periodically.",
+  "# Keep this file empty (or with only comments) to skip heartbeat API calls",
+  "# Add tasks below when you want the agent to check something periodically",
   "```",
   "Add short tasks below the comments only when you want the agent to check something periodically. Keep heartbeat instructions small because they are read during recurring wakes.",
   "## Related",
@@ -53,6 +65,11 @@ const DOCS_HEARTBEAT_TEMPLATE_PAGE_AS_TEMPLATE = [
 ] as const;
 
 const HEARTBEAT_DEFAULT_BODY_LINES = [
+  "# Keep this file empty (or with only comments) to skip heartbeat API calls",
+  "# Add tasks below when you want the agent to check something periodically",
+] as const;
+
+const LEGACY_HEARTBEAT_DEFAULT_BODY_LINES = [
   "# Keep this file empty (or with only comments) to skip heartbeat API calls.",
   "# Add tasks below when you want the agent to check something periodically.",
 ] as const;
@@ -74,7 +91,9 @@ const KNOWN_DIRTY_HEARTBEAT_TEMPLATE_LINES = new Set([
   "Add short tasks below the comments only when you want the agent to check something periodically. Keep heartbeat instructions small because they are read during recurring wakes.",
   ...LEGACY_HEARTBEAT_PROSE_TEMPLATE,
   "# Keep this file empty (or with only comments) to skip heartbeat API calls.",
+  "# Keep this file empty (or with only comments) to skip heartbeat API calls",
   "# Add tasks below when you want the agent to check something periodically.",
+  "# Add tasks below when you want the agent to check something periodically",
   "## Related",
   "- [Heartbeat config](/gateway/config-agents)",
 ]);
@@ -82,7 +101,9 @@ const KNOWN_DIRTY_HEARTBEAT_TEMPLATE_LINES = new Set([
 const KNOWN_REPAIRABLE_DIRTY_HEARTBEAT_TEMPLATES = [
   LEGACY_HEARTBEAT_PROSE_TEMPLATE,
   LEGACY_HEARTBEAT_HEADING_FENCED_TEMPLATE,
+  CURRENT_HEARTBEAT_HEADING_FENCED_TEMPLATE,
   LEGACY_HEARTBEAT_FENCED_TEMPLATE,
+  CURRENT_HEARTBEAT_FENCED_TEMPLATE,
   LEGACY_HEARTBEAT_FENCED_RELATED_TEMPLATE,
   DOCS_HEARTBEAT_TEMPLATE_PAGE_AS_TEMPLATE,
 ] as const;
@@ -108,7 +129,9 @@ export function analyzeHeartbeatTemplateForRepair(
     return { status: "dirty-template" };
   }
 
-  const hasDefaultTemplateBody = HEARTBEAT_DEFAULT_BODY_LINES.every((line) => lines.includes(line));
+  const hasDefaultTemplateBody =
+    HEARTBEAT_DEFAULT_BODY_LINES.every((line) => lines.includes(line)) ||
+    LEGACY_HEARTBEAT_DEFAULT_BODY_LINES.every((line) => lines.includes(line));
   const hasDirtyDocWrapper = lines.some((line) => DIRTY_HEARTBEAT_DOC_WRAPPER_LINES.has(line));
   const hasLegacyProseTemplate = LEGACY_HEARTBEAT_PROSE_TEMPLATE.every((line) =>
     lines.includes(line),


### PR DESCRIPTION
## Summary

- Extends the existing markdownlint docs lane to cover shipped workspace template markdown.
- Includes `src/agents/templates/HEARTBEAT.md` in markdownlint coverage because it is part of the workspace template pack.
- Removes the broad `docs/reference/templates/**` markdownlint exclusion while excluding the two `CLAUDE.md` symlink aliases.
- Updates the docs formatter to skip Git symlink entries instead of formatting symlink target blobs.
- Fixes the resulting template markdownlint failures and keeps the HEARTBEAT public docs, doctor repair recognition, and runtime-template tests aligned with the lint-clean template text.

## Linked context

Closes #91160

Related: #91220 has the same narrow template-lint direction, but its current CI failures are caused by missing heartbeat-template test expectation updates. This PR includes that test sync plus the follow-up docs/doctor repair sync requested by ClawSweeper.

Was this requested by a maintainer or owner?

No direct maintainer request. This follows the open issue and ClawSweeper's suggested narrow implementation shape.

## Real behavior proof (required for external PRs)

* Behavior or issue addressed: Shipped workspace template markdown was excluded from the existing markdownlint docs lane.
* Real environment tested: Local OpenClaw worktree at `fix/91160-markdown-lint-templates`.
* Exact steps or command run after this patch:

```bash
pnpm docs:list
node scripts/run-vitest.mjs src/commands/doctor-heartbeat-template-repair.test.ts src/agents/workspace.test.ts src/auto-reply/heartbeat.test.ts
pnpm lint:docs
DOCS_I18N_GLOSSARY_BASE=upstream/main pnpm check:docs
git diff --check
```

* Evidence after fix:

```text
node scripts/run-vitest.mjs src/commands/doctor-heartbeat-template-repair.test.ts src/agents/workspace.test.ts src/auto-reply/heartbeat.test.ts
[test] passed 3 Vitest shards in 45.92s

pnpm lint:docs
markdownlint-cli2 v0.22.1 (markdownlint v0.40.0)
Finding: docs/**/*.md docs/**/*.mdx src/agents/templates/HEARTBEAT.md README.md !docs/zh-CN/** !docs/.i18n/** !**/.local/** !docs/CLAUDE.md !docs/reference/templates/CLAUDE.md
Linting: 674 file(s)
Summary: 0 error(s)

DOCS_I18N_GLOSSARY_BASE=upstream/main pnpm check:docs
Docs formatting clean (661 files).
markdownlint-cli2 v0.22.1 (markdownlint v0.40.0)
Linting: 674 file(s)
Summary: 0 error(s)
Docs MDX check passed (677 files, 11185ms).
checked_internal_links=4445
broken_links=0

git diff --check
# no output
```

* Observed result after fix: The docs markdownlint lane now includes workspace templates and the shipped HEARTBEAT template while skipping symlink aliases. HEARTBEAT docs, doctor repair recognition, and runtime-template tests are aligned with the updated template text.
* What was not tested: Full runtime behavior and full CI were not run locally because this is a docs/tooling coverage change with focused runtime-template and doctor repair tests.
* Proof limitations or environment constraints: Local `pnpm check:docs` was run with `DOCS_I18N_GLOSSARY_BASE=upstream/main` because this fork's `origin/main` is stale and would otherwise include unrelated upstream docs changes in the i18n glossary check.

## Tests and validation

Commands run:

```bash
pnpm docs:list
node scripts/run-vitest.mjs src/commands/doctor-heartbeat-template-repair.test.ts src/agents/workspace.test.ts src/auto-reply/heartbeat.test.ts
pnpm lint:docs
DOCS_I18N_GLOSSARY_BASE=upstream/main pnpm check:docs
git diff --check
```

Regression coverage added or updated:

- Updated existing markdownlint coverage so shipped workspace templates are linted by the docs lane.
- Updated heartbeat runtime-template tests to match the lint-clean HEARTBEAT template.
- Updated doctor heartbeat repair recognition for both legacy and current docs-wrapper template shapes.

## Risk checklist

Did user-visible behavior change? `No`

Did config, environment, or migration behavior change? `Yes`

Did security, auth, secrets, network, or tool execution behavior change? `No`

What is the highest-risk area?

The markdownlint config and docs formatter now cover/skip a slightly different set of files.

How is that risk mitigated?

The PR keeps the scope narrow, uses existing docs scripts, includes the missing shipped HEARTBEAT template, excludes only symlink aliases, updates the formatter to skip Git symlinks, and keeps runtime-template/doctor repair tests aligned with the changed template text.

## Current review state

What is the next action?

Ready for ClawSweeper re-review and maintainer review.

What is still waiting on author, maintainer, CI, or external proof?

Waiting on CI, ClawSweeper re-review, and maintainer review.
