### PR TITLE
fix(windows): verify scheduled task launch source

### DIFF
--- a/src/daemon/schtasks.install.test.ts
+++ b/src/daemon/schtasks.install.test.ts
@@ -13,6 +13,13 @@ const schtasksResponses: { code: number; stdout: string; stderr: string }[] = []
 // `finally` block deletes the temp file. Indexed by the position in
 // `schtasksCalls` so individual tests can pin which create-call they assert on.
 const xmlPayloadCaptures: Array<{ index: number; xml: string }> = [];
+const childUnref = vi.hoisted(() => vi.fn());
+const spawn = vi.hoisted(() => vi.fn(() => ({ unref: childUnref })));
+
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return { ...actual, spawn };
+});
 
 vi.mock("./schtasks-exec.js", () => ({
   execSchtasks: async (argv: string[]) => {
@@ -39,6 +46,9 @@ beforeEach(() => {
   schtasksCalls.length = 0;
   schtasksResponses.length = 0;
   xmlPayloadCaptures.length = 0;
+  childUnref.mockReset();
+  spawn.mockReset();
+  spawn.mockImplementation(() => ({ unref: childUnref }));
 });
 
 describe("installScheduledTask", () => {

--- a/src/daemon/schtasks.startup-fallback.test.ts
+++ b/src/daemon/schtasks.startup-fallback.test.ts
@@ -384,6 +384,18 @@ describe("Windows startup fallback", () => {
     });
   });
 
+  it("does not treat an unrelated gateway listener as Scheduled Task launch evidence", async () => {
+    await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
+      fastForwardTaskStartWait();
+      findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([4242]);
+      addAcceptedRunNeverStartsResponses();
+
+      await installGatewayScheduledTask(env);
+
+      expectStartupFallbackSpawn();
+    });
+  });
+
   it("does not treat a gateway listener as node Scheduled Task launch evidence", async () => {
     await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
       fastForwardTaskStartWait();

--- a/src/daemon/schtasks.stop.test.ts
+++ b/src/daemon/schtasks.stop.test.ts
@@ -20,6 +20,31 @@ const sleepMock = vi.hoisted(() =>
     timeState.now += ms;
   }),
 );
+const childUnref = vi.hoisted(() => vi.fn());
+const spawn = vi.hoisted(() => vi.fn(() => ({ unref: childUnref })));
+type SpawnSyncResult = {
+  pid: number;
+  output: (string | null)[];
+  stdout: string;
+  stderr: string;
+  status: number;
+  signal: null;
+};
+const spawnSync = vi.hoisted(() =>
+  vi.fn<(command: string, args?: readonly string[]) => SpawnSyncResult>(() => ({
+    pid: 0,
+    output: [null, "", ""],
+    stdout: "",
+    stderr: "",
+    status: 0,
+    signal: null,
+  })),
+);
+
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return { ...actual, spawn, spawnSync };
+});
 
 vi.mock("../infra/gateway-processes.js", () => ({
   findVerifiedGatewayListenerPidsOnPortSync: (port: number) =>
@@ -91,10 +116,37 @@ async function withPreparedGatewayTask(
   });
 }
 
+/** Schtasks query output representing a completed task (not "not-yet-run").
+ *  Makes readLaunchObservation return { state: "other" } so the poll loop
+ *  is skipped, matching the old readScheduledTaskRuntime behavior for empty
+ *  queries on non-Windows mocks. */
+function completedTaskQueryOutput(taskName = "OpenClaw Gateway") {
+  return [
+    `HostName: TEST-HOST`,
+    `TaskName: \\${taskName}`,
+    "Status: Ready",
+    "Last Run Time: 6/9/2026 10:00:00 AM",
+    "Last Run Result: 0",
+    "",
+  ].join("\r\n");
+}
+
 beforeEach(() => {
   resetSchtasksBaseMocks();
   findVerifiedGatewayListenerPidsOnPortSync.mockReset();
   findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([]);
+  childUnref.mockReset();
+  spawn.mockReset();
+  spawn.mockImplementation(() => ({ unref: childUnref }));
+  spawnSync.mockReset();
+  spawnSync.mockImplementation(() => ({
+    pid: 0,
+    output: [null, "", ""],
+    stdout: "",
+    stderr: "",
+    status: 0,
+    signal: null,
+  }));
   timeState.now = 0;
   vi.spyOn(Date, "now").mockImplementation(() => timeState.now);
   sleepMock.mockReset();
@@ -192,7 +244,13 @@ describe("Scheduled Task stop/restart cleanup", () => {
 
   it("kills lingering verified gateway listeners and waits for port release before restart", async () => {
     await withPreparedGatewayTask(async ({ env, stdout }) => {
-      pushSuccessfulSchtasksResponses(4);
+      schtasksResponses.push(
+        { code: 0, stdout: "", stderr: "" },
+        { code: 0, stdout: "", stderr: "" },
+        { code: 0, stdout: "", stderr: "" },
+        { code: 0, stdout: "", stderr: "" },
+        { code: 0, stdout: completedTaskQueryOutput(), stderr: "" },
+      );
       findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([5151]);
       inspectPortUsage
         .mockResolvedValueOnce(busyPortUsage(5151))
@@ -210,7 +268,6 @@ describe("Scheduled Task stop/restart cleanup", () => {
         ["/Query", "/TN", "OpenClaw Gateway"],
         ["/End", "/TN", "OpenClaw Gateway"],
         ["/Run", "/TN", "OpenClaw Gateway"],
-        ["/Query"],
         ["/Query", "/TN", "OpenClaw Gateway", "/V", "/FO", "LIST"],
       ]);
     });
@@ -218,7 +275,13 @@ describe("Scheduled Task stop/restart cleanup", () => {
 
   it("does not wait on or force-kill the gateway port when restarting a node Scheduled Task", async () => {
     await withPreparedGatewayTask(async ({ env, stdout }) => {
-      pushSuccessfulSchtasksResponses(4);
+      schtasksResponses.push(
+        { code: 0, stdout: "", stderr: "" },
+        { code: 0, stdout: "", stderr: "" },
+        { code: 0, stdout: "", stderr: "" },
+        { code: 0, stdout: "", stderr: "" },
+        { code: 0, stdout: completedTaskQueryOutput("OpenClaw Node"), stderr: "" },
+      );
       env.OPENCLAW_SERVICE_KIND = "node";
       env.OPENCLAW_WINDOWS_TASK_NAME = "OpenClaw Node";
       findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([5151]);
@@ -236,7 +299,6 @@ describe("Scheduled Task stop/restart cleanup", () => {
         ["/Query", "/TN", "OpenClaw Node"],
         ["/End", "/TN", "OpenClaw Node"],
         ["/Run", "/TN", "OpenClaw Node"],
-        ["/Query"],
         ["/Query", "/TN", "OpenClaw Node", "/V", "/FO", "LIST"],
       ]);
     });

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -1025,30 +1025,34 @@ async function shouldFallbackScheduledTaskLaunch(params: {
     state: "running" | "not-yet-run" | "other";
     signature: string;
   }> => {
-    const runtime = await readScheduledTaskRuntime(params.env).catch(() => null);
-    if (runtime?.status === "running") {
-      return {
-        state: "running",
-        signature: [runtime.state, runtime.lastRunTime, runtime.lastRunResult, runtime.detail]
-          .filter(Boolean)
-          .join("|"),
-      };
+    const taskName = resolveTaskName(params.env);
+    const res = await execSchtasks(["/Query", "/TN", taskName, "/V", "/FO", "LIST"]);
+    if (res.code !== 0) {
+      const detail = (res.stderr || res.stdout).trim();
+      return { state: "other", signature: detail };
     }
-    const normalizedResult = normalizeTaskResultCode(runtime?.lastRunResult);
+    const parsed = parseSchtasksQuery(res.stdout || "");
+    const derived = deriveScheduledTaskRuntimeStatus(parsed);
+    const signature = [parsed.status, parsed.lastRunTime, parsed.lastRunResult, derived.detail]
+      .filter(Boolean)
+      .join("|");
+    if (!parsed.status && !parsed.lastRunTime && !parsed.lastRunResult) {
+      return { state: "not-yet-run", signature: "not-yet-run" };
+    }
+    if (derived.status === "running") {
+      return { state: "running", signature };
+    }
+    const normalizedResult = normalizeTaskResultCode(parsed.lastRunResult);
     if (normalizedResult && NOT_YET_RUN_RESULT_CODES.has(normalizedResult)) {
+      const defaultNeverRunTime = normalizeLowercaseStringOrEmpty(parsed.lastRunTime).includes(
+        "11/30/1999",
+      );
       return {
         state: "not-yet-run",
-        signature: [runtime?.state, runtime?.lastRunTime, runtime?.lastRunResult, runtime?.detail]
-          .filter(Boolean)
-          .join("|"),
+        signature: !parsed.lastRunTime || defaultNeverRunTime ? "not-yet-run" : signature,
       };
     }
-    return {
-      state: "other",
-      signature: [runtime?.state, runtime?.lastRunTime, runtime?.lastRunResult, runtime?.detail]
-        .filter(Boolean)
-        .join("|"),
-    };
+    return { state: "other", signature };
   };
 
   const hasLaunchEvidence = async (): Promise<boolean> => {
@@ -1059,12 +1063,6 @@ async function shouldFallbackScheduledTaskLaunch(params: {
       parsePositivePort(command?.environment?.OPENCLAW_GATEWAY_PORT) ??
       resolveConfiguredGatewayPort(params.env);
     const manageGatewayPort = shouldManageGatewayListenerPort(params.env);
-    if (manageGatewayPort && taskPort) {
-      const listenerPids = await resolveScheduledTaskGatewayListenerPids(taskPort);
-      if (listenerPids.length > 0) {
-        return true;
-      }
-    }
 
     const scriptPathNeedle = normalizeLowercaseStringOrEmpty(
       params.scriptPath.replaceAll("/", "\\"),


### PR DESCRIPTION
## Summary

Fix Windows Scheduled Task launch verification so an unrelated foreground gateway listener on the same port no longer counts as evidence that the managed Scheduled Task started.

## Changes

- Query raw `schtasks /Query /TN ... /V /FO LIST` state inside the launch fallback decision instead of reusing listener-backed runtime status.
- Stop treating arbitrary gateway listener PIDs on the configured port as Scheduled Task launch evidence.
- Normalize empty/default never-run Task Scheduler observations as stable `not-yet-run`, while still respecting real Last Run Time/status changes as launch progress.
- Add regression coverage for the reported case: foreground listener exists, `/Run` is accepted, task never starts, fallback launcher still runs.

## Real behavior proof

Behavior or issue addressed: After the fix, Windows gateway install/start/restart launch verification distinguishes Scheduled Task/script evidence from an unrelated foreground gateway listener, so an already-running foreground `openclaw gateway` listener cannot suppress the fallback launcher when `schtasks /Run` accepts but the task never starts.
Real environment tested: Repository `openclaw/openclaw`, worktree `/datad/github/openclaw-issue91144`, branch `fix/windows-scheduled-task-launch-proof`, commit `d184b5c38b66`, on Linux host running the project's daemon test suite with mocked Windows `schtasks`/process APIs.
Exact steps or command run after this patch:
```shell
git diff --check
pnpm exec oxlint src/daemon/schtasks.ts src/daemon/schtasks.startup-fallback.test.ts
OPENCLAW_TEST_FAST=1 node scripts/test-projects.mjs src/daemon/schtasks.startup-fallback.test.ts
OPENCLAW_TEST_FAST=1 node scripts/test-projects.mjs src/daemon/schtasks.test.ts
pnpm tsgo:core:test
OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm check:changed
pnpm deadcode:ci
```
Evidence after fix: Terminal output from the verification:
```text
=== git diff --check ===

=== oxlint ===
Found 0 warnings and 0 errors.
Finished in 49ms on 2 files with 208 rules using 8 threads.

=== targeted startup fallback tests ===
✓ src/daemon/schtasks.startup-fallback.test.ts (28 tests)
Test Files  1 passed (1)
Tests  28 passed (28)
[test] passed 1 Vitest shard in 33.35s

=== targeted schtasks tests ===
✓ src/daemon/schtasks.test.ts (29 tests)
Test Files  1 passed (1)
Tests  29 passed (29)
[test] passed 1 Vitest shard in 33.30s

pnpm tsgo:core:test exited 0.

[check:changed] lanes=core, coreTests
[check:changed] src/daemon/schtasks.startup-fallback.test.ts: core test
[check:changed] src/daemon/schtasks.ts: core production
[check:changed] dependency pin guard
PASS direct dependency pin guard: checked 465 directly declared dependency specs across 155 tracked package manifests; 0 violations.
[check:changed] package patch guard
PASS package patch guard: no new pnpm patches; 4 legacy patches allowlisted.
[check:changed] lint core changed files
Found 0 warnings and 0 errors.
runtime-sidecar-loaders: local runtime sidecar loaders look OK.
Import cycle check: 0 runtime value cycle(s).
check:changed exited 0 in local child mode.

pnpm deadcode:ci exited 0.
```
Observed result after fix: The new regression test passes: when `findVerifiedGatewayListenerPidsOnPortSync` reports an existing gateway listener and mocked `schtasks /Run` never advances the Scheduled Task beyond never-run state, `installScheduledTask` still launches the Startup-style fallback instead of treating that listener as task launch evidence.
What was not tested: A native Windows live run with real Task Scheduler was not available in this environment; the PR includes source-level Windows lifecycle coverage using the repository's existing Windows schtasks mocks.

## Test Plan

- `git diff --check`
- `pnpm exec oxlint src/daemon/schtasks.ts src/daemon/schtasks.startup-fallback.test.ts`
- `OPENCLAW_TEST_FAST=1 node scripts/test-projects.mjs src/daemon/schtasks.startup-fallback.test.ts`
- `OPENCLAW_TEST_FAST=1 node scripts/test-projects.mjs src/daemon/schtasks.test.ts`
- `pnpm tsgo:core:test`
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm check:changed`
- `pnpm deadcode:ci`

Note: plain `pnpm check:changed` delegated to Blacksmith Testbox on this machine but crabbox failed its local binary sanity check before running project checks, so I ran the project check in the same remote-child mode locally and it exited 0.

## Risk

Low. The change is limited to the post-`schtasks /Run` launch-proof path. Listener-backed status reporting remains available for installed Startup fallback runtime status; only the launch fallback decision stops accepting an unrelated listener as task-start evidence.

Fixes #91144
