### PR TITLE
perf(control-ui): trace first assistant event

### DIFF
--- a/src/gateway/server-chat-state.ts
+++ b/src/gateway/server-chat-state.ts
@@ -2,10 +2,19 @@
 // Tracks active runs, delta buffers, tool recipients, and session subscribers.
 import type { AgentEventPayload } from "../infra/agent-events.js";
 
+export type ChatRunTiming = {
+  ackedAtMs: number;
+  connId: string;
+  dispatchStartedAtMs?: number;
+  firstAssistantEventSent?: boolean;
+  receivedAtMs: number;
+};
+
 export type ChatRunEntry = {
   sessionKey: string;
   agentId?: string;
   clientRunId: string;
+  chatSendTiming?: ChatRunTiming;
 };
 
 export type BufferedAgentEvent = {

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -413,6 +413,89 @@ describe("agent event handler", () => {
     nowSpy?.mockRestore();
   });
 
+  it("emits the first assistant chat.send timing event to the originating Control UI", () => {
+    const { broadcastToConnIds, chatRunState, handler, nowSpy } = createHarness({ now: 1_000 });
+    chatRunState.registry.add("run-1", {
+      sessionKey: "session-1",
+      clientRunId: "client-1",
+      chatSendTiming: {
+        ackedAtMs: 0,
+        connId: "conn-control-ui",
+        dispatchStartedAtMs: 0,
+        receivedAtMs: 0,
+      },
+    });
+
+    handler({
+      runId: "run-1",
+      seq: 1,
+      stream: "assistant",
+      ts: Date.now(),
+      data: { text: "Hello world" },
+    });
+    handler({
+      runId: "run-1",
+      seq: 2,
+      stream: "assistant",
+      ts: Date.now(),
+      data: { text: "Hello world again" },
+    });
+
+    expect(broadcastToConnIds).toHaveBeenCalledTimes(1);
+    expect(broadcastToConnIds).toHaveBeenCalledWith(
+      "chat.send_timing",
+      expect.objectContaining({
+        phase: "first-assistant-event",
+        runId: "client-1",
+        sessionKey: "session-1",
+        ackToPhaseMs: expect.any(Number),
+        dispatchStartedToPhaseMs: expect.any(Number),
+        receivedToPhaseMs: expect.any(Number),
+      }),
+      new Set(["conn-control-ui"]),
+      { dropIfSlow: true },
+    );
+    nowSpy?.mockRestore();
+  });
+
+  it("emits first assistant chat.send timing when text first flushes on final", () => {
+    const { broadcastToConnIds, chatRunState, handler, nowSpy } = createHarness({ now: 1_000 });
+    chatRunState.registry.add("run-final-only", {
+      sessionKey: "session-1",
+      clientRunId: "client-final",
+      chatSendTiming: {
+        ackedAtMs: 0,
+        connId: "conn-control-ui",
+        dispatchStartedAtMs: 0,
+        receivedAtMs: 0,
+      },
+    });
+    chatRunState.buffers.set("client-final", "Final only reply");
+
+    handler({
+      runId: "run-final-only",
+      seq: 1,
+      stream: "lifecycle",
+      ts: Date.now(),
+      data: { phase: "end" },
+    });
+
+    expect(broadcastToConnIds).toHaveBeenCalledWith(
+      "chat.send_timing",
+      expect.objectContaining({
+        phase: "first-assistant-event",
+        runId: "client-final",
+        sessionKey: "session-1",
+        ackToPhaseMs: expect.any(Number),
+        dispatchStartedToPhaseMs: expect.any(Number),
+        receivedToPhaseMs: expect.any(Number),
+      }),
+      new Set(["conn-control-ui"]),
+      { dropIfSlow: true },
+    );
+    nowSpy?.mockRestore();
+  });
+
   it("coalesces assistant agent events under the chat delta throttle", () => {
     let now = 10_000;
     const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -1,5 +1,6 @@
 // Gateway chat runtime projects agent events into chat/session subscriber
 // streams, lifecycle persistence, heartbeat visibility, and live UI updates.
+import { performance } from "node:perf_hooks";
 import { resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { resolveToolSearchCodeDisplayTarget } from "../agents/tool-display-common.js";
 import { DEFAULT_HEARTBEAT_ACK_MAX_CHARS, stripHeartbeatToken } from "../auto-reply/heartbeat.js";
@@ -18,6 +19,7 @@ import {
 } from "./live-chat-projector.js";
 import type {
   BufferedAgentEvent,
+  ChatRunEntry,
   ChatRunState,
   SessionEventSubscriberRegistry,
   SessionMessageSubscriberRegistry,
@@ -257,6 +259,10 @@ export type AgentEventHandlerOptions = {
   }) => void;
 };
 
+function roundedChatSendTimingMs(value: number): number {
+  return Math.max(0, Math.round(value * 1000) / 1000);
+}
+
 export function createAgentEventHandler({
   broadcast,
   broadcastToConnIds,
@@ -446,6 +452,35 @@ export function createAgentEventHandler({
     }
   };
 
+  const emitFirstAssistantChatSendTiming = (chatLink: ChatRunEntry | undefined) => {
+    const timing = chatLink?.chatSendTiming;
+    if (!timing || timing.firstAssistantEventSent) {
+      return;
+    }
+    timing.firstAssistantEventSent = true;
+    const nowMs = performance.now();
+    broadcastToConnIds(
+      "chat.send_timing",
+      {
+        phase: "first-assistant-event",
+        runId: chatLink.clientRunId,
+        sessionKey: chatLink.sessionKey,
+        ...(chatLink.agentId ? { agentId: chatLink.agentId } : {}),
+        ackToPhaseMs: roundedChatSendTimingMs(nowMs - timing.ackedAtMs),
+        receivedToPhaseMs: roundedChatSendTimingMs(nowMs - timing.receivedAtMs),
+        ...(timing.dispatchStartedAtMs !== undefined
+          ? {
+              dispatchStartedToPhaseMs: roundedChatSendTimingMs(
+                nowMs - timing.dispatchStartedAtMs,
+              ),
+            }
+          : {}),
+      },
+      new Set([timing.connId]),
+      { dropIfSlow: true },
+    );
+  };
+
   const finalizeLifecycleEvent = (evt: AgentEventPayload, opts?: TerminalLifecycleOptions) => {
     const lifecyclePhase =
       evt.stream === "lifecycle" && typeof evt.data?.phase === "string" ? evt.data.phase : null;
@@ -496,7 +531,11 @@ export function createAgentEventHandler({
               evt.data?.error,
               evtStopReason,
               evtErrorKind,
-              { agentId: finished.agentId, controlUiVisible: isControlUiVisible },
+              {
+                agentId: finished.agentId,
+                controlUiVisible: isControlUiVisible,
+                firstAssistantTimingEntry: finished,
+              },
             );
           }
         } else if (!(opts?.skipChatErrorFinal && lifecyclePhase === "error")) {
@@ -632,6 +671,7 @@ export function createAgentEventHandler({
         timestamp: now,
       },
     };
+    emitFirstAssistantChatSendTiming(chatRunState.registry.peek(sourceRunId));
     sendChatPayload(sessionKey, payload, {
       agentId,
       controlUiVisible: opts?.controlUiVisible ?? true,
@@ -667,7 +707,7 @@ export function createAgentEventHandler({
     clientRunId: string,
     sourceRunId: string,
     seq: number,
-    opts?: { controlUiVisible?: boolean },
+    opts?: { controlUiVisible?: boolean; firstAssistantTimingEntry?: ChatRunEntry },
   ) => {
     const { text, shouldSuppressSilent } = resolveBufferedChatTextState(clientRunId, sourceRunId, {
       suppressLeadFragments: true,
@@ -704,6 +744,9 @@ export function createAgentEventHandler({
         timestamp: now,
       },
     };
+    emitFirstAssistantChatSendTiming(
+      opts?.firstAssistantTimingEntry ?? chatRunState.registry.peek(sourceRunId),
+    );
     sendChatPayload(sessionKey, flushPayload, {
       agentId,
       controlUiVisible: opts?.controlUiVisible ?? true,
@@ -740,7 +783,11 @@ export function createAgentEventHandler({
     error?: unknown,
     stopReason?: string,
     errorKind?: ErrorKind,
-    opts?: { agentId?: string; controlUiVisible?: boolean },
+    opts?: {
+      agentId?: string;
+      controlUiVisible?: boolean;
+      firstAssistantTimingEntry?: ChatRunEntry;
+    },
   ) => {
     const { text, shouldSuppressSilent } = resolveBufferedChatTextState(clientRunId, sourceRunId, {
       suppressLeadFragments: false,

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -138,6 +138,7 @@ import {
   createManagedOutgoingImageBlocks,
 } from "../managed-image-attachments.js";
 import { ADMIN_SCOPE } from "../method-scopes.js";
+import type { ChatRunTiming } from "../server-chat-state.js";
 import { getMaxChatHistoryMessagesBytes, MAX_PAYLOAD_BYTES } from "../server-constants.js";
 import { resolveSessionHistoryTailReadOptions } from "../session-history-state.js";
 import { readSessionTranscriptIndex } from "../session-transcript-index.fs.js";
@@ -237,6 +238,7 @@ type ChatSendServerTimingPhase =
   | "dispatch-started"
   | "model-selected"
   | "agent-run-started"
+  | "first-assistant-event"
   | "dispatch-completed"
   | "post-dispatch-completed";
 
@@ -967,6 +969,26 @@ function hasAssistantDisplayMediaContent(
   content: readonly AssistantDisplayContentBlock[] | undefined,
 ): boolean {
   return Boolean(content?.some((block) => block?.type !== "text"));
+}
+
+function hasVisibleAssistantFinalMessage(message: Record<string, unknown> | undefined): boolean {
+  if (!message) {
+    return false;
+  }
+  if (typeof message.text === "string" && message.text.trim()) {
+    return true;
+  }
+  const content = Array.isArray(message.content) ? message.content : [];
+  return content.some((block) => {
+    if (!block || typeof block !== "object") {
+      return false;
+    }
+    const record = block as Record<string, unknown>;
+    if (record.type === "text") {
+      return typeof record.text === "string" && record.text.trim().length > 0;
+    }
+    return true;
+  });
 }
 
 function hasManagedOutgoingAssistantContent(
@@ -3352,11 +3374,6 @@ export const chatHandlers: GatewayRequestHandlers = {
     }
 
     try {
-      context.addChatRun(clientRunId, {
-        sessionKey,
-        agentId: selectedAgent.agentId,
-        clientRunId,
-      });
       const serverTiming = shouldIncludeChatSendAckServerTiming(clientInfo)
         ? {
             receivedToAckMs: roundedChatSendTimingMs(performance.now() - chatSendReceivedAtMs),
@@ -3364,6 +3381,20 @@ export const chatHandlers: GatewayRequestHandlers = {
             ...(prepareAttachmentsMs !== undefined ? { prepareAttachmentsMs } : {}),
           }
         : undefined;
+      const chatSendTiming: ChatRunTiming | undefined =
+        serverTiming && typeof client?.connId === "string" && client.connId.trim()
+          ? {
+              ackedAtMs: performance.now(),
+              connId: client.connId.trim(),
+              receivedAtMs: chatSendReceivedAtMs,
+            }
+          : undefined;
+      context.addChatRun(clientRunId, {
+        sessionKey,
+        agentId: selectedAgent.agentId,
+        clientRunId,
+        ...(chatSendTiming ? { chatSendTiming } : {}),
+      });
       const ackPayload = {
         runId: clientRunId,
         status: "started" as const,
@@ -3383,7 +3414,7 @@ export const chatHandlers: GatewayRequestHandlers = {
         { config: cfg },
       );
       respond(true, ackPayload, undefined, { runId: clientRunId });
-      const chatSendAckedAtMs = performance.now();
+      const chatSendAckedAtMs = chatSendTiming?.ackedAtMs ?? performance.now();
       const persistedImagesPromise = persistChatSendImages({
         images: parsedImages,
         imageOrder,
@@ -3707,7 +3738,21 @@ export const chatHandlers: GatewayRequestHandlers = {
         });
       };
       const dispatchStartedAtMs = performance.now();
+      if (chatSendTiming) {
+        chatSendTiming.dispatchStartedAtMs = dispatchStartedAtMs;
+      }
       emitServerTiming("dispatch-started");
+      let firstAssistantServerTimingEmitted = false;
+      const emitFirstAssistantServerTiming = () => {
+        if (firstAssistantServerTimingEmitted || chatSendTiming?.firstAssistantEventSent) {
+          return;
+        }
+        firstAssistantServerTimingEmitted = true;
+        if (chatSendTiming) {
+          chatSendTiming.firstAssistantEventSent = true;
+        }
+        emitServerTiming("first-assistant-event", undefined, dispatchStartedAtMs);
+      };
       void measureDiagnosticsTimelineSpan(
         "gateway.chat_send.dispatch_inbound",
         async () => {
@@ -4038,6 +4083,9 @@ export const chatHandlers: GatewayRequestHandlers = {
                       };
                     }
                   }
+                  if (hasVisibleAssistantFinalMessage(message)) {
+                    emitFirstAssistantServerTiming();
+                  }
                   broadcastChatFinal({
                     context,
                     runId: clientRunId,
@@ -4360,6 +4408,9 @@ export const chatHandlers: GatewayRequestHandlers = {
                       stopReason: "stop",
                       usage: { input: 0, output: 0, totalTokens: 0 },
                     };
+                    if (hasVisibleAssistantFinalMessage(message)) {
+                      emitFirstAssistantServerTiming();
+                    }
                     broadcastChatFinal({
                       context,
                       runId: clientRunId,

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -1826,6 +1826,160 @@ describe("gateway server chat", () => {
     }
   });
 
+  test("chat.send emits first-assistant timing for direct final replies", async () => {
+    const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
+    try {
+      testState.sessionStorePath = path.join(sessionDir, "sessions.json");
+      await writeSessionStore({
+        entries: {
+          main: {
+            sessionId: "sess-main",
+            updatedAt: Date.now(),
+          },
+        },
+      });
+
+      const responses: Array<{ ok: boolean; payload?: unknown; error?: unknown }> = [];
+      const broadcast = vi.fn();
+      const broadcastToConnIds = vi.fn();
+      const context = {
+        loadGatewayModelCatalog: vi.fn<GatewayRequestContext["loadGatewayModelCatalog"]>(),
+        logGateway: {
+          info: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+          debug: vi.fn(),
+        },
+        agentRunSeq: new Map<string, number>(),
+        chatAbortControllers: new Map(),
+        chatAbortedRuns: new Map(),
+        chatRunBuffers: new Map(),
+        chatDeltaSentAt: new Map(),
+        chatDeltaLastBroadcastLen: new Map(),
+        chatDeltaLastBroadcastText: new Map(),
+        agentDeltaSentAt: new Map(),
+        bufferedAgentEvents: new Map(),
+        clearChatRunState: vi.fn(),
+        addChatRun: vi.fn(),
+        removeChatRun: vi.fn(),
+        broadcast,
+        broadcastToConnIds,
+        nodeSendToSession: vi.fn(),
+        registerToolEventRecipient: vi.fn(),
+        dedupe: new Map(),
+      } as unknown as GatewayRequestContext;
+      dispatchInboundMessageMock.mockImplementationOnce(async (args: unknown) => {
+        const dispatcher = (
+          args as {
+            dispatcher?: {
+              sendFinalReply: (payload: { text: string }) => boolean;
+              markComplete: () => void;
+              waitForIdle: () => Promise<void>;
+            };
+          }
+        ).dispatcher;
+        dispatcher?.sendFinalReply({ text: "direct reply" });
+        dispatcher?.markComplete();
+        await dispatcher?.waitForIdle();
+        return {};
+      });
+
+      const { chatHandlers } = await import("./server-methods/chat.js");
+      await chatHandlers["chat.send"]({
+        req: {
+          type: "req",
+          id: "operator-direct-timing",
+          method: "chat.send",
+          params: {
+            sessionKey: "main",
+            message: "measure direct",
+            idempotencyKey: "idem-direct-server-timing",
+          },
+        },
+        params: {
+          sessionKey: "main",
+          message: "measure direct",
+          idempotencyKey: "idem-direct-server-timing",
+        },
+        client: {
+          connId: "conn-control-ui",
+          connect: {
+            client: {
+              id: GATEWAY_CLIENT_NAMES.CONTROL_UI,
+              mode: GATEWAY_CLIENT_MODES.WEBCHAT,
+            },
+            scopes: ["operator.write"],
+          },
+        } as never,
+        isWebchatConnect: () => true,
+        respond: ((ok, payload, error) => {
+          responses.push({ ok, payload, error });
+        }) as RespondFn,
+        context,
+      });
+
+      expect(responses).toEqual([
+        {
+          ok: true,
+          payload: expect.objectContaining({
+            runId: "idem-direct-server-timing",
+            status: "started",
+          }),
+          error: undefined,
+        },
+      ]);
+      await vi.waitFor(
+        () => {
+          expect(broadcastToConnIds).toHaveBeenCalledWith(
+            "chat.send_timing",
+            expect.objectContaining({
+              phase: "first-assistant-event",
+              runId: "idem-direct-server-timing",
+              sessionKey: "agent:main:main",
+              ackToPhaseMs: expect.any(Number),
+              dispatchStartedToPhaseMs: expect.any(Number),
+              receivedToPhaseMs: expect.any(Number),
+            }),
+            new Set(["conn-control-ui"]),
+            { dropIfSlow: true },
+          );
+          expect(broadcast).toHaveBeenCalledWith(
+            "chat",
+            expect.objectContaining({
+              runId: "idem-direct-server-timing",
+              state: "final",
+              message: expect.objectContaining({
+                content: expect.arrayContaining([
+                  expect.objectContaining({
+                    text: "direct reply",
+                  }),
+                ]),
+              }),
+            }),
+          );
+        },
+        { timeout: 2_000, interval: 5 },
+      );
+
+      const firstAssistantTimingCallIndex = broadcastToConnIds.mock.calls.findIndex(
+        ([event, payload]) =>
+          event === "chat.send_timing" &&
+          (payload as { phase?: unknown }).phase === "first-assistant-event",
+      );
+      expect(firstAssistantTimingCallIndex).toBeGreaterThanOrEqual(0);
+      expect(
+        broadcastToConnIds.mock.invocationCallOrder[firstAssistantTimingCallIndex],
+      ).toBeLessThan(
+        broadcast.mock.invocationCallOrder[0],
+      );
+    } finally {
+      dispatchInboundMessageMock.mockReset();
+      testState.sessionStorePath = undefined;
+      clearConfigCache();
+      await fs.rm(sessionDir, { recursive: true, force: true });
+    }
+  });
+
   test("chat.history backfills claude-cli sessions from Claude project files", async () => {
     await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
       await connectOk(ws);

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -611,6 +611,7 @@ type ChatSendTimingPhase =
   | "server-dispatch-started"
   | "server-model-selected"
   | "server-agent-run-started"
+  | "server-first-assistant-event"
   | "server-dispatch-completed"
   | "server-post-dispatch-completed"
   | "first-assistant-visible"
@@ -637,6 +638,7 @@ type ChatSendServerTimingPhase =
   | "dispatch-started"
   | "model-selected"
   | "agent-run-started"
+  | "first-assistant-event"
   | "dispatch-completed"
   | "post-dispatch-completed";
 
@@ -644,6 +646,7 @@ const CHAT_SEND_SERVER_TIMING_PHASES = new Set<ChatSendServerTimingPhase>([
   "dispatch-started",
   "model-selected",
   "agent-run-started",
+  "first-assistant-event",
   "dispatch-completed",
   "post-dispatch-completed",
 ]);

--- a/ui/src/ui/e2e/chat-flow.e2e.test.ts
+++ b/ui/src/ui/e2e/chat-flow.e2e.test.ts
@@ -386,6 +386,16 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
         agentRunId: "agent-run-e2e",
       });
       await waitForControlUiChatSendPhases(page, runId, ["server-agent-run-started"]);
+      await gateway.emitGatewayEvent("chat.send_timing", {
+        phase: "first-assistant-event",
+        runId,
+        agentId: "ops",
+        sessionKey: "global",
+        ackToPhaseMs: 31,
+        receivedToPhaseMs: 40,
+        dispatchStartedToPhaseMs: 27,
+      });
+      await waitForControlUiChatSendPhases(page, runId, ["server-first-assistant-event"]);
       await gateway.emitGatewayEvent("chat", {
         deltaText: "First token visible.",
         message: {
@@ -404,6 +414,7 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
         "request-start",
         "ack",
         "server-agent-run-started",
+        "server-first-assistant-event",
         "first-assistant-visible",
       ]);
       const sendTimingEvents = (await controlUiEventPayloads(page, "control-ui.chat.send")).filter(
@@ -417,6 +428,7 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
           "pending-visible",
           "request-start",
           "ack",
+          "server-first-assistant-event",
           "first-assistant-visible",
         ]),
       );
@@ -436,6 +448,15 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
         serverDispatchStartedToPhaseMs: 7,
         serverPhase: "agent-run-started",
         serverReceivedToPhaseMs: 20,
+        sessionKey: "global",
+      });
+      expect(sendTimingByPhase.get("server-first-assistant-event")).toMatchObject({
+        agentId: "ops",
+        runId,
+        serverAckToPhaseMs: 31,
+        serverDispatchStartedToPhaseMs: 27,
+        serverPhase: "first-assistant-event",
+        serverReceivedToPhaseMs: 40,
         sessionKey: "global",
       });
       const firstVisibleTiming = sendTimingByPhase.get("first-assistant-visible");


### PR DESCRIPTION
## Summary

- add a `first-assistant-event` server timing phase for Control UI chat sends
- emit the phase when the first assistant payload leaves gateway fanout, including final-flush-only and direct gateway-injected replies
- surface the phase in Control UI timing capture so first-message latency can be split between gateway/runtime and browser paint

## Verification

- `git diff --check`
- Testbox `tbx_01ktn3y6fb46yr2q5jpkfh0zvy`: `COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack pnpm test:serial src/gateway/server-chat.agent-events.test.ts src/gateway/server.chat.gateway-server-chat-b.test.ts` — 244 passed, https://github.com/openclaw/openclaw/actions/runs/27180350117
- Testbox `tbx_01ktn418pzbg7g5mgfgkhb3sgy`: `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack pnpm check:changed` — passed, https://github.com/openclaw/openclaw/actions/runs/27180402933
- Testbox `tbx_01ktn31cesz4rb2wpcvwm5fs1t`: targeted Control UI first-message E2E — passed, https://github.com/openclaw/openclaw/actions/runs/27179845342
- Autoreview: clean, no accepted/actionable findings; patch correct (0.82)
