### PR TITLE
feat(cli): add `openclaw sessions compact` and fail loudly on CLI `/compact` (fixes #90640)

### DIFF
--- a/docs/cli/sessions.md
+++ b/docs/cli/sessions.md
@@ -172,6 +172,60 @@ Related:
 
 - Session config: [Configuration reference](/gateway/config-agents#session)
 
+## Compact a session
+
+Reclaim context budget for a wedged or oversized session. `openclaw sessions compact <key>` is the first-class wrapper around the `sessions.compact` gateway RPC and requires a running gateway.
+
+```bash
+openclaw sessions compact "agent:main:main"
+openclaw sessions compact "agent:main:main" --max-lines 200
+openclaw sessions compact "agent:work:main" --agent work --json
+```
+
+- Without `--max-lines`, the gateway LLM-summarizes the transcript. This can be slow, so the default `--timeout` is `180000` ms.
+- With `--max-lines <n>`, it truncates to the last `n` transcript lines and archives the prior transcript as a `.bak` sidecar.
+- `--agent <id>`: agent that owns the session; required for `global` keys.
+- `--url` / `--token` / `--password`: gateway connection overrides.
+- `--timeout <ms>`: RPC timeout in milliseconds.
+- `--json`: print the raw RPC payload.
+
+The command exits non-zero when the gateway reports a failed compaction or is unreachable, so crons and scripts never mistake a silent no-op for success.
+
+> Note: `openclaw agent --message '/compact ...'` is **not** a compaction path. Slash commands from the CLI are rejected by the authorized-sender check; that invocation exits non-zero with guidance pointing here instead of silently no-opping.
+
+### sessions.compact RPC
+
+`openclaw gateway call sessions.compact --params '<json>'` accepts:
+
+| Field      | Type        | Required | Description                                                |
+| ---------- | ----------- | -------- | ---------------------------------------------------------- |
+| `key`      | string      | yes      | Session key to compact (for example `agent:main:main`).    |
+| `agentId`  | string      | no       | Agent id that owns the session (for `global` keys).        |
+| `maxLines` | integer ≥ 1 | no       | Truncate to the last N lines instead of LLM summarization. |
+
+Example LLM-summarize response:
+
+```json
+{
+  "ok": true,
+  "key": "agent:main:main",
+  "compacted": true,
+  "result": { "tokensBefore": 243868, "tokensAfter": 34941 }
+}
+```
+
+Example truncate response (`--max-lines 200`):
+
+```json
+{
+  "ok": true,
+  "key": "agent:main:main",
+  "compacted": true,
+  "archived": "/home/user/.openclaw/agents/main/sessions/transcripts/<id>.jsonl.bak",
+  "kept": 200
+}
+```
+
 ## Related
 
 - [CLI reference](/cli)

--- a/docs/cli/sessions.md
+++ b/docs/cli/sessions.md
@@ -168,10 +168,6 @@ traffic. Use `--store <path>` for explicit offline repair of a store file.
 }
 ```
 
-Related:
-
-- Session config: [Configuration reference](/gateway/config-agents#session)
-
 ## Compact a session
 
 Reclaim context budget for a wedged or oversized session. `openclaw sessions compact <key>` is the first-class wrapper around the `sessions.compact` gateway RPC and requires a running gateway.
@@ -228,5 +224,6 @@ Example truncate response (`--max-lines 200`):
 
 ## Related
 
+- Session config: [Configuration reference](/gateway/config-agents#session)
 - [CLI reference](/cli)
 - [Session management](/concepts/session)

--- a/src/cli/program/register.status-health-sessions.test.ts
+++ b/src/cli/program/register.status-health-sessions.test.ts
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
   sessionsCommand: vi.fn(),
   sessionsCleanupCommand: vi.fn(),
   sessionsTailCommand: vi.fn(),
+  sessionsCompactCommand: vi.fn(),
   exportTrajectoryCommand: vi.fn(),
   commitmentsListCommand: vi.fn(),
   commitmentsDismissCommand: vi.fn(),
@@ -34,6 +35,7 @@ const healthCommand = mocks.healthCommand;
 const sessionsCommand = mocks.sessionsCommand;
 const sessionsCleanupCommand = mocks.sessionsCleanupCommand;
 const sessionsTailCommand = mocks.sessionsTailCommand;
+const sessionsCompactCommand = mocks.sessionsCompactCommand;
 const exportTrajectoryCommand = mocks.exportTrajectoryCommand;
 const commitmentsListCommand = mocks.commitmentsListCommand;
 const commitmentsDismissCommand = mocks.commitmentsDismissCommand;
@@ -95,6 +97,10 @@ vi.mock("../../commands/sessions-tail.js", () => ({
   sessionsTailCommand: mocks.sessionsTailCommand,
 }));
 
+vi.mock("../../commands/sessions-compact.js", () => ({
+  sessionsCompactCommand: mocks.sessionsCompactCommand,
+}));
+
 vi.mock("../../commands/export-trajectory.js", () => ({
   exportTrajectoryCommand: mocks.exportTrajectoryCommand,
 }));
@@ -142,6 +148,7 @@ describe("registerStatusHealthSessionsCommands", () => {
     sessionsCommand.mockResolvedValue(undefined);
     sessionsCleanupCommand.mockResolvedValue(undefined);
     sessionsTailCommand.mockResolvedValue(undefined);
+    sessionsCompactCommand.mockResolvedValue(undefined);
     exportTrajectoryCommand.mockResolvedValue(undefined);
     commitmentsListCommand.mockResolvedValue(undefined);
     commitmentsDismissCommand.mockResolvedValue(undefined);
@@ -286,6 +293,33 @@ describe("registerStatusHealthSessionsCommands", () => {
       allAgents: true,
       active: "120",
       limit: "25",
+    });
+  });
+
+  it("inherits the parent sessions --agent for compact (regression #91378: wrong-agent compaction)", async () => {
+    await runCli(["sessions", "--agent", "work", "compact", "agent:work:main"]);
+
+    expectCommandOptions(sessionsCompactCommand, {
+      key: "agent:work:main",
+      agent: "work",
+    });
+  });
+
+  it("inherits the parent sessions --json for compact", async () => {
+    await runCli(["sessions", "--json", "compact", "agent:work:main"]);
+
+    expectCommandOptions(sessionsCompactCommand, {
+      key: "agent:work:main",
+      json: true,
+    });
+  });
+
+  it("prefers the compact-level --agent over the parent sessions --agent", async () => {
+    await runCli(["sessions", "--agent", "main", "compact", "agent:work:main", "--agent", "work"]);
+
+    expectCommandOptions(sessionsCompactCommand, {
+      key: "agent:work:main",
+      agent: "work",
     });
   });
 

--- a/src/cli/program/register.status-health-sessions.test.ts
+++ b/src/cli/program/register.status-health-sessions.test.ts
@@ -323,6 +323,22 @@ describe("registerStatusHealthSessionsCommands", () => {
     });
   });
 
+  it("rejects an inherited parent --store for compact instead of mutating a different store (regression #91378)", async () => {
+    await runCli(["sessions", "--store", "/tmp/other-sessions.json", "compact", "agent:work:main"]);
+
+    expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("--store"));
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect(sessionsCompactCommand).not.toHaveBeenCalled();
+  });
+
+  it("rejects other unsupported inherited parent list options for compact", async () => {
+    await runCli(["sessions", "--all-agents", "--limit", "25", "compact", "agent:work:main"]);
+
+    expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("--all-agents"));
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect(sessionsCompactCommand).not.toHaveBeenCalled();
+  });
+
   it("forwards sessions list-side options", async () => {
     await runCli([
       "sessions",

--- a/src/cli/program/register.status-health-sessions.test.ts
+++ b/src/cli/program/register.status-health-sessions.test.ts
@@ -332,9 +332,18 @@ describe("registerStatusHealthSessionsCommands", () => {
   });
 
   it("rejects other unsupported inherited parent list options for compact", async () => {
-    await runCli(["sessions", "--all-agents", "--limit", "25", "compact", "agent:work:main"]);
+    await runCli([
+      "sessions",
+      "--all-agents",
+      "--limit",
+      "25",
+      "--verbose",
+      "compact",
+      "agent:work:main",
+    ]);
 
     expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("--all-agents"));
+    expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("--verbose"));
     expect(runtime.exit).toHaveBeenCalledWith(1);
     expect(sessionsCompactCommand).not.toHaveBeenCalled();
   });

--- a/src/cli/program/register.status-health-sessions.ts
+++ b/src/cli/program/register.status-health-sessions.ts
@@ -392,10 +392,41 @@ export function registerStatusHealthSessionsCommands(program: Command) {
     .action(async (key: string, opts, command) => {
       // Sibling `sessions` subcommands inherit parent options (see list/cleanup
       // above): `--agent`/`--json` may be supplied on the parent `sessions`
-      // command, e.g. `openclaw sessions --agent work compact <key>`. Merge them
+      // command, e.g. `openclaw sessions --agent work compact <key>`. Merge those
       // so a parent `--agent` is not silently dropped and the wrong agent's
       // session compacted.
-      const parentOpts = command.parent?.opts() as { agent?: string; json?: boolean } | undefined;
+      //
+      // The parent also defines list-only options (`--store`/`--all-agents`/
+      // `--active`/`--limit`). `compact` mutates the single session the gateway
+      // resolves from <key> + --agent, so it cannot honor a parent `--store`
+      // (the gateway picks the store) and the rest are meaningless here.
+      // Silently dropping `--store` is the dangerous case — the user could
+      // believe they targeted one store while the gateway compacts another — so
+      // reject any unsupported inherited option instead of ignoring it.
+      const parentOpts = command.parent?.opts() as
+        | {
+            agent?: string;
+            json?: boolean;
+            store?: string;
+            allAgents?: boolean;
+            active?: string;
+            limit?: string;
+          }
+        | undefined;
+      const unsupportedParentOptions = [
+        parentOpts?.store !== undefined ? "--store" : undefined,
+        parentOpts?.allAgents ? "--all-agents" : undefined,
+        parentOpts?.active !== undefined ? "--active" : undefined,
+        parentOpts?.limit !== undefined ? "--limit" : undefined,
+      ].filter((flag): flag is string => flag !== undefined);
+      if (unsupportedParentOptions.length > 0) {
+        const plural = unsupportedParentOptions.length > 1 ? "options" : "option";
+        defaultRuntime.error(
+          `\`sessions compact\` does not support the parent \`sessions\` ${plural} ${unsupportedParentOptions.join(", ")}; the gateway resolves the target store from <key> and --agent.`,
+        );
+        defaultRuntime.exit(1);
+        return;
+      }
       const maxLines = parseStrictPositiveIntOrUndefined(opts.maxLines);
       if (opts.maxLines !== undefined && maxLines === undefined) {
         defaultRuntime.error("--max-lines must be a positive integer.");

--- a/src/cli/program/register.status-health-sessions.ts
+++ b/src/cli/program/register.status-health-sessions.ts
@@ -389,7 +389,13 @@ export function registerStatusHealthSessionsCommands(program: Command) {
           "Backed by the sessions.compact gateway RPC; exits non-zero when compaction fails.",
         )}`,
     )
-    .action(async (key: string, opts) => {
+    .action(async (key: string, opts, command) => {
+      // Sibling `sessions` subcommands inherit parent options (see list/cleanup
+      // above): `--agent`/`--json` may be supplied on the parent `sessions`
+      // command, e.g. `openclaw sessions --agent work compact <key>`. Merge them
+      // so a parent `--agent` is not silently dropped and the wrong agent's
+      // session compacted.
+      const parentOpts = command.parent?.opts() as { agent?: string; json?: boolean } | undefined;
       const maxLines = parseStrictPositiveIntOrUndefined(opts.maxLines);
       if (opts.maxLines !== undefined && maxLines === undefined) {
         defaultRuntime.error("--max-lines must be a positive integer.");
@@ -407,13 +413,13 @@ export function registerStatusHealthSessionsCommands(program: Command) {
         await sessionsCompactCommand(
           {
             key,
-            agent: opts.agent as string | undefined,
+            agent: (opts.agent as string | undefined) ?? parentOpts?.agent,
             maxLines,
             timeout: timeoutMs !== undefined ? String(timeoutMs) : undefined,
             url: opts.url as string | undefined,
             token: opts.token as string | undefined,
             password: opts.password as string | undefined,
-            json: Boolean(opts.json),
+            json: Boolean(opts.json || parentOpts?.json),
           },
           defaultRuntime,
         );

--- a/src/cli/program/register.status-health-sessions.ts
+++ b/src/cli/program/register.status-health-sessions.ts
@@ -356,6 +356,70 @@ export function registerStatusHealthSessionsCommands(program: Command) {
       });
     });
 
+  sessionsCmd
+    .command("compact <key>")
+    .description("Compact a stored session transcript via the running gateway")
+    .option("--agent <id>", "Agent id that owns the session (required for global keys)")
+    .option(
+      "--max-lines <count>",
+      "Truncate to the last N transcript lines instead of LLM summarization",
+    )
+    .option("--url <url>", "Gateway WebSocket URL (defaults to gateway.remote.url when configured)")
+    .option("--token <token>", "Gateway token (if required)")
+    .option("--password <password>", "Gateway password (password auth)")
+    .option("--timeout <ms>", "RPC timeout in milliseconds (summarization can be slow)", "180000")
+    .option("--json", "Output JSON", false)
+    .addHelpText(
+      "after",
+      () =>
+        `\n${theme.heading("Examples:")}\n${formatHelpExamples([
+          [
+            'openclaw sessions compact "agent:main:main"',
+            "LLM-summarize a session to reclaim context budget.",
+          ],
+          [
+            'openclaw sessions compact "agent:main:main" --max-lines 200',
+            "Truncate to the last 200 transcript lines instead.",
+          ],
+          [
+            'openclaw sessions compact "agent:work:main" --agent work --json',
+            "Target one agent's session and emit JSON.",
+          ],
+        ])}\n\n${theme.muted(
+          "Backed by the sessions.compact gateway RPC; exits non-zero when compaction fails.",
+        )}`,
+    )
+    .action(async (key: string, opts) => {
+      const maxLines = parseStrictPositiveIntOrUndefined(opts.maxLines);
+      if (opts.maxLines !== undefined && maxLines === undefined) {
+        defaultRuntime.error("--max-lines must be a positive integer.");
+        defaultRuntime.exit(1);
+        return;
+      }
+      const timeoutMs = parseStrictPositiveIntOrUndefined(opts.timeout);
+      if (opts.timeout !== undefined && timeoutMs === undefined) {
+        defaultRuntime.error("--timeout must be a positive integer (milliseconds).");
+        defaultRuntime.exit(1);
+        return;
+      }
+      await runCommandWithRuntime(defaultRuntime, async () => {
+        const { sessionsCompactCommand } = await import("../../commands/sessions-compact.js");
+        await sessionsCompactCommand(
+          {
+            key,
+            agent: opts.agent as string | undefined,
+            maxLines,
+            timeout: timeoutMs !== undefined ? String(timeoutMs) : undefined,
+            url: opts.url as string | undefined,
+            token: opts.token as string | undefined,
+            password: opts.password as string | undefined,
+            json: Boolean(opts.json),
+          },
+          defaultRuntime,
+        );
+      });
+    });
+
   const commitmentsCmd = program
     .command("commitments")
     .description("List and manage inferred follow-up commitments")

--- a/src/cli/program/register.status-health-sessions.ts
+++ b/src/cli/program/register.status-health-sessions.ts
@@ -411,6 +411,7 @@ export function registerStatusHealthSessionsCommands(program: Command) {
             allAgents?: boolean;
             active?: string;
             limit?: string;
+            verbose?: boolean;
           }
         | undefined;
       const unsupportedParentOptions = [
@@ -418,6 +419,7 @@ export function registerStatusHealthSessionsCommands(program: Command) {
         parentOpts?.allAgents ? "--all-agents" : undefined,
         parentOpts?.active !== undefined ? "--active" : undefined,
         parentOpts?.limit !== undefined ? "--limit" : undefined,
+        parentOpts?.verbose ? "--verbose" : undefined,
       ].filter((flag): flag is string => flag !== undefined);
       if (unsupportedParentOptions.length > 0) {
         const plural = unsupportedParentOptions.length > 1 ? "options" : "option";

--- a/src/commands/agent-via-gateway.test.ts
+++ b/src/commands/agent-via-gateway.test.ts
@@ -1518,29 +1518,6 @@ describe("agentCliCommand", () => {
     });
   });
 
-  it("does not run a fresh embedded session when a /compact control command times out", async () => {
-    await withTempStore(async () => {
-      callGateway.mockRejectedValue(createGatewayTimeoutError());
-
-      await expect(
-        agentCliCommand(
-          {
-            message: "/compact",
-            sessionId: "locked-session",
-            runId: "locked-run",
-          },
-          runtime,
-        ),
-      ).rejects.toThrow("gateway timeout");
-
-      expect(callGateway).toHaveBeenCalledTimes(1);
-      expect(agentCommand).not.toHaveBeenCalled();
-      expect(
-        mockMessages(runtime.error).some((message) => message.includes("EMBEDDED FALLBACK")),
-      ).toBe(false);
-    });
-  });
-
   it("uses the explicit session key agent for timeout fallback sessions", async () => {
     await withTempStore(async () => {
       callGateway.mockRejectedValue(createGatewayTimeoutError());
@@ -1809,5 +1786,48 @@ describe("agentCliCommand", () => {
       expect(fallbackOpts.cleanupCliLiveSessionOnRunEnd).toBe(true);
       expect(fallbackOpts.oneShotCliRun).toBe(false);
     });
+  });
+
+  for (const message of [
+    "/compact",
+    "/compact Keep recent decisions.",
+    "/compact:Keep recent decisions.",
+    "/COMPACT",
+    "  /Compact  ",
+  ]) {
+    it(`rejects ${JSON.stringify(message)} from the CLI before any gateway or embedded turn`, async () => {
+      await withTempStore(async () => {
+        callGateway.mockRejectedValue(createGatewayTimeoutError());
+
+        await agentCliCommand(
+          { message, sessionId: "locked-session", runId: "locked-run", timeout: "0" },
+          runtime,
+        );
+      });
+
+      // The slash-command handler rejects CLI senders, so a /compact turn would
+      // otherwise fall through to a normal turn and exit 0 without compacting.
+      // It must fail loudly before touching the gateway or a fresh embedded session.
+      expect(callGateway).not.toHaveBeenCalled();
+      expect(agentCommand).not.toHaveBeenCalled();
+      expect(runtime.exit).toHaveBeenCalledWith(1);
+      const errorMessages = mockMessages(runtime.error);
+      expect(errorMessages.some((m) => m.includes("openclaw sessions compact"))).toBe(true);
+      expect(errorMessages.some((m) => m.includes("EMBEDDED FALLBACK"))).toBe(false);
+    });
+  }
+
+  it("does not mistake a /compacting-prefixed message for the /compact control command", async () => {
+    await withTempStore(async () => {
+      mockGatewaySuccessReply();
+
+      await agentCliCommand(
+        { message: "/compacting the report, please", to: "+15555550123", timeout: "0" },
+        runtime,
+      );
+    });
+
+    expect(callGateway).toHaveBeenCalledTimes(1);
+    expect(runtime.exit).not.toHaveBeenCalledWith(1);
   });
 });

--- a/src/commands/agent-via-gateway.ts
+++ b/src/commands/agent-via-gateway.ts
@@ -231,9 +231,8 @@ function isGatewayAgentTimeoutError(err: unknown): boolean {
   return err instanceof Error && err.message.includes("gateway request timeout for agent");
 }
 
-function isControlCommandThatMustNotFallback(opts: Pick<AgentCliOpts, "message">): boolean {
-  const normalized = opts.message.trim().toLowerCase();
-  return normalized === "/compact" || normalized.startsWith("/compact ");
+function isCompactControlCommand(message: string): boolean {
+  return /^\/compact(?:\s|:|$)/iu.test(message.trim());
 }
 
 function isSessionResetCommand(message: string): boolean {
@@ -839,6 +838,17 @@ export async function agentCliCommand(
   deps?: AgentCliDeps,
 ) {
   protectJsonStdout(opts);
+  // `/compact` cannot run as a plain CLI agent turn: the slash-command handler
+  // rejects CLI-originated senders, so the message would fall through to a
+  // normal turn and exit 0 without compacting anything (issue #90640 Gap B).
+  // Fail loudly and point at the first-class command instead of no-opping.
+  if (isCompactControlCommand(opts.message)) {
+    runtime.error?.(
+      "Slash commands cannot be executed via --message from the CLI. Use: openclaw sessions compact <key>",
+    );
+    runtime.exit(1);
+    return undefined;
+  }
   const dispatchOpts = await normalizeSessionKeyOptsForDispatch(opts);
   validateExplicitSessionKeyForDispatch(dispatchOpts);
   const gatewayDispatchOpts = dispatchOpts.runId
@@ -876,9 +886,6 @@ export async function agentCliCommand(
         throw err;
       }
       if (isGatewayAgentTimeoutError(err)) {
-        if (isControlCommandThatMustNotFallback(dispatchOpts)) {
-          throw err;
-        }
         const fallbackAgentId = await resolveAgentIdForGatewayTimeoutFallback(dispatchOpts);
         const fallbackSession = createGatewayTimeoutFallbackSession(fallbackAgentId);
         runtime.error?.(

--- a/src/commands/sessions-compact.test.ts
+++ b/src/commands/sessions-compact.test.ts
@@ -1,0 +1,103 @@
+// Sessions compact command tests cover non-zero exits on failure and param forwarding.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { sessionsCompactCommand } from "./sessions-compact.js";
+
+const callGatewayCli = vi.hoisted(() => vi.fn());
+
+vi.mock("../cli/gateway-cli/call.js", () => ({ callGatewayCli }));
+
+function createRuntime() {
+  return {
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: vi.fn(),
+    writeStdout: vi.fn(),
+    writeJson: vi.fn(),
+  };
+}
+
+function joinedArgs(mock: { mock: { calls: unknown[][] } }): string {
+  return mock.mock.calls.map((call) => String(call[0])).join("\n");
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("sessionsCompactCommand", () => {
+  it("prints the token delta and does not exit on a successful compaction", async () => {
+    callGatewayCli.mockResolvedValue({
+      ok: true,
+      key: "agent:main:main",
+      compacted: true,
+      result: { tokensBefore: 243868, tokensAfter: 34941 },
+    });
+    const runtime = createRuntime();
+
+    await sessionsCompactCommand({ key: "agent:main:main" }, runtime);
+
+    expect(runtime.exit).not.toHaveBeenCalled();
+    const logged = joinedArgs(runtime.log);
+    expect(logged).toContain("243868");
+    expect(logged).toContain("34941");
+  });
+
+  it("exits non-zero when the gateway reports ok:false (no silent no-op)", async () => {
+    callGatewayCli.mockResolvedValue({
+      ok: false,
+      key: "agent:main:main",
+      compacted: false,
+      reason: "summarize interrupted",
+    });
+    const runtime = createRuntime();
+
+    await sessionsCompactCommand({ key: "agent:main:main" }, runtime);
+
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect(joinedArgs(runtime.error)).toContain("summarize interrupted");
+  });
+
+  it("exits non-zero and surfaces the error when the RPC throws", async () => {
+    callGatewayCli.mockRejectedValue(new Error("gateway unreachable"));
+    const runtime = createRuntime();
+
+    await sessionsCompactCommand({ key: "agent:main:main" }, runtime);
+
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect(joinedArgs(runtime.error)).toContain("gateway unreachable");
+  });
+
+  it("emits the payload and still exits non-zero in JSON mode when ok:false", async () => {
+    const payload = {
+      ok: false,
+      key: "agent:main:main",
+      compacted: false,
+      reason: "summarize interrupted",
+    };
+    callGatewayCli.mockResolvedValue(payload);
+    const runtime = createRuntime();
+
+    await sessionsCompactCommand({ key: "agent:main:main", json: true }, runtime);
+
+    expect(runtime.writeJson).toHaveBeenCalledTimes(1);
+    expect(runtime.writeJson.mock.calls[0][0]).toEqual(payload);
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+  });
+
+  it("forwards agentId and maxLines to the RPC params", async () => {
+    callGatewayCli.mockResolvedValue({
+      ok: true,
+      key: "agent:work:main",
+      compacted: true,
+      kept: 200,
+    });
+    const runtime = createRuntime();
+
+    await sessionsCompactCommand({ key: "agent:work:main", agent: "work", maxLines: 200 }, runtime);
+
+    expect(callGatewayCli).toHaveBeenCalledTimes(1);
+    const [method, , params] = callGatewayCli.mock.calls[0];
+    expect(method).toBe("sessions.compact");
+    expect(params).toEqual({ key: "agent:work:main", agentId: "work", maxLines: 200 });
+  });
+});

--- a/src/commands/sessions-compact.test.ts
+++ b/src/commands/sessions-compact.test.ts
@@ -42,6 +42,29 @@ describe("sessionsCompactCommand", () => {
     expect(logged).toContain("34941");
   });
 
+  it("reports an asynchronously started Codex compaction as pending, not a no-op", async () => {
+    // Codex app-server `thread/compact/start` returns ok:true / compacted:false
+    // with a pending marker; completion is delivered later, so this is a started
+    // compaction, NOT "no compaction needed".
+    callGatewayCli.mockResolvedValue({
+      ok: true,
+      key: "agent:main:main",
+      compacted: false,
+      result: {
+        tokensBefore: 1200,
+        details: { backend: "codex-app-server", signal: "thread/compact/start", pending: true },
+      },
+    });
+    const runtime = createRuntime();
+
+    await sessionsCompactCommand({ key: "agent:main:main" }, runtime);
+
+    expect(runtime.exit).not.toHaveBeenCalled();
+    const logged = joinedArgs(runtime.log);
+    expect(logged).toContain("pending");
+    expect(logged).not.toContain("No compaction needed");
+  });
+
   it("exits non-zero when the gateway reports ok:false (no silent no-op)", async () => {
     callGatewayCli.mockResolvedValue({
       ok: false,

--- a/src/commands/sessions-compact.test.ts
+++ b/src/commands/sessions-compact.test.ts
@@ -80,6 +80,16 @@ describe("sessionsCompactCommand", () => {
     expect(joinedArgs(runtime.error)).toContain("summarize interrupted");
   });
 
+  it("exits non-zero when the gateway response omits explicit success", async () => {
+    callGatewayCli.mockResolvedValue({ key: "agent:main:main", compacted: false });
+    const runtime = createRuntime();
+
+    await sessionsCompactCommand({ key: "agent:main:main" }, runtime);
+
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect(joinedArgs(runtime.error)).toContain("Compaction failed");
+  });
+
   it("exits non-zero and surfaces the error when the RPC throws", async () => {
     callGatewayCli.mockRejectedValue(new Error("gateway unreachable"));
     const runtime = createRuntime();

--- a/src/commands/sessions-compact.ts
+++ b/src/commands/sessions-compact.ts
@@ -1,0 +1,114 @@
+/**
+ * Sessions compact command.
+ *
+ * Wraps the `sessions.compact` Gateway RPC behind `openclaw sessions compact <key>`
+ * so wedged sessions have a documented, first-class recovery path. The command
+ * propagates a non-zero exit whenever the gateway reports a failed compaction
+ * (transport error or an `ok:false` payload) so automation never mistakes a
+ * silent no-op for success.
+ */
+import { callGatewayCli, type GatewayRpcOpts } from "../cli/gateway-cli/call.js";
+import { formatErrorMessage } from "../infra/errors.js";
+import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
+
+export type SessionsCompactCliOptions = {
+  key: string;
+  agent?: string;
+  maxLines?: number;
+  timeout?: string;
+  url?: string;
+  token?: string;
+  password?: string;
+  json?: boolean;
+};
+
+type SessionsCompactResult = {
+  ok?: boolean;
+  key?: string;
+  compacted?: boolean;
+  reason?: string;
+  kept?: number;
+  archived?: string;
+  result?: {
+    tokensBefore?: number;
+    tokensAfter?: number;
+    sessionId?: string;
+    sessionFile?: string;
+  };
+};
+
+function describeCompaction(result: SessionsCompactResult, fallbackKey: string): string {
+  const sessionKey = result.key ?? fallbackKey;
+  if (!result.compacted) {
+    const reason = result.reason ? ` (${result.reason})` : "";
+    return `No compaction needed for session ${sessionKey}${reason}.`;
+  }
+  const before = result.result?.tokensBefore;
+  const after = result.result?.tokensAfter;
+  let detail = "";
+  if (typeof before === "number" && typeof after === "number") {
+    detail = ` (${before} → ${after} tokens)`;
+  } else if (typeof result.kept === "number") {
+    detail = ` (kept ${result.kept} lines)`;
+  }
+  return `Compacted session ${sessionKey}${detail}.`;
+}
+
+/** Run `openclaw sessions compact <key>` against the running gateway. */
+export async function sessionsCompactCommand(
+  opts: SessionsCompactCliOptions,
+  runtime: RuntimeEnv,
+): Promise<void> {
+  const rpcOpts: GatewayRpcOpts = {
+    url: opts.url,
+    token: opts.token,
+    password: opts.password,
+    timeout: opts.timeout,
+    json: opts.json,
+  };
+  const params = {
+    key: opts.key,
+    ...(opts.agent ? { agentId: opts.agent } : {}),
+    ...(opts.maxLines !== undefined ? { maxLines: opts.maxLines } : {}),
+  };
+
+  let result: SessionsCompactResult;
+  try {
+    result = (await callGatewayCli("sessions.compact", rpcOpts, params)) as SessionsCompactResult;
+  } catch (err) {
+    const message = formatErrorMessage(err);
+    if (opts.json) {
+      writeRuntimeJson(runtime, { ok: false, key: opts.key, error: message });
+    } else {
+      runtime.error(`Compaction failed: ${message}`);
+    }
+    runtime.exit(1);
+    return;
+  }
+
+  // An explicit ok:false means the gateway accepted the request but the
+  // compaction itself did not complete (for example an interrupted summarize
+  // run). Surface it as a failure instead of letting the process exit 0.
+  const failed = result?.ok === false;
+
+  if (opts.json) {
+    writeRuntimeJson(runtime, result);
+    if (failed) {
+      runtime.exit(1);
+    }
+    return;
+  }
+
+  if (failed) {
+    const sessionKey = result?.key ?? opts.key;
+    const reason = result?.reason ? `: ${result.reason}` : "";
+    runtime.error(`Compaction failed for session ${sessionKey}${reason}.`);
+    runtime.exit(1);
+    return;
+  }
+
+  runtime.log(describeCompaction(result ?? {}, opts.key));
+  if (result?.archived) {
+    runtime.log(`Archived transcript: ${result.archived}`);
+  }
+}

--- a/src/commands/sessions-compact.ts
+++ b/src/commands/sessions-compact.ts
@@ -34,12 +34,25 @@ type SessionsCompactResult = {
     tokensAfter?: number;
     sessionId?: string;
     sessionFile?: string;
+    // Codex app-server `thread/compact/start` reports ok:true / compacted:false
+    // with this pending marker; the compaction was *started* and completion is
+    // delivered asynchronously, so it must not be rendered as "no work needed".
+    details?: {
+      backend?: string;
+      threadId?: string;
+      signal?: string;
+      pending?: boolean;
+    };
   };
 };
 
 function describeCompaction(result: SessionsCompactResult, fallbackKey: string): string {
   const sessionKey = result.key ?? fallbackKey;
   if (!result.compacted) {
+    const details = result.result?.details;
+    if (details?.pending === true || details?.signal === "thread/compact/start") {
+      return `Compaction started for session ${sessionKey} (pending; completion is reported asynchronously by the backend).`;
+    }
     const reason = result.reason ? ` (${result.reason})` : "";
     return `No compaction needed for session ${sessionKey}${reason}.`;
   }

--- a/src/commands/sessions-compact.ts
+++ b/src/commands/sessions-compact.ts
@@ -99,10 +99,9 @@ export async function sessionsCompactCommand(
     return;
   }
 
-  // An explicit ok:false means the gateway accepted the request but the
-  // compaction itself did not complete (for example an interrupted summarize
-  // run). Surface it as a failure instead of letting the process exit 0.
-  const failed = result?.ok === false;
+  // Success is explicit. A malformed or version-skewed payload must not turn
+  // into the same exit-0 message as a genuine no-op compaction.
+  const failed = result?.ok !== true;
 
   if (opts.json) {
     writeRuntimeJson(runtime, result);

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { SessionManager } from "../../agents/sessions/session-manager.js";
 import { onSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
 import type { OpenClawConfig } from "../types.openclaw.js";
 import {
@@ -936,21 +937,51 @@ describe("session accessor file-backed seam", () => {
       totalTokensFresh: true,
       updatedAt: 100,
     });
-    fs.writeFileSync(manualTranscriptPath, "line 1\n\nline 2\nline 3\nline 4\n", "utf-8");
+    const transcriptRecords = [
+      {
+        type: "session",
+        version: 3,
+        id: sessionId,
+        timestamp: "2026-06-19T12:00:00.000Z",
+        cwd: tempDir,
+      },
+      ...[1, 2, 3, 4].map((index) => ({
+        type: "message",
+        id: `entry-${index}`,
+        parentId: index === 1 ? null : `entry-${index - 1}`,
+        timestamp: `2026-06-19T12:00:0${index}.000Z`,
+        message: { role: "user", content: `message ${index}`, timestamp: index },
+      })),
+    ];
+    const originalTranscript = `${transcriptRecords.map((record) => JSON.stringify(record)).join("\n")}\n`;
+    fs.writeFileSync(manualTranscriptPath, originalTranscript, { encoding: "utf-8", mode: 0o640 });
     const updates: unknown[] = [];
     const unsubscribe = onSessionTranscriptUpdate((update) => updates.push(update));
 
     const result = await trimSessionTranscriptForManualCompact(scope, {
-      maxLines: 2,
+      maxLines: 3,
       nowMs: 500,
     });
 
     unsubscribe();
-    expect(result).toMatchObject({ compacted: true, kept: 2 });
+    expect(result).toMatchObject({ compacted: true, kept: 3 });
     const archived = result.compacted ? result.archived : "";
     expect(path.basename(archived)).toMatch(new RegExp(`^${sessionId}\\.jsonl\\.bak\\.`));
-    expect(fs.readFileSync(archived, "utf-8")).toBe("line 1\n\nline 2\nline 3\nline 4\n");
-    expect(fs.readFileSync(manualTranscriptPath, "utf-8")).toBe("line 3\nline 4\n");
+    expect(fs.readFileSync(archived, "utf-8")).toBe(originalTranscript);
+    const trimmedRecords = fs
+      .readFileSync(manualTranscriptPath, "utf-8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    expect(trimmedRecords).toMatchObject([
+      { type: "session", id: sessionId },
+      { type: "message", id: "entry-3", parentId: null },
+      { type: "message", id: "entry-4", parentId: "entry-3" },
+    ]);
+    expect(fs.statSync(manualTranscriptPath).mode & 0o777).toBe(0o600);
+    const reopened = SessionManager.open(manualTranscriptPath, tempDir, tempDir);
+    expect(reopened.getEntries().map((entry) => entry.id)).toEqual(["entry-3", "entry-4"]);
+    expect(reopened.buildSessionContext().messages).toHaveLength(2);
     const updatedEntry = loadSessionEntry(scope);
     expect(updatedEntry).toMatchObject({
       sessionFile: manualTranscriptPath,
@@ -963,6 +994,283 @@ describe("session accessor file-backed seam", () => {
     expect(updatedEntry?.totalTokens).toBeUndefined();
     expect(updatedEntry?.totalTokensFresh).toBeUndefined();
     expect(updates).toEqual([{ sessionFile: archived }]);
+  });
+
+  it("keeps retained messages reachable through an out-of-window label", async () => {
+    const sessionId = "22222222-2222-4222-8222-222222222222";
+    const sessionFile = path.join(tempDir, `${sessionId}.jsonl`);
+    const scope = {
+      agentId: "main",
+      sessionId,
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+    const records = [
+      {
+        type: "session",
+        version: 3,
+        id: sessionId,
+        timestamp: "2026-06-19T12:00:00.000Z",
+        cwd: tempDir,
+      },
+      {
+        type: "message",
+        id: "old",
+        parentId: null,
+        timestamp: "2026-06-19T12:00:01.000Z",
+        message: { role: "user", content: "old", timestamp: 1 },
+      },
+      {
+        type: "message",
+        id: "kept-1",
+        parentId: "old",
+        timestamp: "2026-06-19T12:00:02.000Z",
+        message: { role: "user", content: "kept one", timestamp: 2 },
+      },
+      {
+        type: "label",
+        id: "label-1",
+        parentId: "kept-1",
+        targetId: "old",
+        label: "trimmed target",
+        timestamp: "2026-06-19T12:00:03.000Z",
+      },
+      {
+        type: "message",
+        id: "kept-2",
+        parentId: "label-1",
+        timestamp: "2026-06-19T12:00:04.000Z",
+        message: { role: "user", content: "kept two", timestamp: 4 },
+      },
+    ];
+    await upsertSessionEntry(scope, { sessionFile, sessionId, updatedAt: 1 });
+    fs.writeFileSync(
+      sessionFile,
+      `${records.map((record) => JSON.stringify(record)).join("\n")}\n`,
+      "utf-8",
+    );
+
+    await expect(
+      trimSessionTranscriptForManualCompact(scope, { maxLines: 4 }),
+    ).resolves.toMatchObject({ compacted: true, kept: 4 });
+
+    const context = SessionManager.open(sessionFile, tempDir, tempDir).buildSessionContext();
+    expect(JSON.stringify(context.messages)).toContain("kept one");
+    expect(JSON.stringify(context.messages)).toContain("kept two");
+  });
+
+  it("does not reactivate an abandoned branch when a leaf target was trimmed", async () => {
+    const sessionId = "44444444-4444-4444-8444-444444444444";
+    const sessionFile = path.join(tempDir, `${sessionId}.jsonl`);
+    const scope = {
+      agentId: "main",
+      sessionId,
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+    const records = [
+      {
+        type: "session",
+        version: 3,
+        id: sessionId,
+        timestamp: "2026-06-19T12:00:00.000Z",
+        cwd: tempDir,
+      },
+      {
+        type: "message",
+        id: "selected-before-window",
+        parentId: null,
+        timestamp: "2026-06-19T12:00:01.000Z",
+        message: { role: "user", content: "selected", timestamp: 1 },
+      },
+      {
+        type: "message",
+        id: "abandoned-side-row",
+        parentId: "selected-before-window",
+        appendMode: "side",
+        timestamp: "2026-06-19T12:00:02.000Z",
+        message: { role: "user", content: "must stay hidden", timestamp: 2 },
+      },
+      {
+        type: "leaf",
+        id: "leaf-1",
+        parentId: "abandoned-side-row",
+        targetId: "selected-before-window",
+        appendParentId: "selected-before-window",
+        timestamp: "2026-06-19T12:00:03.000Z",
+      },
+    ];
+    await upsertSessionEntry(scope, { sessionFile, sessionId, updatedAt: 1 });
+    fs.writeFileSync(
+      sessionFile,
+      `${records.map((record) => JSON.stringify(record)).join("\n")}\n`,
+      "utf-8",
+    );
+
+    await expect(
+      trimSessionTranscriptForManualCompact(scope, { maxLines: 3 }),
+    ).resolves.toMatchObject({ compacted: true, kept: 3 });
+
+    const persisted = fs
+      .readFileSync(sessionFile, "utf-8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    expect(persisted.find((entry) => entry.type === "leaf")).toMatchObject({
+      targetId: null,
+      appendParentId: null,
+    });
+    expect(
+      SessionManager.open(sessionFile, tempDir, tempDir).buildSessionContext().messages,
+    ).toEqual([]);
+  });
+
+  it("keeps malformed leaf controls transparent while re-rooting retained descendants", async () => {
+    const sessionId = "55555555-5555-4555-8555-555555555555";
+    const sessionFile = path.join(tempDir, `${sessionId}.jsonl`);
+    const scope = {
+      agentId: "main",
+      sessionId,
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+    const records = [
+      {
+        type: "session",
+        version: 3,
+        id: sessionId,
+        timestamp: "2026-06-19T12:00:00.000Z",
+        cwd: tempDir,
+      },
+      {
+        type: "message",
+        id: "trimmed",
+        parentId: null,
+        message: { role: "user", content: "trimmed", timestamp: 1 },
+        timestamp: "2026-06-19T12:00:01.000Z",
+      },
+      {
+        type: "message",
+        id: "retained-root",
+        parentId: "trimmed",
+        message: { role: "user", content: "retained root", timestamp: 2 },
+        timestamp: "2026-06-19T12:00:02.000Z",
+      },
+      {
+        type: "leaf",
+        id: "malformed-leaf",
+        parentId: "retained-root",
+        timestamp: "2026-06-19T12:00:03.000Z",
+      },
+      {
+        type: "message",
+        id: "retained-child",
+        parentId: "malformed-leaf",
+        message: { role: "user", content: "retained child", timestamp: 4 },
+        timestamp: "2026-06-19T12:00:04.000Z",
+      },
+    ];
+    await upsertSessionEntry(scope, { sessionFile, sessionId, updatedAt: 1 });
+    fs.writeFileSync(
+      sessionFile,
+      `${records.map((record) => JSON.stringify(record)).join("\n")}\n`,
+    );
+
+    await expect(
+      trimSessionTranscriptForManualCompact(scope, { maxLines: 4 }),
+    ).resolves.toMatchObject({ compacted: true, kept: 4 });
+
+    const serializedContext = JSON.stringify(
+      SessionManager.open(sessionFile, tempDir, tempDir).buildSessionContext().messages,
+    );
+    expect(serializedContext).toContain("retained root");
+    expect(serializedContext).toContain("retained child");
+  });
+
+  it("repairs a retained compaction boundary when its first kept entry was trimmed", async () => {
+    const sessionId = "33333333-3333-4333-8333-333333333333";
+    const sessionFile = path.join(tempDir, `${sessionId}.jsonl`);
+    const scope = {
+      agentId: "main",
+      sessionId,
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+    const records = [
+      {
+        type: "session",
+        version: 3,
+        id: sessionId,
+        timestamp: "2026-06-19T12:00:00.000Z",
+        cwd: tempDir,
+      },
+      {
+        type: "message",
+        id: "old-boundary",
+        parentId: null,
+        timestamp: "2026-06-19T12:00:01.000Z",
+        message: { role: "user", content: "old", timestamp: 1 },
+      },
+      {
+        type: "message",
+        id: "kept-before-compaction",
+        parentId: "old-boundary",
+        timestamp: "2026-06-19T12:00:02.000Z",
+        message: { role: "user", content: "kept before", timestamp: 2 },
+      },
+      {
+        type: "compaction",
+        id: "compaction-1",
+        parentId: "kept-before-compaction",
+        timestamp: "2026-06-19T12:00:03.000Z",
+        summary: "summary",
+        firstKeptEntryId: "old-boundary",
+        tokensBefore: 100,
+      },
+      {
+        type: "compaction",
+        id: "compaction-2",
+        parentId: "compaction-1",
+        timestamp: "2026-06-19T12:00:04.000Z",
+        summary: "hardened summary",
+        firstKeptEntryId: "compaction-2",
+        tokensBefore: 50,
+      },
+      {
+        type: "message",
+        id: "kept-after-compaction",
+        parentId: "compaction-2",
+        timestamp: "2026-06-19T12:00:05.000Z",
+        message: { role: "user", content: "kept after", timestamp: 5 },
+      },
+    ];
+    await upsertSessionEntry(scope, { sessionFile, sessionId, updatedAt: 1 });
+    fs.writeFileSync(
+      sessionFile,
+      `${records.map((record) => JSON.stringify(record)).join("\n")}\n`,
+      "utf-8",
+    );
+
+    await expect(
+      trimSessionTranscriptForManualCompact(scope, { maxLines: 5 }),
+    ).resolves.toMatchObject({ compacted: true, kept: 5 });
+
+    const reopened = SessionManager.open(sessionFile, tempDir, tempDir);
+    expect(
+      reopened
+        .getEntries()
+        .find((entry) => entry.type === "compaction" && entry.id === "compaction-1"),
+    ).toMatchObject({
+      firstKeptEntryId: "kept-before-compaction",
+    });
+    expect(
+      reopened
+        .getEntries()
+        .find((entry) => entry.type === "compaction" && entry.id === "compaction-2"),
+    ).toMatchObject({ firstKeptEntryId: "compaction-2" });
+    const serializedContext = JSON.stringify(reopened.buildSessionContext().messages);
+    expect(serializedContext).not.toContain("kept before");
+    expect(serializedContext).toContain("kept after");
   });
 
   it("prefers the current generated transcript over a stale generated sessionFile", async () => {
@@ -981,16 +1289,43 @@ describe("session accessor file-backed seam", () => {
       sessionId: currentSessionId,
       updatedAt: 100,
     });
-    fs.writeFileSync(currentTranscriptPath, "current one\ncurrent two\n", "utf-8");
+    const currentHeader = {
+      type: "session",
+      version: 3,
+      id: currentSessionId,
+      timestamp: "2026-06-19T12:00:00.000Z",
+      cwd: tempDir,
+    };
+    const currentOne = {
+      type: "message",
+      id: "current-one",
+      parentId: null,
+      timestamp: "2026-06-19T12:00:01.000Z",
+      message: { role: "user", content: "current one", timestamp: 1 },
+    };
+    const currentTwo = {
+      type: "message",
+      id: "current-two",
+      parentId: "current-one",
+      timestamp: "2026-06-19T12:00:02.000Z",
+      message: { role: "user", content: "current two", timestamp: 2 },
+    };
+    fs.writeFileSync(
+      currentTranscriptPath,
+      `${[currentHeader, currentOne, currentTwo].map((record) => JSON.stringify(record)).join("\n")}\n`,
+      "utf-8",
+    );
     fs.writeFileSync(staleTranscriptPath, "stale one\nstale two\n", "utf-8");
 
     const result = await trimSessionTranscriptForManualCompact(scope, {
-      maxLines: 1,
+      maxLines: 2,
       sessionFile: staleTranscriptPath,
     });
 
-    expect(result).toMatchObject({ compacted: true, kept: 1 });
-    expect(fs.readFileSync(currentTranscriptPath, "utf-8")).toBe("current two\n");
+    expect(result).toMatchObject({ compacted: true, kept: 2 });
+    expect(fs.readFileSync(currentTranscriptPath, "utf-8")).toBe(
+      `${JSON.stringify(currentHeader)}\n${JSON.stringify({ ...currentTwo, parentId: null })}\n`,
+    );
     expect(fs.readFileSync(staleTranscriptPath, "utf-8")).toBe("stale one\nstale two\n");
   });
 

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -278,6 +278,12 @@ export type SessionTranscriptManualTrimResult =
       kept: number;
     };
 
+export type SessionTranscriptManualTrimPreflightResult =
+  | Extract<SessionTranscriptManualTrimResult, { compacted: false }>
+  | {
+      compacted: true;
+    };
+
 export type SessionEntryUpdateOptions = {
   /** Skip prune/cap/rotation maintenance for specialized internal updates. */
   skipMaintenance?: boolean;
@@ -944,6 +950,30 @@ export async function publishTranscriptUpdate(
  * This is one storage-sized mutation: future stores can trim transcript rows and
  * update entry metadata inside the same backend transaction.
  */
+export async function preflightSessionTranscriptForManualCompact(
+  scope: SessionTranscriptRuntimeScope,
+  params: { maxLines: number; sessionFile?: string },
+): Promise<SessionTranscriptManualTrimPreflightResult> {
+  const transcript = await resolveManualCompactTranscriptTarget(scope, params.sessionFile);
+  if (!transcript) {
+    return { compacted: false, reason: "no transcript" };
+  }
+
+  const maxLines = Math.max(1, Math.floor(params.maxLines));
+  let totalLines = 0;
+  try {
+    for await (const _line of streamSessionTranscriptLines(transcript.sessionFile)) {
+      totalLines += 1;
+      if (totalLines > maxLines) {
+        return { compacted: true };
+      }
+    }
+  } catch {
+    return { compacted: false, kept: 0 };
+  }
+  return { compacted: false, kept: totalLines };
+}
+
 export async function trimSessionTranscriptForManualCompact(
   scope: SessionTranscriptRuntimeScope,
   params: { maxLines: number; nowMs?: number; sessionFile?: string },

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -962,7 +962,7 @@ export async function preflightSessionTranscriptForManualCompact(
   const maxLines = Math.max(1, Math.floor(params.maxLines));
   let totalLines = 0;
   try {
-    for await (const _line of streamSessionTranscriptLines(transcript.sessionFile)) {
+    for await (const line of streamSessionTranscriptLines(transcript.sessionFile)) {
       totalLines += 1;
       if (totalLines > maxLines) {
         return { compacted: true };

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -80,6 +80,10 @@ import { writeJsonlLines } from "./transcript-jsonl.js";
 import { replayRecentUserAssistantMessages } from "./transcript-replay.js";
 import { streamSessionTranscriptLines } from "./transcript-stream.js";
 import {
+  scanSessionTranscriptTree,
+  selectSessionTranscriptTreePathNodes,
+} from "./transcript-tree.js";
+import {
   type OwnedSessionTranscriptPublishedEntry,
   resolveOwnedSessionTranscriptWriteLockRunner,
   withOwnedSessionTranscriptWrites,
@@ -963,6 +967,9 @@ export async function preflightSessionTranscriptForManualCompact(
   let totalLines = 0;
   try {
     for await (const line of streamSessionTranscriptLines(transcript.sessionFile)) {
+      if (!line) {
+        continue;
+      }
       totalLines += 1;
       if (totalLines > maxLines) {
         return { compacted: true };
@@ -984,14 +991,20 @@ export async function trimSessionTranscriptForManualCompact(
   }
 
   const maxLines = Math.max(1, Math.floor(params.maxLines));
-  const lines: string[] = [];
+  let headerLine: string | undefined;
+  const tailLines: string[] = [];
+  const maxTailLines = Math.max(0, maxLines - 1);
   let totalLines = 0;
   try {
     for await (const line of streamSessionTranscriptLines(transcript.sessionFile)) {
       totalLines += 1;
-      lines.push(line);
-      if (lines.length > maxLines) {
-        lines.shift();
+      if (totalLines === 1) {
+        headerLine = line;
+        continue;
+      }
+      tailLines.push(line);
+      if (tailLines.length > maxTailLines) {
+        tailLines.shift();
       }
     }
   } catch {
@@ -1001,8 +1014,11 @@ export async function trimSessionTranscriptForManualCompact(
     return { compacted: false, kept: totalLines };
   }
 
-  const archived = await archiveTranscriptFileForManualCompact(transcript.sessionFile);
-  await writeJsonlLines(transcript.sessionFile, lines);
+  const lines = normalizeManualCompactTranscriptLines(headerLine, tailLines);
+  if (!lines) {
+    return { compacted: false, kept: 0 };
+  }
+  const archived = await replaceTranscriptForManualCompact(transcript.sessionFile, lines);
   await patchSessionEntry(
     {
       ...scope,
@@ -1024,9 +1040,113 @@ export async function trimSessionTranscriptForManualCompact(
   return { archived, compacted: true, kept: lines.length };
 }
 
-async function archiveTranscriptFileForManualCompact(filePath: string): Promise<string> {
+function parseManualCompactTranscriptRecord(line: string): Record<string, unknown> | null {
+  try {
+    const parsed = JSON.parse(line) as unknown;
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function normalizeManualCompactTranscriptLines(
+  headerLine: string | undefined,
+  tailLines: readonly string[],
+): string[] | null {
+  if (!headerLine) {
+    return null;
+  }
+  const header = parseManualCompactTranscriptRecord(headerLine);
+  if (header?.type !== "session" || typeof header.id !== "string") {
+    return null;
+  }
+
+  const records = tailLines
+    .map(parseManualCompactTranscriptRecord)
+    .filter((record): record is Record<string, unknown> => record !== null);
+  const retainedIds = new Set<string>();
+  const transparentParents = new Map<string, string | null>();
+  const normalizedRecords: Record<string, unknown>[] = [];
+  for (const record of records) {
+    let parentId = record.parentId;
+    const seenTransparentParents = new Set<string>();
+    while (
+      typeof parentId === "string" &&
+      transparentParents.has(parentId) &&
+      !seenTransparentParents.has(parentId)
+    ) {
+      seenTransparentParents.add(parentId);
+      parentId = transparentParents.get(parentId) ?? null;
+    }
+    let next =
+      typeof parentId === "string" && !retainedIds.has(parentId)
+        ? { ...record, parentId: null }
+        : parentId !== record.parentId
+          ? { ...record, parentId }
+          : record;
+    if (next.type === "leaf") {
+      const targetId = next.targetId;
+      const validTargetId =
+        targetId === null || (typeof targetId === "string" && targetId.trim().length > 0);
+      if (!validTargetId && typeof next.id === "string") {
+        transparentParents.set(
+          next.id,
+          next.parentId === null || typeof next.parentId === "string" ? next.parentId : null,
+        );
+      }
+      if (typeof targetId === "string" && targetId.trim() && !retainedIds.has(targetId)) {
+        // The selected branch fell outside the retained window. Select an
+        // empty root instead of accidentally activating abandoned or side rows.
+        next = { ...next, targetId: null, appendParentId: null };
+      } else if (
+        validTargetId &&
+        typeof next.appendParentId === "string" &&
+        !retainedIds.has(next.appendParentId)
+      ) {
+        next = { ...next, appendParentId: targetId };
+      }
+    }
+    if (next.type === "compaction" && typeof next.id === "string") {
+      const firstKeptEntryId = next.firstKeptEntryId;
+      if (typeof firstKeptEntryId === "string" && firstKeptEntryId !== next.id) {
+        const tree = scanSessionTranscriptTree([...normalizedRecords, next]);
+        const branchPath = selectSessionTranscriptTreePathNodes(tree, next.id);
+        if (!branchPath.some((node) => node.id === firstKeptEntryId)) {
+          // Replay starts at the earliest retained entry on this compaction's
+          // normalized branch, never at an abandoned row earlier in file order.
+          next = { ...next, firstKeptEntryId: branchPath[0]?.id ?? next.id };
+        }
+      }
+    }
+    normalizedRecords.push(next);
+    if (typeof next.id === "string" && next.id.trim()) {
+      retainedIds.add(next.id);
+    }
+  }
+  return [JSON.stringify(header), ...normalizedRecords.map((record) => JSON.stringify(record))];
+}
+
+async function replaceTranscriptForManualCompact(
+  filePath: string,
+  lines: readonly string[],
+): Promise<string> {
   const archived = `${filePath}.bak.${formatSessionArchiveTimestamp()}`;
-  await fs.promises.rename(filePath, archived);
+  const replacement = `${filePath}.compact.${randomUUID()}.tmp`;
+  try {
+    await writeJsonlLines(replacement, lines, { flag: "wx", mode: 0o600 });
+    await fs.promises.rename(filePath, archived);
+    try {
+      await fs.promises.rename(replacement, filePath);
+    } catch (err) {
+      await fs.promises.rename(archived, filePath).catch(() => undefined);
+      throw err;
+    }
+  } catch (err) {
+    await fs.promises.unlink(replacement).catch(() => undefined);
+    throw err;
+  }
   emitSessionTranscriptUpdate({ sessionFile: archived });
   return archived;
 }

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -61,6 +61,7 @@ import { resolveAgentMainSessionKey } from "../../config/sessions/main-session.j
 import {
   applySessionPatchProjection,
   createSessionEntryWithTranscript,
+  preflightSessionTranscriptForManualCompact,
   trimSessionTranscriptForManualCompact,
 } from "../../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -2620,12 +2621,48 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       return;
     }
 
-    // Active-run safety parity with the LLM-summarize branch above. The
-    // maxLines truncate path archives the transcript and overwrites it in
-    // place, so an active runner could otherwise keep appending to the file we
-    // are about to archive and truncate, losing that output (the data-loss mode
-    // tracked by #72765). Interrupt any active run for this session *before*
-    // reading and truncating, exactly as the summarize branch does.
+    const trimPreflight = await preflightSessionTranscriptForManualCompact(
+      {
+        sessionId,
+        storePath,
+        sessionKey: compactTarget.primaryKey,
+        agentId: target.agentId,
+      },
+      {
+        maxLines,
+        sessionFile: entry?.sessionFile,
+      },
+    );
+    if (!trimPreflight.compacted) {
+      if ("kept" in trimPreflight) {
+        respond(
+          true,
+          {
+            ok: true,
+            key: target.canonicalKey,
+            compacted: false,
+            kept: trimPreflight.kept,
+          },
+          undefined,
+        );
+      } else {
+        respond(
+          true,
+          {
+            ok: true,
+            key: target.canonicalKey,
+            compacted: false,
+            reason: "no transcript",
+          },
+          undefined,
+        );
+      }
+      return;
+    }
+
+    // Active-run safety parity with the LLM-summarize branch above. The maxLines
+    // truncate path archives and overwrites the transcript, so once preflight
+    // proves a destructive trim is needed, interrupt before rereading and writing.
     const truncateInterrupt = await interruptSessionRunIfActive({
       req,
       context,

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -2620,6 +2620,27 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       return;
     }
 
+    // Active-run safety parity with the LLM-summarize branch above. The
+    // maxLines truncate path archives the transcript and overwrites it in
+    // place, so an active runner could otherwise keep appending to the file we
+    // are about to archive and truncate, losing that output (the data-loss mode
+    // tracked by #72765). Interrupt any active run for this session *before*
+    // reading and truncating, exactly as the summarize branch does.
+    const truncateInterrupt = await interruptSessionRunIfActive({
+      req,
+      context,
+      client,
+      isWebchatConnect,
+      requestedKey: key,
+      canonicalKey: target.canonicalKey,
+      agentId: requestedAgentId,
+      sessionId,
+    });
+    if (truncateInterrupt.error) {
+      respond(false, undefined, truncateInterrupt.error);
+      return;
+    }
+
     const trimResult = await trimSessionTranscriptForManualCompact(
       {
         sessionId,

--- a/src/gateway/server.sessions.compaction.test.ts
+++ b/src/gateway/server.sessions.compaction.test.ts
@@ -30,6 +30,26 @@ const { createSessionStoreDir, createSelectedGlobalSessionStore, openClient } =
 
 type CheckpointFixture = Awaited<ReturnType<typeof createCheckpointFixture>>;
 
+function buildSessionTranscriptLines(sessionId: string, totalLines: number): string[] {
+  const header = JSON.stringify({
+    type: "session",
+    version: 3,
+    id: sessionId,
+    timestamp: "2026-06-19T12:00:00.000Z",
+    cwd: "/tmp",
+  });
+  const entries = Array.from({ length: Math.max(0, totalLines - 1) }, (_, index) =>
+    JSON.stringify({
+      type: "message",
+      id: `entry-${index}`,
+      parentId: index === 0 ? null : `entry-${index - 1}`,
+      timestamp: `2026-06-19T12:00:${String(index % 60).padStart(2, "0")}.000Z`,
+      message: { role: "user", content: `line-${index}`, timestamp: index },
+    }),
+  );
+  return [header, ...entries];
+}
+
 function compactionCheckpointEntry(
   fixture: CheckpointFixture,
   options: {
@@ -609,9 +629,7 @@ test("sessions.compact treats Codex native compaction start as pending, not comp
 test("sessions.compact maxLines truncates the transcript on disk and archives the original to .bak", async () => {
   const { dir } = await createSessionStoreDir();
   const transcriptPath = path.join(dir, "sess-main.jsonl");
-  const originalLines = Array.from({ length: 500 }, (_, index) =>
-    JSON.stringify({ role: "user", content: `line-${index}` }),
-  );
+  const originalLines = buildSessionTranscriptLines("sess-main", 500);
   await fs.writeFile(transcriptPath, `${originalLines.join("\n")}\n`, "utf-8");
   await writeSessionStore({ entries: { main: sessionStoreEntry("sess-main") } });
 
@@ -628,10 +646,15 @@ test("sessions.compact maxLines truncates the transcript on disk and archives th
   expect(compacted.payload?.compacted).toBe(true);
   expect(compacted.payload?.kept).toBe(50);
 
-  // Active transcript truncated in place on disk: 500 -> 50 lines, newest kept.
+  // Active transcript stays reopenable: header + 49 newest entries.
   const truncated = (await fs.readFile(transcriptPath, "utf-8")).trim().split("\n");
   expect(truncated).toHaveLength(50);
-  expect(truncated.at(-1)).toBe(JSON.stringify({ role: "user", content: "line-499" }));
+  expect(JSON.parse(truncated[0] ?? "{}")).toMatchObject({ type: "session", id: "sess-main" });
+  expect(JSON.parse(truncated[1] ?? "{}")).toMatchObject({ id: "entry-450", parentId: null });
+  expect(JSON.parse(truncated.at(-1) ?? "{}")).toMatchObject({
+    id: "entry-498",
+    message: { content: "line-498" },
+  });
 
   // Original 500 lines preserved verbatim in the .bak archive.
   const archivedPath = compacted.payload?.archived;
@@ -640,7 +663,7 @@ test("sessions.compact maxLines truncates the transcript on disk and archives th
   }
   const archived = (await fs.readFile(archivedPath, "utf-8")).trim().split("\n");
   expect(archived).toHaveLength(500);
-  expect(archived.at(0)).toBe(JSON.stringify({ role: "user", content: "line-0" }));
+  expect(JSON.parse(archived[0] ?? "{}")).toMatchObject({ type: "session", id: "sess-main" });
 
   // No active run present, so the interrupt guard short-circuits without aborting.
   expect(embeddedRunMock.abortCalls).toEqual([]);
@@ -652,9 +675,7 @@ test("sessions.compact maxLines truncates the transcript on disk and archives th
 test("sessions.compact maxLines interrupts an active run before truncating, matching the LLM compact path", async () => {
   const { dir } = await createSessionStoreDir();
   const transcriptPath = path.join(dir, "sess-main.jsonl");
-  const originalLines = Array.from({ length: 500 }, (_, index) =>
-    JSON.stringify({ role: "user", content: `line-${index}` }),
-  );
+  const originalLines = buildSessionTranscriptLines("sess-main", 500);
   await fs.writeFile(transcriptPath, `${originalLines.join("\n")}\n`, "utf-8");
   await writeSessionStore({ entries: { main: sessionStoreEntry("sess-main") } });
 
@@ -689,9 +710,7 @@ test("sessions.compact maxLines interrupts an active run before truncating, matc
 test("sessions.compact maxLines does not interrupt an active run when truncation is a no-op", async () => {
   const { dir } = await createSessionStoreDir();
   const transcriptPath = path.join(dir, "sess-main.jsonl");
-  const originalLines = Array.from({ length: 10 }, (_, index) =>
-    JSON.stringify({ role: "user", content: `line-${index}` }),
-  );
+  const originalLines = buildSessionTranscriptLines("sess-main", 10);
   await fs.writeFile(transcriptPath, `${originalLines.join("\n")}\n`, "utf-8");
   await writeSessionStore({ entries: { main: sessionStoreEntry("sess-main") } });
 

--- a/src/gateway/server.sessions.compaction.test.ts
+++ b/src/gateway/server.sessions.compaction.test.ts
@@ -686,6 +686,57 @@ test("sessions.compact maxLines interrupts an active run before truncating, matc
   ws.close();
 });
 
+test("sessions.compact maxLines does not interrupt an active run when truncation is a no-op", async () => {
+  const { dir } = await createSessionStoreDir();
+  const transcriptPath = path.join(dir, "sess-main.jsonl");
+  const originalLines = Array.from({ length: 10 }, (_, index) =>
+    JSON.stringify({ role: "user", content: `line-${index}` }),
+  );
+  await fs.writeFile(transcriptPath, `${originalLines.join("\n")}\n`, "utf-8");
+  await writeSessionStore({ entries: { main: sessionStoreEntry("sess-main") } });
+
+  const { ws } = await openClient();
+  embeddedRunMock.activeIds.add("sess-main");
+  embeddedRunMock.waitResults.set("sess-main", true);
+
+  const compacted = await rpcReq<{
+    ok: true;
+    compacted: boolean;
+    kept?: number;
+  }>(ws, "sessions.compact", { key: "main", maxLines: 50 });
+
+  expect(compacted.ok).toBe(true);
+  expect(compacted.payload?.compacted).toBe(false);
+  expect(compacted.payload?.kept).toBe(10);
+  expect(embeddedRunMock.abortCalls).toEqual([]);
+  expect(embeddedRunMock.waitCalls).toEqual([]);
+
+  ws.close();
+});
+
+test("sessions.compact maxLines does not interrupt an active run when no transcript exists", async () => {
+  await createSessionStoreDir();
+  await writeSessionStore({ entries: { main: sessionStoreEntry("sess-main") } });
+
+  const { ws } = await openClient();
+  embeddedRunMock.activeIds.add("sess-main");
+  embeddedRunMock.waitResults.set("sess-main", true);
+
+  const compacted = await rpcReq<{
+    ok: true;
+    compacted: boolean;
+    reason?: string;
+  }>(ws, "sessions.compact", { key: "main", maxLines: 50 });
+
+  expect(compacted.ok).toBe(true);
+  expect(compacted.payload?.compacted).toBe(false);
+  expect(compacted.payload?.reason).toBe("no transcript");
+  expect(embeddedRunMock.abortCalls).toEqual([]);
+  expect(embeddedRunMock.waitCalls).toEqual([]);
+
+  ws.close();
+});
+
 test("sessions.compact maxLines aborts without truncating when an active run cannot be interrupted", async () => {
   const { dir, storePath } = await createSessionStoreDir();
   const transcriptPath = path.join(dir, "sess-main.jsonl");

--- a/src/gateway/server.sessions.compaction.test.ts
+++ b/src/gateway/server.sessions.compaction.test.ts
@@ -606,6 +606,122 @@ test("sessions.compact treats Codex native compaction start as pending, not comp
   ws.close();
 });
 
+test("sessions.compact maxLines truncates the transcript on disk and archives the original to .bak", async () => {
+  const { dir } = await createSessionStoreDir();
+  const transcriptPath = path.join(dir, "sess-main.jsonl");
+  const originalLines = Array.from({ length: 500 }, (_, index) =>
+    JSON.stringify({ role: "user", content: `line-${index}` }),
+  );
+  await fs.writeFile(transcriptPath, `${originalLines.join("\n")}\n`, "utf-8");
+  await writeSessionStore({ entries: { main: sessionStoreEntry("sess-main") } });
+
+  const { ws } = await openClient();
+  const compacted = await rpcReq<{
+    ok: true;
+    key: string;
+    compacted: boolean;
+    kept?: number;
+    archived?: string;
+  }>(ws, "sessions.compact", { key: "main", maxLines: 50 });
+
+  expect(compacted.ok).toBe(true);
+  expect(compacted.payload?.compacted).toBe(true);
+  expect(compacted.payload?.kept).toBe(50);
+
+  // Active transcript truncated in place on disk: 500 -> 50 lines, newest kept.
+  const truncated = (await fs.readFile(transcriptPath, "utf-8")).trim().split("\n");
+  expect(truncated).toHaveLength(50);
+  expect(truncated.at(-1)).toBe(JSON.stringify({ role: "user", content: "line-499" }));
+
+  // Original 500 lines preserved verbatim in the .bak archive.
+  const archivedPath = compacted.payload?.archived;
+  if (!archivedPath) {
+    throw new Error("expected archived transcript path");
+  }
+  const archived = (await fs.readFile(archivedPath, "utf-8")).trim().split("\n");
+  expect(archived).toHaveLength(500);
+  expect(archived.at(0)).toBe(JSON.stringify({ role: "user", content: "line-0" }));
+
+  // No active run present, so the interrupt guard short-circuits without aborting.
+  expect(embeddedRunMock.abortCalls).toEqual([]);
+  expect(embeddedRunMock.waitCalls).toEqual([]);
+
+  ws.close();
+});
+
+test("sessions.compact maxLines interrupts an active run before truncating, matching the LLM compact path", async () => {
+  const { dir } = await createSessionStoreDir();
+  const transcriptPath = path.join(dir, "sess-main.jsonl");
+  const originalLines = Array.from({ length: 500 }, (_, index) =>
+    JSON.stringify({ role: "user", content: `line-${index}` }),
+  );
+  await fs.writeFile(transcriptPath, `${originalLines.join("\n")}\n`, "utf-8");
+  await writeSessionStore({ entries: { main: sessionStoreEntry("sess-main") } });
+
+  const { ws } = await openClient();
+  // Simulate an embedded agent run actively appending to this session transcript.
+  embeddedRunMock.activeIds.add("sess-main");
+  embeddedRunMock.waitResults.set("sess-main", true);
+
+  const compacted = await rpcReq<{
+    ok: true;
+    compacted: boolean;
+    kept?: number;
+  }>(ws, "sessions.compact", { key: "main", maxLines: 50 });
+
+  // Regression for the ClawSweeper finding: the maxLines truncate branch must
+  // run the same active-run interrupt guard as the LLM-summarize branch *before*
+  // archiving and overwriting the transcript, so an active runner cannot keep
+  // appending to the file being truncated (the data-loss mode tracked by #72765).
+  expect(embeddedRunMock.abortCalls).toEqual(["sess-main"]);
+  expect(embeddedRunMock.waitCalls).toEqual(["sess-main"]);
+
+  // The guard ran first; truncation still completed deterministically afterwards.
+  expect(compacted.ok).toBe(true);
+  expect(compacted.payload?.compacted).toBe(true);
+  expect(compacted.payload?.kept).toBe(50);
+  const truncated = (await fs.readFile(transcriptPath, "utf-8")).trim().split("\n");
+  expect(truncated).toHaveLength(50);
+
+  ws.close();
+});
+
+test("sessions.compact maxLines aborts without truncating when an active run cannot be interrupted", async () => {
+  const { dir, storePath } = await createSessionStoreDir();
+  const transcriptPath = path.join(dir, "sess-main.jsonl");
+  const originalLines = Array.from({ length: 500 }, (_, index) =>
+    JSON.stringify({ role: "user", content: `line-${index}` }),
+  );
+  await fs.writeFile(transcriptPath, `${originalLines.join("\n")}\n`, "utf-8");
+  await writeSessionStore({ entries: { main: sessionStoreEntry("sess-main") } });
+
+  const { ws } = await openClient();
+  // Active embedded run that fails to end within the interrupt window.
+  embeddedRunMock.activeIds.add("sess-main");
+  embeddedRunMock.waitResults.set("sess-main", false);
+
+  const compacted = await rpcReq<{ ok: boolean }>(ws, "sessions.compact", {
+    key: "main",
+    maxLines: 50,
+  });
+
+  // Order proof: the guard ran first and failed, so the RPC errors out *before*
+  // any archive/truncate. If the guard ran after truncation, the transcript
+  // would already be 50 lines here. It is still 500 with no .bak, proving the
+  // interrupt happens before the destructive tail-read/archive/write.
+  expect(compacted.ok).toBe(false);
+  expect(embeddedRunMock.abortCalls).toEqual(["sess-main"]);
+  expect(embeddedRunMock.waitCalls).toEqual(["sess-main"]);
+
+  const untouched = (await fs.readFile(transcriptPath, "utf-8")).trim().split("\n");
+  expect(untouched).toHaveLength(500);
+  const dirEntries = await fs.readdir(dir);
+  expect(dirEntries.some((name) => name.includes(".bak"))).toBe(false);
+  expect(storePath).toBeTruthy();
+
+  ws.close();
+});
+
 test("sessions.patch preserves nested model ids under provider overrides", async () => {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-sessions-nested-"));
   const storePath = path.join(dir, "sessions.json");

--- a/src/gateway/server.sessions.list-changed.test.ts
+++ b/src/gateway/server.sessions.list-changed.test.ts
@@ -23,6 +23,7 @@ import {
   getGatewayConfigModule,
   getSessionsHandlers,
   createDeferred,
+  createLinearSessionTranscript,
   sessionStoreEntry,
 } from "./test/server-sessions.test-helpers.js";
 
@@ -43,6 +44,19 @@ type MockCalls = {
 };
 type SessionStoreEntryOptions = Parameters<typeof sessionStoreEntry>[1];
 type MutationMethod = "sessions.patch" | "sessions.compact";
+
+function expectedLastMessageTranscript(sessionId: string, contents: string[]): string {
+  const records = createLinearSessionTranscript(sessionId, contents)
+    .trim()
+    .split("\n")
+    .map((line) => JSON.parse(line) as Record<string, unknown>);
+  const header = records[0];
+  const last = records.at(-1);
+  if (!header || !last) {
+    throw new Error("expected a canonical transcript fixture");
+  }
+  return `${JSON.stringify(header)}\n${JSON.stringify({ ...last, parentId: null })}\n`;
+}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
@@ -646,11 +660,11 @@ test("sessions.compact scopes selected global truncation to the requested agent"
     params: {
       key: "global",
       agentId: "work",
-      maxLines: 1,
+      maxLines: 2,
     },
   });
 
-  expectFields(responsePayload, { ok: true, key: "global", compacted: true, kept: 1 });
+  expectFields(responsePayload, { ok: true, key: "global", compacted: true, kept: 2 });
   expectChangedBroadcast(broadcastToConnIds, {
     sessionKey: "global",
     agentId: "work",
@@ -658,9 +672,11 @@ test("sessions.compact scopes selected global truncation to the requested agent"
     compacted: true,
   });
   await expect(fs.readFile(globalStores.mainTranscript, "utf-8")).resolves.toBe(
-    "main one\nmain two\n",
+    createLinearSessionTranscript("sess-main-global", ["main one", "main two"]),
   );
-  await expect(fs.readFile(globalStores.workTranscript, "utf-8")).resolves.toBe("work two\n");
+  await expect(fs.readFile(globalStores.workTranscript, "utf-8")).resolves.toBe(
+    expectedLastMessageTranscript("sess-work-global", ["work one", "work two"]),
+  );
   await resetConfiguredGlobalAgentSessionStore(globalStores);
 });
 
@@ -670,20 +686,22 @@ test("sessions.compact trims default global agent when no agentId is supplied", 
     getRuntimeConfig: globalStores.getRuntimeConfig,
     params: {
       key: "global",
-      maxLines: 1,
+      maxLines: 2,
     },
   });
 
-  expectFields(responsePayload, { ok: true, key: "global", compacted: true, kept: 1 });
+  expectFields(responsePayload, { ok: true, key: "global", compacted: true, kept: 2 });
   expectChangedBroadcast(broadcastToConnIds, {
     sessionKey: "global",
     agentId: "main",
     reason: "compact",
     compacted: true,
   });
-  await expect(fs.readFile(globalStores.mainTranscript, "utf-8")).resolves.toBe("main two\n");
+  await expect(fs.readFile(globalStores.mainTranscript, "utf-8")).resolves.toBe(
+    expectedLastMessageTranscript("sess-main-global", ["main one", "main two"]),
+  );
   await expect(fs.readFile(globalStores.workTranscript, "utf-8")).resolves.toBe(
-    "work one\nwork two\n",
+    createLinearSessionTranscript("sess-work-global", ["work one", "work two"]),
   );
   await resetConfiguredGlobalAgentSessionStore(globalStores);
 });
@@ -699,10 +717,10 @@ test("sessions.compact keeps manual trim no-op response shape", async () => {
     },
   });
 
-  expectFields(responsePayload, { ok: true, key: "global", compacted: false, kept: 2 });
+  expectFields(responsePayload, { ok: true, key: "global", compacted: false, kept: 3 });
   expect(broadcastToConnIds).not.toHaveBeenCalled();
   await expect(fs.readFile(globalStores.workTranscript, "utf-8")).resolves.toBe(
-    "work one\nwork two\n",
+    createLinearSessionTranscript("sess-work-global", ["work one", "work two"]),
   );
   await resetConfiguredGlobalAgentSessionStore(globalStores);
 });

--- a/src/gateway/server.sessions.preview-resolve.test.ts
+++ b/src/gateway/server.sessions.preview-resolve.test.ts
@@ -11,6 +11,7 @@ import {
   sessionStoreEntry,
   getMainPreviewEntry,
   directSessionReq,
+  createLinearSessionTranscript,
 } from "./test/server-sessions.test-helpers.js";
 
 const { createSessionStoreDir, openClient } = setupGatewaySessionsTestHarness();
@@ -124,9 +125,10 @@ test("sessions.resolve and mutators clean legacy main-alias ghost keys", async (
   const transcriptPath = path.join(dir, `${sessionId}.jsonl`);
   await fs.writeFile(
     transcriptPath,
-    `${Array.from({ length: 8 })
-      .map((_, idx) => JSON.stringify({ role: "assistant", content: `line ${idx}` }))
-      .join("\n")}\n`,
+    createLinearSessionTranscript(
+      sessionId,
+      Array.from({ length: 8 }, (_, index) => `line ${index}`),
+    ),
     "utf-8",
   );
 

--- a/src/gateway/server.sessions.store-rpc.test.ts
+++ b/src/gateway/server.sessions.store-rpc.test.ts
@@ -10,6 +10,7 @@ import {
   setupGatewaySessionsTestHarness,
   getGatewayConfigModule,
   getSessionsHandlers,
+  createLinearSessionTranscript,
 } from "./test/server-sessions.test-helpers.js";
 
 const { createSessionStoreDir, openClient } = setupGatewaySessionsTestHarness();
@@ -43,14 +44,15 @@ test("lists and patches session store via sessions.* RPC", async () => {
 
   await fs.writeFile(
     path.join(dir, "sess-main.jsonl"),
-    `${Array.from({ length: 10 })
-      .map((_, idx) => JSON.stringify({ role: "user", content: `line ${idx}` }))
-      .join("\n")}\n`,
+    createLinearSessionTranscript(
+      "sess-main",
+      Array.from({ length: 10 }, (_, index) => `line ${index}`),
+    ),
     "utf-8",
   );
   await fs.writeFile(
     path.join(dir, "sess-group.jsonl"),
-    `${JSON.stringify({ role: "user", content: "group line 0" })}\n`,
+    createLinearSessionTranscript("sess-group", ["group line 0"]),
     "utf-8",
   );
 

--- a/src/gateway/test/server-sessions.test-helpers.ts
+++ b/src/gateway/test/server-sessions.test-helpers.ts
@@ -40,6 +40,28 @@ export async function getSessionsHandlers() {
   return (await import("../server-methods/sessions.js")).sessionsHandlers;
 }
 
+export function createLinearSessionTranscript(sessionId: string, contents: string[]): string {
+  const records: Array<Record<string, unknown>> = [
+    {
+      type: "session",
+      version: 3,
+      id: sessionId,
+      timestamp: "2026-06-19T12:00:00.000Z",
+      cwd: "/tmp",
+    },
+  ];
+  for (const [index, content] of contents.entries()) {
+    records.push({
+      type: "message",
+      id: `${sessionId}-entry-${index}`,
+      parentId: index === 0 ? null : `${sessionId}-entry-${index - 1}`,
+      timestamp: `2026-06-19T12:00:${String(index + 1).padStart(2, "0")}.000Z`,
+      message: { role: "user", content, timestamp: index + 1 },
+    });
+  }
+  return `${records.map((record) => JSON.stringify(record)).join("\n")}\n`;
+}
+
 export function createDeferred<T>() {
   let resolve!: (value: T | PromiseLike<T>) => void;
   let reject!: (reason?: unknown) => void;
@@ -362,8 +384,16 @@ export function setupGatewaySessionsTestHarness() {
     await fs.mkdir(path.dirname(mainStorePath), { recursive: true });
     await fs.mkdir(path.dirname(workStorePath), { recursive: true });
     if (withTranscripts) {
-      await fs.writeFile(mainTranscript, "main one\nmain two\n", "utf-8");
-      await fs.writeFile(workTranscript, "work one\nwork two\n", "utf-8");
+      await fs.writeFile(
+        mainTranscript,
+        createLinearSessionTranscript("sess-main-global", ["main one", "main two"]),
+        "utf-8",
+      );
+      await fs.writeFile(
+        workTranscript,
+        createLinearSessionTranscript("sess-work-global", ["work one", "work two"]),
+        "utf-8",
+      );
     }
     await fs.writeFile(
       mainStorePath,


### PR DESCRIPTION
## Summary

Fixes #90640.

- Adds `openclaw sessions compact <key>` over the existing `sessions.compact` Gateway RPC.
- Makes CLI `agent --message '/compact'` fail with a redirect instead of silently running an ordinary turn.
- Preserves parent `sessions --agent` / `--json`; rejects unsupported inherited list options, including `--store`, `--all-agents`, `--active`, `--limit`, and `--verbose`.
- Reports Codex app-server `thread/compact/start` as pending instead of a no-op.
- Interrupts active runs before destructive `--max-lines` recovery.
- Preserves the required transcript header and active tree semantics when trimming: removed ancestors are re-rooted, malformed controls remain transparent, out-of-window leaf targets fail safe, and retained compaction boundaries follow the normalized active branch.
- Installs the replacement transcript with mode `0600`, rollback, and partial-temp cleanup.
- Requires an explicit `ok:true` RPC result before the CLI exits successfully.

## Implementation notes

The Gateway remains the owner of target resolution and active-run interruption. Transcript mutation stays behind `src/config/sessions/session-accessor.ts`; it archives the original before installing the normalized replacement and clears stale token metadata only after success.

The Codex pending behavior was checked directly against sibling Codex source: `thread/compact/start` returns immediately and completion is reported asynchronously through turn/item notifications.

## Real behavior proof

Behavior addressed: The production CLI reaches real Gateway compaction, CLI slash-command misuse exits non-zero, Codex pending results render correctly, unsupported inherited options fail before mutation, and manual trimming produces a private transcript that `SessionManager` can reopen without changing the selected branch.

Real environment tested: Local Node checkout plus AWS Crabbox Linux lease `cbx_a5289b2e7c04` (`swift-lobster`, c7a.32xlarge). Gateway tests use a real in-process Gateway WebSocket and on-disk session stores/transcripts. Codex tests use the production compact adapter and an on-disk binding.

Exact steps or command run after this patch:

```text
node scripts/run-vitest.mjs +  src/config/sessions/session-accessor.test.ts +  src/commands/sessions-compact.test.ts +  src/cli/program/register.status-health-sessions.test.ts +  src/gateway/server.sessions.compaction.test.ts +  src/gateway/server.sessions.list-changed.test.ts +  src/gateway/server.sessions.preview-resolve.test.ts +  src/gateway/server.sessions.store-rpc.test.ts +  src/commands/agent-via-gateway.test.ts +  extensions/codex/src/app-server/compact.test.ts

node scripts/run-oxlint.mjs <changed runtime and test files>
.agents/skills/autoreview/scripts/autoreview --mode local --no-web-search
```

Evidence after fix: Crabbox run `run_ccc2ece105cb` passed 239 tests across CLI, Gateway, filesystem, and Codex shards. Final-delta run `run_4e6bfe528bca` passed all 42 accessor reopen/tree tests. The Gateway regression proves canonical 500-line JSONL becomes a reopenable 50-line transcript, the original remains in `.bak`, and active-run interruption precedes mutation. Type-aware oxlint is clean. Final autoreview is clean with 0.89 confidence after all accepted findings were repaired.

Observed result after fix: Successful native trim reports `compacted:true`, retains the newest bounded suffix plus the session header, writes mode `0600`, and reopens with the expected context. An active run that cannot be interrupted leaves the transcript and archive state untouched. Codex returns `ok:true / compacted:false / pending:true` and the CLI prints “Compaction started” without treating it as a no-op. Missing or false `ok` exits 1.

What was not tested: No GUI/screenshot path; this is CLI, Gateway, filesystem, and adapter behavior. No live external Codex account call; the exact upstream app-server protocol and request processor were inspected, and the production OpenClaw adapter was exercised with its real disk binding.

## Tests

- AWS Crabbox `run_ccc2ece105cb`: 239 passed.
- AWS Crabbox `run_4e6bfe528bca`: 42 passed on the final transcript-tree delta.
- Local focused Gateway/CLI/accessor/Codex suites: passed.
- Type-aware oxlint: clean.
- Fresh autoreview: clean.
