### PR TITLE
Fix config.patch explicit array replacement

### DIFF
--- a/apps/ios/Sources/Design/AgentProModels.swift
+++ b/apps/ios/Sources/Design/AgentProModels.swift
@@ -329,6 +329,13 @@ struct AgentConfigLite: Decodable {
 struct ConfigPatchParams: Encodable {
     let raw: String
     let baseHash: String
+    let replacePaths: [String]?
+
+    init(raw: String, baseHash: String, replacePaths: [String]? = nil) {
+        self.raw = raw
+        self.baseHash = baseHash
+        self.replacePaths = replacePaths
+    }
 }
 
 enum SkillMutationError: LocalizedError {

--- a/apps/ios/Sources/Design/AgentProTab+Skills.swift
+++ b/apps/ios/Sources/Design/AgentProTab+Skills.swift
@@ -621,7 +621,10 @@ extension AgentProTab {
             }
 
             let raw = try Self.agentSkillsPatchRaw(agentId: self.activeAgentID, skills: skills)
-            let params = ConfigPatchParams(raw: raw, baseHash: baseHash)
+            let params = ConfigPatchParams(
+                raw: raw,
+                baseHash: baseHash,
+                replacePaths: ["agents.list[].skills"])
             let data = try JSONEncoder().encode(params)
             guard let json = String(data: data, encoding: .utf8) else {
                 throw SkillMutationError.invalidPatchPayload

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -2782,7 +2782,7 @@ public struct ConfigPatchParams: Codable, Sendable {
         deliverycontext: [String: AnyCodable]?,
         note: String?,
         restartdelayms: Int?,
-        replacepaths: [String]? = nil)
+        replacepaths: [String]?)
     {
         self.raw = raw
         self.basehash = basehash

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -2773,6 +2773,7 @@ public struct ConfigPatchParams: Codable, Sendable {
     public let deliverycontext: [String: AnyCodable]?
     public let note: String?
     public let restartdelayms: Int?
+    public let replacepaths: [String]?
 
     public init(
         raw: String,
@@ -2780,7 +2781,8 @@ public struct ConfigPatchParams: Codable, Sendable {
         sessionkey: String?,
         deliverycontext: [String: AnyCodable]?,
         note: String?,
-        restartdelayms: Int?)
+        restartdelayms: Int?,
+        replacepaths: [String]? = nil)
     {
         self.raw = raw
         self.basehash = basehash
@@ -2788,6 +2790,7 @@ public struct ConfigPatchParams: Codable, Sendable {
         self.deliverycontext = deliverycontext
         self.note = note
         self.restartdelayms = restartdelayms
+        self.replacepaths = replacepaths
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -2797,6 +2800,7 @@ public struct ConfigPatchParams: Codable, Sendable {
         case deliverycontext = "deliveryContext"
         case note
         case restartdelayms = "restartDelayMs"
+        case replacepaths = "replacePaths"
     }
 }
 

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -601,7 +601,8 @@ For tooling that writes config over the gateway API, prefer this flow:
   summaries)
 - `config.get` to fetch the current snapshot plus `hash`
 - `config.patch` for partial updates (JSON merge patch: objects merge, `null`
-  deletes, arrays replace)
+  deletes, arrays replace when explicitly confirmed with `replacePaths` if
+  entries would be removed)
 - `config.apply` only when you intend to replace the entire config
 - `update.run` for explicit self-update plus restart; include `continuationMessage` when the post-restart session should run one follow-up turn
 - `update.status` to inspect the latest update restart sentinel and verify the running version after a restart
@@ -632,6 +633,14 @@ openclaw gateway call config.patch --params '{
 Both `config.apply` and `config.patch` accept `raw`, `baseHash`, `sessionKey`,
 `note`, and `restartDelayMs`. `baseHash` is required for both methods when a
 config already exists.
+
+`config.patch` also accepts `replacePaths`, an array of config paths whose array
+replacement is intentional. If a patch would replace or delete an existing array
+with fewer entries, the Gateway rejects the write unless that exact path appears
+in `replacePaths`; nested arrays under array entries use `[]`, such as
+`agents.list[].skills`. This prevents truncated `config.get` snapshots from
+silently clobbering routing or allowlist arrays. Use `config.apply` when you
+intend to replace the full config.
 
 ## Environment variables
 

--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -405,7 +405,9 @@ enumeration of `src/gateway/server-methods/*.ts`.
     - `secrets.resolve` resolves command-target secret assignments for a specific command/target set.
     - `config.get` returns the current config snapshot and hash.
     - `config.set` writes a validated config payload.
-    - `config.patch` merges a partial config update.
+    - `config.patch` merges a partial config update. Destructive array
+      replacement requires the affected path in `replacePaths`; nested arrays
+      under array entries use `[]` paths such as `agents.list[].skills`.
     - `config.apply` validates + replaces the full config payload.
     - `config.schema` returns the live config schema payload used by Control UI and CLI tooling: schema, `uiHints`, version, and generation metadata, including plugin + channel schema metadata when the runtime can load it. The schema includes field `title` / `description` metadata derived from the same labels and help text used by the UI, including nested object, wildcard, array-item, and `anyOf` / `oneOf` / `allOf` composition branches when matching field documentation exists.
     - `config.schema.lookup` returns a path-scoped lookup payload for one config path: normalized path, a shallow schema node, matched hint + `hintPath`, optional `reloadKind`, and immediate child summaries for UI/CLI drill-down. `reloadKind` is one of `restart`, `hot`, or `none` and mirrors the Gateway config reload planner for the requested path. Lookup schema nodes keep the user-facing docs and common validation fields (`title`, `description`, `type`, `enum`, `const`, `format`, `pattern`, numeric/string/array/object bounds, and flags like `additionalProperties`, `deprecated`, `readOnly`, `writeOnly`). Child summaries expose `key`, normalized `path`, `type`, `required`, `hasChildren`, optional `reloadKind`, plus the matched `hint` / `hintPath`.

--- a/extensions/qa-lab/src/suite-runtime-gateway.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-gateway.test.ts
@@ -261,18 +261,25 @@ describe("qa suite gateway helpers", () => {
       patchConfig({
         env,
         patch: { tools: { deny: ["read"] } },
+        replacePaths: ["tools.deny"],
         restartDelayMs: 0,
       }),
     ).resolves.toEqual({ ok: true });
 
     expect(gatewayCall).toHaveBeenCalledWith(
       "config.patch",
-      expect.objectContaining({ baseHash: "hash-1" }),
+      expect.objectContaining({
+        baseHash: "hash-1",
+        replacePaths: ["tools.deny"],
+      }),
       { timeoutMs: 180_000 },
     );
     expect(gatewayCall).toHaveBeenCalledWith(
       "config.patch",
-      expect.objectContaining({ baseHash: "hash-2" }),
+      expect.objectContaining({
+        baseHash: "hash-2",
+        replacePaths: ["tools.deny"],
+      }),
       { timeoutMs: 180_000 },
     );
   });

--- a/extensions/qa-lab/src/suite-runtime-gateway.ts
+++ b/extensions/qa-lab/src/suite-runtime-gateway.ts
@@ -241,6 +241,7 @@ async function runConfigMutation(params: {
   };
   note?: string;
   restartDelayMs?: number;
+  replacePaths?: readonly string[];
 }) {
   const restartDelayMs = params.restartDelayMs ?? 1_000;
   const timeoutMs = liveTurnTimeoutMs(params.env, 180_000);
@@ -263,6 +264,7 @@ async function runConfigMutation(params: {
           ...(params.deliveryContext ? { deliveryContext: params.deliveryContext } : {}),
           ...(params.note ? { note: params.note } : {}),
           restartDelayMs,
+          ...(params.replacePaths?.length ? { replacePaths: params.replacePaths } : {}),
         },
         { timeoutMs },
       );
@@ -316,6 +318,7 @@ async function patchConfig(params: {
   };
   note?: string;
   restartDelayMs?: number;
+  replacePaths?: readonly string[];
 }) {
   return await runConfigMutation({
     env: params.env,
@@ -325,6 +328,7 @@ async function patchConfig(params: {
     deliveryContext: params.deliveryContext,
     note: params.note,
     restartDelayMs: params.restartDelayMs,
+    replacePaths: params.replacePaths,
   });
 }
 

--- a/extensions/qa-matrix/src/runners/contract/runtime.test.ts
+++ b/extensions/qa-matrix/src/runners/contract/runtime.test.ts
@@ -613,6 +613,7 @@ describe("matrix live qa runtime", () => {
     await liveTesting.patchMatrixQaGatewayConfig({
       gateway: gateway as never,
       patch,
+      replacePaths: ["channels.matrix.accounts.sut.groupAllowFrom"],
       restartDelayMs: 250,
     });
 
@@ -623,6 +624,7 @@ describe("matrix live qa runtime", () => {
       {
         baseHash: "hash-old",
         raw: JSON.stringify(patch, null, 2),
+        replacePaths: ["channels.matrix.accounts.sut.groupAllowFrom"],
         restartDelayMs: 250,
       },
       { timeoutMs: 60_000 },
@@ -634,6 +636,7 @@ describe("matrix live qa runtime", () => {
       {
         baseHash: "hash-fresh",
         raw: JSON.stringify(patch, null, 2),
+        replacePaths: ["channels.matrix.accounts.sut.groupAllowFrom"],
         restartDelayMs: 250,
       },
       { timeoutMs: 60_000 },

--- a/extensions/qa-matrix/src/runners/contract/runtime.ts
+++ b/extensions/qa-matrix/src/runners/contract/runtime.ts
@@ -546,6 +546,7 @@ async function waitForMatrixChannelReady(
 async function patchMatrixQaGatewayConfig(params: {
   gateway: MatrixQaGatewayChild;
   patch: Record<string, unknown>;
+  replacePaths?: string[];
   restartDelayMs?: number;
 }) {
   for (let attempt = 0; attempt < 2; attempt += 1) {
@@ -561,6 +562,7 @@ async function patchMatrixQaGatewayConfig(params: {
         {
           raw: JSON.stringify(params.patch, null, 2),
           baseHash: snapshot.hash,
+          ...(params.replacePaths?.length ? { replacePaths: params.replacePaths } : {}),
           restartDelayMs: params.restartDelayMs ?? 0,
         },
         { timeoutMs: 60_000 },
@@ -973,6 +975,7 @@ export async function runMatrixQaLive(params: {
                   await patchMatrixQaGatewayConfig({
                     gateway: scenarioGateway.harness.gateway,
                     patch,
+                    replacePaths: opts?.replacePaths,
                     restartDelayMs: opts?.restartDelayMs,
                   });
                 },

--- a/extensions/qa-matrix/src/runners/contract/scenario-runtime-room.ts
+++ b/extensions/qa-matrix/src/runners/contract/scenario-runtime-room.ts
@@ -526,6 +526,7 @@ export async function runAllowlistHotReloadScenario(context: MatrixQaScenarioCon
       },
     },
     {
+      replacePaths: [`channels.matrix.accounts.${accountId}.groupAllowFrom`],
       restartDelayMs: MATRIX_QA_HOT_RELOAD_RESTART_DELAY_MS,
     },
   );

--- a/extensions/qa-matrix/src/runners/contract/scenario-runtime-shared.ts
+++ b/extensions/qa-matrix/src/runners/contract/scenario-runtime-shared.ts
@@ -57,7 +57,7 @@ export type MatrixQaScenarioContext = {
   topology: MatrixQaProvisionedTopology;
   patchGatewayConfig?: (
     patch: Record<string, unknown>,
-    opts?: { restartDelayMs?: number },
+    opts?: { replacePaths?: string[]; restartDelayMs?: number },
   ) => Promise<void>;
   waitGatewayAccountReady?: (accountId: string, opts?: { timeoutMs?: number }) => Promise<void>;
 };

--- a/extensions/qa-matrix/src/runners/contract/scenarios.test.ts
+++ b/extensions/qa-matrix/src/runners/contract/scenarios.test.ts
@@ -1815,6 +1815,7 @@ describe("matrix live qa scenarios", () => {
         },
       },
       {
+        replacePaths: ["channels.matrix.accounts.sut.groupAllowFrom"],
         restartDelayMs: MATRIX_QA_HOT_RELOAD_RESTART_DELAY_MS,
       },
     );

--- a/packages/gateway-protocol/src/schema/config.ts
+++ b/packages/gateway-protocol/src/schema/config.ts
@@ -37,22 +37,29 @@ export const ConfigSetParamsSchema = Type.Object(
 );
 
 /** Shared config apply/patch payload with optional restart notification context. */
-const ConfigApplyLikeParamsSchema = Type.Object(
-  {
-    raw: NonEmptyString,
-    baseHash: Type.Optional(NonEmptyString),
-    sessionKey: Type.Optional(Type.String()),
-    deliveryContext: Type.Optional(ConfigDeliveryContextSchema),
-    note: Type.Optional(Type.String()),
-    restartDelayMs: Type.Optional(Type.Integer({ minimum: 0 })),
-  },
-  { additionalProperties: false },
-);
+const ConfigApplyLikeParamProperties = {
+  raw: NonEmptyString,
+  baseHash: Type.Optional(NonEmptyString),
+  sessionKey: Type.Optional(Type.String()),
+  deliveryContext: Type.Optional(ConfigDeliveryContextSchema),
+  note: Type.Optional(Type.String()),
+  restartDelayMs: Type.Optional(Type.Integer({ minimum: 0 })),
+} as const;
+
+const ConfigApplyLikeParamsSchema = Type.Object(ConfigApplyLikeParamProperties, {
+  additionalProperties: false,
+});
 
 /** Raw config apply request that may schedule a restart. */
 export const ConfigApplyParamsSchema = ConfigApplyLikeParamsSchema;
 /** Raw config patch request that may schedule a restart. */
-export const ConfigPatchParamsSchema = ConfigApplyLikeParamsSchema;
+export const ConfigPatchParamsSchema = Type.Object(
+  {
+    ...ConfigApplyLikeParamProperties,
+    replacePaths: Type.Optional(Type.Array(NonEmptyString, { maxItems: 256 })),
+  },
+  { additionalProperties: false },
+);
 
 /** Empty request payload for fetching the generated config schema. */
 export const ConfigSchemaParamsSchema = Type.Object({}, { additionalProperties: false });

--- a/src/agents/openclaw-gateway-tool.test.ts
+++ b/src/agents/openclaw-gateway-tool.test.ts
@@ -111,6 +111,7 @@ function expectConfigMutationCall(params: {
   action: "config.apply" | "config.patch";
   raw: string;
   sessionKey: string;
+  replacePaths?: string[];
 }) {
   // Config writes must include the base hash from a preceding config.get read.
   expect(params.callGatewayTool.mock.calls.some(([method]) => method === "config.get")).toBe(true);
@@ -122,6 +123,7 @@ function expectConfigMutationCall(params: {
     raw: params.raw.trim(),
     baseHash: "hash-1",
     sessionKey: params.sessionKey,
+    ...(params.replacePaths ? { replacePaths: params.replacePaths } : {}),
   });
 }
 
@@ -319,6 +321,7 @@ describe("gateway tool", () => {
     const result = await tool.execute("call4", {
       action: "config.patch",
       raw,
+      replacePaths: ["channels.telegram.groups"],
     });
 
     expect(result.details).toEqual({
@@ -334,6 +337,7 @@ describe("gateway tool", () => {
       action: "config.patch",
       raw,
       sessionKey,
+      replacePaths: ["channels.telegram.groups"],
     });
   });
 
@@ -346,6 +350,36 @@ describe("gateway tool", () => {
         raw: '{ tools: { exec: { ask: "off" } } }',
       }),
     ).rejects.toThrow("gateway config.patch cannot change protected config paths: tools.exec.ask");
+    expectGatewayMethodCalled("config.get");
+    expectGatewayMethodNotCalled("config.patch");
+  });
+
+  it("normalizes replacePaths before config.patch policy checks", async () => {
+    vi.mocked(callGatewayTool).mockImplementationOnce(async (method: string) => {
+      if (method === "config.get") {
+        return {
+          hash: "hash-1",
+          config: {
+            agents: {
+              list: [
+                { id: "main", default: true, workspace: "/tmp/main" },
+                { id: "work", workspace: "/tmp/work" },
+              ],
+            },
+          },
+        };
+      }
+      return { ok: true };
+    });
+    const tool = requireGatewayTool();
+
+    await expect(
+      tool.execute("call-indexed-replace-path", {
+        action: "config.patch",
+        raw: '{ agents: { list: [{ id: "main", model: "openai/gpt-5.5" }] } }',
+        replacePaths: ["agents.list[0]"],
+      }),
+    ).rejects.toThrow("gateway config.patch cannot change protected config paths");
     expectGatewayMethodCalled("config.get");
     expectGatewayMethodNotCalled("config.patch");
   });

--- a/src/agents/tools/gateway-tool.test.ts
+++ b/src/agents/tools/gateway-tool.test.ts
@@ -149,11 +149,16 @@ describe("gateway tool restart continuation", () => {
     const parameters = tool.parameters as {
       properties?: {
         delayMs?: { minimum?: number; type?: string };
+        replacePaths?: { items?: { type?: string }; type?: string };
         restartDelayMs?: { minimum?: number; type?: string };
         timeoutMs?: { minimum?: number; type?: string };
       };
     };
     expect(parameters.properties?.delayMs).toMatchObject({ type: "integer", minimum: 0 });
+    expect(parameters.properties?.replacePaths).toMatchObject({
+      type: "array",
+      items: { type: "string" },
+    });
     expect(parameters.properties?.restartDelayMs).toMatchObject({ type: "integer", minimum: 0 });
     expect(parameters.properties?.timeoutMs).toMatchObject({ type: "integer", minimum: 1 });
   });
@@ -161,6 +166,7 @@ describe("gateway tool restart continuation", () => {
   it("instructs agents to use continuationMessage for internal post-restart work", async () => {
     const tool = createGatewayTool();
 
+    expect(tool.description).toContain("replacePaths");
     expect(tool.description).toContain("post-restart work must continue internally");
     expect(tool.description).toContain(
       "visible follow-up from that turn must use the message tool",

--- a/src/agents/tools/gateway-tool.ts
+++ b/src/agents/tools/gateway-tool.ts
@@ -13,6 +13,7 @@ import { Type } from "typebox";
 import { isRestartEnabled } from "../../config/commands.flags.js";
 import { parseConfigJson5, resolveConfigSnapshotHash } from "../../config/io.js";
 import { applyMergePatch } from "../../config/merge-patch.js";
+import { normalizeConfigPatchReplacePaths } from "../../config/patch-replace-paths.js";
 import { extractDeliveryInfo } from "../../config/sessions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { GatewayClientRequestError } from "../../gateway/client.js";
@@ -31,6 +32,7 @@ import {
   type AnyAgentTool,
   jsonResult,
   readNonNegativeIntegerParam,
+  readStringArrayParam,
   readStringParam,
 } from "./common.js";
 import { gatewayCallOptionSchemaProperties } from "./gateway-schema.js";
@@ -80,6 +82,7 @@ export function assertGatewayConfigMutationAllowedForTest(params: {
   action: "config.apply" | "config.patch";
   currentConfig: Record<string, unknown>;
   raw: string;
+  replacePaths?: string[];
 }): void {
   assertGatewayConfigMutationAllowed(params);
 }
@@ -312,6 +315,7 @@ function assertGatewayConfigMutationAllowed(params: {
   action: "config.apply" | "config.patch";
   currentConfig: Record<string, unknown>;
   raw: string;
+  replacePaths?: string[];
 }): void {
   const parsed = parseGatewayConfigMutationRaw(params.raw, params.action);
   const nextConfig =
@@ -319,6 +323,7 @@ function assertGatewayConfigMutationAllowed(params: {
       ? (parsed as Record<string, unknown>)
       : (applyMergePatch(params.currentConfig, parsed, {
           mergeObjectArraysById: true,
+          replaceArrayPaths: new Set(params.replacePaths ?? []),
         }) as Record<string, unknown>);
   const changedPaths = [...collectChangedConfigPaths(params.currentConfig, nextConfig)].toSorted();
   const disallowedPaths = changedPaths.filter((path) => !isAllowedGatewayConfigPath(path));
@@ -367,6 +372,7 @@ const GatewayToolSchema = Type.Object({
   // config.apply, config.patch
   raw: Type.Optional(Type.String()),
   baseHash: Type.Optional(Type.String()),
+  replacePaths: Type.Optional(Type.Array(Type.String(), { maxItems: 256 })),
   // config.apply, config.patch, update.run
   sessionKey: Type.Optional(Type.String()),
   note: Type.Optional(Type.String()),
@@ -385,7 +391,7 @@ export function createGatewayTool(opts?: {
     label: "Gateway",
     name: "gateway",
     description:
-      "Gateway restart/config/update. Before config edits, use config.schema.lookup with targeted dot path. Prefer config.patch for partial merge; config.apply only full replace. Writes hot-reload or restart as needed. Always pass human `note` for post-restart delivery. If post-restart work must continue internally, pass one-shot `continuationMessage`; visible follow-up from that turn must use the message tool. Do not write restart sentinel files directly.",
+      "Gateway restart/config/update. Before config edits, use config.schema.lookup with targeted dot path. Prefer config.patch for partial merge; config.apply only full replace. For config.patch that intentionally removes array entries, pass replacePaths with the exact affected array path. Writes hot-reload or restart as needed. Always pass human `note` for post-restart delivery. If post-restart work must continue internally, pass one-shot `continuationMessage`; visible follow-up from that turn must use the message tool. Do not write restart sentinel files directly.",
     parameters: GatewayToolSchema,
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;
@@ -469,8 +475,14 @@ export function createGatewayTool(opts?: {
         sessionKey: string | undefined;
         note: string | undefined;
         restartDelayMs: number | undefined;
+        replacePaths: string[] | undefined;
       }> => {
         const raw = readStringParam(params, "raw", { required: true });
+        const rawReplacePaths =
+          action === "config.patch" ? readStringArrayParam(params, "replacePaths") : undefined;
+        const replacePaths = rawReplacePaths
+          ? [...normalizeConfigPatchReplacePaths(rawReplacePaths)]
+          : undefined;
         const snapshot = await callGatewayTool("config.get", gatewayOpts, {});
         // Always fetch config.get so we can compare protected exec settings
         // against the current snapshot before forwarding any write RPC.
@@ -482,7 +494,7 @@ export function createGatewayTool(opts?: {
         if (!baseHash) {
           throw new Error("Missing baseHash from config snapshot.");
         }
-        return { raw, baseHash, snapshotConfig, ...resolveGatewayWriteMeta() };
+        return { raw, baseHash, snapshotConfig, replacePaths, ...resolveGatewayWriteMeta() };
       };
 
       if (action === "config.get") {
@@ -527,12 +539,13 @@ export function createGatewayTool(opts?: {
         return jsonResult({ ok: true, result: stripConfigWriteResultPayload(result) });
       }
       if (action === "config.patch") {
-        const { raw, baseHash, snapshotConfig, sessionKey, note, restartDelayMs } =
+        const { raw, baseHash, snapshotConfig, sessionKey, note, restartDelayMs, replacePaths } =
           await resolveConfigWriteParams();
         assertGatewayConfigMutationAllowed({
           action: "config.patch",
           currentConfig: snapshotConfig,
           raw,
+          replacePaths,
         });
         const result = await callGatewayTool("config.patch", gatewayOpts, {
           raw,
@@ -540,6 +553,7 @@ export function createGatewayTool(opts?: {
           sessionKey,
           note,
           restartDelayMs,
+          ...(replacePaths ? { replacePaths } : {}),
         });
         return jsonResult({ ok: true, result: stripConfigWriteResultPayload(result) });
       }

--- a/src/config/merge-patch.test.ts
+++ b/src/config/merge-patch.test.ts
@@ -53,6 +53,51 @@ describe("applyMergePatch", () => {
     expect(secondary?.workspace).toBe("/tmp/two");
   });
 
+  it("replaces object arrays by id when the array path is explicit", () => {
+    const { base, patch } = makeAgentListBaseAndPatch();
+
+    const merged = applyMergePatch(base, patch, {
+      mergeObjectArraysById: true,
+      replaceArrayPaths: new Set(["agents.list"]),
+    }) as {
+      agents?: {
+        list?: Array<{ id?: string; memorySearch?: { extraPaths?: string[] } }>;
+      };
+    };
+
+    expect(merged.agents?.list).toEqual([
+      { id: "primary", memorySearch: { extraPaths: ["/tmp/memory.md"] } },
+    ]);
+  });
+
+  it("replaces nested arrays in id-keyed entries when the nested path is explicit", () => {
+    const base = {
+      agents: {
+        list: [
+          { id: "primary", skills: ["a", "b"] },
+          { id: "secondary", skills: ["c"] },
+        ],
+      },
+    };
+    const patch = {
+      agents: {
+        list: [{ id: "primary", skills: ["a"] }],
+      },
+    };
+
+    const merged = applyMergePatch(base, patch, {
+      mergeObjectArraysById: true,
+      replaceArrayPaths: new Set(["agents.list[].skills"]),
+    }) as {
+      agents?: { list?: Array<{ id?: string; skills?: string[] }> };
+    };
+
+    expect(merged.agents?.list).toEqual([
+      { id: "primary", skills: ["a"] },
+      { id: "secondary", skills: ["c"] },
+    ]);
+  });
+
   it("merges by id even when patch entries lack id (appends them)", () => {
     const base = {
       agents: {

--- a/src/config/merge-patch.ts
+++ b/src/config/merge-patch.ts
@@ -6,6 +6,8 @@ type PlainObject = Record<string, unknown>;
 
 type MergePatchOptions = {
   mergeObjectArraysById?: boolean;
+  replaceArrayPaths?: ReadonlySet<string>;
+  path?: string;
 };
 
 function isObjectWithStringId(value: unknown): value is Record<string, unknown> & { id: string } {
@@ -13,6 +15,14 @@ function isObjectWithStringId(value: unknown): value is Record<string, unknown> 
     return false;
   }
   return typeof value.id === "string" && value.id.length > 0;
+}
+
+function formatMergePatchPath(parentPath: string | undefined, key: string): string {
+  return parentPath ? `${parentPath}.${key}` : key;
+}
+
+function formatMergePatchArrayEntryPath(arrayPath: string): string {
+  return `${arrayPath}[]`;
 }
 
 /**
@@ -27,6 +37,7 @@ function mergeObjectArraysById(
   base: unknown[],
   patch: unknown[],
   options: MergePatchOptions,
+  arrayPath: string,
 ): unknown[] | undefined {
   if (!base.every(isObjectWithStringId)) {
     return undefined;
@@ -54,7 +65,10 @@ function mergeObjectArraysById(
       continue;
     }
 
-    merged[existingIndex] = applyMergePatch(merged[existingIndex], patchEntry, options);
+    merged[existingIndex] = applyMergePatch(merged[existingIndex], patchEntry, {
+      ...options,
+      path: formatMergePatchArrayEntryPath(arrayPath),
+    });
   }
 
   return merged;
@@ -81,13 +95,18 @@ export function applyMergePatch(
     if (isBlockedObjectKey(key)) {
       continue;
     }
+    const path = formatMergePatchPath(options.path, key);
     if (value === null) {
       delete result[key];
       continue;
     }
     if (options.mergeObjectArraysById && Array.isArray(result[key]) && Array.isArray(value)) {
+      if (options.replaceArrayPaths?.has(path)) {
+        result[key] = value;
+        continue;
+      }
       // Config arrays like agents/plugins can patch by id; non-id arrays keep RFC replacement.
-      const mergedArray = mergeObjectArraysById(result[key] as unknown[], value, options);
+      const mergedArray = mergeObjectArraysById(result[key] as unknown[], value, options, path);
       if (mergedArray) {
         result[key] = mergedArray;
         continue;
@@ -95,7 +114,10 @@ export function applyMergePatch(
     }
     if (isPlainObject(value)) {
       const baseValue = result[key];
-      result[key] = applyMergePatch(isPlainObject(baseValue) ? baseValue : {}, value, options);
+      result[key] = applyMergePatch(isPlainObject(baseValue) ? baseValue : {}, value, {
+        ...options,
+        path,
+      });
       continue;
     }
     result[key] = value;

--- a/src/config/patch-replace-paths.ts
+++ b/src/config/patch-replace-paths.ts
@@ -1,0 +1,19 @@
+// Normalizes config.patch replacePaths shared by Gateway and agent preflight checks.
+export function normalizeConfigPatchReplacePath(value: string): string {
+  const normalized = value.trim().replace(/\[(?:\d*)\]/g, "[]");
+  return normalized.endsWith("[]") ? normalized.slice(0, -2) : normalized;
+}
+
+export function normalizeConfigPatchReplacePaths(
+  values: readonly unknown[] | undefined,
+): Set<string> {
+  if (!values) {
+    return new Set();
+  }
+  return new Set(
+    values
+      .filter((value): value is string => typeof value === "string")
+      .map(normalizeConfigPatchReplacePath)
+      .filter((value) => value.length > 0),
+  );
+}

--- a/src/gateway/server-methods/config.shared-auth.test.ts
+++ b/src/gateway/server-methods/config.shared-auth.test.ts
@@ -149,7 +149,7 @@ function mockPreviousConfig(config: OpenClawConfig): void {
 
 async function runConfigPatch(
   raw: unknown,
-  params: { sessionKey?: string; restartDelayMs?: number } = {},
+  params: { sessionKey?: string; restartDelayMs?: number; replacePaths?: string[] } = {},
 ) {
   const { options, disconnectClientsUsingSharedGatewayAuth } = createConfigHandlerHarness({
     method: "config.patch",
@@ -158,6 +158,7 @@ async function runConfigPatch(
       raw: typeof raw === "string" ? raw : JSON.stringify(raw),
       restartDelayMs: params.restartDelayMs ?? 1_000,
       ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
+      ...(params.replacePaths ? { replacePaths: params.replacePaths } : {}),
     },
   });
 
@@ -284,16 +285,19 @@ describe("config shared auth disconnects", () => {
       }),
     );
 
-    const { disconnectClientsUsingSharedGatewayAuth } = await runConfigPatch({
-      gateway: {
-        auth: {
-          trustedProxy: {
-            userHeader: "x-forwarded-user",
-            allowUsers: ["bob@example.com"],
+    const { disconnectClientsUsingSharedGatewayAuth } = await runConfigPatch(
+      {
+        gateway: {
+          auth: {
+            trustedProxy: {
+              userHeader: "x-forwarded-user",
+              allowUsers: ["bob@example.com"],
+            },
           },
         },
       },
-    });
+      { replacePaths: ["gateway.auth.trustedProxy.allowUsers"] },
+    );
 
     expectNoDirectRestart();
     expect(disconnectClientsUsingSharedGatewayAuth).toHaveBeenCalledTimes(1);
@@ -306,11 +310,14 @@ describe("config shared auth disconnects", () => {
       }),
     );
 
-    const { disconnectClientsUsingSharedGatewayAuth } = await runConfigPatch({
-      gateway: {
-        trustedProxies: ["10.0.0.10"],
+    const { disconnectClientsUsingSharedGatewayAuth } = await runConfigPatch(
+      {
+        gateway: {
+          trustedProxies: ["10.0.0.10"],
+        },
       },
-    });
+      { replacePaths: ["gateway.trustedProxies"] },
+    );
 
     expectNoDirectRestart();
     expect(disconnectClientsUsingSharedGatewayAuth).toHaveBeenCalledTimes(1);

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -1,6 +1,7 @@
 // Config gateway methods expose config get/set/patch/apply/schema operations
 // with validation, redaction restoration, secret prep, and reload planning.
 import { execFile } from "node:child_process";
+import { isDeepStrictEqual } from "node:util";
 import {
   asDateTimestampMs,
   resolveExpiresAtMsFromDurationMs,
@@ -29,6 +30,7 @@ import {
 import { createMergePatch, projectSourceOntoRuntimeShape } from "../../config/io.write-prepare.js";
 import { formatConfigIssueLines } from "../../config/issue-format.js";
 import { applyMergePatch } from "../../config/merge-patch.js";
+import { normalizeConfigPatchReplacePaths } from "../../config/patch-replace-paths.js";
 import {
   redactConfigObject,
   redactConfigSnapshot,
@@ -43,6 +45,8 @@ import {
 } from "../../config/validation.js";
 import { isBuiltInModelProviderOverlayId } from "../../config/zod-schema.core.js";
 import { formatErrorMessage, toErrorObject } from "../../infra/errors.js";
+import { isPlainObject } from "../../infra/plain-object.js";
+import { isBlockedObjectKey } from "../../infra/prototype-keys.js";
 import {
   prepareSecretsRuntimeSnapshot,
   type PreparedSecretsRuntimeSnapshot,
@@ -125,6 +129,194 @@ function requireConfigBaseHash(
     );
     return false;
   }
+  return true;
+}
+
+function formatConfigPatchPath(parentPath: string, key: string): string {
+  return parentPath ? `${parentPath}.${key}` : key;
+}
+
+function readConfigPatchReplacePaths(params: unknown): Set<string> {
+  const rawPaths = (params as { replacePaths?: unknown }).replacePaths;
+  return normalizeConfigPatchReplacePaths(Array.isArray(rawPaths) ? rawPaths : undefined);
+}
+
+function collectDestructiveArrayPatchPaths(params: {
+  base: unknown;
+  patch: unknown;
+  merged: unknown;
+  path?: string;
+}): string[] {
+  if (!isPlainObject(params.patch) || !isPlainObject(params.base)) {
+    return [];
+  }
+
+  const merged = isPlainObject(params.merged) ? params.merged : {};
+  const paths: string[] = [];
+  for (const [key, patchValue] of Object.entries(params.patch)) {
+    if (isBlockedObjectKey(key)) {
+      continue;
+    }
+    const path = formatConfigPatchPath(params.path ?? "", key);
+    const baseValue = params.base[key];
+    const mergedValue = merged[key];
+
+    if (Array.isArray(baseValue)) {
+      if (patchValue === null || !Array.isArray(patchValue)) {
+        paths.push(path);
+        continue;
+      }
+      if (Array.isArray(mergedValue)) {
+        if (isConfigPatchIdKeyedArray(baseValue)) {
+          if (!idKeyedArrayPreservesBaseIds(baseValue, mergedValue)) {
+            paths.push(path);
+            continue;
+          }
+          paths.push(
+            ...collectDestructiveIdKeyedArrayEntryPatchPaths({
+              base: baseValue,
+              patch: patchValue,
+              merged: mergedValue,
+              path,
+            }),
+          );
+        } else if (!arrayPreservesBaseEntries(baseValue, mergedValue)) {
+          paths.push(path);
+          continue;
+        }
+      }
+    } else if (isPlainObject(baseValue) && !isPlainObject(patchValue)) {
+      paths.push(...collectBaseArrayPaths(baseValue, path));
+      continue;
+    }
+
+    if (isPlainObject(patchValue)) {
+      paths.push(
+        ...collectDestructiveArrayPatchPaths({
+          base: baseValue,
+          patch: patchValue,
+          merged: mergedValue,
+          path,
+        }),
+      );
+    }
+  }
+  return paths;
+}
+
+function collectBaseArrayPaths(base: unknown, path: string): string[] {
+  if (Array.isArray(base)) {
+    return [path];
+  }
+  if (!isPlainObject(base)) {
+    return [];
+  }
+  const paths: string[] = [];
+  for (const [key, value] of Object.entries(base)) {
+    if (isBlockedObjectKey(key)) {
+      continue;
+    }
+    paths.push(...collectBaseArrayPaths(value, formatConfigPatchPath(path, key)));
+  }
+  return paths;
+}
+
+function isConfigPatchObjectWithStringId(
+  value: unknown,
+): value is Record<string, unknown> & { id: string } {
+  return isPlainObject(value) && typeof value.id === "string" && value.id.length > 0;
+}
+
+function isConfigPatchIdKeyedArray(
+  value: unknown[],
+): value is Array<Record<string, unknown> & { id: string }> {
+  return value.every(isConfigPatchObjectWithStringId);
+}
+
+function idKeyedArrayPreservesBaseIds(
+  base: Array<Record<string, unknown> & { id: string }>,
+  merged: unknown[],
+): boolean {
+  const mergedIds = new Set(
+    merged.filter(isConfigPatchObjectWithStringId).map((entry) => entry.id),
+  );
+  return base.every((entry) => mergedIds.has(entry.id));
+}
+
+function arrayPreservesBaseEntries(base: unknown[], merged: unknown[]): boolean {
+  const unmatchedMerged = [...merged];
+  for (const baseEntry of base) {
+    const matchIndex = unmatchedMerged.findIndex((mergedEntry) =>
+      isDeepStrictEqual(mergedEntry, baseEntry),
+    );
+    if (matchIndex === -1) {
+      return false;
+    }
+    unmatchedMerged.splice(matchIndex, 1);
+  }
+  return true;
+}
+
+function collectDestructiveIdKeyedArrayEntryPatchPaths(params: {
+  base: unknown[];
+  patch: unknown[];
+  merged: unknown[];
+  path: string;
+}): string[] {
+  if (!isConfigPatchIdKeyedArray(params.base)) {
+    return [];
+  }
+  const baseById = new Map(params.base.map((entry) => [entry.id, entry]));
+  const mergedById = new Map(
+    params.merged.filter(isConfigPatchObjectWithStringId).map((entry) => [entry.id, entry]),
+  );
+  const paths: string[] = [];
+  for (const patchEntry of params.patch) {
+    if (!isConfigPatchObjectWithStringId(patchEntry)) {
+      continue;
+    }
+    const baseEntry = baseById.get(patchEntry.id);
+    const mergedEntry = mergedById.get(patchEntry.id);
+    if (!baseEntry || !mergedEntry) {
+      continue;
+    }
+    paths.push(
+      ...collectDestructiveArrayPatchPaths({
+        base: baseEntry,
+        patch: patchEntry,
+        merged: mergedEntry,
+        path: `${params.path}[]`,
+      }),
+    );
+  }
+  return paths;
+}
+
+function rejectDestructiveArrayPatchWithoutIntent(params: {
+  currentConfig: OpenClawConfig;
+  mergedConfig: unknown;
+  patch: unknown;
+  replacePaths: Set<string>;
+  respond: RespondFn;
+}): boolean {
+  const destructivePaths = collectDestructiveArrayPatchPaths({
+    base: params.currentConfig,
+    patch: params.patch,
+    merged: params.mergedConfig,
+  });
+  const unconfirmedPaths = destructivePaths.filter((path) => !params.replacePaths.has(path));
+  if (unconfirmedPaths.length === 0) {
+    return false;
+  }
+  params.respond(
+    false,
+    undefined,
+    errorShape(
+      ErrorCodes.INVALID_REQUEST,
+      `config.patch would remove entries from array path(s): ${unconfirmedPaths.join(", ")}. ` +
+        `Pass replacePaths with the exact path(s) when this is intentional, or use config.apply for full-config replacement.`,
+    ),
+  );
   return true;
 }
 
@@ -624,9 +816,11 @@ export const configHandlers: GatewayRequestHandlers = {
       );
       return;
     }
+    const replacePaths = readConfigPatchReplacePaths(params);
     const merged = applyMergePatch(snapshot.config, parsedRes.parsed, {
       // Arrays with stable ids behave like maps for partial control-plane edits.
       mergeObjectArraysById: true,
+      replaceArrayPaths: replacePaths,
     });
     const schemaPatch = loadSchemaWithPlugins();
     const restoredMerge = restoreRedactedValues(merged, snapshot.config, schemaPatch.uiHints);
@@ -639,6 +833,17 @@ export const configHandlers: GatewayRequestHandlers = {
           restoredMerge.humanReadableMessage ?? "invalid config",
         ),
       );
+      return;
+    }
+    if (
+      rejectDestructiveArrayPatchWithoutIntent({
+        currentConfig: snapshot.config,
+        mergedConfig: restoredMerge.result,
+        patch: parsedRes.parsed,
+        replacePaths,
+        respond,
+      })
+    ) {
       return;
     }
     const restoredChangedPaths = diffConfigPaths(snapshot.config, restoredMerge.result);

--- a/src/gateway/server.config-patch.test.ts
+++ b/src/gateway/server.config-patch.test.ts
@@ -107,15 +107,41 @@ async function getCurrentConfigObject() {
   const current = await rpcReq<{
     raw?: string | null;
     hash?: string;
+    path?: string;
     config?: Record<string, unknown>;
   }>(requireWs(), "config.get", {});
   expect(current.ok).toBe(true);
   expect(typeof current.payload?.hash).toBe("string");
+  expect(typeof current.payload?.path).toBe("string");
   return {
     hash: String(current.payload?.hash),
+    path: String(current.payload?.path),
     raw: current.payload?.raw,
     config: requireConfigObject(current.payload?.config, "current config"),
   };
+}
+
+async function restoreConfigFileForTest(
+  original: Awaited<ReturnType<typeof getCurrentConfigObject>>,
+) {
+  await writeJsonFile(original.path, original.config);
+}
+
+function makeRouteBinding(index: number) {
+  return {
+    agentId: "main",
+    match: {
+      channel: "telegram",
+      peer: {
+        kind: "direct",
+        id: `user-${index}`,
+      },
+    },
+  };
+}
+
+function makeAgentEntry(id: string, extra: Record<string, unknown> = {}) {
+  return { id, ...extra };
 }
 
 async function expectSchemaLookupInvalid(pathValue: unknown) {
@@ -433,6 +459,352 @@ describe("gateway config methods", () => {
     });
     expect(res.ok).toBe(false);
     expect(res.error?.message ?? "").toContain("raw must be an object");
+  });
+
+  it("rejects config.patch that shrinks an existing array without replacePaths", async () => {
+    const original = await getCurrentConfigObject();
+    const bindings = [0, 1, 2].map(makeRouteBinding);
+    const seededConfig = { ...original.config, bindings };
+    const seed = await sendConfigApply(configRawPayload(seededConfig, original.hash));
+    expect(seed.ok).toBe(true);
+
+    try {
+      const before = await getCurrentConfigObject();
+      const res = await rpcReq<{ ok?: boolean }>(requireWs(), "config.patch", {
+        raw: JSON.stringify({ bindings: [bindings[0]] }),
+        baseHash: before.hash,
+      });
+
+      expect(res.ok).toBe(false);
+      expect(res.error?.message ?? "").toContain(
+        "config.patch would remove entries from array path(s): bindings",
+      );
+      const after = await getCurrentConfigObject();
+      expect(after.hash).toBe(before.hash);
+      expect(after.config.bindings).toEqual(bindings);
+    } finally {
+      await restoreConfigFileForTest(original);
+    }
+  });
+
+  it("rejects config.patch that removes existing array entries without shrinking length", async () => {
+    const original = await getCurrentConfigObject();
+    const bindings = [0, 1].map(makeRouteBinding);
+    const seededConfig = { ...original.config, bindings };
+    const seed = await sendConfigApply(configRawPayload(seededConfig, original.hash));
+    expect(seed.ok).toBe(true);
+
+    try {
+      const before = await getCurrentConfigObject();
+      const res = await rpcReq<{ ok?: boolean }>(requireWs(), "config.patch", {
+        raw: JSON.stringify({ bindings: [bindings[1], makeRouteBinding(2)] }),
+        baseHash: before.hash,
+      });
+
+      expect(res.ok).toBe(false);
+      expect(res.error?.message ?? "").toContain(
+        "config.patch would remove entries from array path(s): bindings",
+      );
+      const after = await getCurrentConfigObject();
+      expect(after.hash).toBe(before.hash);
+      expect(after.config.bindings).toEqual(bindings);
+    } finally {
+      await restoreConfigFileForTest(original);
+    }
+  });
+
+  it("allows config.patch to append array entries without replacePaths", async () => {
+    const original = await getCurrentConfigObject();
+    const bindings = [0, 1].map(makeRouteBinding);
+    const seededConfig = { ...original.config, bindings };
+    const seed = await sendConfigApply(configRawPayload(seededConfig, original.hash));
+    expect(seed.ok).toBe(true);
+
+    try {
+      const before = await getCurrentConfigObject();
+      const nextBindings = [...bindings, makeRouteBinding(2)];
+      const res = await rpcReq<{ ok?: boolean }>(requireWs(), "config.patch", {
+        raw: JSON.stringify({ bindings: nextBindings }),
+        baseHash: before.hash,
+      });
+
+      expect(res.ok).toBe(true);
+      const after = await getCurrentConfigObject();
+      expect(after.config.bindings).toEqual(nextBindings);
+    } finally {
+      await restoreConfigFileForTest(original);
+    }
+  });
+
+  it("allows config.patch to shrink an existing array with replacePaths", async () => {
+    const original = await getCurrentConfigObject();
+    const bindings = [0, 1, 2].map(makeRouteBinding);
+    const seededConfig = { ...original.config, bindings };
+    const seed = await sendConfigApply(configRawPayload(seededConfig, original.hash));
+    expect(seed.ok).toBe(true);
+
+    try {
+      const before = await getCurrentConfigObject();
+      const replacement = [bindings[0]];
+      const res = await rpcReq<{ ok?: boolean }>(requireWs(), "config.patch", {
+        raw: JSON.stringify({ bindings: replacement }),
+        baseHash: before.hash,
+        replacePaths: ["bindings"],
+      });
+
+      expect(res.ok).toBe(true);
+      const after = await getCurrentConfigObject();
+      expect(after.config.bindings).toEqual(replacement);
+    } finally {
+      await restoreConfigFileForTest(original);
+    }
+  });
+
+  it("accepts exact numeric record keys in replacePaths", async () => {
+    const original = await getCurrentConfigObject();
+    const channels =
+      original.config.channels &&
+      typeof original.config.channels === "object" &&
+      !Array.isArray(original.config.channels)
+        ? (original.config.channels as Record<string, unknown>)
+        : {};
+    const discord = {
+      ...(channels.discord as Record<string, unknown> | undefined),
+      allowFrom: ["*"],
+      guilds: {
+        "123": {
+          channels: {
+            general: {
+              users: ["111", "222"],
+            },
+          },
+        },
+      },
+    };
+    const seed = await sendConfigApply(
+      configRawPayload({ ...original.config, channels: { ...channels, discord } }, original.hash),
+    );
+    expect(seed.ok).toBe(true);
+
+    try {
+      const before = await getCurrentConfigObject();
+      const res = await rpcReq<{ ok?: boolean }>(requireWs(), "config.patch", {
+        raw: JSON.stringify({
+          channels: {
+            discord: {
+              guilds: { "123": { channels: { general: { users: ["111"] } } } },
+            },
+          },
+        }),
+        baseHash: before.hash,
+        replacePaths: ["channels.discord.guilds.123.channels.general.users"],
+      });
+
+      expect(res.ok).toBe(true);
+      const after = await getCurrentConfigObject();
+      const afterChannels = requireConfigObject(after.config.channels, "channels");
+      expect(
+        (
+          afterChannels.discord as {
+            guilds?: { "123"?: { channels?: { general?: { users?: unknown[] } } } };
+          }
+        ).guilds?.["123"]?.channels?.general?.users,
+      ).toEqual(["111"]);
+    } finally {
+      await restoreConfigFileForTest(original);
+    }
+  });
+
+  it("uses replacePaths to replace id-keyed arrays instead of merging by id", async () => {
+    const original = await getCurrentConfigObject();
+    const agents = {
+      ...(original.config.agents as Record<string, unknown> | undefined),
+      list: [makeAgentEntry("main", { default: true }), makeAgentEntry("worker")],
+    };
+    const seed = await sendConfigApply(
+      configRawPayload({ ...original.config, agents }, original.hash),
+    );
+    expect(seed.ok).toBe(true);
+
+    try {
+      const before = await getCurrentConfigObject();
+      const replacement = [makeAgentEntry("main", { default: true })];
+      const res = await rpcReq<{ ok?: boolean }>(requireWs(), "config.patch", {
+        raw: JSON.stringify({ agents: { list: replacement } }),
+        baseHash: before.hash,
+        replacePaths: ["agents.list"],
+      });
+
+      expect(res.ok).toBe(true);
+      const after = await getCurrentConfigObject();
+      expect((after.config.agents as { list?: unknown[] }).list).toEqual(replacement);
+    } finally {
+      await restoreConfigFileForTest(original);
+    }
+  });
+
+  it("rejects nested destructive array patches inside id-keyed arrays without replacePaths", async () => {
+    const original = await getCurrentConfigObject();
+    const agents = {
+      ...(original.config.agents as Record<string, unknown> | undefined),
+      list: [
+        makeAgentEntry("main", { default: true, skills: ["alpha", "beta"] }),
+        makeAgentEntry("worker", { skills: ["gamma"] }),
+      ],
+    };
+    const seed = await sendConfigApply(
+      configRawPayload({ ...original.config, agents }, original.hash),
+    );
+    expect(seed.ok).toBe(true);
+
+    try {
+      const before = await getCurrentConfigObject();
+      const res = await rpcReq<{ ok?: boolean }>(requireWs(), "config.patch", {
+        raw: JSON.stringify({ agents: { list: [{ id: "main", skills: ["alpha"] }] } }),
+        baseHash: before.hash,
+      });
+
+      expect(res.ok).toBe(false);
+      expect(res.error?.message ?? "").toContain(
+        "config.patch would remove entries from array path(s): agents.list[].skills",
+      );
+      const after = await getCurrentConfigObject();
+      expect(after.hash).toBe(before.hash);
+      expect((after.config.agents as { list?: unknown[] }).list).toEqual(agents.list);
+    } finally {
+      await restoreConfigFileForTest(original);
+    }
+  });
+
+  it("rejects nested destructive array patches when replacePaths names only a parent object", async () => {
+    const original = await getCurrentConfigObject();
+    const agents = {
+      ...(original.config.agents as Record<string, unknown> | undefined),
+      list: [
+        makeAgentEntry("main", { default: true, skills: ["alpha", "beta"] }),
+        makeAgentEntry("worker", { skills: ["gamma"] }),
+      ],
+    };
+    const seed = await sendConfigApply(
+      configRawPayload({ ...original.config, agents }, original.hash),
+    );
+    expect(seed.ok).toBe(true);
+
+    try {
+      const before = await getCurrentConfigObject();
+      const res = await rpcReq<{ ok?: boolean }>(requireWs(), "config.patch", {
+        raw: JSON.stringify({ agents: { list: [{ id: "main", skills: ["alpha"] }] } }),
+        baseHash: before.hash,
+        replacePaths: ["agents"],
+      });
+
+      expect(res.ok).toBe(false);
+      expect(res.error?.message ?? "").toContain(
+        "config.patch would remove entries from array path(s): agents.list[].skills",
+      );
+      const after = await getCurrentConfigObject();
+      expect(after.hash).toBe(before.hash);
+      expect((after.config.agents as { list?: unknown[] }).list).toEqual(agents.list);
+    } finally {
+      await restoreConfigFileForTest(original);
+    }
+  });
+
+  it("rejects deleting a parent object that contains arrays without replacePaths", async () => {
+    const original = await getCurrentConfigObject();
+    const agents = {
+      ...(original.config.agents as Record<string, unknown> | undefined),
+      list: [makeAgentEntry("main", { default: true }), makeAgentEntry("worker")],
+    };
+    const seed = await sendConfigApply(
+      configRawPayload({ ...original.config, agents }, original.hash),
+    );
+    expect(seed.ok).toBe(true);
+
+    try {
+      const before = await getCurrentConfigObject();
+      const res = await rpcReq<{ ok?: boolean }>(requireWs(), "config.patch", {
+        raw: JSON.stringify({ agents: null }),
+        baseHash: before.hash,
+      });
+
+      expect(res.ok).toBe(false);
+      expect(res.error?.message ?? "").toContain(
+        "config.patch would remove entries from array path(s): agents.list",
+      );
+      const after = await getCurrentConfigObject();
+      expect(after.hash).toBe(before.hash);
+    } finally {
+      await restoreConfigFileForTest(original);
+    }
+  });
+
+  it("rejects deleting a nested parent object inside id-keyed arrays without replacePaths", async () => {
+    const original = await getCurrentConfigObject();
+    const agents = {
+      ...(original.config.agents as Record<string, unknown> | undefined),
+      list: [
+        makeAgentEntry("main", {
+          default: true,
+          subagents: { allowAgents: ["worker"] },
+        }),
+        makeAgentEntry("worker"),
+      ],
+    };
+    const seed = await sendConfigApply(
+      configRawPayload({ ...original.config, agents }, original.hash),
+    );
+    expect(seed.ok).toBe(true);
+
+    try {
+      const before = await getCurrentConfigObject();
+      const res = await rpcReq<{ ok?: boolean }>(requireWs(), "config.patch", {
+        raw: JSON.stringify({ agents: { list: [{ id: "main", subagents: null }] } }),
+        baseHash: before.hash,
+      });
+
+      expect(res.ok).toBe(false);
+      expect(res.error?.message ?? "").toContain(
+        "config.patch would remove entries from array path(s): agents.list[].subagents.allowAgents",
+      );
+      const after = await getCurrentConfigObject();
+      expect(after.hash).toBe(before.hash);
+    } finally {
+      await restoreConfigFileForTest(original);
+    }
+  });
+
+  it("allows nested destructive array patches inside id-keyed arrays with replacePaths", async () => {
+    const original = await getCurrentConfigObject();
+    const agents = {
+      ...(original.config.agents as Record<string, unknown> | undefined),
+      list: [
+        makeAgentEntry("main", { default: true, skills: ["alpha", "beta"] }),
+        makeAgentEntry("worker", { skills: ["gamma"] }),
+      ],
+    };
+    const seed = await sendConfigApply(
+      configRawPayload({ ...original.config, agents }, original.hash),
+    );
+    expect(seed.ok).toBe(true);
+
+    try {
+      const before = await getCurrentConfigObject();
+      const res = await rpcReq<{ ok?: boolean }>(requireWs(), "config.patch", {
+        raw: JSON.stringify({ agents: { list: [{ id: "main", skills: ["alpha"] }] } }),
+        baseHash: before.hash,
+        replacePaths: ["agents.list[].skills"],
+      });
+
+      expect(res.ok).toBe(true);
+      const after = await getCurrentConfigObject();
+      expect((after.config.agents as { list?: unknown[] }).list).toEqual([
+        makeAgentEntry("main", { default: true, skills: ["alpha"] }),
+        makeAgentEntry("worker", { skills: ["gamma"] }),
+      ]);
+    } finally {
+      await restoreConfigFileForTest(original);
+    }
   });
 
   it("rejects config.patch when merged SecretRefs cannot resolve", async () => {

--- a/src/gateway/server.config-patch.test.ts
+++ b/src/gateway/server.config-patch.test.ts
@@ -31,14 +31,11 @@ function requireWs(): Awaited<ReturnType<typeof startServerWithClient>>["ws"] {
   return startedServer.ws;
 }
 
-function requireConfigObject(
-  value: Record<string, unknown> | undefined,
-  label: string,
-): Record<string, unknown> {
+function requireConfigObject(value: unknown, label: string): Record<string, unknown> {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     throw new Error(`expected ${label}`);
   }
-  return value;
+  return value as Record<string, unknown>;
 }
 
 beforeAll(async () => {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
@@ -910,7 +910,7 @@
   },
   {
     "deferLoading": true,
-    "description": "Gateway restart/config/update. Before config edits, use config.schema.lookup with targeted dot path. Prefer config.patch for partial merge; config.apply only full replace. Writes hot-reload or restart as needed. Always pass human `note` for post-restart delivery. If post-restart work must continue internally, pass one-shot `continuationMessage`; visible follow-up from that turn must use the message tool. Do not write restart sentinel files directly.",
+    "description": "Gateway restart/config/update. Before config edits, use config.schema.lookup with targeted dot path. Prefer config.patch for partial merge; config.apply only full replace. For config.patch that intentionally removes array entries, pass replacePaths with the exact affected array path. Writes hot-reload or restart as needed. Always pass human `note` for post-restart delivery. If post-restart work must continue internally, pass one-shot `continuationMessage`; visible follow-up from that turn must use the message tool. Do not write restart sentinel files directly.",
     "inputSchema": {
       "properties": {
         "action": {
@@ -951,6 +951,13 @@
         },
         "reason": {
           "type": "string"
+        },
+        "replacePaths": {
+          "items": {
+            "type": "string"
+          },
+          "maxItems": 256,
+          "type": "array"
         },
         "restartDelayMs": {
           "minimum": 0,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
@@ -946,7 +946,7 @@
   },
   {
     "deferLoading": true,
-    "description": "Gateway restart/config/update. Before config edits, use config.schema.lookup with targeted dot path. Prefer config.patch for partial merge; config.apply only full replace. Writes hot-reload or restart as needed. Always pass human `note` for post-restart delivery. If post-restart work must continue internally, pass one-shot `continuationMessage`; visible follow-up from that turn must use the message tool. Do not write restart sentinel files directly.",
+    "description": "Gateway restart/config/update. Before config edits, use config.schema.lookup with targeted dot path. Prefer config.patch for partial merge; config.apply only full replace. For config.patch that intentionally removes array entries, pass replacePaths with the exact affected array path. Writes hot-reload or restart as needed. Always pass human `note` for post-restart delivery. If post-restart work must continue internally, pass one-shot `continuationMessage`; visible follow-up from that turn must use the message tool. Do not write restart sentinel files directly.",
     "inputSchema": {
       "properties": {
         "action": {
@@ -987,6 +987,13 @@
         },
         "reason": {
           "type": "string"
+        },
+        "replacePaths": {
+          "items": {
+            "type": "string"
+          },
+          "maxItems": 256,
+          "type": "array"
         },
         "restartDelayMs": {
           "minimum": 0,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
@@ -910,7 +910,7 @@
   },
   {
     "deferLoading": true,
-    "description": "Gateway restart/config/update. Before config edits, use config.schema.lookup with targeted dot path. Prefer config.patch for partial merge; config.apply only full replace. Writes hot-reload or restart as needed. Always pass human `note` for post-restart delivery. If post-restart work must continue internally, pass one-shot `continuationMessage`; visible follow-up from that turn must use the message tool. Do not write restart sentinel files directly.",
+    "description": "Gateway restart/config/update. Before config edits, use config.schema.lookup with targeted dot path. Prefer config.patch for partial merge; config.apply only full replace. For config.patch that intentionally removes array entries, pass replacePaths with the exact affected array path. Writes hot-reload or restart as needed. Always pass human `note` for post-restart delivery. If post-restart work must continue internally, pass one-shot `continuationMessage`; visible follow-up from that turn must use the message tool. Do not write restart sentinel files directly.",
     "inputSchema": {
       "properties": {
         "action": {
@@ -951,6 +951,13 @@
         },
         "reason": {
           "type": "string"
+        },
+        "replacePaths": {
+          "items": {
+            "type": "string"
+          },
+          "maxItems": 256,
+          "type": "array"
         },
         "restartDelayMs": {
           "minimum": 0,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
@@ -223,8 +223,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 44140,
-    "roughTokens": 11035
+    "chars": 44406,
+    "roughTokens": 11102
   },
   "openClawDeveloperInstructions": {
     "chars": 2988,
@@ -235,8 +235,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6925
   },
   "totalWithDynamicToolsJson": {
-    "chars": 71842,
-    "roughTokens": 17961
+    "chars": 72108,
+    "roughTokens": 18027
   },
   "userInputText": {
     "chars": 1629,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -223,8 +223,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 43861,
-    "roughTokens": 10966
+    "chars": 44127,
+    "roughTokens": 11032
   },
   "openClawDeveloperInstructions": {
     "chars": 1964,
@@ -235,8 +235,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6544
   },
   "totalWithDynamicToolsJson": {
-    "chars": 70039,
-    "roughTokens": 17510
+    "chars": 70305,
+    "roughTokens": 17577
   },
   "userInputText": {
     "chars": 1129,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -224,8 +224,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 44956,
-    "roughTokens": 11239
+    "chars": 45222,
+    "roughTokens": 11306
   },
   "openClawDeveloperInstructions": {
     "chars": 1983,
@@ -236,8 +236,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6780
   },
   "totalWithDynamicToolsJson": {
-    "chars": 72077,
-    "roughTokens": 18020
+    "chars": 72343,
+    "roughTokens": 18086
   },
   "userInputText": {
     "chars": 1367,


### PR DESCRIPTION
## Summary

- Add an explicit `replacePaths` contract for destructive `config.patch` array replacement.
- Reject unconfirmed `config.patch` payloads that would remove existing array entries, including nested arrays under id-keyed config arrays.
- Update Gateway agent tool preflight, Matrix QA, iOS skill editing, protocol schema, docs, and focused regression coverage.

Refs #90540

## Verification

- `.agents/skills/autoreview/scripts/autoreview --mode local`
  - `autoreview clean: no accepted/actionable findings reported`
- AWS Crabbox live Gateway/WebSocket/disk proof: `run_c11f1f03de06`, provider `aws`, lease `cbx_baaa409355ec`, machine `c7a.8xlarge`, exit `0`
  - Regression repro: old truncated `config.patch` attempt from 82 bindings to 2 was rejected; disk remained at 82 and hash stayed unchanged.
  - Fix proof: same replacement with `replacePaths: ["bindings"]` succeeded and disk moved to 2 entries intentionally.
- AWS Crabbox focused regression lanes passed in the same run:
  - `src/gateway/server.config-patch.test.ts`
  - `src/agents/tools/gateway-tool.test.ts`
  - `src/agents/openclaw-gateway-tool.test.ts`
  - `extensions/qa-matrix/src/runners/contract/runtime.test.ts`
  - `extensions/qa-matrix/src/runners/contract/scenarios.test.ts`
  - `packages/gateway-protocol/src`
- Local: `pnpm test src/gateway/server.config-patch.test.ts`
- Local: `pnpm test src/agents/tools/gateway-tool.test.ts src/agents/openclaw-gateway-tool.test.ts`
- Local: `pnpm test src/config/merge-patch.test.ts extensions/qa-matrix/src/runners/contract/runtime.test.ts extensions/qa-matrix/src/runners/contract/scenarios.test.ts packages/gateway-protocol/src`
- Local: `pnpm format:docs`
- Local: `git diff --check`
- Local: `swift build` in `apps/shared/OpenClawKit`

Known proof gaps:

- Broader local `swift test` in `apps/shared/OpenClawKit` still fails existing unrelated `TalkConfigContractTests.selectionFixtures` fixture expectations.
- Local iOS `xcodebuild` compiled the touched Design files, then failed existing unrelated `apps/ios/Sources/Onboarding/QRScannerView.swift` / `AppleReviewDemoMode` resolution.

## Real behavior proof

Behavior addressed: `config.patch` could silently remove existing array entries after a truncated `config.get` round-trip.

Real environment tested: AWS Crabbox Linux host via Gateway WebSocket RPCs and on-disk config verification.

Exact steps or command run after this patch: `pnpm crabbox:run -- --provider aws --idle-timeout 90m --ttl 240m --timing-json --script-stdin` with a temporary Gateway RPC proof plus focused regression tests.

Evidence after fix: Crabbox `run_c11f1f03de06` printed `E2E_REGRESSION_REPRO_SUMMARY` showing rejected destructive patch and unchanged disk, then `E2E_FIX_PROOF_SUMMARY` showing explicit `replacePaths` replacement was accepted.

Observed result after fix: Unconfirmed destructive array patch from 82 bindings to 2 was rejected; confirmed replacement with `replacePaths: ["bindings"]` succeeded.

What was not tested: Full Control UI browser flow; this bug’s mutation contract was proven at Gateway RPC and disk-write level.
