### PR TITLE
fix(acp): tolerate unsupported effort config for models like Haiku

### DIFF
--- a/src/acp/control-plane/manager.runtime-config.test.ts
+++ b/src/acp/control-plane/manager.runtime-config.test.ts
@@ -563,6 +563,51 @@ describe("AcpSessionManager runtime config", () => {
     expect(runtimeState.runTurn).not.toHaveBeenCalled();
   });
 
+  it("continues turns when adapters reject effort config", async () => {
+    const runtimeState = createRuntime();
+    runtimeState.getCapabilities.mockResolvedValue({
+      controls: ["session/set_mode", "session/set_config_option", "session/status"],
+      configOptionKeys: ["mode", "model", "effort"],
+    });
+    runtimeState.setConfigOption.mockImplementation(async (input: { key: string }) => {
+      if (input.key === "effort") {
+        throw new AcpRuntimeError(
+          "ACP_TURN_FAILED",
+          'Agent rejected session/set_config_option for "effort": ACP -32602 Invalid params',
+        );
+      }
+    });
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    hoisted.readAcpSessionEntryMock.mockReturnValue({
+      sessionKey: "agent:claude:acp:session-1",
+      storeSessionKey: "agent:claude:acp:session-1",
+      acp: {
+        ...readySessionMeta({ agent: "claude" }),
+        runtimeOptions: {
+          thinking: "high",
+        },
+      },
+    });
+
+    const manager = new AcpSessionManager();
+    await manager.runTurn({
+      cfg: baseCfg,
+      sessionKey: "agent:claude:acp:session-1",
+      text: "do work",
+      mode: "prompt",
+      requestId: "run-effort",
+    });
+
+    expectMockCallFields(runtimeState.setConfigOption, {
+      key: "effort",
+      value: "high",
+    });
+    expect(runtimeState.runTurn).toHaveBeenCalledTimes(1);
+  });
+
   it("maps persisted thinking runtime options to advertised effort config keys before running turns", async () => {
     const runtimeState = createRuntime();
     runtimeState.getCapabilities.mockResolvedValue({

--- a/src/acp/control-plane/manager.runtime-controls.ts
+++ b/src/acp/control-plane/manager.runtime-controls.ts
@@ -18,7 +18,14 @@ import {
   resolveRuntimeOptionsFromMeta,
 } from "./runtime-options.js";
 
-const OPTIONAL_TIMEOUT_CONFIG_KEYS = new Set(["timeout", "timeout_seconds"]);
+const OPTIONAL_CONFIG_KEYS = new Set([
+  "timeout",
+  "timeout_seconds",
+  "effort",
+  "thinking",
+  "reasoning_effort",
+  "thought_level",
+]);
 
 function extractConfigOptionKeys(value: unknown): string[] {
   if (!Array.isArray(value)) {
@@ -43,12 +50,12 @@ function extractRuntimeStatusConfigOptionKeys(status: AcpRuntimeStatus | undefin
   ];
 }
 
-function isOptionalTimeoutConfigKey(key: string): boolean {
-  return OPTIONAL_TIMEOUT_CONFIG_KEYS.has(normalizeLowercaseStringOrEmpty(key));
+function isOptionalConfigKey(key: string): boolean {
+  return OPTIONAL_CONFIG_KEYS.has(normalizeLowercaseStringOrEmpty(key));
 }
 
-function isUnsupportedOptionalTimeoutConfigRejection(key: string, error: unknown): boolean {
-  if (!isOptionalTimeoutConfigKey(key)) {
+function isUnsupportedOptionalConfigRejection(key: string, error: unknown): boolean {
+  if (!isOptionalConfigKey(key)) {
     return false;
   }
   const errorCode = error && typeof error === "object" ? (error as { code?: unknown }).code : null;
@@ -191,7 +198,7 @@ export async function applyManagerRuntimeControls(params: {
               value,
             });
           } catch (error) {
-            if (isUnsupportedOptionalTimeoutConfigRejection(key, error)) {
+            if (isUnsupportedOptionalConfigRejection(key, error)) {
               continue;
             }
             throw error;


### PR DESCRIPTION
## Summary

- Extend the optional config key tolerance pattern from #81603 to cover effort/thinking config options.
- Models like Claude Haiku do not support the `effort` config key via `session/set_config_option`, causing ACP turns to fail with `Unknown config option: effort` even when `thinkingDefault` is set.
- Now `effort`, `thinking`, `reasoning_effort`, and `thought_level` are treated as optional config keys alongside `timeout`/`timeout_seconds`. When an ACP backend rejects these keys, the turn continues instead of failing.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #91514
- Extends pattern from #81603 (timeout config tolerance)

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: ACP turns that send `effort` config to adapters that reject it (e.g., Claude Haiku) now continue instead of throwing `AcpRuntimeError`. The `isUnsupportedOptionalConfigRejection` function was renamed and expanded to cover all thinking/effort aliases.
- Real environment tested: OpenClaw source checkout on PR head `83dafab6`, Node.js v24.16.0, Linux WSL2.
- Exact steps or command run after this patch:
  - `node scripts/run-vitest.mjs src/acp/control-plane/manager.runtime-config.test.ts` → 20/20 passed
  - `node scripts/run-vitest.mjs src/acp/control-plane/manager.test.ts` → 29/29 passed
- Evidence after fix:

```
$ node scripts/run-vitest.mjs src/acp/control-plane/manager.runtime-config.test.ts
 RUN  v4.1.7 /root/.openclaw/workspace/openclaw-repo
 ✓ unit-fast src/acp/control-plane/manager.runtime-config.test.ts (20 tests) 40ms
 Test Files  1 passed (1)
      Tests  20 passed (20)
   Start at  04:19:54
   Duration  8.50s (transform 8.34s, setup 0ms, import 7.41s, tests 40ms, environment 0ms)
[test] passed 1 Vitest shard in 27.68s

$ node scripts/run-vitest.mjs src/acp/control-plane/manager.test.ts
 RUN  v4.1.7 /root/.openclaw/workspace/openclaw-repo
 ✓ unit-fast-fake-timers src/acp/control-plane/manager.test.ts (29 tests) 93ms
 Test Files  1 passed (1)
      Tests  29 passed (29)
   Start at  04:20:26
   Duration  14.93s (transform 9.08s, setup 0ms, import 13.64s, tests 93ms, environment 0ms)
[test] passed 1 Vitest shard in 33.94s
```

- Observed result after fix: Both test suites pass including the new test "continues turns when adapters reject effort config". The existing timeout tolerance tests continue to pass, confirming no regression. The new test verifies that when `setConfigOption` throws `ACP_TURN_FAILED` for `effort` key, the turn still proceeds and `runTurn` is called.
- What was not tested: Live ACP session with actual Claude Haiku adapter (requires real API credentials). The fix is verified through mock-based unit tests that replicate the exact error pattern from #91514.

## Root Cause

In `manager.runtime-controls.ts`, the `isUnsupportedOptionalTimeoutConfigRejection()` function only recognized `timeout` and `timeout_seconds` as optional config keys. When Haiku rejects the `effort` key (mapped from `thinking` runtime option), the error propagated and aborted the turn.

## Fix

Renamed `OPTIONAL_TIMEOUT_CONFIG_KEYS` → `OPTIONAL_CONFIG_KEYS` and added all thinking/effort aliases: `effort`, `thinking`, `reasoning_effort`, `thought_level`. The existing error detection and `continue` logic in `applyManagerRuntimeControls` now covers these keys automatically.