### PR TITLE
test(agents): cover prompt fence tool result persistence

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
@@ -907,6 +907,47 @@ describe("embedded attempt session lock lifecycle", () => {
     expect(controller.hasSessionTakeover()).toBe(false);
   });
 
+  it("keeps owned tool-call and tool-result persistence from tripping the prompt fence", async () => {
+    const sessionFile = await createTempSessionFile();
+    const release = vi.fn(async () => {});
+    const acquireSessionWriteLockLocal34 = vi.fn(async () => ({ release }));
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock: acquireSessionWriteLockLocal34,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+    const sessionManager = guardSessionManager(SessionManager.open(sessionFile), {
+      onMessagePersisted: () => {
+        controller.refreshAfterOwnedSessionWrite();
+      },
+    });
+
+    await controller.releaseForPrompt();
+    sessionManager.appendMessage({
+      role: "assistant",
+      content: [
+        {
+          type: "toolCall",
+          id: "call_session_status",
+          name: "session_status",
+          arguments: {},
+        },
+      ],
+      stopReason: "toolUse",
+      timestamp: 1,
+    });
+    sessionManager.appendMessage({
+      role: "toolResult",
+      toolCallId: "call_session_status",
+      toolName: "session_status",
+      content: [{ type: "text", text: "Model: huggingface/Qwen/Qwen3-8B" }],
+      isError: false,
+      timestamp: 2,
+    });
+
+    await expect(controller.withSessionWriteLock(() => "finalize")).resolves.toBe("finalize");
+    expect(controller.hasSessionTakeover()).toBe(false);
+  });
+
   it("refreshes the prompt fence after an owned session manager compaction append", async () => {
     const sessionFile = await createTempSessionFile();
     const release = vi.fn(async () => {});


### PR DESCRIPTION
## Summary

Embedded gateway runs can persist assistant tool calls and tool results while the prompt lock is released.
This adds regression coverage for the session-fence path that must treat those guarded SessionManager writes as OpenClaw-owned progress, not as an external takeover.
The change is test-only and intentionally does not change runtime behavior.

- Adds a focused regression around `session_status`-style tool-call/tool-result persistence during a released prompt lock.
- Exercises the real guarded `SessionManager` append path with `onMessagePersisted` refreshing the embedded session fence.
- Confirms reacquiring the write lock after those owned writes does not set `hasSessionTakeover()`.
- AI-assisted: yes.

## Linked context

Which issue does this close?

Closes #

Which issues, PRs, or discussions are related?

Related: none linked.

Was this requested by a maintainer or owner?

No maintainer request linked. This is draft regression coverage for an observed embedded session-fence failure mode.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: guarded SessionManager tool-call/tool-result writes should not trip the embedded prompt session fence after the prompt lock has been released.
- Real environment tested: local OpenClaw worktree on macOS, branch `fix/hf-session-fence`, Node/Vitest through the repo test wrapper.
- Exact steps or command run after this patch: `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
[test] starting test/vitest/vitest.agents.config.ts

 RUN  v4.1.7 /Users/onur/oc/openclaw-worktrees/hf-session-fence

 Test Files  1 passed (1)
      Tests  50 passed (50)
   Start at  17:23:27
   Duration  2.31s (transform 1.40s, setup 175ms, import 1.94s, tests 111ms, environment 0ms)

[test] passed 1 Vitest shard in 4.64s
```

- Observed result after fix: the new regression passes and `controller.hasSessionTakeover()` remains false after guarded assistant tool-call and `session_status` tool-result persistence.
- What was not tested: a live Telegram, Discord, or Hugging Face gateway deployment was not exercised as part of this PR.
- Proof limitations or environment constraints: this is regression coverage for an internal lock/fence behavior, not a live channel proof. The full deployed-channel proof should run separately against a gateway setup.
- Before evidence (optional but encouraged): not captured in this PR. The test covers the previously fragile write sequence directly.

## Tests and validation

The focused session-lock suite passes locally.
I also ran local review against `origin/main`; it did not identify an actionable correctness issue in this test-only patch.

- `pnpm exec vitest run src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts`

```text
Test Files  2 passed (2)
Tests       100 passed (100)
```

- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts`

```text
Test Files  1 passed (1)
Tests       50 passed (50)
```

Regression coverage added:

- Adds a test that releases the prompt lock, persists an assistant `session_status` tool call through `guardSessionManager(SessionManager.open(...))`, persists the matching tool result, and verifies a later locked operation does not see a takeover.

What failed before this fix, if known?

- The observed failure mode was `EmbeddedAttemptSessionTakeoverError: session file changed while embedded prompt lock was released` after a successful `session_status` tool result. Current `origin/main` already contains the runtime owned-write handling; this PR preserves that behavior with a narrower regression.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

No.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

The main risk is test maintenance if the session-lock API or message shape changes.

How is that risk mitigated?

The test uses existing helpers and the real guarded `SessionManager` path instead of raw transcript writes.

## Current review state

What is the next action?

Draft PR for maintainer review.

What is still waiting on author, maintainer, CI, or external proof?

- CI has not run yet.
- Live gateway/channel proof is not included in this test-only PR.

Which bot or reviewer comments were addressed?

None yet.
