### PR TITLE
feat: add collapsible workspace files rail

### DIFF
--- a/src/ui-app-settings.agents-files-refresh.test.ts
+++ b/src/ui-app-settings.agents-files-refresh.test.ts
@@ -75,6 +75,7 @@ function createHost(agentsPanel: AgentsPanel): Parameters<typeof refreshActiveTa
       navWidth: 220,
       navGroupsCollapsed: {},
       borderRadius: 50,
+      workspaceFilesCollapsed: false,
     },
     theme: "claw",
     themeMode: "system",

--- a/ui/src/styles/chat/sidebar.css
+++ b/ui/src/styles/chat/sidebar.css
@@ -1,7 +1,7 @@
 /* Split View Layout */
 .chat-workbench {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(230px, 280px);
+  grid-template-columns: minmax(0, 1fr) auto;
   gap: 0;
   flex: 1;
   min-height: 0;
@@ -39,10 +39,24 @@
 .chat-workspace-rail {
   display: flex;
   flex-direction: column;
+  width: 250px;
   min-width: 0;
   min-height: 0;
   border-left: 1px solid var(--border);
   background: color-mix(in srgb, var(--panel) 84%, transparent);
+}
+
+.chat-workspace-rail--collapsed {
+  width: 48px;
+}
+
+.chat-workspace-rail--collapsed .chat-workspace-rail__header {
+  padding: 12px 0;
+  justify-content: center;
+}
+
+.chat-workspace-rail--collapsed .chat-workspace-rail__controls {
+  justify-content: center;
 }
 
 .chat-workspace-rail__header {
@@ -59,6 +73,11 @@
   flex-direction: column;
   gap: 2px;
   min-width: 0;
+}
+
+.chat-workspace-rail__controls {
+  display: flex;
+  gap: 4px;
 }
 
 .chat-workspace-rail__eyebrow {

--- a/ui/src/ui/app-render.helpers.node.test.ts
+++ b/ui/src/ui/app-render.helpers.node.test.ts
@@ -135,6 +135,7 @@ function createSettings(): AppViewState["settings"] {
     navCollapsed: false,
     navGroupsCollapsed: {},
     borderRadius: 50,
+    workspaceFilesCollapsed: false,
     chatShowThinking: false,
     chatShowToolCalls: true,
   };

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -3533,6 +3533,12 @@ export function renderApp(state: AppViewState) {
                     loading: chatWorkspaceFiles.loading,
                     error: chatWorkspaceFiles.error,
                     activeName: chatWorkspaceFiles.activeName,
+                    collapsed: state.settings.workspaceFilesCollapsed,
+                    onToggleCollapsed: () =>
+                      state.applySettings({
+                        ...state.settings,
+                        workspaceFilesCollapsed: !state.settings.workspaceFilesCollapsed,
+                      }),
                     onRefresh: refreshChatWorkspaceFiles,
                     onOpenFile: openChatWorkspaceFile,
                   },

--- a/ui/src/ui/app-settings.test.ts
+++ b/ui/src/ui/app-settings.test.ts
@@ -46,6 +46,7 @@ type SettingsHost = {
     navWidth: number;
     navGroupsCollapsed: Record<string, boolean>;
     borderRadius: number;
+    workspaceFilesCollapsed: boolean;
     textScale?: import("./storage.ts").TextScaleStop;
     customTheme?: import("./custom-theme.ts").ImportedCustomTheme;
   };
@@ -145,6 +146,7 @@ const createHost = (tab: Tab): SettingsHost => ({
     navWidth: 220,
     navGroupsCollapsed: {},
     borderRadius: 50,
+    workspaceFilesCollapsed: false,
     textScale: 100,
   },
   theme: "claw" as unknown as ThemeName & ThemeMode,

--- a/ui/src/ui/storage.node.test.ts
+++ b/ui/src/ui/storage.node.test.ts
@@ -148,6 +148,7 @@ describe("loadSettings default gateway URL derivation", () => {
       recentSessionsCollapsed: false,
       borderRadius: 50,
       textScale: 100,
+      workspaceFilesCollapsed: false,
       sessionsByGateway: {
         "wss://gateway.example:8443/openclaw": {
           sessionKey: "agent",
@@ -181,6 +182,7 @@ describe("loadSettings default gateway URL derivation", () => {
       navWidth: 220,
       navGroupsCollapsed: {},
       borderRadius: 50,
+      workspaceFilesCollapsed: false,
       textScale: 100,
     });
 
@@ -213,6 +215,7 @@ describe("loadSettings default gateway URL derivation", () => {
       navWidth: 220,
       navGroupsCollapsed: {},
       borderRadius: 50,
+      workspaceFilesCollapsed: false,
     });
 
     saveSettings({
@@ -230,6 +233,7 @@ describe("loadSettings default gateway URL derivation", () => {
       navWidth: 220,
       navGroupsCollapsed: {},
       borderRadius: 50,
+      workspaceFilesCollapsed: false,
     });
 
     const settings = loadSettings();
@@ -259,6 +263,7 @@ describe("loadSettings default gateway URL derivation", () => {
       navWidth: 220,
       navGroupsCollapsed: {},
       borderRadius: 50,
+      workspaceFilesCollapsed: false,
     });
     const settings = loadSettings();
     expect(settings.gatewayUrl).toBe(gwUrl);
@@ -278,6 +283,7 @@ describe("loadSettings default gateway URL derivation", () => {
       navGroupsCollapsed: {},
       recentSessionsCollapsed: false,
       borderRadius: 50,
+      workspaceFilesCollapsed: false,
       textScale: 100,
       sessionsByGateway: {
         [gwUrl]: {
@@ -287,6 +293,69 @@ describe("loadSettings default gateway URL derivation", () => {
       },
     });
     expect(sessionStorage.length).toBe(1);
+  });
+
+  it("defaults workspace files collapsed to false", () => {
+    setTestLocation({
+      protocol: "https:",
+      host: "gateway.example:8443",
+      pathname: "/",
+    });
+
+    expect(loadSettings().workspaceFilesCollapsed).toBe(false);
+  });
+
+  it("persists workspace files collapse state across save and load", () => {
+    setTestLocation({
+      protocol: "https:",
+      host: "gateway.example:8443",
+      pathname: "/",
+    });
+
+    const gwUrl = expectedGatewayUrl("");
+    saveSettings({
+      gatewayUrl: gwUrl,
+      token: "",
+      sessionKey: "main",
+      lastActiveSessionKey: "main",
+      theme: "claw",
+      themeMode: "system",
+      chatShowThinking: true,
+      chatShowToolCalls: true,
+      chatAutoScroll: "near-bottom",
+      splitRatio: 0.6,
+      navCollapsed: false,
+      navWidth: 220,
+      navGroupsCollapsed: {},
+      recentSessionsCollapsed: false,
+      workspaceFilesCollapsed: true,
+      borderRadius: 50,
+      textScale: 100,
+    });
+
+    expect(loadSettings().workspaceFilesCollapsed).toBe(true);
+
+    saveSettings({
+      gatewayUrl: gwUrl,
+      token: "",
+      sessionKey: "main",
+      lastActiveSessionKey: "main",
+      theme: "claw",
+      themeMode: "system",
+      chatShowThinking: true,
+      chatShowToolCalls: true,
+      chatAutoScroll: "near-bottom",
+      splitRatio: 0.6,
+      navCollapsed: false,
+      navWidth: 220,
+      navGroupsCollapsed: {},
+      recentSessionsCollapsed: false,
+      workspaceFilesCollapsed: false,
+      borderRadius: 50,
+      textScale: 100,
+    });
+
+    expect(loadSettings().workspaceFilesCollapsed).toBe(false);
   });
 
   it("persists recent sessions collapse state across save and load", () => {
@@ -313,6 +382,7 @@ describe("loadSettings default gateway URL derivation", () => {
       navGroupsCollapsed: {},
       recentSessionsCollapsed: true,
       borderRadius: 50,
+      workspaceFilesCollapsed: false,
       textScale: 100,
     });
 
@@ -334,6 +404,7 @@ describe("loadSettings default gateway URL derivation", () => {
       navGroupsCollapsed: {},
       recentSessionsCollapsed: false,
       borderRadius: 50,
+      workspaceFilesCollapsed: false,
       textScale: 100,
     });
 
@@ -414,6 +485,7 @@ describe("loadSettings default gateway URL derivation", () => {
       navWidth: 220,
       navGroupsCollapsed: {},
       borderRadius: 50,
+      workspaceFilesCollapsed: false,
     });
     saveSettings({
       gatewayUrl: gwUrl,
@@ -429,6 +501,7 @@ describe("loadSettings default gateway URL derivation", () => {
       navWidth: 220,
       navGroupsCollapsed: {},
       borderRadius: 50,
+      workspaceFilesCollapsed: false,
     });
 
     expect(loadSettings().token).toBe("");
@@ -457,6 +530,7 @@ describe("loadSettings default gateway URL derivation", () => {
       navWidth: 320,
       navGroupsCollapsed: {},
       borderRadius: 50,
+      workspaceFilesCollapsed: false,
     });
 
     const scopedKey = `openclaw.control.settings.v1:${gwUrl}`;
@@ -492,6 +566,7 @@ describe("loadSettings default gateway URL derivation", () => {
       navWidth: 220,
       navGroupsCollapsed: {},
       borderRadius: 50,
+      workspaceFilesCollapsed: false,
       customTheme,
     });
 
@@ -522,6 +597,7 @@ describe("loadSettings default gateway URL derivation", () => {
         navWidth: 220,
         navGroupsCollapsed: {},
         borderRadius: 50,
+      workspaceFilesCollapsed: false,
         customTheme: {
           sourceUrl: "https://tweakcn.com/themes/broken",
           themeId: "broken",
@@ -566,6 +642,7 @@ describe("loadSettings default gateway URL derivation", () => {
       navWidth: 220,
       navGroupsCollapsed: {},
       borderRadius: 50,
+      workspaceFilesCollapsed: false,
     });
 
     const settings = loadSettings();
@@ -609,6 +686,7 @@ describe("loadSettings default gateway URL derivation", () => {
       navWidth: 220,
       navGroupsCollapsed: {},
       borderRadius: 50,
+      workspaceFilesCollapsed: false,
     });
 
     const persisted = JSON.parse(localStorage.getItem(scopedKey) ?? "{}");

--- a/ui/src/ui/storage.ts
+++ b/ui/src/ui/storage.ts
@@ -94,6 +94,7 @@ export type UiSettings = {
   navWidth: number; // Sidebar width when expanded (240–400px)
   navGroupsCollapsed: Record<string, boolean>; // Which nav groups are collapsed
   recentSessionsCollapsed?: boolean; // Collapse recent sessions list in sidebar
+  workspaceFilesCollapsed: boolean; // Collapse workspace files rail in chat
   borderRadius: number; // Corner roundness (0–100, default 50)
   textScale?: TextScaleStop; // Browser-local text scale percentage
   customTheme?: ImportedCustomTheme;
@@ -237,6 +238,7 @@ export function loadSettings(): UiSettings {
     navWidth: 220,
     navGroupsCollapsed: {},
     recentSessionsCollapsed: false,
+    workspaceFilesCollapsed: false,
     borderRadius: 50,
     textScale: 100,
   };
@@ -297,6 +299,10 @@ export function loadSettings(): UiSettings {
         typeof parsed.recentSessionsCollapsed === "boolean"
           ? parsed.recentSessionsCollapsed
           : defaults.recentSessionsCollapsed,
+      workspaceFilesCollapsed:
+        typeof parsed.workspaceFilesCollapsed === "boolean"
+          ? parsed.workspaceFilesCollapsed
+          : defaults.workspaceFilesCollapsed,
       borderRadius:
         typeof parsed.borderRadius === "number" &&
         parsed.borderRadius >= 0 &&
@@ -423,6 +429,7 @@ function persistSettings(next: UiSettings) {
     navWidth: next.navWidth,
     navGroupsCollapsed: next.navGroupsCollapsed,
     recentSessionsCollapsed: next.recentSessionsCollapsed ?? false,
+    workspaceFilesCollapsed: next.workspaceFilesCollapsed,
     borderRadius: next.borderRadius,
     textScale: normalizeTextScale(next.textScale),
     ...(next.customTheme ? { customTheme: next.customTheme } : {}),

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -569,6 +569,17 @@ function createChatProps(
     onSplitRatioChange: () => undefined,
     onChatScroll: () => undefined,
     basePath: "",
+    workspaceFiles: {
+      agentId: "main",
+      list: null,
+      loading: false,
+      error: null,
+      activeName: null,
+      collapsed: false,
+      onToggleCollapsed: () => undefined,
+      onRefresh: () => undefined,
+      onOpenFile: () => undefined,
+    },
     ...overrides,
   };
 }
@@ -887,6 +898,8 @@ describe("chat composer workbench", () => {
         loading: false,
         error: null,
         activeName: "AGENTS.md",
+        collapsed: false,
+        onToggleCollapsed: vi.fn(),
         onRefresh,
         onOpenFile,
       },
@@ -905,6 +918,58 @@ describe("chat composer workbench", () => {
     file?.click();
 
     expect(onOpenFile).toHaveBeenCalledWith("AGENTS.md");
+  });
+
+  it("toggles the workspace files rail collapse state", () => {
+    const onToggleCollapsed = vi.fn();
+    const container = renderChatView({
+      workspaceFiles: {
+        agentId: "main",
+        list: {
+          agentId: "main",
+          workspace: "/workspace",
+          files: [{ name: "test.ts", path: "/workspace/test.ts", missing: false, size: 100 }],
+        },
+        loading: false,
+        error: null,
+        activeName: null,
+        collapsed: false,
+        onToggleCollapsed,
+        onRefresh: () => undefined,
+        onOpenFile: () => undefined,
+      },
+    });
+
+    const toggleButton = container.querySelector<HTMLButtonElement>(".chat-workspace-rail__toggle");
+    expect(toggleButton).not.toBeNull();
+
+    toggleButton?.click();
+    expect(onToggleCollapsed).toHaveBeenCalledOnce();
+  });
+
+  it("hides workspace files rail content when collapsed", () => {
+    const container = renderChatView({
+      workspaceFiles: {
+        agentId: "main",
+        list: {
+          agentId: "main",
+          workspace: "/workspace",
+          files: [{ name: "test.ts", path: "/workspace/test.ts", missing: false, size: 100 }],
+        },
+        loading: false,
+        error: null,
+        activeName: null,
+        collapsed: true,
+        onToggleCollapsed: vi.fn(),
+        onRefresh: () => undefined,
+        onOpenFile: () => undefined,
+      },
+    });
+
+    expect(container.querySelector(".chat-workspace-rail__list")).toBeNull();
+    expect(container.querySelector(".chat-workspace-rail__path")).toBeNull();
+    expect(container.querySelector(".chat-workspace-rail__toggle")).not.toBeNull();
+    expect(container.querySelector(".chat-workspace-rail--collapsed")).not.toBeNull();
   });
 
   it("keeps the secondary New session and Export controls suppressed in the composer", () => {

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -190,6 +190,8 @@ export type ChatProps = {
     loading: boolean;
     error: string | null;
     activeName: string | null;
+    collapsed: boolean;
+    onToggleCollapsed: () => void;
     onRefresh: () => void;
     onOpenFile: (name: string) => void;
   };
@@ -1014,66 +1016,92 @@ function renderWorkspaceFileRail(
   }
   const files = workspaceFiles.list?.files ?? [];
   return html`
-    <aside class="chat-workspace-rail" aria-label="Workspace files">
+    <aside
+      class="chat-workspace-rail ${workspaceFiles.collapsed ? "chat-workspace-rail--collapsed" : ""}"
+      aria-label="Workspace files"
+    >
       <div class="chat-workspace-rail__header">
-        <div class="chat-workspace-rail__title">
-          <span class="chat-workspace-rail__eyebrow">Workspace</span>
-          <strong>Files</strong>
-        </div>
-        <button
-          class="btn btn--ghost btn--sm chat-workspace-rail__refresh"
-          type="button"
-          title="Refresh files"
-          aria-label="Refresh files"
-          ?disabled=${workspaceFiles.loading}
-          @click=${workspaceFiles.onRefresh}
-        >
-          ${icons.refresh}
-        </button>
-      </div>
-      ${workspaceFiles.list?.workspace
-        ? html`<div class="chat-workspace-rail__path" title=${workspaceFiles.list.workspace}>
-            ${workspaceFiles.list.workspace}
-          </div>`
-        : nothing}
-      ${workspaceFiles.error
-        ? html`<div class="chat-workspace-rail__state chat-workspace-rail__state--error">
-            ${workspaceFiles.error}
-          </div>`
-        : workspaceFiles.loading && files.length === 0
-          ? html`<div class="chat-workspace-rail__state">Loading files...</div>`
-          : files.length === 0
-            ? html`<div class="chat-workspace-rail__state">No workspace files</div>`
+        ${workspaceFiles.collapsed
+          ? nothing
+          : html`
+              <div class="chat-workspace-rail__title">
+                <span class="chat-workspace-rail__eyebrow">Workspace</span>
+                <strong>Files</strong>
+              </div>
+            `}
+        <div class="chat-workspace-rail__controls">
+          <button
+            class="btn btn--ghost btn--sm chat-workspace-rail__toggle"
+            type="button"
+            title=${workspaceFiles.collapsed ? "Expand workspace files" : "Collapse workspace files"}
+            aria-label=${workspaceFiles.collapsed ? "Expand workspace files" : "Collapse workspace files"}
+            @click=${workspaceFiles.onToggleCollapsed}
+          >
+            ${workspaceFiles.collapsed ? icons.panelLeftOpen : icons.panelLeftClose}
+          </button>
+          ${workspaceFiles.collapsed
+            ? nothing
             : html`
-                <div class="chat-workspace-rail__list" role="list">
-                  ${files.map((file) => {
-                    const size = formatWorkspaceFileSize(file);
-                    const isActive = file.name === workspaceFiles.activeName;
-                    return html`
-                      <button
-                        class="chat-workspace-rail__file ${isActive
-                          ? "chat-workspace-rail__file--active"
-                          : ""}"
-                        type="button"
-                        role="listitem"
-                        title=${file.path || file.name}
-                        @click=${() => workspaceFiles.onOpenFile(file.name)}
-                      >
-                        <span class="chat-workspace-rail__file-icon">${icons.fileText}</span>
-                        <span class="chat-workspace-rail__file-main">
-                          <span class="chat-workspace-rail__file-name">${file.name}</span>
-                          ${size
-                            ? html`<span class="chat-workspace-rail__file-meta">${size}</span>`
-                            : nothing}
-                        </span>
-                        ${file.missing
-                          ? html`<span class="chat-workspace-rail__file-badge">Missing</span>`
-                          : nothing}
-                      </button>
-                    `;
-                  })}
-                </div>
+                <button
+                  class="btn btn--ghost btn--sm chat-workspace-rail__refresh"
+                  type="button"
+                  title="Refresh files"
+                  aria-label="Refresh files"
+                  ?disabled=${workspaceFiles.loading}
+                  @click=${workspaceFiles.onRefresh}
+                >
+                  ${icons.refresh}
+                </button>
               `}
+        </div>
+      </div>
+      ${workspaceFiles.collapsed
+        ? nothing
+        : html`
+            ${workspaceFiles.list?.workspace
+              ? html`<div class="chat-workspace-rail__path" title=${workspaceFiles.list.workspace}>
+                  ${workspaceFiles.list.workspace}
+                </div>`
+              : nothing}
+            ${workspaceFiles.error
+              ? html`<div class="chat-workspace-rail__state chat-workspace-rail__state--error">
+                  ${workspaceFiles.error}
+                </div>`
+              : workspaceFiles.loading && files.length === 0
+                ? html`<div class="chat-workspace-rail__state">Loading files...</div>`
+                : files.length === 0
+                  ? html`<div class="chat-workspace-rail__state">No workspace files</div>`
+                  : html`
+                      <div class="chat-workspace-rail__list" role="list">
+                        ${files.map((file) => {
+                          const size = formatWorkspaceFileSize(file);
+                          const isActive = file.name === workspaceFiles.activeName;
+                          return html`
+                            <button
+                              class="chat-workspace-rail__file ${isActive
+                                ? "chat-workspace-rail__file--active"
+                                : ""}"
+                              type="button"
+                              role="listitem"
+                              title=${file.path || file.name}
+                              @click=${() => workspaceFiles.onOpenFile(file.name)}
+                            >
+                              <span class="chat-workspace-rail__file-icon">${icons.fileText}</span>
+                              <span class="chat-workspace-rail__file-main">
+                                <span class="chat-workspace-rail__file-name">${file.name}</span>
+                                ${size
+                                  ? html`<span class="chat-workspace-rail__file-meta">${size}</span>`
+                                  : nothing}
+                              </span>
+                              ${file.missing
+                                ? html`<span class="chat-workspace-rail__file-badge">Missing</span>`
+                                : nothing}
+                            </button>
+                          `;
+                        })}
+                      </div>
+                    `}
+          `}
     </aside>
   `;
 }

--- a/ui/src/ui/views/overview.render.test.ts
+++ b/ui/src/ui/views/overview.render.test.ts
@@ -25,6 +25,7 @@ function createOverviewProps(overrides: Partial<OverviewProps> = {}): OverviewPr
       navWidth: 220,
       navGroupsCollapsed: {},
       borderRadius: 50,
+      workspaceFilesCollapsed: false,
       locale: "en",
     },
     password: "",


### PR DESCRIPTION
## Summary

* Adds a collapse/expand control for the Workspace Files rail in the Control UI chat view.
* Persists the Workspace Files rail state across page refreshes using the existing UI settings mechanism.
* Reclaims horizontal space for the chat workspace when the rail is collapsed.
* Keeps the change narrowly scoped to the existing Workspace Files rail without changing workspace file APIs or loading behavior.

What problem does this PR solve?

The Workspace Files rail is always visible when workspace files are available. Users currently have no way to hide it and reclaim that screen space.

Why does this matter now?

Issue #91036 requests a way to hide the Workspace Files rail because it can be distracting and consume screen space when not actively being used.

What is the intended outcome?

Users can collapse the Workspace Files rail, expand it again when needed, and keep their preference across page refreshes.

What is intentionally out of scope?

* Workspace file API changes.
* Workspace file loading or refresh behavior changes.
* Mobile-specific UI redesign.
* Additional workspace management features.

What does success look like?

The Workspace Files rail can be collapsed and expanded from the chat UI, the preference persists across refreshes, and collapsing the rail gives the chat area additional space.

What should reviewers focus on?

* The collapse/expand UX for the Workspace Files rail.
* Persistence of the new UI preference.
* Desktop layout behavior in expanded and collapsed states.

## Linked context

Which issue does this close?

Closes #91036

Which issues, PRs, or discussions are related?

Related #

Was this requested by a maintainer or owner?

No. This implements the behavior requested in issue #91036.

## Real behavior proof (required for external PRs)

* Behavior or issue addressed:
  Added a user-facing control to collapse and expand the Workspace Files rail in the Control UI chat view.

* Real environment tested:
  Local OpenClaw checkout running the Control UI in a browser.

* Exact steps or command run after this patch:

```bash
openclaw dashboard
```

1. Open the Chat view with workspace files available.
2. Click the Workspace Files collapse button.
3. Verify the Workspace Files rail collapses.
4. Refresh the page.
5. Verify the collapsed state is preserved.
6. Click the expand button and verify the Workspace Files rail returns.

* Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):
 
<img width="1533" height="855" alt="image" src="https://github.com/user-attachments/assets/087d7bcd-c1b4-4a09-8cdd-5f891d6ed20d" />
<img width="1535" height="855" alt="image" src="https://github.com/user-attachments/assets/9ff3e572-624a-443c-9ac8-7667ad75fe26" />

Screenshots attached showing:

* Expanded Workspace Files rail.

* Collapsed Workspace Files rail.

* Persisted collapsed state after refresh.

* Observed result after fix:

The Workspace Files rail can be collapsed and expanded. The collapsed state persists across refreshes, and the chat area gains additional horizontal space when the rail is collapsed.

* What was not tested:

Mobile-specific behavior beyond ensuring the existing mobile handling was not intentionally changed.

* Proof limitations or environment constraints:

Validation was performed locally using the Control UI. No production deployment environment was available.

* Before evidence (optional but encouraged):

Before this change, the Workspace Files rail was always visible when workspace files were available and there was no way to hide it.

## Tests and validation

Which commands did you run?

```bash
OPENCLAW_TEST_FAST=1 node scripts/test-projects.mjs ui/src/ui/views/chat.test.ts
OPENCLAW_TEST_FAST=1 node scripts/test-projects.mjs ui/src/ui/storage.node.test.ts
git diff --check
```

What regression coverage was added or updated?

* Added coverage for Workspace Files rail collapse/expand behavior.
* Added coverage for persistence of the Workspace Files rail state in UI settings.

What failed before this fix, if known?

There was no mechanism to collapse the Workspace Files rail.

If no test was added, why not?

Tests were added.

## Risk checklist

Did user-visible behavior change? (`Yes`)

Did config, environment, or migration behavior change? (`Yes`)

Did security, auth, secrets, network, or tool execution behavior change? (`No`)

What is the highest-risk area?

Persistence of the new Workspace Files rail UI state and desktop layout behavior.

How is that risk mitigated?

The change uses the existing UI settings persistence system and includes focused regression tests covering persistence and rendering behavior.

## Current review state

What is the next action?

Ready for ClawSweeper review and maintainer review.

What is still waiting on author, maintainer, CI, or external proof?

Waiting on CI, ClawSweeper review, and maintainer review.

Which bot or reviewer comments were addressed?

Implements the behavior requested in issue #91036.

AI-assisted: yes. I used ChatGPT to help understand the issue scope and review requirements. I reviewed the final implementation, tests, and manual validation results myself.
