### PR TITLE
fix(codex): guard sandbox http requests

### DIFF
--- a/extensions/codex/src/app-server/sandbox-exec-server.http.test.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server.http.test.ts
@@ -1,4 +1,5 @@
 // Codex tests cover sandbox exec server.http plugin behavior.
+import { spawn } from "node:child_process";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   closeCodexSandboxExecServersForTests,
@@ -13,7 +14,10 @@ import {
   rpc,
   waitForHttpBodyDeltas,
 } from "./sandbox-exec-server.test-helpers.js";
-import { SANDBOX_HTTP_STREAM_LINE_MAX_CHARS } from "./sandbox-exec-server/http.js";
+import {
+  SANDBOX_HTTP_REQUEST_SCRIPT,
+  SANDBOX_HTTP_STREAM_LINE_MAX_CHARS,
+} from "./sandbox-exec-server/http.js";
 
 afterEach(async () => {
   vi.unstubAllEnvs();
@@ -24,6 +28,32 @@ function testExecEnv(): NodeJS.ProcessEnv {
   return {
     PATH: process.env.PATH,
   };
+}
+
+function runSandboxHttpRequestScript(input: unknown): Promise<{
+  code: number | null;
+  stderr: string;
+  stdout: string;
+}> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("bash", ["-lc", SANDBOX_HTTP_REQUEST_SCRIPT], {
+      env: testExecEnv(),
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString("utf8");
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString("utf8");
+    });
+    child.once("error", reject);
+    child.once("close", (code) => {
+      resolve({ code, stderr, stdout });
+    });
+    child.stdin.end(JSON.stringify(input));
+  });
 }
 
 describe("OpenClaw Codex sandbox exec-server HTTP", () => {
@@ -124,6 +154,30 @@ describe("OpenClaw Codex sandbox exec-server HTTP", () => {
     ).rejects.toThrow("Blocked hostname or private/internal IP");
     expect(buildExecSpec).not.toHaveBeenCalled();
     socket.close();
+  });
+
+  it("blocks protected IP classes inside the sandbox Python helper", async () => {
+    const blockedUrls = [
+      "http://100.100.100.200/",
+      "http://[fd00:ec2::254]/",
+      "http://[fec0::1]/",
+      "http://[64:ff9b::100.100.100.200]/",
+      "http://[64:ff9b:1::6464:64c8]/",
+      "http://[2002:6464:64c8::]/",
+      "http://[2001::9b9b:9b37]/",
+      "http://[2001:4860:1::5efe:6464:64c8]/",
+    ];
+
+    for (const url of blockedUrls) {
+      const result = await runSandboxHttpRequestScript({
+        method: "GET",
+        url,
+        timeoutMs: 1,
+      });
+      expect(result.code, url).not.toBe(0);
+      expect(result.stdout, url).toBe("");
+      expect(result.stderr, url).toContain("Blocked");
+    }
   });
 
   it("streams HTTP response body deltas from the sandbox backend", async () => {

--- a/extensions/codex/src/app-server/sandbox-exec-server.http.test.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server.http.test.ts
@@ -71,6 +71,61 @@ describe("OpenClaw Codex sandbox exec-server HTTP", () => {
     socket.close();
   });
 
+  it("blocks private HTTP targets before starting the sandbox backend", async () => {
+    const runShellCommand = vi.fn(async () => ({
+      stdout: Buffer.alloc(0),
+      stderr: Buffer.alloc(0),
+      code: 0,
+    }));
+    const sandbox = createSandboxContext({ runShellCommand });
+    const client = createClient();
+    await ensureCodexSandboxExecServerEnvironment({
+      client: client as never,
+      sandbox,
+    });
+    const socket = await openSocket(execServerUrlFromClient(client));
+    await rpc(socket, "initialize", { clientName: "test" });
+    socket.send(JSON.stringify({ method: "initialized" }));
+
+    await expect(
+      rpc(socket, "http/request", {
+        requestId: "http-private",
+        method: "GET",
+        url: "http://127.0.0.1:6379/",
+      }),
+    ).rejects.toThrow("Blocked hostname or private/internal IP");
+    expect(runShellCommand).not.toHaveBeenCalled();
+    socket.close();
+  });
+
+  it("blocks metadata HTTP targets before starting the streaming sandbox backend", async () => {
+    const buildExecSpec = vi.fn(async () => ({
+      argv: [process.execPath, "-e", ""],
+      env: testExecEnv(),
+      stdinMode: "pipe-closed" as const,
+    }));
+    const sandbox = createSandboxContext({ buildExecSpec });
+    const client = createClient();
+    await ensureCodexSandboxExecServerEnvironment({
+      client: client as never,
+      sandbox,
+    });
+    const socket = await openSocket(execServerUrlFromClient(client));
+    await rpc(socket, "initialize", { clientName: "test" });
+    socket.send(JSON.stringify({ method: "initialized" }));
+
+    await expect(
+      rpc(socket, "http/request", {
+        requestId: "http-metadata",
+        method: "GET",
+        url: "http://metadata.google.internal/",
+        streamResponse: true,
+      }),
+    ).rejects.toThrow("Blocked hostname or private/internal IP");
+    expect(buildExecSpec).not.toHaveBeenCalled();
+    socket.close();
+  });
+
   it("streams HTTP response body deltas from the sandbox backend", async () => {
     const headerLine = JSON.stringify({
       type: "headers",

--- a/extensions/codex/src/app-server/sandbox-exec-server/http.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server/http.ts
@@ -5,6 +5,7 @@
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { embeddedAgentLog } from "openclaw/plugin-sdk/agent-harness-runtime";
 import type { SandboxContext } from "openclaw/plugin-sdk/sandbox";
+import { SsrFBlockedError, isBlockedHostnameOrIp } from "openclaw/plugin-sdk/ssrf-runtime";
 import type { WebSocket } from "ws";
 import type { JsonObject, JsonValue } from "../protocol.js";
 import { readHttpHeaders, requireNumber, requireObject, requireString } from "./json-rpc.js";
@@ -22,9 +23,11 @@ export async function httpRequest(
 ): Promise<JsonObject> {
   const record = requireObject(params, "http/request params");
   const requestId = requireString(record.requestId, "requestId");
+  const url = requireString(record.url, "url");
+  assertSandboxHttpRequestTargetAllowed(url);
   const request = {
     method: requireString(record.method, "method"),
-    url: requireString(record.url, "url"),
+    url,
     headers: readHttpHeaders(record.headers),
     bodyBase64: typeof record.bodyBase64 === "string" ? record.bodyBase64 : undefined,
     timeoutMs:
@@ -51,6 +54,25 @@ type SandboxHttpRequest = {
   timeoutMs?: number;
   streamResponse: boolean;
 };
+
+function assertSandboxHttpRequestTargetAllowed(url: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new SsrFBlockedError("Invalid URL supplied to sandbox http/request");
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new SsrFBlockedError(
+      `Blocked non-HTTP(S) protocol in sandbox http/request: ${parsed.protocol}`,
+    );
+  }
+  if (isBlockedHostnameOrIp(parsed.hostname)) {
+    throw new SsrFBlockedError(
+      `Blocked hostname or private/internal IP in sandbox http/request: ${parsed.hostname}`,
+    );
+  }
+}
 
 async function runSandboxHttpRequest(
   execServer: OpenClawExecServer,
@@ -236,6 +258,8 @@ trap 'rm -f "$tmp"' EXIT
 cat > "$tmp" <<'PY'
 import base64
 import json
+import ipaddress
+import socket
 import sys
 import urllib.error
 import urllib.parse
@@ -246,6 +270,71 @@ def emit(payload):
 
 def response_headers(response):
     return [{"name": name, "value": value} for name, value in response.headers.items()]
+
+BLOCKED_HOSTNAMES = {
+    "localhost",
+    "localhost.localdomain",
+    "metadata.google.internal",
+}
+PINNED_ADDRESSES = {}
+
+def normalize_hostname(hostname):
+    return (hostname or "").strip("[]").rstrip(".").lower()
+
+def is_blocked_hostname(hostname):
+    normalized = normalize_hostname(hostname)
+    return (
+        normalized in BLOCKED_HOSTNAMES
+        or normalized.endswith(".localhost")
+        or normalized.endswith(".local")
+        or normalized.endswith(".internal")
+    )
+
+def is_blocked_ip(address):
+    try:
+        parsed = ipaddress.ip_address(address)
+    except ValueError:
+        return False
+    return (
+        parsed.is_loopback
+        or parsed.is_private
+        or parsed.is_link_local
+        or parsed.is_multicast
+        or parsed.is_reserved
+        or parsed.is_unspecified
+    )
+
+def assert_url_allowed(url):
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError("http/request only supports http and https URLs")
+    hostname = normalize_hostname(parsed.hostname)
+    if not hostname or is_blocked_hostname(hostname) or is_blocked_ip(hostname):
+        raise ValueError("Blocked hostname or private/internal/special-use IP address")
+    try:
+        results = socket.getaddrinfo(hostname, parsed.port, proto=socket.IPPROTO_TCP)
+    except socket.gaierror as error:
+        raise ValueError(f"Unable to resolve hostname: {hostname}") from error
+    addresses = {entry[4][0] for entry in results if entry[4]}
+    if not addresses or any(is_blocked_ip(address) for address in addresses):
+        raise ValueError("Blocked: resolves to private/internal/special-use IP address")
+    PINNED_ADDRESSES[hostname] = sorted(addresses)
+
+class GuardedRedirectHandler(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        assert_url_allowed(newurl)
+        return super().redirect_request(req, fp, code, msg, headers, newurl)
+
+def pinned_getaddrinfo(original_getaddrinfo):
+    def getaddrinfo(host, port, family=0, type=0, proto=0, flags=0):
+        pinned = PINNED_ADDRESSES.get(normalize_hostname(host))
+        if not pinned:
+            return original_getaddrinfo(host, port, family, type, proto, flags)
+        results = []
+        for address in pinned:
+            results.extend(original_getaddrinfo(address, port, family, type, proto, flags))
+        return results
+    return getaddrinfo
 
 def handle_response(input_data, response):
     headers = response_headers(response)
@@ -276,9 +365,7 @@ def handle_response(input_data, response):
 def main():
     input_data = json.load(sys.stdin)
     url = str(input_data.get("url", ""))
-    parsed = urllib.parse.urlparse(url)
-    if parsed.scheme not in ("http", "https"):
-        raise ValueError("http/request only supports http and https URLs")
+    assert_url_allowed(url)
     body_base64 = input_data.get("bodyBase64")
     data = base64.b64decode(body_base64) if isinstance(body_base64, str) else None
     request = urllib.request.Request(
@@ -292,11 +379,16 @@ def main():
     timeout = None
     if isinstance(timeout_ms, (int, float)) and timeout_ms > 0:
         timeout = timeout_ms / 1000
+    opener = urllib.request.build_opener(urllib.request.ProxyHandler({}), GuardedRedirectHandler)
+    original_getaddrinfo = socket.getaddrinfo
+    socket.getaddrinfo = pinned_getaddrinfo(original_getaddrinfo)
     try:
-        with urllib.request.urlopen(request, timeout=timeout) as response:
+        with opener.open(request, timeout=timeout) as response:
             handle_response(input_data, response)
     except urllib.error.HTTPError as response:
         handle_response(input_data, response)
+    finally:
+        socket.getaddrinfo = original_getaddrinfo
 
 if __name__ == "__main__":
     main()

--- a/extensions/codex/src/app-server/sandbox-exec-server/http.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server/http.ts
@@ -252,7 +252,7 @@ function readStreamingSandboxHttpResponse(params: {
   });
 }
 
-const SANDBOX_HTTP_REQUEST_SCRIPT = String.raw`
+export const SANDBOX_HTTP_REQUEST_SCRIPT = String.raw`
 tmp=$(mktemp "$TMPDIR/openclaw-http.XXXXXX.py" 2>/dev/null || mktemp "/tmp/openclaw-http.XXXXXX.py") || exit 1
 trap 'rm -f "$tmp"' EXIT
 cat > "$tmp" <<'PY'
@@ -276,6 +276,27 @@ BLOCKED_HOSTNAMES = {
     "localhost.localdomain",
     "metadata.google.internal",
 }
+CLOUD_METADATA_IP_ADDRESSES = {
+    "100.100.100.200",
+    "fd00:ec2::254",
+}
+BLOCKED_IPV4_NETWORKS = tuple(
+    ipaddress.ip_network(network)
+    for network in (
+        "100.64.0.0/10",
+        "198.18.0.0/15",
+    )
+)
+BLOCKED_IPV6_NETWORKS = tuple(
+    ipaddress.ip_network(network)
+    for network in (
+        "100::/64",
+        "2001:2::/48",
+        "2001:20::/28",
+        "2001:db8::/32",
+        "fec0::/10",
+    )
+)
 PINNED_ADDRESSES = {}
 
 def normalize_hostname(hostname):
@@ -295,6 +316,17 @@ def is_blocked_ip(address):
         parsed = ipaddress.ip_address(address)
     except ValueError:
         return False
+    embedded_ipv4 = extract_embedded_ipv4(parsed)
+    if embedded_ipv4 is not None and is_blocked_ip(str(embedded_ipv4)):
+        return True
+    if str(parsed).lower() in CLOUD_METADATA_IP_ADDRESSES:
+        return True
+    if isinstance(parsed, ipaddress.IPv4Address):
+        if any(parsed in network for network in BLOCKED_IPV4_NETWORKS):
+            return True
+    else:
+        if any(parsed in network for network in BLOCKED_IPV6_NETWORKS):
+            return True
     return (
         parsed.is_loopback
         or parsed.is_private
@@ -303,6 +335,30 @@ def is_blocked_ip(address):
         or parsed.is_reserved
         or parsed.is_unspecified
     )
+
+def ipv4_from_int(value):
+    return ipaddress.IPv4Address(value & 0xffffffff)
+
+def extract_embedded_ipv4(address):
+    if not isinstance(address, ipaddress.IPv6Address):
+        return None
+    if address.ipv4_mapped is not None:
+        return address.ipv4_mapped
+    value = int(address)
+    hextets = [(value >> shift) & 0xffff for shift in range(112, -1, -16)]
+    if hextets[:6] == [0, 0, 0, 0, 0, 0]:
+        return ipv4_from_int(value)
+    if hextets[:6] == [0x64, 0xff9b, 0, 0, 0, 0]:
+        return ipv4_from_int(value)
+    if hextets[:6] == [0x64, 0xff9b, 1, 0, 0, 0]:
+        return ipv4_from_int(value)
+    if hextets[0] == 0x2002:
+        return ipv4_from_int((hextets[1] << 16) | hextets[2])
+    if hextets[0] == 0x2001 and hextets[1] == 0:
+        return ipv4_from_int(((hextets[6] << 16) | hextets[7]) ^ 0xffffffff)
+    if (hextets[4] & 0xfcff) == 0 and hextets[5] == 0x5efe:
+        return ipv4_from_int((hextets[6] << 16) | hextets[7])
+    return None
 
 def assert_url_allowed(url):
     parsed = urllib.parse.urlparse(url)


### PR DESCRIPTION
## Summary

Harden the Codex sandbox exec-server HTTP bridge so sandbox `http/request` rejects private/internal HTTP targets before dispatch and keeps the in-sandbox request path bound to validated DNS results.

## Changes

- Add TypeScript-side URL scheme and host/IP preflight before buffered or streaming sandbox HTTP execution starts.
- Add in-sandbox Python checks for blocked hostnames, private/internal/special-use resolved addresses, redirect targets, cloud metadata literals, CGNAT/RFC2544 IPv4 ranges, deprecated site-local IPv6, and embedded IPv4 transition forms.
- Disable environment proxy handling for the bridge and pin validated DNS answers for the actual socket connection to avoid validation/connect drift.
- Cover blocked private, metadata-style, and Python-helper protected IP targets in the focused Codex sandbox HTTP tests.

## Validation

- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm exec oxfmt --write --threads=1 extensions/codex/src/app-server/sandbox-exec-server/http.ts extensions/codex/src/app-server/sandbox-exec-server.http.test.ts`
- `node scripts/run-vitest.mjs extensions/codex/src/app-server/sandbox-exec-server.http.test.ts` - passed, 1 file / 7 tests.
- `git diff --check` - passed.
- `node scripts/check-src-extension-import-boundary.mjs --json` - passed, `[]`.
- `node scripts/check-sdk-package-extension-import-boundary.mjs --json` - passed, `[]`.
- `node scripts/check-test-helper-extension-import-boundary.mjs --json` - passed, `[]`.
- `.agents/skills/autoreview/scripts/autoreview --mode local` - clean, no accepted/actionable findings.

Real behavior proof:

- Behavior addressed: sandbox `http/request` blocks protected metadata/internal targets before backend execution, and the embedded sandbox HTTP helper independently blocks the same protected target class.
- Real environment tested: local OpenClaw checkout on branch `734`, Node/Vitest test harness plus the generated shell/Python helper executed by `bash` and `python3`.
- Exact steps or command run after this patch: manual JSON-RPC bridge probe sent `http/request` for `http://100.100.100.200/`; manual embedded-helper probe executed `SANDBOX_HTTP_REQUEST_SCRIPT` with the same URL.
- Evidence after fix: JSON-RPC bridge probe returned `blocked: true`, `backendCalls: 0`, and `Blocked hostname or private/internal IP in sandbox http/request: 100.100.100.200`.
- Observed result after fix: embedded-helper probe exited with code `1`, produced no stdout, and stderr ended with `ValueError: Blocked hostname or private/internal/special-use IP address`.
- What was not tested: a full remote Docker/SSH sandbox session with live external networking was not run; the focused bridge and helper proofs exercise the patched blocking paths directly without contacting the protected endpoint.

## Notes

AI-assisted security hardening PR by @eleqtrizit. The related private tracking context is intentionally not expanded in this public PR body.
