### PR TITLE
fix(ui): prevent false busy state in Control UI webchat

### DIFF
--- a/ui/src/ui/e2e/chat-flow.e2e.test.ts
+++ b/ui/src/ui/e2e/chat-flow.e2e.test.ts
@@ -32,6 +32,17 @@ function requireString(value: unknown, label: string): string {
   return value;
 }
 
+async function waitForUiFrame(page: Page): Promise<void> {
+  await page.evaluate(
+    () =>
+      new Promise<void>((resolve) => {
+        requestAnimationFrame(() => {
+          requestAnimationFrame(() => resolve());
+        });
+      }),
+  );
+}
+
 async function waitForRequests(
   gateway: Awaited<ReturnType<typeof installMockGateway>>,
   method: string,
@@ -876,6 +887,67 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
 
       await page.getByText("Recovered from refreshed history.").waitFor({ timeout: 15_000 });
       expect(await page.locator(".chat-queue").count()).toBe(0);
+    } finally {
+      await context.close();
+    }
+  });
+
+  it("returns to idle when stale active session state arrives after completion", async () => {
+    const context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      historyMessages: [
+        {
+          content: [{ text: "Ready for stale-state proof.", type: "text" }],
+          role: "assistant",
+          timestamp: Date.now(),
+        },
+      ],
+    });
+
+    try {
+      await page.goto(`${server.baseUrl}chat`);
+      await page.getByText("Ready for stale-state proof.").waitFor({ timeout: 10_000 });
+      await page.getByRole("button", { name: "Send message" }).waitFor({ timeout: 10_000 });
+
+      const prompt = "complete and stay idle";
+      await page.locator(".agent-chat__composer-combobox textarea").fill(prompt);
+      await page.getByRole("button", { name: "Send message" }).click();
+
+      const sendRequest = await gateway.waitForRequest("chat.send");
+      const params = requireRecord(sendRequest.params);
+      const runId = requireString(params.idempotencyKey, "chat send idempotency key");
+      await gateway.emitChatFinal({ runId, text: "Completed without a stuck composer." });
+
+      await page.getByText("Completed without a stuck composer.").waitFor({ timeout: 10_000 });
+      await page.locator(".agent-chat__run-status--done").waitFor({ timeout: 10_000 });
+      await page
+        .locator(".agent-chat__run-status--done")
+        .waitFor({ state: "hidden", timeout: 7_000 });
+
+      await gateway.emitGatewayEvent("sessions.changed", {
+        hasActiveRun: true,
+        key: "main",
+        kind: "direct",
+        sessionKey: "main",
+        status: "running",
+        updatedAt: Date.now(),
+      });
+      await waitForUiFrame(page);
+
+      await page
+        .locator(".agent-chat__run-status--in-progress")
+        .waitFor({ state: "hidden", timeout: 2_000 });
+      await page.getByRole("button", { name: "Stop generating" }).waitFor({
+        state: "hidden",
+        timeout: 2_000,
+      });
+      await page.getByRole("button", { name: "Send message" }).waitFor({ timeout: 2_000 });
+      expect(await page.getByRole("button", { name: "Queue message" }).count()).toBe(0);
     } finally {
       await context.close();
     }

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -1228,6 +1228,62 @@ describe("chat loading skeleton", () => {
       nowSpy.mockRestore();
     }
   });
+
+  it("keeps stale abortable session rows from forcing idle composer busy UI", () => {
+    const container = renderChatView({
+      canAbort: true,
+      messages: [
+        {
+          role: "assistant",
+          content: "Finished answer",
+          timestamp: 1,
+        },
+      ],
+      queue: [{ id: "queued-1", text: "follow up", createdAt: 2 }],
+      sessions: {
+        ts: 0,
+        path: "",
+        count: 1,
+        defaults: { modelProvider: null, model: null, contextTokens: 200_000 },
+        sessions: [
+          {
+            key: "main",
+            kind: "direct",
+            updatedAt: null,
+            hasActiveRun: true,
+            status: "running",
+            totalTokens: 190_000,
+            contextTokens: 200_000,
+          },
+        ],
+      },
+      onCompact: () => undefined,
+      onQueueSteer: () => undefined,
+    });
+
+    expect(container.querySelector(".agent-chat__run-status--in-progress")).toBeNull();
+    expect(container.querySelector(".chat-reading-indicator")).toBeNull();
+    expect(container.querySelector(".chat-send-btn--stop")).toBeNull();
+    expect(container.querySelector(".chat-queue__steer")).toBeNull();
+    const sendButton = container.querySelector<HTMLButtonElement>(".chat-send-btn");
+    expect(sendButton?.getAttribute("aria-label")).toBe("Send message");
+    expect(sendButton?.textContent?.trim()).toBe("Send");
+  });
+
+  it("keeps abort controls visible while a local stream is active", () => {
+    const container = renderChatView({
+      canAbort: true,
+      stream: "",
+      queue: [{ id: "queued-1", text: "follow up", createdAt: 2 }],
+      onQueueSteer: () => undefined,
+    });
+
+    expect(container.querySelector(".agent-chat__run-status--in-progress")?.textContent).toContain(
+      "In progress",
+    );
+    expect(container.querySelector(".chat-send-btn--stop")?.textContent?.trim()).toBe("Stop");
+    expect(container.querySelector(".chat-queue__steer")?.textContent?.trim()).toBe("Steer");
+  });
 });
 
 describe("chat voice controls", () => {

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -1570,7 +1570,10 @@ export function renderChat(props: ChatProps) {
   const isBusy = props.sending || props.stream !== null;
   const canAbort = Boolean(props.canAbort && props.onAbort);
   const showAbortableUi = canAbort && !hasTerminalRunStatus(props.runStatus);
-  const composerRunStatus = showAbortableUi ? { phase: "in-progress" as const } : props.runStatus;
+  const showLocalAbortableUi = showAbortableUi && isBusy;
+  const composerRunStatus = showLocalAbortableUi
+    ? { phase: "in-progress" as const }
+    : props.runStatus;
   const compactBusy =
     props.compactionStatus?.phase === "active" || props.compactionStatus?.phase === "retrying";
   const activeSession = props.sessions?.sessions?.find((row) => row.key === props.sessionKey);
@@ -2081,7 +2084,7 @@ export function renderChat(props: ChatProps) {
 
       ${renderChatQueue({
         queue: props.queue,
-        canAbort: showAbortableUi,
+        canAbort: showLocalAbortableUi,
         onQueueRetry: props.onQueueRetry,
         onQueueSteer: props.onQueueSteer,
         onQueueRemove: props.onQueueRemove,
@@ -2232,7 +2235,7 @@ export function renderChat(props: ChatProps) {
             ? html`<div class="agent-chat__composer-controls">${composerControls}</div>`
             : nothing}
           ${renderChatRunControls({
-            canAbort: showAbortableUi,
+            canAbort: showLocalAbortableUi,
             connected: props.connected,
             draft: visibleDraft,
             hasMessages: props.messages.length > 0,


### PR DESCRIPTION
## Summary

Fixes #87387: Control UI webchat could keep showing a false "In progress" status and "Stop" button after the assistant response completed because the main composer consumed session-list abortability even when local send/stream state was idle.

## Changes

- Split session-scoped abortability from main composer busy UI in `ui/src/ui/views/chat.ts`.
- Keep the main badge, queue steer affordance, and Stop button tied to local active evidence (`sending || stream !== null`).
- Add unit regression coverage for stale active session rows after completion, while preserving Stop/Steer during an active local stream.
- Add mocked Chromium Control UI proof for send -> final stream -> stale active session row -> idle composer.

## Real behavior proof

Behavior addressed: Control UI webchat no longer shows a false `In progress` badge, `Stop` button, or queue steer affordance after response completion when only stale session-list active-run state remains.

Real environment tested: Local OpenClaw checkout on rebased PR head `f3d079672376a36eee90452d2a6f7d947d87234c`, mocked Control UI Gateway E2E in Chromium, Node/Vitest through `scripts/run-vitest.mjs`.

Exact steps or command run after this patch:

```text
node scripts/run-vitest.mjs ui/src/ui/views/chat.test.ts ui/src/ui/app-chat.test.ts ui/src/ui/app-gateway.sessions.node.test.ts ui/src/ui/chat/run-controls.test.ts
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/ui/e2e/chat-flow.e2e.test.ts
git diff --check
```

Evidence after fix:

```text
Test Files  4 passed (4)
Tests       137 passed (137)

Test Files  1 passed (1)
Tests       2 passed (2)

git diff --check: clean
```

Observed result after fix: Unit regression fails on the old behavior, then passes with the split. The mocked browser flow sends a WebChat message, receives the final assistant event, waits for the done status to clear, injects stale `sessions.changed` active-run state, and confirms no `In progress`, no `Stop generating`, no `Queue message`, with the composer back on `Send message`.

What was not tested: Broad remote `pnpm check:changed` did not run locally. The delegated Testbox path failed before execution because `.github/workflows/crabbox-hydrate.yml` does not contain a Testbox step, and direct AWS Crabbox is not configured in this environment (`crabbox login --url https://crabbox.openclaw.ai --provider aws` required). Fresh PR CI was triggered by the push to `f3d079672376a36eee90452d2a6f7d947d87234c`.

## AI Assistance

This PR was originally created with AI assistance (iCodemate). Maintainer follow-up added regression and mocked browser proof.
