### PR TITLE
fix(agents): guard malformed tool-search bridge names

### DIFF
--- a/src/agents/tool-display-common.ts
+++ b/src/agents/tool-display-common.ts
@@ -409,6 +409,16 @@ function normalizeToolSearchDisplayToolName(toolName: string | undefined): strin
   return normalizeOptionalString(catalogIdMatch?.[1]) ?? value;
 }
 
+function isMalformedCompoundToolName(toolName: string | undefined): boolean {
+  const value = normalizeOptionalString(toolName);
+  if (!value) {
+    return false;
+  }
+  // Reject stitched snake_case tool names like apply_patch.list_mcp_resources.
+  // Real dotted OpenClaw tools such as config.apply should still pass through.
+  return /^[a-z0-9]+(?:_[a-z0-9]+)+(?:\.[a-z0-9]+(?:_[a-z0-9]+)+)+$/i.test(value);
+}
+
 function collectToolSearchDescribeBindings(code: string): Map<string, string> {
   const bindings = new Map<string, string>();
   const bindingPattern =
@@ -595,7 +605,7 @@ export function resolveToolSearchCodeDisplayTarget(
   const call = parseToolSearchCall(code);
   if (call) {
     const toolName = resolveToolSearchCallTarget(code, call.target);
-    if (!toolName) {
+    if (!toolName || isMalformedCompoundToolName(toolName)) {
       return { toolName: "tool_search_code", detail: "call selected tool", bridgeVerb: "call" };
     }
     return {

--- a/src/agents/tool-display.test.ts
+++ b/src/agents/tool-display.test.ts
@@ -49,6 +49,32 @@ describe("tool display details", () => {
     });
   });
 
+  it("does not project malformed compound tool names from bridge code", () => {
+    expect(
+      resolveToolSearchCodeDisplayTarget({
+        code: 'return await openclaw.tools.call("apply_patch.list_mcp_resources", { path: "x" });',
+      }),
+    ).toEqual({
+      toolName: "tool_search_code",
+      detail: "call selected tool",
+      bridgeVerb: "call",
+    });
+  });
+
+  it("keeps legitimate dotted tool names when they are real tool ids", () => {
+    expect(
+      resolveToolSearchCodeDisplayTarget({
+        code: 'return await openclaw.tools.call("config.apply", { path: "/tmp/openclaw.json" });',
+      }),
+    ).toEqual({
+      toolName: "config.apply",
+      displayToolName: "config.apply",
+      displayArgs: { path: "/tmp/openclaw.json" },
+      detail: undefined,
+      bridgeVerb: "call",
+    });
+  });
+
   it("skips zero/false values for optional detail fields", () => {
     const detail = formatToolDetail(
       resolveToolDisplay({


### PR DESCRIPTION
## Summary
- stop `tool_search_code` projection from surfacing malformed stitched tool names like `apply_patch.list_mcp_resources`
- add regression coverage that preserves legitimate dotted tool ids such as `config.apply`
- document the related Valkyrie watcher/daily-memory remediation in the PR body because that workspace change lives outside this repo

## Problem
An interrupted OpenClaw/Codex turn surfaced the synthetic label `Apply Patch.list Mcp Resources failed`. Investigation showed the scary string was not a real tool pair; it was a malformed projected tool name coming out of the bridge display path. That made the failure summary misleading and complicated incident triage.

## Changes
- add a guard that rejects stitched snake_case compound names during `tool_search_code` display projection
- fall back to the bridge identity (`tool_search_code`) when the projected name is malformed
- keep real dotted tool ids intact

## Verification
- `node scripts/run-vitest.mjs run src/agents/tool-display.test.ts`

## Related operational note
Separately, Valkyrie's workspace documentation was updated locally to document watcher guardrails around daily memory files and a missing `memory/YYYY-MM-DD.md` baseline note was created. That operational documentation is not part of this repo.
