### PR TITLE
fix(cron): add cron edit --clear-model to clear a job's model override

### DIFF
--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -157,6 +157,9 @@ If stdout is non-empty, that text is the delivered result. If stdout is empty an
 <ParamField path="--model" type="string">
   Model override; uses the selected allowed model for the job.
 </ParamField>
+<ParamField path="--clear-model" type="boolean">
+  On `cron edit`, removes a stored model override so the job reverts to the agent/default model. Cannot be combined with `--model`.
+</ParamField>
 <ParamField path="--thinking" type="string">
   Thinking level override.
 </ParamField>
@@ -471,6 +474,7 @@ Model override note:
 - If the model is allowed, that exact provider/model reaches the isolated agent run.
 - If it is not allowed or cannot be resolved, cron fails the run with an explicit validation error.
 - API `cron.update` payload patches can set `model: null` to clear a stored job model override.
+- `openclaw cron edit <job-id> --clear-model` clears that override from the CLI (same effect as the `model: null` patch) and cannot be combined with `--model`.
 - Configured fallback chains still apply because cron `--model` is a job primary, not a session `/model` override.
 - Payload `fallbacks` replaces configured fallbacks for that job; `fallbacks: []` disables fallback and makes the run strict.
 - A plain `--model` with no explicit or configured fallback list does not fall through to the agent primary as a silent extra retry target.

--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -158,7 +158,7 @@ If stdout is non-empty, that text is the delivered result. If stdout is empty an
   Model override; uses the selected allowed model for the job.
 </ParamField>
 <ParamField path="--clear-model" type="boolean">
-  On `cron edit`, removes a stored model override so the job reverts to the agent/default model. Cannot be combined with `--model`.
+  On `cron edit`, removes the per-job model override so the job follows normal cron model-selection precedence (a stored cron-session override if set, otherwise the agent/default model). Cannot be combined with `--model`.
 </ParamField>
 <ParamField path="--thinking" type="string">
   Thinking level override.

--- a/docs/cli/cron.md
+++ b/docs/cli/cron.md
@@ -168,7 +168,7 @@ Use `--due` when you want the manual command to run only if the job is currently
 
 ## Models
 
-`cron add|edit --model <ref>` selects an allowed model for the job. `cron edit <job-id> --clear-model` removes a stored model override so the job reverts to its agent/default model; it cannot be combined with `--model`.
+`cron add|edit --model <ref>` selects an allowed model for the job. `cron edit <job-id> --clear-model` removes the per-job model override so the job follows normal cron model-selection precedence (a stored cron-session override if present, otherwise the agent/default model); it cannot be combined with `--model`.
 
 <Warning>
 If the model is not allowed or cannot be resolved, cron fails the run with an explicit validation error instead of falling back to the job's agent or default model selection.

--- a/docs/cli/cron.md
+++ b/docs/cli/cron.md
@@ -168,7 +168,7 @@ Use `--due` when you want the manual command to run only if the job is currently
 
 ## Models
 
-`cron add|edit --model <ref>` selects an allowed model for the job.
+`cron add|edit --model <ref>` selects an allowed model for the job. `cron edit <job-id> --clear-model` removes a stored model override so the job reverts to its agent/default model; it cannot be combined with `--model`.
 
 <Warning>
 If the model is not allowed or cannot be resolved, cron fails the run with an explicit validation error instead of falling back to the job's agent or default model selection.

--- a/src/cli/cron-cli/register.cron-edit.test.ts
+++ b/src/cli/cron-cli/register.cron-edit.test.ts
@@ -107,4 +107,32 @@ describe("cron edit command", () => {
       },
     );
   });
+
+  it("clears the model override with --clear-model (CLI parity with cron.update model:null)", async () => {
+    const program = createCronProgram();
+
+    await program.parseAsync(["edit", "job-1", "--clear-model"], { from: "user" });
+
+    expect(callGatewayFromCli).toHaveBeenCalledWith(
+      "cron.update",
+      expect.objectContaining({ clearModel: true }),
+      {
+        id: "job-1",
+        patch: {
+          payload: {
+            kind: "agentTurn",
+            model: null,
+          },
+        },
+      },
+    );
+  });
+
+  it("documents the --clear-model flag alongside the sibling --clear-tools", () => {
+    const editCommand = createCronProgram().commands.find((command) => command.name() === "edit");
+    const help = editCommand?.helpInformation() ?? "";
+
+    expect(help).toContain("--clear-model");
+    expect(help).toContain("--clear-tools");
+  });
 });

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -108,6 +108,7 @@ export function registerCronEditCommand(cron: Command) {
         "Thinking level for agent jobs (off|minimal|low|medium|high|xhigh)",
       )
       .option("--model <model>", "Model override for agent jobs")
+      .option("--clear-model", "Remove model override (use agent/default model)", false)
       .option("--timeout-seconds <n>", "Timeout seconds for agent or command jobs")
       .option("--no-output-timeout-seconds <n>", "No-output timeout seconds for command jobs")
       .option("--output-max-bytes <n>", "Maximum captured stdout/stderr bytes for command jobs")
@@ -261,6 +262,9 @@ export function registerCronEditCommand(cron: Command) {
             );
           }
           const model = normalizeOptionalString(opts.model);
+          if (model && opts.clearModel) {
+            throw new Error("Use --model or --clear-model, not both");
+          }
           const thinking = normalizeOptionalString(opts.thinking);
           const toolsAllow = parseCronToolsAllow(opts.tools);
           const rawTimeoutSeconds =
@@ -328,6 +332,7 @@ export function registerCronEditCommand(cron: Command) {
           const hasAgentTurnPayloadField =
             typeof opts.message === "string" ||
             Boolean(model) ||
+            Boolean(opts.clearModel) ||
             Boolean(thinking) ||
             (hasTimeoutSeconds &&
               !hasCommandSpecificPayloadField &&
@@ -355,7 +360,11 @@ export function registerCronEditCommand(cron: Command) {
           } else if (hasAgentTurnPatch) {
             const payload: Record<string, unknown> = { kind: "agentTurn" };
             assignIf(payload, "message", String(opts.message), typeof opts.message === "string");
-            assignIf(payload, "model", model, Boolean(model));
+            if (opts.clearModel) {
+              payload.model = null;
+            } else {
+              assignIf(payload, "model", model, Boolean(model));
+            }
             assignIf(payload, "thinking", thinking, Boolean(thinking));
             assignIf(payload, "timeoutSeconds", timeoutSeconds, hasTimeoutSeconds);
             assignIf(

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -108,7 +108,11 @@ export function registerCronEditCommand(cron: Command) {
         "Thinking level for agent jobs (off|minimal|low|medium|high|xhigh)",
       )
       .option("--model <model>", "Model override for agent jobs")
-      .option("--clear-model", "Remove model override (use agent/default model)", false)
+      .option(
+        "--clear-model",
+        "Remove the per-job model override (restore normal cron model precedence)",
+        false,
+      )
       .option("--timeout-seconds <n>", "Timeout seconds for agent or command jobs")
       .option("--no-output-timeout-seconds <n>", "No-output timeout seconds for command jobs")
       .option("--output-max-bytes <n>", "Maximum captured stdout/stderr bytes for command jobs")


### PR DESCRIPTION
## Summary

- The Gateway RPC `cron.update` already supports **clearing** a cron job's `payload.model` override by sending `model: null` (landed via #91298 — the patch schema, `normalizeCronJobPatch`, and `mergeCronPayload` all honor `null` as "delete this key").
- But the CLI `openclaw cron edit` has **no way to send it**: `--model` only *sets* a value (an empty string is silently ignored), and there is no `--clear-model` flag — unlike the sibling field `toolsAllow`, which has `--clear-tools`. So #91298's fix is unreachable from the CLI, the most common install/edit path, and a model override stuck on a cron job cannot be removed without hand-editing gateway state.
- This adds `--clear-model` to `cron edit`, mirroring the existing `--clear-tools` flag.

## Root cause

`src/cli/cron-cli/register.cron-edit.ts` only ever assigns `model` when it is truthy:

```ts
assignIf(payload, "model", model, Boolean(model)); // empty/absent -> not sent
```

There was no clear flag, so the CLI could never produce the `model: null` patch that `mergeCronPayload` (`src/cron/service/jobs.ts`) already honors:

```ts
if (typeof patch.model === "string") next.model = patch.model;
else if (patch.model === null) delete next.model; // <- reachable from RPC, not CLI
```

`--clear-tools` already demonstrates the intended pattern for the sibling `toolsAllow` field (`payload.toolsAllow = null`).

## What changed (`src/cli/cron-cli/register.cron-edit.ts`)

- Add the `--clear-model` option.
- Reject `--model` + `--clear-model` together (matches the existing `--agent`/`--clear-agent` and `--session-key`/`--clear-session-key` guards).
- Include `--clear-model` in the agentTurn-payload trigger so a clear-only edit still builds the patch.
- Emit `payload.model = null` when `--clear-model` is set (mirrors `--clear-tools` → `toolsAllow: null`).

Net `+10 / -1` in prod, `+28` test.

## Scope boundary

Only `model` is addressed: its RPC null-clear already shipped (#91298), so the CLI flag is the **sole** missing piece. Sibling agentTurn override fields (`thinking`, `fallbacks`) are not yet clearable at the RPC layer either — open PR #67429 adds that — so their CLI clear flags are the natural follow-up once #67429 lands. This change is orthogonal to #67429 (no shared files, no overlap).

## Change Type

- [x] Bug fix

## Linked Issue

Source-discovered while reading the cron clear-override paths. Completes the CLI half of #91298 (model-clear); related: #67429 (RPC null-clear for `fallbacks`/`thinking`).

## Evidence

- [x] **Failing before / passing after.** New test `clears the model override with --clear-model` asserts `cron edit <id> --clear-model` sends `{ payload: { kind: "agentTurn", model: null } }`. Before this change the flag does not exist, so the parse errors with `unknown option '--clear-model'`. New help-doc test asserts `--clear-model` is documented alongside `--clear-tools`. Full file: **6/6 tests pass** (Node 22.22.1).

## Real behavior proof

Behavior addressed: `openclaw cron edit <id> --clear-model` now removes a cron job's `payload.model` override (reverting the job to the agent/default model); previously there was no CLI way to clear it.

Real environment tested: local OpenClaw dev gateway (`gateway run --dev --auth none`) on Node 22.22.1 (macOS), isolated `OPENCLAW_STATE_DIR`/`OPENCLAW_HOME`, CLI driven via `scripts/run-node.mjs` against the live gateway RPC.

Exact steps or command run after this patch:

```
$ openclaw cron add --every 1h --session isolated --message hi --model anthropic/claude-sonnet-4-6 --name clearmodel-proof
$ openclaw cron edit <id> --clear-model
$ openclaw cron edit <id> --model anthropic/claude-sonnet-4-6 --clear-model
```

Evidence after fix (live gateway output, payload read back via `cron list --json`):

```
BEFORE clear:
  payload = {"kind": "agentTurn", "message": "hi", "model": "anthropic/claude-sonnet-4-6"}

$ openclaw cron edit 4ee52523-084a-4fd9-9fe2-6864dfe2ba1a --clear-model
  (ok)
AFTER  clear:
  payload = {"kind": "agentTurn", "message": "hi"}          <- model override removed

$ openclaw cron edit 4ee52523-084a-4fd9-9fe2-6864dfe2ba1a --model X --clear-model
  Error: Use --model or --clear-model, not both             <- conflict guard
```

Observed result after fix: the `model` key is deleted from the stored cron payload (job now runs on the agent/default model); passing both `--model` and `--clear-model` is rejected.

What was not tested: a live agent run of the cleared cron job (the clearing behavior is fully observable in the persisted payload via the gateway; running the job would require a real model/provider).

## Compatibility / Migration

Backward compatible — purely additive CLI flag. No config/schema/migration changes (the Gateway already accepts `model: null` on `cron.update`).

## AI assistance

AI-assisted (Claude Code). Verified locally: 6/6 unit tests, oxlint clean, oxfmt clean, and the live before/after gateway proof above. Author understands the change.
