### PR TITLE
fix(ios): respect chat header safe area

### DIFF
--- a/apps/ios/Sources/Design/ChatProTab.swift
+++ b/apps/ios/Sources/Design/ChatProTab.swift
@@ -64,6 +64,7 @@ struct ChatProTab: View {
                     }
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+                .safeAreaPadding(.top, 8)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
             .navigationBarHidden(true)
@@ -103,7 +104,6 @@ struct ChatProTab: View {
             self.connectionPillButton
         }
         .padding(.horizontal, OpenClawProMetric.pagePadding)
-        .padding(.top, 8)
         .padding(.bottom, 4)
     }
 


### PR DESCRIPTION
## Summary

Fixes the iOS chat header overlapping the status bar / Dynamic Island by applying the existing top inset through SwiftUI safe-area layout.

> [!WARNING]
> Local validation used beta macOS 27 / Xcode 27. The app deployment target is unchanged, and iOS 26.5 simulator build also passed.

AI-assisted PR.

## Before / After

| Before | After |
| --- | --- |
| ![Before: chat header overlaps status area](https://gist.githubusercontent.com/zats/ab041af95d80c610f746c0798e9b25fa/raw/f2af8bf4eea27717d5e129410a5e7e1d75d73ed7/openclaw-ios-chat-header-before.svg) | ![After: chat header respects safe area](https://gist.githubusercontent.com/zats/ab041af95d80c610f746c0798e9b25fa/raw/fca2e5608831f6b1024b7fd2660b209b8e0fabd2/openclaw-ios-chat-header-after.svg) |

## Real behavior proof

- Behavior addressed: Chat header rendered under the iOS status area.
- Real environment tested: OpenClaw iOS app in simulator, connected to a real OpenClaw gateway.
- Exact steps or command run after this patch:
  - `git diff --check HEAD~1..HEAD`
  - `xcodebuild -project apps/ios/OpenClaw.xcodeproj -scheme OpenClaw -destination 'platform=iOS Simulator,OS=26.5,name=iPhone 17 Pro Max' CODE_SIGNING_ALLOWED=NO build`
  - `xcodebuild -project apps/ios/OpenClaw.xcodeproj -scheme OpenClaw -destination 'id=83796C22-9007-438E-8E28-D025EB9D4B33' CODE_SIGNING_ALLOWED=NO build`
  - `.agents/skills/autoreview/scripts/autoreview --mode commit --commit HEAD`
- Evidence after fix: See screenshot table.
- Observed result after fix: Header is below the status area; iOS 26.5 and iOS 27.0 simulator builds pass.
- What was not tested: Physical device runtime; automated snapshot coverage.

## Validation

- `git diff --check HEAD~1..HEAD`: passed
- iOS 26.5 simulator build: passed
- iOS 27.0 simulator build: passed
- Autoreview: clean

## Risk checklist

- [x] User-visible behavior changed: iOS chat header spacing
- [ ] Config, environment, or migration behavior changed
- [ ] Security, auth, secrets, network, or tool execution behavior changed
- [x] Highest risk identified: extra top spacing on devices with different safe-area insets
- [x] Mitigation: uses SwiftUI safe-area layout
