### PR TITLE
docs: preserve channel brand terms in Chinese i18n

### DIFF
--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -620,6 +620,10 @@
     "target": "QQ Bot"
   },
   {
+    "source": "QQBot",
+    "target": "QQ Bot"
+  },
+  {
     "source": "Release Policy",
     "target": "发布策略"
   },

--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -264,8 +264,64 @@
     "target": "Feishu"
   },
   {
+    "source": "ClickClack",
+    "target": "ClickClack"
+  },
+  {
+    "source": "IRC",
+    "target": "IRC"
+  },
+  {
+    "source": "LINE",
+    "target": "LINE"
+  },
+  {
+    "source": "Nextcloud Talk",
+    "target": "Nextcloud Talk"
+  },
+  {
+    "source": "Nostr",
+    "target": "Nostr"
+  },
+  {
+    "source": "QQ bot",
+    "target": "QQ Bot"
+  },
+  {
+    "source": "SMS",
+    "target": "SMS"
+  },
+  {
+    "source": "Synology Chat",
+    "target": "Synology Chat"
+  },
+  {
+    "source": "Tlon",
+    "target": "Tlon"
+  },
+  {
+    "source": "Twitch",
+    "target": "Twitch"
+  },
+  {
+    "source": "Twilio",
+    "target": "Twilio"
+  },
+  {
     "source": "Yuanbao",
     "target": "腾讯元宝"
+  },
+  {
+    "source": "Zalo",
+    "target": "Zalo"
+  },
+  {
+    "source": "Zalo Personal",
+    "target": "Zalo Personal"
+  },
+  {
+    "source": "Zalo personal",
+    "target": "Zalo Personal"
   },
   {
     "source": "WeChat",

--- a/docs/.i18n/glossary.zh-TW.json
+++ b/docs/.i18n/glossary.zh-TW.json
@@ -12,6 +12,10 @@
     "target": "ClawHub"
   },
   {
+    "source": "ClickClack",
+    "target": "ClickClack"
+  },
+  {
     "source": "CLI",
     "target": "命令列介面"
   },
@@ -36,12 +40,36 @@
     "target": "心跳偵測"
   },
   {
+    "source": "Feishu",
+    "target": "Feishu"
+  },
+  {
+    "source": "IRC",
+    "target": "IRC"
+  },
+  {
+    "source": "LINE",
+    "target": "LINE"
+  },
+  {
+    "source": "Mattermost",
+    "target": "Mattermost"
+  },
+  {
     "source": "Mintlify",
     "target": "Mintlify"
   },
   {
+    "source": "Nextcloud Talk",
+    "target": "Nextcloud Talk"
+  },
+  {
     "source": "Node",
     "target": "節點"
+  },
+  {
+    "source": "Nostr",
+    "target": "Nostr"
   },
   {
     "source": "OpenClaw",
@@ -56,8 +84,24 @@
     "target": "外掛"
   },
   {
+    "source": "QQ Bot",
+    "target": "QQ Bot"
+  },
+  {
+    "source": "QQ bot",
+    "target": "QQ Bot"
+  },
+  {
+    "source": "SMS",
+    "target": "SMS"
+  },
+  {
     "source": "Skills",
     "target": "Skills"
+  },
+  {
+    "source": "Synology Chat",
+    "target": "Synology Chat"
   },
   {
     "source": "Tailscale",
@@ -68,11 +112,47 @@
     "target": "TaskFlow"
   },
   {
+    "source": "Tlon",
+    "target": "Tlon"
+  },
+  {
+    "source": "Twitch",
+    "target": "Twitch"
+  },
+  {
+    "source": "Twilio",
+    "target": "Twilio"
+  },
+  {
     "source": "TUI",
     "target": "終端介面"
   },
   {
+    "source": "WeChat",
+    "target": "微信"
+  },
+  {
+    "source": "Weixin",
+    "target": "微信"
+  },
+  {
     "source": "Webhook",
     "target": "網路鉤子"
+  },
+  {
+    "source": "Yuanbao",
+    "target": "騰訊元寶"
+  },
+  {
+    "source": "Zalo",
+    "target": "Zalo"
+  },
+  {
+    "source": "Zalo Personal",
+    "target": "Zalo Personal"
+  },
+  {
+    "source": "Zalo personal",
+    "target": "Zalo Personal"
   }
 ]

--- a/docs/.i18n/glossary.zh-TW.json
+++ b/docs/.i18n/glossary.zh-TW.json
@@ -88,6 +88,10 @@
     "target": "QQ Bot"
   },
   {
+    "source": "QQBot",
+    "target": "QQ Bot"
+  },
+  {
     "source": "QQ bot",
     "target": "QQ Bot"
   },


### PR DESCRIPTION
## Summary

- Add Simplified Chinese and Traditional Chinese docs i18n glossary entries for channel brand/product terms that should remain stable in generated translations.
- Cover LINE plus similar short channel names such as SMS, IRC, ClickClack, Nextcloud Talk, Nostr, Synology Chat, Tlon, Twitch, Twilio, Zalo, and Zalo Personal.
- Keep the fix glossary-only so the existing automatic docs translation pipeline remains the source of generated localized pages.

## Verification

- `jq -e . docs/.i18n/glossary.zh-CN.json`
- `jq -e . docs/.i18n/glossary.zh-TW.json`
- duplicate-source check for both Chinese glossary files
- channel brand coverage check for both Chinese glossary files
- `pnpm docs:check-i18n-glossary`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main`
