### PR TITLE
feat(google): enable raw-transcript reseed for antigravity-cli (multi-turn context fix)

### DIFF
--- a/extensions/google/cli-backend.test.ts
+++ b/extensions/google/cli-backend.test.ts
@@ -1,0 +1,45 @@
+// Google CLI backend tests cover bundled CLI runtime descriptors.
+import { describe, expect, it } from "vitest";
+import { buildGoogleAntigravityCliBackend, buildGoogleGeminiCliBackend } from "./cli-backend.js";
+
+describe("google cli backends", () => {
+  it("keeps the Gemini CLI backend configured for JSON sessions", () => {
+    const backend = buildGoogleGeminiCliBackend();
+
+    expect(backend.id).toBe("google-gemini-cli");
+    expect(backend.modelProvider).toBe("google");
+    expect(backend.config.command).toBe("gemini");
+    expect(backend.config.output).toBe("json");
+    expect(backend.config.sessionMode).toBe("existing");
+  });
+
+  it("builds the Antigravity CLI backend around agy text output", () => {
+    const backend = buildGoogleAntigravityCliBackend();
+
+    expect(backend.id).toBe("google-antigravity-cli");
+    expect(backend.modelProvider).toBe("google");
+    expect(backend.nativeToolMode).toBe("always-on");
+    expect(backend.liveTest).toMatchObject({
+      defaultModelRef: "google-antigravity-cli/gemini-3.5-flash",
+      defaultImageProbe: false,
+      defaultMcpProbe: false,
+      docker: { binaryName: "agy" },
+    });
+    expect(backend.config).toMatchObject({
+      command: "agy",
+      args: ["--print", "{prompt}"],
+      output: "text",
+      input: "arg",
+      modelArg: "--model",
+      modelAliases: {
+        flash: "gemini-3.5-flash",
+        pro: "gemini-3.1-pro-preview",
+      },
+      sessionMode: "none",
+      serialize: true,
+    });
+    expect(backend.config).not.toHaveProperty("parseToolCalls");
+    expect(backend.config).not.toHaveProperty("imageArg");
+    expect(backend.config).not.toHaveProperty("imagePathScope");
+  });
+});

--- a/extensions/google/cli-backend.test.ts
+++ b/extensions/google/cli-backend.test.ts
@@ -42,4 +42,10 @@ describe("google cli backends", () => {
     expect(backend.config).not.toHaveProperty("imageArg");
     expect(backend.config).not.toHaveProperty("imagePathScope");
   });
+
+  it("enables raw-transcript reseed for non-resumable text-mode so OpenClaw can pass conversation history", () => {
+    const backend = buildGoogleAntigravityCliBackend();
+
+    expect(backend.config.reseedFromRawTranscriptWhenUncompacted).toBe(true);
+  });
 });

--- a/extensions/google/cli-backend.ts
+++ b/extensions/google/cli-backend.ts
@@ -91,6 +91,7 @@ export function buildGoogleAntigravityCliBackend(): CliBackendPlugin {
           resume: { ...CLI_RESUME_WATCHDOG_DEFAULTS },
         },
       },
+      reseedFromRawTranscriptWhenUncompacted: true,
       serialize: true,
     },
   };

--- a/extensions/google/cli-backend.ts
+++ b/extensions/google/cli-backend.ts
@@ -11,6 +11,11 @@ const GEMINI_MODEL_ALIASES: Record<string, string> = {
   "flash-lite": "gemini-3.1-flash-lite",
 };
 const GEMINI_CLI_DEFAULT_MODEL_REF = "google-gemini-cli/gemini-3-flash-preview";
+const ANTIGRAVITY_MODEL_ALIASES: Record<string, string> = {
+  pro: "gemini-3.1-pro-preview",
+  flash: "gemini-3.5-flash",
+};
+const ANTIGRAVITY_CLI_DEFAULT_MODEL_REF = "google-antigravity-cli/gemini-3.5-flash";
 
 export function buildGoogleGeminiCliBackend(): CliBackendPlugin {
   return {
@@ -48,6 +53,38 @@ export function buildGoogleGeminiCliBackend(): CliBackendPlugin {
       modelAliases: GEMINI_MODEL_ALIASES,
       sessionMode: "existing",
       sessionIdFields: ["session_id", "sessionId"],
+      reliability: {
+        watchdog: {
+          fresh: { ...CLI_FRESH_WATCHDOG_DEFAULTS },
+          resume: { ...CLI_RESUME_WATCHDOG_DEFAULTS },
+        },
+      },
+      serialize: true,
+    },
+  };
+}
+
+export function buildGoogleAntigravityCliBackend(): CliBackendPlugin {
+  return {
+    id: "google-antigravity-cli",
+    modelProvider: "google",
+    liveTest: {
+      defaultModelRef: ANTIGRAVITY_CLI_DEFAULT_MODEL_REF,
+      defaultImageProbe: false,
+      defaultMcpProbe: false,
+      docker: {
+        binaryName: "agy",
+      },
+    },
+    nativeToolMode: "always-on",
+    config: {
+      command: "agy",
+      args: ["--print", "{prompt}"],
+      output: "text",
+      input: "arg",
+      modelArg: "--model",
+      modelAliases: ANTIGRAVITY_MODEL_ALIASES,
+      sessionMode: "none",
       reliability: {
         watchdog: {
           fresh: { ...CLI_FRESH_WATCHDOG_DEFAULTS },

--- a/extensions/google/index.ts
+++ b/extensions/google/index.ts
@@ -12,7 +12,7 @@ import type {
 import { normalizeResolvedSecretInputString } from "openclaw/plugin-sdk/secret-input";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { VideoGenerationProvider } from "openclaw/plugin-sdk/video-generation";
-import { buildGoogleGeminiCliBackend } from "./cli-backend.js";
+import { buildGoogleAntigravityCliBackend, buildGoogleGeminiCliBackend } from "./cli-backend.js";
 import { registerGoogleGeminiCliProvider } from "./gemini-cli-provider.js";
 import {
   createGoogleMusicGenerationProviderMetadata,
@@ -341,6 +341,7 @@ export default definePluginEntry({
   description: "Bundled Google plugin",
   register(api) {
     api.registerCliBackend(buildGoogleGeminiCliBackend());
+    api.registerCliBackend(buildGoogleAntigravityCliBackend());
     registerGoogleGeminiCliProvider(api);
     registerGoogleProvider(api);
     api.registerMemoryEmbeddingProvider(geminiMemoryEmbeddingProviderAdapter);

--- a/extensions/google/openclaw.plugin.json
+++ b/extensions/google/openclaw.plugin.json
@@ -658,17 +658,6 @@
       "groupLabel": "Google",
       "groupHint": "Gemini API key + OAuth",
       "onboardingFeatured": true
-    },
-    {
-      "provider": "google-antigravity-cli",
-      "method": "oauth",
-      "choiceId": "google-antigravity-cli",
-      "choiceLabel": "Antigravity CLI OAuth",
-      "choiceHint": "Google OAuth delegated to the agy CLI",
-      "groupId": "google",
-      "groupLabel": "Google",
-      "groupHint": "Gemini API key + OAuth",
-      "onboardingFeatured": true
     }
   ],
   "uiHints": {

--- a/extensions/google/openclaw.plugin.json
+++ b/extensions/google/openclaw.plugin.json
@@ -4,9 +4,9 @@
     "onStartup": false
   },
   "enabledByDefault": true,
-  "providers": ["google", "google-gemini-cli", "google-vertex"],
+  "providers": ["google", "google-antigravity-cli", "google-gemini-cli", "google-vertex"],
   "providerCatalogEntry": "./provider-discovery.ts",
-  "autoEnableWhenConfiguredProviders": ["google-gemini-cli"],
+  "autoEnableWhenConfiguredProviders": ["google-antigravity-cli", "google-gemini-cli"],
   "modelIdNormalization": {
     "providers": {
       "google": {
@@ -29,6 +29,16 @@
           "gemini-3.1-flash-lite-preview": "gemini-3.1-flash-lite",
           "gemini-3.1-flash": "gemini-3-flash-preview",
           "gemini-3.1-flash-preview": "gemini-3-flash-preview"
+        }
+      },
+      "google-antigravity-cli": {
+        "aliases": {
+          "gemini-3-pro": "gemini-3.1-pro-preview",
+          "gemini-3-pro-preview": "gemini-3.1-pro-preview",
+          "gemini-3.1-pro": "gemini-3.1-pro-preview",
+          "gemini-3.5-Flash": "gemini-3.5-flash",
+          "gemini-3.5-flash-preview": "gemini-3.5-flash",
+          "gemini-3-5-flash": "gemini-3.5-flash"
         }
       },
       "google-vertex": {
@@ -545,6 +555,14 @@
   },
   "modelPricing": {
     "providers": {
+      "google-antigravity-cli": {
+        "openRouter": {
+          "provider": "google"
+        },
+        "liteLLM": {
+          "provider": "google"
+        }
+      },
       "google-gemini-cli": {
         "openRouter": {
           "provider": "google"
@@ -574,6 +592,9 @@
   "providerRequest": {
     "providers": {
       "google": {
+        "family": "google"
+      },
+      "google-antigravity-cli": {
         "family": "google"
       },
       "google-gemini-cli": {
@@ -611,7 +632,7 @@
       }
     ]
   },
-  "cliBackends": ["google-gemini-cli"],
+  "cliBackends": ["google-antigravity-cli", "google-gemini-cli"],
   "providerAuthChoices": [
     {
       "provider": "google",
@@ -633,6 +654,17 @@
       "choiceId": "google-gemini-cli",
       "choiceLabel": "Gemini CLI OAuth",
       "choiceHint": "Google OAuth with project-aware token payload",
+      "groupId": "google",
+      "groupLabel": "Google",
+      "groupHint": "Gemini API key + OAuth",
+      "onboardingFeatured": true
+    },
+    {
+      "provider": "google-antigravity-cli",
+      "method": "oauth",
+      "choiceId": "google-antigravity-cli",
+      "choiceLabel": "Antigravity CLI OAuth",
+      "choiceHint": "Google OAuth delegated to the agy CLI",
       "groupId": "google",
       "groupLabel": "Google",
       "groupHint": "Gemini API key + OAuth",

--- a/extensions/google/setup-api.test.ts
+++ b/extensions/google/setup-api.test.ts
@@ -19,6 +19,6 @@ describe("google setup entry", () => {
     } as never);
 
     expect(providerIds).toEqual(["google-vertex"]);
-    expect(cliBackendIds).toEqual(["google-gemini-cli"]);
+    expect(cliBackendIds).toEqual(["google-gemini-cli", "google-antigravity-cli"]);
   });
 });

--- a/extensions/google/setup-api.ts
+++ b/extensions/google/setup-api.ts
@@ -1,6 +1,6 @@
 // Google API module exposes the plugin public contract.
 import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
-import { buildGoogleGeminiCliBackend } from "./cli-backend.js";
+import { buildGoogleAntigravityCliBackend, buildGoogleGeminiCliBackend } from "./cli-backend.js";
 import { createGoogleVertexProvider } from "./provider-contract-api.js";
 
 export default definePluginEntry({
@@ -10,5 +10,6 @@ export default definePluginEntry({
   register(api) {
     api.registerProvider(createGoogleVertexProvider());
     api.registerCliBackend(buildGoogleGeminiCliBackend());
+    api.registerCliBackend(buildGoogleAntigravityCliBackend());
   },
 });

--- a/src/config/model-input.ts
+++ b/src/config/model-input.ts
@@ -72,7 +72,12 @@ export function toAgentModelListLike(model?: AgentModelConfig): AgentModelListLi
   return model;
 }
 
-const GOOGLE_PROVIDER_IDS = new Set(["google", "google-gemini-cli", "google-vertex"]);
+const GOOGLE_PROVIDER_IDS = new Set([
+  "google",
+  "google-antigravity-cli",
+  "google-gemini-cli",
+  "google-vertex",
+]);
 
 /** Canonicalizes provider/model refs before they are persisted to config. */
 export function normalizeAgentModelRefForConfig(model: string): string {

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -428,6 +428,7 @@ const BUILT_IN_MODEL_PROVIDER_OVERLAY_IDS = new Set([
   "github-copilot",
   "google",
   "google-antigravity",
+  "google-antigravity-cli",
   "google-gemini-cli",
   "google-vertex",
   "groq",

--- a/src/plugin-sdk/test-helpers/plugin-registration-contract-cases.ts
+++ b/src/plugin-sdk/test-helpers/plugin-registration-contract-cases.ts
@@ -71,7 +71,7 @@ export const pluginRegistrationContractCases = {
   },
   google: {
     pluginId: "google",
-    providerIds: ["google", "google-gemini-cli", "google-vertex"],
+    providerIds: ["google", "google-antigravity-cli", "google-gemini-cli", "google-vertex"],
     webSearchProviderIds: ["gemini"],
     realtimeVoiceProviderIds: ["google"],
     speechProviderIds: ["google"],

--- a/src/plugins/config-state.ts
+++ b/src/plugins/config-state.ts
@@ -35,6 +35,7 @@ export type PluginActivationConfigSource = {
 export type NormalizedPluginsConfig = SharedNormalizedPluginsConfig;
 
 const BUILT_IN_PLUGIN_ALIAS_FALLBACKS: ReadonlyArray<readonly [alias: string, pluginId: string]> = [
+  ["google-antigravity-cli", "google"],
   ["google-gemini-cli", "google"],
   ["minimax-portal", "minimax"],
   ["minimax-portal-auth", "minimax"],

--- a/src/status/agent-runtime-label.ts
+++ b/src/status/agent-runtime-label.ts
@@ -15,6 +15,7 @@ const AGENT_RUNTIME_LABELS: Readonly<Record<string, string>> = {
   codex: "OpenAI Codex",
   "codex-cli": "OpenAI Codex",
   "claude-cli": "Claude CLI",
+  "google-antigravity-cli": "Antigravity CLI",
   "google-gemini-cli": "Gemini CLI",
 };
 


### PR DESCRIPTION
> **Stacked on top of #90975** (`feature/antigravity-cli-fresh`). The first 9 commits in this PR belong to #90975 (the Antigravity-CLI backend itself); the net change introduced by **this** PR is the last 2 commits (`7c00796ae8`, `7d4d4588fe`). Once #90975 merges, this PR will be rebased and its diff reduces to just the plugin-config one-liner.

---

# PR Body — Punkt 4: Antigravity CLI raw-transcript reseed

## Summary

Enables `reseedFromRawTranscriptWhenUncompacted: true` for the
`google-antigravity-cli` backend so OpenClaw passes prior conversation
history to `agy --print` on every turn. Without this flag the multi-turn
context is silently lost after 2-3 turns.

## Real behavior proof

### Behavior or issue addressed

The Antigravity CLI backend uses `sessionMode: "none"` and `output: "text"`,
which means OpenClaw cannot derive a CLI-side session id from agy's
stdout. In `src/agents/cli-runner/prepare.ts:553-559`, the reseed branch
only fires when either a CLI session id exists or
`reseedFromRawTranscriptWhenUncompacted === true`. Without the flag set,
every `agy --print` invocation gets only the current user prompt — no
prior turns, no system context recap.

User-visible symptom: characters / discussions / facts established in
turn 1 are gone by turn 3.

### Real environment tested

- Source repo: PR #90975 head (`507aab6706`) in worktree
  `/Users/rob/Development/openclaw/.worktrees/p4d/`
- Branch: `feature/antigravity-cli-reseed-uncompacted`
- Vitest extension runner: `node scripts/test-extension.mjs google --reporter=verbose`
- TypeScript: `pnpm tsgo:extensions`
- agy 1.0.6 verified via prior session OAuth smoke (see
  `bug-fix/IMPLEMENTATION-2026-06-06.md`)

### Exact steps or command run after this patch

```bash
cd /Users/rob/Development/openclaw/.worktrees/p4d
node scripts/test-extension.mjs google --reporter=verbose
pnpm tsgo:extensions
```

For live multi-turn verification (separate user-side step, blocked on
test-agent setup):

```bash
# requires an isolated agent whose model allowlist includes
# google-antigravity-cli/* (existing main and jibril agents reject it).
# Memory policy forbids --agent main for smoke runs.
openclaw agent --local --agent test --model google-antigravity-cli/gemini-3.5-flash \
  --message "Remember: codeword BANANA-42. Reply: stored." --json --timeout 60
openclaw agent --local --agent test --model google-antigravity-cli/gemini-3.5-flash \
  --message "Tell me one short fact about the Eiffel Tower." --json --timeout 90
openclaw agent --local --agent test --model google-antigravity-cli/gemini-3.5-flash \
  --message "What was the codeword from earlier? Reply only the word or UNKNOWN." \
  --json --timeout 60
```

### Evidence after fix

Vitest run after GREEN:

```
 Test Files  25 passed (25)
      Tests  317 passed (317)
   Duration  55.76s
```

Diagnostics that drove the fix (see
`bug-fix/DIAGNOSIS-PHASE2-2026-06-08.md`):

- 16 of 16 historical `cli exec` log lines for
  `google-antigravity-cli` recorded `historyPrompt=none`
- Reseed truncation marker
  `[OpenClaw reseed history truncated; older turns dropped]`
  appeared 0 times in 24h of logs
- Reseed budget never approached (`promptChars` 33-202; budget cap 256KB)
- Root cause: the reseed gate at `prepare.ts:554` never opens for this
  backend because the flag defaults to undefined and there is no CLI
  session id

### Observed result after fix

`backend.config.reseedFromRawTranscriptWhenUncompacted` is now `true`.
OpenClaw's existing `buildCliSessionHistoryPrompt`
(`src/agents/cli-runner/session-history.ts:170-267`) will now wrap prior
turns in `<conversation_history>` + `<next_user_message>` tags and pass
them with the current prompt to `agy --print`.

### What was not tested

- Live 4-turn retention smoke against `agy 1.0.6`: blocked on test-agent
  setup. The default `main` agent must not be used for smoke per repo
  memory; existing `jibril` agent rejects `google-antigravity-cli/*` via
  its model allowlist. A dedicated `test` agent or an allowlist
  extension is a separate user-side decision.
- Effect on agy's own conversation cache (`~/.gemini/antigravity-cli/`):
  the fix only changes what OpenClaw sends, not how agy persists it.

### Notes

- The flag is already wired in core
  (`prepare.ts:553-559`, `session-history.ts:62-69`,
  `zod-schema.core.ts:799`,
  `types.agent-defaults.ts:184`) and exercised by multiple existing
  backend test cases in `src/agents/cli-runner/prepare.test.ts`. This PR
  is the plugin-side opt-in only — no core changes.
- This builds on PR #90975 (Antigravity CLI backend factory). Either
  rebase onto its merged form or fold these two commits in.
