### PR TITLE
[AI] fix(memory): prevent empty-string expectedModel in resolveMemory…

### DIFF
--- a/extensions/memory-core/src/memory/manager-reindex-state.test.ts
+++ b/extensions/memory-core/src/memory/manager-reindex-state.test.ts
@@ -273,4 +273,37 @@ describe("memory reindex state", () => {
       ),
     ).toBe(false);
   });
+
+  it("falls back to fts-only when provider.model is an empty string", () => {
+    expect(
+      resolveMemoryIndexIdentityState(
+        createIdentityParams({
+          provider: { id: "openai", model: "" },
+          meta: createMeta({ model: "fts-only" }),
+        }),
+      ),
+    ).toEqual({ status: "valid" });
+  });
+
+  it("reports mismatch when empty-string expected model is compared to a non-fts index", () => {
+    const state = resolveMemoryIndexIdentityState(
+      createIdentityParams({
+        provider: { id: "openai", model: "" },
+        meta: createMeta({ model: "text-embedding-3-small" }),
+      }),
+    );
+    expect(state.status).toBe("mismatched");
+    expect(state.reason).toContain("expected fts-only");
+  });
+
+  it("falls back to fts-only when provider.model is whitespace-only", () => {
+    expect(
+      resolveMemoryIndexIdentityState(
+        createIdentityParams({
+          provider: { id: "openai", model: "  " },
+          meta: createMeta({ model: "fts-only" }),
+        }),
+      ),
+    ).toEqual({ status: "valid" });
+  });
 });

--- a/extensions/memory-core/src/memory/manager-reindex-state.test.ts
+++ b/extensions/memory-core/src/memory/manager-reindex-state.test.ts
@@ -293,7 +293,9 @@ describe("memory reindex state", () => {
       }),
     );
     expect(state.status).toBe("mismatched");
-    expect(state.reason).toContain("expected fts-only");
+    if (state.status === "mismatched") {
+      expect(state.reason).toContain("expected fts-only");
+    }
   });
 
   it("falls back to fts-only when provider.model is whitespace-only", () => {

--- a/extensions/memory-core/src/memory/manager-reindex-state.ts
+++ b/extensions/memory-core/src/memory/manager-reindex-state.ts
@@ -159,7 +159,7 @@ export function resolveMemoryIndexIdentityState(params: {
   if (!meta) {
     return { status: "missing", reason: "index metadata is missing" };
   }
-  const expectedModel = params.provider ? params.provider.model : "fts-only";
+  const expectedModel = params.provider?.model?.trim() || "fts-only";
   const matchingModelIdentities = [
     { model: expectedModel, providerKey: params.providerKey },
     ...(params.providerAliases ?? []),

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -517,7 +517,7 @@ export abstract class MemoryManagerSyncOps {
               this.settings.provider,
             model:
               this.settings.model.trim() ||
-              resolveEmbeddingProviderFallbackModel(this.settings.provider, "", this.cfg),
+              resolveEmbeddingProviderFallbackModel(this.settings.provider, "fts-only", this.cfg),
           });
     const provider = hasProviderOverride
       ? params.provider!


### PR DESCRIPTION
## Summary

`resolveMemoryIndexIdentityState` computes `expectedModel` from `provider.model`, but when `provider.model` is an empty string (as happens when `resolveEmbeddingProviderFallbackModel` returns `""` for an unregistered adapter, or when `createWithAdapter` returned empty model before PR #90042), the expected model becomes `""` — causing a permanent identity mismatch that blocks vector search indefinitely.

This PR fixes two code paths that could produce empty-string `expectedModel`:

1. **Identity consumer layer** (`manager-reindex-state.ts:123`): Replace `params.provider ? params.provider.model : "fts-only"` with `params.provider?.model?.trim() || "fts-only"`. Empty or whitespace-only `provider.model` now falls back to `"fts-only"` — the same safe default used when no provider is configured.

2. **Identity computation layer** (`manager-sync-ops.ts:420`): Change `resolveEmbeddingProviderFallbackModel(provider, "", cfg)` to `resolveEmbeddingProviderFallbackModel(provider, "fts-only", cfg)`. When the adapter IS registered (e.g., `"openai"` → defaultModel `"text-embedding-3-small"`), the resolved default model is used. When the adapter is NOT registered (e.g., `"google"` before the Google plugin loads), `fallbackSourceModel = "fts-only"` is returned instead of `""`.

This two-layer approach addresses the ClawSweeper P1 finding: when a configured provider has an empty model, the resolved adapter default model (e.g., `"text-embedding-3-small"`) is used for identity comparison. `"fts-only"` only appears when both the adapter and the configured model are unavailable — matching the no-provider path semantics.

## Change Type

- [x] Bug fix

## Scope

- [x] Memory / storage

## Linked Issue

- Related to #90787 (prevents empty-string expectedModel in identity check; provider auto→openai migration decision is a separate product issue)
- Related to #90042 (provider.model backfill in createWithAdapter; this PR protects the identity check even when backfill hasn't happened yet or the adapter is unavailable)

## Motivation

Users upgrading from 2026.5.26 to 2026.6.1 who previously used Google/Gemini as their memorySearch provider see `Dirty: yes` permanently with `reason: "index was built for model gemini-embedding-001, expected "` — the empty `expected` field makes the index unrecoverable. PR #90042 fixed the root cause at `createWithAdapter` (provider initialization), but the identity check can still produce empty-string `expectedModel` before provider init completes, or when the adapter registry hasn't loaded yet.

## Changes

**File**: `extensions/memory-core/src/memory/manager-reindex-state.ts`

1. Replace `params.provider ? params.provider.model : "fts-only"` with `params.provider?.model?.trim() || "fts-only"` — guard against empty/whitespace `provider.model` at the identity comparison consumer

**File**: `extensions/memory-core/src/memory/manager-sync-ops.ts`

1. Change `resolveEmbeddingProviderFallbackModel(this.settings.provider, "", this.cfg)` to `resolveEmbeddingProviderFallbackModel(this.settings.provider, "fts-only", this.cfg)` — use `"fts-only"` as fallbackSourceModel instead of `""` so unregistered adapters produce a readable fallback instead of empty string

**File**: `extensions/memory-core/src/memory/manager-reindex-state.test.ts`

1. Add 3 tests covering empty-string, whitespace-only, and non-fts mismatch scenarios

No new imports, no config changes, no default surface changes.

## Verification

- `extensions/memory-core/src/memory/manager-reindex-state.test.ts` — 12 passed (9 original + 3 new)
- `extensions/memory-core/src/memory/embeddings.test.ts` — 8 passed (original suite, PR #90042's 2 backfill tests are on a separate branch)

## Real Behavior Proof

**Behavior addressed**: `expectedModel` in `resolveMemoryIndexIdentityState` can become an empty string `""` when `provider.model` is empty, causing permanent identity mismatch (`"index was built for model X, expected "`) and blocking vector search recovery.

**Real environment tested**: Linux (Ubuntu), Node.js 22.19+, local checkout on branch `fix/memory-identity-empty-model-90787`.

**Exact steps or command run after this patch**:
```
node scripts/run-vitest.mjs extensions/memory-core/src/memory/manager-reindex-state.test.ts --run
node /tmp/identity-proof.mjs
node /tmp/fallback-proof.mjs
http_proxy=http://proxyhk.zte.com.cn:80 https_proxy=http://proxyhk.zte.com.cn:80 pnpm openclaw memory status --deep
```

**Evidence after fix**: Direct runtime proof demonstrating the empty-string `provider.model` path changed after the fix. Two focused scripts exercise the exact code paths that this PR changes:

1. **resolveMemoryIndexIdentityState expectedModel comparison** (`node /tmp/identity-proof.mjs`): proves the identity consumer layer now produces `"fts-only"` instead of empty string for empty `provider.model`, while preserving behavior for normal values:

```
=== resolveMemoryIndexIdentityState: expectedModel BEFORE vs AFTER fix ===

Case: provider.model = "" (issue #90787 exact scenario)
  BEFORE: expectedModel = ""
  AFTER:  expectedModel = "fts-only"
  Changed: YES >>> empty string eliminated

Case: provider.model = "  " (whitespace)
  BEFORE: expectedModel = "  "
  AFTER:  expectedModel = "fts-only"
  Changed: YES >>> empty string eliminated

Case: provider.model = "text-embedding-3-small" (normal)
  BEFORE: expectedModel = "text-embedding-3-small"
  AFTER:  expectedModel = "text-embedding-3-small"
  Changed: NO >>> behavior preserved

Case: provider = null (no-provider path)
  BEFORE: expectedModel = "fts-only"
  AFTER:  expectedModel = "fts-only"
  Changed: NO >>> behavior preserved

Case: provider.model = "gemini-embedding-001" (google)
  BEFORE: expectedModel = "gemini-embedding-001"
  AFTER:  expectedModel = "gemini-embedding-001"
  Changed: NO >>> behavior preserved
```

2. **resolveEmbeddingProviderFallbackModel fallbackSourceModel comparison** (`node /tmp/fallback-proof.mjs`): proves the pre-init configured-provider fallback now uses `"fts-only"` for unregistered adapters instead of empty string, while preserving resolved defaultModel for registered adapters:

```
=== resolveEmbeddingProviderFallbackModel: fallbackSourceModel BEFORE vs AFTER ===

Case: openai adapter registered, empty fallbackSourceModel (BEFORE)
  Result: "text-embedding-3-small"

Case: openai adapter registered, fts-only fallbackSourceModel (AFTER)
  Result: "text-embedding-3-small"

Case: google adapter NOT registered, empty fallbackSourceModel (BEFORE)
  Result: ""

Case: google adapter NOT registered, fts-only fallbackSourceModel (AFTER)
  Result: "fts-only"
```

3. **Unit test** (terminal output from `node scripts/run-vitest.mjs`): directly tests `resolveMemoryIndexIdentityState` with `provider.model = ""` → `expectedModel = "fts-only"` (not empty string):

```
 ✓ falls back to fts-only when provider.model is an empty string
 ✓ reports mismatch when empty-string expected model is compared to a non-fts index
 ✓ falls back to fts-only when provider.model is whitespace-only
```

**Before-fix comparison** (from issue #90787 reporter, Rocky Linux, v2026.6.1):

| Field | Before (issue #90787) | After (this patch) |
|-------|----------------------|---------------------|
| `expectedModel` | `""` (empty string) | adapter defaultModel or `"fts-only"` (safe fallback) |
| Identity reason | `"index was built for model gemini-embedding-001, expected "` (trailing empty string) | `"index was built for model gemini-embedding-001, expected text-embedding-3-small"` (adapter default) or `"expected fts-only"` (unregistered adapter) |
| Recovery path | None (permanent Dirty, no rebuild clears it) | Reindex with correct provider → Dirty: no |

**Observed result after fix**: Two-layer protection ensures `expectedModel` is never an empty string. When the adapter IS registered (e.g., `"openai"` → `"text-embedding-3-small"`), the resolved default model is used for identity comparison. When the adapter is NOT registered, `"fts-only"` is used — matching the no-provider path semantics and producing a readable mismatch reason that points the user toward a reindex instead of a broken permanent-stuck state.

**What was not tested**: The provider auto→openai migration decision (separate product issue with `needs-product-decision` label). This PR only fixes the identity-check and fallback-source layers; the migration logic that unconditionally rewrites `provider: "auto"` to `"openai"` is not changed and requires maintainer product decision per #90787's `clawsweeper:needs-product-decision` label.

**Verification test output** (12 tests, including 3 new):

```
 RUN  v4.1.7

 ✓ |extension-memory| extensions/memory-core/src/memory/manager-reindex-state.test.ts (12 tests) 31ms

 Test Files  1 passed (1)
      Tests  12 passed (12)

Key new test assertions:
- "falls back to fts-only when provider.model is an empty string":
    provider.model = "" → expectedModel = "fts-only" → matches fts-only index → status: "valid"
- "reports mismatch when empty-string expected model is compared to a non-fts index":
    provider.model = "" → expectedModel = "fts-only" → mismatched with "text-embedding-3-small" → reason contains "expected fts-only"
- "falls back to fts-only when provider.model is whitespace-only":
    provider.model = "  " → trimmed to "" → expectedModel = "fts-only" → matches fts-only index → status: "valid"
```

## Risks

- **Low risk**: Two-point guard — one at the identity comparison consumer, one at the fallback-source parameter — preserving existing behavior for all non-empty `provider.model` values.
- **Additive**: The guards only activate when `provider.model` is empty or whitespace, or when `fallbackSourceModel` would otherwise be `""`. Previously these produced broken empty-string mismatches. No change for correctly-populated `provider.model`.
- **Complementary with #90042**: PR #90042 fixes `provider.model` at the creation source (`createWithAdapter`); this PR protects the identity check at the consumption layer and the fallback-source computation. Either fix alone reduces the bug surface; together they eliminate it.
- **No config/default surface changes**: No new config keys, env vars, or defaults introduced.
- **Adapter-default resolution preserved**: `resolveEmbeddingProviderFallbackModel("openai", "fts-only", cfg)` still returns `"text-embedding-3-small"` (adapter defaultModel) when the adapter is registered. `"fts-only"` only appears when the adapter is unregistered — which is the correct semantic for the no-provider path.