### PR TITLE
fix(backup): clean up stale .tmp archives from interrupted runs before creating new backup

### DIFF
--- a/src/infra/backup-create.test.ts
+++ b/src/infra/backup-create.test.ts
@@ -311,7 +311,10 @@ describe("cleanupStaleTempArchives", () => {
       await fs.writeFile(finalArchive, "final archive", "utf8");
 
       const log = vi.fn();
-      await cleanupStaleTempArchives({ outputPath, log });
+      // Use a future nowMs so all newly-written files appear older than the
+      // default 30 s staleness threshold.
+      const futureNow = Date.now() + 60_000;
+      await cleanupStaleTempArchives({ outputPath, log, nowMs: futureNow });
 
       // Stale files removed
       await expect(fs.access(stale1)).rejects.toMatchObject({ code: "ENOENT" });
@@ -338,7 +341,7 @@ describe("cleanupStaleTempArchives", () => {
       await fs.writeFile(outputPath, "final archive", "utf8");
 
       const log = vi.fn();
-      await cleanupStaleTempArchives({ outputPath, log });
+      await cleanupStaleTempArchives({ outputPath, log, nowMs: Date.now() + 60_000 });
 
       // Final archive preserved
       await expect(fs.access(outputPath)).resolves.toBeUndefined();
@@ -375,7 +378,8 @@ describe("cleanupStaleTempArchives", () => {
       await fs.writeFile(myStale, "my stale", "utf8");
 
       const log = vi.fn();
-      await cleanupStaleTempArchives({ outputPath, log });
+      const futureNow = Date.now() + 60_000;
+      await cleanupStaleTempArchives({ outputPath, log, nowMs: futureNow });
 
       // Only our .tmp removed
       await expect(fs.access(myStale)).rejects.toMatchObject({ code: "ENOENT" });
@@ -398,10 +402,76 @@ describe("cleanupStaleTempArchives", () => {
       await fs.writeFile(stale1, largeContent);
 
       const log = vi.fn();
-      await cleanupStaleTempArchives({ outputPath, log });
+      const futureNow = Date.now() + 60_000;
+      await cleanupStaleTempArchives({ outputPath, log, nowMs: futureNow });
 
       expect(log).toHaveBeenCalledTimes(1);
       expect(log.mock.calls[0][0]).toContain("(2.0MB)");
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("skips temp archives whose mtime is within the staleness threshold", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-backup-cleanup-"));
+    try {
+      const outputPath = path.join(dir, "backup.tar.gz");
+      // This file was just created — it simulates an active backup writer
+      const activeTmp = `${outputPath}.a1b2c3d4-e5f6-7890-abcd-ef1234567890.tmp`;
+      // This file is much older — it simulates a stale leftover
+      const staleTmp = `${outputPath}.12345678-90ab-cdef-1234-567890abcdef.tmp`;
+
+      await fs.writeFile(activeTmp, "active backup", "utf8");
+      await fs.writeFile(staleTmp, "stale leftover", "utf8");
+
+      // Set the stale file's mtime far in the past
+      const staleMtime = new Date(Date.now() - 120_000); // 2 minutes ago
+      await fs.utimes(staleTmp, staleMtime, staleMtime);
+
+      const log = vi.fn();
+      // Use current time as nowMs — the active file (mtime ~now) should be
+      // within the default 30 s threshold and skipped; the stale file
+      // (mtime 2 min ago) should be removed.
+      await cleanupStaleTempArchives({ outputPath, log });
+
+      // Active file preserved
+      await expect(fs.access(activeTmp)).resolves.toBeUndefined();
+      // Stale file removed
+      await expect(fs.access(staleTmp)).rejects.toMatchObject({ code: "ENOENT" });
+
+      expect(log).toHaveBeenCalledTimes(1);
+      expect(log.mock.calls[0][0]).toContain("Backup cleaned up 1 stale temp archive");
+      expect(log.mock.calls[0][0]).toContain("1 active temp archive skipped");
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("removes all matching temp archives when none are recent", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-backup-cleanup-"));
+    try {
+      const outputPath = path.join(dir, "backup.tar.gz");
+      const tmp1 = `${outputPath}.a1b2c3d4-e5f6-7890-abcd-ef1234567890.tmp`;
+      const tmp2 = `${outputPath}.12345678-90ab-cdef-1234-567890abcdef.tmp`;
+
+      await fs.writeFile(tmp1, "stale 1", "utf8");
+      await fs.writeFile(tmp2, "stale 2", "utf8");
+
+      // Make both files very old
+      const oldTime = new Date(Date.now() - 300_000); // 5 minutes ago
+      await fs.utimes(tmp1, oldTime, oldTime);
+      await fs.utimes(tmp2, oldTime, oldTime);
+
+      const log = vi.fn();
+      await cleanupStaleTempArchives({ outputPath, log });
+
+      await expect(fs.access(tmp1)).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(fs.access(tmp2)).rejects.toMatchObject({ code: "ENOENT" });
+
+      expect(log).toHaveBeenCalledTimes(1);
+      expect(log.mock.calls[0][0]).toContain("Backup cleaned up 2 stale temp archives");
+      // No active-skipped note when nothing was skipped
+      expect(log.mock.calls[0][0]).not.toContain("active temp archive");
     } finally {
       await fs.rm(dir, { recursive: true, force: true });
     }

--- a/src/infra/backup-create.test.ts
+++ b/src/infra/backup-create.test.ts
@@ -291,6 +291,123 @@ describe("writeTarArchiveWithRetry", () => {
   });
 });
 
+describe("cleanupStaleTempArchives", () => {
+  const { cleanupStaleTempArchives } = backupCreateInternals;
+
+  it("removes stale .tmp files matching the backup temp pattern", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-backup-cleanup-"));
+    try {
+      const outputPath = path.join(dir, "backup.tar.gz");
+      const stale1 = `${outputPath}.a1b2c3d4-e5f6-7890-abcd-ef1234567890.tmp`;
+      const stale2 = `${outputPath}.12345678-90ab-cdef-1234-567890abcdef.tmp`;
+      // File that should NOT be cleaned up (not matching UUID pattern)
+      const notStale = `${outputPath}.not-a-uuid.tmp`;
+      // Non-tmp file that should NOT be cleaned up
+      const finalArchive = outputPath;
+
+      await fs.writeFile(stale1, "stale content 1", "utf8");
+      await fs.writeFile(stale2, "stale content 2", "utf8");
+      await fs.writeFile(notStale, "not stale", "utf8");
+      await fs.writeFile(finalArchive, "final archive", "utf8");
+
+      const log = vi.fn();
+      await cleanupStaleTempArchives({ outputPath, log });
+
+      // Stale files removed
+      await expect(fs.access(stale1)).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(fs.access(stale2)).rejects.toMatchObject({ code: "ENOENT" });
+
+      // Non-matching files preserved
+      await expect(fs.access(notStale)).resolves.toBeUndefined();
+      await expect(fs.access(finalArchive)).resolves.toBeUndefined();
+
+      // Log should mention the cleanup
+      expect(log).toHaveBeenCalledTimes(1);
+      expect(log.mock.calls[0][0]).toContain("Backup cleaned up 2 stale temp archives");
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("does nothing when no stale temp archives exist", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-backup-cleanup-"));
+    try {
+      const outputPath = path.join(dir, "backup.tar.gz");
+
+      // Only a non-tmp file
+      await fs.writeFile(outputPath, "final archive", "utf8");
+
+      const log = vi.fn();
+      await cleanupStaleTempArchives({ outputPath, log });
+
+      // Final archive preserved
+      await expect(fs.access(outputPath)).resolves.toBeUndefined();
+
+      // No log messages emitted
+      expect(log).not.toHaveBeenCalled();
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("handles a non-existent output directory gracefully", async () => {
+    const outputPath = path.join(os.tmpdir(), "nonexistent-dir-9999", "backup.tar.gz");
+    const log = vi.fn();
+
+    await expect(
+      cleanupStaleTempArchives({ outputPath, log }),
+    ).resolves.toBeUndefined();
+
+    expect(log).not.toHaveBeenCalled();
+  });
+
+  it("does not match .tmp files from a differently-named archive", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-backup-cleanup-"));
+    try {
+      const outputPath = path.join(dir, "my-backup.tar.gz");
+      const otherOutputPath = path.join(dir, "other-backup.tar.gz");
+      // This file matches the pattern for `other-backup.tar.gz`, not `my-backup.tar.gz`
+      const otherStale = `${otherOutputPath}.a1b2c3d4-e5f6-7890-abcd-ef1234567890.tmp`;
+      // This file matches our output path
+      const myStale = `${outputPath}.12345678-90ab-cdef-1234-567890abcdef.tmp`;
+
+      await fs.writeFile(otherStale, "other archive stale", "utf8");
+      await fs.writeFile(myStale, "my stale", "utf8");
+
+      const log = vi.fn();
+      await cleanupStaleTempArchives({ outputPath, log });
+
+      // Only our .tmp removed
+      await expect(fs.access(myStale)).rejects.toMatchObject({ code: "ENOENT" });
+      // Other archive's .tmp preserved
+      await expect(fs.access(otherStale)).resolves.toBeUndefined();
+
+      expect(log).toHaveBeenCalledTimes(1);
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("reports total size of cleaned archives in human-readable format", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-backup-cleanup-"));
+    try {
+      const outputPath = path.join(dir, "backup.tar.gz");
+      const stale1 = `${outputPath}.a1b2c3d4-e5f6-7890-abcd-ef1234567890.tmp`;
+      // Write a multi-MB file to exercise the size label formatting
+      const largeContent = Buffer.alloc(2_097_152, "x"); // exactly 2 MB
+      await fs.writeFile(stale1, largeContent);
+
+      const log = vi.fn();
+      await cleanupStaleTempArchives({ outputPath, log });
+
+      expect(log).toHaveBeenCalledTimes(1);
+      expect(log.mock.calls[0][0]).toContain("(2.0MB)");
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
 describe("buildExtensionsNodeModulesFilter", () => {
   it("excludes dependency trees only under state extensions", () => {
     const filter = buildExtensionsNodeModulesFilter("/state/");

--- a/src/infra/backup-create.ts
+++ b/src/infra/backup-create.ts
@@ -252,10 +252,16 @@ function buildTempArchiveGlobPattern(outputPath: string): RegExp {
   return new RegExp(`^${escaped}\\.[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\\.tmp$`);
 }
 
+const BACKUP_TEMP_STALE_AGE_MS = 30_000;
+
 async function cleanupStaleTempArchives(params: {
   outputPath: string;
+  staleAgeMs?: number;
+  nowMs?: number;
   log?: (message: string) => void;
 }): Promise<void> {
+  const now = params.nowMs ?? Date.now();
+  const staleAge = params.staleAgeMs ?? BACKUP_TEMP_STALE_AGE_MS;
   const dir = path.dirname(params.outputPath);
   const pattern = buildTempArchiveGlobPattern(params.outputPath);
   let entries: import("node:fs").Dirent[];
@@ -276,6 +282,7 @@ async function cleanupStaleTempArchives(params: {
   }
   let cleaned = 0;
   let cleanedBytes = 0;
+  let skippedActive = 0;
   for (const entry of entries) {
     if (!entry.isFile() || !pattern.test(entry.name)) {
       continue;
@@ -285,6 +292,13 @@ async function cleanupStaleTempArchives(params: {
       const stat = await fs.stat(fullPath);
       // Defensive: skip non-files or already-deleted entries.
       if (!stat.isFile()) {
+        continue;
+      }
+      // Only remove temp archives whose mtime is older than the staleness
+      // threshold. This protects against concurrently running backup processes
+      // that are actively writing to a temp archive for the same output path.
+      if (now - stat.mtimeMs < staleAge) {
+        skippedActive += 1;
         continue;
       }
       const size = stat.size;
@@ -307,10 +321,14 @@ async function cleanupStaleTempArchives(params: {
         : cleanedBytes >= 1_048_576
           ? `${(cleanedBytes / 1_048_576).toFixed(1)}MB`
           : `${cleanedBytes} bytes`;
+    const skippedNote =
+      skippedActive > 0
+        ? ` (${skippedActive} active temp archive${skippedActive === 1 ? "" : "s"} skipped)`
+        : "";
     params.log?.(
       `Backup cleaned up ${cleaned} stale temp archive${
         cleaned === 1 ? "" : "s"
-      } (${sizeLabel}) from a previous interrupted run.`,
+      } (${sizeLabel}) from a previous interrupted run.${skippedNote}`,
     );
   }
 }

--- a/src/infra/backup-create.ts
+++ b/src/infra/backup-create.ts
@@ -191,7 +191,7 @@ async function writeTarArchiveWithRetry(params: {
   throw new Error(`Backup archive write failed: ${final.message}${suffix}`, { cause: final });
 }
 
-export const testApi = { writeTarArchiveWithRetry, isTarEofRaceError };
+export const testApi = { writeTarArchiveWithRetry, isTarEofRaceError, cleanupStaleTempArchives };
 export { testApi as __test };
 
 async function resolveOutputPath(params: {
@@ -244,6 +244,75 @@ async function assertOutputPathReady(outputPath: string): Promise<void> {
 
 function buildTempArchivePath(outputPath: string): string {
   return `${outputPath}.${randomUUID()}.tmp`;
+}
+
+function buildTempArchiveGlobPattern(outputPath: string): RegExp {
+  const escaped = path.basename(outputPath).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  // Match <basename>.<uuid>.tmp where uuid is a standard v4 hex pattern.
+  return new RegExp(`^${escaped}\\.[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\\.tmp$`);
+}
+
+async function cleanupStaleTempArchives(params: {
+  outputPath: string;
+  log?: (message: string) => void;
+}): Promise<void> {
+  const dir = path.dirname(params.outputPath);
+  const pattern = buildTempArchiveGlobPattern(params.outputPath);
+  let entries: import("node:fs").Dirent[];
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true });
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    // ENOENT is fine — the directory doesn't exist yet, so there's nothing to
+    // clean up. Other errors (EPERM, EACCES) are also non-fatal: the backup
+    // archiver will report them at the point where it needs the directory.
+    if (code === "ENOENT") {
+      return;
+    }
+    params.log?.(
+      `Backup could not list the output directory to clean up stale temp archives: ${String(err)}. Continuing.`,
+    );
+    return;
+  }
+  let cleaned = 0;
+  let cleanedBytes = 0;
+  for (const entry of entries) {
+    if (!entry.isFile() || !pattern.test(entry.name)) {
+      continue;
+    }
+    const fullPath = path.join(dir, entry.name);
+    try {
+      const stat = await fs.stat(fullPath);
+      // Defensive: skip non-files or already-deleted entries.
+      if (!stat.isFile()) {
+        continue;
+      }
+      const size = stat.size;
+      await fs.rm(fullPath);
+      cleaned += 1;
+      cleanedBytes += size;
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== "ENOENT") {
+        params.log?.(
+          `Backup could not remove stale temp archive ${fullPath}: ${String(err)}. Continuing.`,
+        );
+      }
+    }
+  }
+  if (cleaned > 0) {
+    const sizeLabel =
+      cleanedBytes >= 1_073_741_824
+        ? `${(cleanedBytes / 1_073_741_824).toFixed(1)}GB`
+        : cleanedBytes >= 1_048_576
+          ? `${(cleanedBytes / 1_048_576).toFixed(1)}MB`
+          : `${cleanedBytes} bytes`;
+    params.log?.(
+      `Backup cleaned up ${cleaned} stale temp archive${
+        cleaned === 1 ? "" : "s"
+      } (${sizeLabel}) from a previous interrupted run.`,
+    );
+  }
 }
 
 async function pathExists(targetPath: string): Promise<boolean> {
@@ -615,6 +684,7 @@ export async function createBackupArchive(
 
   if (!opts.dryRun) {
     await assertOutputPathReady(outputPath);
+    await cleanupStaleTempArchives({ outputPath, log: opts.log });
   }
 
   const createdAt = new Date(nowMs).toISOString();


### PR DESCRIPTION

## Summary

When `openclaw backup create` is interrupted (timeout, SIGKILL, process crash), the temporary `.tar.gz.<uuid>.tmp` file created by `buildTempArchivePath()` is left on disk. On successive runs, each interrupted backup leaves a new `.tmp` file, accumulating and consuming significant disk space (12.6GB across 6 files reported in #50442).

This PR adds `cleanupStaleTempArchives()` that scans the output directory for files matching the backup temp pattern (`<basename>.<uuid>.tmp`) and removes **stale** ones before creating a new archive.

**Key safety property:** Only `.tmp` files whose mtime is older than a 30 s staleness threshold (`BACKUP_TEMP_STALE_AGE_MS`) are removed. This protects against concurrently running backup processes that target the same output path — their actively-written temp archive will be preserved, and the count of skipped active archives is reported in the log message for observability.

The cleanup is non-fatal — errors from missing directories or permission issues are gracefully caught and logged without blocking the backup.

## Changes

- **`src/infra/backup-create.ts`**: Added `buildTempArchiveGlobPattern()`, `cleanupStaleTempArchives()`, and the `BACKUP_TEMP_STALE_AGE_MS` constant (30 s). Called in `createBackupArchive()` before creating the new temp archive (after the overwrite guard, in the non-dry-run path). Exported via `testApi` for testing.
- **`src/infra/backup-create.test.ts`**: Added 7 tests covering:
  - Removal of stale `.tmp` files matching the UUID pattern
  - Preservation of non-tmp files and the final archive
  - Graceful handling of non-existent directories
  - Scoping to only the target archive (not differently-named archives in the same directory)
  - Human-readable size reporting in log output
  - **Active temp archive protection**: files within the staleness threshold are skipped and reported
  - All-stale cleanup when no files are recent

## Real behavior proof

**Behavior addressed:** Stale `.tmp` files from interrupted `openclaw backup create` runs accumulate on disk (up to 12.6GB reported), because the process has no mechanism to discover and remove leftovers before starting a new backup. Additionally, the v1 cleanup could collide with a concurrently running backup targeting the same output path.

**Real environment tested:** Node v22.22.0, Linux 4.19.112-2.el8.x86_64, commit 39c4cf6d36. `tsx` v4.22.3 used to import the actual production module from `src/infra/backup-create.js`.

**Exact steps or command run after this patch:**

1. Import the actual `cleanupStaleTempArchives` from `src/infra/backup-create.js` (real production module, not copied logic)
2. Create 1 active `.tmp` file (mtime = now, simulating a concurrent `openclaw backup create` writer)
3. Create 3 stale `.tmp` files (mtime = 150 s ago, sizes 5MB + 3MB + 2MB, simulating 3 interrupted runs)
4. Invoke `cleanupStaleTempArchives({ outputPath, log })` with default 30 s staleness threshold
5. Verify active file preserved, all 3 stale files removed

**Evidence after fix (terminal capture):**

$ npx tsx -e 'import fs from "node:fs/promises"; import os from "node:os"; import path from "node:path";
const { testApi } = await import("./src/infra/backup-create.js");
const { cleanupStaleTempArchives } = testApi;
const dir = await fs.mkdtemp(path.join(os.tmpdir(), "oc-proof-real-import-"));
const outputPath = path.join(dir, "openclaw-backup.tar.gz");
const activeTmp = outputPath + ".a1b2c3d4-e5f6-7890-abcd-ef1234567890.tmp";
await fs.writeFile(activeTmp, "ACTIVE: backup being written by concurrent process", "utf8");
const stale1 = outputPath + ".b2c3d4e5-f6a7-8901-bcde-f12345678901.tmp";
const stale2 = outputPath + ".c3d4e5f6-a7b8-9012-cdef-123456789012.tmp";
const stale3 = outputPath + ".d4e5f6a7-b8c9-0123-defa-234567890123.tmp";
await fs.writeFile(stale1, Buffer.alloc(5_242_880, "x")); await fs.writeFile(stale2, Buffer.alloc(3_145_728, "y")); await fs.writeFile(stale3, Buffer.alloc(2_097_152, "z"));
const oldTime = new Date(Date.now() - 150_000);
await fs.utimes(stale1, oldTime, oldTime); await fs.utimes(stale2, oldTime, oldTime); await fs.utimes(stale3, oldTime, oldTime);
console.log("Before cleanup:");
for (const f of await fs.readdir(dir)) { const s = await fs.stat(path.join(dir, f)); console.log(" ", f, "|", (s.size/1048576).toFixed(1)+"MB", "|", Math.round((Date.now()-s.mtimeMs)/1000)+"s ago"); }
const logs = [];
await cleanupStaleTempArchives({ outputPath, log: (msg) => logs.push(msg) });
console.log("\nLog:", logs[0]);
console.log("\nAfter cleanup:");
for (const f of await fs.readdir(dir)) console.log(" ", f);
await fs.rm(dir, { recursive: true, force: true });'


Before cleanup:
  openclaw-backup.tar.gz.a1b2c3d4-e5f6-7890-abcd-ef1234567890.tmp | 0.0MB | 0s ago
  openclaw-backup.tar.gz.b2c3d4e5-f6a7-8901-bcde-f12345678901.tmp | 5.0MB | 150s ago
  openclaw-backup.tar.gz.c3d4e5f6-a7b8-9012-cdef-123456789012.tmp | 3.0MB | 150s ago
  openclaw-backup.tar.gz.d4e5f6a7-b8c9-0123-defa-234567890123.tmp | 2.0MB | 150s ago

Log: Backup cleaned up 3 stale temp archives (10.0MB) from a previous interrupted run. (1 active temp archive skipped)

After cleanup:
  openclaw-backup.tar.gz.a1b2c3d4-e5f6-7890-abcd-ef1234567890.tmp

exit code: 0

**Observed result after fix:**
- 3 stale `.tmp` files (10.0MB total) were removed
- 1 active `.tmp` file (concurrent writer) was preserved — staleness guard works
- Log correctly reports "3 stale temp archives" + "(1 active temp archive skipped)"
- The function was imported from the real `src/infra/backup-create.js` module path, not copied inline

**What was not tested:**
- End-to-end `openclaw backup create` CLI command with a full OpenClaw state directory (requires building the entire project and having real agent state)
- Signal-handler cleanup for the interrupted process itself (SIGTERM/SIGKILL still cannot run JavaScript cleanup — this PR mitigates on the next run)
- Behavior when the backup output path is on a network filesystem where mtime precision may differ
