### PR TITLE
feat(neosantara): add Neosantara gateway provider and responses API alias

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -442,6 +442,11 @@
   - changed-files:
       - any-glob-to-any-file:
           - "extensions/moonshot/**"
+"extensions: neosantara":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/neosantara/**"
+          - "docs/providers/neosantara.md"
 "extensions: nvidia":
   - changed-files:
       - any-glob-to-any-file:

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1428,6 +1428,7 @@
                   "providers/minimax",
                   "providers/mistral",
                   "providers/moonshot",
+                  "providers/neosantara",
                   "providers/novita",
                   "providers/nvidia",
                   "providers/ollama",

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -53,6 +53,7 @@ Looking for chat channel docs (WhatsApp/Telegram/Discord/Slack/Mattermost (plugi
 - [MiniMax](/providers/minimax)
 - [Mistral](/providers/mistral)
 - [Moonshot AI (Kimi + Kimi Coding)](/providers/moonshot)
+- [Neosantara](/providers/neosantara)
 - [NVIDIA](/providers/nvidia)
 - [NovitaAI](/providers/novita)
 - [Ollama (cloud + local models)](/providers/ollama)

--- a/docs/providers/neosantara.md
+++ b/docs/providers/neosantara.md
@@ -1,0 +1,117 @@
+---
+summary: "Neosantara setup (auth + model selection)"
+title: "Neosantara"
+read_when:
+  - You want to use Neosantara with OpenClaw
+  - You need the API key env var or CLI auth choice
+---
+
+[Neosantara](https://neosantara.xyz) provides access to advanced AI models through a unified, OpenAI-compatible API gateway.
+
+| Property | Value                           |
+| -------- | ------------------------------- |
+| Provider | `neosantara`                    |
+| Auth     | `NEOSANTARA_API_KEY`            |
+| API      | OpenAI-compatible               |
+| Base URL | `https://api.neosantara.xyz/v1` |
+
+## Getting started
+
+<Steps>
+  <Step title="Get an API key">
+    Create an API key on the [Neosantara Dashboard](https://dashboard.neosantara.xyz).
+  </Step>
+  <Step title="Run onboarding">
+    ```bash
+    openclaw onboard --auth-choice neosantara-api-key
+    ```
+  </Step>
+  <Step title="Set a default model">
+    ```json5
+    {
+      agents: {
+        defaults: {
+          model: {
+            primary: "neosantara/grok-4.1-fast-non-reasoning",
+          },
+        },
+      },
+    }
+    ```
+  </Step>
+</Steps>
+
+### Non-interactive example
+
+```bash
+openclaw onboard --non-interactive \
+  --mode local \
+  --auth-choice neosantara-api-key \
+  --neosantara-api-key "$NEOSANTARA_API_KEY"
+```
+
+<Note>
+The onboarding preset sets `neosantara/grok-4.1-fast-non-reasoning` as the default model.
+</Note>
+
+## Built-in catalog
+
+OpenClaw ships this bundled Neosantara catalog:
+
+| Model ref                                | Name          | Input       | Context | Notes           |
+| ---------------------------------------- | ------------- | ----------- | ------- | --------------- |
+| `neosantara/grok-4.1-fast-non-reasoning` | Grok 4.1 Fast | text, image | 131,072 | Default model   |
+| `neosantara/deepseek-r1`                 | DeepSeek R1   | text        | 65,536  | Reasoning model |
+
+## OpenAI Responses Compatibility
+
+For endpoints that require the OpenAI Responses API rather than standard Chat Completions, an alias provider `neosantara-responses` is registered. This routes requests to Neosantara using the `openai-responses` payload format while reusing the same `NEOSANTARA_API_KEY` credential:
+
+```json5
+{
+  agents: {
+    defaults: {
+      model: {
+        primary: "neosantara-responses/grok-4.1-fast-non-reasoning",
+      },
+    },
+  },
+}
+```
+
+<AccordionGroup>
+  <Accordion title="Environment note">
+    If the Gateway runs as a daemon (launchd/systemd), make sure
+    `NEOSANTARA_API_KEY` is available to that process (for example, in
+    `~/.openclaw/.env` or via `env.shellEnv`).
+
+    <Warning>
+    Keys set only in your interactive shell are not visible to daemon-managed
+    gateway processes. Use `~/.openclaw/.env` or `env.shellEnv` config for
+    persistent availability.
+    </Warning>
+
+  </Accordion>
+
+  <Accordion title="Troubleshooting">
+    - Verify your key works: `openclaw models list --provider neosantara`
+    - If models are not appearing, confirm the API key is set in the correct
+      environment for your Gateway process.
+    - Model refs use the form `neosantara/<model-id>`.
+
+  </Accordion>
+</AccordionGroup>
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Model selection" href="/concepts/model-providers" icon="layers">
+    Provider rules, model refs, and failover behavior.
+  </Card>
+  <Card title="Configuration reference" href="/gateway/configuration-reference" icon="gear">
+    Full config schema including provider settings.
+  </Card>
+  <Card title="Neosantara Docs" href="https://docs.neosantara.xyz" icon="arrow-up-right-from-square">
+    Neosantara API references and billing guides.
+  </Card>
+</CardGroup>

--- a/extensions/neosantara/index.test.ts
+++ b/extensions/neosantara/index.test.ts
@@ -1,0 +1,69 @@
+import { capturePluginRegistration } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { describe, expect, it } from "vitest";
+import plugin from "./index.js";
+
+describe("neosantara provider registration", () => {
+  it("registers Neosantara provider", () => {
+    const captured = capturePluginRegistration(plugin);
+    const [provider] = captured.providers;
+    if (!provider) {
+      throw new Error("Expected Neosantara provider");
+    }
+    expect(provider.id).toBe("neosantara");
+    expect(provider.label).toBe("Neosantara");
+    expect(provider.docsPath).toBe("/providers/neosantara");
+    expect(provider.envVars).toEqual(["NEOSANTARA_API_KEY"]);
+    expect(provider.hookAliases).toEqual(["neosantara-responses"]);
+    expect(provider.auth).toHaveLength(1);
+    expect(provider.auth[0].id).toBe("api-key");
+    expect(provider.auth[0].kind).toBe("api_key");
+  });
+
+  it("normalizes transport for neosantara", () => {
+    const captured = capturePluginRegistration(plugin);
+    const [provider] = captured.providers;
+    if (!provider) {
+      throw new Error("Expected Neosantara provider");
+    }
+    expect(
+      provider.normalizeTransport?.({
+        provider: "neosantara",
+        api: "openai-completions",
+        baseUrl: "https://api.neosantara.xyz/v1",
+      }),
+    ).toEqual({
+      api: "openai-completions",
+      baseUrl: "https://api.neosantara.xyz/v1",
+    });
+
+    expect(
+      provider.normalizeTransport?.({
+        provider: "neosantara-responses",
+        api: "openai-responses",
+        baseUrl: "https://api.neosantara.xyz/v1",
+      }),
+    ).toEqual({
+      api: "openai-responses",
+      baseUrl: "https://api.neosantara.xyz/v1",
+    });
+
+    expect(
+      provider.normalizeTransport?.({
+        provider: "neosantara",
+        api: "openai-responses",
+        baseUrl: "https://api.neosantara.xyz/v1",
+      }),
+    ).toEqual({
+      api: "openai-responses",
+      baseUrl: "https://api.neosantara.xyz/v1",
+    });
+
+    expect(
+      provider.normalizeTransport?.({
+        provider: "other-provider",
+        api: "openai-completions",
+        baseUrl: "https://other.com/v1",
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/extensions/neosantara/index.test.ts
+++ b/extensions/neosantara/index.test.ts
@@ -13,10 +13,52 @@ describe("neosantara provider registration", () => {
     expect(provider.label).toBe("Neosantara");
     expect(provider.docsPath).toBe("/providers/neosantara");
     expect(provider.envVars).toEqual(["NEOSANTARA_API_KEY"]);
-    expect(provider.hookAliases).toEqual(["neosantara-responses"]);
+    expect(provider.aliases).toEqual(["neosantara-responses"]);
     expect(provider.auth).toHaveLength(1);
     expect(provider.auth[0].id).toBe("api-key");
     expect(provider.auth[0].kind).toBe("api_key");
+  });
+
+  it("returns explicit provider configs for both neosantara and neosantara-responses in catalog", async () => {
+    const captured = capturePluginRegistration(plugin);
+    const [provider] = captured.providers;
+    if (!provider) {
+      throw new Error("Expected Neosantara provider");
+    }
+
+    const mockCtx = {
+      config: {},
+      env: {},
+      resolveProviderApiKey: (providerId: string) => {
+        if (providerId === "neosantara") {
+          return { apiKey: "test-key" };
+        }
+        return { apiKey: undefined };
+      },
+      resolveProviderAuth: (providerId: string) => {
+        if (providerId === "neosantara") {
+          return { apiKey: "test-key", mode: "api_key", source: "env" };
+        }
+        return { apiKey: undefined, mode: "none", source: "none" };
+      },
+    };
+
+    const result = await provider.catalog?.run(mockCtx as any);
+    expect(result).toBeDefined();
+    expect(result).toHaveProperty("providers");
+
+    const providers = (result as any).providers;
+    expect(providers).toHaveProperty("neosantara");
+    expect(providers).toHaveProperty("neosantara-responses");
+
+    // Check neosantara config
+    expect(providers.neosantara.apiKey).toBe("test-key");
+    expect(providers.neosantara.api).toBe("openai-completions");
+
+    // Check neosantara-responses config
+    expect(providers["neosantara-responses"].apiKey).toBe("test-key");
+    expect(providers["neosantara-responses"].api).toBe("openai-responses");
+    expect(providers["neosantara-responses"].models[0].api).toBe("openai-responses");
   });
 
   it("normalizes transport for neosantara", () => {

--- a/extensions/neosantara/index.ts
+++ b/extensions/neosantara/index.ts
@@ -1,0 +1,59 @@
+// Neosantara plugin entrypoint registers its OpenClaw integration.
+import { defineSingleProviderPluginEntry } from "openclaw/plugin-sdk/provider-entry";
+import { OPENAI_RESPONSES_STREAM_HOOKS } from "openclaw/plugin-sdk/provider-stream";
+import { applyNeosantaraConfig, NEOSANTARA_DEFAULT_MODEL_REF } from "./onboard.js";
+import { buildNeosantaraProvider } from "./provider-catalog.js";
+
+const PROVIDER_ID = "neosantara";
+
+export default defineSingleProviderPluginEntry({
+  id: PROVIDER_ID,
+  name: "Neosantara Provider",
+  description: "Bundled Neosantara provider plugin",
+  provider: {
+    label: "Neosantara",
+    docsPath: "/providers/neosantara",
+    hookAliases: ["neosantara-responses"],
+    auth: [
+      {
+        methodId: "api-key",
+        label: "Neosantara API key",
+        hint: "API key",
+        optionKey: "neosantaraApiKey",
+        flagName: "--neosantara-api-key",
+        envVar: "NEOSANTARA_API_KEY",
+        promptMessage: "Enter Neosantara API key",
+        defaultModel: NEOSANTARA_DEFAULT_MODEL_REF,
+        expectedProviders: ["neosantara", "neosantara-responses"],
+        applyConfig: (cfg) => applyNeosantaraConfig(cfg),
+        wizard: {
+          groupLabel: "Neosantara",
+        },
+      },
+    ],
+    catalog: {
+      buildProvider: buildNeosantaraProvider,
+    },
+    normalizeTransport: ({ provider, api, baseUrl }) => {
+      const isNeosantara = provider === PROVIDER_ID || provider === "neosantara-responses";
+      const isNeosantaraUrl = baseUrl === "https://api.neosantara.xyz/v1";
+      if (
+        (isNeosantara || isNeosantaraUrl) &&
+        (api === "openai-completions" || api === "openai-responses")
+      ) {
+        return { api, baseUrl: baseUrl ?? "https://api.neosantara.xyz/v1" };
+      }
+      return undefined;
+    },
+    wrapStreamFn: (ctx) => {
+      if (ctx.model?.api === "openai-responses") {
+        return OPENAI_RESPONSES_STREAM_HOOKS.wrapStreamFn?.(ctx) ?? ctx.streamFn;
+      }
+      return ctx.streamFn;
+    },
+    classifyFailoverReason: ({ errorMessage }) =>
+      /\bconcurrency limit\b.*\b(?:breached|reached)\b/i.test(errorMessage)
+        ? "rate_limit"
+        : undefined,
+  },
+});

--- a/extensions/neosantara/index.ts
+++ b/extensions/neosantara/index.ts
@@ -1,8 +1,9 @@
+import { buildPairedProviderApiKeyCatalog } from "openclaw/plugin-sdk/provider-catalog-shared";
 // Neosantara plugin entrypoint registers its OpenClaw integration.
 import { defineSingleProviderPluginEntry } from "openclaw/plugin-sdk/provider-entry";
 import { OPENAI_RESPONSES_STREAM_HOOKS } from "openclaw/plugin-sdk/provider-stream";
 import { applyNeosantaraConfig, NEOSANTARA_DEFAULT_MODEL_REF } from "./onboard.js";
-import { buildNeosantaraProvider } from "./provider-catalog.js";
+import { buildNeosantaraProvider, buildNeosantaraResponsesProvider } from "./provider-catalog.js";
 
 const PROVIDER_ID = "neosantara";
 
@@ -13,7 +14,7 @@ export default defineSingleProviderPluginEntry({
   provider: {
     label: "Neosantara",
     docsPath: "/providers/neosantara",
-    hookAliases: ["neosantara-responses"],
+    aliases: ["neosantara-responses"],
     auth: [
       {
         methodId: "api-key",
@@ -32,7 +33,17 @@ export default defineSingleProviderPluginEntry({
       },
     ],
     catalog: {
-      buildProvider: buildNeosantaraProvider,
+      order: "paired",
+      run: async (ctx) => {
+        return buildPairedProviderApiKeyCatalog({
+          ctx,
+          providerId: "neosantara",
+          buildProviders: async () => ({
+            neosantara: buildNeosantaraProvider(),
+            "neosantara-responses": buildNeosantaraResponsesProvider(),
+          }),
+        });
+      },
     },
     normalizeTransport: ({ provider, api, baseUrl }) => {
       const isNeosantara = provider === PROVIDER_ID || provider === "neosantara-responses";

--- a/extensions/neosantara/models.ts
+++ b/extensions/neosantara/models.ts
@@ -1,0 +1,25 @@
+// Neosantara plugin module implements models behavior.
+import { buildManifestModelProviderConfig } from "openclaw/plugin-sdk/provider-catalog-shared";
+import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import manifest from "./openclaw.plugin.json" with { type: "json" };
+
+const NEOSANTARA_MANIFEST_PROVIDER = buildManifestModelProviderConfig({
+  providerId: "neosantara",
+  catalog: manifest.modelCatalog.providers.neosantara,
+});
+
+export const NEOSANTARA_BASE_URL = NEOSANTARA_MANIFEST_PROVIDER.baseUrl;
+
+export const NEOSANTARA_MODEL_CATALOG: ModelDefinitionConfig[] =
+  NEOSANTARA_MANIFEST_PROVIDER.models;
+
+export function buildNeosantaraModelDefinition(
+  model: (typeof NEOSANTARA_MODEL_CATALOG)[number],
+): ModelDefinitionConfig {
+  return {
+    ...model,
+    api: model.api ?? "openai-completions",
+    input: [...model.input],
+    cost: { ...model.cost },
+  };
+}

--- a/extensions/neosantara/onboard.ts
+++ b/extensions/neosantara/onboard.ts
@@ -1,0 +1,27 @@
+// Neosantara setup module handles plugin onboarding behavior.
+import {
+  createModelCatalogPresetAppliers,
+  type OpenClawConfig,
+} from "openclaw/plugin-sdk/provider-onboard";
+import {
+  buildNeosantaraModelDefinition,
+  NEOSANTARA_BASE_URL,
+  NEOSANTARA_MODEL_CATALOG,
+} from "./models.js";
+
+export const NEOSANTARA_DEFAULT_MODEL_REF = "neosantara/grok-4.1-fast-non-reasoning";
+
+const neosantaraPresetAppliers = createModelCatalogPresetAppliers({
+  primaryModelRef: NEOSANTARA_DEFAULT_MODEL_REF,
+  resolveParams: (_cfg: OpenClawConfig) => ({
+    providerId: "neosantara",
+    api: "openai-completions",
+    baseUrl: NEOSANTARA_BASE_URL,
+    catalogModels: NEOSANTARA_MODEL_CATALOG.map(buildNeosantaraModelDefinition),
+    aliases: [{ modelRef: NEOSANTARA_DEFAULT_MODEL_REF, alias: "Neosantara" }],
+  }),
+});
+
+export function applyNeosantaraConfig(cfg: OpenClawConfig): OpenClawConfig {
+  return neosantaraPresetAppliers.applyConfig(cfg);
+}

--- a/extensions/neosantara/openclaw.plugin.json
+++ b/extensions/neosantara/openclaw.plugin.json
@@ -1,0 +1,96 @@
+{
+  "id": "neosantara",
+  "activation": {
+    "onStartup": false
+  },
+  "enabledByDefault": true,
+  "providers": ["neosantara"],
+  "providerAuthAliases": {
+    "neosantara-responses": "neosantara"
+  },
+  "providerRequest": {
+    "providers": {
+      "neosantara": {
+        "family": "neosantara"
+      },
+      "neosantara-responses": {
+        "family": "neosantara"
+      }
+    }
+  },
+  "setup": {
+    "providers": [
+      {
+        "id": "neosantara",
+        "envVars": ["NEOSANTARA_API_KEY"]
+      }
+    ]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "neosantara",
+      "method": "api-key",
+      "choiceId": "neosantara-api-key",
+      "choiceLabel": "Neosantara API key",
+      "groupId": "neosantara",
+      "groupLabel": "Neosantara",
+      "groupHint": "API key",
+      "optionKey": "neosantaraApiKey",
+      "cliFlag": "--neosantara-api-key",
+      "cliOption": "--neosantara-api-key <key>",
+      "cliDescription": "Neosantara API key"
+    }
+  ],
+  "modelCatalog": {
+    "providers": {
+      "neosantara": {
+        "baseUrl": "https://api.neosantara.xyz/v1",
+        "api": "openai-completions",
+        "models": [
+          {
+            "id": "grok-4.1-fast-non-reasoning",
+            "name": "Grok 4.1 Fast",
+            "reasoning": false,
+            "input": ["text", "image"],
+            "contextWindow": 131072,
+            "maxTokens": 8192,
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "deepseek-r1",
+            "name": "DeepSeek R1",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 65536,
+            "maxTokens": 8192,
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            }
+          }
+        ]
+      }
+    },
+    "aliases": {
+      "neosantara-responses": {
+        "provider": "neosantara",
+        "api": "openai-responses"
+      }
+    },
+    "discovery": {
+      "neosantara": "static"
+    }
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/neosantara/openclaw.plugin.json
+++ b/extensions/neosantara/openclaw.plugin.json
@@ -4,7 +4,7 @@
     "onStartup": false
   },
   "enabledByDefault": true,
-  "providers": ["neosantara"],
+  "providers": ["neosantara", "neosantara-responses"],
   "providerAuthAliases": {
     "neosantara-responses": "neosantara"
   },
@@ -85,7 +85,8 @@
       }
     },
     "discovery": {
-      "neosantara": "static"
+      "neosantara": "static",
+      "neosantara-responses": "static"
     }
   },
   "configSchema": {

--- a/extensions/neosantara/package.json
+++ b/extensions/neosantara/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@openclaw/neosantara-provider",
+  "version": "2026.6.2",
+  "private": true,
+  "description": "OpenClaw Neosantara provider plugin",
+  "type": "module",
+  "devDependencies": {
+    "@openclaw/plugin-sdk": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/neosantara/provider-catalog.ts
+++ b/extensions/neosantara/provider-catalog.ts
@@ -1,0 +1,11 @@
+// Neosantara provider module implements model/runtime integration.
+import { buildManifestModelProviderConfig } from "openclaw/plugin-sdk/provider-catalog-shared";
+import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import manifest from "./openclaw.plugin.json" with { type: "json" };
+
+export function buildNeosantaraProvider(): ModelProviderConfig {
+  return buildManifestModelProviderConfig({
+    providerId: "neosantara",
+    catalog: manifest.modelCatalog.providers.neosantara,
+  });
+}

--- a/extensions/neosantara/provider-catalog.ts
+++ b/extensions/neosantara/provider-catalog.ts
@@ -9,3 +9,15 @@ export function buildNeosantaraProvider(): ModelProviderConfig {
     catalog: manifest.modelCatalog.providers.neosantara,
   });
 }
+
+export function buildNeosantaraResponsesProvider(): ModelProviderConfig {
+  const provider = buildNeosantaraProvider();
+  return {
+    ...provider,
+    api: "openai-responses",
+    models: provider.models.map((model) => ({
+      ...model,
+      api: "openai-responses",
+    })),
+  };
+}

--- a/extensions/neosantara/tsconfig.json
+++ b/extensions/neosantara/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../tsconfig.package-boundary.base.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["./*.ts", "./src/**/*.ts"],
+  "exclude": [
+    "./**/*.test.ts",
+    "./dist/**",
+    "./node_modules/**",
+    "./src/test-support/**",
+    "./src/**/*test-helpers.ts",
+    "./src/**/*test-harness.ts",
+    "./src/**/*test-support.ts"
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1145,6 +1145,12 @@ importers:
         specifier: 2026.5.28
         version: 2026.5.28
 
+  extensions/neosantara:
+    devDependencies:
+      '@openclaw/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../packages/plugin-sdk
+
   extensions/nextcloud-talk:
     dependencies:
       zod:

--- a/src/agents/embedded-agent-runner/compact.ts
+++ b/src/agents/embedded-agent-runner/compact.ts
@@ -50,10 +50,6 @@ import {
 import { createPreparedEmbeddedAgentSettingsManager } from "../agent-project-settings.js";
 import { isDefaultAgentRuntimeId } from "../agent-runtime-id.js";
 import {
-  mapSandboxSkillEntriesForPrompt,
-  resolveSandboxSkillRuntimeInputs,
-} from "./sandbox-skills.js";
-import {
   resolveAgentDir,
   resolveRunModelFallbacksOverride,
   resolveSessionAgentIds,
@@ -164,6 +160,10 @@ import { sanitizeSessionHistory, validateReplayTurns } from "./replay-history.js
 import { createEmbeddedAgentResourceLoader } from "./resource-loader.js";
 import { resolveAttemptSpawnWorkspaceDir } from "./run/attempt.thread-helpers.js";
 import { buildEmbeddedSandboxInfo, resolveEmbeddedSandboxInfoExecPolicy } from "./sandbox-info.js";
+import {
+  mapSandboxSkillEntriesForPrompt,
+  resolveSandboxSkillRuntimeInputs,
+} from "./sandbox-skills.js";
 import { prewarmSessionFile, trackSessionManagerAccess } from "./session-manager-cache.js";
 import {
   resolveEmbeddedAgentBaseStreamFn,

--- a/src/agents/embedded-agent-runner/sandbox-skills.test.ts
+++ b/src/agents/embedded-agent-runner/sandbox-skills.test.ts
@@ -96,7 +96,7 @@ describe("resolveSandboxSkillRuntimeInputs", () => {
   });
 
   it("rebuilds sandbox prompts from materialized skill paths", async () => {
-      const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-sandbox-skills-"));
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-sandbox-skills-"));
     try {
       const effectiveWorkspace = path.join(root, "workspace");
       const materializedWorkspace = path.join(root, "state", "sandbox-skills");
@@ -160,7 +160,9 @@ describe("resolveSandboxSkillRuntimeInputs", () => {
       });
 
       expect(prompt).toContain("/workspace/.openclaw/sandbox-skills/skills/demo/SKILL.md");
-      expect(prompt.replaceAll("\\", "/")).not.toContain(materializedWorkspace.replaceAll("\\", "/"));
+      expect(prompt.replaceAll("\\", "/")).not.toContain(
+        materializedWorkspace.replaceAll("\\", "/"),
+      );
       expect(prompt).not.toContain(hostSkillPath);
       expect(prompt).not.toContain("plugin-skills");
       expect(prompt.replaceAll("\\", "/")).not.toContain("/skills/canvas/SKILL.md");

--- a/src/agents/embedded-agent-runner/sandbox-skills.ts
+++ b/src/agents/embedded-agent-runner/sandbox-skills.ts
@@ -53,10 +53,7 @@ function mapPathFromWorkspaceToContainer(params: {
   if (!relativePath) {
     return params.targetWorkspaceDir.replace(/\\/g, "/");
   }
-  return containerJoin(
-    params.targetWorkspaceDir,
-    ...relativePath.split(path.sep).filter(Boolean),
-  );
+  return containerJoin(params.targetWorkspaceDir, ...relativePath.split(path.sep).filter(Boolean));
 }
 
 export function mapSandboxSkillEntriesForPrompt(params: {

--- a/src/agents/sandbox/types.ts
+++ b/src/agents/sandbox/types.ts
@@ -1,3 +1,4 @@
+import type { SkillEligibilityContext } from "../../skills/types.js";
 /**
  * Sandbox runtime configuration and context types.
  *
@@ -6,7 +7,6 @@
 import type { SandboxBackendHandle, SandboxBackendId } from "./backend-handle.types.js";
 import type { SandboxFsBridge } from "./fs-bridge.types.js";
 import type { SandboxDockerConfig } from "./types.docker.js";
-import type { SkillEligibilityContext } from "../../skills/types.js";
 
 export type { SandboxDockerConfig } from "./types.docker.js";
 

--- a/src/agents/sandbox/workspace-mounts.ts
+++ b/src/agents/sandbox/workspace-mounts.ts
@@ -78,7 +78,8 @@ export function resolveReadOnlyWorkspaceSkillMounts(params: {
   // RW workspaces mount the project as writable, but skill sources remain read-only so agent
   // instructions are visible without letting sandbox commands mutate them.
   const materializedSkillsWorkspaceDir =
-    params.skillsWorkspaceDir ?? resolveMaterializedSandboxSkillsWorkspaceDir(params.agentWorkspaceDir);
+    params.skillsWorkspaceDir ??
+    resolveMaterializedSandboxSkillsWorkspaceDir(params.agentWorkspaceDir);
   const mounts = [
     {
       hostPath: path.join(params.agentWorkspaceDir, "skills"),

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -460,6 +460,8 @@ const BUILT_IN_MODEL_PROVIDER_OVERLAY_IDS = new Set([
   "mistral",
   "modelstudio",
   "moonshot",
+  "neosantara",
+  "neosantara-responses",
   "nvidia",
   "ollama",
   "openai",

--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -460,11 +460,7 @@ export async function runCommandWithTimeout(
       } else {
         killIssuedByAbort = true;
       }
-      if (
-        killProcessTree &&
-        typeof child.pid === "number" &&
-        child.pid > 0
-      ) {
+      if (killProcessTree && typeof child.pid === "number" && child.pid > 0) {
         if (process.platform === "win32") {
           try {
             spawn("taskkill", ["/PID", String(child.pid), "/T"], {

--- a/test/vitest/vitest.extension-provider-paths.mjs
+++ b/test/vitest/vitest.extension-provider-paths.mjs
@@ -22,6 +22,7 @@ export const providerExtensionIds = [
   "mistral",
   "qwen",
   "moonshot",
+  "neosantara",
   "nvidia",
   "ollama",
   "openrouter",


### PR DESCRIPTION
Summary:
- Add bundled Neosantara provider plugin backed by the OpenAI-compatible Neosantara Gateway.
- Register API-key onboarding and provider catalog metadata.
- Support both `openai-completions` and `openai-responses` APIs by declaring `neosantara-responses` alias.
- Add Neosantara provider documentation file (`docs/providers/neosantara.md`).
- Update PR labeler configuration.

Verification:
- `pnpm test:extension neosantara` passes successfully.
- `pnpm test:contracts:plugins` passes successfully.

Real behavior proof:
- Behavior addressed: Missing Neosantara provider and responses API compatibility.
- Real environment tested: Linux workspace sandbox.
- Exact steps or command run after this patch: `pnpm test:extension neosantara`
- Evidence after fix: Unit and contract tests passing successfully.
- Observed result after fix: Clean registration and correct transport normalization for both completions and responses interfaces.
