### PR TITLE
chore(deps): Wave 2 non-native upgrades (commander 15, acp-sdk 0.25, aimock 1.29)

### DIFF
--- a/extensions/browser/package.json
+++ b/extensions/browser/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.29.0",
-    "commander": "14.0.3",
+    "commander": "15.0.0",
     "express": "5.2.1",
     "playwright-core": "1.60.0",
     "typebox": "1.1.39",

--- a/extensions/google-meet/npm-shrinkwrap.json
+++ b/extensions/google-meet/npm-shrinkwrap.json
@@ -8,7 +8,7 @@
       "name": "@openclaw/google-meet",
       "version": "2026.6.2",
       "dependencies": {
-        "commander": "14.0.3",
+        "commander": "15.0.0",
         "typebox": "1.1.39"
       },
       "peerDependencies": {
@@ -21,12 +21,12 @@
       }
     },
     "node_modules/commander": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/typebox": {

--- a/extensions/google-meet/package.json
+++ b/extensions/google-meet/package.json
@@ -8,7 +8,7 @@
   },
   "type": "module",
   "dependencies": {
-    "commander": "14.0.3",
+    "commander": "15.0.0",
     "typebox": "1.1.39"
   },
   "devDependencies": {

--- a/extensions/oc-path/package.json
+++ b/extensions/oc-path/package.json
@@ -5,7 +5,7 @@
   "description": "OpenClaw oc:// workspace path plugin",
   "type": "module",
   "dependencies": {
-    "commander": "14.0.3",
+    "commander": "15.0.0",
     "jsonc-parser": "3.3.1",
     "markdown-it": "14.2.0",
     "yaml": "2.9.0"

--- a/extensions/qa-lab/package.json
+++ b/extensions/qa-lab/package.json
@@ -5,7 +5,7 @@
   "description": "OpenClaw QA lab plugin with private debugger UI and scenario runner",
   "type": "module",
   "dependencies": {
-    "@copilotkit/aimock": "1.27.3",
+    "@copilotkit/aimock": "1.29.0",
     "@modelcontextprotocol/sdk": "1.29.0",
     "playwright-core": "1.60.0",
     "yaml": "2.9.0",

--- a/extensions/voice-call/npm-shrinkwrap.json
+++ b/extensions/voice-call/npm-shrinkwrap.json
@@ -8,7 +8,7 @@
       "name": "@openclaw/voice-call",
       "version": "2026.6.2",
       "dependencies": {
-        "commander": "14.0.3",
+        "commander": "15.0.0",
         "typebox": "1.1.39",
         "ws": "8.21.0",
         "zod": "4.4.3"
@@ -23,12 +23,12 @@
       }
     },
     "node_modules/commander": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/typebox": {

--- a/extensions/voice-call/package.json
+++ b/extensions/voice-call/package.json
@@ -8,7 +8,7 @@
   },
   "type": "module",
   "dependencies": {
-    "commander": "14.0.3",
+    "commander": "15.0.0",
     "typebox": "1.1.39",
     "ws": "8.21.0",
     "zod": "4.4.3"

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@agentclientprotocol/sdk": "0.22.1",
+        "@agentclientprotocol/sdk": "0.25.0",
         "@anthropic-ai/sdk": "0.100.1",
         "@clack/core": "1.3.1",
         "@clack/prompts": "1.4.0",
@@ -28,7 +28,7 @@
         "chalk": "5.6.2",
         "chokidar": "5.0.0",
         "clawpdf": "0.3.0",
-        "commander": "14.0.3",
+        "commander": "15.0.0",
         "croner": "10.0.1",
         "cross-spawn": "7.0.6",
         "diff": "9.0.0",
@@ -77,9 +77,9 @@
       }
     },
     "node_modules/@agentclientprotocol/sdk": {
-      "version": "0.22.1",
-      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-0.22.1.tgz",
-      "integrity": "sha512-DfqXtl/8gO9NImq094MTaCXEU2vkhh6v7q/kT+9UjZxUqj8hYaya2OjLVIqn16MzNHcXEpShTR2RIauLSYeDQQ==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-0.25.0.tgz",
+      "integrity": "sha512-wU1VgXNtMvdVotX49txc3WJUDV+/QbLpsgjMvFhlRmp37osdLbI7L7y+iwAlQATwfjLxcv1r1p3ZxZBcXlGhcQ==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
@@ -818,12 +818,12 @@
       "license": "MIT"
     },
     "node_modules/commander": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/content-disposition": {

--- a/package.json
+++ b/package.json
@@ -1864,7 +1864,7 @@
     "verify": "node scripts/verify.mjs"
   },
   "dependencies": {
-    "@agentclientprotocol/sdk": "0.22.1",
+    "@agentclientprotocol/sdk": "0.25.0",
     "@anthropic-ai/sdk": "0.100.1",
     "@clack/core": "1.3.1",
     "@clack/prompts": "1.4.0",
@@ -1882,7 +1882,7 @@
     "chalk": "5.6.2",
     "chokidar": "5.0.0",
     "clawpdf": "0.3.0",
-    "commander": "14.0.3",
+    "commander": "15.0.0",
     "croner": "10.0.1",
     "cross-spawn": "7.0.6",
     "diff": "9.0.0",
@@ -1922,7 +1922,7 @@
   },
   "devDependencies": {
     "@a2ui/lit": "0.10.0",
-    "@copilotkit/aimock": "1.27.3",
+    "@copilotkit/aimock": "1.29.0",
     "@grammyjs/types": "3.27.3",
     "@lit-labs/signals": "0.3.0",
     "@lit/context": "1.1.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,8 +43,8 @@ importers:
   .:
     dependencies:
       '@agentclientprotocol/sdk':
-        specifier: 0.22.1
-        version: 0.22.1(zod@4.4.3)
+        specifier: 0.25.0
+        version: 0.25.0(zod@4.4.3)
       '@anthropic-ai/sdk':
         specifier: 0.100.1
         version: 0.100.1(zod@4.4.3)
@@ -97,8 +97,8 @@ importers:
         specifier: 0.3.0
         version: 0.3.0
       commander:
-        specifier: 14.0.3
-        version: 14.0.3
+        specifier: 15.0.0
+        version: 15.0.0
       croner:
         specifier: 10.0.1
         version: 10.0.1
@@ -212,8 +212,8 @@ importers:
         specifier: 0.10.0
         version: 0.10.0(signal-polyfill@0.2.2)
       '@copilotkit/aimock':
-        specifier: 1.27.3
-        version: 1.27.3(vitest@4.1.7)
+        specifier: 1.29.0
+        version: 1.29.0(vitest@4.1.7)
       '@grammyjs/types':
         specifier: 3.27.3
         version: 3.27.3
@@ -425,8 +425,8 @@ importers:
         specifier: 1.29.0
         version: 1.29.0(zod@4.4.3)
       commander:
-        specifier: 14.0.3
-        version: 14.0.3
+        specifier: 15.0.0
+        version: 15.0.0
       express:
         specifier: 5.2.1
         version: 5.2.1
@@ -812,8 +812,8 @@ importers:
   extensions/google-meet:
     dependencies:
       commander:
-        specifier: 14.0.3
-        version: 14.0.3
+        specifier: 15.0.0
+        version: 15.0.0
       typebox:
         specifier: 1.1.39
         version: 1.1.39
@@ -1190,8 +1190,8 @@ importers:
   extensions/oc-path:
     dependencies:
       commander:
-        specifier: 14.0.3
-        version: 14.0.3
+        specifier: 15.0.0
+        version: 15.0.0
       jsonc-parser:
         specifier: 3.3.1
         version: 3.3.1
@@ -1316,8 +1316,8 @@ importers:
   extensions/qa-lab:
     dependencies:
       '@copilotkit/aimock':
-        specifier: 1.27.3
-        version: 1.27.3(vitest@4.1.7)
+        specifier: 1.29.0
+        version: 1.29.0(vitest@4.1.7)
       '@modelcontextprotocol/sdk':
         specifier: 1.29.0
         version: 1.29.0(zod@4.4.3)
@@ -1628,8 +1628,8 @@ importers:
   extensions/voice-call:
     dependencies:
       commander:
-        specifier: 14.0.3
-        version: 14.0.3
+        specifier: 15.0.0
+        version: 15.0.0
       typebox:
         specifier: 1.1.39
         version: 1.1.39
@@ -1965,6 +1965,11 @@ packages:
 
   '@agentclientprotocol/sdk@0.22.1':
     resolution: {integrity: sha512-DfqXtl/8gO9NImq094MTaCXEU2vkhh6v7q/kT+9UjZxUqj8hYaya2OjLVIqn16MzNHcXEpShTR2RIauLSYeDQQ==}
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+
+  '@agentclientprotocol/sdk@0.25.0':
+    resolution: {integrity: sha512-wU1VgXNtMvdVotX49txc3WJUDV+/QbLpsgjMvFhlRmp37osdLbI7L7y+iwAlQATwfjLxcv1r1p3ZxZBcXlGhcQ==}
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
@@ -2357,9 +2362,9 @@ packages:
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
 
-  '@copilotkit/aimock@1.27.3':
-    resolution: {integrity: sha512-ttpU7ykV/j0+VIVA7Zb1fiDSH8ScQQ31ui/5ot824+MVnHEvyzZWl9Kbe3Tij3Agknyo7pL7/lK6omZlO2mkCg==}
-    engines: {node: '>=24.0.0'}
+  '@copilotkit/aimock@1.29.0':
+    resolution: {integrity: sha512-xNMHMUDX7zPSc56dm2ZXbttoLk6x72oEBHwWCAakVWNO85zZepLkB8Poc/x1cJrY69FI9frN0gavI/zVuZq/9A==}
+    engines: {node: '>=20.15.0'}
     hasBin: true
     peerDependencies:
       jest: '>=29'
@@ -4697,6 +4702,10 @@ packages:
   commander@14.0.3:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
     engines: {node: '>=20'}
+
+  commander@15.0.0:
+    resolution: {integrity: sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==}
+    engines: {node: '>=22.12.0'}
 
   commander@5.1.0:
     resolution: {integrity: sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==}
@@ -7323,6 +7332,10 @@ snapshots:
     dependencies:
       zod: 4.4.3
 
+  '@agentclientprotocol/sdk@0.25.0(zod@4.4.3)':
+    dependencies:
+      zod: 4.4.3
+
   '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.156':
     optional: true
 
@@ -7971,7 +7984,7 @@ snapshots:
   '@colors/colors@1.5.0':
     optional: true
 
-  '@copilotkit/aimock@1.27.3(vitest@4.1.7)':
+  '@copilotkit/aimock@1.29.0(vitest@4.1.7)':
     optionalDependencies:
       vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(jsdom@29.1.1(@noble/hashes@2.0.1))(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
 
@@ -10248,6 +10261,8 @@ snapshots:
       typical: 7.3.0
 
   commander@14.0.3: {}
+
+  commander@15.0.0: {}
 
   commander@5.1.0: {}
 


### PR DESCRIPTION
## Summary

Wave 2 (non-native) dependency upgrades, part of a wave-by-wave campaign. Pure version bumps; no source changes.

- `commander` 14.0.3 → 15.0.0 — root + 4 extensions (browser, google-meet, voice-call, oc-path)
- `@agentclientprotocol/sdk` 0.22.1 → 0.25.0 — root
- `@copilotkit/aimock` 1.27.3 → 1.29.0 — root + `extensions/qa-lab`
- Regenerated `pnpm-lock.yaml` and the publishable npm shrinkwraps (root + `google-meet` + `voice-call`).

### commander 15 notes
v15 is ESM-only (`engines.node >=22.12`; repo requires `>=22.19` and is fully ESM). Breaking change [#2405](https://github.com/tj/commander.js/pull/2405): a **lone** `--no-*` option still defaults to `true`; when **both** `--x` and `--no-x` are declared with no explicit default, the value is no longer implicitly set. In this repo the positive `--x` is always declared before `--no-x`, so v14 already produced `undefined` when neither flag was passed — v15 changes nothing here. Every both-declared handler (cron-edit/add, onboard, mcp `update`, qa-lab mantis) gates on `typeof opts.x === "boolean"`, so undefined-when-unset is the correct, unchanged behavior. Lone `--no-output-timeout-seconds <n>` yields the boolean `true` default when absent under both v14 and v15; its handlers only read it when `typeof` is string/number.

### acp-sdk 0.22→0.25 notes
0.24.0 removed the unstable model selectors and stabilized `deleteSession`/`logout`/`additionalDirectories`. `src/acp/**` depends on no removed `unstable_*` export (the only reference asserts `unstable_listSessions` is absent). No stable-API breaks.

## Verification
- `pnpm test src/cli/cron-cli`: 33 passed (primary commander-15 gate — both-declared option pairs)
- `pnpm test src/acp`: 52 passed (3 failures were pre-existing Windows `EBUSY` sqlite-temp-file flakes, not regressions)
- `pnpm tsgo:prod`: clean
- `pnpm build`: clean, no `[INEFFECTIVE_DYNAMIC_IMPORT]`
- `pnpm deps:shrinkwrap:check`: pass

CI truth is Linux Node 24; the above was run locally on Windows (corepack pnpm 11.2.2). Reviewed across three independent model lenses before opening.
