### PR TITLE
fix(update): expose plugin convergence repair

### DIFF
--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -19,6 +19,7 @@ updates happen via the package-manager flow in [Updating](/install/updating).
 ```bash
 openclaw update
 openclaw update status
+openclaw update repair
 openclaw update wizard
 openclaw update --channel beta
 openclaw update --channel dev
@@ -75,6 +76,36 @@ Options:
 
 - `--json`: print machine-readable status JSON.
 - `--timeout <seconds>`: timeout for checks (default is 3s).
+
+## `update repair`
+
+Rerun update finalization after the core package already changed but later
+repair work did not finish cleanly. This is the supported recovery path when
+`openclaw update` installed the new core package but post-core plugin sync,
+managed npm plugin metadata, registry refresh, or doctor repair still needs to
+converge.
+
+```bash
+openclaw update repair
+openclaw update repair --channel beta
+openclaw update repair --json
+```
+
+Options:
+
+- `--channel <stable|beta|dev>`: persist the update channel before repair and
+  run plugin convergence against that channel.
+- `--json`: print machine-readable finalization JSON.
+- `--timeout <seconds>`: timeout for repair steps (default `1800`).
+- `--yes`: skip confirmation prompts.
+- `--no-restart`: accepted for update command parity; repair never restarts the
+  Gateway.
+
+`openclaw update repair` runs `openclaw doctor --fix`, reloads the repaired
+config and install records, syncs tracked plugins for the active update channel,
+updates managed npm plugin installs, repairs missing configured plugin payloads,
+refreshes the plugin registry, and writes the converged install-record metadata.
+It does not install a new core package and does not restart the Gateway.
 
 ## `update wizard`
 
@@ -218,9 +249,9 @@ If an exact pinned npm plugin update resolves to an artifact whose integrity dif
 </Warning>
 
 <Note>
-Post-update plugin sync failures that are scoped to a managed plugin and that the sync path can route around (e.g. an unreachable npm registry for a non-essential plugin) are reported as warnings after the core update succeeds. The JSON result keeps the top-level update `status: "ok"` and reports `postUpdate.plugins.status: "warning"` with `openclaw doctor --fix` and `openclaw plugins inspect <id> --runtime --json` guidance. Unexpected updater or sync exceptions still fail the update result. Fix the plugin install or update error, then rerun `openclaw doctor --fix` or `openclaw update`.
+Post-update plugin sync failures that are scoped to a managed plugin and that the sync path can route around (e.g. an unreachable npm registry for a non-essential plugin) are reported as warnings after the core update succeeds. The JSON result keeps the top-level update `status: "ok"` and reports `postUpdate.plugins.status: "warning"` with `openclaw update repair` and `openclaw plugins inspect <id> --runtime --json` guidance. Unexpected updater or sync exceptions still fail the update result. Fix the plugin install or update error, then rerun `openclaw update repair`.
 
-After the per-plugin sync step, `openclaw update` runs a mandatory **post-core convergence** pass before the gateway is restarted: it repairs missing configured plugin payloads, validates each _active_ tracked install record on disk, and statically verifies its `package.json` is parseable (and any explicitly-declared `main` exists). Failures from this pass — and an invalid OpenClaw config snapshot — return `postUpdate.plugins.status: "error"` and flip the top-level update `status` to `"error"`, so `openclaw update` exits non-zero and the gateway is _not_ restarted with an unverified plugin set. The error includes structured `postUpdate.plugins.warnings[].guidance` lines pointing at `openclaw doctor --fix` and `openclaw plugins inspect <id> --runtime --json` for follow-up. Disabled plugin entries and records that are not trusted-source-linked official sync targets are skipped here, mirroring the `skipDisabledPlugins` policy used by the missing-payload check, so a stale disabled plugin record cannot block an otherwise valid update.
+After the per-plugin sync step, `openclaw update` runs a mandatory **post-core convergence** pass before the gateway is restarted: it repairs missing configured plugin payloads, validates each _active_ tracked install record on disk, and statically verifies its `package.json` is parseable (and any explicitly-declared `main` exists). Failures from this pass — and an invalid OpenClaw config snapshot — return `postUpdate.plugins.status: "error"` and flip the top-level update `status` to `"error"`, so `openclaw update` exits non-zero and the gateway is _not_ restarted with an unverified plugin set. The error includes structured `postUpdate.plugins.warnings[].guidance` lines pointing at `openclaw update repair` and `openclaw plugins inspect <id> --runtime --json` for follow-up. Disabled plugin entries and records that are not trusted-source-linked official sync targets are skipped here, mirroring the `skipDisabledPlugins` policy used by the missing-payload check, so a stale disabled plugin record cannot block an otherwise valid update.
 
 When the updated Gateway starts, plugin loading is verify-only: startup does not
 run package managers or mutate dependency trees. Package-manager `update.run`

--- a/src/cli/update-cli.option-collisions.test.ts
+++ b/src/cli/update-cli.option-collisions.test.ts
@@ -89,6 +89,33 @@ describe("update cli option collisions", () => {
       },
     },
     {
+      name: "forwards parent-captured --json/--timeout to `update repair`",
+      argv: ["update", "repair", "--json", "--timeout", "19"],
+      assert: () => {
+        expect(updateFinalizeCommand).toHaveBeenCalledTimes(1);
+        const opts = firstCallOptions(updateFinalizeCommand);
+        expect(
+          (opts as { json?: boolean; timeout?: string; restart?: boolean } | undefined)?.json,
+        ).toBe(true);
+        expect(
+          (opts as { json?: boolean; timeout?: string; restart?: boolean } | undefined)?.timeout,
+        ).toBe("19");
+        expect(
+          (opts as { json?: boolean; timeout?: string; restart?: boolean } | undefined)?.restart,
+        ).toBe(false);
+      },
+    },
+    {
+      name: "forwards repair channel and confirmation options",
+      argv: ["update", "repair", "--channel", "beta", "--yes"],
+      assert: () => {
+        expect(updateFinalizeCommand).toHaveBeenCalledTimes(1);
+        const opts = firstCallOptions(updateFinalizeCommand);
+        expect((opts as { channel?: string; yes?: boolean } | undefined)?.channel).toBe("beta");
+        expect((opts as { channel?: string; yes?: boolean } | undefined)?.yes).toBe(true);
+      },
+    },
+    {
       name: "keeps hidden `update finalize --no-restart` as a no-op parity flag",
       argv: ["update", "finalize", "--no-restart"],
       assert: () => {

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -1028,7 +1028,7 @@ describe("update-cli", () => {
                 reason: "missing-extension-entry: ./dist/index.js",
                 message:
                   'Plugin "demo" failed post-core payload smoke check (missing-extension-entry): ./dist/index.js',
-                guidance: ["Run openclaw doctor --fix to attempt automatic repair."],
+                guidance: ["Run openclaw update repair to retry post-update plugin repair."],
               },
             ],
             sync: {
@@ -1727,13 +1727,13 @@ describe("update-cli", () => {
     expect(jsonOutput?.postUpdate?.plugins?.status).toBe("warning");
     expect(pluginWarning(jsonOutput)?.pluginId).toBe("demo");
     expect(pluginWarning(jsonOutput)?.guidance).toEqual([
-      "Run openclaw doctor --fix to attempt automatic repair.",
+      "Run openclaw update repair to retry post-update plugin repair.",
       "Run openclaw plugins inspect demo --runtime --json for details.",
     ]);
     expect(pluginWarning(jsonOutput)?.reason).toContain("npm package integrity drift");
     expect(jsonOutput?.postUpdate?.plugins?.npm.outcomes[0]?.status).toBe("error");
     expect(jsonOutput?.postUpdate?.plugins?.npm.outcomes[0]?.message).toContain(
-      "Run openclaw doctor --fix to attempt automatic repair.",
+      "Run openclaw update repair to retry post-update plugin repair.",
     );
     expect(jsonOutput?.postUpdate?.plugins?.npm.outcomes[0]?.message).toContain(
       "Run openclaw plugins inspect demo --runtime --json for details.",
@@ -1821,7 +1821,7 @@ describe("update-cli", () => {
       .mock.calls.map((call) => String(call[0]))
       .join("\n");
     expect(logs).toContain("Failed to update demo: registry timeout");
-    expect(logs).toContain("Run openclaw doctor --fix to attempt automatic repair.");
+    expect(logs).toContain("Run openclaw update repair to retry post-update plugin repair.");
     expect(logs).toContain("Run openclaw plugins inspect demo --runtime --json for details.");
   });
 
@@ -1846,7 +1846,7 @@ describe("update-cli", () => {
     expect(jsonOutput?.postUpdate?.plugins?.status).toBe("warning");
     expect(pluginWarning(jsonOutput)?.pluginId).toBe("demo");
     expect(pluginWarning(jsonOutput)?.guidance).toEqual([
-      "Run openclaw doctor --fix to attempt automatic repair.",
+      "Run openclaw update repair to retry post-update plugin repair.",
       "Run openclaw plugins inspect demo --runtime --json for details.",
     ]);
     expect(pluginOutcome(jsonOutput)?.pluginId).toBe("demo");
@@ -1890,9 +1890,9 @@ describe("update-cli", () => {
                     pluginId: "demo",
                     reason: "Failed to update demo: registry timeout",
                     message:
-                      'Plugin "demo" could not be processed after the core update: Failed to update demo: registry timeout Run openclaw doctor --fix to attempt automatic repair. Run openclaw plugins inspect demo --runtime --json for details.',
+                      'Plugin "demo" could not be processed after the core update: Failed to update demo: registry timeout Run openclaw update repair to retry post-update plugin repair. Run openclaw plugins inspect demo --runtime --json for details.',
                     guidance: [
-                      "Run openclaw doctor --fix to attempt automatic repair.",
+                      "Run openclaw update repair to retry post-update plugin repair.",
                       "Run openclaw plugins inspect demo --runtime --json for details.",
                     ],
                   },
@@ -1933,7 +1933,7 @@ describe("update-cli", () => {
     expect(jsonOutput?.status).toBe("ok");
     expect(jsonOutput?.reason).toBeUndefined();
     expect(jsonOutput?.postUpdate?.plugins?.warnings?.[0]?.guidance).toContain(
-      "Run openclaw doctor --fix to attempt automatic repair.",
+      "Run openclaw update repair to retry post-update plugin repair.",
     );
     expect(jsonOutput?.postUpdate?.plugins?.npm.outcomes[0]?.message).toContain("registry timeout");
   });

--- a/src/cli/update-cli.ts
+++ b/src/cli/update-cli.ts
@@ -38,6 +38,44 @@ function inheritedUpdateTimeout(
   return inheritOptionFromParent<string>(command, "timeout");
 }
 
+function registerUpdateRepairCommand(update: Command, name: string, params?: { hidden?: boolean }) {
+  const command = params?.hidden ? update.command(name, { hidden: true }) : update.command(name);
+  command
+    .description("Repair post-update doctor and plugin convergence")
+    .option("--json", "Output result as JSON", false)
+    .option("--channel <stable|beta|dev>", "Persist update channel before repair")
+    .option("--timeout <seconds>", "Timeout for update repair steps in seconds (default: 1800)")
+    .option("--yes", "Skip confirmation prompts (non-interactive)", false)
+    .option("--no-restart", "Accepted for update command parity; repair never restarts")
+    .addHelpText(
+      "after",
+      () =>
+        `\n${theme.heading("Examples:")}\n${formatHelpExamples([
+          ["openclaw update repair", "Rerun post-update doctor and plugin convergence."],
+          ["openclaw update repair --channel beta", "Repair against the beta update channel."],
+          ["openclaw update repair --json", "JSON output for automation."],
+        ])}\n\n${theme.heading("Notes:")}\n${theme.muted(
+          "- Repairs post-update plugin state after the core package already changed",
+        )}\n${theme.muted("- Runs doctor repair and plugin convergence, but never restarts the Gateway")}\n\n${theme.muted(
+          "Docs:",
+        )} ${formatDocsLink("/cli/update", "docs.openclaw.ai/cli/update")}`,
+    )
+    .action(async (opts, command) => {
+      try {
+        await updateFinalizeCommand({
+          json: Boolean(opts.json) || inheritedUpdateJson(command),
+          channel: opts.channel as string | undefined,
+          timeout: inheritedUpdateTimeout(opts, command),
+          yes: Boolean(opts.yes),
+          restart: false,
+        });
+      } catch (err) {
+        defaultRuntime.error(String(err));
+        defaultRuntime.exit(1);
+      }
+    });
+}
+
 /** Attach the update command group to the root CLI. */
 export function registerUpdateCli(program: Command) {
   program.enablePositionalOptions();
@@ -65,6 +103,7 @@ export function registerUpdateCli(program: Command) {
         ["openclaw update --no-restart", "Update without restarting the service"],
         ["openclaw update --json", "Output result as JSON"],
         ["openclaw update --yes", "Non-interactive (accept downgrade prompts)"],
+        ["openclaw update repair", "Repair stranded post-update plugin state"],
         ["openclaw update wizard", "Interactive update wizard"],
         ["openclaw --update", "Shorthand for openclaw update"],
       ] as const;
@@ -115,31 +154,8 @@ ${theme.muted("Docs:")} ${formatDocsLink("/cli/update", "docs.openclaw.ai/cli/up
       }
     });
 
-  update
-    .command("finalize", { hidden: true })
-    .description("Run OpenClaw update finalization after an external core runtime change")
-    .option("--json", "Output result as JSON", false)
-    .option("--channel <stable|beta|dev>", "Persist update channel for finalization")
-    .option(
-      "--timeout <seconds>",
-      "Timeout for update finalization steps in seconds (default: 1800)",
-    )
-    .option("--yes", "Skip confirmation prompts (non-interactive)", false)
-    .option("--no-restart", "Accepted for update command parity; finalization never restarts")
-    .action(async (opts, command) => {
-      try {
-        await updateFinalizeCommand({
-          json: Boolean(opts.json) || inheritedUpdateJson(command),
-          channel: opts.channel as string | undefined,
-          timeout: inheritedUpdateTimeout(opts, command),
-          yes: Boolean(opts.yes),
-          restart: false,
-        });
-      } catch (err) {
-        defaultRuntime.error(String(err));
-        defaultRuntime.exit(1);
-      }
-    });
+  registerUpdateRepairCommand(update, "repair");
+  registerUpdateRepairCommand(update, "finalize", { hidden: true });
 
   update
     .command("wizard")

--- a/src/cli/update-cli.ts
+++ b/src/cli/update-cli.ts
@@ -38,8 +38,8 @@ function inheritedUpdateTimeout(
   return inheritOptionFromParent<string>(command, "timeout");
 }
 
-function registerUpdateRepairCommand(update: Command, name: string, params?: { hidden?: boolean }) {
-  const command = params?.hidden ? update.command(name, { hidden: true }) : update.command(name);
+function registerUpdateFinalizationCommand(update: Command, name: string, hidden: boolean) {
+  const command = update.command(name, { hidden });
   command
     .description("Repair post-update doctor and plugin convergence")
     .option("--json", "Output result as JSON", false)
@@ -154,8 +154,8 @@ ${theme.muted("Docs:")} ${formatDocsLink("/cli/update", "docs.openclaw.ai/cli/up
       }
     });
 
-  registerUpdateRepairCommand(update, "repair");
-  registerUpdateRepairCommand(update, "finalize", { hidden: true });
+  registerUpdateFinalizationCommand(update, "repair", false);
+  registerUpdateFinalizationCommand(update, "finalize", true);
 
   update
     .command("wizard")

--- a/src/cli/update-cli.ts
+++ b/src/cli/update-cli.ts
@@ -60,12 +60,12 @@ function registerUpdateRepairCommand(update: Command, name: string, params?: { h
           "Docs:",
         )} ${formatDocsLink("/cli/update", "docs.openclaw.ai/cli/update")}`,
     )
-    .action(async (opts, command) => {
+    .action(async (opts, actionCommand) => {
       try {
         await updateFinalizeCommand({
-          json: Boolean(opts.json) || inheritedUpdateJson(command),
+          json: Boolean(opts.json) || inheritedUpdateJson(actionCommand),
           channel: opts.channel as string | undefined,
-          timeout: inheritedUpdateTimeout(opts, command),
+          timeout: inheritedUpdateTimeout(opts, actionCommand),
           yes: Boolean(opts.yes),
           restart: false,
         });

--- a/src/cli/update-cli/post-core-plugin-convergence.test.ts
+++ b/src/cli/update-cli/post-core-plugin-convergence.test.ts
@@ -297,7 +297,7 @@ describe("runPostCorePluginConvergence", () => {
           'Failed to install missing configured plugin "discord" from @openclaw/discord: ENETUNREACH.',
         message:
           'Failed to install missing configured plugin "discord" from @openclaw/discord: ENETUNREACH.',
-        guidance: ["Run `openclaw doctor --fix` to retry plugin repair."],
+        guidance: ["Run `openclaw update repair` to retry plugin repair."],
       },
     ]);
   });
@@ -324,7 +324,7 @@ describe("runPostCorePluginConvergence", () => {
           'Failed to install missing configured plugin "matrix" from clawhub:@openclaw/matrix@beta: ClawHub ClawPack download for @openclaw/matrix@2026.6.1-beta.1 body stalled after 30000ms.',
         message:
           'Failed to install missing configured plugin "matrix" from clawhub:@openclaw/matrix@beta: ClawHub ClawPack download for @openclaw/matrix@2026.6.1-beta.1 body stalled after 30000ms.',
-        guidance: ["Run `openclaw doctor --fix` to retry plugin repair."],
+        guidance: ["Run `openclaw update repair` to retry plugin repair."],
       },
     ]);
     expect(mocks.runPluginPayloadSmokeCheck).toHaveBeenCalledWith({
@@ -396,7 +396,7 @@ describe("runPostCorePluginConvergence", () => {
         message:
           'Plugin "brave" failed post-core payload smoke check (missing-main-entry): Plugin main entry "dist/index.js" not found at /p/brave/dist/index.js',
         guidance: [
-          "Run `openclaw doctor --fix` to retry plugin repair.",
+          "Run `openclaw update repair` to retry plugin repair.",
           "Run `openclaw plugins inspect brave --runtime --json` for details.",
         ],
       },
@@ -433,7 +433,7 @@ describe("runPostCorePluginConvergence", () => {
         message:
           'Plugin "brave" failed post-core payload smoke check (missing-install-path): Install path is missing from the plugin install record.',
         guidance: [
-          "Run `openclaw doctor --fix` to retry plugin repair.",
+          "Run `openclaw update repair` to retry plugin repair.",
           "Run `openclaw plugins inspect brave --runtime --json` for details.",
         ],
       },
@@ -473,12 +473,12 @@ describe("convergenceWarningsToOutcomes", () => {
           pluginId: "brave",
           reason: "missing-main-entry: …",
           message: 'Plugin "brave" failed payload smoke check.',
-          guidance: ["Run `openclaw doctor --fix`."],
+          guidance: ["Run `openclaw update repair`."],
         },
         {
           reason: "Failed install",
           message: "Failed install for some plugin.",
-          guidance: ["Run `openclaw doctor --fix`."],
+          guidance: ["Run `openclaw update repair`."],
         },
       ],
       errored: true,

--- a/src/cli/update-cli/post-core-plugin-convergence.ts
+++ b/src/cli/update-cli/post-core-plugin-convergence.ts
@@ -43,7 +43,7 @@ export type PostCoreConvergenceResult = {
   installRecords: Record<string, PluginInstallRecord>;
 };
 
-const REPAIR_GUIDANCE = "Run `openclaw doctor --fix` to retry plugin repair.";
+const REPAIR_GUIDANCE = "Run `openclaw update repair` to retry plugin repair.";
 const inspectGuidance = (pluginId: string) =>
   `Run \`openclaw plugins inspect ${pluginId} --runtime --json\` for details.`;
 

--- a/src/cli/update-cli/update-command.test.ts
+++ b/src/cli/update-cli/update-command.test.ts
@@ -675,7 +675,7 @@ describe("updatePluginsAfterCoreUpdate (invalid config end-to-end)", () => {
           "Plugin post-update convergence skipped because the config is invalid; refusing to restart the gateway with an unverified plugin set.",
         guidance: [
           "Run `openclaw doctor` to inspect the config validation errors.",
-          "Once the config parses, rerun `openclaw update`.",
+          "Once the config parses, rerun `openclaw update repair`.",
         ],
       },
     ]);
@@ -694,7 +694,7 @@ describe("buildInvalidConfigPostCoreUpdateResult", () => {
     const built = buildInvalidConfigPostCoreUpdateResult();
     expect(built.guidance).toStrictEqual([
       "Run `openclaw doctor` to inspect the config validation errors.",
-      "Once the config parses, rerun `openclaw update`.",
+      "Once the config parses, rerun `openclaw update repair`.",
     ]);
     expect(built.result.warnings).toStrictEqual([
       {

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -170,7 +170,8 @@ const POST_INSTALL_DOCTOR_SERVICE_ENV_KEYS = [
   ...SERVICE_REFRESH_PATH_ENV_KEYS,
   "OPENCLAW_PROFILE",
 ] as const;
-const POST_UPDATE_PLUGIN_REPAIR_GUIDANCE = "Run openclaw doctor --fix to attempt automatic repair.";
+const POST_UPDATE_PLUGIN_REPAIR_GUIDANCE =
+  "Run openclaw update repair to retry post-update plugin repair.";
 const JSON_MODE_SERVICE_STDOUT = new Writable({
   write(_chunk, _encoding, callback) {
     callback();
@@ -596,7 +597,7 @@ export function buildInvalidConfigPostCoreUpdateResult(): {
 } {
   const guidance = [
     "Run `openclaw doctor` to inspect the config validation errors.",
-    "Once the config parses, rerun `openclaw update`.",
+    "Once the config parses, rerun `openclaw update repair`.",
   ];
   const message =
     "Plugin post-update convergence skipped because the config is invalid; refusing to restart the gateway with an unverified plugin set.";


### PR DESCRIPTION
## Summary

- Add public `openclaw update repair` command that delegates to the existing update finalization path.
- Keep hidden `openclaw update finalize` as an internal alias while documenting repair as the supported operator recovery command.
- Point post-update plugin/convergence guidance at `openclaw update repair` so partial package updates have a direct rerun path for doctor repair, managed npm plugin convergence, install-record metadata, and registry refresh.

## Verification

- `pnpm docs:list`
- `pnpm format:fix docs/cli/update.md src/cli/update-cli.ts src/cli/update-cli.option-collisions.test.ts src/cli/update-cli/update-command.ts src/cli/update-cli/update-command.test.ts src/cli/update-cli/post-core-plugin-convergence.ts src/cli/update-cli/post-core-plugin-convergence.test.ts src/cli/update-cli.test.ts`
- `git diff --check`
- `node scripts/run-oxlint-shards.mjs --threads=8`
- `node scripts/run-vitest.mjs src/cli/update-cli.option-collisions.test.ts src/cli/update-cli/update-command.test.ts src/cli/update-cli/post-core-plugin-convergence.test.ts src/cli/update-cli.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local` (clean: no accepted/actionable findings)
- `OPENCLAW_HOME=$(mktemp -d /tmp/openclaw-update-repair-proof.XXXXXX) pnpm openclaw update repair --json --yes`

## Real behavior proof

Behavior addressed: After a core package update succeeds but post-core plugin convergence or managed npm plugin metadata is stranded, operators now have a documented `openclaw update repair` command instead of discovering the hidden `update finalize` path or rerunning unrelated repair commands.

Real environment tested: Disposable local OpenClaw home on macOS, using the real CLI entry point from this PR branch. The run used `OPENCLAW_HOME` pointed at a temporary directory so it did not read or mutate the operator's live OpenClaw state.

Exact steps or command run after this patch: `OPENCLAW_HOME=$(mktemp -d /tmp/openclaw-update-repair-proof.XXXXXX) pnpm openclaw update repair --json --yes`

Evidence after fix: The command built the stale local runtime, ran `openclaw update repair`, executed doctor repair and post-core plugin convergence, and exited 0. Redacted terminal output from the final JSON result:

```json
{
  "status": "ok",
  "mode": "finalize",
  "root": "<repo-worktree>",
  "channel": "stable",
  "restart": false,
  "postUpdate": {
    "doctor": {
      "status": "ok"
    },
    "plugins": {
      "status": "ok",
      "changed": false,
      "warnings": [],
      "sync": {
        "changed": false,
        "switchedToBundled": [],
        "switchedToNpm": [],
        "warnings": [],
        "errors": []
      },
      "npm": {
        "changed": false,
        "outcomes": []
      },
      "integrityDrifts": []
    }
  }
}
```

Observed result after fix: `openclaw update repair` completes successfully through the real CLI path, reports `mode: "finalize"`, keeps `restart: false`, and returns `postUpdate.doctor.status: "ok"` plus `postUpdate.plugins.status: "ok"`.

What was not tested: A live partial package update recovery against real managed plugin npm metadata was not run in this branch; the proof covers the public command invocation and successful post-update repair/finalization path in a disposable local setup.

