### PR TITLE
fix(discord): require sender for moderation actions [AI]

### DIFF
--- a/extensions/discord/src/channel-actions.test.ts
+++ b/extensions/discord/src/channel-actions.test.ts
@@ -141,12 +141,14 @@ describe("discordMessageActions", () => {
   });
 
   it("requires trusted requester sender for privileged guild admin actions only from Discord turns", () => {
-    expect(
-      discordMessageActions.requiresTrustedRequesterSender?.({
-        action: "channel-delete",
-        toolContext: { currentChannelProvider: "discord" },
-      }),
-    ).toBe(true);
+    for (const action of ["channel-delete", "timeout", "kick", "ban"] as const) {
+      expect(
+        discordMessageActions.requiresTrustedRequesterSender?.({
+          action,
+          toolContext: { currentChannelProvider: "discord" },
+        }),
+      ).toBe(true);
+    }
     expect(
       discordMessageActions.requiresTrustedRequesterSender?.({
         action: "channel-delete",

--- a/extensions/discord/src/channel-actions.ts
+++ b/extensions/discord/src/channel-actions.ts
@@ -26,6 +26,9 @@ const trustedRequesterGuildAdminActions = new Set<ChannelMessageActionName>([
   "category-edit",
   "category-delete",
   "event-create",
+  "timeout",
+  "kick",
+  "ban",
 ]);
 
 const localExecutionActions = new Set<ChannelMessageActionName>([


### PR DESCRIPTION
## Summary

Discord moderation actions now use the existing trusted requester sender guard in tool-driven Discord contexts.

## Changes

- Add `timeout`, `kick`, and `ban` to the Discord trusted requester sender action set.
- Extend the Discord channel action regression test to cover those moderation actions while preserving the existing non-Discord and unprivileged-action behavior.

## Validation

Behavior addressed: tool-driven Discord moderation actions require trusted requester sender metadata before entering the Discord action runtime.

Real environment tested: local OpenClaw checkout on branch `725` after rebasing onto current `upstream/main`.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs extensions/discord/src/channel-actions.test.ts src/channels/plugins/message-actions.security.test.ts`

Evidence after fix: the focused Vitest wrapper passed 2 shards: `extensions/discord/src/channel-actions.test.ts` (28 tests) and `src/channels/plugins/message-actions.security.test.ts` (3 tests).

Observed result after fix: Discord `channel-delete`, `timeout`, `kick`, and `ban` return `true` from `requiresTrustedRequesterSender` for Discord tool contexts; non-Discord contexts and `read` remain unchanged.

What was not tested: live Discord moderation against a real server; no live Discord credentials were used.

Additional checks:

- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

## Notes

- No config, API, migration, or changelog changes.
- `USER.md` was updated locally with the requested worklog and intentionally left out of the commit.
- AI-assisted by Codex.
