### PR TITLE
fix(config): clarify retired skill workshop plugin warning

### DIFF
--- a/src/config/config.plugin-validation.test.ts
+++ b/src/config/config.plugin-validation.test.ts
@@ -1362,13 +1362,16 @@ describe("config plugin validation", () => {
     expectRemovedPluginWarnings(res, removedId, removedId);
   });
 
-  // Regression for #90244: skill-workshop was extracted into a built-in tool;
-  // upgraded configs that still reference plugins.entries.skill-workshop must warn,
-  // not block startup with "plugin not found".
   it("warns for removed skill-workshop plugin id instead of failing validation", () => {
     const removedId = "skill-workshop";
     const res = validateRemovedPluginConfig(removedId);
-    expectRemovedPluginWarnings(res, removedId, removedId);
+    expect(res.ok).toBe(true);
+    const message =
+      "plugin removed: skill-workshop (stale plugin config ignored; Skill Workshop is built into OpenClaw skills now. Use skills.workshop settings and openclaw skills workshop commands, then remove this plugins config entry)";
+    expectPathMessage(res.warnings, `plugins.entries.${removedId}`, message);
+    expectPathMessage(res.warnings, "plugins.allow", message);
+    expectPathMessage(res.warnings, "plugins.deny", message);
+    expectPathMessage(res.warnings, "plugins.slots.memory", message);
   });
 
   it("does not auto-allow config-loaded overrides of bundled web search plugin ids", () => {

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -57,6 +57,13 @@ const LEGACY_REMOVED_PLUGIN_IDS = new Set([
 ]);
 const BLOCKED_PLUGIN_CANDIDATE_PREFIX = "blocked plugin candidate:";
 
+function formatRemovedPluginConfigWarning(pluginId: string): string {
+  if (pluginId === "skill-workshop") {
+    return "plugin removed: skill-workshop (stale plugin config ignored; Skill Workshop is built into OpenClaw skills now. Use skills.workshop settings and openclaw skills workshop commands, then remove this plugins config entry)";
+  }
+  return `plugin removed: ${pluginId} (stale config entry ignored; remove it from plugins config)`;
+}
+
 type UnknownIssueRecord = Record<string, unknown>;
 type ConfigPathSegment = string | number;
 type ExplicitPluginReferences = {
@@ -1717,7 +1724,7 @@ function validateConfigObjectWithPluginsBase(
     if (LEGACY_REMOVED_PLUGIN_IDS.has(pluginId)) {
       warnings.push({
         path: pathLocal,
-        message: `plugin removed: ${pluginId} (stale config entry ignored; remove it from plugins config)`,
+        message: formatRemovedPluginConfigWarning(pluginId),
       });
       return;
     }


### PR DESCRIPTION
## Summary

Follow-up to #90838.

- Clarify the retired `skill-workshop` plugin warning so stale plugin config points users to the current built-in Skill Workshop surfaces: `skills.workshop` settings and `openclaw skills workshop` commands.
- Remove the verbose regression comments added in #90838 while keeping the regression coverage for warning-only validation.

## Verification

- `node scripts/run-vitest.mjs src/config/config.plugin-validation.test.ts`
- `../../node_modules/.bin/oxfmt --check src/config/validation.ts src/config/config.plugin-validation.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
