### PR TITLE
fix(reply-queue): remove the drained item by reference instead of front index

### DIFF
--- a/src/auto-reply/reply/queue/drain.ts
+++ b/src/auto-reply/reply/queue/drain.ts
@@ -9,6 +9,7 @@ import {
   drainCollectQueueStep,
   drainNextQueueItem,
   hasCrossChannelItems,
+  removeQueuedItemsByRef,
   previewQueueSummaryPrompt,
   waitForQueueDebounce,
 } from "../../../utils/queue-helpers.js";
@@ -497,7 +498,7 @@ export function scheduleFollowupDrain(
             } else {
               await drainGroup();
             }
-            queue.items.splice(0, groupItems.length);
+            removeQueuedItemsByRef(queue.items, groupItems);
             if (pendingSummary) {
               clearFollowupQueueSummaryState(queue);
               pendingSummary = undefined;

--- a/src/utils/queue-helpers.test.ts
+++ b/src/utils/queue-helpers.test.ts
@@ -1,10 +1,12 @@
 // Queue helper tests cover queue ordering and dedupe utility behavior.
 import { describe, expect, it } from "vitest";
 import {
+  applyQueueDropPolicy,
   applyQueueRuntimeSettings,
   buildQueueSummaryPrompt,
   clearQueueSummaryState,
   drainCollectItemIfNeeded,
+  drainNextQueueItem,
   hasCrossChannelItems,
   previewQueueSummaryPrompt,
 } from "./queue-helpers.js";
@@ -167,6 +169,57 @@ describe("drainCollectItemIfNeeded", () => {
 
     expect(result).toBe("empty");
     expect(forced).toBe(true);
+  });
+});
+
+describe("drainNextQueueItem", () => {
+  it("keeps overflow survivors when the queue mutates during an awaited drain", async () => {
+    type Item = { id: string };
+    const queue = {
+      items: [{ id: "m1" }],
+      cap: 3,
+      dropPolicy: "summarize" as const,
+      droppedCount: 0,
+      summaryLines: [],
+    };
+    const delivered: string[] = [];
+    const dropped: string[] = [];
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    const firstDrain = drainNextQueueItem(queue.items, async (item: Item) => {
+      delivered.push(item.id);
+      await gate;
+    });
+    await Promise.resolve();
+
+    for (let index = 2; index <= 8; index += 1) {
+      const item = { id: `m${index}` };
+      const shouldEnqueue = applyQueueDropPolicy({
+        queue,
+        summarize: (queued) => queued.id,
+        onDrop: (items) => {
+          dropped.push(...items.map((queued) => queued.id));
+        },
+      });
+      if (shouldEnqueue) {
+        queue.items.push(item);
+      }
+    }
+
+    release();
+    await firstDrain;
+    while (
+      await drainNextQueueItem(queue.items, async (item) => {
+        delivered.push(item.id);
+      })
+    ) {}
+
+    expect(delivered).toEqual(["m1", "m6", "m7", "m8"]);
+    expect(dropped).toEqual(["m1", "m2", "m3", "m4", "m5"]);
+    expect(queue.items).toEqual([]);
   });
 });
 

--- a/src/utils/queue-helpers.ts
+++ b/src/utils/queue-helpers.ts
@@ -166,6 +166,15 @@ export function beginQueueDrain<T extends { draining: boolean }>(
   return queue;
 }
 
+export function removeQueuedItemsByRef<T>(items: T[], processed: readonly T[]): void {
+  for (const item of processed) {
+    const idx = items.indexOf(item);
+    if (idx !== -1) {
+      items.splice(idx, 1);
+    }
+  }
+}
+
 /** Run and remove the next queued item, returning false when empty. */
 export async function drainNextQueueItem<T>(
   items: T[],
@@ -176,7 +185,7 @@ export async function drainNextQueueItem<T>(
     return false;
   }
   await run(next);
-  items.shift();
+  removeQueuedItemsByRef(items, [next]);
   return true;
 }
 


### PR DESCRIPTION
## Summary

During a burst of inbound messages to a busy session, the reply queue can silently drop a queued message: it is never answered and is not even counted in the "Dropped N messages due to cap" overflow summary.

The drain helper removes the wrong item. `drainNextQueueItem` (`src/utils/queue-helpers.ts`) captures `next = items[0]`, `await`s the run (a real agent turn, seconds long), then calls `items.shift()` on the assumption that index 0 still holds the item it just ran:

```ts
const next = items[0];
await run(next);
items.shift();
```

But `enqueueFollowupRun` mutates the **same shared** `items` array for every concurrent inbound message, and at or over cap `applyQueueDropPolicy` does `items.splice(0, dropCount)`, removing from the **front**. If enough messages arrive while `items[0]` is in flight, the in-flight item is itself spliced off the front (and recorded as dropped), shifting a different, still-undelivered survivor into index 0. When the `await` returns, `items.shift()` deletes that survivor: it was never run, and it is not in the overflow summary either.

The same positional-front assumption breaks the collect path in `src/auto-reply/reply/queue/drain.ts`: it snapshots `const items = queue.items.slice()`, runs each authorization group, then does `queue.items.splice(0, groupItems.length)` after the awaited run, which can splice off survivors that arrived during the run rather than the group it actually processed.

The fix removes the items that were actually processed by identity instead of by front position. A small `removeQueuedItemsByRef` helper does an `indexOf` + `splice` per processed item; `drainNextQueueItem` removes the one item it ran, and the collect path removes the group it ran.

## Diff size

```
 src/auto-reply/reply/queue/drain.ts |  3 ++-
 src/utils/queue-helpers.ts          | 11 ++++++++++-
 2 files changed, 12 insertions(+), 2 deletions(-)
```

## Verification

Local (Node 22.19.0), against this checkout:

- `node scripts/run-vitest.mjs src/utils/queue-helpers.test.ts src/auto-reply/reply/queue/drain.identity-guard.test.ts` - pass (11 tests).
- `node scripts/run-vitest.mjs src/auto-reply/reply/reply-flow.test.ts` - pass (12 tests).
- `tsgo:core` - exit 0. `scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json` on both changed files - clean.
- Red/green proof: a local harness that drives the real exported queue helpers (`drainNextQueueItem`, `applyQueueDropPolicy`, `buildQueueSummaryPrompt`) and recreates a cap-overflow burst during an in-flight drain fails on `origin/main` (a survivor is lost) and passes on this branch. The harness is kept local and is not part of this single-commit fix; its captured before/after output is in Real behavior proof below.

## Real behavior proof

- **Behavior addressed:** when a burst of inbound messages overflows the cap while the queue is draining an in-flight item, a still-undelivered queued message that survives the drop policy is no longer removed without running. Every survivor is now delivered, left queued, or counted in the overflow summary.
- **Real environment tested:** the real exported reply-queue helpers in this checkout (`src/utils/queue-helpers.ts` `drainNextQueueItem`, `applyQueueDropPolicy`, `buildQueueSummaryPrompt`), composed exactly as the drain loop composes them: seed one item, begin draining it, and while that drain is awaiting, push a 7-message burst through `applyQueueDropPolicy` at cap 3 (the same shared array the drain holds), then drain the remainder and read back what was delivered, what stayed queued, what the drop policy dropped, and the emitted overflow summary. No network or provider credentials are involved; the defect is pure in-memory queue bookkeeping.
- **Exact steps or command run after this patch:** seeded `m1`, began draining it, and during the awaited run pushed `m2..m8` through `applyQueueDropPolicy` on the shared array (cap 3, summarize policy), then drained to completion and printed `DELIVERED`, `REMAINING`, `DROPPED_BY_POLICY`, the `SUMMARY_PROMPT`, and `LOST` (any id that is in none of delivered, remaining, or dropped). Ran the identical harness once on this branch and once with the two production files reverted to `origin/main`.
- **Evidence after fix:** live before/after output of the harness. Before is the two production files at `origin/main`; after is this branch:

```
# origin/main (drain shift()s index 0)
DELIVERED:         ["m1","m7","m8"]
REMAINING:         []
DROPPED_BY_POLICY: ["m1","m2","m3","m4","m5"]
SUMMARY_PROMPT:    "[Queue overflow] Dropped 5 messages due to cap.\nSummary:\n- m3\n- m4\n- m5"
LOST:              ["m6"]

# this branch (drain removes the item it ran by reference)
DELIVERED:         ["m1","m6","m7","m8"]
REMAINING:         []
DROPPED_BY_POLICY: ["m1","m2","m3","m4","m5"]
SUMMARY_PROMPT:    "[Queue overflow] Dropped 5 messages due to cap.\nSummary:\n- m3\n- m4\n- m5"
LOST:              []
```

- **Observed result after fix:** `m6` survived the drop policy but, on `origin/main`, appeared in none of delivered, remaining, or the overflow summary (`LOST: ["m6"]`) - silent loss beyond the cap accounting. On this branch the identical burst delivers `m6` (`DELIVERED` includes `m6`, `LOST` is empty); the documented overflow accounting for `m1..m5` is unchanged.
- **What was not tested:** a fully live multi-message burst over a real channel against a running agent. The before/after above exercises the real exported queue helpers composed in the production drain order; it does not stand up a live Discord/Telegram/Slack session, which is unnecessary because the lost-survivor bug lives entirely in the shared in-memory queue bookkeeping these helpers own.
