### PR TITLE
fix(agents): expose sessions_spawn in TUI when subagents.allowAgents is configured

### DIFF
--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -391,7 +391,11 @@ export function createOpenClawTools(
     !embedded ||
     options?.sourceReplyDeliveryMode === "message_tool_only" ||
     messageExplicitlyAllowed;
-  const includeSubagentSpawnTool = !embedded || options?.allowGatewaySubagentBinding === true;
+  const hasSubagentConfig =
+    Array.isArray(resolvedConfig?.agents?.defaults?.subagents?.allowAgents) &&
+    resolvedConfig.agents.defaults.subagents.allowAgents.length > 0;
+  const includeSubagentSpawnTool =
+    !embedded || options?.allowGatewaySubagentBinding === true || hasSubagentConfig;
   const effectiveCallGateway = embedded
     ? createEmbeddedCallGateway()
     : openClawToolsDeps.callGateway;


### PR DESCRIPTION
fix(agents): expose sessions_spawn in TUI when subagents.allowAgents is configured

## What Problem This Solves

The `sessions_spawn` tool is hidden from the TUI when running in embedded mode, even when `subagents.allowAgents` is explicitly configured. Users have no way to spawn subagents from the TUI console.

## Why This Change Was Made

Add `hasSubagentConfig` check so that `sessions_spawn` is exposed when `subagents.allowAgents` has configured agent IDs, not only when `allowGatewaySubagentBinding` is true.

Fixes #91095.

## Evidence

Reproducibility: yes. Current main only exposes `sessions_spawn` when `allowGatewaySubagentBinding` is true, ignoring configured `subagents.allowAgents`.

Direct behavior probe of the config check:

```text
$ node --import tsx -e "
const resolvedConfig = { agents: { defaults: { subagents: { allowAgents: ['agent1'] } } } };
const hasSubagentConfig =
    Array.isArray(resolvedConfig?.agents?.defaults?.subagents?.allowAgents) &&
    resolvedConfig.agents.defaults.subagents.allowAgents.length > 0;
console.log('hasSubagentConfig:', hasSubagentConfig);
const includeSubagentSpawnTool = false || false || hasSubagentConfig;
console.log('includeSubagentSpawnTool:', includeSubagentSpawnTool);
"
hasSubagentConfig: true
includeSubagentSpawnTool: true
```

Formatting:

```text
$ npx oxfmt --check src/agents/openclaw-tools.ts
All matched files use the correct format.
```

Whitespace:

```text
$ git diff --check
```