### PR TITLE
fix(sessions): preserve titles on upsert

### DIFF
--- a/src/config/sessions.test.ts
+++ b/src/config/sessions.test.ts
@@ -699,6 +699,38 @@ describe("sessions", () => {
     expect(store[sessionKey]?.modelProvider).toBeUndefined();
   });
 
+  it("patchSessionEntry replaceEntry remains the intentional human title clear path", async () => {
+    const sessionKey = "agent:main:main";
+    const { storePath } = await createSessionStoreFixture({
+      prefix: "patchSessionEntry-title-clear",
+      entries: {
+        [sessionKey]: {
+          sessionId: "sess-1",
+          updatedAt: 100,
+          label: "Pinned Lane",
+          displayName: "Pinned Lane",
+        },
+      },
+    });
+
+    await patchSessionEntry({
+      storePath,
+      sessionKey,
+      replaceEntry: true,
+      update: (entry) => {
+        const next = { ...entry, updatedAt: 200 };
+        delete next.label;
+        delete next.displayName;
+        return next;
+      },
+    });
+
+    const store = loadSessionStore(storePath);
+    expect(store[sessionKey]?.updatedAt).toBe(200);
+    expect(store[sessionKey]?.label).toBeUndefined();
+    expect(store[sessionKey]?.displayName).toBeUndefined();
+  });
+
   it("upsertSessionEntry drops legacy embedded ACP metadata", async () => {
     const sessionKey = "agent:main:main";
     const acp = {
@@ -732,6 +764,106 @@ describe("sessions", () => {
     const store = loadSessionStore(storePath);
     expect(store[sessionKey]?.sessionId).toBe("sess-2");
     expect(store[sessionKey]?.acp).toBeUndefined();
+  });
+
+  it("upsertSessionEntry preserves the default main session title when runtime metadata omits it", async () => {
+    const sessionKey = "agent:main:main";
+    const { storePath } = await createSessionStoreFixture({
+      prefix: "upsertSessionEntry-main-title-preserve",
+      entries: {
+        [sessionKey]: {
+          sessionId: "sess-1",
+          updatedAt: 100,
+          label: "Stable Main Lane",
+          displayName: "Stable Main Lane",
+          origin: {
+            provider: "webchat",
+            surface: "webchat",
+            chatType: "direct",
+          },
+        },
+      },
+    });
+
+    await upsertSessionEntry({
+      storePath,
+      sessionKey,
+      entry: {
+        sessionId: "sess-2",
+        updatedAt: 200,
+        origin: {
+          provider: "webchat",
+          surface: "webchat",
+          chatType: "direct",
+        },
+      },
+    });
+
+    const store = loadSessionStore(storePath);
+    expect(store[sessionKey]?.sessionId).toBe("sess-2");
+    expect(store[sessionKey]?.label).toBe("Stable Main Lane");
+    expect(store[sessionKey]?.displayName).toBe("Stable Main Lane");
+  });
+
+  it("upsertSessionEntry preserves human titles when replacement metadata is empty", async () => {
+    const sessionKey = "agent:main:telegram:direct:opaque-user";
+    const { storePath } = await createSessionStoreFixture({
+      prefix: "upsertSessionEntry-title-empty-preserve",
+      entries: {
+        [sessionKey]: {
+          sessionId: "sess-1",
+          updatedAt: 100,
+          label: "Channel Lane",
+          displayName: "Channel Lane",
+        },
+      },
+    });
+
+    await upsertSessionEntry({
+      storePath,
+      sessionKey,
+      entry: {
+        sessionId: "sess-2",
+        updatedAt: 200,
+        label: null as unknown as string,
+        displayName: "",
+      },
+    });
+
+    const store = loadSessionStore(storePath);
+    expect(store[sessionKey]?.sessionId).toBe("sess-2");
+    expect(store[sessionKey]?.label).toBe("Channel Lane");
+    expect(store[sessionKey]?.displayName).toBe("Channel Lane");
+  });
+
+  it("upsertSessionEntry accepts non-empty replacement human titles", async () => {
+    const sessionKey = "agent:main:ops-lane";
+    const { storePath } = await createSessionStoreFixture({
+      prefix: "upsertSessionEntry-title-replace",
+      entries: {
+        [sessionKey]: {
+          sessionId: "sess-1",
+          updatedAt: 100,
+          label: "Old Lane",
+          displayName: "Old Lane",
+        },
+      },
+    });
+
+    await upsertSessionEntry({
+      storePath,
+      sessionKey,
+      entry: {
+        sessionId: "sess-2",
+        updatedAt: 200,
+        label: "Ops Lane",
+        displayName: "Ops Lane",
+      },
+    });
+
+    const store = loadSessionStore(storePath);
+    expect(store[sessionKey]?.label).toBe("Ops Lane");
+    expect(store[sessionKey]?.displayName).toBe("Ops Lane");
   });
 
   it("updateSessionStore preserves concurrent additions", async () => {

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -187,6 +187,26 @@ function cloneSessionEntry(entry: SessionEntry): SessionEntry {
   return cloneSessionStoreRecord({ entry }).entry;
 }
 
+function hasNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function preserveHumanSessionTitleFields(params: {
+  existing?: SessionEntry;
+  next: SessionEntry;
+}): void {
+  const { existing, next } = params;
+  if (!existing) {
+    return;
+  }
+  if (!hasNonEmptyString(next.label) && hasNonEmptyString(existing.label)) {
+    next.label = existing.label;
+  }
+  if (!hasNonEmptyString(next.displayName) && hasNonEmptyString(existing.displayName)) {
+    next.displayName = existing.displayName;
+  }
+}
+
 function resolveSessionWorkflowStorePath(
   options: SessionEntryWorkflowOptions & { sessionKey?: string },
 ): string {
@@ -695,6 +715,10 @@ export async function upsertSessionEntry(
     const store = loadMutableSessionStoreForWriter(storePath);
     const resolved = resolveSessionStoreEntry({ store, sessionKey: params.sessionKey });
     const next = cloneSessionEntry(params.entry);
+    preserveHumanSessionTitleFields({
+      existing: resolved.existing,
+      next,
+    });
     await persistResolvedSessionEntry({
       storePath,
       store,


### PR DESCRIPTION
Superseded by #93072.

This older PR targeted `main` and used a broader replacement contract. The replacement PR targets `release/2026.6.8`, narrows compatibility risk by preserving title fields only when replacement metadata omits them, and uses only generic fixtures/text.
