### PR TITLE
fix(memory): abort orphaned embedding work when memory_search times out

### DIFF
--- a/extensions/memory-core/src/memory-tool-manager-mock.ts
+++ b/extensions/memory-core/src/memory-tool-manager-mock.ts
@@ -8,6 +8,7 @@ type SearchImpl = (opts?: {
   sessionKey?: string;
   qmdSearchModeOverride?: "query" | "search" | "vsearch";
   onDebug?: (debug: MemorySearchRuntimeDebug) => void;
+  signal?: AbortSignal;
 }) => Promise<unknown[]>;
 export type MemoryReadParams = { relPath: string; from?: number; lines?: number };
 type MemoryReadResult = {

--- a/extensions/memory-core/src/memory/manager-embedding-ops.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.ts
@@ -163,11 +163,16 @@ export function resolveMemoryIndexConcurrency(params: {
 export async function runEmbeddingOperationWithTimeout<T>(params: {
   timeoutMs: number;
   message: string;
+  /** Caller-owned cancellation, merged with the per-call watchdog abort. */
+  signal?: AbortSignal;
   run: (signal: AbortSignal) => Promise<T>;
 }): Promise<T> {
   const controller = new AbortController();
+  const signal = params.signal
+    ? AbortSignal.any([params.signal, controller.signal])
+    : controller.signal;
   if (!Number.isFinite(params.timeoutMs) || params.timeoutMs <= 0) {
-    return await params.run(controller.signal);
+    return await params.run(signal);
   }
   const timeoutMs = resolveTimerTimeoutMs(params.timeoutMs, 1);
   let timer: NodeJS.Timeout | null = null;
@@ -179,7 +184,7 @@ export async function runEmbeddingOperationWithTimeout<T>(params: {
     }, timeoutMs);
   });
   try {
-    const operation = params.run(controller.signal);
+    const operation = params.run(signal);
     return (await Promise.race([operation, timeoutPromise])) as T;
   } finally {
     if (timer) {
@@ -493,7 +498,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     });
   }
 
-  protected async embedQueryWithRetry(text: string): Promise<number[]> {
+  protected async embedQueryWithRetry(text: string, signal?: AbortSignal): Promise<number[]> {
     const provider = this.provider;
     if (!provider) {
       throw new Error("Cannot embed query in FTS-only mode (no embedding provider)");
@@ -501,14 +506,17 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     try {
       return await runMemoryEmbeddingRetryLoop({
         run: async () => {
+          signal?.throwIfAborted();
           const timeoutMs = this.resolveEmbeddingTimeout("query");
           log.debug("memory embeddings: query start", { provider: provider.id, timeoutMs });
           return await runEmbeddingOperationWithTimeout({
             timeoutMs,
             message: `memory embeddings query timed out after ${Math.round(timeoutMs / 1000)}s`,
-            run: async (signal) => await provider.embedQuery(text, { signal }),
+            signal,
+            run: async (opSignal) => await provider.embedQuery(text, { signal: opSignal }),
           });
         },
+        signal,
         isRetryable: isRetryableMemoryEmbeddingError,
         waitForRetry: async (delayMs) => {
           await this.waitForEmbeddingRetry(delayMs, "retrying query");

--- a/extensions/memory-core/src/memory/manager-embedding-policy.test.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-policy.test.ts
@@ -75,6 +75,30 @@ describe("memory embedding policy", () => {
     expect(waits).toEqual([500, 1000]);
   });
 
+  it("stops retrying after the caller signal aborts, even for retryable-looking errors", async () => {
+    const controller = new AbortController();
+    const run = vi.fn(async () => {
+      controller.abort(new Error("memory_search timed out after 15s"));
+      // "timed out" matches the retryable transport pattern; abort must still win.
+      throw new Error("memory embeddings query timed out after 60s");
+    });
+    const waitForRetry = vi.fn(async () => {});
+
+    await expect(
+      runMemoryEmbeddingRetryLoop({
+        run,
+        isRetryable: isRetryableMemoryEmbeddingError,
+        waitForRetry,
+        maxAttempts: 3,
+        baseDelayMs: 500,
+        signal: controller.signal,
+      }),
+    ).rejects.toThrow("memory embeddings query timed out after 60s");
+
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(waitForRetry).not.toHaveBeenCalled();
+  });
+
   it("retries transient socket/network embedding errors", () => {
     const splittableMessages = [
       "TypeError: fetch failed | other side closed",

--- a/extensions/memory-core/src/memory/manager-embedding-policy.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-policy.ts
@@ -125,6 +125,8 @@ export async function runMemoryEmbeddingRetryLoop<T>(params: {
   waitForRetry: (delayMs: number) => Promise<void>;
   maxAttempts: number;
   baseDelayMs: number;
+  /** Caller-owned cancellation; an aborted caller stops the retry loop. */
+  signal?: AbortSignal;
 }): Promise<T> {
   const attempts = Math.max(1, params.maxAttempts);
   for (const attempt of Array.from({ length: attempts }, (_, index) => index + 1)) {
@@ -132,6 +134,12 @@ export async function runMemoryEmbeddingRetryLoop<T>(params: {
     try {
       return await params.run();
     } catch (err) {
+      // Abort must win over retryable-looking failures: abort reasons often
+      // carry "timed out" messages that match the retryable transport
+      // patterns and would otherwise keep retrying for an absent caller.
+      if (params.signal?.aborted) {
+        throw err;
+      }
       const message = formatErrorMessage(err);
       if (!params.isRetryable(message) || attempt >= params.maxAttempts) {
         throw err;

--- a/extensions/memory-core/src/memory/manager-embedding-timeout.test.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-timeout.test.ts
@@ -135,6 +135,31 @@ describe("memory embedding timeout abort", () => {
     expect(signalSeen?.aborted).toBe(true);
   });
 
+  it("aborts the provider operation when the caller signal aborts before the watchdog", async () => {
+    const external = new AbortController();
+    let signalSeen: AbortSignal | undefined;
+
+    const resultPromise = runEmbeddingOperationWithTimeout({
+      timeoutMs: 60_000,
+      message: "memory embeddings query timed out after 60s",
+      signal: external.signal,
+      run: async (signal) => {
+        signalSeen = signal;
+        return await new Promise<number[]>((_resolve, reject) => {
+          signal.addEventListener(
+            "abort",
+            () => reject(toLintErrorObject(signal.reason, "Non-Error rejection")),
+            { once: true },
+          );
+        });
+      },
+    });
+
+    external.abort(new Error("memory_search timed out after 15s"));
+    await expect(resultPromise).rejects.toThrow("memory_search timed out after 15s");
+    expect(signalSeen?.aborted).toBe(true);
+  });
+
   it("keeps the timeout error when a provider abort listener rejects generically", async () => {
     vi.useFakeTimers();
     const resultPromise = runEmbeddingOperationWithTimeout({

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -592,6 +592,8 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       onDebug?: (debug: MemorySearchRuntimeDebug) => void;
       /** When set, only these chunk sources are considered (must be enabled for this manager). */
       sources?: MemorySource[];
+      /** Caller-owned cancellation; aborts in-flight embedding work when the caller stops waiting. */
+      signal?: AbortSignal;
     },
   ): Promise<MemorySearchResult[]> {
     opts?.onDebug?.({ backend: "builtin" });
@@ -758,8 +760,13 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
 
     let queryVec: number[];
     try {
-      queryVec = await this.embedQueryWithRetry(cleaned);
+      queryVec = await this.embedQueryWithRetry(cleaned, opts?.signal);
     } catch (err) {
+      // An aborted caller already stopped waiting; skip fallback-provider
+      // activation so the abandoned search stops instead of re-embedding.
+      if (opts?.signal?.aborted) {
+        throw err;
+      }
       const message = formatErrorMessage(err);
       const activatedFallback = this.shouldFallbackOnError(err)
         ? await this.activateFallbackProvider(message).catch((fallbackErr: unknown) => {
@@ -778,7 +785,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
           return [];
         }
         keywordResults = await loadKeywordResults();
-        queryVec = await this.embedQueryWithRetry(cleaned);
+        queryVec = await this.embedQueryWithRetry(cleaned, opts?.signal);
       } else if (!this.provider && this.fts.enabled && this.fts.available) {
         log.warn(`memory search: embeddings unavailable; using keyword-only results: ${message}`);
         return this.selectScoredResults(keywordResults, maxResults, minScore, 0);

--- a/extensions/memory-core/src/memory/search-manager.test.ts
+++ b/extensions/memory-core/src/memory/search-manager.test.ts
@@ -339,9 +339,11 @@ describe("getMemorySearchManager caching", () => {
       errorMessage: "qmd query failed",
     });
 
-    const fallbackResults = await firstManager.search("hello");
+    const controller = new AbortController();
+    const fallbackResults = await firstManager.search("hello", { signal: controller.signal });
     expect(fallbackResults).toHaveLength(1);
     expect(fallbackResults[0]?.path).toBe("MEMORY.md");
+    expect(fallbackSearch).toHaveBeenCalledWith("hello", { signal: controller.signal });
 
     const second = await getMemorySearchManager({ cfg, agentId: retryAgentId });
     requireManager(second);

--- a/extensions/memory-core/src/memory/search-manager.ts
+++ b/extensions/memory-core/src/memory/search-manager.ts
@@ -348,6 +348,7 @@ class BorrowedMemoryManager implements MemorySearchManager {
       qmdSearchModeOverride?: "query" | "search" | "vsearch";
       onDebug?: (debug: MemorySearchRuntimeDebug) => void;
       sources?: MemorySource[];
+      signal?: AbortSignal;
     },
   ) {
     return await this.inner.search(query, opts);

--- a/extensions/memory-core/src/tools.test.ts
+++ b/extensions/memory-core/src/tools.test.ts
@@ -188,6 +188,35 @@ describe("memory_search unavailable payloads", () => {
     }
   });
 
+  it("keeps the timeout result when an abort-aware search rejects on abort", async () => {
+    vi.useFakeTimers();
+    try {
+      setMemorySearchImpl(
+        async (opts) =>
+          await new Promise((_resolve, reject) => {
+            opts?.signal?.addEventListener(
+              "abort",
+              () => reject(new Error("openai-compatible embeddings query failed: aborted")),
+              { once: true },
+            );
+          }),
+      );
+      const tool = createMemorySearchToolOrThrow();
+
+      const resultPromise = tool.execute("abort-aware-timeout", { query: "hello" });
+      await vi.advanceTimersByTimeAsync(15_000);
+
+      const result = await resultPromise;
+      expectUnavailableMemorySearchDetails(result.details, {
+        error: "memory_search timed out after 15s",
+        warning: "Memory search is unavailable due to an embedding/provider error.",
+        action: "Check embedding provider configuration and retry memory_search.",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("re-resolves the manager once when a cached sqlite handle was closed", async () => {
     let searchCalls = 0;
     setMemorySearchImpl(async () => {

--- a/extensions/memory-core/src/tools.test.ts
+++ b/extensions/memory-core/src/tools.test.ts
@@ -157,8 +157,10 @@ describe("memory_search unavailable payloads", () => {
     vi.useFakeTimers();
     try {
       let searchCalls = 0;
-      setMemorySearchImpl(async () => {
+      let searchSignal: AbortSignal | undefined;
+      setMemorySearchImpl(async (opts) => {
         searchCalls += 1;
+        searchSignal = opts?.signal;
         return await new Promise(() => {});
       });
       const tool = createMemorySearchToolOrThrow();
@@ -172,6 +174,8 @@ describe("memory_search unavailable payloads", () => {
         warning: "Memory search is unavailable due to an embedding/provider error.",
         action: "Check embedding provider configuration and retry memory_search.",
       });
+      // The deadline must abort the orphaned search, not just race past it.
+      expect(searchSignal?.aborted).toBe(true);
       const cooldownResult = await tool.execute("search-cooldown", { query: "hello again" });
       expectUnavailableMemorySearchDetails(cooldownResult.details, {
         error: "memory_search timed out after 15s",

--- a/extensions/memory-core/src/tools.ts
+++ b/extensions/memory-core/src/tools.ts
@@ -83,14 +83,23 @@ export const testing = {
 
 async function runMemorySearchToolWithDeadline<T>(params: {
   timeoutMs: number;
-  run: () => Promise<T>;
+  run: (signal: AbortSignal) => Promise<T>;
 }): Promise<{ status: "ok"; value: T } | { status: "unavailable"; error: string }> {
+  const timeoutError = () =>
+    new Error(`memory_search timed out after ${Math.round(params.timeoutMs / 1000)}s`);
+  // Abort the losing task when the deadline fires so in-flight embedding work
+  // is cancelled instead of retrying orphaned for minutes after the tool
+  // already returned "timed out" to the agent.
+  const controller = new AbortController();
   let timer: ReturnType<typeof setTimeout> | undefined;
   const timeoutPromise = new Promise<"timeout">((resolve) => {
-    timer = setTimeout(() => resolve("timeout"), params.timeoutMs);
+    timer = setTimeout(() => {
+      controller.abort(timeoutError());
+      resolve("timeout");
+    }, params.timeoutMs);
     timer.unref?.();
   });
-  const task = params.run();
+  const task = params.run(controller.signal);
   task.catch(() => undefined);
 
   try {
@@ -98,7 +107,7 @@ async function runMemorySearchToolWithDeadline<T>(params: {
     if (result === "timeout") {
       return {
         status: "unavailable",
-        error: `memory_search timed out after ${Math.round(params.timeoutMs / 1000)}s`,
+        error: timeoutError().message,
       };
     }
     return { status: "ok", value: result as T };
@@ -382,7 +391,7 @@ export function createMemorySearchTool(options: {
 
         const outcome = await runMemorySearchToolWithDeadline({
           timeoutMs: MEMORY_SEARCH_TOOL_TIMEOUT_MS,
-          run: async () => {
+          run: async (deadlineSignal) => {
             const { resolveMemoryBackendConfig } = await loadMemoryToolRuntime();
             const shouldQuerySupplements = requestedCorpus === "wiki" || requestedCorpus === "all";
             const shouldQueryMemory = requestedCorpus !== "wiki" && !cooldown;
@@ -454,6 +463,7 @@ export function createMemorySearchTool(options: {
                   minScore,
                   sessionKey: options.agentSessionKey,
                   qmdSearchModeOverride,
+                  signal: deadlineSignal,
                   onDebug: (debug: MemorySearchRuntimeDebug) => {
                     runtimeDebug.push(debug);
                   },

--- a/extensions/memory-core/src/tools.ts
+++ b/extensions/memory-core/src/tools.ts
@@ -451,7 +451,6 @@ export function createMemorySearchTool(options: {
               await runUnavailablePhase("memory", async () => {
                 let activeMemory = memory;
                 const runtimeDebug: MemorySearchRuntimeDebug[] = [];
-                const resolvedMemoryBackend = resolveMemoryBackendConfig({ cfg, agentId });
                 const qmdSearchModeOverride = resolveActiveMemoryQmdSearchModeOverride(
                   cfg,
                   options.agentSessionKey,
@@ -467,9 +466,7 @@ export function createMemorySearchTool(options: {
                   minScore,
                   sessionKey: options.agentSessionKey,
                   qmdSearchModeOverride,
-                  ...(resolvedMemoryBackend.backend === "builtin"
-                    ? { signal: deadlineSignal }
-                    : {}),
+                  signal: deadlineSignal,
                   onDebug: (debug: MemorySearchRuntimeDebug) => {
                     runtimeDebug.push(debug);
                   },

--- a/extensions/memory-core/src/tools.ts
+++ b/extensions/memory-core/src/tools.ts
@@ -94,8 +94,11 @@ async function runMemorySearchToolWithDeadline<T>(params: {
   let timer: ReturnType<typeof setTimeout> | undefined;
   const timeoutPromise = new Promise<"timeout">((resolve) => {
     timer = setTimeout(() => {
-      controller.abort(timeoutError());
+      // Resolve before aborting: abort listeners run synchronously and an
+      // abort-aware search could reject the task first, replacing the stable
+      // timeout result with a provider-wrapped abort error.
       resolve("timeout");
+      controller.abort(timeoutError());
     }, params.timeoutMs);
     timer.unref?.();
   });

--- a/extensions/memory-core/src/tools.ts
+++ b/extensions/memory-core/src/tools.ts
@@ -451,6 +451,7 @@ export function createMemorySearchTool(options: {
               await runUnavailablePhase("memory", async () => {
                 let activeMemory = memory;
                 const runtimeDebug: MemorySearchRuntimeDebug[] = [];
+                const resolvedMemoryBackend = resolveMemoryBackendConfig({ cfg, agentId });
                 const qmdSearchModeOverride = resolveActiveMemoryQmdSearchModeOverride(
                   cfg,
                   options.agentSessionKey,
@@ -466,7 +467,9 @@ export function createMemorySearchTool(options: {
                   minScore,
                   sessionKey: options.agentSessionKey,
                   qmdSearchModeOverride,
-                  signal: deadlineSignal,
+                  ...(resolvedMemoryBackend.backend === "builtin"
+                    ? { signal: deadlineSignal }
+                    : {}),
                   onDebug: (debug: MemorySearchRuntimeDebug) => {
                     runtimeDebug.push(debug);
                   },

--- a/packages/memory-host-sdk/src/host/types.ts
+++ b/packages/memory-host-sdk/src/host/types.ts
@@ -101,6 +101,8 @@ export interface MemorySearchManager {
       qmdSearchModeOverride?: "query" | "search" | "vsearch";
       onDebug?: (debug: MemorySearchRuntimeDebug) => void;
       sources?: MemorySource[];
+      /** Caller-owned cancellation; aborts in-flight embedding work when the caller stops waiting. */
+      signal?: AbortSignal;
     },
   ): Promise<MemorySearchResult[]>;
   readFile(params: { relPath: string; from?: number; lines?: number }): Promise<MemoryReadResult>;

--- a/packages/memory-host-sdk/src/host/types.ts
+++ b/packages/memory-host-sdk/src/host/types.ts
@@ -101,7 +101,7 @@ export interface MemorySearchManager {
       qmdSearchModeOverride?: "query" | "search" | "vsearch";
       onDebug?: (debug: MemorySearchRuntimeDebug) => void;
       sources?: MemorySource[];
-      /** Caller-owned cancellation; aborts in-flight embedding work when the caller stops waiting. */
+      /** Optional caller cancellation; managers consume it where their runtime supports cancellation. */
       signal?: AbortSignal;
     },
   ): Promise<MemorySearchResult[]>;


### PR DESCRIPTION
## Summary

Fixes #91718.

`memory_search` raced its 15s tool deadline with a bare `Promise.race`: the agent got a clean "timed out" result, but the underlying `embedQueryWithRetry` loop kept running orphaned (up to 3 attempts x 60s against the embedding backend) with no consumer for the result, holding HTTP connections to a possibly wedged backend (e.g. Ollama).

This threads a tool-owned `AbortSignal` through the existing seams, keeping the change additive and optional at every contract boundary (no config, no result-shape change):

- `runMemorySearchToolWithDeadline` (`extensions/memory-core/src/tools.ts`) now owns an `AbortController` and aborts it when the deadline fires; the signal is passed into `manager.search(...)` via `searchOptions`.
- `MemorySearchManager.search` opts gain an optional `signal` (`packages/memory-host-sdk/src/host/types.ts`) — additive; the qmd backend may ignore it (its search shells out to the `qmd` subprocess and has its own exit handling; it never enters the builtin embedding retry loop this issue is about).
- `MemoryIndexManager.search` forwards the signal to both `embedQueryWithRetry` call sites and skips fallback-provider activation when the caller already aborted, so an abandoned search stops instead of re-embedding on the fallback provider.
- `embedQueryWithRetry` accepts the signal and merges it with the existing per-call watchdog in `runEmbeddingOperationWithTimeout` via `AbortSignal.any`, so the provider `embedQuery` fetch is actually cancelled.
- `runMemoryEmbeddingRetryLoop` checks the signal before retrying. This check must win over message-pattern matching: abort reasons carry "timed out" text, which matches the retryable transport pattern and would otherwise keep the loop retrying for an absent caller.

## Verification

Live before/after reproduction on a real gateway (details in Real behavior proof below), plus:

- `pnpm test extensions/memory-core/src/tools.test.ts extensions/memory-core/src/tools.citations.test.ts extensions/memory-core/src/memory/manager-embedding-timeout.test.ts extensions/memory-core/src/memory/search-manager.test.ts extensions/memory-core/src/memory/manager-embedding-policy.test.ts` — 5 files, 95 tests passed (the acceptance file set named in the ClawSweeper review, plus the retry-policy file this PR touches).
- `pnpm test extensions/memory-core` — 870 passed; the only 2 failures (`dreaming-shadow-trial.test.ts` date rollover, `manager-sync-ops.startup-catchup.test.ts`) fail identically on unmodified `upstream/main` (verified via `git stash` baseline run) and are unrelated.
- `pnpm tsgo:core`, `pnpm tsgo:extensions`, `pnpm tsgo:extensions:test`, `pnpm tsgo:test:packages` — clean.
- `pnpm format:check` + `node scripts/run-oxlint.mjs` on all touched files — clean.
- `pnpm build` — clean (used for the live runs below).

New regression coverage:

- `tools.test.ts`: the existing 15s-deadline test now asserts the orphaned search's `signal.aborted === true` (fake timers; embedding never settles, advance 15s).
- `manager-embedding-timeout.test.ts`: an external caller signal aborts the provider operation signal before the watchdog fires.
- `manager-embedding-policy.test.ts`: an aborted caller stops the retry loop even when the failure message matches the retryable "timed out" transport pattern.

## Real behavior proof

Behavior addressed: `memory_search` tool timeout orphans the background embedding query — the retry loop and its HTTP request keep running against the embedding backend for minutes after the tool already returned "timed out" to the agent.

Real environment tested: macOS (Darwin 25.5.0), Node, real OpenClaw Gateway built from source (`pnpm build`), isolated `--profile pr91718` state, memory-core builtin backend with `memorySearch.provider: "openai-compatible"` pointed at a local stub `/v1/embeddings` server that answers document/indexing requests instantly and hangs on the query request (simulating the wedged-backend scenario from the issue), `MEMORY.md` indexed via `openclaw memory index`.

Exact steps or command run after this patch:

```
node openclaw.mjs --profile pr91718 gateway run --allow-unconfigured --port 19119
node openclaw.mjs --profile pr91718 gateway call tools.invoke --token <redacted> --timeout 30000 --json \
  --params '{"name":"memory_search","args":{"query":"zebra-orbit-quasar launch codename"}}'
```

Evidence after fix (stub server log; the hanging query's socket is aborted exactly at the 15s tool deadline, and no retries follow for 150s of observation):

```
2026-06-09T18:35:29.490Z REQ#1 POST /v1/embeddings kind=QUERY(hang) 1 input(s), first=zebra-orbit-quasar launch codename
2026-06-09T18:35:44.467Z REQ#1 response stream closed (responded=false)
2026-06-09T18:35:44.467Z REQ#1 SOCKET CLOSED by peer/abort
(no further requests for 150s)
```

Tool response after fix (unchanged contract): `"error": "memory_search timed out after 15s"` returned at +15s.

Before-fix baseline for comparison, same setup on unmodified `main` @ 2da7dc9f2c — the tool returned "timed out after 15s" at 18:29:3x, but the orphaned query held its connection until the 60s provider watchdog and then kept retrying for minutes:

```
2026-06-09T18:29:20.819Z REQ#5 POST /v1/embeddings kind=QUERY(hang) ...   <- query arrives; tool returns at +15s
2026-06-09T18:30:20.821Z REQ#5 SOCKET CLOSED by peer/abort               <- only closed by the 60s provider watchdog
2026-06-09T18:30:21.388Z REQ#6 POST /v1/embeddings kind=QUERY(hang) ...  <- orphaned retry #1, ~46s AFTER the tool returned
2026-06-09T18:31:21.387Z REQ#6 SOCKET CLOSED by peer/abort
2026-06-09T18:31:22.465Z REQ#7 POST /v1/embeddings kind=QUERY(hang) ...  <- orphaned retry #2, ~107s after the tool returned
```

Observed result after fix: the embedding backend connection is released at the 15s deadline (60s -> 15s connection hold), zero orphaned retries (previously 2 more 60s-held requests), agent-facing tool result unchanged.

What was not tested: a real stalled Ollama instance sharing a GPU with other workloads; the wedged backend was simulated by a local HTTP server that accepts and never answers the embeddings request, which exercises the same client-side timeout/retry/abort path.
