### PR TITLE
fix(cron): inherit default fallbacks for cron string models

### DIFF
--- a/src/cron/isolated-agent/run-fallback-policy.test.ts
+++ b/src/cron/isolated-agent/run-fallback-policy.test.ts
@@ -263,6 +263,138 @@ describe("resolveCronFallbacksOverride", () => {
     ).toBeUndefined();
   });
 
+  it("lets cron string agent models inherit default model fallbacks", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "deepseek/deepseek-v4-pro",
+            fallbacks: ["deepseek/deepseek-v4-flash", "moonshot/kimi-k2.6"],
+          },
+        },
+        list: [
+          {
+            id: "main",
+            model: "deepseek/deepseek-v4-pro",
+          },
+        ],
+      },
+    };
+
+    expect(
+      resolveCronFallbacksOverride({
+        cfg,
+        agentId: "main",
+        job: makeJob({
+          kind: "agentTurn",
+          message: "summarize",
+        }),
+      }),
+    ).toBeUndefined();
+    expect(
+      resolveCronPreflightCandidates({
+        cfg,
+        agentId: "main",
+        provider: "deepseek",
+        model: "deepseek-v4-pro",
+        job: makeJob({
+          kind: "agentTurn",
+          message: "summarize",
+        }),
+      }),
+    ).toEqual([
+      { provider: "deepseek", model: "deepseek-v4-pro" },
+      { provider: "deepseek", model: "deepseek-v4-flash" },
+      { provider: "moonshot", model: "kimi-k2.6" },
+    ]);
+  });
+
+  it("keeps explicit empty agent fallbacks strict for cron runs", () => {
+    expect(
+      resolveCronFallbacksOverride({
+        cfg: {
+          agents: {
+            defaults: {
+              model: {
+                primary: "deepseek/deepseek-v4-pro",
+                fallbacks: ["deepseek/deepseek-v4-flash"],
+              },
+            },
+            list: [
+              {
+                id: "strict",
+                model: {
+                  primary: "deepseek/deepseek-v4-pro",
+                  fallbacks: [],
+                },
+              },
+            ],
+          },
+        },
+        agentId: "strict",
+        job: makeJob({
+          kind: "agentTurn",
+          message: "summarize",
+        }),
+      }),
+    ).toStrictEqual([]);
+  });
+
+  it("keeps string agent model overrides strict when they differ from the default primary", () => {
+    const rawCfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "deepseek/deepseek-v4-pro",
+            fallbacks: ["deepseek/deepseek-v4-flash"],
+          },
+        },
+        list: [
+          {
+            id: "research",
+            model: "openai/gpt-5.5",
+          },
+        ],
+      },
+    };
+
+    expect(
+      resolveCronFallbacksOverride({
+        cfg: rawCfg,
+        agentId: "research",
+        job: makeJob({
+          kind: "agentTurn",
+          message: "summarize",
+        }),
+      }),
+    ).toStrictEqual([]);
+    expect(
+      resolveCronPreflightCandidates({
+        cfg: {
+          ...rawCfg,
+          agents: {
+            ...rawCfg.agents,
+            defaults: {
+              ...rawCfg.agents?.defaults,
+              model: {
+                primary: "openai/gpt-5.5",
+                fallbacks: ["deepseek/deepseek-v4-flash"],
+              },
+            },
+          },
+        },
+        fallbackPolicyCfg: rawCfg,
+        agentId: "research",
+        provider: "openai",
+        model: "gpt-5.5",
+        job: makeJob({
+          kind: "agentTurn",
+          message: "summarize",
+        }),
+      }),
+    ).toStrictEqual([{ provider: "openai", model: "gpt-5.5" }]);
+  });
+
   it("plans the full configured candidate chain for cron preflight", () => {
     expect(
       resolveCronPreflightCandidates({

--- a/src/cron/isolated-agent/run-fallback-policy.ts
+++ b/src/cron/isolated-agent/run-fallback-policy.ts
@@ -1,6 +1,11 @@
 /** Resolves model fallback chains for isolated cron runs and preflight. */
+import { resolveAgentConfig } from "../../agents/agent-scope-config.js";
 import { resolveModelCandidateChain } from "../../agents/model-fallback.js";
 import type { ModelCandidate } from "../../agents/model-fallback.types.js";
+import {
+  resolveAgentModelFallbackValues,
+  resolveAgentModelPrimaryValue,
+} from "../../config/model-input.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { CronJob } from "../types.js";
 import {
@@ -33,17 +38,30 @@ export function resolveCronFallbacksOverride(params: {
       return subagentFallbacksOverride;
     }
   }
-  return resolveEffectiveModelFallbacks({
+  const effectiveFallbacks = resolveEffectiveModelFallbacks({
     cfg: params.cfg,
     agentId: params.agentId,
     hasSessionModelOverride: hasCronPayloadModelOverride,
     modelOverrideSource: hasCronPayloadModelOverride ? "auto" : undefined,
   });
+  if (!hasCronPayloadModelOverride && effectiveFallbacks?.length === 0) {
+    const agentModel = resolveAgentConfig(params.cfg, params.agentId)?.model;
+    const agentPrimary =
+      typeof agentModel === "string" && agentModel.trim().length > 0 ? agentModel.trim() : null;
+    const defaultPrimary = resolveAgentModelPrimaryValue(params.cfg.agents?.defaults?.model);
+    const hasDefaultFallbacks =
+      resolveAgentModelFallbackValues(params.cfg.agents?.defaults?.model).length > 0;
+    if (agentPrimary && agentPrimary === defaultPrimary?.trim() && hasDefaultFallbacks) {
+      return undefined;
+    }
+  }
+  return effectiveFallbacks;
 }
 
 /** Builds the ordered model candidates used by cron preflight checks. */
 export function resolveCronPreflightCandidates(params: {
   cfg: OpenClawConfig;
+  fallbackPolicyCfg?: OpenClawConfig;
   job: CronJob;
   agentId: string;
   provider: string;
@@ -51,7 +69,7 @@ export function resolveCronPreflightCandidates(params: {
   useSubagentFallbacks?: boolean;
 }): ModelCandidate[] {
   const fallbacksOverride = resolveCronFallbacksOverride({
-    cfg: params.cfg,
+    cfg: params.fallbackPolicyCfg ?? params.cfg,
     job: params.job,
     agentId: params.agentId,
     useSubagentFallbacks: params.useSubagentFallbacks,

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -656,6 +656,7 @@ async function prepareCronRunContext(params: {
   const modelPreflightRuntime = await loadCronModelPreflightRuntime();
   const preflightCandidates = resolveCronPreflightCandidates({
     cfg: cfgWithAgentDefaults,
+    fallbackPolicyCfg: input.cfg,
     job: input.job,
     agentId,
     provider,


### PR DESCRIPTION
## Summary

- Let isolated cron runs inherit `agents.defaults.model.fallbacks` when a string agent model repeats the default primary.
- Keep explicit payload fallbacks, explicit empty agent fallbacks, and string agent model overrides that differ from the default primary strict.
- Use the raw config for cron fallback-policy decisions while preflight still resolves candidates against the effective cron defaults snapshot.

Closes #91362.

## Verification

- `node scripts/run-vitest.mjs src/cron/isolated-agent/run-fallback-policy.test.ts`
- `node scripts/run-vitest.mjs src/agents/agent-scope.test.ts`
- `pnpm exec oxfmt --check src/cron/isolated-agent/run-fallback-policy.ts src/cron/isolated-agent/run-fallback-policy.test.ts src/cron/isolated-agent/run.ts`
- `node scripts/run-oxlint.mjs src/cron/isolated-agent/run-fallback-policy.ts src/cron/isolated-agent/run-fallback-policy.test.ts src/cron/isolated-agent/run.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

## Real behavior proof

**Behavior addressed:** Isolated cron runs without payload fallbacks can inherit configured default model fallbacks when a string agent model repeats the default primary, while strict agent and payload overrides remain strict.
**Real environment tested:** Local OpenClaw checkout on Linux, branch `fix/91362-cron-default-fallbacks`, using the repository Vitest, formatter, lint, and autoreview helpers.
**Exact steps or command run after this patch:** Ran the focused cron fallback policy tests, adjacent agent-scope tests, formatting, oxlint, diff check, and local autoreview commands listed in Verification.
**Evidence after fix:**

```text
node scripts/run-vitest.mjs src/cron/isolated-agent/run-fallback-policy.test.ts
[test] passed 1 Vitest shard in 33.63s

node scripts/run-vitest.mjs src/agents/agent-scope.test.ts
[test] passed 1 Vitest shard in 17.22s

pnpm exec oxfmt --check src/cron/isolated-agent/run-fallback-policy.ts src/cron/isolated-agent/run-fallback-policy.test.ts src/cron/isolated-agent/run.ts
All matched files use the correct format.

node scripts/run-oxlint.mjs src/cron/isolated-agent/run-fallback-policy.ts src/cron/isolated-agent/run-fallback-policy.test.ts src/cron/isolated-agent/run.ts
[qa-channel boundary dts] fresh; skipping
[discord boundary dts] fresh; skipping
[slack boundary dts] fresh; skipping
[whatsapp boundary dts] fresh; skipping

git diff --check
(no output)

.agents/skills/autoreview/scripts/autoreview --mode local
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.82)
```

**Observed result after fix:** The regression tests show the issue configuration now produces a fallback candidate chain with the default fallbacks, while a different string agent primary and explicit `fallbacks: []` still produce strict single-model chains.
**What was not tested:** A live scheduled cron run against real provider failures was not executed; this source-repro issue was validated at the cron fallback/preflight policy boundary.

## Additional runtime resolver proof

Ran a standalone resolver proof against the patched runtime modules after the PR was opened:

```sh
pnpm exec tsx -e 'import { resolveCronFallbacksOverride, resolveCronPreflightCandidates } from "./src/cron/isolated-agent/run-fallback-policy.ts"; /* constructs issue, strict-agent, and payload-strict configs; prints resolver output */'
```

Output:

```json
{
  "issuePreflightCandidates": [
    {
      "provider": "deepseek",
      "model": "deepseek-v4-pro"
    },
    {
      "provider": "deepseek",
      "model": "deepseek-v4-flash"
    },
    {
      "provider": "moonshot",
      "model": "kimi-k2.6"
    }
  ],
  "strictAgentFallbacksOverride": [],
  "strictAgentPreflightCandidates": [
    {
      "provider": "openai",
      "model": "gpt-5.5"
    }
  ],
  "payloadStrictFallbacksOverride": []
}
```

This proves the reported matching string-agent/default-primary cron config now walks `agents.defaults.model.fallbacks`, while a different string agent primary and payload `fallbacks: []` remain strict.
