### PR TITLE
fix(openai-completions): reject provider empty stop replies

### DIFF
--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -1141,6 +1141,96 @@ describe("openai transport stream", () => {
     }
   });
 
+  it("routes OpenAI-compatible loopback empty stop replies into the error path", async () => {
+    const server = createServer((req, res) => {
+      req.resume();
+      req.on("end", () => {
+        res.writeHead(200, {
+          "content-type": "text/event-stream; charset=utf-8",
+          "cache-control": "no-cache",
+          connection: "keep-alive",
+        });
+        const created = Math.floor(Date.now() / 1000);
+        res.write(
+          `data: ${JSON.stringify({
+            id: "chatcmpl-empty-stop",
+            object: "chat.completion.chunk",
+            created,
+            model: "step-router-v1",
+            choices: [{ index: 0, delta: { role: "assistant" }, finish_reason: null }],
+          })}\n\n`,
+        );
+        res.write(
+          `data: ${JSON.stringify({
+            id: "chatcmpl-empty-stop",
+            object: "chat.completion.chunk",
+            created,
+            model: "step-router-v1",
+            choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+          })}\n\n`,
+        );
+        res.write("data: [DONE]\n\n");
+        res.end();
+      });
+    });
+
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    try {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("Missing loopback server address");
+      }
+      const model = {
+        id: "step-router-v1",
+        name: "Step Router",
+        api: "openai-completions",
+        provider: "stepfun",
+        baseUrl: `http://127.0.0.1:${address.port}/v1`,
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 4096,
+        maxTokens: 256,
+      } satisfies Model<"openai-completions">;
+      const stream = createOpenAICompletionsTransportStreamFn()(
+        model,
+        {
+          systemPrompt: "system",
+          messages: [{ role: "user", content: "Reply", timestamp: Date.now() }],
+          tools: [],
+        } as never,
+        { apiKey: "test-key" } as never,
+      );
+
+      let doneReason: string | undefined;
+      let errorPayload: Record<string, unknown> | undefined;
+      for await (const event of stream as AsyncIterable<{
+        type: string;
+        reason?: string;
+        error?: Record<string, unknown>;
+      }>) {
+        if (event.type === "done") {
+          doneReason = event.reason;
+        }
+        if (event.type === "error") {
+          errorPayload = event.error;
+        }
+      }
+
+      expect(doneReason).toBeUndefined();
+      expect(errorPayload).toMatchObject({ stopReason: "error", content: [] });
+      expect(String(errorPayload?.errorMessage)).toContain(
+        "Provider stepfun (model step-router-v1) returned stop with empty content",
+      );
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+
   it("refuses ModelStudio chat streams with no user or assistant payload turns", async () => {
     const model = {
       id: "qwen-coder-plus",
@@ -2113,6 +2203,133 @@ describe("openai transport stream", () => {
 
     expect(output.content).toStrictEqual([{ type: "text", text: "ok" }]);
     expect(output.stopReason).toBe("stop");
+  });
+
+  it("rejects stop-only OpenAI-compatible streams with no raw provider output", async () => {
+    const model = {
+      id: "step-router-v1",
+      name: "Step Router",
+      api: "openai-completions",
+      provider: "stepfun",
+      baseUrl: "http://localhost:8000/v1",
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 128000,
+      maxTokens: 4096,
+    } satisfies Model<"openai-completions">;
+    const output = createAssistantOutput(model);
+    const stream: { push(event: unknown): void } = { push() {} };
+
+    await expect(
+      testing.processOpenAICompletionsStream(
+        streamChunks([
+          {
+            id: "chatcmpl-empty-stop",
+            object: "chat.completion.chunk" as const,
+            created: 1775425651,
+            model: model.id,
+            choices: [{ index: 0, delta: { role: "assistant" as const }, finish_reason: null }],
+          },
+          {
+            id: "chatcmpl-empty-stop",
+            object: "chat.completion.chunk" as const,
+            created: 1775425651,
+            model: model.id,
+            choices: [{ index: 0, delta: {}, finish_reason: "stop" as const }],
+          },
+        ]),
+        output,
+        model,
+        stream,
+      ),
+    ).rejects.toThrow("Provider stepfun (model step-router-v1) returned stop with empty content");
+  });
+
+  it("keeps refusal-only OpenAI-compatible streams deliverable", async () => {
+    const model = {
+      id: "gpt-5.5",
+      name: "GPT-5.5",
+      api: "openai-completions",
+      provider: "openai",
+      baseUrl: "https://api.openai.com/v1",
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 128000,
+      maxTokens: 4096,
+    } satisfies Model<"openai-completions">;
+    const output = createAssistantOutput(model);
+    const stream: { push(event: unknown): void } = { push() {} };
+
+    await testing.processOpenAICompletionsStream(
+      streamChunks([
+        {
+          id: "chatcmpl-refusal",
+          object: "chat.completion.chunk" as const,
+          created: 1775425651,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              delta: { role: "assistant" as const, refusal: "I cannot help with that." },
+              finish_reason: null,
+            },
+          ],
+        },
+        {
+          id: "chatcmpl-refusal",
+          object: "chat.completion.chunk" as const,
+          created: 1775425651,
+          model: model.id,
+          choices: [{ index: 0, delta: {}, finish_reason: "stop" as const }],
+        },
+      ]),
+      output,
+      model,
+      stream,
+    );
+
+    expect(output.stopReason).toBe("stop");
+    expect(output.content).toStrictEqual([{ type: "text", text: "I cannot help with that." }]);
+  });
+
+  it("does not reject raw reasoning that is suppressed by transport options", async () => {
+    const model = createDeepSeekCompletionsModel();
+    const output = createAssistantOutput(model);
+    const stream: { push(event: unknown): void } = { push() {} };
+
+    await testing.processOpenAICompletionsStream(
+      streamChunks([
+        {
+          id: "chatcmpl-reasoning-only",
+          object: "chat.completion.chunk" as const,
+          created: 1775425651,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              delta: { role: "assistant" as const, reasoning_content: "private reasoning" },
+              finish_reason: null,
+            },
+          ],
+        },
+        {
+          id: "chatcmpl-reasoning-only",
+          object: "chat.completion.chunk" as const,
+          created: 1775425651,
+          model: model.id,
+          choices: [{ index: 0, delta: {}, finish_reason: "stop" as const }],
+        },
+      ]),
+      output,
+      model,
+      stream,
+      { emitReasoning: false },
+    );
+
+    expect(output.stopReason).toBe("stop");
+    expect(output.content).toStrictEqual([]);
   });
 
   it("filters DeepSeek DSML content without disturbing native tool calls", async () => {
@@ -10136,9 +10353,7 @@ describe("buildOpenAICompletionsParams sanitizes reasoning replay fields", () =>
   });
 
   it("preserves reasoning_content replay for Gemma 4 openai-completions models", () => {
-    const assistant = getAssistantMessage(
-      buildReplayParams(gemma4Model, "reasoning_content"),
-    );
+    const assistant = getAssistantMessage(buildReplayParams(gemma4Model, "reasoning_content"));
 
     expect(assistant.reasoning_content).toBe("Need to answer politely.");
     expect(assistant).not.toHaveProperty("reasoning_details");

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -2641,6 +2641,39 @@ export function createOpenAICompletionsTransportStreamFn(): StreamFn {
   };
 }
 
+function hasRawOpenAICompletionsDeltaOutput(
+  delta: ChatCompletionChunk["choices"][number]["delta"],
+) {
+  const fields = delta as Record<string, unknown>;
+  const content = fields.content;
+  if (typeof content === "string" && content.length > 0) {
+    return true;
+  }
+  if (Array.isArray(content) && content.length > 0) {
+    return true;
+  }
+  if (typeof fields.refusal === "string" && fields.refusal.length > 0) {
+    return true;
+  }
+  if (Array.isArray(fields.tool_calls) && fields.tool_calls.length > 0) {
+    return true;
+  }
+  for (const field of ["reasoning_content", "reasoning", "reasoning_text"]) {
+    const value = fields[field];
+    if (typeof value === "string" && value.length > 0) {
+      return true;
+    }
+  }
+  return Array.isArray(fields.reasoning_details) && fields.reasoning_details.length > 0;
+}
+
+function buildEmptyOpenAICompletionsStopMessage(model: Model) {
+  return (
+    `Provider ${model.provider} (model ${model.id}) returned stop with empty content: ` +
+    "no text, thinking, or tool calls"
+  );
+}
+
 async function processOpenAICompletionsStream(
   responseStream: AsyncIterable<ChatCompletionChunk>,
   output: MutableAssistantOutput,
@@ -2680,6 +2713,7 @@ async function processOpenAICompletionsStream(
   const toolCallBlocksById = new Map<string, ToolCallBlock>();
   const toolCallBlockBytes = new WeakMap<ToolCallBlock, number>();
   let sawStopFinishReason = false;
+  let sawRawProviderOutput = false;
   const blockIndex = () => output.content.length - 1;
   const measureUtf8Bytes = (text: string) => Buffer.byteLength(text, "utf8");
   let chunkPushedEvent = false;
@@ -2944,6 +2978,9 @@ async function processOpenAICompletionsStream(
       await cooperativeScheduler.afterEvent();
       continue;
     }
+    if (hasRawOpenAICompletionsDeltaOutput(choiceDelta)) {
+      sawRawProviderOutput = true;
+    }
     const reasoningDeltas = getCompletionsReasoningDeltas(
       choiceDelta as Record<string, unknown>,
       compat.visibleReasoningDetailTypes,
@@ -2969,6 +3006,9 @@ async function processOpenAICompletionsStream(
           appendRoutedContentDelta(contentDelta);
         }
       }
+    }
+    if (typeof choiceDelta.refusal === "string" && choiceDelta.refusal.length > 0) {
+      appendFilteredVisibleTextDelta(choiceDelta.refusal);
     }
     for (const reasoningDelta of reasoningDeltas) {
       if (reasoningDelta.kind === "thinking" && !emitReasoning) {
@@ -3071,6 +3111,16 @@ async function processOpenAICompletionsStream(
   }
   if (hasToolCalls && output.stopReason !== "toolUse") {
     output.content = output.content.filter((block) => block.type !== "toolCall");
+  }
+  const hasThinking = output.content.some((block) => block.type === "thinking");
+  if (
+    output.stopReason === "stop" &&
+    !sawRawProviderOutput &&
+    !hasToolCalls &&
+    !hasVisibleText &&
+    !hasThinking
+  ) {
+    throw new Error(buildEmptyOpenAICompletionsStopMessage(model));
   }
 }
 

--- a/src/llm/providers/openai-completions.test.ts
+++ b/src/llm/providers/openai-completions.test.ts
@@ -737,3 +737,62 @@ describe("openai-completions stop-reason tool-call guard", () => {
     expect(result.content.filter((b) => b.type === "toolCall")).toStrictEqual([]);
   });
 });
+
+describe("openai-completions empty-stop guard", () => {
+  it("routes finish_reason stop with no raw provider output into the error path", async () => {
+    mockChunksRef.chunks = [
+      { id: "chatcmpl-test", choices: [{ index: 0, delta: {} }] },
+      makeFinishChunk("stop"),
+    ];
+
+    const stream = streamOpenAICompletions(model, context, { apiKey: "sk-test" });
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("error");
+    expect(result.errorMessage).toContain("returned stop with empty content");
+    expect(result.errorMessage).toContain("Provider openai (model gpt-5.5)");
+    expect(result.content).toStrictEqual([]);
+  });
+
+  it("keeps a normal stop with visible text deliverable", async () => {
+    mockChunksRef.chunks = [makeTextChunk("done"), makeFinishChunk("stop")];
+
+    const stream = streamOpenAICompletions(model, context, { apiKey: "sk-test" });
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("stop");
+    expect(result.content).toStrictEqual([{ type: "text", text: "done" }]);
+  });
+
+  it("keeps a refusal-only stop deliverable", async () => {
+    mockChunksRef.chunks = [
+      {
+        id: "chatcmpl-test",
+        choices: [{ index: 0, delta: { refusal: "I cannot help with that." } }],
+      },
+      makeFinishChunk("stop"),
+    ];
+
+    const stream = streamOpenAICompletions(model, context, { apiKey: "sk-test" });
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("stop");
+    expect(result.content).toStrictEqual([{ type: "text", text: "I cannot help with that." }]);
+  });
+
+  it("does not treat suppressed raw reasoning as provider-empty output", async () => {
+    mockChunksRef.chunks = [
+      {
+        id: "chatcmpl-test",
+        choices: [{ index: 0, delta: { reasoning_content: "private reasoning" } }],
+      },
+      makeFinishChunk("stop"),
+    ];
+
+    const stream = streamOpenAICompletions(reasoningModel, context, { apiKey: "sk-test" });
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("stop");
+    expect(result.content).toStrictEqual([]);
+  });
+});

--- a/src/llm/providers/openai-completions.ts
+++ b/src/llm/providers/openai-completions.ts
@@ -81,6 +81,33 @@ function isImageContentBlock(block: { type: string }): block is ImageContent {
   return block.type === "image";
 }
 
+function hasRawOpenAICompletionsDeltaOutput(delta: ChatCompletionChunk.Choice.Delta) {
+  const fields = delta as Record<string, unknown>;
+  if (typeof delta.content === "string" && delta.content.length > 0) {
+    return true;
+  }
+  if (typeof delta.refusal === "string" && delta.refusal.length > 0) {
+    return true;
+  }
+  if (Array.isArray(delta.tool_calls) && delta.tool_calls.length > 0) {
+    return true;
+  }
+  for (const field of ["reasoning_content", "reasoning", "reasoning_text"]) {
+    const value = fields[field];
+    if (typeof value === "string" && value.length > 0) {
+      return true;
+    }
+  }
+  return Array.isArray(fields.reasoning_details) && fields.reasoning_details.length > 0;
+}
+
+function buildEmptyStopErrorMessage(model: Model<"openai-completions">) {
+  return (
+    `Provider ${model.provider} (model ${model.id}) returned stop with empty content: ` +
+    "no text, thinking, or tool calls"
+  );
+}
+
 export interface OpenAICompletionsOptions extends StreamOptions {
   toolChoice?: "auto" | "none" | "required" | { type: "function"; function: { name: string } };
   reasoningEffort?: "minimal" | "low" | "medium" | "high" | "xhigh";
@@ -189,6 +216,7 @@ export const streamOpenAICompletions: StreamFunction<
       const toolCallBlocksById = new Map<string, StreamingToolCallBlock>();
       const blocks = output.content as StreamingBlock[];
       const getContentIndex = (block: StreamingBlock) => blocks.indexOf(block);
+      let sawRawProviderOutput = false;
       const finishBlock = (block: StreamingBlock) => {
         const contentIndex = getContentIndex(block);
         if (contentIndex === -1) {
@@ -365,6 +393,9 @@ export const streamOpenAICompletions: StreamFunction<
         }
 
         if (choice.delta) {
+          if (hasRawOpenAICompletionsDeltaOutput(choice.delta)) {
+            sawRawProviderOutput = true;
+          }
           // Some endpoints return reasoning in reasoning_content (llama.cpp),
           // or reasoning (other openai compatible endpoints)
           // Use the first non-empty reasoning field to avoid duplication
@@ -389,6 +420,9 @@ export const streamOpenAICompletions: StreamFunction<
             choice.delta.content.length > 0
           ) {
             appendPartitionedContent(choice.delta.content, Boolean(foundReasoningField));
+          }
+          if (typeof choice.delta.refusal === "string" && choice.delta.refusal.length > 0) {
+            appendPartitionedContent(choice.delta.refusal, false);
           }
 
           if (shouldEmitReasoning && foundReasoningField) {
@@ -477,6 +511,16 @@ export const streamOpenAICompletions: StreamFunction<
       }
       if (hasToolCalls && output.stopReason !== "toolUse") {
         output.content = output.content.filter((block) => block.type !== "toolCall");
+      }
+      const hasThinking = output.content.some((block) => block.type === "thinking");
+      if (
+        output.stopReason === "stop" &&
+        !sawRawProviderOutput &&
+        !hasToolCalls &&
+        !hasVisibleText &&
+        !hasThinking
+      ) {
+        throw new Error(buildEmptyStopErrorMessage(model));
       }
 
       stream.push({ type: "done", reason: output.stopReason, message: output });


### PR DESCRIPTION
## Summary

- Fixes OpenAI-compatible chat completion streams that finish with `finish_reason: "stop"` after emitting no assistant output, which currently reaches channels as `content: []` and a silent blank reply.
- Applies the guard to both OpenAI completions stream surfaces: the direct `streamOpenAICompletions` adapter and the boundary-aware transport used by embedded/channel runs.
- Tracks whether the provider emitted raw assistant output before OpenClaw transforms strip or suppress content, so suppressed reasoning and refusal-only streams are not misclassified as provider-empty output.
- Intentionally does not change channel senders, fallback text, config, docs, migrations, or the existing silent-reply policy.

## Linked context

Closes #91394

Related #91403

This is a replacement candidate for #91403. That PR was blocked by ClawSweeper because it guarded only the direct adapter and did not cover the active embedded/channel boundary-aware transport path, and because it keyed only on final `content: []` instead of distinguishing raw provider no-output from transformed/suppressed output.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: `openai-completions` no longer delivers a provider-emitted empty `stop` reply as `done` with `content: []`.
- Real environment tested: macOS local worktree `openclaw-91394`, Node v24.15.0, OpenClaw branch `fix/91394-openai-completions-empty-stop`, local OpenAI-compatible SSE server on `127.0.0.1`, active boundary-aware `createOpenAICompletionsTransportStreamFn()` path.
- Exact steps or command run after this patch: ran a `node --import tsx --input-type=module` proof script that starts a loopback `/v1/chat/completions` SSE server, emits a role-only assistant chunk, then an empty terminal `{ delta: {}, finish_reason: "stop" }`, then `[DONE]`, and consumes the stream through `createOpenAICompletionsTransportStreamFn()` with provider `stepfun`, model `step-router-v1`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
AFTER fix branch behavior
event        : error
doneReason   : (none)
errorReason  : error
content.length: 0
errorMessage : Provider stepfun (model step-router-v1) returned stop with empty content: no text, thinking, or tool calls
```

- Observed result after fix: the active transport path emits an error event with provider/model context instead of a deliverable empty `done`; downstream empty-turn recovery treats `stopReason: "error"` as non-silent.
- What was not tested: no live StepFun API session was run; the provider behavior was reproduced with the same OpenAI-compatible SSE shape against a local loopback endpoint. Full repo lint currently fails on unrelated existing files listed below.
- Proof limitations or environment constraints: the proof is local real transport proof, not a live external provider proof; no secrets or provider credentials were used.
- Before evidence (optional but encouraged):

```text
BEFORE upstream/main behavior
event        : done
doneReason   : stop
errorReason  : (none)
content.length: 0
errorMessage : (none)
```

## Tests and validation

Commands run:

- `pnpm install`
- `node scripts/run-vitest.mjs src/llm/providers/openai-completions.test.ts` — 27 passed
- `node scripts/run-vitest.mjs src/agents/openai-transport-stream.test.ts` — 246 passed
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run.incomplete-turn.test.ts` — 116 passed
- `node scripts/run-vitest.mjs src/auto-reply/reply/get-reply-run.media-only.test.ts` — 80 passed
- `git diff --check` — clean
- `pnpm exec oxfmt --check src/llm/providers/openai-completions.ts src/llm/providers/openai-completions.test.ts src/agents/openai-transport-stream.ts src/agents/openai-transport-stream.test.ts` — clean
- `node scripts/run-oxlint.mjs src/llm/providers/openai-completions.ts src/llm/providers/openai-completions.test.ts src/agents/openai-transport-stream.ts src/agents/openai-transport-stream.test.ts` — clean
- `pnpm tsgo:core` — passed
- `pnpm tsgo:test:src` — passed
- `.agents/skills/autoreview/scripts/autoreview --mode local --base upstream/main` — clean, no accepted/actionable findings

Regression coverage added:

- direct adapter stop-only stream returns `stopReason: "error"`
- boundary-aware transport stop-only SSE emits `error`, not empty `done`
- normal text stop still delivers
- refusal-only stop still delivers visible text
- raw reasoning suppressed by transport options is not treated as provider-empty output

Known unrelated validation gap:

- Full `node scripts/run-oxlint.mjs` currently fails outside this PR on existing `apps/shared/OpenClawKit/Sources/OpenClawKit/Resources/CanvasA2UI/a2ui.bundle.js` and several `test/scripts/*` lint findings. The scoped touched-file lint above is clean.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Truly empty provider `stop` replies now surface as an error/retry path instead of disappearing as blank channel replies.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

Provider terminal-state normalization for OpenAI-compatible completions and message delivery.

How is that risk mitigated?

The guard is limited to `stop` with no raw provider assistant output, no final visible text, no thinking, and no tool calls. Existing tool-call normalization runs first. Refusal-only, text, tool-call, and raw reasoning outputs are covered by regression tests.

## Current review state

What is the next action?

ClawSweeper review and maintainer review.

What is still waiting on author, maintainer, CI, or external proof?

Waiting on CI and ClawSweeper. No known author-side blocker after local proof and autoreview.

Which bot or reviewer comments were addressed?

This PR addresses the #91403 ClawSweeper blockers by covering the boundary-aware transport path and distinguishing raw provider no-output from transformed/suppressed output.

AI-assisted: yes, implemented with Codex. I reviewed the code path, ran the proof and tests above, and understand the change.
