### PR TITLE
fix(search): enforce native web search tool policy

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-ae06e87a060aaa9618e2b245553d90402c0fbbe1ebc864928dc7f771cede7c6d  plugin-sdk-api-baseline.json
-8ae4665726d0a8e2e80587ab0b98afce6718861a996daef2fac207066c29dd4f  plugin-sdk-api-baseline.jsonl
+b15dd03c86dcd1d069c6987f2e158aeaa5d32611dac9eb640b8b1d7e2c6a560e  plugin-sdk-api-baseline.json
+1e184dcbe980490f42bad6f44b4ce5a26b597e1c137fc00433031847829d5c3f  plugin-sdk-api-baseline.jsonl

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-b15dd03c86dcd1d069c6987f2e158aeaa5d32611dac9eb640b8b1d7e2c6a560e  plugin-sdk-api-baseline.json
-1e184dcbe980490f42bad6f44b4ce5a26b597e1c137fc00433031847829d5c3f  plugin-sdk-api-baseline.jsonl
+424f72310250c242a3157994c45f7319370c1bf99014a13ee5f86cc811f43dd4  plugin-sdk-api-baseline.json
+87e786df92be36c22a7b392162c9fa39b634094d15aec4736d8b65be8d7cfd9c  plugin-sdk-api-baseline.jsonl

--- a/extensions/openai/native-web-search.ts
+++ b/extensions/openai/native-web-search.ts
@@ -3,9 +3,14 @@ import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { streamSimple } from "openclaw/plugin-sdk/llm";
 import { normalizeProviderId } from "openclaw/plugin-sdk/provider-model-shared";
+import { isProviderNativeWebSearchAllowedByToolPolicy } from "openclaw/plugin-sdk/provider-stream-family";
 import { streamWithPayloadPatch } from "openclaw/plugin-sdk/provider-stream-shared";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { isOpenAIApiBaseUrl } from "./base-url.js";
+
+type NativeWebSearchPolicyContext = Parameters<
+  typeof isProviderNativeWebSearchAllowedByToolPolicy
+>[0]["nativeWebSearchPolicyContext"];
 
 const OPENAI_WEB_SEARCH_TOOL = { type: "web_search" } as const;
 
@@ -87,11 +92,25 @@ export function patchOpenAINativeWebSearchPayload(
 
 export function createOpenAINativeWebSearchWrapper(
   baseStreamFn: StreamFn | undefined,
-  params: { config?: OpenClawConfig },
+  params: {
+    config?: OpenClawConfig;
+    agentId?: string;
+    nativeWebSearchPolicyContext?: NativeWebSearchPolicyContext;
+  },
 ): StreamFn {
   const underlying = baseStreamFn ?? streamSimple;
   return (model, context, options) => {
     if (!shouldEnableOpenAINativeWebSearch({ config: params.config, model })) {
+      return underlying(model, context, options);
+    }
+    if (
+      !isProviderNativeWebSearchAllowedByToolPolicy({
+        config: params.config,
+        model,
+        agentId: params.agentId,
+        nativeWebSearchPolicyContext: params.nativeWebSearchPolicyContext,
+      })
+    ) {
       return underlying(model, context, options);
     }
     return streamWithPayloadPatch(underlying, model, context, options, (payload) => {

--- a/extensions/openai/native-web-search.ts
+++ b/extensions/openai/native-web-search.ts
@@ -3,14 +3,9 @@ import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { streamSimple } from "openclaw/plugin-sdk/llm";
 import { normalizeProviderId } from "openclaw/plugin-sdk/provider-model-shared";
-import { isProviderNativeWebSearchAllowedByToolPolicy } from "openclaw/plugin-sdk/provider-stream-family";
 import { streamWithPayloadPatch } from "openclaw/plugin-sdk/provider-stream-shared";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { isOpenAIApiBaseUrl } from "./base-url.js";
-
-type NativeWebSearchPolicyContext = Parameters<
-  typeof isProviderNativeWebSearchAllowedByToolPolicy
->[0]["nativeWebSearchPolicyContext"];
 
 const OPENAI_WEB_SEARCH_TOOL = { type: "web_search" } as const;
 
@@ -95,7 +90,7 @@ export function createOpenAINativeWebSearchWrapper(
   params: {
     config?: OpenClawConfig;
     agentId?: string;
-    nativeWebSearchPolicyContext?: NativeWebSearchPolicyContext;
+    nativeWebSearchAllowedByToolPolicy?: boolean;
   },
 ): StreamFn {
   const underlying = baseStreamFn ?? streamSimple;
@@ -103,14 +98,7 @@ export function createOpenAINativeWebSearchWrapper(
     if (!shouldEnableOpenAINativeWebSearch({ config: params.config, model })) {
       return underlying(model, context, options);
     }
-    if (
-      !isProviderNativeWebSearchAllowedByToolPolicy({
-        config: params.config,
-        model,
-        agentId: params.agentId,
-        nativeWebSearchPolicyContext: params.nativeWebSearchPolicyContext,
-      })
-    ) {
+    if (params.nativeWebSearchAllowedByToolPolicy === false) {
       return underlying(model, context, options);
     }
     return streamWithPayloadPatch(underlying, model, context, options, (payload) => {

--- a/extensions/openai/openai-provider.test.ts
+++ b/extensions/openai/openai-provider.test.ts
@@ -82,7 +82,7 @@ function runWrappedPayloadCase(params: {
   extraParams?: Record<string, unknown>;
   cfg?: Record<string, unknown>;
   agentId?: string;
-  nativeWebSearchPolicyContext?: unknown;
+  nativeWebSearchAllowedByToolPolicy?: boolean;
   payload?: Record<string, unknown>;
 }) {
   const payload = params.payload ?? { store: false };
@@ -100,7 +100,7 @@ function runWrappedPayloadCase(params: {
     config: params.cfg as never,
     agentDir: "/tmp/openai-provider-test",
     agentId: params.agentId,
-    nativeWebSearchPolicyContext: params.nativeWebSearchPolicyContext,
+    nativeWebSearchAllowedByToolPolicy: params.nativeWebSearchAllowedByToolPolicy,
     streamFn: baseStreamFn,
   } as never);
 
@@ -1236,6 +1236,7 @@ describe("buildOpenAIProvider", () => {
       provider: "openai",
       modelId: "gpt-5.4",
       agentId: "main",
+      nativeWebSearchAllowedByToolPolicy: false,
       cfg: {
         agents: {
           list: [

--- a/extensions/openai/openai-provider.test.ts
+++ b/extensions/openai/openai-provider.test.ts
@@ -54,6 +54,7 @@ vi.mock("openclaw/plugin-sdk/provider-stream-family", async (importOriginal) => 
     nextStreamFn = actual.createCodexNativeWebSearchWrapper(nextStreamFn, {
       config: ctx.config,
       agentDir: ctx.agentDir,
+      agentId: ctx.agentId,
     });
     return actual.createOpenAIResponsesContextManagementWrapper(
       actual.createOpenAIReasoningCompatibilityWrapper(nextStreamFn),

--- a/extensions/openai/openai-provider.test.ts
+++ b/extensions/openai/openai-provider.test.ts
@@ -81,6 +81,8 @@ function runWrappedPayloadCase(params: {
     | Model<"azure-openai-responses">;
   extraParams?: Record<string, unknown>;
   cfg?: Record<string, unknown>;
+  agentId?: string;
+  nativeWebSearchPolicyContext?: unknown;
   payload?: Record<string, unknown>;
 }) {
   const payload = params.payload ?? { store: false };
@@ -97,6 +99,8 @@ function runWrappedPayloadCase(params: {
     extraParams: params.extraParams,
     config: params.cfg as never,
     agentDir: "/tmp/openai-provider-test",
+    agentId: params.agentId,
+    nativeWebSearchPolicyContext: params.nativeWebSearchPolicyContext,
     streamFn: baseStreamFn,
   } as never);
 
@@ -1216,6 +1220,49 @@ describe("buildOpenAIProvider", () => {
     expect(result.payload.tools).toEqual([
       { type: "function", name: "read" },
       { type: "web_search" },
+    ]);
+  });
+
+  it("keeps managed OpenAI web_search when agent policy denies native web search", () => {
+    const provider = buildOpenAIProvider();
+    const wrap = provider.wrapStreamFn;
+    expect(wrap).toBeTypeOf("function");
+    if (!wrap) {
+      throw new Error("expected OpenAI wrapper");
+    }
+
+    const result = runWrappedPayloadCase({
+      wrap,
+      provider: "openai",
+      modelId: "gpt-5.4",
+      agentId: "main",
+      cfg: {
+        agents: {
+          list: [
+            {
+              id: "main",
+              tools: { deny: ["web_search"] },
+            },
+          ],
+        },
+      },
+      model: {
+        api: "openai-responses",
+        provider: "openai",
+        id: "gpt-5.4",
+        baseUrl: "https://api.openai.com/v1",
+      } as Model<"openai-responses">,
+      payload: {
+        tools: [
+          { type: "function", name: "read" },
+          { type: "function", name: "web_search" },
+        ],
+      },
+    });
+
+    expect(result.payload.tools).toEqual([
+      { type: "function", name: "read" },
+      { type: "function", name: "web_search" },
     ]);
   });
 

--- a/extensions/openai/shared.ts
+++ b/extensions/openai/shared.ts
@@ -88,6 +88,8 @@ const wrapOpenAIResponsesProviderStreamFn: NonNullable<
 > = (ctx) =>
   createOpenAINativeWebSearchWrapper(wrapOpenAIResponsesStreamFn?.(ctx) ?? ctx.streamFn, {
     config: ctx.config,
+    agentId: ctx.agentId,
+    nativeWebSearchPolicyContext: ctx.nativeWebSearchPolicyContext,
   });
 
 export function buildOpenAIResponsesProviderHooks(options?: {

--- a/extensions/openai/shared.ts
+++ b/extensions/openai/shared.ts
@@ -89,7 +89,7 @@ const wrapOpenAIResponsesProviderStreamFn: NonNullable<
   createOpenAINativeWebSearchWrapper(wrapOpenAIResponsesStreamFn?.(ctx) ?? ctx.streamFn, {
     config: ctx.config,
     agentId: ctx.agentId,
-    nativeWebSearchPolicyContext: ctx.nativeWebSearchPolicyContext,
+    nativeWebSearchAllowedByToolPolicy: ctx.nativeWebSearchAllowedByToolPolicy,
   });
 
 export function buildOpenAIResponsesProviderHooks(options?: {

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -285,6 +285,9 @@ function applyModelProviderToolPolicy(
       config: params?.config,
       modelProvider: params?.modelProvider,
       modelApi: params?.modelApi,
+      modelId: params?.modelId,
+      agentId: params?.agentId,
+      sessionKey: params?.sessionKey,
       agentDir: params?.agentDir,
     })
   ) {

--- a/src/agents/codex-native-web-search-core.ts
+++ b/src/agents/codex-native-web-search-core.ts
@@ -45,6 +45,25 @@ type CodexNativeSearchPayloadPatchResult = {
   status: "payload_not_object" | "native_tool_already_present" | "injected";
 };
 
+export type NativeWebSearchToolPolicyParams = {
+  config?: OpenClawConfig;
+  modelProvider?: string;
+  modelId?: string;
+  agentId?: string;
+  sessionKey?: string;
+  sandboxToolPolicy?: SandboxToolPolicy;
+  messageProvider?: string;
+  agentAccountId?: string | null;
+  groupId?: string | null;
+  groupChannel?: string | null;
+  groupSpace?: string | null;
+  spawnedBy?: string | null;
+  senderId?: string | null;
+  senderName?: string | null;
+  senderUsername?: string | null;
+  senderE164?: string | null;
+};
+
 const OPENAI_AUTH_PROVIDER_IDS = ["openai"] as const;
 
 function isOpenAIAuthProviderId(provider: string | undefined): boolean {
@@ -182,6 +201,31 @@ export function resolveCodexNativeSearchActivation(params: {
     };
   }
 
+  if (!isNativeWebSearchAllowedByToolPolicy(params)) {
+    return {
+      globalWebSearchEnabled,
+      codexNativeEnabled: true,
+      codexMode: codexConfig.mode,
+      nativeEligible: true,
+      hasRequiredAuth: true,
+      state: "managed_only",
+      inactiveReason: "tool_policy_denied",
+    };
+  }
+
+  return {
+    globalWebSearchEnabled,
+    codexNativeEnabled: true,
+    codexMode: codexConfig.mode,
+    nativeEligible: true,
+    hasRequiredAuth: true,
+    state: "native_active",
+  };
+}
+
+export function isNativeWebSearchAllowedByToolPolicy(
+  params: NativeWebSearchToolPolicyParams,
+): boolean {
   const {
     agentId,
     globalPolicy,
@@ -247,7 +291,7 @@ export function resolveCodexNativeSearchActivation(params: {
       store: subagentStore,
     },
   );
-  const toolPolicyAllowsWebSearch = isToolAllowedByPolicies("web_search", [
+  return isToolAllowedByPolicies("web_search", [
     profilePolicy,
     providerProfilePolicy,
     globalPolicy,
@@ -260,27 +304,6 @@ export function resolveCodexNativeSearchActivation(params: {
     subagentPolicy,
     inheritedToolPolicy,
   ]);
-
-  if (!toolPolicyAllowsWebSearch) {
-    return {
-      globalWebSearchEnabled,
-      codexNativeEnabled: true,
-      codexMode: codexConfig.mode,
-      nativeEligible: true,
-      hasRequiredAuth: true,
-      state: "managed_only",
-      inactiveReason: "tool_policy_denied",
-    };
-  }
-
-  return {
-    globalWebSearchEnabled,
-    codexNativeEnabled: true,
-    codexMode: codexConfig.mode,
-    nativeEligible: true,
-    hasRequiredAuth: true,
-    state: "native_active",
-  };
 }
 
 /** Builds the OpenAI Responses `web_search` tool payload from config. */

--- a/src/agents/codex-native-web-search-core.ts
+++ b/src/agents/codex-native-web-search-core.ts
@@ -4,6 +4,7 @@
  */
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isRecord } from "../utils.js";
+import { isToolAllowedByPolicies, resolveEffectiveToolPolicy } from "./agent-tools.policy.js";
 import { externalCliDiscoveryForProviderAuth } from "./auth-profiles/external-cli-discovery.js";
 import { listProfilesForProvider } from "./auth-profiles/profile-list.js";
 import { ensureAuthProfileStore } from "./auth-profiles/store.js";
@@ -11,6 +12,7 @@ import {
   type CodexNativeSearchMode,
   resolveCodexNativeWebSearchConfig,
 } from "./codex-native-web-search.shared.js";
+import { mergeAlsoAllowPolicy, resolveToolProfilePolicy } from "./tool-policy.js";
 
 type CodexNativeSearchActivation = {
   globalWebSearchEnabled: boolean;
@@ -23,7 +25,8 @@ type CodexNativeSearchActivation = {
     | "globally_disabled"
     | "codex_not_enabled"
     | "model_not_eligible"
-    | "codex_auth_missing";
+    | "codex_auth_missing"
+    | "tool_policy_denied";
 };
 
 type CodexNativeSearchPayloadPatchResult = {
@@ -96,6 +99,9 @@ export function resolveCodexNativeSearchActivation(params: {
   config?: OpenClawConfig;
   modelProvider?: string;
   modelApi?: string;
+  modelId?: string;
+  agentId?: string;
+  sessionKey?: string;
   agentDir?: string;
 }): CodexNativeSearchActivation {
   const globalWebSearchEnabled = params.config?.tools?.web?.search?.enabled !== false;
@@ -105,6 +111,35 @@ export function resolveCodexNativeSearchActivation(params: {
     params.modelApi !== "openai-chatgpt-responses" ||
     !isOpenAIAuthProviderId(params.modelProvider) ||
     hasAvailableCodexAuth(params);
+  const {
+    globalPolicy,
+    globalProviderPolicy,
+    agentPolicy,
+    agentProviderPolicy,
+    profile,
+    providerProfile,
+    profileAlsoAllow,
+    providerProfileAlsoAllow,
+  } = resolveEffectiveToolPolicy({
+    config: params.config,
+    sessionKey: params.sessionKey,
+    agentId: params.agentId,
+    modelProvider: params.modelProvider,
+    modelId: params.modelId,
+  });
+  const profilePolicy = mergeAlsoAllowPolicy(resolveToolProfilePolicy(profile), profileAlsoAllow);
+  const providerProfilePolicy = mergeAlsoAllowPolicy(
+    resolveToolProfilePolicy(providerProfile),
+    providerProfileAlsoAllow,
+  );
+  const toolPolicyAllowsWebSearch = isToolAllowedByPolicies("web_search", [
+    profilePolicy,
+    providerProfilePolicy,
+    globalPolicy,
+    globalProviderPolicy,
+    agentPolicy,
+    agentProviderPolicy,
+  ]);
 
   if (!globalWebSearchEnabled) {
     return {
@@ -151,6 +186,18 @@ export function resolveCodexNativeSearchActivation(params: {
       hasRequiredAuth: false,
       state: "managed_only",
       inactiveReason: "codex_auth_missing",
+    };
+  }
+
+  if (!toolPolicyAllowsWebSearch) {
+    return {
+      globalWebSearchEnabled,
+      codexNativeEnabled: true,
+      codexMode: codexConfig.mode,
+      nativeEligible: true,
+      hasRequiredAuth: true,
+      state: "managed_only",
+      inactiveReason: "tool_policy_denied",
     };
   }
 
@@ -219,6 +266,9 @@ export function shouldSuppressManagedWebSearchTool(params: {
   config?: OpenClawConfig;
   modelProvider?: string;
   modelApi?: string;
+  modelId?: string;
+  agentId?: string;
+  sessionKey?: string;
   agentDir?: string;
 }): boolean {
   return resolveCodexNativeSearchActivation(params).state === "native_active";

--- a/src/agents/codex-native-web-search-core.ts
+++ b/src/agents/codex-native-web-search-core.ts
@@ -4,7 +4,13 @@
  */
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isRecord } from "../utils.js";
-import { isToolAllowedByPolicies, resolveEffectiveToolPolicy } from "./agent-tools.policy.js";
+import {
+  isToolAllowedByPolicies,
+  resolveEffectiveToolPolicy,
+  resolveGroupToolPolicy,
+  resolveInheritedToolPolicyForSession,
+  resolveSubagentToolPolicyForSession,
+} from "./agent-tools.policy.js";
 import { externalCliDiscoveryForProviderAuth } from "./auth-profiles/external-cli-discovery.js";
 import { listProfilesForProvider } from "./auth-profiles/profile-list.js";
 import { ensureAuthProfileStore } from "./auth-profiles/store.js";
@@ -12,6 +18,12 @@ import {
   type CodexNativeSearchMode,
   resolveCodexNativeWebSearchConfig,
 } from "./codex-native-web-search.shared.js";
+import type { SandboxToolPolicy } from "./sandbox.js";
+import { resolveSenderToolPolicy } from "./sender-tool-policy.js";
+import {
+  isSubagentEnvelopeSession,
+  resolveSubagentCapabilityStore,
+} from "./subagent-capabilities.js";
 import { mergeAlsoAllowPolicy, resolveToolProfilePolicy } from "./tool-policy.js";
 
 type CodexNativeSearchActivation = {
@@ -102,6 +114,17 @@ export function resolveCodexNativeSearchActivation(params: {
   modelId?: string;
   agentId?: string;
   sessionKey?: string;
+  sandboxToolPolicy?: SandboxToolPolicy;
+  messageProvider?: string;
+  agentAccountId?: string | null;
+  groupId?: string | null;
+  groupChannel?: string | null;
+  groupSpace?: string | null;
+  spawnedBy?: string | null;
+  senderId?: string | null;
+  senderName?: string | null;
+  senderUsername?: string | null;
+  senderE164?: string | null;
   agentDir?: string;
 }): CodexNativeSearchActivation {
   const globalWebSearchEnabled = params.config?.tools?.web?.search?.enabled !== false;
@@ -111,36 +134,6 @@ export function resolveCodexNativeSearchActivation(params: {
     params.modelApi !== "openai-chatgpt-responses" ||
     !isOpenAIAuthProviderId(params.modelProvider) ||
     hasAvailableCodexAuth(params);
-  const {
-    globalPolicy,
-    globalProviderPolicy,
-    agentPolicy,
-    agentProviderPolicy,
-    profile,
-    providerProfile,
-    profileAlsoAllow,
-    providerProfileAlsoAllow,
-  } = resolveEffectiveToolPolicy({
-    config: params.config,
-    sessionKey: params.sessionKey,
-    agentId: params.agentId,
-    modelProvider: params.modelProvider,
-    modelId: params.modelId,
-  });
-  const profilePolicy = mergeAlsoAllowPolicy(resolveToolProfilePolicy(profile), profileAlsoAllow);
-  const providerProfilePolicy = mergeAlsoAllowPolicy(
-    resolveToolProfilePolicy(providerProfile),
-    providerProfileAlsoAllow,
-  );
-  const toolPolicyAllowsWebSearch = isToolAllowedByPolicies("web_search", [
-    profilePolicy,
-    providerProfilePolicy,
-    globalPolicy,
-    globalProviderPolicy,
-    agentPolicy,
-    agentProviderPolicy,
-  ]);
-
   if (!globalWebSearchEnabled) {
     return {
       globalWebSearchEnabled,
@@ -188,6 +181,85 @@ export function resolveCodexNativeSearchActivation(params: {
       inactiveReason: "codex_auth_missing",
     };
   }
+
+  const {
+    agentId,
+    globalPolicy,
+    globalProviderPolicy,
+    agentPolicy,
+    agentProviderPolicy,
+    profile,
+    providerProfile,
+    profileAlsoAllow,
+    providerProfileAlsoAllow,
+  } = resolveEffectiveToolPolicy({
+    config: params.config,
+    sessionKey: params.sessionKey,
+    agentId: params.agentId,
+    modelProvider: params.modelProvider,
+    modelId: params.modelId,
+  });
+  const profilePolicy = mergeAlsoAllowPolicy(resolveToolProfilePolicy(profile), profileAlsoAllow);
+  const providerProfilePolicy = mergeAlsoAllowPolicy(
+    resolveToolProfilePolicy(providerProfile),
+    providerProfileAlsoAllow,
+  );
+  const groupPolicy = resolveGroupToolPolicy({
+    config: params.config,
+    sessionKey: params.sessionKey,
+    spawnedBy: params.spawnedBy,
+    messageProvider: params.messageProvider,
+    groupId: params.groupId,
+    groupChannel: params.groupChannel,
+    groupSpace: params.groupSpace,
+    accountId: params.agentAccountId,
+    senderId: params.senderId,
+    senderName: params.senderName,
+    senderUsername: params.senderUsername,
+    senderE164: params.senderE164,
+  });
+  const senderPolicy = resolveSenderToolPolicy({
+    config: params.config,
+    agentId,
+    messageProvider: params.messageProvider,
+    senderId: params.senderId,
+    senderName: params.senderName,
+    senderUsername: params.senderUsername,
+    senderE164: params.senderE164,
+  });
+  const subagentStore = resolveSubagentCapabilityStore(params.sessionKey, {
+    cfg: params.config,
+  });
+  const subagentPolicy =
+    params.sessionKey &&
+    isSubagentEnvelopeSession(params.sessionKey, {
+      cfg: params.config,
+      store: subagentStore,
+    })
+      ? resolveSubagentToolPolicyForSession(params.config, params.sessionKey, {
+          store: subagentStore,
+        })
+      : undefined;
+  const inheritedToolPolicy = resolveInheritedToolPolicyForSession(
+    params.config,
+    params.sessionKey,
+    {
+      store: subagentStore,
+    },
+  );
+  const toolPolicyAllowsWebSearch = isToolAllowedByPolicies("web_search", [
+    profilePolicy,
+    providerProfilePolicy,
+    globalPolicy,
+    globalProviderPolicy,
+    agentPolicy,
+    agentProviderPolicy,
+    groupPolicy,
+    senderPolicy,
+    params.sandboxToolPolicy,
+    subagentPolicy,
+    inheritedToolPolicy,
+  ]);
 
   if (!toolPolicyAllowsWebSearch) {
     return {
@@ -269,6 +341,17 @@ export function shouldSuppressManagedWebSearchTool(params: {
   modelId?: string;
   agentId?: string;
   sessionKey?: string;
+  sandboxToolPolicy?: SandboxToolPolicy;
+  messageProvider?: string;
+  agentAccountId?: string | null;
+  groupId?: string | null;
+  groupChannel?: string | null;
+  groupSpace?: string | null;
+  spawnedBy?: string | null;
+  senderId?: string | null;
+  senderName?: string | null;
+  senderUsername?: string | null;
+  senderE164?: string | null;
   agentDir?: string;
 }): boolean {
   return resolveCodexNativeSearchActivation(params).state === "native_active";

--- a/src/agents/codex-native-web-search.test.ts
+++ b/src/agents/codex-native-web-search.test.ts
@@ -112,6 +112,72 @@ describe("resolveCodexNativeSearchActivation", () => {
     expect(result.state).toBe("managed_only");
     expect(result.inactiveReason).toBe("globally_disabled");
   });
+
+  it("keeps native search inactive when the agent denies web_search", () => {
+    const result = resolveCodexNativeSearchActivation({
+      config: {
+        ...baseConfig,
+        agents: {
+          list: [
+            {
+              id: "main",
+              tools: { deny: ["web_search"] },
+            },
+          ],
+        },
+      },
+      agentId: "main",
+      modelProvider: "gateway",
+      modelApi: "openai-chatgpt-responses",
+      modelId: "gpt-5.5",
+    });
+
+    expect(result.state).toBe("managed_only");
+    expect(result.inactiveReason).toBe("tool_policy_denied");
+  });
+
+  it("keeps native search inactive when the agent denies group:web via session key", () => {
+    const result = resolveCodexNativeSearchActivation({
+      config: {
+        ...baseConfig,
+        agents: {
+          list: [
+            {
+              id: "main",
+              tools: { deny: ["group:web"] },
+            },
+          ],
+        },
+      },
+      sessionKey: "agent:main:main",
+      modelProvider: "gateway",
+      modelApi: "openai-chatgpt-responses",
+      modelId: "gpt-5.5",
+    });
+
+    expect(result.state).toBe("managed_only");
+    expect(result.inactiveReason).toBe("tool_policy_denied");
+  });
+
+  it("keeps native search inactive when provider policy denies web_search", () => {
+    const result = resolveCodexNativeSearchActivation({
+      config: {
+        ...baseConfig,
+        tools: {
+          ...baseConfig.tools,
+          byProvider: {
+            "gateway/gpt-5.5": { deny: ["web_search"] },
+          },
+        },
+      },
+      modelProvider: "gateway",
+      modelApi: "openai-chatgpt-responses",
+      modelId: "gpt-5.5",
+    });
+
+    expect(result.state).toBe("managed_only");
+    expect(result.inactiveReason).toBe("tool_policy_denied");
+  });
 });
 
 describe("Codex native web-search payload helpers", () => {
@@ -228,6 +294,28 @@ describe("shouldSuppressManagedWebSearchTool", () => {
         config: baseConfig,
         modelProvider: "openai",
         modelApi: "openai-responses",
+      }),
+    ).toBe(false);
+  });
+
+  it("does not suppress managed web_search when native search is blocked by policy", () => {
+    expect(
+      shouldSuppressManagedWebSearchTool({
+        config: {
+          ...baseConfig,
+          agents: {
+            list: [
+              {
+                id: "main",
+                tools: { deny: ["group:web"] },
+              },
+            ],
+          },
+        },
+        agentId: "main",
+        modelProvider: "gateway",
+        modelApi: "openai-chatgpt-responses",
+        modelId: "gpt-5.5",
       }),
     ).toBe(false);
   });

--- a/src/agents/codex-native-web-search.test.ts
+++ b/src/agents/codex-native-web-search.test.ts
@@ -1,5 +1,8 @@
 // Covers Codex-native web search activation and payload projection.
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { writeSessionStoreForTest } from "../config/sessions/test-helpers.js";
 import {
   buildCodexNativeWebSearchTool,
   describeCodexNativeWebSearch,
@@ -170,6 +173,73 @@ describe("resolveCodexNativeSearchActivation", () => {
           },
         },
       },
+      modelProvider: "gateway",
+      modelApi: "openai-chatgpt-responses",
+      modelId: "gpt-5.5",
+    });
+
+    expect(result.state).toBe("managed_only");
+    expect(result.inactiveReason).toBe("tool_policy_denied");
+  });
+
+  it("keeps native search inactive when sender policy denies web_search", () => {
+    const result = resolveCodexNativeSearchActivation({
+      config: {
+        ...baseConfig,
+        tools: {
+          ...baseConfig.tools,
+          toolsBySender: {
+            "channel:msteams:alice": { deny: ["web_search"] },
+          },
+        },
+      },
+      messageProvider: "teams",
+      senderId: "alice",
+      modelProvider: "gateway",
+      modelApi: "openai-chatgpt-responses",
+      modelId: "gpt-5.5",
+    });
+
+    expect(result.state).toBe("managed_only");
+    expect(result.inactiveReason).toBe("tool_policy_denied");
+  });
+
+  it("keeps native search inactive when sandbox policy denies group:web", () => {
+    const result = resolveCodexNativeSearchActivation({
+      config: baseConfig,
+      sandboxToolPolicy: { deny: ["group:web"] },
+      modelProvider: "gateway",
+      modelApi: "openai-chatgpt-responses",
+      modelId: "gpt-5.5",
+    });
+
+    expect(result.state).toBe("managed_only");
+    expect(result.inactiveReason).toBe("tool_policy_denied");
+  });
+
+  it("keeps native search inactive when inherited session policy denies web_search", () => {
+    const agentId = `native-inherited-deny-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    const sessionKey = `agent:${agentId}:subagent:limited`;
+    const storePath = path.join(os.tmpdir(), `openclaw-native-inherited-deny-${agentId}.json`);
+    writeSessionStoreForTest(storePath, {
+      [sessionKey]: {
+        sessionId: "limited-session",
+        updatedAt: Date.now(),
+        spawnDepth: 1,
+        subagentRole: "orchestrator",
+        subagentControlScope: "children",
+        inheritedToolDeny: ["web_search"],
+      },
+    });
+
+    const result = resolveCodexNativeSearchActivation({
+      config: {
+        ...baseConfig,
+        session: {
+          store: storePath,
+        },
+      },
+      sessionKey,
       modelProvider: "gateway",
       modelApi: "openai-chatgpt-responses",
       modelId: "gpt-5.5",

--- a/src/agents/embedded-agent-runner-extraparams.test.ts
+++ b/src/agents/embedded-agent-runner-extraparams.test.ts
@@ -468,6 +468,7 @@ function createTestOpenAIProviderWrapper(
   streamFn = createCodexNativeWebSearchWrapper(streamFn, {
     config: params.context.config,
     agentDir: params.context.agentDir,
+    agentId: params.context.agentId,
   });
   streamFn = createOpenAIStringContentWrapper(streamFn);
   streamFn = createOpenAICompletionsStrictMessageKeysWrapper(streamFn);

--- a/src/agents/embedded-agent-runner-extraparams.test.ts
+++ b/src/agents/embedded-agent-runner-extraparams.test.ts
@@ -469,7 +469,7 @@ function createTestOpenAIProviderWrapper(
     config: params.context.config,
     agentDir: params.context.agentDir,
     agentId: params.context.agentId,
-    ...params.context.nativeWebSearchPolicyContext,
+    nativeWebSearchAllowedByToolPolicy: params.context.nativeWebSearchAllowedByToolPolicy,
   });
   streamFn = createOpenAIStringContentWrapper(streamFn);
   streamFn = createOpenAICompletionsStrictMessageKeysWrapper(streamFn);
@@ -563,20 +563,8 @@ describe("applyExtraParamsToAgent", () => {
 
     expect(capturedContext?.agentDir).toBe("/tmp/openclaw-agent");
     expect(capturedContext?.workspaceDir).toBe("/tmp/openclaw-workspace");
-    expect(capturedContext?.nativeWebSearchPolicyContext).toEqual({
-      sessionKey: "agent:cass:main",
-      sandboxToolPolicy: { deny: ["group:web"] },
-      messageProvider: "teams",
-      agentAccountId: "acct-1",
-      groupId: "group-1",
-      groupChannel: "General",
-      groupSpace: "space-1",
-      spawnedBy: "agent:cass:main",
-      senderId: "alice",
-      senderName: "Alice",
-      senderUsername: "alice-user",
-      senderE164: "+15551234567",
-    });
+    expect(capturedContext?.nativeWebSearchAllowedByToolPolicy).toBe(false);
+    expect("nativeWebSearchPolicyContext" in (capturedContext ?? {})).toBe(false);
   });
 
   function runResponsesPayloadMutationCase(params: {

--- a/src/agents/embedded-agent-runner-extraparams.test.ts
+++ b/src/agents/embedded-agent-runner-extraparams.test.ts
@@ -469,6 +469,7 @@ function createTestOpenAIProviderWrapper(
     config: params.context.config,
     agentDir: params.context.agentDir,
     agentId: params.context.agentId,
+    ...params.context.nativeWebSearchPolicyContext,
   });
   streamFn = createOpenAIStringContentWrapper(streamFn);
   streamFn = createOpenAICompletionsStrictMessageKeysWrapper(streamFn);
@@ -541,10 +542,41 @@ describe("applyExtraParamsToAgent", () => {
       "/tmp/openclaw-workspace",
       model,
       "/tmp/openclaw-agent",
+      undefined,
+      {
+        nativeWebSearchPolicyContext: {
+          sessionKey: "agent:cass:main",
+          sandboxToolPolicy: { deny: ["group:web"] },
+          messageProvider: "teams",
+          agentAccountId: "acct-1",
+          groupId: "group-1",
+          groupChannel: "General",
+          groupSpace: "space-1",
+          spawnedBy: "agent:cass:main",
+          senderId: "alice",
+          senderName: "Alice",
+          senderUsername: "alice-user",
+          senderE164: "+15551234567",
+        },
+      },
     );
 
     expect(capturedContext?.agentDir).toBe("/tmp/openclaw-agent");
     expect(capturedContext?.workspaceDir).toBe("/tmp/openclaw-workspace");
+    expect(capturedContext?.nativeWebSearchPolicyContext).toEqual({
+      sessionKey: "agent:cass:main",
+      sandboxToolPolicy: { deny: ["group:web"] },
+      messageProvider: "teams",
+      agentAccountId: "acct-1",
+      groupId: "group-1",
+      groupChannel: "General",
+      groupSpace: "space-1",
+      spawnedBy: "agent:cass:main",
+      senderId: "alice",
+      senderName: "Alice",
+      senderUsername: "alice-user",
+      senderE164: "+15551234567",
+    });
   });
 
   function runResponsesPayloadMutationCase(params: {

--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -394,7 +394,22 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       }),
       "/tmp/workspace",
       undefined,
-      undefined,
+      expectRecordFields(mockCallArg(applyExtraParamsToAgentMock, 0, 11), {
+        nativeWebSearchPolicyContext: {
+          sessionKey: undefined,
+          sandboxToolPolicy: undefined,
+          messageProvider: undefined,
+          agentAccountId: undefined,
+          groupId: undefined,
+          groupChannel: undefined,
+          groupSpace: undefined,
+          spawnedBy: undefined,
+          senderId: undefined,
+          senderName: undefined,
+          senderUsername: undefined,
+          senderE164: undefined,
+        },
+      }),
     );
   });
 

--- a/src/agents/embedded-agent-runner/compact.ts
+++ b/src/agents/embedded-agent-runner/compact.ts
@@ -50,10 +50,6 @@ import {
 import { createPreparedEmbeddedAgentSettingsManager } from "../agent-project-settings.js";
 import { isDefaultAgentRuntimeId } from "../agent-runtime-id.js";
 import {
-  mapSandboxSkillEntriesForPrompt,
-  resolveSandboxSkillRuntimeInputs,
-} from "./sandbox-skills.js";
-import {
   resolveAgentDir,
   resolveRunModelFallbacksOverride,
   resolveSessionAgentIds,
@@ -164,6 +160,10 @@ import { sanitizeSessionHistory, validateReplayTurns } from "./replay-history.js
 import { createEmbeddedAgentResourceLoader } from "./resource-loader.js";
 import { resolveAttemptSpawnWorkspaceDir } from "./run/attempt.thread-helpers.js";
 import { buildEmbeddedSandboxInfo, resolveEmbeddedSandboxInfoExecPolicy } from "./sandbox-info.js";
+import {
+  mapSandboxSkillEntriesForPrompt,
+  resolveSandboxSkillRuntimeInputs,
+} from "./sandbox-skills.js";
 import { prewarmSessionFile, trackSessionManagerAccess } from "./session-manager-cache.js";
 import {
   resolveEmbeddedAgentBaseStreamFn,
@@ -210,6 +210,18 @@ function prepareCompactionSessionAgent(params: {
   effectiveWorkspace: string;
   agentDir: string;
   runtimePlan?: AgentRuntimePlan;
+  sessionKey?: string;
+  sandboxToolPolicy?: { allow?: string[]; deny?: string[] };
+  messageProvider?: string;
+  agentAccountId?: string | null;
+  groupId?: string | null;
+  groupChannel?: string | null;
+  groupSpace?: string | null;
+  spawnedBy?: string | null;
+  senderId?: string | null;
+  senderName?: string | null;
+  senderUsername?: string | null;
+  senderE164?: string | null;
 }) {
   params.session.agent.streamFn = resolveEmbeddedAgentStreamFn({
     currentStreamFn: resolveEmbeddedAgentBaseStreamFn({ session: params.session as never }),
@@ -252,7 +264,25 @@ function prepareCompactionSessionAgent(params: {
     params.effectiveModel,
     params.agentDir,
     undefined,
-    preparedRuntimeExtraParams ? { preparedExtraParams: preparedRuntimeExtraParams } : undefined,
+    {
+      ...(preparedRuntimeExtraParams ? { preparedExtraParams: preparedRuntimeExtraParams } : {}),
+      nativeWebSearchPolicyContext: {
+        // Compaction rebuilds the provider stream wrapper, so preserve the
+        // session-scoped policy inputs that can suppress provider-native search.
+        sessionKey: params.sessionKey,
+        sandboxToolPolicy: params.sandboxToolPolicy,
+        messageProvider: params.messageProvider,
+        agentAccountId: params.agentAccountId,
+        groupId: params.groupId,
+        groupChannel: params.groupChannel,
+        groupSpace: params.groupSpace,
+        spawnedBy: params.spawnedBy,
+        senderId: params.senderId,
+        senderName: params.senderName,
+        senderUsername: params.senderUsername,
+        senderE164: params.senderE164,
+      },
+    },
   );
 }
 
@@ -1259,6 +1289,18 @@ async function compactEmbeddedAgentSessionDirectOnce(
             effectiveWorkspace,
             agentDir,
             runtimePlan,
+            sessionKey: sandboxSessionKey,
+            sandboxToolPolicy: sandbox?.tools,
+            messageProvider: resolvedMessageProvider,
+            agentAccountId: params.agentAccountId,
+            groupId: params.groupId,
+            groupChannel: params.groupChannel,
+            groupSpace: params.groupSpace,
+            spawnedBy: params.spawnedBy,
+            senderId: params.senderId,
+            senderName: params.senderName,
+            senderUsername: params.senderUsername,
+            senderE164: params.senderE164,
           });
 
           const prior = await sanitizeSessionHistory({

--- a/src/agents/embedded-agent-runner/extra-params.ts
+++ b/src/agents/embedded-agent-runner/extra-params.ts
@@ -1,3 +1,7 @@
+import {
+  type NativeWebSearchToolPolicyParams,
+  isNativeWebSearchAllowedByToolPolicy,
+} from "../../agents/codex-native-web-search-core.js";
 /**
  * Resolves model extra parameters and transport overrides for embedded agents.
  */
@@ -30,7 +34,6 @@ import {
   wrapProviderStreamFn as wrapProviderStreamFnRuntime,
 } from "../../plugins/provider-hook-runtime.js";
 import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
-import type { ProviderNativeWebSearchPolicyContext } from "../../plugins/types.js";
 import { canonicalizeMaxTokensParam, resolveMaxTokensParam } from "../model-max-tokens-params.js";
 import { legacyModelKey, modelKey } from "../model-selection-normalize.js";
 import { supportsGptParallelToolCallsPayload } from "../provider-api-families.js";
@@ -1046,7 +1049,7 @@ export function applyExtraParamsToAgent(
   resolvedTransport?: SupportedTransport,
   options?: {
     preparedExtraParams?: Record<string, unknown>;
-    nativeWebSearchPolicyContext?: ProviderNativeWebSearchPolicyContext;
+    nativeWebSearchPolicyContext?: NativeWebSearchToolPolicyParams;
   },
 ): { effectiveExtraParams: Record<string, unknown> } {
   const resolvedExtraParams = resolveExtraParams({
@@ -1093,6 +1096,15 @@ export function applyExtraParamsToAgent(
   };
 
   const providerStreamBase = agent.streamFn;
+  const nativeWebSearchAllowedByToolPolicy = options?.nativeWebSearchPolicyContext
+    ? isNativeWebSearchAllowedByToolPolicy({
+        config: cfg,
+        modelProvider: model?.provider,
+        modelId: model?.id,
+        agentId,
+        ...options.nativeWebSearchPolicyContext,
+      })
+    : undefined;
   const pluginWrappedStreamFn = providerRuntimeDeps.wrapProviderStreamFn({
     provider,
     config: cfg,
@@ -1101,7 +1113,7 @@ export function applyExtraParamsToAgent(
       agentDir,
       workspaceDir,
       agentId,
-      nativeWebSearchPolicyContext: options?.nativeWebSearchPolicyContext,
+      nativeWebSearchAllowedByToolPolicy,
       provider,
       modelId,
       extraParams: effectiveExtraParams,

--- a/src/agents/embedded-agent-runner/extra-params.ts
+++ b/src/agents/embedded-agent-runner/extra-params.ts
@@ -30,6 +30,7 @@ import {
   wrapProviderStreamFn as wrapProviderStreamFnRuntime,
 } from "../../plugins/provider-hook-runtime.js";
 import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
+import type { ProviderNativeWebSearchPolicyContext } from "../../plugins/types.js";
 import { canonicalizeMaxTokensParam, resolveMaxTokensParam } from "../model-max-tokens-params.js";
 import { legacyModelKey, modelKey } from "../model-selection-normalize.js";
 import { supportsGptParallelToolCallsPayload } from "../provider-api-families.js";
@@ -1043,7 +1044,10 @@ export function applyExtraParamsToAgent(
   model?: ProviderRuntimeModel,
   agentDir?: string,
   resolvedTransport?: SupportedTransport,
-  options?: { preparedExtraParams?: Record<string, unknown> },
+  options?: {
+    preparedExtraParams?: Record<string, unknown>;
+    nativeWebSearchPolicyContext?: ProviderNativeWebSearchPolicyContext;
+  },
 ): { effectiveExtraParams: Record<string, unknown> } {
   const resolvedExtraParams = resolveExtraParams({
     cfg,
@@ -1097,6 +1101,7 @@ export function applyExtraParamsToAgent(
       agentDir,
       workspaceDir,
       agentId,
+      nativeWebSearchPolicyContext: options?.nativeWebSearchPolicyContext,
       provider,
       modelId,
       extraParams: effectiveExtraParams,

--- a/src/agents/embedded-agent-runner/extra-params.ts
+++ b/src/agents/embedded-agent-runner/extra-params.ts
@@ -1096,6 +1096,7 @@ export function applyExtraParamsToAgent(
       config: cfg,
       agentDir,
       workspaceDir,
+      agentId,
       provider,
       modelId,
       extraParams: effectiveExtraParams,

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -2637,6 +2637,20 @@ export async function runEmbeddedAttempt(
           transformSystemPrompt: false,
         });
       }
+      const nativeWebSearchPolicyContext = {
+        sessionKey: sandboxSessionKey,
+        sandboxToolPolicy: sandbox?.tools,
+        messageProvider: resolveAttemptToolPolicyMessageProvider(params),
+        agentAccountId: params.agentAccountId,
+        groupId: params.groupId,
+        groupChannel: params.groupChannel,
+        groupSpace: params.groupSpace,
+        spawnedBy: params.spawnedBy,
+        senderId: params.senderId,
+        senderName: params.senderName,
+        senderUsername: params.senderUsername,
+        senderE164: params.senderE164,
+      };
 
       applyExtraParamsToAgent(
         activeSession.agent,
@@ -2650,7 +2664,10 @@ export async function runEmbeddedAttempt(
         params.model,
         agentDir,
         resolvedTransport,
-        { preparedExtraParams: effectiveExtraParams },
+        {
+          preparedExtraParams: effectiveExtraParams,
+          nativeWebSearchPolicyContext,
+        },
       );
       if (codeModeControlsEnabledForRun) {
         activeSession.agent.streamFn = createCodexNativeWebSearchWrapper(
@@ -2659,6 +2676,7 @@ export async function runEmbeddedAttempt(
             config: params.config,
             agentDir,
             agentId: sessionAgentId,
+            ...nativeWebSearchPolicyContext,
             codeModeToolSurfaceEnabled: true,
           },
         );

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -2658,6 +2658,7 @@ export async function runEmbeddedAttempt(
           {
             config: params.config,
             agentDir,
+            agentId: sessionAgentId,
             codeModeToolSurfaceEnabled: true,
           },
         );

--- a/src/llm/providers/stream-wrappers/openai.test.ts
+++ b/src/llm/providers/stream-wrappers/openai.test.ts
@@ -283,6 +283,52 @@ describe("createCodexNativeWebSearchWrapper", () => {
       },
     ]);
   });
+
+  it("does not inject native web_search when agent policy denies web search", () => {
+    const payloads: Array<Record<string, unknown>> = [];
+    const baseStreamFn: StreamFn = (model, _context, options) => {
+      const payload: Record<string, unknown> = {
+        model: model.id,
+        tools: [{ type: "function", name: "read" }],
+      };
+      options?.onPayload?.(payload, model);
+      payloads.push(structuredClone(payload));
+      return createAssistantMessageEventStream();
+    };
+    const wrapped = createCodexNativeWebSearchWrapper(baseStreamFn, {
+      agentId: "main",
+      config: {
+        agents: {
+          list: [
+            {
+              id: "main",
+              tools: { deny: ["group:web"] },
+            },
+          ],
+        },
+        tools: {
+          web: {
+            search: {
+              enabled: true,
+              openaiCodex: { enabled: true, mode: "cached" },
+            },
+          },
+        },
+      },
+    });
+
+    void wrapped(
+      {
+        api: "openai-chatgpt-responses",
+        provider: "gateway",
+        id: "gpt-5.5",
+      } as Model<"openai-chatgpt-responses">,
+      { messages: [] },
+      {},
+    );
+
+    expect(payloads[0]?.tools).toEqual([{ type: "function", name: "read" }]);
+  });
 });
 
 describe("createOpenAICompletionsStrictMessageKeysWrapper", () => {

--- a/src/llm/providers/stream-wrappers/openai.test.ts
+++ b/src/llm/providers/stream-wrappers/openai.test.ts
@@ -329,6 +329,48 @@ describe("createCodexNativeWebSearchWrapper", () => {
 
     expect(payloads[0]?.tools).toEqual([{ type: "function", name: "read" }]);
   });
+
+  it("does not inject native web_search when runtime sender policy denies web search", () => {
+    const payloads: Array<Record<string, unknown>> = [];
+    const baseStreamFn: StreamFn = (model, _context, options) => {
+      const payload: Record<string, unknown> = {
+        model: model.id,
+        tools: [{ type: "function", name: "read" }],
+      };
+      options?.onPayload?.(payload, model);
+      payloads.push(structuredClone(payload));
+      return createAssistantMessageEventStream();
+    };
+    const wrapped = createCodexNativeWebSearchWrapper(baseStreamFn, {
+      messageProvider: "teams",
+      senderId: "alice",
+      config: {
+        tools: {
+          toolsBySender: {
+            "channel:msteams:alice": { deny: ["web_search"] },
+          },
+          web: {
+            search: {
+              enabled: true,
+              openaiCodex: { enabled: true, mode: "cached" },
+            },
+          },
+        },
+      },
+    });
+
+    void wrapped(
+      {
+        api: "openai-chatgpt-responses",
+        provider: "gateway",
+        id: "gpt-5.5",
+      } as Model<"openai-chatgpt-responses">,
+      { messages: [] },
+      {},
+    );
+
+    expect(payloads[0]?.tools).toEqual([{ type: "function", name: "read" }]);
+  });
 });
 
 describe("createOpenAICompletionsStrictMessageKeysWrapper", () => {

--- a/src/llm/providers/stream-wrappers/openai.ts
+++ b/src/llm/providers/stream-wrappers/openai.ts
@@ -630,6 +630,7 @@ export function createCodexNativeWebSearchWrapper(
     senderName?: string | null;
     senderUsername?: string | null;
     senderE164?: string | null;
+    nativeWebSearchAllowedByToolPolicy?: boolean;
     codeModeToolSurfaceEnabled?: boolean;
   },
 ): StreamFn {
@@ -661,6 +662,15 @@ export function createCodexNativeWebSearchWrapper(
         },
       };
       return underlying(model, context, codeModeOptions);
+    }
+
+    if (params.nativeWebSearchAllowedByToolPolicy === false) {
+      log.debug(
+        `skipping Codex native web search (tool_policy_denied) for ${
+          model.provider ?? "unknown"
+        }/${model.id ?? "unknown"}`,
+      );
+      return underlying(model, context, options);
     }
 
     const activation = resolveCodexNativeSearchActivation({

--- a/src/llm/providers/stream-wrappers/openai.ts
+++ b/src/llm/providers/stream-wrappers/openai.ts
@@ -613,7 +613,12 @@ export function createOpenAITextVerbosityWrapper(
 /** @deprecated OpenAI Codex provider-owned stream helper; do not use from third-party plugins. */
 export function createCodexNativeWebSearchWrapper(
   baseStreamFn: StreamFn | undefined,
-  params: { config?: OpenClawConfig; agentDir?: string; codeModeToolSurfaceEnabled?: boolean },
+  params: {
+    config?: OpenClawConfig;
+    agentDir?: string;
+    agentId?: string;
+    codeModeToolSurfaceEnabled?: boolean;
+  },
 ): StreamFn {
   const underlying = baseStreamFn ?? streamSimple;
   return (model, context, options) => {
@@ -649,6 +654,8 @@ export function createCodexNativeWebSearchWrapper(
       config: params.config,
       modelProvider: readStringValue(model.provider),
       modelApi: readStringValue(model.api),
+      modelId: readStringValue(model.id),
+      agentId: params.agentId,
       agentDir: params.agentDir,
     });
 

--- a/src/llm/providers/stream-wrappers/openai.ts
+++ b/src/llm/providers/stream-wrappers/openai.ts
@@ -24,6 +24,7 @@ import {
 import { createOpenAIResponsesTransportStreamFn } from "../../../agents/openai-transport-stream.js";
 import { resolveProviderRequestPolicyConfig } from "../../../agents/provider-request-config.js";
 import type { StreamFn } from "../../../agents/runtime/index.js";
+import type { SandboxToolPolicy } from "../../../agents/sandbox.js";
 import type { ThinkLevel } from "../../../auto-reply/thinking.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { createSubsystemLogger } from "../../../logging/subsystem.js";
@@ -617,6 +618,18 @@ export function createCodexNativeWebSearchWrapper(
     config?: OpenClawConfig;
     agentDir?: string;
     agentId?: string;
+    sessionKey?: string;
+    sandboxToolPolicy?: SandboxToolPolicy;
+    messageProvider?: string;
+    agentAccountId?: string | null;
+    groupId?: string | null;
+    groupChannel?: string | null;
+    groupSpace?: string | null;
+    spawnedBy?: string | null;
+    senderId?: string | null;
+    senderName?: string | null;
+    senderUsername?: string | null;
+    senderE164?: string | null;
     codeModeToolSurfaceEnabled?: boolean;
   },
 ): StreamFn {
@@ -656,6 +669,18 @@ export function createCodexNativeWebSearchWrapper(
       modelApi: readStringValue(model.api),
       modelId: readStringValue(model.id),
       agentId: params.agentId,
+      sessionKey: params.sessionKey,
+      sandboxToolPolicy: params.sandboxToolPolicy,
+      messageProvider: params.messageProvider,
+      agentAccountId: params.agentAccountId,
+      groupId: params.groupId,
+      groupChannel: params.groupChannel,
+      groupSpace: params.groupSpace,
+      spawnedBy: params.spawnedBy,
+      senderId: params.senderId,
+      senderName: params.senderName,
+      senderUsername: params.senderUsername,
+      senderE164: params.senderE164,
       agentDir: params.agentDir,
     });
 

--- a/src/plugin-sdk/provider-stream.ts
+++ b/src/plugin-sdk/provider-stream.ts
@@ -1,4 +1,7 @@
 // Provider stream helpers expose shared wrapper families and payload transforms for provider plugins.
+import { readStringValue } from "@openclaw/normalization-core/string-coerce";
+import { isNativeWebSearchAllowedByToolPolicy } from "../agents/codex-native-web-search-core.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createGoogleThinkingPayloadWrapper } from "../llm/providers/stream-wrappers/google.js";
 import { createMinimaxFastModeWrapper } from "../llm/providers/stream-wrappers/minimax.js";
 import { resolveMoonshotThinkingKeep } from "../llm/providers/stream-wrappers/moonshot-thinking.js";
@@ -21,7 +24,7 @@ import {
   createOpenRouterWrapper,
   isProxyReasoningUnsupported,
 } from "../llm/providers/stream-wrappers/proxy.js";
-import type { ProviderPlugin } from "../plugins/types.js";
+import type { ProviderNativeWebSearchPolicyContext, ProviderPlugin } from "../plugins/types.js";
 import type { ProviderWrapStreamFnContext } from "./plugin-entry.js";
 import {
   createMoonshotThinkingWrapper,
@@ -64,6 +67,21 @@ export type ProviderStreamFamily =
   | "tool-stream-default-on";
 
 type ProviderStreamFamilyHooks = Pick<ProviderPlugin, "wrapStreamFn">;
+
+export function isProviderNativeWebSearchAllowedByToolPolicy(params: {
+  config?: OpenClawConfig;
+  model?: { id?: unknown; provider?: unknown };
+  agentId?: string;
+  nativeWebSearchPolicyContext?: ProviderNativeWebSearchPolicyContext;
+}): boolean {
+  return isNativeWebSearchAllowedByToolPolicy({
+    config: params.config,
+    modelProvider: readStringValue(params.model?.provider),
+    modelId: readStringValue(params.model?.id),
+    agentId: params.agentId,
+    ...params.nativeWebSearchPolicyContext,
+  });
+}
 
 /** Builds provider hook objects for one supported stream-wrapper family. */
 export function buildProviderStreamFamilyHooks(

--- a/src/plugin-sdk/provider-stream.ts
+++ b/src/plugin-sdk/provider-stream.ts
@@ -1,7 +1,4 @@
 // Provider stream helpers expose shared wrapper families and payload transforms for provider plugins.
-import { readStringValue } from "@openclaw/normalization-core/string-coerce";
-import { isNativeWebSearchAllowedByToolPolicy } from "../agents/codex-native-web-search-core.js";
-import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createGoogleThinkingPayloadWrapper } from "../llm/providers/stream-wrappers/google.js";
 import { createMinimaxFastModeWrapper } from "../llm/providers/stream-wrappers/minimax.js";
 import { resolveMoonshotThinkingKeep } from "../llm/providers/stream-wrappers/moonshot-thinking.js";
@@ -24,7 +21,7 @@ import {
   createOpenRouterWrapper,
   isProxyReasoningUnsupported,
 } from "../llm/providers/stream-wrappers/proxy.js";
-import type { ProviderNativeWebSearchPolicyContext, ProviderPlugin } from "../plugins/types.js";
+import type { ProviderPlugin } from "../plugins/types.js";
 import type { ProviderWrapStreamFnContext } from "./plugin-entry.js";
 import {
   createMoonshotThinkingWrapper,
@@ -67,21 +64,6 @@ export type ProviderStreamFamily =
   | "tool-stream-default-on";
 
 type ProviderStreamFamilyHooks = Pick<ProviderPlugin, "wrapStreamFn">;
-
-export function isProviderNativeWebSearchAllowedByToolPolicy(params: {
-  config?: OpenClawConfig;
-  model?: { id?: unknown; provider?: unknown };
-  agentId?: string;
-  nativeWebSearchPolicyContext?: ProviderNativeWebSearchPolicyContext;
-}): boolean {
-  return isNativeWebSearchAllowedByToolPolicy({
-    config: params.config,
-    modelProvider: readStringValue(params.model?.provider),
-    modelId: readStringValue(params.model?.id),
-    agentId: params.agentId,
-    ...params.nativeWebSearchPolicyContext,
-  });
-}
 
 /** Builds provider hook objects for one supported stream-wrapper family. */
 export function buildProviderStreamFamilyHooks(
@@ -149,7 +131,7 @@ export function buildProviderStreamFamilyHooks(
             config: ctx.config,
             agentDir: ctx.agentDir,
             agentId: ctx.agentId,
-            ...ctx.nativeWebSearchPolicyContext,
+            nativeWebSearchAllowedByToolPolicy: ctx.nativeWebSearchAllowedByToolPolicy,
           });
           nextStreamFn = createOpenAIStringContentWrapper(nextStreamFn);
           return createOpenAIResponsesContextManagementWrapper(

--- a/src/plugin-sdk/provider-stream.ts
+++ b/src/plugin-sdk/provider-stream.ts
@@ -130,6 +130,7 @@ export function buildProviderStreamFamilyHooks(
           nextStreamFn = createCodexNativeWebSearchWrapper(nextStreamFn, {
             config: ctx.config,
             agentDir: ctx.agentDir,
+            agentId: ctx.agentId,
           });
           nextStreamFn = createOpenAIStringContentWrapper(nextStreamFn);
           return createOpenAIResponsesContextManagementWrapper(

--- a/src/plugin-sdk/provider-stream.ts
+++ b/src/plugin-sdk/provider-stream.ts
@@ -131,6 +131,7 @@ export function buildProviderStreamFamilyHooks(
             config: ctx.config,
             agentDir: ctx.agentDir,
             agentId: ctx.agentId,
+            ...ctx.nativeWebSearchPolicyContext,
           });
           nextStreamFn = createOpenAIStringContentWrapper(nextStreamFn);
           return createOpenAIResponsesContextManagementWrapper(

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -696,6 +696,21 @@ export type ProviderAuthDoctorHintContext = {
   profileId?: string;
 };
 
+export type ProviderNativeWebSearchPolicyContext = {
+  sessionKey?: string;
+  sandboxToolPolicy?: { allow?: string[]; deny?: string[] };
+  messageProvider?: string;
+  agentAccountId?: string | null;
+  groupId?: string | null;
+  groupChannel?: string | null;
+  groupSpace?: string | null;
+  spawnedBy?: string | null;
+  senderId?: string | null;
+  senderName?: string | null;
+  senderUsername?: string | null;
+  senderE164?: string | null;
+};
+
 /**
  * Provider-owned extra-param normalization before OpenClaw builds its generic
  * stream option wrapper.
@@ -708,6 +723,7 @@ export type ProviderPrepareExtraParamsContext = {
   agentDir?: string;
   workspaceDir?: string;
   agentId?: string;
+  nativeWebSearchPolicyContext?: ProviderNativeWebSearchPolicyContext;
   provider: string;
   modelId: string;
   model?: ProviderRuntimeModel;

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -707,6 +707,7 @@ export type ProviderPrepareExtraParamsContext = {
   config?: OpenClawConfig;
   agentDir?: string;
   workspaceDir?: string;
+  agentId?: string;
   provider: string;
   modelId: string;
   model?: ProviderRuntimeModel;

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -696,21 +696,6 @@ export type ProviderAuthDoctorHintContext = {
   profileId?: string;
 };
 
-export type ProviderNativeWebSearchPolicyContext = {
-  sessionKey?: string;
-  sandboxToolPolicy?: { allow?: string[]; deny?: string[] };
-  messageProvider?: string;
-  agentAccountId?: string | null;
-  groupId?: string | null;
-  groupChannel?: string | null;
-  groupSpace?: string | null;
-  spawnedBy?: string | null;
-  senderId?: string | null;
-  senderName?: string | null;
-  senderUsername?: string | null;
-  senderE164?: string | null;
-};
-
 /**
  * Provider-owned extra-param normalization before OpenClaw builds its generic
  * stream option wrapper.
@@ -723,7 +708,7 @@ export type ProviderPrepareExtraParamsContext = {
   agentDir?: string;
   workspaceDir?: string;
   agentId?: string;
-  nativeWebSearchPolicyContext?: ProviderNativeWebSearchPolicyContext;
+  nativeWebSearchAllowedByToolPolicy?: boolean;
   provider: string;
   modelId: string;
   model?: ProviderRuntimeModel;


### PR DESCRIPTION
## Summary

Enforce OpenClaw tool policy before enabling provider-native Codex/OpenAI `web_search`.

## Changes

- Gate native web-search activation with global, provider, agent, profile, group, sender, sandbox, subagent, and inherited session tool policy layers.
- Thread native web-search policy context through embedded attempts, compaction stream rebuilds, provider stream hooks, and the OpenAI native-search wrapper.
- Keep managed `web_search` visible when native search is unavailable or blocked by policy.
- Update the Plugin SDK API baseline hash for the intentional optional provider context addition.
- Add regression coverage for agent/provider/sender/sandbox/inherited denies, managed-tool suppression parity, provider wrapper context propagation, and payload injection suppression.

## Validation

- `node scripts/run-vitest.mjs src/agents/codex-native-web-search.test.ts src/llm/providers/stream-wrappers/openai.test.ts src/agents/embedded-agent-runner-extraparams.test.ts`
- `corepack pnpm plugin-sdk:api:check`
- `corepack pnpm tsgo:core`
- `node scripts/check-src-extension-import-boundary.mjs --json`
- `node scripts/check-sdk-package-extension-import-boundary.mjs --json`
- `node scripts/check-test-helper-extension-import-boundary.mjs --json`
- `corepack pnpm check:import-cycles`
- `git diff --check`
- `corepack pnpm build`

## Notes

- This is hardening/policy parity; no secret exfiltration or external mutation was demonstrated in the report.
