### PR TITLE
feat(qqbot): add /bot-group-allways command to toggle mention requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Docs: https://docs.openclaw.ai
 - Docs/tooling: add Parallel search docs, refresh weather-skill guidance toward `web_fetch`, clarify legacy `openai-codex` auth, document release/test helper scripts, and tighten changed-test routing docs for CI/debugging work. (#90028, #90250) Thanks @fuller-stack-dev.
 - Release/process: switch release trains to `YYYY.M.PATCH` monthly patch numbering, keep pre-transition tags compatible, and pin the June 2026 floor at `2026.6.5` after the published beta.
 - Platform maintenance: refresh Android, Swift/macOS, Docker, CodeQL, Buildx, Docker build/push, and Codex Action dependencies for this release train. (#74980, #81757, #86481, #86483, #90601)
+- QQBot: add `/bot-group-allways on|off` slash command (with named-account and default-account support) to toggle whether group messages require an `@mention` before the bot replies, and clear the runtime config snapshot after the write so the new account-level `defaultRequireMention` takes effect immediately without restart. (#91423) Thanks @cxyhhhhh.
 
 ### Fixes
 

--- a/extensions/qqbot/src/engine/commands/builtin/register-all.ts
+++ b/extensions/qqbot/src/engine/commands/builtin/register-all.ts
@@ -3,6 +3,7 @@ import type { SlashCommandRegistry } from "../slash-commands.js";
 import { registerApproveCommands } from "./register-approve.js";
 import { registerBasicBotCommands } from "./register-basic.js";
 import { registerClearStorageCommands } from "./register-clear-storage.js";
+import { registerGroupAllwaysCommand } from "./register-group-allways.js";
 import { registerLogCommands } from "./register-logs.js";
 import { registerStreamingCommands } from "./register-streaming.js";
 
@@ -15,4 +16,5 @@ export function registerBuiltinSlashCommands(registry: SlashCommandRegistry): vo
   registerClearStorageCommands(registry);
   registerStreamingCommands(registry);
   registerApproveCommands(registry);
+  registerGroupAllwaysCommand(registry);
 }

--- a/extensions/qqbot/src/engine/commands/builtin/register-group-allways.test.ts
+++ b/extensions/qqbot/src/engine/commands/builtin/register-group-allways.test.ts
@@ -1,17 +1,17 @@
 // Qqbot tests cover group-allways command plugin behavior.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { QueuedMessage } from "../gateway/message-queue.js";
-import type { GatewayAccount } from "../gateway/types.js";
-import { sendText } from "../messaging/sender.js";
-import { trySlashCommand } from "./slash-command-handler.js";
-import { getWrittenQQBotConfig, installCommandRuntime } from "./slash-command-test-support.js";
+import type { QueuedMessage } from "../../gateway/message-queue.js";
+import type { GatewayAccount } from "../../gateway/types.js";
+import { sendText } from "../../messaging/sender.js";
+import { trySlashCommand } from "../slash-command-handler.js";
+import { installCommandRuntime } from "../slash-command-test-support.js";
 
-vi.mock("../messaging/outbound.js", () => ({
+vi.mock("../../messaging/outbound.js", () => ({
   sendDocument: vi.fn(async () => undefined),
 }));
 
-vi.mock("../messaging/sender.js", () => ({
+vi.mock("../../messaging/sender.js", () => ({
   accountToCreds: vi.fn(() => ({ appId: "app", clientSecret: "" })),
   buildDeliveryTarget: vi.fn(() => ({ targetType: "c2c", targetId: "TRUSTED_OPENID" })),
   sendText: vi.fn(async () => undefined),

--- a/extensions/qqbot/src/engine/commands/builtin/register-group-allways.test.ts
+++ b/extensions/qqbot/src/engine/commands/builtin/register-group-allways.test.ts
@@ -1,0 +1,311 @@
+// Qqbot tests cover group-allways command plugin behavior.
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { QueuedMessage } from "../gateway/message-queue.js";
+import type { GatewayAccount } from "../gateway/types.js";
+import { sendText } from "../messaging/sender.js";
+import { trySlashCommand } from "./slash-command-handler.js";
+import { getWrittenQQBotConfig, installCommandRuntime } from "./slash-command-test-support.js";
+
+vi.mock("../messaging/outbound.js", () => ({
+  sendDocument: vi.fn(async () => undefined),
+}));
+
+vi.mock("../messaging/sender.js", () => ({
+  accountToCreds: vi.fn(() => ({ appId: "app", clientSecret: "" })),
+  buildDeliveryTarget: vi.fn(() => ({ targetType: "c2c", targetId: "TRUSTED_OPENID" })),
+  sendText: vi.fn(async () => undefined),
+}));
+
+function createGroupAllwaysMessage(arg = ""): QueuedMessage {
+  return {
+    type: "c2c",
+    senderId: "TRUSTED_OPENID",
+    content: `/bot-group-allways ${arg}`.trim(),
+    messageId: "msg-1",
+    timestamp: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+function createDefaultAccount(overrides?: Record<string, unknown>): GatewayAccount {
+  return {
+    accountId: "default",
+    appId: "app",
+    clientSecret: "",
+    markdownSupport: true,
+    config: {
+      allowFrom: ["*"],
+      defaultRequireMention: true,
+      ...overrides,
+    },
+  };
+}
+
+function createNamedAccount(
+  accountId = "bot-a",
+  overrides?: Record<string, unknown>,
+): GatewayAccount {
+  return {
+    accountId,
+    appId: "app",
+    clientSecret: "",
+    markdownSupport: true,
+    config: {
+      allowFrom: ["*"],
+      ...overrides,
+    },
+  };
+}
+
+type WrittenQQBotConfigWithAllways = {
+  defaultRequireMention?: unknown;
+  accounts?: Record<string, { defaultRequireMention?: unknown }>;
+};
+
+function getAllwaysConfig(
+  write: OpenClawConfig | undefined,
+): WrittenQQBotConfigWithAllways | undefined {
+  return write?.channels?.qqbot as WrittenQQBotConfigWithAllways | undefined;
+}
+
+describe("bot-group-allways command", () => {
+  beforeEach(() => {
+    vi.mocked(sendText).mockClear();
+  });
+
+  describe("no args — show current status", () => {
+    it("shows requireMention=true (off) when defaultRequireMention is true", async () => {
+      const writes: OpenClawConfig[] = [];
+      const config: OpenClawConfig = {
+        commands: {
+          allowFrom: { qqbot: ["TRUSTED_OPENID"] },
+        },
+        channels: {
+          qqbot: {
+            allowFrom: ["*"],
+            defaultRequireMention: true,
+          },
+        },
+      };
+      installCommandRuntime(config, writes);
+
+      const result = await trySlashCommand(createGroupAllwaysMessage(), {
+        account: createDefaultAccount(),
+        cfg: config,
+        getMessagePeerId: () => "c2c:TRUSTED_OPENID",
+        getQueueSnapshot: () => ({
+          totalPending: 0,
+          activeUsers: 0,
+          maxConcurrentUsers: 1,
+          senderPending: 0,
+        }),
+      });
+
+      expect(result).toBe("handled");
+      expect(writes).toHaveLength(0);
+      expect(vi.mocked(sendText).mock.calls.at(0)?.[1]).toContain("仅被 @ 时回复");
+    });
+
+    it("shows requireMention=false (on) when defaultRequireMention is false", async () => {
+      const writes: OpenClawConfig[] = [];
+      const config: OpenClawConfig = {
+        commands: {
+          allowFrom: { qqbot: ["TRUSTED_OPENID"] },
+        },
+        channels: {
+          qqbot: {
+            allowFrom: ["*"],
+            defaultRequireMention: false,
+          },
+        },
+      };
+      installCommandRuntime(config, writes);
+
+      const result = await trySlashCommand(createGroupAllwaysMessage(), {
+        account: createDefaultAccount({ defaultRequireMention: false }),
+        cfg: config,
+        getMessagePeerId: () => "c2c:TRUSTED_OPENID",
+        getQueueSnapshot: () => ({
+          totalPending: 0,
+          activeUsers: 0,
+          maxConcurrentUsers: 1,
+          senderPending: 0,
+        }),
+      });
+
+      expect(result).toBe("handled");
+      expect(vi.mocked(sendText).mock.calls.at(0)?.[1]).toContain("自主判断何时发言");
+    });
+  });
+
+  describe("toggle on/off", () => {
+    it("writes defaultRequireMention=false (on) for default account", async () => {
+      const writes: OpenClawConfig[] = [];
+      const config: OpenClawConfig = {
+        commands: {
+          allowFrom: { qqbot: ["TRUSTED_OPENID"] },
+        },
+        channels: {
+          qqbot: {
+            allowFrom: ["*"],
+            defaultRequireMention: true,
+          },
+        },
+      };
+      installCommandRuntime(config, writes);
+
+      const result = await trySlashCommand(createGroupAllwaysMessage("on"), {
+        account: createDefaultAccount(),
+        cfg: config,
+        getMessagePeerId: () => "c2c:TRUSTED_OPENID",
+        getQueueSnapshot: () => ({
+          totalPending: 0,
+          activeUsers: 0,
+          maxConcurrentUsers: 1,
+          senderPending: 0,
+        }),
+      });
+
+      expect(result).toBe("handled");
+      expect(writes).toHaveLength(1);
+      const qqbot = getAllwaysConfig(writes[0]);
+      expect(qqbot?.defaultRequireMention).toBe(false);
+      expect(vi.mocked(sendText).mock.calls.at(0)?.[1]).toContain("**on**");
+    });
+
+    it("writes defaultRequireMention=true (off) for default account", async () => {
+      const writes: OpenClawConfig[] = [];
+      const config: OpenClawConfig = {
+        commands: {
+          allowFrom: { qqbot: ["TRUSTED_OPENID"] },
+        },
+        channels: {
+          qqbot: {
+            allowFrom: ["*"],
+            defaultRequireMention: false,
+          },
+        },
+      };
+      installCommandRuntime(config, writes);
+
+      const result = await trySlashCommand(createGroupAllwaysMessage("off"), {
+        account: createDefaultAccount({ defaultRequireMention: false }),
+        cfg: config,
+        getMessagePeerId: () => "c2c:TRUSTED_OPENID",
+        getQueueSnapshot: () => ({
+          totalPending: 0,
+          activeUsers: 0,
+          maxConcurrentUsers: 1,
+          senderPending: 0,
+        }),
+      });
+
+      expect(result).toBe("handled");
+      expect(writes).toHaveLength(1);
+      const qqbot = getAllwaysConfig(writes[0]);
+      expect(qqbot?.defaultRequireMention).toBe(true);
+      expect(vi.mocked(sendText).mock.calls.at(0)?.[1]).toContain("**off**");
+    });
+
+    it("writes to accounts.{accountId}.defaultRequireMention for named accounts", async () => {
+      const writes: OpenClawConfig[] = [];
+      const config: OpenClawConfig = {
+        commands: {
+          allowFrom: { qqbot: ["TRUSTED_OPENID"] },
+        },
+        channels: {
+          qqbot: {
+            allowFrom: ["*"],
+            accounts: {
+              "bot-a": {},
+            },
+          },
+        },
+      };
+      installCommandRuntime(config, writes);
+
+      const result = await trySlashCommand(createGroupAllwaysMessage("on"), {
+        account: createNamedAccount("bot-a"),
+        cfg: config,
+        getMessagePeerId: () => "c2c:TRUSTED_OPENID",
+        getQueueSnapshot: () => ({
+          totalPending: 0,
+          activeUsers: 0,
+          maxConcurrentUsers: 1,
+          senderPending: 0,
+        }),
+      });
+
+      expect(result).toBe("handled");
+      expect(writes).toHaveLength(1);
+      const qqbot = getAllwaysConfig(writes[0]);
+      expect(qqbot?.accounts?.["bot-a"]?.defaultRequireMention).toBe(false);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("returns no-op when toggling to same state", async () => {
+      const writes: OpenClawConfig[] = [];
+      const config: OpenClawConfig = {
+        commands: {
+          allowFrom: { qqbot: ["TRUSTED_OPENID"] },
+        },
+        channels: {
+          qqbot: {
+            allowFrom: ["*"],
+            defaultRequireMention: true,
+          },
+        },
+      };
+      installCommandRuntime(config, writes);
+
+      // current is true (requireMention), try off → same state
+      const result = await trySlashCommand(createGroupAllwaysMessage("off"), {
+        account: createDefaultAccount(),
+        cfg: config,
+        getMessagePeerId: () => "c2c:TRUSTED_OPENID",
+        getQueueSnapshot: () => ({
+          totalPending: 0,
+          activeUsers: 0,
+          maxConcurrentUsers: 1,
+          senderPending: 0,
+        }),
+      });
+
+      expect(result).toBe("handled");
+      expect(writes).toHaveLength(0);
+      expect(vi.mocked(sendText).mock.calls.at(0)?.[1]).toContain("无需操作");
+    });
+
+    it("returns error for invalid argument", async () => {
+      const writes: OpenClawConfig[] = [];
+      const config: OpenClawConfig = {
+        commands: {
+          allowFrom: { qqbot: ["TRUSTED_OPENID"] },
+        },
+        channels: {
+          qqbot: {
+            allowFrom: ["*"],
+          },
+        },
+      };
+      installCommandRuntime(config, writes);
+
+      const result = await trySlashCommand(createGroupAllwaysMessage("invalid"), {
+        account: createDefaultAccount(),
+        cfg: config,
+        getMessagePeerId: () => "c2c:TRUSTED_OPENID",
+        getQueueSnapshot: () => ({
+          totalPending: 0,
+          activeUsers: 0,
+          maxConcurrentUsers: 1,
+          senderPending: 0,
+        }),
+      });
+
+      expect(result).toBe("handled");
+      expect(writes).toHaveLength(0);
+      expect(vi.mocked(sendText).mock.calls.at(0)?.[1]).toContain("参数错误");
+    });
+  });
+});

--- a/extensions/qqbot/src/engine/commands/builtin/register-group-allways.ts
+++ b/extensions/qqbot/src/engine/commands/builtin/register-group-allways.ts
@@ -1,0 +1,129 @@
+// 导入运行时配置缓存清除函数，确保配置更新后 getRuntimeConfig() 能读取到最新值
+import { clearRuntimeConfigSnapshot } from "openclaw/plugin-sdk/runtime-config-snapshot";
+// Qqbot plugin module implements register group allways behavior.
+import type { ApproveRuntimeGetter } from "../../adapter/commands.port.js";
+import type { SlashCommandRegistry } from "../slash-commands.js";
+import {
+  getApproveRuntimeGetter,
+  getPluginVersionString,
+  resolveRuntimeServiceVersion,
+} from "./state.js";
+
+export function registerGroupAllwaysCommand(registry: SlashCommandRegistry): void {
+  registry.register({
+    name: "bot-group-allways",
+    description: "修改群消息默认响应模式",
+    requireAuth: true,
+    c2cOnly: true,
+    usage: [
+      `/bot-group-allways on   AI 自主判断何时发言（无需 @）`,
+      `/bot-group-allways off  仅在被 @ 时回复`,
+      `/bot-group-allways      查看当前设置`,
+      ``,
+      `设为 on 后，AI 会自主判断每条消息是否需要回复（无需 @）。`,
+      `仍可通过 groups.{groupId}.requireMention 对单个群覆盖。`,
+      ``,
+      `优先级：具体群配置 > 通配符 "*" > defaultRequireMention（本指令）> 默认 true`,
+    ].join("\n"),
+    handler: async (ctx) => {
+      const arg = ctx.args.trim().toLowerCase();
+
+      // 读取当前 defaultRequireMention 状态
+      const currentVal = ctx.accountConfig?.defaultRequireMention;
+      const currentRequireMention = currentVal ?? true; // 未设置时硬编码默认为 true
+
+      // 无参数：查看当前状态
+      if (!arg) {
+        return [
+          `🤖 群自主发言状态：${currentRequireMention ? "❌ 仅被 @ 时回复" : "✅ 自主判断何时发言"}`,
+          `使用 <qqbot-cmd-input text="/bot-group-allways on" show="/bot-group-allways on"/> 设为自主发言`,
+          `使用 <qqbot-cmd-input text="/bot-group-allways off" show="/bot-group-allways off"/> 设为仅被 @ 时回复`,
+        ].join("\n");
+      }
+
+      if (arg !== "on" && arg !== "off") {
+        return `❌ 参数错误，请使用 on 或 off\n\n示例：/bot-group-allways on`;
+      }
+
+      const newRequireMention = arg === "off"; // on=自主发言(requireMention=false), off=仅被@时回复(requireMention=true)
+
+      // 如果状态没变，直接返回
+      if (newRequireMention === currentRequireMention) {
+        return `🤖 群自主发言已经是"${arg}"状态，无需操作`;
+      }
+
+      // 获取运行时配置 API
+      let runtime: ReturnType<NonNullable<ApproveRuntimeGetter>>;
+      try {
+        const getter = getApproveRuntimeGetter();
+        if (!getter) {
+          throw new Error("runtime not available");
+        }
+        runtime = getter();
+      } catch {
+        const fwVer = resolveRuntimeServiceVersion();
+        const ver = getPluginVersionString();
+        return [
+          `❌ 当前版本不支持该指令`,
+          ``,
+          `🦞框架版本：${fwVer}`,
+          `🤖QQBot 插件版本：v${ver}`,
+          ``,
+          `可通过以下命令手动设置：`,
+          ``,
+          `\`\`\`shell`,
+          `# 设为 AI 自主判断何时发言（defaultRequireMention=false）`,
+          `openclaw config set channels.qqbot.defaultRequireMention false`,
+          `# 或设为仅被 @ 时回复（defaultRequireMention=true）`,
+          `openclaw config set channels.qqbot.defaultRequireMention true`,
+          `\`\`\``,
+        ].join("\n");
+      }
+
+      try {
+        const configApi = runtime.config;
+        const currentCfg = structuredClone(configApi.current() as Record<string, unknown>);
+        const qqbot = ((currentCfg.channels ?? {}) as Record<string, unknown>).qqbot as
+          | Record<string, unknown>
+          | undefined;
+
+        if (!qqbot) {
+          return `❌ 配置文件中未找到 qqbot 通道配置`;
+        }
+
+        const accountId = ctx.accountId;
+        const isNamedAccount =
+          accountId !== "default" &&
+          !!(qqbot.accounts as Record<string, Record<string, unknown>> | undefined)?.[accountId];
+
+        if (isNamedAccount) {
+          // 命名账户：更新 accounts.{accountId}.defaultRequireMention
+          const accounts = (qqbot.accounts as Record<string, Record<string, unknown>>) ?? {};
+          const nextAccounts = { ...accounts };
+          const acct = { ...nextAccounts[accountId] };
+          acct.defaultRequireMention = newRequireMention;
+          nextAccounts[accountId] = acct;
+          qqbot.accounts = nextAccounts;
+        } else {
+          // 默认账户：更新 qqbot.defaultRequireMention
+          qqbot.defaultRequireMention = newRequireMention;
+        }
+
+        await configApi.replaceConfigFile({ nextConfig: currentCfg, afterWrite: { mode: "auto" } });
+
+        // 清除运行时配置缓存，确保 getRuntimeConfig() 下次调用时重新加载最新配置
+        clearRuntimeConfigSnapshot();
+
+        return [
+          `✅ 群自主发言已设置为 ${newRequireMention ? "**off**（仅被 @ 时回复）" : "**on**（AI 自主判断何时发言）"}`,
+          ``,
+          newRequireMention
+            ? `仅在被 @ 机器人才会回复。`
+            : `AI 将自主判断群消息是否需要回复，无需被 @ 即可发言。`,
+        ].join("\n");
+      } catch (err: unknown) {
+        return `❌ 配置写入失败: ${err instanceof Error ? err.message : String(err)}`;
+      }
+    },
+  });
+}

--- a/extensions/qqbot/src/engine/commands/builtin/register-group-allways.ts
+++ b/extensions/qqbot/src/engine/commands/builtin/register-group-allways.ts
@@ -94,7 +94,9 @@ export function registerGroupAllwaysCommand(registry: SlashCommandRegistry): voi
         const accountId = ctx.accountId;
         const isNamedAccount =
           accountId !== "default" &&
-          !!(qqbot.accounts as Record<string, Record<string, unknown>> | undefined)?.[accountId];
+          Boolean(
+            (qqbot.accounts as Record<string, Record<string, unknown>> | undefined)?.[accountId],
+          );
 
         if (isNamedAccount) {
           // 命名账户：更新 accounts.{accountId}.defaultRequireMention

--- a/extensions/qqbot/src/engine/config/group.test.ts
+++ b/extensions/qqbot/src/engine/config/group.test.ts
@@ -81,6 +81,62 @@ describe("engine/config/group", () => {
       };
       expect(resolveHistoryLimit(cfg, "G")).toBe(DEFAULT_GROUP_HISTORY_LIMIT);
     });
+
+    describe("account-level defaultRequireMention layer", () => {
+      it("uses hardcoded true when nothing configured (default account)", () => {
+        const cfg = { channels: { qqbot: { appId: "1" } } };
+        expect(resolveGroupConfig(cfg, "G1").requireMention).toBe(true);
+      });
+
+      it("reads defaultRequireMention from top-level qqbot (default account)", () => {
+        const cfg = {
+          channels: { qqbot: { appId: "1", defaultRequireMention: false } },
+        };
+        expect(resolveGroupConfig(cfg, "G1").requireMention).toBe(false);
+      });
+
+      it("reads defaultRequireMention from named account config", () => {
+        const cfg = {
+          channels: {
+            qqbot: {
+              accounts: { bot2: { appId: "9", defaultRequireMention: false } },
+            },
+          },
+        };
+        expect(resolveRequireMention(cfg, "G1", "bot2")).toBe(false);
+      });
+
+      it("wildcard overrides account-level defaultRequireMention", () => {
+        const cfg = {
+          channels: {
+            qqbot: {
+              appId: "1",
+              defaultRequireMention: false,
+              groups: { "*": { requireMention: true } },
+            },
+          },
+        };
+        // wildcard requireMention=true wins over account-level defaultRequireMention=false
+        expect(resolveGroupConfig(cfg, "G1").requireMention).toBe(true);
+      });
+
+      it("specific group config has highest priority", () => {
+        const cfg = {
+          channels: {
+            qqbot: {
+              appId: "1",
+              defaultRequireMention: false,
+              groups: {
+                "*": { requireMention: true },
+                SPECIAL_GROUP: { requireMention: false },
+              },
+            },
+          },
+        };
+        expect(resolveGroupConfig(cfg, "SPECIAL_GROUP").requireMention).toBe(false);
+        expect(resolveGroupConfig(cfg, "OTHER_GROUP").requireMention).toBe(true); // wildcard
+      });
+    });
   });
 
   describe("named accounts", () => {

--- a/extensions/qqbot/src/engine/config/group.ts
+++ b/extensions/qqbot/src/engine/config/group.ts
@@ -64,15 +64,20 @@ export function resolveGroupConfig(
   groupOpenid?: string | null,
   accountId?: string | null,
 ): GroupConfig {
+  const account = resolveAccountBase(cfg, accountId);
   const groups = readGroupsMap(cfg, accountId);
   const wildcard = groups["*"] ?? {};
   const specific = groupOpenid ? (groups[groupOpenid] ?? {}) : {};
+
+  // 账户级默认值：defaultRequireMention 配置 > 默认 true
+  const accountDefaultRequireMention =
+    asBoolean(account.config.defaultRequireMention) ?? DEFAULT_GROUP_CONFIG.requireMention;
 
   return {
     requireMention:
       readBoolean(specific, "requireMention") ??
       readBoolean(wildcard, "requireMention") ??
-      DEFAULT_GROUP_CONFIG.requireMention,
+      accountDefaultRequireMention,
     ignoreOtherMentions:
       readBoolean(specific, "ignoreOtherMentions") ??
       readBoolean(wildcard, "ignoreOtherMentions") ??


### PR DESCRIPTION
## Summary

**Problem:** Users cannot conveniently toggle `defaultRequireMention` for qqbot groups. Config changes via `replaceConfigFile()` didn't take effect immediately due to `getRuntimeConfig()` caching the first loaded snapshot.

**Solution:** Add `/bot-group-allways` slash command and clear runtime config cache after write.

**Changes:**
- Add `/bot-group-allways on|off|status` command
- Support named accounts and default account
- Call `clearRuntimeConfigSnapshot()` after config write for immediate effect
- Add unit tests (309 lines) and update group config tests (56 lines)

## Real behavior proof

**Before:**
```
17:20:32 [qqbot] Skipped group inbound: reason=skip_no_mention
```

**After:**
```
17:28:13 [reload] config hot reload applied (channels.qqbot.accounts.102901613.defaultRequireMention)
```

**Steps tested:**
1. DM to bot: `/bot-group-allways on`
2. Bot replies: "✅ 群自主发言已设置为 **on**"
3. Send message in group without @ → AI responds
4. `clearRuntimeConfigSnapshot()` called, next `getRuntimeConfig()` returns fresh config

## Tests and validation

```bash
npm test -- --testPathPattern="register-group-allways|group"
npm run typecheck
npm run lint
```

## Risk checklist

- **User-visible behavior change?** Yes - new slash command (additive, not breaking)
- **Config/environment change?** Yes - `clearRuntimeConfigSnapshot()` called after config write
- **Security/auth change?** No
- **Highest-risk area:** `clearRuntimeConfigSnapshot()` performance impact
- **Mitigation:** Only called after successful `replaceConfigFile()`, synchronous and fast

## Current review state

**Next action:** Maintainer review for API design and cache invalidation approach

**Addressed:**
- [x] Caching issue with `clearRuntimeConfigSnapshot()`
- [x] Unit tests added
- [x] Both named and default account support
