### PR TITLE
Validate sandbox bind parent paths [AI]

### DIFF
--- a/src/agents/sandbox-create-args.test.ts
+++ b/src/agents/sandbox-create-args.test.ts
@@ -254,6 +254,12 @@ describe("buildSandboxCreateArgs", () => {
       expected: /blocked path/,
     },
     {
+      name: "bind source covering Docker socket directory",
+      containerName: "openclaw-sbx-covers-docker-socket-dir",
+      cfg: createSandboxConfig({}, ["/var:/var"]),
+      expected: /covers blocked path/,
+    },
+    {
       name: "network host mode",
       containerName: "openclaw-sbx-host",
       cfg: createSandboxConfig({ network: "host" }),

--- a/src/agents/sandbox/validate-sandbox-security.test.ts
+++ b/src/agents/sandbox/validate-sandbox-security.test.ts
@@ -36,8 +36,22 @@ describe("getBlockedBindReason", () => {
     expectBlockedTargetReason("/var/run:/var/run:ro");
   });
 
-  it("does not block /var by default", () => {
-    expect(getBlockedBindReason("/var:/var")).toBeNull();
+  it("blocks parent sources that cover blocked descendants", () => {
+    const reason = getBlockedBindReason("/var:/var");
+    expect(reason).toMatchObject({
+      kind: "covers",
+      blockedPath: "/var/run",
+    });
+  });
+
+  it("blocks home parent sources that cover credential descendants", () => {
+    withEnv({ HOME: "/home/tester" }, () => {
+      const reason = getBlockedBindReason("/home/tester:/mnt/home:ro");
+      expect(reason).toMatchObject({
+        kind: "covers",
+        blockedPath: "/home/tester/.aws",
+      });
+    });
   });
 
   it("blocks sensitive home credential paths", () => {
@@ -165,8 +179,24 @@ describe("validateBindMounts", () => {
     }
   });
 
-  it("allows parent mounts that are not blocked", () => {
-    expect(validateBindMounts(["/var:/var"])).toBeUndefined();
+  it("allows parent mounts that do not cover blocked descendants", () => {
+    expect(validateBindMounts(["/var/data:/data"])).toBeUndefined();
+  });
+
+  it("blocks allowed source roots that cover blocked descendants", () => {
+    expect(() =>
+      validateBindMounts(["/var:/var"], {
+        allowedSourceRoots: ["/var"],
+      }),
+    ).toThrow(/covers blocked path "\/var\/run"/);
+
+    withEnv({ HOME: "/home/tester" }, () => {
+      expect(() =>
+        validateBindMounts(["/home/tester:/mnt/home:ro"], {
+          allowedSourceRoots: ["/home/tester"],
+        }),
+      ).toThrow(/covers blocked path "\/home\/tester\/\.aws"/);
+    });
   });
 
   it("blocks sensitive home credential binds", () => {

--- a/src/agents/sandbox/validate-sandbox-security.ts
+++ b/src/agents/sandbox/validate-sandbox-security.ts
@@ -143,11 +143,14 @@ function getBlockedReasonForSourcePath(
   if (sourceNormalized === "/") {
     return { kind: "covers", blockedPath: "/" };
   }
-  const sourceKey = getSandboxHostPathPolicyKey(sourceNormalized);
   for (const blocked of blockedHostPaths) {
-    const blockedKey = getSandboxHostPathPolicyKey(blocked);
-    if (sourceKey === blockedKey || sourceKey.startsWith(`${blockedKey}/`)) {
+    if (isPathInsidePolicyPath(blocked, sourceNormalized)) {
       return { kind: "targets", blockedPath: blocked };
+    }
+    // Parent mounts can expose blocked descendants such as HOME credentials or
+    // the Docker socket directory even when the source root itself is allowed.
+    if (isPathInsidePolicyPath(sourceNormalized, blocked)) {
+      return { kind: "covers", blockedPath: blocked };
     }
   }
 
@@ -217,13 +220,14 @@ function normalizeAllowedRoots(roots: string[] | undefined): string[] {
   return [...expanded];
 }
 
-function isPathInsidePosix(root: string, target: string): boolean {
-  if (root === "/") {
-    return true;
-  }
+function isPathInsidePolicyPath(root: string, target: string): boolean {
   const rootKey = getSandboxHostPathPolicyKey(root);
   const targetKey = getSandboxHostPathPolicyKey(target);
-  return targetKey === rootKey || targetKey.startsWith(`${rootKey}/`);
+  if (rootKey === "/") {
+    return true;
+  }
+  const rootPrefix = rootKey.endsWith("/") ? rootKey : `${rootKey}/`;
+  return targetKey === rootKey || targetKey.startsWith(rootPrefix);
 }
 
 function getOutsideAllowedRootsReason(
@@ -234,7 +238,7 @@ function getOutsideAllowedRootsReason(
     return null;
   }
   for (const root of allowedRoots) {
-    if (isPathInsidePosix(root, sourceNormalized)) {
+    if (isPathInsidePolicyPath(root, sourceNormalized)) {
       return null;
     }
   }
@@ -252,7 +256,7 @@ function getReservedTargetReason(bind: string): BlockedBindReason | null {
   }
   const target = normalizeHostPath(targetRaw);
   for (const reserved of RESERVED_CONTAINER_TARGET_PATHS) {
-    if (isPathInsidePosix(reserved, target)) {
+    if (isPathInsidePolicyPath(reserved, target)) {
       return {
         kind: "reserved_target",
         targetPath: target,


### PR DESCRIPTION
## Summary

- Validate sandbox bind sources in both path directions, so a bind source that contains a blocked descendant is rejected.
- Keep project-specific parent mounts such as `/var/data` valid when they do not cover blocked paths.
- Add focused regression coverage for parent bind sources and the Docker create-args validation path.
- AI-assisted.

## Linked context

No public issue is linked.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Docker sandbox bind source validation now rejects parent sources that cover blocked descendants.
- Real environment tested: Local Linux checkout using the actual Docker create-args runtime path plus the repo Vitest wrapper.
- Exact steps or command run after this patch: `node --import tsx` script importing `buildSandboxCreateArgs` from `src/agents/sandbox/docker.ts`, plus `node scripts/run-vitest.mjs src/agents/sandbox/validate-sandbox-security.test.ts src/agents/sandbox-create-args.test.ts`
- Evidence after fix:

  ```text
  broad-var-parent: BLOCKED Sandbox security: bind mount "/var:/mnt/var:ro" covers blocked path "/var/run". Mounting system directories, credential paths, or Docker socket paths into sandbox containers is not allowed. Use project-specific paths instead (e.g. /home/user/myproject).
  project-var-data: ALLOWED ["/var/data/myapp:/data:ro"]
  tmp-project: ALLOWED ["/tmp/openclaw-bind-proof-0UVoq1:/data:ro"]
  ```

- Observed result after fix: The real Docker argument builder rejects a broad parent bind before container creation and still emits `-v` arguments for narrower project-specific binds.
- What was not tested: Full Docker daemon container startup and broad CI have not completed yet.
- Proof limitations or environment constraints: The real proof covers the runtime validation path that runs immediately before Docker container creation; it does not start a Docker container.
- Before evidence (optional but encouraged): Existing tests allowed `/var` as a parent source; the updated regression now expects that source to be rejected.

## Tests and validation

- `node scripts/run-vitest.mjs src/agents/sandbox/validate-sandbox-security.test.ts src/agents/sandbox-create-args.test.ts`
- `pnpm format:check -- src/agents/sandbox/validate-sandbox-security.ts src/agents/sandbox/validate-sandbox-security.test.ts src/agents/sandbox-create-args.test.ts`
- `node scripts/run-oxlint.mjs src/agents/sandbox/validate-sandbox-security.ts src/agents/sandbox/validate-sandbox-security.test.ts src/agents/sandbox-create-args.test.ts`
- `git diff --check`

Regression coverage was added for parent sources that cover blocked descendants and for the Docker create-args path that runs sandbox validation.

## Risk checklist

- Did user-visible behavior change? `Yes`
- Did config, environment, or migration behavior change? `No`
- Did security, auth, secrets, network, or tool execution behavior change? `Yes`
- Highest-risk area: Existing sandbox configs that bind broad host parent directories may now fail validation.
- Risk mitigation: The change is limited to blocked-path coverage checks, keeps narrower project paths valid, and is covered by focused regression tests.

## Current review state

- Next action: Run automated review, private completeness gates, and CI checks.
- Waiting on: Review refresh, post-solve gates, and CI.
- Bot or reviewer comments addressed: Added real Docker create-args behavior proof for the parent-bind rejection and narrow-bind allow case.
