### PR TITLE
fix(wizard): report keyless web_search providers as ready, not missing a key

### DIFF
--- a/src/wizard/i18n/locales/en.ts
+++ b/src/wizard/i18n/locales/en.ts
@@ -998,6 +998,7 @@ export const en = {
       webSearchGetKey: "Get your key at: {url}",
       webSearchAuthProfile: "Credential: existing {provider} auth profile.",
       webSearchKeyEnv: "API key: provided via {env} env var.",
+      webSearchKeyFree: "Web search is ready — this provider works with no API key.",
       webSearchKeyRef: "API key: configured via secret reference.",
       webSearchKeyStored: "API key: stored in config.",
       webSearchNeedsKey: "web_search will not work until a key is added.",

--- a/src/wizard/i18n/locales/zh-CN.ts
+++ b/src/wizard/i18n/locales/zh-CN.ts
@@ -962,6 +962,7 @@ export const zh_CN = {
       webSearchGetKey: "获取 key：{url}",
       webSearchAuthProfile: "凭据：使用已有 {provider} auth profile。",
       webSearchKeyEnv: "API key：通过 {env} 环境变量提供。",
+      webSearchKeyFree: "Web search 已就绪 —— 此 provider 无需 API key。",
       webSearchKeyRef: "API key：通过 secret reference 配置。",
       webSearchKeyStored: "API key：已存入配置。",
       webSearchNeedsKey: "添加 key 前 web_search 无法工作。",

--- a/src/wizard/i18n/locales/zh-TW.ts
+++ b/src/wizard/i18n/locales/zh-TW.ts
@@ -963,6 +963,7 @@ export const zh_TW = {
       webSearchGetKey: "取得 key：{url}",
       webSearchAuthProfile: "憑證：使用已有 {provider} auth profile。",
       webSearchKeyEnv: "API key：透過 {env} 環境變數提供。",
+      webSearchKeyFree: "Web search 已就緒 —— 此 provider 無需 API key。",
       webSearchKeyRef: "API key：透過 secret reference 設定。",
       webSearchKeyStored: "API key：已存入設定。",
       webSearchNeedsKey: "新增 key 前 web_search 無法運作。",

--- a/src/wizard/setup.finalize.test.ts
+++ b/src/wizard/setup.finalize.test.ts
@@ -188,6 +188,7 @@ function createWebSearchProviderEntry(
     | "placeholder"
     | "signupUrl"
     | "credentialPath"
+    | "requiresCredential"
   >,
 ): PluginWebSearchProviderEntry {
   return {
@@ -837,6 +838,49 @@ describe("finalizeSetupWizard", () => {
         type: "oauth",
       }),
     );
+  });
+
+  it("reports a keyless provider as ready without prompting for an API key", async () => {
+    listConfiguredWebSearchProviders.mockReturnValue([
+      createWebSearchProviderEntry({
+        id: "parallel-free",
+        label: "Parallel Search (Free)",
+        hint: "Free web search via Parallel's hosted Search MCP",
+        envVars: [],
+        placeholder: "",
+        signupUrl: "https://parallel.ai",
+        credentialPath: "",
+        requiresCredential: false,
+      }),
+    ]);
+
+    const prompter = createLaterPrompter();
+
+    await finalizeSetupWizard(
+      createAdvancedFinalizeArgs({
+        nextConfig: {
+          tools: { web: { search: { provider: "parallel-free", enabled: true } } },
+        },
+        prompter,
+      }),
+    );
+
+    expectNoteContains(
+      prompter,
+      "Web search is ready — this provider works with no API key.",
+      "Web search",
+    );
+    // The credential-required warning must NOT appear for a keyless provider.
+    expect(
+      vi
+        .mocked(prompter.note)
+        .mock.calls.some(
+          ([message, title]) =>
+            title === "Web search" &&
+            (message.includes("no API key was found") ||
+              message.includes("will not work until a key is added")),
+        ),
+    ).toBe(false);
   });
 
   it("uses the setup token for health checks to avoid local env token drift", async () => {

--- a/src/wizard/setup.finalize.ts
+++ b/src/wizard/setup.finalize.ts
@@ -644,6 +644,18 @@ export async function finalizeSetupWizard(
         ].join("\n"),
         t("wizard.finalize.webSearchTitle"),
       );
+    } else if (webSearchEnabled !== false && entry.requiresCredential === false) {
+      // Keyless providers (e.g. Parallel Search (Free), DuckDuckGo, Ollama) need
+      // no API key — report ready rather than the credential-required warning.
+      await prompter.note(
+        [
+          t("wizard.finalize.webSearchKeyFree"),
+          "",
+          t("wizard.finalize.webSearchProvider", { provider: label }),
+          t("wizard.finalize.webDocs"),
+        ].join("\n"),
+        t("wizard.finalize.webSearchTitle"),
+      );
     } else if (webSearchEnabled !== false && hasCredential) {
       await prompter.note(
         [
@@ -655,7 +667,7 @@ export async function finalizeSetupWizard(
         ].join("\n"),
         t("wizard.finalize.webSearchTitle"),
       );
-    } else if (!hasCredential) {
+    } else if (entry.requiresCredential !== false && !hasCredential) {
       await prompter.note(
         [
           t("wizard.finalize.webSearchNoKey", { provider: label }),


### PR DESCRIPTION
## Summary

What problem does this PR solve?

During onboarding, selecting a **keyless** web_search provider (one with `requiresCredential: false`) wrongly shows a missing-API-key warning:

> Provider Parallel Search (Free) is selected but no API key was found. web_search will not work until a key is added. … Get your key at: https://parallel.ai

That's incorrect — keyless providers need no key by design. The onboarding finalize summary (`src/wizard/setup.finalize.ts`) decided the web_search message from credential **presence** alone and never checked `requiresCredential`, so a selected keyless provider with no key fell into the "no API key / won't work / get your key" branch.

Why does this matter now?

It's a pre-existing bug, but it's now hit on the **common path**: since #90849 made **Parallel Search (Free)** the pre-selected zero-config default, a fresh no-key install lands on it and is told — wrongly — that web search won't work without a key, directly contradicting the "free, no key, works out of the box" premise.

What is the intended outcome?

Keyless providers report **ready** instead of demanding a key. The fix is generic (keyed on `requiresCredential === false`), so it covers all three keyless providers — **Parallel Search (Free)**, **DuckDuckGo**, **Ollama** — with no provider-specific hardcoding.

What is intentionally out of scope?

No resolver/default changes; no behavior change for credential-requiring providers (their missing-key warning is preserved, now guarded to `requiresCredential !== false`).

## Linked context

Related #90849 (made `parallel-free` the pre-selected default, which surfaced this).

Was this requested by a maintainer or owner?

No — external contribution.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: onboarding no longer tells a keyless web_search provider it needs an API key; it reports the provider as ready.
- Real environment tested: macOS; isolated `OPENCLAW_HOME` with no search keys in env.
- Exact steps or command run after this patch: run onboarding with no search credentials and inspect the Web search step/summary:

```bash
env -u PARALLEL_API_KEY -u BRAVE_API_KEY -u EXA_API_KEY -u TAVILY_API_KEY \
    -u GEMINI_API_KEY -u OPENROUTER_API_KEY -u XAI_API_KEY \
    OPENCLAW_HOME=/tmp/oc-keyless-proof \
    pnpm openclaw onboard --flow quickstart --accept-risk --auth-choice skip \
      --skip-channels --skip-skills --skip-daemon --skip-ui --skip-health
```

- Evidence after fix: live onboarding confirms `Parallel Search (Free)` is the pre-selected `key-free` default:

```
● Parallel Search (Free) (Free web search via Parallel's hosted Search MCP — no API key required · key-free)
```

  And the finalize summary now renders **"Web search is ready — this provider works with no API key."** instead of the missing-key warning. The exact rendered copy and the *absence* of the warning are pinned by a regression test that exercises the real `finalizeSetupWizard` render with a keyless provider (`src/wizard/setup.finalize.test.ts`). (Before/after onboarding screenshots to follow.)

- Observed result after fix: keyless provider → "ready, no API key" note; credential-requiring provider with no key → unchanged missing-key warning.
- What was not tested: cross-OS beyond macOS.
- Proof limitations or environment constraints: the interactive picker can't be fully driven non-interactively; the finalize copy is verified via the unit test against the real render.

## Tests and validation

Which commands did you run?

`pnpm tsgo:core`; `oxfmt`/`oxlint` on touched files; `pnpm test` on `src/wizard/setup.finalize` and `src/wizard/i18n/index` (locale-parity). `codex review --base origin/main`: no actionable findings.

What regression coverage was added or updated?

Added `setup.finalize.test.ts` case: a keyless provider (`requiresCredential: false`) selected with no key renders the key-free "ready" note and does **not** render "no API key was found" / "will not work until a key is added".

## Risk checklist

Did user-visible behavior change? Yes — onboarding copy for keyless providers (corrected). No change for credential-requiring providers.

Did config, environment, or migration behavior change? No.

Did security, auth, secrets, or network behavior change? No — display/copy only.

What is the highest-risk area? Branch ordering in the finalize note. Mitigated by the regression test plus the preserved keyed-provider behavior (warning guarded to `requiresCredential !== false`).

## Current review state

What is the next action? Add before/after onboarding screenshots, then mark ready.

Which bot or reviewer comments were addressed? Pre-submission `codex review`: clean.
