### PR TITLE
fix(codex): restore memory recall guidance

### DIFF
--- a/extensions/codex/src/app-server/attempt-context.ts
+++ b/extensions/codex/src/app-server/attempt-context.ts
@@ -15,6 +15,8 @@ import {
   type EmbeddedRunAttemptResult,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { resolveAgentWorkspaceDir } from "openclaw/plugin-sdk/agent-runtime";
+import { ensureActiveMemoryCapability } from "openclaw/plugin-sdk/codex-native-task-runtime";
+import { buildMemorySystemPromptAddition } from "openclaw/plugin-sdk/core";
 import type { CodexDynamicToolSpec, JsonValue } from "./protocol.js";
 import { isJsonObject } from "./protocol.js";
 import type { CodexAppServerThreadBinding } from "./session-binding.js";
@@ -164,8 +166,9 @@ export async function buildCodexWorkspaceBootstrapContext(params: {
   memoryToolNames: readonly string[];
 }): Promise<CodexWorkspaceBootstrapContext> {
   try {
-    const memoryToolsAvailable =
-      params.memoryToolNames.length > 0 &&
+    const memoryToolsAvailable = params.memoryToolNames.length > 0;
+    const canRouteWorkspaceMemoryThroughTools =
+      memoryToolsAvailable &&
       canRouteCodexWorkspaceMemoryThroughTools({
         config: params.params.config,
         agentId: params.params.agentId ?? params.sessionAgentId,
@@ -183,7 +186,7 @@ export async function buildCodexWorkspaceBootstrapContext(params: {
       contextMode: params.params.bootstrapContextMode,
       runKind: params.params.bootstrapContextRunKind,
     });
-    const memoryToolRoutedBootstrapFiles = memoryToolsAvailable
+    const memoryToolRoutedBootstrapFiles = canRouteWorkspaceMemoryThroughTools
       ? selectCodexWorkspaceMemoryReferenceFiles({
           bootstrapFiles,
           workspaceDir: params.resolvedWorkspace,
@@ -197,7 +200,7 @@ export async function buildCodexWorkspaceBootstrapContext(params: {
       }),
     );
     const contextFiles = buildBootstrapContextForFiles(
-      memoryToolsAvailable
+      canRouteWorkspaceMemoryThroughTools
         ? bootstrapFiles.filter(
             (file) =>
               !isCodexWorkspaceRootMemoryBootstrapFile({
@@ -218,16 +221,15 @@ export async function buildCodexWorkspaceBootstrapContext(params: {
         targetWorkspaceDir: params.effectiveWorkspace,
       }),
     );
+    const injectOpenClawPromptContext = shouldInjectCodexOpenClawPromptContext(params.params);
     const promptContextFiles = selectCodexWorkspacePromptContextFiles(contextFiles, {
-      excludeMemory: memoryToolsAvailable,
+      excludeMemory: canRouteWorkspaceMemoryThroughTools,
       memoryWorkspaceDir: params.effectiveWorkspace,
     });
-    const developerInstructionFiles = shouldInjectCodexOpenClawPromptContext(params.params)
+    const developerInstructionFiles = injectOpenClawPromptContext
       ? selectCodexWorkspaceInheritedDeveloperInstructionFiles(contextFiles)
       : [];
-    const turnScopedDeveloperInstructionFiles = shouldInjectCodexOpenClawPromptContext(
-      params.params,
-    )
+    const turnScopedDeveloperInstructionFiles = injectOpenClawPromptContext
       ? selectCodexWorkspaceTurnScopedDeveloperInstructionFiles(contextFiles)
       : [];
     const heartbeatReferenceFiles = selectCodexWorkspaceHeartbeatReferenceFiles(contextFiles);
@@ -241,17 +243,20 @@ export async function buildCodexWorkspaceBootstrapContext(params: {
       memoryReferenceFiles,
       memoryToolRoutedBootstrapFiles,
       memoryToolNames: [...params.memoryToolNames],
-      memoryToolRouted: memoryToolsAvailable,
+      memoryToolRouted: canRouteWorkspaceMemoryThroughTools,
       promptContext: renderCodexWorkspaceBootstrapPromptContext(promptContextFiles),
       developerInstructions:
         renderCodexWorkspaceThreadDeveloperInstructions(developerInstructionFiles),
       turnScopedDeveloperInstructions: renderCodexWorkspaceCollaborationDeveloperInstructions(
         turnScopedDeveloperInstructionFiles,
       ),
-      memoryCollaborationInstructions: shouldInjectCodexOpenClawPromptContext(params.params)
-        ? renderCodexWorkspaceMemoryReference({
+      memoryCollaborationInstructions: injectOpenClawPromptContext
+        ? renderCodexWorkspaceMemoryCollaborationInstructions({
             files: memoryReferenceFiles,
             toolNames: params.memoryToolNames,
+            includeRecallInstructions: memoryToolsAvailable,
+            config: params.params.config,
+            citationsMode: params.params.config?.memory?.citations,
           })
         : undefined,
       heartbeatCollaborationInstructions:
@@ -777,6 +782,72 @@ function selectCodexWorkspaceMemoryReferenceFiles(params: {
       );
     })
     .toSorted(compareCodexBootstrapFiles);
+}
+
+function renderCodexWorkspaceMemoryCollaborationInstructions(params: {
+  files: EmbeddedContextFile[];
+  toolNames: readonly string[];
+  includeRecallInstructions: boolean;
+  config?: EmbeddedRunAttemptParams["config"];
+  citationsMode?: Parameters<typeof buildMemorySystemPromptAddition>[0]["citationsMode"];
+}): string | undefined {
+  const toolNames = params.toolNames.map((name) => normalizeCodexDynamicToolName(name));
+  const recallInstructions = params.includeRecallInstructions
+    ? renderCodexMemoryRecallInstructions({
+        toolNames,
+        config: params.config,
+        citationsMode: params.citationsMode,
+      })
+    : undefined;
+  const loadingInstructions = recallInstructions
+    ? renderCodexDeferredMemoryToolLoadingInstructions(toolNames)
+    : undefined;
+  const referenceInstructions = renderCodexWorkspaceMemoryReference({
+    files: params.files,
+    toolNames,
+  });
+  return joinCodexCollaborationSections(
+    loadingInstructions,
+    recallInstructions,
+    referenceInstructions,
+  );
+}
+
+function renderCodexMemoryRecallInstructions(params: {
+  toolNames: readonly string[];
+  config?: EmbeddedRunAttemptParams["config"];
+  citationsMode?: Parameters<typeof buildMemorySystemPromptAddition>[0]["citationsMode"];
+}): string | undefined {
+  ensureActiveMemoryCapability(params.config);
+  const pluginInstructions = buildMemorySystemPromptAddition({
+    availableTools: new Set(params.toolNames),
+    citationsMode: params.citationsMode,
+  });
+  return pluginInstructions?.trim() ? pluginInstructions : undefined;
+}
+
+function renderCodexDeferredMemoryToolLoadingInstructions(
+  toolNames: readonly string[],
+): string | undefined {
+  if (toolNames.length === 0) {
+    return undefined;
+  }
+  const formattedTools = toolNames.map((name) => `\`${name}\``).join(" or ");
+  return [
+    "## Codex Memory Tool Loading",
+    `Memory tools ${formattedTools} may be searchable rather than directly listed in native Codex turns. If a memory recall instruction names a memory tool that is not currently callable, use \`tool_search\` to load that tool first, then call it.`,
+  ].join("\n\n");
+}
+
+function joinCodexCollaborationSections(
+  ...sections: Array<string | undefined>
+): string | undefined {
+  const joined = sections
+    .map((section) => section?.trim())
+    .filter(isNonEmptyString)
+    .join("\n\n")
+    .trim();
+  return joined || undefined;
 }
 
 /**

--- a/extensions/codex/src/app-server/run-attempt-test-harness.ts
+++ b/extensions/codex/src/app-server/run-attempt-test-harness.ts
@@ -10,6 +10,7 @@ import {
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { resetDiagnosticEventsForTest } from "openclaw/plugin-sdk/diagnostic-runtime";
 import { clearInternalHooks, resetGlobalHookRunner } from "openclaw/plugin-sdk/hook-runtime";
+import { clearMemoryPluginState } from "openclaw/plugin-sdk/memory-host-core";
 import { clearPluginCommands } from "openclaw/plugin-sdk/plugin-runtime";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import { afterEach, beforeEach, expect, vi } from "vitest";
@@ -512,6 +513,7 @@ export function setupRunAttemptTestHooks(): void {
     testing.clearPendingCodexNativeHookRelayUnregistersForTests();
     resetCodexRateLimitCacheForTests();
     nativeHookRelayTesting.clearNativeHookRelaysForTests();
+    clearMemoryPluginState();
     clearPluginCommands();
     resetAgentEventsForTest();
     resetDiagnosticEventsForTest();

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -12,6 +12,10 @@ import {
   type DiagnosticEventPayload,
 } from "openclaw/plugin-sdk/diagnostic-runtime";
 import { initializeGlobalHookRunner, registerInternalHook } from "openclaw/plugin-sdk/hook-runtime";
+import {
+  clearMemoryPluginState,
+  registerMemoryCapability,
+} from "openclaw/plugin-sdk/memory-host-core";
 import { registerPluginCommand } from "openclaw/plugin-sdk/plugin-runtime";
 import { createMockPluginRegistry } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { describe, expect, it, vi } from "vitest";
@@ -107,6 +111,23 @@ function expectResumeRequest(
   for (const [key, value] of Object.entries(params)) {
     expect(requestParams?.[key]).toEqual(value);
   }
+}
+
+function registerTestMemoryRecallPrompt(): void {
+  clearMemoryPluginState();
+  registerMemoryCapability("test-memory-core", {
+    promptBuilder: ({ availableTools }) => {
+      const hasMemorySearch = availableTools.has("memory_search");
+      const hasMemoryGet = availableTools.has("memory_get");
+      if (!hasMemorySearch && !hasMemoryGet) {
+        return [];
+      }
+      const guidance = hasMemorySearch
+        ? "Before answering anything about prior work, decisions, dates, people, preferences, or todos: run memory_search before answering."
+        : "Before answering anything about prior work, decisions, dates, people, preferences, or todos that already point to a specific memory file or note: run memory_get before answering.";
+      return ["## Memory Recall", guidance, ""];
+    },
+  });
 }
 
 async function writeExistingBinding(
@@ -2203,6 +2224,7 @@ describe("runCodexAppServerAttempt", () => {
     await fs.writeFile(path.join(workspaceDir, "TOOLS.md"), toolGuidance);
     await fs.writeFile(path.join(workspaceDir, "USER.md"), userProfile);
     await fs.writeFile(path.join(workspaceDir, "MEMORY.md"), memorySummary);
+    registerTestMemoryRecallPrompt();
     testing.setOpenClawCodingToolsFactoryForTests(() => [
       createRuntimeDynamicTool("memory_search"),
       createRuntimeDynamicTool("memory_get"),
@@ -2240,6 +2262,10 @@ describe("runCodexAppServerAttempt", () => {
     expect(collaborationInstructions).toContain(
       "MEMORY.md exists in the active agent workspace as a memory file, not an instruction file",
     );
+    expect(collaborationInstructions).toContain("Codex Memory Tool Loading");
+    expect(collaborationInstructions).toContain("tool_search");
+    expect(collaborationInstructions).toContain("## Memory Recall");
+    expect(collaborationInstructions).toContain("Before answering anything about prior work");
     expect(collaborationInstructions).toContain("memory_search");
     expect(collaborationInstructions).toContain("memory_get");
     expect(collaborationInstructions).not.toContain(memorySummary);
@@ -2253,6 +2279,7 @@ describe("runCodexAppServerAttempt", () => {
     expect(inputText).not.toContain(memorySummary);
     expect(inputText).not.toContain("OpenClaw Workspace Memory");
     expect(inputText).not.toContain("MEMORY.md exists in the active agent workspace");
+    expect(inputText).not.toContain("## Memory Recall");
     expect(inputText).not.toContain("memory_search");
     expect(inputText).not.toContain("memory_get");
     expect(inputText).not.toContain("Codex loads AGENTS.md natively");
@@ -2405,6 +2432,7 @@ describe("runCodexAppServerAttempt", () => {
     const memorySummary = "Memory summary goes here.";
     await fs.mkdir(workspaceDir, { recursive: true });
     await fs.writeFile(path.join(workspaceDir, "MEMORY.md"), memorySummary);
+    registerTestMemoryRecallPrompt();
     testing.setOpenClawCodingToolsFactoryForTests(() => [createRuntimeDynamicTool("memory_get")]);
     const params = createParams(sessionFile, workspaceDir);
     params.disableTools = false;
@@ -2418,6 +2446,9 @@ describe("runCodexAppServerAttempt", () => {
     expect(inputText).not.toContain("memory_search");
     expect(inputText).not.toContain(memorySummary);
     expect(collaborationInstructions).toContain("OpenClaw Workspace Memory");
+    expect(collaborationInstructions).toContain("Codex Memory Tool Loading");
+    expect(collaborationInstructions).toContain("tool_search");
+    expect(collaborationInstructions).toContain("## Memory Recall");
     expect(collaborationInstructions).toContain("memory_get");
     expect(collaborationInstructions).not.toContain("memory_search");
     expect(collaborationInstructions).not.toContain(memorySummary);
@@ -2430,6 +2461,38 @@ describe("runCodexAppServerAttempt", () => {
       injectedChars: 0,
       truncated: false,
     });
+  });
+
+  it("adds memory recall guidance when only daily memory files exist", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const dailyMemory = "Credit-card signup dates live in daily memory.";
+    await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });
+    await fs.writeFile(path.join(workspaceDir, "memory", "2026-05-20.md"), dailyMemory);
+    registerTestMemoryRecallPrompt();
+    testing.setOpenClawCodingToolsFactoryForTests(() => [
+      createRuntimeDynamicTool("memory_search"),
+      createRuntimeDynamicTool("memory_get"),
+    ]);
+    const params = createParams(sessionFile, workspaceDir);
+    params.disableTools = false;
+    params.runtimePlan = createCodexRuntimePlanFixture();
+    setAgentWorkspaceForTest(params, workspaceDir);
+
+    const { collaborationInstructions, inputText, systemPromptReport } =
+      await buildCodexTurnContextForTest(params, workspaceDir);
+
+    expect(collaborationInstructions).toContain("Codex Memory Tool Loading");
+    expect(collaborationInstructions).toContain("tool_search");
+    expect(collaborationInstructions).toContain("## Memory Recall");
+    expect(collaborationInstructions).toContain("Before answering anything about prior work");
+    expect(collaborationInstructions).not.toContain("OpenClaw Workspace Memory");
+    expect(collaborationInstructions).not.toContain(dailyMemory);
+    expect(inputText).not.toContain("## Memory Recall");
+    expect(inputText).not.toContain(dailyMemory);
+    expect(systemPromptReport.injectedWorkspaceFiles).not.toContainEqual(
+      expect.objectContaining({ name: "2026-05-20.md" }),
+    );
   });
 
   it("reports MEMORY.md as truncated when no-tool fallback exceeds the bootstrap budget", async () => {
@@ -2595,6 +2658,7 @@ describe("runCodexAppServerAttempt", () => {
     const memorySummary = "Memory summary goes here.";
     await fs.mkdir(workspaceDir, { recursive: true });
     await fs.writeFile(path.join(workspaceDir, "MEMORY.md"), memorySummary);
+    registerTestMemoryRecallPrompt();
     testing.setOpenClawCodingToolsFactoryForTests(() => [
       createRuntimeDynamicTool("memory_search"),
       createRuntimeDynamicTool("memory_get"),
@@ -2604,12 +2668,14 @@ describe("runCodexAppServerAttempt", () => {
     params.runtimePlan = createCodexRuntimePlanFixture();
     setAgentWorkspaceForTest(params, path.join(tempDir, "memory-workspace"));
 
-    const { inputText, systemPromptReport } = await buildCodexTurnContextForTest(
-      params,
-      workspaceDir,
-    );
+    const { collaborationInstructions, inputText, systemPromptReport } =
+      await buildCodexTurnContextForTest(params, workspaceDir);
     expect(inputText).not.toContain("OpenClaw Workspace Memory");
     expect(inputText).toContain(memorySummary);
+    expect(collaborationInstructions).toContain("Codex Memory Tool Loading");
+    expect(collaborationInstructions).toContain("## Memory Recall");
+    expect(collaborationInstructions).not.toContain("OpenClaw Workspace Memory");
+    expect(collaborationInstructions).not.toContain(memorySummary);
 
     const fileStats = new Map(
       systemPromptReport.injectedWorkspaceFiles.map((file) => [file.name, file]),

--- a/src/plugin-sdk/codex-native-task-runtime.ts
+++ b/src/plugin-sdk/codex-native-task-runtime.ts
@@ -1,7 +1,6 @@
 // Private helper surface for the bundled Codex plugin. This is intentionally
-// local-only so Codex can mirror app-server native subagents into OpenClaw's
-// task registry without promoting detached task mutation helpers to the public
-// plugin SDK.
+// local-only so Codex app-server wiring can use host runtime helpers without
+// promoting them to the public plugin SDK.
 
 export {
   CODEX_NATIVE_SUBAGENT_RUN_ID_PREFIX,
@@ -15,3 +14,5 @@ export {
   finalizeTaskRunByRunId,
   recordTaskRunProgressByRunId,
 } from "../tasks/detached-task-runtime.js";
+
+export { ensureActiveMemoryCapability } from "../plugins/memory-runtime.js";

--- a/src/plugins/memory-runtime.test.ts
+++ b/src/plugins/memory-runtime.test.ts
@@ -13,6 +13,11 @@ const ensureStandaloneRuntimePluginRegistryLoadedMock = vi.hoisted(() =>
 const applyPluginAutoEnableMock =
   vi.fn<typeof import("../config/plugin-auto-enable.js").applyPluginAutoEnable>();
 const getMemoryRuntimeMock = vi.fn<typeof import("./memory-state.js").getMemoryRuntime>();
+const getMemoryCapabilityRegistrationMock =
+  vi.fn<typeof import("./memory-state.js").getMemoryCapabilityRegistration>();
+const getActivePluginRuntimeSubagentModeMock = vi.fn<
+  typeof import("./runtime.js").getActivePluginRuntimeSubagentMode
+>(() => "default");
 const resolveAgentWorkspaceDirMock =
   vi.fn<typeof import("../agents/agent-scope.js").resolveAgentWorkspaceDir>();
 const resolveDefaultAgentIdMock = vi.fn<
@@ -41,13 +46,18 @@ vi.mock("./runtime/standalone-runtime-registry-loader.js", () => ({
 }));
 
 vi.mock("./memory-state.js", () => ({
+  getMemoryCapabilityRegistration: () => getMemoryCapabilityRegistrationMock(),
   getMemoryRuntime: () => getMemoryRuntimeMock(),
 }));
 
+vi.mock("./runtime.js", () => ({
+  getActivePluginRuntimeSubagentMode: () => getActivePluginRuntimeSubagentModeMock(),
+}));
+
+let ensureActiveMemoryCapability: typeof import("./memory-runtime.js").ensureActiveMemoryCapability;
 let getActiveMemorySearchManager: typeof import("./memory-runtime.js").getActiveMemorySearchManager;
 let resolveActiveMemoryBackendConfig: typeof import("./memory-runtime.js").resolveActiveMemoryBackendConfig;
 let closeActiveMemorySearchManager: typeof import("./memory-runtime.js").closeActiveMemorySearchManager;
-let closeActiveMemorySearchManagers: typeof import("./memory-runtime.js").closeActiveMemorySearchManagers;
 
 function createMemoryAutoEnableFixture() {
   const rawConfig = {
@@ -131,33 +141,23 @@ async function expectAutoEnabledMemoryRuntimeCase(params: {
   expectMemoryAutoEnableApplied(rawConfig, autoEnabledConfig);
 }
 
-async function expectCloseMemoryRuntimeCase(params: {
-  config: unknown;
-  setup: () => { closeAllMemorySearchManagers: ReturnType<typeof vi.fn> } | undefined;
-}) {
-  const runtime = params.setup();
-  await closeActiveMemorySearchManagers(params.config as never);
-
-  if (runtime) {
-    expect(runtime.closeAllMemorySearchManagers).toHaveBeenCalledTimes(1);
-  }
-  expectNoMemoryRuntimeBootstrap();
-}
-
 describe("memory runtime auto-enable loading", () => {
   beforeEach(async () => {
     vi.resetModules();
     ({
+      ensureActiveMemoryCapability,
       getActiveMemorySearchManager,
       resolveActiveMemoryBackendConfig,
       closeActiveMemorySearchManager,
-      closeActiveMemorySearchManagers,
     } = await import("./memory-runtime.js"));
     resolveRuntimePluginRegistryMock.mockReset();
     getLoadedRuntimePluginRegistryMock.mockReset();
     ensureStandaloneRuntimePluginRegistryLoadedMock.mockReset();
     applyPluginAutoEnableMock.mockReset();
     getMemoryRuntimeMock.mockReset();
+    getMemoryCapabilityRegistrationMock.mockReset();
+    getActivePluginRuntimeSubagentModeMock.mockReset();
+    getActivePluginRuntimeSubagentModeMock.mockReturnValue("default");
     resolveAgentWorkspaceDirMock.mockReset();
     resolveDefaultAgentIdMock.mockClear();
     applyPluginAutoEnableMock.mockImplementation((params) => ({
@@ -319,33 +319,52 @@ describe("memory runtime auto-enable loading", () => {
     expect(ensureStandaloneRuntimePluginRegistryLoadedMock).not.toHaveBeenCalled();
   });
 
-  it.each([
-    {
-      name: "does not bootstrap the memory runtime just to close managers",
-      config: {
-        plugins: {},
-        channels: { memory: { enabled: true } },
+  it("force-loads the loaded plugin set when a compatible registry exists without memory capability", () => {
+    const rawConfig = {
+      plugins: {
+        slots: {
+          memory: "memory-core",
+        },
       },
-      setup: () => {
-        getMemoryRuntimeMock.mockReturnValue(undefined);
-        return undefined;
+    };
+    const capability = {
+      pluginId: "memory-core",
+      capability: {
+        promptBuilder: () => ["## Memory Recall", "Search memory first."],
       },
-    },
-    {
-      name: "closes an already-registered memory runtime without reloading plugins",
-      config: {},
-      setup: () => {
-        const runtime = {
-          getMemorySearchManager: vi.fn(async () => ({ manager: null, error: "no index" })),
-          resolveMemoryBackendConfig: vi.fn(() => ({ backend: "builtin" as const })),
-          closeAllMemorySearchManagers: vi.fn(async () => {}),
-        };
-        getMemoryRuntimeMock.mockReturnValue(runtime);
-        return runtime;
+    };
+    let registeredCapability: typeof capability | undefined;
+    getActivePluginRuntimeSubagentModeMock.mockReturnValue("gateway-bindable");
+    getLoadedRuntimePluginRegistryMock.mockReturnValue({
+      plugins: [
+        { id: "telegram", status: "loaded" },
+        { id: "memory-core", status: "loaded" },
+        { id: "codex", status: "loaded" },
+      ],
+    } as never);
+    getMemoryCapabilityRegistrationMock.mockImplementation(() => registeredCapability as never);
+    ensureStandaloneRuntimePluginRegistryLoadedMock.mockImplementation(() => {
+      registeredCapability = capability;
+      return undefined as never;
+    });
+
+    const result = ensureActiveMemoryCapability(rawConfig as never);
+
+    expect(result).toBe(capability);
+    expect(getLoadedRuntimePluginRegistryMock).toHaveBeenCalledWith({
+      requiredPluginIds: ["memory-core"],
+    });
+    expect(ensureStandaloneRuntimePluginRegistryLoadedMock).toHaveBeenCalledWith({
+      forceLoad: true,
+      requiredPluginIds: ["codex", "memory-core", "telegram"],
+      loadOptions: {
+        config: rawConfig,
+        onlyPluginIds: ["codex", "memory-core", "telegram"],
+        workspaceDir: "/resolved-workspace",
+        runtimeOptions: { allowGatewaySubagentBinding: true },
+        preferBuiltPluginArtifacts: true,
       },
-    },
-  ] as const)("$name", async ({ config, setup }) => {
-    await expectCloseMemoryRuntimeCase({ config, setup });
+    });
   });
 
   it("delegates scoped cleanup to the loaded memory runtime without reloading plugins", async () => {

--- a/src/plugins/memory-runtime.ts
+++ b/src/plugins/memory-runtime.ts
@@ -4,7 +4,8 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveUserPath } from "../utils.js";
 import { getLoadedRuntimePluginRegistry } from "./active-runtime-registry.js";
 import { normalizePluginsConfig } from "./config-state.js";
-import { getMemoryRuntime } from "./memory-state.js";
+import { getMemoryCapabilityRegistration, getMemoryRuntime } from "./memory-state.js";
+import { getActivePluginRuntimeSubagentMode } from "./runtime.js";
 import { ensureStandaloneRuntimePluginRegistryLoaded } from "./runtime/standalone-runtime-registry-loader.js";
 
 /** Resolves the configured memory slot to the single runtime plugin that may load memory. */
@@ -30,6 +31,70 @@ function resolveMemoryRuntimeWorkspaceDir(cfg: OpenClawConfig): string | undefin
   return resolveUserPath(dir);
 }
 
+type MemoryRuntimeLoadOptions = Parameters<
+  typeof ensureStandaloneRuntimePluginRegistryLoaded
+>[0]["loadOptions"];
+
+function listLoadedRegistryPluginIds(
+  registry: ReturnType<typeof getLoadedRuntimePluginRegistry>,
+): string[] {
+  const ids = new Set<string>();
+  for (const plugin of registry?.plugins ?? []) {
+    if (plugin.status === undefined || plugin.status === "loaded") {
+      ids.add(plugin.id);
+    }
+  }
+  return [...ids].toSorted((left, right) => left.localeCompare(right));
+}
+
+function buildMemoryRuntimeLoadOptions(params: {
+  cfg: OpenClawConfig;
+  pluginIds: string[];
+  workspaceDir: string | undefined;
+}): MemoryRuntimeLoadOptions {
+  const gatewayBindable = getActivePluginRuntimeSubagentMode() === "gateway-bindable";
+  return {
+    config: params.cfg,
+    onlyPluginIds: params.pluginIds,
+    workspaceDir: params.workspaceDir,
+    ...(gatewayBindable
+      ? {
+          runtimeOptions: { allowGatewaySubagentBinding: true as const },
+          preferBuiltPluginArtifacts: true,
+        }
+      : {}),
+  };
+}
+
+/** Ensures the configured memory plugin's prompt/runtime capability is registered. */
+export function ensureActiveMemoryCapability(cfg?: OpenClawConfig) {
+  const current = getMemoryCapabilityRegistration();
+  if (current || !cfg) {
+    return current;
+  }
+  const memoryPluginIds = resolveMemoryRuntimePluginIds(cfg);
+  if (memoryPluginIds.length === 0) {
+    return getMemoryCapabilityRegistration();
+  }
+  const loadedRegistry = getLoadedRuntimePluginRegistry({ requiredPluginIds: memoryPluginIds });
+  if (getMemoryCapabilityRegistration()) {
+    return getMemoryCapabilityRegistration();
+  }
+  const workspaceDir = resolveMemoryRuntimeWorkspaceDir(cfg);
+  // Tool discovery can leave a registry loaded while memory prompt hooks are absent.
+  // Reload that same plugin set so restoring memory does not discard gateway/channel plugins.
+  const pluginIds = loadedRegistry ? listLoadedRegistryPluginIds(loadedRegistry) : memoryPluginIds;
+  ensureStandaloneRuntimePluginRegistryLoaded({
+    requiredPluginIds: pluginIds,
+    ...(loadedRegistry ? { forceLoad: true } : {}),
+    loadOptions: buildMemoryRuntimeLoadOptions({
+      cfg,
+      pluginIds,
+      workspaceDir,
+    }),
+  });
+  return getMemoryCapabilityRegistration();
+}
 function ensureMemoryRuntime(cfg?: OpenClawConfig) {
   const current = getMemoryRuntime();
   if (current || !cfg) {
@@ -46,11 +111,11 @@ function ensureMemoryRuntime(cfg?: OpenClawConfig) {
   const workspaceDir = resolveMemoryRuntimeWorkspaceDir(cfg);
   ensureStandaloneRuntimePluginRegistryLoaded({
     requiredPluginIds: onlyPluginIds,
-    loadOptions: {
-      config: cfg,
-      onlyPluginIds,
+    loadOptions: buildMemoryRuntimeLoadOptions({
+      cfg,
+      pluginIds: onlyPluginIds,
       workspaceDir,
-    },
+    }),
   });
   return getMemoryRuntime();
 }


### PR DESCRIPTION
## Summary

- Ensure native Codex app-server turns activate the configured memory capability before rendering memory recall guidance.
- Keep #87383's intended root `MEMORY.md` guard: raw workspace memory is still excluded when it can be routed through tools, and retained when the effective workspace differs.
- Do not add a Codex-local fallback memory policy, public SDK contract, config option, or new SDK subpath. Codex uses the active memory engine/tool contract.
- Add focused regression coverage for daily-memory recall in Codex and for restoring a missing memory capability from an already-loaded compatible plugin registry.
- AI-assisted: yes. I understand what the code changes and validated it below.

## Linked context

Related: #87383

This fixes a regression introduced by #87383. That PR correctly stopped pasting raw native Codex workspace `MEMORY.md` into ordinary tool-enabled turns, but Codex tied memory recall guidance to the separate question of whether root workspace `MEMORY.md` could be routed through tools. In a real Telegram/Codex run, `memory_search` and `memory_get` were visible as deferred tools, but the first recommendation skipped saved credit-card constraints.

The ownership boundary in this PR is narrow: the memory engine/tool contract owns recall behavior; Codex ensures that capability is active and then forwards/uses the registered memory behavior when memory tools are available. The activation path stays internal to the bundled Codex/private runtime boundary; no public `plugin-sdk/*` contract is added or changed.

## Real behavior proof (required for external PRs)

- Behavior addressed: Native Codex turns could receive searchable memory tools without using the active memory engine's recall behavior, so personalized recommendations could skip saved user constraints until corrected later.
- Real environment tested: Devbox OpenClaw gateway built from this PR source tree at live proof head `fb245bcfe76abe57126d62b9486501c72a6c931f`, launched from `/home/[redacted]/workplace/openclaw-codex-memory-recall/dist/index.js gateway --port 18789` with `brave`, `codex`, `memory-core`, and `telegram` loaded. The live channel path was a Telegram direct route. Telegram bot name, user/chat ids, sender name, message ids, and home username are redacted below. Current head `a3f0079fb939e27d499ef83632cb3ae320b8cce7` only removes the non-Promise await and unused test helper flagged by CI; local validation below was rerun on current head.
- Exact steps or command run after this patch: Built runtime artifacts with `node scripts/build-all.mjs qaRuntime`, restarted `openclaw-gateway-pr-memory-recall.service`, sent the Telegram prompt `I am about to meet the SUB of the Amex Platinum. What card should I get next?`, then inspected the Codex rollout and OpenClaw trajectory for that run.
- Evidence after fix (redacted runtime log and trajectory excerpts):

```text
live proof head: fb245bcfe76abe57126d62b9486501c72a6c931f
service: openclaw-gateway-pr-memory-recall.service
command: /usr/local/bin/node /home/[redacted]/workplace/openclaw-codex-memory-recall/dist/index.js gateway --port 18789

Gateway/runtime log excerpt, same run:
Jun 09 13:02:23 [systemd] Started openclaw-gateway-pr-memory-recall.service - /usr/local/bin/node /home/[redacted]/workplace/openclaw-codex-memory-recall/dist/index.js gateway --port 18789.
2026-06-09T13:02:39.727+00:00 [gateway] agent model: openai/gpt-5.5 (thinking=xhigh, fast=on)
2026-06-09T13:02:39.729+00:00 [gateway] http server listening (4 plugins: brave, codex, memory-core, telegram; 14.8s)
2026-06-09T13:02:39.964+00:00 [gateway] ready
2026-06-09T13:02:41.161+00:00 [telegram] [default] starting provider ([redacted Telegram bot])
2026-06-09T13:02:49.979+00:00 [gateway] agent runtime plugins pre-warmed in 16ms
2026-06-09T13:03:49.892+00:00 [telegram] Inbound message telegram:[redacted] -> [redacted Telegram bot] (direct, 77 chars)
2026-06-09T13:07:00.675+00:00 [telegram] outbound send ok accountId=default chatId=[redacted] messageId=[redacted] operation=sendMessage deliveryKind=text chunkCount=1

rollout=/home/[redacted]/.openclaw/agents/main/agent/codex-home/sessions/2026/06/09/rollout-2026-06-09T13-03-52-019eac7b-74bd-79e2-8701-3664f13e45aa.jsonl
trajectory=/home/[redacted]/.openclaw/agents/main/sessions/1f122560-297d-4036-b22d-e2d6e3e88506.trajectory.jsonl
runId=92d671f5-0104-4276-8d82-b046e9d24b27
sessionKey=agent:main:telegram:direct:[redacted]

context.compiled prompt checks:
  Deferred searchable OpenClaw dynamic tools included memory_get=true, memory_search=true, tool_search=true
  ## Codex Memory Tool Loading present=true
  ## Memory Recall present=true
  raw root MEMORY.md paste path present=false

First relevant rollout/trajectory events:
2026-06-09T13:04:10.858Z response_item tool_search_call arguments={"query":"memory_search memory_get OpenClaw memory tools","limit":5}
2026-06-09T13:04:15.124Z response_item function_call name=memory_search namespace=openclaw arguments={"query":"Ruben credit cards Amex Platinum SUB points travel Chase 5/24 Card next","maxResults":5,"corpus":"all"}
2026-06-09T13:04:20.572Z response_item function_call_output for memory_search returned path="memory/2026-05-20.md" startLine=1 endLine=12 score=1 and path="memory/2026-05-20.md" startLine=10 endLine=22 score=0.9221236275780643
2026-06-09T13:04:25.527Z assistant commentary: "Your saved context says you already have CSP and Amex Gold, avoid business cards, and are likely over Chase 5/24. That narrows this a lot: I’m treating Chase and Amex Gold-type moves as low priority unless today’s terms say otherwise."
2026-06-09T13:04:25.844Z response_item function_call name=memory_get namespace=openclaw arguments={"path":"memory/2026-05-20.md","from":1,"lines":22,"corpus":"memory"}

memory_get returned the saved note:
"Current cards he listed: Bilt Blue, Amex Gold, Bank of America Unlimited Cash Rewards, Iberia Visa Signature, British Airways Visa Signature, Chase Sapphire Preferred, Wells Fargo Autograph."
"Constraint: no business cards; Ruben is on an L1 visa and does not want to apply for business cards."
"After Amex Platinum acceptance on May 20, 2026, count is 8/24 as of June 6, 2026; Chase apps should be treated as off the board until enough accounts age out."

Final visible message excerpt:
"As of today, I’d make your next move **Capital One Venture Rewards**, not Venture X."
"You’re likely over Chase 5/24 and already have CSP, so I’d leave Chase alone for now."
2026-06-09T13:07:00.717Z response_item function_call_output for message: {"ok":true,"messageId":"[redacted]"}
```

- Observed result after fix: In the same Telegram user path, Codex loaded the memory tools before answering, searched and read the saved credit-card memory, applied the saved CSP/no-business/Chase 5/24 constraints in the first recommendation, and avoided the previous initial Chase/Sapphire-style recommendation path.
- What was not tested: Non-Codex harnesses were not live-tested. The live proof used the Telegram channel path plus bundled Codex/memory-core runtime from the PR checkout.
- Proof limitations or environment constraints: The proof relies on existing memory data that contains the saved card-opening context, because that is the real failing path. User/channel identifiers and local usernames are redacted. Full `pnpm build` was attempted separately on the devbox, but `tsdown` was SIGKILLed during DTS-heavy full build with no TypeScript or bundler diagnostic; runtime build plus plugin SDK declaration/export checks passed separately.
- Before evidence: Devbox gateway from an earlier PR branch head before this fix, Telegram direct route, `memory-core` + `codex` + `telegram` loaded from that checkout's `dist`.

```text
Before-fix runtime trace, redacted:
2026-06-09T06:54:25Z [telegram] Inbound message telegram:[redacted] -> [redacted Telegram bot] (direct, 77 chars)
rollout=/home/[redacted]/.openclaw/agents/main/agent/codex-home/sessions/2026/06/09/rollout-2026-06-09T06-54-28-019eab29-409b-76d2-967e-8e683dcbcfbf.jsonl
trajectory=/home/[redacted]/.openclaw/agents/main/sessions/b28b87c0-2982-4a0c-b04d-b4a9c7100343.trajectory.jsonl

prompt/tool summary before fix:
  memory_search available=true
  memory_get available=true
  tool_search available=true
  ## Memory Recall present=false
  ## Codex Memory Tool Loading present=false

tool calls observed before fix:
  web_search=10
  tool_search=0
  memory_search=0
  memory_get=0

observed before fix: visible answer hedged on 5/24 instead of applying the saved card-opening history before the recommendation.
```


## Tests and validation

Current PR head validated: `a3f0079fb939e27d499ef83632cb3ae320b8cce7`.

- `pnpm exec oxfmt --check extensions/codex/src/app-server/attempt-context.ts src/plugins/memory-runtime.test.ts`
- `git diff --check`
- `pnpm exec oxlint extensions/codex/src/app-server/attempt-context.ts src/plugins/memory-runtime.test.ts`
- `pnpm lint --threads=8`
- `pnpm run lint:extensions:bundled`
- `node scripts/run-vitest.mjs src/plugins/memory-runtime.test.ts extensions/codex/src/app-server/attempt-context.test.ts extensions/codex/src/app-server/run-attempt.test.ts` - 104 tests passed
- `node scripts/check-plugin-sdk-subpath-exports.mjs`
- `pnpm build:plugin-sdk:dts && node --experimental-strip-types scripts/write-plugin-sdk-entry-dts.ts && node scripts/check-plugin-sdk-exports.mjs`
- `pnpm tsgo:prod && pnpm tsgo:test`
- `node scripts/build-all.mjs qaRuntime`

## Risk checklist

Did user-visible behavior change? `Yes`

Did config, environment, or migration behavior change? `No`

Did security, auth, secrets, network, or tool execution behavior change? `No`

What is the highest-risk area? Prompt/tool discovery behavior for native Codex memory routing.

How is that risk mitigated? The change activates the configured memory capability through an existing private bundled-Codex runtime boundary, preserves #87383's root `MEMORY.md` routing guard, avoids hardcoded fallback recall wording, and adds focused coverage for the daily-memory Codex path and compatible-registry-with-missing-capability case.

## Current review state

Next action: maintainer review and PR CI.

Waiting on: PR CI.

Bot/reviewer comments addressed: The previous concern about a Codex-local fallback is addressed by this head; there is no hardcoded fallback recall policy in Codex. The SDK-boundary concern is addressed by removing the added public facade export and removing the separate private helper subpath entirely.



