### PR TITLE
docs: link maturity scorecard docs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -118,6 +118,7 @@
       - any-glob-to-any-file:
           - "extensions/qa-lab/**"
           - "qa/scenarios/**"
+          - "docs/maturity/**"
           - "docs/concepts/qa-e2e-automation.md"
           - "docs/concepts/personal-agent-benchmark-pack.md"
           - "docs/channels/qa-channel.md"

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -24,6 +24,14 @@ This directory owns docs authoring, Mintlify link rules, and docs i18n policy.
 - `scripts/docs-sync-publish.mjs` excludes and prunes `docs/internal/**` from the public `openclaw/docs` publish repo if a page is force-added later.
 - Internal docs may mention repo paths, private app names, 1Password item names, and runbooks, but never include secret values.
 
+## Maturity Scorecard Editing
+
+`taxonomy.yaml` and `qa/maturity-scores.yaml` are the source inputs; generated maturity docs under `docs/maturity/` are projections and should not be hand-edited for score, LTS, taxonomy, QA profile, or evidence tables.
+`scripts/qa/render-maturity-docs.ts` owns generation; use `pnpm maturity:render` to refresh committed docs and `pnpm maturity:check` to verify them.
+`.github/workflows/maturity-scorecard.yml` renders artifact previews and can open generated-doc PRs; `.github/workflows/openclaw-release-checks.yml` dispatches it for release QA.
+Keep deterministic `qa-evidence.json.scorecard` data in GitHub Actions artifacts unless a maintainer explicitly asks for a sanitized committed projection.
+Human overrides must change source state in a PR and explain the reason plus public or redacted evidence.
+
 ## Docs i18n
 
 - Foreign-language docs are not maintained in this repo. The generated publish output lives in the separate `openclaw/docs` repo (often cloned locally as `../openclaw-docs`).

--- a/docs/concepts/qa-e2e-automation.md
+++ b/docs/concepts/qa-e2e-automation.md
@@ -966,6 +966,7 @@ output and whose artifact paths are resolved relative to that producer
 `qa run --qa-profile`, the same `qa-evidence.json` also includes the profile
 scorecard summary for the selected taxonomy categories.
 Treat it as a discovery aid, not a gate replacement; the selected scenario still needs the right provider mode, live transport, Multipass, Testbox, or release lane for the behavior under test.
+For scorecard context, see [Maturity scorecard](/maturity/scorecard).
 
 For character and style checks, run the same scenario across multiple live model
 refs and write a judged Markdown report:
@@ -1023,6 +1024,7 @@ When no `--judge-model` is passed, the judges default to
 ## Related docs
 
 - [Matrix QA](/concepts/qa-matrix)
+- [Maturity scorecard](/maturity/scorecard)
 - [Personal agent benchmark pack](/concepts/personal-agent-benchmark-pack)
 - [QA Channel](/channels/qa-channel)
 - [Testing](/help/testing)

--- a/docs/help/testing.md
+++ b/docs/help/testing.md
@@ -20,6 +20,7 @@ of Docker runners. This doc is a "how we test" guide:
 
 - [QA overview](/concepts/qa-e2e-automation) - architecture, command surface, scenario authoring.
 - [Matrix QA](/concepts/qa-matrix) - reference for `pnpm openclaw qa matrix`.
+- [Maturity scorecard](/maturity/scorecard) - how release QA evidence supports stability and LTS decisions.
 - [QA channel](/channels/qa-channel) - the synthetic transport plugin used by repo-backed scenarios.
 
 This page covers running the regular test suites and Docker/Parallels runners. The QA-specific runners section below ([QA-specific runners](#qa-specific-runners)) lists the concrete `qa` invocations and points back at the references above.


### PR DESCRIPTION
## What Problem This Solves

PR #91483 had drifted into maturity docs navigation that now conflicts with the generated maturity scorecard pages on `main`. This update keeps the useful scorecard cross-links and removes the stale `/reference/maturity-tests` route, top-tab navigation, and renderer-output change.

## Why This Change Was Made

- rebase the PR branch onto current `main`
- keep the generated `docs/maturity/scorecard.md` and `docs/maturity/taxonomy.md` pages as the maturity docs reader path
- remove the now-conflicting `reference/maturity-tests` page and all links to it
- keep QA/testing docs pointed directly at the maturity scorecard
- keep labeler ownership aligned with `docs/maturity/**`
- point `docs/AGENTS.md` at the real maturity sources, generator script, local render/check commands, and GitHub Actions workflows that render or dispatch generated scorecard docs

## User Impact

Docs readers get direct links to the maturity scorecard from QA and testing docs without a duplicate maturity explainer route. Agents editing docs get the right source files, generator command, and workflow owners for maturity scorecard changes. No runtime behavior, QA score values, taxonomy source data, generated maturity docs, or release evidence artifacts change in this PR.

## Evidence

- `pnpm docs:list | rg -i 'maturity|AGENTS'`
- `pnpm docs:check-mdx`
- `git diff --check origin/main...HEAD`
- `pnpm docs:check-links`
- `pnpm docs:check-i18n-glossary`
- `pnpm maturity:check`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
