### PR TITLE
fix(agents): bootstrap OpenClaw auth for codex harness when provider is codex

### DIFF
--- a/src/agents/embedded-agent-runner/run.overflow-compaction.test.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.test.ts
@@ -1127,6 +1127,92 @@ describe("runEmbeddedAgent overflow compaction trigger routing", () => {
     });
   });
 
+  it("bootstraps OpenClaw auth for codex harness when provider is codex and model uses responses API", async () => {
+    const { clearAgentHarnesses, registerAgentHarness } = await import("../harness/registry.js");
+    const pluginRunAttempt = vi.fn<AgentHarness["runAttempt"]>(async () =>
+      makeAttemptResult({ assistantTexts: ["ok"] }),
+    );
+    const codexAuthStorage = {
+      setRuntimeApiKey: vi.fn(),
+      getApiKey: vi.fn(async () => "stored-test-key"),
+    };
+    const runtimePlan = makeForwardedRuntimePlan({
+      resolvedRef: {
+        provider: "codex",
+        modelId: "gpt-5.5",
+        harnessId: "codex",
+      },
+      auth: {
+        providerForAuth: "openai",
+        authProfileProviderForAuth: "openai",
+        harnessAuthProvider: "openai",
+        forwardedAuthProfileId: "openai:work",
+      },
+    });
+    const codexAuthStore = {
+      version: 1 as const,
+      profiles: {
+        "openai:work": {
+          type: "oauth" as const,
+          provider: "openai",
+          access: "access-token",
+          refresh: "refresh-token",
+          expires: Date.now() + 60_000,
+        },
+      },
+    };
+    clearAgentHarnesses();
+    registerAgentHarness({
+      id: "codex",
+      label: "Codex",
+      supports: codexHarnessSupportsKnownProviders,
+      runAttempt: pluginRunAttempt,
+    });
+    mockedEnsureAuthProfileStore.mockReturnValueOnce(codexAuthStore);
+    mockedResolveModelAsync.mockResolvedValueOnce({
+      model: {
+        id: "gpt-5.5",
+        provider: "codex",
+        contextWindow: 200_000,
+        api: "openai-chatgpt-responses",
+      },
+      error: null,
+      authStorage: codexAuthStorage,
+      modelRegistry: {},
+    });
+    mockedBuildAgentRuntimePlan.mockReturnValueOnce(runtimePlan);
+
+    try {
+      await runEmbeddedAgent({
+        ...overflowBaseRunParams,
+        provider: "codex",
+        model: "gpt-5.5",
+        authProfileId: "openai:work",
+        authProfileIdSource: "user",
+        runId: "codex-provider-responses-api-auth-bootstrap",
+      });
+    } finally {
+      clearAgentHarnesses();
+    }
+
+    expect(mockedEnsureAuthProfileStore).toHaveBeenCalledTimes(1);
+    expectRecordFields(mockCallArg(mockedEnsureAuthProfileStore, 0, 1), {
+      externalCliProviderIds: ["openai"],
+      allowKeychainPrompt: false,
+    });
+    expect(mockedEnsureAuthProfileStoreWithoutExternalProfiles).not.toHaveBeenCalled();
+    expectMockCallFields(mockedGetApiKeyForModel, {
+      profileId: "openai:work",
+    });
+    expect(pluginRunAttempt).toHaveBeenCalledTimes(1);
+    expectMockCallFields(pluginRunAttempt, {
+      provider: "codex",
+      authProfileId: "openai:work",
+      authProfileIdSource: "user",
+      resolvedApiKey: "test-key",
+    });
+  });
+
   it("loads the external Codex auth overlay before auto-selecting forced Codex runtime profiles", async () => {
     const { clearAgentHarnesses, registerAgentHarness } = await import("../harness/registry.js");
     const pluginRunAttempt = vi.fn<AgentHarness["runAttempt"]>(async () =>

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -823,7 +823,7 @@ export async function runEmbeddedAgent(
 
       const pluginHarnessNeedsOpenClawAuthBootstrap =
         pluginHarnessOwnsTransport &&
-        provider === OPENAI_PROVIDER_ID &&
+        (provider === OPENAI_PROVIDER_ID || provider === "codex") &&
         effectiveModel.api === "openai-chatgpt-responses";
       const openClawNativeCodexResponsesNeedsAuthBootstrap =
         !pluginHarnessOwnsTransport &&


### PR DESCRIPTION
## Summary

Fixes a regression where `codex/gpt-5.5` failed to attach OAuth profiles during inference, resulting in `profile=-` and `401 Unauthorized`.

The root cause was in `pluginHarnessNeedsOpenClawAuthBootstrap` (`src/agents/embedded-agent-runner/run.ts:826`), which required `provider === OPENAI_PROVIDER_ID`. When using `codex/gpt-5.5`, the provider resolves to `"codex"` (from the Codex plugin's `CODEX_PROVIDER_ID`), so the check evaluated to `false`. This caused the auth store to be initialized as empty (`createEmptyAuthProfileStore()`), stripping out the OAuth profile.

**Fix**: Include `"codex"` in the bootstrap condition so OpenClaw properly loads and forwards auth profiles for Codex harness responses-API models.

Regression introduced in commit `4c33aaa86c` ("refactor: unify OpenAI provider identity").

## Verification

- Added regression test: `bootstraps OpenClaw auth for codex harness when provider is codex and model uses responses API`
- Ran `pnpm test src/agents/embedded-agent-runner/run.overflow-compaction.test.ts --run`
- Result: **41/41 tests passed**

## Real behavior proof

**Behavior addressed**: Codex harness (`codex/gpt-5.5`) fails to attach OAuth profiles to inference requests because `pluginHarnessNeedsOpenClawAuthBootstrap` only checks for `provider === "openai"`, not `"codex"`.

**Real environment tested**: Local source checkout with mocked auth harness (no live Codex OAuth credentials available).

**Exact steps or command run after this patch**:
```
$ pnpm test src/agents/embedded-agent-runner/run.overflow-compaction.test.ts --run
```

**Evidence after fix**:

Regression test confirms `mockedEnsureAuthProfileStore` is called with `externalCliProviderIds: ["openai"]` when provider is `"codex"` and model uses `"openai-chatgpt-responses"`, and `mockedEnsureAuthProfileStoreWithoutExternalProfiles` is NOT called.

```
$ node -e "const fs=require('fs');const content=fs.readFileSync('src/agents/embedded-agent-runner/run.ts','utf8');const match=content.match(/pluginHarnessNeedsOpenClawAuthBootstrap[\s\S]{0,500}/);console.log(match[0])"
```

The fix adds `provider === "codex"` to the existing `OPENAI_PROVIDER_ID` check.

**Observed result after fix**: The regression test passes, confirming auth profiles are now correctly bootstrapped for the Codex harness responses-API path.

**What was not tested**: Live end-to-end inference against the actual Codex responses API with real OAuth credentials, due to lack of access.

## References

- Fixes #90528