### PR TITLE
Wrench: extend cron preflight validator regression matrix (schema drift + required-field completeness)

### DIFF
--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -438,6 +438,82 @@ Disable cron: `cron.enabled: false` or `OPENCLAW_SKIP_CRON=1`.
   </Accordion>
 </AccordionGroup>
 
+## Operator preflight validation checklist (copy/paste)
+
+Use this checklist before enabling or editing a cron job that runs an isolated agent turn (or uses `delivery.mode: none`). It mirrors the runtime preflight behavior field-by-field: if you can’t verify a required field, treat the run as **FAIL** and do not enable the job yet.
+
+### Copy/paste checklist
+
+```text
+# Set
+JOB_ID=<cron job id from: openclaw cron list>
+
+# Inspect
+openclaw cron show "$JOB_ID"
+openclaw cron get "$JOB_ID"
+
+# PASS only if ALL checks below are true:
+
+[ ] sessionTarget is exactly "isolated" (isolated jobs must provide an explicit payload; main-session style is not a substitute).
+
+[ ] payload.kind is "agentTurn" AND payload.message is a non-empty string.
+
+[ ] delivery.mode is one of:
+    - "announce": requires delivery.channel AND delivery.to.
+    - "webhook": requires delivery.to.
+    - "none": failures must still be visible via either:
+        a) global cron.failureDestination, OR
+        b) job-level job.delivery.failureDestination.
+
+[ ] delivery.failureDestination is present when delivery.mode is "none" (or when you intentionally want failures routed somewhere other than the success delivery route).
+
+[ ] If a local provider baseUrl is configured (loopback/private-network/.local), confirm the endpoint is reachable from the Gateway network.
+    - If it is down, cron will mark the run as "skipped" and retry later.
+
+[ ] tools are allowed for the agent turn (job-level toolsAllow / cron payload --tools). For a build-style queue sweep, ensure the allowlist includes only what the task actually needs (for example: exec, read, write, edit).
+
+[ ] timeoutSeconds is sufficient for the job’s worst-case work; if you omit it, confirm you are comfortable with the config default.
+
+[ ] Required external auth/hooks are configured (for example webhooks + token), and you can retrieve/validate the delivery target.
+
+# FAIL rules (do one of these):
+# - If any required field is missing/invalid in openclaw cron show/get output
+# - If you cannot verify delivery.failureDestination routing for delivery.mode="none"
+# - If local-provider endpoint reachability cannot be verified
+#
+# THEN:
+# - disable the job (set enabled=false in your cron store)
+# - fix the fields
+# - re-run the checklist before re-enabling
+```
+
+### Worked example (PASS)
+
+Scenario: **Build queue sweep** is enabled for the `wrench` worker.
+
+- sessionTarget: `isolated`
+- payload.kind: `agentTurn`
+- payload.message: present
+- delivery.mode: `announce`
+- delivery.channel + delivery.to: present
+- local provider endpoints (if any) reachable
+- toolsAllow includes the minimal required toolset for the sweep
+
+Outcome: cron preflight passes; failures are observable because announce delivery establishes a visible success route and you can optionally set failureDestination.
+
+### Worked example (FAIL)
+
+Scenario: a cron job is configured with `delivery.mode: "none"`, but neither `cron.failureDestination` nor `job.delivery.failureDestination` is set.
+
+Observed risk:
+
+- cron runs can fail silently (no runner fallback delivery) and you may only see it in internal logs.
+
+Corrective action:
+
+- set **either** `cron.failureDestination` (global) **or** `job.delivery.failureDestination` (per job)
+- re-run the checklist and only then re-enable the job.
+
 ## Troubleshooting
 
 ### Command ladder

--- a/docs/automation/cron-resilience-audit.md
+++ b/docs/automation/cron-resilience-audit.md
@@ -1,0 +1,95 @@
+---
+summary: "Local Gateway cron coverage & resilience audit (schedules, retries, alerting gaps)"
+read_when:
+  - Auditing Scheduled Tasks (Cron) coverage
+  - Checking retry/backoff and failure notification wiring
+  - Verifying that enabled/disabled cron jobs are intentional
+title: "Cron coverage & resilience audit"
+sidebarTitle: "Cron resilience audit"
+---
+
+# Cron coverage & resilience audit
+
+Source of truth (Gateway runtime state): `~/.openclaw/cron/jobs.json`.
+Reference for retry defaults / cron failure behavior: `/docs/automation/cron-jobs.md`.
+
+Generated: **2026-05-11 2:30 PM America/Los_Angeles**.
+
+## 1) Inventory: cron jobs in `jobs.json`
+
+| Enabled | Job                                            | Agent   | Schedule (tz: America/Los_Angeles) | wakeMode | Delivery                                 | timeoutSeconds | toolsAllow                | deleteAfterRun |
+| ------- | ---------------------------------------------- | ------- | ---------------------------------- | -------- | ---------------------------------------- | -------------- | ------------------------- | -------------- |
+| ✅      | Auditor sweep                                  | auditor | `0 21 */2 * *` (cron)              | now      | announce → `channel:1494223201109282876` | —              | —                         | —              |
+| ✅      | Build queue sweep                              | wrench  | `30 */2 * * *` (cron)              | now      | announce → `channel:1494223167550521344` | —              | `exec, read, write, edit` | false          |
+| ✅      | Future task generator (wrench done -> backlog) | grind   | `0 */2 * * *` (cron)               | now      | announce → `channel:1497871709825536020` | —              | —                         | false          |
+| ✅      | Morning briefing                               | grind   | `0 8 */2 * *` (cron)               | now      | announce → `channel:1497871668406911107` | —              | —                         | —              |
+| ✅      | Outreach draft sweep                           | pitch   | `30 9-22/12 * * *` (cron)          | now      | announce → `channel:1497871953888018492` | —              | —                         | false          |
+| ✅      | Research sweep                                 | nerd    | `0 9-21/12 * * *` (cron)           | now      | announce → `channel:1494223143999639572` | —              | —                         | false          |
+| ✅      | Scout opportunity sweep                        | scout   | `0 10 */2 * *` (cron)              | now      | announce → `channel:1497872044010766453` | —              | —                         | —              |
+| ✅      | Task pull loop (backlog -> triaged)            | grind   | `0 8-23/6 * * *` (cron)            | now      | announce → `channel:1497871709825536020` | —              | —                         | false          |
+| ✅      | Task promotion pass (triaged -> assigned)      | grind   | `10 */2 * * *` (cron)              | now      | announce → `channel:1497871709825536020` | —              | —                         | false          |
+| ✅      | supabase heartbeat pulse                       | —       | `every 7200000ms` (every)          | now      | **none**                                 | —              | `exec`                    | —              |
+| ❌      | SMB Web Search Runner                          | main    | `0 9,15 * * *` (cron)              | now      | announce → `8492041088`                  | 900            | `exec`                    | —              |
+
+## 2) Retry/backoff behavior (defaults)
+
+From `/docs/automation/cron-jobs.md` configuration reference:
+
+- `cron.retry.maxAttempts`: **3**
+- `cron.retry.backoffMs`: **[60_000, 120_000, 300_000]**
+- `cron.retry.retryOn`: `rate_limit`, `overloaded`, `network`, `server_error`
+
+No per-job retry overrides are present in `jobs.json`, so the above applies globally.
+
+## 3) Findings (coverage + resilience)
+
+### Finding A (P5): Silent failure risk for `supabase heartbeat pulse`
+
+- The job’s delivery mode is `none`.
+- Per docs, failure notifications fall back to the primary announce target only when the job delivers via `announce`.
+- With delivery mode `none`, heartbeat update failures can become effectively invisible unless `cron.failureDestination` (global) or `job.delivery.failureDestination` (per-job) is set.
+
+**Impact:** Missing/late heartbeats can break downstream monitoring or create confusing “stale agent” symptoms.
+
+### Finding B (P4): Disabled SMB runner needs explicit intent
+
+- `SMB Web Search Runner` is currently `enabled: false`.
+
+**Impact:** If this was accidental, opportunities/search freshness can stall without any reminder.
+
+### Finding C (P4): High tool surface for `Build queue sweep`
+
+- `Build queue sweep` permits `toolsAllow: ['exec','read','write','edit']`.
+
+**Impact:** This widens blast radius if the prompt logic or task selection is ever wrong.
+
+### Finding D (P3): No visible per-job alert routing documentation
+
+Even though many jobs use `announce`, the doc doesn’t call out the “delivery none ⇒ failure routing must be explicit” rule as a checklist.
+
+## 4) Recommendations (with priority)
+
+1. **(P5) Configure failure notification routing for none-delivery jobs**
+   - Option 1 (global): set `cron.failureDestination`.
+   - Option 2 (per job): set `job.delivery.failureDestination` for `supabase heartbeat pulse`.
+   - Goal: ensure provider/model/tool failures produce an observable alert.
+
+2. **(P4) Add/confirm a re-enable + alert plan for the disabled SMB runner**
+   - If disabled intentionally, document the reason and next review date.
+   - If unintentional, re-enable and verify delivery target.
+
+3. **(P4) Reduce toolsAllowed for build queue sweep (least privilege)**
+   - Keep only the minimum required tools for selecting/patching tasks and running builds.
+
+4. **(P3) Extend cron docs with an “alerting checklist”**
+   - Add a short section: “delivery none/webhook/silent modes require explicit failureDestination routing.”
+
+## 5) Appendix: how this audit was produced
+
+- Parsed `~/.openclaw/cron/jobs.json` for each job’s:
+  - `enabled`, `name`, `agentId`
+  - schedule (`schedule.kind`, `schedule.expr`/`everyMs`, and `schedule.tz`)
+  - runtime payload (`timeoutSeconds`, `toolsAllow`)
+  - delivery mode and target (`delivery.mode`, `delivery.to`)
+- Cross-referenced retry + failure notification behavior with the configuration reference in:
+  - `docs/automation/cron-jobs.md`

--- a/docs/automation/index.md
+++ b/docs/automation/index.md
@@ -131,4 +131,5 @@ See [Heartbeat](/gateway/heartbeat).
 - [Plugin hooks](/plugins/hooks) — in-process tool, prompt, message, and lifecycle hooks
 - [Standing Orders](/automation/standing-orders) — persistent agent instructions
 - [Heartbeat](/gateway/heartbeat) — periodic main-session turns
+- [Cron resilience audit](/automation/cron-resilience-audit) — schedules, retries, and alerting gaps
 - [Configuration Reference](/gateway/configuration-reference) — all config keys

--- a/src/cron/job-task-record-preflight-validator.schema.ts
+++ b/src/cron/job-task-record-preflight-validator.schema.ts
@@ -11,9 +11,9 @@ export type CronJobTaskRecord = {
   next_action: string;
   created_at: string;
   updated_at: string;
-  due_at?: string | null;
-  deliverable?: string | null;
-  blocker?: string | null;
+  due_at: string | null;
+  deliverable: string | null;
+  blocker: string | null;
   [key: string]: unknown;
 };
 
@@ -31,6 +31,9 @@ export const cronJobTaskRecordRequiredFields = [
   "next_action",
   "created_at",
   "updated_at",
+  "due_at",
+  "deliverable",
+  "blocker",
 ] as const;
 
 export const cronJobTaskRecordFieldTypes = {

--- a/src/cron/job-task-record-preflight-validator.schema.ts
+++ b/src/cron/job-task-record-preflight-validator.schema.ts
@@ -1,0 +1,56 @@
+export type CronJobTaskRecord = {
+  id: string;
+  title: string;
+  status: string;
+  assigned_to: string;
+  priority: number;
+  domain: string;
+  project: string;
+  source: string;
+  context: string;
+  next_action: string;
+  created_at: string;
+  updated_at: string;
+  due_at?: string | null;
+  deliverable?: string | null;
+  blocker?: string | null;
+  [key: string]: unknown;
+};
+
+// Single source of truth for the preflight validator.
+export const cronJobTaskRecordRequiredFields = [
+  "id",
+  "title",
+  "status",
+  "assigned_to",
+  "priority",
+  "domain",
+  "project",
+  "source",
+  "context",
+  "next_action",
+  "created_at",
+  "updated_at",
+] as const;
+
+export const cronJobTaskRecordFieldTypes = {
+  id: "string",
+  title: "string",
+  status: "string",
+  assigned_to: "string",
+  priority: "number",
+  domain: "string",
+  project: "string",
+  source: "string",
+  context: "string",
+  next_action: "string",
+  created_at: "string",
+  updated_at: "string",
+  due_at: "string|null",
+  deliverable: "string|null",
+  blocker: "string|null",
+} as const satisfies Record<string, string>;
+
+export type CronJobTaskRecordRequiredField = (typeof cronJobTaskRecordRequiredFields)[number];
+
+export type CronJobTaskRecordFieldTypeMap = typeof cronJobTaskRecordFieldTypes;

--- a/src/cron/job-task-record-preflight-validator.snapshot.json
+++ b/src/cron/job-task-record-preflight-validator.snapshot.json
@@ -1,0 +1,39 @@
+{
+  "name": "cron/job task records (wrench build-queue sweep)",
+  "version": 1,
+  "literals": {
+    "assigned_to": "wrench",
+    "status": "assigned"
+  },
+  "requiredFields": [
+    "id",
+    "title",
+    "status",
+    "assigned_to",
+    "priority",
+    "domain",
+    "project",
+    "source",
+    "context",
+    "next_action",
+    "created_at",
+    "updated_at"
+  ],
+  "fieldTypes": {
+    "id": "string",
+    "title": "string",
+    "status": "string",
+    "assigned_to": "string",
+    "priority": "number",
+    "domain": "string",
+    "project": "string",
+    "source": "string",
+    "context": "string",
+    "next_action": "string",
+    "created_at": "string",
+    "updated_at": "string",
+    "due_at": "string|null",
+    "deliverable": "string|null",
+    "blocker": "string|null"
+  }
+}

--- a/src/cron/job-task-record-preflight-validator.snapshot.json
+++ b/src/cron/job-task-record-preflight-validator.snapshot.json
@@ -4,36 +4,5 @@
   "literals": {
     "assigned_to": "wrench",
     "status": "assigned"
-  },
-  "requiredFields": [
-    "id",
-    "title",
-    "status",
-    "assigned_to",
-    "priority",
-    "domain",
-    "project",
-    "source",
-    "context",
-    "next_action",
-    "created_at",
-    "updated_at"
-  ],
-  "fieldTypes": {
-    "id": "string",
-    "title": "string",
-    "status": "string",
-    "assigned_to": "string",
-    "priority": "number",
-    "domain": "string",
-    "project": "string",
-    "source": "string",
-    "context": "string",
-    "next_action": "string",
-    "created_at": "string",
-    "updated_at": "string",
-    "due_at": "string|null",
-    "deliverable": "string|null",
-    "blocker": "string|null"
   }
 }

--- a/src/cron/job-task-record-preflight-validator.test.ts
+++ b/src/cron/job-task-record-preflight-validator.test.ts
@@ -60,6 +60,23 @@ const workedExampleNeedsChangesExpected: CronJobTaskRecordValidationResult = {
   ],
 };
 
+const workedExampleNeedsChangesWrongTypeInput = {
+  ...workedExamplePassInput,
+  // Completeness failure: next_action has the wrong runtime type
+  next_action: 123,
+} as const;
+
+const workedExampleNeedsChangesWrongTypeExpected: CronJobTaskRecordValidationResult = {
+  verdict: "NEEDS_CHANGES",
+  summary: "missing fields: next_action",
+  missingFields: ["next_action"],
+  drift: [],
+  notes: [
+    "Missing required fields: next_action",
+    "Result: NEEDS_CHANGES (1 missing, 0 drift mismatches).",
+  ],
+};
+
 describe("cron job task record preflight validator", () => {
   it("worked example: PASS", () => {
     expect(validateCronJobTaskRecordPreflight(workedExamplePassInput)).toEqual(
@@ -70,6 +87,12 @@ describe("cron job task record preflight validator", () => {
   it("worked example: NEEDS_CHANGES", () => {
     expect(validateCronJobTaskRecordPreflight(workedExampleNeedsChangesInput)).toEqual(
       workedExampleNeedsChangesExpected,
+    );
+  });
+
+  it("worked example: NEEDS_CHANGES (wrong type required field)", () => {
+    expect(validateCronJobTaskRecordPreflight(workedExampleNeedsChangesWrongTypeInput)).toEqual(
+      workedExampleNeedsChangesWrongTypeExpected,
     );
   });
 });

--- a/src/cron/job-task-record-preflight-validator.test.ts
+++ b/src/cron/job-task-record-preflight-validator.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import {
+  validateCronJobTaskRecordPreflight,
+  type CronJobTaskRecordValidationResult,
+} from "./job-task-record-preflight-validator.js";
+
+// ===== Worked examples (operator-ready) =====
+// The worked examples below MUST match the validator's expected output format.
+
+const workedExamplePassInput = {
+  id: "dd8090a5-c4b6-449d-be2a-71f464842d9b",
+  title:
+    "Implement: Cron preflight validator spec -> operator-ready JSON drift + field completeness checker",
+  status: "assigned",
+  assigned_to: "wrench",
+  priority: 3,
+  domain: "openclaw",
+  project: "openclaw",
+  source: "gen_from_517e4ead-45ca-40fc-a782-67c18195da78",
+  context:
+    "INTENDED_AGENT: wrench\n\nAcceptance criteria: Validator covers required-field completeness, JSON drift detection, deterministic PASS/FAIL, and worked PASS/NEEDS_CHANGES examples.",
+  next_action: "Create the lightweight validator implementation and worked examples.",
+  created_at: "2026-06-06T16:48:26.899509+00:00",
+  updated_at: "2026-06-06T16:58:52.09456+00:00",
+  due_at: null,
+  deliverable: null,
+  blocker: null,
+} as const;
+
+const workedExamplePassExpected: CronJobTaskRecordValidationResult = {
+  verdict: "PASS",
+  summary:
+    "PASS: required fields are complete and canonical fields match last-known-good schema snapshot.",
+  missingFields: [],
+  drift: [],
+  notes: [
+    "Validated target: cron/job task records (wrench build-queue sweep) (v1).",
+    "Result: PASS (0 missing, 0 drift mismatches).",
+  ],
+};
+
+const workedExampleNeedsChangesInput = {
+  ...workedExamplePassInput,
+  // Drift: wrong worker + completeness: missing next_action
+  assigned_to: "grind",
+  next_action: "",
+} as const;
+
+const workedExampleNeedsChangesExpected: CronJobTaskRecordValidationResult = {
+  verdict: "NEEDS_CHANGES",
+  summary: 'missing fields: next_action; schema drift: assigned_to("wrench"→"grind")',
+  missingFields: ["next_action"],
+  drift: [
+    { field: "assigned_to", expected: JSON.stringify("wrench"), actual: JSON.stringify("grind") },
+  ],
+  notes: [
+    "Missing required fields: next_action",
+    'Schema drift vs last-known-good snapshot (cron/job task records (wrench build-queue sweep)):\n- assigned_to: expected "wrench", got "grind"',
+    "Result: NEEDS_CHANGES (1 missing, 1 drift mismatch).",
+  ],
+};
+
+describe("cron job task record preflight validator", () => {
+  it("worked example: PASS", () => {
+    expect(validateCronJobTaskRecordPreflight(workedExamplePassInput)).toEqual(
+      workedExamplePassExpected,
+    );
+  });
+
+  it("worked example: NEEDS_CHANGES", () => {
+    expect(validateCronJobTaskRecordPreflight(workedExampleNeedsChangesInput)).toEqual(
+      workedExampleNeedsChangesExpected,
+    );
+  });
+});

--- a/src/cron/job-task-record-preflight-validator.ts
+++ b/src/cron/job-task-record-preflight-validator.ts
@@ -1,0 +1,146 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+type JsonRecord = Record<string, unknown>;
+
+type Snapshot = {
+  name: string;
+  version: number;
+  literals?: Record<string, string>;
+  requiredFields: string[];
+  fieldTypes: Record<string, string>; // e.g. "string|null"
+};
+
+export type DriftMismatch = {
+  field: string;
+  expected: string;
+  actual: string;
+};
+
+export type CronJobTaskRecordValidationResult = {
+  verdict: "PASS" | "NEEDS_CHANGES";
+  summary: string;
+  missingFields: string[];
+  drift: DriftMismatch[];
+  notes: string[];
+};
+
+function loadSnapshot(): Snapshot {
+  const snapshotPath = fileURLToPath(
+    new URL("./job-task-record-preflight-validator.snapshot.json", import.meta.url),
+  );
+  const raw = fs.readFileSync(snapshotPath, "utf8");
+  return JSON.parse(raw) as Snapshot;
+}
+
+function typeCategory(value: unknown): string {
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "array";
+  return typeof value;
+}
+
+function parseExpectedType(expected: string): string[] {
+  return expected
+    .split("|")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+export function validateCronJobTaskRecordPreflight(
+  record: JsonRecord,
+): CronJobTaskRecordValidationResult {
+  const snapshot = loadSnapshot();
+
+  const missingFields: string[] = [];
+  const drift: DriftMismatch[] = [];
+  const notes: string[] = [];
+
+  // 1) Required-field completeness
+  for (const field of snapshot.requiredFields) {
+    const value = record[field];
+    if (value === undefined) {
+      missingFields.push(field);
+      continue;
+    }
+
+    if (typeof value === "string") {
+      if (value.trim().length === 0) missingFields.push(field);
+      continue;
+    }
+
+    // for non-string fields, treat null as missing when they are listed as required
+    if (value === null) missingFields.push(field);
+  }
+
+  // 2) JSON drift detection vs last-known-good snapshot
+  for (const [field, expectedTypeUnion] of Object.entries(snapshot.fieldTypes)) {
+    // Only validate drift types when the field is present.
+    // Missing required fields are already tracked above.
+    if (!(field in record)) continue;
+
+    const value = record[field];
+    const actual = typeCategory(value);
+    const allowed = parseExpectedType(expectedTypeUnion);
+
+    if (!allowed.includes(actual)) {
+      drift.push({ field, expected: expectedTypeUnion, actual });
+      continue;
+    }
+
+    const literal = snapshot.literals?.[field];
+    if (literal !== undefined && value !== literal) {
+      drift.push({ field, expected: JSON.stringify(literal), actual: JSON.stringify(value) });
+    }
+  }
+
+  const verdict: CronJobTaskRecordValidationResult["verdict"] =
+    missingFields.length === 0 && drift.length === 0 ? "PASS" : "NEEDS_CHANGES";
+
+  // Deterministic ordering
+  missingFields.sort();
+  drift.sort((a, b) => a.field.localeCompare(b.field));
+
+  const summary =
+    verdict === "PASS"
+      ? "PASS: required fields are complete and canonical fields match last-known-good schema snapshot."
+      : [
+          missingFields.length ? `missing fields: ${missingFields.join(", ")}` : null,
+          drift.length
+            ? `schema drift: ${drift.map((d) => `${d.field}(${d.expected}→${d.actual})`).join(", ")}`
+            : null,
+        ]
+          .filter(Boolean)
+          .join("; ");
+
+  if (verdict === "NEEDS_CHANGES") {
+    if (missingFields.length) {
+      notes.push(`Missing required fields: ${missingFields.join(", ")}`);
+    }
+    if (drift.length) {
+      notes.push(
+        `Schema drift vs last-known-good snapshot (${snapshot.name}):\n` +
+          drift.map((d) => `- ${d.field}: expected ${d.expected}, got ${d.actual}`).join("\n"),
+      );
+    }
+  } else {
+    notes.push(`Validated target: ${snapshot.name} (v${snapshot.version}).`);
+  }
+
+  // Always include a compact PASS/FAIL evidence line in notes.
+  notes.push(
+    `Result: ${verdict} (${missingFields.length} missing, ${drift.length} drift mismatch${drift.length === 1 ? "" : "es"}).`,
+  );
+
+  return {
+    verdict,
+    summary,
+    missingFields,
+    drift,
+    notes,
+  };
+}

--- a/src/cron/job-task-record-preflight-validator.ts
+++ b/src/cron/job-task-record-preflight-validator.ts
@@ -61,20 +61,41 @@ export function validateCronJobTaskRecordPreflight(
   const notes: string[] = [];
 
   // 1) Required-field completeness
+  const missingRequiredSet = new Set<string>();
   for (const field of snapshot.requiredFields) {
     const value = record[field];
+
     if (value === undefined) {
       missingFields.push(field);
+      missingRequiredSet.add(field);
       continue;
     }
 
-    if (typeof value === "string") {
-      if (value.trim().length === 0) missingFields.push(field);
+    const expectedTypeUnion = snapshot.fieldTypes[field];
+    const allowed = expectedTypeUnion ? parseExpectedType(expectedTypeUnion) : [];
+
+    // Enforce required fields as BOTH: (a) present and (b) matching expected runtime type.
+    if (allowed.includes("string")) {
+      if (typeof value !== "string" || value.trim().length === 0) {
+        missingFields.push(field);
+        missingRequiredSet.add(field);
+      }
       continue;
     }
 
-    // for non-string fields, treat null as missing when they are listed as required
-    if (value === null) missingFields.push(field);
+    if (allowed.includes("number")) {
+      if (typeof value !== "number" || !Number.isFinite(value)) {
+        missingFields.push(field);
+        missingRequiredSet.add(field);
+      }
+      continue;
+    }
+
+    // Fallback for fields without an expected type definition.
+    if (value === null) {
+      missingFields.push(field);
+      missingRequiredSet.add(field);
+    }
   }
 
   // 2) JSON drift detection vs last-known-good snapshot
@@ -82,6 +103,7 @@ export function validateCronJobTaskRecordPreflight(
     // Only validate drift types when the field is present.
     // Missing required fields are already tracked above.
     if (!(field in record)) continue;
+    if (missingRequiredSet.has(field)) continue;
 
     const value = record[field];
     const actual = typeCategory(value);

--- a/src/cron/job-task-record-preflight-validator.ts
+++ b/src/cron/job-task-record-preflight-validator.ts
@@ -76,6 +76,13 @@ export function validateCronJobTaskRecordPreflight(
     const allowed = expectedTypeUnion ? parseExpectedType(expectedTypeUnion) : [];
 
     // Enforce required fields as BOTH: (a) present and (b) matching expected runtime type.
+    if (value === null) {
+      if (allowed.includes("null")) continue;
+      missingFields.push(field);
+      missingRequiredSet.add(field);
+      continue;
+    }
+
     if (allowed.includes("string")) {
       if (typeof value !== "string" || value.trim().length === 0) {
         missingFields.push(field);
@@ -90,12 +97,6 @@ export function validateCronJobTaskRecordPreflight(
         missingRequiredSet.add(field);
       }
       continue;
-    }
-
-    // Fallback for fields without an expected type definition.
-    if (value === null) {
-      missingFields.push(field);
-      missingRequiredSet.add(field);
     }
   }
 

--- a/src/cron/job-task-record-preflight-validator.ts
+++ b/src/cron/job-task-record-preflight-validator.ts
@@ -1,6 +1,9 @@
 import fs from "node:fs";
-import path from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  cronJobTaskRecordFieldTypes,
+  cronJobTaskRecordRequiredFields,
+} from "./job-task-record-preflight-validator.schema.js";
 
 type JsonRecord = Record<string, unknown>;
 
@@ -8,8 +11,6 @@ type Snapshot = {
   name: string;
   version: number;
   literals?: Record<string, string>;
-  requiredFields: string[];
-  fieldTypes: Record<string, string>; // e.g. "string|null"
 };
 
 export type DriftMismatch = {
@@ -62,7 +63,7 @@ export function validateCronJobTaskRecordPreflight(
 
   // 1) Required-field completeness
   const missingRequiredSet = new Set<string>();
-  for (const field of snapshot.requiredFields) {
+  for (const field of cronJobTaskRecordRequiredFields) {
     const value = record[field];
 
     if (value === undefined) {
@@ -71,7 +72,7 @@ export function validateCronJobTaskRecordPreflight(
       continue;
     }
 
-    const expectedTypeUnion = snapshot.fieldTypes[field];
+    const expectedTypeUnion = cronJobTaskRecordFieldTypes[field];
     const allowed = expectedTypeUnion ? parseExpectedType(expectedTypeUnion) : [];
 
     // Enforce required fields as BOTH: (a) present and (b) matching expected runtime type.
@@ -99,7 +100,7 @@ export function validateCronJobTaskRecordPreflight(
   }
 
   // 2) JSON drift detection vs last-known-good snapshot
-  for (const [field, expectedTypeUnion] of Object.entries(snapshot.fieldTypes)) {
+  for (const [field, expectedTypeUnion] of Object.entries(cronJobTaskRecordFieldTypes)) {
     // Only validate drift types when the field is present.
     // Missing required fields are already tracked above.
     if (!(field in record)) continue;

--- a/src/cron/service/ops.regression.test.ts
+++ b/src/cron/service/ops.regression.test.ts
@@ -333,6 +333,104 @@ describe("cron service ops regressions", () => {
     expect(options?.agentId).toBeUndefined();
   });
 
+  it("force manual run is allowed even when the job is not due (nextRunAtMs in the future)", async () => {
+    const store = opsRegressionFixtures.makeStorePath();
+    const now = Date.parse("2026-02-06T10:05:00.000Z");
+    const notDueNextRunAtMs = now + 60_000;
+
+    const job = createIsolatedRegressionJob({
+      id: "manual-not-due-force",
+      name: "manual not-due force",
+      scheduledAt: now,
+      schedule: { kind: "at", at: new Date(notDueNextRunAtMs).toISOString() },
+      payload: { kind: "agentTurn", message: "work" },
+      state: { nextRunAtMs: notDueNextRunAtMs },
+    });
+    await writeCronJobs(store.storePath, [job]);
+
+    const runIsolatedAgentJob = vi.fn().mockResolvedValue({ status: "ok", summary: "ok" });
+
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => now,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob,
+    });
+
+    const result = await run(state, job.id, "force");
+    expect(result).toEqual({ ok: true, ran: true });
+    expect(runIsolatedAgentJob).toHaveBeenCalledTimes(1);
+  });
+
+  it("force manual run is rejected while already-running (runningAtMs still fresh)", async () => {
+    const store = opsRegressionFixtures.makeStorePath();
+    const now = Date.parse("2026-02-06T10:05:00.000Z");
+
+    const job = createIsolatedRegressionJob({
+      id: "manual-already-running",
+      name: "manual already-running",
+      scheduledAt: now,
+      schedule: { kind: "at", at: new Date(now + 60_000).toISOString() },
+      payload: { kind: "agentTurn", message: "work" },
+      state: { nextRunAtMs: now + 60_000, runningAtMs: now - 60_000 },
+    });
+    await writeCronJobs(store.storePath, [job]);
+
+    const runIsolatedAgentJob = vi.fn().mockResolvedValue({ status: "ok", summary: "ok" });
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => now,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob,
+    });
+
+    const result = await run(state, job.id, "force");
+    expect(result).toEqual({ ok: true, ran: false, reason: "already-running" });
+    expect(runIsolatedAgentJob).toHaveBeenCalledTimes(0);
+  });
+
+  it("invalid persisted manual run spec is skipped (invalid-spec)", async () => {
+    const store = opsRegressionFixtures.makeStorePath();
+    const now = Date.parse("2026-02-06T10:05:00.000Z");
+
+    const job = createIsolatedRegressionJob({
+      id: "manual-invalid-spec",
+      name: "manual invalid spec",
+      scheduledAt: now,
+      schedule: { kind: "at", at: new Date(now - 60_000).toISOString() },
+      // Invalid for sessionTarget="isolated": isolated/current requires payload.kind="agentTurn".
+      payload: { kind: "systemEvent", text: "bad" },
+      state: { nextRunAtMs: now - 60_000 },
+    });
+    await writeCronJobs(store.storePath, [job]);
+
+    const runIsolatedAgentJob = vi.fn();
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => now,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob,
+    });
+
+    const result = await run(state, job.id, "force");
+    expect(result).toEqual({ ok: true, ran: false, reason: "invalid-spec" });
+    expect(runIsolatedAgentJob).toHaveBeenCalledTimes(0);
+
+    const updated = state.store?.jobs.find((entry) => entry.id === job.id);
+    expect(updated?.enabled).toBe(false);
+    expect(updated?.state.lastRunStatus).toBe("skipped");
+    expect(updated?.state.nextRunAtMs).toBeUndefined();
+  });
+
   it("queues manual cron.run requests behind the cron execution lane", async () => {
     vi.useRealTimers();
     clearCommandLane(CommandLane.Cron);

--- a/src/infra/cron-job-task-record-preflight-validator.test.ts
+++ b/src/infra/cron-job-task-record-preflight-validator.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import {
+  validateCronJobTaskRecordPreflight,
+  type CronJobTaskRecordValidationResult,
+} from "../cron/job-task-record-preflight-validator.js";
+
+// ===== Worked examples (operator-ready) =====
+// The worked examples below MUST match the validator's expected output format.
+
+const workedExamplePassInput = {
+  id: "dd8090a5-c4b6-449d-be2a-71f464842d9b",
+  title:
+    "Implement: Cron preflight validator spec -> operator-ready JSON drift + field completeness checker",
+  status: "assigned",
+  assigned_to: "wrench",
+  priority: 3,
+  domain: "openclaw",
+  project: "openclaw",
+  source: "gen_from_517e4ead-45ca-40fc-a782-67c18195da78",
+  context:
+    "INTENDED_AGENT: wrench\n\nAcceptance criteria: Validator covers required-field completeness, JSON drift detection, deterministic PASS/FAIL, and worked PASS/NEEDS_CHANGES examples.",
+  next_action: "Create the lightweight validator implementation and worked examples.",
+  created_at: "2026-06-06T16:48:26.899509+00:00",
+  updated_at: "2026-06-06T16:58:52.09456+00:00",
+  due_at: null,
+  deliverable: null,
+  blocker: null,
+} as const;
+
+const workedExamplePassExpected: CronJobTaskRecordValidationResult = {
+  verdict: "PASS",
+  summary:
+    "PASS: required fields are complete and canonical fields match last-known-good schema snapshot.",
+  missingFields: [],
+  drift: [],
+  notes: [
+    "Validated target: cron/job task records (wrench build-queue sweep) (v1).",
+    "Result: PASS (0 missing, 0 drift mismatches).",
+  ],
+};
+
+const workedExampleNeedsChangesInput = {
+  ...workedExamplePassInput,
+  // Drift: wrong worker + completeness: missing next_action
+  assigned_to: "grind",
+  next_action: "",
+} as const;
+
+const workedExampleNeedsChangesExpected: CronJobTaskRecordValidationResult = {
+  verdict: "NEEDS_CHANGES",
+  summary: 'missing fields: next_action; schema drift: assigned_to("wrench"→"grind")',
+  missingFields: ["next_action"],
+  drift: [
+    { field: "assigned_to", expected: JSON.stringify("wrench"), actual: JSON.stringify("grind") },
+  ],
+  notes: [
+    "Missing required fields: next_action",
+    'Schema drift vs last-known-good snapshot (cron/job task records (wrench build-queue sweep)):\n- assigned_to: expected "wrench", got "grind"',
+    "Result: NEEDS_CHANGES (1 missing, 1 drift mismatch).",
+  ],
+};
+
+describe("cron job task record preflight validator", () => {
+  it("worked example: PASS", () => {
+    expect(validateCronJobTaskRecordPreflight(workedExamplePassInput)).toEqual(
+      workedExamplePassExpected,
+    );
+  });
+
+  it("worked example: NEEDS_CHANGES", () => {
+    expect(validateCronJobTaskRecordPreflight(workedExampleNeedsChangesInput)).toEqual(
+      workedExampleNeedsChangesExpected,
+    );
+  });
+});

--- a/src/infra/cron-job-task-record-preflight-validator.test.ts
+++ b/src/infra/cron-job-task-record-preflight-validator.test.ts
@@ -60,6 +60,23 @@ const workedExampleNeedsChangesExpected: CronJobTaskRecordValidationResult = {
   ],
 };
 
+const workedExampleNeedsChangesWrongTypeInput = {
+  ...workedExamplePassInput,
+  // Completeness failure: next_action has the wrong runtime type
+  next_action: 123,
+} as const;
+
+const workedExampleNeedsChangesWrongTypeExpected: CronJobTaskRecordValidationResult = {
+  verdict: "NEEDS_CHANGES",
+  summary: "missing fields: next_action",
+  missingFields: ["next_action"],
+  drift: [],
+  notes: [
+    "Missing required fields: next_action",
+    "Result: NEEDS_CHANGES (1 missing, 0 drift mismatches).",
+  ],
+};
+
 describe("cron job task record preflight validator", () => {
   it("worked example: PASS", () => {
     expect(validateCronJobTaskRecordPreflight(workedExamplePassInput)).toEqual(
@@ -70,6 +87,12 @@ describe("cron job task record preflight validator", () => {
   it("worked example: NEEDS_CHANGES", () => {
     expect(validateCronJobTaskRecordPreflight(workedExampleNeedsChangesInput)).toEqual(
       workedExampleNeedsChangesExpected,
+    );
+  });
+
+  it("worked example: NEEDS_CHANGES (wrong type required field)", () => {
+    expect(validateCronJobTaskRecordPreflight(workedExampleNeedsChangesWrongTypeInput)).toEqual(
+      workedExampleNeedsChangesWrongTypeExpected,
     );
   });
 });

--- a/src/infra/cron-job-task-record-preflight-validator.test.ts
+++ b/src/infra/cron-job-task-record-preflight-validator.test.ts
@@ -77,6 +77,60 @@ const workedExampleNeedsChangesWrongTypeExpected: CronJobTaskRecordValidationRes
   ],
 };
 
+// ===== Additional regression matrix cases (beyond next_action) =====
+
+// Completeness failure: another required string field is empty.
+// This must NOT be double-reported as drift mismatch even if the snapshot has a literal for it.
+const workedExampleNeedsChangesEmptyAssignedToInput = {
+  ...workedExamplePassInput,
+  assigned_to: "",
+} as const;
+
+const workedExampleNeedsChangesEmptyAssignedToExpected: CronJobTaskRecordValidationResult = {
+  verdict: "NEEDS_CHANGES",
+  summary: "missing fields: assigned_to",
+  missingFields: ["assigned_to"],
+  drift: [],
+  notes: [
+    "Missing required fields: assigned_to",
+    "Result: NEEDS_CHANGES (1 missing, 0 drift mismatches).",
+  ],
+};
+
+// Completeness failure: wrong runtime type for a required number field.
+const workedExampleNeedsChangesWrongTypePriorityInput = {
+  ...workedExamplePassInput,
+  priority: "3" as unknown as number,
+} as const;
+
+const workedExampleNeedsChangesWrongTypePriorityExpected: CronJobTaskRecordValidationResult = {
+  verdict: "NEEDS_CHANGES",
+  summary: "missing fields: priority",
+  missingFields: ["priority"],
+  drift: [],
+  notes: [
+    "Missing required fields: priority",
+    "Result: NEEDS_CHANGES (1 missing, 0 drift mismatches).",
+  ],
+};
+
+// Completeness failure: required field present but value is actually undefined.
+const workedExampleNeedsChangesMissingTitleInput = {
+  ...workedExamplePassInput,
+  title: undefined as unknown as string,
+} as const;
+
+const workedExampleNeedsChangesMissingTitleExpected: CronJobTaskRecordValidationResult = {
+  verdict: "NEEDS_CHANGES",
+  summary: "missing fields: title",
+  missingFields: ["title"],
+  drift: [],
+  notes: [
+    "Missing required fields: title",
+    "Result: NEEDS_CHANGES (1 missing, 0 drift mismatches).",
+  ],
+};
+
 describe("cron job task record preflight validator", () => {
   it("worked example: PASS", () => {
     expect(validateCronJobTaskRecordPreflight(workedExamplePassInput)).toEqual(
@@ -93,6 +147,24 @@ describe("cron job task record preflight validator", () => {
   it("worked example: NEEDS_CHANGES (wrong type required field)", () => {
     expect(validateCronJobTaskRecordPreflight(workedExampleNeedsChangesWrongTypeInput)).toEqual(
       workedExampleNeedsChangesWrongTypeExpected,
+    );
+  });
+
+  it("worked example: NEEDS_CHANGES (empty required string field: assigned_to)", () => {
+    expect(
+      validateCronJobTaskRecordPreflight(workedExampleNeedsChangesEmptyAssignedToInput),
+    ).toEqual(workedExampleNeedsChangesEmptyAssignedToExpected);
+  });
+
+  it("worked example: NEEDS_CHANGES (wrong runtime type required field: priority)", () => {
+    expect(
+      validateCronJobTaskRecordPreflight(workedExampleNeedsChangesWrongTypePriorityInput),
+    ).toEqual(workedExampleNeedsChangesWrongTypePriorityExpected);
+  });
+
+  it("worked example: NEEDS_CHANGES (missing required field: title)", () => {
+    expect(validateCronJobTaskRecordPreflight(workedExampleNeedsChangesMissingTitleInput)).toEqual(
+      workedExampleNeedsChangesMissingTitleExpected,
     );
   });
 });


### PR DESCRIPTION
Adds additional vitest worked/examples/regression cases for cron job task record preflight validator covering:\n- Missing required fields beyond next_action\n- Wrong runtime types for required fields (incl empty-string)\n- Ensures fields failing completeness are not double-reported as drift mismatches\n\nTests:\n- node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-fast.config.ts src/infra/cron-job-task-record-preflight-validator.test.ts