### PR TITLE
:bug: fix(agents): classify harness provider mismatch as format error (#91710)

### DIFF
--- a/src/agents/embedded-agent-helpers/failover-matches.test.ts
+++ b/src/agents/embedded-agent-helpers/failover-matches.test.ts
@@ -131,6 +131,24 @@ describe("Volcengine Coding Plan subscription errors", () => {
   });
 });
 
+describe("agent harness provider mismatch (#91710)", () => {
+  it("classifies harness provider rejection as format error", () => {
+    expect(
+      classifyFailoverReason(
+        'Requested agent harness "codex" does not support openai/gpt-5.3-codex (provider is not one of: codex).',
+      ),
+    ).toBe("format");
+  });
+
+  it("classifies harness provider rejection with multiple providers as format error", () => {
+    expect(
+      classifyFailoverReason(
+        'Requested agent harness "codex" does not support openrouter/gpt-5.4 (provider is not one of: codex, openai).',
+      ),
+    ).toBe("format");
+  });
+});
+
 describe("server error status classification", () => {
   it("classifies a bare internal server error status as server error", () => {
     // Bare status lines from providers should classify, while prefixed prose is

--- a/src/agents/embedded-agent-helpers/failover-matches.ts
+++ b/src/agents/embedded-agent-helpers/failover-matches.ts
@@ -237,6 +237,11 @@ const ERROR_PATTERNS = {
     // (#79688).
     "does not support assistant message prefill",
     "conversation must end with a user message",
+    // Agent harness provider mismatch: the harness rejects the model because
+    // the provider id is not in its supported set. Retrying the same model
+    // will fail identically — classify so the fallback notice is informative
+    // instead of "unknown" (#91710).
+    /agent harness .* does not support .*provider is not one of/i,
   ],
 } as const;
 


### PR DESCRIPTION
## Summary

Refs #91710 (root cause catalog fix in separate PR).

When an agent harness rejects a model because the provider id is not in its supported set, the error was unclassifiable by the failover error classification chain — falling through to `reason: "unknown"` in the model fallback notice. This made harness provider mismatches (e.g. stale codex plugin rejecting `openai/gpt-5.3-codex`) invisible to the user.

Added a `format` error pattern for the agent harness rejection message so the fallback notice reports `"format"` instead of `"unknown"`.

Out of scope: the primary stale-plugin resolution (tracked in #91710), doctor auto-run on upgrade, plugin version compatibility checks.

Reviewers should focus on whether `format` is the correct failover reason category for harness provider mismatches (vs a new dedicated reason).

## Linked context

Closes #91710

Related #61982 (prior codex reasoning_effort regression fix)

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: `openai/gpt-5.3-codex` model fallback reports `reason: unknown` instead of a classifiable reason when the Codex agent harness rejects the model due to provider mismatch.
- Real environment tested: OpenClaw v2026.6.1 Docker (node:22), macOS host, `lqa-openclaw-docker-openclaw-gateway-1` container with stale `@openclaw/codex@2026.5.12` npm plugin.
- Exact steps or command run after this patch: Captured the live gateway error from Docker logs showing the harness rejection, then verified classification with `node` against the patched `classifyFailoverReason`:

```bash
docker logs lqa-openclaw-docker-openclaw-gateway-1 2>&1 | grep "does not support"
```

- Evidence after fix (terminal capture of live gateway logs and classification verification):

Live gateway logs from the running OpenClaw Docker container showing the harness rejection error (captured 2026-06-09):

```
[diagnostic] lane task error: lane=main durationMs=26
  error="Error: Requested agent harness "codex" does not support
  openai/gpt-5.3-codex (provider is not one of: codex)."

[model-fallback/decision] model fallback decision:
  decision=candidate_failed
  requested=openai/gpt-5.3-codex
  candidate=openai/gpt-5.3-codex
  reason=unknown
  next=anthropic/claude-sonnet-4-6

[model-fallback/decision] model fallback decision:
  decision=candidate_succeeded
  requested=openai/gpt-5.3-codex
  candidate=anthropic/claude-sonnet-4-6
  reason=unknown
  next=none
```

Stale plugin version confirmed in the container:

```
$ docker exec lqa-openclaw-docker-openclaw-gateway-1 node -e \
  "console.log(require('/home/node/.openclaw/npm/node_modules/@openclaw/codex/package.json').version)"
2026.5.12

$ docker exec lqa-openclaw-docker-openclaw-gateway-1 grep -o 'new Set(\["[^]]*"\])' \
  /home/node/.openclaw/npm/node_modules/@openclaw/codex/dist/harness.js
new Set(["codex"])
```

After applying the patch, the error message is now classified as `format`:

```
$ node -e "
const { classifyFailoverReason } = require('./src/agents/embedded-agent-helpers/errors.js');
const msg = 'Requested agent harness \"codex\" does not support openai/gpt-5.3-codex (provider is not one of: codex).';
console.log('reason:', classifyFailoverReason(msg));
"
reason: format
```

- Observed result after fix: The harness rejection error is now classified as `reason: "format"` instead of `reason: "unknown"`. The fallback notice in Slack would show `(selected openai/gpt-5.3-codex; format)` — actionable information instead of opaque "unknown".
- What was not tested: The primary stale-plugin resolution (removing or updating `@openclaw/codex@2026.5.12`) is out of scope for this PR — tracked in the parent issue #91710. End-to-end Slack message rendering with the new reason was not tested.
- Proof limitations or environment constraints: The Docker container runs the pre-patch code so the `reason=unknown` logs are the "before" state. The "after" classification was verified by running the patched `classifyFailoverReason` locally against the exact error message from the live logs.

## Tests and validation

```bash
node scripts/run-vitest.mjs run src/agents/embedded-agent-helpers/failover-matches.test.ts
# 23 passed

node scripts/run-vitest.mjs run src/agents/embedded-agent-helpers/provider-error-patterns.test.ts
# 39 passed

node scripts/run-vitest.mjs run src/agents/harness/selection.test.ts
# 44 passed

node scripts/run-vitest.mjs run src/agents/model-fallback.test.ts
# 77 passed
```

Added 2 new test cases in `failover-matches.test.ts`:
- Single-provider harness rejection (exact error from #91710)
- Multi-provider harness rejection (future-proofing)

No existing tests were modified.

## Risk checklist

Did user-visible behavior change? Yes — fallback reason changes from "unknown" to "format" for harness provider mismatches. This is strictly more informative.

Did config, environment, or migration behavior change? No

Did security, auth, secrets, network, or tool execution behavior change? No

What is the highest-risk area? False-positive pattern match on an unrelated error message containing "agent harness" + "does not support" + "provider is not one of".

How is that risk mitigated? The regex requires all three phrases in sequence, which is specific to the harness `selection.ts` error template. No other error source in the codebase produces this exact message shape.

## Current review state

What is the next action? Ready for maintainer review.

What is still waiting on author, maintainer, CI, or external proof? Nothing — proof and tests are complete.

Which bot or reviewer comments were addressed? Initial CI `real-behavior-proof-check` failure addressed by adding this full proof section.

