### PR TITLE
fix #63343: Browser bridge tab not found race

### DIFF
--- a/extensions/browser/src/browser/server-context.selection.ts
+++ b/extensions/browser/src/browser/server-context.selection.ts
@@ -11,6 +11,10 @@ import { BrowserTabNotFoundError, BrowserTargetAmbiguousError } from "./errors.j
 import { getBrowserProfileCapabilities } from "./profile-capabilities.js";
 import type { PwAiModule } from "./pw-ai-module.js";
 import { getPwAiModule } from "./pw-ai-module.js";
+import {
+  OPEN_TAB_DISCOVERY_POLL_MS,
+  OPEN_TAB_DISCOVERY_WINDOW_MS,
+} from "./server-context.constants.js";
 import type { BrowserTab, ProfileRuntimeState } from "./server-context.types.js";
 import { resolveTargetIdFromTabs } from "./target-id.js";
 
@@ -29,6 +33,29 @@ type SelectionOps = {
   closeTab: (targetId: string) => Promise<void>;
 };
 
+function mergeOpenedTabSnapshot(tabs: BrowserTab[], openedTab: BrowserTab | null): BrowserTab[] {
+  if (!openedTab) {
+    return tabs;
+  }
+  const index = tabs.findIndex((tab) => tab.targetId === openedTab.targetId);
+  if (index < 0) {
+    return [...tabs, openedTab];
+  }
+  const tab = tabs[index];
+  if (tab && !tab.wsUrl && openedTab.wsUrl) {
+    const merged = tabs.slice();
+    merged[index] = { ...tab, wsUrl: openedTab.wsUrl };
+    return merged;
+  }
+  return tabs;
+}
+
+function waitForTabDiscoveryPoll(): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, OPEN_TAB_DISCOVERY_POLL_MS);
+  });
+}
+
 /** Builds tab selection/focus/close operations for one resolved browser profile. */
 export function createProfileSelectionOps({
   profile,
@@ -45,12 +72,30 @@ export function createProfileSelectionOps({
     await ensureBrowserAvailable();
     const profileState = getProfileState();
     const tabs1 = await listTabs();
+    let openedTab: BrowserTab | null = null;
     if (tabs1.length === 0) {
-      await openTab("about:blank");
+      openedTab = await openTab("about:blank");
     }
 
-    const tabs = await listTabs();
-    const candidates = capabilities.supportsPerTabWs ? tabs.filter((t) => Boolean(t.wsUrl)) : tabs;
+    const candidateTabs = (tabs: BrowserTab[]) =>
+      capabilities.supportsPerTabWs ? tabs.filter((t) => Boolean(t.wsUrl)) : tabs;
+    let tabs = mergeOpenedTabSnapshot(await listTabs(), openedTab);
+    let candidates = candidateTabs(tabs);
+
+    if (capabilities.supportsPerTabWs && candidates.length === 0 && tabs.length > 0) {
+      const deadline = Date.now() + OPEN_TAB_DISCOVERY_WINDOW_MS;
+      while (Date.now() < deadline) {
+        await waitForTabDiscoveryPoll();
+        tabs = mergeOpenedTabSnapshot(await listTabs(), openedTab);
+        candidates = candidateTabs(tabs);
+        if (candidates.length > 0) {
+          break;
+        }
+      }
+      if (candidates.length === 0) {
+        candidates = tabs;
+      }
+    }
 
     const resolveById = (raw: string) => {
       const resolved = resolveTargetIdFromTabs(raw, candidates);

--- a/extensions/browser/src/browser/server-context.selection.ts
+++ b/extensions/browser/src/browser/server-context.selection.ts
@@ -84,16 +84,20 @@ export function createProfileSelectionOps({
 
     if (capabilities.supportsPerTabWs && candidates.length === 0 && tabs.length > 0) {
       const deadline = Date.now() + OPEN_TAB_DISCOVERY_WINDOW_MS;
+      let lastUnfilteredTabs = tabs;
       while (Date.now() < deadline) {
         await waitForTabDiscoveryPoll();
         tabs = mergeOpenedTabSnapshot(await listTabs(), openedTab);
+        if (tabs.length > 0) {
+          lastUnfilteredTabs = tabs;
+        }
         candidates = candidateTabs(tabs);
         if (candidates.length > 0) {
           break;
         }
       }
       if (candidates.length === 0) {
-        candidates = tabs;
+        candidates = lastUnfilteredTabs;
       }
     }
 

--- a/extensions/browser/src/browser/server-context.tab-selection-state.test.ts
+++ b/extensions/browser/src/browser/server-context.tab-selection-state.test.ts
@@ -8,6 +8,10 @@ import * as cdpHelpersModule from "./cdp.helpers.js";
 import * as cdpModule from "./cdp.js";
 import { InvalidBrowserNavigationUrlError } from "./navigation-guard.js";
 import {
+  OPEN_TAB_DISCOVERY_POLL_MS,
+  OPEN_TAB_DISCOVERY_WINDOW_MS,
+} from "./server-context.constants.js";
+import {
   createTestBrowserRouteContext,
   makeManagedTabsWithNew,
   makeState,
@@ -181,6 +185,126 @@ describe("browser server-context tab selection state", () => {
       url: "about:blank",
       ssrfPolicy: undefined,
     });
+  });
+
+  it("uses the just-opened tab when /json/list has not discovered it yet", async () => {
+    vi.spyOn(cdpModule, "createTargetViaCdp").mockRejectedValue(new Error("cdp unavailable"));
+
+    let listCount = 0;
+    const fetchMock = vi.fn(async (url: unknown) => {
+      const value = String(url);
+      if (value.includes("/json/list")) {
+        listCount += 1;
+        return { ok: true, json: async () => [] } as unknown as Response;
+      }
+      if (value.includes("/json/new")) {
+        return {
+          ok: true,
+          json: async () => ({
+            id: "CREATED",
+            title: "New Tab",
+            url: "about:blank",
+            webSocketDebuggerUrl: "ws://127.0.0.1/devtools/page/CREATED",
+            type: "page",
+          }),
+        } as unknown as Response;
+      }
+      throw new Error(`unexpected fetch: ${value}`);
+    });
+
+    global.fetch = withBrowserFetchPreconnect(fetchMock);
+    const state = makeState("openclaw");
+    const ctx = createTestBrowserRouteContext({ getState: () => state });
+    const openclaw = ctx.forProfile("openclaw");
+
+    const selected = await openclaw.ensureTabAvailable();
+    expect(selected).toEqual(
+      expect.objectContaining({
+        targetId: "CREATED",
+        wsUrl: "ws://127.0.0.1/devtools/page/CREATED",
+      }),
+    );
+    expect(state.profiles.get("openclaw")?.lastTargetId).toBe("CREATED");
+    expect(listCount).toBe(2);
+  });
+
+  it("waits for delayed local tab wsUrl discovery before filtering candidates", async () => {
+    let listCount = 0;
+    const fetchMock = vi.fn(async (url: unknown) => {
+      const value = String(url);
+      if (!value.includes("/json/list")) {
+        throw new Error(`unexpected fetch: ${value}`);
+      }
+      listCount += 1;
+      return {
+        ok: true,
+        json: async () => [
+          {
+            id: "LAGGING_WS",
+            title: "Lagging WS",
+            url: "https://example.com",
+            ...(listCount >= 3
+              ? { webSocketDebuggerUrl: "ws://127.0.0.1/devtools/page/LAGGING_WS" }
+              : {}),
+            type: "page",
+          },
+        ],
+      } as unknown as Response;
+    });
+
+    global.fetch = withBrowserFetchPreconnect(fetchMock);
+    const state = makeState("openclaw");
+    const ctx = createTestBrowserRouteContext({ getState: () => state });
+    const openclaw = ctx.forProfile("openclaw");
+
+    const selected = await openclaw.ensureTabAvailable();
+    expect(selected).toEqual(
+      expect.objectContaining({
+        targetId: "LAGGING_WS",
+        wsUrl: "ws://127.0.0.1/devtools/page/LAGGING_WS",
+      }),
+    );
+    expect(listCount).toBe(3);
+  });
+
+  it("falls back to an unfiltered local tab when wsUrl discovery stays behind", async () => {
+    vi.useFakeTimers();
+    try {
+      let listCount = 0;
+      const fetchMock = vi.fn(async (url: unknown) => {
+        const value = String(url);
+        if (!value.includes("/json/list")) {
+          throw new Error(`unexpected fetch: ${value}`);
+        }
+        listCount += 1;
+        return {
+          ok: true,
+          json: async () => [
+            {
+              id: "NO_WS_YET",
+              title: "No WS Yet",
+              url: "https://example.com",
+              type: "page",
+            },
+          ],
+        } as unknown as Response;
+      });
+
+      global.fetch = withBrowserFetchPreconnect(fetchMock);
+      const state = makeState("openclaw");
+      const ctx = createTestBrowserRouteContext({ getState: () => state });
+      const openclaw = ctx.forProfile("openclaw");
+
+      const selectedPromise = openclaw.ensureTabAvailable();
+      await vi.advanceTimersByTimeAsync(OPEN_TAB_DISCOVERY_WINDOW_MS + OPEN_TAB_DISCOVERY_POLL_MS);
+      await expect(selectedPromise).resolves.toEqual(
+        expect.objectContaining({ targetId: "NO_WS_YET" }),
+      );
+      expect(state.profiles.get("openclaw")?.lastTargetId).toBe("NO_WS_YET");
+      expect(listCount).toBeGreaterThan(2);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("opens a real tab when only browser-internal CDP targets are listed", async () => {

--- a/extensions/browser/src/browser/server-context.tab-selection-state.test.ts
+++ b/extensions/browser/src/browser/server-context.tab-selection-state.test.ts
@@ -307,6 +307,49 @@ describe("browser server-context tab selection state", () => {
     }
   });
 
+  it("keeps the last unfiltered local tab when later wsUrl polling lists are empty", async () => {
+    vi.useFakeTimers();
+    try {
+      let listCount = 0;
+      const fetchMock = vi.fn(async (url: unknown) => {
+        const value = String(url);
+        if (!value.includes("/json/list")) {
+          throw new Error(`unexpected fetch: ${value}`);
+        }
+        listCount += 1;
+        return {
+          ok: true,
+          json: async () =>
+            listCount <= 2
+              ? [
+                  {
+                    id: "NO_WS_THEN_EMPTY",
+                    title: "No WS Then Empty",
+                    url: "https://example.com",
+                    type: "page",
+                  },
+                ]
+              : [],
+        } as unknown as Response;
+      });
+
+      global.fetch = withBrowserFetchPreconnect(fetchMock);
+      const state = makeState("openclaw");
+      const ctx = createTestBrowserRouteContext({ getState: () => state });
+      const openclaw = ctx.forProfile("openclaw");
+
+      const selectedPromise = openclaw.ensureTabAvailable();
+      await vi.advanceTimersByTimeAsync(OPEN_TAB_DISCOVERY_WINDOW_MS + OPEN_TAB_DISCOVERY_POLL_MS);
+      await expect(selectedPromise).resolves.toEqual(
+        expect.objectContaining({ targetId: "NO_WS_THEN_EMPTY" }),
+      );
+      expect(state.profiles.get("openclaw")?.lastTargetId).toBe("NO_WS_THEN_EMPTY");
+      expect(listCount).toBeGreaterThan(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("opens a real tab when only browser-internal CDP targets are listed", async () => {
     const createTargetViaCdp = vi
       .spyOn(cdpModule, "createTargetViaCdp")


### PR DESCRIPTION
## Summary

- Preserve the last non-empty unfiltered local tab snapshot while waiting for delayed per-tab CDP WebSocket discovery.
- Add a regression test for the race where `/json/list` first reports a page target without `webSocketDebuggerUrl`, then later returns an empty list before the discovery window expires.
- Add live local-managed Chrome/CDP proof showing `browser doctor --deep` and a follow-up `browser snapshot` succeed without `tab not found`.

## Real behavior proof

- **Behavior or issue addressed:** Live local-managed Chrome/CDP browser commands should not fail with `BrowserTabNotFoundError: tab not found` when `ensureTabAvailable()` has already observed a usable local page target during target discovery.
- **Real environment tested:** Linux with Node v22.22.0, Chrome at `/usr/bin/google-chrome`, isolated `OPENCLAW_HOME` under the evidence directory, loopback token-auth gateway with token redacted, `openclaw` browser profile, headless local-managed Chrome, CDP transport on port 28800.
- **Exact steps or command run after this patch:** Executed from the PR worktree using `node --import tsx src/entry.ts`:

    gateway run --port 28791 --auth token --bind loopback
    browser --json --timeout 60000 --token <redacted> --browser-profile openclaw status
    browser --json --timeout 60000 --token <redacted> --browser-profile openclaw start --headless
    browser --json --timeout 60000 --token <redacted> --browser-profile openclaw tabs
    browser --json --timeout 60000 --token <redacted> --browser-profile openclaw doctor --deep
    browser --json --timeout 60000 --token <redacted> --browser-profile openclaw snapshot --format aria --limit 25
    browser --json --timeout 60000 --token <redacted> --browser-profile openclaw tabs

- **Evidence after fix:**

    /media/vdc/code/ai/aispace/openclaw-pr-91463-evidence/live-local-managed-cdp-proof.md
    /media/vdc/code/ai/aispace/openclaw-pr-91463-evidence/browser-doctor-deep.json
    /media/vdc/code/ai/aispace/openclaw-pr-91463-evidence/browser-snapshot-after-doctor.json
    /media/vdc/code/ai/aispace/openclaw-pr-91463-evidence/live-local-managed-cdp-tab-not-found-grep.txt
    /media/vdc/code/ai/aispace/openclaw-pr-91463-evidence/server-context-tab-selection-state-test.log
    /media/vdc/code/ai/aispace/openclaw-pr-91463-evidence/local-tsgo-test.log

- **Observed result after fix:**

    head: d2c2efb688ad2b8282aedec59374d30ba8feacb2
    profile: openclaw
    transport: cdp
    localManaged: true
    headless: true
    cdpPort: 28800
    cdpReadyAfterStart: true
    doctorOk: true
    liveSnapshotCheck: { name: "live-snapshot", ok: true, detail: "3 nodes/lines" }
    snapshotOk: true
    snapshotFormat: aria
    snapshotNodeCount: 3
    targetId: 52711704B278EFD1BC1375EA846D3EF4
    suggestedTargetId: t5
    tabsVisibleAfterSnapshot: 1
    tabNotFoundSearch: no tab not found found in live proof output

- **What was not tested:** Remote browser profiles, Chrome MCP profiles, and nonlocal Mantis/browser-desktop environments were not exercised in this local proof. The completed proof covers the local-managed Chrome/CDP production path requested for this PR: `browser doctor --deep -> GET /snapshot -> profileCtx.ensureTabAvailable() -> local-managed Chrome CDP snapshot`, followed by `browser snapshot` through the same route after target selection.
- **Fix classification:** Root cause fix.

## Review findings addressed

- RF-001 / RF-002: Added live local-managed Chrome/CDP proof from the production browser CLI path, not a mock-only or unit-only proof.
- RF-003 / RF-006: Changed the polling fallback to keep the last non-empty unfiltered tab snapshot instead of the final possibly-empty `/json/list` result.
- RF-004: The live proof runs `browser doctor --deep` first and then `browser snapshot` after the target has been selected, showing the selected target remains usable for a follow-up command.
- RF-005: Contributor-side action is complete: code hardening, regression coverage, live proof, and verification marker are refreshed on the submitted commit.

## Regression Test Plan

- `node scripts/run-vitest.mjs run extensions/browser/src/browser/server-context.tab-selection-state.test.ts`
  - `Test Files  1 passed (1)`
  - `Tests  18 passed (18)`
- **Target test file:** `extensions/browser/src/browser/server-context.tab-selection-state.test.ts`.
- **Scenario locked in:** `keeps the last unfiltered local tab when later wsUrl polling lists are empty` is a regression test that reproduces the failure shape by returning a no-`webSocketDebuggerUrl` page target for the first polls and `[]` for later polls.
- **Why this is the smallest reliable guardrail:** This single focused test hits the exact state transition that caused the bug: an observed local page target is followed by an empty discovery snapshot before per-tab `wsUrl` appears. Before the fix, this path rejects with `BrowserTabNotFoundError: tab not found`; after the fix, it resolves with `targetId: NO_WS_THEN_EMPTY` and writes `lastTargetId`, guarding both availability and selection-state behavior.

## Root Cause

- **Root cause:** The source selection state in `ensureTabAvailable()` did not preserve the last usable unfiltered tab snapshot while polling for delayed per-tab `webSocketDebuggerUrl` discovery. Because the timeout fallback used the most recent `/json/list` response, a later empty response could replace an earlier observed page target without a per-tab `wsUrl`. That state overwrite caused the selection owner to choose from an empty final list and throw `BrowserTabNotFoundError: tab not found` even though a usable local-managed Chrome target had already been observed.
- **Why this is root-cause fix:** The selection invariant is that the fallback should use the last usable observed local tab snapshot when no per-tab `wsUrl` candidate appears before the discovery deadline. Keeping `lastUnfilteredTabs` in `createProfileSelectionOps()` fixes the source selection state instead of catching or string-matching the downstream `tab not found` error.
- **Why it matters / User impact:** The affected path is used by browser CLI commands such as `browser doctor --deep` and `browser snapshot`. When target discovery races with local-managed Chrome, users can see a browser command fail even though Chrome has a usable page target. The fix preserves that target and avoids a false browser-unavailable result.

## Patch quality notes

- **Patch quality notes:** The production change is one focused selection fallback in `extensions/browser/src/browser/server-context.selection.ts`, paired with one regression in `extensions/browser/src/browser/server-context.tab-selection-state.test.ts`.
- **What did NOT change:** This only changes local-managed browser tab discovery fallback behavior when per-tab WebSocket candidates are unavailable during the polling window. It does not change public CLI flags, browser profile configuration, gateway auth, model provider routing, CDP protocol messages, schema, wire format, migrations, or default browser settings. No unrelated refactor or broad browser lifecycle change is included.
- **Architecture / source-of-truth check:** The fix is in `createProfileSelectionOps()`, the source-of-truth selection path used by `/snapshot` and CLI browser commands. It keeps selection logic in the browser server context instead of adding downstream string matching for `tab not found`.
- **Type-cast warning explanation:** The `as unknown as Response` casts are limited to Vitest `fetch` mocks that only need `ok` and `json()` for `/json/list` responses. No production type escape was added.
- **Contract surface:** Existing `browser doctor --deep` and `browser snapshot` behavior is preserved; they still call the same `/snapshot` route and `ensureTabAvailable()` selection path.
- **Compatibility/default behavior:** Existing candidates with per-tab `wsUrl` still win immediately. Only the no-candidate fallback changes from the final possibly-empty list to the last non-empty observed list.
- **Canonical source-of-truth:** `createProfileSelectionOps()` remains the canonical selection owner for profile tab availability and `lastTargetId` updates.
- **Related open PR scan result:** This is an update to existing PR #91463 for issue #63343; no broader API/config/schema PR is being introduced by this patch.
- **Out of scope:** Remote browser behavior, Chrome MCP behavior, gateway auth behavior, and nonlocal Mantis/browser-desktop proof are outside this focused fix.

## Merge risk

- **Risk labels considered:** `merge-risk: availability`, `merge-risk: session-state`.
- **Risk explanation:** The changed branch decides which observed tab snapshot is eligible for fallback selection after local-managed per-tab `wsUrl` discovery times out. A wrong change here could still choose the wrong target or affect `lastTargetId` state.
- **Why acceptable:** Candidates with a per-tab `wsUrl` still win immediately. The fallback only changes from the final possibly-empty polling result to the last non-empty observed local tab snapshot, which preserves an already-observed target id instead of throwing. The regression test covers the reported race, and the live proof covers the production `/snapshot` path with a follow-up command.
- **Maintainer-ready confidence:** High. The diff is focused, the regression reproduces the failure shape, and the live local-managed Chrome/CDP proof shows the browser command path succeeds without `tab not found`.

## Proof boundary

- Local proof completed: local-managed Chrome/CDP profile on Linux with isolated local gateway and redacted token auth.
- External environment unavailable: nonlocal Mantis/browser-desktop proof was not available in this environment.
- Completed local verification: production browser CLI path, live Chrome process, CDP transport, `doctor --deep`, follow-up `snapshot`, and grep across proof outputs for `tab not found`.