### PR TITLE
fix: clarify provider quota errors

### DIFF
--- a/src/agents/embedded-agent-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/embedded-agent-helpers.formatassistanterrortext.test.ts
@@ -245,6 +245,16 @@ describe("formatAssistantErrorText", () => {
     });
     expect(result).toBe(formatBillingErrorMessage("openrouter", "openai/gpt-5.5"));
   });
+  it("returns billing guidance for Volcengine Coding Plan subscription failures", () => {
+    const msg = makeAssistantError(
+      'HTTP 400 Bad Request: {"error":{"code":"InvalidSubscription","message":"Your account does not have a valid CodingPlan subscription, or your subscription has expired."}}',
+    );
+    const result = formatAssistantErrorText(msg, {
+      provider: "volcengine-plan",
+      model: "ark-code-latest",
+    });
+    expect(result).toBe(formatBillingErrorMessage("volcengine-plan", "ark-code-latest"));
+  });
   it("returns a friendly message for rate limit errors", () => {
     const msg = makeAssistantError("429 rate limit reached");
     expect(formatAssistantErrorText(msg)).toContain("rate limit reached");

--- a/src/agents/embedded-agent-helpers/failover-matches.test.ts
+++ b/src/agents/embedded-agent-helpers/failover-matches.test.ts
@@ -1,5 +1,6 @@
 // Covers provider-specific failover matcher regressions.
 import { describe, expect, it } from "vitest";
+import { classifyFailoverReason } from "./errors.js";
 import {
   isAuthErrorMessage,
   isBillingErrorMessage,
@@ -99,6 +100,34 @@ describe("Z.ai vendor error codes (#48988)", () => {
     it("auth still classified correctly", () => {
       expect(isAuthErrorMessage("invalid api key provided")).toBe(true);
     });
+  });
+});
+
+describe("Volcengine Coding Plan subscription errors", () => {
+  it("classifies InvalidSubscription JSON body as billing", () => {
+    const raw =
+      '{"error":{"code":"InvalidSubscription","message":"Your account does not have a valid CodingPlan subscription, or your subscription has expired."}}';
+    expect(isBillingErrorMessage(raw)).toBe(true);
+  });
+
+  it("classifies long InvalidSubscription payloads as billing", () => {
+    const raw = JSON.stringify({
+      error: {
+        code: "InvalidSubscription",
+        message:
+          "Your account does not have a valid coding plan subscription, or your subscription has expired.",
+        details: "x".repeat(700),
+      },
+    });
+    expect(raw.length).toBeGreaterThan(512);
+    expect(isBillingErrorMessage(raw)).toBe(true);
+  });
+
+  it("classifies InvalidSubscription as billing before auth or rate limit", () => {
+    const raw =
+      '{"error":{"code":"InvalidSubscription","message":"Your account does not have a valid CodingPlan subscription, or your subscription has expired."}}';
+    expect(isRateLimitErrorMessage(raw)).toBe(false);
+    expect(classifyFailoverReason(raw)).toBe("billing");
   });
 });
 

--- a/src/agents/embedded-agent-helpers/failover-matches.ts
+++ b/src/agents/embedded-agent-helpers/failover-matches.ts
@@ -56,6 +56,7 @@ const CJK_AUTH_ERROR_PATTERNS = [
 
 const ZAI_BILLING_CODE_1311_RE = /"code"\s*:\s*1311\b/;
 const ZAI_AUTH_CODE_1113_RE = /"code"\s*:\s*1113\b/;
+const VOLCENGINE_INVALID_SUBSCRIPTION_RE = /"code"\s*:\s*"InvalidSubscription"/i;
 const STATUS_INTERNAL_SERVER_ERROR_RE = /\bstatus:\s*internal server error\b/i;
 const STATUS_INTERNAL_SERVER_ERROR_WITH_500_RE =
   /^(?=[\s\S]*\bstatus:\s*internal server error\b)(?=[\s\S]*\bcode["']?\s*[:=]\s*500\b)/i;
@@ -207,6 +208,10 @@ const ERROR_PATTERNS = {
     "账户余额不足",
     "欠费",
     "账户已欠费",
+    // Volcengine Coding Plan entitlement failure. Official Ark error code:
+    // HTTP 400 + InvalidSubscription means the plan is missing or expired.
+    VOLCENGINE_INVALID_SUBSCRIPTION_RE,
+    /\bdoes not have a valid coding\s*plan subscription\b/i,
     // Z.ai: error 1311 = model not included in current subscription plan (#48988)
     ZAI_BILLING_CODE_1311_RE,
     /\bcurrent\s+subscription\s+plan\b.*\b(?:does\s+not|doesn't|not)\b.*\binclude\s+access\b/i,
@@ -281,7 +286,11 @@ export function isBillingErrorMessage(raw: string): boolean {
   }
 
   if (raw.length > BILLING_ERROR_MAX_LENGTH) {
-    return BILLING_ERROR_HARD_402_RE.test(value) || ZAI_BILLING_CODE_1311_RE.test(value);
+    return (
+      BILLING_ERROR_HARD_402_RE.test(value) ||
+      ZAI_BILLING_CODE_1311_RE.test(value) ||
+      VOLCENGINE_INVALID_SUBSCRIPTION_RE.test(value)
+    );
   }
   if (matchesErrorPatterns(value, ERROR_PATTERNS.billing)) {
     return true;

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -23,7 +23,10 @@ import {
   resolveRunAfterAutoFallbackPrimaryProbeRecheck,
 } from "./agent-runner-execution.js";
 import { HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT } from "./agent-runner-failure-copy.js";
-import { PROVIDER_CONVERSATION_STATE_ERROR_USER_MESSAGE } from "./provider-request-error-classifier.js";
+import {
+  PROVIDER_CONVERSATION_STATE_ERROR_USER_MESSAGE,
+  PROVIDER_RATE_LIMIT_OR_QUOTA_ERROR_USER_MESSAGE,
+} from "./provider-request-error-classifier.js";
 import type { FollowupRun } from "./queue.js";
 import type { ReplyOperation } from "./reply-run-registry.js";
 import type { TypingSignaler } from "./typing-mode.js";
@@ -98,31 +101,36 @@ vi.mock("../../agents/bootstrap-budget.js", () => ({
   resolveBootstrapWarningSignaturesSeen: () => [],
 }));
 
-vi.mock("../../agents/embedded-agent-helpers.js", () => ({
-  BILLING_ERROR_USER_MESSAGE: "billing",
-  formatRateLimitOrOverloadedErrorCopy: (message: string) => {
-    if (/model\s+(?:is\s+)?at capacity/i.test(message)) {
-      return "⚠️ Selected model is at capacity. Try a different model, or wait and retry.";
-    }
-    if (/rate.limit|too many requests|429/i.test(message)) {
-      return "⚠️ API rate limit reached. Please try again later.";
-    }
-    if (/overloaded/i.test(message)) {
-      return "The AI service is temporarily overloaded. Please try again in a moment.";
-    }
-    return undefined;
-  },
-  isCompactionFailureError: (message?: string) => state.isCompactionFailureErrorMock(message),
-  isContextOverflowError: (message?: string) => state.isContextOverflowErrorMock(message),
-  isBillingErrorMessage: () => false,
-  isLikelyContextOverflowError: (message?: string) =>
-    state.isLikelyContextOverflowErrorMock(message),
-  isOverloadedErrorMessage: (message: string) => /overloaded|capacity/i.test(message),
-  isRateLimitErrorMessage: (message: string) =>
-    /rate.limit|too many requests|429|usage limit/i.test(message),
-  isTransientHttpError: () => false,
-  sanitizeUserFacingText: (text?: string) => text ?? "",
-}));
+vi.mock("../../agents/embedded-agent-helpers.js", async () => {
+  const actual = await vi.importActual<typeof import("../../agents/embedded-agent-helpers.js")>(
+    "../../agents/embedded-agent-helpers.js",
+  );
+  return {
+    BILLING_ERROR_USER_MESSAGE: "billing",
+    formatRateLimitOrOverloadedErrorCopy: (message: string) => {
+      if (/model\s+(?:is\s+)?at capacity/i.test(message)) {
+        return "⚠️ Selected model is at capacity. Try a different model, or wait and retry.";
+      }
+      if (/rate.limit|too many requests|429/i.test(message)) {
+        return "⚠️ API rate limit reached. Please try again later.";
+      }
+      if (/overloaded/i.test(message)) {
+        return "The AI service is temporarily overloaded. Please try again in a moment.";
+      }
+      return undefined;
+    },
+    isCompactionFailureError: (message?: string) => state.isCompactionFailureErrorMock(message),
+    isContextOverflowError: (message?: string) => state.isContextOverflowErrorMock(message),
+    isBillingErrorMessage: actual.isBillingErrorMessage,
+    isLikelyContextOverflowError: (message?: string) =>
+      state.isLikelyContextOverflowErrorMock(message),
+    isOverloadedErrorMessage: (message: string) => /overloaded|capacity/i.test(message),
+    isRateLimitErrorMessage: (message: string) =>
+      /rate.limit|too many requests|429|usage limit/i.test(message),
+    isTransientHttpError: () => false,
+    sanitizeUserFacingText: (text?: string) => text ?? "",
+  };
+});
 
 vi.mock("../../config/sessions.js", () => ({
   resolveGroupSessionKey: vi.fn(() => null),
@@ -5417,6 +5425,58 @@ describe("runAgentTurnWithFallback", () => {
     if (result.kind === "final") {
       expect(result.payload.text).toContain("Agent failed before reply");
       expect(result.payload.text).toContain("incomplete terminal response");
+    }
+  });
+
+  it("surfaces provider quota guidance for generic HTTP 429 failures before reply", async () => {
+    const error = new Error(
+      "Something went wrong while processing your request. Please try again.",
+    );
+    Object.assign(error, { status: 429 });
+    state.runEmbeddedAgentMock.mockRejectedValueOnce(error);
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback(
+      createMinimalRunAgentTurnParams({
+        sessionCtx: {
+          Provider: "discord",
+          Surface: "discord",
+          ChatType: "direct",
+          MessageSid: "msg",
+        } as unknown as TemplateContext,
+      }),
+    );
+
+    expect(result.kind).toBe("final");
+    if (result.kind === "final") {
+      expect(result.payload.text).toBe(PROVIDER_RATE_LIMIT_OR_QUOTA_ERROR_USER_MESSAGE);
+      expect(result.payload.text).not.toBe(GENERIC_RUN_FAILURE_TEXT);
+    }
+  });
+
+  it("surfaces billing guidance for Volcengine Coding Plan subscription failures before reply", async () => {
+    state.runEmbeddedAgentMock.mockRejectedValueOnce(
+      new Error(
+        'HTTP 400 Bad Request: {"error":{"code":"InvalidSubscription","message":"Your account does not have a valid CodingPlan subscription, or your subscription has expired."}}',
+      ),
+    );
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback(
+      createMinimalRunAgentTurnParams({
+        sessionCtx: {
+          Provider: "discord",
+          Surface: "discord",
+          ChatType: "direct",
+          MessageSid: "msg",
+        } as unknown as TemplateContext,
+      }),
+    );
+
+    expect(result.kind).toBe("final");
+    if (result.kind === "final") {
+      expect(result.payload.text).toBe("billing");
+      expect(result.payload.text).not.toBe(GENERIC_RUN_FAILURE_TEXT);
     }
   });
 

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -801,7 +801,7 @@ function buildExternalRunFailureReply(
   if (authProfileFailoverFailure) {
     return { text: authProfileFailoverFailure, isGenericRunnerFailure: false };
   }
-  const providerRequestError = classifyProviderRequestError(normalizedMessage);
+  const providerRequestError = classifyProviderRequestError(error ?? normalizedMessage);
   if (providerRequestError) {
     return {
       text: providerRequestError.userMessage,

--- a/src/auto-reply/reply/provider-request-error-classifier.test.ts
+++ b/src/auto-reply/reply/provider-request-error-classifier.test.ts
@@ -37,11 +37,15 @@ describe("provider request error classifier", () => {
     expect(classifyProviderRequestError(new Error("429: rate limit exceeded"))).toBeUndefined();
   });
 
-  it("classifies structured HTTP 429 errors even when the body is generic", () => {
+  it.each([
+    ["top-level status", { status: 429 }],
+    ["response status", { response: { status: "429" } }],
+    ["cause statusCode", { cause: { statusCode: 429 } }],
+  ])("classifies generic HTTP 429 errors from %s metadata", (_label, metadata) => {
     const error = new Error(
       "Something went wrong while processing your request. Please try again.",
     );
-    Object.assign(error, { status: 429 });
+    Object.assign(error, metadata);
 
     expect(classifyProviderRequestError(error)).toEqual({
       code: "provider_rate_limit_or_quota_error",

--- a/src/auto-reply/reply/provider-request-error-classifier.test.ts
+++ b/src/auto-reply/reply/provider-request-error-classifier.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   classifyProviderRequestError,
   PROVIDER_CONVERSATION_STATE_ERROR_USER_MESSAGE,
+  PROVIDER_RATE_LIMIT_OR_QUOTA_ERROR_USER_MESSAGE,
 } from "./provider-request-error-classifier.js";
 
 describe("provider request error classifier", () => {
@@ -32,7 +33,26 @@ describe("provider request error classifier", () => {
     });
   });
 
-  it("ignores unrelated provider errors", () => {
+  it("leaves explicit HTTP 429 rate-limit failures on the existing rate-limit path", () => {
     expect(classifyProviderRequestError(new Error("429: rate limit exceeded"))).toBeUndefined();
+  });
+
+  it("classifies structured HTTP 429 errors even when the body is generic", () => {
+    const error = new Error(
+      "Something went wrong while processing your request. Please try again.",
+    );
+    Object.assign(error, { status: 429 });
+
+    expect(classifyProviderRequestError(error)).toEqual({
+      code: "provider_rate_limit_or_quota_error",
+      userMessage: PROVIDER_RATE_LIMIT_OR_QUOTA_ERROR_USER_MESSAGE,
+      technicalMessage: "Something went wrong while processing your request. Please try again.",
+    });
+  });
+
+  it("ignores unrelated provider errors", () => {
+    expect(
+      classifyProviderRequestError(new Error("INVALID_ARGUMENT: some other failure")),
+    ).toBeUndefined();
   });
 });

--- a/src/auto-reply/reply/provider-request-error-classifier.ts
+++ b/src/auto-reply/reply/provider-request-error-classifier.ts
@@ -71,20 +71,30 @@ function isGenericProviderRuntimeErrorMessage(message: string): boolean {
 
 function hasHttp429Evidence(err: unknown, message: string): boolean {
   return (
-    readDirectHttp429Status(err) ||
+    readHttp429Status(err) ||
     /\b(?:http\s*)?429\b|["'](?:status|code)["']\s*:\s*429\b/iu.test(message)
   );
 }
 
-function readDirectHttp429Status(err: unknown): boolean {
-  if (!err || typeof err !== "object") {
+function readHttp429Status(err: unknown, seen = new Set<unknown>()): boolean {
+  if (!err || typeof err !== "object" || seen.has(err)) {
     return false;
   }
+  seen.add(err);
   const candidate =
     (err as { status?: unknown; statusCode?: unknown }).status ??
     (err as { statusCode?: unknown }).statusCode;
   if (typeof candidate === "number" && Number.isFinite(candidate)) {
-    return candidate === 429;
+    if (candidate === 429) {
+      return true;
+    }
+  } else if (typeof candidate === "string" && Number(candidate.trim()) === 429) {
+    return true;
   }
-  return typeof candidate === "string" && Number(candidate.trim()) === 429;
+  const nested = err as { cause?: unknown; error?: unknown; response?: unknown };
+  return (
+    readHttp429Status(nested.response, seen) ||
+    readHttp429Status(nested.error, seen) ||
+    readHttp429Status(nested.cause, seen)
+  );
 }

--- a/src/auto-reply/reply/provider-request-error-classifier.ts
+++ b/src/auto-reply/reply/provider-request-error-classifier.ts
@@ -3,7 +3,9 @@ import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/st
 import { formatErrorMessage } from "../../infra/errors.js";
 
 /** Provider request error classes that get a specialized user-facing reply. */
-export type ProviderRequestErrorCode = "provider_conversation_state_error";
+export type ProviderRequestErrorCode =
+  | "provider_conversation_state_error"
+  | "provider_rate_limit_or_quota_error";
 
 /** Structured provider error classification for reply failure handling. */
 export type ProviderRequestErrorClassification = {
@@ -16,11 +18,24 @@ export type ProviderRequestErrorClassification = {
 export const PROVIDER_CONVERSATION_STATE_ERROR_USER_MESSAGE =
   "⚠️ The model provider rejected the conversation state. Please try again, or use /new to start a fresh session.";
 
+export const PROVIDER_RATE_LIMIT_OR_QUOTA_ERROR_USER_MESSAGE =
+  "⚠️ The model provider returned HTTP 429 before replying. This can mean rate limiting, exhausted quota, or an account balance/billing issue. Check the selected provider/model, API key, and provider billing/quota dashboard, then try again.";
+
 /** Classifies provider request failures that are actionable for users. */
 export function classifyProviderRequestError(
   err: unknown,
 ): ProviderRequestErrorClassification | undefined {
   const technicalMessage = formatErrorMessage(err);
+  if (
+    hasHttp429Evidence(err, technicalMessage) &&
+    isGenericProviderRuntimeErrorMessage(technicalMessage)
+  ) {
+    return {
+      code: "provider_rate_limit_or_quota_error",
+      userMessage: PROVIDER_RATE_LIMIT_OR_QUOTA_ERROR_USER_MESSAGE,
+      technicalMessage,
+    };
+  }
   if (isProviderConversationStateErrorMessage(technicalMessage)) {
     return {
       code: "provider_conversation_state_error",
@@ -44,4 +59,32 @@ export function isProviderConversationStateErrorMessage(message: string): boolea
     lower.includes("incorrect role information") ||
     lower.includes("roles must alternate")
   );
+}
+
+function isGenericProviderRuntimeErrorMessage(message: string): boolean {
+  const lower = normalizeLowercaseStringOrEmpty(message);
+  return (
+    lower.includes("an error occurred while processing your request") ||
+    lower.includes("something went wrong while processing your request")
+  );
+}
+
+function hasHttp429Evidence(err: unknown, message: string): boolean {
+  return (
+    readDirectHttp429Status(err) ||
+    /\b(?:http\s*)?429\b|["'](?:status|code)["']\s*:\s*429\b/iu.test(message)
+  );
+}
+
+function readDirectHttp429Status(err: unknown): boolean {
+  if (!err || typeof err !== "object") {
+    return false;
+  }
+  const candidate =
+    (err as { status?: unknown; statusCode?: unknown }).status ??
+    (err as { statusCode?: unknown }).statusCode;
+  if (typeof candidate === "number" && Number.isFinite(candidate)) {
+    return candidate === 429;
+  }
+  return typeof candidate === "string" && Number(candidate.trim()) === 429;
 }

--- a/src/commands/agent-via-gateway.test.ts
+++ b/src/commands/agent-via-gateway.test.ts
@@ -180,6 +180,14 @@ async function waitForGatewayCall(expectedCalls = 1) {
   expect(callGateway).toHaveBeenCalledTimes(expectedCalls);
 }
 
+function createDeferredVoid() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((value) => {
+    resolve = value;
+  });
+  return { promise, resolve };
+}
+
 function mockMessages(mock: unknown): string[] {
   const calls = (mock as { mock?: { calls?: unknown[][] } }).mock?.calls ?? [];
   return calls.map(([message]) => String(message));
@@ -1112,6 +1120,7 @@ describe("agentCliCommand", () => {
   it("passes SIGTERM abort signals into local agent runs", async () => {
     await withTempStore(async () => {
       const signals = createSignalProcess();
+      const abortListenerAttached = createDeferredVoid();
       agentCommand.mockImplementationOnce(async (opts: { abortSignal?: AbortSignal }) => {
         expect(opts.abortSignal).toBeInstanceOf(AbortSignal);
         return await new Promise((_, reject) => {
@@ -1124,6 +1133,7 @@ describe("agentCliCommand", () => {
             },
             { once: true },
           );
+          abortListenerAttached.resolve();
         });
       });
 
@@ -1131,6 +1141,7 @@ describe("agentCliCommand", () => {
         process: signals.processLike,
       });
       await waitForAgentCommandCall();
+      await abortListenerAttached.promise;
       signals.emit("SIGTERM");
 
       await run;
@@ -1144,6 +1155,7 @@ describe("agentCliCommand", () => {
   it("exits for local runs that resolve after SIGTERM aborts them", async () => {
     await withTempStore(async () => {
       const signals = createSignalProcess();
+      const abortListenerAttached = createDeferredVoid();
       agentCommand.mockImplementationOnce(async (opts: { abortSignal?: AbortSignal }) => {
         return await new Promise((resolve) => {
           opts.abortSignal?.addEventListener(
@@ -1156,6 +1168,7 @@ describe("agentCliCommand", () => {
             },
             { once: true },
           );
+          abortListenerAttached.resolve();
         });
       });
 
@@ -1163,6 +1176,7 @@ describe("agentCliCommand", () => {
         process: signals.processLike,
       });
       await waitForAgentCommandCall();
+      await abortListenerAttached.promise;
       signals.emit("SIGTERM");
 
       await expect(run).resolves.toBeUndefined();


### PR DESCRIPTION
## Summary

- Surface actionable guidance when a provider returns HTTP 429 with only a generic runtime message before the agent replies.
- Classify Volcengine Ark Coding Plan `InvalidSubscription` responses as billing/subscription failures, including long JSON payloads.
- Keep explicit rate-limit errors on the existing rate-limit path.

## Official Docs / Live Shape

Volcengine's official Ark error-code page lists HTTP 400 `InvalidSubscription` as a Coding Plan subscription failure: https://www.volcengine.com/docs/82379/1282849

A temporary live Volcengine key reproduced that shape as HTTP 400 `InvalidSubscription`; no secret, account id, or request id is included here.

## Real behavior proof

Behavior addressed: provider quota/billing failures that previously collapsed into generic `Something went wrong` user copy now surface billing/quota guidance.

Real environment tested: local OpenClaw worktree plus one live Volcengine Ark request using a temporary key supplied for this verification.

Exact steps or command run after this patch:

```bash
node scripts/run-vitest.mjs src/agents/embedded-agent-helpers/failover-matches.test.ts
node scripts/run-vitest.mjs src/agents/embedded-agent-helpers.formatassistanterrortext.test.ts
node scripts/run-vitest.mjs src/auto-reply/reply/provider-request-error-classifier.test.ts
env -u OPENCLAW_PROFILE -u OPENCLAW_CONFIG_PROFILE node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-execution.test.ts
git diff --check
.agents/skills/autoreview/scripts/autoreview --mode local
```

Evidence after fix:

- `failover-matches.test.ts`: 21 tests passed.
- `embedded-agent-helpers.formatassistanterrortext.test.ts`: 80 tests passed.
- `provider-request-error-classifier.test.ts`: 8 tests passed.
- `agent-runner-execution.test.ts`: 185 tests passed.
- `git diff --check`: passed.
- Autoreview: clean, no accepted/actionable findings.

Observed result after fix: HTTP 400 Volcengine `InvalidSubscription` maps to billing guidance, and structured HTTP 429 generic provider failures map to quota/rate-limit/billing guidance instead of generic runner failure text.

What was not tested: a successful Volcengine completion after purchasing/renewing Coding Plan; that would validate provider subscription success, but is not required to prove this failure-classification fix.


## Agent Transcript

<details>
<summary>Redacted Codex session summary</summary>

- The user reported that provider billing or quota failures could be hidden behind generic `Something went wrong` copy, making the failure hard to diagnose.
- The investigation first checked existing formatter and lifecycle handling for provider auth, rate-limit, and billing failures.
- The user clarified that the reported case came from the Volcengine Seed channel.
- A one-time live verification with a temporary key showed Volcengine returned HTTP 400 `InvalidSubscription`, not the originally suspected HTTP 429 shape.
- Official Volcengine Ark documentation confirmed that `InvalidSubscription` means the Coding Plan subscription is missing or expired.
- The fix added billing classification for the Volcengine `InvalidSubscription` shape, including long payload handling.
- The fix also kept the generic HTTP 429 improvement narrow: it only applies when there is explicit HTTP 429 evidence plus generic provider runtime copy.
- Regression coverage was added at matcher, formatter, provider-request classifier, and auto-reply entry layers.
- Focused tests passed, `git diff --check` passed, and autoreview reported no actionable findings.
- A successful Volcengine completion after recharging was intentionally not required, because this PR fixes failure classification rather than provider subscription success.

</details>
