### PR TITLE
fix(ios): refresh permission rows after grants

### DIFF
--- a/apps/ios/Sources/Settings/PrivacyAccessSectionView.swift
+++ b/apps/ios/Sources/Settings/PrivacyAccessSectionView.swift
@@ -121,13 +121,18 @@ struct PrivacyAccessSectionView: View {
         switch self.contactsStatus {
         case .notDetermined:
             Task {
-                _ = await PermissionRequestBridge.awaitRequest { completion in
+                let granted = await PermissionRequestBridge.awaitRequest { completion in
                     let store = CNContactStore()
                     store.requestAccess(for: .contacts) { granted, _ in
                         completion(granted)
                     }
                 }
-                await MainActor.run { self.refreshAll() }
+                await MainActor.run {
+                    self.refreshAll()
+                    if granted {
+                        self.contactsStatus = .authorized
+                    }
+                }
             }
         case .denied, .restricted:
             self.openSettings()
@@ -164,8 +169,13 @@ struct PrivacyAccessSectionView: View {
         switch self.calendarStatus {
         case .notDetermined:
             Task {
-                _ = await self.requestCalendarWriteOnly()
-                await MainActor.run { self.refreshAll() }
+                let granted = await self.requestCalendarWriteOnly()
+                await MainActor.run {
+                    self.refreshAll()
+                    if granted {
+                        self.calendarStatus = .writeOnly
+                    }
+                }
             }
         case .denied, .restricted:
             self.openSettings()
@@ -206,8 +216,13 @@ struct PrivacyAccessSectionView: View {
         switch self.calendarStatus {
         case .notDetermined, .writeOnly:
             Task {
-                _ = await self.requestCalendarFull()
-                await MainActor.run { self.refreshAll() }
+                let granted = await self.requestCalendarFull()
+                await MainActor.run {
+                    self.refreshAll()
+                    if granted {
+                        self.calendarStatus = .fullAccess
+                    }
+                }
             }
         case .denied, .restricted:
             self.openSettings()
@@ -248,8 +263,13 @@ struct PrivacyAccessSectionView: View {
         switch self.remindersStatus {
         case .notDetermined, .writeOnly:
             Task {
-                _ = await self.requestRemindersFull()
-                await MainActor.run { self.refreshAll() }
+                let granted = await self.requestRemindersFull()
+                await MainActor.run {
+                    self.refreshAll()
+                    if granted {
+                        self.remindersStatus = .fullAccess
+                    }
+                }
             }
         case .denied, .restricted:
             self.openSettings()


### PR DESCRIPTION
## Summary

Fixes stale iOS permission rows after Contacts / Calendar / Reminders grants by applying the granted callback result to the local SwiftUI status after re-reading current OS status.

> [!WARNING]
> Local validation used beta macOS 27 / Xcode 27. The app deployment target is unchanged, and iOS 26.5 simulator build also passed.

AI-assisted PR.

## Before / After

| Before | After |
| --- | --- |
| <img width="200" alt="before" src="https://github.com/user-attachments/assets/dc10b8e4-77dd-40fa-929f-aa927b4b8c31" /><br>Intermittent, but frequent enough: after approving full calendar access, one calendar row could remain stale. | <img width="200" alt="after" src="https://github.com/user-attachments/assets/bbd64614-af27-4707-af81-f64df2742953" /><br>Rows update after the grant callback. |

## Real behavior proof

- Behavior addressed: Permission rows could show stale mixed state after grants.
- Real environment tested: OpenClaw iOS app in simulator, connected to a real OpenClaw gateway.
- Exact steps or command run after this patch:
  - `git diff --check HEAD~1..HEAD`
  - `xcodebuild -project apps/ios/OpenClaw.xcodeproj -scheme OpenClaw -destination 'platform=iOS Simulator,OS=26.5,name=iPhone 17 Pro Max' CODE_SIGNING_ALLOWED=NO build`
  - `xcodebuild -project apps/ios/OpenClaw.xcodeproj -scheme OpenClaw -destination 'id=83796C22-9007-438E-8E28-D025EB9D4B33' CODE_SIGNING_ALLOWED=NO build`
  - `.agents/skills/autoreview/scripts/autoreview --mode commit --commit HEAD`
- Evidence after fix: https://github.com/user-attachments/assets/bbd64614-af27-4707-af81-f64df2742953
- Observed result after fix: Contacts / Calendar / Reminders rows refresh after successful permission grants.
- What was not tested: Physical device runtime; automated UI test coverage.

## Reset To Retest

```fish
set bundle ai.openclaw.ios.test.zats-8t938ah985
for udid in (xcrun simctl list devices booted | string match -r '[A-F0-9-]{36}')
    xcrun simctl privacy $udid reset all $bundle
    xcrun simctl privacy $udid reset location $bundle
    xcrun simctl privacy $udid reset location-always $bundle
    set data (xcrun simctl get_app_container $udid $bundle data)
    set plist "$data/Library/Preferences/$bundle.plist"
    /usr/libexec/PlistBuddy -c 'Delete :camera.enabled' $plist 2>/dev/null; or true
    /usr/libexec/PlistBuddy -c 'Delete :location.enabledMode' $plist 2>/dev/null; or true
    /usr/libexec/PlistBuddy -c 'Delete :screen.preventSleep' $plist 2>/dev/null; or true
end
```

## Validation

- `git diff --check HEAD~1..HEAD`: passed
- iOS 26.5 simulator build: passed
- iOS 27.0 simulator build: passed
- Autoreview: clean

## Risk checklist

- [x] User-visible behavior changed: iOS permission row refresh
- [ ] Config, environment, or migration behavior changed
- [ ] Security, auth, secrets, network, or tool execution behavior changed
- [x] Highest risk identified: UI could overstate success if a grant callback is wrong
- [x] Mitigation: only applies optimistic state when the OS permission callback reports `granted`
