### PR TITLE
[codex] Fix CLI plugin install hook bootstrap

### DIFF
--- a/src/cli/command-bootstrap.test.ts
+++ b/src/cli/command-bootstrap.test.ts
@@ -99,6 +99,21 @@ describe("ensureCliCommandBootstrap", () => {
     });
   });
 
+  it("allows recovery installs to tolerate configured plugin load failures", async () => {
+    await ensureCliCommandBootstrap({
+      runtime: {} as never,
+      commandPath: ["plugins", "install"],
+      loadPlugins: true,
+      throwOnPluginLoadError: false,
+    });
+
+    expect(ensureCliPluginRegistryLoadedMock).toHaveBeenCalledWith({
+      scope: "all",
+      routeLogsToStderr: undefined,
+      throwOnLoadError: false,
+    });
+  });
+
   it("does nothing extra when plugin loading is disabled", async () => {
     await ensureCliCommandBootstrap({
       runtime: {} as never,

--- a/src/cli/command-bootstrap.ts
+++ b/src/cli/command-bootstrap.ts
@@ -19,6 +19,7 @@ export async function ensureCliCommandBootstrap(params: {
   skipConfigGuard?: boolean;
   allowInvalid?: boolean;
   loadPlugins?: boolean;
+  throwOnPluginLoadError?: boolean;
   pluginRegistry?: CliPluginRegistryPolicy;
 }) {
   if (!params.skipConfigGuard) {
@@ -38,5 +39,8 @@ export async function ensureCliCommandBootstrap(params: {
   await ensureCliPluginRegistryLoaded({
     scope: pluginRegistryLoadPolicy.scope,
     routeLogsToStderr: params.suppressDoctorStdout,
+    ...(params.throwOnPluginLoadError !== undefined
+      ? { throwOnLoadError: params.throwOnPluginLoadError }
+      : {}),
   });
 }

--- a/src/cli/command-catalog.ts
+++ b/src/cli/command-catalog.ts
@@ -322,6 +322,11 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
     policy: { hideBanner: true },
   },
   {
+    commandPath: ["plugins", "install"],
+    exact: true,
+    policy: { loadPlugins: "always" },
+  },
+  {
     commandPath: ["plugins", "list"],
     exact: true,
     policy: { ensureCliPath: false, loadPlugins: "never", networkProxy: "bypass" },

--- a/src/cli/command-execution-startup.test.ts
+++ b/src/cli/command-execution-startup.test.ts
@@ -213,6 +213,7 @@ describe("command-execution-startup", () => {
       },
       allowInvalid: true,
       loadPlugins: true,
+      throwOnPluginLoadError: false,
     });
 
     expect(ensureCliCommandBootstrapMock).toHaveBeenLastCalledWith({
@@ -221,6 +222,7 @@ describe("command-execution-startup", () => {
       suppressDoctorStdout: false,
       allowInvalid: true,
       loadPlugins: true,
+      throwOnPluginLoadError: false,
       pluginRegistry: { scope: "all" },
       skipConfigGuard: false,
     });

--- a/src/cli/command-execution-startup.test.ts
+++ b/src/cli/command-execution-startup.test.ts
@@ -111,6 +111,21 @@ describe("command-execution-startup", () => {
     ).toBe(true);
   });
 
+  it("loads plugins for cli plugin installs", () => {
+    expect(
+      mod.resolveCliExecutionStartupContext({
+        argv: ["node", "openclaw", "plugins", "install", "@acme/demo"],
+        jsonOutputMode: false,
+      }).startupPolicy,
+    ).toEqual({
+      suppressDoctorStdout: false,
+      hideBanner: false,
+      skipConfigGuard: false,
+      loadPlugins: true,
+      pluginRegistry: { scope: "all" },
+    });
+  });
+
   it("routes logs to stderr and emits banner only when allowed", async () => {
     await mod.applyCliExecutionStartupPresentation({
       startupPolicy: {

--- a/src/cli/command-execution-startup.ts
+++ b/src/cli/command-execution-startup.ts
@@ -66,6 +66,7 @@ export async function ensureCliExecutionBootstrap(params: {
   startupPolicy: CliStartupPolicy;
   allowInvalid?: boolean;
   loadPlugins?: boolean;
+  throwOnPluginLoadError?: boolean;
   skipConfigGuard?: boolean;
 }) {
   await ensureCliCommandBootstrap({
@@ -74,6 +75,7 @@ export async function ensureCliExecutionBootstrap(params: {
     suppressDoctorStdout: params.startupPolicy.suppressDoctorStdout,
     allowInvalid: params.allowInvalid,
     loadPlugins: params.loadPlugins ?? params.startupPolicy.loadPlugins,
+    throwOnPluginLoadError: params.throwOnPluginLoadError,
     pluginRegistry: params.startupPolicy.pluginRegistry,
     skipConfigGuard: params.skipConfigGuard ?? params.startupPolicy.skipConfigGuard,
   });

--- a/src/cli/command-path-policy.test.ts
+++ b/src/cli/command-path-policy.test.ts
@@ -222,6 +222,9 @@ describe("command-path-policy", () => {
       loadPlugins: "never",
       networkProxy: "bypass",
     });
+    expectResolvedPolicy(["plugins", "install"], {
+      loadPlugins: "always",
+    });
     for (const commandPath of [["tasks"], ["tasks", "list"], ["tasks", "audit"]]) {
       expectResolvedPolicy(commandPath, {
         ensureCliPath: false,
@@ -230,7 +233,6 @@ describe("command-path-policy", () => {
       });
     }
     for (const commandPath of [
-      ["plugins", "install"],
       ["plugins", "inspect"],
       ["plugins", "registry"],
       ["plugins", "doctor"],

--- a/src/cli/plugin-registry-loader.test.ts
+++ b/src/cli/plugin-registry-loader.test.ts
@@ -76,6 +76,18 @@ describe("plugin-registry-loader", () => {
     });
   });
 
+  it("forwards explicit plugin load failure policy overrides", async () => {
+    await ensureCliPluginRegistryLoaded({
+      scope: "all",
+      throwOnLoadError: false,
+    });
+
+    expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledWith({
+      scope: "all",
+      throwOnLoadError: false,
+    });
+  });
+
   it("forwards configured-channel load scope without startup dependency repair", async () => {
     await ensureCliPluginRegistryLoaded({
       scope: "configured-channels",

--- a/src/cli/plugin-registry-loader.ts
+++ b/src/cli/plugin-registry-loader.ts
@@ -19,6 +19,7 @@ export type CliPluginRegistryLoadPolicy = {
 export async function ensureCliPluginRegistryLoaded(params: {
   scope: CliPluginRegistryScope;
   routeLogsToStderr?: boolean;
+  throwOnLoadError?: boolean;
   config?: OpenClawConfig;
   activationSourceConfig?: OpenClawConfig;
 }) {
@@ -30,6 +31,9 @@ export async function ensureCliPluginRegistryLoaded(params: {
   try {
     ensurePluginRegistryLoaded({
       scope: params.scope,
+      ...(params.throwOnLoadError !== undefined
+        ? { throwOnLoadError: params.throwOnLoadError }
+        : {}),
       ...(params.config ? { config: params.config } : {}),
       ...(params.activationSourceConfig
         ? { activationSourceConfig: params.activationSourceConfig }

--- a/src/cli/plugin-registry.test.ts
+++ b/src/cli/plugin-registry.test.ts
@@ -325,6 +325,33 @@ describe("ensurePluginRegistryLoaded", () => {
     });
   });
 
+  it("can keep recovery installs off the fail-fast plugin load path", () => {
+    const config = {
+      plugins: { enabled: true },
+      channels: { "demo-channel-a": { enabled: true } },
+    };
+
+    mocks.resolvePluginRuntimeLoadContext.mockReturnValue({
+      rawConfig: config,
+      config,
+      activationSourceConfig: config,
+      autoEnabledReasons: {},
+      workspaceDir: "/tmp/workspace",
+      env: process.env,
+      logger,
+    } as never);
+
+    ensurePluginRegistryLoaded({ scope: "all", throwOnLoadError: false });
+
+    expect(mocks.loadOpenClawPlugins).toHaveBeenCalledTimes(1);
+    expectLoadOpenClawPluginsCall(0, {
+      config,
+      onlyPluginIds: ["demo"],
+      throwOnLoadError: false,
+      workspaceDir: "/tmp/workspace",
+    });
+  });
+
   it("does not treat a tools-only pre-seeded registry as channel scope", () => {
     const config = {
       plugins: { enabled: true },

--- a/src/cli/program/preaction.test.ts
+++ b/src/cli/program/preaction.test.ts
@@ -252,6 +252,7 @@ describe("registerPreActionHooks", () => {
     });
     expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledWith({
       scope: "all",
+      throwOnLoadError: true,
     });
   });
 
@@ -268,6 +269,7 @@ describe("registerPreActionHooks", () => {
     });
     expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledWith({
       scope: "all",
+      throwOnLoadError: true,
     });
   });
 
@@ -361,6 +363,7 @@ describe("registerPreActionHooks", () => {
     });
     expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledWith({
       scope: "all",
+      throwOnLoadError: false,
     });
 
     vi.clearAllMocks();
@@ -376,6 +379,7 @@ describe("registerPreActionHooks", () => {
     });
     expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledWith({
       scope: "all",
+      throwOnLoadError: false,
     });
 
     vi.clearAllMocks();
@@ -391,6 +395,7 @@ describe("registerPreActionHooks", () => {
     });
     expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledWith({
       scope: "all",
+      throwOnLoadError: false,
     });
 
     vi.clearAllMocks();
@@ -405,6 +410,7 @@ describe("registerPreActionHooks", () => {
     });
     expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledWith({
       scope: "all",
+      throwOnLoadError: true,
     });
 
     vi.clearAllMocks();
@@ -420,6 +426,7 @@ describe("registerPreActionHooks", () => {
     });
     expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledWith({
       scope: "all",
+      throwOnLoadError: false,
     });
 
     vi.clearAllMocks();
@@ -442,6 +449,7 @@ describe("registerPreActionHooks", () => {
     });
     expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledWith({
       scope: "all",
+      throwOnLoadError: true,
     });
   });
 
@@ -607,6 +615,7 @@ describe("registerPreActionHooks", () => {
 
     expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledWith({
       scope: "configured-channels",
+      throwOnLoadError: true,
     });
     expect(stderrDuringPluginLoad).toBe(true);
     // Flag must be restored after plugin loading completes

--- a/src/cli/program/preaction.test.ts
+++ b/src/cli/program/preaction.test.ts
@@ -359,6 +359,9 @@ describe("registerPreActionHooks", () => {
       commandPath: ["plugins", "install"],
       allowInvalid: true,
     });
+    expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledWith({
+      scope: "all",
+    });
 
     vi.clearAllMocks();
     await runPreAction({
@@ -370,6 +373,9 @@ describe("registerPreActionHooks", () => {
       runtime: runtimeMock,
       commandPath: ["plugins", "install"],
       allowInvalid: true,
+    });
+    expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledWith({
+      scope: "all",
     });
 
     vi.clearAllMocks();
@@ -383,6 +389,9 @@ describe("registerPreActionHooks", () => {
       commandPath: ["plugins", "install"],
       allowInvalid: true,
     });
+    expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledWith({
+      scope: "all",
+    });
 
     vi.clearAllMocks();
     await runPreAction({
@@ -393,6 +402,9 @@ describe("registerPreActionHooks", () => {
     expect(ensureConfigReadyMock).toHaveBeenCalledWith({
       runtime: runtimeMock,
       commandPath: ["plugins", "install"],
+    });
+    expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledWith({
+      scope: "all",
     });
 
     vi.clearAllMocks();
@@ -405,6 +417,9 @@ describe("registerPreActionHooks", () => {
       runtime: runtimeMock,
       commandPath: ["plugins", "install"],
       allowInvalid: true,
+    });
+    expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledWith({
+      scope: "all",
     });
 
     vi.clearAllMocks();
@@ -424,6 +439,9 @@ describe("registerPreActionHooks", () => {
     expect(ensureConfigReadyMock).toHaveBeenCalledWith({
       runtime: runtimeMock,
       commandPath: ["plugins", "install"],
+    });
+    expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledWith({
+      scope: "all",
     });
   });
 

--- a/src/cli/program/preaction.ts
+++ b/src/cli/program/preaction.ts
@@ -32,15 +32,27 @@ function setProcessTitleForCommand(actionCommand: Command) {
   process.title = `${cliName}-${name}`;
 }
 
+function resolvePluginInstallPreactionPolicy(actionCommand: Command, commandPath: string[]) {
+  return resolvePluginInstallInvalidConfigPolicy(
+    resolvePluginInstallPreactionRequest({
+      actionCommand,
+      commandPath,
+      argv: process.argv,
+    }),
+  );
+}
+
 function shouldAllowInvalidConfigForAction(actionCommand: Command, commandPath: string[]): boolean {
   return (
-    resolvePluginInstallInvalidConfigPolicy(
-      resolvePluginInstallPreactionRequest({
-        actionCommand,
-        commandPath,
-        argv: process.argv,
-      }),
-    ) === "allow-plugin-recovery"
+    resolvePluginInstallPreactionPolicy(actionCommand, commandPath) === "allow-plugin-recovery"
+  );
+}
+
+function shouldThrowOnPluginLoadError(actionCommand: Command, commandPath: string[]): boolean {
+  // Recovery reinstalls need hook bootstrap, but a fail-fast registry load would
+  // abort the repair command before the install action can replace the bad plugin.
+  return (
+    resolvePluginInstallPreactionPolicy(actionCommand, commandPath) !== "allow-plugin-recovery"
   );
 }
 
@@ -135,6 +147,7 @@ export function registerPreActionHooks(program: Command, programVersion: string)
       commandPath,
       startupPolicy,
       allowInvalid: shouldAllowInvalidConfigForAction(actionCommand, commandPath),
+      throwOnPluginLoadError: shouldThrowOnPluginLoadError(actionCommand, commandPath),
       skipConfigGuard: shouldBypassConfigGuardForCommandPath(commandPath),
     });
   });

--- a/src/cli/program/register.subclis.test.ts
+++ b/src/cli/program/register.subclis.test.ts
@@ -244,7 +244,6 @@ describe("registerSubCliCommands", () => {
   it.each([
     ["plugins update", ["plugins", "update", "lossless-claw"]],
     ["plugins update --all", ["plugins", "update", "--all"]],
-    ["plugins install", ["plugins", "install", "lossless-claw"]],
     ["plugins list", ["plugins", "list"]],
     ["plugins inspect", ["plugins", "inspect", "lossless-claw"]],
     ["plugins registry --refresh", ["plugins", "registry", "--refresh"]],
@@ -258,6 +257,16 @@ describe("registerSubCliCommands", () => {
 
     expect(registerPluginsCli).toHaveBeenCalledTimes(1);
     expect(registerPluginCliCommandsFromValidatedConfig).not.toHaveBeenCalled();
+  });
+
+  it("preloads plugin CLI registrations for builtin plugins install", async () => {
+    process.argv = ["node", "openclaw", "plugins", "install", "lossless-claw"];
+    const program = new Command().name("openclaw");
+
+    await registerSubCliByName(program, "plugins");
+
+    expect(registerPluginsCli).toHaveBeenCalledTimes(1);
+    expect(registerPluginCliCommandsFromValidatedConfig).toHaveBeenCalledTimes(1);
   });
 
   it("does not preload plugin CLI registrations for bare plugin parent help", async () => {

--- a/src/plugins/runtime/runtime-registry-loader.ts
+++ b/src/plugins/runtime/runtime-registry-loader.ts
@@ -131,6 +131,7 @@ export function ensurePluginRegistryLoaded(options?: {
   workspaceDir?: string;
   onlyPluginIds?: string[];
   onlyChannelIds?: string[];
+  throwOnLoadError?: boolean;
 }): void {
   const scope = options?.scope ?? "all";
   const requestedPluginIdsFromOptions = normalizePluginIdScope(options?.onlyPluginIds);
@@ -213,7 +214,7 @@ export function ensurePluginRegistryLoaded(options?: {
       activationSourceConfig: scopedActivationSourceConfig,
     },
     {
-      throwOnLoadError: true,
+      throwOnLoadError: options?.throwOnLoadError ?? true,
       ...(hasExplicitPluginIdScope(requestedPluginIds) ||
       shouldForwardChannelScope({ scope, scopedLoad }) ||
       hasNonEmptyPluginIdScope(expectedPluginIds) ||


### PR DESCRIPTION
## Summary
- load plugins during `openclaw plugins install` CLI startup so the in-process hook runner is initialized before install scans run
- preserve the documented bundled-plugin recovery reinstall path by keeping that narrow CLI startup case off the fail-fast plugin-load path
- add CLI startup regression coverage for `plugins install` policy, bootstrap, registry loading, and preaction behavior

## Why
Fixes #91593.

`before_install` is a process-local hook runner contract. The CLI install path was still using the default `loadPlugins: "never"` policy, so `openclaw plugins install ...` skipped plugin registry bootstrap and never initialized the hook runner before install security scans. That bypassed plugin-enforced install policy on the common CLI path even though `/plugins install` in Gateway already honored it.

This revision also keeps the existing recovery contract intact: bundled or official plugins that explicitly opt into `openclaw.install.allowInvalidConfigRecovery` can still use `openclaw plugins install ...` as a repair path even if another configured plugin currently fails to load.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: `openclaw plugins install <path>` now loads configured plugins early enough for a registered `before_install` hook to observe and block the install on the CLI path, while the narrow documented recovery reinstall path stays bootstrappable.
- Real environment tested: Local OpenClaw CLI from this branch on macOS, using an isolated `OPENCLAW_STATE_DIR`/`OPENCLAW_CONFIG_PATH`, one temporary local policy plugin loaded through `plugins.load.paths`, and one temporary local native plugin used as the install target.
- Exact steps or command run after this patch:
  ```bash
  OPENCLAW_STATE_DIR="/tmp/openclaw-91593-proof-BWlRT6/state" \
  OPENCLAW_CONFIG_PATH="/tmp/openclaw-91593-proof-BWlRT6/state/openclaw.json" \
  node scripts/run-node.mjs plugins install "/tmp/openclaw-91593-proof-BWlRT6/target-plugin"
  ```
  The isolated config enabled a temporary `install-policy` plugin from `/tmp/openclaw-91593-proof-BWlRT6/policy-plugin` that registers `api.on("before_install", ...)` and returns `{ block: true, blockReason: "proof hook blocked proof-target" }` for the `proof-target` plugin id.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):
  ```text
  OpenClaw 2026.6.2 (9ce5ec9)
  Your task has been queued; your dignity has been deprecated.

  Plugin manifest id "proof-target" differs from npm package name "proof-target-package"; using manifest id as the config key.
  WARNING: Plugin "proof-target" installation blocked by plugin hook: proof hook blocked proof-target
  proof hook blocked proof-target
  Also not a valid hook pack: Error: package.json missing openclaw.hooks
  ```
- Observed result after fix: The real CLI install command started successfully, loaded the configured policy plugin, invoked its `before_install` hook during `plugins install`, and blocked the target plugin with the hook's explicit `blockReason`. That demonstrates the CLI install path now initializes the in-process hook runner before install security scans run.
- What was not tested: Gateway `/plugins install` behavior, npm/ClawHub/git install sources, and a pre-fix live binary run.
- Proof limitations or environment constraints: The live proof above exercises the real CLI install path and real plugin loading, but it is still one local isolated setup. Recovery compatibility for invalid-config reinstalls is covered here by focused regression tests rather than a second copied live transcript because the source-checkout launcher in this workspace currently lacks a ready `dist/entry` build and `run-node.mjs` re-enters a heavyweight local build path before CLI execution.
- Before evidence (optional but encouraged): Before this patch, the CLI startup policy for `plugins install` still resolved `loadPlugins: "never"`, and the added regression tests failed because preaction never initialized the plugin registry for this command.

## Tests and validation

Which commands did you run?

- `node scripts/run-vitest.mjs src/cli/command-bootstrap.test.ts src/cli/command-execution-startup.test.ts src/cli/plugin-registry-loader.test.ts src/cli/plugin-registry.test.ts src/cli/program/preaction.test.ts`
- `node scripts/run-vitest.mjs src/cli/command-path-policy.test.ts src/cli/command-execution-startup.test.ts src/cli/command-bootstrap.test.ts src/cli/plugin-registry-loader.test.ts src/cli/plugin-registry.test.ts src/cli/program/preaction.test.ts`
- `OPENCLAW_STATE_DIR="/tmp/openclaw-91593-proof-BWlRT6/state" OPENCLAW_CONFIG_PATH="/tmp/openclaw-91593-proof-BWlRT6/state/openclaw.json" node scripts/run-node.mjs plugins install "/tmp/openclaw-91593-proof-BWlRT6/target-plugin"`

What regression coverage was added or updated?

- `src/cli/command-path-policy.test.ts`
- `src/cli/command-bootstrap.test.ts`
- `src/cli/command-execution-startup.test.ts`
- `src/cli/plugin-registry-loader.test.ts`
- `src/cli/plugin-registry.test.ts`
- `src/cli/program/preaction.test.ts`

What failed before this fix, if known?

- `plugins install` stayed on the default CLI startup policy and skipped plugin bootstrap, so `before_install` hooks were not available on the CLI install path.
- With the first draft of the fix, the CLI startup path would also fail fast on configured plugin load errors before a documented bundled-plugin recovery reinstall could run.

If no test was added, why not?

- N/A; focused regression tests were added.
