### PR TITLE
fix(diagnostics): prune non-idle ghost session entries that have exceeded TTL

### DIFF
--- a/src/logging/diagnostic-session-state.ts
+++ b/src/logging/diagnostic-session-state.ts
@@ -58,6 +58,11 @@ export function pruneDiagnosticSessionStates(now = Date.now(), force = false): v
     const isIdle = state.state === "idle";
     if (isIdle && state.queueDepth <= 0 && ageMs > SESSION_STATE_TTL_MS) {
       diagnosticSessionStates.delete(key);
+    } else if (ageMs > SESSION_STATE_TTL_MS && state.queueDepth <= 0) {
+      // Non-idle ghost entries that have exceeded the TTL and have no queued
+      // work (e.g. orphaned "processing" state from failed session recovery)
+      // also accumulate. Prune them to prevent unbounded Map growth. (#91697)
+      diagnosticSessionStates.delete(key);
     }
   }
 


### PR DESCRIPTION
## Summary

pruneDiagnosticSessionStates() only deleted entries where state === 'idle'. Non-idle entries (e.g. orphaned 'processing' from failed session recovery) accumulated in the Map indefinitely. Add a fallback condition that prunes entries whose age exceeds SESSION_STATE_TTL_MS and have no queued work, regardless of state.

## Linked context

Closes #91697

## Real behavior proof (required for external PRs)

- **Behavior or issue addressed:** Non-idle ghost entries were never pruned, causing unbounded Map growth.
- **Real environment tested:** macOS, Node v22.22.3, latest upstream/main
- **Exact steps or command run after this patch:**
```bash
node scripts/run-vitest.mjs run src/logging/diagnostic.test.ts src/logging/diagnostic-session-context.test.ts --reporter=verbose
```
- **Evidence after fix:** 72 passed (2 test files)
- **Observed result after fix:** Non-idle entries with age > 30 min and no queued work are now pruned.
- **What was not tested:** Live gateway stuck sessions.
- **Proof limitations or environment constraints:** queueDepth <= 0 guard prevents pruning active entries.

## Tests and validation

```bash
node scripts/run-vitest.mjs run src/logging/diagnostic.test.ts src/logging/diagnostic-session-context.test.ts
# 72 passed (2 test files)
```

## Risk checklist

**Did user-visible behavior change?** No
**Did config, environment, or migration behavior change?** No
**Did security, auth, secrets, network, or tool execution behavior change?** No