### PR TITLE
fix(mcp): lowercase SSE event-source header keys to prevent duplicate Authorization (401)

### DIFF
--- a/src/agents/mcp-transport.test.ts
+++ b/src/agents/mcp-transport.test.ts
@@ -8,10 +8,16 @@ type StreamableTransportOptions = {
   authProvider?: unknown;
 };
 
-const { lookupMock, runtimeFetchMock, streamableTransportConstructorMock } = vi.hoisted(() => ({
+const {
+  lookupMock,
+  runtimeFetchMock,
+  streamableTransportConstructorMock,
+  sseTransportConstructorMock,
+} = vi.hoisted(() => ({
   lookupMock: vi.fn(),
   runtimeFetchMock: vi.fn(),
   streamableTransportConstructorMock: vi.fn(),
+  sseTransportConstructorMock: vi.fn(),
 }));
 
 vi.mock("node:dns/promises", () => ({
@@ -34,6 +40,20 @@ vi.mock("@modelcontextprotocol/sdk/client/streamableHttp.js", () => ({
     options?: StreamableTransportOptions,
   ) {
     streamableTransportConstructorMock(url, options);
+  },
+}));
+
+type SseTransportOptions = {
+  eventSourceInit?: { fetch?: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response> };
+};
+
+vi.mock("@modelcontextprotocol/sdk/client/sse.js", () => ({
+  SSEClientTransport: function MockSSEClientTransport(
+    this: unknown,
+    url: URL,
+    options?: SseTransportOptions,
+  ) {
+    sseTransportConstructorMock(url, options);
   },
 }));
 
@@ -69,6 +89,18 @@ function latestStreamableFetch() {
   return fetch;
 }
 
+function latestSseEventSourceFetch() {
+  const latestCall = sseTransportConstructorMock.mock.calls[
+    sseTransportConstructorMock.mock.calls.length - 1
+  ] as unknown[] | undefined;
+  const options = latestCall?.[1] as SseTransportOptions | undefined;
+  const fetch = options?.eventSourceInit?.fetch;
+  if (typeof fetch !== "function") {
+    throw new Error("Expected SSE event-source fetch");
+  }
+  return fetch;
+}
+
 function runtimeFetchCall(index: number): [RequestInfo | URL, RequestInit | undefined] {
   const call = runtimeFetchMock.mock.calls[index] as
     | [RequestInfo | URL, RequestInit | undefined]
@@ -85,6 +117,7 @@ describe("resolveMcpTransport", () => {
     lookupMock.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
     runtimeFetchMock.mockReset();
     streamableTransportConstructorMock.mockClear();
+    sseTransportConstructorMock.mockClear();
   });
 
   it("scrubs custom headers when streamable HTTP follows a cross-origin redirect", async () => {
@@ -298,5 +331,35 @@ describe("resolveMcpTransport", () => {
 
     expect(new Headers(runtimeFetchCall(0)?.[1]?.headers).get("x-tenant")).toBe("docs");
     expect(new Headers(runtimeFetchCall(1)?.[1]?.headers).get("x-tenant")).toBeNull();
+  });
+
+  it("merges SSE event-source headers case-insensitively so auth is not duplicated", async () => {
+    // The SDK's EventSource supplies a lowercase `authorization` header while
+    // operator config supplies a capitalized `Authorization`. A naive object
+    // spread keeps both keys, and undici emits two header lines that RFC 7230
+    // servers (e.g. Home Assistant's MCP endpoint) join into an invalid
+    // `Bearer a, Bearer b` value and reject as 401.
+    runtimeFetchMock.mockResolvedValue(new Response("ok"));
+
+    resolveMcpTransport("probe", {
+      url: "https://mcp.example.com/sse",
+      transport: "sse",
+      headers: {
+        Authorization: "Bearer operator",
+      },
+    });
+
+    const sseFetch = latestSseEventSourceFetch();
+    await sseFetch("https://mcp.example.com/sse", {
+      headers: { authorization: "Bearer sdk" },
+    });
+
+    const sentHeaders = runtimeFetchCall(0)?.[1]?.headers as Record<string, string>;
+    const authKeys = Object.keys(sentHeaders).filter(
+      (key) => key.toLowerCase() === "authorization",
+    );
+    // Exactly one Authorization key, lowercased, with operator config winning.
+    expect(authKeys).toEqual(["authorization"]);
+    expect(sentHeaders.authorization).toBe("Bearer operator");
   });
 });

--- a/src/agents/mcp-transport.ts
+++ b/src/agents/mcp-transport.ts
@@ -78,9 +78,19 @@ function buildSseEventSourceFetch(
         Object.assign(sdkHeaders, init.headers);
       }
     }
+    // Header names are case-insensitive (RFC 7230), but a plain object spread
+    // keeps both the SDK's lowercase `authorization` and an operator-configured
+    // `Authorization`. undici emits both as separate header lines, which servers
+    // join into one invalid `Bearer a, Bearer b` value (Home Assistant's MCP
+    // endpoint rejects it as 401). Lowercase every key before merging so operator
+    // headers override the SDK's and survive as a single entry.
+    const mergedHeaders: Record<string, string> = {};
+    for (const [key, value] of [...Object.entries(sdkHeaders), ...Object.entries(headers)]) {
+      mergedHeaders[key.toLowerCase()] = value;
+    }
     return baseFetch(url, {
       ...(init as RequestInit),
-      headers: { ...sdkHeaders, ...headers },
+      headers: mergedHeaders,
     }) as ReturnType<SseEventSourceFetch>;
   };
 }


### PR DESCRIPTION
## Summary

The SSE MCP transport's `buildSseEventSourceFetch` merged the SDK's headers with
operator-configured headers using a plain object spread:

```ts
headers: { ...sdkHeaders, ...headers }
```

The MCP SDK's `EventSource` supplies a lowercase `authorization` header, while
operator config typically uses a capitalized `Authorization`. Both keys survive
the spread, `undici` emits them as two separate header lines, and per RFC 7230 a
server joins same-name headers with a comma — producing
`Authorization: Bearer <token>, Bearer <token>`, which is not a valid bearer
token. Home Assistant's MCP Server endpoint (`/mcp_server/sse`) rejects this with
**401**, so any HTTP/SSE MCP server configured with a bearer token via an
`Authorization` header fails to connect on every session start.

The fix lowercases every header key before merging, so case variants collapse
into a single entry and operator headers override the SDK's. Only the SSE
event-source path is affected — the streamable-HTTP path passes
`requestInit.headers` straight to the SDK without an SDK-side merge.

## Verification (supplemental)

`pnpm test src/agents/mcp-transport.test.ts` → 10 passed; the added regression
test fails on `main` (`[ 'authorization', 'Authorization' ]`) and passes with the
fix. `pnpm tsgo:core` + `pnpm tsgo:core:test` green; `oxfmt --check` clean.

## Real behavior proof

- Behavior addressed: an HTTP/SSE MCP server configured with an `Authorization: Bearer <token>` header returns 401 on every connect, caused by duplicate case-variant Authorization headers reaching the server.
- Real environment tested: OpenClaw gateway connecting to the Home Assistant "MCP Server" integration over SSE, using a valid long-lived access token.
- Exact steps or command run after this patch: applied the equivalent lowercase-merge to the running gateway build, restarted the gateway, then ran `openclaw mcp probe`. Separately ran a direct `curl` against the SSE endpoint to confirm the token itself was valid.
- Evidence after fix: live `openclaw mcp probe` output after the fix, the pre-fix gateway error line, and the direct curl confirming the token was valid (token + host redacted):

```
# after fix — `openclaw mcp probe`
- home-assistant: 71 tools, resources, prompts
- atlas-memory: 4 tools, resources, prompts

# before fix — gateway log, every session start
bundle-mcp: failed to start server "home-assistant": 401

# same token, direct request — HTTP 200 (token was always valid)
$ curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer <redacted>" http://<ha-host>:8123/mcp_server/sse
200
```

- Observed result after fix: Home Assistant MCP connects and lists its tools on every session start; no further 401s in the gateway log.
- What was not tested: OAuth-auth MCP servers (unaffected — that path passes `{}` into the merge) and non-Authorization custom headers beyond the added unit test.
