### PR TITLE
fix #91420: [Bug]: Delivery retry loop corrupts active sessions (R-004) — retry selector bypasses delivery.mode=none

### DIFF
--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -1580,6 +1580,176 @@ describe("sessions tools", () => {
     expect(calls.some((call) => call.method === "agent")).toBe(false);
   });
 
+  it("sessions_send reports source reply delivery mode mismatch without durable-session fallback", async () => {
+    const calls: Array<{ method?: string; params?: unknown }> = [];
+    const runScopedCallerKey = "agent:leasing-ops:cron:monthly-utility:run:run-fast";
+    const queueMessage = vi.fn(async () => {});
+    setActiveEmbeddedRun(
+      "caller-active-session",
+      {
+        queueMessage,
+        isStreaming: () => true,
+        isCompacting: () => false,
+        supportsTranscriptCommitWait: true,
+        sourceReplyDeliveryMode: "automatic",
+        abort: () => {},
+      },
+      runScopedCallerKey,
+    );
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string; params?: unknown };
+      calls.push(request);
+      if (request.method === "agent") {
+        return { runId: "fallback-run", status: "accepted", acceptedAt: 2000 };
+      }
+      return {};
+    });
+
+    const tool = createOpenClawTools({
+      agentSessionKey: "agent:re-portal:main",
+      agentChannel: "telegram",
+      config: {
+        ...TEST_CONFIG,
+        session: {
+          ...TEST_CONFIG.session,
+          agentToAgent: { maxPingPongTurns: 0 },
+        },
+      },
+    }).find((candidate) => candidate.name === "sessions_send");
+    if (!tool) {
+      throw new Error("missing sessions_send tool");
+    }
+
+    const result = await tool.execute("call-run-scoped-caller", {
+      sessionKey: runScopedCallerKey,
+      message: "[TASK-COMPLETE] re-portal occupancy ready",
+      timeoutSeconds: 0,
+    });
+
+    const details = sessionsSendDetails(result.details);
+    expect(details.status).toBe("error");
+    expect(details.sessionKey).toBe(runScopedCallerKey);
+    expect(details.error).toContain(
+      "queue_message_failed reason=source_reply_delivery_mode_mismatch",
+    );
+    expect(queueMessage).not.toHaveBeenCalled();
+    expect(calls.some((call) => call.method === "agent")).toBe(false);
+  });
+
+  it("sessions_send falls back from stranded cron run key to durable cron parent", async () => {
+    const calls: Array<{ method?: string; params?: unknown }> = [];
+    const runScopedCallerKey = "agent:leasing-ops:cron:monthly-utility:run:run-fast";
+    const durableCronCallerKey = "agent:leasing-ops:cron:monthly-utility";
+    const queueMessage = vi.fn(async () => {});
+    setActiveEmbeddedRun(
+      "caller-active-session",
+      {
+        queueMessage,
+        isStreaming: () => false,
+        isCompacting: () => false,
+        supportsTranscriptCommitWait: true,
+        sourceReplyDeliveryMode: "message_tool_only",
+        abort: () => {},
+      },
+      runScopedCallerKey,
+    );
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string; params?: unknown };
+      calls.push(request);
+      if (request.method === "agent") {
+        return { runId: "durable-fallback-run", status: "accepted", acceptedAt: 2000 };
+      }
+      return {};
+    });
+
+    const tool = createOpenClawTools({
+      agentSessionKey: "agent:re-portal:main",
+      agentChannel: "telegram",
+      config: {
+        ...TEST_CONFIG,
+        session: {
+          ...TEST_CONFIG.session,
+          agentToAgent: { maxPingPongTurns: 0 },
+        },
+      },
+    }).find((candidate) => candidate.name === "sessions_send");
+    if (!tool) {
+      throw new Error("missing sessions_send tool");
+    }
+
+    const result = await tool.execute("call-run-scoped-caller", {
+      sessionKey: runScopedCallerKey,
+      message: "[TASK-COMPLETE] re-portal occupancy ready",
+      timeoutSeconds: 0,
+    });
+
+    const details = sessionsSendDetails(result.details);
+    expect(details.status).toBe("accepted");
+    expect(details.runId).toBe("durable-fallback-run");
+    expect(details.sessionKey).toBe(runScopedCallerKey);
+    expect(queueMessage).not.toHaveBeenCalled();
+    const agentCalls = calls.filter((call) => call.method === "agent");
+    expect(agentCalls).toHaveLength(1);
+    const params = agentParams(agentCalls[0] ?? {});
+    expect(params.sessionKey).toBe(durableCronCallerKey);
+    expect(params.message).toContain("[Inter-session message]");
+    expect(params.message).toContain("[TASK-COMPLETE] re-portal occupancy ready");
+  });
+
+  it("sessions_send rejects non-cron run-looking keys without durable-session fallback", async () => {
+    const calls: Array<{ method?: string; params?: unknown }> = [];
+    const runScopedCallerKey = "agent:leasing-ops:slack:channel:c-room:run:run-fast";
+    const queueMessage = vi.fn(async () => {});
+    setActiveEmbeddedRun(
+      "caller-active-session",
+      {
+        queueMessage,
+        isStreaming: () => false,
+        isCompacting: () => false,
+        supportsTranscriptCommitWait: true,
+        sourceReplyDeliveryMode: "message_tool_only",
+        abort: () => {},
+      },
+      runScopedCallerKey,
+    );
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string; params?: unknown };
+      calls.push(request);
+      if (request.method === "agent") {
+        return { runId: "durable-fallback-run", status: "accepted", acceptedAt: 2000 };
+      }
+      return {};
+    });
+
+    const tool = createOpenClawTools({
+      agentSessionKey: "agent:re-portal:main",
+      agentChannel: "telegram",
+      config: {
+        ...TEST_CONFIG,
+        session: {
+          ...TEST_CONFIG.session,
+          agentToAgent: { maxPingPongTurns: 0 },
+        },
+      },
+    }).find((candidate) => candidate.name === "sessions_send");
+    if (!tool) {
+      throw new Error("missing sessions_send tool");
+    }
+
+    const result = await tool.execute("call-run-scoped-caller", {
+      sessionKey: runScopedCallerKey,
+      message: "[TASK-COMPLETE] re-portal occupancy ready",
+      timeoutSeconds: 0,
+    });
+
+    const details = sessionsSendDetails(result.details);
+    expect(details.status).toBe("error");
+    expect(details.sessionKey).toBe(runScopedCallerKey);
+    expect(details.error).toContain("queue_message_failed reason=not_streaming");
+    expect(queueMessage).not.toHaveBeenCalled();
+    expect(calls.some((call) => call.method === "agent")).toBe(false);
+  });
+
   it("sessions_send preserves active delivery when transcript commit wait is unsupported", async () => {
     const calls: Array<{ method?: string }> = [];
     const runScopedCallerKey = "agent:leasing-ops:cron:monthly-utility:run:run-fast";

--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -1513,11 +1513,10 @@ describe("sessions tools", () => {
     expect(calls.find((call) => call.method === "send")).toBeUndefined();
   });
 
-  it("sessions_send reroutes run-scoped active deliveries when transcript steering is rejected", async () => {
+  it("sessions_send reports active-run queue rejection without durable-session fallback", async () => {
     const calls: Array<{ method?: string; params?: unknown }> = [];
     const requesterKey = "agent:re-portal:main";
     const runScopedCallerKey = "agent:leasing-ops:cron:monthly-utility:run:run-fast";
-    const durableCallerKey = "agent:leasing-ops:cron:monthly-utility";
     const queueMessage = vi.fn(async (_text: string, _options?: unknown) => {
       throw new Error("active session ended before queued steering message was committed");
     });
@@ -1538,13 +1537,6 @@ describe("sessions tools", () => {
       calls.push(request);
       if (request.method === "agent") {
         return { runId: "fallback-run", status: "accepted", acceptedAt: 2000 };
-      }
-      if (request.method === "agent.wait") {
-        const params = request.params as { runId?: string } | undefined;
-        return { runId: params?.runId ?? "fallback-run", status: "ok" };
-      }
-      if (request.method === "chat.history") {
-        return { messages: [] };
       }
       return {};
     });
@@ -1570,9 +1562,11 @@ describe("sessions tools", () => {
       timeoutSeconds: 0,
     });
     const details = sessionsSendDetails(result.details);
-    expect(details.status).toBe("accepted");
+    expect(details.status).toBe("error");
     expect(details.sessionKey).toBe(runScopedCallerKey);
-    expect(details.delivery?.status).toBe("pending");
+    expect(details.error).toContain("queue_message_failed reason=runtime_rejected");
+    expect(details.error).toContain("caller-active-session");
+    expect(details.error).not.toContain("fallback_failed");
     const queuedText = queueMessage.mock.calls[0]?.[0];
     expect(queuedText).toContain("[Inter-session message]");
     expect(queuedText).toContain("[TASK-COMPLETE] re-portal occupancy ready");
@@ -1583,47 +1577,7 @@ describe("sessions tools", () => {
       waitForTranscriptCommit: true,
       sourceReplyDeliveryMode: "message_tool_only",
     });
-
-    await vi.waitFor(() => {
-      const fallbackCall = calls.find(
-        (call) =>
-          call.method === "agent" &&
-          (call.params as { sessionKey?: string } | undefined)?.sessionKey === durableCallerKey,
-      );
-      expect(fallbackCall).toBeDefined();
-    });
-
-    const agentCalls = calls.filter((call) => call.method === "agent");
-    expect(
-      agentCalls.some(
-        (call) =>
-          (call.params as { sessionKey?: string } | undefined)?.sessionKey === runScopedCallerKey,
-      ),
-    ).toBe(false);
-    const fallbackParams = agentCalls.find(
-      (call) =>
-        (call.params as { sessionKey?: string } | undefined)?.sessionKey === durableCallerKey,
-    )?.params as { inputProvenance?: { sourceSessionKey?: string }; message?: string } | undefined;
-    expect(fallbackParams?.message).toContain("[Inter-session message]");
-    expect(fallbackParams?.message).toContain("[TASK-COMPLETE] re-portal occupancy ready");
-    expect(fallbackParams?.inputProvenance?.sourceSessionKey).toBe(requesterKey);
-
-    await vi.waitFor(() => {
-      const waitCall = calls.find(
-        (call) =>
-          call.method === "agent.wait" &&
-          (call.params as { runId?: string } | undefined)?.runId === "fallback-run",
-      );
-      expect(waitCall).toBeDefined();
-    });
-    await vi.waitFor(() => {
-      const historyCall = calls.find(
-        (call) =>
-          call.method === "chat.history" &&
-          (call.params as { sessionKey?: string } | undefined)?.sessionKey === durableCallerKey,
-      );
-      expect(historyCall).toBeDefined();
-    });
+    expect(calls.some((call) => call.method === "agent")).toBe(false);
   });
 
   it("sessions_send preserves active delivery when transcript commit wait is unsupported", async () => {
@@ -1677,7 +1631,7 @@ describe("sessions tools", () => {
     expect(calls.some((call) => call.method === "agent")).toBe(false);
   });
 
-  it("sessions_send reports run-scoped fallback admission failures", async () => {
+  it("sessions_send reports run-scoped queue admission failures without gateway fallback", async () => {
     const runScopedCallerKey = "agent:leasing-ops:cron:monthly-utility:run:run-fast";
     const queueMessage = vi.fn(async () => {
       throw new Error("active session ended before queued steering message was committed");
@@ -1720,7 +1674,12 @@ describe("sessions tools", () => {
     expect(details.status).toBe("error");
     expect(details.sessionKey).toBe(runScopedCallerKey);
     expect(details.error).toContain("queue_message_failed reason=runtime_rejected");
-    expect(details.error).toContain("fallback_failed error=gateway request timeout for agent");
+    expect(details.error).not.toContain("fallback_failed");
+    expect(
+      callGatewayMock.mock.calls.some(
+        (call) => (call[0] as { method?: string } | undefined)?.method === "agent",
+      ),
+    ).toBe(false);
   });
 
   it("sessions_send preserves terminal timeouts without starting A2A", async () => {

--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -1636,6 +1636,62 @@ describe("sessions tools", () => {
     expect(calls.some((call) => call.method === "agent")).toBe(false);
   });
 
+  it("sessions_send keeps ordinary active session targets on the gateway agent path", async () => {
+    const calls: Array<{ method?: string; params?: unknown }> = [];
+    const ordinaryActiveKey = "agent:main:main";
+    const queueMessage = vi.fn(async () => {});
+    setActiveEmbeddedRun(
+      "ordinary-active-session",
+      {
+        queueMessage,
+        isStreaming: () => true,
+        isCompacting: () => false,
+        supportsTranscriptCommitWait: true,
+        sourceReplyDeliveryMode: "automatic",
+        abort: () => {},
+      },
+      ordinaryActiveKey,
+    );
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string; params?: unknown };
+      calls.push(request);
+      if (request.method === "agent") {
+        return { runId: "ordinary-agent-run", status: "accepted", acceptedAt: 2000 };
+      }
+      return {};
+    });
+
+    const tool = createOpenClawTools({
+      agentSessionKey: "agent:re-portal:main",
+      agentChannel: "telegram",
+      config: {
+        ...TEST_CONFIG,
+        session: {
+          ...TEST_CONFIG.session,
+          agentToAgent: { maxPingPongTurns: 0 },
+        },
+      },
+    }).find((candidate) => candidate.name === "sessions_send");
+    if (!tool) {
+      throw new Error("missing sessions_send tool");
+    }
+
+    const result = await tool.execute("call-ordinary-active", {
+      sessionKey: ordinaryActiveKey,
+      message: "ordinary active target should stay gateway routed",
+      timeoutSeconds: 0,
+    });
+
+    const details = sessionsSendDetails(result.details);
+    expect(details.status).toBe("accepted");
+    expect(details.runId).toBe("ordinary-agent-run");
+    expect(details.sessionKey).toBe(ordinaryActiveKey);
+    expect(queueMessage).not.toHaveBeenCalled();
+    const agentCalls = calls.filter((call) => call.method === "agent");
+    expect(agentCalls).toHaveLength(1);
+    expect(agentParams(agentCalls[0] ?? {}).sessionKey).toBe(ordinaryActiveKey);
+  });
+
   it("sessions_send falls back from stranded cron run key to durable cron parent", async () => {
     const calls: Array<{ method?: string; params?: unknown }> = [];
     const runScopedCallerKey = "agent:leasing-ops:cron:monthly-utility:run:run-fast";

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -21,6 +21,7 @@ import {
   toAgentStoreSessionKey,
 } from "../../routing/session-key.js";
 import { annotateInterSessionPromptText } from "../../sessions/input-provenance.js";
+import { isCronRunSessionKey, parseAgentSessionKey } from "../../sessions/session-key-utils.js";
 import { SESSION_LABEL_MAX_LENGTH } from "../../sessions/session-label.js";
 import { stripFormattedReasoningMessage } from "../../shared/text/formatted-reasoning-message.js";
 import {
@@ -30,6 +31,7 @@ import {
 import { listAgentIds } from "../agent-scope.js";
 import {
   type EmbeddedAgentQueueMessageOptions,
+  type EmbeddedAgentQueueMessageOutcome,
   formatEmbeddedAgentQueueFailureSummary,
   queueEmbeddedAgentMessageWithOutcomeAsync,
   resolveActiveEmbeddedRunSessionId,
@@ -199,6 +201,39 @@ function isPendingErrorAgentWaitTimeout(result: AgentWaitResult): boolean {
   );
 }
 
+function resolveCronRunScopedFallbackSessionKey(sessionKey: string): string | undefined {
+  const normalizedSessionKey = normalizeOptionalString(sessionKey);
+  if (!normalizedSessionKey || !isCronRunSessionKey(normalizedSessionKey)) {
+    return undefined;
+  }
+  const parsed = parseAgentSessionKey(normalizedSessionKey);
+  if (!parsed) {
+    return undefined;
+  }
+  const runMarker = ":run:";
+  const runMarkerIndex = parsed.rest.lastIndexOf(runMarker);
+  if (runMarkerIndex <= 0) {
+    return undefined;
+  }
+  const runId = parsed.rest.slice(runMarkerIndex + runMarker.length);
+  if (!runId || runId.includes(":")) {
+    return undefined;
+  }
+  const fallbackRest = parsed.rest.slice(0, runMarkerIndex);
+  if (!fallbackRest) {
+    return undefined;
+  }
+  return `agent:${parsed.agentId}:${fallbackRest}`;
+}
+
+function shouldFallbackCronRunScopedActiveDelivery(
+  outcome: EmbeddedAgentQueueMessageOutcome,
+): boolean {
+  return (
+    !outcome.queued && (outcome.reason === "not_streaming" || outcome.reason === "no_active_run")
+  );
+}
+
 async function startAgentRun(params: {
   callGateway: GatewayCaller;
   runId: string;
@@ -251,6 +286,25 @@ async function startAgentRun(params: {
       }
       if (queueOutcome.queued) {
         return { ok: true, runId: params.runId, activeRunQueue: true };
+      }
+      const fallbackSessionKey = resolveCronRunScopedFallbackSessionKey(params.sessionKey);
+      if (fallbackSessionKey && shouldFallbackCronRunScopedActiveDelivery(queueOutcome)) {
+        const response = await params.callGateway<{ runId: string }>({
+          method: "agent",
+          params: {
+            ...params.sendParams,
+            sessionKey: fallbackSessionKey,
+            idempotencyKey: crypto.randomUUID(),
+          },
+          timeoutMs: 10_000,
+        });
+        return {
+          ok: true,
+          runId:
+            typeof response?.runId === "string" && response.runId ? response.runId : params.runId,
+          a2aSessionKey: fallbackSessionKey,
+          a2aDisplayKey: fallbackSessionKey,
+        };
       }
       const queueSummary =
         formatEmbeddedAgentQueueFailureSummary(queueOutcome) ?? "active run queue rejected";

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -201,6 +201,11 @@ function isPendingErrorAgentWaitTimeout(result: AgentWaitResult): boolean {
   );
 }
 
+function isRunScopedAgentSessionKey(sessionKey: string): boolean {
+  const parsed = parseAgentSessionKey(normalizeOptionalString(sessionKey));
+  return Boolean(parsed && /(?:^|:)run:[^:]+(?::|$)/.test(parsed.rest));
+}
+
 function resolveCronRunScopedFallbackSessionKey(sessionKey: string): string | undefined {
   const normalizedSessionKey = normalizeOptionalString(sessionKey);
   if (!normalizedSessionKey || !isCronRunSessionKey(normalizedSessionKey)) {
@@ -252,9 +257,10 @@ async function startAgentRun(params: {
   | { ok: false; result: ReturnType<typeof jsonResult> }
 > {
   try {
-    const activeRunSessionId = params.allowActiveRunQueueDelivery
-      ? resolveActiveEmbeddedRunSessionId(params.sessionKey)
-      : undefined;
+    const activeRunSessionId =
+      params.allowActiveRunQueueDelivery && isRunScopedAgentSessionKey(params.sessionKey)
+        ? resolveActiveEmbeddedRunSessionId(params.sessionKey)
+        : undefined;
     const messageText =
       typeof params.sendParams.message === "string" ? params.sendParams.message : undefined;
     if (activeRunSessionId && messageText) {

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -92,11 +92,6 @@ function normalizeSessionsSendArguments(args: unknown): Record<string, unknown> 
   return params;
 }
 
-function resolveRunScopedFallbackSessionKey(sessionKey: string): string | undefined {
-  const match = /^(agent:[^:]+:.+):run:[^:]+$/.exec(sessionKey.trim());
-  return match?.[1];
-}
-
 function resolveConfiguredAgentMainSessionKey(params: {
   cfg: OpenClawConfig;
   agentId: string;
@@ -210,7 +205,7 @@ async function startAgentRun(params: {
   sendParams: Record<string, unknown>;
   sessionKey: string;
   deliveryTimeoutMs?: number;
-  allowActiveRunQueueFallback?: boolean;
+  allowActiveRunQueueDelivery?: boolean;
 }): Promise<
   | {
       ok: true;
@@ -222,15 +217,12 @@ async function startAgentRun(params: {
   | { ok: false; result: ReturnType<typeof jsonResult> }
 > {
   try {
-    const activeRunSessionId = params.allowActiveRunQueueFallback
+    const activeRunSessionId = params.allowActiveRunQueueDelivery
       ? resolveActiveEmbeddedRunSessionId(params.sessionKey)
-      : undefined;
-    const fallbackSessionKey = activeRunSessionId
-      ? resolveRunScopedFallbackSessionKey(params.sessionKey)
       : undefined;
     const messageText =
       typeof params.sendParams.message === "string" ? params.sendParams.message : undefined;
-    if (activeRunSessionId && fallbackSessionKey && messageText) {
+    if (activeRunSessionId && messageText) {
       const sourceReplyDeliveryMode =
         params.sendParams.sourceReplyDeliveryMode === "automatic" ||
         params.sendParams.sourceReplyDeliveryMode === "message_tool_only"
@@ -260,30 +252,9 @@ async function startAgentRun(params: {
       if (queueOutcome.queued) {
         return { ok: true, runId: params.runId, activeRunQueue: true };
       }
-      try {
-        const response = await params.callGateway<{ runId: string }>({
-          method: "agent",
-          params: {
-            ...params.sendParams,
-            sessionKey: fallbackSessionKey,
-            idempotencyKey: crypto.randomUUID(),
-          },
-          timeoutMs: 10_000,
-        });
-        return {
-          ok: true,
-          runId:
-            typeof response?.runId === "string" && response.runId ? response.runId : params.runId,
-          a2aSessionKey: fallbackSessionKey,
-          a2aDisplayKey: fallbackSessionKey,
-        };
-      } catch (err) {
-        const queueSummary =
-          formatEmbeddedAgentQueueFailureSummary(queueOutcome) ?? "active run queue rejected";
-        throw new Error(`${queueSummary}; fallback_failed error=${formatErrorMessage(err)}`, {
-          cause: err,
-        });
-      }
+      const queueSummary =
+        formatEmbeddedAgentQueueFailureSummary(queueOutcome) ?? "active run queue rejected";
+      throw new Error(queueSummary);
     }
     const response = await params.callGateway<{ runId: string }>({
       method: "agent",
@@ -643,7 +614,7 @@ export function createSessionsSendTool(opts?: {
           sendParams,
           sessionKey: displayKey,
           deliveryTimeoutMs: announceTimeoutMs,
-          allowActiveRunQueueFallback: true,
+          allowActiveRunQueueDelivery: true,
         });
         if (!start.ok) {
           return start.result;


### PR DESCRIPTION
## Summary

- Narrows run-scoped `sessions_send` retry behavior instead of removing every durable retry path.
- Blocks unsafe run-scoped active-run queue rejection reroutes: `runtime_rejected`, source reply delivery mode mismatch, compacting runs, and non-cron run-looking keys now surface the queue error on the original target.
- Re-gates active queue delivery to run-scoped target keys so ordinary active session sends continue through the existing gateway `agent` path.
- Preserves the #86638 stranded cron pingback path by falling back only from a structurally valid cron run key to its durable cron parent when the active run is no longer steerable.
- Keeps successful run-scoped active-run queue delivery intact, including the best-effort path when transcript commit waiting is unsupported.
- Does not change public schema, config, provider routing, session visibility policy, or documented agent-to-agent reply-back behavior.

## Linked context

Closes #91420

Related: #86638 shipped the stranded cron pingback fallback that this patch keeps, but now under a narrower session-key and queue-reason gate.

Was this requested by a maintainer or owner? No direct maintainer request; this follows the open bug report plus bot/review feedback asking for issue-specific proof and a safer retry design if #86638 remains part of the runtime contract.

## Maintainer review notes

- Fix classification: root-cause fix for the run-scoped active delivery boundary.
- Maintainer-ready confidence: High; the diff is limited to `sessions_send` active-run retry routing plus focused regression coverage, and the runtime proof exercises the blocked unsafe path, the preserved safe cron fallback, and the ordinary active-session gateway path.
- Root cause: the previous retry path treated active-run queue failure as permission to derive another session key and start a fresh `agent` run, so a failed run-scoped delivery could silently cross from active runtime state into a durable session.
- Why this is root-cause fix: run-scoped delivery must respect the active queue as the state boundary; ordinary active session targets must keep using the gateway `agent` path, and only the #86638 stranded cron case has a durable parent contract, so fallback is now gated by structural cron key parsing and safe queue reasons.
- Why it matters / User impact: rejected retry delivery no longer risks duplicate relay messages, polluted durable sessions, or later provider/tool payload confusion, while ordinary active-session sends keep their existing gateway routing and cron pingbacks that were stranded because the active run is no longer streaming can still reach the durable cron parent.
- What did NOT change: normal direct `sessions_send`, ordinary active-session gateway `agent` routing, successful run-scoped active-run queue delivery, transcript-commit best-effort retry, documented A2A reply-back behavior, channel delivery policy, session visibility, provider routing, schema, config, defaults, and migrations.
- Architecture / source-of-truth check: the change stays inside `sessions_send`; it reuses `parseAgentSessionKey()` / `isCronRunSessionKey()` instead of restoring broad `:run:<id>` suffix stripping.
- Related open PR / competition scan: daily-fix candidate checks found no linked open PR for #91420 before this branch was initialized, so this is not a same-contract competing PR.
- Target test file: `src/agents/openclaw-tools.sessions.test.ts`; adjacent guardrails also run `src/agents/embedded-agent-runner/runs.test.ts` and `src/agents/tools/sessions-send-tool.a2a.test.ts`.
- Scenario locked in: unsafe run-scoped active-run queue rejection returns an error for the original run-scoped session key without starting a durable `agent` call; safe stranded cron delivery falls back only to `agent:leasing-ops:cron:monthly-utility`; ordinary active session targets still use the gateway `agent` path and do not fail on source reply mode mismatch.
- Why this is the smallest reliable guardrail: the regression covers the exact state transition that previously leaked across session boundaries, the existing #86638 contract that should not be regressed, and the ordinary active-session compatibility path called out by ClawSweeper.
- Patch quality notes: fallback is not a catch-all default or mitigation shim; it is allowed only for structurally valid cron run keys with `not_streaming` or `no_active_run` queue outcomes.
- Risk labels considered: availability and message-delivery.
- Risk explanation: the highest-risk area is message-delivery availability for callers that depended on broad durable-session reroutes after any active-run queue failure.
- Why acceptable: unsafe delivery failures now fail explicitly, while the known stranded cron pingback path still has a durable parent retry route.
- Maintainer tradeoff to accept before merge: this preserves the #86638 stranded cron parent fallback, but rejects runtime rejection, delivery mode mismatch, compacting, and non-cron `:run:` keys instead of silently starting a new durable-session agent run.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: unsafe rejected run-scoped active-run `sessions_send` delivery no longer falls back through a durable session key, the #86638 stranded cron run case still falls back to the durable cron parent, and ordinary active session targets remain gateway-routed instead of being steered through the active queue.
- Real environment tested: local patched OpenClaw runtime with isolated `OPENCLAW_HOME`; the issue-specific proof invokes the production `sessions_send` tool against the active embedded-run queue registry.
- Exact steps or command run after this patch:
  - Ran a focused TDD RED/GREEN regression for the ordinary active-session gateway path requested by ClawSweeper after the update-branch refresh.
  - Re-ran the full sessions tool regression file and adjacent embedded-run/A2A guardrails on the updated PR head.
  - Ran an isolated issue-path proof harness that registers production active embedded-run handles and invokes production `sessions_send` with `timeoutSeconds: 0` for all three routing boundaries.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

  Copied console output from the isolated issue-path proof harness:

  ```json
  {
    "proof": "issue-91420-safe-sessions-send-run-scoped-delivery",
    "invocation": "production sessions_send tool with active embedded-run queue registry",
    "scenarios": {
      "unsafeRuntimeRejected": {
        "status": "error",
        "sessionKey": "agent:leasing-ops:cron:monthly-utility:run:run-fast",
        "error": "queue_message_failed reason=runtime_rejected sessionId=caller-active-session gatewayHealth=live error=active session ended before queued steering message was committed",
        "queueMessageCalls": 1,
        "gatewayAgentFallbackCalls": 0,
        "assertions": {
          "explicitRuntimeRejectedError": true,
          "originalRunScopedSessionPreserved": true,
          "noDurableAgentFallback": true
        }
      },
      "safeStrandedCronFallback": {
        "status": "accepted",
        "runId": "durable-cron-parent-run",
        "reportedSessionKey": "agent:leasing-ops:cron:monthly-utility:run:run-fast",
        "durableCronParentKey": "agent:leasing-ops:cron:monthly-utility",
        "queueMessageCalls": 0,
        "gatewayAgentFallbackCalls": 1,
        "gatewayAgentSessionKeys": [
          "agent:leasing-ops:cron:monthly-utility"
        ],
        "assertions": {
          "acceptedThroughDurableCronParent": true,
          "originalRunScopedSessionReported": true,
          "onlyDurableCronParentUsed": true,
          "activeQueueNotInvokedAfterNotStreaming": true
        }
      },
      "ordinaryActiveGatewayPath": {
        "status": "accepted",
        "runId": "ordinary-agent-run",
        "reportedSessionKey": "agent:main:main",
        "queueMessageCalls": 0,
        "gatewayAgentCalls": 1,
        "gatewayAgentSessionKeys": [
          "agent:main:main"
        ],
        "assertions": {
          "acceptedThroughGatewayAgent": true,
          "ordinarySessionPreserved": true,
          "noActiveQueueDelivery": true,
          "onlyOrdinaryGatewayAgentUsed": true,
          "noSourceReplyModeMismatch": true
        }
      }
    },
    "assertions": {
      "unsafeRuntimeRejectedDoesNotFallback": true,
      "safeStrandedCronFallbackPreserved": true,
      "ordinaryActiveSessionsStayGatewayRouted": true
    }
  }
  ```

- Observed result after fix: the unsafe runtime-rejected scenario returns `status="error"` with `queue_message_failed reason=runtime_rejected` and records `gatewayAgentFallbackCalls=0`; the safe stranded cron scenario returns `status="accepted"` and records exactly one gateway `agent` call to `agent:leasing-ops:cron:monthly-utility`; the ordinary active-session scenario returns `status="accepted"`, records `queueMessageCalls=0`, and sends exactly one gateway `agent` call to `agent:main:main`.
- What was not tested: the reporter's full macOS 16-agent fleet, external channel accounts, and the intermittent production corruption loop.
- Proof limitations or environment constraints: the deterministic proof uses an in-process local runtime harness because the public gateway HTTP/RPC API does not expose a stable way to force active queue `runtime_rejected` or `not_streaming` on demand; it exercises the production `sessions_send` tool and active-run queue registry, but it is not a live reproduction of the reporter's full external fleet.
- Before evidence (optional but encouraged): before the production change in this iteration, the new focused stranded-cron regression failed with `AssertionError: expected 'error' to be 'accepted'`, proving the safe #86638 fallback had not yet been restored.

## Tests and validation

Commands run:

```text
pnpm install --frozen-lockfile
node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-core.config.ts src/agents/openclaw-tools.sessions.test.ts -t "ordinary active session"
node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-core.config.ts src/agents/openclaw-tools.sessions.test.ts
node scripts/run-vitest.mjs run --config test/vitest/vitest.agents.config.ts src/agents/embedded-agent-runner/runs.test.ts src/agents/tools/sessions-send-tool.a2a.test.ts
OPENCLAW_HOME="$(mktemp -d)" TASK_WORKTREE="$PWD" pnpm exec tsx <issue-91420 runtime proof harness>
```

Regression coverage added or updated:

- Kept the run-scoped `runtime_rejected` active delivery test requiring an explicit error and no durable `agent` call.
- Added source reply delivery mode mismatch coverage requiring no fallback for run-scoped targets.
- Added ordinary active-session coverage requiring gateway `agent` routing and no source reply mode mismatch failure.
- Added stranded cron run coverage requiring fallback only to the durable cron parent.
- Added non-cron run-looking key coverage requiring no suffix-stripping fallback.
- Preserved coverage that successful run-scoped active-run queue delivery still avoids fallback agent runs.

What failed before this fix:

```text
FAIL sessions_send keeps ordinary active session targets on the gateway agent path
AssertionError: expected 'error' to be 'accepted'

Earlier in this PR iteration, before restoring the safe #86638 cron fallback, the stranded-cron regression also failed with:

FAIL sessions_send falls back from stranded cron run key to durable cron parent
AssertionError: expected 'error' to be 'accepted'
```

## Risk checklist

Did user-visible behavior change? (`Yes/No`) Yes — unsafe rejected run-scoped active delivery now reports an error instead of silently retrying through a durable session; ordinary active session targets keep the existing gateway `agent` path; safe stranded cron pingback fallback remains accepted.

Did config, environment, or migration behavior change? (`Yes/No`) No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`) Yes — tool execution routing is narrowed so failed active-run queue delivery cannot use a persistent session as an implicit relay except for the explicitly preserved durable cron parent path.

What is the highest-risk area? Existing workflows that depended on broad durable-session fallback for non-cron or runtime-rejected active-run sends will now see explicit send errors.

How is that risk mitigated? The change only affects rejected run-scoped active queue delivery; normal direct `sessions_send`, ordinary active-session gateway routing, successful run-scoped active-run queue delivery, transcript-commit best-effort delivery, documented A2A reply-back behavior, and the #86638 stranded cron fallback are covered by focused tests and runtime proof.

## Current review state

What is the next action? Ready for CI and bot re-review after the update-branch refresh and round-two author fix.

What is still waiting on author, maintainer, CI, or external proof? CI and ClawSweeper need to consume this updated commit and PR body. External reporter-environment proof is not available from this local setup; the maintainer decision is whether this narrower retry contract correctly balances #91420's session boundary against #86638's stranded cron pingback fallback while preserving ordinary active-session gateway routing.

Which bot or reviewer comments were addressed?

- RF-001: addressed by the round-two author fix below; the previous `status: ⏳ waiting on author` label was caused by the ordinary active-session compatibility finding, not by missing proof.
- RF-002 / RF-003 / RF-005 / RF-006: addressed by re-gating active queue delivery to run-scoped target keys and adding a regression proving ordinary active session targets still use the gateway `agent` path without source reply delivery mode mismatch.
- RF-004: disclosed as the intended compatibility tradeoff for rejected run-scoped sends; the broad durable-session reroute remains blocked, but ordinary active-session sends are no longer affected by that tradeoff.
- RF-007: addressed by rerunning `src/agents/openclaw-tools.sessions.test.ts` on the updated PR head; result: 34 passed.
- RF-008: addressed by rerunning `src/agents/embedded-agent-runner/runs.test.ts` and `src/agents/tools/sessions-send-tool.a2a.test.ts` on the updated PR head; result: 44 passed.
- ClawSweeper/Codex review focus: the PR now includes maintainer-visible proof for the unsafe rejection path, the preserved safe cron fallback, and the ordinary active-session gateway path.
