### PR TITLE
fix(cron): mark job active during startup catch-up replay

### DIFF
--- a/src/cron/service.startup-catchup-active-marker.test.ts
+++ b/src/cron/service.startup-catchup-active-marker.test.ts
@@ -1,0 +1,126 @@
+// Regression: startup catch-up command jobs must set the active marker so
+// long-running runs are not reconciled as "lost" while still in flight.
+// See https://github.com/openclaw/openclaw/issues/91695
+import { beforeEach, describe, expect, it } from "vitest";
+import { isCronJobActive, resetCronActiveJobsForTests } from "./active-jobs.js";
+import { CronService } from "./service.js";
+import { createCronServiceState } from "./service/state.js";
+import { setupCronServiceSuite, writeCronStoreSnapshot } from "./service.test-harness.js";
+import type { CronJob } from "./types.js";
+
+const BASE_TIME_ISO = "2025-12-13T17:00:00.000Z";
+const { logger, makeStorePath } = setupCronServiceSuite({
+  prefix: "openclaw-cron-startup-catchup-active-marker-",
+  baseTimeIso: BASE_TIME_ISO,
+});
+
+function createMissedCommandJob(id: string): CronJob {
+  const now = Date.parse(BASE_TIME_ISO);
+  return {
+    id,
+    name: id.replaceAll("-", " "),
+    enabled: true,
+    createdAtMs: now - 3_600_000,
+    updatedAtMs: now - 3_600_000,
+    schedule: { kind: "cron", expr: "0 * * * *", tz: "UTC" },
+    sessionTarget: "isolated",
+    wakeMode: "next-heartbeat",
+    payload: { kind: "command", argv: ["echo", "nightly-backup"] },
+    delivery: { mode: "none" },
+    state: {
+      // A slot due an hour ago that the gateway "missed" while it was down.
+      nextRunAtMs: now - 3_600_000,
+      lastRunAtMs: now - 7_200_000,
+    },
+  };
+}
+
+function createDeferred(): {
+  promise: Promise<void>;
+  resolve: () => void;
+  reject: (err: Error) => void;
+} {
+  let resolve!: () => void;
+  let reject!: (err: Error) => void;
+  const promise = new Promise<void>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+async function createStartupCatchupHarness(jobId: string) {
+  const store = await makeStorePath();
+  await writeCronStoreSnapshot({ storePath: store.storePath, jobs: [createMissedCommandJob(jobId)] });
+
+  const entered = createDeferred();
+  const release = createDeferred();
+  const cron = new CronService({
+    storePath: store.storePath,
+    cronEnabled: true,
+    log: logger,
+    enqueueSystemEvent: () => {},
+    requestHeartbeat: () => {},
+    runCommandJob: async () => {
+      entered.resolve();
+      await release.promise;
+      return { status: "ok" as const, summary: "ok" };
+    },
+  });
+  return { cron, entered, release, store };
+}
+
+describe("cron activeJobIds — startup catch-up mark/clear", () => {
+  beforeEach(() => {
+    resetCronActiveJobsForTests();
+  });
+
+  it("marks the job active while a missed command job is replayed on startup", async () => {
+    const { cron, entered, release, store } = await createStartupCatchupHarness("catchup-command");
+    try {
+      // start() awaits the in-flight catch-up run, so kick it off without await.
+      const startPromise = cron.start();
+      await entered.promise;
+
+      // The job should be marked active while the command is still running.
+      expect(isCronJobActive("catchup-command")).toBe(true);
+
+      release.resolve();
+      await startPromise;
+
+      // After the run completes, the active marker should be cleared.
+      expect(isCronJobActive("catchup-command")).toBe(false);
+    } finally {
+      cron.stop();
+      await store.cleanup();
+    }
+  });
+
+  it("clears the active marker after a startup catch-up command job errors", async () => {
+    const store = await makeStorePath();
+    await writeCronStoreSnapshot({
+      storePath: store.storePath,
+      jobs: [createMissedCommandJob("catchup-error")],
+    });
+
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: logger,
+      enqueueSystemEvent: () => {},
+      requestHeartbeat: () => {},
+      runCommandJob: async () => {
+        throw new Error("command failed");
+      },
+    });
+
+    try {
+      await cron.start();
+      // After an error, the active marker should still be cleared.
+      expect(isCronJobActive("catchup-error")).toBe(false);
+    } finally {
+      cron.stop();
+      await store.cleanup();
+    }
+  });
+});

--- a/src/cron/service.startup-catchup-active-marker.test.ts
+++ b/src/cron/service.startup-catchup-active-marker.test.ts
@@ -4,7 +4,6 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { isCronJobActive, resetCronActiveJobsForTests } from "./active-jobs.js";
 import { CronService } from "./service.js";
-import { createCronServiceState } from "./service/state.js";
 import { setupCronServiceSuite, writeCronStoreSnapshot } from "./service.test-harness.js";
 import type { CronJob } from "./types.js";
 
@@ -51,7 +50,10 @@ function createDeferred(): {
 
 async function createStartupCatchupHarness(jobId: string) {
   const store = await makeStorePath();
-  await writeCronStoreSnapshot({ storePath: store.storePath, jobs: [createMissedCommandJob(jobId)] });
+  await writeCronStoreSnapshot({
+    storePath: store.storePath,
+    jobs: [createMissedCommandJob(jobId)],
+  });
 
   const entered = createDeferred();
   const release = createDeferred();


### PR DESCRIPTION
> AI-assisted (Claude). All behavior proof below was produced and verified by a human-run command in a real local checkout.

## Summary

- **Problem:** `runStartupCatchupCandidate()` in `src/cron/service/timer.ts` never called `markCronJobActive()` after `tryCreateCronTaskRun()`, creating an asymmetric clear-without-mark pattern. While the catch-up run was in flight, `isCronJobActive(jobId)` stayed `false`.
- **Why now:** The task-registry reconcile (`src/tasks/task-registry.maintenance.ts:483-490`) keys off `isCronJobActive(jobId)` for `runtime:"cron"` tasks. A catch-up run that outlived `TASK_RECONCILE_GRACE_MS` (5 min) was misclassified as `lost` and emitted a `Background task lost` system message while the job was genuinely working. The heartbeat re-entrancy guard (`HEARTBEAT_SKIP_CRON_IN_PROGRESS`, which checks `hasActiveCronJobs()`) was also not engaged for the catch-up window.
- **Root cause:** `markCronJobActive` / `clearCronJobActive` were introduced in `7d1575b5df` (#60310) but wired into only the tick paths (`runDueJob` at line 841, `executeJob` at line 1625). `runStartupCatchupCandidate` calls `tryCreateCronTaskRun` and emits `action:"started"` but never called `markCronJobActive`. The clear side is still present via `applyOutcomeToStoredJob` -> `clearCronJobActive(result.jobId)` at line 658, so the mark/clear pair was asymmetric.
- **Outcome:** Add `markCronJobActive(candidate.job.id)` after `tryCreateCronTaskRun` in `runStartupCatchupCandidate`, restoring mark/clear symmetry with the tick paths.
- **Out of scope:** No changes to `clearCronJobActive` (already called by `applyOutcomeToStoredJob`). No changes to the timer loop paths. No changes to agent-turn startup catch-up (deferred by `deferAgentTurnJobs:true`).
- **Reviewer focus:** Whether the `markCronJobActive` placement restores mark/clear symmetry with the tick paths, and whether the regression test covers the happy path and the error path.

## Linked context

Closes #91695

## Real behavior proof

- **Behavior or issue addressed:** Startup catch-up cron runs never set the active marker, so long command jobs are reconciled as `lost` while still running -- #91695.
- **Real environment tested:** Windows 10, Node.js v22.11.0, local checkout at `upstream/main` `8d08b90489` with the patch applied. Drove the real `CronService.start()` startup replay path with a blocked `runCommandJob` callback to hold the catch-up run in flight.
- **Exact steps or command run after this patch:** Created a throwaway `node --import tsx` script that imports the real `src/cron/active-jobs.ts` and `src/cron/service.ts`, writes a missed command job to a temp cron store, creates a `CronService` with a blocking `runCommandJob`, calls `cron.start()`, checks `isCronJobActive()` while running and after completion. Invoked via `node --import tsx scripts/proof-91695.mts`.
- **Evidence after fix:** Terminal capture from the proof script showing the active marker is set while the command is running and cleared after completion:
  ```
  === startup catch-up active marker proof ===
  Before start: isCronJobActive('catchup-command') = false
  While running: isCronJobActive('catchup-command') = true
  After complete: isCronJobActive('catchup-command') = false

  --- result ---
  active marker set during catch-up run?   YES (was true while running)
  marker cleared after run completes?      YES
  ```
- **Observed result after fix:** `isCronJobActive("catchup-command")` returns `true` while the command is running and `false` after it completes. The error path also clears the marker via `applyOutcomeToStoredJob`.
- **Before evidence:** Same script with the fix reverted (removing the `markCronJobActive` call) shows the marker is never set:
  ```
  === startup catch-up active marker proof ===
  Before start: isCronJobActive('catchup-command') = false
  While running: isCronJobActive('catchup-command') = false
  After complete: isCronJobActive('catchup-command') = false

  --- result ---
  active marker set during catch-up run?   NO <-- bug: marker was never set
  marker cleared after run completes?      YES
  ```
  i.e. `isCronJobActive("catchup-command")` is `false` while the command is actively running through startup catch-up.
- **What was not tested:** Live gateway test with an actual startup catch-up scenario where the command runs for >5 min.
- **Proof limitations or environment constraints:** The proof script uses the repository's real `CronService` constructor with a controlled `runCommandJob` callback; it exercises the real `runStartupCatchupCandidate` -> `markCronJobActive` -> `applyOutcomeToStoredJob` -> `clearCronJobActive` path but does not prove the gateway reconcile behavior directly.

## Tests and validation

- Regression: `src/cron/service.startup-catchup-active-marker.test.ts` -- 2/2 assertions passed
- Existing: `src/cron/service.restart-catchup.test.ts` -- 16/16 assertions passed (no regression)
- Existing: `src/cron/active-jobs-manual-run.test.ts` -- passed (no regression)

## Risk checklist

- **userVisible:** No (internal cron state management)
- **configEnvMigration:** No
- **securityAuthNetwork:** No
- **Mitigation:** Only adds missing mark call; clear path already exists via `applyOutcomeToStoredJob`.
