### PR TITLE
perf(control-ui): lazy load slash commands

### DIFF
--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -1076,7 +1076,7 @@ describe("refreshChat", () => {
     }
   });
 
-  it("uses startup metadata without scheduling a chat.metadata follow-up", async () => {
+  it("uses startup metadata without scheduling command or metadata follow-ups", async () => {
     const { resetSlashCommandsForTest } = await import("./chat/slash-commands.ts");
     resetSlashCommandsForTest();
     const previousFetch = globalThis.fetch;
@@ -1110,11 +1110,7 @@ describe("refreshChat", () => {
       });
       expect(request).not.toHaveBeenCalledWith("chat.metadata", expect.anything());
       expect(request).not.toHaveBeenCalledWith("models.list", expect.anything());
-      expect(request).toHaveBeenCalledWith("commands.list", {
-        agentId: "main",
-        includeArgs: true,
-        scope: "text",
-      });
+      expect(request).not.toHaveBeenCalledWith("commands.list", expect.anything());
       expect(host.chatModelCatalog).toEqual([
         { id: "gpt-fast", name: "GPT Fast", provider: "openai" },
       ]);

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -2060,10 +2060,9 @@ export async function refreshChat(
       .then((metadataApplied) => {
         const metadataRefresh =
           opts?.startup === true && (metadataApplied.commands || metadataApplied.models)
-            ? Promise.allSettled([
-                ...(metadataApplied.models ? [] : [refreshChatModels(host)]),
-                ...(metadataApplied.commands ? [] : [refreshChatCommands(host)]),
-              ])
+            ? metadataApplied.models
+              ? Promise.allSettled([])
+              : Promise.allSettled([refreshChatModels(host)])
             : Promise.allSettled([refreshChatMetadata(host)]);
         return Promise.allSettled([refreshChatAvatar(host), metadataRefresh]);
       })
@@ -2102,7 +2101,7 @@ async function refreshChatModels(host: ChatHost) {
   }
 }
 
-async function refreshChatCommands(host: ChatHost) {
+export async function refreshChatCommands(host: ChatHost) {
   await refreshSlashCommands({
     client: host.client,
     agentId: resolveAgentIdForSession(host),

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -2210,6 +2210,9 @@ export function renderApp(state: AppViewState) {
       open: state.paletteOpen,
       query: state.paletteQuery,
       activeIndex: state.paletteActiveIndex,
+      onOpen: () => {
+        void refreshChatCommands(state).finally(requestHostUpdate);
+      },
       onToggle: () => {
         state.paletteOpen = !state.paletteOpen;
       },

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -8,6 +8,7 @@ import {
   createChatSessionsLoadOverrides,
   hasAbortableSessionRun,
   refreshChat,
+  refreshChatCommands,
   scopedAgentListParamsForSession,
   scopedAgentParamsForSession,
 } from "./app-chat.ts";
@@ -3547,6 +3548,7 @@ export function renderApp(state: AppViewState) {
                   onDraftChange: (next) => state.handleChatDraftChange(next),
                   onRequestUpdate: requestHostUpdate,
                   onHistoryKeydown: (input) => state.handleChatInputHistoryKey(input),
+                  onSlashIntent: () => refreshChatCommands(state).finally(requestHostUpdate),
                   attachments: state.chatAttachments,
                   onAttachmentsChange: (next) => (state.chatAttachments = next),
                   onSend: () => void state.handleSendChat(),

--- a/ui/src/ui/e2e/chat-flow.e2e.test.ts
+++ b/ui/src/ui/e2e/chat-flow.e2e.test.ts
@@ -488,9 +488,11 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
       await page.getByText("First token visible.").waitFor({ timeout: 10_000 });
       expect(await gateway.getRequests("chat.metadata")).toHaveLength(0);
       expect(await gateway.getRequests("models.list")).toHaveLength(0);
-      await gateway.waitForRequest("commands.list");
+      expect(await gateway.getRequests("commands.list")).toHaveLength(0);
       await gateway.emitChatFinal({ runId, text: "History race stayed visible." });
       await page.getByText("History race stayed visible.").waitFor({ timeout: 10_000 });
+      await page.locator(".agent-chat__composer-combobox textarea").fill("/");
+      await gateway.waitForRequest("commands.list");
       expect(await gateway.getRequests("agents.list")).toHaveLength(0);
     } finally {
       await context.close();

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -579,6 +579,16 @@ function renderChatView(overrides: Partial<Parameters<typeof renderChat>[0]> = {
   return container;
 }
 
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (error?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 describe("chat compaction divider", () => {
   it("renders checkpoint recovery copy and action", () => {
     const onOpenSessionCheckpoints = vi.fn();
@@ -1438,6 +1448,55 @@ describe("chat slash menu accessibility", () => {
 
     expect(onDraftChange).toHaveBeenCalledWith("plain first message");
     expect(onSend).toHaveBeenCalledTimes(1);
+  });
+
+  it("requests slash command hydration only after slash intent", () => {
+    const onSlashIntent = vi.fn(async () => undefined);
+    const container = renderChatView({ onSlashIntent });
+
+    inputDraft(container, "plain first message");
+
+    expect(onSlashIntent).not.toHaveBeenCalled();
+
+    inputDraft(container, "/");
+
+    expect(onSlashIntent).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not reopen slash suggestions when command hydration finishes after plain typing", async () => {
+    let draft = "";
+    const hydration = createDeferred<void>();
+    const onSlashIntent = vi.fn(() => hydration.promise);
+    const onDraftChange = vi.fn((next: string) => {
+      draft = next;
+    });
+    const container = document.createElement("div");
+    const renderCurrent = () => {
+      render(
+        renderChat(
+          createChatProps({
+            draft,
+            getDraft: () => draft,
+            onDraftChange,
+            onRequestUpdate: renderCurrent,
+            onSlashIntent,
+          }),
+        ),
+        container,
+      );
+    };
+    renderCurrent();
+
+    inputDraft(container, "/");
+    expect(container.querySelector(".slash-menu")).not.toBeNull();
+
+    inputDraft(container, "plain first message");
+    expect(container.querySelector(".slash-menu")).toBeNull();
+    hydration.resolve();
+    await hydration.promise;
+    await Promise.resolve();
+
+    expect(container.querySelector(".slash-menu")).toBeNull();
   });
 
   it("clears the visible local draft immediately when send clears the host draft", () => {

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -153,6 +153,7 @@ export type ChatProps = {
   onDraftChange: (next: string) => void;
   onRequestUpdate?: () => void;
   onHistoryKeydown?: (input: ChatInputHistoryKeyInput) => ChatInputHistoryKeyResult;
+  onSlashIntent?: () => void | Promise<void>;
   onSend: () => void;
   onCompact?: () => void | Promise<void>;
   onOpenSessionCheckpoints?: () => void | Promise<void>;
@@ -454,6 +455,7 @@ interface ChatEphemeralState {
   slashMenuCommand: SlashCommandDef | null;
   slashMenuArgItems: string[];
   slashMenuExpanded: boolean;
+  slashCommandRefreshPending: boolean;
   searchOpen: boolean;
   searchQuery: string;
   pinnedExpanded: boolean;
@@ -479,6 +481,7 @@ function createChatEphemeralState(): ChatEphemeralState {
     slashMenuCommand: null,
     slashMenuArgItems: [],
     slashMenuExpanded: false,
+    slashCommandRefreshPending: false,
     searchOpen: false,
     searchQuery: "",
     pinnedExpanded: false,
@@ -1106,10 +1109,44 @@ function closeSlashMenuIfNeeded(requestUpdate: () => void): void {
   requestUpdate();
 }
 
-function updateSlashMenu(value: string, requestUpdate: () => void): void {
+function requestSlashCommandRefresh(
+  value: string,
+  props: ChatProps,
+  requestUpdate: () => void,
+  getCurrentValue?: () => string,
+): void {
+  if (!props.onSlashIntent || vs.slashCommandRefreshPending) {
+    return;
+  }
+  const refresh = props.onSlashIntent();
+  if (!refresh || typeof refresh.then !== "function") {
+    return;
+  }
+  vs.slashCommandRefreshPending = true;
+  void Promise.resolve(refresh).finally(() => {
+    vs.slashCommandRefreshPending = false;
+    const nextValue = getCurrentValue?.() ?? props.getDraft?.() ?? value;
+    if (!nextValue.startsWith("/")) {
+      closeSlashMenuIfNeeded(requestUpdate);
+      return;
+    }
+    updateSlashMenu(nextValue, requestUpdate, props, { skipSlashIntent: true });
+  });
+}
+
+function updateSlashMenu(
+  value: string,
+  requestUpdate: () => void,
+  props: ChatProps,
+  opts: { skipSlashIntent?: boolean } = {},
+  getCurrentValue?: () => string,
+): void {
   // Arg mode: /command <partial-arg>
   const argMatch = value.match(/^\/(\S+)\s(.*)$/);
   if (argMatch) {
+    if (!opts.skipSlashIntent) {
+      requestSlashCommandRefresh(value, props, requestUpdate, getCurrentValue);
+    }
     const cmdName = argMatch[1].toLowerCase();
     const argFilter = argMatch[2].toLowerCase();
     const cmd = SLASH_COMMANDS.find((c) => c.name === cmdName);
@@ -1135,6 +1172,9 @@ function updateSlashMenu(value: string, requestUpdate: () => void): void {
   // Command mode: /partial-command
   const match = value.match(/^\/(\S*)$/);
   if (match) {
+    if (!opts.skipSlashIntent) {
+      requestSlashCommandRefresh(value, props, requestUpdate, getCurrentValue);
+    }
     const items = getSlashCommandCompletions(match[1], { showAll: vs.slashMenuExpanded });
     vs.slashMenuItems = items;
     vs.slashMenuOpen = items.length > 0;
@@ -1512,7 +1552,7 @@ function renderSlashMenu(
               e.preventDefault();
               e.stopPropagation();
               vs.slashMenuExpanded = true;
-              updateSlashMenu(draft, requestUpdate);
+              updateSlashMenu(draft, requestUpdate, props);
             }}
           >
             Show ${hiddenCount} more command${hiddenCount !== 1 ? "s" : ""}
@@ -1941,7 +1981,7 @@ export function renderChat(props: ChatProps) {
     if (hostDraftNeeded || target.value.startsWith("/") || hasVisibleSlashMenuState()) {
       commitComposerDraft(props, target.value);
     }
-    updateSlashMenu(target.value, requestUpdate);
+    updateSlashMenu(target.value, requestUpdate, props, {}, () => target.value);
   };
   const handleBlur = (e: FocusEvent) => {
     const target = e.target as HTMLTextAreaElement;

--- a/ui/src/ui/views/command-palette.test.ts
+++ b/ui/src/ui/views/command-palette.test.ts
@@ -130,6 +130,17 @@ describe("command palette", () => {
     expect(prose?.label).toBe("/prose");
   });
 
+  it("requests slash command hydration when the palette opens", async () => {
+    const onOpen = vi.fn();
+
+    await renderPalette({ onOpen });
+    expect(onOpen).toHaveBeenCalledTimes(1);
+
+    render(renderCommandPalette(createProps({ onOpen, query: "overview" })), container);
+    await nextFrame();
+    expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+
   it("matches localized base item labels and descriptions", async () => {
     await i18n.setLocale("zh-CN");
 

--- a/ui/src/ui/views/command-palette.ts
+++ b/ui/src/ui/views/command-palette.ts
@@ -101,6 +101,7 @@ export type CommandPaletteProps = {
   open: boolean;
   query: string;
   activeIndex: number;
+  onOpen?: () => void | Promise<void>;
   onToggle: () => void;
   onQueryChange: (query: string) => void;
   onActiveIndexChange: (index: number) => void;
@@ -137,6 +138,7 @@ function groupItems(items: PaletteItem[]): Array<[string, PaletteItem[]]> {
 
 let previouslyFocused: Element | null = null;
 let activeDialog: HTMLDialogElement | null = null;
+let activeProps: CommandPaletteProps | null = null;
 
 const FOCUSABLE_SELECTOR = [
   "a[href]",
@@ -288,6 +290,7 @@ function syncDialog(el: Element | undefined) {
   if (activeDialog !== el) {
     saveFocus();
     activeDialog = el;
+    void activeProps?.onOpen?.();
   }
   if (el.open) {
     return;
@@ -319,6 +322,7 @@ export function renderCommandPalette(props: CommandPaletteProps) {
   if (!props.open) {
     return nothing;
   }
+  activeProps = props;
 
   const items = filteredItems(props.query);
   const grouped = groupItems(items);


### PR DESCRIPTION
## Summary
- Stop clean Control UI startup from firing `commands.list` when `chat.startup` already returned useful metadata without commands.
- Hydrate remote slash commands only from explicit command intent: composer slash mode or command palette open.
- Keep late slash hydration from reopening stale suggestions after the draft returns to plain text.

## Verification
- `node scripts/run-vitest.mjs ui/src/ui/app-chat.test.ts ui/src/ui/views/chat.test.ts ui/src/ui/views/command-palette.test.ts --reporter=verbose -t "uses startup metadata without scheduling command or metadata follow-ups|requests slash command hydration only after slash intent|does not reopen slash suggestions when command hydration finishes after plain typing|requests slash command hydration when the palette opens"`
- Testbox `tbx_01ktn85f2ssqenaknmcb5n4syf`: `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/ui/e2e/chat-flow.e2e.test.ts --reporter=verbose -t "sends the first chat turn while agents startup loading is still pending"` (Actions run https://github.com/openclaw/openclaw/actions/runs/27182710159)
- Testbox `tbx_01ktn85f2ssqenaknmcb5n4syf`: `env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` clean after fixing the command palette hydration finding.
- Final rebase sanity after `origin/main` moved: `git diff --check origin/main...HEAD`; focused unit command above.

## Notes
- I intentionally did not move command metadata into `chat.startup`: `buildCommandsListResult` walks workspace/skill command sources synchronously, which would put unbounded discovery back on the first-load critical path.
- Known gap: no live provider/browser visual proof beyond mocked Gateway E2E; this patch is scheduling/RPC behavior in Control UI.
