### PR TITLE
Preserve parent delivery for webchat-spawned child sessions

### DIFF
--- a/src/agents/spawn-requester-origin.test.ts
+++ b/src/agents/spawn-requester-origin.test.ts
@@ -3,7 +3,10 @@
 import { describe, expect, it } from "vitest";
 import type { AgentBindingMatch } from "../config/types.agents.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { resolveRequesterOriginForChild } from "./spawn-requester-origin.js";
+import {
+  preferParentExternalOriginWhenLiveOriginIsInternal,
+  resolveRequesterOriginForChild,
+} from "./spawn-requester-origin.js";
 
 describe("resolveRequesterOriginForChild", () => {
   function routeBinding(match: AgentBindingMatch) {
@@ -351,5 +354,29 @@ describe("resolveRequesterOriginForChild", () => {
         to,
       },
     );
+  });
+
+  it("keeps parent external delivery when a webchat view spawns child work for an SMS session", () => {
+    expect(
+      preferParentExternalOriginWhenLiveOriginIsInternal({
+        liveOrigin: {
+          channel: "webchat",
+          accountId: "browser",
+          to: "session:webchat-control",
+          threadId: "webchat-thread",
+        },
+        parentDeliveryContext: {
+          channel: "imessage",
+          accountId: "messages",
+          to: "+17372941355",
+          threadId: "sms-thread",
+        },
+      }),
+    ).toEqual({
+      channel: "imessage",
+      accountId: "messages",
+      to: "+17372941355",
+      threadId: "sms-thread",
+    });
   });
 });

--- a/src/agents/spawn-requester-origin.ts
+++ b/src/agents/spawn-requester-origin.ts
@@ -6,7 +6,11 @@
 import type { ChatType } from "../channels/chat-type.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveFirstBoundAccountId } from "../routing/bound-account-read.js";
-import { normalizeDeliveryContext } from "../utils/delivery-context.shared.js";
+import {
+  mergeDeliveryContext,
+  normalizeDeliveryContext,
+} from "../utils/delivery-context.shared.js";
+import type { DeliveryContext } from "../utils/delivery-context.types.js";
 
 // Delivery targets often carry a transport wrapper (e.g. Matrix `room:<id>` or
 // LINE `line:group:<id>`), while route bindings commonly store raw peer ids on
@@ -135,4 +139,23 @@ export function resolveRequesterOriginForChild(params: {
     to: params.requesterTo,
     threadId: params.requesterThreadId,
   });
+}
+
+export function preferParentExternalOriginWhenLiveOriginIsInternal(params: {
+  liveOrigin?: DeliveryContext;
+  parentDeliveryContext?: DeliveryContext;
+}) {
+  const liveOrigin = normalizeDeliveryContext(params.liveOrigin);
+  const parentDeliveryContext = normalizeDeliveryContext(params.parentDeliveryContext);
+  const liveChannel = liveOrigin?.channel?.toLowerCase();
+  const parentChannel = parentDeliveryContext?.channel?.toLowerCase();
+  if (
+    liveChannel === "webchat" &&
+    parentChannel &&
+    parentChannel !== "webchat" &&
+    parentDeliveryContext?.to
+  ) {
+    return mergeDeliveryContext(parentDeliveryContext, liveOrigin);
+  }
+  return liveOrigin;
 }

--- a/src/agents/subagent-spawn.runtime.ts
+++ b/src/agents/subagent-spawn.runtime.ts
@@ -8,7 +8,12 @@ export {
   DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH,
 } from "../config/agent-limits.js";
 export { getRuntimeConfig } from "../config/config.js";
-export { loadSessionStore, mergeSessionEntry, updateSessionStore } from "../config/sessions.js";
+export {
+  loadSessionStore,
+  mergeSessionEntry,
+  resolveStorePath,
+  updateSessionStore,
+} from "../config/sessions.js";
 export {
   forkSessionFromParent,
   resolveParentForkDecision,
@@ -30,6 +35,7 @@ export {
 export { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 export { emitSessionLifecycleEvent } from "../sessions/session-lifecycle-events.js";
 export {
+  deliveryContextFromSession,
   mergeDeliveryContext,
   normalizeDeliveryContext,
 } from "../utils/delivery-context.shared.js";

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -74,7 +74,10 @@ export {
   SUBAGENT_SPAWN_ACCEPTED_NOTE,
   SUBAGENT_SPAWN_SESSION_ACCEPTED_NOTE,
 } from "./subagent-spawn-accepted-note.js";
-import { resolveRequesterOriginForChild } from "./spawn-requester-origin.js";
+import {
+  preferParentExternalOriginWhenLiveOriginIsInternal,
+  resolveRequesterOriginForChild,
+} from "./spawn-requester-origin.js";
 import {
   resolveConfiguredSubagentRunTimeoutSeconds,
   resolveSubagentModelAndThinkingPlan,
@@ -87,6 +90,7 @@ import {
   DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH,
   buildSubagentSystemPrompt,
   callGateway,
+  deliveryContextFromSession,
   dispatchGatewayMethodInProcess,
   emitSessionLifecycleEvent,
   forkSessionFromParent,
@@ -106,6 +110,7 @@ import {
   resolveGatewaySessionStoreTarget,
   resolveInternalSessionKey,
   resolveMainSessionAlias,
+  resolveStorePath,
   resolveSandboxRuntimeStatus,
   updateSessionStore,
   isAdminOnlyMethod,
@@ -1216,16 +1221,33 @@ export async function spawnSubagentDirect(
       ? { threadId: ctx.agentThreadId }
       : {}),
   });
-  let childSessionOrigin = resolveRequesterOriginForChild({
-    cfg,
-    targetAgentId,
-    requesterAgentId,
-    requesterChannel: ctx.agentChannel,
-    requesterAccountId: ctx.agentAccountId,
-    requesterTo: ctx.agentTo,
-    requesterThreadId: ctx.agentThreadId,
-    requesterGroupSpace: ctx.agentGroupSpace,
-    requesterMemberRoleIds: ctx.agentMemberRoleIds,
+  let parentDeliveryContext: DeliveryContext | undefined;
+  if (requesterInternalKey && requesterAgentId) {
+    try {
+      parentDeliveryContext = deliveryContextFromSession(
+        loadSessionStore(
+          resolveStorePath(cfg.session?.store, {
+            agentId: requesterAgentId,
+          }),
+        )[requesterInternalKey],
+      );
+    } catch {
+      parentDeliveryContext = undefined;
+    }
+  }
+  let childSessionOrigin = preferParentExternalOriginWhenLiveOriginIsInternal({
+    parentDeliveryContext,
+    liveOrigin: resolveRequesterOriginForChild({
+      cfg,
+      targetAgentId,
+      requesterAgentId,
+      requesterChannel: ctx.agentChannel,
+      requesterAccountId: ctx.agentAccountId,
+      requesterTo: ctx.agentTo,
+      requesterThreadId: ctx.agentThreadId,
+      requesterGroupSpace: ctx.agentGroupSpace,
+      requesterMemberRoleIds: ctx.agentMemberRoleIds,
+    }),
   });
   const targetPolicy = resolveSubagentTargetPolicy({
     requesterAgentId,


### PR DESCRIPTION
## Summary
- preserve the parent external delivery context when child work is spawned from a webchat view attached to an external-channel session
- keep SMS/iMessage-origin sessions from drifting to webchat for spawned child/session work
- add a regression test for webchat live origin plus SMS/iMessage parent delivery

## Real behavior proof
**Behavior addressed:** Child/session work spawned while the operator is in webchat should keep the parent external SMS/iMessage delivery context instead of inheriting webchat as the reply target.

**Real environment tested:** Emily MacBook Air, macOS 15.2 arm64, installed OpenClaw 2026.6.1, local gateway on `ws://127.0.0.1:18789`, iMessage channel enabled. The installed package has the equivalent routing patch applied while this PR carries the source fix for current upstream.

**Exact steps or command run after this patch:**
1. Ran the local routing guard against the installed OpenClaw package.
2. Verified both affected compiled runtime paths report fixed.
3. Let the guard run `openclaw status --deep`.
4. Sent live control-lane replies to `sms:+17372941355` after the routing patch was installed.

**Evidence after fix:**
```text
OpenClaw package: /opt/homebrew/lib/node_modules/openclaw
delivery-context: fixed (/opt/homebrew/lib/node_modules/openclaw/dist/delivery-context.shared-DQ3Juxwd.js)
acp-spawn: fixed (/opt/homebrew/lib/node_modules/openclaw/dist/acp-spawn-CJ5JVDEI.js)
routing guard already present
$ openclaw status --deep
Gateway local ws://127.0.0.1:18789 reachable
Gateway service LaunchAgent installed, loaded, running
iMessage ON OK configured
Tasks 0 active, 0 queued, 0 running
```

Additional live receipt evidence from the SMS/iMessage control lane after the patch: outbound message receipts included `meta.service: "sms"` for sends targeting `sms:+17372941355`.

**Observed result after fix:** The patched live setup kept the external SMS/iMessage control lane usable after webchat participation and verified that both installed routing paths remained patched while the gateway was healthy.

**Not tested:** I did not install this exact PR branch over the live gateway; the live proof used the equivalent installed-package patch because this PR targets the upstream source tree. I also did not include unredacted phone numbers, auth tokens, or full local status output.

## Verification
- `node scripts/run-vitest.mjs run src/agents/spawn-requester-origin.test.ts src/utils/delivery-context.test.ts`
- `NODE_OPTIONS=--max-old-space-size=8192 npx --yes pnpm@11.2.2 exec tsc -p test/tsconfig/tsconfig.test.src.json --noEmit --pretty false` was run; routing files type-check, but the command still reports existing unrelated readonly tuple errors in `src/plugins/providers.test.ts` lines 202, 207, and 214.