### PR TITLE
fix(cron): avoid duplicate cron event text in heartbeat prompt when already delivered as system message (fixes #44922)

### DIFF
--- a/src/infra/heartbeat-events-filter.test.ts
+++ b/src/infra/heartbeat-events-filter.test.ts
@@ -112,6 +112,31 @@ describe("heartbeat event prompts", () => {
     expect(prompt.length).toBeLessThan(8_500);
   });
 
+  it.each([
+    {
+      name: "references system message instead of repeating text",
+      events: ["Cron: rotate logs"],
+      opts: { deliverToUser: false, alreadySystemMessage: true },
+      expected: ["system message above", "Act on it"],
+      unexpected: ["Cron: rotate logs", "reminder content", "Handle this reminder internally"],
+    },
+    {
+      name: "references system message with heartbeat_respond in response-tool mode",
+      events: ["Cron: rotate logs"],
+      opts: { deliverToUser: false, alreadySystemMessage: true, useHeartbeatResponseTool: true },
+      expected: ["system message above", "Act on it", "heartbeat_respond"],
+      unexpected: ["Cron: rotate logs", "reminder content"],
+    },
+  ])("$name", ({ events, opts, expected, unexpected }) => {
+    const prompt = buildCronEventPrompt(events, opts);
+    for (const part of expected) {
+      expect(prompt).toContain(part);
+    }
+    for (const part of unexpected) {
+      expect(prompt).not.toContain(part);
+    }
+  });
+
   it("uses heartbeat_respond for empty cron events in response-tool mode", () => {
     const prompt = buildCronEventPrompt([""], { useHeartbeatResponseTool: true });
 

--- a/src/infra/heartbeat-events-filter.ts
+++ b/src/infra/heartbeat-events-filter.ts
@@ -78,10 +78,12 @@ export function buildCronEventPrompt(
   opts?: {
     deliverToUser?: boolean;
     useHeartbeatResponseTool?: boolean;
+    alreadySystemMessage?: boolean;
   },
 ): string {
   const deliverToUser = opts?.deliverToUser ?? true;
   const useHeartbeatResponseTool = opts?.useHeartbeatResponseTool ?? false;
+  const alreadySystemMessage = opts?.alreadySystemMessage ?? false;
   const eventText = pendingEvents.join("\n").trim();
   if (!eventText) {
     if (useHeartbeatResponseTool) {
@@ -100,6 +102,15 @@ export function buildCronEventPrompt(
       "A scheduled cron event was triggered, but no event content was found. " +
       "Reply HEARTBEAT_OK."
     );
+  }
+  if (alreadySystemMessage) {
+    const reference =
+      "A scheduled cron event was triggered. " +
+      "The event content was delivered as a system message above. Act on it.";
+    if (useHeartbeatResponseTool) {
+      return `${reference} ${HEARTBEAT_RESPONSE_TOOL_INSTRUCTIONS}`;
+    }
+    return reference;
   }
   if (!deliverToUser) {
     return (

--- a/src/infra/heartbeat-runner.ghost-reminder.test.ts
+++ b/src/infra/heartbeat-runner.ghost-reminder.test.ts
@@ -284,8 +284,7 @@ describe("Ghost reminder bug (issue #13317)", () => {
     expect(result.status).toBe("ran");
     expect(replyCallCount).toBe(1);
     expect(calledCtx?.Provider).toBe("cron-event");
-    expect(calledCtx?.Body).toContain("scheduled reminder has been triggered");
-    expect(calledCtx?.Body).toContain("Cron: QMD maintenance completed");
+    expect(calledCtx?.Body).toContain("system message above");
     expect(calledCtx?.Body).not.toContain("Read HEARTBEAT.md");
     expect(sendTelegram).toHaveBeenCalled();
   });
@@ -339,7 +338,7 @@ describe("Ghost reminder bug (issue #13317)", () => {
         Body?: string;
       };
       expect(firstCtx.Provider).toBe("cron-event");
-      expect(firstCtx.Body).toContain("Cron: QMD maintenance completed");
+      expect(firstCtx.Body).toContain("system message above");
       expect(secondCtx.Provider).toBe("heartbeat");
       expect(secondCtx.Body).toContain("Read HEARTBEAT.md");
       expect(secondCtx.Body).not.toContain("Cron: QMD maintenance completed");

--- a/src/infra/heartbeat-runner.isolated-key-stability.test.ts
+++ b/src/infra/heartbeat-runner.isolated-key-stability.test.ts
@@ -275,7 +275,7 @@ describe("runHeartbeatOnce – isolated session key stability (#59493)", () => {
 
       expect(firstCtx.SessionKey).toBe(`${baseSessionKey}:heartbeat`);
       expect(firstCtx.Provider).toBe("cron-event");
-      expect(firstCtx.Body).toContain("Cron: QMD maintenance completed");
+      expect(firstCtx.Body).toContain("system message above");
       expect(secondCtx.SessionKey).toBe(`${baseSessionKey}:heartbeat`);
       expect(secondCtx.Body).not.toContain("Cron: QMD maintenance completed");
     });

--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -1787,7 +1787,7 @@ tasks:
         if (expectCronContext) {
           const calledCtx = replyBody(replySpy);
           expect(calledCtx.Provider, name).toBe("cron-event");
-          expect(calledCtx.Body, name).toContain("scheduled reminder has been triggered");
+          expect(calledCtx.Body, name).toContain("system message above");
         }
       } finally {
         replySpy.mockReset();
@@ -1841,7 +1841,7 @@ tasks:
       expect(sendWhatsApp).toHaveBeenCalledTimes(0);
       const calledCtx = replyBody(replySpy);
       expect(calledCtx.Provider).toBe("cron-event");
-      expect(calledCtx.Body).toContain("Handle this reminder internally");
+      expect(calledCtx.Body).toContain("system message above");
       expect(calledCtx.Body).not.toContain("Please relay this reminder to the user");
     } finally {
       replySpy.mockReset();

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -1179,6 +1179,9 @@ function resolveHeartbeatRunPrompt(params: {
         isCronSystemEvent(event.text),
     )
     .map((event) => event.text);
+  const cronEventsAreSystemMessages = pendingEventEntries.some(
+    (event) => event.contextKey?.startsWith("cron:") && isCronSystemEvent(event.text),
+  );
   const execEvents = params.preflight.shouldInspectPendingEvents
     ? pendingEventEntries
         .filter((event) => isExecCompletionEvent(event.text))
@@ -1247,6 +1250,7 @@ ${completionInstruction}`;
       ? buildCronEventPrompt(cronEvents, {
           deliverToUser: params.canRelayToUser,
           useHeartbeatResponseTool: baseUsesHeartbeatResponseTool,
+          alreadySystemMessage: cronEventsAreSystemMessages,
         })
       : baseUsesHeartbeatResponseTool
         ? resolveHeartbeatResponseToolPrompt(params.cfg, params.heartbeat)


### PR DESCRIPTION
### Summary

- **Problem**: When a cron job has `sessionTarget: "main"` and `delivery.mode: "none"`, the model sees the same cron system event text twice — once as a system message injected via `enqueueSystemEvent` and again wrapped inside `buildCronEventPrompt` ("A scheduled reminder has been triggered...").
- **Root Cause**: `resolveHeartbeatRunPrompt` in `heartbeat-runner.ts` always calls `buildCronEventPrompt` with the full cron event text, regardless of whether the event was already delivered to the model as a system message via `contextKey: "cron:*"`.
- **Fix**: When cron events have a `contextKey` starting with `"cron:"` (indicating they were already injected as system messages), `buildCronEventPrompt` now produces a brief reference ("A scheduled cron event was triggered. The event content was delivered as a system message above. Act on it.") instead of repeating the full event text.
- **What changed**:
  - `src/infra/heartbeat-events-filter.ts` — added `alreadySystemMessage` option to `buildCronEventPrompt`
  - `src/infra/heartbeat-runner.ts` — detect cron events with `contextKey: "cron:*"` and pass `alreadySystemMessage` flag
- **What did NOT change (scope boundary)**:
  - Cron events without a `contextKey` (e.g., isolated session cron, non-system-message paths) continue to use the full reminder prompt unchanged
  - Heartbeat delivery semantics (channel relay, response routing) are unchanged
  - Cron timer (`src/cron/service/timer.ts`) is unchanged — the fix is purely in the heartbeat prompt layer

### Reproduction

1. Create a cron job with `sessionTarget: "main"`, `payload.kind: "systemEvent"`, `delivery.mode: "none"`, and `wakeMode: "now"`
2. Wait for the scheduled execution
3. **Before this PR**: The session log shows both a `System:` line with the event text AND the heartbeat wrapper containing "A scheduled reminder has been triggered. The reminder content is: <same text>"
4. **After this PR**: The session log shows the `System:` line with the event text, and the heartbeat says "A scheduled cron event was triggered. The event content was delivered as a system message above. Act on it." — no duplicate text

### Real behavior proof

**Behavior or issue addressed (44922)**: When a cron job with `sessionTarget: "main"` has `payload.kind: "systemEvent"`, the event text is already injected as a system message visible to the model, but `buildCronEventPrompt` repeats the full text in the heartbeat wrapper — producing duplicate content in the model context. This fix makes `buildCronEventPrompt` emit a concise reference ("the event content was delivered as a system message above") instead of repeating the full event text when the cron event has a `contextKey: "cron:*"`.

**Real environment tested**: Linux, Node 22 — Vitest against `buildCronEventPrompt` and `resolveHeartbeatRunPrompt`

**Exact steps or command run after this patch**: `node scripts/run-vitest.mjs src/infra/heartbeat-events-filter.test.ts src/infra/heartbeat-runner.ghost-reminder.test.ts src/infra/heartbeat-runner.returns-default-unset.test.ts src/infra/heartbeat-runner.isolated-key-stability.test.ts`

**Evidence after fix**:
```text
$ node scripts/run-vitest.mjs src/infra/heartbeat-events-filter.test.ts
[test] starting test/vitest/vitest.unit-fast.config.ts
 RUN  v4.1.7 /home/0668001395/openclawProject1
 heartbeat event prompts (10)
   ✓ heartbeat event prompts > builds user-relay cron prompt by default
   ✓ heartbeat event prompts > builds internal-only cron prompt when delivery is disabled
   ✓ heartbeat event prompts > falls back to bare heartbeat reply when cron content is empty
   ✓ heartbeat event prompts > uses internal empty-content fallback when delivery is disabled
   ✓ heartbeat event prompts > references system message instead of repeating text
   ✓ heartbeat event prompts > references system message with heartbeat_respond in response-tool mode
   ✓ heartbeat event prompts > builds user-relay exec prompt by default
   ✓ heartbeat event prompts > builds internal-only exec prompt when delivery is disabled
   ✓ heartbeat event prompts > suppresses empty exec completion prompts
   ✓ heartbeat event prompts > suppresses metadata-only successful exec completions
   ... (41 more)
 heartbeat event classification (29)
 heartbeat event classification > classifies exec completion events (10)
 heartbeat event classification > classifies cron system events (12)
 heartbeat event classification > classifies relayable exec completion events (4)
 isExecCompletionEvent (8)
 isExecCompletionEvent > matches emitExecSystemEvent (gateway/node approval path) events
 isExecCompletionEvent > matches maybeNotifyOnExit (backgrounded allowlisted commands) events
 isExecCompletionEvent > is case-insensitive
 isExecCompletionEvent > does not match non-exec events
 isExecCompletionEvent > does not false-positive on free-form cron text containing exec phrases
 Test Files  1 passed (1)
      Tests  51 passed (51)

$ node scripts/run-vitest.mjs src/infra/heartbeat-runner.ghost-reminder.test.ts
[test] starting test/vitest/vitest.infra.config.ts
 Ghost reminder bug (issue #13317) (16)
   ... all 16 heartbeat runner scenarios pass
 Test Files  1 passed (1)
      Tests  16 passed (16)

$ node scripts/run-vitest.mjs src/infra/heartbeat-runner.returns-default-unset.test.ts
 Test Files  1 passed (1)
      Tests  39 passed (39)

$ node scripts/run-vitest.mjs src/infra/heartbeat-runner.isolated-key-stability.test.ts
 Test Files  1 passed (1)
      Tests  11 passed (11)
```

**Observed result after fix**: The two new test cases verify that `buildCronEventPrompt` with `alreadySystemMessage: true` produces a terse system-message reference ("system message above") without repeating the event text. All existing cron promp tests continue to pass. The `expectCronEventPrompt` helper for non-contextKey cron events still verifies full text inclusion, confirming the fix is scoped only to system-message-injected cron events.

**What was not tested**: Live gateway end-to-end with a real cron timer cycle was not driven. The fix is verified at the unit/integration level covering the heartbeat prompt resolution path.

**Repro confirmation**: A new test case "references system message instead of repeating text" verifies that `alreadySystemMessage: true` produces the reference text and does NOT contain the original event text ("Cron: rotate logs") or the old wrapper text ("reminder content", "Handle this reminder internally").

### Risk / Mitigation

- **Risk**: Other callers relying on `buildCronEventPrompt` always repeating full text
  **Mitigation**: `alreadySystemMessage` defaults to `false` (no behavior change for existing callers). The flag is only set when the code path explicitly detects `contextKey: "cron:*"` system events.
- **Risk**: The reference text ("system message above") may not be clear to all models
  **Mitigation**: The text explicitly says "Act on it." and the model still has the full event content in the preceding system message. The instruction is unambiguous.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] `src/infra/` — heartbeat and cron infrastructure

### Regression Test Plan

- `node scripts/run-vitest.mjs src/infra/heartbeat-events-filter.test.ts`
- `node scripts/run-vitest.mjs src/infra/heartbeat-runner.ghost-reminder.test.ts`
- `node scripts/run-vitest.mjs src/infra/heartbeat-runner.returns-default-unset.test.ts`
- `node scripts/run-vitest.mjs src/infra/heartbeat-runner.isolated-key-stability.test.ts`

### Review Findings Addressed

N/A (initial submission)

### Linked Issue/PR

Fixes #44922
