### PR TITLE
fix: add gemini-3.5-flash to the Google provider catalog

### DIFF
--- a/extensions/google/provider-catalog.test.ts
+++ b/extensions/google/provider-catalog.test.ts
@@ -12,7 +12,12 @@ describe("google provider catalog", () => {
     expect(provider.api).toBe("google-vertex");
     expect(provider.baseUrl).toBe("https://{location}-aiplatform.googleapis.com");
     expect(provider.models.map((model) => model.id)).toEqual(
-      expect.arrayContaining(["gemini-2.5-pro", "gemini-3.1-pro-preview", "gemini-3.1-flash-lite"]),
+      expect.arrayContaining([
+        "gemini-2.5-pro",
+        "gemini-3.1-pro-preview",
+        "gemini-3.1-flash-lite",
+        "gemini-3.5-flash",
+      ]),
     );
     expect(provider.models.find((model) => model.id === "gemini-3.1-flash-lite")).toMatchObject({
       contextWindow: 1_048_576,

--- a/extensions/google/provider-catalog.ts
+++ b/extensions/google/provider-catalog.ts
@@ -54,6 +54,15 @@ const GOOGLE_GEMINI_TEXT_MODELS: ModelDefinitionConfig[] = [
     maxTokens: 65_536,
   },
   {
+    id: "gemini-3.5-flash",
+    name: "Gemini 3.5 Flash",
+    reasoning: true,
+    input: ["text", "image"],
+    cost: GOOGLE_GEMINI_COST,
+    contextWindow: 1_048_576,
+    maxTokens: 65_536,
+  },
+  {
     id: "gemini-3-flash-preview",
     name: "Gemini 3 Flash Preview",
     reasoning: true,

--- a/extensions/google/provider-models.test.ts
+++ b/extensions/google/provider-models.test.ts
@@ -213,6 +213,30 @@ describe("resolveGoogleGeminiForwardCompatModel", () => {
     });
   });
 
+  it("resolves gemini 3.5 flash from direct google templates", () => {
+    const model = resolveGoogleGeminiForwardCompatModel({
+      providerId: "google",
+      ctx: createContext({
+        provider: "google",
+        modelId: "gemini-3.5-flash",
+        models: [
+          createTemplateModel("google", "gemini-3.5-flash", {
+            reasoning: true,
+            contextWindow: 1_048_576,
+          }),
+        ],
+      }),
+    });
+
+    expectModelFields(model, {
+      provider: "google",
+      id: "gemini-3.5-flash",
+      api: "google-generative-ai",
+      reasoning: true,
+      contextWindow: 1_048_576,
+    });
+  });
+
   it("resolves gemini 3.1 flash from direct google templates", () => {
     const model = resolveGoogleGeminiForwardCompatModel({
       providerId: "google",

--- a/extensions/google/provider-models.ts
+++ b/extensions/google/provider-models.ts
@@ -14,6 +14,7 @@ const GEMINI_2_5_FLASH_LITE_PREFIX = "gemini-2.5-flash-lite";
 const GEMINI_2_5_FLASH_PREFIX = "gemini-2.5-flash";
 const GEMINI_3_1_PRO_PREFIX = "gemini-3.1-pro";
 const GEMINI_3_1_FLASH_LITE_PREFIX = "gemini-3.1-flash-lite";
+const GEMINI_3_5_FLASH_PREFIX = "gemini-3.5-flash";
 const GEMINI_3_1_FLASH_PREFIX = "gemini-3.1-flash";
 const GEMINI_3_FLASH_LITE_PREFIX = "gemini-3-flash-lite";
 const GEMINI_3_FLASH_PREFIX = "gemini-3-flash";
@@ -26,6 +27,7 @@ const GEMINI_2_5_FLASH_LITE_TEMPLATE_IDS = ["gemini-2.5-flash-lite"] as const;
 const GEMINI_2_5_FLASH_TEMPLATE_IDS = ["gemini-2.5-flash"] as const;
 const GEMINI_3_1_PRO_TEMPLATE_IDS = ["gemini-3.1-pro-preview", "gemini-3-pro-preview"] as const;
 const GEMINI_3_1_FLASH_LITE_TEMPLATE_IDS = ["gemini-3.1-flash-lite"] as const;
+const GEMINI_3_5_FLASH_TEMPLATE_IDS = ["gemini-3.5-flash"] as const;
 const GEMINI_3_1_FLASH_TEMPLATE_IDS = ["gemini-3-flash-preview", "gemini-2.5-flash"] as const;
 const GEMINI_3_PRO_ANTIGRAVITY_TEMPLATE_IDS = ["gemini-3-pro-low", "gemini-3-pro-high"] as const;
 const GEMINI_3_FLASH_ANTIGRAVITY_TEMPLATE_IDS = ["gemini-3-flash"] as const;
@@ -176,6 +178,12 @@ export function resolveGoogleGeminiForwardCompatModel(params: {
     if (params.providerId === "google" || params.providerId === GOOGLE_GEMINI_CLI_PROVIDER_ID) {
       patch = { reasoning: true };
     }
+  } else if (lower.startsWith(GEMINI_3_5_FLASH_PREFIX)) {
+    family = {
+      googleTemplateIds: GEMINI_3_5_FLASH_TEMPLATE_IDS,
+      cliTemplateIds: GEMINI_3_5_FLASH_TEMPLATE_IDS,
+      antigravityTemplateIds: GEMINI_3_FLASH_ANTIGRAVITY_TEMPLATE_IDS,
+    };
   } else if (
     lower.startsWith(GEMINI_3_1_FLASH_LITE_PREFIX) ||
     lower.startsWith(GEMINI_3_FLASH_LITE_PREFIX) ||


### PR DESCRIPTION
## Summary
- add `gemini-3.5-flash` to the bundled Google AI Studio and Vertex static catalogs
- teach forward-compat model resolution to recognize `gemini-3.5-flash` requests
- extend Google provider tests to cover the new catalog row and resolution path

## Testing
- `npm test -- extensions/google/provider-catalog.test.ts extensions/google/provider-models.test.ts`

Fixes openclaw/openclaw#91540