### PR TITLE
fix(cli): thread silent-empty policy to CLI runner to stop duplicate group reply (fixes #91302)

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -2030,6 +2030,40 @@ describe("runAgentTurnWithFallback", () => {
     });
   });
 
+  it("threads allowEmptyAssistantReplyAsSilent onto CLI run params for silent group turns", async () => {
+    state.isCliProviderMock.mockReturnValue(true);
+    state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({
+      result: await params.run("claude-cli", "claude-opus-4-6"),
+      provider: "claude-cli",
+      model: "claude-opus-4-6",
+      attempts: [],
+    }));
+    state.runCliAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "ambient" }],
+      meta: { agentMeta: { sessionId: "cli-session" } },
+    });
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const followupRun = createFollowupRun();
+    followupRun.currentInboundEventKind = "room_event";
+    followupRun.run.provider = "claude-cli";
+    followupRun.run.model = "claude-opus-4-6";
+    // A Telegram group room-event turn computes the silent-empty policy; it must reach the
+    // CLI runner so an empty tool-only completion is not converted to empty_response (#91302).
+    followupRun.run.allowEmptyAssistantReplyAsSilent = true;
+    const sessionEntry = {} as unknown as SessionEntry;
+
+    const result = await runAgentTurnWithFallback({
+      ...createMinimalRunAgentTurnParams({ followupRun }),
+      getActiveSessionEntry: () => sessionEntry,
+    });
+
+    expect(result.kind).toBe("success");
+    expectMockCallArgFields(state.runCliAgentMock, 0, "CLI run params", {
+      allowEmptyAssistantReplyAsSilent: true,
+    });
+  });
+
   it("drops replacement room-event CLI sessions when reuse fails", async () => {
     state.isCliProviderMock.mockReturnValue(true);
     state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -2187,6 +2187,13 @@ export async function runAgentTurnWithFallback(params: {
                     extraSystemPrompt: params.followupRun.run.extraSystemPrompt,
                     sourceReplyDeliveryMode: params.followupRun.run.sourceReplyDeliveryMode,
                     silentReplyPromptMode: params.followupRun.run.silentReplyPromptMode,
+                    // Thread the computed silent-empty policy onto the CLI path too (the
+                    // embedded path already does). Without it, a clean empty Claude CLI
+                    // completion whose reply already shipped via the message tool throws
+                    // empty_response, re-runs on the fallback model, and posts a duplicate
+                    // user-visible reply (#91302).
+                    allowEmptyAssistantReplyAsSilent:
+                      params.followupRun.run.allowEmptyAssistantReplyAsSilent,
                     extraSystemPromptStatic: params.followupRun.run.extraSystemPromptStatic,
                     ownerNumbers: params.followupRun.run.ownerNumbers,
                     cliSessionId: cliSessionBinding?.sessionId,


### PR DESCRIPTION
## Summary

- **Problem (P1):** In Telegram groups, a `claude-cli` turn that already delivered its reply via the `message` tool returns empty `output.text` by design. The CLI runner then throws `FailoverError({ reason: "empty_response" })`. Since `empty_response` is a transient fallback reason, the model-fallback chain re-runs the same turn on the configured fallback model — which doesn't know the reply already shipped — and posts a **second, user-visible duplicate reply** (in a different model's voice).
- **Root cause:** `get-reply-run` computes `allowEmptyAssistantReplyAsSilent` (true for group silent policy), and the CLI runner already honors it (`cli-runner.ts` skips the `empty_response` throw when it's `true`). But the CLI run path in `agent-runner-execution.ts` never threaded the flag into `runParams` — only the embedded path did (`agent-runner-run-params.ts`). So the flag was computed and dropped on the CLI path.
- **What changed:** One line — pass `allowEmptyAssistantReplyAsSilent: params.followupRun.run.allowEmptyAssistantReplyAsSilent` into the CLI `runParams`, right next to the sibling `sourceReplyDeliveryMode` / `silentReplyPromptMode` fields. Now a clean empty Claude CLI completion under the group silent policy is treated as silent success → no spurious fallback → no duplicate.
- **What did NOT change (scope boundary):** `empty_response` fallback is preserved for true CLI process / parse / timeout / auth / provider failures (those don't set the silent policy). Direct-chat and non-silent-policy behavior is unchanged. This is a threading fix, not a broad disable of `empty_response`.

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway / orchestration (agent runner / fallback)
- [x] Integrations (Telegram group delivery)

## Linked Issue

- Closes #91302 (follow-up to #89008, which covered the thinking-only empty turn; this covers the tool-call-then-empty-text turn)

## User-visible / Behavior Changes

Telegram (and other group `message_tool_only`) turns run on a Claude CLI provider no longer post a duplicate fallback-model reply when the agent delivered its answer via the `message` tool and the model returned empty text.

## Security Impact

- New permissions/capabilities? No · Secrets handling? No · Network calls? No · Tool exec surface? No · Data access scope? No

## Evidence

- [x] **Failing test before + passing after.** New test asserts the CLI `runParams` receives `allowEmptyAssistantReplyAsSilent: true` for a group room-event turn. Removing the threaded line turns it red; restoring it passes.
- Confirmed the fix covers the reporter's scenario: `allowEmptyAssistantReplyAsSilent` is computed `true` for group chats via `resolveGroupSilentReplyBehavior` (`get-reply-run.ts`).
- Full local run (Node 22): **682 tests pass** across `agent-runner-execution.test.ts`, `cli-runner.reliability.test.ts`, `cli-runner.spawn.test.ts`, `get-reply-run.media-only.test.ts`, `embedded-agent-runner/run.incomplete-turn.test.ts` (+ co-located). `tsgo` 0 errors. oxlint + oxfmt clean.

## Human Verification

- Verified: the computed silent-empty policy now reaches the CLI runner (parity with the embedded path); CLI empty-response gate already short-circuits on the flag; group policy computes `true`.
- Not verified: a live Telegram + Claude CLI end-to-end reproduction (verified at unit/source level only, consistent with the issue's read-only repro).

## Compatibility / Migration

- Backward compatible? Yes — additive threading of an existing computed field; fallback for real failures preserved. · Config/env changes? No · Migration needed? No

## AI assistance

AI-assisted (Claude Code). Tested locally (682 tests + typecheck/lint/format). Author understands the change. GitHub Codex review covers the AI-review pass.

## Risks and Mitigations

- Risk: masking a genuine empty-response provider failure as silent success.
  - Mitigation: the flag is only `true` under the group/direct silent-reply policy (where an empty reply is expected because delivery happens via the message tool). Process/parse/timeout/auth/provider failures throw distinct reasons and still fall back.

## Real behavior proof

Behavior addressed: a claude-cli group turn whose reply shipped via the message tool (empty text) no longer triggers empty_response fallback -> no duplicate reply; the computed silent-empty policy is threaded to the CLI runParams.
Real environment tested: Local unit + source verification on Node 22.22.1 (macOS). No live Telegram + Claude CLI run.
Exact steps or command run after this patch: `node node_modules/vitest/vitest.mjs run src/auto-reply/reply/agent-runner-execution.test.ts src/agents/cli-runner.reliability.test.ts src/agents/cli-runner.spawn.test.ts src/auto-reply/reply/get-reply-run.media-only.test.ts src/agents/embedded-agent-runner/run.incomplete-turn.test.ts` plus `pnpm tsgo`, oxlint, oxfmt.
Evidence after fix: 682 tests pass incl. a new test asserting CLI runParams receives `allowEmptyAssistantReplyAsSilent: true` for group room-event turns; removing the threaded line turns it red.
Observed result after fix: allowEmptyAssistantReplyAsSilent reaches the CLI runner; empty completion under group silent policy is silent success (no fallback rerun, no duplicate).
What was not tested: a live Telegram + Claude CLI end-to-end reproduction (verified at unit/source level only).
