### PR TITLE
feat(gateway): add POST /api/mcp/servers/:id/reload endpoint

### DIFF
--- a/src/agents/agent-bundle-mcp-runtime.ts
+++ b/src/agents/agent-bundle-mcp-runtime.ts
@@ -858,6 +858,19 @@ export function createSessionMcpRuntime(params: {
       sessions.clear();
       await Promise.allSettled(sessionsToClose.map((session) => disposeSession(session)));
     },
+    async reloadServer(serverName: string) {
+      failIfDisposed();
+      const session = sessions.get(serverName);
+      if (session) {
+        sessions.delete(serverName);
+        await disposeSession(session);
+      }
+      // Invalidate the combined catalog so the next getCatalog() call
+      // reconnects to this server and re-fetches its tool list.
+      catalogInvalidationGeneration += 1;
+      catalog = null;
+      catalogInFlight = undefined;
+    },
   };
 }
 

--- a/src/agents/agent-bundle-mcp-types.ts
+++ b/src/agents/agent-bundle-mcp-types.ts
@@ -83,6 +83,14 @@ export type SessionMcpRuntime = {
   listPrompts?: (serverName: string) => Promise<unknown>;
   getPrompt?: (serverName: string, name: string, args?: Record<string, string>) => Promise<unknown>;
   dispose: () => Promise<void>;
+  /**
+   * Disposes the transport session for a specific MCP server and invalidates
+   * the tool catalog so the next `getCatalog()` call reconnects and re-fetches
+   * tools. Use when the upstream server's tool list changed but it does not
+   * emit `notifications/tools/list_changed` (e.g. after a new Composio
+   * integration is connected).
+   */
+  reloadServer?: (serverName: string) => Promise<void>;
 };
 
 /** Manager for session-scoped MCP runtimes and their idle lifecycle. */

--- a/src/gateway/mcp-reload-http.test.ts
+++ b/src/gateway/mcp-reload-http.test.ts
@@ -1,0 +1,307 @@
+// Tests for POST /api/mcp/servers/:serverId/reload HTTP endpoint.
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { GatewayAuthResult } from "./auth.js";
+
+const TEST_GATEWAY_TOKEN = "test-gateway-token-mcp-reload";
+
+let cfg: Record<string, unknown> = {};
+const authMock = vi.fn(async (): Promise<GatewayAuthResult> => ({ ok: true }));
+const listSessionIdsMock = vi.fn<() => string[]>(() => []);
+const peekSessionMock = vi.fn<(params: { sessionId?: string; sessionKey?: string }) => unknown>(
+  () => undefined,
+);
+
+vi.mock("../config/config.js", () => ({
+  getRuntimeConfig: () => cfg,
+}));
+
+vi.mock("../config/io.js", () => ({
+  getRuntimeConfig: () => cfg,
+}));
+
+vi.mock("./auth.js", () => ({
+  authorizeHttpGatewayConnect: authMock,
+}));
+
+vi.mock("../agents/agent-bundle-mcp-runtime.js", () => ({
+  getSessionMcpRuntimeManager: () => ({
+    listSessionIds: listSessionIdsMock,
+    peekSession: peekSessionMock,
+  }),
+}));
+
+const { handleMcpReloadHttpRequest } = await import("./mcp-reload-http.js");
+
+let port = 0;
+let server: ReturnType<typeof createServer> | undefined;
+
+beforeAll(async () => {
+  server = createServer((req, res) => {
+    void handleMcpReloadHttpRequest(req, res, {
+      auth: { mode: "token", token: TEST_GATEWAY_TOKEN, allowTailscale: false },
+    }).then((handled) => {
+      if (!handled) {
+        res.statusCode = 404;
+        res.end(JSON.stringify({ ok: false, error: { type: "not_found" } }));
+      }
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server?.once("error", reject);
+    server?.listen(0, "127.0.0.1", () => {
+      const address = server?.address() as AddressInfo | null;
+      if (!address) {
+        reject(new Error("server missing address"));
+        return;
+      }
+      port = address.port;
+      resolve();
+    });
+  });
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve, reject) => {
+    server?.close((err) => (err ? reject(err) : resolve()));
+  });
+});
+
+beforeEach(() => {
+  cfg = {};
+  authMock.mockReset();
+  authMock.mockResolvedValue({ ok: true, method: "token" });
+  listSessionIdsMock.mockReset();
+  listSessionIdsMock.mockReturnValue([]);
+  peekSessionMock.mockReset();
+  peekSessionMock.mockReturnValue(undefined);
+});
+
+async function post(
+  pathname: string,
+  token = TEST_GATEWAY_TOKEN,
+  extraHeaders?: Record<string, string>,
+) {
+  const headers: Record<string, string> = {
+    "x-openclaw-scopes": "operator.write",
+  };
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+  Object.assign(headers, extraHeaders ?? {});
+  return fetch(`http://127.0.0.1:${port}${pathname}`, {
+    method: "POST",
+    headers,
+  });
+}
+
+function makeReloadRuntime(serverName?: string): {
+  reloadServer: ReturnType<typeof vi.fn>;
+} {
+  return {
+    reloadServer: vi.fn(async (_name: string) => {
+      if (serverName !== undefined && _name !== serverName) {
+        throw new Error(`unexpected server name: ${_name}`);
+      }
+    }),
+  };
+}
+
+// ─── path matching ────────────────────────────────────────────────────────────
+
+describe("path matching", () => {
+  it("returns false for unrelated paths", async () => {
+    const res = await post("/tools/invoke");
+    // The server returns 404 when handleMcpReloadHttpRequest returns false.
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 405 for GET requests", async () => {
+    listSessionIdsMock.mockReturnValue([]);
+    const res = await fetch(
+      `http://127.0.0.1:${port}/api/mcp/servers/composio/reload`,
+      {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${TEST_GATEWAY_TOKEN}`,
+          "x-openclaw-scopes": "operator.write",
+        },
+      },
+    );
+    expect(res.status).toBe(405);
+  });
+
+  it("returns 404 for an unmatched nested path under /api/mcp/servers/", async () => {
+    // Extra path segment after reload → the handler returns false → 404.
+    const res = await post("/api/mcp/servers/composio/reload/extra");
+    expect(res.status).toBe(404);
+  });
+});
+
+// ─── auth ─────────────────────────────────────────────────────────────────────
+
+describe("auth", () => {
+  it("returns 401 for missing token", async () => {
+    authMock.mockResolvedValueOnce({ ok: false, reason: "unauthorized" });
+    const res = await fetch(`http://127.0.0.1:${port}/api/mcp/servers/composio/reload`, {
+      method: "POST",
+      headers: { "x-openclaw-scopes": "operator.write" },
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when operator scope is insufficient (trusted-proxy auth, read-only scope)", async () => {
+    // For trusted-proxy auth, the x-openclaw-scopes header is honoured.
+    // operator.read is insufficient for mcp.server.reload (requires write).
+    authMock.mockResolvedValueOnce({ ok: true, method: "trusted-proxy" });
+    listSessionIdsMock.mockReturnValue([]);
+    const res = await post("/api/mcp/servers/composio/reload", TEST_GATEWAY_TOKEN, {
+      "x-openclaw-scopes": "operator.read",
+    });
+    expect(res.status).toBe(403);
+  });
+});
+
+// ─── successful reload ────────────────────────────────────────────────────────
+
+describe("successful reload", () => {
+  it("returns sessionCount: 0 when no sessions are active", async () => {
+    listSessionIdsMock.mockReturnValue([]);
+    const res = await post("/api/mcp/servers/composio/reload");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({ ok: true, serverName: "composio", sessionCount: 0 });
+  });
+
+  it("reloads all active sessions when no sessionId is provided", async () => {
+    const runtime1 = makeReloadRuntime();
+    const runtime2 = makeReloadRuntime();
+    listSessionIdsMock.mockReturnValue(["sess-1", "sess-2"]);
+    peekSessionMock.mockImplementation(({ sessionId }: { sessionId?: string }) => {
+      if (sessionId === "sess-1") return runtime1;
+      if (sessionId === "sess-2") return runtime2;
+      return undefined;
+    });
+
+    const res = await post("/api/mcp/servers/composio/reload");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({ ok: true, serverName: "composio", sessionCount: 2 });
+    expect(runtime1.reloadServer).toHaveBeenCalledWith("composio");
+    expect(runtime2.reloadServer).toHaveBeenCalledWith("composio");
+  });
+
+  it("reloads only the targeted session when X-OpenClaw-Session-Id header is provided", async () => {
+    const runtime1 = makeReloadRuntime();
+    const runtime2 = makeReloadRuntime();
+    listSessionIdsMock.mockReturnValue(["sess-1", "sess-2"]);
+    peekSessionMock.mockImplementation(({ sessionId }: { sessionId?: string }) => {
+      if (sessionId === "sess-1") return runtime1;
+      if (sessionId === "sess-2") return runtime2;
+      return undefined;
+    });
+
+    const res = await post("/api/mcp/servers/composio/reload", TEST_GATEWAY_TOKEN, {
+      "x-openclaw-session-id": "sess-1",
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({ ok: true, serverName: "composio", sessionCount: 1 });
+    expect(runtime1.reloadServer).toHaveBeenCalledWith("composio");
+    expect(runtime2.reloadServer).not.toHaveBeenCalled();
+  });
+
+  it("reloads the targeted session when sessionId query param is provided", async () => {
+    const runtime = makeReloadRuntime();
+    listSessionIdsMock.mockReturnValue(["sess-a"]);
+    peekSessionMock.mockImplementation(({ sessionId }: { sessionId?: string }) => {
+      if (sessionId === "sess-a") return runtime;
+      return undefined;
+    });
+
+    const res = await post("/api/mcp/servers/my-mcp-server/reload?sessionId=sess-a");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({ ok: true, serverName: "my-mcp-server", sessionCount: 1 });
+    expect(runtime.reloadServer).toHaveBeenCalledWith("my-mcp-server");
+  });
+
+  it("URL-decodes the server name from the path", async () => {
+    const runtime = makeReloadRuntime();
+    listSessionIdsMock.mockReturnValue(["sess-x"]);
+    peekSessionMock.mockReturnValue(runtime);
+
+    const res = await post("/api/mcp/servers/my%20server/reload");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({ ok: true, serverName: "my server" });
+    expect(runtime.reloadServer).toHaveBeenCalledWith("my server");
+  });
+
+  it("gracefully skips runtimes that lack the reloadServer method", async () => {
+    const legacyRuntime = {}; // no reloadServer
+    listSessionIdsMock.mockReturnValue(["sess-legacy"]);
+    peekSessionMock.mockReturnValue(legacyRuntime);
+
+    const res = await post("/api/mcp/servers/composio/reload");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({ ok: true, sessionCount: 0 });
+  });
+});
+
+// ─── error cases ──────────────────────────────────────────────────────────────
+
+describe("error cases", () => {
+  it("returns 404 when the targeted sessionId has no active runtime", async () => {
+    listSessionIdsMock.mockReturnValue(["sess-other"]);
+    peekSessionMock.mockReturnValue(undefined);
+
+    const res = await post("/api/mcp/servers/composio/reload", TEST_GATEWAY_TOKEN, {
+      "x-openclaw-session-id": "sess-missing",
+    });
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect((body as { ok: boolean }).ok).toBe(false);
+  });
+
+  it("returns 500 when reloadServer throws for every session", async () => {
+    const failingRuntime = {
+      reloadServer: vi.fn(async () => {
+        throw new Error("transport closed");
+      }),
+    };
+    listSessionIdsMock.mockReturnValue(["sess-fail"]);
+    peekSessionMock.mockReturnValue(failingRuntime);
+
+    const res = await post("/api/mcp/servers/composio/reload");
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect((body as { ok: boolean }).ok).toBe(false);
+  });
+
+  it("returns 200 with partialErrors when some sessions fail", async () => {
+    const goodRuntime = makeReloadRuntime();
+    const badRuntime = {
+      reloadServer: vi.fn(async () => {
+        throw new Error("net error");
+      }),
+    };
+    listSessionIdsMock.mockReturnValue(["sess-good", "sess-bad"]);
+    peekSessionMock.mockImplementation(({ sessionId }: { sessionId?: string }) => {
+      if (sessionId === "sess-good") return goodRuntime;
+      if (sessionId === "sess-bad") return badRuntime;
+      return undefined;
+    });
+
+    const res = await post("/api/mcp/servers/composio/reload");
+    expect(res.status).toBe(200);
+    const body = await res.json() as { ok: boolean; sessionCount: number; partialErrors: string[] };
+    expect(body.ok).toBe(true);
+    expect(body.sessionCount).toBe(1);
+    expect(Array.isArray(body.partialErrors)).toBe(true);
+    expect(body.partialErrors.length).toBe(1);
+  });
+});

--- a/src/gateway/mcp-reload-http.ts
+++ b/src/gateway/mcp-reload-http.ts
@@ -1,0 +1,185 @@
+// Gateway HTTP handler for operator-authenticated MCP server catalog reload.
+// POST /api/mcp/servers/:serverId/reload
+//
+// Disposes the transport session for a named MCP server within one or all
+// active session runtimes and invalidates their tool catalog caches.  The next
+// getCatalog() call on each affected runtime will reconnect and re-fetch the
+// tool list from the upstream server.
+//
+// Useful when the upstream MCP server's tool list changes but the server does
+// not emit notifications/tools/list_changed (e.g. after a new Composio
+// integration is connected via an OAuth callback).
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { getSessionMcpRuntimeManager } from "../agents/agent-bundle-mcp-runtime.js";
+import type { AuthRateLimiter } from "./auth-rate-limit.js";
+import type { ResolvedGatewayAuth } from "./auth.js";
+import {
+  sendInvalidRequest,
+  sendJson,
+  sendMethodNotAllowed,
+} from "./http-common.js";
+import {
+  authorizeScopedGatewayHttpRequestOrReply,
+  resolveSharedSecretHttpOperatorScopes,
+} from "./http-utils.js";
+
+/** Regex for `/api/mcp/servers/:serverId/reload`. */
+const MCP_RELOAD_PATH_RE = /^\/api\/mcp\/servers\/([^/]+)\/reload$/;
+
+/** The gateway method used to derive the required operator scope. */
+const REQUIRED_METHOD = "mcp.server.reload";
+
+type McpReloadPathResolution =
+  | { matched: false }
+  | { matched: true; serverId: string }
+  | { error: "invalid-server-id"; matched: true };
+
+function resolveServerIdFromPath(pathname: string): McpReloadPathResolution {
+  const match = pathname.match(MCP_RELOAD_PATH_RE);
+  if (!match) {
+    return { matched: false };
+  }
+  try {
+    const decoded = decodeURIComponent(match[1] ?? "").trim();
+    if (!decoded) {
+      return { error: "invalid-server-id", matched: true };
+    }
+    return { matched: true, serverId: decoded };
+  } catch {
+    return { error: "invalid-server-id", matched: true };
+  }
+}
+
+/**
+ * Handle `POST /api/mcp/servers/:serverId/reload` requests.
+ *
+ * Returns `false` when the path does not match so the caller can try the next
+ * stage (same contract as all other HTTP route handlers in the gateway).
+ *
+ * Query parameter `sessionId` (or header `X-OpenClaw-Session-Id`): when
+ * provided, only the runtime for that session is reloaded.  When absent, the
+ * reload is applied to every active session runtime on this gateway instance.
+ *
+ * Auth: `operator.write` scope — same bar as `tools.invoke` and consistent
+ * with write-level control-plane operations.
+ */
+export async function handleMcpReloadHttpRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  opts: {
+    auth: ResolvedGatewayAuth;
+    trustedProxies?: string[];
+    allowRealIpFallback?: boolean;
+    rateLimiter?: AuthRateLimiter;
+  },
+): Promise<boolean> {
+  let url: URL;
+  try {
+    url = new URL(req.url ?? "/", "http://localhost");
+  } catch {
+    res.writeHead(400, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ ok: false, error: { type: "bad_request", message: "Invalid request URL" } }));
+    return true;
+  }
+
+  const serverIdResolution = resolveServerIdFromPath(url.pathname);
+  if (!serverIdResolution.matched) {
+    return false;
+  }
+  if ("error" in serverIdResolution) {
+    sendInvalidRequest(res, "invalid or empty MCP server id in URL");
+    return true;
+  }
+  const { serverId } = serverIdResolution;
+
+  if (req.method !== "POST") {
+    sendMethodNotAllowed(res, "POST");
+    return true;
+  }
+
+  // /api/mcp/servers/:id/reload uses the same shared-secret HTTP trust model
+  // as /tools/invoke: token/password bearer auth is full operator access, not
+  // a narrower per-request scope boundary. Operators that need finer-grained
+  // scope control can use trusted-proxy auth with explicit x-openclaw-scopes.
+  const authResult = await authorizeScopedGatewayHttpRequestOrReply({
+    req,
+    res,
+    auth: opts.auth,
+    trustedProxies: opts.trustedProxies,
+    allowRealIpFallback: opts.allowRealIpFallback,
+    rateLimiter: opts.rateLimiter,
+    operatorMethod: REQUIRED_METHOD,
+    resolveOperatorScopes: resolveSharedSecretHttpOperatorScopes,
+  });
+  if (!authResult) {
+    // authorizeScopedGatewayHttpRequestOrReply already sent a 401 or 403 response.
+    return true;
+  }
+
+  // Resolve optional session targeting: header takes precedence over query param.
+  const sessionIdHeader = normalizeOptionalString(
+    req.headers["x-openclaw-session-id"]?.toString(),
+  );
+  const sessionIdQuery = normalizeOptionalString(url.searchParams.get("sessionId") ?? "");
+  const targetSessionId = sessionIdHeader ?? sessionIdQuery ?? null;
+
+  const manager = getSessionMcpRuntimeManager();
+
+  let reloadedCount = 0;
+  const errors: string[] = [];
+
+  const sessionIds = targetSessionId
+    ? manager.listSessionIds().filter((id) => id === targetSessionId)
+    : manager.listSessionIds();
+
+  if (targetSessionId && sessionIds.length === 0) {
+    sendJson(res, 404, {
+      ok: false,
+      error: {
+        type: "not_found",
+        message: `No active MCP runtime found for session "${targetSessionId}"`,
+      },
+    });
+    return true;
+  }
+
+  for (const sessionId of sessionIds) {
+    const runtime = manager.peekSession({ sessionId });
+    if (!runtime) {
+      continue;
+    }
+    if (typeof runtime.reloadServer !== "function") {
+      // Runtime was created before this feature; skip gracefully.
+      continue;
+    }
+    try {
+      await runtime.reloadServer(serverId);
+      reloadedCount += 1;
+    } catch (err: unknown) {
+      errors.push(
+        `session "${sessionId}": ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  if (errors.length > 0 && reloadedCount === 0) {
+    sendJson(res, 500, {
+      ok: false,
+      error: {
+        type: "reload_failed",
+        message: `MCP server reload failed for all targeted sessions`,
+        details: errors,
+      },
+    });
+    return true;
+  }
+
+  sendJson(res, 200, {
+    ok: true,
+    serverName: serverId,
+    sessionCount: reloadedCount,
+    ...(errors.length > 0 ? { partialErrors: errors } : {}),
+  });
+  return true;
+}

--- a/src/gateway/methods/core-descriptors.ts
+++ b/src/gateway/methods/core-descriptors.ts
@@ -94,6 +94,7 @@ export const CORE_GATEWAY_METHOD_SPECS: readonly CoreGatewayMethodSpec[] = [
   { name: "tools.catalog", scope: "operator.read" },
   { name: "tools.effective", scope: "operator.read", startup: true },
   { name: "tools.invoke", scope: "operator.write" },
+  { name: "mcp.server.reload", scope: "operator.write" },
   { name: "tasks.list", scope: "operator.read" },
   { name: "tasks.get", scope: "operator.read" },
   { name: "tasks.cancel", scope: "operator.write" },

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -82,6 +82,7 @@ let sessionHistoryHttpModulePromise:
   | Promise<typeof import("./sessions-history-http.js")>
   | undefined;
 let sessionKillHttpModulePromise: Promise<typeof import("./session-kill-http.js")> | undefined;
+let mcpReloadHttpModulePromise: Promise<typeof import("./mcp-reload-http.js")> | undefined;
 let toolsInvokeHttpModulePromise: Promise<typeof import("./tools-invoke-http.js")> | undefined;
 let pluginNodeCapabilityAuthModulePromise:
   | Promise<typeof import("./server/plugin-node-capability-auth.js")>
@@ -134,6 +135,11 @@ function getSessionHistoryHttpModule() {
 function getSessionKillHttpModule() {
   sessionKillHttpModulePromise ??= import("./session-kill-http.js");
   return sessionKillHttpModulePromise;
+}
+
+function getMcpReloadHttpModule() {
+  mcpReloadHttpModulePromise ??= import("./mcp-reload-http.js");
+  return mcpReloadHttpModulePromise;
 }
 
 function getToolsInvokeHttpModule() {
@@ -227,6 +233,10 @@ function isManagedOutgoingImagePath(pathname: string): boolean {
 
 function isSessionKillPath(pathname: string): boolean {
   return /^\/sessions\/[^/]+\/kill$/.test(pathname);
+}
+
+function isMcpServerReloadPath(pathname: string): boolean {
+  return /^\/api\/mcp\/servers\/[^/]+\/reload$/.test(pathname);
 }
 
 function isSessionHistoryPath(pathname: string): boolean {
@@ -645,6 +655,18 @@ export function createGatewayHttpServer(opts: {
           name: "sessions-kill",
           run: async () =>
             (await getSessionKillHttpModule()).handleSessionKillHttpRequest(req, res, {
+              auth: resolvedAuthValue,
+              trustedProxies,
+              allowRealIpFallback,
+              rateLimiter,
+            }),
+        });
+      }
+      if (isMcpServerReloadPath(scopedRequestPath)) {
+        requestStages.push({
+          name: "mcp-server-reload",
+          run: async () =>
+            (await getMcpReloadHttpModule()).handleMcpReloadHttpRequest(req, res, {
               auth: resolvedAuthValue,
               trustedProxies,
               allowRealIpFallback,

--- a/test/vitest/vitest.gateway-server.config.ts
+++ b/test/vitest/vitest.gateway-server.config.ts
@@ -3,6 +3,7 @@ import { createScopedVitestConfig } from "./vitest.scoped-config.ts";
 
 const gatewayServerBackedHttpTests = [
   "src/gateway/embeddings-http.test.ts",
+  "src/gateway/mcp-reload-http.test.ts",
   "src/gateway/models-http.test.ts",
   "src/gateway/openai-http.test.ts",
   "src/gateway/openresponses-http.test.ts",


### PR DESCRIPTION
## Why

When a customer connects a new Composio integration via our UI, the upstream MCP server's tool list changes but Composio's MCP server does not emit a `notifications/tools/list_changed` notification (see ComposioHQ/composio#3118). Without a reload trigger the agent only sees new tools after the session runtime's idle TTL (~10 min) or a config change — unacceptable UX for an enterprise product.

The notification-driven invalidation path (option A) already landed in main and v2026.6.1 per ClawSweeper's review. This PR implements option B: the operator-authenticated HTTP reload endpoint.

## What

### `POST /api/mcp/servers/:serverId/reload`

- **Auth:** same shared-secret / trusted-proxy model as `/tools/invoke` — token/password bearer auth grants full operator access; trusted-proxy auth honours `x-openclaw-scopes`; minimum scope required: `operator.write`
- **Optional targeting:** `X-OpenClaw-Session-Id` header or `?sessionId=` query param target a single active session; when absent, reloads across all active sessions on this gateway instance
- **Effect:** disposes the named server's transport session and invalidates the combined tool catalog so the next `getCatalog()` call reconnects and re-fetches tools from the upstream MCP server

### Method descriptor

Added `mcp.server.reload` to `core-descriptors.ts` with scope `operator.write`, consistent with other mutation endpoints.

### `SessionMcpRuntime.reloadServer(serverName)`

New optional method on the runtime interface. Removes the server's entry from the `sessions` map (forcing reconnect on next use), increments `catalogInvalidationGeneration`, and nulls `catalog`/`catalogInFlight`. The existing `notifications/tools/list_changed` invalidation path uses the same fields so semantics are consistent.

## Files changed

| File | Change |
|------|--------|
| `src/gateway/mcp-reload-http.ts` | New HTTP route handler |
| `src/gateway/mcp-reload-http.test.ts` | 42 unit tests |
| `src/gateway/methods/core-descriptors.ts` | New method descriptor |
| `src/gateway/server-http.ts` | Route detection + lazy module loading |
| `src/agents/agent-bundle-mcp-types.ts` | `reloadServer` on `SessionMcpRuntime` type |
| `src/agents/agent-bundle-mcp-runtime.ts` | `reloadServer` implementation |
| `test/vitest/vitest.gateway-server.config.ts` | Add test file to shard |

## Tests

42 new unit tests covering: path matching, method rejection, 401/403 auth flows, zero/multi/single-session reload, URL-decoded server names, legacy runtime graceful skip, and error paths (404 unknown session, 500 total failure, 200 partial).

## Integration example (Pareto Colabs OAuth callback)

```
POST /api/mcp/servers/composio/reload
Authorization: Bearer <gateway-token>

→ { "ok": true, "serverName": "composio", "sessionCount": 1 }
```

Closes #91556