### PR TITLE
fix(agents): skip stale orphaned subagent sessions during restart recovery

### DIFF
--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -605,10 +605,14 @@ stop counting as active/pending in `/subagents list`, status summaries,
 descendant completion gating, and per-session concurrency checks.
 
 After a gateway restart, stale unended restored runs are pruned unless
-their child session is marked `abortedLastRun: true`. Those
-restart-aborted child sessions remain recoverable through the sub-agent
-orphan recovery flow, which sends a synthetic resume message before
-clearing the aborted marker.
+their child session is marked `abortedLastRun: true`. The orphan
+recovery flow checks whether the run is still within the subagent
+run-liveness window before attempting automatic recovery.
+Restart-aborted runs that exceed the configured liveness window are
+finalized with an error instead of being resumed, so long-abandoned
+subagents are not resurrected by gateway restarts. Runs still within
+the window remain recoverable: the flow sends a synthetic resume
+message before clearing the aborted marker.
 
 Automatic restart recovery is bounded per child session. If the same
 sub-agent child is accepted for orphan recovery repeatedly inside the

--- a/src/agents/subagent-orphan-recovery.test.ts
+++ b/src/agents/subagent-orphan-recovery.test.ts
@@ -658,4 +658,123 @@ describe("subagent-orphan-recovery", () => {
     expect(finalizeParams.error).toContain("Automatic recovery failed after 2 attempts");
     expect(finalizeParams.error).toContain("service restart");
   });
+
+  // ── Stale-run liveness gate ──────────────────────────────────────────
+
+  it("finalizes stale restart-aborted runs inline instead of resuming", async () => {
+    const staleStartedAt = Date.now() - 3 * 60 * 60 * 1_000;
+    vi.mocked(sessions.loadSessionStore).mockReturnValue({
+      "agent:main:subagent:test-session-1": {
+        sessionId: "session-abc",
+        updatedAt: Date.now(),
+        abortedLastRun: true,
+      },
+    });
+
+    const activeRuns = createActiveRuns(
+      createTestRunRecord({
+        // started 3 hours ago — exceeds the 2-hour STALE_UNENDED_SUBAGENT_RUN_MS window
+        startedAt: staleStartedAt,
+        sessionStartedAt: staleStartedAt,
+        createdAt: staleStartedAt - 60_000,
+      }),
+    );
+
+    const result = await recoverOrphanedSubagentSessions({
+      getActiveRuns: () => activeRuns,
+    });
+
+    expect(result.recovered).toBe(0);
+    expect(result.failed).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(gateway.callGateway).not.toHaveBeenCalled();
+    expect(
+      subagentRegistrySteerRuntime.finalizeInterruptedSubagentRun,
+    ).toHaveBeenCalledOnce();
+    const finalizeParams = requireRecord(
+      firstCallParam(
+        vi.mocked(subagentRegistrySteerRuntime.finalizeInterruptedSubagentRun)
+          .mock.calls,
+        "stale run finalization",
+      ),
+      "stale run finalization params",
+    );
+    expect(finalizeParams.runId).toBe("run-1");
+    expect(finalizeParams.childSessionKey).toBe(
+      "agent:main:subagent:test-session-1",
+    );
+    expect(finalizeParams.error).toContain(
+      "Subagent run was orphaned past the run-liveness window",
+    );
+  });
+
+  it("recovers fresh restart-aborted runs that are within the liveness window", async () => {
+    const freshStartedAt = Date.now() - 30 * 60 * 1_000;
+    vi.mocked(gateway.callGateway).mockResolvedValue({ runId: "resumed-fresh" } as never);
+    vi.mocked(sessions.loadSessionStore).mockReturnValue({
+      "agent:main:subagent:test-session-1": {
+        sessionId: "session-abc",
+        updatedAt: Date.now(),
+        abortedLastRun: true,
+      },
+    });
+
+    const activeRuns = createActiveRuns(
+      createTestRunRecord({
+        // 30 minutes ago — well within the 2-hour window
+        startedAt: freshStartedAt,
+        sessionStartedAt: freshStartedAt,
+        createdAt: freshStartedAt - 60_000,
+      }),
+    );
+
+    const result = await recoverOrphanedSubagentSessions({
+      getActiveRuns: () => activeRuns,
+    });
+
+    expect(result.failed).toBe(0);
+    expect(result.skipped).toBe(0);
+    expect(result.recovered).toBe(1);
+    expect(gateway.callGateway).toHaveBeenCalledOnce();
+    expect(
+      subagentRegistrySteerRuntime.finalizeInterruptedSubagentRun,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("recovers old restart-aborted runs that carry an explicit long timeout extending the window", async () => {
+    const extendedStartedAt = Date.now() - 4 * 60 * 60 * 1_000;
+    vi.mocked(gateway.callGateway).mockResolvedValue({ runId: "resumed-extended" } as never);
+    vi.mocked(sessions.loadSessionStore).mockReturnValue({
+      "agent:main:subagent:test-session-1": {
+        sessionId: "session-abc",
+        updatedAt: Date.now(),
+        abortedLastRun: true,
+      },
+    });
+
+    const activeRuns = createActiveRuns(
+      createTestRunRecord({
+        // 4 hours ago — exceeds the default 2h window,
+        // but the explicit 6-hour runTimeoutSeconds extends the cutoff to ~6h 1m
+        startedAt: extendedStartedAt,
+        sessionStartedAt: extendedStartedAt,
+        createdAt: extendedStartedAt - 60_000,
+        runTimeoutSeconds: 6 * 60 * 60,
+      }),
+    );
+
+    const result = await recoverOrphanedSubagentSessions({
+      getActiveRuns: () => activeRuns,
+    });
+
+    expect(result.failed).toBe(0);
+    expect(result.skipped).toBe(0);
+    expect(result.recovered).toBe(1);
+    expect(result.failed).toBe(0);
+    expect(result.skipped).toBe(0);
+    expect(gateway.callGateway).toHaveBeenCalledOnce();
+    expect(
+      subagentRegistrySteerRuntime.finalizeInterruptedSubagentRun,
+    ).not.toHaveBeenCalled();
+  });
 });

--- a/src/agents/subagent-orphan-recovery.ts
+++ b/src/agents/subagent-orphan-recovery.ts
@@ -24,6 +24,7 @@ import { readSessionMessagesAsync } from "../gateway/session-utils.fs.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { resolveInternalSessionEffectsTranscriptPath } from "./internal-session-effects.js";
+import { isLiveUnendedSubagentRun } from "./subagent-run-liveness.js";
 import {
   evaluateSubagentRecoveryGate,
   markSubagentRecoveryAttempt,
@@ -249,6 +250,32 @@ export async function recoverOrphanedSubagentSessions(params: {
 
         // Check if this session was aborted by the restart
         if (!entry.abortedLastRun) {
+          result.skipped++;
+          continue;
+        }
+
+        // If the run is stale per the existing subagent-run liveness policy,
+        // finalize it instead of attempting automatic recovery. This prevents
+        // resurrecting long-abandoned subagent runs after a gateway restart.
+        // We finalize inline (not via failedRuns) so the parent is notified
+        // immediately rather than waiting for scheduleOrphanRecovery retries.
+        if (!isLiveUnendedSubagentRun(runRecord, now)) {
+          log.warn(
+            `skipping orphan recovery for ${childSessionKey}: subagent run is stale (startedAt=${runRecord.startedAt})`,
+          );
+          try {
+            await finalizeInterruptedSubagentRun({
+              runId,
+              childSessionKey,
+              error:
+                "Subagent run was orphaned past the run-liveness window and " +
+                "could not be automatically recovered. Please retry.",
+            });
+          } catch (finalizeErr) {
+            log.warn(
+              `failed to finalize stale orphaned subagent run ${runId}: ${String(finalizeErr)}`,
+            );
+          }
           result.skipped++;
           continue;
         }


### PR DESCRIPTION
## Summary

After a gateway restart, `recoverOrphanedSubagentSessions()` scans for interrupted subagent runs and attempts to resume them — but it did not check whether a run had exceeded the **existing** subagent run-liveness window. A subagent interrupted days ago could be resurrected on the next restart, replaying stale work and producing misleading late completions.

This PR adds a staleness check using the existing `isLiveUnendedSubagentRun()` from `subagent-run-liveness.ts` **before** attempting automatic recovery. Stale runs are finalized via `finalizeInterruptedSubagentRun()` instead of being resumed. This reuses the established liveness policy, respects `runTimeoutSeconds` extensions, and covers both direct and restored-run paths.

Fixes #90766

## Changes

- **`src/agents/subagent-orphan-recovery.ts`**: Import `isLiveUnendedSubagentRun`. Before attempting recovery, check if the run is still live. Stale runs are finalized inline (single-owner, not via `failedRuns`). 1 file, +27 lines.
- **`src/agents/subagent-orphan-recovery.test.ts`**: Add 3 focused regression tests that exercise `recoverOrphanedSubagentSessions` end-to-end through the stale-gate. 1 file, +119 lines.
- **`docs/tools/subagents.md`**: Update liveness-and-recovery section to describe the new stale-run finalization behavior.

## Real behavior proof

**Behavior addressed:** Orphaned subagent runs with no liveness check can be resurrected long after they exceeded the run-liveness window. The fix applies `isLiveUnendedSubagentRun()` at the orphan-recovery boundary and finalizes stale runs inline via `finalizeInterruptedSubagentRun()`.

**Real environment tested:** Node v22.22.0, Linux 4.19.112-2.el8.x86_64, openclaw commit 760cceb6fa. tsx v4.22.3.

**Exact steps or command run after this patch:**

1. Created proof script at `scripts/proof-91668.mjs` importing `isLiveUnendedSubagentRun` and `STALE_UNENDED_SUBAGENT_RUN_MS` directly from the real production module at `src/agents/subagent-run-liveness.js`
2. Script constructs 3 SubagentRunRecord shapes matching real gateway restart scenarios: fresh run (0.5h), stale run (3h, exceeds default 2h window), extended-timeout run (4h old, runTimeoutSeconds=6h)
3. Each scenario is run through `isLiveUnendedSubagentRun(runRecord, now)` — the exact same function called by the patched `recoverOrphanedSubagentSessions` code path
4. Ran `npx tsx scripts/proof-91668.mjs`

**Evidence after fix (terminal capture):**

$ npx tsx scripts/proof-91668.mjs
====================================================================
openclaw orphan recovery — staleness gate proof
====================================================================
Module: src/agents/subagent-run-liveness.js (real import, not copied logic)
PR: https://github.com/openclaw/openclaw/pull/91668

STALE_UNENDED_SUBAGENT_RUN_MS = 7200000 (2h)
now = 2026-06-11T06:49:40.803Z

--- Fresh run (0.5h old, within 2h window) ---
  startedAt = 2026-06-11T06:19:40.803Z
  age = 0.5h
  isLiveUnendedSubagentRun = true
  Expected: true → RECOVERED (skip stale-gate, proceed to resumeOrphanedSession)
  Match: PASS

--- Stale run (3h old, exceeds 2h window) ---
  startedAt = 2026-06-11T03:49:40.803Z
  age = 3.0h
  isLiveUnendedSubagentRun = false
  Expected: false → FINALIZED (enter stale-gate, finalizeInterruptedSubagentRun)
  Match: PASS

--- Extended timeout run (4h old, runTimeoutSeconds=6h) ---
  startedAt = 2026-06-11T02:49:40.803Z
  age = 4.0h
  runTimeoutSeconds = 21600s (6h)
  isLiveUnendedSubagentRun = true
  Expected: true → RECOVERED (timeout extends window beyond 4h, skip stale-gate)
  Match: PASS

--- Patched code path (subagent-orphan-recovery.ts:257-278) ---
  if (!isLiveUnendedSubagentRun(runRecord, now)) {
    log.warn("skipping orphan recovery: subagent run is stale");
    await finalizeInterruptedSubagentRun({ runId, childSessionKey, error });
    result.skipped++;
    continue;
  }
  // Falls through to: evaluateSubagentRecoveryGate → resumeOrphanedSession

--- Summary ---
  Fresh run (0.5h):      isLive=true → RECOVERED
  Stale run (3h):        isLive=false → FINALIZED
  Extended run (4h/6h):  isLive=true → RECOVERED
  All scenarios match expected behavior.
  isLiveUnendedSubagentRun correctly gates orphan recovery.
exit code: 0

**Observed result after fix:** The proof imports `isLiveUnendedSubagentRun` from the real production module at `src/agents/subagent-run-liveness.js` (not copied logic). Each run record mirrors a real gateway restart scenario: Subagent A (0.5h, fresh) returns `isLiveUnendedSubagentRun = true` and would skip the stale-gate, proceeding to normal recovery via `resumeOrphanedSession`. Subagent B (3h, no timeout) returns `false` and would enter the stale-gate block, finalizing via `finalizeInterruptedSubagentRun`. Subagent C (4h, runTimeoutSeconds=6h) returns `true` because the explicit timeout extends the liveness window, and would skip the stale-gate. The 3 regression tests (vitest, 44 tests total passing) exercise the full production code path through `recoverOrphanedSubagentSessions` including the `isLiveUnendedSubagentRun` gate and inline `finalizeInterruptedSubagentRun` call for stale runs.

**What was not tested:** Full gateway restart with live subagents in a production environment, the `scheduleOrphanRecovery` retry loop interaction with stale runs, parent session notification for stale-run finalization in a real deployment.