### PR TITLE
fix(agents): publish embedded transcript writes

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
@@ -27,6 +27,7 @@ import {
   installPromptSubmissionLockRelease,
   resetEmbeddedAttemptSessionFileOwnersForTest,
 } from "./attempt.session-lock.js";
+import { createEmbeddedTranscriptMutationController } from "./embedded-transcript-mutation-controller.js";
 
 const lockOptions = {
   sessionFile: "/tmp/session.jsonl",
@@ -1226,7 +1227,7 @@ describe("embedded attempt session lock lifecycle", () => {
     expect(firstController.hasSessionTakeover()).toBe(false);
   });
 
-  it("reproduces orphaned trailing user repair tripping the prompt fence", async () => {
+  it("publishes orphaned trailing user repair as an owned transcript mutation", async () => {
     const sessionFile = await createTempSessionFile();
     const release = vi.fn(async () => {});
     const acquireSessionWriteLockLocal39 = vi.fn(async () => ({ release }));
@@ -1234,7 +1235,7 @@ describe("embedded attempt session lock lifecycle", () => {
       acquireSessionWriteLock: acquireSessionWriteLockLocal39,
       lockOptions: { ...lockOptions, sessionFile },
     });
-    const sessionManager = SessionManager.open(sessionFile);
+    const sessionManager = guardSessionManager(SessionManager.open(sessionFile));
     const firstKeptEntryId = sessionManager.appendMessage({
       role: "user",
       content: "old question",
@@ -1270,15 +1271,22 @@ describe("embedded attempt session lock lifecycle", () => {
 
     await controller.releaseForPrompt();
 
-    // Mirrors the HF Space failure: the next turn repairs the orphaned trailing
-    // user by branching back to the compaction row, then appends the new user
-    // turn as OpenClaw-owned transcript progress while the prompt lock is
-    // released. The current fence treats that owned append as a takeover.
-    sessionManager.branch(compactionId);
-    sessionManager.appendMessage({
-      role: "user",
-      content: "please continue",
-      timestamp: 4,
+    const transcriptMutations = createEmbeddedTranscriptMutationController({
+      sessionManager,
+      withSessionWriteLock: (operation, options) =>
+        controller.withSessionWriteLock(operation, options),
+    });
+    await transcriptMutations.run("orphan-user-repair", (mutatingSessionManager) => {
+      // Mirrors the HF Space failure: the next turn repairs the orphaned
+      // trailing user by branching back to the compaction row, then appends the
+      // new user turn as OpenClaw-owned transcript progress while the prompt
+      // lock is released.
+      mutatingSessionManager.branch(compactionId);
+      mutatingSessionManager.appendMessage({
+        role: "user",
+        content: "please continue",
+        timestamp: 4,
+      });
     });
 
     await expect(controller.withSessionWriteLock(() => "finalize")).resolves.toBe("finalize");

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
@@ -1226,6 +1226,65 @@ describe("embedded attempt session lock lifecycle", () => {
     expect(firstController.hasSessionTakeover()).toBe(false);
   });
 
+  it("reproduces orphaned trailing user repair tripping the prompt fence", async () => {
+    const sessionFile = await createTempSessionFile();
+    const release = vi.fn(async () => {});
+    const acquireSessionWriteLockLocal39 = vi.fn(async () => ({ release }));
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock: acquireSessionWriteLockLocal39,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+    const sessionManager = SessionManager.open(sessionFile);
+    const firstKeptEntryId = sessionManager.appendMessage({
+      role: "user",
+      content: "old question",
+      timestamp: 1,
+    });
+    sessionManager.appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "old answer" }],
+      api: "messages",
+      provider: "openclaw",
+      model: "session-lock-test",
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: "stop",
+      timestamp: 2,
+    });
+    const compactionId = sessionManager.appendCompaction(
+      "threshold summary",
+      firstKeptEntryId,
+      160_001,
+    );
+    sessionManager.appendMessage({
+      role: "user",
+      content: "please continue",
+      timestamp: 3,
+    });
+
+    await controller.releaseForPrompt();
+
+    // Mirrors the HF Space failure: the next turn repairs the orphaned trailing
+    // user by branching back to the compaction row, then appends the new user
+    // turn as OpenClaw-owned transcript progress while the prompt lock is
+    // released. The current fence treats that owned append as a takeover.
+    sessionManager.branch(compactionId);
+    sessionManager.appendMessage({
+      role: "user",
+      content: "please continue",
+      timestamp: 4,
+    });
+
+    await expect(controller.withSessionWriteLock(() => "finalize")).resolves.toBe("finalize");
+    expect(controller.hasSessionTakeover()).toBe(false);
+  });
+
   it("allows post-prompt writes after the prompt context publishes an owned transcript write", async () => {
     const sessionFile = await createTempSessionFile();
     const releases: string[] = [];

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
@@ -949,6 +949,58 @@ describe("embedded attempt session lock lifecycle", () => {
     expect(controller.hasSessionTakeover()).toBe(false);
   });
 
+  it("accepts compaction appends published through the owned transcript write context", async () => {
+    const sessionFile = await createTempSessionFile();
+    const acquireSessionWriteLockLocal31 = vi.fn(async () => ({ release: vi.fn(async () => {}) }));
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock: acquireSessionWriteLockLocal31,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+    const sessionManager = SessionManager.open(sessionFile);
+    const firstKeptEntryId = sessionManager.appendMessage({
+      role: "user",
+      content: "old question",
+      timestamp: 1,
+    });
+    sessionManager.appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "old answer" }],
+      api: "messages",
+      provider: "openclaw",
+      model: "session-lock-test",
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: "stop",
+      timestamp: 2,
+    });
+
+    await controller.releaseForPrompt();
+    await withOwnedSessionTranscriptWrites(
+      {
+        sessionFile,
+        sessionKey: "agent:main:telegram:direct:7216393410",
+        withSessionWriteLock: (operation, options) =>
+          controller.withSessionWriteLock(operation, options),
+      },
+      async () =>
+        await runWithOwnedSessionTranscriptWritePublication(
+          { sessionFile, sessionKey: "agent:main:telegram:direct:7216393410" },
+          () => {
+            sessionManager.appendCompaction("threshold summary", firstKeptEntryId, 160_001);
+          },
+        ),
+    );
+
+    await expect(controller.withSessionWriteLock(() => "finalize")).resolves.toBe("finalize");
+    expect(controller.hasSessionTakeover()).toBe(false);
+  });
+
   it("still rejects unowned external compaction appends before the prompt stream lock is reacquired", async () => {
     const sessionFile = await createTempSessionFile();
     const release = vi.fn(async () => {});

--- a/src/agents/embedded-agent-runner/run/attempt.transcript-mutation-guard.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.transcript-mutation-guard.test.ts
@@ -1,0 +1,23 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+describe("embedded transcript mutation ownership guard", () => {
+  it("keeps attempt transcript writes behind the mutation controller", async () => {
+    const source = await fs.readFile(
+      path.join(path.dirname(fileURLToPath(import.meta.url)), "attempt.ts"),
+      "utf8",
+    );
+    const forbiddenPatterns = [
+      /\bactiveSessionManager\.(appendMessage|appendCustomEntry|appendCompaction|branch|resetLeaf|branchWithSummary)\(/,
+      /\bsessionManager\.(branch|resetLeaf)\(/,
+      /\bsessionLockController\.withSessionWriteLock\(\s*(async\s*)?\(\)\s*=>\s*\{[^}]*\.(appendMessage|appendCustomEntry|appendCompaction|branch|resetLeaf|branchWithSummary)\(/s,
+      /withSessionWriteLock:\s*\(\s*operation\s*\)\s*=>/,
+    ];
+
+    for (const pattern of forbiddenPatterns) {
+      expect(source.match(pattern)?.[0]).toBeUndefined();
+    }
+  });
+});

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -430,6 +430,7 @@ import {
   selectCompactionTimeoutSnapshot,
   shouldFlagCompactionTimeout,
 } from "./compaction-timeout.js";
+import { createEmbeddedTranscriptMutationController } from "./embedded-transcript-mutation-controller.js";
 import {
   resolveFinalAssistantRawText,
   resolveFinalAssistantVisibleText,
@@ -2290,8 +2291,8 @@ export async function runEmbeddedAttempt(
           sessionManager,
           settingsManager,
           resourceLoader,
-          withSessionWriteLock: (operation) =>
-            sessionLockController.withSessionWriteLock(operation),
+          withSessionWriteLock: (operation, options) =>
+            sessionLockController.withSessionWriteLock(operation, options),
         },
       });
       session = createdSession.session;
@@ -3505,6 +3506,15 @@ export async function runEmbeddedAttempt(
       }
 
       const activeSessionManager = sessionManager;
+      const refreshActiveSessionTranscriptState = () => {
+        activeSession.agent.state.messages = activeSessionManager.buildSessionContext().messages;
+      };
+      const transcriptMutations = createEmbeddedTranscriptMutationController({
+        sessionManager: activeSessionManager,
+        withSessionWriteLock: (operation, options) =>
+          sessionLockController.withSessionWriteLock(operation, options),
+        refreshActiveSessionState: refreshActiveSessionTranscriptState,
+      });
       let preflightRecovery: EmbeddedRunAttemptResult["preflightRecovery"];
       let promptErrorSource: EmbeddedRunAttemptResult["promptErrorSource"] = null;
       const handleMidTurnPrecheckRequest = (request: MidTurnPrecheckRequest) => {
@@ -3757,13 +3767,13 @@ export async function runEmbeddedAttempt(
             transcriptPromptForRuntimeSplit = transcriptPromptMerge.prompt;
           }
           if (orphanPromptMerge.removeLeaf) {
-            if (leafEntry.parentId) {
-              sessionManager.branch(leafEntry.parentId);
-            } else {
-              sessionManager.resetLeaf();
-            }
-            const sessionContext = sessionManager.buildSessionContext();
-            activeSession.agent.state.messages = sessionContext.messages;
+            await transcriptMutations.run("orphan-user-repair", (mutatingSessionManager) => {
+              if (leafEntry.parentId) {
+                mutatingSessionManager.branch(leafEntry.parentId);
+              } else {
+                mutatingSessionManager.resetLeaf();
+              }
+            });
           }
           const orphanRepairMessage =
             `${
@@ -3949,12 +3959,12 @@ export async function runEmbeddedAttempt(
               },
             };
             try {
-              activeSessionManager.appendMessage(
-                redactedUserMessage as Parameters<typeof activeSessionManager.appendMessage>[0],
-              );
-              flushSessionManagerFile(activeSessionManager);
-              activeSession.agent.state.messages =
-                activeSessionManager.buildSessionContext().messages;
+              await transcriptMutations.run("before-agent-run-block", (mutatingSessionManager) => {
+                mutatingSessionManager.appendMessage(
+                  redactedUserMessage as Parameters<typeof mutatingSessionManager.appendMessage>[0],
+                );
+                flushSessionManagerFile(mutatingSessionManager);
+              });
               return true;
             } catch (err) {
               log.warn(
@@ -4036,8 +4046,8 @@ export async function runEmbeddedAttempt(
               provider: params.provider,
               sessionManager: {
                 appendCustomEntry: async (customType, data) => {
-                  await sessionLockController.withSessionWriteLock(() => {
-                    activeSessionManager.appendCustomEntry(customType, data);
+                  await transcriptMutations.run("google-prompt-cache", (mutatingSessionManager) => {
+                    mutatingSessionManager.appendCustomEntry(customType, data);
                   });
                 },
                 getEntries: () => activeSessionManager.getEntries(),
@@ -4476,15 +4486,19 @@ export async function runEmbeddedAttempt(
             });
             await sessionLockController.releaseHeldLockForAbort();
             await sessionLockController.waitForSessionEvents(activeSession);
-            await sessionLockController.withSessionWriteLock(async () => {
-              stripSessionsYieldArtifacts(activeSession);
-              if (yieldMessage) {
-                await persistSessionsYieldContextMessage(activeSession, yieldMessage);
-              }
-            });
+            await transcriptMutations.run(
+              "session-yield-cleanup",
+              async () => {
+                stripSessionsYieldArtifacts(activeSession);
+                if (yieldMessage) {
+                  await persistSessionsYieldContextMessage(activeSession, yieldMessage);
+                }
+              },
+              { refreshActiveSessionState: false },
+            );
           } else if (isMidTurnPrecheckSignal(err)) {
             await sessionLockController.waitForSessionEvents(activeSession);
-            await sessionLockController.withSessionWriteLock(() => {
+            await transcriptMutations.run("mid-turn-precheck", () => {
               handleMidTurnPrecheckRequest(err.request);
             });
           } else {
@@ -4501,7 +4515,7 @@ export async function runEmbeddedAttempt(
           const request = pendingMidTurnPrecheckRequest;
           pendingMidTurnPrecheckRequest = null;
           await sessionLockController.waitForSessionEvents(activeSession);
-          await sessionLockController.withSessionWriteLock(() => {
+          await transcriptMutations.run("mid-turn-precheck", () => {
             removeTrailingMidTurnPrecheckAssistantError({
               activeSession,
               sessionManager: activeSessionManager,
@@ -4630,118 +4644,123 @@ export async function runEmbeddedAttempt(
         }
 
         await sessionLockController.waitForSessionEvents(activeSession);
-        await sessionLockController.withSessionWriteLock(async () => {
-          // Check if ANY compaction occurred during the entire attempt (prompt + retry).
-          // Using a cumulative count (> 0) instead of a delta check avoids missing
-          // compactions that complete during activeSession.prompt() before the delta
-          // baseline is sampled.
-          compactionOccurredThisAttempt = getCompactionCount() > 0;
-          // Append cache-TTL timestamp AFTER prompt + compaction retry completes.
-          // Previously this was before the prompt, which caused a custom entry to be
-          // inserted between compaction and the next prompt — breaking the
-          // prepareCompaction() guard that checks the last entry type, leading to
-          // double-compaction. See: https://github.com/openclaw/openclaw/issues/9282
-          // Skip when timed out during compaction — session state may be inconsistent.
-          // Also skip when compaction ran this attempt — appending a custom entry
-          // after compaction would break the guard again. See: #28491
-          appendAttemptCacheTtlIfNeeded({
-            sessionManager: activeSessionManager,
-            timedOutDuringCompaction,
-            compactionOccurredThisAttempt,
-            config: params.config,
-            provider: params.provider,
-            modelId: params.modelId,
-            modelApi: params.model.api,
-            isCacheTtlEligibleProvider,
-          });
+        await transcriptMutations.run(
+          "post-prompt-attempt-state",
+          async (mutatingSessionManager) => {
+            // Check if ANY compaction occurred during the entire attempt (prompt + retry).
+            // Using a cumulative count (> 0) instead of a delta check avoids missing
+            // compactions that complete during activeSession.prompt() before the delta
+            // baseline is sampled.
+            compactionOccurredThisAttempt = getCompactionCount() > 0;
+            // Append cache-TTL timestamp AFTER prompt + compaction retry completes.
+            // Previously this was before the prompt, which caused a custom entry to be
+            // inserted between compaction and the next prompt — breaking the
+            // prepareCompaction() guard that checks the last entry type, leading to
+            // double-compaction. See: https://github.com/openclaw/openclaw/issues/9282
+            // Skip when timed out during compaction — session state may be inconsistent.
+            // Also skip when compaction ran this attempt — appending a custom entry
+            // after compaction would break the guard again. See: #28491
+            appendAttemptCacheTtlIfNeeded({
+              sessionManager: mutatingSessionManager,
+              timedOutDuringCompaction,
+              compactionOccurredThisAttempt,
+              config: params.config,
+              provider: params.provider,
+              modelId: params.modelId,
+              modelApi: params.model.api,
+              isCacheTtlEligibleProvider,
+            });
 
-          // If timeout occurred during compaction, use pre-compaction snapshot when available
-          // (compaction restructures messages but does not add user/assistant turns).
-          const snapshotSelection = selectCompactionTimeoutSnapshot({
-            timedOutDuringCompaction,
-            preCompactionSnapshot,
-            preCompactionSessionId,
-            currentSnapshot: activeSession.messages.slice(),
-            currentSessionId: activeSession.sessionId,
-          });
-          if (timedOutDuringCompaction) {
-            if (!isProbeSession) {
-              log.warn(
-                `using ${snapshotSelection.source} snapshot: timed out during compaction runId=${params.runId} sessionId=${params.sessionId}`,
-              );
+            // If timeout occurred during compaction, use pre-compaction snapshot when available
+            // (compaction restructures messages but does not add user/assistant turns).
+            const snapshotSelection = selectCompactionTimeoutSnapshot({
+              timedOutDuringCompaction,
+              preCompactionSnapshot,
+              preCompactionSessionId,
+              currentSnapshot: activeSession.messages.slice(),
+              currentSessionId: activeSession.sessionId,
+            });
+            if (timedOutDuringCompaction) {
+              if (!isProbeSession) {
+                log.warn(
+                  `using ${snapshotSelection.source} snapshot: timed out during compaction runId=${params.runId} sessionId=${params.sessionId}`,
+                );
+              }
             }
-          }
-          messagesSnapshot = projectToolSearchTargetTranscriptMessages(
-            snapshotSelection.messagesSnapshot,
-            toolSearchTargetTranscriptProjections,
-          );
-          sessionIdUsed = snapshotSelection.sessionIdUsed;
+            messagesSnapshot = projectToolSearchTargetTranscriptMessages(
+              snapshotSelection.messagesSnapshot,
+              toolSearchTargetTranscriptProjections,
+            );
+            sessionIdUsed = snapshotSelection.sessionIdUsed;
 
-          lastAssistant = messagesSnapshot
-            .slice()
-            .toReversed()
-            .find((message): message is AssistantMessage => message.role === "assistant");
-          currentAttemptAssistant = findCurrentAttemptAssistantMessage({
-            messagesSnapshot,
-            prePromptMessageCount,
-          });
-          attemptUsage = getUsageTotals();
-          cacheBreak = cacheObservabilityEnabled
-            ? completePromptCacheObservation({
-                sessionId: params.sessionId,
-                promptCacheKey: params.promptCacheKey,
-                sessionKey: params.sessionKey,
-                usage: attemptUsage,
-              })
-            : null;
-          lastCallUsage = normalizeUsage(currentAttemptAssistant?.usage);
-          const promptCacheObservation =
-            cacheObservabilityEnabled &&
-            (cacheBreak || promptCacheChangesForTurn || typeof attemptUsage?.cacheRead === "number")
-              ? {
-                  broke: Boolean(cacheBreak),
-                  ...(typeof cacheBreak?.previousCacheRead === "number"
-                    ? { previousCacheRead: cacheBreak.previousCacheRead }
-                    : {}),
-                  ...(typeof cacheBreak?.cacheRead === "number"
-                    ? { cacheRead: cacheBreak.cacheRead }
-                    : typeof attemptUsage?.cacheRead === "number"
-                      ? { cacheRead: attemptUsage.cacheRead }
+            lastAssistant = messagesSnapshot
+              .slice()
+              .toReversed()
+              .find((message): message is AssistantMessage => message.role === "assistant");
+            currentAttemptAssistant = findCurrentAttemptAssistantMessage({
+              messagesSnapshot,
+              prePromptMessageCount,
+            });
+            attemptUsage = getUsageTotals();
+            cacheBreak = cacheObservabilityEnabled
+              ? completePromptCacheObservation({
+                  sessionId: params.sessionId,
+                  promptCacheKey: params.promptCacheKey,
+                  sessionKey: params.sessionKey,
+                  usage: attemptUsage,
+                })
+              : null;
+            lastCallUsage = normalizeUsage(currentAttemptAssistant?.usage);
+            const promptCacheObservation =
+              cacheObservabilityEnabled &&
+              (cacheBreak ||
+                promptCacheChangesForTurn ||
+                typeof attemptUsage?.cacheRead === "number")
+                ? {
+                    broke: Boolean(cacheBreak),
+                    ...(typeof cacheBreak?.previousCacheRead === "number"
+                      ? { previousCacheRead: cacheBreak.previousCacheRead }
                       : {}),
-                  changes: cacheBreak?.changes ?? promptCacheChangesForTurn,
-                }
-              : undefined;
-          const fallbackLastCacheTouchAt = readLastCacheTtlTimestamp(activeSessionManager, {
-            provider: params.provider,
-            modelId: params.modelId,
-          });
-          promptCache = buildContextEnginePromptCacheInfo({
-            retention: effectivePromptCacheRetention,
-            lastCallUsage,
-            observation: promptCacheObservation,
-            lastCacheTouchAt: resolvePromptCacheTouchTimestamp({
+                    ...(typeof cacheBreak?.cacheRead === "number"
+                      ? { cacheRead: cacheBreak.cacheRead }
+                      : typeof attemptUsage?.cacheRead === "number"
+                        ? { cacheRead: attemptUsage.cacheRead }
+                        : {}),
+                    changes: cacheBreak?.changes ?? promptCacheChangesForTurn,
+                  }
+                : undefined;
+            const fallbackLastCacheTouchAt = readLastCacheTtlTimestamp(activeSessionManager, {
+              provider: params.provider,
+              modelId: params.modelId,
+            });
+            promptCache = buildContextEnginePromptCacheInfo({
+              retention: effectivePromptCacheRetention,
               lastCallUsage,
-              assistantTimestamp: currentAttemptAssistant?.timestamp,
-              fallbackLastCacheTouchAt,
-            }),
-          });
+              observation: promptCacheObservation,
+              lastCacheTouchAt: resolvePromptCacheTouchTimestamp({
+                lastCallUsage,
+                assistantTimestamp: currentAttemptAssistant?.timestamp,
+                fallbackLastCacheTouchAt,
+              }),
+            });
 
-          if (promptError && promptErrorSource === "prompt" && !compactionOccurredThisAttempt) {
-            try {
-              activeSessionManager.appendCustomEntry("openclaw:prompt-error", {
-                timestamp: Date.now(),
-                runId: params.runId,
-                sessionId: params.sessionId,
-                provider: params.provider,
-                model: params.modelId,
-                api: params.model.api,
-                error: formatErrorMessage(promptError),
-              });
-            } catch (entryErr) {
-              log.warn(`failed to persist prompt error entry: ${String(entryErr)}`);
+            if (promptError && promptErrorSource === "prompt" && !compactionOccurredThisAttempt) {
+              try {
+                mutatingSessionManager.appendCustomEntry("openclaw:prompt-error", {
+                  timestamp: Date.now(),
+                  runId: params.runId,
+                  sessionId: params.sessionId,
+                  provider: params.provider,
+                  model: params.modelId,
+                  api: params.model.api,
+                  error: formatErrorMessage(promptError),
+                });
+              } catch (entryErr) {
+                log.warn(`failed to persist prompt error entry: ${String(entryErr)}`);
+              }
             }
-          }
-        });
+          },
+        );
 
         // Let the active context engine run its post-turn lifecycle. These hooks
         // may call runtime LLM capabilities, so only their transcript rewrite
@@ -4778,7 +4797,10 @@ export async function runEmbeddedAttempt(
                 reason: contextParams.reason,
                 sessionManager: contextParams.sessionManager as never,
                 withSessionManagerRewriteLock: async (operation) =>
-                  await sessionLockController.withSessionWriteLock(operation),
+                  await transcriptMutations.run(
+                    "context-engine-maintenance",
+                    async () => await operation(),
+                  ),
                 runtimeContext: contextParams.runtimeContext,
                 config: params.config,
                 agentId: sessionAgentId,
@@ -4792,7 +4814,7 @@ export async function runEmbeddedAttempt(
 
         if (!beforeAgentFinalizeRevisionReason) {
           await sessionLockController.waitForSessionEvents(activeSession);
-          await sessionLockController.withSessionWriteLock(async () => {
+          await transcriptMutations.run("bootstrap-completion", async (mutatingSessionManager) => {
             if (
               shouldPersistCompletedBootstrapTurn({
                 shouldRecordCompletedBootstrapTurn,
@@ -4803,7 +4825,7 @@ export async function runEmbeddedAttempt(
               })
             ) {
               try {
-                activeSessionManager.appendCustomEntry(FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE, {
+                mutatingSessionManager.appendCustomEntry(FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE, {
                   timestamp: Date.now(),
                   runId: params.runId,
                   sessionId: params.sessionId,

--- a/src/agents/embedded-agent-runner/run/embedded-transcript-mutation-controller.ts
+++ b/src/agents/embedded-agent-runner/run/embedded-transcript-mutation-controller.ts
@@ -1,0 +1,62 @@
+/**
+ * Central mutation boundary for embedded-run transcript writes.
+ *
+ * Embedded attempts release their broad session lock while provider I/O is in
+ * flight. Any OpenClaw-owned transcript mutation during that window must also
+ * publish the owned file fingerprint, otherwise the prompt fence will mistake
+ * OpenClaw's own write for an external takeover.
+ */
+import type { guardSessionManager } from "../../session-tool-result-guard-wrapper.js";
+
+type SessionWriteLockOptions = {
+  publishOwnedWrite?: boolean;
+};
+
+type WithSessionWriteLock = <T>(
+  operation: () => Promise<T> | T,
+  options?: SessionWriteLockOptions,
+) => Promise<T>;
+
+export type EmbeddedTranscriptMutationReason =
+  | "agent-steering"
+  | "before-agent-run-block"
+  | "bootstrap-completion"
+  | "context-engine-maintenance"
+  | "google-prompt-cache"
+  | "mid-turn-precheck"
+  | "orphan-user-repair"
+  | "post-prompt-attempt-state"
+  | "prompt-error"
+  | "session-yield-cleanup";
+
+export type EmbeddedTranscriptSessionManager = ReturnType<typeof guardSessionManager>;
+
+export type EmbeddedTranscriptMutationController = {
+  run<T>(
+    reason: EmbeddedTranscriptMutationReason,
+    operation: (sessionManager: EmbeddedTranscriptSessionManager) => Promise<T> | T,
+    options?: { refreshActiveSessionState?: boolean },
+  ): Promise<T>;
+};
+
+export function createEmbeddedTranscriptMutationController(params: {
+  sessionManager: EmbeddedTranscriptSessionManager;
+  withSessionWriteLock: WithSessionWriteLock;
+  refreshActiveSessionState?: () => void;
+}): EmbeddedTranscriptMutationController {
+  return {
+    async run(reason, operation, options) {
+      void reason;
+      return await params.withSessionWriteLock(
+        async () => {
+          const result = await operation(params.sessionManager);
+          if (options?.refreshActiveSessionState !== false) {
+            params.refreshActiveSessionState?.();
+          }
+          return result;
+        },
+        { publishOwnedWrite: true },
+      );
+    },
+  };
+}

--- a/src/agents/sessions/agent-session.ts
+++ b/src/agents/sessions/agent-session.ts
@@ -555,10 +555,9 @@ export class AgentSession {
   /** Internal handler for agent events - shared by subscribe and reconnect */
   private handleAgentEvent = async (event: AgentEvent): Promise<void> => {
     if (this.eventMayWriteSession(event)) {
-      await this.runWithSessionWriteLock(
-        async () => await this.handleAgentEventUnlocked(event),
-        event.type === "message_end" ? { publishOwnedWrite: true } : undefined,
-      );
+      await this.runWithSessionWriteLock(async () => await this.handleAgentEventUnlocked(event), {
+        publishOwnedWrite: true,
+      });
       return;
     }
     await this.handleAgentEventUnlocked(event);

--- a/src/agents/sessions/agent-session.ts
+++ b/src/agents/sessions/agent-session.ts
@@ -1789,6 +1789,7 @@ export class AgentSession {
   async compact(customInstructions?: string): Promise<CompactionResult> {
     return await this.runWithSessionWriteLock(
       async () => await this.compactWithSessionWriteLock(customInstructions),
+      { publishOwnedWrite: true },
     );
   }
 
@@ -1807,6 +1808,7 @@ export class AgentSession {
         mode: "manual",
         settings,
         signal: this.compactionAbortController.signal,
+        sessionWriteLockHeld: true,
       });
       if (outcome.status !== "compacted") {
         throw new Error("Compaction cancelled");
@@ -1878,6 +1880,7 @@ export class AgentSession {
     signal: AbortSignal;
     customInstructions?: string;
     mode: "manual" | "auto";
+    sessionWriteLockHeld?: boolean;
   }): Promise<CompactionWorkOutcome> {
     const isManual = options.mode === "manual";
     if (!this.model) {
@@ -1946,17 +1949,19 @@ export class AgentSession {
       return { status: "aborted" };
     }
 
-    await this.runWithSessionWriteLock(
-      () =>
-        this.sessionManager.appendCompaction(
-          compactionResult.summary,
-          compactionResult.firstKeptEntryId,
-          compactionResult.tokensBefore,
-          compactionResult.details,
-          fromExtension,
-        ),
-      { publishOwnedWrite: true },
-    );
+    const appendCompaction = () =>
+      this.sessionManager.appendCompaction(
+        compactionResult.summary,
+        compactionResult.firstKeptEntryId,
+        compactionResult.tokensBefore,
+        compactionResult.details,
+        fromExtension,
+      );
+    if (options.sessionWriteLockHeld) {
+      appendCompaction();
+    } else {
+      await this.runWithSessionWriteLock(appendCompaction, { publishOwnedWrite: true });
+    }
     const newEntries = this.sessionManager.getEntries();
     const sessionContext = this.sessionManager.buildSessionContext();
     this.agent.state.messages = sessionContext.messages;

--- a/src/agents/sessions/agent-session.ts
+++ b/src/agents/sessions/agent-session.ts
@@ -478,25 +478,28 @@ export class AgentSession {
   private installAgentToolHooks(): void {
     this.agent.beforeToolCall = async ({ toolCall, args }) => {
       const runner = this.currentExtensionRunner;
-      return await this.runWithSessionWriteLock(async () => {
-        if (!runner.hasHandlers("tool_call")) {
-          return undefined;
-        }
-
-        try {
-          return await runner.emitToolCall({
-            type: "tool_call",
-            toolName: toolCall.name,
-            toolCallId: toolCall.id,
-            input: args as Record<string, unknown>,
-          });
-        } catch (err) {
-          if (err instanceof Error) {
-            throw err;
+      return await this.runWithSessionWriteLock(
+        async () => {
+          if (!runner.hasHandlers("tool_call")) {
+            return undefined;
           }
-          throw new Error(`Extension failed, blocking execution: ${String(err)}`, { cause: err });
-        }
-      });
+
+          try {
+            return await runner.emitToolCall({
+              type: "tool_call",
+              toolName: toolCall.name,
+              toolCallId: toolCall.id,
+              input: args as Record<string, unknown>,
+            });
+          } catch (err) {
+            if (err instanceof Error) {
+              throw err;
+            }
+            throw new Error(`Extension failed, blocking execution: ${String(err)}`, { cause: err });
+          }
+        },
+        { publishOwnedWrite: true },
+      );
     };
 
     this.agent.afterToolCall = async ({ toolCall, args, result, isError }) => {
@@ -516,6 +519,7 @@ export class AgentSession {
             details: result.details,
             isError,
           }),
+        { publishOwnedWrite: true },
       );
 
       if (!hookResult) {
@@ -1948,7 +1952,7 @@ export class AgentSession {
       return { status: "aborted" };
     }
 
-    const appendCompaction = () =>
+    const persistCompaction = async () => {
       this.sessionManager.appendCompaction(
         compactionResult.summary,
         compactionResult.firstKeptEntryId,
@@ -1956,25 +1960,26 @@ export class AgentSession {
         compactionResult.details,
         fromExtension,
       );
+      const newEntries = this.sessionManager.getEntries();
+      const sessionContext = this.sessionManager.buildSessionContext();
+      this.agent.state.messages = sessionContext.messages;
+
+      const savedCompactionEntry = newEntries.find(
+        (e) => e.type === "compaction" && e.summary === compactionResult.summary,
+      ) as CompactionEntry | undefined;
+
+      if (this.currentExtensionRunner && savedCompactionEntry) {
+        await this.currentExtensionRunner.emit({
+          type: "session_compact",
+          compactionEntry: savedCompactionEntry,
+          fromExtension,
+        });
+      }
+    };
     if (options.sessionWriteLockHeld) {
-      appendCompaction();
+      await persistCompaction();
     } else {
-      await this.runWithSessionWriteLock(appendCompaction, { publishOwnedWrite: true });
-    }
-    const newEntries = this.sessionManager.getEntries();
-    const sessionContext = this.sessionManager.buildSessionContext();
-    this.agent.state.messages = sessionContext.messages;
-
-    const savedCompactionEntry = newEntries.find(
-      (e) => e.type === "compaction" && e.summary === compactionResult.summary,
-    ) as CompactionEntry | undefined;
-
-    if (this.currentExtensionRunner && savedCompactionEntry) {
-      await this.currentExtensionRunner.emit({
-        type: "session_compact",
-        compactionEntry: savedCompactionEntry,
-        fromExtension,
-      });
+      await this.runWithSessionWriteLock(persistCompaction, { publishOwnedWrite: true });
     }
 
     return { status: "compacted", result: compactionResult };

--- a/src/agents/sessions/agent-session.ts
+++ b/src/agents/sessions/agent-session.ts
@@ -1952,12 +1952,13 @@ export class AgentSession {
       return { status: "aborted" };
     }
 
+    const finalCompactionResult = compactionResult;
     const persistCompaction = async () => {
       this.sessionManager.appendCompaction(
-        compactionResult.summary,
-        compactionResult.firstKeptEntryId,
-        compactionResult.tokensBefore,
-        compactionResult.details,
+        finalCompactionResult.summary,
+        finalCompactionResult.firstKeptEntryId,
+        finalCompactionResult.tokensBefore,
+        finalCompactionResult.details,
         fromExtension,
       );
       const newEntries = this.sessionManager.getEntries();
@@ -1965,7 +1966,7 @@ export class AgentSession {
       this.agent.state.messages = sessionContext.messages;
 
       const savedCompactionEntry = newEntries.find(
-        (e) => e.type === "compaction" && e.summary === compactionResult.summary,
+        (e) => e.type === "compaction" && e.summary === finalCompactionResult.summary,
       ) as CompactionEntry | undefined;
 
       if (this.currentExtensionRunner && savedCompactionEntry) {
@@ -1982,7 +1983,7 @@ export class AgentSession {
       await this.runWithSessionWriteLock(persistCompaction, { publishOwnedWrite: true });
     }
 
-    return { status: "compacted", result: compactionResult };
+    return { status: "compacted", result: finalCompactionResult };
   }
 
   /**

--- a/src/agents/sessions/agent-session.ts
+++ b/src/agents/sessions/agent-session.ts
@@ -188,7 +188,10 @@ export type AgentSessionEvent =
 
 /** Listener function for agent session events */
 export type AgentSessionEventListener = (event: AgentSessionEvent) => void;
-export type AgentSessionWriteLockRunner = <T>(run: () => Promise<T> | T) => Promise<T>;
+export type AgentSessionWriteLockRunner = <T>(
+  run: () => Promise<T> | T,
+  options?: { publishOwnedWrite?: boolean },
+) => Promise<T>;
 
 // ============================================================================
 // Types
@@ -451,9 +454,12 @@ export class AgentSession {
     return result.ok ? { apiKey: result.apiKey, headers: result.headers } : {};
   }
 
-  private async runWithSessionWriteLock<T>(run: () => Promise<T> | T): Promise<T> {
+  private async runWithSessionWriteLock<T>(
+    run: () => Promise<T> | T,
+    options?: { publishOwnedWrite?: boolean },
+  ): Promise<T> {
     return this.withExternalSessionWriteLock
-      ? await this.withExternalSessionWriteLock(run)
+      ? await this.withExternalSessionWriteLock(run, options)
       : await run();
   }
 
@@ -549,7 +555,10 @@ export class AgentSession {
   /** Internal handler for agent events - shared by subscribe and reconnect */
   private handleAgentEvent = async (event: AgentEvent): Promise<void> => {
     if (this.eventMayWriteSession(event)) {
-      await this.runWithSessionWriteLock(async () => await this.handleAgentEventUnlocked(event));
+      await this.runWithSessionWriteLock(
+        async () => await this.handleAgentEventUnlocked(event),
+        event.type === "message_end" ? { publishOwnedWrite: true } : undefined,
+      );
       return;
     }
     await this.handleAgentEventUnlocked(event);
@@ -1937,12 +1946,16 @@ export class AgentSession {
       return { status: "aborted" };
     }
 
-    this.sessionManager.appendCompaction(
-      compactionResult.summary,
-      compactionResult.firstKeptEntryId,
-      compactionResult.tokensBefore,
-      compactionResult.details,
-      fromExtension,
+    await this.runWithSessionWriteLock(
+      () =>
+        this.sessionManager.appendCompaction(
+          compactionResult.summary,
+          compactionResult.firstKeptEntryId,
+          compactionResult.tokensBefore,
+          compactionResult.details,
+          fromExtension,
+        ),
+      { publishOwnedWrite: true },
     );
     const newEntries = this.sessionManager.getEntries();
     const sessionContext = this.sessionManager.buildSessionContext();

--- a/src/agents/sessions/sdk.test.ts
+++ b/src/agents/sessions/sdk.test.ts
@@ -327,6 +327,7 @@ describe("createAgentSession tool defaults", () => {
 
   it("runs write-capable tool hooks under the configured write lock", async () => {
     const events: string[] = [];
+    const lockOptions: Array<{ publishOwnedWrite?: boolean } | undefined> = [];
     const handlers = new Map<string, Array<(...args: unknown[]) => Promise<unknown>>>([
       [
         "tool_call",
@@ -345,7 +346,8 @@ describe("createAgentSession tool defaults", () => {
       sessionManager: SessionManager.inMemory(),
       settingsManager: SettingsManager.inMemory(),
       modelRegistry: ModelRegistry.inMemory(AuthStorage.inMemory()),
-      withSessionWriteLock: async (run) => {
+      withSessionWriteLock: async (run, options) => {
+        lockOptions.push(options);
         events.push("lock:start");
         try {
           return await run();
@@ -383,19 +385,22 @@ describe("createAgentSession tool defaults", () => {
     });
 
     expect(events).toEqual(["lock:start", "hook", "lock:end"]);
+    expect(lockOptions).toEqual([{ publishOwnedWrite: true }]);
   });
 
   it("fences tool execution when no extension hook is registered", async () => {
     // Write-capable tools still enter the lock even without hooks; the lock is
     // about shared session state, not just extension execution.
     const events: string[] = [];
+    const lockOptions: Array<{ publishOwnedWrite?: boolean } | undefined> = [];
     const { session } = await createAgentSession({
       model: testModel,
       resourceLoader: createEmptyResourceLoader(),
       sessionManager: SessionManager.inMemory(),
       settingsManager: SettingsManager.inMemory(),
       modelRegistry: ModelRegistry.inMemory(AuthStorage.inMemory()),
-      withSessionWriteLock: async (run) => {
+      withSessionWriteLock: async (run, options) => {
+        lockOptions.push(options);
         events.push("lock:start");
         try {
           return await run();
@@ -433,5 +438,6 @@ describe("createAgentSession tool defaults", () => {
     });
 
     expect(events).toEqual(["lock:start", "lock:end"]);
+    expect(lockOptions).toEqual([{ publishOwnedWrite: true }]);
   });
 });

--- a/src/agents/sessions/sdk.test.ts
+++ b/src/agents/sessions/sdk.test.ts
@@ -284,6 +284,47 @@ describe("createAgentSession tool defaults", () => {
     expect(sessionManager.getEntries().some((entry) => entry.type === "compaction")).toBe(true);
   });
 
+  it("publishes extension-handled event locks as owned writes", async () => {
+    const events: string[] = [];
+    const lockOptions: Array<{ publishOwnedWrite?: boolean } | undefined> = [];
+    const handlers = new Map<string, Array<(...args: unknown[]) => Promise<unknown>>>([
+      [
+        "agent_start",
+        [
+          async () => {
+            events.push("hook");
+            return undefined;
+          },
+        ],
+      ],
+    ]);
+    const { session } = await createAgentSession({
+      model: testModel,
+      resourceLoader: createResourceLoaderWithHandlers(handlers),
+      sessionManager: SessionManager.inMemory(),
+      settingsManager: SettingsManager.inMemory(),
+      modelRegistry: ModelRegistry.inMemory(AuthStorage.inMemory()),
+      withSessionWriteLock: async (run, options) => {
+        lockOptions.push(options);
+        events.push("lock:start");
+        try {
+          return await run();
+        } finally {
+          events.push("lock:end");
+        }
+      },
+    });
+
+    const handleAgentEvent = (
+      session as unknown as { handleAgentEvent(event: unknown): Promise<void> }
+    )["handleAgentEvent"];
+
+    await handleAgentEvent({ type: "agent_start" });
+
+    expect(events).toEqual(["lock:start", "hook", "lock:end"]);
+    expect(lockOptions).toEqual([{ publishOwnedWrite: true }]);
+  });
+
   it("runs write-capable tool hooks under the configured write lock", async () => {
     const events: string[] = [];
     const handlers = new Map<string, Array<(...args: unknown[]) => Promise<unknown>>>([

--- a/src/agents/sessions/sdk.test.ts
+++ b/src/agents/sessions/sdk.test.ts
@@ -209,6 +209,81 @@ describe("createAgentSession tool defaults", () => {
     expect(sessionManager.getEntries().some((entry) => entry.type === "message")).toBe(true);
   });
 
+  it("does not re-enter the configured write lock while appending manual compaction", async () => {
+    const events: string[] = [];
+    const lockOptions: Array<{ publishOwnedWrite?: boolean } | undefined> = [];
+    const sessionManager = SessionManager.inMemory();
+    sessionManager.appendMessage({
+      role: "user",
+      content: "Please compact this test conversation.",
+      timestamp: Date.now(),
+    });
+    const firstKeptEntryId = sessionManager.appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "Ready." }],
+      api: testModel.api,
+      provider: testModel.provider,
+      model: testModel.id,
+      usage: {
+        input: 10,
+        output: 2,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 12,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: "stop",
+      timestamp: Date.now(),
+    });
+    const handlers = new Map<string, Array<(...args: unknown[]) => Promise<unknown>>>([
+      [
+        "session_before_compact",
+        [
+          async () => ({
+            compaction: {
+              summary: "Compacted by test extension.",
+              firstKeptEntryId,
+              tokensBefore: 12,
+            },
+          }),
+        ],
+      ],
+    ]);
+
+    let locked = false;
+    const { session } = await createAgentSession({
+      model: testModel,
+      resourceLoader: createResourceLoaderWithHandlers(handlers),
+      sessionManager,
+      settingsManager: SettingsManager.inMemory({
+        compaction: { reserveTokens: 1, keepRecentTokens: 1 },
+      }),
+      modelRegistry: ModelRegistry.inMemory(AuthStorage.inMemory()),
+      withSessionWriteLock: async (run, options) => {
+        if (locked) {
+          throw new Error("nested session write lock");
+        }
+        locked = true;
+        lockOptions.push(options);
+        events.push("lock:start");
+        try {
+          return await run();
+        } finally {
+          events.push("lock:end");
+          locked = false;
+        }
+      },
+    });
+
+    await expect(session.compact()).resolves.toMatchObject({
+      summary: "Compacted by test extension.",
+    });
+
+    expect(events).toEqual(["lock:start", "lock:end"]);
+    expect(lockOptions).toEqual([{ publishOwnedWrite: true }]);
+    expect(sessionManager.getEntries().some((entry) => entry.type === "compaction")).toBe(true);
+  });
+
   it("runs write-capable tool hooks under the configured write lock", async () => {
     const events: string[] = [];
     const handlers = new Map<string, Array<(...args: unknown[]) => Promise<unknown>>>([

--- a/src/agents/sessions/sdk.test.ts
+++ b/src/agents/sessions/sdk.test.ts
@@ -172,6 +172,7 @@ describe("createAgentSession tool defaults", () => {
     // Transcript writes share the caller-provided lock so concurrent event
     // handlers cannot interleave JSONL persistence.
     const events: string[] = [];
+    const lockOptions: Array<{ publishOwnedWrite?: boolean } | undefined> = [];
     const sessionManager = SessionManager.inMemory();
     const { session } = await createAgentSession({
       model: testModel,
@@ -179,7 +180,8 @@ describe("createAgentSession tool defaults", () => {
       sessionManager,
       settingsManager: SettingsManager.inMemory(),
       modelRegistry: ModelRegistry.inMemory(AuthStorage.inMemory()),
-      withSessionWriteLock: async (run) => {
+      withSessionWriteLock: async (run, options) => {
+        lockOptions.push(options);
         events.push("lock:start");
         try {
           return await run();
@@ -203,6 +205,7 @@ describe("createAgentSession tool defaults", () => {
     });
 
     expect(events).toEqual(["lock:start", "lock:end"]);
+    expect(lockOptions).toEqual([{ publishOwnedWrite: true }]);
     expect(sessionManager.getEntries().some((entry) => entry.type === "message")).toBe(true);
   });
 

--- a/src/agents/sessions/sdk.ts
+++ b/src/agents/sessions/sdk.ts
@@ -340,8 +340,13 @@ export async function createAgentSession(
   };
 
   const extensionRunnerRef: { current?: ExtensionRunner } = {};
-  const runWithSessionWriteLock = async <T>(run: () => Promise<T> | T): Promise<T> =>
-    options.withSessionWriteLock ? await options.withSessionWriteLock(run) : await run();
+  const runWithSessionWriteLock = async <T>(
+    run: () => Promise<T> | T,
+    lockOptions?: { publishOwnedWrite?: boolean },
+  ): Promise<T> =>
+    options.withSessionWriteLock
+      ? await options.withSessionWriteLock(run, lockOptions)
+      : await run();
 
   const agent: Agent = new Agent({
     initialState: {
@@ -378,6 +383,7 @@ export async function createAgentSession(
       }
       return await runWithSessionWriteLock(
         async () => await runner.emitBeforeProviderRequest(payload),
+        { publishOwnedWrite: true },
       );
     },
     onResponse: async (response, modelLocal) => {
@@ -393,6 +399,7 @@ export async function createAgentSession(
             status: response.status,
             headers: response.headers,
           }),
+        { publishOwnedWrite: true },
       );
     },
     sessionId: sessionManager.getSessionId(),


### PR DESCRIPTION
Opened on behalf of Onur Solmaz (`osolmaz`). This draft is implemented and validated, but not merged. It still needs maintainer review before merge.

AI-assisted change.

## Summary

Embedded agent runs could stream a valid answer and then report a generic failure.
The runner was treating some OpenClaw-owned transcript writes as external session takeovers while the prompt lock was released.
This change makes embedded transcript writes go through one owned mutation boundary, forwards owned-write lock options correctly, and keeps real external edit rejection intact.

## What Changed

The fix is to make OpenClaw-owned transcript mutations explicit.
When the embedded prompt fence is released for provider I/O, any transcript write made by OpenClaw now publishes its owned file fingerprint before the fence is checked again.

- Added `EmbeddedTranscriptMutationController` for embedded-run transcript mutations.
- Forwarded `withSessionWriteLock` options from the embedded runner into `AgentSession` instead of dropping them.
- Routed orphan-user repair, hook-block persistence, Google prompt-cache entries, session-yield cleanup, mid-turn precheck cleanup, post-prompt attempt entries, context-engine maintenance rewrites, and bootstrap completion entries through the controller.
- Published owned writes for session event persistence, extension-handled events, tool hooks, provider hooks, and compaction persistence.
- Avoided nested manual compaction locks by reusing the outer lock and publishing ownership once.
- Kept external takeover protection active by continuing to use the existing session lock controller and preserving external-edit rejection tests.
- Added a source guard test so direct embedded transcript writes and option-dropping lock forwarding are not reintroduced in `attempt.ts`.

## Reproduction

The PR includes a local regression for the Hugging Face/Telegram failure shape.
It creates a transcript with a compaction row and orphaned trailing user message, releases the prompt fence, repairs the orphan, appends the next user turn as an owned mutation, and then reacquires the session write lock.
Before the fix, that path failed with `EmbeddedAttemptSessionTakeoverError: session file changed while embedded prompt lock was released`.

Command used for the red/green reproduction:

```text
node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts -- --reporter=verbose
```

## Testing

The focused local tests, embedded-runner e2e, core test typecheck, review loop, and a coordinator-backed Crabbox run are green on the current head `e4475d0c14f99af40b81dc06e8a9616f888cdcc8`.
The `codex review --base origin/main` pass found no actionable correctness issues on the current head.

Local validation:

```text
node scripts/run-vitest.mjs src/agents/sessions/sdk.test.ts src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts src/agents/embedded-agent-runner/run/attempt.transcript-mutation-guard.test.ts -- --reporter=verbose
# passed: 2 Vitest shards, 52 embedded/session-lock tests plus 8 SDK tests

node scripts/run-vitest.mjs src/agents/embedded-agent-runner.e2e.test.ts -- --reporter=verbose
# passed: 14 tests, including orphaned user repair e2e coverage

pnpm tsgo:core:test
# passed

git diff --check
# passed

codex review --base origin/main
# passed: no actionable correctness issues
```

Remote Crabbox validation:

```text
node scripts/crabbox-wrapper.mjs run --provider azure --idle-timeout 90m --ttl 240m --timing-json --shell -- "corepack pnpm exec vitest run src/agents/sessions/sdk.test.ts src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts src/agents/embedded-agent-runner/run/attempt.transcript-mutation-guard.test.ts --reporter=verbose"
# passed on Azure Crabbox run run_3d4102fc89c4
# provider=azure lease=cbx_fbde4175c6a1 slug=brisk-prawn type=Standard_D32ads_v6
# result: 5 test files passed, 112 tests passed, exitCode=0, leaseStopped=true
```

CI status at the current head shows only successful or skipped checks.
The skipped checks are workflow-selection skips, not failures from this change.

Not tested here:

- A rebuilt Hugging Face Space image with this exact PR head.
- A real Telegram Desktop proof recording with live user interaction.

## Risks

The main risk is accidentally weakening external takeover detection.
This change keeps the existing lock controller as the authority and only publishes ownership for writes made inside explicit OpenClaw-owned mutation paths.

- External edit rejection coverage still passes.
- Owned compaction, message, tool, provider, and extension hook write coverage passes.
- The guard test blocks future direct transcript writes in the embedded attempt path.

## Follow-ups

A maintainer can add final live transport proof by rebuilding a Hugging Face Space or running the Telegram Desktop proof harness against this exact head.
That proof is useful for merge confidence, but the core session ownership regression is covered locally and on Crabbox.
