### PR TITLE
perf(control-ui): warn on slow first replies

### DIFF
--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -53,6 +53,7 @@ let removeQueuedMessage: typeof import("./app-chat.ts").removeQueuedMessage;
 let markQueuedChatSendsWaitingForReconnect: typeof import("./app-chat.ts").markQueuedChatSendsWaitingForReconnect;
 let retryReconnectableQueuedChatSends: typeof import("./app-chat.ts").retryReconnectableQueuedChatSends;
 let recordChatSendServerTiming: typeof import("./app-chat.ts").recordChatSendServerTiming;
+let recordFirstAssistantChatTiming: typeof import("./app-chat.ts").recordFirstAssistantChatTiming;
 
 async function loadChatHelpers(): Promise<void> {
   ({
@@ -68,6 +69,7 @@ async function loadChatHelpers(): Promise<void> {
     markQueuedChatSendsWaitingForReconnect,
     retryReconnectableQueuedChatSends,
     recordChatSendServerTiming,
+    recordFirstAssistantChatTiming,
   } = await import("./app-chat.ts"));
 }
 
@@ -1472,6 +1474,83 @@ describe("handleSendChat", () => {
           agentRunId: "agent-run-1",
         }),
       ]),
+    );
+  });
+
+  it("warns when the first assistant reply paint is slow", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+      queueMicrotask(() => callback(0));
+      return 1;
+    });
+    const runId = "run-slow-first-assistant";
+    const host = makeHost({
+      chatStream: "slow first token",
+      eventLogBuffer: [],
+      tab: "debug",
+    });
+    const timingHost = host as ChatHost & {
+      chatSendTimingsByRun: Map<
+        string,
+        {
+          runId: string;
+          submittedAtMs: number;
+          requestStartedAtMs: number;
+          ackAtMs: number;
+          ackStatus: "started";
+          sendAttempts: number;
+          sendState: "sending";
+          sessionKey: string;
+          agentId: string;
+        }
+      >;
+    };
+    timingHost.chatSendTimingsByRun = new Map([
+      [
+        runId,
+        {
+          runId,
+          submittedAtMs: performance.now() - 2_000,
+          requestStartedAtMs: performance.now() - 1_900,
+          ackAtMs: performance.now() - 1_800,
+          ackStatus: "started",
+          sendAttempts: 1,
+          sendState: "sending",
+          sessionKey: "agent:main",
+          agentId: "main",
+        },
+      ],
+    ]);
+
+    recordFirstAssistantChatTiming(
+      host,
+      {
+        agentId: "main",
+        runId,
+        sessionKey: "agent:main",
+        state: "delta",
+      },
+      "delta",
+    );
+
+    await vi.waitFor(() =>
+      expect(eventPayloads(host, "control-ui.chat.send")).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            phase: "first-assistant-visible",
+            runId,
+            slow: true,
+          }),
+        ]),
+      ),
+    );
+    expect(warn).toHaveBeenCalledWith(
+      "[openclaw] control-ui.chat.send",
+      expect.objectContaining({
+        phase: "first-assistant-visible",
+        runId,
+        slow: true,
+      }),
     );
   });
 

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -650,6 +650,11 @@ const CHAT_SEND_SERVER_TIMING_PHASES = new Set<ChatSendServerTimingPhase>([
   "dispatch-completed",
   "post-dispatch-completed",
 ]);
+const CHAT_SEND_SLOW_FIRST_ASSISTANT_MS = 1_500;
+
+function chatSendTimingOptions(slow: boolean) {
+  return { console: slow, warn: slow, maxBufferedEventsForType: 40 };
+}
 
 function recordChatSendTiming(
   host: ChatHost,
@@ -715,6 +720,7 @@ export function recordChatSendServerTiming(host: ChatHost, payload: unknown) {
   if (durationMs === undefined) {
     return;
   }
+  const slow = phase === "first-assistant-event" && durationMs >= CHAT_SEND_SLOW_FIRST_ASSISTANT_MS;
   recordControlUiPerformanceEvent(
     host as Parameters<typeof recordControlUiPerformanceEvent>[0],
     "control-ui.chat.send",
@@ -749,8 +755,9 @@ export function recordChatSendServerTiming(host: ChatHost, payload: unknown) {
       ...(typeof record.agentRunId === "string" && record.agentRunId.trim()
         ? { agentRunId: record.agentRunId.trim() }
         : {}),
+      ...(slow ? { slow: true } : {}),
     },
-    { console: false, maxBufferedEventsForType: 40 },
+    chatSendTimingOptions(slow),
   );
 }
 
@@ -884,12 +891,14 @@ export function recordFirstAssistantChatTiming(
   entry.firstAssistantVisibleRecorded = true;
   scheduleControlUiAfterPaint(host, () => {
     const paintedAtMs = controlUiNowMs();
+    const durationMs = roundedControlUiDurationMs(paintedAtMs - entry.submittedAtMs);
+    const slow = durationMs >= CHAT_SEND_SLOW_FIRST_ASSISTANT_MS;
     recordControlUiPerformanceEvent(
       host as Parameters<typeof recordControlUiPerformanceEvent>[0],
       "control-ui.chat.send",
       {
         phase,
-        durationMs: roundedControlUiDurationMs(paintedAtMs - entry.submittedAtMs),
+        durationMs,
         runId,
         sessionKey: entry.sessionKey ?? payload.sessionKey,
         agentId: entry.agentId ?? payload.agentId,
@@ -910,8 +919,9 @@ export function recordFirstAssistantChatTiming(
               ackToFirstAssistantEventMs: roundedControlUiDurationMs(eventAtMs - entry.ackAtMs),
             }
           : {}),
+        ...(slow ? { slow: true } : {}),
       },
-      { console: false, maxBufferedEventsForType: 40 },
+      chatSendTimingOptions(slow),
     );
     if (phase === "terminal-before-delta") {
       host.chatSendTimingsByRun?.delete(runId);


### PR DESCRIPTION
## Summary
- mark slow Control UI first-assistant timing events with `slow: true`
- warn only for slow first-assistant/server-first-assistant timing phases; normal chat timing stays buffered-only
- add a focused regression test for the slow first-assistant visible path

## Verification
- `git diff --check`
- Testbox `tbx_01ktn626pj8t3kd0zjwyzw2nj2`: `node scripts/run-vitest.mjs ui/src/ui/app-chat.test.ts --reporter=verbose -t "warns when the first assistant reply paint is slow"` (Actions run 27181556085)
- Testbox `tbx_01ktn621qd2ggj5fazkmmj5pmp`: `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/ui/e2e/chat-flow.e2e.test.ts --reporter=verbose -t "sends the first chat turn while agents startup loading is still pending"` (Actions run 27181553570)
- Testbox `tbx_01ktn64dncq42g0kq2z586vraz`: `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed` (Actions run 27181593288)
- `.agents/skills/autoreview/scripts/autoreview --mode local` -> clean, no accepted/actionable findings

## Notes
- Rejected startup command metadata coalescing after autoreview showed it would move synchronous skill workspace discovery onto the `chat.startup` critical path.
