### PR TITLE
docs: preserve LINE across localized docs glossaries

### DIFF
--- a/docs/.i18n/glossary.ar.json
+++ b/docs/.i18n/glossary.ar.json
@@ -36,6 +36,10 @@
     "target": "Heartbeat"
   },
   {
+    "source": "LINE",
+    "target": "LINE"
+  },
+  {
     "source": "Mintlify",
     "target": "Mintlify"
   },

--- a/docs/.i18n/glossary.de.json
+++ b/docs/.i18n/glossary.de.json
@@ -36,6 +36,10 @@
     "target": "Heartbeat"
   },
   {
+    "source": "LINE",
+    "target": "LINE"
+  },
+  {
     "source": "Mintlify",
     "target": "Mintlify"
   },

--- a/docs/.i18n/glossary.es.json
+++ b/docs/.i18n/glossary.es.json
@@ -36,6 +36,10 @@
     "target": "Heartbeat"
   },
   {
+    "source": "LINE",
+    "target": "LINE"
+  },
+  {
     "source": "Mintlify",
     "target": "Mintlify"
   },

--- a/docs/.i18n/glossary.fa.json
+++ b/docs/.i18n/glossary.fa.json
@@ -36,6 +36,10 @@
     "target": "Heartbeat"
   },
   {
+    "source": "LINE",
+    "target": "LINE"
+  },
+  {
     "source": "Mintlify",
     "target": "Mintlify"
   },

--- a/docs/.i18n/glossary.fr.json
+++ b/docs/.i18n/glossary.fr.json
@@ -36,6 +36,10 @@
     "target": "Heartbeat"
   },
   {
+    "source": "LINE",
+    "target": "LINE"
+  },
+  {
     "source": "Mintlify",
     "target": "Mintlify"
   },

--- a/docs/.i18n/glossary.id.json
+++ b/docs/.i18n/glossary.id.json
@@ -36,6 +36,10 @@
     "target": "Heartbeat"
   },
   {
+    "source": "LINE",
+    "target": "LINE"
+  },
+  {
     "source": "Mintlify",
     "target": "Mintlify"
   },

--- a/docs/.i18n/glossary.it.json
+++ b/docs/.i18n/glossary.it.json
@@ -36,6 +36,10 @@
     "target": "Heartbeat"
   },
   {
+    "source": "LINE",
+    "target": "LINE"
+  },
+  {
     "source": "Mintlify",
     "target": "Mintlify"
   },

--- a/docs/.i18n/glossary.ja-JP.json
+++ b/docs/.i18n/glossary.ja-JP.json
@@ -40,6 +40,10 @@
     "target": "Heartbeat"
   },
   {
+    "source": "LINE",
+    "target": "LINE"
+  },
+  {
     "source": "local loopback",
     "target": "local loopback"
   },

--- a/docs/.i18n/glossary.ko.json
+++ b/docs/.i18n/glossary.ko.json
@@ -36,6 +36,10 @@
     "target": "Heartbeat"
   },
   {
+    "source": "LINE",
+    "target": "LINE"
+  },
+  {
     "source": "Mintlify",
     "target": "Mintlify"
   },

--- a/docs/.i18n/glossary.nl.json
+++ b/docs/.i18n/glossary.nl.json
@@ -36,6 +36,10 @@
     "target": "Heartbeat"
   },
   {
+    "source": "LINE",
+    "target": "LINE"
+  },
+  {
     "source": "Mintlify",
     "target": "Mintlify"
   },

--- a/docs/.i18n/glossary.pl.json
+++ b/docs/.i18n/glossary.pl.json
@@ -36,6 +36,10 @@
     "target": "Heartbeat"
   },
   {
+    "source": "LINE",
+    "target": "LINE"
+  },
+  {
     "source": "Mintlify",
     "target": "Mintlify"
   },

--- a/docs/.i18n/glossary.pt-BR.json
+++ b/docs/.i18n/glossary.pt-BR.json
@@ -36,6 +36,10 @@
     "target": "Heartbeat"
   },
   {
+    "source": "LINE",
+    "target": "LINE"
+  },
+  {
     "source": "Mintlify",
     "target": "Mintlify"
   },

--- a/docs/.i18n/glossary.th.json
+++ b/docs/.i18n/glossary.th.json
@@ -36,6 +36,10 @@
     "target": "Heartbeat"
   },
   {
+    "source": "LINE",
+    "target": "LINE"
+  },
+  {
     "source": "Mintlify",
     "target": "Mintlify"
   },

--- a/docs/.i18n/glossary.tr.json
+++ b/docs/.i18n/glossary.tr.json
@@ -36,6 +36,10 @@
     "target": "Heartbeat"
   },
   {
+    "source": "LINE",
+    "target": "LINE"
+  },
+  {
     "source": "Mintlify",
     "target": "Mintlify"
   },

--- a/docs/.i18n/glossary.uk.json
+++ b/docs/.i18n/glossary.uk.json
@@ -36,6 +36,10 @@
     "target": "Heartbeat"
   },
   {
+    "source": "LINE",
+    "target": "LINE"
+  },
+  {
     "source": "Mintlify",
     "target": "Mintlify"
   },

--- a/docs/.i18n/glossary.vi.json
+++ b/docs/.i18n/glossary.vi.json
@@ -36,6 +36,10 @@
     "target": "Heartbeat"
   },
   {
+    "source": "LINE",
+    "target": "LINE"
+  },
+  {
     "source": "Mintlify",
     "target": "Mintlify"
   },


### PR DESCRIPTION
## Summary

- Add `LINE -> LINE` to the remaining localized docs glossary files.
- Keep this follow-up narrowly scoped to the LINE brand term so generated localized docs do not translate `/channels/line` titles as the generic word "line".
- Leave other channel/product terms for separate evidence-backed follow-ups.

## Verification

- `jq -e . docs/.i18n/glossary.*.json`
- checked all 18 glossary files contain `LINE -> LINE`
- checked all 18 glossary files have no duplicate `source` entries
- `pnpm docs:check-i18n-glossary`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
