### PR TITLE
fix(gateway): restrict non-owner loopback tools

### DIFF
--- a/src/gateway/mcp-http.runtime.ts
+++ b/src/gateway/mcp-http.runtime.ts
@@ -70,7 +70,11 @@ export class McpLoopbackToolCache {
       params.accountId ?? "",
       params.inboundEventKind ?? "",
       params.sourceReplyDeliveryMode ?? "",
-      params.senderIsOwner === true ? "owner" : "non-owner",
+      params.senderIsOwner === true
+        ? "owner"
+        : params.senderIsOwner === false
+          ? "non-owner"
+          : "unknown-owner",
     ].join("\u0000");
     const now = Date.now();
     for (const [key, entry] of this.#entries) {

--- a/src/gateway/mcp-http.test.ts
+++ b/src/gateway/mcp-http.test.ts
@@ -738,6 +738,45 @@ describe("mcp loopback server", () => {
     expect(getScopedToolsCall(3).currentInboundAudio).toBe(true);
   });
 
+  it("keeps explicit non-owner and unknown-owner loopback cache entries separate", () => {
+    const cache = new McpLoopbackToolCache();
+    const baseParams = {
+      accountId: undefined,
+      cfg: { session: { mainKey: "main" } } as never,
+      currentChannelId: "telegram:chat123",
+      currentInboundAudio: undefined,
+      currentMessageId: "message-1",
+      currentThreadTs: "thread-1",
+      inboundEventKind: "room_event",
+      messageProvider: "telegram",
+      sessionKey: "agent:main:telegram:group:chat123",
+      sourceReplyDeliveryMode: "message_tool_only",
+    } satisfies Omit<Parameters<McpLoopbackToolCache["resolve"]>[0], "senderIsOwner">;
+    resolveGatewayScopedToolsMock.mockImplementation((input: unknown) => {
+      const params = input as { senderIsOwner?: boolean };
+      return {
+        agentId: "main",
+        tools:
+          params.senderIsOwner === false
+            ? [makeMessageTool()]
+            : [makeMessageTool(), makeCronTool()],
+      };
+    });
+
+    const unknownFirst = cache.resolve({ ...baseParams, senderIsOwner: undefined });
+    const nonOwnerSecond = cache.resolve({ ...baseParams, senderIsOwner: false });
+    expect(unknownFirst.toolSchema.map((tool) => tool.name)).toContain("cron");
+    expect(nonOwnerSecond.toolSchema.map((tool) => tool.name)).not.toContain("cron");
+
+    const secondCache = new McpLoopbackToolCache();
+    const nonOwnerFirst = secondCache.resolve({ ...baseParams, senderIsOwner: false });
+    const unknownSecond = secondCache.resolve({ ...baseParams, senderIsOwner: undefined });
+    expect(nonOwnerFirst.toolSchema.map((tool) => tool.name)).not.toContain("cron");
+    expect(unknownSecond.toolSchema.map((tool) => tool.name)).toContain("cron");
+
+    expect(resolveGatewayScopedToolsMock).toHaveBeenCalledTimes(4);
+  });
+
   it("caps loopback tool cache cardinality by evicting oldest contexts", () => {
     const cache = new McpLoopbackToolCache();
     const baseParams = {

--- a/src/gateway/tool-resolution.exclude.test.ts
+++ b/src/gateway/tool-resolution.exclude.test.ts
@@ -23,6 +23,24 @@ const hoisted = vi.hoisted(() => ({
       parameters: { type: "object", properties: {} },
       execute: vi.fn(),
     },
+    {
+      name: "cron",
+      description: "Manage schedules",
+      parameters: { type: "object", properties: {} },
+      execute: vi.fn(),
+    },
+    {
+      name: "gateway",
+      description: "Manage gateway",
+      parameters: { type: "object", properties: {} },
+      execute: vi.fn(),
+    },
+    {
+      name: "nodes",
+      description: "Manage nodes",
+      parameters: { type: "object", properties: {} },
+      execute: vi.fn(),
+    },
   ]),
 }));
 
@@ -59,10 +77,31 @@ describe("resolveGatewayScopedTools excludeToolNames", () => {
       excludeToolNames: ["read", "apply_patch"],
     });
 
-    expect(result.tools.map((tool) => tool.name)).toEqual(["sessions_spawn"]);
+    expect(result.tools.map((tool) => tool.name)).toEqual([
+      "sessions_spawn",
+      "cron",
+      "gateway",
+      "nodes",
+    ]);
     const args = readCreateToolsArgs();
     expect(args.pluginToolDenylist).toEqual([]);
     expect(args.inheritedToolDenylist).toEqual([]);
+  });
+
+  it("filters owner-only core tools from non-owner loopback callers", () => {
+    const result = resolveGatewayScopedTools({
+      cfg: {
+        gateway: { tools: { allow: ["gateway"] } },
+      } as OpenClawConfig,
+      sessionKey: "agent:main:direct:test",
+      surface: "loopback",
+      senderIsOwner: false,
+    });
+
+    expect(result.tools.map((tool) => tool.name)).toEqual(["read", "sessions_spawn"]);
+    const args = readCreateToolsArgs();
+    expect(args.pluginToolDenylist).toEqual(["cron", "gateway", "nodes"]);
+    expect(args.inheritedToolDenylist).toEqual(["cron", "gateway", "nodes"]);
   });
 
   it("keeps real gateway deny policy inheritable while excluding native dedup tools", () => {

--- a/src/gateway/tool-resolution.ts
+++ b/src/gateway/tool-resolution.ts
@@ -31,7 +31,7 @@ import { logWarn } from "../logger.js";
 import { getPluginToolMeta } from "../plugins/tools.js";
 import {
   DEFAULT_GATEWAY_HTTP_TOOL_DENY,
-  GATEWAY_HTTP_OWNER_ONLY_CORE_TOOLS,
+  GATEWAY_OWNER_ONLY_CORE_TOOLS,
 } from "../security/dangerous-tools.js";
 
 type GatewayScopedToolSurface = "http" | "loopback";
@@ -117,10 +117,10 @@ export function resolveGatewayScopedTools(params: {
       ? DEFAULT_GATEWAY_HTTP_TOOL_DENY.filter((name) => !gatewayToolsCfg?.allow?.includes(name))
       : [];
   const ownerOnlyGatewayDeny =
-    surface === "http" && params.senderIsOwner !== true
-      ? [...GATEWAY_HTTP_OWNER_ONLY_CORE_TOOLS]
+    params.senderIsOwner === false || (surface === "http" && params.senderIsOwner !== true)
+      ? [...GATEWAY_OWNER_ONLY_CORE_TOOLS]
       : [];
-  // HTTP callers start with a stricter denylist than loopback callers because they cross auth only.
+  // HTTP callers start with additional surface denies because they cross auth only.
   const workspaceDir = resolveAgentWorkspaceDir(
     params.cfg,
     agentId ?? resolveDefaultAgentId(params.cfg),

--- a/src/security/dangerous-tools.ts
+++ b/src/security/dangerous-tools.ts
@@ -34,8 +34,8 @@ export const DEFAULT_GATEWAY_HTTP_TOOL_DENY = [
 ] as const;
 
 /**
- * Core tools that require sender owner identity on Gateway HTTP `POST /tools/invoke`.
+ * Core tools that require sender owner identity on Gateway-scoped surfaces.
  * `gateway.tools.allow` can remove the default HTTP deny only for owner/trusted-operator
  * callers; non-owner identity-bearing callers must not receive server-credential wrappers.
  */
-export const GATEWAY_HTTP_OWNER_ONLY_CORE_TOOLS = ["cron", "gateway", "nodes"] as const;
+export const GATEWAY_OWNER_ONLY_CORE_TOOLS = ["cron", "gateway", "nodes"] as const;


### PR DESCRIPTION
Summary
- Restricts owner-only gateway core tools from explicit non-owner MCP loopback callers.
- Preserves existing owner loopback access and the conservative HTTP non-owner default.

Changes
- Applies the owner-only tool denylist when loopback resolution receives `senderIsOwner: false`.
- Renames the shared owner-only core tool constant so it is no longer HTTP-specific.
- Adds regression coverage for non-owner loopback filtering while preserving omitted loopback owner-state behavior.

Validation
- `node scripts/run-vitest.mjs src/gateway/tool-resolution.exclude.test.ts src/gateway/tool-resolution.test.ts src/gateway/mcp-http.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

Real behavior proof
Behavior addressed: explicit non-owner loopback tool resolution no longer returns owner-only gateway core tools.
Real environment tested: local OpenClaw checkout on branch `742`.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/gateway/tool-resolution.exclude.test.ts src/gateway/tool-resolution.test.ts src/gateway/mcp-http.test.ts`.
Evidence after fix: focused gateway Vitest shard passed with 12 files and 196 tests.
Observed result after fix: non-owner loopback filtering is covered by regression tests; owner/omitted loopback behavior and MCP HTTP tests still pass.
What was not tested: live external channel traffic.

Notes
- No `CHANGELOG.md` update.
- `USER.md` worklog was updated locally and intentionally not committed.
- Agent transcript omitted because adding sanitized logs requires explicit approval.
