### PR TITLE
fix(agents): scope stale usage clearing to pre-compaction messages only [AI-assisted]

### DIFF
--- a/src/agents/embedded-agent-subscribe.handlers.compaction.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.compaction.ts
@@ -43,7 +43,7 @@ export function handleCompactionStart(
   const kind = compactionLogKind(reason);
   ctx.state.compactionInFlight = true;
   ctx.state.livenessState = "paused";
-  ctx.state.preCompactionMessageCount = ctx.params.session.messages?.length ?? 0;
+  ctx.state.preCompactionAssistantMessages = collectAssistantMessages(ctx.params.session.messages);
   ctx.ensureCompactionPromise();
   ctx.log.info(`embedded run ${kind} start`, {
     event: "embedded_run_compaction_start",
@@ -182,25 +182,44 @@ export async function reconcileSessionStoreCompactionCountAfterSuccess(params: {
   return reconcile(params);
 }
 
+/** Collect object references for all assistant messages in the array. */
+function collectAssistantMessages(messages: unknown): Set<object> {
+  const set = new Set<object>();
+  if (!Array.isArray(messages)) {
+    return set;
+  }
+  for (const message of messages) {
+    if (
+      message &&
+      typeof message === "object" &&
+      (message as { role?: unknown }).role === "assistant"
+    ) {
+      set.add(message);
+    }
+  }
+  return set;
+}
+
 function clearStaleAssistantUsageOnSessionMessages(ctx: EmbeddedAgentSubscribeContext): void {
   const messages = ctx.params.session.messages;
   if (!Array.isArray(messages)) {
     return;
   }
-  const preCount = ctx.state.preCompactionMessageCount;
-  // Only clear usage for messages that existed *before* the current
-  // compaction. Messages added during or after compaction (e.g. new
-  // LLM responses with valid usage data) must not be zeroed. (#50795)
-  for (let i = 0; i < messages.length; i++) {
-    const message = messages[i];
+  const preCompactionMessages = ctx.state.preCompactionAssistantMessages;
+  // Only clear usage for assistant messages that existed *before* the current
+  // compaction. Using object-identity (Set of references captured at compaction
+  // start) is safe across compaction rewrites: messages that survive compaction
+  // keep their object identity, while new messages added after compaction are
+  // not in the set and retain their valid usage data. (#50795)
+  for (const message of messages) {
     if (!message || typeof message !== "object") {
       continue;
     }
-    if (typeof preCount === "number" && i >= preCount) {
-      break;
-    }
     const candidate = message as { role?: unknown; usage?: unknown };
     if (candidate.role !== "assistant") {
+      continue;
+    }
+    if (preCompactionMessages && !preCompactionMessages.has(message)) {
       continue;
     }
     // session runtime expects assistant usage to exist when computing context usage.

--- a/src/agents/embedded-agent-subscribe.handlers.compaction.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.compaction.ts
@@ -1,3 +1,8 @@
+/**
+ * Handles embedded-agent compaction lifecycle events. The handlers pause
+ * liveness, emit agent events, run hooks, reconcile persisted counts, and
+ * clear stale usage after compaction rewrites history.
+ */
 import { emitAgentEvent } from "../infra/agent-events.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import type { EmbeddedAgentSubscribeContext } from "./embedded-agent-subscribe.handlers.types.js";
@@ -25,6 +30,8 @@ type CompactionEndEvent =
       aborted?: unknown;
     };
 
+// Unknown reasons come from external runtimes or older sessions. Treat them as
+// threshold compaction so logs and event payloads stay on the closed reason set.
 function normalizeCompactionReason(reason: unknown): CompactionReason {
   return reason === "manual" || reason === "threshold" || reason === "overflow"
     ? reason
@@ -35,6 +42,7 @@ function compactionLogKind(reason: CompactionReason): string {
   return reason === "manual" ? "manual compaction" : "auto-compaction";
 }
 
+/** Handles compaction start events from an embedded agent session. */
 export function handleCompactionStart(
   ctx: EmbeddedAgentSubscribeContext,
   evt: CompactionStartEvent,
@@ -61,7 +69,8 @@ export function handleCompactionStart(
     data: { phase: "start" },
   });
 
-  // Run before_compaction plugin hook (fire-and-forget)
+  // Hooks are fire-and-forget so compaction state updates and liveness pauses
+  // cannot be delayed by plugin work.
   const hookRunner = getGlobalHookRunner();
   if (hookRunner?.hasHooks("before_compaction")) {
     void hookRunner
@@ -75,21 +84,21 @@ export function handleCompactionStart(
           sessionKey: ctx.params.sessionKey,
         },
       )
-      .catch((err) => {
+      .catch((err: unknown) => {
         ctx.log.warn(`before_compaction hook failed: ${String(err)}`);
       });
   }
 }
 
+/** Handles compaction completion, retry, and incomplete events. */
 export function handleCompactionEnd(ctx: EmbeddedAgentSubscribeContext, evt: CompactionEndEvent) {
   const reason = normalizeCompactionReason(evt.reason);
   const kind = compactionLogKind(reason);
   ctx.state.compactionInFlight = false;
   const willRetry = Boolean(evt.willRetry);
-  // Increment counter whenever compaction actually produced a result,
-  // regardless of willRetry.  Overflow-triggered compaction sets willRetry=true
-  // (the framework retries the LLM request), but the compaction itself succeeded
-  // and context was trimmed — the counter must reflect that.  (#38905)
+  // Increment counter whenever compaction actually produced a result, regardless
+  // of willRetry. Overflow-triggered compaction retries the LLM request after
+  // trimming context, and the persisted count must reflect that successful trim.
   const hasResult = evt.result != null;
   const wasAborted = Boolean(evt.aborted);
   if (hasResult && !wasAborted) {
@@ -114,7 +123,7 @@ export function handleCompactionEnd(ctx: EmbeddedAgentSubscribeContext, evt: Com
       agentId: ctx.params.agentId,
       configStore: ctx.params.config?.session?.store,
       observedCompactionCount,
-    }).catch((err) => {
+    }).catch((err: unknown) => {
       ctx.log.warn(`late compaction count reconcile failed: ${String(err)}`);
     });
   }
@@ -150,7 +159,8 @@ export function handleCompactionEnd(ctx: EmbeddedAgentSubscribeContext, evt: Com
     data: { phase: "end", willRetry, completed: hasResult && !wasAborted },
   });
 
-  // Run after_compaction plugin hook (fire-and-forget)
+  // after_compaction runs only once the run will not retry, matching the visible
+  // post-compaction session state plugin authors observe.
   if (!willRetry) {
     const hookRunnerEnd = getGlobalHookRunner();
     if (hookRunnerEnd?.hasHooks("after_compaction")) {
@@ -163,13 +173,14 @@ export function handleCompactionEnd(ctx: EmbeddedAgentSubscribeContext, evt: Com
           },
           { sessionKey: ctx.params.sessionKey },
         )
-        .catch((err) => {
+        .catch((err: unknown) => {
           ctx.log.warn(`after_compaction hook failed: ${String(err)}`);
         });
     }
   }
 }
 
+/** Lazily reconciles persisted compaction count after a successful compaction. */
 export async function reconcileSessionStoreCompactionCountAfterSuccess(params: {
   sessionKey?: string;
   agentId?: string;
@@ -181,6 +192,7 @@ export async function reconcileSessionStoreCompactionCountAfterSuccess(params: {
     await import("./embedded-agent-subscribe.handlers.compaction.runtime.js");
   return reconcile(params);
 }
+
 
 /** Collect object references for all assistant messages in the array. */
 function collectAssistantMessages(messages: unknown): Set<object> {

--- a/src/agents/embedded-agent-subscribe.handlers.compaction.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.compaction.ts
@@ -43,6 +43,7 @@ export function handleCompactionStart(
   const kind = compactionLogKind(reason);
   ctx.state.compactionInFlight = true;
   ctx.state.livenessState = "paused";
+  ctx.state.preCompactionMessageCount = ctx.params.session.messages?.length ?? 0;
   ctx.ensureCompactionPromise();
   ctx.log.info(`embedded run ${kind} start`, {
     event: "embedded_run_compaction_start",
@@ -186,9 +187,17 @@ function clearStaleAssistantUsageOnSessionMessages(ctx: EmbeddedAgentSubscribeCo
   if (!Array.isArray(messages)) {
     return;
   }
-  for (const message of messages) {
+  const preCount = ctx.state.preCompactionMessageCount;
+  // Only clear usage for messages that existed *before* the current
+  // compaction. Messages added during or after compaction (e.g. new
+  // LLM responses with valid usage data) must not be zeroed. (#50795)
+  for (let i = 0; i < messages.length; i++) {
+    const message = messages[i];
     if (!message || typeof message !== "object") {
       continue;
+    }
+    if (typeof preCount === "number" && i >= preCount) {
+      break;
     }
     const candidate = message as { role?: unknown; usage?: unknown };
     if (candidate.role !== "assistant") {

--- a/src/agents/embedded-agent-subscribe.handlers.types.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.types.ts
@@ -1,9 +1,15 @@
+/**
+ * Shared state and context contracts for embedded-agent subscription handlers.
+ * Message, tool, compaction, and liveness handlers all mutate this single
+ * state shape while keeping their implementation files decoupled.
+ */
 import type { InlineCodeState } from "../../packages/markdown-core/src/code-spans.js";
 import type { FenceScanState } from "../../packages/markdown-core/src/fences.js";
 import type { HeartbeatToolResponse } from "../auto-reply/heartbeat-tool-response.js";
 import type { ReplyDirectiveParseResult } from "../auto-reply/reply/reply-directives.js";
 import type { ReasoningLevel } from "../auto-reply/thinking.js";
 import type { HookRunner } from "../plugins/hooks.js";
+import type { AssistantPhase } from "../shared/chat-message-content.js";
 import type { AcceptedSessionSpawn } from "./accepted-session-spawn.js";
 import type { EmbeddedBlockChunker } from "./embedded-agent-block-chunker.js";
 import type {
@@ -34,6 +40,7 @@ type EmbeddedSubscribeLogger = {
   warn: (message: string, meta?: Record<string, unknown>) => void;
 };
 
+/** Per-tool metadata tracked between tool start/update/end events. */
 export type ToolCallSummary = {
   meta?: string;
   mutatingAction: boolean;
@@ -41,13 +48,35 @@ export type ToolCallSummary = {
   fileTarget?: import("./tool-mutation.js").FileTarget;
 };
 
+/** User-visible assistant stream payload emitted to subscribers. */
+export type AssistantStreamData = {
+  text: string;
+  delta: string;
+  replace?: true;
+  mediaUrls?: string[];
+  phase?: AssistantPhase;
+};
+
+/** Deferred assistant stream event plus whether it should emit partial replies. */
+export type AssistantStreamDelivery = {
+  data: AssistantStreamData;
+  emitPartialReply: boolean;
+};
+
+/** Mutable subscription state shared by embedded-agent event handlers. */
 export type EmbeddedAgentSubscribeState = {
   /** Assistant messages that existed when the current compaction started.
    *  Used to scope stale-usage clearing to pre-compaction messages only.
    *  Messages added during/after compaction are excluded. (#50795) */
   preCompactionAssistantMessages?: Set<object>;
   assistantTexts: string[];
-  toolMetas: Array<{ toolName?: string; meta?: string; asyncStarted?: boolean }>;
+  toolMetas: Array<{
+    toolName?: string;
+    meta?: string;
+    asyncStarted?: boolean;
+    asyncTaskRunId?: string;
+    asyncTaskId?: string;
+  }>;
   acceptedSessionSpawns: AcceptedSessionSpawn[];
   toolMetaById: Map<string, ToolCallSummary>;
   toolSummaryById: Set<string>;
@@ -97,6 +126,9 @@ export type EmbeddedAgentSubscribeState = {
   lastStreamedReasoning?: string;
   lastBlockReplyText?: string;
   lastDeliveredBlockReplyText?: string;
+  deferBlockReplyDelivery: boolean;
+  deferredBlockReplies: BlockReplyPayload[];
+  deferredAssistantEvents: AssistantStreamDelivery[];
   toolExecutionSinceLastBlockReply: boolean;
   reasoningStreamOpen: boolean;
   assistantMessageIndex: number;
@@ -123,7 +155,9 @@ export type EmbeddedAgentSubscribeState = {
   yielded?: boolean;
   timeoutPhase?: AgentRunTimeoutPhase;
   providerStarted?: boolean;
+  terminalAborted?: boolean;
   hadDeterministicSideEffect?: boolean;
+  pendingEventChain: Promise<void> | null;
 
   messagingToolSentTexts: string[];
   messagingToolSentTextsNormalized: string[];
@@ -148,6 +182,7 @@ export type EmbeddedAgentSubscribeState = {
   lastAssistant?: AgentMessage;
 };
 
+/** Handler context bundling params, mutable state, emitters, and helper hooks. */
 export type EmbeddedAgentSubscribeContext = {
   params: SubscribeEmbeddedAgentSessionParams;
   state: EmbeddedAgentSubscribeState;
@@ -216,7 +251,15 @@ export type EmbeddedAgentSubscribeContext = {
   getUsageTotals: () => NormalizedUsage | undefined;
   getCompactionCount: () => number;
   getLastCompactionTokensAfter: () => number | undefined;
+  emitAssistantStreamData: (
+    data: AssistantStreamData,
+    options?: { emitPartialReply?: boolean },
+  ) => void;
   emitBlockReply: (payload: BlockReplyPayload) => void;
+  flushDeferredAssistantEvents: () => void;
+  flushDeferredBlockReplies: () => void;
+  clearDeferredAssistantEvents: () => void;
+  clearDeferredBlockReplies: () => void;
 };
 
 /**

--- a/src/agents/embedded-agent-subscribe.handlers.types.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.types.ts
@@ -42,9 +42,10 @@ export type ToolCallSummary = {
 };
 
 export type EmbeddedAgentSubscribeState = {
-  /** Message count when the current compaction started. Used to scope
-   *  stale-usage clearing to pre-compaction messages only. (#50795) */
-  preCompactionMessageCount?: number;
+  /** Assistant messages that existed when the current compaction started.
+   *  Used to scope stale-usage clearing to pre-compaction messages only.
+   *  Messages added during/after compaction are excluded. (#50795) */
+  preCompactionAssistantMessages?: Set<object>;
   assistantTexts: string[];
   toolMetas: Array<{ toolName?: string; meta?: string; asyncStarted?: boolean }>;
   acceptedSessionSpawns: AcceptedSessionSpawn[];

--- a/src/agents/embedded-agent-subscribe.handlers.types.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.types.ts
@@ -42,6 +42,9 @@ export type ToolCallSummary = {
 };
 
 export type EmbeddedAgentSubscribeState = {
+  /** Message count when the current compaction started. Used to scope
+   *  stale-usage clearing to pre-compaction messages only. (#50795) */
+  preCompactionMessageCount?: number;
   assistantTexts: string[];
   toolMetas: Array<{ toolName?: string; meta?: string; asyncStarted?: boolean }>;
   acceptedSessionSpawns: AcceptedSessionSpawn[];


### PR DESCRIPTION
Closing — the Set<object> approach for tracking pre-compaction messages is fragile across session serialize/deserialize cycles. A more robust implementation would require ID-based tracking with deeper knowledge of OpenClaw session internals.