### PR TITLE
feat(google): filter English "I will"/"I am" pre-tool narration from antigravity-cli

### DIFF
--- a/extensions/google/cli-backend.test.ts
+++ b/extensions/google/cli-backend.test.ts
@@ -1,0 +1,45 @@
+// Google CLI backend tests cover bundled CLI runtime descriptors.
+import { describe, expect, it } from "vitest";
+import { buildGoogleAntigravityCliBackend, buildGoogleGeminiCliBackend } from "./cli-backend.js";
+
+describe("google cli backends", () => {
+  it("keeps the Gemini CLI backend configured for JSON sessions", () => {
+    const backend = buildGoogleGeminiCliBackend();
+
+    expect(backend.id).toBe("google-gemini-cli");
+    expect(backend.modelProvider).toBe("google");
+    expect(backend.config.command).toBe("gemini");
+    expect(backend.config.output).toBe("json");
+    expect(backend.config.sessionMode).toBe("existing");
+  });
+
+  it("builds the Antigravity CLI backend around agy text output", () => {
+    const backend = buildGoogleAntigravityCliBackend();
+
+    expect(backend.id).toBe("google-antigravity-cli");
+    expect(backend.modelProvider).toBe("google");
+    expect(backend.nativeToolMode).toBe("always-on");
+    expect(backend.liveTest).toMatchObject({
+      defaultModelRef: "google-antigravity-cli/gemini-3.5-flash",
+      defaultImageProbe: false,
+      defaultMcpProbe: false,
+      docker: { binaryName: "agy" },
+    });
+    expect(backend.config).toMatchObject({
+      command: "agy",
+      args: ["--print", "{prompt}"],
+      output: "text",
+      input: "arg",
+      modelArg: "--model",
+      modelAliases: {
+        flash: "gemini-3.5-flash",
+        pro: "gemini-3.1-pro-preview",
+      },
+      sessionMode: "none",
+      serialize: true,
+    });
+    expect(backend.config).not.toHaveProperty("parseToolCalls");
+    expect(backend.config).not.toHaveProperty("imageArg");
+    expect(backend.config).not.toHaveProperty("imagePathScope");
+  });
+});

--- a/extensions/google/cli-backend.test.ts
+++ b/extensions/google/cli-backend.test.ts
@@ -3,9 +3,15 @@ import { describe, expect, it } from "vitest";
 import { applyPluginTextReplacements } from "../../src/agents/plugin-text-transforms.js";
 import { buildGoogleAntigravityCliBackend, buildGoogleGeminiCliBackend } from "./cli-backend.js";
 
-/** Sentences agy emits as pre-tool narration that should be filtered out. */
+/**
+ * Pre-tool narration agy emits in English — must be filtered out wholesale.
+ * Both "I will <verb> …" and "I am <verb-ing> …" forms, with or without
+ * leading numbered prefix. The setup contract is that legitimate user-facing
+ * Teto answers are in German, so any English first-person narration line is
+ * by definition chatter.
+ */
 const ANTIGRAVITY_NARRATION_POSITIVES = [
-  // "I will <verb> the <obj>." form
+  // "I will …" — narrow tool verbs
   "I will list the contents of the project workspace.",
   "I will read the memory files at ~/.openclaw.",
   "I will search the web for No Game No Life and Disboard.",
@@ -13,23 +19,39 @@ const ANTIGRAVITY_NARRATION_POSITIVES = [
   "I will view the remaining lines of the log.",
   "I will edit the file extensions/google/cli-backend.ts.",
   "I will search the repository for mentions of agy.",
-  // "I am <verb-ing> <obj>." form (background/long-running narration)
-  "I am running the openclaw status command in the background to inspect the overall state of the gateway, channels, and recent sessions.",
-  "I am running a deep probe status check (openclaw status --deep) in the background to inspect all active services, database states, and connection parameters.",
-  "I am fetching the latest 20 lines of Gateway logs to check for any hidden errors or warnings in the background execution.",
-];
-
-/** Legitimate assistant sentences that start with "I will"/"I am" and MUST stay. */
-const ANTIGRAVITY_NARRATION_NEGATIVES = [
-  // I-will legitimates
+  // "I will …" — broader phrasings (previously assumed legitimate, now also dropped)
   "I will see how to start a goal or update the plan.",
   "I will maintain a conversational tone by using natural language.",
   "I will add the following files to the list.",
   "I will return tomorrow with results.",
-  // I-am legitimates — short copular phrases must stay (min-20-char bound)
-  "I am running late today.",
-  "I am happy with the result.",
-  "I am a developer working on this project full time.",
+  "I will review the output as soon as it completes.",
+  "I will report back immediately when the log retrieval completes.",
+  // "I am <verb-ing> …" — background/long-running narration
+  "I am running the openclaw status command in the background to inspect the overall state of the gateway, channels, and recent sessions.",
+  "I am running a deep probe status check (openclaw status --deep) in the background to inspect all active services, database states, and connection parameters.",
+  "I am fetching the latest 20 lines of Gateway logs to check for any hidden errors or warnings in the background execution.",
+  "I am starting by checking the contents of the default project scratch directory to see if we have any existing projects.",
+  // Numbered-prefix variant (agy sometimes lists narration items)
+  "1. I will list the files and subdirectories located in /tmp/step4-smoke.",
+  "2. I am reading the contents of the configuration file.",
+];
+
+/**
+ * Legitimate assistant output that MUST pass through. The contract is
+ * "English I will/am at line-start = pre-tool narration"; everything else
+ * (German answers, prose that happens to contain "I will" mid-sentence,
+ * code blocks, headers) stays intact.
+ */
+const ANTIGRAVITY_NARRATION_NEGATIVES = [
+  // German legitimate Teto responses (the canonical user-facing language)
+  "Ich habe den aktuellen Session- und Gateway-Status für OpenClaw geprüft.",
+  "Hey! Bei mir ist alles super, ich bin startklar.",
+  "Wie kann ich dir heute helfen?",
+  "Möchtest du ein neues Projekt in unserem Arbeitsverzeichnis starten?",
+  // Markdown structure (headers, code refs) — must never be matched
+  "### Option C: Die 5-Ebenen-Aufteilung unserer Antigravity-Integration",
+  // Lines that mention "I will" mid-sentence but do not start with it
+  "Note that I will not run any tool here.",
 ];
 
 describe("google cli backends", () => {

--- a/extensions/google/cli-backend.test.ts
+++ b/extensions/google/cli-backend.test.ts
@@ -5,6 +5,7 @@ import { buildGoogleAntigravityCliBackend, buildGoogleGeminiCliBackend } from ".
 
 /** Sentences agy emits as pre-tool narration that should be filtered out. */
 const ANTIGRAVITY_NARRATION_POSITIVES = [
+  // "I will <verb> the <obj>." form
   "I will list the contents of the project workspace.",
   "I will read the memory files at ~/.openclaw.",
   "I will search the web for No Game No Life and Disboard.",
@@ -12,14 +13,23 @@ const ANTIGRAVITY_NARRATION_POSITIVES = [
   "I will view the remaining lines of the log.",
   "I will edit the file extensions/google/cli-backend.ts.",
   "I will search the repository for mentions of agy.",
+  // "I am <verb-ing> <obj>." form (background/long-running narration)
+  "I am running the openclaw status command in the background to inspect the overall state of the gateway, channels, and recent sessions.",
+  "I am running a deep probe status check (openclaw status --deep) in the background to inspect all active services, database states, and connection parameters.",
+  "I am fetching the latest 20 lines of Gateway logs to check for any hidden errors or warnings in the background execution.",
 ];
 
-/** Legitimate assistant sentences that start with "I will" and MUST stay. */
+/** Legitimate assistant sentences that start with "I will"/"I am" and MUST stay. */
 const ANTIGRAVITY_NARRATION_NEGATIVES = [
+  // I-will legitimates
   "I will see how to start a goal or update the plan.",
   "I will maintain a conversational tone by using natural language.",
   "I will add the following files to the list.",
   "I will return tomorrow with results.",
+  // I-am legitimates — short copular phrases must stay (min-20-char bound)
+  "I am running late today.",
+  "I am happy with the result.",
+  "I am a developer working on this project full time.",
 ];
 
 describe("google cli backends", () => {

--- a/extensions/google/cli-backend.test.ts
+++ b/extensions/google/cli-backend.test.ts
@@ -1,6 +1,26 @@
 // Google CLI backend tests cover bundled CLI runtime descriptors.
 import { describe, expect, it } from "vitest";
+import { applyPluginTextReplacements } from "../../src/agents/plugin-text-transforms.js";
 import { buildGoogleAntigravityCliBackend, buildGoogleGeminiCliBackend } from "./cli-backend.js";
+
+/** Sentences agy emits as pre-tool narration that should be filtered out. */
+const ANTIGRAVITY_NARRATION_POSITIVES = [
+  "I will list the contents of the project workspace.",
+  "I will read the memory files at ~/.openclaw.",
+  "I will search the web for No Game No Life and Disboard.",
+  "I will check the updated config file.",
+  "I will view the remaining lines of the log.",
+  "I will edit the file extensions/google/cli-backend.ts.",
+  "I will search the repository for mentions of agy.",
+];
+
+/** Legitimate assistant sentences that start with "I will" and MUST stay. */
+const ANTIGRAVITY_NARRATION_NEGATIVES = [
+  "I will see how to start a goal or update the plan.",
+  "I will maintain a conversational tone by using natural language.",
+  "I will add the following files to the list.",
+  "I will return tomorrow with results.",
+];
 
 describe("google cli backends", () => {
   it("keeps the Gemini CLI backend configured for JSON sessions", () => {
@@ -41,5 +61,20 @@ describe("google cli backends", () => {
     expect(backend.config).not.toHaveProperty("parseToolCalls");
     expect(backend.config).not.toHaveProperty("imageArg");
     expect(backend.config).not.toHaveProperty("imagePathScope");
+  });
+
+  it("filters agy pre-tool narration without trapping legitimate I-will sentences", () => {
+    const backend = buildGoogleAntigravityCliBackend();
+    const output = backend.textTransforms?.output;
+    expect(output).toBeDefined();
+
+    for (const positive of ANTIGRAVITY_NARRATION_POSITIVES) {
+      const result = applyPluginTextReplacements(positive, output);
+      expect(result.trim()).toBe("");
+    }
+    for (const negative of ANTIGRAVITY_NARRATION_NEGATIVES) {
+      const result = applyPluginTextReplacements(negative, output);
+      expect(result).toBe(negative);
+    }
   });
 });

--- a/extensions/google/cli-backend.ts
+++ b/extensions/google/cli-backend.ts
@@ -17,6 +17,18 @@ const ANTIGRAVITY_MODEL_ALIASES: Record<string, string> = {
 };
 const ANTIGRAVITY_CLI_DEFAULT_MODEL_REF = "google-antigravity-cli/gemini-3.5-flash";
 
+/**
+ * agy emits a pre-tool narration line ("I will list/read/view/check/search/edit/…
+ * the foo at /bar.") before each native tool call. These sentences leak into the
+ * assistant output and add no value for OpenClaw users that already see the tool
+ * card. The pattern is intentionally narrow: it only matches an "I will" line
+ * that starts with a known tool verb followed by a short lowercase object phrase
+ * and a sentence-ending period, so legitimate user-facing "I will …" sentences
+ * stay untouched.
+ */
+const ANTIGRAVITY_PRE_TOOL_NARRATION =
+  /^I will (list|read|view|check|search|edit|open|run|create|delete|write) [a-z][^\n]{2,120}\.\s*$/gim;
+
 export function buildGoogleGeminiCliBackend(): CliBackendPlugin {
   return {
     id: "google-gemini-cli",
@@ -77,6 +89,9 @@ export function buildGoogleAntigravityCliBackend(): CliBackendPlugin {
       },
     },
     nativeToolMode: "always-on",
+    textTransforms: {
+      output: [{ from: ANTIGRAVITY_PRE_TOOL_NARRATION, to: "" }],
+    },
     config: {
       command: "agy",
       args: ["--print", "{prompt}"],

--- a/extensions/google/cli-backend.ts
+++ b/extensions/google/cli-backend.ts
@@ -11,6 +11,11 @@ const GEMINI_MODEL_ALIASES: Record<string, string> = {
   "flash-lite": "gemini-3.1-flash-lite",
 };
 const GEMINI_CLI_DEFAULT_MODEL_REF = "google-gemini-cli/gemini-3-flash-preview";
+const ANTIGRAVITY_MODEL_ALIASES: Record<string, string> = {
+  pro: "gemini-3.1-pro-preview",
+  flash: "gemini-3.5-flash",
+};
+const ANTIGRAVITY_CLI_DEFAULT_MODEL_REF = "google-antigravity-cli/gemini-3.5-flash";
 
 export function buildGoogleGeminiCliBackend(): CliBackendPlugin {
   return {
@@ -48,6 +53,38 @@ export function buildGoogleGeminiCliBackend(): CliBackendPlugin {
       modelAliases: GEMINI_MODEL_ALIASES,
       sessionMode: "existing",
       sessionIdFields: ["session_id", "sessionId"],
+      reliability: {
+        watchdog: {
+          fresh: { ...CLI_FRESH_WATCHDOG_DEFAULTS },
+          resume: { ...CLI_RESUME_WATCHDOG_DEFAULTS },
+        },
+      },
+      serialize: true,
+    },
+  };
+}
+
+export function buildGoogleAntigravityCliBackend(): CliBackendPlugin {
+  return {
+    id: "google-antigravity-cli",
+    modelProvider: "google",
+    liveTest: {
+      defaultModelRef: ANTIGRAVITY_CLI_DEFAULT_MODEL_REF,
+      defaultImageProbe: false,
+      defaultMcpProbe: false,
+      docker: {
+        binaryName: "agy",
+      },
+    },
+    nativeToolMode: "always-on",
+    config: {
+      command: "agy",
+      args: ["--print", "{prompt}"],
+      output: "text",
+      input: "arg",
+      modelArg: "--model",
+      modelAliases: ANTIGRAVITY_MODEL_ALIASES,
+      sessionMode: "none",
       reliability: {
         watchdog: {
           fresh: { ...CLI_FRESH_WATCHDOG_DEFAULTS },

--- a/extensions/google/cli-backend.ts
+++ b/extensions/google/cli-backend.ts
@@ -29,6 +29,17 @@ const ANTIGRAVITY_CLI_DEFAULT_MODEL_REF = "google-antigravity-cli/gemini-3.5-fla
 const ANTIGRAVITY_PRE_TOOL_NARRATION =
   /^I will (list|read|view|check|search|edit|open|run|create|delete|write) [a-z][^\n]{2,120}\.\s*$/gim;
 
+/**
+ * agy also emits a long-running / background variant ("I am running the … in the
+ * background to inspect …", "I am fetching the latest …") before slow tool calls.
+ * Same intent as the "I will" narration: status-chatter that adds no value once
+ * the tool card is visible. Stricter min-length (20 chars after the verb) plus
+ * an -ing verb whitelist guards against false positives like "I am running late
+ * today." or "I am a developer …".
+ */
+const ANTIGRAVITY_PRE_TOOL_NARRATION_AM =
+  /^I am (listing|reading|viewing|checking|searching|editing|opening|running|creating|deleting|writing|fetching) [a-z][^\n]{20,200}\.\s*$/gim;
+
 export function buildGoogleGeminiCliBackend(): CliBackendPlugin {
   return {
     id: "google-gemini-cli",
@@ -90,7 +101,10 @@ export function buildGoogleAntigravityCliBackend(): CliBackendPlugin {
     },
     nativeToolMode: "always-on",
     textTransforms: {
-      output: [{ from: ANTIGRAVITY_PRE_TOOL_NARRATION, to: "" }],
+      output: [
+        { from: ANTIGRAVITY_PRE_TOOL_NARRATION, to: "" },
+        { from: ANTIGRAVITY_PRE_TOOL_NARRATION_AM, to: "" },
+      ],
     },
     config: {
       command: "agy",

--- a/extensions/google/cli-backend.ts
+++ b/extensions/google/cli-backend.ts
@@ -18,27 +18,18 @@ const ANTIGRAVITY_MODEL_ALIASES: Record<string, string> = {
 const ANTIGRAVITY_CLI_DEFAULT_MODEL_REF = "google-antigravity-cli/gemini-3.5-flash";
 
 /**
- * agy emits a pre-tool narration line ("I will list/read/view/check/search/edit/…
- * the foo at /bar.") before each native tool call. These sentences leak into the
- * assistant output and add no value for OpenClaw users that already see the tool
- * card. The pattern is intentionally narrow: it only matches an "I will" line
- * that starts with a known tool verb followed by a short lowercase object phrase
- * and a sentence-ending period, so legitimate user-facing "I will …" sentences
- * stay untouched.
+ * agy emits English first-person pre-tool narration in two forms:
+ *   - "I will <verb> …" (imminent action, e.g. "I will list the contents …")
+ *   - "I am <verb-ing> …" (background/long-running, e.g. "I am running the openclaw
+ *      status command in the background …")
+ *
+ * Both forms leak into the assistant output and add no value once OpenClaw shows
+ * the tool card. Legitimate Teto-style user-facing answers in this setup are in
+ * German, so any line that starts with literal English "I will" / "I am" is
+ * pre-tool chatter and gets dropped wholesale — no verb whitelist, no length
+ * bound. Optional leading numbered prefix ("1. I will …") is also matched.
  */
-const ANTIGRAVITY_PRE_TOOL_NARRATION =
-  /^I will (list|read|view|check|search|edit|open|run|create|delete|write) [a-z][^\n]{2,120}\.\s*$/gim;
-
-/**
- * agy also emits a long-running / background variant ("I am running the … in the
- * background to inspect …", "I am fetching the latest …") before slow tool calls.
- * Same intent as the "I will" narration: status-chatter that adds no value once
- * the tool card is visible. Stricter min-length (20 chars after the verb) plus
- * an -ing verb whitelist guards against false positives like "I am running late
- * today." or "I am a developer …".
- */
-const ANTIGRAVITY_PRE_TOOL_NARRATION_AM =
-  /^I am (listing|reading|viewing|checking|searching|editing|opening|running|creating|deleting|writing|fetching) [a-z][^\n]{20,200}\.\s*$/gim;
+const ANTIGRAVITY_PRE_TOOL_NARRATION = /^[ \t]*(?:\d+\.\s+)?I (?:will|am)\b[^\n]*$/gim;
 
 export function buildGoogleGeminiCliBackend(): CliBackendPlugin {
   return {
@@ -101,10 +92,7 @@ export function buildGoogleAntigravityCliBackend(): CliBackendPlugin {
     },
     nativeToolMode: "always-on",
     textTransforms: {
-      output: [
-        { from: ANTIGRAVITY_PRE_TOOL_NARRATION, to: "" },
-        { from: ANTIGRAVITY_PRE_TOOL_NARRATION_AM, to: "" },
-      ],
+      output: [{ from: ANTIGRAVITY_PRE_TOOL_NARRATION, to: "" }],
     },
     config: {
       command: "agy",

--- a/extensions/google/index.ts
+++ b/extensions/google/index.ts
@@ -12,7 +12,7 @@ import type {
 import { normalizeResolvedSecretInputString } from "openclaw/plugin-sdk/secret-input";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { VideoGenerationProvider } from "openclaw/plugin-sdk/video-generation";
-import { buildGoogleGeminiCliBackend } from "./cli-backend.js";
+import { buildGoogleAntigravityCliBackend, buildGoogleGeminiCliBackend } from "./cli-backend.js";
 import { registerGoogleGeminiCliProvider } from "./gemini-cli-provider.js";
 import {
   createGoogleMusicGenerationProviderMetadata,
@@ -341,6 +341,7 @@ export default definePluginEntry({
   description: "Bundled Google plugin",
   register(api) {
     api.registerCliBackend(buildGoogleGeminiCliBackend());
+    api.registerCliBackend(buildGoogleAntigravityCliBackend());
     registerGoogleGeminiCliProvider(api);
     registerGoogleProvider(api);
     api.registerMemoryEmbeddingProvider(geminiMemoryEmbeddingProviderAdapter);

--- a/extensions/google/openclaw.plugin.json
+++ b/extensions/google/openclaw.plugin.json
@@ -658,17 +658,6 @@
       "groupLabel": "Google",
       "groupHint": "Gemini API key + OAuth",
       "onboardingFeatured": true
-    },
-    {
-      "provider": "google-antigravity-cli",
-      "method": "oauth",
-      "choiceId": "google-antigravity-cli",
-      "choiceLabel": "Antigravity CLI OAuth",
-      "choiceHint": "Google OAuth delegated to the agy CLI",
-      "groupId": "google",
-      "groupLabel": "Google",
-      "groupHint": "Gemini API key + OAuth",
-      "onboardingFeatured": true
     }
   ],
   "uiHints": {

--- a/extensions/google/openclaw.plugin.json
+++ b/extensions/google/openclaw.plugin.json
@@ -4,9 +4,9 @@
     "onStartup": false
   },
   "enabledByDefault": true,
-  "providers": ["google", "google-gemini-cli", "google-vertex"],
+  "providers": ["google", "google-antigravity-cli", "google-gemini-cli", "google-vertex"],
   "providerCatalogEntry": "./provider-discovery.ts",
-  "autoEnableWhenConfiguredProviders": ["google-gemini-cli"],
+  "autoEnableWhenConfiguredProviders": ["google-antigravity-cli", "google-gemini-cli"],
   "modelIdNormalization": {
     "providers": {
       "google": {
@@ -29,6 +29,16 @@
           "gemini-3.1-flash-lite-preview": "gemini-3.1-flash-lite",
           "gemini-3.1-flash": "gemini-3-flash-preview",
           "gemini-3.1-flash-preview": "gemini-3-flash-preview"
+        }
+      },
+      "google-antigravity-cli": {
+        "aliases": {
+          "gemini-3-pro": "gemini-3.1-pro-preview",
+          "gemini-3-pro-preview": "gemini-3.1-pro-preview",
+          "gemini-3.1-pro": "gemini-3.1-pro-preview",
+          "gemini-3.5-Flash": "gemini-3.5-flash",
+          "gemini-3.5-flash-preview": "gemini-3.5-flash",
+          "gemini-3-5-flash": "gemini-3.5-flash"
         }
       },
       "google-vertex": {
@@ -545,6 +555,14 @@
   },
   "modelPricing": {
     "providers": {
+      "google-antigravity-cli": {
+        "openRouter": {
+          "provider": "google"
+        },
+        "liteLLM": {
+          "provider": "google"
+        }
+      },
       "google-gemini-cli": {
         "openRouter": {
           "provider": "google"
@@ -574,6 +592,9 @@
   "providerRequest": {
     "providers": {
       "google": {
+        "family": "google"
+      },
+      "google-antigravity-cli": {
         "family": "google"
       },
       "google-gemini-cli": {
@@ -611,7 +632,7 @@
       }
     ]
   },
-  "cliBackends": ["google-gemini-cli"],
+  "cliBackends": ["google-antigravity-cli", "google-gemini-cli"],
   "providerAuthChoices": [
     {
       "provider": "google",
@@ -633,6 +654,17 @@
       "choiceId": "google-gemini-cli",
       "choiceLabel": "Gemini CLI OAuth",
       "choiceHint": "Google OAuth with project-aware token payload",
+      "groupId": "google",
+      "groupLabel": "Google",
+      "groupHint": "Gemini API key + OAuth",
+      "onboardingFeatured": true
+    },
+    {
+      "provider": "google-antigravity-cli",
+      "method": "oauth",
+      "choiceId": "google-antigravity-cli",
+      "choiceLabel": "Antigravity CLI OAuth",
+      "choiceHint": "Google OAuth delegated to the agy CLI",
       "groupId": "google",
       "groupLabel": "Google",
       "groupHint": "Gemini API key + OAuth",

--- a/extensions/google/setup-api.test.ts
+++ b/extensions/google/setup-api.test.ts
@@ -19,6 +19,6 @@ describe("google setup entry", () => {
     } as never);
 
     expect(providerIds).toEqual(["google-vertex"]);
-    expect(cliBackendIds).toEqual(["google-gemini-cli"]);
+    expect(cliBackendIds).toEqual(["google-gemini-cli", "google-antigravity-cli"]);
   });
 });

--- a/extensions/google/setup-api.ts
+++ b/extensions/google/setup-api.ts
@@ -1,6 +1,6 @@
 // Google API module exposes the plugin public contract.
 import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
-import { buildGoogleGeminiCliBackend } from "./cli-backend.js";
+import { buildGoogleAntigravityCliBackend, buildGoogleGeminiCliBackend } from "./cli-backend.js";
 import { createGoogleVertexProvider } from "./provider-contract-api.js";
 
 export default definePluginEntry({
@@ -10,5 +10,6 @@ export default definePluginEntry({
   register(api) {
     api.registerProvider(createGoogleVertexProvider());
     api.registerCliBackend(buildGoogleGeminiCliBackend());
+    api.registerCliBackend(buildGoogleAntigravityCliBackend());
   },
 });

--- a/src/config/model-input.ts
+++ b/src/config/model-input.ts
@@ -72,7 +72,12 @@ export function toAgentModelListLike(model?: AgentModelConfig): AgentModelListLi
   return model;
 }
 
-const GOOGLE_PROVIDER_IDS = new Set(["google", "google-gemini-cli", "google-vertex"]);
+const GOOGLE_PROVIDER_IDS = new Set([
+  "google",
+  "google-antigravity-cli",
+  "google-gemini-cli",
+  "google-vertex",
+]);
 
 /** Canonicalizes provider/model refs before they are persisted to config. */
 export function normalizeAgentModelRefForConfig(model: string): string {

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -428,6 +428,7 @@ const BUILT_IN_MODEL_PROVIDER_OVERLAY_IDS = new Set([
   "github-copilot",
   "google",
   "google-antigravity",
+  "google-antigravity-cli",
   "google-gemini-cli",
   "google-vertex",
   "groq",

--- a/src/plugin-sdk/test-helpers/plugin-registration-contract-cases.ts
+++ b/src/plugin-sdk/test-helpers/plugin-registration-contract-cases.ts
@@ -71,7 +71,7 @@ export const pluginRegistrationContractCases = {
   },
   google: {
     pluginId: "google",
-    providerIds: ["google", "google-gemini-cli", "google-vertex"],
+    providerIds: ["google", "google-antigravity-cli", "google-gemini-cli", "google-vertex"],
     webSearchProviderIds: ["gemini"],
     realtimeVoiceProviderIds: ["google"],
     speechProviderIds: ["google"],

--- a/src/plugins/config-state.ts
+++ b/src/plugins/config-state.ts
@@ -35,6 +35,7 @@ export type PluginActivationConfigSource = {
 export type NormalizedPluginsConfig = SharedNormalizedPluginsConfig;
 
 const BUILT_IN_PLUGIN_ALIAS_FALLBACKS: ReadonlyArray<readonly [alias: string, pluginId: string]> = [
+  ["google-antigravity-cli", "google"],
   ["google-gemini-cli", "google"],
   ["minimax-portal", "minimax"],
   ["minimax-portal-auth", "minimax"],

--- a/src/status/agent-runtime-label.ts
+++ b/src/status/agent-runtime-label.ts
@@ -15,6 +15,7 @@ const AGENT_RUNTIME_LABELS: Readonly<Record<string, string>> = {
   codex: "OpenAI Codex",
   "codex-cli": "OpenAI Codex",
   "claude-cli": "Claude CLI",
+  "google-antigravity-cli": "Antigravity CLI",
   "google-gemini-cli": "Gemini CLI",
 };
 


### PR DESCRIPTION
## Summary

agy 1.0.6 emits English first-person pre-tool narration in two forms:

- `I will <verb> …` (imminent action — `"I will list the contents of the project workspace."`)
- `I am <verb-ing> …` (background/long-running — `"I am running the openclaw status command in the background to inspect …"`)

Both leak into the user-visible assistant output and add no value once OpenClaw shows the tool card (or, given agy's current lack of tool-call events, once the next real answer arrives). This PR adds a single `textTransforms.output` regex on the `google-antigravity-cli` backend that drops every such English narration line wholesale.

The filter is intentionally aggressive (no verb whitelist, no length bound). The setup contract is that legitimate user-facing answers in this Teto-style agent setup are always in German, so any English line that starts with first-person `I will` / `I am` at line start is by definition pre-tool chatter.

**Stacked on top of #90975** (`feature/antigravity-cli-fresh`). The first 10 commits in this PR belong to #90975 (the Antigravity-CLI backend itself); the net change introduced by **this** PR is the last 4 commits (`cc54e38d86`, `eec589b20f`, `f23821a7ad`, `d5bca68e34`). Once #90975 merges, this PR will be rebased and its diff reduces to just the filter.

The filter targets the `google-antigravity-cli` backend that #90975 introduces.

## Real behavior proof

### Behavior or issue addressed

agy's pre-tool narration ("I will list …", "I am running … in the background") clutters the assistant transcript and forces the user to scroll past several sentences of "I will / I am …" before reaching the actual answer.

### Real environment tested

Local TDD inside a worktree of this branch:
- `cd .worktrees/p2`
- `node scripts/test-extension.mjs google --reporter=verbose`

Plus offline replay of a verbatim live multi-turn Antigravity-CLI sample (Gemini 3.5 Flash via agy 1.0.6 OAuth) — provided in the new test fixtures.

### Exact steps or command run after this patch

```bash
git checkout feature/antigravity-cli-filter-narration
node scripts/test-extension.mjs google --reporter=verbose
```

### Evidence after fix

```
Test Files  25 passed (25)
     Tests  317 passed (317)
  Duration  ~40s
```

The loop test `google cli backends > filters agy pre-tool narration without trapping legitimate I-will sentences` exercises **19 positive fixtures** (must drop to empty) and **6 negative fixtures** (must pass through unchanged) drawn from real agy session logs in `~/.openclaw/agents/*/sessions/*.jsonl` plus a verbatim 4-turn user-facing transcript.

The regex:

```js
/^[ \t]*(?:\d+\.\s+)?I (?:will|am)\b[^\n]*$/gim
```

### Observed result after fix

Positives (all dropped):

| Fixture sample | Before | After |
|---|---|---|
| `I will list the contents of the project workspace.` | leaks | dropped |
| `I will read the memory files at ~/.openclaw.` | leaks | dropped |
| `I will see how to start a goal or update the plan.` | leaks | dropped |
| `I will maintain a conversational tone by using natural language.` | leaks | dropped |
| `I am running the openclaw status command in the background to inspect …` | leaks | dropped |
| `I am fetching the latest 20 lines of Gateway logs …` | leaks | dropped |
| `I am starting by checking the contents of the default project scratch directory …` | leaks | dropped |
| `1. I will list the files and subdirectories located in /tmp/step4-smoke.` | leaks | dropped |
| `2. I am reading the contents of the configuration file.` | leaks | dropped |

Negatives (all preserved):

| Fixture | Before | After |
|---|---|---|
| `Ich habe den aktuellen Session- und Gateway-Status für OpenClaw geprüft.` | kept | kept ✓ |
| `Hey! Bei mir ist alles super, ich bin startklar.` | kept | kept ✓ |
| `Wie kann ich dir heute helfen?` | kept | kept ✓ |
| `### Option C: Die 5-Ebenen-Aufteilung unserer Antigravity-Integration` | kept | kept ✓ |
| `Note that I will not run any tool here.` | kept | kept ✓ |

### What was not tested

- Live multi-turn `openclaw agent --agent test --model google-antigravity-cli/gemini-3.5-flash` session — verified only via the unit-test fixtures plus a verbatim offline replay of a real user-facing transcript.
- Non-English narration. agy 1.0.6 only emits English narration; if a future agy localizes the narration this filter would need the verb whitelist re-introduced.
- Mid-sentence "I will" / "I am" after a period inside the same line is not matched. Empirically, agy emits each narration item on its own line, so this has not surfaced as an issue.

## Why pure-block instead of a narrow verb whitelist

The earlier iteration of this filter (commits `cc54e38d86` + `eec589b20f`) used a narrow tool-verb whitelist (`list|read|view|check|search|edit|open|run|create|delete|write`) to avoid false-positives on legitimate "I will …" sentences. Live testing then revealed two gaps:

1. agy emits narration items with leading numbered prefix (`"1. I will list …"`) that the original line-anchor missed.
2. agy uses a much broader set of verbs in practice (`identify`, `isolate`, `inspect`, `running`, `fetching`, `starting`, …) — keeping the whitelist current is a moving target.

Once we noticed the underlying invariant — agy narration is always English, Teto user-facing output is always German — the language boundary itself became the filter boundary, and the whitelist became unnecessary. Commit `d5bca68e34` formalizes this.

## Related upstream tickets

These workarounds exist because agy 1.0.6 does not yet expose native tool-call events on stdout. Once upstream addresses them, this filter can be removed.

- google-antigravity/antigravity-cli#7 — Conversation-ID on stdout missing
- google-antigravity/antigravity-cli#31 — `parseToolCalls`-consumable output missing
- google-antigravity/antigravity-cli#76 — `--print` / `-p` stdout streaming/buffering

## Test plan

- [x] Loop test green: 19 positives dropped, 6 negatives preserved
- [x] Full extension test suite green: 317/317 (no regression)
- [ ] Live multi-turn smoke against `--agent test` after merge of #90975
