### PR TITLE
perf(control-ui): avoid startup catalog wait

### DIFF
--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -163,7 +163,10 @@ import {
   buildWebchatAssistantMessageFromReplyPayloads,
   buildWebchatAudioContentBlocksFromReplyPayloads,
 } from "./chat-webchat-media.js";
-import { loadOptionalServerMethodModelCatalog } from "./optional-model-catalog.js";
+import {
+  loadOptionalServerMethodModelCatalog,
+  startOptionalServerMethodModelCatalogLoad,
+} from "./optional-model-catalog.js";
 import { hasTrackedActiveSessionRun } from "./session-active-runs.js";
 import { emitSessionsChanged } from "./session-change-event.js";
 import type {
@@ -514,6 +517,7 @@ export { sanitizeChatSendMessageInput } from "../chat-input-sanitize.js";
 
 export const CHAT_HISTORY_MAX_SINGLE_MESSAGE_BYTES = 128 * 1024;
 const CHAT_HISTORY_OVERSIZED_PLACEHOLDER = "[chat.history omitted: message too large]";
+const CHAT_STARTUP_OPTIONAL_MODEL_CATALOG_TIMEOUT_MS = 25;
 const MANAGED_OUTGOING_IMAGE_PATH_PREFIX = "/api/chat/media/outgoing/";
 let chatHistoryPlaceholderEmitCount = 0;
 const chatHistoryManagedImageCleanupState = new Map<string, Promise<void>>();
@@ -2475,14 +2479,26 @@ async function handleChatHistoryRequest({
     respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, selectedAgent.error));
     return;
   }
+  const startupModelCatalogLoad =
+    method === "chat.startup" ? startOptionalServerMethodModelCatalogLoad(context) : undefined;
   const modelCatalogPromise = measureDiagnosticsTimelineSpan(
     `gateway.${method}.model_catalog`,
-    () => loadOptionalServerMethodModelCatalog(context, method),
+    () =>
+      startupModelCatalogLoad
+        ? loadOptionalServerMethodModelCatalog(context, method, {
+            logOnceKey: "chat.startup",
+            startedLoad: startupModelCatalogLoad,
+            timeoutMs: CHAT_STARTUP_OPTIONAL_MODEL_CATALOG_TIMEOUT_MS,
+          })
+        : loadOptionalServerMethodModelCatalog(context, method),
     {
       config: cfg,
       phase: method,
     },
   );
+  if (startupModelCatalogLoad) {
+    void modelCatalogPromise.catch(() => undefined);
+  }
   const sessionId = entry?.sessionId;
   const sessionAgentId = resolveSessionAgentId({
     sessionKey,

--- a/src/gateway/server-methods/optional-model-catalog.ts
+++ b/src/gateway/server-methods/optional-model-catalog.ts
@@ -7,38 +7,72 @@ import type { GatewayRequestContext } from "./types.js";
  * Optional model-catalog loader for methods where metadata improves the result
  * but should never block the primary session response path.
  */
-const OPTIONAL_MODEL_CATALOG_TIMEOUT_MS = 750;
+const DEFAULT_OPTIONAL_MODEL_CATALOG_TIMEOUT_MS = 750;
 
 const loggedSlowCatalogKeys = new Set<string>();
+
+export type OptionalServerMethodModelCatalogLoad = {
+  promise: Promise<ModelCatalogEntry[] | undefined>;
+};
+
+type LoadOptionalServerMethodModelCatalogOptions = {
+  logOnceKey?: string;
+  startedLoad?: OptionalServerMethodModelCatalogLoad;
+  timeoutMs?: number;
+};
+
+function normalizeOptionalModelCatalog(value: unknown): ModelCatalogEntry[] | undefined {
+  return Array.isArray(value) ? value : undefined;
+}
+
+export function startOptionalServerMethodModelCatalogLoad(
+  context: GatewayRequestContext,
+): OptionalServerMethodModelCatalogLoad {
+  let catalogPromise: Promise<unknown>;
+  try {
+    catalogPromise = context.loadGatewayModelCatalog();
+  } catch {
+    catalogPromise = Promise.resolve(undefined);
+  }
+  const promise = catalogPromise.then(
+    (value) => {
+      const catalog = normalizeOptionalModelCatalog(value);
+      return catalog;
+    },
+    () => {
+      return undefined;
+    },
+  );
+  return {
+    promise,
+  };
+}
 
 /** Loads the gateway model catalog with a short timeout and one-time slow logs. */
 export async function loadOptionalServerMethodModelCatalog(
   context: GatewayRequestContext,
   surface: string,
-  options?: { logOnceKey?: string },
+  options?: LoadOptionalServerMethodModelCatalogOptions,
 ): Promise<ModelCatalogEntry[] | undefined> {
   let timeout: NodeJS.Timeout | undefined;
   const timedOut = Symbol("server-method-model-catalog-timeout");
+  const timeoutMs = options?.timeoutMs ?? DEFAULT_OPTIONAL_MODEL_CATALOG_TIMEOUT_MS;
+  const catalogLoad = options?.startedLoad ?? startOptionalServerMethodModelCatalogLoad(context);
   const timeoutPromise = new Promise<typeof timedOut>((resolve) => {
-    timeout = setTimeout(() => resolve(timedOut), OPTIONAL_MODEL_CATALOG_TIMEOUT_MS);
+    timeout = setTimeout(() => resolve(timedOut), timeoutMs);
     timeout.unref?.();
   });
   try {
-    const result = await Promise.race([
-      context.loadGatewayModelCatalog().catch(() => undefined),
-      timeoutPromise,
-    ]);
+    const result = await Promise.race([catalogLoad.promise, timeoutPromise]);
     if (result === timedOut) {
       const logOnceKey = options?.logOnceKey ?? "session-metadata";
       if (!loggedSlowCatalogKeys.has(logOnceKey)) {
         loggedSlowCatalogKeys.add(logOnceKey);
-        context.logGateway.debug(
-          `${surface} continuing without model catalog after ${OPTIONAL_MODEL_CATALOG_TIMEOUT_MS}ms`,
-        );
+        context.logGateway.debug(`${surface} continuing without model catalog after ${timeoutMs}ms`);
       }
       return undefined;
     }
-    return Array.isArray(result) ? result : undefined;
+    return normalizeOptionalModelCatalog(result);
   } finally {
     if (timeout) {
       clearTimeout(timeout);

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -464,6 +464,74 @@ describe("gateway server chat", () => {
     });
   });
 
+  test("chat.startup does not wait for slow optional model catalog metadata", async () => {
+    const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
+    try {
+      testState.sessionStorePath = path.join(sessionDir, "sessions.json");
+      await writeSessionStore({
+        entries: {
+          main: {
+            sessionId: "sess-main",
+            modelProvider: "test-provider",
+            model: "slow-catalog-model",
+            updatedAt: Date.now(),
+          },
+        },
+      });
+      const catalog =
+        createDeferred<Awaited<ReturnType<GatewayRequestContext["loadGatewayModelCatalog"]>>>();
+      const responses: Array<{ ok: boolean; payload?: unknown; error?: unknown }> = [];
+      const context = {
+        loadGatewayModelCatalog: vi
+          .fn<GatewayRequestContext["loadGatewayModelCatalog"]>()
+          .mockReturnValue(catalog.promise),
+        logGateway: {
+          info: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+          debug: vi.fn(),
+        },
+        chatAbortControllers: new Map(),
+        chatRunBuffers: new Map(),
+        getRuntimeConfig: () => ({}),
+      } as unknown as GatewayRequestContext;
+      const { chatHandlers } = await import("./server-methods/chat.js");
+
+      await chatHandlers["chat.startup"]({
+        req: {
+          type: "req",
+          id: "startup-slow-catalog",
+          method: "chat.startup",
+          params: { sessionKey: "main" },
+        },
+        params: { sessionKey: "main" },
+        client: null,
+        isWebchatConnect: () => false,
+        respond: ((ok, payload, error) => {
+          responses.push({ ok, payload, error });
+        }) as RespondFn,
+        context,
+      });
+
+      expect(context.loadGatewayModelCatalog).toHaveBeenCalledTimes(1);
+      expect(responses).toHaveLength(1);
+      expect(responses[0]?.ok).toBe(true);
+      const payload = responses[0]?.payload as
+        | {
+            agentsList?: { agents?: Array<{ id?: string }> };
+            metadata?: unknown;
+            sessionInfo?: { sessionId?: string };
+          }
+        | undefined;
+      expect(payload?.sessionInfo?.sessionId).toBe("sess-main");
+      expect(payload?.agentsList?.agents?.map((agent) => agent.id)).toContain("main");
+      expect(payload?.metadata).toBeUndefined();
+    } finally {
+      testState.sessionStorePath = undefined;
+      await fs.rm(sessionDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+    }
+  });
+
   test("chat.startup omits metadata when configured model visibility needs full discovery", async () => {
     await withGatewayChatHarness(async ({ ws }) => {
       await writeGatewayConfig({
@@ -497,8 +565,18 @@ describe("gateway server chat", () => {
   });
 
   test("chat.startup scopes metadata to agent session keys without explicit agentId", async () => {
-    await withGatewayChatHarness(async ({ ws }) => {
-      await writeGatewayConfig({
+    const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
+    try {
+      testState.sessionStorePath = path.join(sessionDir, "sessions.json");
+      await writeSessionStore({
+        entries: {
+          "agent:work:main": {
+            sessionId: "sess-work",
+            updatedAt: Date.now(),
+          },
+        },
+      });
+      const config = {
         agents: {
           defaults: {
             model: {
@@ -515,6 +593,9 @@ describe("gateway server chat", () => {
               model: {
                 primary: "minimax/MiniMax-M2.7-highspeed",
               },
+              models: {
+                "minimax/MiniMax-M2.7-highspeed": {},
+              },
             },
           ],
         },
@@ -530,17 +611,74 @@ describe("gateway server chat", () => {
             },
           },
         },
+      };
+      await writeGatewayConfig(config);
+      const responses: Array<{ ok: boolean; payload?: unknown; error?: unknown }> = [];
+      const context = {
+        loadGatewayModelCatalog: vi
+          .fn<GatewayRequestContext["loadGatewayModelCatalog"]>()
+          .mockImplementation(async () => {
+            await Promise.resolve();
+            await Promise.resolve();
+            return [
+              {
+                id: "gpt-main",
+                name: "GPT Main",
+                provider: "openai",
+                input: ["text"],
+              },
+              {
+                id: "MiniMax-M2.7-highspeed",
+                name: "MiniMax M2.7 Highspeed",
+                provider: "minimax",
+                input: ["text"],
+              },
+            ];
+          }),
+        logGateway: {
+          info: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+          debug: vi.fn(),
+        },
+        chatAbortControllers: new Map(),
+        chatRunBuffers: new Map(),
+        getRuntimeConfig: () => config,
+      } as unknown as GatewayRequestContext;
+      const { chatHandlers } = await import("./server-methods/chat.js");
+
+      await chatHandlers["chat.startup"]({
+        req: {
+          type: "req",
+          id: "startup-agent-scoped-metadata",
+          method: "chat.startup",
+          params: { sessionKey: "agent:work:main" },
+        },
+        params: { sessionKey: "agent:work:main" },
+        client: null,
+        isWebchatConnect: () => false,
+        respond: ((ok, payload, error) => {
+          responses.push({ ok, payload, error });
+        }) as RespondFn,
+        context,
       });
-      await connectOk(ws);
 
-      const startup = await rpcReq<{
-        metadata?: {
-          models?: Array<{ id?: string; provider?: string }>;
-        };
-      }>(ws, "chat.startup", { sessionKey: "agent:work:main" });
-
-      expect(startup.ok).toBe(true);
-      expect(startup.payload?.metadata?.models).toEqual(
+      expect(context.loadGatewayModelCatalog).toHaveBeenCalledTimes(1);
+      expect(responses).toHaveLength(1);
+      expect(responses[0]?.ok).toBe(true);
+      const payload = responses[0]?.payload as
+        | {
+            metadata?: {
+              models?: Array<{ id?: string; provider?: string }>;
+            };
+            sessionInfo?: { key?: string; sessionId?: string };
+          }
+        | undefined;
+      expect(payload?.sessionInfo).toMatchObject({
+        key: "agent:work:main",
+        sessionId: "sess-work",
+      });
+      expect(payload?.metadata?.models).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
             id: "MiniMax-M2.7-highspeed",
@@ -548,7 +686,10 @@ describe("gateway server chat", () => {
           }),
         ]),
       );
-    });
+    } finally {
+      testState.sessionStorePath = undefined;
+      await fs.rm(sessionDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+    }
   });
 
   test("chat.metadata coalesces configured models and text commands", async () => {


### PR DESCRIPTION
Summary
- Start the optional model catalog load early for chat.startup, then use a 25ms bounded startup-only wait instead of the existing 750ms optional metadata wait.
- Preserve the 750ms optional catalog timeout for other gateway surfaces.
- Add regressions for slow catalog omission, async cached catalog metadata, and agent-scoped startup metadata.

Verification
- node scripts/run-vitest.mjs src/agents/model-catalog-browse.test.ts src/gateway/server.chat.gateway-server-chat-b.test.ts ui/src/ui/app-chat.test.ts -- --reporter=verbose
- node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/ui/e2e/chat-flow.e2e.test.ts -- --reporter=verbose
- .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main
- Testbox-through-Crabbox changed gate: tbx_01ktmz45w39g25285v1t0qvm2x, exit 0
- Post-rebase quick sanity: node scripts/run-vitest.mjs src/gateway/server.chat.gateway-server-chat-b.test.ts -- --reporter=verbose
