### PR TITLE
fix(mattermost): keep default replies in existing threads

### DIFF
--- a/extensions/mattermost/src/mattermost/monitor.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.test.ts
@@ -773,13 +773,23 @@ describe("resolveMattermostEffectiveReplyToId", () => {
     ).toBe("thread-root-456");
   });
 
-  it("suppresses existing thread roots when replyToMode is off", () => {
+  it("keeps an existing thread root when replyToMode is off", () => {
     expect(
       resolveMattermostEffectiveReplyToId({
         kind: "channel",
         postId: "post-123",
         replyToMode: "off",
         threadRootId: "thread-root-456",
+      }),
+    ).toBe("thread-root-456");
+  });
+
+  it("does not start a new thread for top-level messages when replyToMode is off", () => {
+    expect(
+      resolveMattermostEffectiveReplyToId({
+        kind: "channel",
+        postId: "post-123",
+        replyToMode: "off",
       }),
     ).toBeUndefined();
   });
@@ -858,7 +868,7 @@ describe("resolveMattermostThreadSessionContext", () => {
     });
   });
 
-  it("keeps threaded messages top-level when replyToMode is off", () => {
+  it("keeps threaded messages in their Mattermost thread when replyToMode is off", () => {
     expect(
       resolveMattermostThreadSessionContext({
         baseSessionKey: "agent:main:mattermost:default:chan-1",
@@ -866,6 +876,21 @@ describe("resolveMattermostThreadSessionContext", () => {
         postId: "post-123",
         replyToMode: "off",
         threadRootId: "root-456",
+      }),
+    ).toEqual({
+      effectiveReplyToId: "root-456",
+      sessionKey: "agent:main:mattermost:default:chan-1:thread:root-456",
+      parentSessionKey: "agent:main:mattermost:default:chan-1",
+    });
+  });
+
+  it("keeps top-level messages on the base session when replyToMode is off", () => {
+    expect(
+      resolveMattermostThreadSessionContext({
+        baseSessionKey: "agent:main:mattermost:default:chan-1",
+        kind: "group",
+        postId: "post-123",
+        replyToMode: "off",
       }),
     ).toEqual({
       effectiveReplyToId: undefined,

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -442,7 +442,7 @@ export function resolveMattermostEffectiveReplyToId(params: {
     return undefined;
   }
   const threadRootId = normalizeOptionalString(params.threadRootId);
-  if (threadRootId && params.replyToMode !== "off") {
+  if (threadRootId) {
     return threadRootId;
   }
   const postId = normalizeOptionalString(params.postId);


### PR DESCRIPTION
## Summary

- Fix a Mattermost regression from #52543 / `aaba1ae653f` where the default `replyToMode: "off"` discarded an existing Mattermost `root_id`.
- Preserve existing channel/group thread roots so replies to messages inside a Mattermost thread stay in that thread.
- Keep top-level messages top-level when `replyToMode: "off"` and keep DMs non-threaded.

## Regression Context

#52543 fixed a real `replyToMode: "off"` failure, but it overcorrected by suppressing existing thread roots too. The latest docs say the default `off` behavior should not start new threads, but should still reply in a thread when the inbound post is already in one.

Reporter proof: on the latest OpenClaw release, starting a Mattermost thread and sending a message inside it causes the agent reply to land at the top level in the channel.

Latest stable checked: `v2026.6.1` published 2026-06-03. In that tag, `resolveMattermostEffectiveReplyToId` still drops `threadRootId` when `replyToMode` is `off`, while `docs/channels/mattermost.md` documents the opposite default behavior.

## Real behavior proof

Behavior addressed: Mattermost replies to messages sent inside an existing channel/group thread escape to the channel root under the default `replyToMode: "off"`.

Real environment tested: Reporter manually reproduced on the latest OpenClaw release with a real Mattermost channel thread.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs extensions/mattermost/src/mattermost/monitor.test.ts`

Evidence after fix: Focused tests now assert existing channel/group thread roots are preserved when `replyToMode` is `off`, while top-level `off` messages still do not start new threads and DMs remain non-threaded.

Observed result after fix: `resolveMattermostEffectiveReplyToId` and `resolveMattermostThreadSessionContext` keep the existing Mattermost thread root for threaded channel/group follow-ups.

What was not tested: Live Mattermost after the patch.

## Verification

- `node scripts/run-vitest.mjs extensions/mattermost/src/mattermost/monitor.test.ts`
- `pnpm exec oxfmt --check extensions/mattermost/src/mattermost/monitor.ts extensions/mattermost/src/mattermost/monitor.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local --prompt 'Review the Mattermost regression fix...'` - clean, no accepted/actionable findings
