### PR TITLE
fix: stop identifying exec-event heartbeats as heartbeat polls

### DIFF
--- a/src/auto-reply/reply/prompt-prelude.test.ts
+++ b/src/auto-reply/reply/prompt-prelude.test.ts
@@ -216,4 +216,51 @@ describe("buildReplyPromptEnvelope", () => {
     expect(envelope.transcriptCommandBody).toBe("re-read persona files");
     expect(envelope.transcriptCommandBody).not.toContain("Startup context");
   });
+
+  it("uses baseBody as transcript label for exec-event heartbeats instead of [OpenClaw heartbeat poll]", () => {
+    const sessionCtx = finalizeInboundContext({
+      Body: "A background command you started earlier has completed. The completion details are...",
+      BodyStripped:
+        "A background command you started earlier has completed. The completion details are...",
+      Provider: "exec-event",
+      ChatType: "direct",
+    });
+
+    const envelope = buildReplyPromptEnvelope({
+      ctx: sessionCtx,
+      sessionCtx,
+      baseBody:
+        "A background command you started earlier has completed. The completion details are:\n\nExec completed (abc, code 0) :: done\n\nExamine the result.",
+      hasUserBody: true,
+      inboundUserContext: "",
+      isBareSessionReset: false,
+      startupAction: "new",
+      isHeartbeat: true,
+    });
+
+    expect(envelope.transcriptCommandBody).toContain("background command you started earlier");
+    expect(envelope.transcriptCommandBody).not.toContain("[OpenClaw heartbeat poll]");
+  });
+
+  it("keeps [OpenClaw heartbeat poll] transcript label for regular heartbeats", () => {
+    const sessionCtx = finalizeInboundContext({
+      Body: "",
+      BodyStripped: "",
+      Provider: "heartbeat",
+      ChatType: "direct",
+    });
+
+    const envelope = buildReplyPromptEnvelope({
+      ctx: sessionCtx,
+      sessionCtx,
+      baseBody: "Read HEARTBEAT.md...",
+      hasUserBody: true,
+      inboundUserContext: "",
+      isBareSessionReset: false,
+      startupAction: "new",
+      isHeartbeat: true,
+    });
+
+    expect(envelope.transcriptCommandBody).toBe("[OpenClaw heartbeat poll]");
+  });
 });

--- a/src/auto-reply/reply/prompt-prelude.ts
+++ b/src/auto-reply/reply/prompt-prelude.ts
@@ -199,7 +199,9 @@ export function buildReplyPromptEnvelopeBase(
       ? resetModelBody
       : "[User sent media without caption]";
   const transcriptBody = params.isHeartbeat
-    ? HEARTBEAT_TRANSCRIPT_PROMPT
+    ? params.ctx?.Provider === "exec-event"
+      ? params.baseBody
+      : HEARTBEAT_TRANSCRIPT_PROMPT
     : params.isBareSessionReset
       ? softResetTail || `[OpenClaw session ${params.startupAction}]`
       : isRoomEvent


### PR DESCRIPTION
## Summary

- Problem: when a background exec completes, the exec-event wake injects a prompt into the conversation. The transcript label was `[OpenClaw heartbeat poll]`, which triggered the system prompt instruction "If the current user message is a heartbeat poll and nothing needs attention, reply exactly: HEARTBEAT_OK". This caused the agent to ignore the exec completion and reply HEARTBEAT_OK, abandoning the original task.
- Why it matters: agents using background exec (via `background: true`, `yieldMs`, or default 10s auto-yield) never see the completion result and cannot continue the task.
- What changed: when `ctx.Provider === "exec-event"`, the transcript label uses the actual prompt body instead of `[OpenClaw heartbeat poll]`. The model no longer identifies the turn as a heartbeat poll and processes the exec completion normally.
- What did NOT change: regular heartbeat polls (no exec events) still use `[OpenClaw heartbeat poll]` and the HEARTBEAT_OK instruction works as before.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security
- [ ] Chore

## Scope

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Root Cause

The heartbeat runner sets `Provider: "exec-event"` for exec-event wakes (`src/infra/heartbeat-runner.ts:1691`), but `prompt-prelude.ts:201-202` unconditionally used `HEARTBEAT_TRANSCRIPT_PROMPT` for all heartbeat turns regardless of Provider value. The system prompt (`src/agents/system-prompt.ts:245-247`) instructs the model: "If the current user message is a heartbeat poll and nothing needs attention, reply exactly: HEARTBEAT_OK". Because the transcript label was always `[OpenClaw heartbeat poll]`, the model matched this rule and replied HEARTBEAT_OK instead of processing the exec completion content in the body.

## Real behavior proof

- **Behavior addressed:** exec-event heartbeat turns use `[OpenClaw heartbeat poll]` as the transcript label, causing the model to reply HEARTBEAT_OK when it should process the body content.
- **Real environment tested:** WebUI mode with local OpenClaw source checkout, model Qwen3-235B-A22B.
- **Exact steps or command run after this patch:**
  - Unit test: `buildReplyPromptEnvelope` with `Provider: "exec-event"`, `isHeartbeat: true` → `transcriptCommandBody` equals `baseBody`, not `[OpenClaw heartbeat poll]`
  - Unit test: `buildReplyPromptEnvelope` with `Provider: "heartbeat"`, `isHeartbeat: true` → `transcriptCommandBody` is `[OpenClaw heartbeat poll]` (unchanged)
- **Evidence after fix:** The transcript label is now correctly determined by Provider. Unit tests verify both branches:

  ```text
  Vitest: Test Files 1 passed (1) / Tests 8 passed (8)
  
  Test 7: "uses baseBody as transcript label for exec-event heartbeats instead of [OpenClaw heartbeat poll]"
    → transcriptCommandBody contains "background command you started earlier"
    → transcriptCommandBody does NOT contain "[OpenClaw heartbeat poll]"
  
  Test 8: "keeps [OpenClaw heartbeat poll] transcript label for regular heartbeats"
    → transcriptCommandBody === "[OpenClaw heartbeat poll]"
  ```

- **Observed result after fix:** The `transcriptCommandBody` correctly distinguishes exec-event wakes from regular heartbeat polls. When the heartbeat Provider is `"exec-event"`, the model sees the actual body text instead of `[OpenClaw heartbeat poll]`, so the system prompt's "reply HEARTBEAT_OK" rule does not match.
- **What was not tested:** Full E2E with real background exec and heartbeat wake. This fix is one part of a larger change; the companion PR for the exec prompt text and detection logic is needed to fully resolve the background exec completion flow.

## Regression Test Plan

- [x] Unit test: `buildReplyPromptEnvelope` with `Provider: "exec-event"` and `isHeartbeat: true` verifies transcript label uses baseBody
- [x] Unit test: `buildReplyPromptEnvelope` with `Provider: "heartbeat"` and `isHeartbeat: true` verifies transcript label stays `[OpenClaw heartbeat poll]`

## Security Impact

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)