### PR TITLE
feat(gateway): forward generic clientContext onto diagnostic events

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -775,6 +775,7 @@ public struct AgentParams: Codable, Sendable {
     public let voicewaketrigger: String?
     public let idempotencykey: String
     public let label: String?
+    public let clientcontext: [String: AnyCodable]?
 
     public init(
         message: String,
@@ -816,7 +817,8 @@ public struct AgentParams: Codable, Sendable {
         disablemessagetool: Bool?,
         voicewaketrigger: String?,
         idempotencykey: String,
-        label: String?)
+        label: String?,
+        clientcontext: [String: AnyCodable]?)
     {
         self.message = message
         self.agentid = agentid
@@ -858,6 +860,7 @@ public struct AgentParams: Codable, Sendable {
         self.voicewaketrigger = voicewaketrigger
         self.idempotencykey = idempotencykey
         self.label = label
+        self.clientcontext = clientcontext
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -901,6 +904,7 @@ public struct AgentParams: Codable, Sendable {
         case voicewaketrigger = "voiceWakeTrigger"
         case idempotencykey = "idempotencyKey"
         case label
+        case clientcontext = "clientContext"
     }
 }
 

--- a/packages/gateway-protocol/src/schema/agent.test.ts
+++ b/packages/gateway-protocol/src/schema/agent.test.ts
@@ -80,4 +80,19 @@ describe("AgentParamsSchema", () => {
 
     expect(Value.Check(AgentParamsSchema, params)).toBe(false);
   });
+
+  it("accepts an opaque clientContext bag", () => {
+    const params = {
+      message: "run",
+      sessionKey: "agent:main:example",
+      idempotencyKey: "run-1",
+      clientContext: {
+        schemaVersion: "example.context.v1",
+        agentId: "Conductor",
+        nested: { runId: "abc", issueId: "ISSUE-8" },
+      },
+    };
+
+    expect(Value.Check(AgentParamsSchema, params)).toBe(true);
+  });
 });

--- a/packages/gateway-protocol/src/schema/agent.ts
+++ b/packages/gateway-protocol/src/schema/agent.ts
@@ -179,6 +179,14 @@ export const PollParamsSchema = Type.Object(
 );
 
 /** Main agent-run request accepted by the gateway. */
+/**
+ * Opaque object a gateway client may attach to a run. The gateway forwards it
+ * verbatim onto diagnostic events for plugins to interpret and never reads its
+ * contents, so it stays a permissive string-keyed record at the wire boundary;
+ * the runtime normalizer enforces size/depth/key bounds.
+ */
+export const ClientContextSchema = Type.Record(Type.String(), Type.Unknown());
+
 export const AgentParamsSchema = Type.Object(
   {
     message: NonEmptyString,
@@ -231,6 +239,11 @@ export const AgentParamsSchema = Type.Object(
     voiceWakeTrigger: Type.Optional(Type.String()),
     idempotencyKey: NonEmptyString,
     label: Type.Optional(SessionLabelString),
+    // Opaque, caller-supplied context bag forwarded verbatim onto diagnostic
+    // events for plugins to interpret (the gateway never inspects its
+    // contents). Size/depth/key bounds are enforced by the runtime normalizer,
+    // not the wire schema, so this stays permissive.
+    clientContext: Type.Optional(ClientContextSchema),
   },
   { additionalProperties: false },
 );

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -71,6 +71,7 @@ import {
 import { resolveMaintenanceConfigFromInput } from "../../config/sessions/store-maintenance.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { registerAgentRunContext } from "../../infra/agent-events.js";
+import { normalizeDiagnosticClientContext } from "../../infra/diagnostic-client-context.js";
 import { formatUncaughtError, readErrorName } from "../../infra/errors.js";
 import {
   resolveAgentDeliveryPlanWithSessionRoute,
@@ -83,6 +84,7 @@ import {
   loadVoiceWakeRoutingConfig,
   resolveVoiceWakeRouteByTrigger,
 } from "../../infra/voicewake-routing.js";
+import { setDiagnosticSessionClientContext } from "../../logging/diagnostic.js";
 import type { PromptImageOrderEntry } from "../../media/prompt-image-order.js";
 import type { PluginHookSessionEndReason } from "../../plugins/hook-types.js";
 import {
@@ -1076,6 +1078,7 @@ export const agentHandlers: GatewayRequestHandlers = {
       inputProvenance?: InputProvenance;
       workspaceDir?: string;
       voiceWakeTrigger?: string;
+      clientContext?: unknown;
     };
     const allowModelOverride = resolveAllowModelOverrideFromClient(client);
     const canUseInternalRuntimeHandoff = resolveCanUseInternalRuntimeHandoff(client);
@@ -2521,6 +2524,15 @@ export const agentHandlers: GatewayRequestHandlers = {
           }
           const execApprovalFollowupElevatedDefaults =
             execApprovalFollowupRuntimeHandoff?.bashElevated;
+
+          // Seed any caller-supplied opaque context onto this run's diagnostic
+          // session state, keyed by the same session the run uses, so every
+          // message.queued / session.state event the run emits carries it for
+          // plugins to interpret. No-op when absent or out of bounds.
+          setDiagnosticSessionClientContext(
+            { sessionKey: resolvedSessionKey, sessionId: resolvedSessionId },
+            normalizeDiagnosticClientContext(request.clientContext),
+          );
 
           dispatchAgentRunFromGateway({
             ingressOpts: {

--- a/src/infra/diagnostic-client-context.test.ts
+++ b/src/infra/diagnostic-client-context.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import {
+  CLIENT_CONTEXT_MAX_BYTES,
+  CLIENT_CONTEXT_MAX_DEPTH,
+  CLIENT_CONTEXT_MAX_KEYS,
+  normalizeDiagnosticClientContext,
+} from "./diagnostic-client-context.js";
+
+describe("normalizeDiagnosticClientContext", () => {
+  it("passes a small JSON object through and freezes it", () => {
+    const result = normalizeDiagnosticClientContext({
+      schemaVersion: "agentweave.context.v1",
+      source: "paperclip",
+      sessionId: "run-1",
+    });
+    expect(result).toEqual({
+      schemaVersion: "agentweave.context.v1",
+      source: "paperclip",
+      sessionId: "run-1",
+    });
+    expect(Object.isFrozen(result)).toBe(true);
+  });
+
+  it("preserves nested objects, arrays, and JSON primitives", () => {
+    const result = normalizeDiagnosticClientContext({
+      paperclip: { runId: "abc", issueId: null, turnDepth: 2 },
+      issueIds: ["a", "b"],
+      enabled: true,
+    });
+    expect(result).toEqual({
+      paperclip: { runId: "abc", issueId: null, turnDepth: 2 },
+      issueIds: ["a", "b"],
+      enabled: true,
+    });
+  });
+
+  it("orders object keys deterministically at every level", () => {
+    const result = normalizeDiagnosticClientContext({
+      b: 1,
+      a: { z: 1, y: 2 },
+    });
+    expect(JSON.stringify(result)).toBe('{"a":{"y":2,"z":1},"b":1}');
+  });
+
+  it("returns undefined for non-object input", () => {
+    expect(normalizeDiagnosticClientContext("nope")).toBeUndefined();
+    expect(normalizeDiagnosticClientContext(42)).toBeUndefined();
+    expect(normalizeDiagnosticClientContext(null)).toBeUndefined();
+    expect(normalizeDiagnosticClientContext(["a"])).toBeUndefined();
+    expect(normalizeDiagnosticClientContext(undefined)).toBeUndefined();
+  });
+
+  it("returns undefined for an empty object", () => {
+    expect(normalizeDiagnosticClientContext({})).toBeUndefined();
+  });
+
+  it("omits prototype-polluting keys", () => {
+    const parsed = JSON.parse('{"__proto__": {"polluted": true}, "ok": 1}');
+    expect(normalizeDiagnosticClientContext(parsed)).toEqual({ ok: 1 });
+  });
+
+  it("rejects the whole bag when a value is not JSON-serializable", () => {
+    expect(normalizeDiagnosticClientContext({ a: 1, b: () => {} })).toBeUndefined();
+    expect(normalizeDiagnosticClientContext({ a: Number.NaN })).toBeUndefined();
+    expect(normalizeDiagnosticClientContext({ a: Number.POSITIVE_INFINITY })).toBeUndefined();
+  });
+
+  it("rejects nesting deeper than the depth cap", () => {
+    let deep: Record<string, unknown> = { leaf: 1 };
+    for (let i = 0; i < CLIENT_CONTEXT_MAX_DEPTH + 1; i++) {
+      deep = { nested: deep };
+    }
+    expect(normalizeDiagnosticClientContext(deep)).toBeUndefined();
+  });
+
+  it("rejects bags with more keys than the key cap", () => {
+    const big: Record<string, number> = {};
+    for (let i = 0; i < CLIENT_CONTEXT_MAX_KEYS + 1; i++) {
+      big[`k${i}`] = i;
+    }
+    expect(normalizeDiagnosticClientContext(big)).toBeUndefined();
+  });
+
+  it("rejects bags larger than the byte cap", () => {
+    const huge = { blob: "x".repeat(CLIENT_CONTEXT_MAX_BYTES + 1) };
+    expect(normalizeDiagnosticClientContext(huge)).toBeUndefined();
+  });
+});

--- a/src/infra/diagnostic-client-context.ts
+++ b/src/infra/diagnostic-client-context.ts
@@ -1,0 +1,130 @@
+import { isBlockedObjectKey } from "./prototype-keys.js";
+
+/**
+ * Bounds for an opaque, caller-supplied diagnostic context bag. A gateway client
+ * (e.g. an upstream orchestrator) can attach a small JSON object to a run; it is
+ * carried verbatim onto diagnostic events for plugins to interpret. Core never
+ * inspects the contents — these caps only protect the event stream and
+ * prompt-cache determinism from unbounded or hostile input.
+ */
+export const CLIENT_CONTEXT_MAX_DEPTH = 4;
+export const CLIENT_CONTEXT_MAX_KEYS = 64;
+export const CLIENT_CONTEXT_MAX_BYTES = 8192;
+
+export type DiagnosticJsonPrimitive = string | number | boolean | null;
+export type DiagnosticJsonValue =
+  | DiagnosticJsonPrimitive
+  | DiagnosticJsonValue[]
+  | { [key: string]: DiagnosticJsonValue };
+export type DiagnosticClientContext = Readonly<{ [key: string]: DiagnosticJsonValue }>;
+
+type KeyBudget = { count: number };
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Recursively validate + copy a value into a JSON-only shape. Returns `undefined`
+ * to reject the entire bag (null is a valid value and is distinct from this
+ * reject signal). Object keys are sorted for deterministic serialization, and
+ * prototype-polluting keys are dropped.
+ */
+function normalizeValue(
+  value: unknown,
+  depth: number,
+  budget: KeyBudget,
+): DiagnosticJsonValue | undefined {
+  if (value === null) {
+    return null;
+  }
+  const valueType = typeof value;
+  if (valueType === "string") {
+    return value as string;
+  }
+  if (valueType === "boolean") {
+    return value as boolean;
+  }
+  if (valueType === "number") {
+    return Number.isFinite(value) ? (value as number) : undefined;
+  }
+
+  if (Array.isArray(value)) {
+    if (depth >= CLIENT_CONTEXT_MAX_DEPTH) {
+      return undefined;
+    }
+    const out: DiagnosticJsonValue[] = [];
+    for (const item of value) {
+      budget.count += 1;
+      if (budget.count > CLIENT_CONTEXT_MAX_KEYS) {
+        return undefined;
+      }
+      const normalized = normalizeValue(item, depth + 1, budget);
+      if (normalized === undefined) {
+        return undefined;
+      }
+      out.push(normalized);
+    }
+    return out;
+  }
+
+  if (isPlainObject(value)) {
+    if (depth >= CLIENT_CONTEXT_MAX_DEPTH) {
+      return undefined;
+    }
+    const out: Record<string, DiagnosticJsonValue> = {};
+    for (const key of Object.keys(value).toSorted()) {
+      if (isBlockedObjectKey(key)) {
+        continue;
+      }
+      budget.count += 1;
+      if (budget.count > CLIENT_CONTEXT_MAX_KEYS) {
+        return undefined;
+      }
+      const normalized = normalizeValue(value[key], depth + 1, budget);
+      if (normalized === undefined) {
+        return undefined;
+      }
+      out[key] = normalized;
+    }
+    return out;
+  }
+
+  // function / undefined / symbol / bigint — not JSON-serializable.
+  return undefined;
+}
+
+function deepFreeze<T>(value: T): T {
+  if (typeof value === "object" && value !== null) {
+    for (const child of Object.values(value)) {
+      deepFreeze(child);
+    }
+    Object.freeze(value);
+  }
+  return value;
+}
+
+/**
+ * Normalize a caller-supplied context bag into a bounded, deterministic,
+ * frozen JSON object, or `undefined` when the input is not a usable object or
+ * exceeds the size/depth/key caps. The whole bag is dropped rather than
+ * truncated mid-structure, so consumers never see a partial bag.
+ */
+export function normalizeDiagnosticClientContext(
+  input: unknown,
+): DiagnosticClientContext | undefined {
+  if (!isPlainObject(input)) {
+    return undefined;
+  }
+  const normalized = normalizeValue(input, 0, { count: 0 });
+  if (!isPlainObject(normalized)) {
+    return undefined;
+  }
+  if (Object.keys(normalized).length === 0) {
+    return undefined;
+  }
+  if (JSON.stringify(normalized).length > CLIENT_CONTEXT_MAX_BYTES) {
+    return undefined;
+  }
+  return deepFreeze(normalized) as DiagnosticClientContext;
+}

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -1,6 +1,7 @@
 // Defines and sanitizes runtime diagnostic event payloads.
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { TalkBrain, TalkEventType, TalkMode, TalkTransport } from "../talk/talk-events.js";
+import type { DiagnosticClientContext } from "./diagnostic-client-context.js";
 import {
   formatDiagnosticTraceparent,
   getActiveDiagnosticTraceContext,
@@ -91,6 +92,7 @@ export type DiagnosticMessageQueuedEvent = DiagnosticBaseEvent & {
   channel?: string;
   source: string;
   queueDepth?: number;
+  clientContext?: DiagnosticClientContext;
 };
 
 export type DiagnosticMessageReceivedEvent = DiagnosticBaseEvent & {
@@ -183,6 +185,7 @@ export type DiagnosticSessionStateEvent = DiagnosticBaseEvent & {
   state: DiagnosticSessionState;
   reason?: string;
   queueDepth?: number;
+  clientContext?: DiagnosticClientContext;
 };
 
 export type DiagnosticSessionActiveWorkKind = "embedded_run" | "model_call" | "tool_call";

--- a/src/logging/diagnostic-client-context-events.test.ts
+++ b/src/logging/diagnostic-client-context-events.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { normalizeDiagnosticClientContext } from "../infra/diagnostic-client-context.js";
+import {
+  onDiagnosticEvent,
+  resetDiagnosticEventsForTest,
+  setDiagnosticsEnabledForProcess,
+  type DiagnosticEventPayload,
+} from "../infra/diagnostic-events.js";
+import { resetDiagnosticSessionStateForTest } from "./diagnostic-session-state.js";
+import {
+  logMessageQueued,
+  logSessionStateChange,
+  resetDiagnosticStateForTest,
+  setDiagnosticSessionClientContext,
+} from "./diagnostic.js";
+
+const UPSTREAM = normalizeDiagnosticClientContext({
+  schemaVersion: "agentweave.context.v1",
+  agentId: "Conductor",
+});
+
+function captureEvents(run: () => void): DiagnosticEventPayload[] {
+  const events: DiagnosticEventPayload[] = [];
+  const unsubscribe = onDiagnosticEvent((event) => {
+    events.push(event);
+  });
+  try {
+    run();
+  } finally {
+    unsubscribe();
+  }
+  return events;
+}
+
+describe("clientContext propagation onto diagnostic events", () => {
+  beforeEach(() => {
+    setDiagnosticsEnabledForProcess(true);
+    resetDiagnosticStateForTest();
+    resetDiagnosticSessionStateForTest();
+    resetDiagnosticEventsForTest();
+  });
+
+  afterEach(() => {
+    resetDiagnosticEventsForTest();
+    setDiagnosticsEnabledForProcess(false);
+  });
+
+  it("carries seeded clientContext on session.state events", () => {
+    const events = captureEvents(() => {
+      setDiagnosticSessionClientContext(
+        { sessionKey: "agent:main:paperclip-conductor", sessionId: "s1" },
+        UPSTREAM,
+      );
+      logSessionStateChange({
+        sessionId: "s1",
+        sessionKey: "agent:main:paperclip-conductor",
+        state: "processing",
+      });
+    });
+
+    const stateEvent = events.find((event) => event.type === "session.state");
+    expect(stateEvent).toBeDefined();
+    expect((stateEvent as Record<string, unknown>).clientContext).toEqual(UPSTREAM);
+  });
+
+  it("lets a later message.queued inherit clientContext seeded on the session", () => {
+    const events = captureEvents(() => {
+      // The gateway handler seeds context keyed by sessionKey before the run
+      // emits anything. setActiveEmbeddedRun then emits session.state (with
+      // sessionKey), and the queue path emits message.queued by sessionId only
+      // — both must inherit the seeded context from the shared session state.
+      setDiagnosticSessionClientContext(
+        { sessionKey: "agent:main:paperclip-conductor", sessionId: "s1" },
+        UPSTREAM,
+      );
+      logSessionStateChange({
+        sessionId: "s1",
+        sessionKey: "agent:main:paperclip-conductor",
+        state: "processing",
+      });
+      logMessageQueued({ sessionId: "s1", source: "pi-embedded-runner" });
+    });
+
+    const queuedEvent = events.find((event) => event.type === "message.queued");
+    expect(queuedEvent).toBeDefined();
+    expect((queuedEvent as Record<string, unknown>).sessionKey).toBe(
+      "agent:main:paperclip-conductor",
+    );
+    expect((queuedEvent as Record<string, unknown>).clientContext).toEqual(UPSTREAM);
+  });
+
+  it("omits clientContext for sessions without an upstream context", () => {
+    const events = captureEvents(() => {
+      logSessionStateChange({
+        sessionId: "s2",
+        sessionKey: "agent:main:main",
+        state: "processing",
+      });
+      logMessageQueued({ sessionId: "s2", sessionKey: "agent:main:main", source: "dispatch" });
+    });
+
+    for (const event of events) {
+      expect((event as Record<string, unknown>).clientContext).toBeUndefined();
+    }
+  });
+});

--- a/src/logging/diagnostic-client-context-events.test.ts
+++ b/src/logging/diagnostic-client-context-events.test.ts
@@ -89,6 +89,39 @@ describe("clientContext propagation onto diagnostic events", () => {
     expect((queuedEvent as Record<string, unknown>).clientContext).toEqual(UPSTREAM);
   });
 
+  it("clears stale clientContext when a later same-session run supplies none", () => {
+    const ref = { sessionKey: "agent:main:paperclip-conductor", sessionId: "s1" };
+    const events = captureEvents(() => {
+      // First run seeds upstream context.
+      setDiagnosticSessionClientContext(ref, UPSTREAM);
+      // Later run on the same (reused) diagnostic session has no context.
+      setDiagnosticSessionClientContext(ref, undefined);
+      logSessionStateChange({ ...ref, state: "processing" });
+      logMessageQueued({ sessionId: "s1", source: "dispatch" });
+    });
+
+    for (const event of events) {
+      expect((event as Record<string, unknown>).clientContext).toBeUndefined();
+    }
+  });
+
+  it("clears stale clientContext when a later same-session run is out of bounds", () => {
+    const ref = { sessionKey: "agent:main:paperclip-conductor", sessionId: "s1" };
+    // An oversized / invalid bag normalizes to undefined (whole-bag drop).
+    const oversized = normalizeDiagnosticClientContext({ blob: "x".repeat(9000) });
+    expect(oversized).toBeUndefined();
+
+    const events = captureEvents(() => {
+      setDiagnosticSessionClientContext(ref, UPSTREAM);
+      setDiagnosticSessionClientContext(ref, oversized);
+      logSessionStateChange({ ...ref, state: "processing" });
+    });
+
+    const stateEvent = events.find((event) => event.type === "session.state");
+    expect(stateEvent).toBeDefined();
+    expect((stateEvent as Record<string, unknown>).clientContext).toBeUndefined();
+  });
+
   it("omits clientContext for sessions without an upstream context", () => {
     const events = captureEvents(() => {
       logSessionStateChange({

--- a/src/logging/diagnostic-session-state.ts
+++ b/src/logging/diagnostic-session-state.ts
@@ -1,10 +1,13 @@
 // Process-local session-state tracker used by diagnostic stuck-session detection.
+import type { DiagnosticClientContext } from "../infra/diagnostic-client-context.js";
+
 export type SessionStateValue = "idle" | "processing" | "waiting";
 
 /** Mutable diagnostic state for one session key or id. */
 export type SessionState = {
   sessionId?: string;
   sessionKey?: string;
+  clientContext?: DiagnosticClientContext;
   sessionFile?: string;
   lastActivity: number;
   generation?: number;
@@ -107,6 +110,7 @@ function mergeSessionState(target: SessionState, source: SessionState): void {
     sessionStatePriority(source.state) > sessionStatePriority(target.state);
   target.sessionId ??= source.sessionId;
   target.sessionKey ??= source.sessionKey;
+  target.clientContext ??= source.clientContext;
   if (source.sessionFile && (sourceIsNewer || !target.sessionFile)) {
     target.sessionFile = source.sessionFile;
   }

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -50,6 +50,7 @@ import {
   diagnosticSessionStates,
   getDiagnosticSessionState,
   getDiagnosticSessionStateCountForTest as getDiagnosticSessionStateCountForTestImpl,
+  peekDiagnosticSessionState,
   pruneDiagnosticSessionStates,
   resetDiagnosticSessionStateForTest,
   type SessionRef,
@@ -912,10 +913,22 @@ export function setDiagnosticSessionClientContext(
   ref: SessionRef,
   clientContext: DiagnosticClientContext | undefined,
 ): void {
-  if (!clientContext || !areDiagnosticsEnabledForProcess()) {
+  if (!areDiagnosticsEnabledForProcess()) {
     return;
   }
-  getDiagnosticSessionState(ref).clientContext = clientContext;
+  if (clientContext) {
+    getDiagnosticSessionState(ref).clientContext = clientContext;
+    return;
+  }
+  // No (or out-of-bounds) context for this run: actively clear any value a
+  // prior run left on the reused per-session diagnostic state, so later
+  // message.queued / session.state events are not misattributed to a stale
+  // upstream context. Per-session state is keyed by sessionId/sessionKey and
+  // lives until idle TTL, so the seed path must own clearing, not just setting.
+  const existing = peekDiagnosticSessionState(ref);
+  if (existing) {
+    existing.clientContext = undefined;
+  }
 }
 
 export function updateDiagnosticSessionFile(params: SessionRef) {

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -3,6 +3,7 @@ import { monitorEventLoopDelay, performance } from "node:perf_hooks";
 import { getRuntimeConfig } from "../config/config.js";
 import { resolveAllAgentSessionStoreTargetsSync } from "../config/sessions/targets.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { DiagnosticClientContext } from "../infra/diagnostic-client-context.js";
 import {
   areDiagnosticsEnabledForProcess,
   emitInternalDiagnosticEvent as emitDiagnosticEvent,
@@ -672,6 +673,7 @@ export function logMessageQueued(params: {
     channel: params.channel,
     source: params.source,
     queueDepth: state.queueDepth,
+    clientContext: state.clientContext,
   });
   markActivity();
 }
@@ -894,8 +896,26 @@ export function logSessionStateChange(
     state: params.state,
     reason: params.reason,
     queueDepth: state.queueDepth,
+    clientContext: state.clientContext,
   });
   markActivity();
+}
+
+/**
+ * Seed an opaque, caller-supplied context bag onto a session's diagnostic state.
+ * Once seeded, every later `message.queued` / `session.state` event for the run
+ * carries it — the same shared-state propagation that already gives a later
+ * `message.queued` its `sessionKey`. Bounding/validation is the caller's
+ * responsibility (see normalizeDiagnosticClientContext).
+ */
+export function setDiagnosticSessionClientContext(
+  ref: SessionRef,
+  clientContext: DiagnosticClientContext | undefined,
+): void {
+  if (!clientContext || !areDiagnosticsEnabledForProcess()) {
+    return;
+  }
+  getDiagnosticSessionState(ref).clientContext = clientContext;
 }
 
 export function updateDiagnosticSessionFile(params: SessionRef) {


### PR DESCRIPTION
## Summary

Adds a generic, plugin-agnostic way for a gateway client to attach opaque run context that plugins can read off the diagnostic event stream.

The gateway `agent` request gains an optional `clientContext` object. It is bounded + normalized, seeded once onto the per-session diagnostic state, and then carried onto every `message.queued` / `session.state` event for that run — the same shared-state propagation that already gives a later `message.queued` its `sessionKey`. Core never inspects the contents and learns no plugin-specific names; a plugin (e.g. an OTel/tracing bridge) interprets the bag via a `schemaVersion` it owns.

### What's in it

- `src/infra/diagnostic-client-context.ts` — bounded JSON normalizer: size (8 KB), depth (4), and key (64) caps; prototype-key sanitization; deterministic key ordering; whole-bag drop on cap/validation failure (never partial).
- `clientContext?: DiagnosticClientContext` on the `message.queued` and `session.state` event types.
- `clientContext` field on `SessionState` (+ carried in `mergeSessionState`); emitters write `state.clientContext`.
- `setDiagnosticSessionClientContext(ref, ctx)` seeder.
- Additive optional `clientContext` param on `AgentParamsSchema` (`packages/gateway-protocol`); schema stays `additionalProperties: false` (purely additive, no protocol version bump). Regenerated `GatewayModels.swift` to match.
- The gateway `agent` handler normalizes `request.clientContext` and seeds it before dispatch.

### Design notes

- **Plugin-agnostic:** core contains no consumer-specific names; the bag is opaque and the discriminator (`schemaVersion`) lives inside it, owned by the plugin.
- **Bounded:** caps protect the diagnostic stream and prompt-cache determinism (deterministic ordering) from unbounded/hostile input; out-of-bounds input is dropped (field omitted), never truncated mid-structure.
- **Inert without context:** absent/oversized context normalizes to `undefined`, the seeder no-ops, and events omit the field — no behavior change for existing runs.

## Verification (supplemental)

Ran in a clean worktree off `main`: `tsgo:core` (covers `src/` + `packages/`) clean; new unit tests 10/10 (normalizer) and 3/3 (seed → event inheritance); gateway-protocol schema test 4/4 (incl. clientContext acceptance); `diagnostic.test.ts` 68/68 (emitter regression); oxlint + oxfmt clean. CI covers the full suite.

## Real behavior proof

Behavior addressed: A gateway client attaches opaque `clientContext` to an `agent` run; it reaches plugins via `message.queued` / `session.state` diagnostic events, seeded once and inherited for the whole run. Absent or oversized context is a no-op.

Real environment tested: A live `openclaw-gateway.service` carrying this seeding logic, driven by a real upstream orchestrator (Paperclip) that sets `clientContext`, with an OTel bridge plugin reading the diagnostic stream and exporting to Tempo.

Exact steps or command run after this patch: Launched a real orchestrator-managed run through the gateway, then read the gateway journal and queried Tempo for the run id.

Evidence after fix: Redacted runtime log excerpt from the live `openclaw-gateway.service` for run `e0f1ea4f-f440-4097-b8fc-1ee7da341dc0`:

```
[ws] res ok agent ... runId=e0f1ea4f-f440-4097-b8fc-1ee7da341dc0
[bridge] event: session.state sessionKey: agent:main:paperclip-conductor
[bridge] started root span for ... session: e0f1ea4f-... agent: Conductor
[bridge] event: model.call.completed sessionKey: agent:main:paperclip-conductor
[bridge] ended upstream root span for session: agent:main:paperclip-conductor
```

Tempo root span (trace `75839d85fe1df83e0c62370b7040410`), found by `{.prov.upstream.run_id="e0f1ea4f-..."}` and `{.session.id="e0f1ea4f-..."}`, carried `session.id=e0f1ea4f-...`, `prov.upstream.run_id=e0f1ea4f-...`, `prov.upstream.issue_id=53ce84e5-...`, `outcome=completed`. Full end-to-end write-up with the complete log + Tempo searches: https://github.com/arniesaha/agentweave/issues/238#issuecomment-4657108617

Observed result after fix: The `clientContext` supplied on the `agent` request was carried verbatim through the diagnostic stream and consumed by the plugin, which attributed the resulting span/trace to the upstream identity. With no `clientContext`, the attribution path was unchanged.

What was not tested: this PR's generic mechanism beyond the live run above; the downstream plugin itself is out of this repo's scope.
