### PR TITLE
fix(cron): inherit default model fallbacks for plain-string agent models (fixes #91362)

### DIFF
--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -426,6 +426,25 @@ function resolveSelectedModelFallbacksOverride(
   return Array.isArray(raw.fallbacks) ? raw.fallbacks : undefined;
 }
 
+/**
+ * Resolves an agent's fallback override for contexts that should inherit configured
+ * global defaults (isolated cron runs) instead of pinning a plain-string or
+ * primary-only agent model to a single-model chain. Returns `undefined` when the
+ * agent model has no explicit `fallbacks` field, so the caller/runner falls through
+ * to `agents.defaults.model.fallbacks`. An explicit `fallbacks` list (including `[]`)
+ * stays authoritative.
+ */
+export function resolveAgentModelInheritableFallbacksOverride(
+  cfg: OpenClawConfig,
+  agentId: string,
+): string[] | undefined {
+  const raw = resolveAgentConfig(cfg, agentId)?.model;
+  if (typeof raw === "object" && raw !== null && Object.hasOwn(raw, "fallbacks")) {
+    return resolveSelectedModelFallbacksOverride(raw);
+  }
+  return undefined;
+}
+
 function resolveFirstModelFallbacksOverride(
   candidates: Array<AgentModelConfig | undefined>,
 ): string[] | undefined {

--- a/src/cron/isolated-agent/run-execution.runtime.ts
+++ b/src/cron/isolated-agent/run-execution.runtime.ts
@@ -1,5 +1,6 @@
 /** Lazy runtime facade for isolated cron agent execution dependencies. */
 export {
+  resolveAgentModelInheritableFallbacksOverride,
   resolveEffectiveModelFallbacks,
   resolveSubagentModelFallbacksOverride,
 } from "../../agents/agent-scope.js";

--- a/src/cron/isolated-agent/run-fallback-policy.test.ts
+++ b/src/cron/isolated-agent/run-fallback-policy.test.ts
@@ -263,6 +263,70 @@ describe("resolveCronFallbacksOverride", () => {
     ).toBeUndefined();
   });
 
+  it("inherits configured default fallbacks for a plain-string agent model", () => {
+    expect(
+      resolveCronFallbacksOverride({
+        cfg: {
+          agents: {
+            defaults: {
+              model: {
+                primary: "anthropic/claude-opus-4-6",
+                fallbacks: ["openai/gpt-5.4", "google/gemini-3-pro"],
+              },
+            },
+            list: [{ id: "research", model: "deepseek/deepseek-v4-pro" }],
+          },
+        },
+        agentId: "research",
+        job: makeJob({ kind: "agentTurn", message: "summarize" }),
+      }),
+    ).toBeUndefined();
+  });
+
+  it("keeps explicit empty agent fallbacks strict instead of inheriting defaults", () => {
+    expect(
+      resolveCronFallbacksOverride({
+        cfg: {
+          agents: {
+            defaults: {
+              model: { primary: "anthropic/claude-opus-4-6", fallbacks: ["openai/gpt-5.4"] },
+            },
+            list: [
+              { id: "research", model: { primary: "deepseek/deepseek-v4-pro", fallbacks: [] } },
+            ],
+          },
+        },
+        agentId: "research",
+        job: makeJob({ kind: "agentTurn", message: "summarize" }),
+      }),
+    ).toStrictEqual([]);
+  });
+
+  it("walks inherited default fallbacks for a plain-string agent model in cron preflight", () => {
+    expect(
+      resolveCronPreflightCandidates({
+        cfg: {
+          agents: {
+            defaults: {
+              model: { primary: "anthropic/claude-opus-4-6", fallbacks: ["openai/gpt-5.4"] },
+            },
+            list: [{ id: "research", model: "deepseek/deepseek-v4-pro" }],
+          },
+        },
+        agentId: "research",
+        provider: "deepseek",
+        model: "deepseek-v4-pro",
+        job: makeJob({ kind: "agentTurn", message: "summarize" }),
+      }),
+    ).toEqual([
+      { provider: "deepseek", model: "deepseek-v4-pro" },
+      { provider: "openai", model: "gpt-5.4" },
+      // The configured default primary trails as an auto fallback once the agent
+      // model overrides it, so the cron run is no longer a single-point-of-failure.
+      { provider: "anthropic", model: "claude-opus-4-6" },
+    ]);
+  });
+
   it("plans the full configured candidate chain for cron preflight", () => {
     expect(
       resolveCronPreflightCandidates({

--- a/src/cron/isolated-agent/run-fallback-policy.ts
+++ b/src/cron/isolated-agent/run-fallback-policy.ts
@@ -4,6 +4,7 @@ import type { ModelCandidate } from "../../agents/model-fallback.types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { CronJob } from "../types.js";
 import {
+  resolveAgentModelInheritableFallbacksOverride,
   resolveEffectiveModelFallbacks,
   resolveSubagentModelFallbacksOverride,
 } from "./run-execution.runtime.js";
@@ -33,12 +34,21 @@ export function resolveCronFallbacksOverride(params: {
       return subagentFallbacksOverride;
     }
   }
-  return resolveEffectiveModelFallbacks({
-    cfg: params.cfg,
-    agentId: params.agentId,
-    hasSessionModelOverride: hasCronPayloadModelOverride,
-    modelOverrideSource: hasCronPayloadModelOverride ? "auto" : undefined,
-  });
+  if (hasCronPayloadModelOverride) {
+    // A payload model override behaves like an auto model selection and keeps the
+    // configured agent/global fallback chain.
+    return resolveEffectiveModelFallbacks({
+      cfg: params.cfg,
+      agentId: params.agentId,
+      hasSessionModelOverride: true,
+      modelOverrideSource: "auto",
+    });
+  }
+  // No payload model override: the job runs the agent's configured model. A plain-string
+  // or primary-only agent model has no explicit fallbacks, so leave the override unset and
+  // let the runner inherit agents.defaults.model.fallbacks instead of pinning the job to a
+  // single-model chain. An explicit agent `fallbacks` list (including []) stays authoritative.
+  return resolveAgentModelInheritableFallbacksOverride(params.cfg, params.agentId);
 }
 
 /** Builds the ordered model candidates used by cron preflight checks. */

--- a/src/cron/isolated-agent/run.test-harness.ts
+++ b/src/cron/isolated-agent/run.test-harness.ts
@@ -44,6 +44,7 @@ export const buildWorkspaceSkillSnapshotMock = createMock();
 export const resolveAgentConfigMock = createMock();
 export const resolveEffectiveModelFallbacksMock = createMock();
 export const resolveSubagentModelFallbacksOverrideMock = createMock();
+export const resolveAgentModelInheritableFallbacksOverrideMock = createMock();
 export const resolveAgentModelFallbacksOverrideMock = createMock();
 export const resolveAgentSkillsFilterMock = createMock();
 export const getModelRefStatusMock = createMock();
@@ -229,6 +230,7 @@ vi.mock("./run-model-selection.runtime.js", () => ({
 vi.mock("./run-execution.runtime.js", () => ({
   resolveEffectiveModelFallbacks: resolveEffectiveModelFallbacksMock,
   resolveSubagentModelFallbacksOverride: resolveSubagentModelFallbacksOverrideMock,
+  resolveAgentModelInheritableFallbacksOverride: resolveAgentModelInheritableFallbacksOverrideMock,
   resolveBootstrapWarningSignaturesSeen: resolveBootstrapWarningSignaturesSeenMock,
   getCliSessionId: getCliSessionIdMock,
   runCliAgent: runCliAgentMock,
@@ -405,6 +407,12 @@ function resetRunConfigMocks(): void {
       const defaultFallbacks = resolveAgentModelFallbackValues(cfg?.agents?.defaults?.model);
       return agentFallbacksOverride ?? defaultFallbacks;
     },
+  );
+  resolveAgentModelInheritableFallbacksOverrideMock.mockReset();
+  // The no-payload-model cron path resolves the agent's inheritable fallbacks; mirror the
+  // agent-fallbacks source the suite stubs via resolveAgentModelFallbacksOverrideMock.
+  resolveAgentModelInheritableFallbacksOverrideMock.mockImplementation((cfg, agentId) =>
+    resolveAgentModelFallbacksOverrideMock(cfg, agentId),
   );
   resolveSubagentModelFallbacksOverrideMock.mockReset();
   resolveSubagentModelFallbacksOverrideMock.mockImplementation((cfg, agentId) => {


### PR DESCRIPTION
## Summary

- **Problem:** When an agent's model config is a plain string (e.g. `agents.list[].model: "deepseek/deepseek-v4-pro"`), isolated cron runs get an **empty fallback chain** instead of inheriting `agents.defaults.model.fallbacks` — leaving the job as a single-point-of-failure on its primary model.
- **Root cause:** `resolveSelectedModelFallbacksOverride` returns `[]` for a plain-string / primary-only agent model (intentionally strict for normal agent runs, with existing tests). The cron path passed that `[]` straight through, and since `[] !== undefined`, `resolveFallbackCandidatesUncached` never falls through to the configured global defaults.
- **What changed:** A cron-scoped, selection-source-aware fix. New `resolveAgentModelInheritableFallbacksOverride` (agent-scope) treats an *implicit* empty list (plain string / primary-only, no explicit `fallbacks` field) as "inherit configured defaults" → returns `undefined`, while an *explicit* `fallbacks` list (including `[]`) stays authoritative. `resolveCronFallbacksOverride` uses it only on the no-payload-model-override path.
- **What did NOT change (scope boundary):** The shared agent-primary strictness helper is untouched (normal agent runs still get `[]` for string models — existing tests preserved). Payload-model-override behavior, subagent fallback policy, and explicit `fallbacks: []` strictness are all unchanged.

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway / orchestration (cron)
- [x] API / contracts (model/provider fallback routing)

## Linked Issue

- Closes #91362

## User-visible / Behavior Changes

Isolated cron jobs that run an agent whose model is configured as a plain string now inherit `agents.defaults.model.fallbacks` (and the configured default primary as a trailing auto-fallback), matching the documented cron contract that configured fallback chains apply unless payload fallbacks are supplied. An explicit agent `fallbacks: []` still disables fallbacks.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Evidence

- [x] **Failing test before + passing after.** Reverting the cron split turns the two new plain-string tests red (`expected [] to be undefined`); the explicit-`fallbacks: []` strictness test stays green throughout.
- New regression tests in `src/cron/isolated-agent/run-fallback-policy.test.ts`: plain-string agent inherits defaults (returns `undefined`); preflight walks the inherited chain (`[deepseek/deepseek-v4-pro, openai/gpt-5.4, anthropic/claude-opus-4-6]`); explicit `fallbacks: []` stays strict.
- Full local run (Node 22): **104 tests pass** across `src/cron/isolated-agent/run-fallback-policy.test.ts` and `src/agents/agent-scope.test.ts` (all 13 existing fallback-policy invariants + agent-primary strictness preserved). `tsgo` 0 errors. oxlint + oxfmt clean.

## Human Verification

- Verified: plain-string agent model → inherits configured default fallbacks; explicit `fallbacks: []` → strict; primary-only object → inherits; unset agent model → unchanged (`undefined`); payload model override path → unchanged.
- Edge cases: cron preflight builds the full inherited candidate chain.
- Not verified: a live end-to-end cron run (verified at unit/source level only).

## Compatibility / Migration

- Backward compatible? Yes — only affects the previously-broken plain-string-agent cron path; explicit-fallbacks and normal agent runs are unchanged.
- Config/env changes? No · Migration needed? No

## AI assistance

AI-assisted (Claude Code). Fully tested locally (104 tests + typecheck/lint/format). Author understands the change. GitHub Codex review covers the AI-review pass.

## Risks and Mitigations

- Risk: unintentionally loosening strictness for agents that meant to disable fallbacks.
  - Mitigation: explicit `fallbacks: []` is detected via the `fallbacks` own-property and kept authoritative; only implicit-empty (plain string / primary-only) inherits. Covered by the strictness regression test.

## Real behavior proof

Behavior addressed: isolated cron runs with a plain-string agent model now inherit `agents.defaults.model.fallbacks` instead of an empty chain; explicit agent `fallbacks: []` stays strict.
Real environment tested: Local unit + source verification on Node 22.22.1 (macOS). No live cron run.
Exact steps or command run after this patch: `node node_modules/vitest/vitest.mjs run src/cron/isolated-agent/run-fallback-policy.test.ts src/agents/agent-scope.test.ts` plus the cron isolated-agent run-harness tests, `pnpm tsgo`, oxlint, oxfmt.
Evidence after fix: 104 tests pass incl. plain-string-inherits-defaults, preflight-walks-inherited-chain, explicit-empty-stays-strict; reverting the cron split turns the plain-string tests red.
Observed result after fix: plain-string agent model -> resolveCronFallbacksOverride returns undefined (runner inherits defaults); preflight chain = [deepseek/deepseek-v4-pro, openai/gpt-5.4, anthropic/claude-opus-4-6].
What was not tested: a live end-to-end cron run with provider failover (verified at unit/source level only).
