### PR TITLE
fix(cron): inherit default fallbacks for string agent jobs

### DIFF
--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -145,6 +145,7 @@ export function createCronPromptExecutor(params: {
   skillsSnapshot: SkillSnapshot;
   agentPayload: AgentTurnPayload;
   useSubagentFallbacks: boolean;
+  inheritDefaultFallbacksForAgentStringModel?: boolean;
   modelFallbacksOverride?: string[];
   liveSelection: CronLiveSelection;
   cronSession: MutableCronSession;
@@ -170,6 +171,7 @@ export function createCronPromptExecutor(params: {
       job: params.job,
       agentId: params.agentId,
       useSubagentFallbacks: params.useSubagentFallbacks,
+      inheritDefaultFallbacksForAgentStringModel: params.inheritDefaultFallbacksForAgentStringModel,
     });
   let runResult: CronPromptRunResult | undefined;
   let fallbackProvider = params.liveSelection.provider;
@@ -380,6 +382,7 @@ export async function executeCronRun(params: {
   skillsSnapshot: SkillSnapshot;
   agentPayload: AgentTurnPayload;
   useSubagentFallbacks: boolean;
+  inheritDefaultFallbacksForAgentStringModel?: boolean;
   modelFallbacksOverride?: string[];
   agentVerboseDefault: AgentDefaultsConfig["verboseDefault"];
   liveSelection: CronLiveSelection;
@@ -430,6 +433,7 @@ export async function executeCronRun(params: {
     skillsSnapshot: params.skillsSnapshot,
     agentPayload: params.agentPayload,
     useSubagentFallbacks: params.useSubagentFallbacks,
+    inheritDefaultFallbacksForAgentStringModel: params.inheritDefaultFallbacksForAgentStringModel,
     modelFallbacksOverride: params.modelFallbacksOverride,
     liveSelection: params.liveSelection,
     cronSession: params.cronSession,

--- a/src/cron/isolated-agent/run-fallback-policy.test.ts
+++ b/src/cron/isolated-agent/run-fallback-policy.test.ts
@@ -38,6 +38,7 @@ describe("resolveCronFallbacksOverride", () => {
       resolveCronFallbacksOverride({
         cfg: makeConfig(["openai/gpt-5.4", "google/gemini-3-pro"]),
         agentId: "main",
+        inheritDefaultFallbacksForAgentStringModel: true,
         job: makeJob({
           kind: "agentTurn",
           message: "summarize",
@@ -193,6 +194,121 @@ describe("resolveCronFallbacksOverride", () => {
         }),
       }),
     ).toBeUndefined();
+  });
+
+  it("inherits default fallbacks for cron runs when the agent model is a string", () => {
+    expect(
+      resolveCronFallbacksOverride({
+        cfg: {
+          agents: {
+            defaults: {
+              model: {
+                primary: "deepseek/deepseek-v4-pro",
+                fallbacks: ["deepseek/deepseek-v4-flash", "moonshot/kimi-k2.6"],
+              },
+            },
+            list: [
+              {
+                id: "main",
+                model: "deepseek/deepseek-v4-pro",
+              },
+            ],
+          },
+        },
+        agentId: "main",
+        inheritDefaultFallbacksForAgentStringModel: true,
+        job: makeJob({
+          kind: "agentTurn",
+          message: "summarize",
+        }),
+      }),
+    ).toEqual(["deepseek/deepseek-v4-flash", "moonshot/kimi-k2.6"]);
+  });
+
+  it("does not infer inheritance from rewritten cron agent defaults", () => {
+    expect(
+      resolveCronFallbacksOverride({
+        cfg: {
+          agents: {
+            defaults: {
+              model: {
+                primary: "anthropic/claude-sonnet-4-6",
+                fallbacks: ["deepseek/deepseek-v4-flash", "moonshot/kimi-k2.6"],
+              },
+            },
+            list: [
+              {
+                id: "main",
+                model: "anthropic/claude-sonnet-4-6",
+              },
+            ],
+          },
+        },
+        agentId: "main",
+        job: makeJob({
+          kind: "agentTurn",
+          message: "summarize",
+        }),
+      }),
+    ).toStrictEqual([]);
+  });
+
+  it("keeps object-style agent primaries strict for cron runs", () => {
+    expect(
+      resolveCronFallbacksOverride({
+        cfg: {
+          agents: {
+            defaults: {
+              model: {
+                primary: "deepseek/deepseek-v4-pro",
+                fallbacks: ["deepseek/deepseek-v4-flash", "moonshot/kimi-k2.6"],
+              },
+            },
+            list: [
+              {
+                id: "main",
+                model: {
+                  primary: "deepseek/deepseek-v4-pro",
+                },
+              },
+            ],
+          },
+        },
+        agentId: "main",
+        job: makeJob({
+          kind: "agentTurn",
+          message: "summarize",
+        }),
+      }),
+    ).toStrictEqual([]);
+  });
+
+  it("keeps string agent primaries strict when they differ from the default primary", () => {
+    expect(
+      resolveCronFallbacksOverride({
+        cfg: {
+          agents: {
+            defaults: {
+              model: {
+                primary: "deepseek/deepseek-v4-pro",
+                fallbacks: ["deepseek/deepseek-v4-flash", "moonshot/kimi-k2.6"],
+              },
+            },
+            list: [
+              {
+                id: "main",
+                model: "anthropic/claude-sonnet-4-6",
+              },
+            ],
+          },
+        },
+        agentId: "main",
+        job: makeJob({
+          kind: "agentTurn",
+          message: "summarize",
+        }),
+      }),
+    ).toStrictEqual([]);
   });
 
   it("treats string subagent model selection as strict when no fallbacks are configured", () => {

--- a/src/cron/isolated-agent/run-fallback-policy.ts
+++ b/src/cron/isolated-agent/run-fallback-policy.ts
@@ -1,6 +1,7 @@
 /** Resolves model fallback chains for isolated cron runs and preflight. */
 import { resolveModelCandidateChain } from "../../agents/model-fallback.js";
 import type { ModelCandidate } from "../../agents/model-fallback.types.js";
+import { resolveAgentModelFallbackValues } from "../../config/model-input.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { CronJob } from "../types.js";
 import {
@@ -14,6 +15,7 @@ export function resolveCronFallbacksOverride(params: {
   job: CronJob;
   agentId: string;
   useSubagentFallbacks?: boolean;
+  inheritDefaultFallbacksForAgentStringModel?: boolean;
 }): string[] | undefined {
   const payload = params.job.payload.kind === "agentTurn" ? params.job.payload : undefined;
   const payloadFallbacks = Array.isArray(payload?.fallbacks) ? payload.fallbacks : undefined;
@@ -33,6 +35,12 @@ export function resolveCronFallbacksOverride(params: {
       return subagentFallbacksOverride;
     }
   }
+  if (!hasCronPayloadModelOverride && params.inheritDefaultFallbacksForAgentStringModel === true) {
+    const defaultFallbacks = resolveAgentModelFallbackValues(params.cfg.agents?.defaults?.model);
+    if (defaultFallbacks.length > 0) {
+      return defaultFallbacks;
+    }
+  }
   return resolveEffectiveModelFallbacks({
     cfg: params.cfg,
     agentId: params.agentId,
@@ -49,12 +57,14 @@ export function resolveCronPreflightCandidates(params: {
   provider: string;
   model: string;
   useSubagentFallbacks?: boolean;
+  inheritDefaultFallbacksForAgentStringModel?: boolean;
 }): ModelCandidate[] {
   const fallbacksOverride = resolveCronFallbacksOverride({
     cfg: params.cfg,
     job: params.job,
     agentId: params.agentId,
     useSubagentFallbacks: params.useSubagentFallbacks,
+    inheritDefaultFallbacksForAgentStringModel: params.inheritDefaultFallbacksForAgentStringModel,
   });
   return resolveModelCandidateChain({
     cfg: params.cfg,

--- a/src/cron/isolated-agent/run.cron-model-override-forwarding.test.ts
+++ b/src/cron/isolated-agent/run.cron-model-override-forwarding.test.ts
@@ -453,6 +453,129 @@ describe("runCronIsolatedAgentTurn — cron model override forwarding (#58065)",
     expect(capturedFallbacksOverride).toBeUndefined();
   });
 
+  it("inherits default fallbacks for matching string agent model cron runs", async () => {
+    const jobWithoutModel = makeJob({
+      payload: { kind: "agentTurn", message: "summarize" },
+    });
+    resolveAgentConfigMock.mockReturnValue({
+      model: "deepseek/deepseek-v4-pro",
+    });
+    resolveConfiguredModelRefMock.mockReturnValue({
+      provider: "deepseek",
+      model: "deepseek-v4-pro",
+    });
+
+    let capturedFallbacksOverride: string[] | undefined;
+    runWithModelFallbackMock.mockImplementation(
+      async (params: { provider: string; model: string; fallbacksOverride?: string[] }) => {
+        capturedFallbacksOverride = params.fallbacksOverride;
+        return makeSuccessfulRunResult("deepseek", "deepseek-v4-pro");
+      },
+    );
+
+    await runCronIsolatedAgentTurn(
+      makeParams({
+        agentId: "main",
+        cfg: {
+          agents: {
+            defaults: {
+              model: {
+                primary: "deepseek/deepseek-v4-pro",
+                fallbacks: ["deepseek/deepseek-v4-flash", "moonshot/kimi-k2.6"],
+              },
+            },
+            list: [{ id: "main", model: "deepseek/deepseek-v4-pro" }],
+          },
+        },
+        job: jobWithoutModel,
+      }),
+    );
+
+    expect(capturedFallbacksOverride).toEqual(["deepseek/deepseek-v4-flash", "moonshot/kimi-k2.6"]);
+  });
+
+  it("inherits default fallbacks for implicit default-agent cron runs", async () => {
+    const jobWithoutModel = makeJob({
+      payload: { kind: "agentTurn", message: "summarize" },
+    });
+    resolveAgentConfigMock.mockReturnValue({
+      model: "deepseek/deepseek-v4-pro",
+    });
+    resolveConfiguredModelRefMock.mockReturnValue({
+      provider: "deepseek",
+      model: "deepseek-v4-pro",
+    });
+
+    let capturedFallbacksOverride: string[] | undefined;
+    runWithModelFallbackMock.mockImplementation(
+      async (params: { provider: string; model: string; fallbacksOverride?: string[] }) => {
+        capturedFallbacksOverride = params.fallbacksOverride;
+        return makeSuccessfulRunResult("deepseek", "deepseek-v4-pro");
+      },
+    );
+
+    await runCronIsolatedAgentTurn(
+      makeParams({
+        cfg: {
+          agents: {
+            defaults: {
+              model: {
+                primary: "deepseek/deepseek-v4-pro",
+                fallbacks: ["deepseek/deepseek-v4-flash", "moonshot/kimi-k2.6"],
+              },
+            },
+            list: [{ id: "default", model: "deepseek/deepseek-v4-pro" }],
+          },
+        },
+        job: jobWithoutModel,
+      }),
+    );
+
+    expect(capturedFallbacksOverride).toEqual(["deepseek/deepseek-v4-flash", "moonshot/kimi-k2.6"]);
+  });
+
+  it("keeps different string agent model cron runs strict after defaults are rewritten", async () => {
+    const jobWithoutModel = makeJob({
+      payload: { kind: "agentTurn", message: "summarize" },
+    });
+    resolveAgentConfigMock.mockReturnValue({
+      model: "anthropic/claude-sonnet-4-6",
+    });
+    resolveAgentModelFallbacksOverrideMock.mockReturnValue([]);
+    resolveConfiguredModelRefMock.mockReturnValue({
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+    });
+
+    let capturedFallbacksOverride: string[] | undefined;
+    runWithModelFallbackMock.mockImplementation(
+      async (params: { provider: string; model: string; fallbacksOverride?: string[] }) => {
+        capturedFallbacksOverride = params.fallbacksOverride;
+        return makeSuccessfulRunResult("anthropic", "claude-sonnet-4-6");
+      },
+    );
+
+    await runCronIsolatedAgentTurn(
+      makeParams({
+        agentId: "main",
+        cfg: {
+          agents: {
+            defaults: {
+              model: {
+                primary: "deepseek/deepseek-v4-pro",
+                fallbacks: ["deepseek/deepseek-v4-flash", "moonshot/kimi-k2.6"],
+              },
+            },
+            list: [{ id: "main", model: "anthropic/claude-sonnet-4-6" }],
+          },
+        },
+        job: jobWithoutModel,
+      }),
+    );
+
+    expect(capturedFallbacksOverride).toStrictEqual([]);
+  });
+
   it("uses explicit payload fallbacks when both model and fallbacks are set", async () => {
     const jobWithFallbacks = makeJob({
       payload: {

--- a/src/cron/isolated-agent/run.cron-model-override-forwarding.test.ts
+++ b/src/cron/isolated-agent/run.cron-model-override-forwarding.test.ts
@@ -576,6 +576,73 @@ describe("runCronIsolatedAgentTurn — cron model override forwarding (#58065)",
     expect(capturedFallbacksOverride).toStrictEqual([]);
   });
 
+  it("keeps stored cron session model overrides strict for matching string agent models", async () => {
+    const jobWithoutModel = makeJob({
+      payload: { kind: "agentTurn", message: "summarize" },
+      sessionTarget: "session:existing-cron-session",
+    });
+    resolveAgentConfigMock.mockReturnValue({
+      model: "deepseek/deepseek-v4-pro",
+    });
+    resolveAgentModelFallbacksOverrideMock.mockReturnValue([]);
+    resolveConfiguredModelRefMock.mockReturnValue({
+      provider: "deepseek",
+      model: "deepseek-v4-pro",
+    });
+    resolveAllowedModelRefMock.mockImplementation(({ raw }: { raw: string }) => {
+      if (raw === "openai/gpt-5.4") {
+        return { ref: { provider: "openai", model: "gpt-5.4" } };
+      }
+      if (raw === "deepseek/deepseek-v4-pro") {
+        return { ref: { provider: "deepseek", model: "deepseek-v4-pro" } };
+      }
+      return { ref: { provider: "anthropic", model: "claude-opus-4-6" } };
+    });
+    resolveCronSessionMock.mockReturnValue(
+      makeCronSession({
+        sessionEntry: makeCronSessionEntry({
+          modelOverride: "gpt-5.4",
+          providerOverride: "openai",
+        }),
+        isNewSession: false,
+      }),
+    );
+
+    let capturedProvider: string | undefined;
+    let capturedModel: string | undefined;
+    let capturedFallbacksOverride: string[] | undefined;
+    runWithModelFallbackMock.mockImplementation(
+      async (params: { provider: string; model: string; fallbacksOverride?: string[] }) => {
+        capturedProvider = params.provider;
+        capturedModel = params.model;
+        capturedFallbacksOverride = params.fallbacksOverride;
+        return makeSuccessfulRunResult("openai", "gpt-5.4");
+      },
+    );
+
+    await runCronIsolatedAgentTurn(
+      makeParams({
+        agentId: "main",
+        cfg: {
+          agents: {
+            defaults: {
+              model: {
+                primary: "deepseek/deepseek-v4-pro",
+                fallbacks: ["deepseek/deepseek-v4-flash", "moonshot/kimi-k2.6"],
+              },
+            },
+            list: [{ id: "main", model: "deepseek/deepseek-v4-pro" }],
+          },
+        },
+        job: jobWithoutModel,
+      }),
+    );
+
+    expect(capturedProvider).toBe("openai");
+    expect(capturedModel).toBe("gpt-5.4");
+    expect(capturedFallbacksOverride).toStrictEqual([]);
+  });
+
   it("uses explicit payload fallbacks when both model and fallbacks are set", async () => {
     const jobWithFallbacks = makeJob({
       payload: {

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -12,6 +12,7 @@ import {
   getRuntimeConfigSourceSnapshot,
   selectApplicableRuntimeConfig,
 } from "../../config/config.js";
+import { resolveAgentModelPrimaryValue } from "../../config/model-input.js";
 import type { AgentDefaultsConfig } from "../../config/types.agent-defaults.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { clearAgentRunContext } from "../../infra/agent-events.js";
@@ -491,6 +492,7 @@ type PreparedCronRunContext = {
   skillsSnapshot: SkillSnapshot;
   liveSelection: CronLiveSelection;
   useSubagentFallbacks: boolean;
+  inheritDefaultFallbacksForAgentStringModel: boolean;
   modelFallbacksOverride?: string[];
   thinkLevel: ThinkLevel | undefined;
   timeoutMs: number;
@@ -536,10 +538,13 @@ async function prepareCronRunContext(params: {
         ? input.job.agentId
         : undefined;
   const normalizedRequested = requestedAgentId ? normalizeAgentId(requestedAgentId) : undefined;
-  const agentConfigOverride = normalizedRequested
-    ? resolveAgentConfig(runtimeCfg, normalizedRequested)
-    : undefined;
   const agentId = normalizedRequested ?? defaultAgentId;
+  const selectedAgentConfig = resolveAgentConfig(runtimeCfg, agentId);
+  const agentConfigOverride = normalizedRequested ? selectedAgentConfig : undefined;
+  const inheritDefaultFallbacksForAgentStringModel =
+    typeof selectedAgentConfig?.model === "string" &&
+    resolveAgentModelPrimaryValue(selectedAgentConfig.model) ===
+      resolveAgentModelPrimaryValue(runtimeCfg.agents?.defaults?.model);
   const agentCfg: AgentDefaultsConfig = buildCronAgentDefaultsConfig({
     defaults: runtimeCfg.agents?.defaults,
     agentConfigOverride,
@@ -661,6 +666,7 @@ async function prepareCronRunContext(params: {
     provider,
     model,
     useSubagentFallbacks,
+    inheritDefaultFallbacksForAgentStringModel,
   });
   let selectedPreflightCandidate: { provider: string; model: string } | undefined;
   let selectedPreflightCandidateIndex = -1;
@@ -910,6 +916,7 @@ async function prepareCronRunContext(params: {
       skillsSnapshot,
       liveSelection,
       useSubagentFallbacks,
+      inheritDefaultFallbacksForAgentStringModel,
       modelFallbacksOverride,
       thinkLevel,
       timeoutMs,
@@ -1316,6 +1323,8 @@ export async function runCronIsolatedAgentTurn(params: {
       skillsSnapshot: prepared.context.skillsSnapshot,
       agentPayload: prepared.context.agentPayload,
       useSubagentFallbacks: prepared.context.useSubagentFallbacks,
+      inheritDefaultFallbacksForAgentStringModel:
+        prepared.context.inheritDefaultFallbacksForAgentStringModel,
       modelFallbacksOverride: prepared.context.modelFallbacksOverride,
       agentVerboseDefault: prepared.context.agentCfg?.verboseDefault,
       liveSelection: prepared.context.liveSelection,

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -541,7 +541,7 @@ async function prepareCronRunContext(params: {
   const agentId = normalizedRequested ?? defaultAgentId;
   const selectedAgentConfig = resolveAgentConfig(runtimeCfg, agentId);
   const agentConfigOverride = normalizedRequested ? selectedAgentConfig : undefined;
-  const inheritDefaultFallbacksForAgentStringModel =
+  const matchesDefaultFallbackAgentStringModel =
     typeof selectedAgentConfig?.model === "string" &&
     resolveAgentModelPrimaryValue(selectedAgentConfig.model) ===
       resolveAgentModelPrimaryValue(runtimeCfg.agents?.defaults?.model);
@@ -657,6 +657,10 @@ async function prepareCronRunContext(params: {
   let provider = resolvedModelSelection.provider;
   let model = resolvedModelSelection.model;
   const useSubagentFallbacks = resolvedModelSelection.modelSource === "subagent";
+  const inheritDefaultFallbacksForAgentStringModel =
+    matchesDefaultFallbackAgentStringModel &&
+    (resolvedModelSelection.modelSource === "default" ||
+      resolvedModelSelection.modelSource === "agent");
 
   const modelPreflightRuntime = await loadCronModelPreflightRuntime();
   const preflightCandidates = resolveCronPreflightCandidates({


### PR DESCRIPTION
## Summary

- Fixes isolated cron runs where an agent's plain string model matched `agents.defaults.model.primary` but the run still received an empty fallback chain instead of inheriting `agents.defaults.model.fallbacks`.
- Keeps the shared agent model fallback contract strict: string per-agent models and object-style `{ primary }` configs still disable global fallbacks unless the cron prep path explicitly proves this is the default-primary shorthand case.
- Threads a cron-local inheritance signal from raw runtime config through preflight and execution so the decision is not inferred from `cfgWithAgentDefaults` after cron rewrites defaults.
- Intentionally does not change `src/agents/agent-scope.ts`, docs, config schema, provider routing, auth, or non-cron agent runs.

## Linked context

Closes #91362

Related #91373

Was this requested by a maintainer or owner?

- Not directly. This follows #91362 and ClawSweeper's issue guidance recommending a cron-scoped repair instead of changing normal agent-primary strictness. It also addresses the compatibility concern ClawSweeper raised on #91373.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Isolated cron runs now inherit `agents.defaults.model.fallbacks` when the selected agent uses a plain string model equal to the configured default primary, while object-style primaries and differing string agent primaries remain strict.
- Real environment tested: macOS arm64 local OpenClaw worktree from `upstream/main` at `fc6400ede3`, Node v24.15.0, pnpm v11.2.2.
- Exact steps or command run after this patch:

```sh
node --import tsx - <<'EOF_NODE'
import { resolveCronFallbacksOverride } from './src/cron/isolated-agent/run-fallback-policy.ts';
const job = { id: 'cron-91362', name: 'cron 91362', schedule: { kind: 'cron', expr: '0 9 * * *', tz: 'UTC' }, sessionTarget: 'isolated', payload: { kind: 'agentTurn', message: 'summarize' }, state: {} };
const defaults = { model: { primary: 'deepseek/deepseek-v4-pro', fallbacks: ['deepseek/deepseek-v4-flash', 'moonshot/kimi-k2.6'] } };
const cfg = { agents: { defaults, list: [{ id: 'main', model: 'deepseek/deepseek-v4-pro' }] } };
const rewrittenDifferentStringCfg = { agents: { defaults: { model: { primary: 'anthropic/claude-sonnet-4-6', fallbacks: ['deepseek/deepseek-v4-flash', 'moonshot/kimi-k2.6'] } }, list: [{ id: 'main', model: 'anthropic/claude-sonnet-4-6' }] } };
const objectCfg = { agents: { defaults, list: [{ id: 'main', model: { primary: 'deepseek/deepseek-v4-pro' } }] } };
console.log(JSON.stringify({
  inheritedFallbacks: resolveCronFallbacksOverride({ cfg, agentId: 'main', job, inheritDefaultFallbacksForAgentStringModel: true }),
  rewrittenWithoutSignal: resolveCronFallbacksOverride({ cfg: rewrittenDifferentStringCfg, agentId: 'main', job }),
  objectPrimaryFallbacks: resolveCronFallbacksOverride({ cfg: objectCfg, agentId: 'main', job }),
}, null, 2));
EOF_NODE
node scripts/run-vitest.mjs src/cron/isolated-agent/run-fallback-policy.test.ts src/agents/agent-scope.test.ts src/cron/isolated-agent/run.cron-model-override-forwarding.test.ts
pnpm tsgo:core:test
.agents/skills/autoreview/scripts/autoreview --mode local
```

- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
{
  "inheritedFallbacks": [
    "deepseek/deepseek-v4-flash",
    "moonshot/kimi-k2.6"
  ],
  "rewrittenWithoutSignal": [],
  "objectPrimaryFallbacks": []
}

node scripts/run-vitest.mjs src/cron/isolated-agent/run-fallback-policy.test.ts src/agents/agent-scope.test.ts src/cron/isolated-agent/run.cron-model-override-forwarding.test.ts
Test Files  2 passed (2)
Tests  30 passed (30)
Test Files  1 passed (1)
Tests  44 passed (44)
[test] passed 2 Vitest shards

pnpm tsgo:core:test
$ node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo
(exit 0)

.agents/skills/autoreview/scripts/autoreview --mode local
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.79)
```

- Observed result after fix: the #91362 cron fallback shape resolves the configured default fallback list; the guard cases that ClawSweeper called out remain strict, including rewritten defaults without the cron-local inheritance signal and object-style agent primaries.
- What was not tested: a live provider-backed scheduled cron execution against real model APIs. The proof exercises the cron fallback policy plus `runCronIsolatedAgentTurn` regression tests that verify the actual `runWithModelFallback` override passed after cron prepares `cfgWithAgentDefaults`.
- Proof limitations or environment constraints: `pnpm check:test-types` was attempted first and timed out after 240s while still in the core test-type phase; `pnpm tsgo:core:test`, the touched core test-type lane, was then run directly and exited 0.
- Before evidence (optional but encouraged): current `upstream/main` returns an empty cron fallback override for the reporter's string-agent/default-fallback setup, so `resolveModelCandidateChain` never consults `agents.defaults.model.fallbacks` for that isolated cron run.

## Tests and validation

Which commands did you run?

- `pnpm install --frozen-lockfile`
- `node scripts/run-vitest.mjs src/cron/isolated-agent/run-fallback-policy.test.ts src/agents/agent-scope.test.ts src/cron/isolated-agent/run.cron-model-override-forwarding.test.ts`
- `node --import tsx ...` behavior proof shown above
- `pnpm exec oxfmt --write src/cron/isolated-agent/run-fallback-policy.ts src/cron/isolated-agent/run-fallback-policy.test.ts src/cron/isolated-agent/run.ts src/cron/isolated-agent/run-executor.ts src/cron/isolated-agent/run.cron-model-override-forwarding.test.ts`
- `git diff --check`
- `pnpm tsgo:core:test`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

What regression coverage was added or updated?

- `src/cron/isolated-agent/run-fallback-policy.test.ts` covers the direct fallback policy: matching string default-primary inheritance, rewritten-default strictness without the explicit signal, object primary strictness, and differing string model strictness.
- `src/cron/isolated-agent/run.cron-model-override-forwarding.test.ts` covers the runtime preparation path, including explicit agent and implicit default-agent cron runs passing inherited fallbacks to `runWithModelFallback`, and differing string agent models staying strict after defaults are rewritten.
- `src/agents/agent-scope.test.ts` remains unchanged and passing, proving shared string-model strictness was preserved.

What failed before this fix, if known?

- The #91362 source path produced `[]` for the cron fallback override when the selected agent used a plain string model, blocking fallthrough to `agents.defaults.model.fallbacks`.

If no test was added, why not?

- Tests were added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Isolated cron jobs in the narrow default-primary string shorthand case can now retry configured fallback models.

Did config, environment, or migration behavior change? (`Yes/No`)

No. This changes runtime fallback resolution only; no schema, env var, config migration, or docs contract change.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

- Accidentally changing strict model selection semantics for non-cron or intentionally strict cron agents.

How is that risk mitigated?

- The shared `agent-scope` helper is untouched.
- The inheritance decision is computed from raw cron runtime config before `cfgWithAgentDefaults` rewrites defaults.
- Tests cover object-style strict primaries, differing string primaries, rewritten defaults without the explicit signal, and the actual runtime `runWithModelFallback` parameter.

## Current review state

What is the next action?

- Waiting for CI and ClawSweeper review on this PR.

What is still waiting on author, maintainer, CI, or external proof?

- CI and ClawSweeper. Maintainers may also decide whether to close or supersede #91373 because that PR takes the broader shared-helper approach ClawSweeper flagged as a compatibility risk.

Which bot or reviewer comments were addressed?

- Addresses the #91362 ClawSweeper issue guidance: cron-scoped repair, preserve strict user-selected session behavior, and avoid globally changing normal agent-primary strictness.
- Addresses the #91373 ClawSweeper compatibility finding by not changing `resolveSelectedModelFallbacksOverride`.

AI-assisted: yes. I understand the code change and ran the validation above.
