### PR TITLE
fix(cron): clear payload model overrides

### DIFF
--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -171,6 +171,8 @@ If stdout is non-empty, that text is the delivered result. If stdout is empty an
 
 Cron jobs can also carry payload-level `fallbacks`. When present, that list replaces the configured fallback chain for the job. Use `fallbacks: []` in the job payload/API when you want a strict cron run that tries only the selected model. If a job has `--model` but neither payload nor configured fallbacks, OpenClaw passes an explicit empty fallback override so the agent primary is not appended as a hidden extra retry target.
 
+When editing a job through the Gateway API or cron tool, set `payload.model: null` to clear a stored model override and `payload.fallbacks: null` to clear stored fallback overrides. Omitted payload fields preserve existing job values.
+
 Local-provider preflight checks walk configured fallbacks before marking a cron run `skipped`; `fallbacks: []` keeps that preflight path strict.
 
 Model-selection precedence for isolated jobs is:

--- a/packages/gateway-protocol/src/cron-validators.test.ts
+++ b/packages/gateway-protocol/src/cron-validators.test.ts
@@ -171,6 +171,22 @@ describe("cron protocol validators", () => {
     ).toBe(true);
   });
 
+  it("accepts nullable agentTurn payload override clears on update params", () => {
+    expect(
+      validateCronUpdateParams({
+        id: "job-1",
+        patch: {
+          payload: {
+            kind: "agentTurn",
+            model: null,
+            fallbacks: null,
+            toolsAllow: null,
+          },
+        },
+      }),
+    ).toBe(true);
+  });
+
   it("rejects blank cron delivery target strings", () => {
     expect(
       validateCronAddParams({

--- a/packages/gateway-protocol/src/schema/cron.ts
+++ b/packages/gateway-protocol/src/schema/cron.ts
@@ -10,13 +10,18 @@ import { NonEmptyString } from "./primitives.js";
  */
 
 /** Builds create/patch payload variants while preserving per-call field optionality. */
-function cronAgentTurnPayloadSchema(params: { message: TSchema; toolsAllow: TSchema }) {
+function cronAgentTurnPayloadSchema(params: {
+  message: TSchema;
+  model: TSchema;
+  fallbacks: TSchema;
+  toolsAllow: TSchema;
+}) {
   return Type.Object(
     {
       kind: Type.Literal("agentTurn"),
       message: params.message,
-      model: Type.Optional(Type.String()),
-      fallbacks: Type.Optional(Type.Array(Type.String())),
+      model: Type.Optional(params.model),
+      fallbacks: Type.Optional(params.fallbacks),
       thinking: Type.Optional(Type.String()),
       timeoutSeconds: Type.Optional(Type.Number({ minimum: 0 })),
       allowUnsafeExternalContent: Type.Optional(Type.Boolean()),
@@ -227,6 +232,8 @@ export const CronPayloadSchema = Type.Union([
   ),
   cronAgentTurnPayloadSchema({
     message: NonEmptyString,
+    model: Type.String(),
+    fallbacks: Type.Array(Type.String()),
     toolsAllow: Type.Array(Type.String()),
   }),
   cronCommandPayloadSchema({
@@ -245,6 +252,8 @@ export const CronPayloadPatchSchema = Type.Union([
   ),
   cronAgentTurnPayloadSchema({
     message: Type.Optional(NonEmptyString),
+    model: Type.Union([Type.String(), Type.Null()]),
+    fallbacks: Type.Union([Type.Array(Type.String()), Type.Null()]),
     toolsAllow: Type.Union([Type.Array(Type.String()), Type.Null()]),
   }),
   cronCommandPayloadSchema({

--- a/src/agents/tools/cron-tool-canonicalize.ts
+++ b/src/agents/tools/cron-tool-canonicalize.ts
@@ -71,6 +71,10 @@ function isStringArrayOrNull(value: unknown): boolean {
   );
 }
 
+function isStringOrNull(value: unknown): boolean {
+  return value === null || typeof value === "string";
+}
+
 function moveDefinedField(params: {
   source: Record<string, unknown>;
   target: Record<string, unknown>;
@@ -223,7 +227,7 @@ function canonicalizeCronToolPayload(value: Record<string, unknown>): void {
   if (!isCronPayloadKind(payload.kind)) {
     const hasAgentTurnSignal =
       isNonEmptyString(payload.message) ||
-      isNonEmptyString(payload.model) ||
+      (payload.model !== undefined && isStringOrNull(payload.model)) ||
       isNonEmptyString(payload.thinking) ||
       typeof payload.timeoutSeconds === "number" ||
       typeof payload.lightContext === "boolean" ||

--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -493,6 +493,18 @@ describe("cron tool", () => {
     ]);
     expect(patch?.properties?.sessionKey?.type).toBeUndefined();
     expect(patch?.properties?.sessionKey?.description).toContain("null to clear");
+    expect(payload?.properties?.model?.anyOf?.map((entry) => entry.type)).toEqual([
+      "string",
+      "null",
+    ]);
+    expect(payload?.properties?.model?.type).toBeUndefined();
+    expect(payload?.properties?.model?.description).toContain("null to clear");
+    expect(payload?.properties?.fallbacks?.anyOf?.map((entry) => entry.type)).toEqual([
+      "array",
+      "null",
+    ]);
+    expect(payload?.properties?.fallbacks?.type).toBeUndefined();
+    expect(payload?.properties?.fallbacks?.description).toContain("null to clear");
     expect(payload?.properties?.toolsAllow?.anyOf?.map((entry) => entry.type)).toEqual([
       "array",
       "null",
@@ -1564,6 +1576,37 @@ describe("cron tool", () => {
     });
   });
 
+  it("recovers flattened nullable payload clear params for update action", async () => {
+    callGatewayMock.mockResolvedValueOnce({ ok: true });
+
+    const tool = createTestCronTool();
+    await tool.execute("call-update-flat-clear-model", {
+      action: "update",
+      id: "job-5",
+      model: null,
+      fallbacks: null,
+    });
+
+    const params = expectSingleGatewayCallMethod("cron.update") as
+      | {
+          id?: string;
+          patch?: {
+            payload?: {
+              kind?: string;
+              model?: string | null;
+              fallbacks?: string[] | null;
+            };
+          };
+        }
+      | undefined;
+    expect(params?.id).toBe("job-5");
+    expect(params?.patch?.payload).toEqual({
+      kind: "agentTurn",
+      model: null,
+      fallbacks: null,
+    });
+  });
+
   it("recovers concatenated cron update keys from local tool-call parsers", async () => {
     callGatewayMock.mockResolvedValueOnce({ ok: true });
 
@@ -1767,6 +1810,41 @@ describe("cron tool", () => {
     expect(params?.patch?.payload).toEqual({
       kind: "agentTurn",
       toolsAllow: null,
+    });
+  });
+
+  it("preserves null model and fallback payload patches on update", async () => {
+    callGatewayMock.mockResolvedValueOnce({ ok: true });
+
+    const tool = createTestCronTool();
+    await tool.execute("call-update-clear-model", {
+      action: "update",
+      id: "job-8",
+      patch: {
+        payload: {
+          model: null,
+          fallbacks: null,
+        },
+      },
+    });
+
+    const params = expectSingleGatewayCallMethod("cron.update") as
+      | {
+          id?: string;
+          patch?: {
+            payload?: {
+              kind?: string;
+              model?: string | null;
+              fallbacks?: string[] | null;
+            };
+          };
+        }
+      | undefined;
+    expect(params?.id).toBe("job-8");
+    expect(params?.patch?.payload).toEqual({
+      kind: "agentTurn",
+      model: null,
+      fallbacks: null,
     });
   });
 });

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -97,18 +97,22 @@ function failureDestinationModeSchema(params: { nullableClears: boolean }) {
   return Type.Optional(Type.Union(variants));
 }
 
-function cronPayloadObjectSchema(params: { toolsAllow: TSchema }) {
+function cronPayloadObjectSchema(params: {
+  model: TSchema;
+  fallbacks: TSchema;
+  toolsAllow: TSchema;
+}) {
   return Type.Object(
     {
       kind: optionalStringEnum(CRON_PAYLOAD_KINDS, { description: "Payload kind" }),
       text: Type.Optional(Type.String({ description: "systemEvent text" })),
       message: Type.Optional(Type.String({ description: "agentTurn prompt" })),
-      model: Type.Optional(Type.String({ description: "Model override" })),
+      model: params.model,
       thinking: Type.Optional(Type.String({ description: "Thinking override" })),
       timeoutSeconds: optionalFiniteNumberSchema({ minimum: 0 }),
       lightContext: Type.Optional(Type.Boolean()),
       allowUnsafeExternalContent: Type.Optional(Type.Boolean()),
-      fallbacks: Type.Optional(Type.Array(Type.String(), { description: "Fallback models" })),
+      fallbacks: params.fallbacks,
       toolsAllow: params.toolsAllow,
     },
     { additionalProperties: true },
@@ -147,6 +151,8 @@ function createCronScheduleSchema(): TSchema {
 function createCronPayloadSchema(): TSchema {
   return Type.Optional(
     cronPayloadObjectSchema({
+      model: Type.Optional(Type.String({ description: "Model override" })),
+      fallbacks: Type.Optional(Type.Array(Type.String(), { description: "Fallback models" })),
       toolsAllow: Type.Optional(Type.Array(Type.String(), { description: "Allowed tools" })),
     }),
   );
@@ -273,6 +279,8 @@ function createCronPatchObjectSchema(): TSchema {
         wakeMode: optionalStringEnum(CRON_WAKE_MODES),
         payload: Type.Optional(
           cronPayloadObjectSchema({
+            model: nullableStringSchema("Model override, or null to clear"),
+            fallbacks: nullableStringArraySchema("Fallback models, or null to clear"),
             toolsAllow: nullableStringArraySchema("Allowed tool ids, or null to clear"),
           }),
         ),

--- a/src/cron/normalize.test.ts
+++ b/src/cron/normalize.test.ts
@@ -736,6 +736,30 @@ describe("normalizeCronJobPatch", () => {
     expect(payload.model).toBe("anthropic/claude-sonnet-4-6");
   });
 
+  it("preserves null and blank model patches so updates can clear the override", () => {
+    const clearedByNull = normalizeCronJobPatch({
+      payload: {
+        kind: "agentTurn",
+        model: null,
+      },
+    }) as unknown as Record<string, unknown>;
+    const nullPayload = clearedByNull.payload as Record<string, unknown>;
+    expect(nullPayload.kind).toBe("agentTurn");
+    expect(nullPayload.model).toBeNull();
+    expect(validateCronUpdateParams({ id: "job-1", patch: clearedByNull })).toBe(true);
+
+    const clearedByBlank = normalizeCronJobPatch({
+      payload: {
+        kind: "agentTurn",
+        model: "   ",
+      },
+    }) as unknown as Record<string, unknown>;
+    const blankPayload = clearedByBlank.payload as Record<string, unknown>;
+    expect(blankPayload.kind).toBe("agentTurn");
+    expect(blankPayload.model).toBeNull();
+    expect(validateCronUpdateParams({ id: "job-1", patch: clearedByBlank })).toBe(true);
+  });
+
   it("preserves empty fallback lists so patches can disable fallbacks", () => {
     const normalized = normalizeCronJobPatch({
       payload: {
@@ -747,6 +771,20 @@ describe("normalizeCronJobPatch", () => {
     const payload = normalized.payload as Record<string, unknown>;
     expect(payload.kind).toBe("agentTurn");
     expect(payload.fallbacks).toStrictEqual([]);
+  });
+
+  it("preserves null fallback lists so patches can clear the fallback override", () => {
+    const normalized = normalizeCronJobPatch({
+      payload: {
+        kind: "agentTurn",
+        fallbacks: null,
+      },
+    }) as unknown as Record<string, unknown>;
+
+    const payload = normalized.payload as Record<string, unknown>;
+    expect(payload.kind).toBe("agentTurn");
+    expect(payload.fallbacks).toBeNull();
+    expect(validateCronUpdateParams({ id: "job-1", patch: normalized })).toBe(true);
   });
 
   it("preserves empty toolsAllow lists so patches can disable all tools", () => {

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -141,7 +141,7 @@ function coerceSchedule(schedule: UnknownRecord) {
   return next;
 }
 
-function coercePayload(payload: UnknownRecord) {
+function coercePayload(payload: UnknownRecord, options?: { allowPatchClears?: boolean }) {
   const next: UnknownRecord = { ...payload };
   const kindRaw = normalizeLowercaseStringOrEmpty(next.kind);
   if (kindRaw === "agentturn") {
@@ -173,6 +173,11 @@ function coercePayload(payload: UnknownRecord) {
     const model = parseOptionalField(TrimmedNonEmptyStringFieldSchema, next.model);
     if (model !== undefined) {
       next.model = model;
+    } else if (
+      options?.allowPatchClears &&
+      (next.model === null || (typeof next.model === "string" && next.model.trim() === ""))
+    ) {
+      next.model = null;
     } else {
       delete next.model;
     }
@@ -194,7 +199,9 @@ function coercePayload(payload: UnknownRecord) {
     }
   }
   if ("fallbacks" in next) {
-    const fallbacks = normalizeTrimmedStringArray(next.fallbacks);
+    const fallbacks = normalizeTrimmedStringArray(next.fallbacks, {
+      allowNull: options?.allowPatchClears,
+    });
     if (fallbacks !== undefined) {
       next.fallbacks = fallbacks;
     } else {
@@ -540,7 +547,7 @@ export function normalizeCronJobInput(
   }
 
   if (isRecord(base.payload)) {
-    next.payload = coercePayload(base.payload);
+    next.payload = coercePayload(base.payload, { allowPatchClears: !options.applyDefaults });
   }
 
   if (isRecord(base.delivery)) {

--- a/src/cron/service.jobs.test.ts
+++ b/src/cron/service.jobs.test.ts
@@ -369,6 +369,38 @@ describe("applyJobPatch", () => {
     }
   });
 
+  it("clears agentTurn model and fallback overrides when patch requests null", () => {
+    const job = createIsolatedAgentTurnJob("job-model-clear", {
+      mode: "announce",
+      channel: "telegram",
+    });
+    job.payload = {
+      kind: "agentTurn",
+      message: "do it",
+      model: "openrouter/deepseek/deepseek-r1",
+      fallbacks: ["openrouter/gpt-4.1-mini"],
+      thinking: "high",
+      toolsAllow: ["exec"],
+    };
+
+    applyJobPatch(job, {
+      payload: {
+        kind: "agentTurn",
+        model: null,
+        fallbacks: null,
+      },
+    });
+
+    expect(job.payload.kind).toBe("agentTurn");
+    if (job.payload.kind === "agentTurn") {
+      expect(job.payload.message).toBe("do it");
+      expect(job.payload.model).toBeUndefined();
+      expect(job.payload.fallbacks).toBeUndefined();
+      expect(job.payload.thinking).toBe("high");
+      expect(job.payload.toolsAllow).toEqual(["exec"]);
+    }
+  });
+
   it("applies payload.lightContext when replacing payload kind via patch", () => {
     const job = createIsolatedAgentTurnJob("job-light-context-switch", {
       mode: "announce",

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -923,9 +923,13 @@ function mergeCronPayload(existing: CronPayload, patch: CronPayloadPatch): CronP
   }
   if (typeof patch.model === "string") {
     next.model = patch.model;
+  } else if (patch.model === null) {
+    delete next.model;
   }
   if (Array.isArray(patch.fallbacks)) {
     next.fallbacks = patch.fallbacks;
+  } else if (patch.fallbacks === null) {
+    delete next.fallbacks;
   }
   if (Array.isArray(patch.toolsAllow)) {
     next.toolsAllow = patch.toolsAllow;
@@ -975,17 +979,24 @@ function buildPayloadFromPatch(patch: CronPayloadPatch): CronPayload {
     throw new Error('cron.update payload.kind="agentTurn" requires message');
   }
 
-  return {
+  const next: Extract<CronPayload, { kind: "agentTurn" }> = {
     kind: "agentTurn",
     message: patch.message,
-    model: patch.model,
-    fallbacks: patch.fallbacks,
-    toolsAllow: Array.isArray(patch.toolsAllow) ? patch.toolsAllow : undefined,
     thinking: patch.thinking,
     timeoutSeconds: patch.timeoutSeconds,
     lightContext: patch.lightContext,
     allowUnsafeExternalContent: patch.allowUnsafeExternalContent,
   };
+  if (typeof patch.model === "string") {
+    next.model = patch.model;
+  }
+  if (Array.isArray(patch.fallbacks)) {
+    next.fallbacks = patch.fallbacks;
+  }
+  if (Array.isArray(patch.toolsAllow)) {
+    next.toolsAllow = patch.toolsAllow;
+  }
+  return next;
 }
 
 function mergeCronDelivery(

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -256,7 +256,9 @@ type CronAgentTurnPayload = {
 
 type CronAgentTurnPayloadPatch = {
   kind: "agentTurn";
-} & Partial<Omit<CronAgentTurnPayloadFields, "toolsAllow">> & {
+} & Partial<Omit<CronAgentTurnPayloadFields, "model" | "fallbacks" | "toolsAllow">> & {
+    model?: string | null;
+    fallbacks?: string[] | null;
     toolsAllow?: string[] | null;
   };
 

--- a/src/gateway/server.cron.test.ts
+++ b/src/gateway/server.cron.test.ts
@@ -651,7 +651,12 @@ describe("gateway server cron", () => {
         schedule: { kind: "every", everyMs: 60_000 },
         sessionTarget: "isolated",
         wakeMode: "next-heartbeat",
-        payload: { kind: "agentTurn", message: "hello", model: "opus" },
+        payload: {
+          kind: "agentTurn",
+          message: "hello",
+          model: "opus",
+          fallbacks: ["openrouter/gpt-4.1-mini"],
+        },
       });
       expect(mergeRes.ok).toBe(true);
       const mergeJobIdValue = (mergeRes.payload as { id?: unknown } | null)?.id;
@@ -687,13 +692,14 @@ describe("gateway server cron", () => {
       expect(mergeUpdateRes.ok).toBe(true);
       const merged = mergeUpdateRes.payload as
         | {
-            payload?: { kind?: unknown; message?: unknown; model?: unknown };
+            payload?: { kind?: unknown; message?: unknown; model?: unknown; fallbacks?: unknown };
             delivery?: { mode?: unknown; channel?: unknown; to?: unknown };
           }
         | undefined;
       expect(merged?.payload?.kind).toBe("agentTurn");
       expect(merged?.payload?.message).toBe("hello");
       expect(merged?.payload?.model).toBe("opus");
+      expect(merged?.payload?.fallbacks).toEqual(["openrouter/gpt-4.1-mini"]);
       expect(merged?.delivery?.mode).toBe("announce");
       expect(merged?.delivery?.channel).toBe("telegram");
       expect(merged?.delivery?.to).toBe("19098680");
@@ -714,12 +720,44 @@ describe("gateway server cron", () => {
               kind?: unknown;
               message?: unknown;
               model?: unknown;
+              fallbacks?: unknown;
             };
           }
         | undefined;
       expect(modelOnlyPatched?.payload?.kind).toBe("agentTurn");
       expect(modelOnlyPatched?.payload?.message).toBe("hello");
       expect(modelOnlyPatched?.payload?.model).toBe("anthropic/claude-sonnet-4-6");
+      expect(modelOnlyPatched?.payload?.fallbacks).toEqual(["openrouter/gpt-4.1-mini"]);
+
+      const clearModelRes = await directCronReq(cronState, "cron.update", {
+        id: mergeJobId,
+        patch: {
+          payload: {
+            kind: "agentTurn",
+            model: null,
+            fallbacks: null,
+          },
+        },
+      });
+      expect(clearModelRes.ok).toBe(true);
+      const clearedModel = clearModelRes.payload as
+        | {
+            payload?: {
+              kind?: unknown;
+              message?: unknown;
+              model?: unknown;
+              fallbacks?: unknown;
+            };
+            delivery?: { mode?: unknown; channel?: unknown; to?: unknown };
+          }
+        | undefined;
+      expect(clearedModel?.payload?.kind).toBe("agentTurn");
+      expect(clearedModel?.payload?.message).toBe("hello");
+      expect(clearedModel?.payload?.model).toBeUndefined();
+      expect(clearedModel?.payload?.fallbacks).toBeUndefined();
+      expect(clearedModel?.delivery?.mode).toBe("announce");
+      expect(clearedModel?.delivery?.channel).toBe("telegram");
+      expect(clearedModel?.delivery?.to).toBe("19098680");
 
       const deliveryPatchRes = await directCronReq(cronState, "cron.update", {
         id: mergeJobId,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
@@ -623,11 +623,18 @@
                   "type": "boolean"
                 },
                 "fallbacks": {
-                  "description": "Fallback models",
-                  "items": {
-                    "type": "string"
-                  },
-                  "type": "array"
+                  "anyOf": [
+                    {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Fallback models, or null to clear"
                 },
                 "kind": {
                   "description": "Payload kind",
@@ -642,8 +649,15 @@
                   "type": "string"
                 },
                 "model": {
-                  "description": "Model override",
-                  "type": "string"
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Model override, or null to clear"
                 },
                 "text": {
                   "description": "systemEvent text",

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
@@ -623,11 +623,18 @@
                   "type": "boolean"
                 },
                 "fallbacks": {
-                  "description": "Fallback models",
-                  "items": {
-                    "type": "string"
-                  },
-                  "type": "array"
+                  "anyOf": [
+                    {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Fallback models, or null to clear"
                 },
                 "kind": {
                   "description": "Payload kind",
@@ -642,8 +649,15 @@
                   "type": "string"
                 },
                 "model": {
-                  "description": "Model override",
-                  "type": "string"
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Model override, or null to clear"
                 },
                 "text": {
                   "description": "systemEvent text",

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
@@ -623,11 +623,18 @@
                   "type": "boolean"
                 },
                 "fallbacks": {
-                  "description": "Fallback models",
-                  "items": {
-                    "type": "string"
-                  },
-                  "type": "array"
+                  "anyOf": [
+                    {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Fallback models, or null to clear"
                 },
                 "kind": {
                   "description": "Payload kind",
@@ -642,8 +649,15 @@
                   "type": "string"
                 },
                 "model": {
-                  "description": "Model override",
-                  "type": "string"
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Model override, or null to clear"
                 },
                 "text": {
                   "description": "systemEvent text",

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
@@ -223,8 +223,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 43943,
-    "roughTokens": 10986
+    "chars": 44349,
+    "roughTokens": 11088
   },
   "openClawDeveloperInstructions": {
     "chars": 2988,
@@ -235,8 +235,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6925
   },
   "totalWithDynamicToolsJson": {
-    "chars": 71645,
-    "roughTokens": 17912
+    "chars": 72051,
+    "roughTokens": 18013
   },
   "userInputText": {
     "chars": 1629,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -223,8 +223,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 43664,
-    "roughTokens": 10916
+    "chars": 44070,
+    "roughTokens": 11018
   },
   "openClawDeveloperInstructions": {
     "chars": 1964,
@@ -235,8 +235,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6544
   },
   "totalWithDynamicToolsJson": {
-    "chars": 69842,
-    "roughTokens": 17461
+    "chars": 70248,
+    "roughTokens": 17562
   },
   "userInputText": {
     "chars": 1129,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -224,8 +224,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 44759,
-    "roughTokens": 11190
+    "chars": 45165,
+    "roughTokens": 11292
   },
   "openClawDeveloperInstructions": {
     "chars": 1983,
@@ -236,8 +236,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6780
   },
   "totalWithDynamicToolsJson": {
-    "chars": 71880,
-    "roughTokens": 17970
+    "chars": 72286,
+    "roughTokens": 18072
   },
   "userInputText": {
     "chars": 1367,


### PR DESCRIPTION
## Summary
- Allow cron update payload patches to clear stored `payload.model` with `null`.
- Allow `payload.fallbacks: null` to clear stored fallback overrides while omitted fields still preserve existing values.
- Update cron tool schema, gateway validation, docs, regression tests, and prompt snapshots for clear semantics.

Closes #91298

## Real behavior proof
**Behavior or issue addressed:** Cron update payload patches can now clear stored `payload.model` and `payload.fallbacks` overrides with `null` instead of leaving prior overrides in place.

**Real environment tested:** Local OpenClaw checkout at head `af9bf99a34c8a1e37a769e4025c14b7ba39dfdcd`, rebased on upstream `b75d1a0b85b0651ae9d5bd60071bd1f66dd86e0d`, running on macOS with the repository TypeScript source loaded through `tsx`.

**Exact steps or command run after this patch:**

```bash
node --import tsx -e 'import { normalizeCronJobPatch } from "./src/cron/normalize.ts"; import { applyJobPatch } from "./src/cron/service/jobs.ts"; const before = { id: "cron-clear-model", name: "clear model", spec: "0 * * * *", timezone: "UTC", enabled: true, payload: { kind: "agentTurn", message: "run report", model: "gpt-4.1", fallbacks: ["gpt-4.1-mini"], toolsAllow: ["exec"] }, delivery: { mode: "announce", channel: "telegram", to: "19098680" }, createdAt: "2026-06-08T00:00:00.000Z", updatedAt: "2026-06-08T00:00:00.000Z" }; const normalizedPatch = normalizeCronJobPatch({ payload: { kind: "agentTurn", model: null, fallbacks: null } }); const after = applyJobPatch(before, normalizedPatch, "2026-06-08T00:01:00.000Z"); console.log(JSON.stringify({ normalizedPatch, payloadAfter: after.payload, deliveryAfter: after.delivery }, null, 2));'
```

**Evidence after fix:** Copied terminal output from the command above:

```json
{
  "normalizedPatch": {
    "payload": {
      "kind": "agentTurn",
      "model": null,
      "fallbacks": null
    }
  },
  "payloadAfter": {
    "kind": "agentTurn",
    "message": "run report",
    "toolsAllow": [
      "exec"
    ]
  },
  "deliveryAfter": {
    "mode": "announce",
    "channel": "telegram",
    "to": "19098680"
  }
}
```

**Observed result after fix:** The normalized patch preserves explicit `null` clear requests, then the stored cron payload no longer contains `model` or `fallbacks`. The unrelated `message`, `toolsAllow`, and `delivery` fields remain unchanged.

**What was not tested:** No live long-running Gateway daemon was started. The changed path is covered through the cron service, gateway request, protocol validator, and cron tool regression paths.

## Validation
- `node scripts/run-vitest.mjs src/cron/service.jobs.test.ts src/cron/normalize.test.ts src/agents/tools/cron-tool.test.ts src/gateway/server.cron.test.ts packages/gateway-protocol/src/cron-validators.test.ts`
- `pnpm prompt:snapshots:check`
- `pnpm exec oxfmt --check --threads=1 docs/automation/cron-jobs.md packages/gateway-protocol/src/cron-validators.test.ts packages/gateway-protocol/src/schema/cron.ts src/agents/tools/cron-tool-canonicalize.ts src/agents/tools/cron-tool.test.ts src/agents/tools/cron-tool.ts src/cron/normalize.test.ts src/cron/normalize.ts src/cron/service.jobs.test.ts src/cron/service/jobs.ts src/cron/types.ts src/gateway/server.cron.test.ts test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md`
- `pnpm changed:lanes --json` returned `core`, `coreTests`, `docs`, and `tooling` after prompt snapshot updates.
- `pnpm check:docs`
- `git diff --check`
- Direct `pnpm check:changed` hit Crabbox binary sanity failure. Fallback changed gate passed before rebase with `env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false corepack pnpm check:changed`. Post-rebase focused tests, prompt snapshot check, formatter, changed lanes, and whitespace checks passed.

## Risk
User-visible behavior change for cron update payloads only. `null` clears explicit model and fallback overrides. Omitted fields still preserve existing values. No config, env, migration, auth, or network behavior changes.
