### PR TITLE
fix(cron): classify spaced 'timed out' failures as retryable timeout

### DIFF
--- a/src/cron/retry-hint.test.ts
+++ b/src/cron/retry-hint.test.ts
@@ -31,6 +31,37 @@ describe("resolveCronExecutionRetryHint", () => {
     }
   });
 
+  it("classifies timeout phrasings as timeout, including the spaced 'timed out' form", () => {
+    for (const message of [
+      "timeout",
+      "request timeout after 30s",
+      "RequestTimeoutError: deadline exceeded",
+      "ETIMEDOUT",
+      "connect ETIMEDOUT 10.0.0.1:443",
+      "time out waiting for response",
+      "the request timed out",
+      "isolated agent setup timed out before runner start",
+      "job timed_out before completion",
+      "operation timed-out",
+    ]) {
+      expect(resolveCronExecutionRetryHint(message, ["timeout"])).toEqual({
+        retryable: true,
+        category: "timeout",
+      });
+    }
+  });
+
+  it("does not treat incidental 'time out' substrings as a timeout", () => {
+    for (const message of [
+      "runtime out of memory",
+      "lifetime outage report",
+    ]) {
+      expect(resolveCronExecutionRetryHint(message, ["timeout"])).toEqual({
+        retryable: false,
+      });
+    }
+  });
+
   it("does not retry permanent errors", () => {
     expect(resolveCronExecutionRetryHint("invalid API key", ["network"])).toEqual({
       retryable: false,

--- a/src/cron/retry-hint.ts
+++ b/src/cron/retry-hint.ts
@@ -25,7 +25,12 @@ const TRANSIENT_PATTERNS: Record<CronRetryOn, RegExp> = {
     /\b529\b|\boverloaded(?:_error)?\b|high demand|temporar(?:ily|y) overloaded|capacity exceeded/i,
   network:
     /(network|fetch failed|socket|econnreset|econnrefused|eai_again|enetdown|ehostunreach|ehostdown|enetreset|enetunreach|epipe)/i,
-  timeout: /(timeout|etimedout)/i,
+  // Match the solid "timeout"/"timedout" (incl. compounds like "RequestTimeoutError"
+  // and the ETIMEDOUT errno) anywhere, plus the spaced/hyphenated "timed out" /
+  // "time out" forms that real cron failures use ("agent setup timed out"). The
+  // separated form requires a leading word boundary so incidental substrings like
+  // "runtime out of memory" are not misread as a timeout.
+  timeout: /(timed?out|etimedout|\btimed?[ _-]out)/i,
   server_error: SERVER_ERROR_PATTERN,
 };
 


### PR DESCRIPTION
## What

Broaden the cron `timeout` transient-retry classifier so failures phrased with a **space** — e.g. `isolated agent setup timed out before runner start` — are recognized as retryable timeouts.

## Why

`src/cron/retry-hint.ts` classified timeouts with `/(timeout|etimedout)/i`, which only matches the solid word `timeout` (and the `ETIMEDOUT` errno). The agent-setup watchdog and several other code paths emit the **two-word** form `timed out`. Those messages fell through to `retryable: false`, so the recurring transient-retry path in `applyJobResult` never engaged and a daily cron that hit a one-off setup timeout silently lost its slot until the next natural fire.

## Change

```diff
- timeout: /(timeout|etimedout)/i,
+ timeout: /(timed?out|etimedout|\btimed?[ _-]out)/i,
```

- **Solid / compound forms** (`timeout`, `timedout`, `RequestTimeoutError`, `ETIMEDOUT`) match anywhere — no behavior change.
- **Separated forms** (`timed out`, `time out`, `timed-out`, `timed_out`) now match, but only with a **leading word boundary**, so incidental substrings like `runtime out of memory` / `lifetime outage` are **not** misclassified.

## Tests

Added two cases to `retry-hint.test.ts`:
- positive: all timeout phrasings incl. the real `isolated agent setup timed out before runner start`
- negative: `runtime out of memory`, `lifetime outage report` stay non-retryable

## Risk

Low. Pattern is only consulted when `timeout` is in the active `retryOn` set; the boundary guard prevents widening into unrelated messages. No scheduler logic changed.
