### PR TITLE
block unauthorized Telegram DM text from prompt context

### DIFF
--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -2743,13 +2743,127 @@ export const registerTelegramHandlers = ({
     } as Message;
   };
 
-  const recordEditedMessageForReplyChain = async (
-    ctxForDedupe: TelegramUpdateKeyContext,
-    msg: Message,
-  ) => {
-    if (shouldSkipUpdate(ctxForDedupe)) {
+  type TelegramInboundGate =
+    | { allowed: false }
+    | {
+        allowed: true;
+        context: TelegramEventAuthorizationContext;
+        effectiveDmAllow: NormalizedAllowFrom;
+      };
+
+  // Single authorization gate for every message-like update that can reach the
+  // reply-chain cache or dispatch: fresh messages, edits, channel posts. Must run
+  // before any cache/dedupe side effect so blocked content is never recorded.
+  // dmAccess "challenge" may send a pairing reply; "silent" only decides (edits
+  // must never reply).
+  const authorizeInboundMessage = async (params: {
+    msg: Message;
+    chatId: number;
+    isGroup: boolean;
+    isForum: boolean;
+    messageThreadId?: number;
+    senderId: string;
+    senderUsername: string;
+    requireConfiguredGroup: boolean;
+    dmAccess: "challenge" | "silent";
+  }): Promise<TelegramInboundGate> => {
+    const context = await resolveTelegramEventAuthorizationContext({
+      chatId: params.chatId,
+      isGroup: params.isGroup,
+      isForum: params.isForum,
+      senderId: params.senderId,
+      messageThreadId: params.messageThreadId,
+    });
+    const {
+      dmPolicy,
+      resolvedThreadId,
+      dmThreadId,
+      storeAllowFrom,
+      groupConfig,
+      topicConfig,
+      groupAllowOverride,
+      effectiveGroupAllow,
+      hasGroupAllowOverride,
+    } = context;
+    // For DMs, prefer per-DM/topic allowFrom (groupAllowOverride) over account-level allowFrom
+    const expandedDmAllowFrom = await expandTelegramAllowFromWithAccessGroups({
+      cfg,
+      allowFrom: groupAllowOverride ?? allowFrom,
+      accountId,
+      senderId: params.senderId,
+    });
+    const effectiveDmAllow = normalizeDmAllowFromWithStore({
+      allowFrom: expandedDmAllowFrom,
+      storeAllowFrom,
+      dmPolicy,
+    });
+
+    if (params.requireConfiguredGroup && (!groupConfig || groupConfig.enabled === false)) {
+      logVerbose(`Blocked telegram channel ${params.chatId} (channel disabled)`);
+      return { allowed: false };
+    }
+
+    if (
+      shouldSkipGroupMessage({
+        isGroup: params.isGroup,
+        chatId: params.chatId,
+        chatTitle: params.msg.chat.title,
+        resolvedThreadId,
+        senderId: params.senderId,
+        senderUsername: params.senderUsername,
+        effectiveGroupAllow,
+        hasGroupAllowOverride,
+        groupConfig,
+        topicConfig,
+      })
+    ) {
+      return { allowed: false };
+    }
+
+    if (!params.isGroup) {
+      const requireTopic =
+        groupConfig && "requireTopic" in groupConfig ? groupConfig.requireTopic : undefined;
+      if (requireTopic === true && dmThreadId == null) {
+        logVerbose(`Blocked telegram DM ${params.chatId}: requireTopic=true but no topic present`);
+        return { allowed: false };
+      }
+      const dmAuthorized =
+        params.dmAccess === "challenge"
+          ? await enforceTelegramDmAccess({
+              isGroup: params.isGroup,
+              dmPolicy,
+              msg: params.msg,
+              chatId: params.chatId,
+              effectiveDmAllow,
+              accountId,
+              bot,
+              logger,
+              upsertPairingRequest: telegramDeps.upsertChannelPairingRequest,
+            })
+          : await isTelegramDmAccessAllowed({
+              dmPolicy,
+              msg: params.msg,
+              chatId: params.chatId,
+              effectiveDmAllow,
+              accountId,
+            });
+      if (!dmAuthorized) {
+        return { allowed: false };
+      }
+    }
+
+    return { allowed: true, context, effectiveDmAllow };
+  };
+
+  const recordEditedMessageForReplyChain = async (params: {
+    ctxForDedupe: TelegramUpdateKeyContext;
+    msg: Message;
+    requireConfiguredGroup: boolean;
+  }) => {
+    if (shouldSkipUpdate(params.ctxForDedupe)) {
       return;
     }
+    const msg = params.msg;
     const isGroup = msg.chat.type === "group" || msg.chat.type === "supergroup";
     const isForum = await resolveTelegramForumFlag({
       chatId: msg.chat.id,
@@ -2760,52 +2874,21 @@ export const registerTelegramHandlers = ({
       getChat,
     });
     const normalizedMsg = withResolvedTelegramForumFlag(msg, isForum);
-    const resolvedThreadId = resolveTelegramForumThreadId({
+    const gate = await authorizeInboundMessage({
+      msg: normalizedMsg,
+      chatId: normalizedMsg.chat.id,
+      isGroup,
       isForum,
       messageThreadId: normalizedMsg.message_thread_id,
+      senderId: normalizedMsg.from?.id != null ? String(normalizedMsg.from.id) : "",
+      senderUsername: normalizedMsg.from?.username ?? "",
+      requireConfiguredGroup: params.requireConfiguredGroup,
+      dmAccess: "silent",
     });
-    const dmThreadId = !isGroup ? normalizedMsg.message_thread_id : undefined;
-    if (!isGroup) {
-      const senderId = normalizedMsg.from?.id != null ? String(normalizedMsg.from.id) : "";
-      const eventAuthContext = await resolveTelegramEventAuthorizationContext({
-        chatId: normalizedMsg.chat.id,
-        isGroup,
-        isForum,
-        senderId,
-        messageThreadId: normalizedMsg.message_thread_id,
-      });
-      const { dmPolicy, storeAllowFrom, groupConfig, groupAllowOverride } = eventAuthContext;
-      const requireTopic =
-        groupConfig && "requireTopic" in groupConfig ? groupConfig.requireTopic : undefined;
-      if (requireTopic === true && dmThreadId == null) {
-        logVerbose(
-          `Blocked telegram DM ${normalizedMsg.chat.id}: requireTopic=true but no topic present`,
-        );
-        return;
-      }
-      const dmAllowFrom = groupAllowOverride ?? allowFrom;
-      const expandedDmAllowFrom = await expandTelegramAllowFromWithAccessGroups({
-        cfg,
-        allowFrom: dmAllowFrom,
-        accountId,
-        senderId,
-      });
-      const effectiveDmAllow = normalizeDmAllowFromWithStore({
-        allowFrom: expandedDmAllowFrom,
-        storeAllowFrom,
-        dmPolicy,
-      });
-      const dmAuthorized = await isTelegramDmAccessAllowed({
-        dmPolicy,
-        msg: normalizedMsg,
-        chatId: normalizedMsg.chat.id,
-        effectiveDmAllow,
-        accountId,
-      });
-      if (!dmAuthorized) {
-        return;
-      }
+    if (!gate.allowed) {
+      return;
     }
+    const { resolvedThreadId, dmThreadId } = gate.context;
     await recordMessageForReplyChain(normalizedMsg, resolvedThreadId ?? dmThreadId);
   };
 
@@ -2815,13 +2898,21 @@ export const registerTelegramHandlers = ({
       if (shouldSkipUpdate(event.ctxForDedupe)) {
         return;
       }
-      const eventAuthContext = await resolveTelegramEventAuthorizationContext({
+      const gate = await authorizeInboundMessage({
+        msg: event.msg,
         chatId: event.chatId,
         isGroup: event.isGroup,
         isForum: event.isForum,
-        senderId: event.senderId,
         messageThreadId: event.messageThreadId,
+        senderId: event.senderId,
+        senderUsername: event.senderUsername,
+        requireConfiguredGroup: event.requireConfiguredGroup,
+        dmAccess: "challenge",
       });
+      if (!gate.allowed) {
+        return;
+      }
+      const { effectiveDmAllow } = gate;
       const {
         dmPolicy,
         resolvedThreadId,
@@ -2829,71 +2920,8 @@ export const registerTelegramHandlers = ({
         storeAllowFrom,
         groupConfig,
         topicConfig,
-        groupAllowOverride,
         effectiveGroupAllow,
-        hasGroupAllowOverride,
-      } = eventAuthContext;
-      // For DMs, prefer per-DM/topic allowFrom (groupAllowOverride) over account-level allowFrom
-      const dmAllowFrom = groupAllowOverride ?? allowFrom;
-      const expandedDmAllowFrom = await expandTelegramAllowFromWithAccessGroups({
-        cfg,
-        allowFrom: dmAllowFrom,
-        accountId,
-        senderId: event.senderId,
-      });
-      const effectiveDmAllow = normalizeDmAllowFromWithStore({
-        allowFrom: expandedDmAllowFrom,
-        storeAllowFrom,
-        dmPolicy,
-      });
-
-      if (event.requireConfiguredGroup && (!groupConfig || groupConfig.enabled === false)) {
-        logVerbose(`Blocked telegram channel ${event.chatId} (channel disabled)`);
-        return;
-      }
-
-      if (
-        shouldSkipGroupMessage({
-          isGroup: event.isGroup,
-          chatId: event.chatId,
-          chatTitle: event.msg.chat.title,
-          resolvedThreadId,
-          senderId: event.senderId,
-          senderUsername: event.senderUsername,
-          effectiveGroupAllow,
-          hasGroupAllowOverride,
-          groupConfig,
-          topicConfig,
-        })
-      ) {
-        return;
-      }
-
-      const requireTopic =
-        !event.isGroup && groupConfig && "requireTopic" in groupConfig
-          ? groupConfig.requireTopic
-          : undefined;
-      if (!event.isGroup && requireTopic === true && dmThreadId == null) {
-        logVerbose(`Blocked telegram DM ${event.chatId}: requireTopic=true but no topic present`);
-        return;
-      }
-
-      if (!event.isGroup) {
-        const dmAuthorized = await enforceTelegramDmAccess({
-          isGroup: event.isGroup,
-          dmPolicy,
-          msg: event.msg,
-          chatId: event.chatId,
-          effectiveDmAllow,
-          accountId,
-          bot,
-          logger,
-          upsertPairingRequest: telegramDeps.upsertChannelPairingRequest,
-        });
-        if (!dmAuthorized) {
-          return;
-        }
-      }
+      } = gate.context;
 
       const promptContextMinTimestampMs = normalizePromptContextMinTimestampMs(
         resolveTelegramSessionState({
@@ -2999,7 +3027,11 @@ export const registerTelegramHandlers = ({
     if (!msg) {
       return;
     }
-    await recordEditedMessageForReplyChain(ctx, msg);
+    await recordEditedMessageForReplyChain({
+      ctxForDedupe: ctx,
+      msg,
+      requireConfiguredGroup: false,
+    });
   });
 
   // Handle channel posts — enables bot-to-bot communication via Telegram channels.
@@ -3040,6 +3072,10 @@ export const registerTelegramHandlers = ({
     if (!post) {
       return;
     }
-    await recordEditedMessageForReplyChain(ctx, normalizeChannelPostMessage(post));
+    await recordEditedMessageForReplyChain({
+      ctxForDedupe: ctx,
+      msg: normalizeChannelPostMessage(post),
+      requireConfiguredGroup: true,
+    });
   });
 };

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -61,7 +61,6 @@ import {
 } from "./bot-handlers.debounce-key.js";
 import {
   hasInboundMedia,
-  hasReplyTargetMedia,
   isMediaSizeLimitError,
   isRecoverableMediaGroupError,
   resolveInboundMediaFileId,
@@ -103,7 +102,7 @@ import {
   resolveTelegramConversationBaseSessionKey,
   resolveTelegramConversationRoute,
 } from "./conversation-route.js";
-import { enforceTelegramDmAccess } from "./dm-access.js";
+import { enforceTelegramDmAccess, isTelegramDmAccessAllowed } from "./dm-access.js";
 import { resolveTelegramExecApproval } from "./exec-approval-resolver.js";
 import {
   isTelegramExecApprovalApprover,
@@ -2766,6 +2765,47 @@ export const registerTelegramHandlers = ({
       messageThreadId: normalizedMsg.message_thread_id,
     });
     const dmThreadId = !isGroup ? normalizedMsg.message_thread_id : undefined;
+    if (!isGroup) {
+      const senderId = normalizedMsg.from?.id != null ? String(normalizedMsg.from.id) : "";
+      const eventAuthContext = await resolveTelegramEventAuthorizationContext({
+        chatId: normalizedMsg.chat.id,
+        isGroup,
+        isForum,
+        senderId,
+        messageThreadId: normalizedMsg.message_thread_id,
+      });
+      const { dmPolicy, storeAllowFrom, groupConfig, groupAllowOverride } = eventAuthContext;
+      const requireTopic =
+        groupConfig && "requireTopic" in groupConfig ? groupConfig.requireTopic : undefined;
+      if (requireTopic === true && dmThreadId == null) {
+        logVerbose(
+          `Blocked telegram DM ${normalizedMsg.chat.id}: requireTopic=true but no topic present`,
+        );
+        return;
+      }
+      const dmAllowFrom = groupAllowOverride ?? allowFrom;
+      const expandedDmAllowFrom = await expandTelegramAllowFromWithAccessGroups({
+        cfg,
+        allowFrom: dmAllowFrom,
+        accountId,
+        senderId,
+      });
+      const effectiveDmAllow = normalizeDmAllowFromWithStore({
+        allowFrom: expandedDmAllowFrom,
+        storeAllowFrom,
+        dmPolicy,
+      });
+      const dmAuthorized = await isTelegramDmAccessAllowed({
+        dmPolicy,
+        msg: normalizedMsg,
+        chatId: normalizedMsg.chat.id,
+        effectiveDmAllow,
+        accountId,
+      });
+      if (!dmAuthorized) {
+        return;
+      }
+    }
     await recordMessageForReplyChain(normalizedMsg, resolvedThreadId ?? dmThreadId);
   };
 
@@ -2829,7 +2869,16 @@ export const registerTelegramHandlers = ({
         return;
       }
 
-      if (!event.isGroup && (hasInboundMedia(event.msg) || hasReplyTargetMedia(event.msg))) {
+      const requireTopic =
+        !event.isGroup && groupConfig && "requireTopic" in groupConfig
+          ? groupConfig.requireTopic
+          : undefined;
+      if (!event.isGroup && requireTopic === true && dmThreadId == null) {
+        logVerbose(`Blocked telegram DM ${event.chatId}: requireTopic=true but no topic present`);
+        return;
+      }
+
+      if (!event.isGroup) {
         const dmAuthorized = await enforceTelegramDmAccess({
           isGroup: event.isGroup,
           dmPolicy,

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -1713,6 +1713,59 @@ describe("createTelegramBot", () => {
     expect(sendMessageSpy).not.toHaveBeenCalled();
   });
 
+  it("does not cache blocked group-sender edits into authorized prompt context", async () => {
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: {
+          groupPolicy: "allowlist",
+          allowFrom: ["123456789"],
+          groups: { "*": { requireMention: false } },
+        },
+      },
+    });
+    readChannelAllowFromStore.mockResolvedValue([]);
+    sendMessageSpy.mockClear();
+    replySpy.mockClear();
+
+    createTelegramBot({ token: "tok" });
+    const editedHandler = getOnHandler("edited_message") as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+    const messageHandler = getOnHandler("message") as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+
+    await editedHandler({
+      editedMessage: {
+        chat: { id: -100123456789, type: "group", title: "Test Group" },
+        message_id: 416,
+        date: 1736380800,
+        edit_date: 1736380810,
+        text: "edited unauthorized group secret",
+        from: { id: 999999, username: "notallowed" },
+      },
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+    expect(replySpy).not.toHaveBeenCalled();
+
+    await messageHandler({
+      message: {
+        chat: { id: -100123456789, type: "group", title: "Test Group" },
+        message_id: 417,
+        date: 1736380860,
+        text: "authorized follow-up",
+        from: { id: 123456789, username: "allowed" },
+      },
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+
+    expect(replySpy).toHaveBeenCalledTimes(1);
+    expect(replySpy.mock.calls.at(0)?.[0].UntrustedStructuredContext).toBeUndefined();
+    expect(sendMessageSpy).not.toHaveBeenCalled();
+  });
+
   it("drops topic-required root DMs before pairing challenges", async () => {
     loadConfig.mockReturnValue({
       channels: {

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -1615,6 +1615,140 @@ describe("createTelegramBot", () => {
     }
   });
 
+  it("does not leak blocked allowlist text DMs into authorized prompt context", async () => {
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: {
+          dmPolicy: "allowlist",
+          allowFrom: ["123456789"],
+        },
+      },
+    });
+    readChannelAllowFromStore.mockResolvedValue([]);
+    sendMessageSpy.mockClear();
+    replySpy.mockClear();
+
+    createTelegramBot({ token: "tok" });
+    const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
+
+    await handler({
+      message: {
+        chat: { id: 1234, type: "private" },
+        message_id: 411,
+        date: 1736380800,
+        text: "unauthorized secret",
+        from: { id: 999999, username: "notallowed" },
+      },
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+    expect(replySpy).not.toHaveBeenCalled();
+
+    await handler({
+      message: {
+        chat: { id: 1234, type: "private" },
+        message_id: 412,
+        date: 1736380860,
+        text: "authorized follow-up",
+        from: { id: 123456789, username: "allowed" },
+      },
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+
+    expect(replySpy).toHaveBeenCalledTimes(1);
+    expect(replySpy.mock.calls.at(0)?.[0].UntrustedStructuredContext).toBeUndefined();
+    expect(sendMessageSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not cache blocked allowlist edited DMs into authorized prompt context", async () => {
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: {
+          dmPolicy: "allowlist",
+          allowFrom: ["123456789"],
+        },
+      },
+    });
+    readChannelAllowFromStore.mockResolvedValue([]);
+    sendMessageSpy.mockClear();
+    replySpy.mockClear();
+
+    createTelegramBot({ token: "tok" });
+    const editedHandler = getOnHandler("edited_message") as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+    const messageHandler = getOnHandler("message") as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+
+    await editedHandler({
+      editedMessage: {
+        chat: { id: 1234, type: "private" },
+        message_id: 414,
+        date: 1736380800,
+        edit_date: 1736380810,
+        text: "edited unauthorized secret",
+        from: { id: 999999, username: "notallowed" },
+      },
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+    expect(replySpy).not.toHaveBeenCalled();
+
+    await messageHandler({
+      message: {
+        chat: { id: 1234, type: "private" },
+        message_id: 415,
+        date: 1736380860,
+        text: "authorized follow-up",
+        from: { id: 123456789, username: "allowed" },
+      },
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+
+    expect(replySpy).toHaveBeenCalledTimes(1);
+    expect(replySpy.mock.calls.at(0)?.[0].UntrustedStructuredContext).toBeUndefined();
+    expect(sendMessageSpy).not.toHaveBeenCalled();
+  });
+
+  it("drops topic-required root DMs before pairing challenges", async () => {
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: {
+          dmPolicy: "pairing",
+          direct: {
+            "1234": { requireTopic: true },
+          },
+        },
+      },
+    });
+    readChannelAllowFromStore.mockResolvedValue([]);
+    upsertChannelPairingRequest.mockClear();
+    sendMessageSpy.mockClear();
+    replySpy.mockClear();
+
+    createTelegramBot({ token: "tok" });
+    const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
+
+    await handler({
+      message: {
+        chat: { id: 1234, type: "private" },
+        message_id: 413,
+        date: 1736380870,
+        text: "root dm without topic",
+        from: { id: 999999, username: "notallowed" },
+      },
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+
+    expect(upsertChannelPairingRequest).not.toHaveBeenCalled();
+    expect(sendMessageSpy).not.toHaveBeenCalled();
+    expect(replySpy).not.toHaveBeenCalled();
+  });
+
   it("ignores group self-authored message updates instead of re-processing bot output", async () => {
     loadConfig.mockReturnValue({
       channels: { telegram: { dmPolicy: "pairing" } },

--- a/extensions/telegram/src/dm-access.ts
+++ b/extensions/telegram/src/dm-access.ts
@@ -57,6 +57,26 @@ async function decideTelegramDmAccess(params: {
   return result.ingress;
 }
 
+export async function isTelegramDmAccessAllowed(params: {
+  dmPolicy: DmPolicy;
+  msg: Message;
+  chatId: number;
+  effectiveDmAllow: NormalizedAllowFrom;
+  accountId: string;
+}): Promise<boolean> {
+  if (params.dmPolicy === "disabled") {
+    return false;
+  }
+  const sender = resolveTelegramSenderIdentity(params.msg, params.chatId);
+  const access = await decideTelegramDmAccess({
+    accountId: params.accountId,
+    dmPolicy: params.dmPolicy,
+    sender,
+    effectiveDmAllow: params.effectiveDmAllow,
+  });
+  return access.decision === "allow";
+}
+
 export async function enforceTelegramDmAccess(params: {
   isGroup: boolean;
   dmPolicy: DmPolicy;


### PR DESCRIPTION
## Summary

- Move Telegram DM access enforcement before dispatch dedupe, reply-chain recording, prompt-context selection, and message processing for normal inbound DMs.
- Apply the same passive allow check to edited private Telegram messages before they can update the conversation cache.
- Preserve `direct.<chatId>.requireTopic` behavior by dropping root DMs before pairing challenges, and add focused regressions for blocked text, edited text, and topic-required root DMs.

## Issue Scope

Fixes #91209.

The local reproducer for this branch is slightly narrower than the originally reported delivery-failure chain:

- Not proven here: unauthorized text DM -> agent turn -> reply to unauthorized user.
- Proven here: unauthorized text DM -> recorded in Telegram conversation cache -> authorized user sends a later DM -> that authorized agent turn can include the unauthorized text in prompt context.

So this fixes a pre-dispatch state and prompt-context leak. The early gate is still necessary because blocked Telegram DM text must not be recorded before authorization.

## Verification

- `node scripts/run-vitest.mjs extensions/telegram/src/bot.create-telegram-bot.test.ts -t "does not leak blocked allowlist text DMs into authorized prompt context"`
- `node scripts/run-vitest.mjs extensions/telegram/src/bot.create-telegram-bot.test.ts -t "does not cache blocked allowlist edited DMs into authorized prompt context"`
- `node scripts/run-vitest.mjs extensions/telegram/src/bot.create-telegram-bot.test.ts -t "drops topic-required root DMs before pairing challenges"`
- `node scripts/run-vitest.mjs extensions/telegram/src/bot.create-telegram-bot.test.ts`
- `pnpm format:fix extensions/telegram/src/bot-handlers.runtime.ts extensions/telegram/src/bot.create-telegram-bot.test.ts extensions/telegram/src/dm-access.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean, no accepted/actionable findings

## Real Behavior Proof

Automated Testbox proof:

- Provider/id: `blacksmith-testbox`, `tbx_01ktm10y41r4k7pvk2k6dqn0j2`
- Actions run: https://github.com/openclaw/openclaw/actions/runs/27151886658
- Red on clean `origin/main` (`303873e835c983318c1404cc1cbe0bddaeef87fd`): unauthorized sender text appeared in a later authorized turn's `UntrustedStructuredContext`.
- Green after this patch: focused Telegram bot regression passed; `dm-access` tests passed.
- Scope: proves the pre-dispatch cache/prompt-context leak. This does not replace Telegram Desktop visual proof.
