### PR TITLE
Fix transcript image redaction

### DIFF
--- a/packages/media-core/src/inline-image-data-url.test.ts
+++ b/packages/media-core/src/inline-image-data-url.test.ts
@@ -1,9 +1,22 @@
 // Media Core tests cover inline image data url behavior.
 import { describe, expect, it } from "vitest";
-import { sanitizeInlineImageDataUrl, sniffInlineImageMime } from "./inline-image-data-url.js";
+import {
+  sanitizeInlineImageBase64,
+  sanitizeInlineImageDataUrl,
+  sanitizeInlineImageDataUrlForStorage,
+  sniffInlineImageMime,
+} from "./inline-image-data-url.js";
 
 const PNG_1X1 =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgYAAAAAMAASsJTYQAAAAASUVORK5CYII=";
+const BMP_HEADER = Buffer.from("BMfixture", "ascii").toString("base64");
+const HEIC_HEADER = Buffer.from([
+  0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, 0x68, 0x65, 0x69, 0x63, 0x00, 0x00, 0x00, 0x00,
+  0x6d, 0x69, 0x66, 0x31,
+]).toString("base64");
+const HEIF_HEADER = Buffer.from([
+  0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, 0x6d, 0x69, 0x66, 0x31, 0x00, 0x00, 0x00, 0x00,
+]).toString("base64");
 
 describe("inline image data URL sanitizer", () => {
   it("keeps non-data image references unchanged", () => {
@@ -24,6 +37,46 @@ describe("inline image data URL sanitizer", () => {
     expect(sanitizeInlineImageDataUrl(`data:image/jpeg;base64,\n${PNG_1X1}`)).toBe(
       `data:image/png;base64,${PNG_1X1}`,
     );
+  });
+
+  it("rejects image data URLs for formats that require conversion before provider transport", () => {
+    expect(sanitizeInlineImageDataUrl(`data:image/bmp;base64,${BMP_HEADER}`)).toBeUndefined();
+    expect(sanitizeInlineImageDataUrl(`data:image/heic;base64,${HEIC_HEADER}`)).toBeUndefined();
+    expect(sanitizeInlineImageDataUrl(`data:image/heif;base64,${HEIF_HEADER}`)).toBeUndefined();
+  });
+
+  it("canonicalizes valid image data URLs for storage without transport allowlist filtering", () => {
+    expect(sanitizeInlineImageDataUrlForStorage(`data:image/bmp;base64,${BMP_HEADER}`)).toBe(
+      `data:image/bmp;base64,${BMP_HEADER}`,
+    );
+    expect(sanitizeInlineImageDataUrlForStorage(`data:image/heic;base64,${HEIC_HEADER}`)).toBe(
+      `data:image/heic;base64,${HEIC_HEADER}`,
+    );
+  });
+
+  it("canonicalizes valid image base64 with sniffed MIME type", () => {
+    expect(sanitizeInlineImageBase64({ mimeType: "image/jpeg", base64: `\n${PNG_1X1}` })).toEqual({
+      mimeType: "image/png",
+      base64: PNG_1X1,
+    });
+    expect(
+      sanitizeInlineImageBase64({ mimeType: "image/png", base64: "SGVsbG8=" }),
+    ).toBeUndefined();
+  });
+
+  it("accepts supported non-browser image signatures", () => {
+    expect(sanitizeInlineImageBase64({ mimeType: "image/bmp", base64: BMP_HEADER })).toEqual({
+      mimeType: "image/bmp",
+      base64: BMP_HEADER,
+    });
+    expect(sanitizeInlineImageBase64({ mimeType: "image/heic", base64: HEIC_HEADER })).toEqual({
+      mimeType: "image/heic",
+      base64: HEIC_HEADER,
+    });
+    expect(sanitizeInlineImageBase64({ mimeType: "image/heif", base64: HEIF_HEADER })).toEqual({
+      mimeType: "image/heif",
+      base64: HEIF_HEADER,
+    });
   });
 
   it("sniffs supported inline image signatures", () => {

--- a/packages/media-core/src/inline-image-data-url.ts
+++ b/packages/media-core/src/inline-image-data-url.ts
@@ -40,7 +40,16 @@ const IMAGE_SIGNATURES: Array<{
       (buffer.subarray(0, 6).toString("ascii") === "GIF87a" ||
         buffer.subarray(0, 6).toString("ascii") === "GIF89a"),
   },
+  {
+    mime: "image/bmp",
+    matches: (buffer) => buffer.length >= 2 && buffer[0] === 0x42 && buffer[1] === 0x4d,
+  },
 ];
+
+const HEIC_BRANDS = new Set(["heic", "heix", "hevc", "hevx", "heis", "heim", "hevm", "hevs"]);
+const HEIF_BRANDS = new Set(["mif1", "msf1"]);
+const IMAGE_SIGNATURE_PREFIX_BASE64_CHARS = 128;
+const INLINE_IMAGE_DATA_URL_MIMES = new Set(["image/png", "image/jpeg", "image/webp", "image/gif"]);
 
 function startsWithDataUrl(value: string): boolean {
   return (
@@ -49,9 +58,62 @@ function startsWithDataUrl(value: string): boolean {
   );
 }
 
+function sniffIsoBmffImageMime(buffer: Buffer): string | undefined {
+  if (buffer.length < 12 || buffer.subarray(4, 8).toString("ascii") !== "ftyp") {
+    return undefined;
+  }
+  const brands = [buffer.subarray(8, 12).toString("ascii")];
+  for (let offset = 16; offset + 4 <= buffer.length; offset += 4) {
+    brands.push(buffer.subarray(offset, offset + 4).toString("ascii"));
+  }
+  if (brands.some((brand) => HEIC_BRANDS.has(brand))) {
+    return "image/heic";
+  }
+  if (brands.some((brand) => HEIF_BRANDS.has(brand))) {
+    return "image/heif";
+  }
+  return undefined;
+}
+
 /** Sniffs supported inline image formats from decoded bytes. */
 export function sniffInlineImageMime(buffer: Buffer): string | undefined {
-  return IMAGE_SIGNATURES.find((signature) => signature.matches(buffer))?.mime;
+  return (
+    IMAGE_SIGNATURES.find((signature) => signature.matches(buffer))?.mime ??
+    sniffIsoBmffImageMime(buffer)
+  );
+}
+
+function isImageMimeType(value: string): boolean {
+  return value.trim().toLowerCase().startsWith("image/");
+}
+
+export type SanitizedInlineImageBase64 = {
+  mimeType: string;
+  base64: string;
+};
+
+/** Canonicalizes trusted inline image base64 and rejects malformed or non-image payloads. */
+export function sanitizeInlineImageBase64(params: {
+  mimeType: string;
+  base64: string;
+}): SanitizedInlineImageBase64 | undefined {
+  if (!isImageMimeType(params.mimeType)) {
+    return undefined;
+  }
+  const canonicalPayload = canonicalizeBase64(params.base64);
+  if (!canonicalPayload) {
+    return undefined;
+  }
+  const sniffedMimeType = sniffInlineImageMime(
+    Buffer.from(canonicalPayload.slice(0, IMAGE_SIGNATURE_PREFIX_BASE64_CHARS), "base64"),
+  );
+  if (!sniffedMimeType) {
+    return undefined;
+  }
+  return {
+    mimeType: sniffedMimeType,
+    base64: canonicalPayload,
+  };
 }
 
 function parseInlineImageDataUrl(value: string):
@@ -78,12 +140,17 @@ function parseInlineImageDataUrl(value: string):
 
 function metadataAllowsImageBase64(metadata: string[]): boolean {
   const [mimeType, ...options] = metadata;
-  const isImageMimeType = mimeType !== undefined && mimeType.toLowerCase().startsWith("image/");
-  return isImageMimeType && options.some((part) => part.toLowerCase() === "base64");
+  return (
+    mimeType !== undefined &&
+    isImageMimeType(mimeType) &&
+    options.some((part) => part.toLowerCase() === "base64")
+  );
 }
 
-/** Canonicalizes trusted inline image data URLs and rejects malformed or non-image payloads. */
-export function sanitizeInlineImageDataUrl(imageUrl: string): string | undefined {
+function sanitizeInlineImageDataUrlWithAllowedMimes(
+  imageUrl: string,
+  allowedMimes?: Set<string>,
+): string | undefined {
   const parsed = parseInlineImageDataUrl(imageUrl);
   if (!parsed) {
     return undefined;
@@ -95,14 +162,30 @@ export function sanitizeInlineImageDataUrl(imageUrl: string): string | undefined
     return undefined;
   }
 
-  const canonicalPayload = canonicalizeBase64(parsed.payload);
-  if (!canonicalPayload) {
+  const [mimeType] = parsed.metadata;
+  const sanitized = sanitizeInlineImageBase64({
+    mimeType: mimeType ?? "",
+    base64: parsed.payload,
+  });
+  if (!sanitized) {
     return undefined;
   }
-  const sniffedMimeType = sniffInlineImageMime(Buffer.from(canonicalPayload, "base64"));
-  if (!sniffedMimeType) {
+  if (allowedMimes && !allowedMimes.has(sanitized.mimeType)) {
     return undefined;
   }
   // Trust the byte signature over caller-supplied metadata before reinlining.
-  return `data:${sniffedMimeType};base64,${canonicalPayload}`;
+  return `data:${sanitized.mimeType};base64,${sanitized.base64}`;
+}
+
+/**
+ * Canonicalizes trusted inline image data URLs for persistence.
+ * Accepts every image signature supported by `sanitizeInlineImageBase64`.
+ */
+export function sanitizeInlineImageDataUrlForStorage(imageUrl: string): string | undefined {
+  return sanitizeInlineImageDataUrlWithAllowedMimes(imageUrl);
+}
+
+/** Canonicalizes provider-safe inline image data URLs and rejects unsupported formats. */
+export function sanitizeInlineImageDataUrl(imageUrl: string): string | undefined {
+  return sanitizeInlineImageDataUrlWithAllowedMimes(imageUrl, INLINE_IMAGE_DATA_URL_MIMES);
 }

--- a/src/agents/responses-image-payload-sanitizer.test.ts
+++ b/src/agents/responses-image-payload-sanitizer.test.ts
@@ -5,6 +5,9 @@ import { sanitizeResponsesImagePayload } from "./responses-image-payload-sanitiz
 const PNG_1X1 =
   // Valid JPEG-labeled data is sniffed as PNG and normalized to the real MIME type.
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgYAAAAAMAASsJTYQAAAAASUVORK5CYII=";
+const HEIC_HEADER = Buffer.from([
+  0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, 0x68, 0x65, 0x69, 0x63, 0x00, 0x00, 0x00, 0x00,
+]).toString("base64");
 
 describe("Responses image payload sanitizer", () => {
   it("replaces malformed input_image data URLs before sending Responses payloads", () => {
@@ -53,6 +56,31 @@ describe("Responses image payload sanitizer", () => {
         content: [
           { type: "input_image", image_url: `data:image/png;base64,${PNG_1X1}` },
           { type: "input_image", image_url: "https://example.test/image.png" },
+        ],
+      },
+    ]);
+  });
+
+  it("replaces HEIC inline image data URLs before Responses transport", () => {
+    const sanitized = sanitizeResponsesImagePayload({
+      input: [
+        {
+          type: "message",
+          role: "user",
+          content: [{ type: "input_image", image_url: `data:image/heic;base64,${HEIC_HEADER}` }],
+        },
+      ],
+    });
+
+    expect(sanitized.input).toEqual([
+      {
+        type: "message",
+        role: "user",
+        content: [
+          {
+            type: "input_text",
+            text: "[omitted image payload: invalid inline image data]",
+          },
         ],
       },
     ]);

--- a/src/agents/session-file-repair.test.ts
+++ b/src/agents/session-file-repair.test.ts
@@ -56,6 +56,10 @@ function requireFirstLogMessage(log: ReturnType<typeof vi.fn>): string {
   return message;
 }
 
+const PNG_1X1 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgYAAAAAMAASsJTYQAAAAASUVORK5CYII=";
+const BMP_HEADER = Buffer.from("BMfixture", "ascii").toString("base64");
+
 afterEach(async () => {
   vi.restoreAllMocks();
   await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
@@ -290,7 +294,7 @@ describe("repairSessionFileIfNeeded", () => {
         role: "user",
         content: [
           { type: "text", text: "   " },
-          { type: "image", data: "AA==", mimeType: "image/png" },
+          { type: "image", data: PNG_1X1, mimeType: "image/png" },
         ],
       },
     };
@@ -304,7 +308,7 @@ describe("repairSessionFileIfNeeded", () => {
     const repaired = await fs.readFile(file, "utf-8");
     const repairedEntry = JSON.parse(repaired.trim().split("\n")[1] ?? "{}");
     expect(repairedEntry.message.content).toEqual([
-      { type: "image", data: "AA==", mimeType: "image/png" },
+      { type: "image", data: PNG_1X1, mimeType: "image/png" },
     ]);
   });
 
@@ -353,7 +357,7 @@ describe("repairSessionFileIfNeeded", () => {
         role: "user",
         content: [
           { type: "text", text: "inspect this" },
-          { type: "image", data: "AA==", mimeType: "image/png" },
+          { type: "image", data: PNG_1X1, mimeType: "image/png" },
         ],
       },
     };
@@ -365,6 +369,63 @@ describe("repairSessionFileIfNeeded", () => {
     expect(result.repaired).toBe(false);
     const repaired = await fs.readFile(file, "utf-8");
     expect(repaired).toBe(original);
+  });
+
+  it("preserves valid non-browser image blocks during repair", async () => {
+    const { file } = await createTempSessionPath();
+    const { header } = buildSessionHeaderAndMessage();
+    const validUserEntry = {
+      type: "message",
+      id: "msg-valid-bmp",
+      parentId: null,
+      timestamp: new Date().toISOString(),
+      message: {
+        role: "user",
+        content: [
+          { type: "text", text: "inspect this" },
+          { type: "image", data: BMP_HEADER, mimeType: "image/bmp" },
+        ],
+      },
+    };
+    const original = `${JSON.stringify(header)}\n${JSON.stringify(validUserEntry)}\n`;
+    await fs.writeFile(file, original, "utf-8");
+
+    const result = await repairSessionFileIfNeeded({ sessionFile: file });
+
+    expect(result.repaired).toBe(false);
+    const repaired = await fs.readFile(file, "utf-8");
+    expect(repaired).toBe(original);
+  });
+
+  it("rewrites syntactically valid base64 that is not image bytes", async () => {
+    const { file } = await createTempSessionPath();
+    const { header } = buildSessionHeaderAndMessage();
+    const fakeImageUserEntry = {
+      type: "message",
+      id: "msg-fake-image",
+      parentId: null,
+      timestamp: new Date().toISOString(),
+      message: {
+        role: "user",
+        content: [
+          { type: "text", text: "inspect this" },
+          { type: "image", data: "SGVsbG8=", mimeType: "image/png" },
+        ],
+      },
+    };
+    const original = `${JSON.stringify(header)}\n${JSON.stringify(fakeImageUserEntry)}\n`;
+    await fs.writeFile(file, original, "utf-8");
+
+    const result = await repairSessionFileIfNeeded({ sessionFile: file });
+
+    expect(result.repaired).toBe(true);
+    expect(result.removedCorruptedImageBlocks).toBe(1);
+    const repaired = await fs.readFile(file, "utf-8");
+    const repairedEntry = JSON.parse(repaired.trim().split("\n")[1] ?? "{}");
+    expect(repairedEntry.message.content).toEqual([
+      { type: "text", text: "inspect this" },
+      { type: "text", text: CORRUPTED_IMAGE_FALLBACK_TEXT },
+    ]);
   });
 
   it("reports both drops and rewrites in the debug message when both occur", async () => {

--- a/src/agents/session-file-repair.test.ts
+++ b/src/agents/session-file-repair.test.ts
@@ -6,7 +6,11 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { BLANK_USER_FALLBACK_TEXT, repairSessionFileIfNeeded } from "./session-file-repair.js";
+import {
+  BLANK_USER_FALLBACK_TEXT,
+  CORRUPTED_IMAGE_FALLBACK_TEXT,
+  repairSessionFileIfNeeded,
+} from "./session-file-repair.js";
 
 function buildSessionHeaderAndMessage() {
   const header = {
@@ -302,6 +306,65 @@ describe("repairSessionFileIfNeeded", () => {
     expect(repairedEntry.message.content).toEqual([
       { type: "image", data: "AA==", mimeType: "image/png" },
     ]);
+  });
+
+  it("rewrites corrupted image blocks so replay can continue", async () => {
+    const { file } = await createTempSessionPath();
+    const { header } = buildSessionHeaderAndMessage();
+    const poisonedUserEntry = {
+      type: "message",
+      id: "msg-poisoned-image",
+      parentId: null,
+      timestamp: new Date().toISOString(),
+      message: {
+        role: "user",
+        content: [
+          { type: "text", text: "inspect this" },
+          { type: "image", data: "iVBORw0KGgoAKID…MNOPAAA=", mimeType: "image/png" },
+        ],
+      },
+    };
+    const original = `${JSON.stringify(header)}\n${JSON.stringify(poisonedUserEntry)}\n`;
+    await fs.writeFile(file, original, "utf-8");
+
+    const debug = vi.fn();
+    const result = await repairSessionFileIfNeeded({ sessionFile: file, debug });
+
+    expect(result.repaired).toBe(true);
+    expect(result.removedCorruptedImageBlocks).toBe(1);
+    expect(requireFirstLogMessage(debug)).toContain("removed 1 corrupted image block(s)");
+    const repaired = await fs.readFile(file, "utf-8");
+    const repairedEntry = JSON.parse(repaired.trim().split("\n")[1] ?? "{}");
+    expect(repairedEntry.message.content).toEqual([
+      { type: "text", text: "inspect this" },
+      { type: "text", text: CORRUPTED_IMAGE_FALLBACK_TEXT },
+    ]);
+  });
+
+  it("preserves valid image blocks during repair", async () => {
+    const { file } = await createTempSessionPath();
+    const { header } = buildSessionHeaderAndMessage();
+    const validUserEntry = {
+      type: "message",
+      id: "msg-valid-image",
+      parentId: null,
+      timestamp: new Date().toISOString(),
+      message: {
+        role: "user",
+        content: [
+          { type: "text", text: "inspect this" },
+          { type: "image", data: "AA==", mimeType: "image/png" },
+        ],
+      },
+    };
+    const original = `${JSON.stringify(header)}\n${JSON.stringify(validUserEntry)}\n`;
+    await fs.writeFile(file, original, "utf-8");
+
+    const result = await repairSessionFileIfNeeded({ sessionFile: file });
+
+    expect(result.repaired).toBe(false);
+    const repaired = await fs.readFile(file, "utf-8");
+    expect(repaired).toBe(original);
   });
 
   it("reports both drops and rewrites in the debug message when both occur", async () => {

--- a/src/agents/session-file-repair.ts
+++ b/src/agents/session-file-repair.ts
@@ -6,7 +6,7 @@
 import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { canonicalizeBase64 } from "@openclaw/media-core/base64";
+import { sanitizeInlineImageBase64 } from "@openclaw/media-core/inline-image-data-url";
 import { replaceFileAtomic } from "../infra/replace-file.js";
 import type { AgentMessage } from "./runtime/index.js";
 import { makeMissingToolResult } from "./session-transcript-repair.js";
@@ -127,14 +127,19 @@ function isCorruptedImageContentBlock(block: unknown): boolean {
     data?: unknown;
     mimeType?: unknown;
     mediaType?: unknown;
+    media_type?: unknown;
   };
   if (record.type !== "image" || typeof record.data !== "string") {
     return false;
   }
-  if (!isImageMimeType(record.mimeType) && !isImageMimeType(record.mediaType)) {
+  const mimeType = [record.mimeType, record.mediaType, record.media_type].find(isImageMimeType);
+  if (!mimeType) {
     return false;
   }
-  return containsNonAscii(record.data) || canonicalizeBase64(record.data) === undefined;
+  return (
+    containsNonAscii(record.data) ||
+    sanitizeInlineImageBase64({ base64: record.data, mimeType }) === undefined
+  );
 }
 
 function repairEntryWithCorruptedImageBlocks(entry: SessionMessageEntry): {

--- a/src/agents/session-file-repair.ts
+++ b/src/agents/session-file-repair.ts
@@ -105,7 +105,7 @@ function rewriteAssistantEntryWithEmptyContent(entry: SessionMessageEntry): Sess
   };
 }
 
-function isImageMimeType(value: unknown): boolean {
+function isImageMimeType(value: unknown): value is string {
   return typeof value === "string" && /^image\//iu.test(value.trim());
 }
 

--- a/src/agents/session-file-repair.ts
+++ b/src/agents/session-file-repair.ts
@@ -6,6 +6,7 @@
 import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { canonicalizeBase64 } from "@openclaw/media-core/base64";
 import { replaceFileAtomic } from "../infra/replace-file.js";
 import type { AgentMessage } from "./runtime/index.js";
 import { makeMissingToolResult } from "./session-transcript-repair.js";
@@ -18,6 +19,7 @@ import { extractToolCallsFromAssistant, extractToolResultId } from "./tool-call-
  * message do not reject the transcript.
  */
 export const BLANK_USER_FALLBACK_TEXT = "(continue)";
+export const CORRUPTED_IMAGE_FALLBACK_TEXT = "[image omitted: corrupted base64 payload]";
 
 type RepairReport = {
   repaired: boolean;
@@ -25,6 +27,7 @@ type RepairReport = {
   rewrittenAssistantMessages?: number;
   droppedBlankUserMessages?: number;
   rewrittenUserMessages?: number;
+  removedCorruptedImageBlocks?: number;
   insertedToolResults?: number;
   backupPath?: string;
   reason?: string;
@@ -102,6 +105,70 @@ function rewriteAssistantEntryWithEmptyContent(entry: SessionMessageEntry): Sess
   };
 }
 
+function isImageMimeType(value: unknown): boolean {
+  return typeof value === "string" && /^image\//iu.test(value.trim());
+}
+
+function containsNonAscii(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    if (value.charCodeAt(index) > 0x7f) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isCorruptedImageContentBlock(block: unknown): boolean {
+  if (!block || typeof block !== "object" || Array.isArray(block)) {
+    return false;
+  }
+  const record = block as {
+    type?: unknown;
+    data?: unknown;
+    mimeType?: unknown;
+    mediaType?: unknown;
+  };
+  if (record.type !== "image" || typeof record.data !== "string") {
+    return false;
+  }
+  if (!isImageMimeType(record.mimeType) && !isImageMimeType(record.mediaType)) {
+    return false;
+  }
+  return containsNonAscii(record.data) || canonicalizeBase64(record.data) === undefined;
+}
+
+function repairEntryWithCorruptedImageBlocks(entry: SessionMessageEntry): {
+  entry: SessionMessageEntry;
+  removedCorruptedImageBlocks: number;
+} {
+  const content = entry.message.content;
+  if (!Array.isArray(content)) {
+    return { entry, removedCorruptedImageBlocks: 0 };
+  }
+
+  let removedCorruptedImageBlocks = 0;
+  const nextContent = content.map((block) => {
+    if (!isCorruptedImageContentBlock(block)) {
+      return block;
+    }
+    removedCorruptedImageBlocks += 1;
+    return { type: "text", text: CORRUPTED_IMAGE_FALLBACK_TEXT };
+  });
+  if (removedCorruptedImageBlocks === 0) {
+    return { entry, removedCorruptedImageBlocks: 0 };
+  }
+  return {
+    entry: {
+      ...entry,
+      message: {
+        ...entry.message,
+        content: nextContent,
+      },
+    },
+    removedCorruptedImageBlocks,
+  };
+}
+
 type UserEntryRepair =
   | { kind: "drop" }
   | { kind: "rewrite"; entry: SessionMessageEntry }
@@ -175,6 +242,7 @@ function buildRepairSummaryParts(params: {
   rewrittenAssistantMessages: number;
   droppedBlankUserMessages: number;
   rewrittenUserMessages: number;
+  removedCorruptedImageBlocks: number;
   insertedToolResults: number;
 }): string {
   const parts: string[] = [];
@@ -189,6 +257,9 @@ function buildRepairSummaryParts(params: {
   }
   if (params.rewrittenUserMessages > 0) {
     parts.push(`rewrote ${params.rewrittenUserMessages} user message(s)`);
+  }
+  if (params.removedCorruptedImageBlocks > 0) {
+    parts.push(`removed ${params.removedCorruptedImageBlocks} corrupted image block(s)`);
   }
   if (params.insertedToolResults > 0) {
     parts.push(`inserted ${params.insertedToolResults} missing tool result(s)`);
@@ -325,6 +396,7 @@ export async function repairSessionFileIfNeeded(params: {
   let rewrittenAssistantMessages = 0;
   let droppedBlankUserMessages = 0;
   let rewrittenUserMessages = 0;
+  let removedCorruptedImageBlocks = 0;
   let insertedToolResults;
 
   for (const line of lines) {
@@ -347,14 +419,28 @@ export async function repairSessionFileIfNeeded(params: {
         rewrittenAssistantMessages += 1;
         continue;
       }
+      let entryForUserRepair = entry;
       if (
         entry &&
         typeof entry === "object" &&
         (entry as { type?: unknown }).type === "message" &&
-        typeof (entry as { message?: unknown }).message === "object" &&
-        ((entry as { message: { role?: unknown } }).message?.role ?? undefined) === "user"
+        typeof (entry as { message?: unknown }).message === "object"
       ) {
-        const repairedUser = repairUserEntryWithBlankTextContent(entry as SessionMessageEntry);
+        const imageRepair = repairEntryWithCorruptedImageBlocks(entry as SessionMessageEntry);
+        entryForUserRepair = imageRepair.entry;
+        removedCorruptedImageBlocks += imageRepair.removedCorruptedImageBlocks;
+      }
+      if (
+        entryForUserRepair &&
+        typeof entryForUserRepair === "object" &&
+        (entryForUserRepair as { type?: unknown }).type === "message" &&
+        typeof (entryForUserRepair as { message?: unknown }).message === "object" &&
+        ((entryForUserRepair as { message: { role?: unknown } }).message?.role ?? undefined) ===
+          "user"
+      ) {
+        const repairedUser = repairUserEntryWithBlankTextContent(
+          entryForUserRepair as SessionMessageEntry,
+        );
         if (repairedUser.kind === "drop") {
           droppedBlankUserMessages += 1;
           continue;
@@ -365,7 +451,7 @@ export async function repairSessionFileIfNeeded(params: {
           continue;
         }
       }
-      entries.push(entry);
+      entries.push(entryForUserRepair);
     } catch {
       droppedLines += 1;
     }
@@ -386,7 +472,8 @@ export async function repairSessionFileIfNeeded(params: {
     droppedLines === 0 &&
     rewrittenAssistantMessages === 0 &&
     droppedBlankUserMessages === 0 &&
-    rewrittenUserMessages === 0
+    rewrittenUserMessages === 0 &&
+    removedCorruptedImageBlocks === 0
   ) {
     const repairedToolResults = insertMissingCodeModeToolResults(entries);
     insertedToolResults = repairedToolResults.insertedToolResults;
@@ -432,6 +519,7 @@ export async function repairSessionFileIfNeeded(params: {
       rewrittenAssistantMessages,
       droppedBlankUserMessages,
       rewrittenUserMessages,
+      removedCorruptedImageBlocks,
       reason: `repair failed: ${err instanceof Error ? err.message : "unknown error"}`,
     };
   }
@@ -442,6 +530,7 @@ export async function repairSessionFileIfNeeded(params: {
       rewrittenAssistantMessages,
       droppedBlankUserMessages,
       rewrittenUserMessages,
+      removedCorruptedImageBlocks,
       insertedToolResults,
     })} (${path.basename(sessionFile)})`,
   );
@@ -451,6 +540,7 @@ export async function repairSessionFileIfNeeded(params: {
     rewrittenAssistantMessages,
     droppedBlankUserMessages,
     rewrittenUserMessages,
+    removedCorruptedImageBlocks,
     insertedToolResults,
     ...(retainedBackupPath ? { backupPath: retainedBackupPath } : {}),
   };

--- a/src/agents/transcript-redact.test.ts
+++ b/src/agents/transcript-redact.test.ts
@@ -28,6 +28,8 @@ function cfg(mode: "tools" | "off", patterns?: string[]): OpenClawConfig {
 }
 
 const EMAIL_PATTERN = String.raw`([\w]|[-.])+@([\w]|[-.])+\.\w+`;
+const IMAGE_BASE64_WITH_SECRET_TOKEN_SUBSTRING =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAARcnVOZAAAAKIDABCDEFGHIJKLMNOP8JJRuAAAAABJRU5ErkJggg==";
 
 describe("redactTranscriptMessage", () => {
   it("redacts text block matching default patterns (sk- token)", () => {
@@ -293,6 +295,118 @@ describe("redactTranscriptMessage", () => {
     } as unknown as AgentMessage;
     const result = redactTranscriptMessage(msg, cfg("tools"));
     expect(msgContent(result) as string).not.toContain("sk-abcdef1234567890xyz");
+  });
+
+  it("preserves image data while redacting adjacent transcript text", () => {
+    const msg = {
+      role: "user",
+      content: [
+        { type: "text", text: "my key is sk-abcdef1234567890xyz" },
+        {
+          type: "image",
+          data: IMAGE_BASE64_WITH_SECRET_TOKEN_SUBSTRING,
+          mimeType: "image/png",
+        },
+      ],
+    } as unknown as AgentMessage;
+
+    const result = redactTranscriptMessage(msg, cfg("tools"));
+    const content = msgContent(result) as Array<{ type: string; text?: string; data?: string }>;
+    expect(content[0].text).not.toContain("sk-abcdef1234567890xyz");
+    expect(content[1].data).toBe(IMAGE_BASE64_WITH_SECRET_TOKEN_SUBSTRING);
+    expect(JSON.stringify(result)).not.toContain("sk-abcdef1234567890xyz");
+  });
+
+  it("redacts fake image payloads that are not valid image base64", () => {
+    const msg = {
+      role: "user",
+      content: [
+        {
+          type: "image",
+          data: "sk-abcdef1234567890xyz",
+          mimeType: "image/png",
+        },
+      ],
+    } as unknown as AgentMessage;
+
+    const result = redactTranscriptMessage(msg, cfg("tools"));
+    const content = msgContent(result) as Array<{ data: string }>;
+    expect(content[0].data).toBe("sk-abc…0xyz");
+  });
+
+  it("preserves provider-style image base64 source data", () => {
+    const msg = {
+      role: "assistant",
+      content: [
+        {
+          type: "gatewayCustom",
+          source: {
+            type: "base64",
+            media_type: "image/png",
+            data: IMAGE_BASE64_WITH_SECRET_TOKEN_SUBSTRING,
+          },
+          apiKey: "plainsecretvalue123",
+        },
+      ],
+    } as unknown as AgentMessage;
+
+    const result = redactTranscriptMessage(msg, cfg("tools"));
+    const block = (msgContent(result) as Array<{ source: { data: string }; apiKey: string }>)[0];
+    expect(block.source.data).toBe(IMAGE_BASE64_WITH_SECRET_TOKEN_SUBSTRING);
+    expect(block.apiKey).toBe("plains…e123");
+  });
+
+  it("preserves image data URLs without exempting non-image data fields", () => {
+    const dataUrl = `data:image/png;base64,${IMAGE_BASE64_WITH_SECRET_TOKEN_SUBSTRING}`;
+    const msg = {
+      role: "assistant",
+      content: [
+        {
+          type: "input_image",
+          image_url: dataUrl,
+          data: "AKIDABCDEFGHIJKLMNOP",
+        },
+      ],
+    } as unknown as AgentMessage;
+
+    const result = redactTranscriptMessage(msg, cfg("tools"));
+    const block = (msgContent(result) as Array<{ image_url: string; data: string }>)[0];
+    expect(block.image_url).toBe(dataUrl);
+    expect(block.data).toBe("AKIDAB…MNOP");
+  });
+
+  it("preserves image data URLs with metadata parameters before base64", () => {
+    const dataUrl = `data:image/png;charset=utf-8;base64,${IMAGE_BASE64_WITH_SECRET_TOKEN_SUBSTRING}`;
+    const msg = {
+      role: "assistant",
+      content: [
+        {
+          type: "input_image",
+          image_url: dataUrl,
+        },
+      ],
+    } as unknown as AgentMessage;
+
+    const result = redactTranscriptMessage(msg, cfg("tools"));
+    const block = (msgContent(result) as Array<{ image_url: string }>)[0];
+    expect(block.image_url).toBe(dataUrl);
+  });
+
+  it("preserves nested image_url data URL payloads", () => {
+    const dataUrl = `data:image/png;base64,${IMAGE_BASE64_WITH_SECRET_TOKEN_SUBSTRING}`;
+    const msg = {
+      role: "assistant",
+      content: [
+        {
+          type: "image_url",
+          image_url: { url: dataUrl },
+        },
+      ],
+    } as unknown as AgentMessage;
+
+    const result = redactTranscriptMessage(msg, cfg("tools"));
+    const block = (msgContent(result) as Array<{ image_url: { url: string } }>)[0];
+    expect(block.image_url.url).toBe(dataUrl);
   });
 
   it("redacts documented transcript text fields on content-less message types", () => {

--- a/src/agents/transcript-redact.test.ts
+++ b/src/agents/transcript-redact.test.ts
@@ -30,6 +30,10 @@ function cfg(mode: "tools" | "off", patterns?: string[]): OpenClawConfig {
 const EMAIL_PATTERN = String.raw`([\w]|[-.])+@([\w]|[-.])+\.\w+`;
 const IMAGE_BASE64_WITH_SECRET_TOKEN_SUBSTRING =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAARcnVOZAAAAKIDABCDEFGHIJKLMNOP8JJRuAAAAABJRU5ErkJggg==";
+const BMP_BASE64_WITH_SECRET_TOKEN_SUBSTRING = Buffer.from(
+  "BMsk-abcdef1234567890xyz",
+  "ascii",
+).toString("base64");
 
 describe("redactTranscriptMessage", () => {
   it("redacts text block matching default patterns (sk- token)", () => {
@@ -334,6 +338,25 @@ describe("redactTranscriptMessage", () => {
     expect(content[0].data).toBe("sk-abc…0xyz");
   });
 
+  it("preserves valid BMP image base64 while redacting adjacent text", () => {
+    const msg = {
+      role: "user",
+      content: [
+        { type: "text", text: "my key is sk-abcdef1234567890xyz" },
+        {
+          type: "image",
+          data: BMP_BASE64_WITH_SECRET_TOKEN_SUBSTRING,
+          mimeType: "image/bmp",
+        },
+      ],
+    } as unknown as AgentMessage;
+
+    const result = redactTranscriptMessage(msg, cfg("tools"));
+    const content = msgContent(result) as Array<{ type: string; text?: string; data?: string }>;
+    expect(content[0].text).not.toContain("sk-abcdef1234567890xyz");
+    expect(content[1].data).toBe(BMP_BASE64_WITH_SECRET_TOKEN_SUBSTRING);
+  });
+
   it("preserves provider-style image base64 source data", () => {
     const msg = {
       role: "assistant",
@@ -356,6 +379,29 @@ describe("redactTranscriptMessage", () => {
     expect(block.apiKey).toBe("plains…e123");
   });
 
+  it("canonicalizes preserved image MIME from sniffed base64 bytes", () => {
+    const msg = {
+      role: "assistant",
+      content: [
+        {
+          type: "gatewayCustom",
+          source: {
+            type: "base64",
+            media_type: "image/jpeg",
+            data: IMAGE_BASE64_WITH_SECRET_TOKEN_SUBSTRING,
+          },
+        },
+      ],
+    } as unknown as AgentMessage;
+
+    const result = redactTranscriptMessage(msg, cfg("tools"));
+    const block = (
+      msgContent(result) as Array<{ source: { data: string; media_type: string } }>
+    )[0];
+    expect(block.source.data).toBe(IMAGE_BASE64_WITH_SECRET_TOKEN_SUBSTRING);
+    expect(block.source.media_type).toBe("image/png");
+  });
+
   it("preserves image data URLs without exempting non-image data fields", () => {
     const dataUrl = `data:image/png;base64,${IMAGE_BASE64_WITH_SECRET_TOKEN_SUBSTRING}`;
     const msg = {
@@ -375,8 +421,8 @@ describe("redactTranscriptMessage", () => {
     expect(block.data).toBe("AKIDAB…MNOP");
   });
 
-  it("preserves image data URLs with metadata parameters before base64", () => {
-    const dataUrl = `data:image/png;charset=utf-8;base64,${IMAGE_BASE64_WITH_SECRET_TOKEN_SUBSTRING}`;
+  it("preserves valid non-browser image data URLs in transcripts", () => {
+    const dataUrl = `data:image/bmp;base64,${BMP_BASE64_WITH_SECRET_TOKEN_SUBSTRING}`;
     const msg = {
       role: "assistant",
       content: [
@@ -390,6 +436,24 @@ describe("redactTranscriptMessage", () => {
     const result = redactTranscriptMessage(msg, cfg("tools"));
     const block = (msgContent(result) as Array<{ image_url: string }>)[0];
     expect(block.image_url).toBe(dataUrl);
+  });
+
+  it("preserves image data URLs with metadata parameters before base64", () => {
+    const dataUrl = `data:image/png;charset=utf-8;base64,${IMAGE_BASE64_WITH_SECRET_TOKEN_SUBSTRING}`;
+    const canonicalDataUrl = `data:image/png;base64,${IMAGE_BASE64_WITH_SECRET_TOKEN_SUBSTRING}`;
+    const msg = {
+      role: "assistant",
+      content: [
+        {
+          type: "input_image",
+          image_url: dataUrl,
+        },
+      ],
+    } as unknown as AgentMessage;
+
+    const result = redactTranscriptMessage(msg, cfg("tools"));
+    const block = (msgContent(result) as Array<{ image_url: string }>)[0];
+    expect(block.image_url).toBe(canonicalDataUrl);
   });
 
   it("preserves nested image_url data URL payloads", () => {

--- a/src/agents/transcript-redact.ts
+++ b/src/agents/transcript-redact.ts
@@ -56,7 +56,7 @@ function isPlainTranscriptObject(value: object): value is Record<string, unknown
   return prototype === Object.prototype || prototype === null;
 }
 
-function isImageMimeType(value: unknown): boolean {
+function isImageMimeType(value: unknown): value is string {
   return typeof value === "string" && /^image\//iu.test(value.trim());
 }
 

--- a/src/agents/transcript-redact.ts
+++ b/src/agents/transcript-redact.ts
@@ -3,8 +3,10 @@
  *
  * Applies logging redaction rules to persisted messages while preserving unchanged object identity.
  */
-import { Buffer } from "node:buffer";
-import { canonicalizeBase64 } from "@openclaw/media-core/base64";
+import {
+  sanitizeInlineImageBase64,
+  sanitizeInlineImageDataUrlForStorage,
+} from "@openclaw/media-core/inline-image-data-url";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { readLoggingConfig } from "../logging/config.js";
 import {
@@ -72,40 +74,19 @@ function imageMimeTypeForRecord(value: Record<string, unknown>): string | undefi
   );
 }
 
-function base64HasImageSignature(base64: string, mimeType: string): boolean {
-  const canonical = canonicalizeBase64(base64);
-  if (!canonical) {
-    return false;
-  }
-  const header = Buffer.from(canonical.slice(0, 64), "base64");
-  if (mimeType === "image/png") {
-    return header
-      .subarray(0, 8)
-      .equals(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]));
-  }
-  if (mimeType === "image/jpeg" || mimeType === "image/jpg") {
-    return header[0] === 0xff && header[1] === 0xd8 && header[2] === 0xff;
-  }
-  if (mimeType === "image/gif") {
-    return (
-      header.subarray(0, 6).equals(Buffer.from("GIF87a")) ||
-      header.subarray(0, 6).equals(Buffer.from("GIF89a"))
-    );
-  }
-  if (mimeType === "image/webp") {
-    return (
-      header.subarray(0, 4).equals(Buffer.from("RIFF")) &&
-      header.subarray(8, 12).equals(Buffer.from("WEBP"))
-    );
-  }
-  if (mimeType === "image/bmp") {
-    return header.subarray(0, 2).equals(Buffer.from("BM"));
-  }
-  return false;
+function imageMimeTypeFieldsForRecord(value: Record<string, unknown>): string[] {
+  return ["mimeType", "mediaType", "media_type"].filter((key) => isImageMimeType(value[key]));
+}
+
+function sanitizeOpaqueImageBase64(
+  base64: string,
+  mimeType: string | undefined,
+): { mimeType: string; base64: string } | undefined {
+  return mimeType ? sanitizeInlineImageBase64({ mimeType, base64 }) : undefined;
 }
 
 function isValidOpaqueImageBase64(base64: string, mimeType: string | undefined): boolean {
-  return mimeType !== undefined && base64HasImageSignature(base64, mimeType);
+  return sanitizeOpaqueImageBase64(base64, mimeType) !== undefined;
 }
 
 function isTranscriptImageContentBlock(value: Record<string, unknown>): boolean {
@@ -124,47 +105,48 @@ function isImageBase64SourceBlock(value: Record<string, unknown>): boolean {
   );
 }
 
-function imageDataUrlPayload(value: string): { mimeType: string; base64: string } | undefined {
-  const trimmed = value.trimStart();
-  if (!trimmed.toLowerCase().startsWith("data:")) {
+function sanitizeImageRecord(source: Record<string, unknown>): Record<string, unknown> | undefined {
+  const isImageBlock = source.type === "image";
+  const isBase64SourceBlock = source.type === "base64";
+  if ((!isImageBlock && !isBase64SourceBlock) || typeof source.data !== "string") {
     return undefined;
   }
-  const commaIndex = trimmed.indexOf(",");
-  if (commaIndex < 0) {
+  const mimeTypeFields = imageMimeTypeFieldsForRecord(source);
+  if (mimeTypeFields.length === 0) {
     return undefined;
   }
-  const header = trimmed.slice("data:".length, commaIndex);
-  const [rawMimeType, ...metadata] = header.split(";");
-  const mimeType = rawMimeType.trim().toLowerCase();
-  if (
-    !isImageMimeType(mimeType) ||
-    !metadata.some((part) => part.trim().toLowerCase() === "base64")
-  ) {
+  const sanitized = sanitizeOpaqueImageBase64(source.data, imageMimeTypeForRecord(source));
+  if (!sanitized) {
     return undefined;
   }
-  return {
-    mimeType,
-    base64: trimmed.slice(commaIndex + 1),
-  };
+  const hasCanonicalMimeTypes = mimeTypeFields.every((key) => source[key] === sanitized.mimeType);
+  if (source.data === sanitized.base64 && hasCanonicalMimeTypes) {
+    return source;
+  }
+  const next: Record<string, unknown> = { ...source, data: sanitized.base64 };
+  for (const field of mimeTypeFields) {
+    next[field] = sanitized.mimeType;
+  }
+  return next;
 }
 
-function isImageDataUrlField(source: Record<string, unknown>, key: string, value: string): boolean {
-  const parsed = imageDataUrlPayload(value);
-  if (!parsed || !isValidOpaqueImageBase64(parsed.base64, parsed.mimeType)) {
-    return false;
-  }
-  if (source.type === "input_image" && key === "image_url") {
-    return true;
-  }
-  if ((source.type === "image" || source.type === "image_url") && key === "url") {
-    return true;
-  }
-  return source.type === "image" && (key === "source" || key === "data");
+function startsWithDataUrl(value: string): boolean {
+  return value.slice(0, "data:".length).toLowerCase() === "data:";
 }
 
-function isValidImageDataUrl(value: string): boolean {
-  const parsed = imageDataUrlPayload(value);
-  return Boolean(parsed && isValidOpaqueImageBase64(parsed.base64, parsed.mimeType));
+function sanitizeImageDataUrlField(
+  source: Record<string, unknown>,
+  key: string,
+  value: string,
+): string | undefined {
+  if (!startsWithDataUrl(value)) {
+    return undefined;
+  }
+  const isImageDataUrlField =
+    (source.type === "input_image" && key === "image_url") ||
+    ((source.type === "image" || source.type === "image_url") && key === "url") ||
+    (source.type === "image" && (key === "source" || key === "data"));
+  return isImageDataUrlField ? sanitizeInlineImageDataUrlForStorage(value) : undefined;
 }
 
 function shouldPreserveOpaqueImagePayload(
@@ -183,9 +165,9 @@ function shouldPreserveOpaqueImagePayload(
     return true;
   }
   if (preserveImageDataUrlFields && key === "url") {
-    return isValidImageDataUrl(item);
+    return startsWithDataUrl(item) && sanitizeInlineImageDataUrlForStorage(item) !== undefined;
   }
-  return isImageDataUrlField(source, key, item);
+  return sanitizeImageDataUrlField(source, key, item) !== undefined;
 }
 
 function shouldPreserveNestedImageDataUrlFields(
@@ -246,9 +228,28 @@ function redactTranscriptStructuredValue(
   }
 
   seen.add(value);
-  const source = value;
+  const sanitizedImageRecord = sanitizeImageRecord(value);
+  const source = sanitizedImageRecord ?? value;
   let next: Record<string, unknown> | null = null;
+  if (source !== value) {
+    next = { ...source };
+  }
   for (const [key, item] of Object.entries(source)) {
+    if (typeof item === "string") {
+      const sanitizedDataUrl =
+        preserveImageDataUrlFields && key === "url"
+          ? startsWithDataUrl(item)
+            ? sanitizeInlineImageDataUrlForStorage(item)
+            : undefined
+          : sanitizeImageDataUrlField(source, key, item);
+      if (sanitizedDataUrl !== undefined) {
+        if (sanitizedDataUrl !== item) {
+          next ??= { ...source };
+          next[key] = sanitizedDataUrl;
+        }
+        continue;
+      }
+    }
     if (shouldPreserveOpaqueImagePayload(source, key, item, preserveImageDataUrlFields)) {
       continue;
     }

--- a/src/agents/transcript-redact.ts
+++ b/src/agents/transcript-redact.ts
@@ -3,6 +3,8 @@
  *
  * Applies logging redaction rules to persisted messages while preserving unchanged object identity.
  */
+import { Buffer } from "node:buffer";
+import { canonicalizeBase64 } from "@openclaw/media-core/base64";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { readLoggingConfig } from "../logging/config.js";
 import {
@@ -54,11 +56,154 @@ function isPlainTranscriptObject(value: object): value is Record<string, unknown
   return prototype === Object.prototype || prototype === null;
 }
 
+function isImageMimeType(value: unknown): boolean {
+  return typeof value === "string" && /^image\//iu.test(value.trim());
+}
+
+function normalizeImageMimeType(value: unknown): string | undefined {
+  return isImageMimeType(value) ? value.trim().toLowerCase() : undefined;
+}
+
+function imageMimeTypeForRecord(value: Record<string, unknown>): string | undefined {
+  return (
+    normalizeImageMimeType(value.mimeType) ??
+    normalizeImageMimeType(value.mediaType) ??
+    normalizeImageMimeType(value.media_type)
+  );
+}
+
+function base64HasImageSignature(base64: string, mimeType: string): boolean {
+  const canonical = canonicalizeBase64(base64);
+  if (!canonical) {
+    return false;
+  }
+  const header = Buffer.from(canonical.slice(0, 64), "base64");
+  if (mimeType === "image/png") {
+    return header
+      .subarray(0, 8)
+      .equals(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]));
+  }
+  if (mimeType === "image/jpeg" || mimeType === "image/jpg") {
+    return header[0] === 0xff && header[1] === 0xd8 && header[2] === 0xff;
+  }
+  if (mimeType === "image/gif") {
+    return (
+      header.subarray(0, 6).equals(Buffer.from("GIF87a")) ||
+      header.subarray(0, 6).equals(Buffer.from("GIF89a"))
+    );
+  }
+  if (mimeType === "image/webp") {
+    return (
+      header.subarray(0, 4).equals(Buffer.from("RIFF")) &&
+      header.subarray(8, 12).equals(Buffer.from("WEBP"))
+    );
+  }
+  if (mimeType === "image/bmp") {
+    return header.subarray(0, 2).equals(Buffer.from("BM"));
+  }
+  return false;
+}
+
+function isValidOpaqueImageBase64(base64: string, mimeType: string | undefined): boolean {
+  return mimeType !== undefined && base64HasImageSignature(base64, mimeType);
+}
+
+function isTranscriptImageContentBlock(value: Record<string, unknown>): boolean {
+  return (
+    value.type === "image" &&
+    typeof value.data === "string" &&
+    isValidOpaqueImageBase64(value.data, imageMimeTypeForRecord(value))
+  );
+}
+
+function isImageBase64SourceBlock(value: Record<string, unknown>): boolean {
+  return (
+    value.type === "base64" &&
+    typeof value.data === "string" &&
+    isValidOpaqueImageBase64(value.data, imageMimeTypeForRecord(value))
+  );
+}
+
+function imageDataUrlPayload(value: string): { mimeType: string; base64: string } | undefined {
+  const trimmed = value.trimStart();
+  if (!trimmed.toLowerCase().startsWith("data:")) {
+    return undefined;
+  }
+  const commaIndex = trimmed.indexOf(",");
+  if (commaIndex < 0) {
+    return undefined;
+  }
+  const header = trimmed.slice("data:".length, commaIndex);
+  const [rawMimeType, ...metadata] = header.split(";");
+  const mimeType = rawMimeType.trim().toLowerCase();
+  if (
+    !isImageMimeType(mimeType) ||
+    !metadata.some((part) => part.trim().toLowerCase() === "base64")
+  ) {
+    return undefined;
+  }
+  return {
+    mimeType,
+    base64: trimmed.slice(commaIndex + 1),
+  };
+}
+
+function isImageDataUrlField(source: Record<string, unknown>, key: string, value: string): boolean {
+  const parsed = imageDataUrlPayload(value);
+  if (!parsed || !isValidOpaqueImageBase64(parsed.base64, parsed.mimeType)) {
+    return false;
+  }
+  if (source.type === "input_image" && key === "image_url") {
+    return true;
+  }
+  if ((source.type === "image" || source.type === "image_url") && key === "url") {
+    return true;
+  }
+  return source.type === "image" && (key === "source" || key === "data");
+}
+
+function isValidImageDataUrl(value: string): boolean {
+  const parsed = imageDataUrlPayload(value);
+  return Boolean(parsed && isValidOpaqueImageBase64(parsed.base64, parsed.mimeType));
+}
+
+function shouldPreserveOpaqueImagePayload(
+  source: Record<string, unknown>,
+  key: string,
+  item: unknown,
+  preserveImageDataUrlFields: boolean,
+): boolean {
+  if (typeof item !== "string") {
+    return false;
+  }
+  if (
+    key === "data" &&
+    (isTranscriptImageContentBlock(source) || isImageBase64SourceBlock(source))
+  ) {
+    return true;
+  }
+  if (preserveImageDataUrlFields && key === "url") {
+    return isValidImageDataUrl(item);
+  }
+  return isImageDataUrlField(source, key, item);
+}
+
+function shouldPreserveNestedImageDataUrlFields(
+  source: Record<string, unknown>,
+  key: string,
+): boolean {
+  return (
+    key === "image_url" &&
+    (source.type === "image_url" || source.type === "input_image" || source.type === "image")
+  );
+}
+
 function redactTranscriptStructuredValue(
   value: unknown,
   cfg?: OpenClawConfig,
   fieldKey?: string,
   seen: WeakSet<object> = new WeakSet<object>(),
+  preserveImageDataUrlFields = false,
 ): unknown {
   if (typeof value === "string") {
     if (fieldKey) {
@@ -73,7 +218,13 @@ function redactTranscriptStructuredValue(
     seen.add(value);
     let changed = false;
     const redacted = value.map((item) => {
-      const next = redactTranscriptStructuredValue(item, cfg, fieldKey, seen);
+      const next = redactTranscriptStructuredValue(
+        item,
+        cfg,
+        fieldKey,
+        seen,
+        preserveImageDataUrlFields,
+      );
       changed ||= next !== item;
       return next;
     });
@@ -98,7 +249,16 @@ function redactTranscriptStructuredValue(
   const source = value;
   let next: Record<string, unknown> | null = null;
   for (const [key, item] of Object.entries(source)) {
-    const redacted = redactTranscriptStructuredValue(item, cfg, key, seen);
+    if (shouldPreserveOpaqueImagePayload(source, key, item, preserveImageDataUrlFields)) {
+      continue;
+    }
+    const redacted = redactTranscriptStructuredValue(
+      item,
+      cfg,
+      key,
+      seen,
+      preserveImageDataUrlFields || shouldPreserveNestedImageDataUrlFields(source, key),
+    );
     if (redacted === item) {
       continue;
     }

--- a/src/config/sessions/transcript-append-redact.test.ts
+++ b/src/config/sessions/transcript-append-redact.test.ts
@@ -24,6 +24,8 @@ vi.mock("../../logging/config.js", async (importOriginal) => {
 });
 
 const EMAIL_PATTERN = String.raw`([\w]|[-.])+@([\w]|[-.])+\.\w+`;
+const IMAGE_BASE64_WITH_SECRET_TOKEN_SUBSTRING =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAARcnVOZAAAAKIDABCDEFGHIJKLMNOP8JJRuAAAAABJRU5ErkJggg==";
 
 function readMessages(sessionFile: string) {
   return fs
@@ -82,6 +84,41 @@ describe("appendSessionTranscriptMessage - redaction", () => {
       content: Array<{ text: string }>;
     }>;
     expect(msg.content[0].text).not.toContain("sk-abcdef1234567890xyz");
+  });
+
+  it("preserves image base64 payloads before writing to disk", async () => {
+    const sessionFile = resolveSessionTranscriptPathInDir(
+      "redact-image-base64",
+      fixture.sessionsDir(),
+    );
+    const config: OpenClawConfig = { logging: { redactSensitive: "tools" } };
+
+    await appendSessionTranscriptMessage({
+      transcriptPath: sessionFile,
+      message: {
+        role: "user",
+        content: [
+          { type: "text", text: "my key is sk-abcdef1234567890xyz" },
+          {
+            type: "image",
+            data: IMAGE_BASE64_WITH_SECRET_TOKEN_SUBSTRING,
+            mimeType: "image/png",
+          },
+        ],
+      },
+      config,
+    });
+
+    const raw = fs.readFileSync(sessionFile, "utf-8");
+    expect(raw).not.toContain("sk-abcdef1234567890xyz");
+    expect(raw).toContain(IMAGE_BASE64_WITH_SECRET_TOKEN_SUBSTRING);
+    expect(raw).not.toContain("AKID…MNOP");
+
+    const [msg] = readMessages(sessionFile) as Array<{
+      content: Array<{ type: string; text?: string; data?: string }>;
+    }>;
+    expect(msg.content[0].text).not.toContain("sk-abcdef1234567890xyz");
+    expect(msg.content[1].data).toBe(IMAGE_BASE64_WITH_SECRET_TOKEN_SUBSTRING);
   });
 
   it("writes content unchanged when redactSensitive is off", async () => {


### PR DESCRIPTION
## Summary

Fixes #90760.

- preserve validated opaque image payloads during transcript redaction so default secret patterns cannot rewrite base64 bytes with a Unicode ellipsis
- keep redaction active for adjacent text and fake image-shaped secret payloads
- repair already-poisoned session image blocks by replacing unrecoverable corrupted image payloads with replayable fallback text
- keep transcript storage and provider transport boundaries separate: storage can preserve validated image formats such as BMP/HEIC/HEIF, while transport sanitizer remains limited to provider-safe browser image data URLs

## Security Boundary

This intentionally treats validated image bytes as opaque media data, not text to run through secret-pattern substitution. The exemption is bounded by image field shape, strict base64 validation, bounded prefix decoding, and magic-byte/signature sniffing. Adjacent text still goes through normal redaction, and fake image-shaped payloads containing secret-looking strings are still redacted or repaired.

The PR avoids a MIME-only bypass: image claims are accepted only when bytes match a supported image signature. It also avoids widening provider transport behavior by using a separate storage sanitizer from the existing transport sanitizer.

## Verification

- `.agents/skills/autoreview/scripts/autoreview --mode local`
  - clean: no accepted/actionable findings
- AWS Crabbox fix/regression proof after the clean autoreview: provider `aws`, run `run_2da949704798`, lease `cbx_f1c73cdaa4d8`, machine `c7a.8xlarge`, exit `0`
  - `node scripts/run-vitest.mjs packages/media-core/src/inline-image-data-url.test.ts src/agents/transcript-redact.test.ts src/config/sessions/transcript-append-redact.test.ts src/agents/session-file-repair.test.ts src/agents/responses-image-payload-sanitizer.test.ts`
  - passed 3 Vitest shards: 85 tests
  - explicit proof script confirmed valid image payload preservation, adjacent secret redaction, storage-vs-transport data URL boundary, and corrupted replay repair
- Earlier AWS Crabbox live behavior proof: provider `aws`, run `run_46fd11090674`, lease `cbx_a2733bb606fb`, exit `0`
  - redaction-trigger image persisted with `persistedIncludesEllipsis:false`, `nonAsciiCount:0`
  - valid image replay through live Anthropic transport returned `stopReason:"stop"`
  - corrupted transcript repair removed `1` image block
  - repaired transcript replay through live Anthropic transport returned `stopReason:"stop"`
