### PR TITLE
fix(memory): abort search embeddings on tool timeout

### DIFF
--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -1690,6 +1690,53 @@ describe("memory index", () => {
     ).toBe("local");
   });
 
+  it("does not activate fallback when caller cancellation aborts search embeddings", async () => {
+    const cfg = createCfg({
+      storePath: path.join(workspaceDir, "index-search-aborted-fallback.sqlite"),
+      fallback: "fallback-provider",
+      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
+    });
+    const manager = await getPersistentManager(cfg);
+
+    await manager.sync({ reason: "test" });
+    const callsBeforeSearch = providerCalls.length;
+    const controller = new AbortController();
+    (
+      manager as unknown as {
+        provider: {
+          id: string;
+          model: string;
+          embedQuery: () => Promise<number[]>;
+          embedBatch: (texts: string[]) => Promise<number[][]>;
+          close: () => Promise<void>;
+        };
+      }
+    ).provider = {
+      id: "mock",
+      model: "mock-embed",
+      embedQuery: async () => {
+        controller.abort(new Error("memory_search timed out after 15s"));
+        throw createLocalWorkerExitError();
+      },
+      embedBatch: async (texts: string[]) => texts.map(() => [1, 0, 0, 0]),
+      close: async () => {},
+    };
+
+    await expect(manager.search("alpha", { signal: controller.signal })).rejects.toThrow(
+      "memory_search timed out after 15s",
+    );
+
+    expect(providerCalls.slice(callsBeforeSearch)).toStrictEqual([]);
+    expect(
+      (
+        manager as unknown as {
+          provider: { id: string } | null;
+        }
+      ).provider?.id,
+    ).toBe("mock");
+    expect(manager.status().fallback).toBeUndefined();
+  });
+
   it("rebuilds with fallback provider during explicit identity repair", async () => {
     const dbPath = path.join(workspaceDir, "index-cli-fallback-identity-repair.sqlite");
     const oldCfg = createCfg({

--- a/extensions/memory-core/src/memory/manager-embedding-ops.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.ts
@@ -160,6 +160,16 @@ export function resolveMemoryIndexConcurrency(params: {
   return params.providerId === "ollama" ? 1 : EMBEDDING_INDEX_CONCURRENCY;
 }
 
+function createAbortReasonError(reason: unknown, fallbackMessage: string): Error {
+  if (reason instanceof Error) {
+    return reason;
+  }
+  if (typeof reason === "string" && reason.trim()) {
+    return new Error(reason);
+  }
+  return new Error(fallbackMessage);
+}
+
 export async function runEmbeddingOperationWithTimeout<T>(params: {
   timeoutMs: number;
   message: string;
@@ -168,11 +178,34 @@ export async function runEmbeddingOperationWithTimeout<T>(params: {
   run: (signal: AbortSignal) => Promise<T>;
 }): Promise<T> {
   const controller = new AbortController();
-  const signal = params.signal
-    ? AbortSignal.any([params.signal, controller.signal])
-    : controller.signal;
+  let rejectParentAbort: ((error: Error) => void) | undefined;
+  const parentAbortPromise = params.signal
+    ? new Promise<never>((_, reject) => {
+        rejectParentAbort = reject;
+      })
+    : undefined;
+  const abortFromParent = () => {
+    const error = createAbortReasonError(
+      params.signal?.reason,
+      "memory embedding operation aborted",
+    );
+    controller.abort(error);
+    rejectParentAbort?.(error);
+  };
+  if (params.signal?.aborted) {
+    abortFromParent();
+  } else {
+    params.signal?.addEventListener("abort", abortFromParent, { once: true });
+  }
   if (!Number.isFinite(params.timeoutMs) || params.timeoutMs <= 0) {
-    return await params.run(signal);
+    try {
+      const operation = params.run(controller.signal);
+      return parentAbortPromise
+        ? ((await Promise.race([operation, parentAbortPromise])) as T)
+        : await operation;
+    } finally {
+      params.signal?.removeEventListener("abort", abortFromParent);
+    }
   }
   const timeoutMs = resolveTimerTimeoutMs(params.timeoutMs, 1);
   let timer: NodeJS.Timeout | null = null;
@@ -184,9 +217,14 @@ export async function runEmbeddingOperationWithTimeout<T>(params: {
     }, timeoutMs);
   });
   try {
-    const operation = params.run(signal);
-    return (await Promise.race([operation, timeoutPromise])) as T;
+    const operation = params.run(controller.signal);
+    return (await Promise.race(
+      parentAbortPromise
+        ? [operation, timeoutPromise, parentAbortPromise]
+        : [operation, timeoutPromise],
+    )) as T;
   } finally {
+    params.signal?.removeEventListener("abort", abortFromParent);
     if (timer) {
       clearTimeout(timer);
     }
@@ -513,11 +551,11 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
             timeoutMs,
             message: `memory embeddings query timed out after ${Math.round(timeoutMs / 1000)}s`,
             signal,
-            run: async (opSignal) => await provider.embedQuery(text, { signal: opSignal }),
+            run: async (operationSignal) =>
+              await provider.embedQuery(text, { signal: operationSignal }),
           });
         },
-        signal,
-        isRetryable: isRetryableMemoryEmbeddingError,
+        isRetryable: (err) => !signal?.aborted && isRetryableMemoryEmbeddingError(err),
         waitForRetry: async (delayMs) => {
           await this.waitForEmbeddingRetry(delayMs, "retrying query");
         },

--- a/extensions/memory-core/src/memory/manager-embedding-timeout.test.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-timeout.test.ts
@@ -180,6 +180,50 @@ describe("memory embedding timeout abort", () => {
     await rejection;
   });
 
+  it("aborts the provider operation when the caller signal aborts", async () => {
+    vi.useFakeTimers();
+    const controller = new AbortController();
+    let signalSeen: AbortSignal | undefined;
+
+    const resultPromise = runEmbeddingOperationWithTimeout({
+      timeoutMs: 60_000,
+      message: "memory embeddings query timed out after 60s",
+      signal: controller.signal,
+      run: async (signal) => {
+        signalSeen = signal;
+        return await new Promise<number[]>((_resolve, reject) => {
+          signal.addEventListener(
+            "abort",
+            () => reject(toLintErrorObject(signal.reason, "Non-Error rejection")),
+            { once: true },
+          );
+        });
+      },
+    });
+
+    controller.abort(new Error("memory_search timed out after 15s"));
+
+    await expect(resultPromise).rejects.toThrow("memory_search timed out after 15s");
+    expect(signalSeen?.aborted).toBe(true);
+    expect(signalSeen?.reason).toBe(controller.signal.reason);
+  });
+
+  it("does not wait for the operation timeout when a caller aborts and the provider ignores the signal", async () => {
+    vi.useFakeTimers();
+    const controller = new AbortController();
+
+    const resultPromise = runEmbeddingOperationWithTimeout({
+      timeoutMs: 60_000,
+      message: "memory embeddings query timed out after 60s",
+      signal: controller.signal,
+      run: async () => await new Promise<number[]>(() => {}),
+    });
+
+    controller.abort(new Error("memory_search timed out after 15s"));
+
+    await expect(resultPromise).rejects.toThrow("memory_search timed out after 15s");
+  });
+
   it("caps operation watchdog timers before scheduling", async () => {
     const timeoutSpy = vi
       .spyOn(globalThis, "setTimeout")

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -17,7 +17,7 @@ import {
   type MemoryEmbeddingProbeResult,
   type MemoryProviderStatus,
   type MemorySearchManager,
-  type MemorySearchRuntimeDebug,
+  type MemorySearchOptions,
   type MemorySearchResult,
   type MemorySource,
   type MemorySyncProgressUpdate,
@@ -582,20 +582,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     return state;
   }
 
-  async search(
-    query: string,
-    opts?: {
-      maxResults?: number;
-      minScore?: number;
-      sessionKey?: string;
-      qmdSearchModeOverride?: "query" | "search" | "vsearch";
-      onDebug?: (debug: MemorySearchRuntimeDebug) => void;
-      /** When set, only these chunk sources are considered (must be enabled for this manager). */
-      sources?: MemorySource[];
-      /** Caller-owned cancellation; aborts in-flight embedding work when the caller stops waiting. */
-      signal?: AbortSignal;
-    },
-  ): Promise<MemorySearchResult[]> {
+  async search(query: string, opts?: MemorySearchOptions): Promise<MemorySearchResult[]> {
     opts?.onDebug?.({ backend: "builtin" });
     if (this.providerRequirement.mode === "required") {
       await this.ensureProviderInitialized();

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -42,7 +42,7 @@ import {
   type MemoryEmbeddingProbeResult,
   type MemoryProviderStatus,
   type MemorySearchManager,
-  type MemorySearchRuntimeDebug,
+  type MemorySearchOptions,
   type MemorySearchResult,
   type MemorySource,
   type MemorySyncProgressUpdate,
@@ -1217,17 +1217,7 @@ export class QmdMemoryManager implements MemorySearchManager {
     return true;
   }
 
-  async search(
-    query: string,
-    opts?: {
-      maxResults?: number;
-      minScore?: number;
-      sessionKey?: string;
-      qmdSearchModeOverride?: "query" | "search" | "vsearch";
-      onDebug?: (debug: MemorySearchRuntimeDebug) => void;
-      sources?: MemorySource[];
-    },
-  ): Promise<MemorySearchResult[]> {
+  async search(query: string, opts?: MemorySearchOptions): Promise<MemorySearchResult[]> {
     if (!this.isScopeAllowed(opts?.sessionKey)) {
       this.logScopeDenied(opts?.sessionKey);
       return [];

--- a/extensions/memory-core/src/memory/search-manager.ts
+++ b/extensions/memory-core/src/memory/search-manager.ts
@@ -17,8 +17,7 @@ import {
   resolveMemoryBackendConfig,
   type MemoryEmbeddingProbeResult,
   type MemorySearchManager,
-  type MemorySearchRuntimeDebug,
-  type MemorySource,
+  type MemorySearchOptions,
   type MemorySyncProgressUpdate,
   type ResolvedQmdConfig,
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
@@ -362,18 +361,7 @@ class BorrowedMemoryManager implements MemorySearchManager {
     }
   }
 
-  async search(
-    query: string,
-    opts?: {
-      maxResults?: number;
-      minScore?: number;
-      sessionKey?: string;
-      qmdSearchModeOverride?: "query" | "search" | "vsearch";
-      onDebug?: (debug: MemorySearchRuntimeDebug) => void;
-      sources?: MemorySource[];
-      signal?: AbortSignal;
-    },
-  ) {
+  async search(query: string, opts?: MemorySearchOptions) {
     return await this.inner.search(query, opts);
   }
 
@@ -471,17 +459,7 @@ class FallbackMemoryManager implements MemorySearchManager {
     private readonly onClose?: () => void,
   ) {}
 
-  async search(
-    query: string,
-    opts?: {
-      maxResults?: number;
-      minScore?: number;
-      sessionKey?: string;
-      qmdSearchModeOverride?: "query" | "search" | "vsearch";
-      onDebug?: (debug: MemorySearchRuntimeDebug) => void;
-      sources?: MemorySource[];
-    },
-  ) {
+  async search(query: string, opts?: MemorySearchOptions) {
     this.ensureOpen();
     if (!this.primaryFailed) {
       try {

--- a/extensions/memory-core/src/tools.test.ts
+++ b/extensions/memory-core/src/tools.test.ts
@@ -192,12 +192,18 @@ describe("memory_search unavailable payloads", () => {
   it("keeps the timeout result when an abort-aware search rejects on abort", async () => {
     vi.useFakeTimers();
     try {
+      let signalSeen: AbortSignal | undefined;
+      let aborted = false;
       setMemorySearchImpl(
         async (opts) =>
           await new Promise((_resolve, reject) => {
+            signalSeen = opts?.signal;
             opts?.signal?.addEventListener(
               "abort",
-              () => reject(new Error("openai-compatible embeddings query failed: aborted")),
+              () => {
+                aborted = true;
+                reject(new Error("openai-compatible embeddings query failed: aborted"));
+              },
               { once: true },
             );
           }),
@@ -213,6 +219,9 @@ describe("memory_search unavailable payloads", () => {
         warning: "Memory search is unavailable due to an embedding/provider error.",
         action: "Check embedding provider configuration and retry memory_search.",
       });
+      expect(signalSeen).toBeInstanceOf(AbortSignal);
+      expect(signalSeen?.aborted).toBe(true);
+      expect(aborted).toBe(true);
     } finally {
       vi.useRealTimers();
     }

--- a/packages/memory-host-sdk/src/engine-storage.ts
+++ b/packages/memory-host-sdk/src/engine-storage.ts
@@ -34,6 +34,7 @@ export type {
   MemoryEmbeddingProbeResult,
   MemoryProviderStatus,
   MemorySearchManager,
+  MemorySearchOptions,
   MemorySearchRuntimeDebug,
   MemorySearchResult,
   MemorySource,

--- a/packages/memory-host-sdk/src/host/types.ts
+++ b/packages/memory-host-sdk/src/host/types.ts
@@ -90,21 +90,19 @@ export type MemoryProviderStatus = {
   custom?: Record<string, unknown>;
 };
 
+export type MemorySearchOptions = {
+  maxResults?: number;
+  minScore?: number;
+  sessionKey?: string;
+  qmdSearchModeOverride?: "query" | "search" | "vsearch";
+  onDebug?: (debug: MemorySearchRuntimeDebug) => void;
+  sources?: MemorySource[];
+  signal?: AbortSignal;
+};
+
 /** Search/read/sync/status contract implemented by memory managers. */
 export interface MemorySearchManager {
-  search(
-    query: string,
-    opts?: {
-      maxResults?: number;
-      minScore?: number;
-      sessionKey?: string;
-      qmdSearchModeOverride?: "query" | "search" | "vsearch";
-      onDebug?: (debug: MemorySearchRuntimeDebug) => void;
-      sources?: MemorySource[];
-      /** Optional caller cancellation; managers consume it where their runtime supports cancellation. */
-      signal?: AbortSignal;
-    },
-  ): Promise<MemorySearchResult[]>;
+  search(query: string, opts?: MemorySearchOptions): Promise<MemorySearchResult[]>;
   readFile(params: { relPath: string; from?: number; lines?: number }): Promise<MemoryReadResult>;
   status(): MemoryProviderStatus;
   sync?(params?: {

--- a/src/plugin-sdk/memory-core-host-engine-storage.ts
+++ b/src/plugin-sdk/memory-core-host-engine-storage.ts
@@ -62,6 +62,7 @@ export type {
   MemoryProviderStatus,
   MemoryReadResult,
   MemorySearchManager,
+  MemorySearchOptions,
   MemorySearchRuntimeDebug,
   MemorySyncProgressUpdate,
   ResolvedMemoryBackendConfig,


### PR DESCRIPTION
## Summary

Fixes #91718 by making the memory_search tool timeout cancel the underlying builtin memory embedding search instead of only racing the outer tool promise.

- Adds an optional `AbortSignal` to the memory search manager options contract.
- Aborts the in-flight memory search when the 15s tool deadline fires.
- Threads the signal into builtin query embedding and the provider fetch operation.
- Stops embedding retries after caller cancellation.
- Keeps caller-aborted searches from activating the configured fallback provider after cancellation.

## Verification

- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test extensions/memory-core/src/tools.test.ts extensions/memory-core/src/tools.citations.test.ts extensions/memory-core/src/memory/manager-embedding-timeout.test.ts extensions/memory-core/src/memory/search-manager.test.ts`
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=0 pnpm test extensions/memory-core/src/memory/index.test.ts extensions/memory-core/src/memory/manager-embedding-timeout.test.ts`
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree pnpm tsgo:core:test`
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree pnpm tsgo:extensions:test`
- `pnpm format:check -- extensions/memory-core/src/tools.ts extensions/memory-core/src/tools.test.ts extensions/memory-core/src/memory-tool-manager-mock.ts extensions/memory-core/src/memory/manager.ts extensions/memory-core/src/memory/search-manager.ts extensions/memory-core/src/memory/qmd-manager.ts extensions/memory-core/src/memory/manager-embedding-ops.ts extensions/memory-core/src/memory/manager-embedding-timeout.test.ts packages/memory-host-sdk/src/host/types.ts packages/memory-host-sdk/src/engine-storage.ts src/plugin-sdk/memory-core-host-engine-storage.ts`
- `pnpm format:check -- extensions/memory-core/src/memory/manager.ts extensions/memory-core/src/memory/index.test.ts`
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree timeout 300s node scripts/run-oxlint.mjs src/plugin-sdk/memory-core-host-engine-storage.ts`
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree timeout 300s node scripts/run-oxlint.mjs extensions/memory-core/src/tools.ts extensions/memory-core/src/tools.test.ts extensions/memory-core/src/memory-tool-manager-mock.ts extensions/memory-core/src/memory/manager.ts extensions/memory-core/src/memory/search-manager.ts extensions/memory-core/src/memory/qmd-manager.ts extensions/memory-core/src/memory/manager-embedding-ops.ts extensions/memory-core/src/memory/manager-embedding-timeout.test.ts packages/memory-host-sdk/src/host/types.ts packages/memory-host-sdk/src/engine-storage.ts`
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-oxlint.mjs extensions/memory-core/src/memory/manager.ts extensions/memory-core/src/memory/index.test.ts`
- `node --import tsx /tmp/openclaw-91718-proof.mjs`
- `git diff --check`

## Real behavior proof

behavior: memory_search timeout cancellation now reaches the builtin embedding provider operation.

environment: Ubuntu/Linux local OpenClaw source checkout on Node 22.22.2, branch `ai-hpc/fix-memory-search-timeout-abort`.

steps:
1. Started a local delayed HTTP endpoint on `127.0.0.1`.
2. Ran the real `runEmbeddingOperationWithTimeout` implementation with a parent AbortSignal representing the memory_search 15s deadline.
3. Started a provider-style `fetch` against the delayed endpoint using the operation signal.
4. Aborted the parent signal with `memory_search timed out after 15s`.
5. Verified the operation rejected quickly, the provider signal was aborted with the same reason, and the HTTP connection closed before the delayed response.

evidence:
```json
{
  "result": "aborted",
  "errorMessage": "memory_search timed out after 15s",
  "elapsedMs": 219,
  "operationSignalAborted": true,
  "operationSignalReceivedParentReason": true,
  "serverRequestSeen": true,
  "serverConnectionClosedBeforeResponse": true
}
```

observedResult: the caller timeout now cancels the active provider fetch path instead of leaving it to run in the background.

notTested: live external embedding vendor endpoint. The local loopback proof covers the same AbortSignal-to-fetch cancellation path without using real provider credentials.
