### PR TITLE
fix(embedded-runner): refresh compaction retry diagnostics

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -1120,6 +1120,15 @@ export async function runEmbeddedAttempt(
         : {}),
       trace: runTrace,
     };
+    const markDiagnosticAttemptProgress = (reason: string) => {
+      emitTrustedDiagnosticEvent({
+        type: "run.progress",
+        runId: params.runId,
+        ...(params.sessionKey && { sessionKey: params.sessionKey }),
+        ...(params.sessionId && { sessionId: params.sessionId }),
+        reason,
+      });
+    };
     emitTrustedDiagnosticEvent({
       type: "run.started",
       ...diagnosticRunBase,
@@ -4603,6 +4612,7 @@ export async function runEmbeddedAttempt(
                 abortable,
                 aggregateTimeoutMs: COMPACTION_RETRY_AGGREGATE_TIMEOUT_MS,
                 isCompactionStillInFlight: isCompactionInFlight,
+                onHeartbeat: () => markDiagnosticAttemptProgress("compaction_retry:active"),
               });
           if (compactionRetryWait.timedOut) {
             timedOutDuringCompaction = true;

--- a/src/agents/embedded-agent-runner/run/compaction-retry-aggregate-timeout.test.ts
+++ b/src/agents/embedded-agent-runner/run/compaction-retry-aggregate-timeout.test.ts
@@ -41,7 +41,9 @@ function expectClearedTimeoutState(onTimeout: TimeoutCallbackMock, timedOut: boo
 }
 
 async function delay(ms: number): Promise<void> {
-  await new Promise<void>((resolve) => setTimeout(resolve, ms));
+  await new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
+  });
 }
 
 function buildAggregateTimeoutParams(
@@ -131,7 +133,7 @@ describe("waitForCompactionRetryWithAggregateTimeout", () => {
           compactionInFlight = false;
         },
         abortable: async (promise) => await promise,
-        aggregateTimeoutMs: 10,
+        aggregateTimeoutMs: 1,
         isCompactionStillInFlight: () => compactionInFlight,
         onHeartbeat: () => {
           emitTrustedDiagnosticEvent({

--- a/src/agents/embedded-agent-runner/run/compaction-retry-aggregate-timeout.test.ts
+++ b/src/agents/embedded-agent-runner/run/compaction-retry-aggregate-timeout.test.ts
@@ -2,12 +2,9 @@
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { describe, expect, it, vi } from "vitest";
 import {
-  emitTrustedDiagnosticEvent,
-  waitForDiagnosticEventsDrained,
-} from "../../../infra/diagnostic-events.js";
-import {
   getDiagnosticSessionActivitySnapshot,
   markDiagnosticEmbeddedRunStarted,
+  markDiagnosticRunProgress,
 } from "../../../logging/diagnostic-run-activity.js";
 import { classifySessionAttention } from "../../../logging/diagnostic-session-attention.js";
 import { resetDiagnosticStateForTest } from "../../../logging/diagnostic.js";
@@ -140,24 +137,34 @@ describe("waitForCompactionRetryWithAggregateTimeout", () => {
         aggregateTimeoutMs: 10,
         isCompactionStillInFlight: () => compactionInFlight,
         onHeartbeat: () => {
-          emitTrustedDiagnosticEvent({
-            type: "run.progress",
+          markDiagnosticRunProgress({
             runId: "run-heartbeat",
             sessionId,
             sessionKey,
             reason: "compaction_retry:active",
           });
-          resolveHeartbeat?.();
+          const resolve = resolveHeartbeat;
+          resolveHeartbeat = undefined;
+          resolve?.();
         },
       });
 
-      await Promise.race([
-        heartbeatSeen,
-        delay(1_000).then(() => {
-          throw new Error("timed out waiting for compaction retry heartbeat");
-        }),
-      ]);
-      await waitForDiagnosticEventsDrained();
+      let heartbeatTimeout: ReturnType<typeof setTimeout> | undefined;
+      try {
+        await Promise.race([
+          heartbeatSeen,
+          new Promise<never>((_, reject) => {
+            heartbeatTimeout = setTimeout(
+              () => reject(new Error("timed out waiting for compaction retry heartbeat")),
+              1_000,
+            );
+          }),
+        ]);
+      } finally {
+        if (heartbeatTimeout !== undefined) {
+          clearTimeout(heartbeatTimeout);
+        }
+      }
       const activity = getDiagnosticSessionActivitySnapshot({ sessionId, sessionKey }, now);
 
       expect(activity.activeWorkKind).toBe("embedded_run");

--- a/src/agents/embedded-agent-runner/run/compaction-retry-aggregate-timeout.test.ts
+++ b/src/agents/embedded-agent-runner/run/compaction-retry-aggregate-timeout.test.ts
@@ -127,6 +127,10 @@ describe("waitForCompactionRetryWithAggregateTimeout", () => {
       now += 10 * 60_000;
 
       let compactionInFlight = true;
+      let resolveHeartbeat: (() => void) | undefined;
+      const heartbeatSeen = new Promise<void>((resolve) => {
+        resolveHeartbeat = resolve;
+      });
       const resultPromise = waitForCompactionRetryWithAggregateTimeout({
         waitForCompactionRetry: async () => {
           await delay(500);
@@ -143,10 +147,16 @@ describe("waitForCompactionRetryWithAggregateTimeout", () => {
             sessionKey,
             reason: "compaction_retry:active",
           });
+          resolveHeartbeat?.();
         },
       });
 
-      await delay(15);
+      await Promise.race([
+        heartbeatSeen,
+        delay(1_000).then(() => {
+          throw new Error("timed out waiting for compaction retry heartbeat");
+        }),
+      ]);
       await waitForDiagnosticEventsDrained();
       const activity = getDiagnosticSessionActivitySnapshot({ sessionId, sessionKey }, now);
 

--- a/src/agents/embedded-agent-runner/run/compaction-retry-aggregate-timeout.test.ts
+++ b/src/agents/embedded-agent-runner/run/compaction-retry-aggregate-timeout.test.ts
@@ -1,6 +1,16 @@
 // Coverage for aggregate timeout handling while waiting on compaction retry.
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { describe, expect, it, vi } from "vitest";
+import {
+  emitTrustedDiagnosticEvent,
+  waitForDiagnosticEventsDrained,
+} from "../../../infra/diagnostic-events.js";
+import {
+  getDiagnosticSessionActivitySnapshot,
+  markDiagnosticEmbeddedRunStarted,
+} from "../../../logging/diagnostic-run-activity.js";
+import { classifySessionAttention } from "../../../logging/diagnostic-session-attention.js";
+import { resetDiagnosticStateForTest } from "../../../logging/diagnostic.js";
 import { waitForCompactionRetryWithAggregateTimeout } from "./compaction-retry-aggregate-timeout.js";
 
 type AggregateTimeoutParams = Parameters<typeof waitForCompactionRetryWithAggregateTimeout>[0];
@@ -30,6 +40,10 @@ function expectClearedTimeoutState(onTimeout: TimeoutCallbackMock, timedOut: boo
   expect(vi.getTimerCount()).toBe(0);
 }
 
+async function delay(ms: number): Promise<void> {
+  await new Promise<void>((resolve) => setTimeout(resolve, ms));
+}
+
 function buildAggregateTimeoutParams(
   overrides: Partial<AggregateTimeoutParams> &
     Pick<AggregateTimeoutParams, "waitForCompactionRetry">,
@@ -43,6 +57,7 @@ function buildAggregateTimeoutParams(
     abortable: overrides.abortable ?? (async (promise) => await promise),
     aggregateTimeoutMs: overrides.aggregateTimeoutMs ?? 60_000,
     isCompactionStillInFlight: overrides.isCompactionStillInFlight,
+    onHeartbeat: overrides.onHeartbeat,
     onTimeout,
   };
 }
@@ -68,6 +83,7 @@ describe("waitForCompactionRetryWithAggregateTimeout", () => {
     // starts once compaction is no longer in flight.
     await withFakeTimers(async () => {
       let compactionInFlight = true;
+      const onHeartbeat = vi.fn();
       const waitForCompactionRetry = vi.fn(
         async () =>
           await new Promise<void>((resolve) => {
@@ -80,16 +96,78 @@ describe("waitForCompactionRetryWithAggregateTimeout", () => {
       const params = buildAggregateTimeoutParams({
         waitForCompactionRetry,
         isCompactionStillInFlight: () => compactionInFlight,
+        onHeartbeat,
       });
 
       const resultPromise = waitForCompactionRetryWithAggregateTimeout(params);
 
-      await vi.advanceTimersByTimeAsync(170_000);
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(onHeartbeat).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(onHeartbeat).toHaveBeenCalledTimes(2);
+      await vi.advanceTimersByTimeAsync(50_000);
       const result = await resultPromise;
 
       expect(result.timedOut).toBe(false);
       expectClearedTimeoutState(params.onTimeout, false);
     });
+  });
+
+  it("refreshes diagnostic activity while active compaction retry waits", async () => {
+    let now = 1_000_000;
+    const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);
+    const sessionId = "session-heartbeat";
+    const sessionKey = "agent:main:main";
+
+    resetDiagnosticStateForTest();
+    try {
+      markDiagnosticEmbeddedRunStarted({ sessionId, sessionKey });
+      now += 10 * 60_000;
+
+      let compactionInFlight = true;
+      const resultPromise = waitForCompactionRetryWithAggregateTimeout({
+        waitForCompactionRetry: async () => {
+          await delay(35);
+          compactionInFlight = false;
+        },
+        abortable: async (promise) => await promise,
+        aggregateTimeoutMs: 10,
+        isCompactionStillInFlight: () => compactionInFlight,
+        onHeartbeat: () => {
+          emitTrustedDiagnosticEvent({
+            type: "run.progress",
+            runId: "run-heartbeat",
+            sessionId,
+            sessionKey,
+            reason: "compaction_retry:active",
+          });
+        },
+      });
+
+      await delay(15);
+      await waitForDiagnosticEventsDrained();
+      const activity = getDiagnosticSessionActivitySnapshot({ sessionId, sessionKey }, now);
+
+      expect(activity.activeWorkKind).toBe("embedded_run");
+      expect(activity.lastProgressReason).toBe("compaction_retry:active");
+      expect(activity.lastProgressAgeMs).toBe(0);
+      expect(
+        classifySessionAttention({
+          state: "processing",
+          queueDepth: 1,
+          activity,
+          staleMs: 120_000,
+        }),
+      ).toMatchObject({
+        eventType: "session.long_running",
+        reason: "queued_behind_active_work",
+        recoveryEligible: false,
+      });
+      await expect(resultPromise).resolves.toEqual({ timedOut: false });
+    } finally {
+      nowSpy.mockRestore();
+      resetDiagnosticStateForTest();
+    }
   });
 
   it("times out after an idle timeout window", async () => {

--- a/src/agents/embedded-agent-runner/run/compaction-retry-aggregate-timeout.test.ts
+++ b/src/agents/embedded-agent-runner/run/compaction-retry-aggregate-timeout.test.ts
@@ -129,11 +129,11 @@ describe("waitForCompactionRetryWithAggregateTimeout", () => {
       let compactionInFlight = true;
       const resultPromise = waitForCompactionRetryWithAggregateTimeout({
         waitForCompactionRetry: async () => {
-          await delay(35);
+          await delay(500);
           compactionInFlight = false;
         },
         abortable: async (promise) => await promise,
-        aggregateTimeoutMs: 1,
+        aggregateTimeoutMs: 10,
         isCompactionStillInFlight: () => compactionInFlight,
         onHeartbeat: () => {
           emitTrustedDiagnosticEvent({

--- a/src/agents/embedded-agent-runner/run/compaction-retry-aggregate-timeout.ts
+++ b/src/agents/embedded-agent-runner/run/compaction-retry-aggregate-timeout.ts
@@ -13,6 +13,7 @@ export async function waitForCompactionRetryWithAggregateTimeout(params: {
   aggregateTimeoutMs: number;
   onTimeout?: () => void;
   isCompactionStillInFlight?: () => boolean;
+  onHeartbeat?: () => void;
 }): Promise<{ timedOut: boolean }> {
   const timeoutMs = resolveTimerTimeoutMs(params.aggregateTimeoutMs, 1);
 
@@ -46,6 +47,7 @@ export async function waitForCompactionRetryWithAggregateTimeout(params: {
       // Keep extending the timeout window while compaction is actively running.
       // We only trigger the fallback timeout once compaction appears idle.
       if (params.isCompactionStillInFlight?.()) {
+        params.onHeartbeat?.();
         continue;
       }
 


### PR DESCRIPTION
## Summary

- Refresh diagnostic run progress while active compaction retries keep an embedded run waiting.
- Preserve the aggregate timeout fallback for idle/lost compaction retry waits.
- Add focused regression coverage proving the heartbeat refreshes diagnostic activity and keeps stuck-session recovery ineligible while compaction is still active.

Replaces #86558 with a clean branch that contains only the embedded-runner heartbeat fix and focused tests.

## Real behavior proof

Behavior addressed: active compaction retry waits should keep refreshing diagnostic activity so long-running embedded work is not misclassified as stuck while compaction is still in flight.

Real environment tested: local OpenClaw checkout on Windows 11 at `D:\Projects\openclaw`, branch `fix/compaction-retry-diagnostic-heartbeat`, using the repo test runner from the real checkout with Node/Corepack pnpm.

Exact steps or command run after this patch: from `D:\Projects\openclaw`, I ran these commands after applying the patch:

```powershell
git -C D:\Projects\openclaw diff --check
corepack pnpm --dir D:\Projects\openclaw test src/agents/embedded-agent-runner/run/compaction-retry-aggregate-timeout.test.ts
corepack pnpm --dir D:\Projects\openclaw test src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.test.ts src/logging/diagnostic.test.ts src/logging/diagnostic-session-attention.test.ts
```

Evidence after fix: copied live terminal output from the local OpenClaw checkout after the patch:

```text
> openclaw@2026.6.2 test D:\Projects\openclaw
> node scripts/test-projects.mjs src/agents/embedded-agent-runner/run/compaction-retry-aggregate-timeout.test.ts

[test] starting test/vitest/vitest.agents.config.ts

 RUN  v4.1.7 D:/Projects/openclaw

 Test Files  1 passed (1)
      Tests  9 passed (9)
   Start at  11:52:31
   Duration  5.04s (transform 2.93s, setup 474ms, import 4.12s, tests 158ms, environment 0ms)

[test] passed 1 Vitest shard in 11.22s
```

```text
> openclaw@2026.6.2 test D:\Projects\openclaw
> node scripts/test-projects.mjs src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.test.ts src/logging/diagnostic.test.ts src/logging/diagnostic-session-attention.test.ts

[test] starting test/vitest/vitest.unit-fast.config.ts

 RUN  v4.1.7 D:/Projects/openclaw

 Test Files  1 passed (1)
      Tests  10 passed (10)
   Start at  11:55:19
   Duration  295ms (transform 32ms, setup 0ms, import 52ms, tests 5ms, environment 0ms)

[test] starting test/vitest/vitest.logging.config.ts

 RUN  v4.1.7 D:/Projects/openclaw

 Test Files  1 passed (1)
      Tests  68 passed (68)
   Start at  11:55:23
   Duration  5.21s (transform 3.13s, setup 480ms, import 4.14s, tests 258ms, environment 0ms)

[test] starting test/vitest/vitest.agents.config.ts

 RUN  v4.1.7 D:/Projects/openclaw

 Test Files  1 passed (1)
      Tests  13 passed (13)
   Start at  11:55:31
   Duration  1.05s (transform 753ms, setup 474ms, import 140ms, tests 150ms, environment 0ms)

[test] passed 3 Vitest shards in 19.29s
```

Observed result after fix: the local OpenClaw run passed the new regression that starts embedded-run activity, advances diagnostic time by 10 minutes, waits through an active compaction retry heartbeat, observes `lastProgressReason === compaction_retry:active` and `lastProgressAgeMs === 0`, then verifies `classifySessionAttention` returns `session.long_running` / `queued_behind_active_work` with `recoveryEligible: false`. This is the diagnostic behavior that prevents active compaction retry waits from being reclaimed as stale stuck sessions.

What was not tested: I did not run a full live end-to-end embedded compaction retry session recording in a real channel. I also ran `src/logging/diagnostic-stuck-session-recovery.runtime.test.ts` twice; both runs had 19/20 tests pass and failed only while cleaning a Windows temp directory with `EPERM` at `fs.rmSync(tempDir, { recursive: true, force: true })`, not in the heartbeat path.

## Test plan

- [x] `git diff --check`
- [x] `corepack pnpm --dir D:\Projects\openclaw test src/agents/embedded-agent-runner/run/compaction-retry-aggregate-timeout.test.ts`
- [x] `corepack pnpm --dir D:\Projects\openclaw test src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.test.ts src/logging/diagnostic.test.ts src/logging/diagnostic-session-attention.test.ts`