### PR TITLE
fix(plugin-sdk): align Discord component edit facade types

### DIFF
--- a/src/plugin-sdk/discord.test.ts
+++ b/src/plugin-sdk/discord.test.ts
@@ -1,10 +1,34 @@
+import { describe, expect, expectTypeOf, it, vi } from "vitest";
+import type { MessageReceipt } from "./channel-outbound.js";
 /**
  * Tests Discord SDK helpers and Discord-facing compatibility behavior.
  */
-import { describe, expect, it, vi } from "vitest";
+import type {
+  DiscordComponentSendOpts,
+  DiscordComponentSendResult,
+  OpenClawConfig,
+} from "./discord.js";
 
 const mocks = vi.hoisted(() => {
   const runtimeConfig = { channels: { discord: { token: "token" } } };
+  const componentEditResult = {
+    channelId: "channel",
+    messageId: "message",
+    receipt: {
+      parts: [
+        {
+          index: 0,
+          kind: "card",
+          platformMessageId: "message",
+          raw: { channel: "discord", channelId: "channel", messageId: "message" },
+        },
+      ],
+      platformMessageIds: ["message"],
+      primaryPlatformMessageId: "message",
+      raw: [{ channel: "discord", channelId: "channel", messageId: "message" }],
+      sentAt: 0,
+    },
+  };
   const apiModule = {
     buildDiscordComponentMessage: vi.fn((params: { spec: { text?: string } }) => ({
       components: [],
@@ -40,7 +64,7 @@ const mocks = vi.hoisted(() => {
       cfg: params.cfg,
     })),
     collectDiscordAuditChannelIds: vi.fn(() => ({ channelIds: [], unresolvedChannels: [] })),
-    editDiscordComponentMessage: vi.fn(async () => ({ id: "message" })),
+    editDiscordComponentMessage: vi.fn(async () => componentEditResult),
     listThreadBindingsBySessionKey: vi.fn(() => []),
     registerBuiltDiscordComponentMessage: vi.fn(),
     unbindThreadBindingsBySessionKey: vi.fn(() => []),
@@ -48,6 +72,7 @@ const mocks = vi.hoisted(() => {
 
   return {
     apiModule,
+    componentEditResult,
     runtimeModule,
     runtimeConfig,
     loadBundledPluginPublicSurfaceModuleSync: vi.fn((params: { artifactBasename: string }) => {
@@ -128,7 +153,7 @@ describe("discord plugin-sdk facade", () => {
     } = await import("./discord.js");
 
     const built = buildDiscordComponentMessage({ spec: { text: "hello" } });
-    await editDiscordComponentMessage(
+    const editResult = await editDiscordComponentMessage(
       "channel",
       "message",
       { text: "edited" },
@@ -148,10 +173,26 @@ describe("discord plugin-sdk facade", () => {
       { text: "edited" },
       { cfg: mocks.runtimeConfig },
     );
+    expect(editResult).toEqual(mocks.componentEditResult);
     expect(mocks.runtimeModule.registerBuiltDiscordComponentMessage).toHaveBeenCalledWith({
       buildResult: built,
       messageId: "message",
     });
+  });
+
+  it("types Discord component edit options and normalized result", () => {
+    type IsCfgOptional = {} extends Pick<DiscordComponentSendOpts, "cfg"> ? true : false;
+
+    expectTypeOf<IsCfgOptional>().toEqualTypeOf<false>();
+    expectTypeOf<DiscordComponentSendOpts["cfg"]>().toEqualTypeOf<OpenClawConfig>();
+    expectTypeOf<DiscordComponentSendResult>().toEqualTypeOf<{
+      messageId: string;
+      channelId: string;
+      receipt: MessageReceipt;
+    }>();
+    expectTypeOf<keyof DiscordComponentSendResult>().toEqualTypeOf<
+      "messageId" | "channelId" | "receipt"
+    >();
   });
 
   it("fills runtime config for Discord subagent auto-bind calls without cfg", async () => {

--- a/src/plugin-sdk/discord.test.ts
+++ b/src/plugin-sdk/discord.test.ts
@@ -181,7 +181,7 @@ describe("discord plugin-sdk facade", () => {
   });
 
   it("types Discord component edit options and normalized result", () => {
-    type IsCfgOptional = {} extends Pick<DiscordComponentSendOpts, "cfg"> ? true : false;
+    type IsCfgOptional = object extends Pick<DiscordComponentSendOpts, "cfg"> ? true : false;
 
     expectTypeOf<IsCfgOptional>().toEqualTypeOf<false>();
     expectTypeOf<DiscordComponentSendOpts["cfg"]>().toEqualTypeOf<OpenClawConfig>();

--- a/src/plugin-sdk/discord.ts
+++ b/src/plugin-sdk/discord.ts
@@ -9,6 +9,7 @@ import type {
   ChannelStatusIssue,
 } from "./channel-contract.js";
 import type { ChannelPlugin } from "./channel-core.js";
+import type { MessageReceipt } from "./channel-outbound.js";
 import type { OpenClawConfig } from "./config-types.js";
 import {
   createLazyFacadeObjectValue,
@@ -67,7 +68,7 @@ export type DiscordComponentBuildResult = {
 
 /** Send/edit options for Discord component messages. */
 export type DiscordComponentSendOpts = {
-  cfg?: OpenClawConfig;
+  cfg: OpenClawConfig;
   accountId?: string;
   replyTo?: string;
   files?: unknown;
@@ -80,11 +81,11 @@ export type DiscordComponentSendOpts = {
   [key: string]: unknown;
 };
 
-/** Minimal Discord API message result returned by component send/edit helpers. */
+/** Normalized Discord message result returned by component send/edit helpers. */
 export type DiscordComponentSendResult = {
-  id?: string;
-  channel_id?: string;
-  [key: string]: unknown;
+  messageId: string;
+  channelId: string;
+  receipt: MessageReceipt;
 };
 
 /** Resolved Discord account with token source metadata for status and runtime checks. */

--- a/test/scripts/upgrade-survivor-assertions.test.ts
+++ b/test/scripts/upgrade-survivor-assertions.test.ts
@@ -3,12 +3,77 @@ import { execFileSync } from "node:child_process";
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
 import { describe, expect, it } from "vitest";
 
 const ASSERTIONS_PATH = "scripts/e2e/lib/upgrade-survivor/assertions.mjs";
 
 function writeJson(path: string, value: unknown): void {
   writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function writeMigratedSessionState(stateDir: string): void {
+  const agentSessionsDir = join(stateDir, "agents", "main", "sessions");
+  const agentDbDir = join(stateDir, "agents", "main", "agent");
+  const mainSessionFile = join(agentSessionsDir, "upgrade-main-session.jsonl");
+  const directSessionFile = join(agentSessionsDir, "upgrade-direct-session.jsonl");
+  const groupSessionFile = join(agentSessionsDir, "upgrade-group-session.jsonl");
+  mkdirSync(agentSessionsDir, { recursive: true });
+  mkdirSync(agentDbDir, { recursive: true });
+  writeFileSync(mainSessionFile, '{"type":"main"}\n');
+  writeFileSync(directSessionFile, '{"type":"direct"}\n');
+  writeFileSync(groupSessionFile, '{"type":"group"}\n');
+
+  const db = new DatabaseSync(join(agentDbDir, "openclaw-agent.sqlite"));
+  try {
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS cache_entries (
+        scope TEXT NOT NULL,
+        key TEXT NOT NULL,
+        value_json TEXT,
+        blob BLOB,
+        expires_at INTEGER,
+        updated_at INTEGER NOT NULL,
+        PRIMARY KEY (scope, key)
+      );
+    `);
+    const insert = db.prepare(`
+      INSERT INTO cache_entries (scope, key, value_json, updated_at)
+      VALUES (?, ?, ?, ?)
+    `);
+    insert.run(
+      "session_entries",
+      "agent:main:main",
+      JSON.stringify({
+        sessionFile: mainSessionFile,
+        sessionId: "upgrade-main-session",
+        skillsSnapshot: {
+          prompt: "legacy prompt survives as metadata",
+        },
+      }),
+      1710000000000,
+    );
+    insert.run(
+      "session_entries",
+      "agent:main:+15551234567",
+      JSON.stringify({
+        sessionFile: directSessionFile,
+        sessionId: "upgrade-direct-session",
+      }),
+      1710000000100,
+    );
+    insert.run(
+      "session_entries",
+      "agent:main:slack:channel:cupgrade",
+      JSON.stringify({
+        sessionFile: groupSessionFile,
+        sessionId: "upgrade-group-session",
+      }),
+      1710000000200,
+    );
+  } finally {
+    db.close();
+  }
 }
 
 function assertConfiguredPluginState(params: { installPath?: string } = {}): void {
@@ -25,6 +90,7 @@ function assertConfiguredPluginState(params: { installPath?: string } = {}): voi
     writeJson(join(stateDir, "agents", "main", "sessions", "legacy-session.json"), {
       id: "legacy-session",
     });
+    writeMigratedSessionState(stateDir);
     writeJson(join(matrixInstallDir, "package.json"), {
       name: "@openclaw/matrix",
     });


### PR DESCRIPTION
## Summary
- Align the deprecated Discord plugin SDK component edit facade with the runtime contract.
- Require `cfg` in the public facade options and expose the normalized `messageId` / `channelId` / `receipt` result shape.
- Add runtime and type coverage for the Discord facade behavior.

## Verification
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/plugin-sdk/discord.test.ts src/plugin-sdk/discord.ts`
- `OPENCLAW_TSGO_SPARSE_SKIP=1 node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo`
- `node scripts/test-projects-serial.mjs src/plugin-sdk/discord.test.ts extensions/discord/src/send.components.test.ts`
- `node --max-old-space-size=8192 --import tsx scripts/generate-plugin-sdk-api-baseline.ts --check`

## ClawSweeper
Detected from commit review for `07104c80b3bc879647d171f8877b2b5e792253ca`.

Implementation assisted by ProjectClownfish automation; maintainer repair addressed the generated test lint issue before opening this PR.
