### PR TITLE
fix(docs): make pnpm check:docs work in native PowerShell

### DIFF
--- a/config/markdownlint-cli2.jsonc
+++ b/config/markdownlint-cli2.jsonc
@@ -1,6 +1,6 @@
 {
   "globs": ["docs/**/*.md", "docs/**/*.mdx", "README.md"],
-  "ignores": ["docs/zh-CN/**", "docs/.i18n/**", "docs/reference/templates/**", "**/.local/**"],
+  "ignores": ["docs/zh-CN/**", "docs/.i18n/**", "docs/reference/templates/**", "**/.local/**", "**/CLAUDE.md"],
   "config": {
     "default": true,
 

--- a/scripts/format-docs.mjs
+++ b/scripts/format-docs.mjs
@@ -22,20 +22,26 @@ function docsFiles() {
     .filter((relativePath) => fs.existsSync(path.join(ROOT, relativePath)));
 }
 
-function runOxfmt(files) {
-  const result = spawnSync(
-    process.execPath,
-    [OXFMT_BIN, "--write", "--threads=1", "--config", OXFMT_CONFIG, ...files],
-    {
-      cwd: ROOT,
-      encoding: "utf8",
-      maxBuffer: 1024 * 1024 * 16,
-    },
-  );
+function runOxfmt(files, cwd = ROOT) {
+  const chunkSize = 50;
+  const configPath = cwd === ROOT ? OXFMT_CONFIG : path.join(cwd, ".oxfmtrc.jsonc");
+  for (let i = 0; i < files.length; i += chunkSize) {
+    const chunk = files.slice(i, i + chunkSize);
+    const result = spawnSync(
+      process.execPath,
+      [OXFMT_BIN, "--write", "--threads=1", "--config", configPath, ...chunk],
+      {
+        cwd,
+        encoding: "utf8",
+        maxBuffer: 1024 * 1024 * 16,
+      },
+    );
 
-  if (result.status !== 0) {
-    const stderr = result.stderr.trim();
-    throw new Error(`oxfmt failed${stderr ? `:\n${stderr}` : ""}`);
+    if (result.status !== 0 || result.error) {
+      console.error("spawnSync result:", result);
+      const stderr = result.stderr?.trim() ?? "";
+      throw new Error(`oxfmt failed${stderr ? `:\n${stderr}` : ""}`);
+    }
   }
 }
 
@@ -62,6 +68,7 @@ function copyDocsToTemp(files) {
     fs.mkdirSync(path.dirname(target), { recursive: true });
     fs.copyFileSync(source, target);
   }
+  fs.copyFileSync(OXFMT_CONFIG, path.join(tempRoot, ".oxfmtrc.jsonc"));
   return tempRoot;
 }
 
@@ -71,11 +78,11 @@ const files = docsFiles();
 if (CHECK) {
   const tempRoot = copyDocsToTemp(files);
   try {
-    runOxfmt(files.map((relativePath) => path.join(tempRoot, relativePath)));
+    runOxfmt(files, tempRoot);
     repairFiles(tempRoot, files);
     for (const relativePath of files) {
-      const raw = fs.readFileSync(path.join(ROOT, relativePath), "utf8");
-      const formatted = fs.readFileSync(path.join(tempRoot, relativePath), "utf8");
+      const raw = fs.readFileSync(path.join(ROOT, relativePath), "utf8").replace(/\r\n/g, "\n");
+      const formatted = fs.readFileSync(path.join(tempRoot, relativePath), "utf8").replace(/\r\n/g, "\n");
       if (formatted !== raw) {
         changed.push(relativePath);
       }


### PR DESCRIPTION
This PR fixes Windows compatibility issues with the docs check command in native PowerShell.

Details:
1. Batches the file list passed to oxfmt in ormat-docs.mjs to avoid hitting Windows command line length limits.
2. Resolves relative ignorePatterns correctly in check mode by copying the .oxfmtrc.jsonc config file to 	empRoot and setting it as the cwd.
3. Excludes **/CLAUDE.md from markdownlint checks to match oxfmt's ignore behavior.

Closes #44293