### PR TITLE
fix(slack): surface external arg-menu fallback as visible health signal

### DIFF
--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -7,6 +7,7 @@ import { adaptScopedAccountAccessor } from "openclaw/plugin-sdk/channel-config-h
 import {
   buildThreadAwareOutboundSessionRoute,
   createChatChannelPlugin,
+  type ChannelStatusIssue,
 } from "openclaw/plugin-sdk/channel-core";
 import { createChannelMessageAdapterFromOutbound } from "openclaw/plugin-sdk/channel-message";
 import { createPairingPrefixStripper } from "openclaw/plugin-sdk/channel-pairing";
@@ -747,6 +748,34 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount, SlackProbe> = crea
             ...projectCredentialSnapshotFields(account),
           },
         };
+      },
+      collectStatusIssues: (accounts): ChannelStatusIssue[] => {
+        const issues: ChannelStatusIssue[] = [];
+        for (const account of accounts) {
+          const enabled = account.enabled !== false;
+          const configured = account.configured === true;
+          if (!enabled || !configured) {
+            continue;
+          }
+          if (account.externalArgMenuError) {
+            issues.push({
+              channel: "slack",
+              accountId: account.accountId,
+              kind: "runtime",
+              message: `Slack external arg-menu registration failed, falling back to static menus: ${account.externalArgMenuError}`,
+            });
+          }
+          const lastError = typeof account.lastError === "string" ? account.lastError.trim() : "";
+          if (lastError) {
+            issues.push({
+              channel: "slack",
+              accountId: account.accountId,
+              kind: "runtime",
+              message: `Channel error: ${lastError}`,
+            });
+          }
+        }
+        return issues;
       },
     }),
     gateway: {

--- a/extensions/slack/src/monitor/context.ts
+++ b/extensions/slack/src/monitor/context.ts
@@ -172,6 +172,7 @@ export type SlackMonitorContext = {
     title?: string;
     prompts: SlackAssistantSuggestedPrompt[];
   }) => Promise<boolean>;
+  setStatus?: (next: Record<string, unknown>) => void;
 };
 
 const SLACK_ASSISTANT_CONTEXT_TTL_MS = 24 * 60 * 60 * 1000;
@@ -216,6 +217,7 @@ export function createSlackMonitorContext(params: {
   typingReaction: string;
   mediaMaxBytes: number;
   removeAckAfterReply: boolean;
+  setStatus?: (next: Record<string, unknown>) => void;
 }): SlackMonitorContext {
   const channelHistories = new Map<string, HistoryEntry[]>();
   const logger = getChildLogger({ module: "slack-auto-reply" });
@@ -645,5 +647,6 @@ export function createSlackMonitorContext(params: {
     getSlackAssistantThreadContext,
     saveSlackAssistantThreadContext,
     setSlackAssistantSuggestedPrompts,
+    setStatus: params.setStatus,
   };
 }

--- a/extensions/slack/src/monitor/provider.ts
+++ b/extensions/slack/src/monitor/provider.ts
@@ -348,6 +348,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
     typingReaction,
     mediaMaxBytes,
     removeAckAfterReply,
+    setStatus: opts.setStatus,
   });
 
   // Slack's socket-mode client keeps ping/pong health private and closes on

--- a/extensions/slack/src/monitor/slash.test.ts
+++ b/extensions/slack/src/monitor/slash.test.ts
@@ -588,6 +588,7 @@ describe("Slack native command argument menus", () => {
     const commands = new Map<string, (args: unknown) => Promise<void>>();
     const actions = new Map<string | RegExp, (args: unknown) => Promise<void>>();
     const postEphemeral = vi.fn().mockResolvedValue({ ok: true });
+    const setStatus = vi.fn();
     const app = {
       client: { chat: { postEphemeral } },
       command: (name: string, handler: (args: unknown) => Promise<void>) => {
@@ -624,6 +625,7 @@ describe("Slack native command argument menus", () => {
       },
       textLimit: 4000,
       app,
+      setStatus,
       isChannelAllowed: () => true,
       resolveChannelName: async () => ({ name: "dm", type: "im" }),
       resolveUserName: async () => ({ name: "Ada" }),
@@ -635,6 +637,10 @@ describe("Slack native command argument menus", () => {
 
     // Registration should not throw despite app.options() throwing
     await registerCommands(ctx, account);
+    expect(setStatus).toHaveBeenCalledTimes(1);
+    expect(setStatus).toHaveBeenCalledWith({
+      externalArgMenuError: "Cannot read properties of undefined (reading 'listeners')",
+    });
     expect(commands.size).toBeGreaterThan(0);
     expect(
       Array.from(actions.keys()).some(

--- a/extensions/slack/src/monitor/slash.ts
+++ b/extensions/slack/src/monitor/slash.ts
@@ -925,6 +925,7 @@ export async function registerSlackMonitorSlashCommands(params: {
     registerArgOptions();
   } catch (err) {
     supportsExternalArgMenus = false;
+    ctx.setStatus?.({ externalArgMenuError: formatErrorMessage(err) });
     logVerbose(
       `slack: external arg-menu registration failed, falling back to static menus: ${formatErrorMessage(err)}`,
     );

--- a/src/channels/plugins/types.core.ts
+++ b/src/channels/plugins/types.core.ts
@@ -209,6 +209,7 @@ export type ChannelAccountSnapshot = {
   lastEventAt?: number | null;
   lastTransportActivityAt?: number | null;
   lastError?: string | null;
+  externalArgMenuError?: string;
   healthState?: string;
   lastStartAt?: number | null;
   lastStopAt?: number | null;


### PR DESCRIPTION
This PR surfaces the Slack external arg-menu registration fallback error as a visible health signal/warning.

Details:
- Add \externalArgMenuError\ to \ChannelAccountSnapshot\.
- Introduce \setStatus\ callback in \SlackMonitorContext\.
- Propagate Bolt registration failure error details using \setStatus\ warning in Slack slash command setup.
- Surface this issue in status issue collector as a runtime warning.

Closes #44297