### PR TITLE
docs(compaction): warn that compaction.model breaks native compaction on claude-cli/OAuth

### DIFF
--- a/docs/concepts/compaction.md
+++ b/docs/concepts/compaction.md
@@ -117,8 +117,12 @@ way, so the session cannot recover until you fix the model.
 
 On `claude-cli`/OAuth sessions, leave `compaction.model` unset so OpenClaw defers
 to the backend's native compaction. If you must override, point it at a provider
-that has its own configured credentials — for example `anthropic-api/<model>`
-with an API key, or a local `ollama/<model>`. See
+that has its own standalone credentials configured. Note that on a claude-cli
+setup the built-in `anthropic` provider is typically bound to the same OAuth
+profile and carries no separate API key, so a bare `anthropic/<model>` will not
+work. Configure a dedicated provider entry with an Anthropic API key and
+reference it as `<your-provider-id>/<model>`, or use a local `ollama/<model>`
+(which needs no key). See
 [Native compaction ownership](/gateway/cli-backends#native-compaction-ownership).
 </Warning>
 

--- a/docs/concepts/compaction.md
+++ b/docs/concepts/compaction.md
@@ -92,6 +92,36 @@ This works with local models too, for example a second Ollama model dedicated to
 
 When unset, compaction starts with the active session model. If summarization fails with a model-fallback-eligible provider error, OpenClaw retries that compaction attempt through the session's existing model fallback chain. The fallback choice is temporary and is not written back to session state. An explicit `agents.defaults.compaction.model` override remains exact and does not inherit the session fallback chain.
 
+<Warning>
+On CLI backends that own their compaction — for example `claude-cli`, which
+compacts internally — OpenClaw normally **defers** compaction to the backend.
+Setting `agents.defaults.compaction.model` overrides that deferral and forces
+OpenClaw's in-process summarizer to run with the model you name.
+
+If that model's provider has no standalone credentials in your setup, every
+compaction attempt fails. A common case: the session authenticates through the
+`claude-cli` OAuth profile, but `compaction.model` points at a bare
+`anthropic/<model>` that expects a separate Anthropic API key. The attempt fails
+with `No_credentials_found_for_profile_anthropic:claude-cli` in the gateway log,
+and because an explicit override does not inherit the session fallback chain
+(see above), nothing compacts.
+
+The chat sees nothing until the context finally overflows, at which point the
+turn fails with a generic notice:
+
+> ⚠️ Context is too large and auto-compaction could not recover this turn. Try
+> again, use /compact, or use /new to start a fresh session.
+
+The suggested `/compact` runs through the same broken override and fails the same
+way, so the session cannot recover until you fix the model.
+
+On `claude-cli`/OAuth sessions, leave `compaction.model` unset so OpenClaw defers
+to the backend's native compaction. If you must override, point it at a provider
+that has its own configured credentials — for example `anthropic-api/<model>`
+with an API key, or a local `ollama/<model>`. See
+[Native compaction ownership](/gateway/cli-backends#native-compaction-ownership).
+</Warning>
+
 ### Identifier preservation
 
 Compaction summarization preserves opaque identifiers by default (`identifierPolicy: "strict"`). Override with `identifierPolicy: "off"` to disable, or `identifierPolicy: "custom"` plus `identifierInstructions` for custom guidance.


### PR DESCRIPTION
## Summary

The Compaction docs present `agents.defaults.compaction.model` as a safe "use a more
capable model for summaries" knob. On CLI backends that own native compaction (e.g.
`claude-cli`), it is a footgun: the override cancels the backend deferral and forces
OpenClaw's in-process summarizer. If the named provider has no standalone credentials,
**every compaction attempt fails**, and the session only breaks once context overflows —
behind a generic message that hides the real cause.

- Adds a `<Warning>` to `docs/concepts/compaction.md` (§ "Using a different model") covering
  the failure mode, the visible symptom, why `/compact` does not recover, and the fix.
- Cross-links the existing
  [Native compaction ownership](/gateway/cli-backends#native-compaction-ownership) section.
- Docs-only, one file, +30/-0.

Out of scope: no runtime/code change. The deferral and override semantics are unchanged and
already documented on the CLI-backends page; this only surfaces the warning where users make
the risky choice.

## Linked context

No issue to close — this documents an existing configuration footgun. Not requested by a
maintainer.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: On a `claude-cli`/OAuth session, setting
  `agents.defaults.compaction.model` to a provider without standalone credentials makes every
  auto-compaction attempt fail; the user only sees a generic overflow notice and `/compact`
  cannot recover.
- Real environment tested: OpenClaw 2026.6.1 (2e08f0f), `claude-cli` backend authenticated
  via OAuth profile `anthropic:claude-cli`, Telegram channel, Fedora Linux.
- Exact steps or command run after this patch: (1) set `agents.defaults.compaction.model` to
  a bare `anthropic/claude-haiku-4-5-...` model, restart the gateway, drive a session past its
  context budget; (2) remove it with `openclaw config unset agents.defaults.compaction.model`,
  restart, repeat. (Docs-only change — these steps reproduce the behavior the new warning
  describes.)
- Evidence after fix (redacted runtime logs):
  - With override — `[compaction-diag] ... provider=anthropic/claude-haiku-4-5-20251001 attempt=1 maxAttempts=1 outcome=failed detail=No_credentials_found_for_profile_anthropic:claude-cli`
  - Chat received only — `⚠️ Context is too large and auto-compaction could not recover this turn. Try again, use /compact, or use /new to start a fresh session.`
  - After `config unset` + restart — `[agents/cli-compaction] CLI backend "claude-cli" owns native compaction — deferring to backend`
- Observed result after fix: with the override, compaction failed on every attempt and the
  session only failed at overflow with the generic message; with the override removed,
  OpenClaw defers to the backend's native compaction and the session recovers. This matches
  the documented warning.
- What was not tested: did not run the Mintlify docs link-check locally; did not test
  non-`claude-cli` backends or `anthropic` API-key (non-OAuth) setups.
- Proof limitations or environment constraints: docs-only PR, so there is no executable patch
  to run; the evidence is from the author's live OpenClaw instance, not CI. Log lines are
  redacted of session keys and user ids.
- Before evidence: the `No_credentials_found_for_profile_anthropic:claude-cli` log line above
  is the broken (misconfigured) state.

## Tests and validation

- Commands run: reproduced the behavior on a live instance (see proof). No automated tests
  apply to a docs-only change.
- Regression coverage: n/a (docs).
- What failed before: n/a — there was no prior doc text on this footgun.

## AI-assisted

Drafted with Claude Code (Opus 4.8). The behavior and log evidence are from my own live
OpenClaw instance; I reproduced and confirmed both the failure mode and the fix before opening
this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
