### PR TITLE
fix(agents): infer runtime provider from qualified model ids

### DIFF
--- a/src/agents/model-runtime-aliases.test.ts
+++ b/src/agents/model-runtime-aliases.test.ts
@@ -134,6 +134,26 @@ describe("resolveCliRuntimeExecutionProvider", () => {
     ).toBe("claude-cli");
   });
 
+  it("matches provider runtime policy from a provider-qualified model when the caller provider is empty", () => {
+    expect(
+      resolveCliRuntimeExecutionProvider({
+        cfg: {
+          models: {
+            providers: {
+              anthropic: {
+                baseUrl: "https://api.anthropic.example/v1",
+                agentRuntime: { id: "claude-cli" },
+                models: [],
+              },
+            },
+          },
+        } as OpenClawConfig,
+        provider: "",
+        modelId: "anthropic/opus-4.7",
+      }),
+    ).toBe("claude-cli");
+  });
+
   it("does not return a CLI runtime when the matched entry's provider is incompatible with the runtime alias", () => {
     expect(
       resolveCliRuntimeExecutionProvider({

--- a/src/agents/model-runtime-policy.test.ts
+++ b/src/agents/model-runtime-policy.test.ts
@@ -235,6 +235,7 @@ describe("resolveModelRuntimePolicy", () => {
     ).toEqual({
       policy: { id: "claude-cli" },
       source: "model",
+      matchedProvider: "anthropic",
     });
   });
 
@@ -260,6 +261,7 @@ describe("resolveModelRuntimePolicy", () => {
     ).toEqual({
       policy: { id: "claude-cli" },
       source: "provider",
+      matchedProvider: "anthropic",
     });
   });
 

--- a/src/agents/model-runtime-policy.test.ts
+++ b/src/agents/model-runtime-policy.test.ts
@@ -265,6 +265,31 @@ describe("resolveModelRuntimePolicy", () => {
     });
   });
 
+  it("prefers provider-qualified agent entries over bare entries for inferred providers", () => {
+    const config = {
+      agents: {
+        defaults: {
+          models: {
+            "claude-opus-4-7": { agentRuntime: { id: "openclaw" } },
+            "anthropic/claude-opus-4-7": { agentRuntime: { id: "claude-cli" } },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveModelRuntimePolicy({
+        config,
+        provider: "",
+        modelId: "anthropic/claude-opus-4-7",
+      }),
+    ).toEqual({
+      policy: { id: "claude-cli" },
+      source: "model",
+      matchedProvider: "anthropic",
+    });
+  });
+
   it("prefers agent provider wildcard runtime policy over provider runtime policy", () => {
     const config = {
       agents: {

--- a/src/agents/model-runtime-policy.test.ts
+++ b/src/agents/model-runtime-policy.test.ts
@@ -8,8 +8,11 @@ import { resolveModelRuntimePolicy } from "./model-runtime-policy.js";
 const ORIGINAL_BUILD_PRIVATE_QA = process.env.OPENCLAW_BUILD_PRIVATE_QA;
 const ORIGINAL_QA_FORCE_RUNTIME = process.env.OPENCLAW_QA_FORCE_RUNTIME;
 
-const createModelConfig = (agentRuntimeId: string): ModelDefinitionConfig => ({
-  id: "qwen-local",
+const createModelConfig = (
+  agentRuntimeId: string,
+  modelId = "qwen-local",
+): ModelDefinitionConfig => ({
+  id: modelId,
   name: "Qwen Local",
   reasoning: false,
   input: ["text"],
@@ -208,6 +211,55 @@ describe("resolveModelRuntimePolicy", () => {
     ).toEqual({
       policy: { id: "codex" },
       source: "model",
+    });
+  });
+
+  it("uses provider-qualified model ids to resolve provider model runtime policies", () => {
+    const config = {
+      models: {
+        providers: {
+          anthropic: {
+            baseUrl: "https://api.anthropic.example/v1",
+            models: [createModelConfig("claude-cli", "claude-opus-4-7")],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveModelRuntimePolicy({
+        config,
+        provider: "",
+        modelId: "anthropic/claude-opus-4-7",
+      }),
+    ).toEqual({
+      policy: { id: "claude-cli" },
+      source: "model",
+    });
+  });
+
+  it("uses provider-qualified model ids to resolve provider runtime policies", () => {
+    const config = {
+      models: {
+        providers: {
+          anthropic: {
+            baseUrl: "https://api.anthropic.example/v1",
+            agentRuntime: { id: "claude-cli" },
+            models: [],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveModelRuntimePolicy({
+        config,
+        provider: "",
+        modelId: "anthropic/claude-opus-4-7",
+      }),
+    ).toEqual({
+      policy: { id: "claude-cli" },
+      source: "provider",
     });
   });
 

--- a/src/agents/model-runtime-policy.ts
+++ b/src/agents/model-runtime-policy.ts
@@ -88,6 +88,17 @@ function parseProviderModelKey(key: string): { provider: string; modelId: string
   return provider && modelId ? { provider, modelId } : undefined;
 }
 
+function resolveEffectiveProvider(
+  provider: string | undefined,
+  modelId: string | undefined,
+): string | undefined {
+  const normalizedProvider = normalizeProviderId(provider ?? "");
+  if (normalizedProvider) {
+    return normalizedProvider;
+  }
+  return parseProviderModelKey(modelId?.trim() ?? "")?.provider;
+}
+
 function providerMatchesCaller(provider: string, callerProvider: string): boolean {
   return !callerProvider || provider === callerProvider;
 }
@@ -237,6 +248,7 @@ export function resolveModelRuntimePolicy(params: {
   agentId?: string;
   sessionKey?: string;
 }): ResolvedModelRuntimePolicy {
+  const effectiveProvider = resolveEffectiveProvider(params.provider, params.modelId);
   if (process.env.OPENCLAW_BUILD_PRIVATE_QA === "1") {
     const forcedRuntime = process.env.OPENCLAW_QA_FORCE_RUNTIME?.trim().toLowerCase();
     if (forcedRuntime === "openclaw" || forcedRuntime === "codex") {
@@ -244,17 +256,21 @@ export function resolveModelRuntimePolicy(params: {
     }
   }
 
-  const agentModelPolicy = resolveAgentModelEntryRuntimePolicy({ ...params, matchKind: "exact" });
+  const agentModelPolicy = resolveAgentModelEntryRuntimePolicy({
+    ...params,
+    provider: effectiveProvider,
+    matchKind: "exact",
+  });
   if (agentModelPolicy.ambiguous) {
     return {};
   }
   if (agentModelPolicy.policy) {
     return agentModelPolicy;
   }
-  const providerConfig = resolveProviderConfig(params.config, params.provider);
+  const providerConfig = resolveProviderConfig(params.config, effectiveProvider);
   const modelConfig = resolveModelConfig({
     providerConfig,
-    provider: params.provider,
+    provider: effectiveProvider,
     modelId: params.modelId,
   });
   if (hasRuntimePolicy(modelConfig?.agentRuntime)) {
@@ -262,6 +278,7 @@ export function resolveModelRuntimePolicy(params: {
   }
   const agentWildcardModelPolicy = resolveAgentModelEntryRuntimePolicy({
     ...params,
+    provider: effectiveProvider,
     matchKind: "provider-wildcard",
   });
   if (agentWildcardModelPolicy.policy) {

--- a/src/agents/model-runtime-policy.ts
+++ b/src/agents/model-runtime-policy.ts
@@ -107,11 +107,15 @@ function resolvePolicyMatch(
   matches: AgentModelRuntimePolicyMatch[],
   callerProvider: string,
 ): AgentModelRuntimePolicyResolution {
-  const [first] = matches;
+  const providerMatches = callerProvider
+    ? matches.filter((match) => match.provider === callerProvider)
+    : [];
+  const candidates = providerMatches.length > 0 ? providerMatches : matches;
+  const [first] = candidates;
   if (!first) {
     return {};
   }
-  if (!callerProvider && matches.some((match) => match.provider !== first.provider)) {
+  if (!callerProvider && candidates.some((match) => match.provider !== first.provider)) {
     return { ambiguous: true };
   }
   return {

--- a/src/agents/model-runtime-policy.ts
+++ b/src/agents/model-runtime-policy.ts
@@ -248,7 +248,9 @@ export function resolveModelRuntimePolicy(params: {
   agentId?: string;
   sessionKey?: string;
 }): ResolvedModelRuntimePolicy {
+  const callerProvider = normalizeProviderId(params.provider ?? "");
   const effectiveProvider = resolveEffectiveProvider(params.provider, params.modelId);
+  const inferredMatchedProvider = callerProvider ? undefined : effectiveProvider;
   if (process.env.OPENCLAW_BUILD_PRIVATE_QA === "1") {
     const forcedRuntime = process.env.OPENCLAW_QA_FORCE_RUNTIME?.trim().toLowerCase();
     if (forcedRuntime === "openclaw" || forcedRuntime === "codex") {
@@ -274,7 +276,11 @@ export function resolveModelRuntimePolicy(params: {
     modelId: params.modelId,
   });
   if (hasRuntimePolicy(modelConfig?.agentRuntime)) {
-    return { policy: modelConfig?.agentRuntime, source: "model" };
+    return {
+      policy: modelConfig?.agentRuntime,
+      source: "model",
+      ...(inferredMatchedProvider ? { matchedProvider: inferredMatchedProvider } : {}),
+    };
   }
   const agentWildcardModelPolicy = resolveAgentModelEntryRuntimePolicy({
     ...params,
@@ -285,7 +291,11 @@ export function resolveModelRuntimePolicy(params: {
     return agentWildcardModelPolicy;
   }
   if (hasRuntimePolicy(providerConfig?.agentRuntime)) {
-    return { policy: providerConfig?.agentRuntime, source: "provider" };
+    return {
+      policy: providerConfig?.agentRuntime,
+      source: "provider",
+      ...(inferredMatchedProvider ? { matchedProvider: inferredMatchedProvider } : {}),
+    };
   }
   return {};
 }


### PR DESCRIPTION
## Summary
- Infer the effective provider from provider-qualified `modelId` values when `resolveModelRuntimePolicy` is called without an explicit provider.
- Use that inferred provider for provider/model runtime policy lookup and provider-level runtime fallback.
- Add regression coverage for both model-scoped and provider-scoped runtime policies.

## Real behavior proof
Behavior or issue addressed:
`resolveModelRuntimePolicy` already lets `provider: ""` plus `modelId: "anthropic/foo"` match agent-level model runtime entries, but the same provider-qualified model id was not used for `models.providers` lookup. That meant configured provider model runtime policies and provider runtime fallbacks could resolve to `{}` when the caller only supplied the provider-qualified model id.

Real environment tested:
Local OpenClaw checkout on macOS, branch `codex/provider-runtime-qualified-model`, Node/Vitest through repository scripts.

Exact steps or command run after this patch:
```sh
node scripts/run-vitest.mjs run src/agents/model-runtime-policy.test.ts --reporter verbose
./node_modules/.bin/oxfmt --check --threads=1 src/agents/model-runtime-policy.ts src/agents/model-runtime-policy.test.ts
node --import tsx --input-type=module --eval "<resolveModelRuntimePolicy live proof>"
```

Evidence before fix:
The two new regression cases failed with `expected {} to deeply equal { policy: { id: "claude-cli" }, ... }` for both model-scoped and provider-scoped runtime policies.

Evidence after fix:
- Vitest: `Test Files 2 passed (2)`, `Tests 30 passed (30)`.
- oxfmt: `All matched files use the correct format.`
- Live proof output:
```json
{
  "modelScoped": {
    "policy": {
      "id": "claude-cli"
    },
    "source": "model"
  },
  "providerScoped": {
    "policy": {
      "id": "claude-cli"
    },
    "source": "provider"
  }
}
```

Observed result after fix:
`provider: ""` plus `modelId: "anthropic/claude-opus-4-7"` now resolves both `models.providers.anthropic.models[].agentRuntime` and `models.providers.anthropic.agentRuntime` instead of falling through to `{}`.

What was not tested:
Full embedded CLI execution; this patch is limited to runtime policy resolution and is covered by the targeted runtime policy unit tests plus direct function proof.