### PR TITLE
fix: let ClawHub dry runs skip publish approval

### DIFF
--- a/.github/workflows/plugin-clawhub-release.yml
+++ b/.github/workflows/plugin-clawhub-release.yml
@@ -430,7 +430,7 @@ jobs:
 
   approve_plugin_clawhub_release:
     needs: [preview_plugins_clawhub, pack_plugins_clawhub_artifacts]
-    if: github.event_name == 'workflow_dispatch' && needs.preview_plugins_clawhub.outputs.has_candidates == 'true'
+    if: github.event_name == 'workflow_dispatch' && inputs.dry_run != true && needs.preview_plugins_clawhub.outputs.has_candidates == 'true'
     runs-on: ubuntu-latest
     environment: clawhub-plugin-release
     permissions: {}
@@ -440,7 +440,7 @@ jobs:
 
   publish_plugins_clawhub:
     needs: [preview_plugins_clawhub, pack_plugins_clawhub_artifacts, approve_plugin_clawhub_release]
-    if: github.event_name == 'workflow_dispatch' && needs.preview_plugins_clawhub.outputs.has_candidates == 'true'
+    if: always() && github.event_name == 'workflow_dispatch' && needs.preview_plugins_clawhub.outputs.has_candidates == 'true' && needs.pack_plugins_clawhub_artifacts.result == 'success' && (inputs.dry_run == true || needs.approve_plugin_clawhub_release.result == 'success')
     permissions:
       actions: read
       contents: read

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -1571,7 +1571,11 @@ describe("package artifact reuse", () => {
     expect(clawHubWorkflow).toContain("dry_run:");
     expect(clawHubWorkflow).toContain("default: false");
     expect(clawHubWorkflow).toContain("approve_plugin_clawhub_release:");
+    expect(clawHubWorkflow).toContain("inputs.dry_run != true");
     expect(clawHubWorkflow).toContain("Approve ClawHub package publish");
+    expect(clawHubWorkflow).toContain(
+      "always() && github.event_name == 'workflow_dispatch' && needs.preview_plugins_clawhub.outputs.has_candidates == 'true' && needs.pack_plugins_clawhub_artifacts.result == 'success' && (inputs.dry_run == true || needs.approve_plugin_clawhub_release.result == 'success')",
+    );
     expect(clawHubWorkflow).toContain(
       "uses: openclaw/clawhub/.github/workflows/package-publish.yml@c9bb13023598dcc547fdf4a93b9d42512b8c8854",
     );


### PR DESCRIPTION
## Summary
- Skip the protected `clawhub-plugin-release` environment approval when `plugin-clawhub-release.yml` is dispatched with `dry_run=true`.
- Keep real publishes gated on the approval job.
- Keep the reusable ClawHub publish job dependent on successful artifact packing, and allow it to run for dry-runs without approval.

## Verification
- `./node_modules/.bin/vitest run --config test/vitest/vitest.tooling.config.ts test/scripts/package-acceptance-workflow.test.ts`
- Dry-run proof: https://github.com/openclaw/openclaw/actions/runs/27182518869
  - `publish_plugins_clawhub` succeeded with `dry_run: true`.
  - `approve_plugin_clawhub_release` skipped.
  - `verify_published_clawhub_package` skipped.
  - Fake dry-run version `@openclaw/brave-plugin@2026.6.99-beta.1` still returns 404 from ClawHub.
