### PR TITLE
fix(control-ui): wire ui.seamColor from bootstrap config to CSS variables

### DIFF
--- a/src/gateway/control-ui-contract.ts
+++ b/src/gateway/control-ui-contract.ts
@@ -20,4 +20,5 @@ export type ControlUiBootstrapConfig = {
   embedSandbox?: ControlUiEmbedSandboxMode;
   allowExternalEmbedUrls?: boolean;
   chatMessageMaxWidth?: string;
+  seamColor?: string;
 };

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -924,6 +924,7 @@ export async function handleControlUiHttpRequest(
             : "scripts",
       allowExternalEmbedUrls: config?.gateway?.controlUi?.allowExternalEmbedUrls === true,
       chatMessageMaxWidth: config?.gateway?.controlUi?.chatMessageMaxWidth,
+      seamColor: config?.ui?.seamColor,
     } satisfies ControlUiBootstrapConfig);
     return true;
   }

--- a/ui/src/ui/controllers/control-ui-bootstrap.test.ts
+++ b/ui/src/ui/controllers/control-ui-bootstrap.test.ts
@@ -68,6 +68,90 @@ describe("loadControlUiBootstrapConfig", () => {
     vi.unstubAllGlobals();
   });
 
+  it("applies seamColor from bootstrap to CSS custom properties", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        basePath: "",
+        assistantName: "Main",
+        assistantAvatar: "M",
+        assistantAgentId: "main",
+        serverVersion: "2026.4.27",
+        localMediaPreviewRoots: [],
+        embedSandbox: "scripts",
+        allowExternalEmbedUrls: false,
+        seamColor: "#00aaff",
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    const state = {
+      basePath: "",
+      assistantName: "Assistant",
+      assistantAvatar: null,
+      assistantAgentId: null,
+      localMediaPreviewRoots: [],
+      embedSandboxMode: "scripts" as const,
+      allowExternalEmbedUrls: false,
+      serverVersion: null,
+    };
+
+    await loadControlUiBootstrapConfig(state);
+
+    expect(state.seamColor).toBe("#00aaff");
+    const root = document.documentElement.style;
+    expect(root.getPropertyValue("--accent")).toBe("#00aaff");
+    expect(root.getPropertyValue("--accent-hover")).toBe("color-mix(in srgb, #00aaff, white 15%)");
+    expect(root.getPropertyValue("--accent-muted")).toBe("#00aaff");
+    expect(root.getPropertyValue("--accent-subtle")).toBe("rgba(0, 170, 255, 0.1)");
+    expect(root.getPropertyValue("--accent-glow")).toBe("rgba(0, 170, 255, 0.2)");
+    expect(root.getPropertyValue("--ring")).toBe("#00aaff");
+
+    vi.unstubAllGlobals();
+  });
+
+  it("removes seamColor CSS custom properties when bootstrap omits seamColor", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        basePath: "",
+        assistantName: "Main",
+        assistantAvatar: "M",
+        assistantAgentId: "main",
+        serverVersion: "2026.4.27",
+        localMediaPreviewRoots: [],
+        embedSandbox: "scripts",
+        allowExternalEmbedUrls: false,
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    // Pre-seed a prior seamColor so we can verify removal
+    document.documentElement.style.setProperty("--accent", "#00aaff");
+    document.documentElement.style.setProperty("--ring", "#00aaff");
+
+    const state = {
+      basePath: "",
+      assistantName: "Assistant",
+      assistantAvatar: null,
+      assistantAgentId: null,
+      localMediaPreviewRoots: [],
+      embedSandboxMode: "scripts" as const,
+      allowExternalEmbedUrls: false,
+      serverVersion: null,
+      seamColor: "#00aaff",
+    };
+
+    await loadControlUiBootstrapConfig(state);
+
+    expect(state.seamColor).toBeNull();
+    const root = document.documentElement.style;
+    expect(root.getPropertyValue("--accent")).toBe("");
+    expect(root.getPropertyValue("--ring")).toBe("");
+
+    vi.unstubAllGlobals();
+  });
+
   it("can refresh runtime bootstrap settings without clobbering session identity", async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,

--- a/ui/src/ui/controllers/control-ui-bootstrap.test.ts
+++ b/ui/src/ui/controllers/control-ui-bootstrap.test.ts
@@ -129,10 +129,18 @@ describe("loadControlUiBootstrapConfig", () => {
     vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
 
     // Pre-seed a prior seamColor so we can verify removal
-    document.documentElement.style.setProperty("--accent", "#00aaff");
-    document.documentElement.style.setProperty("--ring", "#00aaff");
-    document.documentElement.style.setProperty("--primary", "#00aaff");
-    document.documentElement.style.setProperty("--focus", "#00aaff");
+    for (const v of [
+      "--accent",
+      "--accent-hover",
+      "--accent-muted",
+      "--accent-subtle",
+      "--accent-glow",
+      "--ring",
+      "--primary",
+      "--focus",
+    ]) {
+      document.documentElement.style.setProperty(v, "#00aaff");
+    }
 
     const state = {
       basePath: "",
@@ -150,10 +158,18 @@ describe("loadControlUiBootstrapConfig", () => {
 
     expect(state.seamColor).toBeNull();
     const root = document.documentElement.style;
-    expect(root.getPropertyValue("--accent")).toBe("");
-    expect(root.getPropertyValue("--ring")).toBe("");
-    expect(root.getPropertyValue("--primary")).toBe("");
-    expect(root.getPropertyValue("--focus")).toBe("");
+    for (const v of [
+      "--accent",
+      "--accent-hover",
+      "--accent-muted",
+      "--accent-subtle",
+      "--accent-glow",
+      "--ring",
+      "--primary",
+      "--focus",
+    ]) {
+      expect(root.getPropertyValue(v)).toBe("");
+    }
 
     vi.unstubAllGlobals();
   });

--- a/ui/src/ui/controllers/control-ui-bootstrap.test.ts
+++ b/ui/src/ui/controllers/control-ui-bootstrap.test.ts
@@ -106,6 +106,8 @@ describe("loadControlUiBootstrapConfig", () => {
     expect(root.getPropertyValue("--accent-subtle")).toBe("rgba(0, 170, 255, 0.1)");
     expect(root.getPropertyValue("--accent-glow")).toBe("rgba(0, 170, 255, 0.2)");
     expect(root.getPropertyValue("--ring")).toBe("#00aaff");
+    expect(root.getPropertyValue("--primary")).toBe("#00aaff");
+    expect(root.getPropertyValue("--focus")).toBe("#00aaff");
 
     vi.unstubAllGlobals();
   });
@@ -129,6 +131,8 @@ describe("loadControlUiBootstrapConfig", () => {
     // Pre-seed a prior seamColor so we can verify removal
     document.documentElement.style.setProperty("--accent", "#00aaff");
     document.documentElement.style.setProperty("--ring", "#00aaff");
+    document.documentElement.style.setProperty("--primary", "#00aaff");
+    document.documentElement.style.setProperty("--focus", "#00aaff");
 
     const state = {
       basePath: "",
@@ -148,6 +152,8 @@ describe("loadControlUiBootstrapConfig", () => {
     const root = document.documentElement.style;
     expect(root.getPropertyValue("--accent")).toBe("");
     expect(root.getPropertyValue("--ring")).toBe("");
+    expect(root.getPropertyValue("--primary")).toBe("");
+    expect(root.getPropertyValue("--focus")).toBe("");
 
     vi.unstubAllGlobals();
   });
@@ -190,6 +196,8 @@ describe("loadControlUiBootstrapConfig", () => {
     expect(root.getPropertyValue("--accent-subtle")).toBe("rgba(0, 170, 255, 0.1)");
     expect(root.getPropertyValue("--accent-glow")).toBe("rgba(0, 170, 255, 0.2)");
     expect(root.getPropertyValue("--ring")).toBe("#00aaff");
+    expect(root.getPropertyValue("--primary")).toBe("#00aaff");
+    expect(root.getPropertyValue("--focus")).toBe("#00aaff");
 
     vi.unstubAllGlobals();
   });

--- a/ui/src/ui/controllers/control-ui-bootstrap.test.ts
+++ b/ui/src/ui/controllers/control-ui-bootstrap.test.ts
@@ -152,6 +152,48 @@ describe("loadControlUiBootstrapConfig", () => {
     vi.unstubAllGlobals();
   });
 
+  it("normalizes hashless hex seamColor to #RRGGBB form", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        basePath: "",
+        assistantName: "Main",
+        assistantAvatar: "M",
+        assistantAgentId: "main",
+        serverVersion: "2026.4.27",
+        localMediaPreviewRoots: [],
+        embedSandbox: "scripts",
+        allowExternalEmbedUrls: false,
+        seamColor: "00aaff",
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    const state = {
+      basePath: "",
+      assistantName: "Assistant",
+      assistantAvatar: null,
+      assistantAgentId: null,
+      localMediaPreviewRoots: [],
+      embedSandboxMode: "scripts" as const,
+      allowExternalEmbedUrls: false,
+      serverVersion: null,
+    };
+
+    await loadControlUiBootstrapConfig(state);
+
+    expect(state.seamColor).toBe("00aaff");
+    const root = document.documentElement.style;
+    expect(root.getPropertyValue("--accent")).toBe("#00aaff");
+    expect(root.getPropertyValue("--accent-hover")).toBe("color-mix(in srgb, #00aaff, white 15%)");
+    expect(root.getPropertyValue("--accent-muted")).toBe("#00aaff");
+    expect(root.getPropertyValue("--accent-subtle")).toBe("rgba(0, 170, 255, 0.1)");
+    expect(root.getPropertyValue("--accent-glow")).toBe("rgba(0, 170, 255, 0.2)");
+    expect(root.getPropertyValue("--ring")).toBe("#00aaff");
+
+    vi.unstubAllGlobals();
+  });
+
   it("can refresh runtime bootstrap settings without clobbering session identity", async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,

--- a/ui/src/ui/controllers/control-ui-bootstrap.test.ts
+++ b/ui/src/ui/controllers/control-ui-bootstrap.test.ts
@@ -94,6 +94,7 @@ describe("loadControlUiBootstrapConfig", () => {
       embedSandboxMode: "scripts" as const,
       allowExternalEmbedUrls: false,
       serverVersion: null,
+      seamColor: null,
     };
 
     await loadControlUiBootstrapConfig(state);
@@ -200,6 +201,7 @@ describe("loadControlUiBootstrapConfig", () => {
       embedSandboxMode: "scripts" as const,
       allowExternalEmbedUrls: false,
       serverVersion: null,
+      seamColor: null,
     };
 
     await loadControlUiBootstrapConfig(state);
@@ -366,6 +368,7 @@ describe("loadControlUiBootstrapConfig", () => {
       embedSandboxMode: "scripts" as const,
       allowExternalEmbedUrls: false,
       serverVersion: null,
+      seamColor: null,
     };
 
     await loadControlUiBootstrapConfig(state);

--- a/ui/src/ui/controllers/control-ui-bootstrap.ts
+++ b/ui/src/ui/controllers/control-ui-bootstrap.ts
@@ -73,9 +73,15 @@ function normalizeHexColor(hex: string): string {
 
 function hexToRgba(hex: string, alpha: number): string {
   const normalized = normalizeHexColor(hex);
+  if (normalized.length !== 7) {
+    return "";
+  }
   const r = Number.parseInt(normalized.slice(1, 3), 16);
   const g = Number.parseInt(normalized.slice(3, 5), 16);
   const b = Number.parseInt(normalized.slice(5, 7), 16);
+  if (Number.isNaN(r) || Number.isNaN(g) || Number.isNaN(b)) {
+    return "";
+  }
   return `rgba(${r}, ${g}, ${b}, ${alpha})`;
 }
 

--- a/ui/src/ui/controllers/control-ui-bootstrap.ts
+++ b/ui/src/ui/controllers/control-ui-bootstrap.ts
@@ -63,6 +63,8 @@ const SEAM_COLOR_CSS_VARS = [
   "--accent-subtle",
   "--accent-glow",
   "--ring",
+  "--primary",
+  "--focus",
 ];
 
 function normalizeHexColor(hex: string): string {
@@ -71,9 +73,9 @@ function normalizeHexColor(hex: string): string {
 
 function hexToRgba(hex: string, alpha: number): string {
   const normalized = normalizeHexColor(hex);
-  const r = parseInt(normalized.slice(1, 3), 16);
-  const g = parseInt(normalized.slice(3, 5), 16);
-  const b = parseInt(normalized.slice(5, 7), 16);
+  const r = Number.parseInt(normalized.slice(1, 3), 16);
+  const g = Number.parseInt(normalized.slice(3, 5), 16);
+  const b = Number.parseInt(normalized.slice(5, 7), 16);
   return `rgba(${r}, ${g}, ${b}, ${alpha})`;
 }
 
@@ -92,6 +94,8 @@ function applySeamColor(seamColor: string | null | undefined) {
   root.setProperty("--accent-subtle", hexToRgba(normalized, 0.1));
   root.setProperty("--accent-glow", hexToRgba(normalized, 0.2));
   root.setProperty("--ring", normalized);
+  root.setProperty("--primary", normalized);
+  root.setProperty("--focus", normalized);
 }
 
 export async function loadControlUiBootstrapConfig(

--- a/ui/src/ui/controllers/control-ui-bootstrap.ts
+++ b/ui/src/ui/controllers/control-ui-bootstrap.ts
@@ -24,6 +24,7 @@ export type ControlUiBootstrapState = {
   embedSandboxMode: ControlUiEmbedSandboxMode;
   allowExternalEmbedUrls: boolean;
   chatMessageMaxWidth?: string | null;
+  seamColor?: string | null;
   sessionKey?: string | null;
   hello?: { auth?: { deviceToken?: string | null } | null } | null;
   settings?: { token?: string | null } | null;
@@ -53,6 +54,38 @@ function applyLocalAssistantAvatarOverride(state: ControlUiBootstrapState) {
   state.assistantAvatarSource = localAvatar;
   state.assistantAvatarStatus = "data";
   state.assistantAvatarReason = null;
+}
+
+const SEAM_COLOR_CSS_VARS = [
+  "--accent",
+  "--accent-hover",
+  "--accent-muted",
+  "--accent-subtle",
+  "--accent-glow",
+  "--ring",
+];
+
+function hexToRgba(hex: string, alpha: number): string {
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
+function applySeamColor(seamColor: string | null | undefined) {
+  const root = document.documentElement.style;
+  if (!seamColor) {
+    for (const v of SEAM_COLOR_CSS_VARS) {
+      root.removeProperty(v);
+    }
+    return;
+  }
+  root.setProperty("--accent", seamColor);
+  root.setProperty("--accent-hover", `color-mix(in srgb, ${seamColor}, white 15%)`);
+  root.setProperty("--accent-muted", seamColor);
+  root.setProperty("--accent-subtle", hexToRgba(seamColor, 0.1));
+  root.setProperty("--accent-glow", hexToRgba(seamColor, 0.2));
+  root.setProperty("--ring", seamColor);
 }
 
 export async function loadControlUiBootstrapConfig(
@@ -136,6 +169,8 @@ export async function loadControlUiBootstrapConfig(
       typeof parsed.chatMessageMaxWidth === "string" && parsed.chatMessageMaxWidth.trim()
         ? parsed.chatMessageMaxWidth
         : null;
+    state.seamColor = typeof parsed.seamColor === "string" ? parsed.seamColor : null;
+    applySeamColor(state.seamColor);
   } catch {
     // Ignore bootstrap failures; UI will update identity after connecting.
   }

--- a/ui/src/ui/controllers/control-ui-bootstrap.ts
+++ b/ui/src/ui/controllers/control-ui-bootstrap.ts
@@ -65,10 +65,15 @@ const SEAM_COLOR_CSS_VARS = [
   "--ring",
 ];
 
+function normalizeHexColor(hex: string): string {
+  return hex.startsWith("#") ? hex : `#${hex}`;
+}
+
 function hexToRgba(hex: string, alpha: number): string {
-  const r = parseInt(hex.slice(1, 3), 16);
-  const g = parseInt(hex.slice(3, 5), 16);
-  const b = parseInt(hex.slice(5, 7), 16);
+  const normalized = normalizeHexColor(hex);
+  const r = parseInt(normalized.slice(1, 3), 16);
+  const g = parseInt(normalized.slice(3, 5), 16);
+  const b = parseInt(normalized.slice(5, 7), 16);
   return `rgba(${r}, ${g}, ${b}, ${alpha})`;
 }
 
@@ -80,12 +85,13 @@ function applySeamColor(seamColor: string | null | undefined) {
     }
     return;
   }
-  root.setProperty("--accent", seamColor);
-  root.setProperty("--accent-hover", `color-mix(in srgb, ${seamColor}, white 15%)`);
-  root.setProperty("--accent-muted", seamColor);
-  root.setProperty("--accent-subtle", hexToRgba(seamColor, 0.1));
-  root.setProperty("--accent-glow", hexToRgba(seamColor, 0.2));
-  root.setProperty("--ring", seamColor);
+  const normalized = normalizeHexColor(seamColor);
+  root.setProperty("--accent", normalized);
+  root.setProperty("--accent-hover", `color-mix(in srgb, ${normalized}, white 15%)`);
+  root.setProperty("--accent-muted", normalized);
+  root.setProperty("--accent-subtle", hexToRgba(normalized, 0.1));
+  root.setProperty("--accent-glow", hexToRgba(normalized, 0.2));
+  root.setProperty("--ring", normalized);
 }
 
 export async function loadControlUiBootstrapConfig(


### PR DESCRIPTION
## Summary

Fixes #56068. The `ui.seamColor` config option was accepted by the backend schema and exposed via `talk.config`, but the Control UI frontend ignored it because:

1. The HTTP bootstrap payload (`/__openclaw/control-ui-config.json`) never included `seamColor`
2. The frontend loader never read or applied it to CSS custom properties

This PR wires `seamColor` end-to-end: gateway bootstrap contract → HTTP response → frontend state → inline `:root` CSS variable overrides.

## Changes

- `src/gateway/control-ui-contract.ts`: add `seamColor?: string` to `ControlUiBootstrapConfig`
- `src/gateway/control-ui.ts`: forward `config?.ui?.seamColor` in the bootstrap payload
- `ui/src/ui/controllers/control-ui-bootstrap.ts`:
  - add `seamColor` to `ControlUiBootstrapState`
  - add `applySeamColor()` helper that sets `--accent`, `--accent-hover`, `--accent-muted`, `--accent-subtle`, `--accent-glow`, `--ring`, `--primary`, `--focus` via `document.documentElement.style`
  - removes those properties when `seamColor` is absent so `base.css` hardcoded defaults win
- `ui/src/ui/controllers/control-ui-bootstrap.test.ts`: add tests for CSS variable application, cleanup, hashless hex normalization, and complete removal coverage

## Real behavior proof

- **Behavior addressed**: Issue #56068 — the configured `ui.seamColor` is now applied as the Control UI accent color; removing it falls back to the default red.
- **Real environment tested**: Linux 4.19.112-2.el8.x86_64, Node v22.19.0, Chrome 148.0.7778.215 headless, local OpenClaw source checkout.
- **Exact steps or command run after this patch**:
  1. Add `"ui": { "seamColor": "#00aaff" }` to `~/.openclaw-dev/openclaw.json`
  2. Run `OPENCLAW_SKIP_CHANNELS=1 node scripts/run-node.mjs --dev gateway`
  3. Open `http://localhost:19001/` in Chrome headless and dump the DOM root style
  4. Verify the bootstrap endpoint returns `seamColor` and the root element carries the derived CSS variables
  5. Remove `seamColor` from config, restart gateway, refresh page
  6. Verify the CSS variables are removed and the default red accent returns
- **Evidence after fix**:
  - Bootstrap endpoint returns `seamColor`:
    ```text
    $ curl -s http://localhost:19001/__openclaw/control-ui-config.json | python3 -m json.tool
    {
        "basePath": "",
        "assistantName": "C3-PO",
        "assistantAvatar": "🤖",
        "assistantAvatarSource": "avatars/c3po.png",
        "assistantAvatarStatus": "none",
        "assistantAvatarReason": "missing",
        "assistantAgentId": "dev",
        "serverVersion": "2026.6.2",
        "localMediaPreviewRoots": [
            "/tmp/openclaw",
            "/home/0668000666/.openclaw-dev/media",
            "/home/0668000666/.openclaw-dev/canvas",
            "/home/0668000666/.openclaw-dev/workspace",
            "/home/0668000666/.openclaw-dev/sandboxes",
            "/home/0668000666/.openclaw/workspace-dev"
        ],
        "embedSandbox": "scripts",
        "allowExternalEmbedUrls": false,
        "seamColor": "#00aaff"
    }
    ```
  - The configured blue accent is applied to the `:root` style (Chrome headless DOM dump):
    ```text
    $ google-chrome --headless --disable-gpu --no-sandbox --window-size=1280,720 \
        --virtual-time-budget=5000 --dump-dom http://localhost:19001/ \
        | grep -o 'style="[^"]*"' | head -n 1
    style="color-scheme: light; --radius-sm: 6px; --radius-md: 10px; --radius-lg: 14px; --radius-xl: 20px; --radius-full: 9999px; --radius: 10px; --control-ui-text-scale: 1.00; --accent: #00aaff; --accent-hover: color-mix(in srgb, #00aaff, white 15%); --accent-muted: #00aaff; --accent-subtle: rgba(0, 170, 255, 0.1); --accent-glow: rgba(0, 170, 255, 0.2); --ring: #00aaff; --primary: #00aaff; --focus: #00aaff;"
    ```
  - After removing `seamColor` and restarting the gateway, the derived variables are absent from `:root` and the default red accent returns (fallback screenshot):

    ![Control UI with default red seamColor](https://github.com/user-attachments/assets/eae8f153-81f8-4ce1-b6ef-e2d29bae29cd)
- **Observed result after fix**: The bootstrap endpoint returns the configured `seamColor`, the `:root` element receives the derived blue CSS variables, and the Control UI renders blue accents. After removing `seamColor` and restarting the gateway, the variables are removed and the default red accent returns.
- **What was not tested**: Dark/light theme switching behavior; WebSocket `talk.config` path (already worked); live model chat (no API key in the test environment).

## Verification

- Unit tests: `node scripts/run-vitest.mjs ui/src/ui/controllers/control-ui-bootstrap.test.ts` → 13 passed
- Build: `pnpm build` → passed
- Lint: `npx oxlint --import-plugin --config .oxlintrc.json src/gateway/control-ui-contract.ts src/gateway/control-ui.ts ui/src/ui/controllers/control-ui-bootstrap.ts ui/src/ui/controllers/control-ui-bootstrap.test.ts` → clean