### PR TITLE
ci(windows): add native PowerShell smoke coverage for contributor commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1988,6 +1988,12 @@ jobs:
               ;;
           esac
 
+      - name: Native PowerShell smoke checks
+        shell: pwsh
+        run: |
+          pnpm check:docs
+          pnpm build:strict-smoke
+
   macos-node:
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1991,8 +1991,7 @@ jobs:
       - name: Native PowerShell smoke checks
         shell: pwsh
         run: |
-          pnpm check:docs
-          pnpm build:strict-smoke
+          pnpm check:docs && pnpm build:strict-smoke
 
   macos-node:
     permissions:

--- a/scripts/format-docs.mjs
+++ b/scripts/format-docs.mjs
@@ -12,7 +12,7 @@ import { buildCmdExeCommandLine, resolveWindowsCmdExePath } from "./windows-cmd-
 const ROOT = path.resolve(import.meta.dirname, "..");
 const CHECK = process.argv.includes("--check");
 const DOCS_FORMAT_MAX_BUFFER_BYTES = 1024 * 1024 * 16;
-export const DOCS_FORMAT_MAX_COMMAND_LINE_BYTES = 24 * 1024;
+export const DOCS_FORMAT_MAX_COMMAND_LINE_BYTES = os.platform() === "win32" ? 7000 : 24 * 1024;
 const FAILURE_OUTPUT_TAIL_BYTES = 16 * 1024;
 
 function outputText(value) {


### PR DESCRIPTION
Closes #40922

### What Problem This Solves
The Windows CI lane currently lacks a native PowerShell smoke check for `pnpm check:docs` and `pnpm build:strict-smoke`. This leaves a gap where issues specific to the Windows command line limit or PowerShell semantics might slip into main undetected. For example, `scripts/format-docs.mjs` was failing on Windows because the command line length exceeded the 8191-character limit.

### Why This Change Was Made
By running these smoke checks natively in PowerShell on the Windows runner, we can catch Windows-specific failures before they land in main. We also chain them with `&&` to ensure that failure in one command immediately halts the step, avoiding false positives.

### User Impact
Improves CI coverage and catches Windows-specific command line failures early.

### Evidence
- Adjusted `DOCS_FORMAT_MAX_COMMAND_LINE_BYTES` in `scripts/format-docs.mjs` to 7000 for win32 to respect the Windows cmd.exe 8191-character limit, fixing the "The command line is too long" error.
- Ran `node --import tsx scripts/format-docs.mjs` locally on Windows and verified it succeeds:
```console
$ node --import tsx scripts/format-docs.mjs
Docs formatting clean (669 files).
```
- Chained the smoke checks in `.github/workflows/ci.yml` using `&&`.
