### PR TITLE
fix(qa): reserve shared QA suite flags across runners

### DIFF
--- a/extensions/qa-lab/src/cli.runtime.test.ts
+++ b/extensions/qa-lab/src/cli.runtime.test.ts
@@ -606,18 +606,28 @@ describe("qa cli runtime", () => {
     });
   });
 
-  it("keeps Crabline channel-driver independent from the VM runner", async () => {
-    await expect(
-      runQaSuiteCommand({
-        repoRoot: "/tmp/openclaw-repo",
-        providerMode: "mock-openai",
-        channelDriver: "crabline",
-        channel: "telegram",
-        runner: "multipass",
+  it("passes Crabline channel-driver selection through to the multipass runner", async () => {
+    await runQaSuiteCommand({
+      repoRoot: "/tmp/openclaw-repo",
+      providerMode: "mock-openai",
+      channelDriver: "crabline",
+      channel: "telegram",
+      runner: "multipass",
+      scenarioIds: ["channel-chat-baseline"],
+      allowFailures: true,
+    });
+
+    expect(runQaMultipass).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channelDriverSelection: {
+          capabilityMatrixPath: "crabline-fake-provider-capabilities.json",
+          channel: "telegram",
+          channelDriver: "crabline",
+          smokeArtifactPath: "crabline-fake-provider-smoke.json",
+        },
       }),
-    ).rejects.toThrow("--channel-driver crabline requires --runner host.");
+    );
     expect(runQaSuite).not.toHaveBeenCalled();
-    expect(runQaMultipass).not.toHaveBeenCalled();
   });
 
   it("passes explicit suite plugin enablements into the host gateway run", async () => {
@@ -641,6 +651,24 @@ describe("qa cli runtime", () => {
       scenarioIds: ["channel-chat-baseline"],
       enabledPluginIds: ["browser", "memory-core"],
     });
+  });
+
+  it("passes explicit suite plugin enablements through to the multipass runner", async () => {
+    await runQaSuiteCommand({
+      repoRoot: "/tmp/openclaw-repo",
+      runner: "multipass",
+      providerMode: "mock-openai",
+      scenarioIds: ["channel-chat-baseline"],
+      enabledPluginIds: ["browser", "memory-core"],
+      allowFailures: true,
+    });
+
+    expect(runQaMultipass).toHaveBeenCalledWith(
+      expect.objectContaining({
+        enabledPluginIds: ["browser", "memory-core"],
+      }),
+    );
+    expect(runQaSuite).not.toHaveBeenCalled();
   });
 
   it("passes runtime-pair suite selection through to the host runner", async () => {

--- a/extensions/qa-lab/src/cli.runtime.ts
+++ b/extensions/qa-lab/src/cli.runtime.ts
@@ -905,9 +905,6 @@ export async function runQaSuiteCommand(opts: QaSuiteCommandOptions) {
   if (opts.preflight === true && runner !== "host") {
     throw new Error("--preflight requires --runner host.");
   }
-  if (channelDriver === "crabline" && runner !== "host") {
-    throw new Error("--channel-driver crabline requires --runner host.");
-  }
   const channelDriverSelection =
     channelDriver === "crabline"
       ? resolveOpenClawCrablineChannelDriverSelection({
@@ -953,6 +950,8 @@ export async function runQaSuiteCommand(opts: QaSuiteCommandOptions) {
         ? { concurrency: parseQaPositiveIntegerOption("--concurrency", opts.concurrency) }
         : {}),
       ...(runtimePair ? { runtimePair } : {}),
+      ...(channelDriverSelection ? { channelDriverSelection } : {}),
+      ...(opts.enabledPluginIds !== undefined ? { enabledPluginIds: opts.enabledPluginIds } : {}),
       image: opts.image,
       cpus: parseQaPositiveIntegerOption("--cpus", opts.cpus),
       memory: opts.memory,

--- a/extensions/qa-lab/src/multipass.runtime.test.ts
+++ b/extensions/qa-lab/src/multipass.runtime.test.ts
@@ -158,6 +158,37 @@ describe("qa multipass runtime", () => {
     expect(plan.qaCommand).toEqual(expect.arrayContaining(["--runtime-pair", "openclaw,codex"]));
   });
 
+  it("forwards channel-driver suite selection into the guest qa suite command", () => {
+    const plan = createQaMultipassPlan({
+      repoRoot: process.cwd(),
+      outputDir: path.join(process.cwd(), ".artifacts", "qa-e2e", "crabline-channel-driver-test"),
+      channelDriverSelection: {
+        capabilityMatrixPath: "crabline-fake-provider-capabilities.json",
+        channel: "telegram",
+        channelDriver: "crabline",
+        smokeArtifactPath: "crabline-fake-provider-smoke.json",
+      },
+      scenarioIds: ["channel-chat-baseline"],
+    });
+
+    expect(plan.qaCommand).toEqual(
+      expect.arrayContaining(["--channel-driver", "crabline", "--channel", "telegram"]),
+    );
+  });
+
+  it("forwards suite plugin enablements into the guest qa suite command", () => {
+    const plan = createQaMultipassPlan({
+      repoRoot: process.cwd(),
+      outputDir: path.join(process.cwd(), ".artifacts", "qa-e2e", "multipass-enable-plugin-test"),
+      enabledPluginIds: ["browser", "memory-core", "browser"],
+      scenarioIds: ["channel-chat-baseline"],
+    });
+
+    expect(plan.qaCommand).toEqual(
+      expect.arrayContaining(["--enable-plugin", "browser", "--enable-plugin", "memory-core"]),
+    );
+  });
+
   it("redacts forwarded live secrets in the persisted artifact script", () => {
     vi.stubEnv("OPENAI_API_KEY", "test-openai-key");
     const plan = createQaMultipassPlan({

--- a/extensions/qa-lab/src/multipass.runtime.ts
+++ b/extensions/qa-lab/src/multipass.runtime.ts
@@ -4,6 +4,7 @@ import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import { access, mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
+import type { OpenClawCrablineChannelDriverSelection } from "crabline";
 import { sleep } from "openclaw/plugin-sdk/runtime-env";
 import { appendRegularFile } from "openclaw/plugin-sdk/security-runtime";
 import { uniqueStrings } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -79,6 +80,8 @@ type QaMultipassPlan = {
   fastMode?: boolean;
   thinkingDefault?: string;
   runtimePair?: [RuntimeId, RuntimeId];
+  channelDriverSelection?: OpenClawCrablineChannelDriverSelection;
+  enabledPluginIds?: string[];
   scenarioIds: string[];
   forwardedEnv: Record<string, string>;
   hostCodexHomePath?: string;
@@ -242,6 +245,8 @@ export function createQaMultipassPlan(params: {
   scenarioIds?: string[];
   concurrency?: number;
   runtimePair?: [RuntimeId, RuntimeId];
+  channelDriverSelection?: OpenClawCrablineChannelDriverSelection;
+  enabledPluginIds?: string[];
   image?: string;
   cpus?: number;
   memory?: string;
@@ -249,6 +254,9 @@ export function createQaMultipassPlan(params: {
 }) {
   const outputDir = params.outputDir ?? createQaMultipassOutputDir(params.repoRoot);
   const scenarioIds = uniqueStrings(params.scenarioIds ?? []);
+  const enabledPluginIds = uniqueStrings(
+    (params.enabledPluginIds ?? []).map((pluginId) => pluginId.trim()).filter(Boolean),
+  );
   const transportId = params.transportId?.trim() || "qa-channel";
   const providerMode = params.providerMode ?? DEFAULT_QA_LIVE_PROVIDER_MODE;
   const provider = getQaProvider(providerMode);
@@ -282,6 +290,15 @@ export function createQaMultipassPlan(params: {
       ...(params.allowFailures ? ["--allow-failures"] : []),
       ...(params.concurrency ? ["--concurrency", String(params.concurrency)] : []),
       ...(params.runtimePair ? ["--runtime-pair", params.runtimePair.join(",")] : []),
+      ...(params.channelDriverSelection
+        ? [
+            "--channel-driver",
+            params.channelDriverSelection.channelDriver,
+            "--channel",
+            params.channelDriverSelection.channel,
+          ]
+        : []),
+      ...enabledPluginIds.flatMap((pluginId) => ["--enable-plugin", pluginId]),
     ],
     scenarioIds,
   );
@@ -307,6 +324,8 @@ export function createQaMultipassPlan(params: {
     fastMode: params.fastMode,
     thinkingDefault: params.thinkingDefault,
     runtimePair: params.runtimePair,
+    channelDriverSelection: params.channelDriverSelection,
+    enabledPluginIds,
     scenarioIds,
     forwardedEnv,
     hostCodexHomePath,
@@ -556,6 +575,8 @@ export async function runQaMultipass(params: {
   scenarioIds?: string[];
   concurrency?: number;
   runtimePair?: [RuntimeId, RuntimeId];
+  channelDriverSelection?: OpenClawCrablineChannelDriverSelection;
+  enabledPluginIds?: string[];
   image?: string;
   cpus?: number;
   memory?: string;


### PR DESCRIPTION
## Summary

- Stacked on #91502.
- Preserves shared QA suite selections across both built-in suite runners by forwarding `--channel-driver crabline --channel telegram` and `--enable-plugin` into the existing isolated runner wrapper.
- Keeps the channel driver meaning scoped to the openclaw/crabline messaging/channel SDK; this PR does not add Canonical Multipass VM orchestration behavior, guest command features, or a VM-backed channel driver.
- Leaves the real runner-specific exceptions unchanged: VM resource flags remain Multipass-only, and `--cli-auth-mode` / `--preflight` remain host-only.
- Review focus: whether these are the right parity boundaries for suite-level flags versus runner-lifecycle or credential-sensitive flags.

## Linked context

Stacked on openclaw/openclaw#91502.
Related openclaw/crabline#1.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: shared QA suite selections no longer get dropped or rejected when using `qa suite --runner multipass`; the existing isolated runner wrapper preserves them for the guest suite command.
- Real environment tested: local OpenClaw checkout on `codex/multipass-channel-driver-runner-parity`.
- Exact steps or command run after this patch:
  - `git diff --check`
  - `pnpm exec oxfmt --check CHANGELOG.md extensions/qa-lab/src/cli.runtime.ts extensions/qa-lab/src/cli.runtime.test.ts extensions/qa-lab/src/multipass.runtime.ts extensions/qa-lab/src/multipass.runtime.test.ts`
  - `pnpm tsgo:extensions`
  - `node scripts/run-vitest.mjs extensions/qa-lab/src/cli.runtime.test.ts extensions/qa-lab/src/multipass.runtime.test.ts extensions/qa-lab/src/crabline-channel-driver.test.ts extensions/qa-lab/src/suite.summary-json.test.ts extensions/qa-lab/src/suite.test.ts extensions/qa-lab/src/qa-transport-registry.test.ts`
- Evidence after fix: focused Vitest run passed 6 files / 117 tests; formatting, whitespace, and extension typecheck passed.
- Observed result after fix: `runQaSuiteCommand` now passes channel-driver selection and plugin enablements to `runQaMultipass`, and `createQaMultipassPlan` renders those selections into the generated guest `pnpm openclaw qa suite` command.
- What was not tested: a live run of the existing isolated runner wrapper and live Telegram SDK-channel e2e assertions.
- Proof limitations or environment constraints: this is scoped to deterministic command construction and CLI routing; live isolated-runner validation can run after reviewer agreement on the parity boundary.
- Before evidence: #91502 rejected `--channel-driver crabline` with `--runner multipass`, and the isolated runner wrapper did not forward `--enable-plugin`.

## Tests and validation

- Added CLI runtime coverage for forwarding channel-driver selection and plugin enablements to `runQaMultipass`.
- Added isolated-runner command construction coverage for generated guest command flags.
- Validation run locally:
  - `git diff --check`
  - `pnpm exec oxfmt --check CHANGELOG.md extensions/qa-lab/src/cli.runtime.ts extensions/qa-lab/src/cli.runtime.test.ts extensions/qa-lab/src/multipass.runtime.ts extensions/qa-lab/src/multipass.runtime.test.ts`
  - `pnpm tsgo:extensions`
  - `node scripts/run-vitest.mjs extensions/qa-lab/src/cli.runtime.test.ts extensions/qa-lab/src/multipass.runtime.test.ts extensions/qa-lab/src/crabline-channel-driver.test.ts extensions/qa-lab/src/suite.summary-json.test.ts extensions/qa-lab/src/suite.test.ts extensions/qa-lab/src/qa-transport-registry.test.ts`

## Risk checklist

Did user-visible behavior change? `Yes`: `qa suite --runner multipass` now accepts and preserves shared channel-driver and plugin enablement flags.

Did config, environment, or migration behavior change? `No`.

Did security, auth, secrets, network, or tool execution behavior change? `No`.

What is the highest-risk area? Misclassifying a runner-specific flag as shared suite semantics.

How is that risk mitigated? The PR only forwards deterministic suite selections; credential-sensitive auth mode and preflight artifact behavior stay host-only, and VM sizing flags stay Multipass-only.

## Current review state

Next action: review after #91502.

Still waiting on: #91502 and openclaw/crabline#1.

Bot/reviewer comments addressed: follow-up to maintainer question about runner flag parity; repo identity and channel-driver id updated from `multipass` to `crabline`.
