### PR TITLE
fix(mcp): repair OAuth redirect, errors, and unicode schema patterns

### DIFF
--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -523,6 +523,21 @@ describe("session MCP runtime", () => {
     expect(dynamicRefValidator(1).valid).toBe(false);
   });
 
+  it("compiles draft-2020-12 patterns with redundant unicode-invalid escapes", () => {
+    const validator = createBundleMcpJsonSchemaValidator().getValidator({
+      $schema: "https://json-schema.org/draft/2020-12/schema",
+      type: "object",
+      properties: {
+        url: { type: "string", pattern: "^https\\:\\/\\/" },
+      },
+      required: ["url"],
+      additionalProperties: false,
+    });
+
+    expect(validator({ url: "https://example.com/path" }).valid).toBe(true);
+    expect(validator({ url: "http://example.com" }).valid).toBe(false);
+  });
+
   it("accepts draft-2020-12 local refs into schema arrays", () => {
     const validator = createBundleMcpJsonSchemaValidator().getValidator({
       $schema: "https://json-schema.org/draft/2020-12/schema",

--- a/src/agents/mcp-http-fetch.test.ts
+++ b/src/agents/mcp-http-fetch.test.ts
@@ -121,6 +121,21 @@ describe("MCP HTTP fetch helpers", () => {
     expect(lookupMock).not.toHaveBeenCalled();
   });
 
+  it.each([204, 205, 304])("preserves bodyless HTTP %s responses", async (status) => {
+    testGlobal[TEST_UNDICI_RUNTIME_DEPS_KEY] = {
+      Agent: TestAgent,
+      EnvHttpProxyAgent: TestEnvHttpProxyAgent,
+      ProxyAgent: TestProxyAgent,
+      fetch: async () => new Response(null, { status }),
+    };
+    const fetch = buildMcpHttpFetch({ resourceUrl: "https://mcp.example.com/mcp" });
+
+    const response = await fetch("https://mcp.example.com/mcp");
+
+    expect(response.status).toBe(status);
+    expect(response.body).toBeNull();
+  });
+
   it("keeps same-origin TLS overrides ahead of configured env proxy", async () => {
     vi.stubEnv("https_proxy", "http://proxy.example:8080");
     const fetch = buildMcpHttpFetch({

--- a/src/agents/mcp-http-fetch.test.ts
+++ b/src/agents/mcp-http-fetch.test.ts
@@ -202,16 +202,7 @@ describe("MCP HTTP fetch helpers", () => {
       status = 400;
       statusText = "Bad Request";
       headers = new Headers({ "content-type": "application/json" });
-      body = new ReadableStream({
-        start(controller) {
-          controller.enqueue(
-            new TextEncoder().encode(
-              '{"error":"invalid_client_metadata","error_description":"bad redirect"}',
-            ),
-          );
-          controller.close();
-        },
-      });
+      body = null;
       get ok() {
         return false;
       }

--- a/src/agents/mcp-http-fetch.test.ts
+++ b/src/agents/mcp-http-fetch.test.ts
@@ -1,3 +1,4 @@
+import { parseErrorResponse } from "@modelcontextprotocol/sdk/client/auth.js";
 /**
  * Regression coverage for MCP HTTP fetch wrappers.
  * Verifies SSRF-guarded fetch, scoped dispatcher behavior, and same-origin headers.
@@ -194,5 +195,48 @@ describe("MCP HTTP fetch helpers", () => {
     expect(new Headers(calls[0]?.[1]?.headers).get("x-tenant")).toBe("docs");
     expect(new Headers(calls[0]?.[1]?.headers).get("mcp-protocol-version")).toBe("2025-06-18");
     expect(calls[1]?.[1]?.headers).toBeUndefined();
+  });
+
+  it("returns fetch responses compatible with MCP SDK OAuth error parsing", async () => {
+    class ForeignResponse {
+      status = 400;
+      statusText = "Bad Request";
+      headers = new Headers({ "content-type": "application/json" });
+      body = new ReadableStream({
+        start(controller) {
+          controller.enqueue(
+            new TextEncoder().encode(
+              '{"error":"invalid_client_metadata","error_description":"bad redirect"}',
+            ),
+          );
+          controller.close();
+        },
+      });
+      get ok() {
+        return false;
+      }
+      async text() {
+        return '{"error":"invalid_client_metadata","error_description":"bad redirect"}';
+      }
+    }
+
+    testGlobal[TEST_UNDICI_RUNTIME_DEPS_KEY] = {
+      Agent: TestAgent,
+      EnvHttpProxyAgent: TestEnvHttpProxyAgent,
+      ProxyAgent: TestProxyAgent,
+      fetch: async (url: string | URL | Request, init?: unknown) => {
+        fetchCalls.push({ url, init });
+        return new ForeignResponse() as unknown as Response;
+      },
+    };
+    const fetch = buildMcpHttpFetch({
+      resourceUrl: "https://mcp.example.com/mcp",
+    });
+
+    const response = await fetch("https://auth.example.com/oauth/register", { method: "POST" });
+    expect(response).toBeInstanceOf(Response);
+    const error = await parseErrorResponse(response);
+    expect(error.message).toContain("bad redirect");
+    expect(error.message).not.toContain("[object Response]");
   });
 });

--- a/src/agents/mcp-http-fetch.ts
+++ b/src/agents/mcp-http-fetch.ts
@@ -56,22 +56,30 @@ function resolveFetchRequest(input: RequestInfo | URL, init?: RequestInit) {
   };
 }
 
-function ensureGlobalFetchResponse(response: Response): Response {
-  return new Response(response.body, {
+async function ensureGlobalFetchResponse(response: Response): Promise<Response> {
+  const init = {
     status: response.status,
     statusText: response.statusText,
     headers: response.headers,
-  });
+  };
+  if (response.body != null) {
+    return new Response(response.body, init);
+  }
+  if (typeof response.text === "function") {
+    const text = await response.text();
+    return new Response(text, init);
+  }
+  return new Response(null, init);
 }
 
-function buildManagedMcpResponse(
+async function buildManagedMcpResponse(
   response: Response,
   release: () => Promise<void>,
   refreshTimeout?: () => void,
-): Response {
+): Promise<Response> {
   if (!response.body) {
     void release();
-    return ensureGlobalFetchResponse(response);
+    return await ensureGlobalFetchResponse(response);
   }
 
   const source = response.body;
@@ -115,7 +123,7 @@ function buildManagedMcpResponse(
     },
   });
   managedMcpResponseCleanupRegistry.register(wrappedBody, { finalize }, cleanupRegistrationToken);
-  return ensureGlobalFetchResponse(
+  return await ensureGlobalFetchResponse(
     new Response(wrappedBody, {
       status: response.status,
       statusText: response.statusText,
@@ -165,7 +173,7 @@ export function buildMcpHttpFetch(params: {
       ...(needsCustomDispatcher ? { resolveDispatcherPolicy: resolveCustomDispatcherPolicy } : {}),
     };
     const guarded = await fetchWithSsrFGuard(guardedFetchOptions);
-    return buildManagedMcpResponse(guarded.response, guarded.release, guarded.refreshTimeout);
+    return await buildManagedMcpResponse(guarded.response, guarded.release, guarded.refreshTimeout);
   };
 }
 

--- a/src/agents/mcp-http-fetch.ts
+++ b/src/agents/mcp-http-fetch.ts
@@ -65,6 +65,9 @@ async function ensureGlobalFetchResponse(response: Response): Promise<Response> 
   if (response.body != null) {
     return new Response(response.body, init);
   }
+  if (response.status === 204 || response.status === 205 || response.status === 304) {
+    return new Response(null, init);
+  }
   if (typeof response.text === "function") {
     const text = await response.text();
     return new Response(text, init);

--- a/src/agents/mcp-http-fetch.ts
+++ b/src/agents/mcp-http-fetch.ts
@@ -56,6 +56,14 @@ function resolveFetchRequest(input: RequestInfo | URL, init?: RequestInit) {
   };
 }
 
+function ensureGlobalFetchResponse(response: Response): Response {
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
+}
+
 function buildManagedMcpResponse(
   response: Response,
   release: () => Promise<void>,
@@ -63,7 +71,7 @@ function buildManagedMcpResponse(
 ): Response {
   if (!response.body) {
     void release();
-    return response;
+    return ensureGlobalFetchResponse(response);
   }
 
   const source = response.body;
@@ -107,11 +115,13 @@ function buildManagedMcpResponse(
     },
   });
   managedMcpResponseCleanupRegistry.register(wrappedBody, { finalize }, cleanupRegistrationToken);
-  return new Response(wrappedBody, {
-    status: response.status,
-    statusText: response.statusText,
-    headers: response.headers,
-  });
+  return ensureGlobalFetchResponse(
+    new Response(wrappedBody, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+    }),
+  );
 }
 
 /** Builds an MCP fetch function with optional TLS/client-cert dispatcher support. */

--- a/src/agents/mcp-oauth.test.ts
+++ b/src/agents/mcp-oauth.test.ts
@@ -116,6 +116,21 @@ describe("MCP OAuth provider", () => {
     ]);
   });
 
+  it("does not retry a code exchange redirect mismatch", async () => {
+    authMock.mockReset();
+    authMock.mockRejectedValueOnce(new Error("invalid_grant: redirect_uri mismatch"));
+
+    await expect(
+      runMcpOAuthLogin({
+        serverName: "Calendly",
+        serverUrl: "https://mcp.calendly.com/",
+        authorizationCode: "code-123",
+      }),
+    ).rejects.toThrow("redirect_uri mismatch");
+
+    expect(authMock).toHaveBeenCalledOnce();
+  });
+
   it("persists localhost redirect for a later code exchange login", async () => {
     await withTempHome(
       async (home) => {

--- a/src/agents/mcp-oauth.test.ts
+++ b/src/agents/mcp-oauth.test.ts
@@ -116,6 +116,51 @@ describe("MCP OAuth provider", () => {
     ]);
   });
 
+  it("persists localhost redirect for a later code exchange login", async () => {
+    await withTempHome(
+      async (home) => {
+        authMock.mockReset();
+        authMock
+          .mockRejectedValueOnce(new Error("invalid_client_metadata: redirect_uri rejected"))
+          .mockResolvedValueOnce("REDIRECT");
+
+        await expect(
+          runMcpOAuthLogin({
+            serverName: "Calendly",
+            serverUrl: "https://mcp.calendly.com/",
+            onAuthorizationUrl: () => {},
+          }),
+        ).resolves.toBe("redirect");
+
+        const tokenDir = `${home}/.openclaw/mcp-oauth`;
+        const entries = await fs.readdir(tokenDir);
+        const store = JSON.parse(await fs.readFile(`${tokenDir}/${entries[0]}`, "utf-8")) as {
+          redirectUrl?: string;
+        };
+        expect(store.redirectUrl).toBe("http://localhost:8989/oauth/callback");
+
+        authMock.mockReset();
+        authMock.mockResolvedValueOnce("AUTHORIZED");
+        await runMcpOAuthLogin({
+          serverName: "Calendly",
+          serverUrl: "https://mcp.calendly.com/",
+          authorizationCode: "code-123",
+        });
+        expect(authMock.mock.calls[0]?.[0]?.clientMetadata.redirect_uris).toEqual([
+          "http://localhost:8989/oauth/callback",
+        ]);
+      },
+      {
+        prefix: "openclaw-mcp-oauth-localhost-persist-",
+        skipSessionCleanup: true,
+        env: {
+          OPENCLAW_CONFIG_PATH: undefined,
+          OPENCLAW_STATE_DIR: undefined,
+        },
+      },
+    );
+  });
+
   it("does not start hidden authorization flows without an authorization callback", async () => {
     // Normal agent/tool execution must not open browser auth flows implicitly;
     // operators use the explicit mcp login command instead.

--- a/src/agents/mcp-oauth.test.ts
+++ b/src/agents/mcp-oauth.test.ts
@@ -165,7 +165,10 @@ describe("MCP OAuth provider", () => {
         authMock.mockReset();
         authMock
           .mockRejectedValueOnce(new Error("invalid_client_metadata: redirect_uri rejected"))
-          .mockResolvedValueOnce("REDIRECT");
+          .mockImplementationOnce(async (provider) => {
+            await provider.saveCodeVerifier?.("verifier");
+            return "REDIRECT";
+          });
 
         await expect(
           runMcpOAuthLogin({
@@ -178,9 +181,11 @@ describe("MCP OAuth provider", () => {
         const tokenDir = `${home}/.openclaw/mcp-oauth`;
         const entries = await fs.readdir(tokenDir);
         const store = JSON.parse(await fs.readFile(`${tokenDir}/${entries[0]}`, "utf-8")) as {
+          codeVerifier?: string;
           redirectUrl?: string;
         };
         expect(store.redirectUrl).toBe("http://localhost:8989/oauth/callback");
+        expect(store.codeVerifier).toBe("verifier");
 
         authMock.mockReset();
         authMock.mockResolvedValueOnce("AUTHORIZED");

--- a/src/agents/mcp-oauth.test.ts
+++ b/src/agents/mcp-oauth.test.ts
@@ -131,6 +131,34 @@ describe("MCP OAuth provider", () => {
     expect(authMock).toHaveBeenCalledOnce();
   });
 
+  it("does not persist localhost when the fallback attempt fails", async () => {
+    await withTempHome(
+      async (home) => {
+        authMock.mockReset();
+        authMock
+          .mockRejectedValueOnce(new Error("invalid_client_metadata: redirect_uri rejected"))
+          .mockRejectedValueOnce(new Error("localhost redirect also rejected"));
+
+        await expect(
+          runMcpOAuthLogin({
+            serverName: "Calendly",
+            serverUrl: "https://mcp.calendly.com/",
+          }),
+        ).rejects.toThrow("localhost redirect also rejected");
+
+        await expect(fs.readdir(`${home}/.openclaw/mcp-oauth`)).rejects.toThrow();
+      },
+      {
+        prefix: "openclaw-mcp-oauth-localhost-failure-",
+        skipSessionCleanup: true,
+        env: {
+          OPENCLAW_CONFIG_PATH: undefined,
+          OPENCLAW_STATE_DIR: undefined,
+        },
+      },
+    );
+  });
+
   it("persists localhost redirect for a later code exchange login", async () => {
     await withTempHome(
       async (home) => {

--- a/src/agents/mcp-oauth.test.ts
+++ b/src/agents/mcp-oauth.test.ts
@@ -66,6 +66,16 @@ describe("MCP OAuth provider", () => {
     );
   });
 
+  it("defaults OAuth redirect URI to localhost for authorization-server compatibility", () => {
+    const provider = createMcpOAuthClientProvider({
+      serverName: "Calendly",
+      serverUrl: "https://mcp.calendly.com/",
+    });
+
+    expect(provider.clientMetadata.redirect_uris).toEqual(["http://localhost:8989/oauth/callback"]);
+    expect(provider.redirectUrl).toBe("http://localhost:8989/oauth/callback");
+  });
+
   it("does not start hidden authorization flows without an authorization callback", async () => {
     // Normal agent/tool execution must not open browser auth flows implicitly;
     // operators use the explicit mcp login command instead.

--- a/src/agents/mcp-oauth.test.ts
+++ b/src/agents/mcp-oauth.test.ts
@@ -2,7 +2,19 @@
 import fs from "node:fs/promises";
 import { withTempHome } from "openclaw/plugin-sdk/test-env";
 import { describe, expect, it } from "vitest";
-import { clearMcpOAuthCredentials, createMcpOAuthClientProvider } from "./mcp-oauth.js";
+import { vi } from "vitest";
+import {
+  clearMcpOAuthCredentials,
+  createMcpOAuthClientProvider,
+  isMcpOAuthRedirectRegistrationError,
+  runMcpOAuthLogin,
+} from "./mcp-oauth.js";
+
+const authMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@modelcontextprotocol/sdk/client/auth.js", () => ({
+  auth: authMock,
+}));
 
 describe("MCP OAuth provider", () => {
   it("stores token state under the OpenClaw state directory with restricted permissions", async () => {
@@ -66,14 +78,42 @@ describe("MCP OAuth provider", () => {
     );
   });
 
-  it("defaults OAuth redirect URI to localhost for authorization-server compatibility", () => {
+  it("keeps the legacy loopback redirect as the default for upgrade compatibility", () => {
     const provider = createMcpOAuthClientProvider({
       serverName: "Calendly",
       serverUrl: "https://mcp.calendly.com/",
     });
 
-    expect(provider.clientMetadata.redirect_uris).toEqual(["http://localhost:8989/oauth/callback"]);
-    expect(provider.redirectUrl).toBe("http://localhost:8989/oauth/callback");
+    expect(provider.clientMetadata.redirect_uris).toEqual(["http://127.0.0.1:8989/oauth/callback"]);
+    expect(provider.redirectUrl).toBe("http://127.0.0.1:8989/oauth/callback");
+  });
+
+  it("detects redirect registration failures for localhost fallback", () => {
+    expect(
+      isMcpOAuthRedirectRegistrationError(
+        new Error("HTTP 400: invalid_client_metadata redirect_uri must be localhost"),
+      ),
+    ).toBe(true);
+    expect(isMcpOAuthRedirectRegistrationError(new Error("unauthorized"))).toBe(false);
+  });
+
+  it("retries MCP OAuth login with localhost after redirect registration rejection", async () => {
+    authMock.mockReset();
+    authMock
+      .mockRejectedValueOnce(new Error("invalid_client_metadata: redirect_uri rejected"))
+      .mockResolvedValueOnce("AUTHORIZED");
+
+    await expect(
+      runMcpOAuthLogin({
+        serverName: "Calendly",
+        serverUrl: "https://mcp.calendly.com/",
+      }),
+    ).resolves.toBe("authorized");
+
+    expect(authMock).toHaveBeenCalledTimes(2);
+    expect(authMock.mock.calls[1]?.[0]?.clientMetadata.redirect_uris).toEqual([
+      "http://localhost:8989/oauth/callback",
+    ]);
   });
 
   it("does not start hidden authorization flows without an authorization callback", async () => {

--- a/src/agents/mcp-oauth.ts
+++ b/src/agents/mcp-oauth.ts
@@ -270,6 +270,7 @@ export async function runMcpOAuthLogin(params: {
     return await runMcpOAuthLoginAttempt(loginParams);
   } catch (error) {
     if (
+      !normalizeOptionalString(params.authorizationCode) &&
       !normalizeOptionalString(params.config?.redirectUrl) &&
       isMcpOAuthRedirectRegistrationError(error)
     ) {

--- a/src/agents/mcp-oauth.ts
+++ b/src/agents/mcp-oauth.ts
@@ -281,7 +281,8 @@ export async function runMcpOAuthLogin(params: {
           redirectUrl: LOCALHOST_REDIRECT_URL,
         },
       });
-      await writeStore(filePath, { ...store, redirectUrl: LOCALHOST_REDIRECT_URL });
+      const retryStore = await readStore(filePath);
+      await writeStore(filePath, { ...retryStore, redirectUrl: LOCALHOST_REDIRECT_URL });
       return result;
     }
     throw error;

--- a/src/agents/mcp-oauth.ts
+++ b/src/agents/mcp-oauth.ts
@@ -3,7 +3,8 @@
  * private OpenClaw state directory with one hashed file per MCP server URL.
  */
 import { createHash, randomUUID } from "node:crypto";
-import fs from "node:fs/promises";
+import fs from "node:fs";
+import fsPromises from "node:fs/promises";
 import path from "node:path";
 import {
   auth,
@@ -26,6 +27,7 @@ type McpOAuthStore = {
   codeVerifier?: string;
   discoveryState?: OAuthDiscoveryState;
   lastAuthorizationUrl?: string;
+  redirectUrl?: string;
   state?: string;
 };
 
@@ -59,24 +61,42 @@ function oauthStorePath(serverName: string, serverUrl: string): string {
 
 async function readStore(filePath: string): Promise<McpOAuthStore> {
   try {
-    return JSON.parse(await fs.readFile(filePath, "utf-8")) as McpOAuthStore;
+    return JSON.parse(await fsPromises.readFile(filePath, "utf-8")) as McpOAuthStore;
+  } catch {
+    return {};
+  }
+}
+
+function readStoreSync(filePath: string): McpOAuthStore {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, "utf-8")) as McpOAuthStore;
   } catch {
     return {};
   }
 }
 
 async function writeStore(filePath: string, store: McpOAuthStore): Promise<void> {
-  await fs.mkdir(path.dirname(filePath), { recursive: true, mode: 0o700 });
-  await fs.writeFile(filePath, JSON.stringify(store, null, 2), { encoding: "utf-8", mode: 0o600 });
-  await fs.chmod(filePath, 0o600).catch(() => {});
+  await fsPromises.mkdir(path.dirname(filePath), { recursive: true, mode: 0o700 });
+  await fsPromises.writeFile(filePath, JSON.stringify(store, null, 2), {
+    encoding: "utf-8",
+    mode: 0o600,
+  });
+  await fsPromises.chmod(filePath, 0o600).catch(() => {});
 }
 
-function resolveOAuthRedirectUrl(config: McpOAuthConfig): string {
-  return normalizeOptionalString(config.redirectUrl) ?? LEGACY_DEFAULT_REDIRECT_URL;
+function resolveOAuthRedirectUrl(config: McpOAuthConfig, store: McpOAuthStore = {}): string {
+  return (
+    normalizeOptionalString(config.redirectUrl) ??
+    normalizeOptionalString(store.redirectUrl) ??
+    LEGACY_DEFAULT_REDIRECT_URL
+  );
 }
 
-function buildOAuthClientMetadata(config: McpOAuthConfig): OAuthClientMetadata {
-  const redirectUrl = resolveOAuthRedirectUrl(config);
+function buildOAuthClientMetadata(
+  config: McpOAuthConfig,
+  store: McpOAuthStore = {},
+): OAuthClientMetadata {
+  const redirectUrl = resolveOAuthRedirectUrl(config, store);
   return {
     client_name: "OpenClaw MCP",
     redirect_uris: [redirectUrl],
@@ -99,7 +119,6 @@ export function createMcpOAuthClientProvider(params: {
 }): OAuthClientProvider {
   const config = params.config ?? {};
   const filePath = oauthStorePath(params.serverName, params.serverUrl);
-  const redirectUrl = resolveOAuthRedirectUrl(config);
   const allowAuthorizationRedirect =
     params.allowAuthorizationRedirect ?? Boolean(params.onAuthorizationUrl);
   const assertAuthorizationRedirectAllowed = () => {
@@ -111,11 +130,11 @@ export function createMcpOAuthClientProvider(params: {
   };
   return {
     get redirectUrl() {
-      return redirectUrl;
+      return resolveOAuthRedirectUrl(config, readStoreSync(filePath));
     },
     clientMetadataUrl: normalizeOptionalString(config.clientMetadataUrl),
     get clientMetadata() {
-      return buildOAuthClientMetadata(config);
+      return buildOAuthClientMetadata(config, readStoreSync(filePath));
     },
     async state() {
       assertAuthorizationRedirectAllowed();
@@ -188,7 +207,7 @@ export async function clearMcpOAuthCredentials(params: {
   serverName: string;
   serverUrl: string;
 }): Promise<void> {
-  await fs.rm(oauthStorePath(params.serverName, params.serverUrl), { force: true });
+  await fsPromises.rm(oauthStorePath(params.serverName, params.serverUrl), { force: true });
 }
 
 /** Reads stored OAuth credential presence without exposing credential values. */
@@ -238,13 +257,23 @@ export async function runMcpOAuthLogin(params: {
   fetchFn?: FetchLike;
   onAuthorizationUrl?: (url: URL) => void | Promise<void>;
 }): Promise<"authorized" | "redirect"> {
+  const filePath = oauthStorePath(params.serverName, params.serverUrl);
+  const store = await readStore(filePath);
+  const loginParams = {
+    ...params,
+    config: {
+      ...params.config,
+      redirectUrl: normalizeOptionalString(params.config?.redirectUrl) ?? store.redirectUrl,
+    },
+  };
   try {
-    return await runMcpOAuthLoginAttempt(params);
+    return await runMcpOAuthLoginAttempt(loginParams);
   } catch (error) {
     if (
       !normalizeOptionalString(params.config?.redirectUrl) &&
       isMcpOAuthRedirectRegistrationError(error)
     ) {
+      await writeStore(filePath, { ...store, redirectUrl: LOCALHOST_REDIRECT_URL });
       return await runMcpOAuthLoginAttempt({
         ...params,
         config: {

--- a/src/agents/mcp-oauth.ts
+++ b/src/agents/mcp-oauth.ts
@@ -44,7 +44,7 @@ export type McpOAuthCredentialsStatus = {
   hasLastAuthorizationUrl: boolean;
 };
 
-const DEFAULT_REDIRECT_URL = "http://127.0.0.1:8989/oauth/callback";
+const DEFAULT_REDIRECT_URL = "http://localhost:8989/oauth/callback";
 
 function oauthStorePath(serverName: string, serverUrl: string): string {
   const safeServerName = sanitizeServerName(serverName, new Set<string>());

--- a/src/agents/mcp-oauth.ts
+++ b/src/agents/mcp-oauth.ts
@@ -44,7 +44,12 @@ export type McpOAuthCredentialsStatus = {
   hasLastAuthorizationUrl: boolean;
 };
 
-const DEFAULT_REDIRECT_URL = "http://localhost:8989/oauth/callback";
+const LEGACY_DEFAULT_REDIRECT_URL = "http://127.0.0.1:8989/oauth/callback";
+const LOCALHOST_REDIRECT_URL = "http://localhost:8989/oauth/callback";
+
+export function isMcpOAuthRedirectRegistrationError(error: unknown): boolean {
+  return /invalid_client_metadata|redirect_uri/i.test(String(error));
+}
 
 function oauthStorePath(serverName: string, serverUrl: string): string {
   const safeServerName = sanitizeServerName(serverName, new Set<string>());
@@ -66,8 +71,12 @@ async function writeStore(filePath: string, store: McpOAuthStore): Promise<void>
   await fs.chmod(filePath, 0o600).catch(() => {});
 }
 
+function resolveOAuthRedirectUrl(config: McpOAuthConfig): string {
+  return normalizeOptionalString(config.redirectUrl) ?? LEGACY_DEFAULT_REDIRECT_URL;
+}
+
 function buildOAuthClientMetadata(config: McpOAuthConfig): OAuthClientMetadata {
-  const redirectUrl = normalizeOptionalString(config.redirectUrl) ?? DEFAULT_REDIRECT_URL;
+  const redirectUrl = resolveOAuthRedirectUrl(config);
   return {
     client_name: "OpenClaw MCP",
     redirect_uris: [redirectUrl],
@@ -90,7 +99,7 @@ export function createMcpOAuthClientProvider(params: {
 }): OAuthClientProvider {
   const config = params.config ?? {};
   const filePath = oauthStorePath(params.serverName, params.serverUrl);
-  const redirectUrl = normalizeOptionalString(config.redirectUrl) ?? DEFAULT_REDIRECT_URL;
+  const redirectUrl = resolveOAuthRedirectUrl(config);
   const allowAuthorizationRedirect =
     params.allowAuthorizationRedirect ?? Boolean(params.onAuthorizationUrl);
   const assertAuthorizationRedirectAllowed = () => {
@@ -197,8 +206,7 @@ export async function readMcpOAuthCredentialsStatus(params: {
   };
 }
 
-/** Runs the MCP OAuth login flow, returning whether it authorized or needs redirect. */
-export async function runMcpOAuthLogin(params: {
+async function runMcpOAuthLoginAttempt(params: {
   serverName: string;
   serverUrl: string;
   config?: McpOAuthConfig;
@@ -219,4 +227,32 @@ export async function runMcpOAuthLogin(params: {
     },
   );
   return result === "AUTHORIZED" ? "authorized" : "redirect";
+}
+
+/** Runs the MCP OAuth login flow, returning whether it authorized or needs redirect. */
+export async function runMcpOAuthLogin(params: {
+  serverName: string;
+  serverUrl: string;
+  config?: McpOAuthConfig;
+  authorizationCode?: string;
+  fetchFn?: FetchLike;
+  onAuthorizationUrl?: (url: URL) => void | Promise<void>;
+}): Promise<"authorized" | "redirect"> {
+  try {
+    return await runMcpOAuthLoginAttempt(params);
+  } catch (error) {
+    if (
+      !normalizeOptionalString(params.config?.redirectUrl) &&
+      isMcpOAuthRedirectRegistrationError(error)
+    ) {
+      return await runMcpOAuthLoginAttempt({
+        ...params,
+        config: {
+          ...params.config,
+          redirectUrl: LOCALHOST_REDIRECT_URL,
+        },
+      });
+    }
+    throw error;
+  }
 }

--- a/src/agents/mcp-oauth.ts
+++ b/src/agents/mcp-oauth.ts
@@ -274,14 +274,15 @@ export async function runMcpOAuthLogin(params: {
       !normalizeOptionalString(params.config?.redirectUrl) &&
       isMcpOAuthRedirectRegistrationError(error)
     ) {
-      await writeStore(filePath, { ...store, redirectUrl: LOCALHOST_REDIRECT_URL });
-      return await runMcpOAuthLoginAttempt({
+      const result = await runMcpOAuthLoginAttempt({
         ...params,
         config: {
           ...params.config,
           redirectUrl: LOCALHOST_REDIRECT_URL,
         },
       });
+      await writeStore(filePath, { ...store, redirectUrl: LOCALHOST_REDIRECT_URL });
+      return result;
     }
     throw error;
   }

--- a/src/shared/json-schema-defaults.test.ts
+++ b/src/shared/json-schema-defaults.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { normalizeJsonSchemaForTypeBox } from "./json-schema-defaults.js";
+
+describe("normalizeJsonSchemaForTypeBox", () => {
+  it("combines pattern properties that collide after unicode repair", () => {
+    const normalized = normalizeJsonSchemaForTypeBox({
+      type: "object",
+      patternProperties: {
+        "^https:": { minLength: 1 },
+        "^https\\:": { maxLength: 10 },
+      },
+    });
+
+    expect(normalized).toMatchObject({
+      patternProperties: {
+        "^https:": {
+          allOf: [{ minLength: 1 }, { maxLength: 10 }],
+        },
+      },
+    });
+  });
+});

--- a/src/shared/json-schema-defaults.test.ts
+++ b/src/shared/json-schema-defaults.test.ts
@@ -19,4 +19,18 @@ describe("normalizeJsonSchemaForTypeBox", () => {
       },
     });
   });
+
+  it.each(["constructor", "toString", "__proto__"])(
+    "preserves pattern property key %s",
+    (pattern) => {
+      const normalized = normalizeJsonSchemaForTypeBox({
+        type: "object",
+        patternProperties: Object.fromEntries([[pattern, { type: "string" }]]),
+      });
+
+      expect(normalized).toMatchObject({
+        patternProperties: Object.fromEntries([[pattern, { type: "string" }]]),
+      });
+    },
+  );
 });

--- a/src/shared/json-schema-defaults.ts
+++ b/src/shared/json-schema-defaults.ts
@@ -148,6 +148,18 @@ function normalizeSchemaDependencies(value: unknown): unknown {
   );
 }
 
+function normalizePatternProperties(value: Record<string, unknown>): Record<string, unknown> {
+  const normalized: Record<string, unknown> = {};
+  for (const [pattern, propertySchema] of Object.entries(value)) {
+    const repairedPattern = repairJsonSchemaPatternForUnicodeRegExp(pattern);
+    const repairedSchema = normalizeJsonSchemaNode(propertySchema);
+    const existingSchema = normalized[repairedPattern];
+    normalized[repairedPattern] =
+      existingSchema === undefined ? repairedSchema : { allOf: [existingSchema, repairedSchema] };
+  }
+  return normalized;
+}
+
 function expandJsonSchemaTypeArray(schema: Record<string, unknown>): Record<string, unknown> {
   const { nullable, type, ...rest } = schema;
   const types = Array.isArray(type) ? [...type] : typeof type === "string" ? [type] : null;
@@ -202,15 +214,7 @@ function normalizeJsonSchemaNode(schema: unknown): unknown {
         return [key, repairJsonSchemaPatternForUnicodeRegExp(value)];
       }
       if (key === "patternProperties" && isRecord(value)) {
-        return [
-          key,
-          Object.fromEntries(
-            Object.entries(value).map(([pattern, propertySchema]) => [
-              repairJsonSchemaPatternForUnicodeRegExp(pattern),
-              normalizeJsonSchemaNode(propertySchema),
-            ]),
-          ),
-        ];
+        return [key, normalizePatternProperties(value)];
       }
       if (schemaMapKeywords.has(key)) {
         return [key, normalizeSchemaMap(value)];

--- a/src/shared/json-schema-defaults.ts
+++ b/src/shared/json-schema-defaults.ts
@@ -149,15 +149,17 @@ function normalizeSchemaDependencies(value: unknown): unknown {
 }
 
 function normalizePatternProperties(value: Record<string, unknown>): Record<string, unknown> {
-  const normalized: Record<string, unknown> = {};
+  const normalized = new Map<string, unknown>();
   for (const [pattern, propertySchema] of Object.entries(value)) {
     const repairedPattern = repairJsonSchemaPatternForUnicodeRegExp(pattern);
     const repairedSchema = normalizeJsonSchemaNode(propertySchema);
-    const existingSchema = normalized[repairedPattern];
-    normalized[repairedPattern] =
-      existingSchema === undefined ? repairedSchema : { allOf: [existingSchema, repairedSchema] };
+    const existingSchema = normalized.get(repairedPattern);
+    normalized.set(
+      repairedPattern,
+      existingSchema === undefined ? repairedSchema : { allOf: [existingSchema, repairedSchema] },
+    );
   }
-  return normalized;
+  return Object.fromEntries(normalized);
 }
 
 function expandJsonSchemaTypeArray(schema: Record<string, unknown>): Record<string, unknown> {

--- a/src/shared/json-schema-defaults.ts
+++ b/src/shared/json-schema-defaults.ts
@@ -112,25 +112,28 @@ function normalizeSchemaMap(value: unknown): unknown {
   );
 }
 
+function compilesUnicodePattern(pattern: string): boolean {
+  try {
+    const probe = new RegExp(pattern, "u");
+    void probe;
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 /** Repair JSON Schema regex patterns that fail TypeBox's unicode RegExp compile. */
 export function repairJsonSchemaPatternForUnicodeRegExp(pattern: string): string {
-  try {
-    new RegExp(pattern, "u");
+  if (compilesUnicodePattern(pattern)) {
     return pattern;
-  } catch {
-    const repaired = pattern.replace(/\\([^\\])/g, (match, ch: string) => {
-      if (ch === ":" || ch === "/") {
-        return ch;
-      }
-      return match;
-    });
-    try {
-      new RegExp(repaired, "u");
-      return repaired;
-    } catch {
-      return pattern;
-    }
   }
+  const repaired = pattern.replace(/\\([^\\])/g, (match, ch: string) => {
+    if (ch === ":" || ch === "/") {
+      return ch;
+    }
+    return match;
+  });
+  return compilesUnicodePattern(repaired) ? repaired : pattern;
 }
 
 function normalizeSchemaDependencies(value: unknown): unknown {

--- a/src/shared/json-schema-defaults.ts
+++ b/src/shared/json-schema-defaults.ts
@@ -112,6 +112,27 @@ function normalizeSchemaMap(value: unknown): unknown {
   );
 }
 
+/** Repair JSON Schema regex patterns that fail TypeBox's unicode RegExp compile. */
+export function repairJsonSchemaPatternForUnicodeRegExp(pattern: string): string {
+  try {
+    new RegExp(pattern, "u");
+    return pattern;
+  } catch {
+    const repaired = pattern.replace(/\\([^\\])/g, (match, ch: string) => {
+      if (ch === ":" || ch === "/") {
+        return ch;
+      }
+      return match;
+    });
+    try {
+      new RegExp(repaired, "u");
+      return repaired;
+    } catch {
+      return pattern;
+    }
+  }
+}
+
 function normalizeSchemaDependencies(value: unknown): unknown {
   if (!isRecord(value)) {
     return value;
@@ -173,6 +194,20 @@ function normalizeJsonSchemaNode(schema: unknown): unknown {
     Object.entries(normalizedSchema).map(([key, value]) => {
       if (key === "$dynamicRef" && normalizedSchema.$ref === undefined) {
         return ["$ref", value];
+      }
+      if (key === "pattern" && typeof value === "string") {
+        return [key, repairJsonSchemaPatternForUnicodeRegExp(value)];
+      }
+      if (key === "patternProperties" && isRecord(value)) {
+        return [
+          key,
+          Object.fromEntries(
+            Object.entries(value).map(([pattern, propertySchema]) => [
+              repairJsonSchemaPatternForUnicodeRegExp(pattern),
+              normalizeJsonSchemaNode(propertySchema),
+            ]),
+          ),
+        ];
       }
       if (schemaMapKeywords.has(key)) {
         return [key, normalizeSchemaMap(value)];


### PR DESCRIPTION
## Summary

- Keep the legacy `127.0.0.1` OAuth redirect default for upgrade compatibility, and retry dynamic client registration with `http://localhost:8989/oauth/callback` when an authorization server rejects the IP loopback redirect.
- Surface real OAuth error bodies instead of `"[object Response]"` by normalizing body-less MCP HTTP fetch responses to global `Response` objects the MCP SDK can read.
- Prevent post-auth MCP probe crashes on PayPal-like tool schemas whose JSON Schema `pattern` values use redundant `\:` escapes that are invalid under TypeBox's unicode RegExp compile path.

Why does this matter now?

Remote streamable-http MCP servers with OAuth (PayPal, Calendly) are currently unusable or fail with opaque errors after login.

What is the intended outcome?

Operators can run `openclaw mcp login` / `openclaw mcp probe` against OAuth MCP servers without regex compile crashes, with readable DCR errors, and with a tested localhost fallback for ASes that reject `127.0.0.1`.

What is intentionally out of scope?

- Live end-to-end OAuth against PayPal/Calendly in this PR environment
- Upstream MCP SDK changes

What does success look like?

Regression tests cover all three failure modes; maintainers can confirm live OAuth on PayPal/Calendly with the reporter's repro steps.

What should reviewers focus on?

Localhost redirect fallback policy (only after DCR rejection, legacy default preserved) and the conservative JSON Schema pattern repair applied before TypeBox compile.

## Linked context

Which issue does this close?

Closes #91433

Which issues, PRs, or discussions are related?

Related #91433 (ClawSweeper review and reporter follow-up confirming localhost fixes Calendly)

Was this requested by a maintainer or owner?

No — community bug report with maintainer review pending.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: MCP OAuth regex crash, `[object Response]` error masking, Calendly DCR redirect rejection
- Real environment tested: Local Node v25.6.0 on Windows checkout (`E:/Projects/openclaw`), branch `fix/issue-91433-mcp-oauth-regex`
- Exact steps or command run after this patch:
  - `node -e` repro script for PayPal-like TypeBox pattern compile and body-less OAuth error normalization (copied output below)
  - `node scripts/run-vitest.mjs src/agents/mcp-oauth.test.ts -t "legacy loopback|redirect registration|retries MCP"`
  - `node scripts/run-vitest.mjs src/agents/mcp-http-fetch.test.ts -t "compatible with MCP SDK"`
  - `pnpm exec oxlint` on changed source files

- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

Copied terminal output from a local Node repro after this patch:

```
Terminal output (PayPal-like TypeBox pattern):
  before: Invalid regular expression: /^https\:\/\///u: Invalid escape
  after repair compiles as: ^https:///
Terminal output (OAuth DCR error body path):
  foreign response instanceof Response: false
  wrapped response instanceof Response: true
  parsed error_description: bad redirect
```

- Observed result after fix: PayPal-like unicode-invalid pattern compiles after repair; body-less foreign fetch responses normalize to global `Response` so OAuth error JSON is readable; localhost redirect retry is covered by unit test.
- What was not tested: Live `openclaw mcp login/probe` against PayPal or Calendly
- Proof limitations or environment constraints: No access to external OAuth AS credentials/endpoints in this environment; reporter already confirmed localhost redirect fixes Calendly live.
- Before evidence (optional but encouraged): Issue #91433 repro logs (`Invalid regular expression: /^https\:\/\//u`, `[object Response]`)

## Tests and validation

Which commands did you run?

- `node scripts/run-vitest.mjs src/agents/mcp-oauth.test.ts -t "legacy loopback|redirect registration|retries MCP"`
- `node scripts/run-vitest.mjs src/agents/mcp-http-fetch.test.ts -t "compatible with MCP SDK"`
- `pnpm exec oxlint src/shared/json-schema-defaults.ts src/agents/mcp-oauth.ts src/agents/mcp-http-fetch.ts`

What regression coverage was added or updated?

- `mcp-oauth.test.ts`: legacy default preserved; localhost retry after redirect registration rejection
- `mcp-http-fetch.test.ts`: body-less cross-realm fetch response works with MCP SDK `parseErrorResponse`
- `agent-bundle-mcp-runtime.test.ts`: unicode-invalid JSON Schema pattern compiles and validates

What failed before this fix, if known?

- PayPal probe: `Invalid regular expression: /^https\:\/\//u: Invalid escape`
- Calendly login: `Invalid OAuth error response ... "[object Response]"`
- Calendly DCR: `invalid_client_metadata` for `127.0.0.1` redirect (reporter confirmed localhost works)

If no test was added, why not?

N/A — regression tests added for all three fixes.

## Risk checklist

Did user-visible behavior change? (`Yes`)

New localhost redirect retry on DCR rejection; legacy `127.0.0.1` default preserved for existing registrations.

Did config, environment, or migration behavior change? (`No`)

Did security, auth, secrets, network, or tool execution behavior change? (`Yes`)

OAuth redirect registration fallback and MCP HTTP response normalization for OAuth error readability.

What is the highest-risk area?

OAuth redirect fallback after dynamic client registration failure.

How is that risk mitigated?

Legacy default unchanged; localhost used only on explicit DCR redirect rejection without configured override; existing `--oauth-redirect-url` override remains.

## Current review state

What is the next action?

Wait for maintainer review. CI is green on head `564eac41ac`; request another ClawSweeper re-review after the prior run timed out (`Codex ETIMEDOUT`).

What is still waiting on author, maintainer, CI, or external proof?

- ClawSweeper re-review on `564eac41ac` did not complete (timeout); no fresh bot verdict yet
- Live PayPal/Calendly `openclaw mcp login/probe` proof still unavailable in contributor environment

Which bot or reviewer comments were addressed?

- All prior P1 code findings addressed in `564eac41ac` (body-less error text, redirect persistence)
- CI: `check-lint`, `Real behavior proof`, `checks-node-agentic-agents-support`, `checks-node-agentic-agents-core-runtime` — pass on latest push
