### PR TITLE
fix(imessage): surface inbound startup diagnostics

### DIFF
--- a/extensions/imessage/src/monitor.watch-subscribe-retry.test.ts
+++ b/extensions/imessage/src/monitor.watch-subscribe-retry.test.ts
@@ -4,6 +4,7 @@ import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vites
 import type { createIMessageRpcClient, IMessageRpcClient } from "./client.js";
 import { monitorIMessageProvider } from "./monitor.js";
 import type { attachIMessageMonitorAbortHandler } from "./monitor/abort-handler.js";
+import { describeIMessageInboundDropDiagnostic } from "./monitor/monitor-provider.js";
 
 const waitForTransportReadyMock = vi.hoisted(() =>
   vi.fn<typeof waitForTransportReady>(async () => {}),
@@ -110,9 +111,16 @@ describe("monitorIMessageProvider watch.subscribe startup retry", () => {
       { timeoutMs: 10_000 },
     );
     expect(runtime.log).toHaveBeenCalledTimes(1);
-    expect(String(runtime.log.mock.calls[0]?.[0])).toContain(
-      "imessage: watch.subscribe startup failed (attempt 1/3): Error: imsg rpc timeout (watch.subscribe); retrying",
-    );
+    const retryLog = String(runtime.log.mock.calls[0]?.[0]);
+    expect(retryLog).toContain("imessage: watch.subscribe startup failed attempt=1/3");
+    expect(retryLog).toContain("account=default");
+    expect(retryLog).toContain("cliPath=imsg");
+    expect(retryLog).toContain("dbPath=default");
+    expect(retryLog).toContain("timeoutMs=10000");
+    expect(retryLog).toContain("since_rowid=none");
+    expect(retryLog).toContain("attachments=false");
+    expect(retryLog).toContain("retry_in_ms=1000");
+    expect(retryLog).toContain("Error: imsg rpc timeout (watch.subscribe)");
     expect(
       runtime.error.mock.calls.some(([message]) =>
         String(message).includes("imessage: monitor failed"),
@@ -142,8 +150,48 @@ describe("monitorIMessageProvider watch.subscribe startup retry", () => {
     expect((monitorError as Error).message).toContain("imsg rpc timeout (watch.subscribe)");
     expect(createIMessageRpcClientMock).toHaveBeenCalledTimes(3);
     expect(runtime.error).toHaveBeenCalledTimes(1);
-    expect(String(runtime.error.mock.calls[0]?.[0])).toContain(
-      "imessage: monitor failed: Error: imsg rpc timeout (watch.subscribe)",
+    const failureLog = String(runtime.error.mock.calls[0]?.[0]);
+    expect(failureLog).toContain(
+      "imessage: monitor failed: imessage: watch.subscribe startup failed attempt=3/3",
     );
+    expect(failureLog).toContain("account=default");
+    expect(failureLog).toContain("timeoutMs=10000");
+    expect(failureLog).toContain("Error: imsg rpc timeout (watch.subscribe)");
+  });
+});
+
+describe("describeIMessageInboundDropDiagnostic", () => {
+  it("describes echo-style drops without message content or sender handles", () => {
+    const diagnostic = describeIMessageInboundDropDiagnostic({
+      accountId: "default",
+      reason: "echo",
+      message: {
+        id: 42,
+        chat_id: 123,
+        guid: "p:0/secret-guid",
+        is_group: false,
+        created_at: "2026-06-09T10:00:00.000Z",
+      },
+    });
+
+    expect(diagnostic).toBe(
+      'imessage: dropped inbound message account=default reason="echo" chat_id=123 group=false message_id=42 guid=present created_at=2026-06-09T10:00:00.000Z',
+    );
+    expect(diagnostic).not.toContain("secret-guid");
+    expect(diagnostic).not.toContain("+1555");
+  });
+
+  it("keeps normal policy drops quiet", () => {
+    expect(
+      describeIMessageInboundDropDiagnostic({
+        accountId: "default",
+        reason: "no mention",
+        message: {
+          id: 42,
+          chat_id: 123,
+          is_group: true,
+        },
+      }),
+    ).toBeNull();
   });
 });

--- a/extensions/imessage/src/monitor.watch-subscribe-retry.test.ts
+++ b/extensions/imessage/src/monitor.watch-subscribe-retry.test.ts
@@ -4,7 +4,10 @@ import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vites
 import type { createIMessageRpcClient, IMessageRpcClient } from "./client.js";
 import { monitorIMessageProvider } from "./monitor.js";
 import type { attachIMessageMonitorAbortHandler } from "./monitor/abort-handler.js";
-import { describeIMessageInboundDropDiagnostic } from "./monitor/monitor-provider.js";
+import {
+  describeIMessageInboundDropDiagnostic,
+  shouldThrottleIMessageInboundDropDiagnostic,
+} from "./monitor/monitor-provider.js";
 
 const waitForTransportReadyMock = vi.hoisted(() =>
   vi.fn<typeof waitForTransportReady>(async () => {}),
@@ -179,6 +182,27 @@ describe("describeIMessageInboundDropDiagnostic", () => {
     );
     expect(diagnostic).not.toContain("secret-guid");
     expect(diagnostic).not.toContain("+1555");
+  });
+
+  it("describes from-me drops and marks them for throttling", () => {
+    const diagnostic = describeIMessageInboundDropDiagnostic({
+      accountId: "default",
+      reason: "from me",
+      message: {
+        id: 43,
+        chat_id: 456,
+        guid: "p:0/outbound-guid",
+        is_group: true,
+        created_at: "2026-06-09T10:01:00.000Z",
+      },
+    });
+
+    expect(diagnostic).toBe(
+      'imessage: dropped inbound message account=default reason="from me" chat_id=456 group=true message_id=43 guid=present created_at=2026-06-09T10:01:00.000Z',
+    );
+    expect(diagnostic).not.toContain("outbound-guid");
+    expect(shouldThrottleIMessageInboundDropDiagnostic("from me")).toBe(true);
+    expect(shouldThrottleIMessageInboundDropDiagnostic("echo")).toBe(false);
   });
 
   it("keeps normal policy drops quiet", () => {

--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -260,9 +260,15 @@ function isRetriableWatchSubscribeStartupError(error: unknown): boolean {
 const IMESSAGE_DIAGNOSTIC_DROP_REASONS = new Set([
   "agent echo in self-chat",
   "echo",
+  "from me",
   "reflected assistant content",
   "self-chat echo",
 ]);
+const IMESSAGE_THROTTLED_DIAGNOSTIC_DROP_REASONS = new Set(["from me"]);
+
+export function shouldThrottleIMessageInboundDropDiagnostic(reason: string): boolean {
+  return IMESSAGE_THROTTLED_DIAGNOSTIC_DROP_REASONS.has(reason);
+}
 
 export function describeIMessageInboundDropDiagnostic(params: {
   accountId: string;
@@ -419,6 +425,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
   // replay aggressively without the old catchup cursor/retry bookkeeping.
   const inboundReplayGuard = createIMessageInboundReplayGuard();
   let staleBacklogSuppressed = 0;
+  const loggedThrottledDropDiagnostics = new Set<string>();
 
   // Downtime recovery. We pass the persisted recovery cursor (the last
   // dispatched rowid) to watch.subscribe as since_rowid so imsg replays the rows
@@ -911,7 +918,16 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
         message,
       });
       if (diagnostic) {
-        runtime.log?.(warn(diagnostic));
+        const throttleKey = `${rateLimitKey}:${decision.reason}`;
+        const shouldThrottleDiagnostic = shouldThrottleIMessageInboundDropDiagnostic(
+          decision.reason,
+        );
+        if (!shouldThrottleDiagnostic || !loggedThrottledDropDiagnostics.has(throttleKey)) {
+          if (shouldThrottleDiagnostic) {
+            loggedThrottledDropDiagnostics.add(throttleKey);
+          }
+          runtime.log?.(warn(diagnostic));
+        }
       }
       // Surface the silent-allowlist drop once per chat. Without this, operators
       // who set groupPolicy="allowlist" without populating

--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -257,6 +257,62 @@ function isRetriableWatchSubscribeStartupError(error: unknown): boolean {
   );
 }
 
+const IMESSAGE_DIAGNOSTIC_DROP_REASONS = new Set([
+  "agent echo in self-chat",
+  "echo",
+  "reflected assistant content",
+  "self-chat echo",
+]);
+
+export function describeIMessageInboundDropDiagnostic(params: {
+  accountId: string;
+  reason: string;
+  message: Pick<IMessagePayload, "chat_id" | "created_at" | "guid" | "id" | "is_group">;
+}): string | null {
+  if (!IMESSAGE_DIAGNOSTIC_DROP_REASONS.has(params.reason)) {
+    return null;
+  }
+  const messageId =
+    typeof params.message.id === "number" || typeof params.message.id === "string"
+      ? String(params.message.id)
+      : "unknown";
+  return (
+    `imessage: dropped inbound message account=${params.accountId} reason=${JSON.stringify(
+      params.reason,
+    )} ` +
+    `chat_id=${params.message.chat_id ?? "unknown"} group=${params.message.is_group === true} ` +
+    `message_id=${messageId} guid=${params.message.guid ? "present" : "missing"} ` +
+    `created_at=${params.message.created_at ?? "unknown"}`
+  );
+}
+
+function describeIMessageWatchSubscribeStartupFailure(params: {
+  accountId: string;
+  attempt: number;
+  maxAttempts: number;
+  cliPath: string;
+  dbPath?: string;
+  remoteHost?: string;
+  includeAttachments: boolean;
+  probeTimeoutMs: number;
+  watchSinceRowid: number | null;
+  error: unknown;
+  retryDelayMs?: number;
+}): string {
+  const retry = params.retryDelayMs !== undefined ? ` retry_in_ms=${params.retryDelayMs}` : "";
+  return (
+    `imessage: watch.subscribe startup failed attempt=${params.attempt}/${params.maxAttempts} ` +
+    `account=${params.accountId} cliPath=${params.cliPath} ` +
+    `dbPath=${params.dbPath ? "configured" : "default"} remoteHost=${
+      params.remoteHost ? "configured" : "none"
+    } ` +
+    `timeoutMs=${params.probeTimeoutMs} since_rowid=${params.watchSinceRowid ?? "none"} ` +
+    `attachments=${params.includeAttachments} include_reactions=true${retry}: ${String(
+      params.error,
+    )}`
+  );
+}
+
 async function waitForWatchSubscribeRetryDelay(params: {
   ms: number;
   abortSignal?: AbortSignal;
@@ -849,6 +905,14 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
       if (isLoopDrop) {
         loopRateLimiter.record(rateLimitKey);
       }
+      const diagnostic = describeIMessageInboundDropDiagnostic({
+        accountId: accountInfo.accountId,
+        reason: decision.reason,
+        message,
+      });
+      if (diagnostic) {
+        runtime.log?.(warn(diagnostic));
+      }
       // Surface the silent-allowlist drop once per chat. Without this, operators
       // who set groupPolicy="allowlist" without populating
       // channels.imessage.groups see every group message vanish at default log
@@ -1424,12 +1488,39 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
       const shouldRetry =
         attempt < WATCH_SUBSCRIBE_MAX_ATTEMPTS && isRetriableWatchSubscribeStartupError(err);
       if (!shouldRetry) {
-        runtime.error?.(danger(`imessage: monitor failed: ${String(err)}`));
+        runtime.error?.(
+          danger(
+            `imessage: monitor failed: ${describeIMessageWatchSubscribeStartupFailure({
+              accountId: accountInfo.accountId,
+              attempt,
+              maxAttempts: WATCH_SUBSCRIBE_MAX_ATTEMPTS,
+              cliPath,
+              dbPath,
+              remoteHost,
+              includeAttachments,
+              probeTimeoutMs,
+              watchSinceRowid,
+              error: err,
+            })}`,
+          ),
+        );
         throw err;
       }
       runtime.log?.(
         warn(
-          `imessage: watch.subscribe startup failed (attempt ${attempt}/${WATCH_SUBSCRIBE_MAX_ATTEMPTS}): ${String(err)}; retrying`,
+          describeIMessageWatchSubscribeStartupFailure({
+            accountId: accountInfo.accountId,
+            attempt,
+            maxAttempts: WATCH_SUBSCRIBE_MAX_ATTEMPTS,
+            cliPath,
+            dbPath,
+            remoteHost,
+            includeAttachments,
+            probeTimeoutMs,
+            watchSinceRowid,
+            error: err,
+            retryDelayMs: WATCH_SUBSCRIBE_RETRY_DELAY_MS,
+          }),
         ),
       );
       // Tear down the failed client before waiting so a slow subscribe attempt


### PR DESCRIPTION
## Summary

- Add default-level, privacy-safe diagnostics when inbound rows are dropped for echo/reflection reasons (`echo`, `self-chat echo`, `agent echo in self-chat`, `reflected assistant content`) and for same-account `from me` rows. The log includes account, reason, numeric chat id when present, row/message id, GUID presence, group flag, and timestamp, but not message text, sender handles, or full GUIDs.
- Throttle `from me` diagnostics once per account/conversation/reason so normal outbound watcher rows do not spam default logs while still surfacing the same-account group-chat drop called out by review.
- Add structured `watch.subscribe` startup retry/failure context: account, `cliPath`, db path presence, remote-host presence, timeout, `since_rowid`, attachment/reaction flags, attempt count, and retry delay.
- Keep this diagnostics-only: no inbound delivery policy, watch retry classification, retry count, teardown, or thrown error behavior changes.

Refs #89593.
Refs #87263.

## Verification

Initial proof:

- `node scripts/run-vitest.mjs extensions/imessage/src/monitor.watch-subscribe-retry.test.ts` (4 tests)
- `pnpm format:check -- extensions/imessage/src/monitor/monitor-provider.ts extensions/imessage/src/monitor.watch-subscribe-retry.test.ts`
- `pnpm lint:extensions -- extensions/imessage/src/monitor/monitor-provider.ts extensions/imessage/src/monitor.watch-subscribe-retry.test.ts`
- `pnpm tsgo:extensions`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local --prompt "Review this diagnostics-only iMessage monitor patch. It should not change inbound delivery policy or watch.subscribe retry behavior. Focus on log noise/privacy, whether echo/reflection drops are surfaced without message content/sender handles, whether watch.subscribe retry/failure diagnostics include useful startup context, and whether tests cover the new formatting."` (clean)

Follow-up proof after ClawSweeper noted that `from me` rows also needed diagnostics:

- `node scripts/run-vitest.mjs extensions/imessage/src/monitor.watch-subscribe-retry.test.ts` (5 tests)
- `pnpm format:check -- extensions/imessage/src/monitor/monitor-provider.ts extensions/imessage/src/monitor.watch-subscribe-retry.test.ts`
- `pnpm lint:extensions -- extensions/imessage/src/monitor/monitor-provider.ts extensions/imessage/src/monitor.watch-subscribe-retry.test.ts`
- `pnpm tsgo:extensions`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local --prompt "Review the follow-up to PR #91785. It adds privacy-safe diagnostics for iMessage 'from me' drops and throttles that reason per account/conversation so normal outbound watcher rows do not spam default logs. Focus on whether it satisfies ClawSweeper's from-me diagnostic finding without changing delivery policy or overlogging PII."` (clean)

## Real behavior proof

Behavior addressed: missing runtime diagnostics for iMessage inbound rows that are intentionally dropped before dispatch, plus startup context for `watch.subscribe` retry/failure.
Real environment tested: lobster macOS host, OpenClaw PR head `597684c3650dab508cbb1378a58b74636d581626`, `imsg` 0.11.0, Node v26.0.0.
Exact steps or command run after this patch: checked out `origin/fix/imessage-inbound-startup-diagnostics` on lobster, started `monitorIMessageProvider` through the PR source with a redacting runtime logger, then sent a self-addressed iMessage through `sendMessageIMessage` using `sendTransport = "bridge"`. Account, target, chat id, message id, and any participant details were redacted from output.
Evidence after fix:

```json
{
  "host": "lobster",
  "proofId": "openclaw-lobster-live-monitor-proof-ada22165-6306-46b6-8ed0-6c94fcab6bbc",
  "head": "597684c3650dab508cbb1378a58b74636d581626",
  "transport": "bridge",
  "candidateKey": "account_id",
  "targetKind": "handle",
  "sendMessageIdPresent": false,
  "sendGuidPresent": true,
  "dropDiagnosticFound": true,
  "redactedDropDiagnostic": "imessage: dropped inbound message account=<redacted> reason=\"from me\" chat_id=<redacted> group=false message_id=<redacted> guid=present created_at=2026-06-10T00:20:16.169Z",
  "startupDiagnostics": [],
  "logCount": 1,
  "errorCount": 0,
  "sendError": null,
  "errorSamples": []
}
```

Observed result after fix: the live monitor emitted the new default-level, privacy-safe `from me` drop diagnostic with no message text, sender handle, target handle, or full GUID in the proof output.
What was not tested: a live `watch.subscribe` startup timeout on lobster; that branch remains covered by focused tests because the live monitor startup succeeded.
