### PR TITLE
chore: bump Codex app-server to 0.137.0

### DIFF
--- a/docs/plugins/codex-harness-reference.md
+++ b/docs/plugins/codex-harness-reference.md
@@ -373,17 +373,16 @@ If discovery fails or times out, OpenClaw uses a bundled fallback catalog for:
 - GPT-5.4 mini
 - GPT-5.2
 
-The current bundled harness is `@openai/codex` `0.135.0`. A `model/list` probe
+The current bundled harness is `@openai/codex` `0.137.0`. A `model/list` probe
 against that bundled app-server returned:
 
-| Model id              | Default | Hidden | Input modalities | Reasoning efforts        |
-| --------------------- | ------- | ------ | ---------------- | ------------------------ |
-| `gpt-5.5`             | Yes     | No     | text, image      | low, medium, high, xhigh |
-| `gpt-5.4`             | No      | No     | text, image      | low, medium, high, xhigh |
-| `gpt-5.4-mini`        | No      | No     | text, image      | low, medium, high, xhigh |
-| `gpt-5.3-codex`       | No      | No     | text, image      | low, medium, high, xhigh |
-| `gpt-5.3-codex-spark` | No      | No     | text             | low, medium, high, xhigh |
-| `gpt-5.2`             | No      | No     | text, image      | low, medium, high, xhigh |
+| Model id        | Default | Hidden | Input modalities | Reasoning efforts        |
+| --------------- | ------- | ------ | ---------------- | ------------------------ |
+| `gpt-5.5`       | Yes     | No     | text, image      | low, medium, high, xhigh |
+| `gpt-5.4`       | No      | No     | text, image      | low, medium, high, xhigh |
+| `gpt-5.4-mini`  | No      | No     | text, image      | low, medium, high, xhigh |
+| `gpt-5.3-codex` | No      | No     | text, image      | low, medium, high, xhigh |
+| `gpt-5.2`       | No      | No     | text, image      | low, medium, high, xhigh |
 
 Hidden models can be returned by the app-server catalog for internal or
 specialized flows, but they are not normal model-picker choices.

--- a/extensions/codex/npm-shrinkwrap.json
+++ b/extensions/codex/npm-shrinkwrap.json
@@ -8,16 +8,16 @@
       "name": "@openclaw/codex",
       "version": "2026.6.2",
       "dependencies": {
-        "@openai/codex": "0.135.0",
+        "@openai/codex": "0.137.0",
         "typebox": "1.1.39",
         "ws": "8.21.0",
         "zod": "4.4.3"
       }
     },
     "node_modules/@openai/codex": {
-      "version": "0.135.0",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.135.0.tgz",
-      "integrity": "sha512-ID75QEYmAT1WsUQmpxPlNsL5W1a+2eeD7fP6ywdwGseiXUG8D5i16L+dzbr8MT+2oTkaVqzOdvAqVOCeV/H/Bw==",
+      "version": "0.137.0",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.137.0.tgz",
+      "integrity": "sha512-1jUsCnzDBwv7Z4VFZajIlsz41fC18qg6d5qK4PEZhiUk0zJHS90/uGBA70aQPUJLTUZShvyKVAANjw6J/D9eYQ==",
       "license": "Apache-2.0",
       "bin": {
         "codex": "bin/codex.js"
@@ -26,19 +26,19 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.135.0-darwin-arm64",
-        "@openai/codex-darwin-x64": "npm:@openai/codex@0.135.0-darwin-x64",
-        "@openai/codex-linux-arm64": "npm:@openai/codex@0.135.0-linux-arm64",
-        "@openai/codex-linux-x64": "npm:@openai/codex@0.135.0-linux-x64",
-        "@openai/codex-win32-arm64": "npm:@openai/codex@0.135.0-win32-arm64",
-        "@openai/codex-win32-x64": "npm:@openai/codex@0.135.0-win32-x64"
+        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.137.0-darwin-arm64",
+        "@openai/codex-darwin-x64": "npm:@openai/codex@0.137.0-darwin-x64",
+        "@openai/codex-linux-arm64": "npm:@openai/codex@0.137.0-linux-arm64",
+        "@openai/codex-linux-x64": "npm:@openai/codex@0.137.0-linux-x64",
+        "@openai/codex-win32-arm64": "npm:@openai/codex@0.137.0-win32-arm64",
+        "@openai/codex-win32-x64": "npm:@openai/codex@0.137.0-win32-x64"
       }
     },
     "node_modules/@openai/codex-darwin-arm64": {
       "name": "@openai/codex",
-      "version": "0.135.0-darwin-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.135.0-darwin-arm64.tgz",
-      "integrity": "sha512-wpNzssusKfrldVlq39+HyQh1wCyc9SQNpHdAFGKtPenrgRte4Ct8/oVsDtKWuFZsqLBFwbL4MrzrevnB63+9HA==",
+      "version": "0.137.0-darwin-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.137.0-darwin-arm64.tgz",
+      "integrity": "sha512-YjKmre7DlKslQVhSfocHscgxntZKaZc1LQySKh7q+hNL8jdK+c8nSWSePi583yKFNIxZ8Z/zCkewtjFNvOpQiQ==",
       "cpu": [
         "arm64"
       ],
@@ -53,9 +53,9 @@
     },
     "node_modules/@openai/codex-darwin-x64": {
       "name": "@openai/codex",
-      "version": "0.135.0-darwin-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.135.0-darwin-x64.tgz",
-      "integrity": "sha512-ZrjAqce23lbv9KfkYOhElf1lTI+SysXmyGM0FV5u4+PBCKPkkEs4eaS3H8Uig0i4bUSu1QylrOOCskzYhZ6VyQ==",
+      "version": "0.137.0-darwin-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.137.0-darwin-x64.tgz",
+      "integrity": "sha512-zjzrFV80LZby9et44dan82e3cwUd46U7u1LSVXTIz5AUcY4y1KZpAeN6cSLVKMZuOHXTDpi15MUQdRwzdeqIOg==",
       "cpu": [
         "x64"
       ],
@@ -70,9 +70,9 @@
     },
     "node_modules/@openai/codex-linux-arm64": {
       "name": "@openai/codex",
-      "version": "0.135.0-linux-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.135.0-linux-arm64.tgz",
-      "integrity": "sha512-dM+cv5ZL+BgIQzEIvMg9AxZ98n5lkKLgtp5zJLXWSrbCllbnUSqxYMUiWI5c1a1uBDUtkbY9fcGKXFLf+d+gyg==",
+      "version": "0.137.0-linux-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.137.0-linux-arm64.tgz",
+      "integrity": "sha512-R3ZZymQQA1qpp6OpowN49XJ4scHwSckq7CjVvgmLv3bIs3X+F0XXK3xPFkC9vs2mX3wPekPi3ONpxx+yPAsJ6Q==",
       "cpu": [
         "arm64"
       ],
@@ -87,9 +87,9 @@
     },
     "node_modules/@openai/codex-linux-x64": {
       "name": "@openai/codex",
-      "version": "0.135.0-linux-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.135.0-linux-x64.tgz",
-      "integrity": "sha512-5EosY67yU28UJSnl/obdN2F1CDaimYbzm9SLR8dwwzkeBBnY6dHgAKJ2GTu9Nc8CmgmtVFBGzgPqehsIcueVvA==",
+      "version": "0.137.0-linux-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.137.0-linux-x64.tgz",
+      "integrity": "sha512-n+26MUj8rekbEDUeYTGoD6HXuGS0MmLHn2LOn0i5qTNYIJvXV82B7cCLSTzVKF/RJxRMRl22se9Q0Z035JIVng==",
       "cpu": [
         "x64"
       ],
@@ -104,9 +104,9 @@
     },
     "node_modules/@openai/codex-win32-arm64": {
       "name": "@openai/codex",
-      "version": "0.135.0-win32-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.135.0-win32-arm64.tgz",
-      "integrity": "sha512-SAeR+CUv7KWwE6eTc2UFaFjo6FpHywYfDFKrK6FqLms1rq1NPju2SoX7rhM6UEew/lUx2mdZv/LDs11s/N/Qgg==",
+      "version": "0.137.0-win32-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.137.0-win32-arm64.tgz",
+      "integrity": "sha512-Cofktt213TycdQ/v+nAUuwXUBzjMWfA/ZkXyqefyXxDgw0TMtaiM3cgDna3I8YdXnR0PM9AMbx4t7VloJ3ZZYQ==",
       "cpu": [
         "arm64"
       ],
@@ -121,9 +121,9 @@
     },
     "node_modules/@openai/codex-win32-x64": {
       "name": "@openai/codex",
-      "version": "0.135.0-win32-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.135.0-win32-x64.tgz",
-      "integrity": "sha512-uYwUBMbOfmVlCESJZmZsOG+cYwNFYvkMbQ+FB6C1u9RYz0m3mZeYNN0j+l1hRSyUgPMFJHzNpgNx1Usal5QZFQ==",
+      "version": "0.137.0-win32-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.137.0-win32-x64.tgz",
+      "integrity": "sha512-g9qZ9ERrm5OWXMWJOgojYv1kOc5jajTKq37PBMSe56aJfAr9Jk/qBvIOy7LKq3rABdXuz8k+W65PIt2E1hXilw==",
       "cpu": [
         "x64"
       ],

--- a/extensions/codex/package.json
+++ b/extensions/codex/package.json
@@ -8,7 +8,7 @@
   },
   "type": "module",
   "dependencies": {
-    "@openai/codex": "0.135.0",
+    "@openai/codex": "0.137.0",
     "typebox": "1.1.39",
     "ws": "8.21.0",
     "zod": "4.4.3"

--- a/extensions/codex/src/app-server/protocol-generated/json/DynamicToolCallParams.json
+++ b/extensions/codex/src/app-server/protocol-generated/json/DynamicToolCallParams.json
@@ -1,14 +1,5 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "DynamicToolCallParams",
-  "type": "object",
-  "required": [
-    "arguments",
-    "callId",
-    "threadId",
-    "tool",
-    "turnId"
-  ],
   "properties": {
     "arguments": true,
     "callId": {
@@ -29,5 +20,14 @@
     "turnId": {
       "type": "string"
     }
-  }
+  },
+  "required": [
+    "arguments",
+    "callId",
+    "threadId",
+    "tool",
+    "turnId"
+  ],
+  "title": "DynamicToolCallParams",
+  "type": "object"
 }

--- a/extensions/codex/src/app-server/protocol-generated/json/v2/ErrorNotification.json
+++ b/extensions/codex/src/app-server/protocol-generated/json/v2/ErrorNotification.json
@@ -1,33 +1,10 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "ErrorNotification",
-  "type": "object",
-  "required": [
-    "error",
-    "threadId",
-    "turnId",
-    "willRetry"
-  ],
-  "properties": {
-    "error": {
-      "$ref": "#/definitions/TurnError"
-    },
-    "threadId": {
-      "type": "string"
-    },
-    "turnId": {
-      "type": "string"
-    },
-    "willRetry": {
-      "type": "boolean"
-    }
-  },
   "definitions": {
     "CodexErrorInfo": {
       "description": "This translation layer make sure that we expose codex error code in camel case.\n\nWhen an upstream HTTP status is available (for example, from the Responses API or a provider), it is forwarded in `httpStatusCode` on the relevant `codexErrorInfo` variant.",
       "oneOf": [
         {
-          "type": "string",
           "enum": [
             "contextWindowExceeded",
             "usageLimitExceeded",
@@ -39,139 +16,136 @@
             "threadRollbackFailed",
             "sandboxError",
             "other"
-          ]
+          ],
+          "type": "string"
         },
         {
-          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "httpConnectionFailed": {
+              "properties": {
+                "httpStatusCode": {
+                  "format": "uint16",
+                  "minimum": 0,
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                }
+              },
+              "type": "object"
+            }
+          },
           "required": [
             "httpConnectionFailed"
           ],
+          "title": "HttpConnectionFailedCodexErrorInfo",
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "description": "Failed to connect to the response SSE stream.",
           "properties": {
-            "httpConnectionFailed": {
-              "type": "object",
+            "responseStreamConnectionFailed": {
               "properties": {
                 "httpStatusCode": {
+                  "format": "uint16",
+                  "minimum": 0,
                   "type": [
                     "integer",
                     "null"
-                  ],
-                  "format": "uint16",
-                  "minimum": 0
+                  ]
                 }
-              }
+              },
+              "type": "object"
             }
           },
-          "additionalProperties": false,
-          "title": "HttpConnectionFailedCodexErrorInfo"
-        },
-        {
-          "description": "Failed to connect to the response SSE stream.",
-          "type": "object",
           "required": [
             "responseStreamConnectionFailed"
           ],
+          "title": "ResponseStreamConnectionFailedCodexErrorInfo",
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "description": "The response SSE stream disconnected in the middle of a turn before completion.",
           "properties": {
-            "responseStreamConnectionFailed": {
-              "type": "object",
+            "responseStreamDisconnected": {
               "properties": {
                 "httpStatusCode": {
+                  "format": "uint16",
+                  "minimum": 0,
                   "type": [
                     "integer",
                     "null"
-                  ],
-                  "format": "uint16",
-                  "minimum": 0
+                  ]
                 }
-              }
+              },
+              "type": "object"
             }
           },
-          "additionalProperties": false,
-          "title": "ResponseStreamConnectionFailedCodexErrorInfo"
-        },
-        {
-          "description": "The response SSE stream disconnected in the middle of a turn before completion.",
-          "type": "object",
           "required": [
             "responseStreamDisconnected"
           ],
+          "title": "ResponseStreamDisconnectedCodexErrorInfo",
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "description": "Reached the retry limit for responses.",
           "properties": {
-            "responseStreamDisconnected": {
-              "type": "object",
+            "responseTooManyFailedAttempts": {
               "properties": {
                 "httpStatusCode": {
+                  "format": "uint16",
+                  "minimum": 0,
                   "type": [
                     "integer",
                     "null"
-                  ],
-                  "format": "uint16",
-                  "minimum": 0
+                  ]
                 }
-              }
+              },
+              "type": "object"
             }
           },
-          "additionalProperties": false,
-          "title": "ResponseStreamDisconnectedCodexErrorInfo"
-        },
-        {
-          "description": "Reached the retry limit for responses.",
-          "type": "object",
           "required": [
             "responseTooManyFailedAttempts"
           ],
-          "properties": {
-            "responseTooManyFailedAttempts": {
-              "type": "object",
-              "properties": {
-                "httpStatusCode": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ],
-                  "format": "uint16",
-                  "minimum": 0
-                }
-              }
-            }
-          },
-          "additionalProperties": false,
-          "title": "ResponseTooManyFailedAttemptsCodexErrorInfo"
+          "title": "ResponseTooManyFailedAttemptsCodexErrorInfo",
+          "type": "object"
         },
         {
+          "additionalProperties": false,
           "description": "Returned when `turn/start` or `turn/steer` is submitted while the current active turn cannot accept same-turn steering, for example `/review` or manual `/compact`.",
-          "type": "object",
-          "required": [
-            "activeTurnNotSteerable"
-          ],
           "properties": {
             "activeTurnNotSteerable": {
-              "type": "object",
-              "required": [
-                "turnKind"
-              ],
               "properties": {
                 "turnKind": {
                   "$ref": "#/definitions/NonSteerableTurnKind"
                 }
-              }
+              },
+              "required": [
+                "turnKind"
+              ],
+              "type": "object"
             }
           },
-          "additionalProperties": false,
-          "title": "ActiveTurnNotSteerableCodexErrorInfo"
+          "required": [
+            "activeTurnNotSteerable"
+          ],
+          "title": "ActiveTurnNotSteerableCodexErrorInfo",
+          "type": "object"
         }
       ]
     },
     "NonSteerableTurnKind": {
-      "type": "string",
       "enum": [
         "review",
         "compact"
-      ]
+      ],
+      "type": "string"
     },
     "TurnError": {
-      "type": "object",
-      "required": [
-        "message"
-      ],
       "properties": {
         "additionalDetails": {
           "default": null,
@@ -193,7 +167,33 @@
         "message": {
           "type": "string"
         }
-      }
+      },
+      "required": [
+        "message"
+      ],
+      "type": "object"
     }
-  }
+  },
+  "properties": {
+    "error": {
+      "$ref": "#/definitions/TurnError"
+    },
+    "threadId": {
+      "type": "string"
+    },
+    "turnId": {
+      "type": "string"
+    },
+    "willRetry": {
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "error",
+    "threadId",
+    "turnId",
+    "willRetry"
+  ],
+  "title": "ErrorNotification",
+  "type": "object"
 }

--- a/extensions/codex/src/app-server/protocol-generated/json/v2/GetAccountResponse.json
+++ b/extensions/codex/src/app-server/protocol-generated/json/v2/GetAccountResponse.json
@@ -1,10 +1,84 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "GetAccountResponse",
-  "type": "object",
-  "required": [
-    "requiresOpenaiAuth"
-  ],
+  "definitions": {
+    "Account": {
+      "oneOf": [
+        {
+          "properties": {
+            "type": {
+              "enum": [
+                "apiKey"
+              ],
+              "title": "ApiKeyAccountType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "title": "ApiKeyAccount",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "email": {
+              "type": "string"
+            },
+            "planType": {
+              "$ref": "#/definitions/PlanType"
+            },
+            "type": {
+              "enum": [
+                "chatgpt"
+              ],
+              "title": "ChatgptAccountType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "email",
+            "planType",
+            "type"
+          ],
+          "title": "ChatgptAccount",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "type": {
+              "enum": [
+                "amazonBedrock"
+              ],
+              "title": "AmazonBedrockAccountType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "title": "AmazonBedrockAccount",
+          "type": "object"
+        }
+      ]
+    },
+    "PlanType": {
+      "enum": [
+        "free",
+        "go",
+        "plus",
+        "pro",
+        "prolite",
+        "team",
+        "self_serve_business_usage_based",
+        "business",
+        "enterprise_cbp_usage_based",
+        "enterprise",
+        "edu",
+        "unknown"
+      ],
+      "type": "string"
+    }
+  },
   "properties": {
     "account": {
       "anyOf": [
@@ -20,83 +94,9 @@
       "type": "boolean"
     }
   },
-  "definitions": {
-    "Account": {
-      "oneOf": [
-        {
-          "type": "object",
-          "required": [
-            "type"
-          ],
-          "properties": {
-            "type": {
-              "type": "string",
-              "enum": [
-                "apiKey"
-              ],
-              "title": "ApiKeyAccountType"
-            }
-          },
-          "title": "ApiKeyAccount"
-        },
-        {
-          "type": "object",
-          "required": [
-            "email",
-            "planType",
-            "type"
-          ],
-          "properties": {
-            "email": {
-              "type": "string"
-            },
-            "planType": {
-              "$ref": "#/definitions/PlanType"
-            },
-            "type": {
-              "type": "string",
-              "enum": [
-                "chatgpt"
-              ],
-              "title": "ChatgptAccountType"
-            }
-          },
-          "title": "ChatgptAccount"
-        },
-        {
-          "type": "object",
-          "required": [
-            "type"
-          ],
-          "properties": {
-            "type": {
-              "type": "string",
-              "enum": [
-                "amazonBedrock"
-              ],
-              "title": "AmazonBedrockAccountType"
-            }
-          },
-          "title": "AmazonBedrockAccount"
-        }
-      ]
-    },
-    "PlanType": {
-      "type": "string",
-      "enum": [
-        "free",
-        "go",
-        "plus",
-        "pro",
-        "prolite",
-        "team",
-        "self_serve_business_usage_based",
-        "business",
-        "enterprise_cbp_usage_based",
-        "enterprise",
-        "edu",
-        "unknown"
-      ]
-    }
-  }
+  "required": [
+    "requiresOpenaiAuth"
+  ],
+  "title": "GetAccountResponse",
+  "type": "object"
 }

--- a/extensions/codex/src/app-server/protocol-generated/json/v2/ModelListResponse.json
+++ b/extensions/codex/src/app-server/protocol-generated/json/v2/ModelListResponse.json
@@ -1,65 +1,34 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "ModelListResponse",
-  "type": "object",
-  "required": [
-    "data"
-  ],
-  "properties": {
-    "data": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/Model"
-      }
-    },
-    "nextCursor": {
-      "description": "Opaque cursor to pass to the next call to continue after the last item. If None, there are no more items to return.",
-      "type": [
-        "string",
-        "null"
-      ]
-    }
-  },
   "definitions": {
     "InputModality": {
       "description": "Canonical user-input modality tags advertised by a model.",
       "oneOf": [
         {
           "description": "Plain text turns and tool payloads.",
-          "type": "string",
           "enum": [
             "text"
-          ]
+          ],
+          "type": "string"
         },
         {
           "description": "Image attachments included in user turns.",
-          "type": "string",
           "enum": [
             "image"
-          ]
+          ],
+          "type": "string"
         }
       ]
     },
     "Model": {
-      "type": "object",
-      "required": [
-        "defaultReasoningEffort",
-        "description",
-        "displayName",
-        "hidden",
-        "id",
-        "isDefault",
-        "model",
-        "supportedReasoningEfforts"
-      ],
       "properties": {
         "additionalSpeedTiers": {
-          "description": "Deprecated: use `serviceTiers` instead.",
           "default": [],
-          "type": "array",
+          "description": "Deprecated: use `serviceTiers` instead.",
           "items": {
             "type": "string"
-          }
+          },
+          "type": "array"
         },
         "availabilityNux": {
           "anyOf": [
@@ -73,6 +42,14 @@
         },
         "defaultReasoningEffort": {
           "$ref": "#/definitions/ReasoningEffort"
+        },
+        "defaultServiceTier": {
+          "default": null,
+          "description": "Catalog default service tier id for this model, when one is configured.",
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "description": {
           "type": "string"
@@ -91,10 +68,10 @@
             "text",
             "image"
           ],
-          "type": "array",
           "items": {
             "$ref": "#/definitions/InputModality"
-          }
+          },
+          "type": "array"
         },
         "isDefault": {
           "type": "boolean"
@@ -104,16 +81,16 @@
         },
         "serviceTiers": {
           "default": [],
-          "type": "array",
           "items": {
             "$ref": "#/definitions/ModelServiceTier"
-          }
+          },
+          "type": "array"
         },
         "supportedReasoningEfforts": {
-          "type": "array",
           "items": {
             "$ref": "#/definitions/ReasoningEffortOption"
-          }
+          },
+          "type": "array"
         },
         "supportsPersonality": {
           "default": false,
@@ -135,26 +112,31 @@
             }
           ]
         }
-      }
+      },
+      "required": [
+        "defaultReasoningEffort",
+        "description",
+        "displayName",
+        "hidden",
+        "id",
+        "isDefault",
+        "model",
+        "supportedReasoningEfforts"
+      ],
+      "type": "object"
     },
     "ModelAvailabilityNux": {
-      "type": "object",
-      "required": [
-        "message"
-      ],
       "properties": {
         "message": {
           "type": "string"
         }
-      }
+      },
+      "required": [
+        "message"
+      ],
+      "type": "object"
     },
     "ModelServiceTier": {
-      "type": "object",
-      "required": [
-        "description",
-        "id",
-        "name"
-      ],
       "properties": {
         "description": {
           "type": "string"
@@ -165,13 +147,15 @@
         "name": {
           "type": "string"
         }
-      }
+      },
+      "required": [
+        "description",
+        "id",
+        "name"
+      ],
+      "type": "object"
     },
     "ModelUpgradeInfo": {
-      "type": "object",
-      "required": [
-        "model"
-      ],
       "properties": {
         "migrationMarkdown": {
           "type": [
@@ -194,11 +178,14 @@
             "null"
           ]
         }
-      }
+      },
+      "required": [
+        "model"
+      ],
+      "type": "object"
     },
     "ReasoningEffort": {
       "description": "See https://platform.openai.com/docs/guides/reasoning?api-mode=responses#get-started-with-reasoning",
-      "type": "string",
       "enum": [
         "none",
         "minimal",
@@ -206,14 +193,10 @@
         "medium",
         "high",
         "xhigh"
-      ]
+      ],
+      "type": "string"
     },
     "ReasoningEffortOption": {
-      "type": "object",
-      "required": [
-        "description",
-        "reasoningEffort"
-      ],
       "properties": {
         "description": {
           "type": "string"
@@ -221,7 +204,32 @@
         "reasoningEffort": {
           "$ref": "#/definitions/ReasoningEffort"
         }
-      }
+      },
+      "required": [
+        "description",
+        "reasoningEffort"
+      ],
+      "type": "object"
     }
-  }
+  },
+  "properties": {
+    "data": {
+      "items": {
+        "$ref": "#/definitions/Model"
+      },
+      "type": "array"
+    },
+    "nextCursor": {
+      "description": "Opaque cursor to pass to the next call to continue after the last item. If None, there are no more items to return.",
+      "type": [
+        "string",
+        "null"
+      ]
+    }
+  },
+  "required": [
+    "data"
+  ],
+  "title": "ModelListResponse",
+  "type": "object"
 }

--- a/extensions/codex/src/app-server/protocol-generated/json/v2/ThreadResumeResponse.json
+++ b/extensions/codex/src/app-server/protocol-generated/json/v2/ThreadResumeResponse.json
@@ -1,107 +1,15 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "ThreadResumeResponse",
-  "type": "object",
-  "required": [
-    "approvalPolicy",
-    "approvalsReviewer",
-    "cwd",
-    "model",
-    "modelProvider",
-    "sandbox",
-    "thread"
-  ],
-  "properties": {
-    "activePermissionProfile": {
-      "description": "Named or implicit built-in profile that produced the active permissions, when known.",
-      "default": null,
-      "anyOf": [
-        {
-          "$ref": "#/definitions/ActivePermissionProfile"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "approvalPolicy": {
-      "$ref": "#/definitions/AskForApproval"
-    },
-    "approvalsReviewer": {
-      "description": "Reviewer currently used for approval requests on this thread.",
-      "allOf": [
-        {
-          "$ref": "#/definitions/ApprovalsReviewer"
-        }
-      ]
-    },
-    "cwd": {
-      "$ref": "#/definitions/AbsolutePathBuf"
-    },
-    "instructionSources": {
-      "description": "Instruction source files currently loaded for this thread.",
-      "default": [],
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/AbsolutePathBuf"
-      }
-    },
-    "model": {
-      "type": "string"
-    },
-    "modelProvider": {
-      "type": "string"
-    },
-    "reasoningEffort": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/ReasoningEffort"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "runtimeWorkspaceRoots": {
-      "description": "Thread-scoped runtime workspace roots used to materialize `:workspace_roots`.",
-      "default": [],
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/AbsolutePathBuf"
-      }
-    },
-    "sandbox": {
-      "description": "Legacy sandbox policy retained for compatibility. Experimental clients should prefer `activePermissionProfile` for profile provenance.",
-      "allOf": [
-        {
-          "$ref": "#/definitions/SandboxPolicy"
-        }
-      ]
-    },
-    "serviceTier": {
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "thread": {
-      "$ref": "#/definitions/Thread"
-    }
-  },
   "definitions": {
     "AbsolutePathBuf": {
       "description": "A path that is guaranteed to be absolute and normalized (though it is not guaranteed to be canonicalized or exist on the filesystem).\n\nIMPORTANT: When deserializing an `AbsolutePathBuf`, a base path must be set using [AbsolutePathBufGuard::new]. If no base path is set, the deserialization will fail unless the path being deserialized is already absolute.",
       "type": "string"
     },
     "ActivePermissionProfile": {
-      "type": "object",
-      "required": [
-        "id"
-      ],
       "properties": {
         "extends": {
-          "description": "Parent profile identifier once permissions profiles support inheritance. This is currently always `null`.",
           "default": null,
+          "description": "Parent profile identifier from the selected permissions profile's `extends` setting, when present.",
           "type": [
             "string",
             "null"
@@ -111,44 +19,39 @@
           "description": "Identifier from `default_permissions` or the implicit built-in default, such as `:workspace` or a user-defined `[permissions.<id>]` profile.",
           "type": "string"
         }
-      }
+      },
+      "required": [
+        "id"
+      ],
+      "type": "object"
     },
     "AgentPath": {
       "type": "string"
     },
     "ApprovalsReviewer": {
       "description": "Configures who approval requests are routed to for review. Examples include sandbox escapes, blocked network access, MCP approval prompts, and ARC escalations. Defaults to `user`. `auto_review` uses a carefully prompted subagent to gather relevant context and apply a risk-based decision framework before approving or denying the request. The legacy value `guardian_subagent` is accepted for compatibility.",
-      "type": "string",
       "enum": [
         "user",
         "auto_review",
         "guardian_subagent"
-      ]
+      ],
+      "type": "string"
     },
     "AskForApproval": {
       "oneOf": [
         {
-          "type": "string",
           "enum": [
             "untrusted",
             "on-failure",
             "on-request",
             "never"
-          ]
+          ],
+          "type": "string"
         },
         {
-          "type": "object",
-          "required": [
-            "granular"
-          ],
+          "additionalProperties": false,
           "properties": {
             "granular": {
-              "type": "object",
-              "required": [
-                "mcp_elicitations",
-                "rules",
-                "sandbox_approval"
-              ],
               "properties": {
                 "mcp_elicitations": {
                   "type": "boolean"
@@ -167,38 +70,46 @@
                   "default": false,
                   "type": "boolean"
                 }
-              }
+              },
+              "required": [
+                "mcp_elicitations",
+                "rules",
+                "sandbox_approval"
+              ],
+              "type": "object"
             }
           },
-          "additionalProperties": false,
-          "title": "GranularAskForApproval"
+          "required": [
+            "granular"
+          ],
+          "title": "GranularAskForApproval",
+          "type": "object"
         }
       ]
     },
     "ByteRange": {
-      "type": "object",
+      "properties": {
+        "end": {
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "start": {
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
       "required": [
         "end",
         "start"
       ],
-      "properties": {
-        "end": {
-          "type": "integer",
-          "format": "uint",
-          "minimum": 0
-        },
-        "start": {
-          "type": "integer",
-          "format": "uint",
-          "minimum": 0
-        }
-      }
+      "type": "object"
     },
     "CodexErrorInfo": {
       "description": "This translation layer make sure that we expose codex error code in camel case.\n\nWhen an upstream HTTP status is available (for example, from the Responses API or a provider), it is forwarded in `httpStatusCode` on the relevant `codexErrorInfo` variant.",
       "oneOf": [
         {
-          "type": "string",
           "enum": [
             "contextWindowExceeded",
             "usageLimitExceeded",
@@ -210,132 +121,129 @@
             "threadRollbackFailed",
             "sandboxError",
             "other"
-          ]
+          ],
+          "type": "string"
         },
         {
-          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "httpConnectionFailed": {
+              "properties": {
+                "httpStatusCode": {
+                  "format": "uint16",
+                  "minimum": 0,
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                }
+              },
+              "type": "object"
+            }
+          },
           "required": [
             "httpConnectionFailed"
           ],
+          "title": "HttpConnectionFailedCodexErrorInfo",
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "description": "Failed to connect to the response SSE stream.",
           "properties": {
-            "httpConnectionFailed": {
-              "type": "object",
+            "responseStreamConnectionFailed": {
               "properties": {
                 "httpStatusCode": {
+                  "format": "uint16",
+                  "minimum": 0,
                   "type": [
                     "integer",
                     "null"
-                  ],
-                  "format": "uint16",
-                  "minimum": 0
+                  ]
                 }
-              }
+              },
+              "type": "object"
             }
           },
-          "additionalProperties": false,
-          "title": "HttpConnectionFailedCodexErrorInfo"
-        },
-        {
-          "description": "Failed to connect to the response SSE stream.",
-          "type": "object",
           "required": [
             "responseStreamConnectionFailed"
           ],
+          "title": "ResponseStreamConnectionFailedCodexErrorInfo",
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "description": "The response SSE stream disconnected in the middle of a turn before completion.",
           "properties": {
-            "responseStreamConnectionFailed": {
-              "type": "object",
+            "responseStreamDisconnected": {
               "properties": {
                 "httpStatusCode": {
+                  "format": "uint16",
+                  "minimum": 0,
                   "type": [
                     "integer",
                     "null"
-                  ],
-                  "format": "uint16",
-                  "minimum": 0
+                  ]
                 }
-              }
+              },
+              "type": "object"
             }
           },
-          "additionalProperties": false,
-          "title": "ResponseStreamConnectionFailedCodexErrorInfo"
-        },
-        {
-          "description": "The response SSE stream disconnected in the middle of a turn before completion.",
-          "type": "object",
           "required": [
             "responseStreamDisconnected"
           ],
+          "title": "ResponseStreamDisconnectedCodexErrorInfo",
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "description": "Reached the retry limit for responses.",
           "properties": {
-            "responseStreamDisconnected": {
-              "type": "object",
+            "responseTooManyFailedAttempts": {
               "properties": {
                 "httpStatusCode": {
+                  "format": "uint16",
+                  "minimum": 0,
                   "type": [
                     "integer",
                     "null"
-                  ],
-                  "format": "uint16",
-                  "minimum": 0
+                  ]
                 }
-              }
+              },
+              "type": "object"
             }
           },
-          "additionalProperties": false,
-          "title": "ResponseStreamDisconnectedCodexErrorInfo"
-        },
-        {
-          "description": "Reached the retry limit for responses.",
-          "type": "object",
           "required": [
             "responseTooManyFailedAttempts"
           ],
-          "properties": {
-            "responseTooManyFailedAttempts": {
-              "type": "object",
-              "properties": {
-                "httpStatusCode": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ],
-                  "format": "uint16",
-                  "minimum": 0
-                }
-              }
-            }
-          },
-          "additionalProperties": false,
-          "title": "ResponseTooManyFailedAttemptsCodexErrorInfo"
+          "title": "ResponseTooManyFailedAttemptsCodexErrorInfo",
+          "type": "object"
         },
         {
+          "additionalProperties": false,
           "description": "Returned when `turn/start` or `turn/steer` is submitted while the current active turn cannot accept same-turn steering, for example `/review` or manual `/compact`.",
-          "type": "object",
-          "required": [
-            "activeTurnNotSteerable"
-          ],
           "properties": {
             "activeTurnNotSteerable": {
-              "type": "object",
-              "required": [
-                "turnKind"
-              ],
               "properties": {
                 "turnKind": {
                   "$ref": "#/definitions/NonSteerableTurnKind"
                 }
-              }
+              },
+              "required": [
+                "turnKind"
+              ],
+              "type": "object"
             }
           },
-          "additionalProperties": false,
-          "title": "ActiveTurnNotSteerableCodexErrorInfo"
+          "required": [
+            "activeTurnNotSteerable"
+          ],
+          "title": "ActiveTurnNotSteerableCodexErrorInfo",
+          "type": "object"
         }
       ]
     },
     "CollabAgentState": {
-      "type": "object",
-      "required": [
-        "status"
-      ],
       "properties": {
         "message": {
           "type": [
@@ -346,10 +254,13 @@
         "status": {
           "$ref": "#/definitions/CollabAgentStatus"
         }
-      }
+      },
+      "required": [
+        "status"
+      ],
+      "type": "object"
     },
     "CollabAgentStatus": {
-      "type": "string",
       "enum": [
         "pendingInit",
         "running",
@@ -358,36 +269,30 @@
         "errored",
         "shutdown",
         "notFound"
-      ]
+      ],
+      "type": "string"
     },
     "CollabAgentTool": {
-      "type": "string",
       "enum": [
         "spawnAgent",
         "sendInput",
         "resumeAgent",
         "wait",
         "closeAgent"
-      ]
+      ],
+      "type": "string"
     },
     "CollabAgentToolCallStatus": {
-      "type": "string",
       "enum": [
         "inProgress",
         "completed",
         "failed"
-      ]
+      ],
+      "type": "string"
     },
     "CommandAction": {
       "oneOf": [
         {
-          "type": "object",
-          "required": [
-            "command",
-            "name",
-            "path",
-            "type"
-          ],
           "properties": {
             "command": {
               "type": "string"
@@ -399,21 +304,23 @@
               "$ref": "#/definitions/AbsolutePathBuf"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "read"
               ],
-              "title": "ReadCommandActionType"
+              "title": "ReadCommandActionType",
+              "type": "string"
             }
           },
-          "title": "ReadCommandAction"
-        },
-        {
-          "type": "object",
           "required": [
             "command",
+            "name",
+            "path",
             "type"
           ],
+          "title": "ReadCommandAction",
+          "type": "object"
+        },
+        {
           "properties": {
             "command": {
               "type": "string"
@@ -425,21 +332,21 @@
               ]
             },
             "type": {
-              "type": "string",
               "enum": [
                 "listFiles"
               ],
-              "title": "ListFilesCommandActionType"
+              "title": "ListFilesCommandActionType",
+              "type": "string"
             }
           },
-          "title": "ListFilesCommandAction"
-        },
-        {
-          "type": "object",
           "required": [
             "command",
             "type"
           ],
+          "title": "ListFilesCommandAction",
+          "type": "object"
+        },
+        {
           "properties": {
             "command": {
               "type": "string"
@@ -457,114 +364,113 @@
               ]
             },
             "type": {
-              "type": "string",
               "enum": [
                 "search"
               ],
-              "title": "SearchCommandActionType"
+              "title": "SearchCommandActionType",
+              "type": "string"
             }
           },
-          "title": "SearchCommandAction"
-        },
-        {
-          "type": "object",
           "required": [
             "command",
             "type"
           ],
+          "title": "SearchCommandAction",
+          "type": "object"
+        },
+        {
           "properties": {
             "command": {
               "type": "string"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "unknown"
               ],
-              "title": "UnknownCommandActionType"
+              "title": "UnknownCommandActionType",
+              "type": "string"
             }
           },
-          "title": "UnknownCommandAction"
+          "required": [
+            "command",
+            "type"
+          ],
+          "title": "UnknownCommandAction",
+          "type": "object"
         }
       ]
     },
     "CommandExecutionSource": {
-      "type": "string",
       "enum": [
         "agent",
         "userShell",
         "unifiedExecStartup",
         "unifiedExecInteraction"
-      ]
+      ],
+      "type": "string"
     },
     "CommandExecutionStatus": {
-      "type": "string",
       "enum": [
         "inProgress",
         "completed",
         "failed",
         "declined"
-      ]
+      ],
+      "type": "string"
     },
     "DynamicToolCallOutputContentItem": {
       "oneOf": [
         {
-          "type": "object",
-          "required": [
-            "text",
-            "type"
-          ],
           "properties": {
             "text": {
               "type": "string"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "inputText"
               ],
-              "title": "InputTextDynamicToolCallOutputContentItemType"
+              "title": "InputTextDynamicToolCallOutputContentItemType",
+              "type": "string"
             }
           },
-          "title": "InputTextDynamicToolCallOutputContentItem"
-        },
-        {
-          "type": "object",
           "required": [
-            "imageUrl",
+            "text",
             "type"
           ],
+          "title": "InputTextDynamicToolCallOutputContentItem",
+          "type": "object"
+        },
+        {
           "properties": {
             "imageUrl": {
               "type": "string"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "inputImage"
               ],
-              "title": "InputImageDynamicToolCallOutputContentItemType"
+              "title": "InputImageDynamicToolCallOutputContentItemType",
+              "type": "string"
             }
           },
-          "title": "InputImageDynamicToolCallOutputContentItem"
+          "required": [
+            "imageUrl",
+            "type"
+          ],
+          "title": "InputImageDynamicToolCallOutputContentItem",
+          "type": "object"
         }
       ]
     },
     "DynamicToolCallStatus": {
-      "type": "string",
       "enum": [
         "inProgress",
         "completed",
         "failed"
-      ]
+      ],
+      "type": "string"
     },
     "FileUpdateChange": {
-      "type": "object",
-      "required": [
-        "diff",
-        "kind",
-        "path"
-      ],
       "properties": {
         "diff": {
           "type": "string"
@@ -575,10 +481,15 @@
         "path": {
           "type": "string"
         }
-      }
+      },
+      "required": [
+        "diff",
+        "kind",
+        "path"
+      ],
+      "type": "object"
     },
     "GitInfo": {
-      "type": "object",
       "properties": {
         "branch": {
           "type": [
@@ -598,14 +509,10 @@
             "null"
           ]
         }
-      }
+      },
+      "type": "object"
     },
     "HookPromptFragment": {
-      "type": "object",
-      "required": [
-        "hookRunId",
-        "text"
-      ],
       "properties": {
         "hookRunId": {
           "type": "string"
@@ -613,87 +520,87 @@
         "text": {
           "type": "string"
         }
-      }
+      },
+      "required": [
+        "hookRunId",
+        "text"
+      ],
+      "type": "object"
     },
     "ImageDetail": {
-      "type": "string",
       "enum": [
+        "auto",
+        "low",
         "high",
         "original"
-      ]
+      ],
+      "type": "string"
     },
     "McpToolCallError": {
-      "type": "object",
-      "required": [
-        "message"
-      ],
       "properties": {
         "message": {
           "type": "string"
         }
-      }
+      },
+      "required": [
+        "message"
+      ],
+      "type": "object"
     },
     "McpToolCallResult": {
-      "type": "object",
-      "required": [
-        "content"
-      ],
       "properties": {
         "_meta": true,
         "content": {
-          "type": "array",
-          "items": true
+          "items": true,
+          "type": "array"
         },
         "structuredContent": true
-      }
+      },
+      "required": [
+        "content"
+      ],
+      "type": "object"
     },
     "McpToolCallStatus": {
-      "type": "string",
       "enum": [
         "inProgress",
         "completed",
         "failed"
-      ]
+      ],
+      "type": "string"
     },
     "MemoryCitation": {
-      "type": "object",
+      "properties": {
+        "entries": {
+          "items": {
+            "$ref": "#/definitions/MemoryCitationEntry"
+          },
+          "type": "array"
+        },
+        "threadIds": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
       "required": [
         "entries",
         "threadIds"
       ],
-      "properties": {
-        "entries": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/MemoryCitationEntry"
-          }
-        },
-        "threadIds": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
+      "type": "object"
     },
     "MemoryCitationEntry": {
-      "type": "object",
-      "required": [
-        "lineEnd",
-        "lineStart",
-        "note",
-        "path"
-      ],
       "properties": {
         "lineEnd": {
-          "type": "integer",
           "format": "uint32",
-          "minimum": 0
+          "minimum": 0,
+          "type": "integer"
         },
         "lineStart": {
-          "type": "integer",
           "format": "uint32",
-          "minimum": 0
+          "minimum": 0,
+          "type": "integer"
         },
         "note": {
           "type": "string"
@@ -701,89 +608,92 @@
         "path": {
           "type": "string"
         }
-      }
+      },
+      "required": [
+        "lineEnd",
+        "lineStart",
+        "note",
+        "path"
+      ],
+      "type": "object"
     },
     "MessagePhase": {
       "description": "Classifies an assistant message as interim commentary or final answer text.\n\nProviders do not emit this consistently, so callers must treat `None` as \"phase unknown\" and keep compatibility behavior for legacy models.",
       "oneOf": [
         {
           "description": "Mid-turn assistant text (for example preamble/progress narration).\n\nAdditional tool calls or assistant output may follow before turn completion.",
-          "type": "string",
           "enum": [
             "commentary"
-          ]
+          ],
+          "type": "string"
         },
         {
           "description": "The assistant's terminal answer text for the current turn.",
-          "type": "string",
           "enum": [
             "final_answer"
-          ]
+          ],
+          "type": "string"
         }
       ]
     },
     "NetworkAccess": {
-      "type": "string",
       "enum": [
         "restricted",
         "enabled"
-      ]
+      ],
+      "type": "string"
     },
     "NonSteerableTurnKind": {
-      "type": "string",
       "enum": [
         "review",
         "compact"
-      ]
+      ],
+      "type": "string"
     },
     "PatchApplyStatus": {
-      "type": "string",
       "enum": [
         "inProgress",
         "completed",
         "failed",
         "declined"
-      ]
+      ],
+      "type": "string"
     },
     "PatchChangeKind": {
       "oneOf": [
         {
-          "type": "object",
-          "required": [
-            "type"
-          ],
           "properties": {
             "type": {
-              "type": "string",
               "enum": [
                 "add"
               ],
-              "title": "AddPatchChangeKindType"
+              "title": "AddPatchChangeKindType",
+              "type": "string"
             }
           },
-          "title": "AddPatchChangeKind"
-        },
-        {
-          "type": "object",
           "required": [
             "type"
           ],
+          "title": "AddPatchChangeKind",
+          "type": "object"
+        },
+        {
           "properties": {
             "type": {
-              "type": "string",
               "enum": [
                 "delete"
               ],
-              "title": "DeletePatchChangeKindType"
+              "title": "DeletePatchChangeKindType",
+              "type": "string"
             }
           },
-          "title": "DeletePatchChangeKind"
-        },
-        {
-          "type": "object",
           "required": [
             "type"
           ],
+          "title": "DeletePatchChangeKind",
+          "type": "object"
+        },
+        {
           "properties": {
             "move_path": {
               "type": [
@@ -792,20 +702,23 @@
               ]
             },
             "type": {
-              "type": "string",
               "enum": [
                 "update"
               ],
-              "title": "UpdatePatchChangeKindType"
+              "title": "UpdatePatchChangeKindType",
+              "type": "string"
             }
           },
-          "title": "UpdatePatchChangeKind"
+          "required": [
+            "type"
+          ],
+          "title": "UpdatePatchChangeKind",
+          "type": "object"
         }
       ]
     },
     "ReasoningEffort": {
       "description": "See https://platform.openai.com/docs/guides/reasoning?api-mode=responses#get-started-with-reasoning",
-      "type": "string",
       "enum": [
         "none",
         "minimal",
@@ -813,75 +726,72 @@
         "medium",
         "high",
         "xhigh"
-      ]
+      ],
+      "type": "string"
     },
     "SandboxPolicy": {
       "oneOf": [
         {
-          "type": "object",
-          "required": [
-            "type"
-          ],
           "properties": {
             "type": {
-              "type": "string",
               "enum": [
                 "dangerFullAccess"
               ],
-              "title": "DangerFullAccessSandboxPolicyType"
+              "title": "DangerFullAccessSandboxPolicyType",
+              "type": "string"
             }
           },
-          "title": "DangerFullAccessSandboxPolicy"
-        },
-        {
-          "type": "object",
           "required": [
             "type"
           ],
+          "title": "DangerFullAccessSandboxPolicy",
+          "type": "object"
+        },
+        {
           "properties": {
             "networkAccess": {
               "default": false,
               "type": "boolean"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "readOnly"
               ],
-              "title": "ReadOnlySandboxPolicyType"
+              "title": "ReadOnlySandboxPolicyType",
+              "type": "string"
             }
           },
-          "title": "ReadOnlySandboxPolicy"
-        },
-        {
-          "type": "object",
           "required": [
             "type"
           ],
+          "title": "ReadOnlySandboxPolicy",
+          "type": "object"
+        },
+        {
           "properties": {
             "networkAccess": {
-              "default": "restricted",
               "allOf": [
                 {
                   "$ref": "#/definitions/NetworkAccess"
                 }
-              ]
+              ],
+              "default": "restricted"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "externalSandbox"
               ],
-              "title": "ExternalSandboxSandboxPolicyType"
+              "title": "ExternalSandboxSandboxPolicyType",
+              "type": "string"
             }
           },
-          "title": "ExternalSandboxSandboxPolicy"
-        },
-        {
-          "type": "object",
           "required": [
             "type"
           ],
+          "title": "ExternalSandboxSandboxPolicy",
+          "type": "object"
+        },
+        {
           "properties": {
             "excludeSlashTmp": {
               "default": false,
@@ -896,86 +806,82 @@
               "type": "boolean"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "workspaceWrite"
               ],
-              "title": "WorkspaceWriteSandboxPolicyType"
+              "title": "WorkspaceWriteSandboxPolicyType",
+              "type": "string"
             },
             "writableRoots": {
               "default": [],
-              "type": "array",
               "items": {
                 "$ref": "#/definitions/AbsolutePathBuf"
-              }
+              },
+              "type": "array"
             }
           },
-          "title": "WorkspaceWriteSandboxPolicy"
+          "required": [
+            "type"
+          ],
+          "title": "WorkspaceWriteSandboxPolicy",
+          "type": "object"
         }
       ]
     },
     "SessionSource": {
       "oneOf": [
         {
-          "type": "string",
           "enum": [
             "cli",
             "vscode",
             "exec",
             "appServer",
             "unknown"
-          ]
+          ],
+          "type": "string"
         },
         {
-          "type": "object",
-          "required": [
-            "custom"
-          ],
+          "additionalProperties": false,
           "properties": {
             "custom": {
               "type": "string"
             }
           },
-          "additionalProperties": false,
-          "title": "CustomSessionSource"
+          "required": [
+            "custom"
+          ],
+          "title": "CustomSessionSource",
+          "type": "object"
         },
         {
-          "type": "object",
-          "required": [
-            "subAgent"
-          ],
+          "additionalProperties": false,
           "properties": {
             "subAgent": {
               "$ref": "#/definitions/SubAgentSource"
             }
           },
-          "additionalProperties": false,
-          "title": "SubAgentSessionSource"
+          "required": [
+            "subAgent"
+          ],
+          "title": "SubAgentSessionSource",
+          "type": "object"
         }
       ]
     },
     "SubAgentSource": {
       "oneOf": [
         {
-          "type": "string",
           "enum": [
             "review",
             "compact",
             "memory_consolidation"
-          ]
+          ],
+          "type": "string"
         },
         {
-          "type": "object",
-          "required": [
-            "thread_spawn"
-          ],
+          "additionalProperties": false,
           "properties": {
             "thread_spawn": {
-              "type": "object",
-              "required": [
-                "depth",
-                "parent_thread_id"
-              ],
               "properties": {
                 "agent_nickname": {
                   "default": null,
@@ -985,7 +891,6 @@
                   ]
                 },
                 "agent_path": {
-                  "default": null,
                   "anyOf": [
                     {
                       "$ref": "#/definitions/AgentPath"
@@ -993,7 +898,8 @@
                     {
                       "type": "null"
                     }
-                  ]
+                  ],
+                  "default": null
                 },
                 "agent_role": {
                   "default": null,
@@ -1003,46 +909,50 @@
                   ]
                 },
                 "depth": {
-                  "type": "integer",
-                  "format": "int32"
+                  "format": "int32",
+                  "type": "integer"
                 },
                 "parent_thread_id": {
                   "$ref": "#/definitions/ThreadId"
                 }
-              }
+              },
+              "required": [
+                "depth",
+                "parent_thread_id"
+              ],
+              "type": "object"
             }
           },
-          "additionalProperties": false,
-          "title": "ThreadSpawnSubAgentSource"
+          "required": [
+            "thread_spawn"
+          ],
+          "title": "ThreadSpawnSubAgentSource",
+          "type": "object"
         },
         {
-          "type": "object",
-          "required": [
-            "other"
-          ],
+          "additionalProperties": false,
           "properties": {
             "other": {
               "type": "string"
             }
           },
-          "additionalProperties": false,
-          "title": "OtherSubAgentSource"
+          "required": [
+            "other"
+          ],
+          "title": "OtherSubAgentSource",
+          "type": "object"
         }
       ]
     },
     "TextElement": {
-      "type": "object",
-      "required": [
-        "byteRange"
-      ],
       "properties": {
         "byteRange": {
-          "description": "Byte range in the parent `text` buffer that this element occupies.",
           "allOf": [
             {
               "$ref": "#/definitions/ByteRange"
             }
-          ]
+          ],
+          "description": "Byte range in the parent `text` buffer that this element occupies."
         },
         "placeholder": {
           "description": "Optional human-readable placeholder for the element, displayed in the UI.",
@@ -1051,24 +961,13 @@
             "null"
           ]
         }
-      }
+      },
+      "required": [
+        "byteRange"
+      ],
+      "type": "object"
     },
     "Thread": {
-      "type": "object",
-      "required": [
-        "cliVersion",
-        "createdAt",
-        "cwd",
-        "ephemeral",
-        "id",
-        "modelProvider",
-        "preview",
-        "sessionId",
-        "source",
-        "status",
-        "turns",
-        "updatedAt"
-      ],
       "properties": {
         "agentNickname": {
           "description": "Optional random unique nickname assigned to an AgentControl-spawned sub-agent.",
@@ -1090,16 +989,16 @@
         },
         "createdAt": {
           "description": "Unix timestamp (in seconds) when the thread was created.",
-          "type": "integer",
-          "format": "int64"
+          "format": "int64",
+          "type": "integer"
         },
         "cwd": {
-          "description": "Working directory captured for the thread.",
           "allOf": [
             {
               "$ref": "#/definitions/AbsolutePathBuf"
             }
-          ]
+          ],
+          "description": "Working directory captured for the thread."
         },
         "ephemeral": {
           "description": "Whether the thread is ephemeral and should not be materialized on disk.",
@@ -1113,7 +1012,6 @@
           ]
         },
         "gitInfo": {
-          "description": "Optional Git metadata captured when the thread was created.",
           "anyOf": [
             {
               "$ref": "#/definitions/GitInfo"
@@ -1121,7 +1019,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Optional Git metadata captured when the thread was created."
         },
         "id": {
           "type": "string"
@@ -1132,6 +1031,13 @@
         },
         "name": {
           "description": "Optional user-facing thread title.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "parentThreadId": {
+          "description": "The ID of the parent thread. This will only be set if this thread is a subagent.",
           "type": [
             "string",
             "null"
@@ -1153,23 +1059,22 @@
           "type": "string"
         },
         "source": {
-          "description": "Origin of the thread (CLI, VSCode, codex exec, codex app-server, etc.).",
           "allOf": [
             {
               "$ref": "#/definitions/SessionSource"
             }
-          ]
+          ],
+          "description": "Origin of the thread (CLI, VSCode, codex exec, codex app-server, etc.)."
         },
         "status": {
-          "description": "Current runtime status for the thread.",
           "allOf": [
             {
               "$ref": "#/definitions/ThreadStatus"
             }
-          ]
+          ],
+          "description": "Current runtime status for the thread."
         },
         "threadSource": {
-          "description": "Optional analytics source classification for this thread.",
           "anyOf": [
             {
               "$ref": "#/definitions/ThreadSource"
@@ -1177,28 +1082,44 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Optional analytics source classification for this thread."
         },
         "turns": {
           "description": "Only populated on `thread/resume`, `thread/rollback`, `thread/fork`, and `thread/read` (when `includeTurns` is true) responses. For all other responses and notifications returning a Thread, the turns field will be an empty list.",
-          "type": "array",
           "items": {
             "$ref": "#/definitions/Turn"
-          }
+          },
+          "type": "array"
         },
         "updatedAt": {
           "description": "Unix timestamp (in seconds) when the thread was last updated.",
-          "type": "integer",
-          "format": "int64"
+          "format": "int64",
+          "type": "integer"
         }
-      }
+      },
+      "required": [
+        "cliVersion",
+        "createdAt",
+        "cwd",
+        "ephemeral",
+        "id",
+        "modelProvider",
+        "preview",
+        "sessionId",
+        "source",
+        "status",
+        "turns",
+        "updatedAt"
+      ],
+      "type": "object"
     },
     "ThreadActiveFlag": {
-      "type": "string",
       "enum": [
         "waitingOnApproval",
         "waitingOnUserInput"
-      ]
+      ],
+      "type": "string"
     },
     "ThreadId": {
       "type": "string"
@@ -1206,72 +1127,71 @@
     "ThreadItem": {
       "oneOf": [
         {
-          "type": "object",
+          "properties": {
+            "clientId": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "content": {
+              "items": {
+                "$ref": "#/definitions/UserInput"
+              },
+              "type": "array"
+            },
+            "id": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "userMessage"
+              ],
+              "title": "UserMessageThreadItemType",
+              "type": "string"
+            }
+          },
           "required": [
             "content",
             "id",
             "type"
           ],
+          "title": "UserMessageThreadItem",
+          "type": "object"
+        },
+        {
           "properties": {
-            "content": {
-              "type": "array",
+            "fragments": {
               "items": {
-                "$ref": "#/definitions/UserInput"
-              }
+                "$ref": "#/definitions/HookPromptFragment"
+              },
+              "type": "array"
             },
             "id": {
               "type": "string"
             },
             "type": {
-              "type": "string",
               "enum": [
-                "userMessage"
+                "hookPrompt"
               ],
-              "title": "UserMessageThreadItemType"
+              "title": "HookPromptThreadItemType",
+              "type": "string"
             }
           },
-          "title": "UserMessageThreadItem"
-        },
-        {
-          "type": "object",
           "required": [
             "fragments",
             "id",
             "type"
           ],
-          "properties": {
-            "fragments": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/HookPromptFragment"
-              }
-            },
-            "id": {
-              "type": "string"
-            },
-            "type": {
-              "type": "string",
-              "enum": [
-                "hookPrompt"
-              ],
-              "title": "HookPromptThreadItemType"
-            }
-          },
-          "title": "HookPromptThreadItem"
+          "title": "HookPromptThreadItem",
+          "type": "object"
         },
         {
-          "type": "object",
-          "required": [
-            "id",
-            "text",
-            "type"
-          ],
           "properties": {
             "id": {
               "type": "string"
             },
             "memoryCitation": {
-              "default": null,
               "anyOf": [
                 {
                   "$ref": "#/definitions/MemoryCitation"
@@ -1279,10 +1199,10 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "default": null
             },
             "phase": {
-              "default": null,
               "anyOf": [
                 {
                   "$ref": "#/definitions/MessagePhase"
@@ -1290,29 +1210,30 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "default": null
             },
             "text": {
               "type": "string"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "agentMessage"
               ],
-              "title": "AgentMessageThreadItemType"
+              "title": "AgentMessageThreadItemType",
+              "type": "string"
             }
           },
-          "title": "AgentMessageThreadItem"
-        },
-        {
-          "description": "EXPERIMENTAL - proposed plan item content. The completed plan item is authoritative and may not match the concatenation of `PlanDelta` text.",
-          "type": "object",
           "required": [
             "id",
             "text",
             "type"
           ],
+          "title": "AgentMessageThreadItem",
+          "type": "object"
+        },
+        {
+          "description": "EXPERIMENTAL - proposed plan item content. The completed plan item is authoritative and may not match the concatenation of `PlanDelta` text.",
           "properties": {
             "id": {
               "type": "string"
@@ -1321,59 +1242,56 @@
               "type": "string"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "plan"
               ],
-              "title": "PlanThreadItemType"
+              "title": "PlanThreadItemType",
+              "type": "string"
             }
           },
-          "title": "PlanThreadItem"
-        },
-        {
-          "type": "object",
           "required": [
             "id",
+            "text",
             "type"
           ],
+          "title": "PlanThreadItem",
+          "type": "object"
+        },
+        {
           "properties": {
             "content": {
               "default": [],
-              "type": "array",
               "items": {
                 "type": "string"
-              }
+              },
+              "type": "array"
             },
             "id": {
               "type": "string"
             },
             "summary": {
               "default": [],
-              "type": "array",
               "items": {
                 "type": "string"
-              }
+              },
+              "type": "array"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "reasoning"
               ],
-              "title": "ReasoningThreadItemType"
+              "title": "ReasoningThreadItemType",
+              "type": "string"
             }
           },
-          "title": "ReasoningThreadItem"
-        },
-        {
-          "type": "object",
           "required": [
-            "command",
-            "commandActions",
-            "cwd",
             "id",
-            "status",
             "type"
           ],
+          "title": "ReasoningThreadItem",
+          "type": "object"
+        },
+        {
           "properties": {
             "aggregatedOutput": {
               "description": "The command's output, aggregated from stdout and stderr.",
@@ -1388,34 +1306,34 @@
             },
             "commandActions": {
               "description": "A best-effort parsing of the command to understand the action(s) it will perform. This returns a list of CommandAction objects because a single shell command may be composed of many commands piped together.",
-              "type": "array",
               "items": {
                 "$ref": "#/definitions/CommandAction"
-              }
+              },
+              "type": "array"
             },
             "cwd": {
-              "description": "The command's working directory.",
               "allOf": [
                 {
                   "$ref": "#/definitions/AbsolutePathBuf"
                 }
-              ]
+              ],
+              "description": "The command's working directory."
             },
             "durationMs": {
               "description": "The duration of the command execution in milliseconds.",
+              "format": "int64",
               "type": [
                 "integer",
                 "null"
-              ],
-              "format": "int64"
+              ]
             },
             "exitCode": {
               "description": "The command's exit code.",
+              "format": "int32",
               "type": [
                 "integer",
                 "null"
-              ],
-              "format": "int32"
+              ]
             },
             "id": {
               "type": "string"
@@ -1428,40 +1346,42 @@
               ]
             },
             "source": {
-              "default": "agent",
               "allOf": [
                 {
                   "$ref": "#/definitions/CommandExecutionSource"
                 }
-              ]
+              ],
+              "default": "agent"
             },
             "status": {
               "$ref": "#/definitions/CommandExecutionStatus"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "commandExecution"
               ],
-              "title": "CommandExecutionThreadItemType"
+              "title": "CommandExecutionThreadItemType",
+              "type": "string"
             }
           },
-          "title": "CommandExecutionThreadItem"
-        },
-        {
-          "type": "object",
           "required": [
-            "changes",
+            "command",
+            "commandActions",
+            "cwd",
             "id",
             "status",
             "type"
           ],
+          "title": "CommandExecutionThreadItem",
+          "type": "object"
+        },
+        {
           "properties": {
             "changes": {
-              "type": "array",
               "items": {
                 "$ref": "#/definitions/FileUpdateChange"
-              }
+              },
+              "type": "array"
             },
             "id": {
               "type": "string"
@@ -1470,34 +1390,32 @@
               "$ref": "#/definitions/PatchApplyStatus"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "fileChange"
               ],
-              "title": "FileChangeThreadItemType"
+              "title": "FileChangeThreadItemType",
+              "type": "string"
             }
           },
-          "title": "FileChangeThreadItem"
-        },
-        {
-          "type": "object",
           "required": [
-            "arguments",
+            "changes",
             "id",
-            "server",
             "status",
-            "tool",
             "type"
           ],
+          "title": "FileChangeThreadItem",
+          "type": "object"
+        },
+        {
           "properties": {
             "arguments": true,
             "durationMs": {
               "description": "The duration of the MCP tool call in milliseconds.",
+              "format": "int64",
               "type": [
                 "integer",
                 "null"
-              ],
-              "format": "int64"
+              ]
             },
             "error": {
               "anyOf": [
@@ -1513,6 +1431,12 @@
               "type": "string"
             },
             "mcpAppResourceUri": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "pluginId": {
               "type": [
                 "string",
                 "null"
@@ -1538,42 +1462,43 @@
               "type": "string"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "mcpToolCall"
               ],
-              "title": "McpToolCallThreadItemType"
+              "title": "McpToolCallThreadItemType",
+              "type": "string"
             }
           },
-          "title": "McpToolCallThreadItem"
-        },
-        {
-          "type": "object",
           "required": [
             "arguments",
             "id",
+            "server",
             "status",
             "tool",
             "type"
           ],
+          "title": "McpToolCallThreadItem",
+          "type": "object"
+        },
+        {
           "properties": {
             "arguments": true,
             "contentItems": {
+              "items": {
+                "$ref": "#/definitions/DynamicToolCallOutputContentItem"
+              },
               "type": [
                 "array",
                 "null"
-              ],
-              "items": {
-                "$ref": "#/definitions/DynamicToolCallOutputContentItem"
-              }
+              ]
             },
             "durationMs": {
               "description": "The duration of the dynamic tool call in milliseconds.",
+              "format": "int64",
               "type": [
                 "integer",
                 "null"
-              ],
-              "format": "int64"
+              ]
             },
             "id": {
               "type": "string"
@@ -1597,33 +1522,31 @@
               "type": "string"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "dynamicToolCall"
               ],
-              "title": "DynamicToolCallThreadItemType"
+              "title": "DynamicToolCallThreadItemType",
+              "type": "string"
             }
           },
-          "title": "DynamicToolCallThreadItem"
-        },
-        {
-          "type": "object",
           "required": [
-            "agentsStates",
+            "arguments",
             "id",
-            "receiverThreadIds",
-            "senderThreadId",
             "status",
             "tool",
             "type"
           ],
+          "title": "DynamicToolCallThreadItem",
+          "type": "object"
+        },
+        {
           "properties": {
             "agentsStates": {
-              "description": "Last known status of the target agents, when available.",
-              "type": "object",
               "additionalProperties": {
                 "$ref": "#/definitions/CollabAgentState"
-              }
+              },
+              "description": "Last known status of the target agents, when available.",
+              "type": "object"
             },
             "id": {
               "description": "Unique identifier for this collab tool call.",
@@ -1644,7 +1567,6 @@
               ]
             },
             "reasoningEffort": {
-              "description": "Reasoning effort requested for the spawned agent, when applicable.",
               "anyOf": [
                 {
                   "$ref": "#/definitions/ReasoningEffort"
@@ -1652,52 +1574,57 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Reasoning effort requested for the spawned agent, when applicable."
             },
             "receiverThreadIds": {
               "description": "Thread ID of the receiving agent, when applicable. In case of spawn operation, this corresponds to the newly spawned agent.",
-              "type": "array",
               "items": {
                 "type": "string"
-              }
+              },
+              "type": "array"
             },
             "senderThreadId": {
               "description": "Thread ID of the agent issuing the collab request.",
               "type": "string"
             },
             "status": {
-              "description": "Current status of the collab tool call.",
               "allOf": [
                 {
                   "$ref": "#/definitions/CollabAgentToolCallStatus"
                 }
-              ]
+              ],
+              "description": "Current status of the collab tool call."
             },
             "tool": {
-              "description": "Name of the collab tool that was invoked.",
               "allOf": [
                 {
                   "$ref": "#/definitions/CollabAgentTool"
                 }
-              ]
+              ],
+              "description": "Name of the collab tool that was invoked."
             },
             "type": {
-              "type": "string",
               "enum": [
                 "collabAgentToolCall"
               ],
-              "title": "CollabAgentToolCallThreadItemType"
+              "title": "CollabAgentToolCallThreadItemType",
+              "type": "string"
             }
           },
-          "title": "CollabAgentToolCallThreadItem"
-        },
-        {
-          "type": "object",
           "required": [
+            "agentsStates",
             "id",
-            "query",
+            "receiverThreadIds",
+            "senderThreadId",
+            "status",
+            "tool",
             "type"
           ],
+          "title": "CollabAgentToolCallThreadItem",
+          "type": "object"
+        },
+        {
           "properties": {
             "action": {
               "anyOf": [
@@ -1716,22 +1643,22 @@
               "type": "string"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "webSearch"
               ],
-              "title": "WebSearchThreadItemType"
+              "title": "WebSearchThreadItemType",
+              "type": "string"
             }
           },
-          "title": "WebSearchThreadItem"
-        },
-        {
-          "type": "object",
           "required": [
             "id",
-            "path",
+            "query",
             "type"
           ],
+          "title": "WebSearchThreadItem",
+          "type": "object"
+        },
+        {
           "properties": {
             "id": {
               "type": "string"
@@ -1740,23 +1667,22 @@
               "$ref": "#/definitions/AbsolutePathBuf"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "imageView"
               ],
-              "title": "ImageViewThreadItemType"
+              "title": "ImageViewThreadItemType",
+              "type": "string"
             }
           },
-          "title": "ImageViewThreadItem"
-        },
-        {
-          "type": "object",
           "required": [
             "id",
-            "result",
-            "status",
+            "path",
             "type"
           ],
+          "title": "ImageViewThreadItem",
+          "type": "object"
+        },
+        {
           "properties": {
             "id": {
               "type": "string"
@@ -1784,22 +1710,23 @@
               "type": "string"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "imageGeneration"
               ],
-              "title": "ImageGenerationThreadItemType"
+              "title": "ImageGenerationThreadItemType",
+              "type": "string"
             }
           },
-          "title": "ImageGenerationThreadItem"
-        },
-        {
-          "type": "object",
           "required": [
             "id",
-            "review",
+            "result",
+            "status",
             "type"
           ],
+          "title": "ImageGenerationThreadItem",
+          "type": "object"
+        },
+        {
           "properties": {
             "id": {
               "type": "string"
@@ -1808,22 +1735,22 @@
               "type": "string"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "enteredReviewMode"
               ],
-              "title": "EnteredReviewModeThreadItemType"
+              "title": "EnteredReviewModeThreadItemType",
+              "type": "string"
             }
           },
-          "title": "EnteredReviewModeThreadItem"
-        },
-        {
-          "type": "object",
           "required": [
             "id",
             "review",
             "type"
           ],
+          "title": "EnteredReviewModeThreadItem",
+          "type": "object"
+        },
+        {
           "properties": {
             "id": {
               "type": "string"
@@ -1832,146 +1759,145 @@
               "type": "string"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "exitedReviewMode"
               ],
-              "title": "ExitedReviewModeThreadItemType"
+              "title": "ExitedReviewModeThreadItemType",
+              "type": "string"
             }
           },
-          "title": "ExitedReviewModeThreadItem"
-        },
-        {
-          "type": "object",
           "required": [
             "id",
+            "review",
             "type"
           ],
+          "title": "ExitedReviewModeThreadItem",
+          "type": "object"
+        },
+        {
           "properties": {
             "id": {
               "type": "string"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "contextCompaction"
               ],
-              "title": "ContextCompactionThreadItemType"
+              "title": "ContextCompactionThreadItemType",
+              "type": "string"
             }
           },
-          "title": "ContextCompactionThreadItem"
+          "required": [
+            "id",
+            "type"
+          ],
+          "title": "ContextCompactionThreadItem",
+          "type": "object"
         }
       ]
     },
     "ThreadSource": {
-      "type": "string",
       "enum": [
         "user",
         "subagent",
         "memory_consolidation"
-      ]
+      ],
+      "type": "string"
     },
     "ThreadStatus": {
       "oneOf": [
         {
-          "type": "object",
-          "required": [
-            "type"
-          ],
           "properties": {
             "type": {
-              "type": "string",
               "enum": [
                 "notLoaded"
               ],
-              "title": "NotLoadedThreadStatusType"
+              "title": "NotLoadedThreadStatusType",
+              "type": "string"
             }
           },
-          "title": "NotLoadedThreadStatus"
-        },
-        {
-          "type": "object",
           "required": [
             "type"
           ],
+          "title": "NotLoadedThreadStatus",
+          "type": "object"
+        },
+        {
           "properties": {
             "type": {
-              "type": "string",
               "enum": [
                 "idle"
               ],
-              "title": "IdleThreadStatusType"
+              "title": "IdleThreadStatusType",
+              "type": "string"
             }
           },
-          "title": "IdleThreadStatus"
-        },
-        {
-          "type": "object",
           "required": [
             "type"
           ],
+          "title": "IdleThreadStatus",
+          "type": "object"
+        },
+        {
           "properties": {
             "type": {
-              "type": "string",
               "enum": [
                 "systemError"
               ],
-              "title": "SystemErrorThreadStatusType"
+              "title": "SystemErrorThreadStatusType",
+              "type": "string"
             }
           },
-          "title": "SystemErrorThreadStatus"
+          "required": [
+            "type"
+          ],
+          "title": "SystemErrorThreadStatus",
+          "type": "object"
         },
         {
-          "type": "object",
+          "properties": {
+            "activeFlags": {
+              "items": {
+                "$ref": "#/definitions/ThreadActiveFlag"
+              },
+              "type": "array"
+            },
+            "type": {
+              "enum": [
+                "active"
+              ],
+              "title": "ActiveThreadStatusType",
+              "type": "string"
+            }
+          },
           "required": [
             "activeFlags",
             "type"
           ],
-          "properties": {
-            "activeFlags": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/ThreadActiveFlag"
-              }
-            },
-            "type": {
-              "type": "string",
-              "enum": [
-                "active"
-              ],
-              "title": "ActiveThreadStatusType"
-            }
-          },
-          "title": "ActiveThreadStatus"
+          "title": "ActiveThreadStatus",
+          "type": "object"
         }
       ]
     },
     "Turn": {
-      "type": "object",
-      "required": [
-        "id",
-        "items",
-        "status"
-      ],
       "properties": {
         "completedAt": {
           "description": "Unix timestamp (in seconds) when the turn completed.",
+          "format": "int64",
           "type": [
             "integer",
             "null"
-          ],
-          "format": "int64"
+          ]
         },
         "durationMs": {
           "description": "Duration between turn start and completion in milliseconds, if known.",
+          "format": "int64",
           "type": [
             "integer",
             "null"
-          ],
-          "format": "int64"
+          ]
         },
         "error": {
-          "description": "Only populated when the Turn's status is failed.",
           "anyOf": [
             {
               "$ref": "#/definitions/TurnError"
@@ -1979,45 +1905,48 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Only populated when the Turn's status is failed."
         },
         "id": {
           "type": "string"
         },
         "items": {
           "description": "Thread items currently included in this turn payload.",
-          "type": "array",
           "items": {
             "$ref": "#/definitions/ThreadItem"
-          }
+          },
+          "type": "array"
         },
         "itemsView": {
-          "description": "Describes how much of `items` has been loaded for this turn.",
-          "default": "full",
           "allOf": [
             {
               "$ref": "#/definitions/TurnItemsView"
             }
-          ]
+          ],
+          "default": "full",
+          "description": "Describes how much of `items` has been loaded for this turn."
         },
         "startedAt": {
           "description": "Unix timestamp (in seconds) when the turn started.",
+          "format": "int64",
           "type": [
             "integer",
             "null"
-          ],
-          "format": "int64"
+          ]
         },
         "status": {
           "$ref": "#/definitions/TurnStatus"
         }
-      }
+      },
+      "required": [
+        "id",
+        "items",
+        "status"
+      ],
+      "type": "object"
     },
     "TurnError": {
-      "type": "object",
-      "required": [
-        "message"
-      ],
       "properties": {
         "additionalDetails": {
           "default": null,
@@ -2039,81 +1968,105 @@
         "message": {
           "type": "string"
         }
-      }
+      },
+      "required": [
+        "message"
+      ],
+      "type": "object"
     },
     "TurnItemsView": {
       "oneOf": [
         {
           "description": "`items` was not loaded for this turn. The field is intentionally empty.",
-          "type": "string",
           "enum": [
             "notLoaded"
-          ]
+          ],
+          "type": "string"
         },
         {
           "description": "`items` contains only a display summary for this turn.",
-          "type": "string",
           "enum": [
             "summary"
-          ]
+          ],
+          "type": "string"
         },
         {
           "description": "`items` contains every ThreadItem available from persisted app-server history for this turn.",
-          "type": "string",
           "enum": [
             "full"
-          ]
+          ],
+          "type": "string"
         }
       ]
     },
     "TurnStatus": {
-      "type": "string",
       "enum": [
         "completed",
         "interrupted",
         "failed",
         "inProgress"
-      ]
+      ],
+      "type": "string"
+    },
+    "TurnsPage": {
+      "properties": {
+        "backwardsCursor": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "data": {
+          "items": {
+            "$ref": "#/definitions/Turn"
+          },
+          "type": "array"
+        },
+        "nextCursor": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "data"
+      ],
+      "type": "object"
     },
     "UserInput": {
       "oneOf": [
         {
-          "type": "object",
-          "required": [
-            "text",
-            "type"
-          ],
           "properties": {
             "text": {
               "type": "string"
             },
             "text_elements": {
-              "description": "UI-defined spans within `text` used to render or persist special elements.",
               "default": [],
-              "type": "array",
+              "description": "UI-defined spans within `text` used to render or persist special elements.",
               "items": {
                 "$ref": "#/definitions/TextElement"
-              }
+              },
+              "type": "array"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "text"
               ],
-              "title": "TextUserInputType"
+              "title": "TextUserInputType",
+              "type": "string"
             }
           },
-          "title": "TextUserInput"
+          "required": [
+            "text",
+            "type"
+          ],
+          "title": "TextUserInput",
+          "type": "object"
         },
         {
-          "type": "object",
-          "required": [
-            "type",
-            "url"
-          ],
           "properties": {
             "detail": {
-              "default": null,
               "anyOf": [
                 {
                   "$ref": "#/definitions/ImageDetail"
@@ -2121,30 +2074,30 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "default": null
             },
             "type": {
-              "type": "string",
               "enum": [
                 "image"
               ],
-              "title": "ImageUserInputType"
+              "title": "ImageUserInputType",
+              "type": "string"
             },
             "url": {
               "type": "string"
             }
           },
-          "title": "ImageUserInput"
+          "required": [
+            "type",
+            "url"
+          ],
+          "title": "ImageUserInput",
+          "type": "object"
         },
         {
-          "type": "object",
-          "required": [
-            "path",
-            "type"
-          ],
           "properties": {
             "detail": {
-              "default": null,
               "anyOf": [
                 {
                   "$ref": "#/definitions/ImageDetail"
@@ -2152,28 +2105,28 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "default": null
             },
             "path": {
               "type": "string"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "localImage"
               ],
-              "title": "LocalImageUserInputType"
+              "title": "LocalImageUserInputType",
+              "type": "string"
             }
           },
-          "title": "LocalImageUserInput"
-        },
-        {
-          "type": "object",
           "required": [
-            "name",
             "path",
             "type"
           ],
+          "title": "LocalImageUserInput",
+          "type": "object"
+        },
+        {
           "properties": {
             "name": {
               "type": "string"
@@ -2182,22 +2135,22 @@
               "type": "string"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "skill"
               ],
-              "title": "SkillUserInputType"
+              "title": "SkillUserInputType",
+              "type": "string"
             }
           },
-          "title": "SkillUserInput"
-        },
-        {
-          "type": "object",
           "required": [
             "name",
             "path",
             "type"
           ],
+          "title": "SkillUserInput",
+          "type": "object"
+        },
+        {
           "properties": {
             "name": {
               "type": "string"
@@ -2206,33 +2159,35 @@
               "type": "string"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "mention"
               ],
-              "title": "MentionUserInputType"
+              "title": "MentionUserInputType",
+              "type": "string"
             }
           },
-          "title": "MentionUserInput"
+          "required": [
+            "name",
+            "path",
+            "type"
+          ],
+          "title": "MentionUserInput",
+          "type": "object"
         }
       ]
     },
     "WebSearchAction": {
       "oneOf": [
         {
-          "type": "object",
-          "required": [
-            "type"
-          ],
           "properties": {
             "queries": {
+              "items": {
+                "type": "string"
+              },
               "type": [
                 "array",
                 "null"
-              ],
-              "items": {
-                "type": "string"
-              }
+              ]
             },
             "query": {
               "type": [
@@ -2241,27 +2196,27 @@
               ]
             },
             "type": {
-              "type": "string",
               "enum": [
                 "search"
               ],
-              "title": "SearchWebSearchActionType"
+              "title": "SearchWebSearchActionType",
+              "type": "string"
             }
           },
-          "title": "SearchWebSearchAction"
-        },
-        {
-          "type": "object",
           "required": [
             "type"
           ],
+          "title": "SearchWebSearchAction",
+          "type": "object"
+        },
+        {
           "properties": {
             "type": {
-              "type": "string",
               "enum": [
                 "openPage"
               ],
-              "title": "OpenPageWebSearchActionType"
+              "title": "OpenPageWebSearchActionType",
+              "type": "string"
             },
             "url": {
               "type": [
@@ -2270,13 +2225,13 @@
               ]
             }
           },
-          "title": "OpenPageWebSearchAction"
-        },
-        {
-          "type": "object",
           "required": [
             "type"
           ],
+          "title": "OpenPageWebSearchAction",
+          "type": "object"
+        },
+        {
           "properties": {
             "pattern": {
               "type": [
@@ -2285,11 +2240,11 @@
               ]
             },
             "type": {
-              "type": "string",
               "enum": [
                 "findInPage"
               ],
-              "title": "FindInPageWebSearchActionType"
+              "title": "FindInPageWebSearchActionType",
+              "type": "string"
             },
             "url": {
               "type": [
@@ -2298,25 +2253,129 @@
               ]
             }
           },
-          "title": "FindInPageWebSearchAction"
-        },
-        {
-          "type": "object",
           "required": [
             "type"
           ],
+          "title": "FindInPageWebSearchAction",
+          "type": "object"
+        },
+        {
           "properties": {
             "type": {
-              "type": "string",
               "enum": [
                 "other"
               ],
-              "title": "OtherWebSearchActionType"
+              "title": "OtherWebSearchActionType",
+              "type": "string"
             }
           },
-          "title": "OtherWebSearchAction"
+          "required": [
+            "type"
+          ],
+          "title": "OtherWebSearchAction",
+          "type": "object"
         }
       ]
     }
-  }
+  },
+  "properties": {
+    "activePermissionProfile": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/ActivePermissionProfile"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Named or implicit built-in profile that produced the active permissions, when known."
+    },
+    "approvalPolicy": {
+      "$ref": "#/definitions/AskForApproval"
+    },
+    "approvalsReviewer": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/ApprovalsReviewer"
+        }
+      ],
+      "description": "Reviewer currently used for approval requests on this thread."
+    },
+    "cwd": {
+      "$ref": "#/definitions/AbsolutePathBuf"
+    },
+    "initialTurnsPage": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/TurnsPage"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "`thread/turns/list` page returned when requested by `initialTurnsPage`."
+    },
+    "instructionSources": {
+      "default": [],
+      "description": "Instruction source files currently loaded for this thread.",
+      "items": {
+        "$ref": "#/definitions/AbsolutePathBuf"
+      },
+      "type": "array"
+    },
+    "model": {
+      "type": "string"
+    },
+    "modelProvider": {
+      "type": "string"
+    },
+    "reasoningEffort": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/ReasoningEffort"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "runtimeWorkspaceRoots": {
+      "default": [],
+      "description": "Thread-scoped runtime workspace roots used to materialize `:workspace_roots`.",
+      "items": {
+        "$ref": "#/definitions/AbsolutePathBuf"
+      },
+      "type": "array"
+    },
+    "sandbox": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/SandboxPolicy"
+        }
+      ],
+      "description": "Legacy sandbox policy retained for compatibility. Experimental clients should prefer `activePermissionProfile` for profile provenance."
+    },
+    "serviceTier": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "thread": {
+      "$ref": "#/definitions/Thread"
+    }
+  },
+  "required": [
+    "approvalPolicy",
+    "approvalsReviewer",
+    "cwd",
+    "model",
+    "modelProvider",
+    "sandbox",
+    "thread"
+  ],
+  "title": "ThreadResumeResponse",
+  "type": "object"
 }

--- a/extensions/codex/src/app-server/protocol-generated/json/v2/ThreadStartResponse.json
+++ b/extensions/codex/src/app-server/protocol-generated/json/v2/ThreadStartResponse.json
@@ -1,107 +1,15 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "ThreadStartResponse",
-  "type": "object",
-  "required": [
-    "approvalPolicy",
-    "approvalsReviewer",
-    "cwd",
-    "model",
-    "modelProvider",
-    "sandbox",
-    "thread"
-  ],
-  "properties": {
-    "activePermissionProfile": {
-      "description": "Named or implicit built-in profile that produced the active permissions, when known.",
-      "default": null,
-      "anyOf": [
-        {
-          "$ref": "#/definitions/ActivePermissionProfile"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "approvalPolicy": {
-      "$ref": "#/definitions/AskForApproval"
-    },
-    "approvalsReviewer": {
-      "description": "Reviewer currently used for approval requests on this thread.",
-      "allOf": [
-        {
-          "$ref": "#/definitions/ApprovalsReviewer"
-        }
-      ]
-    },
-    "cwd": {
-      "$ref": "#/definitions/AbsolutePathBuf"
-    },
-    "instructionSources": {
-      "description": "Instruction source files currently loaded for this thread.",
-      "default": [],
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/AbsolutePathBuf"
-      }
-    },
-    "model": {
-      "type": "string"
-    },
-    "modelProvider": {
-      "type": "string"
-    },
-    "reasoningEffort": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/ReasoningEffort"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "runtimeWorkspaceRoots": {
-      "description": "Thread-scoped runtime workspace roots used to materialize `:workspace_roots`.",
-      "default": [],
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/AbsolutePathBuf"
-      }
-    },
-    "sandbox": {
-      "description": "Legacy sandbox policy retained for compatibility. Experimental clients should prefer `activePermissionProfile` for profile provenance.",
-      "allOf": [
-        {
-          "$ref": "#/definitions/SandboxPolicy"
-        }
-      ]
-    },
-    "serviceTier": {
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "thread": {
-      "$ref": "#/definitions/Thread"
-    }
-  },
   "definitions": {
     "AbsolutePathBuf": {
       "description": "A path that is guaranteed to be absolute and normalized (though it is not guaranteed to be canonicalized or exist on the filesystem).\n\nIMPORTANT: When deserializing an `AbsolutePathBuf`, a base path must be set using [AbsolutePathBufGuard::new]. If no base path is set, the deserialization will fail unless the path being deserialized is already absolute.",
       "type": "string"
     },
     "ActivePermissionProfile": {
-      "type": "object",
-      "required": [
-        "id"
-      ],
       "properties": {
         "extends": {
-          "description": "Parent profile identifier once permissions profiles support inheritance. This is currently always `null`.",
           "default": null,
+          "description": "Parent profile identifier from the selected permissions profile's `extends` setting, when present.",
           "type": [
             "string",
             "null"
@@ -111,44 +19,39 @@
           "description": "Identifier from `default_permissions` or the implicit built-in default, such as `:workspace` or a user-defined `[permissions.<id>]` profile.",
           "type": "string"
         }
-      }
+      },
+      "required": [
+        "id"
+      ],
+      "type": "object"
     },
     "AgentPath": {
       "type": "string"
     },
     "ApprovalsReviewer": {
       "description": "Configures who approval requests are routed to for review. Examples include sandbox escapes, blocked network access, MCP approval prompts, and ARC escalations. Defaults to `user`. `auto_review` uses a carefully prompted subagent to gather relevant context and apply a risk-based decision framework before approving or denying the request. The legacy value `guardian_subagent` is accepted for compatibility.",
-      "type": "string",
       "enum": [
         "user",
         "auto_review",
         "guardian_subagent"
-      ]
+      ],
+      "type": "string"
     },
     "AskForApproval": {
       "oneOf": [
         {
-          "type": "string",
           "enum": [
             "untrusted",
             "on-failure",
             "on-request",
             "never"
-          ]
+          ],
+          "type": "string"
         },
         {
-          "type": "object",
-          "required": [
-            "granular"
-          ],
+          "additionalProperties": false,
           "properties": {
             "granular": {
-              "type": "object",
-              "required": [
-                "mcp_elicitations",
-                "rules",
-                "sandbox_approval"
-              ],
               "properties": {
                 "mcp_elicitations": {
                   "type": "boolean"
@@ -167,38 +70,46 @@
                   "default": false,
                   "type": "boolean"
                 }
-              }
+              },
+              "required": [
+                "mcp_elicitations",
+                "rules",
+                "sandbox_approval"
+              ],
+              "type": "object"
             }
           },
-          "additionalProperties": false,
-          "title": "GranularAskForApproval"
+          "required": [
+            "granular"
+          ],
+          "title": "GranularAskForApproval",
+          "type": "object"
         }
       ]
     },
     "ByteRange": {
-      "type": "object",
+      "properties": {
+        "end": {
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "start": {
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
       "required": [
         "end",
         "start"
       ],
-      "properties": {
-        "end": {
-          "type": "integer",
-          "format": "uint",
-          "minimum": 0
-        },
-        "start": {
-          "type": "integer",
-          "format": "uint",
-          "minimum": 0
-        }
-      }
+      "type": "object"
     },
     "CodexErrorInfo": {
       "description": "This translation layer make sure that we expose codex error code in camel case.\n\nWhen an upstream HTTP status is available (for example, from the Responses API or a provider), it is forwarded in `httpStatusCode` on the relevant `codexErrorInfo` variant.",
       "oneOf": [
         {
-          "type": "string",
           "enum": [
             "contextWindowExceeded",
             "usageLimitExceeded",
@@ -210,132 +121,129 @@
             "threadRollbackFailed",
             "sandboxError",
             "other"
-          ]
+          ],
+          "type": "string"
         },
         {
-          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "httpConnectionFailed": {
+              "properties": {
+                "httpStatusCode": {
+                  "format": "uint16",
+                  "minimum": 0,
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                }
+              },
+              "type": "object"
+            }
+          },
           "required": [
             "httpConnectionFailed"
           ],
+          "title": "HttpConnectionFailedCodexErrorInfo",
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "description": "Failed to connect to the response SSE stream.",
           "properties": {
-            "httpConnectionFailed": {
-              "type": "object",
+            "responseStreamConnectionFailed": {
               "properties": {
                 "httpStatusCode": {
+                  "format": "uint16",
+                  "minimum": 0,
                   "type": [
                     "integer",
                     "null"
-                  ],
-                  "format": "uint16",
-                  "minimum": 0
+                  ]
                 }
-              }
+              },
+              "type": "object"
             }
           },
-          "additionalProperties": false,
-          "title": "HttpConnectionFailedCodexErrorInfo"
-        },
-        {
-          "description": "Failed to connect to the response SSE stream.",
-          "type": "object",
           "required": [
             "responseStreamConnectionFailed"
           ],
+          "title": "ResponseStreamConnectionFailedCodexErrorInfo",
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "description": "The response SSE stream disconnected in the middle of a turn before completion.",
           "properties": {
-            "responseStreamConnectionFailed": {
-              "type": "object",
+            "responseStreamDisconnected": {
               "properties": {
                 "httpStatusCode": {
+                  "format": "uint16",
+                  "minimum": 0,
                   "type": [
                     "integer",
                     "null"
-                  ],
-                  "format": "uint16",
-                  "minimum": 0
+                  ]
                 }
-              }
+              },
+              "type": "object"
             }
           },
-          "additionalProperties": false,
-          "title": "ResponseStreamConnectionFailedCodexErrorInfo"
-        },
-        {
-          "description": "The response SSE stream disconnected in the middle of a turn before completion.",
-          "type": "object",
           "required": [
             "responseStreamDisconnected"
           ],
+          "title": "ResponseStreamDisconnectedCodexErrorInfo",
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "description": "Reached the retry limit for responses.",
           "properties": {
-            "responseStreamDisconnected": {
-              "type": "object",
+            "responseTooManyFailedAttempts": {
               "properties": {
                 "httpStatusCode": {
+                  "format": "uint16",
+                  "minimum": 0,
                   "type": [
                     "integer",
                     "null"
-                  ],
-                  "format": "uint16",
-                  "minimum": 0
+                  ]
                 }
-              }
+              },
+              "type": "object"
             }
           },
-          "additionalProperties": false,
-          "title": "ResponseStreamDisconnectedCodexErrorInfo"
-        },
-        {
-          "description": "Reached the retry limit for responses.",
-          "type": "object",
           "required": [
             "responseTooManyFailedAttempts"
           ],
-          "properties": {
-            "responseTooManyFailedAttempts": {
-              "type": "object",
-              "properties": {
-                "httpStatusCode": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ],
-                  "format": "uint16",
-                  "minimum": 0
-                }
-              }
-            }
-          },
-          "additionalProperties": false,
-          "title": "ResponseTooManyFailedAttemptsCodexErrorInfo"
+          "title": "ResponseTooManyFailedAttemptsCodexErrorInfo",
+          "type": "object"
         },
         {
+          "additionalProperties": false,
           "description": "Returned when `turn/start` or `turn/steer` is submitted while the current active turn cannot accept same-turn steering, for example `/review` or manual `/compact`.",
-          "type": "object",
-          "required": [
-            "activeTurnNotSteerable"
-          ],
           "properties": {
             "activeTurnNotSteerable": {
-              "type": "object",
-              "required": [
-                "turnKind"
-              ],
               "properties": {
                 "turnKind": {
                   "$ref": "#/definitions/NonSteerableTurnKind"
                 }
-              }
+              },
+              "required": [
+                "turnKind"
+              ],
+              "type": "object"
             }
           },
-          "additionalProperties": false,
-          "title": "ActiveTurnNotSteerableCodexErrorInfo"
+          "required": [
+            "activeTurnNotSteerable"
+          ],
+          "title": "ActiveTurnNotSteerableCodexErrorInfo",
+          "type": "object"
         }
       ]
     },
     "CollabAgentState": {
-      "type": "object",
-      "required": [
-        "status"
-      ],
       "properties": {
         "message": {
           "type": [
@@ -346,10 +254,13 @@
         "status": {
           "$ref": "#/definitions/CollabAgentStatus"
         }
-      }
+      },
+      "required": [
+        "status"
+      ],
+      "type": "object"
     },
     "CollabAgentStatus": {
-      "type": "string",
       "enum": [
         "pendingInit",
         "running",
@@ -358,36 +269,30 @@
         "errored",
         "shutdown",
         "notFound"
-      ]
+      ],
+      "type": "string"
     },
     "CollabAgentTool": {
-      "type": "string",
       "enum": [
         "spawnAgent",
         "sendInput",
         "resumeAgent",
         "wait",
         "closeAgent"
-      ]
+      ],
+      "type": "string"
     },
     "CollabAgentToolCallStatus": {
-      "type": "string",
       "enum": [
         "inProgress",
         "completed",
         "failed"
-      ]
+      ],
+      "type": "string"
     },
     "CommandAction": {
       "oneOf": [
         {
-          "type": "object",
-          "required": [
-            "command",
-            "name",
-            "path",
-            "type"
-          ],
           "properties": {
             "command": {
               "type": "string"
@@ -399,21 +304,23 @@
               "$ref": "#/definitions/AbsolutePathBuf"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "read"
               ],
-              "title": "ReadCommandActionType"
+              "title": "ReadCommandActionType",
+              "type": "string"
             }
           },
-          "title": "ReadCommandAction"
-        },
-        {
-          "type": "object",
           "required": [
             "command",
+            "name",
+            "path",
             "type"
           ],
+          "title": "ReadCommandAction",
+          "type": "object"
+        },
+        {
           "properties": {
             "command": {
               "type": "string"
@@ -425,21 +332,21 @@
               ]
             },
             "type": {
-              "type": "string",
               "enum": [
                 "listFiles"
               ],
-              "title": "ListFilesCommandActionType"
+              "title": "ListFilesCommandActionType",
+              "type": "string"
             }
           },
-          "title": "ListFilesCommandAction"
-        },
-        {
-          "type": "object",
           "required": [
             "command",
             "type"
           ],
+          "title": "ListFilesCommandAction",
+          "type": "object"
+        },
+        {
           "properties": {
             "command": {
               "type": "string"
@@ -457,114 +364,113 @@
               ]
             },
             "type": {
-              "type": "string",
               "enum": [
                 "search"
               ],
-              "title": "SearchCommandActionType"
+              "title": "SearchCommandActionType",
+              "type": "string"
             }
           },
-          "title": "SearchCommandAction"
-        },
-        {
-          "type": "object",
           "required": [
             "command",
             "type"
           ],
+          "title": "SearchCommandAction",
+          "type": "object"
+        },
+        {
           "properties": {
             "command": {
               "type": "string"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "unknown"
               ],
-              "title": "UnknownCommandActionType"
+              "title": "UnknownCommandActionType",
+              "type": "string"
             }
           },
-          "title": "UnknownCommandAction"
+          "required": [
+            "command",
+            "type"
+          ],
+          "title": "UnknownCommandAction",
+          "type": "object"
         }
       ]
     },
     "CommandExecutionSource": {
-      "type": "string",
       "enum": [
         "agent",
         "userShell",
         "unifiedExecStartup",
         "unifiedExecInteraction"
-      ]
+      ],
+      "type": "string"
     },
     "CommandExecutionStatus": {
-      "type": "string",
       "enum": [
         "inProgress",
         "completed",
         "failed",
         "declined"
-      ]
+      ],
+      "type": "string"
     },
     "DynamicToolCallOutputContentItem": {
       "oneOf": [
         {
-          "type": "object",
-          "required": [
-            "text",
-            "type"
-          ],
           "properties": {
             "text": {
               "type": "string"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "inputText"
               ],
-              "title": "InputTextDynamicToolCallOutputContentItemType"
+              "title": "InputTextDynamicToolCallOutputContentItemType",
+              "type": "string"
             }
           },
-          "title": "InputTextDynamicToolCallOutputContentItem"
-        },
-        {
-          "type": "object",
           "required": [
-            "imageUrl",
+            "text",
             "type"
           ],
+          "title": "InputTextDynamicToolCallOutputContentItem",
+          "type": "object"
+        },
+        {
           "properties": {
             "imageUrl": {
               "type": "string"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "inputImage"
               ],
-              "title": "InputImageDynamicToolCallOutputContentItemType"
+              "title": "InputImageDynamicToolCallOutputContentItemType",
+              "type": "string"
             }
           },
-          "title": "InputImageDynamicToolCallOutputContentItem"
+          "required": [
+            "imageUrl",
+            "type"
+          ],
+          "title": "InputImageDynamicToolCallOutputContentItem",
+          "type": "object"
         }
       ]
     },
     "DynamicToolCallStatus": {
-      "type": "string",
       "enum": [
         "inProgress",
         "completed",
         "failed"
-      ]
+      ],
+      "type": "string"
     },
     "FileUpdateChange": {
-      "type": "object",
-      "required": [
-        "diff",
-        "kind",
-        "path"
-      ],
       "properties": {
         "diff": {
           "type": "string"
@@ -575,10 +481,15 @@
         "path": {
           "type": "string"
         }
-      }
+      },
+      "required": [
+        "diff",
+        "kind",
+        "path"
+      ],
+      "type": "object"
     },
     "GitInfo": {
-      "type": "object",
       "properties": {
         "branch": {
           "type": [
@@ -598,14 +509,10 @@
             "null"
           ]
         }
-      }
+      },
+      "type": "object"
     },
     "HookPromptFragment": {
-      "type": "object",
-      "required": [
-        "hookRunId",
-        "text"
-      ],
       "properties": {
         "hookRunId": {
           "type": "string"
@@ -613,87 +520,87 @@
         "text": {
           "type": "string"
         }
-      }
+      },
+      "required": [
+        "hookRunId",
+        "text"
+      ],
+      "type": "object"
     },
     "ImageDetail": {
-      "type": "string",
       "enum": [
+        "auto",
+        "low",
         "high",
         "original"
-      ]
+      ],
+      "type": "string"
     },
     "McpToolCallError": {
-      "type": "object",
-      "required": [
-        "message"
-      ],
       "properties": {
         "message": {
           "type": "string"
         }
-      }
+      },
+      "required": [
+        "message"
+      ],
+      "type": "object"
     },
     "McpToolCallResult": {
-      "type": "object",
-      "required": [
-        "content"
-      ],
       "properties": {
         "_meta": true,
         "content": {
-          "type": "array",
-          "items": true
+          "items": true,
+          "type": "array"
         },
         "structuredContent": true
-      }
+      },
+      "required": [
+        "content"
+      ],
+      "type": "object"
     },
     "McpToolCallStatus": {
-      "type": "string",
       "enum": [
         "inProgress",
         "completed",
         "failed"
-      ]
+      ],
+      "type": "string"
     },
     "MemoryCitation": {
-      "type": "object",
+      "properties": {
+        "entries": {
+          "items": {
+            "$ref": "#/definitions/MemoryCitationEntry"
+          },
+          "type": "array"
+        },
+        "threadIds": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
       "required": [
         "entries",
         "threadIds"
       ],
-      "properties": {
-        "entries": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/MemoryCitationEntry"
-          }
-        },
-        "threadIds": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
+      "type": "object"
     },
     "MemoryCitationEntry": {
-      "type": "object",
-      "required": [
-        "lineEnd",
-        "lineStart",
-        "note",
-        "path"
-      ],
       "properties": {
         "lineEnd": {
-          "type": "integer",
           "format": "uint32",
-          "minimum": 0
+          "minimum": 0,
+          "type": "integer"
         },
         "lineStart": {
-          "type": "integer",
           "format": "uint32",
-          "minimum": 0
+          "minimum": 0,
+          "type": "integer"
         },
         "note": {
           "type": "string"
@@ -701,89 +608,92 @@
         "path": {
           "type": "string"
         }
-      }
+      },
+      "required": [
+        "lineEnd",
+        "lineStart",
+        "note",
+        "path"
+      ],
+      "type": "object"
     },
     "MessagePhase": {
       "description": "Classifies an assistant message as interim commentary or final answer text.\n\nProviders do not emit this consistently, so callers must treat `None` as \"phase unknown\" and keep compatibility behavior for legacy models.",
       "oneOf": [
         {
           "description": "Mid-turn assistant text (for example preamble/progress narration).\n\nAdditional tool calls or assistant output may follow before turn completion.",
-          "type": "string",
           "enum": [
             "commentary"
-          ]
+          ],
+          "type": "string"
         },
         {
           "description": "The assistant's terminal answer text for the current turn.",
-          "type": "string",
           "enum": [
             "final_answer"
-          ]
+          ],
+          "type": "string"
         }
       ]
     },
     "NetworkAccess": {
-      "type": "string",
       "enum": [
         "restricted",
         "enabled"
-      ]
+      ],
+      "type": "string"
     },
     "NonSteerableTurnKind": {
-      "type": "string",
       "enum": [
         "review",
         "compact"
-      ]
+      ],
+      "type": "string"
     },
     "PatchApplyStatus": {
-      "type": "string",
       "enum": [
         "inProgress",
         "completed",
         "failed",
         "declined"
-      ]
+      ],
+      "type": "string"
     },
     "PatchChangeKind": {
       "oneOf": [
         {
-          "type": "object",
-          "required": [
-            "type"
-          ],
           "properties": {
             "type": {
-              "type": "string",
               "enum": [
                 "add"
               ],
-              "title": "AddPatchChangeKindType"
+              "title": "AddPatchChangeKindType",
+              "type": "string"
             }
           },
-          "title": "AddPatchChangeKind"
-        },
-        {
-          "type": "object",
           "required": [
             "type"
           ],
+          "title": "AddPatchChangeKind",
+          "type": "object"
+        },
+        {
           "properties": {
             "type": {
-              "type": "string",
               "enum": [
                 "delete"
               ],
-              "title": "DeletePatchChangeKindType"
+              "title": "DeletePatchChangeKindType",
+              "type": "string"
             }
           },
-          "title": "DeletePatchChangeKind"
-        },
-        {
-          "type": "object",
           "required": [
             "type"
           ],
+          "title": "DeletePatchChangeKind",
+          "type": "object"
+        },
+        {
           "properties": {
             "move_path": {
               "type": [
@@ -792,20 +702,23 @@
               ]
             },
             "type": {
-              "type": "string",
               "enum": [
                 "update"
               ],
-              "title": "UpdatePatchChangeKindType"
+              "title": "UpdatePatchChangeKindType",
+              "type": "string"
             }
           },
-          "title": "UpdatePatchChangeKind"
+          "required": [
+            "type"
+          ],
+          "title": "UpdatePatchChangeKind",
+          "type": "object"
         }
       ]
     },
     "ReasoningEffort": {
       "description": "See https://platform.openai.com/docs/guides/reasoning?api-mode=responses#get-started-with-reasoning",
-      "type": "string",
       "enum": [
         "none",
         "minimal",
@@ -813,75 +726,72 @@
         "medium",
         "high",
         "xhigh"
-      ]
+      ],
+      "type": "string"
     },
     "SandboxPolicy": {
       "oneOf": [
         {
-          "type": "object",
-          "required": [
-            "type"
-          ],
           "properties": {
             "type": {
-              "type": "string",
               "enum": [
                 "dangerFullAccess"
               ],
-              "title": "DangerFullAccessSandboxPolicyType"
+              "title": "DangerFullAccessSandboxPolicyType",
+              "type": "string"
             }
           },
-          "title": "DangerFullAccessSandboxPolicy"
-        },
-        {
-          "type": "object",
           "required": [
             "type"
           ],
+          "title": "DangerFullAccessSandboxPolicy",
+          "type": "object"
+        },
+        {
           "properties": {
             "networkAccess": {
               "default": false,
               "type": "boolean"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "readOnly"
               ],
-              "title": "ReadOnlySandboxPolicyType"
+              "title": "ReadOnlySandboxPolicyType",
+              "type": "string"
             }
           },
-          "title": "ReadOnlySandboxPolicy"
-        },
-        {
-          "type": "object",
           "required": [
             "type"
           ],
+          "title": "ReadOnlySandboxPolicy",
+          "type": "object"
+        },
+        {
           "properties": {
             "networkAccess": {
-              "default": "restricted",
               "allOf": [
                 {
                   "$ref": "#/definitions/NetworkAccess"
                 }
-              ]
+              ],
+              "default": "restricted"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "externalSandbox"
               ],
-              "title": "ExternalSandboxSandboxPolicyType"
+              "title": "ExternalSandboxSandboxPolicyType",
+              "type": "string"
             }
           },
-          "title": "ExternalSandboxSandboxPolicy"
-        },
-        {
-          "type": "object",
           "required": [
             "type"
           ],
+          "title": "ExternalSandboxSandboxPolicy",
+          "type": "object"
+        },
+        {
           "properties": {
             "excludeSlashTmp": {
               "default": false,
@@ -896,86 +806,82 @@
               "type": "boolean"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "workspaceWrite"
               ],
-              "title": "WorkspaceWriteSandboxPolicyType"
+              "title": "WorkspaceWriteSandboxPolicyType",
+              "type": "string"
             },
             "writableRoots": {
               "default": [],
-              "type": "array",
               "items": {
                 "$ref": "#/definitions/AbsolutePathBuf"
-              }
+              },
+              "type": "array"
             }
           },
-          "title": "WorkspaceWriteSandboxPolicy"
+          "required": [
+            "type"
+          ],
+          "title": "WorkspaceWriteSandboxPolicy",
+          "type": "object"
         }
       ]
     },
     "SessionSource": {
       "oneOf": [
         {
-          "type": "string",
           "enum": [
             "cli",
             "vscode",
             "exec",
             "appServer",
             "unknown"
-          ]
+          ],
+          "type": "string"
         },
         {
-          "type": "object",
-          "required": [
-            "custom"
-          ],
+          "additionalProperties": false,
           "properties": {
             "custom": {
               "type": "string"
             }
           },
-          "additionalProperties": false,
-          "title": "CustomSessionSource"
+          "required": [
+            "custom"
+          ],
+          "title": "CustomSessionSource",
+          "type": "object"
         },
         {
-          "type": "object",
-          "required": [
-            "subAgent"
-          ],
+          "additionalProperties": false,
           "properties": {
             "subAgent": {
               "$ref": "#/definitions/SubAgentSource"
             }
           },
-          "additionalProperties": false,
-          "title": "SubAgentSessionSource"
+          "required": [
+            "subAgent"
+          ],
+          "title": "SubAgentSessionSource",
+          "type": "object"
         }
       ]
     },
     "SubAgentSource": {
       "oneOf": [
         {
-          "type": "string",
           "enum": [
             "review",
             "compact",
             "memory_consolidation"
-          ]
+          ],
+          "type": "string"
         },
         {
-          "type": "object",
-          "required": [
-            "thread_spawn"
-          ],
+          "additionalProperties": false,
           "properties": {
             "thread_spawn": {
-              "type": "object",
-              "required": [
-                "depth",
-                "parent_thread_id"
-              ],
               "properties": {
                 "agent_nickname": {
                   "default": null,
@@ -985,7 +891,6 @@
                   ]
                 },
                 "agent_path": {
-                  "default": null,
                   "anyOf": [
                     {
                       "$ref": "#/definitions/AgentPath"
@@ -993,7 +898,8 @@
                     {
                       "type": "null"
                     }
-                  ]
+                  ],
+                  "default": null
                 },
                 "agent_role": {
                   "default": null,
@@ -1003,46 +909,50 @@
                   ]
                 },
                 "depth": {
-                  "type": "integer",
-                  "format": "int32"
+                  "format": "int32",
+                  "type": "integer"
                 },
                 "parent_thread_id": {
                   "$ref": "#/definitions/ThreadId"
                 }
-              }
+              },
+              "required": [
+                "depth",
+                "parent_thread_id"
+              ],
+              "type": "object"
             }
           },
-          "additionalProperties": false,
-          "title": "ThreadSpawnSubAgentSource"
+          "required": [
+            "thread_spawn"
+          ],
+          "title": "ThreadSpawnSubAgentSource",
+          "type": "object"
         },
         {
-          "type": "object",
-          "required": [
-            "other"
-          ],
+          "additionalProperties": false,
           "properties": {
             "other": {
               "type": "string"
             }
           },
-          "additionalProperties": false,
-          "title": "OtherSubAgentSource"
+          "required": [
+            "other"
+          ],
+          "title": "OtherSubAgentSource",
+          "type": "object"
         }
       ]
     },
     "TextElement": {
-      "type": "object",
-      "required": [
-        "byteRange"
-      ],
       "properties": {
         "byteRange": {
-          "description": "Byte range in the parent `text` buffer that this element occupies.",
           "allOf": [
             {
               "$ref": "#/definitions/ByteRange"
             }
-          ]
+          ],
+          "description": "Byte range in the parent `text` buffer that this element occupies."
         },
         "placeholder": {
           "description": "Optional human-readable placeholder for the element, displayed in the UI.",
@@ -1051,24 +961,13 @@
             "null"
           ]
         }
-      }
+      },
+      "required": [
+        "byteRange"
+      ],
+      "type": "object"
     },
     "Thread": {
-      "type": "object",
-      "required": [
-        "cliVersion",
-        "createdAt",
-        "cwd",
-        "ephemeral",
-        "id",
-        "modelProvider",
-        "preview",
-        "sessionId",
-        "source",
-        "status",
-        "turns",
-        "updatedAt"
-      ],
       "properties": {
         "agentNickname": {
           "description": "Optional random unique nickname assigned to an AgentControl-spawned sub-agent.",
@@ -1090,16 +989,16 @@
         },
         "createdAt": {
           "description": "Unix timestamp (in seconds) when the thread was created.",
-          "type": "integer",
-          "format": "int64"
+          "format": "int64",
+          "type": "integer"
         },
         "cwd": {
-          "description": "Working directory captured for the thread.",
           "allOf": [
             {
               "$ref": "#/definitions/AbsolutePathBuf"
             }
-          ]
+          ],
+          "description": "Working directory captured for the thread."
         },
         "ephemeral": {
           "description": "Whether the thread is ephemeral and should not be materialized on disk.",
@@ -1113,7 +1012,6 @@
           ]
         },
         "gitInfo": {
-          "description": "Optional Git metadata captured when the thread was created.",
           "anyOf": [
             {
               "$ref": "#/definitions/GitInfo"
@@ -1121,7 +1019,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Optional Git metadata captured when the thread was created."
         },
         "id": {
           "type": "string"
@@ -1132,6 +1031,13 @@
         },
         "name": {
           "description": "Optional user-facing thread title.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "parentThreadId": {
+          "description": "The ID of the parent thread. This will only be set if this thread is a subagent.",
           "type": [
             "string",
             "null"
@@ -1153,23 +1059,22 @@
           "type": "string"
         },
         "source": {
-          "description": "Origin of the thread (CLI, VSCode, codex exec, codex app-server, etc.).",
           "allOf": [
             {
               "$ref": "#/definitions/SessionSource"
             }
-          ]
+          ],
+          "description": "Origin of the thread (CLI, VSCode, codex exec, codex app-server, etc.)."
         },
         "status": {
-          "description": "Current runtime status for the thread.",
           "allOf": [
             {
               "$ref": "#/definitions/ThreadStatus"
             }
-          ]
+          ],
+          "description": "Current runtime status for the thread."
         },
         "threadSource": {
-          "description": "Optional analytics source classification for this thread.",
           "anyOf": [
             {
               "$ref": "#/definitions/ThreadSource"
@@ -1177,28 +1082,44 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Optional analytics source classification for this thread."
         },
         "turns": {
           "description": "Only populated on `thread/resume`, `thread/rollback`, `thread/fork`, and `thread/read` (when `includeTurns` is true) responses. For all other responses and notifications returning a Thread, the turns field will be an empty list.",
-          "type": "array",
           "items": {
             "$ref": "#/definitions/Turn"
-          }
+          },
+          "type": "array"
         },
         "updatedAt": {
           "description": "Unix timestamp (in seconds) when the thread was last updated.",
-          "type": "integer",
-          "format": "int64"
+          "format": "int64",
+          "type": "integer"
         }
-      }
+      },
+      "required": [
+        "cliVersion",
+        "createdAt",
+        "cwd",
+        "ephemeral",
+        "id",
+        "modelProvider",
+        "preview",
+        "sessionId",
+        "source",
+        "status",
+        "turns",
+        "updatedAt"
+      ],
+      "type": "object"
     },
     "ThreadActiveFlag": {
-      "type": "string",
       "enum": [
         "waitingOnApproval",
         "waitingOnUserInput"
-      ]
+      ],
+      "type": "string"
     },
     "ThreadId": {
       "type": "string"
@@ -1206,72 +1127,71 @@
     "ThreadItem": {
       "oneOf": [
         {
-          "type": "object",
+          "properties": {
+            "clientId": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "content": {
+              "items": {
+                "$ref": "#/definitions/UserInput"
+              },
+              "type": "array"
+            },
+            "id": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "userMessage"
+              ],
+              "title": "UserMessageThreadItemType",
+              "type": "string"
+            }
+          },
           "required": [
             "content",
             "id",
             "type"
           ],
+          "title": "UserMessageThreadItem",
+          "type": "object"
+        },
+        {
           "properties": {
-            "content": {
-              "type": "array",
+            "fragments": {
               "items": {
-                "$ref": "#/definitions/UserInput"
-              }
+                "$ref": "#/definitions/HookPromptFragment"
+              },
+              "type": "array"
             },
             "id": {
               "type": "string"
             },
             "type": {
-              "type": "string",
               "enum": [
-                "userMessage"
+                "hookPrompt"
               ],
-              "title": "UserMessageThreadItemType"
+              "title": "HookPromptThreadItemType",
+              "type": "string"
             }
           },
-          "title": "UserMessageThreadItem"
-        },
-        {
-          "type": "object",
           "required": [
             "fragments",
             "id",
             "type"
           ],
-          "properties": {
-            "fragments": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/HookPromptFragment"
-              }
-            },
-            "id": {
-              "type": "string"
-            },
-            "type": {
-              "type": "string",
-              "enum": [
-                "hookPrompt"
-              ],
-              "title": "HookPromptThreadItemType"
-            }
-          },
-          "title": "HookPromptThreadItem"
+          "title": "HookPromptThreadItem",
+          "type": "object"
         },
         {
-          "type": "object",
-          "required": [
-            "id",
-            "text",
-            "type"
-          ],
           "properties": {
             "id": {
               "type": "string"
             },
             "memoryCitation": {
-              "default": null,
               "anyOf": [
                 {
                   "$ref": "#/definitions/MemoryCitation"
@@ -1279,10 +1199,10 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "default": null
             },
             "phase": {
-              "default": null,
               "anyOf": [
                 {
                   "$ref": "#/definitions/MessagePhase"
@@ -1290,29 +1210,30 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "default": null
             },
             "text": {
               "type": "string"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "agentMessage"
               ],
-              "title": "AgentMessageThreadItemType"
+              "title": "AgentMessageThreadItemType",
+              "type": "string"
             }
           },
-          "title": "AgentMessageThreadItem"
-        },
-        {
-          "description": "EXPERIMENTAL - proposed plan item content. The completed plan item is authoritative and may not match the concatenation of `PlanDelta` text.",
-          "type": "object",
           "required": [
             "id",
             "text",
             "type"
           ],
+          "title": "AgentMessageThreadItem",
+          "type": "object"
+        },
+        {
+          "description": "EXPERIMENTAL - proposed plan item content. The completed plan item is authoritative and may not match the concatenation of `PlanDelta` text.",
           "properties": {
             "id": {
               "type": "string"
@@ -1321,59 +1242,56 @@
               "type": "string"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "plan"
               ],
-              "title": "PlanThreadItemType"
+              "title": "PlanThreadItemType",
+              "type": "string"
             }
           },
-          "title": "PlanThreadItem"
-        },
-        {
-          "type": "object",
           "required": [
             "id",
+            "text",
             "type"
           ],
+          "title": "PlanThreadItem",
+          "type": "object"
+        },
+        {
           "properties": {
             "content": {
               "default": [],
-              "type": "array",
               "items": {
                 "type": "string"
-              }
+              },
+              "type": "array"
             },
             "id": {
               "type": "string"
             },
             "summary": {
               "default": [],
-              "type": "array",
               "items": {
                 "type": "string"
-              }
+              },
+              "type": "array"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "reasoning"
               ],
-              "title": "ReasoningThreadItemType"
+              "title": "ReasoningThreadItemType",
+              "type": "string"
             }
           },
-          "title": "ReasoningThreadItem"
-        },
-        {
-          "type": "object",
           "required": [
-            "command",
-            "commandActions",
-            "cwd",
             "id",
-            "status",
             "type"
           ],
+          "title": "ReasoningThreadItem",
+          "type": "object"
+        },
+        {
           "properties": {
             "aggregatedOutput": {
               "description": "The command's output, aggregated from stdout and stderr.",
@@ -1388,34 +1306,34 @@
             },
             "commandActions": {
               "description": "A best-effort parsing of the command to understand the action(s) it will perform. This returns a list of CommandAction objects because a single shell command may be composed of many commands piped together.",
-              "type": "array",
               "items": {
                 "$ref": "#/definitions/CommandAction"
-              }
+              },
+              "type": "array"
             },
             "cwd": {
-              "description": "The command's working directory.",
               "allOf": [
                 {
                   "$ref": "#/definitions/AbsolutePathBuf"
                 }
-              ]
+              ],
+              "description": "The command's working directory."
             },
             "durationMs": {
               "description": "The duration of the command execution in milliseconds.",
+              "format": "int64",
               "type": [
                 "integer",
                 "null"
-              ],
-              "format": "int64"
+              ]
             },
             "exitCode": {
               "description": "The command's exit code.",
+              "format": "int32",
               "type": [
                 "integer",
                 "null"
-              ],
-              "format": "int32"
+              ]
             },
             "id": {
               "type": "string"
@@ -1428,40 +1346,42 @@
               ]
             },
             "source": {
-              "default": "agent",
               "allOf": [
                 {
                   "$ref": "#/definitions/CommandExecutionSource"
                 }
-              ]
+              ],
+              "default": "agent"
             },
             "status": {
               "$ref": "#/definitions/CommandExecutionStatus"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "commandExecution"
               ],
-              "title": "CommandExecutionThreadItemType"
+              "title": "CommandExecutionThreadItemType",
+              "type": "string"
             }
           },
-          "title": "CommandExecutionThreadItem"
-        },
-        {
-          "type": "object",
           "required": [
-            "changes",
+            "command",
+            "commandActions",
+            "cwd",
             "id",
             "status",
             "type"
           ],
+          "title": "CommandExecutionThreadItem",
+          "type": "object"
+        },
+        {
           "properties": {
             "changes": {
-              "type": "array",
               "items": {
                 "$ref": "#/definitions/FileUpdateChange"
-              }
+              },
+              "type": "array"
             },
             "id": {
               "type": "string"
@@ -1470,34 +1390,32 @@
               "$ref": "#/definitions/PatchApplyStatus"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "fileChange"
               ],
-              "title": "FileChangeThreadItemType"
+              "title": "FileChangeThreadItemType",
+              "type": "string"
             }
           },
-          "title": "FileChangeThreadItem"
-        },
-        {
-          "type": "object",
           "required": [
-            "arguments",
+            "changes",
             "id",
-            "server",
             "status",
-            "tool",
             "type"
           ],
+          "title": "FileChangeThreadItem",
+          "type": "object"
+        },
+        {
           "properties": {
             "arguments": true,
             "durationMs": {
               "description": "The duration of the MCP tool call in milliseconds.",
+              "format": "int64",
               "type": [
                 "integer",
                 "null"
-              ],
-              "format": "int64"
+              ]
             },
             "error": {
               "anyOf": [
@@ -1513,6 +1431,12 @@
               "type": "string"
             },
             "mcpAppResourceUri": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "pluginId": {
               "type": [
                 "string",
                 "null"
@@ -1538,42 +1462,43 @@
               "type": "string"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "mcpToolCall"
               ],
-              "title": "McpToolCallThreadItemType"
+              "title": "McpToolCallThreadItemType",
+              "type": "string"
             }
           },
-          "title": "McpToolCallThreadItem"
-        },
-        {
-          "type": "object",
           "required": [
             "arguments",
             "id",
+            "server",
             "status",
             "tool",
             "type"
           ],
+          "title": "McpToolCallThreadItem",
+          "type": "object"
+        },
+        {
           "properties": {
             "arguments": true,
             "contentItems": {
+              "items": {
+                "$ref": "#/definitions/DynamicToolCallOutputContentItem"
+              },
               "type": [
                 "array",
                 "null"
-              ],
-              "items": {
-                "$ref": "#/definitions/DynamicToolCallOutputContentItem"
-              }
+              ]
             },
             "durationMs": {
               "description": "The duration of the dynamic tool call in milliseconds.",
+              "format": "int64",
               "type": [
                 "integer",
                 "null"
-              ],
-              "format": "int64"
+              ]
             },
             "id": {
               "type": "string"
@@ -1597,33 +1522,31 @@
               "type": "string"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "dynamicToolCall"
               ],
-              "title": "DynamicToolCallThreadItemType"
+              "title": "DynamicToolCallThreadItemType",
+              "type": "string"
             }
           },
-          "title": "DynamicToolCallThreadItem"
-        },
-        {
-          "type": "object",
           "required": [
-            "agentsStates",
+            "arguments",
             "id",
-            "receiverThreadIds",
-            "senderThreadId",
             "status",
             "tool",
             "type"
           ],
+          "title": "DynamicToolCallThreadItem",
+          "type": "object"
+        },
+        {
           "properties": {
             "agentsStates": {
-              "description": "Last known status of the target agents, when available.",
-              "type": "object",
               "additionalProperties": {
                 "$ref": "#/definitions/CollabAgentState"
-              }
+              },
+              "description": "Last known status of the target agents, when available.",
+              "type": "object"
             },
             "id": {
               "description": "Unique identifier for this collab tool call.",
@@ -1644,7 +1567,6 @@
               ]
             },
             "reasoningEffort": {
-              "description": "Reasoning effort requested for the spawned agent, when applicable.",
               "anyOf": [
                 {
                   "$ref": "#/definitions/ReasoningEffort"
@@ -1652,52 +1574,57 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Reasoning effort requested for the spawned agent, when applicable."
             },
             "receiverThreadIds": {
               "description": "Thread ID of the receiving agent, when applicable. In case of spawn operation, this corresponds to the newly spawned agent.",
-              "type": "array",
               "items": {
                 "type": "string"
-              }
+              },
+              "type": "array"
             },
             "senderThreadId": {
               "description": "Thread ID of the agent issuing the collab request.",
               "type": "string"
             },
             "status": {
-              "description": "Current status of the collab tool call.",
               "allOf": [
                 {
                   "$ref": "#/definitions/CollabAgentToolCallStatus"
                 }
-              ]
+              ],
+              "description": "Current status of the collab tool call."
             },
             "tool": {
-              "description": "Name of the collab tool that was invoked.",
               "allOf": [
                 {
                   "$ref": "#/definitions/CollabAgentTool"
                 }
-              ]
+              ],
+              "description": "Name of the collab tool that was invoked."
             },
             "type": {
-              "type": "string",
               "enum": [
                 "collabAgentToolCall"
               ],
-              "title": "CollabAgentToolCallThreadItemType"
+              "title": "CollabAgentToolCallThreadItemType",
+              "type": "string"
             }
           },
-          "title": "CollabAgentToolCallThreadItem"
-        },
-        {
-          "type": "object",
           "required": [
+            "agentsStates",
             "id",
-            "query",
+            "receiverThreadIds",
+            "senderThreadId",
+            "status",
+            "tool",
             "type"
           ],
+          "title": "CollabAgentToolCallThreadItem",
+          "type": "object"
+        },
+        {
           "properties": {
             "action": {
               "anyOf": [
@@ -1716,22 +1643,22 @@
               "type": "string"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "webSearch"
               ],
-              "title": "WebSearchThreadItemType"
+              "title": "WebSearchThreadItemType",
+              "type": "string"
             }
           },
-          "title": "WebSearchThreadItem"
-        },
-        {
-          "type": "object",
           "required": [
             "id",
-            "path",
+            "query",
             "type"
           ],
+          "title": "WebSearchThreadItem",
+          "type": "object"
+        },
+        {
           "properties": {
             "id": {
               "type": "string"
@@ -1740,23 +1667,22 @@
               "$ref": "#/definitions/AbsolutePathBuf"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "imageView"
               ],
-              "title": "ImageViewThreadItemType"
+              "title": "ImageViewThreadItemType",
+              "type": "string"
             }
           },
-          "title": "ImageViewThreadItem"
-        },
-        {
-          "type": "object",
           "required": [
             "id",
-            "result",
-            "status",
+            "path",
             "type"
           ],
+          "title": "ImageViewThreadItem",
+          "type": "object"
+        },
+        {
           "properties": {
             "id": {
               "type": "string"
@@ -1784,22 +1710,23 @@
               "type": "string"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "imageGeneration"
               ],
-              "title": "ImageGenerationThreadItemType"
+              "title": "ImageGenerationThreadItemType",
+              "type": "string"
             }
           },
-          "title": "ImageGenerationThreadItem"
-        },
-        {
-          "type": "object",
           "required": [
             "id",
-            "review",
+            "result",
+            "status",
             "type"
           ],
+          "title": "ImageGenerationThreadItem",
+          "type": "object"
+        },
+        {
           "properties": {
             "id": {
               "type": "string"
@@ -1808,22 +1735,22 @@
               "type": "string"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "enteredReviewMode"
               ],
-              "title": "EnteredReviewModeThreadItemType"
+              "title": "EnteredReviewModeThreadItemType",
+              "type": "string"
             }
           },
-          "title": "EnteredReviewModeThreadItem"
-        },
-        {
-          "type": "object",
           "required": [
             "id",
             "review",
             "type"
           ],
+          "title": "EnteredReviewModeThreadItem",
+          "type": "object"
+        },
+        {
           "properties": {
             "id": {
               "type": "string"
@@ -1832,146 +1759,145 @@
               "type": "string"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "exitedReviewMode"
               ],
-              "title": "ExitedReviewModeThreadItemType"
+              "title": "ExitedReviewModeThreadItemType",
+              "type": "string"
             }
           },
-          "title": "ExitedReviewModeThreadItem"
-        },
-        {
-          "type": "object",
           "required": [
             "id",
+            "review",
             "type"
           ],
+          "title": "ExitedReviewModeThreadItem",
+          "type": "object"
+        },
+        {
           "properties": {
             "id": {
               "type": "string"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "contextCompaction"
               ],
-              "title": "ContextCompactionThreadItemType"
+              "title": "ContextCompactionThreadItemType",
+              "type": "string"
             }
           },
-          "title": "ContextCompactionThreadItem"
+          "required": [
+            "id",
+            "type"
+          ],
+          "title": "ContextCompactionThreadItem",
+          "type": "object"
         }
       ]
     },
     "ThreadSource": {
-      "type": "string",
       "enum": [
         "user",
         "subagent",
         "memory_consolidation"
-      ]
+      ],
+      "type": "string"
     },
     "ThreadStatus": {
       "oneOf": [
         {
-          "type": "object",
-          "required": [
-            "type"
-          ],
           "properties": {
             "type": {
-              "type": "string",
               "enum": [
                 "notLoaded"
               ],
-              "title": "NotLoadedThreadStatusType"
+              "title": "NotLoadedThreadStatusType",
+              "type": "string"
             }
           },
-          "title": "NotLoadedThreadStatus"
-        },
-        {
-          "type": "object",
           "required": [
             "type"
           ],
+          "title": "NotLoadedThreadStatus",
+          "type": "object"
+        },
+        {
           "properties": {
             "type": {
-              "type": "string",
               "enum": [
                 "idle"
               ],
-              "title": "IdleThreadStatusType"
+              "title": "IdleThreadStatusType",
+              "type": "string"
             }
           },
-          "title": "IdleThreadStatus"
-        },
-        {
-          "type": "object",
           "required": [
             "type"
           ],
+          "title": "IdleThreadStatus",
+          "type": "object"
+        },
+        {
           "properties": {
             "type": {
-              "type": "string",
               "enum": [
                 "systemError"
               ],
-              "title": "SystemErrorThreadStatusType"
+              "title": "SystemErrorThreadStatusType",
+              "type": "string"
             }
           },
-          "title": "SystemErrorThreadStatus"
+          "required": [
+            "type"
+          ],
+          "title": "SystemErrorThreadStatus",
+          "type": "object"
         },
         {
-          "type": "object",
+          "properties": {
+            "activeFlags": {
+              "items": {
+                "$ref": "#/definitions/ThreadActiveFlag"
+              },
+              "type": "array"
+            },
+            "type": {
+              "enum": [
+                "active"
+              ],
+              "title": "ActiveThreadStatusType",
+              "type": "string"
+            }
+          },
           "required": [
             "activeFlags",
             "type"
           ],
-          "properties": {
-            "activeFlags": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/ThreadActiveFlag"
-              }
-            },
-            "type": {
-              "type": "string",
-              "enum": [
-                "active"
-              ],
-              "title": "ActiveThreadStatusType"
-            }
-          },
-          "title": "ActiveThreadStatus"
+          "title": "ActiveThreadStatus",
+          "type": "object"
         }
       ]
     },
     "Turn": {
-      "type": "object",
-      "required": [
-        "id",
-        "items",
-        "status"
-      ],
       "properties": {
         "completedAt": {
           "description": "Unix timestamp (in seconds) when the turn completed.",
+          "format": "int64",
           "type": [
             "integer",
             "null"
-          ],
-          "format": "int64"
+          ]
         },
         "durationMs": {
           "description": "Duration between turn start and completion in milliseconds, if known.",
+          "format": "int64",
           "type": [
             "integer",
             "null"
-          ],
-          "format": "int64"
+          ]
         },
         "error": {
-          "description": "Only populated when the Turn's status is failed.",
           "anyOf": [
             {
               "$ref": "#/definitions/TurnError"
@@ -1979,45 +1905,48 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Only populated when the Turn's status is failed."
         },
         "id": {
           "type": "string"
         },
         "items": {
           "description": "Thread items currently included in this turn payload.",
-          "type": "array",
           "items": {
             "$ref": "#/definitions/ThreadItem"
-          }
+          },
+          "type": "array"
         },
         "itemsView": {
-          "description": "Describes how much of `items` has been loaded for this turn.",
-          "default": "full",
           "allOf": [
             {
               "$ref": "#/definitions/TurnItemsView"
             }
-          ]
+          ],
+          "default": "full",
+          "description": "Describes how much of `items` has been loaded for this turn."
         },
         "startedAt": {
           "description": "Unix timestamp (in seconds) when the turn started.",
+          "format": "int64",
           "type": [
             "integer",
             "null"
-          ],
-          "format": "int64"
+          ]
         },
         "status": {
           "$ref": "#/definitions/TurnStatus"
         }
-      }
+      },
+      "required": [
+        "id",
+        "items",
+        "status"
+      ],
+      "type": "object"
     },
     "TurnError": {
-      "type": "object",
-      "required": [
-        "message"
-      ],
       "properties": {
         "additionalDetails": {
           "default": null,
@@ -2039,81 +1968,79 @@
         "message": {
           "type": "string"
         }
-      }
+      },
+      "required": [
+        "message"
+      ],
+      "type": "object"
     },
     "TurnItemsView": {
       "oneOf": [
         {
           "description": "`items` was not loaded for this turn. The field is intentionally empty.",
-          "type": "string",
           "enum": [
             "notLoaded"
-          ]
+          ],
+          "type": "string"
         },
         {
           "description": "`items` contains only a display summary for this turn.",
-          "type": "string",
           "enum": [
             "summary"
-          ]
+          ],
+          "type": "string"
         },
         {
           "description": "`items` contains every ThreadItem available from persisted app-server history for this turn.",
-          "type": "string",
           "enum": [
             "full"
-          ]
+          ],
+          "type": "string"
         }
       ]
     },
     "TurnStatus": {
-      "type": "string",
       "enum": [
         "completed",
         "interrupted",
         "failed",
         "inProgress"
-      ]
+      ],
+      "type": "string"
     },
     "UserInput": {
       "oneOf": [
         {
-          "type": "object",
-          "required": [
-            "text",
-            "type"
-          ],
           "properties": {
             "text": {
               "type": "string"
             },
             "text_elements": {
-              "description": "UI-defined spans within `text` used to render or persist special elements.",
               "default": [],
-              "type": "array",
+              "description": "UI-defined spans within `text` used to render or persist special elements.",
               "items": {
                 "$ref": "#/definitions/TextElement"
-              }
+              },
+              "type": "array"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "text"
               ],
-              "title": "TextUserInputType"
+              "title": "TextUserInputType",
+              "type": "string"
             }
           },
-          "title": "TextUserInput"
+          "required": [
+            "text",
+            "type"
+          ],
+          "title": "TextUserInput",
+          "type": "object"
         },
         {
-          "type": "object",
-          "required": [
-            "type",
-            "url"
-          ],
           "properties": {
             "detail": {
-              "default": null,
               "anyOf": [
                 {
                   "$ref": "#/definitions/ImageDetail"
@@ -2121,30 +2048,30 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "default": null
             },
             "type": {
-              "type": "string",
               "enum": [
                 "image"
               ],
-              "title": "ImageUserInputType"
+              "title": "ImageUserInputType",
+              "type": "string"
             },
             "url": {
               "type": "string"
             }
           },
-          "title": "ImageUserInput"
+          "required": [
+            "type",
+            "url"
+          ],
+          "title": "ImageUserInput",
+          "type": "object"
         },
         {
-          "type": "object",
-          "required": [
-            "path",
-            "type"
-          ],
           "properties": {
             "detail": {
-              "default": null,
               "anyOf": [
                 {
                   "$ref": "#/definitions/ImageDetail"
@@ -2152,28 +2079,28 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "default": null
             },
             "path": {
               "type": "string"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "localImage"
               ],
-              "title": "LocalImageUserInputType"
+              "title": "LocalImageUserInputType",
+              "type": "string"
             }
           },
-          "title": "LocalImageUserInput"
-        },
-        {
-          "type": "object",
           "required": [
-            "name",
             "path",
             "type"
           ],
+          "title": "LocalImageUserInput",
+          "type": "object"
+        },
+        {
           "properties": {
             "name": {
               "type": "string"
@@ -2182,22 +2109,22 @@
               "type": "string"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "skill"
               ],
-              "title": "SkillUserInputType"
+              "title": "SkillUserInputType",
+              "type": "string"
             }
           },
-          "title": "SkillUserInput"
-        },
-        {
-          "type": "object",
           "required": [
             "name",
             "path",
             "type"
           ],
+          "title": "SkillUserInput",
+          "type": "object"
+        },
+        {
           "properties": {
             "name": {
               "type": "string"
@@ -2206,33 +2133,35 @@
               "type": "string"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "mention"
               ],
-              "title": "MentionUserInputType"
+              "title": "MentionUserInputType",
+              "type": "string"
             }
           },
-          "title": "MentionUserInput"
+          "required": [
+            "name",
+            "path",
+            "type"
+          ],
+          "title": "MentionUserInput",
+          "type": "object"
         }
       ]
     },
     "WebSearchAction": {
       "oneOf": [
         {
-          "type": "object",
-          "required": [
-            "type"
-          ],
           "properties": {
             "queries": {
+              "items": {
+                "type": "string"
+              },
               "type": [
                 "array",
                 "null"
-              ],
-              "items": {
-                "type": "string"
-              }
+              ]
             },
             "query": {
               "type": [
@@ -2241,27 +2170,27 @@
               ]
             },
             "type": {
-              "type": "string",
               "enum": [
                 "search"
               ],
-              "title": "SearchWebSearchActionType"
+              "title": "SearchWebSearchActionType",
+              "type": "string"
             }
           },
-          "title": "SearchWebSearchAction"
-        },
-        {
-          "type": "object",
           "required": [
             "type"
           ],
+          "title": "SearchWebSearchAction",
+          "type": "object"
+        },
+        {
           "properties": {
             "type": {
-              "type": "string",
               "enum": [
                 "openPage"
               ],
-              "title": "OpenPageWebSearchActionType"
+              "title": "OpenPageWebSearchActionType",
+              "type": "string"
             },
             "url": {
               "type": [
@@ -2270,13 +2199,13 @@
               ]
             }
           },
-          "title": "OpenPageWebSearchAction"
-        },
-        {
-          "type": "object",
           "required": [
             "type"
           ],
+          "title": "OpenPageWebSearchAction",
+          "type": "object"
+        },
+        {
           "properties": {
             "pattern": {
               "type": [
@@ -2285,11 +2214,11 @@
               ]
             },
             "type": {
-              "type": "string",
               "enum": [
                 "findInPage"
               ],
-              "title": "FindInPageWebSearchActionType"
+              "title": "FindInPageWebSearchActionType",
+              "type": "string"
             },
             "url": {
               "type": [
@@ -2298,25 +2227,117 @@
               ]
             }
           },
-          "title": "FindInPageWebSearchAction"
-        },
-        {
-          "type": "object",
           "required": [
             "type"
           ],
+          "title": "FindInPageWebSearchAction",
+          "type": "object"
+        },
+        {
           "properties": {
             "type": {
-              "type": "string",
               "enum": [
                 "other"
               ],
-              "title": "OtherWebSearchActionType"
+              "title": "OtherWebSearchActionType",
+              "type": "string"
             }
           },
-          "title": "OtherWebSearchAction"
+          "required": [
+            "type"
+          ],
+          "title": "OtherWebSearchAction",
+          "type": "object"
         }
       ]
     }
-  }
+  },
+  "properties": {
+    "activePermissionProfile": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/ActivePermissionProfile"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Named or implicit built-in profile that produced the active permissions, when known."
+    },
+    "approvalPolicy": {
+      "$ref": "#/definitions/AskForApproval"
+    },
+    "approvalsReviewer": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/ApprovalsReviewer"
+        }
+      ],
+      "description": "Reviewer currently used for approval requests on this thread."
+    },
+    "cwd": {
+      "$ref": "#/definitions/AbsolutePathBuf"
+    },
+    "instructionSources": {
+      "default": [],
+      "description": "Instruction source files currently loaded for this thread.",
+      "items": {
+        "$ref": "#/definitions/AbsolutePathBuf"
+      },
+      "type": "array"
+    },
+    "model": {
+      "type": "string"
+    },
+    "modelProvider": {
+      "type": "string"
+    },
+    "reasoningEffort": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/ReasoningEffort"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "runtimeWorkspaceRoots": {
+      "default": [],
+      "description": "Thread-scoped runtime workspace roots used to materialize `:workspace_roots`.",
+      "items": {
+        "$ref": "#/definitions/AbsolutePathBuf"
+      },
+      "type": "array"
+    },
+    "sandbox": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/SandboxPolicy"
+        }
+      ],
+      "description": "Legacy sandbox policy retained for compatibility. Experimental clients should prefer `activePermissionProfile` for profile provenance."
+    },
+    "serviceTier": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "thread": {
+      "$ref": "#/definitions/Thread"
+    }
+  },
+  "required": [
+    "approvalPolicy",
+    "approvalsReviewer",
+    "cwd",
+    "model",
+    "modelProvider",
+    "sandbox",
+    "thread"
+  ],
+  "title": "ThreadStartResponse",
+  "type": "object"
 }

--- a/extensions/codex/src/app-server/protocol-generated/json/v2/TurnCompletedNotification.json
+++ b/extensions/codex/src/app-server/protocol-generated/json/v2/TurnCompletedNotification.json
@@ -1,48 +1,33 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "TurnCompletedNotification",
-  "type": "object",
-  "required": [
-    "threadId",
-    "turn"
-  ],
-  "properties": {
-    "threadId": {
-      "type": "string"
-    },
-    "turn": {
-      "$ref": "#/definitions/Turn"
-    }
-  },
   "definitions": {
     "AbsolutePathBuf": {
       "description": "A path that is guaranteed to be absolute and normalized (though it is not guaranteed to be canonicalized or exist on the filesystem).\n\nIMPORTANT: When deserializing an `AbsolutePathBuf`, a base path must be set using [AbsolutePathBufGuard::new]. If no base path is set, the deserialization will fail unless the path being deserialized is already absolute.",
       "type": "string"
     },
     "ByteRange": {
-      "type": "object",
+      "properties": {
+        "end": {
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "start": {
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
       "required": [
         "end",
         "start"
       ],
-      "properties": {
-        "end": {
-          "type": "integer",
-          "format": "uint",
-          "minimum": 0
-        },
-        "start": {
-          "type": "integer",
-          "format": "uint",
-          "minimum": 0
-        }
-      }
+      "type": "object"
     },
     "CodexErrorInfo": {
       "description": "This translation layer make sure that we expose codex error code in camel case.\n\nWhen an upstream HTTP status is available (for example, from the Responses API or a provider), it is forwarded in `httpStatusCode` on the relevant `codexErrorInfo` variant.",
       "oneOf": [
         {
-          "type": "string",
           "enum": [
             "contextWindowExceeded",
             "usageLimitExceeded",
@@ -54,132 +39,129 @@
             "threadRollbackFailed",
             "sandboxError",
             "other"
-          ]
+          ],
+          "type": "string"
         },
         {
-          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "httpConnectionFailed": {
+              "properties": {
+                "httpStatusCode": {
+                  "format": "uint16",
+                  "minimum": 0,
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                }
+              },
+              "type": "object"
+            }
+          },
           "required": [
             "httpConnectionFailed"
           ],
+          "title": "HttpConnectionFailedCodexErrorInfo",
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "description": "Failed to connect to the response SSE stream.",
           "properties": {
-            "httpConnectionFailed": {
-              "type": "object",
+            "responseStreamConnectionFailed": {
               "properties": {
                 "httpStatusCode": {
+                  "format": "uint16",
+                  "minimum": 0,
                   "type": [
                     "integer",
                     "null"
-                  ],
-                  "format": "uint16",
-                  "minimum": 0
+                  ]
                 }
-              }
+              },
+              "type": "object"
             }
           },
-          "additionalProperties": false,
-          "title": "HttpConnectionFailedCodexErrorInfo"
-        },
-        {
-          "description": "Failed to connect to the response SSE stream.",
-          "type": "object",
           "required": [
             "responseStreamConnectionFailed"
           ],
+          "title": "ResponseStreamConnectionFailedCodexErrorInfo",
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "description": "The response SSE stream disconnected in the middle of a turn before completion.",
           "properties": {
-            "responseStreamConnectionFailed": {
-              "type": "object",
+            "responseStreamDisconnected": {
               "properties": {
                 "httpStatusCode": {
+                  "format": "uint16",
+                  "minimum": 0,
                   "type": [
                     "integer",
                     "null"
-                  ],
-                  "format": "uint16",
-                  "minimum": 0
+                  ]
                 }
-              }
+              },
+              "type": "object"
             }
           },
-          "additionalProperties": false,
-          "title": "ResponseStreamConnectionFailedCodexErrorInfo"
-        },
-        {
-          "description": "The response SSE stream disconnected in the middle of a turn before completion.",
-          "type": "object",
           "required": [
             "responseStreamDisconnected"
           ],
+          "title": "ResponseStreamDisconnectedCodexErrorInfo",
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "description": "Reached the retry limit for responses.",
           "properties": {
-            "responseStreamDisconnected": {
-              "type": "object",
+            "responseTooManyFailedAttempts": {
               "properties": {
                 "httpStatusCode": {
+                  "format": "uint16",
+                  "minimum": 0,
                   "type": [
                     "integer",
                     "null"
-                  ],
-                  "format": "uint16",
-                  "minimum": 0
+                  ]
                 }
-              }
+              },
+              "type": "object"
             }
           },
-          "additionalProperties": false,
-          "title": "ResponseStreamDisconnectedCodexErrorInfo"
-        },
-        {
-          "description": "Reached the retry limit for responses.",
-          "type": "object",
           "required": [
             "responseTooManyFailedAttempts"
           ],
-          "properties": {
-            "responseTooManyFailedAttempts": {
-              "type": "object",
-              "properties": {
-                "httpStatusCode": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ],
-                  "format": "uint16",
-                  "minimum": 0
-                }
-              }
-            }
-          },
-          "additionalProperties": false,
-          "title": "ResponseTooManyFailedAttemptsCodexErrorInfo"
+          "title": "ResponseTooManyFailedAttemptsCodexErrorInfo",
+          "type": "object"
         },
         {
+          "additionalProperties": false,
           "description": "Returned when `turn/start` or `turn/steer` is submitted while the current active turn cannot accept same-turn steering, for example `/review` or manual `/compact`.",
-          "type": "object",
-          "required": [
-            "activeTurnNotSteerable"
-          ],
           "properties": {
             "activeTurnNotSteerable": {
-              "type": "object",
-              "required": [
-                "turnKind"
-              ],
               "properties": {
                 "turnKind": {
                   "$ref": "#/definitions/NonSteerableTurnKind"
                 }
-              }
+              },
+              "required": [
+                "turnKind"
+              ],
+              "type": "object"
             }
           },
-          "additionalProperties": false,
-          "title": "ActiveTurnNotSteerableCodexErrorInfo"
+          "required": [
+            "activeTurnNotSteerable"
+          ],
+          "title": "ActiveTurnNotSteerableCodexErrorInfo",
+          "type": "object"
         }
       ]
     },
     "CollabAgentState": {
-      "type": "object",
-      "required": [
-        "status"
-      ],
       "properties": {
         "message": {
           "type": [
@@ -190,10 +172,13 @@
         "status": {
           "$ref": "#/definitions/CollabAgentStatus"
         }
-      }
+      },
+      "required": [
+        "status"
+      ],
+      "type": "object"
     },
     "CollabAgentStatus": {
-      "type": "string",
       "enum": [
         "pendingInit",
         "running",
@@ -202,36 +187,30 @@
         "errored",
         "shutdown",
         "notFound"
-      ]
+      ],
+      "type": "string"
     },
     "CollabAgentTool": {
-      "type": "string",
       "enum": [
         "spawnAgent",
         "sendInput",
         "resumeAgent",
         "wait",
         "closeAgent"
-      ]
+      ],
+      "type": "string"
     },
     "CollabAgentToolCallStatus": {
-      "type": "string",
       "enum": [
         "inProgress",
         "completed",
         "failed"
-      ]
+      ],
+      "type": "string"
     },
     "CommandAction": {
       "oneOf": [
         {
-          "type": "object",
-          "required": [
-            "command",
-            "name",
-            "path",
-            "type"
-          ],
           "properties": {
             "command": {
               "type": "string"
@@ -243,21 +222,23 @@
               "$ref": "#/definitions/AbsolutePathBuf"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "read"
               ],
-              "title": "ReadCommandActionType"
+              "title": "ReadCommandActionType",
+              "type": "string"
             }
           },
-          "title": "ReadCommandAction"
-        },
-        {
-          "type": "object",
           "required": [
             "command",
+            "name",
+            "path",
             "type"
           ],
+          "title": "ReadCommandAction",
+          "type": "object"
+        },
+        {
           "properties": {
             "command": {
               "type": "string"
@@ -269,21 +250,21 @@
               ]
             },
             "type": {
-              "type": "string",
               "enum": [
                 "listFiles"
               ],
-              "title": "ListFilesCommandActionType"
+              "title": "ListFilesCommandActionType",
+              "type": "string"
             }
           },
-          "title": "ListFilesCommandAction"
-        },
-        {
-          "type": "object",
           "required": [
             "command",
             "type"
           ],
+          "title": "ListFilesCommandAction",
+          "type": "object"
+        },
+        {
           "properties": {
             "command": {
               "type": "string"
@@ -301,114 +282,113 @@
               ]
             },
             "type": {
-              "type": "string",
               "enum": [
                 "search"
               ],
-              "title": "SearchCommandActionType"
+              "title": "SearchCommandActionType",
+              "type": "string"
             }
           },
-          "title": "SearchCommandAction"
-        },
-        {
-          "type": "object",
           "required": [
             "command",
             "type"
           ],
+          "title": "SearchCommandAction",
+          "type": "object"
+        },
+        {
           "properties": {
             "command": {
               "type": "string"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "unknown"
               ],
-              "title": "UnknownCommandActionType"
+              "title": "UnknownCommandActionType",
+              "type": "string"
             }
           },
-          "title": "UnknownCommandAction"
+          "required": [
+            "command",
+            "type"
+          ],
+          "title": "UnknownCommandAction",
+          "type": "object"
         }
       ]
     },
     "CommandExecutionSource": {
-      "type": "string",
       "enum": [
         "agent",
         "userShell",
         "unifiedExecStartup",
         "unifiedExecInteraction"
-      ]
+      ],
+      "type": "string"
     },
     "CommandExecutionStatus": {
-      "type": "string",
       "enum": [
         "inProgress",
         "completed",
         "failed",
         "declined"
-      ]
+      ],
+      "type": "string"
     },
     "DynamicToolCallOutputContentItem": {
       "oneOf": [
         {
-          "type": "object",
-          "required": [
-            "text",
-            "type"
-          ],
           "properties": {
             "text": {
               "type": "string"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "inputText"
               ],
-              "title": "InputTextDynamicToolCallOutputContentItemType"
+              "title": "InputTextDynamicToolCallOutputContentItemType",
+              "type": "string"
             }
           },
-          "title": "InputTextDynamicToolCallOutputContentItem"
-        },
-        {
-          "type": "object",
           "required": [
-            "imageUrl",
+            "text",
             "type"
           ],
+          "title": "InputTextDynamicToolCallOutputContentItem",
+          "type": "object"
+        },
+        {
           "properties": {
             "imageUrl": {
               "type": "string"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "inputImage"
               ],
-              "title": "InputImageDynamicToolCallOutputContentItemType"
+              "title": "InputImageDynamicToolCallOutputContentItemType",
+              "type": "string"
             }
           },
-          "title": "InputImageDynamicToolCallOutputContentItem"
+          "required": [
+            "imageUrl",
+            "type"
+          ],
+          "title": "InputImageDynamicToolCallOutputContentItem",
+          "type": "object"
         }
       ]
     },
     "DynamicToolCallStatus": {
-      "type": "string",
       "enum": [
         "inProgress",
         "completed",
         "failed"
-      ]
+      ],
+      "type": "string"
     },
     "FileUpdateChange": {
-      "type": "object",
-      "required": [
-        "diff",
-        "kind",
-        "path"
-      ],
       "properties": {
         "diff": {
           "type": "string"
@@ -419,14 +399,15 @@
         "path": {
           "type": "string"
         }
-      }
+      },
+      "required": [
+        "diff",
+        "kind",
+        "path"
+      ],
+      "type": "object"
     },
     "HookPromptFragment": {
-      "type": "object",
-      "required": [
-        "hookRunId",
-        "text"
-      ],
       "properties": {
         "hookRunId": {
           "type": "string"
@@ -434,87 +415,87 @@
         "text": {
           "type": "string"
         }
-      }
+      },
+      "required": [
+        "hookRunId",
+        "text"
+      ],
+      "type": "object"
     },
     "ImageDetail": {
-      "type": "string",
       "enum": [
+        "auto",
+        "low",
         "high",
         "original"
-      ]
+      ],
+      "type": "string"
     },
     "McpToolCallError": {
-      "type": "object",
-      "required": [
-        "message"
-      ],
       "properties": {
         "message": {
           "type": "string"
         }
-      }
+      },
+      "required": [
+        "message"
+      ],
+      "type": "object"
     },
     "McpToolCallResult": {
-      "type": "object",
-      "required": [
-        "content"
-      ],
       "properties": {
         "_meta": true,
         "content": {
-          "type": "array",
-          "items": true
+          "items": true,
+          "type": "array"
         },
         "structuredContent": true
-      }
+      },
+      "required": [
+        "content"
+      ],
+      "type": "object"
     },
     "McpToolCallStatus": {
-      "type": "string",
       "enum": [
         "inProgress",
         "completed",
         "failed"
-      ]
+      ],
+      "type": "string"
     },
     "MemoryCitation": {
-      "type": "object",
+      "properties": {
+        "entries": {
+          "items": {
+            "$ref": "#/definitions/MemoryCitationEntry"
+          },
+          "type": "array"
+        },
+        "threadIds": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
       "required": [
         "entries",
         "threadIds"
       ],
-      "properties": {
-        "entries": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/MemoryCitationEntry"
-          }
-        },
-        "threadIds": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
+      "type": "object"
     },
     "MemoryCitationEntry": {
-      "type": "object",
-      "required": [
-        "lineEnd",
-        "lineStart",
-        "note",
-        "path"
-      ],
       "properties": {
         "lineEnd": {
-          "type": "integer",
           "format": "uint32",
-          "minimum": 0
+          "minimum": 0,
+          "type": "integer"
         },
         "lineStart": {
-          "type": "integer",
           "format": "uint32",
-          "minimum": 0
+          "minimum": 0,
+          "type": "integer"
         },
         "note": {
           "type": "string"
@@ -522,82 +503,85 @@
         "path": {
           "type": "string"
         }
-      }
+      },
+      "required": [
+        "lineEnd",
+        "lineStart",
+        "note",
+        "path"
+      ],
+      "type": "object"
     },
     "MessagePhase": {
       "description": "Classifies an assistant message as interim commentary or final answer text.\n\nProviders do not emit this consistently, so callers must treat `None` as \"phase unknown\" and keep compatibility behavior for legacy models.",
       "oneOf": [
         {
           "description": "Mid-turn assistant text (for example preamble/progress narration).\n\nAdditional tool calls or assistant output may follow before turn completion.",
-          "type": "string",
           "enum": [
             "commentary"
-          ]
+          ],
+          "type": "string"
         },
         {
           "description": "The assistant's terminal answer text for the current turn.",
-          "type": "string",
           "enum": [
             "final_answer"
-          ]
+          ],
+          "type": "string"
         }
       ]
     },
     "NonSteerableTurnKind": {
-      "type": "string",
       "enum": [
         "review",
         "compact"
-      ]
+      ],
+      "type": "string"
     },
     "PatchApplyStatus": {
-      "type": "string",
       "enum": [
         "inProgress",
         "completed",
         "failed",
         "declined"
-      ]
+      ],
+      "type": "string"
     },
     "PatchChangeKind": {
       "oneOf": [
         {
-          "type": "object",
-          "required": [
-            "type"
-          ],
           "properties": {
             "type": {
-              "type": "string",
               "enum": [
                 "add"
               ],
-              "title": "AddPatchChangeKindType"
+              "title": "AddPatchChangeKindType",
+              "type": "string"
             }
           },
-          "title": "AddPatchChangeKind"
-        },
-        {
-          "type": "object",
           "required": [
             "type"
           ],
+          "title": "AddPatchChangeKind",
+          "type": "object"
+        },
+        {
           "properties": {
             "type": {
-              "type": "string",
               "enum": [
                 "delete"
               ],
-              "title": "DeletePatchChangeKindType"
+              "title": "DeletePatchChangeKindType",
+              "type": "string"
             }
           },
-          "title": "DeletePatchChangeKind"
-        },
-        {
-          "type": "object",
           "required": [
             "type"
           ],
+          "title": "DeletePatchChangeKind",
+          "type": "object"
+        },
+        {
           "properties": {
             "move_path": {
               "type": [
@@ -606,20 +590,23 @@
               ]
             },
             "type": {
-              "type": "string",
               "enum": [
                 "update"
               ],
-              "title": "UpdatePatchChangeKindType"
+              "title": "UpdatePatchChangeKindType",
+              "type": "string"
             }
           },
-          "title": "UpdatePatchChangeKind"
+          "required": [
+            "type"
+          ],
+          "title": "UpdatePatchChangeKind",
+          "type": "object"
         }
       ]
     },
     "ReasoningEffort": {
       "description": "See https://platform.openai.com/docs/guides/reasoning?api-mode=responses#get-started-with-reasoning",
-      "type": "string",
       "enum": [
         "none",
         "minimal",
@@ -627,21 +614,18 @@
         "medium",
         "high",
         "xhigh"
-      ]
+      ],
+      "type": "string"
     },
     "TextElement": {
-      "type": "object",
-      "required": [
-        "byteRange"
-      ],
       "properties": {
         "byteRange": {
-          "description": "Byte range in the parent `text` buffer that this element occupies.",
           "allOf": [
             {
               "$ref": "#/definitions/ByteRange"
             }
-          ]
+          ],
+          "description": "Byte range in the parent `text` buffer that this element occupies."
         },
         "placeholder": {
           "description": "Optional human-readable placeholder for the element, displayed in the UI.",
@@ -650,77 +634,80 @@
             "null"
           ]
         }
-      }
+      },
+      "required": [
+        "byteRange"
+      ],
+      "type": "object"
     },
     "ThreadItem": {
       "oneOf": [
         {
-          "type": "object",
+          "properties": {
+            "clientId": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "content": {
+              "items": {
+                "$ref": "#/definitions/UserInput"
+              },
+              "type": "array"
+            },
+            "id": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "userMessage"
+              ],
+              "title": "UserMessageThreadItemType",
+              "type": "string"
+            }
+          },
           "required": [
             "content",
             "id",
             "type"
           ],
+          "title": "UserMessageThreadItem",
+          "type": "object"
+        },
+        {
           "properties": {
-            "content": {
-              "type": "array",
+            "fragments": {
               "items": {
-                "$ref": "#/definitions/UserInput"
-              }
+                "$ref": "#/definitions/HookPromptFragment"
+              },
+              "type": "array"
             },
             "id": {
               "type": "string"
             },
             "type": {
-              "type": "string",
               "enum": [
-                "userMessage"
+                "hookPrompt"
               ],
-              "title": "UserMessageThreadItemType"
+              "title": "HookPromptThreadItemType",
+              "type": "string"
             }
           },
-          "title": "UserMessageThreadItem"
-        },
-        {
-          "type": "object",
           "required": [
             "fragments",
             "id",
             "type"
           ],
-          "properties": {
-            "fragments": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/HookPromptFragment"
-              }
-            },
-            "id": {
-              "type": "string"
-            },
-            "type": {
-              "type": "string",
-              "enum": [
-                "hookPrompt"
-              ],
-              "title": "HookPromptThreadItemType"
-            }
-          },
-          "title": "HookPromptThreadItem"
+          "title": "HookPromptThreadItem",
+          "type": "object"
         },
         {
-          "type": "object",
-          "required": [
-            "id",
-            "text",
-            "type"
-          ],
           "properties": {
             "id": {
               "type": "string"
             },
             "memoryCitation": {
-              "default": null,
               "anyOf": [
                 {
                   "$ref": "#/definitions/MemoryCitation"
@@ -728,10 +715,10 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "default": null
             },
             "phase": {
-              "default": null,
               "anyOf": [
                 {
                   "$ref": "#/definitions/MessagePhase"
@@ -739,29 +726,30 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "default": null
             },
             "text": {
               "type": "string"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "agentMessage"
               ],
-              "title": "AgentMessageThreadItemType"
+              "title": "AgentMessageThreadItemType",
+              "type": "string"
             }
           },
-          "title": "AgentMessageThreadItem"
-        },
-        {
-          "description": "EXPERIMENTAL - proposed plan item content. The completed plan item is authoritative and may not match the concatenation of `PlanDelta` text.",
-          "type": "object",
           "required": [
             "id",
             "text",
             "type"
           ],
+          "title": "AgentMessageThreadItem",
+          "type": "object"
+        },
+        {
+          "description": "EXPERIMENTAL - proposed plan item content. The completed plan item is authoritative and may not match the concatenation of `PlanDelta` text.",
           "properties": {
             "id": {
               "type": "string"
@@ -770,59 +758,56 @@
               "type": "string"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "plan"
               ],
-              "title": "PlanThreadItemType"
+              "title": "PlanThreadItemType",
+              "type": "string"
             }
           },
-          "title": "PlanThreadItem"
-        },
-        {
-          "type": "object",
           "required": [
             "id",
+            "text",
             "type"
           ],
+          "title": "PlanThreadItem",
+          "type": "object"
+        },
+        {
           "properties": {
             "content": {
               "default": [],
-              "type": "array",
               "items": {
                 "type": "string"
-              }
+              },
+              "type": "array"
             },
             "id": {
               "type": "string"
             },
             "summary": {
               "default": [],
-              "type": "array",
               "items": {
                 "type": "string"
-              }
+              },
+              "type": "array"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "reasoning"
               ],
-              "title": "ReasoningThreadItemType"
+              "title": "ReasoningThreadItemType",
+              "type": "string"
             }
           },
-          "title": "ReasoningThreadItem"
-        },
-        {
-          "type": "object",
           "required": [
-            "command",
-            "commandActions",
-            "cwd",
             "id",
-            "status",
             "type"
           ],
+          "title": "ReasoningThreadItem",
+          "type": "object"
+        },
+        {
           "properties": {
             "aggregatedOutput": {
               "description": "The command's output, aggregated from stdout and stderr.",
@@ -837,34 +822,34 @@
             },
             "commandActions": {
               "description": "A best-effort parsing of the command to understand the action(s) it will perform. This returns a list of CommandAction objects because a single shell command may be composed of many commands piped together.",
-              "type": "array",
               "items": {
                 "$ref": "#/definitions/CommandAction"
-              }
+              },
+              "type": "array"
             },
             "cwd": {
-              "description": "The command's working directory.",
               "allOf": [
                 {
                   "$ref": "#/definitions/AbsolutePathBuf"
                 }
-              ]
+              ],
+              "description": "The command's working directory."
             },
             "durationMs": {
               "description": "The duration of the command execution in milliseconds.",
+              "format": "int64",
               "type": [
                 "integer",
                 "null"
-              ],
-              "format": "int64"
+              ]
             },
             "exitCode": {
               "description": "The command's exit code.",
+              "format": "int32",
               "type": [
                 "integer",
                 "null"
-              ],
-              "format": "int32"
+              ]
             },
             "id": {
               "type": "string"
@@ -877,40 +862,42 @@
               ]
             },
             "source": {
-              "default": "agent",
               "allOf": [
                 {
                   "$ref": "#/definitions/CommandExecutionSource"
                 }
-              ]
+              ],
+              "default": "agent"
             },
             "status": {
               "$ref": "#/definitions/CommandExecutionStatus"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "commandExecution"
               ],
-              "title": "CommandExecutionThreadItemType"
+              "title": "CommandExecutionThreadItemType",
+              "type": "string"
             }
           },
-          "title": "CommandExecutionThreadItem"
-        },
-        {
-          "type": "object",
           "required": [
-            "changes",
+            "command",
+            "commandActions",
+            "cwd",
             "id",
             "status",
             "type"
           ],
+          "title": "CommandExecutionThreadItem",
+          "type": "object"
+        },
+        {
           "properties": {
             "changes": {
-              "type": "array",
               "items": {
                 "$ref": "#/definitions/FileUpdateChange"
-              }
+              },
+              "type": "array"
             },
             "id": {
               "type": "string"
@@ -919,34 +906,32 @@
               "$ref": "#/definitions/PatchApplyStatus"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "fileChange"
               ],
-              "title": "FileChangeThreadItemType"
+              "title": "FileChangeThreadItemType",
+              "type": "string"
             }
           },
-          "title": "FileChangeThreadItem"
-        },
-        {
-          "type": "object",
           "required": [
-            "arguments",
+            "changes",
             "id",
-            "server",
             "status",
-            "tool",
             "type"
           ],
+          "title": "FileChangeThreadItem",
+          "type": "object"
+        },
+        {
           "properties": {
             "arguments": true,
             "durationMs": {
               "description": "The duration of the MCP tool call in milliseconds.",
+              "format": "int64",
               "type": [
                 "integer",
                 "null"
-              ],
-              "format": "int64"
+              ]
             },
             "error": {
               "anyOf": [
@@ -962,6 +947,12 @@
               "type": "string"
             },
             "mcpAppResourceUri": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "pluginId": {
               "type": [
                 "string",
                 "null"
@@ -987,42 +978,43 @@
               "type": "string"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "mcpToolCall"
               ],
-              "title": "McpToolCallThreadItemType"
+              "title": "McpToolCallThreadItemType",
+              "type": "string"
             }
           },
-          "title": "McpToolCallThreadItem"
-        },
-        {
-          "type": "object",
           "required": [
             "arguments",
             "id",
+            "server",
             "status",
             "tool",
             "type"
           ],
+          "title": "McpToolCallThreadItem",
+          "type": "object"
+        },
+        {
           "properties": {
             "arguments": true,
             "contentItems": {
+              "items": {
+                "$ref": "#/definitions/DynamicToolCallOutputContentItem"
+              },
               "type": [
                 "array",
                 "null"
-              ],
-              "items": {
-                "$ref": "#/definitions/DynamicToolCallOutputContentItem"
-              }
+              ]
             },
             "durationMs": {
               "description": "The duration of the dynamic tool call in milliseconds.",
+              "format": "int64",
               "type": [
                 "integer",
                 "null"
-              ],
-              "format": "int64"
+              ]
             },
             "id": {
               "type": "string"
@@ -1046,33 +1038,31 @@
               "type": "string"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "dynamicToolCall"
               ],
-              "title": "DynamicToolCallThreadItemType"
+              "title": "DynamicToolCallThreadItemType",
+              "type": "string"
             }
           },
-          "title": "DynamicToolCallThreadItem"
-        },
-        {
-          "type": "object",
           "required": [
-            "agentsStates",
+            "arguments",
             "id",
-            "receiverThreadIds",
-            "senderThreadId",
             "status",
             "tool",
             "type"
           ],
+          "title": "DynamicToolCallThreadItem",
+          "type": "object"
+        },
+        {
           "properties": {
             "agentsStates": {
-              "description": "Last known status of the target agents, when available.",
-              "type": "object",
               "additionalProperties": {
                 "$ref": "#/definitions/CollabAgentState"
-              }
+              },
+              "description": "Last known status of the target agents, when available.",
+              "type": "object"
             },
             "id": {
               "description": "Unique identifier for this collab tool call.",
@@ -1093,7 +1083,6 @@
               ]
             },
             "reasoningEffort": {
-              "description": "Reasoning effort requested for the spawned agent, when applicable.",
               "anyOf": [
                 {
                   "$ref": "#/definitions/ReasoningEffort"
@@ -1101,52 +1090,57 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Reasoning effort requested for the spawned agent, when applicable."
             },
             "receiverThreadIds": {
               "description": "Thread ID of the receiving agent, when applicable. In case of spawn operation, this corresponds to the newly spawned agent.",
-              "type": "array",
               "items": {
                 "type": "string"
-              }
+              },
+              "type": "array"
             },
             "senderThreadId": {
               "description": "Thread ID of the agent issuing the collab request.",
               "type": "string"
             },
             "status": {
-              "description": "Current status of the collab tool call.",
               "allOf": [
                 {
                   "$ref": "#/definitions/CollabAgentToolCallStatus"
                 }
-              ]
+              ],
+              "description": "Current status of the collab tool call."
             },
             "tool": {
-              "description": "Name of the collab tool that was invoked.",
               "allOf": [
                 {
                   "$ref": "#/definitions/CollabAgentTool"
                 }
-              ]
+              ],
+              "description": "Name of the collab tool that was invoked."
             },
             "type": {
-              "type": "string",
               "enum": [
                 "collabAgentToolCall"
               ],
-              "title": "CollabAgentToolCallThreadItemType"
+              "title": "CollabAgentToolCallThreadItemType",
+              "type": "string"
             }
           },
-          "title": "CollabAgentToolCallThreadItem"
-        },
-        {
-          "type": "object",
           "required": [
+            "agentsStates",
             "id",
-            "query",
+            "receiverThreadIds",
+            "senderThreadId",
+            "status",
+            "tool",
             "type"
           ],
+          "title": "CollabAgentToolCallThreadItem",
+          "type": "object"
+        },
+        {
           "properties": {
             "action": {
               "anyOf": [
@@ -1165,22 +1159,22 @@
               "type": "string"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "webSearch"
               ],
-              "title": "WebSearchThreadItemType"
+              "title": "WebSearchThreadItemType",
+              "type": "string"
             }
           },
-          "title": "WebSearchThreadItem"
-        },
-        {
-          "type": "object",
           "required": [
             "id",
-            "path",
+            "query",
             "type"
           ],
+          "title": "WebSearchThreadItem",
+          "type": "object"
+        },
+        {
           "properties": {
             "id": {
               "type": "string"
@@ -1189,23 +1183,22 @@
               "$ref": "#/definitions/AbsolutePathBuf"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "imageView"
               ],
-              "title": "ImageViewThreadItemType"
+              "title": "ImageViewThreadItemType",
+              "type": "string"
             }
           },
-          "title": "ImageViewThreadItem"
-        },
-        {
-          "type": "object",
           "required": [
             "id",
-            "result",
-            "status",
+            "path",
             "type"
           ],
+          "title": "ImageViewThreadItem",
+          "type": "object"
+        },
+        {
           "properties": {
             "id": {
               "type": "string"
@@ -1233,22 +1226,23 @@
               "type": "string"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "imageGeneration"
               ],
-              "title": "ImageGenerationThreadItemType"
+              "title": "ImageGenerationThreadItemType",
+              "type": "string"
             }
           },
-          "title": "ImageGenerationThreadItem"
-        },
-        {
-          "type": "object",
           "required": [
             "id",
-            "review",
+            "result",
+            "status",
             "type"
           ],
+          "title": "ImageGenerationThreadItem",
+          "type": "object"
+        },
+        {
           "properties": {
             "id": {
               "type": "string"
@@ -1257,22 +1251,22 @@
               "type": "string"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "enteredReviewMode"
               ],
-              "title": "EnteredReviewModeThreadItemType"
+              "title": "EnteredReviewModeThreadItemType",
+              "type": "string"
             }
           },
-          "title": "EnteredReviewModeThreadItem"
-        },
-        {
-          "type": "object",
           "required": [
             "id",
             "review",
             "type"
           ],
+          "title": "EnteredReviewModeThreadItem",
+          "type": "object"
+        },
+        {
           "properties": {
             "id": {
               "type": "string"
@@ -1281,63 +1275,62 @@
               "type": "string"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "exitedReviewMode"
               ],
-              "title": "ExitedReviewModeThreadItemType"
+              "title": "ExitedReviewModeThreadItemType",
+              "type": "string"
             }
           },
-          "title": "ExitedReviewModeThreadItem"
-        },
-        {
-          "type": "object",
           "required": [
             "id",
+            "review",
             "type"
           ],
+          "title": "ExitedReviewModeThreadItem",
+          "type": "object"
+        },
+        {
           "properties": {
             "id": {
               "type": "string"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "contextCompaction"
               ],
-              "title": "ContextCompactionThreadItemType"
+              "title": "ContextCompactionThreadItemType",
+              "type": "string"
             }
           },
-          "title": "ContextCompactionThreadItem"
+          "required": [
+            "id",
+            "type"
+          ],
+          "title": "ContextCompactionThreadItem",
+          "type": "object"
         }
       ]
     },
     "Turn": {
-      "type": "object",
-      "required": [
-        "id",
-        "items",
-        "status"
-      ],
       "properties": {
         "completedAt": {
           "description": "Unix timestamp (in seconds) when the turn completed.",
+          "format": "int64",
           "type": [
             "integer",
             "null"
-          ],
-          "format": "int64"
+          ]
         },
         "durationMs": {
           "description": "Duration between turn start and completion in milliseconds, if known.",
+          "format": "int64",
           "type": [
             "integer",
             "null"
-          ],
-          "format": "int64"
+          ]
         },
         "error": {
-          "description": "Only populated when the Turn's status is failed.",
           "anyOf": [
             {
               "$ref": "#/definitions/TurnError"
@@ -1345,45 +1338,48 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Only populated when the Turn's status is failed."
         },
         "id": {
           "type": "string"
         },
         "items": {
           "description": "Thread items currently included in this turn payload.",
-          "type": "array",
           "items": {
             "$ref": "#/definitions/ThreadItem"
-          }
+          },
+          "type": "array"
         },
         "itemsView": {
-          "description": "Describes how much of `items` has been loaded for this turn.",
-          "default": "full",
           "allOf": [
             {
               "$ref": "#/definitions/TurnItemsView"
             }
-          ]
+          ],
+          "default": "full",
+          "description": "Describes how much of `items` has been loaded for this turn."
         },
         "startedAt": {
           "description": "Unix timestamp (in seconds) when the turn started.",
+          "format": "int64",
           "type": [
             "integer",
             "null"
-          ],
-          "format": "int64"
+          ]
         },
         "status": {
           "$ref": "#/definitions/TurnStatus"
         }
-      }
+      },
+      "required": [
+        "id",
+        "items",
+        "status"
+      ],
+      "type": "object"
     },
     "TurnError": {
-      "type": "object",
-      "required": [
-        "message"
-      ],
       "properties": {
         "additionalDetails": {
           "default": null,
@@ -1405,81 +1401,79 @@
         "message": {
           "type": "string"
         }
-      }
+      },
+      "required": [
+        "message"
+      ],
+      "type": "object"
     },
     "TurnItemsView": {
       "oneOf": [
         {
           "description": "`items` was not loaded for this turn. The field is intentionally empty.",
-          "type": "string",
           "enum": [
             "notLoaded"
-          ]
+          ],
+          "type": "string"
         },
         {
           "description": "`items` contains only a display summary for this turn.",
-          "type": "string",
           "enum": [
             "summary"
-          ]
+          ],
+          "type": "string"
         },
         {
           "description": "`items` contains every ThreadItem available from persisted app-server history for this turn.",
-          "type": "string",
           "enum": [
             "full"
-          ]
+          ],
+          "type": "string"
         }
       ]
     },
     "TurnStatus": {
-      "type": "string",
       "enum": [
         "completed",
         "interrupted",
         "failed",
         "inProgress"
-      ]
+      ],
+      "type": "string"
     },
     "UserInput": {
       "oneOf": [
         {
-          "type": "object",
-          "required": [
-            "text",
-            "type"
-          ],
           "properties": {
             "text": {
               "type": "string"
             },
             "text_elements": {
-              "description": "UI-defined spans within `text` used to render or persist special elements.",
               "default": [],
-              "type": "array",
+              "description": "UI-defined spans within `text` used to render or persist special elements.",
               "items": {
                 "$ref": "#/definitions/TextElement"
-              }
+              },
+              "type": "array"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "text"
               ],
-              "title": "TextUserInputType"
+              "title": "TextUserInputType",
+              "type": "string"
             }
           },
-          "title": "TextUserInput"
+          "required": [
+            "text",
+            "type"
+          ],
+          "title": "TextUserInput",
+          "type": "object"
         },
         {
-          "type": "object",
-          "required": [
-            "type",
-            "url"
-          ],
           "properties": {
             "detail": {
-              "default": null,
               "anyOf": [
                 {
                   "$ref": "#/definitions/ImageDetail"
@@ -1487,30 +1481,30 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "default": null
             },
             "type": {
-              "type": "string",
               "enum": [
                 "image"
               ],
-              "title": "ImageUserInputType"
+              "title": "ImageUserInputType",
+              "type": "string"
             },
             "url": {
               "type": "string"
             }
           },
-          "title": "ImageUserInput"
+          "required": [
+            "type",
+            "url"
+          ],
+          "title": "ImageUserInput",
+          "type": "object"
         },
         {
-          "type": "object",
-          "required": [
-            "path",
-            "type"
-          ],
           "properties": {
             "detail": {
-              "default": null,
               "anyOf": [
                 {
                   "$ref": "#/definitions/ImageDetail"
@@ -1518,28 +1512,28 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "default": null
             },
             "path": {
               "type": "string"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "localImage"
               ],
-              "title": "LocalImageUserInputType"
+              "title": "LocalImageUserInputType",
+              "type": "string"
             }
           },
-          "title": "LocalImageUserInput"
-        },
-        {
-          "type": "object",
           "required": [
-            "name",
             "path",
             "type"
           ],
+          "title": "LocalImageUserInput",
+          "type": "object"
+        },
+        {
           "properties": {
             "name": {
               "type": "string"
@@ -1548,22 +1542,22 @@
               "type": "string"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "skill"
               ],
-              "title": "SkillUserInputType"
+              "title": "SkillUserInputType",
+              "type": "string"
             }
           },
-          "title": "SkillUserInput"
-        },
-        {
-          "type": "object",
           "required": [
             "name",
             "path",
             "type"
           ],
+          "title": "SkillUserInput",
+          "type": "object"
+        },
+        {
           "properties": {
             "name": {
               "type": "string"
@@ -1572,33 +1566,35 @@
               "type": "string"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "mention"
               ],
-              "title": "MentionUserInputType"
+              "title": "MentionUserInputType",
+              "type": "string"
             }
           },
-          "title": "MentionUserInput"
+          "required": [
+            "name",
+            "path",
+            "type"
+          ],
+          "title": "MentionUserInput",
+          "type": "object"
         }
       ]
     },
     "WebSearchAction": {
       "oneOf": [
         {
-          "type": "object",
-          "required": [
-            "type"
-          ],
           "properties": {
             "queries": {
+              "items": {
+                "type": "string"
+              },
               "type": [
                 "array",
                 "null"
-              ],
-              "items": {
-                "type": "string"
-              }
+              ]
             },
             "query": {
               "type": [
@@ -1607,27 +1603,27 @@
               ]
             },
             "type": {
-              "type": "string",
               "enum": [
                 "search"
               ],
-              "title": "SearchWebSearchActionType"
+              "title": "SearchWebSearchActionType",
+              "type": "string"
             }
           },
-          "title": "SearchWebSearchAction"
-        },
-        {
-          "type": "object",
           "required": [
             "type"
           ],
+          "title": "SearchWebSearchAction",
+          "type": "object"
+        },
+        {
           "properties": {
             "type": {
-              "type": "string",
               "enum": [
                 "openPage"
               ],
-              "title": "OpenPageWebSearchActionType"
+              "title": "OpenPageWebSearchActionType",
+              "type": "string"
             },
             "url": {
               "type": [
@@ -1636,13 +1632,13 @@
               ]
             }
           },
-          "title": "OpenPageWebSearchAction"
-        },
-        {
-          "type": "object",
           "required": [
             "type"
           ],
+          "title": "OpenPageWebSearchAction",
+          "type": "object"
+        },
+        {
           "properties": {
             "pattern": {
               "type": [
@@ -1651,11 +1647,11 @@
               ]
             },
             "type": {
-              "type": "string",
               "enum": [
                 "findInPage"
               ],
-              "title": "FindInPageWebSearchActionType"
+              "title": "FindInPageWebSearchActionType",
+              "type": "string"
             },
             "url": {
               "type": [
@@ -1664,25 +1660,43 @@
               ]
             }
           },
-          "title": "FindInPageWebSearchAction"
-        },
-        {
-          "type": "object",
           "required": [
             "type"
           ],
+          "title": "FindInPageWebSearchAction",
+          "type": "object"
+        },
+        {
           "properties": {
             "type": {
-              "type": "string",
               "enum": [
                 "other"
               ],
-              "title": "OtherWebSearchActionType"
+              "title": "OtherWebSearchActionType",
+              "type": "string"
             }
           },
-          "title": "OtherWebSearchAction"
+          "required": [
+            "type"
+          ],
+          "title": "OtherWebSearchAction",
+          "type": "object"
         }
       ]
     }
-  }
+  },
+  "properties": {
+    "threadId": {
+      "type": "string"
+    },
+    "turn": {
+      "$ref": "#/definitions/Turn"
+    }
+  },
+  "required": [
+    "threadId",
+    "turn"
+  ],
+  "title": "TurnCompletedNotification",
+  "type": "object"
 }

--- a/extensions/codex/src/app-server/protocol-generated/json/v2/TurnStartResponse.json
+++ b/extensions/codex/src/app-server/protocol-generated/json/v2/TurnStartResponse.json
@@ -1,44 +1,33 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "TurnStartResponse",
-  "type": "object",
-  "required": [
-    "turn"
-  ],
-  "properties": {
-    "turn": {
-      "$ref": "#/definitions/Turn"
-    }
-  },
   "definitions": {
     "AbsolutePathBuf": {
       "description": "A path that is guaranteed to be absolute and normalized (though it is not guaranteed to be canonicalized or exist on the filesystem).\n\nIMPORTANT: When deserializing an `AbsolutePathBuf`, a base path must be set using [AbsolutePathBufGuard::new]. If no base path is set, the deserialization will fail unless the path being deserialized is already absolute.",
       "type": "string"
     },
     "ByteRange": {
-      "type": "object",
+      "properties": {
+        "end": {
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "start": {
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
       "required": [
         "end",
         "start"
       ],
-      "properties": {
-        "end": {
-          "type": "integer",
-          "format": "uint",
-          "minimum": 0
-        },
-        "start": {
-          "type": "integer",
-          "format": "uint",
-          "minimum": 0
-        }
-      }
+      "type": "object"
     },
     "CodexErrorInfo": {
       "description": "This translation layer make sure that we expose codex error code in camel case.\n\nWhen an upstream HTTP status is available (for example, from the Responses API or a provider), it is forwarded in `httpStatusCode` on the relevant `codexErrorInfo` variant.",
       "oneOf": [
         {
-          "type": "string",
           "enum": [
             "contextWindowExceeded",
             "usageLimitExceeded",
@@ -50,132 +39,129 @@
             "threadRollbackFailed",
             "sandboxError",
             "other"
-          ]
+          ],
+          "type": "string"
         },
         {
-          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "httpConnectionFailed": {
+              "properties": {
+                "httpStatusCode": {
+                  "format": "uint16",
+                  "minimum": 0,
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                }
+              },
+              "type": "object"
+            }
+          },
           "required": [
             "httpConnectionFailed"
           ],
+          "title": "HttpConnectionFailedCodexErrorInfo",
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "description": "Failed to connect to the response SSE stream.",
           "properties": {
-            "httpConnectionFailed": {
-              "type": "object",
+            "responseStreamConnectionFailed": {
               "properties": {
                 "httpStatusCode": {
+                  "format": "uint16",
+                  "minimum": 0,
                   "type": [
                     "integer",
                     "null"
-                  ],
-                  "format": "uint16",
-                  "minimum": 0
+                  ]
                 }
-              }
+              },
+              "type": "object"
             }
           },
-          "additionalProperties": false,
-          "title": "HttpConnectionFailedCodexErrorInfo"
-        },
-        {
-          "description": "Failed to connect to the response SSE stream.",
-          "type": "object",
           "required": [
             "responseStreamConnectionFailed"
           ],
+          "title": "ResponseStreamConnectionFailedCodexErrorInfo",
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "description": "The response SSE stream disconnected in the middle of a turn before completion.",
           "properties": {
-            "responseStreamConnectionFailed": {
-              "type": "object",
+            "responseStreamDisconnected": {
               "properties": {
                 "httpStatusCode": {
+                  "format": "uint16",
+                  "minimum": 0,
                   "type": [
                     "integer",
                     "null"
-                  ],
-                  "format": "uint16",
-                  "minimum": 0
+                  ]
                 }
-              }
+              },
+              "type": "object"
             }
           },
-          "additionalProperties": false,
-          "title": "ResponseStreamConnectionFailedCodexErrorInfo"
-        },
-        {
-          "description": "The response SSE stream disconnected in the middle of a turn before completion.",
-          "type": "object",
           "required": [
             "responseStreamDisconnected"
           ],
+          "title": "ResponseStreamDisconnectedCodexErrorInfo",
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "description": "Reached the retry limit for responses.",
           "properties": {
-            "responseStreamDisconnected": {
-              "type": "object",
+            "responseTooManyFailedAttempts": {
               "properties": {
                 "httpStatusCode": {
+                  "format": "uint16",
+                  "minimum": 0,
                   "type": [
                     "integer",
                     "null"
-                  ],
-                  "format": "uint16",
-                  "minimum": 0
+                  ]
                 }
-              }
+              },
+              "type": "object"
             }
           },
-          "additionalProperties": false,
-          "title": "ResponseStreamDisconnectedCodexErrorInfo"
-        },
-        {
-          "description": "Reached the retry limit for responses.",
-          "type": "object",
           "required": [
             "responseTooManyFailedAttempts"
           ],
-          "properties": {
-            "responseTooManyFailedAttempts": {
-              "type": "object",
-              "properties": {
-                "httpStatusCode": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ],
-                  "format": "uint16",
-                  "minimum": 0
-                }
-              }
-            }
-          },
-          "additionalProperties": false,
-          "title": "ResponseTooManyFailedAttemptsCodexErrorInfo"
+          "title": "ResponseTooManyFailedAttemptsCodexErrorInfo",
+          "type": "object"
         },
         {
+          "additionalProperties": false,
           "description": "Returned when `turn/start` or `turn/steer` is submitted while the current active turn cannot accept same-turn steering, for example `/review` or manual `/compact`.",
-          "type": "object",
-          "required": [
-            "activeTurnNotSteerable"
-          ],
           "properties": {
             "activeTurnNotSteerable": {
-              "type": "object",
-              "required": [
-                "turnKind"
-              ],
               "properties": {
                 "turnKind": {
                   "$ref": "#/definitions/NonSteerableTurnKind"
                 }
-              }
+              },
+              "required": [
+                "turnKind"
+              ],
+              "type": "object"
             }
           },
-          "additionalProperties": false,
-          "title": "ActiveTurnNotSteerableCodexErrorInfo"
+          "required": [
+            "activeTurnNotSteerable"
+          ],
+          "title": "ActiveTurnNotSteerableCodexErrorInfo",
+          "type": "object"
         }
       ]
     },
     "CollabAgentState": {
-      "type": "object",
-      "required": [
-        "status"
-      ],
       "properties": {
         "message": {
           "type": [
@@ -186,10 +172,13 @@
         "status": {
           "$ref": "#/definitions/CollabAgentStatus"
         }
-      }
+      },
+      "required": [
+        "status"
+      ],
+      "type": "object"
     },
     "CollabAgentStatus": {
-      "type": "string",
       "enum": [
         "pendingInit",
         "running",
@@ -198,36 +187,30 @@
         "errored",
         "shutdown",
         "notFound"
-      ]
+      ],
+      "type": "string"
     },
     "CollabAgentTool": {
-      "type": "string",
       "enum": [
         "spawnAgent",
         "sendInput",
         "resumeAgent",
         "wait",
         "closeAgent"
-      ]
+      ],
+      "type": "string"
     },
     "CollabAgentToolCallStatus": {
-      "type": "string",
       "enum": [
         "inProgress",
         "completed",
         "failed"
-      ]
+      ],
+      "type": "string"
     },
     "CommandAction": {
       "oneOf": [
         {
-          "type": "object",
-          "required": [
-            "command",
-            "name",
-            "path",
-            "type"
-          ],
           "properties": {
             "command": {
               "type": "string"
@@ -239,21 +222,23 @@
               "$ref": "#/definitions/AbsolutePathBuf"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "read"
               ],
-              "title": "ReadCommandActionType"
+              "title": "ReadCommandActionType",
+              "type": "string"
             }
           },
-          "title": "ReadCommandAction"
-        },
-        {
-          "type": "object",
           "required": [
             "command",
+            "name",
+            "path",
             "type"
           ],
+          "title": "ReadCommandAction",
+          "type": "object"
+        },
+        {
           "properties": {
             "command": {
               "type": "string"
@@ -265,21 +250,21 @@
               ]
             },
             "type": {
-              "type": "string",
               "enum": [
                 "listFiles"
               ],
-              "title": "ListFilesCommandActionType"
+              "title": "ListFilesCommandActionType",
+              "type": "string"
             }
           },
-          "title": "ListFilesCommandAction"
-        },
-        {
-          "type": "object",
           "required": [
             "command",
             "type"
           ],
+          "title": "ListFilesCommandAction",
+          "type": "object"
+        },
+        {
           "properties": {
             "command": {
               "type": "string"
@@ -297,114 +282,113 @@
               ]
             },
             "type": {
-              "type": "string",
               "enum": [
                 "search"
               ],
-              "title": "SearchCommandActionType"
+              "title": "SearchCommandActionType",
+              "type": "string"
             }
           },
-          "title": "SearchCommandAction"
-        },
-        {
-          "type": "object",
           "required": [
             "command",
             "type"
           ],
+          "title": "SearchCommandAction",
+          "type": "object"
+        },
+        {
           "properties": {
             "command": {
               "type": "string"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "unknown"
               ],
-              "title": "UnknownCommandActionType"
+              "title": "UnknownCommandActionType",
+              "type": "string"
             }
           },
-          "title": "UnknownCommandAction"
+          "required": [
+            "command",
+            "type"
+          ],
+          "title": "UnknownCommandAction",
+          "type": "object"
         }
       ]
     },
     "CommandExecutionSource": {
-      "type": "string",
       "enum": [
         "agent",
         "userShell",
         "unifiedExecStartup",
         "unifiedExecInteraction"
-      ]
+      ],
+      "type": "string"
     },
     "CommandExecutionStatus": {
-      "type": "string",
       "enum": [
         "inProgress",
         "completed",
         "failed",
         "declined"
-      ]
+      ],
+      "type": "string"
     },
     "DynamicToolCallOutputContentItem": {
       "oneOf": [
         {
-          "type": "object",
-          "required": [
-            "text",
-            "type"
-          ],
           "properties": {
             "text": {
               "type": "string"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "inputText"
               ],
-              "title": "InputTextDynamicToolCallOutputContentItemType"
+              "title": "InputTextDynamicToolCallOutputContentItemType",
+              "type": "string"
             }
           },
-          "title": "InputTextDynamicToolCallOutputContentItem"
-        },
-        {
-          "type": "object",
           "required": [
-            "imageUrl",
+            "text",
             "type"
           ],
+          "title": "InputTextDynamicToolCallOutputContentItem",
+          "type": "object"
+        },
+        {
           "properties": {
             "imageUrl": {
               "type": "string"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "inputImage"
               ],
-              "title": "InputImageDynamicToolCallOutputContentItemType"
+              "title": "InputImageDynamicToolCallOutputContentItemType",
+              "type": "string"
             }
           },
-          "title": "InputImageDynamicToolCallOutputContentItem"
+          "required": [
+            "imageUrl",
+            "type"
+          ],
+          "title": "InputImageDynamicToolCallOutputContentItem",
+          "type": "object"
         }
       ]
     },
     "DynamicToolCallStatus": {
-      "type": "string",
       "enum": [
         "inProgress",
         "completed",
         "failed"
-      ]
+      ],
+      "type": "string"
     },
     "FileUpdateChange": {
-      "type": "object",
-      "required": [
-        "diff",
-        "kind",
-        "path"
-      ],
       "properties": {
         "diff": {
           "type": "string"
@@ -415,14 +399,15 @@
         "path": {
           "type": "string"
         }
-      }
+      },
+      "required": [
+        "diff",
+        "kind",
+        "path"
+      ],
+      "type": "object"
     },
     "HookPromptFragment": {
-      "type": "object",
-      "required": [
-        "hookRunId",
-        "text"
-      ],
       "properties": {
         "hookRunId": {
           "type": "string"
@@ -430,87 +415,87 @@
         "text": {
           "type": "string"
         }
-      }
+      },
+      "required": [
+        "hookRunId",
+        "text"
+      ],
+      "type": "object"
     },
     "ImageDetail": {
-      "type": "string",
       "enum": [
+        "auto",
+        "low",
         "high",
         "original"
-      ]
+      ],
+      "type": "string"
     },
     "McpToolCallError": {
-      "type": "object",
-      "required": [
-        "message"
-      ],
       "properties": {
         "message": {
           "type": "string"
         }
-      }
+      },
+      "required": [
+        "message"
+      ],
+      "type": "object"
     },
     "McpToolCallResult": {
-      "type": "object",
-      "required": [
-        "content"
-      ],
       "properties": {
         "_meta": true,
         "content": {
-          "type": "array",
-          "items": true
+          "items": true,
+          "type": "array"
         },
         "structuredContent": true
-      }
+      },
+      "required": [
+        "content"
+      ],
+      "type": "object"
     },
     "McpToolCallStatus": {
-      "type": "string",
       "enum": [
         "inProgress",
         "completed",
         "failed"
-      ]
+      ],
+      "type": "string"
     },
     "MemoryCitation": {
-      "type": "object",
+      "properties": {
+        "entries": {
+          "items": {
+            "$ref": "#/definitions/MemoryCitationEntry"
+          },
+          "type": "array"
+        },
+        "threadIds": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
       "required": [
         "entries",
         "threadIds"
       ],
-      "properties": {
-        "entries": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/MemoryCitationEntry"
-          }
-        },
-        "threadIds": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
+      "type": "object"
     },
     "MemoryCitationEntry": {
-      "type": "object",
-      "required": [
-        "lineEnd",
-        "lineStart",
-        "note",
-        "path"
-      ],
       "properties": {
         "lineEnd": {
-          "type": "integer",
           "format": "uint32",
-          "minimum": 0
+          "minimum": 0,
+          "type": "integer"
         },
         "lineStart": {
-          "type": "integer",
           "format": "uint32",
-          "minimum": 0
+          "minimum": 0,
+          "type": "integer"
         },
         "note": {
           "type": "string"
@@ -518,82 +503,85 @@
         "path": {
           "type": "string"
         }
-      }
+      },
+      "required": [
+        "lineEnd",
+        "lineStart",
+        "note",
+        "path"
+      ],
+      "type": "object"
     },
     "MessagePhase": {
       "description": "Classifies an assistant message as interim commentary or final answer text.\n\nProviders do not emit this consistently, so callers must treat `None` as \"phase unknown\" and keep compatibility behavior for legacy models.",
       "oneOf": [
         {
           "description": "Mid-turn assistant text (for example preamble/progress narration).\n\nAdditional tool calls or assistant output may follow before turn completion.",
-          "type": "string",
           "enum": [
             "commentary"
-          ]
+          ],
+          "type": "string"
         },
         {
           "description": "The assistant's terminal answer text for the current turn.",
-          "type": "string",
           "enum": [
             "final_answer"
-          ]
+          ],
+          "type": "string"
         }
       ]
     },
     "NonSteerableTurnKind": {
-      "type": "string",
       "enum": [
         "review",
         "compact"
-      ]
+      ],
+      "type": "string"
     },
     "PatchApplyStatus": {
-      "type": "string",
       "enum": [
         "inProgress",
         "completed",
         "failed",
         "declined"
-      ]
+      ],
+      "type": "string"
     },
     "PatchChangeKind": {
       "oneOf": [
         {
-          "type": "object",
-          "required": [
-            "type"
-          ],
           "properties": {
             "type": {
-              "type": "string",
               "enum": [
                 "add"
               ],
-              "title": "AddPatchChangeKindType"
+              "title": "AddPatchChangeKindType",
+              "type": "string"
             }
           },
-          "title": "AddPatchChangeKind"
-        },
-        {
-          "type": "object",
           "required": [
             "type"
           ],
+          "title": "AddPatchChangeKind",
+          "type": "object"
+        },
+        {
           "properties": {
             "type": {
-              "type": "string",
               "enum": [
                 "delete"
               ],
-              "title": "DeletePatchChangeKindType"
+              "title": "DeletePatchChangeKindType",
+              "type": "string"
             }
           },
-          "title": "DeletePatchChangeKind"
-        },
-        {
-          "type": "object",
           "required": [
             "type"
           ],
+          "title": "DeletePatchChangeKind",
+          "type": "object"
+        },
+        {
           "properties": {
             "move_path": {
               "type": [
@@ -602,20 +590,23 @@
               ]
             },
             "type": {
-              "type": "string",
               "enum": [
                 "update"
               ],
-              "title": "UpdatePatchChangeKindType"
+              "title": "UpdatePatchChangeKindType",
+              "type": "string"
             }
           },
-          "title": "UpdatePatchChangeKind"
+          "required": [
+            "type"
+          ],
+          "title": "UpdatePatchChangeKind",
+          "type": "object"
         }
       ]
     },
     "ReasoningEffort": {
       "description": "See https://platform.openai.com/docs/guides/reasoning?api-mode=responses#get-started-with-reasoning",
-      "type": "string",
       "enum": [
         "none",
         "minimal",
@@ -623,21 +614,18 @@
         "medium",
         "high",
         "xhigh"
-      ]
+      ],
+      "type": "string"
     },
     "TextElement": {
-      "type": "object",
-      "required": [
-        "byteRange"
-      ],
       "properties": {
         "byteRange": {
-          "description": "Byte range in the parent `text` buffer that this element occupies.",
           "allOf": [
             {
               "$ref": "#/definitions/ByteRange"
             }
-          ]
+          ],
+          "description": "Byte range in the parent `text` buffer that this element occupies."
         },
         "placeholder": {
           "description": "Optional human-readable placeholder for the element, displayed in the UI.",
@@ -646,77 +634,80 @@
             "null"
           ]
         }
-      }
+      },
+      "required": [
+        "byteRange"
+      ],
+      "type": "object"
     },
     "ThreadItem": {
       "oneOf": [
         {
-          "type": "object",
+          "properties": {
+            "clientId": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "content": {
+              "items": {
+                "$ref": "#/definitions/UserInput"
+              },
+              "type": "array"
+            },
+            "id": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "userMessage"
+              ],
+              "title": "UserMessageThreadItemType",
+              "type": "string"
+            }
+          },
           "required": [
             "content",
             "id",
             "type"
           ],
+          "title": "UserMessageThreadItem",
+          "type": "object"
+        },
+        {
           "properties": {
-            "content": {
-              "type": "array",
+            "fragments": {
               "items": {
-                "$ref": "#/definitions/UserInput"
-              }
+                "$ref": "#/definitions/HookPromptFragment"
+              },
+              "type": "array"
             },
             "id": {
               "type": "string"
             },
             "type": {
-              "type": "string",
               "enum": [
-                "userMessage"
+                "hookPrompt"
               ],
-              "title": "UserMessageThreadItemType"
+              "title": "HookPromptThreadItemType",
+              "type": "string"
             }
           },
-          "title": "UserMessageThreadItem"
-        },
-        {
-          "type": "object",
           "required": [
             "fragments",
             "id",
             "type"
           ],
-          "properties": {
-            "fragments": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/HookPromptFragment"
-              }
-            },
-            "id": {
-              "type": "string"
-            },
-            "type": {
-              "type": "string",
-              "enum": [
-                "hookPrompt"
-              ],
-              "title": "HookPromptThreadItemType"
-            }
-          },
-          "title": "HookPromptThreadItem"
+          "title": "HookPromptThreadItem",
+          "type": "object"
         },
         {
-          "type": "object",
-          "required": [
-            "id",
-            "text",
-            "type"
-          ],
           "properties": {
             "id": {
               "type": "string"
             },
             "memoryCitation": {
-              "default": null,
               "anyOf": [
                 {
                   "$ref": "#/definitions/MemoryCitation"
@@ -724,10 +715,10 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "default": null
             },
             "phase": {
-              "default": null,
               "anyOf": [
                 {
                   "$ref": "#/definitions/MessagePhase"
@@ -735,29 +726,30 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "default": null
             },
             "text": {
               "type": "string"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "agentMessage"
               ],
-              "title": "AgentMessageThreadItemType"
+              "title": "AgentMessageThreadItemType",
+              "type": "string"
             }
           },
-          "title": "AgentMessageThreadItem"
-        },
-        {
-          "description": "EXPERIMENTAL - proposed plan item content. The completed plan item is authoritative and may not match the concatenation of `PlanDelta` text.",
-          "type": "object",
           "required": [
             "id",
             "text",
             "type"
           ],
+          "title": "AgentMessageThreadItem",
+          "type": "object"
+        },
+        {
+          "description": "EXPERIMENTAL - proposed plan item content. The completed plan item is authoritative and may not match the concatenation of `PlanDelta` text.",
           "properties": {
             "id": {
               "type": "string"
@@ -766,59 +758,56 @@
               "type": "string"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "plan"
               ],
-              "title": "PlanThreadItemType"
+              "title": "PlanThreadItemType",
+              "type": "string"
             }
           },
-          "title": "PlanThreadItem"
-        },
-        {
-          "type": "object",
           "required": [
             "id",
+            "text",
             "type"
           ],
+          "title": "PlanThreadItem",
+          "type": "object"
+        },
+        {
           "properties": {
             "content": {
               "default": [],
-              "type": "array",
               "items": {
                 "type": "string"
-              }
+              },
+              "type": "array"
             },
             "id": {
               "type": "string"
             },
             "summary": {
               "default": [],
-              "type": "array",
               "items": {
                 "type": "string"
-              }
+              },
+              "type": "array"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "reasoning"
               ],
-              "title": "ReasoningThreadItemType"
+              "title": "ReasoningThreadItemType",
+              "type": "string"
             }
           },
-          "title": "ReasoningThreadItem"
-        },
-        {
-          "type": "object",
           "required": [
-            "command",
-            "commandActions",
-            "cwd",
             "id",
-            "status",
             "type"
           ],
+          "title": "ReasoningThreadItem",
+          "type": "object"
+        },
+        {
           "properties": {
             "aggregatedOutput": {
               "description": "The command's output, aggregated from stdout and stderr.",
@@ -833,34 +822,34 @@
             },
             "commandActions": {
               "description": "A best-effort parsing of the command to understand the action(s) it will perform. This returns a list of CommandAction objects because a single shell command may be composed of many commands piped together.",
-              "type": "array",
               "items": {
                 "$ref": "#/definitions/CommandAction"
-              }
+              },
+              "type": "array"
             },
             "cwd": {
-              "description": "The command's working directory.",
               "allOf": [
                 {
                   "$ref": "#/definitions/AbsolutePathBuf"
                 }
-              ]
+              ],
+              "description": "The command's working directory."
             },
             "durationMs": {
               "description": "The duration of the command execution in milliseconds.",
+              "format": "int64",
               "type": [
                 "integer",
                 "null"
-              ],
-              "format": "int64"
+              ]
             },
             "exitCode": {
               "description": "The command's exit code.",
+              "format": "int32",
               "type": [
                 "integer",
                 "null"
-              ],
-              "format": "int32"
+              ]
             },
             "id": {
               "type": "string"
@@ -873,40 +862,42 @@
               ]
             },
             "source": {
-              "default": "agent",
               "allOf": [
                 {
                   "$ref": "#/definitions/CommandExecutionSource"
                 }
-              ]
+              ],
+              "default": "agent"
             },
             "status": {
               "$ref": "#/definitions/CommandExecutionStatus"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "commandExecution"
               ],
-              "title": "CommandExecutionThreadItemType"
+              "title": "CommandExecutionThreadItemType",
+              "type": "string"
             }
           },
-          "title": "CommandExecutionThreadItem"
-        },
-        {
-          "type": "object",
           "required": [
-            "changes",
+            "command",
+            "commandActions",
+            "cwd",
             "id",
             "status",
             "type"
           ],
+          "title": "CommandExecutionThreadItem",
+          "type": "object"
+        },
+        {
           "properties": {
             "changes": {
-              "type": "array",
               "items": {
                 "$ref": "#/definitions/FileUpdateChange"
-              }
+              },
+              "type": "array"
             },
             "id": {
               "type": "string"
@@ -915,34 +906,32 @@
               "$ref": "#/definitions/PatchApplyStatus"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "fileChange"
               ],
-              "title": "FileChangeThreadItemType"
+              "title": "FileChangeThreadItemType",
+              "type": "string"
             }
           },
-          "title": "FileChangeThreadItem"
-        },
-        {
-          "type": "object",
           "required": [
-            "arguments",
+            "changes",
             "id",
-            "server",
             "status",
-            "tool",
             "type"
           ],
+          "title": "FileChangeThreadItem",
+          "type": "object"
+        },
+        {
           "properties": {
             "arguments": true,
             "durationMs": {
               "description": "The duration of the MCP tool call in milliseconds.",
+              "format": "int64",
               "type": [
                 "integer",
                 "null"
-              ],
-              "format": "int64"
+              ]
             },
             "error": {
               "anyOf": [
@@ -958,6 +947,12 @@
               "type": "string"
             },
             "mcpAppResourceUri": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "pluginId": {
               "type": [
                 "string",
                 "null"
@@ -983,42 +978,43 @@
               "type": "string"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "mcpToolCall"
               ],
-              "title": "McpToolCallThreadItemType"
+              "title": "McpToolCallThreadItemType",
+              "type": "string"
             }
           },
-          "title": "McpToolCallThreadItem"
-        },
-        {
-          "type": "object",
           "required": [
             "arguments",
             "id",
+            "server",
             "status",
             "tool",
             "type"
           ],
+          "title": "McpToolCallThreadItem",
+          "type": "object"
+        },
+        {
           "properties": {
             "arguments": true,
             "contentItems": {
+              "items": {
+                "$ref": "#/definitions/DynamicToolCallOutputContentItem"
+              },
               "type": [
                 "array",
                 "null"
-              ],
-              "items": {
-                "$ref": "#/definitions/DynamicToolCallOutputContentItem"
-              }
+              ]
             },
             "durationMs": {
               "description": "The duration of the dynamic tool call in milliseconds.",
+              "format": "int64",
               "type": [
                 "integer",
                 "null"
-              ],
-              "format": "int64"
+              ]
             },
             "id": {
               "type": "string"
@@ -1042,33 +1038,31 @@
               "type": "string"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "dynamicToolCall"
               ],
-              "title": "DynamicToolCallThreadItemType"
+              "title": "DynamicToolCallThreadItemType",
+              "type": "string"
             }
           },
-          "title": "DynamicToolCallThreadItem"
-        },
-        {
-          "type": "object",
           "required": [
-            "agentsStates",
+            "arguments",
             "id",
-            "receiverThreadIds",
-            "senderThreadId",
             "status",
             "tool",
             "type"
           ],
+          "title": "DynamicToolCallThreadItem",
+          "type": "object"
+        },
+        {
           "properties": {
             "agentsStates": {
-              "description": "Last known status of the target agents, when available.",
-              "type": "object",
               "additionalProperties": {
                 "$ref": "#/definitions/CollabAgentState"
-              }
+              },
+              "description": "Last known status of the target agents, when available.",
+              "type": "object"
             },
             "id": {
               "description": "Unique identifier for this collab tool call.",
@@ -1089,7 +1083,6 @@
               ]
             },
             "reasoningEffort": {
-              "description": "Reasoning effort requested for the spawned agent, when applicable.",
               "anyOf": [
                 {
                   "$ref": "#/definitions/ReasoningEffort"
@@ -1097,52 +1090,57 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Reasoning effort requested for the spawned agent, when applicable."
             },
             "receiverThreadIds": {
               "description": "Thread ID of the receiving agent, when applicable. In case of spawn operation, this corresponds to the newly spawned agent.",
-              "type": "array",
               "items": {
                 "type": "string"
-              }
+              },
+              "type": "array"
             },
             "senderThreadId": {
               "description": "Thread ID of the agent issuing the collab request.",
               "type": "string"
             },
             "status": {
-              "description": "Current status of the collab tool call.",
               "allOf": [
                 {
                   "$ref": "#/definitions/CollabAgentToolCallStatus"
                 }
-              ]
+              ],
+              "description": "Current status of the collab tool call."
             },
             "tool": {
-              "description": "Name of the collab tool that was invoked.",
               "allOf": [
                 {
                   "$ref": "#/definitions/CollabAgentTool"
                 }
-              ]
+              ],
+              "description": "Name of the collab tool that was invoked."
             },
             "type": {
-              "type": "string",
               "enum": [
                 "collabAgentToolCall"
               ],
-              "title": "CollabAgentToolCallThreadItemType"
+              "title": "CollabAgentToolCallThreadItemType",
+              "type": "string"
             }
           },
-          "title": "CollabAgentToolCallThreadItem"
-        },
-        {
-          "type": "object",
           "required": [
+            "agentsStates",
             "id",
-            "query",
+            "receiverThreadIds",
+            "senderThreadId",
+            "status",
+            "tool",
             "type"
           ],
+          "title": "CollabAgentToolCallThreadItem",
+          "type": "object"
+        },
+        {
           "properties": {
             "action": {
               "anyOf": [
@@ -1161,22 +1159,22 @@
               "type": "string"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "webSearch"
               ],
-              "title": "WebSearchThreadItemType"
+              "title": "WebSearchThreadItemType",
+              "type": "string"
             }
           },
-          "title": "WebSearchThreadItem"
-        },
-        {
-          "type": "object",
           "required": [
             "id",
-            "path",
+            "query",
             "type"
           ],
+          "title": "WebSearchThreadItem",
+          "type": "object"
+        },
+        {
           "properties": {
             "id": {
               "type": "string"
@@ -1185,23 +1183,22 @@
               "$ref": "#/definitions/AbsolutePathBuf"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "imageView"
               ],
-              "title": "ImageViewThreadItemType"
+              "title": "ImageViewThreadItemType",
+              "type": "string"
             }
           },
-          "title": "ImageViewThreadItem"
-        },
-        {
-          "type": "object",
           "required": [
             "id",
-            "result",
-            "status",
+            "path",
             "type"
           ],
+          "title": "ImageViewThreadItem",
+          "type": "object"
+        },
+        {
           "properties": {
             "id": {
               "type": "string"
@@ -1229,22 +1226,23 @@
               "type": "string"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "imageGeneration"
               ],
-              "title": "ImageGenerationThreadItemType"
+              "title": "ImageGenerationThreadItemType",
+              "type": "string"
             }
           },
-          "title": "ImageGenerationThreadItem"
-        },
-        {
-          "type": "object",
           "required": [
             "id",
-            "review",
+            "result",
+            "status",
             "type"
           ],
+          "title": "ImageGenerationThreadItem",
+          "type": "object"
+        },
+        {
           "properties": {
             "id": {
               "type": "string"
@@ -1253,22 +1251,22 @@
               "type": "string"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "enteredReviewMode"
               ],
-              "title": "EnteredReviewModeThreadItemType"
+              "title": "EnteredReviewModeThreadItemType",
+              "type": "string"
             }
           },
-          "title": "EnteredReviewModeThreadItem"
-        },
-        {
-          "type": "object",
           "required": [
             "id",
             "review",
             "type"
           ],
+          "title": "EnteredReviewModeThreadItem",
+          "type": "object"
+        },
+        {
           "properties": {
             "id": {
               "type": "string"
@@ -1277,63 +1275,62 @@
               "type": "string"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "exitedReviewMode"
               ],
-              "title": "ExitedReviewModeThreadItemType"
+              "title": "ExitedReviewModeThreadItemType",
+              "type": "string"
             }
           },
-          "title": "ExitedReviewModeThreadItem"
-        },
-        {
-          "type": "object",
           "required": [
             "id",
+            "review",
             "type"
           ],
+          "title": "ExitedReviewModeThreadItem",
+          "type": "object"
+        },
+        {
           "properties": {
             "id": {
               "type": "string"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "contextCompaction"
               ],
-              "title": "ContextCompactionThreadItemType"
+              "title": "ContextCompactionThreadItemType",
+              "type": "string"
             }
           },
-          "title": "ContextCompactionThreadItem"
+          "required": [
+            "id",
+            "type"
+          ],
+          "title": "ContextCompactionThreadItem",
+          "type": "object"
         }
       ]
     },
     "Turn": {
-      "type": "object",
-      "required": [
-        "id",
-        "items",
-        "status"
-      ],
       "properties": {
         "completedAt": {
           "description": "Unix timestamp (in seconds) when the turn completed.",
+          "format": "int64",
           "type": [
             "integer",
             "null"
-          ],
-          "format": "int64"
+          ]
         },
         "durationMs": {
           "description": "Duration between turn start and completion in milliseconds, if known.",
+          "format": "int64",
           "type": [
             "integer",
             "null"
-          ],
-          "format": "int64"
+          ]
         },
         "error": {
-          "description": "Only populated when the Turn's status is failed.",
           "anyOf": [
             {
               "$ref": "#/definitions/TurnError"
@@ -1341,45 +1338,48 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Only populated when the Turn's status is failed."
         },
         "id": {
           "type": "string"
         },
         "items": {
           "description": "Thread items currently included in this turn payload.",
-          "type": "array",
           "items": {
             "$ref": "#/definitions/ThreadItem"
-          }
+          },
+          "type": "array"
         },
         "itemsView": {
-          "description": "Describes how much of `items` has been loaded for this turn.",
-          "default": "full",
           "allOf": [
             {
               "$ref": "#/definitions/TurnItemsView"
             }
-          ]
+          ],
+          "default": "full",
+          "description": "Describes how much of `items` has been loaded for this turn."
         },
         "startedAt": {
           "description": "Unix timestamp (in seconds) when the turn started.",
+          "format": "int64",
           "type": [
             "integer",
             "null"
-          ],
-          "format": "int64"
+          ]
         },
         "status": {
           "$ref": "#/definitions/TurnStatus"
         }
-      }
+      },
+      "required": [
+        "id",
+        "items",
+        "status"
+      ],
+      "type": "object"
     },
     "TurnError": {
-      "type": "object",
-      "required": [
-        "message"
-      ],
       "properties": {
         "additionalDetails": {
           "default": null,
@@ -1401,81 +1401,79 @@
         "message": {
           "type": "string"
         }
-      }
+      },
+      "required": [
+        "message"
+      ],
+      "type": "object"
     },
     "TurnItemsView": {
       "oneOf": [
         {
           "description": "`items` was not loaded for this turn. The field is intentionally empty.",
-          "type": "string",
           "enum": [
             "notLoaded"
-          ]
+          ],
+          "type": "string"
         },
         {
           "description": "`items` contains only a display summary for this turn.",
-          "type": "string",
           "enum": [
             "summary"
-          ]
+          ],
+          "type": "string"
         },
         {
           "description": "`items` contains every ThreadItem available from persisted app-server history for this turn.",
-          "type": "string",
           "enum": [
             "full"
-          ]
+          ],
+          "type": "string"
         }
       ]
     },
     "TurnStatus": {
-      "type": "string",
       "enum": [
         "completed",
         "interrupted",
         "failed",
         "inProgress"
-      ]
+      ],
+      "type": "string"
     },
     "UserInput": {
       "oneOf": [
         {
-          "type": "object",
-          "required": [
-            "text",
-            "type"
-          ],
           "properties": {
             "text": {
               "type": "string"
             },
             "text_elements": {
-              "description": "UI-defined spans within `text` used to render or persist special elements.",
               "default": [],
-              "type": "array",
+              "description": "UI-defined spans within `text` used to render or persist special elements.",
               "items": {
                 "$ref": "#/definitions/TextElement"
-              }
+              },
+              "type": "array"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "text"
               ],
-              "title": "TextUserInputType"
+              "title": "TextUserInputType",
+              "type": "string"
             }
           },
-          "title": "TextUserInput"
+          "required": [
+            "text",
+            "type"
+          ],
+          "title": "TextUserInput",
+          "type": "object"
         },
         {
-          "type": "object",
-          "required": [
-            "type",
-            "url"
-          ],
           "properties": {
             "detail": {
-              "default": null,
               "anyOf": [
                 {
                   "$ref": "#/definitions/ImageDetail"
@@ -1483,30 +1481,30 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "default": null
             },
             "type": {
-              "type": "string",
               "enum": [
                 "image"
               ],
-              "title": "ImageUserInputType"
+              "title": "ImageUserInputType",
+              "type": "string"
             },
             "url": {
               "type": "string"
             }
           },
-          "title": "ImageUserInput"
+          "required": [
+            "type",
+            "url"
+          ],
+          "title": "ImageUserInput",
+          "type": "object"
         },
         {
-          "type": "object",
-          "required": [
-            "path",
-            "type"
-          ],
           "properties": {
             "detail": {
-              "default": null,
               "anyOf": [
                 {
                   "$ref": "#/definitions/ImageDetail"
@@ -1514,28 +1512,28 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "default": null
             },
             "path": {
               "type": "string"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "localImage"
               ],
-              "title": "LocalImageUserInputType"
+              "title": "LocalImageUserInputType",
+              "type": "string"
             }
           },
-          "title": "LocalImageUserInput"
-        },
-        {
-          "type": "object",
           "required": [
-            "name",
             "path",
             "type"
           ],
+          "title": "LocalImageUserInput",
+          "type": "object"
+        },
+        {
           "properties": {
             "name": {
               "type": "string"
@@ -1544,22 +1542,22 @@
               "type": "string"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "skill"
               ],
-              "title": "SkillUserInputType"
+              "title": "SkillUserInputType",
+              "type": "string"
             }
           },
-          "title": "SkillUserInput"
-        },
-        {
-          "type": "object",
           "required": [
             "name",
             "path",
             "type"
           ],
+          "title": "SkillUserInput",
+          "type": "object"
+        },
+        {
           "properties": {
             "name": {
               "type": "string"
@@ -1568,33 +1566,35 @@
               "type": "string"
             },
             "type": {
-              "type": "string",
               "enum": [
                 "mention"
               ],
-              "title": "MentionUserInputType"
+              "title": "MentionUserInputType",
+              "type": "string"
             }
           },
-          "title": "MentionUserInput"
+          "required": [
+            "name",
+            "path",
+            "type"
+          ],
+          "title": "MentionUserInput",
+          "type": "object"
         }
       ]
     },
     "WebSearchAction": {
       "oneOf": [
         {
-          "type": "object",
-          "required": [
-            "type"
-          ],
           "properties": {
             "queries": {
+              "items": {
+                "type": "string"
+              },
               "type": [
                 "array",
                 "null"
-              ],
-              "items": {
-                "type": "string"
-              }
+              ]
             },
             "query": {
               "type": [
@@ -1603,27 +1603,27 @@
               ]
             },
             "type": {
-              "type": "string",
               "enum": [
                 "search"
               ],
-              "title": "SearchWebSearchActionType"
+              "title": "SearchWebSearchActionType",
+              "type": "string"
             }
           },
-          "title": "SearchWebSearchAction"
-        },
-        {
-          "type": "object",
           "required": [
             "type"
           ],
+          "title": "SearchWebSearchAction",
+          "type": "object"
+        },
+        {
           "properties": {
             "type": {
-              "type": "string",
               "enum": [
                 "openPage"
               ],
-              "title": "OpenPageWebSearchActionType"
+              "title": "OpenPageWebSearchActionType",
+              "type": "string"
             },
             "url": {
               "type": [
@@ -1632,13 +1632,13 @@
               ]
             }
           },
-          "title": "OpenPageWebSearchAction"
-        },
-        {
-          "type": "object",
           "required": [
             "type"
           ],
+          "title": "OpenPageWebSearchAction",
+          "type": "object"
+        },
+        {
           "properties": {
             "pattern": {
               "type": [
@@ -1647,11 +1647,11 @@
               ]
             },
             "type": {
-              "type": "string",
               "enum": [
                 "findInPage"
               ],
-              "title": "FindInPageWebSearchActionType"
+              "title": "FindInPageWebSearchActionType",
+              "type": "string"
             },
             "url": {
               "type": [
@@ -1660,25 +1660,39 @@
               ]
             }
           },
-          "title": "FindInPageWebSearchAction"
-        },
-        {
-          "type": "object",
           "required": [
             "type"
           ],
+          "title": "FindInPageWebSearchAction",
+          "type": "object"
+        },
+        {
           "properties": {
             "type": {
-              "type": "string",
               "enum": [
                 "other"
               ],
-              "title": "OtherWebSearchActionType"
+              "title": "OtherWebSearchActionType",
+              "type": "string"
             }
           },
-          "title": "OtherWebSearchAction"
+          "required": [
+            "type"
+          ],
+          "title": "OtherWebSearchAction",
+          "type": "object"
         }
       ]
     }
-  }
+  },
+  "properties": {
+    "turn": {
+      "$ref": "#/definitions/Turn"
+    }
+  },
+  "required": [
+    "turn"
+  ],
+  "title": "TurnStartResponse",
+  "type": "object"
 }

--- a/extensions/codex/src/app-server/protocol.ts
+++ b/extensions/codex/src/app-server/protocol.ts
@@ -90,6 +90,7 @@ export type CodexThreadStartParams = JsonObject & {
   developerInstructions?: string;
   experimentalRawEvents?: boolean;
   environments?: CodexTurnEnvironmentParams[] | null;
+  /** Retired by Codex 0.137, but still sent for supported custom app-server 0.125-0.136. */
   persistExtendedHistory?: boolean;
 };
 
@@ -104,6 +105,7 @@ export type CodexThreadResumeParams = JsonObject & {
   serviceTier?: CodexServiceTier | null;
   config?: JsonObject;
   developerInstructions?: string;
+  /** Retired by Codex 0.137, but still sent for supported custom app-server 0.125-0.136. */
   persistExtendedHistory?: boolean;
 };
 

--- a/extensions/codex/src/app-server/version.ts
+++ b/extensions/codex/src/app-server/version.ts
@@ -9,4 +9,4 @@ export const MIN_CODEX_SANDBOX_EXEC_SERVER_APP_SERVER_VERSION = "0.132.0";
 export const MANAGED_CODEX_APP_SERVER_PACKAGE = "@openai/codex";
 // Keep this in sync with the Codex CLI live-test package pin.
 /** Managed Codex app-server package version installed by OpenClaw. */
-export const MANAGED_CODEX_APP_SERVER_PACKAGE_VERSION = "0.135.0";
+export const MANAGED_CODEX_APP_SERVER_PACKAGE_VERSION = "0.137.0";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -514,8 +514,8 @@ importers:
   extensions/codex:
     dependencies:
       '@openai/codex':
-        specifier: 0.135.0
-        version: 0.135.0
+        specifier: 0.137.0
+        version: 0.137.0
       typebox:
         specifier: 1.1.39
         version: 1.1.39
@@ -2995,43 +2995,43 @@ packages:
     resolution: {integrity: sha512-tlc/FcYIv5i8RYsl2iDil4A0gOihaas1R5jPcIC4Zw3GhjKsVilw90aHcVlhZPTBLGBzd379S+VcnsDjd9ChiA==}
     engines: {node: '>=12.4.0'}
 
-  '@openai/codex@0.135.0':
-    resolution: {integrity: sha512-ID75QEYmAT1WsUQmpxPlNsL5W1a+2eeD7fP6ywdwGseiXUG8D5i16L+dzbr8MT+2oTkaVqzOdvAqVOCeV/H/Bw==}
+  '@openai/codex@0.137.0':
+    resolution: {integrity: sha512-1jUsCnzDBwv7Z4VFZajIlsz41fC18qg6d5qK4PEZhiUk0zJHS90/uGBA70aQPUJLTUZShvyKVAANjw6J/D9eYQ==}
     engines: {node: '>=16'}
     hasBin: true
 
-  '@openai/codex@0.135.0-darwin-arm64':
-    resolution: {integrity: sha512-wpNzssusKfrldVlq39+HyQh1wCyc9SQNpHdAFGKtPenrgRte4Ct8/oVsDtKWuFZsqLBFwbL4MrzrevnB63+9HA==}
+  '@openai/codex@0.137.0-darwin-arm64':
+    resolution: {integrity: sha512-YjKmre7DlKslQVhSfocHscgxntZKaZc1LQySKh7q+hNL8jdK+c8nSWSePi583yKFNIxZ8Z/zCkewtjFNvOpQiQ==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
 
-  '@openai/codex@0.135.0-darwin-x64':
-    resolution: {integrity: sha512-ZrjAqce23lbv9KfkYOhElf1lTI+SysXmyGM0FV5u4+PBCKPkkEs4eaS3H8Uig0i4bUSu1QylrOOCskzYhZ6VyQ==}
+  '@openai/codex@0.137.0-darwin-x64':
+    resolution: {integrity: sha512-zjzrFV80LZby9et44dan82e3cwUd46U7u1LSVXTIz5AUcY4y1KZpAeN6cSLVKMZuOHXTDpi15MUQdRwzdeqIOg==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
 
-  '@openai/codex@0.135.0-linux-arm64':
-    resolution: {integrity: sha512-dM+cv5ZL+BgIQzEIvMg9AxZ98n5lkKLgtp5zJLXWSrbCllbnUSqxYMUiWI5c1a1uBDUtkbY9fcGKXFLf+d+gyg==}
+  '@openai/codex@0.137.0-linux-arm64':
+    resolution: {integrity: sha512-R3ZZymQQA1qpp6OpowN49XJ4scHwSckq7CjVvgmLv3bIs3X+F0XXK3xPFkC9vs2mX3wPekPi3ONpxx+yPAsJ6Q==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
 
-  '@openai/codex@0.135.0-linux-x64':
-    resolution: {integrity: sha512-5EosY67yU28UJSnl/obdN2F1CDaimYbzm9SLR8dwwzkeBBnY6dHgAKJ2GTu9Nc8CmgmtVFBGzgPqehsIcueVvA==}
+  '@openai/codex@0.137.0-linux-x64':
+    resolution: {integrity: sha512-n+26MUj8rekbEDUeYTGoD6HXuGS0MmLHn2LOn0i5qTNYIJvXV82B7cCLSTzVKF/RJxRMRl22se9Q0Z035JIVng==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
 
-  '@openai/codex@0.135.0-win32-arm64':
-    resolution: {integrity: sha512-SAeR+CUv7KWwE6eTc2UFaFjo6FpHywYfDFKrK6FqLms1rq1NPju2SoX7rhM6UEew/lUx2mdZv/LDs11s/N/Qgg==}
+  '@openai/codex@0.137.0-win32-arm64':
+    resolution: {integrity: sha512-Cofktt213TycdQ/v+nAUuwXUBzjMWfA/ZkXyqefyXxDgw0TMtaiM3cgDna3I8YdXnR0PM9AMbx4t7VloJ3ZZYQ==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [win32]
 
-  '@openai/codex@0.135.0-win32-x64':
-    resolution: {integrity: sha512-uYwUBMbOfmVlCESJZmZsOG+cYwNFYvkMbQ+FB6C1u9RYz0m3mZeYNN0j+l1hRSyUgPMFJHzNpgNx1Usal5QZFQ==}
+  '@openai/codex@0.137.0-win32-x64':
+    resolution: {integrity: sha512-g9qZ9ERrm5OWXMWJOgojYv1kOc5jajTKq37PBMSe56aJfAr9Jk/qBvIOy7LKq3rABdXuz8k+W65PIt2E1hXilw==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -8570,31 +8570,31 @@ snapshots:
 
   '@nolyfill/domexception@1.0.28': {}
 
-  '@openai/codex@0.135.0':
+  '@openai/codex@0.137.0':
     optionalDependencies:
-      '@openai/codex-darwin-arm64': '@openai/codex@0.135.0-darwin-arm64'
-      '@openai/codex-darwin-x64': '@openai/codex@0.135.0-darwin-x64'
-      '@openai/codex-linux-arm64': '@openai/codex@0.135.0-linux-arm64'
-      '@openai/codex-linux-x64': '@openai/codex@0.135.0-linux-x64'
-      '@openai/codex-win32-arm64': '@openai/codex@0.135.0-win32-arm64'
-      '@openai/codex-win32-x64': '@openai/codex@0.135.0-win32-x64'
+      '@openai/codex-darwin-arm64': '@openai/codex@0.137.0-darwin-arm64'
+      '@openai/codex-darwin-x64': '@openai/codex@0.137.0-darwin-x64'
+      '@openai/codex-linux-arm64': '@openai/codex@0.137.0-linux-arm64'
+      '@openai/codex-linux-x64': '@openai/codex@0.137.0-linux-x64'
+      '@openai/codex-win32-arm64': '@openai/codex@0.137.0-win32-arm64'
+      '@openai/codex-win32-x64': '@openai/codex@0.137.0-win32-x64'
 
-  '@openai/codex@0.135.0-darwin-arm64':
+  '@openai/codex@0.137.0-darwin-arm64':
     optional: true
 
-  '@openai/codex@0.135.0-darwin-x64':
+  '@openai/codex@0.137.0-darwin-x64':
     optional: true
 
-  '@openai/codex@0.135.0-linux-arm64':
+  '@openai/codex@0.137.0-linux-arm64':
     optional: true
 
-  '@openai/codex@0.135.0-linux-x64':
+  '@openai/codex@0.137.0-linux-x64':
     optional: true
 
-  '@openai/codex@0.135.0-win32-arm64':
+  '@openai/codex@0.137.0-win32-arm64':
     optional: true
 
-  '@openai/codex@0.135.0-win32-x64':
+  '@openai/codex@0.137.0-win32-x64':
     optional: true
 
   '@openclaw/fs-safe@0.3.0':

--- a/scripts/check-codex-app-server-protocol.ts
+++ b/scripts/check-codex-app-server-protocol.ts
@@ -47,8 +47,7 @@ const checks: Array<{ file: string; snippets: string[] }> = [
     snippets: [
       "permissions?: string | null",
       "dynamicTools?: Array<DynamicToolSpec> | null",
-      "experimentalRawEvents: boolean",
-      "persistExtendedHistory: boolean",
+      "experimentalRawEvents",
     ],
   },
   {


### PR DESCRIPTION
## Summary

- Bump the managed Codex app-server package from `@openai/codex` `0.135.0` to `0.137.0` in the Codex plugin manifest, pnpm lockfile, npm shrinkwrap, and managed runtime version constant.
- Refresh the Codex app-server generated protocol JSON from the `rust-v0.137.0` exporter output, including the new `ThreadStartResponse` / `ThreadResumeResponse` fields.
- Refresh the Codex harness docs model-list snapshot from a `@openai/codex@0.137.0` app-server `model/list` probe; the visible catalog no longer includes `gpt-5.3-codex-spark`.
- Keep sending `persistExtendedHistory` for custom supported Codex app-server binaries below `0.137.0`; the field is retired from the current generated schema but still matters for OpenClaw's `0.125.0` support floor.

## Dependency Contract Proof

- Checked upstream `../codex` at `rust-v0.137.0` (`f221438b69`).
- Checked `../codex/codex-rs/app-server-protocol/schema/typescript/v2/ModelListResponse.ts:6` and `../codex/codex-rs/app-server-protocol/schema/typescript/v2/Model.ts:11` for the `model/list` response shape, including `defaultServiceTier` at `../codex/codex-rs/app-server-protocol/schema/typescript/v2/Model.ts:16`.
- Checked `../codex/codex-rs/app-server-protocol/src/protocol/v2/thread.rs:162`, `../codex/codex-rs/app-server-protocol/src/protocol/v2/thread.rs:189`, and `../codex/codex-rs/app-server-protocol/src/protocol/v2/thread.rs:404` for `experimentalRawEvents`, `ThreadStartResponse`, and `ThreadResumeResponse`.
- Checked `../codex/codex-rs/app-server/src/request_processors/thread_processor.rs:2453` and `../codex/codex-rs/app-server/src/request_processors/thread_processor.rs:2473` for the current resume behavior: `include_turns = !exclude_turns`.

## Verification

- `pnpm docs:list`
- `pnpm docs:check-mdx`
- `git diff --check`
- Generated protocol JSON parse check over `extensions/codex/src/app-server/protocol-generated/json/**`.
- `node scripts/run-vitest.mjs extensions/codex/src/manifest.test.ts extensions/codex/src/app-server/protocol-validators.test.ts extensions/codex/src/app-server/models.test.ts extensions/codex/provider.test.ts`
- `node scripts/run-vitest.mjs extensions/codex/src/app-server/protocol-validators.test.ts extensions/codex/src/app-server/schema-normalization-runtime-contract.test.ts extensions/codex/src/app-server/thread-lifecycle.test.ts extensions/codex/src/app-server/run-attempt.test.ts extensions/codex/src/commands.test.ts extensions/codex/src/conversation-binding.test.ts extensions/codex/src/conversation-control.test.ts`
- Testbox-through-Crabbox `tbx_01ktmhbktzjg0y3ttsgxm4mneg`, Actions `27167357512`: `pnpm codex-app-server:protocol:check` passed against a fresh `rust-v0.137.0` Codex checkout; `check:changed` passed; full `node scripts/run-vitest.mjs extensions/codex` passed with 86 files / 1340 tests.
- Testbox-through-Crabbox `tbx_01ktmj23d0ap35pmn2vrecw7j8`, Actions `27167977560`: `npx -y @openai/codex@0.137.0 --version` returned `codex-cli 0.137.0`; raw `app-server --listen stdio://` initialize + `model/list` smoke returned app-server `0.137.0` and visible models including `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.3-codex`, and `gpt-5.2`.
- Testbox-through-Crabbox `tbx_01ktmj70qamc96697s82dg881t`, Actions `27168107320`: Docker available, package build/tarball integrity passed, and `corepack pnpm test:docker:codex-on-demand` passed.
- `.agents/skills/autoreview/scripts/autoreview --mode local`: first run found the `persistExtendedHistory` compatibility issue; after keeping the field for older custom app-server support, rerun was clean with no accepted/actionable findings.

## Notes

- `dependency-guard` intentionally still requires maintainer/security approval for the current head because this PR changes the managed executable Codex dependency and lock surfaces.
