### PR TITLE
feat(cron): add readable ISO time fields to `cron runs` JSON output

### DIFF
--- a/src/cli/cron-cli/register.cron-simple.ts
+++ b/src/cli/cron-cli/register.cron-simple.ts
@@ -229,7 +229,7 @@ export function registerCronSimpleCommands(cron: Command) {
   addGatewayClientOptions(
     cron
       .command("runs")
-      .description("Show cron run history (JSONL-backed)")
+      .description("Show cron run history")
       .requiredOption("--id <id>", "Job id")
       .option("--run-id <runId>", "Filter by cron run id")
       .option("--limit <n>", "Max entries (default 50)", "50")

--- a/src/cli/cron-cli/shared.run-times-display.test.ts
+++ b/src/cli/cron-cli/shared.run-times-display.test.ts
@@ -1,0 +1,64 @@
+// Cron run-time display tests cover readable ISO mirrors added for users.
+import { describe, expect, it } from "vitest";
+import { formatTimestamp } from "../../logging/timestamps.js";
+import { defaultRuntime } from "../../runtime.js";
+import { printCronJson } from "./shared.js";
+
+function captureCronJson(value: unknown): unknown {
+  let written: unknown;
+  const original = defaultRuntime.writeJson;
+  defaultRuntime.writeJson = (v: unknown) => {
+    written = v;
+  };
+  try {
+    printCronJson(value);
+  } finally {
+    defaultRuntime.writeJson = original;
+  }
+  return written;
+}
+
+describe("printCronJson readable run times", () => {
+  it("adds local-offset ISO mirrors for finished run entries without changing raw fields", () => {
+    const written = captureCronJson({
+      entries: [
+        {
+          ts: 1_733_551_200_123,
+          jobId: "job-1",
+          action: "finished",
+          status: "ok",
+          runAtMs: 1_733_551_200_000,
+          nextRunAtMs: 1_733_554_800_000,
+        },
+      ],
+    });
+    const entry = (written as { entries: Array<Record<string, unknown>> }).entries[0];
+    expect(entry?.tsIso).toBe(formatTimestamp(new Date(1_733_551_200_123), { style: "long" }));
+    expect(entry?.runAtIso).toBe(formatTimestamp(new Date(1_733_551_200_000), { style: "long" }));
+    expect(entry?.nextRunAtIso).toBe(
+      formatTimestamp(new Date(1_733_554_800_000), { style: "long" }),
+    );
+    // Matches the diagnostic-log `time` shape; raw numeric fields stay intact.
+    expect(entry?.tsIso).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}[+-]\d{2}:\d{2}$/);
+    expect(entry?.ts).toBe(1_733_551_200_123);
+    expect(entry?.runAtMs).toBe(1_733_551_200_000);
+    expect(entry?.nextRunAtMs).toBe(1_733_554_800_000);
+  });
+
+  it("omits ISO mirrors when numeric timestamps are absent", () => {
+    const written = captureCronJson({
+      entries: [{ ts: 1_733_551_200_123, jobId: "job-1", action: "finished", status: "ok" }],
+    });
+    const entry = (written as { entries: Array<Record<string, unknown>> }).entries[0];
+    expect(entry?.tsIso).toBeDefined();
+    expect(entry?.runAtIso).toBeUndefined();
+    expect(entry?.nextRunAtIso).toBeUndefined();
+  });
+
+  it("leaves non-run-log entries untouched", () => {
+    const written = captureCronJson({ entries: [{ status: "error" }] });
+    const entry = (written as { entries: Array<Record<string, unknown>> }).entries[0];
+    expect(entry?.tsIso).toBeUndefined();
+    expect(entry?.runAtIso).toBeUndefined();
+  });
+});

--- a/src/cli/cron-cli/shared.ts
+++ b/src/cli/cron-cli/shared.ts
@@ -18,6 +18,7 @@ import {
   isOffsetlessIsoDateTime,
   parseOffsetlessIsoDateTimeInTimeZone,
 } from "../../infra/format-time/parse-offsetless-zoned-datetime.js";
+import { formatTimestamp } from "../../logging/timestamps.js";
 import { defaultRuntime, type RuntimeEnv } from "../../runtime.js";
 import type { GatewayRpcOpts } from "../gateway-rpc.js";
 import { callGatewayFromCli } from "../gateway-rpc.js";
@@ -30,7 +31,19 @@ export const getCronChannelOptions = () => {
   return pluginIds.length > 0 ? ["last", ...pluginIds].join("|") : "last|<channel-id>";
 };
 
-function addCronRunCauseFields(value: unknown): unknown {
+function toLocalIsoTime(value: unknown): string | undefined {
+  return typeof value === "number" && Number.isFinite(value)
+    ? formatTimestamp(new Date(value), { style: "long" })
+    : undefined;
+}
+
+/**
+ * CLI-only display enrichment for `cron runs` history entries: adds a short
+ * `cause` alias for `errorReason` plus readable local-offset ISO mirrors of the
+ * numeric timestamps (matching the diagnostic log `time` format). Stored data
+ * and the gateway protocol stay unchanged; raw numeric fields are preserved.
+ */
+function enrichCronRunEntriesForDisplay(value: unknown): unknown {
   if (!value || typeof value !== "object") {
     return value;
   }
@@ -44,17 +57,33 @@ function addCronRunCauseFields(value: unknown): unknown {
       return entry;
     }
     const item = entry as Record<string, unknown>;
-    if (item.action !== "finished" || typeof item.errorReason !== "string") {
+    if (item.action !== "finished") {
       return item;
     }
-    const cause = item.errorReason.trim();
-    return cause ? Object.assign({}, item, { cause }) : item;
+    const extra: Record<string, unknown> = {};
+    const cause = typeof item.errorReason === "string" ? item.errorReason.trim() : "";
+    if (cause) {
+      extra.cause = cause;
+    }
+    const tsIso = toLocalIsoTime(item.ts);
+    if (tsIso) {
+      extra.tsIso = tsIso;
+    }
+    const runAtIso = toLocalIsoTime(item.runAtMs);
+    if (runAtIso) {
+      extra.runAtIso = runAtIso;
+    }
+    const nextRunAtIso = toLocalIsoTime(item.nextRunAtMs);
+    if (nextRunAtIso) {
+      extra.nextRunAtIso = nextRunAtIso;
+    }
+    return Object.keys(extra).length > 0 ? Object.assign({}, item, extra) : item;
   });
   return { ...record, entries: nextEntries };
 }
 
 export function printCronJson(value: unknown) {
-  defaultRuntime.writeJson(addCronRunCauseFields(value));
+  defaultRuntime.writeJson(enrichCronRunEntriesForDisplay(value));
 }
 
 /**


### PR DESCRIPTION
## Summary

When inspecting cronjob logs, the existing `ts`, `runAtMs`, and `nextRunAtMs` timestamp fields output by `openclaw cron runs` are purely numeric (epoch milliseconds), which are difficult for humans to read directly.

This patch adds `tsIso`, `runAtIso`, and `nextRunAtIso` to the `cron runs` JSON output. To guarantee zero migration risk and maintain strict backward compatibility, this is implemented purely as a display-layer derivation (Scheme B) in the CLI `shared.ts`. The underlying SQLite storage, Gateway protocol schema, and raw numeric JSON fields remain completely untouched. The new ISO strings adopt the same local-offset ISO 8601 format (`YYYY-MM-DDTHH:mm:ss.sss±HH:mm`) used by the diagnostic logger's `time` field.

## Diff size

```text
 src/cli/cron-cli/register.cron-simple.ts          |  2 +-
 src/cli/cron-cli/shared.run-times-display.test.ts | 64 +++++++++++++++++++++++++
 src/cli/cron-cli/shared.ts                        | 39 ++++++++++++++-
 3 files changed, 98 insertions(+), 7 deletions(-)
```

## Verification

Local (Node 24.16.0), against this checkout:

- `node scripts/run-vitest.mjs src/cli/cron-cli/shared.run-times-display.test.ts` - pass.
- `pnpm test cron-cli` (explicitly ran all 5 cron-cli test files) - pass.
- `pnpm tsgo:core` and `pnpm tsgo:core:test` - clean.
- `pnpm format:check` and `pnpm lint:all` - clean.

## Real behavior proof

- **Behavior addressed:** `cron runs` JSON output lacks human-readable timestamp fields.
- **Real environment tested:** `pnpm dev --profile dev gateway run` with an isolated `agentTurn` cronjob.
- **Exact steps or command run after this patch:** Created a test cronjob, forcefully ran it (`openclaw cron run <jobId> --wait`), and queried the log via `openclaw cron runs --id <jobId> --limit 1`.
- **Evidence after fix:**
```json
{
  "ts": 1780832508200,
  "jobId": "94f04d59-21c4-4095-829c-600cc4819655",
  "action": "finished",
  "status": "error",
  ...
  "runAtMs": 1780832477683,
  ...
  "nextRunAtMs": 1780836060352,
  ...
  "tsIso": "2026-06-07T19:41:48.200+08:00",
  "runAtIso": "2026-06-07T19:41:17.683+08:00",
  "nextRunAtIso": "2026-06-07T20:41:00.352+08:00"
}
```
- **Observed result after fix:** The readable local-offset ISO times (`tsIso`, `runAtIso`, `nextRunAtIso`) are injected successfully into the CLI output alongside the intact original numeric timestamps.
- **What was not tested:** Not applicable, as this is purely a CLI display layer enhancement.
- **Observed at HEAD:** `bf630ef4b44c0d882885665e4b468ed1f3aa1e95`

Made with [Cursor](https://cursor.com)