### PR TITLE
fix(elevated): reject group ids as senders

### DIFF
--- a/src/auto-reply/command-auth.ts
+++ b/src/auto-reply/command-auth.ts
@@ -1,6 +1,5 @@
 /** Command authorization helpers for owner and allowlist checks. */
 import {
-  normalizeLowercaseStringOrEmpty,
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
@@ -19,6 +18,7 @@ import {
   normalizeMessageChannel,
 } from "../utils/message-channel.js";
 import { isNativeCommandTurn, resolveCommandTurnContext } from "./command-turn-context.js";
+import { shouldUseFromAsSenderFallback } from "./sender-identity.js";
 import type { MsgContext } from "./templating.js";
 
 export type CommandAuthorization = {
@@ -459,32 +459,6 @@ function resolveCommandSenderAuthorization(params: {
     );
   }
   return params.commandAuthorized && (params.isOwnerForCommands || params.nativeCommandAuthorized);
-}
-
-function isConversationLikeIdentity(value: string): boolean {
-  const normalized = normalizeOptionalLowercaseString(value);
-  if (!normalized) {
-    return false;
-  }
-  if (normalized.startsWith("chat_id:")) {
-    return true;
-  }
-  return /(^|:)(channel|group|thread|topic|room|space|spaces):/.test(normalized);
-}
-
-function shouldUseFromAsSenderFallback(params: {
-  from?: string | null;
-  chatType?: string | null;
-}): boolean {
-  const from = normalizeOptionalString(params.from) ?? "";
-  if (!from) {
-    return false;
-  }
-  const chatType = normalizeLowercaseStringOrEmpty(params.chatType);
-  if (chatType && chatType !== "direct") {
-    return false;
-  }
-  return !isConversationLikeIdentity(from);
 }
 
 function resolveSenderCandidates(params: {

--- a/src/auto-reply/reply/reply-elevated.test.ts
+++ b/src/auto-reply/reply/reply-elevated.test.ts
@@ -83,19 +83,6 @@ describe("resolveElevatedPermissions", () => {
     });
   });
 
-  it("does not authorize a group conversation id when ChatType is missing", () => {
-    expectAllowFromDecision({
-      allowFrom: ["120363411111111111@g.us", "from:120363411111111111@g.us"],
-      allowed: false,
-      ctx: {
-        ChatType: undefined,
-        From: "120363411111111111@g.us",
-        SenderId: "+15550002222",
-        SenderE164: "+15550002222",
-      },
-    });
-  });
-
   it("keeps direct chat From fallback authorization", () => {
     expectAllowFromDecision({
       allowFrom: ["from:whatsapp:+15550001111"],

--- a/src/auto-reply/reply/reply-elevated.test.ts
+++ b/src/auto-reply/reply/reply-elevated.test.ts
@@ -70,6 +70,45 @@ describe("resolveElevatedPermissions", () => {
     });
   });
 
+  it("does not authorize a group conversation id as a sender identity", () => {
+    expectAllowFromDecision({
+      allowFrom: ["120363411111111111@g.us", "from:120363411111111111@g.us"],
+      allowed: false,
+      ctx: {
+        ChatType: "group",
+        From: "120363411111111111@g.us",
+        SenderId: "+15550002222",
+        SenderE164: "+15550002222",
+      },
+    });
+  });
+
+  it("does not authorize a group conversation id when ChatType is missing", () => {
+    expectAllowFromDecision({
+      allowFrom: ["120363411111111111@g.us", "from:120363411111111111@g.us"],
+      allowed: false,
+      ctx: {
+        ChatType: undefined,
+        From: "120363411111111111@g.us",
+        SenderId: "+15550002222",
+        SenderE164: "+15550002222",
+      },
+    });
+  });
+
+  it("keeps direct chat From fallback authorization", () => {
+    expectAllowFromDecision({
+      allowFrom: ["from:whatsapp:+15550001111"],
+      allowed: true,
+      ctx: {
+        ChatType: "direct",
+        From: "whatsapp:+15550001111",
+        SenderId: undefined,
+        SenderE164: undefined,
+      },
+    });
+  });
+
   it("does not authorize untyped mutable sender fields", () => {
     expectAllowFromDecision({
       allowFrom: ["owner-display-name"],

--- a/src/auto-reply/reply/reply-elevated.ts
+++ b/src/auto-reply/reply/reply-elevated.ts
@@ -4,6 +4,7 @@ import { normalizeStringEntries } from "@openclaw/normalization-core/string-norm
 import { resolveAgentConfig } from "../../agents/agent-scope.js";
 import { getChannelPlugin, normalizeChannelId } from "../../channels/plugins/index.js";
 import type { AgentElevatedAllowFromConfig, OpenClawConfig } from "../../config/config.js";
+import { shouldUseFromAsSenderFallback } from "../sender-identity.js";
 import type { MsgContext } from "../templating.js";
 import {
   type AllowFromFormatter,
@@ -94,7 +95,10 @@ function isApprovedElevatedSender(params: {
       tokens: senderIdTokens,
     });
   }
-  if (senderFrom) {
+  if (
+    senderFrom &&
+    shouldUseFromAsSenderFallback({ from: senderFrom, chatType: params.ctx.ChatType })
+  ) {
     addFormattedTokens({
       formatAllowFrom: params.formatAllowFrom,
       values: [senderFrom, stripSenderPrefix(senderFrom)].filter((value): value is string =>

--- a/src/auto-reply/sender-identity.ts
+++ b/src/auto-reply/sender-identity.ts
@@ -13,9 +13,6 @@ function isConversationLikeIdentity(value: string): boolean {
   if (normalized.startsWith("chat_id:")) {
     return true;
   }
-  if (/(^|:)[0-9]+(?:-[0-9]+)*@g\.us$/.test(normalized)) {
-    return true;
-  }
   return /(^|:)(channel|group|thread|topic|room|space|spaces):/.test(normalized);
 }
 

--- a/src/auto-reply/sender-identity.ts
+++ b/src/auto-reply/sender-identity.ts
@@ -1,0 +1,35 @@
+/** Shared sender identity helpers for authorization checks. */
+import {
+  normalizeLowercaseStringOrEmpty,
+  normalizeOptionalLowercaseString,
+  normalizeOptionalString,
+} from "@openclaw/normalization-core/string-coerce";
+
+function isConversationLikeIdentity(value: string): boolean {
+  const normalized = normalizeOptionalLowercaseString(value);
+  if (!normalized) {
+    return false;
+  }
+  if (normalized.startsWith("chat_id:")) {
+    return true;
+  }
+  if (/(^|:)[0-9]+(?:-[0-9]+)*@g\.us$/.test(normalized)) {
+    return true;
+  }
+  return /(^|:)(channel|group|thread|topic|room|space|spaces):/.test(normalized);
+}
+
+export function shouldUseFromAsSenderFallback(params: {
+  from?: string | null;
+  chatType?: string | null;
+}): boolean {
+  const from = normalizeOptionalString(params.from) ?? "";
+  if (!from) {
+    return false;
+  }
+  const chatType = normalizeLowercaseStringOrEmpty(params.chatType);
+  if (chatType && chatType !== "direct") {
+    return false;
+  }
+  return !isConversationLikeIdentity(from);
+}


### PR DESCRIPTION
## Summary

Tighten elevated allowlist sender matching so shared conversation identifiers are not treated as sender identities.

## Changes

- Extract the existing `From` sender-fallback guard into `src/auto-reply/sender-identity.ts`.
- Reuse that guard in elevated allowlist matching before adding `ctx.From` tokens.
- Add regression coverage for group conversation IDs, missing chat type, and direct-chat `from:` fallback behavior.

## Validation

- `node scripts/run-vitest.mjs src/auto-reply/reply/reply-elevated.test.ts src/auto-reply/command-auth.owner-default.test.ts`
- `node --import tsx --input-type=module` source-level elevated allowlist proof for group and missing-chat-type contexts
- `corepack pnpm exec oxfmt --check --threads=1 src/auto-reply/sender-identity.ts src/auto-reply/command-auth.ts src/auto-reply/reply/reply-elevated.ts src/auto-reply/reply/reply-elevated.test.ts`
- `corepack pnpm tsgo:core`
- `.agents/skills/autoreview/scripts/autoreview --mode local` clean after one accepted finding was fixed

## Notes

AI-assisted by Codex. `CHANGELOG.md` was not updated.

Real behavior proof:
Behavior addressed: elevated allowlist matching no longer treats group conversation IDs as sender identities.
Real environment tested: local OpenClaw source checkout on branch `743` after dependency hydration with `corepack pnpm install --frozen-lockfile`.
Exact steps or command run after this patch: targeted Vitest, source-level `resolveElevatedPermissions` proof, formatter check, core tsgo, and autoreview commands listed above.
Evidence after fix: group and missing-chat-type source-level checks returned `allowed:false` with `tools.elevated.allowFrom.whatsapp` failure.
Observed result after fix: direct-chat `from:` fallback remains allowed, while group conversation ID allowlist entries are rejected.
What was not tested: live WhatsApp device traffic.
