### PR TITLE
feat(discord): capture reaction feedback

### DIFF
--- a/extensions/discord/npm-shrinkwrap.json
+++ b/extensions/discord/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/discord",
-  "version": "2026.6.2",
+  "version": "2026.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/discord",
-      "version": "2026.6.2",
+      "version": "2026.6.3",
       "dependencies": {
         "@discordjs/voice": "0.19.2",
         "discord-api-types": "0.38.48",
@@ -16,7 +16,7 @@
         "ws": "8.21.0"
       },
       "peerDependencies": {
-        "openclaw": ">=2026.6.2"
+        "openclaw": ">=2026.6.3"
       },
       "peerDependenciesMeta": {
         "openclaw": {

--- a/extensions/discord/package.json
+++ b/extensions/discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/discord",
-  "version": "2026.6.2",
+  "version": "2026.6.3",
   "description": "OpenClaw Discord channel plugin for channels, DMs, commands, and app events.",
   "repository": {
     "type": "git",
@@ -20,7 +20,7 @@
     "openclaw": "2026.5.28"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.6.2"
+    "openclaw": ">=2026.6.3"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -67,10 +67,10 @@
       "allowInvalidConfigRecovery": true
     },
     "compat": {
-      "pluginApi": ">=2026.6.2"
+      "pluginApi": ">=2026.6.3"
     },
     "build": {
-      "openclawVersion": "2026.6.2"
+      "openclawVersion": "2026.6.3"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/discord/src/monitor/listeners.reactions.ts
+++ b/extensions/discord/src/monitor/listeners.reactions.ts
@@ -21,13 +21,14 @@ import {
 } from "./allow-list.js";
 import { resolveDiscordDmCommandAccess } from "./dm-command-auth.js";
 import { formatDiscordReactionEmoji, formatDiscordUserTag } from "./format.js";
+import { captureDiscordReactionFeedback } from "./reaction-feedback.js";
 import { runDiscordListenerWithSlowLog, type DiscordListenerLogger } from "./listeners.queue.js";
 import { resolveFetchedDiscordThreadLikeChannelContext } from "./thread-channel-context.js";
 
 type LoadedConfig = OpenClawConfig;
 type RuntimeEnv = import("openclaw/plugin-sdk/runtime-env").RuntimeEnv;
 
-type DiscordReactionEvent = Parameters<MessageReactionAddListener["handle"]>[0];
+export type DiscordReactionEvent = Parameters<MessageReactionAddListener["handle"]>[0];
 
 type DiscordReactionListenerParams = {
   cfg: LoadedConfig;
@@ -222,6 +223,7 @@ async function authorizeDiscordReactionIngress(
 async function handleDiscordThreadReactionNotification(params: {
   reactionMode: DiscordReactionMode;
   message: DiscordReactionEvent["message"];
+  fetchedMessage?: DiscordFetchedReactionMessage;
   parentId?: string;
   resolveThreadChannelAccess: () => Promise<{
     access: DiscordReactionIngressAccess;
@@ -254,7 +256,7 @@ async function handleDiscordThreadReactionNotification(params: {
     return;
   }
 
-  const message = await params.message.fetch().catch(() => null);
+  const message = params.fetchedMessage ?? (await params.message.fetch().catch(() => null));
   const { access, channelConfig } = await params.resolveThreadChannelAccess();
   const messageAuthorId = message?.author?.id ?? undefined;
   if (
@@ -275,6 +277,7 @@ async function handleDiscordChannelReactionNotification(params: {
   isGuildMessage: boolean;
   reactionMode: DiscordReactionMode;
   message: DiscordReactionEvent["message"];
+  fetchedMessage?: DiscordFetchedReactionMessage;
   channelConfig: DiscordReactionChannelConfig;
   parentId?: string;
   authorizeReactionIngressForChannel: (
@@ -315,7 +318,7 @@ async function handleDiscordChannelReactionNotification(params: {
     return;
   }
 
-  const message = await params.message.fetch().catch(() => null);
+  const message = params.fetchedMessage ?? (await params.message.fetch().catch(() => null));
   const messageAuthorId = message?.author?.id ?? undefined;
   if (
     !params.shouldNotifyReaction({
@@ -433,6 +436,7 @@ async function handleDiscordReactionEvent(
     const isDirectMessage = channelType === ChannelType.DM;
     const isGroupDm = channelType === ChannelType.GroupDM;
     const isThreadChannel = channelContext.isThreadChannel;
+    const fetchedMessage = await data.message.fetch().catch(() => null);
     const reactionIngressBase: Omit<DiscordReactionIngressAuthorizationParams, "channelConfig"> = {
       cfg: params.cfg,
       accountId: params.accountId,
@@ -463,6 +467,20 @@ async function handleDiscordReactionEvent(
     const parentId = isThreadChannel ? channelContext.threadParentId : channelContext.parentId;
     const parentName = isThreadChannel ? channelContext.threadParentName : undefined;
     const parentSlug = isThreadChannel ? channelContext.threadParentSlug : "";
+    try {
+      await captureDiscordReactionFeedback({
+        cfg: params.cfg,
+        accountId: params.accountId,
+        action,
+        data,
+        botUserId: params.botUserId,
+        fetchedMessage,
+        threadId: isThreadChannel ? channelContext.threadParentId : undefined,
+        logger: params.logger,
+      });
+    } catch (err) {
+      params.logger.error(danger(`discord reaction capture failed: ${String(err)}`));
+    }
     let reactionBase: { baseText: string; contextKey: string } | null = null;
     const resolveReactionBase = () => {
       if (reactionBase) {
@@ -555,6 +573,7 @@ async function handleDiscordReactionEvent(
       await handleDiscordThreadReactionNotification({
         reactionMode,
         message: data.message,
+        fetchedMessage,
         parentId,
         resolveThreadChannelAccess,
         shouldNotifyReaction,
@@ -579,6 +598,7 @@ async function handleDiscordReactionEvent(
       isGuildMessage,
       reactionMode,
       message: data.message,
+      fetchedMessage,
       channelConfig,
       parentId,
       authorizeReactionIngressForChannel,

--- a/extensions/discord/src/monitor/reaction-feedback.test.ts
+++ b/extensions/discord/src/monitor/reaction-feedback.test.ts
@@ -1,0 +1,109 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { captureDiscordReactionFeedback, resolveDiscordReactionCapturePath } from "./reaction-feedback.js";
+
+const ORIGINAL_OPENCLAW_STATE_DIR = process.env.OPENCLAW_STATE_DIR;
+
+afterEach(() => {
+  process.env.OPENCLAW_STATE_DIR = ORIGINAL_OPENCLAW_STATE_DIR;
+});
+
+function createLogger() {
+  return {
+    error: vi.fn(),
+    warn: vi.fn(),
+  };
+}
+
+describe("reaction feedback capture", () => {
+  it("writes assistant-authored reaction feedback as append-only JSONL", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-reaction-feedback-"));
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+
+    await captureDiscordReactionFeedback({
+      cfg: { channels: { discord: { guilds: {} } } } as never,
+      accountId: "default",
+      action: "added",
+      botUserId: "bot-1",
+      data: {
+        guild_id: "guild-1",
+        channel_id: "channel-1",
+        message_id: "message-1",
+        user: { id: "user-1" },
+        emoji: { name: "👍" },
+      } as never,
+      fetchedMessage: {
+        author: { id: "bot-1", bot: true },
+        timestamp: "2026-06-09T12:00:00.000Z",
+      },
+      threadId: "thread-1",
+      logger: createLogger() as never,
+    });
+
+    const capturePath = resolveDiscordReactionCapturePath("default");
+    const contents = await fs.readFile(capturePath, "utf8");
+    const record = JSON.parse(contents.trim()) as {
+      action: string;
+      assistant_message: boolean;
+      author_id: string;
+      channel_id: string;
+      config_version: string;
+      emoji_name: string;
+      emoji_type: string;
+      guild_id: string;
+      message_author_id: string;
+      message_created_at: string;
+      message_id: string;
+      message_provenance: string;
+      reactor_id: string;
+      reacted_at: string;
+      thread_id: string;
+    };
+
+    expect(record.action).toBe("added");
+    expect(record.assistant_message).toBe(true);
+    expect(record.author_id).toBe("bot-1");
+    expect(record.message_author_id).toBe("bot-1");
+    expect(record.reactor_id).toBe("user-1");
+    expect(record.channel_id).toBe("channel-1");
+    expect(record.thread_id).toBe("thread-1");
+    expect(record.guild_id).toBe("guild-1");
+    expect(record.message_id).toBe("message-1");
+    expect(record.message_created_at).toBe("2026-06-09T12:00:00.000Z");
+    expect(record.message_provenance).toBe("assistant");
+    expect(record.emoji_name).toBe("👍");
+    expect(record.emoji_type).toBe("unicode");
+    expect(record.reacted_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(record.config_version).toMatch(/^sha256:/);
+  });
+
+  it("skips non-assistant messages", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-reaction-feedback-"));
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+
+    await captureDiscordReactionFeedback({
+      cfg: { channels: { discord: {} } } as never,
+      accountId: "default",
+      action: "removed",
+      botUserId: "bot-1",
+      data: {
+        guild_id: "guild-1",
+        channel_id: "channel-1",
+        message_id: "message-1",
+        user: { id: "user-1" },
+        emoji: { name: "👎" },
+      } as never,
+      fetchedMessage: {
+        author: { id: "human-1", bot: false },
+        timestamp: "2026-06-09T12:00:00.000Z",
+      },
+      logger: createLogger() as never,
+    });
+
+    await expect(fs.readFile(resolveDiscordReactionCapturePath("default"), "utf8")).rejects.toThrow(
+      /ENOENT/,
+    );
+  });
+});

--- a/extensions/discord/src/monitor/reaction-feedback.ts
+++ b/extensions/discord/src/monitor/reaction-feedback.ts
@@ -1,0 +1,133 @@
+// Discord plugin module implements reaction feedback capture behavior.
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { resolveStateDir } from "openclaw/plugin-sdk/state-paths";
+import { formatDiscordReactionEmoji } from "./format.js";
+import type { DiscordReactionEvent } from "./listeners.reactions.js";
+import type { DiscordListenerLogger } from "./listeners.queue.js";
+
+type DiscordReactionCaptureRecord = {
+  event_id: string;
+  action: "added" | "removed";
+  timestamp: string;
+  guild_id: string;
+  channel_id: string;
+  thread_id?: string;
+  message_id: string;
+  reactor_id: string;
+  author_id: string;
+  message_author_id: string;
+  emoji_name: string;
+  emoji_type: string;
+  emoji_id?: string;
+  reacted_at?: string;
+  assistant_message: true;
+  config_version: string;
+  message_provenance: "assistant";
+  message_created_at?: string;
+};
+
+const DISCORD_REACTION_CAPTURE_QUEUE = new Map<string, Promise<void>>();
+
+export function resolveDiscordReactionCapturePath(accountId: string): string {
+  const safeAccountId = accountId.trim().replace(/[^a-zA-Z0-9._-]+/g, "_") || "default";
+  return path.join(resolveStateDir(process.env), "discord", `${safeAccountId}-reaction-feedback.jsonl`);
+}
+
+export function resolveDiscordReactionConfigVersion(cfg: OpenClawConfig): string {
+  const discordConfig = cfg.channels?.discord ?? {};
+  return `sha256:${crypto.createHash("sha256").update(JSON.stringify(discordConfig)).digest("hex")}`;
+}
+
+export async function captureDiscordReactionFeedback(params: {
+  cfg: OpenClawConfig;
+  accountId: string;
+  action: "added" | "removed";
+  data: DiscordReactionEvent;
+  botUserId?: string;
+  fetchedMessage: { author?: { id?: string; bot?: boolean | null }; timestamp?: string } | null;
+  threadId?: string;
+  logger?: DiscordListenerLogger;
+}): Promise<void> {
+  const { fetchedMessage } = params;
+  const author = fetchedMessage?.author;
+  const assistantAuthor =
+    Boolean(author?.id && params.botUserId && author.id === params.botUserId) ||
+    (params.botUserId === undefined && Boolean(author?.bot));
+  if (!assistantAuthor || !author?.id) {
+    return;
+  }
+
+  const emojiName = formatDiscordReactionEmoji(params.data.emoji);
+  const capturePath = resolveDiscordReactionCapturePath(params.accountId);
+  const now = new Date().toISOString();
+  const record: DiscordReactionCaptureRecord = {
+    event_id: crypto
+      .createHash("sha256")
+      .update(
+        [
+          params.accountId,
+          params.action,
+          params.data.guild_id ?? "",
+          params.data.channel_id,
+          params.data.message_id,
+          params.data.user.id,
+          emojiName,
+          now,
+        ].join("|"),
+      )
+      .digest("hex"),
+    action: params.action,
+    timestamp: now,
+    guild_id: params.data.guild_id ?? "",
+    channel_id: params.data.channel_id,
+    thread_id: params.threadId,
+    message_id: params.data.message_id,
+    reactor_id: params.data.user.id,
+    author_id: author.id,
+    message_author_id: author.id,
+    emoji_name: emojiName,
+    emoji_type: params.data.emoji.id ? "custom" : "unicode",
+    emoji_id: params.data.emoji.id ?? undefined,
+    reacted_at: now,
+    assistant_message: true,
+    config_version: resolveDiscordReactionConfigVersion(params.cfg),
+    message_provenance: "assistant",
+    message_created_at: fetchedMessage.timestamp ?? undefined,
+  };
+
+  await queueDiscordReactionFeedbackRecord(capturePath, record, params.logger);
+}
+
+async function queueDiscordReactionFeedbackRecord(
+  filePath: string,
+  record: DiscordReactionCaptureRecord,
+  logger?: DiscordListenerLogger,
+): Promise<void> {
+  const previous = DISCORD_REACTION_CAPTURE_QUEUE.get(filePath) ?? Promise.resolve();
+  const next = previous
+    .catch(() => undefined)
+    .then(async () => {
+      await appendDiscordReactionFeedbackRecord(filePath, record);
+    });
+  DISCORD_REACTION_CAPTURE_QUEUE.set(filePath, next);
+  try {
+    await next;
+  } catch (err) {
+    logger?.error?.(`discord reaction capture failed: ${String(err)}`);
+  } finally {
+    if (DISCORD_REACTION_CAPTURE_QUEUE.get(filePath) === next) {
+      DISCORD_REACTION_CAPTURE_QUEUE.delete(filePath);
+    }
+  }
+}
+
+async function appendDiscordReactionFeedbackRecord(
+  filePath: string,
+  record: DiscordReactionCaptureRecord,
+): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.appendFile(filePath, `${JSON.stringify(record)}\n`, "utf8");
+}


### PR DESCRIPTION
Adds durable reaction-feedback capture to the Discord runtime.

Summary:
- fetch reacted message once
- capture assistant-authored reactions as append-only JSONL in state dir
- reuse fetched message for notifications
- add unit tests for capture behavior
- bump @openclaw/discord to 2026.6.3