### PR TITLE
[AI] fix(plugins): recognize document-extractors as a capability kind…

### DIFF
--- a/src/plugins/contracts/shape.contract.test.ts
+++ b/src/plugins/contracts/shape.contract.test.ts
@@ -95,6 +95,15 @@ describe("plugin shape compatibility matrix", () => {
       },
     });
 
+    registerVirtualTestPlugin({
+      registry,
+      config,
+      id: "document-extract-test",
+      name: "Document Extract Test",
+      contracts: { documentExtractors: ["pdf"] },
+      register() {},
+    });
+
     const report = {
       workspaceDir: "/virtual-workspace",
       ...registry.registry,
@@ -130,40 +139,22 @@ describe("plugin shape compatibility matrix", () => {
         shape: "plain-capability",
         capabilityMode: "plain",
       },
+      {
+        id: "document-extract-test",
+        shape: "plain-capability",
+        capabilityMode: "plain",
+      },
     ]);
 
     expect(inspect[0]?.usesLegacyBeforeAgentStart).toBe(true);
     expect(inspect.map((entry) => entry.capabilities.map((capability) => capability.kind))).toEqual(
-      [[], ["text-inference"], ["text-inference", "web-search"], ["channel"]],
+      [
+        [],
+        ["text-inference"],
+        ["text-inference", "web-search"],
+        ["channel"],
+        ["document-extractors"],
+      ],
     );
-  });
-
-  it("recognizes document-extractors contract as a capability kind", () => {
-    const { config, registry } = createPluginRegistryFixture();
-
-    registerVirtualTestPlugin({
-      registry,
-      config,
-      id: "document-extract-test",
-      name: "Document Extract Test",
-      contracts: {
-        documentExtractors: ["pdf", "docx"],
-      },
-      register() {},
-    });
-
-    const report = {
-      workspaceDir: "/virtual-workspace",
-      ...registry.registry,
-    };
-    const plugin = report.plugins.find((p) => p.id === "document-extract-test")!;
-    const summary = buildPluginShapeSummary({ plugin, report });
-
-    expect(summary.shape).toBe("plain-capability");
-    expect(summary.capabilityMode).toBe("plain");
-    expect(summary.capabilityCount).toBe(1);
-    expect(summary.capabilities).toEqual([
-      { kind: "document-extractors", ids: ["pdf", "docx"] },
-    ]);
   });
 });

--- a/src/plugins/contracts/shape.contract.test.ts
+++ b/src/plugins/contracts/shape.contract.test.ts
@@ -137,4 +137,33 @@ describe("plugin shape compatibility matrix", () => {
       [[], ["text-inference"], ["text-inference", "web-search"], ["channel"]],
     );
   });
+
+  it("recognizes document-extractors contract as a capability kind", () => {
+    const { config, registry } = createPluginRegistryFixture();
+
+    registerVirtualTestPlugin({
+      registry,
+      config,
+      id: "document-extract-test",
+      name: "Document Extract Test",
+      contracts: {
+        documentExtractors: ["pdf", "docx"],
+      },
+      register() {},
+    });
+
+    const report = {
+      workspaceDir: "/virtual-workspace",
+      ...registry.registry,
+    };
+    const plugin = report.plugins.find((p) => p.id === "document-extract-test")!;
+    const summary = buildPluginShapeSummary({ plugin, report });
+
+    expect(summary.shape).toBe("plain-capability");
+    expect(summary.capabilityMode).toBe("plain");
+    expect(summary.capabilityCount).toBe(1);
+    expect(summary.capabilities).toEqual([
+      { kind: "document-extractors", ids: ["pdf", "docx"] },
+    ]);
+  });
 });

--- a/src/plugins/inspect-shape.ts
+++ b/src/plugins/inspect-shape.ts
@@ -11,6 +11,7 @@ export type PluginCapabilityKind =
   | "realtime-voice"
   | "media-understanding"
   | "transcript-source"
+  | "document-extractors"
   | "image-generation"
   | "video-generation"
   | "music-generation"
@@ -50,6 +51,7 @@ function buildPluginCapabilityEntries(
     { kind: "realtime-voice" as const, ids: plugin.realtimeVoiceProviderIds },
     { kind: "media-understanding" as const, ids: plugin.mediaUnderstandingProviderIds },
     { kind: "transcript-source" as const, ids: plugin.transcriptSourceProviderIds },
+    { kind: "document-extractors" as const, ids: plugin.contracts?.documentExtractors ?? [] },
     { kind: "image-generation" as const, ids: plugin.imageGenerationProviderIds },
     { kind: "video-generation" as const, ids: plugin.videoGenerationProviderIds },
     { kind: "music-generation" as const, ids: plugin.musicGenerationProviderIds },


### PR DESCRIPTION

## Summary

`PluginCapabilityKind` in `inspect-shape.ts` did not include `"document-extractors"`, so plugins declaring `contracts.documentExtractors` (like the bundled `document-extract` plugin) showed `capabilityCount: 0`, `tools: []`, and `shape: "non-capability"` in `openclaw plugins inspect`. This made the plugin appear broken in diagnostics even though its contract declaration was correct.

Add `"document-extractors"` to the `PluginCapabilityKind` union type and read `plugin.contracts?.documentExtractors` in `buildPluginCapabilityEntries()`, so the inspection system correctly reflects the plugin's declared extraction capability.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue

- Related to #91539
- [x] This PR fixes a bug or regression

## Motivation

The document-extract plugin (bundled, `contracts.documentExtractors: ["pdf"]`) was misclassified as `"non-capability"` shape with `capabilityCount: 0` in `openclaw plugins inspect`. Users upgrading to 2026.6.1 saw the plugin report zero capabilities despite the manifest contract being valid, causing confusion about whether PDF/DOCX extraction was functional.

The root cause is that `PluginCapabilityKind` — the enumeration used by `buildPluginCapabilityEntries()` to count and classify plugin capabilities — never included `"document-extractors"`. All other contract types (providers, channels, etc.) have corresponding capability kinds, but `documentExtractors` was missing from the list.

## Changes

**File**: `src/plugins/inspect-shape.ts`

1. Added `"document-extractors"` to `PluginCapabilityKind` type union (alphabetically after `"transcript-source"`)
2. Added `{ kind: "document-extractors" as const, ids: plugin.contracts?.documentExtractors ?? [] }` entry in `buildPluginCapabilityEntries()`

No new imports. Reads from `plugin.contracts?.documentExtractors` which already exists on `PluginRecord` via `PluginManifestContracts`.

## Verification

- `src/plugins/contracts/shape.contract.test.ts` — passed (1 test)
- `src/plugins/status.test.ts` — passed (27 tests)
- `src/plugins/contracts/registry.contract.test.ts` — passed (21 tests)

## Real Behavior Proof

**Behavior addressed**: Plugins with `contracts.documentExtractors` now show correct `capabilityCount`, `shape`, and `capabilities` in `openclaw plugins inspect` output.

**Real environment tested**: Linux (Ubuntu), Node.js 22.19+, local checkout on branch `fix/document-extractors-capability-kind-91539`, commit 12b8f60cc.

**Exact steps or command run after this patch**:
```
pnpm build
pnpm openclaw plugins inspect document-extract --runtime --json
```

**Evidence after fix**: Live `openclaw plugins inspect` output confirms the fix:

| Field | Before (issue #91539) | After (this patch) |
|-------|----------------------|---------------------|
| `shape` | `"non-capability"` | `"plain-capability"` |
| `capabilityCount` | `0` | `1` |
| `capabilityMode` | `"none"` | `"plain"` |
| `capabilities` | `[]` | `[{"kind":"document-extractors","ids":["pdf"]}]` |

Full after-fix output (redacted workspace path):
```json
{
  "shape": "plain-capability",
  "capabilityMode": "plain",
  "capabilityCount": 1,
  "capabilities": [
    {
      "kind": "document-extractors",
      "ids": ["pdf"]
    }
  ],
  "plugin": {
    "id": "document-extract",
    "status": "loaded",
    "contracts": {
      "documentExtractors": ["pdf"]
    }
  }
}
```

**Observed result after fix**: Shape diagnostic correctly reflects document-extract contract as a plugin capability.

**What was not tested**: Runtime document extraction functionality (PDF/DOCX file reading) is unchanged — this PR only fixes diagnostic display.

## Risks

- **Low risk**: Only changes the inspection/diagnostic surface, not runtime resolution or plugin loading behavior.
- **No config/default surface changes**: No new config keys, env vars, or defaults introduced.
- **Type surface**: `PluginCapabilityKind` is used in `PluginCapabilityEntry.kind` and `PluginShapeSummary.capabilities[].kind`. Adding a new union member is additive — existing consumers that iterate or filter on `kind` will now see `"document-extractors"` entries. No breaking change for code that pattern-matches on the existing kinds.