### PR TITLE
fix(acp): preserve structured error kinds

### DIFF
--- a/src/acp/translator.error-kind.test.ts
+++ b/src/acp/translator.error-kind.test.ts
@@ -1,5 +1,6 @@
 /** Tests Gateway errorKind to ACP stopReason mapping. */
 import { describe, expect, it } from "vitest";
+import { RequestError } from "@agentclientprotocol/sdk";
 import {
   createChatEvent,
   createPendingPromptHarness,
@@ -24,7 +25,24 @@ describe("acp translator errorKind mapping", () => {
     await expect(promptPromise).resolves.toEqual({ stopReason: "refusal" });
   });
 
-  it("maps errorKind: timeout to stopReason: end_turn", async () => {
+  it("maps errorKind: context_length to stopReason: max_tokens", async () => {
+    const { agent, promptPromise, runId } = await createPendingPromptHarness();
+
+    await agent.handleGatewayEvent(
+      createChatEvent({
+        runId,
+        sessionKey: DEFAULT_SESSION_KEY,
+        seq: 1,
+        state: "error",
+        errorKind: "context_length",
+        errorMessage: "Context length exceeded",
+      }),
+    );
+
+    await expect(promptPromise).resolves.toEqual({ stopReason: "max_tokens" });
+  });
+
+  it("maps errorKind: timeout to a RequestError", async () => {
     const { agent, promptPromise, runId } = await createPendingPromptHarness();
 
     await agent.handleGatewayEvent(
@@ -38,10 +56,41 @@ describe("acp translator errorKind mapping", () => {
       }),
     );
 
-    await expect(promptPromise).resolves.toEqual({ stopReason: "end_turn" });
+    await expect(promptPromise).rejects.toSatisfy((err: any) => {
+      return (
+        err instanceof RequestError &&
+        err.code === -32001 &&
+        err.message === "gateway timeout" &&
+        (err.data as any)?.errorKind === "timeout"
+      );
+    });
   });
 
-  it("maps unknown errorKind to stopReason: end_turn", async () => {
+  it("maps errorKind: rate_limit to a RequestError", async () => {
+    const { agent, promptPromise, runId } = await createPendingPromptHarness();
+
+    await agent.handleGatewayEvent(
+      createChatEvent({
+        runId,
+        sessionKey: DEFAULT_SESSION_KEY,
+        seq: 1,
+        state: "error",
+        errorKind: "rate_limit",
+        errorMessage: "rate limit exceeded",
+      }),
+    );
+
+    await expect(promptPromise).rejects.toSatisfy((err: any) => {
+      return (
+        err instanceof RequestError &&
+        err.code === -32002 &&
+        err.message === "rate limit exceeded" &&
+        (err.data as any)?.errorKind === "rate_limit"
+      );
+    });
+  });
+
+  it("maps unknown errorKind to a RequestError", async () => {
     const { agent, promptPromise, runId } = await createPendingPromptHarness();
 
     await agent.handleGatewayEvent(
@@ -55,6 +104,13 @@ describe("acp translator errorKind mapping", () => {
       }),
     );
 
-    await expect(promptPromise).resolves.toEqual({ stopReason: "end_turn" });
+    await expect(promptPromise).rejects.toSatisfy((err: any) => {
+      return (
+        err instanceof RequestError &&
+        err.code === -32603 &&
+        err.message === "something went wrong" &&
+        (err.data as any)?.errorKind === "unknown"
+      );
+    });
   });
 });

--- a/src/acp/translator.ts
+++ b/src/acp/translator.ts
@@ -29,6 +29,7 @@ import type {
   StopReason,
   ToolCallLocation,
   ToolKind,
+  RequestError,
 } from "@agentclientprotocol/sdk";
 import { readBool, readNonNegativeInteger, readString } from "@openclaw/acp-core/meta";
 import { defaultAcpSessionStore, type AcpSessionStore } from "@openclaw/acp-core/session";
@@ -1154,8 +1155,16 @@ export class AcpGatewayAgent implements Agent {
     }
     if (state === "error") {
       const errorKind = payload.errorKind as string | undefined;
-      const stopReason: StopReason = errorKind === "refusal" ? "refusal" : "end_turn";
-      void this.finishPrompt(pending.sessionId, pending, stopReason);
+      const errorMessage = (payload.errorMessage as string | undefined) || "Unknown error";
+      if (errorKind === "refusal") {
+        void this.finishPrompt(pending.sessionId, pending, "refusal");
+      } else if (errorKind === "context_length") {
+        void this.finishPrompt(pending.sessionId, pending, "max_tokens");
+      } else {
+        const code = errorKind === "timeout" ? -32001 : errorKind === "rate_limit" ? -32002 : -32603;
+        const error = new RequestError(code, errorMessage, { errorKind });
+        this.rejectPendingPrompt(pending, error);
+      }
     }
   }
 
@@ -1437,7 +1446,9 @@ export class AcpGatewayAgent implements Agent {
       return false;
     }
     if (result?.status === "error") {
-      void this.finishPrompt(sessionId, currentPending, "end_turn");
+      const errorMessage = result.error || "Unknown error";
+      const error = new RequestError(-32603, errorMessage);
+      this.rejectPendingPrompt(currentPending, error);
       return false;
     }
     if (deadlineExpired) {

--- a/src/acp/translator.ts
+++ b/src/acp/translator.ts
@@ -29,8 +29,8 @@ import type {
   StopReason,
   ToolCallLocation,
   ToolKind,
-  RequestError,
 } from "@agentclientprotocol/sdk";
+import { RequestError } from "@agentclientprotocol/sdk";
 import { readBool, readNonNegativeInteger, readString } from "@openclaw/acp-core/meta";
 import { defaultAcpSessionStore, type AcpSessionStore } from "@openclaw/acp-core/session";
 import { toAcpSessionLineageMeta } from "@openclaw/acp-core/session-lineage-meta";


### PR DESCRIPTION
Closes #44294

### What Problem This Solves
The ACP translator maps most gateway error kinds (like `timeout`, `rate_limit`, `context_length`) into an `end_turn` stop reason, losing structured error information needed by ACP clients to correctly interpret the failure state of a prompt.

### Why This Change Was Made
By preserving the explicit error semantics from the gateway, downstream ACP clients can properly distinguish between a successful run that ended normally, one that was truncated due to token limits, and runs that outright failed due to timeout or rate limits.

- `context_length` errors now map to `max_tokens` stop reason
- `timeout` and `rate_limit` errors now reject the pending prompt via `RequestError` with structured JSON-RPC error codes (-32001, -32002)
- Unknown errors use `-32603` (internal error)

Also fixed: `RequestError` was previously inside an `import type` block but used as a runtime constructor, causing CI TS1361 failures. Moved to a separate runtime import.

### User Impact
ACP clients receive `max_tokens` as a stop reason for context length errors, and rejected prompts with structured error codes for timeout/rate-limit failures, instead of silently treating them as successful `end_turn` outcomes.

### Evidence
- Tests in `src/acp/translator.error-kind.test.ts` assert `RequestError` is thrown for timeouts and unknown errors
- Tests validate `context_length` maps to `max_tokens` stop reason
- Fixed `import type` → runtime import for `RequestError` to resolve CI TS1361 failures

[AI-assisted]