### PR TITLE
Add fail-on-tool-failure contract for isolated cron agent turns

### DIFF
--- a/packages/gateway-protocol/src/cron-validators.test.ts
+++ b/packages/gateway-protocol/src/cron-validators.test.ts
@@ -84,6 +84,31 @@ describe("cron protocol validators", () => {
     ).toBe(true);
   });
 
+  it("accepts fail-on-tool-failure agent turn payloads", () => {
+    expect(
+      validateCronAddParams({
+        ...minimalAddParams,
+        sessionTarget: "isolated",
+        payload: {
+          kind: "agentTurn",
+          message: "run nightly check",
+          failOnToolFailure: true,
+        },
+      }),
+    ).toBe(true);
+    expect(
+      validateCronUpdateParams({
+        id: "job-1",
+        patch: {
+          payload: {
+            kind: "agentTurn",
+            failOnToolFailure: false,
+          },
+        },
+      }),
+    ).toBe(true);
+  });
+
   it("rejects add params when required scheduling fields are missing", () => {
     const { wakeMode: _wakeMode, ...withoutWakeMode } = minimalAddParams;
     expect(validateCronAddParams(withoutWakeMode)).toBe(false);

--- a/packages/gateway-protocol/src/schema/cron.ts
+++ b/packages/gateway-protocol/src/schema/cron.ts
@@ -25,6 +25,7 @@ function cronAgentTurnPayloadSchema(params: {
       timeoutSeconds: Type.Optional(Type.Number({ minimum: 0 })),
       allowUnsafeExternalContent: Type.Optional(Type.Boolean()),
       lightContext: Type.Optional(Type.Boolean()),
+      failOnToolFailure: Type.Optional(Type.Boolean()),
       toolsAllow: Type.Optional(params.toolsAllow),
     },
     { additionalProperties: false },

--- a/src/cron/isolated-agent/run.meta-error-status.test.ts
+++ b/src/cron/isolated-agent/run.meta-error-status.test.ts
@@ -54,6 +54,57 @@ describe("runCronIsolatedAgentTurn - meta.error status propagation", () => {
     expect(result.outputText).toBe("cron isolated run failed: retry limit exceeded");
   });
 
+  it("marks successful final text as a cron error when failOnToolFailure sees failed tools", async () => {
+    runWithModelFallbackMock.mockResolvedValueOnce({
+      result: {
+        payloads: [{ text: "Final success-looking text" }],
+        meta: {
+          toolSummary: { calls: 3, tools: ["exec"], failures: 1, totalToolTimeMs: 120 },
+          agentMeta: { usage: { input: 0, output: 0 } },
+        },
+      },
+      provider: "openai",
+      model: "gpt-5.4",
+      attempts: [],
+    });
+
+    const result = await runCronIsolatedAgentTurn(
+      makeIsolatedAgentTurnParams({
+        job: {
+          payload: {
+            kind: "agentTurn",
+            message: "run checks",
+            failOnToolFailure: true,
+          },
+        },
+      }),
+    );
+
+    expect(result.status).toBe("error");
+    expect(result.error).toBe("cron isolated run failed: 1 tool call failed");
+    expect(result.diagnostics?.summary).toBe("cron isolated run failed: 1 tool call failed");
+  });
+
+  it("keeps successful final text ok when failOnToolFailure is not set", async () => {
+    runWithModelFallbackMock.mockResolvedValueOnce({
+      result: {
+        payloads: [{ text: "Final success-looking text" }],
+        meta: {
+          toolSummary: { calls: 3, tools: ["exec"], failures: 1, totalToolTimeMs: 120 },
+          agentMeta: { usage: { input: 0, output: 0 } },
+        },
+      },
+      provider: "openai",
+      model: "gpt-5.4",
+      attempts: [],
+    });
+
+    const result = await runCronIsolatedAgentTurn(makeIsolatedAgentTurnParams());
+
+    expect(result.status).toBe("ok");
+    expect(result.error).toBeUndefined();
+  });
+
   it("surfaces cron timeout result when the cron-nested lane watchdog fires", async () => {
     runWithModelFallbackMock.mockRejectedValueOnce(
       new CommandLaneTaskTimeoutError("cron-nested", 330_000),

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -435,6 +435,35 @@ function resolvePositiveContextTokens(value: unknown): number | undefined {
   return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : undefined;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function resolveToolFailureCountFromAgentResult(result: unknown): number {
+  if (!isRecord(result) || !isRecord(result.meta) || !isRecord(result.meta.toolSummary)) {
+    return 0;
+  }
+  const failures = result.meta.toolSummary.failures;
+  return typeof failures === "number" && Number.isFinite(failures) && failures > 0
+    ? Math.floor(failures)
+    : 0;
+}
+
+function resolveToolFailureContractError(params: {
+  agentPayload: Extract<CronJob["payload"], { kind: "agentTurn" }> | null;
+  finalRunResult: unknown;
+}): string | undefined {
+  if (params.agentPayload?.failOnToolFailure !== true) {
+    return undefined;
+  }
+  const failures = resolveToolFailureCountFromAgentResult(params.finalRunResult);
+  if (failures <= 0) {
+    return undefined;
+  }
+  const noun = failures === 1 ? "tool call" : "tool calls";
+  return `cron isolated run failed: ${failures} ${noun} failed`;
+}
+
 async function loadCliRunnerRuntime() {
   return await import("../../agents/cli-runner.runtime.js");
 }
@@ -1065,6 +1094,19 @@ async function finalizeCronRun(params: {
   const agentDiagnostics = createCronRunDiagnosticsFromAgentResult(finalRunResult, {
     finalStatus: hasFatalErrorPayload ? "error" : "ok",
   });
+  const toolFailureContractError = resolveToolFailureContractError({
+    agentPayload: prepared.agentPayload,
+    finalRunResult,
+  });
+  const toolFailureContractDiagnostics = toolFailureContractError
+    ? createCronRunDiagnosticsFromError("tool", toolFailureContractError)
+    : undefined;
+  if (toolFailureContractError) {
+    hasFatalErrorPayload = true;
+    embeddedRunError = toolFailureContractError;
+    summary = toolFailureContractError;
+    outputText = toolFailureContractError;
+  }
   const resolveRunOutcome = (result?: {
     delivered?: boolean;
     deliveryAttempted?: boolean;
@@ -1080,15 +1122,16 @@ async function finalizeCronRun(params: {
       delivered: result?.delivered,
       deliveryAttempted: result?.deliveryAttempted,
       delivery: result?.delivery,
-      diagnostics: hasFatalErrorPayload
-        ? mergeCronRunDiagnostics(
-            agentDiagnostics,
-            createCronRunDiagnosticsFromError(
+      diagnostics: mergeCronRunDiagnostics(
+        agentDiagnostics,
+        toolFailureContractDiagnostics,
+        hasFatalErrorPayload
+          ? createCronRunDiagnosticsFromError(
               "agent-run",
               embeddedRunError ?? "cron isolated run returned an error payload",
-            ),
-          )
-        : agentDiagnostics,
+            )
+          : undefined,
+      ),
       ...telemetry,
     });
   const failPendingPresentationWarningUnlessDelivered = (delivered?: boolean) => {

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -265,6 +265,9 @@ function coercePayload(payload: UnknownRecord) {
   ) {
     delete next.allowUnsafeExternalContent;
   }
+  if ("failOnToolFailure" in next && typeof next.failOnToolFailure !== "boolean") {
+    delete next.failOnToolFailure;
+  }
   if (next.kind === "systemEvent") {
     delete next.message;
     delete next.model;
@@ -272,6 +275,7 @@ function coercePayload(payload: UnknownRecord) {
     delete next.thinking;
     delete next.timeoutSeconds;
     delete next.lightContext;
+    delete next.failOnToolFailure;
     delete next.allowUnsafeExternalContent;
     delete next.toolsAllow;
     delete next.argv;
@@ -295,6 +299,7 @@ function coercePayload(payload: UnknownRecord) {
     delete next.fallbacks;
     delete next.thinking;
     delete next.lightContext;
+    delete next.failOnToolFailure;
     delete next.allowUnsafeExternalContent;
     delete next.toolsAllow;
   }

--- a/src/cron/service.jobs.test.ts
+++ b/src/cron/service.jobs.test.ts
@@ -294,6 +294,31 @@ describe("applyJobPatch", () => {
     }
   });
 
+  it("persists agentTurn payload.failOnToolFailure updates when editing existing jobs", () => {
+    const job = createIsolatedAgentTurnJob("job-fail-on-tool", {
+      mode: "announce",
+      channel: "telegram",
+    });
+    job.payload = {
+      kind: "agentTurn",
+      message: "do it",
+      failOnToolFailure: false,
+    };
+
+    applyJobPatch(job, {
+      payload: {
+        kind: "agentTurn",
+        message: "do it",
+        failOnToolFailure: true,
+      },
+    });
+
+    expect(job.payload.kind).toBe("agentTurn");
+    if (job.payload.kind === "agentTurn") {
+      expect(job.payload.failOnToolFailure).toBe(true);
+    }
+  });
+
   it("persists agentTurn payload.fallbacks updates when editing existing jobs", () => {
     const job = createIsolatedAgentTurnJob("job-fallbacks", {
       mode: "announce",

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -943,6 +943,9 @@ function mergeCronPayload(existing: CronPayload, patch: CronPayloadPatch): CronP
   if (typeof patch.lightContext === "boolean") {
     next.lightContext = patch.lightContext;
   }
+  if (typeof patch.failOnToolFailure === "boolean") {
+    next.failOnToolFailure = patch.failOnToolFailure;
+  }
   if (typeof patch.allowUnsafeExternalContent === "boolean") {
     next.allowUnsafeExternalContent = patch.allowUnsafeExternalContent;
   }
@@ -986,6 +989,7 @@ function buildPayloadFromPatch(patch: CronPayloadPatch): CronPayload {
     thinking: patch.thinking,
     timeoutSeconds: patch.timeoutSeconds,
     lightContext: patch.lightContext,
+    failOnToolFailure: patch.failOnToolFailure,
     allowUnsafeExternalContent: patch.allowUnsafeExternalContent,
   };
 }

--- a/src/cron/store/payload-codec.ts
+++ b/src/cron/store/payload-codec.ts
@@ -68,6 +68,7 @@ export function bindPayloadColumns(
   | "payload_allow_unsafe_external_content"
   | "payload_external_content_source_json"
   | "payload_fallbacks_json"
+  | "payload_fail_on_tool_failure"
   | "payload_kind"
   | "payload_light_context"
   | "payload_message"
@@ -87,6 +88,7 @@ export function bindPayloadColumns(
       payload_allow_unsafe_external_content: null,
       payload_external_content_source_json: null,
       payload_light_context: null,
+      payload_fail_on_tool_failure: null,
       payload_tools_allow_json: null,
     };
   }
@@ -102,6 +104,7 @@ export function bindPayloadColumns(
       payload_allow_unsafe_external_content: null,
       payload_external_content_source_json: null,
       payload_light_context: null,
+      payload_fail_on_tool_failure: null,
       payload_tools_allow_json: null,
     };
   }
@@ -115,6 +118,7 @@ export function bindPayloadColumns(
     payload_allow_unsafe_external_content: booleanToInteger(payload.allowUnsafeExternalContent),
     payload_external_content_source_json: serializeJson(payload.externalContentSource),
     payload_light_context: booleanToInteger(payload.lightContext),
+    payload_fail_on_tool_failure: booleanToInteger(payload.failOnToolFailure),
     payload_tools_allow_json: serializeJson(payload.toolsAllow),
   };
 }
@@ -141,6 +145,10 @@ export function payloadFromRow(row: CronJobRow): CronPayload | null {
     );
     const lightContext =
       row.payload_light_context != null ? integerToBoolean(row.payload_light_context) : undefined;
+    const failOnToolFailure =
+      row.payload_fail_on_tool_failure != null
+        ? integerToBoolean(row.payload_fail_on_tool_failure)
+        : undefined;
     const toolsAllow = row.payload_tools_allow_json
       ? parseJsonArray(row.payload_tools_allow_json)
       : undefined;
@@ -154,6 +162,7 @@ export function payloadFromRow(row: CronJobRow): CronPayload | null {
       ...(allowUnsafeExternalContent != null ? { allowUnsafeExternalContent } : {}),
       ...(externalContentSource ? { externalContentSource } : {}),
       ...(lightContext != null ? { lightContext } : {}),
+      ...(failOnToolFailure != null ? { failOnToolFailure } : {}),
       ...(toolsAllow ? { toolsAllow } : {}),
     };
   }

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -246,6 +246,8 @@ type CronAgentTurnPayloadFields = {
   externalContentSource?: HookExternalContentSource;
   /** If true, run with lightweight bootstrap context. */
   lightContext?: boolean;
+  /** If true, any failed tool call makes the cron run fail even if final text exists. */
+  failOnToolFailure?: boolean;
   /** Optional tool allow-list; when set, only these tools are sent to the model. */
   toolsAllow?: string[];
 };

--- a/src/state/openclaw-state-db.generated.d.ts
+++ b/src/state/openclaw-state-db.generated.d.ts
@@ -282,6 +282,7 @@ export interface CronJobs {
   payload_allow_unsafe_external_content: number | null;
   payload_external_content_source_json: string | null;
   payload_fallbacks_json: string | null;
+  payload_fail_on_tool_failure: number | null;
   payload_kind: string;
   payload_light_context: number | null;
   payload_message: string | null;

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -431,6 +431,7 @@ function backfillCronJobsFromJobJson(db: DatabaseSync): void {
             payload_allow_unsafe_external_content = ?,
             payload_external_content_source_json = ?,
             payload_light_context = ?,
+            payload_fail_on_tool_failure = ?,
             payload_tools_allow_json = ?,
             delivery_mode = ?,
             delivery_channel = ?,
@@ -520,6 +521,11 @@ function backfillCronJobsFromJobJson(db: DatabaseSync): void {
       isAgentTurn ? jsonField(payload.externalContentSource) : null,
       isAgentTurn && typeof payload.lightContext === "boolean"
         ? payload.lightContext
+          ? 1
+          : 0
+        : null,
+      isAgentTurn && typeof payload.failOnToolFailure === "boolean"
+        ? payload.failOnToolFailure
           ? 1
           : 0
         : null,
@@ -683,6 +689,7 @@ function ensureAdditiveStateColumns(db: DatabaseSync): void {
   ensureColumn(db, "cron_jobs", "payload_allow_unsafe_external_content INTEGER");
   ensureColumn(db, "cron_jobs", "payload_external_content_source_json TEXT");
   ensureColumn(db, "cron_jobs", "payload_light_context INTEGER");
+  ensureColumn(db, "cron_jobs", "payload_fail_on_tool_failure INTEGER");
   ensureColumn(db, "cron_jobs", "payload_tools_allow_json TEXT");
   ensureColumn(db, "cron_jobs", "delivery_mode TEXT");
   ensureColumn(db, "cron_jobs", "delivery_channel TEXT");

--- a/src/state/openclaw-state-schema.generated.ts
+++ b/src/state/openclaw-state-schema.generated.ts
@@ -883,6 +883,7 @@ CREATE TABLE IF NOT EXISTS cron_jobs (
   payload_allow_unsafe_external_content INTEGER,
   payload_external_content_source_json TEXT,
   payload_light_context INTEGER,
+  payload_fail_on_tool_failure INTEGER,
   payload_tools_allow_json TEXT,
   delivery_mode TEXT,
   delivery_channel TEXT,

--- a/src/state/openclaw-state-schema.sql
+++ b/src/state/openclaw-state-schema.sql
@@ -878,6 +878,7 @@ CREATE TABLE IF NOT EXISTS cron_jobs (
   payload_allow_unsafe_external_content INTEGER,
   payload_external_content_source_json TEXT,
   payload_light_context INTEGER,
+  payload_fail_on_tool_failure INTEGER,
   payload_tools_allow_json TEXT,
   delivery_mode TEXT,
   delivery_channel TEXT,


### PR DESCRIPTION
Title: Add fail-on-tool-failure contract for isolated cron agent turns

## Summary

- add `payload.failOnToolFailure` to agent-turn cron payload validation and runtime types
- persist the flag through cron SQLite projections and additive state-schema repair
- make isolated cron runs return `status: "error"` when `meta.toolSummary.failures > 0` under that flag
- cover public validation, patch merging, and isolated-run behavior with focused tests

## Verification

- `pnpm exec vitest run packages/gateway-protocol/src/cron-validators.test.ts src/cron/service.jobs.test.ts src/cron/isolated-agent/run.meta-error-status.test.ts`
- `pnpm tsgo:core`

## Notes

This keeps the default behavior unchanged. Existing agent-turn crons continue to tolerate recovered tool failures unless the job opts into `failOnToolFailure: true`.

Local branch: `orphu/cron-fail-contract`
Local commit: `97862abf2c4d`
Patch artifact: `/Users/orphu/clawd/comms/openclaw-cron-failcontract.patch`
