### PR TITLE
fix(acp): preserve structured error kinds

### DIFF
--- a/src/acp/translator.error-kind.test.ts
+++ b/src/acp/translator.error-kind.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { RequestError } from "@agentclientprotocol/sdk";
 import {
   createChatEvent,
   createPendingPromptHarness,
@@ -23,7 +24,24 @@ describe("acp translator errorKind mapping", () => {
     await expect(promptPromise).resolves.toEqual({ stopReason: "refusal" });
   });
 
-  it("maps errorKind: timeout to stopReason: end_turn", async () => {
+  it("maps errorKind: context_length to stopReason: max_tokens", async () => {
+    const { agent, promptPromise, runId } = await createPendingPromptHarness();
+
+    await agent.handleGatewayEvent(
+      createChatEvent({
+        runId,
+        sessionKey: DEFAULT_SESSION_KEY,
+        seq: 1,
+        state: "error",
+        errorKind: "context_length",
+        errorMessage: "Context length exceeded",
+      }),
+    );
+
+    await expect(promptPromise).resolves.toEqual({ stopReason: "max_tokens" });
+  });
+
+  it("maps errorKind: timeout to a RequestError", async () => {
     const { agent, promptPromise, runId } = await createPendingPromptHarness();
 
     await agent.handleGatewayEvent(
@@ -37,10 +55,41 @@ describe("acp translator errorKind mapping", () => {
       }),
     );
 
-    await expect(promptPromise).resolves.toEqual({ stopReason: "end_turn" });
+    await expect(promptPromise).rejects.toSatisfy((err: any) => {
+      return (
+        err instanceof RequestError &&
+        err.code === -32001 &&
+        err.message === "gateway timeout" &&
+        (err.data as any)?.errorKind === "timeout"
+      );
+    });
   });
 
-  it("maps unknown errorKind to stopReason: end_turn", async () => {
+  it("maps errorKind: rate_limit to a RequestError", async () => {
+    const { agent, promptPromise, runId } = await createPendingPromptHarness();
+
+    await agent.handleGatewayEvent(
+      createChatEvent({
+        runId,
+        sessionKey: DEFAULT_SESSION_KEY,
+        seq: 1,
+        state: "error",
+        errorKind: "rate_limit",
+        errorMessage: "rate limit exceeded",
+      }),
+    );
+
+    await expect(promptPromise).rejects.toSatisfy((err: any) => {
+      return (
+        err instanceof RequestError &&
+        err.code === -32002 &&
+        err.message === "rate limit exceeded" &&
+        (err.data as any)?.errorKind === "rate_limit"
+      );
+    });
+  });
+
+  it("maps unknown errorKind to a RequestError", async () => {
     const { agent, promptPromise, runId } = await createPendingPromptHarness();
 
     await agent.handleGatewayEvent(
@@ -54,6 +103,13 @@ describe("acp translator errorKind mapping", () => {
       }),
     );
 
-    await expect(promptPromise).resolves.toEqual({ stopReason: "end_turn" });
+    await expect(promptPromise).rejects.toSatisfy((err: any) => {
+      return (
+        err instanceof RequestError &&
+        err.code === -32603 &&
+        err.message === "something went wrong" &&
+        (err.data as any)?.errorKind === "unknown"
+      );
+    });
   });
 });

--- a/src/acp/translator.ts
+++ b/src/acp/translator.ts
@@ -33,6 +33,7 @@ import type {
   ToolCallLocation,
   ToolKind,
 } from "@agentclientprotocol/sdk";
+import { RequestError } from "@agentclientprotocol/sdk";
 import { BASE_THINKING_LEVELS } from "../auto-reply/thinking.shared.js";
 import type { GatewayClient } from "../gateway/client.js";
 import type { EventFrame } from "../gateway/protocol/index.js";
@@ -1422,8 +1423,16 @@ export class AcpGatewayAgent implements Agent {
     }
     if (state === "error") {
       const errorKind = payload.errorKind as string | undefined;
-      const stopReason: StopReason = errorKind === "refusal" ? "refusal" : "end_turn";
-      void this.finishPrompt(pending.sessionId, pending, stopReason);
+      const errorMessage = (payload.errorMessage as string | undefined) || "Unknown error";
+      if (errorKind === "refusal") {
+        void this.finishPrompt(pending.sessionId, pending, "refusal");
+      } else if (errorKind === "context_length") {
+        void this.finishPrompt(pending.sessionId, pending, "max_tokens");
+      } else {
+        const code = errorKind === "timeout" ? -32001 : errorKind === "rate_limit" ? -32002 : -32603;
+        const error = new RequestError(code, errorMessage, { errorKind });
+        this.rejectPendingPrompt(pending, error);
+      }
     }
   }
 
@@ -1699,7 +1708,9 @@ export class AcpGatewayAgent implements Agent {
       return false;
     }
     if (result?.status === "error") {
-      void this.finishPrompt(sessionId, currentPending, "end_turn");
+      const errorMessage = result.error || "Unknown error";
+      const error = new RequestError(-32603, errorMessage);
+      this.rejectPendingPrompt(currentPending, error);
       return false;
     }
     if (deadlineExpired) {


### PR DESCRIPTION
This PR updates the ACP translator to preserve structured error kinds rather than mapping them all to end_turn.

Details:
- If the error kind is a refusal, it maps to refusal.
- If the error kind is context_length, it maps to max_tokens.
- For other error kinds (timeout, rate_limit, etc.), it rejects the pending prompt with a RequestError containing the errorKind in the data.

Closes #44294