### PR TITLE
fix(agents): stop sessions_send falling back to parent session on run-scoped queue rejection

### DIFF
--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -1493,11 +1493,10 @@ describe("sessions tools", () => {
     expect(calls.find((call) => call.method === "send")).toBeUndefined();
   });
 
-  it("sessions_send reroutes run-scoped active deliveries when transcript steering is rejected", async () => {
-    const calls: Array<{ method?: string; params?: unknown }> = [];
+  it("sessions_send returns error on run-scoped queue rejection without starting fallback agent", async () => {
+    const agentCalls: Array<{ method?: string; params?: unknown }> = [];
     const requesterKey = "agent:re-portal:main";
     const runScopedCallerKey = "agent:leasing-ops:cron:monthly-utility:run:run-fast";
-    const durableCallerKey = "agent:leasing-ops:cron:monthly-utility";
     const queueMessage = vi.fn(async (_text: string, _options?: unknown) => {
       throw new Error("active session ended before queued steering message was committed");
     });
@@ -1515,16 +1514,9 @@ describe("sessions tools", () => {
     );
     callGatewayMock.mockImplementation(async (opts: unknown) => {
       const request = opts as { method?: string; params?: unknown };
-      calls.push(request);
       if (request.method === "agent") {
-        return { runId: "fallback-run", status: "accepted", acceptedAt: 2000 };
-      }
-      if (request.method === "agent.wait") {
-        const params = request.params as { runId?: string } | undefined;
-        return { runId: params?.runId ?? "fallback-run", status: "ok" };
-      }
-      if (request.method === "chat.history") {
-        return { messages: [] };
+        agentCalls.push(request);
+        throw new Error("no agent call expected");
       }
       return {};
     });
@@ -1532,13 +1524,6 @@ describe("sessions tools", () => {
     const tool = createOpenClawTools({
       agentSessionKey: requesterKey,
       agentChannel: "telegram",
-      config: {
-        ...TEST_CONFIG,
-        session: {
-          ...TEST_CONFIG.session,
-          agentToAgent: { maxPingPongTurns: 0 },
-        },
-      },
     }).find((candidate) => candidate.name === "sessions_send");
     if (!tool) {
       throw new Error("missing sessions_send tool");
@@ -1550,9 +1535,10 @@ describe("sessions tools", () => {
       timeoutSeconds: 0,
     });
     const details = sessionsSendDetails(result.details);
-    expect(details.status).toBe("accepted");
+    expect(details.status).toBe("error");
     expect(details.sessionKey).toBe(runScopedCallerKey);
-    expect(details.delivery?.status).toBe("pending");
+    expect(details.error).toContain("queue_message_failed reason=runtime_rejected");
+
     const queuedText = queueMessage.mock.calls[0]?.[0];
     expect(queuedText).toContain("[Inter-session message]");
     expect(queuedText).toContain("[TASK-COMPLETE] re-portal occupancy ready");
@@ -1563,47 +1549,7 @@ describe("sessions tools", () => {
       waitForTranscriptCommit: true,
       sourceReplyDeliveryMode: "message_tool_only",
     });
-
-    await vi.waitFor(() => {
-      const fallbackCall = calls.find(
-        (call) =>
-          call.method === "agent" &&
-          (call.params as { sessionKey?: string } | undefined)?.sessionKey === durableCallerKey,
-      );
-      expect(fallbackCall).toBeDefined();
-    });
-
-    const agentCalls = calls.filter((call) => call.method === "agent");
-    expect(
-      agentCalls.some(
-        (call) =>
-          (call.params as { sessionKey?: string } | undefined)?.sessionKey === runScopedCallerKey,
-      ),
-    ).toBe(false);
-    const fallbackParams = agentCalls.find(
-      (call) =>
-        (call.params as { sessionKey?: string } | undefined)?.sessionKey === durableCallerKey,
-    )?.params as { inputProvenance?: { sourceSessionKey?: string }; message?: string } | undefined;
-    expect(fallbackParams?.message).toContain("[Inter-session message]");
-    expect(fallbackParams?.message).toContain("[TASK-COMPLETE] re-portal occupancy ready");
-    expect(fallbackParams?.inputProvenance?.sourceSessionKey).toBe(requesterKey);
-
-    await vi.waitFor(() => {
-      const waitCall = calls.find(
-        (call) =>
-          call.method === "agent.wait" &&
-          (call.params as { runId?: string } | undefined)?.runId === "fallback-run",
-      );
-      expect(waitCall).toBeDefined();
-    });
-    await vi.waitFor(() => {
-      const historyCall = calls.find(
-        (call) =>
-          call.method === "chat.history" &&
-          (call.params as { sessionKey?: string } | undefined)?.sessionKey === durableCallerKey,
-      );
-      expect(historyCall).toBeDefined();
-    });
+    expect(agentCalls).toHaveLength(0);
   });
 
   it("sessions_send preserves active delivery when transcript commit wait is unsupported", async () => {
@@ -1657,27 +1603,25 @@ describe("sessions tools", () => {
     expect(calls.some((call) => call.method === "agent")).toBe(false);
   });
 
-  it("sessions_send reports run-scoped fallback admission failures", async () => {
+  it("sessions_send returns error when active run-scoped session is not streaming", async () => {
     const runScopedCallerKey = "agent:leasing-ops:cron:monthly-utility:run:run-fast";
-    const queueMessage = vi.fn(async () => {
-      throw new Error("active session ended before queued steering message was committed");
-    });
+    const agentCalls: Array<unknown> = [];
     setActiveEmbeddedRun(
       "caller-active-session",
       {
-        queueMessage,
-        isStreaming: () => true,
+        queueMessage: vi.fn(),
+        isStreaming: () => false,
         isCompacting: () => false,
-        supportsTranscriptCommitWait: true,
         sourceReplyDeliveryMode: "message_tool_only",
         abort: () => {},
       },
       runScopedCallerKey,
     );
     callGatewayMock.mockImplementation(async (opts: unknown) => {
-      const request = opts as { method?: string; params?: unknown };
+      const request = opts as { method?: string };
       if (request.method === "agent") {
-        throw new Error("gateway request timeout for agent");
+        agentCalls.push(request);
+        throw new Error("no agent call expected");
       }
       return {};
     });
@@ -1699,8 +1643,8 @@ describe("sessions tools", () => {
     const details = sessionsSendDetails(result.details);
     expect(details.status).toBe("error");
     expect(details.sessionKey).toBe(runScopedCallerKey);
-    expect(details.error).toContain("queue_message_failed reason=runtime_rejected");
-    expect(details.error).toContain("fallback_failed error=gateway request timeout for agent");
+    expect(details.error).toContain("queue_message_failed reason=not_streaming");
+    expect(agentCalls).toHaveLength(0);
   });
 
   it("sessions_send preserves terminal timeouts without starting A2A", async () => {

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -212,25 +212,19 @@ async function startAgentRun(params: {
   deliveryTimeoutMs?: number;
   allowActiveRunQueueFallback?: boolean;
 }): Promise<
-  | {
-      ok: true;
-      runId: string;
-      activeRunQueue?: boolean;
-      a2aSessionKey?: string;
-      a2aDisplayKey?: string;
-    }
+  | { ok: true; runId: string; activeRunQueue?: boolean }
   | { ok: false; result: ReturnType<typeof jsonResult> }
 > {
   try {
     const activeRunSessionId = params.allowActiveRunQueueFallback
       ? resolveActiveEmbeddedRunSessionId(params.sessionKey)
       : undefined;
-    const fallbackSessionKey = activeRunSessionId
-      ? resolveRunScopedFallbackSessionKey(params.sessionKey)
-      : undefined;
+    const isRunScopedKey = activeRunSessionId
+      ? resolveRunScopedFallbackSessionKey(params.sessionKey) !== undefined
+      : false;
     const messageText =
       typeof params.sendParams.message === "string" ? params.sendParams.message : undefined;
-    if (activeRunSessionId && fallbackSessionKey && messageText) {
+    if (activeRunSessionId && isRunScopedKey && messageText) {
       const sourceReplyDeliveryMode =
         params.sendParams.sourceReplyDeliveryMode === "automatic" ||
         params.sendParams.sourceReplyDeliveryMode === "message_tool_only"
@@ -260,30 +254,9 @@ async function startAgentRun(params: {
       if (queueOutcome.queued) {
         return { ok: true, runId: params.runId, activeRunQueue: true };
       }
-      try {
-        const response = await params.callGateway<{ runId: string }>({
-          method: "agent",
-          params: {
-            ...params.sendParams,
-            sessionKey: fallbackSessionKey,
-            idempotencyKey: crypto.randomUUID(),
-          },
-          timeoutMs: 10_000,
-        });
-        return {
-          ok: true,
-          runId:
-            typeof response?.runId === "string" && response.runId ? response.runId : params.runId,
-          a2aSessionKey: fallbackSessionKey,
-          a2aDisplayKey: fallbackSessionKey,
-        };
-      } catch (err) {
-        const queueSummary =
-          formatEmbeddedAgentQueueFailureSummary(queueOutcome) ?? "active run queue rejected";
-        throw new Error(`${queueSummary}; fallback_failed error=${formatErrorMessage(err)}`, {
-          cause: err,
-        });
-      }
+      throw new Error(
+        formatEmbeddedAgentQueueFailureSummary(queueOutcome) ?? "active run queue rejected",
+      );
     }
     const response = await params.callGateway<{ runId: string }>({
       method: "agent",
@@ -619,18 +592,13 @@ export function createSessionsSendTool(opts?: {
         ? ({ status: "skipped", mode: "announce" } as const)
         : ({ status: "pending", mode: "announce" } as const);
 
-      const startA2AFlow = (
-        roundOneReply?: string,
-        waitRunId?: string,
-        flowTargetSessionKey = resolvedKey,
-        flowDisplayKey = displayKey,
-      ) => {
+      const startA2AFlow = (roundOneReply?: string, waitRunId?: string) => {
         if (skipA2AFlow) {
           return;
         }
         void runSessionsSendA2AFlow({
-          targetSessionKey: flowTargetSessionKey,
-          displayKey: flowDisplayKey,
+          targetSessionKey: resolvedKey,
+          displayKey,
           message,
           announceTimeoutMs,
           maxPingPongTurns,
@@ -656,7 +624,7 @@ export function createSessionsSendTool(opts?: {
         }
         runId = start.runId;
         if (!start.activeRunQueue) {
-          startA2AFlow(undefined, runId, start.a2aSessionKey, start.a2aDisplayKey);
+          startA2AFlow(undefined, runId);
         }
         return jsonResult({
           runId,


### PR DESCRIPTION
## Summary

- When `sessions_send` targets a run-scoped session key (`agent:…:run:<id>`) and the active embedded-run queue rejects the message, `startAgentRun` previously launched a fresh `gateway("agent", …)` call targeting the **durable parent session** and returned `a2aSessionKey` to route the A2A flow there
- This fallback is unsafe: the parent session may already be running a new cron iteration or processing another turn; injecting a gateway agent run + A2A ping-pong into it corrupts the transcript and produces duplicate deliveries over `webchat`/`unknown` routes (four deliveries per send observed in the attached issue log)
- Fix: when the queue rejects, throw the `formatEmbeddedAgentQueueFailureSummary` string immediately; the outer `try/catch` converts it to `{ ok: false, result: { status: "error" } }` — clean, no fallback, caller-visible error
- Cleanup in the same change: `fallbackSessionKey` renamed to `isRunScopedKey` (boolean — the string was already dead), `startA2AFlow` closure drops two now-unused optional params (`flowTargetSessionKey`/`flowDisplayKey`), return type drops `a2aSessionKey?`/`a2aDisplayKey?`

## Real behavior proof

**Behavior addressed:** `sessions_send` to a run-scoped target whose active-run queue rejects the message silently starts a new agent run on the durable parent session, triggering the A2A flow against the wrong session and producing duplicate/corrupted deliveries.

**Real environment tested:** Source inspection + local test harness (Linux, Node 24, Vitest 4.1.7). Live cron queue-rejection repro requires a running gateway, confirmed source-reproducible by ClawSweeper at `a4f7e4cbb946`.

**Exact steps or command run after this patch:**
```
node scripts/run-vitest.mjs src/agents/openclaw-tools.sessions.test.ts src/agents/tools/sessions-send-tool.a2a.test.ts src/agents/tools/sessions-send-helpers.test.ts
```

**Evidence after fix:** 30 + 12 + 13 = 55 tests pass; autoreview clean (0.97 confidence); `git diff --numstat`: prod -32/+12 net, tests -73/+17 net.

**Observed result after fix:** `sessions_send` to a run-scoped session whose queue rejects returns `{ status: "error", error: "queue_message_failed reason=<reason> …" }` immediately. No gateway `agent` call is made against the parent session; no A2A flow fires; no transcript corruption.

**What was not tested:** Live cron gateway E2E with a real rejected queue (requires running gateway + cron config); requires Crabbox for full proof.

## Reproduction

1. Configure a cron agent with a run-scoped session key (`agent:…:cron:…:run:<id>`)
2. A second agent calls `sessions_send` targeting that run-scoped key with `timeoutSeconds: 0`
3. The active embedded run's queue rejects (e.g. `not_streaming`, `runtime_rejected`)

**Before this PR:** `startAgentRun` launches a new gateway agent run on the durable parent key and returns `a2aSessionKey = durableKey`; A2A flow pings both requester and parent sessions; parent transcript gets injected messages; next parent turn fails with "provider rejected the request schema or tool payload"; single `sessions_send` can produce 4+ deliveries.

**After this PR:** `startAgentRun` throws the queue failure summary; caller receives `{ status: "error" }`; no gateway call, no A2A flow, no transcript mutation.

## Risk / Mitigation

- **Risk:** Callers that previously relied on the fallback as a "deliver anyway" path will now receive `status: "error"`. No docs or SDK contract describes this fallback as guaranteed behavior (ClawSweeper confirmed: docs say reply-back loop, not durable-session fallback on rejection).
- **Mitigation:** The `transcript_commit_wait_unsupported` retry path (lines 245–253) is preserved; only the post-rejection fallback is gone. Normal non-run-scoped `sessions_send` is unaffected (takes the `gateway("agent", …)` path at line 261).

### Change Type (select all)

- [x] fix
- [x] refactor (no behavior change for non-run-scoped sessions)

### Scope (select all touched areas)

- [x] agents
- [x] sessions_send tool
- [x] tests

### Linked Issue/PR

Fixes #91420