### PR TITLE
fix(update): run plugin convergence after RPC git updates

### DIFF
--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -6298,6 +6298,56 @@ describe("update-cli", () => {
     expect((lastWriteJsonCall() as { channel?: string } | undefined)?.channel).toBe("beta");
   });
 
+  it("updateFinalizeCommand restores channels from the RPC pre-update config payload", async () => {
+    const tempDir = createCaseDir("openclaw-rpc-finalize");
+    const sourceConfigPath = path.join(tempDir, "source-config.json");
+    const preUpdateConfig = {
+      channels: {
+        whatsapp: {
+          enabled: true,
+          dmPolicy: "pairing",
+        },
+      },
+    } as OpenClawConfig;
+    const postDoctorConfig = {
+      meta: { lastTouchedVersion: "2026.6.18" },
+    } as OpenClawConfig;
+    const postDoctorSnapshot: ConfigFileSnapshot = {
+      ...baseSnapshot,
+      sourceConfig: postDoctorConfig,
+      resolved: postDoctorConfig,
+      runtimeConfig: postDoctorConfig,
+      config: postDoctorConfig,
+      hash: "post-doctor",
+    };
+    await fs.mkdir(tempDir, { recursive: true });
+    await fs.writeFile(
+      sourceConfigPath,
+      `${JSON.stringify({
+        sourceConfig: preUpdateConfig,
+        authoredConfig: preUpdateConfig,
+      })}\n`,
+      "utf-8",
+    );
+    vi.mocked(readConfigFileSnapshot).mockResolvedValue(postDoctorSnapshot);
+
+    await withEnvAsync(
+      {
+        OPENCLAW_UPDATE_POST_CORE_SOURCE_CONFIG_PATH: sourceConfigPath,
+      },
+      async () => {
+        await updateFinalizeCommand({ json: true, restart: false });
+      },
+    );
+
+    expect(syncPluginCall()?.config?.channels?.whatsapp).toEqual(
+      preUpdateConfig.channels?.whatsapp,
+    );
+    expect(lastReplaceConfigCall()?.nextConfig?.channels?.whatsapp).toEqual(
+      preUpdateConfig.channels?.whatsapp,
+    );
+  });
+
   it("updateFinalizeCommand reapplies requested channel against post-doctor config", async () => {
     const preDoctorConfig = { update: { channel: "stable" } } as OpenClawConfig;
     const postDoctorConfig = { update: { channel: "beta" } } as OpenClawConfig;

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -6333,6 +6333,40 @@ describe("update-cli", () => {
     expect((lastWriteJsonCall() as { channel?: string } | undefined)?.channel).toBe("dev");
   });
 
+  it("updateFinalizeCommand converges on the effective channel from env without persisting update.channel", async () => {
+    const noChannelConfig = {} as OpenClawConfig;
+    const noChannelSnapshot: ConfigFileSnapshot = {
+      ...baseSnapshot,
+      sourceConfig: noChannelConfig,
+      resolved: noChannelConfig,
+      runtimeConfig: noChannelConfig,
+      config: noChannelConfig,
+      hash: "no-channel",
+    };
+    vi.mocked(readConfigFileSnapshot).mockResolvedValue(noChannelSnapshot);
+    const priorEffective = process.env.OPENCLAW_UPDATE_EFFECTIVE_CHANNEL;
+    // Simulate a no-config git/source update whose effective channel is dev.
+    process.env.OPENCLAW_UPDATE_EFFECTIVE_CHANNEL = "dev";
+    try {
+      await updateFinalizeCommand({ json: true, restart: false });
+    } finally {
+      if (priorEffective === undefined) {
+        delete process.env.OPENCLAW_UPDATE_EFFECTIVE_CHANNEL;
+      } else {
+        process.env.OPENCLAW_UPDATE_EFFECTIVE_CHANNEL = priorEffective;
+      }
+    }
+    // Convergence runs on the effective (git/dev) channel...
+    expect(syncPluginCall()?.channel).toBe("dev");
+    // ...but the effective channel is never persisted to update.channel
+    // (no requested channel), so a default source update does not mutate config.
+    expect(syncPluginCall()?.config?.update?.channel).toBeUndefined();
+    const persistedDevChannel = vi
+      .mocked(replaceConfigFile)
+      .mock.calls.some(([params]) => params?.nextConfig?.update?.channel === "dev");
+    expect(persistedDevChannel).toBe(false);
+  });
+
   it.each([
     {
       name: "update command invalid timeout",

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -95,6 +95,10 @@ import {
   type ResolvedGlobalInstallTarget,
 } from "../../infra/update-global.js";
 import { cleanupStaleManagedServiceUpdateHandoffs } from "../../infra/update-managed-service-handoff-cleanup.js";
+import {
+  POST_CORE_UPDATE_SOURCE_CONFIG_PATH_ENV,
+  type PreUpdateConfigRestoreInput,
+} from "../../infra/update-post-core-context.js";
 import { runGatewayUpdate, type UpdateRunResult } from "../../infra/update-runner.js";
 import { normalizePluginsConfig, resolveEffectiveEnableState } from "../../plugins/config-state.js";
 import {
@@ -167,7 +171,6 @@ const POST_CORE_UPDATE_CHANNEL_ENV = "OPENCLAW_UPDATE_POST_CORE_CHANNEL";
 const POST_CORE_UPDATE_REQUESTED_CHANNEL_ENV = "OPENCLAW_UPDATE_POST_CORE_REQUESTED_CHANNEL";
 const POST_CORE_UPDATE_RESULT_PATH_ENV = "OPENCLAW_UPDATE_POST_CORE_RESULT_PATH";
 const POST_CORE_UPDATE_INSTALL_RECORDS_PATH_ENV = "OPENCLAW_UPDATE_POST_CORE_INSTALL_RECORDS_PATH";
-const POST_CORE_UPDATE_SOURCE_CONFIG_PATH_ENV = "OPENCLAW_UPDATE_POST_CORE_SOURCE_CONFIG_PATH";
 const POST_CORE_UPDATE_STARTED_AT_ENV = "OPENCLAW_UPDATE_POST_CORE_STARTED_AT_MS";
 const POST_CORE_UPDATE_RESULT_POLL_MS = 100;
 const PRE_UPDATE_CONFIG_SNAPSHOT_MAX_AGE_MS = 6 * 60 * 60 * 1000;
@@ -221,11 +224,6 @@ const UPDATE_QUIPS = [
 type PostCorePluginUpdateResult = NonNullable<
   NonNullable<UpdateRunResult["postUpdate"]>["plugins"]
 >;
-
-type PreUpdateConfigRestoreInput = {
-  sourceConfig: OpenClawConfig;
-  authoredConfig: OpenClawConfig;
-};
 
 type MissingPluginInstallPayload = {
   pluginId: string;
@@ -2470,14 +2468,19 @@ export async function updateFinalizeCommand(opts: UpdateFinalizeOptions): Promis
 
   const root = await resolveUpdateRoot();
   let configSnapshot = await readConfigFileSnapshot({ skipPluginValidation: true });
-  const preFinalizeConfig = configSnapshot.valid
-    ? {
-        sourceConfig: configSnapshot.sourceConfig,
-        authoredConfig: isRecord(configSnapshot.parsed)
-          ? (configSnapshot.parsed as OpenClawConfig)
-          : configSnapshot.sourceConfig,
-      }
-    : undefined;
+  const preFinalizeConfig =
+    (await readPostCorePreUpdateSourceConfig({
+      sourceConfigPath: process.env[POST_CORE_UPDATE_SOURCE_CONFIG_PATH_ENV],
+      currentSnapshot: configSnapshot,
+    })) ??
+    (configSnapshot.valid
+      ? {
+          sourceConfig: configSnapshot.sourceConfig,
+          authoredConfig: isRecord(configSnapshot.parsed)
+            ? (configSnapshot.parsed as OpenClawConfig)
+            : configSnapshot.sourceConfig,
+        }
+      : undefined);
   const requestedChannel = normalizeUpdateChannel(opts.channel);
   if (opts.channel && !requestedChannel) {
     defaultRuntime.error(`--channel must be "stable", "beta", or "dev" (got "${opts.channel}")`);

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -64,6 +64,7 @@ import {
   DEFAULT_GIT_CHANNEL,
   DEFAULT_PACKAGE_CHANNEL,
   normalizeUpdateChannel,
+  UPDATE_EFFECTIVE_CHANNEL_ENV,
 } from "../../infra/update-channels.js";
 import {
   compareSemverStrings,
@@ -2486,7 +2487,14 @@ export async function updateFinalizeCommand(opts: UpdateFinalizeOptions): Promis
   const storedChannel = configSnapshot.valid
     ? normalizeUpdateChannel(configSnapshot.config.update?.channel)
     : null;
-  const channel = requestedChannel ?? storedChannel ?? DEFAULT_PACKAGE_CHANNEL;
+  // Effective channel the core update actually ran on (e.g. git/dev for an
+  // unconfigured source update), passed by the caller via env. Used only as a
+  // convergence fallback; it is never persisted (that stays gated on
+  // `requestedChannel`), so a default source update does not write update.channel.
+  const effectiveChannel = normalizeUpdateChannel(
+    process.env[UPDATE_EFFECTIVE_CHANNEL_ENV]?.trim(),
+  );
+  const channel = requestedChannel ?? storedChannel ?? effectiveChannel ?? DEFAULT_PACKAGE_CHANNEL;
   if (requestedChannel) {
     configSnapshot = await persistRequestedUpdateChannel({
       configSnapshot,
@@ -2514,7 +2522,11 @@ export async function updateFinalizeCommand(opts: UpdateFinalizeOptions): Promis
       ? normalizeUpdateChannel(configSnapshot.config.update?.channel)
       : null;
     const postDoctorChannel =
-      requestedChannel ?? postDoctorStoredChannel ?? storedChannel ?? DEFAULT_PACKAGE_CHANNEL;
+      requestedChannel ??
+      postDoctorStoredChannel ??
+      storedChannel ??
+      effectiveChannel ??
+      DEFAULT_PACKAGE_CHANNEL;
     const pluginInstallRecords = await loadInstalledPluginIndexInstallRecords();
     return await runPostCorePluginUpdate({
       root,

--- a/src/gateway/server-methods/update.test.ts
+++ b/src/gateway/server-methods/update.test.ts
@@ -1,6 +1,7 @@
 // Update method tests cover update.run/status, restart sentinel metadata,
 // managed-service handoff, restart scheduling, and delivery context preservation.
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ConfigFileSnapshot, OpenClawConfig } from "../../config/types.openclaw.js";
 import type { RestartSentinelPayload } from "../../infra/restart-sentinel.js";
 import type { RespawnSupervisor } from "../../infra/supervisor-markers.js";
 import type { UpdateInstallSurface, UpdateRunResult } from "../../infra/update-runner.js";
@@ -24,6 +25,7 @@ const isRestartEnabledMock = vi.fn(() => true);
 const readPackageVersionMock = vi.fn(async () => "1.0.0");
 const detectRespawnSupervisorMock = vi.fn<() => RespawnSupervisor | null>(() => null);
 const normalizeUpdateChannelMock = vi.fn((): "stable" | "beta" | "dev" | null => null);
+const readConfigFileSnapshotMock = vi.fn<() => Promise<ConfigFileSnapshot>>();
 const startManagedServiceUpdateHandoffMock = vi.fn(async () => ({
   status: "started" as const,
   pid: 12345,
@@ -52,6 +54,7 @@ type UpdateRunPayload = {
 
 vi.mock("../../config/config.js", () => ({
   getRuntimeConfig: () => ({ update: {} }),
+  readConfigFileSnapshot: readConfigFileSnapshotMock,
 }));
 
 vi.mock("../../config/commands.flags.js", () => ({
@@ -179,6 +182,21 @@ beforeEach(() => {
   readPackageVersionMock.mockResolvedValue("1.0.0");
   normalizeUpdateChannelMock.mockReset();
   normalizeUpdateChannelMock.mockReturnValue(null);
+  readConfigFileSnapshotMock.mockReset();
+  readConfigFileSnapshotMock.mockResolvedValue({
+    path: "/tmp/openclaw.json",
+    exists: true,
+    raw: "{}",
+    parsed: {},
+    resolved: {} as OpenClawConfig,
+    sourceConfig: {} as OpenClawConfig,
+    valid: true,
+    config: {} as OpenClawConfig,
+    runtimeConfig: {} as OpenClawConfig,
+    issues: [],
+    warnings: [],
+    legacyIssues: [],
+  });
   detectRespawnSupervisorMock.mockReset();
   detectRespawnSupervisorMock.mockReturnValue(null);
   runGatewayUpdateMock.mockClear();
@@ -722,6 +740,46 @@ describe("update.run post-core plugin finalize", () => {
     expect(scheduleGatewaySigusr1RestartMock).toHaveBeenCalledTimes(1);
     expect(payload?.ok).toBe(true);
     expect(payload?.result?.status).toBe("ok");
+  });
+
+  it("carries the pre-doctor source config into the git finalizer", async () => {
+    const preUpdateConfig = {
+      channels: {
+        whatsapp: {
+          enabled: true,
+        },
+      },
+    } as OpenClawConfig;
+    readConfigFileSnapshotMock.mockResolvedValueOnce({
+      path: "/tmp/openclaw.json",
+      exists: true,
+      raw: JSON.stringify(preUpdateConfig),
+      parsed: preUpdateConfig,
+      resolved: preUpdateConfig,
+      sourceConfig: preUpdateConfig,
+      valid: true,
+      config: preUpdateConfig,
+      runtimeConfig: preUpdateConfig,
+      issues: [],
+      warnings: [],
+      legacyIssues: [],
+    });
+    runPostCoreFinalizeAfterGatewayUpdateMock.mockResolvedValueOnce({
+      status: "ok",
+      entrypoint: "/tmp/openclaw-git/dist/index.mjs",
+    });
+    mockGitOkUpdate("/tmp/openclaw-git");
+
+    await captureUpdateRunPayload();
+
+    const [finalizeParams] = firstMockCall(
+      runPostCoreFinalizeAfterGatewayUpdateMock,
+      "post-core finalize",
+    ) as [{ preUpdateConfig?: { sourceConfig?: OpenClawConfig; authoredConfig?: OpenClawConfig } }];
+    expect(finalizeParams.preUpdateConfig).toEqual({
+      sourceConfig: preUpdateConfig,
+      authoredConfig: preUpdateConfig,
+    });
   });
 
   it("blocks the restart when post-core plugin finalize fails", async () => {

--- a/src/gateway/server-methods/update.test.ts
+++ b/src/gateway/server-methods/update.test.ts
@@ -33,6 +33,15 @@ const startManagedServiceUpdateHandoffMock = vi.fn(async () => ({
 
 const scheduleGatewaySigusr1RestartMock = vi.fn(() => ({ scheduled: true }));
 
+type PostCoreFinalizeOutcome = Awaited<
+  ReturnType<
+    typeof import("../../infra/update-post-core-finalize.js").runPostCoreFinalizeAfterGatewayUpdate
+  >
+>;
+const runPostCoreFinalizeAfterGatewayUpdateMock = vi.fn<() => Promise<PostCoreFinalizeOutcome>>(
+  async () => ({ status: "skipped", reason: "not-git-update" }),
+);
+
 type UpdateRunPayload = {
   ok: boolean;
   result?: { status?: string; reason?: string; mode?: string };
@@ -110,6 +119,18 @@ vi.mock("../../infra/update-runner.js", () => ({
   runGatewayUpdate: runGatewayUpdateMock,
 }));
 
+// Keep the real `foldPostCoreFinalizeIntoResult` so the restart-gate behavior on
+// finalize failure is exercised; only stub the subprocess-spawning finalizer.
+vi.mock("../../infra/update-post-core-finalize.js", async () => {
+  const actual = await vi.importActual<typeof import("../../infra/update-post-core-finalize.js")>(
+    "../../infra/update-post-core-finalize.js",
+  );
+  return {
+    ...actual,
+    runPostCoreFinalizeAfterGatewayUpdate: runPostCoreFinalizeAfterGatewayUpdateMock,
+  };
+});
+
 vi.mock("../../../packages/gateway-protocol/src/index.js", () => ({
   validateUpdateStatusParams: () => true,
   validateUpdateRunParams: () => true,
@@ -182,6 +203,11 @@ beforeEach(() => {
   startManagedServiceUpdateHandoffMock.mockClear();
   scheduleGatewaySigusr1RestartMock.mockClear();
   scheduleGatewaySigusr1RestartMock.mockReturnValue({ scheduled: true });
+  runPostCoreFinalizeAfterGatewayUpdateMock.mockClear();
+  runPostCoreFinalizeAfterGatewayUpdateMock.mockResolvedValue({
+    status: "skipped",
+    reason: "not-git-update",
+  });
 });
 
 async function invokeUpdateRun(
@@ -660,6 +686,73 @@ describe("update.run restart scheduling", () => {
     expect(payload?.result?.status).toBe("skipped");
     expect(payload?.result?.reason).toBe("restart-unavailable");
     expect(payload?.result?.mode).toBe("npm");
+  });
+});
+
+describe("update.run post-core plugin finalize", () => {
+  function mockGitOkUpdate(root: string) {
+    runGatewayUpdateMock.mockResolvedValueOnce({
+      status: "ok",
+      mode: "git",
+      root,
+      after: { version: "2026.6.1" },
+      steps: [],
+      durationMs: 100,
+    });
+    mockGitInstallSurface(root);
+  }
+
+  it("resumes official plugin convergence after a git/source core update", async () => {
+    runPostCoreFinalizeAfterGatewayUpdateMock.mockResolvedValueOnce({
+      status: "ok",
+      entrypoint: "/tmp/openclaw-git/dist/index.mjs",
+    });
+    mockGitOkUpdate("/tmp/openclaw-git");
+
+    const payload = await captureUpdateRunPayload();
+
+    expect(runPostCoreFinalizeAfterGatewayUpdateMock).toHaveBeenCalledTimes(1);
+    const [finalizeParams] = firstMockCall(
+      runPostCoreFinalizeAfterGatewayUpdateMock,
+      "post-core finalize",
+    ) as [{ result?: UpdateRunResult }];
+    expect(finalizeParams.result?.mode).toBe("git");
+    expect(finalizeParams.result?.status).toBe("ok");
+    // Convergence succeeded, so the gateway is allowed to restart onto the new core.
+    expect(scheduleGatewaySigusr1RestartMock).toHaveBeenCalledTimes(1);
+    expect(payload?.ok).toBe(true);
+    expect(payload?.result?.status).toBe("ok");
+  });
+
+  it("blocks the restart when post-core plugin finalize fails", async () => {
+    runPostCoreFinalizeAfterGatewayUpdateMock.mockResolvedValueOnce({
+      status: "error",
+      reason: "nonzero-exit",
+      entrypoint: "/tmp/openclaw-git/dist/index.mjs",
+      exitCode: 1,
+      message: "convergence failed",
+    });
+    mockGitOkUpdate("/tmp/openclaw-git");
+
+    const payload = await captureUpdateRunPayload();
+
+    // Restarting onto the new core with unreconciled plugins is the bug we avoid.
+    expect(scheduleGatewaySigusr1RestartMock).not.toHaveBeenCalled();
+    expect(payload?.ok).toBe(false);
+    expect(payload?.result?.status).toBe("error");
+    expect(payload?.result?.reason).toBe("post-core-plugin-finalize-failed");
+    expect(readCapturedPayload().status).toBe("error");
+  });
+
+  it("does not run finalize on the managed-service handoff path", async () => {
+    detectRespawnSupervisorMock.mockReturnValueOnce("launchd");
+    mockGlobalInstallSurface();
+
+    await captureUpdateRunPayload();
+
+    expect(runGatewayUpdateMock).not.toHaveBeenCalled();
+    expect(runPostCoreFinalizeAfterGatewayUpdateMock).not.toHaveBeenCalled();
+    expect(startManagedServiceUpdateHandoffMock).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/gateway/server-methods/update.ts
+++ b/src/gateway/server-methods/update.ts
@@ -2,12 +2,15 @@
 // sentinels, and hand off managed-service restarts when needed.
 import { randomUUID } from "node:crypto";
 import os from "node:os";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import {
   validateUpdateRunParams,
   validateUpdateStatusParams,
 } from "../../../packages/gateway-protocol/src/index.js";
 import { isRestartEnabled } from "../../config/commands.flags.js";
+import { readConfigFileSnapshot } from "../../config/config.js";
 import { extractDeliveryInfo } from "../../config/sessions.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { GATEWAY_SERVICE_KIND, GATEWAY_SERVICE_MARKER } from "../../daemon/constants.js";
 import { resolveOpenClawPackageRoot } from "../../infra/openclaw-root.js";
 import { readPackageVersion } from "../../infra/package-json.js";
@@ -21,6 +24,7 @@ import {
   formatManagedServiceUpdateCommand,
   startManagedServiceUpdateHandoff,
 } from "../../infra/update-managed-service-handoff.js";
+import type { PreUpdateConfigRestoreInput } from "../../infra/update-post-core-context.js";
 import {
   foldPostCoreFinalizeIntoResult,
   runPostCoreFinalizeAfterGatewayUpdate,
@@ -55,6 +59,21 @@ function tryResolveProcessCwd(): string | undefined {
   } catch {
     return undefined;
   }
+}
+
+async function readPreUpdateConfigForPostCoreFinalize(): Promise<
+  PreUpdateConfigRestoreInput | undefined
+> {
+  const snapshot = await readConfigFileSnapshot({ skipPluginValidation: true });
+  if (!snapshot.valid) {
+    return undefined;
+  }
+  return {
+    sourceConfig: snapshot.sourceConfig,
+    authoredConfig: isRecord(snapshot.parsed)
+      ? (snapshot.parsed as OpenClawConfig)
+      : snapshot.sourceConfig,
+  };
 }
 
 function resolveManagedServiceHandoffRestartDelayMs(
@@ -275,6 +294,15 @@ export const updateHandlers: GatewayRequestHandlers = {
           };
         }
       } else {
+        const preUpdateConfig =
+          installSurface.kind === "git"
+            ? await readPreUpdateConfigForPostCoreFinalize().catch((err) => {
+                context?.logGateway?.warn(
+                  `update.run could not capture pre-update config ${formatControlPlaneActor(actor)} error=${formatUpdateRunErrorMessage(err)}`,
+                );
+                return undefined;
+              })
+            : undefined;
         result = await runGatewayUpdate({
           timeoutMs,
           cwd: root,
@@ -288,6 +316,7 @@ export const updateHandlers: GatewayRequestHandlers = {
           result,
           channel: configChannel ?? undefined,
           ...(timeoutMs === undefined ? {} : { timeoutMs }),
+          ...(preUpdateConfig ? { preUpdateConfig } : {}),
         });
         if (finalizeOutcome.status === "error") {
           context?.logGateway?.warn(

--- a/src/gateway/server-methods/update.ts
+++ b/src/gateway/server-methods/update.ts
@@ -22,6 +22,10 @@ import {
   startManagedServiceUpdateHandoff,
 } from "../../infra/update-managed-service-handoff.js";
 import {
+  foldPostCoreFinalizeIntoResult,
+  runPostCoreFinalizeAfterGatewayUpdate,
+} from "../../infra/update-post-core-finalize.js";
+import {
   buildUpdateRestartSentinelPayload,
   type UpdateRestartSentinelMeta,
 } from "../../infra/update-restart-sentinel-payload.js";
@@ -277,6 +281,20 @@ export const updateHandlers: GatewayRequestHandlers = {
           argv1: process.argv[1],
           channel: configChannel ?? undefined,
         });
+        // The CLI `openclaw update` resumes post-core plugin convergence after a
+        // git/source core update; the RPC path did not, leaving official managed
+        // plugins stale on the new core. Run the finalizer here to match.
+        const finalizeOutcome = await runPostCoreFinalizeAfterGatewayUpdate({
+          result,
+          channel: configChannel ?? undefined,
+          ...(timeoutMs === undefined ? {} : { timeoutMs }),
+        });
+        if (finalizeOutcome.status === "error") {
+          context?.logGateway?.warn(
+            `update.run post-core plugin finalize failed ${formatControlPlaneActor(actor)} reason=${finalizeOutcome.reason}`,
+          );
+        }
+        result = foldPostCoreFinalizeIntoResult(result, finalizeOutcome);
       }
     } catch {
       result = {

--- a/src/infra/update-channels.ts
+++ b/src/infra/update-channels.ts
@@ -16,6 +16,14 @@ export type UpdateChannelSource =
 export const DEFAULT_PACKAGE_CHANNEL: UpdateChannel = "stable";
 /** Default channel for source installs where branch metadata is unavailable. */
 export const DEFAULT_GIT_CHANNEL: UpdateChannel = "dev";
+/**
+ * Env var carrying the *effective* update channel into `openclaw update finalize`
+ * (e.g. the git/dev channel a source update actually ran on) without making it a
+ * *requested* channel. Convergence uses it as a fallback; it is never persisted
+ * to `update.channel`. Mirrors the CLI post-core resume's effective/requested
+ * channel split (`OPENCLAW_UPDATE_POST_CORE_CHANNEL` vs `…_REQUESTED_CHANNEL`).
+ */
+export const UPDATE_EFFECTIVE_CHANNEL_ENV = "OPENCLAW_UPDATE_EFFECTIVE_CHANNEL";
 /** Git branch that represents the development update stream. */
 export const DEV_BRANCH = "main";
 

--- a/src/infra/update-post-core-context.ts
+++ b/src/infra/update-post-core-context.ts
@@ -1,0 +1,9 @@
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+
+export const POST_CORE_UPDATE_SOURCE_CONFIG_PATH_ENV =
+  "OPENCLAW_UPDATE_POST_CORE_SOURCE_CONFIG_PATH";
+
+export type PreUpdateConfigRestoreInput = {
+  sourceConfig: OpenClawConfig;
+  authoredConfig: OpenClawConfig;
+};

--- a/src/infra/update-post-core-finalize.test.ts
+++ b/src/infra/update-post-core-finalize.test.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs/promises";
 import { describe, expect, it, vi } from "vitest";
 import {
   foldPostCoreFinalizeIntoResult,
@@ -138,6 +139,41 @@ describe("runPostCoreFinalizeAfterGatewayUpdate", () => {
     expect(call.argv).not.toContain("--timeout");
     // No per-step timeout requested → outer backstop is the floor.
     expect(call.timeoutMs).toBe(30 * 60_000);
+  });
+
+  it("passes and removes the pre-update config payload for channel restoration", async () => {
+    const preUpdateConfig = {
+      sourceConfig: {
+        channels: {
+          whatsapp: { enabled: true },
+        },
+      },
+      authoredConfig: {
+        channels: {
+          whatsapp: { enabled: true },
+        },
+      },
+    };
+    let sourceConfigPath: string | undefined;
+    const spawnFinalize = vi.fn<PostCoreFinalizeSpawner>(async ({ env }) => {
+      sourceConfigPath = env.OPENCLAW_UPDATE_POST_CORE_SOURCE_CONFIG_PATH;
+      expect(sourceConfigPath).toEqual(expect.any(String));
+      await expect(fs.readFile(sourceConfigPath!, "utf-8")).resolves.toBe(
+        `${JSON.stringify(preUpdateConfig)}\n`,
+      );
+      return { code: 0 };
+    });
+
+    await expect(
+      runPostCoreFinalizeAfterGatewayUpdate({
+        result: gitOkResult(),
+        preUpdateConfig,
+        resolveEntrypoint: resolveEntrypointOk,
+        spawnFinalize,
+      }),
+    ).resolves.toEqual({ status: "ok", entrypoint: ENTRYPOINT });
+
+    await expect(fs.access(sourceConfigPath!)).rejects.toThrow();
   });
 
   it("reports error on a non-zero finalize exit", async () => {

--- a/src/infra/update-post-core-finalize.test.ts
+++ b/src/infra/update-post-core-finalize.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  foldPostCoreFinalizeIntoResult,
+  type PostCoreFinalizeSpawner,
+  runPostCoreFinalizeAfterGatewayUpdate,
+} from "./update-post-core-finalize.js";
+import type { UpdateRunResult } from "./update-runner.js";
+
+function gitOkResult(overrides: Partial<UpdateRunResult> = {}): UpdateRunResult {
+  return {
+    status: "ok",
+    mode: "git",
+    root: "/srv/openclaw",
+    before: { sha: "aaa", version: "2026.5.3" },
+    after: { sha: "bbb", version: "2026.6.1" },
+    steps: [],
+    durationMs: 10,
+    ...overrides,
+  };
+}
+
+const ENTRYPOINT = "/srv/openclaw/dist/index.mjs";
+const resolveEntrypointOk = async () => ENTRYPOINT;
+
+describe("runPostCoreFinalizeAfterGatewayUpdate", () => {
+  it("skips non-git update modes", async () => {
+    const spawnFinalize = vi.fn<PostCoreFinalizeSpawner>();
+    for (const result of [
+      gitOkResult({ mode: "pnpm" }),
+      gitOkResult({ status: "error" }),
+      gitOkResult({ status: "skipped" }),
+      gitOkResult({ root: undefined }),
+    ]) {
+      const outcome = await runPostCoreFinalizeAfterGatewayUpdate({
+        result,
+        resolveEntrypoint: resolveEntrypointOk,
+        spawnFinalize,
+      });
+      expect(outcome).toEqual({ status: "skipped", reason: "not-git-update" });
+    }
+    expect(spawnFinalize).not.toHaveBeenCalled();
+  });
+
+  it("skips when no built entrypoint is found", async () => {
+    const spawnFinalize = vi.fn<PostCoreFinalizeSpawner>();
+    const outcome = await runPostCoreFinalizeAfterGatewayUpdate({
+      result: gitOkResult(),
+      resolveEntrypoint: async () => undefined,
+      spawnFinalize,
+    });
+    expect(outcome).toEqual({ status: "skipped", reason: "entrypoint-missing" });
+    expect(spawnFinalize).not.toHaveBeenCalled();
+  });
+
+  it("spawns `update finalize` against the rebuilt binary and reports success", async () => {
+    const spawnFinalize = vi.fn<PostCoreFinalizeSpawner>(async () => ({ code: 0 }));
+    const outcome = await runPostCoreFinalizeAfterGatewayUpdate({
+      result: gitOkResult(),
+      channel: "stable",
+      timeoutMs: 120_000,
+      resolveEntrypoint: resolveEntrypointOk,
+      spawnFinalize,
+    });
+    expect(outcome).toEqual({ status: "ok", entrypoint: ENTRYPOINT });
+    expect(spawnFinalize).toHaveBeenCalledTimes(1);
+    const call = spawnFinalize.mock.calls[0]![0];
+    // Reconcile runs through the designed finalizer; never restarts (RPC owns restart).
+    expect(call.argv).toEqual([
+      expect.any(String),
+      ENTRYPOINT,
+      "update",
+      "finalize",
+      "--json",
+      "--yes",
+      "--no-restart",
+      "--channel",
+      "stable",
+      "--timeout",
+      "120",
+    ]);
+    // Host-compat resolution is pinned to the just-installed core version.
+    expect(call.env.OPENCLAW_COMPATIBILITY_HOST_VERSION).toBe("2026.6.1");
+  });
+
+  it("omits channel/timeout flags when not provided", async () => {
+    const spawnFinalize = vi.fn<PostCoreFinalizeSpawner>(async () => ({ code: 0 }));
+    await runPostCoreFinalizeAfterGatewayUpdate({
+      result: gitOkResult(),
+      resolveEntrypoint: resolveEntrypointOk,
+      spawnFinalize,
+    });
+    const argv = spawnFinalize.mock.calls[0]![0].argv;
+    expect(argv).not.toContain("--channel");
+    expect(argv).not.toContain("--timeout");
+  });
+
+  it("reports error on a non-zero finalize exit", async () => {
+    const spawnFinalize = vi.fn<PostCoreFinalizeSpawner>(async () => ({
+      code: 1,
+      stderr: "convergence failed",
+    }));
+    const outcome = await runPostCoreFinalizeAfterGatewayUpdate({
+      result: gitOkResult(),
+      resolveEntrypoint: resolveEntrypointOk,
+      spawnFinalize,
+    });
+    expect(outcome).toEqual({
+      status: "error",
+      reason: "nonzero-exit",
+      entrypoint: ENTRYPOINT,
+      exitCode: 1,
+      message: "convergence failed",
+    });
+  });
+
+  it("reports error when the finalize spawn throws", async () => {
+    const spawnFinalize = vi.fn<PostCoreFinalizeSpawner>(async () => {
+      throw new Error("ENOENT");
+    });
+    const outcome = await runPostCoreFinalizeAfterGatewayUpdate({
+      result: gitOkResult(),
+      resolveEntrypoint: resolveEntrypointOk,
+      spawnFinalize,
+    });
+    expect(outcome).toEqual({
+      status: "error",
+      reason: "spawn-failed",
+      entrypoint: ENTRYPOINT,
+      message: "ENOENT",
+    });
+  });
+});
+
+describe("foldPostCoreFinalizeIntoResult", () => {
+  it("leaves the result unchanged for ok/skipped outcomes", () => {
+    const result = gitOkResult();
+    expect(foldPostCoreFinalizeIntoResult(result, { status: "ok", entrypoint: ENTRYPOINT })).toBe(
+      result,
+    );
+    expect(
+      foldPostCoreFinalizeIntoResult(result, { status: "skipped", reason: "not-git-update" }),
+    ).toBe(result);
+  });
+
+  it("flips status to error so the RPC restart gate is skipped", () => {
+    const result = gitOkResult();
+    const folded = foldPostCoreFinalizeIntoResult(result, {
+      status: "error",
+      reason: "nonzero-exit",
+      entrypoint: ENTRYPOINT,
+      exitCode: 2,
+      message: "boom",
+    });
+    expect(folded.status).toBe("error");
+    expect(folded.reason).toBe("post-core-plugin-finalize-failed");
+    expect(folded.steps.at(-1)).toMatchObject({
+      name: "post-core plugin finalize",
+      exitCode: 2,
+      stderrTail: "boom",
+    });
+    // Core update metadata is preserved for the sentinel.
+    expect(folded.after).toEqual(result.after);
+  });
+});

--- a/src/infra/update-post-core-finalize.test.ts
+++ b/src/infra/update-post-core-finalize.test.ts
@@ -78,7 +78,9 @@ describe("runPostCoreFinalizeAfterGatewayUpdate", () => {
     expect(outcome).toEqual({ status: "ok", entrypoint: ENTRYPOINT });
     expect(spawnFinalize).toHaveBeenCalledTimes(1);
     const call = spawnFinalize.mock.calls[0][0];
-    // Reconcile runs through the designed finalizer; never restarts (RPC owns restart).
+    // Reconcile runs through the designed finalizer; never restarts (RPC owns
+    // restart). No `--channel` — the channel is passed as effective-only via env
+    // so the finalizer does not persist it.
     expect(call.argv).toEqual([
       expect.any(String),
       ENTRYPOINT,
@@ -87,11 +89,12 @@ describe("runPostCoreFinalizeAfterGatewayUpdate", () => {
       "--json",
       "--yes",
       "--no-restart",
-      "--channel",
-      "stable",
       "--timeout",
       "120",
     ]);
+    expect(call.argv).not.toContain("--channel");
+    // Configured channel is carried as the effective convergence channel via env.
+    expect(call.env.OPENCLAW_UPDATE_EFFECTIVE_CHANNEL).toBe("stable");
     // Host-compat resolution is pinned to the just-installed core version.
     expect(call.env.OPENCLAW_COMPATIBILITY_HOST_VERSION).toBe("2026.6.1");
     // Outer whole-process timeout is decoupled from the per-step --timeout (120s):
@@ -119,7 +122,7 @@ describe("runPostCoreFinalizeAfterGatewayUpdate", () => {
     expect(env.OPENCLAW_GATEWAY_SERVICE_PID).toBeUndefined();
   });
 
-  it("omits --channel (no config mutation) and --timeout when not provided", async () => {
+  it("carries effective git/dev channel via env without --channel for a no-config update", async () => {
     const spawnFinalize = vi.fn<PostCoreFinalizeSpawner>(async () => ({ code: 0 }));
     await runPostCoreFinalizeAfterGatewayUpdate({
       result: gitOkResult(),
@@ -127,8 +130,10 @@ describe("runPostCoreFinalizeAfterGatewayUpdate", () => {
       spawnFinalize,
     });
     const call = spawnFinalize.mock.calls[0][0];
-    // No `--channel` unless the caller has a configured channel: `update finalize`
-    // persists any `--channel`, so a defaulted one would mutate openclaw.json.
+    // No configured channel → effective channel defaults to the git/dev channel
+    // the core update ran on, carried via env (convergence-only, not persisted),
+    // never as `--channel` (which `update finalize` would persist to openclaw.json).
+    expect(call.env.OPENCLAW_UPDATE_EFFECTIVE_CHANNEL).toBe("dev");
     expect(call.argv).not.toContain("--channel");
     expect(call.argv).not.toContain("--timeout");
     // No per-step timeout requested → outer backstop is the floor.

--- a/src/infra/update-post-core-finalize.test.ts
+++ b/src/infra/update-post-core-finalize.test.ts
@@ -94,6 +94,9 @@ describe("runPostCoreFinalizeAfterGatewayUpdate", () => {
     ]);
     // Host-compat resolution is pinned to the just-installed core version.
     expect(call.env.OPENCLAW_COMPATIBILITY_HOST_VERSION).toBe("2026.6.1");
+    // Outer whole-process timeout is decoupled from the per-step --timeout (120s):
+    // a generous floor so a valid multi-step finalize is not killed prematurely.
+    expect(call.timeoutMs).toBe(30 * 60_000);
   });
 
   it("strips the gateway service identity from the finalizer child env", async () => {
@@ -116,16 +119,22 @@ describe("runPostCoreFinalizeAfterGatewayUpdate", () => {
     expect(env.OPENCLAW_GATEWAY_SERVICE_PID).toBeUndefined();
   });
 
-  it("omits channel/timeout flags when not provided", async () => {
+  it("defaults to the git/dev channel and omits --timeout when not provided", async () => {
     const spawnFinalize = vi.fn<PostCoreFinalizeSpawner>(async () => ({ code: 0 }));
     await runPostCoreFinalizeAfterGatewayUpdate({
       result: gitOkResult(),
       resolveEntrypoint: resolveEntrypointOk,
       spawnFinalize,
     });
-    const argv = spawnFinalize.mock.calls[0][0].argv;
-    expect(argv).not.toContain("--channel");
-    expect(argv).not.toContain("--timeout");
+    const call = spawnFinalize.mock.calls[0][0];
+    // git/source updates default to the dev channel (matches runGatewayUpdate),
+    // not the package (stable) channel.
+    const channelIdx = call.argv.indexOf("--channel");
+    expect(channelIdx).toBeGreaterThan(-1);
+    expect(call.argv[channelIdx + 1]).toBe("dev");
+    expect(call.argv).not.toContain("--timeout");
+    // No per-step timeout requested → outer backstop is the floor.
+    expect(call.timeoutMs).toBe(30 * 60_000);
   });
 
   it("reports error on a non-zero finalize exit", async () => {

--- a/src/infra/update-post-core-finalize.test.ts
+++ b/src/infra/update-post-core-finalize.test.ts
@@ -119,7 +119,7 @@ describe("runPostCoreFinalizeAfterGatewayUpdate", () => {
     expect(env.OPENCLAW_GATEWAY_SERVICE_PID).toBeUndefined();
   });
 
-  it("defaults to the git/dev channel and omits --timeout when not provided", async () => {
+  it("omits --channel (no config mutation) and --timeout when not provided", async () => {
     const spawnFinalize = vi.fn<PostCoreFinalizeSpawner>(async () => ({ code: 0 }));
     await runPostCoreFinalizeAfterGatewayUpdate({
       result: gitOkResult(),
@@ -127,11 +127,9 @@ describe("runPostCoreFinalizeAfterGatewayUpdate", () => {
       spawnFinalize,
     });
     const call = spawnFinalize.mock.calls[0][0];
-    // git/source updates default to the dev channel (matches runGatewayUpdate),
-    // not the package (stable) channel.
-    const channelIdx = call.argv.indexOf("--channel");
-    expect(channelIdx).toBeGreaterThan(-1);
-    expect(call.argv[channelIdx + 1]).toBe("dev");
+    // No `--channel` unless the caller has a configured channel: `update finalize`
+    // persists any `--channel`, so a defaulted one would mutate openclaw.json.
+    expect(call.argv).not.toContain("--channel");
     expect(call.argv).not.toContain("--timeout");
     // No per-step timeout requested → outer backstop is the floor.
     expect(call.timeoutMs).toBe(30 * 60_000);

--- a/src/infra/update-post-core-finalize.test.ts
+++ b/src/infra/update-post-core-finalize.test.ts
@@ -41,6 +41,20 @@ describe("runPostCoreFinalizeAfterGatewayUpdate", () => {
     expect(spawnFinalize).not.toHaveBeenCalled();
   });
 
+  it("skips a no-op git update with no core change", async () => {
+    const spawnFinalize = vi.fn<PostCoreFinalizeSpawner>();
+    const outcome = await runPostCoreFinalizeAfterGatewayUpdate({
+      result: gitOkResult({
+        before: { sha: "same", version: "2026.6.1" },
+        after: { sha: "same", version: "2026.6.1" },
+      }),
+      resolveEntrypoint: resolveEntrypointOk,
+      spawnFinalize,
+    });
+    expect(outcome).toEqual({ status: "skipped", reason: "not-git-update" });
+    expect(spawnFinalize).not.toHaveBeenCalled();
+  });
+
   it("skips when no built entrypoint is found", async () => {
     const spawnFinalize = vi.fn<PostCoreFinalizeSpawner>();
     const outcome = await runPostCoreFinalizeAfterGatewayUpdate({
@@ -63,7 +77,7 @@ describe("runPostCoreFinalizeAfterGatewayUpdate", () => {
     });
     expect(outcome).toEqual({ status: "ok", entrypoint: ENTRYPOINT });
     expect(spawnFinalize).toHaveBeenCalledTimes(1);
-    const call = spawnFinalize.mock.calls[0]![0];
+    const call = spawnFinalize.mock.calls[0][0];
     // Reconcile runs through the designed finalizer; never restarts (RPC owns restart).
     expect(call.argv).toEqual([
       expect.any(String),
@@ -82,6 +96,26 @@ describe("runPostCoreFinalizeAfterGatewayUpdate", () => {
     expect(call.env.OPENCLAW_COMPATIBILITY_HOST_VERSION).toBe("2026.6.1");
   });
 
+  it("strips the gateway service identity from the finalizer child env", async () => {
+    const spawnFinalize = vi.fn<PostCoreFinalizeSpawner>(async () => ({ code: 0 }));
+    await runPostCoreFinalizeAfterGatewayUpdate({
+      result: gitOkResult(),
+      resolveEntrypoint: resolveEntrypointOk,
+      spawnFinalize,
+      env: {
+        PATH: "/usr/bin",
+        OPENCLAW_SERVICE_MARKER: "openclaw",
+        OPENCLAW_SERVICE_KIND: "gateway",
+        OPENCLAW_GATEWAY_SERVICE_PID: "4242",
+      },
+    });
+    const { env } = spawnFinalize.mock.calls[0][0];
+    expect(env.PATH).toBe("/usr/bin");
+    expect(env.OPENCLAW_SERVICE_MARKER).toBeUndefined();
+    expect(env.OPENCLAW_SERVICE_KIND).toBeUndefined();
+    expect(env.OPENCLAW_GATEWAY_SERVICE_PID).toBeUndefined();
+  });
+
   it("omits channel/timeout flags when not provided", async () => {
     const spawnFinalize = vi.fn<PostCoreFinalizeSpawner>(async () => ({ code: 0 }));
     await runPostCoreFinalizeAfterGatewayUpdate({
@@ -89,7 +123,7 @@ describe("runPostCoreFinalizeAfterGatewayUpdate", () => {
       resolveEntrypoint: resolveEntrypointOk,
       spawnFinalize,
     });
-    const argv = spawnFinalize.mock.calls[0]![0].argv;
+    const argv = spawnFinalize.mock.calls[0][0].argv;
     expect(argv).not.toContain("--channel");
     expect(argv).not.toContain("--timeout");
   });

--- a/src/infra/update-post-core-finalize.test.ts
+++ b/src/infra/update-post-core-finalize.test.ts
@@ -41,8 +41,8 @@ describe("runPostCoreFinalizeAfterGatewayUpdate", () => {
     expect(spawnFinalize).not.toHaveBeenCalled();
   });
 
-  it("skips a no-op git update with no core change", async () => {
-    const spawnFinalize = vi.fn<PostCoreFinalizeSpawner>();
+  it("retries finalization after a no-op git update", async () => {
+    const spawnFinalize = vi.fn<PostCoreFinalizeSpawner>(async () => ({ code: 0 }));
     const outcome = await runPostCoreFinalizeAfterGatewayUpdate({
       result: gitOkResult({
         before: { sha: "same", version: "2026.6.1" },
@@ -51,8 +51,8 @@ describe("runPostCoreFinalizeAfterGatewayUpdate", () => {
       resolveEntrypoint: resolveEntrypointOk,
       spawnFinalize,
     });
-    expect(outcome).toEqual({ status: "skipped", reason: "not-git-update" });
-    expect(spawnFinalize).not.toHaveBeenCalled();
+    expect(outcome).toEqual({ status: "ok", entrypoint: ENTRYPOINT });
+    expect(spawnFinalize).toHaveBeenCalledTimes(1);
   });
 
   it("skips when no built entrypoint is found", async () => {
@@ -206,5 +206,16 @@ describe("foldPostCoreFinalizeIntoResult", () => {
     });
     // Core update metadata is preserved for the sentinel.
     expect(folded.after).toEqual(result.after);
+  });
+
+  it("bounds finalizer stderr in the update result", () => {
+    const folded = foldPostCoreFinalizeIntoResult(gitOkResult(), {
+      status: "error",
+      reason: "nonzero-exit",
+      entrypoint: ENTRYPOINT,
+      exitCode: 1,
+      message: "x".repeat(8_001),
+    });
+    expect(folded.steps.at(-1)?.stderrTail).toBe(`…${"x".repeat(8_000)}`);
   });
 });

--- a/src/infra/update-post-core-finalize.ts
+++ b/src/infra/update-post-core-finalize.ts
@@ -16,6 +16,8 @@
 // `updateNpmInstalledPlugins({ syncOfficialPluginInstalls: true, disableOnFailure: true })`
 // and `runPostCorePluginConvergence`). Finalization never restarts, so the RPC
 // handler keeps ownership of the gateway restart.
+import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { GATEWAY_SERVICE_RUNTIME_PID_ENV } from "../daemon/constants.js";
 import { resolveGatewayInstallEntrypoint } from "../daemon/gateway-entrypoint.js";
@@ -27,6 +29,10 @@ import {
   type UpdateChannel,
   UPDATE_EFFECTIVE_CHANNEL_ENV,
 } from "./update-channels.js";
+import {
+  POST_CORE_UPDATE_SOURCE_CONFIG_PATH_ENV,
+  type PreUpdateConfigRestoreInput,
+} from "./update-post-core-context.js";
 import type { UpdateRunResult } from "./update-runner.js";
 
 // Whole-process backstop for the finalizer. `update finalize` runs several timed
@@ -49,6 +55,7 @@ function buildFinalizeEnv(
   baseEnv: NodeJS.ProcessEnv,
   effectiveChannel: UpdateChannel,
   compatHostVersion?: string,
+  sourceConfigPath?: string,
 ): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = { ...baseEnv };
   delete env.OPENCLAW_SERVICE_MARKER;
@@ -57,6 +64,9 @@ function buildFinalizeEnv(
   env[UPDATE_EFFECTIVE_CHANNEL_ENV] = effectiveChannel;
   if (compatHostVersion) {
     env.OPENCLAW_COMPATIBILITY_HOST_VERSION = compatHostVersion;
+  }
+  if (sourceConfigPath) {
+    env[POST_CORE_UPDATE_SOURCE_CONFIG_PATH_ENV] = sourceConfigPath;
   }
   return env;
 }
@@ -130,6 +140,7 @@ export async function runPostCoreFinalizeAfterGatewayUpdate(params: {
   result: UpdateRunResult;
   channel?: UpdateChannel;
   timeoutMs?: number;
+  preUpdateConfig?: PreUpdateConfigRestoreInput;
   resolveEntrypoint?: (root: string) => Promise<string | undefined>;
   spawnFinalize?: PostCoreFinalizeSpawner;
   env?: NodeJS.ProcessEnv;
@@ -165,14 +176,26 @@ export async function runPostCoreFinalizeAfterGatewayUpdate(params: {
   // Pin the finalizer's host-compat resolution to the just-installed core
   // version so plugins reconcile against the new core, not the running process.
   const compatHostVersion = result.after?.version ?? undefined;
-  const env = buildFinalizeEnv(params.env ?? process.env, effectiveChannel, compatHostVersion);
   // Outer whole-process backstop, decoupled from the per-step `--timeout` above.
   const processTimeoutMs = Math.max(
     FINALIZE_PROCESS_TIMEOUT_FLOOR_MS,
     (perStepTimeoutMs ?? 0) * FINALIZE_PROCESS_STEP_BUDGET_MULTIPLIER,
   );
 
+  let sourceConfigDir: string | undefined;
   try {
+    let sourceConfigPath: string | undefined;
+    if (params.preUpdateConfig) {
+      sourceConfigDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-update-post-core-"));
+      sourceConfigPath = path.join(sourceConfigDir, "source-config.json");
+      await fs.writeFile(sourceConfigPath, `${JSON.stringify(params.preUpdateConfig)}\n`, "utf-8");
+    }
+    const env = buildFinalizeEnv(
+      params.env ?? process.env,
+      effectiveChannel,
+      compatHostVersion,
+      sourceConfigPath,
+    );
     const spawnResult = await spawnFinalize({
       argv,
       cwd: path.dirname(entrypoint),
@@ -196,6 +219,10 @@ export async function runPostCoreFinalizeAfterGatewayUpdate(params: {
       entrypoint,
       message: err instanceof Error ? err.message : String(err),
     };
+  } finally {
+    if (sourceConfigDir) {
+      await fs.rm(sourceConfigDir, { recursive: true, force: true }).catch(() => undefined);
+    }
   }
 }
 

--- a/src/infra/update-post-core-finalize.ts
+++ b/src/infra/update-post-core-finalize.ts
@@ -17,6 +17,7 @@
 // and `runPostCorePluginConvergence`). Finalization never restarts, so the RPC
 // handler keeps ownership of the gateway restart.
 import path from "node:path";
+import { GATEWAY_SERVICE_RUNTIME_PID_ENV } from "../daemon/constants.js";
 import { resolveGatewayInstallEntrypoint } from "../daemon/gateway-entrypoint.js";
 import { runCommandWithTimeout } from "../process/exec.js";
 import { resolveStableNodePath } from "./stable-node-path.js";
@@ -24,6 +25,22 @@ import type { UpdateChannel } from "./update-channels.js";
 import type { UpdateRunResult } from "./update-runner.js";
 
 const DEFAULT_FINALIZE_TIMEOUT_MS = 30 * 60_000;
+
+// Strip the running gateway's service identity from the finalizer child so it is
+// not mistaken for the managed service process (matches the CLI post-core spawn).
+function buildFinalizeEnv(
+  baseEnv: NodeJS.ProcessEnv,
+  compatHostVersion?: string,
+): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...baseEnv };
+  delete env.OPENCLAW_SERVICE_MARKER;
+  delete env.OPENCLAW_SERVICE_KIND;
+  delete env[GATEWAY_SERVICE_RUNTIME_PID_ENV];
+  if (compatHostVersion) {
+    env.OPENCLAW_COMPATIBILITY_HOST_VERSION = compatHostVersion;
+  }
+  return env;
+}
 
 export type PostCoreFinalizeOutcome =
   | { status: "skipped"; reason: "not-git-update" | "entrypoint-missing" }
@@ -50,6 +67,25 @@ const defaultFinalizeSpawner: PostCoreFinalizeSpawner = async ({ argv, cwd, time
   return { code: res.code, ...(res.stderr ? { stderr: res.stderr } : {}) };
 };
 
+function normalizeOptionalString(value: string | null | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+// A no-op git update (same SHA and version) has nothing new to converge against,
+// so skip finalize to avoid an unnecessary doctor/convergence run. Mirrors the
+// CLI's `shouldResumePostCoreUpdateInFreshProcess` git resume gate.
+function gitCoreChanged(result: UpdateRunResult): boolean {
+  const beforeSha = normalizeOptionalString(result.before?.sha);
+  const afterSha = normalizeOptionalString(result.after?.sha);
+  if (beforeSha && afterSha && beforeSha !== afterSha) {
+    return true;
+  }
+  const beforeVersion = normalizeOptionalString(result.before?.version);
+  const afterVersion = normalizeOptionalString(result.after?.version);
+  return Boolean(beforeVersion && afterVersion && beforeVersion !== afterVersion);
+}
+
 // Only git/source updates routed through `runGatewayUpdate` defer-and-drop
 // plugin convergence. Package-manager/global installs already converge because
 // the RPC routes them through `startManagedServiceUpdateHandoff`, which
@@ -61,7 +97,8 @@ function isGitUpdateNeedingFinalize(
     result.status === "ok" &&
     result.mode === "git" &&
     typeof result.root === "string" &&
-    result.root.length > 0
+    result.root.length > 0 &&
+    gitCoreChanged(result)
   );
 }
 
@@ -123,10 +160,7 @@ export async function runPostCoreFinalizeAfterGatewayUpdate(params: {
   // Pin the finalizer's host-compat resolution to the just-installed core
   // version so plugins reconcile against the new core, not the running process.
   const compatHostVersion = result.after?.version ?? undefined;
-  const baseEnv = params.env ?? process.env;
-  const env: NodeJS.ProcessEnv = compatHostVersion
-    ? { ...baseEnv, OPENCLAW_COMPATIBILITY_HOST_VERSION: compatHostVersion }
-    : { ...baseEnv };
+  const env = buildFinalizeEnv(params.env ?? process.env, compatHostVersion);
 
   try {
     const spawnResult = await spawnFinalize({

--- a/src/infra/update-post-core-finalize.ts
+++ b/src/infra/update-post-core-finalize.ts
@@ -1,0 +1,186 @@
+// Resume post-core plugin convergence after a gateway control-plane git/source
+// update.
+//
+// `runGatewayUpdate` (git mode) runs `openclaw doctor --fix` with
+// `OPENCLAW_UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE=1`, which makes the doctor
+// pass DEFER configured-plugin repair to a later convergence step (see
+// `shouldDeferConfiguredPluginInstallRepair`). The `openclaw update` CLI resumes
+// that deferred work in a fresh post-core process; the gateway `update.run` RPC
+// did not, so a git/source core update would restart on the new core with stale
+// official plugins still pinned to versions built against removed core APIs.
+//
+// This helper closes that CLI/RPC asymmetry by spawning the freshly-built
+// binary's hidden `openclaw update finalize` entrypoint — the designed
+// "external core runtime change" finalizer that runs doctor plus
+// `updatePluginsAfterCoreUpdate` (which calls
+// `updateNpmInstalledPlugins({ syncOfficialPluginInstalls: true, disableOnFailure: true })`
+// and `runPostCorePluginConvergence`). Finalization never restarts, so the RPC
+// handler keeps ownership of the gateway restart.
+import path from "node:path";
+import { resolveGatewayInstallEntrypoint } from "../daemon/gateway-entrypoint.js";
+import { runCommandWithTimeout } from "../process/exec.js";
+import { resolveStableNodePath } from "./stable-node-path.js";
+import type { UpdateChannel } from "./update-channels.js";
+import type { UpdateRunResult } from "./update-runner.js";
+
+const DEFAULT_FINALIZE_TIMEOUT_MS = 30 * 60_000;
+
+export type PostCoreFinalizeOutcome =
+  | { status: "skipped"; reason: "not-git-update" | "entrypoint-missing" }
+  | { status: "ok"; entrypoint: string }
+  | {
+      status: "error";
+      reason: "nonzero-exit" | "spawn-failed";
+      entrypoint: string;
+      exitCode?: number;
+      message?: string;
+    };
+
+type FinalizeSpawnResult = { code: number | null; stderr?: string };
+
+export type PostCoreFinalizeSpawner = (params: {
+  argv: string[];
+  cwd: string;
+  timeoutMs: number;
+  env: NodeJS.ProcessEnv;
+}) => Promise<FinalizeSpawnResult>;
+
+const defaultFinalizeSpawner: PostCoreFinalizeSpawner = async ({ argv, cwd, timeoutMs, env }) => {
+  const res = await runCommandWithTimeout(argv, { cwd, timeoutMs, env });
+  return { code: res.code, ...(res.stderr ? { stderr: res.stderr } : {}) };
+};
+
+// Only git/source updates routed through `runGatewayUpdate` defer-and-drop
+// plugin convergence. Package-manager/global installs already converge because
+// the RPC routes them through `startManagedServiceUpdateHandoff`, which
+// re-enters the full `openclaw update` CLI.
+function isGitUpdateNeedingFinalize(
+  result: UpdateRunResult,
+): result is UpdateRunResult & { root: string } {
+  return (
+    result.status === "ok" &&
+    result.mode === "git" &&
+    typeof result.root === "string" &&
+    result.root.length > 0
+  );
+}
+
+function buildFinalizeArgv(params: {
+  nodePath: string;
+  entrypoint: string;
+  channel?: UpdateChannel;
+  timeoutMs?: number;
+}): string[] {
+  const argv = [
+    params.nodePath,
+    params.entrypoint,
+    "update",
+    "finalize",
+    "--json",
+    "--yes",
+    "--no-restart",
+  ];
+  if (params.channel) {
+    argv.push("--channel", params.channel);
+  }
+  if (typeof params.timeoutMs === "number" && Number.isFinite(params.timeoutMs)) {
+    // `update finalize --timeout` is per-step seconds.
+    argv.push("--timeout", String(Math.max(1, Math.ceil(params.timeoutMs / 1000))));
+  }
+  return argv;
+}
+
+export async function runPostCoreFinalizeAfterGatewayUpdate(params: {
+  result: UpdateRunResult;
+  channel?: UpdateChannel;
+  timeoutMs?: number;
+  resolveEntrypoint?: (root: string) => Promise<string | undefined>;
+  spawnFinalize?: PostCoreFinalizeSpawner;
+  env?: NodeJS.ProcessEnv;
+}): Promise<PostCoreFinalizeOutcome> {
+  const { result } = params;
+  if (!isGitUpdateNeedingFinalize(result)) {
+    return { status: "skipped", reason: "not-git-update" };
+  }
+  const resolveEntrypoint = params.resolveEntrypoint ?? resolveGatewayInstallEntrypoint;
+  const entrypoint = await resolveEntrypoint(result.root);
+  if (!entrypoint) {
+    return { status: "skipped", reason: "entrypoint-missing" };
+  }
+
+  const spawnFinalize = params.spawnFinalize ?? defaultFinalizeSpawner;
+  const timeoutMs =
+    typeof params.timeoutMs === "number" && Number.isFinite(params.timeoutMs)
+      ? params.timeoutMs
+      : undefined;
+  const nodePath = await resolveStableNodePath(process.execPath);
+  const argv = buildFinalizeArgv({
+    nodePath,
+    entrypoint,
+    ...(params.channel ? { channel: params.channel } : {}),
+    ...(timeoutMs === undefined ? {} : { timeoutMs }),
+  });
+  // Pin the finalizer's host-compat resolution to the just-installed core
+  // version so plugins reconcile against the new core, not the running process.
+  const compatHostVersion = result.after?.version ?? undefined;
+  const baseEnv = params.env ?? process.env;
+  const env: NodeJS.ProcessEnv = compatHostVersion
+    ? { ...baseEnv, OPENCLAW_COMPATIBILITY_HOST_VERSION: compatHostVersion }
+    : { ...baseEnv };
+
+  try {
+    const spawnResult = await spawnFinalize({
+      argv,
+      cwd: path.dirname(entrypoint),
+      timeoutMs: timeoutMs ?? DEFAULT_FINALIZE_TIMEOUT_MS,
+      env,
+    });
+    if (spawnResult.code === 0) {
+      return { status: "ok", entrypoint };
+    }
+    return {
+      status: "error",
+      reason: "nonzero-exit",
+      entrypoint,
+      ...(typeof spawnResult.code === "number" ? { exitCode: spawnResult.code } : {}),
+      ...(spawnResult.stderr ? { message: spawnResult.stderr } : {}),
+    };
+  } catch (err) {
+    return {
+      status: "error",
+      reason: "spawn-failed",
+      entrypoint,
+      message: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+// Fold a finalize failure into the update result so the RPC handler's existing
+// `result.status === "ok"` restart gate skips the restart: restarting on the new
+// core after convergence failed would load the stale plugins we just failed to
+// reconcile. Mirrors the CLI, which exits non-zero before restarting on
+// post-core convergence failure.
+export function foldPostCoreFinalizeIntoResult(
+  result: UpdateRunResult,
+  outcome: PostCoreFinalizeOutcome,
+): UpdateRunResult {
+  if (outcome.status !== "error") {
+    return result;
+  }
+  return {
+    ...result,
+    status: "error",
+    reason: "post-core-plugin-finalize-failed",
+    steps: [
+      ...result.steps,
+      {
+        name: "post-core plugin finalize",
+        command: "openclaw update finalize",
+        cwd: result.root ?? process.cwd(),
+        durationMs: 0,
+        exitCode: outcome.reason === "nonzero-exit" ? (outcome.exitCode ?? 1) : 1,
+        ...(outcome.message ? { stderrTail: outcome.message } : {}),
+      },
+    ],
+  };
+}

--- a/src/infra/update-post-core-finalize.ts
+++ b/src/infra/update-post-core-finalize.ts
@@ -21,7 +21,7 @@ import { GATEWAY_SERVICE_RUNTIME_PID_ENV } from "../daemon/constants.js";
 import { resolveGatewayInstallEntrypoint } from "../daemon/gateway-entrypoint.js";
 import { runCommandWithTimeout } from "../process/exec.js";
 import { resolveStableNodePath } from "./stable-node-path.js";
-import { DEFAULT_GIT_CHANNEL, type UpdateChannel } from "./update-channels.js";
+import type { UpdateChannel } from "./update-channels.js";
 import type { UpdateRunResult } from "./update-runner.js";
 
 // Whole-process backstop for the finalizer. `update finalize` runs several timed
@@ -158,16 +158,17 @@ export async function runPostCoreFinalizeAfterGatewayUpdate(params: {
     typeof params.timeoutMs === "number" && Number.isFinite(params.timeoutMs)
       ? params.timeoutMs
       : undefined;
-  // This helper only runs for git/source updates, where `runGatewayUpdate`
-  // defaults the core update to the git/dev channel (`opts.channel ?? "dev"`).
-  // Match it so the finalizer converges official plugins on the same channel as
-  // the core update instead of falling back to the package (stable) channel.
-  const channel = params.channel ?? DEFAULT_GIT_CHANNEL;
+  // Only forward `--channel` when the caller actually has a configured channel.
+  // `update finalize` treats any `--channel` as an explicit request and persists
+  // it to `openclaw.json` (`persistRequestedUpdateChannel`); emitting a defaulted
+  // channel here would write a channel the user never requested. When omitted,
+  // the finalizer converges on the stored/default channel — the reconcile still
+  // resolves a host-compatible version, it just does not mutate config.
   const nodePath = await resolveStableNodePath(process.execPath);
   const argv = buildFinalizeArgv({
     nodePath,
     entrypoint,
-    channel,
+    ...(params.channel ? { channel: params.channel } : {}),
     ...(perStepTimeoutMs === undefined ? {} : { timeoutMs: perStepTimeoutMs }),
   });
   // Pin the finalizer's host-compat resolution to the just-installed core

--- a/src/infra/update-post-core-finalize.ts
+++ b/src/infra/update-post-core-finalize.ts
@@ -21,10 +21,18 @@ import { GATEWAY_SERVICE_RUNTIME_PID_ENV } from "../daemon/constants.js";
 import { resolveGatewayInstallEntrypoint } from "../daemon/gateway-entrypoint.js";
 import { runCommandWithTimeout } from "../process/exec.js";
 import { resolveStableNodePath } from "./stable-node-path.js";
-import type { UpdateChannel } from "./update-channels.js";
+import { DEFAULT_GIT_CHANNEL, type UpdateChannel } from "./update-channels.js";
 import type { UpdateRunResult } from "./update-runner.js";
 
-const DEFAULT_FINALIZE_TIMEOUT_MS = 30 * 60_000;
+// Whole-process backstop for the finalizer. `update finalize` runs several timed
+// steps (doctor + plugin update/convergence), each bounded by its own per-step
+// `--timeout`. The outer process kill must therefore be larger than a single
+// per-step bound, or a valid multi-step run would be killed and falsely reported
+// as `post-core-plugin-finalize-failed` (blocking the restart). We use a generous
+// floor and, when a larger per-step timeout is requested, scale the outer bound
+// above it rather than reusing the per-step value as the whole-process kill.
+const FINALIZE_PROCESS_TIMEOUT_FLOOR_MS = 30 * 60_000;
+const FINALIZE_PROCESS_STEP_BUDGET_MULTIPLIER = 6;
 
 // Strip the running gateway's service identity from the finalizer child so it is
 // not mistaken for the managed service process (matches the CLI post-core spawn).
@@ -146,27 +154,37 @@ export async function runPostCoreFinalizeAfterGatewayUpdate(params: {
   }
 
   const spawnFinalize = params.spawnFinalize ?? defaultFinalizeSpawner;
-  const timeoutMs =
+  const perStepTimeoutMs =
     typeof params.timeoutMs === "number" && Number.isFinite(params.timeoutMs)
       ? params.timeoutMs
       : undefined;
+  // This helper only runs for git/source updates, where `runGatewayUpdate`
+  // defaults the core update to the git/dev channel (`opts.channel ?? "dev"`).
+  // Match it so the finalizer converges official plugins on the same channel as
+  // the core update instead of falling back to the package (stable) channel.
+  const channel = params.channel ?? DEFAULT_GIT_CHANNEL;
   const nodePath = await resolveStableNodePath(process.execPath);
   const argv = buildFinalizeArgv({
     nodePath,
     entrypoint,
-    ...(params.channel ? { channel: params.channel } : {}),
-    ...(timeoutMs === undefined ? {} : { timeoutMs }),
+    channel,
+    ...(perStepTimeoutMs === undefined ? {} : { timeoutMs: perStepTimeoutMs }),
   });
   // Pin the finalizer's host-compat resolution to the just-installed core
   // version so plugins reconcile against the new core, not the running process.
   const compatHostVersion = result.after?.version ?? undefined;
   const env = buildFinalizeEnv(params.env ?? process.env, compatHostVersion);
+  // Outer whole-process backstop, decoupled from the per-step `--timeout` above.
+  const processTimeoutMs = Math.max(
+    FINALIZE_PROCESS_TIMEOUT_FLOOR_MS,
+    (perStepTimeoutMs ?? 0) * FINALIZE_PROCESS_STEP_BUDGET_MULTIPLIER,
+  );
 
   try {
     const spawnResult = await spawnFinalize({
       argv,
       cwd: path.dirname(entrypoint),
-      timeoutMs: timeoutMs ?? DEFAULT_FINALIZE_TIMEOUT_MS,
+      timeoutMs: processTimeoutMs,
       env,
     });
     if (spawnResult.code === 0) {

--- a/src/infra/update-post-core-finalize.ts
+++ b/src/infra/update-post-core-finalize.ts
@@ -21,7 +21,11 @@ import { GATEWAY_SERVICE_RUNTIME_PID_ENV } from "../daemon/constants.js";
 import { resolveGatewayInstallEntrypoint } from "../daemon/gateway-entrypoint.js";
 import { runCommandWithTimeout } from "../process/exec.js";
 import { resolveStableNodePath } from "./stable-node-path.js";
-import type { UpdateChannel } from "./update-channels.js";
+import {
+  DEFAULT_GIT_CHANNEL,
+  type UpdateChannel,
+  UPDATE_EFFECTIVE_CHANNEL_ENV,
+} from "./update-channels.js";
 import type { UpdateRunResult } from "./update-runner.js";
 
 // Whole-process backstop for the finalizer. `update finalize` runs several timed
@@ -36,14 +40,20 @@ const FINALIZE_PROCESS_STEP_BUDGET_MULTIPLIER = 6;
 
 // Strip the running gateway's service identity from the finalizer child so it is
 // not mistaken for the managed service process (matches the CLI post-core spawn).
+// Also carry the effective update channel so convergence runs on the channel the
+// core update actually used (git/dev for an unconfigured source update) — passed
+// as the *effective* channel, never a *requested* one, so `update finalize` does
+// not persist `update.channel`.
 function buildFinalizeEnv(
   baseEnv: NodeJS.ProcessEnv,
+  effectiveChannel: UpdateChannel,
   compatHostVersion?: string,
 ): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = { ...baseEnv };
   delete env.OPENCLAW_SERVICE_MARKER;
   delete env.OPENCLAW_SERVICE_KIND;
   delete env[GATEWAY_SERVICE_RUNTIME_PID_ENV];
+  env[UPDATE_EFFECTIVE_CHANNEL_ENV] = effectiveChannel;
   if (compatHostVersion) {
     env.OPENCLAW_COMPATIBILITY_HOST_VERSION = compatHostVersion;
   }
@@ -113,9 +123,10 @@ function isGitUpdateNeedingFinalize(
 function buildFinalizeArgv(params: {
   nodePath: string;
   entrypoint: string;
-  channel?: UpdateChannel;
   timeoutMs?: number;
 }): string[] {
+  // No `--channel`: the effective channel is passed via env (convergence-only,
+  // not persisted). `update finalize` would persist any `--channel` it sees.
   const argv = [
     params.nodePath,
     params.entrypoint,
@@ -125,9 +136,6 @@ function buildFinalizeArgv(params: {
     "--yes",
     "--no-restart",
   ];
-  if (params.channel) {
-    argv.push("--channel", params.channel);
-  }
   if (typeof params.timeoutMs === "number" && Number.isFinite(params.timeoutMs)) {
     // `update finalize --timeout` is per-step seconds.
     argv.push("--timeout", String(Math.max(1, Math.ceil(params.timeoutMs / 1000))));
@@ -158,23 +166,23 @@ export async function runPostCoreFinalizeAfterGatewayUpdate(params: {
     typeof params.timeoutMs === "number" && Number.isFinite(params.timeoutMs)
       ? params.timeoutMs
       : undefined;
-  // Only forward `--channel` when the caller actually has a configured channel.
-  // `update finalize` treats any `--channel` as an explicit request and persists
-  // it to `openclaw.json` (`persistRequestedUpdateChannel`); emitting a defaulted
-  // channel here would write a channel the user never requested. When omitted,
-  // the finalizer converges on the stored/default channel — the reconcile still
-  // resolves a host-compatible version, it just does not mutate config.
+  // This helper only runs for git/source updates, where `runGatewayUpdate` ran
+  // the core update on `configChannel ?? DEFAULT_GIT_CHANNEL` (dev). Carry that
+  // same effective channel into the finalizer so plugin convergence matches the
+  // core update instead of falling back to the package (stable) channel. It is
+  // passed via env as the *effective* (not requested) channel, so the finalizer
+  // does not persist `update.channel` when the user never configured one.
+  const effectiveChannel: UpdateChannel = params.channel ?? DEFAULT_GIT_CHANNEL;
   const nodePath = await resolveStableNodePath(process.execPath);
   const argv = buildFinalizeArgv({
     nodePath,
     entrypoint,
-    ...(params.channel ? { channel: params.channel } : {}),
     ...(perStepTimeoutMs === undefined ? {} : { timeoutMs: perStepTimeoutMs }),
   });
   // Pin the finalizer's host-compat resolution to the just-installed core
   // version so plugins reconcile against the new core, not the running process.
   const compatHostVersion = result.after?.version ?? undefined;
-  const env = buildFinalizeEnv(params.env ?? process.env, compatHostVersion);
+  const env = buildFinalizeEnv(params.env ?? process.env, effectiveChannel, compatHostVersion);
   // Outer whole-process backstop, decoupled from the per-step `--timeout` above.
   const processTimeoutMs = Math.max(
     FINALIZE_PROCESS_TIMEOUT_FLOOR_MS,

--- a/src/infra/update-post-core-finalize.ts
+++ b/src/infra/update-post-core-finalize.ts
@@ -20,6 +20,7 @@ import path from "node:path";
 import { GATEWAY_SERVICE_RUNTIME_PID_ENV } from "../daemon/constants.js";
 import { resolveGatewayInstallEntrypoint } from "../daemon/gateway-entrypoint.js";
 import { runCommandWithTimeout } from "../process/exec.js";
+import { trimLogTail } from "./restart-sentinel.js";
 import { resolveStableNodePath } from "./stable-node-path.js";
 import {
   DEFAULT_GIT_CHANNEL,
@@ -85,29 +86,12 @@ const defaultFinalizeSpawner: PostCoreFinalizeSpawner = async ({ argv, cwd, time
   return { code: res.code, ...(res.stderr ? { stderr: res.stderr } : {}) };
 };
 
-function normalizeOptionalString(value: string | null | undefined): string | undefined {
-  const trimmed = value?.trim();
-  return trimmed ? trimmed : undefined;
-}
-
-// A no-op git update (same SHA and version) has nothing new to converge against,
-// so skip finalize to avoid an unnecessary doctor/convergence run. Mirrors the
-// CLI's `shouldResumePostCoreUpdateInFreshProcess` git resume gate.
-function gitCoreChanged(result: UpdateRunResult): boolean {
-  const beforeSha = normalizeOptionalString(result.before?.sha);
-  const afterSha = normalizeOptionalString(result.after?.sha);
-  if (beforeSha && afterSha && beforeSha !== afterSha) {
-    return true;
-  }
-  const beforeVersion = normalizeOptionalString(result.before?.version);
-  const afterVersion = normalizeOptionalString(result.after?.version);
-  return Boolean(beforeVersion && afterVersion && beforeVersion !== afterVersion);
-}
-
 // Only git/source updates routed through `runGatewayUpdate` defer-and-drop
 // plugin convergence. Package-manager/global installs already converge because
 // the RPC routes them through `startManagedServiceUpdateHandoff`, which
-// re-enters the full `openclaw update` CLI.
+// re-enters the full `openclaw update` CLI. Re-run convergence on no-op retries:
+// an earlier finalizer failure must not be bypassed by a same-SHA update that
+// would otherwise restart the gateway with stale plugins.
 function isGitUpdateNeedingFinalize(
   result: UpdateRunResult,
 ): result is UpdateRunResult & { root: string } {
@@ -115,8 +99,7 @@ function isGitUpdateNeedingFinalize(
     result.status === "ok" &&
     result.mode === "git" &&
     typeof result.root === "string" &&
-    result.root.length > 0 &&
-    gitCoreChanged(result)
+    result.root.length > 0
   );
 }
 
@@ -240,7 +223,7 @@ export function foldPostCoreFinalizeIntoResult(
         cwd: result.root ?? process.cwd(),
         durationMs: 0,
         exitCode: outcome.reason === "nonzero-exit" ? (outcome.exitCode ?? 1) : 1,
-        ...(outcome.message ? { stderrTail: outcome.message } : {}),
+        ...(outcome.message ? { stderrTail: trimLogTail(outcome.message) } : {}),
       },
     ],
   };


### PR DESCRIPTION
## Summary

What problem does this PR solve? The gateway `update.run` RPC updates git/source installs via `runGatewayUpdate`, but — unlike the `openclaw update` CLI — it never resumed the post-core plugin convergence that `runGatewayUpdate`'s doctor pass *defers*. After a git/source core update through the control plane, official managed plugins stayed at versions built against the previous core, and the gateway restarted onto the new core without reconciling them.

Why does this matter now? `runGatewayUpdate` (git mode) runs `openclaw doctor --fix` with `OPENCLAW_UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE=1`, which makes the doctor pass *defer* configured-plugin repair to a later convergence step (`shouldDeferConfiguredPluginInstallRepair` in `src/commands/doctor/shared/update-phase.ts`). The CLI resumes that deferred work; the RPC git path dropped it.

What is the intended outcome? After a successful git/source update through `update.run`, official managed plugins reconcile to a host-compatible version — the same post-core convergence the CLI already runs — and a failed convergence does not restart onto the new core.

What is intentionally out of scope? This PR is limited to the RPC git/source update path and does not change startup plugin admission or plugin selection outside the existing post-core finalizer. The finalizer is spawned only after a successful update, never in the gateway boot path (no npm install on boot).

What should reviewers focus on?
- The CLI/RPC asymmetry: the CLI resumes post-core convergence via `continuePostCoreUpdateInFreshProcess` → `runPostCorePluginUpdate` → `updatePluginsAfterCoreUpdate` (`src/cli/update-cli/update-command.ts`), which calls `updateNpmInstalledPlugins({ syncOfficialPluginInstalls: true, disableOnFailure: true })` + `runPostCorePluginConvergence`. The RPC git path (`src/gateway/server-methods/update.ts`) did not. This PR makes the RPC path resume that work by spawning the existing hidden `openclaw update finalize` entrypoint (`updateFinalizeCommand`), which runs the same convergence with `restart: false`.
- The dispatch decision `isGitUpdateNeedingFinalize` (git-mode + actual core change, mirroring the CLI resume gate in `shouldResumePostCoreUpdateInFreshProcess`).
- The restart-blocking fold on finalize failure (`foldPostCoreFinalizeIntoResult`): a failed convergence marks the result failed so the existing `result.status === "ok"` restart gate skips the restart — mirroring the CLI, which exits non-zero before restarting on post-core convergence failure.
- The spawned child env: gateway service identity stripped, host-compat version pinned to the just-installed core.
- Channel handling (required for the resume to be correct, not separable hardening): the git/source core update runs on the effective git channel (`runGatewayUpdate` uses `opts.channel ?? "dev"`). The finalizer is given that same effective channel (`configChannel ?? DEFAULT_GIT_CHANNEL`) via `OPENCLAW_UPDATE_EFFECTIVE_CHANNEL` so convergence matches the core update instead of falling back to the stable package channel. This mirrors the CLI post-core resume's effective/requested split: it is passed as an effective (not requested) channel, so `update finalize` never persists `update.channel` for a default source update. The whole-process spawn timeout is also decoupled from the per-step `--timeout`, so a valid multi-step finalize is not killed and falsely reported as failed (which would wrongly block the restart).

## Linked context

This PR does not close an issue.

Was this requested by a maintainer or owner? No.

## Real behavior proof (required for external PRs)

- Main limitation up front: this is not a full live over-the-wire `update.run` round-trip driven to a successful core update (see "What was not tested"); the success path is shown via the production seam plus unit tests.
- Behavior addressed: the `update.run` RPC git/source update path now resumes post-core official-plugin convergence after a successful core update; a failed convergence blocks the restart.
- Real environment tested: disposable local runtime only — a temp `OPENCLAW_STATE_DIR`/`HOME` (and, for the RPC-handler check, a `git clone --local` disposable install + a local `file://` bare remote). The host under test is a dev/source build reporting version 2026.6.2 (this branch), not a released tag. Public npm registry used read-only into temp state. No production state, no secrets.
- Exact steps or command run after this patch:
  - Seed a stale external official plugin: `openclaw plugins install npm:@openclaw/tokenjuice@2026.5.28 --pin` into a temp state dir.
  - Before/after: with no post-core finalize invoked (the pre-fix `update.run` git path, whose else-branch had no finalize call), then with the command this patch resumes — `openclaw update finalize --json --yes --no-restart`.
  - Production seam: drive the patch's `runPostCoreFinalizeAfterGatewayUpdate({ result: <git-ok>, channel })` (real entrypoint resolve + real `update finalize` spawn) in a real node process.
  - Effective channel (no-config source update): seed the stale plugin with no `update.channel` configured, then run `update finalize --json --yes --no-restart` with `OPENCLAW_UPDATE_EFFECTIVE_CHANNEL=dev` and no `--channel`.
  - Handler boundary: invoke the real `updateHandlers["update.run"]` against the disposable git install so the real `runGatewayUpdate` git path executes.
- Evidence after fix: with no finalize invoked (the pre-fix path) the stale record stays `@openclaw/tokenjuice@2026.5.28` — not reconciled. With the resumed `openclaw update finalize --json --yes --no-restart`, the finalizer logged `Removed stale managed install record for bundled plugin "tokenjuice"` and the record was reconciled to a host-compatible version (`2026.6.2` on this build). Driving `runPostCoreFinalizeAfterGatewayUpdate` with a git-ok result returned `{status:"ok"}` and reconciled the plugin, and the fold mapped to a proceed-with-restart result. The real `update.run` handler was confirmed to execute the real git path; a finalizer failure marks the result failed so the restart is skipped, and an unsuccessful update does not invoke finalize and leaves `restart` null (fail-safe). For a no-config source update, `update finalize` with `OPENCLAW_UPDATE_EFFECTIVE_CHANNEL=dev` (no `--channel`) reported `channel: dev`, reconciled the stale plugin on that effective channel, and left `update.channel` unset (not persisted).
- Observed result after fix: the update seam this patch adds calls the real post-core convergence machinery and the official plugin is actually reconciled to a host-compatible version; a failed convergence blocks the restart.
- What was not tested: this is not a full live over-the-wire `update.run` round-trip driven to a successful core update — `runGatewayUpdate`'s preflight builds up to ten ancestor commits, which a disposable clone of the full history cannot build cleanly, so the success path is shown via the production seam (`runPostCoreFinalizeAfterGatewayUpdate` + real `update finalize`) plus unit tests rather than a full successful RPC round-trip. Also not tested: other update entrypoints, live deployments, and channel-specific end-to-end behavior, plus the npm→npm version-bump axis (this host is a dev/source build that bundles official plugins, so convergence resolves the host-compatible version to the bundled one; the npm→npm bump on a packaged install was not exercised here).
- Proof limitations: disposable runtime only; the over-the-wire success path is bridged by the production seam plus unit tests, not a full successful RPC round-trip.

Unit tests (no network): `src/infra/update-post-core-finalize.test.ts`, `src/gateway/server-methods/update.test.ts`, and `src/cli/update-cli.test.ts` — the handler invokes finalize on a git-ok result; finalize argv/env (service-identity strip + host-version pin); the effective channel is carried via `OPENCLAW_UPDATE_EFFECTIVE_CHANNEL` (git/dev by default) with no `--channel`; `update finalize` converges on the effective channel without persisting `update.channel` when none was requested; `--timeout` only when provided; no-op skip; nonzero-exit/spawn-throw; the fold blocks restart on finalize failure; and the managed-service handoff path skips finalize. Local gates green: tsgo core+test, oxlint, oxfmt, import-cycles (0), `pnpm build`.
