### PR TITLE
Add claw score taxonomy

### DIFF
--- a/.agents/skills/claw-score/taxonomy.yaml
+++ b/.agents/skills/claw-score/taxonomy.yaml
@@ -1,0 +1,8468 @@
+version: 1
+process_version: 3
+title: Maturity scorecard
+summary: Draft maturity scorecard model for OpenClaw subsystems, features, apps, and platforms.
+snapshot:
+  date: '2026-05-26'
+  source_ref: origin/main@41eef4a7965
+levels:
+  - id: planned
+    code: M0
+    label: Planned
+    meaning: Direction is known, but no supported user path exists.
+    promotion_bar: Design issue, owner, and target surface exist.
+  - id: experimental
+    code: M1
+    label: Experimental
+    meaning: Implemented behind caveats, flags, source builds, or maintainer-only flows.
+    promotion_bar: Maintainer can run the scenario from current main.
+  - id: alpha
+    code: M2
+    label: Alpha
+    meaning: Real users can try it, but breaking changes and incomplete UX are expected.
+    promotion_bar: Documented setup, basic tests, known caveats, and at least one real-environment proof.
+  - id: beta
+    code: M3
+    label: Beta
+    meaning: Public path exists and the main workflow is usable with bounded caveats.
+    promotion_bar: Install/update docs, regression tests, support runbook, and successful scenario proof across the expected environment.
+  - id: stable
+    code: M4
+    label: Stable
+    meaning: Recommended path for normal users. Failures are treated as regressions.
+    promotion_bar: Release gate, doctor/troubleshooting path, broad docs, and repeated real-world proof.
+  - id: lovable
+    code: M5
+    label: Lovable
+    meaning: Polished, delightful, well-instrumented, and competitive with the best comparable workflow.
+    promotion_bar: Stable plus user scorecard pass across representative users.
+surfaces:
+  - id: gateway-runtime
+    name: Gateway runtime
+    family: core
+    level: stable
+    level_code: M4
+    rationale: Core architecture, auth, pairing, protocol docs, daemon docs, and CLI runbooks are broad and current.
+    completeness_instructions: references/completeness/gateway-runtime.md
+    categories:
+      - name: Approvals and Remote Execution
+        features:
+          - name: Exec approvals
+            description: Exec approval request, lookup, wait, resolve, and policy snapshot APIs.
+          - name: Plugin approvals
+            description: Plugin approval request, wait, and resolution flows.
+          - name: Node exec approvals
+            description: Node-local exec approval policy relay through Gateway RPC.
+          - name: Approved node execution
+            description: Canonical `systemRunPlan` binding for node-host execution.
+          - name: Approval mutation safety
+            description: Rejection of mutated `command`, `cwd`, `agentId`, or `sessionKey` after approval preparation.
+          - name: Delivery fallback behavior
+            description: Agent delivery fallback between strict deliverable routes and session-only execution.
+        docs:
+          - docs/gateway/protocol.md
+          - docs/gateway/security/index.md
+        search_anchors:
+          - 'gateway runtime and websocket protocol gateway runtime websocket feature matrix: approval and execution safety'
+          - 'gateway runtime websocket feature matrix: approval and execution safety'
+        category_note: approval-and-execution-safety.md
+        human_lts_override: true
+      - name: HTTP APIs
+        features:
+          - name: OpenAI-compatible APIs
+            description: OpenAI-compatible HTTP APIs (`/v1/models`, `/v1/chat/completions`, `/v1/responses`, `/v1/embeddings`).
+          - name: Tool invocation API
+            description: HTTP tools invoke path.
+          - name: Admin API access
+            description: Optional admin HTTP RPC plugin route.
+          - name: Hook ingress
+            description: Hook hosting and HTTP ingress routes.
+        docs:
+          - docs/gateway/index.md
+          - docs/gateway/openai-http-api.md
+          - docs/gateway/openresponses-http-api.md
+          - docs/gateway/tools-invoke-http-api.md
+          - docs/automation/hooks.md
+          - docs/web/index.md
+        search_anchors:
+          - gateway http api
+          - openai compatible http api
+          - tools invoke http api
+          - admin http rpc
+          - hook ingress
+        category_note: http-apis.md
+        human_lts_override: true
+      - name: Hosted Web Surface
+        features:
+          - name: Control UI
+            description: Control UI hosting on the Gateway server.
+          - name: WebChat hosting
+            description: WebChat hosting.
+          - name: Plugin web routes
+            description: Canvas and other plugin HTTP surfaces served by the Gateway.
+          - name: Canvas and A2UI routes
+            description: Canvas documents, A2UI transport, and browser-hosted plugin routes under the Gateway HTTP server.
+        docs:
+          - docs/gateway/index.md
+          - docs/concepts/architecture.md
+          - docs/web/control-ui.md
+          - docs/web/webchat.md
+          - docs/refactor/canvas.md
+        search_anchors:
+          - hosted web surface
+          - control ui gateway
+          - webchat gateway
+          - plugin http route gateway
+          - canvas a2ui gateway
+        category_note: hosted-web-surface.md
+        human_lts_override: true
+      - name: Gateway RPC APIs and Events
+        features:
+          - name: Health APIs
+            description: '`health` and `status` RPCs.'
+          - name: Identity and presence APIs
+            description: '`gateway.identity.get`, `system-presence`, `system-event`, and heartbeat RPCs.'
+          - name: Model APIs
+            description: '`models.list` RPCs.'
+          - name: Usage and memory APIs
+            description: Usage summaries and memory readiness RPCs.
+          - name: Session APIs
+            description: '`sessions.*` RPCs.'
+          - name: Chat APIs
+            description: '`chat.*` and `agent.wait` RPCs.'
+          - name: Channel APIs
+            description: '`channels.status` and `channels.logout` RPCs.'
+          - name: Web login and wake APIs
+            description: '`web.login.*`, `push.test`, and `voicewake.*` RPCs.'
+          - name: Config and secrets APIs
+            description: '`config.*` and `secrets.*` RPCs.'
+          - name: Update and setup APIs
+            description: '`update.*` and `wizard.*` RPCs.'
+          - name: Agent and artifact APIs
+            description: '`agents.*`, agent files, environments, and artifact RPCs.'
+          - name: Task and automation APIs
+            description: '`wake`, `cron.*`, and `tasks.*` RPCs.'
+          - name: Tool and skill APIs
+            description: '`commands.list`, `tools.*`, and `skills.*` RPCs.'
+          - name: Request and event envelopes
+            description: Request, response, and event frame shapes.
+          - name: Idempotent side effects
+            description: Idempotency requirements for side-effecting methods.
+          - name: Method discovery
+            description: Method discovery via `hello-ok.features.methods`.
+          - name: Event discovery
+            description: Event discovery via `hello-ok.features.events`.
+          - name: Accepted-then-final results
+            description: Immediate accepted ack plus later final result.
+          - name: Event ordering
+            description: Sequence handling and per-client monotonic event ordering.
+          - name: State refresh after gaps
+            description: No-replay event model and explicit gap recovery via state refresh.
+        docs:
+          - docs/gateway/protocol.md
+          - docs/gateway/index.md
+          - docs/concepts/architecture.md
+        search_anchors:
+          - core rpc coverage
+          - rpc framing
+          - control-plane semantics
+          - hello-ok.features.methods
+          - hello-ok.features.events
+          - event sequence
+          - idempotencyKey
+        category_note: core-rpc-coverage.md
+        human_lts_override: true
+      - name: Device Auth and Pairing
+        features:
+          - name: Shared-secret login
+            description: Shared-secret auth by token or password.
+          - name: Trusted proxy auth
+            description: Trusted-proxy and identity-bearing auth modes.
+          - name: Private ingress mode
+            description: 'Private-ingress `gateway.auth.mode: "none"` behavior and its limits.'
+          - name: Device challenge signing
+            description: Device identity signing against the challenge nonce.
+          - name: Device tokens
+            description: Device token issuance, persistence, reconnect reuse, rotation, and revocation.
+          - name: Setup-code bootstrap
+            description: Bootstrap setup-code token flows and bounded operator token handoff.
+          - name: Auth mismatch recovery
+            description: Recovery semantics for `AUTH_TOKEN_MISMATCH` and `AUTH_SCOPE_MISMATCH`.
+          - name: Device auth migration
+            description: Device-auth migration errors and required v2/v3 signature behavior.
+          - name: Client pairing
+            description: Device pairing requirements for new clients.
+          - name: Node pairing
+            description: Node pairing flows, including pending requests, approvals, expiry, and trusted-CIDR or metadata-upgrade auto-approval boundaries.
+        docs:
+          - docs/gateway/protocol.md
+          - docs/gateway/pairing.md
+          - docs/gateway/security/index.md
+        search_anchors:
+          - gateway runtime and websocket protocol device identity, auth, and pairing
+          - device identity, auth, and pairing
+        category_note: device-identity-auth-and-pairing.md
+        human_lts_override: true
+      - name: Network Access and Discovery
+        features:
+          - name: Loopback and LAN access
+            description: Loopback and LAN-facing Gateway exposure.
+          - name: Tailnet access
+            description: Tailnet-facing Gateway exposure and MagicDNS/Tailscale routing.
+          - name: SSH tunnels
+            description: SSH tunneling as the fallback remote path.
+          - name: Endpoint discovery
+            description: Bonjour/DNS-SD discovery, wide-area DNS-SD, and advertised transport hints.
+          - name: Saved endpoints
+            description: Saved remote Gateway endpoints and route preference order.
+          - name: TLS pinning
+            description: TLS enablement and optional certificate fingerprint pinning.
+        docs:
+          - docs/gateway/index.md
+          - docs/gateway/discovery.md
+          - docs/gateway/protocol.md
+        search_anchors:
+          - gateway runtime and websocket protocol network exposure and transport selection
+          - network exposure and transport selection
+        category_note: network-exposure-and-transport-selection.md
+        human_lts_override: true
+      - name: Nodes and Remote Capabilities
+        features:
+          - name: Node presence
+            description: Node presence in the same WS control plane as operator clients.
+          - name: Node capabilities
+            description: Node capability declaration at connect time.
+          - name: Node inventory
+            description: '`node.list`, `node.describe`, and naming/state visibility.'
+          - name: Node actions
+            description: '`node.invoke` and `node.invoke.result`.'
+          - name: Node events
+            description: '`node.event`, especially `node.presence.alive`.'
+          - name: Pending work delivery
+            description: Pending work APIs for connected and disconnected nodes.
+          - name: Remote device capabilities
+            description: Relay of remote capability surfaces such as camera, canvas, screen, location, voice, and browser.
+          - name: Remote host commands
+            description: Relay of remote host-command capability surfaces.
+        docs:
+          - docs/gateway/protocol.md
+          - docs/concepts/architecture.md
+          - docs/nodes/index.md
+        search_anchors:
+          - gateway runtime and websocket protocol node transport and capability relay
+          - node transport and capability relay
+        category_note: node-transport-and-capability-relay.md
+        human_lts_override: false
+      - name: Health, Diagnostics, and Repair
+        features:
+          - name: Health snapshots
+            description: '`health` and `status` snapshots.'
+          - name: Channel readiness
+            description: Channel readiness probing through the running Gateway.
+          - name: Stability diagnostics
+            description: Stability recorder output.
+          - name: Payload diagnostics
+            description: '`payload.large` diagnostics.'
+          - name: Diagnostics exports
+            description: Diagnostics export contents, privacy model, and CLI/chat triggers.
+          - name: Doctor checks
+            description: Doctor checks for UI protocol freshness, service drift, auth/pairing drift, port collisions, sandbox/runtime best practices, and source-install issues.
+          - name: Log tailing
+            description: Log tailing and operational signal visibility.
+        docs:
+          - docs/gateway/index.md
+          - docs/gateway/diagnostics.md
+          - docs/gateway/doctor.md
+        search_anchors:
+          - gateway runtime and websocket protocol observability, health, and repair
+          - observability, health, and repair
+        category_note: observability-health-and-repair.md
+        human_lts_override: true
+      - name: Protocol Compatibility
+        features:
+          - name: Published protocol schema
+            description: TypeBox as the protocol source of truth.
+          - name: Runtime request validation
+            description: Runtime validators for protocol payloads.
+          - name: JSON Schema export
+            description: Generated JSON Schema for protocol payloads.
+          - name: Swift client models
+            description: Swift model generation.
+          - name: Version negotiation
+            description: Current protocol constants and supported protocol range behavior.
+          - name: Client transport defaults
+            description: Client defaults for request timeouts, reconnect backoff, and tick handling.
+          - name: Backward-compatible evolution
+            description: Additive evolution discipline for new methods, events, or payload fields.
+        docs:
+          - docs/gateway/protocol.md
+          - docs/concepts/architecture.md
+          - docs/concepts/typebox.md
+          - docs/gateway/bridge-protocol.md
+        search_anchors:
+          - gateway runtime and websocket protocol protocol typing and compatibility
+          - protocol typing and compatibility
+        category_note: protocol-typing-and-compatibility.md
+        human_lts_override: true
+      - name: Roles and Permissions
+        features:
+          - name: Role negotiation
+            description: '`operator` versus `node` role negotiation.'
+          - name: Operator permissions
+            description: Core operator scopes such as `operator.read`, `operator.write`, `operator.admin`, `operator.approvals`, `operator.pairing`, and `operator.talk.secrets`.
+          - name: Approval-gated actions
+            description: Extra approval-time scope requirements for pairing and dangerous node commands.
+          - name: Untrusted node declarations
+            description: Node-declared `caps`, `commands`, and `permissions` as claims rather than trusted truth.
+          - name: Event scoping
+            description: Broadcast event scoping, including fail-closed behavior for unknown event families.
+        docs:
+          - docs/gateway/protocol.md
+          - docs/gateway/security/index.md
+        search_anchors:
+          - 'gateway runtime and websocket protocol gateway runtime websocket feature matrix: roles, scopes, and operator policy'
+          - 'gateway runtime websocket feature matrix: roles, scopes, and operator policy'
+        category_note: roles-scopes-and-operator-policy.md
+        human_lts_override: true
+      - name: Gateway Lifecycle
+        features:
+          - name: Foreground startup
+            description: Local foreground startup via `openclaw gateway`.
+          - name: Service installation
+            description: Supervised lifecycle installation on macOS, Linux user/systemd, and native Windows task scheduling.
+          - name: Restart and stop
+            description: Correct `restart` and `stop` behavior for supervised installs.
+          - name: Service status
+            description: Status behavior for supervised installs.
+          - name: Bind and port settings
+            description: Bind and port precedence across CLI flags, env vars, config, and persisted supervisor metadata.
+          - name: Config reload
+            description: 'Config reload modes: `off`, `hot`, `restart`, and `hybrid`.'
+          - name: Multi-gateway isolation
+            description: Multiple-gateway isolation on one host, including config/state/workspace separation.
+        docs:
+          - docs/gateway/index.md
+          - docs/concepts/architecture.md
+        search_anchors:
+          - gateway runtime and websocket protocol runtime lifecycle and supervision
+          - runtime lifecycle and supervision
+        category_note: runtime-lifecycle-and-supervision.md
+        human_lts_override: true
+      - name: Security Controls
+        features:
+          - name: Non-loopback auth
+            description: Auth-required non-loopback exposure.
+          - name: Trusted proxy exceptions
+            description: Trusted-proxy and control-plane device-auth exceptions.
+          - name: Gateway and node trust boundaries
+            description: Gateway/node trust-domain definition.
+          - name: Trusted CIDR auto-approval
+            description: Trusted-CIDR limits for node auto-approval.
+          - name: Fail-closed protocol handling
+            description: Fail-fast/fail-closed behavior for protocol violations and unknown event families.
+          - name: Remote execution safeguards
+            description: Security posture around remote node execution and browser-control relay.
+        docs:
+          - docs/gateway/security/index.md
+          - docs/gateway/protocol.md
+          - docs/gateway/discovery.md
+        search_anchors:
+          - gateway runtime and websocket protocol security and hardening posture
+          - security and hardening posture
+        category_note: security-and-hardening-posture.md
+        human_lts_override: true
+      - name: WebSocket Connection
+        features:
+          - name: WebSocket transport
+            description: WebSocket transport with JSON text frames.
+          - name: Connect challenge
+            description: Mandatory pre-connect `connect.challenge`.
+          - name: Connect request
+            description: Mandatory first-frame `connect` request.
+          - name: Protocol version negotiation
+            description: Protocol range negotiation (`minProtocol`/`maxProtocol`).
+          - name: hello-ok snapshot
+            description: 'Required `hello-ok` payload structure: server identity, negotiated auth, feature discovery, snapshot, and policy limits.'
+          - name: Startup retry
+            description: Retryable startup-sidecar `UNAVAILABLE` behavior during Gateway startup.
+          - name: Session limits
+            description: Post-handshake policy advertisement (`maxPayload`, `maxBufferedBytes`, `tickIntervalMs`).
+          - name: Plugin surface URLs
+            description: Optional `pluginSurfaceUrls` issuance and refresh.
+        docs:
+          - docs/gateway/protocol.md
+          - docs/concepts/architecture.md
+        search_anchors:
+          - gateway runtime and websocket protocol websocket handshake and session establishment
+          - websocket handshake and session establishment
+        category_note: websocket-handshake-and-session-establishment.md
+        human_lts_override: true
+    last_score_run:
+      status: complete
+      completed_at: '2026-05-31'
+      by: codex
+      source_ref: null
+      process_version: 3
+  - id: cli-install-update-onboard-doctor
+    name: CLI
+    family: core
+    level: stable
+    level_code: M4
+    rationale: Normal setup and repair paths are documented across install, CLI, and gateway docs. Platform-specific Windows paths are tracked in the Windows via WSL2 and Native Windows rows.
+    completeness_instructions: references/completeness/cli-install-update-onboard-doctor.md
+    categories:
+      - name: CLI Setup
+        features:
+          - name: Installer scripts
+            description: Hosted installer scripts set up Node, install OpenClaw, and optionally start onboarding.
+          - name: Local prefix install
+            description: The local-prefix installer keeps Node and OpenClaw under a dedicated OpenClaw directory instead of relying on a system-wide runtime.
+          - name: Package-manager installs
+            description: npm, pnpm, and bun global installs are supported when the operator manages Node directly, including PATH wiring expectations.
+          - name: Supported Node runtime
+            description: OpenClaw documents the supported Node versions and recommended runtime before normal CLI workflows continue.
+          - name: Source checkout install
+            description: Operators can run OpenClaw from a source checkout for development or recovery workflows, and update flows distinguish this path from package installs.
+          - name: CLI entrypoint
+            description: The packaged openclaw launcher, openclaw --help, openclaw --version, runtime preflight, and basic recovery expectations are documented.
+        docs:
+          - docs/install/index.md
+          - docs/install/installer.md
+          - docs/install/node.md
+          - docs/install/updating.md
+        search_anchors:
+          - cli install, update, onboard, doctor cli installation and launch
+          - cli installation and launch
+          - cli install, update, onboard, doctor runtime prerequisites
+          - runtime prerequisites
+        category_note: package-install-and-cli-entrypoints.md
+        human_lts_override: true
+      - name: Onboarding and Auth Setup
+        features:
+          - name: Guided onboarding
+            description: openclaw onboard walks through workspace, gateway, model auth, channels, skills, and health setup.
+          - name: Targeted reconfiguration
+            description: openclaw configure lets operators revisit only the sections they want to change after the initial setup.
+          - name: Auth choices
+            description: Onboarding and configure support API-key, OAuth, and other provider-specific auth choices.
+          - name: Gateway auth storage
+            description: Gateway token and password setup are documented, including SecretRef-managed storage behavior.
+          - name: Remote onboarding
+            description: Remote-gateway onboarding documents what is configured locally versus what must already exist on the remote host.
+        docs:
+          - docs/cli/onboard.md
+          - docs/cli/configure.md
+          - docs/start/onboarding-overview.md
+        search_anchors:
+          - cli install, update, onboard, doctor onboarding and auth setup
+          - onboarding and auth setup
+        category_note: first-run-onboarding-and-auth-selection.md
+        human_lts_override: true
+      - name: Plugin and Channel Setup
+        features:
+          - name: Channel picker
+            description: Onboarding can guide the operator through choosing which channels to configure.
+          - name: Plugin install sources
+            description: Plugin setup supports bundled, npm, ClawHub, marketplace, git, and local install sources.
+          - name: Channel account setup
+            description: Channel commands support interactive and flag-driven account configuration for supported chat transports.
+          - name: Post-setup probes
+            description: Operators can probe channel status and capabilities after setup to verify that the configured account works.
+          - name: Remote gateway caveat
+            description: Remote onboarding documents that plugin installation does not happen locally when the gateway runs elsewhere.
+        docs:
+          - docs/cli/onboard.md
+          - docs/cli/plugins.md
+          - docs/cli/channels.md
+        search_anchors:
+          - cli install, update, onboard, doctor plugin and channel setup
+          - plugin and channel setup
+        category_note: plugin-and-channel-setup-during-onboarding.md
+        human_lts_override: false
+      - name: Gateway Service Management
+        features:
+          - name: Foreground gateway runs
+            description: Operators can run the gateway directly from the CLI for local development or ad hoc recovery.
+          - name: Service install and control
+            description: The CLI documents install, status, start, stop, restart, and run flows for managed gateway services.
+          - name: Service auth wiring
+            description: Gateway service installation documents how auth tokens and other sensitive values are handled.
+          - name: Drift and reinstall recovery
+            description: Operators are given explicit guidance for repairing or reinstalling a broken managed gateway service.
+          - name: Service health checks
+            description: Gateway service flows point operators at runtime health and troubleshooting checks after install or restart.
+        docs:
+          - docs/cli/gateway.md
+          - docs/install/updating.md
+          - docs/gateway/troubleshooting.md
+        search_anchors:
+          - cli install, update, onboard, doctor gateway service management
+          - gateway service management
+        category_note: gateway-service-install-and-lifecycle.md
+        human_lts_override: true
+      - name: CLI Observability
+        features:
+          - name: Status snapshots
+            description: openclaw status and related flags summarize runtime state, config health, and update context.
+          - name: Health snapshots
+            description: openclaw health gives a fast gateway health read and supports verbose or JSON output.
+          - name: Remote log tailing
+            description: openclaw logs tails gateway logs over RPC, including follow mode and JSON output.
+          - name: Diagnostics export
+            description: Gateway diagnostics bundles can be exported locally for bug reports and support workflows.
+          - name: Support-safe redaction
+            description: Diagnostics and status paths document privacy and redaction expectations before sharing results.
+        docs:
+          - docs/cli/status.md
+          - docs/cli/health.md
+          - docs/cli/logs.md
+          - docs/gateway/diagnostics.md
+        search_anchors:
+          - cli install, update, onboard, doctor status health logs and diagnostics
+          - status health logs and diagnostics
+        category_note: status-health-logs-and-diagnostics-support-path.md
+        human_lts_override: true
+      - name: Doctor
+        features:
+          - name: Interactive repair
+            description: openclaw doctor supports inspect, repair, non-interactive, and forceful repair postures.
+          - name: Config migration
+            description: Doctor rewrites legacy or damaged config and state into supported current formats.
+          - name: Auth and SecretRef checks
+            description: Doctor audits auth shape, token generation, and supported SecretRef-backed config paths.
+          - name: Plugin validation and repair
+            description: Doctor surfaces plugin-config issues and extension schema drift that block normal runtime operation.
+          - name: Lint and JSON findings
+            description: openclaw doctor --lint --json provides stable machine-readable findings for automation.
+          - name: Extra gateway discovery
+            description: Doctor can scan for unexpected gateway services and conflicting installs.
+          - name: Supervisor drift repair
+            description: Doctor checks managed service definitions and can repair launchd, systemd, or Scheduled Task drift.
+          - name: Port and startup diagnosis
+            description: Doctor points operators at port conflicts, restart failures, and recent gateway errors.
+          - name: Runtime path checks
+            description: Doctor checks runtime-path best practices and common path misconfigurations.
+          - name: Restart guidance
+            description: Doctor explains when a health issue needs a restart or a deeper service repair path.
+        docs:
+          - docs/cli/doctor.md
+          - docs/gateway/doctor.md
+          - docs/gateway/secrets.md
+          - docs/gateway/troubleshooting.md
+        search_anchors:
+          - cli install, update, onboard, doctor doctor config and policy repair
+          - doctor config and policy repair
+          - cli install, update, onboard, doctor doctor platform and service repair
+          - doctor platform and service repair
+        category_note: doctor-config-auth-plugin-and-lint.md
+        human_lts_override: true
+      - name: Updates and Upgrades
+        features:
+          - name: Update channels
+            description: openclaw update supports stable, beta, and dev channel selection.
+          - name: Install-kind switching
+            description: Update flows can switch between package installs and git/source installs when supported.
+          - name: Managed gateway restart
+            description: Update flows document when the managed gateway is stopped, restarted, or intentionally left alone.
+          - name: Update status and RPC
+            description: Operators can inspect update status and related gateway control-plane state.
+          - name: Plugin convergence
+            description: Core updates document how plugin versions and plugin repair warnings are handled afterward.
+        docs:
+          - docs/install/updating.md
+          - docs/cli/update.md
+          - docs/gateway/troubleshooting.md
+        search_anchors:
+          - cli install, update, onboard, doctor updates and upgrades
+          - updates and upgrades
+        category_note: update-channel-and-core-upgrade-flow.md
+        human_lts_override: true
+    last_score_run:
+      status: complete
+      completed_at: '2026-05-30'
+      by: codex
+      source_ref: null
+      process_version: 3
+  - id: plugin-sdk-and-bundled-plugin-architecture
+    name: Plugins
+    family: core
+    level: beta
+    level_code: M3
+    rationale: Broad docs and strong internal runtime evidence exist across manifests, discovery, loading, provider/tool architecture, and approval boundaries. Keep the row at beta until public SDK API/subpaths and external distribution proof are stronger.
+    completeness_instructions: references/completeness/plugin-sdk-and-bundled-plugin-architecture.md
+    additional_validation:
+      - name: Plugin SDK exports sync
+        command: pnpm plugin-sdk:check-exports
+        purpose: Verify generated public SDK exports still match the checked-in entrypoint inventory.
+      - name: Plugin SDK API baseline
+        command: pnpm plugin-sdk:api:check
+        purpose: Detect public API drift in the packaged Plugin SDK surface.
+      - name: Plugin SDK surface budget
+        command: pnpm plugin-sdk:surface:check
+        purpose: Enforce public SDK surface-size budgets and deprecated-export limits.
+      - name: Plugin boundary report
+        command: pnpm plugins:boundary-report:ci
+        purpose: Fail on cross-owner reserved imports, unclassified reserved subpaths, and due compatibility debt.
+      - name: Plugin npm release check
+        command: pnpm release:plugins:npm:check
+        purpose: Validate publishable plugin npm metadata and release readiness.
+      - name: Plugin ClawHub release check
+        command: pnpm release:plugins:clawhub:check
+        purpose: Validate publishable plugin ClawHub metadata and release readiness.
+    categories:
+      - name: Authoring and Packaging plugins
+        features:
+          - name: Root SDK entrypoint
+            description: Plugin authors use the supported root Plugin SDK entrypoint when the top-level contract is sufficient.
+          - name: Focused SDK imports
+            description: Plugin authors use focused Plugin SDK subpaths instead of relying on one broad catch-all entrypoint.
+          - name: Entrypoint discovery
+            description: Plugin authors discover the supported public entrypoints and their support status from the SDK docs and entrypoint catalog.
+          - name: Migration shims
+            description: Deprecated or compatibility subpaths continue to resolve during author migrations.
+          - name: Plugin manifest
+            description: '`openclaw.plugin.json` declares plugin identity, capabilities, and config schema.'
+          - name: Package metadata
+            description: '`package.json` carries the required `openclaw` metadata for discovery and release flows.'
+          - name: Runtime compatibility
+            description: Plugin packages declare supported runtime and plugin API compatibility.
+          - name: Validation feedback
+            description: Manifest and package contract validation fails fast on malformed or inconsistent metadata.
+        docs:
+          - docs/plugins/building-plugins.md
+          - docs/plugins/sdk-overview.md
+          - docs/plugins/sdk-entrypoints.md
+          - docs/plugins/sdk-subpaths.md
+          - docs/plugins/manifest.md
+          - docs/plugins/reference.md
+        search_anchors:
+          - plugin sdk entrypoints
+          - plugin sdk subpaths
+          - plugin manifest
+          - package metadata
+          - authoring plugins
+          - packaging plugins
+        category_note: public-sdk-api-and-subpaths.md
+        human_lts_override: true
+      - name: Bundled plugins
+        features:
+          - name: Bundled plugin listing
+            description: Operators and maintainers can inspect the bundled plugin set and its published metadata.
+          - name: Bundled source overlays
+            description: Source overlays work for local development and repo-driven testing.
+          - name: Packaged bundled plugins
+            description: Built distributions discover bundled plugins from packaged roots.
+          - name: Generated plugin inventory
+            description: Generated plugin inventory and reference docs describe what ships in core versus what installs separately.
+          - name: Bundled channel IDs
+            description: Bundled channel ids are discovered and normalized from plugin metadata.
+        docs:
+          - docs/plugins/plugin-inventory.md
+          - docs/cli/plugins.md
+          - docs/plugins/architecture-internals.md
+        search_anchors:
+          - bundled plugins
+          - plugin inventory
+          - bundled plugin metadata
+        category_note: bundled-plugin-discovery-and-inventory.md
+        human_lts_override: true
+      - name: Canvas plugin
+        features:
+          - name: Hosted Canvas and A2UI surfaces
+            description: Canvas plugin registers authenticated Gateway HTTP and WebSocket routes for hosted Canvas documents and A2UI runtime surfaces.
+          - name: Agent canvas tool
+            description: Canvas plugin registers the agent-facing `canvas` tool for present, hide, navigate, eval, snapshot, and A2UI control.
+          - name: Node Canvas commands
+            description: Canvas plugin owns node invoke policy for `canvas.present`, `canvas.navigate`, `canvas.eval`, `canvas.snapshot`, and `canvas.a2ui.*` commands.
+          - name: Control UI embeds
+            description: Assistant output can embed hosted Canvas document URLs in Control UI and WebChat sessions.
+          - name: Canvas documents
+            description: Canvas plugin materializes hosted document files and `/__openclaw__/canvas/documents/...` URLs.
+          - name: A2UI transport and snapshots
+            description: Canvas plugin groups A2UI push, reset, and JSONL transport with snapshot capture and node-rendered Canvas state.
+        docs:
+          - docs/plugins/reference/canvas.md
+          - docs/refactor/canvas.md
+          - docs/gateway/configuration-reference.md
+        search_anchors:
+          - Canvas plugin
+          - hosted canvas documents
+          - A2UI
+          - canvas tool
+          - canvas node commands
+        category_note: canvas-plugin.md
+        human_lts_override: false
+      - name: Installing and running plugins
+        features:
+          - name: Plugin setup
+            description: Operators can run plugin setup flows without fully activating runtime behavior.
+          - name: Runtime activation
+            description: Enabled plugins activate and register runtime behavior after manifest validation succeeds.
+          - name: Enable and disable
+            description: Operators can enable or disable installed plugins without losing install state.
+          - name: Safe load failures
+            description: Unsafe or unsupported plugin loads are blocked with diagnosable failures before runtime execution.
+          - name: Dependency repair
+            description: Runtime can detect and repair missing or stale plugin dependencies.
+          - name: Install update and uninstall
+            description: Install, update, and uninstall lifecycle behavior is defined and tested.
+        docs:
+          - docs/plugins/architecture.md
+          - docs/plugins/architecture-internals.md
+          - docs/cli/plugins.md
+        search_anchors:
+          - installing and running plugins
+          - plugin setup
+          - runtime activation
+          - plugins doctor
+        category_note: runtime-loading-and-lifecycle.md
+        human_lts_override: true
+      - name: Channel plugins
+        features:
+          - name: Inbound event handling
+            description: Channel plugins register inbound hooks and normalize incoming events.
+          - name: Outbound delivery
+            description: Outbound adapters translate model output into channel-specific payloads.
+          - name: Ingress authorization
+            description: Channel ingress runtime enforces the shared inbound authorization boundary.
+          - name: Destination resolution
+            description: Target resolution maps users, threads, and conversations into channel destinations.
+          - name: Native approval prompts
+            description: Native channel actions can route approval prompts and responses through the approval system.
+        docs:
+          - docs/plugins/sdk-channel-plugins.md
+          - docs/plugins/sdk-channel-inbound.md
+          - docs/plugins/sdk-channel-outbound.md
+        search_anchors:
+          - channel plugins
+          - sdk channel plugins
+          - channel inbound
+          - channel outbound
+        category_note: channel-plugin-architecture.md
+        human_lts_override: true
+      - name: Provider and tool plugins
+        features:
+          - name: Provider plugins
+            description: Provider plugins register models and capabilities with the runtime.
+          - name: Tool plugins
+            description: Tool plugins register discoverable tools and static metadata without ambiguous runtime ownership.
+          - name: Model catalogs
+            description: Provider model catalogs are discoverable and merge cleanly into global listings.
+          - name: Provider auth
+            description: Provider auth configuration and secret handling are supported.
+          - name: Web search and fetch
+            description: Provider or tool plugins can expose web search and fetch capabilities.
+          - name: Mixed plugins
+            description: Mixed provider and tool plugins are supported without ambiguous ownership.
+        docs:
+          - docs/plugins/sdk-provider-plugins.md
+          - docs/plugins/tool-plugins.md
+          - docs/plugins/adding-capabilities.md
+        search_anchors:
+          - provider and tool plugins
+          - provider plugins
+          - tool plugins
+          - adding capabilities
+        category_note: provider-tool-plugin-architecture.md
+        human_lts_override: true
+      - name: Plugin approvals
+        features:
+          - name: Approval requests
+            description: Plugin-initiated actions can request and resolve approvals through the standard flow.
+          - name: Native approval delivery
+            description: Privileged plugin actions can route approvals through channel-native prompts and responses.
+          - name: Same-chat fallbacks
+            description: Approval delivery can fall back to same-chat authorization notices when native routing is unavailable.
+          - name: Exec and plugin separation
+            description: Exec approvals remain distinct from plugin approval paths and native permission relays.
+          - name: Approval replay protection
+            description: Approval decisions remain scoped to the originating request, target, and device or node binding.
+          - name: Security helpers
+            description: Security helper exports provide approved primitives without widening trust boundaries.
+        docs:
+          - docs/plugins/plugin-permission-requests.md
+          - docs/tools/exec-approvals.md
+          - docs/plugins/sdk-channel-plugins.md
+        search_anchors:
+          - plugin approvals
+          - plugin permission requests
+          - exec approvals
+        category_note: approval-and-security-boundaries.md
+        human_lts_override: true
+      - name: Publishing plugins
+        features:
+          - name: Install sources
+            description: Supported plugin install sources are explicit and validated.
+          - name: ClawHub publishing
+            description: Plugin metadata and workflows support publishing to ClawHub.
+          - name: npm publishing
+            description: Plugin metadata and workflows support publishing to npm when applicable.
+          - name: Compatibility signaling
+            description: Compatibility registry data maps plugins to supported runtime versions or channels.
+          - name: Update and rollback expectations
+            description: Plugin update semantics define what can be upgraded in place and what requires operator intervention.
+          - name: Third-party publication rules
+            description: External package acceptance rules gate third-party plugin packaging and publication.
+        docs:
+          - docs/cli/plugins.md
+          - docs/plugins/compatibility.md
+          - docs/clawhub/publishing.md
+        search_anchors:
+          - publishing plugins
+          - clawhub publishing
+          - npm publishing
+          - plugin compatibility
+        category_note: distribution-release-and-compatibility.md
+        human_lts_override: true
+      - name: Testing plugins
+        features:
+          - name: Test fixtures
+            description: Fixtures provide reusable plugin metadata and runtime test inputs.
+          - name: Local test environment
+            description: Plugin authors can set up the local test environment and scoped helper configuration for plugin testing.
+          - name: Plugin runtime harness
+            description: Plugin test harnesses cover authoring and runtime integration paths.
+          - name: Unit and integration scaffolds
+            description: Scoped test helpers and configuration support unit and integration testing for plugin surfaces.
+          - name: Docker lifecycle suites
+            description: Docker-based end-to-end scripts validate packaged plugin lifecycle flows.
+          - name: Smoke tests
+            description: Local and packaged smoke tests catch broken installs before release.
+        docs:
+          - docs/plugins/sdk-testing.md
+          - docs/plugins/sdk-setup.md
+          - docs/plugins/codex-harness.md
+        search_anchors:
+          - testing plugins
+          - sdk testing
+          - plugin test fixtures
+          - codex harness
+        category_note: developer-testing-and-fixtures.md
+        human_lts_override: false
+    last_score_run:
+      status: complete
+      completed_at: '2026-05-30'
+      by: codex
+      source_ref: null
+      process_version: 3
+  - id: agent-runtime-and-provider-execution
+    name: Agent Runtime
+    family: core
+    level: beta
+    level_code: M3
+    rationale: Main loop, models, provider routing, and tool streaming are first-class, but provider behavior shifts weekly and needs scenario proof per release.
+    completeness_instructions: references/completeness/agent-runtime-and-provider-execution.md
+    categories:
+      - name: Agent Turn Execution
+        features:
+          - name: Turn startup and runtime choice
+            description: Starting an agent turn and choosing gateway versus embedded runtime execution.
+          - name: Session and run coordination
+            description: Establishing session and run ids, queue locks, and related execution coordination.
+          - name: Abort and terminal outcomes
+            description: Honoring aborts, timing provider/model work, and emitting terminal outcomes.
+        docs:
+          - docs/concepts/agent-loop.md
+          - docs/cli/agent.md
+          - docs/concepts/agent-runtimes.md
+        search_anchors:
+          - agent RPC shape and event stream
+          - runAgentTurnWithFallback
+          - agent.wait timeout and terminal outcomes
+        category_note: agent-turn-orchestration-and-runtime-lifecycle.md
+        human_lts_override: true
+      - name: External Runtimes and Subagents
+        features:
+          - name: External harness selection
+            description: Choosing Codex app-server, ACP, and other external runtime harnesses.
+          - name: CLI runtime aliases
+            description: Runtime aliases and CLI-based execution paths such as Claude CLI and Gemini CLI.
+          - name: Subagent turns
+            description: Spawning, delivering, and announcing subagent work outside the default embedded path.
+          - name: Runtime recovery
+            description: Cleanup, timeout, and liveness behavior for external runtimes and subagents.
+        docs:
+          - docs/concepts/agent-runtimes.md
+          - docs/providers/anthropic.md
+          - docs/providers/google.md
+          - docs/tools/subagents.md
+        search_anchors:
+          - agent runtimes
+          - subagent turns
+          - CLI runtime aliases
+        category_note: cli-harnesses-external-runtimes-and-subagents.md
+        human_lts_override: false
+      - name: Hosted Provider Execution
+        features:
+          - name: Hosted provider turns
+            description: Running agent turns against hosted providers such as OpenAI, Anthropic, and Google.
+          - name: Provider-specific model options
+            description: Provider-specific model parameters and runtime request settings exposed to users or operators.
+          - name: Hosted tool use
+            description: Tool use behavior when the active runtime is a hosted provider.
+          - name: Reasoning and cache controls
+            description: Provider-specific reasoning, thinking, and cache-related controls during hosted execution.
+          - name: Hosted streaming and replies
+            description: Operator-visible streaming and reply behavior while hosted adapters normalize payload differences.
+        docs:
+          - docs/providers/openai.md
+          - docs/providers/anthropic.md
+          - docs/providers/google.md
+          - docs/concepts/models.md
+        search_anchors:
+          - hosted provider turns
+          - provider-specific model options
+          - streaming reply normalization
+        category_note: hosted-provider-adapters-and-payload-compatibility.md
+        human_lts_override: true
+      - name: Local and Self-hosted Providers
+        features:
+          - name: Local provider profiles
+            description: Local model profile configuration for Ollama and OpenAI-compatible local servers.
+          - name: Tool-capability flags
+            description: Local provider capability flags and behavior for tool use.
+          - name: Timeouts and context windows
+            description: Local provider timeout and context-window configuration.
+          - name: Local smoke checks
+            description: Local image and model smoke checks visible to operators.
+          - name: Local failure handling
+            description: Operator-facing failure handling for local and self-hosted providers.
+        docs:
+          - docs/providers/ollama.md
+          - docs/concepts/models.md
+          - docs/cli/agent.md
+        search_anchors:
+          - Ollama local provider profiles
+          - OpenAI-compatible local servers
+          - local smoke checks
+        category_note: local-and-self-hosted-provider-execution.md
+        human_lts_override: false
+      - name: Model and Runtime Selection
+        features:
+          - name: Model reference selection
+            description: Selecting the model reference for an agent turn from user or configured defaults.
+          - name: Provider and runtime overrides
+            description: Handling provider selection and runtime overrides for a turn.
+          - name: Thinking and context settings
+            description: Resolving thinking and context settings as part of model selection.
+          - name: Invalid route recovery
+            description: Preserving or clearing invalid route state when selections drift or fail.
+        docs:
+          - docs/concepts/models.md
+          - docs/cli/models.md
+          - docs/providers/openai.md
+          - docs/concepts/agent-runtimes.md
+        search_anchors:
+          - model reference selection
+          - runtime overrides
+          - thinking and context settings
+        category_note: model-selection-provider-routing-and-runtime-policy.md
+        human_lts_override: true
+      - name: Provider Auth
+        features:
+          - name: Login and API-key setup
+            description: Login, OAuth, and paste-key flows for provider access.
+          - name: Auth profile selection
+            description: Selecting and validating provider auth profiles.
+          - name: Credential health checks
+            description: Doctor, status, and related credential health checks and repair signals.
+          - name: Auth failover
+            description: Same-provider and cross-profile auth fallback behavior.
+          - name: Provider fallback recovery
+            description: Provider and auth-profile fallback behavior when execution fails.
+          - name: Rate-limit and capacity recovery
+            description: Recovery paths for quota, capacity, and rate-limit failures.
+          - name: Missing-key and OAuth guidance
+            description: Operator guidance for missing keys, expired OAuth state, and related auth failures.
+          - name: Restart and stale-route recovery
+            description: Recovery from stale route state, restart requirements, and related provider drift.
+          - name: Structured provider diagnostics
+            description: Structured provider errors and diagnostics delivered into logs or agent replies.
+          - name: Subagent credential propagation
+            description: Propagating provider credentials into subagent and delegated runtime flows.
+        docs:
+          - docs/concepts/models.md
+          - docs/cli/agent.md
+          - docs/cli/models.md
+          - docs/providers/openai.md
+          - docs/providers/anthropic.md
+          - docs/providers/google.md
+          - docs/tools/subagents.md
+        search_anchors:
+          - login and API-key setup
+          - auth profile selection
+          - provider fallback recovery
+        category_note: provider-auth-profiles-and-credential-health.md
+        human_lts_override: true
+      - name: Streaming and Progress
+        features:
+          - name: Streaming replies
+            description: Streaming block updates and partial assistant output before final delivery.
+          - name: Progress visibility
+            description: Progress preview events and item lifecycle updates surfaced during execution.
+        docs:
+          - docs/concepts/streaming.md
+          - docs/concepts/agent-loop.md
+        search_anchors:
+          - streaming replies
+          - progress visibility
+          - event delivery
+        category_note: streaming-progress-and-preview-visibility.md
+        human_lts_override: false
+      - name: Tool Calls and Response Handling
+        features:
+          - name: Tool-call handling
+            description: Reliable tool-call behavior across providers, including malformed or provider-specific payload differences.
+          - name: Usage and response reporting
+            description: Response ids and usage accounting normalized into operator-visible runtime behavior.
+          - name: Failure recovery
+            description: Failure-stream finalization and cleanup when provider output is malformed or incomplete.
+        docs:
+          - docs/concepts/agent-loop.md
+          - docs/providers/ollama.md
+        search_anchors:
+          - tool-call handling
+          - usage reporting
+          - failure recovery
+        category_note: streaming-tool-call-and-response-normalization.md
+        human_lts_override: true
+      - name: Tool Execution Controls
+        features:
+          - name: Tool availability rules
+            description: Which tools are available during a turn after policy resolution and provider-based suppression.
+          - name: Sandboxed exec behavior
+            description: Exec behavior, sandbox roots, and workspace constraints visible to operators.
+          - name: Approval flow
+            description: Operator approval gates for tool execution.
+          - name: Elevated execution
+            description: Elevated host execution rules and related controls.
+          - name: Tool safety controls
+            description: Before-tool-call hooks and related guardrails that shape operator-visible tool behavior.
+          - name: Delegated tool access
+            description: Inherited or narrowed tool policy for subagents and delegated execution.
+        docs:
+          - docs/gateway/sandbox-vs-tool-policy-vs-elevated.md
+          - docs/concepts/agent-loop.md
+          - docs/tools/subagents.md
+        search_anchors:
+          - tool availability rules
+          - sandboxed exec behavior
+          - approval flow
+        category_note: tool-execution-approvals-and-sandbox-policy.md
+        human_lts_override: true
+    last_score_run:
+      status: complete
+      completed_at: '2026-05-30'
+      by: codex
+      source_ref: null
+      process_version: 3
+  - id: session-memory-and-context-engine
+    name: Session, memory, and context engine
+    family: core
+    level: beta
+    level_code: M3
+    rationale: Strong docs and active implementation. Maturity depends on transcript durability, compaction quality, and cross-client parity.
+    completeness_instructions: references/completeness/session-memory-and-context-engine.md
+    categories:
+      - name: CLI Session and Transcript Management
+        features:
+          - name: CLI Session
+            description: Covers CLI Session across `openclaw sessions`, `openclaw transcripts`, cleanup, show/list/path behavior, TUI session history actions, and Gateway-backed session management commands.
+          - name: Transcript Management
+            description: Covers Transcript Management across `openclaw sessions`, `openclaw transcripts`, cleanup, show/list/path behavior, TUI session history actions, and Gateway-backed session management commands.
+        docs:
+          - docs/concepts/session.md
+          - docs/reference/session-management-compaction.md
+          - docs/cli/sessions.md
+        search_anchors:
+          - CLI Session
+          - Transcript Management
+          - session, memory, and context engine cli session and transcript management
+          - cli session and transcript management
+        category_note: cli-session-and-transcript-management.md
+        human_lts_override: true
+      - name: Token Management
+        features:
+          - name: Compaction
+            description: Covers Compaction across manual and automatic compaction, preemptive overflow checks, context-window estimation, session pruning, tool-result trimming, compaction providers, retry/timeout behavior, and compacted transcript checkpoints.
+          - name: Pruning
+            description: Covers Pruning across manual and automatic compaction, preemptive overflow checks, context-window estimation, session pruning, tool-result trimming, compaction providers, retry/timeout behavior, and compacted transcript checkpoints.
+          - name: Token Pressure
+            description: Covers Token Pressure across manual and automatic compaction, preemptive overflow checks, context-window estimation, session pruning, tool-result trimming, compaction providers, retry/timeout behavior, and compacted transcript checkpoints.
+        docs:
+          - docs/concepts/compaction.md
+          - docs/concepts/context.md
+          - docs/reference/session-management-compaction.md
+        search_anchors:
+          - Compaction
+          - Pruning
+          - Token Pressure
+          - session, memory, and context engine compaction, pruning, and token pressure
+          - compaction, pruning, and token pressure
+        category_note: compaction-pruning-and-token-pressure.md
+        human_lts_override: true
+      - name: Context Engine
+        features:
+          - name: Context Engine
+            description: Covers Context Engine across context-engine selection, registry, host compatibility, legacy fallback, assemble/ingest/after-turn/compact lifecycle, runtime context projection, and the boundary between OpenClaw context assembly and native harness history.
+          - name: Runtime Assembly
+            description: Covers Runtime Assembly across context-engine selection, registry, host compatibility, legacy fallback, assemble/ingest/after-turn/compact lifecycle, runtime context projection, and the boundary between OpenClaw context assembly and native harness history.
+        docs:
+          - docs/concepts/context.md
+          - docs/concepts/context-engine.md
+          - docs/plan/codex-context-engine-harness.md
+        search_anchors:
+          - Context Engine
+          - Runtime Assembly
+          - session, memory, and context engine context engine and runtime assembly
+          - context engine and runtime assembly
+        category_note: context-engine-and-runtime-assembly.md
+        human_lts_override: true
+      - name: Cross-client History and Session Parity
+        features:
+          - name: Cross-client History
+            description: Covers Cross-client History across `chat.history`, `chat.send`, WebChat display projection, TUI session actions, Android chat/session selection, OpenAI-compatible history mapping, channel history windows, and history visibility across reset/restart.
+          - name: Session Parity
+            description: Covers Session Parity across `chat.history`, `chat.send`, WebChat display projection, TUI session actions, Android chat/session selection, OpenAI-compatible history mapping, channel history windows, and history visibility across reset/restart.
+        docs:
+          - docs/web/webchat.md
+          - docs/platforms/android.md
+          - docs/channels/channel-routing.md
+        search_anchors:
+          - Cross-client History
+          - Session Parity
+          - session, memory, and context engine cross-client history and session parity
+          - cross-client history and session parity
+        category_note: cross-client-history-and-session-parity.md
+        human_lts_override: false
+      - name: Diagnostics, Maintenance, and Recovery
+        features:
+          - name: Session diagnostic reports
+            description: Covers stuck-session diagnostics, diagnostic bundles, stability snapshots, and operator visibility into transcript and session health.
+          - name: Session maintenance warnings
+            description: Covers restart maintenance warnings, delivery queues, memory/session cleanup signals, and operator-visible maintenance state.
+          - name: Session and transcript recovery
+            description: Covers restart recovery, orphaned subagent resume, transcript repair, and safe restoration of session state after failures.
+        docs:
+          - docs/gateway/diagnostics.md
+          - docs/reference/session-management-compaction.md
+          - docs/diagnostics/flags.md
+        search_anchors:
+          - stuck-session diagnostics
+          - restart recovery
+          - orphaned subagent resume
+          - diagnostic bundles
+          - transcript repair
+          - session maintenance warnings
+        category_note: diagnostics-maintenance-and-recovery.md
+        human_lts_override: false
+      - name: Core Prompts and Context
+        features:
+          - name: Instruction Profile
+            description: Covers Instruction Profile across `AGENTS.md`, `USER.md`, `IDENTITY.md`, `SOUL.md`, project context injection, bootstrap truncation, untrusted supplemental context, context visibility config, and runtime-context leakage prevention.
+          - name: Context Visibility
+            description: Covers Context Visibility across `AGENTS.md`, `USER.md`, `IDENTITY.md`, `SOUL.md`, project context injection, bootstrap truncation, untrusted supplemental context, context visibility config, and runtime-context leakage prevention.
+        docs:
+          - docs/concepts/context.md
+          - docs/reference/transcript-hygiene.md
+          - docs/channels/discord.md
+        search_anchors:
+          - Instruction Profile
+          - Context Visibility
+          - session, memory, and context engine instruction profile and context visibility
+          - instruction profile and context visibility
+        category_note: instruction-profile-and-context-visibility.md
+        human_lts_override: true
+      - name: Memory
+        features:
+          - name: Memory Backend Storage
+            description: Covers Memory Backend Storage across memory backend config, SQLite schema, vector acceleration, embedding provider selection, remote embedding fetch, QMD process/query parsing, session transcript indexing for search, extra paths, and backend security boundaries.
+          - name: Embedding Search
+            description: Covers Embedding Search across memory backend config, SQLite schema, vector acceleration, embedding provider selection, remote embedding fetch, QMD process/query parsing, session transcript indexing for search, extra paths, and backend security boundaries.
+          - name: Memory Files
+            description: Covers Memory Files across root memory files, active memory, memory search/get/store tool exposure, memory prompt sections, memory flush plans, session-memory hook behavior, and memory plugin capability registration visible to agents.
+          - name: Memory search and store tools
+            description: Covers memory search/get/store tool exposure, memory prompt sections, memory flush plans, session-memory hook behavior, and memory plugin capability registration visible to agents.
+          - name: Active Memory
+            description: Covers Active Memory across root memory files, active memory, memory search/get/store tool exposure, memory prompt sections, memory flush plans, session-memory hook behavior, and memory plugin capability registration visible to agents.
+        docs:
+          - docs/reference/memory-config.md
+          - docs/concepts/memory-qmd.md
+          - docs/concepts/memory.md
+          - docs/channels/discord.md
+        search_anchors:
+          - Memory Backend Storage
+          - Embedding Search
+          - Memory Files
+          - memory search
+          - memory get
+          - memory store
+          - Active Memory
+          - root memory files
+          - active memory
+          - memory backend storage and embedding search
+        category_note: memory-files-tools-and-active-memory.md
+        human_lts_override: false
+      - name: Session Routing
+        features:
+          - name: Session Routing
+            description: Covers Session Routing across `sessionKey` construction, target resolution, conversation bindings, session labels, per-conversation isolation, thread binding, model selection continuity tied to sessions, and agent/workspace store targeting.
+          - name: Conversation routing
+            description: Covers Conversation Binding across `sessionKey` construction, target resolution, conversation bindings, session labels, per-conversation isolation, thread binding, model selection continuity tied to sessions, and agent/workspace store targeting.
+        docs:
+          - docs/concepts/session.md
+          - docs/channels/channel-routing.md
+          - docs/channels/discord.md
+        search_anchors:
+          - Session Routing
+          - Conversation Binding
+          - session, memory, and context engine session routing and conversation binding
+          - session routing and conversation binding
+        category_note: session-routing-and-conversation-binding.md
+        human_lts_override: true
+      - name: Transcript Persistence
+        features:
+          - name: Transcript Persistence
+            description: Covers Transcript Persistence across JSONL session files, transcript append and redaction, session write locks, transcript rotation/archive behavior, disk budget cleanup, provider transcript stores, and restart/repair durability.
+          - name: Durability
+            description: Covers Durability across JSONL session files, transcript append and redaction, session write locks, transcript rotation/archive behavior, disk budget cleanup, provider transcript stores, and restart/repair durability.
+        docs:
+          - docs/reference/session-management-compaction.md
+          - docs/reference/transcript-hygiene.md
+        search_anchors:
+          - Transcript Persistence
+          - Durability
+          - session, memory, and context engine transcript persistence and durability
+          - transcript persistence and durability
+        category_note: transcript-persistence-and-durability.md
+        human_lts_override: true
+    last_score_run:
+      status: complete
+      completed_at: '2026-05-30'
+      by: codex
+      source_ref: null
+      process_version: 3
+  - id: channel-framework
+    name: Channel framework
+    family: core
+    level: beta
+    level_code: M3
+    rationale: Many channels share Gateway delivery and routing contracts, but channel behavior varies by upstream API and account-policy constraints.
+    completeness_instructions: references/completeness/channel-framework.md
+    categories:
+      - name: Channel Actions Commands and Approvals
+        features:
+          - name: Channel-native commands
+            description: Channel-native commands and command authorization gates
+          - name: Native command session target
+            description: Native command session target resolution
+          - name: Message actions
+            description: Message actions, action dispatch, and trusted requester checks
+          - name: Message tool API discovery
+            description: Message tool API discovery for channel actions
+          - name: Channel-native approval prompts
+            description: Channel-native approval prompts and plugin/exec approval routing
+        docs:
+          - docs/channels/groups.md
+          - docs/channels/discord.md
+          - docs/channels/googlechat.md
+          - docs/channels/signal.md
+          - docs/channels/matrix.md
+        search_anchors:
+          - channel-native commands
+          - message actions
+          - channel-native approval prompts
+        category_note: channel-actions-commands-and-approvals.md
+        human_lts_override: false
+      - name: Channel Setup
+        features:
+          - name: Supported channel catalog
+            description: Supported channel catalog and docs index
+          - name: Channel status taxonomy in channels list
+            description: Channel status taxonomy in channels list, channels status, and setup status output
+          - name: Setup/onboarding flows
+            description: Setup/onboarding flows, including first-run channel selection and channel account setup
+          - name: Install-on-demand
+            description: Install-on-demand, downloadable, bundled, official external, local, npm, and ClawHub distinctions
+          - name: Setup wizard metadata
+            description: Setup wizard metadata and setup-safe plugin entrypoints
+        docs:
+          - docs/channels/index.md
+          - docs/channels/pairing.md
+          - docs/channels/troubleshooting.md
+          - docs/plugins/sdk-channel-plugins.md
+        search_anchors:
+          - channels list
+          - channels setup
+          - setup wizard metadata
+        category_note: channel-setup.md
+        human_lts_override: true
+      - name: Group Thread and Ambient Room Behavior
+        features:
+          - name: Group/channel session isolation
+            description: Group/channel session isolation and group history context
+          - name: Mention-required
+            description: Mention-required, always-on, and ambient room-event modes
+          - name: Native threads
+            description: Native threads, topics, parent-child bindings, and thread spawn behavior
+          - name: Broadcast groups
+            description: Broadcast groups and multi-agent group routing
+          - name: Bot-loop protection
+            description: Bot-loop protection for room behavior
+        docs:
+          - docs/channels/groups.md
+          - docs/channels/group-messages.md
+          - docs/channels/ambient-room-events.md
+          - docs/channels/broadcast-groups.md
+          - docs/channels/discord.md
+        search_anchors:
+          - mentionRequired
+          - ambient room events
+          - broadcast groups
+        category_note: group-thread-and-ambient-room-behavior.md
+        human_lts_override: false
+      - name: Inbound Access and Identity Gates
+        features:
+          - name: DM pairing
+            description: DM pairing and allowFrom sender controls
+          - name: Group/channel allowlists
+            description: Group/channel allowlists and sender allowlists
+          - name: Access group expansion
+            description: Access group expansion and sender authorization helpers
+          - name: Mention gating
+            description: Mention gating, implicit mentions, command bypass, and bot-loop-aware admission
+          - name: Sanitized inbound identity/route projections
+            description: Sanitized inbound identity/route projections for downstream dispatch
+        docs:
+          - docs/channels/access-groups.md
+          - docs/channels/groups.md
+          - docs/channels/discord.md
+          - docs/channels/line.md
+        search_anchors:
+          - DM pairing
+          - allowFrom
+          - access groups
+        category_note: inbound-access-and-identity-gates.md
+        human_lts_override: true
+      - name: Media Attachments and Rich Channel Data
+        features:
+          - name: Inbound media normalization
+            description: Inbound media normalization, attachment persistence, and history media context
+          - name: Outbound direct text/media sends
+            description: Outbound direct text/media sends and rich payload adapter support
+          - name: Provider-specific channelData
+            description: Provider-specific channelData, quick replies, locations, polls, reactions, and voice-note handling
+          - name: Media roots
+            description: Media roots and file-path safety for channel inbound storage
+        docs:
+          - docs/channels/line.md
+          - docs/channels/signal.md
+          - docs/channels/googlechat.md
+          - docs/channels/matrix.md
+          - docs/channels/discord.md
+        search_anchors:
+          - inbound media normalization
+          - channelData
+          - media roots
+        category_note: media-attachments-and-rich-channel-data.md
+        human_lts_override: false
+      - name: Outbound Delivery and Reply Pipeline
+        features:
+          - name: Automatic final reply delivery
+            description: Automatic final reply delivery and strict message-tool-only visible delivery
+          - name: Durable outbound send orchestration
+            description: Durable outbound send orchestration, receipts, partial failures, and fallback paths
+          - name: Reply pipeline transforms
+            description: Reply pipeline transforms, typing callbacks, draft streaming, and status reactions
+          - name: Provider outbound adapter bridge
+            description: Provider outbound adapter bridge and message capabilities
+        docs:
+          - docs/channels/groups.md
+          - docs/channels/ambient-room-events.md
+          - docs/channels/discord.md
+          - docs/channels/matrix.md
+          - docs/gateway/config-channels.md
+        search_anchors:
+          - automatic final reply delivery
+          - message tool delivery
+          - typing callbacks
+        category_note: outbound-delivery-and-reply-pipeline.md
+        human_lts_override: true
+      - name: Conversation Routing and Delivery
+        features:
+          - name: Inbound conversation routing
+            description: Inbound and command conversation resolution across sessions, threads, and provider-owned targets.
+          - name: Session key construction
+            description: Session key construction and session metadata recording
+          - name: Agent selection precedence
+            description: Agent binding precedence and broadcast group dispatch
+          - name: Runtime conversation routing
+            description: Runtime conversation bindings and ACP session binding routes
+          - name: Thread/parent-child placement
+            description: Thread/parent-child placement and provider-owned target normalization
+          - name: Plugin registry resolution
+            description: Plugin registry resolution and scoped channel runtime creation
+          - name: Channel account startup
+            description: Channel account startup, shutdown, logout, abort, and manual-stop state
+          - name: Whole-channel lifecycle controls
+            description: Whole-channel and per-account lifecycle fanout for start, stop, logout, restart, and runtime snapshots.
+          - name: Config/secrets reload interactions
+            description: Config/secrets reload interactions with channel plugin reload targets
+          - name: Auto-restart
+            description: Auto-restart, backoff, crash-loop caps, and runtime snapshot reporting
+        docs:
+          - docs/channels/channel-routing.md
+          - docs/channels/groups.md
+          - docs/channels/discord.md
+          - docs/channels/matrix.md
+          - docs/channels/troubleshooting.md
+          - docs/gateway/configuration-reference.md
+        search_anchors:
+          - channel routing
+          - session key construction
+          - agent binding precedence
+          - channels.start
+          - channels.stop
+          - channel account startup
+          - health restart
+        category_note: conversation-routing-and-delivery.md
+        human_lts_override: true
+      - name: Status Health and Operator Controls
+        features:
+          - name: channels.status
+            description: channels.status, probes, account snapshots, and warnings
+          - name: Channel health policy
+            description: Channel health policy, health monitor restarts, stale socket detection, cooldowns, and restart caps
+          - name: Operator CLI controls
+            description: Operator CLI controls for start, stop, logout, status, restart, and troubleshoot
+          - name: Status read-model
+            description: Status read-model and plugin status snapshots
+        docs:
+          - docs/gateway/health.md
+          - docs/gateway/configuration-reference.md
+          - docs/channels/troubleshooting.md
+          - docs/channels/discord.md
+        search_anchors:
+          - channels status --probe
+          - channel health policy
+          - operator CLI controls
+        category_note: status-health-and-operator-controls.md
+        human_lts_override: true
+    last_score_run:
+      status: complete
+      completed_at: '2026-05-30'
+      by: codex
+      source_ref: null
+      process_version: 3
+  - id: security-auth-pairing-and-secrets
+    name: Security, auth, pairing, and secrets
+    family: core
+    level: beta
+    level_code: M3
+    rationale: Good docs and hardening surfaces exist. Promote after regular upgrade/security scenario runs prove no setup regressions.
+    completeness_instructions: references/completeness/security-auth-pairing-and-secrets.md
+    categories:
+      - name: Approval Policy and Tool Safeguards
+        features:
+          - name: Approval Policy
+            description: Covers Approval Policy across exec approval policy, host-local approval stores, allowlist and ask modes, dangerous tool safeguards, native/chat approval routing, plugin approval routing, approval decisions, approval binding, and operator-facing CLI management.
+          - name: Dangerous Tool Safeguards
+            description: Covers Dangerous Tool Safeguards across exec approval policy, host-local approval stores, allowlist and ask modes, dangerous tool safeguards, native/chat approval routing, plugin approval routing, approval decisions, approval binding, and operator-facing CLI management.
+        docs:
+          - docs/tools/exec-approvals.md
+          - docs/cli/approvals.md
+          - docs/plugins/plugin-permission-requests.md
+          - docs/gateway/security/audit-checks.md
+        search_anchors:
+          - approval policy
+          - dangerous tool safeguards
+          - exec approvals
+        category_note: approval-policy-and-dangerous-tool-safeguards.md
+        human_lts_override: true
+      - name: Gateway Auth and Remote Access
+        features:
+          - name: Shared Gateway token/password auth
+            description: Token and password auth for Gateway HTTP and WebSocket clients, including runtime auth resolution, startup validation, shared-secret comparison, and operator guidance.
+          - name: Gateway auth mode
+            description: Gateway auth mode selection, including private ingress behavior and operator warnings for unsafe exposure.
+          - name: Trusted-proxy identity
+            description: Trusted-proxy identity, gateway.trustedProxies, trustedProxy.userHeader, requiredHeaders, allowUsers, allowLoopback, reverse-proxy source validation, and scope behavior
+          - name: Tailscale Serve/Funnel
+            description: Tailscale Serve/Funnel and reverse-proxy exposure rules, including Tailscale identity headers, tailscale whois, Funnel password requirements, and separation between Control UI/WS identity and HTTP API auth
+          - name: Bind and origin restrictions
+            description: loopback/LAN/tailnet/custom bind modes, non-loopback exposure checks, browser Origin checks, controlUi.allowedOrigins, Host-header fallback risk, and forwarded-header handling
+          - name: WebSocket handshake auth
+            description: WebSocket handshake auth, including challenge/connect ordering, nonce-bound device auth, shared auth, browser origin checks, pre-auth limits, unauthenticated socket timeout, and stale shared-auth rotation
+          - name: Operator-facing docs
+            description: Operator-facing docs and runbooks for security audit, remote access, exposure rollback, Tailscale, trusted proxy, credential rotation, and explicit credential probing
+          - name: Browser Control UI
+            description: Covers Browser Control UI across Control UI/WebChat browser trust, device pairing for browser clients, allowed origins, Tailscale/trusted-proxy behavior for browser sessions, and related browser control ui and remote client trust behavior.
+          - name: Remote Client Trust
+            description: Covers Remote Client Trust across Control UI/WebChat browser trust, device pairing for browser clients, allowed origins, Tailscale/trusted-proxy behavior for browser sessions, and related browser control ui and remote client trust behavior.
+        docs:
+          - docs/gateway/security/index.md
+          - docs/gateway/security/exposure-runbook.md
+          - docs/gateway/trusted-proxy-auth.md
+          - docs/gateway/tailscale.md
+          - docs/gateway/remote.md
+          - docs/gateway/configuration-reference.md
+          - docs/cli/gateway.md
+          - docs/cli/doctor.md
+          - docs/web/control-ui.md
+          - docs/tools/browser-control.md
+          - docs/gateway/security/audit-checks.md
+        search_anchors:
+          - gateway.auth.mode
+          - trusted proxy auth
+          - Tailscale Serve/Funnel
+          - WebSocket handshake auth
+          - Control UI auth
+          - remote client trust
+          - allowed origins
+        category_note: gateway-auth-and-network-exposure.md
+        human_lts_override: true
+      - name: Channel Access Control
+        features:
+          - name: Channel Identity
+            description: 'Covers Channel Identity across who can talk to OpenClaw through message channels: DM pairing codes, pairing stores, `dmPolicy`, `allowFrom`, and related channel identity, allowlists, and sender pairing behavior.'
+          - name: Allowlists
+            description: 'Covers Allowlists across who can talk to OpenClaw through message channels: DM pairing codes, pairing stores, `dmPolicy`, `allowFrom`, and related channel identity, allowlists, and sender pairing behavior.'
+          - name: Sender Pairing
+            description: 'Covers Sender Pairing across who can talk to OpenClaw through message channels: DM pairing codes, pairing stores, `dmPolicy`, `allowFrom`, and related channel identity, allowlists, and sender pairing behavior.'
+        docs:
+          - docs/channels/pairing.md
+          - docs/channels/telegram.md
+          - docs/channels/access-groups.md
+          - docs/gateway/security/audit-checks.md
+        search_anchors:
+          - DM pairing
+          - allowFrom
+          - sender allowlists
+        category_note: channel-identity-allowlists-and-sender-pairing.md
+        human_lts_override: true
+      - name: Device and Node Pairing
+        features:
+          - name: Setup codes
+            description: Setup codes and QR pairing UX for mobile/node onboarding through the device-pair plugin
+          - name: Device identity creation
+            description: Device identity creation, storage, public-key-derived device IDs, challenge signing, and server verification
+          - name: Device-token issuance
+            description: Device-token issuance, reconnect reuse, token mismatch recovery, token rotation, token revocation, and stale-token cleanup
+          - name: Device pairing approvals for operator
+            description: Device pairing approvals for operator and node roles, including pending requests, role/scope upgrades, and repair requests
+          - name: Operator scopes that gate pairing
+            description: Operator scopes that gate pairing, device token management, node pairing, and higher-risk role/scope approvals
+          - name: Local Control UI
+            description: Local Control UI, WebChat, trusted-proxy, and backend auto-pairing or device-less exception behavior where it affects operator pairing
+          - name: Auth migration
+            description: Auth migration and recovery errors for pre-challenge device signing, token drift, scope mismatch, and mixed gateway auth configuration
+          - name: Operator-facing docs
+            description: Operator-facing docs for devices, pairing, WebChat, Control UI, protocol auth, and troubleshooting
+          - name: Node Pairing
+            description: Covers Node Pairing across node/device pairing for capability hosts, pending and approved node state, trusted-CIDR auto-approval, node-declared command/capability trust boundaries, and related node pairing, capability trust, and remote exec approvals behavior.
+          - name: Capability Trust
+            description: Covers Capability Trust across node/device pairing for capability hosts, pending and approved node state, trusted-CIDR auto-approval, node-declared command/capability trust boundaries, and related node pairing, capability trust, and remote exec approvals behavior.
+          - name: Remote Exec Approvals
+            description: Covers Remote Exec Approvals across node/device pairing for capability hosts, pending and approved node state, trusted-CIDR auto-approval, node-declared command/capability trust boundaries, and related node pairing, capability trust, and remote exec approvals behavior.
+        docs:
+          - docs/gateway/protocol.md
+          - docs/cli/devices.md
+          - docs/channels/pairing.md
+          - docs/gateway/pairing.md
+          - docs/gateway/operator-scopes.md
+          - docs/web/control-ui.md
+          - docs/web/webchat.md
+          - docs/cli/approvals.md
+        search_anchors:
+          - setup codes
+          - device challenge signing
+          - operator scopes
+          - node pairing
+          - node-declared capabilities
+          - remote exec approvals
+        category_note: device-identity-and-operator-pairing.md
+        human_lts_override: true
+      - name: Plugin Trust
+        features:
+          - name: Plugin Installation Trust
+            description: Covers Plugin Installation Trust across plugin manifest trust, plugin install/update safety scans, plugin allowlists, manifest-owned auth/secret metadata, and related plugin installation trust and security boundaries behavior.
+          - name: Security Boundaries
+            description: Covers Security Boundaries across plugin manifest trust, plugin install/update safety scans, plugin allowlists, manifest-owned auth/secret metadata, and related plugin installation trust and security boundaries behavior.
+        docs:
+          - docs/plugins/manifest.md
+          - docs/plugins/plugin-permission-requests.md
+          - docs/plugins/manage-plugins.md
+          - docs/gateway/security/audit-checks.md
+        search_anchors:
+          - plugin manifest trust
+          - plugin install safety scans
+          - plugin allowlists
+        category_note: plugin-installation-trust-and-security-boundaries.md
+        human_lts_override: false
+      - name: Credential and Secret Hygiene
+        features:
+          - name: Provider Auth Profiles
+            description: 'Covers Provider Auth Profiles across provider credentials and auth health as a security/secrets surface: API keys, OAuth profiles, `auth-profiles.json`, auth order, and related provider auth profiles and api key health behavior.'
+          - name: API Key Health
+            description: 'Covers API Key Health across provider credentials and auth health as a security/secrets surface: API keys, OAuth profiles, `auth-profiles.json`, auth order, and related provider auth profiles and api key health behavior.'
+          - name: Secrets Storage
+            description: Covers Secrets Storage across SecretRef contract and providers, runtime secret snapshots, gateway auth SecretRefs, auth-profile and generated model residues, and related secrets storage, redaction, and configuration hygiene behavior.
+          - name: Redaction
+            description: Covers Redaction across SecretRef contract and providers, runtime secret snapshots, gateway auth SecretRefs, auth-profile and generated model residues, and related secrets storage, redaction, and configuration hygiene behavior.
+          - name: Configuration Hygiene
+            description: Covers Configuration Hygiene across SecretRef contract and providers, runtime secret snapshots, gateway auth SecretRefs, auth-profile and generated model residues, and related secrets storage, redaction, and configuration hygiene behavior.
+        docs:
+          - docs/gateway/authentication.md
+          - docs/cli/models.md
+          - docs/providers/openai.md
+          - docs/concepts/oauth.md
+          - docs/gateway/secrets.md
+          - docs/cli/secrets.md
+          - docs/reference/secretref-credential-surface.md
+          - docs/gateway/security/audit-checks.md
+        search_anchors:
+          - auth-profiles.json
+          - provider API keys
+          - OAuth profiles
+          - SecretRef
+          - runtime secret snapshots
+          - redaction patterns
+        category_note: secrets-storage-redaction-and-configuration-hygiene.md
+        human_lts_override: true
+    last_score_run:
+      status: complete
+      completed_at: '2026-05-30'
+      by: codex
+      source_ref: null
+      process_version: 3
+  - id: telemetry-diagnostics-and-observability
+    name: Observability
+    family: core
+    level: beta
+    level_code: M3
+    rationale: OTel, Prometheus, logging, and diagnostics docs exist. Needs a public "what operators should look at first" maturity pass.
+    completeness_instructions: references/completeness/telemetry-diagnostics-and-observability.md
+    categories:
+      - name: Health and Repair
+        features:
+          - name: Background health-monitor loop
+            description: Background health-monitor loop for configured channel accounts
+          - name: Per-account enable/disable settings
+            description: Per-account enable/disable settings behavior, status, and operator-visible verification.
+          - name: Startup grace
+            description: Startup grace, connect grace, stale transport activity detection, busy/stuck handling, restart cooldowns, and max restarts per hour
+          - name: Restart logging
+            description: Restart logging and runtime snapshot evaluation
+          - name: openclaw doctor
+            description: openclaw doctor, openclaw doctor --fix, --repair, --yes, --non-interactive, --deep, and --lint
+          - name: Structured health checks
+            description: Structured health checks, findings, repair results, check selection, JSON lint output, severity filtering, and exit behavior
+          - name: Core doctor checks
+            description: Core doctor checks for gateway config, services, auth, state integrity, skills, plugins, sandbox, migrations, and provider route health
+          - name: Plugin SDK doctor/health contracts
+            description: Plugin SDK doctor/health contracts behavior, status, and operator-visible verification.
+          - name: openclaw status
+            description: openclaw status, openclaw status --all, and openclaw status --deep
+          - name: openclaw health
+            description: openclaw health, openclaw health --verbose, and openclaw health --json
+          - name: Gateway RPC health
+            description: Gateway RPC health and status
+          - name: Cached health snapshots
+            description: Cached health snapshots, live probe refresh, sensitive fields gated by operator admin scope, and event-loop health attachment
+        docs:
+          - docs/gateway/health.md
+          - docs/channels/telegram.md
+          - docs/cli/doctor.md
+          - docs/gateway/doctor.md
+          - docs/plugins/sdk-subpaths.md
+          - docs/cli/health.md
+          - docs/gateway/protocol.md
+        search_anchors:
+          - channel health monitor
+          - restart cooldowns
+          - stale transport activity
+          - openclaw doctor --fix
+          - structured health checks
+          - repair results
+          - openclaw health --json
+          - gateway RPC health
+          - cached health snapshots
+        category_note: health-status-probes.md
+        human_lts_override: true
+      - name: Logging
+        features:
+          - name: Rolling Gateway JSONL file logs
+            description: Rolling Gateway JSONL file logs and console output
+          - name: openclaw logs
+            description: openclaw logs, openclaw logs --follow, JSON/plain/color/timezone modes, and local fallback behavior
+          - name: Gateway RPC logs.tail
+            description: Gateway RPC logs.tail behavior, status, and operator-visible verification.
+          - name: Redaction patterns and sinks
+            description: console, file logs, OTLP log records, transcript text, Control UI tool-call events, support exports, and WS protocol logs
+          - name: Trace correlation fields
+            description: Trace correlation fields on log records and linked diagnostic events.
+        docs:
+          - docs/logging.md
+          - docs/gateway/logging.md
+          - docs/cli/logs.md
+        search_anchors:
+          - openclaw logs --follow
+          - logs.tail
+          - redaction patterns
+        category_note: logging-log-tail-and-redaction.md
+        human_lts_override: true
+      - name: Diagnostic Collection
+        features:
+          - name: openclaw gateway diagnostics export
+            description: openclaw gateway diagnostics export and --json / --output / log-size options
+          - name: openclaw gateway stability --bundle
+            description: openclaw gateway stability --bundle latest --export
+          - name: Chat /diagnostics
+            description: Chat /diagnostics and /codex diagnostics approval flows
+          - name: Support zip composition
+            description: Support zip composition, safe relative paths, sanitized config/status/health/log/stability files, and privacy manifest
+          - name: Bounded in-process stability recorder
+            description: Bounded in-process stability recorder and diagnostics.stability RPC
+          - name: openclaw gateway stability
+            description: openclaw gateway stability, stability filtering, persisted stability bundles, and export-from-bundle
+          - name: Memory pressure events
+            description: Memory pressure events, event-loop liveness warnings, oversized payload events, queue/session summaries, and fatal/shutdown/restart snapshots
+          - name: Critical memory pressure snapshot option
+            description: Critical memory pressure snapshot option with V8/cgroup/session-file evidence
+        docs:
+          - docs/gateway/diagnostics.md
+          - docs/gateway/health.md
+          - docs/plugins/codex-harness.md
+          - docs/gateway/protocol.md
+        search_anchors:
+          - gateway diagnostics export
+          - support bundle
+          - privacy manifest
+          - gateway stability
+          - memory pressure events
+          - critical memory pressure snapshot
+        category_note: diagnostics-export-support-bundles.md
+        human_lts_override: false
+      - name: Telemetry Export
+        features:
+          - name: Diagnostic event types
+            description: Diagnostic event types and trusted/internal/public subscription boundaries
+          - name: Async dispatch
+            description: Async dispatch, queue saturation summaries, immutable event copies, private data handling, and diagnostics enablement
+          - name: W3C trace context creation
+            description: W3C trace context creation, active request scopes, child spans, and trusted traceparent formatting
+          - name: Plugin SDK diagnostic runtime exports
+            description: Plugin SDK diagnostic runtime exports and hook context trace fields
+          - name: Model-call diagnostic events
+            description: Model-call, tool, exec, webhook, message, Talk, session, harness, and exporter diagnostic events.
+          - name: diagnostics-otel plugin install
+            description: diagnostics-otel plugin install, enablement, config, env overrides, sampling, flush interval, and preloaded SDK mode
+          - name: OTLP/HTTP traces
+            description: OTLP/HTTP traces, metrics, and logs
+          - name: Trusted trace context
+            description: Trusted trace context, W3C traceparent propagation to model calls, file-log correlation, content-capture controls, and redacted/bounded attributes
+          - name: Model and runtime telemetry
+            description: Model, tool, message, session, queue, Talk, exec, webhook, context assembly, harness, and exporter-health signals
+          - name: diagnostics-prometheus plugin install
+            description: diagnostics-prometheus plugin install and enablement
+          - name: Gateway-authenticated GET /api/diagnostics/prometheus
+            description: Gateway-authenticated GET /api/diagnostics/prometheus behavior, status, and operator-visible verification.
+          - name: Prometheus text exposition
+            description: Prometheus text exposition, counters, gauges, histograms, label policy, series cap, and overflow metric
+          - name: Trusted diagnostic event subscription
+            description: Trusted diagnostic event subscription and rendering of run, model, tool, message, Talk, queue, session, liveness, payload, memory, and exporter metrics
+        docs:
+          - docs/plugins/hooks.md
+          - docs/gateway/opentelemetry.md
+          - docs/logging.md
+          - docs/plugins/sdk-subpaths.md
+          - docs/plugins/reference/diagnostics-otel.md
+          - docs/gateway/prometheus.md
+          - docs/plugins/reference/diagnostics-prometheus.md
+        search_anchors:
+          - diagnostic events
+          - W3C trace context
+          - hook context trace fields
+          - diagnostics-otel
+          - OTLP/HTTP traces
+          - traceparent
+          - diagnostics-prometheus
+          - /api/diagnostics/prometheus
+          - Prometheus text exposition
+        category_note: diagnostic-events-hooks-and-trace-context.md
+        human_lts_override: false
+      - name: Session Diagnostics
+        features:
+          - name: session.state
+            description: session.state, session.stuck, session.long_running, session.stalled, session.recovery.*, and session.turn.created diagnostic events
+          - name: Diagnostic session activity snapshots
+            description: Diagnostic session activity snapshots for embedded runs, model calls, and tool calls
+          - name: Model usage
+            description: Model usage, token/cost, model-call byte/timing, run attempts, and usage logs
+          - name: Export of session signals to stability
+            description: Export of session signals to stability, OpenTelemetry, and Prometheus
+        docs:
+          - docs/gateway/opentelemetry.md
+          - docs/gateway/prometheus.md
+          - docs/gateway/diagnostics.md
+          - docs/gateway/protocol.md
+        search_anchors:
+          - session.state
+          - usage diagnostics
+          - stability export
+        category_note: session-run-and-usage-diagnostics.md
+        human_lts_override: true
+    last_score_run:
+      status: complete
+      completed_at: '2026-05-30'
+      by: codex
+      source_ref: null
+      process_version: 3
+  - id: automation-cron-hooks-tasks-polling
+    name: 'Automation: cron, hooks, tasks, polling'
+    family: core
+    level: beta
+    level_code: M3
+    rationale: Documented and usable, but scenario proof should cover unattended delivery, retries, and failure visibility.
+    completeness_instructions: references/completeness/automation-cron-hooks-tasks-polling.md
+    categories:
+      - name: Cron Jobs
+        features:
+          - name: Create/edit/remove jobs
+            description: Covers Create/edit/remove jobs across cron job creation, listing, inspection, editing, and related cron job lifecycle behavior.
+          - name: Schedule types
+            description: Covers Schedule types across cron job creation, listing, inspection, editing, and related cron job lifecycle behavior.
+          - name: Timezone and stagger
+            description: Covers Timezone and stagger across cron job creation, listing, inspection, editing, and related cron job lifecycle behavior.
+          - name: Cron RPCs
+            description: Covers Cron RPCs across cron job creation, listing, inspection, editing, and related cron job lifecycle behavior.
+          - name: Agent cron tool
+            description: Covers Agent cron tool across cron job creation, listing, inspection, editing, and related cron job lifecycle behavior.
+          - name: Manual cron runs
+            description: Covers Manual cron runs across scheduler dispatch, timer arming, manual/due runs, isolated agent execution, and related cron runs and diagnostics behavior.
+          - name: Isolated cron execution
+            description: Covers Isolated cron execution across scheduler dispatch, timer arming, manual/due runs, isolated agent execution, and related cron runs and diagnostics behavior.
+          - name: Model/provider preflight
+            description: Covers Model/provider preflight across scheduler dispatch, timer arming, manual/due runs, isolated agent execution, and related cron runs and diagnostics behavior.
+          - name: Run history
+            description: Covers Run history across scheduler dispatch, timer arming, manual/due runs, isolated agent execution, and related cron runs and diagnostics behavior.
+          - name: Timeout and denial diagnostics
+            description: Covers Timeout and denial diagnostics across scheduler dispatch, timer arming, manual/due runs, isolated agent execution, and related cron runs and diagnostics behavior.
+          - name: Chat announce delivery
+            description: Covers Chat announce delivery across cron output delivery modes, channel target resolution, direct delivery retries, transcript mirroring, and related cron delivery and failure alerts behavior.
+          - name: Webhook delivery
+            description: Covers Webhook delivery across cron output delivery modes, channel target resolution, direct delivery retries, transcript mirroring, and related cron delivery and failure alerts behavior.
+          - name: Failure destinations
+            description: Covers Failure destinations across cron output delivery modes, channel target resolution, direct delivery retries, transcript mirroring, and related cron delivery and failure alerts behavior.
+          - name: Skipped-run alerts
+            description: Covers Skipped-run alerts across cron output delivery modes, channel target resolution, direct delivery retries, transcript mirroring, and related cron delivery and failure alerts behavior.
+          - name: Delivery previews
+            description: Covers Delivery previews across cron output delivery modes, channel target resolution, direct delivery retries, transcript mirroring, and related cron delivery and failure alerts behavior.
+        docs:
+          - docs/automation/cron-jobs.md
+          - docs/cli/cron.md
+          - docs/gateway/protocol.md
+          - docs/automation/tasks.md
+          - docs/channels/discord.md
+        search_anchors:
+          - Create/edit/remove jobs
+          - Schedule types
+          - Timezone and stagger
+          - Cron RPCs
+          - Agent cron tool
+          - openclaw cron
+          - Manual cron runs
+          - Isolated cron execution
+          - Model/provider preflight
+          - Run history
+          - Timeout and denial diagnostics
+          - Chat announce delivery
+          - Webhook delivery
+          - Failure destinations
+          - Skipped-run alerts
+          - Delivery previews
+          - failure destination
+          - announce
+        category_note: cron-job-lifecycle.md
+        human_lts_override: false
+      - name: Event Ingress
+        features:
+          - name: Telegram long polling
+            description: Covers Telegram long polling across channel-level long polling and webhook modes, especially Telegram and Zalo; polling liveness, leases, watchdog thresholds, and related channel polling and webhooks behavior.
+          - name: Telegram webhook mode
+            description: Covers Telegram webhook mode across channel-level long polling and webhook modes, especially Telegram and Zalo; polling liveness, leases, watchdog thresholds, and related channel polling and webhooks behavior.
+          - name: Zalo polling/webhook mode
+            description: Covers Zalo polling/webhook mode across channel-level long polling and webhook modes, especially Telegram and Zalo; polling liveness, leases, watchdog thresholds, and related channel polling and webhooks behavior.
+          - name: Polling stall diagnostics
+            description: Covers Polling stall diagnostics across channel-level long polling and webhook modes, especially Telegram and Zalo; polling liveness, leases, watchdog thresholds, and related channel polling and webhooks behavior.
+          - name: iMessage watch fallback
+            description: Covers iMessage watch fallback across channel-level long polling and webhook modes, especially Telegram and Zalo; polling liveness, leases, watchdog thresholds, and related channel polling and webhooks behavior.
+          - name: Gmail setup wizard
+            description: Covers Gmail setup wizard across `openclaw webhooks gmail setup`, `hooks.gmail` config, `gog gmail watch start/serve`, watcher startup and renewal, and related gmail pub/sub watchers behavior.
+          - name: Watcher start/serve
+            description: Covers Watcher start/serve across `openclaw webhooks gmail setup`, `hooks.gmail` config, `gog gmail watch start/serve`, watcher startup and renewal, and related gmail pub/sub watchers behavior.
+          - name: Tailscale/public routing
+            description: Covers Tailscale/public routing across `openclaw webhooks gmail setup`, `hooks.gmail` config, `gog gmail watch start/serve`, watcher startup and renewal, and related gmail pub/sub watchers behavior.
+          - name: Push token validation
+            description: Covers Push token validation across `openclaw webhooks gmail setup`, `hooks.gmail` config, `gog gmail watch start/serve`, watcher startup and renewal, and related gmail pub/sub watchers behavior.
+          - name: Gmail event routing
+            description: Covers Gmail event routing across `openclaw webhooks gmail setup`, `hooks.gmail` config, `gog gmail watch start/serve`, watcher startup and renewal, and related gmail pub/sub watchers behavior.
+          - name: POST /hooks/wake
+            description: Covers POST /hooks/wake across `/hooks/wake`, `/hooks/agent`, mapped hooks under `/hooks/<name>`, token extraction, and related http webhooks behavior.
+          - name: POST /hooks/agent
+            description: Covers POST /hooks/agent across `/hooks/wake`, `/hooks/agent`, mapped hooks under `/hooks/<name>`, token extraction, and related http webhooks behavior.
+          - name: Mapped hooks
+            description: Covers Mapped hooks across `/hooks/wake`, `/hooks/agent`, mapped hooks under `/hooks/<name>`, token extraction, and related http webhooks behavior.
+          - name: Hook auth policy
+            description: Covers Hook auth policy across `/hooks/wake`, `/hooks/agent`, mapped hooks under `/hooks/<name>`, token extraction, and related http webhooks behavior.
+          - name: Async dispatch
+            description: Covers Async dispatch across `/hooks/wake`, `/hooks/agent`, mapped hooks under `/hooks/<name>`, token extraction, and related http webhooks behavior.
+        docs:
+          - docs/channels/telegram.md
+          - docs/channels/zalo.md
+          - docs/channels/troubleshooting.md
+          - docs/channels/imessage-from-bluebubbles.md
+          - docs/automation/cron-jobs.md#gmail-pubsub-integration
+          - docs/automation/gmail-pubsub.md
+          - docs/cli/webhooks.md
+          - docs/automation/cron-jobs.md#webhooks
+          - docs/automation/webhook.md
+        search_anchors:
+          - Telegram long polling
+          - Telegram webhook mode
+          - Zalo polling/webhook mode
+          - Polling stall diagnostics
+          - iMessage watch fallback
+          - Gmail setup wizard
+          - Watcher start/serve
+          - Tailscale/public routing
+          - Push token validation
+          - Gmail event routing
+          - POST /hooks/wake
+          - POST /hooks/agent
+          - Mapped hooks
+          - Hook auth policy
+          - Async dispatch
+        category_note: channel-polling-webhooks.md
+        human_lts_override: false
+      - name: Automation Hooks
+        features:
+          - name: HOOK.md authoring
+            description: Covers HOOK.md authoring across `HOOK.md` metadata, handler loading, bundled/managed/workspace/plugin hook discovery, eligibility policy, and related internal hooks behavior.
+          - name: Hook discovery
+            description: Covers Hook discovery across `HOOK.md` metadata, handler loading, bundled/managed/workspace/plugin hook discovery, eligibility policy, and related internal hooks behavior.
+          - name: Hook CLI management
+            description: Covers Hook CLI management across `HOOK.md` metadata, handler loading, bundled/managed/workspace/plugin hook discovery, eligibility policy, and related internal hooks behavior.
+          - name: Hook packs
+            description: Covers Hook packs across `HOOK.md` metadata, handler loading, bundled/managed/workspace/plugin hook discovery, eligibility policy, and related internal hooks behavior.
+          - name: Lifecycle event dispatch
+            description: Covers Lifecycle event dispatch across `HOOK.md` metadata, handler loading, bundled/managed/workspace/plugin hook discovery, eligibility policy, and related internal hooks behavior.
+          - name: api.on registration
+            description: Covers api.on registration across `api.on(...)` typed hooks, priority/timeout behavior, decision hooks such as `before_tool_call`, message and dispatch hooks, and related plugin hooks behavior.
+          - name: Tool-call policy hooks
+            description: Covers Tool-call policy hooks across `api.on(...)` typed hooks, priority/timeout behavior, decision hooks such as `before_tool_call`, message and dispatch hooks, and related plugin hooks behavior.
+          - name: Message hooks
+            description: Covers Message hooks across `api.on(...)` typed hooks, priority/timeout behavior, decision hooks such as `before_tool_call`, message and dispatch hooks, and related plugin hooks behavior.
+          - name: Session/lifecycle hooks
+            description: Covers Session/lifecycle hooks across `api.on(...)` typed hooks, priority/timeout behavior, decision hooks such as `before_tool_call`, message and dispatch hooks, and related plugin hooks behavior.
+          - name: Plugin approval requests
+            description: Covers Plugin approval requests across `api.on(...)` typed hooks, priority/timeout behavior, decision hooks such as `before_tool_call`, message and dispatch hooks, and related plugin hooks behavior.
+          - name: cron_changed
+            description: Covers cron_changed across `api.on(...)` typed hooks, priority/timeout behavior, decision hooks such as `before_tool_call`, message and dispatch hooks, and related plugin hooks behavior.
+        docs:
+          - docs/automation/hooks.md
+          - docs/cli/hooks.md
+          - docs/plugins/hooks.md
+          - docs/plugins/plugin-permission-requests.md
+          - docs/plugins/sdk-subpaths.md
+        search_anchors:
+          - HOOK.md authoring
+          - Hook discovery
+          - Hook CLI management
+          - Hook packs
+          - Lifecycle event dispatch
+          - api.on registration
+          - Tool-call policy hooks
+          - Message hooks
+          - Session/lifecycle hooks
+          - Plugin approval requests
+          - cron_changed
+        category_note: internal-hooks.md
+        human_lts_override: false
+      - name: Background Tasks and Flows
+        features:
+          - name: Task list/show/cancel
+            description: Covers Task list/show/cancel across task creation, status transitions, runtime types, owner/session access, and related background task ledger behavior.
+          - name: Task notifications
+            description: Covers Task notifications across task creation, status transitions, runtime types, owner/session access, and related background task ledger behavior.
+          - name: Task audit and maintenance
+            description: Covers Task audit and maintenance across task creation, status transitions, runtime types, owner/session access, and related background task ledger behavior.
+          - name: Chat task board
+            description: Covers Chat task board across task creation, status transitions, runtime types, owner/session access, and related background task ledger behavior.
+          - name: Task pressure status
+            description: Covers Task pressure status across task creation, status transitions, runtime types, owner/session access, and related background task ledger behavior.
+          - name: Managed flows
+            description: Covers Managed flows across managed and mirrored flow modes, flow registry persistence, revision tracking, owner-scoped access, and related task flow behavior.
+          - name: Mirrored flows
+            description: Covers Mirrored flows across managed and mirrored flow modes, flow registry persistence, revision tracking, owner-scoped access, and related task flow behavior.
+          - name: openclaw tasks flow
+            description: Covers openclaw tasks flow across managed and mirrored flow modes, flow registry persistence, revision tracking, owner-scoped access, and related task flow behavior.
+          - name: Flow audit and maintenance
+            description: Covers Flow audit and maintenance across managed and mirrored flow modes, flow registry persistence, revision tracking, owner-scoped access, and related task flow behavior.
+          - name: Plugin managedFlows
+            description: Covers Plugin managedFlows across managed and mirrored flow modes, flow registry persistence, revision tracking, owner-scoped access, and related task flow behavior.
+        docs:
+          - docs/automation/tasks.md
+          - docs/automation/index.md
+          - docs/cli/tasks.md
+          - docs/automation/taskflow.md
+          - docs/plugins/sdk-runtime.md
+        search_anchors:
+          - Task list/show/cancel
+          - Task notifications
+          - Task audit and maintenance
+          - Chat task board
+          - Task pressure status
+          - Managed flows
+          - Mirrored flows
+          - openclaw tasks flow
+          - Flow audit and maintenance
+          - Plugin managedFlows
+        category_note: background-task-ledger.md
+        human_lts_override: false
+      - name: Heartbeat
+        features:
+          - name: Heartbeat scheduling
+            description: Covers Heartbeat scheduling across periodic heartbeat runs, active-hours and variable schedule behavior, wake/cooldown handling, heartbeat prompts and due-only task mode, and related heartbeat and commitments behavior.
+          - name: Active hours
+            description: Covers Active hours across periodic heartbeat runs, active-hours and variable schedule behavior, wake/cooldown handling, heartbeat prompts and due-only task mode, and related heartbeat and commitments behavior.
+          - name: Wake and cooldown handling
+            description: Covers Wake and cooldown handling across periodic heartbeat runs, active-hours and variable schedule behavior, wake/cooldown handling, heartbeat prompts and due-only task mode, and related heartbeat and commitments behavior.
+          - name: Due-only heartbeat tasks
+            description: Covers Due-only heartbeat tasks across periodic heartbeat runs, active-hours and variable schedule behavior, wake/cooldown handling, heartbeat prompts and due-only task mode, and related heartbeat and commitments behavior.
+          - name: Commitment check-ins
+            description: Covers Commitment check-ins across periodic heartbeat runs, active-hours and variable schedule behavior, wake/cooldown handling, heartbeat prompts and due-only task mode, and related heartbeat and commitments behavior.
+        docs:
+          - docs/automation/index.md
+          - docs/gateway/heartbeat.md
+          - docs/concepts/commitments.md
+        search_anchors:
+          - Heartbeat scheduling
+          - Active hours
+          - Wake and cooldown handling
+          - Due-only heartbeat tasks
+          - Commitment check-ins
+          - openclaw cron
+        category_note: heartbeat-commitments.md
+        human_lts_override: false
+      - name: Polling Controls
+        features:
+          - name: openclaw message poll
+            description: Covers openclaw message poll across `openclaw message poll`, channel poll adapters, poll parameter normalization, Teams/Matrix/Telegram poll support, and related message polls and process polling behavior.
+          - name: Telegram polls
+            description: Covers Telegram polls across `openclaw message poll`, channel poll adapters, poll parameter normalization, Teams/Matrix/Telegram poll support, and related message polls and process polling behavior.
+          - name: Teams polls
+            description: Covers Teams polls across `openclaw message poll`, channel poll adapters, poll parameter normalization, Teams/Matrix/Telegram poll support, and related message polls and process polling behavior.
+          - name: Poll flags
+            description: Covers Poll flags across `openclaw message poll`, channel poll adapters, poll parameter normalization, Teams/Matrix/Telegram poll support, and related message polls and process polling behavior.
+          - name: Channel capability gates
+            description: Covers Channel capability gates across `openclaw message poll`, channel poll adapters, poll parameter normalization, Teams/Matrix/Telegram poll support, and related message polls and process polling behavior.
+          - name: process poll
+            description: Covers process poll across `openclaw message poll`, channel poll adapters, poll parameter normalization, Teams/Matrix/Telegram poll support, and related message polls and process polling behavior.
+          - name: process log
+            description: Covers process log across `openclaw message poll`, channel poll adapters, poll parameter normalization, Teams/Matrix/Telegram poll support, and related message polls and process polling behavior.
+          - name: Background process status
+            description: Covers Background process status across `openclaw message poll`, channel poll adapters, poll parameter normalization, Teams/Matrix/Telegram poll support, and related message polls and process polling behavior.
+          - name: No-progress loop detection
+            description: Covers No-progress loop detection across `openclaw message poll`, channel poll adapters, poll parameter normalization, Teams/Matrix/Telegram poll support, and related message polls and process polling behavior.
+          - name: Process input controls
+            description: Covers Process input controls across `openclaw message poll`, channel poll adapters, poll parameter normalization, Teams/Matrix/Telegram poll support, and related message polls and process polling behavior.
+        docs:
+          - docs/automation/poll.md
+          - docs/cli/message.md
+          - docs/channels/telegram.md
+          - docs/channels/msteams.md
+          - docs/gateway/background-process.md
+        search_anchors:
+          - openclaw message poll
+          - Telegram polls
+          - Teams polls
+          - Poll flags
+          - Channel capability gates
+          - process poll
+          - process log
+          - Background process status
+        category_note: message-polls-process-polling.md
+        human_lts_override: false
+    last_score_run:
+      status: complete
+      completed_at: '2026-05-30'
+      by: codex
+      source_ref: null
+      process_version: 3
+  - id: media-understanding-and-media-generation
+    name: Media understanding and media generation
+    family: core
+    level: alpha
+    level_code: M2
+    rationale: Broad capability surface exists, but provider variance, file limits, and node/app parity make this not stable yet.
+    completeness_instructions: references/completeness/media-understanding-and-media-generation.md
+    categories:
+      - name: Media Intake and Access
+        features:
+          - name: Local and remote media references
+            description: 'Covers Local and remote media references across Included: Local and remote media references, including plain paths, `file://`, HTTP(S), and related media file intake, storage, and secure access behavior.'
+          - name: MIME and type detection
+            description: 'Covers MIME and type detection across Included: Local and remote media references, including plain paths, `file://`, HTTP(S), and related media file intake, storage, and secure access behavior.'
+          - name: Size caps and bounded reads
+            description: 'Covers Size caps and bounded reads across Included: Local and remote media references, including plain paths, `file://`, HTTP(S), and related media file intake, storage, and secure access behavior.'
+          - name: Safe remote fetch
+            description: 'Covers Safe remote fetch across Included: Local and remote media references, including plain paths, `file://`, HTTP(S), and related media file intake, storage, and secure access behavior.'
+          - name: Local root policy
+            description: 'Covers Local root policy across Included: Local and remote media references, including plain paths, `file://`, HTTP(S), and related media file intake, storage, and secure access behavior.'
+          - name: Inbound media store
+            description: 'Covers Inbound media store across Included: Local and remote media references, including plain paths, `file://`, HTTP(S), and related media file intake, storage, and secure access behavior.'
+          - name: PDF/document extraction dispatch
+            description: 'Covers PDF/document extraction dispatch across Included: Local and remote media references, including plain paths, `file://`, HTTP(S), and related media file intake, storage, and secure access behavior.'
+          - name: QR and media helper classification
+            description: 'Covers QR and media helper classification across Included: Local and remote media references, including plain paths, `file://`, HTTP(S), and related media file intake, storage, and secure access behavior.'
+        docs:
+          - docs/tools/media-overview.md
+          - docs/nodes/media-understanding.md
+          - docs/gateway/security/secure-file-operations.md
+          - docs/tools/pdf.md
+          - docs/tools/image-generation.md
+          - docs/cli/qr.md
+          - docs/channels/line.md
+          - docs/channels/whatsapp.md
+        search_anchors:
+          - Local and remote media references
+          - MIME and type detection
+          - Size caps and bounded reads
+          - Safe remote fetch
+          - Local root policy
+          - Inbound media store
+          - PDF/document extraction dispatch
+          - QR and media helper classification
+        category_note: media-file-intake-storage-and-secure-access.md
+        human_lts_override: false
+      - name: Channel Media Handling
+        features:
+          - name: Inbound attachment staging
+            description: Covers Inbound attachment staging across inbound attachment staging, sandbox rewrites, `MediaPath`/`MediaPaths`/`MediaUrls` templating, media notes, and related channel attachment staging and reply media delivery behavior.
+          - name: Sandbox media rewrites
+            description: Covers Sandbox media rewrites across inbound attachment staging, sandbox rewrites, `MediaPath`/`MediaPaths`/`MediaUrls` templating, media notes, and related channel attachment staging and reply media delivery behavior.
+          - name: Reply media templating
+            description: Covers Reply media templating across inbound attachment staging, sandbox rewrites, `MediaPath`/`MediaPaths`/`MediaUrls` templating, media notes, and related channel attachment staging and reply media delivery behavior.
+          - name: Message-tool attachment delivery
+            description: Covers Message-tool attachment delivery across inbound attachment staging, sandbox rewrites, `MediaPath`/`MediaPaths`/`MediaUrls` templating, media notes, and related channel attachment staging and reply media delivery behavior.
+          - name: Duplicate delivery suppression
+            description: Covers Duplicate delivery suppression across inbound attachment staging, sandbox rewrites, `MediaPath`/`MediaPaths`/`MediaUrls` templating, media notes, and related channel attachment staging and reply media delivery behavior.
+        docs:
+          - docs/nodes/images.md
+          - docs/tools/media-overview.md
+          - docs/channels/discord.md
+        search_anchors:
+          - Inbound attachment staging
+          - Sandbox media rewrites
+          - Reply media templating
+          - Message-tool attachment delivery
+          - Duplicate delivery suppression
+          - Media understanding (audio)
+          - Provider + CLI fallback
+          - Mention detection in groups
+        category_note: channel-attachment-staging-and-reply-media-delivery.md
+        human_lts_override: false
+      - name: Media Configuration
+        features:
+          - name: Media capability configuration
+            description: tools.media image/audio/video config, shared and per-capability media model entries, provider/CLI entry resolution, auth-backed capability selection, fallback ordering, scope rules, concurrency, active-model skip behavior, offloaded image routing, image generation tool factory availability, image generation task status/list/duplicate guard, and generated-media delivery into the reply pipeline
+        docs:
+          - docs/tools/media-overview.md
+          - docs/tools/image-generation.md
+          - docs/plugins/manifest.md
+          - docs/plugins/codex-harness.md
+        search_anchors:
+          - media understanding and media generation media understanding orchestration and configuration
+          - media understanding orchestration and configuration
+        category_note: media-understanding-orchestration-and-configuration.md
+        human_lts_override: false
+      - name: Text-to-Speech Delivery
+        features:
+          - name: TTS
+            description: Covers TTS across `tts` agent/tool and Gateway methods, `messages.tts`, provider registry, directives, and related tts and outbound voice audio delivery behavior.
+          - name: Outbound Voice Audio Delivery
+            description: Covers Outbound Voice Audio Delivery across `tts` agent/tool and Gateway methods, `messages.tts`, provider registry, directives, and related tts and outbound voice audio delivery behavior.
+        docs:
+          - docs/tools/tts.md
+          - docs/tools/media-overview.md
+          - docs/channels/discord.md
+        search_anchors:
+          - TTS
+          - Outbound Voice Audio Delivery
+          - media understanding and media generation tts and outbound voice audio delivery
+          - tts and outbound voice audio delivery
+        category_note: tts-and-outbound-voice-audio-delivery.md
+        human_lts_override: false
+      - name: Media Understanding
+        features:
+          - name: Audio attachment selection
+            description: Covers Audio attachment selection across batch audio/STT media understanding, local CLI fallbacks, provider transcription, voice-note preflight before mention gates, and related audio transcription and voice note understanding behavior.
+          - name: Batch STT provider and CLI fallback
+            description: Covers Batch STT provider and CLI fallback across batch audio/STT media understanding, local CLI fallbacks, provider transcription, voice-note preflight before mention gates, and related audio transcription and voice note understanding behavior.
+          - name: Voice-note mention preflight
+            description: Covers Voice-note mention preflight across batch audio/STT media understanding, local CLI fallbacks, provider transcription, voice-note preflight before mention gates, and related audio transcription and voice note understanding behavior.
+          - name: Transcript insertion and echo
+            description: Covers Transcript insertion and echo across batch audio/STT media understanding, local CLI fallbacks, provider transcription, voice-note preflight before mention gates, and related audio transcription and voice note understanding behavior.
+          - name: Audio proxy and limit handling
+            description: Covers Audio proxy and limit handling across batch audio/STT media understanding, local CLI fallbacks, provider transcription, voice-note preflight before mention gates, and related audio transcription and voice note understanding behavior.
+          - name: Inbound image summarization
+            description: Covers Inbound image summarization across image summarization before reply routing, active-model vision skip behavior, text-only model offload through `MediaPaths`/`media://inbound`, image-model fallback resolution, and related image understanding and vision routing behavior.
+          - name: Active vision model bypass
+            description: Covers Active vision model bypass across image summarization before reply routing, active-model vision skip behavior, text-only model offload through `MediaPaths`/`media://inbound`, image-model fallback resolution, and related image understanding and vision routing behavior.
+          - name: Text-only model media offload
+            description: Covers Text-only model media offload across image summarization before reply routing, active-model vision skip behavior, text-only model offload through `MediaPaths`/`media://inbound`, image-model fallback resolution, and related image understanding and vision routing behavior.
+          - name: Vision provider fallback
+            description: Covers Vision provider fallback across image summarization before reply routing, active-model vision skip behavior, text-only model offload through `MediaPaths`/`media://inbound`, image-model fallback resolution, and related image understanding and vision routing behavior.
+          - name: Image and PDF input routing
+            description: Covers Image and PDF input routing across image summarization before reply routing, active-model vision skip behavior, text-only model offload through `MediaPaths`/`media://inbound`, image-model fallback resolution, and related image understanding and vision routing behavior.
+          - name: Video Understanding
+            description: Covers Video Understanding across video summarization before reply routing, provider/CLI video media entries, size and timeout controls, proxy support, video request construction, and direct video analysis paths. It does not score video generation.
+          - name: Direct Video Analysis
+            description: Covers Direct Video Analysis across video summarization before reply routing, provider/CLI video media entries, size and timeout controls, proxy support, video request construction, and direct video analysis paths. It does not score video generation.
+        docs:
+          - docs/nodes/audio.md
+          - docs/nodes/media-understanding.md
+          - docs/tools/media-overview.md
+          - docs/channels/whatsapp.md
+          - docs/nodes/images.md
+          - docs/cli/infer.md
+          - docs/tools/pdf.md
+        search_anchors:
+          - Audio attachment selection
+          - Batch STT provider and CLI fallback
+          - Voice-note mention preflight
+          - Transcript insertion and echo
+          - Audio proxy and limit handling
+          - Media understanding (audio)
+          - Provider + CLI fallback
+          - Mention detection in groups
+          - Inbound image summarization
+          - Active vision model bypass
+          - Text-only model media offload
+          - Vision provider fallback
+          - Image and PDF input routing
+          - Video Understanding
+          - Direct Video Analysis
+          - media understanding and media generation video understanding and direct video analysis
+          - video understanding and direct video analysis
+        category_note: image-understanding-and-vision-routing.md
+        human_lts_override: false
+      - name: Media Generation
+        features:
+          - name: Image generation tool invocation
+            description: Covers Image generation tool invocation across `image_generate`, model selection, provider registration, provider capability listing, and related image generation tool and provider routing behavior.
+          - name: Provider and model selection
+            description: Covers Provider and model selection across `image_generate`, model selection, provider registration, provider capability listing, and related image generation tool and provider routing behavior.
+          - name: Reference image editing
+            description: Covers Reference image editing across `image_generate`, model selection, provider registration, provider capability listing, and related image generation tool and provider routing behavior.
+          - name: Generated image task lifecycle
+            description: Covers Generated image task lifecycle across `image_generate`, model selection, provider registration, provider capability listing, and related image generation tool and provider routing behavior.
+          - name: Generated image persistence and delivery
+            description: Covers Generated image persistence and delivery across `image_generate`, model selection, provider registration, provider capability listing, and related image generation tool and provider routing behavior.
+          - name: Music generation tool invocation
+            description: Covers Music generation tool invocation across `music_generate`, provider/model config, lyrics/instrumental/duration/format controls, image reference inputs where supported, and related music generation tool and provider routing behavior.
+          - name: Provider and model selection
+            description: Covers Provider and model selection across `music_generate`, provider/model config, lyrics/instrumental/duration/format controls, image reference inputs where supported, and related music generation tool and provider routing behavior.
+          - name: Lyrics, instrumental, duration, and format controls
+            description: Covers Lyrics, instrumental, duration, and format controls across `music_generate`, provider/model config, lyrics/instrumental/duration/format controls, image reference inputs where supported, and related music generation tool and provider routing behavior.
+          - name: Reference inputs where supported
+            description: Covers Reference inputs where supported across `music_generate`, provider/model config, lyrics/instrumental/duration/format controls, image reference inputs where supported, and related music generation tool and provider routing behavior.
+          - name: Music task lifecycle and duplicate status
+            description: Covers Music task lifecycle and duplicate status across `music_generate`, provider/model config, lyrics/instrumental/duration/format controls, image reference inputs where supported, and related music generation tool and provider routing behavior.
+          - name: Generated audio persistence and delivery
+            description: Covers Generated audio persistence and delivery across `music_generate`, provider/model config, lyrics/instrumental/duration/format controls, image reference inputs where supported, and related music generation tool and provider routing behavior.
+          - name: Video generation tool invocation
+            description: Covers Video generation tool invocation across `video_generate`, mode resolution, provider capabilities, reference image/video/audio inputs, and related video generation tool and provider routing behavior.
+          - name: Mode and provider capability selection
+            description: Covers Mode and provider capability selection across `video_generate`, mode resolution, provider capabilities, reference image/video/audio inputs, and related video generation tool and provider routing behavior.
+          - name: Reference image, video, and audio inputs
+            description: Covers Reference image, video, and audio inputs across `video_generate`, mode resolution, provider capabilities, reference image/video/audio inputs, and related video generation tool and provider routing behavior.
+          - name: Provider option validation
+            description: Covers Provider option validation across `video_generate`, mode resolution, provider capabilities, reference image/video/audio inputs, and related video generation tool and provider routing behavior.
+          - name: Video task lifecycle and status
+            description: Covers Video task lifecycle and status across `video_generate`, mode resolution, provider capabilities, reference image/video/audio inputs, and related video generation tool and provider routing behavior.
+          - name: Generated video persistence and delivery
+            description: Covers Generated video persistence and delivery across `video_generate`, mode resolution, provider capabilities, reference image/video/audio inputs, and related video generation tool and provider routing behavior.
+        docs:
+          - docs/tools/image-generation.md
+          - docs/tools/media-overview.md
+          - docs/tools/skills.md
+          - docs/tools/music-generation.md
+          - docs/tools/video-generation.md
+        search_anchors:
+          - Image generation tool invocation
+          - Provider and model selection
+          - Reference image editing
+          - Generated image task lifecycle
+          - Generated image persistence and delivery
+          - Media understanding (audio)
+          - Provider + CLI fallback
+          - Mention detection in groups
+          - Music generation tool invocation
+          - Lyrics, instrumental, duration, and format controls
+          - Reference inputs where supported
+          - Music task lifecycle and duplicate status
+          - Generated audio persistence and delivery
+          - Video generation tool invocation
+          - Mode and provider capability selection
+          - Reference image, video, and audio inputs
+          - Provider option validation
+          - Video task lifecycle and status
+          - Generated video persistence and delivery
+        category_note: image-generation-tool-and-provider-routing.md
+        human_lts_override: false
+    last_score_run:
+      status: complete
+      completed_at: '2026-05-30'
+      by: codex
+      source_ref: null
+      process_version: 3
+  - id: voice-and-realtime-talk
+    name: Voice and realtime talk
+    family: core
+    level: alpha
+    level_code: M2
+    rationale: Multiple implementations exist across Control UI, apps, and providers. Needs latency, failure-mode, and setup scorecards before beta.
+    completeness_instructions: references/completeness/voice-and-realtime-talk.md
+    categories:
+      - name: Talk Providers
+        features:
+          - name: OpenAI Realtime voice backend bridge
+            description: OpenAI Realtime voice backend bridge and browser WebRTC credential path
+          - name: Google Gemini Live backend bridge
+            description: Google Gemini Live backend bridge and browser token/WebSocket path
+          - name: Realtime voice provider SDK contracts
+            description: Realtime voice provider SDK contracts, activation metadata, provider registry, and resolver
+          - name: Provider diagnostics
+            description: Provider diagnostics, reconnect behavior, tool declarations, and bridge session lifecycle
+          - name: Talk catalog
+            description: Talk catalog discovery for transport, brain, speech, realtime voice, and transcription providers.
+          - name: Talk provider config
+            description: Talk provider selection, provider-specific realtime settings, and secret exposure rules.
+          - name: Shared native config parsing
+            description: Shared native config parsing for macOS, iOS, and Android
+        docs:
+          - docs/providers/openai.md
+          - docs/providers/google.md
+          - docs/plugins/sdk-provider-plugins.md
+          - docs/nodes/talk.md
+          - docs/web/control-ui.md
+        search_anchors:
+          - OpenAI Realtime
+          - Google Gemini Live
+          - realtime voice provider
+          - talk.catalog
+          - talk.config
+        category_note: talk-configuration-catalog-and-provider-selection.md
+        human_lts_override: false
+      - name: Realtime Talk Sessions
+        features:
+          - name: Agent consult handoff
+            description: Consult handoff behavior between active Talk sessions and agent runs.
+          - name: Active Talk agent-run status
+            description: Active Talk agent-run status, cancel, steer, and follow-up controls
+          - name: Talkback runtime behavior
+            description: Talkback runtime behavior and assistant speech coordination
+          - name: Forced consult scheduling
+            description: Forced consult scheduling and control event propagation
+          - name: Browser Talk start/stop UI
+            description: Browser Talk start/stop UI and status display
+          - name: Browser WebRTC sessions
+            description: Browser WebRTC sessions for OpenAI Realtime and Google Live providers.
+          - name: Browser relay mode
+            description: Browser relay mode for backend-only realtime providers.
+          - name: Browser tool-call forwarding
+            description: Browser tool-call forwarding, transcript events, and audio playback
+          - name: Realtime session controls
+            description: Realtime session create, audio append, turn cancellation, steering, tool-result submission, and close controls.
+          - name: Gateway relay sessions
+            description: Gateway relay sessions for realtime voice and transcription flows.
+          - name: Audio-frame limits
+            description: Audio-frame limits, session TTL, per-connection/global caps, transcript events, and relay cleanup
+        docs:
+          - docs/nodes/talk.md
+          - docs/web/control-ui.md
+        search_anchors:
+          - Talk agent-run status
+          - talkback
+          - consult handoff
+          - Browser Talk start/stop
+          - OpenAI WebRTC
+          - browser relay mode
+          - talk.session.create
+          - appendAudio
+          - cancelTurn
+          - submitToolResult
+        category_note: gateway-relay-and-realtime-session-runtime.md
+        human_lts_override: false
+      - name: Speech and Transcription
+        features:
+          - name: Voice directives
+            description: Voice directives and directive stripping before TTS playback.
+          - name: Talk speech playback
+            description: Gateway talk.speak and fallback TTS behavior.
+          - name: Transcription relay sessions
+            description: Gateway transcription relay sessions, transcript events, and cleanup behavior.
+          - name: Realtime transcription providers
+            description: Realtime transcription provider selection, diagnostics, and provider-specific bridge behavior.
+          - name: Native directive parsing
+            description: Native directive parsing and Talk speech locale behavior
+        docs:
+          - docs/nodes/talk.md
+          - docs/providers/openai.md
+          - docs/providers/google.md
+        search_anchors:
+          - talk.speak
+          - voice directives
+          - transcription relay sessions
+        category_note: speech-transcription-directives-and-talk-speak.md
+        human_lts_override: false
+      - name: Native App Talk
+        features:
+          - name: macOS native Talk mode
+            description: macOS native Talk mode, speech recognition, TTS playback, and push-to-talk handoff
+          - name: iOS Talk mode
+            description: iOS Talk mode, WebRTC sessions, realtime relay sessions, and wake preferences
+          - name: Android Talk mode
+            description: Android Talk mode, speech-recognizer mode, realtime relay, mic capture, and debug E2E receiver
+          - name: Shared Talk config
+            description: Shared Talk config and command parsing
+        docs:
+          - docs/nodes/talk.md
+          - docs/platforms/mac/voicewake.md
+        search_anchors:
+          - macOS native Talk mode
+          - iOS Talk mode
+          - Android Talk mode
+        category_note: native-app-talk-loops-ios-android-macos.md
+        human_lts_override: false
+      - name: Voice Wake and Routing
+        features:
+          - name: Wake-word settings
+            description: Gateway-owned wake-word settings and routing preferences.
+          - name: Wake routing
+            description: Default, last-focused app, local app, and specific-node routing methods.
+          - name: macOS Voice Wake runtime
+            description: macOS Voice Wake runtime, push-to-talk hotkey, overlay adoption, pause/resume behavior, and forwarding
+          - name: Mobile wake preferences
+            description: iOS and Android wake preferences and command extraction.
+        docs:
+          - docs/nodes/voicewake.md
+          - docs/platforms/mac/voicewake.md
+          - docs/platforms/mac/voice-overlay.md
+        search_anchors:
+          - Voice Wake
+          - push-to-talk
+          - wake-word settings
+        category_note: voice-wake-push-to-talk-and-routing.md
+        human_lts_override: false
+      - name: Talk Observability
+        features:
+          - name: Talk event logging
+            description: Talk event logging and diagnostics event mapping
+          - name: Session-log health
+            description: Session-log health, transcript records, bridge events, and echo/output suppression timing
+          - name: Live smoke output
+            description: Live smoke output and provider event inspection
+          - name: Prometheus diagnostic counters
+            description: Prometheus diagnostic counters for Talk events
+          - name: Operator visibility into setup
+            description: Operator visibility into setup, latency, and failure modes
+        docs:
+          - docs/web/control-ui.md
+          - docs/platforms/mac/voice-overlay.md
+          - docs/nodes/talk.md
+        search_anchors:
+          - Talk event logging
+          - session-log health
+          - latency visibility
+        category_note: observability-diagnostics-session-health-and-latency.md
+        human_lts_override: false
+    last_score_run:
+      status: complete
+      completed_at: '2026-05-30'
+      by: codex
+      source_ref: null
+      process_version: 3
+  - id: browser-control-ui-and-webchat
+    name: Gateway Web App
+    family: core
+    level: beta
+    level_code: M3
+    rationale: Web UI is documented with pairing, chat, PWA, Talk, push, and remote Gateway flows. Promote after cross-browser and mobile-PWA scorecards.
+    completeness_instructions: references/completeness/browser-control-ui-and-webchat.md
+    categories:
+      - name: Browser Realtime Talk
+        features:
+          - name: Browser Talk start/stop
+            description: Covers Browser Talk start/stop across browser Talk controls, Talk options, OpenAI browser WebRTC, Google Live/provider WebSocket, and related browser realtime talk behavior.
+          - name: Provider session selection
+            description: Covers Provider session selection across browser Talk controls, Talk options, OpenAI browser WebRTC, Google Live/provider WebSocket, and related browser realtime talk behavior.
+          - name: Gateway relay audio
+            description: Covers Gateway relay audio across browser Talk controls, Talk options, OpenAI browser WebRTC, Google Live/provider WebSocket, and related browser realtime talk behavior.
+          - name: Tool-call consults
+            description: Covers Tool-call consults across browser Talk controls, Talk options, OpenAI browser WebRTC, Google Live/provider WebSocket, and related browser realtime talk behavior.
+          - name: Steer and cancel
+            description: Covers Steer and cancel across browser Talk controls, Talk options, OpenAI browser WebRTC, Google Live/provider WebSocket, and related browser realtime talk behavior.
+        docs:
+          - docs/web/control-ui.md
+          - docs/gateway/protocol.md
+          - docs/nodes/talk.md
+        search_anchors:
+          - Browser Talk start/stop
+          - Provider session selection
+          - Gateway relay audio
+          - Tool-call consults
+          - Steer and cancel
+          - What it can do (today)
+          - Chat behavior
+          - PWA install and web push
+        category_note: browser-realtime-talk-controls-and-voice-transports.md
+        human_lts_override: false
+      - name: Browser Access and Trust
+        features:
+          - name: Device pairing
+            description: Covers Device pairing across Control UI/WebChat Gateway connection setup, browser-origin checks, token/password auth, trusted-proxy and Tailscale Serve auth, and related gateway connection, auth, device pairing, and remote origins behavior.
+          - name: Token/password auth
+            description: Covers Token/password auth across Control UI/WebChat Gateway connection setup, browser-origin checks, token/password auth, trusted-proxy and Tailscale Serve auth, and related gateway connection, auth, device pairing, and remote origins behavior.
+          - name: Tailscale Serve auth
+            description: Covers Tailscale Serve auth across Control UI/WebChat Gateway connection setup, browser-origin checks, token/password auth, trusted-proxy and Tailscale Serve auth, and related gateway connection, auth, device pairing, and remote origins behavior.
+          - name: Trusted proxy auth
+            description: Covers Trusted proxy auth across Control UI/WebChat Gateway connection setup, browser-origin checks, token/password auth, trusted-proxy and Tailscale Serve auth, and related gateway connection, auth, device pairing, and remote origins behavior.
+          - name: Allowed origins/gatewayUrl
+            description: Covers Allowed origins/gatewayUrl across Control UI/WebChat Gateway connection setup, browser-origin checks, token/password auth, trusted-proxy and Tailscale Serve auth, and related gateway connection, auth, device pairing, and remote origins behavior.
+        docs:
+          - docs/web/control-ui.md
+          - docs/web/dashboard.md
+          - docs/gateway/tailscale.md
+          - docs/gateway/remote.md
+        search_anchors:
+          - Device pairing
+          - Token/password auth
+          - Tailscale Serve auth
+          - Trusted proxy auth
+          - Allowed origins/gatewayUrl
+          - What it can do (today)
+          - Chat behavior
+          - PWA install and web push
+        category_note: gateway-connection-auth-device-pairing-and-origins.md
+        human_lts_override: false
+      - name: Configuration
+        features:
+          - name: Config snapshots
+            description: Covers Config snapshots across `config.get`, `config.set`, `config.apply`, `config.patch`, and related config schema editing and safe writes behavior.
+          - name: Schema form editing
+            description: Covers Schema form editing across `config.get`, `config.set`, `config.apply`, `config.patch`, and related config schema editing and safe writes behavior.
+          - name: Raw JSON editing
+            description: Covers Raw JSON editing across `config.get`, `config.set`, `config.apply`, `config.patch`, and related config schema editing and safe writes behavior.
+          - name: Base-hash guarded writes
+            description: Covers Base-hash guarded writes across `config.get`, `config.set`, `config.apply`, `config.patch`, and related config schema editing and safe writes behavior.
+          - name: Apply and restart
+            description: Covers Apply and restart across `config.get`, `config.set`, `config.apply`, `config.patch`, and related config schema editing and safe writes behavior.
+        docs:
+          - docs/web/control-ui.md
+          - docs/gateway/configuration.md
+        search_anchors:
+          - Config snapshots
+          - Schema form editing
+          - Raw JSON editing
+          - Base-hash guarded writes
+          - Apply and restart
+          - What it can do (today)
+          - Chat behavior
+          - PWA install and web push
+        category_note: config-schema-editing-and-safe-writes.md
+        human_lts_override: false
+      - name: Browser UI
+        features:
+          - name: Gateway-hosted UI
+            description: Covers Gateway-hosted UI across serving the Control UI bundle from the Gateway, root and base-path routing, static asset MIME/cache behavior, public PWA assets, and related control ui shell and routing behavior.
+          - name: Dashboard open/auth bootstrap
+            description: Covers Dashboard open/auth bootstrap across serving the Control UI bundle from the Gateway, root and base-path routing, static asset MIME/cache behavior, public PWA assets, and related control ui shell and routing behavior.
+          - name: Base-path routing
+            description: Covers Base-path routing across serving the Control UI bundle from the Gateway, root and base-path routing, static asset MIME/cache behavior, public PWA assets, and related control ui shell and routing behavior.
+          - name: Static asset recovery
+            description: Covers Static asset recovery across serving the Control UI bundle from the Gateway, root and base-path routing, static asset MIME/cache behavior, public PWA assets, and related control ui shell and routing behavior.
+          - name: Dev gatewayUrl target
+            description: Covers Dev gatewayUrl target across serving the Control UI bundle from the Gateway, root and base-path routing, static asset MIME/cache behavior, public PWA assets, and related control ui shell and routing behavior.
+          - name: PWA install metadata
+            description: Covers PWA install metadata across browser PWA install metadata, production service-worker registration, push event handling, notification-click behavior, and related pwa install and web push notifications behavior.
+          - name: Service worker updates
+            description: Covers Service worker updates across browser PWA install metadata, production service-worker registration, push event handling, notification-click behavior, and related pwa install and web push notifications behavior.
+          - name: VAPID keys
+            description: Covers VAPID keys across browser PWA install metadata, production service-worker registration, push event handling, notification-click behavior, and related pwa install and web push notifications behavior.
+          - name: Subscribe/unsubscribe
+            description: Covers Subscribe/unsubscribe across browser PWA install metadata, production service-worker registration, push event handling, notification-click behavior, and related pwa install and web push notifications behavior.
+          - name: Test notifications
+            description: Covers Test notifications across browser PWA install metadata, production service-worker registration, push event handling, notification-click behavior, and related pwa install and web push notifications behavior.
+        docs:
+          - docs/web/control-ui.md
+          - docs/web/index.md
+          - docs/web/dashboard.md
+          - docs/gateway/protocol.md
+        search_anchors:
+          - Gateway-hosted UI
+          - Dashboard open/auth bootstrap
+          - Base-path routing
+          - Static asset recovery
+          - Dev gatewayUrl target
+          - What it can do (today)
+          - Chat behavior
+          - PWA install and web push
+          - PWA install metadata
+          - Service worker updates
+          - VAPID keys
+          - Subscribe/unsubscribe
+          - Test notifications
+        category_note: control-ui-static-shell-routing-and-pwa.md
+        human_lts_override: false
+      - name: WebChat Conversations
+        features:
+          - name: Send and abort
+            description: 'Covers Send and abort across browser chat composition and display UX after an authenticated Gateway connection exists: composer controls, slash commands, session and agent filtering, model/thinking overrides, and related chat composer and message rendering behavior.'
+          - name: Session and agent picker
+            description: 'Covers Session and agent picker across browser chat composition and display UX after an authenticated Gateway connection exists: composer controls, slash commands, session and agent filtering, model/thinking overrides, and related chat composer and message rendering behavior.'
+          - name: Model/thinking controls
+            description: 'Covers Model/thinking controls across browser chat composition and display UX after an authenticated Gateway connection exists: composer controls, slash commands, session and agent filtering, model/thinking overrides, and related chat composer and message rendering behavior.'
+          - name: Attachments
+            description: 'Covers Attachments across browser chat composition and display UX after an authenticated Gateway connection exists: composer controls, slash commands, session and agent filtering, model/thinking overrides, and related chat composer and message rendering behavior.'
+          - name: Markdown/tool/media rendering
+            description: 'Covers Markdown/tool/media rendering across browser chat composition and display UX after an authenticated Gateway connection exists: composer controls, slash commands, session and agent filtering, model/thinking overrides, and related chat composer and message rendering behavior.'
+          - name: chat.history projection
+            description: Covers chat.history projection across Gateway WebChat RPC/runtime contract, durable transcript projection, active run lifecycle, abort and partial retention, and related webchat runtime and session continuity behavior.
+          - name: chat.send lifecycle
+            description: Covers chat.send lifecycle across Gateway WebChat RPC/runtime contract, durable transcript projection, active run lifecycle, abort and partial retention, and related webchat runtime and session continuity behavior.
+          - name: Abort/partial retention
+            description: Covers Abort/partial retention across Gateway WebChat RPC/runtime contract, durable transcript projection, active run lifecycle, abort and partial retention, and related webchat runtime and session continuity behavior.
+          - name: Injected assistant notes
+            description: Covers Injected assistant notes across Gateway WebChat RPC/runtime contract, durable transcript projection, active run lifecycle, abort and partial retention, and related webchat runtime and session continuity behavior.
+          - name: Reconnect continuity
+            description: Covers Reconnect continuity across Gateway WebChat RPC/runtime contract, durable transcript projection, active run lifecycle, abort and partial retention, and related webchat runtime and session continuity behavior.
+          - name: Hosted embeds
+            description: Covers Hosted embeds across `[embed ...]` rendering policy, `gateway.controlUi.embedSandbox`, external embed URL gating, CSP and frame denial, and related hosted media and embed safety behavior.
+          - name: External embed gating
+            description: Covers External embed gating across `[embed ...]` rendering policy, `gateway.controlUi.embedSandbox`, external embed URL gating, CSP and frame denial, and related hosted media and embed safety behavior.
+          - name: Assistant media tickets
+            description: Covers Assistant media tickets across `[embed ...]` rendering policy, `gateway.controlUi.embedSandbox`, external embed URL gating, CSP and frame denial, and related hosted media and embed safety behavior.
+          - name: Authenticated avatars
+            description: Covers Authenticated avatars across `[embed ...]` rendering policy, `gateway.controlUi.embedSandbox`, external embed URL gating, CSP and frame denial, and related hosted media and embed safety behavior.
+          - name: CSP image policy
+            description: Covers CSP image policy across `[embed ...]` rendering policy, `gateway.controlUi.embedSandbox`, external embed URL gating, CSP and frame denial, and related hosted media and embed safety behavior.
+        docs:
+          - docs/web/control-ui.md
+          - docs/web/webchat.md
+          - docs/start/getting-started.md
+          - docs/channels/channel-routing.md
+          - docs/gateway/security/secure-file-operations.md
+        search_anchors:
+          - Send and abort
+          - Session and agent picker
+          - Model/thinking controls
+          - Attachments
+          - Markdown/tool/media rendering
+          - What it can do (today)
+          - Chat behavior
+          - PWA install and web push
+          - chat.history projection
+          - chat.send lifecycle
+          - Abort/partial retention
+          - Injected assistant notes
+          - Reconnect continuity
+          - Hosted embeds
+          - External embed gating
+          - Assistant media tickets
+          - Authenticated avatars
+          - CSP image policy
+        category_note: chat-composer-session-model-controls-and-rendering.md
+        human_lts_override: false
+      - name: Operator Console
+        features:
+          - name: Health/status/models
+            description: Covers Health/status/models across Debug, Logs, Update, Activity, and related diagnostics, logs, update, and activity behavior.
+          - name: Live log tail
+            description: Covers Live log tail across Debug, Logs, Update, Activity, and related diagnostics, logs, update, and activity behavior.
+          - name: Update run/status
+            description: Covers Update run/status across Debug, Logs, Update, Activity, and related diagnostics, logs, update, and activity behavior.
+          - name: Activity summaries
+            description: Covers Activity summaries across Debug, Logs, Update, Activity, and related diagnostics, logs, update, and activity behavior.
+          - name: RPC timing telemetry
+            description: Covers RPC timing telemetry across Debug, Logs, Update, Activity, and related diagnostics, logs, update, and activity behavior.
+          - name: Channels/login
+            description: 'Covers Channels/login across non-config operator panels in the browser Control UI: channels and login, instances/presence, sessions, cron jobs, skills, nodes, exec approvals, agents, usage, dreams, and the dashboard navigation that surfaces them.'
+          - name: Session manager and history
+            description: Covers browser Control UI session manager, session history, instance presence, approvals, diagnostics, and log tabs.
+          - name: Cron
+            description: 'Covers Cron across non-config operator panels in the browser Control UI: channels and login, instances/presence, sessions, cron jobs, skills, nodes, exec approvals, agents, usage, dreams, and the dashboard navigation that surfaces them.'
+          - name: Skills/nodes
+            description: 'Covers Skills/nodes across non-config operator panels in the browser Control UI: channels and login, instances/presence, sessions, cron jobs, skills, nodes, exec approvals, agents, usage, dreams, and the dashboard navigation that surfaces them.'
+          - name: Exec approvals/agents
+            description: 'Covers Exec approvals/agents across non-config operator panels in the browser Control UI: channels and login, instances/presence, sessions, cron jobs, skills, nodes, exec approvals, agents, usage, dreams, and the dashboard navigation that surfaces them.'
+        docs:
+          - docs/web/control-ui.md
+          - docs/gateway/health.md
+          - docs/gateway/protocol.md
+          - docs/web/dashboard.md
+        search_anchors:
+          - Health/status/models
+          - Live log tail
+          - Update run/status
+          - Activity summaries
+          - RPC timing telemetry
+          - What it can do (today)
+          - Chat behavior
+          - PWA install and web push
+          - Channels/login
+          - session manager
+          - session history
+          - Cron
+          - Skills/nodes
+          - Exec approvals/agents
+        category_note: diagnostics-logs-update-and-activity.md
+        human_lts_override: false
+    last_score_run:
+      status: complete
+      completed_at: '2026-05-30'
+      by: codex
+      source_ref: null
+      process_version: 3
+  - id: tui-and-terminal-ux
+    name: TUI
+    family: core
+    level: alpha
+    level_code: M2
+    rationale: Present in docs and source, but less visible as a primary user workflow. Needs explicit scenario definition.
+    completeness_instructions: references/completeness/tui-and-terminal-ux.md
+    categories:
+      - name: Runtime Modes
+        features:
+          - name: Gateway TUI launch
+            description: Covers Gateway TUI launch across `openclaw tui`, `openclaw chat`, `openclaw terminal`, local-vs-Gateway option validation, launch relaunching from setup/hatch paths, initial message and timeout flags, and launch docs.
+          - name: Local chat launch
+            description: Covers Local chat launch across `openclaw tui`, `openclaw chat`, `openclaw terminal`, local-vs-Gateway option validation, launch relaunching from setup/hatch paths, initial message and timeout flags, and launch docs.
+          - name: Terminal alias launch
+            description: Covers Terminal alias launch across `openclaw tui`, `openclaw chat`, `openclaw terminal`, local-vs-Gateway option validation, launch relaunching from setup/hatch paths, initial message and timeout flags, and launch docs.
+          - name: Initial message launch
+            description: Covers Initial message launch across `openclaw tui`, `openclaw chat`, `openclaw terminal`, local-vs-Gateway option validation, launch relaunching from setup/hatch paths, initial message and timeout flags, and launch docs.
+          - name: Launch option validation
+            description: Covers Launch option validation across `openclaw tui`, `openclaw chat`, `openclaw terminal`, local-vs-Gateway option validation, launch relaunching from setup/hatch paths, initial message and timeout flags, and launch docs.
+          - name: Gateway connection
+            description: Covers Gateway connection across Gateway connection resolution, token/password/SecretRef auth for TUI, `--url` auth requirements, client mode/capability registration, and related gateway transport, auth, and history behavior.
+          - name: Gateway authentication
+            description: Covers Gateway authentication across Gateway connection resolution, token/password/SecretRef auth for TUI, `--url` auth requirements, client mode/capability registration, and related gateway transport, auth, and history behavior.
+          - name: History load on attach
+            description: Covers History load on attach across Gateway connection resolution, token/password/SecretRef auth for TUI, `--url` auth requirements, client mode/capability registration, and related gateway transport, auth, and history behavior.
+          - name: Reconnect visibility
+            description: Covers Reconnect visibility across Gateway connection resolution, token/password/SecretRef auth for TUI, `--url` auth requirements, client mode/capability registration, and related gateway transport, auth, and history behavior.
+          - name: Gateway command RPCs
+            description: Covers Gateway command RPCs across Gateway connection resolution, token/password/SecretRef auth for TUI, `--url` auth requirements, client mode/capability registration, and related gateway transport, auth, and history behavior.
+          - name: Embedded local chat
+            description: Covers Embedded local chat across embedded backend lifecycle, local model catalog loading, local `chat.send` event projection, queued local runs, local session history, local `/auth`, local config repair docs, and Gateway-free recovery scenarios.
+          - name: Local auth flow
+            description: Covers Local auth flow across embedded backend lifecycle, local model catalog loading, local `chat.send` event projection, queued local runs, local session history, local `/auth`, local config repair docs, and Gateway-free recovery scenarios.
+          - name: Config repair loop
+            description: Covers Config repair loop across embedded backend lifecycle, local model catalog loading, local `chat.send` event projection, queued local runs, local session history, local `/auth`, local config repair docs, and Gateway-free recovery scenarios.
+          - name: Gateway-free recovery
+            description: Covers Gateway-free recovery across embedded backend lifecycle, local model catalog loading, local `chat.send` event projection, queued local runs, local session history, local `/auth`, local config repair docs, and Gateway-free recovery scenarios.
+        docs:
+          - docs/cli/tui.md
+          - docs/web/tui.md
+          - docs/cli/index.md
+        search_anchors:
+          - Gateway TUI launch
+          - Local chat launch
+          - Terminal alias launch
+          - Initial message launch
+          - Launch option validation
+          - keyboard shortcuts
+          - gateway mode
+          - local mode
+          - Gateway connection
+          - Gateway authentication
+          - History load on attach
+          - Reconnect visibility
+          - Gateway command RPCs
+          - Embedded local chat
+          - Local auth flow
+          - Config repair loop
+          - Gateway-free recovery
+          - pickers + overlays
+        category_note: launch-modes-and-cli-entrypoints.md
+        human_lts_override: false
+      - name: Input and Commands
+        features:
+          - name: Message composition
+            description: Covers Message composition across editor, submit handler, input history, slash/local shell routing, busy-submit behavior, paste fallback, backspace dedupe, Ctrl/Esc shortcuts, AltGr handling, and documented keyboard shortcuts.
+          - name: Input history
+            description: Covers Input history across editor, submit handler, input history, slash/local shell routing, busy-submit behavior, paste fallback, backspace dedupe, Ctrl/Esc shortcuts, AltGr handling, and documented keyboard shortcuts.
+          - name: Keyboard shortcuts
+            description: Covers Keyboard shortcuts across editor, submit handler, input history, slash/local shell routing, busy-submit behavior, paste fallback, backspace dedupe, Ctrl/Esc shortcuts, AltGr handling, and documented keyboard shortcuts.
+          - name: Paste and busy-submit handling
+            description: Covers Paste and busy-submit handling across editor, submit handler, input history, slash/local shell routing, busy-submit behavior, paste fallback, backspace dedupe, Ctrl/Esc shortcuts, AltGr handling, and documented keyboard shortcuts.
+          - name: IME and AltGr handling
+            description: Covers IME and AltGr handling across editor, submit handler, input history, slash/local shell routing, busy-submit behavior, paste fallback, backspace dedupe, Ctrl/Esc shortcuts, AltGr handling, and documented keyboard shortcuts.
+          - name: Slash Commands
+            description: Covers Slash Commands across slash command parsing, command forwarding, local-only commands, model/agent/session selectors, settings overlay, context mode picker, dynamic Gateway command list, session patch commands, and command docs.
+          - name: Pickers
+            description: Covers Pickers across slash command parsing, command forwarding, local-only commands, model/agent/session selectors, settings overlay, context mode picker, dynamic Gateway command list, session patch commands, and command docs.
+          - name: Settings
+            description: Covers Settings across slash command parsing, command forwarding, local-only commands, model/agent/session selectors, settings overlay, context mode picker, dynamic Gateway command list, session patch commands, and command docs.
+        docs:
+          - docs/web/tui.md
+        search_anchors:
+          - Message composition
+          - Input history
+          - Keyboard shortcuts
+          - Paste and busy-submit handling
+          - IME and AltGr handling
+          - gateway mode
+          - local mode
+          - Slash Commands
+          - Pickers
+          - Settings
+          - tui and terminal ux slash commands, pickers, and settings
+          - slash commands, pickers, and settings
+        category_note: composer-keybindings-and-input-editing.md
+        human_lts_override: false
+      - name: Session Management
+        features:
+          - name: Session Lifecycle
+            description: Covers Session Lifecycle across session-key resolution, last selected session persistence, session picker policy, history loading, and related session lifecycle, history, and resume behavior.
+          - name: History
+            description: Covers History across session-key resolution, last selected session persistence, session picker policy, history loading, and related session lifecycle, history, and resume behavior.
+          - name: Resume
+            description: Covers Resume across session-key resolution, last selected session persistence, session picker policy, history loading, and related session lifecycle, history, and resume behavior.
+        docs:
+          - docs/web/tui.md
+          - docs/cli/sessions.md
+        search_anchors:
+          - Session Lifecycle
+          - History
+          - Resume
+          - tui and terminal ux session lifecycle, history, and resume
+          - session lifecycle, history, and resume
+        category_note: session-lifecycle-history-and-resume.md
+        human_lts_override: false
+      - name: Local Shell Execution
+        features:
+          - name: Bang-command routing
+            description: Covers Bang-command routing across `!` routing, local exec approval prompt, Yes/No overlay, command execution, output capture and cap, exit/error rendering, environment marker, cwd handling, and docs that distinguish local host execution from Gateway execution.
+          - name: Approval prompt
+            description: Covers Approval prompt across `!` routing, local exec approval prompt, Yes/No overlay, command execution, output capture and cap, exit/error rendering, environment marker, cwd handling, and docs that distinguish local host execution from Gateway execution.
+          - name: Command output display
+            description: Covers Command output display across `!` routing, local exec approval prompt, Yes/No overlay, command execution, output capture and cap, exit/error rendering, environment marker, cwd handling, and docs that distinguish local host execution from Gateway execution.
+          - name: Execution environment marker
+            description: Covers Execution environment marker across `!` routing, local exec approval prompt, Yes/No overlay, command execution, output capture and cap, exit/error rendering, environment marker, cwd handling, and docs that distinguish local host execution from Gateway execution.
+        docs:
+          - docs/web/tui.md
+          - docs/cli/tui.md
+        search_anchors:
+          - Bang-command routing
+          - Approval prompt
+          - Command output display
+          - Execution environment marker
+          - keyboard shortcuts
+          - gateway mode
+          - local mode
+          - pickers + overlays
+        category_note: local-shell-execution-and-approval-boundary.md
+        human_lts_override: false
+      - name: Rendering and Output Safety
+        features:
+          - name: Streaming Message Rendering
+            description: Covers Streaming Message Rendering across chat log rendering, assistant stream assembly, final/error resolution, thinking visibility, and related streaming message rendering and tool cards behavior.
+          - name: Tool Cards
+            description: Covers Tool Cards across chat log rendering, assistant stream assembly, final/error resolution, thinking visibility, and related streaming message rendering and tool cards behavior.
+          - name: Terminal Rendering Primitives
+            description: 'Covers Terminal Rendering Primitives across shared terminal output helpers used by CLI/TUI surfaces: safe stream writing, text sanitization, ANSI/OSC handling, table wrapping, and related terminal rendering primitives and output safety behavior.'
+          - name: Output Safety
+            description: 'Covers Output Safety across shared terminal output helpers used by CLI/TUI surfaces: safe stream writing, text sanitization, ANSI/OSC handling, table wrapping, and related terminal rendering primitives and output safety behavior.'
+        docs:
+          - docs/web/tui.md
+          - docs/cli/qr.md
+          - docs/cli/logs.md
+          - docs/cli/completion.md
+        search_anchors:
+          - Streaming Message Rendering
+          - Tool Cards
+          - tui and terminal ux streaming message rendering and tool cards
+          - streaming message rendering and tool cards
+          - Terminal Rendering Primitives
+          - Output Safety
+          - tui and terminal ux terminal rendering primitives and output safety
+          - terminal rendering primitives and output safety
+        category_note: streaming-message-rendering-and-tool-cards.md
+        human_lts_override: false
+    last_score_run:
+      status: complete
+      completed_at: '2026-05-30'
+      by: codex
+      source_ref: null
+      process_version: 3
+  - id: clawhub-and-external-plugin-distribution
+    name: ClawHub
+    family: core
+    level: alpha
+    level_code: M2
+    rationale: Public docs and ecosystem concept exist. Needs install, trust, update, rollback, and compatibility scorecards.
+    completeness_instructions: references/completeness/clawhub-and-external-plugin-distribution.md
+    categories:
+      - name: Publishing
+        features:
+          - name: ClawHub package publishing owner
+            description: ClawHub package publishing owner and scope rules
+          - name: OpenClaw-owned package release validation for ClawHub
+            description: OpenClaw-owned package release validation for ClawHub and npm
+          - name: Version bump gates
+            description: Version bump gates for changed publishable plugins
+          - name: npm trusted publishing provenance
+            description: npm trusted publishing provenance metadata
+          - name: External code plugin package contract required
+            description: External code plugin package contract required before publish
+          - name: Skill package metadata
+            description: Publish-ready skill metadata, file limits, versions, and tags.
+          - name: Skill publishing flow
+            description: Owner-scoped ClawHub skill publishing, validation, release, and review.
+        docs:
+          - docs/clawhub/publishing.md
+          - docs/clawhub/skill-format.md
+          - docs/tools/creating-skills.md
+          - docs/plugins/community.md
+        search_anchors:
+          - clawhub publishing release validation
+          - clawhub and npm publishing release validation
+          - SKILL.md format
+          - Runtime metadata
+          - Release Flow
+          - Skill content
+        category_note: clawhub-and-npm-publishing-release-validation.md
+        human_lts_override: false
+      - name: Catalog Discovery
+        features:
+          - name: openclaw plugins search as the ClawHub
+            description: openclaw plugins search as the ClawHub plugin lookup command
+          - name: Search result metadata
+            description: package name, family, channel, version, summary, and
+          - name: Distinction between plugin search
+            description: Distinction between plugin search and skill search
+          - name: Catalog lookup failure
+            description: Catalog lookup failure and empty-result behavior
+          - name: Skill catalog search
+            description: Search, list, inspect, and install ClawHub-tracked skills from the CLI.
+        docs:
+          - docs/tools/plugin.md
+          - docs/cli/plugins.md
+          - docs/cli/skills.md
+          - docs/tools/skills.md
+          - docs/plugins/community.md
+        search_anchors:
+          - clawhub discovery, catalog metadata, and package lookup
+          - openclaw skills
+          - ClawHub install and sync
+        category_note: clawhub-discovery-catalog-metadata-and-package-lookup.md
+        human_lts_override: false
+      - name: Compatibility and Trust
+        features:
+          - name: openclaw.compat.pluginApi
+            description: openclaw.compat.pluginApi, build metadata, and host/gateway minimums
+          - name: ClawHub package compatibility validation
+            description: Evidence scope for ClawHub package compatibility validation.
+          - name: npm compatibility fallback to the newest
+            description: npm compatibility fallback to the newest compatible stable version
+          - name: Official external plugin catalog behavior
+            description: Official external plugin catalog behavior and bundled-to-external migration
+          - name: Compatibility docs
+            description: Compatibility docs and deprecation registry
+          - name: Operator trust model for installing
+            description: Operator trust model for installing and enabling external code
+          - name: ClawHub archive
+            description: ClawHub archive and ClawPack digest verification
+          - name: npm integrity drift
+            description: npm integrity drift and managed install checks
+          - name: Built-in dangerous-code scanner
+            description: Built-in dangerous-code scanner and break-glass override semantics
+          - name: ClawHub publishing review/hidden-release behavior as upstream
+            description: ClawHub publishing review/hidden-release behavior as upstream trust signal
+          - name: Skill archive safety
+            description: Uploaded skill archives are gated and reuse extraction protections.
+          - name: Skill audit signals
+            description: ClawHub audit status, risk, findings, and trust metadata apply to skill packages.
+        docs:
+          - docs/tools/plugin.md
+          - docs/cli/plugins.md
+          - docs/plugins/compatibility.md
+          - docs/plugins/plugin-inventory.md
+          - docs/clawhub/publishing.md
+          - docs/clawhub/security-audits.md
+          - docs/tools/skills.md
+          - docs/tools/skills-config.md
+        search_anchors:
+          - clawhub compatibility gates and official external catalog
+          - compatibility gates and official external catalog
+          - clawhub external plugin trust, integrity, and install approvals
+          - external plugin trust, integrity, and install approvals
+          - Treat third-party skills as untrusted code
+          - skills.install.allowUploadedArchives
+          - ClawHub security audits
+          - Dynamic skills
+        category_note: compatibility-gates-and-official-external-catalog.md
+        human_lts_override: false
+      - name: Plugin Lifecycle and Health
+        features:
+          - name: Source prefixes
+            description: Source prefixes and shorthand resolution for clawhub:, npm:,
+          - name: Bare package behavior during the launch
+            description: Bare package behavior during the launch cutover
+          - name: Explicit pinned versions
+            description: Explicit pinned versions, prerelease tags, and stable fallback behavior
+          - name: Managed install records that preserve source
+            description: Managed install records that preserve source metadata for update/uninstall
+          - name: Codex
+            description: Codex, Claude, and Cursor-compatible bundle detection
+          - name: Local
+            description: Local, archive, and marketplace install paths
+          - name: Marketplace list
+            description: Marketplace list, shortcut, and install flows
+          - name: Supported mapped features
+            description: Supported mapped features and detected-but-not-executed capabilities
+          - name: Remote marketplace path safety
+            description: Remote marketplace path safety and archive download guards
+          - name: Update by plugin id
+            description: Update by plugin id, npm spec, ClawHub spec, beta channel, and marketplace
+          - name: Reinstall vs update semantics
+            description: Evidence scope for Reinstall vs update semantics.
+          - name: Downgrade
+            description: Downgrade and pinned selectors
+          - name: Uninstall config/index/policy/file cleanup
+            description: Evidence scope for Uninstall config/index/policy/file cleanup.
+          - name: Gateway restart/reload requirements after
+            description: Gateway restart/reload requirements after install/update/uninstall
+          - name: Per-plugin managed npm project
+            description: Per-plugin managed npm project roots
+          - name: npm-pack local release-candidate installs
+            description: npm-pack local release-candidate installs through npm semantics
+          - name: Dependency ownership between plugin packages
+            description: Dependency ownership between plugin packages and OpenClaw
+          - name: Peer dependency relinking
+            description: Peer dependency relinking for openclaw/plugin-sdk/*
+          - name: Legacy dependency root cleanup
+            description: Legacy dependency root cleanup and doctor repair
+          - name: plugins list
+            description: plugins list, plugins inspect, runtime inspect, plugins doctor, and
+          - name: Local plugin index
+            description: Local plugin index and persisted cold registry state
+          - name: Troubleshooting stale config
+            description: Troubleshooting stale config, blocked paths, dependencies, missing plugins,
+          - name: Runtime verification after Gateway
+            description: Runtime verification after Gateway restart
+          - name: ClawHub skill installs
+            description: Install and update ClawHub-tracked workspace or global skills.
+          - name: Skill upload install path
+            description: Trusted private archive upload and install through skills upload APIs.
+          - name: Skill dependency installers
+            description: Declared Brew, Node, Go, uv, or download installers for skill packages.
+        docs:
+          - docs/tools/plugin.md
+          - docs/cli/plugins.md
+          - docs/cli/skills.md
+          - docs/tools/skills.md
+          - docs/gateway/protocol.md
+          - docs/plugins/bundles.md
+          - docs/plugins/dependency-resolution.md
+        search_anchors:
+          - clawhub plugin source selection and install spec resolution
+          - plugin source selection and install spec resolution
+          - clawhub marketplace and compatible bundle import support
+          - marketplace and compatible bundle import support
+          - clawhub update, rollback, uninstall, and gateway reload lifecycle
+          - update, rollback, uninstall, and gateway reload lifecycle
+          - clawhub dependency resolution, managed install roots, and package metadata
+          - dependency resolution, managed install roots, and package metadata
+          - clawhub operator inventory, inspect, doctor, and troubleshooting
+          - operator inventory, inspect, doctor, and troubleshooting
+          - skills.upload.begin
+          - skills.install
+          - skills.update
+          - Skill content
+        category_note: plugin-lifecycle-and-health.md
+        human_lts_override: false
+    last_score_run:
+      status: complete
+      completed_at: '2026-05-30'
+      by: codex
+      source_ref: null
+      process_version: 3
+  - id: openclaw-app-sdk
+    name: OpenClaw App SDK
+    family: core
+    level: alpha
+    level_code: M2
+    rationale: OpenClaw App SDK is a distinct external app contract separate from Gateway runtime and Plugin SDK. Current scoring shows a real `@openclaw/sdk` path with gaps around public packaging, auto-discovery, approvals, helpers, and compatibility.
+    completeness_instructions: references/completeness/openclaw-app-sdk.md
+    categories:
+      - name: Client API
+        features:
+          - name: SDK entrypoints
+            description: Public package imports and helper objects for external apps.
+          - name: Namespace layout
+            description: High-level and low-level namespaces such as agents and sessions.
+          - name: Package split
+            description: Core SDK, React helpers, and testing package boundaries.
+          - name: App/plugin boundary
+            description: Clear distinction between external app integrations and in-process plugin authoring.
+        docs:
+          - docs/concepts/openclaw-sdk.md
+          - docs/reference/openclaw-sdk-api-design.md
+        search_anchors:
+          - OpenClaw App SDK overview
+          - What ships today
+          - Namespace design
+          - Package structure
+          - App SDK vs Plugin SDK
+        category_note: client-api.md
+        human_lts_override: false
+      - name: Gateway Access
+        features:
+          - name: Gateway connect
+            description: SDK construction for explicit Gateway connections.
+          - name: URL and token config
+            description: URL, token, and auth inputs for external clients.
+          - name: Auto gateway
+            description: Automatic Gateway discovery behavior for supported environments.
+          - name: Custom transport
+            description: Transport injection for non-default client environments.
+          - name: Scopes and redaction
+            description: Token scopes, secret-forwarding defaults, and redaction boundaries.
+        docs:
+          - docs/concepts/openclaw-sdk.md
+          - docs/reference/openclaw-sdk-api-design.md
+          - docs/gateway/protocol.md
+          - docs/gateway/security/index.md
+        search_anchors:
+          - Connect to a Gateway
+          - explicit URL/token handling
+          - custom transport injection
+          - gateway auto
+          - Security model
+          - token scopes
+        category_note: gateway-access.md
+        human_lts_override: false
+      - name: Agent Conversations
+        features:
+          - name: Agent handles
+            description: SDK-side agent object creation and lookup.
+          - name: Agent runs
+            description: Agent execution path with streamed run events.
+          - name: Run results
+            description: Run result envelope, wait semantics, timeout handling, and result normalization.
+          - name: Session creation
+            description: Reusable session handle creation.
+          - name: Session send
+            description: Session transcript interaction from external apps.
+          - name: Session controls
+            description: Patch, abort, and compact operations.
+        docs:
+          - docs/concepts/openclaw-sdk.md
+          - docs/reference/openclaw-sdk-api-design.md
+          - docs/gateway/protocol.md
+        search_anchors:
+          - Run an agent
+          - Agent.run
+          - Run result contract
+          - RunResult
+          - Create and reuse sessions
+          - sessions.create
+          - Session.send
+        category_note: agent-conversations.md
+        human_lts_override: false
+      - name: Events and Approvals
+        features:
+          - name: Event stream
+            description: SDK stream subscription for app-wide and per-run events.
+          - name: Event envelope
+            description: Stable event envelope for external clients.
+          - name: Replay cursors
+            description: Replayable event families with stable cursors.
+          - name: Approval callbacks
+            description: First-class approval handling for external apps.
+          - name: Questions
+            description: Question handling alongside approval flows.
+        docs:
+          - docs/concepts/openclaw-sdk.md
+          - docs/reference/openclaw-sdk-api-design.md
+          - docs/gateway/protocol.md
+        search_anchors:
+          - Stream events
+          - OpenClawEvent
+          - Event contract
+          - replayable event families
+          - stable cursors
+          - Approvals and questions
+        category_note: events-and-approvals.md
+        human_lts_override: false
+      - name: Resource Helpers
+        features:
+          - name: Models
+            description: Typed model discovery helpers.
+          - name: ToolSpace
+            description: Tool discovery and invocation abstraction for external apps.
+          - name: Artifacts
+            description: Artifact summaries, retention metadata, and download behavior.
+          - name: Tasks
+            description: SDK helpers around Gateway task APIs.
+          - name: Environments
+            description: Managed environment provider lifecycle and metadata.
+        docs:
+          - docs/concepts/openclaw-sdk.md
+          - docs/reference/openclaw-sdk-api-design.md
+        search_anchors:
+          - Models, tools, artifacts, and approvals
+          - ToolSpace model
+          - Artifact model
+          - tasks and environments
+          - Managed environment provider
+        category_note: resource-helpers.md
+        human_lts_override: false
+      - name: Compatibility
+        features:
+          - name: Generated client
+            description: Client generation from Gateway schemas.
+          - name: Ergonomic wrappers
+            description: Handwritten wrappers layered on generated transport contracts.
+          - name: Unsupported calls
+            description: Explicit errors for unsupported environment mutations and future per-run overrides.
+          - name: Schema alignment
+            description: SDK behavior stays aligned with Gateway schemas.
+          - name: Public package contract
+            description: Package publication and reusable-client expectations tracked explicitly.
+        docs:
+          - docs/reference/openclaw-sdk-api-design.md
+          - docs/concepts/typebox.md
+          - docs/gateway/protocol.md
+        search_anchors:
+          - Generated client strategy
+          - Gateway schemas
+          - handwritten ergonomic wrappers
+          - Explicitly unsupported today
+          - unsupported environment mutations
+          - future per-run overrides
+        category_note: compatibility.md
+        human_lts_override: false
+    last_score_run:
+      status: complete
+      completed_at: '2026-06-01'
+      by: codex
+      source_ref: openclaw@29dd7847fd
+      process_version: 3
+  - id: macos-gateway-host
+    name: macOS Gateway host
+    family: platform-app
+    level: stable
+    level_code: M4
+    rationale: LaunchAgent service path, local/remote Gateway modes, CLI install, and app integration are documented.
+    completeness_instructions: references/completeness/macos-gateway-host.md
+    categories:
+      - name: CLI Setup
+        features:
+          - name: Hosted installer
+            description: Hosted installer and local-prefix install paths on macOS
+          - name: Node 24 recommendation
+            description: Node 24 recommendation and Node 22.19+ compatibility floor
+          - name: App-triggered CLI install
+            description: App-triggered CLI install and runtime discovery
+          - name: Shell PATH and version-manager drift
+            description: Shell PATH, package-manager, and version-manager drift that affect the host Gateway.
+        docs:
+          - docs/platforms/macos.md
+          - docs/platforms/mac/bundled-gateway.md
+          - docs/install/installer.md
+          - docs/install/node.md
+        search_anchors:
+          - macos gateway host macos cli install and runtime prerequisites
+          - macos cli install and runtime prerequisites
+        category_note: cli-install-runtime-prerequisites.md
+        human_lts_override: false
+      - name: Local Gateway Integration
+        features:
+          - name: App local/remote connection mode
+            description: App local/remote connection mode coordination
+          - name: App-managed Gateway LaunchAgent install/restart/uninstall
+            description: App-managed Gateway LaunchAgent install/restart/uninstall through the CLI
+          - name: CLI install detection
+            description: CLI install detection and app install prompt
+          - name: Attach-to-existing local Gateway compatibility
+            description: Attach-to-existing local Gateway compatibility checks
+          - name: Gateway endpoint
+            description: Gateway endpoint, credential, and control-channel resolution
+          - name: gateway.mode=local configuration
+            description: gateway.mode=local configuration and defaulting during service install
+          - name: Loopback bind
+            description: Loopback bind, explicit host/bind overrides, auth requirements, and port precedence
+          - name: Local app endpoint resolution
+            description: Local app endpoint resolution, local control channel, and attach-to-existing Gateway behavior
+          - name: Bonjour discovery
+            description: Bonjour discovery and local status/probe/health surfaces
+        docs:
+          - docs/platforms/macos.md
+          - docs/platforms/mac/bundled-gateway.md
+          - docs/platforms/mac/remote.md
+          - docs/gateway/index.md
+          - docs/cli/gateway.md
+          - docs/gateway/bonjour.md
+        search_anchors:
+          - macos gateway host companion app gateway integration
+          - companion app gateway integration
+          - macos gateway host local gateway mode and host configuration
+          - local gateway mode and host configuration
+        category_note: local-gateway-mode-host-configuration.md
+        human_lts_override: false
+      - name: Remote Gateway Mode
+        features:
+          - name: macOS app "Remote over SSH"
+            description: macOS app "Remote over SSH" and direct remote Gateway modes
+          - name: SSH tunnel setup
+            description: SSH tunnel setup, stable local forward ownership, and tunnel restart/backoff
+          - name: Tailscale MagicDNS
+            description: Tailscale MagicDNS, Serve, and Funnel guidance for remote access
+          - name: Remote endpoint token/password/TLS fingerprint
+            description: Remote endpoint token/password/TLS fingerprint resolution
+          - name: Local node host startup
+            description: Local node host startup and local Gateway suppression while the app is remote
+        docs:
+          - docs/platforms/mac/remote.md
+          - docs/gateway/remote.md
+          - docs/gateway/tailscale.md
+        search_anchors:
+          - macos gateway host remote gateway mode and transport
+          - remote gateway mode and transport
+        category_note: remote-gateway-mode-transport.md
+        human_lts_override: false
+      - name: Gateway Service Lifecycle
+        features:
+          - name: Per-user Gateway LaunchAgent install
+            description: Per-user Gateway LaunchAgent install, stage, uninstall, start, stop, restart, and status
+          - name: launchctl bootstrap
+            description: launchctl bootstrap, bootout, enable, disable, kickstart, runtime parsing, installed-but-unloaded repair, and --disable semantics
+          - name: LaunchAgent labels
+            description: LaunchAgent labels, profile labels, legacy cleanup, service metadata, plist generation, KeepAlive, RunAtLoad, logs, working directory, and temp directory handling
+          - name: Gateway token/env handling
+            description: Gateway token/env handling, owner-only env files/wrappers, managed service env keys, and config audit/status output
+          - name: App-managed LaunchAgent handoff
+            description: macOS app integration that manages the Gateway LaunchAgent in local mode and avoids it in remote or attach-only modes.
+          - name: openclaw update package/git handoff
+            description: openclaw update package/git handoff on macOS
+          - name: Managed service refresh
+            description: Managed service refresh and LaunchAgent rebootstrap after updates
+          - name: Stale updater launchd job detection
+            description: Stale updater launchd job detection and cleanup
+          - name: openclaw uninstall
+            description: openclaw uninstall, service uninstall, state cleanup, and manual launchd removal
+          - name: Stranded service recovery
+            description: Recovery after partially updated or stranded macOS Gateway services.
+        docs:
+          - docs/platforms/macos.md
+          - docs/platforms/mac/bundled-gateway.md
+          - docs/cli/gateway.md
+          - docs/gateway/index.md
+          - docs/cli/update.md
+          - docs/install/updating.md
+          - docs/install/uninstall.md
+          - docs/gateway/troubleshooting.md
+        search_anchors:
+          - macos gateway host launchagent service lifecycle
+          - launchagent service lifecycle
+          - macos gateway host update, uninstall, and recovery
+          - update, uninstall, and recovery
+        category_note: launchagent-service-lifecycle.md
+        human_lts_override: false
+      - name: Diagnostics and Observability
+        features:
+          - name: LaunchAgent log paths
+            description: LaunchAgent log paths and app diagnostic log paths
+          - name: openclaw gateway status --deep
+            description: openclaw gateway status --deep, gateway probe, doctor, health, and logs commands
+          - name: Gateway silently stops responding
+            description: Gateway silently stops responding, ENETDOWN sleep/wake failure, port conflicts, invalid config, and memory pressure runbooks
+          - name: Stale updater jobs
+            description: Stale updater jobs, service config drift, and LaunchAgent environment diagnostics
+        docs:
+          - docs/platforms/mac/bundled-gateway.md
+          - docs/platforms/macos.md
+          - docs/cli/gateway.md
+          - docs/gateway/doctor.md
+          - docs/gateway/troubleshooting.md
+        search_anchors:
+          - macos gateway host diagnostics, logs, and operator observability
+          - diagnostics, logs, and operator observability
+        category_note: diagnostics-logs-operator-observability.md
+        human_lts_override: false
+      - name: Permissions and Native Capabilities
+        features:
+          - name: macOS TCC permission prompts/status
+            description: macOS TCC permission prompts/status for Accessibility, AppleScript, Screen Recording, Microphone, Speech Recognition, Camera, Location, Notifications, and Voice Wake
+          - name: Native node capability exposure
+            description: Native node capability exposure for screen/canvas/browser/system operations
+          - name: system.run policy
+            description: system.run policy and local/remote node execution expectations
+          - name: Permission-driven support
+            description: Permission-driven support and operator diagnostics
+        docs:
+          - docs/platforms/macos.md
+          - docs/platforms/mac/remote.md
+        search_anchors:
+          - macos gateway host macos permissions and native node capabilities
+          - macos permissions and native node capabilities
+        category_note: macos-permissions-native-node-capabilities.md
+        human_lts_override: false
+      - name: Profiles and Isolation
+        features:
+          - name: Profile-specific LaunchAgent labels
+            description: Profile-specific LaunchAgent labels and plist paths
+          - name: Profile-specific state/config/workspace roots
+            description: Profile-specific state, config, and workspace roots for isolated local Gateways.
+          - name: Derived ports
+            description: Derived ports and multi-Gateway conflict avoidance
+          - name: Rescue bot setup
+            description: Rescue bot setup and operator checks
+          - name: Extra Gateway process detection
+            description: Deep status detection for extra Gateway-like services and duplicate local processes.
+        docs:
+          - docs/gateway/multiple-gateways.md
+          - docs/gateway/index.md
+          - docs/cli/gateway.md
+        search_anchors:
+          - macos gateway host profiles and multi-gateway isolation
+          - profiles and multi-gateway isolation
+        category_note: profiles-multi-gateway-isolation.md
+        human_lts_override: false
+    last_score_run:
+      status: complete
+      completed_at: '2026-05-30'
+      by: codex
+      source_ref: null
+      process_version: 3
+  - id: macos-companion-app
+    name: macOS companion app
+    family: platform-app
+    level: beta
+    level_code: M3
+    rationale: Rich menu bar app, permissions, node mode, Canvas, voice wake, WebChat, and remote mode exist. Still fast-moving enough to avoid Stable.
+    completeness_instructions: references/completeness/macos-companion-app.md
+    categories:
+      - name: Canvas
+        features:
+          - name: Canvas panel open/hide/navigate/eval/snapshot
+            description: Canvas panel open/hide/navigate/eval/snapshot behavior, status, and operator-visible verification.
+          - name: Local custom URL scheme
+            description: Local custom URL scheme and session-root file serving
+          - name: A2UI host auto-navigation
+            description: A2UI host auto-navigation, push/reset, and action bridge
+          - name: Canvas enable/disable setting
+            description: Canvas enable/disable setting and node command behavior
+        docs:
+          - docs/platforms/mac/canvas.md
+          - docs/platforms/macos.md
+          - docs/web/webchat.md
+        search_anchors:
+          - macos companion app canvas and a2ui
+          - canvas and a2ui
+        category_note: canvas-a2ui.md
+        human_lts_override: false
+      - name: Local Setup
+        features:
+          - name: Local mode Gateway attach/start/stop
+            description: Local mode Gateway attach/start/stop behavior, status, and operator-visible verification.
+          - name: LaunchAgent install/update/restart/uninstall
+            description: LaunchAgent install/update/restart/uninstall through app-managed CLI calls
+          - name: Existing-listener detection
+            description: Existing-listener detection, port guarding, and launchd log path
+          - name: Native first-run onboarding flow
+            description: Native first-run onboarding flow and completion marker
+          - name: CLI discovery
+            description: CLI discovery and "Install CLI" prompt/install path
+          - name: Local workspace selection
+            description: Local workspace selection and Gateway wizard startup
+          - name: Onboarding WebChat session separation
+            description: Onboarding WebChat session separation behavior, status, and operator-visible verification.
+        docs:
+          - docs/platforms/mac/bundled-gateway.md
+          - docs/platforms/macos.md
+          - docs/platforms/mac/child-process.md
+          - docs/platforms/mac/dev-setup.md
+        search_anchors:
+          - macos companion app local gateway and launchagent
+          - local gateway and launchagent
+          - macos companion app onboarding, cli install, and workspace setup
+          - onboarding, cli install, and workspace setup
+        category_note: onboarding-cli-workspace.md
+        human_lts_override: false
+      - name: Status and Settings
+        features:
+          - name: Menu-bar status
+            description: Menu-bar status, action menu, status icon state, dock menu, dashboard/chat/canvas/talk shortcuts
+          - name: Activity state ingestion
+            description: Activity state ingestion and status row behavior
+          - name: Settings navigation
+            description: Settings navigation and tabs
+          - name: Health polling
+            description: Health polling, channel status, logs, debug actions, config/session/instance visibility
+          - name: Channels settings
+            description: Channels settings and QR/login/probe status surfaced through the app
+        docs:
+          - docs/platforms/mac/menu-bar.md
+          - docs/platforms/mac/icon.md
+          - docs/platforms/macos.md
+          - docs/platforms/mac/health.md
+          - docs/platforms/mac/logging.md
+          - docs/platforms/mac/remote.md
+        search_anchors:
+          - macos companion app menu status and dashboard
+          - menu status and dashboard
+          - macos companion app settings, health, channels, and diagnostics
+          - settings, health, channels, and diagnostics
+        category_note: settings-health-diagnostics.md
+        human_lts_override: false
+      - name: Native Capabilities
+        features:
+          - name: Mac node session connection
+            description: Mac node session connection, capability and command advertisement
+          - name: system.run
+            description: system.run, system.which, system.notify, exec approvals get/set
+          - name: Exec approval policy
+            description: Exec approval policy, app exec host, local socket, and event emission
+          - name: Permission requests
+            description: Permission requests, status polling, settings UI, and node permission advertisement
+          - name: TCC persistence
+            description: TCC persistence, signing requirements, and safe app-owned permission guidance
+        docs:
+          - docs/platforms/macos.md
+          - docs/platforms/mac/xpc.md
+          - docs/platforms/mac/permissions.md
+          - docs/platforms/mac/signing.md
+          - docs/platforms/mac/peekaboo.md
+        search_anchors:
+          - macos companion app node mode, system.run, and exec host
+          - node mode, system.run, and exec host
+          - macos companion app permissions, privacy, and tcc
+          - permissions, privacy, and tcc
+        category_note: node-mode-system-run-exec-host.md
+        human_lts_override: false
+      - name: Remote Connections
+        features:
+          - name: Remote connection mode selection
+            description: Remote connection mode selection and configuration
+          - name: SSH tunnel
+            description: SSH tunnel and direct ws/wss Gateway transport
+          - name: Gateway discovery
+            description: Gateway discovery, TLS pin repair, and remote node-service startup
+        docs:
+          - docs/platforms/mac/remote.md
+          - docs/platforms/macos.md
+          - docs/gateway/remote.md
+        search_anchors:
+          - macos companion app remote mode, discovery, and tunnels
+          - remote mode, discovery, and tunnels
+        category_note: remote-mode-discovery-tunnels.md
+        human_lts_override: false
+      - name: Voice and Talk
+        features:
+          - name: Voice Wake runtime
+            description: Voice Wake runtime, trigger detection, permissions, overlay, chimes, and forwarding
+          - name: Push-to-talk
+            description: Push-to-talk and Talk Mode capture/listen/think/speak lifecycle
+          - name: Talk provider playback plan
+            description: Talk provider playback plan and Gateway talk status
+        docs:
+          - docs/platforms/mac/voicewake.md
+          - docs/platforms/mac/voice-overlay.md
+          - docs/nodes/talk.md
+          - docs/platforms/macos.md
+        search_anchors:
+          - macos companion app voice wake, push-to-talk, and talk mode
+          - voice wake, push-to-talk, and talk mode
+        category_note: voice-wake-talk.md
+        human_lts_override: false
+      - name: WebChat
+        features:
+          - name: Native SwiftUI WebChat window
+            description: Native SwiftUI WebChat window and menu panel
+          - name: Gateway chat transport
+            description: Gateway chat transport, session/model/thinking controls, event mapping, and health
+          - name: Local and remote data-plane reuse
+            description: Local and remote data-plane reuse across native WebChat sessions.
+        docs:
+          - docs/platforms/mac/webchat.md
+          - docs/platforms/macos.md
+          - docs/web/webchat.md
+        search_anchors:
+          - macos companion app webchat and session ui
+          - webchat and session ui
+        category_note: webchat-sessions.md
+        human_lts_override: false
+      - name: Remote WebChat
+        features:
+          - name: macOS WebChat transport
+            description: Covers macOS WebChat transport across native macOS WebChat, Gateway connection reuse, native chat transport mapping, window/panel presentation, and related remote webchat client bridges behavior.
+          - name: SSH tunnel data plane
+            description: Covers SSH tunnel data plane across native macOS WebChat, Gateway connection reuse, native chat transport mapping, window/panel presentation, and related remote webchat client bridges behavior.
+          - name: Direct ws/wss remote mode
+            description: Covers Direct ws/wss remote mode across native macOS WebChat, Gateway connection reuse, native chat transport mapping, window/panel presentation, and related remote webchat client bridges behavior.
+          - name: Session continuity
+            description: Covers Session continuity across native macOS WebChat, Gateway connection reuse, native chat transport mapping, window/panel presentation, and related remote webchat client bridges behavior.
+          - name: Remote troubleshooting
+            description: Covers Remote troubleshooting across native macOS WebChat, Gateway connection reuse, native chat transport mapping, window/panel presentation, and related remote webchat client bridges behavior.
+        docs:
+          - docs/platforms/mac/webchat.md
+          - docs/gateway/remote.md
+          - docs/platforms/mac/remote.md
+        search_anchors:
+          - macOS WebChat transport
+          - SSH tunnel data plane
+          - Direct ws/wss remote mode
+          - Session continuity
+          - Remote troubleshooting
+          - What it can do (today)
+          - Chat behavior
+        category_note: native-webchat-and-remote-client-bridges.md
+        human_lts_override: false
+    last_score_run:
+      status: complete
+      completed_at: '2026-05-30'
+      by: codex
+      source_ref: null
+      process_version: 3
+  - id: linux-gateway-host
+    name: Linux Gateway host
+    family: platform-app
+    level: stable
+    level_code: M4
+    rationale: Node runtime is recommended, systemd user service is documented, and VPS/container guidance is broad.
+    completeness_instructions: references/completeness/linux-gateway-host.md
+    categories:
+      - name: Host Setup and Updates
+        features:
+          - name: Linux CLI install
+            description: Linux CLI installation paths and operator verification after install.
+          - name: Node runtime prerequisites
+            description: Node runtime version requirements and host prerequisite checks for Linux Gateway operation.
+          - name: Package-manager policy
+            description: Supported package-manager and platform policy for Linux install and update paths.
+          - name: Update path
+            description: Linux update workflow, package or git handoff, and post-update verification.
+        docs:
+          - docs/install/index.md
+          - docs/install/updating.md
+          - docs/platforms/linux.md
+          - docs/platforms/index.md
+        search_anchors:
+          - Linux install
+          - Node runtime prerequisites
+          - package-manager policy
+          - updating OpenClaw
+        category_note: linux-cli-install-and-update-path.md
+        human_lts_override: true
+      - name: Gateway Runtime and Service Control
+        features:
+          - name: Foreground Gateway Runtime
+            description: Covers Foreground Gateway Runtime user-facing controls, state display, navigation, and rendering behavior for Foreground Gateway Runtime and Process Control.
+          - name: Process Control
+            description: Covers Process Control user-facing controls, state display, navigation, and rendering behavior for Foreground Gateway Runtime and Process Control.
+          - name: Systemd User Service Lifecycle setup
+            description: Defines Systemd User Service Lifecycle setup setup, credential, configuration, and operator verification behavior for Systemd User Service Lifecycle.
+          - name: Systemd User Service Lifecycle operation
+            description: Defines Systemd User Service Lifecycle operation setup, credential, configuration, and operator verification behavior for Systemd User Service Lifecycle.
+          - name: Systemd User Service Lifecycle status
+            description: Defines Systemd User Service Lifecycle status setup, credential, configuration, and operator verification behavior for Systemd User Service Lifecycle.
+          - name: Systemd User Service Lifecycle recovery
+            description: Defines Systemd User Service Lifecycle recovery setup, credential, configuration, and operator verification behavior for Systemd User Service Lifecycle.
+        docs:
+          - docs/gateway/index.md
+          - docs/cli/gateway.md
+          - docs/platforms/linux.md
+          - docs/vps.md
+        search_anchors:
+          - Foreground Gateway Runtime
+          - Process Control
+          - linux gateway host foreground gateway runtime and process control
+          - foreground gateway runtime and process control
+          - Systemd User Service Lifecycle setup
+          - Systemd User Service Lifecycle operation
+          - Systemd User Service Lifecycle status
+          - Systemd User Service Lifecycle recovery
+          - linux gateway host systemd user service lifecycle
+          - systemd user service lifecycle
+        category_note: foreground-gateway-runtime-and-process-control.md
+        human_lts_override: true
+      - name: Remote Access and Security
+        features:
+          - name: Remote Network Exposure
+            description: Defines Remote Network Exposure authorization, trust, safety boundaries, and operator controls for Remote Network Exposure, Tls, and Tailscale.
+          - name: TLS
+            description: Defines TLS authorization, trust, safety boundaries, and operator controls for Remote Network Exposure, Tls, and Tailscale.
+          - name: Tailscale
+            description: Defines Tailscale authorization, trust, safety boundaries, and operator controls for Remote Network Exposure, Tls, and Tailscale.
+          - name: Gateway exposure safeguards
+            description: Defines exposure checks, unsafe-network warnings, and operator controls for Linux Gateway security boundaries.
+          - name: Gateway authentication modes
+            description: Defines token/password auth, shared-secret resolution, and operator verification for Linux Gateway authentication.
+          - name: Secret Handling
+            description: Defines Secret Handling setup, credential, configuration, and operator verification behavior for Security, Auth, and Secret Handling.
+        docs:
+          - docs/gateway/remote.md
+          - docs/gateway/tailscale.md
+          - docs/gateway/security/exposure-runbook.md
+          - docs/gateway/authentication.md
+          - docs/gateway/secrets.md
+        search_anchors:
+          - Remote Network Exposure
+          - TLS
+          - Tailscale
+          - linux gateway host remote network exposure, tls, and tailscale
+          - remote network exposure, tls, and tailscale
+          - exposure-runbook
+          - Gateway authentication
+          - Secret Handling
+          - linux gateway host security, auth, and secret handling
+          - security, auth, and secret handling
+        category_note: remote-network-exposure-tls-and-tailscale.md
+        human_lts_override: true
+      - name: Diagnostics and Repair
+        features:
+          - name: Gateway diagnostic reports
+            description: Covers Gateway status, diagnostic output, failure handling, and operator repair for diagnostics, logs, doctor, and repair workflows.
+          - name: Gateway log tailing
+            description: Covers log viewing, log tailing, local fallback behavior, and operator-visible Gateway log status.
+          - name: Doctor checks
+            description: Covers `openclaw doctor` checks, Gateway health probes, and operator diagnostics for Linux Gateway deployments.
+          - name: Operator repair guidance
+            description: Covers failure handling, repair guidance, and recovery steps for Linux Gateway diagnostics and doctor findings.
+        docs:
+          - docs/cli/status.md
+          - docs/cli/logs.md
+          - docs/cli/doctor.md
+          - docs/gateway/diagnostics.md
+          - docs/gateway/index.md
+        search_anchors:
+          - openclaw status
+          - gateway diagnostics
+          - openclaw logs
+          - openclaw doctor
+          - repair guidance
+          - linux gateway host diagnostics, logs, doctor, and repair
+          - diagnostics, logs, doctor, and repair
+        category_note: diagnostics-logs-doctor-and-repair.md
+        human_lts_override: true
+      - name: Deployment Targets
+        features:
+          - name: VPS
+            description: Defines VPS setup, credential, configuration, and operator verification behavior for Vps, Container, and Cloud Deployment Guidance.
+          - name: Container
+            description: Defines Container setup, credential, configuration, and operator verification behavior for Vps, Container, and Cloud Deployment Guidance.
+          - name: Cloud Deployment Guidance
+            description: Defines Cloud Deployment Guidance setup, credential, configuration, and operator verification behavior for Vps, Container, and Cloud Deployment Guidance.
+        docs:
+          - docs/vps.md
+          - docs/install/docker.md
+          - docs/install/hetzner.md
+          - docs/install/digitalocean.md
+          - docs/install/kubernetes.md
+          - docs/install/podman.md
+        search_anchors:
+          - Vps
+          - Container
+          - Cloud Deployment Guidance
+          - linux gateway host vps, container, and cloud deployment guidance
+          - vps, container, and cloud deployment guidance
+        category_note: vps-container-and-cloud-deployment-guidance.md
+        human_lts_override: false
+    last_score_run:
+      status: complete
+      completed_at: '2026-05-30'
+      by: codex
+      source_ref: null
+      process_version: 3
+  - id: linux-companion-app
+    name: Linux companion app
+    family: platform-app
+    level: planned
+    level_code: M0
+    rationale: Docs say native Linux companion apps are planned; Gateway is the supported Linux path today.
+    completeness_instructions: references/completeness/linux-companion-app.md
+    categories:
+      - name: App Distribution
+        features:
+          - name: Native app package
+            description: Native Linux companion-app package availability and installation path.
+          - name: Distro package targets
+            description: Distro package targets, desktop files, icons, autostart, and update metadata
+          - name: Official release metadata
+            description: Official release metadata for downstream consoles
+        docs:
+          - docs/platforms/linux.md
+          - docs/platforms/index.md
+          - docs/install/index.md
+        search_anchors:
+          - Native Linux companion apps are planned
+          - Linux app
+          - Gateway service install
+        category_note: packaging-install-update-desktop-integration.md
+        human_lts_override: false
+      - name: Gateway Connectivity
+        features:
+          - name: Local Gateway attach and status
+            description: Local Gateway attach, start, and status behavior from a Linux app.
+          - name: Gateway pairing and auth
+            description: Gateway auth and device pairing from a native Linux client.
+          - name: Remote mode
+            description: Remote mode through direct URL, SSH tunnel, or Tailscale
+          - name: Local and remote resource boundaries
+            description: Local and remote resource boundaries for a Linux companion client.
+        docs:
+          - docs/platforms/linux.md
+          - docs/gateway/index.md
+          - docs/gateway/pairing.md
+          - docs/gateway/remote.md
+        search_anchors:
+          - Linux app
+          - Gateway service install
+          - remote Gateway
+          - pairing
+        category_note: gateway-connection-pairing-local-remote.md
+        human_lts_override: false
+      - name: Chat and Sessions
+        features:
+          - name: Native Linux chat window
+            description: Native Linux chat window behavior, status, and operator-visible verification.
+          - name: Transcript
+            description: Transcript, composer, session picker, model picker, send/abort/follow-up controls
+          - name: Gateway chat transport
+            description: Gateway WebSocket chat transport from a Linux desktop client.
+        docs:
+          - docs/platforms/linux.md
+          - docs/gateway/protocol.md
+          - docs/web/webchat.md
+        search_anchors:
+          - WebChat
+          - Gateway WebSocket
+          - chat history
+        category_note: native-chat-session-controls.md
+        human_lts_override: false
+      - name: Desktop Capabilities
+        features:
+          - name: Linux desktop permissions
+            description: Linux desktop permissions for notifications, microphone, screen, camera, accessibility, portals, and desktop-environment APIs
+          - name: Secret storage
+            description: Secret storage for Gateway token, device identity, approval socket token, and app settings
+          - name: Sandbox/package posture
+            description: Sandbox/package posture for Flatpak/Snap/AppImage or system packages
+          - name: Linux native node identity
+            description: Linux native node identity and capability advertisement
+          - name: Host command execution
+            description: Host command execution through system.run and related desktop tools.
+          - name: Desktop tools
+            description: Desktop tools such as screen, camera, notifications, Canvas, and local command execution
+          - name: Linux native Talk
+            description: Linux native Talk, push-to-talk, voice wake, and transcription
+          - name: Microphone capture
+            description: Microphone capture, screen/camera capture, desktop context sensing, and local media attachment flows
+          - name: Native media permissions
+            description: Native media permissions and foreground/background behavior
+        docs:
+          - docs/platforms/linux.md
+          - docs/tools/exec-approvals.md
+          - docs/gateway/secrets.md
+          - docs/nodes/index.md
+          - docs/tools/exec.md
+          - docs/nodes/talk.md
+          - docs/nodes/camera.md
+        search_anchors:
+          - Native Linux companion apps are planned
+          - Linux app
+          - Exec approvals
+          - headless node host
+          - system.run
+          - Talk mode
+          - microphone capture
+          - camera
+        category_note: desktop-permissions-secrets-sandbox.md
+        human_lts_override: false
+      - name: Status and Diagnostics
+        features:
+          - name: Native Linux app readiness
+            description: Native Linux app readiness states
+          - name: Gateway health/status display
+            description: Gateway health/status display behavior, status, and operator-visible verification.
+          - name: Log/transcript opening
+            description: Log/transcript opening and locality-aware resource handling
+          - name: Doctor/repair affordances
+            description: Doctor/repair affordances and systemd lifecycle diagnostics
+          - name: Linux tray/status item
+            description: Linux tray/status item behavior, status, and operator-visible verification.
+          - name: Runtime status row
+            description: Runtime status row and native notifications
+          - name: Desktop-environment integration
+            description: Desktop-environment integration for GNOME/KDE/Wayland/X11 tray behavior
+        docs:
+          - docs/platforms/linux.md
+          - docs/start/openclaw.md
+          - docs/gateway/doctor.md
+        search_anchors:
+          - Gateway service install
+          - openclaw status
+          - Control UI
+          - Linux app
+          - status
+          - desktop notifications
+        category_note: diagnostics-health-operator-repair.md
+        human_lts_override: false
+    last_score_run:
+      status: complete
+      completed_at: '2026-05-30'
+      by: codex
+      source_ref: null
+      process_version: 3
+  - id: windows-via-wsl2
+    name: Windows via WSL2
+    family: platform-app
+    level: beta
+    level_code: M3
+    rationale: Recommended Windows path with systemd/user-service guidance and boot-chain docs. Promote after repeated install/update scorecards.
+    completeness_instructions: references/completeness/windows-via-wsl2.md
+    categories:
+      - name: WSL Setup
+        features:
+          - name: WSL2 + Ubuntu installation
+            description: WSL2 and Ubuntu installation requirements.
+          - name: Node runtime
+            description: Node 24 and Node 22.19+ runtime requirements inside WSL2.
+          - name: Linux install flow inside WSL2
+            description: Linux install and getting-started flow run inside WSL2.
+          - name: WSL2 runtime boundary
+            description: WSL2 runtime boundary and its distinction from native Windows installs.
+          - name: WSL2 network-family requirements
+            description: WSL2-specific network-family requirements that affect Gateway startup.
+          - name: Source install and build inside WSL2
+            description: Source install and build workflow inside the WSL2 distribution.
+        docs:
+          - docs/platforms/windows.md
+          - docs/start/getting-started.md
+        search_anchors:
+          - WSL2 (recommended)
+          - Ubuntu
+          - Node 24
+          - source install
+        category_note: wsl2-install-and-runtime-prerequisites.md
+        human_lts_override: true
+      - name: CLI
+        features:
+          - name: WSL2 CLI entrypoints
+            description: openclaw CLI install, version, onboard, doctor, status, and update commands run inside the WSL2 Linux environment.
+          - name: openclaw onboard
+            description: openclaw onboard and non-interactive onboarding run inside the WSL2 Linux environment.
+          - name: openclaw doctor status and logs
+            description: openclaw doctor, status, and logs provide WSL2-specific repair and diagnostic feedback.
+          - name: openclaw update
+            description: openclaw update, channel switching, dry-run/status diagnostics
+          - name: npm/pnpm/git package-root
+            description: npm/pnpm/git package-root and install-mode switching
+          - name: Managed systemd Gateway restart
+            description: Managed systemd Gateway restart and update handoff
+          - name: Service metadata refresh
+            description: Service metadata refresh after WSL2 Gateway updates.
+          - name: Package-manager caveats
+            description: Package-manager caveats seen from WSL2 source and package installs.
+        docs:
+          - docs/platforms/windows.md
+          - docs/start/getting-started.md
+          - docs/install/updating.md
+          - docs/cli/onboard.md
+          - docs/cli/doctor.md
+          - docs/cli/status.md
+          - docs/cli/logs.md
+        search_anchors:
+          - windows via wsl2 cli
+          - WSL2 CLI entrypoints
+          - openclaw onboard
+          - openclaw doctor
+          - openclaw status
+          - openclaw logs
+          - openclaw update
+          - package manager
+        category_note: wsl2-cli.md
+        human_lts_override: true
+      - name: Gateway Service Lifecycle
+        features:
+          - name: Onboarded systemd install
+            description: openclaw onboard daemon installation inside WSL2.
+          - name: Gateway service install
+            description: openclaw gateway install behavior under WSL2 systemd.
+          - name: systemd user unit rendering
+            description: systemd user unit rendering and lifecycle metadata.
+          - name: WSL-aware systemd unavailable hints
+            description: Operator hints when systemd is unavailable in the WSL distribution.
+          - name: Doctor service repair
+            description: Doctor repair behavior for WSL2 Gateway services.
+          - name: WSL user-service linger
+            description: WSL user-service linger behavior, status, and operator-visible verification.
+          - name: Systemd availability after Windows boot
+            description: Systemd availability after Windows boot and WSL distribution startup.
+          - name: Windows startup task for WSL
+            description: Windows startup task behavior for launching WSL before login.
+          - name: Verification before Windows sign-in
+            description: Verification before Windows sign-in behavior, status, and operator-visible verification.
+          - name: Clear expectations around PC power
+            description: Clear expectations around PC power, sleep, Windows boot, WSL boot, and Gateway uptime
+        docs:
+          - docs/platforms/windows.md
+          - docs/gateway/index.md
+          - docs/gateway/doctor.md
+        search_anchors:
+          - Gateway service install (CLI)
+          - systemd user service
+          - WSL-aware systemd
+          - Gateway auto-start before Windows login
+          - WSL user-service linger
+          - Windows startup scheduled task
+        category_note: systemd-gateway-service-lifecycle.md
+        human_lts_override: true
+      - name: Gateway Access and Exposure
+        features:
+          - name: Gateway token/password auth
+            description: Gateway token and password auth for clients running through WSL2.
+          - name: Provider credentials
+            description: Provider credential storage and lookup from inside the WSL2 environment.
+          - name: Gateway auth SecretRefs
+            description: Gateway auth SecretRef handling for WSL2-hosted Gateway processes.
+          - name: Remote URL credential precedence
+            description: Remote URL credential precedence when WSL2 clients connect to local or remote Gateways.
+          - name: WSL virtual network
+            description: WSL virtual network behavior and host/guest addressing.
+          - name: Windows portproxy setup
+            description: Windows netsh interface portproxy setup for exposing WSL services.
+          - name: Windows Firewall rules
+            description: Windows Firewall rules for WSL Gateway access.
+          - name: Reachable Gateway URLs
+            description: Gateway URLs that must be reachable from Windows, WSL2, and LAN clients.
+          - name: Loopback and LAN exposure
+            description: Loopback versus LAN listen behavior for WSL2 Gateway exposure.
+          - name: WSL2 IPv4 networking
+            description: WSL2-specific IPv4 network-family behavior.
+          - name: Tailscale remote access
+            description: Tailscale and remote access behavior where it intersects WSL2 networking.
+        docs:
+          - docs/gateway/authentication.md
+          - docs/gateway/secrets.md
+          - docs/gateway/remote.md
+          - docs/gateway/security/exposure-runbook.md
+          - docs/platforms/windows.md
+        search_anchors:
+          - Gateway authentication
+          - SecretRef
+          - Remote URL credential precedence
+          - 'Advanced: expose WSL services over LAN (portproxy)'
+          - portproxy
+          - WSL2 IPv4
+        category_note: auth-secrets-and-exposure-posture.md
+        human_lts_override: true
+      - name: Diagnostics and Repair
+        features:
+          - name: openclaw doctor
+            description: openclaw doctor and repair/migration for WSL2 Gateway
+          - name: openclaw status
+            description: openclaw status, status --all, and Gateway service/runtime summary
+          - name: openclaw logs
+            description: openclaw logs and Linux systemd journal fallback
+          - name: SecretRef
+            description: SecretRef and auth diagnostics visible from status/doctor
+          - name: WSL/systemd unavailable hints
+            description: WSL/systemd unavailable hints and linger checks
+          - name: Operator repair guidance after WSL2 service
+            description: Operator repair guidance after WSL2 service, config, or Gateway failures
+        docs:
+          - docs/platforms/windows.md
+          - docs/cli/status.md
+          - docs/cli/logs.md
+          - docs/cli/doctor.md
+          - docs/gateway/doctor.md
+        search_anchors:
+          - windows via wsl2 diagnostics, doctor, logs, and repair
+          - diagnostics, doctor, logs, and repair
+        category_note: diagnostics-doctor-logs-and-repair.md
+        human_lts_override: true
+      - name: Browser and Control UI
+        features:
+          - name: WSL2 Gateway with Windows browser
+            description: WSL2 Gateway with Windows browser and Windows Chrome
+          - name: Windows Control UI URL
+            description: Windows Control UI URL and origin guidance
+          - name: Raw remote CDP to Windows Chrome
+            description: Raw remote CDP access from WSL2 to a Windows Chrome instance.
+          - name: Host-local Chrome MCP
+            description: Host-local Chrome MCP and existing-session boundary
+          - name: Browser profile cdpUrl
+            description: Browser profile cdpUrl and attachOnly config
+          - name: Layered diagnostics
+            description: Layered diagnostics for auth/origin/CDP failures
+        docs:
+          - docs/tools/browser-wsl2-windows-remote-cdp-troubleshooting.md
+          - docs/tools/browser.md
+          - docs/web/control-ui.md
+        search_anchors:
+          - Raw remote CDP from WSL2 to Windows
+          - Windows Control UI URL
+          - Host-local Chrome MCP
+        category_note: split-host-browser-and-control-ui-interop.md
+        human_lts_override: false
+    last_score_run:
+      status: complete
+      completed_at: '2026-05-30'
+      by: codex
+      source_ref: null
+      process_version: 3
+  - id: native-windows-cli-and-gateway
+    name: Native Windows
+    family: platform-app
+    level: alpha
+    level_code: M2
+    rationale: Core CLI/Gateway flows work, but docs still recommend WSL2 for the full experience and list native caveats.
+    completeness_instructions: references/completeness/native-windows-cli-and-gateway.md
+    categories:
+      - name: CLI
+        features:
+          - name: PowerShell installer
+            description: Native Windows install.ps1 hosted installer path and flags.
+          - name: Node and package-manager bootstrap
+            description: Node, Git, pnpm, npm, and PATH bootstrap for native Windows.
+          - name: npm global install
+            description: npm global install, git checkout install, and generated openclaw.cmd.
+          - name: Packaged CLI launcher
+            description: Packaged openclaw CLI launcher, version, and doctor entrypoints.
+          - name: Windows command shims
+            description: Windows .cmd launcher, PATHEXT, and package-manager shim compatibility.
+          - name: openclaw onboard
+            description: openclaw onboard and openclaw onboard --non-interactive on native Windows
+          - name: Local Gateway config
+            description: Local Gateway config, auth choice, gateway token/password SecretRef handling, and local endpoint defaults.
+          - name: Daemon install flags
+            description: Daemon install flags for native Windows onboarding.
+          - name: Native-vs-WSL setup boundary
+            description: Setup boundary between native Windows Gateway and the recommended WSL2 path.
+        docs:
+          - docs/install/index.md
+          - docs/install/installer.md
+          - docs/platforms/windows.md
+          - docs/start/getting-started.md
+          - docs/cli/onboard.md
+        search_anchors:
+          - native windows cli setup
+          - install.ps1
+          - PowerShell
+          - openclaw.cmd
+          - PATHEXT
+          - openclaw onboard
+          - Local Gateway config
+          - daemon install
+        category_note: native-powershell-install-and-cli-entrypoints.md
+        human_lts_override: true
+      - name: Gateway Management
+        features:
+          - name: openclaw gateway
+            description: openclaw gateway, openclaw gateway run, openclaw gateway status, and foreground process behavior.
+          - name: Foreground runtime health/readiness
+            description: Foreground runtime health/readiness and local loopback Gateway targets
+          - name: Windows-specific restart/signal
+            description: Windows-specific restart/signal and process-control behavior
+          - name: Unmanaged foreground mode
+            description: Operator expectations when running without a managed Scheduled Task.
+          - name: openclaw gateway install
+            description: openclaw gateway install, status, start, stop, restart, and managed startup behavior.
+          - name: Gateway launcher files
+            description: Generated gateway.cmd and hidden launcher files for managed startup.
+          - name: Scheduled Task runtime status
+            description: Scheduled Task runtime status, task-user selection, listener/PID fallback, and task repair.
+          - name: Startup-folder fallback
+            description: Startup-folder fallback when Task Scheduler is unavailable.
+          - name: openclaw status
+            description: openclaw status, openclaw gateway status, gateway status --deep, and Windows repair guidance.
+          - name: Windows service inspection
+            description: Windows service inspection, Task Scheduler runtime parsing, Startup-folder
+          - name: Post-install diagnostics
+            description: Expected diagnostics, status, and repair behavior after native Windows install.
+        docs:
+          - docs/platforms/windows.md
+          - docs/gateway/index.md
+          - docs/cli/gateway.md
+          - docs/cli/doctor.md
+        search_anchors:
+          - openclaw gateway
+          - Foreground runtime
+          - Windows signal handling
+          - openclaw gateway install
+          - Scheduled Tasks
+          - Startup-folder
+          - openclaw status
+          - openclaw doctor
+          - Gateway diagnostics
+        category_note: native-gateway-foreground-runtime-and-process-control.md
+        human_lts_override: false
+      - name: Networking
+        features:
+          - name: Native Windows host networking
+            description: Native Windows host binding and Gateway exposure behavior.
+          - name: netsh interface portproxy
+            description: netsh interface portproxy, Windows Firewall rules, and WSL IP refresh
+          - name: Gateway status and probe output
+            description: Gateway status and probe output that helps operators verify Windows networking.
+          - name: Loopback, LAN, and WSL boundary
+            description: Boundaries between loopback, LAN, and WSL exposure modes.
+        docs:
+          - docs/platforms/windows.md
+          - docs/gateway/index.md
+          - docs/cli/gateway.md
+        search_anchors:
+          - portproxy
+          - Gateway status
+          - loopback
+          - LAN
+        category_note: windows-host-networking-portproxy-and-remote-access.md
+        human_lts_override: false
+      - name: Updates
+        features:
+          - name: openclaw update on native Windows package
+            description: openclaw update on native Windows package installs
+          - name: Managed Gateway stop/restart
+            description: Managed Gateway stop/restart and service metadata refresh during update
+          - name: Detached update handoff
+            description: Detached update handoff from a running Gateway.
+          - name: Windows package locks
+            description: Windows package locks, EBUSY/EPERM behavior, staged swaps, child-window
+        docs:
+          - docs/install/updating.md
+          - docs/ci.md
+        search_anchors:
+          - openclaw update
+          - package locks
+          - restart handoff
+        category_note: windows-update-restart-handoff-and-package-locks.md
+        human_lts_override: false
+    last_score_run:
+      status: complete
+      completed_at: '2026-05-30'
+      by: codex
+      source_ref: null
+      process_version: 3
+  - id: native-windows-companion-app
+    name: Native Windows companion app
+    family: platform-app
+    level: planned
+    level_code: M0
+    rationale: Planned only.
+    completeness_instructions: references/completeness/native-windows-companion-app.md
+    categories:
+      - name: Installation and Updates
+        features:
+          - name: Official app download
+            description: Official app download or installer path for the native Windows companion app.
+          - name: MSI/MSIX/App Installer/winget-style packaging
+            description: MSI/MSIX/App Installer/winget-style packaging, signing, update, rollback, uninstall, and desktop entries
+          - name: Windows architecture handling for x64
+            description: Windows architecture handling for x64 and ARM64
+          - name: App release channel
+            description: App release channel, architecture handling, and update availability.
+        docs:
+          - docs/platforms/windows.md
+          - docs/install/index.md
+        search_anchors:
+          - Native Windows companion apps are planned
+          - Windows companion app
+          - App Installer
+          - winget
+        category_note: packaging-install-update-desktop-integration.md
+        human_lts_override: false
+      - name: Gateway Connection
+        features:
+          - name: App-managed local Gateway attach/start
+            description: App-managed local Gateway attach/start and status
+          - name: Remote Gateway connection modes
+            description: Remote Gateway connection modes, token/TLS handling, and reconnect
+          - name: Device/node pairing
+            description: Device/node pairing, pending approval UX, and pairing recovery
+        docs:
+          - docs/platforms/windows.md
+          - docs/gateway/index.md
+          - docs/gateway/pairing.md
+          - docs/gateway/remote.md
+        search_anchors:
+          - Windows companion app
+          - local Gateway
+          - remote Gateway
+          - pairing
+        category_note: gateway-connection-pairing-local-remote.md
+        human_lts_override: false
+      - name: Chat Sessions
+        features:
+          - name: Native Windows chat window
+            description: Native Windows chat window, transcript, composer, session picker, model/thinking controls, abort/follow-up actions, reconnect handling, and tool rendering
+          - name: Gateway chat transport
+            description: Gateway chat transport and session control from the native Windows app.
+        docs:
+          - docs/platforms/windows.md
+          - docs/gateway/protocol.md
+        search_anchors:
+          - WebChat
+          - Gateway WebSocket
+          - Windows companion app
+        category_note: native-chat-session-controls.md
+        human_lts_override: false
+      - name: Status and Repair
+        features:
+          - name: App health states
+            description: App health states, Gateway/node readiness, diagnostic panels, log opening, update status, repair actions, and support bundle behavior
+          - name: App-specific repair
+            description: App-specific repair for pairing, permissions, service lifecycle, stale versions, and protocol mismatch
+          - name: Windows system tray app
+            description: Windows system tray app, status icon, status menu, native notifications, and app launch/quit controls
+          - name: Status indicators
+            description: Status indicators for Gateway, node pairing, work activity, and updates
+          - name: App-specific notification permission
+            description: App-specific notification permission and failure handling
+        docs:
+          - docs/platforms/windows.md
+          - docs/gateway/doctor.md
+          - docs/gateway/index.md
+        search_anchors:
+          - Windows companion app
+          - Gateway status
+          - doctor repair
+          - system tray
+          - native notifications
+        category_note: diagnostics-health-operator-repair.md
+        human_lts_override: false
+      - name: Desktop Tools and Permissions
+        features:
+          - name: Windows node identity
+            description: Windows node identity and capability advertisement.
+          - name: Host command execution
+            description: Host command execution through system.run and related desktop tools.
+          - name: Desktop command policy
+            description: Desktop command allow/deny policy for native Windows tools.
+          - name: App approval prompts
+            description: App UI prompts for approval-sensitive desktop commands.
+          - name: Screen and media capture
+            description: Screen snapshot, recording, and native media capture affordances.
+          - name: Canvas host behavior
+            description: Canvas and A2UI host behavior in a native Windows companion app.
+          - name: Windows shell integrations
+            description: Windows shell and PowerToys-style desktop integrations.
+          - name: App secrets
+            description: App secrets, token persistence, secure local IPC, app signing identity, AppContainer or desktop permission posture
+          - name: Windows ACL
+            description: Windows ACL and filesystem hygiene for app-owned state
+          - name: Command approval
+            description: Command approval and dangerous capability gating as surfaced to users
+        docs:
+          - docs/platforms/windows.md
+          - docs/nodes/index.md
+          - docs/tools/exec.md
+          - docs/tools/exec-approvals.md
+          - docs/gateway/security/index.md
+        search_anchors:
+          - node host
+          - system.run
+          - Exec approvals
+          - screen capture
+          - Windows ACL
+          - app secrets
+        category_note: node-host-capabilities-exec-approvals.md
+        human_lts_override: false
+    last_score_run:
+      status: complete
+      completed_at: '2026-05-30'
+      by: codex
+      source_ref: null
+      process_version: 3
+  - id: android-app
+    name: Android app
+    family: platform-app
+    level: alpha
+    level_code: M2
+    rationale: Public Google Play path exists, but app docs still describe the rebuild as extremely alpha and call out release hardening work.
+    completeness_instructions: references/completeness/android-app.md
+    categories:
+      - name: Media Capture
+        features:
+          - name: Camera and media capture
+            description: Camera listing, capture, photo, screen, and media capture behavior.
+        docs:
+          - docs/platforms/android.md
+          - docs/nodes/camera.md
+        search_anchors:
+          - camera.list
+          - camera.capture
+          - screen capture
+        category_note: camera-media-capture.md
+        human_lts_override: false
+      - name: Mobile Chat
+        features:
+          - name: Chat tab
+            description: Chat tab, session list/filtering, composer, image attachments, message parsing/rendering, model/provider status adjacent to chat, and Gateway chat RPC integration
+        docs:
+          - docs/platforms/android.md
+        search_anchors:
+          - Chat tab
+          - chat.history
+          - mobile UI
+        category_note: chat-sessions-ui.md
+        human_lts_override: false
+      - name: Connection Setup
+        features:
+          - name: Gateway discovery
+            description: Gateway discovery, setup-code and manual endpoint parsing, WS/WSS connection setup, TLS trust decisions, device identity, stored device tokens, node/operator auth, and connection error handling
+        docs:
+          - docs/platforms/android.md
+          - docs/gateway/bonjour.md
+          - docs/gateway/pairing.md
+        search_anchors:
+          - Setup Code
+          - Manual
+          - Bonjour
+        category_note: gateway-pairing-security.md
+        human_lts_override: false
+      - name: Distribution
+        features:
+          - name: Public Google Play install path
+            description: Public Google Play install path and source build/run entrypoints
+          - name: Manual install path
+            description: Manual install path and Google Play distribution behavior.
+          - name: Release smoke and startup performance
+            description: Release smoke and startup performance checks for Android app distribution.
+        docs:
+          - docs/platforms/android.md
+        search_anchors:
+          - Google Play
+          - Manual
+          - Startup macrobenchmark
+        category_note: install-release-distribution.md
+        human_lts_override: false
+      - name: Settings
+        features:
+          - name: Settings sheet
+            description: Settings sheet and settings detail screens, permission request UX, notification forwarding controls, Nodes & Devices status, provider/model diagnostics, secure preferences, and copyable Gateway diagnostic report
+        docs:
+          - docs/platforms/android.md
+        search_anchors:
+          - Settings sheet
+          - Notification forwarding
+          - diagnostics
+        category_note: settings-permissions-diagnostics.md
+        human_lts_override: false
+      - name: Voice
+        features:
+          - name: Voice tab
+            description: Voice tab, manual mic capture, Talk Mode listen/think/speak loop, Gateway Talk config, talk.speak, realtime relay mode, voice capture service type, and voice e2e receiver/script
+        docs:
+          - docs/platforms/android.md
+          - docs/nodes/talk.md
+        search_anchors:
+          - Talk Mode
+          - Voice tab
+          - wake
+        category_note: voice-talk-wake.md
+        human_lts_override: false
+      - name: Device Runtime
+        features:
+          - name: Background reconnect and presence
+            description: Foreground-service presence, reconnect, and node presence behavior.
+          - name: Device command availability
+            description: Android device command availability and capability advertisement.
+        docs:
+          - docs/platforms/android.md
+          - docs/nodes/troubleshooting.md
+          - docs/gateway/protocol.md
+        search_anchors:
+          - foreground service
+          - node.presence.alive
+          - background reconnect
+          - Additional Android command families
+          - node capabilities
+          - command handling
+        category_note: node-device-capabilities.md
+        human_lts_override: false
+    last_score_run:
+      status: complete
+      completed_at: '2026-05-30'
+      by: codex
+      source_ref: null
+      process_version: 3
+  - id: ios-app
+    name: iOS app
+    family: platform-app
+    level: experimental
+    level_code: M1
+    rationale: Internal preview / super-alpha. TestFlight and relay-backed push flows exist, but no public distribution yet.
+    completeness_instructions: references/completeness/ios-app.md
+    categories:
+      - name: Media and Sharing
+        features:
+          - name: Camera list/snap/clip
+            description: Camera list/snap/clip, photo-library latest image payloads, screen recording as media, Share Extension draft/send flow, attachment extraction, gateway relay settings for share, and mobile media payload limits
+        docs:
+          - docs/platforms/ios.md
+          - docs/nodes/camera.md
+        search_anchors:
+          - camera list
+          - photo library
+          - Share Extension
+        category_note: camera-media-photos-and-share-extension.md
+        human_lts_override: false
+      - name: Canvas and Screen
+        features:
+          - name: Canvas present/hide/navigate/eval/snapshot
+            description: Canvas present/hide/navigate/eval/snapshot, A2UI reset/push/pushJSONL, WKWebView scaffold loading, trusted A2UI action bridge, screen recording, foreground command gates, and Gateway Canvas host URL handling
+        docs:
+          - docs/platforms/ios.md
+          - docs/plugins/reference/canvas.md
+        search_anchors:
+          - Canvas
+          - A2UI
+          - WKWebView
+        category_note: canvas-screen-and-a2ui.md
+        human_lts_override: false
+      - name: Chat and Sessions
+        features:
+          - name: Chat sessions and operator controls
+            description: Operator session transport, Chat tab, chat composer/history/streaming/tool display, command-center, permissions, and session controls.
+        docs:
+          - docs/platforms/ios.md
+          - docs/web/webchat.md
+          - docs/gateway/protocol.md
+        search_anchors:
+          - Chat tab
+          - chat composer
+          - command-center
+          - session picker
+        category_note: chat-operator-ui-and-session-controls.md
+        human_lts_override: false
+      - name: Gateway Setup and Diagnostics
+        features:
+          - name: Bonjour/local
+            description: Bonjour/local and wide-area gateway discovery
+          - name: Manual host/port
+            description: Manual host/port and QR/setup-code onboarding
+          - name: Gateway connect configuration persistence
+            description: Gateway connect configuration persistence behavior, status, and operator-visible verification.
+          - name: TLS fingerprint trust prompt
+            description: TLS fingerprint trust prompt and pinning behavior
+          - name: Pairing approval
+            description: Pairing approval, device auth/keychain storage, and node+operator session auth
+          - name: Pairing/auth diagnostics for users
+            description: Pairing/auth diagnostics for users and operators
+          - name: Settings tab
+            description: Settings tab, Gateway settings, manual networking helpers, QR/setup-code intake, permission toggles and requests, discovery logs, Gateway problem details, diagnostics issue list, notification authorization state, and visible recovery actions
+        docs:
+          - docs/platforms/ios.md
+          - docs/channels/pairing.md
+        search_anchors:
+          - Quick start (pair + connect)
+          - Discovery paths
+          - Node device pairing
+          - Bonjour / DNS-SD discovery
+          - TLS fingerprint trust
+          - Settings tab
+          - permission toggles
+          - diagnostics
+        category_note: settings-permissions-and-diagnostics.md
+        human_lts_override: false
+      - name: Distribution
+        features:
+          - name: Internal preview status
+            description: Internal preview status, source/Xcode manual deploy, local signing, XcodeGen project generation, Fastlane TestFlight archive/upload, versioning/changelog/metadata, release artifacts, and official-vs-local build flags
+        docs:
+          - docs/platforms/ios.md
+        search_anchors:
+          - TestFlight
+          - Xcode manual deploy
+          - signing
+        category_note: install-signing-and-testflight-distribution.md
+        human_lts_override: false
+      - name: Device Commands
+        features:
+          - name: Location modes
+            description: Location modes, current location, significant-location events, motion activity and pedometer, contacts, calendar, reminders, permission request bridges, and personal-context command payloads
+          - name: Device command handling
+            description: iOS device command handling, foreground/background gating, command specifications, and capability visibility.
+        docs:
+          - docs/platforms/ios.md
+          - docs/gateway/protocol.md
+        search_anchors:
+          - location
+          - motion activity
+          - calendar
+          - contacts
+          - reminders
+          - node.invoke
+          - device commands
+          - foreground/background command gating
+        category_note: node-capability-routing-and-device-commands.md
+        human_lts_override: false
+      - name: Notifications and Background
+        features:
+          - name: APNs registration and relay delivery
+            description: Direct and relay-backed APNs registration, push relay trust, stored relay handles, background alive windows, and Live Activity updates.
+        docs:
+          - docs/platforms/ios.md
+          - docs/gateway/configuration.md
+        search_anchors:
+          - APNs registration
+          - push relay
+          - Live Activity
+          - background alive
+        category_note: relay-push-background-and-live-activity.md
+        human_lts_override: false
+      - name: Voice
+        features:
+          - name: Voice wake
+            description: Voice wake, trigger-word sync, Talk Mode, push-to-talk commands, realtime Gateway relay, Speech and microphone permissions, audio session coordination, background suspension, and voice settings
+        docs:
+          - docs/platforms/ios.md
+          - docs/nodes/talk.md
+        search_anchors:
+          - Voice wake
+          - Talk Mode
+          - push-to-talk
+        category_note: voice-talk-mode-and-wake.md
+        human_lts_override: false
+    last_score_run:
+      status: complete
+      completed_at: '2026-05-30'
+      by: codex
+      source_ref: null
+      process_version: 3
+  - id: watchos-companion-surfaces
+    name: watchOS companion surfaces
+    family: platform-app
+    level: experimental
+    level_code: M1
+    rationale: Source has Watch app/extension surfaces; public docs do not yet present this as a user feature.
+    completeness_instructions: references/completeness/watchos-companion-surfaces.md
+    categories:
+      - name: Delivery and Recovery
+        features:
+          - name: APNs relay/direct registration as it affects
+            description: APNs relay/direct registration as it affects watch approval wake/recovery
+          - name: Silent push
+            description: Silent push, background refresh, and significant-location wake paths
+          - name: Pending approval recovery IDs
+            description: Pending approval recovery IDs, snapshot refresh, and resolved/stale cleanup
+          - name: Gateway-side iOS exec approval
+            description: Gateway-side iOS exec approval APNs targeting
+          - name: iPhone-side WatchConnectivity transport
+            description: iPhone-side WatchConnectivity transport and status snapshot
+          - name: Watch-side receiver activation
+            description: Watch-side receiver activation and inbound payload handling
+          - name: Delivery fallback among reachable messages
+            description: Delivery fallback among reachable messages, queued user info, and application context snapshots
+        docs:
+          - docs/platforms/ios.md
+        search_anchors:
+          - watchos companion surfaces apns background recovery and stale approval cleanup
+          - apns background recovery and stale approval cleanup
+          - watchos companion surfaces watchconnectivity session status and delivery
+          - watchconnectivity session status and delivery
+        category_note: apns-background-recovery-and-stale-approval-cleanup.md
+        human_lts_override: false
+      - name: Exec Approvals
+        features:
+          - name: Watch exec approval prompt
+            description: Watch exec approval prompt, snapshot, resolve, resolved, and expired payloads
+          - name: Watch approval list/detail UI
+            description: Watch approval list/detail UI and decision buttons
+          - name: iPhone-side prompt caching
+            description: iPhone-side prompt caching, watch prompt publishing, snapshot handling, and resolution
+        docs:
+          - docs/tools/exec-approvals.md
+          - docs/platforms/ios.md
+        search_anchors:
+          - watchos companion surfaces exec approval review, decisions, and snapshots
+          - exec approval review, decisions, and snapshots
+        category_note: exec-approval-review-decisions-and-snapshots.md
+        human_lts_override: false
+      - name: Distribution and Support
+        features:
+          - name: Watch app
+            description: Watch app and WatchKit extension targets
+          - name: Signing/profile variables
+            description: Signing/profile variables, bundle identifiers, icon assets, and iOS beta release flow
+          - name: Public/support status
+            description: Public/support status for the watch companion as distributed through the iOS app
+          - name: Changelog
+            description: Changelog and repo-history evidence for watchOS companion maturity
+          - name: Release metadata
+            description: Release metadata and app-store/TestFlight preparation evidence
+          - name: Historical bug/regression themes relevant to scoring
+            description: Historical bug/regression themes relevant to scoring current source quality
+        docs:
+          - docs/platforms/ios.md
+        search_anchors:
+          - watchos companion surfaces packaging, signing, and distribution boundary
+          - packaging, signing, and distribution boundary
+          - watchos companion surfaces source history and release evidence
+          - source history and release evidence
+        category_note: packaging-signing-and-distribution-boundary.md
+        human_lts_override: false
+      - name: Notifications and Replies
+        features:
+          - name: watch.status
+            description: watch.status and watch.notify command contracts
+          - name: Payload normalization
+            description: Payload normalization for title/body, prompt/session metadata, priority, risk, and action buttons
+          - name: Mirrored iOS notification fallback when watch
+            description: Mirrored iOS notification fallback when watch delivery is queued
+          - name: Watch action buttons from generic prompt
+            description: Watch action buttons from generic prompt notifications
+          - name: Watch-to-iPhone reply payloads
+            description: Watch-to-iPhone reply payloads behavior, status, and operator-visible verification.
+          - name: iPhone-side dedupe
+            description: iPhone-side dedupe, offline queueing, and agent request forwarding
+          - name: Mirrored iOS notification action
+            description: Mirrored iOS notification action fallback
+        docs:
+          - docs/platforms/ios.md
+        search_anchors:
+          - watchos companion surfaces watch notify command, payloads, and prompt defaults
+          - watch notify command, payloads, and prompt defaults
+          - watchos companion surfaces quick reply actions and agent handoff
+          - quick reply actions and agent handoff
+        category_note: watch-notify-command-payloads-and-prompt-defaults.md
+        human_lts_override: false
+      - name: Watch App UI
+        features:
+          - name: Watch app entry point
+            description: Watch app entry point and SwiftUI navigation
+          - name: Generic inbox
+            description: Generic inbox, prompt actions, exec approval loading/list/detail views
+          - name: Persistent watch inbox state
+            description: Persistent watch inbox state and duplicate-delivery suppression
+        docs:
+          - docs/platforms/ios.md
+        search_anchors:
+          - watchos companion surfaces watch inbox ui and persistent state
+          - watch inbox ui and persistent state
+        category_note: watch-inbox-ui-and-persistent-state.md
+        human_lts_override: false
+    last_score_run:
+      status: complete
+      completed_at: '2026-05-30'
+      by: codex
+      source_ref: null
+      process_version: 3
+  - id: raspberry-pi-small-linux-devices
+    name: Raspberry Pi / small Linux devices
+    family: platform-app
+    level: beta
+    level_code: M3
+    rationale: Platform docs exist and Gateway path is Linux-based. Needs hardware-specific release smoke proof to move higher.
+    completeness_instructions: references/completeness/raspberry-pi-small-linux-devices.md
+    categories:
+      - name: Setup and Compatibility
+        features:
+          - name: Hardware and 64-bit OS requirements
+            description: Defines Hardware and 64-bit OS requirements setup, credential, configuration, and operator verification behavior for ARM Linux Setup and Prerequisites.
+          - name: Node runtime setup
+            description: Defines Node runtime setup setup, credential, configuration, and operator verification behavior for ARM Linux Setup and Prerequisites.
+          - name: OpenClaw install and onboarding
+            description: Defines OpenClaw install and onboarding setup, credential, configuration, and operator verification behavior for ARM Linux Setup and Prerequisites.
+          - name: First-run verification
+            description: Defines First-run verification setup, credential, configuration, and operator verification behavior for ARM Linux Setup and Prerequisites.
+          - name: Supported Pi model selection
+            description: Defines Supported Pi model selection setup, credential, configuration, and operator verification behavior for Hardware Support Boundary.
+          - name: 64-bit ARM boundary
+            description: Defines 64-bit ARM boundary setup, credential, configuration, and operator verification behavior for Hardware Support Boundary.
+          - name: Unsupported device guidance
+            description: Defines Unsupported device guidance setup, credential, configuration, and operator verification behavior for Hardware Support Boundary.
+          - name: Slow-device caveats
+            description: Defines Slow-device caveats setup, credential, configuration, and operator verification behavior for Hardware Support Boundary.
+          - name: npm/pnpm/Bun install modes
+            description: Defines npm/pnpm/Bun install modes setup, credential, configuration, and operator verification behavior for Package Manager and ARM Binary Compatibility.
+          - name: Installer architecture detection
+            description: Defines Installer architecture detection setup, credential, configuration, and operator verification behavior for Package Manager and ARM Binary Compatibility.
+          - name: Optional ARM binary checks
+            description: Defines Optional ARM binary checks setup, credential, configuration, and operator verification behavior for Package Manager and ARM Binary Compatibility.
+          - name: Fallback/build guidance
+            description: Defines Fallback/build guidance setup, credential, configuration, and operator verification behavior for Package Manager and ARM Binary Compatibility.
+        docs:
+          - docs/install/raspberry-pi.md
+          - docs/install/index.md
+          - docs/help/faq-first-run.md
+          - docs/help/faq.md
+          - docs/platforms/linux.md
+          - docs/install/installer.md
+        search_anchors:
+          - Hardware and 64-bit OS requirements
+          - Node runtime setup
+          - OpenClaw install and onboarding
+          - First-run verification
+          - Hardware compatibility
+          - Install Node.js 24
+          - API keys are recommended over OAuth
+          - Access the Control UI
+          - Supported Pi model selection
+          - 64-bit ARM boundary
+          - Unsupported device guidance
+          - Slow-device caveats
+          - npm/pnpm/Bun install modes
+          - Installer architecture detection
+          - Optional ARM binary checks
+          - Fallback/build guidance
+        category_note: arm-linux-install-and-runtime-prerequisites.md
+        human_lts_override: false
+      - name: Remote Access and Auth
+        features:
+          - name: Headless API-key auth
+            description: Defines Headless API-key auth context assembly, persistence, token-pressure handling, and recovery behavior for Gateway Auth, Device Pairing, and Secrets.
+          - name: Gateway shared-secret auth
+            description: Defines Gateway shared-secret auth context assembly, persistence, token-pressure handling, and recovery behavior for Gateway Auth, Device Pairing, and Secrets.
+          - name: Device pairing approvals
+            description: Defines Device pairing approvals context assembly, persistence, token-pressure handling, and recovery behavior for Gateway Auth, Device Pairing, and Secrets.
+          - name: SecretRef handling
+            description: Defines SecretRef handling context assembly, persistence, token-pressure handling, and recovery behavior for Gateway Auth, Device Pairing, and Secrets.
+          - name: Token drift recovery
+            description: Defines Token drift recovery context assembly, persistence, token-pressure handling, and recovery behavior for Gateway Auth, Device Pairing, and Secrets.
+          - name: SSH tunnel dashboard access
+            description: Defines SSH tunnel dashboard access setup, credential, configuration, and operator verification behavior for Remote Access and Control UI.
+          - name: Tailscale Serve/Funnel
+            description: Defines Tailscale Serve/Funnel setup, credential, configuration, and operator verification behavior for Remote Access and Control UI.
+          - name: Loopback/non-loopback exposure controls
+            description: Defines Loopback/non-loopback exposure controls setup, credential, configuration, and operator verification behavior for Remote Access and Control UI.
+          - name: Authenticated Control UI access
+            description: Defines Authenticated Control UI access setup, credential, configuration, and operator verification behavior for Remote Access and Control UI.
+        docs:
+          - docs/install/raspberry-pi.md
+          - docs/gateway/authentication.md
+          - docs/gateway/secrets.md
+          - docs/gateway/pairing.md
+          - docs/cli/devices.md
+          - docs/gateway/remote.md
+          - docs/gateway/tailscale.md
+        search_anchors:
+          - Headless API-key auth
+          - Gateway shared-secret auth
+          - Device pairing approvals
+          - SecretRef handling
+          - Token drift recovery
+          - Hardware compatibility
+          - Install Node.js 24
+          - API keys are recommended over OAuth
+          - SSH tunnel dashboard access
+          - Tailscale Serve/Funnel
+          - Loopback/non-loopback exposure controls
+          - Authenticated Control UI access
+          - Access the Control UI
+        category_note: remote-access-tailscale-ssh-and-control-ui.md
+        human_lts_override: false
+      - name: Gateway Runtime
+        features:
+          - name: Always-on Gateway process
+            description: Defines Always-on Gateway process setup, credential, configuration, and operator verification behavior for Headless Gateway and Model Setup.
+          - name: Cloud model configuration
+            description: Defines Cloud model configuration setup, credential, configuration, and operator verification behavior for Headless Gateway and Model Setup.
+          - name: Channel startup
+            description: Defines Channel startup setup, credential, configuration, and operator verification behavior for Headless Gateway and Model Setup.
+          - name: Gateway health/status
+            description: Defines Gateway health/status setup, credential, configuration, and operator verification behavior for Headless Gateway and Model Setup.
+          - name: User service install
+            description: Defines User service install setup, credential, configuration, and operator verification behavior for systemd Service and Boot Persistence.
+          - name: linger/boot persistence
+            description: Defines linger/boot persistence setup, credential, configuration, and operator verification behavior for systemd Service and Boot Persistence.
+          - name: Service drop-ins
+            description: Defines Service drop-ins setup, credential, configuration, and operator verification behavior for systemd Service and Boot Persistence.
+          - name: Restart tuning
+            description: Defines Restart tuning setup, credential, configuration, and operator verification behavior for systemd Service and Boot Persistence.
+          - name: Status/log inspection
+            description: Defines Status/log inspection setup, credential, configuration, and operator verification behavior for systemd Service and Boot Persistence.
+          - name: Backup/restore
+            description: Defines Backup/restore setup, credential, configuration, and operator verification behavior for systemd Service and Boot Persistence.
+        docs:
+          - docs/gateway/index.md
+          - docs/cli/gateway.md
+          - docs/install/raspberry-pi.md
+          - docs/platforms/linux.md
+          - docs/vps.md
+        search_anchors:
+          - Always-on Gateway process
+          - Cloud model configuration
+          - Channel startup
+          - Gateway health/status
+          - Hardware compatibility
+          - Install Node.js 24
+          - API keys are recommended over OAuth
+          - Access the Control UI
+          - User service install
+          - linger/boot persistence
+          - Service drop-ins
+          - Restart tuning
+          - Status/log inspection
+          - Backup/restore
+        category_note: headless-gateway-runtime-and-model-routing.md
+        human_lts_override: false
+      - name: Performance and Diagnostics
+        features:
+          - name: Swap and low-RAM tuning
+            description: Defines Swap and low-RAM tuning setup, credential, configuration, and operator verification behavior for Resource Tuning and Diagnostics.
+          - name: USB SSD guidance
+            description: Defines USB SSD guidance setup, credential, configuration, and operator verification behavior for Resource Tuning and Diagnostics.
+          - name: Compile cache/no-respawn settings
+            description: Defines Compile cache/no-respawn settings setup, credential, configuration, and operator verification behavior for Resource Tuning and Diagnostics.
+          - name: OOM/performance troubleshooting
+            description: Defines OOM/performance troubleshooting setup, credential, configuration, and operator verification behavior for Resource Tuning and Diagnostics.
+          - name: Diagnostics bundles
+            description: Defines Diagnostics bundles setup, credential, configuration, and operator verification behavior for Resource Tuning and Diagnostics.
+        docs:
+          - docs/install/raspberry-pi.md
+          - docs/platforms/linux.md
+          - docs/gateway/health.md
+          - docs/gateway/diagnostics.md
+        search_anchors:
+          - Swap and low-RAM tuning
+          - USB SSD guidance
+          - Compile cache/no-respawn settings
+          - OOM/performance troubleshooting
+          - Diagnostics bundles
+          - Hardware compatibility
+          - Install Node.js 24
+          - API keys are recommended over OAuth
+        category_note: resource-tuning-diagnostics-and-low-memory-behavior.md
+        human_lts_override: false
+    last_score_run:
+      status: complete
+      completed_at: '2026-05-30'
+      by: codex
+      source_ref: null
+      process_version: 3
+  - id: docker-podman-hosting
+    name: Docker / Podman hosting
+    family: platform-app
+    level: beta
+    level_code: M3
+    rationale: Install docs exist and are common deployment paths. Promote after recurring release smoke captures upgrade and volume behavior.
+    completeness_instructions: references/completeness/docker-podman-hosting.md
+    categories:
+      - name: Container Setup
+        features:
+          - name: Local Image Setup Script
+            description: Covers Local Image Setup Script across `./scripts/docker/setup.sh` local-image and GHCR-image setup. Docker Compose gateway and sidecar CLI shape. First-run onboarding, token handling, bind/origin defaults, and post-start channel setup commands. Docker-only first-run notes, and related docker install, compose, and first-run setup behavior.
+          - name: Docker Compose gateway
+            description: Docker Compose gateway and sidecar CLI shape
+          - name: First-run onboarding
+            description: First-run onboarding, token handling, bind/origin defaults, and post-start channel setup commands
+          - name: Docker-only first-run notes
+            description: Docker-only first-run notes, excluding Podman rootless setup and general Gateway protocol internals
+          - name: Podman setup scripts and Quadlet template
+            description: Podman setup docs, scripts/podman/setup.sh, scripts/run-openclaw-podman.sh, and scripts/podman/openclaw.container.in
+          - name: Rootless Podman image setup
+            description: Rootless Podman image setup, launch, setup/onboarding, host CLI routing, Quadlet autostart, and owner/permission checks
+        docs:
+          - docs/install/docker.md
+          - docs/install/podman.md
+        search_anchors:
+          - docker / podman hosting docker install, compose, and first-run setup
+          - docker install, compose, and first-run setup
+          - docker / podman hosting podman rootless, quadlet, and host cli
+          - podman rootless, quadlet, and host cli
+        category_note: docker-install-compose-and-first-run-setup.md
+        human_lts_override: false
+      - name: Container Operations
+        features:
+          - name: Host CLI routing into running Docker/Podman
+            description: Host CLI routing into running Docker/Podman containers
+          - name: Container Targeting
+            description: Covers Container Targeting across Host CLI routing into running Docker/Podman containers. `--container` and `OPENCLAW_CONTAINER` behavior, env handling, ambiguous runtime detection, loopback proxy guard, and related host cli container targeting and update lifecycle behavior.
+          - name: Container update/rebuild/restart guidance for Docker
+            description: Container update/rebuild/restart guidance for Docker and Podman hosts
+          - name: Docker Compose
+            description: Docker Compose and Podman config/workspace/auth-profile secret mounts
+          - name: Gateway token generation
+            description: Gateway token generation, reuse, .env persistence, and Control UI allowed origins
+          - name: Ownership
+            description: Ownership, permissions, SELinux mount behavior, and state survival across container replacement
+          - name: Docker Compose
+            description: Docker Compose and Podman port publishing, bind mode, host local provider access, Bonjour, Tailscale, and Control UI origins
+          - name: Container health endpoints
+            description: Container health endpoints, Dockerfile/Compose healthchecks, openclaw health, logs, and metrics/OTel docs
+          - name: Provider/VPS Docker hosting docs
+            description: Provider/VPS Docker hosting docs and operational runbooks
+          - name: Docker VM persistence/update guidance
+            description: Docker VM persistence/update guidance, Hetzner/Hostinger/DigitalOcean adjacency, Kubernetes/container warnings, and secure exposure
+          - name: Operator-facing update
+            description: Operator-facing update, backup, persistence, low-memory, and troubleshooting guidance
+        docs:
+          - docs/install/podman.md
+          - docs/install/docker-vm-runtime.md
+          - docs/install/docker.md
+          - docs/install/hetzner.md
+          - docs/install/hostinger.md
+        search_anchors:
+          - docker / podman hosting host cli container targeting and update lifecycle
+          - host cli container targeting and update lifecycle
+          - docker / podman hosting runtime configuration, state persistence, volumes, and secrets
+          - runtime configuration, state persistence, volumes, and secrets
+          - docker / podman hosting networking, control ui, health, and observability
+          - networking, control ui, health, and observability
+          - docker / podman hosting provider-hosted vps and operator runbooks
+          - provider-hosted vps and operator runbooks
+        category_note: runtime-configuration-state-volumes-and-secrets.md
+        human_lts_override: false
+      - name: Image Release and Validation
+        features:
+          - name: Root Dockerfile build stages
+            description: Root Dockerfile build stages, runtime image contents, optional browser and Docker CLI build args
+          - name: Docker release workflow
+            description: Docker release workflow for GHCR publishing, multi-arch tags, manifests, and attestation verification
+          - name: Docker E2E package artifact generation
+            description: Docker E2E package artifact generation and shared build helpers
+          - name: Docker E2E plan/scheduler scripts
+            description: Docker E2E plan/scheduler scripts, lane metadata, targeted grouping, package artifact generation, and GitHub hydration action
+          - name: Release-path install
+            description: Release-path install, update, upgrade survivor, live-provider, plugin, Open WebUI, and cleanup scenario planning
+        docs:
+          - docs/install/docker.md
+          - docs/install/docker-vm-runtime.md
+          - docs/reference/full-release-validation.md
+        search_anchors:
+          - docker / podman hosting image build, release packaging, and attestations
+          - image build, release packaging, and attestations
+          - docker / podman hosting docker e2e release smoke and scheduler
+          - docker e2e release smoke and scheduler
+        category_note: image-build-release-packaging-and-attestations.md
+        human_lts_override: false
+      - name: Agent Sandbox and Tooling
+        features:
+          - name: Docker gateway setup
+            description: Docker gateway setup with OPENCLAW_SANDBOX, Docker CLI build arg, socket mount, sandbox config writes, and rollback behavior
+          - name: Docker-backed agent sandbox support
+            description: Docker-backed agent sandbox docs, source behavior, and tests that affect container-hosted Gateway operators.
+          - name: Container image dependency baking
+            description: Container image dependency baking for skills/plugins/tools
+        docs:
+          - docs/install/docker.md
+          - docs/install/docker-vm-runtime.md
+        search_anchors:
+          - docker / podman hosting containerized agents, sandbox, and tooling support
+          - containerized agents, sandbox, and tooling support
+        category_note: containerized-agents-sandbox-and-tooling-support.md
+        human_lts_override: false
+    last_score_run:
+      status: complete
+      completed_at: '2026-05-30'
+      by: codex
+      source_ref: null
+      process_version: 3
+  - id: kubernetes-hosting
+    name: Kubernetes hosting
+    family: platform-app
+    level: alpha
+    level_code: M2
+    rationale: Kubernetes hosting is a distinct Kustomize-based cluster deployment path. Current scoring shows a real minimal deployment path with gaps around Kubernetes-specific CI, ingress/TLS/NetworkPolicy packaging, backup/restore, and production exposure hardening.
+    completeness_instructions: references/completeness/kubernetes-hosting.md
+    categories:
+      - name: Deployment Setup
+        features:
+          - name: Kustomize packaging
+            description: Kustomize-first deployment posture and Helm non-goal.
+          - name: Cluster prerequisites
+            description: Cluster access, kubectl context, and provider-key prerequisites.
+          - name: Quick deploy
+            description: One-command cluster deployment path.
+          - name: Manifest apply
+            description: Step-by-step secret creation and manifest apply workflow.
+          - name: Kind validation
+            description: Local Kind cluster test workflow.
+        docs:
+          - docs/install/kubernetes.md
+          - docs/install/index.md
+        search_anchors:
+          - Why not Helm
+          - What you need
+          - Quick start
+          - Local testing with Kind
+          - Step by step
+          - Deploy
+          - File structure
+        category_note: deployment-setup.md
+        human_lts_override: false
+      - name: Configuration and Secrets
+        features:
+          - name: Agent instructions
+            description: ConfigMap-based agent instruction injection.
+          - name: Gateway config
+            description: ConfigMap-based Gateway configuration.
+          - name: Provider secrets
+            description: Kubernetes Secret-backed provider-key setup.
+          - name: Secret rotation
+            description: Provider-key patching and redeploy expectations.
+          - name: Image and namespace
+            description: Custom image pinning and namespace override.
+        docs:
+          - docs/install/kubernetes.md
+          - docs/gateway/secrets.md
+          - docs/help/environment.md
+        search_anchors:
+          - Customization
+          - Agent instructions
+          - Gateway config
+          - Add providers
+          - Custom namespace
+          - Custom image
+        category_note: configuration-and-secrets.md
+        human_lts_override: false
+      - name: Access and Exposure
+        features:
+          - name: Port-forward access
+            description: kubectl port-forward path for local Gateway access.
+          - name: Service endpoint
+            description: Kubernetes Service access model for the Gateway.
+          - name: Ingress exposure
+            description: Ingress and load-balancer exposure beyond port-forward.
+          - name: Auth and TLS
+            description: Required authentication, TLS, and origin controls for exposed deployments.
+          - name: Localhost posture
+            description: Cluster-local runtime assumptions and localhost access boundaries.
+        docs:
+          - docs/install/kubernetes.md
+          - docs/gateway/authentication.md
+          - docs/gateway/remote.md
+          - docs/gateway/security/exposure-runbook.md
+        search_anchors:
+          - Access the gateway
+          - Port-forward access path
+          - Expose beyond port-forward
+          - Ingress and load-balancer exposure model
+          - auth, TLS, and origins
+          - localhost access posture
+        category_note: access-and-exposure.md
+        human_lts_override: false
+      - name: Cluster Lifecycle
+        features:
+          - name: Resource layout
+            description: Namespace, Deployment, Service, PVC, ConfigMap, and Secret inventory.
+          - name: State persistence
+            description: PVC-backed state expectations and cleanup implications.
+          - name: Redeploy
+            description: Re-apply manifests and restart pod workflow.
+          - name: Teardown
+            description: Namespace deletion and PVC cleanup path.
+          - name: Security context
+            description: Pod security, namespace scope, and runtime isolation notes.
+        docs:
+          - docs/install/kubernetes.md
+          - docs/gateway/index.md
+        search_anchors:
+          - What gets deployed
+          - Namespace, deployment, service, PVC, ConfigMap, and Secret layout
+          - Re-deploy
+          - Teardown
+          - Architecture notes
+          - Related
+        category_note: cluster-lifecycle.md
+        human_lts_override: false
+    last_score_run:
+      status: complete
+      completed_at: '2026-06-01'
+      by: codex
+      source_ref: openclaw@29dd7847fd
+      process_version: 3
+  - id: nix-install-path
+    name: Nix install path
+    family: platform-app
+    level: experimental
+    level_code: M1
+    rationale: Optional install flow. Needs clearer support promise before alpha/beta promotion.
+    completeness_instructions: references/completeness/nix-install-path.md
+    categories:
+      - name: Install Handoff
+        features:
+          - name: Nix install overview
+            description: Covers Nix install overview across public Nix install page, install index discoverability, docs navigation, and the handoff to the first-party `nix-openclaw` Home Manager module. It excludes the actual external `openclaw/nix-openclaw` repository implementation, and related public nix docs and nix-openclaw handoff behavior.
+          - name: nix-openclaw source-of-truth
+            description: Covers nix-openclaw source-of-truth across public Nix install page, install index discoverability, docs navigation, and the handoff to the first-party `nix-openclaw` Home Manager module. It excludes the actual external `openclaw/nix-openclaw` repository implementation, and related public nix docs and nix-openclaw handoff behavior.
+          - name: Install discoverability
+            description: Covers Install discoverability across public Nix install page, install index discoverability, docs navigation, and the handoff to the first-party `nix-openclaw` Home Manager module. It excludes the actual external `openclaw/nix-openclaw` repository implementation, and related public nix docs and nix-openclaw handoff behavior.
+          - name: Verification handoff
+            description: Covers Verification handoff across public Nix install page, install index discoverability, docs navigation, and the handoff to the first-party `nix-openclaw` Home Manager module. It excludes the actual external `openclaw/nix-openclaw` repository implementation, and related public nix docs and nix-openclaw handoff behavior.
+        docs:
+          - docs/install/nix.md
+          - docs/install/index.md
+          - docs/start/docs-directory.md
+        search_anchors:
+          - Nix install overview
+          - nix-openclaw source-of-truth
+          - Install discoverability
+          - Verification handoff
+        category_note: public-nix-docs-handoff.md
+        human_lts_override: false
+      - name: Plugin Lifecycle
+        features:
+          - name: Lifecycle command refusal
+            description: Covers Lifecycle command refusal across plugin install/update/uninstall/enable/disable behavior in Nix mode, `/nix/store` hardlink handling, manifest registry safety, and user-facing guidance for declarative plugin selection.
+          - name: Declarative plugin selection
+            description: Covers Declarative plugin selection across plugin install/update/uninstall/enable/disable behavior in Nix mode, `/nix/store` hardlink handling, manifest registry safety, and user-facing guidance for declarative plugin selection.
+          - name: Nix-store plugin loading
+            description: Covers Nix-store plugin loading across plugin install/update/uninstall/enable/disable behavior in Nix mode, `/nix/store` hardlink handling, manifest registry safety, and user-facing guidance for declarative plugin selection.
+          - name: Hardlink safety
+            description: Covers Hardlink safety across plugin install/update/uninstall/enable/disable behavior in Nix mode, `/nix/store` hardlink handling, manifest registry safety, and user-facing guidance for declarative plugin selection.
+        docs:
+          - docs/plugins/manage-plugins.md
+          - docs/tools/plugin.md
+          - docs/install/nix.md
+        search_anchors:
+          - Lifecycle command refusal
+          - Declarative plugin selection
+          - Nix-store plugin loading
+          - Hardlink safety
+        category_note: plugin-lifecycle-nix-store-loading.md
+        human_lts_override: false
+      - name: Activation and App UX
+        features:
+          - name: Environment activation
+            description: Covers Environment activation across Nix mode activation, environment-variable detection, macOS default detection, and the operator docs that explain how Nix mode is enabled.
+          - name: macOS defaults activation
+            description: Covers macOS defaults activation across Nix mode activation, environment-variable detection, macOS default detection, and the operator docs that explain how Nix mode is enabled.
+          - name: Runtime Nix-mode detection
+            description: Covers Runtime Nix-mode detection across Nix mode activation, environment-variable detection, macOS default detection, and the operator docs that explain how Nix mode is enabled.
+          - name: Stable Nix defaults
+            description: Covers Stable Nix defaults across macOS app's `openclaw.nixMode` default handling, config read-only UX, settings banner, onboarding behavior, and local config write prevention.
+          - name: Managed-by-Nix banner
+            description: Covers Managed-by-Nix banner across macOS app's `openclaw.nixMode` default handling, config read-only UX, settings banner, onboarding behavior, and local config write prevention.
+          - name: Read-only config controls
+            description: Covers Read-only config controls across macOS app's `openclaw.nixMode` default handling, config read-only UX, settings banner, onboarding behavior, and local config write prevention.
+          - name: Onboarding skip
+            description: Covers Onboarding skip across macOS app's `openclaw.nixMode` default handling, config read-only UX, settings banner, onboarding behavior, and local config write prevention.
+        docs:
+          - docs/install/nix.md
+        search_anchors:
+          - Environment activation
+          - macOS defaults activation
+          - Runtime Nix-mode detection
+          - Stable Nix defaults
+          - Managed-by-Nix banner
+          - Read-only config controls
+          - Onboarding skip
+        category_note: nix-mode-activation-runtime-detection.md
+        human_lts_override: false
+      - name: Config and State
+        features:
+          - name: Immutable config guard
+            description: Covers Immutable config guard across `OPENCLAW_NIX_MODE_CONFIG_IMMUTABLE` guard, source-edit guidance, config writer integration, and the agent-first Nix source instruction.
+          - name: Config writer refusal
+            description: Covers Config writer refusal across `OPENCLAW_NIX_MODE_CONFIG_IMMUTABLE` guard, source-edit guidance, config writer integration, and the agent-first Nix source instruction.
+          - name: Agent-first Nix edits
+            description: Covers Agent-first Nix edits across `OPENCLAW_NIX_MODE_CONFIG_IMMUTABLE` guard, source-edit guidance, config writer integration, and the agent-first Nix source instruction.
+          - name: Explicit config path
+            description: Covers Explicit config path across config/state path environment variables, immutable store expectations, path resolution, state integrity checks around `/nix/store`, and runtime guidance that state should stay writable.
+          - name: Writable state directory
+            description: Covers Writable state directory across config/state path environment variables, immutable store expectations, path resolution, state integrity checks around `/nix/store`, and runtime guidance that state should stay writable.
+          - name: Immutable-store config support
+            description: Covers Immutable-store config support across config/state path environment variables, immutable store expectations, path resolution, state integrity checks around `/nix/store`, and runtime guidance that state should stay writable.
+          - name: State integrity checks
+            description: Covers State integrity checks across config/state path environment variables, immutable store expectations, path resolution, state integrity checks around `/nix/store`, and runtime guidance that state should stay writable.
+        docs:
+          - docs/install/nix.md
+          - docs/cli/setup.md
+          - docs/help/environment.md
+        search_anchors:
+          - Immutable config guard
+          - Config writer refusal
+          - Agent-first Nix edits
+          - Explicit config path
+          - Writable state directory
+          - Immutable-store config support
+          - State integrity checks
+        category_note: state-config-path-immutable-store.md
+        human_lts_override: false
+      - name: Service Runtime and Guards
+        features:
+          - name: Nix profile PATH discovery
+            description: Covers Nix profile PATH discovery across `NIX_PROFILES` handling, `~/.nix-profile/bin` fallback, launchd/systemd service PATH generation, and adjacent safe binary resolution rules.
+          - name: Profile precedence
+            description: Covers Profile precedence across `NIX_PROFILES` handling, `~/.nix-profile/bin` fallback, launchd/systemd service PATH generation, and adjacent safe binary resolution rules.
+          - name: Service PATH fallback
+            description: Covers Service PATH fallback across `NIX_PROFILES` handling, `~/.nix-profile/bin` fallback, launchd/systemd service PATH generation, and adjacent safe binary resolution rules.
+          - name: Trusted binary boundaries
+            description: Covers Trusted binary boundaries across `NIX_PROFILES` handling, `~/.nix-profile/bin` fallback, launchd/systemd service PATH generation, and adjacent safe binary resolution rules.
+          - name: Setup write refusal
+            description: Covers Setup write refusal across `openclaw setup`, `openclaw doctor` repair/token modes, `openclaw update`/startup auto-update behavior, and daemon service install/uninstall behavior under Nix mode.
+          - name: Doctor repair refusal
+            description: Covers Doctor repair refusal across `openclaw setup`, `openclaw doctor` repair/token modes, `openclaw update`/startup auto-update behavior, and daemon service install/uninstall behavior under Nix mode.
+          - name: Update handoff
+            description: Covers Update handoff across `openclaw setup`, `openclaw doctor` repair/token modes, `openclaw update`/startup auto-update behavior, and daemon service install/uninstall behavior under Nix mode.
+          - name: Service lifecycle handoff
+            description: Covers Service lifecycle handoff across `openclaw setup`, `openclaw doctor` repair/token modes, `openclaw update`/startup auto-update behavior, and daemon service install/uninstall behavior under Nix mode.
+        docs:
+          - docs/install/nix.md
+          - docs/cli/setup.md
+          - docs/cli/doctor.md
+          - docs/cli/update.md
+        search_anchors:
+          - Nix profile PATH discovery
+          - Profile precedence
+          - Service PATH fallback
+          - Trusted binary boundaries
+          - Setup write refusal
+          - Doctor repair refusal
+          - Update handoff
+          - Service lifecycle handoff
+        category_note: gateway-service-path-nix-profile-discovery.md
+        human_lts_override: false
+    last_score_run:
+      status: complete
+      completed_at: '2026-05-30'
+      by: codex
+      source_ref: null
+      process_version: 3
+  - id: discord
+    name: Discord
+    family: channel
+    level: stable
+    level_code: M4
+    rationale: Deep docs and broad feature coverage. Voice/delegation paths should stay separately scored as beta/alpha.
+    completeness_instructions: references/completeness/discord.md
+    categories:
+      - name: Channel Setup and Operations
+        features:
+          - name: Application and bot setup
+            description: Covers Application and bot setup across Discord application/bot creation guidance, bot token and `applicationId` configuration, env and SecretRef token resolution, setup wizard/account inspection, and related bot setup and account configuration behavior.
+          - name: Token and application ID configuration
+            description: Covers Token and application ID configuration across Discord application/bot creation guidance, bot token and `applicationId` configuration, env and SecretRef token resolution, setup wizard/account inspection, and related bot setup and account configuration behavior.
+          - name: Setup wizard and account inspection
+            description: Covers Setup wizard and account inspection across Discord application/bot creation guidance, bot token and `applicationId` configuration, env and SecretRef token resolution, setup wizard/account inspection, and related bot setup and account configuration behavior.
+          - name: Status, doctor, and intent checks
+            description: Covers Status, doctor, and intent checks across Discord application/bot creation guidance, bot token and `applicationId` configuration, env and SecretRef token resolution, setup wizard/account inspection, and related bot setup and account configuration behavior.
+          - name: Multi-account bot configuration
+            description: Covers Multi-account bot configuration across Discord application/bot creation guidance, bot token and `applicationId` configuration, env and SecretRef token resolution, setup wizard/account inspection, and related bot setup and account configuration behavior.
+          - name: Account monitor startup
+            description: Covers Account monitor startup across Discord gateway monitor startup path, runtime provider lifecycle, WebSocket gateway client, reconnect/heartbeat handling, and related gateway monitor and runtime lifecycle behavior.
+          - name: Gateway WebSocket lifecycle
+            description: Covers Gateway WebSocket lifecycle across Discord gateway monitor startup path, runtime provider lifecycle, WebSocket gateway client, reconnect/heartbeat handling, and related gateway monitor and runtime lifecycle behavior.
+          - name: Reconnect and heartbeat handling
+            description: Covers Reconnect and heartbeat handling across Discord gateway monitor startup path, runtime provider lifecycle, WebSocket gateway client, reconnect/heartbeat handling, and related gateway monitor and runtime lifecycle behavior.
+          - name: Rate limits and gateway metadata
+            description: Covers Rate limits and gateway metadata across Discord gateway monitor startup path, runtime provider lifecycle, WebSocket gateway client, reconnect/heartbeat handling, and related gateway monitor and runtime lifecycle behavior.
+          - name: Status, probe, and health-monitor recovery
+            description: Covers Status, probe, and health-monitor recovery across Discord gateway monitor startup path, runtime provider lifecycle, WebSocket gateway client, reconnect/heartbeat handling, and related gateway monitor and runtime lifecycle behavior.
+        docs:
+          - docs/channels/discord.md
+          - docs/plugins/reference/discord.md
+          - docs/install/fly.md
+          - docs/tools/slash-commands.md
+          - docs/gateway/health.md
+          - docs/cli/channels.md
+          - docs/gateway/config-channels.md
+        search_anchors:
+          - Application and bot setup
+          - Token and application ID configuration
+          - Setup wizard and account inspection
+          - Status, doctor, and intent checks
+          - Multi-account bot configuration
+          - Account monitor startup
+          - Gateway WebSocket lifecycle
+          - Reconnect and heartbeat handling
+          - Rate limits and gateway metadata
+          - Status, probe, and health-monitor recovery
+        category_note: bot-setup-and-account-configuration.md
+        human_lts_override: true
+      - name: Access and Identity
+        features:
+          - name: DM policy modes
+            description: 'Covers DM policy modes across Discord direct-message `dmPolicy` modes: `pairing`, `allowlist`, `open`, and `disabled`. Canonical and legacy `allowFrom` resolution across top-level Discord config, and related dm pairing and sender authorization behavior.'
+          - name: Allowlist inheritance
+            description: 'Covers Allowlist inheritance across Discord direct-message `dmPolicy` modes: `pairing`, `allowlist`, `open`, and `disabled`. Canonical and legacy `allowFrom` resolution across top-level Discord config, and related dm pairing and sender authorization behavior.'
+          - name: Pairing-code approval
+            description: 'Covers Pairing-code approval across Discord direct-message `dmPolicy` modes: `pairing`, `allowlist`, `open`, and `disabled`. Canonical and legacy `allowFrom` resolution across top-level Discord config, and related dm pairing and sender authorization behavior.'
+          - name: Sender authorization
+            description: 'Covers Sender authorization across Discord direct-message `dmPolicy` modes: `pairing`, `allowlist`, `open`, and `disabled`. Canonical and legacy `allowFrom` resolution across top-level Discord config, and related dm pairing and sender authorization behavior.'
+          - name: Access-group authorization
+            description: 'Covers Access-group authorization across Discord direct-message `dmPolicy` modes: `pairing`, `allowlist`, `open`, and `disabled`. Canonical and legacy `allowFrom` resolution across top-level Discord config, and related dm pairing and sender authorization behavior.'
+          - name: Group DM authorization
+            description: 'Covers Group DM authorization across Discord direct-message `dmPolicy` modes: `pairing`, `allowlist`, `open`, and `disabled`. Canonical and legacy `allowFrom` resolution across top-level Discord config, and related dm pairing and sender authorization behavior.'
+        docs:
+          - docs/channels/discord.md
+          - docs/channels/pairing.md
+          - docs/channels/access-groups.md
+          - docs/channels/groups.md
+        search_anchors:
+          - DM policy modes
+          - Allowlist inheritance
+          - Pairing-code approval
+          - Sender authorization
+          - Access-group authorization
+          - Group DM authorization
+        category_note: dm-pairing-and-sender-authorization.md
+        human_lts_override: true
+      - name: Conversation Routing and Delivery
+        features:
+          - name: Guild and channel admission
+            description: Covers Guild and channel admission across Guild allowlist and `groupPolicy` admission for Discord guild channels and threads. `requireMention`, bot-loop prevention, command/mention bypasses, and unmentioned room-event history. Channel, and related guild channel routing and session isolation behavior.
+          - name: Mention gating
+            description: Covers Mention gating across Guild allowlist and `groupPolicy` admission for Discord guild channels and threads. `requireMention`, bot-loop prevention, command/mention bypasses, and unmentioned room-event history. Channel, and related guild channel routing and session isolation behavior.
+          - name: Session key isolation
+            description: Covers Session key isolation across Guild allowlist and `groupPolicy` admission for Discord guild channels and threads. `requireMention`, bot-loop prevention, command/mention bypasses, and unmentioned room-event history. Channel, and related guild channel routing and session isolation behavior.
+          - name: Configured and runtime routing
+            description: Covers Configured and runtime bindings across Guild allowlist and `groupPolicy` admission for Discord guild channels and threads. `requireMention`, bot-loop prevention, command/mention bypasses, and unmentioned room-event history. Channel, and related guild channel routing and session isolation behavior.
+          - name: Inbound context visibility
+            description: Covers Inbound context visibility across Guild allowlist and `groupPolicy` admission for Discord guild channels and threads. `requireMention`, bot-loop prevention, command/mention bypasses, and unmentioned room-event history. Channel, and related guild channel routing and session isolation behavior.
+          - name: Forum and media-channel thread posts
+            description: 'Covers Forum and media-channel thread posts across Discord forum/media channel posts created as threads from parent channel targets. CLI and message-tool thread actions: `thread-create`, `thread-list`, and `thread-reply`. Discord target parsing for `channel:<id>`, user targets, and related threads, forums, and delegated-agent bindings behavior.'
+          - name: Thread actions
+            description: 'Covers Thread actions across Discord forum/media channel posts created as threads from parent channel targets. CLI and message-tool thread actions: `thread-create`, `thread-list`, and `thread-reply`. Discord target parsing for `channel:<id>`, user targets, and related threads, forums, and delegated-agent bindings behavior.'
+          - name: Target parsing
+            description: 'Covers Target parsing across Discord forum/media channel posts created as threads from parent channel targets. CLI and message-tool thread actions: `thread-create`, `thread-list`, and `thread-reply`. Discord target parsing for `channel:<id>`, user targets, and related threads, forums, and delegated-agent bindings behavior.'
+          - name: Thread context resolution
+            description: 'Covers Thread context resolution across Discord forum/media channel posts created as threads from parent channel targets. CLI and message-tool thread actions: `thread-create`, `thread-list`, and `thread-reply`. Discord target parsing for `channel:<id>`, user targets, and related threads, forums, and delegated-agent bindings behavior.'
+          - name: Thread-bound session routing
+            description: 'Covers Thread-bound session routing across Discord forum/media channel posts created as threads from parent channel targets. CLI and message-tool thread actions: `thread-create`, `thread-list`, and `thread-reply`. Discord target parsing for `channel:<id>`, user targets, and related threads, forums, and delegated-agent bindings behavior.'
+          - name: ACP agent routing
+            description: 'Covers ACP bindings across Discord forum/media channel posts created as threads from parent channel targets. CLI and message-tool thread actions: `thread-create`, `thread-list`, and `thread-reply`. Discord target parsing for `channel:<id>`, user targets, and related threads, forums, and delegated-agent bindings behavior.'
+          - name: Routing lifecycle
+            description: 'Covers Binding lifecycle across Discord forum/media channel posts created as threads from parent channel targets. CLI and message-tool thread actions: `thread-create`, `thread-list`, and `thread-reply`. Discord target parsing for `channel:<id>`, user targets, and related threads, forums, and delegated-agent bindings behavior.'
+        docs:
+          - docs/channels/discord.md
+          - docs/channels/channel-routing.md
+          - docs/channels/groups.md
+          - docs/channels/access-groups.md
+          - docs/tools/acp-agents.md
+          - docs/tools/subagents.md
+        search_anchors:
+          - Guild and channel admission
+          - Mention gating
+          - Session key isolation
+          - Configured and runtime bindings
+          - Inbound context visibility
+          - Forum and media-channel thread posts
+          - Thread actions
+          - Target parsing
+          - Thread context resolution
+          - Thread-bound session routing
+          - ACP bindings
+          - Binding lifecycle
+        category_note: guild-channel-routing-and-session-isolation.md
+        human_lts_override: true
+      - name: Media and Rich Content
+        features:
+          - name: Media and Rich Content
+            description: Evidence scope for Media and Rich Content.
+        docs:
+          - docs/channels/discord.md
+        search_anchors:
+          - discord media and rich content
+          - media and rich content
+        category_note: media-attachments-and-voice-message-handling.md
+        human_lts_override: true
+      - name: Native Controls and Approvals
+        features:
+          - name: Native slash command registration
+            description: Native slash command registration and reconciliation for Discord application commands
+          - name: Native slash command execution
+            description: Native slash command execution, autocomplete, authz, and interaction dispatch
+          - name: Model Picker Commands
+            description: Covers Model Picker Commands across Native slash command registration and reconciliation for Discord application commands. Native slash command execution, autocomplete, authz, and interaction dispatch. `/model` and `/models` picker flows, and related native slash commands, components, and interactive callbacks behavior.
+          - name: Components v2 messages
+            description: Components v2 messages, buttons, string/user/role/mentionable/channel selects, modal triggers, and modal submits
+          - name: Callback TTL
+            description: Callback TTL, reusable versus single-use callbacks, persistent callback registry entries, allowedUsers, guild/DM/group authz, and plugin interactive callback dispatch
+        docs:
+          - docs/channels/discord.md
+          - docs/tools/slash-commands.md
+        search_anchors:
+          - discord native slash commands, components, and interactive callbacks
+          - native slash commands, components, and interactive callbacks
+        category_note: native-slash-commands-components-and-interactive-callbacks.md
+        human_lts_override: false
+      - name: Realtime Voice and Calls
+        features:
+          - name: Voice Channel Lifecycle
+            description: Covers Voice Channel Lifecycle across Includes Discord voice channel sessions controlled by `/vc join`, `/vc status`, and `/vc leave`; config-driven `autoJoin`; `followUsers`; voice/stage channel allowlists; connect/reconnect and DAVE handling; `stt-tts`, `agent-proxy`, and related realtime voice channels behavior.
+          - name: Auto-join and follow-users
+            description: Covers Auto-join and follow-users across Includes Discord voice channel sessions controlled by `/vc join`, `/vc status`, and `/vc leave`; config-driven `autoJoin`; `followUsers`; voice/stage channel allowlists; connect/reconnect and DAVE handling; `stt-tts`, `agent-proxy`, and related realtime voice channels behavior.
+          - name: Realtime voice modes
+            description: Covers Realtime voice modes across Includes Discord voice channel sessions controlled by `/vc join`, `/vc status`, and `/vc leave`; config-driven `autoJoin`; `followUsers`; voice/stage channel allowlists; connect/reconnect and DAVE handling; `stt-tts`, `agent-proxy`, and related realtime voice channels behavior.
+          - name: Wake, barge-in, and echo handling
+            description: Covers Wake, barge-in, and echo handling across Includes Discord voice channel sessions controlled by `/vc join`, `/vc status`, and `/vc leave`; config-driven `autoJoin`; `followUsers`; voice/stage channel allowlists; connect/reconnect and DAVE handling; `stt-tts`, `agent-proxy`, and related realtime voice channels behavior.
+          - name: Voice codec and DAVE recovery
+            description: Covers Voice codec and DAVE recovery across Includes Discord voice channel sessions controlled by `/vc join`, `/vc status`, and `/vc leave`; config-driven `autoJoin`; `followUsers`; voice/stage channel allowlists; connect/reconnect and DAVE handling; `stt-tts`, `agent-proxy`, and related realtime voice channels behavior.
+        docs:
+          - docs/channels/discord.md
+          - docs/providers/openai.md
+          - docs/providers/elevenlabs.md
+          - docs/concepts/qa-e2e-automation.md
+          - docs/gateway/config-channels.md
+        search_anchors:
+          - /vc lifecycle
+          - Auto-join and follow-users
+          - Realtime voice modes
+          - Wake, barge-in, and echo handling
+          - Voice codec and DAVE recovery
+        category_note: realtime-discord-voice-channels.md
+        human_lts_override: false
+    last_score_run:
+      status: complete
+      completed_at: '2026-05-30'
+      by: codex
+      source_ref: null
+      process_version: 3
+  - id: telegram
+    name: Telegram
+    family: channel
+    level: beta
+    level_code: M3
+    rationale: Core channel is mature enough for regular use, but high-variance UX and media edge cases need recurring scenario proof.
+    completeness_instructions: references/completeness/telegram.md
+    categories:
+      - name: Channel Setup and Operations
+        features:
+          - name: BotFather token creation
+            description: BotFather token creation and first gateway start
+          - name: TELEGRAM_BOT_TOKEN
+            description: TELEGRAM_BOT_TOKEN, botToken, tokenFile, and account-scoped token
+          - name: Setup wizard credential capture
+            description: Setup wizard credential capture, allowlist prompts, and DM policy defaults
+          - name: Startup getMe
+            description: Startup getMe, bot-info cache, account throttling, and multi-account default
+          - name: Doctor/status surfacing
+            description: Doctor/status surfacing for invalid tokens, missing defaults, and read-only
+          - name: Named account configuration
+            description: Named account configuration, default account selection, account-local group
+          - name: CLI/message-tool targets
+            description: numeric chat IDs, usernames, forum-topic
+          - name: Directory adapters
+            description: Directory adapters and configured peers/groups for user-facing target lists
+          - name: Channel status
+            description: Channel status, channels status --probe, token source summaries, liveness
+          - name: Account-scoped outbound
+            description: Account-scoped outbound, poll, media, and approval target resolution
+        docs:
+          - docs/channels/telegram.md
+          - docs/gateway/config-channels.md
+          - docs/cli/channels.md
+        search_anchors:
+          - telegram bot setup and account configuration
+          - bot setup and account configuration
+          - telegram multi account cli targets and status
+          - multi account cli targets and status
+        category_note: bot-setup-and-account-configuration.md
+        human_lts_override: true
+      - name: Access and Identity
+        features:
+          - name: dmPolicy modes
+            description: pairing, allowlist, open, and disabled
+          - name: Pairing-code approval
+            description: Pairing-code approval, first-owner bootstrap, and commands.ownerAllowFrom
+          - name: Numeric Telegram user ID normalization with telegram
+            description: 'and tg: prefixes'
+          - name: allowFrom
+            description: allowFrom, groupAllowFrom, access groups, and DM-versus-group boundaries
+          - name: Unauthorized DM
+            description: Unauthorized DM, group, command, callback, and reaction handling
+          - name: Group allowlists
+            description: Group allowlists, groupPolicy, groupAllowFrom, and mention gating
+          - name: Supergroup negative chat IDs
+            description: Supergroup negative chat IDs and group/topic config inheritance
+          - name: Forum topic session keys
+            description: Forum topic session keys, message_thread_id, General topic behavior, and topic routing.
+          - name: ACP topic routing
+            description: ACP topic binding and /acp spawn --thread
+          - name: Session key construction
+            description: Session key construction, conversation route matching, and reply target
+        docs:
+          - docs/channels/telegram.md
+          - docs/channels/pairing.md
+          - docs/channels/access-groups.md
+          - docs/channels/groups.md
+          - docs/concepts/multi-agent.md
+        search_anchors:
+          - telegram dm pairing and sender authorization
+          - dm pairing and sender authorization
+          - telegram group forum topic and session routing
+          - group forum topic and session routing
+        category_note: dm-pairing-and-sender-authorization.md
+        human_lts_override: true
+      - name: Conversation Routing and Delivery
+        features:
+          - name: Conversation Routing and Delivery
+            description: Evidence scope for Conversation Routing and Delivery.
+        docs:
+          - docs/channels/telegram.md
+          - docs/channels/groups.md
+          - docs/concepts/multi-agent.md
+        search_anchors:
+          - telegram conversation routing and delivery
+          - conversation routing and delivery
+        category_note: group-forum-topic-and-session-routing.md
+        human_lts_override: true
+      - name: Media and Rich Content
+        features:
+          - name: Media and Rich Content
+            description: Evidence scope for Media and Rich Content.
+        docs:
+          - docs/channels/telegram.md
+          - docs/channels/location.md
+        search_anchors:
+          - telegram media and rich content
+          - media and rich content
+        category_note: media-location-polls-and-rich-inputs.md
+        human_lts_override: true
+      - name: Native Controls and Approvals
+        features:
+          - name: Inline keyboard rendering
+            description: Inline keyboard rendering, callback query handling, Mini App URL buttons, and approval callbacks.
+          - name: Exec approvals in DMs
+            description: Exec approvals in DMs, channels, topics, or both; approver resolution; plugin
+          - name: Message actions
+            description: send, poll, react, delete, edit, sticker, and sticker search actions.
+          - name: Action capability discovery
+            description: Action capability discovery, gating config, account-scoped action gates, and requester trust checks.
+          - name: Native setMyCommands startup sync
+            description: Native setMyCommands startup sync, custom commands, native aliases, plugin
+          - name: Command name/description normalization
+            description: Command name/description normalization, menu budget trimming, duplicate
+          - name: Built-in commands
+            description: Built-in commands such as /help, /commands, /whoami, /status, and related command UI.
+          - name: Command authorization in DMs
+            description: Command authorization in DMs, groups, and commands addressed to other bots
+          - name: Model buttons
+            description: Model buttons and command UI helpers
+        docs:
+          - docs/channels/telegram.md
+          - docs/tools/exec-approvals.md
+          - docs/tools/reactions.md
+        search_anchors:
+          - telegram inline buttons approvals and actions
+          - inline buttons approvals and actions
+          - telegram native commands and command ui
+          - native commands and command ui
+        category_note: inline-buttons-approvals-and-actions.md
+        human_lts_override: true
+    last_score_run:
+      status: complete
+      completed_at: '2026-05-30'
+      by: codex
+      source_ref: null
+      process_version: 3
+  - id: whatsapp
+    name: WhatsApp
+    family: channel
+    level: beta
+    level_code: M3
+    rationale: Core path is important and documented; upstream Baileys/session volatility keeps it below Stable.
+    completeness_instructions: references/completeness/whatsapp.md
+    categories:
+      - name: Channel Setup and Operations
+        features:
+          - name: Official @openclaw/whatsapp plugin metadata
+            description: Official @openclaw/whatsapp plugin metadata, package entrypoints, and setup discovery.
+          - name: openclaw plugin install whatsapp
+            description: openclaw plugin install whatsapp and config-first setup guidance
+          - name: Channel config schema
+            description: Channel config schema, plugin hooks, setup finalization, default account, and secret handling.
+          - name: Baileys socket lifecycle
+            description: Baileys socket lifecycle, connection controller state, reconnect decisions, and repair status.
+          - name: Operator troubleshooting
+            description: Operator troubleshooting for reconnect loops, stale sockets, Bun/Node runtime
+        docs:
+          - docs/channels/whatsapp.md
+          - docs/gateway/config-channels.md
+          - docs/plugins/reference/whatsapp.md
+          - docs/concepts/qa-e2e-automation.md
+          - docs/gateway/doctor.md
+        search_anchors:
+          - whatsapp operator install and configuration
+          - operator install and configuration
+          - whatsapp runtime health reconnect and doctor
+          - runtime health reconnect and doctor
+        category_note: operator-install-and-configuration.md
+        human_lts_override: false
+      - name: Access and Identity
+        features:
+          - name: QR login
+            description: QR login and agent login QR flows
+          - name: Baileys multi-file auth persistence
+            description: Baileys multi-file auth persistence, queued credential writes, backup restore, and login recovery.
+          - name: DM pairing challenge
+            description: DM pairing challenge and allow-store persistence where it intersects WhatsApp
+          - name: Multi-account/default-account resolution
+            description: Multi-account/default-account resolution and Baileys 515/401 recovery
+          - name: Direct-message dmPolicy
+            description: Direct-message dmPolicy, allowFrom, pairing challenge, pairing-store
+          - name: Sender identity extraction
+            description: Sender identity extraction, read receipts, self-chat safeguards, and contact matching.
+          - name: Privacy controls for plugin hooks
+            description: Privacy controls for plugin hooks and untrusted context
+        docs:
+          - docs/channels/whatsapp.md
+          - docs/gateway/config-channels.md
+          - docs/concepts/qa-e2e-automation.md
+          - docs/channels/pairing.md
+        search_anchors:
+          - whatsapp pairing login and session auth
+          - pairing login and session auth
+          - whatsapp inbound dm access and privacy
+          - inbound dm access and privacy
+        category_note: pairing-login-and-session-auth.md
+        human_lts_override: false
+      - name: Conversation Routing and Delivery
+        features:
+          - name: Group allowlists
+            description: Group allowlists, groupPolicy, exact group JIDs, requireMention, owner
+          - name: Group session keys
+            description: Group session keys, broadcast fanout, outbound mentions, and group prompt
+          - name: Outbound text sends
+            description: Outbound text sends, message-tool delivery, explicit DM/group/newsletter
+          - name: Provider-accepted receipts
+            description: Provider-accepted receipts and durable delivery identifiers
+        docs:
+          - docs/channels/whatsapp.md
+          - docs/channels/group-messages.md
+        search_anchors:
+          - whatsapp group routing and activation
+          - group routing and activation
+          - whatsapp outbound delivery and targeting
+          - outbound delivery and targeting
+        category_note: group-routing-and-activation.md
+        human_lts_override: false
+      - name: Media and Rich Content
+        features:
+          - name: Inbound media download
+            description: Inbound media download and placeholder construction, quoted media extraction, and file handoff.
+          - name: Outbound image
+            description: Outbound image, audio, video, document, and voice-note payload construction.
+        docs:
+          - docs/channels/whatsapp.md
+        search_anchors:
+          - whatsapp media attachments and voice
+          - media attachments and voice
+        category_note: media-attachments-and-voice.md
+        human_lts_override: false
+      - name: Native Controls and Approvals
+        features:
+          - name: Native exec
+            description: Native exec and plugin approval delivery through WhatsApp
+          - name: Approver target resolution
+            description: Approver target resolution, DM/group target eligibility, route suppression, and approval delivery.
+        docs:
+          - docs/channels/whatsapp.md
+        search_anchors:
+          - whatsapp native approvals and reactions
+          - native approvals and reactions
+        category_note: native-approvals-and-reactions.md
+        human_lts_override: false
+    last_score_run:
+      status: complete
+      completed_at: '2026-05-30'
+      by: codex
+      source_ref: null
+      process_version: 3
+  - id: slack
+    name: Slack
+    family: channel
+    level: beta
+    level_code: M3
+    rationale: First-class channel docs and routing surface. Needs workspace install/admin scenario scorecards.
+    completeness_instructions: references/completeness/slack.md
+    categories:
+      - name: Channel Setup and Operations
+        features:
+          - name: App Install
+            description: Covers App Install across installing `@openclaw/slack`, creating the Slack app, choosing recommended/minimal manifests, bot/app/user/signing-secret credential handling, and related app install, auth, manifest, and scopes behavior.
+          - name: Slack app credentials
+            description: Covers bot/app/user tokens, signing-secret handling, and Slack credential setup for app authentication.
+          - name: Manifest
+            description: Covers Manifest across installing `@openclaw/slack`, creating the Slack app, choosing recommended/minimal manifests, bot/app/user/signing-secret credential handling, and related app install, auth, manifest, and scopes behavior.
+          - name: Scopes
+            description: Covers Scopes across installing `@openclaw/slack`, creating the Slack app, choosing recommended/minimal manifests, bot/app/user/signing-secret credential handling, and related app install, auth, manifest, and scopes behavior.
+          - name: Channel status diagnostics
+            description: Covers `openclaw channels status --probe`, account snapshots, token source/status fields, capability and scope diagnostics, and Slack repair guidance.
+          - name: Slack account status
+            description: Covers account snapshots, token source/status fields, capability summaries, and Slack status output.
+          - name: Operator Repair
+            description: Covers Operator Repair across `openclaw channels status --probe`, account snapshots, token source/status fields, capability and scope diagnostics, and related diagnostics, status, and operator repair behavior.
+          - name: Socket
+            description: Covers Socket across Socket Mode startup/reconnect/backoff, HTTP Request URL registration and signing-secret verification, transport mode selection, multi-account lifecycle, status/liveness, and runtime startup/skip behavior.
+          - name: HTTP transport
+            description: Covers HTTP Request URL registration, signing-secret verification, transport mode selection, multi-account lifecycle, status/liveness, and Slack HTTP runtime startup/skip behavior.
+          - name: Runtime Lifecycle
+            description: Covers Runtime Lifecycle across Socket Mode startup/reconnect/backoff, HTTP Request URL registration and signing-secret verification, transport mode selection, multi-account lifecycle, status/liveness, and runtime startup/skip behavior.
+        docs:
+          - docs/channels/slack.md
+          - docs/plugins/reference/slack.md
+          - docs/gateway/secrets.md
+          - docs/concepts/qa-e2e-automation.md
+          - docs/channels/troubleshooting.md
+        search_anchors:
+          - App Install
+          - bot token
+          - signing secret
+          - Manifest
+          - Scopes
+          - recommended manifest
+          - minimal manifest
+          - openclaw channels status --probe
+          - capability and scope diagnostics
+          - account snapshots
+          - Operator Repair
+          - slack diagnostics, status, and operator repair
+          - diagnostics, status, and operator repair
+          - Socket
+          - HTTP Request URL
+          - Runtime Lifecycle
+          - slack socket/http transport and runtime lifecycle
+          - socket/http transport and runtime lifecycle
+        category_note: app-install-auth-manifest-and-scopes.md
+        human_lts_override: true
+      - name: Access and Identity
+        features:
+          - name: Access and Identity
+            description: Evidence scope for Access and Identity.
+        docs:
+          - docs/channels/slack.md
+          - docs/channels/pairing.md
+        search_anchors:
+          - slack access and identity
+          - access and identity
+        category_note: dm-pairing-and-sender-authorization.md
+        human_lts_override: true
+      - name: Conversation Routing and Delivery
+        features:
+          - name: Channel allowlists
+            description: Covers channel allowlists, `groupPolicy`, channel/user gates, mention gates, and subteam mention behavior.
+          - name: Thread routing
+            description: Covers Slack thread routing, thread-aware reply targeting, and session binding for channel threads.
+          - name: Session Isolation
+            description: Covers Session Isolation across channel allowlists, `groupPolicy`, channel/user gates, mention and subteam mention behavior, and related channel/thread routing and session isolation behavior.
+          - name: DM Pairing
+            description: Covers DM Pairing across Slack DM routing, `dmPolicy`, `allowFrom`, pairing approvals, group DMs/MPIMs, account-level allowlist inheritance, command authorization in DMs, and sender identity normalization.
+          - name: Sender Authorization
+            description: Covers Sender Authorization across Slack DM routing, `dmPolicy`, `allowFrom`, pairing approvals, group DMs/MPIMs, account-level allowlist inheritance, command authorization in DMs, and sender identity normalization.
+        docs:
+          - docs/channels/slack.md
+          - docs/channels/bot-loop-protection.md
+          - docs/channels/pairing.md
+        search_anchors:
+          - channel allowlists
+          - Thread routing
+          - Session Isolation
+          - groupPolicy
+          - subteam mention
+          - DM Pairing
+          - Sender Authorization
+          - slack dm pairing and sender authorization
+          - dm pairing and sender authorization
+        category_note: channel-thread-routing-and-session-isolation.md
+        human_lts_override: true
+      - name: Media and Rich Content
+        features:
+          - name: Media and Rich Content
+            description: Evidence scope for Media and Rich Content.
+        docs:
+          - docs/channels/slack.md
+          - docs/concepts/qa-e2e-automation.md
+        search_anchors:
+          - slack media and rich content
+          - media and rich content
+        category_note: media-attachments-files-and-vision.md
+        human_lts_override: true
+      - name: Native Controls and Approvals
+        features:
+          - name: Slash Commands
+            description: Covers Slash Commands across configured slash command mode, native slash commands, command registration expectations, session keys, and related slash commands and native command routing behavior.
+          - name: Native Command Routing
+            description: Covers Native Command Routing across configured slash command mode, native slash commands, command registration expectations, session keys, and related slash commands and native command routing behavior.
+          - name: Interactive Replies
+            description: Covers Interactive Replies across App Home publish/open behavior, Slack assistant thread started/context-changed events, block actions, modal submissions, and related interactive replies, app home, and assistant events behavior.
+          - name: App Home
+            description: Covers App Home across App Home publish/open behavior, Slack assistant thread started/context-changed events, block actions, modal submissions, and related interactive replies, app home, and assistant events behavior.
+          - name: Assistant Events
+            description: Covers Assistant Events across App Home publish/open behavior, Slack assistant thread started/context-changed events, block actions, modal submissions, and related interactive replies, app home, and assistant events behavior.
+          - name: Native Approvals
+            description: Covers Native Approvals across Slack native exec and plugin approvals, Block Kit approval prompts, approval auth, approval routing, and related native approvals, actions, and security-sensitive ops behavior.
+          - name: Actions
+            description: Covers Actions across Slack native exec and plugin approvals, Block Kit approval prompts, approval auth, approval routing, and related native approvals, actions, and security-sensitive ops behavior.
+          - name: Security-sensitive Ops
+            description: Covers Security-sensitive Ops across Slack native exec and plugin approvals, Block Kit approval prompts, approval auth, approval routing, and related native approvals, actions, and security-sensitive ops behavior.
+        docs:
+          - docs/channels/slack.md
+          - docs/tools/slash-commands.md
+          - docs/tools/exec-approvals.md
+        search_anchors:
+          - Slash Commands
+          - Native Command Routing
+          - slack slash commands and native command routing
+          - slash commands and native command routing
+          - Interactive Replies
+          - App Home
+          - Assistant Events
+          - slack interactive replies, app home, and assistant events
+          - interactive replies, app home, and assistant events
+          - Native Approvals
+          - Actions
+          - Security-sensitive Ops
+          - slack native approvals, actions, and security-sensitive ops
+          - native approvals, actions, and security-sensitive ops
+        category_note: slash-commands-and-native-command-routing.md
+        human_lts_override: true
+    last_score_run:
+      status: complete
+      completed_at: '2026-05-30'
+      by: codex
+      source_ref: null
+      process_version: 3
+  - id: imessage-bluebubbles
+    name: iMessage / BlueBubbles
+    family: channel
+    level: beta
+    level_code: M3
+    rationale: Supported iMessage runs through imsg on a signed-in macOS Messages host; legacy BlueBubbles configs require migration. Keep macOS permissions, SSH wrapper, SIP/private API, and migration caveats visible.
+    completeness_instructions: references/completeness/imessage-bluebubbles.md
+    categories:
+      - name: Channel Setup and Operations
+        features:
+          - name: Translate legacy config
+            description: Covers Translate legacy config across removal announcement, migration guide, config reference, old `channels.bluebubbles` key translation, group registry footgun, session caveats, attachment/action parity notes, and operator cutover checklist.
+          - name: Cut over safely
+            description: Covers Cut over safely across removal announcement, migration guide, config reference, old `channels.bluebubbles` key translation, group registry footgun, session caveats, attachment/action parity notes, and operator cutover checklist.
+          - name: Handle migration caveats
+            description: Covers Handle migration caveats across removal announcement, migration guide, config reference, old `channels.bluebubbles` key translation, group registry footgun, session caveats, attachment/action parity notes, and operator cutover checklist.
+          - name: Run local imsg
+            description: Covers Run local imsg across local and remote `imsg rpc`, `cliPath`, `dbPath`, `remoteHost`, and related imsg transport, host requirements, and permissions behavior.
+          - name: Run through SSH wrapper
+            description: Covers Run through SSH wrapper across local and remote `imsg rpc`, `cliPath`, `dbPath`, `remoteHost`, and related imsg transport, host requirements, and permissions behavior.
+          - name: Grant macOS permissions
+            description: Covers Grant macOS permissions across local and remote `imsg rpc`, `cliPath`, `dbPath`, `remoteHost`, and related imsg transport, host requirements, and permissions behavior.
+          - name: Probe runtime health
+            description: Covers Probe runtime health across local and remote `imsg rpc`, `cliPath`, `dbPath`, `remoteHost`, and related imsg transport, host requirements, and permissions behavior.
+          - name: Account setup prompts
+            description: Covers setup prompts, policy writes, account merging, default account selection, and account configuration behavior for iMessage/BlueBubbles.
+          - name: Account status checks
+            description: Covers account status output, setup state, account merging, and default account selection for iMessage/BlueBubbles.
+          - name: Doctor repair checks
+            description: Covers doctor checks, setup repair prompts, and policy verification for iMessage/BlueBubbles account configuration.
+          - name: Account Config
+            description: Covers Account Config across setup prompts, policy writes, account merging, default account selection, and related setup, status, doctor, and account config behavior.
+        docs:
+          - docs/announcements/bluebubbles-imessage.md
+          - docs/channels/imessage-from-bluebubbles.md
+          - docs/gateway/config-channels.md
+          - docs/channels/imessage.md
+        search_anchors:
+          - Translate legacy config
+          - Cut over safely
+          - Handle migration caveats
+          - Run local imsg
+          - Run through SSH wrapper
+          - Grant macOS permissions
+          - Probe runtime health
+          - setup prompts
+          - policy writes
+          - account status
+          - doctor checks
+          - Account Config
+          - imessage / bluebubbles setup, status, doctor, and account config
+          - setup, status, doctor, and account config
+        category_note: setup-status-doctor-and-account-config.md
+        human_lts_override: false
+      - name: Access and Identity
+        features:
+          - name: Authorize direct senders
+            description: Covers Authorize direct senders across `dmPolicy`, `allowFrom`, pairing, sender identity normalization, and related dm pairing, access, and session routing behavior.
+          - name: Route direct conversations
+            description: Covers Route direct conversations across `dmPolicy`, `allowFrom`, pairing, sender identity normalization, and related dm pairing, access, and session routing behavior.
+          - name: Bind ACP sessions
+            description: Covers Bind ACP sessions across `dmPolicy`, `allowFrom`, pairing, sender identity normalization, and related dm pairing, access, and session routing behavior.
+          - name: Group Policy
+            description: Covers Group Policy across `groupPolicy`, `groupAllowFrom`, `groups`, wildcard registry entries, `requireMention`, mention patterns, per-group tools, per-group system prompts, group sessions, and warnings for allowlist misconfiguration.
+          - name: Mentions
+            description: Covers Mentions across `groupPolicy`, `groupAllowFrom`, `groups`, wildcard registry entries, `requireMention`, mention patterns, per-group tools, per-group system prompts, group sessions, and warnings for allowlist misconfiguration.
+          - name: System Prompts
+            description: Covers System Prompts across `groupPolicy`, `groupAllowFrom`, `groups`, wildcard registry entries, `requireMention`, mention patterns, per-group tools, per-group system prompts, group sessions, and warnings for allowlist misconfiguration.
+        docs:
+          - docs/channels/imessage.md
+          - docs/channels/imessage-from-bluebubbles.md
+          - docs/gateway/config-channels.md
+        search_anchors:
+          - Authorize direct senders
+          - Route direct conversations
+          - Bind ACP sessions
+          - Group Policy
+          - Mentions
+          - System Prompts
+          - imessage / bluebubbles group policy, mentions, and system prompts
+          - group policy, mentions, and system prompts
+        category_note: dm-pairing-access-and-session-routing.md
+        human_lts_override: false
+      - name: Conversation Routing and Delivery
+        features:
+          - name: Watch live messages
+            description: Covers Watch live messages across inbound `watch.subscribe`, notification parsing, echo and self-chat guards, sent-message cache, same-sender DM coalescing, DM history, reaction event routing, catchup cursor/replay, and live cursor advancement.
+          - name: Coalesce split-send DMs
+            description: Covers Coalesce split-send DMs across inbound `watch.subscribe`, notification parsing, echo and self-chat guards, sent-message cache, same-sender DM coalescing, DM history, reaction event routing, catchup cursor/replay, and live cursor advancement.
+          - name: Replay missed messages
+            description: Covers Replay missed messages across inbound `watch.subscribe`, notification parsing, echo and self-chat guards, sent-message cache, same-sender DM coalescing, DM history, reaction event routing, catchup cursor/replay, and live cursor advancement.
+          - name: Seed conversation history
+            description: Covers Seed conversation history across inbound `watch.subscribe`, notification parsing, echo and self-chat guards, sent-message cache, same-sender DM coalescing, DM history, reaction event routing, catchup cursor/replay, and live cursor advancement.
+        docs:
+          - docs/channels/imessage.md
+        search_anchors:
+          - Watch live messages
+          - Coalesce split-send DMs
+          - Replay missed messages
+          - Seed conversation history
+        category_note: inbound-monitoring-coalescing-catchup-and-history.md
+        human_lts_override: false
+      - name: Media and Rich Content
+        features:
+          - name: Media
+            description: Covers Media across `includeAttachments`, attachment root allowlists, remote attachment roots, `remoteHost` SCP fetches, HEIC conversion, size caps, outbound media sends, `send-attachment`, text chunking, and media receipts.
+          - name: Attachments
+            description: Covers Attachments across `includeAttachments`, attachment root allowlists, remote attachment roots, `remoteHost` SCP fetches, HEIC conversion, size caps, outbound media sends, `send-attachment`, text chunking, and media receipts.
+          - name: Remote Fetch
+            description: Covers Remote Fetch across `includeAttachments`, attachment root allowlists, remote attachment roots, `remoteHost` SCP fetches, HEIC conversion, size caps, outbound media sends, `send-attachment`, text chunking, and media receipts.
+          - name: Chunking
+            description: Covers Chunking across `includeAttachments`, attachment root allowlists, remote attachment roots, `remoteHost` SCP fetches, HEIC conversion, size caps, outbound media sends, `send-attachment`, text chunking, and media receipts.
+          - name: Native Actions
+            description: Covers Native Actions across private API probing, action availability, action config gates, tapback mapping, edit/unsend/reply/effects/group management, `send-rich --file`, message-tool visibility/target grammar, and action dispatch errors.
+          - name: Private API
+            description: Covers Private API across private API probing, action availability, action config gates, tapback mapping, edit/unsend/reply/effects/group management, `send-rich --file`, message-tool visibility/target grammar, and action dispatch errors.
+          - name: Message Tool
+            description: Covers Message Tool across private API probing, action availability, action config gates, tapback mapping, edit/unsend/reply/effects/group management, `send-rich --file`, message-tool visibility/target grammar, and action dispatch errors.
+        docs:
+          - docs/channels/imessage.md
+          - docs/channels/imessage-from-bluebubbles.md
+          - docs/gateway/config-channels.md
+        search_anchors:
+          - Media
+          - Attachments
+          - Remote Fetch
+          - Chunking
+          - imessage / bluebubbles media, attachments, remote fetch, and chunking
+          - media, attachments, remote fetch, and chunking
+          - Native Actions
+          - Private API
+          - Message Tool
+          - imessage / bluebubbles native actions, private api, and message tool
+          - native actions, private api, and message tool
+        category_note: media-attachments-remote-fetch-and-chunking.md
+        human_lts_override: false
+      - name: Native Controls and Approvals
+        features:
+          - name: Native Approvals
+            description: Covers Native Approvals across native approval delivery, exec/plugin approval routing, reaction-based approval decisions, `/approve` authorization changes, and related native approvals, reactions, and operator control behavior.
+          - name: Reactions
+            description: Covers Reactions across native approval delivery, exec/plugin approval routing, reaction-based approval decisions, `/approve` authorization changes, and related native approvals, reactions, and operator control behavior.
+          - name: Operator Control
+            description: Covers Operator Control across native approval delivery, exec/plugin approval routing, reaction-based approval decisions, `/approve` authorization changes, and related native approvals, reactions, and operator control behavior.
+        docs:
+          - docs/channels/imessage.md
+        search_anchors:
+          - Native Approvals
+          - Reactions
+          - Operator Control
+          - imessage / bluebubbles native approvals, reactions, and operator control
+          - native approvals, reactions, and operator control
+        category_note: native-approvals-reactions-and-operator-control.md
+        human_lts_override: false
+    last_score_run:
+      status: complete
+      completed_at: '2026-05-30'
+      by: codex
+      source_ref: null
+      process_version: 3
+  - id: signal
+    name: Signal
+    family: channel
+    level: alpha
+    level_code: M2
+    rationale: Supported channel docs exist; needs stronger install and reconnect proof.
+    completeness_instructions: references/completeness/signal.md
+    categories:
+      - name: Channel Setup and Operations
+        features:
+          - name: QR link setup
+            description: Defines QR link setup setup, credential, configuration, and operator verification behavior for Setup, Install, and Account Provisioning.
+          - name: SMS registration
+            description: Defines SMS registration setup, credential, configuration, and operator verification behavior for Setup, Install, and Account Provisioning.
+          - name: Installer and binary setup
+            description: Defines Installer and binary setup setup, credential, configuration, and operator verification behavior for Setup, Install, and Account Provisioning.
+          - name: Container account provisioning
+            description: Defines Container account provisioning setup, credential, configuration, and operator verification behavior for Setup, Install, and Account Provisioning.
+          - name: Status probes
+            description: Defines Status probes setup, credential, configuration, and operator verification behavior for Diagnostics, Config Status, and Operator Guardrails.
+          - name: Setup diagnostics
+            description: Defines Setup diagnostics setup, credential, configuration, and operator verification behavior for Diagnostics, Config Status, and Operator Guardrails.
+          - name: Account safety guardrails
+            description: Defines Account safety guardrails setup, credential, configuration, and operator verification behavior for Diagnostics, Config Status, and Operator Guardrails.
+        docs:
+          - docs/channels/signal.md
+          - docs/plugins/reference/signal.md
+        search_anchors:
+          - QR link setup
+          - SMS registration
+          - Installer and binary setup
+          - Container account provisioning
+          - dmPolicy
+          - allowFrom
+          - groupPolicy
+          - requireMention
+          - Status probes
+          - Setup diagnostics
+          - Account safety guardrails
+          - historyLimit
+        category_note: setup-install-account-provisioning.md
+        human_lts_override: false
+      - name: Access and Identity
+        features:
+          - name: DM pairing
+            description: Defines DM pairing setup, credential, configuration, and operator verification behavior for DM Pairing and Access Control.
+          - name: DM allowlists
+            description: Defines DM allowlists setup, credential, configuration, and operator verification behavior for DM Pairing and Access Control.
+          - name: Sender identity normalization
+            description: Defines Sender identity normalization setup, credential, configuration, and operator verification behavior for DM Pairing and Access Control.
+          - name: Group allowlists
+            description: Defines Group allowlists authorization, trust, safety boundaries, and operator controls for Group Routing, Mentions, and Pending History.
+          - name: Mention gates
+            description: Defines Mention gates authorization, trust, safety boundaries, and operator controls for Group Routing, Mentions, and Pending History.
+          - name: Pending group history
+            description: Defines Pending group history authorization, trust, safety boundaries, and operator controls for Group Routing, Mentions, and Pending History.
+        docs:
+          - docs/channels/signal.md
+        search_anchors:
+          - DM pairing
+          - DM allowlists
+          - Sender identity normalization
+          - dmPolicy
+          - allowFrom
+          - groupPolicy
+          - requireMention
+          - historyLimit
+          - Group allowlists
+          - Mention gates
+          - Pending group history
+        category_note: dm-pairing-access-control.md
+        human_lts_override: false
+      - name: Conversation Routing and Delivery
+        features:
+          - name: Conversation Routing and Delivery
+            description: Evidence scope for Conversation Routing and Delivery.
+        docs:
+          - docs/channels/signal.md
+        search_anchors:
+          - signal conversation routing and delivery
+          - conversation routing and delivery
+        category_note: group-routing-mention-history.md
+        human_lts_override: false
+      - name: Media and Rich Content
+        features:
+          - name: Text delivery targets
+            description: Covers Text delivery targets routing, session binding, history, and conversation context for Outbound Delivery, Media, Receipts, and Typing.
+          - name: Media delivery and limits
+            description: Covers Media delivery and limits routing, session binding, history, and conversation context for Outbound Delivery, Media, Receipts, and Typing.
+          - name: Typing and read receipts
+            description: Covers Typing and read receipts routing, session binding, history, and conversation context for Outbound Delivery, Media, Receipts, and Typing.
+          - name: Styled/chunked output
+            description: Covers Styled/chunked output routing, session binding, history, and conversation context for Outbound Delivery, Media, Receipts, and Typing.
+          - name: Reaction action discovery
+            description: Covers Reaction action discovery routing, session binding, history, and conversation context for Reactions Message Tool.
+          - name: Add/remove reactions
+            description: Covers Add/remove reactions routing, session binding, history, and conversation context for Reactions Message Tool.
+          - name: Group reaction targeting
+            description: Covers Group reaction targeting routing, session binding, history, and conversation context for Reactions Message Tool.
+        docs:
+          - docs/channels/signal.md
+        search_anchors:
+          - Text delivery targets
+          - Media delivery and limits
+          - Typing and read receipts
+          - Styled/chunked output
+          - dmPolicy
+          - allowFrom
+          - groupPolicy
+          - requireMention
+          - Reaction action discovery
+          - Add/remove reactions
+          - Group reaction targeting
+          - historyLimit
+        category_note: outbound-delivery-media-receipts.md
+        human_lts_override: false
+      - name: Native Controls and Approvals
+        features:
+          - name: Native approval routing
+            description: Defines Native approval routing authorization, trust, safety boundaries, and operator controls for Approval Routing and Reaction Resolution.
+          - name: Reaction approval responses
+            description: Defines Reaction approval responses authorization, trust, safety boundaries, and operator controls for Approval Routing and Reaction Resolution.
+          - name: Approver targeting
+            description: Defines Approver targeting authorization, trust, safety boundaries, and operator controls for Approval Routing and Reaction Resolution.
+        docs:
+          - docs/channels/signal.md
+        search_anchors:
+          - Native approval routing
+          - Reaction approval responses
+          - Approver targeting
+          - dmPolicy
+          - allowFrom
+          - groupPolicy
+          - requireMention
+          - historyLimit
+        category_note: approval-routing-reaction-resolution.md
+        human_lts_override: false
+    last_score_run:
+      status: complete
+      completed_at: '2026-05-30'
+      by: codex
+      source_ref: null
+      process_version: 3
+  - id: google-chat
+    name: Google Chat
+    family: channel
+    level: alpha
+    level_code: M2
+    rationale: Documented channel, but enterprise/admin setup raises maturity risk.
+    completeness_instructions: references/completeness/google-chat.md
+    categories:
+      - name: Channel Setup and Operations
+        features:
+          - name: Google Cloud project setup
+            description: Covers Google Cloud project setup across Google Chat plugin installation, Google Cloud project and Chat API setup, service account JSON/file/env credential selection, `audienceType`, and related setup auth and workspace app behavior.
+          - name: Chat app configuration
+            description: Covers Chat app configuration across Google Chat plugin installation, Google Cloud project and Chat API setup, service account JSON/file/env credential selection, `audienceType`, and related setup auth and workspace app behavior.
+          - name: Service account setup
+            description: Covers Service account setup across Google Chat plugin installation, Google Cloud project and Chat API setup, service account JSON/file/env credential selection, `audienceType`, and related setup auth and workspace app behavior.
+          - name: Webhook audience and path
+            description: Covers Webhook audience and path across Google Chat plugin installation, Google Cloud project and Chat API setup, service account JSON/file/env credential selection, `audienceType`, and related setup auth and workspace app behavior.
+          - name: Workspace visibility and app status
+            description: Covers Workspace visibility and app status across Google Chat plugin installation, Google Cloud project and Chat API setup, service account JSON/file/env credential selection, `audienceType`, and related setup auth and workspace app behavior.
+          - name: Guided channel setup
+            description: Covers Guided channel setup across Google Chat plugin installation, Google Cloud project and Chat API setup, service account JSON/file/env credential selection, `audienceType`, and related setup auth and workspace app behavior.
+          - name: Account resolution
+            description: Covers Account resolution across `accounts`, `defaultAccount`, top-level and account credential inheritance, service account SecretRefs, and related multi account secrets status and diagnostics behavior.
+          - name: Service account SecretRefs
+            description: Covers Service account SecretRefs across `accounts`, `defaultAccount`, top-level and account credential inheritance, service account SecretRefs, and related multi account secrets status and diagnostics behavior.
+          - name: Env file and inline credentials
+            description: Covers Env file and inline credentials across `accounts`, `defaultAccount`, top-level and account credential inheritance, service account SecretRefs, and related multi account secrets status and diagnostics behavior.
+          - name: Channel status and probes
+            description: Covers Channel status and probes across `accounts`, `defaultAccount`, top-level and account credential inheritance, service account SecretRefs, and related multi account secrets status and diagnostics behavior.
+          - name: Directory and mutable-id diagnostics
+            description: Covers Directory and mutable-id diagnostics across `accounts`, `defaultAccount`, top-level and account credential inheritance, service account SecretRefs, and related multi account secrets status and diagnostics behavior.
+          - name: NPM and ClawHub install
+            description: Covers NPM and ClawHub install across npm/ClawHub plugin metadata, docs navigation, plugin references, official external plugin catalog, and related plugin distribution operator ui and docs behavior.
+          - name: Plugin docs and catalog routing
+            description: Covers Plugin docs and catalog routing across npm/ClawHub plugin metadata, docs navigation, plugin references, official external plugin catalog, and related plugin distribution operator ui and docs behavior.
+          - name: Channel aliases and labels
+            description: Covers Channel aliases and labels across npm/ClawHub plugin metadata, docs navigation, plugin references, official external plugin catalog, and related plugin distribution operator ui and docs behavior.
+          - name: Operator status UI
+            description: Covers Operator status UI across npm/ClawHub plugin metadata, docs navigation, plugin references, official external plugin catalog, and related plugin distribution operator ui and docs behavior.
+          - name: Install/update metadata
+            description: Covers Install/update metadata across npm/ClawHub plugin metadata, docs navigation, plugin references, official external plugin catalog, and related plugin distribution operator ui and docs behavior.
+        docs:
+          - docs/channels/googlechat.md
+          - docs/plugins/reference/googlechat.md
+          - docs/gateway/config-channels.md
+          - docs/start/wizard-cli-reference.md
+          - docs/gateway/secrets.md
+          - docs/reference/secretref-credential-surface.md
+          - docs/gateway/health.md
+          - docs/plugins/plugin-inventory.md
+          - docs/channels/index.md
+          - docs/docs.json
+        search_anchors:
+          - Google Cloud project setup
+          - Chat app configuration
+          - Service account setup
+          - Webhook audience and path
+          - Workspace visibility and app status
+          - Guided channel setup
+          - DM pairing
+          - dm.policy
+          - Account resolution
+          - Service account SecretRefs
+          - Env file and inline credentials
+          - Channel status and probes
+          - Directory and mutable-id diagnostics
+          - allowFrom
+          - NPM and ClawHub install
+          - Plugin docs and catalog routing
+          - Channel aliases and labels
+          - Operator status UI
+          - Install/update metadata
+        category_note: setup-auth-and-workspace-app.md
+        human_lts_override: false
+      - name: Access and Identity
+        features:
+          - name: DM pairing approval
+            description: Covers DM pairing approval across Google Chat DMs, `dm.policy`, `dm.allowFrom`, pairing challenges, and related dm pairing and sender authorization behavior.
+          - name: Sender allowlists
+            description: Covers Sender allowlists across Google Chat DMs, `dm.policy`, `dm.allowFrom`, pairing challenges, and related dm pairing and sender authorization behavior.
+          - name: Google Chat identity matching
+            description: Covers Google Chat identity matching across Google Chat DMs, `dm.policy`, `dm.allowFrom`, pairing challenges, and related dm pairing and sender authorization behavior.
+          - name: Direct session routing
+            description: Covers Direct session routing across Google Chat DMs, `dm.policy`, `dm.allowFrom`, pairing challenges, and related dm pairing and sender authorization behavior.
+          - name: Pairing diagnostics
+            description: Covers Pairing diagnostics across Google Chat DMs, `dm.policy`, `dm.allowFrom`, pairing challenges, and related dm pairing and sender authorization behavior.
+          - name: Space allowlists
+            description: Covers Space allowlists across Google Chat spaces and group messages, `groupPolicy`, `groups`, wildcard groups, and related space routing mentions and session isolation behavior.
+          - name: Mention gating
+            description: Covers Mention gating across Google Chat spaces and group messages, `groupPolicy`, `groups`, wildcard groups, and related space routing mentions and session isolation behavior.
+          - name: Sender access groups
+            description: Covers Sender access groups across Google Chat spaces and group messages, `groupPolicy`, `groups`, wildcard groups, and related space routing mentions and session isolation behavior.
+          - name: Group session isolation
+            description: Covers Group session isolation across Google Chat spaces and group messages, `groupPolicy`, `groups`, wildcard groups, and related space routing mentions and session isolation behavior.
+          - name: Bot-loop protection
+            description: Covers Bot-loop protection across Google Chat spaces and group messages, `groupPolicy`, `groups`, wildcard groups, and related space routing mentions and session isolation behavior.
+          - name: Space diagnostics
+            description: Covers Space diagnostics across Google Chat spaces and group messages, `groupPolicy`, `groups`, wildcard groups, and related space routing mentions and session isolation behavior.
+        docs:
+          - docs/channels/googlechat.md
+          - docs/channels/pairing.md
+          - docs/channels/access-groups.md
+          - docs/gateway/config-channels.md
+          - docs/channels/bot-loop-protection.md
+          - docs/channels/channel-routing.md
+        search_anchors:
+          - DM pairing approval
+          - Sender allowlists
+          - Google Chat identity matching
+          - Direct session routing
+          - Pairing diagnostics
+          - DM pairing
+          - dm.policy
+          - allowFrom
+          - Space allowlists
+          - Mention gating
+          - Sender access groups
+          - Group session isolation
+          - Bot-loop protection
+          - Space diagnostics
+        category_note: dm-pairing-and-sender-authorization.md
+        human_lts_override: false
+      - name: Conversation Routing and Delivery
+        features:
+          - name: Conversation Routing and Delivery
+            description: Evidence scope for Conversation Routing and Delivery.
+        docs:
+          - docs/channels/googlechat.md
+          - docs/channels/bot-loop-protection.md
+          - docs/channels/access-groups.md
+          - docs/channels/channel-routing.md
+        search_anchors:
+          - google chat conversation routing and delivery
+          - conversation routing and delivery
+        category_note: space-routing-mentions-and-session-isolation.md
+        human_lts_override: false
+      - name: Media and Rich Content
+        features:
+          - name: Media and Rich Content
+            description: Evidence scope for Media and Rich Content.
+        docs:
+          - docs/channels/googlechat.md
+          - docs/cli/message.md
+          - docs/nodes/media-understanding.md
+          - docs/reference/secretref-credential-surface.md
+        search_anchors:
+          - google chat media and rich content
+          - media and rich content
+        category_note: media-attachments-and-file-transfer.md
+        human_lts_override: false
+      - name: Native Controls and Approvals
+        features:
+          - name: Inbound attachments
+            description: Covers Inbound attachments across inbound Google Chat attachment download, media store handoff, outbound media reply delivery, `upload-file`, and related media attachments and file transfer behavior.
+          - name: Outbound media replies
+            description: Covers Outbound media replies across inbound Google Chat attachment download, media store handoff, outbound media reply delivery, `upload-file`, and related media attachments and file transfer behavior.
+          - name: Message upload action
+            description: Covers Message upload action across inbound Google Chat attachment download, media store handoff, outbound media reply delivery, `upload-file`, and related media attachments and file transfer behavior.
+          - name: Media source and size controls
+            description: Covers Media source and size controls across inbound Google Chat attachment download, media store handoff, outbound media reply delivery, `upload-file`, and related media attachments and file transfer behavior.
+          - name: Media receipts and thread placement
+            description: Covers Media receipts and thread placement across inbound Google Chat attachment download, media store handoff, outbound media reply delivery, `upload-file`, and related media attachments and file transfer behavior.
+          - name: Text send action
+            description: Covers Text send action across Google Chat message tool action discovery, `send`, `upload-file`, `react`, and related message actions reactions and approval auth behavior.
+          - name: Upload-file action
+            description: Covers Upload-file action across Google Chat message tool action discovery, `send`, `upload-file`, `react`, and related message actions reactions and approval auth behavior.
+          - name: Reaction actions
+            description: Covers Reaction actions across Google Chat message tool action discovery, `send`, `upload-file`, `react`, and related message actions reactions and approval auth behavior.
+          - name: Action capability gates
+            description: Covers Action capability gates across Google Chat message tool action discovery, `send`, `upload-file`, `react`, and related message actions reactions and approval auth behavior.
+          - name: Approval sender matching
+            description: Covers Approval sender matching across Google Chat message tool action discovery, `send`, `upload-file`, `react`, and related message actions reactions and approval auth behavior.
+          - name: Thread-aware replies
+            description: Covers Thread-aware replies across inbound thread resource propagation, `replyToMode`, Google Chat `messageReplyOption=REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD`, text chunking, and related threaded replies streaming and typing lifecycle behavior.
+          - name: Streaming and chunked replies
+            description: Covers Streaming and chunked replies across inbound thread resource propagation, `replyToMode`, Google Chat `messageReplyOption=REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD`, text chunking, and related threaded replies streaming and typing lifecycle behavior.
+          - name: Typing placeholder lifecycle
+            description: Covers Typing placeholder lifecycle across inbound thread resource propagation, `replyToMode`, Google Chat `messageReplyOption=REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD`, text chunking, and related threaded replies streaming and typing lifecycle behavior.
+          - name: Message-tool current-source replies
+            description: Covers Message-tool current-source replies across inbound thread resource propagation, `replyToMode`, Google Chat `messageReplyOption=REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD`, text chunking, and related threaded replies streaming and typing lifecycle behavior.
+          - name: NO_REPLY cleanup
+            description: Covers NO_REPLY cleanup across inbound thread resource propagation, `replyToMode`, Google Chat `messageReplyOption=REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD`, text chunking, and related threaded replies streaming and typing lifecycle behavior.
+          - name: Markdown/text rendering
+            description: Covers Markdown/text rendering across inbound thread resource propagation, `replyToMode`, Google Chat `messageReplyOption=REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD`, text chunking, and related threaded replies streaming and typing lifecycle behavior.
+        docs:
+          - docs/channels/googlechat.md
+          - docs/cli/message.md
+          - docs/nodes/media-understanding.md
+          - docs/reference/secretref-credential-surface.md
+          - docs/tools/reactions.md
+          - docs/tools/slash-commands.md
+          - docs/gateway/config-agents.md
+          - docs/concepts/message-lifecycle-refactor.md
+        search_anchors:
+          - Inbound attachments
+          - Outbound media replies
+          - Message upload action
+          - Media source and size controls
+          - Media receipts and thread placement
+          - DM pairing
+          - dm.policy
+          - allowFrom
+          - Text send action
+          - Upload-file action
+          - Reaction actions
+          - Action capability gates
+          - Approval sender matching
+          - Thread-aware replies
+          - Streaming and chunked replies
+          - Typing placeholder lifecycle
+          - Message-tool current-source replies
+          - NO_REPLY cleanup
+          - Markdown/text rendering
+        category_note: message-actions-reactions-and-approval-auth.md
+        human_lts_override: false
+    last_score_run:
+      status: complete
+      completed_at: '2026-05-30'
+      by: codex
+      source_ref: null
+      process_version: 3
+  - id: matrix
+    name: Matrix
+    family: channel
+    level: alpha
+    level_code: M2
+    rationale: Supported via bundled plugin. Needs bridge, auth, and room lifecycle scorecards.
+    completeness_instructions: references/completeness/matrix.md
+    categories:
+      - name: Channel Setup and Operations
+        features:
+          - name: Matrix plugin identity
+            description: Matrix plugin identity, install metadata, runtime/setup entries, and account configuration.
+          - name: Setup wizard
+            description: Setup wizard, setup adapter, validation, post-write bootstrap, and account setup.
+          - name: Account discovery
+            description: Account discovery, default account rules, env-backed accounts, and stored account metadata.
+          - name: Matrix doctor warnings
+            description: Matrix doctor warnings, config normalization, and stale plugin config cleanup.
+          - name: Matrix probe/status
+            description: Matrix probe/status, live directory lookup, CLI diagnostics, and QA runtime status.
+        docs:
+          - docs/channels/matrix.md
+          - docs/channels/matrix-migration.md
+        search_anchors:
+          - matrix setup, config, and account selection
+          - setup, config, and account selection
+          - matrix diagnostics, doctor, and operational repair
+          - diagnostics, doctor, and operational repair
+        category_note: setup-config-and-account-selection.md
+        human_lts_override: false
+      - name: Access and Identity
+        features:
+          - name: DM policy
+            description: DM policy, pairing, allowFrom, groupAllowFrom, room allowlists, and live access checks.
+          - name: Direct-room classification
+            description: Direct-room classification and repair-adjacent routing decisions
+          - name: Inbound route selection across sender-bound DMs
+            description: Inbound route selection across sender-bound DMs, room bindings, and account-scoped routes.
+          - name: Mention gates
+            description: Mention gates, slash command access checks, bot-loop suppression, and context admission.
+          - name: Matrix thread reply routing
+            description: Matrix thread reply routing, thread root/context extraction, and thread-aware session placement.
+          - name: Persisted Matrix thread routing managers
+            description: Persisted Matrix thread binding managers, child session binding, and activity tracking.
+          - name: ACP/subagent spawn hooks
+            description: ACP/subagent spawn hooks and Matrix delivery targets for child sessions
+        docs:
+          - docs/channels/matrix.md
+          - docs/channels/groups.md
+          - docs/channels/bot-loop-protection.md
+        search_anchors:
+          - matrix dm room routing and access policy
+          - dm room routing and access policy
+          - matrix threads, acp, and subagent bindings
+          - threads, acp, and subagent bindings
+        category_note: dm-room-routing-and-access-policy.md
+        human_lts_override: false
+      - name: Conversation Routing and Delivery
+        features:
+          - name: Conversation Routing and Delivery
+            description: Evidence scope for Conversation Routing and Delivery.
+        docs:
+          - docs/channels/matrix.md
+        search_anchors:
+          - matrix conversation routing and delivery
+          - conversation routing and delivery
+        category_note: threads-acp-and-subagent-bindings.md
+        human_lts_override: false
+      - name: Media and Rich Content
+        features:
+          - name: Media and Rich Content
+            description: Evidence scope for Media and Rich Content.
+        docs:
+          - docs/channels/matrix.md
+        search_anchors:
+          - matrix media and rich content
+          - media and rich content
+        category_note: outbound-messages-media-and-streaming.md
+        human_lts_override: false
+      - name: Native Controls and Approvals
+        features:
+          - name: Channel action discovery
+            description: Channel action discovery, account-scoped action gates, and tool schemas
+          - name: Message send/read/edit/delete
+            description: Message send/read/edit/delete, poll voting, reaction add/remove/list, pins, and related room tools.
+          - name: Profile media loading
+            description: Profile media loading from URL or local path.
+          - name: Outbound Matrix text
+            description: Outbound Matrix text, media, encrypted media, poll, typing, read receipt, and delivery behavior.
+          - name: Message presentation metadata
+            description: Message presentation metadata, Matrix mention metadata, and chunked delivery behavior.
+          - name: Inbound media failure handling
+            description: Inbound media download failure handling when it affects outbound replies.
+        docs:
+          - docs/channels/matrix.md
+        search_anchors:
+          - matrix actions, profile, polls, reactions, and room tools
+          - actions, profile, polls, reactions, and room tools
+          - matrix outbound messages, media, and streaming
+          - outbound messages, media, and streaming
+        category_note: actions-profile-polls-reactions-and-room-tools.md
+        human_lts_override: false
+      - name: Encryption and Verification
+        features:
+          - name: Encryption setup
+            description: Encryption setup, crypto availability, recovery-key storage, and secret storage.
+          - name: Encrypted media upload/download
+            description: Encrypted media upload/download and startup verification notices
+          - name: Legacy state
+            description: Legacy state and crypto migration, migration snapshots, and gateway startup repair.
+        docs:
+          - docs/channels/matrix.md
+          - docs/channels/matrix-migration.md
+        search_anchors:
+          - matrix e2ee, verification, backup, and migration
+          - e2ee, verification, backup, and migration
+        category_note: e2ee-verification-backup-and-migration.md
+        human_lts_override: false
+    last_score_run:
+      status: complete
+      completed_at: '2026-05-30'
+      by: codex
+      source_ref: null
+      process_version: 3
+  - id: microsoft-teams
+    name: Microsoft Teams
+    family: channel
+    level: alpha
+    level_code: M2
+    rationale: Enterprise auth/admin flows need explicit scenario proof.
+    completeness_instructions: references/completeness/microsoft-teams.md
+    categories:
+      - name: Channel Setup and Operations
+        features:
+          - name: Teams CLI app creation
+            description: Covers Microsoft Teams channel installation through `teams app create`, bot registration, manifest creation, credential generation, and setup verification.
+          - name: Bot registration and manifest upload
+            description: Covers Entra ID application registration, Azure Bot setup, Teams app manifest/RSC permissions, and Teams app package upload.
+          - name: Credential configuration
+            description: Covers CLIENT_ID, CLIENT_SECRET, TENANT_ID, `MSTEAMS_*` environment variables, and OpenClaw `channels.msteams` credential configuration.
+          - name: Teams app install verification
+            description: Covers Teams install links, app installation in Teams, and `teams app doctor` verification after setup.
+          - name: Setup status
+            description: Covers Setup status across setup wizard status, credential prompts, env credential detection, setup docs, and related diagnostics and repair behavior.
+          - name: Probe and scope reporting
+            description: Covers Probe and scope reporting across setup wizard status, credential prompts, env credential detection, setup docs, and related diagnostics and repair behavior.
+          - name: Teams app doctor
+            description: Covers Teams app doctor across setup wizard status, credential prompts, env credential detection, setup docs, and related diagnostics and repair behavior.
+          - name: Webhook and health diagnostics
+            description: Covers Webhook and health diagnostics across setup wizard status, credential prompts, env credential detection, setup docs, and related diagnostics and repair behavior.
+          - name: Operator repair paths
+            description: Covers Operator repair paths across setup wizard status, credential prompts, env credential detection, setup docs, and related diagnostics and repair behavior.
+        docs:
+          - docs/channels/msteams.md
+          - docs/plugins/reference/msteams.md
+          - docs/gateway/config-channels.md
+          - docs/gateway/health.md
+        search_anchors:
+          - Quick setup
+          - teams app create
+          - app registration
+          - bot registration
+          - Teams app manifest
+          - RSC permissions
+          - credential generation
+          - Configure OpenClaw
+          - MSTEAMS_APP_ID
+          - channels.msteams
+          - Install the app in Teams
+          - teams app doctor
+          - Setup status
+          - Probe and scope reporting
+          - Teams app doctor
+          - Webhook and health diagnostics
+          - Operator repair paths
+        category_note: setup-app-registration-credentials-admin-install.md
+        human_lts_override: false
+      - name: Access and Identity
+        features:
+          - name: DM pairing
+            description: Covers DM pairing across DM pairing, `dmPolicy`, `allowFrom`, AAD ID matching, and related dm pairing and sender access behavior.
+          - name: Stable sender identity
+            description: Covers Stable sender identity across DM pairing, `dmPolicy`, `allowFrom`, AAD ID matching, and related dm pairing and sender access behavior.
+          - name: Allowlists and access groups
+            description: Covers Allowlists and access groups across DM pairing, `dmPolicy`, `allowFrom`, AAD ID matching, and related dm pairing and sender access behavior.
+          - name: Invoke and command authorization
+            description: Covers Invoke and command authorization across DM pairing, `dmPolicy`, `allowFrom`, AAD ID matching, and related dm pairing and sender access behavior.
+          - name: Teams-originated config writes
+            description: Covers Teams-originated config writes across DM pairing, `dmPolicy`, `allowFrom`, AAD ID matching, and related dm pairing and sender access behavior.
+          - name: Bot Framework SSO invokes
+            description: Covers Bot Framework SSO invoke handling and OAuth token exchange for Microsoft Teams users.
+          - name: Delegated token storage
+            description: Covers delegated token storage, token refresh, and recovery for Microsoft Teams user auth.
+          - name: Graph directory lookup
+            description: Covers Graph app token resolution and directory lookup behavior for Teams routing and user metadata.
+          - name: Member profile lookup
+            description: Covers member info lookup and user metadata retrieval for Microsoft Teams conversations.
+        docs:
+          - docs/channels/msteams.md
+          - docs/channels/pairing.md
+          - docs/channels/access-groups.md
+        search_anchors:
+          - DM pairing
+          - Stable sender identity
+          - Allowlists and access groups
+          - Invoke and command authorization
+          - Teams-originated config writes
+          - Bot Framework SSO invokes
+          - OAuth token exchange
+          - delegated token storage
+          - Graph app token resolution
+          - member info
+        category_note: dm-pairing-sender-authorization-config-writes.md
+        human_lts_override: false
+      - name: Conversation Routing and Delivery
+        features:
+          - name: Team and channel allowlists
+            description: Covers Teams/channel allowlists, stable conversation IDs, `channels.msteams.teams`, wildcard routing, and team/channel name resolution.
+          - name: Deterministic channel replies
+            description: Covers deterministic reply routing back to the Teams channel where a message arrived and wildcard routing safeguards.
+          - name: Mention-gated group access
+            description: Covers `groupPolicy`, `groupAllowFrom`, `requireMention`, and mention-gated group or channel replies.
+          - name: Session routing
+            description: Covers deterministic reply routing, session keys, channel bindings, and conversation isolation for Microsoft Teams rooms and channels.
+          - name: Reply and thread context
+            description: Covers reply context, quoted source messages, thread-aware routing, and room context for Teams conversations.
+        docs:
+          - docs/channels/msteams.md
+          - docs/channels/groups.md
+          - docs/channels/channel-routing.md
+        search_anchors:
+          - Teams + channel allowlist
+          - deterministic routing
+          - replies always go back to the channel
+          - mention-gated
+          - Session key shapes
+          - groupPolicy
+          - groupAllowFrom
+          - requireMention
+          - channel routing
+          - Reply context
+        category_note: team-channel-routing-mention-gates-sessions-thread-context.md
+        human_lts_override: false
+      - name: Media and Rich Content
+        features:
+          - name: Inbound attachments
+            description: Covers Inbound attachments across inbound attachments, inline images, `msteams://media` placeholders, Graph hosted content, and related media and file sharing behavior.
+          - name: Graph-hosted media
+            description: Covers Graph-hosted media across inbound attachments, inline images, `msteams://media` placeholders, Graph hosted content, and related media and file sharing behavior.
+          - name: File consent
+            description: Covers File consent across inbound attachments, inline images, `msteams://media` placeholders, Graph hosted content, and related media and file sharing behavior.
+          - name: SharePoint and OneDrive sharing
+            description: Covers SharePoint and OneDrive sharing across inbound attachments, inline images, `msteams://media` placeholders, Graph hosted content, and related media and file sharing behavior.
+          - name: Media fetch safety
+            description: Covers Media fetch safety across inbound attachments, inline images, `msteams://media` placeholders, Graph hosted content, and related media and file sharing behavior.
+        docs:
+          - docs/channels/msteams.md
+        search_anchors:
+          - Inbound attachments
+          - Graph-hosted media
+          - File consent
+          - SharePoint and OneDrive sharing
+          - Media fetch safety
+        category_note: media-attachments-file-consent-graph-file-flows.md
+        human_lts_override: false
+      - name: Native Controls and Approvals
+        features:
+          - name: Message action discovery
+            description: Covers Message action discovery across message-tool discovery, upload-file, poll, read/search, and related actions and approvals behavior.
+          - name: Polls and reactions
+            description: Covers Polls and reactions across message-tool discovery, upload-file, poll, read/search, and related actions and approvals behavior.
+          - name: Read, edit, delete, and pin
+            description: Covers Read, edit, delete, and pin across message-tool discovery, upload-file, poll, read/search, and related actions and approvals behavior.
+          - name: Native approval cards
+            description: Covers Native approval cards across message-tool discovery, upload-file, poll, read/search, and related actions and approvals behavior.
+          - name: Feedback and group actions
+            description: Covers Feedback and group actions across message-tool discovery, upload-file, poll, read/search, and related actions and approvals behavior.
+        docs:
+          - docs/channels/msteams.md
+          - docs/tools/exec-approvals-advanced.md
+        search_anchors:
+          - Message action discovery
+          - Polls and reactions
+          - Read, edit, delete, and pin
+          - Native approval cards
+          - Feedback and group actions
+        category_note: actions-reactions-polls-approvals-group-management.md
+        human_lts_override: false
+    last_score_run:
+      status: complete
+      completed_at: '2026-05-30'
+      by: codex
+      source_ref: null
+      process_version: 3
+  - id: mattermost-line-irc-nextcloud-talk-nostr-twitch-tlon-synology-chat
+    name: Mattermost, LINE, IRC, Nextcloud Talk, Nostr, Twitch, Tlon, Synology Chat
+    family: channel
+    level: alpha
+    level_code: M2
+    rationale: Supported surfaces exist, but maturity likely varies by upstream and maintainer coverage. Score individually later.
+    completeness_instructions: references/completeness/mattermost-line-irc-nextcloud-talk-nostr-twitch-tlon-synology-chat.md
+    categories:
+      - name: Channel Setup and Operations
+        features:
+          - name: Channel Setup and Operations
+            description: Evidence scope for Channel Setup and Operations.
+        docs: []
+        search_anchors:
+          - mattermost, line, irc, nextcloud talk, nostr, twitch, tlon, synology chat channel setup and operations
+          - channel setup and operations
+        category_note: channel-setup-and-operations.md
+        human_lts_override: false
+      - name: Access and Identity
+        features:
+          - name: Access and Identity
+            description: Evidence scope for Access and Identity.
+        docs: []
+        search_anchors:
+          - mattermost, line, irc, nextcloud talk, nostr, twitch, tlon, synology chat access and identity
+          - access and identity
+        category_note: access-and-identity.md
+        human_lts_override: false
+      - name: Conversation Routing and Delivery
+        features:
+          - name: Conversation Routing and Delivery
+            description: Evidence scope for Conversation Routing and Delivery.
+        docs: []
+        search_anchors:
+          - mattermost, line, irc, nextcloud talk, nostr, twitch, tlon, synology chat conversation routing and delivery
+          - conversation routing and delivery
+        category_note: conversation-routing-and-delivery.md
+        human_lts_override: false
+      - name: Media and Rich Content
+        features:
+          - name: Media and Rich Content
+            description: Evidence scope for Media and Rich Content.
+        docs: []
+        search_anchors:
+          - mattermost, line, irc, nextcloud talk, nostr, twitch, tlon, synology chat media and rich content
+          - media and rich content
+        category_note: media-and-rich-content.md
+        human_lts_override: false
+    last_score_run:
+      status: complete
+      completed_at: '2026-05-30'
+      by: codex
+      source_ref: null
+      process_version: 3
+  - id: feishu-qq-bot-wechat-yuanbao-zalo-zalo-personal-regional-channels
+    name: Feishu, QQ Bot, WeChat, Yuanbao, Zalo, Zalo Personal, regional channels
+    family: channel
+    level: alpha
+    level_code: M2
+    rationale: Important regional coverage, but public support level should be calibrated per account type, upstream approval, and maintainer proof.
+    completeness_instructions: references/completeness/feishu-qq-bot-wechat-yuanbao-zalo-zalo-personal-regional-channels.md
+    categories:
+      - name: Channel Setup and Operations
+        features:
+          - name: Docs channel index
+            description: Docs channel index, plugin reference pages, redirects, and pairing support list for regional channels
+          - name: Official external channel catalog entries
+            description: Official external channel catalog entries for WeCom, Yuanbao, Weixin, and adjacent external channels
+          - name: Core channel-plugin catalog
+            description: Core channel-plugin catalog, alias normalization, install-plan resolution, trusted-source flags, repair hints, and status/list output
+          - name: Channel setup wizard
+            description: Channel setup wizard and i18n blurbs for regional channels
+          - name: Missing-plugin
+            description: Missing-plugin, stale-plugin, raw package-manager upgrade, and doctor/repair paths
+          - name: Cross-channel ingress/access/refactor concerns
+            description: Cross-channel ingress/access/refactor concerns for regional plugins
+        docs:
+          - docs/channels/index.md
+          - docs/channels/pairing.md
+          - docs/plugins/reference/feishu.md
+          - docs/plugins/architecture-internals.md
+        search_anchors:
+          - 'feishu, qq bot, wechat, yuanbao, zalo, zalo personal, regional channels feishu, qq bot, wechat, yuanbao, zalo, zalo personal, regional channels feature matrix: shared regional channel catalog, install, and status'
+          - 'feishu, qq bot, wechat, yuanbao, zalo, zalo personal, regional channels feature matrix: shared regional channel catalog, install, and status'
+        category_note: shared-regional-channel-catalog-install-status.md
+        human_lts_override: false
+      - name: Access and Identity
+        features:
+          - name: Access and Identity
+            description: Evidence scope for Access and Identity.
+        docs: []
+        search_anchors:
+          - feishu, qq bot, wechat, yuanbao, zalo, zalo personal, regional channels access and identity
+          - access and identity
+        category_note: access-and-identity.md
+        human_lts_override: false
+      - name: Conversation Routing and Delivery
+        features:
+          - name: Conversation Routing and Delivery
+            description: Evidence scope for Conversation Routing and Delivery.
+        docs: []
+        search_anchors:
+          - feishu, qq bot, wechat, yuanbao, zalo, zalo personal, regional channels conversation routing and delivery
+          - conversation routing and delivery
+        category_note: conversation-routing-and-delivery.md
+        human_lts_override: false
+      - name: Media and Rich Content
+        features:
+          - name: Media and Rich Content
+            description: Evidence scope for Media and Rich Content.
+        docs: []
+        search_anchors:
+          - feishu, qq bot, wechat, yuanbao, zalo, zalo personal, regional channels media and rich content
+          - media and rich content
+        category_note: media-and-rich-content.md
+        human_lts_override: false
+    last_score_run:
+      status: complete
+      completed_at: '2026-05-30'
+      by: codex
+      source_ref: null
+      process_version: 3
+  - id: voice-call-channel
+    name: Voice Call channel
+    family: channel
+    level: experimental
+    level_code: M1
+    rationale: Optional/plugin path with complex realtime behavior. Needs scenario scorecard before public beta.
+    completeness_instructions: references/completeness/voice-call-channel.md
+    categories:
+      - name: Channel Setup and Operations
+        features:
+          - name: Voice Call Channel
+            description: Cli, Gateway Rpc, and Agent Tool
+          - name: Voice Call Channel
+            description: Setup, Configuration, and Smoke
+        docs:
+          - docs/cli/voicecall.md
+          - docs/plugins/voice-call.md
+          - docs/gateway/protocol.md
+        search_anchors:
+          - 'voice call channel voice call channel: cli, gateway rpc, and agent tool'
+          - 'voice call channel: cli, gateway rpc, and agent tool'
+          - 'voice call channel voice call channel: setup, configuration, and smoke'
+          - 'voice call channel: setup, configuration, and smoke'
+        category_note: setup-configuration-and-smoke.md
+        human_lts_override: false
+      - name: Access and Identity
+        features:
+          - name: Voice Call Channel
+            description: Webhook Exposure and Security
+        docs:
+          - docs/plugins/voice-call.md
+          - docs/cli/voicecall.md
+        search_anchors:
+          - 'voice call channel voice call channel: webhook exposure and security'
+          - 'voice call channel: webhook exposure and security'
+        category_note: webhook-exposure-and-security.md
+        human_lts_override: false
+      - name: Conversation Routing and Delivery
+        features:
+          - name: Voice Call Channel
+            description: Inbound Routing, Sessions, and Lifecycle
+        docs:
+          - docs/plugins/voice-call.md
+        search_anchors:
+          - 'voice call channel voice call channel: inbound routing, sessions, and lifecycle'
+          - 'voice call channel: inbound routing, sessions, and lifecycle'
+        category_note: inbound-routing-sessions-and-lifecycle.md
+        human_lts_override: false
+      - name: Media and Rich Content
+        features:
+          - name: Voice Call Channel
+            description: Provider Transports and Call Control
+          - name: Voice Call Channel
+            description: Telephony Tts, Playback, Dtmf, and Audio
+        docs:
+          - docs/plugins/voice-call.md
+          - docs/plugins/plugin-inventory.md
+        search_anchors:
+          - 'voice call channel voice call channel: provider transports and call control'
+          - 'voice call channel: provider transports and call control'
+          - 'voice call channel voice call channel: telephony tts, playback, dtmf, and audio'
+          - 'voice call channel: telephony tts, playback, dtmf, and audio'
+        category_note: provider-transports-and-call-control.md
+        human_lts_override: false
+      - name: Realtime Voice and Calls
+        features:
+          - name: Voice Call Channel
+            description: Realtime Voice and Agent Consult
+          - name: Voice Call Channel
+            description: Streaming Transcription and Auto-response
+        docs:
+          - docs/plugins/voice-call.md
+        search_anchors:
+          - 'voice call channel voice call channel: realtime voice and agent consult'
+          - 'voice call channel: realtime voice and agent consult'
+          - 'voice call channel voice call channel: streaming transcription and auto-response'
+          - 'voice call channel: streaming transcription and auto-response'
+        category_note: realtime-voice-and-agent-consult.md
+        human_lts_override: false
+    last_score_run:
+      status: complete
+      completed_at: '2026-05-30'
+      by: codex
+      source_ref: null
+      process_version: 3
+  - id: openai-codex-provider-path
+    name: OpenAI / Codex provider path
+    family: provider-tool
+    level: beta
+    level_code: M3
+    rationale: Deep docs, OAuth/subscription path, realtime voice, image, and compatibility behavior. Provider churn keeps this from Stable without release-scorecard proof.
+    completeness_instructions: references/completeness/openai-codex-provider-path.md
+    categories:
+      - name: Model and Auth
+        features:
+          - name: Canonical OpenAI Model Routing
+            description: 'Covers Canonical OpenAI Model Routing across user/operator-facing model route contract: canonical `openai/gpt-*` refs, legacy `openai-codex/*` model refs, model catalog rows, context limits, and related canonical openai model routing and catalog behavior.'
+          - name: Catalog
+            description: 'Covers Catalog across user/operator-facing model route contract: canonical `openai/gpt-*` refs, legacy `openai-codex/*` model refs, model catalog rows, context limits, and related canonical openai model routing and catalog behavior.'
+          - name: Codex OAuth Profiles
+            description: Covers Codex OAuth Profiles across `openai-codex` auth profiles, profile ordering, profile metadata repair, token refresh, account-id propagation, usage/cooldown handling, and auth selection for Codex-backed OpenAI agent turns.
+          - name: Subscription Usage
+            description: Covers Subscription Usage across `openai-codex` auth profiles, profile ordering, profile metadata repair, token refresh, account-id propagation, usage/cooldown handling, and auth selection for Codex-backed OpenAI agent turns.
+          - name: Doctor Diagnostics
+            description: 'Covers Doctor Diagnostics across operator-facing repair and diagnosis for OpenAI/Codex provider path problems: stale route migration, persisted session pins, runtime pins, auth-profile sidecars, profile metadata, status/probe output, and recovery commands.'
+          - name: Operator Repair
+            description: 'Covers Operator Repair across operator-facing repair and diagnosis for OpenAI/Codex provider path problems: stale route migration, persisted session pins, runtime pins, auth-profile sidecars, profile metadata, status/probe output, and recovery commands.'
+        docs:
+          - docs/providers/openai.md
+          - docs/plugins/codex-harness.md
+          - docs/concepts/models.md
+          - docs/concepts/oauth.md
+          - docs/plugins/codex-harness-reference.md
+          - docs/automation/auth-monitoring.md
+        search_anchors:
+          - Canonical OpenAI Model Routing
+          - Catalog
+          - openai / codex provider path canonical openai model routing and catalog
+          - canonical openai model routing and catalog
+          - Codex OAuth Profiles
+          - Subscription Usage
+          - openai / codex provider path codex oauth profiles and subscription usage
+          - codex oauth profiles and subscription usage
+          - Doctor Diagnostics
+          - Operator Repair
+          - openai / codex provider path doctor diagnostics and operator repair
+          - doctor diagnostics and operator repair
+        category_note: canonical-openai-model-routing-and-catalog.md
+        human_lts_override: true
+      - name: Responses and Tool Compatibility
+        features:
+          - name: Codex Responses Transport
+            description: Covers Codex Responses Transport across low-level provider request/streaming path for `openai-codex-responses` and the shared OpenAI Responses conversion code used by direct OpenAI and Codex-auth compatibility routes.
+          - name: Payload Compatibility
+            description: Covers Payload Compatibility across low-level provider request/streaming path for `openai-codex-responses` and the shared OpenAI Responses conversion code used by direct OpenAI and Codex-auth compatibility routes.
+          - name: Tool Context
+            description: Covers Tool Context across provider-facing tools, context injection, media inputs, native-vs-client tool ownership, OpenAI Responses compatibility, and how OpenAI/Codex models receive OpenClaw runtime context.
+          - name: Capability Compatibility
+            description: Covers Capability Compatibility across provider-facing tools, context injection, media inputs, native-vs-client tool ownership, OpenAI Responses compatibility, and how OpenAI/Codex models receive OpenClaw runtime context.
+        docs:
+          - docs/providers/openai.md
+          - docs/gateway/openresponses-http-api.md
+          - docs/gateway/openai-http-api.md
+          - docs/plugins/codex-native-plugins.md
+        search_anchors:
+          - Codex Responses Transport
+          - Payload Compatibility
+          - openai / codex provider path codex responses transport and payload compatibility
+          - codex responses transport and payload compatibility
+          - Tool Context
+          - Capability Compatibility
+          - openai / codex provider path tool context and capability compatibility
+          - tool context and capability compatibility
+        category_note: codex-responses-transport-and-payload-compatibility.md
+        human_lts_override: true
+      - name: Native Codex Harness
+        features:
+          - name: Native Codex App-server Harness
+            description: Covers Native Codex App-server Harness across native Codex app-server runtime path used by OpenAI agent turns when the Codex harness owns thread identity, native model loop, compaction, native tools, and native app-server controls.
+          - name: Thread Lifecycle
+            description: Covers Thread Lifecycle across native Codex app-server runtime path used by OpenAI agent turns when the Codex harness owns thread identity, native model loop, compaction, native tools, and native app-server controls.
+        docs:
+          - docs/plugins/codex-harness.md
+          - docs/plugins/codex-harness-runtime.md
+          - docs/plugins/codex-harness-reference.md
+          - docs/plugins/codex-native-plugins.md
+        search_anchors:
+          - Native Codex App-server Harness
+          - Thread Lifecycle
+          - openai / codex provider path native codex app-server harness and thread lifecycle
+          - native codex app-server harness and thread lifecycle
+        category_note: native-codex-app-server-harness-and-thread-lifecycle.md
+        human_lts_override: true
+      - name: Image and Multimodal Input
+        features:
+          - name: Image Generation Editing
+            description: Covers Image Generation Editing across OpenAI image generation and editing, Codex OAuth image backend, transparent-background routing, Azure/private OpenAI image endpoints, and related image generation editing and multimodal input behavior.
+          - name: Multimodal Input
+            description: Covers Multimodal Input across OpenAI image generation and editing, Codex OAuth image backend, transparent-background routing, Azure/private OpenAI image endpoints, and related image generation editing and multimodal input behavior.
+        docs:
+          - docs/providers/openai.md
+          - docs/tools/image-generation.md
+          - docs/nodes/images.md
+        search_anchors:
+          - Image Generation Editing
+          - Multimodal Input
+          - openai / codex provider path image generation editing and multimodal input
+          - image generation editing and multimodal input
+        category_note: image-generation-editing-and-multimodal-input.md
+        human_lts_override: false
+      - name: Voice and Realtime Audio
+        features:
+          - name: Realtime Voice Transcription
+            description: Covers Realtime Voice Transcription across OpenAI text-to-speech, batch speech-to-text, Realtime transcription, Realtime voice, browser Talk/WebRTC, backend WebSocket bridges, OAuth-backed client secret minting, Azure Realtime deployments, and voice-control behavior.
+          - name: Speech
+            description: Covers Speech across OpenAI text-to-speech, batch speech-to-text, Realtime transcription, Realtime voice, browser Talk/WebRTC, backend WebSocket bridges, OAuth-backed client secret minting, Azure Realtime deployments, and voice-control behavior.
+        docs:
+          - docs/providers/openai.md
+          - docs/channels/discord.md
+          - docs/plugins/voice-call.md
+        search_anchors:
+          - Realtime Voice Transcription
+          - Speech
+          - openai / codex provider path realtime voice transcription and speech
+          - realtime voice transcription and speech
+        category_note: realtime-voice-transcription-and-speech.md
+        human_lts_override: false
+    last_score_run:
+      status: complete
+      completed_at: '2026-05-30'
+      by: codex
+      source_ref: null
+      process_version: 3
+  - id: anthropic-provider-path
+    name: Anthropic provider path
+    family: provider-tool
+    level: beta
+    level_code: M3
+    rationale: First-class model provider. Needs recurring auth/catalog/tool-call scenario proof.
+    completeness_instructions: references/completeness/anthropic-provider-path.md
+    categories:
+      - name: Provider Auth and Recovery
+        features:
+          - name: API-key onboarding
+            description: 'Covers API-key onboarding across Anthropic credential surface before a model request is made: onboarding choices, API-key storage, Claude CLI credential migration, setup-token validation, and related credential setup and health behavior.'
+          - name: Claude CLI credential reuse
+            description: 'Covers Claude CLI credential reuse across Anthropic credential surface before a model request is made: onboarding choices, API-key storage, Claude CLI credential migration, setup-token validation, and related credential setup and health behavior.'
+          - name: Setup-token auth
+            description: 'Covers Setup-token auth across Anthropic credential surface before a model request is made: onboarding choices, API-key storage, Claude CLI credential migration, setup-token validation, and related credential setup and health behavior.'
+          - name: Auth profile health
+            description: 'Covers Auth profile health across Anthropic credential surface before a model request is made: onboarding choices, API-key storage, Claude CLI credential migration, setup-token validation, and related credential setup and health behavior.'
+          - name: Model status
+            description: 'Covers Model status across operator diagnostics and recovery for Anthropic provider failures: status output, usage windows, auth profile source reporting, cooldown and disabled profile reporting, and related diagnostics and recovery behavior.'
+          - name: Usage windows
+            description: 'Covers Usage windows across operator diagnostics and recovery for Anthropic provider failures: status output, usage windows, auth profile source reporting, cooldown and disabled profile reporting, and related diagnostics and recovery behavior.'
+          - name: Cooldown/profile reporting
+            description: 'Covers Cooldown/profile reporting across operator diagnostics and recovery for Anthropic provider failures: status output, usage windows, auth profile source reporting, cooldown and disabled profile reporting, and related diagnostics and recovery behavior.'
+          - name: Long-context recovery
+            description: 'Covers Long-context recovery across operator diagnostics and recovery for Anthropic provider failures: status output, usage windows, auth profile source reporting, cooldown and disabled profile reporting, and related diagnostics and recovery behavior.'
+          - name: Fallback guidance
+            description: 'Covers Fallback guidance across operator diagnostics and recovery for Anthropic provider failures: status output, usage windows, auth profile source reporting, cooldown and disabled profile reporting, and related diagnostics and recovery behavior.'
+        docs:
+          - docs/providers/anthropic.md
+          - docs/gateway/doctor.md
+          - docs/gateway/configuration-examples.md
+          - docs/gateway/troubleshooting.md
+          - docs/reference/prompt-caching.md
+        search_anchors:
+          - API-key onboarding
+          - Claude CLI credential reuse
+          - Setup-token auth
+          - Auth profile health
+          - Model status
+          - Usage windows
+          - Cooldown/profile reporting
+          - Long-context recovery
+          - Fallback guidance
+        category_note: auth-onboarding-and-credential-profile-health.md
+        human_lts_override: false
+      - name: Model and Runtime Selection
+        features:
+          - name: Bundled Claude catalog
+            description: 'Covers Bundled Claude catalog across Anthropic model catalog and policy layer: bundled model rows, model aliases, current and future Claude model id normalization, runtime-provider selection, and related model catalog and policy behavior.'
+          - name: Canonical anthropic refs
+            description: 'Covers Canonical anthropic refs across Anthropic model catalog and policy layer: bundled model rows, model aliases, current and future Claude model id normalization, runtime-provider selection, and related model catalog and policy behavior.'
+          - name: Claude CLI compatibility
+            description: 'Covers Claude CLI compatibility across Anthropic model catalog and policy layer: bundled model rows, model aliases, current and future Claude model id normalization, runtime-provider selection, and related model catalog and policy behavior.'
+          - name: Model picker availability
+            description: 'Covers Model picker availability across Anthropic model catalog and policy layer: bundled model rows, model aliases, current and future Claude model id normalization, runtime-provider selection, and related model catalog and policy behavior.'
+          - name: Capability metadata
+            description: 'Covers Capability metadata across Anthropic model catalog and policy layer: bundled model rows, model aliases, current and future Claude model id normalization, runtime-provider selection, and related model catalog and policy behavior.'
+          - name: Runtime selection
+            description: 'Covers Runtime selection across OpenClaw''s host-local Claude CLI path after auth is available: the `claude-cli` backend, its command/args/env defaults, MCP tool bridge, native tool mode, and related claude cli backend behavior.'
+          - name: Session continuity
+            description: 'Covers Session continuity across OpenClaw''s host-local Claude CLI path after auth is available: the `claude-cli` backend, its command/args/env defaults, MCP tool bridge, native tool mode, and related claude cli backend behavior.'
+          - name: MCP/tool bridge
+            description: 'Covers MCP/tool bridge across OpenClaw''s host-local Claude CLI path after auth is available: the `claude-cli` backend, its command/args/env defaults, MCP tool bridge, native tool mode, and related claude cli backend behavior.'
+          - name: Permission-mode mapping
+            description: 'Covers Permission-mode mapping across OpenClaw''s host-local Claude CLI path after auth is available: the `claude-cli` backend, its command/args/env defaults, MCP tool bridge, native tool mode, and related claude cli backend behavior.'
+          - name: Fallback prelude
+            description: 'Covers Fallback prelude across OpenClaw''s host-local Claude CLI path after auth is available: the `claude-cli` backend, its command/args/env defaults, MCP tool bridge, native tool mode, and related claude cli backend behavior.'
+        docs:
+          - docs/providers/anthropic.md
+          - docs/gateway/config-agents.md
+          - docs/concepts/models.md
+          - docs/gateway/cli-backends.md
+        search_anchors:
+          - Bundled Claude catalog
+          - Canonical anthropic refs
+          - Claude CLI compatibility
+          - Model picker availability
+          - Capability metadata
+          - Runtime selection
+          - Session continuity
+          - MCP/tool bridge
+          - Permission-mode mapping
+          - Fallback prelude
+        category_note: model-catalog-aliases-and-runtime-policy.md
+        human_lts_override: false
+      - name: Request Transport and Turn Semantics
+        features:
+          - name: API-key/OAuth transport
+            description: 'Covers API-key/OAuth transport across direct Anthropic `api: "anthropic-messages"` request and stream behavior: API-key and OAuth transport setup, Anthropic beta headers, model-id normalization for direct hosts, payload construction, and related direct anthropic api behavior.'
+          - name: Messages payloads
+            description: 'Covers Messages payloads across direct Anthropic `api: "anthropic-messages"` request and stream behavior: API-key and OAuth transport setup, Anthropic beta headers, model-id normalization for direct hosts, payload construction, and related direct anthropic api behavior.'
+          - name: Streaming decode
+            description: 'Covers Streaming decode across direct Anthropic `api: "anthropic-messages"` request and stream behavior: API-key and OAuth transport setup, Anthropic beta headers, model-id normalization for direct hosts, payload construction, and related direct anthropic api behavior.'
+          - name: Usage and stop reasons
+            description: 'Covers Usage and stop reasons across direct Anthropic `api: "anthropic-messages"` request and stream behavior: API-key and OAuth transport setup, Anthropic beta headers, model-id normalization for direct hosts, payload construction, and related direct anthropic api behavior.'
+          - name: Abort/error handling
+            description: 'Covers Abort/error handling across direct Anthropic `api: "anthropic-messages"` request and stream behavior: API-key and OAuth transport setup, Anthropic beta headers, model-id normalization for direct hosts, payload construction, and related direct anthropic api behavior.'
+          - name: Tool-use blocks
+            description: 'Covers Tool-use blocks across Anthropic-specific turn semantics inside agent runs: tool declarations, tool-use block conversion, tool-result conversion, tool-call id normalization, and related tools and thinking behavior.'
+          - name: Tool-result replay
+            description: 'Covers Tool-result replay across Anthropic-specific turn semantics inside agent runs: tool declarations, tool-use block conversion, tool-result conversion, tool-call id normalization, and related tools and thinking behavior.'
+          - name: Partial JSON recovery
+            description: 'Covers Partial JSON recovery across Anthropic-specific turn semantics inside agent runs: tool declarations, tool-use block conversion, tool-result conversion, tool-call id normalization, and related tools and thinking behavior.'
+          - name: Native thinking
+            description: 'Covers Native thinking across Anthropic-specific turn semantics inside agent runs: tool declarations, tool-use block conversion, tool-result conversion, tool-call id normalization, and related tools and thinking behavior.'
+          - name: Signed/redacted thinking replay
+            description: 'Covers Signed/redacted thinking replay across Anthropic-specific turn semantics inside agent runs: tool declarations, tool-use block conversion, tool-result conversion, tool-call id normalization, and related tools and thinking behavior.'
+        docs:
+          - docs/providers/anthropic.md
+          - docs/reference/prompt-caching.md
+          - docs/gateway/troubleshooting.md
+          - docs/gateway/cli-backends.md
+          - docs/concepts/model-providers.md
+        search_anchors:
+          - API-key/OAuth transport
+          - Messages payloads
+          - Streaming decode
+          - Usage and stop reasons
+          - Abort/error handling
+          - Tool-use blocks
+          - Tool-result replay
+          - Partial JSON recovery
+          - Native thinking
+          - Signed/redacted thinking replay
+        category_note: direct-anthropic-messages-transport-and-streaming.md
+        human_lts_override: false
+      - name: Prompt Cache and Context
+        features:
+          - name: Cache retention
+            description: 'Covers Cache retention across Anthropic-specific request knobs outside the core content stream: prompt cache retention, cache-control markers, system-prompt cache boundary, 1M context sizing, and related prompt cache and context behavior.'
+          - name: System-prompt cache boundary
+            description: 'Covers System-prompt cache boundary across Anthropic-specific request knobs outside the core content stream: prompt cache retention, cache-control markers, system-prompt cache boundary, 1M context sizing, and related prompt cache and context behavior.'
+          - name: 1M context
+            description: 'Covers 1M context across Anthropic-specific request knobs outside the core content stream: prompt cache retention, cache-control markers, system-prompt cache boundary, 1M context sizing, and related prompt cache and context behavior.'
+          - name: Fast mode/service tier
+            description: 'Covers Fast mode/service tier across Anthropic-specific request knobs outside the core content stream: prompt cache retention, cache-control markers, system-prompt cache boundary, 1M context sizing, and related prompt cache and context behavior.'
+          - name: Cache diagnostics
+            description: 'Covers Cache diagnostics across Anthropic-specific request knobs outside the core content stream: prompt cache retention, cache-control markers, system-prompt cache boundary, 1M context sizing, and related prompt cache and context behavior.'
+        docs:
+          - docs/providers/anthropic.md
+          - docs/reference/prompt-caching.md
+          - docs/gateway/troubleshooting.md
+          - docs/gateway/heartbeat.md
+        search_anchors:
+          - Cache retention
+          - System-prompt cache boundary
+          - 1M context
+          - Fast mode/service tier
+          - Cache diagnostics
+        category_note: prompt-caching-context-windows-and-request-knobs.md
+        human_lts_override: false
+      - name: Media Inputs
+        features:
+          - name: Image input
+            description: 'Covers Image input across Anthropic media understanding as part of the provider path: image input support, PDF native document input metadata, default media model selection, auto-priority, and related media inputs behavior.'
+          - name: PDF document input
+            description: 'Covers PDF document input across Anthropic media understanding as part of the provider path: image input support, PDF native document input metadata, default media model selection, auto-priority, and related media inputs behavior.'
+          - name: Media model fallback
+            description: 'Covers Media model fallback across Anthropic media understanding as part of the provider path: image input support, PDF native document input metadata, default media model selection, auto-priority, and related media inputs behavior.'
+          - name: Image tool results
+            description: 'Covers Image tool results across Anthropic media understanding as part of the provider path: image input support, PDF native document input metadata, default media model selection, auto-priority, and related media inputs behavior.'
+        docs:
+          - docs/providers/anthropic.md
+          - docs/gateway/config-agents.md
+        search_anchors:
+          - Image input
+          - PDF document input
+          - Media model fallback
+          - Image tool results
+        category_note: media-understanding-and-document-inputs.md
+        human_lts_override: false
+    last_score_run:
+      status: complete
+      completed_at: '2026-05-30'
+      by: codex
+      source_ref: null
+      process_version: 3
+  - id: google-provider-path
+    name: Google provider path
+    family: provider-tool
+    level: beta
+    level_code: M3
+    rationale: First-class provider with model and realtime surfaces. Needs separate Live/Talk scoring.
+    completeness_instructions: references/completeness/google-provider-path.md
+    categories:
+      - name: Provider Setup and Credentials
+        features:
+          - name: API key onboarding
+            description: Covers API key onboarding across direct `GEMINI_API_KEY` and `GOOGLE_API_KEY` auth, setup provider metadata, setup auth choices, provider config fields, and related provider auth and setup behavior.
+          - name: Auth choice metadata
+            description: Covers Auth choice metadata across direct `GEMINI_API_KEY` and `GOOGLE_API_KEY` auth, setup provider metadata, setup auth choices, provider config fields, and related provider auth and setup behavior.
+          - name: Gemini CLI OAuth setup
+            description: Covers Gemini CLI OAuth setup across direct `GEMINI_API_KEY` and `GOOGLE_API_KEY` auth, setup provider metadata, setup auth choices, provider config fields, and related provider auth and setup behavior.
+          - name: Vertex ADC setup
+            description: Covers Vertex ADC setup across direct `GEMINI_API_KEY` and `GOOGLE_API_KEY` auth, setup provider metadata, setup auth choices, provider config fields, and related provider auth and setup behavior.
+          - name: Daemon and fallback credentials
+            description: Covers Daemon and fallback credentials across direct `GEMINI_API_KEY` and `GOOGLE_API_KEY` auth, setup provider metadata, setup auth choices, provider config fields, and related provider auth and setup behavior.
+          - name: CLI runtime selection
+            description: 'Covers CLI runtime selection across `google-gemini-cli` provider, canonical `google/*` model refs using `agentRuntime.id: "google-gemini-cli"`, legacy `google-gemini-cli/*` refs, Gemini CLI command invocation, and related gemini cli oauth behavior.'
+          - name: OAuth login and refresh
+            description: 'Covers OAuth login and refresh across `google-gemini-cli` provider, canonical `google/*` model refs using `agentRuntime.id: "google-gemini-cli"`, legacy `google-gemini-cli/*` refs, Gemini CLI command invocation, and related gemini cli oauth behavior.'
+          - name: Canonical Google model refs
+            description: 'Covers Canonical Google model refs across `google-gemini-cli` provider, canonical `google/*` model refs using `agentRuntime.id: "google-gemini-cli"`, legacy `google-gemini-cli/*` refs, Gemini CLI command invocation, and related gemini cli oauth behavior.'
+          - name: CLI usage normalization
+            description: 'Covers CLI usage normalization across `google-gemini-cli` provider, canonical `google/*` model refs using `agentRuntime.id: "google-gemini-cli"`, legacy `google-gemini-cli/*` refs, Gemini CLI command invocation, and related gemini cli oauth behavior.'
+          - name: OAuth diagnostics
+            description: 'Covers OAuth diagnostics across `google-gemini-cli` provider, canonical `google/*` model refs using `agentRuntime.id: "google-gemini-cli"`, legacy `google-gemini-cli/*` refs, Gemini CLI command invocation, and related gemini cli oauth behavior.'
+        docs:
+          - docs/providers/google.md
+          - docs/concepts/model-providers.md
+        search_anchors:
+          - API key onboarding
+          - Auth choice metadata
+          - Gemini CLI OAuth setup
+          - Vertex ADC setup
+          - Daemon and fallback credentials
+          - CLI runtime selection
+          - OAuth login and refresh
+          - Canonical Google model refs
+          - CLI usage normalization
+          - OAuth diagnostics
+        category_note: provider-auth-credentials-and-operator-setup.md
+        human_lts_override: false
+      - name: Model Routing and Endpoints
+        features:
+          - name: Catalog rows and aliases
+            description: Covers Catalog rows and aliases across model catalog rows, model ID normalization, dynamic model resolution, provider hooks, and related model catalog and routing behavior.
+          - name: Dynamic model resolution
+            description: Covers Dynamic model resolution across model catalog rows, model ID normalization, dynamic model resolution, provider hooks, and related model catalog and routing behavior.
+          - name: Provider routing
+            description: Covers Provider routing across model catalog rows, model ID normalization, dynamic model resolution, provider hooks, and related model catalog and routing behavior.
+          - name: Google-native config normalization
+            description: Covers Google-native config normalization across model catalog rows, model ID normalization, dynamic model resolution, provider hooks, and related model catalog and routing behavior.
+          - name: Model picker availability
+            description: Covers Model picker availability across model catalog rows, model ID normalization, dynamic model resolution, provider hooks, and related model catalog and routing behavior.
+          - name: Vertex provider selection
+            description: Covers Vertex provider selection across `google-vertex`, Vertex ADC/service-account auth, project/location endpoint construction, custom Google-compatible base URL handling, and related vertex ai and custom endpoints behavior.
+          - name: ADC/service-account auth
+            description: Covers ADC/service-account auth across `google-vertex`, Vertex ADC/service-account auth, project/location endpoint construction, custom Google-compatible base URL handling, and related vertex ai and custom endpoints behavior.
+          - name: Project/location endpoints
+            description: Covers Project/location endpoints across `google-vertex`, Vertex ADC/service-account auth, project/location endpoint construction, custom Google-compatible base URL handling, and related vertex ai and custom endpoints behavior.
+          - name: Custom base URL policy
+            description: Covers Custom base URL policy across `google-vertex`, Vertex ADC/service-account auth, project/location endpoint construction, custom Google-compatible base URL handling, and related vertex ai and custom endpoints behavior.
+          - name: Compatibility boundaries
+            description: Covers Compatibility boundaries across `google-vertex`, Vertex ADC/service-account auth, project/location endpoint construction, custom Google-compatible base URL handling, and related vertex ai and custom endpoints behavior.
+        docs:
+          - docs/providers/google.md
+          - docs/concepts/model-providers.md
+          - docs/plugins/reference/google.md
+          - docs/tools/gemini-search.md
+        search_anchors:
+          - Catalog rows and aliases
+          - Dynamic model resolution
+          - Provider routing
+          - Google-native config normalization
+          - Model picker availability
+          - Vertex provider selection
+          - ADC/service-account auth
+          - Project/location endpoints
+          - Custom base URL policy
+          - Compatibility boundaries
+        category_note: model-catalog-provider-routing-and-config-normalization.md
+        human_lts_override: false
+      - name: Direct Gemini Runtime
+        features:
+          - name: Direct Gemini chat
+            description: 'Covers Direct Gemini chat across direct `google-generative-ai` Gemini transport and shared Google message/stream conversion: request URL construction, request config, text/image/audio/video/tool payload conversion, function response handling, and related direct gemini api behavior.'
+          - name: Multimodal inputs
+            description: 'Covers Multimodal inputs across direct `google-generative-ai` Gemini transport and shared Google message/stream conversion: request URL construction, request config, text/image/audio/video/tool payload conversion, function response handling, and related direct gemini api behavior.'
+          - name: Tool-call streaming
+            description: 'Covers Tool-call streaming across direct `google-generative-ai` Gemini transport and shared Google message/stream conversion: request URL construction, request config, text/image/audio/video/tool payload conversion, function response handling, and related direct gemini api behavior.'
+          - name: Usage and stop reasons
+            description: 'Covers Usage and stop reasons across direct `google-generative-ai` Gemini transport and shared Google message/stream conversion: request URL construction, request config, text/image/audio/video/tool payload conversion, function response handling, and related direct gemini api behavior.'
+          - name: Thought-signature replay
+            description: 'Covers Thought-signature replay across direct `google-generative-ai` Gemini transport and shared Google message/stream conversion: request URL construction, request config, text/image/audio/video/tool payload conversion, function response handling, and related direct gemini api behavior.'
+          - name: Thinking-level mapping
+            description: Covers Thinking-level mapping across Gemini thinking-level mapping, adaptive thinking request shape, `thoughtSignature` capture/replay/sanitization, Google replay policy, and related thinking and turn recovery behavior.
+          - name: Thought-signature replay
+            description: Covers Thought-signature replay across Gemini thinking-level mapping, adaptive thinking request shape, `thoughtSignature` capture/replay/sanitization, Google replay policy, and related thinking and turn recovery behavior.
+          - name: Tool turn ordering
+            description: Covers Tool turn ordering across Gemini thinking-level mapping, adaptive thinking request shape, `thoughtSignature` capture/replay/sanitization, Google replay policy, and related thinking and turn recovery behavior.
+          - name: Incomplete-turn recovery
+            description: Covers Incomplete-turn recovery across Gemini thinking-level mapping, adaptive thinking request shape, `thoughtSignature` capture/replay/sanitization, Google replay policy, and related thinking and turn recovery behavior.
+          - name: Planning-only turn recovery
+            description: Covers Planning-only turn recovery across Gemini thinking-level mapping, adaptive thinking request shape, `thoughtSignature` capture/replay/sanitization, Google replay policy, and related thinking and turn recovery behavior.
+        docs:
+          - docs/providers/google.md
+          - docs/concepts/model-providers.md
+          - docs/help/faq-models.md
+          - docs/help/testing-live.md
+        search_anchors:
+          - Direct Gemini chat
+          - Multimodal inputs
+          - Tool-call streaming
+          - Usage and stop reasons
+          - Thought-signature replay
+          - Thinking-level mapping
+          - Tool turn ordering
+          - Incomplete-turn recovery
+          - Planning-only turn recovery
+        category_note: direct-gemini-api-transport-streaming-and-multimodal-payloads.md
+        human_lts_override: false
+      - name: Media, Search, and Realtime
+        features:
+          - name: Bundled plugin distribution
+            description: Covers Bundled plugin distribution across bundled `@openclaw/google-plugin` package, plugin manifest distribution, auto-enable metadata, capability-provider registration, and related google plugin adapters behavior.
+          - name: Provider auto-enable metadata
+            description: Covers Provider auto-enable metadata across bundled `@openclaw/google-plugin` package, plugin manifest distribution, auto-enable metadata, capability-provider registration, and related google plugin adapters behavior.
+          - name: Image and media adapters
+            description: Covers Image and media adapters across bundled `@openclaw/google-plugin` package, plugin manifest distribution, auto-enable metadata, capability-provider registration, and related google plugin adapters behavior.
+          - name: Speech and realtime adapters
+            description: Covers Speech and realtime adapters across bundled `@openclaw/google-plugin` package, plugin manifest distribution, auto-enable metadata, capability-provider registration, and related google plugin adapters behavior.
+          - name: Search and generation tools
+            description: Covers Search and generation tools across bundled `@openclaw/google-plugin` package, plugin manifest distribution, auto-enable metadata, capability-provider registration, and related google plugin adapters behavior.
+          - name: Realtime voice sessions
+            description: Covers Realtime voice sessions across Gemini Live realtime voice provider behavior, Talk relay integration, constrained browser websocket tokens, audio queueing, and related gemini live talk behavior.
+          - name: Constrained browser tokens
+            description: Covers Constrained browser tokens across Gemini Live realtime voice provider behavior, Talk relay integration, constrained browser websocket tokens, audio queueing, and related gemini live talk behavior.
+          - name: Audio and transcript events
+            description: Covers Audio and transcript events across Gemini Live realtime voice provider behavior, Talk relay integration, constrained browser websocket tokens, audio queueing, and related gemini live talk behavior.
+          - name: Live tool calls
+            description: Covers Live tool calls across Gemini Live realtime voice provider behavior, Talk relay integration, constrained browser websocket tokens, audio queueing, and related gemini live talk behavior.
+          - name: Session reconnects
+            description: Covers Session reconnects across Gemini Live realtime voice provider behavior, Talk relay integration, constrained browser websocket tokens, audio queueing, and related gemini live talk behavior.
+        docs:
+          - docs/plugins/reference/google.md
+          - docs/providers/google.md
+        search_anchors:
+          - Bundled plugin distribution
+          - Provider auto-enable metadata
+          - Image and media adapters
+          - Speech and realtime adapters
+          - Search and generation tools
+          - Realtime voice sessions
+          - Constrained browser tokens
+          - Audio and transcript events
+          - Live tool calls
+          - Session reconnects
+        category_note: plugin-distribution-and-cross-surface-capability-adapters.md
+        human_lts_override: false
+      - name: Prompt Caching
+        features:
+          - name: Cache retention config
+            description: Covers Cache retention config across direct `google-generative-ai` Gemini prompt cache eligibility, `cacheRetention`, managed `cachedContents` create/reuse/refresh, manual `cachedContent` config, and related prompt caching behavior.
+          - name: Managed cachedContents
+            description: Covers Managed cachedContents across direct `google-generative-ai` Gemini prompt cache eligibility, `cacheRetention`, managed `cachedContents` create/reuse/refresh, manual `cachedContent` config, and related prompt caching behavior.
+          - name: Manual cachedContent handles
+            description: Covers Manual cachedContent handles across direct `google-generative-ai` Gemini prompt cache eligibility, `cacheRetention`, managed `cachedContents` create/reuse/refresh, manual `cachedContent` config, and related prompt caching behavior.
+          - name: Cache usage accounting
+            description: Covers Cache usage accounting across direct `google-generative-ai` Gemini prompt cache eligibility, `cacheRetention`, managed `cachedContents` create/reuse/refresh, manual `cachedContent` config, and related prompt caching behavior.
+          - name: Cache diagnostics and live proof
+            description: Covers Cache diagnostics and live proof across direct `google-generative-ai` Gemini prompt cache eligibility, `cacheRetention`, managed `cachedContents` create/reuse/refresh, manual `cachedContent` config, and related prompt caching behavior.
+        docs:
+          - docs/reference/prompt-caching.md
+          - docs/providers/google.md
+          - docs/concepts/model-providers.md
+          - docs/reference/token-use.md
+        search_anchors:
+          - Cache retention config
+          - Managed cachedContents
+          - Manual cachedContent handles
+          - Cache usage accounting
+          - Cache diagnostics and live proof
+        category_note: prompt-cache-cache-retention-and-usage-accounting.md
+        human_lts_override: false
+    last_score_run:
+      status: complete
+      completed_at: '2026-05-30'
+      by: codex
+      source_ref: null
+      process_version: 3
+  - id: openrouter-provider-path
+    name: OpenRouter provider path
+    family: provider-tool
+    level: beta
+    level_code: M3
+    rationale: Unified provider path is documented and valuable, but model-specific behavior varies.
+    completeness_instructions: references/completeness/openrouter-provider-path.md
+    categories:
+      - name: Provider Setup and Auth
+        features:
+          - name: First-run setup
+            description: 'Covers First-run setup across user-facing setup and provider registration: the `/providers/openrouter` docs, plugin manifest, provider registration hook, default model registration, and related operator setup and model selection behavior.'
+          - name: Default model selection
+            description: 'Covers Default model selection across user-facing setup and provider registration: the `/providers/openrouter` docs, plugin manifest, provider registration hook, default model registration, and related operator setup and model selection behavior.'
+          - name: Provider plugin registration
+            description: 'Covers Provider plugin registration across user-facing setup and provider registration: the `/providers/openrouter` docs, plugin manifest, provider registration hook, default model registration, and related operator setup and model selection behavior.'
+          - name: Model-ref examples
+            description: 'Covers Model-ref examples across user-facing setup and provider registration: the `/providers/openrouter` docs, plugin manifest, provider registration hook, default model registration, and related operator setup and model selection behavior.'
+          - name: OPENROUTER_API_KEY
+            description: Covers OPENROUTER_API_KEY across `OPENROUTER_API_KEY` discovery, onboarding/auth-choice storage, `auth-profiles.json`, status/probe visibility, and related credentials and auth profiles behavior.
+          - name: Auth profiles and auth order
+            description: Covers Auth profiles and auth order across `OPENROUTER_API_KEY` discovery, onboarding/auth-choice storage, `auth-profiles.json`, status/probe visibility, and related credentials and auth profiles behavior.
+          - name: Status/probe and removal
+            description: Covers Status/probe and removal across `OPENROUTER_API_KEY` discovery, onboarding/auth-choice storage, `auth-profiles.json`, status/probe visibility, and related credentials and auth profiles behavior.
+          - name: Provider-entry SecretRef/API-key resolution
+            description: Covers Provider-entry SecretRef/API-key resolution across `OPENROUTER_API_KEY` discovery, onboarding/auth-choice storage, `auth-profiles.json`, status/probe visibility, and related credentials and auth profiles behavior.
+          - name: Gateway env inheritance
+            description: Covers Gateway env inheritance across `OPENROUTER_API_KEY` discovery, onboarding/auth-choice storage, `auth-profiles.json`, status/probe visibility, and related credentials and auth profiles behavior.
+          - name: Static catalog rows
+            description: Covers Static catalog rows across static catalog rows, dynamic model capability discovery, model-id normalization, `openrouter/<provider>/<model>` references, and related model catalog and dynamic discovery behavior.
+          - name: Dynamic /models discovery
+            description: Covers Dynamic /models discovery across static catalog rows, dynamic model capability discovery, model-id normalization, `openrouter/<provider>/<model>` references, and related model catalog and dynamic discovery behavior.
+          - name: openrouter/auto and nested refs
+            description: Covers openrouter/auto and nested refs across static catalog rows, dynamic model capability discovery, model-id normalization, `openrouter/<provider>/<model>` references, and related model catalog and dynamic discovery behavior.
+          - name: Free-model scan/probe
+            description: Covers Free-model scan/probe across static catalog rows, dynamic model capability discovery, model-id normalization, `openrouter/<provider>/<model>` references, and related model catalog and dynamic discovery behavior.
+          - name: Model list/picker cache
+            description: Covers Model list/picker cache across static catalog rows, dynamic model capability discovery, model-id normalization, `openrouter/<provider>/<model>` references, and related model catalog and dynamic discovery behavior.
+        docs:
+          - docs/providers/openrouter.md
+          - docs/concepts/model-providers.md
+          - docs/cli/configure.md
+          - docs/gateway/authentication.md
+          - docs/help/environment.md
+          - docs/cli/models.md
+          - docs/concepts/models.md
+        search_anchors:
+          - First-run setup
+          - Default model selection
+          - Provider plugin registration
+          - Model-ref examples
+          - OPENROUTER_API_KEY
+          - Auth profiles and auth order
+          - Status/probe and removal
+          - Provider-entry SecretRef/API-key resolution
+          - Gateway env inheritance
+          - Static catalog rows
+          - Dynamic /models discovery
+          - openrouter/auto and nested refs
+          - Free-model scan/probe
+          - Model list/picker cache
+        category_note: operator-setup-and-provider-registration.md
+        human_lts_override: false
+      - name: Chat Runtime and Normalization
+        features:
+          - name: Chat completions route
+            description: Covers Chat completions route across OpenRouter chat completions transport, `models.providers.openrouter.params.provider` routing, per-model routing overrides, OpenRouter proxy reasoning payloads, and related chat routing and reasoning behavior.
+          - name: Provider routing params
+            description: Covers Provider routing params across OpenRouter chat completions transport, `models.providers.openrouter.params.provider` routing, per-model routing overrides, OpenRouter proxy reasoning payloads, and related chat routing and reasoning behavior.
+          - name: Per-model route overrides
+            description: Covers Per-model route overrides across OpenRouter chat completions transport, `models.providers.openrouter.params.provider` routing, per-model routing overrides, OpenRouter proxy reasoning payloads, and related chat routing and reasoning behavior.
+          - name: Reasoning payload policy
+            description: Covers Reasoning payload policy across OpenRouter chat completions transport, `models.providers.openrouter.params.provider` routing, per-model routing overrides, OpenRouter proxy reasoning payloads, and related chat routing and reasoning behavior.
+          - name: Anthropic/Gemini/DeepSeek variants
+            description: Covers Anthropic/Gemini/DeepSeek variants across OpenRouter chat completions transport, `models.providers.openrouter.params.provider` routing, per-model routing overrides, OpenRouter proxy reasoning payloads, and related chat routing and reasoning behavior.
+          - name: Streamed content parsing
+            description: Covers Streamed content parsing across streamed response parsing, visible output extraction from OpenRouter `reasoning_details`, tool-call delta preservation, Mistral strict9 replay policy, and related streaming and tool-call replay behavior.
+          - name: reasoning_details visible output
+            description: Covers reasoning_details visible output across streamed response parsing, visible output extraction from OpenRouter `reasoning_details`, tool-call delta preservation, Mistral strict9 replay policy, and related streaming and tool-call replay behavior.
+          - name: Tool-call delta preservation
+            description: Covers Tool-call delta preservation across streamed response parsing, visible output extraction from OpenRouter `reasoning_details`, tool-call delta preservation, Mistral strict9 replay policy, and related streaming and tool-call replay behavior.
+          - name: Family-specific replay policy
+            description: Covers Family-specific replay policy across streamed response parsing, visible output extraction from OpenRouter `reasoning_details`, tool-call delta preservation, Mistral strict9 replay policy, and related streaming and tool-call replay behavior.
+          - name: Response-model and usage normalization
+            description: Covers Response-model and usage normalization across streamed response parsing, visible output extraction from OpenRouter `reasoning_details`, tool-call delta preservation, Mistral strict9 replay policy, and related streaming and tool-call replay behavior.
+          - name: Attribution headers
+            description: Covers Attribution headers across OpenRouter app attribution, response cache headers, TTL and clear behavior, Anthropic cache-control markers, prompt-cache retention, cache-read/cache-write usage mapping, verified-route gating, and custom proxy exclusions.
+          - name: Response-cache headers/TTL/clear
+            description: Covers Response-cache headers/TTL/clear across OpenRouter app attribution, response cache headers, TTL and clear behavior, Anthropic cache-control markers, prompt-cache retention, cache-read/cache-write usage mapping, verified-route gating, and custom proxy exclusions.
+          - name: Anthropic cache-control markers
+            description: Covers Anthropic cache-control markers across OpenRouter app attribution, response cache headers, TTL and clear behavior, Anthropic cache-control markers, prompt-cache retention, cache-read/cache-write usage mapping, verified-route gating, and custom proxy exclusions.
+          - name: Cache usage mapping
+            description: Covers Cache usage mapping across OpenRouter app attribution, response cache headers, TTL and clear behavior, Anthropic cache-control markers, prompt-cache retention, cache-read/cache-write usage mapping, verified-route gating, and custom proxy exclusions.
+          - name: Custom proxy exclusions
+            description: Covers Custom proxy exclusions across OpenRouter app attribution, response cache headers, TTL and clear behavior, Anthropic cache-control markers, prompt-cache retention, cache-read/cache-write usage mapping, verified-route gating, and custom proxy exclusions.
+        docs:
+          - docs/providers/openrouter.md
+          - docs/concepts/model-providers.md
+          - docs/reference/prompt-caching.md
+        search_anchors:
+          - Chat completions route
+          - Provider routing params
+          - Per-model route overrides
+          - Reasoning payload policy
+          - Anthropic/Gemini/DeepSeek variants
+          - Streamed content parsing
+          - reasoning_details visible output
+          - Tool-call delta preservation
+          - Family-specific replay policy
+          - Response-model and usage normalization
+          - Attribution headers
+          - Response-cache headers/TTL/clear
+          - Anthropic cache-control markers
+          - Cache usage mapping
+          - Custom proxy exclusions
+        category_note: chat-completions-transport-routing-and-reasoning.md
+        human_lts_override: false
+      - name: Provider Recovery and Diagnostics
+        features:
+          - name: Timeout/retry classification
+            description: Covers Timeout/retry classification across OpenRouter timeout and retry classification, provider-specific generic errors, auth/billing/key-limit classification, context overflow parsing, and related failover and diagnostics behavior.
+          - name: Auth/billing/key-limit classification
+            description: Covers Auth/billing/key-limit classification across OpenRouter timeout and retry classification, provider-specific generic errors, auth/billing/key-limit classification, context overflow parsing, and related failover and diagnostics behavior.
+          - name: Context overflow
+            description: Covers Context overflow across OpenRouter timeout and retry classification, provider-specific generic errors, auth/billing/key-limit classification, context overflow parsing, and related failover and diagnostics behavior.
+          - name: Model fallback notices
+            description: Covers Model fallback notices across OpenRouter timeout and retry classification, provider-specific generic errors, auth/billing/key-limit classification, context overflow parsing, and related failover and diagnostics behavior.
+          - name: Guarded fetch/pricing warnings
+            description: Covers Guarded fetch/pricing warnings across OpenRouter timeout and retry classification, provider-specific generic errors, auth/billing/key-limit classification, context overflow parsing, and related failover and diagnostics behavior.
+        docs:
+          - docs/concepts/model-failover.md
+          - docs/providers/openrouter.md
+          - docs/cli/models.md
+        search_anchors:
+          - Timeout/retry classification
+          - Auth/billing/key-limit classification
+          - Context overflow
+          - Model fallback notices
+          - Guarded fetch/pricing warnings
+        category_note: failover-errors-overflow-and-diagnostics.md
+        human_lts_override: false
+      - name: Media Generation and Speech
+        features:
+          - name: image_generate OpenRouter route
+            description: Covers image_generate OpenRouter route across OpenRouter image, video, music, TTS, and related image, video, music, and speech behavior.
+          - name: video_generate async jobs/polling/download
+            description: Covers video_generate async jobs/polling/download across OpenRouter image, video, music, TTS, and related image, video, music, and speech behavior.
+          - name: music_generate audio route
+            description: Covers music_generate audio route across OpenRouter image, video, music, TTS, and related image, video, music, and speech behavior.
+          - name: Text-to-speech
+            description: Covers Text-to-speech across OpenRouter image, video, music, TTS, and related image, video, music, and speech behavior.
+          - name: Speech-to-text transcription
+            description: Covers Speech-to-text transcription across OpenRouter image, video, music, TTS, and related image, video, music, and speech behavior.
+          - name: Inbound media understanding
+            description: Covers Inbound media understanding across OpenRouter image, video, music, TTS, and related image, video, music, and speech behavior.
+          - name: Generated artifact delivery
+            description: Covers Generated artifact delivery across OpenRouter image, video, music, TTS, and related image, video, music, and speech behavior.
+        docs:
+          - docs/providers/openrouter.md
+          - docs/tools/image-generation.md
+          - docs/tools/music-generation.md
+          - docs/tools/media-overview.md
+          - docs/tools/video-generation.md
+          - docs/tools/tts.md
+        search_anchors:
+          - image_generate OpenRouter route
+          - video_generate async jobs/polling/download
+          - music_generate audio route
+          - Text-to-speech
+          - Speech-to-text transcription
+          - Inbound media understanding
+          - Generated artifact delivery
+        category_note: media-generation-speech-and-media-understanding.md
+        human_lts_override: false
+    last_score_run:
+      status: complete
+      completed_at: '2026-05-30'
+      by: codex
+      source_ref: null
+      process_version: 3
+  - id: local-model-providers-ollama-vllm-sglang-lm-studio
+    name: 'Local model providers: Ollama, vLLM, SGLang, LM Studio'
+    family: provider-tool
+    level: alpha
+    level_code: M2
+    rationale: Useful and documented, but environment variance is high.
+    completeness_instructions: references/completeness/local-model-providers-ollama-vllm-sglang-lm-studio.md
+    categories:
+      - name: Provider Setup, Lifecycle, and Diagnostics
+        features:
+          - name: Provider Selection
+            description: Covers Provider Selection across provider choice, `openclaw onboard`, model-picker contributions, non-interactive setup, and related provider selection and onboarding behavior.
+          - name: Onboarding
+            description: Covers Onboarding across provider choice, `openclaw onboard`, model-picker contributions, non-interactive setup, and related provider selection and onboarding behavior.
+          - name: localService configuration
+            description: Covers localService configuration across `localService` config contract, process startup, readiness probes, lease/release behavior during provider requests, and related local service lifecycle and readiness behavior.
+          - name: Process startup and readiness
+            description: Covers Process startup and readiness across `localService` config contract, process startup, readiness probes, lease/release behavior during provider requests, and related local service lifecycle and readiness behavior.
+          - name: Request leases and idle shutdown
+            description: Covers Request leases and idle shutdown across `localService` config contract, process startup, readiness probes, lease/release behavior during provider requests, and related local service lifecycle and readiness behavior.
+          - name: Health checks and restart
+            description: Covers Health checks and restart across `localService` config contract, process startup, readiness probes, lease/release behavior during provider requests, and related local service lifecycle and readiness behavior.
+          - name: Provider recipes
+            description: Covers Provider recipes across `localService` config contract, process startup, readiness probes, lease/release behavior during provider requests, and related local service lifecycle and readiness behavior.
+          - name: Local provider status
+            description: Covers Local provider status across user-facing diagnostic commands, provider HTTP error normalization, model-not-found classification, direct local backend probes, and related diagnostics and troubleshooting behavior.
+          - name: Backend reachability probes
+            description: Covers Backend reachability probes across user-facing diagnostic commands, provider HTTP error normalization, model-not-found classification, direct local backend probes, and related diagnostics and troubleshooting behavior.
+          - name: Model availability errors
+            description: Covers Model availability errors across user-facing diagnostic commands, provider HTTP error normalization, model-not-found classification, direct local backend probes, and related diagnostics and troubleshooting behavior.
+          - name: Memory readiness diagnostics
+            description: Covers Memory readiness diagnostics across user-facing diagnostic commands, provider HTTP error normalization, model-not-found classification, direct local backend probes, and related diagnostics and troubleshooting behavior.
+          - name: Provider troubleshooting docs
+            description: Covers Provider troubleshooting docs across user-facing diagnostic commands, provider HTTP error normalization, model-not-found classification, direct local backend probes, and related diagnostics and troubleshooting behavior.
+        docs:
+          - docs/gateway/local-models.md
+          - docs/providers/lmstudio.md
+          - docs/providers/ollama.md
+          - docs/providers/vllm.md
+          - docs/gateway/local-model-services.md
+          - docs/gateway/config-agents.md
+          - docs/gateway/troubleshooting.md
+          - docs/gateway/doctor.md
+        search_anchors:
+          - Provider Selection
+          - Onboarding
+          - 'local model providers: ollama, vllm, sglang, lm studio provider selection and onboarding'
+          - provider selection and onboarding
+          - localService configuration
+          - Process startup and readiness
+          - Request leases and idle shutdown
+          - Health checks and restart
+          - Provider recipes
+          - Local provider status
+          - Backend reachability probes
+          - Model availability errors
+          - Memory readiness diagnostics
+          - Provider troubleshooting docs
+        category_note: provider-selection-and-onboarding.md
+        human_lts_override: false
+      - name: Native Provider Plugins
+        features:
+          - name: Ollama setup and model pulling
+            description: Covers Ollama setup and model pulling across native Ollama chat/model discovery, cloud+local/local-only setup, local auth markers, model pulling, and related ollama native provider behavior.
+          - name: Model discovery
+            description: Covers Model discovery across native Ollama chat/model discovery, cloud+local/local-only setup, local auth markers, model pulling, and related ollama native provider behavior.
+          - name: Streaming and vision
+            description: Covers Streaming and vision across native Ollama chat/model discovery, cloud+local/local-only setup, local auth markers, model pulling, and related ollama native provider behavior.
+          - name: Ollama embeddings
+            description: Covers Ollama embeddings across native Ollama chat/model discovery, cloud+local/local-only setup, local auth markers, model pulling, and related ollama native provider behavior.
+          - name: Web-search support
+            description: Covers Web-search support across native Ollama chat/model discovery, cloud+local/local-only setup, local auth markers, model pulling, and related ollama native provider behavior.
+          - name: LM Studio setup
+            description: Covers LM Studio setup across LM Studio provider plugin, `/providers/lmstudio` docs, model discovery from LM Studio APIs, auth behavior for local and authenticated instances, preload/JIT behavior, OpenAI-compatible streaming, and LM Studio memory embeddings.
+          - name: Model discovery and auth
+            description: Covers Model discovery and auth across LM Studio provider plugin, `/providers/lmstudio` docs, model discovery from LM Studio APIs, auth behavior for local and authenticated instances, preload/JIT behavior, OpenAI-compatible streaming, and LM Studio memory embeddings.
+          - name: Model preload and JIT loading
+            description: Covers Model preload and JIT loading across LM Studio provider plugin, `/providers/lmstudio` docs, model discovery from LM Studio APIs, auth behavior for local and authenticated instances, preload/JIT behavior, OpenAI-compatible streaming, and LM Studio memory embeddings.
+          - name: Streaming compatibility
+            description: Covers Streaming compatibility across LM Studio provider plugin, `/providers/lmstudio` docs, model discovery from LM Studio APIs, auth behavior for local and authenticated instances, preload/JIT behavior, OpenAI-compatible streaming, and LM Studio memory embeddings.
+          - name: LM Studio embeddings
+            description: Covers LM Studio embeddings across LM Studio provider plugin, `/providers/lmstudio` docs, model discovery from LM Studio APIs, auth behavior for local and authenticated instances, preload/JIT behavior, OpenAI-compatible streaming, and LM Studio memory embeddings.
+        docs:
+          - docs/providers/ollama.md
+          - docs/providers/lmstudio.md
+        search_anchors:
+          - Ollama setup and model pulling
+          - Model discovery
+          - Streaming and vision
+          - Ollama embeddings
+          - Web-search support
+          - LM Studio setup
+          - Model discovery and auth
+          - Model preload and JIT loading
+          - Streaming compatibility
+          - LM Studio embeddings
+        category_note: ollama-native-provider.md
+        human_lts_override: false
+      - name: OpenAI-Compatible Runtime Compatibility
+        features:
+          - name: Bundled provider setup
+            description: Covers Bundled provider setup across bundled `vllm` and `sglang` provider plugins, docs, default env/base URL behavior, `/v1/models` discovery, and related vllm and sglang openai-compatible providers behavior.
+          - name: Model Discovery Endpoint
+            description: Covers Model Discovery Endpoint across bundled `vllm` and `sglang` provider plugins, docs, default env/base URL behavior, `/v1/models` discovery, and related vllm and sglang openai-compatible providers behavior.
+          - name: Non-interactive configuration
+            description: Covers Non-interactive configuration across bundled `vllm` and `sglang` provider plugins, docs, default env/base URL behavior, `/v1/models` discovery, and related vllm and sglang openai-compatible providers behavior.
+          - name: vLLM thinking controls
+            description: Covers vLLM thinking controls across bundled `vllm` and `sglang` provider plugins, docs, default env/base URL behavior, `/v1/models` discovery, and related vllm and sglang openai-compatible providers behavior.
+          - name: OpenAI-compatible chat and tool semantics
+            description: Covers OpenAI-compatible chat and tool semantics across bundled `vllm` and `sglang` provider plugins, docs, default env/base URL behavior, `/v1/models` discovery, and related vllm and sglang openai-compatible providers behavior.
+          - name: SGLang compatibility guidance
+            description: Covers SGLang compatibility guidance across bundled `vllm` and `sglang` provider plugins, docs, default env/base URL behavior, `/v1/models` discovery, and related vllm and sglang openai-compatible providers behavior.
+          - name: Request Stream Compatibility
+            description: Covers Request Stream Compatibility across chat and Responses-style request shaping, streaming normalization, tool-call compatibility, local-model reasoning controls, and related request stream compatibility and tool calling behavior.
+          - name: Tool Calling
+            description: Covers Tool Calling across chat and Responses-style request shaping, streaming normalization, tool-call compatibility, local-model reasoning controls, and related request stream compatibility and tool calling behavior.
+        docs:
+          - docs/providers/vllm.md
+          - docs/providers/sglang.md
+          - docs/gateway/local-models.md
+          - docs/providers/lmstudio.md
+        search_anchors:
+          - Bundled provider setup
+          - /v1/models discovery
+          - Non-interactive configuration
+          - vLLM thinking controls
+          - OpenAI-compatible chat and tool semantics
+          - SGLang compatibility guidance
+          - Request Stream Compatibility
+          - Tool Calling
+          - 'local model providers: ollama, vllm, sglang, lm studio request stream compatibility and tool calling'
+          - request stream compatibility and tool calling
+        category_note: request-stream-compatibility-and-tool-calling.md
+        human_lts_override: false
+      - name: Local Memory and Embeddings
+        features:
+          - name: Embedding provider selection
+            description: Covers Embedding provider selection across local embedding provider registration for Ollama and LM Studio, memory host embedding behavior, memory search readiness, local `memoryFlush` model overrides, and related local embeddings and memory behavior.
+          - name: Memory search readiness
+            description: Covers Memory search readiness across local embedding provider registration for Ollama and LM Studio, memory host embedding behavior, memory search readiness, local `memoryFlush` model overrides, and related local embeddings and memory behavior.
+          - name: memoryFlush model override
+            description: Covers memoryFlush model override across local embedding provider registration for Ollama and LM Studio, memory host embedding behavior, memory search readiness, local `memoryFlush` model overrides, and related local embeddings and memory behavior.
+          - name: Fallback lexical search
+            description: Covers Fallback lexical search across local embedding provider registration for Ollama and LM Studio, memory host embedding behavior, memory search readiness, local `memoryFlush` model overrides, and related local embeddings and memory behavior.
+          - name: Provider mismatch guidance
+            description: Covers Provider mismatch guidance across local embedding provider registration for Ollama and LM Studio, memory host embedding behavior, memory search readiness, local `memoryFlush` model overrides, and related local embeddings and memory behavior.
+        docs:
+          - docs/concepts/memory.md
+          - docs/gateway/doctor.md
+        search_anchors:
+          - Embedding provider selection
+          - Memory search readiness
+          - memoryFlush model override
+          - Fallback lexical search
+          - Provider mismatch guidance
+        category_note: local-embeddings-and-memory-provider-usage.md
+        human_lts_override: false
+      - name: Network Safety and Prompt Controls
+        features:
+          - name: Safety Network
+            description: Covers Safety Network across private-network and exact-origin trust for local provider base URLs, SSRF protections for self-hosted setup, special-token sanitization, local-model lean prompt behavior, and related safety network and prompt pressure controls behavior.
+          - name: Prompt Pressure Controls
+            description: Covers Prompt Pressure Controls across private-network and exact-origin trust for local provider base URLs, SSRF protections for self-hosted setup, special-token sanitization, local-model lean prompt behavior, and related safety network and prompt pressure controls behavior.
+        docs:
+          - docs/gateway/security/index.md
+          - docs/gateway/config-tools.md
+          - docs/gateway/local-models.md
+        search_anchors:
+          - Safety Network
+          - Prompt Pressure Controls
+          - 'local model providers: ollama, vllm, sglang, lm studio safety network and prompt pressure controls'
+          - safety network and prompt pressure controls
+        category_note: safety-network-and-prompt-pressure-controls.md
+        human_lts_override: false
+    last_score_run:
+      status: complete
+      completed_at: '2026-05-30'
+      by: codex
+      source_ref: null
+      process_version: 3
+  - id: long-tail-hosted-providers
+    name: Long-tail hosted providers
+    family: provider-tool
+    level: alpha
+    level_code: M2
+    rationale: Many docs/reference pages exist; score should be generated from provider metadata plus live smoke coverage.
+    completeness_instructions: references/completeness/long-tail-hosted-providers.md
+    categories:
+      - name: Hosted LLM Providers
+        features:
+          - name: Bedrock setup
+            description: Covers Bedrock setup across Amazon Bedrock, Bedrock Mantle, Cloudflare AI Gateway, Vercel AI Gateway, and related cloud and gateway providers behavior.
+          - name: Gateway/proxy routing
+            description: Covers Gateway/proxy routing across Amazon Bedrock, Bedrock Mantle, Cloudflare AI Gateway, Vercel AI Gateway, and related cloud and gateway providers behavior.
+          - name: Copilot/OpenCode hosted access
+            description: Covers Copilot/OpenCode hosted access across Amazon Bedrock, Bedrock Mantle, Cloudflare AI Gateway, Vercel AI Gateway, and related cloud and gateway providers behavior.
+          - name: Proxy capability diagnostics
+            description: Covers Proxy capability diagnostics across Amazon Bedrock, Bedrock Mantle, Cloudflare AI Gateway, Vercel AI Gateway, and related cloud and gateway providers behavior.
+          - name: Hosted text completion
+            description: 'Covers Hosted text completion across hosted text providers that mostly use OpenAI-compatible routes or close variants: DeepSeek, Groq, Mistral, Together, and related openai-compatible hosted text providers behavior.'
+          - name: Tool-call and streaming compatibility
+            description: 'Covers Tool-call and streaming compatibility across hosted text providers that mostly use OpenAI-compatible routes or close variants: DeepSeek, Groq, Mistral, Together, and related openai-compatible hosted text providers behavior.'
+          - name: Model catalog resolution
+            description: 'Covers Model catalog resolution across hosted text providers that mostly use OpenAI-compatible routes or close variants: DeepSeek, Groq, Mistral, Together, and related openai-compatible hosted text providers behavior.'
+          - name: Provider-specific request shaping
+            description: 'Covers Provider-specific request shaping across hosted text providers that mostly use OpenAI-compatible routes or close variants: DeepSeek, Groq, Mistral, Together, and related openai-compatible hosted text providers behavior.'
+          - name: Regional provider setup
+            description: Covers Regional provider setup across Qwen, Alibaba, Tencent, Qianfan, and related regional hosted llm providers behavior.
+          - name: Region and plan routing
+            description: Covers Region and plan routing across Qwen, Alibaba, Tencent, Qianfan, and related regional hosted llm providers behavior.
+          - name: Regional live smoke
+            description: Covers Regional live smoke across Qwen, Alibaba, Tencent, Qianfan, and related regional hosted llm providers behavior.
+          - name: Account prerequisite diagnostics
+            description: Covers Account prerequisite diagnostics across Qwen, Alibaba, Tencent, Qianfan, and related regional hosted llm providers behavior.
+        docs:
+          - docs/providers/index.md
+          - docs/concepts/model-providers.md
+          - docs/help/testing-live.md
+          - docs/cli/onboard.md
+        search_anchors:
+          - Bedrock setup
+          - Gateway/proxy routing
+          - Copilot/OpenCode hosted access
+          - Proxy capability diagnostics
+          - Hosted text completion
+          - Tool-call and streaming compatibility
+          - Model catalog resolution
+          - Provider-specific request shaping
+          - Regional provider setup
+          - Region and plan routing
+          - Regional live smoke
+          - Account prerequisite diagnostics
+        category_note: openai-compatible-hosted-text-adapters.md
+        human_lts_override: false
+      - name: Hosted Media Providers
+        features:
+          - name: Image generation providers
+            description: Covers Image generation providers across hosted image, video, and music generation provider paths, including DeepInfra, and related hosted media generation providers behavior.
+          - name: Video generation providers
+            description: Covers Video generation providers across hosted image, video, and music generation provider paths, including DeepInfra, and related hosted media generation providers behavior.
+          - name: Music generation providers
+            description: Covers Music generation providers across hosted image, video, and music generation provider paths, including DeepInfra, and related hosted media generation providers behavior.
+          - name: Media mode coverage
+            description: Covers Media mode coverage across hosted image, video, and music generation provider paths, including DeepInfra, and related hosted media generation providers behavior.
+          - name: Text-to-speech providers
+            description: Covers Text-to-speech providers across text-to-speech, speech-to-text, realtime transcription, telephony audio, and related hosted speech, transcription, and audio providers behavior.
+          - name: Speech-to-text providers
+            description: Covers Speech-to-text providers across text-to-speech, speech-to-text, realtime transcription, telephony audio, and related hosted speech, transcription, and audio providers behavior.
+          - name: Realtime transcription providers
+            description: Covers Realtime transcription providers across text-to-speech, speech-to-text, realtime transcription, telephony audio, and related hosted speech, transcription, and audio providers behavior.
+          - name: Audio format diagnostics
+            description: Covers Audio format diagnostics across text-to-speech, speech-to-text, realtime transcription, telephony audio, and related hosted speech, transcription, and audio providers behavior.
+        docs:
+          - docs/plugins/manifest.md
+          - docs/help/testing-live.md
+          - docs/providers/index.md
+        search_anchors:
+          - Image generation providers
+          - Video generation providers
+          - Music generation providers
+          - Media mode coverage
+          - Text-to-speech providers
+          - Speech-to-text providers
+          - Realtime transcription providers
+          - Audio format diagnostics
+        category_note: hosted-media-generation-providers.md
+        human_lts_override: false
+      - name: Provider Operations
+        features:
+          - name: Provider directory
+            description: Covers Provider directory across public provider directory, provider docs links, model provider overview tables, manifest provider metadata, and related provider catalog and discovery behavior.
+          - name: Provider install catalog
+            description: Covers Provider install catalog across public provider directory, provider docs links, model provider overview tables, manifest provider metadata, and related provider catalog and discovery behavior.
+          - name: Model catalog metadata
+            description: Covers Model catalog metadata across public provider directory, provider docs links, model provider overview tables, manifest provider metadata, and related provider catalog and discovery behavior.
+          - name: Catalog parity checks
+            description: Covers Catalog parity checks across public provider directory, provider docs links, model provider overview tables, manifest provider metadata, and related provider catalog and discovery behavior.
+          - name: Provider setup descriptors
+            description: Covers Provider setup descriptors across provider setup descriptors, provider auth choices, auth env-var metadata, auth aliases, and related setup and credential health behavior.
+          - name: Auth profiles and aliases
+            description: Covers Auth profiles and aliases across provider setup descriptors, provider auth choices, auth env-var metadata, auth aliases, and related setup and credential health behavior.
+          - name: Credential health probes
+            description: Covers Credential health probes across provider setup descriptors, provider auth choices, auth env-var metadata, auth aliases, and related setup and credential health behavior.
+          - name: Key rotation and recovery
+            description: Covers Key rotation and recovery across provider setup descriptors, provider auth choices, auth env-var metadata, auth aliases, and related setup and credential health behavior.
+          - name: Direct provider smoke
+            description: Covers Direct provider smoke across direct live provider/model smoke, Gateway live profile smoke, `models status --probe`, auth/status buckets, and related provider diagnostics and fallback repair behavior.
+          - name: Gateway live smoke
+            description: Covers Gateway live smoke across direct live provider/model smoke, Gateway live profile smoke, `models status --probe`, auth/status buckets, and related provider diagnostics and fallback repair behavior.
+          - name: Models status probes
+            description: Covers Models status probes across direct live provider/model smoke, Gateway live profile smoke, `models status --probe`, auth/status buckets, and related provider diagnostics and fallback repair behavior.
+          - name: Fallback trace and repair
+            description: Covers Fallback trace and repair across direct live provider/model smoke, Gateway live profile smoke, `models status --probe`, auth/status buckets, and related provider diagnostics and fallback repair behavior.
+        docs:
+          - docs/providers/index.md
+          - docs/concepts/model-providers.md
+          - docs/plugins/manifest.md
+          - docs/help/testing-live.md
+          - docs/cli/models.md
+        search_anchors:
+          - Provider directory
+          - Provider install catalog
+          - Model catalog metadata
+          - Catalog parity checks
+          - Provider setup descriptors
+          - Auth profiles and aliases
+          - Credential health probes
+          - Key rotation and recovery
+          - Direct provider smoke
+          - Gateway live smoke
+          - Models status probes
+          - Fallback trace and repair
+        category_note: setup-auth-profiles-and-credential-health.md
+        human_lts_override: false
+    last_score_run:
+      status: complete
+      completed_at: '2026-05-30'
+      by: codex
+      source_ref: null
+      process_version: 3
+  - id: web-search-tools
+    name: Web search tools
+    family: provider-tool
+    level: beta
+    level_code: M3
+    rationale: Multiple providers and docs exist. Needs quota/error/SSRF proof per provider family.
+    completeness_instructions: references/completeness/web-search-tools.md
+    categories:
+      - name: Search Providers
+        features:
+          - name: API-backed providers
+            description: Covers API-backed providers provider routing, request shaping, streaming, and response normalization for Structured Search Providers.
+          - name: Keyless and self-hosted providers
+            description: Covers Keyless and self-hosted providers provider routing, request shaping, streaming, and response normalization for Structured Search Providers.
+          - name: Provider comparison and auto-detection
+            description: Covers Provider comparison and auto-detection provider routing, request shaping, streaming, and response normalization for Structured Search Providers.
+          - name: Provider-specific filters and extraction
+            description: Covers Provider-specific filters and extraction provider routing, request shaping, streaming, and response normalization for Structured Search Providers.
+          - name: Result normalization
+            description: Covers Result normalization provider routing, request shaping, streaming, and response normalization for Structured Search Providers.
+          - name: OpenAI native web_search
+            description: Covers OpenAI native web_search routing, session binding, history, and conversation context for Provider-Native Grounded Search.
+          - name: Codex native web_search
+            description: Covers Codex native web_search routing, session binding, history, and conversation context for Provider-Native Grounded Search.
+          - name: Gemini grounding
+            description: Covers Gemini grounding routing, session binding, history, and conversation context for Provider-Native Grounded Search.
+          - name: Grok web grounding
+            description: Covers Grok web grounding routing, session binding, history, and conversation context for Provider-Native Grounded Search.
+          - name: Kimi web search
+            description: Covers Kimi web search routing, session binding, history, and conversation context for Provider-Native Grounded Search.
+          - name: Provider-native citations
+            description: Covers Provider-native citations routing, session binding, history, and conversation context for Provider-Native Grounded Search.
+          - name: Model and filter routing
+            description: Covers Model and filter routing routing, session binding, history, and conversation context for Provider-Native Grounded Search.
+          - name: webSearchProviders
+            description: Defines webSearchProviders setup, credential, configuration, and operator verification behavior for Web Provider Plugin Contracts.
+          - name: registerWebSearchProvider
+            description: Defines registerWebSearchProvider setup, credential, configuration, and operator verification behavior for Web Provider Plugin Contracts.
+          - name: webFetchProviders
+            description: Defines webFetchProviders setup, credential, configuration, and operator verification behavior for Web Provider Plugin Contracts.
+          - name: registerWebFetchProvider
+            description: Defines registerWebFetchProvider setup, credential, configuration, and operator verification behavior for Web Provider Plugin Contracts.
+          - name: public-artifact loading
+            description: Defines public-artifact loading setup, credential, configuration, and operator verification behavior for Web Provider Plugin Contracts.
+          - name: runtime resolution
+            description: Defines runtime resolution setup, credential, configuration, and operator verification behavior for Web Provider Plugin Contracts.
+          - name: contract tests
+            description: Defines contract tests setup, credential, configuration, and operator verification behavior for Web Provider Plugin Contracts.
+        docs:
+          - docs/tools/web.md
+          - docs/tools/brave-search.md
+          - docs/tools/tavily.md
+          - docs/tools/exa-search.md
+          - docs/tools/firecrawl.md
+          - docs/tools/perplexity-search.md
+          - docs/tools/duckduckgo-search.md
+          - docs/tools/searxng-search.md
+          - docs/tools/gemini-search.md
+          - docs/tools/grok-search.md
+          - docs/tools/kimi-search.md
+          - docs/tools/minimax-search.md
+          - docs/tools/ollama-search.md
+          - docs/plugins/sdk-subpaths.md
+          - docs/plugins/sdk-overview.md
+          - docs/plugins/manifest.md
+        search_anchors:
+          - API-backed providers
+          - Keyless and self-hosted providers
+          - Provider comparison and auto-detection
+          - Provider-specific filters and extraction
+          - Result normalization
+          - OpenAI native web_search
+          - Codex native web_search
+          - Gemini grounding
+          - Grok web grounding
+          - Kimi web search
+          - Provider-native citations
+          - Model and filter routing
+          - webSearchProviders
+          - registerWebSearchProvider
+          - webFetchProviders
+          - registerWebFetchProvider
+          - public-artifact loading
+          - runtime resolution
+          - contract tests
+        category_note: bundled-structured-search-providers.md
+        human_lts_override: false
+      - name: Setup and Diagnostics
+        features:
+          - name: Provider credentials
+            description: Defines Provider credentials setup, credential, configuration, and operator verification behavior for Setup and Credential Repair.
+          - name: Default provider selection
+            description: Defines Default provider selection setup, credential, configuration, and operator verification behavior for Setup and Credential Repair.
+          - name: Credential repair
+            description: Defines Credential repair setup, credential, configuration, and operator verification behavior for Setup and Credential Repair.
+          - name: Status checks
+            description: Defines Status checks setup, credential, configuration, and operator verification behavior for Setup and Credential Repair.
+          - name: Quota errors
+            description: Covers Quota errors status, diagnostics, failure handling, and operator repair for Provider Reliability and Diagnostics.
+          - name: Cache controls
+            description: Covers Cache controls status, diagnostics, failure handling, and operator repair for Provider Reliability and Diagnostics.
+          - name: Provider diagnostics
+            description: Covers Provider diagnostics status, diagnostics, failure handling, and operator repair for Provider Reliability and Diagnostics.
+          - name: Retry and fallback
+            description: Covers Retry and fallback status, diagnostics, failure handling, and operator repair for Provider Reliability and Diagnostics.
+          - name: Operator repair
+            description: Covers Operator repair status, diagnostics, failure handling, and operator repair for Provider Reliability and Diagnostics.
+        docs:
+          - docs/tools/web.md
+          - docs/tools/web-fetch.md
+          - docs/help/faq.md
+          - docs/reference/api-usage-costs.md
+          - docs/tools/brave-search.md
+          - docs/tools/perplexity-search.md
+          - docs/tools/tavily.md
+          - docs/tools/firecrawl.md
+        search_anchors:
+          - Provider credentials
+          - Default provider selection
+          - Credential repair
+          - Status checks
+          - Quota errors
+          - Cache controls
+          - Provider diagnostics
+          - Retry and fallback
+          - Operator repair
+        category_note: operator-setup-provider-selection-and-credential-repair.md
+        human_lts_override: false
+      - name: Network Safety
+        features:
+          - name: Network Safety
+            description: Defines Network Safety authorization, trust, safety boundaries, and operator controls for Network Safety, Ssrf, Redirects, and Untrusted Content.
+          - name: SSRF
+            description: Defines SSRF authorization, trust, safety boundaries, and operator controls for Network Safety, Ssrf, Redirects, and Untrusted Content.
+          - name: Redirects
+            description: Defines Redirects authorization, trust, safety boundaries, and operator controls for Network Safety, Ssrf, Redirects, and Untrusted Content.
+          - name: Untrusted Content
+            description: Defines Untrusted Content authorization, trust, safety boundaries, and operator controls for Network Safety, Ssrf, Redirects, and Untrusted Content.
+        docs:
+          - docs/tools/web.md
+          - docs/tools/web-fetch.md
+          - docs/tools/firecrawl.md
+          - docs/tools/searxng-search.md
+        search_anchors:
+          - Network Safety
+          - SSRF
+          - Redirects
+          - Untrusted Content
+          - web search tools network safety, ssrf, redirects, and untrusted content
+          - network safety, ssrf, redirects, and untrusted content
+        category_note: network-safety-ssrf-redirects-and-untrusted-content.md
+        human_lts_override: false
+      - name: Tool Availability and Fetch
+        features:
+          - name: web_search exposure
+            description: Defines web_search exposure setup, credential, configuration, and operator verification behavior for Tool Availability and Policy.
+          - name: web_fetch exposure
+            description: Defines web_fetch exposure setup, credential, configuration, and operator verification behavior for Tool Availability and Policy.
+          - name: x_search exposure
+            description: Defines x_search exposure setup, credential, configuration, and operator verification behavior for Tool Availability and Policy.
+          - name: group:web policy
+            description: Defines group:web policy setup, credential, configuration, and operator verification behavior for Tool Availability and Policy.
+          - name: disabled-state diagnostics
+            description: Defines disabled-state diagnostics setup, credential, configuration, and operator verification behavior for Tool Availability and Policy.
+          - name: provider/model gating
+            description: Defines provider/model gating setup, credential, configuration, and operator verification behavior for Tool Availability and Policy.
+          - name: URL fetch
+            description: Covers URL fetch tool invocation, host execution, sandbox policy, and artifact handling for Web Fetch and Content Extraction.
+          - name: HTML extraction
+            description: Covers HTML extraction tool invocation, host execution, sandbox policy, and artifact handling for Web Fetch and Content Extraction.
+          - name: PDF/text extraction
+            description: Covers PDF/text extraction tool invocation, host execution, sandbox policy, and artifact handling for Web Fetch and Content Extraction.
+          - name: Safe truncation
+            description: Covers Safe truncation tool invocation, host execution, sandbox policy, and artifact handling for Web Fetch and Content Extraction.
+          - name: Content citation handoff
+            description: Covers Content citation handoff tool invocation, host execution, sandbox policy, and artifact handling for Web Fetch and Content Extraction.
+        docs:
+          - docs/gateway/config-tools.md
+          - docs/tools/web-fetch.md
+          - docs/tools/web.md
+          - docs/help/faq.md
+        search_anchors:
+          - web_search exposure
+          - web_fetch exposure
+          - x_search exposure
+          - group:web policy
+          - disabled-state diagnostics
+          - provider/model gating
+          - URL fetch
+          - HTML extraction
+          - PDF/text extraction
+          - Safe truncation
+          - Content citation handoff
+        category_note: tool-exposure-policy-and-runtime-tool-wiring.md
+        human_lts_override: false
+    last_score_run:
+      status: complete
+      completed_at: '2026-05-30'
+      by: codex
+      source_ref: null
+      process_version: 3
+  - id: browser-automation-and-exec-sandbox-tools
+    name: Browser automation and exec/sandbox tools
+    family: provider-tool
+    level: beta
+    level_code: M3
+    rationale: Core tools are documented, but host security and permission UX should stay under active scorecard review.
+    completeness_instructions: references/completeness/browser-automation-and-exec-sandbox-tools.md
+    categories:
+      - name: Browser Automation
+        features:
+          - name: Browser Actions
+            description: Covers Browser Actions across browser tool action schemas, navigate/act/snapshot/screenshot operations, AI/role/ARIA snapshot formats, action ref storage, and related browser actions, snapshots, and artifacts behavior.
+          - name: Snapshots
+            description: Covers Snapshots across browser tool action schemas, navigate/act/snapshot/screenshot operations, AI/role/ARIA snapshot formats, action ref storage, and related browser actions, snapshots, and artifacts behavior.
+          - name: Artifacts
+            description: Covers Artifacts across browser tool action schemas, navigate/act/snapshot/screenshot operations, AI/role/ARIA snapshot formats, action ref storage, and related browser actions, snapshots, and artifacts behavior.
+          - name: Browser Plugin Service
+            description: Covers Browser Plugin Service across bundled browser plugin activation, browser CLI registration, `browser.request` Gateway routing, control-service startup, and related browser plugin service and profiles behavior.
+          - name: Profiles
+            description: Covers Profiles across bundled browser plugin activation, browser CLI registration, `browser.request` Gateway routing, control-service startup, and related browser plugin service and profiles behavior.
+          - name: Browser Security
+            description: Covers Browser Security across browser-control auth, navigation URL validation, delayed navigation guards, strict private-network SSRF policy, and related browser security, ssrf, and remote control behavior.
+          - name: SSRF
+            description: Covers SSRF across browser-control auth, navigation URL validation, delayed navigation guards, strict private-network SSRF policy, and related browser security, ssrf, and remote control behavior.
+          - name: Remote Control
+            description: Covers Remote Control across browser-control auth, navigation URL validation, delayed navigation guards, strict private-network SSRF policy, and related browser security, ssrf, and remote control behavior.
+        docs:
+          - docs/tools/browser-control.md
+          - docs/help/testing.md
+          - docs/tools/browser.md
+          - docs/gateway/security/index.md
+          - docs/gateway/security/audit-checks.md
+        search_anchors:
+          - Browser Actions
+          - Snapshots
+          - Artifacts
+          - browser automation and exec/sandbox tools browser actions, snapshots, and artifacts
+          - browser actions, snapshots, and artifacts
+          - Browser Plugin Service
+          - Profiles
+          - browser automation and exec/sandbox tools browser plugin service and profiles
+          - browser plugin service and profiles
+          - Browser Security
+          - SSRF
+          - Remote Control
+          - browser automation and exec/sandbox tools browser security, ssrf, and remote control
+          - browser security, ssrf, and remote control
+        category_note: browser-actions-snapshots-and-artifacts.md
+        human_lts_override: false
+      - name: Tool Invocation and Execution
+        features:
+          - name: Exec Routing
+            description: Covers Exec Routing across `exec` foreground and background execution, `yieldMs`, timeouts, PTY, and related exec routing and process lifecycle behavior.
+          - name: Process Lifecycle
+            description: Covers Process Lifecycle across `exec` foreground and background execution, `yieldMs`, timeouts, PTY, and related exec routing and process lifecycle behavior.
+          - name: Direct Tool Invoke API
+            description: Covers Direct Tool Invoke API across HTTP `POST /tools/invoke`, Gateway RPC `tools.invoke`, request body and auth semantics, shared-secret operator scope restoration, and related direct tool invoke api and node system.run behavior.
+          - name: Node System.run
+            description: Covers Node System.run across HTTP `POST /tools/invoke`, Gateway RPC `tools.invoke`, request body and auth semantics, shared-secret operator scope restoration, and related direct tool invoke api and node system.run behavior.
+          - name: Host Exec Approvals
+            description: Covers Host Exec Approvals across exec approval policy, local approvals state, approval request registration and waiting, allow-once consumption, and related host exec approvals and elevated mode behavior.
+          - name: Elevated Mode
+            description: Covers Elevated Mode across exec approval policy, local approvals state, approval request registration and waiting, allow-once consumption, and related host exec approvals and elevated mode behavior.
+        docs:
+          - docs/tools/exec.md
+          - docs/gateway/background-process.md
+          - docs/gateway/tools-invoke-http-api.md
+          - docs/gateway/operator-scopes.md
+          - docs/gateway/protocol.md
+          - docs/tools/exec-approvals.md
+          - docs/tools/exec-approvals-advanced.md
+          - docs/tools/elevated.md
+        search_anchors:
+          - Exec Routing
+          - Process Lifecycle
+          - browser automation and exec/sandbox tools exec routing and process lifecycle
+          - exec routing and process lifecycle
+          - Direct Tool Invoke API
+          - Node System.run
+          - browser automation and exec/sandbox tools direct tool invoke api and node system.run
+          - direct tool invoke api and node system.run
+          - Host Exec Approvals
+          - Elevated Mode
+          - browser automation and exec/sandbox tools host exec approvals and elevated mode
+          - host exec approvals and elevated mode
+        category_note: exec-routing-and-process-lifecycle.md
+        human_lts_override: true
+      - name: Sandbox and Tool Policy
+        features:
+          - name: Sandbox Backends
+            description: Covers Sandbox Backends across sandbox modes, scopes, workspace roots, workspaceAccess, and related sandbox backends and workspace isolation behavior.
+          - name: Workspace Isolation
+            description: Covers Workspace Isolation across sandbox modes, scopes, workspace roots, workspaceAccess, and related sandbox backends and workspace isolation behavior.
+          - name: Sandboxed Browser
+            description: Covers Sandboxed Browser across sandbox browser config, Docker browser container creation, CDP relay authentication, noVNC password/token flow, and related sandboxed browser and codex dynamic tools behavior.
+          - name: Codex Dynamic Tools
+            description: Covers Codex Dynamic Tools across sandbox browser config, Docker browser container creation, CDP relay authentication, noVNC password/token flow, and related sandboxed browser and codex dynamic tools behavior.
+          - name: Tool Policy
+            description: Covers Tool Policy across tool profiles, tool groups, allow/deny policy, provider policy, and related tool policy and sandbox tool gates behavior.
+          - name: Sandbox Tool Gates
+            description: Covers Sandbox Tool Gates across tool profiles, tool groups, allow/deny policy, provider policy, and related tool policy and sandbox tool gates behavior.
+        docs:
+          - docs/gateway/sandboxing.md
+          - docs/gateway/sandbox-vs-tool-policy-vs-elevated.md
+          - docs/tools/multi-agent-sandbox-tools.md
+          - docs/plugins/codex-harness-reference.md
+          - docs/gateway/config-tools.md
+        search_anchors:
+          - Sandbox Backends
+          - Workspace Isolation
+          - browser automation and exec/sandbox tools sandbox backends and workspace isolation
+          - sandbox backends and workspace isolation
+          - Sandboxed Browser
+          - Codex Dynamic Tools
+          - browser automation and exec/sandbox tools sandboxed browser and codex dynamic tools
+          - sandboxed browser and codex dynamic tools
+          - Tool Policy
+          - Sandbox Tool Gates
+          - browser automation and exec/sandbox tools tool policy and sandbox tool gates
+          - tool policy and sandbox tool gates
+        category_note: sandbox-backends-and-workspace-isolation.md
+        human_lts_override: true
+    last_score_run:
+      status: complete
+      completed_at: '2026-05-30'
+      by: codex
+      source_ref: null
+      process_version: 3
+  - id: image-video-music-generation-tools
+    name: Image/video/music generation tools
+    family: provider-tool
+    level: alpha
+    level_code: M2
+    rationale: Capability exists across providers, but quality, latency, and parameter compatibility vary too much for beta without per-provider proof.
+    completeness_instructions: references/completeness/image-video-music-generation-tools.md
+    categories:
+      - name: Media Routing and Discovery
+        features:
+          - name: default media model config
+            description: Covers default media model config across `imageGenerationModel`, `videoGenerationModel`, `musicGenerationModel`, provider/model refs, and related model routing and tool discovery behavior.
+          - name: per-call model refs and fallbacks
+            description: Covers per-call model refs and fallbacks across `imageGenerationModel`, `videoGenerationModel`, `musicGenerationModel`, provider/model refs, and related model routing and tool discovery behavior.
+          - name: auth-backed tool discovery
+            description: Covers auth-backed tool discovery across `imageGenerationModel`, `videoGenerationModel`, `musicGenerationModel`, provider/model refs, and related model routing and tool discovery behavior.
+          - name: action=list provider inspection
+            description: Covers action=list provider inspection across `imageGenerationModel`, `videoGenerationModel`, `musicGenerationModel`, provider/model refs, and related model routing and tool discovery behavior.
+        docs:
+          - docs/gateway/config-agents.md
+          - docs/tools/image-generation.md
+          - docs/tools/video-generation.md
+          - docs/tools/music-generation.md
+        search_anchors:
+          - default media model config
+          - per-call model refs and fallbacks
+          - auth-backed tool discovery
+          - action=list provider inspection
+        category_note: configuration-model-refs-and-provider-discovery.md
+        human_lts_override: false
+      - name: Task Lifecycle and Delivery
+        features:
+          - name: background task creation
+            description: Covers background task creation across `image_generate`, `video_generate`, and `music_generate` tool exposure, background task scheduling, and related async task lifecycle behavior.
+          - name: task status/list/show/cancel
+            description: Covers task status/list/show/cancel across `image_generate`, `video_generate`, and `music_generate` tool exposure, background task scheduling, and related async task lifecycle behavior.
+          - name: duplicate guards
+            description: Covers duplicate guards across `image_generate`, `video_generate`, and `music_generate` tool exposure, background task scheduling, and related async task lifecycle behavior.
+          - name: progress keepalive
+            description: Covers progress keepalive across `image_generate`, `video_generate`, and `music_generate` tool exposure, background task scheduling, and related async task lifecycle behavior.
+          - name: completion/failure wake
+            description: Covers completion/failure wake across `image_generate`, `video_generate`, and `music_generate` tool exposure, background task scheduling, and related async task lifecycle behavior.
+          - name: no-session inline fallback
+            description: Covers no-session inline fallback across `image_generate`, `video_generate`, and `music_generate` tool exposure, background task scheduling, and related async task lifecycle behavior.
+          - name: local media persistence
+            description: Covers local media persistence across generated image/audio/video artifact objects, MIME and filename inference, local media paths, hosted media URLs, and related generated media delivery behavior.
+          - name: MIME/filename inference
+            description: Covers MIME/filename inference across generated image/audio/video artifact objects, MIME and filename inference, local media paths, hosted media URLs, and related generated media delivery behavior.
+          - name: Hosted URL fallback
+            description: Covers hosted URL fallback across generated image/audio/video artifact objects, MIME and filename inference, local media paths, hosted media URLs, and related generated media delivery behavior.
+          - name: message-tool handoff
+            description: Covers message-tool handoff across generated image/audio/video artifact objects, MIME and filename inference, local media paths, hosted media URLs, and related generated media delivery behavior.
+          - name: idempotent missing-media fallback
+            description: Covers idempotent missing-media fallback across generated image/audio/video artifact objects, MIME and filename inference, local media paths, hosted media URLs, and related generated media delivery behavior.
+          - name: channel attachment proof
+            description: Covers channel attachment proof across generated image/audio/video artifact objects, MIME and filename inference, local media paths, hosted media URLs, and related generated media delivery behavior.
+        docs:
+          - docs/tools/media-overview.md
+          - docs/tools/image-generation.md
+          - docs/tools/video-generation.md
+          - docs/tools/music-generation.md
+        search_anchors:
+          - background task creation
+          - task status/list/show/cancel
+          - duplicate guards
+          - progress keepalive
+          - completion/failure wake
+          - no-session inline fallback
+          - local media persistence
+          - MIME/filename inference
+          - Hosted URL fallback
+          - message-tool handoff
+          - idempotent missing-media fallback
+          - channel attachment proof
+        category_note: session-backed-tool-invocation-and-task-lifecycle.md
+        human_lts_override: false
+      - name: Image Generation
+        features:
+          - name: text-to-image
+            description: 'Covers text-to-image across image generation and editing runtime behavior after a provider candidate has been selected: request normalization, timeout handling, reference-image inputs, image response parsing, and related image generation and editing behavior.'
+          - name: reference-image editing
+            description: 'Covers reference-image editing across image generation and editing runtime behavior after a provider candidate has been selected: request normalization, timeout handling, reference-image inputs, image response parsing, and related image generation and editing behavior.'
+          - name: output hints
+            description: 'Covers output hints across image generation and editing runtime behavior after a provider candidate has been selected: request normalization, timeout handling, reference-image inputs, image response parsing, and related image generation and editing behavior.'
+          - name: action=status
+            description: 'Covers action=status across image generation and editing runtime behavior after a provider candidate has been selected: request normalization, timeout handling, reference-image inputs, image response parsing, and related image generation and editing behavior.'
+          - name: provider attempt metadata
+            description: 'Covers provider attempt metadata across image generation and editing runtime behavior after a provider candidate has been selected: request normalization, timeout handling, reference-image inputs, image response parsing, and related image generation and editing behavior.'
+          - name: OpenAI/Codex OAuth
+            description: Covers OpenAI/Codex OAuth across provider registrations and auth paths for image generation and editing, including OpenAI/Codex OAuth, OpenRouter, xAI, and related image providers and auth behavior.
+          - name: API-key OpenAI
+            description: Covers API-key OpenAI across provider registrations and auth paths for image generation and editing, including OpenAI/Codex OAuth, OpenRouter, xAI, and related image providers and auth behavior.
+          - name: OpenRouter/xAI/fal/LiteLLM/DeepInfra/Google/MiniMax/ComfyUI auth
+            description: Covers OpenRouter/xAI/fal/LiteLLM/DeepInfra/Google/MiniMax/ComfyUI auth across provider registrations and auth paths for image generation and editing, including OpenAI/Codex OAuth, OpenRouter, xAI, and related image providers and auth behavior.
+          - name: provider error diagnostics
+            description: Covers provider error diagnostics across provider registrations and auth paths for image generation and editing, including OpenAI/Codex OAuth, OpenRouter, xAI, and related image providers and auth behavior.
+        docs:
+          - docs/tools/image-generation.md
+          - docs/cli/infer.md
+          - docs/tools/media-overview.md
+        search_anchors:
+          - text-to-image
+          - reference-image editing
+          - output hints
+          - action=status
+          - provider attempt metadata
+          - OpenAI/Codex OAuth
+          - API-key OpenAI
+          - OpenRouter/xAI/fal/LiteLLM/DeepInfra/Google/MiniMax/ComfyUI auth
+          - provider error diagnostics
+        category_note: image-generation-and-editing-runtime.md
+        human_lts_override: false
+      - name: Video Generation
+        features:
+          - name: text-to-video
+            description: 'Covers text-to-video across video generation request normalization before provider execution: `generate`, `imageToVideo`, and `videoToVideo` modes, reference media typing and roles, and related video generation modes behavior.'
+          - name: image-to-video
+            description: 'Covers image-to-video across video generation request normalization before provider execution: `generate`, `imageToVideo`, and `videoToVideo` modes, reference media typing and roles, and related video generation modes behavior.'
+          - name: video-to-video
+            description: 'Covers video-to-video across video generation request normalization before provider execution: `generate`, `imageToVideo`, and `videoToVideo` modes, reference media typing and roles, and related video generation modes behavior.'
+          - name: reference role validation
+            description: 'Covers reference role validation across video generation request normalization before provider execution: `generate`, `imageToVideo`, and `videoToVideo` modes, reference media typing and roles, and related video generation modes behavior.'
+          - name: audio refs
+            description: 'Covers audio refs across video generation request normalization before provider execution: `generate`, `imageToVideo`, and `videoToVideo` modes, reference media typing and roles, and related video generation modes behavior.'
+          - name: typed providerOptions
+            description: 'Covers typed providerOptions across video generation request normalization before provider execution: `generate`, `imageToVideo`, and `videoToVideo` modes, reference media typing and roles, and related video generation modes behavior.'
+          - name: queue-backed jobs
+            description: 'Covers queue-backed jobs across provider integration and async polling for video generation after request normalization: OpenAI Sora, OpenRouter, fal, Runway, and related video providers and polling behavior.'
+          - name: polling/timeout handling
+            description: 'Covers polling/timeout handling across provider integration and async polling for video generation after request normalization: OpenAI Sora, OpenRouter, fal, Runway, and related video providers and polling behavior.'
+          - name: Hosted URL download
+            description: 'Covers hosted URL download across provider integration and async polling for video generation after request normalization: OpenAI Sora, OpenRouter, fal, Runway, and related video providers and polling behavior.'
+          - name: provider skip explanations
+            description: 'Covers provider skip explanations across provider integration and async polling for video generation after request normalization: OpenAI Sora, OpenRouter, fal, Runway, and related video providers and polling behavior.'
+          - name: returned asset metadata
+            description: 'Covers returned asset metadata across provider integration and async polling for video generation after request normalization: OpenAI Sora, OpenRouter, fal, Runway, and related video providers and polling behavior.'
+        docs:
+          - docs/tools/video-generation.md
+          - docs/providers/runway.md
+          - docs/providers/pixverse.md
+          - docs/providers/fal.md
+          - docs/providers/openrouter.md
+        search_anchors:
+          - text-to-video
+          - image-to-video
+          - video-to-video
+          - reference role validation
+          - audio refs
+          - typed providerOptions
+          - queue-backed jobs
+          - polling/timeout handling
+          - Hosted URL download
+          - provider skip explanations
+          - returned asset metadata
+        category_note: video-generation-modes-and-request-normalization.md
+        human_lts_override: false
+      - name: Music Generation
+        features:
+          - name: prompt and lyrics input
+            description: Covers prompt and lyrics input across `music_generate`, prompt and lyrics inputs, instrumental mode, duration, and related music generation behavior.
+          - name: instrumental mode
+            description: Covers instrumental mode across `music_generate`, prompt and lyrics inputs, instrumental mode, duration, and related music generation behavior.
+          - name: duration/format controls
+            description: Covers duration/format controls across `music_generate`, prompt and lyrics inputs, instrumental mode, duration, and related music generation behavior.
+          - name: image-reference edit lanes
+            description: Covers image-reference edit lanes across `music_generate`, prompt and lyrics inputs, instrumental mode, duration, and related music generation behavior.
+          - name: generated audio outputs
+            description: Covers generated audio outputs across `music_generate`, prompt and lyrics inputs, instrumental mode, duration, and related music generation behavior.
+          - name: provider fallback
+            description: Covers provider fallback across `music_generate`, prompt and lyrics inputs, instrumental mode, duration, and related music generation behavior.
+        docs:
+          - docs/tools/music-generation.md
+        search_anchors:
+          - prompt and lyrics input
+          - instrumental mode
+          - duration/format controls
+          - image-reference edit lanes
+          - generated audio outputs
+          - provider fallback
+        category_note: music-generation-tools-and-providers.md
+        human_lts_override: false
+    last_score_run:
+      status: complete
+      completed_at: '2026-05-30'
+      by: codex
+      source_ref: null
+      process_version: 3


### PR DESCRIPTION
## Summary

- Add the repo-local `claw-score` taxonomy source at `.agents/skills/claw-score/taxonomy.yaml`.
- Preserve the copied taxonomy as a standalone agent skill data file for OpenClaw maturity scorecard work.

## Verification

- `git diff --check origin/main...HEAD`

## Notes

- No Agent Transcript section is included.
