### PR TITLE
fix: make sqlite session entry writes atomic

### DIFF
--- a/src/agents/command/attempt-execution.shared.ts
+++ b/src/agents/command/attempt-execution.shared.ts
@@ -61,7 +61,9 @@ export async function persistSessionEntry(
     },
     {
       resolveSingleEntryPersistence: (entry) =>
-        entry ? { sessionKey: params.sessionKey, entry } : null,
+        entry && !params.shouldPersist && (params.clearedFields?.length ?? 0) === 0
+          ? { sessionKey: params.sessionKey, entry, patch: params.entry }
+          : null,
       takeCacheOwnership: true,
     },
   );

--- a/src/agents/command/session-store.test.ts
+++ b/src/agents/command/session-store.test.ts
@@ -227,11 +227,15 @@ describe("updateSessionStoreAfterAgentRun", () => {
           sessionId,
           updatedAt: 2,
         } as SessionEntry),
-      ).toEqual({
+      ).toMatchObject({
         sessionKey,
         entry: {
           sessionId,
           updatedAt: 2,
+        },
+        patch: {
+          model: "gpt-5.5",
+          modelProvider: "openai",
         },
       });
     });

--- a/src/agents/command/session-store.ts
+++ b/src/agents/command/session-store.ts
@@ -46,13 +46,24 @@ function resolvePositiveInteger(value: number | undefined): number | undefined {
   return Math.floor(value);
 }
 
-function removeLifecycleStateFromMetadataPatch(entry: SessionEntry): SessionEntry {
-  const next = { ...entry };
-  delete next.status;
-  delete next.startedAt;
-  delete next.endedAt;
-  delete next.runtimeMs;
-  return next;
+const TRANSIENT_LIFECYCLE_SESSION_FIELDS = new Set(["status", "startedAt", "endedAt", "runtimeMs"]);
+
+function sameJsonValue(left: unknown, right: unknown): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function deriveRunMetadataPatch(previous: SessionEntry, next: SessionEntry): Partial<SessionEntry> {
+  const patch: Record<string, unknown> = {};
+  const keys = new Set([...Object.keys(previous), ...Object.keys(next)]);
+  for (const key of keys) {
+    if (TRANSIENT_LIFECYCLE_SESSION_FIELDS.has(key)) {
+      continue;
+    }
+    if (!sameJsonValue(previous[key as keyof SessionEntry], next[key as keyof SessionEntry])) {
+      patch[key] = next[key as keyof SessionEntry];
+    }
+  }
+  return patch as Partial<SessionEntry>;
 }
 
 /** Applies run result metadata, usage, and CLI bindings to a session entry. */
@@ -291,7 +302,7 @@ export async function updateSessionStoreAfterAgentRun(params: {
         updatedAt: next.updatedAt,
         ...(touchInteraction ? { lastInteractionAt: next.lastInteractionAt } : {}),
       }
-    : removeLifecycleStateFromMetadataPatch(next);
+    : deriveRunMetadataPatch(entry, next);
   const maintenanceConfig = resolveMaintenanceConfigFromInput(cfg.session?.maintenance);
   const persisted = await updateSessionStore(
     storePath,
@@ -307,7 +318,7 @@ export async function updateSessionStoreAfterAgentRun(params: {
       takeCacheOwnership: true,
       maintenanceConfig,
       resolveSingleEntryPersistence: (entryLocal) =>
-        entryLocal ? { sessionKey, entry: entryLocal } : undefined,
+        entryLocal ? { sessionKey, entry: entryLocal, patch: metadataPatch } : undefined,
     },
   );
   if (persisted) {

--- a/src/auto-reply/reply/commands-session-store.ts
+++ b/src/auto-reply/reply/commands-session-store.ts
@@ -24,7 +24,7 @@ export async function persistSessionEntry(params: CommandParams): Promise<boolea
       },
       {
         resolveSingleEntryPersistence: (entry) =>
-          entry ? { sessionKey: params.sessionKey, entry } : null,
+          entry ? { sessionKey: params.sessionKey, entry, patch: params.sessionEntry } : null,
         skipMaintenance: true,
       },
     );
@@ -50,6 +50,12 @@ export async function persistAbortTargetEntry(params: {
   sessionStore[key] = entry;
 
   if (storePath) {
+    const patch: Partial<SessionEntry> = {
+      abortedLastRun: true,
+      abortCutoffMessageSid: abortCutoff?.messageSid,
+      abortCutoffTimestamp: abortCutoff?.timestamp,
+      updatedAt: entry.updatedAt,
+    };
     await updateSessionStore(
       storePath,
       (store) => {
@@ -65,7 +71,7 @@ export async function persistAbortTargetEntry(params: {
       },
       {
         resolveSingleEntryPersistence: (updated) =>
-          updated ? { sessionKey: key, entry: updated } : null,
+          updated ? { sessionKey: key, entry: updated, patch } : null,
       },
     );
   }

--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -52,7 +52,9 @@ async function persistSessionEntryUpdate(params: {
     },
     {
       resolveSingleEntryPersistence: (entry) =>
-        entry && params.sessionKey ? { sessionKey: params.sessionKey, entry } : null,
+        entry && params.sessionKey
+          ? { sessionKey: params.sessionKey, entry, patch: params.nextEntry }
+          : null,
     },
   );
 }

--- a/src/config/sessions.test.ts
+++ b/src/config/sessions.test.ts
@@ -1048,6 +1048,41 @@ describe("sessions", () => {
     expect(store[mainSessionKey]?.thinkingLevel).toBe("high");
   });
 
+  it("updateSessionStoreEntry preserves external SQLite writes made while callback runs", async () => {
+    const mainSessionKey = "agent:main:main";
+    const { storePath } = await createSessionStoreFixture({
+      prefix: "updateSessionStoreEntry-atomic-reread",
+      entries: {
+        [mainSessionKey]: {
+          sessionId: "sess-1",
+          updatedAt: 123,
+          thinkingLevel: "low",
+        },
+      },
+    });
+
+    await updateSessionStoreEntry({
+      storePath,
+      sessionKey: mainSessionKey,
+      update: async (entry) => {
+        expect(entry.providerOverride).toBeUndefined();
+        replaceSqliteSessionStoreBehindCache(storePath, {
+          [mainSessionKey]: {
+            sessionId: "sess-1",
+            updatedAt: 124,
+            thinkingLevel: "low",
+            providerOverride: "anthropic",
+          },
+        });
+        return { thinkingLevel: "high" };
+      },
+    });
+
+    const store = loadSessionStore(storePath, { skipCache: true });
+    expect(store[mainSessionKey]?.providerOverride).toBe("anthropic");
+    expect(store[mainSessionKey]?.thinkingLevel).toBe("high");
+  });
+
   it("updateSessionStoreEntry can skip maintenance for existing-entry metadata writes", async () => {
     const mainSessionKey = "agent:main:main";
     const staleSessionKey = "agent:main:stale";

--- a/src/config/sessions/store-sqlite.ts
+++ b/src/config/sessions/store-sqlite.ts
@@ -22,7 +22,11 @@ import {
   resolveAgentIdFromSessionStorePath,
   resolveStateDirFromSessionStorePath,
 } from "./paths.js";
-import type { SessionEntry } from "./types.js";
+import {
+  mergeSessionEntry,
+  mergeSessionEntryPreserveActivity,
+  type SessionEntry,
+} from "./types.js";
 
 const SESSION_STORE_SCOPE = "session_entries";
 
@@ -174,6 +178,69 @@ export function replaceSqliteSessionStore(
     database.db.exec("VACUUM;");
   }
   database.walMaintenance.checkpoint();
+}
+
+export type PatchSqliteSessionEntryMode = "merge" | "preserve-activity" | "replace";
+
+export function patchSqliteSessionEntry(params: {
+  storePath: string;
+  sessionKey: string;
+  fallbackEntry: SessionEntry;
+  patch: Partial<SessionEntry>;
+  mode?: PatchSqliteSessionEntryMode;
+}): SessionEntry {
+  const databaseOptions = resolveSessionStoreDatabaseOptions(params.storePath);
+  let persisted = params.fallbackEntry;
+  runOpenClawAgentWriteTransaction((database) => {
+    const db = getNodeSqliteKysely<SessionStoreDatabase>(database.db);
+    const row =
+      executeSqliteQueryTakeFirstSync(
+        database.db,
+        db
+          .selectFrom("cache_entries")
+          .select(["value_json"])
+          .where("scope", "=", SESSION_STORE_SCOPE)
+          .where("key", "=", params.sessionKey),
+      ) ?? null;
+    const current = row ? parseSessionEntryValue(row.value_json) : undefined;
+    persisted =
+      params.mode === "replace"
+        ? params.fallbackEntry
+        : current
+          ? params.mode === "preserve-activity"
+            ? mergeSessionEntryPreserveActivity(current, params.patch)
+            : mergeSessionEntry(current, params.patch)
+          : params.fallbackEntry;
+    const valueJson = JSON.stringify(persisted);
+    persisted = parseSessionEntryValue(valueJson) ?? persisted;
+    const updatedAt =
+      typeof persisted.updatedAt === "number" && Number.isFinite(persisted.updatedAt)
+        ? persisted.updatedAt
+        : Date.now();
+    executeSqliteQuerySync(
+      database.db,
+      db
+        .insertInto("cache_entries")
+        .values({
+          scope: SESSION_STORE_SCOPE,
+          key: params.sessionKey,
+          value_json: valueJson,
+          blob: null,
+          expires_at: null,
+          updated_at: updatedAt,
+        })
+        .onConflict((conflict) =>
+          conflict.columns(["scope", "key"]).doUpdateSet({
+            value_json: valueJson,
+            blob: null,
+            expires_at: null,
+            updated_at: updatedAt,
+          }),
+        ),
+    );
+  }, databaseOptions);
+  openOpenClawAgentDatabase(databaseOptions).walMaintenance.checkpoint();
+  return persisted;
 }
 
 export function clearExistingSqliteSessionStore(

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -48,7 +48,7 @@ import {
   type ResolvedSessionMaintenanceConfig,
   type SessionMaintenanceWarning,
 } from "./store-maintenance.js";
-import { replaceSqliteSessionStore } from "./store-sqlite.js";
+import { patchSqliteSessionEntry, replaceSqliteSessionStore } from "./store-sqlite.js";
 import { runExclusiveSessionStoreWrite } from "./store-writer.js";
 import {
   mergeSessionEntry,
@@ -174,6 +174,8 @@ type UpdateSessionStoreOptions<T> = SaveSessionStoreOptions & {
 type SingleEntryPersistencePatch = {
   sessionKey: string;
   entry: SessionEntry;
+  patch: Partial<SessionEntry>;
+  mode?: "merge" | "preserve-activity" | "replace";
 };
 
 type SessionEntryWorkflowOptions = {
@@ -305,6 +307,21 @@ function sessionEntriesHaveSameSerializedForm(
   next: SessionEntry,
 ): boolean {
   return previous !== undefined && JSON.stringify(previous) === JSON.stringify(next);
+}
+
+function reconcileFreshSessionStoreForCache(params: {
+  writerStore: Record<string, SessionEntry>;
+  freshStore: Record<string, SessionEntry>;
+}): Record<string, SessionEntry> {
+  const reconciled: Record<string, SessionEntry> = {};
+  for (const [key, freshEntry] of Object.entries(params.freshStore)) {
+    const writerEntry = params.writerStore[key];
+    reconciled[key] =
+      writerEntry && sessionEntriesHaveSameSerializedForm(writerEntry, freshEntry)
+        ? writerEntry
+        : freshEntry;
+  }
+  return reconciled;
 }
 
 async function saveSessionStoreUnlocked(
@@ -460,6 +477,30 @@ async function saveSessionStoreUnlocked(
     return;
   }
 
+  if (opts?.singleEntryPersistence && !maintenanceChangedStore) {
+    const persisted = patchSqliteSessionEntry({
+      storePath,
+      sessionKey: opts.singleEntryPersistence.sessionKey,
+      fallbackEntry: opts.singleEntryPersistence.entry,
+      patch: opts.singleEntryPersistence.patch,
+      mode: opts.singleEntryPersistence.mode,
+    });
+    store[opts.singleEntryPersistence.sessionKey] = persisted;
+    const freshStore = loadSessionStore(storePath, { skipCache: true, clone: false });
+    const cacheStore = reconcileFreshSessionStoreForCache({
+      writerStore: store,
+      freshStore,
+    });
+    store[opts.singleEntryPersistence.sessionKey] =
+      cacheStore[opts.singleEntryPersistence.sessionKey] ?? persisted;
+    updateSessionStoreWriteCache({
+      storePath,
+      store: cacheStore,
+      takeOwnership: true,
+    });
+    return;
+  }
+
   replaceSqliteSessionStore(storePath, store, { compact: maintenanceChangedStore });
   updateSessionStoreWriteCache({
     storePath,
@@ -558,6 +599,8 @@ async function persistResolvedSessionEntry(params: {
   store: Record<string, SessionEntry>;
   resolved: ReturnType<typeof resolveSessionStoreEntry>;
   next: SessionEntry;
+  patch?: Partial<SessionEntry>;
+  persistenceMode?: "merge" | "preserve-activity" | "replace";
   skipMaintenance?: boolean;
   takeCacheOwnership?: boolean;
   returnDetached?: boolean;
@@ -576,11 +619,17 @@ async function persistResolvedSessionEntry(params: {
     skipSerializeForUnchangedStore: entryUnchanged,
     singleEntryPersistence:
       params.resolved.legacyKeys.length === 0 && params.resolved.existing
-        ? { sessionKey: params.resolved.normalizedKey, entry: next }
+        ? {
+            sessionKey: params.resolved.normalizedKey,
+            entry: next,
+            patch: params.patch ?? next,
+            mode: params.persistenceMode,
+          }
         : undefined,
     takeCacheOwnership: params.takeCacheOwnership,
   });
-  return entryUnchanged || params.returnDetached ? cloneSessionEntry(next) : next;
+  const persisted = params.store[params.resolved.normalizedKey] ?? next;
+  return entryUnchanged || params.returnDetached ? cloneSessionEntry(persisted) : persisted;
 }
 
 export async function updateSessionStoreEntry(params: {
@@ -610,6 +659,7 @@ export async function updateSessionStoreEntry(params: {
       store,
       resolved,
       next,
+      patch,
       skipMaintenance: params.skipMaintenance,
       takeCacheOwnership: params.takeCacheOwnership ?? true,
       returnDetached: params.takeCacheOwnership !== true,
@@ -638,6 +688,7 @@ export async function applySessionStoreEntryPatch(params: {
       store,
       resolved,
       next,
+      patch,
       skipMaintenance: params.skipMaintenance,
       takeCacheOwnership: params.takeCacheOwnership ?? true,
       returnDetached: params.takeCacheOwnership !== true,
@@ -678,6 +729,12 @@ export async function patchSessionEntry(
       store,
       resolved,
       next,
+      patch,
+      persistenceMode: params.replaceEntry
+        ? "replace"
+        : params.preserveActivity
+          ? "preserve-activity"
+          : "merge",
       takeCacheOwnership: true,
       returnDetached: true,
     });
@@ -700,6 +757,8 @@ export async function upsertSessionEntry(
       store,
       resolved,
       next,
+      patch: next,
+      persistenceMode: "replace",
       takeCacheOwnership: true,
     });
   });
@@ -758,6 +817,8 @@ export async function recordSessionMetaFromInbound(params: {
       store,
       resolved,
       next,
+      patch,
+      persistenceMode: existing ? "preserve-activity" : "merge",
       takeCacheOwnership: true,
       returnDetached: true,
     });
@@ -855,6 +916,8 @@ export async function updateLastRoute(params: {
       store,
       resolved,
       next,
+      patch: metaPatch ? { ...basePatch, ...metaPatch } : basePatch,
+      persistenceMode: "preserve-activity",
       takeCacheOwnership: true,
       returnDetached: true,
     });

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -2000,6 +2000,7 @@ export const agentHandlers: GatewayRequestHandlers = {
             | {
                 sessionKey: string;
                 entry: SessionEntry;
+                patch: Partial<SessionEntry>;
               }
             | undefined;
           const persisted = await updateSessionStore(
@@ -2054,6 +2055,7 @@ export const agentHandlers: GatewayRequestHandlers = {
                   ? {
                       sessionKey: primaryKey,
                       entry: merged,
+                      patch: effectivePatch,
                     }
                   : undefined;
               return merged;


### PR DESCRIPTION
## Summary

This PR hardens the SQLite session metadata path that landed in #91322 by moving ordinary hot session-entry writes off the stale whole-store replacement path.

- Adds an atomic SQLite single-entry patch path that re-reads the current `session_entries` row inside the per-agent SQLite write transaction, merges the caller's explicit patch, and upserts only that row.
- Threads explicit patch intent through the existing session-store facade so normal metadata touches can preserve unrelated concurrent fields written by another process.
- Refactors safe production adapters to pass narrow patches for agent run metadata, slash-command session updates, auto-reply session updates, and gateway admission touches.
- Leaves the whole-store replacement path for maintenance/migration/pruning/capping/legacy-key cleanup and other multi-row operations; this PR reduces exposure to that path, but does not try to make whole-store replacement generally safe.
- Intentionally does not introduce the broader typed session/transcript schema. This is the tactical post-#91322 safety slice on top of the current `cache_entries` blob backend.

Review focus: the row-patch semantics, the cache reconciliation after a row patch, and whether each migrated caller provides a patch that accurately represents its intended write.

## Linked context

Related #91322, which moved session metadata from `sessions.json` into SQLite but retained the old load/mutate/delete-and-reinsert whole-store write shape for normal metadata updates.

Related tracker #88838 for the broader core session/transcript runtime-state SQLite migration.

Supersession notes for Josh's existing stack:

- Supersedes the immediate session-metadata atomic-write/safe-hot-write slice of #89178 on top of current `main`. It does not supersede #89178's broader typed relational schema direction or transcript/event table design.
- Partially supersedes the current-backend session-entry lifecycle mutation safety rationale in #89519, because ordinary entry patches now get a row-safe persistence path without waiting for a new accessor stack.
- Partially covers the auto-reply/agent session write safety motivation behind #89124 for the callers touched here.
- Does not supersede #90463 as an accessor/boundary ratchet, and does not supersede the transcript identity/event work such as #89121, #89123, #89201, #90437, or the later transcript-target PRs. Those remain valuable when reframed around boundaries, transcript identity, and eventual normalized storage rather than the initial SQLite storage flip.

Requested by Josh during review of the post-#91322 SQLite session-store behavior.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: ordinary session metadata writes could load a whole-store snapshot, run a callback, then replace all SQLite `session_entries` rows, which can clobber unrelated fields written by another process between the callback read and the final transaction.
- Real environment tested: local OpenClaw Codex worktree using the repo's `node scripts/run-vitest.mjs` wrapper for focused session/agent tests.
- Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/config/sessions.cache.test.ts src/config/sessions.test.ts src/agents/command/session-store.test.ts src/agents/command/attempt-execution.shared.test.ts`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): command passed 2 Vitest shards, 4 test files, 129 tests in 16.78s.
- Observed result after fix: added regression coverage proves `updateSessionStoreEntry` preserves an external SQLite write made while its update callback is running, while still applying the local patch.
- What was not tested: full suite, broad Crabbox/Testbox gate, and live gateway session workflow.
- Proof limitations or environment constraints: this is focused local regression proof for a narrow storage race; broad release verification should still run before merge.
- Before evidence (optional but encouraged): prior #91322 behavior used `replaceSqliteSessionStore`, which deletes all rows for the `session_entries` scope and reinserts from the callback's previously loaded store snapshot.

## Tests and validation

Commands run:

- `git diff --check`
- `node scripts/run-vitest.mjs src/config/sessions.cache.test.ts src/config/sessions.test.ts src/agents/command/session-store.test.ts src/agents/command/attempt-execution.shared.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

Regression coverage added:

- `src/config/sessions.test.ts` now covers preserving an external SQLite write while an `updateSessionStoreEntry` callback is in flight.
- `src/agents/command/session-store.test.ts` now verifies after-run persistence passes a narrow metadata patch rather than a broad entry-shaped persistence payload.

Autoreview result: clean, no accepted/actionable findings.

## Risk checklist

Did user-visible behavior change? `No` intended user-facing behavior change; session metadata persistence should be more concurrency-safe.

Did config, environment, or migration behavior change? `No`.

Did security, auth, secrets, network, or tool execution behavior change? `No`.

Highest-risk area: incorrectly classifying a caller as safe for row patching when its callback actually depends on deletion, conditional persistence, legacy key cleanup, maintenance, or multi-row invariants.

Mitigation: this PR only uses the row path when callers provide explicit patches. `attempt-execution.shared.ts` opts out when `clearedFields` or `shouldPersist` are present, because those require semantics beyond a simple merge patch. Whole-store replacement remains available for maintenance and structurally unsafe operations.

## Current review state

Draft PR for review. Next action is maintainer review of the row-patch contract and the supersession relationship to the older session-store PR stack.

Still waiting on broad CI/Testbox proof before this should be treated as land-ready.
