### PR TITLE
fix(ui): route skill workshop RPCs through current session agent

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -3297,6 +3297,7 @@ export function renderApp(state: AppViewState) {
           : nothing}
         ${state.tab === "skillWorkshop"
           ? renderLazyView(lazySkillWorkshop, (m) => {
+              const workshopAgentId = resolveAgentIdFromSessionKey(state.sessionKey);
               const visibleProposals = m.filterSkillWorkshopProposals(
                 state.skillWorkshopProposals,
                 state.skillWorkshopStatusFilter,
@@ -3313,7 +3314,11 @@ export function renderApp(state: AppViewState) {
                   selectedIndex < 0
                     ? 0
                     : (selectedIndex + delta + visibleProposals.length) % visibleProposals.length;
-                selectSkillWorkshopProposal(state, visibleProposals[nextIndex].key);
+                selectSkillWorkshopProposal(
+                  state,
+                  workshopAgentId,
+                  visibleProposals[nextIndex].key,
+                );
               };
               const selectVisibleFallback = (proposals: typeof visibleProposals) => {
                 if (
@@ -3323,7 +3328,7 @@ export function renderApp(state: AppViewState) {
                   return;
                 }
                 state.skillWorkshopFilePreviewKey = null;
-                selectSkillWorkshopProposal(state, proposals[0].key);
+                selectSkillWorkshopProposal(state, workshopAgentId, proposals[0].key);
               };
               return m.renderSkillWorkshop({
                 loading: state.skillWorkshopLoading,
@@ -3368,24 +3373,30 @@ export function renderApp(state: AppViewState) {
                 onModeChange: (mode) => setSkillWorkshopMode(state, mode),
                 onSelect: (key) => {
                   state.skillWorkshopFilePreviewKey = null;
-                  selectSkillWorkshopProposal(state, key);
+                  selectSkillWorkshopProposal(state, workshopAgentId, key);
                 },
                 onPrev: () => selectRelativeProposal(-1),
                 onNext: () => selectRelativeProposal(1),
-                onApply: (key) => void runSkillWorkshopLifecycleAction(state, "apply", key),
+                onApply: (key) =>
+                  void runSkillWorkshopLifecycleAction(state, workshopAgentId, "apply", key),
                 onRevise: (key) => {
                   state.skillWorkshopRevisionKey = key;
                   state.skillWorkshopRevisionDraft = "";
                 },
-                onReject: (key) => void runSkillWorkshopLifecycleAction(state, "reject", key),
+                onReject: (key) =>
+                  void runSkillWorkshopLifecycleAction(state, workshopAgentId, "reject", key),
                 onRevisionDraftChange: (draft) => (state.skillWorkshopRevisionDraft = draft),
                 onRevisionCancel: () => {
                   state.skillWorkshopRevisionKey = null;
                   state.skillWorkshopRevisionDraft = "";
                 },
                 onRevisionSubmit: (key) =>
-                  void requestSkillWorkshopRevision(state, key, (message, proposal) =>
-                    sendSkillWorkshopRevisionRequest(state, message, proposal),
+                  void requestSkillWorkshopRevision(
+                    state,
+                    workshopAgentId,
+                    key,
+                    (message, proposal) =>
+                      sendSkillWorkshopRevisionRequest(state, message, proposal),
                   ),
                 onPreviewFile: (key, path) => {
                   state.skillWorkshopSelectedKey = key;

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -3297,7 +3297,10 @@ export function renderApp(state: AppViewState) {
           : nothing}
         ${state.tab === "skillWorkshop"
           ? renderLazyView(lazySkillWorkshop, (m) => {
-              const workshopAgentId = resolveAgentIdFromSessionKey(state.sessionKey);
+              const parsedWorkshopAgent = parseAgentSessionKey(state.sessionKey);
+              const workshopAgentId = parsedWorkshopAgent
+                ? normalizeAgentId(parsedWorkshopAgent.agentId)
+                : undefined;
               const visibleProposals = m.filterSkillWorkshopProposals(
                 state.skillWorkshopProposals,
                 state.skillWorkshopStatusFilter,

--- a/ui/src/ui/app-settings.refresh-active-tab.node.test.ts
+++ b/ui/src/ui/app-settings.refresh-active-tab.node.test.ts
@@ -53,6 +53,7 @@ const mocks = vi.hoisted(() => ({
   loadPresenceMock: vi.fn(async () => {}),
   loadSessionsMock: vi.fn(async () => {}),
   loadSkillsMock: vi.fn(async () => {}),
+  loadSkillWorkshopProposalsMock: vi.fn(async () => {}),
   loadUsageMock: vi.fn(async () => {}),
   loadWorkboardMock: vi.fn(async () => {}),
   startDebugPollingMock: vi.fn(),
@@ -136,6 +137,9 @@ vi.mock("./controllers/sessions.ts", () => ({
 }));
 vi.mock("./controllers/skills.ts", () => ({
   loadSkills: mocks.loadSkillsMock,
+}));
+vi.mock("./controllers/skill-workshop.ts", () => ({
+  loadSkillWorkshopProposals: mocks.loadSkillWorkshopProposalsMock,
 }));
 vi.mock("./controllers/usage.ts", () => ({
   loadUsage: mocks.loadUsageMock,
@@ -627,5 +631,41 @@ describe("refreshActiveTab", () => {
           (entry as { event?: unknown }).event === "control-ui.cron.runs",
       ),
     ).toBe(false);
+  });
+
+  it("passes the scoped agent id when refreshing the skill workshop tab from an agent session", async () => {
+    const host = createHost();
+    host.tab = "skillWorkshop";
+    host.sessionKey = "agent:research:main";
+
+    await refreshActiveTab(host as never);
+
+    expect(mocks.loadSkillWorkshopProposalsMock).toHaveBeenCalledWith(host, "research", {
+      force: true,
+    });
+  });
+
+  it("leaves agent id undefined for the skill workshop tab on default sessions", async () => {
+    const host = createHost();
+    host.tab = "skillWorkshop";
+    host.sessionKey = "main";
+
+    await refreshActiveTab(host as never);
+
+    expect(mocks.loadSkillWorkshopProposalsMock).toHaveBeenCalledWith(host, undefined, {
+      force: true,
+    });
+  });
+
+  it("leaves agent id undefined for the skill workshop tab on global sessions", async () => {
+    const host = createHost();
+    host.tab = "skillWorkshop";
+    host.sessionKey = "global";
+
+    await refreshActiveTab(host as never);
+
+    expect(mocks.loadSkillWorkshopProposalsMock).toHaveBeenCalledWith(host, undefined, {
+      force: true,
+    });
   });
 });

--- a/ui/src/ui/app-settings.ts
+++ b/ui/src/ui/app-settings.ts
@@ -71,11 +71,7 @@ import {
   tabFromPath,
   type Tab,
 } from "./navigation.ts";
-import {
-  normalizeAgentId,
-  parseAgentSessionKey,
-  resolveAgentIdFromSessionKey,
-} from "./session-key.ts";
+import { normalizeAgentId, parseAgentSessionKey } from "./session-key.ts";
 import {
   normalizeTextScale,
   saveLocalUserIdentity,

--- a/ui/src/ui/app-settings.ts
+++ b/ui/src/ui/app-settings.ts
@@ -476,7 +476,8 @@ export async function refreshActiveTab(host: SettingsHost, opts?: { chatStartup?
         await loadSkills(app);
         break;
       case "skillWorkshop": {
-        const workshopAgentId = resolveAgentIdFromSessionKey(host.sessionKey);
+        const parsed = parseAgentSessionKey(host.sessionKey);
+        const workshopAgentId = parsed ? normalizeAgentId(parsed.agentId) : undefined;
         await loadSkillWorkshopProposals(app, workshopAgentId, { force: true });
         break;
       }

--- a/ui/src/ui/app-settings.ts
+++ b/ui/src/ui/app-settings.ts
@@ -71,7 +71,11 @@ import {
   tabFromPath,
   type Tab,
 } from "./navigation.ts";
-import { normalizeAgentId, parseAgentSessionKey } from "./session-key.ts";
+import {
+  normalizeAgentId,
+  parseAgentSessionKey,
+  resolveAgentIdFromSessionKey,
+} from "./session-key.ts";
 import {
   normalizeTextScale,
   saveLocalUserIdentity,
@@ -471,9 +475,11 @@ export async function refreshActiveTab(host: SettingsHost, opts?: { chatStartup?
       case "skills":
         await loadSkills(app);
         break;
-      case "skillWorkshop":
-        await loadSkillWorkshopProposals(app, { force: true });
+      case "skillWorkshop": {
+        const workshopAgentId = resolveAgentIdFromSessionKey(host.sessionKey);
+        await loadSkillWorkshopProposals(app, workshopAgentId, { force: true });
         break;
+      }
       case "agents":
         await refreshAgentsTab(host, app);
         break;

--- a/ui/src/ui/controllers/skill-workshop.test.ts
+++ b/ui/src/ui/controllers/skill-workshop.test.ts
@@ -1,0 +1,158 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  loadSkillWorkshopProposals,
+  loadSkillWorkshopProposalDetail,
+  runSkillWorkshopLifecycleAction,
+  type SkillWorkshopState,
+} from "./skill-workshop.ts";
+
+function createClient() {
+  return {
+    request: vi.fn(),
+  };
+}
+
+function createState(overrides?: Partial<SkillWorkshopState>): SkillWorkshopState {
+  const client = createClient();
+  return {
+    client: client as unknown as SkillWorkshopState["client"],
+    connected: true,
+    skillWorkshopLoading: false,
+    skillWorkshopLoaded: false,
+    skillWorkshopError: null,
+    skillWorkshopInspectingKey: null,
+    skillWorkshopProposals: [],
+    skillWorkshopSelectedKey: null,
+    skillWorkshopActionBusy: null,
+    skillWorkshopActionNotice: null,
+    skillWorkshopRevisionKey: null,
+    skillWorkshopRevisionDraft: "",
+    skillWorkshopStatusFilter: "all",
+    skillWorkshopQuery: "",
+    skillWorkshopFilePreviewKey: null,
+    skillWorkshopFilePreviewQuery: "",
+    skillWorkshopQueueWidth: 320,
+    skillWorkshopMode: "proposals",
+    skillWorkshopUseCurrentChatForRevisions: false,
+    ...overrides,
+  } as SkillWorkshopState;
+}
+
+describe("loadSkillWorkshopProposals", () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("omits agentId from RPC params when agentId is undefined", async () => {
+    const state = createState();
+    state.client!.request.mockResolvedValueOnce({
+      schema: "openclaw.skill-workshop.proposals-manifest.v1",
+      updatedAt: new Date().toISOString(),
+      proposals: [],
+    });
+
+    await loadSkillWorkshopProposals(state, undefined);
+
+    expect(state.client!.request).toHaveBeenCalledOnce();
+    expect(state.client!.request).toHaveBeenCalledWith("skills.proposals.list", {});
+  });
+
+  it("includes agentId in RPC params when agentId is provided", async () => {
+    const state = createState();
+    state.client!.request.mockResolvedValueOnce({
+      schema: "openclaw.skill-workshop.proposals-manifest.v1",
+      updatedAt: new Date().toISOString(),
+      proposals: [],
+    });
+
+    await loadSkillWorkshopProposals(state, "research");
+
+    expect(state.client!.request).toHaveBeenCalledOnce();
+    expect(state.client!.request).toHaveBeenCalledWith("skills.proposals.list", {
+      agentId: "research",
+    });
+  });
+});
+
+describe("loadSkillWorkshopProposalDetail", () => {
+  it("omits agentId from inspect RPC params when agentId is undefined", async () => {
+    const state = createState();
+    state.client!.request.mockResolvedValueOnce({
+      record: {
+        id: "proposal-1",
+        kind: "create",
+        status: "pending",
+        title: "Test",
+        description: "",
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        proposedVersion: "v1",
+        target: { skillName: "test", skillKey: "test" },
+      },
+      content: "",
+    });
+
+    await loadSkillWorkshopProposalDetail(state, undefined, "proposal-1");
+
+    expect(state.client!.request).toHaveBeenCalledOnce();
+    expect(state.client!.request).toHaveBeenCalledWith("skills.proposals.inspect", {
+      proposalId: "proposal-1",
+    });
+  });
+
+  it("includes agentId in inspect RPC params when agentId is provided", async () => {
+    const state = createState();
+    state.client!.request.mockResolvedValueOnce({
+      record: {
+        id: "proposal-1",
+        kind: "create",
+        status: "pending",
+        title: "Test",
+        description: "",
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        proposedVersion: "v1",
+        target: { skillName: "test", skillKey: "test" },
+      },
+      content: "",
+    });
+
+    await loadSkillWorkshopProposalDetail(state, "research", "proposal-1");
+
+    expect(state.client!.request).toHaveBeenCalledOnce();
+    expect(state.client!.request).toHaveBeenCalledWith("skills.proposals.inspect", {
+      proposalId: "proposal-1",
+      agentId: "research",
+    });
+  });
+});
+
+describe("runSkillWorkshopLifecycleAction", () => {
+  it("omits agentId from apply RPC params when agentId is undefined", async () => {
+    const state = createState();
+    state.client!.request.mockResolvedValueOnce(undefined);
+
+    await runSkillWorkshopLifecycleAction(state, undefined, "apply", "proposal-1");
+
+    const applyCall = state.client!.request.mock.calls.find(
+      ([method]) => method === "skills.proposals.apply",
+    );
+    expect(applyCall).toEqual(["skills.proposals.apply", { proposalId: "proposal-1" }]);
+  });
+
+  it("includes agentId in reject RPC params when agentId is provided", async () => {
+    const state = createState();
+    state.client!.request.mockResolvedValueOnce(undefined);
+
+    await runSkillWorkshopLifecycleAction(state, "research", "reject", "proposal-1");
+
+    const rejectCall = state.client!.request.mock.calls.find(
+      ([method]) => method === "skills.proposals.reject",
+    );
+    expect(rejectCall).toEqual([
+      "skills.proposals.reject",
+      { proposalId: "proposal-1", agentId: "research" },
+    ]);
+  });
+});

--- a/ui/src/ui/controllers/skill-workshop.ts
+++ b/ui/src/ui/controllers/skill-workshop.ts
@@ -286,7 +286,7 @@ export function countSkillWorkshopProposals(
 
 export async function loadSkillWorkshopProposals(
   state: SkillWorkshopState,
-  agentId: string,
+  agentId: string | undefined,
   options?: { force?: boolean },
 ): Promise<void> {
   if (!state.client || !state.connected || state.skillWorkshopLoading) {
@@ -298,9 +298,14 @@ export async function loadSkillWorkshopProposals(
   state.skillWorkshopLoading = true;
   state.skillWorkshopError = null;
   try {
-    const result = await state.client.request<SkillProposalManifest>("skills.proposals.list", {
-      agentId,
-    });
+    const params: { agentId?: string } = {};
+    if (agentId) {
+      params.agentId = agentId;
+    }
+    const result = await state.client.request<SkillProposalManifest>(
+      "skills.proposals.list",
+      params,
+    );
     const previousByKey = new Map(
       state.skillWorkshopProposals.map((proposal) => [proposal.key, proposal]),
     );
@@ -324,7 +329,7 @@ export async function loadSkillWorkshopProposals(
 
 export async function loadSkillWorkshopProposalDetail(
   state: SkillWorkshopState,
-  agentId: string,
+  agentId: string | undefined,
   proposalId: string,
   options?: { force?: boolean },
 ): Promise<void> {
@@ -338,12 +343,13 @@ export async function loadSkillWorkshopProposalDetail(
   state.skillWorkshopInspectingKey = proposalId;
   state.skillWorkshopError = null;
   try {
+    const params: { proposalId: string; agentId?: string } = { proposalId };
+    if (agentId) {
+      params.agentId = agentId;
+    }
     const result = await state.client.request<SkillProposalInspectResult>(
       "skills.proposals.inspect",
-      {
-        proposalId,
-        agentId,
-      },
+      params,
     );
     mergeProposal(state, proposalFromInspect(result, existing));
   } catch (err) {
@@ -357,7 +363,7 @@ export async function loadSkillWorkshopProposalDetail(
 
 export function selectSkillWorkshopProposal(
   state: SkillWorkshopState,
-  agentId: string,
+  agentId: string | undefined,
   proposalId: string,
 ): void {
   state.skillWorkshopSelectedKey = proposalId;
@@ -366,7 +372,7 @@ export function selectSkillWorkshopProposal(
 
 async function refreshAfterMutation(
   state: SkillWorkshopState,
-  agentId: string,
+  agentId: string | undefined,
   proposalId: string,
 ): Promise<void> {
   state.skillWorkshopLoaded = false;
@@ -376,7 +382,7 @@ async function refreshAfterMutation(
 
 export async function runSkillWorkshopLifecycleAction(
   state: SkillWorkshopState,
-  agentId: string,
+  agentId: string | undefined,
   action: Extract<SkillWorkshopAction, "apply" | "reject">,
   proposalId: string,
 ): Promise<void> {
@@ -389,7 +395,11 @@ export async function runSkillWorkshopLifecycleAction(
   state.skillWorkshopError = null;
   try {
     const method = action === "apply" ? "skills.proposals.apply" : "skills.proposals.reject";
-    await state.client.request(method, { proposalId, agentId });
+    const params: { proposalId: string; agentId?: string } = { proposalId };
+    if (agentId) {
+      params.agentId = agentId;
+    }
+    await state.client.request(method, params);
     await refreshAfterMutation(state, agentId, proposalId);
     const updated = state.skillWorkshopProposals.find((proposal) => proposal.key === proposalId);
     showActionNotice(state, updated ?? previous, action === "apply" ? "Applied" : "Rejected");
@@ -407,7 +417,7 @@ export async function runSkillWorkshopLifecycleAction(
 
 export async function requestSkillWorkshopRevision(
   state: SkillWorkshopState,
-  agentId: string,
+  agentId: string | undefined,
   proposalId: string,
   sendRevisionRequest: (instructions: string, proposal: SkillWorkshopProposal) => Promise<void>,
 ): Promise<boolean> {

--- a/ui/src/ui/controllers/skill-workshop.ts
+++ b/ui/src/ui/controllers/skill-workshop.ts
@@ -286,6 +286,7 @@ export function countSkillWorkshopProposals(
 
 export async function loadSkillWorkshopProposals(
   state: SkillWorkshopState,
+  agentId: string,
   options?: { force?: boolean },
 ): Promise<void> {
   if (!state.client || !state.connected || state.skillWorkshopLoading) {
@@ -297,7 +298,9 @@ export async function loadSkillWorkshopProposals(
   state.skillWorkshopLoading = true;
   state.skillWorkshopError = null;
   try {
-    const result = await state.client.request<SkillProposalManifest>("skills.proposals.list", {});
+    const result = await state.client.request<SkillProposalManifest>("skills.proposals.list", {
+      agentId,
+    });
     const previousByKey = new Map(
       state.skillWorkshopProposals.map((proposal) => [proposal.key, proposal]),
     );
@@ -310,7 +313,7 @@ export async function loadSkillWorkshopProposals(
       state.skillWorkshopSelectedKey = proposals[0]?.key ?? null;
     }
     if (state.skillWorkshopSelectedKey) {
-      await loadSkillWorkshopProposalDetail(state, state.skillWorkshopSelectedKey);
+      await loadSkillWorkshopProposalDetail(state, agentId, state.skillWorkshopSelectedKey);
     }
   } catch (err) {
     state.skillWorkshopError = getErrorMessage(err);
@@ -321,6 +324,7 @@ export async function loadSkillWorkshopProposals(
 
 export async function loadSkillWorkshopProposalDetail(
   state: SkillWorkshopState,
+  agentId: string,
   proposalId: string,
   options?: { force?: boolean },
 ): Promise<void> {
@@ -338,6 +342,7 @@ export async function loadSkillWorkshopProposalDetail(
       "skills.proposals.inspect",
       {
         proposalId,
+        agentId,
       },
     );
     mergeProposal(state, proposalFromInspect(result, existing));
@@ -350,19 +355,28 @@ export async function loadSkillWorkshopProposalDetail(
   }
 }
 
-export function selectSkillWorkshopProposal(state: SkillWorkshopState, proposalId: string): void {
+export function selectSkillWorkshopProposal(
+  state: SkillWorkshopState,
+  agentId: string,
+  proposalId: string,
+): void {
   state.skillWorkshopSelectedKey = proposalId;
-  void loadSkillWorkshopProposalDetail(state, proposalId);
+  void loadSkillWorkshopProposalDetail(state, agentId, proposalId);
 }
 
-async function refreshAfterMutation(state: SkillWorkshopState, proposalId: string): Promise<void> {
+async function refreshAfterMutation(
+  state: SkillWorkshopState,
+  agentId: string,
+  proposalId: string,
+): Promise<void> {
   state.skillWorkshopLoaded = false;
-  await loadSkillWorkshopProposals(state, { force: true });
-  await loadSkillWorkshopProposalDetail(state, proposalId, { force: true });
+  await loadSkillWorkshopProposals(state, agentId, { force: true });
+  await loadSkillWorkshopProposalDetail(state, agentId, proposalId, { force: true });
 }
 
 export async function runSkillWorkshopLifecycleAction(
   state: SkillWorkshopState,
+  agentId: string,
   action: Extract<SkillWorkshopAction, "apply" | "reject">,
   proposalId: string,
 ): Promise<void> {
@@ -375,8 +389,8 @@ export async function runSkillWorkshopLifecycleAction(
   state.skillWorkshopError = null;
   try {
     const method = action === "apply" ? "skills.proposals.apply" : "skills.proposals.reject";
-    await state.client.request(method, { proposalId });
-    await refreshAfterMutation(state, proposalId);
+    await state.client.request(method, { proposalId, agentId });
+    await refreshAfterMutation(state, agentId, proposalId);
     const updated = state.skillWorkshopProposals.find((proposal) => proposal.key === proposalId);
     showActionNotice(state, updated ?? previous, action === "apply" ? "Applied" : "Rejected");
   } catch (err) {
@@ -393,6 +407,7 @@ export async function runSkillWorkshopLifecycleAction(
 
 export async function requestSkillWorkshopRevision(
   state: SkillWorkshopState,
+  agentId: string,
   proposalId: string,
   sendRevisionRequest: (instructions: string, proposal: SkillWorkshopProposal) => Promise<void>,
 ): Promise<boolean> {
@@ -408,7 +423,7 @@ export async function requestSkillWorkshopRevision(
   state.skillWorkshopActionNotice = null;
   state.skillWorkshopError = null;
   try {
-    await loadSkillWorkshopProposalDetail(state, proposalId);
+    await loadSkillWorkshopProposalDetail(state, agentId, proposalId);
     const currentProposal =
       state.skillWorkshopProposals.find((item) => item.key === proposalId) ?? proposal;
     await sendRevisionRequest(instructions, currentProposal);


### PR DESCRIPTION
## Summary
- Pass the current session's `agentId` to all Skill Workshop Gateway RPCs (`skills.proposals.list`, `skills.proposals.inspect`, `skills.proposals.apply`, `skills.proposals.reject`) when the session key is explicitly agent-scoped.
- For default sessions (`main`, `global`, or otherwise unparsed keys), leave `agentId` undefined so the Gateway preserves its existing configured-default-agent fallback. This avoids regressing users whose configured default agent is not `main`.
- Resolve `agentId` from `sessionKey` using `parseAgentSessionKey` + `normalizeAgentId` in both the refresh path (`app-settings.ts`) and the render callbacks (`app-render.ts`).
- This aligns Control UI behavior with the CLI (`skills workshop --agent <id> list`), which already supports per-agent workshop queries.

## Test plan
- [x] `pnpm tsgo:test:ui` type-checks cleanly
- [x] `pnpm build` completes successfully
- [x] `node scripts/run-vitest.mjs ui/src/ui/controllers/skill-workshop.test.ts ui/src/ui/app-settings.refresh-active-tab.node.test.ts` passes (new focused coverage)
- [x] `pnpm format` produces no changes

## Verification
Behavior addressed: Control UI Skill Workshop shows empty when the active session belongs to a non-default agent, even though `skills workshop --agent <id> list` CLI shows proposals. Also addresses the compatibility concern that default/global sessions could be forced to hard-coded `main` instead of the configured default agent.
Real environment tested: Linux, Node v22.22.0
Exact steps or command run after this patch:
1. `pnpm format` — no changes
2. `pnpm tsgo:test:ui` — passes with no type errors
3. `pnpm build` — builds UI and runtime successfully
4. `node scripts/run-vitest.mjs ui/src/ui/controllers/skill-workshop.test.ts ui/src/ui/app-settings.refresh-active-tab.node.test.ts` — 37/37 tests pass
Evidence after fix:
- Workshop controller functions now accept `agentId: string | undefined` and only include it in RPC params when provided.
- `refreshActiveTab` tests verify that agent-scoped sessions (`agent:research:main`) pass `"research"`, while default (`main`) and global sessions pass `undefined`.
- Controller tests verify `skills.proposals.list`, `skills.proposals.inspect`, `skills.proposals.apply`, and `skills.proposals.reject` omit `agentId` when undefined and include it when provided.
Observed result after fix: Default-agent sessions continue to use Gateway's configured-default fallback; non-default agent sessions now see their own workshop proposals in the Control UI.
What was not tested: Live Gateway + Control UI integration test (would require starting a real Gateway and creating a skill proposal via a non-default agent).

Fixes #90756