### PR TITLE
fix(openai): honor configured embedding model input limits

### DIFF
--- a/extensions/openai/embedding-provider.test.ts
+++ b/extensions/openai/embedding-provider.test.ts
@@ -120,4 +120,48 @@ describe("OpenAI embedding provider", () => {
       }),
     );
   });
+
+  it("uses configured model maxTokens for third-party OpenAI-compatible embedding models", async () => {
+    const { provider } = await createOpenAiEmbeddingProvider(
+      createOptions({
+        provider: "siliconflow",
+        model: "BAAI/bge-large-zh-v1.5",
+        config: {
+          models: {
+            providers: {
+              siliconflow: {
+                api: "openai-completions",
+                baseUrl: "https://api.siliconflow.cn/v1",
+                models: [{ id: "BAAI/bge-large-zh-v1.5", maxTokens: 512 }],
+              },
+            },
+          },
+        } as MemoryEmbeddingProviderCreateOptions["config"],
+      }),
+    );
+
+    expect(provider.maxInputTokens).toBe(512);
+  });
+
+  it("falls back to configured model contextWindow when maxTokens is unavailable", async () => {
+    const { provider } = await createOpenAiEmbeddingProvider(
+      createOptions({
+        provider: "siliconflow",
+        model: "BAAI/bge-large-zh-v1.5",
+        config: {
+          models: {
+            providers: {
+              siliconflow: {
+                api: "openai-completions",
+                baseUrl: "https://api.siliconflow.cn/v1",
+                models: [{ id: "BAAI/bge-large-zh-v1.5", contextWindow: 768 }],
+              },
+            },
+          },
+        } as MemoryEmbeddingProviderCreateOptions["config"],
+      }),
+    );
+
+    expect(provider.maxInputTokens).toBe(768);
+  });
 });

--- a/extensions/openai/embedding-provider.ts
+++ b/extensions/openai/embedding-provider.ts
@@ -1,3 +1,4 @@
+import { findNormalizedProviderValue } from "@openclaw/model-catalog-core/provider-id";
 // Openai provider module implements model/runtime integration.
 import {
   fetchRemoteEmbeddingVectors,
@@ -34,6 +35,29 @@ function normalizeOpenAiModel(model: string): string {
     return DEFAULT_OPENAI_EMBEDDING_MODEL;
   }
   return trimmed.startsWith("openai/") ? trimmed.slice("openai/".length) : trimmed;
+}
+
+function resolveConfiguredModelMaxInputTokens(
+  options: MemoryEmbeddingProviderCreateOptions,
+  normalizedModel: string,
+): number | undefined {
+  const providerId = options.provider?.trim();
+  if (!providerId) {
+    return undefined;
+  }
+  const providerConfig = findNormalizedProviderValue(options.config.models?.providers, providerId);
+  const configuredModel = providerConfig?.models?.find(
+    (entry) => typeof entry?.id === "string" && entry.id.trim() === normalizedModel,
+  );
+  const maxTokens = configuredModel?.maxTokens;
+  if (typeof maxTokens === "number" && Number.isFinite(maxTokens) && maxTokens > 0) {
+    return Math.floor(maxTokens);
+  }
+  const contextWindow = configuredModel?.contextWindow;
+  if (typeof contextWindow === "number" && Number.isFinite(contextWindow) && contextWindow > 0) {
+    return Math.floor(contextWindow);
+  }
+  return undefined;
 }
 
 export async function createOpenAiEmbeddingProvider(
@@ -75,13 +99,16 @@ export async function createOpenAiEmbeddingProvider(
     });
   };
 
+  const configuredMaxInputTokens = resolveConfiguredModelMaxInputTokens(options, client.model);
+
   return {
     provider: {
       id: "openai",
       model: client.model,
-      ...(typeof OPENAI_MAX_INPUT_TOKENS[client.model] === "number"
-        ? { maxInputTokens: OPENAI_MAX_INPUT_TOKENS[client.model] }
-        : {}),
+      ...(() => {
+        const maxInputTokens = OPENAI_MAX_INPUT_TOKENS[client.model] ?? configuredMaxInputTokens;
+        return typeof maxInputTokens === "number" ? { maxInputTokens } : {};
+      })(),
       embedQuery: async (text, optionsValue) => {
         const [vec] = await embed([text], "query", optionsValue?.signal);
         return vec ?? [];


### PR DESCRIPTION
## Change Type / Scope / Linked Issue

- Type: fix
- Scope: `extensions/openai`, memory embeddings
- Linked Issue: fixes #91396

## Motivation

Fix memory indexing failures for third-party OpenAI-compatible embedding models whose real input limit is smaller than OpenClaw’s generic fallback.

Before this change, the OpenAI memory embedding provider only applied explicit input limits for a small built-in set of native OpenAI embedding models. When a third-party OpenAI-compatible embedding model was configured, the provider usually exposed no `maxInputTokens`, so downstream chunk enforcement fell back to the generic `8192` token default.

That is too permissive for providers such as SiliconFlow serving models like `BAAI/bge-large-zh-v1.5`, where the effective request limit can be much smaller. In that setup, oversized chunks could be sent upstream and memory indexing could fail with HTTP 400.

The issue author’s follow-up analysis narrowed the root cause well: this was not primarily a guarded-fetch transport problem, but a model-limit resolution problem.

## Changes

### Configured embedding limit fallback

#### `extensions/openai/embedding-provider.ts`

Added `resolveConfiguredModelMaxInputTokens(...)`.

When the embedding model is not one of the built-in OpenAI entries in `OPENAI_MAX_INPUT_TOKENS`, the provider now:

- looks up the configured provider in `config.models.providers`
- finds the matching configured model entry
- prefers configured `maxTokens`
- falls back to configured `contextWindow`

The resolved value is then exposed as `provider.maxInputTokens`, so existing memory chunk enforcement can honor the configured model limit before remote embedding requests are sent.

### Preserve existing OpenAI-native behavior

#### `extensions/openai/embedding-provider.ts`

Kept the current hardcoded limits for known native OpenAI embedding models.

The new config-based path only applies when no built-in OpenAI limit is available.

### Regression coverage

#### `extensions/openai/embedding-provider.test.ts`

Added focused tests covering:

- third-party OpenAI-compatible embedding models inheriting configured `maxTokens`
- fallback to configured `contextWindow` when `maxTokens` is not present

## Real behavior proof

### Behavior or issue addressed

Fixes provider-side embedding input limit resolution for third-party OpenAI-compatible memory embedding models.

Before this patch, the OpenAI memory embedding provider only assigned built-in input limits for a small set of native OpenAI embedding models. For configured third-party OpenAI-compatible embedding models, the provider could otherwise fall back to the generic `8192` token default unless model-specific configuration was surfaced correctly.

This patch verifies that, when no built-in OpenAI limit applies, the provider honors configured third-party model metadata by preferring `maxTokens` and then falling back to `contextWindow`.

### Real environment tested

- Local OpenClaw checkout on Linux
- Real repository code from this patched branch
- Real repository Vitest runner from the checkout

### Exact steps or command run after this patch

```bash
cd /root/openclaw
node /root/openclaw/scripts/run-vitest.mjs extensions/openai/embedding-provider.test.ts
```

Evidence after fix (terminal capture / copied live output / redacted runtime output)
Real test output from the patched checkout:

[test] starting test/vitest/vitest.extension-provider-openai.config.ts

 RUN  v4.1.7 /root/openclaw

 Test Files  1 passed (1)
      Tests  8 passed (8)
   Start at  13:27:28
   Duration  2.98s (transform 1.33s, setup 589ms, import 1.81s, tests 137ms, environment 0ms)

[test] passed 1 Vitest shard in 18.11s


The passing regression coverage now verifies the exact touched path:

a configured third-party OpenAI-compatible embedding model exposes configured maxTokens as provider.maxInputTokens
when maxTokens is absent, the provider falls back to configured contextWindow
Observed result after fix
In the real patched repository run, the OpenAI embedding provider test target now passes with regression coverage for third-party configured limit resolution. The exercised provider path now correctly preserves built-in OpenAI limits for native models while honoring configured limits for third-party OpenAI-compatible embedding models.

What was not tested
I did not run a credentialed live end-to-end SiliconFlow memory indexing reproduction in this environment
I did not validate every third-party OpenAI-compatible backend against a live remote API
Proof limitations or environment constraints
This verification is targeted to the exact provider behavior changed in this patch. The proof is based on real execution of the repository test target covering configured third-party model limit resolution, rather than a live external provider session.