### PR TITLE
Add Multipass mock channel foundation

### DIFF
--- a/extensions/qa-lab/src/channel-capability-matrix.test.ts
+++ b/extensions/qa-lab/src/channel-capability-matrix.test.ts
@@ -1,0 +1,46 @@
+// Qa Lab tests cover mock channel capability matrix behavior.
+import { describe, expect, it } from "vitest";
+import {
+  buildQaChannelCapabilityMatrix,
+  getQaMockChannelDriver,
+  listQaMockChannelIds,
+} from "./channel-capability-matrix.js";
+
+describe("channel capability matrix", () => {
+  it("declares the first concrete mock upstream driver for Telegram", () => {
+    const driver = getQaMockChannelDriver("telegram");
+
+    expect(driver).toMatchObject({
+      channelId: "telegram",
+      mockDriverId: "telegram-normalized-bus-v1",
+      channelLive: false,
+      runtimePluginIds: ["qa-channel"],
+    });
+    expect(driver?.capabilities.dm.status).toBe("covered");
+    expect(driver?.capabilities["group-mention"].status).toBe("covered");
+    expect(driver?.capabilities["outbound-transcript"].status).toBe("covered");
+    expect(driver?.capabilities.thread.status).toBe("planned");
+  });
+
+  it("keeps missing channel drivers visible as planned rows", () => {
+    const matrix = buildQaChannelCapabilityMatrix();
+
+    expect(listQaMockChannelIds()).toEqual(["telegram"]);
+    expect(matrix.channels.map((entry) => entry.channelId)).toEqual([
+      "telegram",
+      "discord",
+      "slack",
+      "whatsapp",
+    ]);
+    expect(getQaMockChannelDriver("discord")).toBeUndefined();
+    expect(matrix.channels.find((entry) => entry.channelId === "discord")).toMatchObject({
+      mockDriverId: null,
+      capabilities: {
+        dm: {
+          status: "planned",
+          coverageId: "channels.discord.dm",
+        },
+      },
+    });
+  });
+});

--- a/extensions/qa-lab/src/channel-capability-matrix.ts
+++ b/extensions/qa-lab/src/channel-capability-matrix.ts
@@ -1,0 +1,136 @@
+// Qa Lab plugin module defines mock channel coverage for scorecard ingestion.
+
+export type QaMockChannelId = "telegram";
+
+export type QaChannelId = QaMockChannelId | "discord" | "slack" | "whatsapp";
+
+export type QaChannelCapabilityId =
+  | "dm"
+  | "group-mention"
+  | "thread"
+  | "media-metadata"
+  | "native-approval"
+  | "reconnect"
+  | "outbound-transcript";
+
+export type QaChannelCapabilityStatus = "covered" | "planned";
+
+export type QaChannelCapabilityMatrixEntry = {
+  channelId: QaChannelId;
+  label: string;
+  mockDriverId: string | null;
+  channelLive: false;
+  runtimePluginIds: readonly string[];
+  coverageIds: readonly string[];
+  capabilities: Readonly<
+    Record<
+      QaChannelCapabilityId,
+      {
+        status: QaChannelCapabilityStatus;
+        coverageId: string;
+      }
+    >
+  >;
+};
+
+export type QaChannelCapabilityMatrix = {
+  version: 1;
+  channels: readonly QaChannelCapabilityMatrixEntry[];
+};
+
+export type QaMockChannelDriver = QaChannelCapabilityMatrixEntry & {
+  channelId: QaMockChannelId;
+  mockDriverId: string;
+};
+
+export const QA_CHANNEL_CAPABILITY_MATRIX_PATH = "channel-capability-matrix.json";
+
+const qaChannelCapabilityIds = [
+  "dm",
+  "group-mention",
+  "thread",
+  "media-metadata",
+  "native-approval",
+  "reconnect",
+  "outbound-transcript",
+] as const satisfies readonly QaChannelCapabilityId[];
+
+function buildCapabilitySet(
+  channelId: QaChannelId,
+  coveredCapabilityIds: readonly QaChannelCapabilityId[] = [],
+) {
+  const covered = new Set<QaChannelCapabilityId>(coveredCapabilityIds);
+  return Object.fromEntries(
+    qaChannelCapabilityIds.map((capabilityId) => [
+      capabilityId,
+      {
+        status: covered.has(capabilityId) ? "covered" : "planned",
+        coverageId: `channels.${channelId}.${capabilityId}`,
+      },
+    ]),
+  ) as QaChannelCapabilityMatrixEntry["capabilities"];
+}
+
+const channelCapabilityMatrix: QaChannelCapabilityMatrix = {
+  version: 1,
+  channels: [
+    {
+      channelId: "telegram",
+      label: "Telegram",
+      mockDriverId: "telegram-normalized-bus-v1",
+      channelLive: false,
+      runtimePluginIds: ["qa-channel"],
+      coverageIds: [
+        "channels.telegram.mock-upstream",
+        "channels.telegram.dm",
+        "channels.telegram.group-mention",
+        "channels.telegram.outbound-transcript",
+      ],
+      capabilities: buildCapabilitySet("telegram", ["dm", "group-mention", "outbound-transcript"]),
+    },
+    {
+      channelId: "discord",
+      label: "Discord",
+      mockDriverId: null,
+      channelLive: false,
+      runtimePluginIds: [],
+      coverageIds: ["channels.discord.mock-upstream"],
+      capabilities: buildCapabilitySet("discord"),
+    },
+    {
+      channelId: "slack",
+      label: "Slack",
+      mockDriverId: null,
+      channelLive: false,
+      runtimePluginIds: [],
+      coverageIds: ["channels.slack.mock-upstream"],
+      capabilities: buildCapabilitySet("slack"),
+    },
+    {
+      channelId: "whatsapp",
+      label: "WhatsApp",
+      mockDriverId: null,
+      channelLive: false,
+      runtimePluginIds: [],
+      coverageIds: ["channels.whatsapp.mock-upstream"],
+      capabilities: buildCapabilitySet("whatsapp"),
+    },
+  ],
+};
+
+export function buildQaChannelCapabilityMatrix(): QaChannelCapabilityMatrix {
+  return channelCapabilityMatrix;
+}
+
+export function listQaMockChannelIds(): readonly QaMockChannelId[] {
+  return channelCapabilityMatrix.channels
+    .filter((entry): entry is QaMockChannelDriver => entry.mockDriverId !== null)
+    .map((entry) => entry.channelId);
+}
+
+export function getQaMockChannelDriver(channelId: string): QaMockChannelDriver | undefined {
+  return channelCapabilityMatrix.channels.find(
+    (entry): entry is QaMockChannelDriver =>
+      entry.channelId === channelId && entry.mockDriverId !== null,
+  );
+}

--- a/extensions/qa-lab/src/cli.runtime.test.ts
+++ b/extensions/qa-lab/src/cli.runtime.test.ts
@@ -1464,6 +1464,25 @@ describe("qa cli runtime", () => {
     });
   });
 
+  it("passes selected mock channel drivers through to the multipass runner", async () => {
+    await runQaSuiteCommand({
+      repoRoot: "/tmp/openclaw-repo",
+      runner: "multipass",
+      transportId: "telegram",
+      providerMode: "mock-openai",
+      allowFailures: true,
+      scenarioIds: ["channel-chat-baseline"],
+    });
+
+    expectFields(mockFirstObjectArg(runQaMultipass), {
+      repoRoot: path.resolve("/tmp/openclaw-repo"),
+      transportId: "telegram",
+      providerMode: "mock-openai",
+      allowFailures: true,
+      scenarioIds: ["channel-chat-baseline"],
+    });
+  });
+
   it("sets a failing exit code when multipass summary reports failed scenarios", async () => {
     const repoRoot = await fs.mkdtemp(path.join(os.tmpdir(), "qa-multipass-summary-"));
     const summaryPath = path.join(repoRoot, "qa-suite-summary.json");

--- a/extensions/qa-lab/src/cli.ts
+++ b/extensions/qa-lab/src/cli.ts
@@ -13,6 +13,7 @@ import {
   QA_FRONTIER_PARITY_BASELINE_LABEL,
   QA_FRONTIER_PARITY_CANDIDATE_LABEL,
 } from "./providers/live-frontier/parity.js";
+import { formatQaTransportIdHelp } from "./qa-transport-registry.js";
 import type { QaProviderMode, QaProviderModeInput } from "./run-config.js";
 import { hasQaScenarioPack } from "./scenario-catalog.js";
 
@@ -299,7 +300,7 @@ export function registerQaLabCli(program: Command) {
     .option("--repo-root <path>", "Repository root to target when running from a neutral cwd")
     .option("--output-dir <path>", "Suite artifact directory")
     .option("--runner <kind>", "Execution runner: host or multipass", "host")
-    .option("--transport <id>", "QA transport id", "qa-channel")
+    .option("--transport <id>", formatQaTransportIdHelp(), "qa-channel")
     .option("--provider-mode <mode>", formatQaProviderModeHelp(), DEFAULT_QA_LIVE_PROVIDER_MODE)
     .option("--model <ref>", "Primary provider/model ref")
     .option("--alt-model <ref>", "Alternate provider/model ref")

--- a/extensions/qa-lab/src/mock-channel-transport.test.ts
+++ b/extensions/qa-lab/src/mock-channel-transport.test.ts
@@ -1,0 +1,24 @@
+// Qa Lab tests cover mock channel transport behavior.
+import { describe, expect, it } from "vitest";
+import { createQaBusState } from "./bus-state.js";
+import { createQaMockChannelTransport } from "./mock-channel-transport.js";
+
+describe("mock channel transport", () => {
+  it("selects Telegram while routing through the normalized QA channel shim", () => {
+    const transport = createQaMockChannelTransport({
+      channelId: "telegram",
+      state: createQaBusState(),
+    });
+
+    expect(transport.id).toBe("telegram");
+    expect(transport.channelId).toBe("telegram");
+    expect(transport.channelLive).toBe(false);
+    expect(transport.mockUpstreamDriverId).toBe("telegram-normalized-bus-v1");
+    expect(transport.requiredPluginIds).toEqual(["qa-channel"]);
+    expect(transport.buildAgentDelivery({ target: "qa-room" })).toEqual({
+      channel: "qa-channel",
+      replyChannel: "qa-channel",
+      replyTo: "qa-room",
+    });
+  });
+});

--- a/extensions/qa-lab/src/mock-channel-transport.ts
+++ b/extensions/qa-lab/src/mock-channel-transport.ts
@@ -1,0 +1,90 @@
+// Qa Lab plugin module implements mock upstream channel transports.
+import type { QaBusState } from "./bus-state.js";
+import type { QaMockChannelDriver, QaMockChannelId } from "./channel-capability-matrix.js";
+import { getQaMockChannelDriver } from "./channel-capability-matrix.js";
+import { getQaProvider } from "./providers/index.js";
+import {
+  createQaChannelGatewayConfig,
+  handleQaChannelAction,
+  QA_CHANNEL_ID,
+  waitForQaChannelReady,
+} from "./qa-channel-transport.js";
+import { QaStateBackedTransportAdapter } from "./qa-transport.js";
+import type {
+  QaTransportActionName,
+  QaTransportGatewayConfig,
+  QaTransportGatewayClient,
+  QaTransportReportParams,
+} from "./qa-transport.js";
+
+const QA_MOCK_CHANNEL_ACCOUNT_ID = "mock";
+
+function createMockChannelReportNotes(
+  driver: QaMockChannelDriver,
+  params: QaTransportReportParams,
+) {
+  const provider = getQaProvider(params.providerMode);
+  const providerText =
+    provider.kind === "mock"
+      ? `${params.providerMode} provider fixture`
+      : `live frontier models (${params.primaryModel}, ${params.alternateModel})`;
+  return [
+    `Runs ${driver.label} through mock upstream driver ${driver.mockDriverId} backed by the qa-lab normalized bus.`,
+    `Gateway transport execution uses the qa-channel shim while summary metadata records channel=${driver.channelId} and channel_live=false.`,
+    `Model responses use ${providerText}${params.fastMode ? " with fast mode enabled" : ""}.`,
+  ];
+}
+
+class QaMockChannelTransport extends QaStateBackedTransportAdapter {
+  constructor(
+    state: QaBusState,
+    private readonly driver: QaMockChannelDriver,
+  ) {
+    super({
+      id: driver.channelId,
+      channelId: driver.channelId,
+      channelLive: false,
+      mockUpstreamDriverId: driver.mockDriverId,
+      label: `${driver.label} mock upstream + qa-lab bus`,
+      accountId: QA_MOCK_CHANNEL_ACCOUNT_ID,
+      requiredPluginIds: driver.runtimePluginIds,
+      state,
+    });
+  }
+
+  createGatewayConfig = (params: { baseUrl: string }): QaTransportGatewayConfig =>
+    createQaChannelGatewayConfig(params);
+
+  waitReady = (params: {
+    gateway: QaTransportGatewayClient;
+    timeoutMs?: number;
+    pollIntervalMs?: number;
+  }) => waitForQaChannelReady(params);
+
+  buildAgentDelivery = ({ target }: { target: string }) => ({
+    channel: QA_CHANNEL_ID,
+    replyChannel: QA_CHANNEL_ID,
+    replyTo: target,
+  });
+
+  handleAction = (params: {
+    action: QaTransportActionName;
+    args: Record<string, unknown>;
+    cfg: Parameters<typeof handleQaChannelAction>[0]["cfg"];
+    accountId?: string | null;
+  }) => handleQaChannelAction(params);
+
+  createReportNotes = (params: QaTransportReportParams) =>
+    createMockChannelReportNotes(this.driver, params);
+}
+
+export function createQaMockChannelTransport(params: {
+  channelId: QaMockChannelId;
+  state: QaBusState;
+}) {
+  const driver = getQaMockChannelDriver(params.channelId);
+  if (!driver) {
+    throw new Error(`unsupported QA mock channel: ${params.channelId}`);
+  }
+  return new QaMockChannelTransport(params.state, driver);
+}

--- a/extensions/qa-lab/src/multipass.runtime.test.ts
+++ b/extensions/qa-lab/src/multipass.runtime.test.ts
@@ -147,6 +147,20 @@ describe("qa multipass runtime", () => {
     expect(plan.qaCommand).toContain("--allow-failures");
   });
 
+  it("forwards a selected mock channel driver into the guest qa suite command", () => {
+    const plan = createQaMultipassPlan({
+      repoRoot: process.cwd(),
+      outputDir: path.join(process.cwd(), ".artifacts", "qa-e2e", "multipass-telegram-test"),
+      transportId: "telegram",
+      providerMode: "mock-openai",
+      scenarioIds: ["channel-chat-baseline"],
+    });
+
+    expect(plan.transportId).toBe("telegram");
+    expect(plan.qaCommand).toEqual(expect.arrayContaining(["--transport", "telegram"]));
+    expect(plan.qaCommand).toEqual(expect.arrayContaining(["--provider-mode", "mock-openai"]));
+  });
+
   it("forwards --runtime-pair into the guest qa suite command when requested", () => {
     const plan = createQaMultipassPlan({
       repoRoot: process.cwd(),

--- a/extensions/qa-lab/src/qa-channel-transport.ts
+++ b/extensions/qa-lab/src/qa-channel-transport.ts
@@ -13,12 +13,12 @@ import type {
 } from "./qa-transport.js";
 import { qaChannelPlugin } from "./runtime-api.js";
 
-const QA_CHANNEL_ID = "qa-channel";
+export const QA_CHANNEL_ID = "qa-channel";
 const QA_CHANNEL_ACCOUNT_ID = "default";
 export const QA_CHANNEL_REQUIRED_PLUGIN_IDS = Object.freeze([QA_CHANNEL_ID]);
 export const QA_CHANNEL_DEFAULT_SUITE_CONCURRENCY = 4;
 
-async function waitForQaChannelReady(params: {
+export async function waitForQaChannelReady(params: {
   gateway: QaTransportGatewayClient;
   timeoutMs?: number;
   pollIntervalMs?: number;
@@ -110,7 +110,7 @@ function createQaChannelReportNotes(params: QaTransportReportParams) {
   ];
 }
 
-async function handleQaChannelAction(params: {
+export async function handleQaChannelAction(params: {
   action: QaTransportActionName;
   args: Record<string, unknown>;
   cfg: OpenClawConfig;
@@ -129,6 +129,8 @@ class QaChannelTransport extends QaStateBackedTransportAdapter {
   constructor(state: QaBusState) {
     super({
       id: QA_CHANNEL_ID,
+      channelId: QA_CHANNEL_ID,
+      channelLive: false,
       label: "qa-channel + qa-lab bus",
       accountId: QA_CHANNEL_ACCOUNT_ID,
       requiredPluginIds: QA_CHANNEL_REQUIRED_PLUGIN_IDS,

--- a/extensions/qa-lab/src/qa-transport-registry.test.ts
+++ b/extensions/qa-lab/src/qa-transport-registry.test.ts
@@ -1,8 +1,24 @@
 // Qa Lab tests cover qa transport registry plugin behavior.
 import { describe, expect, it } from "vitest";
-import { normalizeQaTransportId } from "./qa-transport-registry.js";
+import {
+  defaultQaSuiteConcurrencyForTransport,
+  formatQaTransportIdHelp,
+  normalizeQaTransportId,
+} from "./qa-transport-registry.js";
 
 describe("qa transport registry", () => {
+  it("selects the first mock channel driver by channel id", () => {
+    expect(normalizeQaTransportId("telegram")).toBe("telegram");
+    expect(formatQaTransportIdHelp()).toContain("telegram");
+    expect(defaultQaSuiteConcurrencyForTransport("telegram")).toBe(1);
+  });
+
+  it("does not accept an opaque all-channel mock transport", () => {
+    expect(() => normalizeQaTransportId("all-mock-channels")).toThrow(
+      "unsupported QA transport: all-mock-channels",
+    );
+  });
+
   it("rejects inherited prototype keys as unsupported transport ids", () => {
     expect(() => normalizeQaTransportId("toString")).toThrow("unsupported QA transport: toString");
     expect(() => normalizeQaTransportId("__proto__")).toThrow(

--- a/extensions/qa-lab/src/qa-transport-registry.ts
+++ b/extensions/qa-lab/src/qa-transport-registry.ts
@@ -1,19 +1,26 @@
 // Qa Lab plugin module implements qa transport registry behavior.
 import type { QaBusState } from "./bus-state.js";
+import { listQaMockChannelIds, type QaMockChannelId } from "./channel-capability-matrix.js";
+import { createQaMockChannelTransport } from "./mock-channel-transport.js";
 import {
   createQaChannelTransport,
   QA_CHANNEL_DEFAULT_SUITE_CONCURRENCY,
 } from "./qa-channel-transport.js";
 import type { QaTransportAdapter } from "./qa-transport.js";
 
-export type QaTransportId = "qa-channel";
+export type QaTransportId = "qa-channel" | QaMockChannelId;
 
 const DEFAULT_QA_TRANSPORT_ID: QaTransportId = "qa-channel";
+const MOCK_CHANNEL_DEFAULT_SUITE_CONCURRENCY = 1;
 
 const QA_TRANSPORT_REGISTRY = {
   "qa-channel": {
     create: createQaChannelTransport,
     defaultSuiteConcurrency: QA_CHANNEL_DEFAULT_SUITE_CONCURRENCY,
+  },
+  telegram: {
+    create: (state: QaBusState) => createQaMockChannelTransport({ channelId: "telegram", state }),
+    defaultSuiteConcurrency: MOCK_CHANNEL_DEFAULT_SUITE_CONCURRENCY,
   },
 } as const satisfies Record<
   QaTransportId,
@@ -22,6 +29,14 @@ const QA_TRANSPORT_REGISTRY = {
     defaultSuiteConcurrency: number;
   }
 >;
+
+export function listQaTransportIds(): readonly QaTransportId[] {
+  return [DEFAULT_QA_TRANSPORT_ID, ...listQaMockChannelIds()];
+}
+
+export function formatQaTransportIdHelp(): string {
+  return `QA transport id: ${listQaTransportIds().join(", ")}`;
+}
 
 export function normalizeQaTransportId(input?: string | null): QaTransportId {
   const transportId = input?.trim() || DEFAULT_QA_TRANSPORT_ID;

--- a/extensions/qa-lab/src/qa-transport.ts
+++ b/extensions/qa-lab/src/qa-transport.ts
@@ -159,6 +159,9 @@ export function createFailureAwareTransportWaitForCondition(state: QaTransportSt
 
 export type QaTransportAdapter = {
   id: string;
+  channelId: string;
+  channelLive: boolean;
+  mockUpstreamDriverId?: string;
   label: string;
   accountId: string;
   requiredPluginIds: readonly string[];
@@ -186,6 +189,9 @@ export type QaTransportAdapter = {
 
 export abstract class QaStateBackedTransportAdapter implements QaTransportAdapter {
   readonly id: string;
+  readonly channelId: string;
+  readonly channelLive: boolean;
+  readonly mockUpstreamDriverId?: string;
   readonly label: string;
   readonly accountId: string;
   readonly requiredPluginIds: readonly string[];
@@ -194,12 +200,18 @@ export abstract class QaStateBackedTransportAdapter implements QaTransportAdapte
 
   protected constructor(params: {
     id: string;
+    channelId: string;
+    channelLive: boolean;
+    mockUpstreamDriverId?: string;
     label: string;
     accountId: string;
     requiredPluginIds: readonly string[];
     state: QaTransportState;
   }) {
     this.id = params.id;
+    this.channelId = params.channelId;
+    this.channelLive = params.channelLive;
+    this.mockUpstreamDriverId = params.mockUpstreamDriverId;
     this.label = params.label;
     this.accountId = params.accountId;
     this.requiredPluginIds = params.requiredPluginIds;

--- a/extensions/qa-lab/src/suite-summary.ts
+++ b/extensions/qa-lab/src/suite-summary.ts
@@ -52,6 +52,11 @@ export type QaSuiteSummaryJson = {
     alternateModelName: string | null;
     fastMode: boolean;
     concurrency: number;
+    transportId: string;
+    channelId: string;
+    channelLive: boolean;
+    mockUpstreamDriverId?: string | null;
+    channelCapabilityMatrixPath?: string | null;
     scenarioIds: string[] | null;
     runtimePair?: [RuntimeId, RuntimeId] | null;
   };

--- a/extensions/qa-lab/src/suite.summary-json.test.ts
+++ b/extensions/qa-lab/src/suite.summary-json.test.ts
@@ -18,6 +18,11 @@ describe("buildQaSuiteSummaryJson", () => {
     alternateModel: "openai/gpt-5.5-alt",
     fastMode: true,
     concurrency: 2,
+    transportId: "telegram",
+    channelId: "telegram",
+    channelLive: false,
+    mockUpstreamDriverId: "telegram-normalized-bus-v1",
+    channelCapabilityMatrixPath: "channel-capability-matrix.json",
   };
 
   it("records provider/model/mode so parity gates can verify labels", () => {
@@ -33,6 +38,11 @@ describe("buildQaSuiteSummaryJson", () => {
     expect(json.run.alternateModelName).toBe("gpt-5.5-alt");
     expect(json.run.fastMode).toBe(true);
     expect(json.run.concurrency).toBe(2);
+    expect(json.run.transportId).toBe("telegram");
+    expect(json.run.channelId).toBe("telegram");
+    expect(json.run.channelLive).toBe(false);
+    expect(json.run.mockUpstreamDriverId).toBe("telegram-normalized-bus-v1");
+    expect(json.run.channelCapabilityMatrixPath).toBe("channel-capability-matrix.json");
     expect(json.run.scenarioIds).toBeNull();
   });
 

--- a/extensions/qa-lab/src/suite.ts
+++ b/extensions/qa-lab/src/suite.ts
@@ -12,6 +12,10 @@ import {
   type QaReportScenario,
 } from "openclaw/plugin-sdk/qa-runtime";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
+import {
+  buildQaChannelCapabilityMatrix,
+  QA_CHANNEL_CAPABILITY_MATRIX_PATH,
+} from "./channel-capability-matrix.js";
 import { startQaGatewayChild, type QaCliBackendAuthMode } from "./gateway-child.js";
 import type {
   QaLabLatestReport,
@@ -541,6 +545,11 @@ export type QaSuiteSummaryJsonParams = {
   alternateModel: string;
   fastMode: boolean;
   concurrency: number;
+  transportId: string;
+  channelId: string;
+  channelLive: boolean;
+  mockUpstreamDriverId?: string | null;
+  channelCapabilityMatrixPath?: string | null;
   scenarioIds?: readonly string[];
   runtimePair?: [RuntimeId, RuntimeId];
 };
@@ -599,6 +608,11 @@ export function buildQaSuiteSummaryJson(params: QaSuiteSummaryJsonParams): QaSui
       alternateModelName: alternateSplit?.model ?? null,
       fastMode: params.fastMode,
       concurrency: params.concurrency,
+      transportId: params.transportId,
+      channelId: params.channelId,
+      channelLive: params.channelLive,
+      mockUpstreamDriverId: params.mockUpstreamDriverId ?? null,
+      channelCapabilityMatrixPath: params.channelCapabilityMatrixPath ?? null,
       scenarioIds:
         params.scenarioIds && params.scenarioIds.length > 0 ? [...params.scenarioIds] : null,
       runtimePair: params.runtimePair ?? null,
@@ -859,10 +873,30 @@ async function writeQaSuiteArtifacts(params: {
   });
   const reportPath = path.join(params.outputDir, "qa-suite-report.md");
   const summaryPath = path.join(params.outputDir, "qa-suite-summary.json");
+  const channelCapabilityMatrixPath = path.join(
+    params.outputDir,
+    QA_CHANNEL_CAPABILITY_MATRIX_PATH,
+  );
+  await fs.writeFile(
+    channelCapabilityMatrixPath,
+    `${JSON.stringify(buildQaChannelCapabilityMatrix(), null, 2)}\n`,
+    "utf8",
+  );
   await fs.writeFile(reportPath, report, "utf8");
   await fs.writeFile(
     summaryPath,
-    `${JSON.stringify(buildQaSuiteSummaryJson(params), null, 2)}\n`,
+    `${JSON.stringify(
+      buildQaSuiteSummaryJson({
+        ...params,
+        transportId: params.transport.id,
+        channelId: params.transport.channelId,
+        channelLive: params.transport.channelLive,
+        mockUpstreamDriverId: params.transport.mockUpstreamDriverId ?? null,
+        channelCapabilityMatrixPath: QA_CHANNEL_CAPABILITY_MATRIX_PATH,
+      }),
+      null,
+      2,
+    )}\n`,
     "utf8",
   );
   return { report, reportPath, summaryPath };


### PR DESCRIPTION
## Summary

- add a QA Lab mock-channel capability matrix artifact for future scorecard/QA wrapper consumption
- register Telegram as the first single-channel mock upstream driver, selected with `--transport telegram`
- carry channel metadata into `qa-suite-summary.json` and forward the selected channel through the Multipass guest command

## Behavior

`pnpm openclaw qa suite --runner multipass --transport telegram --provider-mode mock-openai` now selects a Telegram mock-channel lane and forwards that selection into the Multipass guest run. The first driver records `channelId: telegram`, `channelLive: false`, and `mockUpstreamDriverId: telegram-normalized-bus-v1` while using the existing QA Lab normalized bus/`qa-channel` runtime shim. The emitted `channel-capability-matrix.json` marks Telegram DM, group mention, and outbound transcript cells covered, and keeps Discord/Slack/WhatsApp gaps visible as planned rows.

## Verification

- `pnpm install --frozen-lockfile`
- `node scripts/run-vitest.mjs extensions/qa-lab/src/channel-capability-matrix.test.ts extensions/qa-lab/src/mock-channel-transport.test.ts extensions/qa-lab/src/qa-transport-registry.test.ts extensions/qa-lab/src/suite.summary-json.test.ts extensions/qa-lab/src/multipass.runtime.test.ts extensions/qa-lab/src/cli.runtime.test.ts`
- `pnpm tsgo:extensions`
- `pnpm exec oxfmt --check extensions/qa-lab/src/channel-capability-matrix.ts extensions/qa-lab/src/channel-capability-matrix.test.ts extensions/qa-lab/src/mock-channel-transport.ts extensions/qa-lab/src/mock-channel-transport.test.ts extensions/qa-lab/src/qa-channel-transport.ts extensions/qa-lab/src/qa-transport.ts extensions/qa-lab/src/qa-transport-registry.ts extensions/qa-lab/src/qa-transport-registry.test.ts extensions/qa-lab/src/suite.ts extensions/qa-lab/src/suite-summary.ts extensions/qa-lab/src/suite.summary-json.test.ts extensions/qa-lab/src/multipass.runtime.test.ts extensions/qa-lab/src/cli.ts extensions/qa-lab/src/cli.runtime.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local` -> clean, no accepted/actionable findings

## Real Behavior Proof

Behavior addressed: QA Lab can select one mock messaging channel for a Multipass run and emit channel capability evidence for future scorecard work.

Real environment tested: Local OpenClaw checkout on branch `dallin/multipass-channel-foundation`, using the QA Lab Vitest project and extension typecheck.

Exact steps or command run after this patch: The verification commands above were run after the final patch and commit.

Evidence after fix: Focused QA Lab Vitest passed 6 files / 96 tests; `pnpm tsgo:extensions`, scoped `oxfmt --check`, and `git diff --check` passed.

Observed result after fix: The registry accepts `--transport telegram`, rejects `all-mock-channels`, Multipass forwards `--transport telegram`, and suite summary metadata includes the selected channel plus the capability matrix path.

What was not tested: A real Multipass VM execution was not run locally; this PR proves the selection, forwarding, artifact, summary, and type contracts with deterministic tests.
