### PR TITLE
fix(tools): sanitize url parameter in web_fetch to handle model formatting errors

### DIFF
--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -672,7 +672,10 @@ export function createWebFetchTool(options?: {
         return providerFallbackCache;
       };
       const params = args as Record<string, unknown>;
-      const url = readStringParam(params, "url", { required: true });
+      let url = readStringParam(params, "url", { required: true });
+      if (typeof url === "string") {
+        url = url.trim().replace(/^(https?:\/\/)\s+/, "$1");
+      }
       const extractMode = readStringParam(params, "extractMode") === "text" ? "text" : "markdown";
       const maxChars = readNumberParam(params, "maxChars", { integer: true });
       const maxCharsCap = resolveFetchMaxCharsCap(executionFetch);


### PR DESCRIPTION
### Description

This PR fixes a bug where `web_fetch` fails when the LLM generates a URL containing whitespaces (e.g., `"https:// docs.openclaw.ai"`).

### Rationale

LLMs (especially smaller models) sometimes introduce spaces after protocol markers or surrounding the URL argument. Rather than failing immediately, we should clean up the input URL by:
1. Trimming leading/trailing whitespace.
2. Stripping spaces immediately after `http://` or `https://`.

This prevents hard errors from being returned to the user chat client.

Fixes #91651
