### PR TITLE
Harden external CLI auth sync diagnostics

### DIFF
--- a/src/agents/auth-health.test.ts
+++ b/src/agents/auth-health.test.ts
@@ -181,6 +181,12 @@ describe("buildAuthHealthSummary", () => {
     const provider = summary.providers.find((entry) => entry.provider === "openai");
     expect(provider?.status).toBe("ok");
     expect(provider?.expiresAt).toBe(now + DEFAULT_OAUTH_WARN_MS + 60_000);
+    expect(summary.profiles[0]?.externalCli).toMatchObject({
+      status: "synced",
+      persistence: "runtime-only",
+      externalProvider: "openai",
+      externalExpires: now + DEFAULT_OAUTH_WARN_MS + 60_000,
+    });
     expect(readCodexCliCredentialsCachedMock).toHaveBeenCalledWith(
       expect.objectContaining({ allowKeychainPrompt: false }),
     );

--- a/src/agents/auth-health.ts
+++ b/src/agents/auth-health.ts
@@ -18,6 +18,10 @@ import {
 } from "./auth-profiles/credential-state.js";
 import { resolveAuthProfileDisplayLabel } from "./auth-profiles/display.js";
 import { resolveEffectiveOAuthCredential } from "./auth-profiles/effective-oauth.js";
+import {
+  diagnoseExternalCliAuthProfileSync,
+  type ExternalCliAuthSyncDiagnostic,
+} from "./auth-profiles/external-cli-sync.js";
 import { resolveAuthProfileOrder } from "./auth-profiles/order.js";
 import type { AuthProfileCredential, AuthProfileStore } from "./auth-profiles/types.js";
 import { resolveProviderIdForAuth } from "./provider-auth-aliases.js";
@@ -36,6 +40,7 @@ type AuthProfileHealth = {
   remainingMs?: number;
   source: AuthProfileSource;
   label: string;
+  externalCli?: ExternalCliAuthSyncDiagnostic;
 };
 
 export type AuthProviderHealthStatus = "ok" | "expiring" | "expired" | "missing" | "static";
@@ -247,6 +252,14 @@ function buildProfileHealth(params: {
     expiresAt,
     remainingMs,
   } = resolveOAuthStatus(effectiveCredential.expires, now, oauthWarnAfterMs);
+  const externalCli =
+    credential.type === "oauth"
+      ? diagnoseExternalCliAuthProfileSync({
+          profileId,
+          credential,
+          allowKeychainPrompt: allowKeychainPrompt ?? false,
+        })
+      : null;
   return {
     profileId,
     provider,
@@ -256,6 +269,7 @@ function buildProfileHealth(params: {
     remainingMs,
     source,
     label,
+    ...(externalCli ? { externalCli } : {}),
   };
 }
 

--- a/src/agents/auth-profiles.external-cli-sync.test.ts
+++ b/src/agents/auth-profiles.external-cli-sync.test.ts
@@ -3,7 +3,7 @@
  * Covers cached credential readers, bootstrap/replace policy, and runtime-only
  * profile persistence decisions without touching real CLI credential stores.
  */
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AuthProfileStore, OAuthCredential } from "./auth-profiles/types.js";
 import type { ClaudeCliCredential } from "./cli-credentials.js";
 
@@ -16,6 +16,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 let readManagedExternalCliCredential: typeof import("./auth-profiles/external-cli-sync.js").readManagedExternalCliCredential;
+let diagnoseExternalCliAuthProfileSync: typeof import("./auth-profiles/external-cli-sync.js").diagnoseExternalCliAuthProfileSync;
 let resolveExternalCliAuthProfiles: typeof import("./auth-profiles/external-cli-sync.js").resolveExternalCliAuthProfiles;
 let hasUsableOAuthCredential: typeof import("./auth-profiles/external-cli-sync.js").hasUsableOAuthCredential;
 let isSafeToUseExternalCliCredential: typeof import("./auth-profiles/external-cli-sync.js").isSafeToUseExternalCliCredential;
@@ -108,6 +109,10 @@ function expectReaderPolicyCall(mock: { mock: { calls: unknown[][] } }) {
 }
 
 describe("external cli oauth resolution", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   beforeEach(async () => {
     vi.resetModules();
     vi.doMock("./cli-credentials.js", () => ({
@@ -119,6 +124,7 @@ describe("external cli oauth resolution", () => {
     mocks.readCodexCliCredentialsCached.mockReset().mockReturnValue(null);
     mocks.readMiniMaxCliCredentialsCached.mockReset().mockReturnValue(null);
     ({
+      diagnoseExternalCliAuthProfileSync,
       hasUsableOAuthCredential,
       isSafeToUseExternalCliCredential,
       readManagedExternalCliCredential,
@@ -331,6 +337,138 @@ describe("external cli oauth resolution", () => {
         accountId: "acct-codex",
       },
     );
+  });
+
+  it("diagnoses successful runtime Codex CLI sync", () => {
+    const now = 1_700_000_000_000;
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    mocks.readCodexCliCredentialsCached.mockReturnValue(
+      makeOAuthCredential({
+        provider: "openai",
+        access: "codex-cli-access",
+        refresh: "codex-cli-refresh",
+        expires: now + 5 * 24 * 60 * 60_000,
+        accountId: "acct-codex",
+      }),
+    );
+
+    const diagnostic = diagnoseExternalCliAuthProfileSync({
+      profileId: OPENAI_CODEX_DEFAULT_PROFILE_ID,
+      credential: {
+        type: "oauth",
+        provider: "openai",
+      } as OAuthCredential,
+      allowKeychainPrompt: false,
+    });
+
+    expect(diagnostic).toMatchObject({
+      profileId: OPENAI_CODEX_DEFAULT_PROFILE_ID,
+      provider: "openai",
+      externalProvider: "openai",
+      status: "synced",
+      persistence: "runtime-only",
+      externalExpires: now + 5 * 24 * 60 * 60_000,
+    });
+    expect(diagnostic?.message).toContain("being used at runtime");
+    expect(diagnostic?.action).toContain("openclaw models auth login --provider openai");
+  });
+
+  it("diagnoses stale local Codex OAuth that cannot be replaced by CLI sync", () => {
+    const now = 1_700_000_000_000;
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    mocks.readCodexCliCredentialsCached.mockReturnValue(
+      makeOAuthCredential({
+        provider: "openai",
+        access: "codex-cli-access",
+        refresh: "codex-cli-refresh",
+        expires: now + 5 * 24 * 60 * 60_000,
+        accountId: "acct-codex",
+      }),
+    );
+
+    const diagnostic = diagnoseExternalCliAuthProfileSync({
+      profileId: OPENAI_CODEX_DEFAULT_PROFILE_ID,
+      credential: makeOAuthCredential({
+        provider: "openai",
+        access: "local-stale-access",
+        refresh: "local-refresh",
+        expires: now - 5_000,
+        accountId: "acct-codex",
+      }),
+      allowKeychainPrompt: false,
+    });
+
+    expect(diagnostic).toMatchObject({
+      status: "local_stale",
+      persistence: "runtime-only",
+      localExpires: now - 5_000,
+      externalExpires: now + 5 * 24 * 60 * 60_000,
+    });
+    expect(diagnostic?.message).toContain("must be refreshed directly");
+  });
+
+  it("diagnoses stale external Codex CLI credentials", () => {
+    const now = 1_700_000_000_000;
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    mocks.readCodexCliCredentialsCached.mockReturnValue(
+      makeOAuthCredential({
+        provider: "openai",
+        access: "codex-cli-access",
+        refresh: "codex-cli-refresh",
+        expires: now - 5_000,
+        accountId: "acct-codex",
+      }),
+    );
+
+    const diagnostic = diagnoseExternalCliAuthProfileSync({
+      profileId: OPENAI_CODEX_DEFAULT_PROFILE_ID,
+      credential: {
+        type: "oauth",
+        provider: "openai",
+      } as OAuthCredential,
+      allowKeychainPrompt: false,
+    });
+
+    expect(diagnostic).toMatchObject({
+      status: "external_stale",
+      persistence: "runtime-only",
+      externalExpires: now - 5_000,
+    });
+    expect(diagnostic?.message).toContain("stale or near expiry");
+    expect(diagnostic?.action).toContain("openclaw models auth login --provider openai");
+  });
+
+  it("diagnoses account mismatches before external CLI adoption", () => {
+    const now = 1_700_000_000_000;
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    mocks.readMiniMaxCliCredentialsCached.mockReturnValue(
+      makeOAuthCredential({
+        provider: "minimax-portal",
+        access: "external-access",
+        refresh: "external-refresh",
+        expires: now + 5 * 24 * 60 * 60_000,
+        email: "external@example.com",
+      }),
+    );
+
+    const diagnostic = diagnoseExternalCliAuthProfileSync({
+      profileId: MINIMAX_CLI_PROFILE_ID,
+      credential: makeOAuthCredential({
+        provider: "minimax-portal",
+        access: "local-stale-access",
+        refresh: "local-refresh",
+        expires: now - 5_000,
+        email: "local@example.com",
+      }),
+      allowKeychainPrompt: false,
+    });
+
+    expect(diagnostic).toMatchObject({
+      status: "account_mismatch",
+      persistence: "persisted",
+      externalProvider: "minimax-portal",
+    });
+    expect(diagnostic?.message).toContain("account does not match");
   });
 
   it("keeps any existing default codex oauth over Codex CLI bootstrap credentials", () => {

--- a/src/agents/auth-profiles/external-cli-sync.ts
+++ b/src/agents/auth-profiles/external-cli-sync.ts
@@ -39,6 +39,26 @@ export type ExternalCliResolvedProfile = {
   persistence?: "runtime-only" | "persisted";
 };
 
+export type ExternalCliAuthSyncDiagnosticStatus =
+  | "synced"
+  | "local_kept"
+  | "local_stale"
+  | "external_stale"
+  | "account_mismatch"
+  | "missing_identity_binding";
+
+export type ExternalCliAuthSyncDiagnostic = {
+  profileId: string;
+  provider: string;
+  externalProvider: string;
+  status: ExternalCliAuthSyncDiagnosticStatus;
+  persistence?: "runtime-only" | "persisted";
+  localExpires?: number;
+  externalExpires?: number;
+  message: string;
+  action: string;
+};
+
 export type ExternalCliAuthProfileOptions = {
   allowKeychainPrompt?: boolean;
   providerIds?: Iterable<string>;
@@ -199,6 +219,23 @@ function hasInlineOAuthTokenMaterial(credential: OAuthCredential): boolean {
   );
 }
 
+function buildAuthLoginAction(provider: string): string {
+  return `Run \`openclaw models auth login --provider ${provider}\` to refresh the local profile.`;
+}
+
+function externalCliLabel(provider: ExternalCliSyncProvider): string {
+  if (provider.profileId === OPENAI_CODEX_DEFAULT_PROFILE_ID) {
+    return "Codex CLI";
+  }
+  if (provider.profileId === CLAUDE_CLI_PROFILE_ID) {
+    return "Claude CLI";
+  }
+  if (provider.profileId === MINIMAX_CLI_PROFILE_ID) {
+    return "MiniMax CLI";
+  }
+  return `${provider.provider} CLI`;
+}
+
 /** Read a CLI credential only for safe bootstrap of an unusable local profile. */
 export function readExternalCliBootstrapCredential(params: {
   profileId: string;
@@ -224,6 +261,169 @@ export function readExternalCliBootstrapCredential(params: {
 }
 
 export const readManagedExternalCliCredential = readExternalCliBootstrapCredential;
+
+/** Explain how an external CLI credential would be used for a stored profile. */
+export function diagnoseExternalCliAuthProfileSync(params: {
+  profileId: string;
+  credential: OAuthCredential;
+  allowKeychainPrompt?: boolean;
+}): ExternalCliAuthSyncDiagnostic | null {
+  const providerConfig = resolveExternalCliSyncProvider(params);
+  if (!providerConfig) {
+    return null;
+  }
+
+  const label = externalCliLabel(providerConfig);
+  const action = buildAuthLoginAction(params.credential.provider);
+  if (
+    providerConfig.bootstrapOnly &&
+    hasInlineOAuthTokenMaterial(params.credential) &&
+    !hasUsableOAuthCredential(params.credential)
+  ) {
+    const external = normalizeExternalCliCredentialProvider(
+      providerConfig.readCredentials({ allowKeychainPrompt: params.allowKeychainPrompt }),
+      params.credential.provider,
+    );
+    if (!external) {
+      return {
+        profileId: params.profileId,
+        provider: params.credential.provider,
+        externalProvider: providerConfig.provider,
+        status: "local_stale",
+        persistence: "runtime-only",
+        localExpires: params.credential.expires,
+        message: `${label} sync skipped because the local OAuth profile owns stale token material.`,
+        action,
+      };
+    }
+    if (!hasUsableOAuthCredential(external)) {
+      return {
+        profileId: params.profileId,
+        provider: params.credential.provider,
+        externalProvider: providerConfig.provider,
+        status: "external_stale",
+        persistence: "runtime-only",
+        localExpires: params.credential.expires,
+        externalExpires: external.expires,
+        message: `${label} credentials are also stale or near expiry.`,
+        action,
+      };
+    }
+    if (!isSafeToUseExternalCliCredential(params.credential, external)) {
+      return {
+        profileId: params.profileId,
+        provider: params.credential.provider,
+        externalProvider: providerConfig.provider,
+        status: "account_mismatch",
+        persistence: "runtime-only",
+        localExpires: params.credential.expires,
+        externalExpires: external.expires,
+        message: `${label} account does not match the local OAuth profile.`,
+        action,
+      };
+    }
+    return {
+      profileId: params.profileId,
+      provider: params.credential.provider,
+      externalProvider: providerConfig.provider,
+      status: "local_stale",
+      persistence: "runtime-only",
+      localExpires: params.credential.expires,
+      externalExpires: external.expires,
+      message: `${label} has usable credentials, but this local profile must be refreshed directly.`,
+      action,
+    };
+  }
+
+  const external = normalizeExternalCliCredentialProvider(
+    providerConfig.readCredentials({ allowKeychainPrompt: params.allowKeychainPrompt }),
+    params.credential.provider,
+  );
+  if (!external) {
+    return null;
+  }
+  const persistence = providerConfig.bootstrapOnly ? "runtime-only" : "persisted";
+  if (!hasUsableOAuthCredential(external)) {
+    return {
+      profileId: params.profileId,
+      provider: params.credential.provider,
+      externalProvider: providerConfig.provider,
+      status: "external_stale",
+      persistence,
+      localExpires: params.credential.expires,
+      externalExpires: external.expires,
+      message: `${label} credentials are stale or near expiry.`,
+      action,
+    };
+  }
+  if (!isSafeToUseExternalCliCredential(params.credential, external)) {
+    return {
+      profileId: params.profileId,
+      provider: params.credential.provider,
+      externalProvider: providerConfig.provider,
+      status: "account_mismatch",
+      persistence,
+      localExpires: params.credential.expires,
+      externalExpires: external.expires,
+      message: `${label} account does not match the local OAuth profile.`,
+      action,
+    };
+  }
+  if (
+    !isSafeToAdoptBootstrapOAuthIdentity(params.credential, external) &&
+    !areOAuthCredentialsEquivalent(params.credential, external)
+  ) {
+    return {
+      profileId: params.profileId,
+      provider: params.credential.provider,
+      externalProvider: providerConfig.provider,
+      status: "missing_identity_binding",
+      persistence,
+      localExpires: params.credential.expires,
+      externalExpires: external.expires,
+      message: `${label} cannot be adopted because the local profile is missing a matching identity binding.`,
+      action,
+    };
+  }
+  if (
+    shouldBootstrapFromExternalCliCredential({
+      existing: params.credential,
+      imported: external,
+    })
+  ) {
+    return {
+      profileId: params.profileId,
+      provider: params.credential.provider,
+      externalProvider: providerConfig.provider,
+      status: "synced",
+      persistence,
+      localExpires: params.credential.expires,
+      externalExpires: external.expires,
+      message:
+        persistence === "runtime-only"
+          ? `${label} credentials are being used at runtime for this profile.`
+          : `${label} credentials are eligible to sync into this profile.`,
+      action:
+        persistence === "runtime-only"
+          ? `${action} This keeps future refreshes owned by OpenClaw.`
+          : "No action needed.",
+    };
+  }
+  if (hasUsableOAuthCredential(params.credential)) {
+    return {
+      profileId: params.profileId,
+      provider: params.credential.provider,
+      externalProvider: providerConfig.provider,
+      status: "local_kept",
+      persistence,
+      localExpires: params.credential.expires,
+      externalExpires: external.expires,
+      message: `Local OAuth profile is usable; ${label} credentials were not needed.`,
+      action: "No action needed.",
+    };
+  }
+  return null;
+}
 
 /** Read a CLI credential as a fallback for refresh/runtime auth recovery. */
 export function readExternalCliFallbackCredential(params: {

--- a/src/commands/doctor-auth.profile-health.test.ts
+++ b/src/commands/doctor-auth.profile-health.test.ts
@@ -27,12 +27,31 @@ const authProfileMocks = vi.hoisted(() => ({
   resolveProfileUnusableUntilForDisplay: vi.fn(),
 }));
 
+const cliCredentialMocks = vi.hoisted(() => ({
+  readCodexCliCredentialsCached: vi.fn<
+    () => {
+      type: "oauth";
+      provider: "openai";
+      access: string;
+      refresh: string;
+      expires: number;
+      accountId?: string;
+    } | null
+  >(() => null),
+}));
+
 vi.mock("../agents/auth-profiles.js", () => ({
   ensureAuthProfileStore: authProfileMocks.ensureAuthProfileStore,
   hasAnyAuthProfileStoreSource: authProfileMocks.hasAnyAuthProfileStoreSource,
   hasLocalAuthProfileStoreSource: authProfileMocks.hasLocalAuthProfileStoreSource,
   resolveApiKeyForProfile: authProfileMocks.resolveApiKeyForProfile,
   resolveProfileUnusableUntilForDisplay: authProfileMocks.resolveProfileUnusableUntilForDisplay,
+}));
+
+vi.mock("../agents/cli-credentials.js", () => ({
+  readClaudeCliCredentialsCached: () => null,
+  readCodexCliCredentialsCached: cliCredentialMocks.readCodexCliCredentialsCached,
+  readMiniMaxCliCredentialsCached: () => null,
 }));
 
 vi.mock("../../packages/terminal-core/src/note.js", () => ({ note: vi.fn() }));
@@ -54,6 +73,8 @@ describe("noteAuthProfileHealth", () => {
     authProfileMocks.hasLocalAuthProfileStoreSource.mockReturnValue(false);
     authProfileMocks.resolveApiKeyForProfile.mockReset();
     authProfileMocks.resolveProfileUnusableUntilForDisplay.mockReset();
+    cliCredentialMocks.readCodexCliCredentialsCached.mockReset();
+    cliCredentialMocks.readCodexCliCredentialsCached.mockReturnValue(null);
     noteMock.mockReset();
   });
 
@@ -81,6 +102,7 @@ describe("noteAuthProfileHealth", () => {
       },
     };
   }
+
   it("skips external auth profile resolution when no auth source exists", async () => {
     await noteAuthProfileHealth({
       cfg: { channels: { telegram: { enabled: true } } } as OpenClawConfig,
@@ -116,6 +138,55 @@ describe("noteAuthProfileHealth", () => {
     expect(authProfileMocks.ensureAuthProfileStore).toHaveBeenCalledWith(defaultDir, {
       allowKeychainPrompt: false,
     });
+  });
+
+  it("surfaces successful Codex CLI runtime auth sync without prompting for refresh", async () => {
+    const now = 1_700_000_000_000;
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    const defaultDir = path.join(tempDir, "default-agent");
+    authProfileMocks.hasAnyAuthProfileStoreSource.mockImplementation(
+      (agentDir) => agentDir === defaultDir,
+    );
+    authProfileMocks.ensureAuthProfileStore.mockReturnValue({
+      version: 1,
+      profiles: {
+        "openai:default": {
+          type: "oauth",
+          provider: "openai",
+        },
+      },
+    } as never);
+    cliCredentialMocks.readCodexCliCredentialsCached.mockReturnValue({
+      type: "oauth",
+      provider: "openai",
+      access: "codex-access",
+      refresh: "codex-refresh",
+      expires: now + 86_400_000 + 60_000,
+      accountId: "acct-codex",
+    });
+    const confirmAutoFix = vi.fn(async () => false);
+
+    await noteAuthProfileHealth({
+      cfg: {
+        agents: {
+          list: [{ id: "main", default: true, agentDir: defaultDir }],
+        },
+      } as OpenClawConfig,
+      prompter: {
+        confirmAutoFix,
+      } as unknown as DoctorPrompter,
+      allowKeychainPrompt: false,
+    });
+
+    expect(noteMock).toHaveBeenCalledWith(
+      expect.stringContaining("Codex CLI credentials are being used at runtime"),
+      "External CLI auth sync",
+    );
+    expect(noteMock).toHaveBeenCalledWith(
+      expect.stringContaining("openclaw models auth login --provider openai"),
+      "External CLI auth sync",
+    );
+    expect(confirmAutoFix).not.toHaveBeenCalled();
   });
 
   it("labels model auth diagnostics by agent when multiple agent auth stores are checked", async () => {

--- a/src/commands/doctor-auth.ts
+++ b/src/commands/doctor-auth.ts
@@ -260,6 +260,32 @@ async function formatAuthIssueLine(
   return `- ${issue.profileId}: ${issue.status}${reason}${remaining}${hint ? ` — ${hint}` : ""}`;
 }
 
+function formatExternalCliSyncLine(
+  profile: ReturnType<typeof buildAuthHealthSummary>["profiles"][number],
+): string | null {
+  const diagnostic = profile.externalCli;
+  if (!diagnostic || diagnostic.status === "local_kept") {
+    return null;
+  }
+  const externalExpiry =
+    diagnostic.externalExpires !== undefined
+      ? ` (external expires in ${formatRemainingShort(diagnostic.externalExpires - Date.now())})`
+      : "";
+  return `- ${diagnostic.profileId}: ${diagnostic.message}${externalExpiry} ${diagnostic.action}`;
+}
+
+function noteExternalCliSyncDiagnostics(
+  summary: ReturnType<typeof buildAuthHealthSummary>,
+  noteTitle: (title: string) => string,
+): void {
+  const externalCliSyncLines = summary.profiles
+    .map((profile) => formatExternalCliSyncLine(profile))
+    .filter((line): line is string => Boolean(line));
+  if (externalCliSyncLines.length > 0) {
+    note(externalCliSyncLines.join("\n"), noteTitle("External CLI auth sync"));
+  }
+}
+
 async function noteAuthProfileHealthForTarget(params: {
   cfg: OpenClawConfig;
   prompter: DoctorPrompter;
@@ -314,6 +340,8 @@ async function noteAuthProfileHealthForTarget(params: {
           profile.status === "expiring" ||
           profile.status === "missing"),
     );
+
+  noteExternalCliSyncDiagnostics(summary, noteTitle);
 
   let issues = findIssues();
   if (issues.length === 0) {

--- a/src/commands/models/list.status-command.ts
+++ b/src/commands/models/list.status-command.ts
@@ -1263,6 +1263,24 @@ export async function modelsStatusCommand(
                 ? ` expires in ${formatRemainingShort(profile.remainingMs)}`
                 : " expires unknown";
           runtime.log(`  - ${labelLocal} ${status}${expiry}`);
+          if (profile.externalCli && profile.externalCli.status !== "local_kept") {
+            const diagnostic = profile.externalCli;
+            const externalExpiry =
+              diagnostic.externalExpires !== undefined
+                ? ` external expires in ${formatRemainingShort(
+                    diagnostic.externalExpires - Date.now(),
+                  )};`
+                : "";
+            runtime.log(
+              `    ${colorize(
+                rich,
+                diagnostic.status === "synced" ? theme.success : theme.warn,
+                "external CLI",
+              )}: ${diagnostic.message}${externalExpiry ? ` ${externalExpiry}` : ""} ${
+                diagnostic.action
+              }`,
+            );
+          }
         }
       }
     }

--- a/src/commands/models/list.status.test.ts
+++ b/src/commands/models/list.status.test.ts
@@ -2010,6 +2010,54 @@ describe("modelsStatusCommand auth overview", () => {
     );
   });
 
+  it("renders external CLI auth sync diagnostics in text status", async () => {
+    const localRuntime = createRuntime();
+    buildAuthHealthSummaryMock.mockReturnValue({
+      now: Date.now(),
+      warnAfterMs: 86_400_000,
+      profiles: [
+        {
+          profileId: "openai:default",
+          provider: "openai",
+          type: "oauth",
+          status: "expired",
+          source: "store",
+          label: "openai:default",
+          externalCli: {
+            profileId: "openai:default",
+            provider: "openai",
+            externalProvider: "openai",
+            status: "local_stale",
+            persistence: "runtime-only",
+            localExpires: Date.now() - 60_000,
+            externalExpires: Date.now() + 60_000,
+            message:
+              "Codex CLI has usable credentials, but this local profile must be refreshed directly.",
+            action:
+              "Run `openclaw models auth login --provider openai` to refresh the local profile.",
+          },
+        },
+      ],
+      providers: [
+        {
+          provider: "openai",
+          status: "expired",
+          profiles: [],
+          effectiveProfiles: [],
+        },
+      ],
+    });
+
+    await modelsStatusCommand({}, localRuntime as never);
+    const output = (localRuntime.log as Mock).mock.calls
+      .map((call: unknown[]) => String(call[0]))
+      .join("\n");
+
+    expect(output).toContain("external CLI");
+    expect(output).toContain("Codex CLI has usable credentials");
+    expect(output).toContain("openclaw models auth login --provider openai");
+  });
+
   it("throws when agent id is unknown", async () => {
     const localRuntime = createRuntime();
     await expect(modelsStatusCommand({ agent: "unknown" }, localRuntime as never)).rejects.toThrow(


### PR DESCRIPTION
﻿## Summary
- Add structured external CLI auth sync diagnostics for Codex/CLI-backed OAuth profiles.
- Surface stale local credentials, stale external credentials, account mismatches, and successful runtime syncs in auth health, doctor auth, and model status output.
- Extend focused tests for the auth-profile sync path plus nearest status and doctor surfaces.

## Test Plan
- [x] `pnpm test src/agents/auth-profiles.external-cli-sync.test.ts`
- [x] `pnpm test src/agents/auth-health.test.ts`
- [x] `pnpm test src/commands/doctor-auth.profile-health.test.ts`
- [x] `pnpm test src/commands/models/list.status.test.ts -t "renders external CLI auth sync diagnostics"`
- [x] Linux/CI-like Crabbox Azure fallback: `env CI=1 corepack pnpm test src/agents/auth-profiles.external-cli-sync.test.ts src/agents/auth-health.test.ts src/commands/doctor-auth.profile-health.test.ts src/commands/models/list.status.test.ts`

## Notes
- Blacksmith Testbox was attempted first but the local `blacksmith` executable was not available on PATH, so the proof used the repo-owned Azure Crabbox fallback.
- The Azure lease was stopped after validation.
