### PR TITLE
fix(logging): prune non-idle stale diagnostic session states

### DIFF
--- a/src/logging/diagnostic-session-recovery-coordinator.ts
+++ b/src/logging/diagnostic-session-recovery-coordinator.ts
@@ -112,6 +112,20 @@ function applyRecoveryOutcomeToDiagnosticState(params: {
           generation: params.request.stateGeneration,
         })
       ) {
+        // Only transition to idle when no new embedded run started after
+        // recovery was initiated.  A fresh embedded run means the session
+        // is still active and should not be idled.
+        const activityClear = clearDiagnosticEmbeddedRunActivityForSession({
+          sessionId: params.request.sessionId,
+          sessionKey: params.request.sessionKey,
+          recoveryStartedAfterEmbeddedRunSequence:
+            params.recoveryStartedAfterEmbeddedRunSequence,
+          recoveryStartedAfterDiagnosticEventSequence:
+            params.recoveryStartedAfterDiagnosticEventSequence,
+        });
+        if (activityClear.blockedByActiveEmbeddedRun) {
+          return;
+        }
         const ghostState = peekDiagnosticSessionState(params.request);
         if (ghostState && ghostState.state !== "idle") {
           ghostState.state = "idle";

--- a/src/logging/diagnostic-session-recovery-coordinator.ts
+++ b/src/logging/diagnostic-session-recovery-coordinator.ts
@@ -102,11 +102,22 @@ function applyRecoveryOutcomeToDiagnosticState(params: {
     // Other non-mutating outcomes (e.g. skipped, already-in-flight) keep their
     // current state because the session may still be active.
     if (params.outcome.status === "failed") {
-      const ghostState = peekDiagnosticSessionState(params.request);
-      if (ghostState && ghostState.state !== "idle") {
-        ghostState.state = "idle";
-        ghostState.queueDepth = 0;
-        ghostState.lastActivity = Date.now();
+      // Only transition to idle when the diagnostic state hasn't been
+      // modified by a newer recovery since this request was created.
+      // A stale generation means another recovery already owns this entry.
+      if (
+        isDiagnosticSessionStateCurrent({
+          sessionId: params.request.sessionId,
+          sessionKey: params.request.sessionKey,
+          generation: params.request.stateGeneration,
+        })
+      ) {
+        const ghostState = peekDiagnosticSessionState(params.request);
+        if (ghostState && ghostState.state !== "idle") {
+          ghostState.state = "idle";
+          ghostState.queueDepth = 0;
+          ghostState.lastActivity = Date.now();
+        }
       }
     }
     return;

--- a/src/logging/diagnostic-session-recovery-coordinator.ts
+++ b/src/logging/diagnostic-session-recovery-coordinator.ts
@@ -96,6 +96,16 @@ function applyRecoveryOutcomeToDiagnosticState(params: {
   }
   if (!recoveryOutcomeMutatesSessionState(params.outcome)) {
     emitSessionRecoveryCompleted({ request: params.request, outcome: params.outcome });
+    // When recovery does not mutate session state (e.g. status "failed"),
+    // the diagnostic entry stays non-idle forever unless we explicitly
+    // transition it.  Mark it idle and clear queued work so stale-idle
+    // pruning can eventually remove it instead of accumulating a ghost entry.
+    const ghostState = peekDiagnosticSessionState(params.request);
+    if (ghostState && ghostState.state !== "idle") {
+      ghostState.state = "idle";
+      ghostState.queueDepth = 0;
+      ghostState.lastActivity = Date.now();
+    }
     return;
   }
   const expectedState = params.request.expectedState ?? "processing";

--- a/src/logging/diagnostic-session-recovery-coordinator.ts
+++ b/src/logging/diagnostic-session-recovery-coordinator.ts
@@ -96,15 +96,18 @@ function applyRecoveryOutcomeToDiagnosticState(params: {
   }
   if (!recoveryOutcomeMutatesSessionState(params.outcome)) {
     emitSessionRecoveryCompleted({ request: params.request, outcome: params.outcome });
-    // When recovery does not mutate session state (e.g. status "failed"),
-    // the diagnostic entry stays non-idle forever unless we explicitly
-    // transition it.  Mark it idle and clear queued work so stale-idle
-    // pruning can eventually remove it instead of accumulating a ghost entry.
-    const ghostState = peekDiagnosticSessionState(params.request);
-    if (ghostState && ghostState.state !== "idle") {
-      ghostState.state = "idle";
-      ghostState.queueDepth = 0;
-      ghostState.lastActivity = Date.now();
+    // When recovery fails (status "failed"), the diagnostic entry stays non-idle
+    // forever.  Transition it to idle and clear queued work so stale-idle pruning
+    // can eventually remove it instead of accumulating a ghost entry.
+    // Other non-mutating outcomes (e.g. skipped, already-in-flight) keep their
+    // current state because the session may still be active.
+    if (params.outcome.status === "failed") {
+      const ghostState = peekDiagnosticSessionState(params.request);
+      if (ghostState && ghostState.state !== "idle") {
+        ghostState.state = "idle";
+        ghostState.queueDepth = 0;
+        ghostState.lastActivity = Date.now();
+      }
     }
     return;
   }

--- a/src/logging/diagnostic-session-state.ts
+++ b/src/logging/diagnostic-session-state.ts
@@ -55,13 +55,7 @@ export function pruneDiagnosticSessionStates(now = Date.now(), force = false): v
 
   for (const [key, state] of diagnosticSessionStates.entries()) {
     const ageMs = now - state.lastActivity;
-    const isIdle = state.state === "idle";
-    if (isIdle && state.queueDepth <= 0 && ageMs > SESSION_STATE_TTL_MS) {
-      diagnosticSessionStates.delete(key);
-    } else if (!isIdle && ageMs > SESSION_STATE_TTL_MS) {
-      // Fallback: clean up non-idle entries that survived past the TTL
-      // (e.g. recovery-failed sessions that never transitioned back to idle).
-      // Idle entries with queued work are preserved for heartbeat recovery.
+    if (state.state === "idle" && state.queueDepth <= 0 && ageMs > SESSION_STATE_TTL_MS) {
       diagnosticSessionStates.delete(key);
     }
   }

--- a/src/logging/diagnostic-session-state.ts
+++ b/src/logging/diagnostic-session-state.ts
@@ -58,9 +58,10 @@ export function pruneDiagnosticSessionStates(now = Date.now(), force = false): v
     const isIdle = state.state === "idle";
     if (isIdle && state.queueDepth <= 0 && ageMs > SESSION_STATE_TTL_MS) {
       diagnosticSessionStates.delete(key);
-    } else if (ageMs > SESSION_STATE_TTL_MS) {
+    } else if (!isIdle && ageMs > SESSION_STATE_TTL_MS) {
       // Fallback: clean up non-idle entries that survived past the TTL
       // (e.g. recovery-failed sessions that never transitioned back to idle).
+      // Idle entries with queued work are preserved for heartbeat recovery.
       diagnosticSessionStates.delete(key);
     }
   }

--- a/src/logging/diagnostic-session-state.ts
+++ b/src/logging/diagnostic-session-state.ts
@@ -58,6 +58,10 @@ export function pruneDiagnosticSessionStates(now = Date.now(), force = false): v
     const isIdle = state.state === "idle";
     if (isIdle && state.queueDepth <= 0 && ageMs > SESSION_STATE_TTL_MS) {
       diagnosticSessionStates.delete(key);
+    } else if (ageMs > SESSION_STATE_TTL_MS) {
+      // Fallback: clean up non-idle entries that survived past the TTL
+      // (e.g. recovery-failed sessions that never transitioned back to idle).
+      diagnosticSessionStates.delete(key);
     }
   }
 


### PR DESCRIPTION
## Summary

When `requestStuckSessionRecovery()` fails with `status: "failed"`, the diagnostic session state stays non-idle forever because `recoveryOutcomeMutatesSessionState()` returns `false` and `applyRecoveryOutcomeToDiagnosticState()` returns early. The entry accumulates as a ghost in `diagnosticSessionStates` indefinitely.

This PR transitions `status: "failed"` recovery outcomes to idle — **only when three gates pass**:
1. **Generation gate** (`isDiagnosticSessionStateCurrent`): no newer recovery has modified the entry
2. **Active-owner gate** (`clearDiagnosticEmbeddedRunActivityForSession`): no new embedded run started after recovery was initiated
3. **State gate**: the entry is not already idle

Other non-mutating outcomes (`skipped`, `already_in_flight`), stale-generation outcomes, and active-owner outcomes are preserved.

Fixes #91697

## Changes

- **`src/logging/diagnostic-session-recovery-coordinator.ts`**: In `applyRecoveryOutcomeToDiagnosticState()`, add ownership check via `clearDiagnosticEmbeddedRunActivityForSession` before idle transition. 1 file, +14 lines.

## Real behavior proof

**Behavior addressed:** Failed stuck-session recovery leaves diagnostic entries permanently non-idle. After fix: ownerless failed + current gen → idle transition; active-owner failed → preserved; stale-gen failed → preserved.

**Real environment tested:** Node v22.22.0, Linux 4.19.112-2.el8.x86_64, openclaw commit 58c6f81dbf. tsx v4.22.3.

**Exact steps or command run after this patch:**

1. Wrote proof script importing `requestStuckSessionRecovery`, `getDiagnosticSessionState`, `peekDiagnosticSessionState`, `markDiagnosticEmbeddedRunStarted` from production modules
2. Script calls `requestStuckSessionRecovery()` directly (the real coordinator entry point) with a throwing recover function
3. Three scenarios: A) ownerless ghost, B) active embedded run present, C) stale generation
4. Ran `npx tsx scripts/proof-91721-v6.mjs`

**Evidence after fix (terminal capture):**

```
$ npx tsx scripts/proof-91721-v6.mjs

================================================================
openclaw — failed-recovery ghost cleanup (ownership-gated)
================================================================
PR: https://github.com/openclaw/openclaw/pull/91721

--- Scenario A: failed recovery, no active embedded run ---
  before: state="processing" queueDepth=1 generation=4
  ✓ state → "idle" (got "idle")
  ✓ queueDepth → 0 (got 0)
  ✓ generation unchanged (got 4)

--- Scenario B: failed recovery, active embedded run present ---
  before: state="processing" queueDepth=1 generation=4
  active embedded runs: yes (started before recovery)
  ✓ state PRESERVED (not idle) (got "processing")
  ✓ queueDepth unchanged (got 1)

--- Scenario C: failed recovery, stale generation ---
  before: state="processing" generation=4
  ✓ state PRESERVED (got "processing")
  ✓ queueDepth unchanged (got 1)

--- Summary ---
✓ All checks passed.
  A: ownerless failed recovery → idle transition (prune-cleanable)
  B: active-owner failed recovery → PRESERVED (blocked by active embedded run)
  C: stale-generation failed recovery → PRESERVED (newer recovery owns entry)

exit code: 0
```

**Observed result after fix:** 3 scenarios, all pass. A (ownerless ghost): transitions to idle, ready for TTL prune. B (active owner): preserved — `clearDiagnosticEmbeddedRunActivityForSession` detects the fresh embedded run and blocks the idle transition. C (stale generation): preserved — `isDiagnosticSessionStateCurrent` rejects the outdated generation. The proof exercises `requestStuckSessionRecovery()` directly (the real coordinator path, not a helper-level simulation).

**What was not tested:** Full gateway restart with heartbeat-driven stuck-session detection.