### PR TITLE
fix(cron): preserve scheduled turn tool policy [AI]

### DIFF
--- a/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
+++ b/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
@@ -739,6 +739,60 @@ describe("createOpenClawCodingTools", () => {
     expect(inheritedAllow?.includes("process")).toBe(false);
   });
 
+  it("passes group-restricted tool surface to cron-created agent turns", () => {
+    const createOpenClawToolsMock = vi.mocked(createOpenClawTools);
+    createOpenClawToolsMock.mockClear();
+
+    createOpenClawCodingTools({
+      sessionKey: "agent:main:whatsapp:group:restricted-room",
+      config: {
+        tools: { allow: ["read", "exec", "process", "cron"] },
+        channels: {
+          whatsapp: {
+            groups: {
+              "restricted-room": {
+                tools: { allow: ["read", "cron"] },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(createOpenClawToolsMock).toHaveBeenCalledTimes(1);
+    const cronAllow = latestCreateOpenClawToolsOptions().cronCreatorToolAllowlist;
+    expectListIncludes(cronAllow, ["read", "cron"]);
+    expect(cronAllow?.includes("exec")).toBe(false);
+    expect(cronAllow?.includes("process")).toBe(false);
+  });
+
+  it("passes deny-restricted tool surface to cron-created agent turns", () => {
+    const createOpenClawToolsMock = vi.mocked(createOpenClawTools);
+    createOpenClawToolsMock.mockClear();
+
+    createOpenClawCodingTools({
+      sessionKey: "agent:main:whatsapp:group:restricted-room",
+      config: {
+        tools: { allow: ["read", "exec", "process", "cron"] },
+        channels: {
+          whatsapp: {
+            groups: {
+              "restricted-room": {
+                tools: { deny: ["exec", "process"] },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(createOpenClawToolsMock).toHaveBeenCalledTimes(1);
+    const cronAllow = latestCreateOpenClawToolsOptions().cronCreatorToolAllowlist;
+    expectListIncludes(cronAllow, ["read", "cron"]);
+    expect(cronAllow?.includes("exec")).toBe(false);
+    expect(cronAllow?.includes("process")).toBe(false);
+  });
+
   it("records core tool-prep stages for hot-path diagnostics", () => {
     const stages: string[] = [];
 

--- a/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
+++ b/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
@@ -27,9 +27,11 @@ import * as openClawPluginTools from "./openclaw-plugin-tools.js";
 import { createOpenClawTools } from "./openclaw-tools.js";
 import { expectReadWriteEditTools } from "./test-helpers/agent-tools-fs-helpers.js";
 import { createAgentToolsSandboxContext } from "./test-helpers/agent-tools-sandbox-context.js";
+import { stubTool } from "./test-helpers/fast-tool-stubs.js";
 import { createHostSandboxFsBridge } from "./test-helpers/host-sandbox-fs-bridge.js";
 import { buildEmptyExplicitToolAllowlistError } from "./tool-allowlist-guard.js";
 import { DEFAULT_PLUGIN_TOOLS_ALLOWLIST_ENTRY, normalizeToolName } from "./tool-policy.js";
+import { replaceWithEffectiveCronCreatorToolAllowlist } from "./tools/cron-tool.js";
 
 const tinyPngBuffer = Buffer.from(
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO2f7z8AAAAASUVORK5CYII=",
@@ -771,6 +773,32 @@ describe("createOpenClawCodingTools", () => {
     expectListIncludes(cronAllowNames, ["read", "cron"]);
     expect(cronAllowNames?.includes("exec")).toBe(false);
     expect(cronAllowNames?.includes("process")).toBe(false);
+  });
+
+  it("lets embedded attempts refresh a caller-owned cron creator tool surface", () => {
+    const createOpenClawToolsMock = vi.mocked(createOpenClawTools);
+    createOpenClawToolsMock.mockClear();
+    const cronCreatorToolAllowlistRef: NonNullable<
+      OpenClawToolsOptions["cronCreatorToolAllowlist"]
+    > = [];
+
+    createOpenClawCodingTools({
+      config: { tools: { allow: ["read", "cron"] } },
+      cronCreatorToolAllowlistRef,
+    });
+
+    expect(createOpenClawToolsMock).toHaveBeenCalledTimes(1);
+    const cronAllow = latestCreateOpenClawToolsOptions().cronCreatorToolAllowlist;
+    expect(cronAllow).toBe(cronCreatorToolAllowlistRef);
+    expect(cronCreatorToolNames(cronAllow)).toEqual(["read", "cron"]);
+
+    replaceWithEffectiveCronCreatorToolAllowlist(cronCreatorToolAllowlistRef, [
+      stubTool("read"),
+      stubTool("cron"),
+      stubTool("bundle_mcp_search"),
+    ]);
+
+    expect(cronCreatorToolNames(cronAllow)).toEqual(["read", "cron", "bundle_mcp_search"]);
   });
 
   it("passes deny-restricted tool surface to cron-created agent turns", () => {

--- a/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
+++ b/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
@@ -154,6 +154,12 @@ function expectListIncludes(
   }
 }
 
+function cronCreatorToolNames(
+  list: OpenClawToolsOptions["cronCreatorToolAllowlist"] | undefined,
+): string[] | undefined {
+  return list?.map((entry) => (typeof entry === "string" ? entry : entry.name));
+}
+
 describe("createOpenClawCodingTools", () => {
   const testConfig: OpenClawConfig = {};
 
@@ -761,9 +767,10 @@ describe("createOpenClawCodingTools", () => {
 
     expect(createOpenClawToolsMock).toHaveBeenCalledTimes(1);
     const cronAllow = latestCreateOpenClawToolsOptions().cronCreatorToolAllowlist;
-    expectListIncludes(cronAllow, ["read", "cron"]);
-    expect(cronAllow?.includes("exec")).toBe(false);
-    expect(cronAllow?.includes("process")).toBe(false);
+    const cronAllowNames = cronCreatorToolNames(cronAllow);
+    expectListIncludes(cronAllowNames, ["read", "cron"]);
+    expect(cronAllowNames?.includes("exec")).toBe(false);
+    expect(cronAllowNames?.includes("process")).toBe(false);
   });
 
   it("passes deny-restricted tool surface to cron-created agent turns", () => {
@@ -788,9 +795,10 @@ describe("createOpenClawCodingTools", () => {
 
     expect(createOpenClawToolsMock).toHaveBeenCalledTimes(1);
     const cronAllow = latestCreateOpenClawToolsOptions().cronCreatorToolAllowlist;
-    expectListIncludes(cronAllow, ["read", "cron"]);
-    expect(cronAllow?.includes("exec")).toBe(false);
-    expect(cronAllow?.includes("process")).toBe(false);
+    const cronAllowNames = cronCreatorToolNames(cronAllow);
+    expectListIncludes(cronAllowNames, ["read", "cron"]);
+    expect(cronAllowNames?.includes("exec")).toBe(false);
+    expect(cronAllowNames?.includes("process")).toBe(false);
   });
 
   it("records core tool-prep stages for hot-path diagnostics", () => {

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -120,6 +120,10 @@ import { resolveWorkspaceRoot } from "./workspace-dir.js";
 
 const MEMORY_FLUSH_ALLOWED_TOOL_NAMES = new Set(["read", "write"]);
 
+function hasExplicitDenyPolicy(policy?: { deny?: string[] }): boolean {
+  return Array.isArray(policy?.deny) && policy.deny.some((entry) => entry.trim());
+}
+
 type GuardContainerMount = {
   containerRoot: string;
   hostRoot: string;
@@ -922,7 +926,7 @@ export function createOpenClawCodingTools(options?: {
   // Passed by reference to sessions_spawn and populated after the final policy
   // pass so child sessions inherit the actual parent tool surface.
   const inheritedToolAllowlist: string[] = [];
-  const shouldInheritEffectiveToolAllowlist = [
+  const toolPolicyInheritanceSources = [
     profilePolicy,
     providerProfilePolicy,
     globalPolicy,
@@ -935,7 +939,13 @@ export function createOpenClawCodingTools(options?: {
     subagentPolicy,
     inheritedToolPolicy,
     options?.runtimeToolAllowlist ? { allow: options.runtimeToolAllowlist } : undefined,
-  ].some(hasRestrictiveAllowPolicy);
+  ];
+  const shouldInheritEffectiveToolAllowlist =
+    toolPolicyInheritanceSources.some(hasRestrictiveAllowPolicy);
+  const cronCreatorToolAllowlist: string[] = [];
+  const shouldCaptureCronCreatorToolAllowlist = toolPolicyInheritanceSources.some(
+    (policy) => hasRestrictiveAllowPolicy(policy) || hasExplicitDenyPolicy(policy),
+  );
   const pluginToolsOnly =
     includeOpenClawTools || !includePluginTools
       ? []
@@ -1045,6 +1055,9 @@ export function createOpenClawCodingTools(options?: {
           config: options?.config,
           pluginToolAllowlist,
           pluginToolDenylist,
+          cronCreatorToolAllowlist: shouldCaptureCronCreatorToolAllowlist
+            ? cronCreatorToolAllowlist
+            : undefined,
           currentChannelId: options?.currentChannelId,
           currentMessagingTarget: options?.currentMessagingTarget,
           currentThreadTs: options?.currentThreadTs,
@@ -1164,6 +1177,9 @@ export function createOpenClawCodingTools(options?: {
   });
   if (shouldInheritEffectiveToolAllowlist) {
     replaceWithEffectiveToolAllowlist(inheritedToolAllowlist, subagentFiltered);
+  }
+  if (shouldCaptureCronCreatorToolAllowlist) {
+    replaceWithEffectiveToolAllowlist(cronCreatorToolAllowlist, subagentFiltered);
   }
   options?.recordToolPrepStage?.("authorization-policy");
   // Always normalize tool JSON Schemas before handing them to OpenClaw model runtime.

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -121,7 +121,34 @@ import { resolveWorkspaceRoot } from "./workspace-dir.js";
 const MEMORY_FLUSH_ALLOWED_TOOL_NAMES = new Set(["read", "write"]);
 
 function hasExplicitDenyPolicy(policy?: { deny?: string[] }): boolean {
-  return Array.isArray(policy?.deny) && policy.deny.some((entry) => entry.trim());
+  return (
+    Array.isArray(policy?.deny) &&
+    policy.deny.some((entry) => typeof entry === "string" && entry.trim())
+  );
+}
+
+type EffectiveCronCreatorTool = {
+  name: string;
+  pluginId?: string;
+};
+
+function replaceWithEffectiveCronCreatorToolAllowlist(
+  target: EffectiveCronCreatorTool[],
+  tools: AnyAgentTool[],
+): void {
+  target.length = 0;
+  const seen = new Set<string>();
+  for (const tool of tools) {
+    const name = normalizeToolName(tool.name);
+    if (!name || seen.has(name)) {
+      continue;
+    }
+    seen.add(name);
+    const meta = getPluginToolMeta(tool);
+    const pluginId =
+      typeof meta?.pluginId === "string" ? normalizeToolName(meta.pluginId) : undefined;
+    target.push(pluginId ? { name, pluginId } : { name });
+  }
 }
 
 type GuardContainerMount = {
@@ -942,7 +969,7 @@ export function createOpenClawCodingTools(options?: {
   ];
   const shouldInheritEffectiveToolAllowlist =
     toolPolicyInheritanceSources.some(hasRestrictiveAllowPolicy);
-  const cronCreatorToolAllowlist: string[] = [];
+  const cronCreatorToolAllowlist: EffectiveCronCreatorTool[] = [];
   const shouldCaptureCronCreatorToolAllowlist = toolPolicyInheritanceSources.some(
     (policy) => hasRestrictiveAllowPolicy(policy) || hasExplicitDenyPolicy(policy),
   );
@@ -1179,7 +1206,7 @@ export function createOpenClawCodingTools(options?: {
     replaceWithEffectiveToolAllowlist(inheritedToolAllowlist, subagentFiltered);
   }
   if (shouldCaptureCronCreatorToolAllowlist) {
-    replaceWithEffectiveToolAllowlist(cronCreatorToolAllowlist, subagentFiltered);
+    replaceWithEffectiveCronCreatorToolAllowlist(cronCreatorToolAllowlist, subagentFiltered);
   }
   options?.recordToolPrepStage?.("authorization-policy");
   // Always normalize tool JSON Schemas before handing them to OpenClaw model runtime.

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -527,6 +527,8 @@ export function createOpenClawCodingTools(options?: {
   allowGatewaySubagentBinding?: boolean;
   /** Runtime-scoped explicit allowlist used to materialize matching plugin tools. */
   runtimeToolAllowlist?: string[];
+  /** Mutable cron creator cap ref for callers that append final runtime tools later. */
+  cronCreatorToolAllowlistRef?: CronCreatorToolAllowlistEntry[];
   /** If true, the model has native vision capability */
   modelHasVision?: boolean;
   /** Require explicit message targets (no implicit last-route sends). */
@@ -949,7 +951,7 @@ export function createOpenClawCodingTools(options?: {
   ];
   const shouldInheritEffectiveToolAllowlist =
     toolPolicyInheritanceSources.some(hasRestrictiveAllowPolicy);
-  const cronCreatorToolAllowlist: CronCreatorToolAllowlistEntry[] = [];
+  const cronCreatorToolAllowlist = options?.cronCreatorToolAllowlistRef ?? [];
   const shouldCaptureCronCreatorToolAllowlist = toolPolicyInheritanceSources.some(
     (policy) => hasRestrictiveAllowPolicy(policy) || hasExplicitDenyPolicy(policy),
   );

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -116,6 +116,10 @@ import {
   type ToolSearchCatalogRef,
   type ToolSearchCatalogToolExecutor,
 } from "./tool-search.js";
+import {
+  replaceWithEffectiveCronCreatorToolAllowlist,
+  type CronCreatorToolAllowlistEntry,
+} from "./tools/cron-tool.js";
 import { resolveWorkspaceRoot } from "./workspace-dir.js";
 
 const MEMORY_FLUSH_ALLOWED_TOOL_NAMES = new Set(["read", "write"]);
@@ -125,30 +129,6 @@ function hasExplicitDenyPolicy(policy?: { deny?: string[] }): boolean {
     Array.isArray(policy?.deny) &&
     policy.deny.some((entry) => typeof entry === "string" && entry.trim())
   );
-}
-
-type EffectiveCronCreatorTool = {
-  name: string;
-  pluginId?: string;
-};
-
-function replaceWithEffectiveCronCreatorToolAllowlist(
-  target: EffectiveCronCreatorTool[],
-  tools: AnyAgentTool[],
-): void {
-  target.length = 0;
-  const seen = new Set<string>();
-  for (const tool of tools) {
-    const name = normalizeToolName(tool.name);
-    if (!name || seen.has(name)) {
-      continue;
-    }
-    seen.add(name);
-    const meta = getPluginToolMeta(tool);
-    const pluginId =
-      typeof meta?.pluginId === "string" ? normalizeToolName(meta.pluginId) : undefined;
-    target.push(pluginId ? { name, pluginId } : { name });
-  }
 }
 
 type GuardContainerMount = {
@@ -969,7 +949,7 @@ export function createOpenClawCodingTools(options?: {
   ];
   const shouldInheritEffectiveToolAllowlist =
     toolPolicyInheritanceSources.some(hasRestrictiveAllowPolicy);
-  const cronCreatorToolAllowlist: EffectiveCronCreatorTool[] = [];
+  const cronCreatorToolAllowlist: CronCreatorToolAllowlistEntry[] = [];
   const shouldCaptureCronCreatorToolAllowlist = toolPolicyInheritanceSources.some(
     (policy) => hasRestrictiveAllowPolicy(policy) || hasExplicitDenyPolicy(policy),
   );
@@ -1206,7 +1186,11 @@ export function createOpenClawCodingTools(options?: {
     replaceWithEffectiveToolAllowlist(inheritedToolAllowlist, subagentFiltered);
   }
   if (shouldCaptureCronCreatorToolAllowlist) {
-    replaceWithEffectiveCronCreatorToolAllowlist(cronCreatorToolAllowlist, subagentFiltered);
+    replaceWithEffectiveCronCreatorToolAllowlist(
+      cronCreatorToolAllowlist,
+      subagentFiltered,
+      (tool) => getPluginToolMeta(tool),
+    );
   }
   options?.recordToolPrepStage?.("authorization-policy");
   // Always normalize tool JSON Schemas before handing them to OpenClaw model runtime.

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -236,6 +236,10 @@ import {
   type ToolSearchCatalogToolExecutor,
   type ToolSearchTargetTranscriptProjection,
 } from "../../tool-search.js";
+import {
+  replaceWithEffectiveCronCreatorToolAllowlist,
+  type CronCreatorToolAllowlistEntry,
+} from "../../tools/cron-tool.js";
 import { shouldAllowProviderOwnedThinkingReplay } from "../../transcript-policy.js";
 import { normalizeUsage, type NormalizedUsage } from "../../usage.js";
 import { DEFAULT_BOOTSTRAP_FILENAME, type WorkspaceBootstrapFile } from "../../workspace.js";
@@ -1221,6 +1225,7 @@ export async function runEmbeddedAttempt(
         ? createToolSearchCatalogRef()
         : undefined;
     const toolSearchTargetTranscriptProjections: ToolSearchTargetTranscriptProjection[] = [];
+    const cronCreatorToolAllowlist: CronCreatorToolAllowlistEntry[] = [];
     const toolsRaw = !shouldConstructTools
       ? []
       : (() => {
@@ -1308,6 +1313,7 @@ export async function runEmbeddedAttempt(
             enableHeartbeatTool: params.enableHeartbeatTool,
             forceHeartbeatTool: params.forceHeartbeatTool,
             runtimeToolAllowlist: effectiveToolsAllow,
+            cronCreatorToolAllowlistRef: cronCreatorToolAllowlist,
             authProfileStore: params.authProfileStore,
             recordToolPrepStage: (name) => corePluginToolStages.mark(name),
             onToolOutcome: params.onToolOutcome,
@@ -1602,6 +1608,15 @@ export async function runEmbeddedAttempt(
       agentId: sessionAgentId,
       preserveToolNames: localModelLeanPreserveToolNames,
     });
+    if (cronCreatorToolAllowlist.length > 0) {
+      // Cron is constructed before bundled MCP/LSP tools are appended; refresh
+      // the shared cap so scheduled turns preserve the creator's full surface.
+      replaceWithEffectiveCronCreatorToolAllowlist(
+        cronCreatorToolAllowlist,
+        projectedUncompactedEffectiveTools,
+        (tool) => getPluginToolMeta(tool),
+      );
+    }
     const uncompactedToolSchemaProjection = filterRuntimeCompatibleTools(
       projectedUncompactedEffectiveTools,
     );

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -109,6 +109,8 @@ export function createOpenClawTools(
     config?: OpenClawConfig;
     pluginToolAllowlist?: string[];
     pluginToolDenylist?: string[];
+    /** Effective caller tool surface to persist on isolated cron agentTurn jobs. */
+    cronCreatorToolAllowlist?: string[];
     /** Current channel ID for auto-threading. */
     currentChannelId?: string;
     /** Routable target for the current conversation when it differs from the native channel ID. */
@@ -426,6 +428,7 @@ export function createOpenClawTools(
               accountId: options?.agentAccountId,
               threadId: options?.currentThreadTs ?? options?.agentThreadId,
             },
+            creatorToolAllowlist: options?.cronCreatorToolAllowlist,
             ...(options?.cronSelfRemoveOnlyJobId
               ? { selfRemoveOnlyJobId: options.cronSelfRemoveOnlyJobId }
               : {}),

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -41,7 +41,7 @@ import type { ToolFsPolicy } from "./tool-fs-policy.js";
 import { resolveToolLoopDetectionConfig } from "./tool-loop-detection-config.js";
 import { createAgentsListTool } from "./tools/agents-list-tool.js";
 import type { AnyAgentTool } from "./tools/common.js";
-import { createCronTool } from "./tools/cron-tool.js";
+import { createCronTool, type CronCreatorToolAllowlistEntry } from "./tools/cron-tool.js";
 import { createEmbeddedCallGateway } from "./tools/embedded-gateway-stub.js";
 import { createGatewayTool } from "./tools/gateway-tool.js";
 import {
@@ -110,7 +110,7 @@ export function createOpenClawTools(
     pluginToolAllowlist?: string[];
     pluginToolDenylist?: string[];
     /** Effective caller tool surface to persist on isolated cron agentTurn jobs. */
-    cronCreatorToolAllowlist?: string[];
+    cronCreatorToolAllowlist?: CronCreatorToolAllowlistEntry[];
     /** Current channel ID for auto-threading. */
     currentChannelId?: string;
     /** Routable target for the current conversation when it differs from the native channel ID. */

--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -900,6 +900,65 @@ describe("cron tool", () => {
     expect(params?.payload?.toolsAllow).toEqual(["read", "cron"]);
   });
 
+  it("expands plugin selectors against the creator tool surface on agentTurn adds", async () => {
+    const tool = createTestCronTool({
+      agentSessionKey: "agent:main:telegram:group:restricted-room",
+      creatorToolAllowlist: [
+        { name: "active_memory_search", pluginId: "active-memory" },
+        { name: "active_memory_store", pluginId: "active-memory" },
+        { name: "cron" },
+      ],
+    });
+
+    await tool.execute("call-capped-add-plugin-tools", {
+      action: "add",
+      job: {
+        ...buildReminderAgentTurnJob(),
+        payload: {
+          kind: "agentTurn",
+          message: "hello",
+          toolsAllow: ["active-memory", "cron", "exec"],
+        },
+      },
+    });
+
+    const params = expectSingleGatewayCallMethod("cron.add") as
+      | { payload?: { toolsAllow?: string[] } }
+      | undefined;
+    expect(params?.payload?.toolsAllow).toEqual([
+      "active_memory_search",
+      "active_memory_store",
+      "cron",
+    ]);
+  });
+
+  it("expands group:plugins against the creator tool surface on agentTurn adds", async () => {
+    const tool = createTestCronTool({
+      agentSessionKey: "agent:main:telegram:group:restricted-room",
+      creatorToolAllowlist: [
+        { name: "active_memory_search", pluginId: "active-memory" },
+        { name: "cron" },
+      ],
+    });
+
+    await tool.execute("call-capped-add-plugin-group", {
+      action: "add",
+      job: {
+        ...buildReminderAgentTurnJob(),
+        payload: {
+          kind: "agentTurn",
+          message: "hello",
+          toolsAllow: ["group:plugins"],
+        },
+      },
+    });
+
+    const params = expectSingleGatewayCallMethod("cron.add") as
+      | { payload?: { toolsAllow?: string[] } }
+      | undefined;
+    expect(params?.payload?.toolsAllow).toEqual(["active_memory_search"]);
+  });
+
   it("recovers concatenated cron add keys from local tool-call parsers", async () => {
     const tool = createTestCronTool();
     await tool.execute("call-concatenated-add", {
@@ -2017,6 +2076,44 @@ describe("cron tool", () => {
     expect(params?.patch?.payload).toEqual({
       kind: "agentTurn",
       toolsAllow: ["read", "cron"],
+    });
+  });
+
+  it("adds the creator tool surface when updating an existing agentTurn without a payload patch", async () => {
+    callGatewayMock
+      .mockResolvedValueOnce({
+        id: "job-9",
+        payload: { kind: "agentTurn", message: "hello" },
+      })
+      .mockResolvedValueOnce({ ok: true });
+
+    const tool = createTestCronTool({
+      agentSessionKey: "agent:main:telegram:group:restricted-room",
+      creatorToolAllowlist: ["read", "cron"],
+    });
+    await tool.execute("call-update-capped-no-payload", {
+      action: "update",
+      id: "job-9",
+      patch: { enabled: false },
+    });
+
+    expect(callGatewayMock).toHaveBeenCalledTimes(2);
+    expect(readGatewayCall(0)).toEqual({
+      method: "cron.get",
+      params: { id: "job-9" },
+    });
+    expect(readGatewayCall(1)).toEqual({
+      method: "cron.update",
+      params: {
+        id: "job-9",
+        patch: {
+          enabled: false,
+          payload: {
+            kind: "agentTurn",
+            toolsAllow: ["read", "cron"],
+          },
+        },
+      },
     });
   });
 

--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -859,6 +859,47 @@ describe("cron tool", () => {
     expect(params?.failureAlert).toEqual({ after: 3, cooldownMs: 60_000 });
   });
 
+  it("caps agentTurn add toolsAllow to the creator tool surface", async () => {
+    const tool = createTestCronTool({
+      agentSessionKey: "agent:main:telegram:group:restricted-room",
+      creatorToolAllowlist: ["read", "cron"],
+    });
+
+    await tool.execute("call-capped-add-tools", {
+      action: "add",
+      job: {
+        ...buildReminderAgentTurnJob(),
+        payload: {
+          kind: "agentTurn",
+          message: "hello",
+          toolsAllow: ["exec", "read"],
+        },
+      },
+    });
+
+    const params = expectSingleGatewayCallMethod("cron.add") as
+      | { payload?: { toolsAllow?: string[] } }
+      | undefined;
+    expect(params?.payload?.toolsAllow).toEqual(["read"]);
+  });
+
+  it("stores the creator tool surface on agentTurn adds without explicit toolsAllow", async () => {
+    const tool = createTestCronTool({
+      agentSessionKey: "agent:main:telegram:group:restricted-room",
+      creatorToolAllowlist: ["read", "cron"],
+    });
+
+    await tool.execute("call-default-capped-add-tools", {
+      action: "add",
+      job: buildReminderAgentTurnJob(),
+    });
+
+    const params = expectSingleGatewayCallMethod("cron.add") as
+      | { payload?: { toolsAllow?: string[] } }
+      | undefined;
+    expect(params?.payload?.toolsAllow).toEqual(["read", "cron"]);
+  });
+
   it("recovers concatenated cron add keys from local tool-call parsers", async () => {
     const tool = createTestCronTool();
     await tool.execute("call-concatenated-add", {
@@ -1909,6 +1950,73 @@ describe("cron tool", () => {
     expect(params?.patch?.payload).toEqual({
       kind: "agentTurn",
       toolsAllow: null,
+    });
+  });
+
+  it("caps agentTurn update toolsAllow to the creator tool surface", async () => {
+    callGatewayMock.mockResolvedValueOnce({ ok: true });
+
+    const tool = createTestCronTool({
+      agentSessionKey: "agent:main:telegram:group:restricted-room",
+      creatorToolAllowlist: ["read", "cron"],
+    });
+    await tool.execute("call-update-capped-tools", {
+      action: "update",
+      id: "job-7",
+      patch: {
+        payload: {
+          toolsAllow: [" exec ", " read "],
+        },
+      },
+    });
+
+    const params = expectSingleGatewayCallMethod("cron.update") as
+      | {
+          id?: string;
+          patch?: {
+            payload?: {
+              kind?: string;
+              toolsAllow?: string[];
+            };
+          };
+        }
+      | undefined;
+    expect(params?.patch?.payload).toEqual({
+      kind: "agentTurn",
+      toolsAllow: ["read"],
+    });
+  });
+
+  it("keeps the creator tool surface when an agentTurn update clears toolsAllow", async () => {
+    callGatewayMock.mockResolvedValueOnce({ ok: true });
+
+    const tool = createTestCronTool({
+      agentSessionKey: "agent:main:telegram:group:restricted-room",
+      creatorToolAllowlist: ["read", "cron"],
+    });
+    await tool.execute("call-update-capped-tools-clear", {
+      action: "update",
+      id: "job-8",
+      patch: {
+        payload: {
+          toolsAllow: null,
+        },
+      },
+    });
+
+    const params = expectSingleGatewayCallMethod("cron.update") as
+      | {
+          patch?: {
+            payload?: {
+              kind?: string;
+              toolsAllow?: string[];
+            };
+          };
+        }
+      | undefined;
+    expect(params?.patch?.payload).toEqual({
+      kind: "agentTurn",
+      toolsAllow: ["read", "cron"],
     });
   });
 

--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -2211,6 +2211,44 @@ describe("cron tool", () => {
     });
   });
 
+  it("adds the creator tool surface when converting an existing job to agentTurn", async () => {
+    callGatewayMock
+      .mockResolvedValueOnce({
+        id: "job-12",
+        payload: { kind: "systemEvent", text: "hello" },
+      })
+      .mockResolvedValueOnce({ ok: true });
+
+    const tool = createTestCronTool({
+      agentSessionKey: "agent:main:telegram:group:restricted-room",
+      creatorToolAllowlist: ["read", "cron"],
+    });
+    await tool.execute("call-update-convert-capped-agent-turn", {
+      action: "update",
+      id: "job-12",
+      patch: {
+        sessionTarget: "isolated",
+        payload: { kind: "agentTurn", message: "run later" },
+      },
+    });
+
+    expect(callGatewayMock).toHaveBeenCalledTimes(2);
+    expect(readGatewayCall(1)).toEqual({
+      method: "cron.update",
+      params: {
+        id: "job-12",
+        patch: {
+          sessionTarget: "isolated",
+          payload: {
+            kind: "agentTurn",
+            message: "run later",
+            toolsAllow: ["read", "cron"],
+          },
+        },
+      },
+    });
+  });
+
   it("preserves null model payload patches on update", async () => {
     callGatewayMock.mockResolvedValueOnce({ ok: true });
 

--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -900,6 +900,30 @@ describe("cron tool", () => {
     expect(params?.payload?.toolsAllow).toEqual(["read", "cron"]);
   });
 
+  it("preserves explicit empty agentTurn add toolsAllow under a creator tool surface", async () => {
+    const tool = createTestCronTool({
+      agentSessionKey: "agent:main:telegram:group:restricted-room",
+      creatorToolAllowlist: ["read", "cron"],
+    });
+
+    await tool.execute("call-empty-capped-add-tools", {
+      action: "add",
+      job: {
+        ...buildReminderAgentTurnJob(),
+        payload: {
+          kind: "agentTurn",
+          message: "hello",
+          toolsAllow: [],
+        },
+      },
+    });
+
+    const params = expectSingleGatewayCallMethod("cron.add") as
+      | { payload?: { toolsAllow?: string[] } }
+      | undefined;
+    expect(params?.payload?.toolsAllow).toEqual([]);
+  });
+
   it("expands plugin selectors against the creator tool surface on agentTurn adds", async () => {
     const tool = createTestCronTool({
       agentSessionKey: "agent:main:telegram:group:restricted-room",
@@ -2111,6 +2135,76 @@ describe("cron tool", () => {
           payload: {
             kind: "agentTurn",
             toolsAllow: ["read", "cron"],
+          },
+        },
+      },
+    });
+  });
+
+  it("preserves an existing narrower toolsAllow when updating without a payload patch", async () => {
+    callGatewayMock
+      .mockResolvedValueOnce({
+        id: "job-10",
+        payload: { kind: "agentTurn", message: "hello", toolsAllow: ["read"] },
+      })
+      .mockResolvedValueOnce({ ok: true });
+
+    const tool = createTestCronTool({
+      agentSessionKey: "agent:main:telegram:group:restricted-room",
+      creatorToolAllowlist: ["read", "exec", "cron"],
+    });
+    await tool.execute("call-update-preserve-existing-tools", {
+      action: "update",
+      id: "job-10",
+      patch: { enabled: false },
+    });
+
+    expect(callGatewayMock).toHaveBeenCalledTimes(2);
+    expect(readGatewayCall(1)).toEqual({
+      method: "cron.update",
+      params: {
+        id: "job-10",
+        patch: {
+          enabled: false,
+          payload: {
+            kind: "agentTurn",
+            toolsAllow: ["read"],
+          },
+        },
+      },
+    });
+  });
+
+  it("preserves an existing narrower toolsAllow when updating payload fields without toolsAllow", async () => {
+    callGatewayMock
+      .mockResolvedValueOnce({
+        id: "job-11",
+        payload: { kind: "agentTurn", message: "hello", toolsAllow: ["read"] },
+      })
+      .mockResolvedValueOnce({ ok: true });
+
+    const tool = createTestCronTool({
+      agentSessionKey: "agent:main:telegram:group:restricted-room",
+      creatorToolAllowlist: ["read", "exec", "cron"],
+    });
+    await tool.execute("call-update-preserve-existing-payload-tools", {
+      action: "update",
+      id: "job-11",
+      patch: {
+        payload: { model: "openai/gpt-5.5" },
+      },
+    });
+
+    expect(callGatewayMock).toHaveBeenCalledTimes(2);
+    expect(readGatewayCall(1)).toEqual({
+      method: "cron.update",
+      params: {
+        id: "job-11",
+        patch: {
+          payload: {
+            kind: "agentTurn",
+            model: "openai/gpt-5.5",
+            toolsAllow: ["read"],
           },
         },
       },

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -360,6 +360,26 @@ type NormalizedCronCreatorTool = {
   pluginId?: string;
 };
 
+export function replaceWithEffectiveCronCreatorToolAllowlist<T extends { name: string }>(
+  target: CronCreatorToolAllowlistEntry[],
+  tools: readonly T[],
+  toolMeta?: (tool: T) => { pluginId?: string } | undefined,
+): void {
+  target.length = 0;
+  const seen = new Set<string>();
+  for (const tool of tools) {
+    const name = normalizeToolName(tool.name);
+    if (!name || seen.has(name)) {
+      continue;
+    }
+    seen.add(name);
+    const meta = toolMeta?.(tool);
+    const pluginId =
+      typeof meta?.pluginId === "string" ? normalizeToolName(meta.pluginId) : undefined;
+    target.push(pluginId ? { name, pluginId } : { name });
+  }
+}
+
 type GatewayToolCaller = typeof callGatewayTool;
 
 type CronToolDeps = {

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -24,6 +24,7 @@ import {
   stringEnum,
 } from "../schema/typebox.js";
 import { CRON_TOOL_DISPLAY_SUMMARY } from "../tool-description-presets.js";
+import { expandToolGroups, normalizeToolName } from "../tool-policy.js";
 import { setToolTerminalPresentation } from "../tool-terminal-presentation.js";
 import {
   type AnyAgentTool,
@@ -332,6 +333,12 @@ export const CronToolSchema = createCronToolSchema();
 type CronToolOptions = {
   agentSessionKey?: string;
   currentDeliveryContext?: DeliveryContext;
+  /**
+   * Effective tool names visible to the caller that created or edited a cron job.
+   * Isolated cron runs use a fresh session, so agent-origin jobs need this cap
+   * persisted on agentTurn payloads before the original session policy is lost.
+   */
+  creatorToolAllowlist?: string[];
   selfRemoveOnlyJobId?: string;
 };
 
@@ -364,6 +371,56 @@ function assertNoCronCommandPayload(value: unknown): void {
       "cron command payloads cannot be created or edited through the agent cron tool; use the CLI or Gateway API.",
     );
   }
+}
+
+function normalizeCronToolsAllow(values: readonly string[]): string[] {
+  const normalized: string[] = [];
+  const seen = new Set<string>();
+  for (const entry of expandToolGroups([...values])) {
+    const toolName = normalizeToolName(entry);
+    if (!toolName || seen.has(toolName)) {
+      continue;
+    }
+    seen.add(toolName);
+    normalized.push(toolName);
+  }
+  return normalized;
+}
+
+function capCronAgentTurnToolsAllow(params: {
+  payload: Record<string, unknown>;
+  creatorToolAllowlist: string[];
+}): void {
+  if (params.payload.kind !== "agentTurn") {
+    return;
+  }
+  const creatorToolsAllow = normalizeCronToolsAllow(params.creatorToolAllowlist);
+  const requestedRaw = params.payload.toolsAllow;
+  if (!Array.isArray(requestedRaw)) {
+    params.payload.toolsAllow = creatorToolsAllow;
+    return;
+  }
+  const requestedToolsAllow = normalizeCronToolsAllow(
+    requestedRaw.filter((entry): entry is string => typeof entry === "string"),
+  );
+  if (requestedToolsAllow.includes("*")) {
+    params.payload.toolsAllow = creatorToolsAllow;
+    return;
+  }
+  const creatorAllowSet = new Set(creatorToolsAllow);
+  params.payload.toolsAllow = requestedToolsAllow.filter((toolName) =>
+    creatorAllowSet.has(toolName),
+  );
+}
+
+function capCronAgentTurnJobToolsAllow(
+  value: unknown,
+  creatorToolAllowlist: string[] | undefined,
+): void {
+  if (!creatorToolAllowlist || !isRecord(value) || !isRecord(value.payload)) {
+    return;
+  }
+  capCronAgentTurnToolsAllow({ payload: value.payload, creatorToolAllowlist });
 }
 
 function truncateText(input: string, maxLen: number) {
@@ -730,6 +787,7 @@ Use jobId canonical; id accepted compat. contextMessages (0-10) adds previous me
             normalizeCronJobCreate(canonicalJob, {
               sessionContext: { sessionKey: opts?.agentSessionKey },
             }) ?? canonicalJob;
+          capCronAgentTurnJobToolsAllow(job, opts?.creatorToolAllowlist);
           const cfg = getRuntimeConfig();
           if (job && typeof job === "object") {
             const { mainKey, alias } = resolveMainSessionAlias(cfg);
@@ -845,6 +903,7 @@ Use jobId canonical; id accepted compat. contextMessages (0-10) adds previous me
           assertNoCronCommandPayload(canonicalPatch);
           assertCronDeliveryInputNonBlankFields(canonicalPatch.delivery);
           const patch = normalizeCronJobPatch(canonicalPatch) ?? canonicalPatch;
+          capCronAgentTurnJobToolsAllow(patch, opts?.creatorToolAllowlist);
           if (recoveredFlatPatch && isEmptyRecoveredCronPatch(patch)) {
             throw new Error("patch required");
           }

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -24,7 +24,13 @@ import {
   stringEnum,
 } from "../schema/typebox.js";
 import { CRON_TOOL_DISPLAY_SUMMARY } from "../tool-description-presets.js";
-import { expandToolGroups, normalizeToolName } from "../tool-policy.js";
+import { isToolAllowedByPolicyName } from "../tool-policy-match.js";
+import {
+  buildPluginToolGroups,
+  expandPolicyWithPluginGroups,
+  expandToolGroups,
+  normalizeToolName,
+} from "../tool-policy.js";
 import { setToolTerminalPresentation } from "../tool-terminal-presentation.js";
 import {
   type AnyAgentTool,
@@ -334,12 +340,24 @@ type CronToolOptions = {
   agentSessionKey?: string;
   currentDeliveryContext?: DeliveryContext;
   /**
-   * Effective tool names visible to the caller that created or edited a cron job.
+   * Effective tool surface visible to the caller that created or edited a cron job.
    * Isolated cron runs use a fresh session, so agent-origin jobs need this cap
    * persisted on agentTurn payloads before the original session policy is lost.
    */
-  creatorToolAllowlist?: string[];
+  creatorToolAllowlist?: CronCreatorToolAllowlistEntry[];
   selfRemoveOnlyJobId?: string;
+};
+
+export type CronCreatorToolAllowlistEntry =
+  | string
+  | {
+      name: string;
+      pluginId?: string;
+    };
+
+type NormalizedCronCreatorTool = {
+  name: string;
+  pluginId?: string;
 };
 
 type GatewayToolCaller = typeof callGatewayTool;
@@ -387,40 +405,116 @@ function normalizeCronToolsAllow(values: readonly string[]): string[] {
   return normalized;
 }
 
+function normalizeCronCreatorToolsAllow(
+  values: readonly CronCreatorToolAllowlistEntry[],
+): NormalizedCronCreatorTool[] {
+  const normalized: NormalizedCronCreatorTool[] = [];
+  const seen = new Set<string>();
+  for (const entry of values) {
+    const name = normalizeToolName(typeof entry === "string" ? entry : entry.name);
+    if (!name || seen.has(name)) {
+      continue;
+    }
+    seen.add(name);
+    const pluginId =
+      typeof entry === "string" || typeof entry.pluginId !== "string"
+        ? undefined
+        : normalizeToolName(entry.pluginId);
+    normalized.push(pluginId ? { name, pluginId } : { name });
+  }
+  return normalized;
+}
+
+function cronCreatorToolNames(tools: readonly NormalizedCronCreatorTool[]): string[] {
+  return tools.map((tool) => tool.name);
+}
+
 function capCronAgentTurnToolsAllow(params: {
   payload: Record<string, unknown>;
-  creatorToolAllowlist: string[];
+  creatorToolAllowlist: CronCreatorToolAllowlistEntry[];
 }): void {
   if (params.payload.kind !== "agentTurn") {
     return;
   }
-  const creatorToolsAllow = normalizeCronToolsAllow(params.creatorToolAllowlist);
+  const creatorToolsAllow = normalizeCronCreatorToolsAllow(params.creatorToolAllowlist);
+  const creatorToolNames = cronCreatorToolNames(creatorToolsAllow);
   const requestedRaw = params.payload.toolsAllow;
   if (!Array.isArray(requestedRaw)) {
-    params.payload.toolsAllow = creatorToolsAllow;
+    params.payload.toolsAllow = creatorToolNames;
     return;
   }
   const requestedToolsAllow = normalizeCronToolsAllow(
     requestedRaw.filter((entry): entry is string => typeof entry === "string"),
   );
   if (requestedToolsAllow.includes("*")) {
-    params.payload.toolsAllow = creatorToolsAllow;
+    params.payload.toolsAllow = creatorToolNames;
     return;
   }
-  const creatorAllowSet = new Set(creatorToolsAllow);
-  params.payload.toolsAllow = requestedToolsAllow.filter((toolName) =>
-    creatorAllowSet.has(toolName),
+  const pluginGroups = buildPluginToolGroups({
+    tools: creatorToolsAllow,
+    toolMeta: (tool) => (tool.pluginId ? { pluginId: tool.pluginId } : undefined),
+  });
+  const requestedPolicy = expandPolicyWithPluginGroups(
+    { allow: requestedToolsAllow },
+    pluginGroups,
+  );
+  params.payload.toolsAllow = creatorToolNames.filter((toolName) =>
+    isToolAllowedByPolicyName(toolName, requestedPolicy),
   );
 }
 
 function capCronAgentTurnJobToolsAllow(
   value: unknown,
-  creatorToolAllowlist: string[] | undefined,
+  creatorToolAllowlist: CronCreatorToolAllowlistEntry[] | undefined,
 ): void {
   if (!creatorToolAllowlist || !isRecord(value) || !isRecord(value.payload)) {
     return;
   }
   capCronAgentTurnToolsAllow({ payload: value.payload, creatorToolAllowlist });
+}
+
+function readCronPayloadKind(value: unknown): string | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  return typeof value.kind === "string" ? value.kind : undefined;
+}
+
+async function capCronAgentTurnUpdatePatchToolsAllow(params: {
+  id: string;
+  patch: Record<string, unknown>;
+  creatorToolAllowlist: CronCreatorToolAllowlistEntry[] | undefined;
+  gatewayOpts: GatewayCallOptions;
+  callGateway: GatewayToolCaller;
+}): Promise<void> {
+  if (!params.creatorToolAllowlist) {
+    return;
+  }
+  const payload = isRecord(params.patch.payload) ? params.patch.payload : undefined;
+  const patchPayloadKind = readCronPayloadKind(payload);
+  if (patchPayloadKind === "agentTurn") {
+    capCronAgentTurnToolsAllow({
+      payload,
+      creatorToolAllowlist: params.creatorToolAllowlist,
+    });
+    return;
+  }
+  if (patchPayloadKind === "systemEvent" || patchPayloadKind === "command" || patchPayloadKind) {
+    return;
+  }
+
+  const existing = await params.callGateway("cron.get", params.gatewayOpts, { id: params.id });
+  const existingPayload = isRecord(existing) ? existing.payload : undefined;
+  if (readCronPayloadKind(existingPayload) !== "agentTurn") {
+    return;
+  }
+  const nextPayload: Record<string, unknown> = payload ?? {};
+  nextPayload.kind = "agentTurn";
+  params.patch.payload = nextPayload;
+  capCronAgentTurnToolsAllow({
+    payload: nextPayload,
+    creatorToolAllowlist: params.creatorToolAllowlist,
+  });
 }
 
 function truncateText(input: string, maxLen: number) {
@@ -903,10 +997,16 @@ Use jobId canonical; id accepted compat. contextMessages (0-10) adds previous me
           assertNoCronCommandPayload(canonicalPatch);
           assertCronDeliveryInputNonBlankFields(canonicalPatch.delivery);
           const patch = normalizeCronJobPatch(canonicalPatch) ?? canonicalPatch;
-          capCronAgentTurnJobToolsAllow(patch, opts?.creatorToolAllowlist);
           if (recoveredFlatPatch && isEmptyRecoveredCronPatch(patch)) {
             throw new Error("patch required");
           }
+          await capCronAgentTurnUpdatePatchToolsAllow({
+            id,
+            patch,
+            creatorToolAllowlist: opts?.creatorToolAllowlist,
+            gatewayOpts,
+            callGateway,
+          });
           return jsonResult(
             await callGateway("cron.update", gatewayOpts, {
               id,

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -519,6 +519,7 @@ async function capCronAgentTurnUpdatePatchToolsAllow(params: {
   }
   const payload = isRecord(params.patch.payload) ? params.patch.payload : undefined;
   const patchPayloadKind = readCronPayloadKind(payload);
+  const patchRequestsAgentTurn = patchPayloadKind === "agentTurn";
   if (patchPayloadKind === "agentTurn" && payload && Object.hasOwn(payload, "toolsAllow")) {
     capCronAgentTurnToolsAllow({
       payload,
@@ -536,7 +537,8 @@ async function capCronAgentTurnUpdatePatchToolsAllow(params: {
 
   const existing = await params.callGateway("cron.get", params.gatewayOpts, { id: params.id });
   const existingPayload = isRecord(existing) ? existing.payload : undefined;
-  if (readCronPayloadKind(existingPayload) !== "agentTurn") {
+  const existingPayloadKind = readCronPayloadKind(existingPayload);
+  if (!patchRequestsAgentTurn && existingPayloadKind !== "agentTurn") {
     return;
   }
   const nextPayload: Record<string, unknown> = payload ?? {};
@@ -545,7 +547,10 @@ async function capCronAgentTurnUpdatePatchToolsAllow(params: {
   capCronAgentTurnToolsAllow({
     payload: nextPayload,
     creatorToolAllowlist: params.creatorToolAllowlist,
-    defaultToolsAllow: isRecord(existingPayload) ? existingPayload.toolsAllow : undefined,
+    defaultToolsAllow:
+      existingPayloadKind === "agentTurn" && isRecord(existingPayload)
+        ? existingPayload.toolsAllow
+        : undefined,
   });
 }
 

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -432,13 +432,16 @@ function cronCreatorToolNames(tools: readonly NormalizedCronCreatorTool[]): stri
 function capCronAgentTurnToolsAllow(params: {
   payload: Record<string, unknown>;
   creatorToolAllowlist: CronCreatorToolAllowlistEntry[];
+  defaultToolsAllow?: unknown;
 }): void {
   if (params.payload.kind !== "agentTurn") {
     return;
   }
   const creatorToolsAllow = normalizeCronCreatorToolsAllow(params.creatorToolAllowlist);
   const creatorToolNames = cronCreatorToolNames(creatorToolsAllow);
-  const requestedRaw = params.payload.toolsAllow;
+  const requestedRaw = Object.hasOwn(params.payload, "toolsAllow")
+    ? params.payload.toolsAllow
+    : params.defaultToolsAllow;
   if (!Array.isArray(requestedRaw)) {
     params.payload.toolsAllow = creatorToolNames;
     return;
@@ -446,6 +449,10 @@ function capCronAgentTurnToolsAllow(params: {
   const requestedToolsAllow = normalizeCronToolsAllow(
     requestedRaw.filter((entry): entry is string => typeof entry === "string"),
   );
+  if (requestedToolsAllow.length === 0) {
+    params.payload.toolsAllow = [];
+    return;
+  }
   if (requestedToolsAllow.includes("*")) {
     params.payload.toolsAllow = creatorToolNames;
     return;
@@ -492,14 +499,18 @@ async function capCronAgentTurnUpdatePatchToolsAllow(params: {
   }
   const payload = isRecord(params.patch.payload) ? params.patch.payload : undefined;
   const patchPayloadKind = readCronPayloadKind(payload);
-  if (patchPayloadKind === "agentTurn") {
+  if (patchPayloadKind === "agentTurn" && payload && Object.hasOwn(payload, "toolsAllow")) {
     capCronAgentTurnToolsAllow({
       payload,
       creatorToolAllowlist: params.creatorToolAllowlist,
     });
     return;
   }
-  if (patchPayloadKind === "systemEvent" || patchPayloadKind === "command" || patchPayloadKind) {
+  if (
+    patchPayloadKind === "systemEvent" ||
+    patchPayloadKind === "command" ||
+    (patchPayloadKind && patchPayloadKind !== "agentTurn")
+  ) {
     return;
   }
 
@@ -514,6 +525,7 @@ async function capCronAgentTurnUpdatePatchToolsAllow(params: {
   capCronAgentTurnToolsAllow({
     payload: nextPayload,
     creatorToolAllowlist: params.creatorToolAllowlist,
+    defaultToolsAllow: isRecord(existingPayload) ? existingPayload.toolsAllow : undefined,
   });
 }
 

--- a/src/gateway/tool-resolution.exclude.test.ts
+++ b/src/gateway/tool-resolution.exclude.test.ts
@@ -5,44 +5,31 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 
 type CreateOpenClawToolsArg = {
+  cronCreatorToolAllowlist?: Array<string | { name: string; pluginId?: string }>;
   inheritedToolDenylist?: string[];
   pluginToolDenylist?: string[];
 };
 
-const hoisted = vi.hoisted(() => ({
-  createOpenClawToolsMock: vi.fn((_args: CreateOpenClawToolsArg) => [
-    {
-      name: "read",
-      description: "Read files",
+const hoisted = vi.hoisted(() => {
+  function makeTool(name: string) {
+    return {
+      name,
+      description: `${name} tool`,
       parameters: { type: "object", properties: {} },
       execute: vi.fn(),
-    },
-    {
-      name: "sessions_spawn",
-      description: "Spawn sessions",
-      parameters: { type: "object", properties: {} },
-      execute: vi.fn(),
-    },
-    {
-      name: "cron",
-      description: "Manage schedules",
-      parameters: { type: "object", properties: {} },
-      execute: vi.fn(),
-    },
-    {
-      name: "gateway",
-      description: "Manage gateway",
-      parameters: { type: "object", properties: {} },
-      execute: vi.fn(),
-    },
-    {
-      name: "nodes",
-      description: "Manage nodes",
-      parameters: { type: "object", properties: {} },
-      execute: vi.fn(),
-    },
-  ]),
-}));
+    };
+  }
+  return {
+    makeTool,
+    createOpenClawToolsMock: vi.fn((_args: CreateOpenClawToolsArg) => [
+      makeTool("read"),
+      makeTool("sessions_spawn"),
+      makeTool("cron"),
+      makeTool("gateway"),
+      makeTool("nodes"),
+    ]),
+  };
+});
 
 vi.mock("../agents/openclaw-tools.js", () => ({
   createOpenClawTools: (args: CreateOpenClawToolsArg) => hoisted.createOpenClawToolsMock(args),
@@ -56,6 +43,7 @@ describe("resolveGatewayScopedTools excludeToolNames", () => {
   });
 
   function readCreateToolsArgs(): {
+    cronCreatorToolAllowlist?: Array<string | { name: string; pluginId?: string }>;
     inheritedToolDenylist?: string[];
     pluginToolDenylist?: string[];
   } {
@@ -64,6 +52,7 @@ describe("resolveGatewayScopedTools excludeToolNames", () => {
       throw new Error("expected createOpenClawTools args");
     }
     return args as {
+      cronCreatorToolAllowlist?: Array<string | { name: string; pluginId?: string }>;
       inheritedToolDenylist?: string[];
       pluginToolDenylist?: string[];
     };
@@ -117,5 +106,27 @@ describe("resolveGatewayScopedTools excludeToolNames", () => {
     const args = readCreateToolsArgs();
     expect(args.pluginToolDenylist).toEqual(["exec"]);
     expect(args.inheritedToolDenylist).toEqual(["exec"]);
+  });
+
+  it("passes final filtered tool surface to gateway cron jobs", () => {
+    hoisted.createOpenClawToolsMock.mockReturnValueOnce([
+      hoisted.makeTool("read"),
+      hoisted.makeTool("cron"),
+      hoisted.makeTool("exec"),
+    ]);
+
+    const result = resolveGatewayScopedTools({
+      cfg: {
+        tools: { allow: ["read", "cron"] },
+      } as OpenClawConfig,
+      sessionKey: "agent:main:direct:test",
+      surface: "loopback",
+    });
+
+    expect(result.tools.map((tool) => tool.name)).toEqual(["read", "cron"]);
+    expect(readCreateToolsArgs().cronCreatorToolAllowlist).toEqual([
+      { name: "read" },
+      { name: "cron" },
+    ]);
   });
 });

--- a/src/gateway/tool-resolution.ts
+++ b/src/gateway/tool-resolution.ts
@@ -24,6 +24,10 @@ import {
   resolveToolProfilePolicy,
 } from "../agents/tool-policy.js";
 import type { AnyAgentTool } from "../agents/tools/common.js";
+import {
+  replaceWithEffectiveCronCreatorToolAllowlist,
+  type CronCreatorToolAllowlistEntry,
+} from "../agents/tools/cron-tool.js";
 import type { SourceReplyDeliveryMode } from "../auto-reply/get-reply-options.types.js";
 import type { InboundEventKind } from "../channels/inbound-event/kind.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -144,6 +148,7 @@ export function resolveGatewayScopedTools(params: {
   // Passed by reference to sessions_spawn and populated after the final policy
   // pass so child sessions inherit the actual parent tool surface.
   const inheritedToolAllowlist: string[] = [];
+  const cronCreatorToolAllowlist: CronCreatorToolAllowlistEntry[] = [];
   const shouldInheritEffectiveToolAllowlist = [
     profilePolicy,
     providerProfilePolicy,
@@ -156,6 +161,10 @@ export function resolveGatewayScopedTools(params: {
     inheritedToolPolicy,
     gatewayRequestedTools.length > 0 ? { allow: gatewayRequestedTools } : undefined,
   ].some(hasRestrictiveAllowPolicy);
+  const shouldCaptureCronCreatorToolAllowlist =
+    shouldInheritEffectiveToolAllowlist ||
+    explicitDenylist.length > 0 ||
+    excludedToolNames.length > 0;
 
   const allTools = createOpenClawTools({
     agentSessionKey: params.sessionKey,
@@ -190,6 +199,9 @@ export function resolveGatewayScopedTools(params: {
       gatewayRequestedTools.length > 0 ? { allow: gatewayRequestedTools } : undefined,
     ]),
     pluginToolDenylist: explicitDenylist,
+    cronCreatorToolAllowlist: shouldCaptureCronCreatorToolAllowlist
+      ? cronCreatorToolAllowlist
+      : undefined,
     inheritedToolAllowlist,
     inheritedToolDenylist,
   });
@@ -227,6 +239,11 @@ export function resolveGatewayScopedTools(params: {
   const tools = policyFiltered.filter((tool) => !gatewayDenySet.has(tool.name));
   if (shouldInheritEffectiveToolAllowlist) {
     replaceWithEffectiveToolAllowlist(inheritedToolAllowlist, tools);
+  }
+  if (shouldCaptureCronCreatorToolAllowlist) {
+    replaceWithEffectiveCronCreatorToolAllowlist(cronCreatorToolAllowlist, tools, (tool) =>
+      getPluginToolMeta(tool),
+    );
   }
 
   return {

--- a/src/mcp/openclaw-tools-serve.ts
+++ b/src/mcp/openclaw-tools-serve.ts
@@ -12,7 +12,7 @@ import { formatErrorMessage } from "../infra/errors.js";
 import { connectToolsMcpServerToStdio, createToolsMcpServer } from "./tools-stdio-server.js";
 
 export function resolveOpenClawToolsForMcp(): AnyAgentTool[] {
-  return [createCronTool({ creatorToolAllowlist: ["cron"] })];
+  return [createCronTool({ creatorToolAllowlist: [{ name: "cron" }] })];
 }
 
 function createOpenClawToolsMcpServer(

--- a/src/mcp/openclaw-tools-serve.ts
+++ b/src/mcp/openclaw-tools-serve.ts
@@ -12,7 +12,7 @@ import { formatErrorMessage } from "../infra/errors.js";
 import { connectToolsMcpServerToStdio, createToolsMcpServer } from "./tools-stdio-server.js";
 
 export function resolveOpenClawToolsForMcp(): AnyAgentTool[] {
-  return [createCronTool()];
+  return [createCronTool({ creatorToolAllowlist: ["cron"] })];
 }
 
 function createOpenClawToolsMcpServer(

--- a/src/skills/runtime/tool-dispatch.test.ts
+++ b/src/skills/runtime/tool-dispatch.test.ts
@@ -1,0 +1,51 @@
+// Skill tool dispatch tests cover policy-filtered tool surfaces.
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+
+type CreateOpenClawToolsArg = {
+  cronCreatorToolAllowlist?: Array<string | { name: string; pluginId?: string }>;
+};
+
+const hoisted = vi.hoisted(() => {
+  function makeTool(name: string) {
+    return {
+      name,
+      description: `${name} tool`,
+      parameters: { type: "object", properties: {} },
+      execute: vi.fn(),
+    };
+  }
+  return {
+    createOpenClawToolsMock: vi.fn((_args: CreateOpenClawToolsArg) => [
+      makeTool("read"),
+      makeTool("cron"),
+      makeTool("exec"),
+    ]),
+  };
+});
+
+vi.mock("../../agents/openclaw-tools.runtime.js", () => ({
+  createOpenClawTools: (args: CreateOpenClawToolsArg) => hoisted.createOpenClawToolsMock(args),
+}));
+
+import { resolveSkillDispatchTools } from "./tool-dispatch.js";
+
+describe("resolveSkillDispatchTools", () => {
+  it("passes final filtered tool surface to cron jobs", () => {
+    const tools = resolveSkillDispatchTools({
+      message: { surface: "telegram", senderId: "user-1" },
+      cfg: {
+        tools: { allow: ["read", "cron"] },
+      } as OpenClawConfig,
+      agentId: "main",
+      sessionKey: "agent:main:telegram:group:restricted-room",
+      workspaceDir: "/tmp/openclaw-skill-tool-dispatch-test",
+      provider: "openai",
+      model: "gpt-5.5",
+    });
+
+    const args = hoisted.createOpenClawToolsMock.mock.calls[0]?.[0];
+    expect(tools.map((tool) => tool.name)).toEqual(["read", "cron"]);
+    expect(args?.cronCreatorToolAllowlist).toEqual([{ name: "read" }, { name: "cron" }]);
+  });
+});

--- a/src/skills/runtime/tool-dispatch.ts
+++ b/src/skills/runtime/tool-dispatch.ts
@@ -25,6 +25,10 @@ import {
   replaceWithEffectiveToolAllowlist,
   resolveToolProfilePolicy,
 } from "../../agents/tool-policy.js";
+import {
+  replaceWithEffectiveCronCreatorToolAllowlist,
+  type CronCreatorToolAllowlistEntry,
+} from "../../agents/tools/cron-tool.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { logVerbose } from "../../globals.js";
@@ -152,7 +156,11 @@ export function resolveSkillDispatchTools(params: {
     subagentPolicy,
     inheritedToolPolicy,
   ];
+  const explicitDenylist = collectExplicitDenylist(explicitPolicyList);
   const inheritedToolAllowlist: string[] = [];
+  const cronCreatorToolAllowlist: CronCreatorToolAllowlistEntry[] = [];
+  const shouldCaptureCronCreatorToolAllowlist =
+    explicitPolicyList.some(hasRestrictiveAllowPolicy) || explicitDenylist.length > 0;
   const beforeToolCallHookContext = params.skillCommand
     ? {
         cwd: params.workspaceDir,
@@ -191,9 +199,12 @@ export function resolveSkillDispatchTools(params: {
     modelProvider: params.provider,
     modelId: params.model,
     pluginToolAllowlist: collectExplicitAllowlist(explicitPolicyList),
-    pluginToolDenylist: collectExplicitDenylist(explicitPolicyList),
+    pluginToolDenylist: explicitDenylist,
+    cronCreatorToolAllowlist: shouldCaptureCronCreatorToolAllowlist
+      ? cronCreatorToolAllowlist
+      : undefined,
     inheritedToolAllowlist,
-    inheritedToolDenylist: collectExplicitDenylist(explicitPolicyList),
+    inheritedToolDenylist: explicitDenylist,
   });
   const policyFiltered = applyToolPolicyPipeline({
     tools,
@@ -222,6 +233,11 @@ export function resolveSkillDispatchTools(params: {
   });
   if (explicitPolicyList.some(hasRestrictiveAllowPolicy)) {
     replaceWithEffectiveToolAllowlist(inheritedToolAllowlist, policyFiltered);
+  }
+  if (shouldCaptureCronCreatorToolAllowlist) {
+    replaceWithEffectiveCronCreatorToolAllowlist(cronCreatorToolAllowlist, policyFiltered, (tool) =>
+      getPluginToolMeta(tool),
+    );
   }
   return policyFiltered;
 }


### PR DESCRIPTION
## Summary

- Preserve the effective creator tool surface when agent-created cron `agentTurn` jobs are persisted, so delayed scheduled turns keep the same tool boundary as the creator.
- Apply the same cap to cron payload edits, gateway-scoped tool projection, skill dispatch, embedded bundled tool construction, and the standalone OpenClaw tools MCP cron surface.
- Add focused regression coverage for cron payload capping and policy-pipeline wiring.
- AI-assisted.

## Linked context

No public issue linked.

## Real behavior proof

Behavior addressed: scheduled agent turns created or edited from a narrower tool surface retain that surface for later runs.

Real environment tested: local isolated OpenClaw profile `cron-proof-profile` with a foreground loopback Gateway on port 18874 and the actual cron tool creating/fetching a scheduled job through Gateway RPC.

Exact steps or command run after this patch: `pnpm openclaw --profile cron-proof-profile config set gateway.port 18874 --strict-json`; `pnpm openclaw --profile cron-proof-profile gateway run --auth none --port 18874 --allow-unconfigured --ws-log compact`; `OPENCLAW_PROFILE=cron-proof-profile OPENCLAW_GATEWAY_URL=ws://127.0.0.1:18874 pnpm exec tsx /tmp/openclaw-cron-live-proof.ts`

Evidence after fix: copied live terminal output from the isolated Gateway run:

```text
[agents/tool-policy] tool policy removed 23 tool(s) via tools.allow: agents_list, apply_patch, create_goal, edit, exec, gateway, get_goal, message, nodes, process, session_status, sessions_history, sessions_list, sessions_send, sessions_spawn, sessions_yield, skill_workshop, subagents, tts, update_goal, web_fetch, web_search, write
OpenClaw live proof head: 8587ea2
Profile: cron-proof-profile
Gateway: ws://127.0.0.1:18874
Creator runtime tools: cron,read
Requested payload.toolsAllow: exec,read,cron
Persisted job id: 2eadfd67-6d28-4653-9846-d4c09a59e756
Persisted payload.toolsAllow: read,cron
Exec present after create: no
```

Observed result after fix: a live cron job requested `exec,read,cron` from a restricted creator surface that only exposed `cron,read`; the persisted scheduled job stored `read,cron`, and `exec` was absent after fetching the job back from the Gateway.

What was not tested: live chat-channel delivery and model-provider execution of the later scheduled turn.

Proof limitations or environment constraints: the live proof used a local auth-none loopback Gateway in an isolated profile and stopped the Gateway after the probe; focused tests and CI cover sibling gateway, skill, update, and embedded bundled-tool cases.

## Tests and validation

- `node scripts/run-vitest.mjs src/agents/tools/cron-tool.test.ts src/agents/agent-tools.create-openclaw-coding-tools.test.ts src/gateway/tool-resolution.exclude.test.ts src/gateway/tool-resolution.test.ts src/skills/runtime/tool-dispatch.test.ts src/agents/embedded-agent-runner/run/attempt.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/agents/agent-tools.ts src/agents/embedded-agent-runner/run/attempt.ts src/agents/openclaw-tools.ts src/agents/tools/cron-tool.ts src/agents/agent-tools.create-openclaw-coding-tools.test.ts src/agents/tools/cron-tool.test.ts src/gateway/tool-resolution.ts src/gateway/tool-resolution.exclude.test.ts src/mcp/openclaw-tools-serve.ts src/skills/runtime/tool-dispatch.ts src/skills/runtime/tool-dispatch.test.ts`
- `git diff --check`
- `pnpm tsgo:core`

## Risk checklist

- Did user-visible behavior change? Yes. Scheduled agent turns created from a narrower tool surface now persist that same runtime tool cap.
- Did config, environment, or migration behavior change? No.
- Did tool execution behavior change? Yes.
- Highest-risk area: existing cron `agentTurn` creation flows that intentionally rely on a narrower creator tool surface.
- How is that risk mitigated? Unrestricted creators are unchanged; the new cap is only populated when the source tool policy has a restrictive allowlist, denylist, runtime allowlist, or equivalent final filtered surface, and focused tests cover add, update, allow-policy, deny-policy, gateway, skill, and embedded bundled-tool cases.

## Current review state

- Local validation: passed.
- Review gate: passed with repo-local autoreview clean and differential review complete.
- GitHub CI: branch CI passed for head `8587ea2cb0c7a990bb504d5bfffd952c46bb6b99`; metadata-only checks may rerun after body updates.
- Bot or reviewer comments addressed: none open.
