### PR TITLE
fix(android): queue notification events until node connect

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -72,8 +72,51 @@ import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
+import java.util.ArrayDeque
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicLong
+
+private const val NOTIFICATIONS_CHANGED_EVENT = "notifications.changed"
+private const val MAX_PENDING_NOTIFICATION_EVENTS = 128
+
+internal data class PendingNotificationEvent(
+  val event: String,
+  val payloadJson: String?,
+)
+
+internal class PendingNotificationEventQueue(
+  private val maxSize: Int = MAX_PENDING_NOTIFICATION_EVENTS,
+) {
+  private val lock = Any()
+  private val pending = ArrayDeque<PendingNotificationEvent>()
+
+  fun add(event: PendingNotificationEvent) {
+    synchronized(lock) {
+      while (pending.size >= maxSize) {
+        pending.removeFirst()
+      }
+      pending.addLast(event)
+    }
+  }
+
+  fun drain(): List<PendingNotificationEvent> =
+    synchronized(lock) {
+      val drained = pending.toList()
+      pending.clear()
+      drained
+    }
+
+  fun prepend(events: List<PendingNotificationEvent>) {
+    synchronized(lock) {
+      for (event in events.asReversed()) {
+        while (pending.size >= maxSize) {
+          pending.removeLast()
+        }
+        pending.addFirst(event)
+      }
+    }
+  }
+}
 
 /**
  * Process runtime that owns gateway sessions, node command handlers, capture managers, and UI-facing state.
@@ -421,6 +464,7 @@ class NodeRuntime(
   private val canvasRehydrateSeq = AtomicLong(0)
 
   @Volatile private var nodePresenceAliveLastSuccessAtMs: Long? = null
+  private val pendingNotificationEvents = PendingNotificationEventQueue()
   private var operatorConnected = false
   private var operatorStatusText: String = "Offline"
   private var nodeStatusText: String = "Offline"
@@ -501,6 +545,8 @@ class NodeRuntime(
         updateStatus()
         showLocalCanvasOnConnect()
         publishNodePresenceAliveBeacon(NodePresenceAliveBeacon.Trigger.Connect)
+        flushQueuedNotificationEvents()
+        DeviceNotificationListenerService.reconcileActiveNotifications()
         val endpoint = connectedEndpoint
         val auth = activeGatewayAuth
         if (endpoint != null && auth != null) {
@@ -530,7 +576,32 @@ class NodeRuntime(
   init {
     DeviceNotificationListenerService.setNodeEventSink { event, payloadJson ->
       scope.launch {
-        nodeSession.sendNodeEvent(event = event, payloadJson = payloadJson)
+        sendNotificationEventOrQueue(event = event, payloadJson = payloadJson)
+      }
+    }
+  }
+
+  private suspend fun sendNotificationEventOrQueue(
+    event: String,
+    payloadJson: String?,
+  ) {
+    val sent = nodeSession.sendNodeEvent(event = event, payloadJson = payloadJson)
+    if (!sent && event == NOTIFICATIONS_CHANGED_EVENT) {
+      pendingNotificationEvents.add(
+        PendingNotificationEvent(event = event, payloadJson = payloadJson),
+      )
+    }
+  }
+
+  private fun flushQueuedNotificationEvents() {
+    scope.launch {
+      val drained = pendingNotificationEvents.drain()
+      for ((index, pending) in drained.withIndex()) {
+        val sent = nodeSession.sendNodeEvent(event = pending.event, payloadJson = pending.payloadJson)
+        if (!sent) {
+          pendingNotificationEvents.prepend(drained.drop(index))
+          return@launch
+        }
       }
     }
   }

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
@@ -199,6 +199,8 @@ class GatewaySession(
 
   @Volatile private var currentConnection: Connection? = null
 
+  @Volatile private var connectingConnection: Connection? = null
+
   // One reconnect can retry a shared-token mismatch by pairing the shared token with the stored device token.
   @Volatile private var pendingDeviceTokenRetry = false
 
@@ -216,34 +218,34 @@ class GatewaySession(
     options: GatewayConnectOptions,
     tls: GatewayTlsParams? = null,
   ) {
-    val connectionToClose: Connection?
+    val connectionsToClose: List<Connection>
     synchronized(lifecycleLock) {
       desired = DesiredConnection(endpoint, token, bootstrapToken, password, options, tls)
       pendingDeviceTokenRetry = false
       deviceTokenRetryBudgetUsed = false
       reconnectPausedForAuthFailure = false
-      connectionToClose = currentConnection
+      connectionsToClose = listOfNotNull(currentConnection, connectingConnection).distinct()
       if (job?.isActive != true) {
         job = scope.launch(Dispatchers.IO) { runLoop() }
       }
     }
-    connectionToClose?.closeQuietly()
+    connectionsToClose.forEach { it.closeQuietly() }
   }
 
   /** Clears desired connection state, closes the socket, and stops reconnect attempts. */
   fun disconnect() {
     val jobToCancel: Job?
-    val connectionToClose: Connection?
+    val connectionsToClose: List<Connection>
     synchronized(lifecycleLock) {
       desired = null
       pendingDeviceTokenRetry = false
       deviceTokenRetryBudgetUsed = false
       reconnectPausedForAuthFailure = false
-      connectionToClose = currentConnection
+      connectionsToClose = listOfNotNull(currentConnection, connectingConnection).distinct()
       jobToCancel = job
       job = null
     }
-    connectionToClose?.closeQuietly()
+    connectionsToClose.forEach { it.closeQuietly() }
     scope.launch(Dispatchers.IO) {
       jobToCancel?.cancelAndJoin()
       if (desired == null) {
@@ -257,7 +259,7 @@ class GatewaySession(
   /** Forces the current socket closed so the loop reconnects to the current desired endpoint. */
   fun reconnect() {
     reconnectPausedForAuthFailure = false
-    currentConnection?.closeQuietly()
+    listOfNotNull(currentConnection, connectingConnection).distinct().forEach { it.closeQuietly() }
   }
 
   fun currentCanvasHostUrl(): String? = pluginSurfaceUrls["canvas"]
@@ -409,7 +411,16 @@ class GatewaySession(
     val error: ErrorShape?,
   )
 
+  private fun promoteConnectedConnection(conn: Connection): Boolean =
+    synchronized(lifecycleLock) {
+      if (desired != conn.desiredTarget || connectingConnection !== conn) return@synchronized false
+      currentConnection = conn
+      connectingConnection = null
+      true
+    }
+
   private inner class Connection(
+    val desiredTarget: DesiredConnection,
     val endpoint: GatewayEndpoint,
     private val token: String?,
     private val bootstrapToken: String?,
@@ -662,6 +673,9 @@ class GatewaySession(
           deviceAuthStore.clearToken(identity.deviceId, options.role)
         }
         throw GatewayConnectFailure(error)
+      }
+      if (!promoteConnectedConnection(this)) {
+        throw IllegalStateException("connection no longer desired")
       }
       handleConnectSuccess(res, identity.deviceId, selectedAuth.authSource)
       connectDeferred.complete(Unit)
@@ -1093,18 +1107,34 @@ class GatewaySession(
     withContext(Dispatchers.IO) {
       val conn =
         Connection(
-          target.endpoint,
-          target.token,
-          target.bootstrapToken,
-          target.password,
-          target.options,
-          target.tls,
+          desiredTarget = target,
+          endpoint = target.endpoint,
+          token = target.token,
+          bootstrapToken = target.bootstrapToken,
+          password = target.password,
+          options = target.options,
+          tls = target.tls,
         )
-      currentConnection = conn
+      val shouldConnect =
+        synchronized(lifecycleLock) {
+          if (desired == target) {
+            connectingConnection = conn
+            true
+          } else {
+            false
+          }
+        }
+      if (!shouldConnect) {
+        conn.closeQuietly()
+        return@withContext
+      }
       try {
         conn.connect()
         conn.awaitClose()
       } finally {
+        if (connectingConnection === conn) {
+          connectingConnection = null
+        }
         if (currentConnection === conn) {
           currentConnection = null
           pluginSurfaceUrls = emptyMap()

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/DeviceNotificationListenerService.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/DeviceNotificationListenerService.kt
@@ -105,13 +105,17 @@ private object DeviceNotificationStore {
   private val lock = Any()
   private var connected = false
   private val byKey = LinkedHashMap<String, DeviceNotificationEntry>()
+  private val postedEventKeys = LinkedHashSet<String>()
 
   fun replace(entries: List<DeviceNotificationEntry>) {
     synchronized(lock) {
       byKey.clear()
+      val activeKeys = LinkedHashSet<String>()
       for (entry in entries) {
         byKey[entry.key] = entry
+        activeKeys += entry.key
       }
+      postedEventKeys.retainAll(activeKeys)
     }
   }
 
@@ -124,8 +128,22 @@ private object DeviceNotificationStore {
   fun remove(key: String) {
     synchronized(lock) {
       byKey.remove(key)
+      postedEventKeys.remove(key)
     }
   }
+
+  fun notePostedEvent(key: String) {
+    synchronized(lock) {
+      postedEventKeys += key
+    }
+  }
+
+  fun entriesMissingPostedEvents(): List<DeviceNotificationEntry> =
+    synchronized(lock) {
+      byKey.values
+        .filter { !postedEventKeys.contains(it.key) }
+        .sortedByDescending { it.postTimeMs }
+    }
 
   fun setConnected(value: Boolean) {
     synchronized(lock) {
@@ -133,6 +151,7 @@ private object DeviceNotificationStore {
       if (!value) {
         // Android invalidates activeNotifications when the listener disconnects.
         byKey.clear()
+        postedEventKeys.clear()
       }
     }
   }
@@ -150,6 +169,21 @@ private object DeviceNotificationStore {
   }
 }
 
+internal fun replayMissedActiveNotificationEntries(
+  entries: List<DeviceNotificationEntry>,
+  emitPosted: (DeviceNotificationEntry) -> Boolean,
+): Int {
+  DeviceNotificationStore.replace(entries)
+  var replayed = 0
+  for (entry in DeviceNotificationStore.entriesMissingPostedEvents()) {
+    if (emitPosted(entry)) {
+      DeviceNotificationStore.notePostedEvent(entry.key)
+      replayed += 1
+    }
+  }
+  return replayed
+}
+
 /**
  * Android notification listener that mirrors notification state and executes gateway actions.
  */
@@ -161,7 +195,7 @@ class DeviceNotificationListenerService : NotificationListenerService() {
     super.onListenerConnected()
     activeService = this
     DeviceNotificationStore.setConnected(true)
-    refreshActiveNotifications()
+    reconcileActiveNotifications()
   }
 
   override fun onListenerDisconnected() {
@@ -187,8 +221,7 @@ class DeviceNotificationListenerService : NotificationListenerService() {
     if (entry.packageName == packageName) {
       return
     }
-    val payload = notificationChangedPayload(entry) ?: return
-    emitNotificationsChanged(payload)
+    emitPostedNotification(entry)
   }
 
   override fun onNotificationRemoved(sbn: StatusBarNotification?) {
@@ -215,6 +248,13 @@ class DeviceNotificationListenerService : NotificationListenerService() {
         isClearable = removed.isClearable,
       ) ?: return
     emitNotificationsChanged(payload)
+  }
+
+  private fun emitPostedNotification(entry: DeviceNotificationEntry): Boolean {
+    val payload = notificationChangedPayload(entry) ?: return false
+    if (!emitNotificationsChanged(payload)) return false
+    DeviceNotificationStore.notePostedEvent(entry.key)
+    return true
   }
 
   private fun notificationChangedPayload(entry: DeviceNotificationEntry): String? =
@@ -272,14 +312,14 @@ class DeviceNotificationListenerService : NotificationListenerService() {
     }.toString()
   }
 
-  private fun refreshActiveNotifications() {
+  private fun reconcileActiveNotifications() {
     val entries =
       runCatching {
         activeNotifications
           ?.mapNotNull { it.toEntry() }
           ?: emptyList()
       }.getOrElse { emptyList() }
-    DeviceNotificationStore.replace(entries)
+    replayMissedActiveNotificationEntries(entries, ::emitPostedNotification)
   }
 
   private fun StatusBarNotification.toEntry(): DeviceNotificationEntry {
@@ -361,6 +401,11 @@ class DeviceNotificationListenerService : NotificationListenerService() {
       enabled: Boolean = isAccessEnabled(context),
     ): DeviceNotificationSnapshot = DeviceNotificationStore.snapshot(enabled = enabled)
 
+    /** Replays active posted notifications that were not emitted before the gateway became ready. */
+    fun reconcileActiveNotifications() {
+      activeService?.reconcileActiveNotifications()
+    }
+
     /** Asks Android to rebind the listener after settings grant access but callbacks have not arrived. */
     fun requestServiceRebind(context: Context) {
       runCatching {
@@ -390,11 +435,12 @@ class DeviceNotificationListenerService : NotificationListenerService() {
       return service.executeActionInternal(request)
     }
 
-    private fun emitNotificationsChanged(payloadJson: String) {
+    private fun emitNotificationsChanged(payloadJson: String): Boolean =
       runCatching {
-        nodeEventSink?.invoke(NOTIFICATIONS_CHANGED_EVENT, payloadJson)
-      }
-    }
+        val sink = nodeEventSink ?: return false
+        sink.invoke(NOTIFICATIONS_CHANGED_EVENT, payloadJson)
+        true
+      }.getOrDefault(false)
 
     private fun rememberRecentPackage(packageName: String?) {
       val service = activeService ?: return

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionInvokeTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionInvokeTest.kt
@@ -22,6 +22,7 @@ import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.RecordedRequest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -793,6 +794,113 @@ class GatewaySessionInvokeTest {
 
         assertEquals(true, sent)
         assertEquals("agent.request", params["event"]?.jsonPrimitive?.content)
+      } finally {
+        shutdownHarness(harness, server)
+      }
+    }
+
+  @Test
+  fun sendNodeEvent_returnsFalseWhileConnectResponseIsPending() =
+    runBlocking {
+      val json = testJson()
+      val connected = CompletableDeferred<Unit>()
+      val connectStarted = CompletableDeferred<Unit>()
+      val nodeEventSeen = CompletableDeferred<Unit>()
+      val lastDisconnect = AtomicReference("")
+      val methods = CopyOnWriteArrayList<String>()
+      val connectSocket = AtomicReference<WebSocket?>()
+      val server =
+        startGatewayServer(json) { webSocket, _, method, _ ->
+          methods += method
+          when (method) {
+            "connect" -> {
+              connectSocket.set(webSocket)
+              connectStarted.complete(Unit)
+            }
+            "node.event" -> nodeEventSeen.complete(Unit)
+          }
+        }
+
+      val harness =
+        createNodeHarness(
+          connected = connected,
+          lastDisconnect = lastDisconnect,
+        ) { GatewaySession.InvokeResult.ok("""{"handled":true}""") }
+
+      try {
+        connectNodeSession(harness.session, server.port)
+        withTimeout(TEST_TIMEOUT_MS) { connectStarted.await() }
+
+        val sent =
+          withTimeout(500) {
+            harness.session.sendNodeEvent(
+              event = "notifications.changed",
+              payloadJson = """{"key":"pending-connect"}""",
+            )
+          }
+
+        assertFalse(sent)
+        assertNull(withTimeoutOrNull(300) { nodeEventSeen.await() })
+        assertEquals(listOf("connect"), methods.toList())
+      } finally {
+        connectSocket.get()?.close(1000, "done")
+        shutdownHarness(harness, server)
+      }
+    }
+
+  @Test
+  fun onConnectedCallbackCanSendNodeEventAfterConnectSuccess() =
+    runBlocking {
+      val json = testJson()
+      val nodeEventParams = CompletableDeferred<JsonObject>()
+      val callbackSent = CompletableDeferred<Boolean>()
+      val lastDisconnect = AtomicReference("")
+      val sessionJob = SupervisorJob()
+      lateinit var session: GatewaySession
+      val server =
+        startGatewayServer(json) { webSocket, id, method, frame ->
+          when (method) {
+            "connect" -> webSocket.send(connectResponseFrame(id))
+            "node.event" -> {
+              if (!nodeEventParams.isCompleted) {
+                nodeEventParams.complete(frame["params"]?.jsonObject ?: JsonObject(emptyMap()))
+              }
+              webSocket.send(
+                """{"type":"res","id":"$id","ok":true,"payload":{"handled":true}}""",
+              )
+              webSocket.close(1000, "done")
+            }
+          }
+        }
+      val app = RuntimeEnvironment.getApplication()
+      val deviceAuthStore = InMemoryDeviceAuthStore()
+      session =
+        GatewaySession(
+          scope = CoroutineScope(sessionJob + Dispatchers.Default),
+          identityStore = DeviceIdentityStore(app),
+          deviceAuthStore = deviceAuthStore,
+          onConnected = {
+            runBlocking {
+              callbackSent.complete(
+                session.sendNodeEvent(
+                  event = "notifications.changed",
+                  payloadJson = """{"key":"after-connect"}""",
+                ),
+              )
+            }
+          },
+          onDisconnected = { message -> lastDisconnect.set(message) },
+          onEvent = { _, _ -> },
+          onInvoke = { GatewaySession.InvokeResult.ok("""{"handled":true}""") },
+        )
+      val harness = NodeHarness(session = session, sessionJob = sessionJob, deviceAuthStore = deviceAuthStore)
+
+      try {
+        connectNodeSession(harness.session, server.port)
+
+        assertEquals(true, withTimeout(TEST_TIMEOUT_MS) { callbackSent.await() })
+        val params = withTimeout(TEST_TIMEOUT_MS) { nodeEventParams.await() }
+        assertEquals("notifications.changed", params["event"]?.jsonPrimitive?.content)
       } finally {
         shutdownHarness(harness, server)
       }

--- a/apps/android/app/src/test/java/ai/openclaw/app/node/DeviceNotificationListenerServiceTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/node/DeviceNotificationListenerServiceTest.kt
@@ -3,6 +3,8 @@ package ai.openclaw.app.node
 import ai.openclaw.app.NotificationBurstLimiter
 import ai.openclaw.app.NotificationForwardingPolicy
 import ai.openclaw.app.NotificationPackageFilterMode
+import ai.openclaw.app.PendingNotificationEvent
+import ai.openclaw.app.PendingNotificationEventQueue
 import ai.openclaw.app.isWithinQuietHours
 import android.content.Context
 import org.junit.Assert.assertEquals
@@ -128,4 +130,108 @@ class DeviceNotificationListenerServiceTest {
     assertTrue(limiter.allow(nowEpochMs = nowEpochMs, maxEventsPerMinute = 2))
     assertFalse(limiter.allow(nowEpochMs = nowEpochMs, maxEventsPerMinute = 2))
   }
+
+  @Test
+  fun reconcileActiveNotificationEntries_replaysMissedPostsWithoutDuplicatingDeliveredKeys() {
+    val first = sampleNotificationEntry(key = "first", postTimeMs = 100L)
+    val second = sampleNotificationEntry(key = "second", postTimeMs = 200L)
+    val third = sampleNotificationEntry(key = "third", postTimeMs = 300L)
+    val emitted = mutableListOf<String>()
+
+    try {
+      replayMissedActiveNotificationEntries(emptyList()) { false }
+
+      assertEquals(
+        2,
+        replayMissedActiveNotificationEntries(listOf(first, second)) { entry ->
+          emitted += entry.key
+          true
+        },
+      )
+      assertEquals(listOf("second", "first"), emitted)
+
+      assertEquals(
+        0,
+        replayMissedActiveNotificationEntries(listOf(first, second)) { entry ->
+          emitted += entry.key
+          true
+        },
+      )
+
+      assertEquals(
+        1,
+        replayMissedActiveNotificationEntries(listOf(first, second, third)) { entry ->
+          emitted += entry.key
+          true
+        },
+      )
+      assertEquals(listOf("second", "first", "third"), emitted)
+    } finally {
+      replayMissedActiveNotificationEntries(emptyList()) { false }
+    }
+  }
+
+  @Test
+  fun reconcileActiveNotificationEntries_retriesWhenSinkIsUnavailable() {
+    val entry = sampleNotificationEntry(key = "retry", postTimeMs = 100L)
+    val emitted = mutableListOf<String>()
+
+    try {
+      replayMissedActiveNotificationEntries(emptyList()) { false }
+
+      assertEquals(
+        0,
+        replayMissedActiveNotificationEntries(listOf(entry)) {
+          false
+        },
+      )
+      assertEquals(
+        1,
+        replayMissedActiveNotificationEntries(listOf(entry)) { candidate ->
+          emitted += candidate.key
+          true
+        },
+      )
+      assertEquals(listOf("retry"), emitted)
+    } finally {
+      replayMissedActiveNotificationEntries(emptyList()) { false }
+    }
+  }
+
+  @Test
+  fun pendingNotificationQueue_isBoundedAndPrependsFailedFlushRemainder() {
+    val queue = PendingNotificationEventQueue(maxSize = 2)
+    queue.add(PendingNotificationEvent(event = "notifications.changed", payloadJson = "first"))
+    queue.add(PendingNotificationEvent(event = "notifications.changed", payloadJson = "second"))
+    queue.add(PendingNotificationEvent(event = "notifications.changed", payloadJson = "third"))
+
+    assertEquals(listOf("second", "third"), queue.drain().map { it.payloadJson })
+
+    queue.add(PendingNotificationEvent(event = "notifications.changed", payloadJson = "new"))
+    queue.prepend(
+      listOf(
+        PendingNotificationEvent(event = "notifications.changed", payloadJson = "failed"),
+        PendingNotificationEvent(event = "notifications.changed", payloadJson = "remaining"),
+      ),
+    )
+
+    assertEquals(listOf("failed", "remaining"), queue.drain().map { it.payloadJson })
+  }
+
+  private fun sampleNotificationEntry(
+    key: String,
+    postTimeMs: Long,
+  ): DeviceNotificationEntry =
+    DeviceNotificationEntry(
+      key = key,
+      packageName = "com.example.app",
+      title = "Title $key",
+      text = "Body $key",
+      subText = null,
+      category = null,
+      channelId = null,
+      postTimeMs = postTimeMs,
+      isOngoing = false,
+      isClearable = true,
+    )
 }


### PR DESCRIPTION
## Summary

- Fixes the Android node gateway handshake window so `node.event` cannot be sent before the `connect` RPC has succeeded.
- Adds a bounded queue for failed `notifications.changed` events and flushes it after node reconnect.
- Reconciles active Android notifications after listener/node reconnect so missed posted notifications are replayed without duplicating already emitted keys.

## Real behavior proof

- **Behavior or issue addressed:** Android notification forwarding could emit `notifications.changed` as `node.event` while the WebSocket `connect` RPC was still pending, making the gateway reject the session because the first accepted request was not the completed connect handshake. Reconnect windows could also drop notification events because failed sends were not queued and active notifications were not replayed.
- **Why it matters / User impact:** Android users could miss notification forwarding events after app start or reconnect, and the node session could enter an invalid handshake state instead of recovering cleanly.
- **Real environment tested:** Local Linux Android JVM/Robolectric environment using the production Android `GatewaySession`, `NodeRuntime`, and `DeviceNotificationListenerService` code paths with OkHttp WebSocket + MockWebServer gateway. `ANDROID_HOME=$HOME/.android-sdk`; `JAVA_HOME=$HOME/.jdks/jdk-21.0.7+6`.
- **Exact steps or command run after this patch:** From `apps/android`: `ANDROID_HOME="$HOME/.android-sdk" ANDROID_SDK_ROOT="$HOME/.android-sdk" JAVA_HOME="$HOME/.jdks/jdk-21.0.7+6" ./gradlew --no-daemon :app:testPlayDebugUnitTest --tests ai.openclaw.app.gateway.GatewaySessionInvokeTest --tests ai.openclaw.app.node.DeviceNotificationListenerServiceTest --rerun-tasks`
- **Evidence after fix:** Evidence log: `openclaw-issue-79552-evidence/android-focused-tests-after-commit.log`

      > Task :app:testPlayDebugUnitTest
      BUILD SUCCESSFUL in 3m 13s
      30 actionable tasks: 30 executed

- **Observed result after fix:** The focused JVM run exercised the production Android WebSocket session and notification listener paths. The new gateway regression verifies `sendNodeEvent()` returns false while the connect response is pending and the server only observes `connect`; the companion regression verifies `onConnected` can immediately send `notifications.changed` after connect success. The notification regressions verify bounded queue behavior, failed flush re-prepending, active-notification replay, retry when the sink is unavailable, and no duplicate replay of delivered keys.
- **What was not tested:** No physical Android device, OS notification shade, or external OpenClaw gateway was used; the proof is limited to local Android JVM/Robolectric plus local WebSocket gateway behavior.
- **Fix classification:** Root cause fix.

## Review findings addressed

- No maintainer review findings existed for this new PR at submission time.
- ClawSweeper issue criteria were covered locally: focused `GatewaySessionInvokeTest`, focused `DeviceNotificationListenerServiceTest`, and `git diff --check`.

## Regression Test Plan

- **Target test file:** `apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionInvokeTest.kt` and `apps/android/app/src/test/java/ai/openclaw/app/node/DeviceNotificationListenerServiceTest.kt`.
- **Scenario locked in:** The regression tests lock the exact lifecycle scenario: a WebSocket is open, the gateway has received the `connect` request, the connect response is still pending, and Android notification forwarding attempts to send `notifications.changed`. They also lock the reconnect scenario where queued notification events flush after connect and active posted notifications replay only when their keys have not already emitted a posted event.
- **Why this is the smallest reliable guardrail:** The guardrail lives at the Android node/gateway boundary that was broken. It checks the real `GatewaySession.sendNodeEvent()` result and the notification replay state instead of asserting implementation details, so future refactors can change internals without reintroducing pre-handshake `node.event` delivery or duplicate active-notification replay.
- Android focused JVM tests:

      cd apps/android
      ANDROID_HOME="$HOME/.android-sdk" ANDROID_SDK_ROOT="$HOME/.android-sdk" JAVA_HOME="$HOME/.jdks/jdk-21.0.7+6" ./gradlew --no-daemon :app:testPlayDebugUnitTest --tests ai.openclaw.app.gateway.GatewaySessionInvokeTest --tests ai.openclaw.app.node.DeviceNotificationListenerServiceTest --rerun-tasks

  Result: `BUILD SUCCESSFUL in 3m 13s`; evidence: `openclaw-issue-79552-evidence/android-focused-tests-after-commit.log`.
- Android ktlint:

      cd apps/android
      ANDROID_HOME="$HOME/.android-sdk" ANDROID_SDK_ROOT="$HOME/.android-sdk" JAVA_HOME="$HOME/.jdks/jdk-21.0.7+6" ./gradlew --no-daemon :app:ktlintCheck :benchmark:ktlintCheck

  Result: `BUILD SUCCESSFUL in 22s`; evidence: `openclaw-issue-79552-evidence/android-ktlint-after-commit.log`.
- Whitespace check:

      git diff --check

  Result: passed with no output; evidence: `openclaw-issue-79552-evidence/git-diff-check-after-commit.log`.

## Merge risk

- **Risk labels considered:** `merge-risk: 🚨 message-delivery`, `merge-risk: 🚨 availability`, `merge-risk: 🚨 session-state`.
- **What did NOT change:** Out of scope: gateway wire format, `node.event` payload schema, notification action APIs, Android forwarding policy defaults, provider/auth token selection, `agent.request`, and presence beacon behavior remain unchanged. The patch only changes when the Android node exposes a ready connection and how `notifications.changed` recovers during reconnect.
- **Architecture / source-of-truth check:** The source-of-truth boundary is Android `GatewaySession` connection lifecycle state plus `DeviceNotificationStore` active-notification state. This does not add a new public contract, schema, default, migration, or partial override; it restores the existing protocol invariant that the first gateway RPC for a socket is `connect`. Related open PR scan for issue #79552 found no linked open PRs in `openclaw-issue-79552-evidence/linked-open-prs-for-issue.json`.
- **Risk explanation:** The patch changes Android node connection readiness and notification event delivery around reconnect. It deliberately limits queueing to `notifications.changed`, keeps `agent.request` and presence beacon failure semantics unchanged, bounds queued notifications to 128 entries, and only promotes a gateway connection when the completed connect RPC still belongs to the current desired target.
- **Why acceptable:** The changed behavior is constrained to the broken Android notification forwarding path and handshake exposure boundary. Tests cover the pending-handshake false path, post-connect immediate send path, bounded queue flush/requeue behavior, active notification replay, unavailable sink retry, and duplicate replay prevention.
- **Maintainer-ready confidence:** High: the fix is focused to Android gateway/session notification delivery, includes production-path regression tests, and has fresh local evidence collected after the final code changes.
- **Patch quality notes:** No dependency, lockfile, public API, schema, protocol format, or configuration default changes. No unrelated files were changed. Patch quality warnings are intentional lifecycle guard/default boundaries: the `connectingConnection` guard prevents stale handshakes from being promoted, the notification `false` returns distinguish unavailable sinks from successful emits, and the queue lock is a process-local monitor for the bounded pending notification list rather than a type escape across APIs.

## Root Cause

- **Root cause:** The Android gateway lifecycle state used `currentConnection` as both the handshake-stage socket and the ready node socket. That violated the protocol invariant that the first usable gateway RPC on a socket is the successful `connect` RPC, so notification forwarding could treat a not-yet-connected socket as ready and send `node.event` during the handshake window. Failed `notifications.changed` sends were also fire-and-forget, and reconnect did not use active notification state as the source for replaying posted notifications missed while the node connection was unavailable.
- **Why this is root-cause fix:** The patch restores the lifecycle state invariant at the source: `connectingConnection` represents a socket whose `connect` RPC is still pending, while `currentConnection` becomes visible only after connect success and before `onConnected` callbacks run. Notification recovery is tied to the same ready-state transition by queueing only failed `notifications.changed` events, flushing them after reconnect, and reconciling active notification entries that have not already emitted a posted event. This fixes the invalid first-request source path and the missed-notification recovery path without masking the symptom in downstream gateway error handling or changing unrelated node events.
