### PR TITLE
fix(agents): reconcile stale restart-aborted subagent runs instead of resurrecting them (fixes #90766)

### DIFF
--- a/src/agents/subagent-registry-helpers.ts
+++ b/src/agents/subagent-registry-helpers.ts
@@ -190,9 +190,11 @@ export function resolveSubagentRunOrphanReason(params: {
     }
     if (
       params.includeStaleUnended === true &&
-      sessionEntry.abortedLastRun !== true &&
       isStaleUnendedSubagentRun(params.entry, params.now)
     ) {
+      // Stale-unended pruning also covers restart-aborted runs: the shared liveness window
+      // keeps fresh restart recovery (recent aborts are not yet stale) while a long-downtime
+      // aborted run is reconciled instead of auto-resurrected after the gateway comes back (#90766).
       return "stale-unended-run";
     }
     return null;

--- a/src/agents/subagent-registry.persistence.test.ts
+++ b/src/agents/subagent-registry.persistence.test.ts
@@ -724,22 +724,11 @@ describe("subagent registry persistence", () => {
     expect(listSubagentRunsForRequester("agent:main:main")).toHaveLength(0);
   });
 
-  it("keeps stale unended restored runs with abortedLastRun for restart recovery", async () => {
-    vi.mocked(callGateway).mockImplementationOnce(async (request) => {
-      expectFields(request, {
-        method: "agent.wait",
-      });
-      expectFields((request as { params?: unknown }).params, {
-        runId: "run-stale-aborted-restore",
-      });
-      return {
-        status: "pending",
-      };
-    });
+  it("reconciles stale unended restored runs even when restart-aborted (#90766)", async () => {
     const now = Date.now();
     const runId = "run-stale-aborted-restore";
     const childSessionKey = "agent:main:subagent:stale-aborted-restore";
-    await writePersistedRegistry(
+    const registryPath = await writePersistedRegistry(
       {
         version: 2,
         runs: {
@@ -748,7 +737,7 @@ describe("subagent registry persistence", () => {
             childSessionKey,
             requesterSessionKey: "agent:main:main",
             requesterDisplayKey: "main",
-            task: "stale restart-recoverable work",
+            task: "stale restart-aborted work",
             cleanup: "keep",
             createdAt: now - 3 * 60 * 60 * 1_000,
             startedAt: now - 3 * 60 * 60 * 1_000,
@@ -760,6 +749,59 @@ describe("subagent registry persistence", () => {
     await writeChildSessionEntry({
       sessionKey: childSessionKey,
       sessionId: "sess-stale-aborted-restore",
+      updatedAt: now,
+      abortedLastRun: true,
+    });
+
+    restartRegistry();
+    await waitForRegistryWork(async () => {
+      const after = JSON.parse(await fs.readFile(registryPath, "utf8")) as {
+        runs?: Record<string, unknown>;
+      };
+      return after.runs?.[runId] === undefined;
+    });
+
+    // Long-downtime aborted run is reconciled, not auto-resumed.
+    expect(callGateway).not.toHaveBeenCalled();
+    expect(listSubagentRunsForRequester("agent:main:main")).toHaveLength(0);
+  });
+
+  it("recovers fresh restart-aborted runs that are not yet stale (#90766)", async () => {
+    vi.mocked(callGateway).mockImplementationOnce(async (request) => {
+      expectFields(request, {
+        method: "agent.wait",
+      });
+      expectFields((request as { params?: unknown }).params, {
+        runId: "run-fresh-aborted-restore",
+      });
+      return {
+        status: "pending",
+      };
+    });
+    const now = Date.now();
+    const runId = "run-fresh-aborted-restore";
+    const childSessionKey = "agent:main:subagent:fresh-aborted-restore";
+    await writePersistedRegistry(
+      {
+        version: 2,
+        runs: {
+          [runId]: {
+            runId,
+            childSessionKey,
+            requesterSessionKey: "agent:main:main",
+            requesterDisplayKey: "main",
+            task: "fresh restart-recoverable work",
+            cleanup: "keep",
+            createdAt: now - 60_000,
+            startedAt: now - 60_000,
+          },
+        },
+      },
+      { seedChildSessions: false },
+    );
+    await writeChildSessionEntry({
+      sessionKey: childSessionKey,
+      sessionId: "sess-fresh-aborted-restore",
       updatedAt: now,
       abortedLastRun: true,
     });


### PR DESCRIPTION
## Summary

- **Problem:** After the gateway is down for a long time, restart/orphan recovery **resurrects** subagent runs that were aborted hours ago — replaying `agent.wait` on a run that is no longer relevant.
- **Root cause:** The restore reconciliation in `resolveSubagentRunOrphanReason` (`subagent-registry-helpers.ts`) only classifies a run as `stale-unended-run` when `abortedLastRun !== true`. So restart-aborted runs were **exempted** from the shared stale-liveness policy and preserved indefinitely, then auto-recovered no matter how old.
- **What changed:** Remove that one-line exemption so the existing `isStaleUnendedSubagentRun` policy (`STALE_UNENDED_SUBAGENT_RUN_MS = 2h`, or the run's timeout + grace) applies to aborted runs too. A long-downtime aborted run is now reconciled (pruned) instead of resurrected.
- **What did NOT change (scope boundary):** **Fresh** restart recovery is preserved — a recently-aborted run is not yet stale, so it is still kept and recovered. The rapid re-wedge tombstone gate (`evaluateSubagentRecoveryGate`, 2-minute window) and non-aborted stale pruning are untouched. No new config or stale window — it reuses the existing liveness policy.

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway / orchestration (subagent recovery)

## Linked Issue

- Closes #90766

## User-visible / Behavior Changes

After long downtime, the gateway no longer auto-resumes subagent runs that were aborted more than the stale-liveness window ago; they are reconciled out of the registry. Fresh restart-aborted runs (within the window) still recover as before.

## Security Impact

- New permissions/capabilities? No · Secrets handling? No · Network calls? No · Tool exec surface? No · Data access scope? No

## Evidence

- [x] **Failing test before + passing after.** Updated `reconciles stale unended restored runs even when restart-aborted (#90766)` (3-hour aborted run → pruned, no `agent.wait`) fails with the exemption restored. New `recovers fresh restart-aborted runs that are not yet stale (#90766)` (1-minute aborted run → still recovered) stays green throughout, proving fresh restart recovery is preserved.
- Local run (Node 22): **92 tests pass** across `subagent-registry.persistence.test.ts`, `subagent-orphan-recovery.test.ts`, `subagent-registry-queries.test.ts` (+ co-located). oxlint + oxfmt clean.

## Human Verification

- Verified: a 3-hour aborted unended run is pruned and not resumed after `restartRegistry()`; a 1-minute aborted run is still kept and resumed via `agent.wait`; non-aborted stale pruning and the re-wedge gate are unchanged.
- Not verified: a live multi-hour gateway-downtime reproduction (verified at unit/source level, consistent with the issue's read-only repro).

## Compatibility / Migration

- Backward compatible? Yes — only stale (older than the liveness window) aborted runs change behavior; fresh recovery and all other paths are unchanged. · Config/env changes? No · Migration needed? No

## AI assistance

AI-assisted (Claude Code). Tested locally (92 tests + lint/format). Author understands the change. GitHub Codex review covers the AI-review pass.

## Real behavior proof

Behavior addressed: restart/orphan recovery no longer resurrects subagent runs aborted longer ago than the shared stale-liveness window; those are reconciled instead, while fresh restart-aborted runs still recover.
Real environment tested: Local unit + source verification on Node 22.22.1 (macOS). No live multi-hour gateway-downtime run.
Exact steps or command run after this patch: `node node_modules/vitest/vitest.mjs run src/agents/subagent-registry.persistence.test.ts src/agents/subagent-orphan-recovery.test.ts src/agents/subagent-registry-queries.test.ts` plus oxlint + oxfmt on the touched files.
Evidence after fix: 92 tests pass including the updated stale-aborted-pruning test and the new fresh-aborted-recovery test; re-adding the `abortedLastRun !== true` exemption turns the stale-aborted test red (it gets resurrected) while the fresh test stays green.
Observed result after fix: a 3-hour-old aborted run is pruned from the registry (`callGateway` not called); a 1-minute-old aborted run is recovered (`agent.wait`, kept in the registry).
What was not tested: a live gateway restart after multi-hour downtime against a real registry (verified at unit/source level only).

## Risks and Mitigations

- Risk: pruning an aborted run a user still wanted to resume after a long outage.
  - Mitigation: the window matches the existing stale-liveness policy already used for non-aborted runs (and honors a longer per-run timeout), so behavior is consistent across run types; recently-aborted runs remain recoverable.
