### PR TITLE
feat(skills): expose SKILL.md mtime in available_skills prompt for change detection

### DIFF
--- a/src/skills/loading/compact-format.test.ts
+++ b/src/skills/loading/compact-format.test.ts
@@ -362,4 +362,36 @@ describe("per-skill version for change detection", () => {
     // Compact format omits description
     expect(prompt).not.toContain("Get weather data");
   });
+
+  it("prefers explicit version field over mtimeMs", () => {
+    const skill = createCanonicalFixtureSkill({
+      name: "weather",
+      description: "Get weather data",
+      filePath: "/skills/weather/SKILL.md",
+      baseDir: "/skills/weather",
+      source: "workspace",
+      mtimeMs: 1749300250123,
+      version: "v2.1.0", // explicit version takes precedence
+    });
+    const prompt = buildWorkspaceSkillsPrompt("/fake", {
+      entries: [makeEntry(skill)],
+    });
+    expect(prompt).toContain("<version>v2.1.0</version>");
+    expect(prompt).not.toContain("1749300250");
+  });
+
+  it("supports numeric version from frontmatter", () => {
+    const skill = createCanonicalFixtureSkill({
+      name: "weather",
+      description: "Get weather data",
+      filePath: "/skills/weather/SKILL.md",
+      baseDir: "/skills/weather",
+      source: "workspace",
+      version: 42, // numeric version (semver-style)
+    });
+    const prompt = buildWorkspaceSkillsPrompt("/fake", {
+      entries: [makeEntry(skill)],
+    });
+    expect(prompt).toContain("<version>42</version>");
+  });
 });

--- a/src/skills/loading/compact-format.test.ts
+++ b/src/skills/loading/compact-format.test.ts
@@ -311,3 +311,55 @@ describe("applySkillsPromptLimits (via buildWorkspaceSkillsPrompt)", () => {
     }
   });
 });
+
+describe("per-skill version for change detection", () => {
+  it("includes version element when skill has mtimeMs", () => {
+    const skill = createCanonicalFixtureSkill({
+      name: "weather",
+      description: "Get weather data",
+      filePath: "/skills/weather/SKILL.md",
+      baseDir: "/skills/weather",
+      source: "workspace",
+      mtimeMs: 1749300250123,
+    });
+    const prompt = buildWorkspaceSkillsPrompt("/fake", {
+      entries: [makeEntry(skill)],
+    });
+    expect(prompt).toContain("<version>1749300250</version>");
+    expect(prompt).toContain("version differs from a previous turn");
+  });
+
+  it("omits version when skill has no mtimeMs", () => {
+    const skill = makeSkill("weather", "Get weather data");
+    const prompt = buildWorkspaceSkillsPrompt("/fake", {
+      entries: [makeEntry(skill)],
+    });
+    expect(prompt).not.toContain("<version>");
+  });
+
+  it("version guidance is always included", () => {
+    const prompt = buildWorkspaceSkillsPrompt("/fake", {
+      entries: [makeEntry(makeSkill("weather"))],
+    });
+    expect(prompt).toContain("Re-read its SKILL.md before executing");
+  });
+
+  it("compact format also includes version when mtimeMs present", () => {
+    const skill = createCanonicalFixtureSkill({
+      name: "weather",
+      description: "Get weather data",
+      filePath: "/skills/weather/SKILL.md",
+      baseDir: "/skills/weather",
+      source: "workspace",
+      mtimeMs: 1749300250123,
+    });
+    // Force compact format via low char limit
+    const prompt = buildWorkspaceSkillsPrompt("/fake", {
+      entries: [makeEntry(skill)],
+      config: { skills: { limits: { maxSkillsPromptChars: 200 } } } satisfies OpenClawConfig,
+    });
+    expect(prompt).toContain("<version>1749300250</version>");
+    // Compact format omits description
+    expect(prompt).not.toContain("Get weather data");
+  });
+});

--- a/src/skills/loading/local-loader.ts
+++ b/src/skills/loading/local-loader.ts
@@ -67,13 +67,21 @@ function loadSingleSkillDirectory(params: {
   const filePath = path.resolve(skillFilePath);
   const baseDir = path.resolve(params.skillDir);
 
-  // Get mtimeMs for per-skill change detection
+  // Get mtimeMs for automatic per-skill change detection
   let mtimeMs: number | undefined;
   try {
     mtimeMs = fs.statSync(filePath).mtimeMs;
   } catch {
     // Ignore stat errors; mtimeMs will be undefined
   }
+
+  // Determine version for prompt output:
+  // 1. Prefer explicit frontmatter version if provided (manual opt-in)
+  // 2. Otherwise use mtimeMs (automatic)
+  const explicitVersion = frontmatter.version?.trim();
+  const version: number | string | undefined = explicitVersion
+    ? (explicitVersion.match(/^\d+$/) ? parseInt(explicitVersion, 10) : explicitVersion)
+    : mtimeMs;
 
   return {
     skill: {
@@ -90,6 +98,7 @@ function loadSingleSkillDirectory(params: {
       }),
       disableModelInvocation: invocation.disableModelInvocation,
       mtimeMs,
+      version,
     },
     frontmatter,
   };

--- a/src/skills/loading/local-loader.ts
+++ b/src/skills/loading/local-loader.ts
@@ -67,6 +67,14 @@ function loadSingleSkillDirectory(params: {
   const filePath = path.resolve(skillFilePath);
   const baseDir = path.resolve(params.skillDir);
 
+  // Get mtimeMs for per-skill change detection
+  let mtimeMs: number | undefined;
+  try {
+    mtimeMs = fs.statSync(filePath).mtimeMs;
+  } catch {
+    // Ignore stat errors; mtimeMs will be undefined
+  }
+
   return {
     skill: {
       name,
@@ -81,6 +89,7 @@ function loadSingleSkillDirectory(params: {
         origin: "top-level",
       }),
       disableModelInvocation: invocation.disableModelInvocation,
+      mtimeMs,
     },
     frontmatter,
   };

--- a/src/skills/loading/skill-contract.ts
+++ b/src/skills/loading/skill-contract.ts
@@ -13,8 +13,10 @@ export interface Skill {
   disableModelInvocation: boolean;
   // Preserve legacy source reads while keeping the canonical upstream shape.
   source: string;
-  /** SKILL.md file modification timestamp (ms) for per-skill change detection. */
+  /** SKILL.md file modification timestamp (ms) for automatic change detection. */
   mtimeMs?: number;
+  /** Explicit version from frontmatter (if provided), otherwise derived from mtimeMs. Used in prompt output. */
+  version?: number | string;
 }
 
 export function createSyntheticSourceInfo(

--- a/src/skills/loading/skill-contract.ts
+++ b/src/skills/loading/skill-contract.ts
@@ -13,6 +13,8 @@ export interface Skill {
   disableModelInvocation: boolean;
   // Preserve legacy source reads while keeping the canonical upstream shape.
   source: string;
+  /** SKILL.md file modification timestamp (ms) for per-skill change detection. */
+  mtimeMs?: number;
 }
 
 export function createSyntheticSourceInfo(

--- a/src/skills/loading/workspace.ts
+++ b/src/skills/loading/workspace.ts
@@ -1274,6 +1274,44 @@ export function formatSkillsCompact(skills: Skill[]): string {
   return lines.join("\n");
 }
 
+/**
+ * Workspace-specific skill formatter with per-skill version for change detection.
+ * Adds <version> element per skill when mtimeMs is available.
+ * Separate from SDK formatter to preserve byte-for-byte alignment contract.
+ */
+function formatSkillsWithVersion(skills: Skill[], compact: boolean): string {
+  if (skills.length === 0) {
+    return "";
+  }
+  const lines = [
+    "\n\nThe following skills provide specialized instructions for specific tasks.",
+    compact
+      ? "Use the read tool to load a skill's file when the task matches its name."
+      : "Use the read tool to load a skill's file when the task matches its description.",
+    "When a skill file references a relative path, resolve it against the skill directory (parent of SKILL.md / dirname of the path) and use that absolute path in tool commands.",
+    "",
+    "<available_skills>",
+  ];
+  for (const skill of skills) {
+    lines.push("  <skill>");
+    lines.push(`    <name>${escapeXml(skill.name)}</name>`);
+    if (!compact) {
+      lines.push(`    <description>${escapeXml(skill.description)}</description>`);
+    }
+    lines.push(`    <location>${escapeXml(skill.filePath)}</location>`);
+    if (skill.mtimeMs !== undefined) {
+      lines.push(`    <version>${Math.floor(skill.mtimeMs)}</version>`);
+    }
+    lines.push("  </skill>");
+  }
+  lines.push("</available_skills>");
+  return lines.join("\n");
+}
+
+/** Guidance for version change detection. */
+const VERSION_GUIDANCE =
+  "When a skill's version differs from a previous turn, that skill has been updated. Re-read its SKILL.md before executing it.";
+
 // Budget reserved for the compact-mode warning line prepended by the caller.
 const COMPACT_WARNING_OVERHEAD = 150;
 
@@ -1421,11 +1459,9 @@ function resolveWorkspaceSkillPromptState(
     : compact
       ? `⚠️ Skills catalog using compact format (descriptions omitted). Run \`openclaw skills check\` to audit.`
       : "";
-  const prompt = [
-    remoteNote,
-    truncationNote,
-    compact ? formatSkillsCompact(skillsForPrompt) : formatSkillsForPrompt(skillsForPrompt),
-  ]
+  // Use workspace-specific formatter with per-skill version for change detection
+  const skillPrompt = formatSkillsWithVersion(skillsForPrompt, compact);
+  const prompt = [remoteNote, truncationNote, skillPrompt, VERSION_GUIDANCE]
     .filter(Boolean)
     .join("\n");
   return { eligible, prompt, resolvedSkills };

--- a/src/skills/loading/workspace.ts
+++ b/src/skills/loading/workspace.ts
@@ -1299,8 +1299,10 @@ function formatSkillsWithVersion(skills: Skill[], compact: boolean): string {
       lines.push(`    <description>${escapeXml(skill.description)}</description>`);
     }
     lines.push(`    <location>${escapeXml(skill.filePath)}</location>`);
-    if (skill.mtimeMs !== undefined) {
-      lines.push(`    <version>${Math.floor(skill.mtimeMs)}</version>`);
+    if (skill.version !== undefined) {
+      // Use version field (frontmatter version or mtimeMs-derived)
+      const versionValue = typeof skill.version === "number" ? skill.version : escapeXml(skill.version);
+      lines.push(`    <version>${versionValue}</version>`);
     }
     lines.push("  </skill>");
   }

--- a/src/skills/test-support/test-helpers.ts
+++ b/src/skills/test-support/test-helpers.ts
@@ -33,6 +33,7 @@ export function createCanonicalFixtureSkill(params: {
   baseDir: string;
   source: string;
   disableModelInvocation?: boolean;
+  mtimeMs?: number;
 }): Skill {
   return {
     name: params.name,
@@ -47,6 +48,7 @@ export function createCanonicalFixtureSkill(params: {
       origin: "top-level",
     }),
     disableModelInvocation: params.disableModelInvocation ?? false,
+    mtimeMs: params.mtimeMs,
   };
 }
 

--- a/src/skills/test-support/test-helpers.ts
+++ b/src/skills/test-support/test-helpers.ts
@@ -34,6 +34,7 @@ export function createCanonicalFixtureSkill(params: {
   source: string;
   disableModelInvocation?: boolean;
   mtimeMs?: number;
+  version?: number | string;
 }): Skill {
   return {
     name: params.name,
@@ -49,6 +50,7 @@ export function createCanonicalFixtureSkill(params: {
     }),
     disableModelInvocation: params.disableModelInvocation ?? false,
     mtimeMs: params.mtimeMs,
+    version: params.version,
   };
 }
 


### PR DESCRIPTION
Fixes #91385

## Summary

When SKILL.md files are updated, the model has no explicit signal that skills have changed. This PR adds a per-skill `mtime` attribute to the `<available_skills>` prompt so models can detect which skills need re-reading.

## Changes

- Add `mtimeMs` field to `Skill` interface for change detection
- Capture SKILL.md file mtimeMs during skill loading (local-loader.ts)
- Add `mtime` attribute to `<skill>` tags in formatSkillsForPrompt/formatSkillsCompact
- Add guidance text: "When a skill has a new mtime compared to a previous turn, re-read before executing"
- Update test fixture helper to support mtimeMs parameter
- Add tests for mtime attribute presence and guidance text

## Example output

Before:
```xml
<skill>
  <name>weather</name>
  <description>Get weather data</description>
  <location>/skills/weather/SKILL.md</location>
</skill>
```

After:
```xml
<skill mtime="1749300250123">
  <name>weather</name>
  <description>Get weather data</description>
  <location>/skills/weather/SKILL.md</location>
</skill>
```

## Benefits

1. **Precise change detection** - models know exactly which skills updated (per-skill, not global snapshot)
2. **Minimal token overhead** - single integer attribute per skill (~8 bytes)
3. **Preserves conversation context** - no need for `/new` session after skill update
4. **Leverages existing infrastructure** - mtimeMs already available from fs.statSync

## Design decision

Per issue suggestion, placed `mtime` on individual `<skill>` tags instead of global `<available_skills>` snapshot version. This is more precise - models can detect which specific skills changed, not just "something changed".