### PR TITLE
fix: make docs i18n frontmatter translation resilient

### DIFF
--- a/scripts/docs-i18n/main_test.go
+++ b/scripts/docs-i18n/main_test.go
@@ -51,6 +51,18 @@ func (transcriptFrontmatterTranslator) TranslateRaw(_ context.Context, text, _, 
 
 func (transcriptFrontmatterTranslator) Close() {}
 
+type errorTranslator struct{}
+
+func (errorTranslator) Translate(context.Context, string, string, string) (string, error) {
+	return "", errors.New("codex exec failed: exit status 1")
+}
+
+func (errorTranslator) TranslateRaw(context.Context, string, string, string) (string, error) {
+	return "", errors.New("codex exec failed: exit status 1")
+}
+
+func (errorTranslator) Close() {}
+
 type partialFailTranslator struct{}
 
 func (partialFailTranslator) Translate(_ context.Context, text, _, _ string) (string, error) {
@@ -153,6 +165,59 @@ func TestRunDocsI18NAllowPartialKeepsSuccessfulDocOutputs(t *testing.T) {
 	}
 }
 
+func TestRunDocsI18NRewritesLineTitleFromExactGlossaryWithoutModel(t *testing.T) {
+	t.Parallel()
+
+	docsRoot := t.TempDir()
+	writeFile(t, filepath.Join(docsRoot, "docs.json"), `{"redirects":[]}`)
+	linePath := filepath.Join(docsRoot, "channels", "line.md")
+	writeFile(t, linePath, stringsJoin(
+		"---",
+		"title: LINE",
+		"---",
+		"",
+	))
+
+	locales := []string{"zh-CN", "zh-TW", "de", "es"}
+	for _, locale := range locales {
+		writeFile(t, filepath.Join(docsRoot, ".i18n", "glossary."+locale+".json"), `[{"source":"LINE","target":"LINE"}]`)
+		writeFile(t, filepath.Join(docsRoot, locale, "channels", "line.md"), stringsJoin(
+			"---",
+			"title: 行",
+			"---",
+			"",
+		))
+
+		err := runDocsI18N(context.Background(), runConfig{
+			targetLang: locale,
+			sourceLang: "en",
+			docsRoot:   docsRoot,
+			mode:       "doc",
+			thinking:   "low",
+			overwrite:  true,
+			parallel:   1,
+		}, []string{linePath}, func(srcLang, tgtLang string, glossary []GlossaryEntry, thinking string) (docsTranslator, error) {
+			translator, err := NewCodexTranslator(srcLang, tgtLang, glossary, thinking)
+			if err != nil {
+				return nil, err
+			}
+			translator.runPrompt = func(context.Context, codexPromptRequest) (string, error) {
+				t.Fatalf("exact LINE title for %s should not call Codex", tgtLang)
+				return "", nil
+			}
+			return translator, nil
+		})
+		if err != nil {
+			t.Fatalf("runDocsI18N(%s) failed: %v", locale, err)
+		}
+
+		got := mustReadFile(t, filepath.Join(docsRoot, locale, "channels", "line.md"))
+		if !containsLine(got, "title: LINE") {
+			t.Fatalf("expected %s title to stay LINE, got:\n%s", locale, got)
+		}
+	}
+}
+
 func TestTranslateSnippetDoesNotCacheFallbackToSource(t *testing.T) {
 	t.Parallel()
 
@@ -190,6 +255,26 @@ func TestTranslateSnippetRejectsTranscriptArtifact(t *testing.T) {
 	cacheKey := cacheKey(cacheNamespace(), "en", "th", "tools/reactions.md:frontmatter:read_when:0", hashText(source))
 	if _, ok := tm.Get(cacheKey); ok {
 		t.Fatalf("expected fallback translation not to be cached")
+	}
+}
+
+func TestTranslateSnippetFallsBackWhenFrontmatterTranslatorFails(t *testing.T) {
+	t.Parallel()
+
+	tm := &TranslationMemory{entries: map[string]TMEntry{}}
+	source := "LINE Messaging API plugin setup, config, and usage"
+
+	translated, err := translateSnippet(context.Background(), errorTranslator{}, tm, "channels/line.md:frontmatter:summary", source, "en", "zh-CN")
+	if err != nil {
+		t.Fatalf("translateSnippet returned error: %v", err)
+	}
+	if translated != source {
+		t.Fatalf("expected fallback to source text, got %q", translated)
+	}
+
+	cacheKey := cacheKey(cacheNamespace(), "en", "zh-CN", "channels/line.md:frontmatter:summary", hashText(source))
+	if _, ok := tm.Get(cacheKey); ok {
+		t.Fatalf("expected failed frontmatter translation not to be cached")
 	}
 }
 

--- a/scripts/docs-i18n/main_test.go
+++ b/scripts/docs-i18n/main_test.go
@@ -278,6 +278,31 @@ func TestTranslateSnippetFallsBackWhenFrontmatterTranslatorFails(t *testing.T) {
 	}
 }
 
+func TestTranslateSnippetCachesDocumentSourcePath(t *testing.T) {
+	t.Parallel()
+
+	tm := &TranslationMemory{entries: map[string]TMEntry{}}
+	source := "Gateway"
+	segmentID := "gateway/index.md:frontmatter:title"
+
+	translated, err := translateSnippet(context.Background(), fakeDocsTranslator{}, tm, segmentID, source, "en", "zh-CN")
+	if err != nil {
+		t.Fatalf("translateSnippet returned error: %v", err)
+	}
+	if translated != source {
+		t.Fatalf("unexpected translation %q", translated)
+	}
+
+	cacheKey := cacheKey(cacheNamespace(), "en", "zh-CN", segmentID, hashText(source))
+	entry, ok := tm.Get(cacheKey)
+	if !ok {
+		t.Fatal("expected successful frontmatter translation to be cached")
+	}
+	if entry.SourcePath != "gateway/index.md" {
+		t.Fatalf("expected document source path, got %q", entry.SourcePath)
+	}
+}
+
 func TestValidateNoTranslationTranscriptArtifacts(t *testing.T) {
 	t.Parallel()
 

--- a/scripts/docs-i18n/process.go
+++ b/scripts/docs-i18n/process.go
@@ -214,7 +214,8 @@ func translateSnippet(ctx context.Context, translator docsTranslator, tm *Transl
 	}
 	translated, err := translator.Translate(ctx, textValue, srcLang, tgtLang)
 	if err != nil {
-		return "", err
+		log.Printf("docs-i18n: frontmatter fallback %s reason=%v", segmentID, err)
+		return textValue, nil
 	}
 	shouldCache := true
 	if validationErr := validateFrontmatterScalarTranslation(textValue, translated); validationErr != nil {

--- a/scripts/docs-i18n/process.go
+++ b/scripts/docs-i18n/process.go
@@ -223,10 +223,14 @@ func translateSnippet(ctx context.Context, translator docsTranslator, tm *Transl
 		translated = textValue
 		shouldCache = false
 	}
+	sourcePath := segmentID
+	if path, _, ok := strings.Cut(segmentID, ":frontmatter:"); ok {
+		sourcePath = path
+	}
 	entry := TMEntry{
 		CacheKey:   ck,
 		SegmentID:  segmentID,
-		SourcePath: segmentID,
+		SourcePath: sourcePath,
 		TextHash:   textHash,
 		Text:       textValue,
 		Translated: translated,

--- a/scripts/docs-i18n/translator.go
+++ b/scripts/docs-i18n/translator.go
@@ -30,9 +30,10 @@ var translateRetryDelay = func(attempt int) time.Duration {
 }
 
 type CodexTranslator struct {
-	systemPrompt string
-	thinking     string
-	runPrompt    codexPromptRunner
+	systemPrompt          string
+	exactGlossaryMappings map[string]string
+	thinking              string
+	runPrompt             codexPromptRunner
 }
 
 type docsTranslator interface {
@@ -54,9 +55,10 @@ type codexPromptRequest struct {
 
 func NewCodexTranslator(srcLang, tgtLang string, glossary []GlossaryEntry, thinking string) (*CodexTranslator, error) {
 	return &CodexTranslator{
-		systemPrompt: translationPrompt(srcLang, tgtLang, glossary),
-		thinking:     normalizeThinking(thinking),
-		runPrompt:    runCodexExecPrompt,
+		systemPrompt:          translationPrompt(srcLang, tgtLang, glossary),
+		exactGlossaryMappings: exactGlossaryMappings(glossary),
+		thinking:              normalizeThinking(thinking),
+		runPrompt:             runCodexExecPrompt,
 	}, nil
 }
 
@@ -73,6 +75,9 @@ func (t *CodexTranslator) translate(ctx context.Context, text string, run func(c
 	if core == "" {
 		return text, nil
 	}
+	if translated, ok := t.exactGlossaryMappings[core]; ok {
+		return prefix + translated + suffix, nil
+	}
 	translated, err := t.translateWithRetry(ctx, func(ctx context.Context) (string, error) {
 		return run(ctx, core)
 	})
@@ -80,6 +85,19 @@ func (t *CodexTranslator) translate(ctx context.Context, text string, run func(c
 		return "", err
 	}
 	return prefix + translated + suffix, nil
+}
+
+func exactGlossaryMappings(glossary []GlossaryEntry) map[string]string {
+	mappings := map[string]string{}
+	for _, entry := range glossary {
+		source := strings.TrimSpace(entry.Source)
+		target := strings.TrimSpace(entry.Target)
+		if source == "" || target == "" {
+			continue
+		}
+		mappings[source] = target
+	}
+	return mappings
 }
 
 func (t *CodexTranslator) translateWithRetry(ctx context.Context, run func(context.Context) (string, error)) (string, error) {
@@ -224,9 +242,16 @@ func runCodexExecPrompt(ctx context.Context, req codexPromptRequest) (string, er
 	command.Stdout = &stdout
 	command.Stderr = &stderr
 	if err := command.Run(); err != nil {
+		if translated, readErr := readCodexOutputLastMessage(outputPath); readErr == nil {
+			return translated, nil
+		}
 		return "", fmt.Errorf("codex exec failed: %w (%s)", err, previewCommandOutput(stdout.String(), stderr.String()))
 	}
 
+	return readCodexOutputLastMessage(outputPath)
+}
+
+func readCodexOutputLastMessage(outputPath string) (string, error) {
 	data, err := os.ReadFile(outputPath)
 	if err != nil {
 		return "", err

--- a/scripts/docs-i18n/translator_test.go
+++ b/scripts/docs-i18n/translator_test.go
@@ -147,6 +147,29 @@ func TestCodexTranslatorStripsInputWrapperEcho(t *testing.T) {
 	}
 }
 
+func TestCodexTranslatorUsesExactGlossaryMatchWithoutPrompt(t *testing.T) {
+	t.Parallel()
+
+	translator, err := NewCodexTranslator("en", "zh-CN", []GlossaryEntry{
+		{Source: "LINE", Target: "LINE"},
+	}, "low")
+	if err != nil {
+		t.Fatalf("NewCodexTranslator returned error: %v", err)
+	}
+	translator.runPrompt = func(context.Context, codexPromptRequest) (string, error) {
+		t.Fatal("exact glossary matches should not call Codex")
+		return "", nil
+	}
+
+	got, err := translator.TranslateRaw(context.Background(), " LINE ", "en", "zh-CN")
+	if err != nil {
+		t.Fatalf("TranslateRaw returned error: %v", err)
+	}
+	if got != " LINE " {
+		t.Fatalf("unexpected translation %q", got)
+	}
+}
+
 func TestBuildCodexTranslationPromptIncludesGuardrailsAndInput(t *testing.T) {
 	prompt := buildCodexTranslationPrompt("System prompt.", "Hello\nworld")
 
@@ -239,6 +262,44 @@ printf 'translated from codex\n' > "$out"
 		t.Fatalf("runCodexExecPrompt returned error: %v", err)
 	}
 	if got != "translated from codex" {
+		t.Fatalf("unexpected output %q", got)
+	}
+}
+
+func TestRunCodexExecPromptUsesOutputLastMessageAfterNonZeroExit(t *testing.T) {
+	dir := t.TempDir()
+	fakeCodex := filepath.Join(dir, "codex")
+	if err := os.WriteFile(fakeCodex, []byte(`#!/bin/sh
+set -eu
+out=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --output-last-message)
+      shift
+      out="$1"
+      ;;
+  esac
+  shift || true
+done
+cat >/dev/null
+printf 'translated despite nonzero\n' > "$out"
+echo "transient Codex shutdown failure" >&2
+exit 1
+`), 0o755); err != nil {
+		t.Fatalf("write fake codex: %v", err)
+	}
+	t.Setenv(envDocsI18nCodexExecutable, fakeCodex)
+
+	got, err := runCodexExecPrompt(context.Background(), codexPromptRequest{
+		SystemPrompt: "Translate.",
+		Message:      "Hello",
+		Model:        "gpt-5.5",
+		Thinking:     "high",
+	})
+	if err != nil {
+		t.Fatalf("runCodexExecPrompt returned error: %v", err)
+	}
+	if got != "translated despite nonzero" {
 		t.Fatalf("unexpected output %q", got)
 	}
 }


### PR DESCRIPTION
## Summary

- keep exact glossary matches deterministic so entries like `LINE -> LINE` do not call Codex
- consume `--output-last-message` when Codex produced a translation but exits non-zero
- fall back to the source frontmatter scalar when a frontmatter translation call fails, instead of failing the whole localized page
- add regression coverage for rewriting stale `channels/line` localized titles across `zh-CN`, `zh-TW`, `de`, and `es`

## Verification

- `cd scripts/docs-i18n && go test ./...`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- real translator smoke: temporary docs root, one `channels/line.md`, `OPENCLAW_DOCS_I18N_MODEL=gpt-5.3-codex-spark`, `--thinking low --parallel 1 --overwrite`; Codex failed one `summary` frontmatter call with exit 1, the script fell back for that scalar, completed generation, and rewrote stale `title: 行` to `title: LINE`

## Notes

- This is PR 1 for the actual translation failure. A separate publish-repo PR can still tighten workflow/finalizer behavior so future translation failures cannot be reported as a silent success.
