### PR TITLE
fix(ui): scope avatar storage per agent ID

### DIFF
--- a/ui/src/ui/controllers/assistant-identity.test.ts
+++ b/ui/src/ui/controllers/assistant-identity.test.ts
@@ -199,4 +199,30 @@ describe("setAssistantAvatarOverride", () => {
     // An agent with no specific avatar should fall back to the global key.
     expect(loadLocalAssistantIdentity("new-agent").avatar).toBe("data:image/png;base64,Z2xvYmFs");
   });
+
+  it("handles legacy global key after scoped clear (upgrade scenario)", () => {
+    // Simulate legacy state: global avatar exists from before the scoping fix.
+    setAssistantAvatarOverride({}, "data:image/png;base64,bGVnYWN5");
+
+    // Agent "main" should see the legacy global avatar.
+    expect(loadLocalAssistantIdentity("main").avatar).toBe("data:image/png;base64,bGVnYWN5");
+
+    // Set a scoped avatar for "main".
+    const mainState: Parameters<typeof setAssistantAvatarOverride>[0] = {
+      assistantAgentId: "main",
+    };
+    setAssistantAvatarOverride(mainState, "data:image/png;base64,c2NvcGVk");
+    expect(loadLocalAssistantIdentity("main").avatar).toBe("data:image/png;base64,c2NvcGVk");
+
+    // Clear the scoped avatar for "main".
+    setAssistantAvatarOverride(mainState, null);
+    expect(loadLocalAssistantIdentity("main").avatar).toBeNull();
+
+    // The legacy global avatar should still be available for other agents.
+    expect(loadLocalAssistantIdentity("other-agent").avatar).toBe("data:image/png;base64,bGVnYWN5");
+
+    // After clearing scoped, "main" should NOT fall back to global
+    // (the scoped key exists with null value, which blocks fallback).
+    expect(loadLocalAssistantIdentity("main").avatar).toBeNull();
+  });
 });

--- a/ui/src/ui/controllers/assistant-identity.test.ts
+++ b/ui/src/ui/controllers/assistant-identity.test.ts
@@ -170,4 +170,33 @@ describe("setAssistantAvatarOverride", () => {
     );
     expect(loadLocalAssistantIdentity({ agentId: "toString" }).avatar).toBeNull();
   });
+
+  it("scopes avatar storage per agent ID (regression #90890)", () => {
+    const mainState: Parameters<typeof setAssistantAvatarOverride>[0] = {
+      assistantAgentId: "main",
+    };
+    const workerState: Parameters<typeof setAssistantAvatarOverride>[0] = {
+      assistantAgentId: "worker",
+    };
+
+    setAssistantAvatarOverride(mainState, "data:image/png;base64,bWFpbg==");
+    setAssistantAvatarOverride(workerState, "data:image/png;base64,d29ya2Vy");
+
+    // Each agent should have its own avatar.
+    expect(loadLocalAssistantIdentity("main").avatar).toBe("data:image/png;base64,bWFpbg==");
+    expect(loadLocalAssistantIdentity("worker").avatar).toBe("data:image/png;base64,d29ya2Vy");
+
+    // Clearing one agent should not affect the other.
+    setAssistantAvatarOverride(mainState, null);
+    expect(loadLocalAssistantIdentity("main").avatar).toBeNull();
+    expect(loadLocalAssistantIdentity("worker").avatar).toBe("data:image/png;base64,d29ya2Vy");
+  });
+
+  it("falls back to global key when agent-specific key is not set", () => {
+    // Set a global avatar (no agent ID).
+    setAssistantAvatarOverride({}, "data:image/png;base64,Z2xvYmFs");
+
+    // An agent with no specific avatar should fall back to the global key.
+    expect(loadLocalAssistantIdentity("new-agent").avatar).toBe("data:image/png;base64,Z2xvYmFs");
+  });
 });

--- a/ui/src/ui/controllers/assistant-identity.ts
+++ b/ui/src/ui/controllers/assistant-identity.ts
@@ -20,6 +20,7 @@ export type AssistantAvatarOverrideState = {
   assistantAvatarSource?: string | null;
   assistantAvatarStatus?: "none" | "local" | "remote" | "data" | null;
   assistantAvatarReason?: string | null;
+  assistantAgentId?: string | null;
 };
 
 const assistantIdentityRequestVersions = new WeakMap<object, number>();

--- a/ui/src/ui/controllers/proof-avatar-per-agent.proof.test.ts
+++ b/ui/src/ui/controllers/proof-avatar-per-agent.proof.test.ts
@@ -97,7 +97,9 @@ describe("avatar storage per agent ID — real code proof (#90890)", () => {
     const keys: string[] = [];
     for (let i = 0; i < localStorage.length; i++) {
       const k = localStorage.key(i);
-      if (k && k.startsWith("openclaw.control.assistant.v1")) keys.push(k);
+      if (k && k.startsWith("openclaw.control.assistant.v1")) {
+        keys.push(k);
+      }
     }
     keys.sort();
 

--- a/ui/src/ui/controllers/proof-avatar-per-agent.proof.test.ts
+++ b/ui/src/ui/controllers/proof-avatar-per-agent.proof.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Proof script: avatar storage per agent ID (issue #90890).
+ *
+ * Runs the REAL loadLocalAssistantIdentity / saveLocalAssistantIdentity
+ * functions from ui/src/ui/storage.ts against an in-memory localStorage.
+ * Uses vitest to properly mock globalThis.localStorage so the real code paths
+ * are exercised exactly as they run in the browser.
+ *
+ * Usage: npx vitest run scripts/proof-avatar-per-agent.proof.test.ts --reporter verbose
+ */
+// @vitest-environment node
+import { afterEach, beforeEach, describe, it, vi, expect } from "vitest";
+import { createStorageMock } from "../../test-helpers/storage.ts";
+import { loadLocalAssistantIdentity, saveLocalAssistantIdentity } from "../storage.ts";
+
+describe("avatar storage per agent ID — real code proof (#90890)", () => {
+  beforeEach(() => {
+    vi.stubGlobal("localStorage", createStorageMock());
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("Test 1: per-agent scoping — main and worker have independent avatars", () => {
+    saveLocalAssistantIdentity({ avatar: "data:image/png;base64,bWFpbg==" }, "main");
+    saveLocalAssistantIdentity({ avatar: "data:image/png;base64,d29ya2Vy" }, "worker");
+
+    // Each agent should have its own avatar stored in a separate scoped key.
+    expect(loadLocalAssistantIdentity("main").avatar).toBe("data:image/png;base64,bWFpbg==");
+    expect(loadLocalAssistantIdentity("worker").avatar).toBe("data:image/png;base64,d29ya2Vy");
+
+    // Verify the localStorage keys are different.
+    const mainRaw = localStorage.getItem("openclaw.control.assistant.v1:main");
+    const workerRaw = localStorage.getItem("openclaw.control.assistant.v1:worker");
+    expect(mainRaw).toBeTruthy();
+    expect(workerRaw).toBeTruthy();
+    expect(mainRaw).not.toBe(workerRaw);
+  });
+
+  it("Test 2: clear isolation — clearing main does not affect worker", () => {
+    saveLocalAssistantIdentity({ avatar: "data:image/png;base64,bWFpbg==" }, "main");
+    saveLocalAssistantIdentity({ avatar: "data:image/png;base64,d29ya2Vy" }, "worker");
+
+    // Clear main's avatar.
+    saveLocalAssistantIdentity({ avatar: null }, "main");
+
+    // main's avatar should be null; worker should be unaffected.
+    expect(loadLocalAssistantIdentity("main").avatar).toBeNull();
+    expect(loadLocalAssistantIdentity("worker").avatar).toBe("data:image/png;base64,d29ya2Vy");
+  });
+
+  it("Test 3: global fallback — new agent without scoped key falls back to global", () => {
+    // Set a global avatar (no agent ID).
+    saveLocalAssistantIdentity({ avatar: "data:image/png;base64,Z2xvYmFs" });
+
+    // A brand-new agent with no scoped key should fall back to the global key.
+    expect(loadLocalAssistantIdentity("brand-new-agent").avatar).toBe(
+      "data:image/png;base64,Z2xvYmFs",
+    );
+  });
+
+  it("Test 4: scoped clear blocks legacy global fallback (upgrade scenario)", () => {
+    // Simulate legacy state: a global avatar exists from before the scoping fix.
+    saveLocalAssistantIdentity({ avatar: "data:image/png;base64,bGVnYWN5" });
+
+    // Agent "main" should see the legacy global avatar initially.
+    expect(loadLocalAssistantIdentity("main").avatar).toBe("data:image/png;base64,bGVnYWN5");
+
+    // Set a scoped avatar for "main".
+    saveLocalAssistantIdentity({ avatar: "data:image/png;base64,c2NvcGVk" }, "main");
+    expect(loadLocalAssistantIdentity("main").avatar).toBe("data:image/png;base64,c2NvcGVk");
+
+    // Clear the scoped avatar for "main".
+    saveLocalAssistantIdentity({ avatar: null }, "main");
+
+    // main should NOT fall back to global (explicit null blocks it).
+    expect(loadLocalAssistantIdentity("main").avatar).toBeNull();
+
+    // Other agents still see the global fallback.
+    expect(loadLocalAssistantIdentity("other-agent").avatar).toBe("data:image/png;base64,bGVnYWN5");
+  });
+
+  it("Test 5: explicit null stored in scoped key to prevent fallback", () => {
+    saveLocalAssistantIdentity({ avatar: "data:image/png;base64,bWFpbg==" }, "main");
+    saveLocalAssistantIdentity({ avatar: null }, "main");
+
+    // The scoped key should contain an explicit null, not be removed.
+    const raw = localStorage.getItem("openclaw.control.assistant.v1:main");
+    expect(raw).toBe('{"avatar":null}');
+  });
+
+  it("Test 6: localStorage key naming — scoped keys use colon separator", () => {
+    saveLocalAssistantIdentity({ avatar: "data:image/png;base64,bWFpbg==" }, "main");
+    saveLocalAssistantIdentity({ avatar: "data:image/png;base64,d29ya2Vy" }, "worker");
+    saveLocalAssistantIdentity({ avatar: "data:image/png;base64,Z2xvYmFs" }); // global
+
+    const keys: string[] = [];
+    for (let i = 0; i < localStorage.length; i++) {
+      const k = localStorage.key(i);
+      if (k && k.startsWith("openclaw.control.assistant.v1")) keys.push(k);
+    }
+    keys.sort();
+
+    // Global key + per-agent scoped keys
+    expect(keys).toEqual([
+      "openclaw.control.assistant.v1",
+      "openclaw.control.assistant.v1:main",
+      "openclaw.control.assistant.v1:worker",
+    ]);
+  });
+});

--- a/ui/src/ui/storage.ts
+++ b/ui/src/ui/storage.ts
@@ -2,7 +2,12 @@
 const SETTINGS_KEY_PREFIX = "openclaw.control.settings.v1:";
 const LEGACY_SETTINGS_KEY = "openclaw.control.settings.v1";
 const LOCAL_USER_IDENTITY_KEY = "openclaw.control.user.v1";
-const LOCAL_ASSISTANT_IDENTITY_KEY = "openclaw.control.assistant.v1";
+const LOCAL_ASSISTANT_IDENTITY_KEY_PREFIX = "openclaw.control.assistant.v1";
+
+function localAssistantIdentityKey(agentId?: string): string {
+  const id = agentId?.trim();
+  return id ? `${LOCAL_ASSISTANT_IDENTITY_KEY_PREFIX}:${id}` : LOCAL_ASSISTANT_IDENTITY_KEY_PREFIX;
+}
 const LEGACY_TOKEN_SESSION_KEY = "openclaw.control.token.v1";
 const TOKEN_SESSION_KEY_PREFIX = "openclaw.control.token.v1:";
 const MAX_SCOPED_SESSION_ENTRIES = 10;
@@ -410,9 +415,18 @@ export function loadLocalAssistantIdentity(opts?: {
     return { avatar: null };
   }
   const storage = getSafeLocalStorage();
+  const key = localAssistantIdentityKey(agentId);
   try {
-    const raw = storage?.getItem(LOCAL_ASSISTANT_IDENTITY_KEY);
+    const raw = storage?.getItem(key);
     if (!raw) {
+      // Fall back to global key for backward compatibility
+      if (agentId) {
+        const globalRaw = storage?.getItem(localAssistantIdentityKey());
+        if (globalRaw) {
+          const parsed = JSON.parse(globalRaw) as Partial<LocalAssistantIdentity>;
+          return { avatar: typeof parsed.avatar === "string" ? parsed.avatar : null };
+        }
+      }
       return { avatar: null };
     }
     const { avatars, legacyAvatar } = parseLocalAssistantAvatarMap(raw);


### PR DESCRIPTION
## Summary

- **Problem:** The avatar storage used a single global localStorage key `openclaw.control.assistant.v1`, causing setting an avatar for one agent to overwrite it for all agents.
- **Why now:** Users with multiple agents (e.g. `main`, `worker`) cannot set different avatars for each agent. Setting an avatar for one agent silently overwrites the avatar for all other agents via the shared key.
- **Outcome:** Scope the localStorage key per agent ID: `openclaw.control.assistant.v1:{agentId}`. When clearing a scoped avatar, store `null` explicitly to prevent fallback to the global key. Include backward compatibility: existing global avatars are used as fallback when no agent-specific avatar exists.
- **Out of scope:** No changes to avatar upload, display, or server-side storage.
- **Reviewer focus:** Whether the `localAssistantIdentityKey()` function correctly scopes keys, whether the explicit null prevents legacy fallback, and whether the global fallback is preserved for new agents.

## Linked context

Closes #90890

## Real behavior proof

- **Behavior or issue addressed:** Setting avatar for one agent changes it for all agents; clearing a scoped avatar incorrectly falls back to the legacy global avatar -- #90890.
- **Real environment tested:** Windows 10, Node.js v22.22.3, vitest 4.1.7, local checkout on branch `fix/90890-avatar-per-agent`.
- **Exact steps or command run after this patch:** Ran `npx vitest run ui/src/ui/controllers/assistant-identity.test.ts ui/src/ui/controllers/proof-avatar-per-agent.proof.test.ts --config test/vitest/vitest.ui.config.ts --reporter verbose`. The proof test (`proof-avatar-per-agent.proof.test.ts`) imports and exercises the real `loadLocalAssistantIdentity()` and `saveLocalAssistantIdentity()` functions from `ui/src/ui/storage.ts` against an in-memory localStorage mock via `vi.stubGlobal("localStorage", createStorageMock())`. The regression test (`assistant-identity.test.ts`) exercises the real `setAssistantAvatarOverride()` controller function which delegates to those same storage functions.
- **Evidence after fix:**
  ```
  RUN  v4.1.7 D:/JavaUp/openclaw

  ✓ |ui| ui/src/ui/controllers/proof-avatar-per-agent.proof.test.ts > avatar storage per agent ID — real code proof (#90890) > Test 1: per-agent scoping — main and worker have independent avatars 4ms
  ✓ |ui| ui/src/ui/controllers/proof-avatar-per-agent.proof.test.ts > avatar storage per agent ID — real code proof (#90890) > Test 2: clear isolation — clearing main does not affect worker 1ms
  ✓ |ui| ui/src/ui/controllers/proof-avatar-per-agent.proof.test.ts > avatar storage per agent ID — real code proof (#90890) > Test 3: global fallback — new agent without scoped key falls back to global 0ms
  ✓ |ui| ui/src/ui/controllers/proof-avatar-per-agent.proof.test.ts > avatar storage per agent ID — real code proof (#90890) > Test 4: scoped clear blocks legacy global fallback (upgrade scenario) 1ms
  ✓ |ui| ui/src/ui/controllers/proof-avatar-per-agent.proof.test.ts > avatar storage per agent ID — real code proof (#90890) > Test 5: explicit null stored in scoped key to prevent fallback 0ms
  ✓ |ui| ui/src/ui/controllers/proof-avatar-per-agent.proof.test.ts > avatar storage per agent ID — real code proof (#90890) > Test 6: localStorage key naming — scoped keys use colon separator 1ms
  ✓ |ui| ui/src/ui/controllers/assistant-identity.test.ts > loadAssistantIdentity > ignores stale identity responses after the active session changes 6ms
  ✓ |ui| ui/src/ui/controllers/assistant-identity.test.ts > setAssistantAvatarOverride > persists the assistant avatar locally and mirrors the user avatar pattern 1ms
  ✓ |ui| ui/src/ui/controllers/assistant-identity.test.ts > setAssistantAvatarOverride > clears the local override 1ms
  ✓ |ui| ui/src/ui/controllers/assistant-identity.test.ts > setAssistantAvatarOverride > scopes avatar storage per agent ID (regression #90890) 1ms
  ✓ |ui| ui/src/ui/controllers/assistant-identity.test.ts > setAssistantAvatarOverride > falls back to global key when agent-specific key is not set 0ms
  ✓ |ui| ui/src/ui/controllers/assistant-identity.test.ts > setAssistantAvatarOverride > handles legacy global key after scoped clear (upgrade scenario) 1ms

  Test Files  2 passed (2)
       Tests  12 passed (12)
  ```
- **Observed result after fix:** All 12 tests pass across 2 test files. Per-agent scoping works: `main` and `worker` have independent avatars. Clearing one agent does not affect others. New agents without scoped keys fall back to the global key. Scoped clears store explicit `{\"avatar\":null}` to prevent legacy fallback. The `setAssistantAvatarOverride` controller correctly passes `state.assistantAgentId` to storage functions, and `loadAssistantIdentity` reads scoped local overrides.
- **What was not tested:** Live Control UI test with multiple agents in a running gateway (requires gateway setup with multiple agent configurations).

## Tests and validation

- Regression: `ui/src/ui/controllers/assistant-identity.test.ts` -- 6/6 passed
- Proof: `ui/src/ui/controllers/proof-avatar-per-agent.proof.test.ts` -- 6/6 passed
- Total: 12/12 passed

## Risk checklist

- **userVisible:** Yes (avatars now scoped per agent; legacy fallback behavior changed for scoped clears)
- **configEnvMigration:** No (backward compatible with global key)
- **securityAuthNetwork:** No
- **Mitigation:** Backward compatible; existing global avatars used as fallback for new agents. Scoped clears now store explicit null to prevent unexpected legacy fallback.