### PR TITLE
refactor(cron): replace store-load double casts with raw-boundary record types (fixes #91314)

### DIFF
--- a/src/cron/service/store.ts
+++ b/src/cron/service/store.ts
@@ -104,13 +104,13 @@ export async function ensureLoaded(
     previousJobsById.set(job.id, job);
   }
   const loaded = await loadCronJobsStoreWithConfigJobs(state.deps.storePath);
-  const loadedJobs = (loaded.store.jobs ?? []) as unknown as CronJob[];
+  // Persisted cron rows are validated lazily, so treat them as raw records at the
+  // store boundary and only trust the CronJob shape after validation below.
+  const loadedJobs = (loaded.store.jobs ?? []) as unknown as Record<string, unknown>[];
   const jobs: CronJob[] = [];
   const quarantinedConfigJobs: QuarantinedCronConfigJob[] = [...loaded.invalidConfigRows];
-  for (const [index, job] of loadedJobs.entries()) {
-    const decodedRaw = job as unknown as Record<string, unknown>;
-    const rawConfigJob = loaded.configJobs[index] ?? structuredClone(decodedRaw);
-    const raw = decodedRaw;
+  for (const [index, raw] of loadedJobs.entries()) {
+    const rawConfigJob = loaded.configJobs[index] ?? structuredClone(raw);
     const sourceIndex = loaded.configJobIndexes[index] ?? index;
     const runtimeEntry = loaded.configJobRuntimeEntries[index];
     // Accept old `jobId` rows at the raw boundary only; the in-memory store
@@ -129,11 +129,8 @@ export async function ensureLoaded(
         "cron: job has invalid persisted sessionTarget; run openclaw doctor --fix to repair",
       );
     }
-    const hydrated =
-      normalized && typeof normalized === "object" ? (normalized as unknown as CronJob) : job;
-    const invalidReason = getInvalidPersistedCronJobReason(
-      hydrated as unknown as Record<string, unknown>,
-    );
+    const hydratedRaw = normalized ?? raw;
+    const invalidReason = getInvalidPersistedCronJobReason(hydratedRaw);
     if (invalidReason) {
       const quarantineEntry: QuarantinedCronConfigJob = {
         sourceIndex,
@@ -157,6 +154,8 @@ export async function ensureLoaded(
       warnInvalidPersistedCronJob({ state, raw, index: sourceIndex, reason: invalidReason });
       continue;
     }
+    // Validated above, so the raw record is now a trusted CronJob.
+    const hydrated = hydratedRaw as unknown as CronJob;
     jobs.push(hydrated);
     invalidateStaleNextRunOnScheduleChange({ previousJobsById, hydrated });
   }


### PR DESCRIPTION
## Summary

- **Problem:** `ensureLoaded` in `src/cron/service/store.ts` cast persisted rows through `as unknown as CronJob[]` and then re-cast each item back to `Record<string, unknown>`, plus cast `normalized`→`CronJob` and `hydrated`→`Record`. The `CronJob[]` label was a lie — the rows are unvalidated raw data at that point — and the chained `as unknown as` casts bypassed type safety.
- **What changed:** Treat the loaded rows as raw `Record<string, unknown>[]` at the store boundary (honest type), keep them as records through `normalizeCronJobIdentityFields` / `normalizeCronJobInput` / `getInvalidPersistedCronJobReason`, and apply a single trusted `CronJob` cast only **after** validation passes.
- **What did NOT change:** The normalize → validate → quarantine → SQLite flow is byte-for-byte identical (same object references, same branches). No runtime behavior change.
- **Net:** `as unknown as` casts in the function drop from 4 → 2 (both now justified raw-boundary / post-validation casts with comments), and 2 lines are removed.

## Change Type

- [x] Refactor

## Scope

- [x] Memory / storage (cron SQLite store loading)

## Linked Issue

- Closes #91314

## User-visible / Behavior Changes

None. Pure type-safety cleanup.

## Security Impact

- New permissions/capabilities? No · Secrets handling? No · Network calls? No · Tool exec surface? No · Data access scope? No

## Evidence

- No behavior change: the loop keeps operating on the same mutated raw record (`normalized ?? raw`) and only casts to `CronJob` after `getInvalidPersistedCronJobReason` returns no reason — identical control flow to before.
- Full local run (Node 22): **46 tests pass** across `src/cron/service/store.test.ts` and `src/cron/store.test.ts` (load, `jobId` normalization, persisted session-target handling, quarantine, force-reload). `tsgo` 0 errors. oxlint + oxfmt clean.

## Human Verification

- Verified: store loading, job hydration, invalid-row quarantine, and force-reload paths all pass unchanged; cast count reduced and remaining casts are documented boundary conversions.
- Not verified: nothing additional — this is a type-only refactor covered by the existing store seam tests.

## Compatibility / Migration

- Backward compatible? Yes (no behavior or shape change) · Config/env changes? No · Migration needed? No

## AI assistance

AI-assisted (Claude Code). Tested locally (46 tests + typecheck/lint/format). Author understands the change.

## Risks and Mitigations

- Risk: a subtle behavior change from reworking the hydration cast.
  - Mitigation: `normalized ?? raw` is equivalent to the prior `normalized && typeof normalized === "object" ? normalized : job` (a non-null normalized is always an object, and `raw`/`job` are the same mutated reference); the CronJob cast moved after validation, where the shape is already verified. Covered by the unchanged store seam tests.

## Real behavior proof

Behavior addressed: none — pure type-safety refactor of cron store loading; runtime behavior is unchanged.
Real environment tested: Local unit + source verification on Node 22.22.1 (macOS).
Exact steps or command run after this patch: `node node_modules/vitest/vitest.mjs run src/cron/service/store.test.ts src/cron/store.test.ts` plus `pnpm tsgo`, oxlint, oxfmt.
Evidence after fix: 46 store-seam tests pass unchanged; `as unknown as` casts reduced 4->2; tsgo 0 errors.
Observed result after fix: store load / hydrate / quarantine / force-reload behave identically; only types changed.
What was not tested: nothing additional — type-only refactor covered by existing store seam tests.
