### PR TITLE
fix(docs): continue partial i18n batches after file errors

### DIFF
--- a/extensions/microsoft-foundry/onboard.ts
+++ b/extensions/microsoft-foundry/onboard.ts
@@ -212,7 +212,7 @@ export async function selectFoundryDeployment(
     })),
   });
   const selected =
-    supported.find((deployment) => deployment.name === selectedDeploymentName) ?? supported[0]!;
+    supported.find((deployment) => deployment.name === selectedDeploymentName) ?? supported[0];
   return { selected, supported };
 }
 

--- a/scripts/docs-i18n/main.go
+++ b/scripts/docs-i18n/main.go
@@ -136,7 +136,7 @@ func runDocsI18N(ctx context.Context, cfg runConfig, files []string, newTranslat
 	switch cfg.mode {
 	case "doc":
 		if parallel > 1 {
-			proc, skip, outputs, err := runDocParallel(ctx, ordered, resolvedDocsRoot, cfg.sourceLang, cfg.targetLang, cfg.overwrite, parallel, glossary, cfg.thinking, newTranslator)
+			proc, skip, outputs, err := runDocParallel(ctx, ordered, resolvedDocsRoot, cfg.sourceLang, cfg.targetLang, cfg.overwrite, cfg.allowPartial, parallel, glossary, cfg.thinking, newTranslator)
 			processed += proc
 			skipped += skip
 			localizedFiles = append(localizedFiles, outputs...)
@@ -149,7 +149,7 @@ func runDocsI18N(ctx context.Context, cfg runConfig, files []string, newTranslat
 				return err
 			}
 			defer translator.Close()
-			proc, skip, outputs, err := runDocSequential(ctx, ordered, translator, resolvedDocsRoot, cfg.sourceLang, cfg.targetLang, cfg.overwrite)
+			proc, skip, outputs, err := runDocSequential(ctx, ordered, translator, resolvedDocsRoot, cfg.sourceLang, cfg.targetLang, cfg.overwrite, cfg.allowPartial)
 			processed += proc
 			skipped += skip
 			localizedFiles = append(localizedFiles, outputs...)
@@ -191,17 +191,25 @@ func runDocsI18N(ctx context.Context, cfg runConfig, files []string, newTranslat
 	return translationErr
 }
 
-func runDocSequential(ctx context.Context, ordered []string, translator docsTranslator, docsRoot, srcLang, tgtLang string, overwrite bool) (int, int, []string, error) {
+func runDocSequential(ctx context.Context, ordered []string, translator docsTranslator, docsRoot, srcLang, tgtLang string, overwrite, allowPartial bool) (int, int, []string, error) {
 	processed := 0
 	skipped := 0
 	outputs := []string{}
+	var firstErr error
 	for index, file := range ordered {
 		relPath := resolveRelPath(docsRoot, file)
 		log.Printf("docs-i18n: [%d/%d] start %s", index+1, len(ordered), relPath)
 		start := time.Now()
 		skip, outputPath, err := processFileDoc(ctx, translator, docsRoot, file, srcLang, tgtLang, overwrite)
 		if err != nil {
-			return processed, skipped, outputs, err
+			if shouldStopDocRun(ctx, allowPartial) {
+				return processed, skipped, outputs, err
+			}
+			if firstErr == nil {
+				firstErr = err
+			}
+			log.Printf("docs-i18n: [%d/%d] failed %s (%s): %v", index+1, len(ordered), relPath, time.Since(start).Round(time.Millisecond), err)
+			continue
 		}
 		if skip {
 			skipped++
@@ -212,10 +220,10 @@ func runDocSequential(ctx context.Context, ordered []string, translator docsTran
 			log.Printf("docs-i18n: [%d/%d] done %s (%s)", index+1, len(ordered), relPath, time.Since(start).Round(time.Millisecond))
 		}
 	}
-	return processed, skipped, outputs, nil
+	return processed, skipped, outputs, firstErr
 }
 
-func runDocParallel(ctx context.Context, ordered []string, docsRoot, srcLang, tgtLang string, overwrite bool, parallel int, glossary []GlossaryEntry, thinking string, newTranslator docsTranslatorFactory) (int, int, []string, error) {
+func runDocParallel(ctx context.Context, ordered []string, docsRoot, srcLang, tgtLang string, overwrite, allowPartial bool, parallel int, glossary []GlossaryEntry, thinking string, newTranslator docsTranslatorFactory) (int, int, []string, error) {
 	jobs := make(chan docJob)
 	results := make(chan docResult, len(ordered))
 	ctx, cancel := context.WithCancel(ctx)
@@ -247,7 +255,7 @@ func runDocParallel(ctx context.Context, ordered []string, docsRoot, srcLang, tg
 					skipped:  skip,
 					err:      err,
 				}
-				if err != nil {
+				if err != nil && shouldStopDocRun(ctx, allowPartial) {
 					cancel()
 					return
 				}
@@ -283,6 +291,8 @@ func runDocParallel(ctx context.Context, ordered []string, docsRoot, srcLang, tg
 		if result.skipped {
 			skipped++
 			log.Printf("docs-i18n: [w* %d/%d] skipped %s (%s)", result.index, len(ordered), result.rel, result.duration.Round(time.Millisecond))
+		} else if result.err != nil {
+			log.Printf("docs-i18n: [w* %d/%d] failed %s (%s): %v", result.index, len(ordered), result.rel, result.duration.Round(time.Millisecond), result.err)
 		} else if result.err == nil {
 			processed++
 			outputs = append(outputs, result.output)
@@ -290,6 +300,13 @@ func runDocParallel(ctx context.Context, ordered []string, docsRoot, srcLang, tg
 		}
 	}
 	return processed, skipped, outputs, firstErr
+}
+
+func shouldStopDocRun(ctx context.Context, allowPartial bool) bool {
+	if !allowPartial {
+		return true
+	}
+	return ctx.Err() != nil
 }
 
 func runSegmentSequential(ctx context.Context, ordered []string, translator docsTranslator, tm *TranslationMemory, docsRoot, srcLang, tgtLang string) (int, []string, error) {

--- a/scripts/docs-i18n/main.go
+++ b/scripts/docs-i18n/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"log"
@@ -185,6 +186,9 @@ func runDocsI18N(ctx context.Context, cfg runConfig, files []string, newTranslat
 	elapsed := time.Since(start).Round(time.Millisecond)
 	log.Printf("docs-i18n: completed processed=%d skipped=%d elapsed=%s", processed, skipped, elapsed)
 	if translationErr != nil && cfg.allowPartial && cfg.mode == "doc" && processed > 0 {
+		if ctx.Err() != nil || errors.Is(translationErr, context.Canceled) || errors.Is(translationErr, context.DeadlineExceeded) {
+			return translationErr
+		}
 		log.Printf("docs-i18n: allowing partial doc output after translation error: %v", translationErr)
 		return nil
 	}

--- a/scripts/docs-i18n/main.go
+++ b/scripts/docs-i18n/main.go
@@ -206,7 +206,7 @@ func runDocSequential(ctx context.Context, ordered []string, translator docsTran
 		start := time.Now()
 		skip, outputPath, err := processFileDoc(ctx, translator, docsRoot, file, srcLang, tgtLang, overwrite)
 		if err != nil {
-			if shouldStopDocRun(ctx, allowPartial) {
+			if shouldStopDocRun(ctx, err, allowPartial) {
 				return processed, skipped, outputs, err
 			}
 			if firstErr == nil {
@@ -259,7 +259,7 @@ func runDocParallel(ctx context.Context, ordered []string, docsRoot, srcLang, tg
 					skipped:  skip,
 					err:      err,
 				}
-				if err != nil && shouldStopDocRun(ctx, allowPartial) {
+				if err != nil && shouldStopDocRun(ctx, err, allowPartial) {
 					cancel()
 					return
 				}
@@ -306,11 +306,11 @@ func runDocParallel(ctx context.Context, ordered []string, docsRoot, srcLang, tg
 	return processed, skipped, outputs, firstErr
 }
 
-func shouldStopDocRun(ctx context.Context, allowPartial bool) bool {
+func shouldStopDocRun(ctx context.Context, err error, allowPartial bool) bool {
 	if !allowPartial {
 		return true
 	}
-	return ctx.Err() != nil
+	return ctx.Err() != nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
 }
 
 func runSegmentSequential(ctx context.Context, ordered []string, translator docsTranslator, tm *TranslationMemory, docsRoot, srcLang, tgtLang string) (int, []string, error) {

--- a/scripts/docs-i18n/main_test.go
+++ b/scripts/docs-i18n/main_test.go
@@ -126,6 +126,31 @@ func (cancelAwareTranslator) TranslateRaw(ctx context.Context, text, _, _ string
 
 func (cancelAwareTranslator) Close() {}
 
+type cancelAfterFirstDocTranslator struct {
+	cancel context.CancelFunc
+	calls  int
+}
+
+func (t *cancelAfterFirstDocTranslator) Translate(ctx context.Context, text, _, _ string) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	return text, nil
+}
+
+func (t *cancelAfterFirstDocTranslator) TranslateRaw(ctx context.Context, text, _, _ string) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	t.calls++
+	if t.calls == 1 {
+		t.cancel()
+	}
+	return text, nil
+}
+
+func (t *cancelAfterFirstDocTranslator) Close() {}
+
 func TestRunDocsI18NRewritesFinalLocalizedPageLinks(t *testing.T) {
 	t.Parallel()
 
@@ -310,6 +335,41 @@ func TestRunDocsI18NAllowPartialStopsAfterRunCancellation(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected canceled run to fail even with allowPartial=true")
+	}
+	if _, err := os.Stat(filepath.Join(docsRoot, "zh-CN", "zzz-second.md")); err == nil {
+		t.Fatal("did not expect later output to be written after run cancellation")
+	}
+}
+
+func TestRunDocsI18NAllowPartialReturnsCancellationAfterPartialSuccess(t *testing.T) {
+	t.Parallel()
+
+	docsRoot := t.TempDir()
+	writeFile(t, filepath.Join(docsRoot, ".i18n", "glossary.zh-CN.json"), "[]")
+	writeFile(t, filepath.Join(docsRoot, "docs.json"), `{"redirects":[]}`)
+	firstPath := filepath.Join(docsRoot, "aaa-first.md")
+	secondPath := filepath.Join(docsRoot, "zzz-second.md")
+	writeFile(t, firstPath, "# Gateway\n")
+	writeFile(t, secondPath, "# Gateway\n")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	err := runDocsI18N(ctx, runConfig{
+		targetLang:   "zh-CN",
+		sourceLang:   "en",
+		docsRoot:     docsRoot,
+		mode:         "doc",
+		thinking:     "high",
+		overwrite:    true,
+		allowPartial: true,
+		parallel:     1,
+	}, []string{firstPath, secondPath}, func(_, _ string, _ []GlossaryEntry, _ string) (docsTranslator, error) {
+		return &cancelAfterFirstDocTranslator{cancel: cancel}, nil
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected canceled run after partial success, got %v", err)
+	}
+	if got := mustReadFile(t, filepath.Join(docsRoot, "zh-CN", "aaa-first.md")); !strings.Contains(got, "# Gateway") {
+		t.Fatalf("expected first output to be written before cancellation, got:\n%s", got)
 	}
 	if _, err := os.Stat(filepath.Join(docsRoot, "zh-CN", "zzz-second.md")); err == nil {
 		t.Fatal("did not expect later output to be written after run cancellation")

--- a/scripts/docs-i18n/main_test.go
+++ b/scripts/docs-i18n/main_test.go
@@ -126,6 +126,24 @@ func (cancelAwareTranslator) TranslateRaw(ctx context.Context, text, _, _ string
 
 func (cancelAwareTranslator) Close() {}
 
+type contextErrorTranslator struct{}
+
+func (contextErrorTranslator) Translate(_ context.Context, text, _, _ string) (string, error) {
+	if strings.Contains(text, "CANCEL") {
+		return "", context.Canceled
+	}
+	return text, nil
+}
+
+func (contextErrorTranslator) TranslateRaw(_ context.Context, text, _, _ string) (string, error) {
+	if strings.Contains(text, "CANCEL") {
+		return "", context.Canceled
+	}
+	return text, nil
+}
+
+func (contextErrorTranslator) Close() {}
+
 type cancelAfterFirstDocTranslator struct {
 	cancel context.CancelFunc
 	calls  int
@@ -373,6 +391,42 @@ func TestRunDocsI18NAllowPartialReturnsCancellationAfterPartialSuccess(t *testin
 	}
 	if _, err := os.Stat(filepath.Join(docsRoot, "zh-CN", "zzz-second.md")); err == nil {
 		t.Fatal("did not expect later output to be written after run cancellation")
+	}
+}
+
+func TestRunDocsI18NAllowPartialStopsAfterContextError(t *testing.T) {
+	t.Parallel()
+
+	docsRoot := t.TempDir()
+	writeFile(t, filepath.Join(docsRoot, ".i18n", "glossary.zh-CN.json"), "[]")
+	writeFile(t, filepath.Join(docsRoot, "docs.json"), `{"redirects":[]}`)
+	firstPath := filepath.Join(docsRoot, "aaa-first.md")
+	cancelPath := filepath.Join(docsRoot, "bbb-cancel.md")
+	laterPath := filepath.Join(docsRoot, "zzz-later.md")
+	writeFile(t, firstPath, "# Gateway\n")
+	writeFile(t, cancelPath, "# CANCEL\n")
+	writeFile(t, laterPath, "# Gateway\n")
+
+	err := runDocsI18N(context.Background(), runConfig{
+		targetLang:   "zh-CN",
+		sourceLang:   "en",
+		docsRoot:     docsRoot,
+		mode:         "doc",
+		thinking:     "high",
+		overwrite:    true,
+		allowPartial: true,
+		parallel:     1,
+	}, []string{firstPath, cancelPath, laterPath}, func(_, _ string, _ []GlossaryEntry, _ string) (docsTranslator, error) {
+		return contextErrorTranslator{}, nil
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected cancellation error to remain terminal, got %v", err)
+	}
+	if got := mustReadFile(t, filepath.Join(docsRoot, "zh-CN", "aaa-first.md")); !strings.Contains(got, "# Gateway") {
+		t.Fatalf("expected first output to be written before cancellation, got:\n%s", got)
+	}
+	if _, err := os.Stat(filepath.Join(docsRoot, "zh-CN", "zzz-later.md")); err == nil {
+		t.Fatal("did not expect later output to be written after context error")
 	}
 }
 

--- a/scripts/docs-i18n/main_test.go
+++ b/scripts/docs-i18n/main_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 type fakeDocsTranslator struct{}
@@ -81,6 +82,50 @@ func (partialFailTranslator) TranslateRaw(_ context.Context, text, _, _ string) 
 
 func (partialFailTranslator) Close() {}
 
+type partialFailSlowTranslator struct{}
+
+func (partialFailSlowTranslator) Translate(ctx context.Context, text, srcLang, tgtLang string) (string, error) {
+	if strings.Contains(text, "SLOW") {
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+	return partialFailTranslator{}.Translate(ctx, text, srcLang, tgtLang)
+}
+
+func (partialFailSlowTranslator) TranslateRaw(ctx context.Context, text, srcLang, tgtLang string) (string, error) {
+	if strings.Contains(text, "SLOW") {
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+	return partialFailTranslator{}.TranslateRaw(ctx, text, srcLang, tgtLang)
+}
+
+func (partialFailSlowTranslator) Close() {}
+
+type cancelAwareTranslator struct{}
+
+func (cancelAwareTranslator) Translate(ctx context.Context, text, _, _ string) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	return text, nil
+}
+
+func (cancelAwareTranslator) TranslateRaw(ctx context.Context, text, _, _ string) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	return text, nil
+}
+
+func (cancelAwareTranslator) Close() {}
+
 func TestRunDocsI18NRewritesFinalLocalizedPageLinks(t *testing.T) {
 	t.Parallel()
 
@@ -131,7 +176,7 @@ func TestRunDocsI18NRewritesFinalLocalizedPageLinks(t *testing.T) {
 	}
 }
 
-func TestRunDocsI18NAllowPartialKeepsSuccessfulDocOutputs(t *testing.T) {
+func TestRunDocsI18NAllowPartialKeepsEarlierSuccessfulDocOutputs(t *testing.T) {
 	t.Parallel()
 
 	docsRoot := t.TempDir()
@@ -162,6 +207,109 @@ func TestRunDocsI18NAllowPartialKeepsSuccessfulDocOutputs(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(docsRoot, "zh-CN", "zzz-fail.md")); err == nil {
 		t.Fatal("did not expect failed output to be written")
+	}
+}
+
+func TestRunDocsI18NAllowPartialContinuesAfterFailedDoc(t *testing.T) {
+	t.Parallel()
+
+	docsRoot := t.TempDir()
+	writeFile(t, filepath.Join(docsRoot, ".i18n", "glossary.zh-CN.json"), "[]")
+	writeFile(t, filepath.Join(docsRoot, "docs.json"), `{"redirects":[]}`)
+	failPath := filepath.Join(docsRoot, "aaa-fail.md")
+	okPath := filepath.Join(docsRoot, "zzz-ok.md")
+	writeFile(t, failPath, "# FAIL\n")
+	writeFile(t, okPath, "# Gateway\n")
+
+	err := runDocsI18N(context.Background(), runConfig{
+		targetLang:   "zh-CN",
+		sourceLang:   "en",
+		docsRoot:     docsRoot,
+		mode:         "doc",
+		thinking:     "high",
+		overwrite:    true,
+		allowPartial: true,
+		parallel:     1,
+	}, []string{failPath, okPath}, func(_, _ string, _ []GlossaryEntry, _ string) (docsTranslator, error) {
+		return partialFailTranslator{}, nil
+	})
+	if err != nil {
+		t.Fatalf("runDocsI18N failed despite later partial output: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(docsRoot, "zh-CN", "aaa-fail.md")); err == nil {
+		t.Fatal("did not expect failed output to be written")
+	}
+	if got := mustReadFile(t, filepath.Join(docsRoot, "zh-CN", "zzz-ok.md")); !strings.Contains(got, "# Gateway") {
+		t.Fatalf("expected later successful output to be written, got:\n%s", got)
+	}
+}
+
+func TestRunDocsI18NAllowPartialParallelKeepsQueuedDocsAfterFailure(t *testing.T) {
+	t.Parallel()
+
+	docsRoot := t.TempDir()
+	writeFile(t, filepath.Join(docsRoot, ".i18n", "glossary.zh-CN.json"), "[]")
+	writeFile(t, filepath.Join(docsRoot, "docs.json"), `{"redirects":[]}`)
+	failPath := filepath.Join(docsRoot, "aaa-fail.md")
+	slowPath := filepath.Join(docsRoot, "bbb-slow.md")
+	okPath := filepath.Join(docsRoot, "zzz-ok.md")
+	writeFile(t, failPath, "# FAIL\n")
+	writeFile(t, slowPath, "# SLOW\n")
+	writeFile(t, okPath, "# Gateway\n")
+
+	err := runDocsI18N(context.Background(), runConfig{
+		targetLang:   "zh-CN",
+		sourceLang:   "en",
+		docsRoot:     docsRoot,
+		mode:         "doc",
+		thinking:     "high",
+		overwrite:    true,
+		allowPartial: true,
+		parallel:     2,
+	}, []string{failPath, slowPath, okPath}, func(_, _ string, _ []GlossaryEntry, _ string) (docsTranslator, error) {
+		return partialFailSlowTranslator{}, nil
+	})
+	if err != nil {
+		t.Fatalf("runDocsI18N failed despite later parallel output: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(docsRoot, "zh-CN", "aaa-fail.md")); err == nil {
+		t.Fatal("did not expect failed output to be written")
+	}
+	if got := mustReadFile(t, filepath.Join(docsRoot, "zh-CN", "zzz-ok.md")); !strings.Contains(got, "# Gateway") {
+		t.Fatalf("expected queued output to be written after a failed doc, got:\n%s", got)
+	}
+}
+
+func TestRunDocsI18NAllowPartialStopsAfterRunCancellation(t *testing.T) {
+	t.Parallel()
+
+	docsRoot := t.TempDir()
+	writeFile(t, filepath.Join(docsRoot, ".i18n", "glossary.zh-CN.json"), "[]")
+	writeFile(t, filepath.Join(docsRoot, "docs.json"), `{"redirects":[]}`)
+	firstPath := filepath.Join(docsRoot, "aaa-first.md")
+	secondPath := filepath.Join(docsRoot, "zzz-second.md")
+	writeFile(t, firstPath, "# Gateway\n")
+	writeFile(t, secondPath, "# Gateway\n")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := runDocsI18N(ctx, runConfig{
+		targetLang:   "zh-CN",
+		sourceLang:   "en",
+		docsRoot:     docsRoot,
+		mode:         "doc",
+		thinking:     "high",
+		overwrite:    true,
+		allowPartial: true,
+		parallel:     1,
+	}, []string{firstPath, secondPath}, func(_, _ string, _ []GlossaryEntry, _ string) (docsTranslator, error) {
+		return cancelAwareTranslator{}, nil
+	})
+	if err == nil {
+		t.Fatal("expected canceled run to fail even with allowPartial=true")
+	}
+	if _, err := os.Stat(filepath.Join(docsRoot, "zh-CN", "zzz-second.md")); err == nil {
+		t.Fatal("did not expect later output to be written after run cancellation")
 	}
 }
 

--- a/scripts/docs-i18n/main_test.go
+++ b/scripts/docs-i18n/main_test.go
@@ -275,6 +275,9 @@ func TestRunDocsI18NAllowPartialParallelKeepsQueuedDocsAfterFailure(t *testing.T
 	if _, err := os.Stat(filepath.Join(docsRoot, "zh-CN", "aaa-fail.md")); err == nil {
 		t.Fatal("did not expect failed output to be written")
 	}
+	if got := mustReadFile(t, filepath.Join(docsRoot, "zh-CN", "bbb-slow.md")); !strings.Contains(got, "# SLOW") {
+		t.Fatalf("expected in-flight output to be written after a failed doc, got:\n%s", got)
+	}
 	if got := mustReadFile(t, filepath.Join(docsRoot, "zh-CN", "zzz-ok.md")); !strings.Contains(got, "# Gateway") {
 		t.Fatalf("expected queued output to be written after a failed doc, got:\n%s", got)
 	}


### PR DESCRIPTION
## Summary

- Fix doc-mode `--allow-partial` so a per-file translation failure does not cancel the remaining docs queue.
- Keep the failed file unwritten, continue writing later successful localized docs, and preserve fail-fast behavior when `--allow-partial` is disabled.
- Preserve run-cancellation semantics: if the run context is canceled, `--allow-partial` still stops instead of continuing through the rest of the queue.

## Root Cause

`--allow-partial` only allowed already-written outputs to survive a later error. If a body translation failed early in the ordered docs list, sequential mode returned immediately and parallel mode canceled the worker context, so unrelated later docs never had a chance to regenerate.

This matches the recent docs CI symptom: Translate All run https://github.com/openclaw/docs/actions/runs/27182895507 used the frontmatter fallback fix from #91578, then zh-CN hit `body translate failed for agent-runtime-architecture.md`, finished with `processed=0`, and never reached `channels/line.md`. The publish repo therefore kept the stale localized LINE page even though the glossary and source sync were current.

## Verification

- Temporarily reverted the implementation change while keeping the new tests; the new allow-partial continuation tests failed on the old behavior with `processed=0`.
- `cd scripts/docs-i18n && go test . -count=1 -run 'TestRunDocsI18NAllowPartial|TestRunDocsI18NRewritesLineTitle'`
- `cd scripts/docs-i18n && go test . -count=1`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local` clean after fixing the cancellation finding
