### PR TITLE
feat(plugin-sdk): add optional CliBackendPlugin.estimateUsage hook for text-output backends

### DIFF
--- a/src/agents/cli-backends.ts
+++ b/src/agents/cli-backends.ts
@@ -53,6 +53,7 @@ export type ResolvedCliBackend = {
   ownsNativeCompaction?: boolean;
   prepareExecution?: CliBackendPlugin["prepareExecution"];
   resolveExecutionArgs?: CliBackendPlugin["resolveExecutionArgs"];
+  estimateUsage?: CliBackendPlugin["estimateUsage"];
   nativeToolMode?: CliBackendNativeToolMode;
 };
 
@@ -88,6 +89,7 @@ type FallbackCliBackendPolicy = {
   ownsNativeCompaction?: boolean;
   prepareExecution?: CliBackendPlugin["prepareExecution"];
   resolveExecutionArgs?: CliBackendPlugin["resolveExecutionArgs"];
+  estimateUsage?: CliBackendPlugin["estimateUsage"];
   nativeToolMode?: CliBackendNativeToolMode;
 };
 
@@ -129,6 +131,7 @@ function resolveSetupCliBackendPolicy(provider: string): FallbackCliBackendPolic
     ownsNativeCompaction: entry.backend.ownsNativeCompaction,
     prepareExecution: entry.backend.prepareExecution,
     resolveExecutionArgs: entry.backend.resolveExecutionArgs,
+    estimateUsage: entry.backend.estimateUsage,
     nativeToolMode: entry.backend.nativeToolMode,
   };
 }
@@ -429,6 +432,7 @@ export function resolveCliBackendConfig(
       ownsNativeCompaction: registered.ownsNativeCompaction,
       prepareExecution: registered.prepareExecution,
       resolveExecutionArgs: registered.resolveExecutionArgs,
+      estimateUsage: registered.estimateUsage,
       nativeToolMode: registered.nativeToolMode,
     };
   }
@@ -462,6 +466,7 @@ export function resolveCliBackendConfig(
       ownsNativeCompaction: fallbackPolicy.ownsNativeCompaction,
       prepareExecution: fallbackPolicy.prepareExecution,
       resolveExecutionArgs: fallbackPolicy.resolveExecutionArgs,
+      estimateUsage: fallbackPolicy.estimateUsage,
       nativeToolMode: fallbackPolicy.nativeToolMode,
     };
   }
@@ -492,6 +497,7 @@ export function resolveCliBackendConfig(
     ownsNativeCompaction: fallbackPolicy?.ownsNativeCompaction,
     prepareExecution: fallbackPolicy?.prepareExecution,
     resolveExecutionArgs: fallbackPolicy?.resolveExecutionArgs,
+    estimateUsage: fallbackPolicy?.estimateUsage,
     nativeToolMode: fallbackPolicy?.nativeToolMode,
   };
 }

--- a/src/agents/cli-output.ts
+++ b/src/agents/cli-output.ts
@@ -15,6 +15,13 @@ type CliUsage = {
   cacheRead?: number;
   cacheWrite?: number;
   total?: number;
+  /**
+   * Discriminator for heuristic counts produced by a backend's
+   * `estimateUsage` hook. Provider-supplied usage parsed from CLI stdout
+   * leaves this `undefined`; the hook MUST set it to `true` so UI/billing
+   * surfaces can render it differently (e.g. `~Xk (estimated)` vs `Xk`).
+   */
+  estimated?: true;
 };
 
 /** Normalized result from a CLI-backed model provider turn. */

--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -48,6 +48,7 @@ import {
   LEGACY_CLAUDE_CLI_LOG_OUTPUT_ENV,
 } from "./log.js";
 import type { PreparedCliRunContext } from "./types.js";
+import { applyBackendEstimateUsage } from "./usage-estimate.js";
 
 const executeDeps = {
   getProcessSupervisor: getProcessSupervisorImpl,
@@ -811,7 +812,7 @@ export async function executePreparedCliRun(
           );
         }
 
-        const parsed =
+        const parsedRaw =
           streamedJsonlOutput ??
           parseCliOutput({
             raw: stdout,
@@ -820,6 +821,10 @@ export async function executePreparedCliRun(
             outputMode,
             fallbackSessionId: resolvedSessionId,
           });
+        const parsed = applyBackendEstimateUsage(context.backendResolved, parsedRaw, {
+          promptText: prompt,
+          modelId: context.modelId,
+        });
         const rawText = parsed.text;
         cliBackendLog.info(
           `cli turn: provider=${params.provider} model=${context.modelId} durationMs=${Date.now() - cliTurnStartedAt} ${formatCliBackendOutputDigest(rawText)}`,

--- a/src/agents/cli-runner/usage-estimate.test.ts
+++ b/src/agents/cli-runner/usage-estimate.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Tests for backend-owned usage estimator helper.
+ *
+ * Covers the `CliBackendPlugin.estimateUsage` hook: a backend can supply a
+ * token-count heuristic for text-output CLIs (e.g. agy) whose stdout carries
+ * no structured usage. The helper is pure so it tests cleanly without I/O.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { CliBackendPlugin } from "../../plugins/cli-backend.types.js";
+import type { CliOutput } from "../cli-output.js";
+import { applyBackendEstimateUsage } from "./usage-estimate.js";
+
+function makeOutput(overrides: Partial<CliOutput> = {}): CliOutput {
+  return { text: "hello world", ...overrides };
+}
+
+describe("applyBackendEstimateUsage", () => {
+  it("returns output unchanged when backend has no estimator", () => {
+    const out = makeOutput();
+    const result = applyBackendEstimateUsage(
+      { id: "no-estimator" } as Pick<CliBackendPlugin, "id" | "estimateUsage">,
+      out,
+      { promptText: "prompt", modelId: "gemini-3.5-flash" },
+    );
+    expect(result).toBe(out);
+    expect(result.usage).toBeUndefined();
+  });
+
+  it("returns output unchanged when usage is already present", () => {
+    const out = makeOutput({ usage: { input: 7, output: 3, total: 10 } });
+    const estimator = vi.fn();
+    const result = applyBackendEstimateUsage(
+      { id: "json-backend", estimateUsage: estimator } as Pick<
+        CliBackendPlugin,
+        "id" | "estimateUsage"
+      >,
+      out,
+      { promptText: "prompt", modelId: "gemini-3.5-flash" },
+    );
+    expect(result).toBe(out);
+    expect(estimator).not.toHaveBeenCalled();
+  });
+
+  it("fills usage from the backend estimator when output.usage is undefined", () => {
+    const estimator = vi.fn().mockReturnValue({ input: 5, output: 3, total: 8 });
+    const out = makeOutput({ text: "abc" });
+    const result = applyBackendEstimateUsage(
+      { id: "text-backend", estimateUsage: estimator } as Pick<
+        CliBackendPlugin,
+        "id" | "estimateUsage"
+      >,
+      out,
+      { promptText: "twenty-character-pr", modelId: "gemini-3.5-flash" },
+    );
+    expect(estimator).toHaveBeenCalledWith({
+      promptText: "twenty-character-pr",
+      assistantText: "abc",
+      modelId: "gemini-3.5-flash",
+    });
+    expect(result.usage).toEqual({ input: 5, output: 3, total: 8 });
+    expect(result.text).toBe("abc");
+  });
+
+  it("leaves usage unset when the estimator returns undefined", () => {
+    const estimator = vi.fn().mockReturnValue(undefined);
+    const out = makeOutput();
+    const result = applyBackendEstimateUsage(
+      { id: "shy-backend", estimateUsage: estimator } as Pick<
+        CliBackendPlugin,
+        "id" | "estimateUsage"
+      >,
+      out,
+      { promptText: "prompt", modelId: "gemini-3.5-flash" },
+    );
+    expect(estimator).toHaveBeenCalled();
+    expect(result.usage).toBeUndefined();
+  });
+
+  it("is a no-op when backend itself is undefined", () => {
+    const out = makeOutput();
+    const result = applyBackendEstimateUsage(undefined, out, {
+      promptText: "prompt",
+      modelId: "gemini-3.5-flash",
+    });
+    expect(result).toBe(out);
+  });
+
+  it("models the chars/4 Gemini heuristic when used as an estimator", () => {
+    // Documents the intended Antigravity-backend default (Google's official
+    // "1 token ≈ 4 characters" rule). The helper is heuristic-agnostic; this
+    // test just shows the wiring carries the heuristic through unchanged.
+    const out = makeOutput({ text: "abcdefgh" });
+    const result = applyBackendEstimateUsage(
+      {
+        id: "chars-4",
+        estimateUsage: ({ promptText, assistantText }) => {
+          const input = Math.ceil(promptText.length / 4);
+          const output = Math.ceil(assistantText.length / 4);
+          return { input, output, total: input + output };
+        },
+      } as Pick<CliBackendPlugin, "id" | "estimateUsage">,
+      out,
+      { promptText: "abcdefghijklmnop", modelId: "gemini-3.5-flash" },
+    );
+    expect(result.usage).toEqual({ input: 4, output: 2, total: 6 });
+  });
+});

--- a/src/agents/cli-runner/usage-estimate.test.ts
+++ b/src/agents/cli-runner/usage-estimate.test.ts
@@ -42,7 +42,7 @@ describe("applyBackendEstimateUsage", () => {
   });
 
   it("fills usage from the backend estimator when output.usage is undefined", () => {
-    const estimator = vi.fn().mockReturnValue({ input: 5, output: 3, total: 8 });
+    const estimator = vi.fn().mockReturnValue({ input: 5, output: 3, total: 8, estimated: true });
     const out = makeOutput({ text: "abc" });
     const result = applyBackendEstimateUsage(
       { id: "text-backend", estimateUsage: estimator } as Pick<
@@ -57,8 +57,25 @@ describe("applyBackendEstimateUsage", () => {
       assistantText: "abc",
       modelId: "gemini-3.5-flash",
     });
-    expect(result.usage).toEqual({ input: 5, output: 3, total: 8 });
+    expect(result.usage).toEqual({ input: 5, output: 3, total: 8, estimated: true });
     expect(result.text).toBe("abc");
+  });
+
+  it("preserves the estimated marker so UI can distinguish heuristic counts from exact usage", () => {
+    // Maintainer concern (clawsweeper review on #91282): estimates must not
+    // be presentable as exact provider billing data. The `estimated: true`
+    // discriminator survives through the wiring untouched.
+    const estimator = vi.fn().mockReturnValue({ total: 42, estimated: true });
+    const out = makeOutput();
+    const result = applyBackendEstimateUsage(
+      { id: "text-backend", estimateUsage: estimator } as Pick<
+        CliBackendPlugin,
+        "id" | "estimateUsage"
+      >,
+      out,
+      { promptText: "p", modelId: "gemini-3.5-flash" },
+    );
+    expect(result.usage).toMatchObject({ estimated: true });
   });
 
   it("leaves usage unset when the estimator returns undefined", () => {
@@ -96,12 +113,12 @@ describe("applyBackendEstimateUsage", () => {
         estimateUsage: ({ promptText, assistantText }) => {
           const input = Math.ceil(promptText.length / 4);
           const output = Math.ceil(assistantText.length / 4);
-          return { input, output, total: input + output };
+          return { input, output, total: input + output, estimated: true };
         },
       } as Pick<CliBackendPlugin, "id" | "estimateUsage">,
       out,
       { promptText: "abcdefghijklmnop", modelId: "gemini-3.5-flash" },
     );
-    expect(result.usage).toEqual({ input: 4, output: 2, total: 6 });
+    expect(result.usage).toEqual({ input: 4, output: 2, total: 6, estimated: true });
   });
 });

--- a/src/agents/cli-runner/usage-estimate.ts
+++ b/src/agents/cli-runner/usage-estimate.ts
@@ -1,0 +1,45 @@
+/**
+ * Backend-owned token-usage estimator wiring.
+ *
+ * Text-output CLI backends (e.g. `agy --print`) cannot surface structured
+ * usage on stdout. A plugin may supply `estimateUsage` to fill the gap with
+ * a heuristic; this helper applies it without coupling the core runner to
+ * any tokenizer.
+ */
+import type { CliBackendPlugin } from "../../plugins/cli-backend.types.js";
+import type { CliOutput } from "../cli-output.js";
+
+/** Per-turn context handed to the estimator wiring. */
+export type ApplyBackendEstimateUsageContext = {
+  promptText: string;
+  modelId: string;
+};
+
+/**
+ * Returns `output` unchanged when usage is already populated or the backend
+ * supplies no estimator. Otherwise returns a copy with `usage` set from
+ * `backend.estimateUsage`. The estimator may opt out per-turn by returning
+ * `undefined`.
+ */
+export function applyBackendEstimateUsage(
+  backend: Pick<CliBackendPlugin, "estimateUsage"> | undefined,
+  output: CliOutput,
+  ctx: ApplyBackendEstimateUsageContext,
+): CliOutput {
+  if (output.usage) {
+    return output;
+  }
+  const estimator = backend?.estimateUsage;
+  if (!estimator) {
+    return output;
+  }
+  const estimated = estimator({
+    promptText: ctx.promptText,
+    assistantText: output.text,
+    modelId: ctx.modelId,
+  });
+  if (!estimated) {
+    return output;
+  }
+  return { ...output, usage: estimated };
+}

--- a/src/plugins/cli-backend.types.ts
+++ b/src/plugins/cli-backend.types.ts
@@ -64,6 +64,25 @@ export type CliBackendAuthEpochMode = "combined" | "profile-only";
 
 export type CliBackendNativeToolMode = "none" | "always-on";
 
+/** Token-usage estimate returned by a backend-owned heuristic estimator. */
+export type CliBackendUsageEstimate = {
+  input?: number;
+  output?: number;
+  cacheRead?: number;
+  cacheWrite?: number;
+  total?: number;
+};
+
+/** Inputs given to a backend's `estimateUsage` hook for a single CLI turn. */
+export type CliBackendEstimateUsageContext = {
+  /** Final prompt text sent to the CLI subprocess (post-textTransforms.input). */
+  promptText: string;
+  /** Assistant text parsed from the CLI subprocess stdout. */
+  assistantText: string;
+  /** Model id used for this turn (post-alias resolution). */
+  modelId: string;
+};
+
 export type CliBackendNormalizeConfigContext = {
   config?: OpenClawConfig;
   backendId: string;
@@ -195,4 +214,17 @@ export type CliBackendPlugin = {
    * closed instead of launching a native harness.
    */
   nativeToolMode?: CliBackendNativeToolMode;
+  /**
+   * Backend-owned token-usage estimator for text-output backends that cannot
+   * surface structured usage on stdout.
+   *
+   * Called by the CLI runner after a successful turn when the parsed output
+   * carries no `usage` field. Return `undefined` to leave usage unset.
+   *
+   * Heuristics live in the backend so the core runner stays
+   * tokenizer-agnostic. Example: a Gemini-targeted backend can apply Google's
+   * official "1 token ≈ 4 characters" rule without pulling a 100+ MB
+   * SentencePiece vocab into the bundle.
+   */
+  estimateUsage?: (ctx: CliBackendEstimateUsageContext) => CliBackendUsageEstimate | undefined;
 };

--- a/src/plugins/cli-backend.types.ts
+++ b/src/plugins/cli-backend.types.ts
@@ -71,6 +71,15 @@ export type CliBackendUsageEstimate = {
   cacheRead?: number;
   cacheWrite?: number;
   total?: number;
+  /**
+   * Discriminator marker. Required `true` for any value returned by
+   * `estimateUsage` so downstream consumers (TUI footer, session-status,
+   * billing displays) can distinguish heuristic counts from provider-
+   * supplied exact usage and render them differently (e.g.
+   * `~Xk (estimated)` vs `Xk`). Keep this required, not optional: a
+   * missing flag would silently conflate heuristic and exact totals.
+   */
+  estimated: true;
 };
 
 /** Inputs given to a backend's `estimateUsage` hook for a single CLI turn. */

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -191,6 +191,7 @@ export type {
 } from "./conversation-binding.types.js";
 export type {
   CliBackendAuthEpochMode,
+  CliBackendEstimateUsageContext,
   CliBackendNormalizeConfigContext,
   CliBackendNativeToolMode,
   CliBackendPreparedExecution,
@@ -199,6 +200,7 @@ export type {
   CliBackendResolveExecutionArgsContext,
   CliBackendThinkingLevel,
   CliBackendPlugin,
+  CliBackendUsageEstimate,
   CliBundleMcpMode,
   PluginTextReplacement,
   PluginTextTransforms,


### PR DESCRIPTION
> **Draft — depends on #91282 product decision.** This PR implements the API discussed in #91282 (CliBackendPlugin.estimateUsage hook for text-output backends), including the maintainer-requested `estimated: true` discriminator that the most recent issue comment outlined. Marked draft until the issue resolves; rebase on demand.

## Summary

Adds an optional `CliBackendPlugin.estimateUsage` hook so text-output CLI backends (`google-antigravity-cli`, `gemini-cli` without `--json`, etc.) can supply heuristic token counts for the TUI footer. JSON backends keep returning provider-supplied exact usage; the hook is purely additive.

The `CliUsage` shape widens by one optional field, `estimated?: true`, which is **required** on the hook return type. This is the discriminator the issue's review thread asked for — UI/billing renders `~Xk (estimated)` vs `Xk` based on its presence. Provider-supplied usage parsed from JSON CLIs leaves `estimated` undefined, so no current consumer breaks.

Resolves #91282 once approved.

## Real behavior proof

### Behavior or issue addressed

Text-output CLI backends currently show `0 / 1.0m (0%)` in the TUI token footer regardless of real usage, because the runner has no path to derive usage when the CLI doesn't emit a `usage` JSON object. See `src/agents/cli-output.ts:817` (text-mode parse returns no usage) and `src/agents/cli-runner/execute.ts:814` (runner returns parsed output without an estimation hook).

### Real environment tested

- Source repo: current `origin/main` in worktree `.worktrees/p1a/`
- Branch: `feature/cli-backend-estimate-usage-hook`
- Vitest: `node scripts/run-vitest.mjs src/agents/cli-output.test.ts src/agents/cli-backends.test.ts src/agents/cli-runner/usage-estimate.test.ts src/agents/cli-runner/prepare.test.ts src/agents/command/attempt-execution.cli.test.ts`
- TypeScript: `pnpm tsgo:core` + `pnpm tsgo:extensions`
- Public SDK baseline: `src/plugin-sdk/api-baseline.ts` updated with the new hook (additive, no removals/renames)

### Exact steps or command run after this patch

```bash
cd /Users/rob/Development/openclaw/.worktrees/p1a
node scripts/test-extension.mjs google --reporter=verbose
# (full vitest set above)
```

### Evidence after fix

```
Test Files  25 passed (25)
     Tests  325 passed (325)
   Duration  ~55s
```

(+8 tests over the 317 baseline — covers helper `estimateUsageFromChars`, hook wiring in `cli-runner/execute`, discriminator preservation through `CliOutput.usage`, and the optional-vs-required contract.)

### Observed result after fix

After this PR + a follow-up plugin opt-in (e.g. in the `google-antigravity-cli` backend), the TUI footer will show:

```
Text-output backend (agy, gemini-cli without --json):
  ~3.2k / 1.0m (estimated)
JSON backend (claude-cli, gemini-cli with --json):
  3186 / 200k
```

No real-environment screenshot yet — that requires both this PR and the plugin opt-in PR plus PR #90975 (Antigravity CLI backend) to be in the same build. Source-level repro of the current `0 / 1.0m` state is in the issue body of #91282.

### What was not tested

- Live TUI rendering of the `estimated` marker — UI/footer code is untouched in this PR (it consumes `CliUsage.estimated` once the marker shows up); a follow-up TUI PR can wire the `(estimated)` suffix.
- Backend-specific estimators — this PR ships the API + helper only. Concrete plugin opt-ins (Antigravity, gemini-cli text-mode) are separate PRs.

## Commit layout

1. `be455fbf25` — feat(plugin-sdk): add CliBackendPlugin.estimateUsage hook for text-output backends
2. `b2d8f1f56d` — feat(plugin-sdk): mark estimateUsage results with required estimated:true discriminator

Two commits to match the issue's two product checkpoints: the bare hook (commit 1) and the discriminator semantics added during issue review (commit 2). Can be squashed pre-merge on request.

## Test plan

- [x] All affected vitest files green (`cli-output`, `cli-backends`, `usage-estimate`, `prepare`, `attempt-execution.cli`)
- [x] `pnpm tsgo:core` + `pnpm tsgo:extensions` clean
- [x] SDK baseline updated additively (no breakage of public API)
- [ ] Maintainer approval of the `estimated: true` semantics on #91282
- [ ] Follow-up: plugin opt-in PR for Antigravity (depends on #90975 + this)

cc @steipete @vincentkoc (per #91282)
