### PR TITLE
fix(memory): keep local embedding indexes clean when only local.modelPath is set

### DIFF
--- a/extensions/memory-core/src/memory/embedding.test-mocks.ts
+++ b/extensions/memory-core/src/memory/embedding.test-mocks.ts
@@ -28,6 +28,10 @@ export function resetEmbeddingMocks(): void {
 
 vi.mock("./embeddings.js", () => ({
   resolveEmbeddingProviderAdapterId: (providerId: string) => providerId,
+  resolveEmbeddingProviderAdapterTransport: (providerId: string) =>
+    providerId === "local" ? "local" : "remote",
+  resolveEmbeddingProviderFallbackModel: (_providerId: string, fallbackSourceModel: string) =>
+    fallbackSourceModel,
   createEmbeddingProvider: async () => ({
     requestedProvider: "openai",
     provider: {

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -76,6 +76,7 @@ vi.mock("./embeddings.js", () => {
     createEmbeddingProvider: async (options: {
       provider?: string;
       model?: string;
+      local?: { modelPath?: string };
       outputDimensionality?: number;
     }) => {
       providerCalls.push({
@@ -96,10 +97,16 @@ vi.mock("./embeddings.js", () => {
         options.provider === "fallback-provider" ||
         options.provider === "batch-test" ||
         options.provider === "batch-wide-test" ||
-        options.provider === "ollama"
+        options.provider === "ollama" ||
+        options.provider === "local"
           ? options.provider
           : "mock";
-      const model = options.model ?? "mock-embed";
+      // Mirror the llama.cpp adapter: the local provider takes its model
+      // identity from local.modelPath and ignores the configured model.
+      const model =
+        options.provider === "local"
+          ? options.local?.modelPath?.trim() || options.model || "mock-embed"
+          : (options.model ?? "mock-embed");
       return {
         requestedProvider: options.provider ?? "openai",
         provider: {
@@ -308,6 +315,7 @@ describe("memory index", () => {
     providerAliases?: NonNullable<NonNullable<TestCfg["models"]>["providers"]>;
     batchEnabled?: boolean;
     model?: string;
+    local?: { modelPath?: string };
     outputDimensionality?: number;
     multimodal?: {
       enabled?: boolean;
@@ -327,6 +335,7 @@ describe("memory index", () => {
           memorySearch: {
             ...(params.provider !== undefined ? { provider: params.provider } : {}),
             model: params.model ?? "mock-embed",
+            ...(params.local !== undefined ? { local: params.local } : {}),
             fallback: params.fallback,
             outputDimensionality: params.outputDimensionality,
             store: { path: params.storePath, vector: { enabled: params.vectorEnabled ?? false } },
@@ -1562,6 +1571,38 @@ describe("memory index", () => {
       expect(status.custom?.indexIdentity).toEqual({ status: "valid" });
     } finally {
       await manager.close?.();
+    }
+  });
+
+  it("keeps local llama.cpp indexes clean when only local.modelPath is configured", async () => {
+    const dbPath = path.join(workspaceDir, "index-local-modelpath-identity.sqlite");
+    const modelPath = "/models/embeddinggemma-300M-Q8_0.gguf";
+    const cfg = createCfg({
+      storePath: dbPath,
+      provider: "local",
+      model: "",
+      local: { modelPath },
+    });
+
+    const buildManager = await getFreshManager(cfg);
+    await buildManager.sync({ reason: "test", force: true });
+    const builtMeta = (
+      buildManager as unknown as { readMeta(): MemoryIndexMeta | null }
+    ).readMeta();
+    // The live local provider derives its model identity from local.modelPath.
+    expect(builtMeta?.model).toBe(modelPath);
+    await buildManager.close?.();
+
+    // Status-only managers compare identity before provider init. The configured
+    // model must mirror the local adapter's modelPath-based identity, otherwise
+    // the index looks mismatched against the adapter default and stays Dirty.
+    const statusManager = await getFreshManager(cfg, "status");
+    try {
+      const status = statusManager.status();
+      expect(status.custom?.indexIdentity).toEqual({ status: "valid" });
+      expect(status.dirty).toBe(false);
+    } finally {
+      await statusManager.close?.();
     }
   });
 

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -40,6 +40,7 @@ import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coer
 import {
   createEmbeddingProvider,
   resolveEmbeddingProviderAdapterId,
+  resolveEmbeddingProviderAdapterTransport,
   resolveEmbeddingProviderFallbackModel,
   type EmbeddingProvider,
   type EmbeddingProviderId,
@@ -406,24 +407,11 @@ export abstract class MemoryManagerSyncOps {
     hasIndexedChunks?: boolean;
   }): MemoryIndexIdentityState {
     const hasProviderOverride = params && "provider" in params;
-    // Plain status can compare identity before provider init. Mirror provider
-    // init's empty-model fallback so adapter defaults do not look mismatched.
-    const configuredProvider =
-      this.settings.provider === "none"
-        ? null
-        : {
-            id:
-              resolveEmbeddingProviderAdapterId(this.settings.provider, this.cfg) ??
-              this.settings.provider,
-            model:
-              this.settings.model.trim() ||
-              resolveEmbeddingProviderFallbackModel(this.settings.provider, "", this.cfg),
-          };
     const provider = hasProviderOverride
       ? params.provider!
       : this.provider
         ? { id: this.provider.id, model: this.provider.model }
-        : configuredProvider;
+        : this.resolveConfiguredProviderIdentity();
     const vectorReady =
       params && "vectorReady" in params
         ? Boolean(params.vectorReady)
@@ -452,6 +440,33 @@ export abstract class MemoryManagerSyncOps {
           : this.hasIndexedChunks(),
       ftsTokenizer: this.settings.store.fts.tokenizer,
     });
+  }
+
+  // Plain status can compare identity before provider init. Mirror the model
+  // the live provider would report so adapter defaults do not look mismatched.
+  private resolveConfiguredProviderIdentity(): { id: string; model: string } | null {
+    if (this.settings.provider === "none") {
+      return null;
+    }
+    return {
+      id:
+        resolveEmbeddingProviderAdapterId(this.settings.provider, this.cfg) ??
+        this.settings.provider,
+      model: this.resolveConfiguredProviderModel(),
+    };
+  }
+
+  private resolveConfiguredProviderModel(): string {
+    const fallbackModel = () =>
+      resolveEmbeddingProviderFallbackModel(this.settings.provider, "", this.cfg);
+    // Local-transport adapters (llama.cpp) take their model identity from
+    // local.modelPath and ignore settings.model. The status mirror must do the
+    // same, or an index built from a configured modelPath looks mismatched
+    // against the adapter default and stays Dirty forever (#91001).
+    if (resolveEmbeddingProviderAdapterTransport(this.settings.provider, this.cfg) === "local") {
+      return this.settings.local?.modelPath?.trim() || fallbackModel();
+    }
+    return this.settings.model.trim() || fallbackModel();
   }
 
   protected resetVectorState(): void {


### PR DESCRIPTION
## Summary

Fixes #91001. A local (llama.cpp) embeddings index configured solely via `local.modelPath` was permanently reported as `Dirty: yes`, pausing vector search even right after a successful `openclaw memory status --index`.

**Root cause:** the llama.cpp adapter derives the provider's model identity from `local.modelPath` and ignores top-level `settings.model` (`extensions/llama-cpp/src/embedding-provider.ts` → `buildMemoryCreateOptions`). So a built index stores `meta.model` as the gguf path. But the plain-status identity mirror in `extensions/memory-core/src/memory/manager-sync-ops.ts` only consulted `settings.model` (empty) and fell back to the adapter default (the `hf:` URI), so the expected model never matched the stored model → perpetual `mismatched` → `Dirty: yes`, vector search paused.

**Fix:** when no live provider is initialized (status path), mirror the adapter by preferring `local.modelPath` for local-transport providers when computing the expected model identity. Remote providers are unchanged. No-`modelPath` local configs still fall back to the adapter default, which is exactly what the adapter uses, so they keep matching.

Net diff: source +15/-14 (one inlined block replaced by a small, documented, lazily-invoked helper); tests +47.

## Real behavior proof

- **Behavior addressed:** local embeddings index reports `Dirty: yes` / "index was built for model <path>, expected …" forever when configured with only `local.modelPath`, pausing vector search.
- **Real environment tested:** OpenClaw source checkout, macOS, Node v22.22.3, real local llama.cpp embeddings. Downloaded the actual `embeddinggemma-300m-qat-Q8_0.gguf` (313 MB), configured `agents.defaults.memorySearch` with `provider: "local"` and `local.modelPath` pointed at the on-disk gguf, added one source file, and built a real index with native `node-llama-cpp` (768-dim vectors via `sqlite-vec`).
- **Exact steps or command run:**
  ```
  # config: { agents.defaults.memorySearch: { provider: "local", fallback: "none",
  #          local: { modelPath: "/…/embeddinggemma.gguf" } } }
  openclaw memory status --index --agent default   # build real index
  openclaw memory status --agent default           # read status
  ```
- **Evidence — BEFORE the fix** (pre-fix code at `6e8c2f8d0d^`, same on-disk index, no rebuild):
  ```
  Model: local
  Dirty: yes
  Index identity: index was built for model /…/embeddinggemma.gguf,
    expected hf:ggml-org/embeddinggemma-300m-qat-q8_0-GGUF/embeddinggemma-300m-qat-Q8_0.gguf
  Vector search: paused until memory is rebuilt
  Fix: Run: openclaw memory status --index --agent default
  ```
- **Observed result AFTER the fix** (this PR's code, same on-disk index, no rebuild):
  ```
  Model: /…/embeddinggemma.gguf
  Indexed: 1/1 files · 1 chunks
  Dirty: no
  Embeddings: ready
  ```
  Only the one runtime file (`manager-sync-ops.ts`) was swapped between the two runs — the index was not rebuilt — proving the change is purely the status identity comparison.
- **Unit regression:** `node scripts/run-vitest.mjs extensions/memory-core/src/memory/index.test.ts` → `Test Files 1 passed`, `Tests 49 passed (49)`, including the new "keeps local llama.cpp indexes clean when only local.modelPath is configured" (red before the source fix, green after). `oxfmt --check` clean; editor lint clean.
- **What was not tested:** no local structured autoreview (no review-engine CLI installed on this machine). One unrelated test, `manager-sync-ops.startup-catchup.test.ts > "retries transient session transcript reads"`, fails — verified **pre-existing on clean `origin/main`** (shelved this change → still fails), in a session-catch-up path untouched by this PR.

## Verification

```
# Real local llama.cpp index, before/after on the same index (see Real behavior proof)
openclaw memory status --index --agent default   # Dirty: no, Model: /…/embeddinggemma.gguf
# pre-fix code on same index → Dirty: yes (expected hf: default)

node scripts/run-vitest.mjs extensions/memory-core/src/memory/index.test.ts
# Test Files 1 passed (1) / Tests 49 passed (49)
```
