### PR TITLE
fix(update): recover package gateway restart after refresh failure

### DIFF
--- a/src/cli/daemon-cli/restart-health.test.ts
+++ b/src/cli/daemon-cli/restart-health.test.ts
@@ -376,6 +376,69 @@ describe("inspectGatewayRestart", () => {
     expect(snapshot.versionMismatch).toBeUndefined();
   });
 
+  it("waits for the managed service when running service proof is required", async () => {
+    probeGateway.mockResolvedValue({
+      ok: true,
+      close: null,
+      server: { version: "2026.4.24", connId: "new" },
+    });
+    inspectPortUsage.mockResolvedValue({
+      port: 18789,
+      status: "busy",
+      listeners: [{ pid: 8000, commandLine: "openclaw-gateway" }],
+      hints: [],
+    });
+    const readRuntime = vi
+      .fn()
+      .mockResolvedValueOnce({ status: "stopped" })
+      .mockResolvedValue({ status: "running", pid: 8000 });
+
+    const { waitForGatewayHealthyRestart } = await import("./restart-health.js");
+    const snapshot = await waitForGatewayHealthyRestart({
+      service: { readRuntime } as unknown as GatewayService,
+      port: 18789,
+      expectedVersion: "2026.4.24",
+      requireRunningService: true,
+      attempts: 3,
+      delayMs: 1,
+    });
+
+    expect(snapshot.healthy).toBe(true);
+    expect(snapshot.runtime.status).toBe("running");
+    expect(snapshot.waitOutcome).toBe("healthy");
+    expect(snapshot.elapsedMs).toBe(1);
+    expect(sleep).toHaveBeenCalledOnce();
+  });
+
+  it("times out when running service proof never arrives", async () => {
+    probeGateway.mockResolvedValue({
+      ok: true,
+      close: null,
+      server: { version: "2026.4.24", connId: "stale" },
+    });
+    inspectPortUsage.mockResolvedValue({
+      port: 18789,
+      status: "busy",
+      listeners: [{ pid: 5151, commandLine: "openclaw-gateway" }],
+      hints: [],
+    });
+
+    const { waitForGatewayHealthyRestart } = await import("./restart-health.js");
+    const snapshot = await waitForGatewayHealthyRestart({
+      service: makeGatewayService({ status: "stopped" }),
+      port: 18789,
+      expectedVersion: "2026.4.24",
+      requireRunningService: true,
+      attempts: 2,
+      delayMs: 1,
+    });
+
+    expect(snapshot.healthy).toBe(true);
+    expect(snapshot.runtime.status).toBe("stopped");
+    expect(snapshot.waitOutcome).toBe("timeout");
+    expect(sleep).toHaveBeenCalledTimes(2);
+  });
+
   it("accepts matching-version restart liveness when the probe lacks operator scope", async () => {
     probeGateway.mockResolvedValue({
       ok: false,

--- a/src/cli/daemon-cli/restart-health.ts
+++ b/src/cli/daemon-cli/restart-health.ts
@@ -522,6 +522,7 @@ export async function waitForGatewayHealthyRestart(params: {
   env?: NodeJS.ProcessEnv;
   expectedVersion?: string | null;
   includeUnknownListenersAsStale?: boolean;
+  requireRunningService?: boolean;
 }): Promise<GatewayRestartSnapshot> {
   const attempts = params.attempts ?? DEFAULT_RESTART_HEALTH_ATTEMPTS;
   const delayMs = params.delayMs ?? DEFAULT_RESTART_HEALTH_DELAY_MS;
@@ -544,7 +545,9 @@ export async function waitForGatewayHealthyRestart(params: {
   );
 
   for (let attempt = 0; attempt < attempts; attempt += 1) {
-    if (snapshot.healthy) {
+    const healthy =
+      snapshot.healthy && (!params.requireRunningService || snapshot.runtime.status === "running");
+    if (healthy) {
       return withWaitContext(snapshot, "healthy", attempt * delayMs);
     }
     if (snapshot.activatedPluginErrors?.length) {

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -5015,6 +5015,9 @@ describe("update-cli", () => {
         }),
     });
     serviceLoaded.mockResolvedValue(true);
+    serviceReadCommand.mockResolvedValue({
+      programArguments: ["node", updatedEntrypoint, "gateway", "run"],
+    });
     vi.mocked(runCommandWithTimeout).mockImplementation(async (argv) => ({
       stdout: "",
       stderr:
@@ -5026,39 +5029,22 @@ describe("update-cli", () => {
       killed: false,
       termination: "exit",
     }));
-    probeGateway
-      .mockResolvedValueOnce({
-        ok: true,
-        close: null,
-        server: {
-          version: "2026.4.23",
-          connId: "old-gateway",
-        },
-        auth: { role: "operator", scopes: ["operator.read"], capability: "read_only" },
-        health: null,
-        status: null,
-        presence: null,
-        configSnapshot: null,
-        connectLatencyMs: 1,
-        error: null,
-        url: "ws://127.0.0.1:18789",
-      })
-      .mockResolvedValue({
-        ok: true,
-        close: null,
-        server: {
-          version: "2026.4.24",
-          connId: "updated-gateway",
-        },
-        auth: { role: "operator", scopes: ["operator.read"], capability: "read_only" },
-        health: null,
-        status: null,
-        presence: null,
-        configSnapshot: null,
-        connectLatencyMs: 1,
-        error: null,
-        url: "ws://127.0.0.1:18789",
-      });
+    probeGateway.mockResolvedValue({
+      ok: true,
+      close: null,
+      server: {
+        version: "2026.4.24",
+        connId: "updated-gateway",
+      },
+      auth: { role: "operator", scopes: ["operator.read"], capability: "read_only" },
+      health: null,
+      status: null,
+      presence: null,
+      configSnapshot: null,
+      connectLatencyMs: 1,
+      error: null,
+      url: "ws://127.0.0.1:18789",
+    });
 
     await updateCommand({ yes: true });
 
@@ -5074,6 +5060,152 @@ describe("update-cli", () => {
         .mock.calls.map((call) => String(call[0]))
         .join("\n"),
     ).toContain("Gateway: restarted and verified.");
+  });
+
+  it("accepts same-version refresh failure recovery when the managed service restarts", async () => {
+    const updatedRoot = createCaseDir("openclaw-updated-root");
+    const updatedEntrypoint = path.join(updatedRoot, "dist", "entry.js");
+    const updatedPackageJson = path.join(updatedRoot, "package.json");
+    await fs.mkdir(updatedRoot, { recursive: true });
+    await fs.writeFile(
+      updatedPackageJson,
+      JSON.stringify({ name: "openclaw", version: "2026.4.24" }),
+      "utf8",
+    );
+    setupUpdatedRootRefresh({
+      entrypoints: [updatedEntrypoint],
+      gatewayUpdateImpl: async () =>
+        makeOkUpdateResult({
+          mode: "npm",
+          root: updatedRoot,
+          before: { version: "2026.4.24" },
+          after: { version: "2026.4.24" },
+        }),
+    });
+    pathExists.mockImplementation(
+      async (candidate: string) =>
+        candidate === updatedEntrypoint || candidate === updatedPackageJson,
+    );
+    serviceLoaded.mockResolvedValue(true);
+    serviceReadCommand.mockResolvedValue({
+      programArguments: ["node", updatedEntrypoint, "gateway", "run"],
+    });
+    vi.mocked(runCommandWithTimeout).mockImplementation(async (argv) => ({
+      stdout: "",
+      stderr:
+        argv[1] === updatedEntrypoint && argv[2] === "gateway" && argv[3] === "install"
+          ? "launchctl bootstrap failed"
+          : "",
+      code: argv[1] === updatedEntrypoint && argv[2] === "gateway" && argv[3] === "install" ? 1 : 0,
+      signal: null,
+      killed: false,
+      termination: "exit",
+    }));
+    probeGateway.mockResolvedValue({
+      ok: true,
+      close: null,
+      server: {
+        version: "2026.4.24",
+        connId: "matching-old-gateway",
+      },
+      auth: { role: "operator", scopes: ["operator.read"], capability: "read_only" },
+      health: null,
+      status: null,
+      presence: null,
+      configSnapshot: null,
+      connectLatencyMs: 1,
+      error: null,
+      url: "ws://127.0.0.1:18789",
+    });
+
+    await updateCommand({ yes: true });
+
+    expect(gatewayCommandCall(updatedEntrypoint, "install")).toBeDefined();
+    expect(gatewayCommandCall(updatedEntrypoint, "restart")).toBeDefined();
+    expect(runRestartScript).not.toHaveBeenCalled();
+    expect(defaultRuntime.exit).not.toHaveBeenCalledWith(1);
+  });
+
+  it("rejects same-version refresh failure recovery from a stale service definition", async () => {
+    const oldRoot = createCaseDir("openclaw-old-root");
+    const updatedRoot = createCaseDir("openclaw-updated-root");
+    const oldEntrypoint = path.join(oldRoot, "dist", "entry.js");
+    const updatedEntrypoint = path.join(updatedRoot, "dist", "entry.js");
+    const oldPackageJson = path.join(oldRoot, "package.json");
+    const updatedPackageJson = path.join(updatedRoot, "package.json");
+    await Promise.all([
+      fs.mkdir(oldRoot, { recursive: true }),
+      fs.mkdir(updatedRoot, { recursive: true }),
+    ]);
+    await Promise.all([
+      fs.writeFile(
+        oldPackageJson,
+        JSON.stringify({ name: "openclaw", version: "2026.4.24" }),
+        "utf8",
+      ),
+      fs.writeFile(
+        updatedPackageJson,
+        JSON.stringify({ name: "openclaw", version: "2026.4.24" }),
+        "utf8",
+      ),
+    ]);
+    setupUpdatedRootRefresh({
+      entrypoints: [oldEntrypoint, updatedEntrypoint],
+      gatewayUpdateImpl: async () =>
+        makeOkUpdateResult({
+          mode: "npm",
+          root: updatedRoot,
+          before: { version: "2026.4.24" },
+          after: { version: "2026.4.24" },
+        }),
+    });
+    pathExists.mockImplementation(async (candidate: string) =>
+      [oldEntrypoint, updatedEntrypoint, oldPackageJson, updatedPackageJson].includes(candidate),
+    );
+    serviceLoaded.mockResolvedValue(true);
+    serviceReadCommand.mockResolvedValue({
+      programArguments: ["node", oldEntrypoint, "gateway", "run"],
+    });
+    vi.mocked(runCommandWithTimeout).mockImplementation(async (argv) => ({
+      stdout: "",
+      stderr:
+        argv[1] === updatedEntrypoint && argv[2] === "gateway" && argv[3] === "install"
+          ? "launchctl bootstrap failed"
+          : "",
+      code: argv[1] === updatedEntrypoint && argv[2] === "gateway" && argv[3] === "install" ? 1 : 0,
+      signal: null,
+      killed: false,
+      termination: "exit",
+    }));
+    probeGateway.mockResolvedValue({
+      ok: true,
+      close: null,
+      server: {
+        version: "2026.4.24",
+        connId: "matching-old-service",
+      },
+      auth: { role: "operator", scopes: ["operator.read"], capability: "read_only" },
+      health: null,
+      status: null,
+      presence: null,
+      configSnapshot: null,
+      connectLatencyMs: 1,
+      error: null,
+      url: "ws://127.0.0.1:18789",
+    });
+
+    await updateCommand({ yes: true });
+
+    expect(gatewayCommandCall(updatedEntrypoint, "install")).toBeDefined();
+    expect(gatewayCommandCall(updatedEntrypoint, "restart")).toBeDefined();
+    expect(runRestartScript).not.toHaveBeenCalled();
+    expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
+    expect(
+      vi
+        .mocked(defaultRuntime.log)
+        .mock.calls.map((call) => String(call[0]))
+        .join("\n"),
+    ).toContain("did not point at the updated install");
   });
 
   it("fails a JSON package update when fallback restart leaves the old gateway running", async () => {

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -5001,6 +5001,81 @@ describe("update-cli", () => {
     ).toContain("updated install entrypoint not found");
   });
 
+  it("tries the updated install restart when package service refresh fails", async () => {
+    const updatedRoot = createCaseDir("openclaw-updated-root");
+    const updatedEntrypoint = path.join(updatedRoot, "dist", "entry.js");
+    setupUpdatedRootRefresh({
+      entrypoints: [updatedEntrypoint],
+      gatewayUpdateImpl: async () =>
+        makeOkUpdateResult({
+          mode: "npm",
+          root: updatedRoot,
+          before: { version: "2026.4.23" },
+          after: { version: "2026.4.24" },
+        }),
+    });
+    serviceLoaded.mockResolvedValue(true);
+    vi.mocked(runCommandWithTimeout).mockImplementation(async (argv) => ({
+      stdout: "",
+      stderr:
+        argv[1] === updatedEntrypoint && argv[2] === "gateway" && argv[3] === "install"
+          ? "launchctl bootstrap failed"
+          : "",
+      code: argv[1] === updatedEntrypoint && argv[2] === "gateway" && argv[3] === "install" ? 1 : 0,
+      signal: null,
+      killed: false,
+      termination: "exit",
+    }));
+    probeGateway
+      .mockResolvedValueOnce({
+        ok: true,
+        close: null,
+        server: {
+          version: "2026.4.23",
+          connId: "old-gateway",
+        },
+        auth: { role: "operator", scopes: ["operator.read"], capability: "read_only" },
+        health: null,
+        status: null,
+        presence: null,
+        configSnapshot: null,
+        connectLatencyMs: 1,
+        error: null,
+        url: "ws://127.0.0.1:18789",
+      })
+      .mockResolvedValue({
+        ok: true,
+        close: null,
+        server: {
+          version: "2026.4.24",
+          connId: "updated-gateway",
+        },
+        auth: { role: "operator", scopes: ["operator.read"], capability: "read_only" },
+        health: null,
+        status: null,
+        presence: null,
+        configSnapshot: null,
+        connectLatencyMs: 1,
+        error: null,
+        url: "ws://127.0.0.1:18789",
+      });
+
+    await updateCommand({ yes: true });
+
+    expect(gatewayCommandCall(updatedEntrypoint, "install")).toBeDefined();
+    const restartCall = gatewayCommandCall(updatedEntrypoint, "restart");
+    expect(restartCall?.[0].slice(1)).toEqual([updatedEntrypoint, "gateway", "restart"]);
+    expect(restartCall?.[1].cwd).toBe(updatedRoot);
+    expect(runRestartScript).not.toHaveBeenCalled();
+    expect(defaultRuntime.exit).not.toHaveBeenCalledWith(1);
+    expect(
+      vi
+        .mocked(defaultRuntime.log)
+        .mock.calls.map((call) => String(call[0]))
+        .join("\n"),
+    ).toContain("Gateway: restarted and verified.");
+  });
+
   it("fails a JSON package update when fallback restart leaves the old gateway running", async () => {
     const updatedRoot = createCaseDir("openclaw-updated-root");
     const updatedEntrypoint = path.join(updatedRoot, "dist", "entry.js");

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -1409,6 +1409,29 @@ async function resolveManagedServicePackageUpdateRoot(params: {
   };
 }
 
+async function gatewayServiceCommandUsesRoot(params: {
+  root: string | undefined;
+  env?: NodeJS.ProcessEnv;
+}): Promise<boolean> {
+  const expectedRoot = normalizeOptionalString(params.root);
+  if (!expectedRoot) {
+    return false;
+  }
+  const command = await resolveGatewayService()
+    .readCommand(params.env ?? process.env)
+    .catch(() => null);
+  const layout = await summarizeGatewayServiceLayout(command);
+  const serviceRoot = layout?.packageRoot;
+  if (!serviceRoot) {
+    return false;
+  }
+  const [expectedRootReal, serviceRootReal] = await Promise.all([
+    tryRealpathOrResolve(expectedRoot),
+    tryRealpathOrResolve(serviceRoot),
+  ]);
+  return expectedRootReal === serviceRootReal;
+}
+
 async function runPackageInstallUpdate(params: {
   root: string;
   installKind: "git" | "package" | "unknown";
@@ -1974,7 +1997,10 @@ async function maybeRestartService(params: {
   invocationCwd?: string;
   nodeRunner?: string;
 }): Promise<boolean> {
-  const verifyRestartedGateway = async (expectedGatewayVersion: string | undefined) => {
+  const verifyRestartedGateway = async (
+    expectedGatewayVersion: string | undefined,
+    opts: { requireRunningService?: boolean } = {},
+  ) => {
     const restartAfterStaleCleanup = async () => {
       if (params.refreshServiceEnv && isPackageManagerUpdateMode(params.result.mode)) {
         await runUpdatedInstallGatewayRestart({
@@ -1996,6 +2022,7 @@ async function maybeRestartService(params: {
       port: params.gatewayPort,
       expectedVersion: expectedGatewayVersion,
       env: params.serviceEnv,
+      requireRunningService: opts.requireRunningService,
     });
     if (!health.healthy && health.staleGatewayPids.length > 0) {
       if (!params.opts.json) {
@@ -2012,6 +2039,7 @@ async function maybeRestartService(params: {
         port: params.gatewayPort,
         expectedVersion: expectedGatewayVersion,
         env: params.serviceEnv,
+        requireRunningService: opts.requireRunningService,
       });
     }
 
@@ -2038,7 +2066,9 @@ async function maybeRestartService(params: {
       }
     }
 
-    if (health.healthy) {
+    const serviceRuntimeHealthy =
+      !opts.requireRunningService || health.runtime.status === "running";
+    if (health.healthy && serviceRuntimeHealthy) {
       if (!params.opts.json) {
         defaultRuntime.log(theme.success("Gateway: restarted and verified."));
       }
@@ -2047,6 +2077,9 @@ async function maybeRestartService(params: {
 
     const diagnosticLines = [
       "Gateway did not become healthy after restart.",
+      ...(health.healthy && opts.requireRunningService
+        ? ["Gateway responded, but the managed service did not report running after restart."]
+        : []),
       ...renderRestartDiagnostics(health),
       ...(launchAgentRecovery?.attempted
         ? [
@@ -2086,10 +2119,14 @@ async function maybeRestartService(params: {
         ? normalizeOptionalString(params.result.after?.version)
         : undefined;
       const isPackageUpdate = isPackageManagerUpdateMode(params.result.mode);
+      const canVerifyUpdatedGatewayByVersion =
+        expectedGatewayVersion !== undefined &&
+        expectedGatewayVersion !== normalizeOptionalString(params.result.before?.version);
       let restarted = false;
       let restartInitiated = false;
       let refreshedGatewayAlreadyHealthy = false;
-      let serviceEnvRefreshFailed = false;
+      let updatedInstallRestartNeedsServiceRootProof = false;
+      let restartScriptPath = params.restartScriptPath;
       if (params.refreshServiceEnv) {
         try {
           await refreshGatewayServiceEnv({
@@ -2099,6 +2136,24 @@ async function maybeRestartService(params: {
             env: params.serviceEnv,
             nodeRunner: params.nodeRunner,
           });
+          if (isPackageUpdate && expectedGatewayVersion) {
+            const health = await waitForGatewayHealthyRestart({
+              service: resolveGatewayService(),
+              port: params.gatewayPort,
+              expectedVersion: expectedGatewayVersion,
+              env: params.serviceEnv,
+              attempts: POST_REFRESH_ALREADY_HEALTHY_ATTEMPTS,
+              delayMs: POST_REFRESH_ALREADY_HEALTHY_DELAY_MS,
+            });
+            refreshedGatewayAlreadyHealthy = health.healthy;
+            if (refreshedGatewayAlreadyHealthy && !params.opts.json) {
+              defaultRuntime.log(
+                theme.muted(
+                  "Gateway already reports the updated version after service refresh; skipped redundant restart.",
+                ),
+              );
+            }
+          }
         } catch (err) {
           // Always log the refresh failure so callers can detect it (issue #56772).
           // Previously this was silently suppressed in --json mode, hiding the root
@@ -2109,37 +2164,18 @@ async function maybeRestartService(params: {
           } else {
             defaultRuntime.log(theme.warn(message));
           }
-          serviceEnvRefreshFailed = true;
-        }
-        if (isPackageUpdate && expectedGatewayVersion) {
-          const health = await waitForGatewayHealthyRestart({
-            service: resolveGatewayService(),
-            port: params.gatewayPort,
-            expectedVersion: expectedGatewayVersion,
-            env: params.serviceEnv,
-            attempts: POST_REFRESH_ALREADY_HEALTHY_ATTEMPTS,
-            delayMs: POST_REFRESH_ALREADY_HEALTHY_DELAY_MS,
-          });
-          refreshedGatewayAlreadyHealthy = health.healthy;
-          if (refreshedGatewayAlreadyHealthy && !params.opts.json) {
-            defaultRuntime.log(
-              theme.muted(
-                "Gateway already reports the updated version after service refresh; skipped redundant restart.",
-              ),
-            );
+          if (isPackageUpdate) {
+            restartScriptPath = null;
+            updatedInstallRestartNeedsServiceRootProof = !canVerifyUpdatedGatewayByVersion;
           }
         }
       }
       // Service refresh can bootstrap a RunAtLoad LaunchAgent directly. When
       // that already produced the expected gateway version, a second kickstart
       // would only race the healthy supervisor-owned process.
-      if (
-        !refreshedGatewayAlreadyHealthy &&
-        params.restartScriptPath &&
-        !(isPackageUpdate && serviceEnvRefreshFailed)
-      ) {
+      if (!refreshedGatewayAlreadyHealthy && restartScriptPath) {
         await createUpdateConfigSnapshot();
-        await runRestartScript(params.restartScriptPath);
+        await runRestartScript(restartScriptPath);
         restartInitiated = true;
       } else if (!refreshedGatewayAlreadyHealthy && params.refreshServiceEnv && isPackageUpdate) {
         await createUpdateConfigSnapshot();
@@ -2150,6 +2186,20 @@ async function maybeRestartService(params: {
           env: params.serviceEnv,
           nodeRunner: params.nodeRunner,
         });
+        if (
+          updatedInstallRestartNeedsServiceRootProof &&
+          !(await gatewayServiceCommandUsesRoot({
+            root: params.result.root,
+            env: params.serviceEnv,
+          }))
+        ) {
+          if (!params.opts.json) {
+            defaultRuntime.log(
+              theme.warn("Gateway service did not point at the updated install after restart."),
+            );
+          }
+          return false;
+        }
       } else if (
         !refreshedGatewayAlreadyHealthy &&
         shouldUseLegacyProcessRestartAfterUpdate({ updateMode: params.result.mode })
@@ -2165,7 +2215,9 @@ async function maybeRestartService(params: {
         restartInitiated ||
         (restarted && expectedGatewayVersion !== undefined);
       if (shouldVerifyRestart) {
-        const restartHealthy = await verifyRestartedGateway(expectedGatewayVersion);
+        const restartHealthy = await verifyRestartedGateway(expectedGatewayVersion, {
+          requireRunningService: updatedInstallRestartNeedsServiceRootProof,
+        });
         if (!restartHealthy) {
           if (!params.opts.json) {
             defaultRuntime.log("");

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -2089,6 +2089,7 @@ async function maybeRestartService(params: {
       let restarted = false;
       let restartInitiated = false;
       let refreshedGatewayAlreadyHealthy = false;
+      let serviceEnvRefreshFailed = false;
       if (params.refreshServiceEnv) {
         try {
           await refreshGatewayServiceEnv({
@@ -2108,9 +2109,7 @@ async function maybeRestartService(params: {
           } else {
             defaultRuntime.log(theme.warn(message));
           }
-          if (isPackageUpdate) {
-            return false;
-          }
+          serviceEnvRefreshFailed = true;
         }
         if (isPackageUpdate && expectedGatewayVersion) {
           const health = await waitForGatewayHealthyRestart({
@@ -2134,7 +2133,11 @@ async function maybeRestartService(params: {
       // Service refresh can bootstrap a RunAtLoad LaunchAgent directly. When
       // that already produced the expected gateway version, a second kickstart
       // would only race the healthy supervisor-owned process.
-      if (!refreshedGatewayAlreadyHealthy && params.restartScriptPath) {
+      if (
+        !refreshedGatewayAlreadyHealthy &&
+        params.restartScriptPath &&
+        !(isPackageUpdate && serviceEnvRefreshFailed)
+      ) {
         await createUpdateConfigSnapshot();
         await runRestartScript(params.restartScriptPath);
         restartInitiated = true;


### PR DESCRIPTION
## Summary
- Continue package-update restart recovery when refreshing the managed gateway service environment from the updated install fails.
- Prefer the updated install's `gateway restart` path after refresh failure so unmanaged/stale gateway listeners can be replaced by the newer CLI.
- Add regression coverage for the observed stale-gateway sequence: refresh fails, first probe sees the old version, updated-root restart runs, second probe sees the new version.


## Verification
- `node scripts/run-vitest.mjs src/cli/update-cli.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `git diff --check`
- `npm pack --json --pack-destination /tmp/openclaw-pr-91581-artifacts` from PR head `2fa5a5b2c15ec64d7d6d771d33f4496a2730d917`
- Isolated macOS LaunchAgent package-update proof using published `openclaw@2026.6.1` -> PR tarball `openclaw-2026.6.2.tgz`


## Real behavior proof
Behavior addressed: Package-manager update could install the new OpenClaw package but stop restart recovery when `gateway install --force` failed, leaving an old gateway process serving the port.
Real environment tested: Local macOS LaunchAgent with disposable `HOME`, disposable npm prefix, named profile `pr91581`, service label `ai.openclaw.pr91581`, gateway port `19981`, published baseline package `openclaw@2026.6.1`, and PR-head tarball `openclaw-2026.6.2.tgz` built from `2fa5a5b2c15ec64d7d6d771d33f4496a2730d917`.
Exact steps or command run after this patch: Installed `openclaw@2026.6.1` into `/tmp/openclaw-pr-91581-live5/npm-prefix`, ran `openclaw --profile pr91581 gateway install --force --port 19981`, verified the baseline gateway, then ran `NPM_CONFIG_PREFIX=/tmp/openclaw-pr-91581-live5/npm-prefix openclaw --profile pr91581 update --tag /tmp/openclaw-pr-91581-artifacts/openclaw-2026.6.2.tgz --yes --timeout 240`.
Evidence after fix: Terminal capture from the isolated run:
```text
npm_root_g=/tmp/openclaw-pr-91581-live5/npm-prefix/lib/node_modules
baseline_cli=OpenClaw 2026.6.1 (2e08f0f)

# baseline gateway status
{
  "gatewayVersion": "2026.6.1",
  "port": 19981,
  "serviceLoaded": true,
  "serviceRuntime": "running",
  "program": [
    "/Users/jason/.nvm/versions/node/v23.11.1/bin/node",
    "/private/tmp/openclaw-pr-91581-live5/npm-prefix/lib/node_modules/openclaw/dist/index.js",
    "gateway",
    "--port",
    "19981"
  ]
}

Update Result: OK
  Root: /tmp/openclaw-pr-91581-live5/npm-prefix/lib/node_modules/openclaw
  Before: 2026.6.1
  After: 2026.6.2

Steps:
  ✓ global update (20.04s)
  ✓ global install swap (1.22s)
  ✓ openclaw doctor (5.69s)

Restarting service...
Gateway already reports the updated version after service refresh; skipped redundant restart.
Gateway: restarted and verified.
```
A separate disposable forced-failure run patched only the generated `ai.openclaw.pr91581` service env during the update so the updated install's first `launchctl bootstrap` failed. That run reached the refresh-failure branch in the PR-head package:
```text
Failed to refresh gateway service environment from updated install: Error: updated install refresh failed (/tmp/openclaw-pr-91581-live6/npm-prefix/lib/node_modules/openclaw/dist/index.js):
Gateway install failed: Error: launchctl bootstrap failed: simulated launchctl bootstrap failure for PR 91581 proof
```
Observed result after fix: The real named-profile package update replaced the baseline `2026.6.1` package with the PR `2026.6.2` package and verified the LaunchAgent gateway on port `19981`. The forced-failure harness confirmed the updated package emits the refresh-failure path under a real package update, while the committed Vitest regression covers the intended fallback to updated-root `gateway restart` after that failure.
What was not tested: An organic macOS `launchctl`/LaunchAgent failure from the OS; the refresh-failure case was forced with a temporary launchctl wrapper in a disposable profile. The forced-failure harness was suitable for reaching the failure branch but not for a clean recovery-success claim, so the fallback success remains covered by the focused regression test.
