### PR TITLE
fix(config): use Start-Process -FilePath for Windows config opener

### DIFF
--- a/src/gateway/server-methods/config.test.ts
+++ b/src/gateway/server-methods/config.test.ts
@@ -74,14 +74,14 @@ describe("resolveConfigOpenCommand", () => {
     });
   });
 
-  it("uses a quoted PowerShell literal on Windows", () => {
+  it("uses a quoted PowerShell FilePath on Windows", () => {
     expect(resolveConfigOpenCommand(String.raw`C:\tmp\o'hai & calc.json`, "win32")).toEqual({
       command: "powershell.exe",
       args: [
         "-NoProfile",
         "-NonInteractive",
         "-Command",
-        String.raw`Start-Process -LiteralPath 'C:\tmp\o''hai & calc.json'`,
+        String.raw`Start-Process -FilePath 'C:\tmp\o''hai & calc.json'`,
       ],
     });
   });

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -183,7 +183,7 @@ export function resolveConfigOpenCommand(
         "-NoProfile",
         "-NonInteractive",
         "-Command",
-        `Start-Process -LiteralPath '${escapePowerShellSingleQuotedString(configPath)}'`,
+        `Start-Process -FilePath '${escapePowerShellSingleQuotedString(configPath)}'`,
       ],
     };
   }


### PR DESCRIPTION
## Summary

Fixes the Dashboard **Open config** action on Windows.

The gateway builds the Windows opener command with `Start-Process -LiteralPath '<path>'`. `Start-Process` has no `-LiteralPath` parameter (it exposes `-FilePath`), so on both Windows PowerShell 5.1 and pwsh 7+ the command fails with a parameter-binding error and the config file never opens.

This changes only the Windows branch of `resolveConfigOpenCommand` to `Start-Process -FilePath '<path>'`, preserving the existing single-quoted PowerShell escaping (`escapePowerShellSingleQuotedString`) so the path stays data, not executable shell text. macOS (`open`) and Linux (`xdg-open`) branches are untouched.

Fixes #90157

## Why this shape

- **Smallest correct fix:** 1 prod line + 1 test line; only the Windows token changes.
- **Matches shipped in-repo precedent:** core already ships this exact idiom on Windows at `src/cli/update-cli/restart-helper.ts:319` (`Start-Process -FilePath $launcherPath ...`). This patch conforms a broken call site to an idiom the project already relies on in production, rather than introducing a new one.
- **Escaping unchanged:** the path remains inside a single-quoted PowerShell literal, so `&`, `$(...)`, and spaces stay inert. The existing `String.raw` regression case (`C:\tmp\o'hai & calc.json`) still exercises quote-doubling + metacharacters.

## Relationship to existing PRs

- **#90176** is the byte-identical fix; it was self-closed by its author only to stay under the active-PR cap ("remains available on the fork if maintainers want to pick it back up"), not rejected on the merits. This PR is the landable, owned version of that same change.
- **#90339** carries the identical correct gateway fix but bundles it with ~23 unrelated lines added to `extensions/anthropic/openclaw.plugin.json`. That mixes a one-line Windows fix with a compat-sensitive plugin catalog surface; the catalog edits should be split into their own PR. This PR intentionally contains only the #90157 fix.

## Verification

```
node scripts/run-vitest.mjs src/gateway/server-methods/config.test.ts
node scripts/run-vitest.mjs ui/src/ui/controllers/config.test.ts
git diff --check
```

Both test files pass (gateway: 18 tests; UI controller suite green). Local Codex autoreview: clean, no accepted/actionable findings.

## Real behavior proof

**Behavior addressed:** Dashboard "Open config" on Windows calls gateway `config.openFile`, which built `Start-Process -LiteralPath '<openclaw.json>'`. `Start-Process` supports `-FilePath` for files/documents, not `-LiteralPath`, so Windows users saw the request fail instead of opening `openclaw.json`. After this patch the command is `Start-Process -FilePath '<escaped path>'`.

**Real environment tested:** Local OpenClaw checkout on macOS (`darwin`), commit `5b76436c45`. Proof exercised the actual `resolveConfigOpenCommand()` gateway builder, the `config.openFile` gateway test, and the UI controller test that issues `config.openFile`. Windows command behavior cross-checked against Microsoft Learn `Start-Process` docs (PowerShell 7.x and 5.1), which list `[-FilePath] <string>` and no `-LiteralPath` parameter, and against shipped in-repo Windows usage at `src/cli/update-cli/restart-helper.ts:319`.

**Exact steps or command run after this patch:**
```
node scripts/run-vitest.mjs src/gateway/server-methods/config.test.ts
node scripts/run-vitest.mjs ui/src/ui/controllers/config.test.ts
git diff --check
```

**Evidence after fix:**
```
resolveConfigOpenCommand(String.raw`C:\tmp\o'hai & calc.json`, "win32") =>
{
  command: "powershell.exe",
  args: [
    "-NoProfile",
    "-NonInteractive",
    "-Command",
    "Start-Process -FilePath 'C:\\tmp\\o''hai & calc.json'"
  ]
}

Gateway config tests:  18 passed (18)
UI controller tests:   green
```

**Observed result after fix:** The Windows opener emits `powershell.exe -NoProfile -NonInteractive -Command "Start-Process -FilePath '<escaped config path>'"`, preserving quote escaping while using the supported `Start-Process` parameter.

**What was not tested:** I did not run a live Windows Dashboard "Open config" click-through. This is a macOS-only environment with no Windows machine, no Parallels, and no access to a Crabbox/Testbox Windows broker, so live PowerShell execution on Windows is not available to me. The unproven residual is solely the runtime launch on Windows; the emitted command contract is verified by unit tests, Microsoft `Start-Process` documentation, and shipped in-repo Windows usage of `Start-Process -FilePath`. **Requesting a maintainer with a Windows host (or Testbox) to confirm** with the throwaway-file check below before landing:

```powershell
$f = Join-Path $env:TEMP 'openclaw-proof.json'; 'x' | Out-File $f
try { Start-Process -LiteralPath $f; 'OLD-OK' } catch { 'OLD-ERR: ' + $_.Exception.Message }  # expect parameter-binding error (reproduces #90157)
try { Start-Process -FilePath  $f; 'NEW-OK' } catch { 'NEW-ERR: ' + $_.Exception.Message }     # expect the parameter to bind (fix)
```
