### PR TITLE
test(github-copilot): cover live xhigh reasoning for non-Claude mini models (#59416)

### DIFF
--- a/extensions/github-copilot/index.test.ts
+++ b/extensions/github-copilot/index.test.ts
@@ -273,6 +273,37 @@ describe("github-copilot plugin", () => {
     expect(profile?.levels.map((level) => level.id)).not.toContain("max");
   });
 
+  it("exposes xhigh thinking for non-Claude Copilot models with catalog xhigh effort", () => {
+    // Regression for #59416: mini-family models (e.g. gpt-5.4-mini) are
+    // entitled to xhigh per live /models, but the static xhigh allowlist only
+    // contains gpt-5.4 and gpt-5.3-codex. When live metadata wins, the
+    // resolved compat must drive xhigh for these non-Claude ids as well.
+    const provider = registerProviderWithPluginConfig({});
+
+    const profile = provider.resolveThinkingProfile({
+      provider: "github-copilot",
+      modelId: "gpt-5.4-mini",
+      compat: { supportedReasoningEfforts: ["none", "low", "medium", "high", "xhigh"] },
+    });
+
+    expect(profile?.levels.map((level) => level.id)).toContain("xhigh");
+  });
+
+  it("omits xhigh for non-Claude Copilot models whose catalog effort lacks it", () => {
+    // Negative half of the #59416 regression: live-first must not over-grant.
+    // gpt-5-mini reports only [low, medium, high] live, so xhigh must stay off
+    // even though the reporter asked for the whole mini family to gain it.
+    const provider = registerProviderWithPluginConfig({});
+
+    const profile = provider.resolveThinkingProfile({
+      provider: "github-copilot",
+      modelId: "gpt-5-mini",
+      compat: { supportedReasoningEfforts: ["low", "medium", "high"] },
+    });
+
+    expect(profile?.levels.map((level) => level.id)).not.toContain("xhigh");
+  });
+
   it("uses live plugin config to re-enable discovery after startup disable", async () => {
     mocks.resolveCopilotApiToken.mockResolvedValueOnce({
       token: "copilot_api_token",


### PR DESCRIPTION
## What

Adds regression tests covering **xhigh reasoning resolution for non-Claude "mini" Copilot models** via the live `/models` extended-thinking compat path.

- `gpt-5.4-mini` **should** gain `xhigh` when the live catalog advertises it (live extended-thinking compat applies).
- `gpt-5-mini` **must not** over-grant `xhigh` (guards against the compat helper widening reasoning levels too broadly).

Refs #59416.

## Why this PR shrank

This branch originally proposed a live `/models` catalog with static fallback union. That idea has since **landed upstream independently** (live discovery via `75405f64d0` / `d2279591bf`; the old `models-defaults.ts` helper was removed in `46c42d4a0d`), with live-first precedence handled centrally — so the original implementation is now redundant and unmergeable as-was.

Rather than resurrect dead code, this PR is reset onto `main` and reduced to the **one piece not yet covered upstream**: the non-Claude mini xhigh reasoning boundary tests above.

## Real behavior proof

- Behavior or issue addressed: non-Claude Copilot mini model reasoning compatibility had no regression coverage for the `xhigh` boundary after the live catalog path landed upstream.
- Real environment tested: OpenClaw pull-request validation on this exact PR head, exercising the repository's github-copilot extension test path.
- Exact steps or command run after this patch:
  ```bash
  vitest github-copilot extension tests
  oxlint
  oxfmt
  ```
- Evidence after fix:
  ```text
  vitest (github-copilot extension): 21/21 passed
  oxlint: 0 warnings / 0 errors
  oxfmt: clean
  ```
- Observed result after fix: the tests-only branch now covers both the `gpt-5.4-mini` xhigh allow case and the `gpt-5-mini` no-overgrant guard without changing runtime code.
- What was not tested: live Copilot network calls; this PR intentionally adds regression coverage only.

## Testing

- `vitest` (github-copilot extension): **21/21 passed**
- `oxlint`: 0 warnings / 0 errors
- `oxfmt`: clean

Tests-only change — no runtime behavior modified.
