### PR TITLE
refactor(sqlite): drop unused async Kysely driver from node:sqlite dialect

### DIFF
--- a/src/infra/kysely-node-sqlite.test.ts
+++ b/src/infra/kysely-node-sqlite.test.ts
@@ -1,8 +1,13 @@
-// Covers the Kysely dialect backed by Node sqlite.
+// Covers the build-only Kysely dialect and the sync helpers that execute its compiled queries.
 import { DatabaseSync } from "node:sqlite";
-import { CompiledQuery, Kysely, sql, type Generated } from "kysely";
-import { afterEach, describe, expect, it, vi } from "vitest";
-import { NodeSqliteKyselyDialect } from "./kysely-node-sqlite.js";
+import type { Generated } from "kysely";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  clearNodeSqliteKyselyCacheForDatabase,
+  executeSqliteQuerySync,
+  executeSqliteQueryTakeFirstSync,
+  getNodeSqliteKysely,
+} from "./kysely-sync.js";
 
 type TestDatabase = {
   person: {
@@ -12,159 +17,85 @@ type TestDatabase = {
 };
 
 describe("NodeSqliteKyselyDialect", () => {
-  let db: Kysely<TestDatabase> | undefined;
+  let db: DatabaseSync | undefined;
 
-  afterEach(async () => {
-    await db?.destroy();
-    db = undefined;
-  });
-
-  it("uses node:sqlite with raw row-returning queries and returning clauses", async () => {
-    db = await createTestDb();
-
-    await expect(db.selectFrom("person").selectAll().execute()).resolves.toEqual([
-      { id: 1, name: "Ada" },
-    ]);
-    await expect(sql`select name from person where id = ${1}`.execute(db)).resolves.toEqual({
-      rows: [{ name: "Ada" }],
-    });
-    await expect(
-      db.insertInto("person").values({ name: "Grace" }).returning(["id", "name"]).execute(),
-    ).resolves.toEqual([{ id: 2, name: "Grace" }]);
-    await expect(
-      sql`insert into person (name) values ('Lin') returning *`.execute(db),
-    ).resolves.toEqual({
-      rows: [{ id: 3, name: "Lin" }],
-    });
-
-    const ignoredInsert = await sql`
-      insert or ignore into person (id, name) values (${1}, ${"Ada Again"})
-    `.execute(db);
-    expect(ignoredInsert.insertId).toBeUndefined();
-    expect(ignoredInsert.numAffectedRows).toBe(0n);
-
-    const update = await sql`update person set name = ${"Ada Lovelace"} where id = ${1}`.execute(
-      db,
-    );
-    expect(update.insertId).toBeUndefined();
-    expect(update.numAffectedRows).toBe(1n);
-  });
-
-  it("creates the database lazily and runs the connection hook once", async () => {
-    const sqlite = new DatabaseSync(":memory:");
-    const createDatabase = vi.fn(() => sqlite);
-    const onCreateConnection = vi.fn(async (connection) => {
-      await connection.executeQuery(CompiledQuery.raw("pragma user_version = 7"));
-    });
-
-    db = new Kysely<TestDatabase>({
-      dialect: new NodeSqliteKyselyDialect({
-        database: createDatabase,
-        onCreateConnection,
-      }),
-    });
-
-    await expect(sql<{ user_version: number }>`pragma user_version`.execute(db)).resolves.toEqual({
-      rows: [{ user_version: 7 }],
-    });
-    expect(createDatabase).toHaveBeenCalledTimes(1);
-    expect(onCreateConnection).toHaveBeenCalledTimes(1);
-  });
-
-  it("returns insert metadata only for changed insert statements", async () => {
-    db = new Kysely<TestDatabase>({
-      dialect: new NodeSqliteKyselyDialect({
-        database: new DatabaseSync(":memory:"),
-      }),
-    });
-    await createPersonTable(db);
-
-    const insertResult = await db
-      .insertInto("person")
-      .values({ name: "Ada" })
-      .executeTakeFirstOrThrow();
-    expect(insertResult.insertId).toBe(1n);
-    expect(insertResult.numInsertedOrUpdatedRows).toBe(1n);
-
-    const updateResult = await db
-      .updateTable("person")
-      .set({ name: "Ada Lovelace" })
-      .where("id", "=", 1)
-      .executeTakeFirstOrThrow();
-    expect(updateResult.numUpdatedRows).toBe(1n);
-
-    const ignoredInsert = await sql`
-      insert or ignore into person (id, name) values (${1}, ${"Ada Again"})
-    `.execute(db);
-    expect(ignoredInsert.insertId).toBeUndefined();
-    expect(ignoredInsert.numAffectedRows).toBe(0n);
-  });
-
-  it("rolls back transactions and controlled savepoints", async () => {
-    db = new Kysely<TestDatabase>({
-      dialect: new NodeSqliteKyselyDialect({
-        database: new DatabaseSync(":memory:"),
-      }),
-    });
-    await createPersonTable(db);
-
-    await expect(
-      db.transaction().execute(async (trx) => {
-        await trx.insertInto("person").values({ name: "Rollback" }).execute();
-        throw new Error("rollback outer");
-      }),
-    ).rejects.toThrow("rollback outer");
-    await expect(db.selectFrom("person").selectAll().execute()).resolves.toStrictEqual([]);
-
-    const trx = await db.startTransaction().execute();
-    await trx.insertInto("person").values({ name: "Ada" }).execute();
-    const afterAda = await trx.savepoint("after_ada").execute();
-    await afterAda.insertInto("person").values({ name: "Grace" }).execute();
-    const afterRollback = await afterAda.rollbackToSavepoint("after_ada").execute();
-    await afterRollback.insertInto("person").values({ name: "Lin" }).execute();
-    await afterRollback.commit().execute();
-
-    await expect(db.selectFrom("person").select("name").orderBy("id").execute()).resolves.toEqual([
-      { name: "Ada" },
-      { name: "Lin" },
-    ]);
-  });
-
-  it("streams selected rows through node:sqlite iteration", async () => {
-    db = await createTestDb();
-    await db
-      .insertInto("person")
-      .values([{ name: "Grace" }, { name: "Lin" }])
-      .execute();
-
-    const rows: Array<{ id: number; name: string }> = [];
-    for await (const row of db.selectFrom("person").selectAll().orderBy("id").stream(1)) {
-      rows.push(row);
+  afterEach(() => {
+    if (db) {
+      clearNodeSqliteKyselyCacheForDatabase(db);
+      db.close();
+      db = undefined;
     }
+  });
 
+  it("compiles queries through the build-only dialect", () => {
+    db = createPersonDb();
+    const kysely = getNodeSqliteKysely<TestDatabase>(db);
+
+    expect(kysely.insertInto("person").values({ name: "Ada" }).compile().sql).toBe(
+      'insert into "person" ("name") values (?)',
+    );
+  });
+
+  it("returns insert metadata only for changed insert statements", () => {
+    db = createPersonDb();
+    const kysely = getNodeSqliteKysely<TestDatabase>(db);
+
+    const inserted = executeSqliteQuerySync(
+      db,
+      kysely.insertInto("person").values({ name: "Ada" }),
+    );
+    expect(inserted.insertId).toBe(1n);
+    expect(inserted.numAffectedRows).toBe(1n);
+
+    const updated = executeSqliteQuerySync(
+      db,
+      kysely.updateTable("person").set({ name: "Ada Lovelace" }).where("id", "=", 1),
+    );
+    expect(updated.insertId).toBeUndefined();
+    expect(updated.numAffectedRows).toBe(1n);
+
+    const ignored = executeSqliteQuerySync(
+      db,
+      kysely.insertInto("person").orIgnore().values({ id: 1, name: "Ada Again" }),
+    );
+    expect(ignored.insertId).toBeUndefined();
+    expect(ignored.numAffectedRows).toBe(0n);
+
+    const removed = executeSqliteQuerySync(db, kysely.deleteFrom("person").where("id", "=", 1));
+    expect(removed.insertId).toBeUndefined();
+    expect(removed.numAffectedRows).toBe(1n);
+  });
+
+  it("returns rows for select and insert-returning queries", () => {
+    db = createPersonDb();
+    const kysely = getNodeSqliteKysely<TestDatabase>(db);
+    executeSqliteQuerySync(db, kysely.insertInto("person").values({ name: "Ada" }));
+
+    const returned = executeSqliteQuerySync(
+      db,
+      kysely.insertInto("person").values({ name: "Grace" }).returning(["id", "name"]),
+    ).rows;
+    expect(returned).toEqual([{ id: 2, name: "Grace" }]);
+
+    const rows = executeSqliteQuerySync(
+      db,
+      kysely.selectFrom("person").select(["id", "name"]).orderBy("id"),
+    ).rows;
     expect(rows).toEqual([
       { id: 1, name: "Ada" },
       { id: 2, name: "Grace" },
-      { id: 3, name: "Lin" },
     ]);
+
+    const first = executeSqliteQueryTakeFirstSync(
+      db,
+      kysely.selectFrom("person").select(["id", "name"]).orderBy("id"),
+    );
+    expect(first).toEqual({ id: 1, name: "Ada" });
   });
 });
 
-async function createTestDb(): Promise<Kysely<TestDatabase>> {
-  const testDb = new Kysely<TestDatabase>({
-    dialect: new NodeSqliteKyselyDialect({
-      database: new DatabaseSync(":memory:"),
-    }),
-  });
-  await createPersonTable(testDb);
-  await testDb.insertInto("person").values({ name: "Ada" }).execute();
-  return testDb;
-}
-
-async function createPersonTable(testDb: Kysely<TestDatabase>): Promise<void> {
-  await testDb.schema
-    .createTable("person")
-    .addColumn("id", "integer", (col) => col.primaryKey().autoIncrement())
-    .addColumn("name", "text", (col) => col.notNull())
-    .execute();
+function createPersonDb(): DatabaseSync {
+  const db = new DatabaseSync(":memory:");
+  db.exec("create table person (id integer primary key autoincrement, name text not null)");
+  return db;
 }

--- a/src/infra/kysely-node-sqlite.ts
+++ b/src/infra/kysely-node-sqlite.ts
@@ -1,47 +1,20 @@
-// Adapts Node's sync sqlite API to Kysely.
-import type { DatabaseSync, SQLInputValue } from "node:sqlite";
+// Build-only Kysely dialect for Node's node:sqlite API.
 import type {
-  DatabaseConnection,
   DatabaseIntrospector,
   Dialect,
   DialectAdapter,
   Driver,
   Kysely,
   QueryCompiler,
-  QueryResult,
-  TransactionSettings,
 } from "kysely";
-import {
-  CompiledQuery,
-  IdentifierNode,
-  RawNode,
-  SqliteAdapter,
-  SqliteIntrospector,
-  SqliteQueryCompiler,
-  createQueryId,
-} from "kysely";
+import { DummyDriver, SqliteAdapter, SqliteIntrospector, SqliteQueryCompiler } from "kysely";
 
-// Kysely dialect for Node's synchronous node:sqlite API. The driver serializes
-// connection use because DatabaseSync is single-connection and blocking.
-type MaybePromise<T> = T | Promise<T>;
-
-/** Configuration for the node:sqlite Kysely dialect. */
-export type NodeSqliteKyselyDialectConfig = {
-  database: DatabaseSync | (() => MaybePromise<DatabaseSync>);
-  onCreateConnection?: (connection: DatabaseConnection) => MaybePromise<void>;
-  transactionMode?: "deferred" | "immediate" | "exclusive";
-};
-
-/** Kysely dialect backed by a node:sqlite DatabaseSync instance. */
+/** Build-only Kysely dialect: compiles queries for the sync helpers in `kysely-sync.ts`.
+ *  Execution never goes through Kysely's async driver — `executeSqliteQuerySync` runs the
+ *  compiled SQL directly against node:sqlite — so a DummyDriver is sufficient. */
 export class NodeSqliteKyselyDialect implements Dialect {
-  readonly #config: NodeSqliteKyselyDialectConfig;
-
-  constructor(config: NodeSqliteKyselyDialectConfig) {
-    this.#config = Object.freeze({ ...config });
-  }
-
   createDriver(): Driver {
-    return new NodeSqliteKyselyDriver(this.#config);
+    return new DummyDriver();
   }
 
   createQueryCompiler(): QueryCompiler {
@@ -54,166 +27,5 @@ export class NodeSqliteKyselyDialect implements Dialect {
 
   createIntrospector(db: Kysely<unknown>): DatabaseIntrospector {
     return new SqliteIntrospector(db);
-  }
-}
-
-class NodeSqliteKyselyDriver implements Driver {
-  readonly #config: NodeSqliteKyselyDialectConfig;
-  readonly #mutex = new ConnectionMutex();
-
-  #db?: DatabaseSync;
-  #connection?: DatabaseConnection;
-
-  constructor(config: NodeSqliteKyselyDialectConfig) {
-    this.#config = Object.freeze({ ...config });
-  }
-
-  async init(): Promise<void> {
-    this.#db =
-      typeof this.#config.database === "function"
-        ? await this.#config.database()
-        : this.#config.database;
-
-    this.#connection = new NodeSqliteKyselyConnection(this.#db);
-    await this.#config.onCreateConnection?.(this.#connection);
-  }
-
-  async acquireConnection(): Promise<DatabaseConnection> {
-    // Kysely expects async acquisition even though node:sqlite is sync; the
-    // mutex preserves transaction ordering across concurrent callers.
-    await this.#mutex.lock();
-    return this.#connection!;
-  }
-
-  async beginTransaction(
-    connection: DatabaseConnection,
-    _settings: TransactionSettings,
-  ): Promise<void> {
-    const mode = this.#config.transactionMode ?? "deferred";
-    await connection.executeQuery(CompiledQuery.raw(`begin ${mode}`));
-  }
-
-  async commitTransaction(connection: DatabaseConnection): Promise<void> {
-    await connection.executeQuery(CompiledQuery.raw("commit"));
-  }
-
-  async rollbackTransaction(connection: DatabaseConnection): Promise<void> {
-    await connection.executeQuery(CompiledQuery.raw("rollback"));
-  }
-
-  async savepoint(
-    connection: DatabaseConnection,
-    savepointName: string,
-    compileQuery: QueryCompiler["compileQuery"],
-  ): Promise<void> {
-    await connection.executeQuery(
-      compileQuery(createSavepointCommand("savepoint", savepointName), createQueryId()),
-    );
-  }
-
-  async rollbackToSavepoint(
-    connection: DatabaseConnection,
-    savepointName: string,
-    compileQuery: QueryCompiler["compileQuery"],
-  ): Promise<void> {
-    await connection.executeQuery(
-      compileQuery(createSavepointCommand("rollback to", savepointName), createQueryId()),
-    );
-  }
-
-  async releaseSavepoint(
-    connection: DatabaseConnection,
-    savepointName: string,
-    compileQuery: QueryCompiler["compileQuery"],
-  ): Promise<void> {
-    await connection.executeQuery(
-      compileQuery(createSavepointCommand("release", savepointName), createQueryId()),
-    );
-  }
-
-  async releaseConnection(): Promise<void> {
-    this.#mutex.unlock();
-  }
-
-  async destroy(): Promise<void> {
-    this.#db?.close();
-    this.#db = undefined;
-    this.#connection = undefined;
-  }
-}
-
-class NodeSqliteKyselyConnection implements DatabaseConnection {
-  readonly #db: DatabaseSync;
-
-  constructor(db: DatabaseSync) {
-    this.#db = db;
-  }
-
-  executeQuery<O>(compiledQuery: CompiledQuery): Promise<QueryResult<O>> {
-    const { sql, parameters } = compiledQuery;
-    const stmt = this.#db.prepare(sql);
-    const sqliteParameters = parameters as SQLInputValue[];
-
-    if (stmt.columns().length > 0) {
-      return Promise.resolve({ rows: stmt.all(...sqliteParameters) as O[] });
-    }
-
-    const { changes, lastInsertRowid } = stmt.run(...sqliteParameters);
-    const baseResult: QueryResult<O> = {
-      numAffectedRows: BigInt(changes),
-      rows: [],
-    };
-    if (isInsertStatement(sql) && changes > 0) {
-      return Promise.resolve({
-        ...baseResult,
-        insertId: BigInt(lastInsertRowid),
-      });
-    }
-    return Promise.resolve(baseResult);
-  }
-
-  async *streamQuery<O>(
-    compiledQuery: CompiledQuery,
-    _chunkSize?: number,
-  ): AsyncIterableIterator<QueryResult<O>> {
-    const { sql, parameters } = compiledQuery;
-    const stmt = this.#db.prepare(sql);
-
-    for (const row of stmt.iterate(...(parameters as SQLInputValue[]))) {
-      yield { rows: [row as O] };
-    }
-  }
-}
-
-function isInsertStatement(sql: string): boolean {
-  return sql.trimStart().toLowerCase().startsWith("insert");
-}
-
-function createSavepointCommand(command: string, savepointName: string): RawNode {
-  return RawNode.createWithChildren([
-    RawNode.createWithSql(`${command} `),
-    IdentifierNode.create(savepointName),
-  ]);
-}
-
-class ConnectionMutex {
-  #promise?: Promise<void>;
-  #resolve?: () => void;
-
-  async lock(): Promise<void> {
-    while (this.#promise) {
-      await this.#promise;
-    }
-
-    this.#promise = new Promise((resolve) => {
-      this.#resolve = resolve;
-    });
-  }
-
-  unlock(): void {
-    const resolve = this.#resolve;
-    this.#promise = undefined;
-    this.#resolve = undefined;
-    resolve?.();
   }
 }

--- a/src/infra/kysely-sync.ts
+++ b/src/infra/kysely-sync.ts
@@ -18,7 +18,7 @@ export function getNodeSqliteKysely<Database>(db: DatabaseSync): Kysely<Database
     return existing as Kysely<Database>;
   }
   const kysely = new KyselyInstance<Database>({
-    dialect: new NodeSqliteKyselyDialect({ database: db }),
+    dialect: new NodeSqliteKyselyDialect(),
   });
   kyselyByDatabase.set(db, kysely as Kysely<unknown>);
   return kysely;


### PR DESCRIPTION
## Summary

`NodeSqliteKyselyDialect` was a full Kysely dialect with an async driver — connection `executeQuery`/`streamQuery`, transactions, savepoints, and a connection mutex. That async driver was the only place it processed raw nodes, and it was **dead code outside its own tests**: every production call site builds a query and runs it through the synchronous helpers (`executeSqliteQuerySync` / `executeSqliteQueryTakeFirstSync` in `src/infra/kysely-sync.ts`), which `.compile()` the query and run the SQL directly against `node:sqlite`. Nothing in production calls `.execute()`/`.stream()`/`.transaction()`/`.startTransaction()` on these Kysely instances.

A `Kysely<DB>` only needs the query **compiler** to build and `.compile()` queries, so the dialect is now **build-only** using Kysely's `DummyDriver`:

- `src/infra/kysely-node-sqlite.ts` — deleted `NodeSqliteKyselyDriver`, `NodeSqliteKyselyConnection`, `ConnectionMutex`, the savepoint/`isInsertStatement` helpers, and the `NodeSqliteKyselyDialectConfig` type. The dialect is now a stateless class returning `DummyDriver` + `SqliteQueryCompiler`/`SqliteAdapter`/`SqliteIntrospector`.
- `src/infra/kysely-sync.ts` — `new NodeSqliteKyselyDialect()` (the dialect no longer takes config). Sync helpers and the `WeakMap` cache are unchanged.
- `src/infra/kysely-node-sqlite.test.ts` — dropped the driver-only tests (raw `sql` execute, lazy `onCreateConnection`, transaction/savepoint rollback, streaming); retargeted execution-semantics coverage onto the sync helpers; added a build-only compile assertion.

**No production behavior change.** This is a standalone cleanup, independent of the `#90007` crash fix (a later step).

## Verification

- `tsgo:core` + `tsgo:core:test` — clean (catches unused imports / type breaks)
- `oxlint` + `oxfmt --check` on all three files — clean
- `check-kysely-guardrails.mjs` — OK; `check-import-cycles.ts` — 0 cycles
- Tests green: `kysely-node-sqlite.test.ts`, `kysely-sync.types.test.ts`, plus `installed-plugin-index-store.test.ts` and `doctor-state-migrations.test.ts` (74 tests) — the last two exercise the sync helpers end-to-end, proving production query execution is unaffected by removing the driver.
- `git diff --numstat`: net LOC reduction (prod −188, tests −72).
