### PR TITLE
fix: enable DeepSeek DSML filtering for proxy providers via model id detection

### DIFF
--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -2640,10 +2640,10 @@ async function processOpenAICompletionsStream(
   const MAX_TOOL_CALL_ARGUMENT_BUFFER_BYTES = 256_000;
   const emitReasoning = options?.emitReasoning ?? true;
   const compat = getCompat(model as OpenAIModeModel);
-  const deepSeekTextFilter = shouldFilterDeepSeekDsmlText(compat)
+  const deepSeekTextFilter = shouldFilterDeepSeekDsmlText(compat, model.id)
     ? createDeepSeekTextFilter()
     : null;
-  const deepSeekToolCallRecoverer = shouldFilterDeepSeekDsmlText(compat)
+  const deepSeekToolCallRecoverer = shouldFilterDeepSeekDsmlText(compat, model.id)
     ? createDeepSeekDsmlToolCallRecoverer()
     : null;
   const reasoningTagTextPartitioner = createReasoningTagTextPartitioner();
@@ -3074,8 +3074,11 @@ type CompletionsReasoningDelta =
       text: string;
     };
 
-function shouldFilterDeepSeekDsmlText(compat: ReturnType<typeof getCompat>) {
-  return compat.thinkingFormat === "deepseek";
+function shouldFilterDeepSeekDsmlText(
+  compat: ReturnType<typeof getCompat>,
+  modelId?: string,
+) {
+  return compat.thinkingFormat === "deepseek" || modelId?.includes("deepseek") === true;
 }
 
 type RecoveredDeepSeekDsmlToolCall = {


### PR DESCRIPTION
## Root Cause

DSML filtering was gated on `compat.thinkingFormat === "deepseek"`, which resolves only for native deepseek endpoint (api.deepseek.com) or providers with provider key "deepseek". When DeepSeek models are served through proxy providers like SiliconFlow, the endpoint class falls back to "custom" and the filter is never created.

## Impact

This causes `<|DSML|function_calls>` markup to leak into visible text, which triggers Feishu streaming-card re-render events that create a feedback loop — resulting in explosive duplicate messages.

## Fix

One-line change to `shouldFilterDeepSeekDsmlText`: fall back to checking whether the model id contains "deepseek" when endpoint-based detection fails. This is a defense-in-depth measure that catches any proxy-hosted DeepSeek models.

## Reproduce

1. Configure a proxy provider (e.g. SiliconFlow) with a deepseek-ai/DeepSeek-V4-* model
2. Send a message via Feishu channel
3. When the model emits DSML markup, observe explosive duplicate messages

## Verification

Before: `thinkingFormat === "deepseek"` → false for proxy providers → DSML unfiltered → card re-render → feedback loop  
After: `thinkingFormat === "deepseek" || modelId?.includes("deepseek")` → true → DSML stripped → clean text → no loop