### PR TITLE
macos: resolve canvas/a2ui paths through gateway capability URL

### DIFF
--- a/apps/macos/Sources/OpenClaw/CanvasManager.swift
+++ b/apps/macos/Sources/OpenClaw/CanvasManager.swift
@@ -13,6 +13,7 @@ final class CanvasManager {
     private var panelController: CanvasWindowController?
     private var panelSessionKey: String?
     private var lastAutoA2UIUrl: String?
+    private var canvasPluginSurfaceUrl: String?
     private var gatewayWatchTask: Task<Void, Never>?
 
     private init() {
@@ -57,6 +58,7 @@ final class CanvasManager {
             }
             controller.presentAnchoredPanel(anchorProvider: anchorProvider)
             controller.applyPreferredPlacement(placement)
+            controller.canvasPluginSurfaceUrl = self.canvasPluginSurfaceUrl
             self.refreshDebugStatus()
 
             // Existing session: only navigate when an explicit target was provided.
@@ -93,6 +95,7 @@ final class CanvasManager {
         controller.onVisibilityChanged = { [weak self] visible in
             self?.onPanelVisibilityChanged?(visible)
         }
+        controller.canvasPluginSurfaceUrl = self.canvasPluginSurfaceUrl
         self.panelController = controller
         self.panelSessionKey = session
         controller.applyPreferredPlacement(placement)
@@ -155,6 +158,7 @@ final class CanvasManager {
         let raw =
             (snapshot.pluginsurfaceurls?["canvas"]?.value as? String)?
                 .trimmingCharacters(in: CharacterSet.whitespacesAndNewlines) ?? ""
+        self.canvasPluginSurfaceUrl = raw.isEmpty ? nil : raw
         if raw.isEmpty {
             Self.logger.debug("canvas plugin surface URL missing in gateway snapshot")
         } else {
@@ -170,6 +174,7 @@ final class CanvasManager {
             }
             return
         }
+        controller.canvasPluginSurfaceUrl = self.canvasPluginSurfaceUrl
         self.maybeAutoNavigateToA2UI(controller: controller, a2uiUrl: a2uiUrl)
     }
 

--- a/apps/macos/Sources/OpenClaw/CanvasWindowController+Testing.swift
+++ b/apps/macos/Sources/OpenClaw/CanvasWindowController+Testing.swift
@@ -46,5 +46,9 @@ extension CanvasWindowController {
     static func _testIsLocalNetworkCanvasURL(_ url: URL) -> Bool {
         CanvasA2UIActionMessageHandler.isLocalNetworkCanvasURL(url)
     }
+
+    static func _testResolveCanvasUrl(target: String, canvasPluginSurfaceUrl: String?) -> String? {
+        Self.resolveCanvasUrl(target: target, canvasPluginSurfaceUrl: canvasPluginSurfaceUrl)?.absoluteString
+    }
 }
 #endif

--- a/apps/macos/Sources/OpenClaw/CanvasWindowController.swift
+++ b/apps/macos/Sources/OpenClaw/CanvasWindowController.swift
@@ -16,6 +16,7 @@ final class CanvasWindowController: NSWindowController, WKNavigationDelegate, NS
     private let container: HoverChromeContainerView
     let presentation: CanvasPresentation
     var preferredPlacement: CanvasPlacement?
+    var canvasPluginSurfaceUrl: String?
     private(set) var currentTarget: String?
     private var debugStatusEnabled = false
     private var debugStatusTitle: String?
@@ -214,6 +215,13 @@ final class CanvasWindowController: NSWindowController, WKNavigationDelegate, NS
         let trimmed = target.trimmingCharacters(in: .whitespacesAndNewlines)
         self.currentTarget = trimmed
 
+        // Resolve hosted canvas/a2ui paths through the gateway capability URL.
+        if let resolved = Self.resolveCanvasUrl(target: trimmed, canvasPluginSurfaceUrl: self.canvasPluginSurfaceUrl) {
+            canvasWindowLogger.debug("canvas load resolved \(resolved.absoluteString, privacy: .public)")
+            self.webView.load(URLRequest(url: resolved))
+            return
+        }
+
         if let url = URL(string: trimmed), let scheme = url.scheme?.lowercased() {
             if scheme == "https" || scheme == "http" {
                 canvasWindowLogger.debug("canvas load url \(url.absoluteString, privacy: .public)")
@@ -265,6 +273,57 @@ final class CanvasWindowController: NSWindowController, WKNavigationDelegate, NS
             enabled: self.debugStatusEnabled,
             title: self.debugStatusTitle,
             subtitle: self.debugStatusSubtitle)
+    }
+
+    // MARK: - Capability URL resolution
+
+    private static let canvasHostPath = "/__openclaw__/canvas"
+    private static let a2uiPath = "/__openclaw__/a2ui"
+    private static let capabilityPrefix = "/__openclaw__/cap"
+
+    private static func isCanvasHttpPath(_ pathname: String) -> Bool {
+        pathname == canvasHostPath || pathname.hasPrefix("\(canvasHostPath)/")
+            || pathname == a2uiPath || pathname.hasPrefix("\(a2uiPath)/")
+    }
+
+    static func resolveCanvasUrl(target: String, canvasPluginSurfaceUrl: String?) -> URL? {
+        guard let surfaceUrl = canvasPluginSurfaceUrl?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !surfaceUrl.isEmpty
+        else { return nil }
+        guard let base = URL(string: surfaceUrl) else { return nil }
+        let scopedPrefix = base.path.replacingOccurrences(of: #"/+$"#, with: "", options: .regularExpression)
+        guard scopedPrefix.hasPrefix(capabilityPrefix) else { return nil }
+
+        let trimmed = target.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        let entry: URL
+        if let absolute = URL(string: trimmed), absolute.scheme != nil {
+            entry = absolute
+        } else {
+            guard let relative = URL(string: trimmed, relativeTo: base) else { return nil }
+            entry = relative
+        }
+
+        let pathname = entry.path
+        guard isCanvasHttpPath(pathname) else { return nil }
+
+        var components = URLComponents()
+        components.scheme = base.scheme
+        components.host = base.host
+        if let port = base.port {
+            components.port = port
+        }
+        components.user = base.user
+        components.password = base.password
+        components.path = "\(scopedPrefix)\(pathname)"
+
+        if let entryComponents = URLComponents(url: entry, resolvingAgainstBaseURL: true) {
+            components.query = entryComponents.query
+            components.fragment = entryComponents.fragment
+        }
+
+        return components.url
     }
 
     private func loadFile(_ url: URL) {

--- a/apps/macos/Tests/OpenClawIPCTests/CanvasWindowSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/CanvasWindowSmokeTests.swift
@@ -79,4 +79,59 @@ struct CanvasWindowSmokeTests {
         #expect(controller
             .shouldAutoNavigateToA2UI(lastAutoTarget: currentTarget, candidateTarget: currentTarget) == false)
     }
+
+    @Test func `capability url resolution`() {
+        let base = "https://tailscale-host/__openclaw__/cap/abc123"
+
+        // Path target
+        #expect(CanvasWindowController._testResolveCanvasUrl(
+            target: "/__openclaw__/canvas/test.html",
+            canvasPluginSurfaceUrl: base)
+            == "https://tailscale-host/__openclaw__/cap/abc123/__openclaw__/canvas/test.html")
+
+        // A2UI path
+        #expect(CanvasWindowController._testResolveCanvasUrl(
+            target: "/__openclaw__/a2ui/?platform=macos",
+            canvasPluginSurfaceUrl: base)
+            == "https://tailscale-host/__openclaw__/cap/abc123/__openclaw__/a2ui/?platform=macos")
+
+        // With query and fragment
+        #expect(CanvasWindowController._testResolveCanvasUrl(
+            target: "/__openclaw__/canvas/dash.html?q=1#section",
+            canvasPluginSurfaceUrl: base)
+            == "https://tailscale-host/__openclaw__/cap/abc123/__openclaw__/canvas/dash.html?q=1#section")
+
+        // Non-canvas path should not resolve
+        #expect(CanvasWindowController._testResolveCanvasUrl(
+            target: "/some/other/path.html",
+            canvasPluginSurfaceUrl: base) == nil)
+
+        // Full HTTP URL to canvas path should resolve
+        #expect(CanvasWindowController._testResolveCanvasUrl(
+            target: "http://other-host/__openclaw__/canvas/test.html",
+            canvasPluginSurfaceUrl: base)
+            == "https://tailscale-host/__openclaw__/cap/abc123/__openclaw__/canvas/test.html")
+
+        // No capability URL should not resolve
+        #expect(CanvasWindowController._testResolveCanvasUrl(
+            target: "/__openclaw__/canvas/test.html",
+            canvasPluginSurfaceUrl: nil) == nil)
+
+        // Invalid capability URL prefix should not resolve
+        #expect(CanvasWindowController._testResolveCanvasUrl(
+            target: "/__openclaw__/canvas/test.html",
+            canvasPluginSurfaceUrl: "https://host/other/prefix") == nil)
+
+        // Trailing slash in capability URL
+        #expect(CanvasWindowController._testResolveCanvasUrl(
+            target: "/__openclaw__/canvas/test.html",
+            canvasPluginSurfaceUrl: "https://tailscale-host/__openclaw__/cap/abc123/")
+            == "https://tailscale-host/__openclaw__/cap/abc123/__openclaw__/canvas/test.html")
+
+        // Non-default port
+        #expect(CanvasWindowController._testResolveCanvasUrl(
+            target: "/__openclaw__/canvas/test.html",
+            canvasPluginSurfaceUrl: "https://tailscale-host:8443/__openclaw__/cap/abc123")
+            == "https://tailscale-host:8443/__openclaw__/cap/abc123/__openclaw__/canvas/test.html")
+    }
 }


### PR DESCRIPTION
## Summary

Fix #91083

When the macOS Canvas navigates to paths like `/__openclaw__/canvas/...` or `/__openclaw__/a2ui/...`, the existing code passes them directly to the WKWebView, which breaks hosted canvas surfaces that must be resolved through the gateway capability URL.

This change reads the `pluginsurfaceurls.canvas` value from the gateway snapshot and uses it to resolve canvas/a2ui paths into fully-qualified capability URLs before loading.

## Changes

- `CanvasManager.swift`: Reads `pluginsurfaceurls.canvas` from the gateway snapshot, caches it as `canvasPluginSurfaceUrl`, and injects it into `CanvasWindowController` on creation and reuse.
- `CanvasWindowController.swift`: Adds `resolveCanvasUrl(target:canvasPluginSurfaceUrl:)` to resolve `/__openclaw__/canvas/*` and `/__openclaw__/a2ui/*` paths against the capability base URL. Preserves query strings, fragments, ports, and non-default schemes.
- `CanvasWindowController+Testing.swift`: Exposes `_testResolveCanvasUrl` for unit-test access.
- `CanvasWindowSmokeTests.swift`: Adds `capability url resolution` tests covering path targets, a2ui paths, query + fragment, non-canvas path rejection, absolute canvas URL rewriting, missing capability URL, invalid capability prefix, trailing slash normalization, and non-default ports.

## Verification

### Automated tests

Run the canvas window smoke tests:

```bash
cd apps/macos
xcodebuild test -scheme OpenClaw -destination 'platform=macOS' -only-testing OpenClawIPCTests/CanvasWindowSmokeTests/capability_url_resolution
```

Or run the full CanvasWindowSmokeTests suite:

```bash
xcodebuild test -scheme OpenClaw -destination 'platform=macOS' -only-testing OpenClawIPCTests/CanvasWindowSmokeTests
```

### Test coverage

The `capability url resolution` test validates the following scenarios:

| Scenario | Input target | Capability URL | Expected result |
|---|---|---|---|
| Path target | `/__openclaw__/canvas/test.html` | `https://tailscale-host/__openclaw__/cap/abc123` | `https://tailscale-host/__openclaw__/cap/abc123/__openclaw__/canvas/test.html` |
| A2UI path | `/__openclaw__/a2ui/?platform=macos` | `https://tailscale-host/__openclaw__/cap/abc123` | `https://tailscale-host/__openclaw__/cap/abc123/__openclaw__/a2ui/?platform=macos` |
| Query + fragment | `/__openclaw__/canvas/dash.html?q=1#section` | `https://tailscale-host/__openclaw__/cap/abc123` | `https://tailscale-host/__openclaw__/cap/abc123/__openclaw__/canvas/dash.html?q=1#section` |
| Non-canvas path | `/some/other/path.html` | `https://tailscale-host/__openclaw__/cap/abc123` | `nil` (does not resolve) |
| Absolute canvas URL | `http://other-host/__openclaw__/canvas/test.html` | `https://tailscale-host/__openclaw__/cap/abc123` | `https://tailscale-host/__openclaw__/cap/abc123/__openclaw__/canvas/test.html` |
| Missing capability URL | `/__openclaw__/canvas/test.html` | `nil` | `nil` (does not resolve) |
| Invalid capability prefix | `/__openclaw__/canvas/test.html` | `https://host/other/prefix` | `nil` (does not resolve) |
| Trailing slash | `/__openclaw__/canvas/test.html` | `https://tailscale-host/__openclaw__/cap/abc123/` | `https://tailscale-host/__openclaw__/cap/abc123/__openclaw__/canvas/test.html` |
| Non-default port | `/__openclaw__/canvas/test.html` | `https://tailscale-host:8443/__openclaw__/cap/abc123` | `https://tailscale-host:8443/__openclaw__/cap/abc123/__openclaw__/canvas/test.html` |

### Behavior verification

- Existing `http`/`https`/`file` URL loading paths remain unchanged; the new capability resolution only triggers when the target matches `/__openclaw__/canvas/*` or `/__openclaw__/a2ui/*`.
- When no capability URL is configured or the prefix does not match `/__openclaw__/cap`, the method returns `nil` and the caller falls back to the original plain URL loading logic.
