### PR TITLE
fix(supervisor): spawn claude .cmd shim correctly on Windows

### DIFF
--- a/src/process/supervisor/adapters/child.ts
+++ b/src/process/supervisor/adapters/child.ts
@@ -14,7 +14,7 @@ const WINDOWS_CLOSE_STATE_SETTLE_TIMEOUT_MS = 250;
 function resolveCommand(command: string): string {
   return resolveWindowsCommandShim({
     command,
-    cmdCommands: ["npm", "pnpm", "yarn", "npx"],
+    cmdCommands: ["npm", "pnpm", "yarn", "npx", "claude"],
   });
 }
 
@@ -46,6 +46,12 @@ export async function createChildAdapter(params: {
   // existing POSIX detached behavior.
   const useDetached = process.platform !== "win32" && !isServiceManagedRuntime();
 
+  // On Windows, npm-style shims resolve to .cmd/.bat files. These cannot be
+  // launched directly by child_process.spawn without a shell (EINVAL on recent
+  // Node.js), so enable shell mode for batch-file commands.
+  const resolvedCmd = resolvedArgv[0] ?? "";
+  const useShell = /\.(cmd|bat)$/i.test(resolvedCmd);
+
   const options: SpawnOptions = {
     cwd: params.cwd,
     env: preparedSpawn.env,
@@ -53,6 +59,7 @@ export async function createChildAdapter(params: {
     detached: useDetached,
     windowsHide: true,
     windowsVerbatimArguments: params.windowsVerbatimArguments,
+    ...(useShell ? { shell: true } : {}),
   };
   if (stdinMode === "inherit") {
     options.stdio = ["inherit", "pipe", "pipe"];


### PR DESCRIPTION
## Summary
Fixes spawning the `claude` command on Windows, where it failed with `ENOENT` and `EINVAL`.

On Windows, npm-style executables (such as `claude`) are installed as `.cmd` shims. Two problems prevented the supervisor from launching them:

1. `resolveCommand` did not include `claude` in `cmdCommands`, so the `.cmd` extension was never appended and the command could not be found → `ENOENT`.
2. `createChildAdapter` did not set `shell: true` for `.cmd`/`.bat` files, which recent Node.js versions require to launch batch files → `EINVAL`.

## Changes
`src/process/supervisor/adapters/child.ts`:
- Add `"claude"` to the `cmdCommands` list in `resolveCommand`.
- Set `shell: true` in the spawn options when the resolved command ends with `.cmd` or `.bat`.

## Testing
- Verified on Windows 10 (10.0.19045) that `claude` resolves to `claude.cmd` and spawns without `ENOENT`/`EINVAL`.

Fixes #91489
