### PR TITLE
fix(tui): surface error detail in abort notification (fixes #90982)

### DIFF
--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -806,7 +806,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
     });
   }
 
-  private emitChatAborted(runId: string, run: LocalRunState) {
+  private emitChatAborted(runId: string, run: LocalRunState, errorMessage?: string) {
     this.clearPendingLifecycleError(runId);
     run.markQueuedRunReady();
     const alreadyFinal = run.finalSent;
@@ -822,6 +822,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
       runId,
       sessionKey: run.sessionKey,
       state: "aborted",
+      ...(errorMessage ? { errorMessage } : {}),
     });
   }
 
@@ -934,7 +935,8 @@ export class EmbeddedTuiBackend implements TuiBackend {
     if (phase === "error") {
       run.finishing = false;
       if (aborted) {
-        this.emitChatAborted(evt.runId, run);
+        const errorMessage = typeof evt.data?.error === "string" ? evt.data.error : undefined;
+        this.emitChatAborted(evt.runId, run, errorMessage);
         return;
       }
       const errorMessage = typeof evt.data?.error === "string" ? evt.data.error : undefined;

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -679,7 +679,11 @@ export function createEventHandlers(context: EventHandlerContext) {
     if (evt.state === "aborted") {
       forgetLocalBtwRunId?.(evt.runId);
       const wasActiveRun = state.activeChatRunId === evt.runId;
-      chatLog.addSystem("run aborted");
+      const abortMessage =
+        evt.errorMessage && evt.errorMessage.length > 0
+          ? `run aborted: ${evt.errorMessage}`
+          : "run aborted";
+      chatLog.addSystem(abortMessage);
       terminateRun({ runId: evt.runId, wasActiveRun, status: "aborted" });
       maybeRefreshHistoryForRun(evt.runId);
     }


### PR DESCRIPTION
### Summary

- **Problem**: When an agent run aborts due to tool-call validation errors (or any error during the error lifecycle phase), the TUI displays only "run aborted" with no indication of what failed. Users cannot distinguish between a model crash, network timeout, context-overflow abort, and a validation-failure-retry-loop abort.
- **Root Cause**: `emitChatAborted` in `src/tui/embedded-backend.ts` did not accept or forward an `errorMessage` parameter, unlike its sibling method `emitChatError` which already forwards error details. The `phase === "error"` + `aborted` call site had access to `evt.data.error` but did not pass it through.
- **Fix**: Add an optional `errorMessage` parameter to `emitChatAborted`, pass it through in the emit payload, and display it in the TUI abort handler when present.
- **What changed**:
  - `src/tui/embedded-backend.ts` — `emitChatAborted` now accepts optional `errorMessage`; the `phase === "error"` + `aborted` call site extracts and forwards `evt.data.error`
  - `src/tui/tui-event-handlers.ts` — abort handler now appends the error message when `evt.errorMessage` is non-empty
- **What did NOT change (scope boundary)**:
  - Gateway `chat-abort.ts` abort event emission (out of scope; the gateway path emits `stopReason` separately)
  - The `phase === "end"` + `aborted` path (no error context is available there)
  - Error-state rendering (`emitChatError` / `renderTerminalRunError`) — those already surface errors correctly

### Reproduction

1. Send a prompt that causes the model to emit tool-call arguments that fail JSON Schema validation
2. The model retries with the same wrong shape; after repeated failures the run aborts
3. **Before this PR**: TUI displays only `run aborted` — no indication of the tool validation failure
4. **After this PR**: TUI displays `run aborted: Validation failed for tool "edit": edits: must have required properties edits`

### Real behavior proof

**Behavior or issue addressed (90982)**: When an agent run aborts during the error lifecycle phase with a known error message, the TUI now includes that error detail in the abort notification so users can distinguish tool validation failures from timeouts or model crashes.

**Real environment tested**: Linux, Node 22 — Vitest with the TUI vitest config against `emitChatAborted` and the chat event handler

**Exact steps or command run after this patch**: `node scripts/run-vitest.mjs src/tui/embedded-backend.test.ts src/tui/tui-event-handlers.test.ts`

**Evidence after fix**:
```text
Test Files  2 passed (2)
     Tests  109 passed (109)
  Start at  20:46:24
  Duration  6.95s (transform 3.08s, setup 412ms, import 979ms, tests 5.29s, environment 0ms)
```

**Observed result after fix**: The `emitChatAborted` method now forwards an optional `errorMessage` through the chat event payload; the TUI event handler consumes it and renders `run aborted: <error>` when an error message is present, falling back to the original `run aborted` text when none is available. The existing test suite (109 tests across both colocated test files) continues to pass.

**What was not tested**: A live agent run across an embedded gateway that actually triggers repeated tool validation failures and observes the TUI render output. The unit tests exercise the emit and handler paths but not the full embedded-runner lifecycle integration.

**Repro confirmation**: The before state shows `emitChatAborted` emitting only `{ runId, sessionKey, state: "aborted" }` with no error detail; the after state includes `errorMessage` in the emit payload when available, matching the pattern already used by `emitChatError`.

### Risk / Mitigation

- **Risk**: The `errorMessage` field is already an optional part of the `TuiChatEvent` type (`state: "delta" | "final" | "aborted" | "error"` with `errorMessage?: string`), so adding it to the abort variant is backwards-compatible
  **Mitigation**: External TUI consumers that already handle `evt.errorMessage` for the `error` state will see it for `aborted` events too; consumers that don't will ignore the new field
- **Risk**: The error message from `evt.data.error` could be very long, making the abort line noisy
  **Mitigation**: The error text from the lifecycle event is typically a one-line summary (e.g., "Validation failed for tool X: ..."), not a full stack trace

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] tui

### Regression Test Plan

- `node scripts/run-vitest.mjs src/tui/embedded-backend.test.ts`
- `node scripts/run-vitest.mjs src/tui/tui-event-handlers.test.ts`

### Review Findings Addressed

N/A (initial submission)

### Linked Issue/PR

Fixes #90982
