### PR TITLE
Fix one-shot Codex app-server teardown

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -1872,6 +1872,51 @@ describe("runCodexAppServerAttempt", () => {
     );
   });
 
+  it("retires the shared Codex app-server client after one-shot turn start failures", async () => {
+    const retireSpy = vi.spyOn(sharedClientModule, "retireSharedCodexAppServerClientIfCurrent");
+    retireSpy.mockReturnValue({ activeLeases: 0, closed: true });
+    const events: string[] = [];
+    const closeAndWait = vi.fn(async () => {
+      events.push("closeAndWait");
+      return true;
+    });
+    let startedClient: unknown;
+    setCodexAppServerClientFactoryForTest(async () => {
+      const client = {
+        request: vi.fn(async (method: string) => {
+          events.push(`request:${method}`);
+          if (method === "thread/start") {
+            return threadStartResult();
+          }
+          if (method === "turn/start") {
+            throw new Error("turn start failed");
+          }
+          return {};
+        }),
+        addNotificationHandler: vi.fn(() => () => undefined),
+        addRequestHandler: vi.fn(() => () => undefined),
+        addCloseHandler: vi.fn(() => () => undefined),
+        closeAndWait,
+      };
+      startedClient = client;
+      return client as never;
+    });
+    const params = createParams(
+      path.join(tempDir, "session.jsonl"),
+      path.join(tempDir, "workspace"),
+    );
+    params.cleanupBundleMcpOnRunEnd = true;
+
+    await expect(runCodexAppServerAttempt(params)).rejects.toThrow("turn start failed");
+
+    expect(retireSpy).toHaveBeenCalledWith(startedClient);
+    expect(closeAndWait).toHaveBeenCalledWith({ exitTimeoutMs: 2_000, forceKillDelayMs: 250 });
+    expect(events.indexOf("request:thread/unsubscribe")).toBeGreaterThan(-1);
+    expect(events.indexOf("closeAndWait")).toBeGreaterThan(
+      events.indexOf("request:thread/unsubscribe"),
+    );
+  });
+
   it("keeps the shared Codex app-server client warm without one-shot cleanup", async () => {
     const retireSpy = vi.spyOn(sharedClientModule, "retireSharedCodexAppServerClientIfCurrent");
     const closeAndWait = vi.fn(async () => true);

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -1810,6 +1810,117 @@ describe("runCodexAppServerAttempt", () => {
     expect(request.mock.calls.map(([method]) => method)).not.toContain("app/list");
   });
 
+  it("retires the shared Codex app-server client after one-shot cleanup turns", async () => {
+    const retireSpy = vi.spyOn(sharedClientModule, "retireSharedCodexAppServerClientIfCurrent");
+    retireSpy.mockReturnValue({ activeLeases: 0, closed: true });
+    const events: string[] = [];
+    const closeAndWait = vi.fn(async () => {
+      events.push("closeAndWait");
+      return true;
+    });
+    let startedClient: unknown;
+    let notify: ((notification: CodexServerNotification) => Promise<void>) | undefined;
+    setCodexAppServerClientFactoryForTest(async () => {
+      const client = {
+        request: vi.fn(async (method: string) => {
+          events.push(`request:${method}`);
+          if (method === "thread/start") {
+            return threadStartResult();
+          }
+          if (method === "turn/start") {
+            return turnStartResult();
+          }
+          return {};
+        }),
+        addNotificationHandler: vi.fn((handler) => {
+          notify = handler;
+          return () => undefined;
+        }),
+        addRequestHandler: vi.fn(() => () => undefined),
+        addCloseHandler: vi.fn(() => () => undefined),
+        closeAndWait,
+      };
+      startedClient = client;
+      return client as never;
+    });
+    const params = createParams(
+      path.join(tempDir, "session.jsonl"),
+      path.join(tempDir, "workspace"),
+    );
+    params.cleanupBundleMcpOnRunEnd = true;
+
+    const run = runCodexAppServerAttempt(params);
+    await vi.waitFor(() => expect(notify).toBeDefined(), fastWait);
+    if (!notify) {
+      throw new Error("expected turn notification handler");
+    }
+    await notify({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        turn: { id: "turn-1", status: "completed" },
+      },
+    });
+    await run;
+
+    expect(retireSpy).toHaveBeenCalledWith(startedClient);
+    expect(closeAndWait).toHaveBeenCalledWith({ exitTimeoutMs: 2_000, forceKillDelayMs: 250 });
+    expect(events.indexOf("request:thread/unsubscribe")).toBeGreaterThan(-1);
+    expect(events.indexOf("closeAndWait")).toBeGreaterThan(
+      events.indexOf("request:thread/unsubscribe"),
+    );
+  });
+
+  it("keeps the shared Codex app-server client warm without one-shot cleanup", async () => {
+    const retireSpy = vi.spyOn(sharedClientModule, "retireSharedCodexAppServerClientIfCurrent");
+    const closeAndWait = vi.fn(async () => true);
+    let notify: ((notification: CodexServerNotification) => Promise<void>) | undefined;
+    setCodexAppServerClientFactoryForTest(
+      async () =>
+        ({
+          request: vi.fn(async (method: string) => {
+            if (method === "thread/start") {
+              return threadStartResult();
+            }
+            if (method === "turn/start") {
+              return turnStartResult();
+            }
+            return {};
+          }),
+          addNotificationHandler: vi.fn((handler) => {
+            notify = handler;
+            return () => undefined;
+          }),
+          addRequestHandler: vi.fn(() => () => undefined),
+          addCloseHandler: vi.fn(() => () => undefined),
+          closeAndWait,
+        }) as never,
+    );
+    const params = createParams(
+      path.join(tempDir, "session.jsonl"),
+      path.join(tempDir, "workspace"),
+    );
+
+    const run = runCodexAppServerAttempt(params);
+    await vi.waitFor(() => expect(notify).toBeDefined(), fastWait);
+    if (!notify) {
+      throw new Error("expected turn notification handler");
+    }
+    await notify({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        turn: { id: "turn-1", status: "completed" },
+      },
+    });
+    await run;
+
+    expect(retireSpy).not.toHaveBeenCalled();
+    expect(closeAndWait).not.toHaveBeenCalled();
+  });
+
   it("keeps searchable Codex dynamic tools canonical in mirrored transcript snapshots", async () => {
     const params = createParams(
       path.join(tempDir, "session.jsonl"),

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -224,6 +224,7 @@ import {
   writeCodexAppServerBinding,
   type CodexAppServerThreadBinding,
 } from "./session-binding.js";
+import { retireSharedCodexAppServerClientIfCurrent } from "./shared-client.js";
 import { rotateOversizedCodexAppServerStartupBinding } from "./startup-binding.js";
 import {
   buildDeveloperInstructions,
@@ -1119,6 +1120,7 @@ export async function runCodexAppServerAttempt(
   };
   let nativeHookRelay: NativeHookRelayRegistrationHandle | undefined;
   let releaseSharedClientLease: (() => void) | undefined;
+  let sharedCodexClientRetiredForOneShotCleanup = false;
   const releaseSharedClientLeaseOnce = () => {
     const release = releaseSharedClientLease;
     if (!release) {
@@ -1126,6 +1128,27 @@ export async function runCodexAppServerAttempt(
     }
     releaseSharedClientLease = undefined;
     release();
+  };
+  const retireSharedCodexClientForOneShotCleanup = async () => {
+    if (params.cleanupBundleMcpOnRunEnd !== true) {
+      return;
+    }
+    if (sharedCodexClientRetiredForOneShotCleanup) {
+      return;
+    }
+    sharedCodexClientRetiredForOneShotCleanup = true;
+    const retired = retireSharedCodexAppServerClientIfCurrent(client);
+    embeddedAgentLog.info("codex app-server one-shot cleanup retired shared client", {
+      runId: params.runId,
+      sessionId: params.sessionId,
+      sessionKey: params.sessionKey,
+      activeLeases: retired?.activeLeases ?? null,
+      closed: retired?.closed ?? false,
+      matchedSharedClient: Boolean(retired),
+    });
+    if (retired?.closed) {
+      await client.closeAndWait({ exitTimeoutMs: 2_000, forceKillDelayMs: 250 });
+    }
   };
   let sandboxExecEnvironmentAcquired = false;
   const releaseSandboxExecEnvironment = async () => {
@@ -2773,6 +2796,7 @@ export async function runCodexAppServerAttempt(
     requestCleanup();
     closeCleanup?.();
     releaseSharedClientLeaseOnce();
+    await retireSharedCodexClientForOneShotCleanup();
     if (nativeHookRelay) {
       if (shouldDelayNativeHookRelayUnregister) {
         // Codex hook subprocesses can outlive a completed app-server turn by a

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -1150,6 +1150,10 @@ export async function runCodexAppServerAttempt(
       await client.closeAndWait({ exitTimeoutMs: 2_000, forceKillDelayMs: 250 });
     }
   };
+  const releaseSharedClientLeaseAndRetireOneShotClient = async () => {
+    releaseSharedClientLeaseOnce();
+    await retireSharedCodexClientForOneShotCleanup();
+  };
   let sandboxExecEnvironmentAcquired = false;
   const releaseSandboxExecEnvironment = async () => {
     if (sandboxExecEnvironmentAcquired) {
@@ -2325,7 +2329,7 @@ export async function runCodexAppServerAttempt(
         },
       });
       params.abortSignal?.removeEventListener("abort", abortFromUpstream);
-      releaseSharedClientLeaseOnce();
+      await releaseSharedClientLeaseAndRetireOneShotClient();
       if (usageLimitError) {
         await markCodexAuthProfileBlockedFromRateLimits({
           params,
@@ -2345,7 +2349,7 @@ export async function runCodexAppServerAttempt(
     }
   }
   if (!turn) {
-    releaseSharedClientLeaseOnce();
+    await releaseSharedClientLeaseAndRetireOneShotClient();
     throw new Error("codex app-server turn/start failed without an error");
   }
   turnIdRef.current = turn.turn.id;
@@ -2795,8 +2799,7 @@ export async function runCodexAppServerAttempt(
     notificationCleanup();
     requestCleanup();
     closeCleanup?.();
-    releaseSharedClientLeaseOnce();
-    await retireSharedCodexClientForOneShotCleanup();
+    await releaseSharedClientLeaseAndRetireOneShotClient();
     if (nativeHookRelay) {
       if (shouldDelayNativeHookRelayUnregister) {
         // Codex hook subprocesses can outlive a completed app-server turn by a

--- a/packages/gateway-protocol/src/schema/agent.ts
+++ b/packages/gateway-protocol/src/schema/agent.ts
@@ -205,8 +205,8 @@ export const AgentParamsSchema = Type.Object(
     timeout: Type.Optional(Type.Integer({ minimum: 0 })),
     bestEffortDeliver: Type.Optional(Type.Boolean()),
     lane: Type.Optional(Type.String()),
-    // Backward-compatible no-op. Older CLI clients sent this field on gateway
-    // agent requests; the gateway accepts but intentionally ignores it.
+    // One-shot CLI gateway requests can ask the gateway to close process-wide
+    // bundle MCP resources after the run instead of keeping them warm.
     cleanupBundleMcpOnRunEnd: Type.Optional(Type.Boolean()),
     modelRun: Type.Optional(Type.Boolean()),
     promptMode: Type.Optional(

--- a/src/agents/embedded-agent-runner/run.before-agent-reply-cron.test.ts
+++ b/src/agents/embedded-agent-runner/run.before-agent-reply-cron.test.ts
@@ -23,12 +23,20 @@ function firstBeforeAgentReplyCall() {
 }
 
 function firstAttemptParams(): {
+  cleanupBundleMcpOnRunEnd?: boolean;
   modelRun?: boolean;
   promptMode?: string;
   promptCacheKey?: string;
 } {
   const call = mockedRunEmbeddedAttempt.mock.calls[0] as
-    | [{ modelRun?: boolean; promptMode?: string; promptCacheKey?: string }]
+    | [
+        {
+          cleanupBundleMcpOnRunEnd?: boolean;
+          modelRun?: boolean;
+          promptMode?: string;
+          promptCacheKey?: string;
+        },
+      ]
     | undefined;
   if (!call) {
     throw new Error("expected embedded attempt call");
@@ -153,6 +161,17 @@ describe("runEmbeddedAgent cron before_agent_reply seam", () => {
     const attemptParams = firstAttemptParams();
     expect(attemptParams.modelRun).toBe(true);
     expect(attemptParams.promptMode).toBe("none");
+  });
+
+  it("forwards one-shot bundle MCP cleanup into the embedded attempt", async () => {
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
+
+    await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      cleanupBundleMcpOnRunEnd: true,
+    });
+
+    expect(firstAttemptParams().cleanupBundleMcpOnRunEnd).toBe(true);
   });
 
   it("forwards prompt cache identity into the embedded attempt", async () => {

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -1869,6 +1869,7 @@ async function runEmbeddedAgentInternal(
             bootstrapContextRunKind: params.bootstrapContextRunKind,
             jobId: params.jobId,
             toolsAllow: params.toolsAllow,
+            cleanupBundleMcpOnRunEnd: params.cleanupBundleMcpOnRunEnd,
             disableMessageTool: params.disableMessageTool,
             forceMessageTool: params.forceMessageTool,
             enableHeartbeatTool: params.enableHeartbeatTool,

--- a/src/commands/agent-via-gateway.test.ts
+++ b/src/commands/agent-via-gateway.test.ts
@@ -301,7 +301,7 @@ describe("agentCliCommand", () => {
       expect(request.clientName).toBe("cli");
       expect(request.mode).toBe("cli");
       expect(request).not.toHaveProperty("scopes");
-      expect(request.params).not.toHaveProperty("cleanupBundleMcpOnRunEnd");
+      expect(request.params).toHaveProperty("cleanupBundleMcpOnRunEnd", true);
       expect(agentCommand).not.toHaveBeenCalled();
       expect(agentModuleLoadCount).not.toHaveBeenCalled();
       expect(runtime.log).toHaveBeenCalledWith("hello");

--- a/src/commands/agent-via-gateway.ts
+++ b/src/commands/agent-via-gateway.ts
@@ -704,6 +704,7 @@ async function agentViaGatewayCommand(
             timeout: timeoutSeconds,
             lane: opts.lane,
             extraSystemPrompt: opts.extraSystemPrompt,
+            cleanupBundleMcpOnRunEnd: true,
             idempotencyKey,
           },
           expectFinal: true,


### PR DESCRIPTION
## Summary
- Close the Codex app-server shared client after one-shot OpenClaw agent runs finish.
- Thread cleanup metadata through gateway/CLI agent paths so CLI sessions do not leave app-server or Agent Hub proxy children behind.
- Add regression coverage for cleanup, gateway propagation, and session resume behavior.

## Real behavior proof
- **Behavior or issue addressed:** One-shot Codex/OpenClaw agent runs could leave shared app-server and Agent Hub proxy children alive after the run ended, which made Jarvis/fleet sessions accumulate stale processes and degraded multi-session reliability.
- **Real environment tested:** Live managed OpenClaw runtime on `openclaw-vm01`, host runtime `OpenClaw 2026.6.2 (a23b0c7)`, managed plugin `@openclaw/codex 2026.6.2`.
- **Exact steps or command run after this patch:** Ran a Jarvis managed-plugin smoke session through the real OpenClaw gateway using session `agent:jarvis:teardown-source-aligned-smoke-20260609161031`; then checked runtime cleanup logs and waited 25 seconds before checking for lingering `codex app-server` or `agent-hub-proxy.ts` children.
- **Evidence after fix:** Terminal output from the live smoke showed `embedded fallback: false`, assistant reply `gateway path ok`, cleanup log `activeLeases=0 closed=true matchedSharedClient=true`, and the 25s post-run process check found no Codex app-server or Agent Hub proxy children except the grep process.
- **Observed result after fix:** The live run completed on the gateway path and cleaned up the shared managed-plugin client without leaving stale child processes behind.
- **What was not tested:** Full production merge/release rollout was not tested in this PR; validation was limited to local CI-equivalent gates plus the live managed-plugin smoke on `openclaw-vm01`.

## Validation
- `pnpm check:test-types`
- `pnpm tsgo:prod`
- `pnpm lint --threads=8`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.process.config.ts --reporter=verbose`
- `pnpm run lint:tmp:no-raw-channel-fetch`
- `pnpm protocol:gen && pnpm protocol:gen:swift` with generated Swift protocol artifact included
- Focused teardown/gateway tests and package/tarball validation were run before the live deployment smoke.