### PR TITLE
fix(gateway): surface headless LaunchAgent state

### DIFF
--- a/src/cli/daemon-cli/launchd-recovery.test.ts
+++ b/src/cli/daemon-cli/launchd-recovery.test.ts
@@ -5,6 +5,15 @@ const launchAgentPlistExists = vi.hoisted(() => vi.fn());
 const repairLaunchAgentBootstrap = vi.hoisted(() => vi.fn());
 
 vi.mock("../../daemon/launchd.js", () => ({
+  formatLaunchAgentGuiSessionError: (params: {
+    detail: string;
+    domain: string;
+    actionHint: string;
+  }) =>
+    [
+      `launchctl bootstrap failed: ${params.detail}`,
+      `LaunchAgent ${params.actionHint} requires a logged-in macOS GUI session for this user (${params.domain}).`,
+    ].join("\n"),
   launchAgentPlistExists: (env: Record<string, string | undefined>) => launchAgentPlistExists(env),
   repairLaunchAgentBootstrap: (args: { env?: Record<string, string | undefined> }) =>
     repairLaunchAgentBootstrap(args),
@@ -64,5 +73,20 @@ describe("recoverInstalledLaunchAgent", () => {
     });
 
     await expect(recoverInstalledLaunchAgent({ result: "started" })).resolves.toBeNull();
+  });
+
+  it("surfaces headless GUI bootstrap failures instead of falling back to unmanaged restart", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
+    launchAgentPlistExists.mockResolvedValue(true);
+    repairLaunchAgentBootstrap.mockResolvedValue({
+      ok: false,
+      status: "gui-session-unavailable",
+      detail: "Bootstrap failed: 125: Domain does not support specified action",
+      domain: "gui/501",
+    });
+
+    await expect(recoverInstalledLaunchAgent({ result: "restarted" })).rejects.toThrow(
+      "requires a logged-in macOS GUI session",
+    );
   });
 });

--- a/src/cli/daemon-cli/launchd-recovery.ts
+++ b/src/cli/daemon-cli/launchd-recovery.ts
@@ -1,5 +1,9 @@
 // macOS LaunchAgent recovery helper for daemon lifecycle commands.
-import { launchAgentPlistExists, repairLaunchAgentBootstrap } from "../../daemon/launchd.js";
+import {
+  formatLaunchAgentGuiSessionError,
+  launchAgentPlistExists,
+  repairLaunchAgentBootstrap,
+} from "../../daemon/launchd.js";
 
 const LAUNCH_AGENT_RECOVERY_MESSAGE =
   "Gateway LaunchAgent was installed but not loaded; re-bootstrapped launchd service.";
@@ -30,6 +34,17 @@ export async function recoverInstalledLaunchAgent(params: {
     status: "bootstrap-failed" as const,
   }));
   if (!repaired.ok) {
+    if (repaired.status === "gui-session-unavailable") {
+      const actionHint =
+        params.result === "started" ? "openclaw gateway start" : "openclaw gateway restart";
+      throw new Error(
+        formatLaunchAgentGuiSessionError({
+          detail: repaired.detail,
+          domain: repaired.domain,
+          actionHint,
+        }),
+      );
+    }
     return null;
   }
   return {

--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -574,6 +574,20 @@ describe("runDaemonRestart health checks", () => {
     expect(waitForGatewayHealthyRestart).toHaveBeenCalledTimes(1);
   });
 
+  it("does not fall back to unmanaged restart when launchd repair reports headless GUI bootstrap failure", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
+    recoverInstalledLaunchAgent.mockRejectedValue(
+      new Error("LaunchAgent openclaw gateway restart requires a logged-in macOS GUI session"),
+    );
+    findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([4200]);
+    mockUnmanagedRestart();
+
+    await expect(runDaemonRestart({ json: true })).rejects.toThrow("logged-in macOS GUI session");
+
+    expect(signalVerifiedGatewayPidSync).not.toHaveBeenCalled();
+    expect(waitForGatewayHealthyListener).not.toHaveBeenCalled();
+  });
+
   it("re-bootstraps an installed LaunchAgent on restart when no unmanaged listener exists", async () => {
     vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
     recoverInstalledLaunchAgent.mockResolvedValue({

--- a/src/cli/daemon-cli/shared.test.ts
+++ b/src/cli/daemon-cli/shared.test.ts
@@ -4,6 +4,7 @@ import { theme } from "../../../packages/terminal-core/src/theme.js";
 import {
   filterContainerGenericHints,
   parsePortFromArgs,
+  renderRuntimeHints,
   renderGatewayServiceStartHints,
   resolveDaemonContainerContext,
   resolveRuntimeStatusColor,
@@ -34,6 +35,15 @@ describe("parsePortFromArgs", () => {
 });
 
 describe("renderGatewayServiceStartHints", () => {
+  it("uses GUI session wording for installed LaunchAgents that cannot access gui/$UID", () => {
+    expect(
+      renderRuntimeHints(
+        { missingSupervision: true, missingGuiSession: true },
+        {} as NodeJS.ProcessEnv,
+      ).join("\n"),
+    ).toContain("logged-in macOS GUI session");
+  });
+
   it("resolves daemon container context from either env key", () => {
     expect(
       resolveDaemonContainerContext({

--- a/src/cli/daemon-cli/shared.ts
+++ b/src/cli/daemon-cli/shared.ts
@@ -157,7 +157,14 @@ export function normalizeListenerAddress(raw: string): string {
 
 /** Render platform-specific hints for missing/stopped Gateway runtimes. */
 export function renderRuntimeHints(
-  runtime: { missingUnit?: boolean; missingSupervision?: boolean; status?: string } | undefined,
+  runtime:
+    | {
+        missingUnit?: boolean;
+        missingSupervision?: boolean;
+        missingGuiSession?: boolean;
+        status?: string;
+      }
+    | undefined,
   env: NodeJS.ProcessEnv = process.env,
   logFile?: string | null,
 ): string[] {
@@ -168,6 +175,21 @@ export function renderRuntimeHints(
   const fileLog = logFile ?? null;
   if (runtime.missingUnit) {
     hints.push(`Service not installed. Run: ${formatCliCommand("openclaw gateway install", env)}`);
+    if (fileLog) {
+      hints.push(`File logs: ${fileLog}`);
+    }
+    return hints;
+  }
+  if (runtime.missingGuiSession) {
+    hints.push(
+      "LaunchAgent requires a logged-in macOS GUI session; SSH/headless/sudo shells cannot bootstrap gui/$UID.",
+    );
+    hints.push(
+      `Sign in to the macOS desktop as this user, then run: ${formatCliCommand("openclaw gateway restart", env)}`,
+    );
+    hints.push(
+      "For headless VM setups, enable auto-login for the target user or use a custom LaunchDaemon (not shipped).",
+    );
     if (fileLog) {
       hints.push(`File logs: ${fileLog}`);
     }

--- a/src/cli/daemon-cli/status.print.test.ts
+++ b/src/cli/daemon-cli/status.print.test.ts
@@ -258,6 +258,31 @@ describe("printDaemonStatus", () => {
     expectMockLineContains(runtime.error, "Errors: suppressed");
   });
 
+  it("prints GUI-session wording before generic missing-supervision wording", () => {
+    printDaemonStatus(
+      {
+        service: {
+          label: "LaunchAgent",
+          loaded: false,
+          loadedText: "loaded",
+          notLoadedText: "not loaded",
+          runtime: {
+            status: "unknown",
+            missingSupervision: true,
+            missingGuiSession: true,
+            detail: "Bootstrap failed: 125: Domain does not support specified action",
+          },
+        },
+        extraServices: [],
+      },
+      { json: false },
+    );
+
+    expectMockLineContains(runtime.error, "macOS has no usable GUI session");
+    const errors = runtime.error.mock.calls.map(([line]) => line).join("\n");
+    expect(errors).not.toContain("launchd has no loaded job");
+  });
+
   it("prints probe kind and capability separately", () => {
     printDaemonStatus(
       {

--- a/src/cli/daemon-cli/status.print.ts
+++ b/src/cli/daemon-cli/status.print.ts
@@ -345,6 +345,17 @@ export function printDaemonStatus(status: DaemonStatus, opts: { json: boolean; d
     for (const hint of renderRuntimeHints(service.runtime, process.env, status.logFile)) {
       defaultRuntime.error(errorText(hint));
     }
+  } else if (service.runtime?.missingGuiSession) {
+    defaultRuntime.error(
+      errorText("LaunchAgent plist exists, but macOS has no usable GUI session for this user."),
+    );
+    for (const hint of renderRuntimeHints(
+      service.runtime,
+      service.command?.environment ?? process.env,
+      status.logFile,
+    )) {
+      defaultRuntime.error(errorText(hint));
+    }
   } else if (service.runtime?.missingSupervision) {
     defaultRuntime.error(errorText("LaunchAgent plist exists but launchd has no loaded job."));
     for (const hint of renderRuntimeHints(

--- a/src/commands/doctor-format.test.ts
+++ b/src/commands/doctor-format.test.ts
@@ -3,6 +3,20 @@ import { describe, expect, it } from "vitest";
 import { buildGatewayRuntimeHints } from "./doctor-format.js";
 
 describe("buildGatewayRuntimeHints", () => {
+  it("prioritizes macOS GUI-session failures over generic missing supervision", () => {
+    const hints = buildGatewayRuntimeHints(
+      {
+        status: "unknown",
+        missingSupervision: true,
+        missingGuiSession: true,
+      },
+      { platform: "darwin", env: {} },
+    );
+
+    expect(hints.join("\n")).toContain("logged-in macOS GUI session");
+    expect(hints.join("\n")).not.toContain("LaunchAgent installed but not loaded");
+  });
+
   it("surfaces suspicious systemd cgroup hygiene with inspection commands", () => {
     expect(
       buildGatewayRuntimeHints(

--- a/src/commands/doctor-format.ts
+++ b/src/commands/doctor-format.ts
@@ -79,6 +79,21 @@ export function buildGatewayRuntimeHints(
     }
     return hints;
   }
+  if (runtime.missingGuiSession && platform === "darwin") {
+    hints.push(
+      "LaunchAgent requires a logged-in macOS GUI session; SSH/headless/sudo shells cannot bootstrap gui/$UID.",
+    );
+    hints.push(
+      `Sign in to the macOS desktop as this user, then run: ${formatCliCommand("openclaw gateway restart", env)}`,
+    );
+    hints.push(
+      "For headless VM setups, enable auto-login for the target user or use a custom LaunchDaemon (not shipped).",
+    );
+    if (fileLog) {
+      hints.push(`File logs: ${fileLog}`);
+    }
+    return hints;
+  }
   if (runtime.missingSupervision && platform === "darwin") {
     hints.push(
       `LaunchAgent installed but not loaded. Run: ${formatCliCommand("openclaw gateway restart", env)}`,

--- a/src/commands/doctor-gateway-daemon-flow.test.ts
+++ b/src/commands/doctor-gateway-daemon-flow.test.ts
@@ -33,6 +33,8 @@ const readGatewayRestartHandoffSync = vi.hoisted(() =>
 const findSystemGatewayServices = vi.hoisted(() =>
   vi.fn<() => Promise<ExtraGatewayService[]>>(async () => []),
 );
+const buildGatewayRuntimeHints = vi.hoisted(() => vi.fn((): string[] => []));
+const formatGatewayRuntimeSummary = vi.hoisted(() => vi.fn((): string | null => null));
 
 vi.mock("../config/config.js", async () => {
   const actual = await vi.importActual<typeof import("../config/config.js")>("../config/config.js");
@@ -128,8 +130,8 @@ vi.mock("./daemon-install-helpers.js", () => ({
 }));
 
 vi.mock("./doctor-format.js", () => ({
-  buildGatewayRuntimeHints: vi.fn(() => []),
-  formatGatewayRuntimeSummary: vi.fn(() => null),
+  buildGatewayRuntimeHints,
+  formatGatewayRuntimeSummary,
 }));
 
 vi.mock("./gateway-install-token.js", () => ({
@@ -172,6 +174,14 @@ describe("maybeRepairGatewayDaemon", () => {
       connections: [],
     });
     isExpectedGatewayListeners.mockReturnValue(false);
+    vi.mocked(launchd.isLaunchAgentLoaded).mockResolvedValue(false);
+    vi.mocked(launchd.launchAgentPlistExists).mockResolvedValue(false);
+    vi.mocked(launchd.repairLaunchAgentBootstrap).mockResolvedValue({
+      ok: true,
+      status: "repaired",
+    });
+    buildGatewayRuntimeHints.mockReturnValue([]);
+    formatGatewayRuntimeSummary.mockReturnValue(null);
   });
 
   afterEach(() => {
@@ -612,6 +622,79 @@ describe("maybeRepairGatewayDaemon", () => {
     expect(launchd.repairLaunchAgentBootstrap).not.toHaveBeenCalled();
     expect(service.install).not.toHaveBeenCalled();
     expect(note).toHaveBeenCalledWith(EXTERNAL_SERVICE_REPAIR_NOTE, "Gateway LaunchAgent");
+  });
+
+  it("reports macOS GUI-session runtime instead of install guidance for a not-loaded LaunchAgent", async () => {
+    setPlatform("darwin");
+    service.isLoaded.mockResolvedValue(false);
+    service.readRuntime.mockResolvedValue({
+      status: "unknown",
+      detail: "Bootstrap failed: 125: Domain does not support specified action",
+      missingSupervision: true,
+      missingGuiSession: true,
+    });
+    buildGatewayRuntimeHints.mockReturnValue([
+      "LaunchAgent requires a logged-in macOS GUI session; SSH/headless/sudo shells cannot bootstrap gui/$UID.",
+    ]);
+
+    await runAutoRepair();
+
+    expect(launchd.repairLaunchAgentBootstrap).not.toHaveBeenCalled();
+    expect(service.install).not.toHaveBeenCalled();
+    expect(buildGatewayRuntimeHints).toHaveBeenCalledWith(
+      {
+        status: "unknown",
+        detail: "Bootstrap failed: 125: Domain does not support specified action",
+        missingSupervision: true,
+        missingGuiSession: true,
+      },
+      { platform: "darwin", env: process.env },
+    );
+    expect(note).toHaveBeenCalledWith(
+      "LaunchAgent requires a logged-in macOS GUI session; SSH/headless/sudo shells cannot bootstrap gui/$UID.",
+      "Gateway",
+    );
+    expect(note).not.toHaveBeenCalledWith("Gateway service not installed.", "Gateway");
+  });
+
+  it("routes GUI-session bootstrap failures through the doctor runtime hint", async () => {
+    setPlatform("darwin");
+    service.isLoaded.mockResolvedValue(false);
+    service.readRuntime.mockResolvedValue({
+      status: "unknown",
+      missingSupervision: true,
+    });
+    vi.mocked(launchd.isLaunchAgentLoaded).mockResolvedValue(false);
+    vi.mocked(launchd.launchAgentPlistExists).mockResolvedValueOnce(true).mockResolvedValue(false);
+    vi.mocked(launchd.repairLaunchAgentBootstrap).mockResolvedValueOnce({
+      ok: false,
+      status: "gui-session-unavailable",
+      detail: "Bootstrap failed: 125: Domain does not support specified action",
+      domain: "gui/501",
+    });
+    buildGatewayRuntimeHints.mockReturnValue([
+      "LaunchAgent requires a logged-in macOS GUI session; SSH/headless/sudo shells cannot bootstrap gui/$UID.",
+    ]);
+
+    const runtime = await runAutoRepair();
+
+    expect(runtime.error).not.toHaveBeenCalledWith(
+      expect.stringContaining("LaunchAgent bootstrap failed"),
+    );
+    expect(service.install).not.toHaveBeenCalled();
+    expect(buildGatewayRuntimeHints).toHaveBeenCalledWith(
+      {
+        status: "unknown",
+        detail: "Bootstrap failed: 125: Domain does not support specified action",
+        missingSupervision: true,
+        missingGuiSession: true,
+      },
+      { platform: "darwin", env: process.env },
+    );
+    expect(note).toHaveBeenCalledWith(
+      "LaunchAgent requires a logged-in macOS GUI session; SSH/headless/sudo shells cannot bootstrap gui/$UID.",
+      "Gateway",
+    );
   });
 
   it("skips restart prompt when gateway is healthy after recent restart handoff in normal doctor flow", async () => {

--- a/src/commands/doctor-gateway-daemon-flow.ts
+++ b/src/commands/doctor-gateway-daemon-flow.ts
@@ -14,6 +14,7 @@ import {
   launchAgentPlistExists,
   repairLaunchAgentBootstrap,
 } from "../daemon/launchd.js";
+import type { GatewayServiceRuntime } from "../daemon/service-runtime.js";
 import { describeGatewayServiceRestart, resolveGatewayService } from "../daemon/service.js";
 import { renderSystemdUnavailableHints } from "../daemon/systemd-hints.js";
 import { isSystemdUserServiceAvailable } from "../daemon/systemd.js";
@@ -50,31 +51,58 @@ import { resolveGatewayInstallToken } from "./gateway-install-token.js";
 import { formatHealthCheckFailure } from "./health-format.js";
 import { healthCommand } from "./health.js";
 
+type LaunchAgentBootstrapDoctorOutcome =
+  | { status: "skipped" }
+  | { status: "repaired" }
+  | { status: "gui-session-unavailable"; detail: string };
+
+function noteGatewayRuntime(
+  serviceRuntime: GatewayServiceRuntime | undefined,
+  env: Record<string, string | undefined>,
+): boolean {
+  const summary = formatGatewayRuntimeSummary(serviceRuntime);
+  const hints = buildGatewayRuntimeHints(serviceRuntime, {
+    platform: process.platform,
+    env,
+  });
+  if (!summary && hints.length === 0) {
+    return false;
+  }
+
+  const lines: string[] = [];
+  if (summary) {
+    lines.push(`Runtime: ${summary}`);
+  }
+  lines.push(...hints);
+  note(lines.join("\n"), "Gateway");
+  return true;
+}
+
 async function maybeRepairLaunchAgentBootstrap(params: {
   env: Record<string, string | undefined>;
   title: string;
   runtime: RuntimeEnv;
   prompter: DoctorPrompter;
   serviceRepairExternal: boolean;
-}): Promise<boolean> {
+}): Promise<LaunchAgentBootstrapDoctorOutcome> {
   if (process.platform !== "darwin") {
-    return false;
+    return { status: "skipped" };
   }
 
   const plistExists = await launchAgentPlistExists(params.env);
   if (!plistExists) {
-    return false;
+    return { status: "skipped" };
   }
 
   const loaded = await isLaunchAgentLoaded({ env: params.env });
   if (loaded) {
-    return false;
+    return { status: "skipped" };
   }
 
   note("LaunchAgent is installed but not loaded in launchd.", `${params.title} LaunchAgent`);
   if (params.serviceRepairExternal) {
     note(EXTERNAL_SERVICE_REPAIR_NOTE, `${params.title} LaunchAgent`);
-    return false;
+    return { status: "skipped" };
   }
 
   const shouldFix = await confirmDoctorServiceRepair(params.prompter, {
@@ -82,26 +110,29 @@ async function maybeRepairLaunchAgentBootstrap(params: {
     initialValue: true,
   });
   if (!shouldFix) {
-    return false;
+    return { status: "skipped" };
   }
 
   params.runtime.log(`Bootstrapping ${params.title} LaunchAgent...`);
   const repair = await repairLaunchAgentBootstrap({ env: params.env });
   if (!repair.ok) {
+    if (repair.status === "gui-session-unavailable") {
+      return { status: "gui-session-unavailable", detail: repair.detail };
+    }
     params.runtime.error(
       `${params.title} LaunchAgent bootstrap failed: ${repair.detail ?? "unknown error"}`,
     );
-    return false;
+    return { status: "skipped" };
   }
 
   const verified = await isLaunchAgentLoaded({ env: params.env });
   if (!verified) {
     params.runtime.error(`${params.title} LaunchAgent still not loaded after repair.`);
-    return false;
+    return { status: "skipped" };
   }
 
   note(`${params.title} LaunchAgent repaired.`, `${params.title} LaunchAgent`);
-  return true;
+  return { status: "repaired" };
 }
 
 function renderBlockingSystemGatewayServices(services: ExtraGatewayService[]): string {
@@ -194,7 +225,9 @@ export async function maybeRepairGatewayDaemon(params: {
         ...command.environment,
       } satisfies NodeJS.ProcessEnv)
     : process.env;
-  if (loaded) {
+  const shouldReadRuntime =
+    loaded || (process.platform === "darwin" && params.cfg.gateway?.mode !== "remote");
+  if (shouldReadRuntime) {
     serviceRuntime = await service.readRuntime(serviceEnv).catch(() => undefined);
   }
   if (params.options.deep) {
@@ -205,13 +238,15 @@ export async function maybeRepairGatewayDaemon(params: {
   }
 
   if (process.platform === "darwin" && params.cfg.gateway?.mode !== "remote") {
-    const gatewayRepaired = await maybeRepairLaunchAgentBootstrap({
-      env: process.env,
-      title: "Gateway",
-      runtime: params.runtime,
-      prompter: params.prompter,
-      serviceRepairExternal,
-    });
+    const gatewayRepair = serviceRuntime?.missingGuiSession
+      ? ({ status: "gui-session-unavailable", detail: serviceRuntime.detail ?? "" } as const)
+      : await maybeRepairLaunchAgentBootstrap({
+          env: process.env,
+          title: "Gateway",
+          runtime: params.runtime,
+          prompter: params.prompter,
+          serviceRepairExternal,
+        });
     await maybeRepairLaunchAgentBootstrap({
       env: {
         ...process.env,
@@ -222,7 +257,15 @@ export async function maybeRepairGatewayDaemon(params: {
       prompter: params.prompter,
       serviceRepairExternal,
     });
-    if (gatewayRepaired) {
+    if (gatewayRepair.status === "gui-session-unavailable") {
+      serviceRuntime = {
+        status: "unknown",
+        detail: gatewayRepair.detail || serviceRuntime?.detail,
+        missingSupervision: true,
+        missingGuiSession: true,
+      };
+    }
+    if (gatewayRepair.status === "repaired") {
       loaded = await service.isLoaded({ env: process.env });
       if (loaded) {
         serviceRuntime = await service.readRuntime(process.env).catch(() => undefined);
@@ -252,6 +295,15 @@ export async function maybeRepairGatewayDaemon(params: {
   }
 
   if (!loaded) {
+    if (
+      process.platform === "darwin" &&
+      (serviceRuntime?.missingGuiSession ||
+        serviceRuntime?.missingSupervision ||
+        serviceRuntime?.cachedLabel)
+    ) {
+      noteGatewayRuntime(serviceRuntime, process.env);
+      return;
+    }
     if (process.platform === "linux") {
       const systemdAvailable = await isSystemdUserServiceAvailable().catch(() => false);
       if (!systemdAvailable) {
@@ -345,19 +397,7 @@ export async function maybeRepairGatewayDaemon(params: {
     return;
   }
 
-  const summary = formatGatewayRuntimeSummary(serviceRuntime);
-  const hints = buildGatewayRuntimeHints(serviceRuntime, {
-    platform: process.platform,
-    env: process.env,
-  });
-  if (summary || hints.length > 0) {
-    const lines: string[] = [];
-    if (summary) {
-      lines.push(`Runtime: ${summary}`);
-    }
-    lines.push(...hints);
-    note(lines.join("\n"), "Gateway");
-  }
+  noteGatewayRuntime(serviceRuntime, process.env);
 
   if (serviceRuntime?.status !== "running") {
     if (params.healthSkipped && serviceRuntime?.status !== "stopped") {

--- a/src/commands/doctor-gateway-daemon-flow.ts
+++ b/src/commands/doctor-gateway-daemon-flow.ts
@@ -59,14 +59,14 @@ type LaunchAgentBootstrapDoctorOutcome =
 function noteGatewayRuntime(
   serviceRuntime: GatewayServiceRuntime | undefined,
   env: Record<string, string | undefined>,
-): boolean {
+): void {
   const summary = formatGatewayRuntimeSummary(serviceRuntime);
   const hints = buildGatewayRuntimeHints(serviceRuntime, {
     platform: process.platform,
     env,
   });
   if (!summary && hints.length === 0) {
-    return false;
+    return;
   }
 
   const lines: string[] = [];
@@ -75,7 +75,6 @@ function noteGatewayRuntime(
   }
   lines.push(...hints);
   note(lines.join("\n"), "Gateway");
-  return true;
 }
 
 async function maybeRepairLaunchAgentBootstrap(params: {
@@ -208,6 +207,8 @@ export async function maybeRepairGatewayDaemon(params: {
   const serviceRepairPolicy = resolveServiceRepairPolicy();
   const serviceRepairExternal = isServiceRepairExternallyManaged(serviceRepairPolicy);
   const service = resolveGatewayService();
+  const isLocalDarwinGateway =
+    process.platform === "darwin" && params.cfg.gateway?.mode !== "remote";
   // systemd can throw in containers/WSL; treat as "not loaded" and fall back to hints.
   let loaded;
   try {
@@ -225,8 +226,7 @@ export async function maybeRepairGatewayDaemon(params: {
         ...command.environment,
       } satisfies NodeJS.ProcessEnv)
     : process.env;
-  const shouldReadRuntime =
-    loaded || (process.platform === "darwin" && params.cfg.gateway?.mode !== "remote");
+  const shouldReadRuntime = loaded || isLocalDarwinGateway;
   if (shouldReadRuntime) {
     serviceRuntime = await service.readRuntime(serviceEnv).catch(() => undefined);
   }
@@ -237,7 +237,7 @@ export async function maybeRepairGatewayDaemon(params: {
     }
   }
 
-  if (process.platform === "darwin" && params.cfg.gateway?.mode !== "remote") {
+  if (isLocalDarwinGateway) {
     const gatewayRepair = serviceRuntime?.missingGuiSession
       ? ({ status: "gui-session-unavailable", detail: serviceRuntime.detail ?? "" } as const)
       : await maybeRepairLaunchAgentBootstrap({
@@ -296,7 +296,7 @@ export async function maybeRepairGatewayDaemon(params: {
 
   if (!loaded) {
     if (
-      process.platform === "darwin" &&
+      isLocalDarwinGateway &&
       (serviceRuntime?.missingGuiSession ||
         serviceRuntime?.missingSupervision ||
         serviceRuntime?.cachedLabel)

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -428,6 +428,20 @@ describe("launchd runtime state", () => {
     expect(runtime.detail).toBe("Could not find service");
   });
 
+  it("marks installed LaunchAgents unavailable when the GUI domain is missing", async () => {
+    const env = createDefaultLaunchdEnv();
+    state.files.set(resolveLaunchAgentPlistPath(env), "<plist/>");
+    state.printError = "Bootstrap failed: 125: Domain does not support specified action";
+    state.printFailuresRemaining = 1;
+
+    const runtime = await readLaunchAgentRuntime(env);
+
+    expect(runtime.status).toBe("unknown");
+    expect(runtime.missingSupervision).toBe(true);
+    expect(runtime.missingGuiSession).toBe(true);
+    expect(runtime.detail).toContain("Domain does not support specified action");
+  });
+
   it("marks a missing unit when launchd has no job and no plist exists", async () => {
     const env = createDefaultLaunchdEnv();
     state.serviceLoaded = false;
@@ -776,6 +790,21 @@ describe("launchd bootstrap repair", () => {
     }
     expect(repair.status).toBe("bootstrap-failed");
     expect(repair.detail).toContain("Could not find specified service");
+    expect(launchctlCommandNames()).not.toContain("kickstart");
+  });
+
+  it("classifies headless GUI bootstrap failures separately from generic not-loaded repair", async () => {
+    state.bootstrapError = "Bootstrap failed: 125: Domain does not support specified action";
+    const env = createDefaultLaunchdEnv();
+
+    const repair = await repairLaunchAgentBootstrap({ env });
+
+    expect(repair).toEqual({
+      ok: false,
+      status: "gui-session-unavailable",
+      detail: "Bootstrap failed: 125: Domain does not support specified action",
+      domain: typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501",
+    });
     expect(launchctlCommandNames()).not.toContain("kickstart");
   });
 

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -428,10 +428,13 @@ describe("launchd runtime state", () => {
     expect(runtime.detail).toBe("Could not find service");
   });
 
-  it("marks installed LaunchAgents unavailable when the GUI domain is missing", async () => {
+  it.each([
+    "Bootstrap failed: 125: Domain does not support specified action",
+    "Could not find domain for user gui: 999999",
+  ])("marks installed LaunchAgents unavailable when launchd reports %s", async (detail) => {
     const env = createDefaultLaunchdEnv();
     state.files.set(resolveLaunchAgentPlistPath(env), "<plist/>");
-    state.printError = "Bootstrap failed: 125: Domain does not support specified action";
+    state.printError = detail;
     state.printFailuresRemaining = 1;
 
     const runtime = await readLaunchAgentRuntime(env);
@@ -439,7 +442,7 @@ describe("launchd runtime state", () => {
     expect(runtime.status).toBe("unknown");
     expect(runtime.missingSupervision).toBe(true);
     expect(runtime.missingGuiSession).toBe(true);
-    expect(runtime.detail).toContain("Domain does not support specified action");
+    expect(runtime.detail).toBe(detail);
   });
 
   it("marks a missing unit when launchd has no job and no plist exists", async () => {
@@ -793,8 +796,11 @@ describe("launchd bootstrap repair", () => {
     expect(launchctlCommandNames()).not.toContain("kickstart");
   });
 
-  it("classifies headless GUI bootstrap failures separately from generic not-loaded repair", async () => {
-    state.bootstrapError = "Bootstrap failed: 125: Domain does not support specified action";
+  it.each([
+    "Bootstrap failed: 125: Domain does not support specified action",
+    "Could not find domain for user gui: 999999",
+  ])("classifies %s separately from generic not-loaded repair", async (detail) => {
+    state.bootstrapError = detail;
     const env = createDefaultLaunchdEnv();
 
     const repair = await repairLaunchAgentBootstrap({ env });
@@ -802,7 +808,7 @@ describe("launchd bootstrap repair", () => {
     expect(repair).toEqual({
       ok: false,
       status: "gui-session-unavailable",
-      detail: "Bootstrap failed: 125: Domain does not support specified action",
+      detail,
       domain: typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501",
     });
     expect(launchctlCommandNames()).not.toContain("kickstart");

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -421,16 +421,22 @@ function throwBootstrapGuiSessionError(params: {
   domain: string;
   actionHint: string;
 }) {
-  throw new Error(
-    [
-      `launchctl bootstrap failed: ${params.detail}`,
-      `LaunchAgent ${params.actionHint} requires a logged-in macOS GUI session for this user (${params.domain}).`,
-      "This usually means you are running from SSH/headless context or as the wrong user (including sudo).",
-      `Fix: sign in to the macOS desktop as the target user and rerun \`${params.actionHint}\`.`,
-      "For headless VM setups, enable auto-login for the target user so macOS creates the GUI session after boot.",
-      "Headless deployments should use a dedicated logged-in user session or a custom LaunchDaemon (not shipped): https://docs.openclaw.ai/gateway",
-    ].join("\n"),
-  );
+  throw new Error(formatLaunchAgentGuiSessionError(params));
+}
+
+export function formatLaunchAgentGuiSessionError(params: {
+  detail: string;
+  domain: string;
+  actionHint: string;
+}): string {
+  return [
+    `launchctl bootstrap failed: ${params.detail}`,
+    `LaunchAgent ${params.actionHint} requires a logged-in macOS GUI session for this user (${params.domain}).`,
+    "This usually means you are running from SSH/headless context or as the wrong user (including sudo).",
+    `Fix: sign in to the macOS desktop as the target user and rerun \`${params.actionHint}\`.`,
+    "For headless VM setups, enable auto-login for the target user so macOS creates the GUI session after boot.",
+    "Headless deployments should use a dedicated logged-in user session or a custom LaunchDaemon (not shipped): https://docs.openclaw.ai/gateway",
+  ].join("\n");
 }
 
 function writeLaunchAgentActionLine(
@@ -573,10 +579,14 @@ export async function readLaunchAgentRuntime(
   const res = await execLaunchctl(["print", `${domain}/${label}`]);
   if (res.code !== 0) {
     const plistExists = await launchAgentPlistExists(env);
+    const detail = (res.stderr || res.stdout).trim() || undefined;
+    const missingGuiSession = plistExists && isUnsupportedGuiDomain(detail ?? "");
     return {
       status: "unknown",
-      detail: (res.stderr || res.stdout).trim() || undefined,
-      ...(plistExists ? { missingSupervision: true } : { missingUnit: true }),
+      detail,
+      ...(plistExists
+        ? { missingSupervision: true, ...(missingGuiSession ? { missingGuiSession } : {}) }
+        : { missingUnit: true }),
     };
   }
   const parsed = parseLaunchctlPrint(res.stdout || res.stderr || "");
@@ -595,7 +605,12 @@ export async function readLaunchAgentRuntime(
 
 type LaunchAgentBootstrapRepairResult =
   | { ok: true; status: "repaired" | "already-loaded" }
-  | { ok: false; status: "bootstrap-failed" | "kickstart-failed"; detail?: string };
+  | {
+      ok: false;
+      status: "bootstrap-failed" | "kickstart-failed";
+      detail?: string;
+    }
+  | { ok: false; status: "gui-session-unavailable"; detail: string; domain: string };
 
 function isLaunchctlAlreadyLoaded(res: { stdout: string; stderr: string; code: number }): boolean {
   const detail = normalizeLowercaseStringOrEmpty(res.stderr || res.stdout);
@@ -615,6 +630,14 @@ export async function repairLaunchAgentBootstrap(args: {
   let repairStatus: "repaired" | "already-loaded" = "repaired";
   if (boot.code !== 0) {
     const detail = (boot.stderr || boot.stdout).trim();
+    if (isUnsupportedGuiDomain(detail)) {
+      return {
+        ok: false,
+        status: "gui-session-unavailable",
+        detail,
+        domain,
+      };
+    }
     if (!isLaunchctlAlreadyLoaded(boot)) {
       return { ok: false, status: "bootstrap-failed", detail: detail || undefined };
     }

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -707,6 +707,7 @@ function isUnsupportedGuiDomain(detail: string): boolean {
   const normalized = normalizeLowercaseStringOrEmpty(detail);
   return (
     normalized.includes("domain does not support specified action") ||
+    normalized.includes("could not find domain for user gui") ||
     normalized.includes("bootstrap failed: 125")
   );
 }

--- a/src/daemon/service-runtime.ts
+++ b/src/daemon/service-runtime.ts
@@ -22,6 +22,7 @@ export type GatewayServiceRuntime = {
   cachedLabel?: boolean;
   missingUnit?: boolean;
   missingSupervision?: boolean;
+  missingGuiSession?: boolean;
   systemd?: GatewayServiceSystemdRuntime;
 };
 


### PR DESCRIPTION
## Summary

- classify macOS `gui/$UID` LaunchAgent bootstrap/print failures as a distinct missing GUI-session state
- stop `gateway restart` recovery from falling through to unmanaged-process restart when LaunchAgent bootstrap cannot access a logged-in GUI session
- update `gateway status` and `doctor` hints so installed-but-headless LaunchAgents explain the GUI-session requirement instead of only saying "installed but not loaded"

## Real behavior proof

Behavior addressed: macOS Gateway LaunchAgent installed-but-not-loaded/headless state handling for status, doctor, start/restart recovery, and bootstrap repair.

Real environment tested: local macOS Codex worktree on macOS with an active Aqua `gui/501` session, plus delegated Blacksmith Testbox attempts.

Exact steps or command run after this patch:
- `pnpm docs:list`
- `pnpm oxfmt src/daemon/service-runtime.ts src/daemon/launchd.ts src/daemon/launchd.test.ts src/cli/daemon-cli/launchd-recovery.ts src/cli/daemon-cli/launchd-recovery.test.ts src/cli/daemon-cli/shared.ts src/cli/daemon-cli/shared.test.ts src/cli/daemon-cli/status.print.ts src/cli/daemon-cli/status.print.test.ts src/cli/daemon-cli/lifecycle.test.ts src/commands/doctor-format.ts src/commands/doctor-format.test.ts`
- `git diff --check`
- `node scripts/run-vitest.mjs src/daemon/launchd.test.ts src/cli/daemon-cli/launchd-recovery.test.ts src/cli/daemon-cli/shared.test.ts src/cli/daemon-cli/status.print.test.ts src/cli/daemon-cli/lifecycle.test.ts src/commands/doctor-format.test.ts`
- `launchctl print gui/$(id -u)`
- `launchctl print gui/999999/com.openclaw.gateway`
- `launchctl bootstrap gui/999999 /tmp/openclaw-codex-missing.plist`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

Evidence after fix: terminal output from the local macOS setup shows this machine has a usable GUI domain, so the exact headless `Bootstrap failed: 125: Domain does not support specified action` path is not directly reproducible here. The same live `launchctl` probes show the domain/label error surface that the patch classifies, and focused regression coverage exercised the unavailable headless branch.

```text
$ id -u
501

$ launchctl print gui/501 | sed -n '1,12p'
gui/501 = {
	type = login
	handle = 100017
	active count = 467
	service count = 466
	active service count = 157
	creator = loginwindow[598]
	creator euid = 0
	session = Aqua
	endpoint destination = com.apple.xpc.launchd.domain.user.501
	auxiliary bootstrapper = com.apple.xpc.otherbsd (complete)
	security context = {

$ launchctl print gui/999999/com.openclaw.gateway
Bad request.
Could not find domain for user gui: 999999

$ launchctl bootstrap gui/999999 /tmp/openclaw-codex-missing.plist
Could not find domain for user gui: 999999
```

Supplemental regression proof: focused Vitest wrapper passed 3 shards: 2 unit-fast files / 13 tests, 1 daemon file / 87 tests, 3 cli files / 45 tests. Autoreview initially found the doctor hint priority gap; after fixing `src/commands/doctor-format.ts`, rerun was clean: `autoreview clean: no accepted/actionable findings reported`.

Observed result after fix: LaunchAgent headless GUI bootstrap failures now produce a `missingGuiSession` runtime/recovery state, status and doctor prioritize GUI-session guidance over generic missing-supervision wording, and restart recovery does not fall through to unmanaged restart after that launchd failure.

What was not tested: a true headless macOS loginwindow-disabled host where `launchctl bootstrap gui/$UID ...` returns `Bootstrap failed: 125: Domain does not support specified action`; this local Mac has an active Aqua session for `gui/501`. Final post-doctor-fix remote `pnpm check:changed` could not complete because Blacksmith Testbox leases `tbx_01ktnbgxkyn9s5bf0xj652azgx` and `tbx_01ktnbhsvaeykqj4qd9f5kbevt` shut down before command execution; default Crabbox mapped to Azure but this host lacks Azure CLI/session; direct AWS Crabbox requires broker login. A prior Blacksmith Testbox changed gate before the doctor follow-up completed successfully on `tbx_01ktnavppcknwpxsfnhn9g6cd0` with `pnpm check:changed` exit 0.
