### PR TITLE
fix #73837: stop after failed Node package installs

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -524,6 +524,15 @@ run_quiet_step() {
     return 1
 }
 
+run_required_step() {
+    local title="$1"
+    shift
+    if run_quiet_step "$title" "$@"; then
+        return 0
+    fi
+    exit 1
+}
+
 cleanup_legacy_submodules() {
     local repo_dir="$1"
     local legacy_dir="$repo_dir/Peekaboo"
@@ -1747,9 +1756,9 @@ finish_linux_node_install() {
 install_node_with_apk() {
     ui_info "Installing Node.js via apk (Alpine Linux detected)"
     if is_root; then
-        run_quiet_step "Installing Node.js" apk add --no-cache nodejs npm
+        run_required_step "Installing Node.js" apk add --no-cache nodejs npm
     else
-        run_quiet_step "Installing Node.js" sudo apk add --no-cache nodejs npm
+        run_required_step "Installing Node.js" sudo apk add --no-cache nodejs npm
     fi
 
     activate_supported_node_on_path || true
@@ -1763,9 +1772,9 @@ install_node_with_apk() {
     ui_warn "Alpine nodejs package installed ${apk_node_version}, below required v${NODE_MIN_VERSION}+"
     ui_info "Trying Alpine nodejs-current package"
     if is_root; then
-        run_quiet_step "Installing nodejs-current" apk add --no-cache nodejs-current npm
+        run_required_step "Installing nodejs-current" apk add --no-cache nodejs-current npm
     else
-        run_quiet_step "Installing nodejs-current" sudo apk add --no-cache nodejs-current npm
+        run_required_step "Installing nodejs-current" sudo apk add --no-cache nodejs-current npm
     fi
 
     activate_supported_node_on_path || true
@@ -1810,9 +1819,9 @@ install_node() {
         if command -v pacman &> /dev/null || is_arch_linux; then
             ui_info "Installing Node.js via pacman (Arch-based distribution detected)"
             if is_root; then
-                run_quiet_step "Installing Node.js" pacman -Sy --noconfirm nodejs npm
+                run_required_step "Installing Node.js" pacman -Sy --noconfirm nodejs npm
             else
-                run_quiet_step "Installing Node.js" sudo pacman -Sy --noconfirm nodejs npm
+                run_required_step "Installing Node.js" sudo pacman -Sy --noconfirm nodejs npm
             fi
             finish_linux_node_install
             return 0
@@ -1827,35 +1836,35 @@ install_node() {
         if command -v apt-get &> /dev/null; then
             local tmp
             tmp="$(mktempfile)"
-            run_quiet_step "Downloading NodeSource setup script" download_file "https://deb.nodesource.com/setup_${NODE_DEFAULT_MAJOR}.x" "$tmp"
+            run_required_step "Downloading NodeSource setup script" download_file "https://deb.nodesource.com/setup_${NODE_DEFAULT_MAJOR}.x" "$tmp"
             if is_root; then
-                run_quiet_step "Configuring NodeSource repository" bash "$tmp"
-                run_quiet_step "Installing Node.js" apt_get_install nodejs
+                run_required_step "Configuring NodeSource repository" bash "$tmp"
+                run_required_step "Installing Node.js" apt_get_install nodejs
             else
-                run_quiet_step "Configuring NodeSource repository" sudo -E bash "$tmp"
-                run_quiet_step "Installing Node.js" apt_get_install nodejs
+                run_required_step "Configuring NodeSource repository" sudo -E bash "$tmp"
+                run_required_step "Installing Node.js" apt_get_install nodejs
             fi
         elif command -v dnf &> /dev/null; then
             local tmp
             tmp="$(mktempfile)"
-            run_quiet_step "Downloading NodeSource setup script" download_file "https://rpm.nodesource.com/setup_${NODE_DEFAULT_MAJOR}.x" "$tmp"
+            run_required_step "Downloading NodeSource setup script" download_file "https://rpm.nodesource.com/setup_${NODE_DEFAULT_MAJOR}.x" "$tmp"
             if is_root; then
-                run_quiet_step "Configuring NodeSource repository" bash "$tmp"
-                run_quiet_step "Installing Node.js" dnf install -y -q nodejs
+                run_required_step "Configuring NodeSource repository" bash "$tmp"
+                run_required_step "Installing Node.js" dnf install -y -q nodejs
             else
-                run_quiet_step "Configuring NodeSource repository" sudo bash "$tmp"
-                run_quiet_step "Installing Node.js" sudo dnf install -y -q nodejs
+                run_required_step "Configuring NodeSource repository" sudo bash "$tmp"
+                run_required_step "Installing Node.js" sudo dnf install -y -q nodejs
             fi
         elif command -v yum &> /dev/null; then
             local tmp
             tmp="$(mktempfile)"
-            run_quiet_step "Downloading NodeSource setup script" download_file "https://rpm.nodesource.com/setup_${NODE_DEFAULT_MAJOR}.x" "$tmp"
+            run_required_step "Downloading NodeSource setup script" download_file "https://rpm.nodesource.com/setup_${NODE_DEFAULT_MAJOR}.x" "$tmp"
             if is_root; then
-                run_quiet_step "Configuring NodeSource repository" bash "$tmp"
-                run_quiet_step "Installing Node.js" yum install -y -q nodejs
+                run_required_step "Configuring NodeSource repository" bash "$tmp"
+                run_required_step "Installing Node.js" yum install -y -q nodejs
             else
-                run_quiet_step "Configuring NodeSource repository" sudo bash "$tmp"
-                run_quiet_step "Installing Node.js" sudo yum install -y -q nodejs
+                run_required_step "Configuring NodeSource repository" sudo bash "$tmp"
+                run_required_step "Installing Node.js" sudo yum install -y -q nodejs
             fi
         else
             ui_error "Could not detect package manager"

--- a/test/scripts/install-sh.test.ts
+++ b/test/scripts/install-sh.test.ts
@@ -160,12 +160,14 @@ describe("install.sh", () => {
     expect(script).toContain("is_alpine_linux()");
     expect(script).toContain("install_node_with_apk()");
     expect(script).toContain('ui_info "Installing Node.js via apk (Alpine Linux detected)"');
-    expect(script).toContain('run_quiet_step "Installing Node.js" apk add --no-cache nodejs npm');
     expect(script).toContain(
-      'run_quiet_step "Installing Node.js" sudo apk add --no-cache nodejs npm',
+      'run_required_step "Installing Node.js" apk add --no-cache nodejs npm',
     );
     expect(script).toContain(
-      'run_quiet_step "Installing nodejs-current" apk add --no-cache nodejs-current npm',
+      'run_required_step "Installing Node.js" sudo apk add --no-cache nodejs npm',
+    );
+    expect(script).toContain(
+      'run_required_step "Installing nodejs-current" apk add --no-cache nodejs-current npm',
     );
     expect(script).toContain("if ! node_is_at_least_required; then");
 
@@ -284,6 +286,84 @@ describe("install.sh", () => {
       "error:Alpine apk repositories did not provide Node.js v22.19+",
     );
     expect(result.stdout).toContain("Use Alpine 3.21+ or install Node.js 24 manually");
+  });
+
+  it("stops when NodeSource repository setup fails", () => {
+    const result = runInstallShell(`
+      set -euo pipefail
+      source "${SCRIPT_PATH}"
+      OS=linux
+      require_sudo() { :; }
+      install_build_tools_linux() { return 0; }
+      is_root() { return 0; }
+      is_alpine_linux() { return 1; }
+      apt-get() { :; }
+      download_file() { :; }
+      ui_info() { printf 'info:%s\\n' "$*"; }
+      ui_success() { printf 'success:%s\\n' "$*"; }
+      ui_error() { printf 'error:%s\\n' "$*"; }
+      run_quiet_step() {
+        printf 'step:%s|%s\\n' "$1" "\${*:2}"
+        if [[ "$1" == "Configuring NodeSource repository" ]]; then
+          return 64
+        fi
+        return 0
+      }
+      node() {
+        if [[ "\${1:-}" == "-v" ]]; then
+          printf 'v24.0.0\\n'
+        fi
+      }
+      activate_supported_node_on_path() { :; }
+      if install_node; then
+        echo "install_node returned success"
+      fi
+    `);
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain("step:Configuring NodeSource repository|bash");
+    expect(result.stdout).not.toContain("step:Installing Node.js|apt_get_install nodejs");
+    expect(result.stdout).not.toContain("success:Node.js v24.0.0 installed");
+    expect(result.stdout).not.toContain("install_node returned success");
+  });
+
+  it("stops when apt cannot install the Node.js package", () => {
+    const result = runInstallShell(`
+      set -euo pipefail
+      source "${SCRIPT_PATH}"
+      OS=linux
+      require_sudo() { :; }
+      install_build_tools_linux() { return 0; }
+      is_root() { return 0; }
+      is_alpine_linux() { return 1; }
+      apt-get() { :; }
+      download_file() { :; }
+      ui_info() { printf 'info:%s\\n' "$*"; }
+      ui_success() { printf 'success:%s\\n' "$*"; }
+      ui_error() { printf 'error:%s\\n' "$*"; }
+      run_quiet_step() {
+        printf 'step:%s|%s\\n' "$1" "\${*:2}"
+        if [[ "$1" == "Installing Node.js" ]]; then
+          return 65
+        fi
+        return 0
+      }
+      node() {
+        if [[ "\${1:-}" == "-v" ]]; then
+          printf 'v24.0.0\\n'
+        fi
+      }
+      activate_supported_node_on_path() { :; }
+      if install_node; then
+        echo "install_node returned success"
+      fi
+    `);
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain("step:Configuring NodeSource repository|bash");
+    expect(result.stdout).toContain("step:Installing Node.js|apt_get_install nodejs");
+    expect(result.stdout).not.toContain("success:Node.js v24.0.0 installed");
+    expect(result.stdout).not.toContain("install_node returned success");
   });
 
   it("installs Git with apk on Alpine", () => {
@@ -769,7 +849,7 @@ describe("install.sh", () => {
       /detect_os_or_die\s+if \[\[ "\$OS" == "linux" \]\]; then\s+export DEBIAN_FRONTEND="\$\{DEBIAN_FRONTEND:-noninteractive\}"\s+export NEEDRESTART_MODE="\$\{NEEDRESTART_MODE:-a\}"\s+fi/m,
     );
     expect(script).toContain(
-      'run_quiet_step "Configuring NodeSource repository" sudo -E bash "$tmp"',
+      'run_required_step "Configuring NodeSource repository" sudo -E bash "$tmp"',
     );
   });
 


### PR DESCRIPTION
Fixes #73837.

## Summary
- Stop Linux Node.js installer paths immediately when required package-manager steps fail.
- Keep the existing noninteractive apt wrapper and final Node runtime validation, but prevent failed NodeSource setup/install commands from falling through to a misleading success path.
- Add regression coverage for NodeSource setup failure and apt nodejs install failure when `install_node` is called from a conditional shell context.

## Root Cause
- **Fix classification:** Root-cause Linux installer failure handling bug fix.
- **Maintainer-ready confidence:** High. The patch stays inside `scripts/install.sh` Node runtime installation and the adjacent installer test file.
- **Root cause:** The root cause is Bash's conditional-function `errexit` suppression: because `install_node` can be invoked from an `if install_node` shell context, bare `run_quiet_step` failures inside that function no longer abort the function, which caused failed NodeSource setup or package install commands to continue into later installer logic instead of stopping at the failed step.
- **Why this is root-cause fix:** Required Linux Node installation commands now go through `run_required_step`, which exits immediately if `run_quiet_step` reports failure. The existing post-install `finish_linux_node_install` validation remains in place, so success is only printed after a supported `node` binary is active on PATH.
- **Patch quality notes:** Patch quality/default-return warning is intentional: `run_required_step` returns only after a successful wrapped command and exits on failure, so it cannot mask the failed package-manager command. No package manager selection, apt noninteractive flags, Node minimum version, npm install path, or macOS behavior changed.

## Real behavior proof
- **Behavior or issue addressed:** A failed NodeSource setup or apt `nodejs` install no longer falls through and reports a successful Node.js install before later crashing.
- **Real environment tested:** Disposable Debian 12 Docker container from the local `pgvector/pgvector:pg17` image, with the patched worktree mounted read-only and Docker run with `--network none`. The proof sources production `scripts/install.sh`, sets `OS=linux`, and invokes `install_node` from an `if install_node; then` conditional shell context. The container image has Debian's real `/usr/lib/apt/apt-helper download-file` but no curl/wget, so the proof exposes apt-helper through a temporary curl-compatible wrapper in `/tmp/proof-bin`; no repository code or installer function was changed.
- **Exact steps or command run after this patch:**
```bash
cd /media/vdc/code/ai/aispace/openclaw-worktrees/issue-73837
sudo docker run --rm --network none --entrypoint bash \
  -v "$PWD:/repo:ro" -w /repo pgvector/pgvector:pg17 -lc '
    set -Eeuo pipefail
    mkdir -p /tmp/proof-bin
    # /tmp/proof-bin/curl adapts Debian apt-helper download-file to the curl -o URL shape used by install.sh.
    export PATH="/tmp/proof-bin:$PATH"
    export OPENCLAW_INSTALL_SH_NO_RUN=1 TERM=dumb CI=1
    source scripts/install.sh
    OS=linux
    if install_node; then echo "UNEXPECTED: install_node returned success"; fi
  '
```
- **Evidence after fix:**
```text
inside-container: invoking install_node
· Installing Node.js via NodeSource
· Downloading NodeSource setup script
✗ Downloading NodeSource setup script failed — re-run with --verbose for details
Ign:1 https://deb.nodesource.com/setup_24.x
Err:1 https://deb.nodesource.com/setup_24.x
  Temporary failure resolving 'deb.nodesource.com'
E: Failed to fetch https://deb.nodesource.com/setup_24.x  Temporary failure resolving 'deb.nodesource.com'
E: Download Failed
docker_run_exit_status=1
assert:exit_status_1=true
assert:nodesource_step_failed=true
assert:real_dns_failure=true
assert:no_install_node_success=true
assert:no_linux_success_message=true
ASSERT_PASS: install_node exited at the failed required NodeSource step and did not print success
```
- **Observed result after fix:** The production installer reached the required NodeSource download step in a real Linux container, hit the real container DNS/network failure for `deb.nodesource.com`, exited with status 1 through `run_required_step`, and did not continue to `apt_get_install nodejs`, `finish_linux_node_install`, or any Node.js success message.
- **Secondary deterministic regression proof:** I also ran `/media/vdc/code/ai/aispace/openclaw-issue-73837-evidence/local-installer-node-failure-proof.mjs`, which sources production `scripts/install.sh` and locks both previously reported conditional-`errexit` failure shapes: NodeSource setup failure and apt `nodejs` install failure both exit with status 1 and never return `install_node` success.
- **What was not tested:** No successful Node installation was performed, and the host package manager was not modified. The real-environment proof intentionally uses a network-disabled disposable container to force the NodeSource failure path; the successful package-manager path remains covered by the existing post-install Node runtime validation rather than by this failure proof.

## Review findings addressed
- **RF-001 — fixed:** Added redacted terminal output from a disposable Debian 12 Docker container where patched production `install_node` hits a real NodeSource DNS/network failure for `https://deb.nodesource.com/setup_24.x`, exits with status 1 at `Downloading NodeSource setup script`, and does not print a Node.js success message.
- **RF-002 — stale / CI infrastructure:** The previously in-progress check runs reached terminal state. Current non-success checks on head `3952d599015d7356ffd5a4251f3255c079141e5f` are self-hosted runner communication failures, with GitHub annotations saying the runner lost communication with the server; there is no current-head test assertion failure attributable to this PR.
- **RF-003 — fixed:** Replaced the prior proof-only fixture story with the real Linux container proof above. The local fixture proof is now only secondary deterministic regression evidence, not the primary real behavior proof.
- **RF-004 — maintainer decision disclosed:** The 21 required Linux Node package-manager setup/install call sites intentionally fail closed on nonzero exit. This is the requested behavior boundary: a failed required Node runtime install should not rely on later validation or fallback before stopping.
- **RF-005 — fixed:** Added actual Linux/container failure output from a disposable Debian container, including the real `Temporary failure resolving 'deb.nodesource.com'` NodeSource failure and the `ASSERT_PASS` checks for exit status and absence of success output.
- **RF-006 — stale / CI infrastructure:** Final CI state is no longer pending; the remaining current-head failures are runner infrastructure failures rather than PR-code failures, so no code change is made for CI.
- **RF-007 — fixed / maintainer review remains:** No automated repair was needed. The contributor-side proof gap is addressed with container evidence; maintainer review of the intentional fail-closed installer semantics still remains appropriate.
- **Proof judgment note:** The local OpenClaw chat/RPC/gateway proof path is not applicable to this reviewer request because the changed behavior is the installer’s Linux package-manager failure path. The applicable local proof path is the Docker/Linux installer run above.

## Tests
- **Target test file:** `test/scripts/install-sh.test.ts`.
- **Scenario locked in:** NodeSource repository setup failure and apt `nodejs` install failure stop `install_node` immediately and do not print Node.js installation success.
- **Why this is the smallest reliable guardrail:** The tests source the real installer script and call `install_node` under the same conditional-shell shape that can suppress `errexit`, while keeping package-manager operations local and deterministic.
- **Exact commands run:**
```bash
PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false corepack pnpm@11.2.2 --dir /media/vdc/code/ai/aispace/openclaw-worktrees/issue-73837 exec vitest run test/scripts/install-sh.test.ts --reporter=dot
PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false corepack pnpm@11.2.2 --dir /media/vdc/code/ai/aispace/openclaw-worktrees/issue-73837 exec oxfmt --check --threads=1 scripts/install.sh test/scripts/install-sh.test.ts
PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false corepack pnpm@11.2.2 --dir /media/vdc/code/ai/aispace/openclaw-worktrees/issue-73837 exec oxlint --deny-warnings test/scripts/install-sh.test.ts
OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false corepack pnpm@11.2.2 --dir /media/vdc/code/ai/aispace/openclaw-worktrees/issue-73837 check:changed
git -C /media/vdc/code/ai/aispace/openclaw-worktrees/issue-73837 diff --check
```
- **Observed test result after fix:** Installer Vitest passed 47/47 tests; `oxfmt --check` passed; `oxlint --deny-warnings` passed; `check:changed` passed the tooling lane; `git diff --check` passed with no output.

## Risk / Scope
- **Why it matters / User impact:** Linux users no longer see a successful Node.js install message after a failed NodeSource setup or apt install step.
- **What did NOT change:** Only required Linux Node package-manager failure handling changed; the Node version floor, NodeSource URL, apt noninteractive wrapper, package-manager detection order, npm installation behavior, Homebrew path, and installer UI copy are unchanged, with no unrelated installer scope expansion.
- **Architecture / source-of-truth check:** The source-of-truth boundary is the installer step wrapper plus the existing Node runtime validation path: `run_required_step` owns required command failure handling, and `finish_linux_node_install` remains the validation gate before any installed-success message.
- **Risk labels considered:** `merge-risk: 🚨 availability`, `merge-risk: 🚨 compatibility`.
- **Risk explanation:** The installer now exits earlier when package-manager setup/install commands fail; this changes only failed installation flows that previously continued misleadingly.
- **Why acceptable:** Continuing after a failed required Node runtime install cannot produce a valid OpenClaw install, and the final supported-node validation remains unchanged for successful installs.
