### PR TITLE
fix: require ACP metadata for deleted-agent bypass

### DIFF
--- a/src/acp/runtime/session-meta.test.ts
+++ b/src/acp/runtime/session-meta.test.ts
@@ -8,7 +8,9 @@ import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db
 import { withTempDir } from "../../test-helpers/temp-dir.js";
 import {
   listAcpSessionEntries,
+  moveAcpSessionMetaForMigration,
   readAcpSessionEntry,
+  readAcpSessionMetaForEntry,
   upsertAcpSessionMeta,
   writeAcpSessionMetaForMigration,
 } from "./session-meta.js";
@@ -210,6 +212,57 @@ describe("ACP session metadata SQLite store", () => {
         "codex-current",
       );
       expect(await listAcpSessionEntries({ cfg, databasePath })).toHaveLength(1);
+    });
+  });
+
+  it("moves ACP metadata rows when session-store keys are canonicalized", async () => {
+    await withTempDir({ prefix: "openclaw-acp-meta-" }, async (dir) => {
+      const storePath = path.join(dir, "sessions.json");
+      const databasePath = path.join(dir, "state", "openclaw.sqlite");
+      const cfg = { session: { store: storePath } } as OpenClawConfig;
+      const legacyKey = "agent:CODEX:acp:legacy-runtime";
+      const canonicalKey = "agent:codex:acp:legacy-runtime";
+      await writeSessionStoreForTestAsync(storePath, {
+        [canonicalKey]: {
+          sessionId: "sess-acp",
+          updatedAt: 100,
+        },
+      });
+      writeAcpSessionMetaForMigration({
+        databasePath,
+        sessionKey: legacyKey,
+        sessionId: "sess-acp",
+        meta: {
+          backend: "acpx",
+          agent: "codex",
+          runtimeSessionName: legacyKey,
+          mode: "persistent",
+          state: "idle",
+          lastActivityAt: 123,
+        },
+      });
+
+      expect(
+        moveAcpSessionMetaForMigration({
+          databasePath,
+          fromSessionKey: legacyKey,
+          toSessionKey: canonicalKey,
+          entry: { sessionId: "sess-acp" },
+          now: () => 200,
+        }),
+      ).toBe(true);
+
+      expect(
+        readAcpSessionMetaForEntry({
+          databasePath,
+          sessionKey: legacyKey,
+          entry: { sessionId: "sess-acp" },
+        }),
+      ).toBeUndefined();
+      expect(
+        readAcpSessionEntry({ cfg, databasePath, sessionKey: canonicalKey })?.acp
+          ?.runtimeSessionName,
+      ).toBe(legacyKey);
     });
   });
 

--- a/src/acp/runtime/session-meta.test.ts
+++ b/src/acp/runtime/session-meta.test.ts
@@ -8,9 +8,9 @@ import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db
 import { withTempDir } from "../../test-helpers/temp-dir.js";
 import {
   listAcpSessionEntries,
-  moveAcpSessionMetaForMigration,
   readAcpSessionEntry,
   readAcpSessionMetaForEntry,
+  repairAcpSessionMetaKeyForMigration,
   upsertAcpSessionMeta,
   writeAcpSessionMetaForMigration,
 } from "./session-meta.js";
@@ -215,7 +215,7 @@ describe("ACP session metadata SQLite store", () => {
     });
   });
 
-  it("moves ACP metadata rows when session-store keys are canonicalized", async () => {
+  it("repairs ACP metadata rows when session-store keys are canonicalized", async () => {
     await withTempDir({ prefix: "openclaw-acp-meta-" }, async (dir) => {
       const storePath = path.join(dir, "sessions.json");
       const databasePath = path.join(dir, "state", "openclaw.sqlite");
@@ -243,10 +243,9 @@ describe("ACP session metadata SQLite store", () => {
       });
 
       expect(
-        moveAcpSessionMetaForMigration({
+        repairAcpSessionMetaKeyForMigration({
           databasePath,
-          fromSessionKey: legacyKey,
-          toSessionKey: canonicalKey,
+          sessionKey: canonicalKey,
           entry: { sessionId: "sess-acp" },
           now: () => 200,
         }),

--- a/src/acp/runtime/session-meta.ts
+++ b/src/acp/runtime/session-meta.ts
@@ -253,6 +253,7 @@ export function writeAcpSessionMetaForMigration(params: {
 
 export function repairAcpSessionMetaKeyForMigration(params: {
   sessionKey: string;
+  candidateSessionKeys?: Iterable<string | null | undefined>;
   entry?: Pick<SessionEntry, "sessionId">;
   env?: NodeJS.ProcessEnv;
   databasePath?: string;
@@ -272,17 +273,38 @@ export function repairAcpSessionMetaKeyForMigration(params: {
       }
 
       const normalizedSessionKey = normalizeLowercaseStringOrEmpty(sessionKey);
-      const row = executeSqliteQuerySync(
+      const candidateKeys = new Set<string>();
+      candidateKeys.add(normalizedSessionKey);
+      for (const candidate of params.candidateSessionKeys ?? []) {
+        const trimmed = typeof candidate === "string" ? candidate.trim() : "";
+        if (
+          trimmed &&
+          trimmed !== sessionKey &&
+          normalizeLowercaseStringOrEmpty(trimmed) === normalizedSessionKey
+        ) {
+          candidateKeys.add(trimmed);
+        }
+      }
+
+      let row: AcpSessionRow | undefined;
+      for (const candidateKey of candidateKeys) {
+        const candidateRow = selectAcpSessionRow(database.db, candidateKey);
+        if (candidateRow && acpSessionRowMatchesEntry(candidateRow, params.entry)) {
+          row = candidateRow;
+          break;
+        }
+      }
+      row ??= executeSqliteQuerySync(
         database.db,
         getAcpSessionKysely(database.db)
           .selectFrom("acp_sessions")
           .selectAll()
+          .where((eb) => eb.fn<string>("lower", ["session_key"]), "=", normalizedSessionKey)
           .orderBy("last_activity_at", "desc")
           .orderBy("session_key", "asc"),
       ).rows.find(
         (candidate) =>
           candidate.session_key !== sessionKey &&
-          normalizeLowercaseStringOrEmpty(candidate.session_key) === normalizedSessionKey &&
           acpSessionRowMatchesEntry(candidate, params.entry),
       );
       if (!row) {

--- a/src/acp/runtime/session-meta.ts
+++ b/src/acp/runtime/session-meta.ts
@@ -157,7 +157,10 @@ function selectAcpSessionRow(db: DatabaseSync, sessionKey: string): AcpSessionRo
   );
 }
 
-function acpSessionRowMatchesEntry(row: AcpSessionRow, entry: SessionEntry | undefined): boolean {
+function acpSessionRowMatchesEntry(
+  row: AcpSessionRow,
+  entry: Pick<SessionEntry, "sessionId"> | undefined,
+): boolean {
   // Rows tied to a specific sessionId are stale after the JSON session entry rotates.
   return row.session_id == null || row.session_id === entry?.sessionId;
 }
@@ -191,7 +194,7 @@ export function readAcpSessionMeta(params: {
 
 export function readAcpSessionMetaForEntry(params: {
   sessionKey: string;
-  entry: SessionEntry | undefined;
+  entry: Pick<SessionEntry, "sessionId"> | undefined;
   env?: NodeJS.ProcessEnv;
   databasePath?: string;
 }): SessionAcpMeta | undefined {
@@ -246,6 +249,45 @@ export function writeAcpSessionMetaForMigration(params: {
     },
     { env: params.env, path: params.databasePath },
   );
+}
+
+export function moveAcpSessionMetaForMigration(params: {
+  fromSessionKey: string;
+  toSessionKey: string;
+  entry?: Pick<SessionEntry, "sessionId">;
+  env?: NodeJS.ProcessEnv;
+  databasePath?: string;
+  now?: () => number;
+}): boolean {
+  const fromSessionKey = params.fromSessionKey.trim();
+  const toSessionKey = params.toSessionKey.trim();
+  if (!fromSessionKey || !toSessionKey || fromSessionKey === toSessionKey) {
+    return false;
+  }
+
+  let moved = false;
+  runOpenClawStateWriteTransaction(
+    (database) => {
+      const row = selectAcpSessionRow(database.db, fromSessionKey);
+      if (!row || !acpSessionRowMatchesEntry(row, params.entry)) {
+        return;
+      }
+      upsertAcpSessionMetaRow(database.db, {
+        ...row,
+        session_key: toSessionKey,
+        updated_at: params.now?.() ?? Date.now(),
+      });
+      executeSqliteQuerySync(
+        database.db,
+        getAcpSessionKysely(database.db)
+          .deleteFrom("acp_sessions")
+          .where("session_key", "=", fromSessionKey),
+      );
+      moved = true;
+    },
+    { env: params.env, path: params.databasePath },
+  );
+  return moved;
 }
 
 function upsertAcpSessionMetaRow(db: DatabaseSync, row: Insertable<AcpSessionsTable>): void {

--- a/src/acp/runtime/session-meta.ts
+++ b/src/acp/runtime/session-meta.ts
@@ -251,43 +251,59 @@ export function writeAcpSessionMetaForMigration(params: {
   );
 }
 
-export function moveAcpSessionMetaForMigration(params: {
-  fromSessionKey: string;
-  toSessionKey: string;
+export function repairAcpSessionMetaKeyForMigration(params: {
+  sessionKey: string;
   entry?: Pick<SessionEntry, "sessionId">;
   env?: NodeJS.ProcessEnv;
   databasePath?: string;
   now?: () => number;
 }): boolean {
-  const fromSessionKey = params.fromSessionKey.trim();
-  const toSessionKey = params.toSessionKey.trim();
-  if (!fromSessionKey || !toSessionKey || fromSessionKey === toSessionKey) {
+  const sessionKey = params.sessionKey.trim();
+  if (!sessionKey) {
     return false;
   }
 
-  let moved = false;
+  let repaired = false;
   runOpenClawStateWriteTransaction(
     (database) => {
-      const row = selectAcpSessionRow(database.db, fromSessionKey);
-      if (!row || !acpSessionRowMatchesEntry(row, params.entry)) {
+      const currentRow = selectAcpSessionRow(database.db, sessionKey);
+      if (currentRow && acpSessionRowMatchesEntry(currentRow, params.entry)) {
+        return;
+      }
+
+      const normalizedSessionKey = normalizeLowercaseStringOrEmpty(sessionKey);
+      const row = executeSqliteQuerySync(
+        database.db,
+        getAcpSessionKysely(database.db)
+          .selectFrom("acp_sessions")
+          .selectAll()
+          .orderBy("last_activity_at", "desc")
+          .orderBy("session_key", "asc"),
+      ).rows.find(
+        (candidate) =>
+          candidate.session_key !== sessionKey &&
+          normalizeLowercaseStringOrEmpty(candidate.session_key) === normalizedSessionKey &&
+          acpSessionRowMatchesEntry(candidate, params.entry),
+      );
+      if (!row) {
         return;
       }
       upsertAcpSessionMetaRow(database.db, {
         ...row,
-        session_key: toSessionKey,
+        session_key: sessionKey,
         updated_at: params.now?.() ?? Date.now(),
       });
       executeSqliteQuerySync(
         database.db,
         getAcpSessionKysely(database.db)
           .deleteFrom("acp_sessions")
-          .where("session_key", "=", fromSessionKey),
+          .where("session_key", "=", row.session_key),
       );
-      moved = true;
+      repaired = true;
     },
     { env: params.env, path: params.databasePath },
   );
-  return moved;
+  return repaired;
 }
 
 function upsertAcpSessionMetaRow(db: DatabaseSync, row: Insertable<AcpSessionsTable>): void {

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -39,12 +39,12 @@ import {
 } from "../../agents/agent-scope.js";
 import { rewriteTranscriptEntriesInSessionFile } from "../../agents/embedded-agent-runner/transcript-rewrite.js";
 import { runAgentHarnessBeforeMessageWriteHook } from "../../agents/harness/hook-helpers.js";
+import { modelCatalogBrowseRequiresFullDiscovery } from "../../agents/model-catalog-browse.js";
+import type { ModelCatalogEntry } from "../../agents/model-catalog.types.js";
 import { resolveProviderIdForAuth } from "../../agents/provider-auth-aliases.js";
 import type { AgentMessage } from "../../agents/runtime/index.js";
 import { ensureSandboxWorkspaceForSession } from "../../agents/sandbox/context.js";
 import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
-import type { ModelCatalogEntry } from "../../agents/model-catalog.types.js";
-import { modelCatalogBrowseRequiresFullDiscovery } from "../../agents/model-catalog-browse.js";
 import { dispatchInboundMessage } from "../../auto-reply/dispatch.js";
 import {
   getReplyPayloadMetadata,
@@ -3080,7 +3080,7 @@ export const chatHandlers: GatewayRequestHandlers = {
     }
     const requestedSessionId = normalizeOptionalText(p.sessionId);
     const backingSessionId = entry?.sessionId ?? requestedSessionId;
-    const deletedAgentId = resolveDeletedAgentIdFromSessionKey(cfg, sessionKey);
+    const deletedAgentId = resolveDeletedAgentIdFromSessionKey(cfg, sessionKey, entry);
     if (deletedAgentId !== null) {
       respond(
         false,

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -3068,7 +3068,7 @@ export const chatHandlers: GatewayRequestHandlers = {
       },
     );
     const sessionLoadMs = roundedChatSendTimingMs(performance.now() - sessionLoadStartedAtMs);
-    const { cfg, entry, canonicalKey: sessionKey } = sessionLoadResult;
+    const { cfg, entry, canonicalKey: sessionKey, legacyKey } = sessionLoadResult;
     const selectedAgent = validateChatSelectedAgent({
       cfg,
       requestedSessionKey: rawSessionKey,
@@ -3080,7 +3080,9 @@ export const chatHandlers: GatewayRequestHandlers = {
     }
     const requestedSessionId = normalizeOptionalText(p.sessionId);
     const backingSessionId = entry?.sessionId ?? requestedSessionId;
-    const deletedAgentId = resolveDeletedAgentIdFromSessionKey(cfg, sessionKey, entry);
+    const deletedAgentId = resolveDeletedAgentIdFromSessionKey(cfg, sessionKey, entry, {
+      acpMetadataSessionKey: legacyKey ?? sessionKey,
+    });
     if (deletedAgentId !== null) {
       respond(
         false,

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -787,7 +787,7 @@ async function handleSessionSend(params: {
   const loaded = loadSessionEntry(key, { agentId: requestedAgentId });
   let { entry, canonicalKey, storePath } = loaded;
   // Reject sends/steers targeting sessions whose owning agent was deleted (#65524).
-  const deletedAgentId = resolveDeletedAgentIdFromSessionKey(cfg, canonicalKey);
+  const deletedAgentId = resolveDeletedAgentIdFromSessionKey(cfg, canonicalKey, entry);
   if (deletedAgentId !== null) {
     params.respond(
       false,

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -785,9 +785,11 @@ async function handleSessionSend(params: {
   }
   const requestedAgentId = requestedAgent.agentId;
   const loaded = loadSessionEntry(key, { agentId: requestedAgentId });
-  let { entry, canonicalKey, storePath } = loaded;
+  let { entry, canonicalKey, storePath, legacyKey } = loaded;
   // Reject sends/steers targeting sessions whose owning agent was deleted (#65524).
-  const deletedAgentId = resolveDeletedAgentIdFromSessionKey(cfg, canonicalKey, entry);
+  const deletedAgentId = resolveDeletedAgentIdFromSessionKey(cfg, canonicalKey, entry, {
+    acpMetadataSessionKey: legacyKey ?? canonicalKey,
+  });
   if (deletedAgentId !== null) {
     params.respond(
       false,

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -785,7 +785,8 @@ async function handleSessionSend(params: {
   }
   const requestedAgentId = requestedAgent.agentId;
   const loaded = loadSessionEntry(key, { agentId: requestedAgentId });
-  let { entry, canonicalKey, storePath, legacyKey } = loaded;
+  const { legacyKey } = loaded;
+  let { entry, canonicalKey, storePath } = loaded;
   // Reject sends/steers targeting sessions whose owning agent was deleted (#65524).
   const deletedAgentId = resolveDeletedAgentIdFromSessionKey(cfg, canonicalKey, entry, {
     acpMetadataSessionKey: legacyKey ?? canonicalKey,

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -828,22 +828,43 @@ describe("gateway session utils", () => {
     expect(resolveDeletedAgentIdFromSessionKey(cfg, "agent:main:discord:direct:u1")).toBe("main");
   });
 
-  test("resolveDeletedAgentIdFromSessionKey ignores ACP harness session keys", () => {
+  test("resolveDeletedAgentIdFromSessionKey ignores confirmed ACP runtime session keys", () => {
     const cfg = {
       agents: { list: [{ id: "main", default: true }] },
     } as OpenClawConfig;
+    const acpEntry = (agent: string, runtimeSessionName: string) =>
+      ({
+        acp: {
+          backend: "acpx",
+          agent,
+          runtimeSessionName,
+          mode: "oneshot",
+          state: "idle",
+          lastActivityAt: 1,
+        },
+      }) as Pick<SessionEntry, "acp">;
+    const claudeKey = "agent:claude:acp:11111111-1111-4111-8111-111111111111";
+    const cursorKey = "agent:cursor:acp:22222222-2222-4222-8222-222222222222";
+    expect(
+      resolveDeletedAgentIdFromSessionKey(cfg, claudeKey, acpEntry("claude", claudeKey)),
+    ).toBeNull();
+    expect(
+      resolveDeletedAgentIdFromSessionKey(cfg, cursorKey, acpEntry("cursor", cursorKey)),
+    ).toBeNull();
+  });
+
+  test("resolveDeletedAgentIdFromSessionKey rejects ACP-shaped bridge keys without ACP metadata", () => {
+    const cfg = {
+      agents: { list: [{ id: "main", default: true }] },
+    } as OpenClawConfig;
+
     expect(
       resolveDeletedAgentIdFromSessionKey(
         cfg,
-        "agent:claude:acp:11111111-1111-4111-8111-111111111111",
+        "agent:deleted-agent:acp:bridge-session-without-runtime-meta",
+        { acp: undefined },
       ),
-    ).toBeNull();
-    expect(
-      resolveDeletedAgentIdFromSessionKey(
-        cfg,
-        "agent:cursor:acp:22222222-2222-4222-8222-222222222222",
-      ),
-    ).toBeNull();
+    ).toBe("deleted-agent");
   });
 
   test("resolveDeletedAgentIdFromSessionKey rejects deleted configured ACP binding owners", () => {

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -860,6 +860,12 @@ describe("gateway session utils", () => {
     } as OpenClawConfig;
 
     expect(
+      resolveDeletedAgentIdFromSessionKey(cfg, "agent:main:acp:configured-bridge-without-meta", {
+        acp: undefined,
+      } as SessionEntry),
+    ).toBeNull();
+
+    expect(
       resolveDeletedAgentIdFromSessionKey(
         cfg,
         "agent:deleted-agent:acp:bridge-session-without-runtime-meta",

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -871,7 +871,7 @@ describe("gateway session utils", () => {
       resolveDeletedAgentIdFromSessionKey(
         cfg,
         "agent:deleted-agent:acp:bridge-session-without-runtime-meta",
-        { acp: undefined },
+        { acp: undefined, sessionId: "sess-deleted-bridge", updatedAt: 1 },
       ),
     ).toBe("deleted-agent");
   });

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -842,7 +842,7 @@ describe("gateway session utils", () => {
           state: "idle",
           lastActivityAt: 1,
         },
-      }) as Pick<SessionEntry, "acp">;
+      }) as SessionEntry;
     const claudeKey = "agent:claude:acp:11111111-1111-4111-8111-111111111111";
     const cursorKey = "agent:cursor:acp:22222222-2222-4222-8222-222222222222";
     expect(

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -862,7 +862,9 @@ describe("gateway session utils", () => {
     expect(
       resolveDeletedAgentIdFromSessionKey(cfg, "agent:main:acp:configured-bridge-without-meta", {
         acp: undefined,
-      } as SessionEntry),
+        sessionId: "sess-configured-bridge",
+        updatedAt: 1,
+      }),
     ).toBeNull();
 
     expect(

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, test, vi } from "vitest";
+import { writeAcpSessionMetaForMigration } from "../acp/runtime/session-meta.js";
 import { resetConfigRuntimeState, setRuntimeConfigSnapshot } from "../config/config.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { loadSessionStore, type SessionEntry } from "../config/sessions.js";
@@ -865,6 +866,45 @@ describe("gateway session utils", () => {
         { acp: undefined },
       ),
     ).toBe("deleted-agent");
+  });
+
+  test("resolveDeletedAgentIdFromSessionKey repairs canonical ACP metadata aliases", async () => {
+    await withStateDirEnv("session-utils-acp-deleted-agent-repair-", async ({ stateDir }) => {
+      const storePath = path.join(stateDir, "agents", "claude", "sessions", "sessions.json");
+      const acpKey = "agent:claude:acp:55555555-5555-4555-8555-555555555555";
+      const legacyAcpKey = "agent:CLAUDE:acp:55555555-5555-4555-8555-555555555555";
+      const entry = {
+        sessionId: "sess-acp-repair",
+        updatedAt: 1,
+      } satisfies SessionEntry;
+      writeSessionStoreForTest(storePath, {
+        [acpKey]: entry,
+      });
+      writeAcpSessionMetaForMigration({
+        sessionKey: legacyAcpKey,
+        sessionId: "sess-acp-repair",
+        meta: {
+          backend: "acpx",
+          agent: "claude",
+          runtimeSessionName: legacyAcpKey,
+          mode: "oneshot",
+          state: "idle",
+          lastActivityAt: 1,
+        },
+      });
+      const cfg = {
+        session: {
+          store: path.join(stateDir, "agents", "{agentId}", "sessions", "sessions.json"),
+        },
+        agents: { list: [{ id: "main", default: true }] },
+      } as OpenClawConfig;
+
+      expect(
+        resolveDeletedAgentIdFromSessionKey(cfg, acpKey, entry, {
+          acpMetadataSessionKey: acpKey,
+        }),
+      ).toBeNull();
+    });
   });
 
   test("resolveDeletedAgentIdFromSessionKey rejects deleted configured ACP binding owners", () => {

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -951,6 +951,7 @@ function readAcpMetaForDeletedAgentCheck(params: {
 
   repairAcpSessionMetaKeyForMigration({
     sessionKey: params.sessionKey,
+    candidateSessionKeys: directKeys,
     entry: params.entry ?? undefined,
   });
   return readAcpSessionMetaForEntry({

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -916,19 +916,22 @@ function resolveTranscriptUsageFallback(params: {
 /**
  * Returns the owning agent id if the session key belongs to an agent that is no
  * longer present in config (deleted). Returns null for non-agent legacy/global
- * keys, ACP harness session keys, or when the owning agent still exists (#65524).
+ * keys, confirmed ACP runtime session keys, or when the owning agent still
+ * exists (#65524).
  */
 export function resolveDeletedAgentIdFromSessionKey(
   cfg: OpenClawConfig,
   sessionKey: string,
+  entry?: Pick<SessionEntry, "acp"> | null,
 ): string | null {
   const parsed = parseAgentSessionKey(sessionKey);
   if (!parsed) {
     return null;
   }
-  // Free ACP spawn keys use agent:<harnessId>:acp:<uuid>, but configured ACP
-  // bindings use agent:<agentId>:acp:binding:* where agentId remains the owner.
-  if (isAcpSessionKey(sessionKey) && !parsed.rest.startsWith("acp:binding:")) {
+  // Free ACP runtime keys use agent:<harnessId>:acp:<uuid>, but key shape is
+  // not proof: ACP bridge sessions can use ACP-shaped keys without SessionAcpMeta.
+  // Configured acp:binding keys stay owner-scoped even when ACP metadata exists.
+  if (isAcpSessionKey(sessionKey) && !parsed.rest.startsWith("acp:binding:") && entry?.acp) {
     return null;
   }
   const agentId = normalizeAgentId(parsed.agentId);

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -975,6 +975,10 @@ export function resolveDeletedAgentIdFromSessionKey(
   if (!parsed) {
     return null;
   }
+  const agentId = normalizeAgentId(parsed.agentId);
+  if (listAgentIds(cfg).includes(agentId)) {
+    return null;
+  }
   if (isAcpSessionKey(sessionKey) && !parsed.rest.startsWith("acp:binding:")) {
     // Free ACP runtime keys use agent:<harnessId>:acp:<uuid>, but key shape is
     // not proof: ACP bridge sessions can use ACP-shaped keys without SessionAcpMeta.
@@ -988,10 +992,6 @@ export function resolveDeletedAgentIdFromSessionKey(
     if (acpMeta) {
       return null;
     }
-  }
-  const agentId = normalizeAgentId(parsed.agentId);
-  if (listAgentIds(cfg).includes(agentId)) {
-    return null;
   }
   return agentId;
 }

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -923,6 +923,7 @@ export function resolveDeletedAgentIdFromSessionKey(
   cfg: OpenClawConfig,
   sessionKey: string,
   entry?: SessionEntry | null,
+  options?: { acpMetadataSessionKey?: string | null },
 ): string | null {
   const parsed = parseAgentSessionKey(sessionKey);
   if (!parsed) {
@@ -932,8 +933,15 @@ export function resolveDeletedAgentIdFromSessionKey(
     // Free ACP runtime keys use agent:<harnessId>:acp:<uuid>, but key shape is
     // not proof: ACP bridge sessions can use ACP-shaped keys without SessionAcpMeta.
     // Configured acp:binding keys stay owner-scoped even when ACP metadata exists.
+    const acpMetadataSessionKey = normalizeOptionalString(options?.acpMetadataSessionKey);
     const acpMeta =
-      entry?.acp ?? readAcpSessionMetaForEntry({ sessionKey, entry: entry ?? undefined });
+      entry?.acp ??
+      (acpMetadataSessionKey
+        ? readAcpSessionMetaForEntry({
+            sessionKey: acpMetadataSessionKey,
+            entry: entry ?? undefined,
+          })
+        : readAcpSessionMeta({ sessionKey, cfg }));
     if (acpMeta) {
       return null;
     }

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -9,7 +9,11 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import type { SessionsListParams } from "../../packages/gateway-protocol/src/index.js";
-import { readAcpSessionMeta, readAcpSessionMetaForEntry } from "../acp/runtime/session-meta.js";
+import {
+  readAcpSessionMeta,
+  readAcpSessionMetaForEntry,
+  repairAcpSessionMetaKeyForMigration,
+} from "../acp/runtime/session-meta.js";
 import { resolveModelAgentRuntimeMetadata } from "../agents/agent-runtime-metadata.js";
 import {
   listAgentIds,
@@ -913,6 +917,48 @@ function resolveTranscriptUsageFallback(params: {
   };
 }
 
+function readAcpMetaForDeletedAgentCheck(params: {
+  cfg: OpenClawConfig;
+  sessionKey: string;
+  entry?: Pick<SessionEntry, "acp" | "sessionId"> | null;
+  acpMetadataSessionKey?: string | null;
+}) {
+  if (params.entry?.acp) {
+    return params.entry.acp;
+  }
+
+  const acpMetadataSessionKey = normalizeOptionalString(params.acpMetadataSessionKey);
+  const directKeys = new Set<string>();
+  if (acpMetadataSessionKey) {
+    directKeys.add(acpMetadataSessionKey);
+  } else {
+    const acpMeta = readAcpSessionMeta({ sessionKey: params.sessionKey, cfg: params.cfg });
+    if (acpMeta) {
+      return acpMeta;
+    }
+  }
+  directKeys.add(params.sessionKey);
+
+  for (const directKey of directKeys) {
+    const acpMeta = readAcpSessionMetaForEntry({
+      sessionKey: directKey,
+      entry: params.entry ?? undefined,
+    });
+    if (acpMeta) {
+      return acpMeta;
+    }
+  }
+
+  repairAcpSessionMetaKeyForMigration({
+    sessionKey: params.sessionKey,
+    entry: params.entry ?? undefined,
+  });
+  return readAcpSessionMetaForEntry({
+    sessionKey: params.sessionKey,
+    entry: params.entry ?? undefined,
+  });
+}
+
 /**
  * Returns the owning agent id if the session key belongs to an agent that is no
  * longer present in config (deleted). Returns null for non-agent legacy/global
@@ -933,15 +979,12 @@ export function resolveDeletedAgentIdFromSessionKey(
     // Free ACP runtime keys use agent:<harnessId>:acp:<uuid>, but key shape is
     // not proof: ACP bridge sessions can use ACP-shaped keys without SessionAcpMeta.
     // Configured acp:binding keys stay owner-scoped even when ACP metadata exists.
-    const acpMetadataSessionKey = normalizeOptionalString(options?.acpMetadataSessionKey);
-    const acpMeta =
-      entry?.acp ??
-      (acpMetadataSessionKey
-        ? readAcpSessionMetaForEntry({
-            sessionKey: acpMetadataSessionKey,
-            entry: entry ?? undefined,
-          })
-        : readAcpSessionMeta({ sessionKey, cfg }));
+    const acpMeta = readAcpMetaForDeletedAgentCheck({
+      cfg,
+      sessionKey,
+      entry,
+      acpMetadataSessionKey: options?.acpMetadataSessionKey,
+    });
     if (acpMeta) {
       return null;
     }

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -9,7 +9,7 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import type { SessionsListParams } from "../../packages/gateway-protocol/src/index.js";
-import { readAcpSessionMeta } from "../acp/runtime/session-meta.js";
+import { readAcpSessionMeta, readAcpSessionMetaForEntry } from "../acp/runtime/session-meta.js";
 import { resolveModelAgentRuntimeMetadata } from "../agents/agent-runtime-metadata.js";
 import {
   listAgentIds,
@@ -922,17 +922,21 @@ function resolveTranscriptUsageFallback(params: {
 export function resolveDeletedAgentIdFromSessionKey(
   cfg: OpenClawConfig,
   sessionKey: string,
-  entry?: Pick<SessionEntry, "acp"> | null,
+  entry?: SessionEntry | null,
 ): string | null {
   const parsed = parseAgentSessionKey(sessionKey);
   if (!parsed) {
     return null;
   }
-  // Free ACP runtime keys use agent:<harnessId>:acp:<uuid>, but key shape is
-  // not proof: ACP bridge sessions can use ACP-shaped keys without SessionAcpMeta.
-  // Configured acp:binding keys stay owner-scoped even when ACP metadata exists.
-  if (isAcpSessionKey(sessionKey) && !parsed.rest.startsWith("acp:binding:") && entry?.acp) {
-    return null;
+  if (isAcpSessionKey(sessionKey) && !parsed.rest.startsWith("acp:binding:")) {
+    // Free ACP runtime keys use agent:<harnessId>:acp:<uuid>, but key shape is
+    // not proof: ACP bridge sessions can use ACP-shaped keys without SessionAcpMeta.
+    // Configured acp:binding keys stay owner-scoped even when ACP metadata exists.
+    const acpMeta =
+      entry?.acp ?? readAcpSessionMetaForEntry({ sessionKey, entry: entry ?? undefined });
+    if (acpMeta) {
+      return null;
+    }
   }
   const agentId = normalizeAgentId(parsed.agentId);
   if (listAgentIds(cfg).includes(agentId)) {

--- a/src/gateway/sessions-resolve-store.test.ts
+++ b/src/gateway/sessions-resolve-store.test.ts
@@ -295,6 +295,13 @@ describe("resolveSessionKeyFromResolveParams store canonicalization", () => {
           p: { key: acpKey },
         }),
       ).resolves.toEqual({ ok: true, key: acpKey });
+
+      await expect(
+        resolveSessionKeyFromResolveParams({
+          cfg,
+          p: { key: acpKey },
+        }),
+      ).resolves.toEqual({ ok: true, key: acpKey });
     });
   });
 

--- a/src/gateway/sessions-resolve-store.test.ts
+++ b/src/gateway/sessions-resolve-store.test.ts
@@ -222,6 +222,14 @@ describe("resolveSessionKeyFromResolveParams store canonicalization", () => {
           sessionId: "sess-acp-harness",
           label: "claude-delegate",
           updatedAt: freshUpdatedAt(),
+          acp: {
+            backend: "acpx",
+            agent: "claude",
+            runtimeSessionName: acpKey,
+            mode: "oneshot",
+            state: "idle",
+            lastActivityAt: freshUpdatedAt(),
+          },
         },
       });
 
@@ -245,6 +253,51 @@ describe("resolveSessionKeyFromResolveParams store canonicalization", () => {
           p: { label: "claude-delegate" },
         }),
       ).resolves.toEqual({ ok: true, key: acpKey });
+    });
+  });
+
+  it("rejects ACP-shaped bridge sessions without ACP runtime metadata under deleted agents", async () => {
+    await withStateDirEnv("openclaw-sessions-resolve-acp-bridge-deleted-", async () => {
+      const cfg: OpenClawConfig = {
+        agents: { list: [{ id: "main", default: true }] },
+      };
+      const acpBridgeKey = "agent:deleted-agent:acp:bridge-session-without-runtime-meta";
+      const deletedStorePath = resolveStorePath(cfg.session?.store, { agentId: "deleted-agent" });
+      await saveSessionStore(deletedStorePath, {
+        [acpBridgeKey]: {
+          sessionId: "sess-acp-bridge-deleted",
+          label: "deleted-bridge",
+          updatedAt: freshUpdatedAt(),
+        },
+      });
+      const expected = {
+        ok: false,
+        error: {
+          code: ErrorCodes.INVALID_REQUEST,
+          message: 'Agent "deleted-agent" no longer exists in configuration',
+        },
+      };
+
+      await expect(
+        resolveSessionKeyFromResolveParams({
+          cfg,
+          p: { key: acpBridgeKey },
+        }),
+      ).resolves.toEqual(expected);
+
+      await expect(
+        resolveSessionKeyFromResolveParams({
+          cfg,
+          p: { sessionId: "sess-acp-bridge-deleted" },
+        }),
+      ).resolves.toEqual(expected);
+
+      await expect(
+        resolveSessionKeyFromResolveParams({
+          cfg,
+          p: { label: "deleted-bridge" },
+        }),
+      ).resolves.toEqual(expected);
     });
   });
 

--- a/src/gateway/sessions-resolve-store.test.ts
+++ b/src/gateway/sessions-resolve-store.test.ts
@@ -261,6 +261,43 @@ describe("resolveSessionKeyFromResolveParams store canonicalization", () => {
     });
   });
 
+  it("resolves migrated ACP harness keys when metadata remains under the matched store key", async () => {
+    await withStateDirEnv("openclaw-sessions-resolve-acp-harness-legacy-", async () => {
+      const cfg: OpenClawConfig = {
+        agents: { list: [{ id: "main", default: true }] },
+      };
+      const acpKey = "agent:claude:acp:33333333-3333-4333-8333-333333333333";
+      const legacyAcpKey = "agent:CLAUDE:acp:33333333-3333-4333-8333-333333333333";
+      const claudeStorePath = resolveStorePath(cfg.session?.store, { agentId: "claude" });
+      await saveSessionStore(claudeStorePath, {
+        [legacyAcpKey]: {
+          sessionId: "sess-acp-harness-legacy",
+          label: "claude-delegate-legacy",
+          updatedAt: freshUpdatedAt(),
+        },
+      });
+      writeAcpSessionMetaForMigration({
+        sessionKey: legacyAcpKey,
+        sessionId: "sess-acp-harness-legacy",
+        meta: {
+          backend: "acpx",
+          agent: "claude",
+          runtimeSessionName: legacyAcpKey,
+          mode: "oneshot",
+          state: "idle",
+          lastActivityAt: freshUpdatedAt(),
+        },
+      });
+
+      await expect(
+        resolveSessionKeyFromResolveParams({
+          cfg,
+          p: { key: acpKey },
+        }),
+      ).resolves.toEqual({ ok: true, key: acpKey });
+    });
+  });
+
   it("rejects ACP-shaped bridge sessions without ACP runtime metadata under deleted agents", async () => {
     await withStateDirEnv("openclaw-sessions-resolve-acp-bridge-deleted-", async () => {
       const cfg: OpenClawConfig = {

--- a/src/gateway/sessions-resolve-store.test.ts
+++ b/src/gateway/sessions-resolve-store.test.ts
@@ -305,6 +305,50 @@ describe("resolveSessionKeyFromResolveParams store canonicalization", () => {
     });
   });
 
+  it("repairs ACP metadata when the session store key was already canonicalized", async () => {
+    await withStateDirEnv("openclaw-sessions-resolve-acp-harness-partial-", async () => {
+      const cfg: OpenClawConfig = {
+        agents: { list: [{ id: "main", default: true }] },
+      };
+      const acpKey = "agent:claude:acp:44444444-4444-4444-8444-444444444444";
+      const legacyAcpKey = "agent:CLAUDE:acp:44444444-4444-4444-8444-444444444444";
+      const claudeStorePath = resolveStorePath(cfg.session?.store, { agentId: "claude" });
+      await saveSessionStore(claudeStorePath, {
+        [acpKey]: {
+          sessionId: "sess-acp-harness-partial",
+          label: "claude-delegate-partial",
+          updatedAt: freshUpdatedAt(),
+        },
+      });
+      writeAcpSessionMetaForMigration({
+        sessionKey: legacyAcpKey,
+        sessionId: "sess-acp-harness-partial",
+        meta: {
+          backend: "acpx",
+          agent: "claude",
+          runtimeSessionName: legacyAcpKey,
+          mode: "oneshot",
+          state: "idle",
+          lastActivityAt: freshUpdatedAt(),
+        },
+      });
+
+      await expect(
+        resolveSessionKeyFromResolveParams({
+          cfg,
+          p: { key: acpKey },
+        }),
+      ).resolves.toEqual({ ok: true, key: acpKey });
+
+      await expect(
+        resolveSessionKeyFromResolveParams({
+          cfg,
+          p: { key: acpKey },
+        }),
+      ).resolves.toEqual({ ok: true, key: acpKey });
+    });
+  });
+
   it("rejects ACP-shaped bridge sessions without ACP runtime metadata under deleted agents", async () => {
     await withStateDirEnv("openclaw-sessions-resolve-acp-bridge-deleted-", async () => {
       const cfg: OpenClawConfig = {

--- a/src/gateway/sessions-resolve-store.test.ts
+++ b/src/gateway/sessions-resolve-store.test.ts
@@ -4,6 +4,7 @@
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { ErrorCodes } from "../../packages/gateway-protocol/src/index.js";
+import { writeAcpSessionMetaForMigration } from "../acp/runtime/session-meta.js";
 import { resolveStorePath, saveSessionStore } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
@@ -222,14 +223,18 @@ describe("resolveSessionKeyFromResolveParams store canonicalization", () => {
           sessionId: "sess-acp-harness",
           label: "claude-delegate",
           updatedAt: freshUpdatedAt(),
-          acp: {
-            backend: "acpx",
-            agent: "claude",
-            runtimeSessionName: acpKey,
-            mode: "oneshot",
-            state: "idle",
-            lastActivityAt: freshUpdatedAt(),
-          },
+        },
+      });
+      writeAcpSessionMetaForMigration({
+        sessionKey: acpKey,
+        sessionId: "sess-acp-harness",
+        meta: {
+          backend: "acpx",
+          agent: "claude",
+          runtimeSessionName: acpKey,
+          mode: "oneshot",
+          state: "idle",
+          lastActivityAt: freshUpdatedAt(),
         },
       });
 

--- a/src/gateway/sessions-resolve.test.ts
+++ b/src/gateway/sessions-resolve.test.ts
@@ -185,7 +185,19 @@ describe("resolveSessionKeyFromResolveParams", () => {
       storePath,
     });
     hoisted.loadSessionStoreMock.mockReturnValue({
-      [acpKey]: { sessionId: "sess-acp", updatedAt: 1, label: "claude-delegate-test" },
+      [acpKey]: {
+        sessionId: "sess-acp",
+        updatedAt: 1,
+        label: "claude-delegate-test",
+        acp: {
+          backend: "acpx",
+          agent: "claude",
+          runtimeSessionName: acpKey,
+          mode: "oneshot",
+          state: "idle",
+          lastActivityAt: 1,
+        },
+      },
     });
     hoisted.listAgentIdsMock.mockReturnValue(["main"]);
 

--- a/src/gateway/sessions-resolve.ts
+++ b/src/gateway/sessions-resolve.ts
@@ -185,7 +185,7 @@ export async function resolveSessionKeyFromResolveParams(params: {
       cfg,
       target.canonicalKey,
       migratedStore[target.canonicalKey],
-      { acpMetadataSessionKey: legacyKey },
+      { acpMetadataSessionKey: target.canonicalKey },
     );
     if (agentCheckLegacy) {
       return agentCheckLegacy;

--- a/src/gateway/sessions-resolve.ts
+++ b/src/gateway/sessions-resolve.ts
@@ -7,9 +7,11 @@ import {
   errorShape,
   type SessionsResolveParams,
 } from "../../packages/gateway-protocol/src/index.js";
+import { moveAcpSessionMetaForMigration } from "../acp/runtime/session-meta.js";
 import { loadSessionStore, updateSessionStore, type SessionEntry } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveSessionIdMatchSelection } from "../sessions/session-id-resolution.js";
+import { isAcpSessionKey } from "../sessions/session-key-utils.js";
 import { parseSessionLabel } from "../sessions/session-label.js";
 import {
   filterAndSortSessionEntries,
@@ -161,6 +163,13 @@ export async function resolveSessionKeyFromResolveParams(params: {
       }
     });
     const migratedStore = loadSessionStore(target.storePath);
+    if (isAcpSessionKey(target.canonicalKey) || isAcpSessionKey(legacyKey)) {
+      moveAcpSessionMetaForMigration({
+        fromSessionKey: legacyKey,
+        toSessionKey: target.canonicalKey,
+        entry: migratedStore[target.canonicalKey],
+      });
+    }
     if (
       !isResolvedSessionKeyVisible({
         cfg,

--- a/src/gateway/sessions-resolve.ts
+++ b/src/gateway/sessions-resolve.ts
@@ -42,8 +42,9 @@ function noSessionFoundResult(key: string): SessionsResolveResult {
 function validateSessionAgentExists(
   cfg: OpenClawConfig,
   key: string,
+  entry?: Pick<SessionEntry, "acp"> | null,
 ): SessionsResolveResult | null {
-  const deletedAgentId = resolveDeletedAgentIdFromSessionKey(cfg, key);
+  const deletedAgentId = resolveDeletedAgentIdFromSessionKey(cfg, key, entry);
   if (deletedAgentId === null) {
     return null;
   }
@@ -137,7 +138,11 @@ export async function resolveSessionKeyFromResolveParams(params: {
       ) {
         return noSessionFoundResult(key);
       }
-      const agentCheck = validateSessionAgentExists(cfg, target.canonicalKey);
+      const agentCheck = validateSessionAgentExists(
+        cfg,
+        target.canonicalKey,
+        store[target.canonicalKey],
+      );
       if (agentCheck) {
         return agentCheck;
       }
@@ -153,18 +158,23 @@ export async function resolveSessionKeyFromResolveParams(params: {
         s[primaryKey] = s[legacyKey];
       }
     });
+    const migratedStore = loadSessionStore(target.storePath);
     if (
       !isResolvedSessionKeyVisible({
         cfg,
         p,
         storePath: target.storePath,
-        store: loadSessionStore(target.storePath),
+        store: migratedStore,
         key: target.canonicalKey,
       })
     ) {
       return noSessionFoundResult(key);
     }
-    const agentCheckLegacy = validateSessionAgentExists(cfg, target.canonicalKey);
+    const agentCheckLegacy = validateSessionAgentExists(
+      cfg,
+      target.canonicalKey,
+      migratedStore[target.canonicalKey],
+    );
     if (agentCheckLegacy) {
       return agentCheckLegacy;
     }
@@ -193,7 +203,12 @@ export async function resolveSessionKeyFromResolveParams(params: {
         ),
       };
     }
-    const agentCheckSessionId = validateSessionAgentExists(cfg, selection.sessionKey);
+    const selectedEntry = matches.find(([key]) => key === selection.sessionKey)?.[1];
+    const agentCheckSessionId = validateSessionAgentExists(
+      cfg,
+      selection.sessionKey,
+      selectedEntry,
+    );
     if (agentCheckSessionId) {
       return agentCheckSessionId;
     }
@@ -242,7 +257,8 @@ export async function resolveSessionKeyFromResolveParams(params: {
     };
   }
 
-  const agentCheckLabel = validateSessionAgentExists(cfg, list.sessions[0].key);
+  const labelKey = list.sessions[0].key;
+  const agentCheckLabel = validateSessionAgentExists(cfg, labelKey, store[labelKey]);
   if (agentCheckLabel) {
     return agentCheckLabel;
   }

--- a/src/gateway/sessions-resolve.ts
+++ b/src/gateway/sessions-resolve.ts
@@ -42,7 +42,7 @@ function noSessionFoundResult(key: string): SessionsResolveResult {
 function validateSessionAgentExists(
   cfg: OpenClawConfig,
   key: string,
-  entry?: Pick<SessionEntry, "acp"> | null,
+  entry?: SessionEntry | null,
 ): SessionsResolveResult | null {
   const deletedAgentId = resolveDeletedAgentIdFromSessionKey(cfg, key, entry);
   if (deletedAgentId === null) {

--- a/src/gateway/sessions-resolve.ts
+++ b/src/gateway/sessions-resolve.ts
@@ -7,11 +7,9 @@ import {
   errorShape,
   type SessionsResolveParams,
 } from "../../packages/gateway-protocol/src/index.js";
-import { repairAcpSessionMetaKeyForMigration } from "../acp/runtime/session-meta.js";
 import { loadSessionStore, updateSessionStore, type SessionEntry } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveSessionIdMatchSelection } from "../sessions/session-id-resolution.js";
-import { isAcpSessionKey } from "../sessions/session-key-utils.js";
 import { parseSessionLabel } from "../sessions/session-label.js";
 import {
   filterAndSortSessionEntries,
@@ -130,12 +128,6 @@ export async function resolveSessionKeyFromResolveParams(params: {
     const target = resolveGatewaySessionStoreTarget({ cfg, key });
     const store = loadSessionStore(target.storePath);
     if (store[target.canonicalKey]) {
-      if (isAcpSessionKey(target.canonicalKey)) {
-        repairAcpSessionMetaKeyForMigration({
-          sessionKey: target.canonicalKey,
-          entry: store[target.canonicalKey],
-        });
-      }
       if (
         !isResolvedSessionKeyVisible({
           cfg,
@@ -169,12 +161,6 @@ export async function resolveSessionKeyFromResolveParams(params: {
       }
     });
     const migratedStore = loadSessionStore(target.storePath);
-    if (isAcpSessionKey(target.canonicalKey) || isAcpSessionKey(legacyKey)) {
-      repairAcpSessionMetaKeyForMigration({
-        sessionKey: target.canonicalKey,
-        entry: migratedStore[target.canonicalKey],
-      });
-    }
     if (
       !isResolvedSessionKeyVisible({
         cfg,

--- a/src/gateway/sessions-resolve.ts
+++ b/src/gateway/sessions-resolve.ts
@@ -7,7 +7,7 @@ import {
   errorShape,
   type SessionsResolveParams,
 } from "../../packages/gateway-protocol/src/index.js";
-import { moveAcpSessionMetaForMigration } from "../acp/runtime/session-meta.js";
+import { repairAcpSessionMetaKeyForMigration } from "../acp/runtime/session-meta.js";
 import { loadSessionStore, updateSessionStore, type SessionEntry } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveSessionIdMatchSelection } from "../sessions/session-id-resolution.js";
@@ -130,6 +130,12 @@ export async function resolveSessionKeyFromResolveParams(params: {
     const target = resolveGatewaySessionStoreTarget({ cfg, key });
     const store = loadSessionStore(target.storePath);
     if (store[target.canonicalKey]) {
+      if (isAcpSessionKey(target.canonicalKey)) {
+        repairAcpSessionMetaKeyForMigration({
+          sessionKey: target.canonicalKey,
+          entry: store[target.canonicalKey],
+        });
+      }
       if (
         !isResolvedSessionKeyVisible({
           cfg,
@@ -164,9 +170,8 @@ export async function resolveSessionKeyFromResolveParams(params: {
     });
     const migratedStore = loadSessionStore(target.storePath);
     if (isAcpSessionKey(target.canonicalKey) || isAcpSessionKey(legacyKey)) {
-      moveAcpSessionMetaForMigration({
-        fromSessionKey: legacyKey,
-        toSessionKey: target.canonicalKey,
+      repairAcpSessionMetaKeyForMigration({
+        sessionKey: target.canonicalKey,
         entry: migratedStore[target.canonicalKey],
       });
     }

--- a/src/gateway/sessions-resolve.ts
+++ b/src/gateway/sessions-resolve.ts
@@ -43,8 +43,9 @@ function validateSessionAgentExists(
   cfg: OpenClawConfig,
   key: string,
   entry?: SessionEntry | null,
+  options?: { acpMetadataSessionKey?: string | null },
 ): SessionsResolveResult | null {
-  const deletedAgentId = resolveDeletedAgentIdFromSessionKey(cfg, key, entry);
+  const deletedAgentId = resolveDeletedAgentIdFromSessionKey(cfg, key, entry, options);
   if (deletedAgentId === null) {
     return null;
   }
@@ -142,6 +143,7 @@ export async function resolveSessionKeyFromResolveParams(params: {
         cfg,
         target.canonicalKey,
         store[target.canonicalKey],
+        { acpMetadataSessionKey: target.canonicalKey },
       );
       if (agentCheck) {
         return agentCheck;
@@ -174,6 +176,7 @@ export async function resolveSessionKeyFromResolveParams(params: {
       cfg,
       target.canonicalKey,
       migratedStore[target.canonicalKey],
+      { acpMetadataSessionKey: legacyKey },
     );
     if (agentCheckLegacy) {
       return agentCheckLegacy;

--- a/src/gateway/sessions-resolve.ts
+++ b/src/gateway/sessions-resolve.ts
@@ -206,7 +206,7 @@ export async function resolveSessionKeyFromResolveParams(params: {
         ),
       };
     }
-    const selectedEntry = matches.find(([key]) => key === selection.sessionKey)?.[1];
+    const selectedEntry = matches.find(([matchKey]) => matchKey === selection.sessionKey)?.[1];
     const agentCheckSessionId = validateSessionAgentExists(
       cfg,
       selection.sessionKey,


### PR DESCRIPTION
Summary:
- Tightens the deleted-agent guard for ACP-shaped session keys. ACP key shape alone is no longer treated as proof that a session is an ACP runtime session.
- Preserves the existing fast path for configured agents. If the agent still exists in config, the guard returns before doing ACP metadata or SQLite work.
- Keeps configured `acp:binding:*` sessions owner-scoped, so a deleted configured owner is still rejected instead of being exempted by ACP metadata.
- Updates `sessions.resolve`, `chat.send`, `sessions.send`, and `sessions.steer` so deleted-agent validation sees the loaded session entry, not just the session key string.
- Uses persisted ACP metadata to distinguish real ACP runtime sessions from ACP-shaped bridge sessions under missing agents.
- Repairs legacy/case-canonicalized ACP metadata rows when a JSON session key has already moved to the canonical key but the ACP metadata row is still stored under the old key.
- Bounds the metadata repair lookup: exact candidate keys are tried first, then normalized/lowercase lookup, with a case-insensitive SQLite fallback only for rare partial-migration states.

Why:
- ACP bridge sessions can use `agent:<id>:acp:...` key shapes without persisted `SessionAcpMeta`.
- Treating that shape as sufficient would let sessions under deleted configured agents bypass the deleted-agent guard incorrectly.
- The fix makes the bypass depend on the runtime metadata that proves the session is actually ACP-owned.

Verification:
- Rebased on latest `origin/main`.
- Auto-review: clean, no accepted/actionable findings.
- Crabbox AWS `cbx_a603919bef5b`, run `run_15e01e46ecf9`:
  - Focused ACP/gateway tests passed: 18 files, 524 tests.
  - `pnpm check:changed` passed.
