### PR TITLE
perf(control-ui): reuse startup model metadata

### DIFF
--- a/src/agents/model-catalog-browse.ts
+++ b/src/agents/model-catalog-browse.ts
@@ -43,6 +43,18 @@ function resolveModelCatalogBrowseTimeoutMs(value: number | undefined): number {
   );
 }
 
+/** True when a browse view cannot be answered from read-only cached catalog entries. */
+export function modelCatalogBrowseRequiresFullDiscovery(params: {
+  cfg: OpenClawConfig;
+  view?: ModelCatalogBrowseView;
+}): boolean {
+  const view = params.view ?? "default";
+  return (
+    view === "all" ||
+    parseConfiguredModelVisibilityEntries({ cfg: params.cfg }).providerWildcards.size > 0
+  );
+}
+
 /** Loads catalog entries for browse views, using read-only discovery unless full catalog is required. */
 export async function loadModelCatalogForBrowse(params: {
   cfg: OpenClawConfig;
@@ -52,10 +64,7 @@ export async function loadModelCatalogForBrowse(params: {
   onTimeout?: (timeoutMs: number) => void;
 }): Promise<ModelCatalogEntry[]> {
   const view = params.view ?? "default";
-  if (view === "all") {
-    return await params.loadCatalog({ readOnly: false });
-  }
-  if (parseConfiguredModelVisibilityEntries({ cfg: params.cfg }).providerWildcards.size > 0) {
+  if (modelCatalogBrowseRequiresFullDiscovery({ cfg: params.cfg, view })) {
     // Wildcards depend on provider discovery; read-only cached entries can hide matching models.
     return await params.loadCatalog({ readOnly: false });
   }

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -43,6 +43,8 @@ import { resolveProviderIdForAuth } from "../../agents/provider-auth-aliases.js"
 import type { AgentMessage } from "../../agents/runtime/index.js";
 import { ensureSandboxWorkspaceForSession } from "../../agents/sandbox/context.js";
 import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
+import type { ModelCatalogEntry } from "../../agents/model-catalog.types.js";
+import { modelCatalogBrowseRequiresFullDiscovery } from "../../agents/model-catalog-browse.js";
 import { dispatchInboundMessage } from "../../auto-reply/dispatch.js";
 import { getReplyPayloadMetadata, type ReplyPayload } from "../../auto-reply/reply-payload.js";
 import { createReplyDispatcher } from "../../auto-reply/reply/reply-dispatcher.js";
@@ -213,6 +215,11 @@ type PreRegisteredAgentRun = {
 
 type ChatHistoryMethod = "chat.history" | "chat.startup";
 
+type ChatMetadataResult = {
+  commands?: unknown[];
+  models?: unknown[];
+};
+
 type ChatSendAckServerTiming = {
   receivedToAckMs: number;
   loadSessionMs: number;
@@ -324,28 +331,73 @@ async function handleChatMetadataRequest({
     return;
   }
   try {
-    const [{ buildModelsListResult }, { buildCommandsListResult }] = await Promise.all([
-      import("./models-list-result.js"),
-      import("./commands-list-result.js"),
-    ]);
-    const [models, commands] = await Promise.all([
-      buildModelsListResult({
+    respond(
+      true,
+      await buildChatMetadataResult({
+        cfg,
         context,
         agentId: requestedAgentId,
-        params: { view: "configured" },
       }),
-      Promise.resolve(
-        buildCommandsListResult({
-          cfg,
-          agentId: requestedAgentId,
-          includeArgs: true,
-          scope: "text",
-        }),
-      ),
-    ]);
-    respond(true, { ...models, ...commands });
+    );
   } catch (err) {
     respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, String(err)));
+  }
+}
+
+async function buildChatMetadataResult(params: {
+  cfg: OpenClawConfig;
+  context: GatewayRequestContext;
+  agentId: string;
+  preloadedModelCatalog?: ModelCatalogEntry[];
+}): Promise<ChatMetadataResult> {
+  const [{ buildModelsListResult }, { buildCommandsListResult }] = await Promise.all([
+    import("./models-list-result.js"),
+    import("./commands-list-result.js"),
+  ]);
+  const [models, commands] = await Promise.all([
+    buildModelsListResult({
+      context: params.context,
+      agentId: params.agentId,
+      params: { view: "configured" },
+      preloadedCatalog: params.preloadedModelCatalog,
+    }),
+    Promise.resolve(
+      buildCommandsListResult({
+        cfg: params.cfg,
+        agentId: params.agentId,
+        includeArgs: true,
+        scope: "text",
+      }),
+    ),
+  ]);
+  return { ...models, ...commands };
+}
+
+async function buildChatStartupMetadataResult(params: {
+  cfg: OpenClawConfig;
+  context: GatewayRequestContext;
+  agentId: string;
+  modelCatalog: ModelCatalogEntry[] | undefined;
+}): Promise<ChatMetadataResult | undefined> {
+  if (!params.modelCatalog) {
+    return undefined;
+  }
+  if (modelCatalogBrowseRequiresFullDiscovery({ cfg: params.cfg, view: "configured" })) {
+    return undefined;
+  }
+  try {
+    const { buildModelsListResult } = await import("./models-list-result.js");
+    return await buildModelsListResult({
+      context: params.context,
+      agentId: params.agentId,
+      params: { view: "configured" },
+      preloadedCatalog: params.modelCatalog,
+    });
+  } catch (err) {
+    params.context.logGateway.debug(
+      `chat.startup continuing without metadata: ${formatErrorMessage(err)}`,
+    );
+    return undefined;
   }
 }
 
@@ -2380,9 +2432,11 @@ async function handleChatHistoryRequest({
   context,
   method,
   includeAgentsList,
+  includeMetadata,
 }: GatewayRequestHandlerOptions & {
   method: ChatHistoryMethod;
   includeAgentsList?: boolean;
+  includeMetadata?: boolean;
 }) {
   if (!validateChatHistoryParams(params)) {
     respond(
@@ -2510,6 +2564,15 @@ async function handleChatHistoryRequest({
     );
   }
   const modelCatalog = await modelCatalogPromise;
+  const defaultAgentId = resolveDefaultAgentId(cfg);
+  const startupMetadata = includeMetadata
+    ? await buildChatStartupMetadataResult({
+        cfg,
+        context,
+        agentId: sessionAgentId,
+        modelCatalog,
+      })
+    : undefined;
   const sessionInfo = buildGatewaySessionInfo({
     cfg,
     storePath,
@@ -2519,7 +2582,6 @@ async function handleChatHistoryRequest({
     agentId: selectedAgent.agentId,
     modelCatalog,
   });
-  const defaultAgentId = resolveDefaultAgentId(cfg);
   const activeRunAgentId =
     canonicalKey === "global" ? (selectedAgent.agentId ?? defaultAgentId) : selectedAgent.agentId;
   sessionInfo.hasActiveRun = hasTrackedActiveSessionRun({
@@ -2560,6 +2622,7 @@ async function handleChatHistoryRequest({
     verboseLevel,
     ...(boundedInFlightRun ? { inFlightRun: boundedInFlightRun } : {}),
     ...(includeAgentsList ? { agentsList: listAgentsForGateway(cfg, modelCatalog) } : {}),
+    ...(startupMetadata ? { metadata: startupMetadata } : {}),
   };
   respond(true, payload);
 }
@@ -2569,7 +2632,12 @@ export const chatHandlers: GatewayRequestHandlers = {
     await handleChatHistoryRequest({ ...opts, method: "chat.history" });
   },
   "chat.startup": async (opts) => {
-    await handleChatHistoryRequest({ ...opts, method: "chat.startup", includeAgentsList: true });
+    await handleChatHistoryRequest({
+      ...opts,
+      method: "chat.startup",
+      includeAgentsList: true,
+      includeMetadata: true,
+    });
   },
   "chat.metadata": handleChatMetadataRequest,
   "chat.message.get": async ({ params, respond, context }) => {

--- a/src/gateway/server-methods/models-list-result.ts
+++ b/src/gateway/server-methods/models-list-result.ts
@@ -264,6 +264,7 @@ export async function buildModelsListResult(params: {
   context: GatewayRequestContext;
   agentId?: string;
   params: Record<string, unknown>;
+  preloadedCatalog?: ModelCatalogEntry[];
 }): Promise<{ models: ModelsListEntry[] }> {
   const cfg = params.context.getRuntimeConfig();
   const agentId = params.agentId ?? resolveDefaultAgentId(cfg);
@@ -272,7 +273,13 @@ export async function buildModelsListResult(params: {
   const catalog = await loadModelCatalogForBrowse({
     cfg,
     view,
-    loadCatalog: params.context.loadGatewayModelCatalog,
+    loadCatalog: async (loadParams) => {
+      const readOnlyLoad = loadParams.readOnly ?? true;
+      if (params.preloadedCatalog && readOnlyLoad) {
+        return params.preloadedCatalog;
+      }
+      return await params.context.loadGatewayModelCatalog(loadParams);
+    },
     onTimeout: (timeoutMs) => {
       if (loggedSlowModelsListCatalog) {
         return;

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -378,6 +378,27 @@ describe("gateway server chat", () => {
 
   test("chat.startup returns chat history with the initial agents list", async () => {
     await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
+      await writeGatewayConfig({
+        agents: {
+          defaults: {
+            model: {
+              primary: "openai/gpt-main",
+            },
+            models: {
+              "openai/gpt-main": {},
+            },
+          },
+          list: [{ id: "main", default: true }],
+        },
+        models: {
+          providers: {
+            openai: {
+              baseUrl: "https://openai.example.com/v1",
+              models: [{ id: "gpt-main", name: "GPT Main" }],
+            },
+          },
+        },
+      });
       await connectOk(ws);
       const sessionDir = await createSessionDir();
       const updatedAt = Date.now();
@@ -407,6 +428,10 @@ describe("gateway server chat", () => {
           defaultId?: string | null;
           mainKey?: string | null;
         };
+        metadata?: {
+          commands?: Array<{ name?: string; textAliases?: string[] }>;
+          models?: Array<{ id?: string; provider?: string }>;
+        };
         messages?: unknown[];
         sessionInfo?: { key?: string; sessionId?: string };
       }>(ws, "chat.startup", { sessionKey: "main" });
@@ -419,11 +444,107 @@ describe("gateway server chat", () => {
         key: "agent:main:main",
         sessionId: "sess-main",
       });
+      expect(startup.payload?.metadata?.models).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: "gpt-main",
+            provider: "openai",
+          }),
+        ]),
+      );
+      expect(startup.payload?.metadata?.commands).toBeUndefined();
       expect(startup.payload?.messages).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
             role: "user",
             content: [{ type: "text", text: "startup hydrate" }],
+          }),
+        ]),
+      );
+    });
+  });
+
+  test("chat.startup omits metadata when configured model visibility needs full discovery", async () => {
+    await withGatewayChatHarness(async ({ ws }) => {
+      await writeGatewayConfig({
+        agents: {
+          defaults: {
+            model: { primary: "openai/gpt-main" },
+            models: {
+              "openai/*": {},
+            },
+          },
+          list: [{ id: "main", default: true }],
+        },
+        models: {
+          providers: {
+            openai: {
+              baseUrl: "https://openai.example.com/v1",
+              models: [{ id: "gpt-main", name: "GPT Main" }],
+            },
+          },
+        },
+      });
+      await connectOk(ws);
+
+      const startup = await rpcReq<{ metadata?: unknown }>(ws, "chat.startup", {
+        sessionKey: "main",
+      });
+
+      expect(startup.ok).toBe(true);
+      expect(startup.payload?.metadata).toBeUndefined();
+    });
+  });
+
+  test("chat.startup scopes metadata to agent session keys without explicit agentId", async () => {
+    await withGatewayChatHarness(async ({ ws }) => {
+      await writeGatewayConfig({
+        agents: {
+          defaults: {
+            model: {
+              primary: "openai/gpt-main",
+            },
+            models: {
+              "openai/gpt-main": {},
+            },
+          },
+          list: [
+            { id: "main", default: true },
+            {
+              id: "work",
+              model: {
+                primary: "minimax/MiniMax-M2.7-highspeed",
+              },
+            },
+          ],
+        },
+        models: {
+          providers: {
+            openai: {
+              baseUrl: "https://openai.example.com/v1",
+              models: [{ id: "gpt-main", name: "GPT Main" }],
+            },
+            minimax: {
+              baseUrl: "https://minimax.example.com/v1",
+              models: [{ id: "MiniMax-M2.7-highspeed", name: "MiniMax M2.7 Highspeed" }],
+            },
+          },
+        },
+      });
+      await connectOk(ws);
+
+      const startup = await rpcReq<{
+        metadata?: {
+          models?: Array<{ id?: string; provider?: string }>;
+        };
+      }>(ws, "chat.startup", { sessionKey: "agent:work:main" });
+
+      expect(startup.ok).toBe(true);
+      expect(startup.payload?.metadata?.models).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: "MiniMax-M2.7-highspeed",
+            provider: "minimax",
           }),
         ]),
       );

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -454,6 +454,9 @@ function installControlUiMockGateway(input: {
             scope: "agent",
           },
           messages: scenario.historyMessages,
+          metadata: {
+            models: scenario.models,
+          },
           sessionId: "control-ui-e2e-session",
           thinkingLevel: null,
         };

--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -1074,6 +1074,54 @@ describe("refreshChat", () => {
     }
   });
 
+  it("uses startup metadata without scheduling a chat.metadata follow-up", async () => {
+    const { resetSlashCommandsForTest } = await import("./chat/slash-commands.ts");
+    resetSlashCommandsForTest();
+    const previousFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn().mockResolvedValue({ ok: false }) as never;
+    try {
+      const request = vi.fn((method: string) => {
+        if (method === "chat.startup") {
+          return Promise.resolve({
+            messages: [],
+            metadata: {
+              models: [{ id: "gpt-fast", name: "GPT Fast", provider: "openai" }],
+            },
+          });
+        }
+        return pendingPromise();
+      });
+      const host = makeHost({
+        client: { request } as unknown as ChatHost["client"],
+        sessionKey: "main",
+      });
+
+      await refreshChat(host, { startup: true });
+
+      await vi.waitFor(() => expect(host.chatModelCatalog).toHaveLength(1));
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 75);
+      });
+      expect(request).toHaveBeenCalledWith("chat.startup", {
+        sessionKey: "main",
+        limit: 100,
+      });
+      expect(request).not.toHaveBeenCalledWith("chat.metadata", expect.anything());
+      expect(request).not.toHaveBeenCalledWith("models.list", expect.anything());
+      expect(request).toHaveBeenCalledWith("commands.list", {
+        agentId: "main",
+        includeArgs: true,
+        scope: "text",
+      });
+      expect(host.chatModelCatalog).toEqual([
+        { id: "gpt-fast", name: "GPT Fast", provider: "openai" },
+      ]);
+    } finally {
+      resetSlashCommandsForTest();
+      globalThis.fetch = previousFetch;
+    }
+  });
+
   it("falls back to separate metadata RPCs when chat.metadata is not advertised", async () => {
     const request = vi.fn(() => pendingPromise());
     const host = makeHost({

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -1,5 +1,4 @@
 // Control UI module implements app chat behavior.
-import type { CommandsListResult } from "../../../packages/gateway-protocol/src/index.js";
 import { setLastActiveSessionKey } from "./app-last-active-session.ts";
 import { scheduleChatScroll, resetChatScroll } from "./app-scroll.ts";
 import { resetToolStream } from "./app-tool-stream.ts";
@@ -50,6 +49,7 @@ import {
   sendSteerChatMessage,
   type ChatEventPayload,
   type ChatHistoryResult,
+  type ChatMetadataResult,
   type ChatSendAck,
   type ChatState,
   isGatewayMethodAdvertised,
@@ -140,8 +140,9 @@ type ChatAgentsListSnapshot = Partial<Omit<AgentsListResult, "agents">> & {
   agents?: Array<{ id: string }>;
 };
 
-type ChatMetadataResult = CommandsListResult & {
-  models?: ModelCatalogEntry[];
+type ChatMetadataApplyResult = {
+  commands: boolean;
+  models: boolean;
 };
 
 function setChatError(host: ChatHost, error: string | null) {
@@ -1988,6 +1989,8 @@ export async function refreshChat(
   opts?: { scheduleScroll?: boolean; awaitHistory?: boolean; startup?: boolean },
 ) {
   const refreshedSessionKey = host.sessionKey;
+  const refreshedClient = host.client;
+  const refreshedAgentId = resolveAgentIdForSession(host);
   const requestUpdate = () => host.requestUpdate?.();
   const previousSessionsResult = host.sessionsResult;
   const historyLoad = loadChatHistory(host as unknown as ChatState, {
@@ -2008,6 +2011,23 @@ export async function refreshChat(
       );
     }
   });
+  const startupMetadataRefresh =
+    opts?.startup === true
+      ? historyLoad.then((history) => {
+          if (!history?.metadata || !refreshedClient) {
+            return { commands: false, models: false };
+          }
+          if (
+            host.client !== refreshedClient ||
+            !host.connected ||
+            host.sessionKey !== refreshedSessionKey ||
+            resolveAgentIdForSession(host) !== refreshedAgentId
+          ) {
+            return { commands: false, models: false };
+          }
+          return applyChatMetadataResult(host, refreshedClient, refreshedAgentId, history.metadata);
+        })
+      : Promise.resolve({ commands: false, models: false });
   flushChatQueueAfterIdleSessionReconciliation(
     host,
     refreshedSessionKey,
@@ -2015,14 +2035,26 @@ export async function refreshChat(
     sessionsRefresh,
     previousSessionsResult,
   );
-  const secondaryRefresh = Promise.allSettled([sessionsRefresh]).finally(requestUpdate);
+  const secondaryRefresh = Promise.allSettled([sessionsRefresh, startupMetadataRefresh]).finally(
+    requestUpdate,
+  );
   scheduleChatMetadataRefresh(() => {
     if (host.sessionKey !== refreshedSessionKey || !host.connected) {
       return;
     }
-    void Promise.allSettled([refreshChatAvatar(host), refreshChatMetadata(host)]).finally(
-      requestUpdate,
-    );
+    void startupMetadataRefresh
+      .catch(() => ({ commands: false, models: false }))
+      .then((metadataApplied) => {
+        const metadataRefresh =
+          opts?.startup === true && (metadataApplied.commands || metadataApplied.models)
+            ? Promise.allSettled([
+                ...(metadataApplied.models ? [] : [refreshChatModels(host)]),
+                ...(metadataApplied.commands ? [] : [refreshChatCommands(host)]),
+              ])
+            : Promise.allSettled([refreshChatMetadata(host)]);
+        return Promise.allSettled([refreshChatAvatar(host), metadataRefresh]);
+      })
+      .finally(requestUpdate);
   });
   void historyRefresh;
   void secondaryRefresh;
@@ -2064,6 +2096,24 @@ async function refreshChatCommands(host: ChatHost) {
   });
 }
 
+function applyChatMetadataResult(
+  host: ChatHost,
+  client: GatewayBrowserClient,
+  agentId: string | null | undefined,
+  result: ChatMetadataResult,
+): ChatMetadataApplyResult {
+  const models = applyModelCatalogResult(result.models);
+  if (models) {
+    host.chatModelCatalog = models;
+  }
+  const commandsApplied = applyRemoteSlashCommandsResult({
+    client,
+    agentId,
+    result,
+  });
+  return { commands: commandsApplied, models: Boolean(models) };
+}
+
 async function refreshChatMetadata(host: ChatHost) {
   if (!host.client || !host.connected) {
     host.chatModelsLoading = false;
@@ -2096,19 +2146,11 @@ async function refreshChatMetadata(host: ChatHost) {
     ) {
       return;
     }
-    const models = applyModelCatalogResult(result.models);
-    if (models) {
-      host.chatModelCatalog = models;
-    }
-    const commandsApplied = applyRemoteSlashCommandsResult({
-      client,
-      agentId,
-      result,
-    });
-    if (!models || !commandsApplied) {
+    const metadataApplied = applyChatMetadataResult(host, client, agentId, result);
+    if (!metadataApplied.models || !metadataApplied.commands) {
       await Promise.allSettled([
-        ...(models ? [] : [refreshChatModels(host)]),
-        ...(commandsApplied ? [] : [refreshChatCommands(host)]),
+        ...(metadataApplied.models ? [] : [refreshChatModels(host)]),
+        ...(metadataApplied.commands ? [] : [refreshChatCommands(host)]),
       ]);
     }
   } catch {

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -1,4 +1,5 @@
 // Control UI controller manages chat gateway state.
+import type { CommandsListResult } from "../../../../packages/gateway-protocol/src/index.js";
 import { getChatAttachmentDataUrl } from "../chat/attachment-payload-store.ts";
 import {
   isAssistantHeartbeatAckForDisplay,
@@ -32,7 +33,12 @@ import {
   parseAgentSessionKey,
 } from "../session-key.ts";
 import { normalizeLowercaseStringOrEmpty } from "../string-coerce.ts";
-import type { AgentsListResult, GatewaySessionRow, GatewaySessionsDefaults } from "../types.ts";
+import type {
+  AgentsListResult,
+  GatewaySessionRow,
+  GatewaySessionsDefaults,
+  ModelCatalogEntry,
+} from "../types.ts";
 import type { ChatAttachment } from "../ui-types.ts";
 import { generateUUID } from "../uuid.ts";
 import {
@@ -418,6 +424,11 @@ export type ChatHistoryResult = {
   defaults?: GatewaySessionsDefaults;
   sessionInfo?: GatewaySessionRow;
   agentsList?: AgentsListResult;
+  metadata?: ChatMetadataResult;
+};
+
+export type ChatMetadataResult = CommandsListResult & {
+  models?: ModelCatalogEntry[];
 };
 
 export type ChatEventPayload = {

--- a/ui/src/ui/e2e/chat-flow.e2e.test.ts
+++ b/ui/src/ui/e2e/chat-flow.e2e.test.ts
@@ -341,7 +341,7 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
       defaultAgentId: "ops",
-      deferredMethods: ["chat.metadata", "chat.startup"],
+      deferredMethods: ["chat.startup"],
       historyMessages: [],
       sessionKey: "global",
     });
@@ -349,8 +349,8 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
     try {
       await page.goto(`${server.baseUrl}chat`);
       await gateway.waitForRequest("chat.startup");
-      await gateway.waitForRequest("chat.metadata");
       expect(await gateway.getRequests("agents.list")).toHaveLength(0);
+      expect(await gateway.getRequests("chat.metadata")).toHaveLength(0);
       expect(await gateway.getRequests("commands.list")).toHaveLength(0);
       expect(await gateway.getRequests("models.list")).toHaveLength(0);
 
@@ -457,15 +457,17 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
           scope: "agent",
         },
         messages: [],
+        metadata: {
+          models: [],
+        },
         sessionId: "control-ui-e2e-session",
         thinkingLevel: null,
       });
-      await gateway.resolveDeferred("chat.metadata", {
-        commands: [],
-        models: [],
-      });
       await page.locator(".chat-thread").getByText(prompt).waitFor({ timeout: 10_000 });
       await page.getByText("First token visible.").waitFor({ timeout: 10_000 });
+      expect(await gateway.getRequests("chat.metadata")).toHaveLength(0);
+      expect(await gateway.getRequests("models.list")).toHaveLength(0);
+      await gateway.waitForRequest("commands.list");
       await gateway.emitChatFinal({ runId, text: "History race stayed visible." });
       await page.getByText("History race stayed visible.").waitFor({ timeout: 10_000 });
       expect(await gateway.getRequests("agents.list")).toHaveLength(0);


### PR DESCRIPTION
Summary:
- reuse opportunistic model metadata from `chat.startup` so a clean Control UI chat boot can skip the follow-up model metadata RPC
- keep command discovery off the startup critical path; the UI only fetches commands separately when startup metadata supplies models
- guard startup metadata when configured model visibility requires full provider discovery, and preserve agent-scoped session metadata

Verification:
- `node scripts/run-vitest.mjs src/agents/model-catalog-browse.test.ts src/gateway/server.chat.gateway-server-chat-b.test.ts ui/src/ui/app-chat.test.ts -- --reporter=verbose`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/ui/e2e/chat-flow.e2e.test.ts -- --reporter=verbose`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` -> clean, no accepted/actionable findings
- Blacksmith Testbox `tbx_01ktmw1g1tb9g7anqzx6vvqq1m`: `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed` exited 0 after typecheck, lint, and import-cycle guard
