### PR TITLE
[codex] Fix Claude tool-only empty response fallback

### DIFF
--- a/src/agents/cli-output.test.ts
+++ b/src/agents/cli-output.test.ts
@@ -619,6 +619,60 @@ describe("createCliJsonlStreamingParser", () => {
     ]);
   });
 
+  it("preserves tool-use count for Claude tool-only empty result turns", () => {
+    const parser = createCliJsonlStreamingParser({
+      backend: {
+        command: "claude",
+        output: "jsonl",
+        jsonlDialect: "claude-stream-json",
+        sessionIdFields: ["session_id"],
+      },
+      providerId: "claude-cli",
+      onAssistantDelta: () => {},
+      onToolUseStart: () => {},
+      onToolResult: () => {},
+    });
+
+    parser.push(
+      [
+        JSON.stringify({
+          type: "assistant",
+          message: {
+            role: "assistant",
+            content: [
+              {
+                type: "tool_use",
+                id: "toolu_message",
+                name: "message",
+                input: { text: "Already delivered" },
+              },
+            ],
+          },
+        }),
+        JSON.stringify({
+          type: "result",
+          result: "",
+          session_id: "claude-session-1",
+          usage: { input_tokens: 12, output_tokens: 1 },
+        }),
+      ].join("\n") + "\n",
+    );
+    parser.finish();
+
+    expect(parser.getOutput()).toEqual({
+      text: "",
+      sessionId: "claude-session-1",
+      usage: {
+        input: 12,
+        output: 1,
+        cacheRead: undefined,
+        cacheWrite: undefined,
+        total: undefined,
+      },
+      toolUseCount: 1,
+    });
+  });
+
   it("reassembles streamed tool args from input_json_delta chunks", () => {
     const starts: CliToolUseStartDelta[] = [];
     const parser = createCliJsonlStreamingParser({

--- a/src/agents/cli-output.ts
+++ b/src/agents/cli-output.ts
@@ -24,7 +24,14 @@ export type CliOutput = {
   sessionId?: string;
   usage?: CliUsage;
   finalPromptText?: string;
+  toolUseCount?: number;
 };
+
+function withCliToolUseCount<T extends CliOutput>(output: T, count: number | undefined): T {
+  return typeof count === "number" && count > 0
+    ? ({ ...output, toolUseCount: count } as T)
+    : output;
+}
 
 /** Incremental assistant text emitted while parsing a streaming CLI response. */
 export type CliStreamingDelta = {
@@ -367,6 +374,7 @@ function parseClaudeCliJsonlResult(params: {
   parsed: Record<string, unknown>;
   sessionId?: string;
   usage?: CliUsage;
+  toolUseCount?: number;
 }): CliOutput | null {
   if (!usesClaudeStreamJsonDialect(params)) {
     return null;
@@ -378,11 +386,17 @@ function parseClaudeCliJsonlResult(params: {
   ) {
     const resultText = unwrapNestedCliResultText(params.parsed.result).trim();
     if (resultText) {
-      return { text: resultText, sessionId: params.sessionId, usage: params.usage };
+      return withCliToolUseCount(
+        { text: resultText, sessionId: params.sessionId, usage: params.usage },
+        params.toolUseCount,
+      );
     }
     // Claude may finish with an empty result after tool-only work. Keep the
     // resolved session handle and usage instead of dropping them.
-    return { text: "", sessionId: params.sessionId, usage: params.usage };
+    return withCliToolUseCount(
+      { text: "", sessionId: params.sessionId, usage: params.usage },
+      params.toolUseCount,
+    );
   }
   return null;
 }
@@ -657,12 +671,24 @@ export function createCliJsonlStreamingParser(params: {
       usage = nextUsage ?? usage;
     }
 
+    if (params.onToolUseStart || params.onToolResult) {
+      dispatchClaudeCliStreamingToolEvent({
+        backend: params.backend,
+        providerId: params.providerId,
+        parsed,
+        tracker: toolTracker,
+        onToolUseStart: params.onToolUseStart,
+        onToolResult: params.onToolResult,
+      });
+    }
+
     const result = parseClaudeCliJsonlResult({
       backend: params.backend,
       providerId: params.providerId,
       parsed,
       sessionId,
       usage,
+      toolUseCount: toolTracker.startedIds.size,
     });
     if (result) {
       output = result;
@@ -675,17 +701,6 @@ export function createCliJsonlStreamingParser(params: {
       if (!type || type.includes("message")) {
         texts.push(item.text);
       }
-    }
-
-    if (params.onToolUseStart || params.onToolResult) {
-      dispatchClaudeCliStreamingToolEvent({
-        backend: params.backend,
-        providerId: params.providerId,
-        parsed,
-        tracker: toolTracker,
-        onToolUseStart: params.onToolUseStart,
-        onToolResult: params.onToolResult,
-      });
     }
 
     const delta = parseClaudeCliStreamingDelta({
@@ -747,7 +762,9 @@ export function createCliJsonlStreamingParser(params: {
         return output;
       }
       const text = texts.join("\n").trim();
-      return text ? { text, sessionId, usage } : null;
+      return text
+        ? withCliToolUseCount({ text, sessionId, usage }, toolTracker.startedIds.size)
+        : null;
     },
   };
 }
@@ -766,6 +783,7 @@ export function parseCliJsonl(
   let sessionId: string | undefined;
   let usage: CliUsage | undefined;
   const texts: string[] = [];
+  const toolTracker = createToolUseTracker();
   for (const line of lines) {
     for (const parsed of parseJsonRecordCandidates(line)) {
       sessionId = pickCliSessionId(parsed, backend) ?? sessionId;
@@ -778,12 +796,20 @@ export function parseCliJsonl(
         usage = nextUsage ?? usage;
       }
 
+      dispatchClaudeCliStreamingToolEvent({
+        backend,
+        providerId,
+        parsed,
+        tracker: toolTracker,
+      });
+
       const claudeResult = parseClaudeCliJsonlResult({
         backend,
         providerId,
         parsed,
         sessionId,
         usage,
+        toolUseCount: toolTracker.startedIds.size,
       });
       if (claudeResult) {
         return claudeResult;
@@ -802,7 +828,7 @@ export function parseCliJsonl(
   if (!text) {
     return null;
   }
-  return { text, sessionId, usage };
+  return withCliToolUseCount({ text, sessionId, usage }, toolTracker.startedIds.size);
 }
 
 /** Parses CLI output according to the backend output mode with text fallback. */

--- a/src/agents/cli-runner.reliability.test.ts
+++ b/src/agents/cli-runner.reliability.test.ts
@@ -1720,6 +1720,77 @@ describe("runCliAgent reliability", () => {
     expect(hookRunner.runLlmOutput).not.toHaveBeenCalled();
   });
 
+  it("does not fail over when a Claude CLI turn has tool calls but no assistant text", async () => {
+    const hookRunner = {
+      hasHooks: vi.fn((hookName: string) => hookName === "llm_output"),
+      runLlmInput: vi.fn(async () => undefined),
+      runLlmOutput: vi.fn(async () => undefined),
+      runAgentEnd: vi.fn(async () => undefined),
+    };
+    setHookRunnerForTest(hookRunner);
+
+    supervisorSpawnMock.mockResolvedValueOnce(
+      createManagedRun({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 50,
+        stdout:
+          [
+            JSON.stringify({
+              type: "assistant",
+              message: {
+                role: "assistant",
+                content: [
+                  {
+                    type: "tool_use",
+                    id: "toolu_message",
+                    name: "message",
+                    input: { text: "Already delivered in Telegram" },
+                  },
+                ],
+              },
+            }),
+            JSON.stringify({
+              type: "result",
+              result: "",
+              session_id: "claude-session-1",
+            }),
+          ].join("\n") + "\n",
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      }),
+    );
+
+    const context = buildPreparedContext({
+      provider: "claude-cli",
+      model: "claude-sonnet-4-6",
+      runId: "run-tool-only-empty-result",
+    });
+    const backend = {
+      ...context.preparedBackend.backend,
+      output: "jsonl" as const,
+      jsonlDialect: "claude-stream-json" as const,
+      sessionIdFields: ["session_id"],
+    };
+    const result = await runPreparedCliAgent({
+      ...context,
+      backendResolved: {
+        ...context.backendResolved,
+        config: backend,
+      },
+      preparedBackend: {
+        ...context.preparedBackend,
+        backend,
+      },
+    });
+
+    expect(result.payloads).toBeUndefined();
+    expect(result.meta.executionTrace?.fallbackUsed).toBe(false);
+    expect(hookRunner.runLlmOutput).not.toHaveBeenCalled();
+  });
+
   it("returns silent payload for empty CLI output when silence is allowed", async () => {
     const hookRunner = {
       hasHooks: vi.fn((hookName: string) => hookName === "llm_output"),

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -543,7 +543,11 @@ export async function runPreparedCliAgent(
           };
     const output = await executePreparedCliRun(attemptContext, cliSessionIdToUse);
     const assistantText = output.text.trim();
-    if (!assistantText && params.allowEmptyAssistantReplyAsSilent !== true) {
+    if (
+      !assistantText &&
+      params.allowEmptyAssistantReplyAsSilent !== true &&
+      (output.toolUseCount ?? 0) === 0
+    ) {
       throw new FailoverError("CLI backend returned an empty response.", {
         reason: "empty_response",
         provider: params.provider,


### PR DESCRIPTION
Fixes #91302.

## What changed

- Track Claude CLI tool-use events in JSONL output parsing.
- Preserve tool-use metadata on Claude turns that finish with an empty `result`.
- Avoid `empty_response` failover when a CLI turn has tool calls but no final assistant text.

## Why

Claude can complete a turn by calling a delivery tool, such as `message`, and then emit `result: ""`. The runner previously treated that empty text as a failed response, which could trigger fallback behavior and duplicate externally delivered replies.

## Validation

```sh
node scripts/run-vitest.mjs run src/agents/cli-output.test.ts src/agents/cli-runner.reliability.test.ts
```
