### PR TITLE
fix(mcp): harden stdio env filtering

### DIFF
--- a/src/agents/mcp-config-shared.ts
+++ b/src/agents/mcp-config-shared.ts
@@ -4,7 +4,43 @@
  * MCP transport setup uses these functions to normalize loose JSON config into
  * string records/arrays while dropping unsafe host environment variables.
  */
-import { isDangerousHostEnvVarName } from "../infra/host-env-security.js";
+import {
+  isDangerousHostEnvVarName,
+  isDangerousHostInheritedEnvVarName,
+  normalizeEnvVarKey,
+} from "../infra/host-env-security.js";
+
+const MCP_EXPLICIT_CREDENTIAL_ENV_KEYS = new Set([
+  // Explicit MCP server credentials are operator-configured auth inputs, not
+  // inherited host config pivots. If policy adds credential keys, add only
+  // direct credentials here; keep loader/search/config pivots blocked.
+  "AMQP_URL",
+  "AWS_ACCESS_KEY_ID",
+  "AWS_SECRET_ACCESS_KEY",
+  "AWS_SECURITY_TOKEN",
+  "AWS_SESSION_TOKEN",
+  "AZURE_CLIENT_ID",
+  "AZURE_CLIENT_SECRET",
+  "DATABASE_URL",
+  "GH_TOKEN",
+  "GITHUB_TOKEN",
+  "GITLAB_TOKEN",
+  "MONGODB_URI",
+  "NODE_AUTH_TOKEN",
+  "NPM_TOKEN",
+  "REDIS_URL",
+]);
+
+function isDangerousMcpStdioEnvVarName(rawKey: string): boolean {
+  if (isDangerousHostEnvVarName(rawKey)) {
+    return true;
+  }
+  const key = normalizeEnvVarKey(rawKey);
+  if (!key || MCP_EXPLICIT_CREDENTIAL_ENV_KEYS.has(key.toUpperCase())) {
+    return false;
+  }
+  return isDangerousHostInheritedEnvVarName(key);
+}
 
 /** Returns whether a value is a plain MCP config record. */
 export function isMcpConfigRecord(value: unknown): value is Record<string, unknown> {
@@ -63,7 +99,7 @@ export function toMcpEnvRecord(
   return toMcpFilteredStringRecord(value, {
     ...options,
     preserveEmptyWhenKeysDropped: true,
-    shouldDropKey: (key) => isDangerousHostEnvVarName(key),
+    shouldDropKey: (key) => isDangerousMcpStdioEnvVarName(key),
   });
 }
 

--- a/src/agents/mcp-transport-config.test.ts
+++ b/src/agents/mcp-transport-config.test.ts
@@ -49,8 +49,9 @@ describe("resolveMcpTransportConfig", () => {
   });
 
   it("drops dangerous env overrides from stdio config", () => {
-    // Stdio env is executable process input. Block loader/shell hook variables
-    // while preserving ordinary provider tokens and scalar env values.
+    // Stdio env is inherited executable process input. Block loader/shell hook
+    // variables and child-process config pivots while preserving explicit MCP
+    // credentials and ordinary scalar env values.
     const resolved = resolveMcpTransportConfig("probe", {
       command: "node",
       env: {
@@ -62,6 +63,8 @@ describe("resolveMcpTransportConfig", () => {
         NODE_OPTIONS: "--require=./evil.js",
         LD_PRELOAD: "/tmp/pwn.so",
         BASH_ENV: "/tmp/pwn.sh",
+        ANSIBLE_CONFIG: "/tmp/evil-ansible.cfg",
+        TF_CLI_CONFIG_FILE: "/tmp/evil-terraform.rc",
       },
     });
 
@@ -91,6 +94,12 @@ describe("resolveMcpTransportConfig", () => {
     );
     expect(logWarn).toHaveBeenCalledWith(
       'bundle-mcp: server "probe": env "BASH_ENV" is blocked for stdio startup safety and was ignored.',
+    );
+    expect(logWarn).toHaveBeenCalledWith(
+      'bundle-mcp: server "probe": env "ANSIBLE_CONFIG" is blocked for stdio startup safety and was ignored.',
+    );
+    expect(logWarn).toHaveBeenCalledWith(
+      'bundle-mcp: server "probe": env "TF_CLI_CONFIG_FILE" is blocked for stdio startup safety and was ignored.',
     );
   });
 


### PR DESCRIPTION
## Summary

Harden stdio MCP server environment filtering so configured child-process env drops inherited execution/config pivot variables consistently with OpenClaw host process hardening.

## Changes

- Adds a dedicated MCP stdio env predicate that keeps existing always-dangerous host env blocking.
- Drops inherited child-process config pivots such as Ansible and Terraform config env keys before stdio MCP spawn.
- Preserves explicit MCP credential env keys, such as `GITHUB_TOKEN`, so configured authenticated MCP servers keep working.
- Documents the explicit credential allowlist maintenance contract so future policy additions keep credential keys separate from loader/search/config pivots.
- Expands `resolveMcpTransportConfig` coverage for the new dropped and preserved env behavior.

## Validation

- `node scripts/run-vitest.mjs src/agents/mcp-transport-config.test.ts` -> 1 file passed, 9 tests passed.
- `git diff --check` -> passed.
- `git diff origin/main...HEAD --check` -> passed.
- `.agents/skills/autoreview/scripts/autoreview --mode local` -> clean, no accepted/actionable findings.
- Real MCP stdio proof with an isolated temporary config:
  - Command path: `OPENCLAW_CONFIG_PATH=<temp>/openclaw.json OPENCLAW_TEST_FAST=1 corepack pnpm openclaw mcp add env-proof ... --no-probe`, then `OPENCLAW_CONFIG_PATH=<temp>/openclaw.json OPENCLAW_TEST_FAST=1 corepack pnpm openclaw mcp probe env-proof --json`.
  - Probe result: connected successfully, listed `env-proof__ping`, diagnostics `[]`.
  - Startup warnings: `ANSIBLE_CONFIG` and `TF_CLI_CONFIG_FILE` were blocked for stdio startup safety.
  - Spawned child proof JSON: `ANSIBLE_CONFIG_present=false`, `TF_CLI_CONFIG_FILE_present=false`, `GITHUB_TOKEN_present=true`, `HTTP_PROXY_present=true`.

## Notes

- Compatibility impact is intentional: configured stdio MCP env keys already classified as inherited child-process config pivots are now ignored with the existing startup-safety warning.
- Explicit credential env keys and allowed inherited operator env such as `GITHUB_TOKEN` and `HTTP_PROXY` continue to pass.
- Refs NVIDIA tracking issue: https://github.com/NVIDIA-dev/openclaw-tracking/issues/745
