### PR TITLE
fix(feishu): preserve quoted context for mention-only replies

### DIFF
--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -413,7 +413,11 @@ afterAll(() => {
   vi.resetModules();
 });
 
-async function dispatchMessage(params: { cfg: ClawdbotConfig; event: FeishuMessageEvent }) {
+async function dispatchMessage(params: {
+  cfg: ClawdbotConfig;
+  event: FeishuMessageEvent;
+  botOpenId?: string;
+}) {
   const runtime = createRuntimeEnv();
   const feishuConfig = params.cfg.channels?.feishu;
   const cfg =
@@ -432,6 +436,7 @@ async function dispatchMessage(params: { cfg: ClawdbotConfig; event: FeishuMessa
   await handleFeishuMessage({
     cfg,
     event: params.event,
+    botOpenId: params.botOpenId,
     runtime,
   });
   return runtime;
@@ -1585,7 +1590,9 @@ describe("handleFeishuMessage command authorization", () => {
         chat_type: "group",
         message_type: "text",
         content: JSON.stringify({ text: "@_user_1/model" }),
-        mentions: [{ key: "@_user_1", id: { open_id: "ou-bot" }, name: "Bot", tenant_key: "" }],
+        mentions: [
+          { key: "@_user_1", id: { open_id: "ou-bot" }, name: "Bot", tenant_key: "" },
+        ],
       },
     };
 
@@ -3743,6 +3750,101 @@ describe("handleFeishuMessage command authorization", () => {
 
     // No reply should be dispatched: empty message is silently skipped
     expect(mockDispatchReplyFromConfig).not.toHaveBeenCalled();
+  });
+
+  it("skips empty quoted group replies that do not mention the bot", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          groupPolicy: "open",
+          groups: {
+            "oc-group": {
+              requireMention: false,
+            },
+          },
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: {
+        sender_id: {
+          open_id: "ou-empty-quoted-sender",
+        },
+      },
+      message: {
+        message_id: "msg-empty-quote-unmentioned",
+        parent_id: "om_parent_unmentioned",
+        chat_id: "oc-group",
+        chat_type: "group",
+        message_type: "text",
+        content: JSON.stringify({ text: "" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event, botOpenId: "ou-bot" });
+
+    expect(mockGetMessageFeishu).not.toHaveBeenCalled();
+    expect(mockDispatchReplyFromConfig).not.toHaveBeenCalled();
+  });
+
+  it("dispatches mention-only group replies when quoted parent content is available (#90177)", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+    mockGetMessageFeishu.mockResolvedValueOnce({
+      messageId: "om_parent_90177",
+      chatId: "oc-group",
+      senderId: "ou-parent-author",
+      senderType: "user",
+      content: "quoted parent content",
+      contentType: "text",
+    });
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          groupPolicy: "open",
+          groups: {
+            "oc-group": {
+              requireMention: true,
+            },
+          },
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: {
+        sender_id: {
+          open_id: "ou-reply-only-bot",
+        },
+      },
+      message: {
+        message_id: "msg-empty-with-quote-90177",
+        parent_id: "om_parent_90177",
+        chat_id: "oc-group",
+        chat_type: "group",
+        message_type: "text",
+        content: JSON.stringify({ text: "@_user_1" }),
+        mentions: [
+          { key: "@_user_1", id: { open_id: "ou-bot" }, name: "Bot", tenant_key: "" },
+        ],
+      },
+    };
+
+    await dispatchMessage({ cfg, event, botOpenId: "ou-bot" });
+
+    expect(mockGetMessageFeishu).toHaveBeenCalledWith(
+      expect.objectContaining({ messageId: "om_parent_90177" }),
+    );
+    const context = mockCallArg<{
+      BodyForAgent?: string;
+      SupplementalContext?: { quote?: { body?: string } };
+    }>(mockFinalizeInboundContext, 0, 0);
+    expect(context.SupplementalContext?.quote?.body).toBe("quoted parent content");
+    expect(context.BodyForAgent).toContain('[Replying to: "quoted parent content"]');
+    expect(mockDispatchReplyFromConfig).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -952,15 +952,61 @@ export async function handleFeishuMessage(params: {
       log,
       accountId: account.accountId,
     });
-    // Skip messages with no text content and no media attachments. Feishu can
-    // deliver empty-text events (e.g. `{"text":""}`) when a user sends a blank
-    // message or when media parsing produces an empty string. Writing a blank
-    // user turn to the session causes downstream LLM providers (e.g. MiniMax)
-    // to reject the request with "messages must not be empty" errors. Logging
-    // the skip avoids silent loss without polluting the agent session.
-    if (!ctx.content.trim() && mediaList.length === 0) {
+
+    const hasCurrentUserPayload = Boolean(ctx.content.trim()) || mediaList.length > 0;
+    const canUseQuoteForEmptyMessage = isGroup && ctx.mentionedBot;
+
+    // Fetch quoted/replied message content before the empty-message guard so
+    // mention-only group replies still reach the agent when the parent carries
+    // the actual user context. Plain blank replies stay protected by the guard.
+    let quotedMessageInfo: Awaited<ReturnType<typeof getMessageFeishu>> = null;
+    let quotedContent: string | undefined;
+    if (ctx.parentId && (hasCurrentUserPayload || canUseQuoteForEmptyMessage)) {
+      try {
+        quotedMessageInfo = await getMessageFeishu({
+          cfg,
+          messageId: ctx.parentId,
+          accountId: account.accountId,
+        });
+        if (
+          quotedMessageInfo &&
+          (await shouldIncludeFetchedGroupContextMessage({
+            cfg,
+            accountId: account.accountId,
+            chatId: ctx.chatId,
+            isGroup,
+            allowFrom: effectiveGroupSenderAllowFrom,
+            mode: contextVisibilityMode,
+            kind: "quote",
+            senderId: quotedMessageInfo.senderId,
+            senderType: quotedMessageInfo.senderType,
+          }))
+        ) {
+          quotedContent = quotedMessageInfo.content;
+          log(
+            `feishu[${account.accountId}]: fetched quoted message: ${quotedContent?.slice(0, 100)}`,
+          );
+        } else if (quotedMessageInfo) {
+          log(
+            `feishu[${account.accountId}]: skipped quoted message from sender ${quotedMessageInfo.senderId ?? "unknown"} (mode=${contextVisibilityMode})`,
+          );
+        }
+      } catch (err) {
+        log(`feishu[${account.accountId}]: failed to fetch quoted message: ${String(err)}`);
+      }
+    }
+
+    // Skip messages with no user-supplied text or media. Feishu can deliver
+    // empty-text events (e.g. `{"text":""}`) when a user sends a blank message
+    // or when media parsing produces an empty string. Writing a blank user turn
+    // to the session causes downstream LLM providers (e.g. MiniMax) to reject
+    // the request with "messages must not be empty" errors. Logging the skip
+    // avoids silent loss without polluting the agent session.
+    const quoteSuppliesMentionOnlyGroupReply =
+      canUseQuoteForEmptyMessage && Boolean(quotedContent?.trim());
+    if (!hasCurrentUserPayload && !quoteSuppliesMentionOnlyGroupReply) {
       log(
-        `feishu[${account.accountId}]: skipping empty message (no text, no media) from ${ctx.senderOpenId}`,
+        `feishu[${account.accountId}]: skipping empty message (no text, no media, no quoted) from ${ctx.senderOpenId}`,
       );
       return;
     }
@@ -1029,44 +1075,6 @@ export async function handleFeishuMessage(params: {
               })
             ).commandAccess.authorized
       : undefined;
-
-    // Fetch quoted/replied message content if parentId exists
-    let quotedMessageInfo: Awaited<ReturnType<typeof getMessageFeishu>> = null;
-    let quotedContent: string | undefined;
-    if (ctx.parentId) {
-      try {
-        quotedMessageInfo = await getMessageFeishu({
-          cfg,
-          messageId: ctx.parentId,
-          accountId: account.accountId,
-        });
-        if (
-          quotedMessageInfo &&
-          (await shouldIncludeFetchedGroupContextMessage({
-            cfg,
-            accountId: account.accountId,
-            chatId: ctx.chatId,
-            isGroup,
-            allowFrom: effectiveGroupSenderAllowFrom,
-            mode: contextVisibilityMode,
-            kind: "quote",
-            senderId: quotedMessageInfo.senderId,
-            senderType: quotedMessageInfo.senderType,
-          }))
-        ) {
-          quotedContent = quotedMessageInfo.content;
-          log(
-            `feishu[${account.accountId}]: fetched quoted message: ${quotedContent?.slice(0, 100)}`,
-          );
-        } else if (quotedMessageInfo) {
-          log(
-            `feishu[${account.accountId}]: skipped quoted message from sender ${quotedMessageInfo.senderId ?? "unknown"} (mode=${contextVisibilityMode})`,
-          );
-        }
-      } catch (err) {
-        log(`feishu[${account.accountId}]: failed to fetch quoted message: ${String(err)}`);
-      }
-    }
 
     const isTopicSessionForThread =
       isGroup &&


### PR DESCRIPTION
## Summary

Fixes #90177.

Feishu group replies that contain only the bot mention can normalize to empty text before dispatch. The handler previously returned at the empty-message guard before fetching quoted parent content, so the reply was dropped even when the parent message carried the real user context.

This patch moves quoted parent lookup ahead of the empty-message guard, but keeps the bypass narrow: quoted content can supply an otherwise empty turn only for addressed group bot-mention replies. Plain blank quoted replies still skip.

AI-assisted: prepared with Codex; final diff and proof were reviewed locally before PR creation.

## Linked context

Closes #90177

Duplicate work checked June 9, 2026: #90192 is open and related. This PR follows the same Feishu owner-boundary direction, but adds a negative regression and narrows the bypass so blank quoted replies without a bot mention still skip.

## Real behavior proof

Behavior addressed: Feishu group reply containing only the bot mention and a quoted parent no longer drops before quoted content is fetched.

Real environment tested: Local OpenClaw source checkout with Feishu handler tests and mocked Feishu event/API responses.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs extensions/feishu/src/bot.test.ts` passed with 75 tests; `node scripts/run-vitest.mjs extensions/feishu` passed with 67 files and 858 tests; `git diff --check` passed; `uv run --python 3.12 python .agents/skills/autoreview/scripts/autoreview --mode commit --commit 22ff3c6f8fae605c7e8e3c8270aae0fd55cb8f0b ...` passed clean after one accepted finding was fixed.

Evidence after fix: Added a positive regression for a group message whose only text is the bot mention, with `parent_id` set. The test verifies Feishu quoted content is fetched, added to supplemental context, and dispatched. Added a negative regression for an empty quoted group reply without a bot mention. The test verifies the parent is not fetched and no dispatch occurs.

Observed result after fix: Mention-only group replies with quoted parent content dispatch with quote context. Blank quoted group replies that do not mention the bot still skip.

What was not tested: Live Feishu E2E with real bot credentials and a real group chat. No Feishu live test lane or credentials were available in this checkout.

Proof limitations or environment constraints: GitHub's `Real behavior proof` check failed on June 9, 2026 because this PR currently has local test proof only. I attempted a local runtime capture with the Feishu webhook monitor and a signed Feishu-style event, but the quoted-parent path needs `client.im.message.get`. The Feishu SDK's custom-domain path filler treats `:port` in a localhost API URL as a path parameter, and binding a temporary localhost server on port 80 is not permitted in this environment. A real Feishu workspace/API run, a maintainer-provided runtime log, or a maintainer `proof: override` label is needed before this external PR satisfies the proof gate.

## Tests and validation

- `node scripts/run-vitest.mjs extensions/feishu/src/bot.test.ts` - passed, 75 tests
- `node scripts/run-vitest.mjs extensions/feishu` - passed, 67 files / 858 tests
- `git diff --check` - passed
- `uv run --python 3.12 python .agents/skills/autoreview/scripts/autoreview --mode commit --commit 22ff3c6f8fae605c7e8e3c8270aae0fd55cb8f0b ...` - clean after addressing one accepted finding

## Risk checklist

- [x] Feishu plugin-owned behavior only
- [x] No core/channel SDK changes
- [x] True empty-message skip remains protected
- [x] No secret/config/schema changes
- [x] Duplicate work checked and documented
- [ ] Live Feishu proof supplied

## Current review state

Draft. Not ready for review yet: the related `Real behavior proof` check is failing for the known proof gap above, and #90192 remains open as duplicate/competing work.
