### PR TITLE
feat(extensions): add Liner as a bundled web search provider

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -398,6 +398,10 @@
   - changed-files:
       - any-glob-to-any-file:
           - "extensions/kilocode/**"
+"extensions: liner":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/liner/**"
 "extensions: lmstudio":
   - changed-files:
       - any-glob-to-any-file:

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1329,6 +1329,7 @@
                       "tools/gemini-search",
                       "tools/grok-search",
                       "tools/kimi-search",
+                      "tools/liner-search",
                       "tools/minimax-search",
                       "tools/ollama-search",
                       "tools/parallel-search",

--- a/docs/reference/secretref-credential-surface.md
+++ b/docs/reference/secretref-credential-surface.md
@@ -52,6 +52,7 @@ Scope intent:
 - `plugins.entries.minimax.config.webSearch.apiKey`
 - `plugins.entries.tavily.config.webSearch.apiKey`
 - `plugins.entries.parallel.config.webSearch.apiKey`
+- `plugins.entries.liner.config.webSearch.apiKey`
 - `plugins.entries.voice-call.config.realtime.providers.*.apiKey`
 - `plugins.entries.voice-call.config.streaming.providers.*.apiKey`
 - `plugins.entries.voice-call.config.tts.providers.*.apiKey`

--- a/docs/reference/secretref-user-supplied-credentials-matrix.json
+++ b/docs/reference/secretref-user-supplied-credentials-matrix.json
@@ -576,6 +576,13 @@
       "optIn": true
     },
     {
+      "id": "plugins.entries.liner.config.webSearch.apiKey",
+      "configFile": "openclaw.json",
+      "path": "plugins.entries.liner.config.webSearch.apiKey",
+      "secretShape": "secret_input",
+      "optIn": true
+    },
+    {
       "id": "plugins.entries.minimax.config.webSearch.apiKey",
       "configFile": "openclaw.json",
       "path": "plugins.entries.minimax.config.webSearch.apiKey",

--- a/docs/tools/liner-search.md
+++ b/docs/tools/liner-search.md
@@ -1,0 +1,95 @@
+---
+summary: "Liner Search -- source-grounded AI search results with per-result excerpts"
+read_when:
+  - You want to use Liner for web_search
+  - You need a LINER_API_KEY
+  - You want ranked web results with excerpts for AI agents
+title: "Liner search"
+---
+
+OpenClaw supports [Liner](https://liner.com/) as a `web_search` provider. Liner
+returns ranked, source-grounded web results with a per-result excerpt, tuned for
+AI agents.
+
+## Get an API key
+
+<Steps>
+  <Step title="Create an account">
+    Sign up at [platform.liner.com](https://platform.liner.com) and generate an
+    API key from your dashboard. New accounts include free credits to start.
+  </Step>
+  <Step title="Store the key">
+    Set `LINER_API_KEY` in the Gateway environment, or configure via:
+
+    ```bash
+    openclaw configure --section web
+    ```
+
+  </Step>
+</Steps>
+
+## Config
+
+```json5
+{
+  plugins: {
+    entries: {
+      liner: {
+        config: {
+          webSearch: {
+            apiKey: "sk_live_...", // optional if LINER_API_KEY is set
+            baseUrl: "https://platform.liner.com", // optional; OpenClaw appends /api/v1/search/web
+          },
+        },
+      },
+    },
+  },
+  tools: {
+    web: {
+      search: {
+        provider: "liner",
+      },
+    },
+  },
+}
+```
+
+**Environment alternative:** set `LINER_API_KEY` in the Gateway environment. For
+a gateway install, put it in `~/.openclaw/.env`.
+
+## Base URL override
+
+Set `plugins.entries.liner.config.webSearch.baseUrl` when Liner requests should
+go through a compatible proxy or alternate endpoint. OpenClaw normalizes bare
+hosts by prepending `https://` and appends `/api/v1/search/web` unless the path
+already ends there. The resolved endpoint is included in the search cache key,
+so results from different endpoints are not shared.
+
+## Tool parameters
+
+<ParamField path="query" type="string" required>
+The search query — a natural-language question or keyword phrase.
+</ParamField>
+
+<ParamField path="count" type="number">
+Results to return (1-50).
+</ParamField>
+
+## Notes
+
+- Each result includes a `title`, `url`, and a `description` excerpt; a
+  `published` date and `siteName` are included when available
+- OpenClaw always forwards a resolved result count to Liner as `max_results`.
+  The caller's `count` arg wins, then the top-level
+  `tools.web.search.maxResults` setting, otherwise OpenClaw's generic
+  `web_search` default (5). This keeps result volume consistent when switching
+  between providers
+- `requestId` from Liner is passed through when present
+- Results are cached for 15 minutes by default (configurable via
+  `cacheTtlMinutes`)
+
+## Related
+
+- [Web Search overview](/tools/web) -- all providers and auto-detection
+- [Exa search](/tools/exa-search) -- neural search with content extraction
+- [Perplexity Search](/tools/perplexity-search) -- structured results with domain filtering

--- a/docs/tools/web.md
+++ b/docs/tools/web.md
@@ -81,6 +81,9 @@ local while `web_search` and `x_search` can use xAI Responses under the hood.
   <Card title="MiniMax Search" icon="globe" href="/tools/minimax-search">
     Structured results via the MiniMax Token Plan search API.
   </Card>
+  <Card title="Liner" icon="magnifying-glass" href="/tools/liner-search">
+    Source-grounded AI search results with per-result excerpts (`LINER_API_KEY`).
+  </Card>
   <Card title="Ollama Web Search" icon="globe" href="/tools/ollama-search">
     Search via a signed-in local Ollama host or the hosted Ollama API.
   </Card>
@@ -112,6 +115,7 @@ local while `web_search` and `x_search` can use xAI Responses under the hood.
 | [Gemini](/tools/gemini-search)                   | AI-synthesized + citations                                     | --                                               | `GEMINI_API_KEY`                                                                        |
 | [Grok](/tools/grok-search)                       | AI-synthesized + citations                                     | --                                               | xAI OAuth, `XAI_API_KEY`, or `plugins.entries.xai.config.webSearch.apiKey`              |
 | [Kimi](/tools/kimi-search)                       | AI-synthesized + citations; fails on ungrounded chat fallbacks | --                                               | `KIMI_API_KEY` / `MOONSHOT_API_KEY`                                                     |
+| [Liner](/tools/liner-search)                     | Source-grounded results with excerpts                          | --                                               | `LINER_API_KEY`                                                                         |
 | [MiniMax Search](/tools/minimax-search)          | Structured snippets                                            | Region (`global` / `cn`)                         | `MINIMAX_CODE_PLAN_KEY` / `MINIMAX_CODING_API_KEY` / `MINIMAX_OAUTH_TOKEN`              |
 | [Ollama Web Search](/tools/ollama-search)        | Structured snippets                                            | --                                               | None for signed-in local hosts; `OLLAMA_API_KEY` for direct `https://ollama.com` search |
 | [Parallel](/tools/parallel-search)               | Dense excerpts ranked for LLM context                          | --                                               | `PARALLEL_API_KEY` (paid)                                                               |
@@ -193,13 +197,14 @@ API-backed providers first:
 8. **Exa** -- `EXA_API_KEY` or `plugins.entries.exa.config.webSearch.apiKey`; optional `plugins.entries.exa.config.webSearch.baseUrl` overrides the Exa endpoint (order 65)
 9. **Tavily** -- `TAVILY_API_KEY` or `plugins.entries.tavily.config.webSearch.apiKey` (order 70)
 10. **Parallel** -- paid Parallel Search API via `PARALLEL_API_KEY` or `plugins.entries.parallel.config.webSearch.apiKey`; optional `plugins.entries.parallel.config.webSearch.baseUrl` overrides the endpoint (order 75)
+11. **Liner** -- `LINER_API_KEY` or `plugins.entries.liner.config.webSearch.apiKey`; optional `plugins.entries.liner.config.webSearch.baseUrl` overrides the endpoint (order 80)
 
 Key-free fallbacks after that:
 
-11. **Parallel Search (Free)** -- the zero-config default: works with no account or API key via Parallel's free hosted [Search MCP](https://docs.parallel.ai/integrations/mcp/search-mcp) (order 76)
-12. **DuckDuckGo** -- key-free HTML fallback with no account or API key (order 100)
-13. **Ollama Web Search** -- key-free fallback via your configured local Ollama host when it is reachable and signed in with `ollama signin`; can reuse Ollama provider bearer auth when the host needs it, and can call direct `https://ollama.com` search when configured with `OLLAMA_API_KEY` (order 110)
-14. **SearXNG** -- `SEARXNG_BASE_URL` or `plugins.entries.searxng.config.webSearch.baseUrl` (order 200)
+12. **Parallel Search (Free)** -- the zero-config default: works with no account or API key via Parallel's free hosted [Search MCP](https://docs.parallel.ai/integrations/mcp/search-mcp) (order 76)
+13. **DuckDuckGo** -- key-free HTML fallback with no account or API key (order 100)
+14. **Ollama Web Search** -- key-free fallback via your configured local Ollama host when it is reachable and signed in with `ollama signin`; can reuse Ollama provider bearer auth when the host needs it, and can call direct `https://ollama.com` search when configured with `OLLAMA_API_KEY` (order 110)
+15. **SearXNG** -- `SEARXNG_BASE_URL` or `plugins.entries.searxng.config.webSearch.baseUrl` (order 200)
 
 When no API-backed provider is configured, OpenClaw defaults to **Parallel
 Search (Free)**, so `web_search` works without an API key.
@@ -213,7 +218,7 @@ to route them through the managed path.
   All provider key fields support SecretRef objects. Plugin-scoped SecretRefs
   under `plugins.entries.<plugin>.config.webSearch.apiKey` are resolved for the
   bundled API-backed web search providers, including Brave, Exa, Firecrawl,
-  Gemini, Grok, Kimi, MiniMax, Parallel, Perplexity, and Tavily,
+  Gemini, Grok, Kimi, Liner, MiniMax, Parallel, Perplexity, and Tavily,
   whether the provider is picked explicitly via `tools.web.search.provider` or
   selected through auto-detect. In auto-detect mode, OpenClaw resolves only the
   selected provider key -- non-selected SecretRefs stay inactive, so you can

--- a/extensions/liner/index.ts
+++ b/extensions/liner/index.ts
@@ -1,0 +1,13 @@
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+import { createLinerWebSearchProvider } from "./src/liner-web-search-provider.js";
+
+export default definePluginEntry({
+  id: "liner",
+  name: "Liner Plugin",
+  description: "Bundled Liner web search plugin",
+  register(api) {
+    // Liner Search v1 REST API (requires LINER_API_KEY). Issue a key at
+    // https://platform.liner.com — new accounts get free credits to start.
+    api.registerWebSearchProvider(createLinerWebSearchProvider());
+  },
+});

--- a/extensions/liner/liner.live.test.ts
+++ b/extensions/liner/liner.live.test.ts
@@ -1,0 +1,42 @@
+import { isLiveTestEnabled } from "openclaw/plugin-sdk/test-env";
+import { describe, expect, it } from "vitest";
+import { createLinerWebSearchProvider } from "./src/liner-web-search-provider.js";
+
+const LINER_API_KEY = process.env.LINER_API_KEY?.trim() ?? "";
+const describeLive = isLiveTestEnabled() && LINER_API_KEY.length > 0 ? describe : describe.skip;
+
+const LINER_LIVE_TIMEOUT_MS = 120_000;
+
+describeLive("liner plugin live", () => {
+  it(
+    "runs Liner web search through the provider tool",
+    async () => {
+      const provider = createLinerWebSearchProvider();
+      const tool = provider.createTool?.({
+        config: {},
+        searchConfig: { liner: { apiKey: LINER_API_KEY } },
+      });
+      if (!tool) {
+        throw new Error("Expected Liner provider tool");
+      }
+
+      const result = (await tool.execute({
+        query: "openclaw github repository",
+        count: 3,
+      })) as {
+        provider?: string;
+        count?: number;
+        results?: Array<{ url?: string; title?: string; description?: string }>;
+        requestId?: string;
+      };
+
+      expect(result.provider).toBe("liner");
+      expect(typeof result.count).toBe("number");
+      expect(Array.isArray(result.results)).toBe(true);
+      expect((result.results ?? []).length).toBeGreaterThan(0);
+      const first = result.results?.[0];
+      expect((first?.url ?? "").startsWith("http")).toBe(true);
+    },
+    LINER_LIVE_TIMEOUT_MS,
+  );
+});

--- a/extensions/liner/openclaw.plugin.json
+++ b/extensions/liner/openclaw.plugin.json
@@ -1,0 +1,50 @@
+{
+  "id": "liner",
+  "activation": {
+    "onStartup": false
+  },
+  "setup": {
+    "providers": [
+      {
+        "id": "liner",
+        "envVars": ["LINER_API_KEY"]
+      }
+    ]
+  },
+  "uiHints": {
+    "webSearch.apiKey": {
+      "label": "Liner API Key",
+      "help": "Liner Search API key from https://platform.liner.com (fallback: LINER_API_KEY env var).",
+      "sensitive": true,
+      "placeholder": "sk_live_..."
+    },
+    "webSearch.baseUrl": {
+      "label": "Liner Search Base URL",
+      "help": "Optional Liner API base URL override. OpenClaw appends /api/v1/search/web when the URL does not already end there."
+    }
+  },
+  "contracts": {
+    "webSearchProviders": ["liner"]
+  },
+  "configContracts": {
+    "compatibilityRuntimePaths": ["tools.web.search.apiKey"]
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "webSearch": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "apiKey": {
+            "type": ["string", "object"]
+          },
+          "baseUrl": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/extensions/liner/package.json
+++ b/extensions/liner/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@openclaw/liner-plugin",
+  "version": "2026.6.8",
+  "private": true,
+  "description": "OpenClaw Liner web search plugin",
+  "type": "module",
+  "devDependencies": {
+    "@openclaw/plugin-sdk": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/liner/src/liner-web-search-provider.runtime.ts
+++ b/extensions/liner/src/liner-web-search-provider.runtime.ts
@@ -1,0 +1,287 @@
+import { createRequire } from "node:module";
+import { readPluginPackageVersion } from "openclaw/plugin-sdk/extension-shared";
+import {
+  buildSearchCacheKey,
+  DEFAULT_SEARCH_COUNT,
+  mergeScopedSearchConfig,
+  readCachedSearchPayload,
+  readConfiguredSecretString,
+  readNumberParam,
+  readProviderEnvValue,
+  readStringParam,
+  resolveProviderWebSearchPluginConfig,
+  resolveSearchCacheTtlMs,
+  resolveSearchTimeoutSeconds,
+  resolveSiteName,
+  type SearchConfigRecord,
+  withTrustedWebSearchEndpoint,
+  wrapWebContent,
+  writeCachedSearchPayload,
+} from "openclaw/plugin-sdk/provider-web-search";
+import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+
+const LINER_BASE_URL = "https://platform.liner.com";
+const LINER_SEARCH_PATHNAME = "/api/v1/search/web";
+// Liner Search accepts max_results 1-50.
+const LINER_MAX_SEARCH_COUNT = 50;
+
+const require = createRequire(import.meta.url);
+const PLUGIN_VERSION = readPluginPackageVersion({ require });
+const USER_AGENT = `openclaw-liner/${PLUGIN_VERSION} (${process.platform})`;
+
+type LinerConfig = {
+  apiKey?: string;
+  baseUrl?: string;
+};
+
+type LinerSearchResult = {
+  title?: unknown;
+  url?: unknown;
+  description?: unknown;
+  date?: unknown;
+};
+
+export type LinerSearchResponse = {
+  requestId?: unknown;
+  results?: unknown;
+  totalCount?: unknown;
+};
+
+function resolveLinerConfig(searchConfig?: SearchConfigRecord): LinerConfig {
+  const liner = searchConfig?.liner;
+  return liner && typeof liner === "object" && !Array.isArray(liner) ? (liner as LinerConfig) : {};
+}
+
+function resolveLinerApiKey(liner?: LinerConfig): string | undefined {
+  return (
+    readConfiguredSecretString(liner?.apiKey, "tools.web.search.liner.apiKey") ??
+    readProviderEnvValue(["LINER_API_KEY"])
+  );
+}
+
+function invalidBaseUrlPayload(value: string) {
+  return {
+    error: "invalid_base_url",
+    message: `plugins.entries.liner.config.webSearch.baseUrl must be a valid http(s) URL. Got: ${value}`,
+    docs: "https://docs.openclaw.ai/tools/liner-search",
+  };
+}
+
+function resolveLinerSearchEndpoint(
+  liner?: LinerConfig,
+): { endpoint: string } | { error: string; message: string; docs: string } {
+  const configured = normalizeOptionalString(liner?.baseUrl);
+  if (!configured) {
+    return { endpoint: `${LINER_BASE_URL}${LINER_SEARCH_PATHNAME}` };
+  }
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(configured) && !/^https?:\/\//i.test(configured)) {
+    return invalidBaseUrlPayload(configured);
+  }
+  const candidate = /^https?:\/\//i.test(configured) ? configured : `https://${configured}`;
+  let parsed: URL;
+  try {
+    parsed = new URL(candidate);
+  } catch {
+    return invalidBaseUrlPayload(configured);
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return invalidBaseUrlPayload(configured);
+  }
+  const pathname = parsed.pathname.replace(/\/+$/, "");
+  parsed.pathname = pathname.endsWith(LINER_SEARCH_PATHNAME)
+    ? pathname
+    : `${pathname === "" ? "" : pathname}${LINER_SEARCH_PATHNAME}`;
+  parsed.hash = "";
+  return { endpoint: parsed.toString() };
+}
+
+function missingLinerKeyPayload() {
+  return {
+    error: "missing_liner_api_key",
+    message:
+      "web_search (liner) needs a Liner API key. Set LINER_API_KEY in the Gateway environment, or configure plugins.entries.liner.config.webSearch.apiKey.",
+    docs: "https://docs.openclaw.ai/tools/liner-search",
+  };
+}
+
+function invalidQueryPayload() {
+  return {
+    error: "invalid_query",
+    message: "query must be a non-empty string.",
+    docs: "https://docs.openclaw.ai/tools/liner-search",
+  };
+}
+
+export function resolveLinerSearchCount(value: number): number {
+  return Math.max(1, Math.min(LINER_MAX_SEARCH_COUNT, Math.floor(value)));
+}
+
+export function normalizeLinerResults(payload: unknown): LinerSearchResult[] {
+  if (!payload || typeof payload !== "object") {
+    return [];
+  }
+  const results = (payload as LinerSearchResponse).results;
+  if (!Array.isArray(results)) {
+    return [];
+  }
+  return results.filter((entry): entry is LinerSearchResult =>
+    Boolean(entry && typeof entry === "object" && !Array.isArray(entry)),
+  );
+}
+
+/** Maps a Liner `/api/v1/search/web` response into wrapped `web_search` results. */
+export function mapLinerResults(response: LinerSearchResponse): Record<string, unknown>[] {
+  return normalizeLinerResults(response)
+    .filter((entry) => typeof entry.url === "string" && entry.url.length > 0)
+    .map((entry) => {
+      const title = typeof entry.title === "string" ? entry.title : "";
+      const url = entry.url as string;
+      const description = typeof entry.description === "string" ? entry.description : "";
+      const published = typeof entry.date === "string" && entry.date ? entry.date : undefined;
+      return Object.assign(
+        {
+          title: title ? wrapWebContent(title, "web_search") : "",
+          url,
+          description: description ? wrapWebContent(description, "web_search") : "",
+          siteName: resolveSiteName(url) || undefined,
+        },
+        published ? { published } : {},
+      );
+    });
+}
+
+export function buildLinerCacheKey(params: {
+  endpoint: string;
+  query: string;
+  count: number;
+}): string {
+  return buildSearchCacheKey(["liner", params.endpoint, params.query, params.count]);
+}
+
+async function runLinerSearch(params: {
+  apiKey: string;
+  endpoint: string;
+  query: string;
+  maxResults: number;
+  timeoutSeconds: number;
+}): Promise<LinerSearchResponse> {
+  const body: Record<string, unknown> = {
+    query: params.query,
+    max_results: params.maxResults,
+  };
+
+  return withTrustedWebSearchEndpoint(
+    {
+      url: params.endpoint,
+      timeoutSeconds: params.timeoutSeconds,
+      init: {
+        method: "POST",
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+          "X-API-KEY": params.apiKey,
+          "User-Agent": USER_AGENT,
+        },
+        body: JSON.stringify(body),
+      },
+    },
+    async (res) => {
+      if (!res.ok) {
+        const detail = await res.text().catch(() => "");
+        throw new Error(`Liner API error (${res.status}): ${detail || res.statusText}`);
+      }
+      try {
+        return (await res.json()) as LinerSearchResponse;
+      } catch (cause) {
+        throw new Error("Liner API returned malformed JSON", { cause });
+      }
+    },
+  );
+}
+
+export async function executeLinerWebSearchProviderTool(
+  ctx: { config?: Record<string, unknown>; searchConfig?: SearchConfigRecord },
+  args: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  const searchConfig = mergeScopedSearchConfig(
+    ctx.searchConfig,
+    "liner",
+    resolveProviderWebSearchPluginConfig(ctx.config, "liner"),
+  ) as SearchConfigRecord | undefined;
+  const linerConfig = resolveLinerConfig(searchConfig);
+  const apiKey = resolveLinerApiKey(linerConfig);
+  if (!apiKey) {
+    return missingLinerKeyPayload();
+  }
+  const endpointResult = resolveLinerSearchEndpoint(linerConfig);
+  if ("error" in endpointResult) {
+    return endpointResult;
+  }
+  const endpoint = endpointResult.endpoint;
+
+  // Accept both the generic `query` arg (operator CLI / generic web_search) and
+  // a `q` alias; Liner's tool schema declares `query`.
+  const query =
+    normalizeOptionalString(readStringParam(args, "query")) ??
+    normalizeOptionalString(readStringParam(args, "q"));
+  if (!query) {
+    return invalidQueryPayload();
+  }
+
+  const requestedCount =
+    readNumberParam(args, "count", { integer: true }) ??
+    (typeof searchConfig?.maxResults === "number" ? searchConfig.maxResults : undefined);
+  // Always forward an explicit max_results so Liner matches OpenClaw's generic
+  // web_search default of 5 rather than its own server-side default.
+  const count = resolveLinerSearchCount(requestedCount ?? DEFAULT_SEARCH_COUNT);
+
+  const cacheKey = buildLinerCacheKey({ endpoint, query, count });
+  const cached = readCachedSearchPayload(cacheKey);
+  if (cached) {
+    return cached;
+  }
+
+  const start = Date.now();
+  const response = await runLinerSearch({
+    apiKey,
+    endpoint,
+    query,
+    maxResults: count,
+    timeoutSeconds: resolveSearchTimeoutSeconds(searchConfig),
+  });
+  const results = mapLinerResults(response);
+
+  const payload: Record<string, unknown> = {
+    query,
+    provider: "liner",
+    count: results.length,
+    tookMs: Date.now() - start,
+    externalContent: {
+      untrusted: true,
+      source: "web_search",
+      provider: "liner",
+      wrapped: true,
+    },
+    results,
+  };
+  if (typeof response.requestId === "string") {
+    payload.requestId = response.requestId;
+  }
+
+  writeCachedSearchPayload(cacheKey, payload, resolveSearchCacheTtlMs(searchConfig));
+  return payload;
+}
+
+export const testing = {
+  buildLinerCacheKey,
+  mapLinerResults,
+  missingLinerKeyPayload,
+  normalizeLinerResults,
+  resolveLinerApiKey,
+  resolveLinerConfig,
+  resolveLinerSearchCount,
+  resolveLinerSearchEndpoint,
+  USER_AGENT,
+} as const;
+
+export { testing as __testing };

--- a/extensions/liner/src/liner-web-search-provider.shared.ts
+++ b/extensions/liner/src/liner-web-search-provider.shared.ts
@@ -1,0 +1,26 @@
+import { createWebSearchProviderContractFields } from "openclaw/plugin-sdk/provider-web-search-contract";
+
+const LINER_CREDENTIAL_PATH = "plugins.entries.liner.config.webSearch.apiKey";
+const LINER_ONBOARDING_SCOPES: Array<"text-inference"> = ["text-inference"];
+
+export function createLinerWebSearchProviderBase() {
+  return {
+    id: "liner",
+    label: "Liner Search",
+    hint: "Source-grounded AI search results with per-result excerpts",
+    onboardingScopes: [...LINER_ONBOARDING_SCOPES],
+    credentialLabel: "Liner API key",
+    envVars: ["LINER_API_KEY"],
+    placeholder: "sk_live_...",
+    signupUrl: "https://platform.liner.com",
+    docsUrl: "https://docs.openclaw.ai/tools/liner-search",
+    autoDetectOrder: 80,
+    credentialPath: LINER_CREDENTIAL_PATH,
+    ...createWebSearchProviderContractFields({
+      credentialPath: LINER_CREDENTIAL_PATH,
+      searchCredential: { type: "scoped", scopeId: "liner" },
+      configuredCredential: { pluginId: "liner" },
+      selectionPluginId: "liner",
+    }),
+  };
+}

--- a/extensions/liner/src/liner-web-search-provider.test.ts
+++ b/extensions/liner/src/liner-web-search-provider.test.ts
@@ -1,0 +1,296 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type EndpointCall = {
+  url: string;
+  timeoutSeconds: number;
+  init: RequestInit;
+};
+
+const endpointMockState = vi.hoisted(() => ({
+  calls: [] as EndpointCall[],
+  responses: [] as Response[],
+}));
+
+vi.mock("openclaw/plugin-sdk/provider-web-search", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/provider-web-search")>();
+  const runEndpoint = async (
+    params: EndpointCall,
+    run: (response: Response) => Promise<unknown>,
+  ) => {
+    endpointMockState.calls.push(params);
+    const response = endpointMockState.responses.shift();
+    if (!response) {
+      throw new Error("Missing mocked Liner response.");
+    }
+    return await run(response);
+  };
+  return {
+    ...actual,
+    withTrustedWebSearchEndpoint: vi.fn(runEndpoint),
+  };
+});
+
+function readMockedBody(call: EndpointCall | undefined): unknown {
+  if (!call || typeof call.init.body !== "string") {
+    throw new Error("Expected mocked Liner request to carry a JSON string body.");
+  }
+  return JSON.parse(call.init.body);
+}
+
+import { testing } from "../test-api.js";
+import { createLinerWebSearchProvider as createContractLinerWebSearchProvider } from "../web-search-contract-api.js";
+import { createLinerWebSearchProvider } from "./liner-web-search-provider.js";
+
+describe("liner web search provider", () => {
+  beforeEach(() => {
+    endpointMockState.calls = [];
+    endpointMockState.responses = [];
+  });
+
+  it("exposes the expected metadata and selection wiring", () => {
+    const provider = createLinerWebSearchProvider();
+    if (!provider.applySelectionConfig) {
+      throw new Error("Expected applySelectionConfig to be defined");
+    }
+    const applied = provider.applySelectionConfig({});
+
+    expect(provider.id).toBe("liner");
+    expect(provider.onboardingScopes).toEqual(["text-inference"]);
+    expect(provider.credentialPath).toBe("plugins.entries.liner.config.webSearch.apiKey");
+    const pluginEntry = applied.plugins?.entries?.liner;
+    if (!pluginEntry) {
+      throw new Error("expected Liner plugin entry");
+    }
+    expect(pluginEntry.enabled).toBe(true);
+  });
+
+  it("keeps the lightweight contract surface aligned with provider metadata", () => {
+    const provider = createLinerWebSearchProvider();
+    const contractProvider = createContractLinerWebSearchProvider();
+    if (!contractProvider.applySelectionConfig) {
+      throw new Error("Expected contract applySelectionConfig to be defined");
+    }
+    const applied = contractProvider.applySelectionConfig({});
+
+    expect({
+      id: contractProvider.id,
+      label: contractProvider.label,
+      hint: contractProvider.hint,
+      onboardingScopes: contractProvider.onboardingScopes,
+      credentialLabel: contractProvider.credentialLabel,
+      envVars: contractProvider.envVars,
+      placeholder: contractProvider.placeholder,
+      signupUrl: contractProvider.signupUrl,
+      docsUrl: contractProvider.docsUrl,
+      autoDetectOrder: contractProvider.autoDetectOrder,
+      credentialPath: contractProvider.credentialPath,
+    }).toEqual({
+      id: provider.id,
+      label: provider.label,
+      hint: provider.hint,
+      onboardingScopes: provider.onboardingScopes,
+      credentialLabel: provider.credentialLabel,
+      envVars: provider.envVars,
+      placeholder: provider.placeholder,
+      signupUrl: provider.signupUrl,
+      docsUrl: provider.docsUrl,
+      autoDetectOrder: provider.autoDetectOrder,
+      credentialPath: provider.credentialPath,
+    });
+    expect(contractProvider.createTool({ config: {}, searchConfig: {} })).toBeNull();
+    const pluginEntry = applied.plugins?.entries?.liner;
+    if (!pluginEntry) {
+      throw new Error("expected contract Liner plugin entry");
+    }
+    expect(pluginEntry.enabled).toBe(true);
+  });
+
+  it("prefers scoped configured api keys over environment fallbacks", () => {
+    expect(testing.resolveLinerApiKey({ apiKey: "sk_live_secret" })).toBe("sk_live_secret");
+  });
+
+  it("resolves Liner search base URL overrides", () => {
+    expect(testing.resolveLinerSearchEndpoint()).toEqual({
+      endpoint: "https://platform.liner.com/api/v1/search/web",
+    });
+    expect(
+      testing.resolveLinerSearchEndpoint({ baseUrl: "https://proxy.example/liner" }),
+    ).toEqual({
+      endpoint: "https://proxy.example/liner/api/v1/search/web",
+    });
+    expect(
+      testing.resolveLinerSearchEndpoint({ baseUrl: "proxy.example/liner/api/v1/search/web/" }),
+    ).toEqual({
+      endpoint: "https://proxy.example/liner/api/v1/search/web",
+    });
+    expect(testing.resolveLinerSearchEndpoint({ baseUrl: "ftp://proxy.example/liner" })).toEqual({
+      docs: "https://docs.openclaw.ai/tools/liner-search",
+      error: "invalid_base_url",
+      message:
+        "plugins.entries.liner.config.webSearch.baseUrl must be a valid http(s) URL. Got: ftp://proxy.example/liner",
+    });
+  });
+
+  it("partitions Liner cache keys by resolved endpoint, query, and count", () => {
+    const base = { query: "openclaw github", count: 5 };
+    expect(
+      testing.buildLinerCacheKey({ ...base, endpoint: "https://platform.liner.com/api/v1/search/web" }),
+    ).not.toBe(testing.buildLinerCacheKey({ ...base, endpoint: "https://proxy.example/api/v1/search/web" }));
+    const endpoint = "https://platform.liner.com/api/v1/search/web";
+    expect(testing.buildLinerCacheKey({ endpoint, query: "a", count: 5 })).not.toBe(
+      testing.buildLinerCacheKey({ endpoint, query: "b", count: 5 }),
+    );
+    expect(testing.buildLinerCacheKey({ endpoint, query: "a", count: 5 })).not.toBe(
+      testing.buildLinerCacheKey({ endpoint, query: "a", count: 10 }),
+    );
+  });
+
+  it("normalizes the Liner response shape", () => {
+    expect(
+      testing.normalizeLinerResults({
+        results: [
+          { url: "https://example.com/a", title: "Sample", description: "excerpt", date: "2026-04-01" },
+          "not-an-object",
+        ],
+      }),
+    ).toEqual([
+      { url: "https://example.com/a", title: "Sample", description: "excerpt", date: "2026-04-01" },
+    ]);
+    expect(testing.normalizeLinerResults({})).toEqual([]);
+    expect(testing.normalizeLinerResults(null)).toEqual([]);
+  });
+
+  it("maps Liner results into wrapped web_search entries (description -> description, date -> published)", () => {
+    const mapped = testing.mapLinerResults({
+      results: [
+        {
+          title: "Liner",
+          url: "https://liner.com/",
+          description: "AI search assistant",
+          date: "2025-09-20",
+        },
+        { title: "No URL", description: "dropped" },
+      ],
+    });
+    expect(mapped).toHaveLength(1);
+    expect(mapped[0]).toMatchObject({
+      url: "https://liner.com/",
+      published: "2025-09-20",
+    });
+    expect(String(mapped[0].title)).toContain("Liner");
+    expect(String(mapped[0].description)).toContain("AI search assistant");
+  });
+
+  it("clamps Liner result counts to the documented 1-50 range", () => {
+    expect(testing.resolveLinerSearchCount(5)).toBe(5);
+    expect(testing.resolveLinerSearchCount(120)).toBe(50);
+    expect(testing.resolveLinerSearchCount(0)).toBe(1);
+  });
+
+  it("returns a stable missing-key payload that points at the real config path", () => {
+    expect(testing.missingLinerKeyPayload()).toEqual({
+      error: "missing_liner_api_key",
+      message:
+        "web_search (liner) needs a Liner API key. Set LINER_API_KEY in the Gateway environment, or configure plugins.entries.liner.config.webSearch.apiKey.",
+      docs: "https://docs.openclaw.ai/tools/liner-search",
+    });
+  });
+
+  it("identifies the plugin via a versioned User-Agent header", () => {
+    expect(testing.USER_AGENT).toMatch(/^openclaw-liner\/\d+\.\d+\.\d+/);
+  });
+
+  it("returns an error payload when query is missing or empty", async () => {
+    const provider = createLinerWebSearchProvider();
+    const tool = provider.createTool({
+      config: {},
+      searchConfig: { liner: { apiKey: "sk_live_secret" } },
+    });
+    if (!tool) {
+      throw new Error("Expected tool definition");
+    }
+    expect(await tool.execute({})).toMatchObject({ error: "invalid_query" });
+    expect(await tool.execute({ query: "   " })).toMatchObject({ error: "invalid_query" });
+    expect(endpointMockState.calls).toHaveLength(0);
+  });
+
+  it("sends query + max_results with the API key header and maps the response", async () => {
+    endpointMockState.responses.push(
+      new Response(
+        JSON.stringify({
+          requestId: "req-1",
+          totalCount: 1,
+          results: [
+            { title: "A", url: "https://example.com/a", description: "alpha", date: null },
+          ],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    const provider = createLinerWebSearchProvider();
+    const tool = provider.createTool({
+      config: {},
+      searchConfig: { liner: { apiKey: "sk_live_secret" }, maxResults: 3, timeoutSeconds: 5 },
+    });
+    if (!tool) {
+      throw new Error("Expected tool definition");
+    }
+    const result = (await tool.execute({ query: "liner ai search" })) as Record<string, unknown>;
+
+    expect(endpointMockState.calls).toHaveLength(1);
+    const [call] = endpointMockState.calls;
+    expect(call.url).toBe("https://platform.liner.com/api/v1/search/web");
+    expect(call.timeoutSeconds).toBe(5);
+    expect(readMockedBody(call)).toEqual({ query: "liner ai search", max_results: 3 });
+    const headers = (call.init.headers ?? {}) as Record<string, string>;
+    expect(headers["X-API-KEY"]).toBe("sk_live_secret");
+    expect(headers["User-Agent"]).toMatch(/^openclaw-liner\//);
+    expect(result).toMatchObject({ provider: "liner", requestId: "req-1", count: 1 });
+  });
+
+  it("always sends max_results matching the OpenClaw web_search default when no count is provided", async () => {
+    endpointMockState.responses.push(
+      new Response(JSON.stringify({ requestId: "x", totalCount: 0, results: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    const provider = createLinerWebSearchProvider();
+    const tool = provider.createTool({
+      config: {},
+      searchConfig: { liner: { apiKey: "sk_live_secret" } },
+    });
+    if (!tool) {
+      throw new Error("Expected tool definition");
+    }
+    await tool.execute({ query: "openclaw" });
+    const body = readMockedBody(endpointMockState.calls[0]) as { max_results?: number };
+    expect(body.max_results).toBe(5);
+  });
+
+  it("serves identical queries from the cache without a second HTTP call", async () => {
+    const query = `liner-cache-${Date.now()}-${Math.random()}`;
+    endpointMockState.responses.push(
+      new Response(
+        JSON.stringify({
+          requestId: "first",
+          totalCount: 1,
+          results: [{ title: "A", url: "https://example.com/a", description: "alpha" }],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    const provider = createLinerWebSearchProvider();
+    const tool = provider.createTool({
+      config: {},
+      searchConfig: { liner: { apiKey: "sk_live_secret" } },
+    });
+    if (!tool) {
+      throw new Error("Expected tool definition");
+    }
+    const first = (await tool.execute({ query })) as { requestId?: string };
+    const second = (await tool.execute({ query })) as { requestId?: string };
+    expect(endpointMockState.calls).toHaveLength(1);
+    expect(second.requestId).toBe(first.requestId);
+  });
+});

--- a/extensions/liner/src/liner-web-search-provider.ts
+++ b/extensions/liner/src/liner-web-search-provider.ts
@@ -1,0 +1,50 @@
+import type { WebSearchProviderPlugin } from "openclaw/plugin-sdk/provider-web-search-contract";
+import { createLinerWebSearchProviderBase } from "./liner-web-search-provider.shared.js";
+
+const LINER_MAX_SEARCH_COUNT = 50;
+
+type LinerWebSearchRuntime = typeof import("./liner-web-search-provider.runtime.js");
+
+let linerWebSearchRuntimePromise: Promise<LinerWebSearchRuntime> | undefined;
+
+function loadLinerWebSearchRuntime(): Promise<LinerWebSearchRuntime> {
+  linerWebSearchRuntimePromise ??= import("./liner-web-search-provider.runtime.js");
+  return linerWebSearchRuntimePromise;
+}
+
+// Liner Search exposes a single-query `web_search` shape: a keyword/question
+// `query` plus an optional result `count`. This matches OpenClaw's generic
+// `web_search` contract directly (no provider-specific richer schema needed).
+export const LinerSearchSchema = {
+  type: "object",
+  properties: {
+    query: {
+      type: "string",
+      description: "The search query — a question or keyword phrase.",
+    },
+    count: {
+      type: "integer",
+      description: "Number of results to return (1-50).",
+      minimum: 1,
+      maximum: LINER_MAX_SEARCH_COUNT,
+    },
+  },
+  required: ["query"],
+  additionalProperties: false,
+} satisfies Record<string, unknown>;
+
+export function createLinerWebSearchProvider(): WebSearchProviderPlugin {
+  return {
+    ...createLinerWebSearchProviderBase(),
+    createTool: (ctx) => ({
+      description:
+        "Search the web with Liner. Returns ranked, source-grounded results optimized for AI agents, " +
+        "each with a title, URL, and excerpt. Pass a natural-language question or keyword phrase as `query`.",
+      parameters: LinerSearchSchema,
+      execute: async (args) => {
+        const { executeLinerWebSearchProviderTool } = await loadLinerWebSearchRuntime();
+        return await executeLinerWebSearchProviderTool(ctx, args);
+      },
+    }),
+  };
+}

--- a/extensions/liner/test-api.ts
+++ b/extensions/liner/test-api.ts
@@ -1,0 +1,1 @@
+export { testing, testing as __testing } from "./src/liner-web-search-provider.runtime.js";

--- a/extensions/liner/tsconfig.json
+++ b/extensions/liner/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../tsconfig.package-boundary.base.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["./*.ts", "./src/**/*.ts"],
+  "exclude": [
+    "./**/*.test.ts",
+    "./dist/**",
+    "./node_modules/**",
+    "./src/test-support/**",
+    "./src/**/*test-helpers.ts",
+    "./src/**/*test-harness.ts",
+    "./src/**/*test-support.ts"
+  ]
+}

--- a/extensions/liner/web-search-contract-api.ts
+++ b/extensions/liner/web-search-contract-api.ts
@@ -1,0 +1,9 @@
+import type { WebSearchProviderPlugin } from "openclaw/plugin-sdk/provider-web-search-contract";
+import { createLinerWebSearchProviderBase } from "./src/liner-web-search-provider.shared.js";
+
+export function createLinerWebSearchProvider(): WebSearchProviderPlugin {
+  return {
+    ...createLinerWebSearchProviderBase(),
+    createTool: () => null,
+  };
+}

--- a/extensions/liner/web-search-provider.ts
+++ b/extensions/liner/web-search-provider.ts
@@ -1,0 +1,1 @@
+export { createLinerWebSearchProvider } from "./src/liner-web-search-provider.js";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -917,6 +917,12 @@ importers:
         specifier: 2026.5.28
         version: 2026.5.28
 
+  extensions/liner:
+    devDependencies:
+      '@openclaw/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../packages/plugin-sdk
+
   extensions/litellm:
     devDependencies:
       '@openclaw/plugin-sdk':

--- a/src/commands/doctor/shared/legacy-web-search-migrate.ts
+++ b/src/commands/doctor/shared/legacy-web-search-migrate.ts
@@ -18,6 +18,7 @@ const BUNDLED_LEGACY_WEB_SEARCH_OWNERS = new Map<string, string>([
   ["gemini", "google"],
   ["grok", "xai"],
   ["kimi", "moonshot"],
+  ["liner", "liner"],
   ["minimax", "minimax"],
   ["ollama", "ollama"],
   ["parallel", "parallel"],
@@ -27,9 +28,11 @@ const BUNDLED_LEGACY_WEB_SEARCH_OWNERS = new Map<string, string>([
   ["tavily", "tavily"],
 ]);
 
-// Tavily and Parallel (paid + free) only ever used the plugin-owned config path,
-// so there is no legacy `tools.web.search.<id>.*` shape to migrate for them.
+// Tavily, Parallel (paid + free), and Liner only ever used the plugin-owned
+// config path, so there is no legacy `tools.web.search.<id>.*` shape to migrate
+// for them.
 const NON_MIGRATED_LEGACY_WEB_SEARCH_PROVIDER_IDS = new Set([
+  "liner",
   "parallel",
   "parallel-free",
   "tavily",

--- a/src/plugin-sdk/test-helpers/plugin-registration-contract-cases.ts
+++ b/src/plugin-sdk/test-helpers/plugin-registration-contract-cases.ts
@@ -185,6 +185,10 @@ export const pluginRegistrationContractCases = {
     requireGenerateImage: true,
     requireGenerateVideo: true,
   },
+  liner: {
+    pluginId: "liner",
+    webSearchProviderIds: ["liner"],
+  },
   parallel: {
     pluginId: "parallel",
     webSearchProviderIds: ["parallel", "parallel-free"],

--- a/src/plugins/contracts/plugin-registration.liner.contract.test.ts
+++ b/src/plugins/contracts/plugin-registration.liner.contract.test.ts
@@ -1,0 +1,4 @@
+import { pluginRegistrationContractCases } from "openclaw/plugin-sdk/plugin-test-contracts";
+import { describePluginRegistrationContract } from "openclaw/plugin-sdk/plugin-test-contracts";
+
+describePluginRegistrationContract(pluginRegistrationContractCases.liner);

--- a/src/plugins/contracts/providers.contract.test.ts
+++ b/src/plugins/contracts/providers.contract.test.ts
@@ -21,6 +21,7 @@ for (const providerId of [
   "exa",
   "firecrawl",
   "google",
+  "liner",
   "minimax",
   "moonshot",
   "parallel",

--- a/src/plugins/web-search-providers.runtime.test.ts
+++ b/src/plugins/web-search-providers.runtime.test.ts
@@ -22,6 +22,7 @@ const BUNDLED_WEB_SEARCH_PROVIDERS = [
   { pluginId: "exa", id: "exa", order: 65 },
   { pluginId: "tavily", id: "tavily", order: 70 },
   { pluginId: "parallel", id: "parallel", order: 75 },
+  { pluginId: "liner", id: "liner", order: 80 },
   { pluginId: "duckduckgo", id: "duckduckgo", order: 100 },
 ] as const;
 
@@ -52,6 +53,7 @@ const EXPECTED_BUNDLED_RUNTIME_WEB_SEARCH_PROVIDER_KEYS = [
   "google:gemini",
   "xai:grok",
   "moonshot:kimi",
+  "liner:liner",
   "parallel:parallel",
   "perplexity:perplexity",
   "tavily:tavily",

--- a/test/vitest/vitest.extension-misc-paths.mjs
+++ b/test/vitest/vitest.extension-misc-paths.mjs
@@ -9,6 +9,7 @@ export const miscExtensionTestRoots = [
   "extensions/firecrawl",
   "extensions/fireworks",
   "extensions/kilocode",
+  "extensions/liner",
   "extensions/litellm",
   "extensions/llm-task",
   "extensions/lobster",


### PR DESCRIPTION
## What

Adds **Liner Search** as a bundled web search provider, mirroring the existing
`exa` / `parallel` providers. It exposes [Liner](https://liner.com/)'s
`POST /api/v1/search/web` endpoint through OpenClaw's generic `web_search`
contract.

Liner is an AI search product (web + academic) for professionals and agents.
This lets OpenClaw agents use Liner as a ranked, source-grounded search option,
with a per-result excerpt for each source.

Purely additive — no existing provider is affected.

## Authentication & config

API-key, exactly like brave/exa/parallel:

- `LINER_API_KEY` env var, or `plugins.entries.liner.config.webSearch.apiKey`
- optional `plugins.entries.liner.config.webSearch.baseUrl` override
  (default `https://platform.liner.com`; OpenClaw appends `/api/v1/search/web`)
- auto-detect order **80**
- new accounts get free credits at [platform.liner.com](https://platform.liner.com)

## Mapping

| Liner field | `web_search` result |
| --- | --- |
| `title` | `title` (wrapped) |
| `url` | `url` |
| `description` | `description` (wrapped excerpt) |
| `date` | `published` |

The tool takes `query` (required) and `count` (1–50). `count` maps to Liner's
`max_results`; OpenClaw's generic default (5) is forwarded when unset so result
volume stays consistent across providers. Results go through the shared trusted
endpoint, content wrapping, and search cache like the other providers.

## Tests

- Unit tests (mocked endpoint): metadata/selection wiring, contract-surface
  parity, base-URL resolution, cache-key partitioning, response normalization +
  mapping, count clamping, missing-key / invalid-query payloads, request shape,
  and cache hits.
- Live test gated on `LINER_API_KEY` + `OPENCLAW_LIVE_TEST=1`.
- Contract suites: `providers.contract.test.ts`,
  `plugin-registration.liner.contract.test.ts`, and the bundled
  web-search-providers runtime registration test all include `liner`.

Reference: Parallel provider (#85158).
