### PR TITLE
fix(agents): clean Gemini tool schemas by model id

### DIFF
--- a/src/agents/agent-tools-parameter-schema.ts
+++ b/src/agents/agent-tools-parameter-schema.ts
@@ -29,6 +29,9 @@ function resolveToolParameterSchemaCacheKey(
 ): string {
   const normalizedProvider = normalizeLowercaseStringOrEmpty(options?.modelProvider);
   const normalizedModelId = normalizeLowercaseStringOrEmpty(options?.modelId);
+  const toolSchemaProfile = normalizeLowercaseStringOrEmpty(
+    options?.modelCompat?.toolSchemaProfile,
+  );
   const unsupportedKeywords = Array.from(
     resolveUnsupportedToolSchemaKeywords(options?.modelCompat),
   ).toSorted();
@@ -36,6 +39,7 @@ function resolveToolParameterSchemaCacheKey(
   return JSON.stringify([
     normalizedProvider,
     normalizedModelId,
+    toolSchemaProfile,
     unsupportedKeywords,
     omitEmptyArrayItems,
   ]);
@@ -55,6 +59,10 @@ function rememberCachedToolParameterSchema(schema: object, key: string, value: T
     ),
   );
   return value;
+}
+
+function isGeminiModelId(modelId: string): boolean {
+  return /(?:^|[/:])gemini(?:$|[-/:.])/.test(modelId);
 }
 
 function extractEnumValues(schema: unknown): unknown[] | undefined {
@@ -769,8 +777,15 @@ function normalizeToolParameterSchemaUncached(
   //
   // Normalize once here so callers can always pass `tools` through unchanged.
   const normalizedProvider = normalizeLowercaseStringOrEmpty(options?.modelProvider);
+  const normalizedModelId = normalizeLowercaseStringOrEmpty(options?.modelId);
+  const normalizedToolSchemaProfile = normalizeLowercaseStringOrEmpty(
+    options?.modelCompat?.toolSchemaProfile,
+  );
   const isGeminiProvider =
-    normalizedProvider.includes("google") || normalizedProvider.includes("gemini");
+    normalizedProvider.includes("google") ||
+    normalizedProvider.includes("gemini") ||
+    isGeminiModelId(normalizedModelId) ||
+    normalizedToolSchemaProfile === "gemini";
   const isAnthropicProvider = normalizedProvider.includes("anthropic");
   const unsupportedToolSchemaKeywords = resolveUnsupportedToolSchemaKeywords(options?.modelCompat);
   const omitEmptyArrayItems = shouldOmitEmptyArrayItems(options?.modelCompat);
@@ -781,7 +796,13 @@ function normalizeToolParameterSchemaUncached(
       ? stripEmptyArrayItemsFromArraySchemas(normalizedSchema)
       : normalizedSchema;
     if (isGeminiProvider && !isAnthropicProvider) {
-      return cleanSchemaForGemini(arrayItemsCompatibleSchema);
+      const geminiCompatibleSchema = cleanSchemaForGemini(arrayItemsCompatibleSchema);
+      return unsupportedToolSchemaKeywords.size > 0
+        ? (stripUnsupportedSchemaKeywords(
+            geminiCompatibleSchema,
+            unsupportedToolSchemaKeywords,
+          ) as TSchema)
+        : geminiCompatibleSchema;
     }
     if (unsupportedToolSchemaKeywords.size > 0) {
       return stripUnsupportedSchemaKeywords(

--- a/src/agents/agent-tools.schema.test.ts
+++ b/src/agents/agent-tools.schema.test.ts
@@ -42,6 +42,93 @@ describe("normalizeToolParameterSchema", () => {
     expect(providerSpecific).toEqual(first);
   });
 
+  it("uses Gemini cleanup for OpenAI-compatible providers when the model id is Gemini", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        sessionKey: {
+          description: "Explicit session key, or null to clear it",
+          anyOf: [{ type: "string" }, { type: "null" }],
+        },
+      },
+    };
+
+    expect(
+      normalizeToolParameterSchema(schema, {
+        modelProvider: "jjcc",
+        modelId: "gemini-3.1-pro-preview",
+      }),
+    ).toEqual({
+      type: "object",
+      properties: {
+        sessionKey: {
+          type: "string",
+          description: "Explicit session key, or null to clear it",
+        },
+      },
+    });
+    expect(
+      normalizeToolParameterSchema(schema, {
+        modelProvider: "stepfun",
+        modelId: "step-router-v1",
+      }),
+    ).toEqual(schema);
+  });
+
+  it("keeps normalized tool-schema profile behavior aligned with the cache key", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        sessionKey: {
+          anyOf: [{ type: "string" }, { type: "null" }],
+        },
+      },
+    };
+
+    const defaultSchema = normalizeToolParameterSchema(schema, {
+      modelProvider: "openai-compatible",
+      modelId: "custom-model",
+    });
+    const mixedCaseGeminiProfileSchema = normalizeToolParameterSchema(schema, {
+      modelProvider: "openai-compatible",
+      modelId: "custom-model",
+      modelCompat: { toolSchemaProfile: "Gemini" },
+    });
+
+    expect(defaultSchema).toEqual(schema);
+    expect(mixedCaseGeminiProfileSchema).toEqual({
+      type: "object",
+      properties: {
+        sessionKey: { type: "string" },
+      },
+    });
+  });
+
+  it("applies explicit unsupported keyword stripping after Gemini cleanup", () => {
+    expect(
+      normalizeToolParameterSchema(
+        {
+          type: "object",
+          properties: {
+            count: {
+              anyOf: [{ type: "integer", vendorOnly: true }, { type: "null" }],
+            },
+          },
+        },
+        {
+          modelProvider: "jjcc",
+          modelId: "gemini-3.1-pro-preview",
+          modelCompat: { unsupportedToolSchemaKeywords: ["vendorOnly"] },
+        },
+      ),
+    ).toEqual({
+      type: "object",
+      properties: {
+        count: { type: "integer" },
+      },
+    });
+  });
+
   it("normalizes truly empty schemas to type:object with properties:{}", () => {
     expect(normalizeToolParameterSchema({})).toEqual({
       type: "object",

--- a/src/agents/tools/cron-tool.schema.test.ts
+++ b/src/agents/tools/cron-tool.schema.test.ts
@@ -33,6 +33,10 @@ describe("CronToolSchema", () => {
   const providerSchemaRecord = normalizeToolParameterSchema(createCronToolSchema(), {
     modelProvider: "gemini",
   }) as unknown as Record<string, unknown>;
+  const jjccGeminiSchemaRecord = normalizeToolParameterSchema(createCronToolSchema(), {
+    modelProvider: "jjcc",
+    modelId: "gemini-3.1-pro-preview",
+  }) as unknown as Record<string, unknown>;
 
   // Regression: models like GPT-5.4 rely on these fields to populate job/patch.
   // If a field is removed from this list the test must be updated intentionally.
@@ -252,6 +256,22 @@ describe("CronToolSchema", () => {
     expect(patchProps?.payload?.properties?.toolsAllow?.description).toMatch(/null to clear/i);
     expect(patchProps?.payload?.properties?.model?.type).toBe("string");
     expect(patchProps?.payload?.properties?.model?.description).toMatch(/null to clear/i);
+  });
+
+  it("projects nullable cron fields for Gemini models behind OpenAI-compatible providers", () => {
+    expect(propertyAt(jjccGeminiSchemaRecord, "job.agentId")).toMatchObject({
+      type: "string",
+    });
+    expect(propertyAt(jjccGeminiSchemaRecord, "job.sessionKey")).toMatchObject({
+      type: "string",
+    });
+    expect(propertyAt(jjccGeminiSchemaRecord, "patch.payload.toolsAllow")).toMatchObject({
+      type: "array",
+    });
+    expect(propertyAt(jjccGeminiSchemaRecord, "patch.delivery.channel")).toMatchObject({
+      type: "string",
+    });
+    expect(JSON.stringify(jjccGeminiSchemaRecord)).not.toContain('"anyOf"');
   });
 
   // Regression guard: ensure no OpenAPI 3.0 incompatible keywords leak into the


### PR DESCRIPTION
## Summary

- Fixes #91542 by applying the existing Gemini tool-schema cleanup when an OpenAI-compatible provider uses a Gemini model id, not only when the provider id itself is `google` or `gemini`.
- Includes `modelCompat.toolSchemaProfile` in both the Gemini decision and the tool-schema normalization cache key so provider-specific schema projections stay deterministic.
- Preserves configured `unsupportedToolSchemaKeywords` after Gemini cleanup for custom OpenAI-compatible providers that need additional stripping.

## Verification

- `node_modules/.bin/tsx -e '<direct schema normalization probe>'`
- `node scripts/run-vitest.mjs src/agents/tools/cron-tool.schema.test.ts src/agents/agent-tools.schema.test.ts src/agents/agent-tools.create-openclaw-coding-tools.test.ts`
- `node_modules/.bin/oxfmt --check src/agents/agent-tools-parameter-schema.ts src/agents/agent-tools.schema.test.ts src/agents/tools/cron-tool.schema.test.ts`
- `node scripts/run-oxlint.mjs src/agents/agent-tools-parameter-schema.ts src/agents/agent-tools.schema.test.ts src/agents/tools/cron-tool.schema.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main`

## Real behavior proof

Behavior addressed: Gemini models routed through OpenAI-compatible providers, such as `jjcc` with `gemini-3.1-pro-preview`, now receive provider-facing cron tool schemas with nullable `anyOf` fields projected to concrete `type` schemas.

Real environment tested: Local OpenClaw source checkout rebased on latest `upstream/main`, running the actual schema normalization code with `tsx` against `createCronToolSchema()` and `normalizeToolParameterSchema()`.

Exact steps or command run after this patch:

```bash
node_modules/.bin/tsx -e '
import { normalizeToolParameterSchema } from "./src/agents/agent-tools.schema.ts";
import { createCronToolSchema } from "./src/agents/tools/cron-tool.ts";
const schema = normalizeToolParameterSchema(createCronToolSchema(), {
  modelProvider: "jjcc",
  modelId: "gemini-3.1-pro-preview",
}) as Record<string, any>;
function prop(path: string): any {
  let cursor: any = schema;
  for (const segment of path.split(".")) cursor = cursor?.properties?.[segment];
  return cursor;
}
const evidence = {
  provider: "jjcc",
  modelId: "gemini-3.1-pro-preview",
  jobAgentIdType: prop("job.agentId")?.type,
  jobSessionKeyType: prop("job.sessionKey")?.type,
  patchToolsAllowType: prop("patch.payload.toolsAllow")?.type,
  patchDeliveryChannelType: prop("patch.delivery.channel")?.type,
  serializedContainsAnyOf: JSON.stringify(schema).includes("\"anyOf\""),
};
console.log(JSON.stringify(evidence, null, 2));
'
```

Evidence after fix:

```json
{
  "provider": "jjcc",
  "modelId": "gemini-3.1-pro-preview",
  "jobAgentIdType": "string",
  "jobSessionKeyType": "string",
  "patchToolsAllowType": "array",
  "patchDeliveryChannelType": "string",
  "serializedContainsAnyOf": false
}
```

Observed result after fix: The real source-code probe produced provider-facing cron schema fields with explicit `type` values for the issue's rejected paths and no serialized `anyOf`. Focused Vitest also passed: `3` test files, `121` tests total across the requested shards; final autoreview reported no accepted/actionable findings.

What was not tested: No live jjcc/Gemini API request was run because credentials were not available in this environment.
