### PR TITLE
fix(ui): keep mobile composer above keyboard

### DIFF
--- a/ui/src/main.ts
+++ b/ui/src/main.ts
@@ -2,6 +2,7 @@
 import "./styles.css";
 import "./ui/app.ts";
 import { inferControlUiPublicAssetPath } from "./ui/public-assets.ts";
+import { installViewportKeyboardInset } from "./ui/viewport-keyboard-inset.ts";
 
 type ViteImportMeta = ImportMeta & {
   readonly env?: {
@@ -14,6 +15,7 @@ declare const OPENCLAW_CONTROL_UI_BUILD_ID: string | undefined;
 const isProd = (import.meta as ViteImportMeta).env?.PROD === true;
 
 syncDocumentPublicAssetLinks();
+installViewportKeyboardInset();
 
 if (isProd && "serviceWorker" in navigator) {
   const swUrl = new URL(inferControlUiPublicAssetPath("sw.js"), window.location.origin);

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -119,6 +119,7 @@
   --safe-area-right: env(safe-area-inset-right, 0px);
   --safe-area-bottom: env(safe-area-inset-bottom, 0px);
   --safe-area-left: env(safe-area-inset-left, 0px);
+  --keyboard-inset-bottom: 0px;
 
   color-scheme: dark;
 }

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -2400,7 +2400,7 @@
   }
 
   .agent-chat__input {
-    margin: 0 8px calc(14px + var(--safe-area-bottom));
+    margin: 0 8px calc(14px + max(var(--safe-area-bottom), var(--keyboard-inset-bottom)));
   }
 
   .agent-chat__suggestions {
@@ -2414,7 +2414,9 @@
 
 @media (display-mode: standalone) and (max-width: 768px) {
   .agent-chat__input {
-    margin-bottom: calc(14px + max(var(--safe-area-bottom), 34px));
+    margin-bottom: calc(
+      14px + max(var(--safe-area-bottom), var(--keyboard-inset-bottom), 34px)
+    );
   }
 }
 

--- a/ui/src/ui/chat/chat-responsive.browser.test.ts
+++ b/ui/src/ui/chat/chat-responsive.browser.test.ts
@@ -525,6 +525,20 @@ describeBrowserLayout("chat responsive browser layout", () => {
     }
   });
 
+  it("keeps the mobile composer above a simulated virtual keyboard inset", async () => {
+    const page = await openFixture(390, 844);
+    try {
+      await page.evaluate(() => {
+        document.documentElement.style.setProperty("--keyboard-inset-bottom", "320px");
+      });
+
+      const input = await getRect(page, ".agent-chat__input");
+      expect(input.bottom).toBeLessThanOrEqual(844 - 320 + 1);
+    } finally {
+      await page.close();
+    }
+  });
+
   it("uses the compact mobile grid when the agent filter is not rendered", async () => {
     const page = await openFixture(320, 568, { singleAgent: true });
     try {

--- a/ui/src/ui/viewport-keyboard-inset.test.ts
+++ b/ui/src/ui/viewport-keyboard-inset.test.ts
@@ -1,0 +1,91 @@
+// Control UI tests cover mobile keyboard inset detection.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  computeKeyboardInsetBottom,
+  installViewportKeyboardInset,
+  KEYBOARD_INSET_BOTTOM_VAR,
+} from "./viewport-keyboard-inset.ts";
+
+function createMockVisualViewport(params: { height: number; offsetTop: number }) {
+  const listeners = new Map<string, Set<EventListenerOrEventListenerObject>>();
+  return {
+    height: params.height,
+    offsetTop: params.offsetTop,
+    addEventListener(type: string, listener: EventListenerOrEventListenerObject) {
+      const current = listeners.get(type) ?? new Set<EventListenerOrEventListenerObject>();
+      current.add(listener);
+      listeners.set(type, current);
+    },
+    removeEventListener(type: string, listener: EventListenerOrEventListenerObject) {
+      listeners.get(type)?.delete(listener);
+    },
+    dispatch(type: string) {
+      for (const listener of listeners.get(type) ?? []) {
+        if (typeof listener === "function") {
+          listener(new Event(type));
+        } else {
+          listener.handleEvent(new Event(type));
+        }
+      }
+    },
+  };
+}
+
+async function waitForAnimationFrame() {
+  await new Promise<void>((resolve) => {
+    window.requestAnimationFrame(() => resolve());
+  });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  document.documentElement.style.removeProperty(KEYBOARD_INSET_BOTTOM_VAR);
+});
+
+describe("computeKeyboardInsetBottom", () => {
+  it("returns the viewport area hidden below the visual viewport", () => {
+    expect(
+      computeKeyboardInsetBottom({
+        layoutViewportHeight: 844,
+        visualViewport: { height: 520.4, offsetTop: 0 },
+      }),
+    ).toBe(324);
+  });
+
+  it("accounts for shifted visual viewports", () => {
+    expect(
+      computeKeyboardInsetBottom({
+        layoutViewportHeight: 844,
+        visualViewport: { height: 500, offsetTop: 44 },
+      }),
+    ).toBe(300);
+  });
+
+  it("returns zero when the visual viewport already fits the layout viewport", () => {
+    expect(
+      computeKeyboardInsetBottom({
+        layoutViewportHeight: 844,
+        visualViewport: { height: 844, offsetTop: 0 },
+      }),
+    ).toBe(0);
+  });
+
+  it("syncs the keyboard inset CSS variable from visual viewport changes", async () => {
+    const visualViewport = createMockVisualViewport({ height: 844, offsetTop: 0 });
+    vi.stubGlobal("innerHeight", 844);
+    vi.stubGlobal("visualViewport", visualViewport);
+
+    const cleanup = installViewportKeyboardInset();
+    expect(document.documentElement.style.getPropertyValue(KEYBOARD_INSET_BOTTOM_VAR)).toBe("0px");
+
+    visualViewport.height = 520;
+    visualViewport.dispatch("resize");
+    await waitForAnimationFrame();
+
+    expect(document.documentElement.style.getPropertyValue(KEYBOARD_INSET_BOTTOM_VAR)).toBe(
+      "324px",
+    );
+    cleanup();
+    expect(document.documentElement.style.getPropertyValue(KEYBOARD_INSET_BOTTOM_VAR)).toBe("");
+  });
+});

--- a/ui/src/ui/viewport-keyboard-inset.ts
+++ b/ui/src/ui/viewport-keyboard-inset.ts
@@ -1,0 +1,66 @@
+// Control UI module tracks the visible viewport hidden by mobile keyboards.
+
+export const KEYBOARD_INSET_BOTTOM_VAR = "--keyboard-inset-bottom";
+
+type KeyboardInsetViewport = {
+  height: number;
+  offsetTop: number;
+};
+
+export function computeKeyboardInsetBottom(params: {
+  layoutViewportHeight: number;
+  visualViewport: KeyboardInsetViewport | null | undefined;
+}): number {
+  const { layoutViewportHeight, visualViewport } = params;
+  if (!visualViewport || !Number.isFinite(layoutViewportHeight)) {
+    return 0;
+  }
+  const bottomInset = layoutViewportHeight - visualViewport.offsetTop - visualViewport.height;
+  if (!Number.isFinite(bottomInset) || bottomInset <= 0) {
+    return 0;
+  }
+  return Math.round(bottomInset);
+}
+
+export function installViewportKeyboardInset() {
+  if (typeof window === "undefined" || typeof document === "undefined") {
+    return () => {};
+  }
+
+  const root = document.documentElement;
+  let frame: number | null = null;
+
+  const update = () => {
+    frame = null;
+    const inset = computeKeyboardInsetBottom({
+      layoutViewportHeight: window.innerHeight,
+      visualViewport: window.visualViewport,
+    });
+    root.style.setProperty(KEYBOARD_INSET_BOTTOM_VAR, `${inset}px`);
+  };
+
+  const scheduleUpdate = () => {
+    if (frame !== null) {
+      return;
+    }
+    frame = window.requestAnimationFrame(update);
+  };
+
+  update();
+  window.visualViewport?.addEventListener("resize", scheduleUpdate);
+  window.visualViewport?.addEventListener("scroll", scheduleUpdate);
+  window.addEventListener("resize", scheduleUpdate);
+  window.addEventListener("orientationchange", scheduleUpdate);
+
+  return () => {
+    if (frame !== null) {
+      window.cancelAnimationFrame(frame);
+      frame = null;
+    }
+    window.visualViewport?.removeEventListener("resize", scheduleUpdate);
+    window.visualViewport?.removeEventListener("scroll", scheduleUpdate);
+    window.removeEventListener("resize", scheduleUpdate);
+    window.removeEventListener("orientationchange", scheduleUpdate);
+    root.style.removeProperty(KEYBOARD_INSET_BOTTOM_VAR);
+  };
+}


### PR DESCRIPTION
## Summary
- track the mobile visual viewport keyboard overlap in `--keyboard-inset-bottom`
- use that inset for the mobile chat composer bottom margin while preserving standalone/PWA home-indicator clearance
- add unit coverage for the inset calculation and CSS variable sync plus a responsive fixture assertion for simulated keyboard clearance

## Real behavior proof
- **Behavior or issue addressed:** In the mobile Control UI chat, the composer could remain slightly covered by the virtual keyboard/suggestion bar. This patch moves the composer above the visual viewport keyboard inset instead of relying only on the safe-area inset.
- **Real environment tested:** Local OpenClaw Control UI checkout at `/home/node/projects/home-lab/openclaw-cleanfix` on Linux, using the real production Control UI build output under `dist/control-ui` after applying this patch.
- **Exact steps or command run after this patch:** Ran the Control UI production build, then inspected the emitted bundle for the runtime keyboard inset token and `visualViewport` startup listener.
- **Evidence after fix:** Terminal output from the built Control UI bundle shows the runtime CSS token and keyboard viewport listener were emitted:

```text
dist/control-ui/assets/index-mg0jHESO.css: --keyboard-inset-bottom:0px

dist/control-ui/assets/index-DsOzEYa9.js: var tJ=`--keyboard-inset-bottom`; ... visualViewport ... window.visualViewport?.addEventListener(`resize`,r) ... window.visualViewport?.addEventListener(`scroll`,r) ... if(iJ(),rJ(),`serviceWorker`in navigator)
```

- **Observed result after fix:** The generated Control UI bundle now initializes the keyboard inset tracker at startup and carries the keyboard inset CSS variable into the shipped stylesheet, so mobile composer spacing can respond to the visible viewport shrinking under the keyboard.
- **What was not tested:** Local Chromium browser execution in this container is blocked by missing system library `libglib-2.0.so.0`, so real-device iOS/Android PWA screenshot proof still needs maintainer or CI runner coverage.

## Verification
- `pnpm exec vitest run --config vitest.config.ts --project unit src/ui/viewport-keyboard-inset.test.ts`
- `pnpm exec oxfmt --check --threads=1 ui/src/main.ts ui/src/ui/viewport-keyboard-inset.ts ui/src/ui/viewport-keyboard-inset.test.ts ui/src/ui/chat/chat-responsive.browser.test.ts`
- `git diff --check`
- `pnpm build`

## Notes
- Local Playwright browser execution is blocked in this container because downloaded Chromium cannot load `libglib-2.0.so.0`; CI should exercise the browser fixture on a runner with Chromium deps installed.