### PR TITLE
fix(control-ui): persist Set Default agent through config save

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -53,6 +53,7 @@ import {
   resetToolsEffectiveState,
   refreshVisibleToolsEffectiveForCurrentSession,
   saveAgentsConfig,
+  setDefaultAgent,
 } from "./controllers/agents.ts";
 import { setAssistantAvatarOverride } from "./controllers/assistant-identity.ts";
 import { loadChannels } from "./controllers/channels.ts";
@@ -66,7 +67,6 @@ import {
   resetConfigPendingChanges,
   runUpdate,
   saveConfig,
-  stageDefaultAgentConfigEntry,
   stageConfigPreset,
   updateConfigRawValue,
   updateConfigFormValue,
@@ -3480,7 +3480,7 @@ export function renderApp(state: AppViewState) {
                   updateConfigFormValue(state, basePathResult, { primary, fallbacks: normalized });
                 },
                 onSetDefault: (agentId) => {
-                  stageDefaultAgentConfigEntry(state, agentId);
+                  void setDefaultAgent(state, agentId);
                 },
               }),
             )

--- a/ui/src/ui/controllers/agents.test.ts
+++ b/ui/src/ui/controllers/agents.test.ts
@@ -1,6 +1,12 @@
 // Control UI tests cover agents behavior.
 import { describe, expect, it, vi } from "vitest";
-import { loadAgents, loadToolsCatalog, loadToolsEffective, saveAgentsConfig } from "./agents.ts";
+import {
+  loadAgents,
+  loadToolsCatalog,
+  loadToolsEffective,
+  saveAgentsConfig,
+  setDefaultAgent,
+} from "./agents.ts";
 import type { AgentsConfigSaveState, AgentsState } from "./agents.ts";
 
 type TestRequest = (method: string, payload?: unknown) => Promise<unknown>;
@@ -428,5 +434,48 @@ describe("saveAgentsConfig", () => {
     await saveAgentsConfig(state);
 
     expect(state.agentsSelectedId).toBe("main");
+  });
+});
+
+describe("setDefaultAgent", () => {
+  it("stages the canonical default flag and persists it through config.set", async () => {
+    const { state, request } = createSaveState();
+    state.configForm = { agents: { list: [{ id: "main" }, { id: "kimi" }] } };
+    request
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce({
+        hash: "hash-2",
+        raw: '{"agents":{"list":[{"id":"main"},{"id":"kimi","default":true}]}}',
+        config: { agents: { list: [{ id: "main" }, { id: "kimi", default: true }] } },
+        valid: true,
+        issues: [],
+      })
+      .mockResolvedValueOnce({
+        defaultId: "kimi",
+        mainKey: "main",
+        scope: "per-sender",
+        agents: [
+          { id: "main", name: "main" },
+          { id: "kimi", name: "kimi" },
+        ],
+      });
+
+    await setDefaultAgent(state, "kimi");
+
+    const [method, params] = requireFirstRequestCall(request);
+    const requestParams = requireRecord(params);
+    expect(method).toBe("config.set");
+    expect(JSON.parse(String(requestParams.raw))).toEqual({
+      agents: { list: [{ id: "main" }, { id: "kimi", default: true }] },
+    });
+  });
+
+  it("does not persist when the agent is absent from the config list", async () => {
+    const { state, request } = createSaveState();
+    state.configForm = { agents: { list: [{ id: "main" }] } };
+
+    await setDefaultAgent(state, "ghost");
+
+    expect(request).not.toHaveBeenCalled();
   });
 });

--- a/ui/src/ui/controllers/agents.test.ts
+++ b/ui/src/ui/controllers/agents.test.ts
@@ -441,6 +441,8 @@ describe("setDefaultAgent", () => {
   it("stages the canonical default flag and persists it through config.set", async () => {
     const { state, request } = createSaveState();
     state.configForm = { agents: { list: [{ id: "main" }, { id: "kimi" }] } };
+    state.configFormOriginal = { agents: { list: [{ id: "main" }, { id: "kimi" }] } };
+    state.configFormDirty = false;
     request
       .mockResolvedValueOnce(undefined)
       .mockResolvedValueOnce({
@@ -477,5 +479,29 @@ describe("setDefaultAgent", () => {
     await setDefaultAgent(state, "ghost");
 
     expect(request).not.toHaveBeenCalled();
+  });
+
+  it("does not persist unrelated dirty agent config drafts", async () => {
+    const { state, request } = createSaveState();
+    state.configFormDirty = true;
+    state.configFormOriginal = { agents: { list: [{ id: "main" }, { id: "kimi" }] } };
+    state.configForm = {
+      agents: {
+        list: [{ id: "main", model: "gpt-5.5" }, { id: "kimi" }],
+      },
+    };
+
+    await setDefaultAgent(state, "kimi");
+
+    expect(request).not.toHaveBeenCalled();
+    expect(state.configForm).toEqual({
+      agents: {
+        list: [
+          { id: "main", model: "gpt-5.5" },
+          { id: "kimi", default: true },
+        ],
+      },
+    });
+    expect(state.configFormDirty).toBe(true);
   });
 });

--- a/ui/src/ui/controllers/agents.ts
+++ b/ui/src/ui/controllers/agents.ts
@@ -251,10 +251,13 @@ export async function setDefaultAgent(
   state: AgentsConfigSaveState,
   agentId: string,
 ): Promise<void> {
-  // Set Default is a one-click action: stage the canonical agents.list[].default flag,
-  // then persist through the shared save path. Staging the form draft alone is silently
-  // dropped on refresh, so without the save the default never sticks (impact:data-loss).
+  const hadPendingConfigDraft = state.configFormDirty;
+  // Set Default is a one-click action on a clean draft, but saveConfig serializes the
+  // whole form. If other edits were already dirty, keep them staged for the explicit
+  // Save button instead of committing unrelated pending config changes.
   if (stageDefaultAgentConfigEntry(state, agentId)) {
-    await saveAgentsConfig(state);
+    if (!hadPendingConfigDraft && state.configFormDirty) {
+      await saveAgentsConfig(state);
+    }
   }
 }

--- a/ui/src/ui/controllers/agents.ts
+++ b/ui/src/ui/controllers/agents.ts
@@ -13,7 +13,7 @@ import type {
   ToolsCatalogResult,
   ToolsEffectiveResult,
 } from "../types.ts";
-import { saveConfig } from "./config.ts";
+import { saveConfig, stageDefaultAgentConfigEntry } from "./config.ts";
 import type { ConfigState } from "./config.ts";
 import {
   formatMissingOperatorReadScopeMessage,
@@ -244,5 +244,17 @@ export async function saveAgentsConfig(state: AgentsConfigSaveState) {
   await loadAgents(state);
   if (selectedBefore && state.agentsList?.agents.some((entry) => entry.id === selectedBefore)) {
     state.agentsSelectedId = selectedBefore;
+  }
+}
+
+export async function setDefaultAgent(
+  state: AgentsConfigSaveState,
+  agentId: string,
+): Promise<void> {
+  // Set Default is a one-click action: stage the canonical agents.list[].default flag,
+  // then persist through the shared save path. Staging the form draft alone is silently
+  // dropped on refresh, so without the save the default never sticks (impact:data-loss).
+  if (stageDefaultAgentConfigEntry(state, agentId)) {
+    await saveAgentsConfig(state);
   }
 }

--- a/ui/src/ui/e2e/agents-set-default-persistence.e2e.test.ts
+++ b/ui/src/ui/e2e/agents-set-default-persistence.e2e.test.ts
@@ -1,0 +1,106 @@
+// Control UI tests cover Agents page Set Default persistence behavior.
+import { chromium, type Browser } from "playwright";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  canRunPlaywrightChromium,
+  installMockGateway,
+  resolvePlaywrightChromiumExecutablePath,
+  startControlUiE2eServer,
+  type ControlUiE2eServer,
+  type MockGatewayRequest,
+} from "../../test-helpers/control-ui-e2e.ts";
+
+const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
+const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
+const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
+const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+
+let browser: Browser;
+let server: ControlUiE2eServer;
+
+function requireRecord(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("Expected object value");
+  }
+  return value as Record<string, unknown>;
+}
+
+function requestParams(request: MockGatewayRequest): Record<string, unknown> {
+  return requireRecord(request.params);
+}
+
+describeControlUiE2e("Control UI agents Set Default mocked Gateway E2E", () => {
+  beforeAll(async () => {
+    if (!chromiumAvailable) {
+      throw new Error(
+        `Playwright Chromium is not installed or cannot start at ${chromiumExecutablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
+      );
+    }
+    server = await startControlUiE2eServer();
+    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
+  });
+
+  afterAll(async () => {
+    await browser?.close();
+    await server?.close();
+  });
+
+  it("persists Set Default through config.set instead of only staging the form draft", async () => {
+    const context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      assistantName: "Main agent",
+      defaultAgentId: "main",
+      methodResponses: {
+        "agents.list": {
+          agents: [
+            { id: "main", name: "Main agent" },
+            { id: "kimi", name: "Kimi agent" },
+          ],
+          defaultId: "main",
+          mainKey: "main",
+          scope: "agent",
+        },
+        "config.get": {
+          config: { agents: { list: [{ id: "main" }, { id: "kimi" }] } },
+          hash: "hash-1",
+          issues: [],
+          raw: '{"agents":{"list":[{"id":"main"},{"id":"kimi"}]}}',
+          valid: true,
+        },
+        "config.set": {
+          config: { agents: { list: [{ id: "main" }, { id: "kimi", default: true }] } },
+          hash: "hash-2",
+          issues: [],
+          raw: '{"agents":{"list":[{"id":"main"},{"id":"kimi","default":true}]}}',
+          valid: true,
+        },
+      },
+    });
+
+    try {
+      const response = await page.goto(`${server.baseUrl}agents`);
+      expect(response?.status()).toBe(200);
+
+      // selectOption / click auto-wait for the element to be actionable (enabled), so
+      // these implicitly assert the dropdown loaded and Set Default is clickable for a
+      // non-default agent.
+      await page.locator("select.agents-select").selectOption("kimi");
+      await page.getByRole("button", { name: "Set Default", exact: true }).click();
+
+      // The fix routes Set Default through the canonical save path; without it the click
+      // only stages a form draft and never emits config.set, so this request never arrives.
+      const setRequest = await gateway.waitForRequest("config.set");
+      const raw = requestParams(setRequest).raw;
+      expect(JSON.parse(String(raw))).toEqual({
+        agents: { list: [{ id: "main" }, { id: "kimi", default: true }] },
+      });
+    } finally {
+      await context.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

The Agents page **Set Default** button did not persist the chosen default agent: clicking it only staged a config *form draft* and never wrote it back, so the selection was silently discarded on refresh. This PR routes the one-click action through the canonical config-save path so the default actually sticks.

This addresses the **default-persistence half** of #57067 (labeled `impact:data-loss`). The issue's other half — replacing the agent **dropdown** with a visible list to reduce navigation friction — is a separate UI change and will follow in its own PR, so this PR intentionally does **not** `Closes` the issue.

**What did NOT change:** the dropdown selector, the Agents page layout, the canonical default representation (`agents.list[].default`), the config save/reload RPCs, or any other handler. No new config keys, no new source of truth, no `agents.defaultId` reintroduced.

> AI-assisted (Claude). I authored and reviewed the code; the proof below is from a real browser run I executed locally.

## Root Cause

`onSetDefault` in `ui/src/ui/app-render.ts` called only:

```ts
stageDefaultAgentConfigEntry(state, agentId);
```

`stageDefaultAgentConfigEntry` (`ui/src/ui/controllers/config.ts`) mutates the in-memory config **form draft** (setting `agents.list[].default` on the target, clearing it elsewhere) but never sends `config.set`. Every sibling Agents-page mutation that must persist goes through `saveAgentsConfig` (e.g. `onConfigSave` at `app-render.ts:3098`), which runs `saveConfig` (`config.set`) → `loadAgents` → restores selection. The Set Default handler was the only one that staged without saving, so on the next `config.get`/refresh the staged draft was dropped.

The fix belongs at the controller boundary, not inline in the renderer: a new `setDefaultAgent` helper composes the existing canonical pieces (stage the canonical flag, then persist via the shared save path). The renderer handler becomes thin wiring.

```ts
export async function setDefaultAgent(state, agentId) {
  if (stageDefaultAgentConfigEntry(state, agentId)) {
    await saveAgentsConfig(state);
  }
}
```

## Verification (supplemental automated checks)

- `pnpm test ui/src/ui/controllers/agents.test.ts` — 15 passed (incl. 2 new `setDefaultAgent` cases).
- `pnpm test ui/src/ui/controllers/config.test.ts ui/src/ui/views/agents.test.ts` — 51 passed.
- A new Playwright + stub-gateway regression in `ui/src/ui/e2e/agents-set-default-persistence.e2e.test.ts`.
- `pnpm tsgo:core` / `pnpm tsgo:test:ui`, `oxlint`, `oxfmt --check` — all clean.

## Regression Test Plan

- **Unit** (`controllers/agents.test.ts`): `setDefaultAgent` stages the canonical `agents.list[].default` flag and persists it through `config.set` with the expected raw; and it issues no request when the target agent is absent from the config list.
- **Browser regression** (`e2e/agents-set-default-persistence.e2e.test.ts`): loads the Agents page with two agents, selects the non-default one, clicks **Set Default**, and asserts a `config.set` request is emitted carrying `kimi`'s `default: true`. This guard fails on the pre-fix code (no `config.set` is ever emitted).

## Real behavior proof

- **Behavior addressed:** Clicking **Set Default** on the Agents page now persists the chosen agent as default through the real Gateway config write path instead of only staging an unsaved config draft.
- **Real environment tested:** Real browser Control UI connected to two real local Gateway processes on loopback, not a stub Gateway. The before environment used current upstream `main` at `9d9389b`; the after environment used this PR branch at `5d064f3`. Both used isolated proof state dirs, `gateway.auth.mode: "none"` for local loopback screenshot access only, and `OPENCLAW_SKIP_CHANNELS=1` so chat channels did not start.
- **Exact steps or command run after this patch:**

```text
# before/current-main environment
OPENCLAW_STATE_DIR=/tmp/openclaw-pr91457-before pnpm openclaw config set agents.list '[{"id":"main"},{"id":"openclaw_test_agent"}]' --strict-json --replace
OPENCLAW_STATE_DIR=/tmp/openclaw-pr91457-before OPENCLAW_SKIP_CHANNELS=1 pnpm openclaw gateway --port 18889
# Browser: open http://127.0.0.1:18889/agents, select openclaw_test_agent, click Set Default, refresh.

# after/PR environment
OPENCLAW_STATE_DIR=/tmp/openclaw-pr91457-after pnpm openclaw config set agents.list '[{"id":"main"},{"id":"openclaw_test_agent"}]' --strict-json --replace
OPENCLAW_STATE_DIR=/tmp/openclaw-pr91457-after OPENCLAW_SKIP_CHANNELS=1 pnpm openclaw gateway --port 18899
# Browser: open http://127.0.0.1:18899/agents, select openclaw_test_agent, click Set Default, refresh.
```

- **Evidence before fix:** On upstream `main`, the browser showed `openclaw_test_agent` selected while `main` still appeared as `(default)`, and the page displayed `You have unsaved config changes.` After the same UI action and refresh, reading the real Gateway config still showed no persisted default flag:

```json
[
  {
    "id": "main"
  },
  {
    "id": "openclaw_test_agent"
  }
]
```

- **Evidence after fix:** On this PR branch, the real Gateway log recorded the Set Default click going through `config.set`, followed by reload/readback:

```text
14:29:28 [reload] config change detected; evaluating reload (agents.list, meta.lastTouchedAt)
14:29:28 [reload] config hot reload applied (agents.list)
14:29:29 [ws] ⇄ res ✓ config.set 1212ms conn=14e512cc…11d3 id=3174cef8…4cee
14:29:29 [ws] ⇄ res ✓ config.get 203ms conn=14e512cc…11d3 id=924d3e76…a0f5
```

Reading the real Gateway config after the browser refresh showed the chosen agent persisted as canonical `agents.list[].default`:

```json
[
  {
    "id": "main"
  },
  {
    "id": "openclaw_test_agent",
    "default": true
  }
]
```

- **Observed result after fix:** After clicking **Set Default** and refreshing the Agents page, the dropdown showed `openclaw_test_agent (default)` and the Default button was disabled for that selected agent. The persisted config also survived the UI refresh because the real Gateway wrote `openclaw_test_agent.default: true` to the active config.
- **Screenshot evidence:** Local screenshots were captured and checked: the before screenshot shows `openclaw_test_agent` selected while `main (default)` remains the default and the UI reports unsaved config changes;  The after-fix screenshot shows `openclaw_test_agent (default)` still selected after refresh, with the **Default** button disabled for that selected agent.
<img width="2557" height="927" alt="image" src="https://github.com/user-attachments/assets/5e13c487-739c-4d60-ad34-a23bbb7d33a8" />
<img width="2542" height="948" alt="image" src="https://github.com/user-attachments/assets/2306a055-dc45-439f-8b19-f08deda5fbb2" />

- **What was not tested:** Remote/non-loopback auth and channel startup were intentionally out of scope for this Control UI persistence proof; channels were skipped. The dropdown-to-list UX change remains out of scope for this PR.

## Merge risk

- **Surface:** Control UI config persistence (config-adjacent). Touches one handler + one new controller helper; no protocol change, no config schema change, no new config/env surface.
- **Compatibility:** none affected — uses the existing canonical `agents.list[].default` representation and the existing `config.set` path. No migration, no new key, no removed fallback.
- **Self-claimed labels:** `impact:data-loss` (this fixes the reported loss), Control UI. No product-decision or security implications for this half.

Refs #57067
