### PR TITLE
fix(gateway): surface approval delivery failures

### DIFF
--- a/src/gateway/exec-approval-ios-push.test.ts
+++ b/src/gateway/exec-approval-ios-push.test.ts
@@ -163,7 +163,7 @@ describe("createExecApprovalIosPushDelivery", () => {
 
     const accepted = await delivery.handleRequested(approvalRequest("approval-1"));
 
-    expect(accepted).toBe(false);
+    expect(accepted).toEqual({ delivered: false, attempted: false });
     expect(loadApnsRegistrationsMock).not.toHaveBeenCalled();
     expect(sendApnsExecApprovalAlertMock).not.toHaveBeenCalled();
   });
@@ -175,7 +175,7 @@ describe("createExecApprovalIosPushDelivery", () => {
 
     const accepted = await delivery.handleRequested(approvalRequest("approval-2"));
 
-    expect(accepted).toBe(true);
+    expect(accepted).toEqual({ delivered: true, attempted: true });
     expect(loadApnsRegistrationsMock).toHaveBeenCalledWith(["ios-device-1"]);
     expect(sendApnsExecApprovalAlertMock).toHaveBeenCalledTimes(1);
   });
@@ -216,7 +216,7 @@ describe("createExecApprovalIosPushDelivery", () => {
       isTargetVisible,
     });
 
-    expect(accepted).toBe(false);
+    expect(accepted).toEqual({ delivered: false, attempted: false });
     expect(isTargetVisible).toHaveBeenCalledWith({
       deviceId: "ios-device-1",
       scopes: ["operator.approvals", "operator.read"],
@@ -242,7 +242,7 @@ describe("createExecApprovalIosPushDelivery", () => {
 
     const accepted = await delivery.handleRequested(approvalRequest("approval-dead-route"));
 
-    expect(accepted).toBe(false);
+    expect(accepted).toEqual({ delivered: false, attempted: true });
     expect(sendApnsExecApprovalAlertMock).toHaveBeenCalledTimes(1);
     expect(warn).toHaveBeenCalledWith(
       "exec approvals: iOS request push failed node=ios-device-1 status=410 reason=Unregistered",

--- a/src/gateway/exec-approval-ios-push.ts
+++ b/src/gateway/exec-approval-ios-push.ts
@@ -362,7 +362,7 @@ export function createExecApprovalIosPushDelivery(params: { log: GatewayLikeLogg
     async handleRequested(
       request: ExecApprovalRequest,
       opts?: { isTargetVisible?: (target: ApprovalPushTarget) => boolean },
-    ): Promise<boolean> {
+    ): Promise<{ delivered: boolean; attempted: boolean }> {
       const deliveryStatePromise = (async (): Promise<ApprovalDeliveryState | null> => {
         const plan = await resolveDeliveryPlan({
           requireApprovalScope: true,
@@ -394,7 +394,7 @@ export function createExecApprovalIosPushDelivery(params: { log: GatewayLikeLogg
         pendingDeliveryStateById.delete(request.id);
       }
       if (!deliveryState) {
-        return false;
+        return { delivered: false, attempted: false };
       }
 
       const { attempted, delivered } = await deliveryState.requestPushPromise;
@@ -408,9 +408,9 @@ export function createExecApprovalIosPushDelivery(params: { log: GatewayLikeLogg
         ) {
           approvalDeliveriesById.delete(request.id);
         }
-        return false;
+        return { delivered: false, attempted: true };
       }
-      return true;
+      return { delivered: true, attempted: true };
     },
 
     /** Sends cleanup wakes for resolved approval requests. */

--- a/src/gateway/server-methods/approval-shared.test.ts
+++ b/src/gateway/server-methods/approval-shared.test.ts
@@ -325,6 +325,50 @@ describe("handlePendingApprovalRequest", () => {
     await requestPromise;
   });
 
+  it("expires turn-source approvals when explicit delivery fails", async () => {
+    const manager = new ExecApprovalManager();
+    const record = manager.create(
+      {
+        command: "echo ok",
+        turnSourceChannel: "slack",
+        turnSourceAccountId: "work",
+      },
+      60_000,
+      "approval-explicit-delivery-failed",
+    );
+    const decisionPromise = manager.register(record, 60_000);
+    const respond = vi.fn();
+
+    await handlePendingApprovalRequest({
+      manager,
+      record,
+      decisionPromise,
+      respond,
+      context: {
+        broadcast: vi.fn(),
+        hasExecApprovalClients: () => false,
+      } as unknown as GatewayRequestContext,
+      requestEventName: "exec.approval.requested",
+      requestEvent: {
+        id: record.id,
+        request: record.request,
+        createdAtMs: record.createdAtMs,
+        expiresAtMs: record.expiresAtMs,
+      },
+      twoPhase: true,
+      approvalKind: "exec",
+      deliverRequest: () => ({ delivered: false, attempted: true }),
+    });
+
+    expect(hasApprovalTurnSourceRouteMock).not.toHaveBeenCalled();
+    expect(manager.getSnapshot(record.id)?.resolvedBy).toBe("no-approval-route");
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ id: "approval-explicit-delivery-failed", decision: null }),
+      undefined,
+    );
+  });
+
   it("targets requested approval events to visible approval clients when available", async () => {
     const manager = new ExecApprovalManager();
     const record = manager.create(

--- a/src/gateway/server-methods/approval-shared.ts
+++ b/src/gateway/server-methods/approval-shared.ts
@@ -51,6 +51,13 @@ type RequestedApprovalEvent<TPayload extends ApprovalTurnSourceFields> = {
   expiresAtMs: number;
 };
 
+type ApprovalDeliveryResult =
+  | boolean
+  | {
+      delivered: boolean;
+      attempted?: boolean;
+    };
+
 type PendingApprovalListEntry<TPayload> = {
   id: string;
   request: TPayload;
@@ -82,6 +89,16 @@ type ApprovalRecordLookupResult<TPayload> =
 
 function isPromiseLike<T>(value: T | Promise<T>): value is Promise<T> {
   return typeof value === "object" && value !== null && "then" in value;
+}
+
+function normalizeApprovalDeliveryResult(result: ApprovalDeliveryResult): {
+  delivered: boolean;
+  attempted: boolean;
+} {
+  if (typeof result === "boolean") {
+    return { delivered: result, attempted: result };
+  }
+  return { delivered: result.delivered, attempted: result.attempted === true };
 }
 
 export function isApprovalDecision(value: string): value is ExecApprovalDecision {
@@ -394,7 +411,7 @@ export async function handlePendingApprovalRequest<
   requestEvent: RequestedApprovalEvent<TPayload>;
   twoPhase: boolean;
   approvalKind?: "exec" | "plugin";
-  deliverRequest: () => boolean | Promise<boolean>;
+  deliverRequest: () => ApprovalDeliveryResult | Promise<ApprovalDeliveryResult>;
   afterDecision?: (
     decision: ExecApprovalDecision | null,
     requestEvent: RequestedApprovalEvent<TPayload>,
@@ -433,12 +450,14 @@ export async function handlePendingApprovalRequest<
       ? approvalClientConnIds.size > 0
       : (params.context.hasExecApprovalClients?.(params.clientConnId) ?? false);
   const deliveredResult = suppressDelivery ? false : params.deliverRequest();
-  const delivered = isPromiseLike(deliveredResult) ? await deliveredResult : deliveredResult;
+  const delivery = normalizeApprovalDeliveryResult(
+    isPromiseLike(deliveredResult) ? await deliveredResult : deliveredResult,
+  );
   // A turn-source route can approve without an active approval client, so keep
-  // the record alive when the originating channel/account can still receive it.
+  // the record alive when no explicit delivery route was attempted.
   const hasTurnSourceRoute =
     !hasApprovalClients &&
-    !delivered &&
+    !delivery.attempted &&
     hasApprovalTurnSourceRoute({
       turnSourceChannel: params.record.request.turnSourceChannel,
       turnSourceAccountId: params.record.request.turnSourceAccountId,
@@ -450,7 +469,7 @@ export async function handlePendingApprovalRequest<
     !params.keepPendingWithoutRoute &&
     !hasApprovalClients &&
     !hasTurnSourceRoute &&
-    !delivered
+    !delivery.delivered
   ) {
     params.manager.expire(params.record.id, "no-approval-route");
     params.respond(

--- a/src/gateway/server-methods/exec-approval.ts
+++ b/src/gateway/server-methods/exec-approval.ts
@@ -52,16 +52,37 @@ const APPROVAL_ALLOW_ALWAYS_UNAVAILABLE_DETAILS = {
 } as const;
 const RESERVED_PLUGIN_APPROVAL_ID_PREFIX = "plugin:";
 
+type ApprovalDeliveryTaskResult = {
+  delivered: boolean;
+  attempted: boolean;
+};
+
+type ApprovalDeliveryHandlerResult =
+  | boolean
+  | {
+      delivered: boolean;
+      attempted?: boolean;
+    };
+
 type ExecApprovalIosPushDelivery = {
   handleRequested?: (
     request: ExecApprovalRequest,
     opts?: {
       isTargetVisible?: (target: { deviceId: string; scopes: readonly string[] }) => boolean;
     },
-  ) => Promise<boolean>;
+  ) => Promise<ApprovalDeliveryHandlerResult>;
   handleResolved?: (resolved: ExecApprovalResolved) => Promise<void>;
   handleExpired?: (request: ExecApprovalRequest) => Promise<void>;
 };
+
+function normalizeDeliveryTaskResult(
+  result: ApprovalDeliveryHandlerResult,
+): ApprovalDeliveryTaskResult {
+  if (typeof result === "boolean") {
+    return { delivered: result, attempted: result };
+  }
+  return { delivered: result.delivered, attempted: result.attempted === true };
+}
 
 function normalizeCommandSpans(
   spans: { startIndex: number; endIndex: number }[] | undefined,
@@ -354,15 +375,18 @@ export function createExecApprovalHandlers(
         requireDeliveryRoute: p.requireDeliveryRoute,
         suppressDelivery: p.suppressDelivery,
         deliverRequest: () => {
-          const deliveryTasks: Array<Promise<boolean>> = [];
+          const deliveryTasks: Array<Promise<ApprovalDeliveryTaskResult>> = [];
           if (opts?.forwarder) {
             deliveryTasks.push(
-              opts.forwarder.handleRequested(requestEvent).catch((err: unknown) => {
-                context.logGateway?.error?.(
-                  `exec approvals: forward request failed: ${String(err)}`,
-                );
-                return false;
-              }),
+              opts.forwarder
+                .handleRequested(requestEvent)
+                .then(normalizeDeliveryTaskResult)
+                .catch((err: unknown) => {
+                  context.logGateway?.error?.(
+                    `exec approvals: forward request failed: ${String(err)}`,
+                  );
+                  return { delivered: false, attempted: true };
+                }),
             );
           }
           if (opts?.iosPushDelivery?.handleRequested) {
@@ -381,23 +405,27 @@ export function createExecApprovalHandlers(
                       } as GatewayClient,
                     }),
                 })
+                .then(normalizeDeliveryTaskResult)
                 .catch((err: unknown) => {
                   context.logGateway?.error?.(
                     `exec approvals: iOS push request failed: ${String(err)}`,
                   );
-                  return false;
+                  return { delivered: false, attempted: true };
                 }),
             );
           }
           if (deliveryTasks.length === 0) {
-            return false;
+            return { delivered: false, attempted: false };
           }
           return (async () => {
             let delivered = false;
+            let attempted = false;
             for (const task of deliveryTasks) {
-              delivered = (await task) || delivered;
+              const result = await task;
+              delivered = result.delivered || delivered;
+              attempted = result.attempted || attempted;
             }
-            return delivered;
+            return { delivered, attempted };
           })();
         },
         afterDecision: async (decision) => {

--- a/src/gateway/server-methods/plugin-approval.test.ts
+++ b/src/gateway/server-methods/plugin-approval.test.ts
@@ -382,6 +382,41 @@ describe("createPluginApprovalHandlers", () => {
       }
     });
 
+    it("expires plugin approvals when explicit forwarding fails", async () => {
+      const forwarder = {
+        handleRequested: vi.fn(async () => false),
+        handleResolved: vi.fn(async () => {}),
+        handlePluginApprovalRequested: vi.fn(async () => {
+          throw new Error("plugin delivery failed");
+        }),
+        handlePluginApprovalResolved: vi.fn(async () => {}),
+        stop: vi.fn(),
+      };
+      const handlers = createPluginApprovalHandlers(manager, { forwarder });
+      const respond = vi.fn();
+      const opts = createMockOptions(
+        "plugin.approval.request",
+        {
+          title: "Sensitive action",
+          description: "Desc",
+          twoPhase: true,
+          turnSourceChannel: "slack",
+          turnSourceTo: "C123",
+        },
+        {
+          respond,
+          context: createApprovalContext({ hasExecApprovalClients: () => false }),
+        },
+      );
+
+      await handlers["plugin.approval.request"](opts);
+
+      expect(forwarder.handlePluginApprovalRequested).toHaveBeenCalledTimes(1);
+      const result = expectResponseOk(respond);
+      expect(result.decision).toBeNull();
+      expect(manager.getSnapshot(String(result.id))?.resolvedBy).toBe("no-approval-route");
+    });
+
     it.each(invalidRequestCases)("rejects $name", async ({ params }) => {
       const handlers = createPluginApprovalHandlers(manager);
       const opts = createMockOptions("plugin.approval.request", params);

--- a/src/gateway/server-methods/plugin-approval.ts
+++ b/src/gateway/server-methods/plugin-approval.ts
@@ -125,15 +125,16 @@ export function createPluginApprovalHandlers(
         approvalKind: "plugin",
         deliverRequest: () => {
           if (!opts?.forwarder?.handlePluginApprovalRequested) {
-            return false;
+            return { delivered: false, attempted: false };
           }
           return opts.forwarder
             .handlePluginApprovalRequested(requestEvent)
+            .then((delivered) => ({ delivered, attempted: delivered }))
             .catch((err: unknown) => {
               context.logGateway?.error?.(
                 `plugin approvals: forward request failed: ${String(err)}`,
               );
-              return false;
+              return { delivered: false, attempted: true };
             });
         },
       });

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -3438,6 +3438,47 @@ describe("exec approval handlers", () => {
     }
   });
 
+  it("expires approvals when explicit exec forwarding fails", async () => {
+    const { manager, handlers, forwarder, respond, context } =
+      createForwardingExecApprovalFixture();
+    const expireSpy = vi.spyOn(manager, "expire");
+    let rejectDelivery: (err: Error) => void = () => {};
+    forwarder.handleRequested.mockReturnValueOnce(
+      new Promise<boolean>((_, reject) => {
+        rejectDelivery = reject;
+      }),
+    );
+
+    const requestPromise = requestExecApproval({
+      handlers,
+      respond,
+      context,
+      params: {
+        twoPhase: true,
+        timeoutMs: 60_000,
+        id: "approval-forwarding-failed",
+        host: "gateway",
+        turnSourceChannel: "slack",
+        turnSourceTo: "D123",
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(forwarder.handleRequested).toHaveBeenCalledTimes(1);
+    });
+
+    rejectDelivery(new Error("approval delivery failed"));
+    await requestPromise;
+
+    expect(expireSpy).toHaveBeenCalledWith("approval-forwarding-failed", "no-approval-route");
+    expect(lastMockCallArg(respond)).toBe(true);
+    expectRecordFields(lastMockCallArg(respond, 1), {
+      id: "approval-forwarding-failed",
+      decision: null,
+    });
+    expect(lastMockCallArg(respond, 2)).toBeUndefined();
+  });
+
   it("keeps approvals pending when the originating chat can handle /approve directly", async () => {
     vi.useFakeTimers();
     try {

--- a/src/infra/exec-approval-forwarder.test.ts
+++ b/src/infra/exec-approval-forwarder.test.ts
@@ -423,6 +423,89 @@ describe("exec approval forwarder", () => {
     expect(deliver).toHaveBeenCalledTimes(2);
   });
 
+  it("reports request delivery failure when all approval targets fail", async () => {
+    vi.useFakeTimers();
+    const deliver = vi.fn().mockResolvedValue({
+      status: "failed",
+      error: new Error("Outbound not configured for channel: discord"),
+    });
+    const { forwarder } = createForwarder({
+      cfg: makeTargetsCfg([{ channel: "discord", to: "channel:123" }]),
+      deliver,
+    });
+
+    await expect(forwarder.handleRequested(baseRequest)).rejects.toThrow(
+      "exec approvals: failed to deliver request req-1",
+    );
+    expect(deliver).toHaveBeenCalledTimes(1);
+
+    await forwarder.handleResolved({
+      id: baseRequest.id,
+      decision: "allow-once",
+      resolvedBy: "discord:channel:123",
+      ts: 2000,
+    });
+    await vi.advanceTimersByTimeAsync(baseRequest.expiresAtMs - baseRequest.createdAtMs);
+    expect(deliver).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps approval pending when at least one request target delivers", async () => {
+    vi.useFakeTimers();
+    const deliver = vi
+      .fn()
+      .mockResolvedValueOnce({
+        status: "failed",
+        error: new Error("first target failed"),
+      })
+      .mockResolvedValue([]);
+    const { forwarder } = createForwarder({
+      cfg: makeTargetsCfg([
+        { channel: "discord", to: "channel:123" },
+        { channel: "slack", to: "U123" },
+      ]),
+      deliver,
+    });
+
+    await expect(forwarder.handleRequested(baseRequest)).resolves.toBe(true);
+    expect(deliver).toHaveBeenCalledTimes(2);
+
+    await forwarder.handleResolved({
+      id: baseRequest.id,
+      decision: "allow-once",
+      resolvedBy: "slack:U123",
+      ts: 2000,
+    });
+    expect(deliver).toHaveBeenCalledTimes(4);
+  });
+
+  it("keeps approval pending when partial_failed includes visible delivery results", async () => {
+    vi.useFakeTimers();
+    const deliver = vi
+      .fn()
+      .mockResolvedValueOnce({
+        status: "partial_failed",
+        results: [{ ok: true }],
+        error: new Error("later payload failed"),
+        sentBeforeError: true,
+      })
+      .mockResolvedValue([]);
+    const { forwarder } = createForwarder({
+      cfg: TARGETS_CFG,
+      deliver,
+    });
+
+    await expect(forwarder.handleRequested(baseRequest)).resolves.toBe(true);
+    expect(deliver).toHaveBeenCalledTimes(1);
+
+    await forwarder.handleResolved({
+      id: baseRequest.id,
+      decision: "allow-once",
+      resolvedBy: "slack:U123",
+      ts: 2000,
+    });
+    expect(deliver).toHaveBeenCalledTimes(2);
+  });
+
   it("deduplicates session and explicit approval targets through normalized route identity", async () => {
     vi.useFakeTimers();
     const cfg = {

--- a/src/infra/exec-approval-forwarder.test.ts
+++ b/src/infra/exec-approval-forwarder.test.ts
@@ -449,6 +449,33 @@ describe("exec approval forwarder", () => {
     expect(deliver).toHaveBeenCalledTimes(1);
   });
 
+  it("reports request delivery failure when all approval targets are suppressed", async () => {
+    vi.useFakeTimers();
+    const deliver = vi.fn().mockResolvedValue({
+      status: "suppressed",
+      results: [],
+      reason: "no_visible_result",
+    });
+    const { forwarder } = createForwarder({
+      cfg: makeTargetsCfg([{ channel: "slack", to: "U-suppressed" }]),
+      deliver,
+    });
+
+    await expect(forwarder.handleRequested(baseRequest)).rejects.toThrow(
+      "exec approvals: failed to deliver request req-1",
+    );
+    expect(deliver).toHaveBeenCalledTimes(1);
+
+    await forwarder.handleResolved({
+      id: baseRequest.id,
+      decision: "allow-once",
+      resolvedBy: "slack:U-suppressed",
+      ts: 2000,
+    });
+    await vi.advanceTimersByTimeAsync(baseRequest.expiresAtMs - baseRequest.createdAtMs);
+    expect(deliver).toHaveBeenCalledTimes(1);
+  });
+
   it("keeps approval pending when at least one request target delivers", async () => {
     vi.useFakeTimers();
     const deliver = vi

--- a/src/infra/exec-approval-forwarder.ts
+++ b/src/infra/exec-approval-forwarder.ts
@@ -404,6 +404,9 @@ async function deliverToTargets(params: {
         }
         throw send.error instanceof Error ? send.error : new Error(String(send.error));
       }
+      if (send.status === "suppressed") {
+        return { attempted: true, delivered: false, failed: false };
+      }
       return { attempted: true, delivered: true, failed: false };
     } catch (err) {
       log.error(`exec approvals: failed to deliver to ${channel}:${target.to}: ${String(err)}`);
@@ -661,7 +664,7 @@ function createApprovalHandlers<
         pending.delete(requestId);
         clearTimeout(timeoutId);
       }
-      if (delivery.attempted > 0 && delivery.failed > 0) {
+      if (delivery.attempted > 0) {
         throw new Error(
           `${params.strategy.kind} approvals: failed to deliver request ${requestId}`,
         );

--- a/src/infra/exec-approval-forwarder.ts
+++ b/src/infra/exec-approval-forwarder.ts
@@ -59,6 +59,12 @@ type ResolveSessionTargetFn = (params: {
 type ApprovalKind = "exec" | "plugin";
 type ForwardTarget = ExecApprovalForwardTarget & { source: "session" | "target" };
 
+type DeliverySummary = {
+  attempted: number;
+  delivered: number;
+  failed: number;
+};
+
 type ApprovalRouteRequest = {
   agentId?: string | null;
   sessionKey?: string | null;
@@ -369,14 +375,14 @@ async function deliverToTargets(params: {
   deliver: DeliverApprovalPayloads;
   beforeDeliver?: (target: ForwardTarget, payload: ReplyPayload) => Promise<void> | void;
   shouldSend?: () => boolean;
-}) {
+}): Promise<DeliverySummary> {
   const deliveries = params.targets.map(async (target) => {
     if (params.shouldSend && !params.shouldSend()) {
-      return;
+      return { attempted: false, delivered: false, failed: false };
     }
     const channel = normalizeMessageChannel(target.channel) ?? target.channel;
     if (!isDeliverableMessageChannel(channel)) {
-      return;
+      return { attempted: false, delivered: false, failed: false };
     }
     try {
       const payload = params.buildPayload(target);
@@ -389,14 +395,30 @@ async function deliverToTargets(params: {
         threadId: target.threadId,
         payloads: [payload],
       });
-      if (send.status === "failed" || send.status === "partial_failed") {
-        throw send.error;
+      if (send.status === "failed") {
+        throw send.error instanceof Error ? send.error : new Error(String(send.error));
       }
+      if (send.status === "partial_failed") {
+        if (send.results.length > 0) {
+          return { attempted: true, delivered: true, failed: true };
+        }
+        throw send.error instanceof Error ? send.error : new Error(String(send.error));
+      }
+      return { attempted: true, delivered: true, failed: false };
     } catch (err) {
       log.error(`exec approvals: failed to deliver to ${channel}:${target.to}: ${String(err)}`);
+      return { attempted: true, delivered: false, failed: true };
     }
   });
-  await Promise.allSettled(deliveries);
+  const results = await Promise.all(deliveries);
+  return results.reduce(
+    (summary, result) => ({
+      attempted: summary.attempted + (result.attempted ? 1 : 0),
+      delivered: summary.delivered + (result.delivered ? 1 : 0),
+      failed: summary.failed + (result.failed ? 1 : 0),
+    }),
+    { attempted: 0, delivered: 0, failed: 0 },
+  );
 }
 
 function buildApprovalRenderPayload<TParams>(params: {
@@ -604,7 +626,7 @@ function createApprovalHandlers<
       return false;
     }
 
-    void deliverToTargets({
+    const delivery = await deliverToTargets({
       cfg,
       targets: filteredTargets,
       buildPayload: (target) =>
@@ -632,11 +654,20 @@ function createApprovalHandlers<
       },
       deliver: params.deliver,
       shouldSend: () => pending.get(requestId) === pendingEntry,
-    }).catch((err: unknown) => {
-      log.error(
-        `${params.strategy.kind} approvals: failed to deliver request ${requestId}: ${String(err)}`,
-      );
     });
+    if (delivery.delivered === 0) {
+      const entry = pending.get(requestId);
+      if (entry === pendingEntry) {
+        pending.delete(requestId);
+        clearTimeout(timeoutId);
+      }
+      if (delivery.attempted > 0 && delivery.failed > 0) {
+        throw new Error(
+          `${params.strategy.kind} approvals: failed to deliver request ${requestId}`,
+        );
+      }
+      return false;
+    }
     return true;
   };
 


### PR DESCRIPTION
Fixes #89217.

## Summary
- Track explicit exec/plugin approval delivery attempts separately from successful delivery.
- Surface configured delivery failures as no-route approval responses instead of silently falling back to turn-source routing.
- Add regression coverage for shared approval routing, gateway handler behavior, forwarder all-target failure/suppression handling, and iOS push attempted/delivered accounting.

## Root Cause
- **Fix classification:** Root-cause gateway approval delivery failure handling bug fix.
- **Maintainer-ready confidence:** High. The patch stays inside the approval request delivery path and preserves existing fallback behavior only when no explicit delivery route was attempted.
- **Root cause:** The approval request flow only knew whether a delivery succeeded. A configured explicit target that failed delivery was indistinguishable from “no explicit route attempted”, so the handler could fall back to turn-source routing and leave the approval waiting silently.
- **Why this is root-cause fix:** The shared approval source of truth now carries both `delivered` and `attempted`; turn-source fallback is only allowed when no explicit delivery was attempted. Forwarders now throw when every configured target was attempted but produced zero visible deliveries, including failed and suppressed sends, and gateway handlers convert that into an attempted failed delivery.
- **Patch quality notes:** The diff is limited to exec/plugin approval delivery and focused regression tests; no public protocol/schema/default config changes.

## Real behavior proof
- **Behavior or issue addressed:** Configured exec approval delivery failures now surface immediately instead of being treated like an undelivered optional route that can fall back to turn-source waiting.
- **Real environment tested:** Linux local checkout on current `origin/main`, Node v22.22.0, pnpm 11.2.2, production TypeScript modules loaded through `node --import tsx`, with an isolated OpenClaw config file.
- **Exact steps or command run after this patch:**
```bash
cd /media/vdc/code/ai/aispace/openclaw-worktrees/pr-91481
OPENCLAW_CONFIG_PATH=/media/vdc/code/ai/aispace/openclaw-pr-91481-evidence/proof-openclaw-config.json \
  OPENCLAW_STATE_DIR=/media/vdc/code/ai/aispace/openclaw-pr-91481-evidence/proof-state \
  OPENCLAW_TEST_FAST=1 \
  node --import tsx /media/vdc/code/ai/aispace/openclaw-pr-91481-evidence/local-approval-delivery-proof.mjs
```
- **Evidence after fix:**
```json
{
  "issue": 89217,
  "proof": "production gateway approval delivery failure behavior",
  "scenarios": {
    "sharedFallbackComparison": {
      "fallbackWithoutExplicitAttempt": {
        "firstResponse": "accepted",
        "remainedPendingBeforeDecision": true,
        "finalDecision": "deny"
      },
      "explicitAttemptFailure": {
        "responseDecision": null,
        "resolvedBy": "no-approval-route",
        "finalResponseCount": 1
      }
    },
    "gatewayHandlerFailure": {
      "responseDecision": null,
      "resolvedBy": "no-approval-route",
      "loggedErrorPrefix": "exec approvals: forward request failed"
    },
    "forwarderAllTargetFailure": {
      "attemptedTargets": 1,
      "failedTarget": {
        "channel": "slack",
        "to": "U-proof",
        "count": 1
      },
      "surfacedError": "exec approvals: failed to deliver request proof-forwarder-request"
    },
    "forwarderAllTargetSuppressed": {
      "attemptedTargets": 1,
      "suppressedTarget": {
        "channel": "slack",
        "to": "U-suppressed",
        "count": 1
      },
      "surfacedError": "exec approvals: failed to deliver request proof-forwarder-suppressed-request"
    }
  },
  "result": "passed"
}
```
- **Observed result after fix:** A turn-source fallback remains pending when no explicit delivery was attempted, but an explicit attempted failure resolves the approval with `decision: null` and `resolvedBy: "no-approval-route"`; the production forwarder rejects when all configured targets fail or are suppressed before producing a visible message.
- **What was not tested:** No live Slack/Discord/Telegram/iOS APNs delivery was sent; the proof injects a local failed delivery result at the durable-message boundary to exercise production gateway/forwarder behavior without external channel credentials.

## Tests
- **Target test file:** `src/gateway/server-methods/approval-shared.test.ts`, `src/gateway/server-methods/plugin-approval.test.ts`, `src/gateway/server-methods/server-methods.test.ts`, `src/infra/exec-approval-forwarder.test.ts`, `src/gateway/exec-approval-ios-push.test.ts`.
- **Scenario locked in:** Explicit attempted failures expire no-route instead of falling back; all-target forwarder failures and suppressed sends throw; partial success remains accepted; iOS attempted/no-device accounting is surfaced.
- **Why this is the smallest reliable guardrail:** These tests pin the shared handler, concrete gateway methods, forwarder, and iOS delivery adapter at the boundaries where the attempted/delivered distinction is consumed.
- **Exact commands run:**
```bash
corepack pnpm@11.2.2 --dir /media/vdc/code/ai/aispace/openclaw-worktrees/pr-91481 exec vitest run src/gateway/server-methods/approval-shared.test.ts src/gateway/server-methods/plugin-approval.test.ts src/gateway/server-methods/server-methods.test.ts src/infra/exec-approval-forwarder.test.ts src/gateway/exec-approval-ios-push.test.ts --reporter=dot
corepack pnpm@11.2.2 --dir /media/vdc/code/ai/aispace/openclaw-worktrees/pr-91481 exec oxfmt --check --threads=1 src/gateway/exec-approval-ios-push.test.ts src/gateway/exec-approval-ios-push.ts src/gateway/server-methods/approval-shared.test.ts src/gateway/server-methods/approval-shared.ts src/gateway/server-methods/exec-approval.ts src/gateway/server-methods/plugin-approval.test.ts src/gateway/server-methods/plugin-approval.ts src/gateway/server-methods/server-methods.test.ts src/infra/exec-approval-forwarder.test.ts src/infra/exec-approval-forwarder.ts
corepack pnpm@11.2.2 --dir /media/vdc/code/ai/aispace/openclaw-worktrees/pr-91481 exec oxlint --deny-warnings src/gateway/exec-approval-ios-push.test.ts src/gateway/exec-approval-ios-push.ts src/gateway/server-methods/approval-shared.test.ts src/gateway/server-methods/approval-shared.ts src/gateway/server-methods/exec-approval.ts src/gateway/server-methods/plugin-approval.test.ts src/gateway/server-methods/plugin-approval.ts src/gateway/server-methods/server-methods.test.ts src/infra/exec-approval-forwarder.test.ts src/infra/exec-approval-forwarder.ts
OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false corepack pnpm@11.2.2 --dir /media/vdc/code/ai/aispace/openclaw-worktrees/pr-91481 check:changed
git -C /media/vdc/code/ai/aispace/openclaw-worktrees/pr-91481 diff --check
```
- **Observed test result after fix:** Targeted Vitest passed 9 files / 288 tests; `oxfmt --check` passed on all 10 changed files; `oxlint --deny-warnings` passed on all changed files; `git diff --check` passed; local child-mode `check:changed` passed core lanes including core typecheck, core test typecheck, core lint, import-cycle guard, dependency guards, and changed-file architecture checks.

## Review findings addressed
- **RF-001 status: waiting on author:** Addressed by the focused suppressed-send repair below; expected to clear after bot re-review because the PR now includes the requested code/test/proof update.
- **RF-002 suppressed delivery classification:** Fixed. Durable `status: "suppressed"` now counts as `attempted: true` and `delivered: false`, and all-target suppressed delivery has a regression test.
- **RF-003 compatibility-sensitive fallback change:** Disclosed and bounded. The intentional behavior change still applies only after an explicit configured delivery route was attempted; the no-explicit-route turn-source fallback remains unchanged.
- **RF-004 suppressed-send silent pending gap:** Fixed. A configured target that suppresses every visible approval prompt now surfaces the same delivery failure path instead of leaving the approval pending.
- **RF-005 focused repair shape:** Fixed with a narrow forwarder-only code change plus adjacent test coverage; no API, schema, config default, or channel adapter expansion.
- **RF-006 `src/infra/exec-approval-forwarder.ts:407`:** Fixed by classifying suppressed sends before the generic delivered fall-through and by throwing when attempted delivery produces zero visible deliveries.
- **RF-007 requested Vitest coverage:** Fixed. Targeted approval suite passed 9 files / 288 tests in the PR repair worktree.
- **RF-008 whitespace check:** Fixed. `git -C /media/vdc/code/ai/aispace/openclaw-worktrees/pr-91481 diff --check` passed with no output.

## Risk / Scope
- **Why it matters / User impact:** Explicit approval targets that fail delivery no longer leave operator commands waiting silently on an unintended fallback path.
- **What did NOT change:** No approval protocol schema, public config shape, default approval mode, decision enum, command execution semantics, or live channel credentials changed.
- **Architecture / source-of-truth check:** The attempted/delivered decision is handled in shared approval routing and concrete delivery adapters, not downstream string matching or per-channel special cases.
- **Risk labels considered:** `merge-risk: 🚨 message-delivery`, `merge-risk: 🚨 availability`.
- **Risk explanation:** The patch changes approval request routing when explicit delivery fails, but only after a configured delivery path was actually attempted and failed.
- **Why acceptable:** The old fallback behavior remains intact for the “no explicit route attempted” case, while failed configured routes are surfaced so callers do not wait silently.
