### PR TITLE
fix: bound native hook relay lifetime

### DIFF
--- a/extensions/codex/src/app-server/native-hook-relay.test.ts
+++ b/extensions/codex/src/app-server/native-hook-relay.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildCodexNativeHookRelayConfig,
   buildCodexNativeHookRelayDisabledConfig,
+  resolveCodexNativeHookRelayCommandTimeoutMs,
   resolveCodexNativeHookRelayUnregisterGraceMs,
 } from "./native-hook-relay.js";
 
@@ -23,7 +24,7 @@ describe("Codex native hook relay config", () => {
             {
               type: "command",
               command:
-                "openclaw hooks relay --provider codex --relay-id relay-1 --generation generation-1 --event pre_tool_use",
+                "openclaw hooks relay --provider codex --relay-id relay-1 --generation generation-1 --event pre_tool_use --timeout 6000",
               timeout: 7,
               async: false,
               statusMessage: "OpenClaw native hook relay",
@@ -37,7 +38,7 @@ describe("Codex native hook relay config", () => {
             {
               type: "command",
               command:
-                "openclaw hooks relay --provider codex --relay-id relay-1 --generation generation-1 --event post_tool_use",
+                "openclaw hooks relay --provider codex --relay-id relay-1 --generation generation-1 --event post_tool_use --timeout 6000",
               timeout: 7,
               async: false,
               statusMessage: "OpenClaw native hook relay",
@@ -51,7 +52,7 @@ describe("Codex native hook relay config", () => {
             {
               type: "command",
               command:
-                "openclaw hooks relay --provider codex --relay-id relay-1 --generation generation-1 --event permission_request",
+                "openclaw hooks relay --provider codex --relay-id relay-1 --generation generation-1 --event permission_request --timeout 6000",
               timeout: 7,
               async: false,
               statusMessage: "OpenClaw native hook relay",
@@ -65,7 +66,7 @@ describe("Codex native hook relay config", () => {
             {
               type: "command",
               command:
-                "openclaw hooks relay --provider codex --relay-id relay-1 --generation generation-1 --event before_agent_finalize",
+                "openclaw hooks relay --provider codex --relay-id relay-1 --generation generation-1 --event before_agent_finalize --timeout 6000",
               timeout: 7,
               async: false,
               statusMessage: "OpenClaw native hook relay",
@@ -128,7 +129,7 @@ describe("Codex native hook relay config", () => {
             {
               type: "command",
               command:
-                "openclaw hooks relay --provider codex --relay-id relay-1 --generation generation-1 --event permission_request",
+                "openclaw hooks relay --provider codex --relay-id relay-1 --generation generation-1 --event permission_request --timeout 4000",
               timeout: 5,
               async: false,
               statusMessage: "OpenClaw native hook relay",
@@ -163,7 +164,7 @@ describe("Codex native hook relay config", () => {
             {
               type: "command",
               command:
-                "openclaw hooks relay --provider codex --relay-id relay-1 --generation generation-1 --event pre_tool_use",
+                "openclaw hooks relay --provider codex --relay-id relay-1 --generation generation-1 --event pre_tool_use --timeout 4000",
               timeout: 5,
               async: false,
               statusMessage: "OpenClaw native hook relay",
@@ -200,7 +201,7 @@ describe("Codex native hook relay config", () => {
             {
               type: "command",
               command:
-                "openclaw hooks relay --provider codex --relay-id relay-1 --generation generation-1 --event pre_tool_use --pre-tool-use-unavailable noop",
+                "openclaw hooks relay --provider codex --relay-id relay-1 --generation generation-1 --event pre_tool_use --pre-tool-use-unavailable noop --timeout 4000",
               timeout: 5,
               async: false,
               statusMessage: "OpenClaw native hook relay",
@@ -238,7 +239,7 @@ describe("Codex native hook relay config", () => {
             {
               type: "command",
               command:
-                "openclaw hooks relay --provider codex --relay-id relay-1 --generation generation-1 --event permission_request",
+                "openclaw hooks relay --provider codex --relay-id relay-1 --generation generation-1 --event permission_request --timeout 4000",
               timeout: 5,
               async: false,
               statusMessage: "OpenClaw native hook relay",
@@ -264,6 +265,12 @@ describe("Codex native hook relay config", () => {
         "<session-flags>/config.toml:stop:0:0": { enabled: false },
       },
     });
+  });
+
+  it("reserves relay timeout margin before Codex can kill the hook subprocess", () => {
+    expect(resolveCodexNativeHookRelayCommandTimeoutMs(undefined)).toBe(4000);
+    expect(resolveCodexNativeHookRelayCommandTimeoutMs(1)).toBe(750);
+    expect(resolveCodexNativeHookRelayCommandTimeoutMs(7)).toBe(6000);
   });
 
   it("omits matchers so Codex MCP tool names reach the relay with a stable trust hash", () => {
@@ -311,12 +318,12 @@ function createRelay(options?: {
     allowedEvents: ["pre_tool_use", "post_tool_use", "permission_request", "before_agent_finalize"],
     expiresAtMs: Date.now() + 1000,
     shouldRelayEvent: (event) => !inactiveEvents.has(event),
-    commandForEvent: (event) =>
+    commandForEvent: (event, commandOptions) =>
       `openclaw hooks relay --provider codex --relay-id relay-1 --generation generation-1 --event ${event}${
         event === "pre_tool_use" && inactiveEvents.has(event)
           ? " --pre-tool-use-unavailable noop"
           : ""
-      }`,
+      }${commandOptions?.timeoutMs ? ` --timeout ${commandOptions.timeoutMs}` : ""}`,
     renew: () => undefined,
     unregister: () => undefined,
   };

--- a/extensions/codex/src/app-server/native-hook-relay.ts
+++ b/extensions/codex/src/app-server/native-hook-relay.ts
@@ -29,6 +29,8 @@ const CODEX_NATIVE_HOOK_RELAY_EVENTS_WITH_APP_SERVER_APPROVALS =
 const CODEX_NATIVE_HOOK_RELAY_MIN_TTL_MS = 30 * 60_000;
 /** Extra relay lifetime after the expected turn budget, preventing late hook drops. */
 export const CODEX_NATIVE_HOOK_RELAY_TTL_GRACE_MS = 5 * 60_000;
+const CODEX_NATIVE_HOOK_RELAY_COMMAND_MIN_PARENT_MARGIN_MS = 250;
+const CODEX_NATIVE_HOOK_RELAY_COMMAND_MAX_PARENT_MARGIN_MS = 1_000;
 const CODEX_NATIVE_HOOK_RELAY_UNREGISTER_GRACE_MS = 10_000;
 const CODEX_NATIVE_HOOK_RELAY_UNREGISTER_EXTRA_GRACE_MS = 5_000;
 
@@ -263,8 +265,10 @@ export function buildCodexNativeHookRelayConfig(params: {
       }
       continue;
     }
-    const command = params.relay.commandForEvent(event);
     const timeout = normalizeHookTimeoutSec(params.hookTimeoutSec);
+    const command = params.relay.commandForEvent(event, {
+      timeoutMs: resolveCodexNativeHookRelayCommandTimeoutMs(timeout),
+    });
     config[`hooks.${codexEvent}`] = [
       {
         hooks: [
@@ -309,6 +313,18 @@ export function buildCodexNativeHookRelayDisabledConfig(): JsonObject {
 
 function normalizeHookTimeoutSec(value: number | undefined): number {
   return typeof value === "number" && Number.isFinite(value) && value > 0 ? Math.ceil(value) : 5;
+}
+
+export function resolveCodexNativeHookRelayCommandTimeoutMs(
+  hookTimeoutSec: number | undefined,
+): number {
+  const parentTimeoutMs =
+    finiteSecondsToTimerSafeMilliseconds(normalizeHookTimeoutSec(hookTimeoutSec)) ?? 5_000;
+  const parentMarginMs = Math.min(
+    CODEX_NATIVE_HOOK_RELAY_COMMAND_MAX_PARENT_MARGIN_MS,
+    Math.max(CODEX_NATIVE_HOOK_RELAY_COMMAND_MIN_PARENT_MARGIN_MS, Math.floor(parentTimeoutMs / 5)),
+  );
+  return Math.max(1, parentTimeoutMs - parentMarginMs);
 }
 
 function codexCommandHookTrustedHash(params: {

--- a/src/agents/harness/native-hook-relay.test.ts
+++ b/src/agents/harness/native-hook-relay.test.ts
@@ -249,6 +249,14 @@ describe("native hook relay registry", () => {
       "/usr/local/bin/node '/opt/Open Claw/openclaw.mjs' hooks relay --provider codex --relay-id " +
         `${relay.relayId} --generation ${relay.generation} --event pre_tool_use --timeout 1234`,
     );
+    expect(relay.commandForEvent("pre_tool_use", { timeoutMs: 900 })).toBe(
+      "/usr/local/bin/node '/opt/Open Claw/openclaw.mjs' hooks relay --provider codex --relay-id " +
+        `${relay.relayId} --generation ${relay.generation} --event pre_tool_use --timeout 900`,
+    );
+    expect(relay.commandForEvent("pre_tool_use", { timeoutMs: 2_000 })).toBe(
+      "/usr/local/bin/node '/opt/Open Claw/openclaw.mjs' hooks relay --provider codex --relay-id " +
+        `${relay.relayId} --generation ${relay.generation} --event pre_tool_use --timeout 1234`,
+    );
   });
 
   it("rejects relay registrations when expiry would exceed Date range", () => {

--- a/src/agents/harness/native-hook-relay.ts
+++ b/src/agents/harness/native-hook-relay.ts
@@ -111,7 +111,10 @@ export type NativeHookRelayRegistration = {
 export type NativeHookRelayRegistrationHandle = NativeHookRelayRegistration & {
   generation?: string;
   shouldRelayEvent: (event: NativeHookRelayEvent) => boolean;
-  commandForEvent: (event: NativeHookRelayEvent) => string;
+  commandForEvent: (
+    event: NativeHookRelayEvent,
+    options?: NativeHookRelayCommandForEventOptions,
+  ) => string;
   renew: (ttlMs?: number) => void;
   unregister: () => void;
 };
@@ -137,6 +140,10 @@ export type NativeHookRelayCommandOptions = {
   executable?: string;
   nice?: number | false;
   nodeExecutable?: string;
+  timeoutMs?: number;
+};
+
+export type NativeHookRelayCommandForEventOptions = {
   timeoutMs?: number;
 };
 
@@ -436,7 +443,7 @@ export function registerNativeHookRelay(
   const handle: ActiveNativeHookRelayRegistrationHandle = {
     ...registration,
     shouldRelayEvent: (event) => nativeHookRelayEventHasLocalWork(registration, event),
-    commandForEvent: (event) =>
+    commandForEvent: (event, options) =>
       buildNativeHookRelayCommand({
         provider: params.provider,
         relayId,
@@ -447,7 +454,10 @@ export function registerNativeHookRelay(
             ? "noop"
             : undefined,
         nice: params.command?.nice,
-        timeoutMs: params.command?.timeoutMs,
+        timeoutMs: resolveNativeHookRelayCommandTimeoutMs(
+          params.command?.timeoutMs,
+          options?.timeoutMs,
+        ),
         executable: params.command?.executable,
         nodeExecutable: params.command?.nodeExecutable,
       }),
@@ -517,6 +527,21 @@ function resolveNativeHookRelayNicePrefix(value: number | false | undefined): st
     return [];
   }
   return ["nice", "-n", String(nice)];
+}
+
+function resolveNativeHookRelayCommandTimeoutMs(
+  configuredTimeoutMs: number | undefined,
+  overrideTimeoutMs: number | undefined,
+): number | undefined {
+  const configured = normalizeOptionalPositiveInteger(configuredTimeoutMs);
+  const override = normalizeOptionalPositiveInteger(overrideTimeoutMs);
+  if (configured === undefined) {
+    return override;
+  }
+  if (override === undefined) {
+    return configured;
+  }
+  return Math.min(configured, override);
 }
 
 export function buildNativeHookRelayCommand(params: {
@@ -2155,6 +2180,12 @@ function normalizePositiveInteger(value: number | undefined, fallback: number): 
   return typeof value === "number" && Number.isFinite(value) && value > 0
     ? Math.floor(value)
     : fallback;
+}
+
+function normalizeOptionalPositiveInteger(value: number | undefined): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? Math.floor(value)
+    : undefined;
 }
 
 function shellQuoteArgs(args: readonly string[]): string {

--- a/src/cli/native-hook-relay-cli.test.ts
+++ b/src/cli/native-hook-relay-cli.test.ts
@@ -1,4 +1,5 @@
 // Native hook relay CLI tests cover relay command registration and runtime delegation.
+import { PassThrough } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
 import {
   createReadableTextStream,
@@ -8,7 +9,7 @@ import {
 
 describe("native hook relay CLI", () => {
   it("reads Codex hook JSON from stdin and forwards it to the gateway relay", async () => {
-    const callGateway = vi.fn(async () => ({ stdout: "", stderr: "", exitCode: 0 }));
+    const callGateway = vi.fn(async (_opts: unknown) => ({ stdout: "", stderr: "", exitCode: 0 }));
     const stdout = createWritableTextBuffer();
     const stderr = createWritableTextBuffer();
 
@@ -50,9 +51,14 @@ describe("native hook relay CLI", () => {
           tool_input: { command: "pnpm test" },
         },
       },
-      timeoutMs: 1234,
+      timeoutMs: expect.any(Number),
+      signal: expect.any(AbortSignal),
       scopes: ["operator.admin"],
     });
+    const call = callGateway.mock.calls[0]?.[0] as { timeoutMs?: number } | undefined;
+    expect(call).toBeDefined();
+    expect(call?.timeoutMs).toBeGreaterThan(0);
+    expect(call?.timeoutMs).toBeLessThanOrEqual(1234);
   });
 
   it("renders provider-compatible stdout, stderr, and exit code from the gateway response", async () => {
@@ -260,6 +266,115 @@ describe("native hook relay CLI", () => {
     expect(callGateway).not.toHaveBeenCalled();
   });
 
+  it.each([
+    {
+      event: "pre_tool_use",
+      preToolUseUnavailable: "noop",
+      stdout: null,
+    },
+    {
+      event: "pre_tool_use",
+      stdout: {
+        hookSpecificOutput: {
+          hookEventName: "PreToolUse",
+          permissionDecision: "deny",
+          permissionDecisionReason: "Native hook relay timed out",
+        },
+      },
+    },
+    {
+      event: "permission_request",
+      stdout: {
+        hookSpecificOutput: {
+          hookEventName: "PermissionRequest",
+          decision: {
+            behavior: "deny",
+            message: "Native hook relay timed out",
+          },
+        },
+      },
+    },
+    {
+      event: "post_tool_use",
+      stdout: null,
+    },
+  ])(
+    "bounds valid $event hook input that never reaches EOF",
+    async (testCase) => {
+      const invokeBridge = vi.fn();
+      const callGateway = vi.fn();
+      const stdin = createHeldOpenTextStream("{}");
+      const stdout = createWritableTextBuffer();
+      const stderr = createWritableTextBuffer();
+
+      const exitCode = await runNativeHookRelayCli(
+        {
+          provider: "codex",
+          relayId: "relay-1",
+          generation: "generation-1",
+          event: testCase.event,
+          preToolUseUnavailable: testCase.preToolUseUnavailable,
+          timeout: "25",
+        },
+        {
+          stdin,
+          stdout,
+          stderr,
+          invokeBridge: invokeBridge as never,
+          callGateway: callGateway as never,
+        },
+      );
+
+      expect(exitCode).toBe(0);
+      if (testCase.stdout) {
+        expect(JSON.parse(stdout.text())).toEqual(testCase.stdout);
+      } else {
+        expect(stdout.text()).toBe("");
+      }
+      expect(stderr.text()).toContain("native hook relay timed out");
+      expect(stdin.destroyed).toBe(true);
+      expect(invokeBridge).not.toHaveBeenCalled();
+      expect(callGateway).not.toHaveBeenCalled();
+    },
+    1_000,
+  );
+
+  it("applies the relay deadline to gateway fallback", async () => {
+    const invokeBridge = vi.fn(async () => {
+      throw new Error("bridge unavailable");
+    });
+    const callGateway = vi.fn(async () => await new Promise<never>(() => {}));
+    const stdout = createWritableTextBuffer();
+    const stderr = createWritableTextBuffer();
+
+    const exitCode = await runNativeHookRelayCli(
+      {
+        provider: "codex",
+        relayId: "relay-1",
+        generation: "generation-1",
+        event: "post_tool_use",
+        timeout: "25",
+      },
+      {
+        stdin: createReadableTextStream("{}"),
+        stdout,
+        stderr,
+        invokeBridge: invokeBridge as never,
+        callGateway: callGateway as never,
+      },
+    );
+
+    expect(exitCode).toBe(0);
+    expect(stdout.text()).toBe("");
+    expect(stderr.text()).toContain("native hook relay timed out");
+    expect(callGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "nativeHook.invoke",
+        signal: expect.any(AbortSignal),
+      }),
+    );
+  }, 1_000);
+
   it("rejects oversized hook input without touching the gateway", async () => {
     const callGateway = vi.fn();
     const stderr = createWritableTextBuffer();
@@ -417,3 +532,9 @@ describe("native hook relay CLI", () => {
     expect(stderr.text()).toContain("native hook relay unavailable");
   });
 });
+
+function createHeldOpenTextStream(text: string): PassThrough {
+  const stream = new PassThrough();
+  stream.write(text);
+  return stream;
+}

--- a/src/cli/native-hook-relay-cli.ts
+++ b/src/cli/native-hook-relay-cli.ts
@@ -8,6 +8,7 @@ import {
 } from "../agents/harness/native-hook-relay.js";
 import { callGateway } from "../gateway/call.js";
 import { ADMIN_SCOPE } from "../gateway/method-scopes.js";
+import { setSafeTimeout } from "../utils/timer-delay.js";
 import { parseTimeoutMsWithFallback } from "./parse-timeout.js";
 
 const MAX_NATIVE_HOOK_STDIN_BYTES = 1024 * 1024;
@@ -29,6 +30,20 @@ type NativeHookRelayCliDeps = {
   invokeBridge?: typeof invokeNativeHookRelayBridge;
   callGateway?: typeof callGateway;
 };
+
+type NativeHookRelayDeadline = {
+  expiresAtMs: number;
+  signal: AbortSignal;
+  timeoutMs: number;
+  dispose: () => void;
+};
+
+class NativeHookRelayDeadlineError extends Error {
+  constructor(timeoutMs: number) {
+    super(`native hook relay timed out after ${timeoutMs}ms`);
+    this.name = "NativeHookRelayDeadlineError";
+  }
+}
 
 /** Run one native hook relay invocation from stdin JSON to stdout/stderr response streams. */
 export async function runNativeHookRelayCli(
@@ -52,66 +67,93 @@ export async function runNativeHookRelayCli(
     return 1;
   }
 
-  let rawPayload: unknown;
+  const deadline = createNativeHookRelayDeadline(timeoutMs);
   try {
-    const rawInput = await readStreamText(stdin, MAX_NATIVE_HOOK_STDIN_BYTES);
-    rawPayload = rawInput.trim() ? JSON.parse(rawInput) : null;
-  } catch (error) {
-    writeText(stderr, formatRelayCliError("failed to read native hook input", error));
-    return 1;
-  }
+    let rawPayload: unknown;
+    try {
+      const rawInput = await readStreamText(stdin, MAX_NATIVE_HOOK_STDIN_BYTES, deadline);
+      rawPayload = rawInput.trim() ? JSON.parse(rawInput) : null;
+    } catch (error) {
+      if (isNativeHookRelayDeadlineError(error)) {
+        return writeNativeHookRelayDeadlineResponse({
+          stdout,
+          stderr,
+          opts,
+          provider,
+          event,
+          error,
+        });
+      }
+      writeText(stderr, formatRelayCliError("failed to read native hook input", error));
+      return 1;
+    }
 
-  try {
-    const response = await invokeBridge({
-      provider,
-      relayId,
-      generation,
-      event,
-      rawPayload,
-      registrationTimeoutMs: 100,
-      timeoutMs,
-    });
-    writeText(stdout, response.stdout);
-    writeText(stderr, response.stderr);
-    return response.exitCode;
-  } catch (error) {
-    if (isNativeHookRelayBridgeStaleRegistrationError(error)) {
-      writeText(stderr, formatRelayCliError("native hook relay unavailable", error));
-      const response = renderNativeHookRelayUnavailableResponse({
-        provider,
-        event,
-        preToolUseUnavailable: opts.preToolUseUnavailable,
-        message: "Native hook relay unavailable",
-      });
+    try {
+      const remainingMs = remainingNativeHookRelayDeadlineMs(deadline);
+      const response = await withNativeHookRelayDeadline(
+        deadline,
+        invokeBridge({
+          provider,
+          relayId,
+          generation,
+          event,
+          rawPayload,
+          registrationTimeoutMs: Math.min(100, remainingMs),
+          timeoutMs: remainingMs,
+        }),
+      );
       writeText(stdout, response.stdout);
       writeText(stderr, response.stderr);
       return response.exitCode;
+    } catch (error) {
+      if (isNativeHookRelayDeadlineError(error)) {
+        return writeNativeHookRelayDeadlineResponse({
+          stdout,
+          stderr,
+          opts,
+          provider,
+          event,
+          error,
+        });
+      }
+      if (isNativeHookRelayBridgeStaleRegistrationError(error)) {
+        writeText(stderr, formatRelayCliError("native hook relay unavailable", error));
+        return writeNativeHookRelayUnavailableResponse({ stdout, stderr, opts, provider, event });
+      }
+      // Fall through to the gateway path for embedded/local gateway cases and
+      // older registrations that predate the direct relay bridge.
     }
-    // Fall through to the gateway path for embedded/local gateway cases and
-    // older registrations that predate the direct relay bridge.
-  }
 
-  try {
-    const response = await callGatewayFn<NativeHookRelayProcessResponse>({
-      method: "nativeHook.invoke",
-      params: { provider, relayId, generation, event, rawPayload },
-      timeoutMs,
-      scopes: [ADMIN_SCOPE],
-    });
-    writeText(stdout, response.stdout);
-    writeText(stderr, response.stderr);
-    return response.exitCode;
-  } catch (error) {
-    writeText(stderr, formatRelayCliError("native hook relay unavailable", error));
-    const response = renderNativeHookRelayUnavailableResponse({
-      provider,
-      event,
-      preToolUseUnavailable: opts.preToolUseUnavailable,
-      message: "Native hook relay unavailable",
-    });
-    writeText(stdout, response.stdout);
-    writeText(stderr, response.stderr);
-    return response.exitCode;
+    try {
+      const response = await withNativeHookRelayDeadline(
+        deadline,
+        callGatewayFn<NativeHookRelayProcessResponse>({
+          method: "nativeHook.invoke",
+          params: { provider, relayId, generation, event, rawPayload },
+          timeoutMs: remainingNativeHookRelayDeadlineMs(deadline),
+          signal: deadline.signal,
+          scopes: [ADMIN_SCOPE],
+        }),
+      );
+      writeText(stdout, response.stdout);
+      writeText(stderr, response.stderr);
+      return response.exitCode;
+    } catch (error) {
+      if (isNativeHookRelayDeadlineError(error)) {
+        return writeNativeHookRelayDeadlineResponse({
+          stdout,
+          stderr,
+          opts,
+          provider,
+          event,
+          error,
+        });
+      }
+      writeText(stderr, formatRelayCliError("native hook relay unavailable", error));
+      return writeNativeHookRelayUnavailableResponse({ stdout, stderr, opts, provider, event });
+    }
+  } finally {
+    deadline.dispose();
   }
 }
 
@@ -122,18 +164,38 @@ function readRequiredOption(value: string | undefined, name: string): string {
   throw new Error(`Missing required option --${name}`);
 }
 
-async function readStreamText(stream: NodeJS.ReadableStream, maxBytes: number): Promise<string> {
+async function readStreamText(
+  stream: NodeJS.ReadableStream,
+  maxBytes: number,
+  deadline: NativeHookRelayDeadline,
+): Promise<string> {
   const chunks: Buffer[] = [];
   let total = 0;
-  for await (const chunk of stream) {
-    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
-    total += buffer.byteLength;
-    if (total > maxBytes) {
-      throw new Error(`native hook input exceeds ${maxBytes} bytes`);
+  const abortRead = () => {
+    destroyReadableStream(stream, createNativeHookRelayDeadlineError(deadline));
+  };
+  deadline.signal.addEventListener("abort", abortRead, { once: true });
+  try {
+    throwIfNativeHookRelayDeadlineExpired(deadline);
+    for await (const chunk of stream) {
+      throwIfNativeHookRelayDeadlineExpired(deadline);
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      total += buffer.byteLength;
+      if (total > maxBytes) {
+        throw new Error(`native hook input exceeds ${maxBytes} bytes`);
+      }
+      chunks.push(buffer);
     }
-    chunks.push(buffer);
+    throwIfNativeHookRelayDeadlineExpired(deadline);
+    return Buffer.concat(chunks, total).toString("utf8");
+  } catch (error) {
+    if (isNativeHookRelayDeadlineError(error) || deadline.signal.aborted) {
+      throw createNativeHookRelayDeadlineError(deadline);
+    }
+    throw error;
+  } finally {
+    deadline.signal.removeEventListener("abort", abortRead);
   }
-  return Buffer.concat(chunks, total).toString("utf8");
 }
 
 function writeText(stream: NodeJS.WritableStream, value: string | undefined): void {
@@ -145,6 +207,112 @@ function writeText(stream: NodeJS.WritableStream, value: string | undefined): vo
 function formatRelayCliError(prefix: string, error: unknown): string {
   const message = error instanceof Error ? error.message : String(error);
   return `${prefix}: ${message}\n`;
+}
+
+function createNativeHookRelayDeadline(timeoutMs: number): NativeHookRelayDeadline {
+  const controller = new AbortController();
+  const timer = setSafeTimeout(() => controller.abort(), timeoutMs);
+  timer.unref?.();
+  return {
+    expiresAtMs: Date.now() + timeoutMs,
+    signal: controller.signal,
+    timeoutMs,
+    dispose: () => clearTimeout(timer),
+  };
+}
+
+function createNativeHookRelayDeadlineError(
+  deadline: NativeHookRelayDeadline,
+): NativeHookRelayDeadlineError {
+  return new NativeHookRelayDeadlineError(deadline.timeoutMs);
+}
+
+function isNativeHookRelayDeadlineError(error: unknown): error is NativeHookRelayDeadlineError {
+  return error instanceof Error && error.name === "NativeHookRelayDeadlineError";
+}
+
+function remainingNativeHookRelayDeadlineMs(deadline: NativeHookRelayDeadline): number {
+  const remainingMs = deadline.expiresAtMs - Date.now();
+  if (remainingMs <= 0 || deadline.signal.aborted) {
+    throw createNativeHookRelayDeadlineError(deadline);
+  }
+  return Math.max(1, remainingMs);
+}
+
+function throwIfNativeHookRelayDeadlineExpired(deadline: NativeHookRelayDeadline): void {
+  void remainingNativeHookRelayDeadlineMs(deadline);
+}
+
+function destroyReadableStream(stream: NodeJS.ReadableStream, error: Error): void {
+  const destroy = (stream as NodeJS.ReadableStream & { destroy?: (error?: Error) => void }).destroy;
+  if (typeof destroy === "function") {
+    destroy.call(stream, error);
+    return;
+  }
+  stream.pause();
+}
+
+async function withNativeHookRelayDeadline<T>(
+  deadline: NativeHookRelayDeadline,
+  promise: Promise<T>,
+): Promise<T> {
+  throwIfNativeHookRelayDeadlineExpired(deadline);
+  return await new Promise<T>((resolve, reject) => {
+    const cleanup = () => deadline.signal.removeEventListener("abort", abort);
+    const abort = () => {
+      cleanup();
+      reject(createNativeHookRelayDeadlineError(deadline));
+    };
+    deadline.signal.addEventListener("abort", abort, { once: true });
+    promise.then(
+      (value) => {
+        cleanup();
+        resolve(value);
+      },
+      (error: unknown) => {
+        cleanup();
+        reject(error instanceof Error ? error : new Error(String(error)));
+      },
+    );
+  });
+}
+
+function writeNativeHookRelayUnavailableResponse(params: {
+  stdout: NodeJS.WritableStream;
+  stderr: NodeJS.WritableStream;
+  opts: NativeHookRelayCliOptions;
+  provider: string;
+  event: string;
+  message?: string;
+}): number {
+  const response = renderNativeHookRelayUnavailableResponse({
+    provider: params.provider,
+    event: params.event,
+    preToolUseUnavailable: params.opts.preToolUseUnavailable,
+    message: params.message ?? "Native hook relay unavailable",
+  });
+  writeText(params.stdout, response.stdout);
+  writeText(params.stderr, response.stderr);
+  return response.exitCode;
+}
+
+function writeNativeHookRelayDeadlineResponse(params: {
+  stdout: NodeJS.WritableStream;
+  stderr: NodeJS.WritableStream;
+  opts: NativeHookRelayCliOptions;
+  provider: string;
+  event: string;
+  error: NativeHookRelayDeadlineError;
+}): number {
+  writeText(params.stderr, formatRelayCliError("native hook relay timed out", params.error));
+  return writeNativeHookRelayUnavailableResponse({
+    stdout: params.stdout,
+    stderr: params.stderr,
+    opts: params.opts,
+    provider: params.provider,
+    event: params.event,
+    message: "Native hook relay timed out",
+  });
 }
 
 /** Create a readable text stream for relay CLI tests. */


### PR DESCRIPTION
## Summary

Fixes #90993.

- Add an OpenClaw-owned native hook relay deadline that starts before stdin is read, applies through direct bridge and gateway fallback, and aborts/destroys the held input path on timeout.
- Preserve existing provider-compatible timeout fallback behavior: PreToolUse noop/fail-closed, PermissionRequest deny, and observational noop for non-blocking events.
- Keep Codex-generated relay command timeouts below Codex's parent hook timeout so the relay has time to emit its fail-closed/noop response before the parent can kill it.

## Verification

- `.agents/skills/autoreview/scripts/autoreview --mode local` after final changes: clean, no accepted/actionable findings.
- `node scripts/run-vitest.mjs src/cli/native-hook-relay-cli.test.ts src/agents/harness/native-hook-relay.test.ts extensions/codex/src/app-server/native-hook-relay.test.ts extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts` passed: 122 tests.
- `pnpm exec oxfmt --check src/cli/native-hook-relay-cli.ts src/cli/native-hook-relay-cli.test.ts src/agents/harness/native-hook-relay.ts src/agents/harness/native-hook-relay.test.ts extensions/codex/src/app-server/native-hook-relay.ts extensions/codex/src/app-server/native-hook-relay.test.ts` passed.
- `node scripts/run-oxlint.mjs src/cli/native-hook-relay-cli.ts src/cli/native-hook-relay-cli.test.ts src/agents/harness/native-hook-relay.ts src/agents/harness/native-hook-relay.test.ts extensions/codex/src/app-server/native-hook-relay.ts extensions/codex/src/app-server/native-hook-relay.test.ts` passed.
- `pnpm tsgo:core`, `pnpm tsgo:core:test`, `pnpm tsgo:extensions`, `pnpm tsgo:extensions:test` passed.
- `pnpm build` passed.
- Local child-process regression against freshly built `openclaw.mjs`: held-open stdin exited code 0, was not killed, and emitted `native hook relay timed out after 1000ms`.
- AWS Crabbox regression proof: provider `aws`, run `run_0d76a211a57b`, lease `cbx_9d9647b4079b`, slug `brisk-crayfish`; held-open stdin exited code 0 with the timeout line.

`pnpm check:changed` could not run because the local Crabbox binary is `0.20.0` and current Blacksmith Testbox delegation requires `>=0.22.0`; the matching direct checks above cover the changed core and Codex extension surfaces.

## Real behavior proof

Behavior addressed: Native hook relay CLI processes can no longer wait indefinitely for EOF on stdin; timeout paths return the provider-compatible unavailable/noop/fail-closed response instead of leaking `openclaw-hooks` children.

Real environment tested: AWS Crabbox Linux, provider `aws`, run `run_0d76a211a57b`, lease `cbx_9d9647b4079b`, slug `brisk-crayfish`, plus local built `openclaw.mjs` child-process repro.

Exact steps or command run after this patch: Spawned `openclaw hooks relay --provider codex --event pre_tool_use --pre-tool-use-unavailable noop --timeout 1000`, wrote valid Codex PreToolUse JSON to stdin, intentionally kept stdin open, and observed whether the child exited before the 60s watchdog.

Evidence after fix: On AWS Crabbox, the held-open stdin child exited code 0 without watchdog kill and stderr included `native hook relay timed out: native hook relay timed out after 1000ms`.

Observed result after fix: The held-open relay process terminated instead of accumulating; the closed-stdin control also exited normally.

What was not tested: A multi-hour authenticated Codex app-server heartbeat scenario with real provider credentials was not run; the proved live path covers the root leak class through the actual relay CLI process.
