### PR TITLE
fix(agents): classify embedded prompt lock-changed error as permanent announce failure (fixes #91527)

### DIFF
--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -3991,7 +3991,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       internalEvents: [
         {
           type: "task_completion",
-          source: "child_session",
+          source: "subagent",
           childSessionKey: "child:task-lock-changed",
           childSessionId: "task-lock-changed",
           announceType: "child task",

--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -3968,6 +3968,52 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     );
   });
 
+  it("treats embedded prompt lock-changed error as permanent during completion delivery", async () => {
+    const callGateway = vi.fn(async () => {
+      throw new Error(
+        "session file changed while embedded prompt lock was released: /tmp/session.jsonl",
+      );
+    }) as unknown as typeof runtimeCallGateway;
+    const queueEmbeddedAgentMessageWithOutcome = createQueueOutcomeSequenceMock([
+      "transcript_commit_wait_unsupported",
+      "no_active_run",
+    ]);
+    const sendMessage = createSendMessageMock();
+    const result = await deliverSlackChannelAnnouncement({
+      callGateway,
+      sendMessage,
+      queueEmbeddedAgentMessageWithOutcome,
+      sessionId: "requester-session-text-lock-changed",
+      isActive: true,
+      expectsCompletionMessage: true,
+      directIdempotencyKey: "announce-text-lock-changed",
+      sourceTool: "sessions_spawn",
+      internalEvents: [
+        {
+          type: "task_completion",
+          source: "child_session",
+          childSessionKey: "child:task-lock-changed",
+          childSessionId: "task-lock-changed",
+          announceType: "child task",
+          taskLabel: "lock changed task",
+          status: "ok",
+          statusLabel: "completed successfully",
+          result: "Task completed: summary output.",
+          replyInstruction: "Tell the user the task is done.",
+        },
+      ],
+    });
+
+    expectRecordFields(result, {
+      delivered: false,
+      path: "direct",
+      error: expect.stringContaining(
+        "session file changed while embedded prompt lock was released",
+      ),
+    });
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
   it("keeps generic requester handoff errors visible after active wake failure", async () => {
     const callGateway = vi.fn(async () => {
       throw new Error("requester handoff exploded after dispatch");

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -378,6 +378,7 @@ const PERMANENT_ANNOUNCE_DELIVERY_ERROR_PATTERNS: readonly RegExp[] = [
   /forbidden: bot was kicked/i,
   /recipient is not a valid/i,
   /outbound not configured for channel/i,
+  /session file changed while embedded prompt lock was released/i,
 ];
 
 function isTransientAnnounceDeliveryError(error: unknown): boolean {


### PR DESCRIPTION
### Summary

- **Problem**: Subagent completion announcements produce 3× duplicate Telegram messages when the transcript mirror fails with `EmbeddedPromptLockFileChangedError` after a successful outbound send.
- **Root Cause**: `PERMANENT_ANNOUNCE_DELIVERY_ERROR_PATTERNS` in `subagent-announce-delivery.ts` does not include the lock-changed error, so the announce retry loop classifies it as retriable and re-sends the completion up to `maxAnnounceRetryCount` times.
- **Fix**: Add `/session file changed while embedded prompt lock was released/i` to `PERMANENT_ANNOUNCE_DELIVERY_ERROR_PATTERNS` so the error is treated as terminal, matching the pattern established by PR #89812 in the general outbound delivery path.
- **What changed**:
  - `src/agents/subagent-announce-delivery.ts` — added one regex pattern to the permanent error array
- **What did NOT change (scope boundary)**:
  - The general outbound delivery retry path (already fixed by #89812 in `src/infra/outbound/deliver.ts`)
  - Retry budget, backoff, or lifecycle accounting (unchanged)
  - Channel-specific delivery logic (unchanged)

### Reproduction

1. From a parent session, call `sessions_spawn(taskName="...", mode="run")` with a long-running subagent task
2. Parent calls `sessions_yield` to wait for the auto-announce
3. The parent session is concurrently modified by deferred turn maintenance while the subagent completion attempts to mirror to the transcript
4. The transcript mirror throws `EmbeddedPromptLockFileChangedError`
5. **Before this PR**: The announce retry loop fires 3 times, each retry independently triggering an outbound send → user receives 3 identical messages
6. **After this PR**: The lock-changed error is classified as permanent, preventing retry → user receives exactly 1 message

### Real behavior proof

**Behavior or issue addressed (#91527)**: When a subagent completion has already been sent to the external channel but the transcript mirror fails with `EmbeddedPromptLockFileChangedError`, the announce delivery layer now treats the error as terminal instead of retrying, preventing duplicate message delivery.

**Real environment tested**: Linux, Node 22 — `deliverSlackChannelAnnouncement` exercised through the completion delivery path with Gateway and channel send mocks

**Exact steps or command run after this patch**: `node scripts/run-vitest.mjs src/agents/subagent-announce-delivery.test.ts src/agents/subagent-announce-dispatch.test.ts src/agents/subagent-registry-lifecycle.test.ts`

**Evidence after fix**:
```text
✓ src/agents/subagent-announce-delivery.test.ts (98 tests)
✓ src/agents/subagent-announce-dispatch.test.ts (22 tests)  
✓ src/agents/subagent-registry-lifecycle.test.ts (19 tests)
Test Files  3 passed (3)
Tests  139 passed (139)
```

**Observed result after fix**: The new test case "treats embedded prompt lock-changed error as permanent during completion delivery" verifies that when `callGateway` throws the lock-changed error during a text completion delivery, the result correctly has `delivered: false` with the error message preserved, and `sendMessage` is never called — confirming no duplicate outbound send.

**What was not tested**: Live Telegram end-to-end delivery with concurrent session modifications was not driven; the fix was validated at the announce delivery unit level with mocked Gateway and channel sends, matching the existing test patterns in the file.

**Repro confirmation**: The new test case throws the exact error message from the reporter's logs (`session file changed while embedded prompt lock was released: /tmp/session.jsonl`) and confirms the result is `delivered: false` with no `sendMessage` call — on origin/main without this patch, the same error would have been classified as retriable and the announce lifecycle would have retried up to 3 times.

### Risk / Mitigation

- **Risk**: Classifying the lock-changed error as permanent means the subagent completion will not be retried if the transcript mirror fails, potentially losing the completion from the session transcript.
  **Mitigation**: The outbound message has already been sent successfully before the mirror failure (`[telegram] outbound send ok` appears in logs before the error). The user still receives the completion — only the transcript archival is skipped, and the next turn will naturally include the context.

- **Risk**: The regex pattern may match unrelated errors containing the same substring.
  **Mitigation**: The error message is specific (`session file changed while embedded prompt lock was released`) and produced by a single code path in `EmbeddedPromptLockFileChangedError`. The existing permanent patterns in the same array use similar specificity (e.g., `/unsupported channel/i`, `/chat not found/i`).

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] agents — subagent announce delivery and error classification

### Regression Test Plan

- `node scripts/run-vitest.mjs src/agents/subagent-announce-delivery.test.ts`
- `node scripts/run-vitest.mjs src/agents/subagent-announce-dispatch.test.ts`
- `node scripts/run-vitest.mjs src/agents/subagent-registry-lifecycle.test.ts`

### Review Findings Addressed

N/A (initial submission)

### Linked Issue/PR

Fixes #91527
