### PR TITLE
fix(control-ui): show agents as a visible list instead of a dropdown

### DIFF
--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -4527,10 +4527,63 @@ td.data-table-key-col {
   gap: 14px;
 }
 
+/* Desktop shows the agent list beside the panels; the narrow-screen fallback (the
+   toolbar select) is toggled in by the media query below. See issue #57067. */
+.agents-layout--nav {
+  grid-template-columns: minmax(0, 264px) minmax(0, 1fr);
+  grid-template-areas:
+    "nav toolbar"
+    "nav main";
+  grid-template-rows: auto 1fr;
+  align-items: start;
+}
+
+.agents-layout--nav > .agents-sidebar {
+  grid-area: nav;
+}
+
+.agents-layout--nav > .agents-toolbar {
+  grid-area: toolbar;
+}
+
+.agents-layout--nav > .agents-main {
+  grid-area: main;
+}
+
 .agents-sidebar {
   display: grid;
   gap: 12px;
   align-self: start;
+}
+
+.agents-nav-empty {
+  color: var(--muted);
+  font-size: 13px;
+  padding: 8px 4px;
+}
+
+/* The agent list is the desktop navigation, so the duplicate toolbar select is hidden
+   until the layout collapses to a single column. */
+.agents-control-select--mobile {
+  display: none;
+}
+
+@media (max-width: 600px) {
+  .agents-layout--nav {
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      "toolbar"
+      "main";
+    grid-template-rows: auto auto;
+  }
+
+  .agents-sidebar {
+    display: none;
+  }
+
+  .agents-control-select--mobile {
+    display: block;
+  }
 }
 
 .agents-toolbar {
@@ -4669,6 +4722,9 @@ td.data-table-key-col {
 
 .agent-title {
   font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .agent-sub {

--- a/ui/src/ui/views/agents.test.ts
+++ b/ui/src/ui/views/agents.test.ts
@@ -568,3 +568,46 @@ describe("renderAgentFiles", () => {
     expect(previewExpandButton.getAttribute("aria-label")).toBe("Expand preview");
   });
 });
+
+describe("renderAgents agent navigation", () => {
+  it("renders a visible agent row per agent with default and active markers", () => {
+    const container = document.createElement("div");
+    render(renderAgents(createProps()), container);
+
+    const rows = container.querySelectorAll<HTMLButtonElement>(".agents-sidebar .agent-row");
+    expect(rows).toHaveLength(2);
+    expect(directText(rows[0]?.querySelector(".agent-title"))).toBe("Alpha");
+    // alpha is the default agent; beta is the selected agent.
+    expect(rows[0]?.querySelector(".agent-pill")).not.toBeNull();
+    expect(rows[1]?.querySelector(".agent-pill")).toBeNull();
+    expect(rows[0]?.classList.contains("active")).toBe(false);
+    expect(rows[1]?.classList.contains("active")).toBe(true);
+  });
+
+  it("selects an agent when its row is clicked", () => {
+    const container = document.createElement("div");
+    const onSelectAgent = vi.fn();
+    render(renderAgents(createProps({ onSelectAgent })), container);
+
+    const rows = container.querySelectorAll<HTMLButtonElement>(".agents-sidebar .agent-row");
+    rows[0]?.click();
+
+    expect(onSelectAgent).toHaveBeenCalledWith("alpha");
+  });
+
+  it("shows an empty hint and no rows when there are no agents", () => {
+    const container = document.createElement("div");
+    render(
+      renderAgents(
+        createProps({
+          agentsList: { defaultId: "", mainKey: "main", scope: "workspace", agents: [] },
+          selectedAgentId: null,
+        }),
+      ),
+      container,
+    );
+
+    expect(container.querySelector(".agents-sidebar .agent-row")).toBeNull();
+    expect(directText(container.querySelector(".agents-nav-empty"))).toBe(t("agents.noAgents"));
+  });
+});

--- a/ui/src/ui/views/agents.ts
+++ b/ui/src/ui/views/agents.ts
@@ -147,10 +147,15 @@ export function renderAgents(props: AgentsProps) {
   };
 
   return html`
-    <div class="agents-layout">
+    <div class="agents-layout agents-layout--nav">
+      <aside class="agents-sidebar">
+        ${renderAgentNav(agents, selectedId, defaultId, props.loading, (id) =>
+          props.onSelectAgent(id),
+        )}
+      </aside>
       <section class="agents-toolbar">
         <div class="agents-toolbar-row">
-          <div class="agents-control-select">
+          <div class="agents-control-select agents-control-select--mobile">
             <select
               class="agents-select"
               .value=${selectedId ?? ""}
@@ -346,6 +351,46 @@ export function renderAgents(props: AgentsProps) {
             `}
       </section>
     </div>
+  `;
+}
+
+// Desktop-visible agent navigation. The toolbar `<select>` stays as the narrow-screen
+// fallback (CSS toggles them), so users with many agents can switch in one click instead
+// of opening a dropdown every time. See issue #57067.
+function renderAgentNav(
+  agents: AgentsListResult["agents"],
+  selectedId: string | null,
+  defaultId: string | null,
+  loading: boolean,
+  onSelect: (agentId: string) => void,
+) {
+  if (agents.length === 0) {
+    return html`<div class="agents-nav-empty">${t("agents.noAgents")}</div>`;
+  }
+  return html`
+    <nav class="agent-list" aria-label=${t("agents.selectTitle")}>
+      ${agents.map((agent) => {
+        const label = normalizeAgentLabel(agent);
+        const isSelected = agent.id === selectedId;
+        const isDefault = Boolean(agentBadgeText(agent.id, defaultId));
+        return html`
+          <button
+            type="button"
+            class="agent-row ${isSelected ? "active" : ""}"
+            aria-pressed=${isSelected}
+            ?disabled=${loading}
+            @click=${() => onSelect(agent.id)}
+          >
+            <span class="agent-avatar" aria-hidden="true">${label.slice(0, 1).toUpperCase()}</span>
+            <span class="agent-info">
+              <span class="agent-title">${label}</span>
+              ${label === agent.id ? nothing : html`<span class="agent-sub">${agent.id}</span>`}
+            </span>
+            ${isDefault ? html`<span class="agent-pill">${t("agents.default")}</span>` : nothing}
+          </button>
+        `;
+      })}
+    </nav>
   `;
 }
 


### PR DESCRIPTION
## Summary

The Agents page hid every agent behind a single `<select>`, so switching agents meant opening a dropdown every time — high friction once you have many agents (the core complaint in #57067). This PR renders a **visible agent navigation list** on desktop and keeps the dropdown only as the **narrow-screen fallback**, toggled purely by CSS (a `grid-template-areas` layout + one media query).

This is the **navigation half** of #57067; the companion #91457 fixes the **Set Default persistence** half. I left this as `Refs` (not `Closes`) so a maintainer can close the issue once both land.

**What did NOT change:** the toolbar actions (Copy ID / Set Default / Refresh), the per-agent tabs/panels, agent selection state (`onSelectAgent` / `selectedAgentId` remain the single source of truth), and the dropdown itself (still present as the mobile control). No new props, no controller/RPC changes.

## Root Cause / Approach

`renderAgents` (`ui/src/ui/views/agents.ts`) exposed agents only through `<select class="agents-select">`. The repo already shipped — but never wired up — `.agents-sidebar` / `.agent-list` / `.agent-row` styles from the original dashboard, so the visible-list pattern is part of the existing design system rather than a net-new invention.

The change:
- A new `renderAgentNav` helper renders one `.agent-row` button per agent (avatar initial, name, id, and a `default` pill), marking the selected row `active` and calling the existing `onSelectAgent`.
- `.agents-layout--nav` uses `grid-template-areas` (`nav` / `toolbar` / `main`) so the sidebar sits beside the existing toolbar+panels **without** wrapping them in an extra element (keeps the view diff minimal).
- Below 600px the grid collapses to one column, the sidebar is hidden, and `.agents-control-select--mobile` reveals the original `<select>`.

## Verification (supplemental automated checks)

- `pnpm test ui/src/ui/views/agents.test.ts` — 11 passed (incl. 3 new navigation cases: one row per agent with default/active markers; row click selects; empty-state hint).
- `pnpm tsgo:test:ui`, `oxlint`, `oxfmt --check` — all clean.

## Regression Test Plan

- New `renderAgents agent navigation` suite asserts: a `.agent-row` per agent with the default `.agent-pill` on the default agent and `active` on the selected one; clicking a row invokes `onSelectAgent` with that id; an empty agent list shows the `.agents-nav-empty` hint and no rows.

## Real behavior proof

- **Behavior addressed:** The Agents page now lists agents directly (one visible, clickable row each) on desktop instead of hiding them in a dropdown, while narrow viewports keep the dropdown.
- **Real environment tested:** The Control UI production bundle served by the repo's Vite Control-UI server in real Chromium (Playwright) on Linux/WSL, with a local stub Gateway returning four agents (`main` as default, plus `kimi`, `ops`, `research`); no live daemon.
- **Exact steps or command run after this patch:** Ran a standalone `node --import tsx` driver that opened `/agents` at 1280px and at 420px, read the computed `display` of the list and the fallback control from the live DOM, clicked an agent row, and captured a screenshot at each width.
- **Evidence after fix:** Live DOM facts printed from the running page at both widths (real `getComputedStyle` readings; screenshots also captured):

```text
[runtime][desktop 1280px] {"navRows":4,"sidebar":"grid","dropdown":"none","active":"Main agent"}
[runtime][desktop after clicking 'Ops agent'] {"navRows":4,"sidebar":"grid","dropdown":"none","active":"Ops agent"}
[runtime][mobile 420px]    {"navRows":4,"sidebar":"none","dropdown":"block","active":"Main agent"}
```

- **Observed result after fix:** At 1280px all four agents render as visible rows (`sidebar: grid`) and the dropdown is removed (`dropdown: none`); clicking the `Ops agent` row switches the active agent with no dropdown interaction. At 420px the list is hidden (`sidebar: none`) and the dropdown returns (`dropdown: block`). Desktop and mobile screenshots match.
- **What was not tested:** A production gateway with real agent identities/avatars (used a local stub Gateway); exact pixel styling across every theme.

## Merge risk

- **Surface:** Control UI presentation only (`ui/src/ui/views/agents.ts` + `ui/src/styles/components.css`). No protocol, config, or controller change; no new props.
- **Compatibility:** The dropdown still exists as the mobile control, so existing selection behavior and any narrow-screen muscle memory are preserved. The reused `.agent-*` classes were previously unused (except `.agent-pill`, which is unchanged).
- **Self-claimed labels:** UI / Control UI, UX. Reviewers may have a preference on the exact desktop treatment (list vs sidebar width/density) — happy to adjust.

Refs #57067
