### PR TITLE
fix(openai-completions): route empty stop with no content into error path

### DIFF
--- a/src/llm/providers/openai-completions.test.ts
+++ b/src/llm/providers/openai-completions.test.ts
@@ -737,3 +737,29 @@ describe("openai-completions stop-reason tool-call guard", () => {
     expect(result.content.filter((b) => b.type === "toolCall")).toStrictEqual([]);
   });
 });
+
+describe("openai-completions empty-stop guard", () => {
+  it("routes finish_reason stop with empty content into the error path", async () => {
+    mockChunksRef.chunks = [makeFinishChunk("stop")];
+
+    const stream = streamOpenAICompletions(model, context, { apiKey: "sk-test" });
+    const result = await stream.result();
+
+    // An empty stop must not surface as a deliverable turn. Downstream silent-reply
+    // policy already treats stopReason="error" as non-silent, so routing here keeps
+    // the blank provider reply from silently disappearing (impact:message-loss).
+    expect(result.stopReason).toBe("error");
+    expect(result.errorMessage).toContain("empty content");
+    expect(result.content).toStrictEqual([]);
+  });
+
+  it("keeps a normal stop with visible text deliverable", async () => {
+    mockChunksRef.chunks = [makeTextChunk("done"), makeFinishChunk("stop")];
+
+    const stream = streamOpenAICompletions(model, context, { apiKey: "sk-test" });
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("stop");
+    expect(result.content.some((b) => b.type === "text")).toBe(true);
+  });
+});

--- a/src/llm/providers/openai-completions.ts
+++ b/src/llm/providers/openai-completions.ts
@@ -479,6 +479,22 @@ export const streamOpenAICompletions: StreamFunction<
         output.content = output.content.filter((block) => block.type !== "toolCall");
       }
 
+      // A provider that finishes `stop` with no tool calls, no visible text, and
+      // no thinking emitted an empty turn. Passing it through as `done` makes
+      // channels deliver a blank reply with no error (impact:message-loss). Route
+      // it into the existing error path so empty-turn recovery/retry applies; the
+      // downstream silent-reply policy already excludes stopReason="error", so
+      // intentional NO_REPLY (a visible token) and reasoning-only turns are
+      // unaffected. The thrown message carries provider/model context so operators
+      // can spot misbehaving models.
+      const hasThinking = output.content.some((block) => block.type === "thinking");
+      if (output.stopReason === "stop" && !hasToolCalls && !hasVisibleText && !hasThinking) {
+        throw new Error(
+          `Provider ${model.provider} (model ${model.id}) returned stop with empty content: ` +
+            "no text, thinking, or tool calls",
+        );
+      }
+
       stream.push({ type: "done", reason: output.stopReason, message: output });
       stream.end();
     } catch (error) {


### PR DESCRIPTION
## Summary

- **Problem:** When an OpenAI-compatible provider finishes a stream with `finish_reason: stop` but **no content** (no text, no thinking, no tool calls), the `openai-completions` adapter emits `done` with `stopReason: "stop"` and an empty `content: []`. Channels deliver this as a blank reply, so the user sees **nothing** with no error (impact:message-loss). Reproduced with `stepfun/step-router-v1` immediately after tool results.
- **Solution:** Guard the adapter's terminal path: an empty `stop` (no visible text, no thinking, no tool calls) is routed into the adapter's **existing error path** instead of `done`, carrying provider/model context so operators can spot misbehaving models.
- **What changed:**
  - `src/llm/providers/openai-completions.ts` — one guard before the `done` push; reuses the existing `catch` → `stopReason: "error"` + error event.
  - `src/llm/providers/openai-completions.test.ts` — regression test for the empty-`stop` case + a guard that a normal text `stop` stays deliverable.
- **What did NOT change:**
  - The silent-reply policy / `allowEmptyAssistantReplyAsSilent` machinery in `src/agents/embedded-agent-runner/run/incomplete-turn.ts` and `src/auto-reply/reply/get-reply-run.ts` — **not a single line**. It already treats `stopReason: "error"` as non-silent (`incomplete-turn.ts:575,607,690`), so the fix slots in without touching policy.
  - Intentional `NO_REPLY` (a **visible** silent token) — still has visible text, so the guard never fires on it.
  - Reasoning-only turns (thinking present) — excluded by the `!hasThinking` clause; their dedicated retry path is untouched.
  - Sibling adapters (`anthropic`, `openai-responses`, `mistral`) — see Merge risk.
- Closes #91394

## Root Cause

- **Root cause:** `streamOpenAICompletions` initializes `output.content = []` / `stopReason = "stop"`, and the terminal block (`src/llm/providers/openai-completions.ts`, the `stop`/`toolUse` normalization before the `done` push) has guards for tool-call/stop mismatches but **none for an empty `stop`**. A streamed completion that only supplies `finish_reason: stop` reaches `done` with empty content.
- **Why this is the root-cause fix:** The empty turn must be rejected at the **provider normalization boundary** (where the anomaly originates), not patched in each channel sender. Routing into the *existing* `catch`/error path reuses the adapter's own retry/error semantics — one canonical path, no new branch downstream. The downstream recovery already special-cases `stopReason: "error"`, so the source-of-truth for "is this turn silent?" stays exactly where it was.
- **Fix classification:** Root-cause behavior bug fix (provider adapter).
- **Maintainer-ready confidence:** High — direction matches the ClawSweeper/Codex review's stated best solution ("normalize an empty `stop` … into the existing retry/error path, warn with provider/model context, keep silent-reply policy unchanged"); reviewed against the same commit `310d28f719`.
- **Patch quality notes:** +16 prod LOC (≈8 are an invariant comment), +26 test LOC, zero deletions. No new config surface, no new helper, no downstream edits.
- **Architecture / source-of-truth check:** Adapter owns provider-shape normalization; the embedded runner owns reply/silence policy. Fixing the adapter and leaving `stopReason: "error"` handling to the runner respects that boundary — no channel/protocol/config surface touched.

## Verification

- `git diff --check` — clean
- `pnpm test src/llm/providers/openai-completions.test.ts` — 1 file, **25 passed** (+2 new)
- `pnpm test src/agents/embedded-agent-runner/run.incomplete-turn.test.ts` — **80 passed**
- `pnpm test src/auto-reply/reply/get-reply-run.media-only.test.ts` — **116 passed**
- `pnpm tsgo:core` + `pnpm tsgo:test:src` — exit 0
- `oxfmt --check` + `node scripts/run-oxlint.mjs` — clean

(Acceptance test set mirrors the ClawSweeper review's listed criteria.)

## Regression Test Plan

- **Target test file:** `src/llm/providers/openai-completions.test.ts` (`describe("openai-completions empty-stop guard")`)
- **Scenario locked in:** a stream of `[makeFinishChunk("stop")]` (empty delta + `finish_reason: stop`) — the exact StepFun shape — must resolve to `stopReason: "error"` with empty content; a normal `text + stop` must still resolve to `stopReason: "stop"`.
- **Why this is the smallest reliable guardrail:** it pins both directions (fires on the anomaly, does **not** over-fire on a real reply) at the adapter boundary using the existing chunk harness; no broader runner test needed because downstream `error` handling is already covered.

## Real behavior proof (required for external PRs)

- **Behavior or issue addressed:** openai-completions adapter silently delivering an empty `finish_reason: stop` turn (#91394).
- **Real environment tested:** Linux 6.6 (WSL2) · Node v24.14.0 · OpenClaw worktree SHA `310d28f719` + this patch · adapter driven through the **real `openai` SDK transport** against a localhost OpenAI-compatible SSE endpoint emitting `finish_reason: stop` with an empty delta (provider id `stepfun`, model `step-router-v1`).
- **Exact steps or command run after this patch:** a standalone `tsx` script started a `127.0.0.1` HTTP server streaming the SSE chunks `{delta:{role:"assistant"},finish_reason:null}` → `{delta:{},finish_reason:"stop"}` → `[DONE]`, pointed a `Model<"openai-completions">` at `http://127.0.0.1:<port>/v1`, and consumed `streamOpenAICompletions(...).result()`. Run once with the guard (AFTER) and once with the guard `git stash`ed (BEFORE = upstream/main behavior).
- **Evidence after fix:**

  ```text
  ########## AFTER (fix branch, guard present) ##########
  provider/model: stepfun step-router-v1
  stopReason   : error
  content.length: 0
  errorMessage : Provider stepfun (model step-router-v1) returned stop with empty content: no text, thinking, or tool calls

  ########## BEFORE (guard stashed => upstream/main behavior) ##########
  provider/model: stepfun step-router-v1
  stopReason   : stop
  content.length: 0
  errorMessage : (none)
  ```

- **Observed result after fix:** the empty `stop` no longer surfaces as a deliverable turn — it becomes `stopReason: "error"` with provider/model context, which the embedded runner treats as non-silent (retry/surface) instead of dropping a blank reply.
- **What was not tested:** no **live StepFun** session was available, so the original `process.poll → empty reply` transcript and the 12 ms provider timing remain reporter-provided (same gap noted in the ClawSweeper read-only review). The empty-`stop` SSE shape itself was reproduced verbatim against the real adapter + real SDK transport above. Whether `anthropic`/`openai-responses`/`mistral` should get the same guard is a maintainer call (see Merge risk).

## Merge risk

- **Risk labels considered:** `impact:message-loss`, message-delivery, provider/runtime behavior.
- **Risk explanation:** This changes a provider terminal state (empty `stop` → `error`) on a path that feeds reply delivery and the silent-reply policy. A group **explicitly configured** `allowEmptyAssistantReplyAsSilent` with a model that returns a *truly empty* `stop` (no `NO_REPLY` token) will now retry/surface instead of staying silent.
- **Why acceptable:**
  - That behavior change is the issue's explicit intent — a 12 ms post-tool empty `stop` is a provider anomaly, not deliberate silence; deliberate silence uses the visible `NO_REPLY` token, which the guard never matches.
  - Bounded: only the `openai-completions` terminal path changed; the silent-reply policy code is untouched and already excludes `stopReason: "error"`.
  - One-sided to `openai-completions` on purpose: it is the reported + reproduced surface and the class of endpoint (OpenAI-compatible third-party routers) that emits empty `stop`. `anthropic`'s native API always returns a content/`tool_use` block, so it cannot hit this. Extending the same guard to `openai-responses`/`mistral` can be a follow-up if reproduced there.
  - Covered by a two-direction regression test + the real-transport before/after proof above.

---

AI-assisted (Claude). The behavior proof above was produced by really running the adapter against a local OpenAI-compatible endpoint; outputs are verbatim.
