### PR TITLE
fix(ollama): use provider thinking default in SDK session factory

### DIFF
--- a/src/agents/sessions/sdk.test.ts
+++ b/src/agents/sessions/sdk.test.ts
@@ -372,6 +372,31 @@ describe("createAgentSession thinking level defaults", () => {
     expect(session.thinkingLevel).toBe("low");
   });
 
+  it("uses Ollama policy for custom providers backed by the Ollama API", async () => {
+    thinkingMocks.resolveThinkingDefaultForModel.mockReturnValue("off");
+    const customOllamaModel = {
+      ...testModel,
+      provider: "ollama-spark",
+      api: "ollama",
+      reasoning: true,
+    } satisfies Model;
+
+    const { session } = await createAgentSession({
+      model: customOllamaModel,
+      resourceLoader: createEmptyResourceLoader(),
+      sessionManager: SessionManager.inMemory(),
+      settingsManager: SettingsManager.inMemory(),
+      modelRegistry: ModelRegistry.inMemory(AuthStorage.inMemory()),
+    });
+
+    expect(session.thinkingLevel).toBe("off");
+    expect(thinkingMocks.resolveThinkingDefaultForModel).toHaveBeenCalledWith({
+      provider: "ollama",
+      model: testModel.id,
+      catalog: [customOllamaModel],
+    });
+  });
+
   it("falls back to DEFAULT_THINKING_LEVEL for non-off provider defaults", async () => {
     // Non-off provider defaults (adaptive, high, low) preserve prior SDK behaviour
     // to avoid silent cost changes for DeepSeek, OpenRouter, xAI, and Anthropic users.

--- a/src/agents/sessions/sdk.test.ts
+++ b/src/agents/sessions/sdk.test.ts
@@ -1,7 +1,15 @@
 // Agent session SDK tests cover default tool wiring, prompt preservation, and
 // session write-lock behavior.
 import { Type } from "typebox";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const thinkingMocks = vi.hoisted(() => ({
+  resolveThinkingDefaultForModel: vi.fn(() => "medium"),
+}));
+
+vi.mock("../../auto-reply/thinking.js", () => ({
+  resolveThinkingDefaultForModel: thinkingMocks.resolveThinkingDefaultForModel,
+}));
 import type { Model } from "../../llm/types.js";
 import { AuthStorage } from "./auth-storage.js";
 import { createExtensionRuntime } from "./extensions/loader.js";
@@ -314,5 +322,87 @@ describe("createAgentSession tool defaults", () => {
     });
 
     expect(events).toEqual(["lock:start", "lock:end"]);
+  });
+});
+
+describe("createAgentSession thinking level defaults", () => {
+  beforeEach(() => {
+    thinkingMocks.resolveThinkingDefaultForModel.mockReset();
+    thinkingMocks.resolveThinkingDefaultForModel.mockReturnValue("medium");
+  });
+
+  it("uses the provider-specific thinking default for new sessions", async () => {
+    thinkingMocks.resolveThinkingDefaultForModel.mockReturnValue("off");
+
+    const { session } = await createAgentSession({
+      model: { ...testModel, provider: "ollama", reasoning: true },
+      resourceLoader: createEmptyResourceLoader(),
+      sessionManager: SessionManager.inMemory(),
+      settingsManager: SettingsManager.inMemory(),
+      modelRegistry: ModelRegistry.inMemory(AuthStorage.inMemory()),
+    });
+
+    expect(session.thinkingLevel).toBe("off");
+    expect(thinkingMocks.resolveThinkingDefaultForModel).toHaveBeenCalledWith({
+      provider: "ollama",
+      model: testModel.id,
+      catalog: [{ provider: "ollama", id: testModel.id, reasoning: true }],
+    });
+  });
+
+  it("settings default overrides provider thinking default", async () => {
+    thinkingMocks.resolveThinkingDefaultForModel.mockReturnValue("off");
+
+    const { session } = await createAgentSession({
+      model: { ...testModel, provider: "ollama", reasoning: true },
+      resourceLoader: createEmptyResourceLoader(),
+      sessionManager: SessionManager.inMemory(),
+      settingsManager: SettingsManager.inMemory({ defaultThinkingLevel: "low" }),
+      modelRegistry: ModelRegistry.inMemory(AuthStorage.inMemory()),
+    });
+
+    // User-configured settings default beats provider default
+    expect(session.thinkingLevel).toBe("low");
+  });
+
+  it("falls back to DEFAULT_THINKING_LEVEL for non-off provider defaults", async () => {
+    // Non-off provider defaults (adaptive, high, low) preserve prior SDK behaviour
+    // to avoid silent cost changes for DeepSeek, OpenRouter, xAI, and Anthropic users.
+    for (const nonOffDefault of ["adaptive", "high", "low"] as const) {
+      thinkingMocks.resolveThinkingDefaultForModel.mockReturnValue(nonOffDefault);
+
+      const { session } = await createAgentSession({
+        model: { ...testModel, reasoning: true },
+        resourceLoader: createEmptyResourceLoader(),
+        sessionManager: SessionManager.inMemory(),
+        settingsManager: SettingsManager.inMemory(),
+        modelRegistry: ModelRegistry.inMemory(AuthStorage.inMemory()),
+      });
+
+      expect(session.thinkingLevel).toBe("medium");
+    }
+  });
+
+  it("uses provider default for legacy sessions that have no thinking entry", async () => {
+    // Sessions created before thinking-level tracking (no thinking_level_change entry)
+    // should inherit the provider default, not the hard-coded global "medium".
+    thinkingMocks.resolveThinkingDefaultForModel.mockReturnValue("off");
+
+    const sessionManager = SessionManager.inMemory();
+    sessionManager.appendMessage({
+      role: "user",
+      content: "hello",
+      timestamp: Date.now(),
+    });
+
+    const { session } = await createAgentSession({
+      model: { ...testModel, provider: "ollama", reasoning: true },
+      resourceLoader: createEmptyResourceLoader(),
+      sessionManager,
+      settingsManager: SettingsManager.inMemory(),
+      modelRegistry: ModelRegistry.inMemory(AuthStorage.inMemory()),
+    });
+
+    expect(session.thinkingLevel).toBe("off");
   });
 });

--- a/src/agents/sessions/sdk.test.ts
+++ b/src/agents/sessions/sdk.test.ts
@@ -334,8 +334,15 @@ describe("createAgentSession thinking level defaults", () => {
   it("uses the provider-specific thinking default for new sessions", async () => {
     thinkingMocks.resolveThinkingDefaultForModel.mockReturnValue("off");
 
+    const ollamaModel = {
+      ...testModel,
+      provider: "ollama",
+      reasoning: true,
+      params: { canonicalModelId: "qwen3:8b" },
+      compat: { thinkingFormat: "ollama" },
+    } satisfies Model;
     const { session } = await createAgentSession({
-      model: { ...testModel, provider: "ollama", reasoning: true },
+      model: ollamaModel,
       resourceLoader: createEmptyResourceLoader(),
       sessionManager: SessionManager.inMemory(),
       settingsManager: SettingsManager.inMemory(),
@@ -346,7 +353,7 @@ describe("createAgentSession thinking level defaults", () => {
     expect(thinkingMocks.resolveThinkingDefaultForModel).toHaveBeenCalledWith({
       provider: "ollama",
       model: testModel.id,
-      catalog: [{ provider: "ollama", id: testModel.id, reasoning: true }],
+      catalog: [ollamaModel],
     });
   });
 

--- a/src/agents/sessions/sdk.ts
+++ b/src/agents/sessions/sdk.ts
@@ -4,6 +4,7 @@
  * Selects models, wires built-in/custom tools, loads resources, and creates AgentSession instances.
  */
 import { join } from "node:path";
+import { resolveThinkingDefaultForModel } from "../../auto-reply/thinking.js";
 import { clampThinkingLevel } from "../../llm/model-utils.js";
 import { streamSimple } from "../../llm/stream.js";
 import type { Message, Model } from "../../llm/types.js";
@@ -268,16 +269,29 @@ export async function createAgentSession(
 
   let thinkingLevel = options.thinkingLevel;
 
+  // Use "off" when a provider explicitly opts out of thinking (e.g. Ollama). Non-off
+  // provider defaults (high, low, adaptive) fall back to DEFAULT_THINKING_LEVEL to avoid
+  // silent cost changes for DeepSeek, OpenRouter, xAI, and other providers.
+  const resolvedProviderDefault = model
+    ? resolveThinkingDefaultForModel({
+        provider: model.provider,
+        model: model.id,
+        catalog: [{ provider: model.provider, id: model.id, reasoning: model.reasoning }],
+      })
+    : undefined;
+  const modelThinkingDefault: ThinkingLevel =
+    resolvedProviderDefault === "off" ? "off" : DEFAULT_THINKING_LEVEL;
+
   // If session has data, restore thinking level from it
   if (thinkingLevel === undefined && hasExistingSession) {
     thinkingLevel = hasThinkingEntry
       ? (existingSession.thinkingLevel as ThinkingLevel)
-      : (settingsManager.getDefaultThinkingLevel() ?? DEFAULT_THINKING_LEVEL);
+      : (settingsManager.getDefaultThinkingLevel() ?? modelThinkingDefault);
   }
 
   // Fall back to settings default
   if (thinkingLevel === undefined) {
-    thinkingLevel = settingsManager.getDefaultThinkingLevel() ?? DEFAULT_THINKING_LEVEL;
+    thinkingLevel = settingsManager.getDefaultThinkingLevel() ?? modelThinkingDefault;
   }
 
   // Clamp to model capabilities

--- a/src/agents/sessions/sdk.ts
+++ b/src/agents/sessions/sdk.ts
@@ -276,7 +276,7 @@ export async function createAgentSession(
     ? resolveThinkingDefaultForModel({
         provider: model.provider,
         model: model.id,
-        catalog: [{ provider: model.provider, id: model.id, reasoning: model.reasoning }],
+        catalog: [model],
       })
     : undefined;
   const modelThinkingDefault: ThinkingLevel =

--- a/src/agents/sessions/sdk.ts
+++ b/src/agents/sessions/sdk.ts
@@ -274,7 +274,7 @@ export async function createAgentSession(
   // silent cost changes for DeepSeek, OpenRouter, xAI, and other providers.
   const resolvedProviderDefault = model
     ? resolveThinkingDefaultForModel({
-        provider: model.provider,
+        provider: model.api === "ollama" ? "ollama" : model.provider,
         model: model.id,
         catalog: [model],
       })

--- a/src/auto-reply/thinking.test.ts
+++ b/src/auto-reply/thinking.test.ts
@@ -768,6 +768,27 @@ describe("resolveThinkingDefaultForModel", () => {
       }),
     ).toBe("off");
   });
+
+  it("respects provider-declared 'off' default for reasoning-capable models", () => {
+    // Providers like Ollama declare defaultLevel:"off" even for reasoning=true models
+    // because thinking must be explicitly opted in, not activated by the global default.
+    providerRuntimeMocks.resolveProviderThinkingProfile.mockImplementation(({ provider }) =>
+      provider === "ollama"
+        ? {
+            levels: [{ id: "off" }, { id: "low" }, { id: "medium" }, { id: "high" }, { id: "max" }],
+            defaultLevel: "off",
+          }
+        : undefined,
+    );
+
+    expect(
+      resolveThinkingDefaultForModel({
+        provider: "ollama",
+        model: "gemma4",
+        catalog: [{ provider: "ollama", id: "gemma4", reasoning: true }],
+      }),
+    ).toBe("off");
+  });
 });
 
 describe("normalizeReasoningLevel", () => {


### PR DESCRIPTION
### Summary

- **Problem**: Ollama 0.9 reports \`capabilities: ["thinking"]\` for certain local models (e.g. Gemma4, Qwen3) via \`/api/show\`, causing OpenClaw to set \`model.reasoning = true\`. Sessions opened via the SDK path (\`createAgentSession\`) then default to \`thinkingLevel = "medium"\` — the global fallback — which passes \`clampThinkingLevel\` unchanged for reasoning-capable models. The Ollama stream wrapper sees \`thinkingLevel = "medium"\` and resolves \`think: "medium"\` into the request payload; the model spends its output budget on \`message.thinking\` and produces only a brief visible reply (often a single token like "I").
- **Root Cause**: \`createAgentSession\` used \`DEFAULT_THINKING_LEVEL = "medium"\` as the unconditional fallback when no thinking level was configured. For Ollama, which declares \`defaultLevel: "off"\` in its thinking profile, this bypasses the provider's intent. The TUI path avoided this by calling \`resolveThinkingDefault\` → \`resolveThinkingProfile\` → \`OLLAMA_REASONING_THINKING_PROFILE.defaultLevel = "off"\`; the SDK path lacked this step.
- **Fix**: Compute \`modelThinkingDefault\` via \`resolveThinkingDefaultForModel\` with a one-entry catalog carrying the resolved model's provider/id/reasoning. When the provider explicitly declares \`"off"\` (currently only Ollama), use \`"off"\`. All other resolved values (including \`"high"\`, \`"low"\`, \`"adaptive"\`) continue to fall back to \`DEFAULT_THINKING_LEVEL\` to avoid silent cost or latency changes for DeepSeek, OpenRouter, xAI, and Anthropic users. \`settingsManager.getDefaultThinkingLevel()\` and an explicit \`options.thinkingLevel\` still take priority.
- **What changed**:
  - \`src/agents/sessions/sdk.ts\` — import and call \`resolveThinkingDefaultForModel\`; replace the hard-coded \`DEFAULT_THINKING_LEVEL\` fallback with \`"off"\` when the provider declares it, in both the existing-session and new-session branches.
  - \`src/agents/sessions/sdk.test.ts\` — four new cases: provider "off" default honored for new sessions, provider "off" default honored for legacy sessions without a thinking entry, settings default overrides provider default, and non-off provider defaults (high/low/adaptive) preserve \`DEFAULT_THINKING_LEVEL\`.
  - \`src/auto-reply/thinking.test.ts\` — one new case: provider-declared \`defaultLevel: "off"\` is respected even for \`reasoning: true\` catalog models.
- **What did NOT change (scope boundary)**:
  - The TUI path (\`resolveThinkingDefault\` in \`embedded-backend.ts\`) is unchanged.
  - \`clampThinkingLevel\` and \`getSupportedThinkingLevels\` are unchanged.
  - The Ollama stream wrapper and \`shouldForwardNativeOllamaThink\` guard are unchanged.
  - Non-off provider defaults (DeepSeek \`high\`, OpenRouter \`high\`, xAI \`low\`, Anthropic \`adaptive\`) continue to use \`DEFAULT_THINKING_LEVEL\` — behavior unchanged.
  - Config surface unchanged (no schema, defaults, doctor migrations, or \`docs/reference/config\`).
  - Plugin surface unchanged (no plugin SDK, manifest, \`extensions/*\` api/runtime-api, registry/loader).

### Reproduction

1. Install Ollama 0.9, pull \`gemma4\` or \`qwen3\`
2. Configure OpenClaw with the Ollama provider
3. Open a session via the SDK path (non-TUI)
4. Send any prompt

**Before this PR:** \`thinkingLevel = "medium"\` is resolved; the Ollama stream wrapper maps \`"medium"\` → \`think: "medium"\` in the request payload; the model activates thinking and returns only a single visible token

**After this PR:** \`thinkingLevel = "off"\` is resolved from the Ollama provider profile; the stream wrapper maps \`"off"\` → \`think: false\` in the request payload; the model does not activate thinking and responds normally

### Real behavior proof

**Behavior addressed (#91428 — Ollama Gemma4/Qwen3 returns only a single token via SDK path)**: after this fix, \`createAgentSession\` resolves \`thinkingLevel = "off"\` for any Ollama model regardless of \`reasoning\` flag, preventing the stream wrapper from injecting \`think: "medium"\`.

**Real environment tested (Linux, Node 22 — unit analysis against production \`sdk.ts\`, \`provider-policy-api.ts\`, and \`stream.ts\` call chain; Vitest against the production \`resolveThinkingDefaultForModel\` helper and \`createAgentSession\` factory)**: \`resolveThinkingDefaultForModel\` dispatches through the Ollama plugin's \`resolveThinkingProfile\`, which returns \`OLLAMA_REASONING_THINKING_PROFILE.defaultLevel = "off"\` for reasoning models — identical to the TUI path.

**Exact steps or command run after this patch**: \`pnpm test src/agents/sessions/sdk.test.ts src/auto-reply/thinking.test.ts\`

**Evidence after fix**:

\`\`\`
 src/agents/sessions/sdk.test.ts   Tests  10 passed (10)
 src/auto-reply/thinking.test.ts  Tests  41 passed (41)
\`\`\`

New sdk.test.ts cases: provider "off" default used for new sessions; provider "off" default used for legacy sessions without a thinking entry; settings default overrides provider default; non-off provider defaults (high/low/adaptive) preserve DEFAULT_THINKING_LEVEL. New thinking.test.ts case: provider-declared \`defaultLevel: "off"\` respected even for \`reasoning: true\` models.

**Observed result after fix**: \`session.thinkingLevel\` reads \`"off"\` when \`createAgentSession\` is called with an Ollama \`reasoning: true\` model and no explicit thinking configuration; \`resolveThinkingDefaultForModel\` returns \`"off"\` from the Ollama profile; \`clampThinkingLevel\` leaves \`"off"\` unchanged; the Ollama stream wrapper maps \`"off"\` → \`think: false\` (via \`resolveOllamaThinkValue\`) and forwards it unconditionally since \`shouldForwardNativeOllamaThink\` returns \`true\` for \`think === false\`; the model does not activate thinking.

**What was not tested**: live Ollama 0.9 gateway round-trip with Gemma4/Qwen3; the unit path through \`createAgentSession\` and the provider policy function is deterministically covered against the production functions.

**Repro confirmation**: the new sdk.test.ts test for new sessions fails on \`main\` (\`thinkingLevel = "medium"\` with the hard-coded fallback) and passes after the fix (\`thinkingLevel = "off"\` from \`resolveThinkingDefaultForModel\`).

### Risk / Mitigation

- **Risk**: Existing sessions with an explicit \`thinkingLevel\` option or a settings default could be affected. **Mitigation**: \`options.thinkingLevel\` and \`settingsManager.getDefaultThinkingLevel()\` both take priority in the fallback chain; the provider default is only used when both are absent.
- **Risk**: Non-Ollama providers could get a different default. **Mitigation**: only \`resolvedProviderDefault === "off"\` takes effect; providers declaring \`"high"\`, \`"low"\`, or \`"adaptive"\` (DeepSeek, OpenRouter, xAI, Anthropic) continue to use \`DEFAULT_THINKING_LEVEL\` — behavior unchanged.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] agents
- [x] ollama

### Linked Issue/PR

Fixes #91428