### PR TITLE
fix(reply): project preflight compaction gate by next-input size on fresh tokens

### DIFF
--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -1314,6 +1314,79 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(compactCall.authProfileId).toBe("anthropic:claude@martian.engineering");
     expect(compactCall.contextTokenBudget).toBe(258_000);
   });
+  it("preflight compacts a fresh session when the current prompt estimate pushes the next request over budget", async () => {
+    registerMemoryFlushPlanResolverForTest(() => ({
+      softThresholdTokens: 0,
+      forceFlushTranscriptBytes: 1_000_000_000,
+      reserveTokensFloor: 10,
+      prompt: "Pre-compaction memory flush.\nNO_REPLY",
+      systemPrompt: "Write memory to memory/YYYY-MM-DD.md.",
+      relativePath: "memory/2023-11-14.md",
+    }));
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 985,
+      totalTokensFresh: true,
+      compactionCount: 0,
+    };
+
+    await runPreflightCompactionIfNeeded({
+      cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+      followupRun: createTestFollowupRun({
+        provider: "anthropic",
+        model: "claude",
+        sessionKey: "agent:main:main",
+      }),
+      promptForEstimate: "Please summarize the entire design discussion above. ".repeat(8),
+      defaultModel: "anthropic/claude",
+      agentCfgContextTokens: 1000,
+      sessionEntry,
+      sessionStore: { "agent:main:main": sessionEntry },
+      sessionKey: "agent:main:main",
+      isHeartbeat: false,
+      replyOperation: createReplyOperation(),
+    });
+
+    expect(compactEmbeddedAgentSessionMock).toHaveBeenCalledTimes(1);
+  });
+  it("does not preflight compact a fresh session when only accumulated output tokens are large and the latest output keeps the request under budget", async () => {
+    registerMemoryFlushPlanResolverForTest(() => ({
+      softThresholdTokens: 0,
+      forceFlushTranscriptBytes: 1_000_000_000,
+      reserveTokensFloor: 10,
+      prompt: "Pre-compaction memory flush.\nNO_REPLY",
+      systemPrompt: "Write memory to memory/YYYY-MM-DD.md.",
+      relativePath: "memory/2023-11-14.md",
+    }));
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 985,
+      outputTokens: 50_000,
+      totalTokensFresh: true,
+      compactionCount: 0,
+    };
+
+    await runPreflightCompactionIfNeeded({
+      cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+      followupRun: createTestFollowupRun({
+        provider: "anthropic",
+        model: "claude",
+        sessionKey: "agent:main:main",
+      }),
+      promptForEstimate: "",
+      defaultModel: "anthropic/claude",
+      agentCfgContextTokens: 1000,
+      sessionEntry,
+      sessionStore: { "agent:main:main": sessionEntry },
+      sessionKey: "agent:main:main",
+      isHeartbeat: false,
+      replyOperation: createReplyOperation(),
+    });
+
+    expect(compactEmbeddedAgentSessionMock).not.toHaveBeenCalled();
+  });
   it("updates the active preflight run after transcript rotation", async () => {
     const sessionFile = path.join(rootDir, "session.jsonl");
     const successorFile = path.join(rootDir, "session-rotated.jsonl");
@@ -2011,7 +2084,7 @@ describe("runMemoryFlushIfNeeded", () => {
     const compactCall = requireCompactEmbeddedAgentSessionCall();
     expect(compactCall.sessionId).toBe("session");
     expect(compactCall.trigger).toBe("budget");
-    expect(compactCall.currentTokenCount).toBe(10);
+    expect(compactCall.currentTokenCount).toBe(12);
     expect(compactCall.sessionFile).toContain("large-session.jsonl");
   });
 

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -756,10 +756,24 @@ export async function runPreflightCompactionIfNeeded(params: {
   const promptTokenEstimate = estimatePromptTokensForMemoryFlush(
     params.promptForEstimate ?? params.followupRun.prompt,
   );
+  const serverCompactionThreshold = resolveResponsesServerCompactionThreshold({
+    cfg: params.cfg,
+    provider: params.followupRun.run.provider,
+    modelId: params.followupRun.run.model ?? params.defaultModel,
+  });
+  const threshold = Math.max(
+    contextWindowTokens - reserveTokensFloor - softThresholdTokens,
+    serverCompactionThreshold ?? 0,
+  );
+  const freshNeedsOutputRead =
+    typeof freshPersistedTokens === "number" &&
+    typeof promptTokenEstimate === "number" &&
+    threshold > 0 &&
+    freshPersistedTokens + promptTokenEstimate >= threshold - TRANSCRIPT_OUTPUT_READ_BUFFER_TOKENS;
   const maxActiveTranscriptBytes = resolveMaxActiveTranscriptBytes(params.cfg);
   const shouldCheckActiveTranscriptBytes = typeof maxActiveTranscriptBytes === "number";
   const transcriptUsageTokens =
-    typeof freshPersistedTokens === "number"
+    typeof freshPersistedTokens === "number" && !freshNeedsOutputRead
       ? undefined
       : await estimatePromptTokensFromSessionTranscript({
           sessionId: entry.sessionId,
@@ -801,8 +815,17 @@ export async function runPreflightCompactionIfNeeded(params: {
           promptTokenEstimate,
         )
       : undefined;
+  const freshProjectedTokenCount =
+    typeof freshPersistedTokens === "number"
+      ? resolveEffectivePromptTokens(
+          freshPersistedTokens,
+          transcriptOutputTokens,
+          promptTokenEstimate,
+        )
+      : undefined;
   const projectedTokenCount = Math.max(
     usageProjectedTokenCount ?? 0,
+    freshProjectedTokenCount ?? 0,
     stalePersistedPromptTokens ?? 0,
   );
   const tokenCountForCompaction =
@@ -810,15 +833,6 @@ export async function runPreflightCompactionIfNeeded(params: {
       ? projectedTokenCount
       : undefined;
 
-  const serverCompactionThreshold = resolveResponsesServerCompactionThreshold({
-    cfg: params.cfg,
-    provider: params.followupRun.run.provider,
-    modelId: params.followupRun.run.model ?? params.defaultModel,
-  });
-  const threshold = Math.max(
-    contextWindowTokens - reserveTokensFloor - softThresholdTokens,
-    serverCompactionThreshold ?? 0,
-  );
   logVerbose(
     `preflightCompaction check: sessionKey=${params.sessionKey} ` +
       `tokenCount=${tokenCountForCompaction ?? freshPersistedTokens ?? "undefined"} ` +


### PR DESCRIPTION
## Summary

On the embedded runtime, proactive **preflight** compaction under-triggers on long-lived sessions. The pre-send gate (`runPreflightCompactionIfNeeded`) decides whether to compact *before* the next request, but in the common fresh-tokens path it sizes the next request using only the prompt-only `entry.totalTokens` snapshot, dropping both the current user prompt and the previous turn's output. As a result the gate skips compaction on a turn whose request actually crosses the context budget, and the session falls into the overflow-and-retry recovery path instead of a clean proactive checkpoint.

This is distinct from #63892 / #64384 (the gate not *running at all* after the first compaction, which current `main` already reaches): this is the token count the gate uses *once it runs*.

## Root cause

`entry.totalTokens` is, by design, a prompt-only context snapshot that excludes completion/output tokens (`src/agents/usage.ts`, `deriveSessionTotalTokens`). The intended projection for "what will the next request weigh" is `base + previous output + current prompt estimate`, encoded in `resolveEffectivePromptTokens` (`src/auto-reply/reply/agent-runner-memory.ts`).

Two paths apply that projection correctly and one did not:

- The sibling memory-flush gate (`runMemoryFlushIfNeeded`, same file) projects `base + output + estimate`, and reads the transcript for output tokens even when persisted tokens are fresh, gated by `TRANSCRIPT_OUTPUT_READ_BUFFER_TOKENS` when near the threshold.
- The stale branch of `runPreflightCompactionIfNeeded` itself projects `base + output + estimate`.
- The **fresh** branch of `runPreflightCompactionIfNeeded` set `transcriptUsageTokens` to `undefined` whenever `freshPersistedTokens` was a number (so output was never read), and fed the raw prompt-only `entry.totalTokens` into the threshold check. The `promptTokenEstimate` was computed and then discarded in this branch.

So with the same threshold formula as the sibling, the preflight gate under-counted the next request by `previousOutput + currentPrompt` on every fresh turn.

## Fix

Make the fresh preflight path project the next-input the same way the memory-flush sibling and the stale branch already do:

- Read transcript output tokens in the fresh case when within `TRANSCRIPT_OUTPUT_READ_BUFFER_TOKENS` of the threshold (`freshNeedsOutputRead`), mirroring the sibling.
- Project the fresh persisted base through `resolveEffectivePromptTokens(freshPersistedTokens, transcriptOutputTokens, promptTokenEstimate)` and feed that into the gate.

The threshold computation is hoisted above the transcript read so the read gate can use it. No config, schema, or public surface changes. Net +14 lines, single function.

## Real behavior proof

Behavior addressed: On the embedded runtime, `runPreflightCompactionIfNeeded` skips proactive compaction for a session whose `totalTokens` snapshot is fresh and just below the budget threshold, even though the request about to be sent (history + current user prompt, plus the previous turn's output) crosses the threshold. The turn is then sent over budget and only recovers via overflow-retry.

Real environment tested: Local checkout on a branch off `origin/main` 105d77d486b, Node 22.19. Drove the production `runPreflightCompactionIfNeeded` decision path directly with `node` (tsx loader) for an Anthropic embedded followup run; a fresh `SessionEntry` (`totalTokens: 985`, `totalTokensFresh: true`), context window 1000, reserve 10, soft 0 (threshold 990), and a real user prompt of ~106 tokens. The compaction call was routed to an in-process recorder so the real gate decision is observed without performing an actual compaction. Same script, same inputs, run once before the patch and once after.

Exact steps or command run after this patch: ran the production preflight decision path for the fresh-snapshot session described above and printed whether the gate requested compaction, before vs after the change.

Evidence after fix: copied live terminal output from the production preflight decision path.

Before (origin/main, no patch):
```
context=1000 reserve=10 soft=0 threshold=990
session totalTokens(prompt-only,fresh)=985  next user prompt=~106 tokens
actual next request input >= 1091 (exceeds threshold 990 by >= 101)
preflight decision => NOT REQUESTED (request sent over budget)
```

After:
```
context=1000 reserve=10 soft=0 threshold=990
session totalTokens(prompt-only,fresh)=985  next user prompt=~106 tokens
actual next request input >= 1091 (exceeds threshold 990 by >= 101)
preflight decision => COMPACTION REQUESTED
```

Observed result after fix: with the next request projected as base + previous output + current prompt (matching the memory-flush sibling), the fresh-snapshot session now triggers proactive compaction before the over-budget request is sent. A session safely below the threshold (no output/prompt projection pushing it over) is unaffected and still proceeds without compaction.

What was not tested: a live model round-trip over a real provider API (decision path only, no network call); the stale-tokens and transcript-byte-size branches were already projecting correctly and are unchanged.

## Verification

Local (Node 22.19.0): `oxfmt --check` on the changed file clean; type-aware oxlint on the changed file clean; `tsgo:core` exit 0; existing `src/auto-reply/reply/agent-runner-memory.test.ts` suite green.

## Related (not duplicates)

- #63892 / #64384 — preflight gate not re-firing at all after the first compaction (fresh-tokens fast-path early return). Current `main` reaches the threshold check; this PR fixes the count that check consumes.
- #45360 / #45424 / #55722 — the same "omit output / current prompt" undercount, fixed previously for the **memory-flush** gate only. This PR brings the preflight gate to parity.
- #81916 (#81178) — bounds stale transcript usage and post-compaction tail pressure inside the transcript estimator (the stale-tokens path). It does not touch the fresh `entry.totalTokens` projection this PR fixes (the estimator is not even called when tokens are fresh), so the two are complementary, not duplicates.
