### PR TITLE
fix(qqbot): read group toggle state from current config

### DIFF
--- a/extensions/qqbot/src/engine/commands/builtin/register-group-allways.test.ts
+++ b/extensions/qqbot/src/engine/commands/builtin/register-group-allways.test.ts
@@ -128,6 +128,24 @@ describe("bot-group-allways command", () => {
     expect(reply).toContain(testCase.expectedReply);
   });
 
+  it("shows default account status from accounts.default when present", async () => {
+    const { result, reply, writes } = await runGroupAllwaysCommand({
+      config: createConfig({
+        allowFrom: ["*"],
+        defaultRequireMention: true,
+        accounts: {
+          default: {
+            defaultRequireMention: false,
+          },
+        },
+      }),
+    });
+
+    expect(result).toBe("handled");
+    expect(writes).toHaveLength(0);
+    expect(reply).toContain("自主判断何时发言");
+  });
+
   it.each([
     {
       arg: "on",
@@ -161,6 +179,69 @@ describe("bot-group-allways command", () => {
       testCase.expectedDefaultRequireMention,
     );
     expect(reply).toContain(testCase.expectedReply);
+  });
+
+  it("reads current runtime config instead of the stale account snapshot for sequential toggles", async () => {
+    const writes: OpenClawConfig[] = [];
+    const config = createConfig({
+      allowFrom: ["*"],
+      defaultRequireMention: true,
+    });
+    const account = createAccount();
+    const commandCtx = {
+      account,
+      cfg: config,
+      getMessagePeerId: () => "c2c:TRUSTED_OPENID",
+      getQueueSnapshot: () => queueSnapshot,
+    };
+    installCommandRuntime(config, writes);
+
+    await expect(trySlashCommand(createGroupAllwaysMessage("on"), commandCtx)).resolves.toBe(
+      "handled",
+    );
+    await expect(trySlashCommand(createGroupAllwaysMessage("off"), commandCtx)).resolves.toBe(
+      "handled",
+    );
+
+    expect(writes).toHaveLength(2);
+    expect(getAllwaysConfig(writes[0])?.defaultRequireMention).toBe(false);
+    expect(getAllwaysConfig(writes[1])?.defaultRequireMention).toBe(true);
+    expect(vi.mocked(sendText).mock.calls.at(1)?.[1]).toContain("**off**");
+  });
+
+  it("mirrors sequential default-account toggles into accounts.default when present", async () => {
+    const writes: OpenClawConfig[] = [];
+    const config = createConfig({
+      allowFrom: ["*"],
+      defaultRequireMention: true,
+      accounts: {
+        default: {
+          defaultRequireMention: true,
+        },
+      },
+    });
+    const account = createAccount();
+    const commandCtx = {
+      account,
+      cfg: config,
+      getMessagePeerId: () => "c2c:TRUSTED_OPENID",
+      getQueueSnapshot: () => queueSnapshot,
+    };
+    installCommandRuntime(config, writes);
+
+    await expect(trySlashCommand(createGroupAllwaysMessage("on"), commandCtx)).resolves.toBe(
+      "handled",
+    );
+    await expect(trySlashCommand(createGroupAllwaysMessage("off"), commandCtx)).resolves.toBe(
+      "handled",
+    );
+
+    expect(writes).toHaveLength(2);
+    expect(getAllwaysConfig(writes[0])?.defaultRequireMention).toBe(false);
+    expect(getAllwaysConfig(writes[0])?.accounts?.default?.defaultRequireMention).toBe(false);
+    expect(getAllwaysConfig(writes[1])?.defaultRequireMention).toBe(true);
+    expect(getAllwaysConfig(writes[1])?.accounts?.default?.defaultRequireMention).toBe(true);
+    expect(vi.mocked(sendText).mock.calls.at(1)?.[1]).toContain("**off**");
   });
 
   it("writes to accounts.{accountId}.defaultRequireMention for named accounts", async () => {

--- a/extensions/qqbot/src/engine/commands/builtin/register-group-allways.ts
+++ b/extensions/qqbot/src/engine/commands/builtin/register-group-allways.ts
@@ -1,6 +1,5 @@
-// 导入运行时配置缓存清除函数，确保配置更新后 getRuntimeConfig() 能读取到最新值
 import { clearRuntimeConfigSnapshot } from "openclaw/plugin-sdk/runtime-config-snapshot";
-// Qqbot plugin module implements register group allways behavior.
+import { asBoolean } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { ApproveRuntimeGetter } from "../../adapter/commands.port.js";
 import type { SlashCommandRegistry } from "../slash-commands.js";
 import {
@@ -8,6 +7,17 @@ import {
   getPluginVersionString,
   resolveRuntimeServiceVersion,
 } from "./state.js";
+
+function readDefaultRequireMention(config: Record<string, unknown>): boolean {
+  return asBoolean(config.defaultRequireMention) ?? true;
+}
+
+function readAccountMap(config: Record<string, unknown>): Record<string, Record<string, unknown>> {
+  const accounts = config.accounts;
+  return accounts && typeof accounts === "object"
+    ? (accounts as Record<string, Record<string, unknown>>)
+    : {};
+}
 
 export function registerGroupAllwaysCommand(registry: SlashCommandRegistry): void {
   registry.register({
@@ -28,31 +38,10 @@ export function registerGroupAllwaysCommand(registry: SlashCommandRegistry): voi
     handler: async (ctx) => {
       const arg = ctx.args.trim().toLowerCase();
 
-      // 读取当前 defaultRequireMention 状态
-      const currentVal = ctx.accountConfig?.defaultRequireMention;
-      const currentRequireMention = currentVal ?? true; // 未设置时硬编码默认为 true
-
-      // 无参数：查看当前状态
-      if (!arg) {
-        return [
-          `🤖 群自主发言状态：${currentRequireMention ? "❌ 仅被 @ 时回复" : "✅ 自主判断何时发言"}`,
-          `使用 <qqbot-cmd-input text="/bot-group-allways on" show="/bot-group-allways on"/> 设为自主发言`,
-          `使用 <qqbot-cmd-input text="/bot-group-allways off" show="/bot-group-allways off"/> 设为仅被 @ 时回复`,
-        ].join("\n");
-      }
-
-      if (arg !== "on" && arg !== "off") {
+      if (arg && arg !== "on" && arg !== "off") {
         return `❌ 参数错误，请使用 on 或 off\n\n示例：/bot-group-allways on`;
       }
 
-      const newRequireMention = arg === "off"; // on=自主发言(requireMention=false), off=仅被@时回复(requireMention=true)
-
-      // 如果状态没变，直接返回
-      if (newRequireMention === currentRequireMention) {
-        return `🤖 群自主发言已经是"${arg}"状态，无需操作`;
-      }
-
-      // 获取运行时配置 API
       let runtime: ReturnType<NonNullable<ApproveRuntimeGetter>>;
       try {
         const getter = getApproveRuntimeGetter();
@@ -92,15 +81,30 @@ export function registerGroupAllwaysCommand(registry: SlashCommandRegistry): voi
         }
 
         const accountId = ctx.accountId;
-        const isNamedAccount =
-          accountId !== "default" &&
-          Boolean(
-            (qqbot.accounts as Record<string, Record<string, unknown>> | undefined)?.[accountId],
-          );
+        const accounts = readAccountMap(qqbot);
+        const defaultAccount = accounts.default;
+        const isNamedAccount = accountId !== "default" && Boolean(accounts[accountId]);
+        const accountConfig = isNamedAccount
+          ? accounts[accountId]
+          : { ...qqbot, ...defaultAccount };
+        const currentRequireMention = readDefaultRequireMention(accountConfig);
+
+        if (!arg) {
+          return [
+            `🤖 群自主发言状态：${currentRequireMention ? "❌ 仅被 @ 时回复" : "✅ 自主判断何时发言"}`,
+            `使用 <qqbot-cmd-input text="/bot-group-allways on" show="/bot-group-allways on"/> 设为自主发言`,
+            `使用 <qqbot-cmd-input text="/bot-group-allways off" show="/bot-group-allways off"/> 设为仅被 @ 时回复`,
+          ].join("\n");
+        }
+
+        const newRequireMention = arg === "off"; // on=自主发言(requireMention=false), off=仅被@时回复(requireMention=true)
+
+        if (newRequireMention === currentRequireMention) {
+          return `🤖 群自主发言已经是"${arg}"状态，无需操作`;
+        }
 
         if (isNamedAccount) {
           // 命名账户：更新 accounts.{accountId}.defaultRequireMention
-          const accounts = (qqbot.accounts as Record<string, Record<string, unknown>>) ?? {};
           const nextAccounts = { ...accounts };
           const acct = { ...nextAccounts[accountId] };
           acct.defaultRequireMention = newRequireMention;
@@ -109,6 +113,15 @@ export function registerGroupAllwaysCommand(registry: SlashCommandRegistry): voi
         } else {
           // 默认账户：更新 qqbot.defaultRequireMention
           qqbot.defaultRequireMention = newRequireMention;
+          if (defaultAccount) {
+            qqbot.accounts = {
+              ...accounts,
+              default: {
+                ...defaultAccount,
+                defaultRequireMention: newRequireMention,
+              },
+            };
+          }
         }
 
         await configApi.replaceConfigFile({ nextConfig: currentCfg, afterWrite: { mode: "auto" } });

--- a/extensions/qqbot/src/engine/commands/slash-command-test-support.ts
+++ b/extensions/qqbot/src/engine/commands/slash-command-test-support.ts
@@ -16,7 +16,9 @@ export function installCommandRuntime(
   currentConfig: OpenClawConfig,
   writes: OpenClawConfig[],
 ): void {
+  let activeConfig = currentConfig;
   const replaceConfigFile: ReplaceConfigFile = async (params) => {
+    activeConfig = params.nextConfig;
     writes.push(params.nextConfig);
     return undefined as unknown as ReplaceConfigFileResult;
   };
@@ -26,7 +28,7 @@ export function installCommandRuntime(
     pluginVersion: "0.0.0-test",
     approveRuntimeGetter: () => ({
       config: {
-        current: () => currentConfig,
+        current: () => activeConfig,
         replaceConfigFile,
       },
     }),

--- a/extensions/qqbot/src/engine/config/group.test.ts
+++ b/extensions/qqbot/src/engine/config/group.test.ts
@@ -95,6 +95,46 @@ describe("engine/config/group", () => {
         expect(resolveGroupConfig(cfg, "G1").requireMention).toBe(false);
       });
 
+      it("reads defaultRequireMention from accounts.default for the default account", () => {
+        const cfg = {
+          channels: {
+            qqbot: {
+              appId: "1",
+              defaultRequireMention: true,
+              accounts: {
+                default: { defaultRequireMention: false },
+              },
+            },
+          },
+        };
+        expect(resolveGroupConfig(cfg, "G1").requireMention).toBe(false);
+      });
+
+      it("merges accounts.default groups over top-level default-account groups", () => {
+        const cfg = {
+          channels: {
+            qqbot: {
+              appId: "1",
+              groups: {
+                "*": { requireMention: true, historyLimit: 20 },
+                GROUPA: { requireMention: true, historyLimit: 7 },
+              },
+              accounts: {
+                default: {
+                  groups: {
+                    GROUPA: { requireMention: false },
+                  },
+                },
+              },
+            },
+          },
+        };
+        expect(resolveGroupConfig(cfg, "GROUPA").requireMention).toBe(false);
+        expect(resolveGroupConfig(cfg, "GROUPA").historyLimit).toBe(7);
+        expect(resolveGroupConfig(cfg, "GROUPB").requireMention).toBe(true);
+        expect(resolveGroupConfig(cfg, "GROUPB").historyLimit).toBe(20);
+      });
+
       it("reads defaultRequireMention from named account config", () => {
         const cfg = {
           channels: {

--- a/extensions/qqbot/src/engine/config/group.ts
+++ b/extensions/qqbot/src/engine/config/group.ts
@@ -1,7 +1,7 @@
 // Qqbot plugin module implements group behavior.
 import { asBoolean } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { asOptionalObjectRecord as asRecord } from "../utils/string-normalize.js";
-import { resolveAccountBase } from "./resolve.js";
+import { DEFAULT_ACCOUNT_ID, resolveAccountBase } from "./resolve.js";
 
 interface GroupConfig {
   requireMention: boolean;
@@ -23,12 +23,58 @@ const DEFAULT_GROUP_CONFIG: Readonly<Omit<GroupConfig, "prompt">> = {
   historyLimit: DEFAULT_GROUP_HISTORY_LIMIT,
 };
 
+function mergeGroupMaps(
+  baseGroups: Record<string, unknown> | undefined,
+  overrideGroups: Record<string, unknown> | undefined,
+): Record<string, Record<string, unknown>> | undefined {
+  if (!baseGroups && !overrideGroups) {
+    return undefined;
+  }
+  const merged: Record<string, Record<string, unknown>> = {};
+  for (const groupId of new Set([
+    ...Object.keys(baseGroups ?? {}),
+    ...Object.keys(overrideGroups ?? {}),
+  ])) {
+    const baseGroup = asRecord(baseGroups?.[groupId]) ?? {};
+    const overrideGroup = asRecord(overrideGroups?.[groupId]) ?? {};
+    merged[groupId] = { ...baseGroup, ...overrideGroup };
+  }
+  return merged;
+}
+
+function resolveEffectiveAccountConfig(
+  cfg: Record<string, unknown>,
+  accountId?: string | null,
+): Record<string, unknown> {
+  const account = resolveAccountBase(cfg, accountId);
+  if (account.accountId !== DEFAULT_ACCOUNT_ID) {
+    return account.config;
+  }
+
+  const channels = asRecord(cfg.channels);
+  const qqbot = asRecord(channels?.qqbot);
+  const accounts = asRecord(qqbot?.accounts);
+  const defaultAccount = asRecord(accounts?.[DEFAULT_ACCOUNT_ID]);
+  if (!defaultAccount) {
+    return account.config;
+  }
+
+  const groups = asRecord(account.config.groups);
+  const defaultGroups = asRecord(defaultAccount.groups);
+  const mergedGroups = mergeGroupMaps(groups, defaultGroups);
+  return {
+    ...account.config,
+    ...defaultAccount,
+    ...(mergedGroups ? { groups: mergedGroups } : {}),
+  };
+}
+
 function readGroupsMap(
   cfg: Record<string, unknown>,
   accountId?: string | null,
 ): Record<string, Record<string, unknown>> {
-  const account = resolveAccountBase(cfg, accountId);
-  const groups = asRecord(account.config.groups);
+  const accountConfig = resolveEffectiveAccountConfig(cfg, accountId);
+  const groups = asRecord(accountConfig.groups);
   if (!groups) {
     return {};
   }
@@ -64,14 +110,14 @@ export function resolveGroupConfig(
   groupOpenid?: string | null,
   accountId?: string | null,
 ): GroupConfig {
-  const account = resolveAccountBase(cfg, accountId);
+  const accountConfig = resolveEffectiveAccountConfig(cfg, accountId);
   const groups = readGroupsMap(cfg, accountId);
   const wildcard = groups["*"] ?? {};
   const specific = groupOpenid ? (groups[groupOpenid] ?? {}) : {};
 
   // 账户级默认值：defaultRequireMention 配置 > 默认 true
   const accountDefaultRequireMention =
-    asBoolean(account.config.defaultRequireMention) ?? DEFAULT_GROUP_CONFIG.requireMention;
+    asBoolean(accountConfig.defaultRequireMention) ?? DEFAULT_GROUP_CONFIG.requireMention;
 
   return {
     requireMention:

--- a/extensions/qqbot/src/engine/gateway/interaction-handler.test.ts
+++ b/extensions/qqbot/src/engine/gateway/interaction-handler.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createSdkAccessAdapter } from "../../bridge/sdk-adapter.js";
 import { registerPlatformAdapter, type PlatformAdapter } from "../adapter/index.js";
 import type { InteractionEvent } from "../types.js";
+import { InteractionType } from "./constants.js";
 import { createInteractionHandler } from "./interaction-handler.js";
 import type { GatewayAccount, GatewayPluginRuntime } from "./types.js";
 
@@ -355,5 +356,81 @@ describe("createInteractionHandler approval buttons", () => {
       { content: "Approval is unavailable." },
     );
     expect(resolveApprovalMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("createInteractionHandler config updates", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    installPlatformAdapter();
+  });
+
+  it("mirrors default-account require_mention group updates into accounts.default", async () => {
+    const writes: OpenClawConfig[] = [];
+    let activeConfig = {
+      channels: {
+        qqbot: {
+          appId: "app",
+          clientSecret: "secret",
+          groups: {
+            "group-1": { requireMention: true },
+          },
+          accounts: {
+            default: {
+              groups: {
+                "group-1": { requireMention: true },
+              },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const configRuntime = {
+      config: {
+        current: () => activeConfig,
+        replaceConfigFile: vi.fn(async ({ nextConfig }: { nextConfig: OpenClawConfig }) => {
+          activeConfig = nextConfig;
+          writes.push(nextConfig);
+        }),
+      },
+      channel: {
+        routing: {
+          resolveAgentRoute: vi.fn(() => ({ agentId: "default" })),
+        },
+      },
+    } as unknown as GatewayPluginRuntime;
+    const handler = createInteractionHandler(account, configRuntime);
+
+    handler(
+      makeApprovalEvent({
+        data: {
+          type: InteractionType.CONFIG_UPDATE,
+          resolved: {
+            claw_cfg: { require_mention: "always" },
+          },
+        },
+      }),
+    );
+
+    await vi.waitFor(() => expect(configRuntime.config?.replaceConfigFile).toHaveBeenCalled());
+
+    const qqbot = writes[0]?.channels?.qqbot as
+      | {
+          groups?: Record<string, { requireMention?: unknown }>;
+          accounts?: Record<string, { groups?: Record<string, { requireMention?: unknown }> }>;
+        }
+      | undefined;
+    expect(qqbot?.groups?.["group-1"]?.requireMention).toBe(false);
+    expect(qqbot?.accounts?.default?.groups?.["group-1"]?.requireMention).toBe(false);
+    await vi.waitFor(() =>
+      expect(acknowledgeInteractionMock).toHaveBeenCalledWith(
+        { appId: "app", clientSecret: "secret" },
+        "interaction-1",
+        0,
+        expect.objectContaining({
+          claw_cfg: expect.objectContaining({ require_mention: "always" }),
+        }),
+      ),
+    );
   });
 });

--- a/extensions/qqbot/src/engine/gateway/interaction-handler.ts
+++ b/extensions/qqbot/src/engine/gateway/interaction-handler.ts
@@ -155,6 +155,25 @@ function applyRequireMentionUpdate(
     const groups = (qqbot.groups ?? {}) as Record<string, Record<string, unknown>>;
     groups[groupOpenid] = { ...groups[groupOpenid], requireMention: requireMentionBool };
     qqbot.groups = groups;
+    const accounts = (qqbot.accounts ?? {}) as Record<string, Record<string, unknown>>;
+    const defaultAccount = accounts.default;
+    if (defaultAccount) {
+      const accountGroups = (defaultAccount.groups ?? {}) as Record<
+        string,
+        Record<string, unknown>
+      >;
+      accounts.default = {
+        ...defaultAccount,
+        groups: {
+          ...accountGroups,
+          [groupOpenid]: {
+            ...accountGroups[groupOpenid],
+            requireMention: requireMentionBool,
+          },
+        },
+      };
+      qqbot.accounts = accounts;
+    }
   }
 }
 

--- a/extensions/qqbot/src/engine/types.ts
+++ b/extensions/qqbot/src/engine/types.ts
@@ -244,6 +244,7 @@ export interface InteractionEvent {
       user_id?: string;
       feature_id?: string;
       message_id?: string;
+      claw_cfg?: Record<string, unknown>;
     };
   };
 }


### PR DESCRIPTION
## Summary

- Read `/bot-group-allways` status and no-op decisions from `runtime.config.current()` instead of the gateway account snapshot.
- Keep QQBot default-account config compatibility aligned by honoring `channels.qqbot.accounts.default` for group default resolution and mirroring writes into that scope when present.
- Update command/config/interaction tests for sequential toggles, `accounts.default.defaultRequireMention`, and default-account group update mirroring.

## Verification

- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo`
- `node scripts/run-oxlint-shards.mjs --threads=8`
- `node scripts/run-vitest.mjs extensions/qqbot/src/engine/commands/builtin/register-group-allways.test.ts extensions/qqbot/src/engine/commands/slash-command-handler.test.ts extensions/qqbot/src/engine/commands/slash-commands-impl.test.ts extensions/qqbot/src/engine/config/group.test.ts extensions/qqbot/src/engine/gateway/interaction-handler.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

## Real behavior proof

Behavior addressed: `/bot-group-allways` could make status and no-op decisions from a stale `ctx.accountConfig` snapshot after the command had already written a newer `defaultRequireMention` value. Default-account configs that store account fields under `channels.qqbot.accounts.default` also needed to stay aligned with runtime group resolution.

Real environment tested: Local OpenClaw source checkout with QQBot command/config/interaction runtime tests and extension test typecheck; no live QQBot gateway credentials were used.

Exact steps or command run after this patch:

```bash
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo
node scripts/run-vitest.mjs extensions/qqbot/src/engine/commands/builtin/register-group-allways.test.ts extensions/qqbot/src/engine/commands/slash-command-handler.test.ts extensions/qqbot/src/engine/commands/slash-commands-impl.test.ts extensions/qqbot/src/engine/config/group.test.ts extensions/qqbot/src/engine/gateway/interaction-handler.test.ts
node scripts/run-oxlint-shards.mjs --threads=8
.agents/skills/autoreview/scripts/autoreview --mode local
```

Evidence after fix: Regression tests execute `/bot-group-allways on` then `/bot-group-allways off` through the same `GatewayAccount` snapshot while `runtime.config.current()` reflects the first write, and cover `accounts.default.defaultRequireMention` plus default-account interaction updates.

Observed result after fix: The second command writes `defaultRequireMention: true` instead of returning the stale no-op response, default-account `accounts.default` group/config entries remain aligned with top-level QQBot config, and the interaction test fixture type now accepts the existing `resolved.claw_cfg` callback payload.

What was not tested: Live QQBot gateway interaction against Tencent QQ.
