### PR TITLE
fix(memory): use local modelPath for status identity so custom local models aren't always dirty (fixes #91001)

### DIFF
--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -74,6 +74,7 @@ vi.mock("./embeddings.js", () => {
       provider?: string;
       model?: string;
       outputDimensionality?: number;
+      local?: { modelPath?: string };
     }) => {
       providerCalls.push({
         provider: options.provider,
@@ -93,8 +94,14 @@ vi.mock("./embeddings.js", () => {
         options.provider === "fallback-provider" ||
         options.provider === "ollama"
           ? options.provider
-          : "mock";
-      const model = options.model ?? "mock-embed";
+          : options.provider === "local"
+            ? "local"
+            : "mock";
+      // The real local provider reports its modelPath as the provider model identity.
+      const model =
+        options.provider === "local"
+          ? options.local?.modelPath?.trim() || "default-local-model.gguf"
+          : (options.model ?? "mock-embed");
       return {
         requestedProvider: options.provider ?? "openai",
         provider: {
@@ -280,6 +287,7 @@ describe("memory index", () => {
     providerAliases?: NonNullable<NonNullable<TestCfg["models"]>["providers"]>;
     model?: string;
     outputDimensionality?: number;
+    local?: { modelPath?: string };
     multimodal?: {
       enabled?: boolean;
       modalities?: Array<"image" | "audio" | "all">;
@@ -297,6 +305,7 @@ describe("memory index", () => {
           workspace: workspaceDir,
           memorySearch: {
             ...(params.provider !== undefined ? { provider: params.provider } : {}),
+            ...(params.local !== undefined ? { local: params.local } : {}),
             model: params.model ?? "mock-embed",
             fallback: params.fallback,
             outputDimensionality: params.outputDimensionality,
@@ -536,6 +545,43 @@ describe("memory index", () => {
       storePath: dbPath,
       provider: "gemini",
       model: "",
+      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
+    });
+    const statusManager = await getFreshManager(statusCfg, "status");
+    try {
+      const status = statusManager.status();
+
+      expect(status.dirty).toBe(false);
+      expect(status.custom?.indexIdentity).toEqual({ status: "valid" });
+    } finally {
+      await statusManager.close?.();
+    }
+  });
+
+  it("keeps status clean for a custom local embedding modelPath (#91001)", async () => {
+    const dbPath = path.join(workspaceDir, "index-local-modelpath-status.sqlite");
+    const modelPath = "/models/embeddinggemma-300M-Q8_0.gguf";
+    await fs.writeFile(path.join(memoryDir, "2026-02-02.md"), "# Log\nLocal model memory line.");
+
+    // Index with the local provider, which reports its modelPath as the model identity.
+    const indexCfg = createCfg({
+      storePath: dbPath,
+      provider: "local",
+      model: "",
+      local: { modelPath },
+      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
+    });
+    const indexManager = await getFreshManager(indexCfg);
+    await indexManager.sync({ reason: "test", force: true });
+    await indexManager.close?.();
+
+    // Plain status before provider init must mirror the local modelPath identity, not the
+    // empty settings.model / adapter default — otherwise status always reads dirty (#91001).
+    const statusCfg = createCfg({
+      storePath: dbPath,
+      provider: "local",
+      model: "",
+      local: { modelPath },
       hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
     });
     const statusManager = await getFreshManager(statusCfg, "status");

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -6,7 +6,10 @@ import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
 import chokidar, { FSWatcher } from "chokidar";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
-import { classifyMemoryMultimodalPath } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
+import {
+  classifyMemoryMultimodalPath,
+  DEFAULT_LOCAL_MODEL,
+} from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
 import {
   createSubsystemLogger,
   onSessionTranscriptUpdate,
@@ -40,6 +43,7 @@ import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coer
 import {
   createEmbeddingProvider,
   resolveEmbeddingProviderAdapterId,
+  resolveEmbeddingProviderAdapterTransport,
   resolveEmbeddingProviderFallbackModel,
   type EmbeddingProvider,
   type EmbeddingProviderId,
@@ -303,6 +307,13 @@ export abstract class MemoryManagerSyncOps {
     const hasProviderOverride = params && "provider" in params;
     // Plain status can compare identity before provider init. Mirror provider
     // init's empty-model fallback so adapter defaults do not look mismatched.
+    // The local provider's identity is its modelPath (what the worker returns and
+    // indexing persists), so a custom local.modelPath must mirror that here instead
+    // of settings.model / the adapter default — otherwise status always reads "dirty"
+    // before provider init (#91001).
+    const isLocalEmbeddingProvider =
+      this.settings.provider !== "none" &&
+      resolveEmbeddingProviderAdapterTransport(this.settings.provider, this.cfg) === "local";
     const configuredProvider =
       this.settings.provider === "none"
         ? null
@@ -310,9 +321,10 @@ export abstract class MemoryManagerSyncOps {
             id:
               resolveEmbeddingProviderAdapterId(this.settings.provider, this.cfg) ??
               this.settings.provider,
-            model:
-              this.settings.model.trim() ||
-              resolveEmbeddingProviderFallbackModel(this.settings.provider, "", this.cfg),
+            model: isLocalEmbeddingProvider
+              ? this.settings.local?.modelPath?.trim() || DEFAULT_LOCAL_MODEL
+              : this.settings.model.trim() ||
+                resolveEmbeddingProviderFallbackModel(this.settings.provider, "", this.cfg),
           };
     const provider = hasProviderOverride
       ? params.provider!


### PR DESCRIPTION
## Summary

- **Problem:** With `memorySearch.provider: "local"` and a custom `local.modelPath`, `openclaw memory status` always reports the index as **dirty** even right after a clean `memory index --force`. The index never looks "valid," so it appears to need a rebuild every time.
- **Root cause:** The local embedding worker reports its **`modelPath`** as the provider model identity (`{ id: "local", model: modelPath }`), and indexing persists that into `memory_index_meta_v1`. But the status-only identity path (`resolveCurrentIndexIdentityState` in `manager-sync-ops.ts`), which runs before provider init, builds the *expected* model from `settings.model` or the adapter default — never the configured `local.modelPath`. So the expected identity and the indexed identity never match → permanent "dirty."
- **What changed:** In the status path's `configuredProvider`, when the provider transport is `local`, use the same model identity indexing writes: `local.modelPath?.trim() || DEFAULT_LOCAL_MODEL`. Non-local providers are unchanged.
- **What did NOT change (scope boundary):** Only the local-provider, status-before-init identity. Remote providers, the adapter-default fallback for empty `settings.model` (#90413), provider-key/scope/sources/multimodal identity checks, and indexing itself are all untouched. No new config option or fallback path (clawsweeper flagged that as the wrong layer).

## Change Type

- [x] Bug fix

## Scope

- [x] Memory / storage (memory-core embedding index identity)

## Linked Issue

- Closes #91001

## User-visible / Behavior Changes

`openclaw memory status` no longer reports a permanently dirty index for a local embedding provider with a custom `local.modelPath`. Status identity now agrees with what indexing persisted, so a clean index reads as `valid`.

## Security Impact

- New permissions/capabilities? No · Secrets handling? No · Network calls? No · Tool exec surface? No · Data access scope? No

## Evidence

- [x] **Failing test before + passing after.** New test `keeps status clean for a custom local embedding modelPath (#91001)` in `extensions/memory-core/src/memory/index.test.ts`: indexes with the local provider + a custom modelPath, then asserts `status().dirty === false` and `indexIdentity === { status: "valid" }`. Reverting the source change turns it red (`expected true to be false` — status was dirty).
- Mirrors the sibling fix `#90413` (status identity for an empty `settings.model`).
- Local run (Node 22): **50 tests pass** across `index.test.ts` + `manager-reindex-state.test.ts`. oxlint + oxfmt clean on touched files.

## Human Verification

- Verified: a clean local index with a custom `local.modelPath` reads `valid` (not dirty) on status-before-init; non-local providers and the empty-model adapter-default path are unchanged; the test's mock provider now mirrors the real worker (reports `modelPath` as the provider model).
- Not verified: a live Docker/GGUF run with a real local model (verified at unit/source level, consistent with the issue's read-only repro).

## Compatibility / Migration

- Backward compatible? Yes — status-only identity repair; no stored shape or indexing change. · Config/env changes? No · Migration needed? No

## AI assistance

AI-assisted (Claude Code). Tested locally (50 tests + lint/format; whole-project tsgo run for types). Author understands the change. GitHub Codex review covers the AI-review pass.

## Real behavior proof

Behavior addressed: local embedding provider with a custom `local.modelPath` no longer reports a permanently dirty `memory status`; status-only index identity now mirrors the `modelPath` identity that indexing persists.
Real environment tested: Local unit + source verification on Node 22.22.1 (macOS). No live Docker/GGUF local-model run.
Exact steps or command run after this patch: `node node_modules/vitest/vitest.mjs run extensions/memory-core/src/memory/index.test.ts extensions/memory-core/src/memory/manager-reindex-state.test.ts` plus oxlint + oxfmt on the touched files; full-project `pnpm tsgo`. For a live check: set `memorySearch.provider: "local"` with a custom `local.modelPath`, run `openclaw memory index --force --agent main` then `openclaw memory status --agent main`.
Evidence after fix: 50 tests pass including the new #91001 regression test; reverting the source fix turns that test red (status reads dirty).
Observed result after fix: `status().dirty === false` and `indexIdentity === { status: "valid" }` for a freshly indexed local provider with a custom modelPath.
What was not tested: a live Docker + real GGUF local model end-to-end run (verified at unit/source level only).

## Risks and Mitigations

- Risk: changing the local provider's status identity could mask a genuine model change.
  - Mitigation: the identity now matches exactly what indexing persists (the same `modelPath || DEFAULT_LOCAL_MODEL` the worker reports), so a real modelPath change still flips identity to dirty; only the spurious always-dirty case is fixed.
