### PR TITLE
fix(agents): trim dense text delta snapshots

### DIFF
--- a/extensions/ollama/src/stream-runtime.test.ts
+++ b/extensions/ollama/src/stream-runtime.test.ts
@@ -1630,9 +1630,9 @@ describe("createOllamaStreamFn streaming events", () => {
         const textStartEvent = events.find((e) => e.type === "text_start");
         expect(textStartEvent?.partial.content).toStrictEqual([]);
 
-        // text_delta partials accumulate content progressively
-        expect(deltas[0].partial.content).toEqual([{ type: "text", text: "Hello" }]);
-        expect(deltas[1].partial.content).toEqual([{ type: "text", text: "Hello world" }]);
+        // text_delta events stay lightweight; text_end/done carry the full snapshot.
+        expect(deltas[0]).not.toHaveProperty("partial");
+        expect(deltas[1]).not.toHaveProperty("partial");
 
         // done event contains the final message
         const doneEvent = events.at(-1);
@@ -2106,7 +2106,7 @@ describe("createOllamaStreamFn streaming events", () => {
     );
   });
 
-  it("sanitizes Kimi inline reasoning in text_delta, text_end, partial, and done output", async () => {
+  it("sanitizes Kimi inline reasoning in text_delta, text_end, and done output", async () => {
     await withMockNdjsonFetch(
       [
         JSON.stringify({
@@ -2149,8 +2149,8 @@ describe("createOllamaStreamFn streaming events", () => {
         expect(deltas).toHaveLength(2);
         expect(deltas[0]?.delta).toBe("Final answer");
         expect(deltas[1]?.delta).toBe(" only.");
-        expect(deltas[0]?.partial.content).toEqual([{ type: "text", text: "Final answer" }]);
-        expect(deltas[1]?.partial.content).toEqual([{ type: "text", text: "Final answer only." }]);
+        expect(deltas[0]).not.toHaveProperty("partial");
+        expect(deltas[1]).not.toHaveProperty("partial");
 
         const textEnd = events.find((e) => e.type === "text_end");
         expect(textEnd?.content).toBe("Final answer only.");

--- a/extensions/ollama/src/stream.ts
+++ b/extensions/ollama/src/stream.ts
@@ -1322,17 +1322,10 @@ function createRawOllamaStreamFn(
             }
 
             accumulatedVisibleContent = nextVisibleContent;
-            const partial = buildStreamAssistantMessage({
-              model: modelInfo,
-              content: buildCurrentContent(),
-              stopReason: "stop",
-              usage: buildUsageWithNoCost({}),
-            });
             stream.push({
               type: "text_delta",
               contentIndex: textContentIndex(),
               delta,
-              partial,
             });
           };
 

--- a/packages/agent-core/src/agent-loop.test.ts
+++ b/packages/agent-core/src/agent-loop.test.ts
@@ -76,12 +76,12 @@ describe("agentLoop EventStream failures", () => {
 });
 
 describe("agentLoop streaming updates", () => {
-  it("reuses the current assistant message for text deltas without partial snapshots", async () => {
+  it("rebuilds assistant message snapshots for text deltas without partial snapshots", async () => {
     const streamFn: StreamFn = async () => {
       const stream = createAssistantMessageEventStream();
-      const message: AssistantMessage = {
+      const startMessage: AssistantMessage = {
         role: "assistant",
-        content: [{ type: "text", text: "" }],
+        content: [],
         api: model.api,
         provider: model.provider,
         model: model.id,
@@ -96,17 +96,24 @@ describe("agentLoop streaming updates", () => {
         stopReason: "stop",
         timestamp: 1,
       };
+      const textStartMessage: AssistantMessage = { ...startMessage, content: [] };
+      const finalMessage: AssistantMessage = {
+        ...startMessage,
+        content: [{ type: "text", text: "Hello world" }],
+      };
 
       queueMicrotask(() => {
-        stream.push({ type: "start", partial: message });
-        stream.push({ type: "text_start", contentIndex: 0, partial: message });
-        const textBlock = message.content[0];
-        if (textBlock?.type === "text") {
-          textBlock.text = "Hello";
-        }
+        stream.push({ type: "start", partial: startMessage });
+        stream.push({ type: "text_start", contentIndex: 0, partial: textStartMessage });
         stream.push({ type: "text_delta", contentIndex: 0, delta: "Hello" });
-        stream.push({ type: "text_end", contentIndex: 0, content: "Hello", partial: message });
-        stream.push({ type: "done", reason: "stop", message });
+        stream.push({ type: "text_delta", contentIndex: 0, delta: " world" });
+        stream.push({
+          type: "text_end",
+          contentIndex: 0,
+          content: "Hello world",
+          partial: finalMessage,
+        });
+        stream.push({ type: "done", reason: "stop", message: finalMessage });
       });
 
       return stream;
@@ -121,15 +128,17 @@ describe("agentLoop streaming updates", () => {
     );
     const events = await collectEvents(stream);
 
-    const deltaUpdate = events.find(
+    const deltaUpdates = events.filter(
       (event): event is Extract<AgentEvent, { type: "message_update" }> =>
         event.type === "message_update" && event.assistantMessageEvent.type === "text_delta",
     );
-    expect(deltaUpdate).toMatchObject({
-      type: "message_update",
-      message: { role: "assistant", content: [{ type: "text", text: "Hello" }] },
-      assistantMessageEvent: { type: "text_delta", delta: "Hello" },
-    });
-    expect(deltaUpdate?.assistantMessageEvent).not.toHaveProperty("partial");
+    expect(deltaUpdates).toHaveLength(2);
+    expect(deltaUpdates.map((event) => event.message)).toMatchObject([
+      { role: "assistant", content: [{ type: "text", text: "Hello" }] },
+      { role: "assistant", content: [{ type: "text", text: "Hello world" }] },
+    ]);
+    for (const update of deltaUpdates) {
+      expect(update.assistantMessageEvent).not.toHaveProperty("partial");
+    }
   });
 });

--- a/packages/agent-core/src/agent-loop.test.ts
+++ b/packages/agent-core/src/agent-loop.test.ts
@@ -1,7 +1,8 @@
 // Agent Core tests cover agent loop behavior.
 import { describe, expect, it } from "vitest";
 import { agentLoop, agentLoopContinue } from "./agent-loop.js";
-import type { Message, Model } from "./llm.js";
+import { createAssistantMessageEventStream } from "./llm.js";
+import type { AssistantMessage, Message, Model } from "./llm.js";
 import type { AgentContext, AgentEvent, AgentLoopConfig, AgentMessage, StreamFn } from "./types.js";
 
 const model: Model = {
@@ -71,5 +72,64 @@ describe("agentLoop EventStream failures", () => {
     const result = await stream.result();
 
     expectTerminalFailure(events, result);
+  });
+});
+
+describe("agentLoop streaming updates", () => {
+  it("reuses the current assistant message for text deltas without partial snapshots", async () => {
+    const streamFn: StreamFn = async () => {
+      const stream = createAssistantMessageEventStream();
+      const message: AssistantMessage = {
+        role: "assistant",
+        content: [{ type: "text", text: "" }],
+        api: model.api,
+        provider: model.provider,
+        model: model.id,
+        usage: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 0,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+        stopReason: "stop",
+        timestamp: 1,
+      };
+
+      queueMicrotask(() => {
+        stream.push({ type: "start", partial: message });
+        stream.push({ type: "text_start", contentIndex: 0, partial: message });
+        const textBlock = message.content[0];
+        if (textBlock?.type === "text") {
+          textBlock.text = "Hello";
+        }
+        stream.push({ type: "text_delta", contentIndex: 0, delta: "Hello" });
+        stream.push({ type: "text_end", contentIndex: 0, content: "Hello", partial: message });
+        stream.push({ type: "done", reason: "stop", message });
+      });
+
+      return stream;
+    };
+
+    const stream = agentLoop(
+      [{ role: "user", content: "hello", timestamp: 1 }],
+      { systemPrompt: "", messages: [] },
+      config,
+      undefined,
+      streamFn,
+    );
+    const events = await collectEvents(stream);
+
+    const deltaUpdate = events.find(
+      (event): event is Extract<AgentEvent, { type: "message_update" }> =>
+        event.type === "message_update" && event.assistantMessageEvent.type === "text_delta",
+    );
+    expect(deltaUpdate).toMatchObject({
+      type: "message_update",
+      message: { role: "assistant", content: [{ type: "text", text: "Hello" }] },
+      assistantMessageEvent: { type: "text_delta", delta: "Hello" },
+    });
+    expect(deltaUpdate?.assistantMessageEvent).not.toHaveProperty("partial");
   });
 });

--- a/packages/agent-core/src/agent-loop.ts
+++ b/packages/agent-core/src/agent-loop.ts
@@ -402,7 +402,7 @@ async function streamAssistantResponse(
       case "toolcall_delta":
       case "toolcall_end":
         if (partialMessage) {
-          const message = event.partial;
+          const message: AssistantMessage = event.partial ?? partialMessage;
           partialMessage = message;
           context.messages[context.messages.length - 1] = message;
           await emit({

--- a/packages/agent-core/src/agent-loop.ts
+++ b/packages/agent-core/src/agent-loop.ts
@@ -3,6 +3,7 @@
 import { EventStream as LlmEventStream } from "@openclaw/llm-core";
 import type {
   AssistantMessage,
+  AssistantMessageEvent,
   Context,
   EventStream,
   ToolResultMessage,
@@ -34,6 +35,49 @@ const EMPTY_USAGE = {
 };
 
 const EventStreamConstructor: typeof SourceEventStream = LlmEventStream;
+
+type AssistantMessageUpdateEvent = Extract<
+  AssistantMessageEvent,
+  {
+    type:
+      | "text_start"
+      | "text_delta"
+      | "text_end"
+      | "thinking_start"
+      | "thinking_delta"
+      | "thinking_end"
+      | "toolcall_start"
+      | "toolcall_delta"
+      | "toolcall_end";
+  }
+>;
+
+function appendTextDeltaToAssistantMessage(
+  message: AssistantMessage,
+  contentIndex: number,
+  delta: string,
+): AssistantMessage {
+  const content = [...message.content];
+  const currentContent = content[contentIndex];
+  content[contentIndex] =
+    currentContent?.type === "text"
+      ? { ...currentContent, text: currentContent.text + delta }
+      : { type: "text", text: delta };
+  return { ...message, content };
+}
+
+function resolveAssistantMessageUpdate(
+  event: AssistantMessageUpdateEvent,
+  currentMessage: AssistantMessage,
+): AssistantMessage {
+  if ("partial" in event && event.partial) {
+    return event.partial;
+  }
+  if (event.type === "text_delta") {
+    return appendTextDeltaToAssistantMessage(currentMessage, event.contentIndex, event.delta);
+  }
+  return currentMessage;
+}
 
 /**
  * Start an agent loop with a new prompt message.
@@ -402,7 +446,7 @@ async function streamAssistantResponse(
       case "toolcall_delta":
       case "toolcall_end":
         if (partialMessage) {
-          const message: AssistantMessage = event.partial ?? partialMessage;
+          const message = resolveAssistantMessageUpdate(event, partialMessage);
           partialMessage = message;
           context.messages[context.messages.length - 1] = message;
           await emit({

--- a/packages/llm-core/src/types.ts
+++ b/packages/llm-core/src/types.ts
@@ -366,6 +366,11 @@ export interface Context {
 export type AssistantMessageEvent =
   | { type: "start"; partial: AssistantMessage }
   | { type: "text_start"; contentIndex: number; partial: AssistantMessage }
+  /**
+   * Plain text deltas may omit `partial` to avoid retaining one full assistant
+   * snapshot per token. Consumers that need current text should replay `delta`
+   * from the latest start/end partial checkpoint.
+   */
   | { type: "text_delta"; contentIndex: number; delta: string; partial?: AssistantMessage }
   | { type: "text_end"; contentIndex: number; content: string; partial: AssistantMessage }
   | { type: "thinking_start"; contentIndex: number; partial: AssistantMessage }

--- a/packages/llm-core/src/types.ts
+++ b/packages/llm-core/src/types.ts
@@ -366,7 +366,7 @@ export interface Context {
 export type AssistantMessageEvent =
   | { type: "start"; partial: AssistantMessage }
   | { type: "text_start"; contentIndex: number; partial: AssistantMessage }
-  | { type: "text_delta"; contentIndex: number; delta: string; partial: AssistantMessage }
+  | { type: "text_delta"; contentIndex: number; delta: string; partial?: AssistantMessage }
   | { type: "text_end"; contentIndex: number; content: string; partial: AssistantMessage }
   | { type: "thinking_start"; contentIndex: number; partial: AssistantMessage }
   | { type: "thinking_delta"; contentIndex: number; delta: string; partial: AssistantMessage }

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -25,7 +25,7 @@ import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "./system-prompt-cache-boundary.js"
 type OpenAICompletionsOutput = Parameters<typeof testing.processOpenAICompletionsStream>[1];
 type OpenAIResponsesOutput = Parameters<typeof testing.processResponsesStream>[1];
 
-type CapturedStreamEvent = { type?: string; delta?: string };
+type CapturedStreamEvent = { type?: string; delta?: string; partial?: unknown };
 
 function createDeepSeekCompletionsModel(): Model<"openai-completions"> {
   return {
@@ -1859,6 +1859,64 @@ describe("openai transport stream", () => {
     expect(stream.push.mock.calls.length).toBeLessThan(512);
   });
 
+  it("omits accumulated partial snapshots from OpenAI-compatible text deltas", async () => {
+    const model = {
+      id: "dense-local",
+      name: "Dense Local",
+      api: "openai-completions",
+      provider: "local",
+      baseUrl: "http://127.0.0.1:18065/v1",
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 128000,
+      maxTokens: 4096,
+    } satisfies Model<"openai-completions">;
+    const output = createAssistantOutput(model);
+    const events: CapturedStreamEvent[] = [];
+
+    await testing.processOpenAICompletionsStream(
+      streamChunks([
+        {
+          id: "chatcmpl-dense",
+          object: "chat.completion.chunk" as const,
+          created: 1775425651,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              delta: { role: "assistant" as const, content: "a" },
+              logprobs: null,
+              finish_reason: null,
+            },
+          ],
+        },
+        {
+          id: "chatcmpl-dense",
+          object: "chat.completion.chunk" as const,
+          created: 1775425651,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              delta: { content: "b" },
+              logprobs: null,
+              finish_reason: null,
+            },
+          ],
+        },
+      ]),
+      output,
+      model,
+      { push: (event) => events.push(event as CapturedStreamEvent) },
+    );
+
+    const textDeltas = events.filter((event) => event.type === "text_delta");
+    expect(textDeltas).toHaveLength(2);
+    expect(textDeltas.every((event) => !("partial" in event))).toBe(true);
+    expect(output.content).toEqual([{ type: "text", text: "ab" }]);
+  });
+
   it("yields to aborts during bursty Responses streams", async () => {
     const model = createAzureResponsesModel();
     const output = createResponsesAssistantOutput(model);
@@ -1885,6 +1943,28 @@ describe("openai transport stream", () => {
     ).rejects.toThrow("Request was aborted");
     expect(yieldedToTimer).toBe(true);
     expect(stream.push.mock.calls.length).toBeLessThan(512);
+  });
+
+  it("omits accumulated partial snapshots from Responses text deltas", async () => {
+    const model = createAzureResponsesModel();
+    const output = createResponsesAssistantOutput(model);
+    const events: CapturedStreamEvent[] = [];
+
+    await testing.processResponsesStream(
+      streamChunks([
+        { type: "response.output_item.added", item: { type: "message" } },
+        { type: "response.output_text.delta", delta: "a" },
+        { type: "response.output_text.delta", delta: "b" },
+      ]),
+      output,
+      { push: (event) => events.push(event as CapturedStreamEvent) },
+      model,
+    );
+
+    const textDeltas = events.filter((event) => event.type === "text_delta");
+    expect(textDeltas).toHaveLength(2);
+    expect(textDeltas.every((event) => !("partial" in event))).toBe(true);
+    expect(output.content).toEqual([{ type: "text", text: "ab" }]);
   });
 
   it("skips null and non-object OpenAI-compatible stream chunks", async () => {

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -1578,7 +1578,6 @@ async function processResponsesStream(
           type: "text_delta",
           contentIndex: blockIndex(),
           delta: stringifyUnknown(event.delta),
-          partial: output,
         });
       }
     } else if (type === "response.function_call_arguments.delta") {
@@ -2740,7 +2739,6 @@ async function processOpenAICompletionsStream(
       type: "text_delta",
       contentIndex: blockIndex(),
       delta: text,
-      partial: output,
     });
   };
   const flushPendingPostToolCallDeltas = () => {


### PR DESCRIPTION
## Summary

- Drops full accumulated assistant-message snapshots from plain `text_delta` events for OpenAI-compatible, OpenAI Responses, and Ollama streams.
- Keeps full snapshots on stream start/end/done plus tool/thinking events, so final state and structured events still have the full message.
- Updates the agent loop to reconstruct current assistant snapshots from lightweight text deltas.
- Adds regression coverage for OpenAI-compatible, Responses, Ollama, and agent-loop consumers.

## Linked context

Fixes #86599

Related #86633

Requested by maintainer follow-up on https://github.com/openclaw/openclaw/issues/86599.

## Maintainer contract decision

Accept the exported stream contract change: plain `AssistantMessageEvent` `text_delta` events may omit `partial` to avoid retaining one full assistant snapshot per token. Consumers that need the live assistant message should replay `delta` from the latest start/end partial checkpoint or use the reconstructed `message_update.message`; `text_start`, `text_end`, thinking, tool, terminal, and final events still carry full snapshots.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: local/OpenAI-compatible dense streams no longer carry the full answer-so-far inside every plain text delta.
- Real environment tested: Blacksmith Testbox / Crabbox on Linux, using a fake OpenAI-compatible local backend that emits 30,000 one-character SSE chunks.
- Exact steps or command run after this patch: built the CLI through `tsdown`/runtime-postbuild, then ran `node dist/entry.js infer model run --local --model local/dense --prompt hi --json` against the fake backend.
- Evidence after fix:

```text
OpenClaw 2026.6.2 (aef1fad)
curl_elapsed=0.05 maxrss_kb=11264
openclaw_local_elapsed=3.51 maxrss_kb=658044
4830164 /tmp/oc86599runtime/curl.sse
  30204 /tmp/oc86599runtime/local.json
served_chunks=30000 elapsed_ms=56
served_chunks=30000 elapsed_ms=52
```

- Observed result after fix: the fake backend served the dense stream in about 52-56ms, raw curl completed in 0.05s, and the built OpenClaw local model run completed in 3.51s without carrying 30k full partial snapshots.
- What was not tested: Windows desktop with a real Ollama/llama.cpp model.
- Proof limitations or environment constraints: Gateway `infer model run --gateway` was attempted in isolated Testbox state, but the client was blocked by Gateway device-pairing scope approval. Full `pnpm build` reached `tsdown` and runtime-postbuild, then the sparse GWT/Testbox omitted `ui/config/control-ui-chunking.ts`, so the UI build was not counted as passing proof.
- Before evidence: prior current-main Crabbox repro for the same fake 30k-chunk backend measured raw curl at 0.03s, local OpenClaw at 4.11s, and gateway at 10.31s; the root issue was the repeated full partial payload work rather than backend generation time.

## Tests and validation

- Exact-head changed gate: `node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox --timing-json -- env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed` on `tbx_01ktn8y7eph04qd9x71f4ez3we` / `violet-crab`: passed in 9m21s.
- Review-fix targeted proof: `crabbox run --provider blacksmith-testbox --timing-json --shell -- 'git diff --check && node scripts/run-vitest.mjs run packages/agent-core/src/agent-loop.test.ts src/agents/openai-transport-stream.test.ts extensions/ollama/src/stream-runtime.test.ts'` on `tbx_01ktn8tztvfyjc9azkj8ayhpf3` / `silver-shrimp`: passed 347 tests in 54.3s.
- Earlier exact-head targeted run before the review fix: same 3 Vitest shards passed on `tbx_01ktn5hrk4akdp5558h8f5k8ws` / `swift-hermit`.
- ClawSweeper/autoreview on `9569e072e535d677a0dfa2c747a0b12a4ad8c667`: ready for maintainer look, proof sufficient, no concrete contributor-facing blocker left.
- GitHub checks on the exact PR head: pass or skip only; no pending/failing checks at merge review time.

Regression coverage added:

- agent loop rebuilds `message_update.message` for immutable, partial-less `text_delta` snapshots.
- OpenAI-compatible and Responses text deltas omit accumulated partial snapshots.
- Ollama text deltas omit accumulated partial snapshots while `text_end` and `done` keep final content.

## Risk checklist

Did user-visible behavior change? `Yes`

Did config, environment, or migration behavior change? `No`

Did security, auth, secrets, network, or tool execution behavior change? `No`

What is the highest-risk area?

- Stream consumers that previously assumed every text delta carried `partial`.

How is that risk mitigated?

- The type now marks only plain text-delta `partial` as optional and documents the replay contract.
- Agent-loop reconstruction keeps message updates populated from lightweight deltas.
- Tool calls, thinking blocks, text start/end, and final done events still carry snapshots.
- Existing and added provider/agent tests cover the touched stream surfaces.
