### PR TITLE
fix: use Start-Process FilePath on Windows

### DIFF
--- a/src/gateway/server-methods/config.test.ts
+++ b/src/gateway/server-methods/config.test.ts
@@ -74,14 +74,14 @@ describe("resolveConfigOpenCommand", () => {
     });
   });
 
-  it("uses a quoted PowerShell literal on Windows", () => {
+  it("uses a quoted PowerShell file path on Windows", () => {
     expect(resolveConfigOpenCommand(String.raw`C:\tmp\o'hai & calc.json`, "win32")).toEqual({
       command: "powershell.exe",
       args: [
         "-NoProfile",
         "-NonInteractive",
         "-Command",
-        String.raw`Start-Process -LiteralPath 'C:\tmp\o''hai & calc.json'`,
+        String.raw`Start-Process -FilePath 'C:\tmp\o''hai & calc.json'`,
       ],
     });
   });

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -183,7 +183,7 @@ export function resolveConfigOpenCommand(
         "-NoProfile",
         "-NonInteractive",
         "-Command",
-        `Start-Process -LiteralPath '${escapePowerShellSingleQuotedString(configPath)}'`,
+        `Start-Process -FilePath '${escapePowerShellSingleQuotedString(configPath)}'`,
       ],
     };
   }


### PR DESCRIPTION
## Summary
- switch dashboard config-opening on Windows from `Start-Process -LiteralPath` to the supported `-FilePath` parameter
- keep the existing single-quoted PowerShell escaping behavior
- update the config command test to assert the working PowerShell invocation

## Testing
- `npm test -- src/gateway/server-methods/config.test.ts`

Fixes openclaw/openclaw#90157